### PR TITLE
Fix 6 review findings from Epic 21 enhanced review (Round 1)

### DIFF
--- a/lib/loopctl/token_usage.ex
+++ b/lib/loopctl/token_usage.ex
@@ -554,7 +554,7 @@ defmodule Loopctl.TokenUsage do
     spend = get_scope_spend(tenant_id, budget.scope_type, budget.scope_id)
 
     utilization_pct =
-      if budget.budget_millicents > 0, do: spend * 100 / budget.budget_millicents, else: 0
+      if budget.budget_millicents > 0, do: div(spend * 100, budget.budget_millicents), else: 0
 
     reset_attrs =
       %{}
@@ -898,7 +898,7 @@ defmodule Loopctl.TokenUsage do
       spend = get_scope_spend(tenant_id, budget.scope_type, budget.scope_id)
 
       utilization_pct =
-        if budget.budget_millicents > 0, do: spend * 100 / budget.budget_millicents, else: 0
+        if budget.budget_millicents > 0, do: div(spend * 100, budget.budget_millicents), else: 0
 
       # Fire warning and exceeded independently so both fire when a single
       # report pushes past both thresholds at once.
@@ -914,9 +914,16 @@ defmodule Loopctl.TokenUsage do
     end)
   end
 
-  # Fires a budget_warning webhook event if not already fired (dedup via warning_fired flag).
+  # Fires a budget_warning webhook event using atomic CAS to prevent duplicate
+  # fires under concurrent requests. The UPDATE ... WHERE warning_fired = false
+  # atomically claims the right to fire; only the winner (count == 1) proceeds.
   defp maybe_fire_warning_webhook(tenant_id, budget, spend, utilization_pct, report) do
-    if not budget.warning_fired do
+    {count, _} =
+      Budget
+      |> where([b], b.id == ^budget.id and b.warning_fired == false)
+      |> AdminRepo.update_all(set: [warning_fired: true, updated_at: DateTime.utc_now()])
+
+    if count == 1 do
       payload = %{
         "budget_id" => budget.id,
         "scope_type" => to_string(budget.scope_type),
@@ -929,13 +936,18 @@ defmodule Loopctl.TokenUsage do
       }
 
       fire_budget_event(tenant_id, "token.budget_warning", report.project_id, payload)
-      mark_budget_flag(budget, :warning_fired)
     end
   end
 
-  # Fires a budget_exceeded webhook event if not already fired (dedup via exceeded_fired flag).
+  # Fires a budget_exceeded webhook event using atomic CAS to prevent duplicate
+  # fires under concurrent requests. Same pattern as warning above.
   defp maybe_fire_exceeded_webhook(tenant_id, budget, spend, utilization_pct, report) do
-    if not budget.exceeded_fired do
+    {count, _} =
+      Budget
+      |> where([b], b.id == ^budget.id and b.exceeded_fired == false)
+      |> AdminRepo.update_all(set: [exceeded_fired: true, updated_at: DateTime.utc_now()])
+
+    if count == 1 do
       overage = max(spend - budget.budget_millicents, 0)
 
       payload = %{
@@ -951,7 +963,6 @@ defmodule Loopctl.TokenUsage do
       }
 
       fire_budget_event(tenant_id, "token.budget_exceeded", report.project_id, payload)
-      mark_budget_flag(budget, :exceeded_fired)
     end
   end
 
@@ -986,17 +997,6 @@ defmodule Loopctl.TokenUsage do
           )
       end
     end)
-  end
-
-  # Updates a dedup flag on the budget. Logs failures instead of crashing.
-  defp mark_budget_flag(budget, flag) when flag in [:warning_fired, :exceeded_fired] do
-    case budget |> Ecto.Changeset.change(%{flag => true}) |> AdminRepo.update() do
-      {:ok, _} ->
-        :ok
-
-      {:error, reason} ->
-        Logger.warning("Failed to set #{flag} on budget #{budget.id}: #{inspect(reason)}")
-    end
   end
 
   # Finds all budgets applicable to a report: story-level, epic-level, project-level.

