### PR TITLE
US-21.6: Skill Performance Cost Extension

### DIFF
--- a/lib/loopctl/skills.ex
+++ b/lib/loopctl/skills.ex
@@ -632,6 +632,60 @@ defmodule Loopctl.Skills do
     }
   end
 
+  # ===================================================================
+  # Skill Cost Performance (US-21.6)
+  # ===================================================================
+
+  @doc """
+  Returns cost performance metrics per version for a skill.
+
+  Requires token_usage_reports to have skill_version_id set. Versions
+  without any linked token usage reports are not included.
+
+  ## Metrics per version
+
+  - `version_number` -- integer version number
+  - `total_invocations` -- number of token usage reports linked to this version
+  - `total_cost_millicents` -- sum of cost_millicents
+  - `avg_cost_per_invocation_millicents` -- average cost per report (rounded integer)
+  - `stories_verified_count` -- distinct stories where verified_status = verified
+  - `stories_rejected_count` -- distinct stories where verified_status = rejected
+  - `verification_rate_pct` -- stories_verified / (stories_verified + stories_rejected) * 100
+  - `cost_change_pct` -- pct change vs previous version's avg_cost (nil for v1)
+  - `cost_regression` -- true when avg_cost > 2x previous version AND >= 3 invocations
+
+  ## Returns
+
+  - `{:ok, [map()]}` on success
+  - `{:error, :not_found}` if skill not found
+  """
+  @spec cost_performance(Ecto.UUID.t(), Ecto.UUID.t()) ::
+          {:ok, [map()]} | {:error, :not_found}
+  def cost_performance(tenant_id, skill_id) do
+    with {:ok, _skill} <- get_skill(tenant_id, skill_id) do
+      rows = query_cost_performance(tenant_id, skill_id)
+      {:ok, enrich_with_comparison(rows)}
+    end
+  end
+
+  @doc """
+  Returns a cost summary for a specific skill version.
+
+  Returns `nil` when no token usage reports are linked to this version.
+
+  ## Returns
+
+  - `{:ok, map() | nil}` on success
+  - `{:error, :not_found}` if skill or version not found
+  """
+  @spec version_cost_summary(Ecto.UUID.t(), Ecto.UUID.t(), integer()) ::
+          {:ok, map() | nil} | {:error, :not_found}
+  def version_cost_summary(tenant_id, skill_id, version_number) do
+    with {:ok, version} <- get_version(tenant_id, skill_id, version_number) do
+      query_version_cost_summary(tenant_id, version.id, version_number)
+    end
+  end
+
   # --- Private helpers ---
 
   defp lock_skill_for_update(skill_id) do
@@ -672,4 +726,121 @@ defmodule Loopctl.Skills do
     like_pattern = "%#{pattern}%"
     where(query, [s], ilike(s.name, ^like_pattern))
   end
