### PR TITLE
Fix 10 adversarial findings from Epic 21 review (Round 2)

### DIFF
--- a/lib/loopctl/token_usage.ex
+++ b/lib/loopctl/token_usage.ex
@@ -337,20 +337,13 @@ defmodule Loopctl.TokenUsage do
           }
         end)
         |> mark_affected_cost_summaries_stale_multi(tenant_id, report)
+        |> Multi.run(:reset_budget_flags, fn _repo, _changes ->
+          reset_budget_flags_if_needed(tenant_id, report)
+          {:ok, :ok}
+        end)
 
       case AdminRepo.transaction(multi) do
         {:ok, %{report: deleted_report}} ->
-          # Reset budget flags if spend dropped below thresholds
-          try do
-            reset_budget_flags_if_needed(tenant_id, report)
-          rescue
-            e ->
-              Logger.warning(
-                "Budget flag reset failed after deleting report #{report.id}: " <>
-                  Exception.message(e)
-              )
-          end
-
           {:ok, deleted_report}
 
         {:error, _step, error, _} ->
@@ -394,8 +387,7 @@ defmodule Loopctl.TokenUsage do
   def create_correction(tenant_id, original_report_id, attrs, opts \\ []) do
     attrs = normalize_attrs(attrs)
 
-    with {:ok, original} <- get_report(tenant_id, original_report_id),
-         :ok <- validate_correction_totals(tenant_id, original, attrs) do
+    with {:ok, original} <- get_report(tenant_id, original_report_id) do
       correction_input_tokens = Map.get(attrs, :input_tokens, 0)
       correction_output_tokens = Map.get(attrs, :output_tokens, 0)
 
@@ -419,6 +411,9 @@ defmodule Loopctl.TokenUsage do
 
       multi =
         Multi.new()
+        |> Multi.run(:validate_totals, fn _repo, _changes ->
+          validate_correction_totals(tenant_id, original, attrs)
+        end)
         |> Multi.insert(:correction, changeset, returning: [:total_tokens])
         |> Audit.log_in_multi(:audit, fn %{correction: correction} ->
           %{
@@ -448,21 +443,17 @@ defmodule Loopctl.TokenUsage do
           }
         end)
         |> mark_affected_cost_summaries_stale_multi(tenant_id, original)
+        |> Multi.run(:reset_budget_flags, fn _repo, _changes ->
+          reset_budget_flags_if_needed(tenant_id, original)
+          {:ok, :ok}
+        end)
 
       case AdminRepo.transaction(multi) do
         {:ok, %{correction: correction}} ->
-          # Reset budget flags if spend dropped below thresholds
-          try do
-            reset_budget_flags_if_needed(tenant_id, original)
-          rescue
-            e ->
-              Logger.warning(
-                "Budget flag reset failed after correcting report #{original.id}: " <>
-                  Exception.message(e)
-              )
-          end
-
           {:ok, correction}
+
+        {:error, :validate_totals, {:unprocessable_entity, message}, _} ->
+          {:error, :unprocessable_entity, message}
 
         {:error, :correction, %Ecto.Changeset{} = changeset, _} ->
           {:error, changeset}
@@ -488,19 +479,16 @@ defmodule Loopctl.TokenUsage do
 
     cond do
       new_input < 0 ->
-        {:error, :unprocessable_entity,
-         "correction would make total input_tokens negative (current: #{totals.total_input_tokens}, correction: #{correction_input})"}
+        {:error, {:unprocessable_entity, "correction would make total input_tokens negative"}}
 
       new_output < 0 ->
-        {:error, :unprocessable_entity,
-         "correction would make total output_tokens negative (current: #{totals.total_output_tokens}, correction: #{correction_output})"}
+        {:error, {:unprocessable_entity, "correction would make total output_tokens negative"}}
 
       new_cost < 0 ->
-        {:error, :unprocessable_entity,
-         "correction would make total cost_millicents negative (current: #{totals.total_cost_millicents}, correction: #{correction_cost})"}
+        {:error, {:unprocessable_entity, "correction would make total cost_millicents negative"}}
 
       true ->
-        :ok
+        {:ok, :ok}
     end
   end
 

--- a/lib/loopctl/token_usage/analytics.ex
+++ b/lib/loopctl/token_usage/analytics.ex
@@ -517,6 +517,7 @@ defmodule Loopctl.TokenUsage.Analytics do
         stories_count: count(r.story_id, :distinct)
       })
       |> order_by([r], asc: r.model_name, asc: r.phase)
