### PR TITLE
US-22.5: ArticleLink REST API Endpoints

### DIFF
--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -315,7 +315,7 @@ defmodule Loopctl.Knowledge do
   - `{:error, changeset}` on validation failure
   """
   @spec create_link(Ecto.UUID.t(), map(), keyword()) ::
-          {:ok, ArticleLink.t()} | {:error, Ecto.Changeset.t()}
+          {:ok, ArticleLink.t()} | {:error, Ecto.Changeset.t() | :target_not_found}
   def create_link(tenant_id, attrs, opts \\ []) do
     source_id = attrs[:source_article_id] || attrs["source_article_id"]
     target_id = attrs[:target_article_id] || attrs["target_article_id"]

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -314,9 +314,9 @@ defmodule Loopctl.Knowledge do
   - `{:ok, %ArticleLink{}}` on success
   - `{:error, changeset}` on validation failure
   """
-  @spec create_link(Ecto.UUID.t(), map()) ::
+  @spec create_link(Ecto.UUID.t(), map(), keyword()) ::
           {:ok, ArticleLink.t()} | {:error, Ecto.Changeset.t()}
-  def create_link(tenant_id, attrs) do
+  def create_link(tenant_id, attrs, opts \\ []) do
     source_id = attrs[:source_article_id] || attrs["source_article_id"]
     target_id = attrs[:target_article_id] || attrs["target_article_id"]
     rel_type = attrs[:relationship_type] || attrs["relationship_type"]
@@ -330,7 +330,7 @@ defmodule Loopctl.Knowledge do
         Multi.new()
         |> Multi.insert(:link, changeset)
         |> maybe_supersede_target(tenant_id, target_id, rel_type)
-        |> Audit.log_in_multi(:audit, &build_link_audit(tenant_id, &1))
+        |> Audit.log_in_multi(:audit, &build_link_audit(tenant_id, &1, opts))
 
       case AdminRepo.transaction(multi) do
         {:ok, %{link: link}} -> {:ok, link}
