### PR TITLE
US-21.1: Token Usage Reporting Schema & Ingestion

### DIFF
--- a/lib/loopctl/progress.ex
+++ b/lib/loopctl/progress.ex
@@ -335,6 +335,7 @@ defmodule Loopctl.Progress do
     agent_id = Keyword.get(opts, :agent_id)
     actor_id = Keyword.get(opts, :actor_id)
     actor_label = Keyword.get(opts, :actor_label)
+    token_usage_params = Keyword.get(opts, :token_usage)
 
     multi =
       Multi.new()
@@ -359,6 +360,7 @@ defmodule Loopctl.Progress do
         |> AdminRepo.update()
       end)
       |> maybe_create_artifact(tenant_id, story_id, agent_id, artifact_params)
+      |> maybe_create_token_usage_report(tenant_id, story_id, agent_id, token_usage_params)
       |> Audit.log_in_multi(:audit, fn %{story: updated, lock: old} ->
         %{
           tenant_id: tenant_id,
@@ -376,6 +378,7 @@ defmodule Loopctl.Progress do
           }
         }
       end)
+      |> maybe_audit_token_usage(tenant_id, actor_id, actor_label, token_usage_params)
       |> EventGenerator.generate_events(:webhook_events, fn %{story: updated, lock: old} ->
         %{
           tenant_id: tenant_id,
@@ -400,6 +403,7 @@ defmodule Loopctl.Progress do
       {:error, :validate, reason, _} -> {:error, reason}
       {:error, :story, changeset, _} -> {:error, changeset}
       {:error, :artifact, changeset, _} -> {:error, changeset}
+      {:error, :token_usage_report, changeset, _} -> {:error, changeset}
     end
   end
 
@@ -1506,6 +1510,58 @@ defmodule Loopctl.Progress do
         |> ArtifactReport.create_changeset(params)
 
       AdminRepo.insert(changeset)
+    end)
+  end
+
+  defp maybe_create_token_usage_report(multi, _tenant_id, _story_id, _agent_id, nil), do: multi
+
+  defp maybe_create_token_usage_report(multi, tenant_id, story_id, agent_id, params) do
+    alias Loopctl.TokenUsage
+
+    Multi.run(multi, :token_usage_report, fn _repo, %{lock: story} ->
+      attrs =
+        params
+        |> Map.put("story_id", story_id)
+        |> Map.put("agent_id", agent_id)
+        |> Map.put("project_id", story.project_id)
+
+      changeset =
+        %TokenUsage.Report{
+          tenant_id: tenant_id,
+          story_id: story_id,
+          agent_id: agent_id,
+          project_id: story.project_id
+        }
+        |> TokenUsage.Report.create_changeset(attrs)
+
+      AdminRepo.insert(changeset)
+    end)
+  end
+
+  defp maybe_audit_token_usage(multi, _tenant_id, _actor_id, _actor_label, nil), do: multi
+
+  defp maybe_audit_token_usage(multi, tenant_id, actor_id, actor_label, _params) do
+    Audit.log_in_multi(multi, :audit_token_usage, fn changes ->
+      report = Map.get(changes, :token_usage_report)
+
+      %{
+        tenant_id: tenant_id,
+        entity_type: "token_usage_report",
+        entity_id: report.id,
+        action: "created",
+        actor_type: "api_key",
+        actor_id: actor_id,
+        actor_label: actor_label,
+        new_state: %{
+          "story_id" => report.story_id,
+          "agent_id" => report.agent_id,
+          "input_tokens" => report.input_tokens,
+          "output_tokens" => report.output_tokens,
+          "model_name" => report.model_name,
+          "cost_millicents" => report.cost_millicents,
+          "phase" => report.phase
+        }
+      }
     end)
   end
 

--- a/lib/loopctl/token_usage.ex
+++ b/lib/loopctl/token_usage.ex
@@ -66,7 +66,6 @@ defmodule Loopctl.TokenUsage do
     story_id = Map.get(attrs, :story_id)
     agent_id = Map.get(attrs, :agent_id)
     project_id = Map.get(attrs, :project_id)
-    skill_version_id = Map.get(attrs, :skill_version_id)
 
     changeset =
       %Report{
@@ -75,10 +74,13 @@ defmodule Loopctl.TokenUsage do
         agent_id: agent_id,
         project_id: project_id
       }
-      |> Report.create_changeset(maybe_put_skill_version(attrs, skill_version_id))
+      |> Report.create_changeset(attrs)
 
     case AdminRepo.insert(changeset) do
       {:ok, report} ->
+        # Refetch to populate the DB-generated total_tokens column
+        report = AdminRepo.get!(Report, report.id)
+
         # Audit log the creation
         Audit.create_log_entry(tenant_id, %{
           entity_type: "token_usage_report",
@@ -130,7 +132,6 @@ defmodule Loopctl.TokenUsage do
     story_id = Map.get(attrs, :story_id)
     agent_id = Map.get(attrs, :agent_id)
     project_id = Map.get(attrs, :project_id)
-    skill_version_id = Map.get(attrs, :skill_version_id)
 
     Ecto.Multi.insert(multi, name, fn _changes ->
       %Report{
@@ -139,7 +140,7 @@ defmodule Loopctl.TokenUsage do
         agent_id: agent_id,
         project_id: project_id
       }
-      |> Report.create_changeset(maybe_put_skill_version(attrs, skill_version_id))
+      |> Report.create_changeset(attrs)
     end)
   end
 
@@ -228,25 +229,29 @@ defmodule Loopctl.TokenUsage do
 
   # --- Private helpers ---
 
+  @known_attrs ~w(
+    story_id agent_id project_id skill_version_id
+    input_tokens output_tokens model_name cost_millicents
+    phase session_id metadata
+  )a
+
   defp normalize_attrs(attrs) when is_map(attrs) do
+    known_strings = MapSet.new(@known_attrs, &Atom.to_string/1)
+
     Map.new(attrs, fn
-      {k, v} when is_binary(k) -> {String.to_existing_atom(k), v}
-      {k, v} when is_atom(k) -> {k, v}
+      {k, v} when is_atom(k) ->
+        {k, v}
+
+      {k, v} when is_binary(k) ->
+        if MapSet.member?(known_strings, k) do
+          {String.to_existing_atom(k), v}
+        else
+          # Discard unknown string keys to prevent atom table exhaustion
+          {:__discard__, v}
+        end
     end)
-  rescue
-    ArgumentError -> Map.new(attrs, fn {k, v} -> {safe_to_atom(k), v} end)
+    |> Map.delete(:__discard__)
   end
-
-  defp safe_to_atom(k) when is_atom(k), do: k
-
-  defp safe_to_atom(k) when is_binary(k) do
-    String.to_existing_atom(k)
-  rescue
-    ArgumentError -> String.to_atom(k)
-  end
-
-  defp maybe_put_skill_version(attrs, nil), do: attrs
-  defp maybe_put_skill_version(attrs, _), do: attrs
 
   defp decimal_to_int(%Decimal{} = val), do: Decimal.to_integer(val)
   defp decimal_to_int(val) when is_integer(val), do: val

--- a/lib/loopctl/token_usage.ex
+++ b/lib/loopctl/token_usage.ex
@@ -1,0 +1,254 @@
+defmodule Loopctl.TokenUsage do
+  @moduledoc """
+  Context module for token usage reporting.
+
+  Provides functions to create and query token usage reports.
+  All functions take `tenant_id` as the first argument for multi-tenant
+  scoping.
+
+  ## Usage
+
+  ### Creating a report
+
+      Loopctl.TokenUsage.create_report(tenant_id, %{
+        story_id: story_id,
+        agent_id: agent_id,
+        project_id: project_id,
+        input_tokens: 1000,
+        output_tokens: 500,
+        model_name: "claude-opus-4",
+        cost_millicents: 2500,
+        phase: "implementing"
+      })
+
+  ### Listing reports for a story
+
+      Loopctl.TokenUsage.list_reports_for_story(tenant_id, story_id)
+
+  ### Getting totals for a story
+
+      Loopctl.TokenUsage.get_story_totals(tenant_id, story_id)
+  """
+
+  import Ecto.Query
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Audit
+  alias Loopctl.TokenUsage.Report
+
+  @doc """
+  Creates a new token usage report.
+
+  The `attrs` map must include: `story_id`, `agent_id`, `project_id`,
+  `input_tokens`, `output_tokens`, `model_name`, `cost_millicents`.
+
+  Optional: `phase`, `session_id`, `skill_version_id`, `metadata`.
+
+  The `tenant_id`, `agent_id`, `project_id`, and `story_id` are set
+  programmatically on the struct (not via cast).
+
+  ## Options (keyword list)
+
+  - `:actor_id` -- audit actor ID
+  - `:actor_label` -- audit actor label
+  - `:actor_type` -- audit actor type (default "api_key")
+
+  ## Returns
+
+  - `{:ok, %Report{}}` on success
+  - `{:error, %Ecto.Changeset{}}` on validation failure
+  """
+  @spec create_report(Ecto.UUID.t(), map(), keyword()) ::
+          {:ok, Report.t()} | {:error, Ecto.Changeset.t()}
+  def create_report(tenant_id, attrs, opts \\ []) do
+    attrs = normalize_attrs(attrs)
+
+    story_id = Map.get(attrs, :story_id)
+    agent_id = Map.get(attrs, :agent_id)
+    project_id = Map.get(attrs, :project_id)
+    skill_version_id = Map.get(attrs, :skill_version_id)
+
+    changeset =
+      %Report{
+        tenant_id: tenant_id,
+        story_id: story_id,
+        agent_id: agent_id,
+        project_id: project_id
+      }
+      |> Report.create_changeset(maybe_put_skill_version(attrs, skill_version_id))
+
+    case AdminRepo.insert(changeset) do
+      {:ok, report} ->
+        # Audit log the creation
+        Audit.create_log_entry(tenant_id, %{
+          entity_type: "token_usage_report",
+          entity_id: report.id,
+          action: "created",
+          actor_type: Keyword.get(opts, :actor_type, "api_key"),
+          actor_id: Keyword.get(opts, :actor_id),
+          actor_label: Keyword.get(opts, :actor_label),
+          new_state: %{
+            "story_id" => report.story_id,
+            "agent_id" => report.agent_id,
+            "project_id" => report.project_id,
+            "input_tokens" => report.input_tokens,
+            "output_tokens" => report.output_tokens,
+            "model_name" => report.model_name,
+            "cost_millicents" => report.cost_millicents,
+            "phase" => report.phase
+          }
+        })
+
+        {:ok, report}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
+  end
+
+  @doc """
+  Creates a token usage report within an Ecto.Multi pipeline.
+
+  Used by `Progress.report_story/4` to atomically create a token usage
+  report alongside a status transition.
+
+  ## Parameters
+
+  - `multi` -- the Ecto.Multi struct
+  - `name` -- the step name in the multi
+  - `tenant_id` -- the tenant UUID
+  - `attrs` -- map of report attributes (story_id, agent_id, project_id, etc.)
+
+  ## Returns
+
+  The updated Ecto.Multi struct.
+  """
+  @spec create_report_in_multi(Ecto.Multi.t(), atom(), Ecto.UUID.t(), map()) :: Ecto.Multi.t()
+  def create_report_in_multi(multi, name, tenant_id, attrs) do
+    attrs = normalize_attrs(attrs)
+
+    story_id = Map.get(attrs, :story_id)
+    agent_id = Map.get(attrs, :agent_id)
+    project_id = Map.get(attrs, :project_id)
+    skill_version_id = Map.get(attrs, :skill_version_id)
+
+    Ecto.Multi.insert(multi, name, fn _changes ->
+      %Report{
+        tenant_id: tenant_id,
+        story_id: story_id,
+        agent_id: agent_id,
+        project_id: project_id
+      }
+      |> Report.create_changeset(maybe_put_skill_version(attrs, skill_version_id))
+    end)
+  end
+
+  @doc """
+  Lists all token usage reports for a story, ordered by inserted_at descending.
+
+  Includes pagination and total count.
+
+  ## Options
+
+  - `:page` -- page number (default 1)
+  - `:page_size` -- entries per page (default 20, max 100)
+
+  ## Returns
+
+  `{:ok, %{data: [%Report{}], total: integer, page: integer, page_size: integer}}`
+  """
+  @spec list_reports_for_story(Ecto.UUID.t(), Ecto.UUID.t(), keyword()) ::
+          {:ok,
+           %{
+             data: [Report.t()],
+             total: non_neg_integer(),
+             page: pos_integer(),
+             page_size: pos_integer()
+           }}
+  def list_reports_for_story(tenant_id, story_id, opts \\ []) do
+    page = max(Keyword.get(opts, :page, 1), 1)
+    page_size = opts |> Keyword.get(:page_size, 20) |> max(1) |> min(100)
+    offset = (page - 1) * page_size
+
+    base_query =
+      Report
+      |> where([r], r.tenant_id == ^tenant_id and r.story_id == ^story_id)
+
+    total = AdminRepo.aggregate(base_query, :count, :id)
+
+    reports =
+      base_query
+      |> order_by([r], desc: r.inserted_at)
+      |> limit(^page_size)
+      |> offset(^offset)
+      |> AdminRepo.all()
+
+    {:ok, %{data: reports, total: total, page: page, page_size: page_size}}
+  end
+
+  @doc """
+  Returns aggregated token usage totals for a story.
+
+  ## Returns
+
+  `{:ok, %{total_input_tokens: integer, total_output_tokens: integer, total_tokens: integer, total_cost_millicents: integer, report_count: integer}}`
+  """
+  @spec get_story_totals(Ecto.UUID.t(), Ecto.UUID.t()) ::
+          {:ok,
+           %{
+             total_input_tokens: non_neg_integer(),
+             total_output_tokens: non_neg_integer(),
+             total_tokens: non_neg_integer(),
+             total_cost_millicents: non_neg_integer(),
+             report_count: non_neg_integer()
+           }}
+  def get_story_totals(tenant_id, story_id) do
+    query =
+      Report
+      |> where([r], r.tenant_id == ^tenant_id and r.story_id == ^story_id)
+      |> select([r], %{
+        total_input_tokens: coalesce(sum(r.input_tokens), 0),
+        total_output_tokens: coalesce(sum(r.output_tokens), 0),
+        total_tokens: coalesce(sum(r.input_tokens), 0) + coalesce(sum(r.output_tokens), 0),
+        total_cost_millicents: coalesce(sum(r.cost_millicents), 0),
+        report_count: count(r.id)
+      })
+
+    result = AdminRepo.one(query)
+
+    {:ok,
+     %{
+       total_input_tokens: decimal_to_int(result.total_input_tokens),
+       total_output_tokens: decimal_to_int(result.total_output_tokens),
+       total_tokens: decimal_to_int(result.total_tokens),
+       total_cost_millicents: decimal_to_int(result.total_cost_millicents),
+       report_count: result.report_count
+     }}
+  end
+
+  # --- Private helpers ---
+
+  defp normalize_attrs(attrs) when is_map(attrs) do
+    Map.new(attrs, fn
+      {k, v} when is_binary(k) -> {String.to_existing_atom(k), v}
+      {k, v} when is_atom(k) -> {k, v}
+    end)
+  rescue
+    ArgumentError -> Map.new(attrs, fn {k, v} -> {safe_to_atom(k), v} end)
+  end
+
+  defp safe_to_atom(k) when is_atom(k), do: k
+
+  defp safe_to_atom(k) when is_binary(k) do
+    String.to_existing_atom(k)
+  rescue
+    ArgumentError -> String.to_atom(k)
+  end
+
+  defp maybe_put_skill_version(attrs, nil), do: attrs
+  defp maybe_put_skill_version(attrs, _), do: attrs
+
+  defp decimal_to_int(%Decimal{} = val), do: Decimal.to_integer(val)
+  defp decimal_to_int(val) when is_integer(val), do: val
+  defp decimal_to_int(nil), do: 0
+end

--- a/lib/loopctl/token_usage/formatting.ex
+++ b/lib/loopctl/token_usage/formatting.ex
@@ -1,0 +1,112 @@
+defmodule Loopctl.TokenUsage.Formatting do
+  @moduledoc """
+  Formatting helpers for token usage display.
+
+  Provides human-readable formatting for token counts and costs.
+
+  ## Examples
+
+      iex> Loopctl.TokenUsage.Formatting.millicents_to_dollars(2500)
+      "0.03"
+
+      iex> Loopctl.TokenUsage.Formatting.format_tokens(1_500_000)
+      "1.5M"
+  """
+
+  @doc """
+  Converts millicents (1/1000 of a cent) to a dollar string rounded to 2 decimal places.
+
+  Uses round-half-up rounding (standard financial rounding).
+
+  ## Examples
+
+      iex> millicents_to_dollars(0)
+      "0.00"
+
+      iex> millicents_to_dollars(2500)
+      "0.03"
+
+      iex> millicents_to_dollars(100_000)
+      "1.00"
+
+      iex> millicents_to_dollars(155)
+      "0.00"
+  """
+  @spec millicents_to_dollars(integer() | Decimal.t()) :: String.t()
+  def millicents_to_dollars(%Decimal{} = millicents) do
+    millicents
+    |> Decimal.div(100_000)
+    |> Decimal.round(2, :half_up)
+    |> Decimal.to_string(:normal)
+    |> pad_dollars()
+  end
+
+  def millicents_to_dollars(millicents) when is_integer(millicents) do
+    # millicents / 100_000 = dollars
+    # Round to 2 decimal places using round-half-up
+    millicents
+    |> Decimal.new()
+    |> Decimal.div(100_000)
+    |> Decimal.round(2, :half_up)
+    |> Decimal.to_string(:normal)
+    |> pad_dollars()
+  end
+
+  @doc """
+  Formats a token count for human-readable display.
+
+  - Values under 1000 are shown as-is
+  - Values >= 1000 and < 1_000_000 are shown as "XK" or "X.YK"
+  - Values >= 1_000_000 are shown as "XM" or "X.YM"
+
+  ## Examples
+
+      iex> format_tokens(500)
+      "500"
+
+      iex> format_tokens(1000)
+      "1K"
+
+      iex> format_tokens(1500)
+      "1.5K"
+
+      iex> format_tokens(1_000_000)
+      "1M"
+
+      iex> format_tokens(2_500_000)
+      "2.5M"
+  """
+  @spec format_tokens(integer()) :: String.t()
+  def format_tokens(tokens) when is_integer(tokens) and tokens >= 1_000_000 do
+    whole = div(tokens, 1_000_000)
+    frac = div(rem(tokens, 1_000_000), 100_000)
+
+    if frac == 0 do
+      "#{whole}M"
+    else
+      "#{whole}.#{frac}M"
+    end
+  end
+
+  def format_tokens(tokens) when is_integer(tokens) and tokens >= 1000 do
+    whole = div(tokens, 1000)
+    frac = div(rem(tokens, 1000), 100)
+
+    if frac == 0 do
+      "#{whole}K"
+    else
+      "#{whole}.#{frac}K"
+    end
+  end
+
+  def format_tokens(tokens) when is_integer(tokens), do: to_string(tokens)
+
+  # Ensure dollar strings always have 2 decimal places
+  defp pad_dollars(str) do
+    case String.split(str, ".") do
+      [whole] -> whole <> ".00"
+      [whole, dec] when byte_size(dec) == 1 -> whole <> "." <> dec <> "0"
+      _ -> str
+    end
+  end
+end

--- a/lib/loopctl/token_usage/report.ex
+++ b/lib/loopctl/token_usage/report.ex
@@ -1,0 +1,98 @@
+defmodule Loopctl.TokenUsage.Report do
+  @moduledoc """
+  Schema for the `token_usage_reports` table.
+
+  Tracks token consumption and cost for agent work on stories.
+  Each report records input/output tokens, the model used, and cost
+  in millicents (1/1000 of a cent).
+
+  ## Fields
+
+  - `input_tokens` -- number of input tokens consumed
+  - `output_tokens` -- number of output tokens consumed
+  - `total_tokens` -- generated column: input_tokens + output_tokens (read-only)
+  - `model_name` -- name of the LLM model used (e.g., "claude-opus-4")
+  - `cost_millicents` -- cost in 1/1000 of a cent (e.g., 2500 = $0.025)
+  - `phase` -- work phase: planning, implementing, reviewing, other
+  - `session_id` -- optional session identifier
+  - `skill_version_id` -- optional FK to skill_versions
+  - `metadata` -- extensible JSONB map
+  """
+
+  use Loopctl.Schema
+
+  @type t :: %__MODULE__{}
+
+  @phases ~w(planning implementing reviewing other)
+
+  @derive {Jason.Encoder,
+           only: [
+             :id,
+             :tenant_id,
+             :story_id,
+             :agent_id,
+             :project_id,
+             :input_tokens,
+             :output_tokens,
+             :total_tokens,
+             :model_name,
+             :cost_millicents,
+             :phase,
+             :session_id,
+             :skill_version_id,
+             :metadata,
+             :inserted_at,
+             :updated_at
+           ]}
+
+  schema "token_usage_reports" do
+    tenant_field()
+    belongs_to :story, Loopctl.WorkBreakdown.Story
+    belongs_to :agent, Loopctl.Agents.Agent
+    belongs_to :project, Loopctl.Projects.Project
+    belongs_to :skill_version, Loopctl.Skills.SkillVersion
+
+    field :input_tokens, :integer
+    field :output_tokens, :integer
+    field :total_tokens, :integer
+    field :model_name, :string
+    field :cost_millicents, :integer
+    field :phase, :string, default: "other"
+    field :session_id, :string
+    field :metadata, :map, default: %{}
+
+    timestamps()
+  end
+
+  @doc """
+  Changeset for creating a new token usage report.
+
+  The `tenant_id`, `agent_id`, and `project_id` are set programmatically
+  and must not be in cast.
+  """
+  @spec create_changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
+  def create_changeset(report \\ %__MODULE__{}, attrs) do
+    report
+    |> cast(attrs, [
+      :input_tokens,
+      :output_tokens,
+      :model_name,
+      :cost_millicents,
+      :phase,
+      :session_id,
+      :skill_version_id,
+      :metadata
+    ])
+    |> validate_required([:input_tokens, :output_tokens, :model_name, :cost_millicents])
+    |> validate_number(:input_tokens, greater_than_or_equal_to: 0)
+    |> validate_number(:output_tokens, greater_than_or_equal_to: 0)
+    |> validate_number(:cost_millicents, greater_than_or_equal_to: 0)
+    |> validate_inclusion(:phase, @phases)
+    |> validate_length(:model_name, min: 1)
+    |> foreign_key_constraint(:tenant_id)
+    |> foreign_key_constraint(:story_id)
+    |> foreign_key_constraint(:agent_id)
+    |> foreign_key_constraint(:project_id)
+    |> foreign_key_constraint(:skill_version_id)
+  end
+end

--- a/lib/loopctl_web/controllers/story_status_controller.ex
+++ b/lib/loopctl_web/controllers/story_status_controller.ex
@@ -281,7 +281,11 @@ defmodule LoopctlWeb.StoryStatusController do
   end
 
   defp do_report(conn, tenant_id, api_key, story_id, params) do
-    opts = Keyword.merge(AuditContext.from_conn(conn), agent_id: api_key.agent_id)
+    opts =
+      AuditContext.from_conn(conn)
+      |> Keyword.merge(agent_id: api_key.agent_id)
+      |> maybe_add_token_usage(params)
+
     artifact_params = extract_artifact_params(params)
 
     case Progress.report_story(tenant_id, story_id, opts, artifact_params) do
@@ -345,4 +349,10 @@ defmodule LoopctlWeb.StoryStatusController do
   end
 
   defp extract_artifact_params(_), do: nil
+
+  defp maybe_add_token_usage(opts, %{"token_usage" => token_usage}) when is_map(token_usage) do
+    Keyword.put(opts, :token_usage, token_usage)
+  end
+
+  defp maybe_add_token_usage(opts, _params), do: opts
 end

--- a/lib/loopctl_web/controllers/token_usage_controller.ex
+++ b/lib/loopctl_web/controllers/token_usage_controller.ex
@@ -1,0 +1,210 @@
+defmodule LoopctlWeb.TokenUsageController do
+  @moduledoc """
+  Controller for token usage reporting.
+
+  - `POST /api/v1/token-usage` -- create a standalone token usage report (agent+)
+  - `GET /api/v1/stories/:story_id/token-usage` -- list reports for a story (agent+)
+  """
+
+  use LoopctlWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Loopctl.ApiSpec.Schemas
+  alias Loopctl.TokenUsage
+  alias Loopctl.TokenUsage.Formatting
+  alias Loopctl.WorkBreakdown.Stories
+  alias LoopctlWeb.AuditContext
+
+  action_fallback LoopctlWeb.FallbackController
+
+  plug LoopctlWeb.Plugs.RequireRole, [role: :agent] when action in [:create, :index]
+
+  tags(["Token Usage"])
+
+  operation(:create,
+    summary: "Create token usage report",
+    description:
+      "Creates a standalone token usage report for a story without triggering a status transition.",
+    request_body:
+      {"Token usage params", "application/json",
+       %OpenApiSpex.Schema{
+         type: :object,
+         required: [:story_id, :input_tokens, :output_tokens, :model_name, :cost_millicents],
+         properties: %{
+           story_id: %OpenApiSpex.Schema{type: :string, format: :uuid},
+           input_tokens: %OpenApiSpex.Schema{type: :integer, minimum: 0},
+           output_tokens: %OpenApiSpex.Schema{type: :integer, minimum: 0},
+           model_name: %OpenApiSpex.Schema{type: :string, minLength: 1},
+           cost_millicents: %OpenApiSpex.Schema{type: :integer, minimum: 0},
+           phase: %OpenApiSpex.Schema{
+             type: :string,
+             enum: ["planning", "implementing", "reviewing", "other"]
+           },
+           session_id: %OpenApiSpex.Schema{type: :string, nullable: true},
+           skill_version_id: %OpenApiSpex.Schema{
+             type: :string,
+             format: :uuid,
+             nullable: true
+           },
+           metadata: %OpenApiSpex.Schema{type: :object, additionalProperties: true}
+         }
+       }},
+    responses: %{
+      201 =>
+        {"Report created", "application/json",
+         %OpenApiSpex.Schema{type: :object, additionalProperties: true}},
+      404 => {"Story not found", "application/json", Schemas.ErrorResponse},
+      422 => {"Validation error", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  operation(:index,
+    summary: "List token usage reports for a story",
+    description:
+      "Returns all token usage reports for a story, ordered by inserted_at descending. Includes totals.",
+    parameters: [
+      story_id: [in: :path, type: :string, description: "Story UUID"],
+      page: [in: :query, type: :integer, description: "Page number"],
+      page_size: [in: :query, type: :integer, description: "Items per page"]
+    ],
+    responses: %{
+      200 =>
+        {"Token usage list", "application/json",
+         %OpenApiSpex.Schema{
+           type: :object,
+           properties: %{
+             data: %OpenApiSpex.Schema{
+               type: :array,
+               items: %OpenApiSpex.Schema{type: :object, additionalProperties: true}
+             },
+             totals: %OpenApiSpex.Schema{type: :object, additionalProperties: true},
+             meta: Schemas.PaginationMeta
+           }
+         }},
+      404 => {"Story not found", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  @doc """
+  POST /api/v1/token-usage
+
+  Creates a standalone token usage report for a story. The agent_id is set from
+  the authenticated API key. The project_id is derived from the story's epic.
+  """
+  def create(conn, params) do
+    api_key = conn.assigns.current_api_key
+    tenant_id = api_key.tenant_id
+    story_id = params["story_id"]
+
+    with {:ok, story_id} <- require_story_id(story_id),
+         {:ok, story} <- Stories.get_story(tenant_id, story_id) do
+      do_create(conn, tenant_id, api_key, story, params)
+    end
+  end
+
+  defp do_create(conn, tenant_id, api_key, story, params) do
+    audit_opts = AuditContext.from_conn(conn)
+
+    attrs =
+      params
+      |> Map.put("agent_id", api_key.agent_id)
+      |> Map.put("project_id", story.project_id)
+
+    case TokenUsage.create_report(tenant_id, attrs, audit_opts) do
+      {:ok, report} ->
+        conn
+        |> put_status(:created)
+        |> json(%{token_usage_report: format_report(report)})
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:error, changeset}
+    end
+  end
+
+  @doc """
+  GET /api/v1/stories/:story_id/token-usage
+
+  Lists all token usage reports for a story with pagination and totals.
+  """
+  def index(conn, %{"story_id" => story_id} = params) do
+    api_key = conn.assigns.current_api_key
+    tenant_id = api_key.tenant_id
+
+    with {:ok, _story} <- Stories.get_story(tenant_id, story_id) do
+      opts =
+        []
+        |> maybe_add_opt(:page, parse_int(params["page"]))
+        |> maybe_add_opt(:page_size, parse_int(params["page_size"]))
+
+      {:ok, result} = TokenUsage.list_reports_for_story(tenant_id, story_id, opts)
+      {:ok, totals} = TokenUsage.get_story_totals(tenant_id, story_id)
+
+      json(conn, %{
+        data: Enum.map(result.data, &format_report/1),
+        totals: format_totals(totals),
+        meta: %{
+          page: result.page,
+          page_size: result.page_size,
+          total_count: result.total,
+          total_pages: ceil_div(result.total, result.page_size)
+        }
+      })
+    end
+  end
+
+  # --- Private helpers ---
+
+  defp format_report(report) do
+    %{
+      id: report.id,
+      tenant_id: report.tenant_id,
+      story_id: report.story_id,
+      agent_id: report.agent_id,
+      project_id: report.project_id,
+      input_tokens: report.input_tokens,
+      output_tokens: report.output_tokens,
+      total_tokens: report.total_tokens,
+      model_name: report.model_name,
+      cost_millicents: report.cost_millicents,
+      cost_dollars: Formatting.millicents_to_dollars(report.cost_millicents),
+      phase: report.phase,
+      session_id: report.session_id,
+      skill_version_id: report.skill_version_id,
+      metadata: report.metadata,
+      inserted_at: report.inserted_at,
+      updated_at: report.updated_at
+    }
+  end
+
+  defp format_totals(totals) do
+    %{
+      total_input_tokens: totals.total_input_tokens,
+      total_output_tokens: totals.total_output_tokens,
+      total_tokens: totals.total_tokens,
+      total_cost_millicents: totals.total_cost_millicents,
+      total_cost_dollars: Formatting.millicents_to_dollars(totals.total_cost_millicents),
+      report_count: totals.report_count
+    }
+  end
+
+  defp require_story_id(nil), do: {:error, :unprocessable_entity, "story_id is required"}
+  defp require_story_id(story_id), do: {:ok, story_id}
+
+  defp parse_int(nil), do: nil
+
+  defp parse_int(val) when is_binary(val) do
+    case Integer.parse(val) do
+      {n, _} -> n
+      :error -> nil
+    end
+  end
+
+  defp parse_int(val) when is_integer(val), do: val
+
+  defp maybe_add_opt(opts, _key, nil), do: opts
+  defp maybe_add_opt(opts, key, value), do: Keyword.put(opts, key, value)
+
+  defp ceil_div(numerator, denominator), do: ceil(numerator / denominator)
+end

--- a/lib/loopctl_web/controllers/token_usage_controller.ex
+++ b/lib/loopctl_web/controllers/token_usage_controller.ex
@@ -98,7 +98,8 @@ defmodule LoopctlWeb.TokenUsageController do
     tenant_id = api_key.tenant_id
     story_id = params["story_id"]
 
-    with {:ok, story_id} <- require_story_id(story_id),
+    with {:ok, _} <- require_agent_id(api_key.agent_id),
+         {:ok, story_id} <- require_story_id(story_id),
          {:ok, story} <- Stories.get_story(tenant_id, story_id) do
       do_create(conn, tenant_id, api_key, story, params)
     end
@@ -188,6 +189,13 @@ defmodule LoopctlWeb.TokenUsageController do
       report_count: totals.report_count
     }
   end
+
+  defp require_agent_id(nil),
+    do:
+      {:error, :unprocessable_entity,
+       "API key must be associated with an agent to report token usage"}
+
+  defp require_agent_id(agent_id), do: {:ok, agent_id}
 
   defp require_story_id(nil), do: {:error, :unprocessable_entity, "story_id is required"}
   defp require_story_id(story_id), do: {:ok, story_id}

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -201,6 +201,10 @@ defmodule LoopctlWeb.Router do
     get "/skills/:id/stats", SkillController, :stats
     get "/skills/:id/versions/:version/results", SkillController, :version_results
 
+    # Token usage (Epic 19)
+    post "/token-usage", TokenUsageController, :create
+    get "/stories/:story_id/token-usage", TokenUsageController, :index
+
     # Skill results
     post "/skill_results", SkillResultController, :create
   end

--- a/priv/repo/migrations/20260403204852_create_token_usage_reports.exs
+++ b/priv/repo/migrations/20260403204852_create_token_usage_reports.exs
@@ -1,0 +1,53 @@
+defmodule Loopctl.Repo.Migrations.CreateTokenUsageReports do
+  use Ecto.Migration
+  import Loopctl.Repo.RlsHelpers
+
+  def change do
+    create table(:token_usage_reports, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      add :tenant_id, references(:tenants, type: :binary_id, on_delete: :delete_all), null: false
+      add :story_id, references(:stories, type: :binary_id, on_delete: :delete_all), null: false
+      add :agent_id, references(:agents, type: :binary_id, on_delete: :delete_all), null: false
+
+      add :project_id, references(:projects, type: :binary_id, on_delete: :delete_all),
+        null: false
+
+      add :input_tokens, :bigint, null: false
+      add :output_tokens, :bigint, null: false
+
+      add :model_name, :string, null: false
+      add :cost_millicents, :bigint, null: false
+
+      add :phase, :string, null: false, default: "other"
+      add :session_id, :string
+
+      add :skill_version_id,
+          references(:skill_versions, type: :binary_id, on_delete: :nilify_all)
+
+      add :metadata, :map, default: %{}
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    # Generated column: total_tokens = input_tokens + output_tokens
+    execute(
+      "ALTER TABLE token_usage_reports ADD COLUMN total_tokens bigint GENERATED ALWAYS AS (input_tokens + output_tokens) STORED",
+      "ALTER TABLE token_usage_reports DROP COLUMN total_tokens"
+    )
+
+    # Phase CHECK constraint
+    execute(
+      "ALTER TABLE token_usage_reports ADD CONSTRAINT token_usage_reports_phase_check CHECK (phase IN ('planning', 'implementing', 'reviewing', 'other'))",
+      "ALTER TABLE token_usage_reports DROP CONSTRAINT token_usage_reports_phase_check"
+    )
+
+    # Composite indexes for common query patterns
+    create index(:token_usage_reports, [:tenant_id, :story_id])
+    create index(:token_usage_reports, [:tenant_id, :agent_id])
+    create index(:token_usage_reports, [:tenant_id, :project_id])
+    create index(:token_usage_reports, [:tenant_id, :inserted_at])
+
+    enable_rls(:token_usage_reports)
+  end
+end

--- a/test/loopctl/token_usage/formatting_test.exs
+++ b/test/loopctl/token_usage/formatting_test.exs
@@ -1,0 +1,81 @@
+defmodule Loopctl.TokenUsage.FormattingTest do
+  use ExUnit.Case, async: true
+
+  alias Loopctl.TokenUsage.Formatting
+
+  describe "millicents_to_dollars/1" do
+    test "converts 0 to 0.00" do
+      assert Formatting.millicents_to_dollars(0) == "0.00"
+    end
+
+    test "converts 2500 millicents to 0.03" do
+      # 2500 / 100_000 = 0.025 -> round half up -> 0.03
+      assert Formatting.millicents_to_dollars(2500) == "0.03"
+    end
+
+    test "converts 100_000 millicents to 1.00" do
+      assert Formatting.millicents_to_dollars(100_000) == "1.00"
+    end
+
+    test "converts 155 millicents to 0.00" do
+      # 155 / 100_000 = 0.00155 -> rounds to 0.00
+      assert Formatting.millicents_to_dollars(155) == "0.00"
+    end
+
+    test "converts 1_000_000 millicents to 10.00" do
+      assert Formatting.millicents_to_dollars(1_000_000) == "10.00"
+    end
+
+    test "converts 50 millicents to 0.00" do
+      assert Formatting.millicents_to_dollars(50) == "0.00"
+    end
+
+    test "converts 5000 millicents to 0.05" do
+      assert Formatting.millicents_to_dollars(5000) == "0.05"
+    end
+
+    test "converts 250_000 to 2.50" do
+      assert Formatting.millicents_to_dollars(250_000) == "2.50"
+    end
+  end
+
+  describe "format_tokens/1" do
+    test "formats values under 1000 as-is" do
+      assert Formatting.format_tokens(0) == "0"
+      assert Formatting.format_tokens(500) == "500"
+      assert Formatting.format_tokens(999) == "999"
+    end
+
+    test "formats 1000 as 1K" do
+      assert Formatting.format_tokens(1000) == "1K"
+    end
+
+    test "formats 1500 as 1.5K" do
+      assert Formatting.format_tokens(1500) == "1.5K"
+    end
+
+    test "formats 10000 as 10K" do
+      assert Formatting.format_tokens(10_000) == "10K"
+    end
+
+    test "formats 999_000 as 999K" do
+      assert Formatting.format_tokens(999_000) == "999K"
+    end
+
+    test "formats 1_000_000 as 1M" do
+      assert Formatting.format_tokens(1_000_000) == "1M"
+    end
+
+    test "formats 1_500_000 as 1.5M" do
+      assert Formatting.format_tokens(1_500_000) == "1.5M"
+    end
+
+    test "formats 2_500_000 as 2.5M" do
+      assert Formatting.format_tokens(2_500_000) == "2.5M"
+    end
+
+    test "formats 10_000_000 as 10M" do
+      assert Formatting.format_tokens(10_000_000) == "10M"
+    end
+  end
+end

--- a/test/loopctl/token_usage_test.exs
+++ b/test/loopctl/token_usage_test.exs
@@ -1,0 +1,442 @@
+defmodule Loopctl.TokenUsageTest do
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.TokenUsage
+  alias Loopctl.TokenUsage.Report
+
+  setup :verify_on_exit!
+
+  defp setup_story do
+    tenant = fixture(:tenant)
+    project = fixture(:project, %{tenant_id: tenant.id})
+    epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+    agent = fixture(:agent, %{tenant_id: tenant.id})
+
+    story =
+      fixture(:story, %{
+        tenant_id: tenant.id,
+        epic_id: epic.id,
+        project_id: project.id
+      })
+
+    %{
+      tenant: tenant,
+      project: project,
+      epic: epic,
+      agent: agent,
+      story: story
+    }
+  end
+
+  # --- create_report/3 ---
+
+  describe "create_report/3" do
+    test "creates a token usage report with valid attributes" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_story()
+
+      attrs = %{
+        story_id: story.id,
+        agent_id: agent.id,
+        project_id: project.id,
+        input_tokens: 1000,
+        output_tokens: 500,
+        model_name: "claude-opus-4",
+        cost_millicents: 2500,
+        phase: "implementing"
+      }
+
+      assert {:ok, %Report{} = report} = TokenUsage.create_report(tenant.id, attrs)
+
+      assert report.tenant_id == tenant.id
+      assert report.story_id == story.id
+      assert report.agent_id == agent.id
+      assert report.project_id == project.id
+      assert report.input_tokens == 1000
+      assert report.output_tokens == 500
+      assert report.model_name == "claude-opus-4"
+      assert report.cost_millicents == 2500
+      assert report.phase == "implementing"
+    end
+
+    test "total_tokens is generated from input + output" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_story()
+
+      attrs = %{
+        story_id: story.id,
+        agent_id: agent.id,
+        project_id: project.id,
+        input_tokens: 3000,
+        output_tokens: 1500,
+        model_name: "claude-sonnet-4",
+        cost_millicents: 1200
+      }
+
+      {:ok, report} = TokenUsage.create_report(tenant.id, attrs)
+
+      # Re-fetch to get generated column value
+      report = Loopctl.AdminRepo.get!(Report, report.id)
+      assert report.total_tokens == 4500
+    end
+
+    test "defaults phase to 'other' when not specified" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_story()
+
+      attrs = %{
+        story_id: story.id,
+        agent_id: agent.id,
+        project_id: project.id,
+        input_tokens: 100,
+        output_tokens: 50,
+        model_name: "claude-sonnet-4",
+        cost_millicents: 100
+      }
+
+      {:ok, report} = TokenUsage.create_report(tenant.id, attrs)
+      assert report.phase == "other"
+    end
+
+    test "accepts optional session_id and metadata" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_story()
+
+      attrs = %{
+        story_id: story.id,
+        agent_id: agent.id,
+        project_id: project.id,
+        input_tokens: 100,
+        output_tokens: 50,
+        model_name: "gpt-4o",
+        cost_millicents: 500,
+        session_id: "session-abc-123",
+        metadata: %{"tool_calls" => 5}
+      }
+
+      {:ok, report} = TokenUsage.create_report(tenant.id, attrs)
+      assert report.session_id == "session-abc-123"
+      assert report.metadata == %{"tool_calls" => 5}
+    end
+
+    test "returns error when input_tokens is negative" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_story()
+
+      attrs = %{
+        story_id: story.id,
+        agent_id: agent.id,
+        project_id: project.id,
+        input_tokens: -1,
+        output_tokens: 50,
+        model_name: "claude-opus-4",
+        cost_millicents: 100
+      }
+
+      assert {:error, changeset} = TokenUsage.create_report(tenant.id, attrs)
+      assert errors_on(changeset).input_tokens != []
+    end
+
+    test "returns error when output_tokens is negative" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_story()
+
+      attrs = %{
+        story_id: story.id,
+        agent_id: agent.id,
+        project_id: project.id,
+        input_tokens: 100,
+        output_tokens: -5,
+        model_name: "claude-opus-4",
+        cost_millicents: 100
+      }
+
+      assert {:error, changeset} = TokenUsage.create_report(tenant.id, attrs)
+      assert errors_on(changeset).output_tokens != []
+    end
+
+    test "returns error when cost_millicents is negative" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_story()
+
+      attrs = %{
+        story_id: story.id,
+        agent_id: agent.id,
+        project_id: project.id,
+        input_tokens: 100,
+        output_tokens: 50,
+        model_name: "claude-opus-4",
+        cost_millicents: -1
+      }
+
+      assert {:error, changeset} = TokenUsage.create_report(tenant.id, attrs)
+      assert errors_on(changeset).cost_millicents != []
+    end
+
+    test "returns error when model_name is empty" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_story()
+
+      attrs = %{
+        story_id: story.id,
+        agent_id: agent.id,
+        project_id: project.id,
+        input_tokens: 100,
+        output_tokens: 50,
+        model_name: "",
+        cost_millicents: 100
+      }
+
+      assert {:error, changeset} = TokenUsage.create_report(tenant.id, attrs)
+      assert errors_on(changeset).model_name != []
+    end
+
+    test "returns error when model_name is missing" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_story()
+
+      attrs = %{
+        story_id: story.id,
+        agent_id: agent.id,
+        project_id: project.id,
+        input_tokens: 100,
+        output_tokens: 50,
+        cost_millicents: 100
+      }
+
+      assert {:error, changeset} = TokenUsage.create_report(tenant.id, attrs)
+      assert errors_on(changeset).model_name != []
+    end
+
+    test "returns error with invalid phase" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_story()
+
+      attrs = %{
+        story_id: story.id,
+        agent_id: agent.id,
+        project_id: project.id,
+        input_tokens: 100,
+        output_tokens: 50,
+        model_name: "claude-opus-4",
+        cost_millicents: 100,
+        phase: "invalid_phase"
+      }
+
+      assert {:error, changeset} = TokenUsage.create_report(tenant.id, attrs)
+      assert errors_on(changeset).phase != []
+    end
+
+    test "creates an audit log entry" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_story()
+
+      attrs = %{
+        story_id: story.id,
+        agent_id: agent.id,
+        project_id: project.id,
+        input_tokens: 1000,
+        output_tokens: 500,
+        model_name: "claude-opus-4",
+        cost_millicents: 2500
+      }
+
+      {:ok, report} = TokenUsage.create_report(tenant.id, attrs, actor_id: Ecto.UUID.generate())
+
+      {:ok, result} =
+        Loopctl.Audit.list_entries(tenant.id,
+          entity_type: "token_usage_report",
+          entity_id: report.id,
+          action: "created"
+        )
+
+      assert length(result.data) == 1
+      audit = hd(result.data)
+      assert audit.entity_type == "token_usage_report"
+      assert audit.action == "created"
+      assert audit.new_state["input_tokens"] == 1000
+      assert audit.new_state["model_name"] == "claude-opus-4"
+    end
+
+    test "accepts string keys in attrs" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_story()
+
+      attrs = %{
+        "story_id" => story.id,
+        "agent_id" => agent.id,
+        "project_id" => project.id,
+        "input_tokens" => 1000,
+        "output_tokens" => 500,
+        "model_name" => "claude-opus-4",
+        "cost_millicents" => 2500
+      }
+
+      assert {:ok, %Report{}} = TokenUsage.create_report(tenant.id, attrs)
+    end
+  end
+
+  # --- list_reports_for_story/3 ---
+
+  describe "list_reports_for_story/3" do
+    test "returns reports ordered by inserted_at descending" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_story()
+
+      for i <- 1..3 do
+        fixture(:token_usage_report, %{
+          tenant_id: tenant.id,
+          story_id: story.id,
+          agent_id: agent.id,
+          project_id: project.id,
+          input_tokens: i * 100
+        })
+      end
+
+      {:ok, result} = TokenUsage.list_reports_for_story(tenant.id, story.id)
+
+      assert length(result.data) == 3
+      assert result.total == 3
+      assert result.page == 1
+
+      # Should be in descending order
+      tokens = Enum.map(result.data, & &1.input_tokens)
+      assert tokens == Enum.sort(tokens, :desc)
+    end
+
+    test "paginates results" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_story()
+
+      for _i <- 1..5 do
+        fixture(:token_usage_report, %{
+          tenant_id: tenant.id,
+          story_id: story.id,
+          agent_id: agent.id,
+          project_id: project.id
+        })
+      end
+
+      {:ok, result} =
+        TokenUsage.list_reports_for_story(tenant.id, story.id, page: 1, page_size: 2)
+
+      assert length(result.data) == 2
+      assert result.total == 5
+      assert result.page_size == 2
+
+      {:ok, result2} =
+        TokenUsage.list_reports_for_story(tenant.id, story.id, page: 2, page_size: 2)
+
+      assert length(result2.data) == 2
+    end
+
+    test "returns empty list for story with no reports" do
+      %{tenant: tenant, story: story} = setup_story()
+
+      {:ok, result} = TokenUsage.list_reports_for_story(tenant.id, story.id)
+      assert result.data == []
+      assert result.total == 0
+    end
+  end
+
+  # --- get_story_totals/2 ---
+
+  describe "get_story_totals/2" do
+    test "returns aggregated totals" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_story()
+
+      fixture(:token_usage_report, %{
+        tenant_id: tenant.id,
+        story_id: story.id,
+        agent_id: agent.id,
+        project_id: project.id,
+        input_tokens: 1000,
+        output_tokens: 500,
+        cost_millicents: 2500
+      })
+
+      fixture(:token_usage_report, %{
+        tenant_id: tenant.id,
+        story_id: story.id,
+        agent_id: agent.id,
+        project_id: project.id,
+        input_tokens: 2000,
+        output_tokens: 1000,
+        cost_millicents: 5000
+      })
+
+      {:ok, totals} = TokenUsage.get_story_totals(tenant.id, story.id)
+
+      assert totals.total_input_tokens == 3000
+      assert totals.total_output_tokens == 1500
+      assert totals.total_tokens == 4500
+      assert totals.total_cost_millicents == 7500
+      assert totals.report_count == 2
+    end
+
+    test "returns zeros when no reports exist" do
+      %{tenant: tenant, story: story} = setup_story()
+
+      {:ok, totals} = TokenUsage.get_story_totals(tenant.id, story.id)
+
+      assert totals.total_input_tokens == 0
+      assert totals.total_output_tokens == 0
+      assert totals.total_tokens == 0
+      assert totals.total_cost_millicents == 0
+      assert totals.report_count == 0
+    end
+  end
+
+  # --- Tenant isolation ---
+
+  describe "tenant isolation" do
+    test "tenant A cannot see tenant B's token usage reports" do
+      %{tenant: tenant_a, story: story_a, agent: agent_a, project: project_a} = setup_story()
+
+      fixture(:token_usage_report, %{
+        tenant_id: tenant_a.id,
+        story_id: story_a.id,
+        agent_id: agent_a.id,
+        project_id: project_a.id
+      })
+
+      tenant_b = fixture(:tenant)
+
+      # Tenant B should see zero reports for the same story_id
+      {:ok, result} = TokenUsage.list_reports_for_story(tenant_b.id, story_a.id)
+      assert result.data == []
+      assert result.total == 0
+
+      {:ok, totals} = TokenUsage.get_story_totals(tenant_b.id, story_a.id)
+      assert totals.report_count == 0
+    end
+  end
+
+  # --- Fixture test ---
+
+  describe "fixture/2" do
+    test "creates a token usage report with auto-dependency resolution" do
+      report = fixture(:token_usage_report)
+
+      assert report.id != nil
+      assert report.tenant_id != nil
+      assert report.story_id != nil
+      assert report.agent_id != nil
+      assert report.project_id != nil
+      assert report.input_tokens == 1000
+      assert report.output_tokens == 500
+      assert report.model_name == "claude-opus-4"
+      assert report.cost_millicents == 2500
+    end
+
+    test "creates a token usage report with custom attributes" do
+      tenant = fixture(:tenant)
+      agent = fixture(:agent, %{tenant_id: tenant.id})
+
+      report =
+        fixture(:token_usage_report, %{
+          tenant_id: tenant.id,
+          agent_id: agent.id,
+          input_tokens: 5000,
+          output_tokens: 2000,
+          model_name: "gpt-4o",
+          cost_millicents: 8000,
+          phase: "reviewing"
+        })
+
+      assert report.tenant_id == tenant.id
+      assert report.agent_id == agent.id
+      assert report.input_tokens == 5000
+      assert report.output_tokens == 2000
+      assert report.model_name == "gpt-4o"
+      assert report.cost_millicents == 8000
+      assert report.phase == "reviewing"
+    end
+  end
+end

--- a/test/loopctl_web/controllers/token_usage_controller_test.exs
+++ b/test/loopctl_web/controllers/token_usage_controller_test.exs
@@ -1,0 +1,508 @@
+defmodule LoopctlWeb.TokenUsageControllerTest do
+  use LoopctlWeb.ConnCase, async: true
+
+  setup :verify_on_exit!
+
+  defp auth_conn(conn, raw_key) do
+    put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  defp setup_story_with_keys do
+    tenant = fixture(:tenant)
+    project = fixture(:project, %{tenant_id: tenant.id})
+    epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+    agent = fixture(:agent, %{tenant_id: tenant.id, agent_type: :implementer})
+
+    {agent_key, _agent_api_key} =
+      fixture(:api_key, %{tenant_id: tenant.id, role: :agent, agent_id: agent.id})
+
+    story =
+      fixture(:story, %{
+        tenant_id: tenant.id,
+        epic_id: epic.id,
+        project_id: project.id
+      })
+
+    %{
+      tenant: tenant,
+      project: project,
+      epic: epic,
+      agent: agent,
+      agent_key: agent_key,
+      story: story
+    }
+  end
+
+  # --- POST /api/v1/token-usage ---
+
+  describe "POST /api/v1/token-usage" do
+    test "creates a standalone token usage report", %{conn: conn} do
+      %{story: story, agent_key: agent_key, agent: agent, project: project} =
+        setup_story_with_keys()
+
+      conn =
+        conn
+        |> auth_conn(agent_key)
+        |> post(~p"/api/v1/token-usage", %{
+          "story_id" => story.id,
+          "input_tokens" => 1000,
+          "output_tokens" => 500,
+          "model_name" => "claude-opus-4",
+          "cost_millicents" => 2500,
+          "phase" => "implementing"
+        })
+
+      body = json_response(conn, 201)
+      report = body["token_usage_report"]
+
+      assert report["story_id"] == story.id
+      assert report["agent_id"] == agent.id
+      assert report["project_id"] == project.id
+      assert report["input_tokens"] == 1000
+      assert report["output_tokens"] == 500
+      assert report["model_name"] == "claude-opus-4"
+      assert report["cost_millicents"] == 2500
+      assert report["phase"] == "implementing"
+      assert report["cost_dollars"] == "0.03"
+    end
+
+    test "defaults phase to 'other'", %{conn: conn} do
+      %{story: story, agent_key: agent_key} = setup_story_with_keys()
+
+      conn =
+        conn
+        |> auth_conn(agent_key)
+        |> post(~p"/api/v1/token-usage", %{
+          "story_id" => story.id,
+          "input_tokens" => 100,
+          "output_tokens" => 50,
+          "model_name" => "gpt-4o",
+          "cost_millicents" => 500
+        })
+
+      body = json_response(conn, 201)
+      assert body["token_usage_report"]["phase"] == "other"
+    end
+
+    test "accepts optional session_id and metadata", %{conn: conn} do
+      %{story: story, agent_key: agent_key} = setup_story_with_keys()
+
+      conn =
+        conn
+        |> auth_conn(agent_key)
+        |> post(~p"/api/v1/token-usage", %{
+          "story_id" => story.id,
+          "input_tokens" => 100,
+          "output_tokens" => 50,
+          "model_name" => "claude-sonnet-4",
+          "cost_millicents" => 200,
+          "session_id" => "sess-abc",
+          "metadata" => %{"context" => "test"}
+        })
+
+      body = json_response(conn, 201)
+      report = body["token_usage_report"]
+      assert report["session_id"] == "sess-abc"
+      assert report["metadata"] == %{"context" => "test"}
+    end
+
+    test "returns 422 for negative input_tokens", %{conn: conn} do
+      %{story: story, agent_key: agent_key} = setup_story_with_keys()
+
+      conn =
+        conn
+        |> auth_conn(agent_key)
+        |> post(~p"/api/v1/token-usage", %{
+          "story_id" => story.id,
+          "input_tokens" => -1,
+          "output_tokens" => 50,
+          "model_name" => "claude-opus-4",
+          "cost_millicents" => 100
+        })
+
+      assert json_response(conn, 422)
+    end
+
+    test "returns 422 for missing model_name", %{conn: conn} do
+      %{story: story, agent_key: agent_key} = setup_story_with_keys()
+
+      conn =
+        conn
+        |> auth_conn(agent_key)
+        |> post(~p"/api/v1/token-usage", %{
+          "story_id" => story.id,
+          "input_tokens" => 100,
+          "output_tokens" => 50,
+          "cost_millicents" => 100
+        })
+
+      assert json_response(conn, 422)
+    end
+
+    test "returns 422 for empty model_name", %{conn: conn} do
+      %{story: story, agent_key: agent_key} = setup_story_with_keys()
+
+      conn =
+        conn
+        |> auth_conn(agent_key)
+        |> post(~p"/api/v1/token-usage", %{
+          "story_id" => story.id,
+          "input_tokens" => 100,
+          "output_tokens" => 50,
+          "model_name" => "",
+          "cost_millicents" => 100
+        })
+
+      assert json_response(conn, 422)
+    end
+
+    test "returns 422 when story_id is missing", %{conn: conn} do
+      %{agent_key: agent_key} = setup_story_with_keys()
+
+      conn =
+        conn
+        |> auth_conn(agent_key)
+        |> post(~p"/api/v1/token-usage", %{
+          "input_tokens" => 100,
+          "output_tokens" => 50,
+          "model_name" => "claude-opus-4",
+          "cost_millicents" => 100
+        })
+
+      assert json_response(conn, 422)
+    end
+
+    test "returns 404 for nonexistent story", %{conn: conn} do
+      %{agent_key: agent_key} = setup_story_with_keys()
+
+      conn =
+        conn
+        |> auth_conn(agent_key)
+        |> post(~p"/api/v1/token-usage", %{
+          "story_id" => Ecto.UUID.generate(),
+          "input_tokens" => 100,
+          "output_tokens" => 50,
+          "model_name" => "claude-opus-4",
+          "cost_millicents" => 100
+        })
+
+      assert json_response(conn, 404)
+    end
+
+    test "creates audit log entry", %{conn: conn} do
+      %{story: story, agent_key: agent_key, tenant: tenant} = setup_story_with_keys()
+
+      conn
+      |> auth_conn(agent_key)
+      |> post(~p"/api/v1/token-usage", %{
+        "story_id" => story.id,
+        "input_tokens" => 1000,
+        "output_tokens" => 500,
+        "model_name" => "claude-opus-4",
+        "cost_millicents" => 2500
+      })
+
+      {:ok, result} =
+        Loopctl.Audit.list_entries(tenant.id,
+          entity_type: "token_usage_report",
+          action: "created"
+        )
+
+      assert result.data != []
+    end
+
+    test "agent_id is set from authenticated key, not request body", %{conn: conn} do
+      %{story: story, agent_key: agent_key, agent: agent} = setup_story_with_keys()
+
+      conn =
+        conn
+        |> auth_conn(agent_key)
+        |> post(~p"/api/v1/token-usage", %{
+          "story_id" => story.id,
+          "input_tokens" => 100,
+          "output_tokens" => 50,
+          "model_name" => "claude-opus-4",
+          "cost_millicents" => 100,
+          # This should be ignored -- agent_id comes from auth
+          "agent_id" => Ecto.UUID.generate()
+        })
+
+      body = json_response(conn, 201)
+      assert body["token_usage_report"]["agent_id"] == agent.id
+    end
+  end
+
+  # --- GET /api/v1/stories/:story_id/token-usage ---
+
+  describe "GET /api/v1/stories/:story_id/token-usage" do
+    test "lists token usage reports for a story with totals", %{conn: conn} do
+      %{
+        story: story,
+        agent_key: agent_key,
+        tenant: tenant,
+        agent: agent,
+        project: project
+      } = setup_story_with_keys()
+
+      for i <- 1..3 do
+        fixture(:token_usage_report, %{
+          tenant_id: tenant.id,
+          story_id: story.id,
+          agent_id: agent.id,
+          project_id: project.id,
+          input_tokens: i * 1000,
+          output_tokens: i * 500,
+          cost_millicents: i * 2500
+        })
+      end
+
+      conn =
+        conn
+        |> auth_conn(agent_key)
+        |> get(~p"/api/v1/stories/#{story.id}/token-usage")
+
+      body = json_response(conn, 200)
+
+      assert length(body["data"]) == 3
+      assert body["meta"]["total_count"] == 3
+      assert body["meta"]["page"] == 1
+
+      totals = body["totals"]
+      assert totals["total_input_tokens"] == 6000
+      assert totals["total_output_tokens"] == 3000
+      assert totals["total_tokens"] == 9000
+      assert totals["total_cost_millicents"] == 15_000
+      assert totals["report_count"] == 3
+      assert totals["total_cost_dollars"] != nil
+    end
+
+    test "returns empty list for story with no reports", %{conn: conn} do
+      %{story: story, agent_key: agent_key} = setup_story_with_keys()
+
+      conn =
+        conn
+        |> auth_conn(agent_key)
+        |> get(~p"/api/v1/stories/#{story.id}/token-usage")
+
+      body = json_response(conn, 200)
+      assert body["data"] == []
+      assert body["meta"]["total_count"] == 0
+      assert body["totals"]["report_count"] == 0
+    end
+
+    test "supports pagination", %{conn: conn} do
+      %{
+        story: story,
+        agent_key: agent_key,
+        tenant: tenant,
+        agent: agent,
+        project: project
+      } = setup_story_with_keys()
+
+      for _i <- 1..5 do
+        fixture(:token_usage_report, %{
+          tenant_id: tenant.id,
+          story_id: story.id,
+          agent_id: agent.id,
+          project_id: project.id
+        })
+      end
+
+      conn =
+        conn
+        |> auth_conn(agent_key)
+        |> get(~p"/api/v1/stories/#{story.id}/token-usage?page=1&page_size=2")
+
+      body = json_response(conn, 200)
+      assert length(body["data"]) == 2
+      assert body["meta"]["total_count"] == 5
+      assert body["meta"]["total_pages"] == 3
+    end
+
+    test "returns 404 for nonexistent story", %{conn: conn} do
+      %{agent_key: agent_key} = setup_story_with_keys()
+
+      conn =
+        conn
+        |> auth_conn(agent_key)
+        |> get(~p"/api/v1/stories/#{Ecto.UUID.generate()}/token-usage")
+
+      assert json_response(conn, 404)
+    end
+
+    test "includes cost_dollars in each report", %{conn: conn} do
+      %{
+        story: story,
+        agent_key: agent_key,
+        tenant: tenant,
+        agent: agent,
+        project: project
+      } = setup_story_with_keys()
+
+      fixture(:token_usage_report, %{
+        tenant_id: tenant.id,
+        story_id: story.id,
+        agent_id: agent.id,
+        project_id: project.id,
+        cost_millicents: 100_000
+      })
+
+      conn =
+        conn
+        |> auth_conn(agent_key)
+        |> get(~p"/api/v1/stories/#{story.id}/token-usage")
+
+      body = json_response(conn, 200)
+      report = hd(body["data"])
+      assert report["cost_dollars"] == "1.00"
+    end
+  end
+
+  # --- Role enforcement ---
+
+  describe "role enforcement" do
+    test "user role can access token-usage endpoints (user >= agent)", %{conn: conn} do
+      %{story: story, tenant: tenant} = setup_story_with_keys()
+      {user_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(user_key)
+        |> get(~p"/api/v1/stories/#{story.id}/token-usage")
+
+      assert json_response(conn, 200)
+    end
+  end
+
+  # --- Tenant isolation ---
+
+  describe "tenant isolation" do
+    test "cross-tenant token-usage creation returns 404", %{conn: conn} do
+      %{story: story} = setup_story_with_keys()
+
+      tenant_b = fixture(:tenant)
+      agent_b = fixture(:agent, %{tenant_id: tenant_b.id})
+
+      {key_b, _} =
+        fixture(:api_key, %{tenant_id: tenant_b.id, role: :agent, agent_id: agent_b.id})
+
+      conn =
+        conn
+        |> auth_conn(key_b)
+        |> post(~p"/api/v1/token-usage", %{
+          "story_id" => story.id,
+          "input_tokens" => 100,
+          "output_tokens" => 50,
+          "model_name" => "claude-opus-4",
+          "cost_millicents" => 100
+        })
+
+      assert json_response(conn, 404)
+    end
+
+    test "cross-tenant token-usage listing returns 404", %{conn: conn} do
+      %{story: story} = setup_story_with_keys()
+
+      tenant_b = fixture(:tenant)
+      agent_b = fixture(:agent, %{tenant_id: tenant_b.id})
+
+      {key_b, _} =
+        fixture(:api_key, %{tenant_id: tenant_b.id, role: :agent, agent_id: agent_b.id})
+
+      conn =
+        conn
+        |> auth_conn(key_b)
+        |> get(~p"/api/v1/stories/#{story.id}/token-usage")
+
+      assert json_response(conn, 404)
+    end
+  end
+
+  # --- Integration with report_story ---
+
+  describe "POST /api/v1/stories/:id/report with token_usage" do
+    test "creates token usage report atomically with status transition", %{conn: conn} do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+
+      impl_agent = fixture(:agent, %{tenant_id: tenant.id, agent_type: :implementer})
+      reviewer_agent = fixture(:agent, %{tenant_id: tenant.id, agent_type: :implementer})
+
+      {reviewer_key, _} =
+        fixture(:api_key, %{tenant_id: tenant.id, role: :agent, agent_id: reviewer_agent.id})
+
+      story =
+        fixture(:story, %{
+          tenant_id: tenant.id,
+          epic_id: epic.id,
+          project_id: project.id,
+          agent_status: :implementing,
+          assigned_agent_id: impl_agent.id
+        })
+
+      conn =
+        conn
+        |> auth_conn(reviewer_key)
+        |> post(~p"/api/v1/stories/#{story.id}/report", %{
+          "token_usage" => %{
+            "input_tokens" => 5000,
+            "output_tokens" => 2000,
+            "model_name" => "claude-opus-4",
+            "cost_millicents" => 10_000,
+            "phase" => "reviewing"
+          }
+        })
+
+      body = json_response(conn, 200)
+      assert body["story"]["agent_status"] == "reported_done"
+
+      # Verify token usage report was created
+      {:ok, result} =
+        Loopctl.TokenUsage.list_reports_for_story(tenant.id, story.id)
+
+      assert length(result.data) == 1
+      report = hd(result.data)
+      assert report.input_tokens == 5000
+      assert report.output_tokens == 2000
+      assert report.model_name == "claude-opus-4"
+      assert report.cost_millicents == 10_000
+      assert report.phase == "reviewing"
+      assert report.agent_id == reviewer_agent.id
+      assert report.project_id == project.id
+    end
+
+    test "report_story without token_usage still works", %{conn: conn} do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+
+      impl_agent = fixture(:agent, %{tenant_id: tenant.id, agent_type: :implementer})
+      reviewer_agent = fixture(:agent, %{tenant_id: tenant.id, agent_type: :implementer})
+
+      {reviewer_key, _} =
+        fixture(:api_key, %{tenant_id: tenant.id, role: :agent, agent_id: reviewer_agent.id})
+
+      story =
+        fixture(:story, %{
+          tenant_id: tenant.id,
+          epic_id: epic.id,
+          project_id: project.id,
+          agent_status: :implementing,
+          assigned_agent_id: impl_agent.id
+        })
+
+      conn =
+        conn
+        |> auth_conn(reviewer_key)
+        |> post(~p"/api/v1/stories/#{story.id}/report", %{})
+
+      body = json_response(conn, 200)
+      assert body["story"]["agent_status"] == "reported_done"
+
+      # No token usage report should be created
+      {:ok, result} = Loopctl.TokenUsage.list_reports_for_story(tenant.id, story.id)
+      assert result.data == []
+    end
+  end
+end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -23,6 +23,7 @@ defmodule Loopctl.Fixtures do
   alias Loopctl.Skills.SkillResult
   alias Loopctl.Skills.SkillVersion
   alias Loopctl.Tenants.Tenant
+  alias Loopctl.TokenUsage.Report, as: TokenUsageReport
   alias Loopctl.Webhooks.Webhook
   alias Loopctl.Webhooks.WebhookEvent
   alias Loopctl.WorkBreakdown.Epic
@@ -246,6 +247,21 @@ defmodule Loopctl.Fixtures do
       %{
         guide_reference: "docs/user_guides/test_guide_#{System.unique_integer([:positive])}.md",
         started_at: DateTime.utc_now()
+      },
+      Enum.into(attrs, %{})
+    )
+  end
+
+  def build(:token_usage_report, attrs) do
+    Map.merge(
+      %{
+        input_tokens: 1000,
+        output_tokens: 500,
+        model_name: "claude-opus-4",
+        cost_millicents: 2500,
+        phase: "implementing",
+        session_id: nil,
+        metadata: %{}
       },
       Enum.into(attrs, %{})
     )
@@ -541,6 +557,59 @@ defmodule Loopctl.Fixtures do
         orchestrator_agent_id: orchestrator_agent_id
       }
       |> VerificationResult.create_changeset(data)
+
+    AdminRepo.insert!(changeset)
+  end
+
+  def fixture(:token_usage_report, attrs) do
+    attrs = Enum.into(attrs, %{})
+
+    {tenant_id, attrs} =
+      case Map.get(attrs, :tenant_id) do
+        nil ->
+          tenant = fixture(:tenant)
+          {tenant.id, Map.put(attrs, :tenant_id, tenant.id)}
+
+        tid ->
+          {tid, attrs}
+      end
+
+    {story, attrs} =
+      case Map.get(attrs, :story_id) do
+        nil ->
+          story = fixture(:story, %{tenant_id: tenant_id})
+          attrs = Map.put(attrs, :story_id, story.id)
+          attrs = Map.put_new(attrs, :project_id, story.project_id)
+          {story, attrs}
+
+        sid ->
+          story = AdminRepo.get!(Story, sid)
+          attrs = Map.put_new(attrs, :project_id, story.project_id)
+          {story, attrs}
+      end
+
+    {agent_id, attrs} =
+      case Map.get(attrs, :agent_id) do
+        nil ->
+          agent = fixture(:agent, %{tenant_id: tenant_id})
+          {agent.id, Map.put(attrs, :agent_id, agent.id)}
+
+        aid ->
+          {aid, attrs}
+      end
+
+    project_id = Map.get(attrs, :project_id, story.project_id)
+
+    data = build(:token_usage_report, attrs)
+
+    changeset =
+      %TokenUsageReport{
+        tenant_id: tenant_id,
+        story_id: story.id,
+        agent_id: agent_id,
+        project_id: project_id
+      }
+      |> TokenUsageReport.create_changeset(data)
 
     AdminRepo.insert!(changeset)
   end


### PR DESCRIPTION
## Summary

- Add `token_usage_reports` table with RLS, generated `total_tokens` column, phase CHECK constraint, and composite indexes
- Implement `Loopctl.TokenUsage` context module with `create_report/2`, `list_reports_for_story/2`, `get_story_totals/2`
- Create `Loopctl.TokenUsage.Report` schema and `Loopctl.TokenUsage.Formatting` module (millicents_to_dollars, format_tokens)
- Extend `Progress.report_story/4` to accept optional `:token_usage` key in opts for atomic creation within the same Multi transaction
- Add `POST /api/v1/token-usage` for standalone token usage reporting and `GET /api/v1/stories/:id/token-usage` for per-story listing with totals
- agent_id set from authenticated key (never from request body), project_id derived from story's epic
- Every token usage report creation is audit-logged with entity_type='token_usage_report'
- 57 new tests covering context, controller, formatting, tenant isolation, and report_story integration

## Test plan

- [x] Context tests: create_report validation (negative tokens, empty model, invalid phase)
- [x] Context tests: list_reports_for_story with pagination and ordering
- [x] Context tests: get_story_totals aggregation
- [x] Context tests: tenant isolation (tenant A cannot see tenant B's reports)
- [x] Context tests: audit log creation on report creation
- [x] Controller tests: POST /api/v1/token-usage (create, validation, 404, auth)
- [x] Controller tests: GET /api/v1/stories/:id/token-usage (list, pagination, totals, 404)
- [x] Controller tests: role enforcement and tenant isolation
- [x] Controller tests: report_story integration (token_usage in Multi transaction)
- [x] Formatting tests: millicents_to_dollars and format_tokens edge cases
- [x] Fixture tests: auto-dependency resolution