### PR TITLE
Fix FORCE RLS blocking writes on Epic 21 tables

### DIFF
--- a/lib/loopctl/repo/rls_helpers.ex
+++ b/lib/loopctl/repo/rls_helpers.ex
@@ -44,10 +44,11 @@ defmodule Loopctl.Repo.RlsHelpers do
         "ALTER TABLE #{table_name} DISABLE ROW LEVEL SECURITY"
       )
 
-      Ecto.Migration.execute(
-        "ALTER TABLE #{table_name} FORCE ROW LEVEL SECURITY",
-        "SELECT 1"
-      )
+      # NOTE: We intentionally do NOT use FORCE ROW LEVEL SECURITY.
+      # In production, the DB role (schema_admin) is the table owner
+      # without BYPASSRLS. ENABLE alone enforces RLS for non-owner roles,
+      # while allowing the owner to write. FORCE would block the owner too.
+      # Older tables also omit FORCE, so this keeps the pattern consistent.
 
       Ecto.Migration.execute(
         """

--- a/priv/repo/migrations/20260404043500_remove_force_rls_from_epic21_tables.exs
+++ b/priv/repo/migrations/20260404043500_remove_force_rls_from_epic21_tables.exs
@@ -1,0 +1,17 @@
+defmodule Loopctl.Repo.Migrations.RemoveForceRlsFromEpic21Tables do
+  use Ecto.Migration
+
+  @epic21_tables ~w(token_usage_reports token_budgets cost_summaries cost_anomalies)
+
+  def up do
+    for table <- @epic21_tables do
+      execute("ALTER TABLE #{table} NO FORCE ROW LEVEL SECURITY")
+    end
+  end
+
+  def down do
+    for table <- @epic21_tables do
+      execute("ALTER TABLE #{table} FORCE ROW LEVEL SECURITY")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Production DB role `schema_admin` is the table owner without `BYPASSRLS`
- Old tables use `ENABLE ROW LEVEL SECURITY` only — the owner bypasses RLS automatically
- Epic 21's `enable_rls` macro added `FORCE ROW LEVEL SECURITY` which blocks **even the table owner**
- This caused 500 errors on all write operations to the 4 Epic 21 tables

**Fix:**
- Migration removes `FORCE` from `token_usage_reports`, `token_budgets`, `cost_summaries`, `cost_anomalies`
- Updated `enable_rls` macro to not use `FORCE`, matching the pattern of all existing tables

## Test plan

- [x] 1582 tests pass
- [x] `mix precommit` clean
- [ ] After deploy, verify `POST /token-usage` and `POST /token-budgets` return 2xx

🤖 Generated with [Claude Code](https://claude.com/claude-code)