### PR TITLE
US-23.5: Knowledge Index Endpoint

### DIFF
--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -201,6 +201,94 @@ defmodule Loopctl.Knowledge do
   end
 
   @doc """
+  Returns a lightweight knowledge index of published articles.
+
+  The index includes only metadata fields (no body, embedding, or metadata)
+  and groups results by category, sorted by `updated_at` descending within
+  each group.
+
+  Results are capped at 1000 articles. When the total exceeds 1000,
+  `meta.truncated` is set to `true` and `meta.total_count` reflects the
+  full count.
+
+  ## Parameters
+
+  - `tenant_id` -- the tenant UUID
+  - `opts` -- keyword list with:
+    - `:project_id` -- when provided, includes both tenant-wide (nil project_id)
+      and project-specific articles
+
+  ## Returns
+
+  - `{:ok, %{articles: %{category => [map()]}, meta: map()}}`
+  """
+  @spec list_index(Ecto.UUID.t(), keyword()) ::
+          {:ok,
+           %{
+             articles: %{optional(String.t()) => [map()]},
+             meta: %{
+               total_count: non_neg_integer(),
+               categories: %{optional(String.t()) => non_neg_integer()},
+               truncated: boolean()
+             }
+           }}
+  def list_index(tenant_id, opts \\ []) do
+    project_id = Keyword.get(opts, :project_id)
+
+    query =
+      from(a in Article,
+        where: a.tenant_id == ^tenant_id,
+        where: a.status == :published,
+        select: %{
+          id: a.id,
+          title: a.title,
+          category: a.category,
+          tags: a.tags,
+          status: a.status,
+          updated_at: a.updated_at
+        },
+        order_by: [asc: a.category, desc: a.updated_at]
+      )
+
+    query =
+      if project_id do
+        where(query, [a], is_nil(a.project_id) or a.project_id == ^project_id)
+      else
+        query
+      end
+
+    # Get total count via subquery
+    count_query = from(q in subquery(query), select: count())
+    total_count = AdminRepo.one(count_query)
+
+    # Cap at 1000
+    results =
+      query
+      |> limit(1000)
+      |> AdminRepo.all()
+
+    truncated = total_count > 1000
+
+    # Group by category (convert enum atoms to strings for JSON)
+    grouped =
+      Enum.group_by(results, fn article ->
+        to_string(article.category)
+      end)
+
+    categories = Map.new(grouped, fn {cat, arts} -> {cat, length(arts)} end)
+
+    {:ok,
+     %{
+       articles: grouped,
+       meta: %{
+         total_count: total_count,
+         categories: categories,
+         truncated: truncated
+       }
+     }}
+  end
+
+  @doc """
   Full-text keyword search on articles using PostgreSQL tsvector.
 
   Uses `websearch_to_tsquery` for parsing the query string, weighted

--- a/lib/loopctl_web/controllers/knowledge_index_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_index_controller.ex
@@ -1,0 +1,77 @@
+defmodule LoopctlWeb.KnowledgeIndexController do
+  @moduledoc """
+  Controller for the lightweight knowledge catalog endpoint.
+
+  - `GET /api/v1/knowledge/index` -- tenant-wide catalog of published articles (agent+)
+  - `GET /api/v1/projects/:project_id/knowledge/index` -- project-scoped catalog (agent+)
+
+  Returns article metadata (no body) grouped by category, capped at 1000 articles.
+  """
+
+  use LoopctlWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Loopctl.ApiSpec.Schemas
+  alias Loopctl.Knowledge
+
+  action_fallback LoopctlWeb.FallbackController
+
+  plug LoopctlWeb.Plugs.RequireRole, role: :agent
+
+  tags(["Knowledge Wiki"])
+
+  operation(:index,
+    summary: "Knowledge index",
+    description:
+      "Returns a lightweight catalog of published articles grouped by category. " <>
+        "Each article includes only id, title, category, tags, status, and updated_at. " <>
+        "When called via GET /projects/:project_id/knowledge/index, includes both " <>
+        "tenant-wide and project-specific articles. Capped at 1000 articles. " <>
+        "Role: agent+.",
+    parameters: [
+      project_id: [
+        in: :path,
+        type: :string,
+        description: "Project UUID (optional, for project-scoped index)",
+        required: false
+      ]
+    ],
+    responses: %{
+      200 =>
+        {"Knowledge index", "application/json",
+         %OpenApiSpex.Schema{
+           type: :object,
+           properties: %{
+             data: %OpenApiSpex.Schema{
+               type: :object,
+               description: "Articles grouped by category"
+             },
+             meta: %OpenApiSpex.Schema{
+               type: :object,
+               properties: %{
+                 total_count: %OpenApiSpex.Schema{type: :integer},
+                 categories: %OpenApiSpex.Schema{type: :object},
+                 truncated: %OpenApiSpex.Schema{type: :boolean}
+               }
+             }
+           }
+         }},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  @doc "GET /api/v1/knowledge/index or GET /api/v1/projects/:project_id/knowledge/index"
+  def index(conn, params) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+
+    opts =
+      case params["project_id"] do
+        nil -> []
+        project_id -> [project_id: project_id]
+      end
+
+    {:ok, result} = Knowledge.list_index(tenant_id, opts)
+
+    json(conn, LoopctlWeb.KnowledgeIndexJSON.index(result))
+  end
+end

--- a/lib/loopctl_web/controllers/knowledge_index_json.ex
+++ b/lib/loopctl_web/controllers/knowledge_index_json.ex
@@ -1,0 +1,34 @@
+defmodule LoopctlWeb.KnowledgeIndexJSON do
+  @moduledoc """
+  JSON rendering helpers for the knowledge index endpoint.
+
+  Renders articles grouped by category with lightweight metadata
+  (no body, embedding, or full metadata).
+  """
+
+  @doc "Renders the knowledge index with articles grouped by category."
+  def index(%{articles: grouped, meta: meta}) do
+    %{
+      data:
+        Map.new(grouped, fn {category, articles} ->
+          {category, Enum.map(articles, &article_summary/1)}
+        end),
+      meta: %{
+        total_count: meta.total_count,
+        categories: meta.categories,
+        truncated: meta.truncated
+      }
+    }
+  end
+
+  defp article_summary(article) do
+    %{
+      id: article.id,
+      title: article.title,
+      category: to_string(article.category),
+      tags: article.tags,
+      status: to_string(article.status),
+      updated_at: article.updated_at
+    }
+  end
+end

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -233,8 +233,12 @@ defmodule LoopctlWeb.Router do
     # Knowledge Wiki (Epic 19)
     resources "/articles", ArticleController, except: [:new, :edit]
 
+    # Knowledge Index (lightweight catalog)
+    get "/knowledge/index", KnowledgeIndexController, :index
+
     scope "/projects/:project_id" do
       resources "/articles", ArticleController, only: [:create, :index], as: :project_article
+      get "/knowledge/index", KnowledgeIndexController, :index
     end
 
     # ArticleLink management

--- a/test/loopctl_web/controllers/knowledge_index_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_index_controller_test.exs
@@ -1,0 +1,290 @@
+defmodule LoopctlWeb.KnowledgeIndexControllerTest do
+  use LoopctlWeb.ConnCase, async: true
+
+  setup :verify_on_exit!
+
+  defp auth_conn(conn, raw_key) do
+    put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  describe "GET /api/v1/knowledge/index" do
+    test "returns lightweight catalog grouped by category, drafts excluded", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      # Published articles in different categories
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Pattern A",
+        category: :pattern,
+        status: :published,
+        tags: ["elixir"]
+      })
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Convention B",
+        category: :convention,
+        status: :published,
+        tags: ["naming"]
+      })
+
+      # Draft article -- should be excluded
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Draft Article",
+        category: :finding,
+        status: :draft,
+        tags: []
+      })
+
+      # Archived article -- should be excluded
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Old Article",
+        category: :decision,
+        status: :archived,
+        tags: []
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/index")
+
+      body = json_response(conn, 200)
+
+      # Should have data grouped by category
+      assert is_map(body["data"])
+      assert Map.has_key?(body["data"], "pattern")
+      assert Map.has_key?(body["data"], "convention")
+      refute Map.has_key?(body["data"], "finding")
+      refute Map.has_key?(body["data"], "decision")
+
+      # Verify article fields are lightweight (no body/embedding/metadata)
+      [pattern_article] = body["data"]["pattern"]
+      assert pattern_article["id"]
+      assert pattern_article["title"] == "Pattern A"
+      assert pattern_article["category"] == "pattern"
+      assert pattern_article["tags"] == ["elixir"]
+      assert pattern_article["status"] == "published"
+      assert pattern_article["updated_at"]
+      refute Map.has_key?(pattern_article, "body")
+      refute Map.has_key?(pattern_article, "embedding")
+      refute Map.has_key?(pattern_article, "metadata")
+
+      # Verify meta
+      assert body["meta"]["total_count"] == 2
+      assert body["meta"]["truncated"] == false
+      assert body["meta"]["categories"]["pattern"] == 1
+      assert body["meta"]["categories"]["convention"] == 1
+    end
+
+    test "returns empty result when no published articles exist", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/index")
+
+      body = json_response(conn, 200)
+      assert body["data"] == %{}
+      assert body["meta"]["total_count"] == 0
+      assert body["meta"]["truncated"] == false
+      assert body["meta"]["categories"] == %{}
+    end
+
+    test "unauthenticated returns 401", %{conn: conn} do
+      conn = get(conn, ~p"/api/v1/knowledge/index")
+      assert json_response(conn, 401)
+    end
+  end
+
+  describe "GET /api/v1/projects/:project_id/knowledge/index" do
+    test "project-scoped includes tenant-wide + project-specific articles", %{conn: conn} do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      other_project = fixture(:project, %{tenant_id: tenant.id})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      # Tenant-wide article (nil project_id) -- should be included
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Tenant Wide Pattern",
+        category: :pattern,
+        status: :published
+      })
+
+      # Project-specific article -- should be included
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        project_id: project.id,
+        title: "Project Convention",
+        category: :convention,
+        status: :published
+      })
+
+      # Other project's article -- should be excluded
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        project_id: other_project.id,
+        title: "Other Project Finding",
+        category: :finding,
+        status: :published
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/projects/#{project.id}/knowledge/index")
+
+      body = json_response(conn, 200)
+
+      assert body["meta"]["total_count"] == 2
+      assert Map.has_key?(body["data"], "pattern")
+      assert Map.has_key?(body["data"], "convention")
+      refute Map.has_key?(body["data"], "finding")
+
+      # Verify tenant-wide article is included
+      [pattern] = body["data"]["pattern"]
+      assert pattern["title"] == "Tenant Wide Pattern"
+
+      # Verify project-specific article is included
+      [convention] = body["data"]["convention"]
+      assert convention["title"] == "Project Convention"
+    end
+  end
+
+  describe "tenant isolation" do
+    test "tenant A cannot see tenant B's articles", %{conn: conn} do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      {raw_key_a, _} = fixture(:api_key, %{tenant_id: tenant_a.id, role: :agent})
+
+      fixture(:article, %{
+        tenant_id: tenant_a.id,
+        title: "Tenant A Article",
+        category: :pattern,
+        status: :published
+      })
+
+      fixture(:article, %{
+        tenant_id: tenant_b.id,
+        title: "Tenant B Article",
+        category: :pattern,
+        status: :published
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key_a)
+        |> get(~p"/api/v1/knowledge/index")
+
+      body = json_response(conn, 200)
+
+      assert body["meta"]["total_count"] == 1
+      [article] = body["data"]["pattern"]
+      assert article["title"] == "Tenant A Article"
+    end
+  end
+
+  describe "sorting within category" do
+    test "articles are sorted by updated_at desc within each category", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      # Create articles with different updated_at times
+      older =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Older Pattern",
+          category: :pattern,
+          status: :published
+        })
+
+      newer =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Newer Pattern",
+          category: :pattern,
+          status: :published
+        })
+
+      # Force different updated_at timestamps
+      now = DateTime.utc_now()
+      one_hour_ago = DateTime.add(now, -3600, :second)
+
+      import Ecto.Query
+
+      Loopctl.AdminRepo.update_all(
+        from(a in Loopctl.Knowledge.Article, where: a.id == ^older.id),
+        set: [updated_at: one_hour_ago]
+      )
+
+      Loopctl.AdminRepo.update_all(
+        from(a in Loopctl.Knowledge.Article, where: a.id == ^newer.id),
+        set: [updated_at: now]
+      )
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/index")
+
+      body = json_response(conn, 200)
+
+      patterns = body["data"]["pattern"]
+      assert length(patterns) == 2
+      # Newer should come first (desc order)
+      assert Enum.at(patterns, 0)["title"] == "Newer Pattern"
+      assert Enum.at(patterns, 1)["title"] == "Older Pattern"
+    end
+  end
+
+  describe "correct grouping with many articles" do
+    test "20 articles return correct grouping (no N+1)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      categories = [:pattern, :convention, :decision, :finding, :reference]
+
+      # Create 20 published articles (4 per category)
+      for i <- 1..20 do
+        category = Enum.at(categories, rem(i - 1, 5))
+
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Article #{i}",
+          category: category,
+          status: :published,
+          tags: ["tag-#{i}"]
+        })
+      end
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/index")
+
+      body = json_response(conn, 200)
+
+      assert body["meta"]["total_count"] == 20
+      assert body["meta"]["truncated"] == false
+
+      # All 5 categories should be present
+      assert map_size(body["data"]) == 5
+
+      # Each category should have exactly 4 articles
+      for {_cat, articles} <- body["data"] do
+        assert length(articles) == 4
+      end
+
+      # Category counts should match
+      for {cat, count} <- body["meta"]["categories"] do
+        assert count == 4, "Expected category #{cat} to have 4 articles, got #{count}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add Knowledge.list_index/2 context function returning published article metadata grouped by category
- Add KnowledgeIndexController with two routes: tenant-wide (GET /knowledge/index) and project-scoped (GET /projects/:project_id/knowledge/index)
- Project-scoped endpoint merges tenant-wide (nil project_id) + project-specific articles
- Response capped at 1000 articles with meta.truncated flag when exceeded

## Test plan
- [x] Returns lightweight catalog grouped by category, drafts/archived excluded (TC-20.5.1)
- [x] Project-scoped includes tenant-wide + project-specific articles (TC-20.5.2)
- [x] Tenant isolation: tenant A cannot see tenant B articles (TC-20.5.3)
- [x] Sorted by updated_at desc within each category (TC-20.5.4)
- [x] Unauthenticated returns 401 (TC-20.5.5)
- [x] 20 articles return correct grouping, single query (TC-20.5.6)
- [x] Empty result when no published articles exist
- [x] mix precommit passes (1781 tests, 0 failures, credo clean, dialyzer clean)