### PR TITLE
US-21.3: Cost Aggregation Oban Workers & Anomaly Detection

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -76,12 +76,13 @@ config :hammer,
 # Oban background jobs
 config :loopctl, Oban,
   repo: Loopctl.Repo,
-  queues: [default: 10, webhooks: 5, cleanup: 2],
+  queues: [default: 10, webhooks: 5, cleanup: 2, analytics: 3],
   plugins: [
     {Oban.Plugins.Cron,
      crontab: [
        {"0 * * * *", Loopctl.Workers.IdempotencyCleanupWorker},
        {"0 2 * * *", Loopctl.Workers.AuditPartitionWorker},
+       {"0 2 * * *", Loopctl.Workers.CostRollupWorker},
        {"0 3 * * *", Loopctl.Workers.WebhookCleanupWorker}
      ]}
   ]

--- a/config/test.exs
+++ b/config/test.exs
@@ -69,6 +69,9 @@ config :loopctl, :rate_limiter, Loopctl.MockRateLimiter
 # DI: Use mock clock in tests
 config :loopctl, :clock, Loopctl.MockClock
 
+# DI: Use mock cost rollup in tests
+config :loopctl, :cost_rollup, Loopctl.MockCostRollup
+
 # DI: Use Req.Test plug for webhook delivery in tests
 config :loopctl, :webhook_req_plug, {Req.Test, Loopctl.Webhooks.ReqDelivery}
 

--- a/lib/loopctl/token_usage.ex
+++ b/lib/loopctl/token_usage.ex
@@ -38,6 +38,7 @@ defmodule Loopctl.TokenUsage do
   alias Loopctl.Projects.Project
   alias Loopctl.Tenants.Tenant
   alias Loopctl.TokenUsage.Budget
+  alias Loopctl.TokenUsage.CostAnomaly
   alias Loopctl.TokenUsage.Report
   alias Loopctl.WorkBreakdown.Epic
   alias Loopctl.WorkBreakdown.Story
@@ -789,5 +790,154 @@ defmodule Loopctl.TokenUsage do
       _ ->
         false
     end)
+  end
+
+  # --- Cost Anomaly functions ---
+
+  @doc """
+  Lists unresolved cost anomalies for a tenant with filtering and pagination.
+
+  Results include the story title and agent name for display purposes.
+
+  ## Options
+
+  - `:anomaly_type` -- filter by anomaly type (`:high_cost`, `:suspiciously_low`, `:budget_exceeded`)
+  - `:project_id` -- filter by project UUID
+  - `:resolved` -- filter by resolved status (default: false)
+  - `:page` -- page number (default 1)
+  - `:page_size` -- entries per page (default 20, max 100)
+
+  ## Returns
+
+  `{:ok, %{data: [map()], total: integer, page: integer, page_size: integer}}`
+  """
+  @spec list_anomalies(Ecto.UUID.t(), keyword()) ::
+          {:ok,
+           %{
+             data: [map()],
+             total: non_neg_integer(),
+             page: pos_integer(),
+             page_size: pos_integer()
+           }}
+  def list_anomalies(tenant_id, opts \\ []) do
+    page = max(Keyword.get(opts, :page, 1), 1)
+    page_size = opts |> Keyword.get(:page_size, 20) |> max(1) |> min(100)
+    offset = (page - 1) * page_size
+    resolved = Keyword.get(opts, :resolved, false)
+
+    base_query =
+      CostAnomaly
+      |> where([a], a.tenant_id == ^tenant_id)
+      |> where([a], a.resolved == ^resolved)
+      |> apply_anomaly_filter(:anomaly_type, Keyword.get(opts, :anomaly_type))
+      |> apply_anomaly_filter(:project_id, Keyword.get(opts, :project_id), tenant_id)
+
+    total = AdminRepo.aggregate(base_query, :count, :id)
+
+    anomalies =
+      base_query
+      |> order_by([a], desc: a.inserted_at)
+      |> limit(^page_size)
+      |> offset(^offset)
+      |> AdminRepo.all()
+      |> AdminRepo.preload(story: [:assigned_agent])
+
+    data = Enum.map(anomalies, &format_anomaly/1)
+
+    {:ok, %{data: data, total: total, page: page, page_size: page_size}}
+  end
+
+  @doc """
+  Gets a single cost anomaly by ID, scoped to a tenant.
+
+  ## Returns
+
+  - `{:ok, %CostAnomaly{}}` if found
+  - `{:error, :not_found}` if not found or wrong tenant
+  """
+  @spec get_anomaly(Ecto.UUID.t(), Ecto.UUID.t()) ::
+          {:ok, CostAnomaly.t()} | {:error, :not_found}
+  def get_anomaly(tenant_id, anomaly_id) do
+    case AdminRepo.get_by(CostAnomaly, id: anomaly_id, tenant_id: tenant_id) do
+      nil -> {:error, :not_found}
+      anomaly -> {:ok, anomaly}
+    end
+  end
+
+  @doc """
+  Marks a cost anomaly as resolved.
+
+  ## Returns
+
+  - `{:ok, %CostAnomaly{}}` on success
+  - `{:error, :not_found}` if anomaly not found
+  """
+  @spec resolve_anomaly(Ecto.UUID.t(), Ecto.UUID.t()) ::
+          {:ok, CostAnomaly.t()} | {:error, :not_found}
+  def resolve_anomaly(tenant_id, anomaly_id) do
+    with {:ok, anomaly} <- get_anomaly(tenant_id, anomaly_id) do
+      anomaly
+      |> CostAnomaly.resolve_changeset()
+      |> AdminRepo.update()
+    end
+  end
+
+  # --- Anomaly private helpers ---
+
+  defp apply_anomaly_filter(query, _field, nil), do: query
+  defp apply_anomaly_filter(query, _field, ""), do: query
+
+  defp apply_anomaly_filter(query, :anomaly_type, value) when is_binary(value) do
+    known = ~w(high_cost suspiciously_low budget_exceeded)
+
+    if value in known do
+      atom_val = String.to_existing_atom(value)
+      where(query, [a], a.anomaly_type == ^atom_val)
+    else
+      where(query, [_a], false)
+    end
+  end
+
+  defp apply_anomaly_filter(query, :anomaly_type, value) when is_atom(value) do
+    where(query, [a], a.anomaly_type == ^value)
+  end
+
+  defp apply_anomaly_filter(query, :project_id, nil, _tenant_id), do: query
+  defp apply_anomaly_filter(query, :project_id, "", _tenant_id), do: query
+
+  defp apply_anomaly_filter(query, :project_id, project_id, _tenant_id) do
+    query
+    |> join(:inner, [a], s in Story, on: a.story_id == s.id)
+    |> where([_a, s], s.project_id == ^project_id)
+  end
+
+  defp format_anomaly(%CostAnomaly{} = anomaly) do
+    story_title =
+      if Ecto.assoc_loaded?(anomaly.story),
+        do: anomaly.story.title,
+        else: nil
+
+    agent_name =
+      if Ecto.assoc_loaded?(anomaly.story) and
+           anomaly.story.assigned_agent != nil and
+           Ecto.assoc_loaded?(anomaly.story.assigned_agent),
+         do: anomaly.story.assigned_agent.name,
+         else: nil
+
+    %{
+      id: anomaly.id,
+      tenant_id: anomaly.tenant_id,
+      story_id: anomaly.story_id,
+      story_title: story_title,
+      agent_name: agent_name,
+      anomaly_type: anomaly.anomaly_type,
+      story_cost_millicents: anomaly.story_cost_millicents,
+      reference_avg_millicents: anomaly.reference_avg_millicents,
+      deviation_factor: anomaly.deviation_factor,
+      resolved: anomaly.resolved,
+      metadata: anomaly.metadata,
+      inserted_at: anomaly.inserted_at,
+      updated_at: anomaly.updated_at
+    }
   end
 end

--- a/lib/loopctl/token_usage.ex
+++ b/lib/loopctl/token_usage.ex
@@ -867,18 +867,45 @@ defmodule Loopctl.TokenUsage do
   @doc """
   Marks a cost anomaly as resolved.
 
+  ## Options (keyword list)
+
+  - `:actor_id` -- audit actor ID
+  - `:actor_label` -- audit actor label
+  - `:actor_type` -- audit actor type (default "api_key")
+
   ## Returns
 
   - `{:ok, %CostAnomaly{}}` on success
   - `{:error, :not_found}` if anomaly not found
   """
-  @spec resolve_anomaly(Ecto.UUID.t(), Ecto.UUID.t()) ::
+  @spec resolve_anomaly(Ecto.UUID.t(), Ecto.UUID.t(), keyword()) ::
           {:ok, CostAnomaly.t()} | {:error, :not_found}
-  def resolve_anomaly(tenant_id, anomaly_id) do
+  def resolve_anomaly(tenant_id, anomaly_id, opts \\ []) do
     with {:ok, anomaly} <- get_anomaly(tenant_id, anomaly_id) do
-      anomaly
-      |> CostAnomaly.resolve_changeset()
-      |> AdminRepo.update()
+      changeset = CostAnomaly.resolve_changeset(anomaly)
+
+      multi =
+        Multi.new()
+        |> Multi.update(:anomaly, changeset)
+        |> Audit.log_in_multi(:audit, fn %{anomaly: resolved} ->
+          %{
+            tenant_id: tenant_id,
+            entity_type: "cost_anomaly",
+            entity_id: resolved.id,
+            action: "resolved",
+            actor_type: Keyword.get(opts, :actor_type, "api_key"),
+            actor_id: Keyword.get(opts, :actor_id),
+            actor_label: Keyword.get(opts, :actor_label),
+            old_state: %{"resolved" => false},
+            new_state: %{"resolved" => true}
+          }
+        end)
+
+      case AdminRepo.transaction(multi) do
+        {:ok, %{anomaly: anomaly}} -> {:ok, anomaly}
+        {:error, :anomaly, changeset, _} -> {:error, changeset}
+        {:error, _step, error, _} -> {:error, error}
+      end
     end
   end
 

--- a/lib/loopctl/token_usage/cost_anomaly.ex
+++ b/lib/loopctl/token_usage/cost_anomaly.ex
@@ -1,0 +1,96 @@
+defmodule Loopctl.TokenUsage.CostAnomaly do
+  @moduledoc """
+  Schema for the `cost_anomalies` table.
+
+  Tracks stories whose cost deviates significantly from the epic average.
+  Created by the `CostAnomalyWorker` after each daily rollup.
+
+  ## Anomaly Types
+
+  - `high_cost` -- story cost exceeds 3x the epic average
+  - `suspiciously_low` -- story cost is below 0.1x the epic average
+  - `budget_exceeded` -- story cost exceeds the configured budget
+
+  ## Fields
+
+  - `story_id` -- FK to the flagged story
+  - `anomaly_type` -- one of the types above
+  - `story_cost_millicents` -- the story's actual cost
+  - `reference_avg_millicents` -- the epic average used for comparison
+  - `deviation_factor` -- how many times the story cost deviates from average
+  - `resolved` -- whether the anomaly has been acknowledged/resolved
+  - `metadata` -- extensible JSONB map
+  """
+
+  use Loopctl.Schema
+
+  @type t :: %__MODULE__{}
+
+  @anomaly_types [:high_cost, :suspiciously_low, :budget_exceeded]
+
+  @derive {Jason.Encoder,
+           only: [
+             :id,
+             :tenant_id,
+             :story_id,
+             :anomaly_type,
+             :story_cost_millicents,
+             :reference_avg_millicents,
+             :deviation_factor,
+             :resolved,
+             :metadata,
+             :inserted_at,
+             :updated_at
+           ]}
+
+  schema "cost_anomalies" do
+    tenant_field()
+    belongs_to :story, Loopctl.WorkBreakdown.Story
+
+    field :anomaly_type, Ecto.Enum, values: @anomaly_types
+    field :story_cost_millicents, :integer
+    field :reference_avg_millicents, :integer
+    field :deviation_factor, :decimal
+    field :resolved, :boolean, default: false
+    field :metadata, :map, default: %{}
+
+    timestamps()
+  end
+
+  @doc """
+  Changeset for creating a cost anomaly.
+
+  The `tenant_id` and `story_id` are set programmatically and must not be in cast.
+  """
+  @spec create_changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
+  def create_changeset(anomaly \\ %__MODULE__{}, attrs) do
+    anomaly
+    |> cast(attrs, [
+      :anomaly_type,
+      :story_cost_millicents,
+      :reference_avg_millicents,
+      :deviation_factor,
+      :resolved,
+      :metadata
+    ])
+    |> validate_required([
+      :anomaly_type,
+      :story_cost_millicents,
+      :reference_avg_millicents,
+      :deviation_factor
+    ])
+    |> validate_inclusion(:anomaly_type, @anomaly_types)
+    |> validate_number(:story_cost_millicents, greater_than_or_equal_to: 0)
+    |> validate_number(:reference_avg_millicents, greater_than_or_equal_to: 0)
+    |> foreign_key_constraint(:tenant_id)
+    |> foreign_key_constraint(:story_id)
+  end
+
+  @doc """
+  Changeset for resolving an anomaly.
+  """
+  @spec resolve_changeset(%__MODULE__{}) :: Ecto.Changeset.t()
+  def resolve_changeset(anomaly) do
+    change(anomaly, resolved: true)
+  end
+end