--- a/lib/loopctl/token_usage/analytics.ex
+++ b/lib/loopctl/token_usage/analytics.ex
@@ -423,7 +423,8 @@ defmodule Loopctl.TokenUsage.Analytics do
       |> select([r], %{
         period: fragment("date(?)::date", r.inserted_at),
         total_cost_millicents: sum(r.cost_millicents),
-        total_tokens: sum(r.input_tokens) + sum(r.output_tokens),
+        total_tokens:
+          fragment("coalesce(sum(?), 0) + coalesce(sum(?), 0)", r.input_tokens, r.output_tokens),
         report_count: count(r.id),
         unique_agents: count(r.agent_id, :distinct)
       })
@@ -449,7 +450,8 @@ defmodule Loopctl.TokenUsage.Analytics do
       |> select([r], %{
         period: fragment("date_trunc('week', ?)::date", r.inserted_at),
         total_cost_millicents: sum(r.cost_millicents),
-        total_tokens: sum(r.input_tokens) + sum(r.output_tokens),
+        total_tokens:
+          fragment("coalesce(sum(?), 0) + coalesce(sum(?), 0)", r.input_tokens, r.output_tokens),
         report_count: count(r.id),
         unique_agents: count(r.agent_id, :distinct)
       })
@@ -509,7 +511,8 @@ defmodule Loopctl.TokenUsage.Analytics do
       |> select([r], %{
         model_name: r.model_name,
         phase: r.phase,
-        total_tokens: sum(r.input_tokens) + sum(r.output_tokens),
+        total_tokens:
+          fragment("coalesce(sum(?), 0) + coalesce(sum(?), 0)", r.input_tokens, r.output_tokens),
         total_cost_millicents: sum(r.cost_millicents),
         stories_count: count(r.story_id, :distinct)
       })
@@ -640,7 +643,8 @@ defmodule Loopctl.TokenUsage.Analytics do
     |> select([r], %{
       agent_id: r.agent_id,
       model_name: r.model_name,
-      total_tokens: sum(r.input_tokens) + sum(r.output_tokens)
+      total_tokens:
+        fragment("coalesce(sum(?), 0) + coalesce(sum(?), 0)", r.input_tokens, r.output_tokens)
     })
     |> AdminRepo.all()
     |> Enum.group_by(& &1.agent_id)

--- a/lib/loopctl/token_usage/default_rollup.ex
+++ b/lib/loopctl/token_usage/default_rollup.ex
@@ -35,23 +35,26 @@ defmodule Loopctl.TokenUsage.DefaultRollup do
 
   # --- Agent scope ---
   defp aggregate_by_agent(tenant_id, start_dt, end_dt) do
