### PR TITLE
US-21.8: Change Feed & Audit Integration for Token Events

### DIFF
--- a/lib/loopctl/audit.ex
+++ b/lib/loopctl/audit.ex
@@ -217,10 +217,9 @@ defmodule Loopctl.Audit do
 
   Used by the story history shortcut endpoint and similar entity history views.
 
-  Currently returns only direct audit entries for the given entity. It does
-  not include entries for related entities (e.g., artifact_reports or
-  verification_results referencing a story_id). Cross-entity history
-  requires schemas from Epics 6-8.
+  For `entity_type = "story"`, also includes token_usage_report audit entries
+  where `metadata->>'story_id' = entity_id`, interleaved chronologically.
+  This satisfies AC-21.8.6 (token usage events in story timeline).
 
   ## Options
 
@@ -240,13 +239,7 @@ defmodule Loopctl.Audit do
     page_size = opts |> Keyword.get(:page_size, 100) |> max(1) |> min(100)
     offset = (page - 1) * page_size
 
-    # NOTE(Epics 6-8): When artifact_reports and verification_results
-    # schemas with story_id references are added, extend this query to
-    # include related entity entries via UNION or OR-based entity_id matching.
-    base_query =
-      AuditLog
-      |> where([a], a.tenant_id == ^tenant_id)
-      |> where([a], a.entity_type == ^entity_type and a.entity_id == ^entity_id)
+    base_query = build_entity_history_query(tenant_id, entity_type, entity_id)
 
     total = AdminRepo.aggregate(base_query, :count, :id)
 
@@ -258,6 +251,25 @@ defmodule Loopctl.Audit do
       |> AdminRepo.all()
 
     {:ok, %{data: entries, total: total, page: page, page_size: page_size}}
+  end
+
+  # Builds the history query for an entity. For "story" entities, expands the
+  # query to include related token_usage_report entries via metadata->>'story_id'.
+  defp build_entity_history_query(tenant_id, "story", entity_id) do
+    AuditLog
+    |> where([a], a.tenant_id == ^tenant_id)
+    |> where(
+      [a],
+      (a.entity_type == "story" and a.entity_id == ^entity_id) or
+        (a.entity_type == "token_usage_report" and
+           fragment("?->>'story_id' = ?", a.metadata, ^entity_id))
+    )
+  end
+
+  defp build_entity_history_query(tenant_id, entity_type, entity_id) do
+    AuditLog
+    |> where([a], a.tenant_id == ^tenant_id)
+    |> where([a], a.entity_type == ^entity_type and a.entity_id == ^entity_id)
   end
 
   # --- Private filter helpers ---

--- a/lib/loopctl/token_usage.ex
+++ b/lib/loopctl/token_usage.ex
@@ -88,7 +88,7 @@ defmodule Loopctl.TokenUsage do
         # Refetch to populate the DB-generated total_tokens column
         report = AdminRepo.get!(Report, report.id)
 
-        # Audit log the creation
+        # Audit log the creation (also serves as the change feed entry for AC-21.8.1)
         Audit.create_log_entry(tenant_id, %{
           entity_type: "token_usage_report",
           entity_id: report.id,
@@ -96,15 +96,20 @@ defmodule Loopctl.TokenUsage do
           actor_type: Keyword.get(opts, :actor_type, "api_key"),
           actor_id: Keyword.get(opts, :actor_id),
           actor_label: Keyword.get(opts, :actor_label),
+          project_id: report.project_id,
           new_state: %{
             "story_id" => report.story_id,
             "agent_id" => report.agent_id,
-            "project_id" => report.project_id,
-            "input_tokens" => report.input_tokens,
-            "output_tokens" => report.output_tokens,
             "model_name" => report.model_name,
             "cost_millicents" => report.cost_millicents,
-            "phase" => report.phase
+            "total_tokens" => report.total_tokens
+          },
+          metadata: %{
+            "story_id" => report.story_id,
+            "agent_id" => report.agent_id,
+            "model_name" => report.model_name,
+            "cost_millicents" => report.cost_millicents,
+            "total_tokens" => report.total_tokens
           }
         })
 

--- a/lib/loopctl/token_usage.ex
+++ b/lib/loopctl/token_usage.ex
@@ -113,6 +113,9 @@ defmodule Loopctl.TokenUsage do
           }
         })
 
+        # Check budget thresholds after report creation (AC-21.8.2)
+        check_budget_thresholds(tenant_id, report)
+
         {:ok, report}
 
       {:error, changeset} ->
@@ -531,6 +534,89 @@ defmodule Loopctl.TokenUsage do
 
     result = AdminRepo.one(query)
     decimal_to_int(result || 0)
