### PR TITLE
US-19.1: Publish loopctl MCP server to npm

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,26 @@
+name: Publish MCP Server to npm
+
+on:
+  push:
+    tags:
+      - 'mcp-v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mcp-server
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm install
+
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     defaults:
       run:
         working-directory: mcp-server
@@ -19,8 +22,13 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Sync version from tag
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/mcp-v}"
+          npm version "$VERSION" --no-git-tag-version
+
       - run: npm install
 
-      - run: npm publish
+      - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,8 @@ erl_crash.dump
 .env
 deploy/certs/
 
+# MCP server
+mcp-server/node_modules/
+
 # Generated assets (built by esbuild/tailwind)
 /priv/static/assets/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,18 +143,18 @@ mix ecto.reset         # Drop, create, migrate
 - **User Stories**: `docs/user_stories/epic_N_name/us_N.M.json` — 60 stories across 15 epics
 - **Skills**: `skills/loopctl-*.md` — 6 orchestration skills
 - **Orchestration Guide**: `docs/orchestration-guide.md` — methodology: loop, trust model, checkpointing
-- **MCP Server**: `mcp-server/` — 17 typed tools for Claude Code agents (no curl needed)
+- **MCP Server**: `mcp-server/` — 19 typed tools for Claude Code agents (no curl needed), published as `loopctl-mcp-server` on npm
 - **Build Status**: memory-keeper key `build_status`, channel `loopctl`
 
 ## MCP Server
 
-Claude Code agents should use the loopctl MCP tools instead of curl. Configure in `~/.claude/mcp.json` or `.mcp.json`:
+Claude Code agents should use the loopctl MCP tools instead of curl. Install via `npm install loopctl-mcp-server`, then configure in `~/.claude/mcp.json` or `.mcp.json`:
 
 ```json
-{"mcpServers": {"loopctl": {"command": "node", "args": ["<path>/loopctl/mcp-server/index.js"], "env": {"LOOPCTL_SERVER": "...", "LOOPCTL_ORCH_KEY": "...", "LOOPCTL_AGENT_KEY": "..."}}}}
+{"mcpServers": {"loopctl": {"command": "npx", "args": ["loopctl-mcp-server"], "env": {"LOOPCTL_SERVER": "https://loopctl.com", "LOOPCTL_ORCH_KEY": "...", "LOOPCTL_AGENT_KEY": "..."}}}}
 ```
 
-Tools: `mcp__loopctl__list_projects`, `mcp__loopctl__list_stories`, `mcp__loopctl__verify_story`, etc. (17 total). See README for the full list.
+Tools: `mcp__loopctl__list_projects`, `mcp__loopctl__list_stories`, `mcp__loopctl__verify_story`, etc. (19 total). See `mcp-server/README.md` for the full list.
 
 ## Chain-of-Custody Enforcement
 

--- a/lib/loopctl_web/controllers/page_html.ex
+++ b/lib/loopctl_web/controllers/page_html.ex
@@ -85,14 +85,17 @@ defmodule LoopctlWeb.PageHTML do
   """
 
   @step4_code ~S"""
