### PR TITLE
US-21.7: Webhook Events for Cost Alerts

### DIFF
--- a/lib/loopctl/token_usage.ex
+++ b/lib/loopctl/token_usage.ex
@@ -126,8 +126,18 @@ defmodule Loopctl.TokenUsage do
             }
           })
 
-          # Check budget thresholds after report creation (AC-21.8.2)
-          check_budget_thresholds(tenant_id, report)
+          # Check budget thresholds after report creation (AC-21.8.2).
+          # Wrapped in try/rescue so a DB failure during threshold checking
+          # does not crash the report creation flow (the report is committed).
+          try do
+            check_budget_thresholds(tenant_id, report)
+          rescue
+            e ->
+              Logger.warning(
+                "Budget threshold check failed for report #{report.id}: " <>
+                  Exception.message(e)
+              )
+          end
 
           {:ok, report}
 

--- a/lib/loopctl/token_usage.ex
+++ b/lib/loopctl/token_usage.ex
@@ -42,8 +42,11 @@ defmodule Loopctl.TokenUsage do
   alias Loopctl.TokenUsage.Budget
   alias Loopctl.TokenUsage.CostAnomaly
   alias Loopctl.TokenUsage.Report
+  alias Loopctl.Webhooks.EventGenerator
+  alias Loopctl.Webhooks.WebhookEvent
   alias Loopctl.WorkBreakdown.Epic
   alias Loopctl.WorkBreakdown.Story
+  alias Loopctl.Workers.WebhookDeliveryWorker
 
   @doc """
   Creates a new token usage report.
@@ -545,10 +548,12 @@ defmodule Loopctl.TokenUsage do
     decimal_to_int(result || 0)
   end
 
-  # --- Budget threshold check (AC-21.8.2) ---
+  # --- Budget threshold check (AC-21.8.2, AC-21.7.5, AC-21.7.6) ---
 
   # After a token usage report is created, check all applicable budgets
-  # and emit threshold_crossed audit entries for any that have been crossed.
+  # and emit threshold_crossed audit entries and webhook events for any
+  # that have been crossed. Deduplication is enforced via warning_fired
+  # and exceeded_fired boolean flags on the budget.
   defp check_budget_thresholds(tenant_id, report) do
     budgets = find_applicable_budgets(tenant_id, report)
 
@@ -561,14 +566,94 @@ defmodule Loopctl.TokenUsage do
       cond do
         utilization_pct >= 100 ->
           emit_threshold_crossed(tenant_id, budget, utilization_pct, "exceeded")
+          maybe_fire_budget_webhook(tenant_id, budget, spend, utilization_pct, report.id)
 
         utilization_pct >= budget.alert_threshold_pct ->
           emit_threshold_crossed(tenant_id, budget, utilization_pct, "warning")
+          maybe_fire_budget_webhook(tenant_id, budget, spend, utilization_pct, report.id)
 
         true ->
           :ok
       end
     end)
+  end
+
+  # Fires a budget_warning or budget_exceeded webhook event if not already fired.
+  # Uses deduplication flags: warning_fired / exceeded_fired on the budget.
+  defp maybe_fire_budget_webhook(tenant_id, budget, spend, utilization_pct, report_id) do
+    overage = max(spend - budget.budget_millicents, 0)
+
+    cond do
+      utilization_pct >= 100 and not budget.exceeded_fired ->
+        payload = %{
+          "budget_id" => budget.id,
+          "scope_type" => to_string(budget.scope_type),
+          "scope_id" => budget.scope_id,
+          "budget_millicents" => budget.budget_millicents,
+          "current_spend_millicents" => spend,
+          "utilization_pct" => utilization_pct,
+          "alert_threshold_pct" => budget.alert_threshold_pct,
+          "triggering_report_id" => report_id,
+          "overage_millicents" => overage
+        }
+
+        fire_budget_event(tenant_id, "token.budget_exceeded", budget, payload)
+        mark_budget_exceeded(budget)
+
+      utilization_pct >= budget.alert_threshold_pct and not budget.warning_fired ->
+        payload = %{
+          "budget_id" => budget.id,
+          "scope_type" => to_string(budget.scope_type),
+          "scope_id" => budget.scope_id,
+          "budget_millicents" => budget.budget_millicents,
+          "current_spend_millicents" => spend,
+          "utilization_pct" => utilization_pct,
+          "alert_threshold_pct" => budget.alert_threshold_pct,
+          "triggering_report_id" => report_id
+        }
+
+        fire_budget_event(tenant_id, "token.budget_warning", budget, payload)
+        mark_budget_warning(budget)
+
+      true ->
+        :ok
+    end
+  end
+
+  defp fire_budget_event(tenant_id, event_type, _budget, payload) do
+    webhooks = EventGenerator.matching_webhooks(tenant_id, event_type, nil)
+
+    Enum.each(webhooks, fn webhook ->
+      {:ok, event} =
+        %WebhookEvent{
+          tenant_id: tenant_id,
+          webhook_id: webhook.id
+        }
+        |> WebhookEvent.create_changeset(%{
+          event_type: event_type,
+          payload: payload
+        })
+        |> AdminRepo.insert()
+
+      {:ok, _job} =
+        WebhookDeliveryWorker.new(%{
+          webhook_event_id: event.id,
+          tenant_id: tenant_id
+        })
+        |> Oban.insert()
+    end)
+  end
+
+  defp mark_budget_warning(budget) do
+    budget
+    |> Ecto.Changeset.change(%{warning_fired: true})
+    |> AdminRepo.update()
+  end
+
+  defp mark_budget_exceeded(budget) do
+    budget
+    |> Ecto.Changeset.change(%{exceeded_fired: true})
+    |> AdminRepo.update()
   end
 
   # Finds all budgets applicable to a report: story-level, epic-level, project-level.

--- a/lib/loopctl/token_usage.ex
+++ b/lib/loopctl/token_usage.ex
@@ -30,6 +30,8 @@ defmodule Loopctl.TokenUsage do
       Loopctl.TokenUsage.get_story_totals(tenant_id, story_id)
   """
 
+  require Logger
+
   import Ecto.Query
 
   alias Ecto.Multi
@@ -554,6 +556,9 @@ defmodule Loopctl.TokenUsage do
   # and emit threshold_crossed audit entries and webhook events for any
   # that have been crossed. Deduplication is enforced via warning_fired
   # and exceeded_fired boolean flags on the budget.
+  #
+  # When a single report pushes spend past both thresholds (e.g., from 50%
+  # to 120%), both the warning AND exceeded events fire independently.
   defp check_budget_thresholds(tenant_id, report) do
     budgets = find_applicable_budgets(tenant_id, report)
 
@@ -563,97 +568,103 @@ defmodule Loopctl.TokenUsage do
       utilization_pct =
         if budget.budget_millicents > 0, do: spend * 100 / budget.budget_millicents, else: 0
 
-      cond do
-        utilization_pct >= 100 ->
-          emit_threshold_crossed(tenant_id, budget, utilization_pct, "exceeded")
-          maybe_fire_budget_webhook(tenant_id, budget, spend, utilization_pct, report.id)
+      # Fire warning and exceeded independently so both fire when a single
+      # report pushes past both thresholds at once.
+      if utilization_pct >= budget.alert_threshold_pct do
+        emit_threshold_crossed(tenant_id, budget, utilization_pct, "warning")
+        maybe_fire_warning_webhook(tenant_id, budget, spend, utilization_pct, report)
+      end
 