+  end
+
+  # --- Budget threshold check (AC-21.8.2) ---
+
+  # After a token usage report is created, check all applicable budgets
+  # and emit threshold_crossed audit entries for any that have been crossed.
+  defp check_budget_thresholds(tenant_id, report) do
+    budgets = find_applicable_budgets(tenant_id, report)
+
+    Enum.each(budgets, fn budget ->
+      spend = get_scope_spend(tenant_id, budget.scope_type, budget.scope_id)
+
+      utilization_pct =
+        if budget.budget_millicents > 0, do: spend * 100 / budget.budget_millicents, else: 0
+
+      cond do
+        utilization_pct >= 100 ->
+          emit_threshold_crossed(tenant_id, budget, utilization_pct, "exceeded")
+
+        utilization_pct >= budget.alert_threshold_pct ->
+          emit_threshold_crossed(tenant_id, budget, utilization_pct, "warning")
+
+        true ->
+          :ok
+      end
+    end)
+  end
+
+  # Finds all budgets applicable to a report: story-level, epic-level, project-level.
+  defp find_applicable_budgets(tenant_id, report) do
+    story_budget =
+      AdminRepo.get_by(Budget,
+        tenant_id: tenant_id,
+        scope_type: :story,
+        scope_id: report.story_id
+      )
+
+    # Look up the story's epic_id for epic-level budget check
+    epic_budget =
+      case AdminRepo.get_by(Story, id: report.story_id, tenant_id: tenant_id) do
+        nil ->
+          nil
+
+        story ->
+          AdminRepo.get_by(Budget,
+            tenant_id: tenant_id,
+            scope_type: :epic,
+            scope_id: story.epic_id
+          )
+      end
+
+    project_budget =
+      AdminRepo.get_by(Budget,
+        tenant_id: tenant_id,
+        scope_type: :project,
+        scope_id: report.project_id
+      )
+
+    [story_budget, epic_budget, project_budget]
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp emit_threshold_crossed(tenant_id, budget, utilization_pct, threshold_type) do
+    Audit.create_log_entry(tenant_id, %{
+      entity_type: "token_budget",
+      entity_id: budget.id,
+      action: "threshold_crossed",
+      actor_type: "system",
+      new_state: %{
+        "budget_id" => budget.id,
+        "scope_type" => to_string(budget.scope_type),
+        "scope_id" => budget.scope_id,
+        "utilization_pct" => utilization_pct,
+        "threshold_type" => threshold_type,
+        "budget_millicents" => budget.budget_millicents
+      },
+      metadata: %{
+        "budget_id" => budget.id,
+        "scope_type" => to_string(budget.scope_type),
+        "scope_id" => budget.scope_id,
+        "threshold_type" => threshold_type
+      }
+    })
   end
 
   # --- Private helpers ---

--- a/lib/loopctl/workers/cost_anomaly_worker.ex
+++ b/lib/loopctl/workers/cost_anomaly_worker.ex
@@ -24,6 +24,7 @@ defmodule Loopctl.Workers.CostAnomalyWorker do
   import Ecto.Query
 
   alias Loopctl.AdminRepo
+  alias Loopctl.Audit
   alias Loopctl.Tenants.Tenant
   alias Loopctl.TokenUsage.CostAnomaly
   alias Loopctl.TokenUsage.CostSummary
@@ -137,14 +138,38 @@ defmodule Loopctl.Workers.CostAnomalyWorker do
       })
       |> AdminRepo.update!()
     else
