### PR TITLE
US-22.3: Knowledge Context CRUD

### DIFF
--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -328,6 +328,7 @@ defmodule Loopctl.Knowledge do
       case AdminRepo.transaction(multi) do
         {:ok, %{link: link}} -> {:ok, link}
         {:error, :link, changeset, _} -> {:error, changeset}
+        {:error, :superseded_target, reason, _} -> {:error, reason}
       end
     end
   end
@@ -377,6 +378,8 @@ defmodule Loopctl.Knowledge do
 
         case AdminRepo.transaction(multi) do
           {:ok, %{link: deleted}} -> {:ok, deleted}
+          {:error, :link, changeset, _} -> {:error, changeset}
+          {:error, :audit, changeset, _} -> {:error, changeset}
         end
     end
   end
@@ -480,10 +483,13 @@ defmodule Loopctl.Knowledge do
     end
   end
 
-  defp maybe_supersede_target(multi, _tenant_id, _target_id, rel_type)
+  defp maybe_supersede_target(multi, tenant_id, _target_id, rel_type)
        when rel_type in [:supersedes, "supersedes"] do
     Multi.run(multi, :superseded_target, fn _repo, changes ->
-      case AdminRepo.get(Article, changes.link.target_article_id) do
+      case AdminRepo.get_by(Article,
+             id: changes.link.target_article_id,
+             tenant_id: tenant_id
+           ) do
         nil ->
           {:error, :target_not_found}
 

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -155,8 +155,8 @@ defmodule Loopctl.Knowledge do
           meta: %{total_count: non_neg_integer(), limit: pos_integer(), offset: non_neg_integer()}
         }
   def list_articles(tenant_id, opts \\ []) do
