### PR TITLE
US-21.2: Token Budget Configuration

### DIFF
--- a/lib/loopctl/tenants/tenant.ex
+++ b/lib/loopctl/tenants/tenant.ex
@@ -12,6 +12,7 @@ defmodule Loopctl.Tenants.Tenant do
   - `email` — contact email for the tenant
   - `settings` — jsonb map for tenant-level configuration
   - `status` — `:active`, `:suspended`, or `:deactivated`
+  - `default_story_budget_millicents` — nullable tenant-wide default budget for stories
   """
 
   use Loopctl.Schema, tenant_scoped: false
@@ -28,6 +29,7 @@ defmodule Loopctl.Tenants.Tenant do
     field :email, :string
     field :settings, :map, default: %{}
     field :status, Ecto.Enum, values: @statuses, default: :active
+    field :default_story_budget_millicents, :integer
 
     timestamps()
   end
@@ -52,10 +54,11 @@ defmodule Loopctl.Tenants.Tenant do
   @spec update_changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
   def update_changeset(tenant, attrs) do
     tenant
-    |> cast(attrs, [:name, :slug, :email, :settings])
+    |> cast(attrs, [:name, :slug, :email, :settings, :default_story_budget_millicents])
     |> validate_slug()
     |> validate_email()
     |> validate_settings()
+    |> validate_number(:default_story_budget_millicents, greater_than: 0)
     |> unique_constraint(:slug)
   end
 

--- a/lib/loopctl/token_usage.ex
+++ b/lib/loopctl/token_usage.ex
@@ -32,9 +32,15 @@ defmodule Loopctl.TokenUsage do
 
   import Ecto.Query
 
+  alias Ecto.Multi
   alias Loopctl.AdminRepo
   alias Loopctl.Audit
+  alias Loopctl.Projects.Project
+  alias Loopctl.Tenants.Tenant
+  alias Loopctl.TokenUsage.Budget
   alias Loopctl.TokenUsage.Report
+  alias Loopctl.WorkBreakdown.Epic
+  alias Loopctl.WorkBreakdown.Story
 
   @doc """
   Creates a new token usage report.
@@ -227,6 +233,300 @@ defmodule Loopctl.TokenUsage do
      }}
   end
 