+      |> limit(1000)
       |> AdminRepo.all()
 
     # Verification data per (model_name, phase) pair
@@ -841,6 +842,7 @@ defmodule Loopctl.TokenUsage.Analytics do
         stories_count: count(r.story_id, :distinct)
       })
       |> order_by([r], asc: r.model_name, asc: r.phase)
+      |> limit(1000)
       |> AdminRepo.all()
 
     verification_map = agent_model_phase_verification_data(tenant_id, agent_id, opts)
@@ -1003,6 +1005,7 @@ defmodule Loopctl.TokenUsage.Analytics do
             s.id
           )
       })
+      |> limit(1000)
       |> AdminRepo.all()
 
     # Build per-agent enriched data

--- a/lib/loopctl/token_usage/budget.ex
+++ b/lib/loopctl/token_usage/budget.ex
@@ -81,6 +81,7 @@ defmodule Loopctl.TokenUsage.Budget do
       less_than_or_equal_to: 100
     )
     |> validate_inclusion(:scope_type, @scope_types)
+    |> validate_metadata_size()
     |> foreign_key_constraint(:tenant_id)
     |> unique_constraint([:tenant_id, :scope_type, :scope_id],
       name: :token_budgets_tenant_id_scope_type_scope_id_index,
@@ -114,6 +115,7 @@ defmodule Loopctl.TokenUsage.Budget do
       greater_than_or_equal_to: 1,
       less_than_or_equal_to: 100
     )
+    |> validate_metadata_size()
     |> maybe_reset_dedup_flags()
   end
 
@@ -128,5 +130,15 @@ defmodule Loopctl.TokenUsage.Budget do
     else
       changeset
     end
+  end
+
+  @metadata_max_bytes 65_536
+
+  defp validate_metadata_size(changeset) do
+    validate_change(changeset, :metadata, fn :metadata, value ->
+      if byte_size(Jason.encode!(value)) > @metadata_max_bytes,
+        do: [metadata: "must be smaller than 64KB"],
+        else: []
+    end)
   end
 end

--- a/lib/loopctl/token_usage/cost_anomaly.ex
+++ b/lib/loopctl/token_usage/cost_anomaly.ex
@@ -85,6 +85,7 @@ defmodule Loopctl.TokenUsage.CostAnomaly do
     |> validate_inclusion(:anomaly_type, @anomaly_types)
     |> validate_number(:story_cost_millicents, greater_than_or_equal_to: 0)
     |> validate_number(:reference_avg_millicents, greater_than_or_equal_to: 0)
+    |> validate_metadata_size()
     |> foreign_key_constraint(:tenant_id)
     |> foreign_key_constraint(:story_id)
   end
@@ -95,5 +96,15 @@ defmodule Loopctl.TokenUsage.CostAnomaly do
   @spec resolve_changeset(%__MODULE__{}) :: Ecto.Changeset.t()
   def resolve_changeset(anomaly) do
     change(anomaly, resolved: true)
+  end
+
+  @metadata_max_bytes 65_536
+
+  defp validate_metadata_size(changeset) do
+    validate_change(changeset, :metadata, fn :metadata, value ->
+      if byte_size(Jason.encode!(value)) > @metadata_max_bytes,
+        do: [metadata: "must be smaller than 64KB"],
+        else: []
+    end)
   end
 end

--- a/lib/loopctl/token_usage/default_archival.ex
+++ b/lib/loopctl/token_usage/default_archival.ex
@@ -119,7 +119,7 @@ defmodule Loopctl.TokenUsage.DefaultArchival do
           )
 
         {count, _} =
-          from(r in Report, where: r.id in subquery(subq))
+          from(r in Report, where: r.id in subquery(subq), where: r.tenant_id == ^tenant_id)
           |> Repo.delete_all()
 
         count

--- a/lib/loopctl/token_usage/report.ex
+++ b/lib/loopctl/token_usage/report.ex
@@ -95,6 +95,7 @@ defmodule Loopctl.TokenUsage.Report do
     |> validate_number(:cost_millicents, greater_than_or_equal_to: 0)
     |> validate_inclusion(:phase, @phases)
     |> validate_length(:model_name, min: 1)
+    |> validate_metadata_size()
     |> foreign_key_constraint(:tenant_id)
     |> foreign_key_constraint(:story_id)
     |> foreign_key_constraint(:agent_id)