-      %CostAnomaly{tenant_id: tenant_id, story_id: story_id}
-      |> CostAnomaly.create_changeset(%{
-        anomaly_type: anomaly_type,
-        story_cost_millicents: story_cost,
-        reference_avg_millicents: epic_avg,
-        deviation_factor: Decimal.round(factor, 2)
+      anomaly =
+        %CostAnomaly{tenant_id: tenant_id, story_id: story_id}
+        |> CostAnomaly.create_changeset(%{
+          anomaly_type: anomaly_type,
+          story_cost_millicents: story_cost,
+          reference_avg_millicents: epic_avg,
+          deviation_factor: Decimal.round(factor, 2)
+        })
+        |> AdminRepo.insert!()
+
+      # Emit change feed + audit log entry for the newly detected anomaly (AC-21.8.3, AC-21.8.5)
+      Audit.create_log_entry(tenant_id, %{
+        entity_type: "cost_anomaly",
+        entity_id: anomaly.id,
+        action: "detected",
+        actor_type: "system",
+        new_state: %{
+          "anomaly_type" => to_string(anomaly.anomaly_type),
+          "story_id" => anomaly.story_id,
+          "deviation_factor" => Decimal.to_string(anomaly.deviation_factor),
+          "story_cost_millicents" => anomaly.story_cost_millicents,
+          "reference_avg_millicents" => anomaly.reference_avg_millicents
+        },
+        metadata: %{
+          "anomaly_id" => anomaly.id,
+          "story_id" => anomaly.story_id,
+          "anomaly_type" => to_string(anomaly.anomaly_type),
+          "deviation_factor" => Decimal.to_string(anomaly.deviation_factor)
+        }
       })
-      |> AdminRepo.insert!()
+
+      anomaly
     end
   end
 

--- a/priv/repo/migrations/20260403232059_add_audit_log_metadata_story_id_index.exs
+++ b/priv/repo/migrations/20260403232059_add_audit_log_metadata_story_id_index.exs
@@ -1,0 +1,19 @@
+defmodule Loopctl.Repo.Migrations.AddAuditLogMetadataStoryIdIndex do
+  use Ecto.Migration
+
+  def up do
+    # Btree index on the extracted story_id from the audit_log metadata JSONB
+    # column. Supports efficient story history queries that include
+    # token_usage_report entries via metadata->>'story_id' (AC-21.8.6).
+    # Note: Cannot use CONCURRENTLY on partitioned tables.
+    execute """
+    CREATE INDEX IF NOT EXISTS audit_log_metadata_story_id_idx
+      ON audit_log ((metadata->>'story_id'))
+      WHERE metadata->>'story_id' IS NOT NULL
+    """
+  end
+
+  def down do
+    execute "DROP INDEX IF EXISTS audit_log_metadata_story_id_idx"
+  end
+end

--- a/test/loopctl/token_usage_change_feed_test.exs
+++ b/test/loopctl/token_usage_change_feed_test.exs
@@ -1,0 +1,721 @@
+defmodule Loopctl.TokenUsageChangeFeedTest do
+  @moduledoc """
+  Tests for US-21.8: Change Feed & Audit Integration for Token Events.
+
+  Verifies that token-related mutations (report creation, budget mutations,
+  anomaly detection/resolution) emit change feed entries via the audit log,
+  and that story history includes related token usage events.
+  """
+
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Audit
+  alias Loopctl.Audit.AuditLog
+  alias Loopctl.TokenUsage
+  alias Loopctl.TokenUsage.CostSummary
+  alias Loopctl.Workers.CostAnomalyWorker
+
+  import Ecto.Query
+
+  defp setup_context do
+    tenant = fixture(:tenant)
+    project = fixture(:project, %{tenant_id: tenant.id})
+    epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+    agent = fixture(:agent, %{tenant_id: tenant.id})
+
+    story =
+      fixture(:story, %{
+        tenant_id: tenant.id,
+        epic_id: epic.id,
+        project_id: project.id
+      })
+
+    %{tenant: tenant, project: project, epic: epic, agent: agent, story: story}
+  end
+
+  defp find_audit_entries(tenant_id, entity_type, action) do
+    AuditLog
+    |> where(
+      [a],
+      a.tenant_id == ^tenant_id and
+        a.entity_type == ^entity_type and
+        a.action == ^action
+    )
+    |> AdminRepo.all()
+  end
+
+  # --- AC-21.8.1: Token usage report creation generates a change feed entry ---
+
+  describe "create_report/3 change feed integration (AC-21.8.1)" do
+    test "emits audit log entry with entity_type='token_usage_report' and action='created'" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+
+      attrs = %{
+        story_id: story.id,
+        agent_id: agent.id,
+        project_id: project.id,
+        input_tokens: 1000,
+        output_tokens: 500,
+        model_name: "claude-opus-4",
+        cost_millicents: 2500
+      }
+
+      {:ok, _report} = TokenUsage.create_report(tenant.id, attrs)
+
+      entries = find_audit_entries(tenant.id, "token_usage_report", "created")
+      assert length(entries) == 1
+    end
+
+    test "change feed entry new_state includes story_id, agent_id, model_name, cost_millicents, total_tokens" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+
+      attrs = %{
+        story_id: story.id,
+        agent_id: agent.id,
+        project_id: project.id,
+        input_tokens: 2000,
+        output_tokens: 1000,
+        model_name: "claude-sonnet-4",
+        cost_millicents: 3500
+      }
+
+      {:ok, _report} = TokenUsage.create_report(tenant.id, attrs)
+
+      [entry] = find_audit_entries(tenant.id, "token_usage_report", "created")
+
+      assert entry.new_state["story_id"] == story.id
+      assert entry.new_state["agent_id"] == agent.id
+      assert entry.new_state["model_name"] == "claude-sonnet-4"
+      assert entry.new_state["cost_millicents"] == 3500
+      assert entry.new_state["total_tokens"] == 3000
+    end
+
+    test "change feed entry metadata includes story_id for story history lookup" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+
+      attrs = %{
+        story_id: story.id,
+        agent_id: agent.id,
+        project_id: project.id,
+        input_tokens: 500,
+        output_tokens: 200,
+        model_name: "claude-haiku-4",
+        cost_millicents: 700
+      }
+
+      {:ok, _report} = TokenUsage.create_report(tenant.id, attrs)
+
+      [entry] = find_audit_entries(tenant.id, "token_usage_report", "created")
+
+      assert entry.metadata["story_id"] == story.id
+      assert entry.metadata["agent_id"] == agent.id
+      assert entry.metadata["model_name"] == "claude-haiku-4"
+      assert entry.metadata["cost_millicents"] == 700
+    end
+
+    test "tenant isolation: report creation only emits entry for its own tenant" do
+      %{tenant: tenant_a, story: story_a, agent: agent_a, project: project_a} = setup_context()
+      %{tenant: tenant_b, story: story_b, agent: agent_b, project: project_b} = setup_context()
+
+      attrs_a = %{
+        story_id: story_a.id,
+        agent_id: agent_a.id,
+        project_id: project_a.id,
+        input_tokens: 100,
+        output_tokens: 50,
+        model_name: "claude-opus-4",
+        cost_millicents: 100
+      }
+
+      attrs_b = %{
+        story_id: story_b.id,
+        agent_id: agent_b.id,
+        project_id: project_b.id,
+        input_tokens: 200,
+        output_tokens: 100,
+        model_name: "claude-opus-4",
+        cost_millicents: 200
+      }
+
+      {:ok, _} = TokenUsage.create_report(tenant_a.id, attrs_a)
+      {:ok, _} = TokenUsage.create_report(tenant_b.id, attrs_b)
+
+      entries_a = find_audit_entries(tenant_a.id, "token_usage_report", "created")
+      entries_b = find_audit_entries(tenant_b.id, "token_usage_report", "created")
+
+      assert length(entries_a) == 1
+      assert length(entries_b) == 1
+      # Tenant A's entry references tenant A's story
+      assert hd(entries_a).new_state["story_id"] == story_a.id
+      assert hd(entries_b).new_state["story_id"] == story_b.id
+    end
+  end
+
+  # --- AC-21.8.5: Budget mutations are audited ---
+
+  describe "budget mutation audit log (AC-21.8.5)" do
+    test "create_budget/3 emits audit log entry with entity_type='token_budget' and action='created'" do
+      %{tenant: tenant, story: story} = setup_context()
+
+      {:ok, _budget} =
+        TokenUsage.create_budget(tenant.id, %{
+          scope_type: :story,
+          scope_id: story.id,
+          budget_millicents: 500_000
+        })
+
+      entries = find_audit_entries(tenant.id, "token_budget", "created")
+      assert length(entries) == 1
+    end
+
+    test "update_budget/4 emits audit log entry with action='updated'" do
+      %{tenant: tenant, story: story} = setup_context()
+
+      {:ok, budget} =
+        TokenUsage.create_budget(tenant.id, %{
+          scope_type: :story,
+          scope_id: story.id,
+          budget_millicents: 500_000
+        })
+
+      {:ok, _} =
+        TokenUsage.update_budget(tenant.id, budget.id, %{budget_millicents: 750_000})
+
+      entries = find_audit_entries(tenant.id, "token_budget", "updated")
+      assert length(entries) == 1
+    end
+
+    test "delete_budget/3 emits audit log entry with action='deleted'" do
+      %{tenant: tenant, story: story} = setup_context()
+
+      {:ok, budget} =
+        TokenUsage.create_budget(tenant.id, %{
+          scope_type: :story,
+          scope_id: story.id,
+          budget_millicents: 500_000
+        })
+
+      {:ok, _} = TokenUsage.delete_budget(tenant.id, budget.id)
+
+      entries = find_audit_entries(tenant.id, "token_budget", "deleted")
+      assert length(entries) == 1
+    end
+
+    test "resolve_anomaly/3 emits audit log entry with entity_type='cost_anomaly' and action='resolved'" do
+      %{tenant: tenant, story: story} = setup_context()
+
+      anomaly =
+        fixture(:cost_anomaly, %{
+          tenant_id: tenant.id,
+          story_id: story.id,
+          anomaly_type: :high_cost
+        })
+
+      {:ok, _} = TokenUsage.resolve_anomaly(tenant.id, anomaly.id)
+
+      entries = find_audit_entries(tenant.id, "cost_anomaly", "resolved")
+      assert length(entries) == 1
+    end
+  end
+
+  # --- AC-21.8.3: Cost anomaly detection generates change feed entry ---
+
+  describe "CostAnomalyWorker change feed integration (AC-21.8.3, AC-21.8.5)" do
+    defp create_story_with_report(tenant, epic, agent, cost_millicents) do
+      story =
+        fixture(:story, %{
+          tenant_id: tenant.id,
+          epic_id: epic.id,
+          project_id: epic.project_id
+        })
+
+      fixture(:token_usage_report, %{
+        tenant_id: tenant.id,
+        story_id: story.id,
+        agent_id: agent.id,
+        project_id: epic.project_id,
+        cost_millicents: cost_millicents
+      })
+
+      story
+    end
+
+    defp insert_cost_summary(tenant_id, epic_id, period_start, period_end, avg) do
+      %CostSummary{tenant_id: tenant_id}
+      |> CostSummary.changeset(%{
+        scope_type: :epic,
+        scope_id: epic_id,
+        period_start: period_start,
+        period_end: period_end,
+        total_cost_millicents: avg * 4,
+        report_count: 4,
+        avg_cost_per_story_millicents: avg
+      })
+      |> AdminRepo.insert!()
+    end
+
+    test "new anomaly detection emits audit log with entity_type='cost_anomaly' and action='detected'" do
+      %{tenant: tenant, epic: epic, agent: agent} = setup_context()
+      period = Date.utc_today()
+
+      _normal1 = create_story_with_report(tenant, epic, agent, 10_000)
+      _normal2 = create_story_with_report(tenant, epic, agent, 10_000)
+      _normal3 = create_story_with_report(tenant, epic, agent, 10_000)
+      _expensive = create_story_with_report(tenant, epic, agent, 100_000)
+
+      insert_cost_summary(tenant.id, epic.id, period, period, 32_500)
+
+      CostAnomalyWorker.perform(%Oban.Job{
+        args: %{
+          "period_start" => Date.to_iso8601(period),
+          "period_end" => Date.to_iso8601(period)
+        }
+      })
+
+      entries = find_audit_entries(tenant.id, "cost_anomaly", "detected")
+      assert length(entries) == 1
+    end
+
+    test "anomaly detected entry includes anomaly_type and deviation_factor in new_state" do
+      %{tenant: tenant, epic: epic, agent: agent} = setup_context()
+      period = Date.utc_today()
+
+      _normal1 = create_story_with_report(tenant, epic, agent, 10_000)
+      _normal2 = create_story_with_report(tenant, epic, agent, 10_000)
+      _normal3 = create_story_with_report(tenant, epic, agent, 10_000)
+      expensive = create_story_with_report(tenant, epic, agent, 100_000)
+
+      insert_cost_summary(tenant.id, epic.id, period, period, 32_500)
+
+      CostAnomalyWorker.perform(%Oban.Job{
+        args: %{
+          "period_start" => Date.to_iso8601(period),
+          "period_end" => Date.to_iso8601(period)
+        }
+      })
+
+      [entry] = find_audit_entries(tenant.id, "cost_anomaly", "detected")
+
+      assert entry.new_state["anomaly_type"] == "high_cost"
+      assert entry.new_state["story_id"] == expensive.id
+      assert entry.new_state["story_cost_millicents"] == 100_000
+      assert entry.new_state["reference_avg_millicents"] == 32_500
+      assert entry.new_state["deviation_factor"] != nil
+    end
+
+    test "anomaly detected entry includes metadata with anomaly_id and story_id" do
+      %{tenant: tenant, epic: epic, agent: agent} = setup_context()
+      period = Date.utc_today()
+
+      _normal1 = create_story_with_report(tenant, epic, agent, 10_000)
+      _normal2 = create_story_with_report(tenant, epic, agent, 10_000)
+      _normal3 = create_story_with_report(tenant, epic, agent, 10_000)
+      expensive = create_story_with_report(tenant, epic, agent, 100_000)
+
+      insert_cost_summary(tenant.id, epic.id, period, period, 32_500)
+
+      CostAnomalyWorker.perform(%Oban.Job{
+        args: %{
+          "period_start" => Date.to_iso8601(period),
+          "period_end" => Date.to_iso8601(period)
+        }
+      })
+
+      [entry] = find_audit_entries(tenant.id, "cost_anomaly", "detected")
+
+      assert entry.metadata["anomaly_id"] != nil
+      assert entry.metadata["story_id"] == expensive.id
+      assert entry.metadata["anomaly_type"] == "high_cost"
+    end
+
+    test "updating existing anomaly does NOT emit a new detected entry" do
+      %{tenant: tenant, epic: epic, agent: agent, story: story} = setup_context()
+      period = Date.utc_today()
+
+      # Pre-create an existing unresolved anomaly
+      fixture(:cost_anomaly, %{
+        tenant_id: tenant.id,
+        story_id: story.id,
+        anomaly_type: :high_cost,
+        story_cost_millicents: 80_000,
+        reference_avg_millicents: 20_000,
+        deviation_factor: Decimal.new("4.0")
+      })
+
+      # The existing anomaly story's cost now appears in reports
+      fixture(:token_usage_report, %{
+        tenant_id: tenant.id,
+        story_id: story.id,
+        agent_id: agent.id,
+        project_id: epic.project_id,
+        cost_millicents: 100_000
+      })
+
+      insert_cost_summary(tenant.id, epic.id, period, period, 25_000)
+
+      CostAnomalyWorker.perform(%Oban.Job{
+        args: %{
+          "period_start" => Date.to_iso8601(period),
+          "period_end" => Date.to_iso8601(period)
+        }
+      })
+
+      # No new "detected" entries since the anomaly was updated, not created
+      entries = find_audit_entries(tenant.id, "cost_anomaly", "detected")
+      assert entries == []
+    end
+
+    test "tenant isolation: anomaly detection only emits entries for its own tenant" do
+      %{tenant: tenant_a, epic: epic_a, agent: agent_a} = setup_context()
+      %{tenant: tenant_b} = setup_context()
+      period = Date.utc_today()
+
+      _normal1 = create_story_with_report(tenant_a, epic_a, agent_a, 10_000)
+      _normal2 = create_story_with_report(tenant_a, epic_a, agent_a, 10_000)
+      _normal3 = create_story_with_report(tenant_a, epic_a, agent_a, 10_000)
+      _expensive = create_story_with_report(tenant_a, epic_a, agent_a, 100_000)
+
+      insert_cost_summary(tenant_a.id, epic_a.id, period, period, 32_500)
+
+      CostAnomalyWorker.perform(%Oban.Job{
+        args: %{
+          "period_start" => Date.to_iso8601(period),
+          "period_end" => Date.to_iso8601(period)
+        }
+      })
+
+      entries_a = find_audit_entries(tenant_a.id, "cost_anomaly", "detected")
+      entries_b = find_audit_entries(tenant_b.id, "cost_anomaly", "detected")
+
+      assert length(entries_a) == 1
+      assert entries_b == []
+    end
+  end
+
+  # --- AC-21.8.4: Change feed entity_type filter accepts token event types ---
+
+  describe "change feed entity_type filter (AC-21.8.4)" do
+    test "list_changes/3 filters by entity_type='token_usage_report'" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+      since = DateTime.add(DateTime.utc_now(), -60)
+
+      # Create a token usage report (emits audit log)
+      TokenUsage.create_report(tenant.id, %{
+        story_id: story.id,
+        agent_id: agent.id,
+        project_id: project.id,
+        input_tokens: 100,
+        output_tokens: 50,
+        model_name: "claude-opus-4",
+        cost_millicents: 200
+      })
+
+      # Create a non-token audit entry
+      Audit.create_log_entry(tenant.id, %{
+        entity_type: "story",
+        entity_id: story.id,
+        action: "status_changed",
+        actor_type: "api_key",
+        new_state: %{}
+      })
+
+      {:ok, result} =
+        Audit.list_changes(tenant.id, since, entity_type: "token_usage_report")
+
+      assert length(result.data) == 1
+      assert hd(result.data).entity_type == "token_usage_report"
+    end
+
+    test "list_changes/3 filters by entity_type='token_budget'" do
+      %{tenant: tenant, story: story} = setup_context()
+      since = DateTime.add(DateTime.utc_now(), -60)
+
+      TokenUsage.create_budget(tenant.id, %{
+        scope_type: :story,
+        scope_id: story.id,
+        budget_millicents: 500_000
+      })
+
+      # Add a non-budget entry
+      Audit.create_log_entry(tenant.id, %{
+        entity_type: "story",
+        entity_id: story.id,
+        action: "created",
+        actor_type: "api_key",
+        new_state: %{}
+      })
+
+      {:ok, result} =
+        Audit.list_changes(tenant.id, since, entity_type: "token_budget")
+
+      assert length(result.data) == 1
+      assert hd(result.data).entity_type == "token_budget"
+    end
+
+    test "list_changes/3 filters by entity_type='cost_anomaly'" do
+      %{tenant: tenant, story: story} = setup_context()
+      since = DateTime.add(DateTime.utc_now(), -60)
+
+      # Insert an anomaly resolution to emit a cost_anomaly audit entry
+      anomaly =
+        fixture(:cost_anomaly, %{
+          tenant_id: tenant.id,
+          story_id: story.id
+        })
+
+      TokenUsage.resolve_anomaly(tenant.id, anomaly.id)
+
+      {:ok, result} =
+        Audit.list_changes(tenant.id, since, entity_type: "cost_anomaly")
+
+      assert length(result.data) == 1
+      assert hd(result.data).entity_type == "cost_anomaly"
+    end
+
+    test "list_changes/3 returns token events interleaved chronologically" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+      since = DateTime.add(DateTime.utc_now(), -60)
+
+      # Interleave token and non-token events
+      Audit.create_log_entry(tenant.id, %{
+        entity_type: "story",
+        entity_id: story.id,
+        action: "created",
+        actor_type: "api_key",
+        actor_label: "step:1",
+        new_state: %{}
+      })
+
+      TokenUsage.create_report(tenant.id, %{
+        story_id: story.id,
+        agent_id: agent.id,
+        project_id: project.id,
+        input_tokens: 100,
+        output_tokens: 50,
+        model_name: "claude-opus-4",
+        cost_millicents: 200
+      })
+
+      Audit.create_log_entry(tenant.id, %{
+        entity_type: "story",
+        entity_id: story.id,
+        action: "status_changed",
+        actor_type: "api_key",
+        actor_label: "step:3",
+        new_state: %{}
+      })
+
+      {:ok, result} = Audit.list_changes(tenant.id, since)
+
+      # Should include all 3 entries in ascending time order
+      assert length(result.data) >= 3
+      entity_types = Enum.map(result.data, & &1.entity_type)
+      assert "token_usage_report" in entity_types
+      assert "story" in entity_types
+    end
+  end
+
+  # --- AC-21.8.6: Story history includes token usage events ---
+
+  describe "story history token usage integration (AC-21.8.6)" do
+    test "entity_history/4 for a story includes related token_usage_report audit entries" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+
+      # Create a story audit entry
+      Audit.create_log_entry(tenant.id, %{
+        entity_type: "story",
+        entity_id: story.id,
+        action: "status_changed",
+        actor_type: "api_key",
+        new_state: %{"agent_status" => "implementing"}
+      })
+
+      # Create a token usage report for this story (which emits audit log with story_id in metadata)
+      TokenUsage.create_report(tenant.id, %{
+        story_id: story.id,
+        agent_id: agent.id,
+        project_id: project.id,
+        input_tokens: 1000,
+        output_tokens: 500,
+        model_name: "claude-opus-4",
+        cost_millicents: 2500
+      })
+
+      {:ok, result} = Audit.entity_history(tenant.id, "story", story.id)
+
+      # Should include both the direct story entry and the token_usage_report entry
+      assert result.total == 2
+      entity_types = Enum.map(result.data, & &1.entity_type)
+      assert "story" in entity_types
+      assert "token_usage_report" in entity_types
+    end
+
+    test "entity_history/4 orders entries chronologically ascending" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+
+      Audit.create_log_entry(tenant.id, %{
+        entity_type: "story",
+        entity_id: story.id,
+        action: "created",
+        actor_type: "api_key",
+        new_state: %{}
+      })
+
+      TokenUsage.create_report(tenant.id, %{
+        story_id: story.id,
+        agent_id: agent.id,
+        project_id: project.id,
+        input_tokens: 500,
+        output_tokens: 200,
+        model_name: "claude-opus-4",
+        cost_millicents: 1000
+      })
+
+      {:ok, result} = Audit.entity_history(tenant.id, "story", story.id)
+
+      assert result.total == 2
+      timestamps = Enum.map(result.data, & &1.inserted_at)
+      assert timestamps == Enum.sort(timestamps, {:asc, DateTime})
+    end
+
+    test "entity_history/4 for non-story entity types does NOT include token entries" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+      project_id = project.id
+
+      # Create a project audit entry
+      Audit.create_log_entry(tenant.id, %{
+        entity_type: "project",
+        entity_id: project_id,
+        action: "created",
+        actor_type: "api_key",
+        new_state: %{}
+      })
+
+      # Create a token usage report for a story in this project
+      TokenUsage.create_report(tenant.id, %{
+        story_id: story.id,
+        agent_id: agent.id,
+        project_id: project.id,
+        input_tokens: 100,
+        output_tokens: 50,
+        model_name: "claude-opus-4",
+        cost_millicents: 200
+      })
+
+      {:ok, result} = Audit.entity_history(tenant.id, "project", project_id)
+
+      # Only the direct project entry is returned, not the token entry
+      assert result.total == 1
+      assert hd(result.data).entity_type == "project"
+    end
+
+    test "entity_history/4 does not include token entries for other stories" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+
+      other_story = fixture(:story, %{tenant_id: tenant.id, epic_id: story.epic_id})
+
+      # Story audit entry for the target story
+      Audit.create_log_entry(tenant.id, %{
+        entity_type: "story",
+        entity_id: story.id,
+        action: "created",
+        actor_type: "api_key",
+        new_state: %{}
+      })
+
+      # Token usage report for a DIFFERENT story
+      TokenUsage.create_report(tenant.id, %{
+        story_id: other_story.id,
+        agent_id: agent.id,
+        project_id: project.id,
+        input_tokens: 100,
+        output_tokens: 50,
+        model_name: "claude-opus-4",
+        cost_millicents: 200
+      })
+
+      {:ok, result} = Audit.entity_history(tenant.id, "story", story.id)
+
+      # Only the direct story entry — no token entries from the other story
+      assert result.total == 1
+      assert hd(result.data).entity_type == "story"
+    end
+
+    test "entity_history/4 tenant isolation: does not include other tenant's token entries" do
+      %{tenant: tenant_a, story: story_a, agent: agent_a, project: project_a} = setup_context()
+      %{tenant: tenant_b, story: story_b, agent: agent_b, project: project_b} = setup_context()
+
+      # Story audit entry for tenant A
+      Audit.create_log_entry(tenant_a.id, %{
+        entity_type: "story",
+        entity_id: story_a.id,
+        action: "created",
+        actor_type: "api_key",
+        new_state: %{}
+      })
+
+      # Token usage report for tenant A's story
+      TokenUsage.create_report(tenant_a.id, %{
+        story_id: story_a.id,
+        agent_id: agent_a.id,
+        project_id: project_a.id,
+        input_tokens: 100,
+        output_tokens: 50,
+        model_name: "claude-opus-4",
+        cost_millicents: 200
+      })
+
+      # Token usage report for tenant B's story (same story UUID won't match but different tenant)
+      TokenUsage.create_report(tenant_b.id, %{
+        story_id: story_b.id,
+        agent_id: agent_b.id,
+        project_id: project_b.id,
+        input_tokens: 300,
+        output_tokens: 100,
+        model_name: "claude-opus-4",
+        cost_millicents: 500
+      })
+
+      {:ok, result_a} = Audit.entity_history(tenant_a.id, "story", story_a.id)
+      {:ok, result_b} = Audit.entity_history(tenant_b.id, "story", story_b.id)
+
+      # Tenant A sees 1 story entry + 1 token entry = 2
+      assert result_a.total == 2
+      # Tenant B sees only their own token entry (no story-type audit entry created)
+      assert result_b.total == 1
+      assert hd(result_b.data).entity_type == "token_usage_report"
+    end
+
+    test "multiple token reports for same story appear in story history" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+
+      Audit.create_log_entry(tenant.id, %{
+        entity_type: "story",
+        entity_id: story.id,
+        action: "created",
+        actor_type: "api_key",
+        new_state: %{}
+      })
+
+      for _i <- 1..3 do
+        TokenUsage.create_report(tenant.id, %{
+          story_id: story.id,
+          agent_id: agent.id,
+          project_id: project.id,
+          input_tokens: 100,
+          output_tokens: 50,
+          model_name: "claude-opus-4",
+          cost_millicents: 200
+        })
+      end
+
+      {:ok, result} = Audit.entity_history(tenant.id, "story", story.id)
+
+      # 1 story entry + 3 token entries = 4
+      assert result.total == 4
+    end
+  end
+end

--- a/test/loopctl/token_usage_change_feed_test.exs
+++ b/test/loopctl/token_usage_change_feed_test.exs
@@ -154,6 +154,230 @@ defmodule Loopctl.TokenUsageChangeFeedTest do
     end
   end
 
+  # --- AC-21.8.2: Budget threshold crossings generate change feed entries ---
+
+  describe "budget threshold crossing change feed (AC-21.8.2)" do
+    test "emits threshold_crossed with threshold_type='warning' when spend crosses alert_threshold_pct" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+
+      # Create a budget with alert_threshold_pct=80 and budget of 10,000 millicents
+      {:ok, budget} =
+        TokenUsage.create_budget(tenant.id, %{
+          scope_type: :story,
+          scope_id: story.id,
+          budget_millicents: 10_000,
+          alert_threshold_pct: 80
+        })
+
+      # Create a report that pushes spend to 85% (8,500 out of 10,000)
+      {:ok, _report} =
+        TokenUsage.create_report(tenant.id, %{
+          story_id: story.id,
+          agent_id: agent.id,
+          project_id: project.id,
+          input_tokens: 1000,
+          output_tokens: 500,
+          model_name: "claude-opus-4",
+          cost_millicents: 8_500
+        })
+
+      entries = find_audit_entries(tenant.id, "token_budget", "threshold_crossed")
+      assert length(entries) == 1
+
+      [entry] = entries
+      assert entry.new_state["budget_id"] == budget.id
+      assert entry.new_state["scope_type"] == "story"
+      assert entry.new_state["scope_id"] == story.id
+      assert entry.new_state["threshold_type"] == "warning"
+      assert entry.new_state["utilization_pct"] >= 80
+    end
+
+    test "emits threshold_crossed with threshold_type='exceeded' when spend crosses 100%" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+
+      {:ok, _budget} =
+        TokenUsage.create_budget(tenant.id, %{
+          scope_type: :story,
+          scope_id: story.id,
+          budget_millicents: 5_000,
+          alert_threshold_pct: 80
+        })
+
+      # Create a report that pushes spend above 100% (6,000 out of 5,000)
+      {:ok, _report} =
+        TokenUsage.create_report(tenant.id, %{
+          story_id: story.id,
+          agent_id: agent.id,
+          project_id: project.id,
+          input_tokens: 1000,
+          output_tokens: 500,
+          model_name: "claude-opus-4",
+          cost_millicents: 6_000
+        })
+
+      entries = find_audit_entries(tenant.id, "token_budget", "threshold_crossed")
+      assert length(entries) == 1
+
+      [entry] = entries
+      assert entry.new_state["threshold_type"] == "exceeded"
+      assert entry.new_state["utilization_pct"] >= 100
+    end
+
+    test "does NOT emit threshold_crossed when spend is below alert_threshold_pct" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+
+      {:ok, _budget} =
+        TokenUsage.create_budget(tenant.id, %{
+          scope_type: :story,
+          scope_id: story.id,
+          budget_millicents: 100_000,
+          alert_threshold_pct: 80
+        })
+
+      # Spend only 10% of budget
+      {:ok, _report} =
+        TokenUsage.create_report(tenant.id, %{
+          story_id: story.id,
+          agent_id: agent.id,
+          project_id: project.id,
+          input_tokens: 100,
+          output_tokens: 50,
+          model_name: "claude-opus-4",
+          cost_millicents: 10_000
+        })
+
+      entries = find_audit_entries(tenant.id, "token_budget", "threshold_crossed")
+      assert entries == []
+    end
+
+    test "checks project-level budget threshold" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+
+      {:ok, _budget} =
+        TokenUsage.create_budget(tenant.id, %{
+          scope_type: :project,
+          scope_id: project.id,
+          budget_millicents: 10_000,
+          alert_threshold_pct: 80
+        })
+
+      # Push project spend to 90%
+      {:ok, _report} =
+        TokenUsage.create_report(tenant.id, %{
+          story_id: story.id,
+          agent_id: agent.id,
+          project_id: project.id,
+          input_tokens: 1000,
+          output_tokens: 500,
+          model_name: "claude-opus-4",
+          cost_millicents: 9_000
+        })
+
+      entries = find_audit_entries(tenant.id, "token_budget", "threshold_crossed")
+      assert length(entries) == 1
+      assert hd(entries).new_state["scope_type"] == "project"
+    end
+
+    test "checks epic-level budget threshold" do
+      %{tenant: tenant, story: story, agent: agent, project: project, epic: epic} =
+        setup_context()
+
+      {:ok, _budget} =
+        TokenUsage.create_budget(tenant.id, %{
+          scope_type: :epic,
+          scope_id: epic.id,
+          budget_millicents: 10_000,
+          alert_threshold_pct: 80
+        })
+
+      # Push epic spend to 90%
+      {:ok, _report} =
+        TokenUsage.create_report(tenant.id, %{
+          story_id: story.id,
+          agent_id: agent.id,
+          project_id: project.id,
+          input_tokens: 1000,
+          output_tokens: 500,
+          model_name: "claude-opus-4",
+          cost_millicents: 9_000
+        })
+
+      entries = find_audit_entries(tenant.id, "token_budget", "threshold_crossed")
+      assert length(entries) == 1
+      assert hd(entries).new_state["scope_type"] == "epic"
+    end
+
+    test "emits threshold_crossed for multiple budgets when applicable" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+
+      # Create both story and project budgets
+      {:ok, _story_budget} =
+        TokenUsage.create_budget(tenant.id, %{
+          scope_type: :story,
+          scope_id: story.id,
+          budget_millicents: 5_000,
+          alert_threshold_pct: 80
+        })
+
+      {:ok, _project_budget} =
+        TokenUsage.create_budget(tenant.id, %{
+          scope_type: :project,
+          scope_id: project.id,
+          budget_millicents: 8_000,
+          alert_threshold_pct: 80
+        })
+
+      # Push both over threshold
+      {:ok, _report} =
+        TokenUsage.create_report(tenant.id, %{
+          story_id: story.id,
+          agent_id: agent.id,
+          project_id: project.id,
+          input_tokens: 1000,
+          output_tokens: 500,
+          model_name: "claude-opus-4",
+          cost_millicents: 7_000
+        })
+
+      entries = find_audit_entries(tenant.id, "token_budget", "threshold_crossed")
+      # Both budgets should be crossed (7000/5000 > 100%, 7000/8000 > 80%)
+      assert length(entries) == 2
+
+      scope_types = Enum.map(entries, & &1.new_state["scope_type"]) |> Enum.sort()
+      assert scope_types == ["project", "story"]
+    end
+
+    test "threshold_crossed entry includes metadata with budget_id and scope_id" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+
+      {:ok, budget} =
+        TokenUsage.create_budget(tenant.id, %{
+          scope_type: :story,
+          scope_id: story.id,
+          budget_millicents: 5_000,
+          alert_threshold_pct: 80
+        })
+
+      {:ok, _report} =
+        TokenUsage.create_report(tenant.id, %{
+          story_id: story.id,
+          agent_id: agent.id,
+          project_id: project.id,
+          input_tokens: 1000,
+          output_tokens: 500,
+          model_name: "claude-opus-4",
+          cost_millicents: 5_500
+        })
+
+      [entry] = find_audit_entries(tenant.id, "token_budget", "threshold_crossed")
+
+      assert entry.metadata["budget_id"] == budget.id
+      assert entry.metadata["scope_type"] == "story"
+      assert entry.metadata["scope_id"] == story.id
+      assert entry.metadata["threshold_type"] == "exceeded"
+    end
+  end
+
   # --- AC-21.8.5: Budget mutations are audited ---
 
   describe "budget mutation audit log (AC-21.8.5)" do

--- a/test/loopctl/token_usage_test.exs
+++ b/test/loopctl/token_usage_test.exs
@@ -243,8 +243,11 @@ defmodule Loopctl.TokenUsageTest do
       audit = hd(result.data)
       assert audit.entity_type == "token_usage_report"
       assert audit.action == "created"
-      assert audit.new_state["input_tokens"] == 1000
+
+      # AC-21.8.1: new_state contains story_id, agent_id, model_name, cost_millicents, total_tokens
       assert audit.new_state["model_name"] == "claude-opus-4"
+      assert audit.new_state["total_tokens"] == 1500
+      assert audit.new_state["cost_millicents"] == 2500
     end
 
     test "accepts string keys in attrs" do


### PR DESCRIPTION
## Summary

- Integrates token usage events into the change feed and audit log per AC-21.8.1–21.8.6
- Extends `Audit.entity_history/4` to include related `token_usage_report` audit entries in story history timelines
- Adds change feed emission in `CostAnomalyWorker` when new anomalies are detected

## Changes

**`lib/loopctl/audit.ex`**
- `entity_history/4` now queries both direct `entity_type='story'` entries AND `token_usage_report` entries where `metadata->>'story_id' = story_id`, interleaved chronologically (AC-21.8.6)
- Extracted `build_entity_history_query/3` private helper for clean separation

**`lib/loopctl/token_usage.ex`**
- `create_report/2` audit entry `new_state` updated to include `story_id`, `agent_id`, `model_name`, `cost_millicents`, `total_tokens` (AC-21.8.1)
- Audit entry `metadata` now includes `story_id`, `agent_id`, `model_name`, `cost_millicents`, `total_tokens` to enable story history cross-entity lookup
- `project_id` added to the audit entry for change feed filtering

**`lib/loopctl/workers/cost_anomaly_worker.ex`**
- `create_anomaly/6` now calls `Audit.create_log_entry/2` when a new anomaly is inserted (not when updating existing), emitting `entity_type='cost_anomaly'`, `action='detected'`, `actor_type='system'` (AC-21.8.3, AC-21.8.5)

## Test plan

- [ ] 23 new tests in `test/loopctl/token_usage_change_feed_test.exs` covering:
  - AC-21.8.1: Token report creation emits change feed entry with correct payload
  - AC-21.8.3: Anomaly detection emits change feed entry
  - AC-21.8.4: Change feed `entity_type` filter works for all three token entity types
  - AC-21.8.5: Budget create/update/delete and anomaly resolution are all audited
  - AC-21.8.6: Story history includes token usage events interleaved chronologically
  - Tenant isolation tests for all new paths
- [ ] All 127 previously related tests still pass
- [ ] Full precommit gate passes (compile, format, credo --strict, dialyzer, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)