### PR TITLE
Fix 5 BA findings from Epic 21 review

### DIFF
--- a/lib/loopctl/token_usage/cost_summary.ex
+++ b/lib/loopctl/token_usage/cost_summary.ex
@@ -92,9 +92,6 @@ defmodule Loopctl.TokenUsage.CostSummary do
       :period_end
     ])
     |> validate_inclusion(:scope_type, @scope_types)
-    |> validate_number(:total_input_tokens, greater_than_or_equal_to: 0)
-    |> validate_number(:total_output_tokens, greater_than_or_equal_to: 0)
-    |> validate_number(:total_cost_millicents, greater_than_or_equal_to: 0)
     |> validate_number(:report_count, greater_than_or_equal_to: 0)
     |> foreign_key_constraint(:tenant_id)
     |> unique_constraint([:tenant_id, :scope_type, :scope_id, :period_start],

--- a/lib/loopctl_web/controllers/cost_anomaly_controller.ex
+++ b/lib/loopctl_web/controllers/cost_anomaly_controller.ex
@@ -37,6 +37,12 @@ defmodule LoopctlWeb.CostAnomalyController do
         type: :boolean,
         description: "Include archived anomalies (default: false)"
       ],
+      resolved: [
+        in: :query,
+        type: :boolean,
+        description:
+          "Filter by resolved status. true = resolved only, false = unresolved only (default: false)"
+      ],
       page: [in: :query, type: :integer, description: "Page number"],
       page_size: [in: :query, type: :integer, description: "Items per page"]
     ],
@@ -99,6 +105,7 @@ defmodule LoopctlWeb.CostAnomalyController do
       |> maybe_add_opt(:anomaly_type, params["anomaly_type"])
       |> maybe_add_opt(:project_id, params["project_id"])
       |> maybe_add_opt(:include_archived, parse_bool(params["include_archived"]))
+      |> maybe_add_opt(:resolved, parse_bool(params["resolved"]))
       |> maybe_add_opt(:page, parse_int(params["page"]))
       |> maybe_add_opt(:page_size, parse_int(params["page_size"]))
 

--- a/lib/loopctl_web/controllers/token_budget_controller.ex
+++ b/lib/loopctl_web/controllers/token_budget_controller.ex
@@ -273,7 +273,22 @@ defmodule LoopctlWeb.TokenBudgetController do
     with {:ok, budget} <- TokenUsage.get_budget(tenant_id, id) do
       spend = TokenUsage.get_scope_spend(tenant_id, budget.scope_type, budget.scope_id)
 
-      json(conn, %{token_budget: format_budget_with_spend(budget, spend)})
+      {:ok, effective} =
+        TokenUsage.get_effective_budget(tenant_id, budget.scope_type, budget.scope_id)
+
+      {effective_budget_millicents, budget_source} =
+        case effective do
+          {millicents, source} -> {millicents, source}
+          nil -> {nil, nil}
+        end
+
+      json(conn, %{
+        token_budget:
+          budget
+          |> format_budget_with_spend(spend)
+          |> Map.put(:effective_budget_millicents, effective_budget_millicents)
+          |> Map.put(:budget_source, budget_source)
+      })
     end
   end
 
@@ -321,14 +336,16 @@ defmodule LoopctlWeb.TokenBudgetController do
 
   defp format_budget_with_spend(budget, spend) do
     remaining = max(budget.budget_millicents - spend, 0)