-        utilization_pct >= budget.alert_threshold_pct ->
-          emit_threshold_crossed(tenant_id, budget, utilization_pct, "warning")
-          maybe_fire_budget_webhook(tenant_id, budget, spend, utilization_pct, report.id)
-
-        true ->
-          :ok
+      if utilization_pct >= 100 do
+        emit_threshold_crossed(tenant_id, budget, utilization_pct, "exceeded")
+        maybe_fire_exceeded_webhook(tenant_id, budget, spend, utilization_pct, report)
       end
     end)
   end
 
-  # Fires a budget_warning or budget_exceeded webhook event if not already fired.
-  # Uses deduplication flags: warning_fired / exceeded_fired on the budget.
-  defp maybe_fire_budget_webhook(tenant_id, budget, spend, utilization_pct, report_id) do
-    overage = max(spend - budget.budget_millicents, 0)
+  # Fires a budget_warning webhook event if not already fired (dedup via warning_fired flag).
+  defp maybe_fire_warning_webhook(tenant_id, budget, spend, utilization_pct, report) do
+    if not budget.warning_fired do
+      payload = %{
+        "budget_id" => budget.id,
+        "scope_type" => to_string(budget.scope_type),
+        "scope_id" => budget.scope_id,
+        "budget_millicents" => budget.budget_millicents,
+        "current_spend_millicents" => spend,
+        "utilization_pct" => utilization_pct,
+        "alert_threshold_pct" => budget.alert_threshold_pct,
+        "triggering_report_id" => report.id
+      }
 
-    cond do
-      utilization_pct >= 100 and not budget.exceeded_fired ->
-        payload = %{
-          "budget_id" => budget.id,
-          "scope_type" => to_string(budget.scope_type),
-          "scope_id" => budget.scope_id,
-          "budget_millicents" => budget.budget_millicents,
-          "current_spend_millicents" => spend,
-          "utilization_pct" => utilization_pct,
-          "alert_threshold_pct" => budget.alert_threshold_pct,
-          "triggering_report_id" => report_id,
-          "overage_millicents" => overage
-        }
-
-        fire_budget_event(tenant_id, "token.budget_exceeded", budget, payload)
-        mark_budget_exceeded(budget)
-
-      utilization_pct >= budget.alert_threshold_pct and not budget.warning_fired ->
-        payload = %{
-          "budget_id" => budget.id,
-          "scope_type" => to_string(budget.scope_type),
-          "scope_id" => budget.scope_id,
-          "budget_millicents" => budget.budget_millicents,
-          "current_spend_millicents" => spend,
-          "utilization_pct" => utilization_pct,
-          "alert_threshold_pct" => budget.alert_threshold_pct,
-          "triggering_report_id" => report_id
-        }
-
-        fire_budget_event(tenant_id, "token.budget_warning", budget, payload)
-        mark_budget_warning(budget)
-
-      true ->
-        :ok
+      fire_budget_event(tenant_id, "token.budget_warning", report.project_id, payload)
+      mark_budget_flag(budget, :warning_fired)
     end
   end
 
-  defp fire_budget_event(tenant_id, event_type, _budget, payload) do
-    webhooks = EventGenerator.matching_webhooks(tenant_id, event_type, nil)
+  # Fires a budget_exceeded webhook event if not already fired (dedup via exceeded_fired flag).
+  defp maybe_fire_exceeded_webhook(tenant_id, budget, spend, utilization_pct, report) do
+    if not budget.exceeded_fired do
+      overage = max(spend - budget.budget_millicents, 0)
+
+      payload = %{
+        "budget_id" => budget.id,
+        "scope_type" => to_string(budget.scope_type),
+        "scope_id" => budget.scope_id,
+        "budget_millicents" => budget.budget_millicents,
+        "current_spend_millicents" => spend,
+        "utilization_pct" => utilization_pct,
+        "alert_threshold_pct" => budget.alert_threshold_pct,
+        "triggering_report_id" => report.id,
+        "overage_millicents" => overage
+      }
+
+      fire_budget_event(tenant_id, "token.budget_exceeded", report.project_id, payload)
+      mark_budget_flag(budget, :exceeded_fired)
+    end
+  end
+
+  # Creates webhook events for matching subscriptions. Passes project_id so
+  # project-scoped webhooks also receive budget alerts. Errors are caught to
+  # avoid crashing the report creation flow (the report is already committed).
+  defp fire_budget_event(tenant_id, event_type, project_id, payload) do
+    webhooks = EventGenerator.matching_webhooks(tenant_id, event_type, project_id)
 
     Enum.each(webhooks, fn webhook ->
-      {:ok, event} =
-        %WebhookEvent{
-          tenant_id: tenant_id,
-          webhook_id: webhook.id
-        }
-        |> WebhookEvent.create_changeset(%{
-          event_type: event_type,
-          payload: payload
-        })
-        |> AdminRepo.insert()
-
-      {:ok, _job} =
-        WebhookDeliveryWorker.new(%{
-          webhook_event_id: event.id,
-          tenant_id: tenant_id
-        })
-        |> Oban.insert()
+      with {:ok, event} <-
+             %WebhookEvent{
+               tenant_id: tenant_id,
+               webhook_id: webhook.id
+             }
+             |> WebhookEvent.create_changeset(%{
+               event_type: event_type,
+               payload: payload
+             })
+             |> AdminRepo.insert(),
+           {:ok, _job} <-
+             WebhookDeliveryWorker.new(%{
+               webhook_event_id: event.id,
+               tenant_id: tenant_id
+             })
+             |> Oban.insert() do
+        :ok
+      else
+        {:error, reason} ->
+          Logger.warning(
+            "Failed to create #{event_type} webhook event for tenant #{tenant_id}: #{inspect(reason)}"
+          )
+      end
     end)
   end
 
-  defp mark_budget_warning(budget) do
-    budget
-    |> Ecto.Changeset.change(%{warning_fired: true})
-    |> AdminRepo.update()
-  end
+  # Updates a dedup flag on the budget. Logs failures instead of crashing.
+  defp mark_budget_flag(budget, flag) when flag in [:warning_fired, :exceeded_fired] do
+    case budget |> Ecto.Changeset.change(%{flag => true}) |> AdminRepo.update() do
+      {:ok, _} ->
+        :ok
 
-  defp mark_budget_exceeded(budget) do
-    budget
-    |> Ecto.Changeset.change(%{exceeded_fired: true})
-    |> AdminRepo.update()
+      {:error, reason} ->
+        Logger.warning("Failed to set #{flag} on budget #{budget.id}: #{inspect(reason)}")
+    end
   end
 
   # Finds all budgets applicable to a report: story-level, epic-level, project-level.

--- a/lib/loopctl/token_usage/budget.ex
+++ b/lib/loopctl/token_usage/budget.ex
@@ -32,6 +32,8 @@ defmodule Loopctl.TokenUsage.Budget do
              :budget_input_tokens,
              :budget_output_tokens,
              :alert_threshold_pct,
+             :warning_fired,
+             :exceeded_fired,
              :metadata,
              :inserted_at,
              :updated_at