-    Report
-    |> where([r], r.tenant_id == ^tenant_id)
-    |> where([r], is_nil(r.deleted_at))
-    |> where([r], r.inserted_at >= ^start_dt and r.inserted_at <= ^end_dt)
-    |> where([r], not is_nil(r.agent_id))
-    |> group_by([r], r.agent_id)
-    |> select([r], %{
-      scope_id: r.agent_id,
-      total_input_tokens: sum(r.input_tokens),
-      total_output_tokens: sum(r.output_tokens),
-      total_cost_millicents: sum(r.cost_millicents),
-      report_count: count(r.id)
-    })
-    |> AdminRepo.all()
-    |> Enum.map(fn row ->
-      model_breakdown = build_model_breakdown(tenant_id, :agent, row.scope_id, start_dt, end_dt)
+    rows =
+      Report
+      |> where([r], r.tenant_id == ^tenant_id)
+      |> where([r], is_nil(r.deleted_at))
+      |> where([r], r.inserted_at >= ^start_dt and r.inserted_at <= ^end_dt)
+      |> where([r], not is_nil(r.agent_id))
+      |> group_by([r], r.agent_id)
+      |> select([r], %{
+        scope_id: r.agent_id,
+        total_input_tokens: sum(r.input_tokens),
+        total_output_tokens: sum(r.output_tokens),
+        total_cost_millicents: sum(r.cost_millicents),
+        report_count: count(r.id)
+      })
+      |> AdminRepo.all()
 
+    scope_ids = Enum.map(rows, & &1.scope_id)
+    breakdowns = batch_model_breakdowns(:agent, tenant_id, scope_ids, start_dt, end_dt)
+
+    Enum.map(rows, fn row ->
       %{
         scope_type: :agent,
         scope_id: row.scope_id,
@@ -59,7 +62,7 @@ defmodule Loopctl.TokenUsage.DefaultRollup do
         total_output_tokens: to_int(row.total_output_tokens),
         total_cost_millicents: to_int(row.total_cost_millicents),
         report_count: row.report_count,
-        model_breakdown: model_breakdown,
+        model_breakdown: Map.get(breakdowns, row.scope_id, %{}),
         avg_cost_per_story_millicents: nil
       }
     end)
@@ -67,24 +70,27 @@ defmodule Loopctl.TokenUsage.DefaultRollup do
 
   # --- Epic scope ---
   defp aggregate_by_epic(tenant_id, start_dt, end_dt) do
-    Report
-    |> join(:inner, [r], s in Story, on: r.story_id == s.id)
-    |> where([r, _s], r.tenant_id == ^tenant_id)
-    |> where([r, _s], is_nil(r.deleted_at))
-    |> where([r, _s], r.inserted_at >= ^start_dt and r.inserted_at <= ^end_dt)
-    |> group_by([_r, s], s.epic_id)
-    |> select([r, s], %{
-      scope_id: s.epic_id,
-      total_input_tokens: sum(r.input_tokens),
-      total_output_tokens: sum(r.output_tokens),
-      total_cost_millicents: sum(r.cost_millicents),
-      report_count: count(r.id),
-      distinct_stories: count(r.story_id, :distinct)
-    })
-    |> AdminRepo.all()
-    |> Enum.map(fn row ->
-      model_breakdown = build_model_breakdown(tenant_id, :epic, row.scope_id, start_dt, end_dt)
+    rows =
+      Report
+      |> join(:inner, [r], s in Story, on: r.story_id == s.id)
+      |> where([r, _s], r.tenant_id == ^tenant_id)
+      |> where([r, _s], is_nil(r.deleted_at))
+      |> where([r, _s], r.inserted_at >= ^start_dt and r.inserted_at <= ^end_dt)
+      |> group_by([_r, s], s.epic_id)
+      |> select([r, s], %{
+        scope_id: s.epic_id,
+        total_input_tokens: sum(r.input_tokens),
+        total_output_tokens: sum(r.output_tokens),
+        total_cost_millicents: sum(r.cost_millicents),
+        report_count: count(r.id),
+        distinct_stories: count(r.story_id, :distinct)
+      })
+      |> AdminRepo.all()
 
+    scope_ids = Enum.map(rows, & &1.scope_id)
+    breakdowns = batch_model_breakdowns(:epic, tenant_id, scope_ids, start_dt, end_dt)
+
+    Enum.map(rows, fn row ->
       avg =
         if row.distinct_stories > 0,
           do: div(to_int(row.total_cost_millicents), row.distinct_stories),
@@ -97,7 +103,7 @@ defmodule Loopctl.TokenUsage.DefaultRollup do
         total_output_tokens: to_int(row.total_output_tokens),
         total_cost_millicents: to_int(row.total_cost_millicents),
         report_count: row.report_count,
-        model_breakdown: model_breakdown,
+        model_breakdown: Map.get(breakdowns, row.scope_id, %{}),
         avg_cost_per_story_millicents: avg
       }
     end)
@@ -105,24 +111,27 @@ defmodule Loopctl.TokenUsage.DefaultRollup do
 
   # --- Project scope ---
   defp aggregate_by_project(tenant_id, start_dt, end_dt) do
-    Report
-    |> where([r], r.tenant_id == ^tenant_id)
-    |> where([r], is_nil(r.deleted_at))
-    |> where([r], r.inserted_at >= ^start_dt and r.inserted_at <= ^end_dt)
-    |> where([r], not is_nil(r.project_id))
-    |> group_by([r], r.project_id)
-    |> select([r], %{
-      scope_id: r.project_id,
-      total_input_tokens: sum(r.input_tokens),
-      total_output_tokens: sum(r.output_tokens),
-      total_cost_millicents: sum(r.cost_millicents),
-      report_count: count(r.id),
-      distinct_stories: count(r.story_id, :distinct)
-    })
-    |> AdminRepo.all()
-    |> Enum.map(fn row ->
-      model_breakdown = build_model_breakdown(tenant_id, :project, row.scope_id, start_dt, end_dt)
+    rows =
+      Report
+      |> where([r], r.tenant_id == ^tenant_id)
+      |> where([r], is_nil(r.deleted_at))
+      |> where([r], r.inserted_at >= ^start_dt and r.inserted_at <= ^end_dt)
+      |> where([r], not is_nil(r.project_id))
+      |> group_by([r], r.project_id)
+      |> select([r], %{
+        scope_id: r.project_id,
+        total_input_tokens: sum(r.input_tokens),
+        total_output_tokens: sum(r.output_tokens),
+        total_cost_millicents: sum(r.cost_millicents),
+        report_count: count(r.id),
+        distinct_stories: count(r.story_id, :distinct)
+      })
+      |> AdminRepo.all()
 
+    scope_ids = Enum.map(rows, & &1.scope_id)
+    breakdowns = batch_model_breakdowns(:project, tenant_id, scope_ids, start_dt, end_dt)
+
+    Enum.map(rows, fn row ->
       avg =
         if row.distinct_stories > 0,
           do: div(to_int(row.total_cost_millicents), row.distinct_stories),
@@ -135,17 +144,18 @@ defmodule Loopctl.TokenUsage.DefaultRollup do
         total_output_tokens: to_int(row.total_output_tokens),
         total_cost_millicents: to_int(row.total_cost_millicents),
         report_count: row.report_count,
-        model_breakdown: model_breakdown,
+        model_breakdown: Map.get(breakdowns, row.scope_id, %{}),
         avg_cost_per_story_millicents: avg
       }
     end)
   end
 
-  # --- Model breakdown ---
-  defp build_model_breakdown(tenant_id, scope_type, scope_id, start_dt, end_dt) do
-    query = scope_breakdown_query(scope_type, scope_id, tenant_id, start_dt, end_dt)
+  # --- Model breakdown (batched: 1 query per scope type instead of N) ---
 
-    query
+  defp batch_model_breakdowns(_scope_type, _tenant_id, [], _start_dt, _end_dt), do: %{}
+
+  defp batch_model_breakdowns(scope_type, tenant_id, scope_ids, start_dt, end_dt) do
+    batched_breakdown_query(scope_type, tenant_id, scope_ids, start_dt, end_dt)
     |> AdminRepo.all()
     |> Enum.reduce(%{}, fn row, acc ->
       model = row.model_name
@@ -157,19 +167,22 @@ defmodule Loopctl.TokenUsage.DefaultRollup do
         "cost_millicents" => to_int(row.cost_millicents)
       }
 
-      model_data = Map.get(acc, model, %{})
-      Map.put(acc, model, Map.put(model_data, phase, phase_data))
+      scope_map = Map.get(acc, row.scope_id, %{})
+      model_data = Map.get(scope_map, model, %{})
+      updated_model = Map.put(model_data, phase, phase_data)
+      Map.put(acc, row.scope_id, Map.put(scope_map, model, updated_model))
     end)
   end
 
