### PR TITLE
US-23.6: Search API Endpoint

### DIFF
--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -1221,6 +1221,20 @@ defmodule Loopctl.Knowledge do
     :ok
   end
 
+  @doc """
+  Generate an embedding for the given text with circuit breaker and timeout protection.
+
+  Wraps the configured embedding client with:
+  - Circuit breaker (opens after #{@failure_threshold} failures within #{@failure_window_seconds}s)
+  - 5-second Task.async timeout
+  - Crash rescue handler
+
+  Returns `{:ok, embedding}` or `{:error, reason}`.
+  """
+  def generate_embedding(query_string) do
+    try_generate_embedding(query_string)
+  end
+
   defp try_generate_embedding(query_string) do
     ensure_circuit_breaker_table()
 

--- a/lib/loopctl_web/controllers/knowledge_search_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_search_controller.ex
@@ -1,0 +1,260 @@
+defmodule LoopctlWeb.KnowledgeSearchController do
+  @moduledoc """
+  Controller for the unified knowledge search endpoint.
+
+  - `GET /api/v1/knowledge/search` -- search articles by keyword, semantic, or combined mode (agent+)
+
+  Supports three search modes:
+
+  - `keyword` -- full-text search using PostgreSQL ts_rank_cd
+  - `semantic` -- vector similarity search via pgvector (embedding generated on-the-fly)
+  - `combined` (default) -- weighted merge of keyword + semantic scores with graceful fallback
+
+  Returns article metadata with a score and snippet (max 300 chars). Never returns the full body.
+  """
+
+  use LoopctlWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Loopctl.ApiSpec.Schemas
+  alias Loopctl.Knowledge
+
+  action_fallback LoopctlWeb.FallbackController
+
+  plug LoopctlWeb.Plugs.RequireRole, role: :agent
+
+  tags(["Knowledge Wiki"])
+
+  @valid_modes ~w(keyword semantic combined)
+
+  operation(:search,
+    summary: "Search knowledge articles",
+    description:
+      "Unified search endpoint supporting keyword, semantic, and combined modes. " <>
+        "Returns article metadata with scores and snippets (max 300 chars). " <>
+        "No full body is returned. Combined mode is the default and falls back to " <>
+        "keyword-only if embedding generation fails. Role: agent+.",
+    parameters: [
+      q: [
+        in: :query,
+        type: :string,
+        description: "Search query (required, max 500 characters)",
+        required: true
+      ],
+      mode: [
+        in: :query,
+        type: :string,
+        description: "Search mode: keyword, semantic, or combined (default: combined)",
+        required: false
+      ],
+      project_id: [
+        in: :query,
+        type: :string,
+        description: "Filter by project UUID",
+        required: false
+      ],
+      category: [
+        in: :query,
+        type: :string,
+        description: "Filter by category",
+        required: false
+      ],
+      tags: [
+        in: :query,
+        type: :string,
+        description: "Comma-separated tags to filter by",
+        required: false
+      ],
+      limit: [
+        in: :query,
+        type: :integer,
+        description: "Max results to return (default 10, max 50)",
+        required: false
+      ],
+      offset: [
+        in: :query,
+        type: :integer,
+        description: "Results to skip for pagination (default 0)",
+        required: false
+      ]
+    ],
+    responses: %{
+      200 =>
+        {"Search results", "application/json",
+         %OpenApiSpex.Schema{
+           type: :object,
+           properties: %{
+             data: %OpenApiSpex.Schema{
+               type: :array,
+               description: "Matching articles with scores and snippets"
+             },
+             meta: %OpenApiSpex.Schema{
+               type: :object,
+               properties: %{
+                 total_count: %OpenApiSpex.Schema{type: :integer},
+                 limit: %OpenApiSpex.Schema{type: :integer},
+                 offset: %OpenApiSpex.Schema{type: :integer}
+               }
+             }
+           }
+         }},
+      400 => {"Bad request", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError},
+      503 =>
+        {"Service unavailable", "application/json",
+         %OpenApiSpex.Schema{
+           type: :object,
+           properties: %{
+             error: %OpenApiSpex.Schema{
+               type: :object,
+               properties: %{
+                 status: %OpenApiSpex.Schema{type: :integer},
+                 message: %OpenApiSpex.Schema{type: :string}
+               }
+             }
+           }
+         }}
+    }
+  )
+
+  @doc "GET /api/v1/knowledge/search"
+  def search(conn, params) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+
+    with {:ok, q} <- validate_query(params),
+         {:ok, mode} <- validate_mode(params),
+         {:ok, opts} <- build_opts(params) do
+      case execute_search(tenant_id, q, mode, opts) do
+        {:ok, result} ->
+          json(conn, LoopctlWeb.KnowledgeSearchJSON.search(result, mode))
+
+        {:error, :embedding_unavailable} ->
+          conn
+          |> put_status(503)
+          |> json(%{error: %{status: 503, message: "Embedding service unavailable"}})
+
+        {:error, :empty_query} ->
+          {:error, :bad_request, "Query parameter 'q' is required and cannot be empty"}
+
+        {:error, :bad_request, msg} ->
+          {:error, :bad_request, msg}
+      end
+    end
+  end
+
+  defp validate_query(%{"q" => q}) when is_binary(q) do
+    trimmed = String.trim(q)
+
+    cond do
+      trimmed == "" ->
+        {:error, :bad_request, "Query parameter 'q' is required and cannot be empty"}
+
+      String.length(trimmed) > 500 ->
+        {:error, :bad_request, "Query parameter 'q' exceeds maximum length of 500 characters"}
+
+      true ->
+        {:ok, trimmed}
+    end
+  end
+
+  defp validate_query(_) do
+    {:error, :bad_request, "Query parameter 'q' is required and cannot be empty"}
+  end
+
+  defp validate_mode(%{"mode" => mode}) when mode in @valid_modes, do: {:ok, mode}
+
+  defp validate_mode(%{"mode" => _invalid}) do
+    {:error, :bad_request, "Invalid search mode. Valid modes: keyword, semantic, combined"}
+  end
+
+  defp validate_mode(_), do: {:ok, "combined"}
+
+  defp build_opts(params) do
+    opts =
+      []
+      |> maybe_add_opt(:project_id, params["project_id"])
+      |> maybe_add_category(params["category"])
+      |> maybe_add_tags(params["tags"])
+      |> maybe_add_limit(params["limit"])
+      |> maybe_add_offset(params["offset"])
+
+    {:ok, opts}
+  end
+
+  defp maybe_add_opt(opts, _key, nil), do: opts
+  defp maybe_add_opt(opts, _key, ""), do: opts
+  defp maybe_add_opt(opts, key, value), do: [{key, value} | opts]
+
+  defp maybe_add_category(opts, nil), do: opts
+  defp maybe_add_category(opts, ""), do: opts
+
+  defp maybe_add_category(opts, category) do
+    [{:category, String.to_existing_atom(category)} | opts]
+  rescue
+    ArgumentError -> opts
+  end
+
+  defp maybe_add_tags(opts, nil), do: opts
+  defp maybe_add_tags(opts, ""), do: opts
+
+  defp maybe_add_tags(opts, tags_str) do
+    tags =
+      tags_str
+      |> String.split(",")
+      |> Enum.map(&String.trim/1)
+      |> Enum.reject(&(&1 == ""))
+
+    if tags == [], do: opts, else: [{:tags, tags} | opts]
+  end
+
+  defp maybe_add_limit(opts, nil), do: [{:limit, 10} | opts]
+
+  defp maybe_add_limit(opts, value) when is_binary(value) do
+    case Integer.parse(value) do
+      {int, ""} -> [{:limit, int |> max(1) |> min(50)} | opts]
+      _ -> [{:limit, 10} | opts]
+    end
+  end
+
+  defp maybe_add_limit(opts, value) when is_integer(value) do
+    [{:limit, value |> max(1) |> min(50)} | opts]
+  end
+
+  defp maybe_add_limit(opts, _), do: [{:limit, 10} | opts]
+
+  defp maybe_add_offset(opts, nil), do: [{:offset, 0} | opts]
+
+  defp maybe_add_offset(opts, value) when is_binary(value) do
+    case Integer.parse(value) do
+      {int, ""} -> [{:offset, max(int, 0)} | opts]
+      _ -> [{:offset, 0} | opts]
+    end
+  end
+
+  defp maybe_add_offset(opts, value) when is_integer(value) do
+    [{:offset, max(value, 0)} | opts]
+  end
+
+  defp maybe_add_offset(opts, _), do: [{:offset, 0} | opts]
+
+  defp execute_search(tenant_id, q, "keyword", opts) do
+    Knowledge.search_keyword(tenant_id, q, opts)
+  end
+
+  defp execute_search(tenant_id, q, "semantic", opts) do
+    client = embedding_client()
+
+    case client.generate_embedding(q) do
+      {:ok, embedding} -> Knowledge.search_semantic(tenant_id, embedding, opts)
+      {:error, _} -> {:error, :embedding_unavailable}
+    end
+  end
+
+  defp execute_search(tenant_id, q, "combined", opts) do
+    Knowledge.search_combined(tenant_id, q, opts)
+  end
+
+  defp embedding_client do
+    Application.get_env(:loopctl, :embedding_client, Loopctl.Knowledge.EmbeddingClient)
+  end
+end

