### PR TITLE
Fix 6 Yellow findings from Epic 21 review

### DIFF
--- a/lib/loopctl/token_usage.ex
+++ b/lib/loopctl/token_usage.ex
@@ -95,11 +95,8 @@ defmodule Loopctl.TokenUsage do
         }
         |> Report.create_changeset(attrs)
 
-      case AdminRepo.insert(changeset) do
+      case AdminRepo.insert(changeset, returning: [:total_tokens]) do
         {:ok, report} ->
-          # Refetch to populate the DB-generated total_tokens column
-          report = AdminRepo.get!(Report, report.id)
-
           # Audit log the creation (also serves as the change feed entry for AC-21.8.1)
           Audit.create_log_entry(tenant_id, %{
             entity_type: "token_usage_report",
@@ -422,7 +419,7 @@ defmodule Loopctl.TokenUsage do
 
       multi =
         Multi.new()
-        |> Multi.insert(:correction, changeset)
+        |> Multi.insert(:correction, changeset, returning: [:total_tokens])
         |> Audit.log_in_multi(:audit, fn %{correction: correction} ->
           %{
             tenant_id: tenant_id,
@@ -454,9 +451,6 @@ defmodule Loopctl.TokenUsage do
 
       case AdminRepo.transaction(multi) do
         {:ok, %{correction: correction}} ->
-          # Refetch to populate the DB-generated total_tokens column
-          correction = AdminRepo.get!(Report, correction.id)
-
           # Reset budget flags if spend dropped below thresholds
           try do
             reset_budget_flags_if_needed(tenant_id, original)
@@ -1000,37 +994,34 @@ defmodule Loopctl.TokenUsage do
   end
 
   # Finds all budgets applicable to a report: story-level, epic-level, project-level.
+  # Uses two queries instead of up to four:
+  #   1. Fetch the story to resolve its epic_id.
+  #   2. Fetch all matching budgets in a single query using OR conditions.
   defp find_applicable_budgets(tenant_id, report) do
-    story_budget =
-      AdminRepo.get_by(Budget,
-        tenant_id: tenant_id,
-        scope_type: :story,
-        scope_id: report.story_id
-      )
-
-    # Look up the story's epic_id for epic-level budget check
-    epic_budget =
+    epic_id =
       case AdminRepo.get_by(Story, id: report.story_id, tenant_id: tenant_id) do
-        nil ->
-          nil
-
-        story ->
-          AdminRepo.get_by(Budget,
-            tenant_id: tenant_id,
-            scope_type: :epic,
-            scope_id: story.epic_id
-          )
+        nil -> nil
+        story -> story.epic_id
       end
 
-    project_budget =
-      AdminRepo.get_by(Budget,
-        tenant_id: tenant_id,
-        scope_type: :project,
-        scope_id: report.project_id
+    scope_filter =
+      dynamic(
+        [b],
+        (b.scope_type == :story and b.scope_id == ^report.story_id) or
+          (b.scope_type == :project and b.scope_id == ^report.project_id)
       )
 
-    [story_budget, epic_budget, project_budget]
-    |> Enum.reject(&is_nil/1)
+    scope_filter =
+      if epic_id do
+        dynamic([b], ^scope_filter or (b.scope_type == :epic and b.scope_id == ^epic_id))
+      else
+        scope_filter
+      end
+
+    Budget
+    |> where([b], b.tenant_id == ^tenant_id)
+    |> where(^scope_filter)
+    |> AdminRepo.all()
   end
 
   defp emit_threshold_crossed(tenant_id, budget, utilization_pct, threshold_type) do

--- a/lib/loopctl/token_usage/analytics.ex
+++ b/lib/loopctl/token_usage/analytics.ex
@@ -972,61 +972,48 @@ defmodule Loopctl.TokenUsage.Analytics do
 
   # AC-21.5.4: Comparative view — mixed-model vs single-model agents.
   # Returns avg verification rate and avg cost per story for each group.
+  # Uses a single query with a LEFT JOIN to stories and conditional aggregation
+  # to avoid two separate full-table scans of token_usage_reports.
   defp model_mix_comparative(tenant_id, opts) do
-    # Compute per-agent: model_count, total_cost, story_count, verified_count
+    # Single query: per-agent stats + verification counts via conditional aggregation
     agent_stats =
       Report
-      |> where([r], r.tenant_id == ^tenant_id)
-      |> where([r], is_nil(r.deleted_at))
-      |> where([r], not is_nil(r.agent_id))
-      |> apply_date_filters(opts)
-      |> apply_project_filter(opts)
-      |> group_by([r], r.agent_id)
-      |> select([r], %{
-        agent_id: r.agent_id,
-        model_count: count(r.model_name, :distinct),
-        total_cost_millicents: sum(r.cost_millicents),
-        stories_count: count(r.story_id, :distinct)
-      })
-      |> AdminRepo.all()
-
-    # Verification counts per agent (from verified/rejected stories)
-    agent_verification =
-      Report
-      |> join(:inner, [r], s in Story, on: r.story_id == s.id)
+      |> join(:left, [r], s in Story, on: r.story_id == s.id)
       |> where([r, _s], r.tenant_id == ^tenant_id)
       |> where([r, _s], is_nil(r.deleted_at))
       |> where([r, _s], not is_nil(r.agent_id))
-      |> where([_r, s], s.verified_status in [:verified, :rejected])
       |> apply_model_date_filters(opts)
       |> apply_model_project_filter(opts)
-      |> group_by([r, s], [r.agent_id, s.verified_status])
+      |> group_by([r, _s], r.agent_id)
       |> select([r, s], %{
         agent_id: r.agent_id,
-        verified_status: s.verified_status,
-        story_count: count(s.id, :distinct)
+        model_count: count(r.model_name, :distinct),
+        total_cost_millicents: sum(r.cost_millicents),
+        stories_count: count(r.story_id, :distinct),
+        verified_count:
+          fragment(
+            "COUNT(DISTINCT CASE WHEN ? = 'verified' THEN ? END)",
+            s.verified_status,
+            s.id
+          ),
+        rejected_count:
+          fragment(
+            "COUNT(DISTINCT CASE WHEN ? = 'rejected' THEN ? END)",
+            s.verified_status,
+            s.id
+          )
       })
       |> AdminRepo.all()
-      |> Enum.group_by(& &1.agent_id)
-      |> Map.new(fn {agent_id, rows} ->
-        verified = Enum.find(rows, &(&1.verified_status == :verified))
-        rejected = Enum.find(rows, &(&1.verified_status == :rejected))
-
-        {agent_id,
-         %{
-           verified: if(verified, do: verified.story_count, else: 0),
-           rejected: if(rejected, do: rejected.story_count, else: 0)
-         }}
-      end)
 
     # Build per-agent enriched data
     enriched =
       Enum.map(agent_stats, fn row ->
-        vd = Map.get(agent_verification, row.agent_id, %{verified: 0, rejected: 0})
-        total_verifiable = vd.verified + vd.rejected
+        verified = row.verified_count || 0
+        rejected = row.rejected_count || 0
+        total_verifiable = verified + rejected
 
         verification_rate =
-          if total_verifiable > 0, do: safe_div(vd.verified * 100, total_verifiable), else: nil
+          if total_verifiable > 0, do: safe_div(verified * 100, total_verifiable), else: nil
 
         cost = to_int(row.total_cost_millicents)
         avg_cost = safe_div(cost, row.stories_count)

--- a/lib/loopctl/token_usage/formatting.ex
+++ b/lib/loopctl/token_usage/formatting.ex
@@ -32,7 +32,9 @@ defmodule Loopctl.TokenUsage.Formatting do
       iex> millicents_to_dollars(155)
       "0.00"
   """
-  @spec millicents_to_dollars(integer() | Decimal.t()) :: String.t()
+  @spec millicents_to_dollars(integer() | Decimal.t() | nil) :: String.t()
+  def millicents_to_dollars(nil), do: "0.00"
+
   def millicents_to_dollars(%Decimal{} = millicents) do
     millicents
     |> Decimal.div(100_000)
@@ -76,7 +78,9 @@ defmodule Loopctl.TokenUsage.Formatting do
       iex> format_tokens(2_500_000)
       "2.5M"
   """
-  @spec format_tokens(integer()) :: String.t()
+  @spec format_tokens(integer() | nil) :: String.t()
+  def format_tokens(nil), do: "0"
+
   def format_tokens(tokens) when is_integer(tokens) and tokens >= 1_000_000 do
     whole = div(tokens, 1_000_000)
     frac = div(rem(tokens, 1_000_000), 100_000)

--- a/lib/loopctl/workers/cost_anomaly_worker.ex
+++ b/lib/loopctl/workers/cost_anomaly_worker.ex
@@ -64,35 +64,43 @@ defmodule Loopctl.Workers.CostAnomalyWorker do
       |> where([cs], cs.avg_cost_per_story_millicents > 0)
       |> AdminRepo.all()
 
-    # For each epic, get per-story costs in this period
-    Enum.each(epic_summaries, fn summary ->
-      check_epic_stories(tenant_id, summary, period_start, period_end)
-    end)
+    if epic_summaries == [] do
+      :ok
+    else
+      # Build a map of epic_id => avg_cost_per_story_millicents for fast lookup
+      epic_avg_map =
+        Map.new(epic_summaries, fn cs -> {cs.scope_id, cs.avg_cost_per_story_millicents} end)
+
+      epic_ids = Map.keys(epic_avg_map)
+      check_all_epic_stories(tenant_id, epic_ids, epic_avg_map, period_start, period_end)
+    end
 
     :ok
   end
 
-  defp check_epic_stories(tenant_id, epic_summary, period_start, period_end) do
+  # Issues ONE query for per-story costs across ALL epics, then processes in memory.
+  defp check_all_epic_stories(tenant_id, epic_ids, epic_avg_map, period_start, period_end) do
     start_dt = NaiveDateTime.new!(period_start, ~T[00:00:00])
     end_dt = NaiveDateTime.new!(period_end, ~T[23:59:59.999999])
-    epic_avg = epic_summary.avg_cost_per_story_millicents
 
-    # Get per-story costs for this epic in the period (exclude soft-deleted reports)
+    # Single query: per-story costs grouped by (story_id, epic_id) for all epics
     story_costs =
       Report
       |> join(:inner, [r], s in Story, on: r.story_id == s.id)
-      |> where([r, s], r.tenant_id == ^tenant_id)
+      |> where([r, _s], r.tenant_id == ^tenant_id)
       |> where([r, _s], is_nil(r.deleted_at))
-      |> where([_r, s], s.epic_id == ^epic_summary.scope_id)
+      |> where([_r, s], s.epic_id in ^epic_ids)
       |> where([r, _s], r.inserted_at >= ^start_dt and r.inserted_at <= ^end_dt)
-      |> group_by([r, _s], r.story_id)
-      |> select([r, _s], %{
+      |> group_by([r, s], [r.story_id, s.epic_id])
+      |> select([r, s], %{
         story_id: r.story_id,
+        epic_id: s.epic_id,
         total_cost: sum(r.cost_millicents)
       })
       |> AdminRepo.all()
 
-    Enum.each(story_costs, fn %{story_id: story_id, total_cost: total_cost} ->
+    Enum.each(story_costs, fn %{story_id: story_id, epic_id: epic_id, total_cost: total_cost} ->
+      epic_avg = Map.get(epic_avg_map, epic_id)
       cost = to_int(total_cost)
       check_and_flag_anomaly(tenant_id, story_id, cost, epic_avg)
     end)
@@ -268,8 +276,16 @@ defmodule Loopctl.Workers.CostAnomalyWorker do
         yesterday = Date.add(Date.utc_today(), -1)
         {yesterday, yesterday}
 
-      {start_str, end_str} ->
+      {start_str, end_str} when is_binary(start_str) and is_binary(end_str) ->
         {Date.from_iso8601!(start_str), Date.from_iso8601!(end_str)}
+
+      other ->
+        Logger.warning(
+          "CostAnomalyWorker: invalid period args #{inspect(other)}, defaulting to yesterday"
+        )
+
+        yesterday = Date.add(Date.utc_today(), -1)
+        {yesterday, yesterday}
     end
   end
 

--- a/lib/loopctl/workers/cost_rollup_worker.ex
+++ b/lib/loopctl/workers/cost_rollup_worker.ex
@@ -121,8 +121,16 @@ defmodule Loopctl.Workers.CostRollupWorker do
         yesterday = Date.add(Date.utc_today(), -1)
         {yesterday, yesterday}
 
-      {start_str, end_str} ->
+      {start_str, end_str} when is_binary(start_str) and is_binary(end_str) ->
         {Date.from_iso8601!(start_str), Date.from_iso8601!(end_str)}
+
+      other ->
+        Logger.warning(
+          "CostRollupWorker: invalid period args #{inspect(other)}, defaulting to yesterday"
+        )
+
+        yesterday = Date.add(Date.utc_today(), -1)
+        {yesterday, yesterday}
     end
   end
 


### PR DESCRIPTION
## Summary

- **Fix 7**: Add `nil` guard clauses to `millicents_to_dollars/1` and `format_tokens/1` in `Formatting` to prevent `FunctionClauseError` on nil input
- **Fix 8**: Collapse per-epic N+1 in `CostAnomalyWorker` — replaced one DB query per epic with a single query grouped by `(story_id, epic_id)` across all epics
- **Fix 9**: Guard `resolve_period/1` in both `CostRollupWorker` and `CostAnomalyWorker` with `is_binary/is_binary` pattern match; added catch-all that logs a warning and defaults to yesterday instead of crashing via `Date.from_iso8601!`
- **Fix 10**: Replace two full-table scans of `token_usage_reports` in `model_mix_comparative/2` with one query using `LEFT JOIN stories` and `COUNT(DISTINCT CASE WHEN verified_status = ...)` conditional aggregation
- **Fix 11**: Use `AdminRepo.insert(changeset, returning: [:total_tokens])` in `create_report` and `Multi.insert(:correction, changeset, returning: [:total_tokens])` in `create_correction` to eliminate the post-insert `AdminRepo.get!` re-fetch
- **Fix 12**: Replace up to 4 sequential `AdminRepo.get_by` calls in `find_applicable_budgets/2` with 2 queries: one story lookup to resolve `epic_id`, then one bulk query using `dynamic/2` OR conditions for all three scope types

## Test plan

- [ ] `mix precommit` passes: 1581 tests, 0 failures, 0 compiler warnings, credo clean, dialyzer clean
- [ ] Budget threshold tests (`token_usage_change_feed_test`, `token_usage_webhook_events_test`, `token_usage_corrections_test`) all pass with the dynamic OR approach in Fix 12
- [ ] No regressions in any existing test suite