@@ -46,6 +48,8 @@ defmodule Loopctl.TokenUsage.Budget do
     field :budget_input_tokens, :integer
     field :budget_output_tokens, :integer
     field :alert_threshold_pct, :integer, default: 80
+    field :warning_fired, :boolean, default: false
+    field :exceeded_fired, :boolean, default: false
     field :metadata, :map, default: %{}
 
     timestamps()
@@ -88,6 +92,10 @@ defmodule Loopctl.TokenUsage.Budget do
   Changeset for updating an existing token budget.
 
   Cannot change `scope_type` or `scope_id`.
+
+  When `budget_millicents` or `alert_threshold_pct` changes, the
+  `warning_fired` and `exceeded_fired` deduplication flags are reset
+  to `false` so that webhook events will re-fire at the new threshold.
   """
   @spec update_changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
   def update_changeset(budget, attrs) do
@@ -106,5 +114,19 @@ defmodule Loopctl.TokenUsage.Budget do
       greater_than_or_equal_to: 1,
       less_than_or_equal_to: 100
     )
+    |> maybe_reset_dedup_flags()
+  end
+
+  # If budget_millicents or alert_threshold_pct changed, reset the
+  # warning_fired / exceeded_fired flags so webhook events re-fire at the
+  # new threshold level (AC-21.7.6).
+  defp maybe_reset_dedup_flags(changeset) do
+    if get_change(changeset, :budget_millicents) || get_change(changeset, :alert_threshold_pct) do
+      changeset
+      |> put_change(:warning_fired, false)
+      |> put_change(:exceeded_fired, false)
+    else
+      changeset
+    end
   end
 end

--- a/lib/loopctl/webhooks/webhook.ex
+++ b/lib/loopctl/webhooks/webhook.ex
@@ -34,6 +34,9 @@ defmodule Loopctl.Webhooks.Webhook do
     agent.registered
     project.imported
     webhook.test
+    token.budget_warning
+    token.budget_exceeded
+    token.anomaly_detected
   )
 
   @doc """

--- a/lib/loopctl/workers/cost_anomaly_worker.ex
+++ b/lib/loopctl/workers/cost_anomaly_worker.ex
@@ -24,12 +24,16 @@ defmodule Loopctl.Workers.CostAnomalyWorker do
   import Ecto.Query
 
   alias Loopctl.AdminRepo
+  alias Loopctl.Agents.Agent
   alias Loopctl.Audit
   alias Loopctl.Tenants.Tenant
   alias Loopctl.TokenUsage.CostAnomaly
   alias Loopctl.TokenUsage.CostSummary
   alias Loopctl.TokenUsage.Report
+  alias Loopctl.Webhooks.EventGenerator
+  alias Loopctl.Webhooks.WebhookEvent
   alias Loopctl.WorkBreakdown.Story
+  alias Loopctl.Workers.WebhookDeliveryWorker
 
   @high_cost_threshold Decimal.new("3.0")
   @low_cost_threshold Decimal.new("0.1")
@@ -169,7 +173,71 @@ defmodule Loopctl.Workers.CostAnomalyWorker do
         }
       })
 
+      # Fire token.anomaly_detected webhook event (AC-21.7.7)
+      fire_anomaly_webhook(tenant_id, anomaly)
+
       anomaly
+    end
+  end
+
+  # Fires a token.anomaly_detected webhook for newly created anomalies.
+  # Looks up story title and agent name for a rich payload.
+  defp fire_anomaly_webhook(tenant_id, anomaly) do
+    webhooks = EventGenerator.matching_webhooks(tenant_id, "token.anomaly_detected", nil)
+
+    if webhooks != [] do
+      {story_title, agent_id, agent_name} = fetch_story_context(anomaly.story_id, tenant_id)
+
+      payload = %{
+        "anomaly_id" => anomaly.id,
+        "story_id" => anomaly.story_id,
+        "story_title" => story_title,
+        "agent_id" => agent_id,
+        "agent_name" => agent_name,
+        "anomaly_type" => to_string(anomaly.anomaly_type),
+        "story_cost_millicents" => anomaly.story_cost_millicents,
+        "reference_avg_millicents" => anomaly.reference_avg_millicents,
+        "deviation_factor" => Decimal.to_string(anomaly.deviation_factor)
+      }
+
+      Enum.each(webhooks, fn webhook ->
+        {:ok, event} =
+          %WebhookEvent{
+            tenant_id: tenant_id,
+            webhook_id: webhook.id
+          }
+          |> WebhookEvent.create_changeset(%{
+            event_type: "token.anomaly_detected",
+            payload: payload
+          })
+          |> AdminRepo.insert()
+
+        {:ok, _job} =
+          WebhookDeliveryWorker.new(%{
+            webhook_event_id: event.id,
+            tenant_id: tenant_id
+          })
+          |> Oban.insert()
+      end)
+    end
+  end
+
+  # Fetches story title and assigned agent name for the anomaly webhook payload.
+  # Returns {story_title, agent_id, agent_name} with nil fallbacks.
+  defp fetch_story_context(story_id, tenant_id) do
+    story = AdminRepo.get_by(Story, id: story_id, tenant_id: tenant_id)
+
+    case story do
+      nil ->
+        {nil, nil, nil}
+
+      %Story{assigned_agent_id: nil} ->
+        {story.title, nil, nil}
+
+      %Story{assigned_agent_id: agent_id} ->
+        agent = AdminRepo.get(Agent, agent_id)
+        agent_name = if agent, do: agent.name, else: nil
+        {story.title, agent_id, agent_name}
     end
   end
 

--- a/lib/loopctl/workers/cost_anomaly_worker.ex
+++ b/lib/loopctl/workers/cost_anomaly_worker.ex
@@ -181,13 +181,18 @@ defmodule Loopctl.Workers.CostAnomalyWorker do
   end
 
   # Fires a token.anomaly_detected webhook for newly created anomalies.
-  # Looks up story title and agent name for a rich payload.
+  # Looks up story title and agent name for a rich payload. Passes project_id
+  # so project-scoped webhooks also receive anomaly events.
+  # Errors are caught and logged rather than bubbling up (the anomaly record
+  # is already created; losing the webhook should not lose the anomaly).
   defp fire_anomaly_webhook(tenant_id, anomaly) do
-    webhooks = EventGenerator.matching_webhooks(tenant_id, "token.anomaly_detected", nil)
+    {story_title, agent_id, agent_name, project_id} =
+      fetch_story_context(anomaly.story_id, tenant_id)
+
+    webhooks =
+      EventGenerator.matching_webhooks(tenant_id, "token.anomaly_detected", project_id)
 
     if webhooks != [] do
-      {story_title, agent_id, agent_name} = fetch_story_context(anomaly.story_id, tenant_id)
-
       payload = %{
         "anomaly_id" => anomaly.id,
         "story_id" => anomaly.story_id,
@@ -200,44 +205,48 @@ defmodule Loopctl.Workers.CostAnomalyWorker do
         "deviation_factor" => Decimal.to_string(anomaly.deviation_factor)
       }
 
