### PR TITLE
US-24.3: Knowledge Publish Workflow

### DIFF
--- a/lib/loopctl/audit.ex
+++ b/lib/loopctl/audit.ex
@@ -99,7 +99,7 @@ defmodule Loopctl.Audit do
         }
       end)
   """
-  @spec log_in_multi(Multi.t(), atom(), (map() -> map())) :: Multi.t()
+  @spec log_in_multi(Multi.t(), Multi.name(), (map() -> map())) :: Multi.t()
   def log_in_multi(%Multi{} = multi, name, fun) when is_function(fun, 1) do
     Multi.insert(multi, name, fn changes ->
       attrs = fun.(changes)

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -752,7 +752,10 @@ defmodule Loopctl.Knowledge do
   - `{:error, :unprocessable_entity, message}` on invalid transition
   """
   @spec publish_article(Ecto.UUID.t(), Ecto.UUID.t(), keyword()) ::
-          {:ok, Article.t()} | {:error, :not_found | Ecto.Changeset.t()}
+          {:ok, Article.t()}
+          | {:error, :not_found}
+          | {:error, :unprocessable_entity, String.t()}
+          | {:error, Ecto.Changeset.t()}
   def publish_article(tenant_id, article_id, opts \\ []) do
     transition_article(tenant_id, article_id, :published, "article.published", opts)
   end
@@ -776,7 +779,10 @@ defmodule Loopctl.Knowledge do
   - `{:error, :unprocessable_entity, message}` on invalid transition
   """
   @spec unpublish_article(Ecto.UUID.t(), Ecto.UUID.t(), keyword()) ::
-          {:ok, Article.t()} | {:error, :not_found | Ecto.Changeset.t()}
+          {:ok, Article.t()}
+          | {:error, :not_found}
+          | {:error, :unprocessable_entity, String.t()}
+          | {:error, Ecto.Changeset.t()}
   def unpublish_article(tenant_id, article_id, opts \\ []) do
     transition_article(tenant_id, article_id, :draft, "article.unpublished", opts)
   end
@@ -801,7 +807,10 @@ defmodule Loopctl.Knowledge do
   - `{:error, :unprocessable_entity, message}` on invalid transition
   """
   @spec archive_article_workflow(Ecto.UUID.t(), Ecto.UUID.t(), keyword()) ::
-          {:ok, Article.t()} | {:error, :not_found | Ecto.Changeset.t()}
+          {:ok, Article.t()}
+          | {:error, :not_found}
+          | {:error, :unprocessable_entity, String.t()}
+          | {:error, Ecto.Changeset.t()}
   def archive_article_workflow(tenant_id, article_id, opts \\ []) do
     transition_article(tenant_id, article_id, :archived, "article.archived", opts)
   end
@@ -988,22 +997,24 @@ defmodule Loopctl.Knowledge do
     actor_label = Keyword.get(opts, :actor_label)
     actor_type = Keyword.get(opts, :actor_type, "api_key")
 
