### PR TITLE
Add BA, Architect agents to docs; show full review team

### DIFF
--- a/lib/loopctl_web/controllers/page_html.ex
+++ b/lib/loopctl_web/controllers/page_html.ex
@@ -249,6 +249,36 @@ defmodule LoopctlWeb.PageHTML do
   ---</code></pre>
   """
 
+  @docs_ba_agent_code ~S"""
+  <pre><code>---
+  name: business-analyst
+  description: Requirements analysis, AC validation, and story quality review
+  permissionMode: bypassPermissions
+  model: opus
+  effort: high
+  skills:
+  - patterns-elixir
+  - patterns-ecto
+  - patterns-phoenix-web
+  ---</code></pre>
+  """
+
+  @docs_architect_agent_code ~S"""
+  <pre><code>---
+  name: systems-architect
+  description: Architecture review, OTP compliance, fault tolerance, scalability
+  permissionMode: bypassPermissions
+  model: opus
+  effort: high
+  skills:
+  - patterns-elixir
+  - patterns-ecto
+  - patterns-phoenix-web
+  - patterns-elixir-otp
+  - patterns-elixir-integration
+  ---</code></pre>
+  """
+
   @docs_review_pipeline_code ~S"""
   <pre><code>Team Review (3 agents)  ──&gt;  VCA  ──&gt;  Fix
         │                                  │
@@ -353,6 +383,16 @@ defmodule LoopctlWeb.PageHTML do
   def docs_impl_agent_code_block(assigns) do
     _ = assigns
     Phoenix.HTML.raw(@docs_impl_agent_code)
+  end
+
+  def docs_ba_agent_code_block(assigns) do
+    _ = assigns
+    Phoenix.HTML.raw(@docs_ba_agent_code)
+  end
+
+  def docs_architect_agent_code_block(assigns) do
+    _ = assigns
+    Phoenix.HTML.raw(@docs_architect_agent_code)
   end
 
   def docs_security_agent_code_block(assigns) do

--- a/lib/loopctl_web/controllers/page_html/docs.html.heex
+++ b/lib/loopctl_web/controllers/page_html/docs.html.heex
@@ -285,14 +285,30 @@
           <h2 class="font-display text-xl font-semibold text-slate-100">Agent Definitions</h2>
           <div class="mt-4 space-y-4 text-sm text-slate-400">
             <p>
-              Agents are defined as YAML frontmatter files. Each agent has a name,
-              description, permission mode, model, and a set of skills that inform
-              its behavior.
+              Agents are defined as YAML frontmatter files in <span class="font-mono text-slate-300">.claude/agents/</span>. Each agent has a name,
+              permission mode, model, and preloaded skills. The loopctl workflow uses
+              two groups of agents:
             </p>
+            <ul class="list-disc list-inside space-y-1 pl-1">
+              <li>
+                <span class="text-slate-200">Implementation agent</span>
+                — writes code (uses <span class="font-mono">sonnet</span>
+                for speed)
+              </li>
+              <li>
+                <span class="text-slate-200">Review team</span>
+                — BA + Architect + Engineer review in round 1, then all three + Security Adversary
+                in round 2 (all use <span class="font-mono">opus</span>
+                for depth)
+              </li>
+            </ul>
           </div>
 
           <%!-- Implementation agent --%>
-          <h3 class="mt-8 text-sm font-semibold text-slate-200">Implementation Agent</h3>
+          <h3 class="mt-8 text-sm font-semibold text-accent-400 uppercase tracking-wider text-xs">
+            Implementation
+          </h3>
+          <h3 class="mt-2 text-sm font-semibold text-slate-200">Implementation Agent</h3>
           <div class="mt-3 bg-slate-800 border border-slate-700 rounded-md overflow-hidden">
             <div class="flex bg-slate-900 border-b border-slate-700">
               <div class="px-4 py-2 text-xs font-mono text-slate-400">
@@ -334,8 +350,70 @@
             </p>
           </div>
 
