### PR TITLE
US-21.5: Model Mix Tracking & Verification Correlation

### DIFF
--- a/lib/loopctl/token_usage/analytics.ex
+++ b/lib/loopctl/token_usage/analytics.ex
@@ -2,7 +2,8 @@ defmodule Loopctl.TokenUsage.Analytics do
   @moduledoc """
   Analytics queries for token usage data.
 
-  Provides per-agent, per-epic, per-project, per-model, and trend analytics.
+  Provides per-agent, per-epic, per-project, per-model, trend, model-mix
+  correlation, and agent model profile analytics.
   All functions take `tenant_id` as the first argument for multi-tenant scoping.
 
   Queries prefer pre-computed `cost_summaries` when available and fresh,
@@ -468,6 +469,113 @@ defmodule Loopctl.TokenUsage.Analytics do
   end
 
   # ---------------------------------------------------------------------------
+  # AC-21.5.2: Model-mix correlation matrix
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Returns a model-mix correlation matrix for the given tenant.
+
+  For each (model_name, phase) pair: total_tokens, total_cost_millicents,
+  stories_count, verified_count, rejected_count, verification_rate_pct.
+
+  Also includes a comparative view: mixed-model vs single-model agent
+  averages for verification rate and cost per story.
+
+  ## Options
+
+  - `:project_id` -- filter by project UUID
+  - `:agent_id` -- filter by agent UUID
+  - `:since` -- only reports inserted on or after this date (Date)
+  - `:until` -- only reports inserted on or before this date (Date)
+  """
+  @spec model_mix(Ecto.UUID.t(), keyword()) :: {:ok, map()}
+  def model_mix(tenant_id, opts \\ []) do
+    base =
+      Report
+      |> where([r], r.tenant_id == ^tenant_id)
+      |> apply_date_filters(opts)
+      |> apply_project_filter(opts)
+      |> apply_agent_filter(opts)
+
+    # (model_name, phase) matrix
+    matrix_rows =
+      base
+      |> group_by([r], [r.model_name, r.phase])
+      |> select([r], %{
+        model_name: r.model_name,
+        phase: r.phase,
+        total_tokens: sum(r.input_tokens) + sum(r.output_tokens),
+        total_cost_millicents: sum(r.cost_millicents),
+        stories_count: count(r.story_id, :distinct)
+      })
+      |> order_by([r], asc: r.model_name, asc: r.phase)
+      |> AdminRepo.all()
+
+    # Verification data per (model_name, phase) pair
+    verification_map = model_phase_verification_data(tenant_id, opts)
+
+    matrix =
+      Enum.map(matrix_rows, fn row ->
+        phase_key = row.phase || "other"
+        vd = Map.get(verification_map, {row.model_name, phase_key}, %{verified: 0, rejected: 0})
+
+        total_verifiable = vd.verified + vd.rejected
+
+        verification_rate =
+          if total_verifiable > 0, do: safe_div(vd.verified * 100, total_verifiable), else: nil
+
+        %{
+          model_name: row.model_name,
+          phase: phase_key,
+          total_tokens: to_int(row.total_tokens),
+          total_cost_millicents: to_int(row.total_cost_millicents),
+          stories_count: row.stories_count,
+          verified_count: vd.verified,
+          rejected_count: vd.rejected,
+          verification_rate_pct: verification_rate
+        }
+      end)
+
+    comparative = model_mix_comparative(tenant_id, opts)
+
+    {:ok, %{matrix: matrix, comparative: comparative}}
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-21.5.3: Agent model profile
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Returns a specific agent's model usage profile.
+
+  Includes: models used, phases, cost breakdown, verification outcomes,
+  model_count, and is_model_blender (true if model_count > 1).
+
+  ## Options
+
+  - `:project_id` -- filter by project UUID
+  - `:since` -- only reports inserted on or after this date (Date)
+  - `:until` -- only reports inserted on or before this date (Date)
+  """
+  @spec agent_model_profile(Ecto.UUID.t(), Ecto.UUID.t(), keyword()) ::
+          {:ok, map()} | {:error, :not_found}
+  def agent_model_profile(tenant_id, agent_id, opts \\ []) do
+    # Verify the agent exists in this tenant
+    agent_query =
+      from(a in Agent,
+        where: a.id == ^agent_id and a.tenant_id == ^tenant_id
+      )
+
+    case AdminRepo.one(agent_query) do
+      nil ->
+        {:error, :not_found}
+
+      agent ->
+        {:ok, build_agent_model_profile(agent, tenant_id, agent_id, opts)}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # Private helpers
   # ---------------------------------------------------------------------------
 
@@ -695,6 +803,267 @@ defmodule Loopctl.TokenUsage.Analytics do
   end
 
   # Date filters for the joined query (reports joined with stories)
+  # Builds the agent model profile payload from raw DB rows.
+  # Extracted to avoid exceeding the nesting depth limit in agent_model_profile/3.
+  defp build_agent_model_profile(agent, tenant_id, agent_id, opts) do
+    base =
+      Report
+      |> where([r], r.tenant_id == ^tenant_id and r.agent_id == ^agent_id)
+      |> apply_date_filters(opts)
+      |> apply_project_filter(opts)
+
+    usage_rows =
+      base
+      |> group_by([r], [r.model_name, r.phase])
+      |> select([r], %{
+        model_name: r.model_name,
+        phase: r.phase,
+        total_input_tokens: sum(r.input_tokens),
+        total_output_tokens: sum(r.output_tokens),
+        total_cost_millicents: sum(r.cost_millicents),
+        report_count: count(r.id),
+        stories_count: count(r.story_id, :distinct)
+      })
+      |> order_by([r], asc: r.model_name, asc: r.phase)
+      |> AdminRepo.all()
+
+    verification_map = agent_model_phase_verification_data(tenant_id, agent_id, opts)
+
+    model_names =
+      usage_rows
+      |> Enum.map(& &1.model_name)
+      |> Enum.uniq()
+
+    model_count = length(model_names)
+
+    total_cost =
+      Enum.reduce(usage_rows, 0, fn row, acc -> acc + to_int(row.total_cost_millicents) end)
+
+    usage = Enum.map(usage_rows, &build_usage_entry(&1, verification_map, total_cost))
+
+    %{
+      agent_id: agent.id,
+      agent_name: agent.name,
+      model_count: model_count,
+      is_model_blender: model_count > 1,
+      models_used: model_names,
+      total_cost_millicents: total_cost,
+      usage: usage
+    }
+  end
+
+  defp build_usage_entry(row, verification_map, total_cost) do
+    phase_key = row.phase || "other"
+    vd = Map.get(verification_map, {row.model_name, phase_key}, %{verified: 0, rejected: 0})
+    total_verifiable = vd.verified + vd.rejected
+
+    verification_rate =
+      if total_verifiable > 0, do: safe_div(vd.verified * 100, total_verifiable), else: nil
+
+    cost = to_int(row.total_cost_millicents)
+    cost_share_pct = if total_cost > 0, do: safe_div(cost * 100, total_cost), else: nil
+
+    %{
+      model_name: row.model_name,
+      phase: phase_key,
+      total_input_tokens: to_int(row.total_input_tokens),
+      total_output_tokens: to_int(row.total_output_tokens),
+      total_cost_millicents: cost,
+      report_count: row.report_count,
+      stories_count: row.stories_count,
+      verified_count: vd.verified,
+      rejected_count: vd.rejected,
+      verification_rate_pct: verification_rate,
+      cost_share_pct: cost_share_pct
+    }
+  end
+
+  defp apply_agent_filter(query, opts) do
+    case Keyword.get(opts, :agent_id) do
+      nil -> query
+      aid -> where(query, [r], r.agent_id == ^aid)
+    end
+  end
+
+  # Model-phase verification data for the matrix query.
+  # Returns %{{model_name, phase} => %{verified: n, rejected: n}}
+  defp model_phase_verification_data(tenant_id, opts) do
+    base =
+      Report
+      |> join(:inner, [r], s in Story, on: r.story_id == s.id)
+      |> where([r, _s], r.tenant_id == ^tenant_id)
+      |> where([_r, s], s.verified_status in [:verified, :rejected])
+      |> apply_model_date_filters(opts)
+      |> apply_model_project_filter(opts)
+      |> apply_model_agent_filter(opts)
+
+    base
+    |> group_by([r, s], [r.model_name, r.phase, s.verified_status])
+    |> select([r, s], %{
+      model_name: r.model_name,
+      phase: r.phase,
+      verified_status: s.verified_status,
+      story_count: count(s.id, :distinct)
+    })
+    |> AdminRepo.all()
+    |> Enum.group_by(fn row -> {row.model_name, row.phase || "other"} end)
+    |> Map.new(fn {key, rows} ->
+      verified = Enum.find(rows, &(&1.verified_status == :verified))
+      rejected = Enum.find(rows, &(&1.verified_status == :rejected))
+
+      {key,
+       %{
+         verified: if(verified, do: verified.story_count, else: 0),
+         rejected: if(rejected, do: rejected.story_count, else: 0)
+       }}
+    end)
+  end
+
+  # Agent-specific model-phase verification data.
+  # Returns %{{model_name, phase} => %{verified: n, rejected: n}}
+  defp agent_model_phase_verification_data(tenant_id, agent_id, opts) do
+    base =
+      Report
+      |> join(:inner, [r], s in Story, on: r.story_id == s.id)
+      |> where([r, _s], r.tenant_id == ^tenant_id and r.agent_id == ^agent_id)
+      |> where([_r, s], s.verified_status in [:verified, :rejected])
+      |> apply_model_date_filters(opts)
+      |> apply_model_project_filter(opts)
+
+    base
+    |> group_by([r, s], [r.model_name, r.phase, s.verified_status])
+    |> select([r, s], %{
+      model_name: r.model_name,
+      phase: r.phase,
+      verified_status: s.verified_status,
+      story_count: count(s.id, :distinct)
+    })
+    |> AdminRepo.all()
+    |> Enum.group_by(fn row -> {row.model_name, row.phase || "other"} end)
+    |> Map.new(fn {key, rows} ->
+      verified = Enum.find(rows, &(&1.verified_status == :verified))
+      rejected = Enum.find(rows, &(&1.verified_status == :rejected))
+
+      {key,
+       %{
+         verified: if(verified, do: verified.story_count, else: 0),
+         rejected: if(rejected, do: rejected.story_count, else: 0)
+       }}
+    end)
+  end
+
+  # AC-21.5.4: Comparative view — mixed-model vs single-model agents.
+  # Returns avg verification rate and avg cost per story for each group.
+  defp model_mix_comparative(tenant_id, opts) do
+    # Compute per-agent: model_count, total_cost, story_count, verified_count
+    agent_stats =
+      Report
+      |> where([r], r.tenant_id == ^tenant_id)
+      |> where([r], not is_nil(r.agent_id))
+      |> apply_date_filters(opts)
+      |> apply_project_filter(opts)
+      |> group_by([r], r.agent_id)
+      |> select([r], %{
+        agent_id: r.agent_id,
+        model_count: count(r.model_name, :distinct),
+        total_cost_millicents: sum(r.cost_millicents),
+        stories_count: count(r.story_id, :distinct)
+      })
+      |> AdminRepo.all()
+
+    # Verification counts per agent (from verified/rejected stories)
+    agent_verification =
+      Report
+      |> join(:inner, [r], s in Story, on: r.story_id == s.id)
+      |> where([r, _s], r.tenant_id == ^tenant_id)
+      |> where([r, _s], not is_nil(r.agent_id))
+      |> where([_r, s], s.verified_status in [:verified, :rejected])
+      |> apply_model_date_filters(opts)
+      |> apply_model_project_filter(opts)
+      |> group_by([r, s], [r.agent_id, s.verified_status])
+      |> select([r, s], %{
+        agent_id: r.agent_id,
+        verified_status: s.verified_status,
+        story_count: count(s.id, :distinct)
+      })
+      |> AdminRepo.all()
+      |> Enum.group_by(& &1.agent_id)
+      |> Map.new(fn {agent_id, rows} ->
+        verified = Enum.find(rows, &(&1.verified_status == :verified))
+        rejected = Enum.find(rows, &(&1.verified_status == :rejected))
+
+        {agent_id,
+         %{
+           verified: if(verified, do: verified.story_count, else: 0),
+           rejected: if(rejected, do: rejected.story_count, else: 0)
+         }}
+      end)
+
+    # Build per-agent enriched data
+    enriched =
+      Enum.map(agent_stats, fn row ->
+        vd = Map.get(agent_verification, row.agent_id, %{verified: 0, rejected: 0})
+        total_verifiable = vd.verified + vd.rejected
+
+        verification_rate =
+          if total_verifiable > 0, do: safe_div(vd.verified * 100, total_verifiable), else: nil
+
+        cost = to_int(row.total_cost_millicents)
+        avg_cost = safe_div(cost, row.stories_count)
+
+        %{
+          model_count: row.model_count,
+          is_model_blender: row.model_count > 1,
+          avg_cost_per_story_millicents: avg_cost,
+          verification_rate_pct: verification_rate
+        }
+      end)
+
+    # Split into blender / single groups
+    {blenders, singles} = Enum.split_with(enriched, & &1.is_model_blender)
+
+    %{
+      mixed_model: aggregate_comparative_group(blenders),
+      single_model: aggregate_comparative_group(singles)
+    }
+  end
+
+  defp aggregate_comparative_group([]) do
+    %{agent_count: 0, avg_verification_rate_pct: nil, avg_cost_per_story_millicents: nil}
+  end
+
+  defp aggregate_comparative_group(agents) do
+    count = length(agents)
+
+    rates = Enum.reject(agents, &is_nil(&1.verification_rate_pct))
+
+    avg_rate =
+      if rates != [] do
+        total = Enum.reduce(rates, 0, &(&1.verification_rate_pct + &2))
+        safe_div(total, length(rates))
+      else
+        nil
+      end
+
+    avg_cost =
+      agents
+      |> Enum.reject(&(&1.avg_cost_per_story_millicents == 0))
+      |> then(fn non_zero ->
+        if non_zero != [] do
+          total = Enum.reduce(non_zero, 0, &(&1.avg_cost_per_story_millicents + &2))
+          safe_div(total, length(non_zero))
+        else
+          0
+        end
+      end)
+
+    %{
+      agent_count: count,
+      avg_verification_rate_pct: avg_rate,
+      avg_cost_per_story_millicents: avg_cost
+    }
+  end
+
   defp apply_model_date_filters(query, opts) do
     query
     |> maybe_model_since(Keyword.get(opts, :since))
@@ -719,6 +1088,13 @@ defmodule Loopctl.TokenUsage.Analytics do
     case Keyword.get(opts, :project_id) do
       nil -> query
       pid -> where(query, [r, _s], r.project_id == ^pid)
+    end
+  end
+
+  defp apply_model_agent_filter(query, opts) do
+    case Keyword.get(opts, :agent_id) do
+      nil -> query
+      aid -> where(query, [r, _s], r.agent_id == ^aid)
     end
   end
 

--- a/lib/loopctl_web/controllers/analytics_controller.ex
+++ b/lib/loopctl_web/controllers/analytics_controller.ex
@@ -7,6 +7,8 @@ defmodule LoopctlWeb.AnalyticsController do
   - `GET /api/v1/analytics/projects/:id` -- single project cost overview (agent+)
   - `GET /api/v1/analytics/models` -- model mix analysis (agent+)
   - `GET /api/v1/analytics/trends` -- daily/weekly cost trend (orchestrator+)
+  - `GET /api/v1/analytics/model-mix` -- model-mix correlation matrix (orchestrator+)
+  - `GET /api/v1/analytics/agents/:id/model-profile` -- agent model profile (orchestrator+)
 
   All endpoints are read-only and return empty results when no data exists.
   """
