### PR TITLE
US-18.2: Deploy loopctl to Fly.io with managed PostgreSQL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,10 +188,25 @@ jobs:
         run: mix dialyzer
 
   deploy:
-    name: Deploy
+    name: Deploy (beelink)
     runs-on: [self-hosted, beelink]
     needs: [lint, test, security, dialyzer]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - name: Deploy to beelink
         run: bash $HOME/workspace/loopctl/deploy/deploy.sh
+
+  fly-deploy:
+    name: Deploy (Fly.io)
+    runs-on: ubuntu-latest
+    needs: [lint, test, security, dialyzer]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to Fly.io
+        run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Multi-stage Docker build for loopctl (API-only Phoenix app).
+# Multi-stage Docker build for loopctl (Phoenix app with LiveView assets).
 #
 # Based on these images:
 #   - https://hub.docker.com/r/hexpm/elixir/tags - for the build image
@@ -14,7 +14,7 @@ ARG RUNNER_IMAGE="docker.io/debian:${DEBIAN_VERSION}"
 
 FROM ${BUILDER_IMAGE} AS builder
 
-# install build dependencies (no nodejs/npm — loopctl is API-only, no assets)
+# install build dependencies (no nodejs/npm — esbuild and tailwind are standalone binaries)
 RUN apt-get update \
   && apt-get install -y --no-install-recommends build-essential git \
   && rm -rf /var/lib/apt/lists/*
@@ -42,9 +42,13 @@ RUN mix deps.compile
 
 COPY priv priv
 COPY lib lib
+COPY assets assets
 
 # Compile the release
 RUN mix compile
+
+# Build assets (esbuild + tailwind are standalone binaries — no Node.js needed)
+RUN mix assets.deploy
 
 # Changes to config/runtime.exs don't require recompiling the code
 COPY config/runtime.exs config/
@@ -73,6 +77,8 @@ RUN chown nobody /app
 
 # set runner ENV
 ENV MIX_ENV="prod"
+ENV PORT=8080
+EXPOSE 8080
 
 # Only copy the final release from the build stage
 COPY --from=builder --chown=nobody:root /app/_build/${MIX_ENV}/rel/loopctl ./

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -66,7 +66,10 @@ if config_env() == :prod do
     # ssl: true,
     url: database_url,
     pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
-    socket_options: maybe_ipv6
+    socket_options: maybe_ipv6,
+    connect_timeout: 15_000,
+    queue_target: 5_000,
+    queue_interval: 10_000
 
   # AdminRepo — same database, different role with BYPASSRLS in production
   admin_database_url =
@@ -75,7 +78,10 @@ if config_env() == :prod do
   config :loopctl, Loopctl.AdminRepo,
     url: admin_database_url,
     pool_size: String.to_integer(System.get_env("ADMIN_POOL_SIZE") || "3"),
-    socket_options: maybe_ipv6
+    socket_options: maybe_ipv6,
+    connect_timeout: 15_000,
+    queue_target: 5_000,
+    queue_interval: 10_000
 
   # The secret key base is used to sign/encrypt cookies and other secrets.
   # A default value is used in config/dev.exs and config/test.exs but you

--- a/deploy/FLY_SECRETS.md
+++ b/deploy/FLY_SECRETS.md
@@ -1,0 +1,139 @@
+# Fly.io Deployment Guide for loopctl
+
+## Required Secrets
+
+Set all secrets before first deploy:
+
+```bash
+# Database connections — MUST use port 5433 (direct, bypasses PgBouncer) for RLS
+fly secrets set DATABASE_URL="postgres://loopctl_app:PASSWORD@loopctl-db.flycast:5433/loopctl"
+fly secrets set ADMIN_DATABASE_URL="postgres://loopctl_admin:PASSWORD@loopctl-db.flycast:5433/loopctl"
+
+# Phoenix secret key base (generate with: mix phx.gen.secret)
+fly secrets set SECRET_KEY_BASE="GENERATED_SECRET"
+
+# Cloak encryption key (generate with: :crypto.strong_rand_bytes(32) |> Base.encode64())
+fly secrets set CLOAK_KEY="GENERATED_BASE64_KEY"
+```
+
+### Secret Reference
+
+| Secret             | Required | Description                                         |
+|--------------------|----------|-----------------------------------------------------|
+| `DATABASE_URL`     | Yes      | Ecto URL for `Loopctl.Repo` (loopctl_app role, RLS enforced) |
+| `ADMIN_DATABASE_URL` | Yes    | Ecto URL for `Loopctl.AdminRepo` (loopctl_admin role, BYPASSRLS) |
+| `SECRET_KEY_BASE`  | Yes      | Phoenix cookie signing/encryption key               |
+| `CLOAK_KEY`        | Yes      | AES-256-GCM encryption key for API key hashing      |
+
+### Environment Variables (set in fly.toml, not secrets)
+
+| Variable       | Value          | Description                    |
+|----------------|----------------|--------------------------------|
+| `PHX_HOST`     | `loopctl.com`  | Canonical hostname             |
+| `PORT`         | `8080`         | HTTP listener port             |
+| `PHX_SERVER`   | `true`         | Start Phoenix server on boot   |
+
+### Optional Environment Variables
+
+| Variable            | Default | Description                              |
+|---------------------|---------|------------------------------------------|
+| `POOL_SIZE`         | `10`    | Repo connection pool size                |
+| `ADMIN_POOL_SIZE`   | `3`     | AdminRepo connection pool size           |
+| `ECTO_IPV6`         | -       | Set to `true` to enable IPv6 for DB     |
+| `DNS_CLUSTER_QUERY` | -       | DNS query for clustering (not needed for single machine) |
+
+## Database Setup
+
+**Before first deploy**, provision the Fly Postgres cluster and run the RLS role setup:
+
+1. Create the Postgres cluster:
+   ```bash
+   fly postgres create --name loopctl-db --region lax
+   ```
+
+2. Attach to the app (creates the `loopctl` database):
+   ```bash
+   fly postgres attach loopctl-db -a loopctl
+   ```
+
+3. Connect and run the role setup SQL from `deploy/fly-db-setup.sh`:
+   ```bash
+   fly postgres connect -a loopctl-db
+   # Paste the SQL from deploy/fly-db-setup.sh
+   ```
+
+4. Set the secrets with the chosen passwords (port 5433 is critical):
+   ```bash
+   fly secrets set DATABASE_URL="postgres://loopctl_app:PASSWORD@loopctl-db.flycast:5433/loopctl"
+   fly secrets set ADMIN_DATABASE_URL="postgres://loopctl_admin:PASSWORD@loopctl-db.flycast:5433/loopctl"
+   ```
+
+**Why port 5433?** Fly Postgres runs PgBouncer on port 5432. PgBouncer uses
+transaction-level pooling which breaks `SET LOCAL` statements required for RLS
+tenant isolation. Port 5433 connects directly to PostgreSQL.
+
+## DNS Setup
+
+loopctl.com is an apex (naked) domain. CNAME records are not allowed on apex
+domains per RFC 1034. Use A records pointing to Fly's anycast IP addresses.
+
+1. Get Fly.io's dedicated IPv4 address:
+   ```bash
+   fly ips allocate-v4 -a loopctl
+   ```
+
+2. Configure DNS at your registrar:
+   ```
+   A     loopctl.com    → <fly-ipv4-address>
+   AAAA  loopctl.com    → <fly-ipv6-address>  (optional, from fly ips list)
+   ```
+
+3. Issue the TLS certificate:
+   ```bash
+   fly certs add loopctl.com -a loopctl
+   ```
+
+4. Verify certificate status:
+   ```bash
+   fly certs show loopctl.com -a loopctl
+   ```
+
+## Deployment
+
+Deployments happen automatically via GitHub Actions on push to `master`.
+
+Manual deploy:
+```bash
+fly deploy
+```
+
+## Post-Deploy Verification
+
+After each deployment, verify the application is healthy:
+
+1. **Health check endpoint**:
+   ```bash
+   curl -s https://loopctl.com/health | jq .
+   # Expected: {"status":"ok","version":"0.1.0","checks":{"database":"ok","oban":"ok"}}
+   ```
+
+2. **Fly machine status**:
+   ```bash
+   fly status -a loopctl
+   fly logs -a loopctl
+   ```
+
+3. **Database connectivity**:
+   ```bash
+   fly ssh console -a loopctl -C "/app/bin/loopctl eval 'Loopctl.Repo.query!(\"SELECT 1\")'"
+   ```
+
+4. **Migration status**:
+   ```bash
+   fly ssh console -a loopctl -C "/app/bin/loopctl eval 'Loopctl.Release.migrate()'"
+   ```
+
+5. **API smoke test** (replace with a valid API key):
+   ```bash
+   curl -s -H "Authorization: Bearer API_KEY" https://loopctl.com/api/v1/projects | jq .
+   ```

--- a/deploy/fly-db-setup.sh
+++ b/deploy/fly-db-setup.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# ==============================================================================
+# Fly.io PostgreSQL RLS Role Setup
+# ==============================================================================
+#
+# ONE-TIME MANUAL STEP: Run this SQL via `fly postgres connect -a loopctl-db`
+# after provisioning the Fly Postgres cluster.
+#
+# This creates the two database roles required by loopctl's RLS architecture:
+#
+#   loopctl_app   — Regular app role. RLS policies are enforced for this role.
+#                   Used by Loopctl.Repo (the main application connection pool).
+#
+#   loopctl_admin — Admin role with BYPASSRLS. RLS policies are NOT enforced.
+#                   Used by Loopctl.AdminRepo for migrations and superadmin ops.
+#
+# IMPORTANT: DATABASE_URL Connection Port
+# ----------------------------------------
+# Fly Postgres includes PgBouncer on port 5432 (default). PgBouncer uses
+# transaction-level pooling which breaks SET LOCAL statements — these are
+# required for RLS tenant isolation (SET LOCAL app.current_tenant_id = '...').
+#
+# You MUST use port 5433 (direct PostgreSQL connection, bypassing PgBouncer)
+# in both DATABASE_URL and ADMIN_DATABASE_URL:
+#
+#   fly secrets set DATABASE_URL="postgres://loopctl_app:PASSWORD@loopctl-db.flycast:5433/loopctl"
+#   fly secrets set ADMIN_DATABASE_URL="postgres://loopctl_admin:PASSWORD@loopctl-db.flycast:5433/loopctl"
+#
+# Port 5432 = PgBouncer (breaks SET LOCAL / RLS)
+# Port 5433 = Direct PostgreSQL (required for RLS)
+#
+# ==============================================================================
+# HOW TO RUN:
+#
+#   1. Connect to Fly Postgres:
+#      fly postgres connect -a loopctl-db
+#
+#   2. Paste the SQL below into the psql session.
+#
+#   3. Set the passwords as Fly secrets:
+#      fly secrets set DATABASE_URL="postgres://loopctl_app:CHOSEN_PASSWORD@loopctl-db.flycast:5433/loopctl"
+#      fly secrets set ADMIN_DATABASE_URL="postgres://loopctl_admin:CHOSEN_PASSWORD@loopctl-db.flycast:5433/loopctl"
+#
+# ==============================================================================
+
+cat <<'SQL'
+-- Create application role (RLS enforced)
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'loopctl_app') THEN
+    CREATE ROLE loopctl_app WITH LOGIN PASSWORD 'CHANGE_ME_APP_PASSWORD';
+  END IF;
+END $$;
+
+-- Create admin role (BYPASSRLS for migrations and superadmin operations)
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'loopctl_admin') THEN
+    CREATE ROLE loopctl_admin WITH LOGIN BYPASSRLS PASSWORD 'CHANGE_ME_ADMIN_PASSWORD';
+  END IF;
+END $$;
+
+-- Grant database-level privileges
+GRANT ALL PRIVILEGES ON DATABASE loopctl TO loopctl_app, loopctl_admin;
+
+-- Grant schema-level privileges
+GRANT ALL ON ALL TABLES IN SCHEMA public TO loopctl_app, loopctl_admin;
+GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO loopctl_app, loopctl_admin;
+
+-- Ensure future tables/sequences are also accessible
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO loopctl_app, loopctl_admin;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO loopctl_app, loopctl_admin;
+
+-- RLS helper function: returns the current tenant ID set via SET LOCAL
+CREATE OR REPLACE FUNCTION current_tenant_id() RETURNS uuid AS $$
+  SELECT nullif(current_setting('app.current_tenant_id', true), '')::uuid
+$$ LANGUAGE sql STABLE;
+SQL

--- a/fly.toml
+++ b/fly.toml
@@ -1,25 +1,25 @@
-# Fly.io deployment configuration (placeholder for future cloud deployment)
+# Fly.io deployment configuration for loopctl
 # See https://fly.io/docs/reference/configuration/
-#
-# Currently loopctl is deployed to beelink (self-hosted).
-# This file will be configured when migrating to Fly.io.
 
 app = "loopctl"
-primary_region = "ord"
+primary_region = "lax"
 
 [build]
   [build.args]
     MIX_ENV = "prod"
 
+[deploy]
+  release_command = "/app/bin/migrate"
+
 [env]
-  PHX_HOST = "loopctl.fly.dev"
-  PORT = "4000"
+  PHX_HOST = "loopctl.com"
+  PORT = "8080"
   PHX_SERVER = "true"
 
 [http_service]
-  internal_port = 4000
+  internal_port = 8080
   force_https = true
-  auto_stop_machines = true
+  auto_stop_machines = "suspend"
   auto_start_machines = true
   min_machines_running = 1
 
@@ -27,6 +27,9 @@ primary_region = "ord"
     type = "connections"
     hard_limit = 1000
     soft_limit = 800
+
+  [http_service.http_options]
+    h2_backend = false
 
   [[http_service.checks]]
     interval = "10s"

--- a/lib/loopctl/release.ex
+++ b/lib/loopctl/release.ex
@@ -2,34 +2,42 @@ defmodule Loopctl.Release do
   @moduledoc """
   Release tasks for running migrations in production.
 
-  Used by the deploy script to run migrations without Mix:
+  Uses `Loopctl.AdminRepo` (BYPASSRLS role) because RLS policy
+  migrations require elevated privileges that the regular app role
+  does not have.
+
+  Used by the release migrate script:
 
       bin/loopctl eval "Loopctl.Release.migrate()"
+
+  Or via Fly.io release_command:
+
+      /app/bin/migrate
   """
 
   @app :loopctl
 
   @doc """
-  Runs all pending Ecto migrations.
+  Runs all pending Ecto migrations using AdminRepo.
+
+  AdminRepo connects with the BYPASSRLS role, which is required
+  because RLS policy DDL statements fail under a restricted role.
   """
   def migrate do
     load_app()
 
-    for repo <- repos() do
-      {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :up, all: true))
-    end
+    {:ok, _, _} =
+      Ecto.Migrator.with_repo(Loopctl.AdminRepo, &Ecto.Migrator.run(&1, :up, all: true))
   end
 
   @doc """
-  Rolls back the last migration.
+  Rolls back the last migration using AdminRepo.
   """
-  def rollback(repo, version) do
+  def rollback(version) do
     load_app()
-    {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :down, to: version))
-  end
 
-  defp repos do
-    Application.fetch_env!(@app, :ecto_repos)
+    {:ok, _, _} =
+      Ecto.Migrator.with_repo(Loopctl.AdminRepo, &Ecto.Migrator.run(&1, :down, to: version))
   end
 
   defp load_app do

--- a/test/loopctl/release_test.exs
+++ b/test/loopctl/release_test.exs
@@ -1,0 +1,41 @@
+defmodule Loopctl.ReleaseTest do
+  use ExUnit.Case, async: true
+
+  alias Loopctl.Release
+
+  describe "migrate/0" do
+    test "calls Ecto.Migrator with AdminRepo (BYPASSRLS required for RLS migrations)" do
+      # Ensure the module is loaded
+      Code.ensure_loaded!(Release)
+
+      # Verify the module function exists and is accessible
+      assert function_exported?(Release, :migrate, 0)
+
+      # Inspect the source to confirm AdminRepo is used, not Repo.
+      # The migrate/0 function must use AdminRepo because:
+      #   - RLS policy DDL requires BYPASSRLS privilege
+      #   - The regular loopctl_app role cannot create/alter RLS policies
+      {:docs_v1, _, _, _, module_doc, _, _} = Code.fetch_docs(Release)
+
+      # Module doc references AdminRepo
+      assert %{"en" => doc_text} = module_doc
+      assert doc_text =~ "AdminRepo"
+
+      # Verify the source code pattern: Release.migrate/0 must reference
+      # Loopctl.AdminRepo, not iterate over all ecto_repos.
+      {:ok, source} = File.read("lib/loopctl/release.ex")
+      assert source =~ "Loopctl.AdminRepo"
+
+      # Ensure it does NOT use the generic repos() pattern that would
+      # iterate over ecto_repos config (which only lists Repo, not AdminRepo)
+      refute source =~ "for repo <- repos()"
+    end
+  end
+
+  describe "rollback/1" do
+    test "accepts a version argument for targeted rollback" do
+      Code.ensure_loaded!(Release)
+      assert function_exported?(Release, :rollback, 1)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Production-ready `fly.toml`: region `lax`, PHX_HOST `loopctl.com`, port 8080, `auto_stop_machines = "suspend"`, `h2_backend = false`, health check on `/health`
- Dockerfile adds asset compilation (`COPY assets` + `mix assets.deploy`) without Node.js, sets `EXPOSE 8080` and `ENV PORT 8080`, keeps tini as init
- `Release.migrate/0` updated to use `Loopctl.AdminRepo` (BYPASSRLS) instead of iterating `ecto_repos` — required for RLS policy DDL
- `config/runtime.exs` adds `connect_timeout: 15_000`, `queue_target: 5_000`, `queue_interval: 10_000` to both Repo and AdminRepo
- CI: new parallel `fly-deploy` job using `superfly/flyctl-actions`, existing beelink deploy unchanged
- `deploy/fly-db-setup.sh`: one-time RLS role setup SQL with port 5433 documentation (bypasses PgBouncer for SET LOCAL)
- `deploy/FLY_SECRETS.md`: all required secrets, DNS A-record setup, post-deploy verification steps
- Beelink docker-compose unaffected (PORT default stays 4000 in runtime.exs)

## Test plan

- [x] `mix precommit` passes (1126 tests, 0 failures, credo, dialyzer, sobelow all clean)
- [x] TC-18.2.7: Unit test verifies `Release.migrate/0` uses AdminRepo, not generic repos() iteration
- [ ] Operator: provision Fly Postgres, run `deploy/fly-db-setup.sh` SQL, set secrets per `deploy/FLY_SECRETS.md`
- [ ] Operator: configure DNS A record for loopctl.com, issue TLS cert via `fly certs add`
- [ ] Operator: add `FLY_API_TOKEN` to GitHub repo secrets for CI deploy job
- [ ] Post-deploy: verify `curl https://loopctl.com/health` returns OK