+          <%!-- Review team header --%>
+          <h3 class="mt-12 text-sm font-semibold text-accent-400 uppercase tracking-wider text-xs">
+            Review Team (Round 1: Team Review)
+          </h3>
+          <p class="mt-2 text-sm text-slate-400">
+            Three agents review the implementation in parallel. Each brings a different perspective:
+            business requirements, system architecture, and engineering quality.
+          </p>
+
+          <%!-- Business analyst agent --%>
+          <h3 class="mt-6 text-sm font-semibold text-slate-200">Business Analyst Agent</h3>
+          <div class="mt-3 bg-slate-800 border border-slate-700 rounded-md overflow-hidden">
+            <div class="flex bg-slate-900 border-b border-slate-700">
+              <div class="px-4 py-2 text-xs font-mono text-slate-400">
+                .claude/agents/business-analyst.md
+              </div>
+            </div>
+            <div class="p-4 sm:p-6 font-mono text-xs text-slate-300 overflow-x-auto leading-relaxed">
+              {docs_ba_agent_code_block(assigns)}
+            </div>
+          </div>
+          <div class="mt-3 text-sm text-slate-400">
+            <p>
+              Reviews implementation against acceptance criteria. Validates that the story's
+              business requirements are met, checks for missing edge cases, and verifies
+              that test cases cover all specified behaviors. Uses
+              <span class="font-mono text-slate-300">opus</span>
+              for deeper reasoning about requirements.
+            </p>
+          </div>
+
+          <%!-- Systems architect agent --%>
+          <h3 class="mt-10 text-sm font-semibold text-slate-200">Systems Architect Agent</h3>
+          <div class="mt-3 bg-slate-800 border border-slate-700 rounded-md overflow-hidden">
+            <div class="flex bg-slate-900 border-b border-slate-700">
+              <div class="px-4 py-2 text-xs font-mono text-slate-400">
+                .claude/agents/systems-architect.md
+              </div>
+            </div>
+            <div class="p-4 sm:p-6 font-mono text-xs text-slate-300 overflow-x-auto leading-relaxed">
+              {docs_architect_agent_code_block(assigns)}
+            </div>
+          </div>
+          <div class="mt-3 text-sm text-slate-400">
+            <p>
+              Reviews system design, OTP compliance, fault tolerance, and scalability.
+              Checks supervision trees, GenServer patterns, database query performance,
+              and cross-context boundaries. Loaded with OTP and integration pattern skills
+              for deep architectural analysis.
+            </p>
+          </div>
+
+          <%!-- Adversarial round header --%>
+          <h3 class="mt-12 text-sm font-semibold text-accent-400 uppercase tracking-wider text-xs">
+            Adversarial Round (Round 2)
+          </h3>
+          <p class="mt-2 text-sm text-slate-400">
+            After round 1 findings are fixed, the same BA, Architect, and Engineer agents re-run
+            with an adversarial mindset — actively trying to break the code. A fourth agent
+            joins: the Security Adversary, focused on defensive edge cases.
+          </p>
+
           <%!-- Security adversary agent --%>
-          <h3 class="mt-10 text-sm font-semibold text-slate-200">Security Adversary Agent</h3>
+          <h3 class="mt-6 text-sm font-semibold text-slate-200">Security Adversary Agent</h3>
           <div class="mt-3 bg-slate-800 border border-slate-700 rounded-md overflow-hidden">
             <div class="flex bg-slate-900 border-b border-slate-700">
               <div class="px-4 py-2 text-xs font-mono text-slate-400">


### PR DESCRIPTION
## Summary
- Add Business Analyst and Systems Architect agent frontmatter examples
- Restructure agents section: Implementation → Review Team (Round 1) → Adversarial Round (Round 2)
- Show the full 4-agent adversarial review team composition
- Explain that round 2 reuses the same 3 agents in adversarial mode + adds Security Adversary

## Test plan
- [ ] /docs page shows all 4 agent types (Implementation, BA, Architect, Security)
- [ ] Review Team and Adversarial Round sections clearly labeled
- [ ] No project-specific leaks