+
+  # --- Cost performance private helpers ---
+
+  defp query_cost_performance(tenant_id, skill_id) do
+    alias Loopctl.TokenUsage.Report
+    alias Loopctl.WorkBreakdown.Story
+
+    Report
+    |> join(:inner, [r], sv in SkillVersion, on: r.skill_version_id == sv.id)
+    |> join(:left, [r, _sv], s in Story, on: r.story_id == s.id)
+    |> where([r, sv, _s], sv.skill_id == ^skill_id and r.tenant_id == ^tenant_id)
+    |> group_by([_r, sv, _s], sv.version)
+    |> select([r, sv, s], %{
+      version_number: sv.version,
+      total_invocations: count(r.id),
+      total_cost_millicents: coalesce(sum(r.cost_millicents), 0),
+      avg_cost_per_invocation_millicents:
+        fragment("ROUND(AVG(?)::numeric, 0)::bigint", r.cost_millicents),
+      stories_verified_count:
+        fragment(
+          "count(DISTINCT CASE WHEN ? = 'verified' THEN ? END)",
+          s.verified_status,
+          s.id
+        ),
+      stories_rejected_count:
+        fragment(
+          "count(DISTINCT CASE WHEN ? = 'rejected' THEN ? END)",
+          s.verified_status,
+          s.id
+        )
+    })
+    |> order_by([_r, sv, _s], asc: sv.version)
+    |> AdminRepo.all()
+    |> Enum.map(fn row ->
+      verified = row.stories_verified_count
+      rejected = row.stories_rejected_count
+      total_verifiable = verified + rejected
+
+      verification_rate_pct =
+        if total_verifiable > 0,
+          do: round(verified * 100 / total_verifiable),
+          else: nil
+
+      %{
+        version_number: row.version_number,
+        total_invocations: row.total_invocations,
+        total_cost_millicents: decimal_to_int(row.total_cost_millicents),
+        avg_cost_per_invocation_millicents:
+          decimal_to_int(row.avg_cost_per_invocation_millicents),
+        stories_verified_count: row.stories_verified_count,
+        stories_rejected_count: row.stories_rejected_count,
+        verification_rate_pct: verification_rate_pct,
+        cost_change_pct: nil,
+        cost_regression: false
+      }
+    end)
+  end
+
+  defp enrich_with_comparison([]), do: []
+
+  defp enrich_with_comparison(rows) do
+    rows
+    |> Enum.with_index()
+    |> Enum.map(fn {row, idx} ->
+      prev = if idx > 0, do: Enum.at(rows, idx - 1), else: nil
+
+      {cost_change_pct, cost_regression} =
+        cond do
+          is_nil(prev) ->
+            {nil, false}
+
+          prev.avg_cost_per_invocation_millicents == 0 ->
+            {nil, false}
+
+          true ->
+            curr_avg = row.avg_cost_per_invocation_millicents
+            prev_avg = prev.avg_cost_per_invocation_millicents
+            change_pct = round((curr_avg - prev_avg) * 100 / prev_avg)
+            regression = curr_avg > 2 * prev_avg and row.total_invocations >= 3
+            {change_pct, regression}
+        end
+
+      %{row | cost_change_pct: cost_change_pct, cost_regression: cost_regression}
+    end)
+  end
+
+  defp query_version_cost_summary(tenant_id, skill_version_id, version_number) do
+    alias Loopctl.TokenUsage.Report
+
+    result =
+      Report
+      |> where([r], r.tenant_id == ^tenant_id and r.skill_version_id == ^skill_version_id)
+      |> select([r], %{
+        total_invocations: count(r.id),
+        total_cost_millicents: coalesce(sum(r.cost_millicents), 0),
+        avg_cost_per_invocation_millicents:
+          fragment("ROUND(AVG(?)::numeric, 0)::bigint", r.cost_millicents)
+      })
+      |> AdminRepo.one()
+
+    if result.total_invocations == 0 do
+      {:ok, nil}
+    else
+      {:ok,
+       %{
+         version_number: version_number,
+         total_invocations: result.total_invocations,
+         total_cost_millicents: decimal_to_int(result.total_cost_millicents),
+         avg_cost_per_invocation_millicents:
+           decimal_to_int(result.avg_cost_per_invocation_millicents)
+       }}
+    end
+  end
+
+  defp decimal_to_int(%Decimal{} = val), do: Decimal.to_integer(val)
+  defp decimal_to_int(val) when is_integer(val), do: val
+  defp decimal_to_int(nil), do: 0
 end

--- a/lib/loopctl/token_usage.ex
+++ b/lib/loopctl/token_usage.ex
@@ -36,6 +36,8 @@ defmodule Loopctl.TokenUsage do
   alias Loopctl.AdminRepo
   alias Loopctl.Audit
   alias Loopctl.Projects.Project
+  alias Loopctl.Skills.Skill
+  alias Loopctl.Skills.SkillVersion
   alias Loopctl.Tenants.Tenant
   alias Loopctl.TokenUsage.Budget
   alias Loopctl.TokenUsage.CostAnomaly
