### PR TITLE
US-23.1: Keyword Search with tsvector

### DIFF
--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -228,66 +228,68 @@ defmodule Loopctl.Knowledge do
   def search_keyword(_tenant_id, nil, _opts), do: {:error, :empty_query}
   def search_keyword(_tenant_id, "", _opts), do: {:error, :empty_query}
 
-  def search_keyword(_tenant_id, query_string, _opts) when byte_size(query_string) > 500 do
-    {:error, :bad_request, "Query too long (max 500 characters)"}
-  end
-
   def search_keyword(tenant_id, query_string, opts) do
     query_string = String.trim(query_string)
 
-    if query_string == "" do
-      {:error, :empty_query}
-    else
-      limit = opts |> Keyword.get(:limit, 20) |> max(1) |> min(100)
-      offset = opts |> Keyword.get(:offset, 0) |> max(0)
-      status = Keyword.get(opts, :status, :published)
+    cond do
+      query_string == "" ->
+        {:error, :empty_query}
 
-      base_query =
-        from(a in Article,
-          where: a.tenant_id == ^tenant_id,
-          where: fragment("search_vector @@ websearch_to_tsquery('english', ?)", ^query_string),
-          select: %{
-            id: a.id,
-            tenant_id: a.tenant_id,
-            project_id: a.project_id,
-            title: a.title,
-            category: a.category,
-            status: a.status,
-            tags: a.tags,
-            inserted_at: a.inserted_at,
-            updated_at: a.updated_at,
-            relevance_score:
-              fragment(
-                "ts_rank_cd(search_vector, websearch_to_tsquery('english', ?))",
-                ^query_string
-              ),
-            snippet:
-              fragment(
-                "ts_headline('english', body, websearch_to_tsquery('english', ?), 'StartSel=**, StopSel=**, MaxWords=35, MinWords=15')",
-                ^query_string
-              )
-          },
-          order_by: [
-            desc:
-              fragment(
-                "ts_rank_cd(search_vector, websearch_to_tsquery('english', ?))",
-                ^query_string
-              )
-          ]
-        )
+      String.length(query_string) > 500 ->
+        {:error, :bad_request, "Query too long (max 500 characters)"}
 
-      filtered_query = apply_search_filters(base_query, status, opts)
+      true ->
+        limit = opts |> Keyword.get(:limit, 20) |> max(1) |> min(100)
+        offset = opts |> Keyword.get(:offset, 0) |> max(0)
+        status = Keyword.get(opts, :status, :published)
 
-      count_query = from(q in subquery(filtered_query), select: count())
-      total_count = AdminRepo.one(count_query)
+        base_query =
+          from(a in Article,
+            where: a.tenant_id == ^tenant_id,
+            where: fragment("search_vector @@ websearch_to_tsquery('english', ?)", ^query_string),
+            select: %{
+              id: a.id,
+              tenant_id: a.tenant_id,
+              project_id: a.project_id,
+              title: a.title,
+              category: a.category,
+              status: a.status,
+              tags: a.tags,
+              inserted_at: a.inserted_at,
+              updated_at: a.updated_at,
+              relevance_score:
+                fragment(
+                  "ts_rank_cd(search_vector, websearch_to_tsquery('english', ?))",
+                  ^query_string
+                ),
+              snippet:
+                fragment(
+                  "ts_headline('english', body, websearch_to_tsquery('english', ?), 'StartSel=**, StopSel=**, MaxWords=35, MinWords=15')",
+                  ^query_string
+                )
+            },
+            order_by: [
+              desc:
+                fragment(
+                  "ts_rank_cd(search_vector, websearch_to_tsquery('english', ?))",
+                  ^query_string
+                )
+            ]
+          )
 
-      results =
-        filtered_query
-        |> limit(^limit)
-        |> offset(^offset)
-        |> AdminRepo.all()
+        filtered_query = apply_search_filters(base_query, status, opts)
 