-    multi =
-      articles
-      |> Enum.reduce(Multi.new(), fn article, multi ->
-        key = String.to_atom("publish_#{article.id}")
-        changeset = Article.update_changeset(article, %{status: :published})
+    # Use {action, index} tuples as Multi keys to avoid atom exhaustion.
+    # String.to_atom with dynamic UUIDs would leak atoms (never GC'd).
+    indexed_articles = Enum.with_index(articles)
 
-        Multi.update(multi, key, changeset)
+    multi =
+      indexed_articles
+      |> Enum.reduce(Multi.new(), fn {article, idx}, multi ->
+        changeset = Article.update_changeset(article, %{status: :published})
+        Multi.update(multi, {:publish, idx}, changeset)
       end)
-      |> add_bulk_audit_entries(tenant_id, articles, actor_id, actor_label, actor_type)
+      |> add_bulk_audit_entries(tenant_id, indexed_articles, actor_id, actor_label, actor_type)
       |> add_bulk_embedding_jobs(tenant_id, article_ids)
 
     case AdminRepo.transaction(multi) do
       {:ok, results} ->
         published =
-          article_ids
-          |> Enum.map(fn id -> Map.get(results, String.to_atom("publish_#{id}")) end)
+          indexed_articles
+          |> Enum.map(fn {_article, idx} -> Map.get(results, {:publish, idx}) end)
           |> Enum.reject(&is_nil/1)
 
         {:ok, %{published: published, count: length(published)}}
@@ -1013,12 +1024,17 @@ defmodule Loopctl.Knowledge do
     end
   end
 
-  defp add_bulk_audit_entries(multi, tenant_id, articles, actor_id, actor_label, actor_type) do
-    Enum.reduce(articles, multi, fn article, multi ->
-      audit_key = String.to_atom("audit_#{article.id}")
-
-      Audit.log_in_multi(multi, audit_key, fn changes ->
-        updated = Map.get(changes, String.to_atom("publish_#{article.id}"))
+  defp add_bulk_audit_entries(
+         multi,
+         tenant_id,
+         indexed_articles,
+         actor_id,
+         actor_label,
+         actor_type
+       ) do
+    Enum.reduce(indexed_articles, multi, fn {_article, idx}, multi ->
+      Audit.log_in_multi(multi, {:audit, idx}, fn changes ->
+        updated = Map.get(changes, {:publish, idx})
 
         %{
           tenant_id: tenant_id,

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -731,6 +731,321 @@ defmodule Loopctl.Knowledge do
     end
   end
 
+  # --- Publish Workflow ---
+
+  @doc """
+  Publishes an article by transitioning its status from `:draft` to `:published`.
+
+  Validates the transition via `Article.valid_transition?/2` and records
+  the `article.published` audit event. Enqueues embedding generation.
+
+  ## Parameters
+
+  - `tenant_id` -- the tenant UUID
+  - `article_id` -- the article UUID
+  - `opts` -- keyword list with `:actor_id`, `:actor_label`, `:actor_type`
+
+  ## Returns
+
+  - `{:ok, %Article{}}` on success
+  - `{:error, :not_found}` if not found or belongs to another tenant
+  - `{:error, :unprocessable_entity, message}` on invalid transition
+  """
+  @spec publish_article(Ecto.UUID.t(), Ecto.UUID.t(), keyword()) ::
+          {:ok, Article.t()} | {:error, :not_found | Ecto.Changeset.t()}
+  def publish_article(tenant_id, article_id, opts \\ []) do
+    transition_article(tenant_id, article_id, :published, "article.published", opts)
+  end
+
+  @doc """
+  Unpublishes an article by transitioning its status from `:published` to `:draft`.
+
+  Validates the transition via `Article.valid_transition?/2` and records
+  the `article.unpublished` audit event.
+
+  ## Parameters
+
+  - `tenant_id` -- the tenant UUID
+  - `article_id` -- the article UUID
+  - `opts` -- keyword list with `:actor_id`, `:actor_label`, `:actor_type`
+
+  ## Returns
+
+  - `{:ok, %Article{}}` on success
+  - `{:error, :not_found}` if not found or belongs to another tenant
+  - `{:error, :unprocessable_entity, message}` on invalid transition
+  """
+  @spec unpublish_article(Ecto.UUID.t(), Ecto.UUID.t(), keyword()) ::
+          {:ok, Article.t()} | {:error, :not_found | Ecto.Changeset.t()}
+  def unpublish_article(tenant_id, article_id, opts \\ []) do
+    transition_article(tenant_id, article_id, :draft, "article.unpublished", opts)
+  end
+
+  @doc """
+  Archives an article via the publish workflow.
+
+  Unlike `archive_article/3` (called by DELETE), this function validates
+  the status transition. Only `:draft` and `:published` articles can be
+  archived. `:superseded` articles return a 422 error.
+
+  ## Parameters
+
+  - `tenant_id` -- the tenant UUID
+  - `article_id` -- the article UUID
+  - `opts` -- keyword list with `:actor_id`, `:actor_label`, `:actor_type`
+
+  ## Returns
+
+  - `{:ok, %Article{}}` on success
+  - `{:error, :not_found}` if not found or belongs to another tenant
+  - `{:error, :unprocessable_entity, message}` on invalid transition
+  """
+  @spec archive_article_workflow(Ecto.UUID.t(), Ecto.UUID.t(), keyword()) ::
+          {:ok, Article.t()} | {:error, :not_found | Ecto.Changeset.t()}
+  def archive_article_workflow(tenant_id, article_id, opts \\ []) do
+    transition_article(tenant_id, article_id, :archived, "article.archived", opts)
+  end
+
+  @doc """
+  Atomically publishes multiple draft articles.
+
+  Validates that all article IDs belong to the tenant and that all
+  articles are in `:draft` status. If any article fails validation,
+  the entire operation is rolled back (atomic Multi).
+
+  ## Parameters
+
+  - `tenant_id` -- the tenant UUID
+  - `article_ids` -- list of article UUIDs (max 100)
+  - `opts` -- keyword list with `:actor_id`, `:actor_label`, `:actor_type`
+
+  ## Returns
+
+  - `{:ok, %{published: [%Article{}], count: integer}}` on success
+  - `{:error, :bad_request, message}` when article_ids exceeds 100
+  - `{:error, :bad_request, message}` when article_ids is empty
+  - `{:error, :unprocessable_entity, message}` when any article is not a draft
+  - `{:error, :not_found}` when any article ID is not found in the tenant
+  """
+  @spec bulk_publish(Ecto.UUID.t(), [Ecto.UUID.t()], keyword()) ::
+          {:ok, %{published: [Article.t()], count: non_neg_integer()}}
+          | {:error, atom(), String.t()}
+          | {:error, :not_found}
+  def bulk_publish(tenant_id, article_ids, opts \\ []) do
+    cond do
+      article_ids == [] or is_nil(article_ids) ->
+        {:error, :bad_request, "article_ids must not be empty"}
+
+      length(article_ids) > 100 ->
+        {:error, :bad_request, "Maximum 100 articles per bulk publish"}
+
+      true ->
+        do_bulk_publish(tenant_id, article_ids, opts)
+    end
+  end
+
+  @doc """
+  Lists draft articles for a tenant, ordered by inserted_at desc.
+
+  Returns source_type and source_id for review queue visibility.
+
+  ## Parameters
+
+  - `tenant_id` -- the tenant UUID
+  - `opts` -- keyword list with:
+    - `:project_id` -- filter by project UUID (optional)
+    - `:limit` -- max records to return (default 20, max 100)
+    - `:offset` -- records to skip for pagination (default 0)
+
+  ## Returns
+
+  - `%{data: [%Article{}], meta: %{total_count: integer, limit: integer, offset: integer}}`
+  """
+  @spec list_drafts(Ecto.UUID.t(), keyword()) :: %{
+          data: [Article.t()],
+          meta: %{total_count: non_neg_integer(), limit: pos_integer(), offset: non_neg_integer()}
+        }
+  def list_drafts(tenant_id, opts \\ []) do
+    limit = opts |> Keyword.get(:limit, 20) |> max(1) |> min(100)
+    offset = opts |> Keyword.get(:offset, 0) |> max(0)
+
+    base =
+      from(a in Article,
+        where: a.tenant_id == ^tenant_id,
+        where: a.status == :draft,
+        order_by: [desc: a.inserted_at]
+      )
+
+    base = maybe_filter_by_project_id(base, Keyword.get(opts, :project_id))
+
+    total_count = AdminRepo.aggregate(base, :count, :id)
+
+    articles =
+      base
+      |> limit(^limit)
+      |> offset(^offset)
+      |> AdminRepo.all()
+
+    %{
+      data: articles,
+      meta: %{total_count: total_count, limit: limit, offset: offset}
+    }
+  end
+
+  # Shared transition logic for publish/unpublish/archive workflow
+  defp transition_article(tenant_id, article_id, target_status, audit_action, opts) do
+    actor_id = Keyword.get(opts, :actor_id)
+    actor_label = Keyword.get(opts, :actor_label)
+    actor_type = Keyword.get(opts, :actor_type, "api_key")
+
+    with {:ok, article} <- fetch_article(tenant_id, article_id),
+         :ok <- validate_transition(article.status, target_status) do
+      old_status = to_string(article.status)
+      changeset = Article.update_changeset(article, %{status: target_status})
+
+      needs_embedding? = target_status == :published
+
+      multi =
+        Multi.new()
+        |> Multi.update(:article, changeset)
+        |> Audit.log_in_multi(:audit, fn %{article: updated} ->
+          %{
+            tenant_id: tenant_id,
+            entity_type: "article",
+            entity_id: updated.id,
+            action: audit_action,
+            actor_type: actor_type,
+            actor_id: actor_id,
+            actor_label: actor_label,
+            old_state: %{"status" => old_status},
+            new_state: %{"status" => to_string(updated.status)}
+          }
+        end)
+        |> EventGenerator.generate_events(:webhook_events, fn %{article: updated} ->
+          %{
+            tenant_id: tenant_id,
+            event_type: audit_action,
+            project_id: updated.project_id,
+            payload: article_event_payload(updated)
+          }
+        end)
+        |> maybe_enqueue_embedding(tenant_id, needs_embedding?)
+
+      case AdminRepo.transaction(multi) do
+        {:ok, %{article: updated}} -> {:ok, updated}
+        {:error, :article, changeset, _} -> {:error, changeset}
+      end
+    end
+  end
+
+  defp validate_transition(from, to) do
+    if Article.valid_transition?(from, to) do
+      :ok
+    else
+      {:error, :unprocessable_entity, "Cannot transition from #{from} to #{to}"}
+    end
+  end
+
+  defp do_bulk_publish(tenant_id, article_ids, opts) do
+    # Fetch all articles up front and validate
+    articles =
+      from(a in Article,
+        where: a.tenant_id == ^tenant_id,
+        where: a.id in ^article_ids
+      )
+      |> AdminRepo.all()
+
+    with :ok <- validate_bulk_all_found(articles, article_ids),
+         :ok <- validate_bulk_all_drafts(articles) do
+      execute_bulk_publish(tenant_id, articles, article_ids, opts)
+    end
+  end
+
+  defp validate_bulk_all_found(articles, article_ids) do
+    found_ids = MapSet.new(articles, & &1.id)
+    requested_ids = MapSet.new(article_ids)
+
+    if MapSet.subset?(requested_ids, found_ids) do
+      :ok
+    else
+      {:error, :not_found}
+    end
+  end
+
+  defp validate_bulk_all_drafts(articles) do
+    case Enum.find(articles, &(&1.status != :draft)) do
+      nil ->
+        :ok
+
+      non_draft ->
+        {:error, :unprocessable_entity,
+         "Article #{non_draft.id} is in status #{non_draft.status}, expected draft"}
+    end
+  end
+
+  defp execute_bulk_publish(tenant_id, articles, article_ids, opts) do
+    actor_id = Keyword.get(opts, :actor_id)
+    actor_label = Keyword.get(opts, :actor_label)
+    actor_type = Keyword.get(opts, :actor_type, "api_key")
+
+    multi =
+      articles
+      |> Enum.reduce(Multi.new(), fn article, multi ->
+        key = String.to_atom("publish_#{article.id}")
+        changeset = Article.update_changeset(article, %{status: :published})
+
+        Multi.update(multi, key, changeset)
+      end)
+      |> add_bulk_audit_entries(tenant_id, articles, actor_id, actor_label, actor_type)
+      |> add_bulk_embedding_jobs(tenant_id, article_ids)
+
+    case AdminRepo.transaction(multi) do
+      {:ok, results} ->
+        published =
+          article_ids
+          |> Enum.map(fn id -> Map.get(results, String.to_atom("publish_#{id}")) end)
+          |> Enum.reject(&is_nil/1)
+
+        {:ok, %{published: published, count: length(published)}}
+
+      {:error, _key, changeset, _completed} ->
+        {:error, changeset}
+    end
+  end
+
+  defp add_bulk_audit_entries(multi, tenant_id, articles, actor_id, actor_label, actor_type) do
+    Enum.reduce(articles, multi, fn article, multi ->
+      audit_key = String.to_atom("audit_#{article.id}")
+
+      Audit.log_in_multi(multi, audit_key, fn changes ->
+        updated = Map.get(changes, String.to_atom("publish_#{article.id}"))
+
+        %{
+          tenant_id: tenant_id,
+          entity_type: "article",
+          entity_id: updated.id,
+          action: "article.published",
+          actor_type: actor_type,
+          actor_id: actor_id,
+          actor_label: actor_label,
+          old_state: %{"status" => "draft"},
+          new_state: %{"status" => to_string(updated.status)}
+        }
+      end)
+    end)
+  end
+
+  defp add_bulk_embedding_jobs(multi, tenant_id, article_ids) do
+    Multi.run(multi, :embedding_jobs, fn _repo, _changes ->
+      Enum.each(article_ids, fn article_id ->
+        ArticleEmbeddingWorker.new(%{article_id: article_id, tenant_id: tenant_id})
+        |> Oban.insert()
+      end)
+
+      {:ok, :enqueued}
+    end)
+  end
+
   # --- Article Links ---
 
   @doc """

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -907,51 +907,74 @@ defmodule Loopctl.Knowledge do
     actor_label = Keyword.get(opts, :actor_label)
     actor_type = Keyword.get(opts, :actor_type, "api_key")
 
-    with {:ok, article} <- fetch_article(tenant_id, article_id),
-         :ok <- validate_transition(article.status, target_status) do
-      old_status = to_string(article.status)
-      changeset = Article.update_changeset(article, %{status: target_status})
+    needs_embedding? = target_status == :published
 
-      needs_embedding? = target_status == :published
+    # Fetch-and-lock inside the transaction to eliminate TOCTOU races where
+    # concurrent requests could change the status between validation and update.
+    multi =
+      Multi.new()
+      |> Multi.run(:fetch, fn _repo, _changes ->
+        query =
+          from(a in Article,
+            where: a.id == ^article_id and a.tenant_id == ^tenant_id,
+            lock: "FOR UPDATE"
+          )
 
-      multi =
-        Multi.new()
-        |> Multi.update(:article, changeset)
-        |> Audit.log_in_multi(:audit, fn %{article: updated} ->
-          %{
-            tenant_id: tenant_id,
-            entity_type: "article",
-            entity_id: updated.id,
-            action: audit_action,
-            actor_type: actor_type,
-            actor_id: actor_id,
-            actor_label: actor_label,
-            old_state: %{"status" => old_status},
-            new_state: %{"status" => to_string(updated.status)}
-          }
-        end)
-        |> EventGenerator.generate_events(:webhook_events, fn %{article: updated} ->
-          %{
-            tenant_id: tenant_id,
-            event_type: audit_action,
-            project_id: updated.project_id,
-            payload: article_event_payload(updated)
-          }
-        end)
-        |> maybe_enqueue_embedding(tenant_id, needs_embedding?)
+        case AdminRepo.one(query) do
+          nil -> {:error, {:not_found, nil}}
+          article -> validate_transition_and_wrap(article, target_status)
+        end
+      end)
+      |> Multi.run(:article, fn _repo, %{fetch: {article, _old_status}} ->
+        changeset = Article.update_changeset(article, %{status: target_status})
+        AdminRepo.update(changeset)
+      end)
+      |> Audit.log_in_multi(:audit, fn %{fetch: {_article, old_status}, article: updated} ->
+        %{
+          tenant_id: tenant_id,
+          entity_type: "article",
+          entity_id: updated.id,
+          action: audit_action,
+          actor_type: actor_type,
+          actor_id: actor_id,
+          actor_label: actor_label,
+          old_state: %{"status" => old_status},
+          new_state: %{"status" => to_string(updated.status)}
+        }
+      end)
+      |> EventGenerator.generate_events(:webhook_events, fn %{article: updated} ->
+        %{
+          tenant_id: tenant_id,
+          event_type: audit_action,
+          project_id: updated.project_id,
+          payload: article_event_payload(updated)
+        }
+      end)
+      |> maybe_enqueue_embedding(tenant_id, needs_embedding?)
 
-      case AdminRepo.transaction(multi) do
-        {:ok, %{article: updated}} -> {:ok, updated}
-        {:error, :article, changeset, _} -> {:error, changeset}
-      end
+    case AdminRepo.transaction(multi) do
+      {:ok, %{article: updated}} ->
+        {:ok, updated}
+
+      {:error, :fetch, {:not_found, _}, _} ->
+        {:error, :not_found}
+
+      {:error, :fetch, {:unprocessable_entity, message}, _} ->
+        {:error, :unprocessable_entity, message}
+
+      {:error, :article, changeset, _} ->
+        {:error, changeset}
     end
   end
 
-  defp validate_transition(from, to) do
-    if Article.valid_transition?(from, to) do
-      :ok
+  # Validates the transition and wraps the result for Multi.run compatibility.
+  # Returns {:ok, {article, old_status_string}} or {:error, {error_type, detail}}.
+  defp validate_transition_and_wrap(article, target_status) do
+    if Article.valid_transition?(article.status, target_status) do
+      {:ok, {article, to_string(article.status)}}
     else
-      {:error, :unprocessable_entity, "Cannot transition from #{from} to #{to}"}
+      {:error,
+       {:unprocessable_entity, "Cannot transition from #{article.status} to #{target_status}"}}
     end
   end
 

--- a/lib/loopctl/knowledge/article.ex
+++ b/lib/loopctl/knowledge/article.ex
@@ -115,6 +115,36 @@ defmodule Loopctl.Knowledge.Article do
   @doc false
   def known_source_types, do: @known_source_types
 
+  @valid_transitions [
+    {:draft, :published},
+    {:published, :draft},
+    {:published, :archived},
+    {:draft, :archived},
+    {:superseded, :draft}
+  ]
+
+  @doc """
+  Returns whether a status transition is valid.
+
+  ## Valid transitions
+
+  - draft -> published
+  - published -> draft
+  - published -> archived
+  - draft -> archived
+  - superseded -> draft
+
+  ## Examples
+
+      iex> Article.valid_transition?(:draft, :published)
+      true
+
+      iex> Article.valid_transition?(:archived, :published)
+      false
+  """
+  @spec valid_transition?(atom(), atom()) :: boolean()
+  def valid_transition?(from, to), do: {from, to} in @valid_transitions
+
   @doc """
   Changeset for setting or clearing an article's embedding vector.
 

--- a/lib/loopctl/workers/review_knowledge_worker.ex
+++ b/lib/loopctl/workers/review_knowledge_worker.ex
@@ -125,13 +125,11 @@ defmodule Loopctl.Workers.ReviewKnowledgeWorker do
     }
   end
 
-  defp validate_and_filter(raw_articles) when is_list(raw_articles) do
+  defp validate_and_filter(raw_articles) do
     raw_articles
     |> Enum.take(@max_articles)
     |> Enum.filter(&valid_article?/1)
   end
-
-  defp validate_and_filter(_), do: []
 
   defp valid_article?(attrs) when is_map(attrs) do
     valid_title?(attrs) and valid_body?(attrs) and valid_category?(attrs) and valid_tags?(attrs)

--- a/lib/loopctl_web/controllers/article_workflow_controller.ex
+++ b/lib/loopctl_web/controllers/article_workflow_controller.ex
@@ -1,0 +1,214 @@
+defmodule LoopctlWeb.ArticleWorkflowController do
+  @moduledoc """
+  Controller for article publish workflow operations.
+
+  - `POST /api/v1/articles/:id/publish` -- publish a draft article (user+)
+  - `POST /api/v1/articles/:id/unpublish` -- unpublish a published article (user+)
+  - `POST /api/v1/articles/:id/archive` -- archive an article (user+)
+  - `POST /api/v1/knowledge/bulk-publish` -- bulk publish drafts (user+)
+  - `GET /api/v1/knowledge/drafts` -- list draft articles (user+)
+  """
+
+  use LoopctlWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Loopctl.ApiSpec.Schemas
+  alias Loopctl.Knowledge
+  alias LoopctlWeb.ArticleJSON
+  alias LoopctlWeb.AuditContext
+
+  action_fallback LoopctlWeb.FallbackController
+
+  plug LoopctlWeb.Plugs.RequireRole, role: :user
+
+  tags(["Knowledge Wiki"])
+
+  operation(:publish,
+    summary: "Publish article",
+    description:
+      "Transitions article from draft to published. " <>
+        "Returns 422 if the transition is invalid. Role: user+.",
+    parameters: [id: [in: :path, type: :string, description: "Article UUID"]],
+    responses: %{
+      200 =>
+        {"Published article", "application/json",
+         %OpenApiSpex.Schema{type: :object, additionalProperties: true}},
+      404 => {"Not found", "application/json", Schemas.ErrorResponse},
+      422 => {"Invalid transition", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  operation(:unpublish,
+    summary: "Unpublish article",
+    description:
+      "Transitions article from published back to draft. " <>
+        "Returns 422 if the transition is invalid. Role: user+.",
+    parameters: [id: [in: :path, type: :string, description: "Article UUID"]],
+    responses: %{
+      200 =>
+        {"Unpublished article", "application/json",
+         %OpenApiSpex.Schema{type: :object, additionalProperties: true}},
+      404 => {"Not found", "application/json", Schemas.ErrorResponse},
+      422 => {"Invalid transition", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  operation(:archive,
+    summary: "Archive article",
+    description:
+      "Transitions article to archived status. " <>
+        "Valid from draft or published. Returns 422 if superseded. Role: user+.",
+    parameters: [id: [in: :path, type: :string, description: "Article UUID"]],
+    responses: %{
+      200 =>
+        {"Archived article", "application/json",
+         %OpenApiSpex.Schema{type: :object, additionalProperties: true}},
+      404 => {"Not found", "application/json", Schemas.ErrorResponse},
+      422 => {"Invalid transition", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  operation(:bulk_publish,
+    summary: "Bulk publish articles",
+    description:
+      "Atomically publishes up to 100 draft articles. " <>
+        "All articles must be drafts belonging to the tenant. " <>
+        "If any article fails validation, the entire operation is rolled back. Role: user+.",
+    request_body:
+      {"Bulk publish params", "application/json",
+       %OpenApiSpex.Schema{
+         type: :object,
+         required: [:article_ids],
+         properties: %{
+           article_ids: %OpenApiSpex.Schema{
+             type: :array,
+             items: %OpenApiSpex.Schema{type: :string, format: :uuid},
+             maxItems: 100
+           }
+         }
+       }},
+    responses: %{
+      200 =>
+        {"Bulk publish result", "application/json",
+         %OpenApiSpex.Schema{
+           type: :object,
+           properties: %{
+             data: %OpenApiSpex.Schema{type: :array},
+             meta: %OpenApiSpex.Schema{type: :object}
+           }
+         }},
+      400 => {"Bad request", "application/json", Schemas.ErrorResponse},
+      404 => {"Article not found", "application/json", Schemas.ErrorResponse},
+      422 => {"Non-draft article", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  operation(:drafts,
+    summary: "List draft articles",
+    description:
+      "Lists draft articles ordered by inserted_at desc. " <>
+        "Includes source_type and source_id for review queue visibility. Role: user+.",
+    parameters: [
+      project_id: [in: :query, type: :string, description: "Filter by project UUID"],
+      limit: [in: :query, type: :integer, description: "Max results (default 20, max 100)"],
+      offset: [in: :query, type: :integer, description: "Records to skip"]
+    ],
+    responses: %{
+      200 =>
+        {"Drafts list", "application/json",
+         %OpenApiSpex.Schema{
+           type: :object,
+           properties: %{
+             data: %OpenApiSpex.Schema{type: :array},
+             meta: %OpenApiSpex.Schema{type: :object}
+           }
+         }},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  # --- Actions ---
+
+  @doc "POST /api/v1/articles/:id/publish"
+  def publish(conn, %{"id" => article_id}) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+    audit_opts = AuditContext.from_conn(conn)
+
+    with {:ok, article} <- Knowledge.publish_article(tenant_id, article_id, audit_opts) do
+      json(conn, ArticleJSON.update(%{article: article}))
+    end
+  end
+
+  @doc "POST /api/v1/articles/:id/unpublish"
+  def unpublish(conn, %{"id" => article_id}) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+    audit_opts = AuditContext.from_conn(conn)
+
+    with {:ok, article} <- Knowledge.unpublish_article(tenant_id, article_id, audit_opts) do
+      json(conn, ArticleJSON.update(%{article: article}))
+    end
+  end
+
+  @doc "POST /api/v1/articles/:id/archive"
+  def archive(conn, %{"id" => article_id}) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+    audit_opts = AuditContext.from_conn(conn)
+
+    with {:ok, article} <-
+           Knowledge.archive_article_workflow(tenant_id, article_id, audit_opts) do
+      json(conn, ArticleJSON.update(%{article: article}))
+    end
+  end
+
+  @doc "POST /api/v1/knowledge/bulk-publish"
+  def bulk_publish(conn, params) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+    audit_opts = AuditContext.from_conn(conn)
+    article_ids = params["article_ids"] || []
+
+    with {:ok, result} <- Knowledge.bulk_publish(tenant_id, article_ids, audit_opts) do
+      json(conn, %{
+        data: Enum.map(result.published, &ArticleJSON.article_data/1),
+        meta: %{count: result.count}
+      })
+    end
+  end
+
+  @doc "GET /api/v1/knowledge/drafts"
+  def drafts(conn, params) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+
+    opts =
+      []
+      |> maybe_add_opt(:project_id, params["project_id"])
+      |> maybe_add_opt(:limit, parse_int(params["limit"]))
+      |> maybe_add_opt(:offset, parse_int(params["offset"]))
+
+    result = Knowledge.list_drafts(tenant_id, opts)
+
+    json(conn, %{
+      data: Enum.map(result.data, &ArticleJSON.article_data/1),
+      meta: result.meta
+    })
+  end
+
+  # --- Private helpers ---
+
+  defp maybe_add_opt(opts, _key, nil), do: opts
+  defp maybe_add_opt(opts, key, value), do: Keyword.put(opts, key, value)
+
+  defp parse_int(nil), do: nil
+
+  defp parse_int(val) when is_binary(val) do
+    case Integer.parse(val) do
+      {n, _} -> n
+      :error -> nil
+    end
+  end
+
+  defp parse_int(val) when is_integer(val), do: val
+end

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -231,7 +231,15 @@ defmodule LoopctlWeb.Router do
     post "/skill_results", SkillResultController, :create
 
     # Knowledge Wiki (Epic 19)
+    # Publish workflow routes (must precede resources to avoid route conflicts)
+    post "/articles/:id/publish", ArticleWorkflowController, :publish
+    post "/articles/:id/unpublish", ArticleWorkflowController, :unpublish
+    post "/articles/:id/archive", ArticleWorkflowController, :archive
     resources "/articles", ArticleController, except: [:new, :edit]
+
+    # Knowledge bulk-publish and drafts queue
+    post "/knowledge/bulk-publish", ArticleWorkflowController, :bulk_publish
+    get "/knowledge/drafts", ArticleWorkflowController, :drafts
 
     # Knowledge Index (lightweight catalog)
     get "/knowledge/index", KnowledgeIndexController, :index

--- a/priv/plts/dialyzer_ignore.exs
+++ b/priv/plts/dialyzer_ignore.exs
@@ -1,10 +1,1 @@
-[
-  # Ecto.Multi.t() opaque type warnings — known upstream issue
-  # https://github.com/elixir-ecto/ecto/issues/1882
-  ~r/call_without_opaque/,
-
-  # MapSet opaque type warnings — known upstream issue in Erlang/OTP dialyzer
-  # The reachable?/4 function passes MapSet to recursive calls, which dialyzer
-  # flags as opaque term crossing function boundaries.
-  ~r/call_with_opaque.*reachable\?/
-]
+[]

--- a/test/loopctl/knowledge/article_transition_test.exs
+++ b/test/loopctl/knowledge/article_transition_test.exs
@@ -1,0 +1,58 @@
+defmodule Loopctl.Knowledge.ArticleTransitionTest do
+  use ExUnit.Case, async: true
+
+  alias Loopctl.Knowledge.Article
+
+  describe "valid_transition?/2" do
+    test "draft -> published is valid" do
+      assert Article.valid_transition?(:draft, :published)
+    end
+
+    test "published -> draft is valid" do
+      assert Article.valid_transition?(:published, :draft)
+    end
+
+    test "published -> archived is valid" do
+      assert Article.valid_transition?(:published, :archived)
+    end
+
+    test "draft -> archived is valid" do
+      assert Article.valid_transition?(:draft, :archived)
+    end
+
+    test "superseded -> draft is valid" do
+      assert Article.valid_transition?(:superseded, :draft)
+    end
+
+    test "archived -> published is invalid" do
+      refute Article.valid_transition?(:archived, :published)
+    end
+
+    test "archived -> draft is invalid" do
+      refute Article.valid_transition?(:archived, :draft)
+    end
+
+    test "superseded -> published is invalid" do
+      refute Article.valid_transition?(:superseded, :published)
+    end
+
+    test "superseded -> archived is invalid" do
+      refute Article.valid_transition?(:superseded, :archived)
+    end
+
+    test "same status transition is invalid" do
+      refute Article.valid_transition?(:draft, :draft)
+      refute Article.valid_transition?(:published, :published)
+      refute Article.valid_transition?(:archived, :archived)
+      refute Article.valid_transition?(:superseded, :superseded)
+    end
+
+    test "draft -> superseded is invalid (only via article links)" do
+      refute Article.valid_transition?(:draft, :superseded)
+    end
+
+    test "published -> superseded is invalid (only via article links)" do
+      refute Article.valid_transition?(:published, :superseded)
+    end
+  end
+end

--- a/test/loopctl_web/controllers/article_workflow_controller_test.exs
+++ b/test/loopctl_web/controllers/article_workflow_controller_test.exs
@@ -1,0 +1,494 @@
+defmodule LoopctlWeb.ArticleWorkflowControllerTest do
+  use LoopctlWeb.ConnCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Audit.AuditLog
+  alias Loopctl.Knowledge.Article
+
+  import Ecto.Query
+
+  defp auth_conn(conn, raw_key) do
+    put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  # --- TC-21.3.1: Publish draft -> published with audit ---
+
+  describe "POST /api/v1/articles/:id/publish" do
+    test "publishes a draft article and records audit event", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      article = fixture(:article, %{tenant_id: tenant.id, status: :draft})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/articles/#{article.id}/publish")
+
+      body = json_response(conn, 200)
+      assert body["data"]["id"] == article.id
+      assert body["data"]["status"] == "published"
+
+      # Verify DB state
+      updated = AdminRepo.get!(Article, article.id)
+      assert updated.status == :published
+
+      # Verify audit log
+      audit =
+        from(a in AuditLog,
+          where: a.entity_type == "article" and a.entity_id == ^article.id,
+          where: a.action == "article.published"
+        )
+        |> AdminRepo.one!()
+
+      assert audit.tenant_id == tenant.id
+      assert audit.old_state == %{"status" => "draft"}
+      assert audit.new_state == %{"status" => "published"}
+    end
+
+    # --- TC-21.3.2: Reject publish of non-draft (422) ---
+
+    test "returns 422 when article is already published", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      article = fixture(:article, %{tenant_id: tenant.id, status: :published})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/articles/#{article.id}/publish")
+
+      body = json_response(conn, 422)
+      assert body["error"]["message"] =~ "Cannot transition from published to published"
+    end
+
+    test "returns 422 when article is archived", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      article = fixture(:article, %{tenant_id: tenant.id, status: :archived})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/articles/#{article.id}/publish")
+
+      body = json_response(conn, 422)
+      assert body["error"]["message"] =~ "Cannot transition from archived to published"
+    end
+
+    test "returns 404 for non-existent article", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      fake_id = Ecto.UUID.generate()
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/articles/#{fake_id}/publish")
+
+      assert json_response(conn, 404)
+    end
+
+    test "rejects agent role (requires user+)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      article = fixture(:article, %{tenant_id: tenant.id, status: :draft})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/articles/#{article.id}/publish")
+
+      assert json_response(conn, 403)
+    end
+  end
+
+  # --- TC-21.3.7: Unpublish returns to draft with audit ---
+
+  describe "POST /api/v1/articles/:id/unpublish" do
+    test "unpublishes a published article and records audit event", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      article = fixture(:article, %{tenant_id: tenant.id, status: :published})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/articles/#{article.id}/unpublish")
+
+      body = json_response(conn, 200)
+      assert body["data"]["id"] == article.id
+      assert body["data"]["status"] == "draft"
+
+      # Verify audit log
+      audit =
+        from(a in AuditLog,
+          where: a.entity_type == "article" and a.entity_id == ^article.id,
+          where: a.action == "article.unpublished"
+        )
+        |> AdminRepo.one!()
+
+      assert audit.old_state == %{"status" => "published"}
+      assert audit.new_state == %{"status" => "draft"}
+    end
+
+    test "returns 422 when article is a draft (invalid transition)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      article = fixture(:article, %{tenant_id: tenant.id, status: :draft})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/articles/#{article.id}/unpublish")
+
+      body = json_response(conn, 422)
+      assert body["error"]["message"] =~ "Cannot transition from draft to draft"
+    end
+  end
+
+  # --- TC-21.3.8: Archive published article ---
+
+  describe "POST /api/v1/articles/:id/archive" do
+    test "archives a published article", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      article = fixture(:article, %{tenant_id: tenant.id, status: :published})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/articles/#{article.id}/archive")
+
+      body = json_response(conn, 200)
+      assert body["data"]["status"] == "archived"
+
+      updated = AdminRepo.get!(Article, article.id)
+      assert updated.status == :archived
+    end
+
+    test "archives a draft article", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      article = fixture(:article, %{tenant_id: tenant.id, status: :draft})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/articles/#{article.id}/archive")
+
+      body = json_response(conn, 200)
+      assert body["data"]["status"] == "archived"
+    end
+
+    test "returns 422 when article is superseded", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      article = fixture(:article, %{tenant_id: tenant.id, status: :superseded})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/articles/#{article.id}/archive")
+
+      body = json_response(conn, 422)
+      assert body["error"]["message"] =~ "Cannot transition from superseded to archived"
+    end
+  end
+
+  # --- TC-21.3.3: Bulk publish 3 drafts atomically ---
+
+  describe "POST /api/v1/knowledge/bulk-publish" do
+    test "bulk publishes multiple draft articles atomically", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      a1 = fixture(:article, %{tenant_id: tenant.id, status: :draft, title: "Draft One"})
+      a2 = fixture(:article, %{tenant_id: tenant.id, status: :draft, title: "Draft Two"})
+      a3 = fixture(:article, %{tenant_id: tenant.id, status: :draft, title: "Draft Three"})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/bulk-publish", %{
+          "article_ids" => [a1.id, a2.id, a3.id]
+        })
+
+      body = json_response(conn, 200)
+      assert body["meta"]["count"] == 3
+      assert length(body["data"]) == 3
+
+      # Verify all published in DB
+      for id <- [a1.id, a2.id, a3.id] do
+        article = AdminRepo.get!(Article, id)
+        assert article.status == :published
+      end
+
+      # Verify audit logs
+      audit_count =
+        AuditLog
+        |> where([a], a.tenant_id == ^tenant.id and a.action == "article.published")
+        |> AdminRepo.aggregate(:count, :id)
+
+      assert audit_count == 3
+    end
+
+    # --- TC-21.3.4: Bulk publish fails atomically when one is non-draft ---
+
+    test "fails atomically when one article is not a draft", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      a1 = fixture(:article, %{tenant_id: tenant.id, status: :draft})
+      a2 = fixture(:article, %{tenant_id: tenant.id, status: :published})
+      a3 = fixture(:article, %{tenant_id: tenant.id, status: :draft})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/bulk-publish", %{
+          "article_ids" => [a1.id, a2.id, a3.id]
+        })
+
+      body = json_response(conn, 422)
+      assert body["error"]["message"] =~ "expected draft"
+
+      # None should have changed (atomic rollback)
+      assert AdminRepo.get!(Article, a1.id).status == :draft
+      assert AdminRepo.get!(Article, a2.id).status == :published
+      assert AdminRepo.get!(Article, a3.id).status == :draft
+    end
+
+    test "returns 404 when an article ID does not belong to tenant", %{conn: conn} do
+      tenant = fixture(:tenant)
+      other_tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      a1 = fixture(:article, %{tenant_id: tenant.id, status: :draft})
+      # Article belongs to a different tenant
+      a2 = fixture(:article, %{tenant_id: other_tenant.id, status: :draft})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/bulk-publish", %{
+          "article_ids" => [a1.id, a2.id]
+        })
+
+      assert json_response(conn, 404)
+    end
+
+    test "returns 400 when article_ids is empty", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/bulk-publish", %{
+          "article_ids" => []
+        })
+
+      body = json_response(conn, 400)
+      assert body["error"]["message"] =~ "must not be empty"
+    end
+
+    test "returns 400 when article_ids exceeds 100", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      ids = Enum.map(1..101, fn _ -> Ecto.UUID.generate() end)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/bulk-publish", %{
+          "article_ids" => ids
+        })
+
+      body = json_response(conn, 400)
+      assert body["error"]["message"] =~ "Maximum 100"
+    end
+  end
+
+  # --- TC-21.3.5: Drafts listing excludes published, includes source info ---
+
+  describe "GET /api/v1/knowledge/drafts" do
+    test "lists only draft articles with source info", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      draft =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :draft,
+          title: "Draft Article",
+          source_type: "review_finding",
+          source_id: Ecto.UUID.generate()
+        })
+
+      _published =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :published,
+          title: "Published Article"
+        })
+
+      _archived =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :archived,
+          title: "Archived Article"
+        })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/drafts")
+
+      body = json_response(conn, 200)
+      assert body["meta"]["total_count"] == 1
+      assert length(body["data"]) == 1
+
+      article_data = hd(body["data"])
+      assert article_data["id"] == draft.id
+      assert article_data["title"] == "Draft Article"
+      assert article_data["source_type"] == "review_finding"
+      assert article_data["source_id"] != nil
+    end
+
+    test "supports pagination", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      for i <- 1..5 do
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :draft,
+          title: "Draft #{i}"
+        })
+      end
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/drafts?limit=2&offset=0")
+
+      body = json_response(conn, 200)
+      assert body["meta"]["total_count"] == 5
+      assert length(body["data"]) == 2
+    end
+
+    test "filters by project_id", %{conn: conn} do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        project_id: project.id,
+        status: :draft,
+        title: "Project Draft"
+      })
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        status: :draft,
+        title: "Tenant Draft"
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/drafts?project_id=#{project.id}")
+
+      body = json_response(conn, 200)
+      assert body["meta"]["total_count"] == 1
+      assert hd(body["data"])["title"] == "Project Draft"
+    end
+  end
+
+  # --- TC-21.3.6: Tenant isolation on publish ---
+
+  describe "tenant isolation" do
+    test "cannot publish article from another tenant", %{conn: conn} do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      {raw_key_a, _} = fixture(:api_key, %{tenant_id: tenant_a.id, role: :user})
+      article_b = fixture(:article, %{tenant_id: tenant_b.id, status: :draft})
+
+      conn =
+        conn
+        |> auth_conn(raw_key_a)
+        |> post(~p"/api/v1/articles/#{article_b.id}/publish")
+
+      assert json_response(conn, 404)
+    end
+
+    test "cannot unpublish article from another tenant", %{conn: conn} do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      {raw_key_a, _} = fixture(:api_key, %{tenant_id: tenant_a.id, role: :user})
+      article_b = fixture(:article, %{tenant_id: tenant_b.id, status: :published})
+
+      conn =
+        conn
+        |> auth_conn(raw_key_a)
+        |> post(~p"/api/v1/articles/#{article_b.id}/unpublish")
+
+      assert json_response(conn, 404)
+    end
+
+    test "cannot archive article from another tenant", %{conn: conn} do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      {raw_key_a, _} = fixture(:api_key, %{tenant_id: tenant_a.id, role: :user})
+      article_b = fixture(:article, %{tenant_id: tenant_b.id, status: :draft})
+
+      conn =
+        conn
+        |> auth_conn(raw_key_a)
+        |> post(~p"/api/v1/articles/#{article_b.id}/archive")
+
+      assert json_response(conn, 404)
+    end
+
+    test "bulk publish cannot see other tenant's articles", %{conn: conn} do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      {raw_key_a, _} = fixture(:api_key, %{tenant_id: tenant_a.id, role: :user})
+
+      a_own = fixture(:article, %{tenant_id: tenant_a.id, status: :draft})
+      a_other = fixture(:article, %{tenant_id: tenant_b.id, status: :draft})
+
+      conn =
+        conn
+        |> auth_conn(raw_key_a)
+        |> post(~p"/api/v1/knowledge/bulk-publish", %{
+          "article_ids" => [a_own.id, a_other.id]
+        })
+
+      # The other tenant's article is not found
+      assert json_response(conn, 404)
+    end
+
+    test "drafts listing is tenant-scoped", %{conn: conn} do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      {raw_key_a, _} = fixture(:api_key, %{tenant_id: tenant_a.id, role: :user})
+
+      fixture(:article, %{tenant_id: tenant_a.id, status: :draft, title: "A Draft"})
+      fixture(:article, %{tenant_id: tenant_b.id, status: :draft, title: "B Draft"})
+
+      conn =
+        conn
+        |> auth_conn(raw_key_a)
+        |> get(~p"/api/v1/knowledge/drafts")
+
+      body = json_response(conn, 200)
+      assert body["meta"]["total_count"] == 1
+      assert hd(body["data"])["title"] == "A Draft"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `Article.valid_transition?/2` with comprehensive unit tests for all status transition pairs
- Implement publish/unpublish/archive/bulk-publish context functions with transition validation, audit logging, and webhook events
- Create `ArticleWorkflowController` with 5 endpoints: publish, unpublish, archive, bulk_publish, drafts
- Add routes under `/api/v1` with `user+` role requirement on all workflow operations
- Atomic bulk publish via `Ecto.Multi` (max 100 articles, validates all IDs belong to tenant)
- Drafts listing with source_type/source_id for review queue visibility, paginated