+  # --- Budget functions ---
+
+  @doc """
+  Creates a new token budget for a given scope.
+
+  The `scope_type` must be one of `:project`, `:epic`, or `:story`, and the
+  `scope_id` must reference an existing entity of the correct type within
+  the tenant.
+
+  ## Options (keyword list)
+
+  - `:actor_id` -- audit actor ID
+  - `:actor_label` -- audit actor label
+  - `:actor_type` -- audit actor type (default "api_key")
+
+  ## Returns
+
+  - `{:ok, %Budget{}}` on success
+  - `{:error, %Ecto.Changeset{}}` on validation failure
+  - `{:error, :not_found}` if the scope entity does not exist
+  - `{:error, :conflict}` if a budget already exists for this scope
+  """
+  @spec create_budget(Ecto.UUID.t(), map(), keyword()) ::
+          {:ok, Budget.t()} | {:error, Ecto.Changeset.t() | :not_found | :conflict}
+  def create_budget(tenant_id, attrs, opts \\ []) do
+    attrs = normalize_budget_attrs(attrs)
+
+    scope_type = Map.get(attrs, :scope_type)
+    scope_id = Map.get(attrs, :scope_id)
+
+    with :ok <- validate_scope_entity(tenant_id, scope_type, scope_id) do
+      changeset =
+        %Budget{tenant_id: tenant_id}
+        |> Budget.create_changeset(attrs)
+
+      multi =
+        Multi.new()
+        |> Multi.insert(:budget, changeset)
+        |> Audit.log_in_multi(:audit, fn %{budget: budget} ->
+          %{
+            tenant_id: tenant_id,
+            entity_type: "token_budget",
+            entity_id: budget.id,
+            action: "created",
+            actor_type: Keyword.get(opts, :actor_type, "api_key"),
+            actor_id: Keyword.get(opts, :actor_id),
+            actor_label: Keyword.get(opts, :actor_label),
+            new_state: %{
+              "scope_type" => to_string(budget.scope_type),
+              "scope_id" => budget.scope_id,
+              "budget_millicents" => budget.budget_millicents,
+              "budget_input_tokens" => budget.budget_input_tokens,
+              "budget_output_tokens" => budget.budget_output_tokens,
+              "alert_threshold_pct" => budget.alert_threshold_pct
+            }
+          }
+        end)
+
+      multi
+      |> AdminRepo.transaction()
+      |> handle_budget_insert_result()
+    end
+  end
+
+  defp handle_budget_insert_result({:ok, %{budget: budget}}), do: {:ok, budget}
+
+  defp handle_budget_insert_result({:error, :budget, %Ecto.Changeset{} = changeset, _}) do
+    if has_unique_constraint_error?(changeset),
+      do: {:error, :conflict},
+      else: {:error, changeset}
+  end
+
+  defp handle_budget_insert_result({:error, _step, changeset, _}), do: {:error, changeset}
+
+  @doc """
+  Gets a single token budget by ID, scoped to a tenant.
+
+  ## Returns
+
+  - `{:ok, %Budget{}}` if found
+  - `{:error, :not_found}` if not found or wrong tenant
+  """
+  @spec get_budget(Ecto.UUID.t(), Ecto.UUID.t()) :: {:ok, Budget.t()} | {:error, :not_found}
+  def get_budget(tenant_id, budget_id) do
+    case AdminRepo.get_by(Budget, id: budget_id, tenant_id: tenant_id) do
+      nil -> {:error, :not_found}
+      budget -> {:ok, budget}
+    end
+  end
+
+  @doc """
+  Lists token budgets for a tenant with optional filtering and pagination.
+
+  ## Options
+
+  - `:scope_type` -- filter by scope type (`:project`, `:epic`, or `:story`)
+  - `:scope_id` -- filter by scope ID (UUID)
+  - `:page` -- page number (default 1)
+  - `:page_size` -- entries per page (default 20, max 100)
+
+  ## Returns
+
+  `{:ok, %{data: [%Budget{}], total: integer, page: integer, page_size: integer}}`
+
+  Each budget in the result includes `:current_spend_millicents` and
+  `:remaining_millicents` virtual fields populated from token_usage_reports.
+  """
+  @spec list_budgets(Ecto.UUID.t(), keyword()) ::
+          {:ok,
+           %{
+             data: [map()],
+             total: non_neg_integer(),
+             page: pos_integer(),
+             page_size: pos_integer()
+           }}
+  def list_budgets(tenant_id, opts \\ []) do
+    page = max(Keyword.get(opts, :page, 1), 1)
+    page_size = opts |> Keyword.get(:page_size, 20) |> max(1) |> min(100)
+    offset = (page - 1) * page_size
+
+    base_query =
+      Budget
+      |> where([b], b.tenant_id == ^tenant_id)
+      |> apply_budget_filter(:scope_type, Keyword.get(opts, :scope_type))
+      |> apply_budget_filter(:scope_id, Keyword.get(opts, :scope_id))
+
+    total = AdminRepo.aggregate(base_query, :count, :id)
+
+    budgets =
+      base_query
+      |> order_by([b], desc: b.inserted_at)
+      |> limit(^page_size)
+      |> offset(^offset)
+      |> AdminRepo.all()
+
+    budgets_with_spend = Enum.map(budgets, &attach_spend(tenant_id, &1))
+
+    {:ok, %{data: budgets_with_spend, total: total, page: page, page_size: page_size}}
+  end
+
+  @doc """
+  Updates an existing token budget.
+
+  Cannot change `scope_type` or `scope_id`.
+
+  ## Options (keyword list)
+
+  - `:actor_id` -- audit actor ID
+  - `:actor_label` -- audit actor label
+  - `:actor_type` -- audit actor type (default "api_key")
+
+  ## Returns
+
+  - `{:ok, %Budget{}}` on success
+  - `{:error, %Ecto.Changeset{}}` on validation failure
+  - `{:error, :not_found}` if budget not found
+  """
+  @spec update_budget(Ecto.UUID.t(), Ecto.UUID.t(), map(), keyword()) ::
+          {:ok, Budget.t()} | {:error, Ecto.Changeset.t() | :not_found}
+  def update_budget(tenant_id, budget_id, attrs, opts \\ []) do
+    attrs = normalize_budget_attrs(attrs)
+
+    with {:ok, budget} <- get_budget(tenant_id, budget_id) do
+      old_state = %{
+        "budget_millicents" => budget.budget_millicents,
+        "budget_input_tokens" => budget.budget_input_tokens,
+        "budget_output_tokens" => budget.budget_output_tokens,
+        "alert_threshold_pct" => budget.alert_threshold_pct
+      }
+
+      changeset = Budget.update_changeset(budget, attrs)
+
+      multi =
+        Multi.new()
+        |> Multi.update(:budget, changeset)
+        |> Audit.log_in_multi(:audit, fn %{budget: updated} ->
+          %{
+            tenant_id: tenant_id,
+            entity_type: "token_budget",
+            entity_id: updated.id,
+            action: "updated",
+            actor_type: Keyword.get(opts, :actor_type, "api_key"),
+            actor_id: Keyword.get(opts, :actor_id),
+            actor_label: Keyword.get(opts, :actor_label),
+            old_state: old_state,
+            new_state: %{
+              "budget_millicents" => updated.budget_millicents,
+              "budget_input_tokens" => updated.budget_input_tokens,
+              "budget_output_tokens" => updated.budget_output_tokens,
+              "alert_threshold_pct" => updated.alert_threshold_pct
+            }
+          }
+        end)
+
+      case AdminRepo.transaction(multi) do
+        {:ok, %{budget: budget}} -> {:ok, budget}
+        {:error, :budget, changeset, _} -> {:error, changeset}
+        {:error, _step, changeset, _} -> {:error, changeset}
+      end
+    end
+  end
+
+  @doc """
+  Deletes a token budget. Does not delete associated token usage reports.
+
+  ## Options (keyword list)
+
+  - `:actor_id` -- audit actor ID
+  - `:actor_label` -- audit actor label
+  - `:actor_type` -- audit actor type (default "api_key")
+
+  ## Returns
+
+  - `{:ok, %Budget{}}` on success
+  - `{:error, :not_found}` if budget not found
+  """
+  @spec delete_budget(Ecto.UUID.t(), Ecto.UUID.t(), keyword()) ::
+          {:ok, Budget.t()} | {:error, :not_found}
+  def delete_budget(tenant_id, budget_id, opts \\ []) do
+    with {:ok, budget} <- get_budget(tenant_id, budget_id) do
+      multi =
+        Multi.new()
+        |> Multi.delete(:budget, budget)
+        |> Audit.log_in_multi(:audit, fn _changes ->
+          %{
+            tenant_id: tenant_id,
+            entity_type: "token_budget",
+            entity_id: budget.id,
+            action: "deleted",
+            actor_type: Keyword.get(opts, :actor_type, "api_key"),
+            actor_id: Keyword.get(opts, :actor_id),
+            actor_label: Keyword.get(opts, :actor_label),
+            old_state: %{
+              "scope_type" => to_string(budget.scope_type),
+              "scope_id" => budget.scope_id,
+              "budget_millicents" => budget.budget_millicents
+            }
+          }
+        end)
+
+      case AdminRepo.transaction(multi) do
+        {:ok, %{budget: budget}} -> {:ok, budget}
+        {:error, _step, error, _} -> {:error, error}
+      end
+    end
+  end
+
+  @doc """
+  Returns the effective budget for a given scope, using budget inheritance.
+
+  Resolution order:
+  1. Explicit budget for the given (scope_type, scope_id)
+  2. For stories: check epic budget, then project budget, then tenant default
+  3. For epics: check project budget, then tenant default
+  4. For projects: tenant default (for stories only)
+
+  ## Returns
+
+  - `{:ok, {budget_millicents, source}}` where source is `:explicit`,
+    `:epic_inherited`, `:project_inherited`, or `:tenant_default`
+  - `{:ok, nil}` when no budget at any level
+  """
+  @spec get_effective_budget(Ecto.UUID.t(), atom(), Ecto.UUID.t()) ::
+          {:ok, {integer(), atom()} | nil}
+  def get_effective_budget(tenant_id, scope_type, scope_id) do
+    # 1. Check for explicit budget
+    case get_explicit_budget(tenant_id, scope_type, scope_id) do
+      {:ok, budget} ->
+        {:ok, {budget.budget_millicents, :explicit}}
+
+      :none ->
+        resolve_inherited_budget(tenant_id, scope_type, scope_id)
+    end
+  end
+
+  @doc """
+  Calculates current spend for a budget scope.
+
+  For `:story` -- sums cost_millicents WHERE story_id = scope_id.
+  For `:epic` -- sums cost_millicents WHERE the report's story belongs to the epic.
+  For `:project` -- sums cost_millicents WHERE the report's project_id = scope_id.
+
+  ## Returns
+
+  An integer representing total spend in millicents.
+  """
+  @spec get_scope_spend(Ecto.UUID.t(), atom(), Ecto.UUID.t()) :: non_neg_integer()
+  def get_scope_spend(tenant_id, scope_type, scope_id) do
+    query = spend_query(tenant_id, scope_type, scope_id)
+
+    result = AdminRepo.one(query)
+    decimal_to_int(result || 0)
+  end
+
   # --- Private helpers ---
 
   @known_attrs ~w(
@@ -256,4 +556,187 @@ defmodule Loopctl.TokenUsage do
   defp decimal_to_int(%Decimal{} = val), do: Decimal.to_integer(val)
   defp decimal_to_int(val) when is_integer(val), do: val
   defp decimal_to_int(nil), do: 0
+
+  # --- Budget private helpers ---
+
+  @budget_attrs ~w(
+    scope_type scope_id budget_millicents budget_input_tokens
+    budget_output_tokens alert_threshold_pct metadata
+  )a
+
+  defp normalize_budget_attrs(attrs) when is_map(attrs) do
+    known_strings = MapSet.new(@budget_attrs, &Atom.to_string/1)
+
+    Map.new(attrs, fn
+      {k, v} when is_atom(k) ->
+        {k, v}
+
+      {k, v} when is_binary(k) ->
+        if MapSet.member?(known_strings, k) do
+          {String.to_existing_atom(k), v}
+        else
+          {:__discard__, v}
+        end
+    end)
+    |> Map.delete(:__discard__)
+    |> maybe_atomize_scope_type()
+  end
+
+  defp maybe_atomize_scope_type(%{scope_type: st} = attrs) when is_binary(st) do
+    if st in ~w(project epic story) do
+      Map.put(attrs, :scope_type, String.to_existing_atom(st))
+    else
+      attrs
+    end
+  end
+
+  defp maybe_atomize_scope_type(attrs), do: attrs
+
+  defp validate_scope_entity(_tenant_id, nil, _scope_id), do: :ok
+  defp validate_scope_entity(_tenant_id, _scope_type, nil), do: :ok
+
+  defp validate_scope_entity(tenant_id, scope_type, scope_id) do
+    scope_type
+    |> to_scope_atom()
+    |> scope_schema()
+    |> check_entity_exists(scope_id, tenant_id)
+  end
+
+  defp to_scope_atom(st) when is_binary(st), do: String.to_existing_atom(st)
+  defp to_scope_atom(st) when is_atom(st), do: st
+
+  defp scope_schema(:project), do: Project
+  defp scope_schema(:epic), do: Epic
+  defp scope_schema(:story), do: Story
+  defp scope_schema(_), do: nil
+
+  defp check_entity_exists(nil, _scope_id, _tenant_id), do: :ok
+
+  defp check_entity_exists(schema, scope_id, tenant_id) do
+    case AdminRepo.get_by(schema, id: scope_id, tenant_id: tenant_id) do
+      nil -> {:error, :not_found}
+      _entity -> :ok
+    end
+  end
+
+  defp apply_budget_filter(query, _field, nil), do: query
+  defp apply_budget_filter(query, _field, ""), do: query
+
+  defp apply_budget_filter(query, :scope_type, value) when is_binary(value) do
+    where(query, [b], b.scope_type == ^value)
+  end
+
+  defp apply_budget_filter(query, :scope_type, value) when is_atom(value) do
+    where(query, [b], b.scope_type == ^value)
+  end
+
+  defp apply_budget_filter(query, :scope_id, value) do
+    where(query, [b], b.scope_id == ^value)
+  end
+
+  defp spend_query(tenant_id, :story, scope_id) do
+    Report
+    |> where([r], r.tenant_id == ^tenant_id and r.story_id == ^scope_id)
+    |> select([r], coalesce(sum(r.cost_millicents), 0))
+  end
+
+  defp spend_query(tenant_id, :epic, scope_id) do
+    Report
+    |> join(:inner, [r], s in Story, on: r.story_id == s.id)
+    |> where([r, s], r.tenant_id == ^tenant_id and s.epic_id == ^scope_id)
+    |> select([r, _s], coalesce(sum(r.cost_millicents), 0))
+  end
+
+  defp spend_query(tenant_id, :project, scope_id) do
+    Report
+    |> where([r], r.tenant_id == ^tenant_id and r.project_id == ^scope_id)
+    |> select([r], coalesce(sum(r.cost_millicents), 0))
+  end
+
+  defp attach_spend(tenant_id, %Budget{} = budget) do
+    spend = get_scope_spend(tenant_id, budget.scope_type, budget.scope_id)
+    remaining = max(budget.budget_millicents - spend, 0)
+
+    %{
+      budget: budget,
+      current_spend_millicents: spend,
+      remaining_millicents: remaining
+    }
+  end
+
+  defp get_explicit_budget(tenant_id, scope_type, scope_id) do
+    scope_type_string = to_string(scope_type)
+
+    case AdminRepo.get_by(Budget,
+           tenant_id: tenant_id,
+           scope_type: scope_type_string,
+           scope_id: scope_id
+         ) do
+      nil -> :none
+      budget -> {:ok, budget}
+    end
+  end
+
+  defp resolve_inherited_budget(tenant_id, :story, scope_id) do
+    # Story -> check epic budget -> check project budget -> tenant default
+    with %Story{} = story <- AdminRepo.get_by(Story, id: scope_id, tenant_id: tenant_id),
+         :none <- get_explicit_budget(tenant_id, :epic, story.epic_id),
+         :none <- get_explicit_budget(tenant_id, :project, story.project_id) do
+      check_tenant_default(tenant_id)
+    else
+      nil -> {:ok, nil}
+      {:ok, %{scope_type: :epic} = budget} -> {:ok, {budget.budget_millicents, :epic_inherited}}
+      {:ok, budget} -> {:ok, {budget.budget_millicents, :project_inherited}}
+    end
+  end
+
+  defp resolve_inherited_budget(tenant_id, :epic, scope_id) do
+    # Epic -> check project budget -> tenant default
+    case AdminRepo.get_by(Epic, id: scope_id, tenant_id: tenant_id) do
+      nil ->
+        {:ok, nil}
+
+      epic ->
+        case get_explicit_budget(tenant_id, :project, epic.project_id) do
+          {:ok, budget} ->
+            {:ok, {budget.budget_millicents, :project_inherited}}
+
+          :none ->
+            check_tenant_default(tenant_id)
+        end
+    end
+  end
+
+  defp resolve_inherited_budget(tenant_id, :project, _scope_id) do
+    # Project -> tenant default
+    check_tenant_default(tenant_id)
+  end
+
+  defp resolve_inherited_budget(_tenant_id, _scope_type, _scope_id) do
+    {:ok, nil}
+  end
+
+  defp check_tenant_default(tenant_id) do
+    case AdminRepo.get(Tenant, tenant_id) do
+      nil ->
+        {:ok, nil}
+
+      tenant ->
+        if tenant.default_story_budget_millicents do
+          {:ok, {tenant.default_story_budget_millicents, :tenant_default}}
+        else
+          {:ok, nil}
+        end
+    end
+  end
+
+  defp has_unique_constraint_error?(%Ecto.Changeset{} = changeset) do
+    Enum.any?(changeset.errors, fn
+      {:tenant_id, {_msg, meta}} ->
+        Keyword.get(meta, :constraint) == :unique
+
+      _ ->
+        false
+    end)
+  end
 end

--- a/lib/loopctl/token_usage.ex
+++ b/lib/loopctl/token_usage.ex
@@ -634,7 +634,11 @@ defmodule Loopctl.TokenUsage do
   defp apply_budget_filter(query, _field, ""), do: query
 
   defp apply_budget_filter(query, :scope_type, value) when is_binary(value) do
-    where(query, [b], b.scope_type == ^value)
+    # Convert string to atom for Ecto.Enum compatibility; unknown values return no results
+    case to_scope_atom(value) do
+      nil -> where(query, [_b], false)
+      atom_val -> where(query, [b], b.scope_type == ^atom_val)
+    end
   end
 
   defp apply_budget_filter(query, :scope_type, value) when is_atom(value) do

--- a/lib/loopctl/token_usage.ex
+++ b/lib/loopctl/token_usage.ex
@@ -368,7 +368,7 @@ defmodule Loopctl.TokenUsage do
       |> offset(^offset)
       |> AdminRepo.all()
 
-    budgets_with_spend = Enum.map(budgets, &attach_spend(tenant_id, &1))
+    budgets_with_spend = batch_attach_spend(tenant_id, budgets)
 
     {:ok, %{data: budgets_with_spend, total: total, page: page, page_size: page_size}}
   end
@@ -596,14 +596,25 @@ defmodule Loopctl.TokenUsage do
   defp validate_scope_entity(_tenant_id, _scope_type, nil), do: :ok
 
   defp validate_scope_entity(tenant_id, scope_type, scope_id) do
-    scope_type
-    |> to_scope_atom()
-    |> scope_schema()
-    |> check_entity_exists(scope_id, tenant_id)
+    case to_scope_atom(scope_type) do
+      nil ->
+        # Unknown scope type — skip entity validation, let changeset catch it
+        :ok
+
+      atom_type ->
+        atom_type
+        |> scope_schema()
+        |> check_entity_exists(scope_id, tenant_id)
+    end
   end
 
-  defp to_scope_atom(st) when is_binary(st), do: String.to_existing_atom(st)
-  defp to_scope_atom(st) when is_atom(st), do: st
+  @known_scope_types ~w(project epic story)
+  defp to_scope_atom(st) when is_binary(st) do
+    if st in @known_scope_types, do: String.to_existing_atom(st), else: nil
+  end
+
+  defp to_scope_atom(st) when st in [:project, :epic, :story], do: st
+  defp to_scope_atom(_), do: nil
 
   defp scope_schema(:project), do: Project
   defp scope_schema(:epic), do: Epic
@@ -653,23 +664,63 @@ defmodule Loopctl.TokenUsage do
     |> select([r], coalesce(sum(r.cost_millicents), 0))
   end
 
-  defp attach_spend(tenant_id, %Budget{} = budget) do
-    spend = get_scope_spend(tenant_id, budget.scope_type, budget.scope_id)
-    remaining = max(budget.budget_millicents - spend, 0)
+  # Batch computes spend for all budgets in at most 3 queries (one per scope type)
+  # instead of N individual queries (N+1 pattern).
+  defp batch_attach_spend(tenant_id, budgets) do
+    spend_map =
+      budgets
+      |> Enum.group_by(& &1.scope_type)
+      |> Enum.flat_map(fn {scope_type, scope_budgets} ->
+        scope_ids = Enum.map(scope_budgets, & &1.scope_id)
+        batch_spend_query(tenant_id, scope_type, scope_ids)
+      end)
+      |> Map.new()
 
-    %{
-      budget: budget,
-      current_spend_millicents: spend,
-      remaining_millicents: remaining
-    }
+    Enum.map(budgets, fn budget ->
+      spend = Map.get(spend_map, {budget.scope_type, budget.scope_id}, 0)
+      remaining = max(budget.budget_millicents - spend, 0)
+
+      %{
+        budget: budget,
+        current_spend_millicents: spend,
+        remaining_millicents: remaining
+      }
+    end)
   end
 
-  defp get_explicit_budget(tenant_id, scope_type, scope_id) do
-    scope_type_string = to_string(scope_type)
+  defp batch_spend_query(tenant_id, :story, scope_ids) do
+    Report
+    |> where([r], r.tenant_id == ^tenant_id and r.story_id in ^scope_ids)
+    |> group_by([r], r.story_id)
+    |> select([r], {r.story_id, coalesce(sum(r.cost_millicents), 0)})
+    |> AdminRepo.all()
+    |> Enum.map(fn {scope_id, spend} -> {{:story, scope_id}, decimal_to_int(spend)} end)
+  end
 
+  defp batch_spend_query(tenant_id, :epic, scope_ids) do
+    Report
+    |> join(:inner, [r], s in Story, on: r.story_id == s.id)
+    |> where([r, s], r.tenant_id == ^tenant_id and s.epic_id in ^scope_ids)
+    |> group_by([r, s], s.epic_id)
+    |> select([r, s], {s.epic_id, coalesce(sum(r.cost_millicents), 0)})
+    |> AdminRepo.all()
+    |> Enum.map(fn {scope_id, spend} -> {{:epic, scope_id}, decimal_to_int(spend)} end)
+  end
+
+  defp batch_spend_query(tenant_id, :project, scope_ids) do
+    Report
+    |> where([r], r.tenant_id == ^tenant_id and r.project_id in ^scope_ids)
+    |> group_by([r], r.project_id)
+    |> select([r], {r.project_id, coalesce(sum(r.cost_millicents), 0)})
+    |> AdminRepo.all()
+    |> Enum.map(fn {scope_id, spend} -> {{:project, scope_id}, decimal_to_int(spend)} end)
+  end
+
+  defp get_explicit_budget(tenant_id, scope_type, scope_id)
+       when scope_type in [:project, :epic, :story] do
     case AdminRepo.get_by(Budget,
            tenant_id: tenant_id,
-           scope_type: scope_type_string,
+           scope_type: scope_type,
            scope_id: scope_id
          ) do
       nil -> :none
@@ -710,10 +761,6 @@ defmodule Loopctl.TokenUsage do
   defp resolve_inherited_budget(tenant_id, :project, _scope_id) do
     # Project -> tenant default
     check_tenant_default(tenant_id)
-  end
-
-  defp resolve_inherited_budget(_tenant_id, _scope_type, _scope_id) do
-    {:ok, nil}
   end
 
   defp check_tenant_default(tenant_id) do

--- a/lib/loopctl/token_usage/budget.ex
+++ b/lib/loopctl/token_usage/budget.ex
@@ -1,0 +1,110 @@
+defmodule Loopctl.TokenUsage.Budget do
+  @moduledoc """
+  Schema for the `token_budgets` table.
+
+  Defines cost and token budgets at project, epic, or story scope.
+  Each budget is uniquely constrained to `(tenant_id, scope_type, scope_id)`.
+
+  ## Fields
+
+  - `scope_type` -- `:project`, `:epic`, or `:story`
+  - `scope_id` -- UUID of the project, epic, or story
+  - `budget_millicents` -- total cost budget in 1/1000 of a cent
+  - `budget_input_tokens` -- optional input token budget
+  - `budget_output_tokens` -- optional output token budget
+  - `alert_threshold_pct` -- percentage at which to alert (default 80)
+  - `metadata` -- extensible JSONB map
+  """
+
+  use Loopctl.Schema
+
+  @type t :: %__MODULE__{}
+
+  @scope_types [:project, :epic, :story]
+
+  @derive {Jason.Encoder,
+           only: [
+             :id,
+             :tenant_id,
+             :scope_type,
+             :scope_id,
+             :budget_millicents,
+             :budget_input_tokens,
+             :budget_output_tokens,
+             :alert_threshold_pct,
+             :metadata,
+             :inserted_at,
+             :updated_at
+           ]}
+
+  schema "token_budgets" do
+    tenant_field()
+
+    field :scope_type, Ecto.Enum, values: @scope_types
+    field :scope_id, :binary_id
+    field :budget_millicents, :integer
+    field :budget_input_tokens, :integer
+    field :budget_output_tokens, :integer
+    field :alert_threshold_pct, :integer, default: 80
+    field :metadata, :map, default: %{}
+
+    timestamps()
+  end
+
+  @doc """
+  Changeset for creating a new token budget.
+
+  The `tenant_id` is set programmatically and must not be in cast.
+  """
+  @spec create_changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
+  def create_changeset(budget \\ %__MODULE__{}, attrs) do
+    budget
+    |> cast(attrs, [
+      :scope_type,
+      :scope_id,
+      :budget_millicents,
+      :budget_input_tokens,
+      :budget_output_tokens,
+      :alert_threshold_pct,
+      :metadata
+    ])
+    |> validate_required([:scope_type, :scope_id, :budget_millicents])
+    |> validate_number(:budget_millicents, greater_than: 0)
+    |> validate_number(:budget_input_tokens, greater_than_or_equal_to: 0)
+    |> validate_number(:budget_output_tokens, greater_than_or_equal_to: 0)
+    |> validate_number(:alert_threshold_pct,
+      greater_than_or_equal_to: 1,
+      less_than_or_equal_to: 100
+    )
+    |> validate_inclusion(:scope_type, @scope_types)
+    |> foreign_key_constraint(:tenant_id)
+    |> unique_constraint([:tenant_id, :scope_type, :scope_id],
+      name: :token_budgets_tenant_id_scope_type_scope_id_index,
+      message: "budget already exists for this scope"
+    )
+  end
+
+  @doc """
+  Changeset for updating an existing token budget.
+
+  Cannot change `scope_type` or `scope_id`.
+  """
+  @spec update_changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
+  def update_changeset(budget, attrs) do
+    budget
+    |> cast(attrs, [
+      :budget_millicents,
+      :budget_input_tokens,
+      :budget_output_tokens,
+      :alert_threshold_pct,
+      :metadata
+    ])
+    |> validate_number(:budget_millicents, greater_than: 0)
+    |> validate_number(:budget_input_tokens, greater_than_or_equal_to: 0)
+    |> validate_number(:budget_output_tokens, greater_than_or_equal_to: 0)
+    |> validate_number(:alert_threshold_pct,
+      greater_than_or_equal_to: 1,
+      less_than_or_equal_to: 100
+    )
+  end
+end

--- a/lib/loopctl_web/controllers/token_budget_controller.ex
+++ b/lib/loopctl_web/controllers/token_budget_controller.ex
@@ -1,0 +1,337 @@
+defmodule LoopctlWeb.TokenBudgetController do
+  @moduledoc """
+  Controller for token budget configuration.
+
+  - `POST /api/v1/token-budgets` -- create a budget (user+)
+  - `GET /api/v1/token-budgets` -- list budgets for tenant (agent+)
+  - `GET /api/v1/token-budgets/:id` -- get a single budget (agent+)
+  - `PATCH /api/v1/token-budgets/:id` -- update a budget (user+)
+  - `DELETE /api/v1/token-budgets/:id` -- delete a budget (user+)
+  """
+
+  use LoopctlWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Loopctl.ApiSpec.Schemas
+  alias Loopctl.TokenUsage
+  alias Loopctl.TokenUsage.Formatting
+  alias LoopctlWeb.AuditContext
+
+  action_fallback LoopctlWeb.FallbackController
+
+  plug LoopctlWeb.Plugs.RequireRole, [role: :user] when action in [:create, :update, :delete]
+  plug LoopctlWeb.Plugs.RequireRole, [role: :agent] when action in [:index, :show]
+
+  tags(["Token Budgets"])
+
+  operation(:create,
+    summary: "Create token budget",
+    description:
+      "Creates a budget for a project, epic, or story scope. " <>
+        "Only one budget per (scope_type, scope_id) pair is allowed.",
+    request_body:
+      {"Token budget params", "application/json",
+       %OpenApiSpex.Schema{
+         type: :object,
+         required: [:scope_type, :scope_id, :budget_millicents],
+         properties: %{
+           scope_type: %OpenApiSpex.Schema{
+             type: :string,
+             enum: ["project", "epic", "story"]
+           },
+           scope_id: %OpenApiSpex.Schema{type: :string, format: :uuid},
+           budget_millicents: %OpenApiSpex.Schema{type: :integer, minimum: 1},
+           budget_input_tokens: %OpenApiSpex.Schema{
+             type: :integer,
+             minimum: 0,
+             nullable: true
+           },
+           budget_output_tokens: %OpenApiSpex.Schema{
+             type: :integer,
+             minimum: 0,
+             nullable: true
+           },
+           alert_threshold_pct: %OpenApiSpex.Schema{
+             type: :integer,
+             minimum: 1,
+             maximum: 100,
+             default: 80
+           },
+           metadata: %OpenApiSpex.Schema{type: :object, additionalProperties: true}
+         }
+       }},
+    responses: %{
+      201 =>
+        {"Budget created", "application/json",
+         %OpenApiSpex.Schema{type: :object, additionalProperties: true}},
+      404 => {"Scope entity not found", "application/json", Schemas.ErrorResponse},
+      409 => {"Budget already exists for scope", "application/json", Schemas.ErrorResponse},
+      422 => {"Validation error", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  operation(:index,
+    summary: "List token budgets",
+    description:
+      "Returns all token budgets for the tenant. Filterable by scope_type and scope_id. " <>
+        "Includes current spend and remaining budget for each entry.",
+    parameters: [
+      scope_type: [
+        in: :query,
+        type: :string,
+        description: "Filter by scope type: project, epic, story"
+      ],
+      scope_id: [in: :query, type: :string, description: "Filter by scope UUID"],
+      page: [in: :query, type: :integer, description: "Page number"],
+      page_size: [in: :query, type: :integer, description: "Items per page"]
+    ],
+    responses: %{
+      200 =>
+        {"Budget list", "application/json",
+         %OpenApiSpex.Schema{
+           type: :object,
+           properties: %{
+             data: %OpenApiSpex.Schema{
+               type: :array,
+               items: %OpenApiSpex.Schema{type: :object, additionalProperties: true}
+             },
+             meta: Schemas.PaginationMeta
+           }
+         }},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  operation(:show,
+    summary: "Get token budget",
+    description:
+      "Returns a single token budget with current spend and remaining calculated in real-time.",
+    parameters: [
+      id: [in: :path, type: :string, description: "Budget UUID"]
+    ],
+    responses: %{
+      200 =>
+        {"Budget details", "application/json",
+         %OpenApiSpex.Schema{type: :object, additionalProperties: true}},
+      404 => {"Budget not found", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  operation(:update,
+    summary: "Update token budget",
+    description:
+      "Updates budget_millicents, token limits, or alert_threshold_pct. " <>
+        "Cannot change scope_type or scope_id.",
+    parameters: [
+      id: [in: :path, type: :string, description: "Budget UUID"]
+    ],
+    request_body:
+      {"Token budget update params", "application/json",
+       %OpenApiSpex.Schema{
+         type: :object,
+         properties: %{
+           budget_millicents: %OpenApiSpex.Schema{type: :integer, minimum: 1},
+           budget_input_tokens: %OpenApiSpex.Schema{
+             type: :integer,
+             minimum: 0,
+             nullable: true
+           },
+           budget_output_tokens: %OpenApiSpex.Schema{
+             type: :integer,
+             minimum: 0,
+             nullable: true
+           },
+           alert_threshold_pct: %OpenApiSpex.Schema{
+             type: :integer,
+             minimum: 1,
+             maximum: 100
+           },
+           metadata: %OpenApiSpex.Schema{type: :object, additionalProperties: true}
+         }
+       }},
+    responses: %{
+      200 =>
+        {"Budget updated", "application/json",
+         %OpenApiSpex.Schema{type: :object, additionalProperties: true}},
+      404 => {"Budget not found", "application/json", Schemas.ErrorResponse},
+      422 => {"Validation error", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  operation(:delete,
+    summary: "Delete token budget",
+    description: "Deletes a token budget. Does not delete associated token usage reports.",
+    parameters: [
+      id: [in: :path, type: :string, description: "Budget UUID"]
+    ],
+    responses: %{
+      200 =>
+        {"Budget deleted", "application/json",
+         %OpenApiSpex.Schema{type: :object, additionalProperties: true}},
+      404 => {"Budget not found", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  @doc """
+  POST /api/v1/token-budgets
+
+  Creates a token budget for a project, epic, or story scope.
+  """
+  def create(conn, params) do
+    api_key = conn.assigns.current_api_key
+    tenant_id = api_key.tenant_id
+    audit_opts = AuditContext.from_conn(conn)
+
+    case TokenUsage.create_budget(tenant_id, params, audit_opts) do
+      {:ok, budget} ->
+        spend = TokenUsage.get_scope_spend(tenant_id, budget.scope_type, budget.scope_id)
+
+        conn
+        |> put_status(:created)
+        |> json(%{token_budget: format_budget_with_spend(budget, spend)})
+
+      {:error, :not_found} ->
+        {:error, :not_found}
+
+      {:error, :conflict} ->
+        {:error, :conflict}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:error, changeset}
+    end
+  end
+
+  @doc """
+  GET /api/v1/token-budgets
+
+  Lists all token budgets for the tenant with filtering and pagination.
+  """
+  def index(conn, params) do
+    api_key = conn.assigns.current_api_key
+    tenant_id = api_key.tenant_id
+
+    opts =
+      []
+      |> maybe_add_opt(:scope_type, params["scope_type"])
+      |> maybe_add_opt(:scope_id, params["scope_id"])
+      |> maybe_add_opt(:page, parse_int(params["page"]))
+      |> maybe_add_opt(:page_size, parse_int(params["page_size"]))
+
+    {:ok, result} = TokenUsage.list_budgets(tenant_id, opts)
+
+    json(conn, %{
+      data: Enum.map(result.data, &format_budget_entry/1),
+      meta: %{
+        page: result.page,
+        page_size: result.page_size,
+        total_count: result.total,
+        total_pages: ceil_div(result.total, result.page_size)
+      }
+    })
+  end
+
+  @doc """
+  GET /api/v1/token-budgets/:id
+
+  Returns a single budget with current spend and remaining.
+  """
+  def show(conn, %{"id" => id}) do
+    api_key = conn.assigns.current_api_key
+    tenant_id = api_key.tenant_id
+
+    with {:ok, budget} <- TokenUsage.get_budget(tenant_id, id) do
+      spend = TokenUsage.get_scope_spend(tenant_id, budget.scope_type, budget.scope_id)
+
+      json(conn, %{token_budget: format_budget_with_spend(budget, spend)})
+    end
+  end
+
+  @doc """
+  PATCH /api/v1/token-budgets/:id
+
+  Updates budget amounts and thresholds. Cannot change scope.
+  """
+  def update(conn, %{"id" => id} = params) do
+    api_key = conn.assigns.current_api_key
+    tenant_id = api_key.tenant_id
+    audit_opts = AuditContext.from_conn(conn)
+
+    # Strip the id from params so it's not passed as an attr
+    attrs = Map.delete(params, "id")
+
+    with {:ok, budget} <- TokenUsage.update_budget(tenant_id, id, attrs, audit_opts) do
+      spend = TokenUsage.get_scope_spend(tenant_id, budget.scope_type, budget.scope_id)
+
+      json(conn, %{token_budget: format_budget_with_spend(budget, spend)})
+    end
+  end
+
+  @doc """
+  DELETE /api/v1/token-budgets/:id
+
+  Deletes a budget. Does not delete associated token usage reports.
+  """
+  def delete(conn, %{"id" => id}) do
+    api_key = conn.assigns.current_api_key
+    tenant_id = api_key.tenant_id
+    audit_opts = AuditContext.from_conn(conn)
+
+    with {:ok, budget} <- TokenUsage.delete_budget(tenant_id, id, audit_opts) do
+      json(conn, %{
+        token_budget: %{
+          id: budget.id,
+          deleted: true
+        }
+      })
+    end
+  end
+
+  # --- Private helpers ---
+
+  defp format_budget_with_spend(budget, spend) do
+    remaining = max(budget.budget_millicents - spend, 0)
+
+    %{
+      id: budget.id,
+      tenant_id: budget.tenant_id,
+      scope_type: budget.scope_type,
+      scope_id: budget.scope_id,
+      budget_millicents: budget.budget_millicents,
+      budget_dollars: Formatting.millicents_to_dollars(budget.budget_millicents),
+      budget_input_tokens: budget.budget_input_tokens,
+      budget_output_tokens: budget.budget_output_tokens,
+      alert_threshold_pct: budget.alert_threshold_pct,
+      current_spend_millicents: spend,
+      current_spend_dollars: Formatting.millicents_to_dollars(spend),
+      remaining_millicents: remaining,
+      remaining_dollars: Formatting.millicents_to_dollars(remaining),
+      metadata: budget.metadata,
+      inserted_at: budget.inserted_at,
+      updated_at: budget.updated_at
+    }
+  end
+
+  defp format_budget_entry(%{budget: budget, current_spend_millicents: spend}) do
+    format_budget_with_spend(budget, spend)
+  end
+
+  defp parse_int(nil), do: nil
+
+  defp parse_int(val) when is_binary(val) do
+    case Integer.parse(val) do
+      {n, _} -> n
+      :error -> nil
+    end
+  end
+
+  defp parse_int(val) when is_integer(val), do: val
+
+  defp maybe_add_opt(opts, _key, nil), do: opts
+  defp maybe_add_opt(opts, key, value), do: Keyword.put(opts, key, value)
+
+  defp ceil_div(numerator, denominator), do: ceil(numerator / denominator)
+end

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -205,6 +205,10 @@ defmodule LoopctlWeb.Router do
     post "/token-usage", TokenUsageController, :create
     get "/stories/:story_id/token-usage", TokenUsageController, :index
 
+    # Token budgets (Epic 19)
+    resources "/token-budgets", TokenBudgetController,
+      only: [:create, :index, :show, :update, :delete]
+
     # Skill results
     post "/skill_results", SkillResultController, :create
   end

--- a/priv/plts/dialyzer_ignore.exs
+++ b/priv/plts/dialyzer_ignore.exs
@@ -5,5 +5,10 @@
 
   # Ecto.Multi.t() opaque type warnings — known upstream issue
   # https://github.com/elixir-ecto/ecto/issues/1882
-  ~r/call_without_opaque/
+  ~r/call_without_opaque/,
+
+  # MapSet opaque type warnings — known upstream issue in Erlang/OTP dialyzer
+  # The reachable?/4 function passes MapSet to recursive calls, which dialyzer
+  # flags as opaque term crossing function boundaries.
+  ~r/call_with_opaque.*reachable\?/
 ]

--- a/priv/repo/migrations/20260403211420_create_token_budgets.exs
+++ b/priv/repo/migrations/20260403211420_create_token_budgets.exs
@@ -1,0 +1,42 @@
+defmodule Loopctl.Repo.Migrations.CreateTokenBudgets do
+  use Ecto.Migration
+  import Loopctl.Repo.RlsHelpers
+
+  def change do
+    create table(:token_budgets, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      add :tenant_id, references(:tenants, type: :binary_id, on_delete: :delete_all), null: false
+      add :scope_type, :string, null: false
+      add :scope_id, :binary_id, null: false
+
+      add :budget_millicents, :bigint, null: false
+      add :budget_input_tokens, :bigint
+      add :budget_output_tokens, :bigint
+      add :alert_threshold_pct, :integer, null: false, default: 80
+      add :metadata, :map, default: %{}
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    # scope_type CHECK constraint
+    execute(
+      "ALTER TABLE token_budgets ADD CONSTRAINT token_budgets_scope_type_check CHECK (scope_type IN ('project', 'epic', 'story'))",
+      "ALTER TABLE token_budgets DROP CONSTRAINT token_budgets_scope_type_check"
+    )
+
+    # Composite unique index — one budget per (tenant, scope_type, scope_id)
+    create unique_index(:token_budgets, [:tenant_id, :scope_type, :scope_id])
+
+    # Lookup indexes
+    create index(:token_budgets, [:tenant_id])
+    create index(:token_budgets, [:tenant_id, :scope_type])
+
+    enable_rls(:token_budgets)
+
+    # Add default_story_budget_millicents to tenants table
+    alter table(:tenants) do
+      add :default_story_budget_millicents, :bigint
+    end
+  end
+end

--- a/test/loopctl/token_usage/budget_test.exs
+++ b/test/loopctl/token_usage/budget_test.exs
@@ -1,0 +1,842 @@
+defmodule Loopctl.TokenUsage.BudgetTest do
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.TokenUsage
+  alias Loopctl.TokenUsage.Budget
+
+  setup :verify_on_exit!
+
+  defp setup_project do
+    tenant = fixture(:tenant)
+    project = fixture(:project, %{tenant_id: tenant.id})
+    epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+
+    story =
+      fixture(:story, %{
+        tenant_id: tenant.id,
+        epic_id: epic.id,
+        project_id: project.id
+      })
+
+    %{tenant: tenant, project: project, epic: epic, story: story}
+  end
+
+  # --- create_budget/3 ---
+
+  describe "create_budget/3" do
+    test "creates a budget for a story scope" do
+      %{tenant: tenant, story: story} = setup_project()
+
+      attrs = %{
+        scope_type: :story,
+        scope_id: story.id,
+        budget_millicents: 500_000
+      }
+
+      assert {:ok, %Budget{} = budget} = TokenUsage.create_budget(tenant.id, attrs)
+      assert budget.tenant_id == tenant.id
+      assert budget.scope_type == :story
+      assert budget.scope_id == story.id
+      assert budget.budget_millicents == 500_000
+      assert budget.alert_threshold_pct == 80
+    end
+
+    test "creates a budget for an epic scope" do
+      %{tenant: tenant, epic: epic} = setup_project()
+
+      attrs = %{
+        scope_type: :epic,
+        scope_id: epic.id,
+        budget_millicents: 2_000_000
+      }
+
+      assert {:ok, %Budget{} = budget} = TokenUsage.create_budget(tenant.id, attrs)
+      assert budget.scope_type == :epic
+      assert budget.scope_id == epic.id
+    end
+
+    test "creates a budget for a project scope" do
+      %{tenant: tenant, project: project} = setup_project()
+
+      attrs = %{
+        scope_type: :project,
+        scope_id: project.id,
+        budget_millicents: 10_000_000
+      }
+
+      assert {:ok, %Budget{} = budget} = TokenUsage.create_budget(tenant.id, attrs)
+      assert budget.scope_type == :project
+      assert budget.scope_id == project.id
+    end
+
+    test "accepts optional budget_input_tokens and budget_output_tokens" do
+      %{tenant: tenant, story: story} = setup_project()
+
+      attrs = %{
+        scope_type: :story,
+        scope_id: story.id,
+        budget_millicents: 500_000,
+        budget_input_tokens: 100_000,
+        budget_output_tokens: 50_000
+      }
+
+      assert {:ok, budget} = TokenUsage.create_budget(tenant.id, attrs)
+      assert budget.budget_input_tokens == 100_000
+      assert budget.budget_output_tokens == 50_000
+    end
+
+    test "accepts custom alert_threshold_pct" do
+      %{tenant: tenant, story: story} = setup_project()
+
+      attrs = %{
+        scope_type: :story,
+        scope_id: story.id,
+        budget_millicents: 500_000,
+        alert_threshold_pct: 90
+      }
+
+      assert {:ok, budget} = TokenUsage.create_budget(tenant.id, attrs)
+      assert budget.alert_threshold_pct == 90
+    end
+
+    test "accepts metadata" do
+      %{tenant: tenant, story: story} = setup_project()
+
+      attrs = %{
+        scope_type: :story,
+        scope_id: story.id,
+        budget_millicents: 500_000,
+        metadata: %{"reason" => "hotfix budget"}
+      }
+
+      assert {:ok, budget} = TokenUsage.create_budget(tenant.id, attrs)
+      assert budget.metadata == %{"reason" => "hotfix budget"}
+    end
+
+    test "returns :conflict when budget already exists for scope" do
+      %{tenant: tenant, story: story} = setup_project()
+
+      attrs = %{
+        scope_type: :story,
+        scope_id: story.id,
+        budget_millicents: 500_000
+      }
+
+      assert {:ok, _} = TokenUsage.create_budget(tenant.id, attrs)
+      assert {:error, :conflict} = TokenUsage.create_budget(tenant.id, attrs)
+    end
+
+    test "returns :not_found when scope entity does not exist" do
+      tenant = fixture(:tenant)
+
+      attrs = %{
+        scope_type: :story,
+        scope_id: Ecto.UUID.generate(),
+        budget_millicents: 500_000
+      }
+
+      assert {:error, :not_found} = TokenUsage.create_budget(tenant.id, attrs)
+    end
+
+    test "returns error when budget_millicents is zero" do
+      %{tenant: tenant, story: story} = setup_project()
+
+      attrs = %{
+        scope_type: :story,
+        scope_id: story.id,
+        budget_millicents: 0
+      }
+
+      assert {:error, changeset} = TokenUsage.create_budget(tenant.id, attrs)
+      assert errors_on(changeset).budget_millicents != []
+    end
+
+    test "returns error when budget_millicents is missing" do
+      %{tenant: tenant, story: story} = setup_project()
+
+      attrs = %{
+        scope_type: :story,
+        scope_id: story.id
+      }
+
+      assert {:error, changeset} = TokenUsage.create_budget(tenant.id, attrs)
+      assert errors_on(changeset).budget_millicents != []
+    end
+
+    test "returns error when alert_threshold_pct is out of range" do
+      %{tenant: tenant, story: story} = setup_project()
+
+      attrs = %{
+        scope_type: :story,
+        scope_id: story.id,
+        budget_millicents: 500_000,
+        alert_threshold_pct: 101
+      }
+
+      assert {:error, changeset} = TokenUsage.create_budget(tenant.id, attrs)
+      assert errors_on(changeset).alert_threshold_pct != []
+    end
+
+    test "creates an audit log entry" do
+      %{tenant: tenant, story: story} = setup_project()
+
+      attrs = %{
+        scope_type: :story,
+        scope_id: story.id,
+        budget_millicents: 500_000
+      }
+
+      {:ok, budget} =
+        TokenUsage.create_budget(tenant.id, attrs, actor_id: Ecto.UUID.generate())
+
+      {:ok, result} =
+        Loopctl.Audit.list_entries(tenant.id,
+          entity_type: "token_budget",
+          entity_id: budget.id,
+          action: "created"
+        )
+
+      assert length(result.data) == 1
+      audit = hd(result.data)
+      assert audit.entity_type == "token_budget"
+      assert audit.action == "created"
+      assert audit.new_state["budget_millicents"] == 500_000
+    end
+
+    test "accepts string keys in attrs" do
+      %{tenant: tenant, story: story} = setup_project()
+
+      attrs = %{
+        "scope_type" => "story",
+        "scope_id" => story.id,
+        "budget_millicents" => 500_000
+      }
+
+      assert {:ok, %Budget{}} = TokenUsage.create_budget(tenant.id, attrs)
+    end
+  end
+
+  # --- get_budget/2 ---
+
+  describe "get_budget/2" do
+    test "returns a budget by id" do
+      %{tenant: tenant, story: story} = setup_project()
+
+      budget =
+        fixture(:token_budget, %{
+          tenant_id: tenant.id,
+          scope_type: :story,
+          scope_id: story.id
+        })
+
+      assert {:ok, found} = TokenUsage.get_budget(tenant.id, budget.id)
+      assert found.id == budget.id
+    end
+
+    test "returns :not_found for nonexistent budget" do
+      tenant = fixture(:tenant)
+      assert {:error, :not_found} = TokenUsage.get_budget(tenant.id, Ecto.UUID.generate())
+    end
+
+    test "returns :not_found for wrong tenant" do
+      %{tenant: tenant, story: story} = setup_project()
+
+      budget =
+        fixture(:token_budget, %{
+          tenant_id: tenant.id,
+          scope_type: :story,
+          scope_id: story.id
+        })
+
+      other_tenant = fixture(:tenant)
+      assert {:error, :not_found} = TokenUsage.get_budget(other_tenant.id, budget.id)
+    end
+  end
+
+  # --- list_budgets/2 ---
+
+  describe "list_budgets/2" do
+    test "returns all budgets for a tenant" do
+      %{tenant: tenant, project: project, epic: epic, story: story} = setup_project()
+
+      fixture(:token_budget, %{
+        tenant_id: tenant.id,
+        scope_type: :project,
+        scope_id: project.id
+      })
+
+      fixture(:token_budget, %{
+        tenant_id: tenant.id,
+        scope_type: :epic,
+        scope_id: epic.id
+      })
+
+      fixture(:token_budget, %{
+        tenant_id: tenant.id,
+        scope_type: :story,
+        scope_id: story.id
+      })
+
+      {:ok, result} = TokenUsage.list_budgets(tenant.id)
+      assert result.total == 3
+      assert length(result.data) == 3
+    end
+
+    test "filters by scope_type" do
+      %{tenant: tenant, project: project, story: story} = setup_project()
+
+      fixture(:token_budget, %{
+        tenant_id: tenant.id,
+        scope_type: :project,
+        scope_id: project.id
+      })
+
+      fixture(:token_budget, %{
+        tenant_id: tenant.id,
+        scope_type: :story,
+        scope_id: story.id
+      })
+
+      {:ok, result} = TokenUsage.list_budgets(tenant.id, scope_type: :story)
+      assert result.total == 1
+    end
+
+    test "filters by scope_id" do
+      %{tenant: tenant, story: story} = setup_project()
+
+      fixture(:token_budget, %{
+        tenant_id: tenant.id,
+        scope_type: :story,
+        scope_id: story.id
+      })
+
+      story2 =
+        fixture(:story, %{tenant_id: tenant.id})
+
+      fixture(:token_budget, %{
+        tenant_id: tenant.id,
+        scope_type: :story,
+        scope_id: story2.id
+      })
+
+      {:ok, result} = TokenUsage.list_budgets(tenant.id, scope_id: story.id)
+      assert result.total == 1
+    end
+
+    test "includes current spend and remaining" do
+      %{tenant: tenant, story: story} = setup_project()
+      agent = fixture(:agent, %{tenant_id: tenant.id})
+
+      fixture(:token_budget, %{
+        tenant_id: tenant.id,
+        scope_type: :story,
+        scope_id: story.id,
+        budget_millicents: 10_000
+      })
+
+      fixture(:token_usage_report, %{
+        tenant_id: tenant.id,
+        story_id: story.id,
+        agent_id: agent.id,
+        cost_millicents: 3000
+      })
+
+      {:ok, result} = TokenUsage.list_budgets(tenant.id)
+      entry = hd(result.data)
+
+      assert entry.current_spend_millicents == 3000
+      assert entry.remaining_millicents == 7000
+    end
+
+    test "paginates results" do
+      %{tenant: tenant} = setup_project()
+
+      for _i <- 1..5 do
+        story = fixture(:story, %{tenant_id: tenant.id})
+
+        fixture(:token_budget, %{
+          tenant_id: tenant.id,
+          scope_type: :story,
+          scope_id: story.id
+        })
+      end
+
+      {:ok, result} = TokenUsage.list_budgets(tenant.id, page: 1, page_size: 2)
+      assert length(result.data) == 2
+      assert result.total == 5
+    end
+  end
+
+  # --- update_budget/4 ---
+
+  describe "update_budget/4" do
+    test "updates budget_millicents" do
+      %{tenant: tenant, story: story} = setup_project()
+
+      budget =
+        fixture(:token_budget, %{
+          tenant_id: tenant.id,
+          scope_type: :story,
+          scope_id: story.id,
+          budget_millicents: 500_000
+        })
+
+      assert {:ok, updated} =
+               TokenUsage.update_budget(tenant.id, budget.id, %{budget_millicents: 1_000_000})
+
+      assert updated.budget_millicents == 1_000_000
+    end
+
+    test "updates alert_threshold_pct" do
+      %{tenant: tenant, story: story} = setup_project()
+
+      budget =
+        fixture(:token_budget, %{
+          tenant_id: tenant.id,
+          scope_type: :story,
+          scope_id: story.id
+        })
+
+      assert {:ok, updated} =
+               TokenUsage.update_budget(tenant.id, budget.id, %{alert_threshold_pct: 95})
+
+      assert updated.alert_threshold_pct == 95
+    end
+
+    test "updates budget_input_tokens and budget_output_tokens" do
+      %{tenant: tenant, story: story} = setup_project()
+
+      budget =
+        fixture(:token_budget, %{
+          tenant_id: tenant.id,
+          scope_type: :story,
+          scope_id: story.id
+        })
+
+      assert {:ok, updated} =
+               TokenUsage.update_budget(tenant.id, budget.id, %{
+                 budget_input_tokens: 200_000,
+                 budget_output_tokens: 100_000
+               })
+
+      assert updated.budget_input_tokens == 200_000
+      assert updated.budget_output_tokens == 100_000
+    end
+
+    test "returns :not_found for nonexistent budget" do
+      tenant = fixture(:tenant)
+
+      assert {:error, :not_found} =
+               TokenUsage.update_budget(tenant.id, Ecto.UUID.generate(), %{
+                 budget_millicents: 100
+               })
+    end
+
+    test "creates an audit log entry" do
+      %{tenant: tenant, story: story} = setup_project()
+
+      budget =
+        fixture(:token_budget, %{
+          tenant_id: tenant.id,
+          scope_type: :story,
+          scope_id: story.id,
+          budget_millicents: 500_000
+        })
+
+      {:ok, _} =
+        TokenUsage.update_budget(tenant.id, budget.id, %{budget_millicents: 1_000_000},
+          actor_id: Ecto.UUID.generate()
+        )
+
+      {:ok, result} =
+        Loopctl.Audit.list_entries(tenant.id,
+          entity_type: "token_budget",
+          entity_id: budget.id,
+          action: "updated"
+        )
+
+      assert length(result.data) == 1
+      audit = hd(result.data)
+      assert audit.old_state["budget_millicents"] == 500_000
+      assert audit.new_state["budget_millicents"] == 1_000_000
+    end
+  end
+
+  # --- delete_budget/3 ---
+
+  describe "delete_budget/3" do
+    test "deletes a budget" do
+      %{tenant: tenant, story: story} = setup_project()
+
+      budget =
+        fixture(:token_budget, %{
+          tenant_id: tenant.id,
+          scope_type: :story,
+          scope_id: story.id
+        })
+
+      assert {:ok, deleted} = TokenUsage.delete_budget(tenant.id, budget.id)
+      assert deleted.id == budget.id
+      assert {:error, :not_found} = TokenUsage.get_budget(tenant.id, budget.id)
+    end
+
+    test "does not delete associated token usage reports" do
+      %{tenant: tenant, story: story} = setup_project()
+      agent = fixture(:agent, %{tenant_id: tenant.id})
+
+      fixture(:token_budget, %{
+        tenant_id: tenant.id,
+        scope_type: :story,
+        scope_id: story.id
+      })
+
+      report =
+        fixture(:token_usage_report, %{
+          tenant_id: tenant.id,
+          story_id: story.id,
+          agent_id: agent.id
+        })
+
+      budgets = Loopctl.AdminRepo.all(Budget)
+      budget = hd(budgets)
+
+      {:ok, _} = TokenUsage.delete_budget(tenant.id, budget.id)
+
+      # Report should still exist
+      assert Loopctl.AdminRepo.get(Loopctl.TokenUsage.Report, report.id) != nil
+    end
+
+    test "returns :not_found for nonexistent budget" do
+      tenant = fixture(:tenant)
+      assert {:error, :not_found} = TokenUsage.delete_budget(tenant.id, Ecto.UUID.generate())
+    end
+
+    test "creates an audit log entry" do
+      %{tenant: tenant, story: story} = setup_project()
+
+      budget =
+        fixture(:token_budget, %{
+          tenant_id: tenant.id,
+          scope_type: :story,
+          scope_id: story.id,
+          budget_millicents: 500_000
+        })
+
+      {:ok, _} =
+        TokenUsage.delete_budget(tenant.id, budget.id, actor_id: Ecto.UUID.generate())
+
+      {:ok, result} =
+        Loopctl.Audit.list_entries(tenant.id,
+          entity_type: "token_budget",
+          entity_id: budget.id,
+          action: "deleted"
+        )
+
+      assert length(result.data) == 1
+    end
+  end
+
+  # --- get_effective_budget/3 ---
+
+  describe "get_effective_budget/3" do
+    test "returns explicit story budget" do
+      %{tenant: tenant, story: story} = setup_project()
+
+      fixture(:token_budget, %{
+        tenant_id: tenant.id,
+        scope_type: :story,
+        scope_id: story.id,
+        budget_millicents: 500_000
+      })
+
+      assert {:ok, {500_000, :explicit}} =
+               TokenUsage.get_effective_budget(tenant.id, :story, story.id)
+    end
+
+    test "inherits epic budget when no story budget exists" do
+      %{tenant: tenant, epic: epic, story: story} = setup_project()
+
+      fixture(:token_budget, %{
+        tenant_id: tenant.id,
+        scope_type: :epic,
+        scope_id: epic.id,
+        budget_millicents: 2_000_000
+      })
+
+      assert {:ok, {2_000_000, :epic_inherited}} =
+               TokenUsage.get_effective_budget(tenant.id, :story, story.id)
+    end
+
+    test "inherits project budget when no story or epic budget exists" do
+      %{tenant: tenant, project: project, story: story} = setup_project()
+
+      fixture(:token_budget, %{
+        tenant_id: tenant.id,
+        scope_type: :project,
+        scope_id: project.id,
+        budget_millicents: 10_000_000
+      })
+
+      assert {:ok, {10_000_000, :project_inherited}} =
+               TokenUsage.get_effective_budget(tenant.id, :story, story.id)
+    end
+
+    test "returns tenant default when no explicit budgets exist" do
+      %{tenant: tenant, story: story} = setup_project()
+
+      # Set tenant default
+      tenant
+      |> Ecto.Changeset.change(%{default_story_budget_millicents: 100_000})
+      |> Loopctl.AdminRepo.update!()
+
+      assert {:ok, {100_000, :tenant_default}} =
+               TokenUsage.get_effective_budget(tenant.id, :story, story.id)
+    end
+
+    test "returns nil when no budget at any level" do
+      %{tenant: tenant, story: story} = setup_project()
+
+      assert {:ok, nil} = TokenUsage.get_effective_budget(tenant.id, :story, story.id)
+    end
+
+    test "story budget takes precedence over epic budget" do
+      %{tenant: tenant, epic: epic, story: story} = setup_project()
+
+      fixture(:token_budget, %{
+        tenant_id: tenant.id,
+        scope_type: :story,
+        scope_id: story.id,
+        budget_millicents: 500_000
+      })
+
+      fixture(:token_budget, %{
+        tenant_id: tenant.id,
+        scope_type: :epic,
+        scope_id: epic.id,
+        budget_millicents: 2_000_000
+      })
+
+      assert {:ok, {500_000, :explicit}} =
+               TokenUsage.get_effective_budget(tenant.id, :story, story.id)
+    end
+
+    test "epic budget takes precedence over project budget for story" do
+      %{tenant: tenant, project: project, epic: epic, story: story} = setup_project()
+
+      fixture(:token_budget, %{
+        tenant_id: tenant.id,
+        scope_type: :epic,
+        scope_id: epic.id,
+        budget_millicents: 2_000_000
+      })
+
+      fixture(:token_budget, %{
+        tenant_id: tenant.id,
+        scope_type: :project,
+        scope_id: project.id,
+        budget_millicents: 10_000_000
+      })
+
+      assert {:ok, {2_000_000, :epic_inherited}} =
+               TokenUsage.get_effective_budget(tenant.id, :story, story.id)
+    end
+
+    test "epic inherits project budget" do
+      %{tenant: tenant, project: project, epic: epic} = setup_project()
+
+      fixture(:token_budget, %{
+        tenant_id: tenant.id,
+        scope_type: :project,
+        scope_id: project.id,
+        budget_millicents: 10_000_000
+      })
+
+      assert {:ok, {10_000_000, :project_inherited}} =
+               TokenUsage.get_effective_budget(tenant.id, :epic, epic.id)
+    end
+
+    test "epic falls back to tenant default" do
+      %{tenant: tenant, epic: epic} = setup_project()
+
+      tenant
+      |> Ecto.Changeset.change(%{default_story_budget_millicents: 100_000})
+      |> Loopctl.AdminRepo.update!()
+
+      assert {:ok, {100_000, :tenant_default}} =
+               TokenUsage.get_effective_budget(tenant.id, :epic, epic.id)
+    end
+
+    test "project falls back to tenant default" do
+      %{tenant: tenant, project: project} = setup_project()
+
+      tenant
+      |> Ecto.Changeset.change(%{default_story_budget_millicents: 100_000})
+      |> Loopctl.AdminRepo.update!()
+
+      assert {:ok, {100_000, :tenant_default}} =
+               TokenUsage.get_effective_budget(tenant.id, :project, project.id)
+    end
+  end
+
+  # --- get_scope_spend/3 ---
+
+  describe "get_scope_spend/3" do
+    test "calculates story-level spend" do
+      %{tenant: tenant, story: story} = setup_project()
+      agent = fixture(:agent, %{tenant_id: tenant.id})
+
+      fixture(:token_usage_report, %{
+        tenant_id: tenant.id,
+        story_id: story.id,
+        agent_id: agent.id,
+        cost_millicents: 3000
+      })
+
+      fixture(:token_usage_report, %{
+        tenant_id: tenant.id,
+        story_id: story.id,
+        agent_id: agent.id,
+        cost_millicents: 2000
+      })
+
+      assert TokenUsage.get_scope_spend(tenant.id, :story, story.id) == 5000
+    end
+
+    test "calculates epic-level spend across stories" do
+      %{tenant: tenant, epic: epic, story: story} = setup_project()
+      agent = fixture(:agent, %{tenant_id: tenant.id})
+
+      story2 =
+        fixture(:story, %{
+          tenant_id: tenant.id,
+          epic_id: epic.id,
+          project_id: story.project_id
+        })
+
+      fixture(:token_usage_report, %{
+        tenant_id: tenant.id,
+        story_id: story.id,
+        agent_id: agent.id,
+        cost_millicents: 3000
+      })
+
+      fixture(:token_usage_report, %{
+        tenant_id: tenant.id,
+        story_id: story2.id,
+        agent_id: agent.id,
+        cost_millicents: 2000
+      })
+
+      assert TokenUsage.get_scope_spend(tenant.id, :epic, epic.id) == 5000
+    end
+
+    test "calculates project-level spend across all stories" do
+      %{tenant: tenant, project: project, story: story} = setup_project()
+      agent = fixture(:agent, %{tenant_id: tenant.id})
+
+      fixture(:token_usage_report, %{
+        tenant_id: tenant.id,
+        story_id: story.id,
+        agent_id: agent.id,
+        cost_millicents: 5000
+      })
+
+      assert TokenUsage.get_scope_spend(tenant.id, :project, project.id) == 5000
+    end
+
+    test "returns zero when no reports exist" do
+      %{tenant: tenant, story: story} = setup_project()
+      assert TokenUsage.get_scope_spend(tenant.id, :story, story.id) == 0
+    end
+  end
+
+  # --- Tenant isolation ---
+
+  describe "tenant isolation" do
+    test "tenant A cannot see tenant B's budgets" do
+      %{tenant: tenant_a, story: story_a} = setup_project()
+
+      fixture(:token_budget, %{
+        tenant_id: tenant_a.id,
+        scope_type: :story,
+        scope_id: story_a.id
+      })
+
+      tenant_b = fixture(:tenant)
+
+      {:ok, result} = TokenUsage.list_budgets(tenant_b.id)
+      assert result.data == []
+      assert result.total == 0
+    end
+
+    test "tenant A cannot get tenant B's budget by id" do
+      %{tenant: tenant_a, story: story_a} = setup_project()
+
+      budget =
+        fixture(:token_budget, %{
+          tenant_id: tenant_a.id,
+          scope_type: :story,
+          scope_id: story_a.id
+        })
+
+      tenant_b = fixture(:tenant)
+      assert {:error, :not_found} = TokenUsage.get_budget(tenant_b.id, budget.id)
+    end
+
+    test "budgets are scoped to their tenant for unique constraint" do
+      # Two different tenants can have budgets for different stories
+      %{tenant: tenant_a, story: story_a} = setup_project()
+
+      fixture(:token_budget, %{
+        tenant_id: tenant_a.id,
+        scope_type: :story,
+        scope_id: story_a.id
+      })
+
+      tenant_b = fixture(:tenant)
+      story_b = fixture(:story, %{tenant_id: tenant_b.id})
+
+      # This should succeed (different tenant, different story)
+      assert {:ok, _} =
+               TokenUsage.create_budget(tenant_b.id, %{
+                 scope_type: :story,
+                 scope_id: story_b.id,
+                 budget_millicents: 500_000
+               })
+    end
+  end
+
+  # --- Fixture test ---
+
+  describe "fixture/2" do
+    test "creates a token budget with auto-dependency resolution" do
+      budget = fixture(:token_budget)
+
+      assert budget.id != nil
+      assert budget.tenant_id != nil
+      assert budget.scope_id != nil
+      assert budget.scope_type == :story
+      assert budget.budget_millicents == 500_000
+    end
+
+    test "creates a token budget with custom attributes" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+
+      budget =
+        fixture(:token_budget, %{
+          tenant_id: tenant.id,
+          scope_type: :project,
+          scope_id: project.id,
+          budget_millicents: 10_000_000,
+          alert_threshold_pct: 90
+        })
+
+      assert budget.tenant_id == tenant.id
+      assert budget.scope_type == :project
+      assert budget.scope_id == project.id
+      assert budget.budget_millicents == 10_000_000
+      assert budget.alert_threshold_pct == 90
+    end
+  end
+end

--- a/test/loopctl_web/controllers/token_budget_controller_test.exs
+++ b/test/loopctl_web/controllers/token_budget_controller_test.exs
@@ -1,0 +1,589 @@
+defmodule LoopctlWeb.TokenBudgetControllerTest do
+  use LoopctlWeb.ConnCase, async: true
+
+  setup :verify_on_exit!
+
+  defp auth_conn(conn, raw_key) do
+    put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  defp setup_project_with_keys do
+    tenant = fixture(:tenant)
+    project = fixture(:project, %{tenant_id: tenant.id})
+    epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+
+    story =
+      fixture(:story, %{
+        tenant_id: tenant.id,
+        epic_id: epic.id,
+        project_id: project.id
+      })
+
+    {user_key, _user_api_key} =
+      fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+    agent = fixture(:agent, %{tenant_id: tenant.id})
+
+    {agent_key, _agent_api_key} =
+      fixture(:api_key, %{tenant_id: tenant.id, role: :agent, agent_id: agent.id})
+
+    %{
+      tenant: tenant,
+      project: project,
+      epic: epic,
+      story: story,
+      user_key: user_key,
+      agent_key: agent_key,
+      agent: agent
+    }
+  end
+
+  # --- POST /api/v1/token-budgets ---
+
+  describe "POST /api/v1/token-budgets" do
+    test "creates a budget for a story", %{conn: conn} do
+      %{story: story, user_key: user_key, tenant: tenant} = setup_project_with_keys()
+
+      conn =
+        conn
+        |> auth_conn(user_key)
+        |> post(~p"/api/v1/token-budgets", %{
+          "scope_type" => "story",
+          "scope_id" => story.id,
+          "budget_millicents" => 500_000
+        })
+
+      body = json_response(conn, 201)
+      budget = body["token_budget"]
+
+      assert budget["scope_type"] == "story"
+      assert budget["scope_id"] == story.id
+      assert budget["budget_millicents"] == 500_000
+      assert budget["alert_threshold_pct"] == 80
+      assert budget["budget_dollars"] == "5.00"
+      assert budget["current_spend_millicents"] == 0
+      assert budget["remaining_millicents"] == 500_000
+      assert budget["tenant_id"] == tenant.id
+    end
+
+    test "creates a budget for a project", %{conn: conn} do
+      %{project: project, user_key: user_key} = setup_project_with_keys()
+
+      conn =
+        conn
+        |> auth_conn(user_key)
+        |> post(~p"/api/v1/token-budgets", %{
+          "scope_type" => "project",
+          "scope_id" => project.id,
+          "budget_millicents" => 10_000_000
+        })
+
+      body = json_response(conn, 201)
+      assert body["token_budget"]["scope_type"] == "project"
+    end
+
+    test "creates a budget for an epic", %{conn: conn} do
+      %{epic: epic, user_key: user_key} = setup_project_with_keys()
+
+      conn =
+        conn
+        |> auth_conn(user_key)
+        |> post(~p"/api/v1/token-budgets", %{
+          "scope_type" => "epic",
+          "scope_id" => epic.id,
+          "budget_millicents" => 2_000_000
+        })
+
+      body = json_response(conn, 201)
+      assert body["token_budget"]["scope_type"] == "epic"
+    end
+
+    test "accepts optional fields", %{conn: conn} do
+      %{story: story, user_key: user_key} = setup_project_with_keys()
+
+      conn =
+        conn
+        |> auth_conn(user_key)
+        |> post(~p"/api/v1/token-budgets", %{
+          "scope_type" => "story",
+          "scope_id" => story.id,
+          "budget_millicents" => 500_000,
+          "budget_input_tokens" => 100_000,
+          "budget_output_tokens" => 50_000,
+          "alert_threshold_pct" => 90,
+          "metadata" => %{"reason" => "test"}
+        })
+
+      body = json_response(conn, 201)
+      budget = body["token_budget"]
+
+      assert budget["budget_input_tokens"] == 100_000
+      assert budget["budget_output_tokens"] == 50_000
+      assert budget["alert_threshold_pct"] == 90
+      assert budget["metadata"] == %{"reason" => "test"}
+    end
+
+    test "returns 409 on duplicate budget", %{conn: conn} do
+      %{story: story, user_key: user_key} = setup_project_with_keys()
+
+      params = %{
+        "scope_type" => "story",
+        "scope_id" => story.id,
+        "budget_millicents" => 500_000
+      }
+
+      conn
+      |> auth_conn(user_key)
+      |> post(~p"/api/v1/token-budgets", params)
+
+      conn2 =
+        build_conn()
+        |> auth_conn(user_key)
+        |> post(~p"/api/v1/token-budgets", params)
+
+      assert json_response(conn2, 409)
+    end
+
+    test "returns 404 for nonexistent scope entity", %{conn: conn} do
+      %{user_key: user_key} = setup_project_with_keys()
+
+      conn =
+        conn
+        |> auth_conn(user_key)
+        |> post(~p"/api/v1/token-budgets", %{
+          "scope_type" => "story",
+          "scope_id" => Ecto.UUID.generate(),
+          "budget_millicents" => 500_000
+        })
+
+      assert json_response(conn, 404)
+    end
+
+    test "returns 422 for missing budget_millicents", %{conn: conn} do
+      %{story: story, user_key: user_key} = setup_project_with_keys()
+
+      conn =
+        conn
+        |> auth_conn(user_key)
+        |> post(~p"/api/v1/token-budgets", %{
+          "scope_type" => "story",
+          "scope_id" => story.id
+        })
+
+      assert json_response(conn, 422)
+    end
+
+    test "returns 422 for zero budget_millicents", %{conn: conn} do
+      %{story: story, user_key: user_key} = setup_project_with_keys()
+
+      conn =
+        conn
+        |> auth_conn(user_key)
+        |> post(~p"/api/v1/token-budgets", %{
+          "scope_type" => "story",
+          "scope_id" => story.id,
+          "budget_millicents" => 0
+        })
+
+      assert json_response(conn, 422)
+    end
+
+    test "agent role cannot create budgets", %{conn: conn} do
+      %{story: story, agent_key: agent_key} = setup_project_with_keys()
+
+      conn =
+        conn
+        |> auth_conn(agent_key)
+        |> post(~p"/api/v1/token-budgets", %{
+          "scope_type" => "story",
+          "scope_id" => story.id,
+          "budget_millicents" => 500_000
+        })
+
+      assert json_response(conn, 403)
+    end
+  end
+
+  # --- GET /api/v1/token-budgets ---
+
+  describe "GET /api/v1/token-budgets" do
+    test "lists budgets for tenant", %{conn: conn} do
+      %{
+        tenant: tenant,
+        project: project,
+        story: story,
+        agent_key: agent_key,
+        agent: agent
+      } = setup_project_with_keys()
+
+      fixture(:token_budget, %{
+        tenant_id: tenant.id,
+        scope_type: :project,
+        scope_id: project.id
+      })
+
+      fixture(:token_budget, %{
+        tenant_id: tenant.id,
+        scope_type: :story,
+        scope_id: story.id
+      })
+
+      # Add some spend
+      fixture(:token_usage_report, %{
+        tenant_id: tenant.id,
+        story_id: story.id,
+        agent_id: agent.id,
+        cost_millicents: 3000
+      })
+
+      conn =
+        conn
+        |> auth_conn(agent_key)
+        |> get(~p"/api/v1/token-budgets")
+
+      body = json_response(conn, 200)
+
+      assert length(body["data"]) == 2
+      assert body["meta"]["total_count"] == 2
+
+      # Each entry should have spend info
+      Enum.each(body["data"], fn entry ->
+        assert Map.has_key?(entry, "current_spend_millicents")
+        assert Map.has_key?(entry, "remaining_millicents")
+        assert Map.has_key?(entry, "budget_dollars")
+      end)
+    end
+
+    test "filters by scope_type", %{conn: conn} do
+      %{tenant: tenant, project: project, story: story, agent_key: agent_key} =
+        setup_project_with_keys()
+
+      fixture(:token_budget, %{
+        tenant_id: tenant.id,
+        scope_type: :project,
+        scope_id: project.id
+      })
+
+      fixture(:token_budget, %{
+        tenant_id: tenant.id,
+        scope_type: :story,
+        scope_id: story.id
+      })
+
+      conn =
+        conn
+        |> auth_conn(agent_key)
+        |> get(~p"/api/v1/token-budgets?scope_type=story")
+
+      body = json_response(conn, 200)
+      assert body["meta"]["total_count"] == 1
+      assert hd(body["data"])["scope_type"] == "story"
+    end
+
+    test "filters by scope_id", %{conn: conn} do
+      %{tenant: tenant, story: story, agent_key: agent_key} = setup_project_with_keys()
+
+      fixture(:token_budget, %{
+        tenant_id: tenant.id,
+        scope_type: :story,
+        scope_id: story.id
+      })
+
+      story2 = fixture(:story, %{tenant_id: tenant.id})
+
+      fixture(:token_budget, %{
+        tenant_id: tenant.id,
+        scope_type: :story,
+        scope_id: story2.id
+      })
+
+      conn =
+        conn
+        |> auth_conn(agent_key)
+        |> get(~p"/api/v1/token-budgets?scope_id=#{story.id}")
+
+      body = json_response(conn, 200)
+      assert body["meta"]["total_count"] == 1
+    end
+
+    test "supports pagination", %{conn: conn} do
+      %{tenant: tenant, agent_key: agent_key} = setup_project_with_keys()
+
+      for _i <- 1..5 do
+        story = fixture(:story, %{tenant_id: tenant.id})
+
+        fixture(:token_budget, %{
+          tenant_id: tenant.id,
+          scope_type: :story,
+          scope_id: story.id
+        })
+      end
+
+      conn =
+        conn
+        |> auth_conn(agent_key)
+        |> get(~p"/api/v1/token-budgets?page=1&page_size=2")
+
+      body = json_response(conn, 200)
+      assert length(body["data"]) == 2
+      assert body["meta"]["total_count"] == 5
+      assert body["meta"]["total_pages"] == 3
+    end
+  end
+
+  # --- GET /api/v1/token-budgets/:id ---
+
+  describe "GET /api/v1/token-budgets/:id" do
+    test "returns a single budget with spend info", %{conn: conn} do
+      %{
+        tenant: tenant,
+        story: story,
+        agent_key: agent_key,
+        agent: agent
+      } = setup_project_with_keys()
+
+      budget =
+        fixture(:token_budget, %{
+          tenant_id: tenant.id,
+          scope_type: :story,
+          scope_id: story.id,
+          budget_millicents: 500_000
+        })
+
+      fixture(:token_usage_report, %{
+        tenant_id: tenant.id,
+        story_id: story.id,
+        agent_id: agent.id,
+        cost_millicents: 3000
+      })
+
+      conn =
+        conn
+        |> auth_conn(agent_key)
+        |> get(~p"/api/v1/token-budgets/#{budget.id}")
+
+      body = json_response(conn, 200)
+      result = body["token_budget"]
+
+      assert result["id"] == budget.id
+      assert result["budget_millicents"] == 500_000
+      assert result["current_spend_millicents"] == 3000
+      assert result["remaining_millicents"] == 497_000
+    end
+
+    test "returns 404 for nonexistent budget", %{conn: conn} do
+      %{agent_key: agent_key} = setup_project_with_keys()
+
+      conn =
+        conn
+        |> auth_conn(agent_key)
+        |> get(~p"/api/v1/token-budgets/#{Ecto.UUID.generate()}")
+
+      assert json_response(conn, 404)
+    end
+  end
+
+  # --- PATCH /api/v1/token-budgets/:id ---
+
+  describe "PATCH /api/v1/token-budgets/:id" do
+    test "updates budget_millicents", %{conn: conn} do
+      %{tenant: tenant, story: story, user_key: user_key} = setup_project_with_keys()
+
+      budget =
+        fixture(:token_budget, %{
+          tenant_id: tenant.id,
+          scope_type: :story,
+          scope_id: story.id,
+          budget_millicents: 500_000
+        })
+
+      conn =
+        conn
+        |> auth_conn(user_key)
+        |> patch(~p"/api/v1/token-budgets/#{budget.id}", %{
+          "budget_millicents" => 1_000_000
+        })
+
+      body = json_response(conn, 200)
+      assert body["token_budget"]["budget_millicents"] == 1_000_000
+    end
+
+    test "updates alert_threshold_pct", %{conn: conn} do
+      %{tenant: tenant, story: story, user_key: user_key} = setup_project_with_keys()
+
+      budget =
+        fixture(:token_budget, %{
+          tenant_id: tenant.id,
+          scope_type: :story,
+          scope_id: story.id
+        })
+
+      conn =
+        conn
+        |> auth_conn(user_key)
+        |> patch(~p"/api/v1/token-budgets/#{budget.id}", %{
+          "alert_threshold_pct" => 95
+        })
+
+      body = json_response(conn, 200)
+      assert body["token_budget"]["alert_threshold_pct"] == 95
+    end
+
+    test "returns 404 for nonexistent budget", %{conn: conn} do
+      %{user_key: user_key} = setup_project_with_keys()
+
+      conn =
+        conn
+        |> auth_conn(user_key)
+        |> patch(~p"/api/v1/token-budgets/#{Ecto.UUID.generate()}", %{
+          "budget_millicents" => 100
+        })
+
+      assert json_response(conn, 404)
+    end
+
+    test "agent role cannot update budgets", %{conn: conn} do
+      %{tenant: tenant, story: story, agent_key: agent_key} = setup_project_with_keys()
+
+      budget =
+        fixture(:token_budget, %{
+          tenant_id: tenant.id,
+          scope_type: :story,
+          scope_id: story.id
+        })
+
+      conn =
+        conn
+        |> auth_conn(agent_key)
+        |> patch(~p"/api/v1/token-budgets/#{budget.id}", %{
+          "budget_millicents" => 1_000_000
+        })
+
+      assert json_response(conn, 403)
+    end
+  end
+
+  # --- DELETE /api/v1/token-budgets/:id ---
+
+  describe "DELETE /api/v1/token-budgets/:id" do
+    test "deletes a budget", %{conn: conn} do
+      %{tenant: tenant, story: story, user_key: user_key} = setup_project_with_keys()
+
+      budget =
+        fixture(:token_budget, %{
+          tenant_id: tenant.id,
+          scope_type: :story,
+          scope_id: story.id
+        })
+
+      conn =
+        conn
+        |> auth_conn(user_key)
+        |> delete(~p"/api/v1/token-budgets/#{budget.id}")
+
+      body = json_response(conn, 200)
+      assert body["token_budget"]["id"] == budget.id
+      assert body["token_budget"]["deleted"] == true
+    end
+
+    test "returns 404 for nonexistent budget", %{conn: conn} do
+      %{user_key: user_key} = setup_project_with_keys()
+
+      conn =
+        conn
+        |> auth_conn(user_key)
+        |> delete(~p"/api/v1/token-budgets/#{Ecto.UUID.generate()}")
+
+      assert json_response(conn, 404)
+    end
+
+    test "agent role cannot delete budgets", %{conn: conn} do
+      %{tenant: tenant, story: story, agent_key: agent_key} = setup_project_with_keys()
+
+      budget =
+        fixture(:token_budget, %{
+          tenant_id: tenant.id,
+          scope_type: :story,
+          scope_id: story.id
+        })
+
+      conn =
+        conn
+        |> auth_conn(agent_key)
+        |> delete(~p"/api/v1/token-budgets/#{budget.id}")
+
+      assert json_response(conn, 403)
+    end
+  end
+
+  # --- Tenant isolation ---
+
+  describe "tenant isolation" do
+    test "cross-tenant budget creation returns 404", %{conn: conn} do
+      %{story: story} = setup_project_with_keys()
+
+      tenant_b = fixture(:tenant)
+      {key_b, _} = fixture(:api_key, %{tenant_id: tenant_b.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(key_b)
+        |> post(~p"/api/v1/token-budgets", %{
+          "scope_type" => "story",
+          "scope_id" => story.id,
+          "budget_millicents" => 500_000
+        })
+
+      assert json_response(conn, 404)
+    end
+
+    test "cross-tenant budget listing returns empty", %{conn: conn} do
+      %{tenant: tenant_a, story: story} = setup_project_with_keys()
+
+      fixture(:token_budget, %{
+        tenant_id: tenant_a.id,
+        scope_type: :story,
+        scope_id: story.id
+      })
+
+      tenant_b = fixture(:tenant)
+      agent_b = fixture(:agent, %{tenant_id: tenant_b.id})
+
+      {key_b, _} =
+        fixture(:api_key, %{tenant_id: tenant_b.id, role: :agent, agent_id: agent_b.id})
+
+      conn =
+        conn
+        |> auth_conn(key_b)
+        |> get(~p"/api/v1/token-budgets")
+
+      body = json_response(conn, 200)
+      assert body["data"] == []
+      assert body["meta"]["total_count"] == 0
+    end
+
+    test "cross-tenant budget show returns 404", %{conn: conn} do
+      %{tenant: tenant_a, story: story} = setup_project_with_keys()
+
+      budget =
+        fixture(:token_budget, %{
+          tenant_id: tenant_a.id,
+          scope_type: :story,
+          scope_id: story.id
+        })
+
+      tenant_b = fixture(:tenant)
+      agent_b = fixture(:agent, %{tenant_id: tenant_b.id})
+
+      {key_b, _} =
+        fixture(:api_key, %{tenant_id: tenant_b.id, role: :agent, agent_id: agent_b.id})
+
+      conn =
+        conn
+        |> auth_conn(key_b)
+        |> get(~p"/api/v1/token-budgets/#{budget.id}")
+
+      assert json_response(conn, 404)
+    end
+  end
+end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -23,6 +23,7 @@ defmodule Loopctl.Fixtures do
   alias Loopctl.Skills.SkillResult
   alias Loopctl.Skills.SkillVersion
   alias Loopctl.Tenants.Tenant
+  alias Loopctl.TokenUsage.Budget, as: TokenBudget
   alias Loopctl.TokenUsage.Report, as: TokenUsageReport
   alias Loopctl.Webhooks.Webhook
   alias Loopctl.Webhooks.WebhookEvent
@@ -261,6 +262,20 @@ defmodule Loopctl.Fixtures do
         cost_millicents: 2500,
         phase: "implementing",
         session_id: nil,
+        metadata: %{}
+      },
+      Enum.into(attrs, %{})
+    )
+  end
+
+  def build(:token_budget, attrs) do
+    Map.merge(
+      %{
+        scope_type: :story,
+        budget_millicents: 500_000,
+        budget_input_tokens: nil,
+        budget_output_tokens: nil,
+        alert_threshold_pct: 80,
         metadata: %{}
       },
       Enum.into(attrs, %{})
@@ -610,6 +625,55 @@ defmodule Loopctl.Fixtures do
         project_id: project_id
       }
       |> TokenUsageReport.create_changeset(data)
+
+    AdminRepo.insert!(changeset)
+  end
+
+  def fixture(:token_budget, attrs) do
+    attrs = Enum.into(attrs, %{})
+
+    {tenant_id, attrs} =
+      case Map.get(attrs, :tenant_id) do
+        nil ->
+          tenant = fixture(:tenant)
+          {tenant.id, Map.put(attrs, :tenant_id, tenant.id)}
+
+        tid ->
+          {tid, attrs}
+      end
+
+    # Auto-create the scope entity if scope_id is not provided
+    scope_type = Map.get(attrs, :scope_type, :story)
+
+    {scope_id, attrs} =
+      case Map.get(attrs, :scope_id) do
+        nil ->
+          case scope_type do
+            :project ->
+              project = fixture(:project, %{tenant_id: tenant_id})
+              {project.id, Map.put(attrs, :scope_id, project.id)}
+
+            :epic ->
+              epic = fixture(:epic, %{tenant_id: tenant_id})
+              {epic.id, Map.put(attrs, :scope_id, epic.id)}
+
+            :story ->
+              story = fixture(:story, %{tenant_id: tenant_id})
+              {story.id, Map.put(attrs, :scope_id, story.id)}
+
+            _ ->
+              {Ecto.UUID.generate(), attrs}
+          end
+
+        sid ->
+          {sid, attrs}
+      end
+
+    data = build(:token_budget, attrs)
+
+    changeset =
+      %TokenBudget{tenant_id: tenant_id}
+      |> TokenBudget.create_changeset(Map.put(data, :scope_id, scope_id))
 
     AdminRepo.insert!(changeset)
   end


### PR DESCRIPTION
## Summary

- Adds `token_budgets` table with RLS policies, scope_type enum (project/epic/story), and composite unique index on `(tenant_id, scope_type, scope_id)`
- Implements full CRUD endpoints: `POST/GET/PATCH/DELETE /api/v1/token-budgets` with role-based access (user+ for mutations, agent+ for reads)
- Real-time spend tracking via aggregation of `token_usage_reports` for each budget scope (story-level, epic-level via story joins, project-level)
- Budget inheritance resolution: explicit story budget > epic budget > project budget > tenant default via `get_effective_budget/3`
- Adds `default_story_budget_millicents` nullable bigint column to `tenants` table
- All budget mutations (create, update, delete) recorded in audit log via `Ecto.Multi`
- 74 new tests (context + controller) covering all ACs, tenant isolation, and edge cases

## Acceptance Criteria Coverage

- AC-21.2.1: token_budgets table with all specified columns
- AC-21.2.2: RLS policies scoped by tenant_id
- AC-21.2.3: POST /api/v1/token-budgets (user role) with scope validation
- AC-21.2.4: GET /api/v1/token-budgets with filtering, spend, remaining
- AC-21.2.5: GET /api/v1/token-budgets/:id with real-time spend
- AC-21.2.6: PATCH /api/v1/token-budgets/:id (cannot change scope)
- AC-21.2.7: DELETE /api/v1/token-budgets/:id (preserves usage reports)
- AC-21.2.8: Composite unique index, 409 on conflict
- AC-21.2.9: Tenant default + get_effective_budget/3 inheritance
- AC-21.2.10: All mutations audited via Ecto.Multi

## Test plan

- [x] Context tests: create, get, list, update, delete budgets
- [x] Budget inheritance: story > epic > project > tenant default
- [x] Spend calculation: story, epic (via join), project level
- [x] Controller tests: all CRUD endpoints with proper role enforcement
- [x] Tenant isolation: cross-tenant access denied for all operations
- [x] Unique constraint: 409 on duplicate (tenant_id, scope_type, scope_id)
- [x] Edge cases: zero budget, missing fields, nonexistent scope entities