### PR TITLE
US-21.13: Token Usage Report Correction & Deletion

### DIFF
--- a/lib/loopctl/skills.ex
+++ b/lib/loopctl/skills.ex
@@ -737,6 +737,7 @@ defmodule Loopctl.Skills do
     |> join(:inner, [r], sv in SkillVersion, on: r.skill_version_id == sv.id)
     |> join(:left, [r, _sv], s in Story, on: r.story_id == s.id)
     |> where([r, sv, _s], sv.skill_id == ^skill_id and r.tenant_id == ^tenant_id)
+    |> where([r, _sv, _s], is_nil(r.deleted_at))
     |> group_by([_r, sv, _s], sv.version)
     |> select([r, sv, s], %{
       version_number: sv.version,
@@ -818,6 +819,7 @@ defmodule Loopctl.Skills do
     result =
       Report
       |> where([r], r.tenant_id == ^tenant_id and r.skill_version_id == ^skill_version_id)
+      |> where([r], is_nil(r.deleted_at))
       |> select([r], %{
         total_invocations: count(r.id),
         total_cost_millicents: coalesce(sum(r.cost_millicents), 0),

--- a/lib/loopctl/token_usage.ex
+++ b/lib/loopctl/token_usage.ex
@@ -514,40 +514,32 @@ defmodule Loopctl.TokenUsage do
   # AC-21.13.7: When a report is deleted or corrected, related summaries are stale.
   defp mark_affected_cost_summaries_stale_multi(multi, tenant_id, report) do
     Multi.run(multi, :mark_summaries_stale, fn _repo, _changes ->
-      story_scope_ids = [report.story_id]
-
-      epic_scope_ids =
-        case AdminRepo.get_by(Story, id: report.story_id, tenant_id: tenant_id) do
-          nil -> []
-          story -> [story.epic_id]
-        end
-
-      project_scope_ids = [report.project_id]
-
-      # Mark story-scope summaries stale
-      {_n, _} =
-        CostSummary
-        |> where([cs], cs.tenant_id == ^tenant_id)
-        |> where([cs], cs.scope_type == :story and cs.scope_id in ^story_scope_ids)
-        |> AdminRepo.update_all(set: [stale: true])
-
-      # Mark epic-scope summaries stale
-      if epic_scope_ids != [] do
-        CostSummary
-        |> where([cs], cs.tenant_id == ^tenant_id)
-        |> where([cs], cs.scope_type == :epic and cs.scope_id in ^epic_scope_ids)
-        |> AdminRepo.update_all(set: [stale: true])
-      end
-
-      # Mark project-scope summaries stale
-      {_n, _} =
-        CostSummary
-        |> where([cs], cs.tenant_id == ^tenant_id)
-        |> where([cs], cs.scope_type == :project and cs.scope_id in ^project_scope_ids)
-        |> AdminRepo.update_all(set: [stale: true])
-
+      affected_scopes = collect_affected_scopes(tenant_id, report)
+      Enum.each(affected_scopes, &mark_scope_stale(tenant_id, &1))
       {:ok, :ok}
     end)
+  end
+
+  defp collect_affected_scopes(tenant_id, report) do
+    epic_id =
+      case AdminRepo.get_by(Story, id: report.story_id, tenant_id: tenant_id) do
+        nil -> nil
+        story -> story.epic_id
+      end
+
+    [{:story, report.story_id}, {:project, report.project_id}]
+    |> maybe_add_scope(:epic, epic_id)
+    |> maybe_add_scope(:agent, report.agent_id)
+  end
+
+  defp maybe_add_scope(scopes, _type, nil), do: scopes
+  defp maybe_add_scope(scopes, type, id), do: [{type, id} | scopes]
+
+  defp mark_scope_stale(tenant_id, {scope_type, scope_id}) do
+    CostSummary
+    |> where([cs], cs.tenant_id == ^tenant_id)
+    |> where([cs], cs.scope_type == ^scope_type and cs.scope_id == ^scope_id)
+    |> AdminRepo.update_all(set: [stale: true])
   end
 
   # Resets warning_fired/exceeded_fired on applicable budgets when spend

--- a/lib/loopctl/token_usage.ex
+++ b/lib/loopctl/token_usage.ex
@@ -43,6 +43,7 @@ defmodule Loopctl.TokenUsage do
   alias Loopctl.Tenants.Tenant
   alias Loopctl.TokenUsage.Budget
   alias Loopctl.TokenUsage.CostAnomaly
+  alias Loopctl.TokenUsage.CostSummary
   alias Loopctl.TokenUsage.Report
   alias Loopctl.Webhooks.EventGenerator
   alias Loopctl.Webhooks.WebhookEvent
@@ -213,6 +214,7 @@ defmodule Loopctl.TokenUsage do
     base_query =
       Report
       |> where([r], r.tenant_id == ^tenant_id and r.story_id == ^story_id)
+      |> where([r], is_nil(r.deleted_at))
 
     total = AdminRepo.aggregate(base_query, :count, :id)
 
@@ -246,6 +248,7 @@ defmodule Loopctl.TokenUsage do
     query =
       Report
       |> where([r], r.tenant_id == ^tenant_id and r.story_id == ^story_id)
+      |> where([r], is_nil(r.deleted_at))
       |> select([r], %{
         total_input_tokens: coalesce(sum(r.input_tokens), 0),
         total_output_tokens: coalesce(sum(r.output_tokens), 0),
@@ -265,6 +268,333 @@ defmodule Loopctl.TokenUsage do
        report_count: result.report_count
      }}
   end
+
+  # --- Report deletion and correction (US-21.13) ---
+
+  @doc """
+  Gets a single token usage report by ID, scoped to a tenant.
+
+  Only returns non-deleted reports.
+
+  ## Returns
+
+  - `{:ok, %Report{}}` if found and active
+  - `{:error, :not_found}` if not found, wrong tenant, or soft-deleted
+  """
+  @spec get_report(Ecto.UUID.t(), Ecto.UUID.t()) :: {:ok, Report.t()} | {:error, :not_found}
+  def get_report(tenant_id, report_id) do
+    case AdminRepo.get_by(Report, id: report_id, tenant_id: tenant_id) do
+      nil -> {:error, :not_found}
+      %Report{deleted_at: nil} = report -> {:ok, report}
+      %Report{} -> {:error, :not_found}
+    end
+  end
+
+  @doc """
+  Soft-deletes a token usage report by setting `deleted_at`.
+
+  The report is excluded from all queries and analytics after deletion.
+  Budget warning/exceeded flags are reset if the new spend drops below
+  their respective thresholds.
+
+  ## Options (keyword list)
+
+  - `:actor_id` -- audit actor ID
+  - `:actor_label` -- audit actor label
+  - `:actor_type` -- audit actor type (default "api_key")
+
+  ## Returns
+
+  - `{:ok, %Report{}}` on success
+  - `{:error, :not_found}` if not found, wrong tenant, or already deleted
+  """
+  @spec delete_report(Ecto.UUID.t(), Ecto.UUID.t(), keyword()) ::
+          {:ok, Report.t()} | {:error, :not_found}
+  def delete_report(tenant_id, report_id, opts \\ []) do
+    with {:ok, report} <- get_report(tenant_id, report_id) do
+      old_state = %{
+        "story_id" => report.story_id,
+        "cost_millicents" => report.cost_millicents,
+        "total_tokens" => report.total_tokens,
+        "model_name" => report.model_name
+      }
+
+      multi =
+        Multi.new()
+        |> Multi.update(:report, Loopctl.Schema.soft_delete_changeset(report))
+        |> Audit.log_in_multi(:audit, fn _changes ->
+          %{
+            tenant_id: tenant_id,
+            entity_type: "token_usage_report",
+            entity_id: report.id,
+            action: "deleted",
+            actor_type: Keyword.get(opts, :actor_type, "api_key"),
+            actor_id: Keyword.get(opts, :actor_id),
+            actor_label: Keyword.get(opts, :actor_label),
+            old_state: old_state,
+            metadata: %{
+              "story_id" => report.story_id,
+              "project_id" => report.project_id,
+              "cost_millicents" => report.cost_millicents
+            }
+          }
+        end)
+        |> mark_affected_cost_summaries_stale_multi(tenant_id, report)
+
+      case AdminRepo.transaction(multi) do
+        {:ok, %{report: deleted_report}} ->
+          # Reset budget flags if spend dropped below thresholds
+          try do
+            reset_budget_flags_if_needed(tenant_id, report)
+          rescue
+            e ->
+              Logger.warning(
+                "Budget flag reset failed after deleting report #{report.id}: " <>
+                  Exception.message(e)
+              )
+          end
+
+          {:ok, deleted_report}
+
+        {:error, _step, error, _} ->
+          {:error, error}
+      end
+    end
+  end
+
+  @doc """
+  Creates a correction report that references the original report.
+
+  Corrections allow negative `input_tokens`, `output_tokens`, and
+  `cost_millicents` to subtract from the story's running total.
+
+  ## Validation
+
+  The sum of the original report's fields plus the correction values must be
+  >= 0 for `input_tokens`, `output_tokens`, and `cost_millicents`. Returns
+  `{:error, :unprocessable_entity, message}` if the correction would make
+  any total negative.
+
+  ## Options (keyword list)
+
+  - `:actor_id` -- audit actor ID
+  - `:actor_label` -- audit actor label
+  - `:actor_type` -- audit actor type (default "api_key")
+
+  ## Returns
+
+  - `{:ok, %Report{}}` on success (the correction report)
+  - `{:error, :not_found}` if the original report not found or wrong tenant
+  - `{:error, :unprocessable_entity, message}` if the correction would produce
+    negative totals
+  - `{:error, %Ecto.Changeset{}}` on validation failure
+  """
+  @spec create_correction(Ecto.UUID.t(), Ecto.UUID.t(), map(), keyword()) ::
+          {:ok, Report.t()}
+          | {:error, :not_found}
+          | {:error, :unprocessable_entity, String.t()}
+          | {:error, Ecto.Changeset.t()}
+  def create_correction(tenant_id, original_report_id, attrs, opts \\ []) do
+    attrs = normalize_attrs(attrs)
+
+    with {:ok, original} <- get_report(tenant_id, original_report_id),
+         :ok <- validate_correction_totals(tenant_id, original, attrs) do
+      correction_input_tokens = Map.get(attrs, :input_tokens, 0)
+      correction_output_tokens = Map.get(attrs, :output_tokens, 0)
+
+      changeset =
+        %Report{
+          tenant_id: tenant_id,
+          story_id: original.story_id,
+          agent_id: original.agent_id,
+          project_id: original.project_id,
+          corrects_report_id: original.id
+        }
+        |> Report.correction_changeset(
+          Map.merge(
+            %{
+              model_name: original.model_name,
+              phase: original.phase
+            },
+            attrs
+          )
+        )
+
+      multi =
+        Multi.new()
+        |> Multi.insert(:correction, changeset)
+        |> Audit.log_in_multi(:audit, fn %{correction: correction} ->
+          %{
+            tenant_id: tenant_id,
+            entity_type: "token_usage_report",
+            entity_id: correction.id,
+            action: "corrected",
+            actor_type: Keyword.get(opts, :actor_type, "api_key"),
+            actor_id: Keyword.get(opts, :actor_id),
+            actor_label: Keyword.get(opts, :actor_label),
+            new_state: %{
+              "corrects_report_id" => original.id,
+              "story_id" => correction.story_id,
+              "input_tokens" => correction.input_tokens,
+              "output_tokens" => correction.output_tokens,
+              "cost_millicents" => correction.cost_millicents,
+              "model_name" => correction.model_name
+            },
+            metadata: %{
+              "corrects_report_id" => original.id,
+              "story_id" => correction.story_id,
+              "project_id" => correction.project_id,
+              "input_tokens" => correction_input_tokens,
+              "output_tokens" => correction_output_tokens,
+              "cost_millicents" => Map.get(attrs, :cost_millicents, 0)
+            }
+          }
+        end)
+        |> mark_affected_cost_summaries_stale_multi(tenant_id, original)
+
+      case AdminRepo.transaction(multi) do
+        {:ok, %{correction: correction}} ->
+          # Refetch to populate the DB-generated total_tokens column
+          correction = AdminRepo.get!(Report, correction.id)
+
+          # Reset budget flags if spend dropped below thresholds
+          try do
+            reset_budget_flags_if_needed(tenant_id, original)
+          rescue
+            e ->
+              Logger.warning(
+                "Budget flag reset failed after correcting report #{original.id}: " <>
+                  Exception.message(e)
+              )
+          end
+
+          {:ok, correction}
+
+        {:error, :correction, %Ecto.Changeset{} = changeset, _} ->
+          {:error, changeset}
+
+        {:error, _step, error, _} ->
+          {:error, error}
+      end
+    end
+  end
+
+  # Validates that the sum of story totals + correction values >= 0.
+  # AC-21.13.3: Negative corrections are valid as long as the sum is non-negative.
+  defp validate_correction_totals(tenant_id, original, attrs) do
+    {:ok, totals} = get_story_totals(tenant_id, original.story_id)
+
+    correction_input = Map.get(attrs, :input_tokens, 0)
+    correction_output = Map.get(attrs, :output_tokens, 0)
+    correction_cost = Map.get(attrs, :cost_millicents, 0)
+
+    new_input = totals.total_input_tokens + correction_input
+    new_output = totals.total_output_tokens + correction_output
+    new_cost = totals.total_cost_millicents + correction_cost
+
+    cond do
+      new_input < 0 ->
+        {:error, :unprocessable_entity,
+         "correction would make total input_tokens negative (current: #{totals.total_input_tokens}, correction: #{correction_input})"}
+
+      new_output < 0 ->
+        {:error, :unprocessable_entity,
+         "correction would make total output_tokens negative (current: #{totals.total_output_tokens}, correction: #{correction_output})"}
+
+      new_cost < 0 ->
+        {:error, :unprocessable_entity,
+         "correction would make total cost_millicents negative (current: #{totals.total_cost_millicents}, correction: #{correction_cost})"}
+
+      true ->
+        :ok
+    end
+  end
+
+  # Marks cost_summaries as stale for all scopes affected by a report change.
+  # AC-21.13.7: When a report is deleted or corrected, related summaries are stale.
+  defp mark_affected_cost_summaries_stale_multi(multi, tenant_id, report) do
+    Multi.run(multi, :mark_summaries_stale, fn _repo, _changes ->
+      story_scope_ids = [report.story_id]
+
+      epic_scope_ids =
+        case AdminRepo.get_by(Story, id: report.story_id, tenant_id: tenant_id) do
+          nil -> []
+          story -> [story.epic_id]
+        end
+
+      project_scope_ids = [report.project_id]
+
+      # Mark story-scope summaries stale
+      {_n, _} =
+        CostSummary
+        |> where([cs], cs.tenant_id == ^tenant_id)
+        |> where([cs], cs.scope_type == :story and cs.scope_id in ^story_scope_ids)
+        |> AdminRepo.update_all(set: [stale: true])
+
+      # Mark epic-scope summaries stale
+      if epic_scope_ids != [] do
+        CostSummary
+        |> where([cs], cs.tenant_id == ^tenant_id)
+        |> where([cs], cs.scope_type == :epic and cs.scope_id in ^epic_scope_ids)
+        |> AdminRepo.update_all(set: [stale: true])
+      end
+
+      # Mark project-scope summaries stale
+      {_n, _} =
+        CostSummary
+        |> where([cs], cs.tenant_id == ^tenant_id)
+        |> where([cs], cs.scope_type == :project and cs.scope_id in ^project_scope_ids)
+        |> AdminRepo.update_all(set: [stale: true])
+
+      {:ok, :ok}
+    end)
+  end
+
+  # Resets warning_fired/exceeded_fired on applicable budgets when spend
+  # drops below the threshold after a deletion or correction.
+  # AC-21.13.4.
+  defp reset_budget_flags_if_needed(tenant_id, report) do
+    budgets = find_applicable_budgets(tenant_id, report)
+    Enum.each(budgets, &maybe_reset_budget_flags(tenant_id, &1))
+  end
+
+  defp maybe_reset_budget_flags(tenant_id, budget) do
+    spend = get_scope_spend(tenant_id, budget.scope_type, budget.scope_id)
+
+    utilization_pct =
+      if budget.budget_millicents > 0, do: spend * 100 / budget.budget_millicents, else: 0
+
+    reset_attrs =
+      %{}
+      |> maybe_reset_flag(budget, :warning_fired, utilization_pct < budget.alert_threshold_pct)
+      |> maybe_reset_flag(budget, :exceeded_fired, utilization_pct < 100)
+
+    apply_budget_flag_reset(budget, reset_attrs)
+  end
+
+  defp apply_budget_flag_reset(_budget, attrs) when attrs == %{}, do: :ok
+
+  defp apply_budget_flag_reset(budget, reset_attrs) do
+    case budget |> Ecto.Changeset.change(reset_attrs) |> AdminRepo.update() do
+      {:ok, _} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("Failed to reset budget flags on budget #{budget.id}: #{inspect(reason)}")
+    end
+  end
+
+  defp maybe_reset_flag(attrs, budget, :warning_fired, should_reset)
+       when should_reset and budget.warning_fired do
+    Map.put(attrs, :warning_fired, false)
+  end
+
+  defp maybe_reset_flag(attrs, budget, :exceeded_fired, should_reset)
+       when should_reset and budget.exceeded_fired do
+    Map.put(attrs, :exceeded_fired, false)
+  end
+
+  defp maybe_reset_flag(attrs, _budget, _flag, _should_reset), do: attrs
 
   # --- Budget functions ---
 
@@ -880,6 +1210,7 @@ defmodule Loopctl.TokenUsage do
   defp spend_query(tenant_id, :story, scope_id) do
     Report
     |> where([r], r.tenant_id == ^tenant_id and r.story_id == ^scope_id)
+    |> where([r], is_nil(r.deleted_at))
     |> select([r], coalesce(sum(r.cost_millicents), 0))
   end
 
@@ -887,12 +1218,14 @@ defmodule Loopctl.TokenUsage do
     Report
     |> join(:inner, [r], s in Story, on: r.story_id == s.id)
     |> where([r, s], r.tenant_id == ^tenant_id and s.epic_id == ^scope_id)
+    |> where([r, _s], is_nil(r.deleted_at))
     |> select([r, _s], coalesce(sum(r.cost_millicents), 0))
   end
 
   defp spend_query(tenant_id, :project, scope_id) do
     Report
     |> where([r], r.tenant_id == ^tenant_id and r.project_id == ^scope_id)
+    |> where([r], is_nil(r.deleted_at))
     |> select([r], coalesce(sum(r.cost_millicents), 0))
   end
 
@@ -923,6 +1256,7 @@ defmodule Loopctl.TokenUsage do
   defp batch_spend_query(tenant_id, :story, scope_ids) do
     Report
     |> where([r], r.tenant_id == ^tenant_id and r.story_id in ^scope_ids)
+    |> where([r], is_nil(r.deleted_at))
     |> group_by([r], r.story_id)
     |> select([r], {r.story_id, coalesce(sum(r.cost_millicents), 0)})
     |> AdminRepo.all()
@@ -933,6 +1267,7 @@ defmodule Loopctl.TokenUsage do
     Report
     |> join(:inner, [r], s in Story, on: r.story_id == s.id)
     |> where([r, s], r.tenant_id == ^tenant_id and s.epic_id in ^scope_ids)
+    |> where([r, _s], is_nil(r.deleted_at))
     |> group_by([r, s], s.epic_id)
     |> select([r, s], {s.epic_id, coalesce(sum(r.cost_millicents), 0)})
     |> AdminRepo.all()
@@ -942,6 +1277,7 @@ defmodule Loopctl.TokenUsage do
   defp batch_spend_query(tenant_id, :project, scope_ids) do
     Report
     |> where([r], r.tenant_id == ^tenant_id and r.project_id in ^scope_ids)
+    |> where([r], is_nil(r.deleted_at))
     |> group_by([r], r.project_id)
     |> select([r], {r.project_id, coalesce(sum(r.cost_millicents), 0)})
     |> AdminRepo.all()

--- a/lib/loopctl/token_usage/analytics.ex
+++ b/lib/loopctl/token_usage/analytics.ex
@@ -65,6 +65,7 @@ defmodule Loopctl.TokenUsage.Analytics do
     base =
       Report
       |> where([r], r.tenant_id == ^tenant_id)
+      |> where([r], is_nil(r.deleted_at))
       |> where([r], not is_nil(r.agent_id))
       |> apply_date_filters(opts)
       |> apply_project_filter(opts)
@@ -241,6 +242,7 @@ defmodule Loopctl.TokenUsage.Analytics do
         totals =
           Report
           |> where([r], r.tenant_id == ^tenant_id and r.project_id == ^project_id)
+          |> where([r], is_nil(r.deleted_at))
           |> select([r], %{
             total_input_tokens: coalesce(sum(r.input_tokens), 0),
             total_output_tokens: coalesce(sum(r.output_tokens), 0),
@@ -308,6 +310,7 @@ defmodule Loopctl.TokenUsage.Analytics do
     base =
       Report
       |> where([r], r.tenant_id == ^tenant_id)
+      |> where([r], is_nil(r.deleted_at))
       |> apply_date_filters(opts)
       |> apply_project_filter(opts)
 
@@ -397,6 +400,7 @@ defmodule Loopctl.TokenUsage.Analytics do
     base =
       Report
       |> where([r], r.tenant_id == ^tenant_id)
+      |> where([r], is_nil(r.deleted_at))
       |> apply_date_filters(opts)
       |> apply_project_filter(opts)
 
@@ -493,6 +497,7 @@ defmodule Loopctl.TokenUsage.Analytics do
     base =
       Report
       |> where([r], r.tenant_id == ^tenant_id)
+      |> where([r], is_nil(r.deleted_at))
       |> apply_date_filters(opts)
       |> apply_project_filter(opts)
       |> apply_agent_filter(opts)
@@ -628,6 +633,7 @@ defmodule Loopctl.TokenUsage.Analytics do
     # Uses a window function to rank models per agent by total tokens.
     Report
     |> where([r], r.tenant_id == ^tenant_id and r.agent_id in ^agent_ids)
+    |> where([r], is_nil(r.deleted_at))
     |> apply_date_filters(opts)
     |> apply_project_filter(opts)
     |> group_by([r], [r.agent_id, r.model_name])
@@ -652,6 +658,7 @@ defmodule Loopctl.TokenUsage.Analytics do
     Report
     |> join(:inner, [r], s in Story, on: r.story_id == s.id)
     |> where([r, _s], r.tenant_id == ^tenant_id)
+    |> where([r, _s], is_nil(r.deleted_at))
     |> where([_r, s], s.epic_id in ^epic_ids)
     |> group_by([_r, s], s.epic_id)
     |> select([r, s], %{
@@ -701,6 +708,7 @@ defmodule Loopctl.TokenUsage.Analytics do
     Report
     |> join(:inner, [r], s in Story, on: r.story_id == s.id)
     |> where([r, _s], r.tenant_id == ^tenant_id)
+    |> where([r, _s], is_nil(r.deleted_at))
     |> where([_r, s], s.epic_id in ^epic_ids)
     |> group_by([r, s], [s.epic_id, r.model_name])
     |> select([r, s], %{
@@ -740,6 +748,7 @@ defmodule Loopctl.TokenUsage.Analytics do
   defp get_cost_by_phase(tenant_id, project_id) do
     Report
     |> where([r], r.tenant_id == ^tenant_id and r.project_id == ^project_id)
+    |> where([r], is_nil(r.deleted_at))
     |> group_by([r], r.phase)
     |> select([r], %{
       phase: r.phase,
@@ -752,6 +761,7 @@ defmodule Loopctl.TokenUsage.Analytics do
   defp get_project_model_breakdown(tenant_id, project_id) do
     Report
     |> where([r], r.tenant_id == ^tenant_id and r.project_id == ^project_id)
+    |> where([r], is_nil(r.deleted_at))
     |> group_by([r], r.model_name)
     |> select([r], %{
       model_name: r.model_name,
@@ -777,6 +787,7 @@ defmodule Loopctl.TokenUsage.Analytics do
       Report
       |> join(:inner, [r], s in Story, on: r.story_id == s.id)
       |> where([r, _s], r.tenant_id == ^tenant_id)
+      |> where([r, _s], is_nil(r.deleted_at))
       |> where([_r, s], s.verified_status in [:verified, :rejected])
       |> apply_model_date_filters(opts)
       |> apply_model_project_filter(opts)
@@ -809,6 +820,7 @@ defmodule Loopctl.TokenUsage.Analytics do
     base =
       Report
       |> where([r], r.tenant_id == ^tenant_id and r.agent_id == ^agent_id)
+      |> where([r], is_nil(r.deleted_at))
       |> apply_date_filters(opts)
       |> apply_project_filter(opts)
 
@@ -892,6 +904,7 @@ defmodule Loopctl.TokenUsage.Analytics do
       Report
       |> join(:inner, [r], s in Story, on: r.story_id == s.id)
       |> where([r, _s], r.tenant_id == ^tenant_id)
+      |> where([r, _s], is_nil(r.deleted_at))
       |> where([_r, s], s.verified_status in [:verified, :rejected])
       |> apply_model_date_filters(opts)
       |> apply_model_project_filter(opts)
@@ -926,6 +939,7 @@ defmodule Loopctl.TokenUsage.Analytics do
       Report
       |> join(:inner, [r], s in Story, on: r.story_id == s.id)
       |> where([r, _s], r.tenant_id == ^tenant_id and r.agent_id == ^agent_id)
+      |> where([r, _s], is_nil(r.deleted_at))
       |> where([_r, s], s.verified_status in [:verified, :rejected])
       |> apply_model_date_filters(opts)
       |> apply_model_project_filter(opts)
@@ -959,6 +973,7 @@ defmodule Loopctl.TokenUsage.Analytics do
     agent_stats =
       Report
       |> where([r], r.tenant_id == ^tenant_id)
+      |> where([r], is_nil(r.deleted_at))
       |> where([r], not is_nil(r.agent_id))
       |> apply_date_filters(opts)
       |> apply_project_filter(opts)
@@ -976,6 +991,7 @@ defmodule Loopctl.TokenUsage.Analytics do
       Report
       |> join(:inner, [r], s in Story, on: r.story_id == s.id)
       |> where([r, _s], r.tenant_id == ^tenant_id)
+      |> where([r, _s], is_nil(r.deleted_at))
       |> where([r, _s], not is_nil(r.agent_id))
       |> where([_r, s], s.verified_status in [:verified, :rejected])
       |> apply_model_date_filters(opts)

--- a/lib/loopctl/token_usage/cost_summary.ex
+++ b/lib/loopctl/token_usage/cost_summary.ex
@@ -41,6 +41,7 @@ defmodule Loopctl.TokenUsage.CostSummary do
              :report_count,
              :model_breakdown,
              :avg_cost_per_story_millicents,
+             :stale,
              :inserted_at,
              :updated_at
            ]}
@@ -58,6 +59,7 @@ defmodule Loopctl.TokenUsage.CostSummary do
     field :report_count, :integer, default: 0
     field :model_breakdown, :map, default: %{}
     field :avg_cost_per_story_millicents, :integer
+    field :stale, :boolean, default: false
 
     timestamps()
   end
@@ -80,7 +82,8 @@ defmodule Loopctl.TokenUsage.CostSummary do
       :total_cost_millicents,
       :report_count,
       :model_breakdown,
-      :avg_cost_per_story_millicents
+      :avg_cost_per_story_millicents,
+      :stale
     ])
     |> validate_required([
       :scope_type,

--- a/lib/loopctl/token_usage/default_rollup.ex
+++ b/lib/loopctl/token_usage/default_rollup.ex
@@ -37,6 +37,7 @@ defmodule Loopctl.TokenUsage.DefaultRollup do
   defp aggregate_by_agent(tenant_id, start_dt, end_dt) do
     Report
     |> where([r], r.tenant_id == ^tenant_id)
+    |> where([r], is_nil(r.deleted_at))
     |> where([r], r.inserted_at >= ^start_dt and r.inserted_at <= ^end_dt)
     |> where([r], not is_nil(r.agent_id))
     |> group_by([r], r.agent_id)
@@ -69,6 +70,7 @@ defmodule Loopctl.TokenUsage.DefaultRollup do
     Report
     |> join(:inner, [r], s in Story, on: r.story_id == s.id)
     |> where([r, _s], r.tenant_id == ^tenant_id)
+    |> where([r, _s], is_nil(r.deleted_at))
     |> where([r, _s], r.inserted_at >= ^start_dt and r.inserted_at <= ^end_dt)
     |> group_by([_r, s], s.epic_id)
     |> select([r, s], %{
@@ -105,6 +107,7 @@ defmodule Loopctl.TokenUsage.DefaultRollup do
   defp aggregate_by_project(tenant_id, start_dt, end_dt) do
     Report
     |> where([r], r.tenant_id == ^tenant_id)
+    |> where([r], is_nil(r.deleted_at))
     |> where([r], r.inserted_at >= ^start_dt and r.inserted_at <= ^end_dt)
     |> where([r], not is_nil(r.project_id))
     |> group_by([r], r.project_id)
@@ -163,6 +166,7 @@ defmodule Loopctl.TokenUsage.DefaultRollup do
     Report
     |> where([r], r.agent_id == ^scope_id)
     |> where([r], r.tenant_id == ^tenant_id)
+    |> where([r], is_nil(r.deleted_at))
     |> where([r], r.inserted_at >= ^start_dt and r.inserted_at <= ^end_dt)
     |> group_by([r], [r.model_name, r.phase])
     |> select([r], %{
@@ -178,6 +182,7 @@ defmodule Loopctl.TokenUsage.DefaultRollup do
     Report
     |> join(:inner, [r], s in Story, on: r.story_id == s.id)
     |> where([r, _s], r.tenant_id == ^tenant_id)
+    |> where([r, _s], is_nil(r.deleted_at))
     |> where([r, _s], r.inserted_at >= ^start_dt and r.inserted_at <= ^end_dt)
     |> where([_r, s], s.epic_id == ^scope_id)
     |> group_by([r, _s], [r.model_name, r.phase])
@@ -194,6 +199,7 @@ defmodule Loopctl.TokenUsage.DefaultRollup do
     Report
     |> where([r], r.project_id == ^scope_id)
     |> where([r], r.tenant_id == ^tenant_id)
+    |> where([r], is_nil(r.deleted_at))
     |> where([r], r.inserted_at >= ^start_dt and r.inserted_at <= ^end_dt)
     |> group_by([r], [r.model_name, r.phase])
     |> select([r], %{

--- a/lib/loopctl/token_usage/report.ex
+++ b/lib/loopctl/token_usage/report.ex
@@ -8,18 +8,20 @@ defmodule Loopctl.TokenUsage.Report do
 
   ## Fields
 
-  - `input_tokens` -- number of input tokens consumed
-  - `output_tokens` -- number of output tokens consumed
+  - `input_tokens` -- number of input tokens consumed (may be negative for corrections)
+  - `output_tokens` -- number of output tokens consumed (may be negative for corrections)
   - `total_tokens` -- generated column: input_tokens + output_tokens (read-only)
   - `model_name` -- name of the LLM model used (e.g., "claude-opus-4")
-  - `cost_millicents` -- cost in 1/1000 of a cent (e.g., 2500 = $0.025)
+  - `cost_millicents` -- cost in 1/1000 of a cent (may be negative for corrections)
   - `phase` -- work phase: planning, implementing, reviewing, other
   - `session_id` -- optional session identifier
   - `skill_version_id` -- optional FK to skill_versions
   - `metadata` -- extensible JSONB map
+  - `deleted_at` -- soft-delete timestamp; nil means active (AC-21.13.1)
+  - `corrects_report_id` -- FK to the original report this corrects (AC-21.13.2)
   """
 
-  use Loopctl.Schema
+  use Loopctl.Schema, soft_delete: true
 
   @type t :: %__MODULE__{}
 
@@ -41,6 +43,8 @@ defmodule Loopctl.TokenUsage.Report do
              :session_id,
              :skill_version_id,
              :metadata,
+             :deleted_at,
+             :corrects_report_id,
              :inserted_at,
              :updated_at
            ]}
@@ -51,6 +55,7 @@ defmodule Loopctl.TokenUsage.Report do
     belongs_to :agent, Loopctl.Agents.Agent
     belongs_to :project, Loopctl.Projects.Project
     belongs_to :skill_version, Loopctl.Skills.SkillVersion
+    belongs_to :corrects_report, __MODULE__, foreign_key: :corrects_report_id
 
     field :input_tokens, :integer
     field :output_tokens, :integer
@@ -60,6 +65,7 @@ defmodule Loopctl.TokenUsage.Report do
     field :phase, :string, default: "other"
     field :session_id, :string
     field :metadata, :map, default: %{}
+    field :deleted_at, :utc_datetime_usec
 
     timestamps()
   end
@@ -94,5 +100,36 @@ defmodule Loopctl.TokenUsage.Report do
     |> foreign_key_constraint(:agent_id)
     |> foreign_key_constraint(:project_id)
     |> foreign_key_constraint(:skill_version_id)
+  end
+
+  @doc """
+  Changeset for creating a correction report.
+
+  Corrections allow negative `input_tokens`, `output_tokens`, and
+  `cost_millicents` (to subtract from the story's running total).
+  The `corrects_report_id` is set programmatically.
+  """
+  @spec correction_changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
+  def correction_changeset(report \\ %__MODULE__{}, attrs) do
+    report
+    |> cast(attrs, [
+      :input_tokens,
+      :output_tokens,
+      :model_name,
+      :cost_millicents,
+      :phase,
+      :session_id,
+      :skill_version_id,
+      :metadata
+    ])
+    |> validate_required([:input_tokens, :output_tokens, :model_name, :cost_millicents])
+    |> validate_inclusion(:phase, @phases)
+    |> validate_length(:model_name, min: 1)
+    |> foreign_key_constraint(:tenant_id)
+    |> foreign_key_constraint(:story_id)
+    |> foreign_key_constraint(:agent_id)
+    |> foreign_key_constraint(:project_id)
+    |> foreign_key_constraint(:skill_version_id)
+    |> foreign_key_constraint(:corrects_report_id)
   end
 end

--- a/lib/loopctl/workers/cost_anomaly_worker.ex
+++ b/lib/loopctl/workers/cost_anomaly_worker.ex
@@ -85,11 +85,12 @@ defmodule Loopctl.Workers.CostAnomalyWorker do
     end_dt = NaiveDateTime.new!(period_end, ~T[23:59:59.999999])
     epic_avg = epic_summary.avg_cost_per_story_millicents
 
-    # Get per-story costs for this epic in the period
+    # Get per-story costs for this epic in the period (exclude soft-deleted reports)
     story_costs =
       Report
       |> join(:inner, [r], s in Story, on: r.story_id == s.id)
       |> where([r, s], r.tenant_id == ^tenant_id)
+      |> where([r, _s], is_nil(r.deleted_at))
       |> where([_r, s], s.epic_id == ^epic_summary.scope_id)
       |> where([r, _s], r.inserted_at >= ^start_dt and r.inserted_at <= ^end_dt)
       |> group_by([r, _s], r.story_id)

--- a/lib/loopctl_web/controllers/token_usage_controller.ex
+++ b/lib/loopctl_web/controllers/token_usage_controller.ex
@@ -4,6 +4,8 @@ defmodule LoopctlWeb.TokenUsageController do
 
   - `POST /api/v1/token-usage` -- create a standalone token usage report (agent+)
   - `GET /api/v1/stories/:story_id/token-usage` -- list reports for a story (agent+)
+  - `DELETE /api/v1/token-usage/:id` -- soft-delete a report (user only)
+  - `POST /api/v1/token-usage/:id/correction` -- create correction report (user only)
   """
 
   use LoopctlWeb, :controller
@@ -18,6 +20,7 @@ defmodule LoopctlWeb.TokenUsageController do
   action_fallback LoopctlWeb.FallbackController
 
   plug LoopctlWeb.Plugs.RequireRole, [role: :agent] when action in [:create, :index]
+  plug LoopctlWeb.Plugs.RequireRole, [exact_role: :user] when action in [:delete, :correct]
 
   tags(["Token Usage"])
 
@@ -83,6 +86,64 @@ defmodule LoopctlWeb.TokenUsageController do
            }
          }},
       404 => {"Story not found", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  operation(:delete,
+    summary: "Soft-delete a token usage report",
+    description:
+      "Soft-deletes a token usage report by setting deleted_at. " <>
+        "Report is excluded from all queries and analytics. " <>
+        "Budget flags are reset if spend drops below threshold. " <>
+        "Only users (not agents) may delete reports.",
+    parameters: [
+      id: [in: :path, type: :string, description: "Report UUID"]
+    ],
+    responses: %{
+      200 =>
+        {"Report deleted", "application/json",
+         %OpenApiSpex.Schema{type: :object, additionalProperties: true}},
+      403 => {"Forbidden", "application/json", Schemas.ErrorResponse},
+      404 => {"Report not found", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  operation(:correct,
+    summary: "Create a correction report",
+    description:
+      "Creates a correction report referencing the original. " <>
+        "Allows negative input_tokens, output_tokens, cost_millicents. " <>
+        "Returns 422 if the correction would make any total negative. " <>
+        "Only users (not agents) may create corrections.",
+    parameters: [
+      id: [in: :path, type: :string, description: "Original report UUID"]
+    ],
+    request_body:
+      {"Correction params", "application/json",
+       %OpenApiSpex.Schema{
+         type: :object,
+         properties: %{
+           input_tokens: %OpenApiSpex.Schema{type: :integer},
+           output_tokens: %OpenApiSpex.Schema{type: :integer},
+           cost_millicents: %OpenApiSpex.Schema{type: :integer},
+           model_name: %OpenApiSpex.Schema{type: :string, minLength: 1},
+           phase: %OpenApiSpex.Schema{
+             type: :string,
+             enum: ["planning", "implementing", "reviewing", "other"]
+           },
+           session_id: %OpenApiSpex.Schema{type: :string, nullable: true},
+           metadata: %OpenApiSpex.Schema{type: :object, additionalProperties: true}
+         }
+       }},
+    responses: %{
+      201 =>
+        {"Correction created", "application/json",
+         %OpenApiSpex.Schema{type: :object, additionalProperties: true}},
+      403 => {"Forbidden", "application/json", Schemas.ErrorResponse},
+      404 => {"Original report not found", "application/json", Schemas.ErrorResponse},
+      422 => {"Validation error or negative totals", "application/json", Schemas.ErrorResponse},
       429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
     }
   )
@@ -158,6 +219,54 @@ defmodule LoopctlWeb.TokenUsageController do
     end
   end
 
+  @doc """
+  DELETE /api/v1/token-usage/:id
+
+  Soft-deletes a token usage report. Only users (not agents) can delete.
+  """
+  def delete(conn, %{"id" => report_id}) do
+    api_key = conn.assigns.current_api_key
+    tenant_id = api_key.tenant_id
+    audit_opts = AuditContext.from_conn(conn)
+
+    with {:ok, deleted_report} <- TokenUsage.delete_report(tenant_id, report_id, audit_opts) do
+      json(conn, %{token_usage_report: format_report(deleted_report)})
+    end
+  end
+
+  @doc """
+  POST /api/v1/token-usage/:id/correction
+
+  Creates a correction report for the given original report.
+  Allows negative token/cost values to subtract from the story total.
+  Returns 422 if the correction would make any field's total negative.
+  """
+  def correct(conn, %{"id" => report_id} = params) do
+    api_key = conn.assigns.current_api_key
+    tenant_id = api_key.tenant_id
+    audit_opts = AuditContext.from_conn(conn)
+
+    correction_attrs =
+      params
+      |> Map.drop(["id"])
+
+    case TokenUsage.create_correction(tenant_id, report_id, correction_attrs, audit_opts) do
+      {:ok, correction} ->
+        conn
+        |> put_status(:created)
+        |> json(%{token_usage_report: format_report(correction)})
+
+      {:error, :not_found} ->
+        {:error, :not_found}
+
+      {:error, :unprocessable_entity, message} ->
+        {:error, :unprocessable_entity, message}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:error, changeset}
+    end
+  end
+
   # --- Private helpers ---
 
   defp format_report(report) do
@@ -177,6 +286,8 @@ defmodule LoopctlWeb.TokenUsageController do
       session_id: report.session_id,
       skill_version_id: report.skill_version_id,
       metadata: report.metadata,
+      deleted_at: report.deleted_at,
+      corrects_report_id: report.corrects_report_id,
       inserted_at: report.inserted_at,
       updated_at: report.updated_at
     }

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -203,8 +203,10 @@ defmodule LoopctlWeb.Router do
     # Skill cost performance (US-21.6)
     get "/skills/:id/cost-performance", SkillController, :cost_performance
 
-    # Token usage (Epic 19)
+    # Token usage (Epic 19, US-21.13)
     post "/token-usage", TokenUsageController, :create
+    delete "/token-usage/:id", TokenUsageController, :delete
+    post "/token-usage/:id/correction", TokenUsageController, :correct
     get "/stories/:story_id/token-usage", TokenUsageController, :index
 
     # Token budgets (Epic 19)

--- a/priv/repo/migrations/20260404000001_add_soft_delete_and_corrections_to_token_usage.exs
+++ b/priv/repo/migrations/20260404000001_add_soft_delete_and_corrections_to_token_usage.exs
@@ -1,0 +1,24 @@
+defmodule Loopctl.Repo.Migrations.AddSoftDeleteAndCorrectionsToTokenUsage do
+  use Ecto.Migration
+
+  def change do
+    # --- token_usage_reports: soft delete and corrections ---
+
+    alter table(:token_usage_reports) do
+      add :deleted_at, :utc_datetime_usec, null: true
+      add :corrects_report_id, references(:token_usage_reports, type: :binary_id), null: true
+    end
+
+    # Partial index for active (non-deleted) reports — used by tenant-scoped queries
+    execute(
+      "CREATE INDEX token_usage_reports_active_idx ON token_usage_reports (tenant_id, story_id) WHERE deleted_at IS NULL",
+      "DROP INDEX token_usage_reports_active_idx"
+    )
+
+    # --- cost_summaries: stale flag ---
+
+    alter table(:cost_summaries) do
+      add :stale, :boolean, default: false, null: false
+    end
+  end
+end

--- a/test/loopctl/token_usage_corrections_test.exs
+++ b/test/loopctl/token_usage_corrections_test.exs
@@ -1,0 +1,595 @@
+defmodule Loopctl.TokenUsageCorrectionsTest do
+  @moduledoc """
+  Tests for US-21.13: Token Usage Report Correction & Deletion.
+
+  Covers:
+  - AC-21.13.1: DELETE soft-deletes and excludes from queries
+  - AC-21.13.2: POST correction creates correction report with corrects_report_id
+  - AC-21.13.3: Negative corrections allowed; sum must be >= 0
+  - AC-21.13.4: Budget flags reset when spend drops below threshold
+  - AC-21.13.5: Audit log entries for deleted/corrected
+  - AC-21.13.6: Change feed entries (via audit log)
+  - AC-21.13.7: Cost summaries marked stale
+  - AC-21.13.9: Tenant isolation — returns 404 for cross-tenant
+  """
+
+  use Loopctl.DataCase, async: true
+
+  import Ecto.Query
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Audit.AuditLog
+  alias Loopctl.TokenUsage
+  alias Loopctl.TokenUsage.Budget
+  alias Loopctl.TokenUsage.CostSummary
+  alias Loopctl.TokenUsage.Report
+
+  setup :verify_on_exit!
+
+  defp setup_context do
+    tenant = fixture(:tenant)
+    project = fixture(:project, %{tenant_id: tenant.id})
+    epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+    agent = fixture(:agent, %{tenant_id: tenant.id})
+
+    story =
+      fixture(:story, %{
+        tenant_id: tenant.id,
+        epic_id: epic.id,
+        project_id: project.id
+      })
+
+    %{tenant: tenant, project: project, epic: epic, agent: agent, story: story}
+  end
+
+  defp create_report(tenant_id, story, agent, project, overrides \\ %{}) do
+    attrs =
+      Map.merge(
+        %{
+          story_id: story.id,
+          agent_id: agent.id,
+          project_id: project.id,
+          input_tokens: 1000,
+          output_tokens: 500,
+          model_name: "claude-opus-4",
+          cost_millicents: 2500
+        },
+        overrides
+      )
+
+    {:ok, report} = TokenUsage.create_report(tenant_id, attrs)
+    report
+  end
+
+  defp find_audit_entries(tenant_id, entity_type, action) do
+    AuditLog
+    |> where(
+      [a],
+      a.tenant_id == ^tenant_id and
+        a.entity_type == ^entity_type and
+        a.action == ^action
+    )
+    |> AdminRepo.all()
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-21.13.1: Soft delete
+  # ---------------------------------------------------------------------------
+
+  describe "delete_report/3 (AC-21.13.1)" do
+    test "soft-deletes a report by setting deleted_at" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+      report = create_report(tenant.id, story, agent, project)
+
+      assert {:ok, deleted} = TokenUsage.delete_report(tenant.id, report.id)
+
+      assert deleted.deleted_at != nil
+      assert deleted.id == report.id
+    end
+
+    test "deleted report is excluded from list_reports_for_story" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+      report = create_report(tenant.id, story, agent, project)
+
+      {:ok, before_delete} = TokenUsage.list_reports_for_story(tenant.id, story.id)
+      assert before_delete.total == 1
+
+      TokenUsage.delete_report(tenant.id, report.id)
+
+      {:ok, after_delete} = TokenUsage.list_reports_for_story(tenant.id, story.id)
+      assert after_delete.total == 0
+      assert after_delete.data == []
+    end
+
+    test "deleted report is excluded from get_story_totals" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+      report = create_report(tenant.id, story, agent, project)
+
+      {:ok, before_totals} = TokenUsage.get_story_totals(tenant.id, story.id)
+      assert before_totals.total_cost_millicents == 2500
+
+      TokenUsage.delete_report(tenant.id, report.id)
+
+      {:ok, after_totals} = TokenUsage.get_story_totals(tenant.id, story.id)
+      assert after_totals.total_cost_millicents == 0
+      assert after_totals.report_count == 0
+    end
+
+    test "returns not_found for already deleted report" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+      report = create_report(tenant.id, story, agent, project)
+
+      {:ok, _} = TokenUsage.delete_report(tenant.id, report.id)
+      assert {:error, :not_found} = TokenUsage.delete_report(tenant.id, report.id)
+    end
+
+    test "returns not_found for nonexistent report" do
+      %{tenant: tenant} = setup_context()
+      assert {:error, :not_found} = TokenUsage.delete_report(tenant.id, Ecto.UUID.generate())
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-21.13.2: Correction report
+  # ---------------------------------------------------------------------------
+
+  describe "create_correction/4 (AC-21.13.2)" do
+    test "creates a correction report with corrects_report_id FK" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+      original = create_report(tenant.id, story, agent, project)
+
+      assert {:ok, correction} =
+               TokenUsage.create_correction(tenant.id, original.id, %{
+                 input_tokens: -100,
+                 output_tokens: -50,
+                 cost_millicents: -250
+               })
+
+      assert correction.corrects_report_id == original.id
+      assert correction.story_id == original.story_id
+      assert correction.input_tokens == -100
+      assert correction.output_tokens == -50
+      assert correction.cost_millicents == -250
+    end
+
+    test "both original and correction exist in DB" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+      original = create_report(tenant.id, story, agent, project)
+
+      {:ok, correction} =
+        TokenUsage.create_correction(tenant.id, original.id, %{
+          input_tokens: -100,
+          output_tokens: -50,
+          cost_millicents: -250
+        })
+
+      db_original = AdminRepo.get!(Report, original.id)
+      db_correction = AdminRepo.get!(Report, correction.id)
+
+      assert db_original.deleted_at == nil
+      assert db_correction.corrects_report_id == original.id
+    end
+
+    test "analytics sums all non-deleted reports including corrections" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+      original = create_report(tenant.id, story, agent, project)
+
+      # 1000 input + 500 output = 2500 cost
+      {:ok, totals_before} = TokenUsage.get_story_totals(tenant.id, story.id)
+      assert totals_before.total_cost_millicents == 2500
+
+      # Correction subtracts 250
+      {:ok, _} =
+        TokenUsage.create_correction(tenant.id, original.id, %{
+          input_tokens: -100,
+          output_tokens: -50,
+          cost_millicents: -250
+        })
+
+      # Net = 2500 - 250 = 2250
+      {:ok, totals_after} = TokenUsage.get_story_totals(tenant.id, story.id)
+      assert totals_after.total_cost_millicents == 2250
+      # 2 reports: original + correction
+      assert totals_after.report_count == 2
+    end
+
+    test "correction inherits model_name and phase from original when not specified" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+
+      original =
+        create_report(tenant.id, story, agent, project, %{
+          model_name: "claude-opus-4",
+          phase: "implementing"
+        })
+
+      {:ok, correction} =
+        TokenUsage.create_correction(tenant.id, original.id, %{
+          input_tokens: -100,
+          output_tokens: -50,
+          cost_millicents: -250
+        })
+
+      assert correction.model_name == "claude-opus-4"
+      assert correction.phase == "implementing"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-21.13.3: Negative corrections, sum must be >= 0
+  # ---------------------------------------------------------------------------
+
+  describe "create_correction/4 negative value validation (AC-21.13.3)" do
+    test "allows negative correction values within bounds" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+      original = create_report(tenant.id, story, agent, project)
+
+      # original: input=1000, output=500, cost=2500
+      # correction: input=-999, output=-499, cost=-2499 (all >= 0 after sum)
+      assert {:ok, _correction} =
+               TokenUsage.create_correction(tenant.id, original.id, %{
+                 input_tokens: -999,
+                 output_tokens: -499,
+                 cost_millicents: -2499
+               })
+    end
+
+    test "returns 422 if correction would make input_tokens total negative" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+      original = create_report(tenant.id, story, agent, project)
+
+      # input_tokens = 1000, correction = -1001, net = -1
+      assert {:error, :unprocessable_entity, message} =
+               TokenUsage.create_correction(tenant.id, original.id, %{
+                 input_tokens: -1001,
+                 output_tokens: 0,
+                 cost_millicents: 0
+               })
+
+      assert message =~ "input_tokens"
+    end
+
+    test "returns 422 if correction would make output_tokens total negative" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+      original = create_report(tenant.id, story, agent, project)
+
+      # output_tokens = 500, correction = -501, net = -1
+      assert {:error, :unprocessable_entity, message} =
+               TokenUsage.create_correction(tenant.id, original.id, %{
+                 input_tokens: 0,
+                 output_tokens: -501,
+                 cost_millicents: 0
+               })
+
+      assert message =~ "output_tokens"
+    end
+
+    test "returns 422 if correction would make cost_millicents total negative" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+      original = create_report(tenant.id, story, agent, project)
+
+      # cost_millicents = 2500, correction = -2501, net = -1
+      assert {:error, :unprocessable_entity, message} =
+               TokenUsage.create_correction(tenant.id, original.id, %{
+                 input_tokens: 0,
+                 output_tokens: 0,
+                 cost_millicents: -2501
+               })
+
+      assert message =~ "cost_millicents"
+    end
+
+    test "correction that exactly zeroes out a value is allowed" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+      original = create_report(tenant.id, story, agent, project)
+
+      # Exactly cancel the cost
+      assert {:ok, _} =
+               TokenUsage.create_correction(tenant.id, original.id, %{
+                 input_tokens: -1000,
+                 output_tokens: -500,
+                 cost_millicents: -2500
+               })
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-21.13.4: Budget flags reset after deletion/correction
+  # ---------------------------------------------------------------------------
+
+  describe "budget flag reset (AC-21.13.4)" do
+    test "resets warning_fired when spend drops below warning threshold after deletion" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+
+      # Create a budget at 80% warning threshold
+      {:ok, budget} =
+        TokenUsage.create_budget(tenant.id, %{
+          scope_type: :story,
+          scope_id: story.id,
+          budget_millicents: 3000,
+          alert_threshold_pct: 80
+        })
+
+      # 80% of 3000 = 2400. Create a report at 2500 (above threshold)
+      report = create_report(tenant.id, story, agent, project, %{cost_millicents: 2500})
+
+      # Manually set warning_fired = true (simulating it was fired)
+      budget
+      |> Ecto.Changeset.change(%{warning_fired: true})
+      |> AdminRepo.update!()
+
+      # Delete the report — spend drops to 0 (below 80% threshold)
+      {:ok, _} = TokenUsage.delete_report(tenant.id, report.id)
+
+      updated_budget = AdminRepo.get!(Budget, budget.id)
+      assert updated_budget.warning_fired == false
+    end
+
+    test "resets exceeded_fired when spend drops below 100% after deletion" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+
+      {:ok, budget} =
+        TokenUsage.create_budget(tenant.id, %{
+          scope_type: :story,
+          scope_id: story.id,
+          budget_millicents: 2000,
+          alert_threshold_pct: 80
+        })
+
+      # Spend = 2500 > 2000 budget
+      report = create_report(tenant.id, story, agent, project, %{cost_millicents: 2500})
+
+      budget
+      |> Ecto.Changeset.change(%{warning_fired: true, exceeded_fired: true})
+      |> AdminRepo.update!()
+
+      # Delete the report — spend drops to 0
+      {:ok, _} = TokenUsage.delete_report(tenant.id, report.id)
+
+      updated_budget = AdminRepo.get!(Budget, budget.id)
+      assert updated_budget.warning_fired == false
+      assert updated_budget.exceeded_fired == false
+    end
+
+    test "does not reset flags when spend is still above threshold after correction" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+
+      {:ok, budget} =
+        TokenUsage.create_budget(tenant.id, %{
+          scope_type: :story,
+          scope_id: story.id,
+          budget_millicents: 1000,
+          alert_threshold_pct: 80
+        })
+
+      # Two reports: 2000 total (above 1000 budget)
+      create_report(tenant.id, story, agent, project, %{cost_millicents: 1500})
+      report2 = create_report(tenant.id, story, agent, project, %{cost_millicents: 500})
+
+      budget
+      |> Ecto.Changeset.change(%{warning_fired: true, exceeded_fired: true})
+      |> AdminRepo.update!()
+
+      # Correction of -100 on report2 → net = 1500 + 400 = 1900 (still above 1000)
+      {:ok, _} =
+        TokenUsage.create_correction(tenant.id, report2.id, %{
+          input_tokens: 0,
+          output_tokens: 0,
+          cost_millicents: -100
+        })
+
+      updated_budget = AdminRepo.get!(Budget, budget.id)
+      # Still above 100% threshold so exceeded_fired stays
+      assert updated_budget.exceeded_fired == true
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-21.13.5: Audit log entries
+  # ---------------------------------------------------------------------------
+
+  describe "audit log (AC-21.13.5)" do
+    test "deletion creates audit log entry with action='deleted'" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+      report = create_report(tenant.id, story, agent, project)
+
+      {:ok, _} = TokenUsage.delete_report(tenant.id, report.id)
+
+      entries = find_audit_entries(tenant.id, "token_usage_report", "deleted")
+      assert length(entries) == 1
+      entry = hd(entries)
+      assert entry.entity_id == report.id
+      assert entry.old_state["cost_millicents"] == 2500
+    end
+
+    test "correction creates audit log entry with action='corrected'" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+      original = create_report(tenant.id, story, agent, project)
+
+      {:ok, correction} =
+        TokenUsage.create_correction(tenant.id, original.id, %{
+          input_tokens: -100,
+          output_tokens: -50,
+          cost_millicents: -250
+        })
+
+      entries = find_audit_entries(tenant.id, "token_usage_report", "corrected")
+      assert length(entries) == 1
+      entry = hd(entries)
+      assert entry.entity_id == correction.id
+      assert entry.new_state["corrects_report_id"] == original.id
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-21.13.6: Change feed entries (via audit log)
+  # ---------------------------------------------------------------------------
+
+  describe "change feed (AC-21.13.6)" do
+    test "deletion creates a change feed entry visible via audit log" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+      report = create_report(tenant.id, story, agent, project)
+
+      {:ok, _} = TokenUsage.delete_report(tenant.id, report.id)
+
+      # Change feed is implemented via audit log (same as AC-21.8.1 pattern)
+      entries = find_audit_entries(tenant.id, "token_usage_report", "deleted")
+      assert entries != []
+    end
+
+    test "correction creates a change feed entry visible via audit log" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+      original = create_report(tenant.id, story, agent, project)
+
+      {:ok, _} =
+        TokenUsage.create_correction(tenant.id, original.id, %{
+          input_tokens: -100,
+          output_tokens: -50,
+          cost_millicents: -250
+        })
+
+      entries = find_audit_entries(tenant.id, "token_usage_report", "corrected")
+      assert entries != []
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-21.13.7: Cost summaries marked stale
+  # ---------------------------------------------------------------------------
+
+  describe "cost summary stale flag (AC-21.13.7)" do
+    test "deletion marks affected cost summaries as stale" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+      report = create_report(tenant.id, story, agent, project)
+
+      # Insert a cost summary for the story scope
+      %CostSummary{tenant_id: tenant.id}
+      |> CostSummary.changeset(%{
+        scope_type: :story,
+        scope_id: story.id,
+        period_start: ~D[2026-04-01],
+        period_end: ~D[2026-04-01],
+        total_cost_millicents: 2500,
+        report_count: 1,
+        stale: false
+      })
+      |> AdminRepo.insert!()
+
+      {:ok, _} = TokenUsage.delete_report(tenant.id, report.id)
+
+      summaries =
+        CostSummary
+        |> where([cs], cs.tenant_id == ^tenant.id and cs.scope_id == ^story.id)
+        |> AdminRepo.all()
+
+      assert Enum.all?(summaries, & &1.stale)
+    end
+
+    test "correction marks affected cost summaries as stale" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+      original = create_report(tenant.id, story, agent, project)
+
+      %CostSummary{tenant_id: tenant.id}
+      |> CostSummary.changeset(%{
+        scope_type: :story,
+        scope_id: story.id,
+        period_start: ~D[2026-04-01],
+        period_end: ~D[2026-04-01],
+        total_cost_millicents: 2500,
+        report_count: 1,
+        stale: false
+      })
+      |> AdminRepo.insert!()
+
+      {:ok, _} =
+        TokenUsage.create_correction(tenant.id, original.id, %{
+          input_tokens: -100,
+          output_tokens: -50,
+          cost_millicents: -250
+        })
+
+      summaries =
+        CostSummary
+        |> where([cs], cs.tenant_id == ^tenant.id and cs.scope_id == ^story.id)
+        |> AdminRepo.all()
+
+      assert Enum.all?(summaries, & &1.stale)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # AC-21.13.9: Tenant isolation
+  # ---------------------------------------------------------------------------
+
+  describe "tenant isolation (AC-21.13.9)" do
+    test "delete returns not_found when accessing cross-tenant report" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+      report = create_report(tenant.id, story, agent, project)
+
+      other_tenant = fixture(:tenant)
+      assert {:error, :not_found} = TokenUsage.delete_report(other_tenant.id, report.id)
+
+      # Original report should remain untouched
+      assert {:ok, _} = TokenUsage.get_report(tenant.id, report.id)
+    end
+
+    test "create_correction returns not_found when accessing cross-tenant report" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+      original = create_report(tenant.id, story, agent, project)
+
+      other_tenant = fixture(:tenant)
+
+      assert {:error, :not_found} =
+               TokenUsage.create_correction(other_tenant.id, original.id, %{
+                 input_tokens: -100,
+                 output_tokens: -50,
+                 cost_millicents: -250
+               })
+    end
+
+    test "tenant A's deleted report does not affect tenant B's list" do
+      ctx_a = setup_context()
+      ctx_b = setup_context()
+
+      report_a =
+        create_report(ctx_a.tenant.id, ctx_a.story, ctx_a.agent, ctx_a.project)
+
+      create_report(ctx_b.tenant.id, ctx_b.story, ctx_b.agent, ctx_b.project)
+
+      TokenUsage.delete_report(ctx_a.tenant.id, report_a.id)
+
+      {:ok, b_result} = TokenUsage.list_reports_for_story(ctx_b.tenant.id, ctx_b.story.id)
+      assert b_result.total == 1
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # get_report/2 helper
+  # ---------------------------------------------------------------------------
+
+  describe "get_report/2" do
+    test "returns report when found and active" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+      report = create_report(tenant.id, story, agent, project)
+
+      assert {:ok, fetched} = TokenUsage.get_report(tenant.id, report.id)
+      assert fetched.id == report.id
+    end
+
+    test "returns not_found for soft-deleted report" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+      report = create_report(tenant.id, story, agent, project)
+
+      TokenUsage.delete_report(tenant.id, report.id)
+
+      assert {:error, :not_found} = TokenUsage.get_report(tenant.id, report.id)
+    end
+
+    test "returns not_found for cross-tenant" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+      report = create_report(tenant.id, story, agent, project)
+
+      other_tenant = fixture(:tenant)
+      assert {:error, :not_found} = TokenUsage.get_report(other_tenant.id, report.id)
+    end
+  end
+end

--- a/test/loopctl_web/controllers/token_usage_corrections_controller_test.exs
+++ b/test/loopctl_web/controllers/token_usage_corrections_controller_test.exs
@@ -1,0 +1,267 @@
+defmodule LoopctlWeb.TokenUsageCorrectionsControllerTest do
+  @moduledoc """
+  Controller tests for US-21.13: Token Usage Report Correction & Deletion.
+
+  Covers:
+  - DELETE /api/v1/token-usage/:id (role: user only)
+  - POST /api/v1/token-usage/:id/correction (role: user only)
+  - AC-21.13.8: Agent role cannot delete or correct (403)
+  - AC-21.13.9: Tenant isolation (404)
+  """
+
+  use LoopctlWeb.ConnCase, async: true
+
+  setup :verify_on_exit!
+
+  defp auth_conn(conn, raw_key) do
+    put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  defp setup_with_user_key do
+    tenant = fixture(:tenant)
+    project = fixture(:project, %{tenant_id: tenant.id})
+    epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+    agent = fixture(:agent, %{tenant_id: tenant.id, agent_type: :implementer})
+
+    {agent_key, _agent_api_key} =
+      fixture(:api_key, %{tenant_id: tenant.id, role: :agent, agent_id: agent.id})
+
+    {user_key, _user_api_key} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+    story =
+      fixture(:story, %{
+        tenant_id: tenant.id,
+        epic_id: epic.id,
+        project_id: project.id
+      })
+
+    report =
+      fixture(:token_usage_report, %{
+        tenant_id: tenant.id,
+        story_id: story.id,
+        agent_id: agent.id,
+        project_id: project.id,
+        input_tokens: 1000,
+        output_tokens: 500,
+        cost_millicents: 2500
+      })
+
+    %{
+      tenant: tenant,
+      project: project,
+      epic: epic,
+      agent: agent,
+      agent_key: agent_key,
+      user_key: user_key,
+      story: story,
+      report: report
+    }
+  end
+
+  # ---------------------------------------------------------------------------
+  # DELETE /api/v1/token-usage/:id
+  # ---------------------------------------------------------------------------
+
+  describe "DELETE /api/v1/token-usage/:id" do
+    test "user role can soft-delete a report (200)", %{conn: conn} do
+      %{user_key: user_key, report: report} = setup_with_user_key()
+
+      conn =
+        conn
+        |> auth_conn(user_key)
+        |> delete(~p"/api/v1/token-usage/#{report.id}")
+
+      body = json_response(conn, 200)
+      assert body["token_usage_report"]["id"] == report.id
+      assert body["token_usage_report"]["deleted_at"] != nil
+    end
+
+    test "deleted report is excluded from the listing", %{conn: conn} do
+      %{user_key: user_key, agent_key: agent_key, story: story, report: report} =
+        setup_with_user_key()
+
+      conn
+      |> auth_conn(user_key)
+      |> delete(~p"/api/v1/token-usage/#{report.id}")
+
+      list_conn =
+        build_conn()
+        |> auth_conn(agent_key)
+        |> get(~p"/api/v1/stories/#{story.id}/token-usage")
+
+      body = json_response(list_conn, 200)
+      assert body["meta"]["total_count"] == 0
+      assert body["data"] == []
+    end
+
+    test "returns 404 for nonexistent report", %{conn: conn} do
+      %{user_key: user_key} = setup_with_user_key()
+
+      conn =
+        conn
+        |> auth_conn(user_key)
+        |> delete(~p"/api/v1/token-usage/#{Ecto.UUID.generate()}")
+
+      assert json_response(conn, 404)
+    end
+
+    test "returns 404 for already deleted report", %{conn: conn} do
+      %{user_key: user_key, report: report} = setup_with_user_key()
+
+      # First delete
+      conn
+      |> auth_conn(user_key)
+      |> delete(~p"/api/v1/token-usage/#{report.id}")
+
+      # Second delete attempt
+      conn2 =
+        build_conn()
+        |> auth_conn(user_key)
+        |> delete(~p"/api/v1/token-usage/#{report.id}")
+
+      assert json_response(conn2, 404)
+    end
+
+    # AC-21.13.8: Agent role CANNOT delete
+    test "agent role returns 403 on delete", %{conn: conn} do
+      %{agent_key: agent_key, report: report} = setup_with_user_key()
+
+      conn =
+        conn
+        |> auth_conn(agent_key)
+        |> delete(~p"/api/v1/token-usage/#{report.id}")
+
+      assert json_response(conn, 403)
+    end
+
+    # AC-21.13.9: Tenant isolation
+    test "cross-tenant delete returns 404", %{conn: conn} do
+      %{report: report} = setup_with_user_key()
+
+      other_tenant = fixture(:tenant)
+      {other_user_key, _} = fixture(:api_key, %{tenant_id: other_tenant.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(other_user_key)
+        |> delete(~p"/api/v1/token-usage/#{report.id}")
+
+      assert json_response(conn, 404)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # POST /api/v1/token-usage/:id/correction
+  # ---------------------------------------------------------------------------
+
+  describe "POST /api/v1/token-usage/:id/correction" do
+    test "user role can create a correction (201)", %{conn: conn} do
+      %{user_key: user_key, report: report} = setup_with_user_key()
+
+      conn =
+        conn
+        |> auth_conn(user_key)
+        |> post(~p"/api/v1/token-usage/#{report.id}/correction", %{
+          "input_tokens" => -100,
+          "output_tokens" => -50,
+          "cost_millicents" => -250
+        })
+
+      body = json_response(conn, 201)
+      correction = body["token_usage_report"]
+      assert correction["corrects_report_id"] == report.id
+      assert correction["input_tokens"] == -100
+      assert correction["output_tokens"] == -50
+      assert correction["cost_millicents"] == -250
+    end
+
+    test "correction shows in story listing as separate report", %{conn: conn} do
+      %{user_key: user_key, agent_key: agent_key, story: story, report: report} =
+        setup_with_user_key()
+
+      conn
+      |> auth_conn(user_key)
+      |> post(~p"/api/v1/token-usage/#{report.id}/correction", %{
+        "input_tokens" => -100,
+        "output_tokens" => -50,
+        "cost_millicents" => -250
+      })
+
+      list_conn =
+        build_conn()
+        |> auth_conn(agent_key)
+        |> get(~p"/api/v1/stories/#{story.id}/token-usage")
+
+      body = json_response(list_conn, 200)
+      # original + correction = 2 reports
+      assert body["meta"]["total_count"] == 2
+      # net cost: 2500 - 250 = 2250
+      assert body["totals"]["total_cost_millicents"] == 2250
+    end
+
+    test "returns 422 if correction would make total negative", %{conn: conn} do
+      %{user_key: user_key, report: report} = setup_with_user_key()
+
+      conn =
+        conn
+        |> auth_conn(user_key)
+        |> post(~p"/api/v1/token-usage/#{report.id}/correction", %{
+          "input_tokens" => 0,
+          "output_tokens" => 0,
+          "cost_millicents" => -9999
+        })
+
+      assert json_response(conn, 422)
+    end
+
+    test "returns 404 for nonexistent original report", %{conn: conn} do
+      %{user_key: user_key} = setup_with_user_key()
+
+      conn =
+        conn
+        |> auth_conn(user_key)
+        |> post(~p"/api/v1/token-usage/#{Ecto.UUID.generate()}/correction", %{
+          "input_tokens" => -100,
+          "output_tokens" => -50,
+          "cost_millicents" => -250
+        })
+
+      assert json_response(conn, 404)
+    end
+
+    # AC-21.13.8: Agent role CANNOT create corrections
+    test "agent role returns 403 on correction", %{conn: conn} do
+      %{agent_key: agent_key, report: report} = setup_with_user_key()
+
+      conn =
+        conn
+        |> auth_conn(agent_key)
+        |> post(~p"/api/v1/token-usage/#{report.id}/correction", %{
+          "input_tokens" => -100,
+          "output_tokens" => -50,
+          "cost_millicents" => -250
+        })
+
+      assert json_response(conn, 403)
+    end
+
+    # AC-21.13.9: Tenant isolation
+    test "cross-tenant correction returns 404", %{conn: conn} do
+      %{report: report} = setup_with_user_key()
+
+      other_tenant = fixture(:tenant)
+      {other_user_key, _} = fixture(:api_key, %{tenant_id: other_tenant.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(other_user_key)
+        |> post(~p"/api/v1/token-usage/#{report.id}/correction", %{
+          "input_tokens" => -100,
+          "output_tokens" => -50,
+          "cost_millicents" => -250
+        })
+
+      assert json_response(conn, 404)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds soft delete (`deleted_at`) and correction workflow (`corrects_report_id`) for token usage reports with migration, schema, context, controller, and route changes
- All existing token_usage_reports queries across analytics, rollup worker, and anomaly worker updated to filter `WHERE deleted_at IS NULL`
- Budget `warning_fired`/`exceeded_fired` flags reset when spend drops below thresholds after deletion or correction; cost_summaries marked stale atomically

## Test plan

- [ ] Run `mix test test/loopctl/token_usage_corrections_test.exs` — 29 context tests covering all ACs
- [ ] Run `mix test test/loopctl_web/controllers/token_usage_corrections_controller_test.exs` — 12 controller tests including 403 for agent role and 404 for cross-tenant
- [ ] Run `mix test test/loopctl/token_usage_test.exs test/loopctl_web/controllers/token_usage_controller_test.exs` — existing tests still pass (no regressions)
- [ ] Run `mix precommit` — credo clean, dialyzer passes, format clean