+    budget_millicents = budget.budget_millicents
+    utilization_pct = if budget_millicents > 0, do: div(spend * 100, budget_millicents), else: 0
 
     %{
       id: budget.id,
       tenant_id: budget.tenant_id,
       scope_type: budget.scope_type,
       scope_id: budget.scope_id,
-      budget_millicents: budget.budget_millicents,
-      budget_dollars: Formatting.millicents_to_dollars(budget.budget_millicents),
+      budget_millicents: budget_millicents,
+      budget_dollars: Formatting.millicents_to_dollars(budget_millicents),
       budget_input_tokens: budget.budget_input_tokens,
       budget_output_tokens: budget.budget_output_tokens,
       alert_threshold_pct: budget.alert_threshold_pct,
@@ -336,6 +353,7 @@ defmodule LoopctlWeb.TokenBudgetController do
       current_spend_dollars: Formatting.millicents_to_dollars(spend),
       remaining_millicents: remaining,
       remaining_dollars: Formatting.millicents_to_dollars(remaining),
+      utilization_pct: utilization_pct,
       metadata: budget.metadata,
       inserted_at: budget.inserted_at,
       updated_at: budget.updated_at

--- a/lib/loopctl_web/controllers/token_usage_controller.ex
+++ b/lib/loopctl_web/controllers/token_usage_controller.ex
@@ -20,7 +20,7 @@ defmodule LoopctlWeb.TokenUsageController do
   action_fallback LoopctlWeb.FallbackController
 
   plug LoopctlWeb.Plugs.RequireRole, [role: :agent] when action in [:create, :index]
-  plug LoopctlWeb.Plugs.RequireRole, [exact_role: :user] when action in [:delete, :correct]
+  plug LoopctlWeb.Plugs.RequireRole, [role: :user] when action in [:delete, :correct]
 
   tags(["Token Efficiency"])
 

--- a/test/loopctl/token_usage/cost_summary_test.exs
+++ b/test/loopctl/token_usage/cost_summary_test.exs
@@ -62,25 +62,35 @@ defmodule Loopctl.TokenUsage.CostSummaryTest do
       end
     end
 
-    test "validates non-negative numbers" do
+    test "validates report_count is non-negative" do
       changeset =
         CostSummary.changeset(%CostSummary{}, %{
           scope_type: :project,
           scope_id: Ecto.UUID.generate(),
           period_start: ~D[2026-04-01],
           period_end: ~D[2026-04-01],
-          total_input_tokens: -1,
-          total_output_tokens: -1,
-          total_cost_millicents: -1,
           report_count: -1
         })
 
       refute changeset.valid?
       errors = errors_on(changeset)
-      assert errors[:total_input_tokens]
-      assert errors[:total_output_tokens]
-      assert errors[:total_cost_millicents]
       assert errors[:report_count]
+    end
+
+    test "allows negative token and cost aggregates from corrections" do
+      changeset =
+        CostSummary.changeset(%CostSummary{}, %{
+          scope_type: :project,
+          scope_id: Ecto.UUID.generate(),
+          period_start: ~D[2026-04-01],
+          period_end: ~D[2026-04-01],
+          total_input_tokens: -100,
+          total_output_tokens: -50,
+          total_cost_millicents: -200,
+          report_count: 1
+        })
+
+      assert changeset.valid?
     end
   end
 


### PR DESCRIPTION
## Summary

- **BA-2**: `show/2` in `TokenBudgetController` now calls `get_effective_budget/3` and includes `effective_budget_millicents` and `budget_source` in the response (AC-21.2.9)
- **BA-3**: `format_budget_with_spend/2` now computes and returns `utilization_pct` as `div(spend * 100, budget_millicents)` (TC-21.2.3)
- **BA-5**: Changed `exact_role: :user` to `role: :user` on the `delete`/`correct` plug in `TokenUsageController` so superadmins can perform these operations via the role hierarchy
- **BA-6**: `CostAnomalyController` now parses `params["resolved"]` and passes it to `list_anomalies/2`; also added `resolved` parameter to the OpenAPI operation spec
- **BA-8**: Removed `>= 0` validations on `total_input_tokens`, `total_output_tokens`, and `total_cost_millicents` in `CostSummary.changeset/2`; negative aggregates are valid when corrections exist. Updated the corresponding test to assert the new semantics.

## Test plan

- [x] `mix compile --warnings-as-errors` — zero warnings
- [x] `mix precommit` — 1582 tests, 0 failures (format, credo, sobelow, dialyzer, ExUnit all pass)