--- a/lib/loopctl/token_usage/cost_summary.ex
+++ b/lib/loopctl/token_usage/cost_summary.ex
@@ -1,0 +1,102 @@
+defmodule Loopctl.TokenUsage.CostSummary do
+  @moduledoc """
+  Schema for the `cost_summaries` table.
+
+  Stores aggregated cost data for a given scope (agent, epic, project, story)
+  over a date range. The rollup worker computes these summaries daily and
+  upserts them using the composite unique index on
+  `(tenant_id, scope_type, scope_id, period_start)`.
+
+  ## Fields
+
+  - `scope_type` -- `:agent`, `:epic`, `:project`, or `:story`
+  - `scope_id` -- UUID of the scoped entity
+  - `period_start` -- start date of the aggregation period
+  - `period_end` -- end date of the aggregation period
+  - `total_input_tokens` -- sum of input tokens in the period
+  - `total_output_tokens` -- sum of output tokens in the period
+  - `total_cost_millicents` -- sum of cost in millicents in the period
+  - `report_count` -- number of token usage reports aggregated
+  - `model_breakdown` -- per-model per-phase JSONB breakdown
+  - `avg_cost_per_story_millicents` -- average cost per story (nullable)
+  """
+
+  use Loopctl.Schema
+
+  @type t :: %__MODULE__{}
+
+  @scope_types [:agent, :epic, :project, :story]
+
+  @derive {Jason.Encoder,
+           only: [
+             :id,
+             :tenant_id,
+             :scope_type,
+             :scope_id,
+             :period_start,
+             :period_end,
+             :total_input_tokens,
+             :total_output_tokens,
+             :total_cost_millicents,
+             :report_count,
+             :model_breakdown,
+             :avg_cost_per_story_millicents,
+             :inserted_at,
+             :updated_at
+           ]}
+
+  schema "cost_summaries" do
+    tenant_field()
+
+    field :scope_type, Ecto.Enum, values: @scope_types
+    field :scope_id, :binary_id
+    field :period_start, :date
+    field :period_end, :date
+    field :total_input_tokens, :integer, default: 0
+    field :total_output_tokens, :integer, default: 0
+    field :total_cost_millicents, :integer, default: 0
+    field :report_count, :integer, default: 0
+    field :model_breakdown, :map, default: %{}
+    field :avg_cost_per_story_millicents, :integer
+
+    timestamps()
+  end
+
+  @doc """
+  Changeset for creating or updating a cost summary.
+
+  The `tenant_id` is set programmatically and must not be in cast.
+  """
+  @spec changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
+  def changeset(summary \\ %__MODULE__{}, attrs) do
+    summary
+    |> cast(attrs, [
+      :scope_type,
+      :scope_id,
+      :period_start,
+      :period_end,
+      :total_input_tokens,
+      :total_output_tokens,
+      :total_cost_millicents,
+      :report_count,
+      :model_breakdown,
+      :avg_cost_per_story_millicents
+    ])
+    |> validate_required([
+      :scope_type,
+      :scope_id,
+      :period_start,
+      :period_end
+    ])
+    |> validate_inclusion(:scope_type, @scope_types)
+    |> validate_number(:total_input_tokens, greater_than_or_equal_to: 0)
+    |> validate_number(:total_output_tokens, greater_than_or_equal_to: 0)
+    |> validate_number(:total_cost_millicents, greater_than_or_equal_to: 0)
+    |> validate_number(:report_count, greater_than_or_equal_to: 0)
+    |> foreign_key_constraint(:tenant_id)
+    |> unique_constraint([:tenant_id, :scope_type, :scope_id, :period_start],
+      name: :cost_summaries_tenant_scope_period_idx,
+      message: "summary already exists for this scope and period"
+    )
+  end
+end

--- a/lib/loopctl/token_usage/default_rollup.ex
+++ b/lib/loopctl/token_usage/default_rollup.ex
@@ -1,0 +1,211 @@
+defmodule Loopctl.TokenUsage.DefaultRollup do
+  @moduledoc """
+  Default implementation of `Loopctl.TokenUsage.RollupBehaviour`.
+
+  Aggregates token usage reports for a tenant within a date range,
+  producing cost summaries grouped by scope type (agent, epic, project).
+
+  The aggregation queries use `AdminRepo` because the caller
+  (`CostRollupWorker`) runs from a cron job context without
+  per-tenant RLS transactions.
+  """
+
+  @behaviour Loopctl.TokenUsage.RollupBehaviour
+
+  import Ecto.Query
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.TokenUsage.Report
+  alias Loopctl.WorkBreakdown.Story
+
+  @impl true
+  def aggregate(tenant_id, period_start, period_end) do
+    # Convert dates to NaiveDateTime for comparison with timestamps
+    start_dt = NaiveDateTime.new!(period_start, ~T[00:00:00])
+    end_dt = NaiveDateTime.new!(period_end, ~T[23:59:59.999999])
+
+    agent_rows = aggregate_by_agent(tenant_id, start_dt, end_dt)
+    epic_rows = aggregate_by_epic(tenant_id, start_dt, end_dt)
+    project_rows = aggregate_by_project(tenant_id, start_dt, end_dt)
+
+    {:ok, agent_rows ++ epic_rows ++ project_rows}
+  rescue
+    e -> {:error, Exception.message(e)}
+  end
+
+  # --- Agent scope ---
+  defp aggregate_by_agent(tenant_id, start_dt, end_dt) do
+    Report
+    |> where([r], r.tenant_id == ^tenant_id)
+    |> where([r], r.inserted_at >= ^start_dt and r.inserted_at <= ^end_dt)
+    |> where([r], not is_nil(r.agent_id))
+    |> group_by([r], r.agent_id)
+    |> select([r], %{
+      scope_id: r.agent_id,
+      total_input_tokens: sum(r.input_tokens),
+      total_output_tokens: sum(r.output_tokens),
+      total_cost_millicents: sum(r.cost_millicents),
+      report_count: count(r.id)
+    })
+    |> AdminRepo.all()
+    |> Enum.map(fn row ->
+      model_breakdown = build_model_breakdown(tenant_id, :agent, row.scope_id, start_dt, end_dt)
+
+      %{
+        scope_type: :agent,
+        scope_id: row.scope_id,
+        total_input_tokens: to_int(row.total_input_tokens),
+        total_output_tokens: to_int(row.total_output_tokens),
+        total_cost_millicents: to_int(row.total_cost_millicents),
+        report_count: row.report_count,
+        model_breakdown: model_breakdown,
+        avg_cost_per_story_millicents: nil
+      }
+    end)
+  end
+
+  # --- Epic scope ---
+  defp aggregate_by_epic(tenant_id, start_dt, end_dt) do
+    Report
+    |> join(:inner, [r], s in Story, on: r.story_id == s.id)
+    |> where([r, _s], r.tenant_id == ^tenant_id)
+    |> where([r, _s], r.inserted_at >= ^start_dt and r.inserted_at <= ^end_dt)
+    |> group_by([_r, s], s.epic_id)
+    |> select([r, s], %{
+      scope_id: s.epic_id,
+      total_input_tokens: sum(r.input_tokens),
+      total_output_tokens: sum(r.output_tokens),
+      total_cost_millicents: sum(r.cost_millicents),
+      report_count: count(r.id),
+      distinct_stories: count(r.story_id, :distinct)
+    })
+    |> AdminRepo.all()
+    |> Enum.map(fn row ->
+      model_breakdown = build_model_breakdown(tenant_id, :epic, row.scope_id, start_dt, end_dt)
+
+      avg =
+        if row.distinct_stories > 0,
+          do: div(to_int(row.total_cost_millicents), row.distinct_stories),
+          else: nil
+
+      %{
+        scope_type: :epic,
+        scope_id: row.scope_id,
+        total_input_tokens: to_int(row.total_input_tokens),
+        total_output_tokens: to_int(row.total_output_tokens),
+        total_cost_millicents: to_int(row.total_cost_millicents),
+        report_count: row.report_count,
+        model_breakdown: model_breakdown,
+        avg_cost_per_story_millicents: avg
+      }
+    end)
+  end
+
+  # --- Project scope ---
+  defp aggregate_by_project(tenant_id, start_dt, end_dt) do
+    Report
+    |> where([r], r.tenant_id == ^tenant_id)
+    |> where([r], r.inserted_at >= ^start_dt and r.inserted_at <= ^end_dt)
+    |> where([r], not is_nil(r.project_id))
+    |> group_by([r], r.project_id)
+    |> select([r], %{
+      scope_id: r.project_id,
+      total_input_tokens: sum(r.input_tokens),
+      total_output_tokens: sum(r.output_tokens),
+      total_cost_millicents: sum(r.cost_millicents),
+      report_count: count(r.id),
+      distinct_stories: count(r.story_id, :distinct)
+    })
+    |> AdminRepo.all()
+    |> Enum.map(fn row ->
+      model_breakdown = build_model_breakdown(tenant_id, :project, row.scope_id, start_dt, end_dt)
+
+      avg =
+        if row.distinct_stories > 0,
+          do: div(to_int(row.total_cost_millicents), row.distinct_stories),
+          else: nil
+
+      %{
+        scope_type: :project,
+        scope_id: row.scope_id,
+        total_input_tokens: to_int(row.total_input_tokens),
+        total_output_tokens: to_int(row.total_output_tokens),
+        total_cost_millicents: to_int(row.total_cost_millicents),
+        report_count: row.report_count,
+        model_breakdown: model_breakdown,
+        avg_cost_per_story_millicents: avg
+      }
+    end)
+  end
+
+  # --- Model breakdown ---
+  defp build_model_breakdown(tenant_id, scope_type, scope_id, start_dt, end_dt) do
+    query = scope_breakdown_query(scope_type, scope_id, tenant_id, start_dt, end_dt)
+
+    query
+    |> AdminRepo.all()
+    |> Enum.reduce(%{}, fn row, acc ->
+      model = row.model_name
+      phase = row.phase || "other"
+
+      phase_data = %{
+        "input_tokens" => to_int(row.input_tokens),
+        "output_tokens" => to_int(row.output_tokens),
+        "cost_millicents" => to_int(row.cost_millicents)
+      }
+
+      model_data = Map.get(acc, model, %{})
+      Map.put(acc, model, Map.put(model_data, phase, phase_data))
+    end)
+  end
+
+  defp scope_breakdown_query(:agent, scope_id, tenant_id, start_dt, end_dt) do
+    Report
+    |> where([r], r.agent_id == ^scope_id)
+    |> where([r], r.tenant_id == ^tenant_id)
+    |> where([r], r.inserted_at >= ^start_dt and r.inserted_at <= ^end_dt)
+    |> group_by([r], [r.model_name, r.phase])
+    |> select([r], %{
+      model_name: r.model_name,
+      phase: r.phase,
+      input_tokens: sum(r.input_tokens),
+      output_tokens: sum(r.output_tokens),
+      cost_millicents: sum(r.cost_millicents)
+    })
+  end
+
+  defp scope_breakdown_query(:epic, scope_id, tenant_id, start_dt, end_dt) do
+    Report
+    |> join(:inner, [r], s in Story, on: r.story_id == s.id)
+    |> where([r, _s], r.tenant_id == ^tenant_id)
+    |> where([r, _s], r.inserted_at >= ^start_dt and r.inserted_at <= ^end_dt)
+    |> where([_r, s], s.epic_id == ^scope_id)
+    |> group_by([r, _s], [r.model_name, r.phase])
+    |> select([r, _s], %{
+      model_name: r.model_name,
+      phase: r.phase,
+      input_tokens: sum(r.input_tokens),
+      output_tokens: sum(r.output_tokens),
+      cost_millicents: sum(r.cost_millicents)
+    })
+  end
+
+  defp scope_breakdown_query(:project, scope_id, tenant_id, start_dt, end_dt) do
+    Report
+    |> where([r], r.project_id == ^scope_id)
+    |> where([r], r.tenant_id == ^tenant_id)
+    |> where([r], r.inserted_at >= ^start_dt and r.inserted_at <= ^end_dt)
+    |> group_by([r], [r.model_name, r.phase])
+    |> select([r], %{
+      model_name: r.model_name,
+      phase: r.phase,
+      input_tokens: sum(r.input_tokens),
+      output_tokens: sum(r.output_tokens),
+      cost_millicents: sum(r.cost_millicents)
+    })
+  end
+
+  defp to_int(%Decimal{} = val), do: Decimal.to_integer(val)
+  defp to_int(val) when is_integer(val), do: val
+  defp to_int(nil), do: 0
+end