-  <pre>// Add to .mcp.json
+  <pre>npm install loopctl-mcp-server
+
+  // Add to .mcp.json
   {
   "mcpServers": {
     "loopctl": {
-      "command": "node",
-      "args": ["node_modules/@loopctl/mcp-server/index.js"],
+      "command": "npx",
+      "args": ["loopctl-mcp-server"],
       "env": {
         "LOOPCTL_SERVER": "https://loopctl.com",
+        "LOOPCTL_ORCH_KEY": "lc_your_orchestrator_key",
         "LOOPCTL_AGENT_KEY": "lc_your_agent_key"
       }
     }
@@ -361,8 +364,8 @@ defmodule LoopctlWeb.PageHTML do
   <pre><code>{
   "mcpServers": {
     "loopctl": {
-      "command": "node",
-      "args": ["node_modules/@loopctl/mcp-server/index.js"],
+      "command": "npx",
+      "args": ["loopctl-mcp-server"],
       "env": {
         "LOOPCTL_SERVER": "https://loopctl.com",
         "LOOPCTL_ORCH_KEY": "lc_your_orchestrator_key",

--- a/lib/loopctl_web/controllers/page_html/home.html.heex
+++ b/lib/loopctl_web/controllers/page_html/home.html.heex
@@ -625,12 +625,10 @@
                   {step4_code_block(assigns)}
                 </div>
                 <p class="mt-1.5 text-xs text-slate-500">
-                  Available on <a
-                    href="https://github.com/mkreyman/loopctl/tree/master/mcp-server"
-                    class="text-accent-400 hover:text-accent-300"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >GitHub</a>. npm package coming soon.
+                  Install via
+                  <span class="text-slate-400 font-mono">npm install loopctl-mcp-server</span>
+                  or run with <span class="text-slate-400 font-mono">npx loopctl-mcp-server</span>.
+                  19 typed tools for AI coding agents.
                 </p>
               </div>
             </div>

--- a/mcp-server/LICENSE
+++ b/mcp-server/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 Michael Kreyman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -62,7 +62,6 @@ Or if installed locally:
 | `LOOPCTL_API_KEY` | Global API key override (if set, always used) | -- |
 | `LOOPCTL_ORCH_KEY` | Orchestrator role API key (verify, reject, review, import) | -- |
 | `LOOPCTL_AGENT_KEY` | Agent role API key (contract, claim, start, request-review) | -- |
-| `LOOPCTL_REVIEWER_KEY` | Reviewer role API key (if separate from orchestrator) | -- |
 
 Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_KEY`.
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,0 +1,170 @@
+# loopctl-mcp-server
+
+MCP (Model Context Protocol) server for [loopctl](https://loopctl.com) -- structural trust for AI development loops.
+
+Wraps the loopctl REST API into 19 typed MCP tools so AI coding agents (Claude Code, etc.) can interact with loopctl without writing curl commands.
+
+## Installation
+
+```bash
+npm install loopctl-mcp-server
+```
+
+Or run directly with npx:
+
+```bash
+npx loopctl-mcp-server
+```
+
+## Configuration
+
+Add to your `.mcp.json` (Claude Code) or equivalent MCP config:
+
+```json
+{
+  "mcpServers": {
+    "loopctl": {
+      "command": "npx",
+      "args": ["loopctl-mcp-server"],
+      "env": {
+        "LOOPCTL_SERVER": "https://loopctl.com",
+        "LOOPCTL_ORCH_KEY": "lc_your_orchestrator_key",
+        "LOOPCTL_AGENT_KEY": "lc_your_agent_key"
+      }
+    }
+  }
+}
+```
+
+Or if installed locally:
+
+```json
+{
+  "mcpServers": {
+    "loopctl": {
+      "command": "node",
+      "args": ["node_modules/loopctl-mcp-server/index.js"],
+      "env": {
+        "LOOPCTL_SERVER": "https://loopctl.com",
+        "LOOPCTL_ORCH_KEY": "lc_your_orchestrator_key",
+        "LOOPCTL_AGENT_KEY": "lc_your_agent_key"
+      }
+    }
+  }
+}
+```
+
+## Environment Variables
+
+| Variable | Description | Default |
+|---|---|---|
+| `LOOPCTL_SERVER` | loopctl server URL | `https://loopctl.com` |
+| `LOOPCTL_API_KEY` | Global API key override (if set, always used) | -- |
+| `LOOPCTL_ORCH_KEY` | Orchestrator role API key (verify, reject, review, import) | -- |
+| `LOOPCTL_AGENT_KEY` | Agent role API key (contract, claim, start, request-review) | -- |
+| `LOOPCTL_REVIEWER_KEY` | Reviewer role API key (if separate from orchestrator) | -- |
+
+Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_KEY`.
+
+## Tools (19)
+
+### Project Tools
+
+| Tool | Description |
+|---|---|
+| `get_tenant` | Get current tenant info. Use to verify connectivity. |
+| `list_projects` | List all projects in the current tenant. |
+| `create_project` | Create a new project in the current tenant. |
+| `get_progress` | Get progress summary for a project, including story counts by status. |
+| `import_stories` | Import stories into a project from a structured payload (Epic 12 import format). |
+
+### Story Tools
+
+| Tool | Description |
+|---|---|
+| `list_stories` | List stories for a project, optionally filtered by agent_status, verified_status, or epic_id. |
+| `list_ready_stories` | List stories that are ready to be worked on (contracted, dependencies met). |
+| `get_story` | Get full details for a single story by ID. |
+
+### Workflow Tools (agent key)
+
+| Tool | Description |
+|---|---|
+| `contract_story` | Agent acknowledges a story's acceptance criteria. Transitions pending -> contracted. |
+| `claim_story` | Agent claims a contracted story with pessimistic locking. Transitions contracted -> assigned. |
+| `start_story` | Agent starts work on a claimed story. Transitions assigned -> implementing. |
+| `request_review` | Agent signals implementation is complete and ready for review. |
+
+### Reviewer Tools (orchestrator key)
+
+| Tool | Description |
+|---|---|
+| `report_story` | Reviewer confirms the implementation is done. Transitions implementing -> reported_done. |
+| `review_complete` | Record that a review has been completed for a story. Required before verify. |
+
+### Verification Tools (orchestrator key)
+
+| Tool | Description |
+|---|---|
+| `verify_story` | Orchestrator verifies a reported_done story. Transitions reported_done -> verified. |
+| `reject_story` | Orchestrator rejects a story with a reason. |
+
+### Bulk Tools (orchestrator key)
+
+| Tool | Description |
+|---|---|
+| `bulk_mark_complete` | Bulk mark multiple stories as complete in a single API call. |
+| `verify_all_in_epic` | Bulk verify all reported_done, unverified stories in an epic. |
+
+### Discovery Tools
+
+| Tool | Description |
+|---|---|
+| `list_routes` | List all available API routes on the loopctl server. |
+
+## Chain-of-Custody Enforcement
+
+loopctl enforces that nobody marks their own work as done. The API returns `409` if the caller's identity matches the story's assigned agent:
+
+- `report_story` -- 409 `self_report_blocked`
+- `review_complete` -- 409 `self_review_blocked`
+- `verify_story` -- 409 `self_verify_blocked`
+
+The implementer's final action is `request_review`. All subsequent steps (report, review, verify) must come from different agents.
+
+## Troubleshooting
+
+### Connection errors
+
+- Verify `LOOPCTL_SERVER` is set and reachable
+- Check that the server URL includes the protocol (`https://`)
+- If using a self-signed certificate, set `NODE_TLS_REJECT_UNAUTHORIZED=0` in your environment (not recommended for production)
+
+### Authentication errors (401)
+
+- Verify your API key is correct and active
+- Check that the key has the right role for the operation (agent vs orchestrator)
+- Keys are prefixed with `lc_` -- ensure the full key is provided
+
+### Permission errors (403)
+
+- Orchestrator operations require an orchestrator-role key
+- Agent operations require an agent-role key
+- Chain-of-custody violations return 409, not 403
+
+### Tool not found
+
+- Ensure the MCP server is running (`npx loopctl-mcp-server` to test)
+- Check your `.mcp.json` configuration syntax
+- Restart your AI coding tool after configuration changes
+
+## Links
+
+- [loopctl.com](https://loopctl.com) -- landing page and documentation
+- [API docs](https://loopctl.com/swaggerui) -- Swagger UI
+- [GitHub](https://github.com/mkreyman/loopctl) -- source code
+- [npm](https://www.npmjs.com/package/loopctl-mcp-server) -- npm package
+
+## License
+
+MIT

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -61,7 +61,11 @@ async function apiCall(method, path, body, keyOverride) {
   try {
     response = await fetch(url, options);
   } catch (err) {
-    return { error: true, status: 0, body: `Network error: ${err.message}` };
+    if (err.name === "TimeoutError") {
+      return { error: true, status: 0, body: "Request timed out after 30s" };
+    }
+    const cause = err.cause?.message ? ` (${err.cause.message})` : "";
+    return { error: true, status: 0, body: `Network error: ${err.message}${cause}` };
   }
 
   if (response.status === 204) {
@@ -73,13 +77,24 @@ async function apiCall(method, path, body, keyOverride) {
   if (contentType.includes("application/json")) {
     responseBody = await response.json();
   } else {
-    responseBody = await response.text();
+    const text = await response.text();
+    try {
+      responseBody = JSON.parse(text);
+    } catch {
+      responseBody = text;
+    }
   }
 
   if (!response.ok) {
     let errorBody = responseBody;
     if (typeof errorBody === "string" && errorBody.length > 500) {
-      errorBody = errorBody.replace(/<[^>]+>/g, " ").trim().slice(0, 500) + "... (truncated)";
+      errorBody = errorBody
+        .replace(/<[^>]+>/g, " ")
+        .replace(/&amp;/g, "&").replace(/&lt;/g, "<").replace(/&gt;/g, ">")
+        .replace(/&quot;/g, '"').replace(/&#39;/g, "'").replace(/&nbsp;/g, " ")
+        .replace(/\s+/g, " ")
+        .trim()
+        .slice(0, 500) + "... (truncated)";
     }
     return { error: true, status: response.status, body: errorBody };
   }
@@ -88,6 +103,7 @@ async function apiCall(method, path, body, keyOverride) {
 }
 
 function toContent(result) {
+  const isErr = result && result.error === true;
   return {
     content: [
       {
@@ -95,6 +111,7 @@ function toContent(result) {
         text: JSON.stringify(result, null, 2),
       },
     ],
+    ...(isErr && { isError: true }),
   };
 }
 

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -16,7 +16,7 @@ import {
 // ---------------------------------------------------------------------------
 
 function getBaseUrl() {
-  return process.env.LOOPCTL_SERVER || "https://loopctl.com";
+  return (process.env.LOOPCTL_SERVER || "https://loopctl.com").replace(/\/$/, "");
 }
 
 /**
@@ -39,6 +39,10 @@ async function apiCall(method, path, body, keyOverride) {
   const url = `${getBaseUrl()}${path}`;
   const key = resolveKey(keyOverride);
 
+  if (!key) {
+    return { error: true, status: 0, body: "No API key configured. Set LOOPCTL_API_KEY, LOOPCTL_ORCH_KEY, or LOOPCTL_AGENT_KEY." };
+  }
+
   const options = {
     method,
     headers: {
@@ -46,13 +50,23 @@ async function apiCall(method, path, body, keyOverride) {
       "Content-Type": "application/json",
       Accept: "application/json",
     },
+    signal: AbortSignal.timeout(30_000),
   };
 
   if (body !== undefined && body !== null) {
     options.body = JSON.stringify(body);
   }
 
-  const response = await fetch(url, options);
+  let response;
+  try {
+    response = await fetch(url, options);
+  } catch (err) {
+    return { error: true, status: 0, body: `Network error: ${err.message}` };
+  }
+
+  if (response.status === 204) {
+    return { ok: true };
+  }
 
   let responseBody;
   const contentType = response.headers.get("content-type") || "";
@@ -63,11 +77,11 @@ async function apiCall(method, path, body, keyOverride) {
   }
 
   if (!response.ok) {
-    return {
-      error: true,
-      status: response.status,
-      body: responseBody,
-    };
+    let errorBody = responseBody;
+    if (typeof errorBody === "string" && errorBody.length > 500) {
+      errorBody = errorBody.replace(/<[^>]+>/g, " ").trim().slice(0, 500) + "... (truncated)";
+    }
+    return { error: true, status: response.status, body: errorBody };
   }
 
   return responseBody;
@@ -382,11 +396,11 @@ const TOOLS = [
           description: "Filter by epic UUID.",
         },
         limit: {
-          type: "number",
+          type: "integer",
           description: "Maximum number of stories to return.",
         },
         offset: {
-          type: "number",
+          type: "integer",
           description: "Number of stories to skip (for pagination).",
         },
       },
@@ -405,7 +419,7 @@ const TOOLS = [
           description: "The UUID of the project.",
         },
         limit: {
-          type: "number",
+          type: "integer",
           description: "Maximum number of stories to return.",
         },
       },
@@ -446,7 +460,7 @@ const TOOLS = [
           description: "Must match the story's title exactly (anti-confusion check).",
         },
         ac_count: {
-          type: "number",
+          type: "integer",
           description: "Must match the number of acceptance criteria in the story.",
         },
       },
@@ -545,15 +559,15 @@ const TOOLS = [
             "The type of review conducted (e.g. enhanced_6_agent, single_reviewer, orchestrator).",
         },
         findings_count: {
-          type: "number",
+          type: "integer",
           description: "Optional: number of findings from the review.",
         },
         fixes_count: {
-          type: "number",
+          type: "integer",
           description: "Number of fixes applied. fixes_count + disproved_count must equal findings_count.",
         },
         disproved_count: {
-          type: "number",
+          type: "integer",
           description: "Number of findings disproved as false positives. fixes_count + disproved_count must equal findings_count.",
         },
         summary: {
@@ -780,4 +794,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 // ---------------------------------------------------------------------------
 
 const transport = new StdioServerTransport();
-await server.connect(transport);
+await server.connect(transport).catch((err) => {
+  process.stderr.write(`loopctl MCP server failed to start: ${err.message}\n`);
+  process.exit(1);
+});

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -1,9 +1,8 @@
+#!/usr/bin/env node
+
 // loopctl MCP Server
 // Wraps the loopctl REST API into typed MCP tools for Claude Code agents.
 // Runs via stdio (stdin/stdout).
-
-// Self-signed cert support — must be set before any HTTPS requests
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
@@ -17,7 +16,7 @@ import {
 // ---------------------------------------------------------------------------
 
 function getBaseUrl() {
-  return process.env.LOOPCTL_SERVER || "https://192.168.86.55:8443";
+  return process.env.LOOPCTL_SERVER || "https://loopctl.com";
 }
 
 /**

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,14 +1,21 @@
 {
-  "name": "loopctl-mcp",
+  "name": "loopctl-mcp-server",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "loopctl-mcp",
+      "name": "loopctl-mcp-server",
       "version": "1.0.0",
+      "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "latest"
+        "@modelcontextprotocol/sdk": "^1.28.0"
+      },
+      "bin": {
+        "loopctl-mcp-server": "index.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@hono/node-server": {

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,13 +1,38 @@
 {
-  "name": "loopctl-mcp",
+  "name": "loopctl-mcp-server",
   "version": "1.0.0",
-  "description": "MCP server wrapping the loopctl REST API for Claude Code agents",
+  "description": "MCP server for loopctl — structural trust for AI development loops",
   "type": "module",
   "main": "index.js",
+  "bin": {
+    "loopctl-mcp-server": "index.js"
+  },
   "scripts": {
     "start": "node index.js"
   },
+  "keywords": [
+    "mcp",
+    "ai-agents",
+    "claude-code",
+    "loopctl",
+    "model-context-protocol",
+    "ai-development"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mkreyman/loopctl.git",
+    "directory": "mcp-server"
+  },
+  "homepage": "https://loopctl.com",
+  "license": "MIT",
+  "engines": {
+    "node": ">=18"
+  },
+  "files": [
+    "index.js",
+    "README.md"
+  ],
   "dependencies": {
-    "@modelcontextprotocol/sdk": "latest"
+    "@modelcontextprotocol/sdk": "^1.28.0"
   }
 }

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -24,13 +24,16 @@
     "directory": "mcp-server"
   },
   "homepage": "https://loopctl.com",
+  "author": "Mark Kreyman",
   "license": "MIT",
+  "exports": "./index.js",
   "engines": {
     "node": ">=18"
   },
   "files": [
     "index.js",
-    "README.md"
+    "README.md",
+    "LICENSE"
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.28.0"


### PR DESCRIPTION
## Summary

- Published `loopctl-mcp-server` package to npm (AC-19.1.1, AC-19.1.3)
- Removed `NODE_TLS_REJECT_UNAUTHORIZED = "0"` security bypass from index.js
- Updated default server URL from `192.168.86.55:8443` to `https://loopctl.com`
- Added `#!/usr/bin/env node` shebang for npx support
- Pinned `@modelcontextprotocol/sdk` to `^1.28.0` (was `latest`)
- Added proper package.json fields: bin, keywords, repository, homepage, license, engines, files
- Created `mcp-server/README.md` documenting all 19 tools, configuration, environment variables, and troubleshooting (AC-19.1.2)
- Created `.github/workflows/npm-publish.yml` for tag-based npm publishing on `mcp-v*` tags (AC-19.1.4)
- Updated landing page step 4 with `npm install loopctl-mcp-server` instructions (AC-19.1.5)
- Verified tool count (19) matches between landing page and actual package (AC-19.1.6)
- Updated docs page MCP config example to use `npx loopctl-mcp-server`
- Updated CLAUDE.md with correct tool count (19) and npm install instructions

## Remaining manual step

The `npm publish` command failed with 403 because the current npm credentials (`shopkeeper2`) lack publish permissions. After merging, run:

```bash
cd mcp-server
npm login  # authenticate with an account that has publish rights
npm publish
npm token create  # create CI token
gh secret set NPM_TOKEN --body "<token>" --repo mkreyman/loopctl
```

## Test plan

- [x] `mix precommit` passes (compile, format, credo, sobelow, dialyzer, 1133 tests)
- [x] Landing page compiles without warnings
- [x] Package name `loopctl-mcp-server` is available on npm
- [ ] After npm login fix: `npm publish` succeeds
- [ ] After publish: `npx loopctl-mcp-server` starts the server
- [ ] After publish: `npm install loopctl-mcp-server` installs correctly