-  defp scope_breakdown_query(:agent, scope_id, tenant_id, start_dt, end_dt) do
+  defp batched_breakdown_query(:agent, tenant_id, scope_ids, start_dt, end_dt) do
     Report
-    |> where([r], r.agent_id == ^scope_id)
+    |> where([r], r.agent_id in ^scope_ids)
     |> where([r], r.tenant_id == ^tenant_id)
     |> where([r], is_nil(r.deleted_at))
     |> where([r], r.inserted_at >= ^start_dt and r.inserted_at <= ^end_dt)
-    |> group_by([r], [r.model_name, r.phase])
+    |> group_by([r], [r.agent_id, r.model_name, r.phase])
     |> select([r], %{
+      scope_id: r.agent_id,
       model_name: r.model_name,
       phase: r.phase,
       input_tokens: sum(r.input_tokens),
@@ -178,15 +191,16 @@ defmodule Loopctl.TokenUsage.DefaultRollup do
     })
   end
 
-  defp scope_breakdown_query(:epic, scope_id, tenant_id, start_dt, end_dt) do
+  defp batched_breakdown_query(:epic, tenant_id, scope_ids, start_dt, end_dt) do
     Report
     |> join(:inner, [r], s in Story, on: r.story_id == s.id)
     |> where([r, _s], r.tenant_id == ^tenant_id)
     |> where([r, _s], is_nil(r.deleted_at))
     |> where([r, _s], r.inserted_at >= ^start_dt and r.inserted_at <= ^end_dt)