--- a/lib/loopctl/token_usage/rollup_behaviour.ex
+++ b/lib/loopctl/token_usage/rollup_behaviour.ex
@@ -1,0 +1,29 @@
+defmodule Loopctl.TokenUsage.RollupBehaviour do
+  @moduledoc """
+  Behaviour for cost rollup aggregation.
+
+  Defines the contract for aggregating token usage reports into
+  cost summaries for a given tenant and period. The default
+  implementation queries `token_usage_reports` and groups by
+  scope (agent, epic, project).
+
+  Used by `Loopctl.Workers.CostRollupWorker` via compile-time DI.
+  """
+
+  @type summary_row :: %{
+          scope_type: :agent | :epic | :project | :story,
+          scope_id: Ecto.UUID.t(),
+          total_input_tokens: non_neg_integer(),
+          total_output_tokens: non_neg_integer(),
+          total_cost_millicents: non_neg_integer(),
+          report_count: non_neg_integer(),
+          model_breakdown: map(),
+          avg_cost_per_story_millicents: non_neg_integer() | nil
+        }
+
+  @callback aggregate(
+              tenant_id :: Ecto.UUID.t(),
+              period_start :: Date.t(),
+              period_end :: Date.t()
+            ) :: {:ok, [summary_row()]} | {:error, term()}
+end

--- a/lib/loopctl/workers/cost_anomaly_worker.ex
+++ b/lib/loopctl/workers/cost_anomaly_worker.ex
@@ -1,0 +1,171 @@
+defmodule Loopctl.Workers.CostAnomalyWorker do
+  @moduledoc """
+  Oban worker that detects cost anomalies after each daily rollup.
+
+  Compares each story's total cost to its epic's average cost per story.
+  Stories that deviate significantly are flagged as anomalies:
+
+  - `high_cost` -- story cost > 3x the epic average
+  - `suspiciously_low` -- story cost < 0.1x the epic average
+
+  Runs after `CostRollupWorker` completes, chained via `Oban.insert/1`.
+
+  ## Thresholds
+
+  Hardcoded defaults for v1:
+  - High cost: 3.0x average
+  - Suspiciously low: 0.1x average
+  """
+
+  use Oban.Worker, queue: :analytics, max_attempts: 3
+
+  require Logger
+
+  import Ecto.Query
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Tenants.Tenant
+  alias Loopctl.TokenUsage.CostAnomaly
+  alias Loopctl.TokenUsage.CostSummary
+  alias Loopctl.TokenUsage.Report
+  alias Loopctl.WorkBreakdown.Story
+
+  @high_cost_threshold Decimal.new("3.0")
+  @low_cost_threshold Decimal.new("0.1")
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: args}) do
+    {period_start, period_end} = resolve_period(args)
+
+    tenants = list_active_tenants()
+    Logger.info("CostAnomalyWorker: scanning #{length(tenants)} tenants for anomalies")
+
+    Enum.each(tenants, fn tenant ->
+      case detect_anomalies(tenant.id, period_start, period_end) do
+        :ok ->
+          :ok
+
+        {:error, reason} ->
+          Logger.warning("CostAnomalyWorker: failed for tenant #{tenant.id}: #{inspect(reason)}")
+      end
+    end)
+
+    :ok
+  end
+
+  defp detect_anomalies(tenant_id, period_start, period_end) do
+    # Get epic summaries for this period that have an avg cost
+    epic_summaries =
+      CostSummary
+      |> where([cs], cs.tenant_id == ^tenant_id)
+      |> where([cs], cs.scope_type == :epic)
+      |> where([cs], cs.period_start == ^period_start)
+      |> where([cs], cs.period_end == ^period_end)
+      |> where([cs], not is_nil(cs.avg_cost_per_story_millicents))
+      |> where([cs], cs.avg_cost_per_story_millicents > 0)
+      |> AdminRepo.all()
+
+    # For each epic, get per-story costs in this period
+    Enum.each(epic_summaries, fn summary ->
+      check_epic_stories(tenant_id, summary, period_start, period_end)
+    end)
+
+    :ok
+  rescue
+    e -> {:error, Exception.message(e)}
+  end
+
+  defp check_epic_stories(tenant_id, epic_summary, period_start, period_end) do
+    start_dt = NaiveDateTime.new!(period_start, ~T[00:00:00])
+    end_dt = NaiveDateTime.new!(period_end, ~T[23:59:59.999999])
+    epic_avg = epic_summary.avg_cost_per_story_millicents
+
+    # Get per-story costs for this epic in the period
+    story_costs =
+      Report
+      |> join(:inner, [r], s in Story, on: r.story_id == s.id)
+      |> where([r, s], r.tenant_id == ^tenant_id)
+      |> where([_r, s], s.epic_id == ^epic_summary.scope_id)
+      |> where([r, _s], r.inserted_at >= ^start_dt and r.inserted_at <= ^end_dt)
+      |> group_by([r, _s], r.story_id)
+      |> select([r, _s], %{
+        story_id: r.story_id,
+        total_cost: sum(r.cost_millicents)
+      })
+      |> AdminRepo.all()
+
+    Enum.each(story_costs, fn %{story_id: story_id, total_cost: total_cost} ->
+      cost = to_int(total_cost)
+      check_and_flag_anomaly(tenant_id, story_id, cost, epic_avg)
+    end)
+  end
+
+  defp check_and_flag_anomaly(tenant_id, story_id, story_cost, epic_avg) when epic_avg > 0 do
+    factor = Decimal.div(Decimal.new(story_cost), Decimal.new(epic_avg))
+
+    cond do
+      Decimal.compare(factor, @high_cost_threshold) == :gt ->
+        create_anomaly(tenant_id, story_id, :high_cost, story_cost, epic_avg, factor)
+
+      Decimal.compare(factor, @low_cost_threshold) == :lt ->
+        create_anomaly(tenant_id, story_id, :suspiciously_low, story_cost, epic_avg, factor)
+
+      true ->
+        :ok
+    end
+  end
+
+  defp check_and_flag_anomaly(_tenant_id, _story_id, _story_cost, _epic_avg), do: :ok
+
+  defp create_anomaly(tenant_id, story_id, anomaly_type, story_cost, epic_avg, factor) do
+    # Check if an unresolved anomaly of this type already exists for this story
+    existing =
+      CostAnomaly
+      |> where([a], a.tenant_id == ^tenant_id)
+      |> where([a], a.story_id == ^story_id)
+      |> where([a], a.anomaly_type == ^anomaly_type)
+      |> where([a], a.resolved == false)
+      |> AdminRepo.one()
+
+    if existing do
+      # Update the existing anomaly with latest figures
+      existing
+      |> CostAnomaly.create_changeset(%{
+        story_cost_millicents: story_cost,
+        reference_avg_millicents: epic_avg,
+        deviation_factor: Decimal.round(factor, 2)
+      })
+      |> AdminRepo.update!()
+    else
+      %CostAnomaly{tenant_id: tenant_id, story_id: story_id}
+      |> CostAnomaly.create_changeset(%{
+        anomaly_type: anomaly_type,
+        story_cost_millicents: story_cost,
+        reference_avg_millicents: epic_avg,
+        deviation_factor: Decimal.round(factor, 2)
+      })
+      |> AdminRepo.insert!()
+    end
+  end
+
+  defp resolve_period(args) do
+    case {Map.get(args, "period_start"), Map.get(args, "period_end")} do
+      {nil, nil} ->
+        yesterday = Date.add(Date.utc_today(), -1)
+        {yesterday, yesterday}
+
+      {start_str, end_str} ->
+        {Date.from_iso8601!(start_str), Date.from_iso8601!(end_str)}
+    end
+  end
+
+  defp list_active_tenants do
+    Tenant
+    |> where([t], t.status == :active)
+    |> AdminRepo.all()
+  end
+
+  defp to_int(%Decimal{} = val), do: Decimal.to_integer(val)
+  defp to_int(val) when is_integer(val), do: val
+  defp to_int(nil), do: 0
+end