-      {:ok, %{results: results, meta: %{total_count: total_count, limit: limit, offset: offset}}}
+        count_query = from(q in subquery(filtered_query), select: count())
+        total_count = AdminRepo.one(count_query)
+
+        results =
+          filtered_query
+          |> limit(^limit)
+          |> offset(^offset)
+          |> AdminRepo.all()
+
+        {:ok,
+         %{results: results, meta: %{total_count: total_count, limit: limit, offset: offset}}}
     end
   end
 

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -195,6 +195,111 @@ defmodule Loopctl.Knowledge do
   end
 
   @doc """
+  Full-text keyword search on articles using PostgreSQL tsvector.
+
+  Uses `websearch_to_tsquery` for parsing the query string, weighted
+  `ts_rank_cd` for relevance ranking, and `ts_headline` for snippet
+  generation.
+
+  ## Parameters
+
+  - `tenant_id` -- the tenant UUID
+  - `query_string` -- the search query (max 500 characters)
+  - `opts` -- keyword list with:
+    - `:project_id` -- filter by project UUID (optional)
+    - `:category` -- filter by category atom (optional)
+    - `:status` -- filter by status atom (default: `:published`)
+    - `:tags` -- filter by tag overlap, articles matching ANY tag (optional)
+    - `:limit` -- max results to return (default 20, max 100, min 1)
+    - `:offset` -- results to skip for pagination (default 0)
+
+  ## Returns
+
+  - `{:ok, %{results: [map()], meta: map()}}` on success
+  - `{:error, :empty_query}` when query is empty or nil
+  - `{:error, :bad_request, String.t()}` when query exceeds 500 characters
+  """
+  @spec search_keyword(Ecto.UUID.t(), String.t() | nil, keyword()) ::
+          {:ok, %{results: [map()], meta: map()}}
+          | {:error, atom()}
+          | {:error, atom(), String.t()}
+  def search_keyword(tenant_id, query_string, opts \\ [])
+
+  def search_keyword(_tenant_id, nil, _opts), do: {:error, :empty_query}
+  def search_keyword(_tenant_id, "", _opts), do: {:error, :empty_query}
+
+  def search_keyword(_tenant_id, query_string, _opts) when byte_size(query_string) > 500 do
+    {:error, :bad_request, "Query too long (max 500 characters)"}
+  end
+
+  def search_keyword(tenant_id, query_string, opts) do
+    query_string = String.trim(query_string)
+
+    if query_string == "" do
+      {:error, :empty_query}
+    else
+      limit = opts |> Keyword.get(:limit, 20) |> max(1) |> min(100)
+      offset = opts |> Keyword.get(:offset, 0) |> max(0)
+      status = Keyword.get(opts, :status, :published)
+
+      base_query =
+        from(a in Article,
+          where: a.tenant_id == ^tenant_id,
+          where: fragment("search_vector @@ websearch_to_tsquery('english', ?)", ^query_string),
+          select: %{
+            id: a.id,
+            tenant_id: a.tenant_id,
+            project_id: a.project_id,
+            title: a.title,
+            category: a.category,
+            status: a.status,
+            tags: a.tags,
+            inserted_at: a.inserted_at,
+            updated_at: a.updated_at,
+            relevance_score:
+              fragment(
+                "ts_rank_cd(search_vector, websearch_to_tsquery('english', ?))",
+                ^query_string
+              ),
+            snippet:
+              fragment(
+                "ts_headline('english', body, websearch_to_tsquery('english', ?), 'StartSel=**, StopSel=**, MaxWords=35, MinWords=15')",
+                ^query_string
+              )
+          },
+          order_by: [
+            desc:
+              fragment(
+                "ts_rank_cd(search_vector, websearch_to_tsquery('english', ?))",
+                ^query_string
+              )
+          ]
+        )
+
+      filtered_query = apply_search_filters(base_query, status, opts)
+
+      count_query = from(q in subquery(filtered_query), select: count())
+      total_count = AdminRepo.one(count_query)
+
+      results =
+        filtered_query
+        |> limit(^limit)
+        |> offset(^offset)
+        |> AdminRepo.all()
+
+      {:ok, %{results: results, meta: %{total_count: total_count, limit: limit, offset: offset}}}
+    end
+  end
+
+  defp apply_search_filters(query, status, opts) do
+    query
+    |> maybe_filter_by_status(status)
+    |> maybe_filter_by_project_id(Keyword.get(opts, :project_id))
+    |> maybe_filter_by_category(Keyword.get(opts, :category))
+    |> maybe_filter_by_tags(Keyword.get(opts, :tags))
+  end
+
+  @doc """
   Updates an existing article.
 
   Uses `update_changeset` and records the `article.updated` audit event.

--- a/priv/repo/migrations/20260410021836_add_search_vector_to_articles.exs
+++ b/priv/repo/migrations/20260410021836_add_search_vector_to_articles.exs
@@ -1,0 +1,20 @@
+defmodule Loopctl.Repo.Migrations.AddSearchVectorToArticles do
+  use Ecto.Migration
+
+  def up do
+    execute """
+    ALTER TABLE articles ADD COLUMN search_vector tsvector
+    GENERATED ALWAYS AS (
+      setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
+      setweight(to_tsvector('english', coalesce(body, '')), 'B')
+    ) STORED
+    """
+
+    execute "CREATE INDEX articles_search_vector_idx ON articles USING GIN (search_vector)"
+  end
+
+  def down do
+    execute "DROP INDEX IF EXISTS articles_search_vector_idx"
+    execute "ALTER TABLE articles DROP COLUMN IF EXISTS search_vector"
+  end
+end

--- a/test/loopctl/knowledge_search_test.exs
+++ b/test/loopctl/knowledge_search_test.exs
@@ -1,0 +1,419 @@
+defmodule Loopctl.KnowledgeSearchTest do
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.Knowledge
+
+  defp setup_tenant do
+    tenant = fixture(:tenant)
+    %{tenant: tenant}
+  end
+
+  defp setup_tenant_with_project do
+    tenant = fixture(:tenant)
+    project = fixture(:project, %{tenant_id: tenant.id})
+    %{tenant: tenant, project: project}
+  end
+
+  defp create_published_article(tenant_id, attrs) do
+    fixture(
+      :article,
+      Map.merge(
+        %{tenant_id: tenant_id, status: :published},
+        Enum.into(attrs, %{})
+      )
+    )
+  end
+
+  # --- TC-20.1.1: Ranked results with snippets (title match ranks higher) ---
+
+  describe "search_keyword/3 - ranked results with snippets" do
+    test "returns results ranked by relevance with title matches scoring higher" do
+      %{tenant: tenant} = setup_tenant()
+
+      # Article with match only in body
+      _body_match =
+        create_published_article(tenant.id, %{
+          title: "General Guidelines",
+          body: "When working with PostgreSQL databases, indexing is crucial for performance."
+        })
+
+      # Article with match in title (should rank higher due to weight 'A')
+      _title_match =
+        create_published_article(tenant.id, %{
+          title: "PostgreSQL Performance Tuning",
+          body: "This article covers various optimization strategies."
+        })
+
+      assert {:ok, %{results: results, meta: meta}} =
+               Knowledge.search_keyword(tenant.id, "PostgreSQL")
+
+      assert length(results) == 2
+      assert meta.total_count == 2
+
+      # Title match should rank higher (weight A > weight B)
+      [first, second] = results
+      assert first.title == "PostgreSQL Performance Tuning"
+      assert second.title == "General Guidelines"
+
+      # Both should have relevance scores
+      assert is_float(first.relevance_score)
+      assert is_float(second.relevance_score)
+      assert first.relevance_score >= second.relevance_score
+    end
+
+    test "results include snippet with highlighted terms" do
+      %{tenant: tenant} = setup_tenant()
+
+      create_published_article(tenant.id, %{
+        title: "Indexing Strategies",
+        body:
+          "PostgreSQL provides several indexing strategies for optimizing query performance. GIN indexes are particularly useful for full-text search operations."
+      })
+
+      assert {:ok, %{results: [result]}} =
+               Knowledge.search_keyword(tenant.id, "indexing")
+
+      assert is_binary(result.snippet)
+      # Snippets use ** as start/stop markers
+      assert result.snippet =~ "**"
+    end
+  end
+
+  # --- TC-20.1.2: Filters by project_id, category, tags ---
+
+  describe "search_keyword/3 - filters" do
+    test "filters by project_id" do
+      %{tenant: tenant, project: project} = setup_tenant_with_project()
+      other_project = fixture(:project, %{tenant_id: tenant.id})
+
+      create_published_article(tenant.id, %{
+        title: "Ecto Patterns for Project A",
+        body: "Use Ecto.Multi for atomic operations.",
+        project_id: project.id
+      })
+
+      create_published_article(tenant.id, %{
+        title: "Ecto Patterns for Project B",
+        body: "Use Ecto.Multi for atomic transactions.",
+        project_id: other_project.id
+      })
+
+      assert {:ok, %{results: results}} =
+               Knowledge.search_keyword(tenant.id, "Ecto", project_id: project.id)
+
+      assert length(results) == 1
+      assert hd(results).project_id == project.id
+    end
+
+    test "filters by category" do
+      %{tenant: tenant} = setup_tenant()
+
+      create_published_article(tenant.id, %{
+        title: "Database Convention",
+        body: "Always use migrations for schema changes.",
+        category: :convention
+      })
+
+      create_published_article(tenant.id, %{
+        title: "Database Pattern",
+        body: "Use database connection pooling for scalability.",
+        category: :pattern
+      })
+
+      assert {:ok, %{results: results}} =
+               Knowledge.search_keyword(tenant.id, "database", category: :convention)
+
+      assert length(results) == 1
+      assert hd(results).category == :convention
+    end
+
+    test "filters by tags (overlap)" do
+      %{tenant: tenant} = setup_tenant()
+
+      create_published_article(tenant.id, %{
+        title: "Elixir Testing Guide",
+        body: "Write comprehensive tests for all modules.",
+        tags: ["elixir", "testing"]
+      })
+
+      create_published_article(tenant.id, %{
+        title: "Elixir Deployment Guide",
+        body: "Deploy your Elixir application to production.",
+        tags: ["elixir", "deployment"]
+      })
+
+      assert {:ok, %{results: results}} =
+               Knowledge.search_keyword(tenant.id, "Elixir", tags: ["testing"])
+
+      assert length(results) == 1
+      assert hd(results).title == "Elixir Testing Guide"
+    end
+  end
+
+  # --- TC-20.1.3: Default published-only, explicit status override ---
+
+  describe "search_keyword/3 - status filtering" do
+    test "defaults to published articles only" do
+      %{tenant: tenant} = setup_tenant()
+
+      create_published_article(tenant.id, %{
+        title: "Published GenServer Guide",
+        body: "Use GenServer for stateful processes."
+      })
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Draft GenServer Guide",
+        body: "Draft content about GenServer patterns.",
+        status: :draft
+      })
+
+      assert {:ok, %{results: results}} =
+               Knowledge.search_keyword(tenant.id, "GenServer")
+
+      assert length(results) == 1
+      assert hd(results).status == :published
+    end
+
+    test "explicit status override returns matching status" do
+      %{tenant: tenant} = setup_tenant()
+
+      create_published_article(tenant.id, %{
+        title: "Published OTP Guide",
+        body: "OTP supervision trees for fault tolerance."
+      })
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Draft OTP Guide",
+        body: "Draft content about OTP patterns.",
+        status: :draft
+      })
+
+      assert {:ok, %{results: results}} =
+               Knowledge.search_keyword(tenant.id, "OTP", status: :draft)
+
+      assert length(results) == 1
+      assert hd(results).status == :draft
+    end
+  end
+
+  # --- TC-20.1.4: Pagination (limit/offset with total_count) ---
+
+  describe "search_keyword/3 - pagination" do
+    test "respects limit and offset with correct total_count" do
+      %{tenant: tenant} = setup_tenant()
+
+      for i <- 1..5 do
+        create_published_article(tenant.id, %{
+          title: "Phoenix LiveView Pattern #{i}",
+          body: "LiveView pattern number #{i} for building interactive UIs."
+        })
+      end
+
+      assert {:ok, %{results: results, meta: meta}} =
+               Knowledge.search_keyword(tenant.id, "LiveView", limit: 2, offset: 0)
+
+      assert length(results) == 2
+      assert meta.total_count == 5
+      assert meta.limit == 2
+      assert meta.offset == 0
+
+      # Second page
+      assert {:ok, %{results: page2, meta: meta2}} =
+               Knowledge.search_keyword(tenant.id, "LiveView", limit: 2, offset: 2)
+
+      assert length(page2) == 2
+      assert meta2.total_count == 5
+      assert meta2.offset == 2
+    end
+
+    test "defaults to limit 20 and offset 0" do
+      %{tenant: tenant} = setup_tenant()
+
+      create_published_article(tenant.id, %{
+        title: "Default Pagination Test",
+        body: "Testing default pagination values."
+      })
+
+      assert {:ok, %{meta: meta}} =
+               Knowledge.search_keyword(tenant.id, "pagination")
+
+      assert meta.limit == 20
+      assert meta.offset == 0
+    end
+
+    test "caps limit at 100" do
+      %{tenant: tenant} = setup_tenant()
+
+      create_published_article(tenant.id, %{
+        title: "Limit Cap Test",
+        body: "Testing that limit is capped at 100."
+      })
+
+      assert {:ok, %{meta: meta}} =
+               Knowledge.search_keyword(tenant.id, "limit", limit: 200)
+
+      assert meta.limit == 100
+    end
+
+    test "floors limit at 1" do
+      %{tenant: tenant} = setup_tenant()
+
+      create_published_article(tenant.id, %{
+        title: "Limit Floor Test",
+        body: "Testing that limit floors at 1."
+      })
+
+      assert {:ok, %{meta: meta}} =
+               Knowledge.search_keyword(tenant.id, "limit", limit: 0)
+
+      assert meta.limit == 1
+    end
+  end
+
+  # --- TC-20.1.5: Empty query returns {:error, :empty_query}; stop-words return empty results ---
+
+  describe "search_keyword/3 - empty and stop-word queries" do
+    test "empty string returns {:error, :empty_query}" do
+      %{tenant: tenant} = setup_tenant()
+
+      assert {:error, :empty_query} = Knowledge.search_keyword(tenant.id, "")
+    end
+
+    test "nil returns {:error, :empty_query}" do
+      %{tenant: tenant} = setup_tenant()
+
+      assert {:error, :empty_query} = Knowledge.search_keyword(tenant.id, nil)
+    end
+
+    test "whitespace-only string returns {:error, :empty_query}" do
+      %{tenant: tenant} = setup_tenant()
+
+      assert {:error, :empty_query} = Knowledge.search_keyword(tenant.id, "   ")
+    end
+
+    test "stop-word-only query returns empty results" do
+      %{tenant: tenant} = setup_tenant()
+
+      create_published_article(tenant.id, %{
+        title: "Some Article",
+        body: "This is a test article with content."
+      })
+
+      # "the" is a common English stop word
+      assert {:ok, %{results: results}} =
+               Knowledge.search_keyword(tenant.id, "the")
+
+      assert results == []
+    end
+
+    test "query exceeding 500 characters returns {:error, :bad_request, message}" do
+      %{tenant: tenant} = setup_tenant()
+
+      long_query = String.duplicate("a", 501)
+
+      assert {:error, :bad_request, "Query too long (max 500 characters)"} =
+               Knowledge.search_keyword(tenant.id, long_query)
+    end
+  end
+
+  # --- TC-20.1.6: Tenant isolation ---
+
+  describe "search_keyword/3 - tenant isolation" do
+    test "tenant A cannot see tenant B's articles" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+
+      create_published_article(tenant_a.id, %{
+        title: "Tenant A Supervision Trees",
+        body: "Supervision trees for tenant A applications."
+      })
+
+      create_published_article(tenant_b.id, %{
+        title: "Tenant B Supervision Trees",
+        body: "Supervision trees for tenant B applications."
+      })
+
+      # Tenant A only sees their own articles
+      assert {:ok, %{results: results_a}} =
+               Knowledge.search_keyword(tenant_a.id, "Supervision")
+
+      assert length(results_a) == 1
+      assert hd(results_a).tenant_id == tenant_a.id
+
+      # Tenant B only sees their own articles
+      assert {:ok, %{results: results_b}} =
+               Knowledge.search_keyword(tenant_b.id, "Supervision")
+
+      assert length(results_b) == 1
+      assert hd(results_b).tenant_id == tenant_b.id
+    end
+  end
+
+  # --- TC-20.1.7: search_vector updates when title/body changes ---
+
+  describe "search_keyword/3 - search_vector updates on article change" do
+    test "search_vector updates when title changes" do
+      %{tenant: tenant} = setup_tenant()
+
+      article =
+        create_published_article(tenant.id, %{
+          title: "Original Mnesia Guide",
+          body: "Content about distributed databases."
+        })
+
+      # Should find by original title
+      assert {:ok, %{results: [_]}} =
+               Knowledge.search_keyword(tenant.id, "Mnesia")
+
+      # Update the title
+      assert {:ok, _updated} =
+               Knowledge.update_article(tenant.id, article.id, %{
+                 title: "Updated ETS Guide"
+               })
+
+      # Should no longer match old title
+      assert {:ok, %{results: []}} =
+               Knowledge.search_keyword(tenant.id, "Mnesia")
+
+      # Should match new title
+      assert {:ok, %{results: [result]}} =
+               Knowledge.search_keyword(tenant.id, "ETS")
+
+      assert result.title == "Updated ETS Guide"
+    end
+
+    test "search_vector updates when body changes" do
+      %{tenant: tenant} = setup_tenant()
+
+      article =
+        create_published_article(tenant.id, %{
+          title: "Architecture Guide",
+          body: "Microservices architecture with Kubernetes orchestration."
+        })
+
+      # Should find by original body content
+      assert {:ok, %{results: [_]}} =
+               Knowledge.search_keyword(tenant.id, "Kubernetes")
+
+      # Update the body
+      assert {:ok, _updated} =
+               Knowledge.update_article(tenant.id, article.id, %{
+                 body: "Monolithic architecture with Phoenix framework."
+               })
+
+      # Should no longer match old body
+      assert {:ok, %{results: []}} =
+               Knowledge.search_keyword(tenant.id, "Kubernetes")
+
+      # Should match new body
+      assert {:ok, %{results: [result]}} =
+               Knowledge.search_keyword(tenant.id, "Phoenix")
+
+      assert result.title == "Architecture Guide"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add PostgreSQL generated tsvector column (`search_vector`) to the articles table with weighted title (A) and body (B) fields, backed by a GIN index
- Implement `Knowledge.search_keyword/3` with `websearch_to_tsquery`, relevance ranking via `ts_rank_cd`, snippet highlighting via `ts_headline`, filtering (project_id, category, tags, status), and pagination
- 19 tests covering ranked results, snippets, filters, status defaults, pagination, empty/stop-word queries, tenant isolation, and search_vector auto-update on article changes

## Test plan

- [x] TC-20.1.1: Ranked results with snippets (title match ranks higher)
- [x] TC-20.1.2: Filters by project_id, category, tags
- [x] TC-20.1.3: Default published-only, explicit status override
- [x] TC-20.1.4: Pagination (limit/offset with total_count)
- [x] TC-20.1.5: Empty query returns `{:error, :empty_query}`; stop-words return empty results
- [x] TC-20.1.6: Tenant isolation
- [x] TC-20.1.7: search_vector updates when title/body changes
- [x] All 1724 tests pass, `mix precommit` clean