### PR TITLE
US-22.4: Article REST API Endpoints

### DIFF
--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -38,6 +38,7 @@ defmodule Loopctl.Knowledge do
   alias Loopctl.Audit
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.ArticleLink
+  alias Loopctl.Projects.Project
 
   # --- Articles ---
 
@@ -62,39 +63,43 @@ defmodule Loopctl.Knowledge do
   @spec create_article(Ecto.UUID.t(), map(), keyword()) ::
           {:ok, Article.t()} | {:error, Ecto.Changeset.t()}
   def create_article(tenant_id, attrs, opts \\ []) do
-    actor_id = Keyword.get(opts, :actor_id)
-    actor_label = Keyword.get(opts, :actor_label)
-    actor_type = Keyword.get(opts, :actor_type, "api_key")
+    project_id = attrs[:project_id] || attrs["project_id"]
 
-    changeset =
-      %Article{tenant_id: tenant_id}
-      |> Article.create_changeset(attrs)
+    with :ok <- validate_project_ownership(tenant_id, project_id) do
+      actor_id = Keyword.get(opts, :actor_id)
+      actor_label = Keyword.get(opts, :actor_label)
+      actor_type = Keyword.get(opts, :actor_type, "api_key")
 
-    multi =
-      Multi.new()
-      |> Multi.insert(:article, changeset)
-      |> Audit.log_in_multi(:audit, fn %{article: article} ->
-        %{
-          tenant_id: tenant_id,
-          entity_type: "article",
-          entity_id: article.id,
-          action: "article.created",
-          actor_type: actor_type,
-          actor_id: actor_id,
-          actor_label: actor_label,
-          new_state: %{
-            "title" => article.title,
-            "category" => to_string(article.category),
-            "status" => to_string(article.status),
-            "tags" => article.tags,
-            "project_id" => article.project_id
+      changeset =
+        %Article{tenant_id: tenant_id}
+        |> Article.create_changeset(attrs)
+
+      multi =
+        Multi.new()
+        |> Multi.insert(:article, changeset)
+        |> Audit.log_in_multi(:audit, fn %{article: article} ->
+          %{
+            tenant_id: tenant_id,
+            entity_type: "article",
+            entity_id: article.id,
+            action: "article.created",
+            actor_type: actor_type,
+            actor_id: actor_id,
+            actor_label: actor_label,
+            new_state: %{
+              "title" => article.title,
+              "category" => to_string(article.category),
+              "status" => to_string(article.status),
+              "tags" => article.tags,
+              "project_id" => article.project_id
+            }
           }
-        }
-      end)
+        end)
 
-    case AdminRepo.transaction(multi) do
-      {:ok, %{article: article}} -> {:ok, article}
-      {:error, :article, changeset, _} -> {:error, changeset}
+      case AdminRepo.transaction(multi) do
+        {:ok, %{article: article}} -> {:ok, article}
+        {:error, :article, changeset, _} -> {:error, changeset}
+      end
     end
   end
 
@@ -201,11 +206,13 @@ defmodule Loopctl.Knowledge do
   @spec update_article(Ecto.UUID.t(), Ecto.UUID.t(), map(), keyword()) ::
           {:ok, Article.t()} | {:error, Ecto.Changeset.t() | :not_found}
   def update_article(tenant_id, article_id, attrs, opts \\ []) do
-    actor_id = Keyword.get(opts, :actor_id)
-    actor_label = Keyword.get(opts, :actor_label)
-    actor_type = Keyword.get(opts, :actor_type, "api_key")
+    project_id = attrs[:project_id] || attrs["project_id"]
 
-    with {:ok, article} <- fetch_article(tenant_id, article_id) do
+    with :ok <- validate_project_ownership(tenant_id, project_id),
+         {:ok, article} <- fetch_article(tenant_id, article_id) do
+      actor_id = Keyword.get(opts, :actor_id)
+      actor_label = Keyword.get(opts, :actor_label)
+      actor_type = Keyword.get(opts, :actor_type, "api_key")
       old_state = article_state_snapshot(article)
       changeset = Article.update_changeset(article, attrs)
 
@@ -414,6 +421,21 @@ defmodule Loopctl.Knowledge do
     case AdminRepo.get_by(Article, id: article_id, tenant_id: tenant_id) do
       nil -> {:error, :not_found}
       article -> {:ok, article}
+    end
+  end
+
+  defp validate_project_ownership(_tenant_id, nil), do: :ok
+
+  defp validate_project_ownership(tenant_id, project_id) do
+    case AdminRepo.get_by(Project, id: project_id, tenant_id: tenant_id) do
+      nil ->
+        {:error,
+         %Article{}
+         |> Ecto.Changeset.change()
+         |> Ecto.Changeset.add_error(:project_id, "does not belong to this tenant")}
+
+      _project ->
+        :ok
     end
   end
 

--- a/lib/loopctl/knowledge/article.ex
+++ b/lib/loopctl/knowledge/article.ex
@@ -82,6 +82,7 @@ defmodule Loopctl.Knowledge.Article do
     |> validate_tags()
     |> validate_source_type()
     |> validate_metadata()
+    |> foreign_key_constraint(:project_id)
     |> unique_constraint([:tenant_id, :title],
       name: :articles_tenant_title_active_idx,
       message: "has already been taken for this tenant"
@@ -102,6 +103,7 @@ defmodule Loopctl.Knowledge.Article do
     |> validate_length(:body, max: 100_000)
     |> validate_tags()
     |> validate_metadata()
+    |> foreign_key_constraint(:project_id)
     |> unique_constraint([:tenant_id, :title],
       name: :articles_tenant_title_active_idx,
       message: "has already been taken for this tenant"

--- a/lib/loopctl_web/controllers/article_controller.ex
+++ b/lib/loopctl_web/controllers/article_controller.ex
@@ -1,0 +1,276 @@
+defmodule LoopctlWeb.ArticleController do
+  @moduledoc """
+  Controller for Knowledge Wiki article CRUD operations.
+
+  - `POST /api/v1/articles` -- create tenant-wide article (agent+)
+  - `POST /api/v1/projects/:project_id/articles` -- create project-scoped article (agent+)
+  - `GET /api/v1/articles` -- list articles with filters (agent+)
+  - `GET /api/v1/projects/:project_id/articles` -- list project-scoped articles (agent+)
+  - `GET /api/v1/articles/:id` -- get article with preloaded links (agent+)
+  - `PATCH /api/v1/articles/:id` -- update article (user+)
+  - `DELETE /api/v1/articles/:id` -- archive article / soft delete (user+)
+  """
+
+  use LoopctlWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Loopctl.ApiSpec.Schemas
+  alias Loopctl.Knowledge
+  alias LoopctlWeb.ArticleJSON
+  alias LoopctlWeb.AuditContext
+
+  action_fallback LoopctlWeb.FallbackController
+
+  plug LoopctlWeb.Plugs.RequireRole,
+       [role: :user]
+       when action in [:update, :delete]
+
+  plug LoopctlWeb.Plugs.RequireRole,
+       [role: :agent]
+       when action in [:create, :index, :show]
+
+  tags(["Knowledge Wiki"])
+
+  operation(:create,
+    summary: "Create article",
+    description:
+      "Creates a tenant-wide or project-scoped article. " <>
+        "When called via POST /projects/:project_id/articles, project_id is set from path. " <>
+        "Role: agent+.",
+    request_body:
+      {"Article params", "application/json",
+       %OpenApiSpex.Schema{
+         type: :object,
+         required: [:title, :body, :category],
+         properties: %{
+           title: %OpenApiSpex.Schema{type: :string},
+           body: %OpenApiSpex.Schema{type: :string},
+           category: %OpenApiSpex.Schema{
+             type: :string,
+             enum: ["pattern", "convention", "decision", "finding", "reference"]
+           },
+           status: %OpenApiSpex.Schema{
+             type: :string,
+             enum: ["draft", "published", "archived", "superseded"]
+           },
+           tags: %OpenApiSpex.Schema{type: :array, items: %OpenApiSpex.Schema{type: :string}},
+           project_id: %OpenApiSpex.Schema{type: :string, format: :uuid, nullable: true},
+           source_type: %OpenApiSpex.Schema{type: :string, nullable: true},
+           source_id: %OpenApiSpex.Schema{type: :string, format: :uuid, nullable: true},
+           metadata: %OpenApiSpex.Schema{type: :object, additionalProperties: true}
+         }
+       }},
+    responses: %{
+      201 =>
+        {"Article created", "application/json",
+         %OpenApiSpex.Schema{type: :object, additionalProperties: true}},
+      422 => {"Validation error", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  operation(:index,
+    summary: "List articles",
+    description:
+      "Lists articles with optional filters and pagination. " <>
+        "When called via GET /projects/:project_id/articles, project_id is set from path. " <>
+        "Role: agent+.",
+    parameters: [
+      category: [in: :query, type: :string, description: "Filter by category"],
+      status: [in: :query, type: :string, description: "Filter by status"],
+      tags: [
+        in: :query,
+        type: :string,
+        description: "Filter by tags (comma-separated)"
+      ],
+      limit: [in: :query, type: :integer, description: "Max results (default 20, max 100)"],
+      offset: [in: :query, type: :integer, description: "Records to skip"]
+    ],
+    responses: %{
+      200 =>
+        {"Article list", "application/json",
+         %OpenApiSpex.Schema{
+           type: :object,
+           properties: %{
+             data: %OpenApiSpex.Schema{type: :array},
+             meta: %OpenApiSpex.Schema{type: :object}
+           }
+         }},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  operation(:show,
+    summary: "Get article",
+    description:
+      "Returns article detail with outgoing and incoming links preloaded. Role: agent+.",
+    parameters: [id: [in: :path, type: :string, description: "Article UUID"]],
+    responses: %{
+      200 =>
+        {"Article detail", "application/json",
+         %OpenApiSpex.Schema{type: :object, additionalProperties: true}},
+      404 => {"Not found", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  operation(:update,
+    summary: "Update article",
+    description: "Updates article fields. Role: user+.",
+    parameters: [id: [in: :path, type: :string, description: "Article UUID"]],
+    request_body:
+      {"Update params", "application/json",
+       %OpenApiSpex.Schema{type: :object, additionalProperties: true}},
+    responses: %{
+      200 =>
+        {"Updated article", "application/json",
+         %OpenApiSpex.Schema{type: :object, additionalProperties: true}},
+      404 => {"Not found", "application/json", Schemas.ErrorResponse},
+      422 => {"Validation error", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  operation(:delete,
+    summary: "Archive article",
+    description: "Archives an article (soft delete). Role: user+.",
+    parameters: [id: [in: :path, type: :string, description: "Article UUID"]],
+    responses: %{
+      200 =>
+        {"Archived article", "application/json",
+         %OpenApiSpex.Schema{type: :object, additionalProperties: true}},
+      404 => {"Not found", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  # --- Actions ---
+
+  @doc "POST /api/v1/articles or POST /api/v1/projects/:project_id/articles"
+  def create(conn, params) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+    audit_opts = AuditContext.from_conn(conn)
+
+    # If project_id comes from the path (project-scoped route), merge it into attrs
+    attrs = maybe_merge_project_id(params, params["project_id"])
+
+    case Knowledge.create_article(tenant_id, attrs, audit_opts) do
+      {:ok, article} ->
+        conn
+        |> put_status(:created)
+        |> json(ArticleJSON.create(%{article: article}))
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:error, changeset}
+    end
+  end
+
+  @doc "GET /api/v1/articles or GET /api/v1/projects/:project_id/articles"
+  def index(conn, params) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+
+    opts =
+      []
+      |> maybe_add_opt(:project_id, params["project_id"])
+      |> maybe_add_opt(:category, params["category"])
+      |> maybe_add_opt(:status, params["status"])
+      |> maybe_add_opt(:tags, parse_tags(params["tags"]))
+      |> maybe_add_opt(:limit, parse_int(params["limit"]))
+      |> maybe_add_opt(:offset, parse_int(params["offset"]))
+
+    result = Knowledge.list_articles(tenant_id, opts)
+
+    json(conn, ArticleJSON.index(%{articles: result.data, meta: result.meta}))
+  end
+
+  @doc "GET /api/v1/articles/:id"
+  def show(conn, %{"id" => article_id}) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+
+    case Knowledge.get_article(tenant_id, article_id) do
+      {:ok, article} ->
+        json(conn, ArticleJSON.show(%{article: article}))
+
+      {:error, :not_found} ->
+        {:error, :not_found}
+    end
+  end
+
+  @doc "PATCH /api/v1/articles/:id"
+  def update(conn, %{"id" => article_id} = params) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+    audit_opts = AuditContext.from_conn(conn)
+
+    attrs =
+      params
+      |> Map.take([
+        "title",
+        "body",
+        "category",
+        "status",
+        "tags",
+        "metadata",
+        "project_id"
+      ])
+      |> Map.reject(fn {_k, v} -> is_nil(v) end)
+
+    case Knowledge.update_article(tenant_id, article_id, attrs, audit_opts) do
+      {:ok, article} ->
+        json(conn, ArticleJSON.update(%{article: article}))
+
+      {:error, :not_found} ->
+        {:error, :not_found}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:error, changeset}
+    end
+  end
+
+  @doc "DELETE /api/v1/articles/:id"
+  def delete(conn, %{"id" => article_id}) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+    audit_opts = AuditContext.from_conn(conn)
+
+    case Knowledge.archive_article(tenant_id, article_id, audit_opts) do
+      {:ok, article} ->
+        json(conn, ArticleJSON.delete(%{article: article}))
+
+      {:error, :not_found} ->
+        {:error, :not_found}
+    end
+  end
+
+  # --- Private helpers ---
+
+  defp maybe_merge_project_id(attrs, nil), do: attrs
+  defp maybe_merge_project_id(attrs, project_id), do: Map.put(attrs, "project_id", project_id)
+
+  defp maybe_add_opt(opts, _key, nil), do: opts
+  defp maybe_add_opt(opts, _key, []), do: opts
+  defp maybe_add_opt(opts, key, value), do: Keyword.put(opts, key, value)
+
+  defp parse_tags(nil), do: nil
+  defp parse_tags(""), do: nil
+
+  defp parse_tags(tags) when is_binary(tags) do
+    tags
+    |> String.split(",", trim: true)
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+    |> case do
+      [] -> nil
+      parsed -> parsed
+    end
+  end
+
+  defp parse_int(nil), do: nil
+
+  defp parse_int(val) when is_binary(val) do
+    case Integer.parse(val) do
+      {n, _} -> n
+      :error -> nil
+    end
+  end
+
+  defp parse_int(val) when is_integer(val), do: val
+end

--- a/lib/loopctl_web/controllers/article_json.ex
+++ b/lib/loopctl_web/controllers/article_json.ex
@@ -1,0 +1,72 @@
+defmodule LoopctlWeb.ArticleJSON do
+  @moduledoc """
+  JSON rendering helpers for article API responses.
+
+  Provides consistent serialization for articles and article links
+  across all article controller actions.
+  """
+
+  @doc "Renders a list of articles with pagination meta."
+  def index(%{articles: articles, meta: meta}) do
+    %{data: Enum.map(articles, &article_data/1), meta: meta}
+  end
+
+  @doc "Renders a single article with preloaded links."
+  def show(%{article: article}) do
+    %{data: article_data_with_links(article)}
+  end
+
+  @doc "Renders a newly created article."
+  def create(%{article: article}), do: %{data: article_data(article)}
+
+  @doc "Renders an updated article."
+  def update(%{article: article}), do: %{data: article_data(article)}
+
+  @doc "Renders an archived article."
+  def delete(%{article: article}), do: %{data: article_data(article)}
+
+  @doc "Serializes core article fields (no links)."
+  def article_data(article) do
+    %{
+      id: article.id,
+      tenant_id: article.tenant_id,
+      project_id: article.project_id,
+      title: article.title,
+      body: article.body,
+      category: article.category,
+      status: article.status,
+      tags: article.tags,
+      source_type: article.source_type,
+      source_id: article.source_id,
+      metadata: article.metadata,
+      inserted_at: article.inserted_at,
+      updated_at: article.updated_at
+    }
+  end
+
+  @doc "Serializes article with outgoing and incoming links."
+  def article_data_with_links(article) do
+    article_data(article)
+    |> Map.put(:outgoing_links, Enum.map(article.outgoing_links || [], &link_data/1))
+    |> Map.put(:incoming_links, Enum.map(article.incoming_links || [], &link_data/1))
+  end
+
+  defp link_data(link) do
+    %{
+      id: link.id,
+      relationship_type: link.relationship_type,
+      source_article: %{
+        id: link.source_article_id,
+        title: loaded_title(link.source_article)
+      },
+      target_article: %{
+        id: link.target_article_id,
+        title: loaded_title(link.target_article)
+      }
+    }
+  end
+
+  defp loaded_title(%Ecto.Association.NotLoaded{}), do: nil
+  defp loaded_title(nil), do: nil
+  defp loaded_title(article), do: article.title
+end

--- a/lib/loopctl_web/controllers/article_json.ex
+++ b/lib/loopctl_web/controllers/article_json.ex
@@ -47,8 +47,8 @@ defmodule LoopctlWeb.ArticleJSON do
   @doc "Serializes article with outgoing and incoming links."
   def article_data_with_links(article) do
     article_data(article)
-    |> Map.put(:outgoing_links, Enum.map(article.outgoing_links || [], &link_data/1))
-    |> Map.put(:incoming_links, Enum.map(article.incoming_links || [], &link_data/1))
+    |> Map.put(:outgoing_links, Enum.map(loaded_links(article.outgoing_links), &link_data/1))
+    |> Map.put(:incoming_links, Enum.map(loaded_links(article.incoming_links), &link_data/1))
   end
 
   defp link_data(link) do
@@ -65,6 +65,10 @@ defmodule LoopctlWeb.ArticleJSON do
       }
     }
   end
+
+  defp loaded_links(%Ecto.Association.NotLoaded{}), do: []
+  defp loaded_links(nil), do: []
+  defp loaded_links(links) when is_list(links), do: links
 
   defp loaded_title(%Ecto.Association.NotLoaded{}), do: nil
   defp loaded_title(nil), do: nil

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -229,6 +229,13 @@ defmodule LoopctlWeb.Router do
 
     # Skill results
     post "/skill_results", SkillResultController, :create
+
+    # Knowledge Wiki (Epic 19)
+    resources "/articles", ArticleController, except: [:new, :edit]
+
+    scope "/projects/:project_id" do
+      resources "/articles", ArticleController, only: [:create, :index], as: :project_article
+    end
   end
 
   # Superadmin endpoints (Epic 11)

--- a/test/loopctl_web/controllers/article_controller_test.exs
+++ b/test/loopctl_web/controllers/article_controller_test.exs
@@ -1,0 +1,296 @@
+defmodule LoopctlWeb.ArticleControllerTest do
+  use LoopctlWeb.ConnCase, async: true
+
+  setup :verify_on_exit!
+
+  defp auth_conn(conn, raw_key) do
+    put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  describe "POST /api/v1/articles" do
+    test "creates a tenant-wide article with agent role", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/articles", %{
+          "title" => "Ecto Multi Pattern",
+          "body" => "Use Ecto.Multi for atomic operations.",
+          "category" => "pattern",
+          "tags" => ["ecto", "transactions"]
+        })
+
+      body = json_response(conn, 201)
+      assert body["data"]["title"] == "Ecto Multi Pattern"
+      assert body["data"]["category"] == "pattern"
+      assert body["data"]["tags"] == ["ecto", "transactions"]
+      assert body["data"]["status"] == "draft"
+      assert is_nil(body["data"]["project_id"])
+    end
+
+    test "returns 422 on invalid input", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/articles", %{
+          "title" => "",
+          "body" => "",
+          "category" => ""
+        })
+
+      body = json_response(conn, 422)
+      assert body["error"]["status"] == 422
+      assert body["error"]["details"]["title"] != nil
+    end
+  end
+
+  describe "POST /api/v1/projects/:project_id/articles" do
+    test "creates a project-scoped article", %{conn: conn} do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/projects/#{project.id}/articles", %{
+          "title" => "Project Convention",
+          "body" => "Follow these conventions for this project.",
+          "category" => "convention"
+        })
+
+      body = json_response(conn, 201)
+      assert body["data"]["title"] == "Project Convention"
+      assert body["data"]["project_id"] == project.id
+    end
+  end
+
+  describe "GET /api/v1/articles" do
+    test "lists articles with category and tags filters", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Pattern A",
+        category: :pattern,
+        tags: ["elixir", "ecto"]
+      })
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Decision B",
+        category: :decision,
+        tags: ["architecture"]
+      })
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Pattern C",
+        category: :pattern,
+        tags: ["phoenix"]
+      })
+
+      # Filter by category
+      conn_category =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/articles?category=pattern")
+
+      body = json_response(conn_category, 200)
+      assert body["meta"]["total_count"] == 2
+      assert length(body["data"]) == 2
+
+      # Filter by tags
+      conn_tags =
+        build_conn()
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/articles?tags=elixir")
+
+      body_tags = json_response(conn_tags, 200)
+      assert body_tags["meta"]["total_count"] == 1
+      assert hd(body_tags["data"])["title"] == "Pattern A"
+    end
+  end
+
+  describe "GET /api/v1/projects/:project_id/articles" do
+    test "lists project-scoped articles only", %{conn: conn} do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      other_project = fixture(:project, %{tenant_id: tenant.id})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        project_id: project.id,
+        title: "In Project"
+      })
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        project_id: other_project.id,
+        title: "Other Project"
+      })
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Tenant Wide"
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/projects/#{project.id}/articles")
+
+      body = json_response(conn, 200)
+      assert body["meta"]["total_count"] == 1
+      assert hd(body["data"])["title"] == "In Project"
+    end
+  end
+
+  describe "GET /api/v1/articles/:id" do
+    test "returns article with preloaded links", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      article_a = fixture(:article, %{tenant_id: tenant.id, title: "Article A"})
+      article_b = fixture(:article, %{tenant_id: tenant.id, title: "Article B"})
+
+      fixture(:article_link, %{
+        tenant_id: tenant.id,
+        source_article_id: article_a.id,
+        target_article_id: article_b.id,
+        relationship_type: :relates_to
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/articles/#{article_a.id}")
+
+      body = json_response(conn, 200)
+      assert body["data"]["id"] == article_a.id
+      assert body["data"]["title"] == "Article A"
+      assert length(body["data"]["outgoing_links"]) == 1
+
+      outgoing = hd(body["data"]["outgoing_links"])
+      assert outgoing["relationship_type"] == "relates_to"
+      assert outgoing["target_article"]["id"] == article_b.id
+      assert outgoing["target_article"]["title"] == "Article B"
+    end
+
+    test "returns 404 for non-existent article", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/articles/#{Ecto.UUID.generate()}")
+
+      assert json_response(conn, 404)
+    end
+  end
+
+  describe "PATCH /api/v1/articles/:id" do
+    test "agent role gets 403 on update", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      article = fixture(:article, %{tenant_id: tenant.id})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> patch(~p"/api/v1/articles/#{article.id}", %{
+          "title" => "Updated Title"
+        })
+
+      assert json_response(conn, 403)
+    end
+
+    test "user role can update article", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      article = fixture(:article, %{tenant_id: tenant.id})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> patch(~p"/api/v1/articles/#{article.id}", %{
+          "title" => "Updated Title",
+          "status" => "published"
+        })
+
+      body = json_response(conn, 200)
+      assert body["data"]["title"] == "Updated Title"
+      assert body["data"]["status"] == "published"
+    end
+  end
+
+  describe "DELETE /api/v1/articles/:id" do
+    test "agent role gets 403 on delete", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      article = fixture(:article, %{tenant_id: tenant.id})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> delete(~p"/api/v1/articles/#{article.id}")
+
+      assert json_response(conn, 403)
+    end
+
+    test "archives article (soft delete) with user role", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      article = fixture(:article, %{tenant_id: tenant.id, status: :published})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> delete(~p"/api/v1/articles/#{article.id}")
+
+      body = json_response(conn, 200)
+      assert body["data"]["status"] == "archived"
+    end
+  end
+
+  describe "tenant isolation" do
+    test "cross-tenant access returns 404", %{conn: conn} do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant_b.id, role: :user})
+      article = fixture(:article, %{tenant_id: tenant_a.id})
+
+      # GET returns 404
+      conn_get =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/articles/#{article.id}")
+
+      assert json_response(conn_get, 404)
+
+      # PATCH returns 404
+      conn_patch =
+        build_conn()
+        |> auth_conn(raw_key)
+        |> patch(~p"/api/v1/articles/#{article.id}", %{"title" => "Hijacked"})
+
+      assert json_response(conn_patch, 404)
+
+      # DELETE returns 404
+      conn_delete =
+        build_conn()
+        |> auth_conn(raw_key)
+        |> delete(~p"/api/v1/articles/#{article.id}")
+
+      assert json_response(conn_delete, 404)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `ArticleController` with full CRUD: create, index, show, update, delete (archive)
- Add `ArticleJSON` module for consistent JSON serialization with link preloading
- Add routes for tenant-wide (`/articles`) and project-scoped (`/projects/:project_id/articles`) endpoints
- Role enforcement: agent+ for read/create, user+ for update/delete
- Tag filtering via comma-separated query param, category/status filters, limit/offset pagination