## Acceptance Criteria Coverage

- AC-21.3.1: POST /articles/:id/publish (draft->published, user+, 200/422)
- AC-21.3.2: POST /articles/:id/unpublish (published->draft, user+, 200/422)
- AC-21.3.3: POST /knowledge/bulk-publish (atomic Multi, max 100, user+)
- AC-21.3.4: GET /knowledge/drafts (ordered by inserted_at desc, paginated)
- AC-21.3.5: Only published articles in search/index (pre-existing)
- AC-21.3.6: Valid transitions enforced, invalid -> 422
- AC-21.3.7: Audit events for publish/unpublish
- AC-21.3.8: POST /articles/:id/archive (422 if superseded)
- AC-21.3.9: Tenant-scoped via RLS/AdminRepo
- AC-21.3.10: Bulk publish validates all IDs belong to tenant
- AC-21.3.11: Routes in /api/v1 scope
- AC-21.3.12: Article.valid_transition?/2 with unit tests

## Test plan

- [x] 12 unit tests for `Article.valid_transition?/2` covering all valid and invalid transitions
- [x] 23 controller integration tests covering publish, unpublish, archive, bulk publish, drafts, role enforcement, and tenant isolation
- [x] 1886 total tests passing (0 failures)
- [x] `mix precommit` passes (compile, format, credo --strict, dialyzer, tests)