-      Enum.each(webhooks, fn webhook ->
-        {:ok, event} =
-          %WebhookEvent{
-            tenant_id: tenant_id,
-            webhook_id: webhook.id
-          }
-          |> WebhookEvent.create_changeset(%{
-            event_type: "token.anomaly_detected",
-            payload: payload
-          })
-          |> AdminRepo.insert()
-
-        {:ok, _job} =
-          WebhookDeliveryWorker.new(%{
-            webhook_event_id: event.id,
-            tenant_id: tenant_id
-          })
-          |> Oban.insert()
-      end)
+      Enum.each(webhooks, &deliver_anomaly_event(tenant_id, &1, payload, anomaly.id))
     end
   end
 
-  # Fetches story title and assigned agent name for the anomaly webhook payload.
-  # Returns {story_title, agent_id, agent_name} with nil fallbacks.
+  # Delivers a single anomaly webhook event. Errors are logged, not raised.
+  defp deliver_anomaly_event(tenant_id, webhook, payload, anomaly_id) do
+    with {:ok, event} <-
+           %WebhookEvent{tenant_id: tenant_id, webhook_id: webhook.id}
+           |> WebhookEvent.create_changeset(%{
+             event_type: "token.anomaly_detected",
+             payload: payload
+           })
+           |> AdminRepo.insert(),
+         {:ok, _job} <-
+           WebhookDeliveryWorker.new(%{webhook_event_id: event.id, tenant_id: tenant_id})
+           |> Oban.insert() do
+      :ok
+    else
+      {:error, reason} ->
+        Logger.warning(
+          "Failed to create token.anomaly_detected webhook event " <>
+            "for anomaly #{anomaly_id}: #{inspect(reason)}"
+        )
+    end
+  end
+
+  # Fetches story title, assigned agent name, and project_id for the anomaly webhook payload.
+  # Returns {story_title, agent_id, agent_name, project_id} with nil fallbacks.
   defp fetch_story_context(story_id, tenant_id) do
     story = AdminRepo.get_by(Story, id: story_id, tenant_id: tenant_id)
 
     case story do
       nil ->
-        {nil, nil, nil}
+        {nil, nil, nil, nil}
 
       %Story{assigned_agent_id: nil} ->
-        {story.title, nil, nil}
+        {story.title, nil, nil, story.project_id}
 
       %Story{assigned_agent_id: agent_id} ->
         agent = AdminRepo.get(Agent, agent_id)
         agent_name = if agent, do: agent.name, else: nil
-        {story.title, agent_id, agent_name}
+        {story.title, agent_id, agent_name, story.project_id}
     end
   end
 

--- a/priv/repo/migrations/20260403180329_add_dedup_flags_to_token_budgets.exs
+++ b/priv/repo/migrations/20260403180329_add_dedup_flags_to_token_budgets.exs
@@ -1,0 +1,10 @@
+defmodule Loopctl.Repo.Migrations.AddDedupFlagsToTokenBudgets do
+  use Ecto.Migration
+
+  def change do
+    alter table(:token_budgets) do
+      add :warning_fired, :boolean, null: false, default: false
+      add :exceeded_fired, :boolean, null: false, default: false
+    end
+  end
+end

--- a/test/loopctl/token_usage_change_feed_test.exs
+++ b/test/loopctl/token_usage_change_feed_test.exs
@@ -216,11 +216,14 @@ defmodule Loopctl.TokenUsageChangeFeedTest do
         })
 
       entries = find_audit_entries(tenant.id, "token_budget", "threshold_crossed")
-      assert length(entries) == 1
+      # Both warning and exceeded fire independently when spend jumps past both thresholds
+      assert length(entries) == 2
 
-      [entry] = entries
-      assert entry.new_state["threshold_type"] == "exceeded"
-      assert entry.new_state["utilization_pct"] >= 100
+      threshold_types = Enum.map(entries, & &1.new_state["threshold_type"]) |> Enum.sort()
+      assert threshold_types == ["exceeded", "warning"]
+
+      exceeded_entry = Enum.find(entries, &(&1.new_state["threshold_type"] == "exceeded"))
+      assert exceeded_entry.new_state["utilization_pct"] >= 100
     end
 
     test "does NOT emit threshold_crossed when spend is below alert_threshold_pct" do
@@ -340,11 +343,13 @@ defmodule Loopctl.TokenUsageChangeFeedTest do
         })
 
       entries = find_audit_entries(tenant.id, "token_budget", "threshold_crossed")
-      # Both budgets should be crossed (7000/5000 > 100%, 7000/8000 > 80%)
-      assert length(entries) == 2
+      # Story budget: 7000/5000 = 140% -> both warning + exceeded entries (2)
+      # Project budget: 7000/8000 = 87.5% -> warning entry only (1)
+      # Total: 3
+      assert length(entries) == 3
 
       scope_types = Enum.map(entries, & &1.new_state["scope_type"]) |> Enum.sort()
-      assert scope_types == ["project", "story"]
+      assert scope_types == ["project", "story", "story"]
     end
 
     test "threshold_crossed entry includes metadata with budget_id and scope_id" do
@@ -369,12 +374,17 @@ defmodule Loopctl.TokenUsageChangeFeedTest do
           cost_millicents: 5_500
         })
 
-      [entry] = find_audit_entries(tenant.id, "token_budget", "threshold_crossed")
+      entries = find_audit_entries(tenant.id, "token_budget", "threshold_crossed")
+      # Spend 5500/5000 = 110% -> both warning + exceeded audit entries fire
+      assert length(entries) == 2
 
-      assert entry.metadata["budget_id"] == budget.id
-      assert entry.metadata["scope_type"] == "story"
-      assert entry.metadata["scope_id"] == story.id
-      assert entry.metadata["threshold_type"] == "exceeded"
+      exceeded_entry =
+        Enum.find(entries, &(&1.new_state["threshold_type"] == "exceeded"))
+
+      assert exceeded_entry.metadata["budget_id"] == budget.id
+      assert exceeded_entry.metadata["scope_type"] == "story"
+      assert exceeded_entry.metadata["scope_id"] == story.id
+      assert exceeded_entry.metadata["threshold_type"] == "exceeded"
     end
   end
 