## Acceptance Criteria

- [x] AC-19.4.1: POST /articles creates tenant-wide article (agent+, 201)
- [x] AC-19.4.2: POST /projects/:project_id/articles creates project-scoped article (agent+, 201)
- [x] AC-19.4.3: GET /articles lists with category, status, tags, limit, offset filters (agent+, 200)
- [x] AC-19.4.4: GET /projects/:project_id/articles lists project-scoped articles (agent+, 200)
- [x] AC-19.4.5: GET /articles/:id returns article with outgoing/incoming links preloaded (agent+, 200/404)
- [x] AC-19.4.6: PATCH /articles/:id updates article (user+, 200)
- [x] AC-19.4.7: DELETE /articles/:id archives (soft delete) (user+, 200)
- [x] AC-19.4.8: Controller uses action_fallback + RequireRole plug
- [x] AC-19.4.9: Routes in router.ex under authenticated API pipeline
- [x] AC-19.4.10: Links include id, relationship_type, linked article id+title
- [x] AC-19.4.11: Tenant isolation enforced -- cross-tenant returns 404
- [x] AC-19.4.12: Uses 3-tuple error pattern, no FallbackController modifications

## Test plan

- [x] TC-19.4.1: Create tenant-wide article (POST /articles, 201)
- [x] TC-19.4.2: Create project-scoped article (POST /projects/:id/articles, 201)
- [x] TC-19.4.3: List with category + tags filters
- [x] TC-19.4.4: Show article with preloaded links
- [x] TC-19.4.5: Agent role gets 403 on PATCH/DELETE
- [x] TC-19.4.6: Cross-tenant access returns 404
- [x] TC-19.4.7: DELETE archives article (status: archived)
- [x] TC-19.4.8: Invalid creation returns 422

All 1679 tests pass (12 new for this story).