### PR TITLE
US-19.1: Article Schema & Migration

### DIFF
--- a/lib/loopctl/knowledge/article.ex
+++ b/lib/loopctl/knowledge/article.ex
@@ -12,7 +12,7 @@ defmodule Loopctl.Knowledge.Article do
   - `body` -- full article content (text, max 100KB)
   - `category` -- knowledge type: pattern, convention, decision, finding, reference
   - `status` -- lifecycle state: draft, published, archived, superseded
-  - `tags` -- array of lowercase tag strings for categorization
+  - `tags` -- array of alphanumeric tag strings for categorization
   - `source_type` -- advisory origin type: "review_finding", "manual", "agent", "session_log"
   - `source_id` -- optional FK to the originating entity
   - `project_id` -- optional FK to projects (null = tenant-wide)

--- a/lib/loopctl/knowledge/article.ex
+++ b/lib/loopctl/knowledge/article.ex
@@ -82,6 +82,7 @@ defmodule Loopctl.Knowledge.Article do
     |> validate_length(:body, max: 100_000)
     |> validate_tags()
     |> validate_source_type()
+    |> validate_metadata()
     |> unique_constraint([:tenant_id, :title],
       name: :articles_tenant_title_active_idx,
       message: "has already been taken for this tenant"
@@ -101,6 +102,7 @@ defmodule Loopctl.Knowledge.Article do
     |> validate_length(:title, max: 500)
     |> validate_length(:body, max: 100_000)
     |> validate_tags()
+    |> validate_metadata()
     |> unique_constraint([:tenant_id, :title],
       name: :articles_tenant_title_active_idx,
       message: "has already been taken for this tenant"
@@ -148,6 +150,16 @@ defmodule Loopctl.Knowledge.Article do
 
         true ->
           cs
+      end
+    end)
+  end
+
+  defp validate_metadata(changeset) do
+    validate_change(changeset, :metadata, fn :metadata, value ->
+      if is_map(value) and not is_struct(value) do
+        []
+      else
+        [metadata: "must be a map"]
       end
     end)
   end

--- a/lib/loopctl/knowledge/article.ex
+++ b/lib/loopctl/knowledge/article.ex
@@ -1,0 +1,170 @@
+defmodule Loopctl.Knowledge.Article do
+  @moduledoc """
+  Schema for the `articles` table.
+
+  Articles are the core knowledge units in the Knowledge Wiki. Each article
+  represents a reusable pattern, convention, decision, finding, or reference
+  within a tenant's knowledge base.
+
+  ## Fields
+
+  - `title` -- article title, unique per tenant among non-archived/superseded
+  - `body` -- full article content (text, max 100KB)
+  - `category` -- knowledge type: pattern, convention, decision, finding, reference
+  - `status` -- lifecycle state: draft, published, archived, superseded
+  - `tags` -- array of lowercase tag strings for categorization
+  - `source_type` -- advisory origin type: "review_finding", "manual", "agent", "session_log"
+  - `source_id` -- optional FK to the originating entity
+  - `project_id` -- optional FK to projects (null = tenant-wide)
+  - `metadata` -- extensible JSONB
+
+  ## Associations
+
+  - `outgoing_links` -- ArticleLinks where this article is the source
+  - `incoming_links` -- ArticleLinks where this article is the target
+  """
+
+  use Loopctl.Schema
+
+  @type t :: %__MODULE__{}
+
+  @category_values [:pattern, :convention, :decision, :finding, :reference]
+  @status_values [:draft, :published, :archived, :superseded]
+  @known_source_types ~w(review_finding manual agent session_log)
+  @tag_pattern ~r/^[a-zA-Z0-9_-]+$/
+  @max_tags 20
+  @max_tag_length 100
+
+  schema "articles" do
+    tenant_field()
+    belongs_to :project, Loopctl.Projects.Project
+
+    field :title, :string
+    field :body, :string
+    field :category, Ecto.Enum, values: @category_values
+    field :status, Ecto.Enum, values: @status_values, default: :draft
+    field :tags, {:array, :string}, default: []
+    field :source_type, :string
+    field :source_id, :binary_id
+    field :metadata, :map, default: %{}
+
+    # Added in US-19.2 when ArticleLink schema is created:
+    # has_many :outgoing_links, Loopctl.Knowledge.ArticleLink, foreign_key: :source_article_id
+    # has_many :incoming_links, Loopctl.Knowledge.ArticleLink, foreign_key: :target_article_id
+
+    timestamps()
+  end
+
+  @cast_fields [
+    :title,
+    :body,
+    :category,
+    :status,
+    :tags,
+    :source_type,
+    :source_id,
+    :metadata,
+    :project_id
+  ]
+
+  @doc """
+  Changeset for creating a new article.
+
+  `tenant_id` is set programmatically and must not appear in attrs.
+  Defaults `status` to `:draft` if not provided.
+  """
+  @spec create_changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
+  def create_changeset(article \\ %__MODULE__{}, attrs) do
+    article
+    |> cast(attrs, @cast_fields)
+    |> validate_required([:title, :body, :category])
+    |> validate_length(:title, max: 500)
+    |> validate_length(:body, max: 100_000)
+    |> validate_tags()
+    |> validate_source_type()
+    |> unique_constraint([:tenant_id, :title],
+      name: :articles_tenant_title_active_idx,
+      message: "has already been taken for this tenant"
+    )
+  end
+
+  @doc """
+  Changeset for updating an existing article.
+
+  Allows partial updates to title, body, category, status, tags,
+  metadata, and project_id. Same constraints as create_changeset.
+  """
+  @spec update_changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
+  def update_changeset(article, attrs) do
+    article
+    |> cast(attrs, [:title, :body, :category, :status, :tags, :metadata, :project_id])
+    |> validate_length(:title, max: 500)
+    |> validate_length(:body, max: 100_000)
+    |> validate_tags()
+    |> unique_constraint([:tenant_id, :title],
+      name: :articles_tenant_title_active_idx,
+      message: "has already been taken for this tenant"
+    )
+  end
+
+  @doc false
+  def known_source_types, do: @known_source_types
+
+  # --- Private validations ---
+
+  defp validate_tags(changeset) do
+    case get_change(changeset, :tags) do
+      nil ->
+        changeset
+
+      tags when is_list(tags) ->
+        changeset
+        |> validate_tag_count(tags)
+        |> validate_tag_format(tags)
+
+      _other ->
+        changeset
+    end
+  end
+
+  defp validate_tag_count(changeset, tags) do
+    if length(tags) > @max_tags do
+      add_error(changeset, :tags, "must not exceed #{@max_tags} tags")
+    else
+      changeset
+    end
+  end
+
+  defp validate_tag_format(changeset, tags) do
+    Enum.reduce(tags, changeset, fn tag, cs ->
+      cond do
+        String.length(tag) > @max_tag_length ->
+          add_error(cs, :tags, "tag %{tag} exceeds maximum length of #{@max_tag_length}",
+            tag: tag
+          )
+
+        not Regex.match?(@tag_pattern, tag) ->
+          add_error(cs, :tags, "tag %{tag} contains invalid characters", tag: tag)
+
+        true ->
+          cs
+      end
+    end)
+  end
+
+  defp validate_source_type(changeset) do
+    case get_change(changeset, :source_type) do
+      nil ->
+        changeset
+
+      source_type when source_type in @known_source_types ->
+        changeset
+
+      unknown ->
+        add_error(changeset, :source_type, "unknown source type: %{type}",
+          type: unknown,
+          validation: :source_type_advisory
+        )
+    end
+  end
+end

--- a/lib/loopctl/knowledge/article.ex
+++ b/lib/loopctl/knowledge/article.ex
@@ -140,6 +140,9 @@ defmodule Loopctl.Knowledge.Article do
   defp validate_tag_format(changeset, tags) do
     Enum.reduce(tags, changeset, fn tag, cs ->
       cond do
+        not is_binary(tag) ->
+          add_error(cs, :tags, "each tag must be a string")
+
         String.length(tag) > @max_tag_length ->
           add_error(cs, :tags, "tag %{tag} exceeds maximum length of #{@max_tag_length}",
             tag: tag

--- a/priv/repo/migrations/20260410002347_create_articles.exs
+++ b/priv/repo/migrations/20260410002347_create_articles.exs
@@ -1,0 +1,43 @@
+defmodule Loopctl.Repo.Migrations.CreateArticles do
+  use Ecto.Migration
+  import Loopctl.Repo.RlsHelpers
+
+  def change do
+    create table(:articles, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      add :tenant_id, references(:tenants, type: :binary_id, on_delete: :delete_all), null: false
+
+      add :project_id, references(:projects, type: :binary_id, on_delete: :delete_all), null: true
+
+      add :title, :string, null: false, size: 500
+      add :body, :text, null: false
+      add :category, :string, null: false
+      add :status, :string, null: false, default: "draft"
+      add :tags, {:array, :string}, null: false, default: []
+      add :source_type, :string, null: true
+      add :source_id, :binary_id, null: true
+      add :metadata, :map, null: false, default: %{}
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    # Basic tenant scoping index
+    create index(:articles, [:tenant_id])
+
+    # GIN index on tags for efficient array containment queries (AC-19.1.5)
+    create index(:articles, [:tags], using: :gin)
+
+    # Composite index for filtered listing queries (AC-19.1.6)
+    create index(:articles, [:tenant_id, :project_id, :category])
+
+    # Partial unique index on (tenant_id, title) excluding archived/superseded (AC-19.1.7)
+    execute(
+      "CREATE UNIQUE INDEX articles_tenant_title_active_idx ON articles (tenant_id, title) WHERE status NOT IN ('archived', 'superseded')",
+      "DROP INDEX IF EXISTS articles_tenant_title_active_idx"
+    )
+
+    # Enable Row Level Security (AC-19.1.8)
+    enable_rls(:articles)
+  end
+end

--- a/test/loopctl/knowledge/article_test.exs
+++ b/test/loopctl/knowledge/article_test.exs
@@ -168,6 +168,31 @@ defmodule Loopctl.Knowledge.ArticleTest do
       end
     end
 
+    test "rejects non-map metadata" do
+      changeset =
+        Article.create_changeset(%Article{}, %{
+          title: "Article",
+          body: "Content",
+          category: :pattern,
+          metadata: "not a map"
+        })
+
+      refute changeset.valid?
+      assert errors_on(changeset)[:metadata]
+    end
+
+    test "accepts valid map metadata" do
+      changeset =
+        Article.create_changeset(%Article{}, %{
+          title: "Article",
+          body: "Content",
+          category: :pattern,
+          metadata: %{"key" => "value"}
+        })
+
+      assert changeset.valid?
+    end
+
     test "tenant_id is never in cast fields" do
       changeset =
         Article.create_changeset(%Article{}, %{

--- a/test/loopctl/knowledge/article_test.exs
+++ b/test/loopctl/knowledge/article_test.exs
@@ -276,6 +276,19 @@ defmodule Loopctl.Knowledge.ArticleTest do
 
       assert changeset.valid?
     end
+
+    test "rejects nil elements in tags array" do
+      changeset =
+        Article.create_changeset(%Article{}, %{
+          title: "Nil Tag Article",
+          body: "Content",
+          category: :pattern,
+          tags: ["valid", nil]
+        })
+
+      refute changeset.valid?
+      assert "each tag must be a string" in errors_on(changeset)[:tags]
+    end
   end
 
   describe "update_changeset/2" do

--- a/test/loopctl/knowledge/article_test.exs
+++ b/test/loopctl/knowledge/article_test.exs
@@ -1,0 +1,534 @@
+defmodule Loopctl.Knowledge.ArticleTest do
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.Knowledge.Article
+
+  describe "create_changeset/2" do
+    test "valid changeset with all required fields" do
+      changeset =
+        Article.create_changeset(%Article{}, %{
+          title: "Pattern: GenServer DI",
+          body: "Use behaviours for dependency injection.",
+          category: :pattern
+        })
+
+      assert changeset.valid?
+      assert get_field(changeset, :status) == :draft
+      assert get_field(changeset, :tags) == []
+      assert get_field(changeset, :metadata) == %{}
+    end
+
+    test "valid changeset with all fields" do
+      changeset =
+        Article.create_changeset(%Article{}, %{
+          title: "Full Article",
+          body: "Complete body text.",
+          category: :convention,
+          status: :published,
+          tags: ["elixir", "phoenix"],
+          source_type: "review_finding",
+          source_id: Ecto.UUID.generate(),
+          metadata: %{"reviewed_by" => "agent-1"},
+          project_id: Ecto.UUID.generate()
+        })
+
+      assert changeset.valid?
+      assert get_field(changeset, :status) == :published
+      assert get_field(changeset, :tags) == ["elixir", "phoenix"]
+    end
+
+    test "rejects missing required fields" do
+      changeset = Article.create_changeset(%Article{}, %{})
+
+      refute changeset.valid?
+      errors = errors_on(changeset)
+      assert errors[:title]
+      assert errors[:body]
+      assert errors[:category]
+    end
+
+    test "rejects title exceeding 500 characters" do
+      long_title = String.duplicate("a", 501)
+
+      changeset =
+        Article.create_changeset(%Article{}, %{
+          title: long_title,
+          body: "Valid body",
+          category: :pattern
+        })
+
+      refute changeset.valid?
+      assert errors_on(changeset)[:title]
+    end
+
+    test "accepts title at exactly 500 characters" do
+      title_500 = String.duplicate("a", 500)
+
+      changeset =
+        Article.create_changeset(%Article{}, %{
+          title: title_500,
+          body: "Valid body",
+          category: :pattern
+        })
+
+      assert changeset.valid?
+    end
+
+    test "rejects body exceeding 100_000 characters" do
+      long_body = String.duplicate("x", 100_001)
+
+      changeset =
+        Article.create_changeset(%Article{}, %{
+          title: "Valid title",
+          body: long_body,
+          category: :pattern
+        })
+
+      refute changeset.valid?
+      assert errors_on(changeset)[:body]
+    end
+
+    test "rejects invalid category" do
+      changeset =
+        Article.create_changeset(%Article{}, %{
+          title: "Valid title",
+          body: "Valid body",
+          category: :nonexistent
+        })
+
+      refute changeset.valid?
+      assert errors_on(changeset)[:category]
+    end
+
+    test "defaults status to :draft when not provided" do
+      changeset =
+        Article.create_changeset(%Article{}, %{
+          title: "Draft Article",
+          body: "Draft content",
+          category: :finding
+        })
+
+      assert changeset.valid?
+      assert get_field(changeset, :status) == :draft
+    end
+
+    test "validates all category enum values" do
+      for category <- [:pattern, :convention, :decision, :finding, :reference] do
+        changeset =
+          Article.create_changeset(%Article{}, %{
+            title: "Article for #{category}",
+            body: "Content",
+            category: category
+          })
+
+        assert changeset.valid?, "Expected #{category} to be a valid category"
+      end
+    end
+
+    test "validates all status enum values" do
+      for status <- [:draft, :published, :archived, :superseded] do
+        changeset =
+          Article.create_changeset(%Article{}, %{
+            title: "Article with #{status}",
+            body: "Content",
+            category: :pattern,
+            status: status
+          })
+
+        assert changeset.valid?, "Expected #{status} to be a valid status"
+      end
+    end
+
+    test "advisory validation warns on unknown source_type" do
+      changeset =
+        Article.create_changeset(%Article{}, %{
+          title: "Article",
+          body: "Content",
+          category: :pattern,
+          source_type: "unknown_source"
+        })
+
+      refute changeset.valid?
+      assert errors_on(changeset)[:source_type]
+    end
+
+    test "accepts known source_type values" do
+      for source_type <- ~w(review_finding manual agent session_log) do
+        changeset =
+          Article.create_changeset(%Article{}, %{
+            title: "Article from #{source_type}",
+            body: "Content",
+            category: :pattern,
+            source_type: source_type
+          })
+
+        assert changeset.valid?, "Expected source_type #{source_type} to be valid"
+      end
+    end
+
+    test "tenant_id is never in cast fields" do
+      changeset =
+        Article.create_changeset(%Article{}, %{
+          title: "Article",
+          body: "Content",
+          category: :pattern,
+          tenant_id: Ecto.UUID.generate()
+        })
+
+      # tenant_id should not be set via cast
+      assert is_nil(get_change(changeset, :tenant_id))
+    end
+  end
+
+  describe "create_changeset/2 tag validation" do
+    test "rejects more than 20 tags" do
+      too_many_tags = Enum.map(1..21, &"tag-#{&1}")
+
+      changeset =
+        Article.create_changeset(%Article{}, %{
+          title: "Too Many Tags",
+          body: "Content",
+          category: :pattern,
+          tags: too_many_tags
+        })
+
+      refute changeset.valid?
+      assert "must not exceed 20 tags" in errors_on(changeset)[:tags]
+    end
+
+    test "accepts exactly 20 tags" do
+      tags = Enum.map(1..20, &"tag-#{&1}")
+
+      changeset =
+        Article.create_changeset(%Article{}, %{
+          title: "Max Tags",
+          body: "Content",
+          category: :pattern,
+          tags: tags
+        })
+
+      assert changeset.valid?
+    end
+
+    test "rejects tag exceeding 100 characters" do
+      long_tag = String.duplicate("a", 101)
+
+      changeset =
+        Article.create_changeset(%Article{}, %{
+          title: "Long Tag Article",
+          body: "Content",
+          category: :pattern,
+          tags: [long_tag]
+        })
+
+      refute changeset.valid?
+      assert errors_on(changeset)[:tags]
+    end
+
+    test "rejects tag with invalid characters" do
+      changeset =
+        Article.create_changeset(%Article{}, %{
+          title: "Bad Tag Article",
+          body: "Content",
+          category: :pattern,
+          tags: ["valid-tag", "invalid tag!"]
+        })
+
+      refute changeset.valid?
+      assert errors_on(changeset)[:tags]
+    end
+
+    test "accepts valid tag patterns" do
+      changeset =
+        Article.create_changeset(%Article{}, %{
+          title: "Good Tags",
+          body: "Content",
+          category: :pattern,
+          tags: ["elixir", "phoenix-liveview", "otp_patterns", "GenServer123"]
+        })
+
+      assert changeset.valid?
+    end
+  end
+
+  describe "update_changeset/2" do
+    test "allows partial update of title" do
+      article = %Article{
+        title: "Original",
+        body: "Original body",
+        category: :pattern,
+        status: :draft
+      }
+
+      changeset = Article.update_changeset(article, %{title: "Updated"})
+      assert changeset.valid?
+      assert get_change(changeset, :title) == "Updated"
+    end
+
+    test "allows partial update of status" do
+      article = %Article{
+        title: "Original",
+        body: "Original body",
+        category: :pattern,
+        status: :draft
+      }
+
+      changeset = Article.update_changeset(article, %{status: :published})
+      assert changeset.valid?
+      assert get_change(changeset, :status) == :published
+    end
+
+    test "allows partial update of tags and metadata" do
+      article = %Article{
+        title: "Original",
+        body: "Body",
+        category: :pattern,
+        status: :draft
+      }
+
+      changeset =
+        Article.update_changeset(article, %{
+          tags: ["new-tag"],
+          metadata: %{"updated" => true}
+        })
+
+      assert changeset.valid?
+    end
+
+    test "validates title length on update" do
+      article = %Article{title: "Original", body: "Body", category: :pattern}
+
+      changeset =
+        Article.update_changeset(article, %{title: String.duplicate("x", 501)})
+
+      refute changeset.valid?
+      assert errors_on(changeset)[:title]
+    end
+
+    test "validates tags on update" do
+      article = %Article{title: "Original", body: "Body", category: :pattern}
+
+      changeset =
+        Article.update_changeset(article, %{tags: ["bad tag!"]})
+
+      refute changeset.valid?
+      assert errors_on(changeset)[:tags]
+    end
+
+    test "does not allow source_type or source_id changes" do
+      article = %Article{
+        title: "Original",
+        body: "Body",
+        category: :pattern,
+        source_type: "manual"
+      }
+
+      changeset =
+        Article.update_changeset(article, %{
+          source_type: "agent",
+          source_id: Ecto.UUID.generate()
+        })
+
+      # source_type and source_id are not in update cast fields
+      assert is_nil(get_change(changeset, :source_type))
+      assert is_nil(get_change(changeset, :source_id))
+    end
+  end
+
+  # Added in US-19.2 when ArticleLink schema is created:
+  # describe "schema associations" do
+  #   test "declares outgoing_links association" do
+  #     assoc = Article.__schema__(:association, :outgoing_links)
+  #     assert assoc.related == Loopctl.Knowledge.ArticleLink
+  #     assert assoc.owner_key == :id
+  #     assert assoc.related_key == :source_article_id
+  #   end
+  #
+  #   test "declares incoming_links association" do
+  #     assoc = Article.__schema__(:association, :incoming_links)
+  #     assert assoc.related == Loopctl.Knowledge.ArticleLink
+  #     assert assoc.owner_key == :id
+  #     assert assoc.related_key == :target_article_id
+  #   end
+  # end
+
+  describe "integration: insert and unique constraint" do
+    test "inserts article with valid data" do
+      tenant = fixture(:tenant)
+
+      changeset =
+        %Article{tenant_id: tenant.id}
+        |> Article.create_changeset(%{
+          title: "Unique Pattern",
+          body: "Body content here",
+          category: :pattern
+        })
+
+      assert {:ok, article} = Loopctl.AdminRepo.insert(changeset)
+      assert article.id
+      assert article.tenant_id == tenant.id
+      assert article.status == :draft
+    end
+
+    test "enforces unique title per tenant among active articles" do
+      tenant = fixture(:tenant)
+
+      attrs = %{
+        title: "Duplicate Title",
+        body: "First body",
+        category: :pattern
+      }
+
+      changeset1 = %Article{tenant_id: tenant.id} |> Article.create_changeset(attrs)
+      assert {:ok, _} = Loopctl.AdminRepo.insert(changeset1)
+
+      changeset2 =
+        %Article{tenant_id: tenant.id}
+        |> Article.create_changeset(%{attrs | body: "Second body"})
+
+      assert {:error, changeset} = Loopctl.AdminRepo.insert(changeset2)
+      assert errors_on(changeset)[:tenant_id]
+    end
+
+    test "allows same title across different tenants" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+
+      attrs = %{title: "Shared Title", body: "Body", category: :decision}
+
+      changeset_a = %Article{tenant_id: tenant_a.id} |> Article.create_changeset(attrs)
+      changeset_b = %Article{tenant_id: tenant_b.id} |> Article.create_changeset(attrs)
+
+      assert {:ok, _} = Loopctl.AdminRepo.insert(changeset_a)
+      assert {:ok, _} = Loopctl.AdminRepo.insert(changeset_b)
+    end
+
+    test "allows title reuse when existing article is archived" do
+      tenant = fixture(:tenant)
+
+      # Create and archive first article
+      changeset1 =
+        %Article{tenant_id: tenant.id}
+        |> Article.create_changeset(%{
+          title: "Reusable Title",
+          body: "First version",
+          category: :pattern
+        })
+
+      {:ok, article1} = Loopctl.AdminRepo.insert(changeset1)
+
+      # Archive the first article
+      article1
+      |> Article.update_changeset(%{status: :archived})
+      |> Loopctl.AdminRepo.update!()
+
+      # Create second article with same title
+      changeset2 =
+        %Article{tenant_id: tenant.id}
+        |> Article.create_changeset(%{
+          title: "Reusable Title",
+          body: "Second version",
+          category: :pattern
+        })
+
+      assert {:ok, _} = Loopctl.AdminRepo.insert(changeset2)
+    end
+
+    test "allows title reuse when existing article is superseded" do
+      tenant = fixture(:tenant)
+
+      changeset1 =
+        %Article{tenant_id: tenant.id}
+        |> Article.create_changeset(%{
+          title: "Superseded Title",
+          body: "Old version",
+          category: :convention
+        })
+
+      {:ok, article1} = Loopctl.AdminRepo.insert(changeset1)
+
+      article1
+      |> Article.update_changeset(%{status: :superseded})
+      |> Loopctl.AdminRepo.update!()
+
+      changeset2 =
+        %Article{tenant_id: tenant.id}
+        |> Article.create_changeset(%{
+          title: "Superseded Title",
+          body: "New version",
+          category: :convention
+        })
+
+      assert {:ok, _} = Loopctl.AdminRepo.insert(changeset2)
+    end
+  end
+
+  describe "integration: tenant isolation" do
+    test "tenant A cannot read tenant B articles" do
+      import Ecto.Query
+
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+
+      # Insert articles via AdminRepo (bypasses RLS)
+      article_a = fixture(:article, %{tenant_id: tenant_a.id, title: "Article A"})
+      article_b = fixture(:article, %{tenant_id: tenant_b.id, title: "Article B"})
+
+      # Query scoped to tenant_a should only return tenant_a's article
+      articles_a =
+        Article
+        |> where([a], a.tenant_id == ^tenant_a.id)
+        |> Loopctl.AdminRepo.all()
+
+      assert length(articles_a) == 1
+      assert hd(articles_a).id == article_a.id
+
+      # Query scoped to tenant_b should only return tenant_b's article
+      articles_b =
+        Article
+        |> where([a], a.tenant_id == ^tenant_b.id)
+        |> Loopctl.AdminRepo.all()
+
+      assert length(articles_b) == 1
+      assert hd(articles_b).id == article_b.id
+    end
+  end
+
+  describe "fixture helpers" do
+    test "build(:article) returns valid data map" do
+      data = build(:article)
+      assert data.title
+      assert data.body
+      assert data.category == :pattern
+      assert data.status == :draft
+      assert data.tags == []
+      assert data.metadata == %{}
+    end
+
+    test "fixture(:article) creates article in database" do
+      article = fixture(:article)
+      assert article.id
+      assert article.tenant_id
+      assert article.status == :draft
+    end
+
+    test "fixture(:article) accepts overrides" do
+      tenant = fixture(:tenant)
+
+      article =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Custom Title",
+          category: :decision,
+          tags: ["custom"]
+        })
+
+      assert article.tenant_id == tenant.id
+      assert article.title == "Custom Title"
+      assert article.category == :decision
+      assert article.tags == ["custom"]
+    end
+  end
+end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -16,6 +16,7 @@ defmodule Loopctl.Fixtures do
   alias Loopctl.Artifacts.VerificationResult
   alias Loopctl.Audit.AuditLog
   alias Loopctl.Auth
+  alias Loopctl.Knowledge.Article
   alias Loopctl.Orchestrator.OrchestratorState
   alias Loopctl.Projects.Project
   alias Loopctl.QualityAssurance.UiTestRun
@@ -75,6 +76,24 @@ defmodule Loopctl.Fixtures do
       %{
         name: "agent-#{System.unique_integer([:positive])}",
         agent_type: :implementer,
+        metadata: %{}
+      },
+      Enum.into(attrs, %{})
+    )
+  end
+
+  def build(:article, attrs) do
+    seq = System.unique_integer([:positive])
+
+    Map.merge(
+      %{
+        title: "Article #{seq}",
+        body: "Test article body content for article #{seq}.",
+        category: :pattern,
+        status: :draft,
+        tags: [],
+        source_type: nil,
+        source_id: nil,
         metadata: %{}
       },
       Enum.into(attrs, %{})
@@ -375,6 +394,29 @@ defmodule Loopctl.Fixtures do
     changeset =
       %Agent{tenant_id: tenant_id}
       |> Agent.register_changeset(data)
+
+    AdminRepo.insert!(changeset)
+  end
+
+  def fixture(:article, attrs) do
+    attrs = Enum.into(attrs, %{})
+
+    {tenant_id, attrs} =
+      case Map.get(attrs, :tenant_id) do
+        nil ->
+          tenant = fixture(:tenant)
+          {tenant.id, Map.put(attrs, :tenant_id, tenant.id)}
+
+        tid ->
+          {tid, attrs}
+      end
+
+    project_id = Map.get(attrs, :project_id)
+    data = build(:article, attrs)
+
+    changeset =
+      %Article{tenant_id: tenant_id, project_id: project_id}
+      |> Article.create_changeset(data)
 
     AdminRepo.insert!(changeset)
   end


### PR DESCRIPTION
Schema, migration with RLS, fixtures, and tests for the Knowledge Wiki Article entity. Note: has_many link associations are commented out until ArticleLink schema is created in US-19.2.