--- a/test/loopctl/token_usage_webhook_events_test.exs
+++ b/test/loopctl/token_usage_webhook_events_test.exs
@@ -1,0 +1,861 @@
+defmodule Loopctl.TokenUsageWebhookEventsTest do
+  @moduledoc """
+  Tests for US-21.7: Webhook Events for Cost Alerts.
+
+  Verifies that:
+  - AC-21.7.1: New event types are registered and accepted by webhook subscriptions
+  - AC-21.7.2: token.budget_warning payload has the correct fields
+  - AC-21.7.3: token.budget_exceeded payload has the correct fields including overage_millicents
+  - AC-21.7.4: token.anomaly_detected payload has the correct fields
+  - AC-21.7.5: Budget webhook events fire synchronously when a report is created
+  - AC-21.7.6: Deduplication via warning_fired/exceeded_fired flags; reset on budget update
+  - AC-21.7.7: CostAnomalyWorker fires anomaly webhooks for newly created anomalies
+  - AC-21.7.8: All webhook events are signed (consistent with existing delivery infrastructure)
+  """
+
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.TokenUsage
+  alias Loopctl.TokenUsage.Budget
+  alias Loopctl.TokenUsage.CostSummary
+  alias Loopctl.Webhooks
+  alias Loopctl.Webhooks.WebhookEvent
+  alias Loopctl.Workers.CostAnomalyWorker
+
+  import Ecto.Query
+
+  defp setup_context do
+    tenant = fixture(:tenant)
+    project = fixture(:project, %{tenant_id: tenant.id})
+    epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+    agent = fixture(:agent, %{tenant_id: tenant.id})
+
+    story =
+      fixture(:story, %{
+        tenant_id: tenant.id,
+        epic_id: epic.id,
+        project_id: project.id
+      })
+
+    %{tenant: tenant, project: project, epic: epic, agent: agent, story: story}
+  end
+
+  defp create_webhook_for_events(tenant_id, events) do
+    {:ok, %{webhook: webhook}} =
+      Webhooks.create_webhook(tenant_id, %{
+        "url" => "https://example.com/hooks/#{System.unique_integer([:positive])}",
+        "events" => events
+      })
+
+    webhook
+  end
+
+  defp find_webhook_events(tenant_id, event_type) do
+    WebhookEvent
+    |> where([e], e.tenant_id == ^tenant_id and e.event_type == ^event_type)
+    |> AdminRepo.all()
+  end
+
+  # --- AC-21.7.1: New event types are registered ---
+
+  describe "valid event types (AC-21.7.1)" do
+    test "token.budget_warning is a valid event type for webhook subscription" do
+      tenant = fixture(:tenant)
+
+      {:ok, %{webhook: webhook}} =
+        Webhooks.create_webhook(tenant.id, %{
+          "url" => "https://example.com/hooks",
+          "events" => ["token.budget_warning"]
+        })
+
+      assert "token.budget_warning" in webhook.events
+    end
+
+    test "token.budget_exceeded is a valid event type for webhook subscription" do
+      tenant = fixture(:tenant)
+
+      {:ok, %{webhook: webhook}} =
+        Webhooks.create_webhook(tenant.id, %{
+          "url" => "https://example.com/hooks",
+          "events" => ["token.budget_exceeded"]
+        })
+
+      assert "token.budget_exceeded" in webhook.events
+    end
+
+    test "token.anomaly_detected is a valid event type for webhook subscription" do
+      tenant = fixture(:tenant)
+
+      {:ok, %{webhook: webhook}} =
+        Webhooks.create_webhook(tenant.id, %{
+          "url" => "https://example.com/hooks",
+          "events" => ["token.anomaly_detected"]
+        })
+
+      assert "token.anomaly_detected" in webhook.events
+    end
+
+    test "can subscribe to all three new event types simultaneously" do
+      tenant = fixture(:tenant)
+
+      {:ok, %{webhook: webhook}} =
+        Webhooks.create_webhook(tenant.id, %{
+          "url" => "https://example.com/hooks",
+          "events" => ["token.budget_warning", "token.budget_exceeded", "token.anomaly_detected"]
+        })
+
+      assert length(webhook.events) == 3
+    end
+
+    test "existing event types still valid after addition of new types" do
+      tenant = fixture(:tenant)
+
+      {:ok, %{webhook: webhook}} =
+        Webhooks.create_webhook(tenant.id, %{
+          "url" => "https://example.com/hooks",
+          "events" => ["story.status_changed", "token.budget_warning"]
+        })
+
+      assert "story.status_changed" in webhook.events
+      assert "token.budget_warning" in webhook.events
+    end
+  end
+
+  # --- AC-21.7.2: token.budget_warning payload ---
+
+  describe "token.budget_warning payload (AC-21.7.2)" do
+    test "fires with correct payload fields when spend crosses alert threshold" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+
+      _webhook = create_webhook_for_events(tenant.id, ["token.budget_warning"])
+
+      {:ok, budget} =
+        TokenUsage.create_budget(tenant.id, %{
+          scope_type: :story,
+          scope_id: story.id,
+          budget_millicents: 10_000,
+          alert_threshold_pct: 80
+        })
+
+      # Spend pushes to 85% (8,500 out of 10,000)
+      {:ok, report} =
+        TokenUsage.create_report(tenant.id, %{
+          story_id: story.id,
+          agent_id: agent.id,
+          project_id: project.id,
+          input_tokens: 1000,
+          output_tokens: 500,
+          model_name: "claude-opus-4",
+          cost_millicents: 8_500
+        })
+
+      events = find_webhook_events(tenant.id, "token.budget_warning")
+      assert [event] = events
+      payload = event.payload
+
+      assert payload["budget_id"] == budget.id
+      assert payload["scope_type"] == "story"
+      assert payload["scope_id"] == story.id
+      assert payload["budget_millicents"] == 10_000
+      assert payload["current_spend_millicents"] == 8_500
+      assert payload["utilization_pct"] >= 80
+      assert payload["alert_threshold_pct"] == 80
+      assert payload["triggering_report_id"] == report.id
+      # overage_millicents is NOT present in warning payload
+      refute Map.has_key?(payload, "overage_millicents")
+    end
+  end
+
+  # --- AC-21.7.3: token.budget_exceeded payload ---
+
+  describe "token.budget_exceeded payload (AC-21.7.3)" do
+    test "fires with correct payload including overage_millicents when budget exceeded" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+
+      _webhook = create_webhook_for_events(tenant.id, ["token.budget_exceeded"])
+
+      {:ok, budget} =
+        TokenUsage.create_budget(tenant.id, %{
+          scope_type: :story,
+          scope_id: story.id,
+          budget_millicents: 5_000,
+          alert_threshold_pct: 80
+        })
+
+      # Spend pushes to 120% (6,000 out of 5,000)
+      {:ok, report} =
+        TokenUsage.create_report(tenant.id, %{
+          story_id: story.id,
+          agent_id: agent.id,
+          project_id: project.id,
+          input_tokens: 1000,
+          output_tokens: 500,
+          model_name: "claude-opus-4",
+          cost_millicents: 6_000
+        })
+
+      events = find_webhook_events(tenant.id, "token.budget_exceeded")
+      assert [event] = events
+      payload = event.payload
+
+      assert payload["budget_id"] == budget.id
+      assert payload["scope_type"] == "story"
+      assert payload["scope_id"] == story.id
+      assert payload["budget_millicents"] == 5_000
+      assert payload["current_spend_millicents"] == 6_000
+      assert payload["utilization_pct"] >= 100
+      assert payload["alert_threshold_pct"] == 80
+      assert payload["triggering_report_id"] == report.id
+      assert payload["overage_millicents"] == 1_000
+    end
+
+    test "overage_millicents is zero when spend exactly equals budget" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+
+      _webhook = create_webhook_for_events(tenant.id, ["token.budget_exceeded"])
+
+      {:ok, _budget} =
+        TokenUsage.create_budget(tenant.id, %{
+          scope_type: :story,
+          scope_id: story.id,
+          budget_millicents: 5_000,
+          alert_threshold_pct: 80
+        })
+
+      {:ok, _report} =
+        TokenUsage.create_report(tenant.id, %{
+          story_id: story.id,
+          agent_id: agent.id,
+          project_id: project.id,
+          input_tokens: 1000,
+          output_tokens: 500,
+          model_name: "claude-opus-4",
+          cost_millicents: 5_000
+        })
+
+      events = find_webhook_events(tenant.id, "token.budget_exceeded")
+      assert [event] = events
+      assert event.payload["overage_millicents"] == 0
+    end
+  end
+
+  # --- AC-21.7.5: Budget checks fire synchronously when report is created ---
+
+  describe "synchronous firing (AC-21.7.5)" do
+    test "webhook event is created in the same operation as the report" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+
+      _webhook = create_webhook_for_events(tenant.id, ["token.budget_warning"])
+
+      {:ok, _budget} =
+        TokenUsage.create_budget(tenant.id, %{
+          scope_type: :story,
+          scope_id: story.id,
+          budget_millicents: 10_000,
+          alert_threshold_pct: 80
+        })
+
+      {:ok, _report} =
+        TokenUsage.create_report(tenant.id, %{
+          story_id: story.id,
+          agent_id: agent.id,
+          project_id: project.id,
+          input_tokens: 1000,
+          output_tokens: 500,
+          model_name: "claude-opus-4",
+          cost_millicents: 9_000
+        })
+
+      # Event should already exist immediately after report creation
+      events = find_webhook_events(tenant.id, "token.budget_warning")
+      assert events != []
+    end
+
+    test "no webhook events created when spend is below threshold" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+
+      _webhook = create_webhook_for_events(tenant.id, ["token.budget_warning"])
+
+      {:ok, _budget} =
+        TokenUsage.create_budget(tenant.id, %{
+          scope_type: :story,
+          scope_id: story.id,
+          budget_millicents: 100_000,
+          alert_threshold_pct: 80
+        })
+
+      {:ok, _report} =
+        TokenUsage.create_report(tenant.id, %{
+          story_id: story.id,
+          agent_id: agent.id,
+          project_id: project.id,
+          input_tokens: 100,
+          output_tokens: 50,
+          model_name: "claude-opus-4",
+          cost_millicents: 1_000
+        })
+
+      events = find_webhook_events(tenant.id, "token.budget_warning")
+      assert events == []
+    end
+
+    test "no webhook event fires if no webhook subscribed to event type" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+
+      # Only subscribe to a different event
+      _webhook = create_webhook_for_events(tenant.id, ["story.verified"])
+
+      {:ok, _budget} =
+        TokenUsage.create_budget(tenant.id, %{
+          scope_type: :story,
+          scope_id: story.id,
+          budget_millicents: 5_000,
+          alert_threshold_pct: 80
+        })
+
+      {:ok, _report} =
+        TokenUsage.create_report(tenant.id, %{
+          story_id: story.id,
+          agent_id: agent.id,
+          project_id: project.id,
+          input_tokens: 1000,
+          output_tokens: 500,
+          model_name: "claude-opus-4",
+          cost_millicents: 9_000
+        })
+
+      events = find_webhook_events(tenant.id, "token.budget_warning")
+      assert events == []
+    end
+  end
+
+  # --- AC-21.7.6: Deduplication via warning_fired/exceeded_fired ---
+
+  describe "deduplication flags (AC-21.7.6)" do
+    test "warning webhook fires only once (warning_fired set to true after first fire)" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+
+      _webhook = create_webhook_for_events(tenant.id, ["token.budget_warning"])
+
+      {:ok, budget} =
+        TokenUsage.create_budget(tenant.id, %{
+          scope_type: :story,
+          scope_id: story.id,
+          budget_millicents: 10_000,
+          alert_threshold_pct: 80
+        })
+
+      # First report: crosses warning threshold
+      {:ok, _} =
+        TokenUsage.create_report(tenant.id, %{
+          story_id: story.id,
+          agent_id: agent.id,
+          project_id: project.id,
+          input_tokens: 1000,
+          output_tokens: 500,
+          model_name: "claude-opus-4",
+          cost_millicents: 8_500
+        })
+
+      events_after_first = find_webhook_events(tenant.id, "token.budget_warning")
+      assert events_after_first != []
+
+      # Verify warning_fired is now true
+      reloaded_budget = AdminRepo.get!(Budget, budget.id)
+      assert reloaded_budget.warning_fired == true
+
+      # Second report: still in warning range, should NOT fire again
+      {:ok, _} =
+        TokenUsage.create_report(tenant.id, %{
+          story_id: story.id,
+          agent_id: agent.id,
+          project_id: project.id,
+          input_tokens: 100,
+          output_tokens: 50,
+          model_name: "claude-opus-4",
+          cost_millicents: 200
+        })
+
+      events_after_second = find_webhook_events(tenant.id, "token.budget_warning")
+      assert Enum.count(events_after_second) == 1
+    end
+
+    test "exceeded webhook fires only once (exceeded_fired set to true after first fire)" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+
+      _webhook = create_webhook_for_events(tenant.id, ["token.budget_exceeded"])
+
+      {:ok, budget} =
+        TokenUsage.create_budget(tenant.id, %{
+          scope_type: :story,
+          scope_id: story.id,
+          budget_millicents: 5_000,
+          alert_threshold_pct: 80
+        })
+
+      # First report: crosses 100%
+      {:ok, _} =
+        TokenUsage.create_report(tenant.id, %{
+          story_id: story.id,
+          agent_id: agent.id,
+          project_id: project.id,
+          input_tokens: 1000,
+          output_tokens: 500,
+          model_name: "claude-opus-4",
+          cost_millicents: 6_000
+        })
+
+      events_after_first = find_webhook_events(tenant.id, "token.budget_exceeded")
+      assert events_after_first != []
+
+      reloaded_budget = AdminRepo.get!(Budget, budget.id)
+      assert reloaded_budget.exceeded_fired == true
+
+      # Second report: still over 100%, should NOT fire again
+      {:ok, _} =
+        TokenUsage.create_report(tenant.id, %{
+          story_id: story.id,
+          agent_id: agent.id,
+          project_id: project.id,
+          input_tokens: 100,
+          output_tokens: 50,
+          model_name: "claude-opus-4",
+          cost_millicents: 100
+        })
+
+      events_after_second = find_webhook_events(tenant.id, "token.budget_exceeded")
+      assert Enum.count(events_after_second) == 1
+    end
+
+    test "warning_fired and exceeded_fired default to false on new budgets" do
+      tenant = fixture(:tenant)
+      story = fixture(:story, %{tenant_id: tenant.id})
+
+      {:ok, budget} =
+        TokenUsage.create_budget(tenant.id, %{
+          scope_type: :story,
+          scope_id: story.id,
+          budget_millicents: 10_000,
+          alert_threshold_pct: 80
+        })
+
+      assert budget.warning_fired == false
+      assert budget.exceeded_fired == false
+    end
+
+    test "flags are reset when budget_millicents is updated" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+
+      _webhook = create_webhook_for_events(tenant.id, ["token.budget_warning"])
+
+      {:ok, budget} =
+        TokenUsage.create_budget(tenant.id, %{
+          scope_type: :story,
+          scope_id: story.id,
+          budget_millicents: 10_000,
+          alert_threshold_pct: 80
+        })
+
+      # Fire the warning
+      {:ok, _} =
+        TokenUsage.create_report(tenant.id, %{
+          story_id: story.id,
+          agent_id: agent.id,
+          project_id: project.id,
+          input_tokens: 1000,
+          output_tokens: 500,
+          model_name: "claude-opus-4",
+          cost_millicents: 8_500
+        })
+
+      reloaded = AdminRepo.get!(Budget, budget.id)
+      assert reloaded.warning_fired == true
+
+      # Update budget_millicents — should reset flags
+      {:ok, updated} =
+        TokenUsage.update_budget(tenant.id, budget.id, %{budget_millicents: 20_000})
+
+      assert updated.warning_fired == false
+      assert updated.exceeded_fired == false
+    end
+
+    test "flags are reset when alert_threshold_pct is updated" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+
+      _webhook = create_webhook_for_events(tenant.id, ["token.budget_warning"])
+
+      {:ok, budget} =
+        TokenUsage.create_budget(tenant.id, %{
+          scope_type: :story,
+          scope_id: story.id,
+          budget_millicents: 10_000,
+          alert_threshold_pct: 80
+        })
+
+      # Fire the warning
+      {:ok, _} =
+        TokenUsage.create_report(tenant.id, %{
+          story_id: story.id,
+          agent_id: agent.id,
+          project_id: project.id,
+          input_tokens: 1000,
+          output_tokens: 500,
+          model_name: "claude-opus-4",
+          cost_millicents: 8_500
+        })
+
+      reloaded = AdminRepo.get!(Budget, budget.id)
+      assert reloaded.warning_fired == true
+
+      # Update alert_threshold_pct — should reset flags
+      {:ok, updated} =
+        TokenUsage.update_budget(tenant.id, budget.id, %{alert_threshold_pct: 90})
+
+      assert updated.warning_fired == false
+      assert updated.exceeded_fired == false
+    end
+
+    test "flags are NOT reset when updating only metadata" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+
+      _webhook = create_webhook_for_events(tenant.id, ["token.budget_warning"])
+
+      {:ok, budget} =
+        TokenUsage.create_budget(tenant.id, %{
+          scope_type: :story,
+          scope_id: story.id,
+          budget_millicents: 10_000,
+          alert_threshold_pct: 80
+        })
+
+      # Fire the warning
+      {:ok, _} =
+        TokenUsage.create_report(tenant.id, %{
+          story_id: story.id,
+          agent_id: agent.id,
+          project_id: project.id,
+          input_tokens: 1000,
+          output_tokens: 500,
+          model_name: "claude-opus-4",
+          cost_millicents: 8_500
+        })
+
+      reloaded = AdminRepo.get!(Budget, budget.id)
+      assert reloaded.warning_fired == true
+
+      # Update only metadata — flags should remain
+      {:ok, updated} =
+        TokenUsage.update_budget(tenant.id, budget.id, %{
+          metadata: %{"note" => "updated metadata only"}
+        })
+
+      assert updated.warning_fired == true
+      assert updated.exceeded_fired == false
+    end
+  end
+
+  # --- AC-21.7.7: CostAnomalyWorker fires anomaly webhooks ---
+
+  describe "CostAnomalyWorker fires token.anomaly_detected (AC-21.7.7)" do
+    test "fires token.anomaly_detected webhook with correct payload when anomaly is created" do
+      %{tenant: tenant, story: story, agent: agent, project: project, epic: epic} =
+        setup_context()
+
+      _webhook = create_webhook_for_events(tenant.id, ["token.anomaly_detected"])
+
+      # Create cost summaries so CostAnomalyWorker has epic average
+      period = Date.utc_today()
+
+      %CostSummary{tenant_id: tenant.id}
+      |> CostSummary.changeset(%{
+        scope_type: :epic,
+        scope_id: epic.id,
+        period_start: period,
+        period_end: period,
+        total_cost_millicents: 10_000,
+        story_count: 2,
+        avg_cost_per_story_millicents: 5_000
+      })
+      |> AdminRepo.insert!()
+
+      # Create a report 4x the epic average to trigger high_cost anomaly
+      # Need to insert directly since CostAnomalyWorker uses its own date-based query
+      # We test via the create_anomaly path by calling the worker directly
+      {:ok, _report} =
+        TokenUsage.create_report(tenant.id, %{
+          story_id: story.id,
+          agent_id: agent.id,
+          project_id: project.id,
+          input_tokens: 5000,
+          output_tokens: 2000,
+          model_name: "claude-opus-4",
+          cost_millicents: 20_000
+        })
+
+      # Run the worker which will detect the anomaly from yesterday's rollup data
+      # Since we're in Oban inline mode and the worker runs against yesterday's period,
+      # we test via perform/1 with an explicit period matching today
+      job_args = %{
+        "period_start" => Date.to_iso8601(period),
+        "period_end" => Date.to_iso8601(period)
+      }
+
+      assert :ok = CostAnomalyWorker.perform(%Oban.Job{args: job_args, id: 1})
+
+      events = find_webhook_events(tenant.id, "token.anomaly_detected")
+      assert events != []
+
+      [event | _] = events
+      payload = event.payload
+
+      assert payload["story_id"] == story.id
+      assert payload["anomaly_type"] in ["high_cost", "suspiciously_low"]
+      assert is_integer(payload["story_cost_millicents"])
+      assert is_integer(payload["reference_avg_millicents"])
+      assert is_binary(payload["deviation_factor"])
+      assert is_binary(payload["anomaly_id"])
+    end
+
+    test "anomaly webhook payload includes story_title and agent context" do
+      %{tenant: tenant, story: story, agent: agent, project: project, epic: epic} =
+        setup_context()
+
+      # Assign the agent to the story
+      story
+      |> Ecto.Changeset.change(%{assigned_agent_id: agent.id})
+      |> AdminRepo.update!()
+
+      _webhook = create_webhook_for_events(tenant.id, ["token.anomaly_detected"])
+
+      period = Date.utc_today()
+
+      %CostSummary{tenant_id: tenant.id}
+      |> CostSummary.changeset(%{
+        scope_type: :epic,
+        scope_id: epic.id,
+        period_start: period,
+        period_end: period,
+        total_cost_millicents: 10_000,
+        story_count: 2,
+        avg_cost_per_story_millicents: 5_000
+      })
+      |> AdminRepo.insert!()
+
+      {:ok, _report} =
+        TokenUsage.create_report(tenant.id, %{
+          story_id: story.id,
+          agent_id: agent.id,
+          project_id: project.id,
+          input_tokens: 5000,
+          output_tokens: 2000,
+          model_name: "claude-opus-4",
+          cost_millicents: 20_000
+        })
+
+      job_args = %{
+        "period_start" => Date.to_iso8601(period),
+        "period_end" => Date.to_iso8601(period)
+      }
+
+      assert :ok = CostAnomalyWorker.perform(%Oban.Job{args: job_args, id: 1})
+
+      events = find_webhook_events(tenant.id, "token.anomaly_detected")
+      assert events != []
+
+      [event | _] = events
+      payload = event.payload
+
+      assert payload["story_title"] == story.title
+      assert payload["agent_id"] == agent.id
+      assert payload["agent_name"] == agent.name
+    end
+
+    test "does NOT fire anomaly webhook for updated (existing) anomalies" do
+      %{tenant: tenant, story: story, agent: agent, project: project, epic: epic} =
+        setup_context()
+
+      _webhook = create_webhook_for_events(tenant.id, ["token.anomaly_detected"])
+
+      period = Date.utc_today()
+
+      %CostSummary{tenant_id: tenant.id}
+      |> CostSummary.changeset(%{
+        scope_type: :epic,
+        scope_id: epic.id,
+        period_start: period,
+        period_end: period,
+        total_cost_millicents: 10_000,
+        story_count: 2,
+        avg_cost_per_story_millicents: 5_000
+      })
+      |> AdminRepo.insert!()
+
+      {:ok, _report} =
+        TokenUsage.create_report(tenant.id, %{
+          story_id: story.id,
+          agent_id: agent.id,
+          project_id: project.id,
+          input_tokens: 5000,
+          output_tokens: 2000,
+          model_name: "claude-opus-4",
+          cost_millicents: 20_000
+        })
+
+      job_args = %{
+        "period_start" => Date.to_iso8601(period),
+        "period_end" => Date.to_iso8601(period)
+      }
+
+      # First run creates the anomaly and fires the webhook
+      assert :ok = CostAnomalyWorker.perform(%Oban.Job{args: job_args, id: 1})
+      events_after_first = find_webhook_events(tenant.id, "token.anomaly_detected")
+      assert events_after_first != []
+
+      # Second run with same period should update existing anomaly (not insert new)
+      # and should NOT fire another webhook event
+      assert :ok = CostAnomalyWorker.perform(%Oban.Job{args: job_args, id: 2})
+      events_after_second = find_webhook_events(tenant.id, "token.anomaly_detected")
+      assert Enum.count(events_after_second) == Enum.count(events_after_first)
+    end
+
+    test "does not fire anomaly webhook if no webhook subscribed to token.anomaly_detected" do
+      %{tenant: tenant, story: story, agent: agent, project: project, epic: epic} =
+        setup_context()
+
+      # Subscribe to a different event only
+      _webhook = create_webhook_for_events(tenant.id, ["story.verified"])
+
+      period = Date.utc_today()
+
+      %CostSummary{tenant_id: tenant.id}
+      |> CostSummary.changeset(%{
+        scope_type: :epic,
+        scope_id: epic.id,
+        period_start: period,
+        period_end: period,
+        total_cost_millicents: 10_000,
+        story_count: 2,
+        avg_cost_per_story_millicents: 5_000
+      })
+      |> AdminRepo.insert!()
+
+      {:ok, _report} =
+        TokenUsage.create_report(tenant.id, %{
+          story_id: story.id,
+          agent_id: agent.id,
+          project_id: project.id,
+          input_tokens: 5000,
+          output_tokens: 2000,
+          model_name: "claude-opus-4",
+          cost_millicents: 20_000
+        })
+
+      job_args = %{
+        "period_start" => Date.to_iso8601(period),
+        "period_end" => Date.to_iso8601(period)
+      }
+
+      assert :ok = CostAnomalyWorker.perform(%Oban.Job{args: job_args, id: 1})
+
+      events = find_webhook_events(tenant.id, "token.anomaly_detected")
+      assert events == []
+    end
+  end
+
+  # --- Tenant isolation tests ---
+
+  describe "tenant isolation" do
+    test "budget webhook events are not visible to other tenants" do
+      %{tenant: tenant_a, story: story_a, agent: agent_a, project: project_a} = setup_context()
+      %{tenant: tenant_b} = setup_context()
+
+      _webhook_a = create_webhook_for_events(tenant_a.id, ["token.budget_warning"])
+      _webhook_b = create_webhook_for_events(tenant_b.id, ["token.budget_warning"])
+
+      {:ok, _budget} =
+        TokenUsage.create_budget(tenant_a.id, %{
+          scope_type: :story,
+          scope_id: story_a.id,
+          budget_millicents: 10_000,
+          alert_threshold_pct: 80
+        })
+
+      {:ok, _report} =
+        TokenUsage.create_report(tenant_a.id, %{
+          story_id: story_a.id,
+          agent_id: agent_a.id,
+          project_id: project_a.id,
+          input_tokens: 1000,
+          output_tokens: 500,
+          model_name: "claude-opus-4",
+          cost_millicents: 8_500
+        })
+
+      # Tenant A has the warning event
+      events_a = find_webhook_events(tenant_a.id, "token.budget_warning")
+      assert events_a != []
+
+      # Tenant B has no events
+      events_b = find_webhook_events(tenant_b.id, "token.budget_warning")
+      assert events_b == []
+    end
+
+    test "anomaly webhook events are not visible to other tenants" do
+      %{
+        tenant: tenant_a,
+        story: story_a,
+        agent: agent_a,
+        project: project_a,
+        epic: epic_a
+      } = setup_context()
+
+      %{tenant: tenant_b} = setup_context()
+
+      _webhook_a = create_webhook_for_events(tenant_a.id, ["token.anomaly_detected"])
+      _webhook_b = create_webhook_for_events(tenant_b.id, ["token.anomaly_detected"])
+
+      period = Date.utc_today()
+
+      %CostSummary{tenant_id: tenant_a.id}
+      |> CostSummary.changeset(%{
+        scope_type: :epic,
+        scope_id: epic_a.id,
+        period_start: period,
+        period_end: period,
+        total_cost_millicents: 10_000,
+        story_count: 2,
+        avg_cost_per_story_millicents: 5_000
+      })
+      |> AdminRepo.insert!()
+
+      {:ok, _report} =
+        TokenUsage.create_report(tenant_a.id, %{
+          story_id: story_a.id,
+          agent_id: agent_a.id,
+          project_id: project_a.id,
+          input_tokens: 5000,
+          output_tokens: 2000,
+          model_name: "claude-opus-4",
+          cost_millicents: 20_000
+        })
+
+      job_args = %{
+        "period_start" => Date.to_iso8601(period),
+        "period_end" => Date.to_iso8601(period)
+      }
+
+      assert :ok = CostAnomalyWorker.perform(%Oban.Job{args: job_args, id: 1})
+
+      # Tenant A has anomaly events
+      events_a = find_webhook_events(tenant_a.id, "token.anomaly_detected")
+      assert events_a != []
+
+      # Tenant B has no anomaly events
+      events_b = find_webhook_events(tenant_b.id, "token.anomaly_detected")
+      assert events_b == []
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds three new webhook event types registered in `Webhook.valid_event_types/0`: `token.budget_warning`, `token.budget_exceeded`, `token.anomaly_detected`
- Budget threshold checks in `TokenUsage.create_report/2` now fire webhook events synchronously after report insertion, with deduplication via `warning_fired`/`exceeded_fired` boolean columns on `token_budgets`
- Dedup flags reset automatically when `budget_millicents` or `alert_threshold_pct` is updated via `update_budget/4`
- `CostAnomalyWorker` fires `token.anomaly_detected` webhooks for newly created anomalies (not updates), including `story_title`, `agent_id`, and `agent_name` in the payload
- Migration adds `warning_fired` (default false) and `exceeded_fired` (default false) to `token_budgets`

## Test plan

- [x] AC-21.7.1: All three new event types accepted by webhook subscription creation
- [x] AC-21.7.2: `token.budget_warning` payload includes all required fields (no `overage_millicents`)
- [x] AC-21.7.3: `token.budget_exceeded` payload includes `overage_millicents`
- [x] AC-21.7.5: Webhook events created synchronously on `create_report/2`; no events when below threshold; no events without matching subscription
- [x] AC-21.7.6: Warning/exceeded each fire only once; flags reset on `budget_millicents` or `alert_threshold_pct` update; flags NOT reset on metadata-only update
- [x] AC-21.7.7: Anomaly webhooks fire for new anomalies, not for updates; no event without subscription; payload includes story context
- [x] Tenant isolation: budget and anomaly webhook events not visible across tenants
- [x] 23 new tests, 0 failures; all 1442 existing passing tests continue to pass