@@ -125,11 +126,22 @@ defmodule Loopctl.TokenUsage.Report do
     |> validate_required([:input_tokens, :output_tokens, :model_name, :cost_millicents])
     |> validate_inclusion(:phase, @phases)
     |> validate_length(:model_name, min: 1)
+    |> validate_metadata_size()
     |> foreign_key_constraint(:tenant_id)
     |> foreign_key_constraint(:story_id)
     |> foreign_key_constraint(:agent_id)
     |> foreign_key_constraint(:project_id)
     |> foreign_key_constraint(:skill_version_id)
     |> foreign_key_constraint(:corrects_report_id)
+  end
+
+  @metadata_max_bytes 65_536
+
+  defp validate_metadata_size(changeset) do
+    validate_change(changeset, :metadata, fn :metadata, value ->
+      if byte_size(Jason.encode!(value)) > @metadata_max_bytes,
+        do: [metadata: "must be smaller than 64KB"],
+        else: []
+    end)
   end
 end

--- a/lib/loopctl/workers/cost_anomaly_worker.ex
+++ b/lib/loopctl/workers/cost_anomaly_worker.ex
@@ -124,7 +124,9 @@ defmodule Loopctl.Workers.CostAnomalyWorker do
   defp check_and_flag_anomaly(_tenant_id, _story_id, _story_cost, _epic_avg), do: :ok
 
   defp create_anomaly(tenant_id, story_id, anomaly_type, story_cost, epic_avg, factor) do
-    # Check if an unresolved anomaly of this type already exists for this story
+    # Check if an unresolved anomaly of this type already exists for this story.
+    # The unique partial index (cost_anomalies_unresolved_unique) prevents races,
+    # but we still check first so that updates do NOT emit audit/webhook events.
     existing =
       CostAnomaly
       |> where([a], a.tenant_id == ^tenant_id)
@@ -134,7 +136,7 @@ defmodule Loopctl.Workers.CostAnomalyWorker do
       |> AdminRepo.one()
 
     if existing do
-      # Update the existing anomaly with latest figures
+      # Update the existing anomaly with latest figures (no audit/webhook)
       case existing
            |> CostAnomaly.create_changeset(%{
              story_cost_millicents: story_cost,
@@ -162,7 +164,14 @@ defmodule Loopctl.Workers.CostAnomalyWorker do
           deviation_factor: Decimal.round(factor, 2)
         })
 