--- a/lib/loopctl_web/controllers/knowledge_search_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_search_controller.ex
@@ -242,9 +242,7 @@ defmodule LoopctlWeb.KnowledgeSearchController do
   end
 
   defp execute_search(tenant_id, q, "semantic", opts) do
-    client = embedding_client()
-
-    case client.generate_embedding(q) do
+    case Knowledge.generate_embedding(q) do
       {:ok, embedding} -> Knowledge.search_semantic(tenant_id, embedding, opts)
       {:error, _} -> {:error, :embedding_unavailable}
     end
@@ -252,9 +250,5 @@ defmodule LoopctlWeb.KnowledgeSearchController do
 
   defp execute_search(tenant_id, q, "combined", opts) do
     Knowledge.search_combined(tenant_id, q, opts)
-  end
-
-  defp embedding_client do
-    Application.get_env(:loopctl, :embedding_client, Loopctl.Knowledge.EmbeddingClient)
   end
 end

--- a/lib/loopctl_web/controllers/knowledge_search_json.ex
+++ b/lib/loopctl_web/controllers/knowledge_search_json.ex
@@ -1,0 +1,82 @@
+defmodule LoopctlWeb.KnowledgeSearchJSON do
+  @moduledoc """
+  JSON rendering helpers for the knowledge search endpoint.
+
+  Renders search results with a unified `score` field that maps to the
+  appropriate score key based on search mode:
+
+  - `keyword` -> `relevance_score`
+  - `semantic` -> `similarity_score`
+  - `combined` -> `final_score`
+
+  Snippets are truncated to 300 characters maximum.
+  Full article body is never included.
+  """
+
+  @max_snippet_length 300
+
+  @doc "Renders search results with unified score field and truncated snippets."
+  def search(%{results: results, meta: meta}, mode) do
+    %{
+      data: Enum.map(results, &render_result(&1, mode)),
+      meta: render_meta(meta)
+    }
+  end
+
+  defp render_result(result, mode) do
+    base = %{
+      id: result[:id] || result.id,
+      title: result[:title] || result.title,
+      category: to_string(result[:category] || result.category),
+      tags: result[:tags] || result.tags || [],
+      score: extract_score(result, mode)
+    }
+
+    maybe_add_snippet(base, result)
+  end
+
+  defp extract_score(result, "keyword") do
+    result[:relevance_score] || 0.0
+  end
+
+  defp extract_score(result, "semantic") do
+    result[:similarity_score] || 0.0
+  end
+
+  defp extract_score(result, "combined") do
+    result[:final_score] || 0.0
+  end
+
+  defp maybe_add_snippet(base, result) do
+    case result[:snippet] do
+      nil -> base
+      snippet -> Map.put(base, :snippet, truncate_snippet(snippet))
+    end
+  end
+
+  defp truncate_snippet(snippet) when is_binary(snippet) do
+    if String.length(snippet) > @max_snippet_length do
+      snippet
+      |> String.slice(0, @max_snippet_length)
+      |> Kernel.<>("...")
+    else
+      snippet
+    end
+  end
+
+  defp truncate_snippet(_), do: nil
+
+  defp render_meta(meta) do
+    base = %{
+      total_count: meta[:total_count] || meta.total_count,
+      limit: meta[:limit] || meta.limit,
+      offset: meta[:offset] || meta.offset
+    }
+
+    # Include fallback flag when present (combined mode falling back to keyword)
+    case meta[:fallback] do
+      true -> Map.put(base, :fallback, true)
+      _ -> base
+    end
+  end
+end

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -236,6 +236,9 @@ defmodule LoopctlWeb.Router do
     # Knowledge Index (lightweight catalog)
     get "/knowledge/index", KnowledgeIndexController, :index
 
