### PR TITLE
Remove beta language from landing page

### DIFF
--- a/lib/loopctl_web/controllers/page_html/home.html.heex
+++ b/lib/loopctl_web/controllers/page_html/home.html.heex
@@ -153,7 +153,7 @@
                   v0.1.0
                 </span>
                 <span class="ml-3 text-sm font-medium text-slate-400">
-                  Now in public beta
+                  Free and open source
                 </span>
               </span>
             </div>
@@ -550,7 +550,7 @@
             Up and running in 5 minutes
           </p>
           <p class="mt-4 text-base text-slate-400 max-w-2xl">
-            loopctl is free during public beta. No credit card required. Rate limit: 300 requests per API key per minute.
+            loopctl is free to use. No credit card required. Rate limit: 300 requests per API key per minute.
           </p>
 
           <div class="mt-10 space-y-8">


### PR DESCRIPTION
Change 'Now in public beta' to 'Free and open source' and 'free during public beta' to 'free to use'