--- a/lib/loopctl/workers/cost_rollup_worker.ex
+++ b/lib/loopctl/workers/cost_rollup_worker.ex
@@ -97,6 +97,7 @@ defmodule Loopctl.Workers.CostRollupWorker do
         on_conflict:
           {:replace,
            [
+             :period_end,
              :total_input_tokens,
              :total_output_tokens,
              :total_cost_millicents,

--- a/lib/loopctl/workers/cost_rollup_worker.ex
+++ b/lib/loopctl/workers/cost_rollup_worker.ex
@@ -1,0 +1,147 @@
+defmodule Loopctl.Workers.CostRollupWorker do
+  @moduledoc """
+  Oban worker that computes daily cost summaries for all active tenants.
+
+  Runs daily at 02:00 UTC via Oban Cron (`0 2 * * *`). For each active
+  tenant, aggregates token usage reports from the previous day into
+  `cost_summaries` records grouped by scope (agent, epic, project).
+
+  The rollup is idempotent: uses UPSERT keyed on the composite unique
+  index `(tenant_id, scope_type, scope_id, period_start)`.
+
+  After completing all tenant rollups, chains the `CostAnomalyWorker`
+  to detect cost anomalies.
+
+  ## DI
+
+  Uses compile-time DI for the rollup service:
+
+      @rollup_service Application.compile_env(:loopctl, :cost_rollup, Loopctl.TokenUsage.DefaultRollup)
+
+  In test, `config/test.exs` maps to `Loopctl.MockCostRollup`.
+  """
+
+  use Oban.Worker, queue: :analytics, max_attempts: 3
+
+  require Logger
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Tenants.Tenant
+  alias Loopctl.TokenUsage.CostSummary
+  alias Loopctl.Workers.CostAnomalyWorker
+
+  @rollup_service Application.compile_env(
+                    :loopctl,
+                    :cost_rollup,
+                    Loopctl.TokenUsage.DefaultRollup
+                  )
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: args}) do
+    # Allow overriding the period for testing/backfills
+    {period_start, period_end} = resolve_period(args)
+
+    tenants = list_active_tenants()
+    Logger.info("CostRollupWorker: starting rollup for #{length(tenants)} tenants")
+
+    results =
+      Enum.map(tenants, fn tenant ->
+        case rollup_tenant(tenant.id, period_start, period_end) do
+          :ok ->
+            :ok
+
+          {:error, reason} ->
+            Logger.warning("CostRollupWorker: failed for tenant #{tenant.id}: #{inspect(reason)}")
+
+            {:error, tenant.id, reason}
+        end
+      end)
+
+    errors = Enum.filter(results, &match?({:error, _, _}, &1))
+
+    if errors == [] do
+      # Chain the anomaly worker after successful rollup
+      chain_anomaly_worker(period_start, period_end)
+      :ok
+    else
+      Logger.warning("CostRollupWorker: #{length(errors)} tenant(s) failed")
+      # Return :ok so the job is not retried for partial failures.
+      # Individual tenant failures are logged above.
+      :ok
+    end
+  end
+
+  @doc false
+  def rollup_tenant(tenant_id, period_start, period_end) do
+    case @rollup_service.aggregate(tenant_id, period_start, period_end) do
+      {:ok, rows} ->
+        upsert_summaries(tenant_id, rows, period_start, period_end)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp upsert_summaries(tenant_id, rows, period_start, period_end) do
+    Enum.each(rows, fn row ->
+      changeset =
+        %CostSummary{tenant_id: tenant_id}
+        |> CostSummary.changeset(
+          Map.merge(row, %{
+            period_start: period_start,
+            period_end: period_end
+          })
+        )
+
+      AdminRepo.insert!(changeset,
+        on_conflict:
+          {:replace,
+           [
+             :total_input_tokens,
+             :total_output_tokens,
+             :total_cost_millicents,
+             :report_count,
+             :model_breakdown,
+             :avg_cost_per_story_millicents,
+             :updated_at
+           ]},
+        conflict_target: [:tenant_id, :scope_type, :scope_id, :period_start]
+      )
+    end)
+
+    :ok
+  end
+
+  defp resolve_period(args) do
+    case {Map.get(args, "period_start"), Map.get(args, "period_end")} do
+      {nil, nil} ->
+        yesterday = Date.add(Date.utc_today(), -1)
+        {yesterday, yesterday}
+
+      {start_str, end_str} ->
+        {Date.from_iso8601!(start_str), Date.from_iso8601!(end_str)}
+    end
+  end
+
+  defp list_active_tenants do
+    import Ecto.Query
+
+    Tenant
+    |> where([t], t.status == :active)
+    |> AdminRepo.all()
+  end
+
+  defp chain_anomaly_worker(period_start, period_end) do
+    %{
+      "period_start" => Date.to_iso8601(period_start),
+      "period_end" => Date.to_iso8601(period_end)
+    }
+    |> CostAnomalyWorker.new(scheduled_at: scheduled_anomaly_time())
+    |> Oban.insert()
+  end
+
+  # Schedule the anomaly worker 5 minutes after the rollup
+  defp scheduled_anomaly_time do
+    DateTime.add(DateTime.utc_now(), 300, :second)
+  end
+end