@@ -66,60 +68,65 @@ defmodule Loopctl.TokenUsage do
   - `{:error, %Ecto.Changeset{}}` on validation failure
   """
   @spec create_report(Ecto.UUID.t(), map(), keyword()) ::
-          {:ok, Report.t()} | {:error, Ecto.Changeset.t()}
+          {:ok, Report.t()}
+          | {:error, Ecto.Changeset.t()}
+          | {:error, :unprocessable_entity, String.t()}
   def create_report(tenant_id, attrs, opts \\ []) do
     attrs = normalize_attrs(attrs)
 
     story_id = Map.get(attrs, :story_id)
     agent_id = Map.get(attrs, :agent_id)
     project_id = Map.get(attrs, :project_id)
+    skill_version_id = Map.get(attrs, :skill_version_id)
 
-    changeset =
-      %Report{
-        tenant_id: tenant_id,
-        story_id: story_id,
-        agent_id: agent_id,
-        project_id: project_id
-      }
-      |> Report.create_changeset(attrs)
+    with :ok <- validate_skill_version_ownership(tenant_id, skill_version_id) do
+      changeset =
+        %Report{
+          tenant_id: tenant_id,
+          story_id: story_id,
+          agent_id: agent_id,
+          project_id: project_id
+        }
+        |> Report.create_changeset(attrs)
 
-    case AdminRepo.insert(changeset) do
-      {:ok, report} ->
-        # Refetch to populate the DB-generated total_tokens column
-        report = AdminRepo.get!(Report, report.id)
+      case AdminRepo.insert(changeset) do
+        {:ok, report} ->
+          # Refetch to populate the DB-generated total_tokens column
+          report = AdminRepo.get!(Report, report.id)
 
-        # Audit log the creation (also serves as the change feed entry for AC-21.8.1)
-        Audit.create_log_entry(tenant_id, %{
-          entity_type: "token_usage_report",
-          entity_id: report.id,
-          action: "created",
-          actor_type: Keyword.get(opts, :actor_type, "api_key"),
-          actor_id: Keyword.get(opts, :actor_id),
-          actor_label: Keyword.get(opts, :actor_label),
-          project_id: report.project_id,
-          new_state: %{
-            "story_id" => report.story_id,
-            "agent_id" => report.agent_id,
-            "model_name" => report.model_name,
-            "cost_millicents" => report.cost_millicents,
-            "total_tokens" => report.total_tokens
-          },
-          metadata: %{
-            "story_id" => report.story_id,
-            "agent_id" => report.agent_id,
-            "model_name" => report.model_name,
-            "cost_millicents" => report.cost_millicents,
-            "total_tokens" => report.total_tokens
-          }
-        })
+          # Audit log the creation (also serves as the change feed entry for AC-21.8.1)
+          Audit.create_log_entry(tenant_id, %{
+            entity_type: "token_usage_report",
+            entity_id: report.id,
+            action: "created",
+            actor_type: Keyword.get(opts, :actor_type, "api_key"),
+            actor_id: Keyword.get(opts, :actor_id),
+            actor_label: Keyword.get(opts, :actor_label),
+            project_id: report.project_id,
+            new_state: %{
+              "story_id" => report.story_id,
+              "agent_id" => report.agent_id,
+              "model_name" => report.model_name,
+              "cost_millicents" => report.cost_millicents,
+              "total_tokens" => report.total_tokens
+            },
+            metadata: %{
+              "story_id" => report.story_id,
+              "agent_id" => report.agent_id,
+              "model_name" => report.model_name,
+              "cost_millicents" => report.cost_millicents,
+              "total_tokens" => report.total_tokens
+            }
+          })
 
-        # Check budget thresholds after report creation (AC-21.8.2)
-        check_budget_thresholds(tenant_id, report)
+          # Check budget thresholds after report creation (AC-21.8.2)
+          check_budget_thresholds(tenant_id, report)
 
-        {:ok, report}
+          {:ok, report}
 
-      {:error, changeset} ->
-        {:error, changeset}
+        {:error, changeset} ->
+          {:error, changeset}
+      end
     end
   end
 
@@ -620,6 +627,27 @@ defmodule Loopctl.TokenUsage do
   end
 
   # --- Private helpers ---
+
+  # Validates that skill_version_id (if provided) exists and belongs to the tenant.
+  # The ownership chain is: skill_versions -> skills -> tenant_id.
+  @spec validate_skill_version_ownership(Ecto.UUID.t(), Ecto.UUID.t() | nil) ::
+          :ok | {:error, :unprocessable_entity, String.t()}
+  defp validate_skill_version_ownership(_tenant_id, nil), do: :ok
+
+  defp validate_skill_version_ownership(tenant_id, skill_version_id) do
+    exists =
+      SkillVersion
+      |> join(:inner, [sv], s in Skill, on: sv.skill_id == s.id)
+      |> where([sv, s], sv.id == ^skill_version_id and s.tenant_id == ^tenant_id)
+      |> AdminRepo.exists?()
+
+    if exists do
+      :ok
+    else
+      {:error, :unprocessable_entity,
+       "skill_version_id does not exist or belongs to a different tenant"}
+    end
+  end
 
   @known_attrs ~w(
     story_id agent_id project_id skill_version_id

--- a/lib/loopctl/token_usage.ex
+++ b/lib/loopctl/token_usage.ex
@@ -108,14 +108,16 @@ defmodule Loopctl.TokenUsage do
               "agent_id" => report.agent_id,
               "model_name" => report.model_name,
               "cost_millicents" => report.cost_millicents,
-              "total_tokens" => report.total_tokens
+              "total_tokens" => report.total_tokens,
+              "skill_version_id" => report.skill_version_id
             },
             metadata: %{
               "story_id" => report.story_id,
               "agent_id" => report.agent_id,
               "model_name" => report.model_name,
               "cost_millicents" => report.cost_millicents,
-              "total_tokens" => report.total_tokens
+              "total_tokens" => report.total_tokens,
+              "skill_version_id" => report.skill_version_id
             }
           })
 

--- a/lib/loopctl_web/controllers/skill_controller.ex
+++ b/lib/loopctl_web/controllers/skill_controller.ex
@@ -10,6 +10,7 @@ defmodule LoopctlWeb.SkillController do
   - `POST /api/v1/skills/:id/versions` -- create new version (user role)
   - `GET /api/v1/skills/:id/versions` -- list versions (agent+ role)
   - `GET /api/v1/skills/:id/versions/:version` -- get specific version (agent+ role)
+  - `GET /api/v1/skills/:id/cost-performance` -- cost metrics per version (user role)
   """
 
   use LoopctlWeb, :controller
@@ -22,7 +23,15 @@ defmodule LoopctlWeb.SkillController do
   action_fallback LoopctlWeb.FallbackController
 
   plug LoopctlWeb.Plugs.RequireRole,
-       [role: :user] when action in [:create, :update, :delete, :create_version, :import_skills]
+       [role: :user]
+       when action in [
+              :create,
+              :update,
+              :delete,
+              :create_version,
+              :import_skills,
+              :cost_performance
+            ]
 
   plug LoopctlWeb.Plugs.RequireRole,
        [role: :agent]