@@ -355,9 +355,13 @@ defmodule Loopctl.Knowledge do
   - `{:ok, %ArticleLink{}}` on success
   - `{:error, :not_found}` if not found or belongs to another tenant
   """
-  @spec delete_link(Ecto.UUID.t(), Ecto.UUID.t()) ::
-          {:ok, ArticleLink.t()} | {:error, :not_found}
-  def delete_link(tenant_id, link_id) do
+  @spec delete_link(Ecto.UUID.t(), Ecto.UUID.t(), keyword()) ::
+          {:ok, ArticleLink.t()} | {:error, :not_found | Ecto.Changeset.t()}
+  def delete_link(tenant_id, link_id, opts \\ []) do
+    actor_id = Keyword.get(opts, :actor_id)
+    actor_label = Keyword.get(opts, :actor_label)
+    actor_type = Keyword.get(opts, :actor_type, "api_key")
+
     case AdminRepo.get_by(ArticleLink, id: link_id, tenant_id: tenant_id) do
       nil ->
         {:error, :not_found}
@@ -372,9 +376,9 @@ defmodule Loopctl.Knowledge do
               entity_type: "article_link",
               entity_id: deleted.id,
               action: "article_link.deleted",
-              actor_type: "api_key",
-              actor_id: nil,
-              actor_label: nil,
+              actor_type: actor_type,
+              actor_id: actor_id,
+              actor_label: actor_label,
               old_state: %{
                 "source_article_id" => to_string(deleted.source_article_id),
                 "target_article_id" => to_string(deleted.target_article_id),
@@ -525,7 +529,11 @@ defmodule Loopctl.Knowledge do
 
   defp maybe_supersede_target(multi, _tenant_id, _target_id, _rel_type), do: multi
 
-  defp build_link_audit(tenant_id, changes) do
+  defp build_link_audit(tenant_id, changes, opts) do
+    actor_id = Keyword.get(opts, :actor_id)
+    actor_label = Keyword.get(opts, :actor_label)
+    actor_type = Keyword.get(opts, :actor_type, "api_key")
+
     new_state = %{
       "source_article_id" => to_string(changes.link.source_article_id),
       "target_article_id" => to_string(changes.link.target_article_id),
@@ -544,9 +552,9 @@ defmodule Loopctl.Knowledge do
       entity_type: "article_link",
       entity_id: changes.link.id,
       action: "article_link.created",
-      actor_type: "api_key",
-      actor_id: nil,
-      actor_label: nil,
+      actor_type: actor_type,
+      actor_id: actor_id,
+      actor_label: actor_label,
       new_state: new_state
     }
   end

--- a/lib/loopctl_web/controllers/article_link_controller.ex
+++ b/lib/loopctl_web/controllers/article_link_controller.ex
@@ -1,0 +1,124 @@
+defmodule LoopctlWeb.ArticleLinkController do
+  @moduledoc """
+  Controller for Knowledge Wiki article link management.
+
+  - `POST /api/v1/article_links` -- create link between articles (agent+)
+  - `DELETE /api/v1/article_links/:id` -- delete a link (user+)
+  - `GET /api/v1/articles/:article_id/links` -- list links for an article (agent+)
+  """
+
+  use LoopctlWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Loopctl.ApiSpec.Schemas
+  alias Loopctl.Knowledge
+  alias LoopctlWeb.ArticleLinkJSON
+
+  action_fallback LoopctlWeb.FallbackController
+
+  plug LoopctlWeb.Plugs.RequireRole,
+       [role: :user]
+       when action in [:delete]
+
+  plug LoopctlWeb.Plugs.RequireRole,
+       [role: :agent]
+       when action in [:create, :index]
+
+  tags(["Knowledge Wiki"])
+
+  operation(:create,
+    summary: "Create article link",
+    description:
+      "Creates a directed link between two articles in the same tenant. " <>
+        "When relationship_type is 'supersedes', the target article's status " <>
+        "is set to 'superseded'. Role: agent+.",
+    request_body:
+      {"ArticleLink params", "application/json",
+       %OpenApiSpex.Schema{
+         type: :object,
+         required: [:source_article_id, :target_article_id, :relationship_type],
+         properties: %{
+           source_article_id: %OpenApiSpex.Schema{type: :string, format: :uuid},
+           target_article_id: %OpenApiSpex.Schema{type: :string, format: :uuid},
+           relationship_type: %OpenApiSpex.Schema{
+             type: :string,
+             enum: ["relates_to", "derived_from", "contradicts", "supersedes"]
+           },
+           metadata: %OpenApiSpex.Schema{type: :object, additionalProperties: true}
+         }
+       }},
+    responses: %{
+      201 =>
+        {"Link created", "application/json",
+         %OpenApiSpex.Schema{type: :object, additionalProperties: true}},
+      422 => {"Validation error", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  operation(:delete,
+    summary: "Delete article link",
+    description: "Deletes an article link. Role: user+.",
+    parameters: [id: [in: :path, type: :string, description: "ArticleLink UUID"]],
+    responses: %{
+      204 => {"No content", "application/json", %OpenApiSpex.Schema{type: :string}},
+      404 => {"Not found", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  operation(:index,
+    summary: "List links for article",
+    description:
+      "Returns all links (outgoing and incoming) for an article, " <>
+        "with linked articles preloaded. Role: agent+.",
+    parameters: [
+      article_id: [in: :path, type: :string, description: "Article UUID"]
+    ],
+    responses: %{
+      200 =>
+        {"Link list", "application/json",
+         %OpenApiSpex.Schema{type: :object, additionalProperties: true}},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  # --- Actions ---
+
+  @doc "POST /api/v1/article_links"
+  def create(conn, params) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+
+    case Knowledge.create_link(tenant_id, params) do
+      {:ok, link} ->
+        conn
+        |> put_status(:created)
+        |> json(ArticleLinkJSON.create(%{link: link}))
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:error, changeset}
+    end
+  end
+
+  @doc "DELETE /api/v1/article_links/:id"
+  def delete(conn, %{"id" => link_id}) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+
+    case Knowledge.delete_link(tenant_id, link_id) do
+      {:ok, _link} ->
+        send_resp(conn, :no_content, "")
+
+      {:error, :not_found} ->
+        {:error, :not_found}
+    end
+  end
+
+  @doc "GET /api/v1/articles/:article_id/links"
+  def index(conn, %{"article_id" => article_id}) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+
+    links = Knowledge.list_links_for_article(tenant_id, article_id)
+
+    json(conn, ArticleLinkJSON.index(%{links: links}))
+  end
+end

--- a/lib/loopctl_web/controllers/article_link_controller.ex
+++ b/lib/loopctl_web/controllers/article_link_controller.ex
@@ -13,6 +13,7 @@ defmodule LoopctlWeb.ArticleLinkController do
   alias Loopctl.ApiSpec.Schemas
   alias Loopctl.Knowledge
   alias LoopctlWeb.ArticleLinkJSON
+  alias LoopctlWeb.AuditContext
 
   action_fallback LoopctlWeb.FallbackController
 
@@ -88,8 +89,9 @@ defmodule LoopctlWeb.ArticleLinkController do
   @doc "POST /api/v1/article_links"
   def create(conn, params) do
     tenant_id = conn.assigns.current_api_key.tenant_id
+    audit_opts = AuditContext.from_conn(conn)
 
-    case Knowledge.create_link(tenant_id, params) do
+    case Knowledge.create_link(tenant_id, params, audit_opts) do
       {:ok, link} ->
         conn
         |> put_status(:created)
@@ -103,13 +105,17 @@ defmodule LoopctlWeb.ArticleLinkController do
   @doc "DELETE /api/v1/article_links/:id"
   def delete(conn, %{"id" => link_id}) do
     tenant_id = conn.assigns.current_api_key.tenant_id
+    audit_opts = AuditContext.from_conn(conn)
 
-    case Knowledge.delete_link(tenant_id, link_id) do
+    case Knowledge.delete_link(tenant_id, link_id, audit_opts) do
       {:ok, _link} ->
         send_resp(conn, :no_content, "")
 
       {:error, :not_found} ->
         {:error, :not_found}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:error, changeset}
     end
   end
 

--- a/lib/loopctl_web/controllers/article_link_controller.ex
+++ b/lib/loopctl_web/controllers/article_link_controller.ex
@@ -99,6 +99,9 @@ defmodule LoopctlWeb.ArticleLinkController do
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:error, changeset}
+
+      {:error, :target_not_found} ->
+        {:error, :not_found}
     end
   end
 

--- a/lib/loopctl_web/controllers/article_link_json.ex
+++ b/lib/loopctl_web/controllers/article_link_json.ex
@@ -1,0 +1,35 @@
+defmodule LoopctlWeb.ArticleLinkJSON do
+  @moduledoc """
+  JSON rendering helpers for article link API responses.
+
+  Provides consistent serialization for article links across
+  all article link controller actions.
+  """
+
+  @doc "Renders a newly created article link."
+  def create(%{link: link}), do: %{data: link_data(link)}
+
+  @doc "Renders a list of article links with preloaded articles."
+  def index(%{links: links}), do: %{data: Enum.map(links, &link_data_with_article/1)}
+
+  defp link_data(link) do
+    %{
+      id: link.id,
+      source_article_id: link.source_article_id,
+      target_article_id: link.target_article_id,
+      relationship_type: link.relationship_type,
+      metadata: link.metadata,
+      inserted_at: link.inserted_at
+    }
+  end
+
+  defp link_data_with_article(link) do
+    link_data(link)
+    |> Map.put(:source_article, article_ref(link.source_article))
+    |> Map.put(:target_article, article_ref(link.target_article))
+  end
+
+  defp article_ref(%Ecto.Association.NotLoaded{}), do: nil
+  defp article_ref(%{id: id, title: title}), do: %{id: id, title: title}
+  defp article_ref(_), do: nil
+end

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -236,6 +236,10 @@ defmodule LoopctlWeb.Router do
     scope "/projects/:project_id" do
       resources "/articles", ArticleController, only: [:create, :index], as: :project_article
     end
+
+    # ArticleLink management
+    resources "/article_links", ArticleLinkController, only: [:create, :delete]
+    get "/articles/:article_id/links", ArticleLinkController, :index
   end
 
   # Superadmin endpoints (Epic 11)

--- a/test/loopctl_web/controllers/article_link_controller_test.exs
+++ b/test/loopctl_web/controllers/article_link_controller_test.exs
@@ -206,5 +206,26 @@ defmodule LoopctlWeb.ArticleLinkControllerTest do
 
       assert json_response(conn, 404)
     end
+
+    test "cross-tenant index returns empty list", %{conn: conn} do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant_b.id, role: :agent})
+      article_a = fixture(:article, %{tenant_id: tenant_a.id})
+
+      fixture(:article_link, %{
+        tenant_id: tenant_a.id,
+        source_article_id: article_a.id,
+        relationship_type: :relates_to
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/articles/#{article_a.id}/links")
+
+      body = json_response(conn, 200)
+      assert body["data"] == []
+    end
   end
 end

--- a/test/loopctl_web/controllers/article_link_controller_test.exs
+++ b/test/loopctl_web/controllers/article_link_controller_test.exs
@@ -1,0 +1,210 @@
+defmodule LoopctlWeb.ArticleLinkControllerTest do
+  use LoopctlWeb.ConnCase, async: true
+
+  setup :verify_on_exit!
+
+  defp auth_conn(conn, raw_key) do
+    put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  describe "POST /api/v1/article_links" do
+    test "creates link with valid data (201)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      article_a = fixture(:article, %{tenant_id: tenant.id, title: "Source Article"})
+      article_b = fixture(:article, %{tenant_id: tenant.id, title: "Target Article"})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/article_links", %{
+          "source_article_id" => article_a.id,
+          "target_article_id" => article_b.id,
+          "relationship_type" => "relates_to",
+          "metadata" => %{"reason" => "related topic"}
+        })
+
+      body = json_response(conn, 201)
+      assert body["data"]["source_article_id"] == article_a.id
+      assert body["data"]["target_article_id"] == article_b.id
+      assert body["data"]["relationship_type"] == "relates_to"
+      assert body["data"]["metadata"] == %{"reason" => "related topic"}
+      assert body["data"]["id"] != nil
+      assert body["data"]["inserted_at"] != nil
+    end
+
+    test ":supersedes link sets target article status to :superseded", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      article_a = fixture(:article, %{tenant_id: tenant.id, title: "New Version"})
+
+      article_b =
+        fixture(:article, %{tenant_id: tenant.id, title: "Old Version", status: :published})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/article_links", %{
+          "source_article_id" => article_a.id,
+          "target_article_id" => article_b.id,
+          "relationship_type" => "supersedes"
+        })
+
+      assert json_response(conn, 201)
+
+      # Verify the target article is now superseded
+      {:ok, updated_target} = Loopctl.Knowledge.get_article(tenant.id, article_b.id)
+      assert updated_target.status == :superseded
+    end
+
+    test "rejects self-link (422)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      article = fixture(:article, %{tenant_id: tenant.id})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/article_links", %{
+          "source_article_id" => article.id,
+          "target_article_id" => article.id,
+          "relationship_type" => "relates_to"
+        })
+
+      body = json_response(conn, 422)
+      assert body["error"]["status"] == 422
+    end
+
+    test "rejects cross-tenant link (422)", %{conn: conn} do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant_a.id, role: :agent})
+      article_a = fixture(:article, %{tenant_id: tenant_a.id})
+      article_b = fixture(:article, %{tenant_id: tenant_b.id})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/article_links", %{
+          "source_article_id" => article_a.id,
+          "target_article_id" => article_b.id,
+          "relationship_type" => "relates_to"
+        })
+
+      body = json_response(conn, 422)
+      assert body["error"]["status"] == 422
+    end
+  end
+
+  describe "GET /api/v1/articles/:article_id/links" do
+    test "lists links for article (both outgoing and incoming)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      article_a = fixture(:article, %{tenant_id: tenant.id, title: "Article A"})
+      article_b = fixture(:article, %{tenant_id: tenant.id, title: "Article B"})
+      article_c = fixture(:article, %{tenant_id: tenant.id, title: "Article C"})
+
+      # Outgoing link from A -> B
+      fixture(:article_link, %{
+        tenant_id: tenant.id,
+        source_article_id: article_a.id,
+        target_article_id: article_b.id,
+        relationship_type: :relates_to
+      })
+
+      # Incoming link from C -> A
+      fixture(:article_link, %{
+        tenant_id: tenant.id,
+        source_article_id: article_c.id,
+        target_article_id: article_a.id,
+        relationship_type: :derived_from
+      })
+
+      # Unrelated link B -> C (should not appear)
+      fixture(:article_link, %{
+        tenant_id: tenant.id,
+        source_article_id: article_b.id,
+        target_article_id: article_c.id,
+        relationship_type: :relates_to
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/articles/#{article_a.id}/links")
+
+      body = json_response(conn, 200)
+      assert length(body["data"]) == 2
+
+      # Verify preloaded article data
+      link_ids = Enum.map(body["data"], & &1["id"])
+      assert length(link_ids) == 2
+
+      Enum.each(body["data"], fn link ->
+        assert link["source_article"] != nil
+        assert link["target_article"] != nil
+        assert link["source_article"]["id"] != nil
+        assert link["source_article"]["title"] != nil
+      end)
+    end
+  end
+
+  describe "DELETE /api/v1/article_links/:id" do
+    test "agent role gets 403 on delete", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      link =
+        fixture(:article_link, %{
+          tenant_id: tenant.id,
+          relationship_type: :relates_to
+        })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> delete(~p"/api/v1/article_links/#{link.id}")
+
+      assert json_response(conn, 403)
+    end
+
+    test "user role can delete link (204)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      link =
+        fixture(:article_link, %{
+          tenant_id: tenant.id,
+          relationship_type: :relates_to
+        })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> delete(~p"/api/v1/article_links/#{link.id}")
+
+      assert response(conn, 204)
+    end
+  end
+
+  describe "tenant isolation" do
+    test "cross-tenant delete returns 404", %{conn: conn} do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant_b.id, role: :user})
+
+      link =
+        fixture(:article_link, %{
+          tenant_id: tenant_a.id,
+          relationship_type: :relates_to
+        })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> delete(~p"/api/v1/article_links/#{link.id}")
+
+      assert json_response(conn, 404)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `POST /api/v1/article_links` (agent+, 201) for creating directed links between articles
- Add `DELETE /api/v1/article_links/:id` (user+, 204) for removing links
- Add `GET /api/v1/articles/:article_id/links` (agent+, 200) for listing outgoing and incoming links with preloaded article refs
- Supersedes relationship automatically sets target article status to `:superseded` (end-to-end via API)
- Self-link and cross-tenant validation return 422
- Role-based access: agents can create/list, only users can delete
- Tenant isolation enforced on all operations

## Test plan

- [x] TC-19.5.1: Create link with valid data returns 201 with correct JSON shape
- [x] TC-19.5.2: `:supersedes` link sets target article status to `:superseded`
- [x] TC-19.5.3: Self-link rejected with 422
- [x] TC-19.5.4: Cross-tenant link rejected with 422
- [x] TC-19.5.5: List links returns both outgoing and incoming with preloaded articles
- [x] TC-19.5.6: Delete requires user role (agent gets 403, user gets 204)
- [x] TC-19.5.7: Tenant isolation on delete returns 404
- [x] All 1687 tests passing, 0 failures
- [x] Credo strict: no issues
- [x] Dialyzer: 0 errors