-      case AdminRepo.insert(changeset) do
+      # Use on_conflict: :nothing to gracefully handle a race with the unique
+      # partial index (cost_anomalies_unresolved_unique) -- ADV-3.
+      case AdminRepo.insert(changeset,
+             on_conflict: :nothing,
+             conflict_target:
+               {:unsafe_fragment,
+                ~s|("tenant_id","story_id","anomaly_type") WHERE resolved = false|}
+           ) do
         {:ok, anomaly} ->
           # Emit change feed + audit log entry for the newly detected anomaly (AC-21.8.3, AC-21.8.5)
           Audit.create_log_entry(tenant_id, %{
@@ -264,7 +273,7 @@ defmodule Loopctl.Workers.CostAnomalyWorker do
         {story.title, nil, nil, story.project_id}
 
       %Story{assigned_agent_id: agent_id} ->
-        agent = AdminRepo.get(Agent, agent_id)
+        agent = AdminRepo.get_by(Agent, id: agent_id, tenant_id: tenant_id)
         agent_name = if agent, do: agent.name, else: nil
         {story.title, agent_id, agent_name, story.project_id}
     end
@@ -277,7 +286,35 @@ defmodule Loopctl.Workers.CostAnomalyWorker do
         {yesterday, yesterday}
 
       {start_str, end_str} when is_binary(start_str) and is_binary(end_str) ->
-        {Date.from_iso8601!(start_str), Date.from_iso8601!(end_str)}
+        yesterday = Date.add(Date.utc_today(), -1)
+
+        start_date =
+          case Date.from_iso8601(start_str) do
+            {:ok, d} ->
+              d
+
+            {:error, _} ->
+              Logger.warning(
+                "CostAnomalyWorker: malformed period_start #{inspect(start_str)}, defaulting to yesterday"
+              )
+
+              yesterday
+          end
+
+        end_date =
+          case Date.from_iso8601(end_str) do
+            {:ok, d} ->
+              d
+
+            {:error, _} ->
+              Logger.warning(
+                "CostAnomalyWorker: malformed period_end #{inspect(end_str)}, defaulting to yesterday"
+              )
+
+              yesterday
+          end
+
+        {start_date, end_date}
 
       other ->
         Logger.warning(

--- a/lib/loopctl/workers/cost_rollup_worker.ex
+++ b/lib/loopctl/workers/cost_rollup_worker.ex
@@ -59,16 +59,15 @@ defmodule Loopctl.Workers.CostRollupWorker do
 
     errors = Enum.filter(results, &match?({:error, _, _}, &1))
 
-    if errors == [] do
-      # Chain the anomaly worker after successful rollup
-      chain_anomaly_worker(period_start, period_end)
-      :ok
-    else
+    if errors != [] do
       Logger.warning("CostRollupWorker: #{length(errors)} tenant(s) failed")
-      # Return :ok so the job is not retried for partial failures.
-      # Individual tenant failures are logged above.
-      :ok
     end
+
+    # Chain the anomaly worker regardless of partial failures so that
+    # successful tenants still get anomaly detection (ADV-11).
+    chain_anomaly_worker(period_start, period_end)
+
+    :ok
   end
 
   @doc false
@@ -122,7 +121,35 @@ defmodule Loopctl.Workers.CostRollupWorker do
         {yesterday, yesterday}
 
       {start_str, end_str} when is_binary(start_str) and is_binary(end_str) ->
-        {Date.from_iso8601!(start_str), Date.from_iso8601!(end_str)}
+        yesterday = Date.add(Date.utc_today(), -1)
+
+        start_date =
+          case Date.from_iso8601(start_str) do
+            {:ok, d} ->
+              d
+
+            {:error, _} ->
+              Logger.warning(
+                "CostRollupWorker: malformed period_start #{inspect(start_str)}, defaulting to yesterday"
+              )
+
+              yesterday
+          end
+
+        end_date =
+          case Date.from_iso8601(end_str) do
+            {:ok, d} ->
+              d
+
+            {:error, _} ->
+              Logger.warning(
+                "CostRollupWorker: malformed period_end #{inspect(end_str)}, defaulting to yesterday"
+              )
+
+              yesterday
+          end
+
+        {start_date, end_date}
 
       other ->
         Logger.warning(

--- a/priv/repo/migrations/20260404025850_add_unique_index_to_cost_anomalies.exs
+++ b/priv/repo/migrations/20260404025850_add_unique_index_to_cost_anomalies.exs
@@ -1,0 +1,13 @@
+defmodule Loopctl.Repo.Migrations.AddUniqueIndexToCostAnomalies do
+  use Ecto.Migration
+
+  def change do
+    create_if_not_exists(
+      index(:cost_anomalies, [:tenant_id, :story_id, :anomaly_type],
+        unique: true,
+        where: "resolved = false",
+        name: :cost_anomalies_unresolved_unique
+      )
+    )
+  end
+end


### PR DESCRIPTION
## Summary

Fixes 10 confirmed adversarial review findings from the Epic 21 enhanced review:

- **ADV-1**: Cross-tenant agent name leakage in anomaly webhook -- scope `AdminRepo.get(Agent)` by `tenant_id`
- **ADV-2**: TOCTOU race in correction totals validation -- move validation inside `Multi.run` for transactional safety
- **ADV-3**: Duplicate anomalies -- add unique partial index `cost_anomalies_unresolved_unique` with `on_conflict: :nothing` race guard
- **ADV-4**: Unbounded `model_mix`, `agent_model_profile`, and comparative queries -- add `LIMIT 1000`
- **ADV-5**: `Date.from_iso8601!` crash on malformed strings -- replace with non-bang variant + warning log + fallback
- **ADV-7**: Budget flag reset failure causes permanent webhook suppression -- move into `Multi.run` for atomic rollback
- **ADV-8**: No size limit on metadata JSONB fields -- add 64KB validation to Report, Budget, and CostAnomaly changesets
- **ADV-9**: Correction error messages disclose exact totals -- strip current/correction values from error strings
- **ADV-11**: Partial rollup failure prevents anomaly detection for ALL tenants -- chain anomaly worker unconditionally
- **ADV-12**: Hard-delete outer query lacks `tenant_id` filter -- add defense-in-depth `WHERE tenant_id` clause

## Test plan

- [x] `mix compile --warnings-as-errors` -- zero warnings
- [x] `mix precommit` -- all quality gates pass (format, credo --strict, dialyzer, 1582 tests 0 failures)
- [x] Migration creates partial unique index on `cost_anomalies` table
- [x] Existing tests for correction 422, anomaly detection, webhook events, change feed all still pass