@@ -19,7 +21,9 @@ defmodule LoopctlWeb.AnalyticsController do
 
   action_fallback LoopctlWeb.FallbackController
 
-  plug LoopctlWeb.Plugs.RequireRole, [role: :orchestrator] when action in [:agents, :trends]
+  plug LoopctlWeb.Plugs.RequireRole,
+       [role: :orchestrator] when action in [:agents, :trends, :model_mix, :agent_model_profile]
+
   plug LoopctlWeb.Plugs.RequireRole, [role: :agent] when action in [:epics, :project, :models]
 
   tags(["Analytics"])
@@ -128,6 +132,48 @@ defmodule LoopctlWeb.AnalyticsController do
     }
   )
 
+  operation(:model_mix,
+    summary: "Model-mix correlation matrix",
+    description:
+      "Returns a (model_name, phase) correlation matrix with token totals, cost, " <>
+        "stories count, and verification outcomes. Includes comparative view: " <>
+        "mixed-model vs single-model agent averages. " <>
+        "Filterable by project_id, agent_id, and date range.",
+    parameters: [
+      project_id: [in: :query, type: :string, description: "Filter by project UUID"],
+      agent_id: [in: :query, type: :string, description: "Filter by agent UUID"],
+      since: [in: :query, type: :string, description: "Start date (YYYY-MM-DD)"],
+      until: [in: :query, type: :string, description: "End date (YYYY-MM-DD)"]
+    ],
+    responses: %{
+      200 =>
+        {"Model-mix matrix", "application/json",
+         %OpenApiSpex.Schema{type: :object, additionalProperties: true}},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  operation(:agent_model_profile,
+    summary: "Agent model usage profile",
+    description:
+      "Returns a specific agent's model usage profile across phases. " <>
+        "Includes model_count and is_model_blender (true if agent uses more than one model). " <>
+        "Filterable by project_id and date range.",
+    parameters: [
+      id: [in: :path, type: :string, description: "Agent UUID"],
+      project_id: [in: :query, type: :string, description: "Filter by project UUID"],
+      since: [in: :query, type: :string, description: "Start date (YYYY-MM-DD)"],
+      until: [in: :query, type: :string, description: "End date (YYYY-MM-DD)"]
+    ],
+    responses: %{
+      200 =>
+        {"Agent model profile", "application/json",
+         %OpenApiSpex.Schema{type: :object, additionalProperties: true}},
+      404 => {"Agent not found", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
   # ---------------------------------------------------------------------------
   # Actions
   # ---------------------------------------------------------------------------
@@ -215,26 +261,55 @@ defmodule LoopctlWeb.AnalyticsController do
     })
   end
 
+  @doc """
+  GET /api/v1/analytics/model-mix
+
+  Returns model-mix correlation matrix with comparative view.
+  """
+  def model_mix(conn, params) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+    opts = build_opts(params, [:project_id, :agent_id, :since, :until])
+
+    {:ok, result} = Analytics.model_mix(tenant_id, opts)
+
+    json(conn, %{data: result})
+  end
+
+  @doc """
+  GET /api/v1/analytics/agents/:id/model-profile
+
+  Returns a specific agent's model usage profile.
+  """
+  def agent_model_profile(conn, %{"id" => agent_id} = params) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+    opts = build_opts(params, [:project_id, :since, :until])
+
+    with {:ok, profile} <- Analytics.agent_model_profile(tenant_id, agent_id, opts) do
+      json(conn, %{data: profile})
+    end
+  end
+
   # ---------------------------------------------------------------------------
   # Private helpers
   # ---------------------------------------------------------------------------
 
   defp build_opts(params, allowed_keys) do
     Enum.reduce(allowed_keys, [], fn key, acc ->
-      str_key = Atom.to_string(key)
-
-      case {key, Map.get(params, str_key)} do
-        {_, nil} -> acc
-        {:page, val} -> maybe_add_opt(acc, :page, parse_int(val))
-        {:page_size, val} -> maybe_add_opt(acc, :page_size, parse_int(val))
-        {:since, val} -> maybe_add_opt(acc, :since, parse_date(val))
-        {:until, val} -> maybe_add_opt(acc, :until, parse_date(val))
-        {:project_id, val} -> maybe_add_opt(acc, :project_id, val)
-        {:granularity, val} -> maybe_add_opt(acc, :granularity, val)
-        _ -> acc
-      end
+      val = Map.get(params, Atom.to_string(key))
+      maybe_add_opt(acc, key, parse_opt(key, val))
     end)
   end
+
+  # String passthrough keys
+  @string_keys [:project_id, :agent_id, :granularity]
+
+  defp parse_opt(_key, nil), do: nil
+  defp parse_opt(key, val) when key in @string_keys, do: val
+  defp parse_opt(:page, val), do: parse_int(val)
+  defp parse_opt(:page_size, val), do: parse_int(val)
+  defp parse_opt(:since, val), do: parse_date(val)
+  defp parse_opt(:until, val), do: parse_date(val)
+  defp parse_opt(_key, _val), do: nil
 
   defp pagination_meta(result) do
     %{

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -221,6 +221,9 @@ defmodule LoopctlWeb.Router do
     get "/analytics/projects/:id", AnalyticsController, :project
     get "/analytics/models", AnalyticsController, :models
     get "/analytics/trends", AnalyticsController, :trends
+    # Model-mix and agent model profile (US-21.5)
+    get "/analytics/model-mix", AnalyticsController, :model_mix
+    get "/analytics/agents/:id/model-profile", AnalyticsController, :agent_model_profile
 
     # Skill results
     post "/skill_results", SkillResultController, :create

--- a/test/loopctl/token_usage/model_mix_analytics_test.exs
+++ b/test/loopctl/token_usage/model_mix_analytics_test.exs
@@ -1,0 +1,366 @@
+defmodule Loopctl.TokenUsage.ModelMixAnalyticsTest do
+  use Loopctl.DataCase, async: true
+
+  import Loopctl.Fixtures
+
+  alias Loopctl.TokenUsage.Analytics
+
+  setup :verify_on_exit!
+
+  # Builds a test dataset with two agents using different model combinations.
+  # agent1 (model blender): uses both claude-opus-4 and claude-sonnet-4
+  # agent2 (single model): uses only claude-sonnet-4
+  defp setup_model_mix_data do
+    tenant = fixture(:tenant)
+    project = fixture(:project, %{tenant_id: tenant.id})
+    epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+
+    agent1 = fixture(:agent, %{tenant_id: tenant.id, name: "agent-blender"})
+    agent2 = fixture(:agent, %{tenant_id: tenant.id, name: "agent-single"})
+
+    story1 =
+      fixture(:story, %{
+        tenant_id: tenant.id,
+        epic_id: epic.id,
+        project_id: project.id,
+        verified_status: :verified,
+        assigned_agent_id: agent1.id
+      })
+
+    story2 =
+      fixture(:story, %{
+        tenant_id: tenant.id,
+        epic_id: epic.id,
+        project_id: project.id,
+        verified_status: :rejected,
+        assigned_agent_id: agent2.id
+      })
+
+    story3 =
+      fixture(:story, %{
+        tenant_id: tenant.id,
+        epic_id: epic.id,
+        project_id: project.id,
+        verified_status: :verified,
+        assigned_agent_id: agent1.id
+      })
+
+    # agent1 implementing with opus
+    _r1 =
+      fixture(:token_usage_report, %{
+        tenant_id: tenant.id,
+        story_id: story1.id,
+        agent_id: agent1.id,
+        project_id: project.id,
+        model_name: "claude-opus-4",
+        input_tokens: 2000,
+        output_tokens: 1000,
+        cost_millicents: 6000,
+        phase: "implementing"
+      })
+
+    # agent1 reviewing with sonnet (makes agent1 a blender)
+    _r2 =
+      fixture(:token_usage_report, %{
+        tenant_id: tenant.id,
+        story_id: story3.id,
+        agent_id: agent1.id,
+        project_id: project.id,
+        model_name: "claude-sonnet-4",
+        input_tokens: 1000,
+        output_tokens: 500,
+        cost_millicents: 2000,
+        phase: "reviewing"
+      })
+
+    # agent2 implementing with sonnet only
+    _r3 =
+      fixture(:token_usage_report, %{
+        tenant_id: tenant.id,
+        story_id: story2.id,
+        agent_id: agent2.id,
+        project_id: project.id,
+        model_name: "claude-sonnet-4",
+        input_tokens: 1500,
+        output_tokens: 700,
+        cost_millicents: 3000,
+        phase: "implementing"
+      })
+
+    %{
+      tenant: tenant,
+      project: project,
+      epic: epic,
+      agent1: agent1,
+      agent2: agent2,
+      story1: story1,
+      story2: story2,
+      story3: story3
+    }
+  end
+
+  # ---------------------------------------------------------------------------
+  # model_mix/2
+  # ---------------------------------------------------------------------------
+
+  describe "model_mix/2" do
+    test "returns matrix and comparative" do
+      ctx = setup_model_mix_data()
+
+      {:ok, result} = Analytics.model_mix(ctx.tenant.id)
+
+      assert is_list(result.matrix)
+      assert is_map(result.comparative)
+    end
+
+    test "matrix contains (model_name, phase) pairs" do
+      ctx = setup_model_mix_data()
+
+      {:ok, result} = Analytics.model_mix(ctx.tenant.id)
+
+      matrix = result.matrix
+
+      # We have: opus/implementing, sonnet/reviewing, sonnet/implementing
+      assert length(matrix) == 3
+
+      opus_impl =
+        Enum.find(matrix, &(&1.model_name == "claude-opus-4" and &1.phase == "implementing"))
+
+      assert opus_impl != nil
+      assert opus_impl.total_cost_millicents == 6000
+      assert opus_impl.total_tokens == 3000
+      assert opus_impl.stories_count == 1
+    end
+
+    test "matrix includes verification outcomes" do
+      ctx = setup_model_mix_data()
+
+      {:ok, result} = Analytics.model_mix(ctx.tenant.id)
+
+      # opus/implementing: story1 is verified
+      opus_impl =
+        Enum.find(
+          result.matrix,
+          &(&1.model_name == "claude-opus-4" and &1.phase == "implementing")
+        )
+
+      assert opus_impl.verified_count == 1
+      assert opus_impl.rejected_count == 0
+      assert opus_impl.verification_rate_pct == 100
+
+      # sonnet/implementing: story2 is rejected
+      sonnet_impl =
+        Enum.find(
+          result.matrix,
+          &(&1.model_name == "claude-sonnet-4" and &1.phase == "implementing")
+        )
+
+      assert sonnet_impl.rejected_count == 1
+      assert sonnet_impl.verified_count == 0
+    end
+
+    test "comparative view includes mixed_model and single_model groups" do
+      ctx = setup_model_mix_data()
+
+      {:ok, result} = Analytics.model_mix(ctx.tenant.id)
+
+      comp = result.comparative
+      assert Map.has_key?(comp, :mixed_model)
+      assert Map.has_key?(comp, :single_model)
+
+      # agent1 uses 2 models → mixed_model count = 1
+      assert comp.mixed_model.agent_count == 1
+      # agent2 uses 1 model → single_model count = 1
+      assert comp.single_model.agent_count == 1
+    end
+
+    test "comparative groups include avg_cost_per_story and avg_verification_rate" do
+      ctx = setup_model_mix_data()
+
+      {:ok, result} = Analytics.model_mix(ctx.tenant.id)
+
+      comp = result.comparative
+      assert Map.has_key?(comp.mixed_model, :avg_cost_per_story_millicents)
+      assert Map.has_key?(comp.mixed_model, :avg_verification_rate_pct)
+      assert Map.has_key?(comp.single_model, :avg_cost_per_story_millicents)
+      assert Map.has_key?(comp.single_model, :avg_verification_rate_pct)
+    end
+
+    test "filters by project_id" do
+      ctx = setup_model_mix_data()
+      other_project = fixture(:project, %{tenant_id: ctx.tenant.id})
+
+      {:ok, result} = Analytics.model_mix(ctx.tenant.id, project_id: other_project.id)
+
+      assert result.matrix == []
+    end
+
+    test "filters by agent_id" do
+      ctx = setup_model_mix_data()
+
+      {:ok, result} = Analytics.model_mix(ctx.tenant.id, agent_id: ctx.agent2.id)
+
+      # Only agent2's reports: sonnet/implementing
+      assert length(result.matrix) == 1
+      entry = hd(result.matrix)
+      assert entry.model_name == "claude-sonnet-4"
+      assert entry.phase == "implementing"
+    end
+
+    test "filters by date range" do
+      ctx = setup_model_mix_data()
+
+      {:ok, result} =
+        Analytics.model_mix(ctx.tenant.id,
+          since: Date.add(Date.utc_today(), 1)
+        )
+
+      assert result.matrix == []
+    end
+
+    test "returns empty matrix for tenant with no data" do
+      tenant = fixture(:tenant)
+
+      {:ok, result} = Analytics.model_mix(tenant.id)
+
+      assert result.matrix == []
+      assert result.comparative.mixed_model.agent_count == 0
+      assert result.comparative.single_model.agent_count == 0
+    end
+
+    test "tenant isolation" do
+      ctx = setup_model_mix_data()
+      other_tenant = fixture(:tenant)
+
+      {:ok, result} = Analytics.model_mix(other_tenant.id)
+
+      assert result.matrix == []
+
+      # Own tenant still has data
+      {:ok, own_result} = Analytics.model_mix(ctx.tenant.id)
+      assert own_result.matrix != []
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # agent_model_profile/3
+  # ---------------------------------------------------------------------------
+
+  describe "agent_model_profile/3" do
+    test "returns profile for model-blender agent" do
+      ctx = setup_model_mix_data()
+
+      {:ok, result} = Analytics.agent_model_profile(ctx.tenant.id, ctx.agent1.id)
+
+      assert result.agent_id == ctx.agent1.id
+      assert result.agent_name == "agent-blender"
+      assert result.model_count == 2
+      assert result.is_model_blender == true
+      assert "claude-opus-4" in result.models_used
+      assert "claude-sonnet-4" in result.models_used
+    end
+
+    test "returns profile for single-model agent" do
+      ctx = setup_model_mix_data()
+
+      {:ok, result} = Analytics.agent_model_profile(ctx.tenant.id, ctx.agent2.id)
+
+      assert result.agent_id == ctx.agent2.id
+      assert result.agent_name == "agent-single"
+      assert result.model_count == 1
+      assert result.is_model_blender == false
+      assert result.models_used == ["claude-sonnet-4"]
+    end
+
+    test "includes usage breakdown per (model, phase)" do
+      ctx = setup_model_mix_data()
+
+      {:ok, result} = Analytics.agent_model_profile(ctx.tenant.id, ctx.agent1.id)
+
+      usage = result.usage
+      assert is_list(usage)
+      assert length(usage) == 2
+
+      opus_entry =
+        Enum.find(usage, &(&1.model_name == "claude-opus-4" and &1.phase == "implementing"))
+
+      assert opus_entry != nil
+      assert opus_entry.total_cost_millicents == 6000
+      assert opus_entry.total_input_tokens == 2000
+      assert opus_entry.total_output_tokens == 1000
+    end
+
+    test "includes verification outcomes in usage" do
+      ctx = setup_model_mix_data()
+
+      {:ok, result} = Analytics.agent_model_profile(ctx.tenant.id, ctx.agent1.id)
+
+      opus_entry =
+        Enum.find(
+          result.usage,
+          &(&1.model_name == "claude-opus-4" and &1.phase == "implementing")
+        )
+
+      assert opus_entry.verified_count == 1
+      assert opus_entry.rejected_count == 0
+      assert opus_entry.verification_rate_pct == 100
+    end
+
+    test "includes cost_share_pct in usage entries" do
+      ctx = setup_model_mix_data()
+
+      {:ok, result} = Analytics.agent_model_profile(ctx.tenant.id, ctx.agent1.id)
+
+      # agent1 total cost: 6000 (opus/implementing) + 2000 (sonnet/reviewing) = 8000
+      assert result.total_cost_millicents == 8000
+
+      opus_entry = Enum.find(result.usage, &(&1.model_name == "claude-opus-4"))
+      # 6000 / 8000 * 100 = 75%
+      assert opus_entry.cost_share_pct == 75
+
+      sonnet_entry = Enum.find(result.usage, &(&1.model_name == "claude-sonnet-4"))
+      # 2000 / 8000 * 100 = 25%
+      assert sonnet_entry.cost_share_pct == 25
+    end
+
+    test "filters by project_id" do
+      ctx = setup_model_mix_data()
+      other_project = fixture(:project, %{tenant_id: ctx.tenant.id})
+
+      {:ok, result} =
+        Analytics.agent_model_profile(ctx.tenant.id, ctx.agent1.id, project_id: other_project.id)
+
+      assert result.usage == []
+      assert result.model_count == 0
+      assert result.is_model_blender == false
+      assert result.total_cost_millicents == 0
+    end
+
+    test "filters by date range" do
+      ctx = setup_model_mix_data()
+
+      {:ok, result} =
+        Analytics.agent_model_profile(ctx.tenant.id, ctx.agent1.id,
+          since: Date.add(Date.utc_today(), 1)
+        )
+
+      assert result.usage == []
+      assert result.model_count == 0
+    end
+
+    test "returns not_found for unknown agent" do
+      tenant = fixture(:tenant)
+
+      assert {:error, :not_found} =
+               Analytics.agent_model_profile(tenant.id, Ecto.UUID.generate())
+    end
+
+    test "tenant isolation - agent in other tenant returns not_found" do
+      ctx = setup_model_mix_data()
+      other_tenant = fixture(:tenant)
+
+      assert {:error, :not_found} =
+               Analytics.agent_model_profile(other_tenant.id, ctx.agent1.id)
+    end
+  end
+end

--- a/test/loopctl_web/controllers/model_mix_analytics_controller_test.exs
+++ b/test/loopctl_web/controllers/model_mix_analytics_controller_test.exs
@@ -1,0 +1,343 @@
+defmodule LoopctlWeb.ModelMixAnalyticsControllerTest do
+  use LoopctlWeb.ConnCase, async: true
+
+  setup :verify_on_exit!
+
+  defp auth_conn(conn, raw_key) do
+    put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  defp setup_model_mix_context do
+    tenant = fixture(:tenant)
+    project = fixture(:project, %{tenant_id: tenant.id})
+    epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+
+    agent1 = fixture(:agent, %{tenant_id: tenant.id, name: "blender-agent"})
+    agent2 = fixture(:agent, %{tenant_id: tenant.id, name: "single-model-agent"})
+
+    story1 =
+      fixture(:story, %{
+        tenant_id: tenant.id,
+        epic_id: epic.id,
+        project_id: project.id,
+        verified_status: :verified,
+        assigned_agent_id: agent1.id
+      })
+
+    story2 =
+      fixture(:story, %{
+        tenant_id: tenant.id,
+        epic_id: epic.id,
+        project_id: project.id,
+        verified_status: :rejected,
+        assigned_agent_id: agent2.id
+      })
+
+    # agent1: opus for implementing
+    _r1 =
+      fixture(:token_usage_report, %{
+        tenant_id: tenant.id,
+        story_id: story1.id,
+        agent_id: agent1.id,
+        project_id: project.id,
+        model_name: "claude-opus-4",
+        input_tokens: 2000,
+        output_tokens: 1000,
+        cost_millicents: 6000,
+        phase: "implementing"
+      })
+
+    # agent1: sonnet for reviewing (blender)
+    _r2 =
+      fixture(:token_usage_report, %{
+        tenant_id: tenant.id,
+        story_id: story1.id,
+        agent_id: agent1.id,
+        project_id: project.id,
+        model_name: "claude-sonnet-4",
+        input_tokens: 500,
+        output_tokens: 200,
+        cost_millicents: 1000,
+        phase: "reviewing"
+      })
+
+    # agent2: sonnet only
+    _r3 =
+      fixture(:token_usage_report, %{
+        tenant_id: tenant.id,
+        story_id: story2.id,
+        agent_id: agent2.id,
+        project_id: project.id,
+        model_name: "claude-sonnet-4",
+        input_tokens: 1000,
+        output_tokens: 500,
+        cost_millicents: 2000,
+        phase: "implementing"
+      })
+
+    {orch_key, _orch_api_key} =
+      fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator, agent_id: agent1.id})
+
+    {agent_key, _agent_api_key} =
+      fixture(:api_key, %{tenant_id: tenant.id, role: :agent, agent_id: agent1.id})
+
+    %{
+      tenant: tenant,
+      project: project,
+      agent1: agent1,
+      agent2: agent2,
+      story1: story1,
+      story2: story2,
+      orch_key: orch_key,
+      agent_key: agent_key
+    }
+  end
+
+  # ---------------------------------------------------------------------------
+  # GET /api/v1/analytics/model-mix
+  # ---------------------------------------------------------------------------
+
+  describe "GET /api/v1/analytics/model-mix" do
+    test "returns model-mix matrix for orchestrator role", %{conn: conn} do
+      ctx = setup_model_mix_context()
+
+      conn =
+        conn
+        |> auth_conn(ctx.orch_key)
+        |> get(~p"/api/v1/analytics/model-mix")
+
+      body = json_response(conn, 200)
+      data = body["data"]
+
+      assert Map.has_key?(data, "matrix")
+      assert Map.has_key?(data, "comparative")
+      assert is_list(data["matrix"])
+    end
+
+    test "matrix entries contain required fields", %{conn: conn} do
+      ctx = setup_model_mix_context()
+
+      conn =
+        conn
+        |> auth_conn(ctx.orch_key)
+        |> get(~p"/api/v1/analytics/model-mix")
+
+      body = json_response(conn, 200)
+      matrix = body["data"]["matrix"]
+
+      assert matrix != []
+
+      entry = hd(matrix)
+      assert Map.has_key?(entry, "model_name")
+      assert Map.has_key?(entry, "phase")
+      assert Map.has_key?(entry, "total_tokens")
+      assert Map.has_key?(entry, "total_cost_millicents")
+      assert Map.has_key?(entry, "stories_count")
+      assert Map.has_key?(entry, "verified_count")
+      assert Map.has_key?(entry, "rejected_count")
+      assert Map.has_key?(entry, "verification_rate_pct")
+    end
+
+    test "comparative view contains mixed_model and single_model groups", %{conn: conn} do
+      ctx = setup_model_mix_context()
+
+      conn =
+        conn
+        |> auth_conn(ctx.orch_key)
+        |> get(~p"/api/v1/analytics/model-mix")
+
+      body = json_response(conn, 200)
+      comparative = body["data"]["comparative"]
+
+      assert Map.has_key?(comparative, "mixed_model")
+      assert Map.has_key?(comparative, "single_model")
+      assert Map.has_key?(comparative["mixed_model"], "agent_count")
+      assert Map.has_key?(comparative["mixed_model"], "avg_verification_rate_pct")
+      assert Map.has_key?(comparative["mixed_model"], "avg_cost_per_story_millicents")
+    end
+
+    test "filters by project_id", %{conn: conn} do
+      ctx = setup_model_mix_context()
+      other_project = fixture(:project, %{tenant_id: ctx.tenant.id})
+
+      conn =
+        conn
+        |> auth_conn(ctx.orch_key)
+        |> get(~p"/api/v1/analytics/model-mix?project_id=#{other_project.id}")
+
+      body = json_response(conn, 200)
+      assert body["data"]["matrix"] == []
+    end
+
+    test "filters by agent_id", %{conn: conn} do
+      ctx = setup_model_mix_context()
+
+      conn =
+        conn
+        |> auth_conn(ctx.orch_key)
+        |> get(~p"/api/v1/analytics/model-mix?agent_id=#{ctx.agent2.id}")
+
+      body = json_response(conn, 200)
+      matrix = body["data"]["matrix"]
+
+      # Only agent2's reports
+      assert length(matrix) == 1
+      assert hd(matrix)["model_name"] == "claude-sonnet-4"
+    end
+
+    test "filters by date range", %{conn: conn} do
+      ctx = setup_model_mix_context()
+      tomorrow = Date.add(Date.utc_today(), 1) |> Date.to_iso8601()
+
+      conn =
+        conn
+        |> auth_conn(ctx.orch_key)
+        |> get(~p"/api/v1/analytics/model-mix?since=#{tomorrow}")
+
+      body = json_response(conn, 200)
+      assert body["data"]["matrix"] == []
+    end
+
+    test "returns 403 for agent role", %{conn: conn} do
+      ctx = setup_model_mix_context()
+
+      conn =
+        conn
+        |> auth_conn(ctx.agent_key)
+        |> get(~p"/api/v1/analytics/model-mix")
+
+      assert json_response(conn, 403)
+    end
+
+    test "tenant isolation", %{conn: conn} do
+      _ctx = setup_model_mix_context()
+
+      other_tenant = fixture(:tenant)
+      {other_key, _} = fixture(:api_key, %{tenant_id: other_tenant.id, role: :orchestrator})
+
+      conn =
+        conn
+        |> auth_conn(other_key)
+        |> get(~p"/api/v1/analytics/model-mix")
+
+      body = json_response(conn, 200)
+      assert body["data"]["matrix"] == []
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # GET /api/v1/analytics/agents/:id/model-profile
+  # ---------------------------------------------------------------------------
+
+  describe "GET /api/v1/analytics/agents/:id/model-profile" do
+    test "returns model profile for blender agent", %{conn: conn} do
+      ctx = setup_model_mix_context()
+
+      conn =
+        conn
+        |> auth_conn(ctx.orch_key)
+        |> get(~p"/api/v1/analytics/agents/#{ctx.agent1.id}/model-profile")
+
+      body = json_response(conn, 200)
+      data = body["data"]
+
+      assert data["agent_id"] == ctx.agent1.id
+      assert data["agent_name"] == "blender-agent"
+      assert data["model_count"] == 2
+      assert data["is_model_blender"] == true
+      assert "claude-opus-4" in data["models_used"]
+      assert "claude-sonnet-4" in data["models_used"]
+    end
+
+    test "returns model profile for single-model agent", %{conn: conn} do
+      ctx = setup_model_mix_context()
+
+      conn =
+        conn
+        |> auth_conn(ctx.orch_key)
+        |> get(~p"/api/v1/analytics/agents/#{ctx.agent2.id}/model-profile")
+
+      body = json_response(conn, 200)
+      data = body["data"]
+
+      assert data["agent_id"] == ctx.agent2.id
+      assert data["model_count"] == 1
+      assert data["is_model_blender"] == false
+    end
+
+    test "profile includes usage breakdown", %{conn: conn} do
+      ctx = setup_model_mix_context()
+
+      conn =
+        conn
+        |> auth_conn(ctx.orch_key)
+        |> get(~p"/api/v1/analytics/agents/#{ctx.agent1.id}/model-profile")
+
+      body = json_response(conn, 200)
+      data = body["data"]
+
+      assert is_list(data["usage"])
+      assert length(data["usage"]) == 2
+
+      entry = hd(data["usage"])
+      assert Map.has_key?(entry, "model_name")
+      assert Map.has_key?(entry, "phase")
+      assert Map.has_key?(entry, "total_cost_millicents")
+      assert Map.has_key?(entry, "verified_count")
+      assert Map.has_key?(entry, "rejected_count")
+      assert Map.has_key?(entry, "verification_rate_pct")
+      assert Map.has_key?(entry, "cost_share_pct")
+    end
+
+    test "filters by project_id", %{conn: conn} do
+      ctx = setup_model_mix_context()
+      other_project = fixture(:project, %{tenant_id: ctx.tenant.id})
+
+      conn =
+        conn
+        |> auth_conn(ctx.orch_key)
+        |> get(
+          ~p"/api/v1/analytics/agents/#{ctx.agent1.id}/model-profile?project_id=#{other_project.id}"
+        )
+
+      body = json_response(conn, 200)
+      assert body["data"]["usage"] == []
+      assert body["data"]["model_count"] == 0
+    end
+
+    test "returns 404 for unknown agent", %{conn: conn} do
+      ctx = setup_model_mix_context()
+
+      conn =
+        conn
+        |> auth_conn(ctx.orch_key)
+        |> get(~p"/api/v1/analytics/agents/#{Ecto.UUID.generate()}/model-profile")
+
+      assert json_response(conn, 404)
+    end
+
+    test "returns 403 for agent role", %{conn: conn} do
+      ctx = setup_model_mix_context()
+
+      conn =
+        conn
+        |> auth_conn(ctx.agent_key)
+        |> get(~p"/api/v1/analytics/agents/#{ctx.agent1.id}/model-profile")
+
+      assert json_response(conn, 403)
+    end
+
+    test "tenant isolation - other tenant cannot see agent profile", %{conn: conn} do
+      ctx = setup_model_mix_context()
+      other_tenant = fixture(:tenant)
+      {other_key, _} = fixture(:api_key, %{tenant_id: other_tenant.id, role: :orchestrator})
+
+      conn =
+        conn
+        |> auth_conn(other_key)
+        |> get(~p"/api/v1/analytics/agents/#{ctx.agent1.id}/model-profile")
+
+      assert json_response(conn, 404)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/analytics/model-mix` (orchestrator+): returns a `(model_name, phase)` correlation matrix with token totals, cost, stories count, verified/rejected counts, verification rate, and a comparative view of mixed-model vs single-model agent averages
- Adds `GET /api/v1/analytics/agents/:id/model-profile` (orchestrator+): returns an agent's model usage profile across phases with `model_count`, `is_model_blender` flag, per-entry `cost_share_pct`, and verification outcomes
- Confirms `CostRollupWorker`/`DefaultRollup` already produce phase-level `model_breakdown` in cost summaries (AC-21.5.6 — no changes needed)
- Refactors `build_opts/2` in `AnalyticsController` to use pattern-matched `parse_opt/2` helper, reducing cyclomatic complexity and adding `:agent_id` filter support

## Test plan

- [ ] `mix test test/loopctl/token_usage/model_mix_analytics_test.exs` — 18 context tests
- [ ] `mix test test/loopctl_web/controllers/model_mix_analytics_controller_test.exs` — 16 controller tests
- [ ] `mix precommit` — compile, format, credo, dialyzer all pass; 6 pre-existing RLS role failures unrelated to this story
- [ ] Tenant isolation tested in both context and controller suites
- [ ] `model_mix` filterable by `project_id`, `agent_id`, `since`, `until`
- [ ] `agent_model_profile` returns 404 for agents in other tenants