-    |> where([_r, s], s.epic_id == ^scope_id)
-    |> group_by([r, _s], [r.model_name, r.phase])
-    |> select([r, _s], %{
+    |> where([_r, s], s.epic_id in ^scope_ids)
+    |> group_by([r, s], [s.epic_id, r.model_name, r.phase])
+    |> select([r, s], %{
+      scope_id: s.epic_id,
       model_name: r.model_name,
       phase: r.phase,
       input_tokens: sum(r.input_tokens),
@@ -195,14 +209,15 @@ defmodule Loopctl.TokenUsage.DefaultRollup do
     })
   end
 
-  defp scope_breakdown_query(:project, scope_id, tenant_id, start_dt, end_dt) do
+  defp batched_breakdown_query(:project, tenant_id, scope_ids, start_dt, end_dt) do
     Report
-    |> where([r], r.project_id == ^scope_id)
+    |> where([r], r.project_id in ^scope_ids)
     |> where([r], r.tenant_id == ^tenant_id)
     |> where([r], is_nil(r.deleted_at))
     |> where([r], r.inserted_at >= ^start_dt and r.inserted_at <= ^end_dt)
-    |> group_by([r], [r.model_name, r.phase])
+    |> group_by([r], [r.project_id, r.model_name, r.phase])
     |> select([r], %{
+      scope_id: r.project_id,
       model_name: r.model_name,
       phase: r.phase,
       input_tokens: sum(r.input_tokens),

--- a/lib/loopctl/workers/cost_anomaly_worker.ex
+++ b/lib/loopctl/workers/cost_anomaly_worker.ex
@@ -46,13 +46,7 @@ defmodule Loopctl.Workers.CostAnomalyWorker do
     Logger.info("CostAnomalyWorker: scanning #{length(tenants)} tenants for anomalies")
 
     Enum.each(tenants, fn tenant ->
-      case detect_anomalies(tenant.id, period_start, period_end) do
-        :ok ->
-          :ok
-
-        {:error, reason} ->
-          Logger.warning("CostAnomalyWorker: failed for tenant #{tenant.id}: #{inspect(reason)}")
-      end
+      detect_anomalies(tenant.id, period_start, period_end)
     end)
 
     :ok
@@ -76,8 +70,6 @@ defmodule Loopctl.Workers.CostAnomalyWorker do
     end)
 
     :ok
-  rescue
-    e -> {:error, Exception.message(e)}
   end
 
   defp check_epic_stories(tenant_id, epic_summary, period_start, period_end) do
@@ -135,15 +127,25 @@ defmodule Loopctl.Workers.CostAnomalyWorker do
 
     if existing do
       # Update the existing anomaly with latest figures
-      existing
-      |> CostAnomaly.create_changeset(%{
-        story_cost_millicents: story_cost,
-        reference_avg_millicents: epic_avg,
-        deviation_factor: Decimal.round(factor, 2)
-      })
-      |> AdminRepo.update!()
+      case existing
+           |> CostAnomaly.create_changeset(%{
+             story_cost_millicents: story_cost,
+             reference_avg_millicents: epic_avg,
+             deviation_factor: Decimal.round(factor, 2)
+           })
+           |> AdminRepo.update() do
+        {:ok, updated} ->
+          updated
+
+        {:error, changeset} ->
+          Logger.warning(
+            "CostAnomalyWorker: failed to update anomaly #{existing.id}: #{inspect(changeset.errors)}"
+          )
+
+          existing
+      end
     else
-      anomaly =
+      changeset =
         %CostAnomaly{tenant_id: tenant_id, story_id: story_id}
         |> CostAnomaly.create_changeset(%{
           anomaly_type: anomaly_type,
@@ -151,33 +153,42 @@ defmodule Loopctl.Workers.CostAnomalyWorker do
           reference_avg_millicents: epic_avg,
           deviation_factor: Decimal.round(factor, 2)
         })
-        |> AdminRepo.insert!()
 
-      # Emit change feed + audit log entry for the newly detected anomaly (AC-21.8.3, AC-21.8.5)
-      Audit.create_log_entry(tenant_id, %{
-        entity_type: "cost_anomaly",
-        entity_id: anomaly.id,
-        action: "detected",
-        actor_type: "system",
-        new_state: %{
-          "anomaly_type" => to_string(anomaly.anomaly_type),
-          "story_id" => anomaly.story_id,
-          "deviation_factor" => Decimal.to_string(anomaly.deviation_factor),
-          "story_cost_millicents" => anomaly.story_cost_millicents,
-          "reference_avg_millicents" => anomaly.reference_avg_millicents
-        },
-        metadata: %{
-          "anomaly_id" => anomaly.id,
-          "story_id" => anomaly.story_id,
-          "anomaly_type" => to_string(anomaly.anomaly_type),
-          "deviation_factor" => Decimal.to_string(anomaly.deviation_factor)
-        }
-      })
+      case AdminRepo.insert(changeset) do
+        {:ok, anomaly} ->
+          # Emit change feed + audit log entry for the newly detected anomaly (AC-21.8.3, AC-21.8.5)
+          Audit.create_log_entry(tenant_id, %{
+            entity_type: "cost_anomaly",
+            entity_id: anomaly.id,
+            action: "detected",
+            actor_type: "system",
+            new_state: %{
+              "anomaly_type" => to_string(anomaly.anomaly_type),
+              "story_id" => anomaly.story_id,
+              "deviation_factor" => Decimal.to_string(anomaly.deviation_factor),
+              "story_cost_millicents" => anomaly.story_cost_millicents,
+              "reference_avg_millicents" => anomaly.reference_avg_millicents
+            },
+            metadata: %{
+              "anomaly_id" => anomaly.id,
+              "story_id" => anomaly.story_id,
+              "anomaly_type" => to_string(anomaly.anomaly_type),
+              "deviation_factor" => Decimal.to_string(anomaly.deviation_factor)
+            }
+          })
 
-      # Fire token.anomaly_detected webhook event (AC-21.7.7)
-      fire_anomaly_webhook(tenant_id, anomaly)
+          # Fire token.anomaly_detected webhook event (AC-21.7.7)
+          fire_anomaly_webhook(tenant_id, anomaly)
 
-      anomaly
+          anomaly
+
+        {:error, changeset} ->
+          Logger.warning(
+            "CostAnomalyWorker: failed to insert anomaly for story #{story_id}: #{inspect(changeset.errors)}"
+          )
+
+          nil
+      end
     end
   end
 

--- a/lib/loopctl/workers/cost_rollup_worker.ex
+++ b/lib/loopctl/workers/cost_rollup_worker.ex
@@ -89,7 +89,8 @@ defmodule Loopctl.Workers.CostRollupWorker do
         |> CostSummary.changeset(
           Map.merge(row, %{
             period_start: period_start,
-            period_end: period_end
+            period_end: period_end,
+            stale: false
           })
         )
 
@@ -104,6 +105,7 @@ defmodule Loopctl.Workers.CostRollupWorker do
              :report_count,
              :model_breakdown,
              :avg_cost_per_story_millicents,
+             :stale,
              :updated_at
            ]},
         conflict_target: [:tenant_id, :scope_type, :scope_id, :period_start]


### PR DESCRIPTION
## Summary

Fixes 6 confirmed bugs from an enhanced code review of Epic 21 (Token Efficiency):

1. **Rollup N+1 model breakdown queries** (`default_rollup.ex`) — `build_model_breakdown/5` was called per-row inside `Enum.map`, issuing N extra queries per scope type. Replaced with batched queries: one `GROUP BY scope_id, model_name, phase WHERE scope_id IN ^ids` per scope type, results distributed in-memory via lookup map.

2. **Budget dedup race condition** (`token_usage.ex`) — `maybe_fire_warning_webhook` and `maybe_fire_exceeded_webhook` read flag in memory, checked it, fired webhook, then updated flag. Two concurrent requests could both read `false` and both fire. Replaced with atomic CAS: `AdminRepo.update_all` with `WHERE flag = false` returning `{count, _}` — only the winner (count == 1) fires the webhook. Removed now-unused `mark_budget_flag/2`.

3. **Stale flag never cleared by rollup upsert** (`cost_rollup_worker.ex`) — The upsert `on_conflict: {:replace, [...]}` list did not include `:stale`. When a summary was marked stale, the rollup would upsert fresh data but leave `stale: true` permanently. Added `:stale` to the replace list and `stale: false` to the changeset data.

4. **Float division in budget utilization** (`token_usage.ex`) — `spend * 100 / budget.budget_millicents` used float division. At boundary values (e.g., exactly 80%), float imprecision could produce 79.999... instead of 80, missing the threshold. Replaced both occurrences with `div(spend * 100, budget.budget_millicents)` for deterministic integer math.

5. **Missing coalesce in analytics sum+sum** (`analytics.ex`) — `sum(r.input_tokens) + sum(r.output_tokens)` in PostgreSQL yields NULL if either column's sum is NULL. Fixed all 4 occurrences with `coalesce(sum(?), 0) + coalesce(sum(?), 0)`.

6. **Blanket rescue + bang ops in anomaly worker** (`cost_anomaly_worker.ex`) — `detect_anomalies/3` wrapped everything in `rescue e ->`, swallowing all exceptions. `create_anomaly/6` used `AdminRepo.insert!` and `AdminRepo.update!` inside this rescue, losing structured error info. Removed the blanket rescue (Oban handles retries for crashes). Replaced bang ops with `AdminRepo.insert`/`AdminRepo.update` + explicit `{:error, changeset}` handling with `Logger.warning`.

## Test plan

- [x] `mix compile --warnings-as-errors` — zero warnings
- [x] `mix precommit` passes (compile, format, credo --strict, deps.audit, dialyzer, test)
- [x] All 1581 tests pass, 0 failures