-    limit = min(Keyword.get(opts, :limit, 20), 100)
-    offset = Keyword.get(opts, :offset, 0)
+    limit = opts |> Keyword.get(:limit, 20) |> max(1) |> min(100)
+    offset = opts |> Keyword.get(:offset, 0) |> max(0)
 
     base =
       from(a in Article,

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -1,0 +1,537 @@
+defmodule Loopctl.Knowledge do
+  @moduledoc """
+  Context module for the Knowledge Wiki.
+
+  Provides CRUD operations for articles and article links. Articles
+  are the core knowledge units — reusable patterns, conventions,
+  decisions, findings, and references within a tenant's knowledge base.
+
+  All operations use AdminRepo (BYPASSRLS) with explicit `tenant_id`
+  scoping, following the same pattern as other loopctl contexts.
+
+  ## Usage
+
+  ### Creating an article
+
+      Loopctl.Knowledge.create_article(tenant_id, %{
+        title: "Ecto Multi Pattern",
+        body: "Use Ecto.Multi for atomic operations...",
+        category: :pattern,
+        tags: ["ecto", "transactions"]
+      }, actor_id: api_key.id, actor_label: "user:admin")
+
+  ### Listing articles with filters
+
+      Loopctl.Knowledge.list_articles(tenant_id,
+        project_id: project_id,
+        category: :pattern,
+        tags: ["ecto"],
+        limit: 10,
+        offset: 0
+      )
+  """
+
+  import Ecto.Query
+
+  alias Ecto.Multi
+  alias Loopctl.AdminRepo
+  alias Loopctl.Audit
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.ArticleLink
+
+  # --- Articles ---
+
+  @doc """
+  Creates a new article within a tenant.
+
+  Sets `tenant_id` programmatically and records the `article.created`
+  audit event.
+
+  ## Parameters
+
+  - `tenant_id` -- the tenant UUID
+  - `attrs` -- map with title (required), body (required), category (required),
+    and optional: status, tags, source_type, source_id, metadata, project_id
+  - `opts` -- keyword list with `:actor_id`, `:actor_label`, `:actor_type`
+
+  ## Returns
+
+  - `{:ok, %Article{}}` on success
+  - `{:error, changeset}` on validation failure
+  """
+  @spec create_article(Ecto.UUID.t(), map(), keyword()) ::
+          {:ok, Article.t()} | {:error, Ecto.Changeset.t()}
+  def create_article(tenant_id, attrs, opts \\ []) do
+    actor_id = Keyword.get(opts, :actor_id)
+    actor_label = Keyword.get(opts, :actor_label)
+    actor_type = Keyword.get(opts, :actor_type, "api_key")
+
+    changeset =
+      %Article{tenant_id: tenant_id}
+      |> Article.create_changeset(attrs)
+
+    multi =
+      Multi.new()
+      |> Multi.insert(:article, changeset)
+      |> Audit.log_in_multi(:audit, fn %{article: article} ->
+        %{
+          tenant_id: tenant_id,
+          entity_type: "article",
+          entity_id: article.id,
+          action: "article.created",
+          actor_type: actor_type,
+          actor_id: actor_id,
+          actor_label: actor_label,
+          new_state: %{
+            "title" => article.title,
+            "category" => to_string(article.category),
+            "status" => to_string(article.status),
+            "tags" => article.tags,
+            "project_id" => article.project_id
+          }
+        }
+      end)
+
+    case AdminRepo.transaction(multi) do
+      {:ok, %{article: article}} -> {:ok, article}
+      {:error, :article, changeset, _} -> {:error, changeset}
+    end
+  end
+
+  @doc """
+  Retrieves a single article by ID, scoped to the tenant.
+
+  Preloads outgoing links (with target articles) and incoming links
+  (with source articles).
+
+  ## Parameters
+
+  - `tenant_id` -- the tenant UUID
+  - `article_id` -- the article UUID
+
+  ## Returns
+
+  - `{:ok, %Article{}}` with preloaded links
+  - `{:error, :not_found}` if not found or belongs to another tenant
+  """
+  @spec get_article(Ecto.UUID.t(), Ecto.UUID.t()) ::
+          {:ok, Article.t()} | {:error, :not_found}
+  def get_article(tenant_id, article_id) do
+    case AdminRepo.get_by(Article, id: article_id, tenant_id: tenant_id) do
+      nil ->
+        {:error, :not_found}
+
+      article ->
+        article =
+          AdminRepo.preload(article,
+            outgoing_links: :target_article,
+            incoming_links: :source_article
+          )
+
+        {:ok, article}
+    end
+  end
+
+  @doc """
+  Lists articles for a tenant with optional filtering and pagination.
+
+  ## Parameters
+
+  - `tenant_id` -- the tenant UUID
+  - `opts` -- keyword list with:
+    - `:project_id` -- filter by project UUID (optional)
+    - `:category` -- filter by category atom (optional)
+    - `:status` -- filter by status atom (optional)
+    - `:tags` -- filter by tag overlap, articles matching ANY tag (optional)
+    - `:limit` -- max records to return (default 20, max 100)
+    - `:offset` -- records to skip for pagination (default 0)
+
+  ## Returns
+
+  - `%{data: [%Article{}], meta: %{total_count: integer, limit: integer, offset: integer}}`
+  """
+  @spec list_articles(Ecto.UUID.t(), keyword()) :: %{
+          data: [Article.t()],
+          meta: %{total_count: non_neg_integer(), limit: pos_integer(), offset: non_neg_integer()}
+        }
+  def list_articles(tenant_id, opts \\ []) do
+    limit = min(Keyword.get(opts, :limit, 20), 100)
+    offset = Keyword.get(opts, :offset, 0)
+
+    base =
+      from(a in Article,
+        where: a.tenant_id == ^tenant_id,
+        order_by: [desc: a.inserted_at]
+      )
+
+    base = apply_article_filters(base, opts)
+
+    total_count = AdminRepo.aggregate(base, :count, :id)
+
+    articles =
+      base
+      |> limit(^limit)
+      |> offset(^offset)
+      |> AdminRepo.all()
+
+    %{
+      data: articles,
+      meta: %{total_count: total_count, limit: limit, offset: offset}
+    }
+  end
+
+  @doc """
+  Updates an existing article.
+
+  Uses `update_changeset` and records the `article.updated` audit event.
+
+  ## Parameters
+
+  - `tenant_id` -- the tenant UUID
+  - `article_id` -- the article UUID
+  - `attrs` -- map of fields to update
+  - `opts` -- keyword list with `:actor_id`, `:actor_label`, `:actor_type`
+
+  ## Returns
+
+  - `{:ok, %Article{}}` on success
+  - `{:error, changeset}` on validation failure
+  - `{:error, :not_found}` if not found or belongs to another tenant
+  """
+  @spec update_article(Ecto.UUID.t(), Ecto.UUID.t(), map(), keyword()) ::
+          {:ok, Article.t()} | {:error, Ecto.Changeset.t() | :not_found}
+  def update_article(tenant_id, article_id, attrs, opts \\ []) do
+    actor_id = Keyword.get(opts, :actor_id)
+    actor_label = Keyword.get(opts, :actor_label)
+    actor_type = Keyword.get(opts, :actor_type, "api_key")
+
+    with {:ok, article} <- fetch_article(tenant_id, article_id) do
+      old_state = article_state_snapshot(article)
+      changeset = Article.update_changeset(article, attrs)
+
+      multi =
+        Multi.new()
+        |> Multi.update(:article, changeset)
+        |> Audit.log_in_multi(:audit, fn %{article: updated} ->
+          %{
+            tenant_id: tenant_id,
+            entity_type: "article",
+            entity_id: updated.id,
+            action: "article.updated",
+            actor_type: actor_type,
+            actor_id: actor_id,
+            actor_label: actor_label,
+            old_state: old_state,
+            new_state: article_state_snapshot(updated)
+          }
+        end)
+
+      case AdminRepo.transaction(multi) do
+        {:ok, %{article: updated}} -> {:ok, updated}
+        {:error, :article, changeset, _} -> {:error, changeset}
+      end
+    end
+  end
+
+  @doc """
+  Archives an article by setting its status to `:archived`.
+
+  Records the `article.archived` audit event.
+
+  ## Parameters
+
+  - `tenant_id` -- the tenant UUID
+  - `article_id` -- the article UUID
+  - `opts` -- keyword list with `:actor_id`, `:actor_label`, `:actor_type`
+
+  ## Returns
+
+  - `{:ok, %Article{}}` on success
+  - `{:error, :not_found}` if not found or belongs to another tenant
+  """
+  @spec archive_article(Ecto.UUID.t(), Ecto.UUID.t(), keyword()) ::
+          {:ok, Article.t()} | {:error, :not_found}
+  def archive_article(tenant_id, article_id, opts \\ []) do
+    actor_id = Keyword.get(opts, :actor_id)
+    actor_label = Keyword.get(opts, :actor_label)
+    actor_type = Keyword.get(opts, :actor_type, "api_key")
+
+    with {:ok, article} <- fetch_article(tenant_id, article_id) do
+      old_status = to_string(article.status)
+      changeset = Article.update_changeset(article, %{status: :archived})
+
+      multi =
+        Multi.new()
+        |> Multi.update(:article, changeset)
+        |> Audit.log_in_multi(:audit, fn %{article: updated} ->
+          %{
+            tenant_id: tenant_id,
+            entity_type: "article",
+            entity_id: updated.id,
+            action: "article.archived",
+            actor_type: actor_type,
+            actor_id: actor_id,
+            actor_label: actor_label,
+            old_state: %{"status" => old_status},
+            new_state: %{"status" => to_string(updated.status)}
+          }
+        end)
+
+      case AdminRepo.transaction(multi) do
+        {:ok, %{article: updated}} -> {:ok, updated}
+        {:error, :article, changeset, _} -> {:error, changeset}
+      end
+    end
+  end
+
+  # --- Article Links ---
+
+  @doc """
+  Creates a new link between two articles.
+
+  Sets `tenant_id` programmatically. Validates that both source and target
+  articles exist within the same tenant. Records the `article_link.created`
+  audit event.
+
+  When the relationship type is `:supersedes`, the target article's status
+  is set to `:superseded` within the same Multi transaction.
+
+  ## Parameters
+
+  - `tenant_id` -- the tenant UUID
+  - `attrs` -- map with source_article_id, target_article_id, relationship_type,
+    and optional metadata
+
+  ## Returns
+
+  - `{:ok, %ArticleLink{}}` on success
+  - `{:error, changeset}` on validation failure
+  """
+  @spec create_link(Ecto.UUID.t(), map()) ::
+          {:ok, ArticleLink.t()} | {:error, Ecto.Changeset.t()}
+  def create_link(tenant_id, attrs) do
+    source_id = attrs[:source_article_id] || attrs["source_article_id"]
+    target_id = attrs[:target_article_id] || attrs["target_article_id"]
+    rel_type = attrs[:relationship_type] || attrs["relationship_type"]
+
+    with :ok <- validate_articles_exist(tenant_id, source_id, target_id) do
+      changeset =
+        %ArticleLink{tenant_id: tenant_id}
+        |> ArticleLink.changeset(attrs)
+
+      multi =
+        Multi.new()
+        |> Multi.insert(:link, changeset)
+        |> maybe_supersede_target(tenant_id, target_id, rel_type)
+        |> Audit.log_in_multi(:audit, &build_link_audit(tenant_id, &1))
+
+      case AdminRepo.transaction(multi) do
+        {:ok, %{link: link}} -> {:ok, link}
+        {:error, :link, changeset, _} -> {:error, changeset}
+      end
+    end
+  end
+
+  @doc """
+  Deletes an article link, scoped by tenant.
+
+  Records the `article_link.deleted` audit event.
+
+  ## Parameters
+
+  - `tenant_id` -- the tenant UUID
+  - `link_id` -- the article link UUID
+
+  ## Returns
+
+  - `{:ok, %ArticleLink{}}` on success
+  - `{:error, :not_found}` if not found or belongs to another tenant
+  """
+  @spec delete_link(Ecto.UUID.t(), Ecto.UUID.t()) ::
+          {:ok, ArticleLink.t()} | {:error, :not_found}
+  def delete_link(tenant_id, link_id) do
+    case AdminRepo.get_by(ArticleLink, id: link_id, tenant_id: tenant_id) do
+      nil ->
+        {:error, :not_found}
+
+      link ->
+        multi =
+          Multi.new()
+          |> Multi.delete(:link, link)
+          |> Audit.log_in_multi(:audit, fn %{link: deleted} ->
+            %{
+              tenant_id: tenant_id,
+              entity_type: "article_link",
+              entity_id: deleted.id,
+              action: "article_link.deleted",
+              actor_type: "api_key",
+              actor_id: nil,
+              actor_label: nil,
+              old_state: %{
+                "source_article_id" => to_string(deleted.source_article_id),
+                "target_article_id" => to_string(deleted.target_article_id),
+                "relationship_type" => to_string(deleted.relationship_type)
+              }
+            }
+          end)
+
+        case AdminRepo.transaction(multi) do
+          {:ok, %{link: deleted}} -> {:ok, deleted}
+        end
+    end
+  end
+
+  @doc """
+  Lists all links for an article (both outgoing and incoming),
+  with linked articles preloaded.
+
+  ## Parameters
+
+  - `tenant_id` -- the tenant UUID
+  - `article_id` -- the article UUID
+
+  ## Returns
+
+  - List of `%ArticleLink{}` structs with linked articles preloaded
+  """
+  @spec list_links_for_article(Ecto.UUID.t(), Ecto.UUID.t()) :: [ArticleLink.t()]
+  def list_links_for_article(tenant_id, article_id) do
+    from(l in ArticleLink,
+      where: l.tenant_id == ^tenant_id,
+      where: l.source_article_id == ^article_id or l.target_article_id == ^article_id,
+      preload: [:source_article, :target_article],
+      order_by: [desc: l.inserted_at]
+    )
+    |> AdminRepo.all()
+  end
+
+  # --- Private helpers ---
+
+  defp fetch_article(tenant_id, article_id) do
+    case AdminRepo.get_by(Article, id: article_id, tenant_id: tenant_id) do
+      nil -> {:error, :not_found}
+      article -> {:ok, article}
+    end
+  end
+
+  defp apply_article_filters(query, opts) do
+    query
+    |> maybe_filter_by_project_id(Keyword.get(opts, :project_id))
+    |> maybe_filter_by_category(Keyword.get(opts, :category))
+    |> maybe_filter_by_status(Keyword.get(opts, :status))
+    |> maybe_filter_by_tags(Keyword.get(opts, :tags))
+  end
+
+  defp maybe_filter_by_project_id(query, nil), do: query
+
+  defp maybe_filter_by_project_id(query, project_id) do
+    where(query, [a], a.project_id == ^project_id)
+  end
+
+  defp maybe_filter_by_category(query, nil), do: query
+
+  defp maybe_filter_by_category(query, category) do
+    where(query, [a], a.category == ^category)
+  end
+
+  defp maybe_filter_by_status(query, nil), do: query
+
+  defp maybe_filter_by_status(query, status) do
+    where(query, [a], a.status == ^status)
+  end
+
+  defp maybe_filter_by_tags(query, nil), do: query
+  defp maybe_filter_by_tags(query, []), do: query
+
+  defp maybe_filter_by_tags(query, tags) when is_list(tags) do
+    where(query, [a], fragment("? && ?", a.tags, ^tags))
+  end
+
+  defp validate_articles_exist(tenant_id, source_id, target_id) do
+    source_exists =
+      from(a in Article,
+        where: a.id == ^source_id and a.tenant_id == ^tenant_id,
+        select: true
+      )
+      |> AdminRepo.one()
+
+    target_exists =
+      from(a in Article,
+        where: a.id == ^target_id and a.tenant_id == ^tenant_id,
+        select: true
+      )
+      |> AdminRepo.one()
+
+    cond do
+      is_nil(source_exists) ->
+        {:error,
+         %Article{}
+         |> Ecto.Changeset.change()
+         |> Ecto.Changeset.add_error(:source_article_id, "does not exist in this tenant")}
+
+      is_nil(target_exists) ->
+        {:error,
+         %Article{}
+         |> Ecto.Changeset.change()
+         |> Ecto.Changeset.add_error(:target_article_id, "does not exist in this tenant")}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp maybe_supersede_target(multi, _tenant_id, _target_id, rel_type)
+       when rel_type in [:supersedes, "supersedes"] do
+    Multi.run(multi, :superseded_target, fn _repo, changes ->
+      case AdminRepo.get(Article, changes.link.target_article_id) do
+        nil ->
+          {:error, :target_not_found}
+
+        target ->
+          target
+          |> Article.update_changeset(%{status: :superseded})
+          |> AdminRepo.update()
+      end
+    end)
+  end
+
+  defp maybe_supersede_target(multi, _tenant_id, _target_id, _rel_type), do: multi
+
+  defp build_link_audit(tenant_id, changes) do
+    new_state = %{
+      "source_article_id" => to_string(changes.link.source_article_id),
+      "target_article_id" => to_string(changes.link.target_article_id),
+      "relationship_type" => to_string(changes.link.relationship_type)
+    }
+
+    new_state =
+      if Map.has_key?(changes, :superseded_target) do
+        Map.put(new_state, "target_superseded", true)
+      else
+        new_state
+      end
+
+    %{
+      tenant_id: tenant_id,
+      entity_type: "article_link",
+      entity_id: changes.link.id,
+      action: "article_link.created",
+      actor_type: "api_key",
+      actor_id: nil,
+      actor_label: nil,
+      new_state: new_state
+    }
+  end
+
+  defp article_state_snapshot(article) do
+    %{
+      "title" => article.title,
+      "body" => article.body,
+      "category" => to_string(article.category),
+      "status" => to_string(article.status),
+      "tags" => article.tags,
+      "project_id" => article.project_id,
+      "metadata" => article.metadata
+    }
+  end
+end

--- a/test/loopctl/knowledge_test.exs
+++ b/test/loopctl/knowledge_test.exs
@@ -1,0 +1,715 @@
+defmodule Loopctl.KnowledgeTest do
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Audit.AuditLog
+  alias Loopctl.Knowledge
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.ArticleLink
+
+  defp setup_tenant do
+    tenant = fixture(:tenant)
+    %{tenant: tenant}
+  end
+
+  defp setup_tenant_with_project do
+    tenant = fixture(:tenant)
+    project = fixture(:project, %{tenant_id: tenant.id})
+    %{tenant: tenant, project: project}
+  end
+
+  # --- TC-19.3.1: Create article, verify audit log entry ---
+
+  describe "create_article/3" do
+    test "creates article with valid attributes and records audit log" do
+      %{tenant: tenant} = setup_tenant()
+
+      attrs = %{
+        title: "Ecto Multi Pattern",
+        body: "Use Ecto.Multi for atomic operations.",
+        category: :pattern,
+        tags: ["ecto", "transactions"]
+      }
+
+      actor_id = Ecto.UUID.generate()
+
+      assert {:ok, %Article{} = article} =
+               Knowledge.create_article(tenant.id, attrs,
+                 actor_id: actor_id,
+                 actor_label: "user:test"
+               )
+
+      assert article.tenant_id == tenant.id
+      assert article.title == "Ecto Multi Pattern"
+      assert article.body == "Use Ecto.Multi for atomic operations."
+      assert article.category == :pattern
+      assert article.status == :draft
+      assert article.tags == ["ecto", "transactions"]
+
+      # Verify audit log entry exists
+      audit =
+        from(a in AuditLog,
+          where: a.entity_type == "article" and a.entity_id == ^article.id,
+          where: a.action == "article.created"
+        )
+        |> AdminRepo.one!()
+
+      assert audit.tenant_id == tenant.id
+      assert audit.actor_id == actor_id
+      assert audit.actor_label == "user:test"
+      assert audit.new_state["title"] == "Ecto Multi Pattern"
+      assert audit.new_state["category"] == "pattern"
+      assert audit.new_state["status"] == "draft"
+    end
+
+    test "returns error changeset for invalid attributes" do
+      %{tenant: tenant} = setup_tenant()
+
+      assert {:error, changeset} = Knowledge.create_article(tenant.id, %{})
+      assert %{title: _, body: _, category: _} = errors_on(changeset)
+    end
+
+    test "sets tenant_id programmatically" do
+      %{tenant: tenant} = setup_tenant()
+
+      attrs = %{
+        title: "Test Article",
+        body: "Body content.",
+        category: :convention
+      }
+
+      assert {:ok, article} = Knowledge.create_article(tenant.id, attrs)
+      assert article.tenant_id == tenant.id
+    end
+
+    test "accepts actor_type option" do
+      %{tenant: tenant} = setup_tenant()
+
+      attrs = %{
+        title: "Test Actor Type",
+        body: "Body content.",
+        category: :decision
+      }
+
+      assert {:ok, article} =
+               Knowledge.create_article(tenant.id, attrs, actor_type: "system")
+
+      audit =
+        from(a in AuditLog,
+          where: a.entity_type == "article" and a.entity_id == ^article.id
+        )
+        |> AdminRepo.one!()
+
+      assert audit.actor_type == "system"
+    end
+  end
+
+  # --- TC-19.3.2: List with tag overlap filtering ---
+
+  describe "list_articles/2 tag filtering" do
+    test "filters articles by tag overlap (ANY match)" do
+      %{tenant: tenant} = setup_tenant()
+
+      {:ok, _a1} =
+        Knowledge.create_article(tenant.id, %{
+          title: "Elixir Patterns",
+          body: "Body",
+          category: :pattern,
+          tags: ["elixir", "otp"]
+        })
+
+      {:ok, _a2} =
+        Knowledge.create_article(tenant.id, %{
+          title: "Phoenix LiveView",
+          body: "Body",
+          category: :pattern,
+          tags: ["phoenix", "liveview"]
+        })
+
+      {:ok, _a3} =
+        Knowledge.create_article(tenant.id, %{
+          title: "Ecto Patterns",
+          body: "Body",
+          category: :pattern,
+          tags: ["elixir", "ecto"]
+        })
+
+      # Filter by "elixir" tag -- should match a1 and a3
+      result = Knowledge.list_articles(tenant.id, tags: ["elixir"])
+      assert length(result.data) == 2
+      titles = Enum.map(result.data, & &1.title)
+      assert "Elixir Patterns" in titles
+      assert "Ecto Patterns" in titles
+    end
+  end
+
+  # --- TC-19.3.3: List filtered by category AND project_id ---
+
+  describe "list_articles/2 combined filters" do
+    test "filters by category and project_id" do
+      %{tenant: tenant, project: project} = setup_tenant_with_project()
+      project2 = fixture(:project, %{tenant_id: tenant.id})
+
+      {:ok, _a1} =
+        Knowledge.create_article(tenant.id, %{
+          title: "Pattern A",
+          body: "Body",
+          category: :pattern,
+          project_id: project.id
+        })
+
+      {:ok, _a2} =
+        Knowledge.create_article(tenant.id, %{
+          title: "Convention A",
+          body: "Body",
+          category: :convention,
+          project_id: project.id
+        })
+
+      {:ok, _a3} =
+        Knowledge.create_article(tenant.id, %{
+          title: "Pattern B",
+          body: "Body",
+          category: :pattern,
+          project_id: project2.id
+        })
+
+      result =
+        Knowledge.list_articles(tenant.id,
+          category: :pattern,
+          project_id: project.id
+        )
+
+      assert length(result.data) == 1
+      assert hd(result.data).title == "Pattern A"
+    end
+
+    test "filters by status" do
+      %{tenant: tenant} = setup_tenant()
+
+      {:ok, _published} =
+        Knowledge.create_article(tenant.id, %{
+          title: "Published Article",
+          body: "Body",
+          category: :pattern,
+          status: :published
+        })
+
+      {:ok, _draft} =
+        Knowledge.create_article(tenant.id, %{
+          title: "Draft Article",
+          body: "Body",
+          category: :pattern
+        })
+
+      result = Knowledge.list_articles(tenant.id, status: :published)
+      assert length(result.data) == 1
+      assert hd(result.data).title == "Published Article"
+    end
+  end
+
+  # --- TC-19.3.4: Get article preloads outgoing and incoming links ---
+
+  describe "get_article/2" do
+    test "preloads outgoing links with target articles and incoming links with source articles" do
+      %{tenant: tenant} = setup_tenant()
+
+      {:ok, source} =
+        Knowledge.create_article(tenant.id, %{
+          title: "Source Article",
+          body: "Body",
+          category: :pattern
+        })
+
+      {:ok, target} =
+        Knowledge.create_article(tenant.id, %{
+          title: "Target Article",
+          body: "Body",
+          category: :convention
+        })
+
+      {:ok, _link} =
+        Knowledge.create_link(tenant.id, %{
+          source_article_id: source.id,
+          target_article_id: target.id,
+          relationship_type: :relates_to
+        })
+
+      # Verify source article has outgoing link with target preloaded
+      {:ok, fetched_source} = Knowledge.get_article(tenant.id, source.id)
+      assert length(fetched_source.outgoing_links) == 1
+      outgoing = hd(fetched_source.outgoing_links)
+      assert outgoing.target_article.id == target.id
+      assert outgoing.target_article.title == "Target Article"
+
+      # Verify target article has incoming link with source preloaded
+      {:ok, fetched_target} = Knowledge.get_article(tenant.id, target.id)
+      assert length(fetched_target.incoming_links) == 1
+      incoming = hd(fetched_target.incoming_links)
+      assert incoming.source_article.id == source.id
+      assert incoming.source_article.title == "Source Article"
+    end
+
+    test "returns {:error, :not_found} for non-existent article" do
+      %{tenant: tenant} = setup_tenant()
+
+      assert {:error, :not_found} =
+               Knowledge.get_article(tenant.id, Ecto.UUID.generate())
+    end
+  end
+
+  # --- TC-19.3.5: Archive article sets status to :archived + audit log ---
+
+  describe "archive_article/3" do
+    test "sets status to :archived and records audit log" do
+      %{tenant: tenant} = setup_tenant()
+      actor_id = Ecto.UUID.generate()
+
+      {:ok, article} =
+        Knowledge.create_article(tenant.id, %{
+          title: "To Archive",
+          body: "Body",
+          category: :pattern,
+          status: :published
+        })
+
+      assert {:ok, archived} =
+               Knowledge.archive_article(tenant.id, article.id,
+                 actor_id: actor_id,
+                 actor_label: "user:admin"
+               )
+
+      assert archived.status == :archived
+
+      audit =
+        from(a in AuditLog,
+          where: a.entity_type == "article" and a.entity_id == ^article.id,
+          where: a.action == "article.archived"
+        )
+        |> AdminRepo.one!()
+
+      assert audit.actor_id == actor_id
+      assert audit.old_state["status"] == "published"
+      assert audit.new_state["status"] == "archived"
+    end
+
+    test "returns {:error, :not_found} for non-existent article" do
+      %{tenant: tenant} = setup_tenant()
+
+      assert {:error, :not_found} =
+               Knowledge.archive_article(tenant.id, Ecto.UUID.generate())
+    end
+  end
+
+  # --- TC-19.3.6: Tenant isolation ---
+
+  describe "tenant isolation" do
+    test "tenant A cannot access tenant B's articles" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+
+      {:ok, article_a} =
+        Knowledge.create_article(tenant_a.id, %{
+          title: "Tenant A Article",
+          body: "Body",
+          category: :pattern
+        })
+
+      {:ok, article_b} =
+        Knowledge.create_article(tenant_b.id, %{
+          title: "Tenant B Article",
+          body: "Body",
+          category: :pattern
+        })
+
+      # Tenant A cannot get tenant B's article
+      assert {:error, :not_found} =
+               Knowledge.get_article(tenant_a.id, article_b.id)
+
+      # Tenant B cannot get tenant A's article
+      assert {:error, :not_found} =
+               Knowledge.get_article(tenant_b.id, article_a.id)
+
+      # list_articles returns only own tenant's articles
+      result_a = Knowledge.list_articles(tenant_a.id)
+      assert length(result_a.data) == 1
+      assert hd(result_a.data).id == article_a.id
+
+      result_b = Knowledge.list_articles(tenant_b.id)
+      assert length(result_b.data) == 1
+      assert hd(result_b.data).id == article_b.id
+    end
+
+    test "tenant A cannot update or archive tenant B's articles" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+
+      {:ok, article_b} =
+        Knowledge.create_article(tenant_b.id, %{
+          title: "Tenant B Article",
+          body: "Body",
+          category: :pattern
+        })
+
+      assert {:error, :not_found} =
+               Knowledge.update_article(tenant_a.id, article_b.id, %{title: "Hacked"})
+
+      assert {:error, :not_found} =
+               Knowledge.archive_article(tenant_a.id, article_b.id)
+    end
+
+    test "tenant A cannot delete tenant B's links" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+
+      link_b = fixture(:article_link, %{tenant_id: tenant_b.id})
+
+      assert {:error, :not_found} =
+               Knowledge.delete_link(tenant_a.id, link_b.id)
+    end
+  end
+
+  # --- TC-19.3.7: Create link validates both articles belong to same tenant ---
+
+  describe "create_link/2" do
+    test "creates link between articles in same tenant" do
+      %{tenant: tenant} = setup_tenant()
+
+      {:ok, source} =
+        Knowledge.create_article(tenant.id, %{
+          title: "Source",
+          body: "Body",
+          category: :pattern
+        })
+
+      {:ok, target} =
+        Knowledge.create_article(tenant.id, %{
+          title: "Target",
+          body: "Body",
+          category: :convention
+        })
+
+      assert {:ok, %ArticleLink{} = link} =
+               Knowledge.create_link(tenant.id, %{
+                 source_article_id: source.id,
+                 target_article_id: target.id,
+                 relationship_type: :relates_to
+               })
+
+      assert link.tenant_id == tenant.id
+      assert link.source_article_id == source.id
+      assert link.target_article_id == target.id
+      assert link.relationship_type == :relates_to
+
+      # Verify audit log
+      audit =
+        from(a in AuditLog,
+          where: a.entity_type == "article_link" and a.entity_id == ^link.id,
+          where: a.action == "article_link.created"
+        )
+        |> AdminRepo.one!()
+
+      assert audit.tenant_id == tenant.id
+    end
+
+    test "rejects link when source article belongs to different tenant" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+
+      {:ok, source_b} =
+        Knowledge.create_article(tenant_b.id, %{
+          title: "Other Tenant Source",
+          body: "Body",
+          category: :pattern
+        })
+
+      {:ok, target_a} =
+        Knowledge.create_article(tenant_a.id, %{
+          title: "Target",
+          body: "Body",
+          category: :pattern
+        })
+
+      assert {:error, changeset} =
+               Knowledge.create_link(tenant_a.id, %{
+                 source_article_id: source_b.id,
+                 target_article_id: target_a.id,
+                 relationship_type: :relates_to
+               })
+
+      assert %{source_article_id: ["does not exist in this tenant"]} =
+               errors_on(changeset)
+    end
+
+    test "rejects link when target article belongs to different tenant" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+
+      {:ok, source_a} =
+        Knowledge.create_article(tenant_a.id, %{
+          title: "Source",
+          body: "Body",
+          category: :pattern
+        })
+
+      {:ok, target_b} =
+        Knowledge.create_article(tenant_b.id, %{
+          title: "Other Tenant Target",
+          body: "Body",
+          category: :pattern
+        })
+
+      assert {:error, changeset} =
+               Knowledge.create_link(tenant_a.id, %{
+                 source_article_id: source_a.id,
+                 target_article_id: target_b.id,
+                 relationship_type: :relates_to
+               })
+
+      assert %{target_article_id: ["does not exist in this tenant"]} =
+               errors_on(changeset)
+    end
+
+    test "supersedes link sets target article status to :superseded" do
+      %{tenant: tenant} = setup_tenant()
+
+      {:ok, old_article} =
+        Knowledge.create_article(tenant.id, %{
+          title: "Old Convention",
+          body: "Body",
+          category: :convention,
+          status: :published
+        })
+
+      {:ok, new_article} =
+        Knowledge.create_article(tenant.id, %{
+          title: "New Convention",
+          body: "Body",
+          category: :convention,
+          status: :published
+        })
+
+      assert {:ok, _link} =
+               Knowledge.create_link(tenant.id, %{
+                 source_article_id: new_article.id,
+                 target_article_id: old_article.id,
+                 relationship_type: :supersedes
+               })
+
+      # Verify the target article is now superseded
+      {:ok, refreshed_old} = Knowledge.get_article(tenant.id, old_article.id)
+      assert refreshed_old.status == :superseded
+    end
+  end
+
+  # --- TC-19.3.8: Pagination defaults and limits ---
+
+  describe "list_articles/2 pagination" do
+    test "defaults to limit 20 and offset 0" do
+      %{tenant: tenant} = setup_tenant()
+
+      result = Knowledge.list_articles(tenant.id)
+
+      assert result.meta.limit == 20
+      assert result.meta.offset == 0
+      assert result.meta.total_count == 0
+      assert result.data == []
+    end
+
+    test "caps limit at 100 when higher value requested" do
+      %{tenant: tenant} = setup_tenant()
+
+      result = Knowledge.list_articles(tenant.id, limit: 500)
+      assert result.meta.limit == 100
+    end
+
+    test "respects custom limit and offset" do
+      %{tenant: tenant} = setup_tenant()
+
+      # Create 5 articles
+      for i <- 1..5 do
+        Knowledge.create_article(tenant.id, %{
+          title: "Article #{i}",
+          body: "Body #{i}",
+          category: :pattern
+        })
+      end
+
+      result = Knowledge.list_articles(tenant.id, limit: 2, offset: 0)
+      assert length(result.data) == 2
+      assert result.meta.total_count == 5
+      assert result.meta.limit == 2
+      assert result.meta.offset == 0
+
+      result2 = Knowledge.list_articles(tenant.id, limit: 2, offset: 2)
+      assert length(result2.data) == 2
+      assert result2.meta.total_count == 5
+      assert result2.meta.offset == 2
+    end
+
+    test "returns correct total_count with filters applied" do
+      %{tenant: tenant} = setup_tenant()
+
+      for i <- 1..3 do
+        Knowledge.create_article(tenant.id, %{
+          title: "Pattern #{i}",
+          body: "Body",
+          category: :pattern
+        })
+      end
+
+      Knowledge.create_article(tenant.id, %{
+        title: "Convention 1",
+        body: "Body",
+        category: :convention
+      })
+
+      result = Knowledge.list_articles(tenant.id, category: :pattern)
+      assert result.meta.total_count == 3
+      assert length(result.data) == 3
+    end
+  end
+
+  # --- Additional coverage ---
+
+  describe "update_article/4" do
+    test "updates article and records audit log with old and new state" do
+      %{tenant: tenant} = setup_tenant()
+      actor_id = Ecto.UUID.generate()
+
+      {:ok, article} =
+        Knowledge.create_article(tenant.id, %{
+          title: "Original Title",
+          body: "Original body",
+          category: :pattern
+        })
+
+      assert {:ok, updated} =
+               Knowledge.update_article(tenant.id, article.id, %{title: "Updated Title"},
+                 actor_id: actor_id,
+                 actor_label: "user:editor"
+               )
+
+      assert updated.title == "Updated Title"
+      assert updated.body == "Original body"
+
+      audit =
+        from(a in AuditLog,
+          where: a.entity_type == "article" and a.entity_id == ^article.id,
+          where: a.action == "article.updated"
+        )
+        |> AdminRepo.one!()
+
+      assert audit.old_state["title"] == "Original Title"
+      assert audit.new_state["title"] == "Updated Title"
+    end
+
+    test "returns {:error, :not_found} for non-existent article" do
+      %{tenant: tenant} = setup_tenant()
+
+      assert {:error, :not_found} =
+               Knowledge.update_article(tenant.id, Ecto.UUID.generate(), %{
+                 title: "No such article"
+               })
+    end
+  end
+
+  describe "delete_link/2" do
+    test "deletes link and records audit log" do
+      %{tenant: tenant} = setup_tenant()
+
+      {:ok, source} =
+        Knowledge.create_article(tenant.id, %{
+          title: "Source",
+          body: "Body",
+          category: :pattern
+        })
+
+      {:ok, target} =
+        Knowledge.create_article(tenant.id, %{
+          title: "Target",
+          body: "Body",
+          category: :pattern
+        })
+
+      {:ok, link} =
+        Knowledge.create_link(tenant.id, %{
+          source_article_id: source.id,
+          target_article_id: target.id,
+          relationship_type: :relates_to
+        })
+
+      assert {:ok, deleted} = Knowledge.delete_link(tenant.id, link.id)
+      assert deleted.id == link.id
+
+      # Verify audit log
+      audit =
+        from(a in AuditLog,
+          where: a.entity_type == "article_link" and a.entity_id == ^link.id,
+          where: a.action == "article_link.deleted"
+        )
+        |> AdminRepo.one!()
+
+      assert audit.old_state["relationship_type"] == "relates_to"
+    end
+
+    test "returns {:error, :not_found} for non-existent link" do
+      %{tenant: tenant} = setup_tenant()
+
+      assert {:error, :not_found} =
+               Knowledge.delete_link(tenant.id, Ecto.UUID.generate())
+    end
+  end
+
+  describe "list_links_for_article/2" do
+    test "returns outgoing and incoming links with articles preloaded" do
+      %{tenant: tenant} = setup_tenant()
+
+      {:ok, article} =
+        Knowledge.create_article(tenant.id, %{
+          title: "Center",
+          body: "Body",
+          category: :pattern
+        })
+
+      {:ok, outgoing_target} =
+        Knowledge.create_article(tenant.id, %{
+          title: "Outgoing Target",
+          body: "Body",
+          category: :pattern
+        })
+
+      {:ok, incoming_source} =
+        Knowledge.create_article(tenant.id, %{
+          title: "Incoming Source",
+          body: "Body",
+          category: :pattern
+        })
+
+      {:ok, _outgoing_link} =
+        Knowledge.create_link(tenant.id, %{
+          source_article_id: article.id,
+          target_article_id: outgoing_target.id,
+          relationship_type: :relates_to
+        })
+
+      {:ok, _incoming_link} =
+        Knowledge.create_link(tenant.id, %{
+          source_article_id: incoming_source.id,
+          target_article_id: article.id,
+          relationship_type: :derived_from
+        })
+
+      links = Knowledge.list_links_for_article(tenant.id, article.id)
+      assert length(links) == 2
+
+      # All links should have source and target articles preloaded
+      Enum.each(links, fn link ->
+        assert %Article{} = link.source_article
+        assert %Article{} = link.target_article
+      end)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Implement `Loopctl.Knowledge` context module with full CRUD for articles and article links
- Tag filtering uses PostgreSQL array overlap (`&&`) for ANY-match semantics
- Pagination with configurable limit (default 20, max 100) and offset, returning `%{data, meta}` structure
- All mutations use `Ecto.Multi` with `Audit.log_in_multi/3` for audit trail
- `create_link` with `:supersedes` type atomically sets target article status to `:superseded`
- Cross-tenant article validation prevents linking articles across tenant boundaries

## Functions

| Function | Description |
|----------|-------------|
| `create_article/3` | Creates article with audit log |
| `get_article/2` | Returns article with preloaded outgoing/incoming links |
| `list_articles/2` | Paginated list with project_id, category, status, tags filters |
| `update_article/4` | Updates article with old/new state audit log |
| `archive_article/3` | Sets status to `:archived` with audit log |
| `create_link/2` | Creates link, validates both articles in tenant, supersedes workflow |
| `delete_link/2` | Deletes link with audit log |
| `list_links_for_article/2` | Lists all links (outgoing + incoming) with articles preloaded |

## Test plan

- [x] TC-19.3.1: Create article, verify audit log entry
- [x] TC-19.3.2: List with tag overlap filtering (articles with "elixir" tag)
- [x] TC-19.3.3: List filtered by category AND project_id
- [x] TC-19.3.4: Get article preloads outgoing and incoming links
- [x] TC-19.3.5: Archive article sets status to :archived + audit log
- [x] TC-19.3.6: Tenant isolation — tenant_a cannot access tenant_b articles
- [x] TC-19.3.7: Create link validates both articles belong to same tenant
- [x] TC-19.3.8: Pagination defaults (20) and limits (max 100) enforced
- [x] 27 tests passing, 1667 total suite (0 failures)
- [x] `mix precommit` clean (compile, format, credo --strict, dialyzer, test)