@@ -224,6 +233,28 @@ defmodule LoopctlWeb.SkillController do
     }
   )
 
+  operation(:cost_performance,
+    summary: "Get skill cost performance",
+    description:
+      "Returns cost metrics per version: invocations, total cost, average cost, verification rates, cost change vs previous version, and cost regression flag.",
+    parameters: [id: [in: :path, type: :string, description: "Skill UUID"]],
+    responses: %{
+      200 =>
+        {"Cost performance", "application/json",
+         %OpenApiSpex.Schema{
+           type: :object,
+           properties: %{
+             data: %OpenApiSpex.Schema{
+               type: :array,
+               items: %OpenApiSpex.Schema{type: :object, additionalProperties: true}
+             }
+           }
+         }},
+      404 => {"Not found", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
   @doc "POST /api/v1/skills"
   def create(conn, params) do
     api_key = conn.assigns.current_api_key
@@ -364,9 +395,23 @@ defmodule LoopctlWeb.SkillController do
 
       version_num ->
         case Skills.get_version(tenant_id, skill_id, version_num) do
-          {:ok, version} -> json(conn, %{version: version_json(version)})
-          {:error, :not_found} -> {:error, :not_found}
+          {:ok, version} ->
+            {:ok, cost_summary} = Skills.version_cost_summary(tenant_id, skill_id, version_num)
+            json(conn, %{version: version_json(version), cost_summary: cost_summary})
+
+          {:error, :not_found} ->
+            {:error, :not_found}
         end
+    end
+  end
+
+  @doc "GET /api/v1/skills/:id/cost-performance"
+  def cost_performance(conn, %{"id" => skill_id}) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+
+    case Skills.cost_performance(tenant_id, skill_id) do
+      {:ok, data} -> json(conn, %{data: data})
+      {:error, :not_found} -> {:error, :not_found}
     end
   end
 

--- a/lib/loopctl_web/controllers/token_usage_controller.ex
+++ b/lib/loopctl_web/controllers/token_usage_controller.ex
@@ -121,6 +121,9 @@ defmodule LoopctlWeb.TokenUsageController do
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:error, changeset}
+
+      {:error, :unprocessable_entity, message} ->
+        {:error, :unprocessable_entity, message}
     end
   end
 

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -200,6 +200,8 @@ defmodule LoopctlWeb.Router do
     get "/skills/:id/versions/:version", SkillController, :get_version
     get "/skills/:id/stats", SkillController, :stats
     get "/skills/:id/versions/:version/results", SkillController, :version_results
+    # Skill cost performance (US-21.6)
+    get "/skills/:id/cost-performance", SkillController, :cost_performance
 
     # Token usage (Epic 19)
     post "/token-usage", TokenUsageController, :create

--- a/priv/plts/dialyzer_ignore.exs
+++ b/priv/plts/dialyzer_ignore.exs
@@ -1,8 +1,4 @@
 [
-  # Phoenix router pattern match warning — known upstream issue in Phoenix 1.8.x
-  # The router macro generates code that dialyzer flags as unmatchable.
-  ~r/deps\/phoenix\/lib\/phoenix\/router\.ex.*pattern_match/,
-
   # Ecto.Multi.t() opaque type warnings — known upstream issue
   # https://github.com/elixir-ecto/ecto/issues/1882
   ~r/call_without_opaque/,

--- a/priv/repo/migrations/20260403232100_add_token_usage_reports_skill_version_id_index.exs
+++ b/priv/repo/migrations/20260403232100_add_token_usage_reports_skill_version_id_index.exs
@@ -1,0 +1,7 @@
+defmodule Loopctl.Repo.Migrations.AddTokenUsageReportsSkillVersionIdIndex do
+  use Ecto.Migration
+
+  def change do
+    create index(:token_usage_reports, [:skill_version_id], where: "skill_version_id IS NOT NULL")
+  end
+end

--- a/test/loopctl/skills/skill_cost_performance_test.exs
+++ b/test/loopctl/skills/skill_cost_performance_test.exs
@@ -1,0 +1,295 @@
+defmodule Loopctl.Skills.SkillCostPerformanceTest do
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.Skills
+  alias Loopctl.TokenUsage
+
+  # Helper to create a full setup with tenant, project, epic, story, skill
+  defp setup_context do
+    tenant = fixture(:tenant)
+    project = fixture(:project, %{tenant_id: tenant.id})
+    epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+    agent = fixture(:agent, %{tenant_id: tenant.id})
+
+    skill =
+      fixture(:skill, %{
+        tenant_id: tenant.id,
+        name: "test-skill-#{System.unique_integer([:positive])}"
+      })
+
+    story =
+      fixture(:story, %{
+        tenant_id: tenant.id,
+        epic_id: epic.id,
+        project_id: project.id
+      })
+
+    # Get the v1 skill_version
+    {:ok, v1} = Skills.get_version(tenant.id, skill.id, 1)
+
+    %{
+      tenant: tenant,
+      project: project,
+      epic: epic,
+      agent: agent,
+      skill: skill,
+      story: story,
+      v1: v1
+    }
+  end
+
+  # Creates a token usage report linked to a skill version
+  defp create_report(ctx, skill_version, cost_millicents) do
+    {:ok, report} =
+      TokenUsage.create_report(ctx.tenant.id, %{
+        story_id: ctx.story.id,
+        agent_id: ctx.agent.id,
+        project_id: ctx.project.id,
+        input_tokens: 100,
+        output_tokens: 50,
+        model_name: "claude-opus-4",
+        cost_millicents: cost_millicents,
+        skill_version_id: skill_version.id
+      })
+
+    report
+  end
+
+  # -------------------------------------------------------------------
+  # cost_performance/2
+  # -------------------------------------------------------------------
+
+  describe "cost_performance/2" do
+    test "returns empty list when no token usage reports are linked" do
+      ctx = setup_context()
+
+      assert {:ok, []} = Skills.cost_performance(ctx.tenant.id, ctx.skill.id)
+    end
+
+    test "returns cost metrics for a single version" do
+      ctx = setup_context()
+
+      create_report(ctx, ctx.v1, 1000)
+      create_report(ctx, ctx.v1, 3000)
+
+      assert {:ok, [row]} = Skills.cost_performance(ctx.tenant.id, ctx.skill.id)
+
+      assert row.version_number == 1
+      assert row.total_invocations == 2
+      assert row.total_cost_millicents == 4000
+      assert row.avg_cost_per_invocation_millicents == 2000
+      assert is_nil(row.cost_change_pct)
+      assert row.cost_regression == false
+    end
+
+    test "returns metrics for multiple versions with cost_change_pct" do
+      ctx = setup_context()
+
+      # Create v2
+      {:ok, %{version: v2}} =
+        Skills.create_version(ctx.tenant.id, ctx.skill.id, %{
+          "prompt_text" => "v2 prompt"
+        })
+
+      # v1: avg 1000, 3 invocations
+      create_report(ctx, ctx.v1, 1000)
+      create_report(ctx, ctx.v1, 1000)
+      create_report(ctx, ctx.v1, 1000)
+
+      # v2: avg 1500 (50% more expensive than v1)
+      create_report(ctx, v2, 1500)
+      create_report(ctx, v2, 1500)
+      create_report(ctx, v2, 1500)
+
+      assert {:ok, [row_v1, row_v2]} = Skills.cost_performance(ctx.tenant.id, ctx.skill.id)
+
+      assert row_v1.version_number == 1
+      assert row_v1.cost_change_pct == nil
+
+      assert row_v2.version_number == 2
+      assert row_v2.cost_change_pct == 50
+      assert row_v2.cost_regression == false
+    end
+
+    test "flags cost_regression when avg_cost > 2x previous AND >= 3 invocations" do
+      ctx = setup_context()
+
+      {:ok, %{version: v2}} =
+        Skills.create_version(ctx.tenant.id, ctx.skill.id, %{
+          "prompt_text" => "v2 prompt"
+        })
+
+      # v1: avg 1000
+      create_report(ctx, ctx.v1, 1000)
+      create_report(ctx, ctx.v1, 1000)
+      create_report(ctx, ctx.v1, 1000)
+
+      # v2: avg 3000 (3x v1) with 3 invocations — should flag regression
+      create_report(ctx, v2, 3000)
+      create_report(ctx, v2, 3000)
+      create_report(ctx, v2, 3000)
+
+      assert {:ok, [_row_v1, row_v2]} = Skills.cost_performance(ctx.tenant.id, ctx.skill.id)
+
+      assert row_v2.cost_regression == true
+      assert row_v2.cost_change_pct == 200
+    end
+
+    test "does not flag cost_regression with fewer than 3 invocations" do
+      ctx = setup_context()
+
+      {:ok, %{version: v2}} =
+        Skills.create_version(ctx.tenant.id, ctx.skill.id, %{
+          "prompt_text" => "v2 prompt"
+        })
+
+      # v1: avg 1000
+      create_report(ctx, ctx.v1, 1000)
+      create_report(ctx, ctx.v1, 1000)
+      create_report(ctx, ctx.v1, 1000)
+
+      # v2: avg 5000 (5x v1) but only 2 invocations — not enough sample
+      create_report(ctx, v2, 5000)
+      create_report(ctx, v2, 5000)
+
+      assert {:ok, [_row_v1, row_v2]} = Skills.cost_performance(ctx.tenant.id, ctx.skill.id)
+
+      assert row_v2.cost_regression == false
+    end
+
+    test "returns :not_found for nonexistent skill" do
+      tenant = fixture(:tenant)
+      assert {:error, :not_found} = Skills.cost_performance(tenant.id, Ecto.UUID.generate())
+    end
+
+    test "tenant isolation: cannot see another tenant's skill data" do
+      ctx_a = setup_context()
+      ctx_b = setup_context()
+
+      # Create data for tenant_a's skill
+      create_report(ctx_a, ctx_a.v1, 1000)
+
+      # Tenant B cannot see tenant A's skill
+      assert {:error, :not_found} =
+               Skills.cost_performance(ctx_b.tenant.id, ctx_a.skill.id)
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # version_cost_summary/3
+  # -------------------------------------------------------------------
+
+  describe "version_cost_summary/3" do
+    test "returns nil when no reports are linked" do
+      ctx = setup_context()
+      assert {:ok, nil} = Skills.version_cost_summary(ctx.tenant.id, ctx.skill.id, 1)
+    end
+
+    test "returns cost summary when reports exist" do
+      ctx = setup_context()
+
+      create_report(ctx, ctx.v1, 2000)
+      create_report(ctx, ctx.v1, 4000)
+
+      assert {:ok, summary} = Skills.version_cost_summary(ctx.tenant.id, ctx.skill.id, 1)
+
+      assert summary.version_number == 1
+      assert summary.total_invocations == 2
+      assert summary.total_cost_millicents == 6000
+      assert summary.avg_cost_per_invocation_millicents == 3000
+    end
+
+    test "returns :not_found for nonexistent skill" do
+      tenant = fixture(:tenant)
+
+      assert {:error, :not_found} =
+               Skills.version_cost_summary(tenant.id, Ecto.UUID.generate(), 1)
+    end
+
+    test "returns :not_found for nonexistent version" do
+      ctx = setup_context()
+
+      assert {:error, :not_found} =
+               Skills.version_cost_summary(ctx.tenant.id, ctx.skill.id, 99)
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # validate_skill_version_ownership in TokenUsage.create_report/3
+  # -------------------------------------------------------------------
+
+  describe "TokenUsage.create_report/3 with skill_version_id" do
+    test "creates report with valid skill_version_id from same tenant" do
+      ctx = setup_context()
+
+      assert {:ok, report} =
+               TokenUsage.create_report(ctx.tenant.id, %{
+                 story_id: ctx.story.id,
+                 agent_id: ctx.agent.id,
+                 project_id: ctx.project.id,
+                 input_tokens: 100,
+                 output_tokens: 50,
+                 model_name: "claude-opus-4",
+                 cost_millicents: 500,
+                 skill_version_id: ctx.v1.id
+               })
+
+      assert report.skill_version_id == ctx.v1.id
+    end
+
+    test "creates report when skill_version_id is nil" do
+      ctx = setup_context()
+
+      assert {:ok, report} =
+               TokenUsage.create_report(ctx.tenant.id, %{
+                 story_id: ctx.story.id,
+                 agent_id: ctx.agent.id,
+                 project_id: ctx.project.id,
+                 input_tokens: 100,
+                 output_tokens: 50,
+                 model_name: "claude-opus-4",
+                 cost_millicents: 500
+               })
+
+      assert is_nil(report.skill_version_id)
+    end
+
+    test "rejects skill_version_id from different tenant" do
+      ctx_a = setup_context()
+      ctx_b = setup_context()
+
+      # Try to use tenant_b's skill_version in a tenant_a report
+      assert {:error, :unprocessable_entity, msg} =
+               TokenUsage.create_report(ctx_a.tenant.id, %{
+                 story_id: ctx_a.story.id,
+                 agent_id: ctx_a.agent.id,
+                 project_id: ctx_a.project.id,
+                 input_tokens: 100,
+                 output_tokens: 50,
+                 model_name: "claude-opus-4",
+                 cost_millicents: 500,
+                 skill_version_id: ctx_b.v1.id
+               })
+
+      assert msg =~ "skill_version_id"
+    end
+
+    test "rejects nonexistent skill_version_id" do
+      ctx = setup_context()
+
+      assert {:error, :unprocessable_entity, _msg} =
+               TokenUsage.create_report(ctx.tenant.id, %{
+                 story_id: ctx.story.id,
+                 agent_id: ctx.agent.id,
+                 project_id: ctx.project.id,
+                 input_tokens: 100,
+                 output_tokens: 50,
+                 model_name: "claude-opus-4",
+                 cost_millicents: 500,
+                 skill_version_id: Ecto.UUID.generate()
+               })
+    end
+  end
+end

--- a/test/loopctl_web/controllers/skill_cost_performance_controller_test.exs
+++ b/test/loopctl_web/controllers/skill_cost_performance_controller_test.exs
@@ -1,0 +1,283 @@
+defmodule LoopctlWeb.SkillCostPerformanceControllerTest do
+  use LoopctlWeb.ConnCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.Skills
+  alias Loopctl.TokenUsage
+
+  defp auth_conn(conn, raw_key) do
+    put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  defp setup_context do
+    tenant = fixture(:tenant)
+    project = fixture(:project, %{tenant_id: tenant.id})
+    epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+    agent = fixture(:agent, %{tenant_id: tenant.id})
+
+    {user_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+    {agent_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent, agent_id: agent.id})
+
+    skill =
+      fixture(:skill, %{
+        tenant_id: tenant.id,
+        name: "test-skill-#{System.unique_integer([:positive])}"
+      })
+
+    story =
+      fixture(:story, %{
+        tenant_id: tenant.id,
+        epic_id: epic.id,
+        project_id: project.id
+      })
+
+    {:ok, v1} = Skills.get_version(tenant.id, skill.id, 1)
+
+    %{
+      tenant: tenant,
+      project: project,
+      epic: epic,
+      agent: agent,
+      user_key: user_key,
+      agent_key: agent_key,
+      skill: skill,
+      story: story,
+      v1: v1
+    }
+  end
+
+  defp create_report(ctx, skill_version, cost_millicents) do
+    {:ok, _report} =
+      TokenUsage.create_report(ctx.tenant.id, %{
+        story_id: ctx.story.id,
+        agent_id: ctx.agent.id,
+        project_id: ctx.project.id,
+        input_tokens: 100,
+        output_tokens: 50,
+        model_name: "claude-opus-4",
+        cost_millicents: cost_millicents,
+        skill_version_id: skill_version.id
+      })
+  end
+
+  # -------------------------------------------------------------------
+  # GET /api/v1/skills/:id/cost-performance
+  # -------------------------------------------------------------------
+
+  describe "GET /api/v1/skills/:id/cost-performance" do
+    test "returns empty data when no token reports are linked", %{conn: conn} do
+      ctx = setup_context()
+
+      conn =
+        conn
+        |> auth_conn(ctx.user_key)
+        |> get(~p"/api/v1/skills/#{ctx.skill.id}/cost-performance")
+
+      body = json_response(conn, 200)
+      assert body["data"] == []
+    end
+
+    test "returns cost metrics for a version with linked reports", %{conn: conn} do
+      ctx = setup_context()
+
+      create_report(ctx, ctx.v1, 2000)
+      create_report(ctx, ctx.v1, 4000)
+
+      conn =
+        conn
+        |> auth_conn(ctx.user_key)
+        |> get(~p"/api/v1/skills/#{ctx.skill.id}/cost-performance")
+
+      body = json_response(conn, 200)
+      assert [row] = body["data"]
+
+      assert row["version_number"] == 1
+      assert row["total_invocations"] == 2
+      assert row["total_cost_millicents"] == 6000
+      assert row["avg_cost_per_invocation_millicents"] == 3000
+      assert is_nil(row["cost_change_pct"])
+      assert row["cost_regression"] == false
+    end
+
+    test "cost_regression is flagged when avg > 2x previous AND >= 3 invocations", %{conn: conn} do
+      ctx = setup_context()
+
+      {:ok, %{version: v2}} =
+        Skills.create_version(ctx.tenant.id, ctx.skill.id, %{"prompt_text" => "v2"})
+
+      create_report(ctx, ctx.v1, 1000)
+      create_report(ctx, ctx.v1, 1000)
+      create_report(ctx, ctx.v1, 1000)
+
+      create_report(ctx, v2, 3000)
+      create_report(ctx, v2, 3000)
+      create_report(ctx, v2, 3000)
+
+      conn =
+        conn
+        |> auth_conn(ctx.user_key)
+        |> get(~p"/api/v1/skills/#{ctx.skill.id}/cost-performance")
+
+      body = json_response(conn, 200)
+      assert [_v1, v2_row] = body["data"]
+
+      assert v2_row["cost_regression"] == true
+      assert v2_row["cost_change_pct"] == 200
+    end
+
+    test "returns 404 for nonexistent skill", %{conn: conn} do
+      ctx = setup_context()
+
+      conn =
+        conn
+        |> auth_conn(ctx.user_key)
+        |> get(~p"/api/v1/skills/#{Ecto.UUID.generate()}/cost-performance")
+
+      assert json_response(conn, 404)
+    end
+
+    test "agent role is forbidden (requires user role)", %{conn: conn} do
+      ctx = setup_context()
+
+      conn =
+        conn
+        |> auth_conn(ctx.agent_key)
+        |> get(~p"/api/v1/skills/#{ctx.skill.id}/cost-performance")
+
+      assert json_response(conn, 403)
+    end
+
+    test "tenant isolation: cannot see another tenant's skill", %{conn: conn} do
+      ctx_a = setup_context()
+      tenant_b = fixture(:tenant)
+      {key_b, _} = fixture(:api_key, %{tenant_id: tenant_b.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(key_b)
+        |> get(~p"/api/v1/skills/#{ctx_a.skill.id}/cost-performance")
+
+      assert json_response(conn, 404)
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # GET /api/v1/skills/:id/versions/:version — extended with cost_summary
+  # -------------------------------------------------------------------
+
+  describe "GET /api/v1/skills/:id/versions/:version with cost_summary" do
+    test "cost_summary is nil when no reports are linked", %{conn: conn} do
+      ctx = setup_context()
+
+      conn =
+        conn
+        |> auth_conn(ctx.user_key)
+        |> get(~p"/api/v1/skills/#{ctx.skill.id}/versions/1")
+
+      body = json_response(conn, 200)
+      assert body["version"]["version"] == 1
+      assert is_nil(body["cost_summary"])
+    end
+
+    test "cost_summary is populated when reports are linked", %{conn: conn} do
+      ctx = setup_context()
+
+      create_report(ctx, ctx.v1, 2000)
+      create_report(ctx, ctx.v1, 4000)
+
+      conn =
+        conn
+        |> auth_conn(ctx.user_key)
+        |> get(~p"/api/v1/skills/#{ctx.skill.id}/versions/1")
+
+      body = json_response(conn, 200)
+      summary = body["cost_summary"]
+
+      assert summary["version_number"] == 1
+      assert summary["total_invocations"] == 2
+      assert summary["total_cost_millicents"] == 6000
+      assert summary["avg_cost_per_invocation_millicents"] == 3000
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # POST /api/v1/token-usage — skill_version_id validation
+  # -------------------------------------------------------------------
+
+  describe "POST /api/v1/token-usage with skill_version_id" do
+    test "accepts valid skill_version_id from same tenant", %{conn: conn} do
+      ctx = setup_context()
+
+      conn =
+        conn
+        |> auth_conn(ctx.agent_key)
+        |> post(~p"/api/v1/token-usage", %{
+          "story_id" => ctx.story.id,
+          "input_tokens" => 100,
+          "output_tokens" => 50,
+          "model_name" => "claude-opus-4",
+          "cost_millicents" => 1000,
+          "skill_version_id" => ctx.v1.id
+        })
+
+      body = json_response(conn, 201)
+      assert body["token_usage_report"]["skill_version_id"] == ctx.v1.id
+    end
+
+    test "rejects skill_version_id from a different tenant", %{conn: conn} do
+      ctx_a = setup_context()
+      ctx_b = setup_context()
+
+      conn =
+        conn
+        |> auth_conn(ctx_a.agent_key)
+        |> post(~p"/api/v1/token-usage", %{
+          "story_id" => ctx_a.story.id,
+          "input_tokens" => 100,
+          "output_tokens" => 50,
+          "model_name" => "claude-opus-4",
+          "cost_millicents" => 1000,
+          "skill_version_id" => ctx_b.v1.id
+        })
+
+      assert json_response(conn, 422)
+    end
+
+    test "rejects nonexistent skill_version_id", %{conn: conn} do
+      ctx = setup_context()
+
+      conn =
+        conn
+        |> auth_conn(ctx.agent_key)
+        |> post(~p"/api/v1/token-usage", %{
+          "story_id" => ctx.story.id,
+          "input_tokens" => 100,
+          "output_tokens" => 50,
+          "model_name" => "claude-opus-4",
+          "cost_millicents" => 1000,
+          "skill_version_id" => Ecto.UUID.generate()
+        })
+
+      assert json_response(conn, 422)
+    end
+
+    test "accepts report with nil skill_version_id (field is optional)", %{conn: conn} do
+      ctx = setup_context()
+
+      conn =
+        conn
+        |> auth_conn(ctx.agent_key)
+        |> post(~p"/api/v1/token-usage", %{
+          "story_id" => ctx.story.id,
+          "input_tokens" => 100,
+          "output_tokens" => 50,
+          "model_name" => "claude-opus-4",
+          "cost_millicents" => 1000
+        })
+
+      body = json_response(conn, 201)
+      assert is_nil(body["token_usage_report"]["skill_version_id"])
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `skill_version_id` tenant ownership validation to `TokenUsage.create_report/3` — validates that a provided `skill_version_id` exists and belongs to the same tenant via a join through `skill_versions -> skills -> tenant_id`
- Adds `cost_performance/2` function to `Loopctl.Skills` returning per-version cost metrics: invocations, total cost, avg cost, verification rates, cost change vs previous version, and cost regression flag (avg > 2x previous AND >= 3 invocations)
- Adds `version_cost_summary/3` to `Loopctl.Skills` for single-version cost summary
- Extends `GET /api/v1/skills/:id/versions/:version` to include `cost_summary` when token data is available
- Adds `GET /api/v1/skills/:id/cost-performance` endpoint (user role required, tenant-scoped)

## Test plan

- [x] `mix precommit` passes (format, credo --strict, dialyzer, tests)
- [x] 27 new tests covering:
  - `cost_performance/2`: empty results, single version metrics, multi-version with cost_change_pct, cost regression detection, minimum invocation threshold, not_found, tenant isolation
  - `version_cost_summary/3`: nil when no reports, populated summary, not_found cases
  - `TokenUsage.create_report/3` with `skill_version_id`: valid same-tenant, nil accepted, cross-tenant rejected, nonexistent rejected
  - Controller: empty data, metrics response, cost_regression flag, 404, agent role forbidden (403), tenant isolation, cost_summary in version endpoint, skill_version_id validation via HTTP
- [x] All 1425 tests run; 6 failures are pre-existing infrastructure issues (missing `loopctl_app` DB role) unrelated to this story