### PR TITLE
Lower create/update project role to orchestrator

### DIFF
--- a/lib/loopctl_web/controllers/project_controller.ex
+++ b/lib/loopctl_web/controllers/project_controller.ex
@@ -2,10 +2,10 @@ defmodule LoopctlWeb.ProjectController do
   @moduledoc """
   Controller for project CRUD operations and progress summary.
 
-  - `POST /api/v1/projects` -- user role, creates a project
+  - `POST /api/v1/projects` -- orchestrator+, creates a project
   - `GET /api/v1/projects` -- agent+, lists projects with pagination
   - `GET /api/v1/projects/:id` -- agent+, project detail
-  - `PATCH /api/v1/projects/:id` -- user role, updates a project
+  - `PATCH /api/v1/projects/:id` -- orchestrator+, updates a project
   - `DELETE /api/v1/projects/:id` -- user role, archives a project
   - `GET /api/v1/projects/:id/progress` -- agent+, progress summary
   """
@@ -19,7 +19,8 @@ defmodule LoopctlWeb.ProjectController do
 
   action_fallback LoopctlWeb.FallbackController
 
-  plug LoopctlWeb.Plugs.RequireRole, [role: :user] when action in [:create, :update, :delete]
+  plug LoopctlWeb.Plugs.RequireRole, [role: :orchestrator] when action in [:create, :update]
+  plug LoopctlWeb.Plugs.RequireRole, [role: :user] when action in [:delete]
   plug LoopctlWeb.Plugs.RequireRole, [role: :agent] when action in [:index, :show, :progress]
 
   tags(["Projects"])


### PR DESCRIPTION
## Summary

`POST /api/v1/projects` and `PATCH /api/v1/projects/:id` required `role: :user` (level 3), but the MCP server sends the ORCH_KEY (orchestrator, level 2). Orchestrators need to create/update projects as part of their workflow.

- Create/update: lowered to `orchestrator`
- Delete: remains `user` (destructive operation)

Fixes the 403 agents were hitting when using `mcp__loopctl__create_project`.

## Test plan

- [x] 30 project controller tests pass
- [x] `mix compile --warnings-as-errors` clean

Related: #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)