--- a/lib/loopctl_web/controllers/cost_anomaly_controller.ex
+++ b/lib/loopctl_web/controllers/cost_anomaly_controller.ex
@@ -1,0 +1,135 @@
+defmodule LoopctlWeb.CostAnomalyController do
+  @moduledoc """
+  Controller for cost anomaly management.
+
+  - `GET /api/v1/cost-anomalies` -- list unresolved anomalies (user+)
+  - `PATCH /api/v1/cost-anomalies/:id` -- mark anomaly as resolved (user+)
+  """
+
+  use LoopctlWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Loopctl.ApiSpec.Schemas
+  alias Loopctl.TokenUsage
+
+  action_fallback LoopctlWeb.FallbackController
+
+  plug LoopctlWeb.Plugs.RequireRole, role: :user
+
+  tags(["Cost Anomalies"])
+
+  operation(:index,
+    summary: "List cost anomalies",
+    description:
+      "Returns unresolved cost anomalies for the tenant. " <>
+        "Filterable by anomaly_type and project_id. " <>
+        "Includes story title and agent name.",
+    parameters: [
+      anomaly_type: [
+        in: :query,
+        type: :string,
+        description: "Filter by anomaly type: high_cost, suspiciously_low, budget_exceeded"
+      ],
+      project_id: [in: :query, type: :string, description: "Filter by project UUID"],
+      page: [in: :query, type: :integer, description: "Page number"],
+      page_size: [in: :query, type: :integer, description: "Items per page"]
+    ],
+    responses: %{
+      200 =>
+        {"Anomaly list", "application/json",
+         %OpenApiSpex.Schema{
+           type: :object,
+           properties: %{
+             data: %OpenApiSpex.Schema{
+               type: :array,
+               items: %OpenApiSpex.Schema{type: :object, additionalProperties: true}
+             },
+             meta: Schemas.PaginationMeta
+           }
+         }},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  operation(:update,
+    summary: "Resolve cost anomaly",
+    description: "Marks a cost anomaly as resolved.",
+    parameters: [
+      id: [in: :path, type: :string, description: "Anomaly UUID"]
+    ],
+    responses: %{
+      200 =>
+        {"Anomaly resolved", "application/json",
+         %OpenApiSpex.Schema{type: :object, additionalProperties: true}},
+      404 => {"Anomaly not found", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  @doc """
+  GET /api/v1/cost-anomalies
+
+  Lists unresolved cost anomalies for the tenant.
+  """
+  def index(conn, params) do
+    api_key = conn.assigns.current_api_key
+    tenant_id = api_key.tenant_id
+
+    opts =
+      []
+      |> maybe_add_opt(:anomaly_type, params["anomaly_type"])
+      |> maybe_add_opt(:project_id, params["project_id"])
+      |> maybe_add_opt(:page, parse_int(params["page"]))
+      |> maybe_add_opt(:page_size, parse_int(params["page_size"]))
+
+    {:ok, result} = TokenUsage.list_anomalies(tenant_id, opts)
+
+    json(conn, %{
+      data: result.data,
+      meta: %{
+        page: result.page,
+        page_size: result.page_size,
+        total_count: result.total,
+        total_pages: ceil_div(result.total, result.page_size)
+      }
+    })
+  end
+
+  @doc """
+  PATCH /api/v1/cost-anomalies/:id
+
+  Marks a cost anomaly as resolved.
+  """
+  def update(conn, %{"id" => id}) do
+    api_key = conn.assigns.current_api_key
+    tenant_id = api_key.tenant_id
+
+    with {:ok, anomaly} <- TokenUsage.resolve_anomaly(tenant_id, id) do
+      json(conn, %{
+        cost_anomaly: %{
+          id: anomaly.id,
+          resolved: anomaly.resolved,
+          updated_at: anomaly.updated_at
+        }
+      })
+    end
+  end
+
+  # --- Private helpers ---
+
+  defp parse_int(nil), do: nil
+
+  defp parse_int(val) when is_binary(val) do
+    case Integer.parse(val) do
+      {n, _} -> n
+      :error -> nil
+    end
+  end
+
+  defp parse_int(val) when is_integer(val), do: val
+
+  defp maybe_add_opt(opts, _key, nil), do: opts
+  defp maybe_add_opt(opts, key, value), do: Keyword.put(opts, key, value)
+
+  defp ceil_div(numerator, denominator), do: ceil(numerator / denominator)
+end

--- a/lib/loopctl_web/controllers/cost_anomaly_controller.ex
+++ b/lib/loopctl_web/controllers/cost_anomaly_controller.ex
@@ -104,7 +104,13 @@ defmodule LoopctlWeb.CostAnomalyController do
     api_key = conn.assigns.current_api_key
     tenant_id = api_key.tenant_id
 
-    with {:ok, anomaly} <- TokenUsage.resolve_anomaly(tenant_id, id) do
+    audit_opts = [
+      actor_id: api_key.id,
+      actor_label: api_key.name,
+      actor_type: "api_key"
+    ]
+
+    with {:ok, anomaly} <- TokenUsage.resolve_anomaly(tenant_id, id, audit_opts) do
       json(conn, %{
         cost_anomaly: %{
           id: anomaly.id,

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -209,6 +209,10 @@ defmodule LoopctlWeb.Router do
     resources "/token-budgets", TokenBudgetController,
       only: [:create, :index, :show, :update, :delete]
 
+    # Cost anomalies (Epic 21)
+    get "/cost-anomalies", CostAnomalyController, :index
+    patch "/cost-anomalies/:id", CostAnomalyController, :update
+
     # Skill results
     post "/skill_results", SkillResultController, :create
   end

--- a/priv/repo/migrations/20260403220533_create_cost_summaries_and_anomalies.exs
+++ b/priv/repo/migrations/20260403220533_create_cost_summaries_and_anomalies.exs
@@ -1,0 +1,77 @@
+defmodule Loopctl.Repo.Migrations.CreateCostSummariesAndAnomalies do
+  use Ecto.Migration
+  import Loopctl.Repo.RlsHelpers
+
+  def change do
+    # --- cost_summaries ---
+
+    create table(:cost_summaries, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      add :tenant_id, references(:tenants, type: :binary_id, on_delete: :delete_all), null: false
+      add :scope_type, :string, null: false
+      add :scope_id, :binary_id, null: false
+
+      add :period_start, :date, null: false
+      add :period_end, :date, null: false
+
+      add :total_input_tokens, :bigint, default: 0
+      add :total_output_tokens, :bigint, default: 0
+      add :total_cost_millicents, :bigint, default: 0
+      add :report_count, :integer, default: 0
+      add :model_breakdown, :map, default: %{}
+      add :avg_cost_per_story_millicents, :bigint
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    # scope_type CHECK constraint: agent, epic, project, story
+    execute(
+      "ALTER TABLE cost_summaries ADD CONSTRAINT cost_summaries_scope_type_check CHECK (scope_type IN ('agent', 'epic', 'project', 'story'))",
+      "ALTER TABLE cost_summaries DROP CONSTRAINT cost_summaries_scope_type_check"
+    )
+
+    # Composite unique index for idempotent upsert (AC-21.3.10)
+    create unique_index(:cost_summaries, [:tenant_id, :scope_type, :scope_id, :period_start],
+             name: :cost_summaries_tenant_scope_period_idx
+           )
+
+    # Lookup indexes
+    create index(:cost_summaries, [:tenant_id])
+    create index(:cost_summaries, [:tenant_id, :scope_type])
+
+    enable_rls(:cost_summaries)
+
+    # --- cost_anomalies ---
+
+    create table(:cost_anomalies, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      add :tenant_id, references(:tenants, type: :binary_id, on_delete: :delete_all), null: false
+      add :story_id, references(:stories, type: :binary_id, on_delete: :delete_all), null: false
+
+      add :anomaly_type, :string, null: false
+      add :story_cost_millicents, :bigint, null: false
+      add :reference_avg_millicents, :bigint, null: false
+      add :deviation_factor, :decimal, null: false
+      add :resolved, :boolean, default: false, null: false
+      add :metadata, :map, default: %{}
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    # anomaly_type CHECK constraint
+    execute(
+      "ALTER TABLE cost_anomalies ADD CONSTRAINT cost_anomalies_anomaly_type_check CHECK (anomaly_type IN ('high_cost', 'suspiciously_low', 'budget_exceeded'))",
+      "ALTER TABLE cost_anomalies DROP CONSTRAINT cost_anomalies_anomaly_type_check"
+    )
+
+    # Indexes for common queries
+    create index(:cost_anomalies, [:tenant_id])
+    create index(:cost_anomalies, [:tenant_id, :resolved])
+    create index(:cost_anomalies, [:tenant_id, :anomaly_type])
+    create index(:cost_anomalies, [:story_id])
+
+    enable_rls(:cost_anomalies)
+  end
+end

--- a/test/loopctl/token_usage/cost_anomaly_test.exs
+++ b/test/loopctl/token_usage/cost_anomaly_test.exs
@@ -1,0 +1,174 @@
+defmodule Loopctl.TokenUsage.CostAnomalyTest do
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.TokenUsage
+
+  defp setup_tenant_with_anomalies do
+    tenant = fixture(:tenant)
+    project = fixture(:project, %{tenant_id: tenant.id})
+    epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+    agent = fixture(:agent, %{tenant_id: tenant.id})
+
+    story1 =
+      fixture(:story, %{
+        tenant_id: tenant.id,
+        epic_id: epic.id,
+        project_id: project.id,
+        assigned_agent_id: agent.id
+      })
+
+    story2 =
+      fixture(:story, %{
+        tenant_id: tenant.id,
+        epic_id: epic.id,
+        project_id: project.id
+      })
+
+    anomaly1 =
+      fixture(:cost_anomaly, %{
+        tenant_id: tenant.id,
+        story_id: story1.id,
+        anomaly_type: :high_cost,
+        story_cost_millicents: 100_000,
+        reference_avg_millicents: 25_000,
+        deviation_factor: Decimal.new("4.0")
+      })
+
+    anomaly2 =
+      fixture(:cost_anomaly, %{
+        tenant_id: tenant.id,
+        story_id: story2.id,
+        anomaly_type: :suspiciously_low,
+        story_cost_millicents: 100,
+        reference_avg_millicents: 25_000,
+        deviation_factor: Decimal.new("0.004")
+      })
+
+    %{
+      tenant: tenant,
+      project: project,
+      epic: epic,
+      agent: agent,
+      story1: story1,
+      story2: story2,
+      anomaly1: anomaly1,
+      anomaly2: anomaly2
+    }
+  end
+
+  describe "list_anomalies/2" do
+    test "returns unresolved anomalies for a tenant" do
+      ctx = setup_tenant_with_anomalies()
+      {:ok, result} = TokenUsage.list_anomalies(ctx.tenant.id)
+
+      assert result.total == 2
+      assert length(result.data) == 2
+
+      # Check that story title is included
+      anomaly_data = Enum.find(result.data, &(&1.story_id == ctx.story1.id))
+      assert anomaly_data.story_title != nil
+      assert anomaly_data.anomaly_type == :high_cost
+    end
+
+    test "includes agent name when story has an assigned agent" do
+      ctx = setup_tenant_with_anomalies()
+      {:ok, result} = TokenUsage.list_anomalies(ctx.tenant.id)
+
+      anomaly_with_agent = Enum.find(result.data, &(&1.story_id == ctx.story1.id))
+      assert anomaly_with_agent.agent_name == ctx.agent.name
+    end
+
+    test "filters by anomaly_type" do
+      ctx = setup_tenant_with_anomalies()
+
+      {:ok, result} = TokenUsage.list_anomalies(ctx.tenant.id, anomaly_type: "high_cost")
+      assert result.total == 1
+      assert hd(result.data).anomaly_type == :high_cost
+    end
+
+    test "filters by project_id" do
+      ctx = setup_tenant_with_anomalies()
+
+      {:ok, result} = TokenUsage.list_anomalies(ctx.tenant.id, project_id: ctx.project.id)
+      assert result.total == 2
+
+      # Different project should return 0
+      other_project = fixture(:project, %{tenant_id: ctx.tenant.id})
+      {:ok, result} = TokenUsage.list_anomalies(ctx.tenant.id, project_id: other_project.id)
+      assert result.total == 0
+    end
+
+    test "excludes resolved anomalies by default" do
+      ctx = setup_tenant_with_anomalies()
+
+      # Resolve one anomaly
+      {:ok, _} = TokenUsage.resolve_anomaly(ctx.tenant.id, ctx.anomaly1.id)
+
+      {:ok, result} = TokenUsage.list_anomalies(ctx.tenant.id)
+      assert result.total == 1
+      assert hd(result.data).story_id == ctx.story2.id
+    end
+
+    test "supports pagination" do
+      ctx = setup_tenant_with_anomalies()
+
+      {:ok, result} = TokenUsage.list_anomalies(ctx.tenant.id, page: 1, page_size: 1)
+      assert result.total == 2
+      assert result.page == 1
+      assert result.page_size == 1
+      assert length(result.data) == 1
+    end
+
+    test "tenant isolation - tenant A cannot see tenant B's anomalies" do
+      ctx = setup_tenant_with_anomalies()
+
+      tenant_b = fixture(:tenant)
+      {:ok, result} = TokenUsage.list_anomalies(tenant_b.id)
+      assert result.total == 0
+      assert result.data == []
+
+      # Verify tenant A can see its own
+      {:ok, result_a} = TokenUsage.list_anomalies(ctx.tenant.id)
+      assert result_a.total == 2
+    end
+  end
+
+  describe "get_anomaly/2" do
+    test "returns anomaly by ID and tenant" do
+      ctx = setup_tenant_with_anomalies()
+
+      {:ok, anomaly} = TokenUsage.get_anomaly(ctx.tenant.id, ctx.anomaly1.id)
+      assert anomaly.id == ctx.anomaly1.id
+    end
+
+    test "returns not_found for wrong tenant" do
+      ctx = setup_tenant_with_anomalies()
+      tenant_b = fixture(:tenant)
+
+      assert {:error, :not_found} = TokenUsage.get_anomaly(tenant_b.id, ctx.anomaly1.id)
+    end
+
+    test "returns not_found for non-existent anomaly" do
+      tenant = fixture(:tenant)
+      assert {:error, :not_found} = TokenUsage.get_anomaly(tenant.id, Ecto.UUID.generate())
+    end
+  end
+
+  describe "resolve_anomaly/2" do
+    test "marks anomaly as resolved" do
+      ctx = setup_tenant_with_anomalies()
+
+      {:ok, anomaly} = TokenUsage.resolve_anomaly(ctx.tenant.id, ctx.anomaly1.id)
+      assert anomaly.resolved == true
+    end
+
+    test "returns not_found for wrong tenant" do
+      ctx = setup_tenant_with_anomalies()
+      tenant_b = fixture(:tenant)
+
+      assert {:error, :not_found} = TokenUsage.resolve_anomaly(tenant_b.id, ctx.anomaly1.id)
+    end
+  end
+end

--- a/test/loopctl/token_usage/cost_summary_test.exs
+++ b/test/loopctl/token_usage/cost_summary_test.exs
@@ -1,0 +1,143 @@
+defmodule Loopctl.TokenUsage.CostSummaryTest do
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.TokenUsage.CostSummary
+
+  describe "changeset/2" do
+    test "valid changeset with required fields" do
+      changeset =
+        CostSummary.changeset(%CostSummary{}, %{
+          scope_type: :project,
+          scope_id: Ecto.UUID.generate(),
+          period_start: ~D[2026-04-01],
+          period_end: ~D[2026-04-01],
+          total_input_tokens: 1000,
+          total_output_tokens: 500,
+          total_cost_millicents: 2500,
+          report_count: 5,
+          model_breakdown: %{"claude-opus-4" => %{"other" => %{"input_tokens" => 1000}}}
+        })
+
+      assert changeset.valid?
+    end
+
+    test "requires scope_type, scope_id, period_start, period_end" do
+      changeset = CostSummary.changeset(%CostSummary{}, %{})
+
+      refute changeset.valid?
+      errors = errors_on(changeset)
+      assert errors[:scope_type]
+      assert errors[:scope_id]
+      assert errors[:period_start]
+      assert errors[:period_end]
+    end
+
+    test "validates scope_type enum values" do
+      changeset =
+        CostSummary.changeset(%CostSummary{}, %{
+          scope_type: :invalid,
+          scope_id: Ecto.UUID.generate(),
+          period_start: ~D[2026-04-01],
+          period_end: ~D[2026-04-01]
+        })
+
+      refute changeset.valid?
+      assert errors_on(changeset)[:scope_type]
+    end
+
+    test "accepts all valid scope types" do
+      for scope_type <- [:agent, :epic, :project, :story] do
+        changeset =
+          CostSummary.changeset(%CostSummary{}, %{
+            scope_type: scope_type,
+            scope_id: Ecto.UUID.generate(),
+            period_start: ~D[2026-04-01],
+            period_end: ~D[2026-04-01]
+          })
+
+        assert changeset.valid?, "Expected #{scope_type} to be valid"
+      end
+    end
+
+    test "validates non-negative numbers" do
+      changeset =
+        CostSummary.changeset(%CostSummary{}, %{
+          scope_type: :project,
+          scope_id: Ecto.UUID.generate(),
+          period_start: ~D[2026-04-01],
+          period_end: ~D[2026-04-01],
+          total_input_tokens: -1,
+          total_output_tokens: -1,
+          total_cost_millicents: -1,
+          report_count: -1
+        })
+
+      refute changeset.valid?
+      errors = errors_on(changeset)
+      assert errors[:total_input_tokens]
+      assert errors[:total_output_tokens]
+      assert errors[:total_cost_millicents]
+      assert errors[:report_count]
+    end
+  end
+
+  describe "fixture" do
+    test "creates a cost summary with defaults" do
+      summary = fixture(:cost_summary)
+
+      assert summary.id
+      assert summary.tenant_id
+      assert summary.scope_type == :project
+      assert summary.total_cost_millicents == 25_000
+    end
+
+    test "creates a cost summary with overrides" do
+      tenant = fixture(:tenant)
+      epic = fixture(:epic, %{tenant_id: tenant.id})
+
+      summary =
+        fixture(:cost_summary, %{
+          tenant_id: tenant.id,
+          scope_type: :epic,
+          scope_id: epic.id,
+          total_cost_millicents: 99_999
+        })
+
+      assert summary.scope_type == :epic
+      assert summary.scope_id == epic.id
+      assert summary.total_cost_millicents == 99_999
+    end
+  end
+
+  describe "unique constraint" do
+    test "enforces unique (tenant_id, scope_type, scope_id, period_start)" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+
+      _first =
+        fixture(:cost_summary, %{
+          tenant_id: tenant.id,
+          scope_type: :project,
+          scope_id: project.id,
+          period_start: ~D[2026-04-01],
+          period_end: ~D[2026-04-01]
+        })
+
+      # Second insert with same key should fail
+      changeset =
+        %CostSummary{tenant_id: tenant.id}
+        |> CostSummary.changeset(%{
+          scope_type: :project,
+          scope_id: project.id,
+          period_start: ~D[2026-04-01],
+          period_end: ~D[2026-04-01]
+        })
+
+      assert {:error, changeset} = AdminRepo.insert(changeset)
+      assert errors_on(changeset)[:tenant_id]
+    end
+  end
+end

--- a/test/loopctl/token_usage/default_rollup_test.exs
+++ b/test/loopctl/token_usage/default_rollup_test.exs
@@ -1,0 +1,141 @@
+defmodule Loopctl.TokenUsage.DefaultRollupTest do
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.TokenUsage.DefaultRollup
+
+  defp setup_tenant_with_reports do
+    tenant = fixture(:tenant)
+    project = fixture(:project, %{tenant_id: tenant.id})
+    epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+    agent = fixture(:agent, %{tenant_id: tenant.id})
+
+    story1 =
+      fixture(:story, %{
+        tenant_id: tenant.id,
+        epic_id: epic.id,
+        project_id: project.id
+      })
+
+    story2 =
+      fixture(:story, %{
+        tenant_id: tenant.id,
+        epic_id: epic.id,
+        project_id: project.id
+      })
+
+    # Create reports for story1
+    fixture(:token_usage_report, %{
+      tenant_id: tenant.id,
+      story_id: story1.id,
+      agent_id: agent.id,
+      project_id: project.id,
+      input_tokens: 1000,
+      output_tokens: 500,
+      cost_millicents: 2500,
+      model_name: "claude-opus-4",
+      phase: "implementing"
+    })
+
+    # Create reports for story2
+    fixture(:token_usage_report, %{
+      tenant_id: tenant.id,
+      story_id: story2.id,
+      agent_id: agent.id,
+      project_id: project.id,
+      input_tokens: 2000,
+      output_tokens: 1000,
+      cost_millicents: 5000,
+      model_name: "claude-opus-4",
+      phase: "reviewing"
+    })
+
+    %{
+      tenant: tenant,
+      project: project,
+      epic: epic,
+      agent: agent,
+      story1: story1,
+      story2: story2
+    }
+  end
+
+  describe "aggregate/3" do
+    test "aggregates reports by agent, epic, and project" do
+      ctx = setup_tenant_with_reports()
+
+      # Use a wide date range to capture all reports
+      period_start = Date.add(Date.utc_today(), -1)
+      period_end = Date.add(Date.utc_today(), 1)
+
+      {:ok, rows} = DefaultRollup.aggregate(ctx.tenant.id, period_start, period_end)
+
+      # Should have agent, epic, and project summaries
+      agent_rows = Enum.filter(rows, &(&1.scope_type == :agent))
+      epic_rows = Enum.filter(rows, &(&1.scope_type == :epic))
+      project_rows = Enum.filter(rows, &(&1.scope_type == :project))
+
+      assert agent_rows != []
+      assert epic_rows != []
+      assert project_rows != []
+
+      # Check project aggregate
+      project_row = Enum.find(project_rows, &(&1.scope_id == ctx.project.id))
+      assert project_row.total_input_tokens == 3000
+      assert project_row.total_output_tokens == 1500
+      assert project_row.total_cost_millicents == 7500
+      assert project_row.report_count == 2
+
+      # Check epic aggregate
+      epic_row = Enum.find(epic_rows, &(&1.scope_id == ctx.epic.id))
+      assert epic_row.total_cost_millicents == 7500
+      # avg_cost_per_story = 7500 / 2 stories = 3750
+      assert epic_row.avg_cost_per_story_millicents == 3750
+
+      # Check model breakdown contains data
+      assert map_size(project_row.model_breakdown) > 0
+    end
+
+    test "returns empty list when no reports exist for period" do
+      tenant = fixture(:tenant)
+
+      {:ok, rows} = DefaultRollup.aggregate(tenant.id, ~D[2025-01-01], ~D[2025-01-01])
+      assert rows == []
+    end
+
+    test "tenant isolation - only aggregates reports for the given tenant" do
+      ctx = setup_tenant_with_reports()
+      tenant_b = fixture(:tenant)
+
+      period_start = Date.add(Date.utc_today(), -1)
+      period_end = Date.add(Date.utc_today(), 1)
+
+      {:ok, rows_a} = DefaultRollup.aggregate(ctx.tenant.id, period_start, period_end)
+      {:ok, rows_b} = DefaultRollup.aggregate(tenant_b.id, period_start, period_end)
+
+      assert rows_a != []
+      assert rows_b == []
+    end
+
+    test "includes model breakdown with per-phase data" do
+      ctx = setup_tenant_with_reports()
+
+      period_start = Date.add(Date.utc_today(), -1)
+      period_end = Date.add(Date.utc_today(), 1)
+
+      {:ok, rows} = DefaultRollup.aggregate(ctx.tenant.id, period_start, period_end)
+
+      project_row =
+        Enum.find(rows, &(&1.scope_type == :project and &1.scope_id == ctx.project.id))
+
+      assert is_map(project_row.model_breakdown)
+
+      # Should have claude-opus-4 with implementing and reviewing phases
+      assert Map.has_key?(project_row.model_breakdown, "claude-opus-4")
+      model_data = project_row.model_breakdown["claude-opus-4"]
+      assert Map.has_key?(model_data, "implementing")
+      assert Map.has_key?(model_data, "reviewing")
+    end
+  end
+end

--- a/test/loopctl/workers/cost_anomaly_worker_test.exs
+++ b/test/loopctl/workers/cost_anomaly_worker_test.exs
@@ -1,0 +1,215 @@
+defmodule Loopctl.Workers.CostAnomalyWorkerTest do
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.TokenUsage.CostAnomaly
+  alias Loopctl.TokenUsage.CostSummary
+  alias Loopctl.Workers.CostAnomalyWorker
+
+  defp setup_tenant_with_epic do
+    tenant = fixture(:tenant)
+    project = fixture(:project, %{tenant_id: tenant.id})
+    epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+    agent = fixture(:agent, %{tenant_id: tenant.id})
+
+    %{tenant: tenant, project: project, epic: epic, agent: agent}
+  end
+
+  defp create_story_with_reports(tenant, epic, agent, cost_millicents) do
+    story =
+      fixture(:story, %{
+        tenant_id: tenant.id,
+        epic_id: epic.id,
+        project_id: epic.project_id
+      })
+
+    # Insert a token usage report directly for this story
+    fixture(:token_usage_report, %{
+      tenant_id: tenant.id,
+      story_id: story.id,
+      agent_id: agent.id,
+      project_id: epic.project_id,
+      cost_millicents: cost_millicents
+    })
+
+    story
+  end
+
+  describe "perform/1" do
+    test "flags high_cost stories (>3x epic average)" do
+      ctx = setup_tenant_with_epic()
+      period_start = Date.utc_today()
+      period_end = Date.utc_today()
+
+      # Create stories: 3 normal cost, 1 very expensive
+      _normal1 = create_story_with_reports(ctx.tenant, ctx.epic, ctx.agent, 10_000)
+      _normal2 = create_story_with_reports(ctx.tenant, ctx.epic, ctx.agent, 10_000)
+      _normal3 = create_story_with_reports(ctx.tenant, ctx.epic, ctx.agent, 10_000)
+      expensive = create_story_with_reports(ctx.tenant, ctx.epic, ctx.agent, 100_000)
+
+      # Epic average = (10k + 10k + 10k + 100k) / 4 = 32_500
+      # The expensive story = 100_000 / 32_500 = 3.07x -> flagged
+
+      # Create the epic cost summary (as if rollup ran)
+      %CostSummary{tenant_id: ctx.tenant.id}
+      |> CostSummary.changeset(%{
+        scope_type: :epic,
+        scope_id: ctx.epic.id,
+        period_start: period_start,
+        period_end: period_end,
+        total_cost_millicents: 130_000,
+        report_count: 4,
+        avg_cost_per_story_millicents: 32_500
+      })
+      |> AdminRepo.insert!()
+
+      assert :ok =
+               CostAnomalyWorker.perform(%Oban.Job{
+                 args: %{
+                   "period_start" => Date.to_iso8601(period_start),
+                   "period_end" => Date.to_iso8601(period_end)
+                 }
+               })
+
+      anomalies = AdminRepo.all(CostAnomaly)
+      high_cost = Enum.filter(anomalies, &(&1.anomaly_type == :high_cost))
+
+      assert length(high_cost) == 1
+      anomaly = hd(high_cost)
+      assert anomaly.story_id == expensive.id
+      assert anomaly.story_cost_millicents == 100_000
+      assert anomaly.reference_avg_millicents == 32_500
+      assert anomaly.resolved == false
+    end
+
+    test "flags suspiciously_low stories (<0.1x epic average)" do
+      ctx = setup_tenant_with_epic()
+      period_start = Date.utc_today()
+      period_end = Date.utc_today()
+
+      # Create stories: 3 normal cost, 1 very cheap
+      _normal1 = create_story_with_reports(ctx.tenant, ctx.epic, ctx.agent, 50_000)
+      _normal2 = create_story_with_reports(ctx.tenant, ctx.epic, ctx.agent, 50_000)
+      _normal3 = create_story_with_reports(ctx.tenant, ctx.epic, ctx.agent, 50_000)
+      cheap = create_story_with_reports(ctx.tenant, ctx.epic, ctx.agent, 100)
+
+      # Epic average = (50k + 50k + 50k + 100) / 4 = 37_525
+      # The cheap story = 100 / 37_525 = 0.0026x -> flagged
+
+      %CostSummary{tenant_id: ctx.tenant.id}
+      |> CostSummary.changeset(%{
+        scope_type: :epic,
+        scope_id: ctx.epic.id,
+        period_start: period_start,
+        period_end: period_end,
+        total_cost_millicents: 150_100,
+        report_count: 4,
+        avg_cost_per_story_millicents: 37_525
+      })
+      |> AdminRepo.insert!()
+
+      assert :ok =
+               CostAnomalyWorker.perform(%Oban.Job{
+                 args: %{
+                   "period_start" => Date.to_iso8601(period_start),
+                   "period_end" => Date.to_iso8601(period_end)
+                 }
+               })
+
+      anomalies = AdminRepo.all(CostAnomaly)
+      low_cost = Enum.filter(anomalies, &(&1.anomaly_type == :suspiciously_low))
+
+      assert length(low_cost) == 1
+      assert hd(low_cost).story_id == cheap.id
+    end
+
+    test "does not flag stories within normal range" do
+      ctx = setup_tenant_with_epic()
+      period_start = Date.utc_today()
+      period_end = Date.utc_today()
+
+      # All stories have similar cost
+      _s1 = create_story_with_reports(ctx.tenant, ctx.epic, ctx.agent, 10_000)
+      _s2 = create_story_with_reports(ctx.tenant, ctx.epic, ctx.agent, 12_000)
+      _s3 = create_story_with_reports(ctx.tenant, ctx.epic, ctx.agent, 8_000)
+
+      # Average = 10_000
+      %CostSummary{tenant_id: ctx.tenant.id}
+      |> CostSummary.changeset(%{
+        scope_type: :epic,
+        scope_id: ctx.epic.id,
+        period_start: period_start,
+        period_end: period_end,
+        total_cost_millicents: 30_000,
+        report_count: 3,
+        avg_cost_per_story_millicents: 10_000
+      })
+      |> AdminRepo.insert!()
+
+      assert :ok =
+               CostAnomalyWorker.perform(%Oban.Job{
+                 args: %{
+                   "period_start" => Date.to_iso8601(period_start),
+                   "period_end" => Date.to_iso8601(period_end)
+                 }
+               })
+
+      assert AdminRepo.all(CostAnomaly) == []
+    end
+
+    test "updates existing unresolved anomaly instead of duplicating" do
+      ctx = setup_tenant_with_epic()
+      period_start = Date.utc_today()
+      period_end = Date.utc_today()
+
+      expensive = create_story_with_reports(ctx.tenant, ctx.epic, ctx.agent, 100_000)
+
+      # Pre-existing anomaly for this story
+      existing =
+        fixture(:cost_anomaly, %{
+          tenant_id: ctx.tenant.id,
+          story_id: expensive.id,
+          anomaly_type: :high_cost,
+          story_cost_millicents: 80_000,
+          reference_avg_millicents: 20_000,
+          deviation_factor: Decimal.new("4.0")
+        })
+
+      %CostSummary{tenant_id: ctx.tenant.id}
+      |> CostSummary.changeset(%{
+        scope_type: :epic,
+        scope_id: ctx.epic.id,
+        period_start: period_start,
+        period_end: period_end,
+        total_cost_millicents: 100_000,
+        report_count: 1,
+        avg_cost_per_story_millicents: 25_000
+      })
+      |> AdminRepo.insert!()
+
+      assert :ok =
+               CostAnomalyWorker.perform(%Oban.Job{
+                 args: %{
+                   "period_start" => Date.to_iso8601(period_start),
+                   "period_end" => Date.to_iso8601(period_end)
+                 }
+               })
+
+      anomalies = AdminRepo.all(CostAnomaly)
+      # Should still be only 1 anomaly (updated, not duplicated)
+      assert length(anomalies) == 1
+      anomaly = hd(anomalies)
+      assert anomaly.id == existing.id
+      # Updated with new figures
+      assert anomaly.story_cost_millicents == 100_000
+      assert anomaly.reference_avg_millicents == 25_000
+    end
+
+    test "succeeds when no tenants exist" do
+      # Delete all tenants (clean state)
+      assert :ok = CostAnomalyWorker.perform(%Oban.Job{args: %{}})
+    end
+  end
+end

--- a/test/loopctl/workers/cost_rollup_worker_test.exs
+++ b/test/loopctl/workers/cost_rollup_worker_test.exs
@@ -1,0 +1,179 @@
+defmodule Loopctl.Workers.CostRollupWorkerTest do
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.TokenUsage.CostSummary
+  alias Loopctl.Workers.CostRollupWorker
+
+  describe "perform/1" do
+    test "calls rollup service and upserts cost summaries" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      agent = fixture(:agent, %{tenant_id: tenant.id})
+
+      period_start = ~D[2026-04-02]
+      period_end = ~D[2026-04-02]
+
+      expected_tenant_id = tenant.id
+
+      # Mock the rollup service to return aggregated data
+      expect(Loopctl.MockCostRollup, :aggregate, fn tenant_id, start_date, end_date ->
+        assert tenant_id == expected_tenant_id
+        assert start_date == period_start
+        assert end_date == period_end
+
+        {:ok,
+         [
+           %{
+             scope_type: :project,
+             scope_id: project.id,
+             total_input_tokens: 50_000,
+             total_output_tokens: 25_000,
+             total_cost_millicents: 75_000,
+             report_count: 10,
+             model_breakdown: %{
+               "claude-opus-4" => %{"implementing" => %{"input_tokens" => 50_000}}
+             },
+             avg_cost_per_story_millicents: 7_500
+           },
+           %{
+             scope_type: :agent,
+             scope_id: agent.id,
+             total_input_tokens: 30_000,
+             total_output_tokens: 15_000,
+             total_cost_millicents: 45_000,
+             report_count: 5,
+             model_breakdown: %{},
+             avg_cost_per_story_millicents: nil
+           }
+         ]}
+      end)
+
+      assert :ok =
+               CostRollupWorker.perform(%Oban.Job{
+                 args: %{
+                   "period_start" => "2026-04-02",
+                   "period_end" => "2026-04-02"
+                 }
+               })
+
+      # Verify summaries were created
+      summaries = AdminRepo.all(CostSummary)
+      assert length(summaries) == 2
+
+      project_summary = Enum.find(summaries, &(&1.scope_type == :project))
+      assert project_summary.tenant_id == tenant.id
+      assert project_summary.scope_id == project.id
+      assert project_summary.total_input_tokens == 50_000
+      assert project_summary.total_output_tokens == 25_000
+      assert project_summary.total_cost_millicents == 75_000
+      assert project_summary.report_count == 10
+      assert project_summary.avg_cost_per_story_millicents == 7_500
+      assert project_summary.period_start == ~D[2026-04-02]
+      assert project_summary.period_end == ~D[2026-04-02]
+
+      agent_summary = Enum.find(summaries, &(&1.scope_type == :agent))
+      assert agent_summary.scope_id == agent.id
+      assert agent_summary.total_cost_millicents == 45_000
+      assert agent_summary.avg_cost_per_story_millicents == nil
+    end
+
+    test "rollup is idempotent - running twice produces same result" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+
+      rollup_data = [
+        %{
+          scope_type: :project,
+          scope_id: project.id,
+          total_input_tokens: 10_000,
+          total_output_tokens: 5_000,
+          total_cost_millicents: 15_000,
+          report_count: 3,
+          model_breakdown: %{},
+          avg_cost_per_story_millicents: 5_000
+        }
+      ]
+
+      # Run rollup twice with same data
+      expect(Loopctl.MockCostRollup, :aggregate, 2, fn _, _, _ ->
+        {:ok, rollup_data}
+      end)
+
+      assert :ok =
+               CostRollupWorker.perform(%Oban.Job{
+                 args: %{"period_start" => "2026-04-02", "period_end" => "2026-04-02"}
+               })
+
+      assert :ok =
+               CostRollupWorker.perform(%Oban.Job{
+                 args: %{"period_start" => "2026-04-02", "period_end" => "2026-04-02"}
+               })
+
+      # Should still have only 1 record (upserted, not duplicated)
+      summaries = AdminRepo.all(CostSummary)
+      assert length(summaries) == 1
+      assert hd(summaries).total_cost_millicents == 15_000
+    end
+
+    test "handles rollup service errors gracefully" do
+      _tenant = fixture(:tenant)
+
+      expect(Loopctl.MockCostRollup, :aggregate, fn _, _, _ ->
+        {:error, "database timeout"}
+      end)
+
+      # Should still return :ok (logs errors but doesn't fail job)
+      assert :ok =
+               CostRollupWorker.perform(%Oban.Job{
+                 args: %{"period_start" => "2026-04-02", "period_end" => "2026-04-02"}
+               })
+    end
+
+    test "defaults period to yesterday when not provided" do
+      _tenant = fixture(:tenant)
+
+      yesterday = Date.add(Date.utc_today(), -1)
+
+      expect(Loopctl.MockCostRollup, :aggregate, fn _, period_start, period_end ->
+        assert period_start == yesterday
+        assert period_end == yesterday
+        {:ok, []}
+      end)
+
+      assert :ok = CostRollupWorker.perform(%Oban.Job{args: %{}})
+    end
+
+    test "processes multiple tenants" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+
+      expect(Loopctl.MockCostRollup, :aggregate, 2, fn tenant_id, _, _ ->
+        assert tenant_id in [tenant_a.id, tenant_b.id]
+        {:ok, []}
+      end)
+
+      assert :ok =
+               CostRollupWorker.perform(%Oban.Job{
+                 args: %{"period_start" => "2026-04-02", "period_end" => "2026-04-02"}
+               })
+    end
+
+    test "skips suspended tenants" do
+      _active_tenant = fixture(:tenant)
+      _suspended_tenant = fixture(:tenant, %{status: :suspended})
+
+      # Should only be called once (for active tenant)
+      expect(Loopctl.MockCostRollup, :aggregate, fn _, _, _ ->
+        {:ok, []}
+      end)
+
+      assert :ok =
+               CostRollupWorker.perform(%Oban.Job{
+                 args: %{"period_start" => "2026-04-02", "period_end" => "2026-04-02"}
+               })
+    end
+  end
+end

--- a/test/loopctl_web/controllers/cost_anomaly_controller_test.exs
+++ b/test/loopctl_web/controllers/cost_anomaly_controller_test.exs
@@ -1,0 +1,227 @@
+defmodule LoopctlWeb.CostAnomalyControllerTest do
+  use LoopctlWeb.ConnCase, async: true
+
+  setup :verify_on_exit!
+
+  defp auth_conn(conn, raw_key) do
+    put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  defp setup_tenant_with_anomalies do
+    tenant = fixture(:tenant)
+    project = fixture(:project, %{tenant_id: tenant.id})
+    epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+    agent = fixture(:agent, %{tenant_id: tenant.id})
+
+    story1 =
+      fixture(:story, %{
+        tenant_id: tenant.id,
+        epic_id: epic.id,
+        project_id: project.id,
+        assigned_agent_id: agent.id
+      })
+
+    story2 =
+      fixture(:story, %{
+        tenant_id: tenant.id,
+        epic_id: epic.id,
+        project_id: project.id
+      })
+
+    anomaly1 =
+      fixture(:cost_anomaly, %{
+        tenant_id: tenant.id,
+        story_id: story1.id,
+        anomaly_type: :high_cost,
+        story_cost_millicents: 100_000,
+        reference_avg_millicents: 25_000,
+        deviation_factor: Decimal.new("4.0")
+      })
+
+    anomaly2 =
+      fixture(:cost_anomaly, %{
+        tenant_id: tenant.id,
+        story_id: story2.id,
+        anomaly_type: :suspiciously_low,
+        story_cost_millicents: 100,
+        reference_avg_millicents: 25_000,
+        deviation_factor: Decimal.new("0.004")
+      })
+
+    {user_key, _user_api_key} =
+      fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+    {agent_key, _agent_api_key} =
+      fixture(:api_key, %{tenant_id: tenant.id, role: :agent, agent_id: agent.id})
+
+    %{
+      tenant: tenant,
+      project: project,
+      epic: epic,
+      agent: agent,
+      story1: story1,
+      story2: story2,
+      anomaly1: anomaly1,
+      anomaly2: anomaly2,
+      user_key: user_key,
+      agent_key: agent_key
+    }
+  end
+
+  # --- GET /api/v1/cost-anomalies ---
+
+  describe "GET /api/v1/cost-anomalies" do
+    test "lists unresolved anomalies", %{conn: conn} do
+      ctx = setup_tenant_with_anomalies()
+
+      conn =
+        conn
+        |> auth_conn(ctx.user_key)
+        |> get(~p"/api/v1/cost-anomalies")
+
+      body = json_response(conn, 200)
+
+      assert length(body["data"]) == 2
+      assert body["meta"]["total_count"] == 2
+      assert body["meta"]["page"] == 1
+    end
+
+    test "includes story title and agent name", %{conn: conn} do
+      ctx = setup_tenant_with_anomalies()
+
+      conn =
+        conn
+        |> auth_conn(ctx.user_key)
+        |> get(~p"/api/v1/cost-anomalies")
+
+      body = json_response(conn, 200)
+
+      anomaly_with_agent =
+        Enum.find(body["data"], &(&1["story_id"] == ctx.story1.id))
+
+      assert anomaly_with_agent["story_title"] != nil
+      assert anomaly_with_agent["agent_name"] == ctx.agent.name
+    end
+
+    test "filters by anomaly_type", %{conn: conn} do
+      ctx = setup_tenant_with_anomalies()
+
+      conn =
+        conn
+        |> auth_conn(ctx.user_key)
+        |> get(~p"/api/v1/cost-anomalies?anomaly_type=high_cost")
+
+      body = json_response(conn, 200)
+
+      assert length(body["data"]) == 1
+      assert hd(body["data"])["anomaly_type"] == "high_cost"
+    end
+
+    test "filters by project_id", %{conn: conn} do
+      ctx = setup_tenant_with_anomalies()
+
+      conn =
+        conn
+        |> auth_conn(ctx.user_key)
+        |> get(~p"/api/v1/cost-anomalies?project_id=#{ctx.project.id}")
+
+      body = json_response(conn, 200)
+      assert body["meta"]["total_count"] == 2
+    end
+
+    test "supports pagination", %{conn: conn} do
+      ctx = setup_tenant_with_anomalies()
+
+      conn =
+        conn
+        |> auth_conn(ctx.user_key)
+        |> get(~p"/api/v1/cost-anomalies?page=1&page_size=1")
+
+      body = json_response(conn, 200)
+      assert length(body["data"]) == 1
+      assert body["meta"]["total_count"] == 2
+      assert body["meta"]["page"] == 1
+      assert body["meta"]["page_size"] == 1
+    end
+
+    test "returns 403 for agent role", %{conn: conn} do
+      ctx = setup_tenant_with_anomalies()
+
+      conn =
+        conn
+        |> auth_conn(ctx.agent_key)
+        |> get(~p"/api/v1/cost-anomalies")
+
+      assert json_response(conn, 403)
+    end
+
+    test "tenant isolation - returns empty for different tenant", %{conn: conn} do
+      _ctx = setup_tenant_with_anomalies()
+
+      other_tenant = fixture(:tenant)
+      {other_key, _} = fixture(:api_key, %{tenant_id: other_tenant.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(other_key)
+        |> get(~p"/api/v1/cost-anomalies")
+
+      body = json_response(conn, 200)
+      assert body["data"] == []
+      assert body["meta"]["total_count"] == 0
+    end
+  end
+
+  # --- PATCH /api/v1/cost-anomalies/:id ---
+
+  describe "PATCH /api/v1/cost-anomalies/:id" do
+    test "marks anomaly as resolved", %{conn: conn} do
+      ctx = setup_tenant_with_anomalies()
+
+      conn =
+        conn
+        |> auth_conn(ctx.user_key)
+        |> patch(~p"/api/v1/cost-anomalies/#{ctx.anomaly1.id}")
+
+      body = json_response(conn, 200)
+      assert body["cost_anomaly"]["id"] == ctx.anomaly1.id
+      assert body["cost_anomaly"]["resolved"] == true
+    end
+
+    test "returns 404 for wrong tenant", %{conn: conn} do
+      ctx = setup_tenant_with_anomalies()
+
+      other_tenant = fixture(:tenant)
+      {other_key, _} = fixture(:api_key, %{tenant_id: other_tenant.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(other_key)
+        |> patch(~p"/api/v1/cost-anomalies/#{ctx.anomaly1.id}")
+
+      assert json_response(conn, 404)
+    end
+
+    test "returns 404 for non-existent anomaly", %{conn: conn} do
+      ctx = setup_tenant_with_anomalies()
+
+      conn =
+        conn
+        |> auth_conn(ctx.user_key)
+        |> patch(~p"/api/v1/cost-anomalies/#{Ecto.UUID.generate()}")
+
+      assert json_response(conn, 404)
+    end
+
+    test "returns 403 for agent role", %{conn: conn} do
+      ctx = setup_tenant_with_anomalies()
+
+      conn =
+        conn
+        |> auth_conn(ctx.agent_key)
+        |> patch(~p"/api/v1/cost-anomalies/#{ctx.anomaly1.id}")
+
+      assert json_response(conn, 403)
+    end
+  end
+end

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -77,6 +77,11 @@ defmodule Loopctl.DataCase do
       DateTime.utc_now()
     end)
 
+    # Default stub for cost rollup -- returns empty results
+    Mox.stub(Loopctl.MockCostRollup, :aggregate, fn _tenant_id, _start, _end ->
+      {:ok, []}
+    end)
+
     # Default Req.Test stub for webhook delivery -- allows Oban inline mode
     # to process delivery jobs without test-specific HTTP stub setup.
     Req.Test.stub(Loopctl.Webhooks.ReqDelivery, fn conn ->

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -24,6 +24,8 @@ defmodule Loopctl.Fixtures do
   alias Loopctl.Skills.SkillVersion
   alias Loopctl.Tenants.Tenant
   alias Loopctl.TokenUsage.Budget, as: TokenBudget
+  alias Loopctl.TokenUsage.CostAnomaly
+  alias Loopctl.TokenUsage.CostSummary
   alias Loopctl.TokenUsage.Report, as: TokenUsageReport
   alias Loopctl.Webhooks.Webhook
   alias Loopctl.Webhooks.WebhookEvent
@@ -282,6 +284,37 @@ defmodule Loopctl.Fixtures do
     )
   end
 
+  def build(:cost_summary, attrs) do
+    Map.merge(
+      %{
+        scope_type: :project,
+        period_start: Date.add(Date.utc_today(), -1),
+        period_end: Date.add(Date.utc_today(), -1),
+        total_input_tokens: 10_000,
+        total_output_tokens: 5_000,
+        total_cost_millicents: 25_000,
+        report_count: 10,
+        model_breakdown: %{},
+        avg_cost_per_story_millicents: 2_500
+      },
+      Enum.into(attrs, %{})
+    )
+  end
+
+  def build(:cost_anomaly, attrs) do
+    Map.merge(
+      %{
+        anomaly_type: :high_cost,
+        story_cost_millicents: 75_000,
+        reference_avg_millicents: 25_000,
+        deviation_factor: Decimal.new("3.0"),
+        resolved: false,
+        metadata: %{}
+      },
+      Enum.into(attrs, %{})
+    )
+  end
+
   def build(:review_record, attrs) do
     Map.merge(
       %{
@@ -445,6 +478,7 @@ defmodule Loopctl.Fixtures do
     # Handle optional status overrides
     agent_status = Map.get(attrs, :agent_status, :pending)
     verified_status = Map.get(attrs, :verified_status, :unverified)
+    assigned_agent_id = Map.get(attrs, :assigned_agent_id)
 
     data = build(:story, attrs)
 
@@ -454,14 +488,7 @@ defmodule Loopctl.Fixtures do
 
     story = AdminRepo.insert!(changeset)
 
-    # Apply status overrides if non-default
-    if agent_status != :pending or verified_status != :unverified do
-      story
-      |> Ecto.Changeset.change(%{agent_status: agent_status, verified_status: verified_status})
-      |> AdminRepo.update!()
-    else
-      story
-    end
+    apply_story_overrides(story, agent_status, verified_status, assigned_agent_id)
   end
 
   def fixture(:epic_dependency, attrs) do
@@ -674,6 +701,54 @@ defmodule Loopctl.Fixtures do
     changeset =
       %TokenBudget{tenant_id: tenant_id}
       |> TokenBudget.create_changeset(Map.put(data, :scope_id, scope_id))
+
+    AdminRepo.insert!(changeset)
+  end
+
+  def fixture(:cost_summary, attrs) do
+    attrs = Enum.into(attrs, %{})
+
+    {tenant_id, attrs} = ensure_tenant(attrs)
+    scope_type = Map.get(attrs, :scope_type, :project)
+    {scope_id, attrs} = ensure_scope_entity(attrs, scope_type, tenant_id)
+
+    data = build(:cost_summary, attrs)
+
+    changeset =
+      %CostSummary{tenant_id: tenant_id}
+      |> CostSummary.changeset(Map.put(data, :scope_id, scope_id))
+
+    AdminRepo.insert!(changeset)
+  end
+
+  def fixture(:cost_anomaly, attrs) do
+    attrs = Enum.into(attrs, %{})
+
+    {tenant_id, attrs} =
+      case Map.get(attrs, :tenant_id) do
+        nil ->
+          tenant = fixture(:tenant)
+          {tenant.id, Map.put(attrs, :tenant_id, tenant.id)}
+
+        tid ->
+          {tid, attrs}
+      end
+
+    {story_id, attrs} =
+      case Map.get(attrs, :story_id) do
+        nil ->
+          story = fixture(:story, %{tenant_id: tenant_id})
+          {story.id, Map.put(attrs, :story_id, story.id)}
+
+        sid ->
+          {sid, attrs}
+      end
+
+    data = build(:cost_anomaly, attrs)
+
+    changeset =
+      %CostAnomaly{tenant_id: tenant_id, story_id: story_id}
+      |> CostAnomaly.create_changeset(data)
 
     AdminRepo.insert!(changeset)
   end
@@ -1034,4 +1109,60 @@ defmodule Loopctl.Fixtures do
   Generates a fresh binary UUID for use in tests.
   """
   def uuid, do: Ecto.UUID.generate()
+
+  # --- Private helpers ---
+
+  defp apply_story_overrides(story, :pending, :unverified, nil), do: story
+
+  defp apply_story_overrides(story, agent_status, verified_status, assigned_agent_id) do
+    overrides =
+      %{agent_status: agent_status, verified_status: verified_status}
+      |> maybe_put(:assigned_agent_id, assigned_agent_id)
+
+    story
+    |> Ecto.Changeset.change(overrides)
+    |> AdminRepo.update!()
+  end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp ensure_tenant(attrs) do
+    case Map.get(attrs, :tenant_id) do
+      nil ->
+        tenant = fixture(:tenant)
+        {tenant.id, Map.put(attrs, :tenant_id, tenant.id)}
+
+      tid ->
+        {tid, attrs}
+    end
+  end
+
+  defp ensure_scope_entity(%{scope_id: sid} = attrs, _scope_type, _tenant_id) do
+    {sid, attrs}
+  end
+
+  defp ensure_scope_entity(attrs, :project, tenant_id) do
+    entity = fixture(:project, %{tenant_id: tenant_id})
+    {entity.id, Map.put(attrs, :scope_id, entity.id)}
+  end
+
+  defp ensure_scope_entity(attrs, :epic, tenant_id) do
+    entity = fixture(:epic, %{tenant_id: tenant_id})
+    {entity.id, Map.put(attrs, :scope_id, entity.id)}
+  end
+
+  defp ensure_scope_entity(attrs, :agent, tenant_id) do
+    entity = fixture(:agent, %{tenant_id: tenant_id})
+    {entity.id, Map.put(attrs, :scope_id, entity.id)}
+  end
+
+  defp ensure_scope_entity(attrs, :story, tenant_id) do
+    entity = fixture(:story, %{tenant_id: tenant_id})
+    {entity.id, Map.put(attrs, :scope_id, entity.id)}
+  end
+
+  defp ensure_scope_entity(attrs, _unknown, _tenant_id) do
+    {Ecto.UUID.generate(), attrs}
+  end
 end

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -1,3 +1,4 @@
 Mox.defmock(Loopctl.MockHealthChecker, for: Loopctl.HealthCheck.Behaviour)
 Mox.defmock(Loopctl.MockRateLimiter, for: Loopctl.RateLimiter.Behaviour)
 Mox.defmock(Loopctl.MockClock, for: Loopctl.Clock.Behaviour)
+Mox.defmock(Loopctl.MockCostRollup, for: Loopctl.TokenUsage.RollupBehaviour)


### PR DESCRIPTION
## Summary

- Add `cost_summaries` and `cost_anomalies` tables with PostgreSQL RLS policies and CHECK constraints
- Implement `CostRollupWorker` (daily cron at 02:00 UTC, `analytics` queue) that aggregates token usage reports into cost summaries by agent/epic/project scope, with idempotent UPSERT keyed on `(tenant_id, scope_type, scope_id, period_start)`
- Implement `CostAnomalyWorker` chained after rollup, detecting stories with cost >3x (high_cost) or <0.1x (suspiciously_low) the epic average
- Add `RollupBehaviour` + `DefaultRollup` with config-based DI (`Loopctl.MockCostRollup` in test)
- Add REST endpoints: `GET /api/v1/cost-anomalies` (filterable by anomaly_type, project_id) and `PATCH /api/v1/cost-anomalies/:id` (resolve anomaly), both requiring `user` role
- New fixtures: `fixture(:cost_summary)`, `fixture(:cost_anomaly)`

## Test plan

- [ ] CostSummary schema changeset validation (required fields, enum values, non-negative constraints, unique index)
- [ ] DefaultRollup integration tests (agent/epic/project aggregation, model breakdown, tenant isolation)
- [ ] CostRollupWorker tests (mocked rollup service, idempotent upsert, multi-tenant, error handling, skips suspended tenants)
- [ ] CostAnomalyWorker tests (high_cost detection, suspiciously_low detection, normal range no-flag, updates existing anomalies)
- [ ] TokenUsage context tests (list/get/resolve anomalies, filtering, pagination, tenant isolation)
- [ ] CostAnomalyController tests (GET list with filters, PATCH resolve, role enforcement, tenant isolation)
- [ ] 46 new tests, all passing

Generated with [Claude Code](https://claude.com/claude-code)