+    # Knowledge Search (unified keyword / semantic / combined)
+    get "/knowledge/search", KnowledgeSearchController, :search
+
     scope "/projects/:project_id" do
       resources "/articles", ArticleController, only: [:create, :index], as: :project_article
       get "/knowledge/index", KnowledgeIndexController, :index

--- a/test/loopctl_web/controllers/knowledge_search_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_search_controller_test.exs
@@ -1,0 +1,281 @@
+defmodule LoopctlWeb.KnowledgeSearchControllerTest do
+  use LoopctlWeb.ConnCase, async: true
+
+  setup :verify_on_exit!
+
+  defp auth_conn(conn, raw_key) do
+    put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  describe "GET /api/v1/knowledge/search" do
+    test "keyword search returns snippets without body", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Ecto Multi Pattern",
+        body: "Use Ecto.Multi for atomic multi-step database operations.",
+        category: :pattern,
+        status: :published,
+        tags: ["ecto", "transactions"]
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{q: "Ecto", mode: "keyword"})
+
+      body = json_response(conn, 200)
+
+      assert is_list(body["data"])
+      assert body["data"] != []
+
+      result = List.first(body["data"])
+      assert result["id"]
+      assert result["title"] == "Ecto Multi Pattern"
+      assert result["category"] == "pattern"
+      assert result["tags"] == ["ecto", "transactions"]
+      assert is_number(result["score"])
+      assert result["score"] > 0
+
+      # Snippet is present, body is not
+      assert is_binary(result["snippet"]) or is_nil(result["snippet"])
+      refute Map.has_key?(result, "body")
+
+      # Meta is present
+      assert body["meta"]["total_count"] >= 1
+      assert body["meta"]["limit"] == 10
+      assert body["meta"]["offset"] == 0
+    end
+
+    test "combined mode is default when mode param is omitted", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Test Pattern",
+        body: "A test body for combined search default mode.",
+        category: :pattern,
+        status: :published,
+        tags: ["test"]
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{q: "test"})
+
+      body = json_response(conn, 200)
+
+      # Should succeed (combined is default)
+      assert is_list(body["data"])
+      assert is_map(body["meta"])
+    end
+
+    test "missing q returns 400", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search")
+
+      body = json_response(conn, 400)
+      assert body["error"]["status"] == 400
+      assert body["error"]["message"] =~ "q"
+    end
+
+    test "empty q returns 400", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{q: ""})
+
+      body = json_response(conn, 400)
+      assert body["error"]["status"] == 400
+      assert body["error"]["message"] =~ "q"
+    end
+
+    test "q exceeding 500 characters returns 400", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      long_query = String.duplicate("a", 501)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{q: long_query})
+
+      body = json_response(conn, 400)
+      assert body["error"]["status"] == 400
+      assert body["error"]["message"] =~ "500"
+    end
+
+    test "semantic mode returns 503 on embedding failure", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _text ->
+        {:error, :service_unavailable}
+      end)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{q: "test query", mode: "semantic"})
+
+      body = json_response(conn, 503)
+      assert body["error"]["status"] == 503
+      assert body["error"]["message"] =~ "Embedding service unavailable"
+    end
+
+    test "filters by project_id, category, and tags", %{conn: conn} do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        project_id: project.id,
+        title: "Filtered Pattern Ecto",
+        body: "Ecto pattern for filtering test.",
+        category: :pattern,
+        status: :published,
+        tags: ["ecto", "filtering"]
+      })
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Unrelated Convention Ecto",
+        body: "Ecto convention that should not match filters.",
+        category: :convention,
+        status: :published,
+        tags: ["naming"]
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{
+          q: "Ecto",
+          mode: "keyword",
+          project_id: project.id,
+          category: "pattern",
+          tags: "ecto"
+        })
+
+      body = json_response(conn, 200)
+
+      assert length(body["data"]) == 1
+      assert List.first(body["data"])["title"] == "Filtered Pattern Ecto"
+    end
+
+    test "invalid mode returns 400 listing valid modes", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{q: "test", mode: "invalid"})
+
+      body = json_response(conn, 400)
+      assert body["error"]["status"] == 400
+      assert body["error"]["message"] =~ "keyword"
+      assert body["error"]["message"] =~ "semantic"
+      assert body["error"]["message"] =~ "combined"
+    end
+
+    test "pagination with limit and offset", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      # Create 5 articles with "pagination" in the body
+      for i <- 1..5 do
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Pagination Article #{i}",
+          body: "Content about pagination and testing for article number #{i}.",
+          category: :pattern,
+          status: :published,
+          tags: ["pagination"]
+        })
+      end
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{
+          q: "pagination",
+          mode: "keyword",
+          limit: "2",
+          offset: "1"
+        })
+
+      body = json_response(conn, 200)
+
+      assert body["meta"]["limit"] == 2
+      assert body["meta"]["offset"] == 1
+      assert length(body["data"]) <= 2
+    end
+
+    test "tenant isolation — tenant A cannot see tenant B's articles", %{conn: conn} do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      {raw_key_a, _} = fixture(:api_key, %{tenant_id: tenant_a.id, role: :agent})
+
+      fixture(:article, %{
+        tenant_id: tenant_a.id,
+        title: "Tenant A Isolation Article",
+        body: "Content for isolation test in tenant A.",
+        category: :pattern,
+        status: :published,
+        tags: ["isolation"]
+      })
+
+      fixture(:article, %{
+        tenant_id: tenant_b.id,
+        title: "Tenant B Isolation Article",
+        body: "Content for isolation test in tenant B.",
+        category: :pattern,
+        status: :published,
+        tags: ["isolation"]
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key_a)
+        |> get(~p"/api/v1/knowledge/search", %{q: "isolation", mode: "keyword"})
+
+      body = json_response(conn, 200)
+
+      assert length(body["data"]) == 1
+      assert List.first(body["data"])["title"] == "Tenant A Isolation Article"
+    end
+
+    test "unauthenticated returns 401", %{conn: conn} do
+      conn = get(conn, ~p"/api/v1/knowledge/search", %{q: "test"})
+      assert json_response(conn, 401)
+    end
+
+    test "whitespace-only q returns 400", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{q: "   "})
+
+      body = json_response(conn, 400)
+      assert body["error"]["status"] == 400
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add unified GET /api/v1/knowledge/search endpoint supporting keyword, semantic, and combined search modes
- Combined mode is the default; falls back to keyword-only with meta.fallback: true when embedding generation fails
- Semantic-only mode returns 503 when embedding service is unavailable
- Results include id, title, category, tags, unified score, and snippet (max 300 chars) -- never full body
- Supports filtering by project_id, category, and comma-separated tags, with pagination (limit/offset)
- Input validation: required q param (max 500 chars), valid mode enum, 400 responses with descriptive messages

## Test plan

- [x] TC-20.6.1: Keyword search returns snippets without body
- [x] TC-20.6.2: Combined mode is default when mode param omitted
- [x] TC-20.6.3: Missing/empty/whitespace-only q returns 400
- [x] TC-20.6.4: Semantic mode returns 503 on embedding failure (Mox expect)
- [x] TC-20.6.5: Filters by project_id, category, and tags
- [x] TC-20.6.6: Invalid mode returns 400 listing valid modes
- [x] TC-20.6.7: Pagination with limit and offset
- [x] TC-20.6.8: Tenant isolation (tenant A cannot see tenant B articles)
- [x] q exceeding 500 characters returns 400
- [x] Unauthenticated returns 401
- [x] Full precommit: 1793 tests, 0 failures, credo clean, dialyzer clean