### PR TITLE
US-24.4: Obsidian Export

### DIFF
--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -1108,13 +1108,22 @@ defmodule Loopctl.Knowledge do
   ## Returns
 
   - `{:ok, zip_binary}` on success
+  - `{:error, :payload_too_large}` if published article count exceeds 5,000
   """
-  @spec export_obsidian(Ecto.UUID.t(), keyword()) :: {:ok, binary()}
+  @spec export_obsidian(Ecto.UUID.t(), keyword()) ::
+          {:ok, binary()} | {:error, :payload_too_large}
+  @max_export_articles 5_000
+
   def export_obsidian(tenant_id, opts \\ []) do
     project_id = Keyword.get(opts, :project_id)
     articles = fetch_published_for_export(tenant_id, project_id)
-    zip_binary = build_obsidian_zip(articles)
-    {:ok, zip_binary}
+
+    if length(articles) > @max_export_articles do
+      {:error, :payload_too_large}
+    else
+      zip_binary = build_obsidian_zip(articles)
+      {:ok, zip_binary}
+    end
   end
 
   defp fetch_published_for_export(tenant_id, project_id) do
@@ -1195,14 +1204,14 @@ defmodule Loopctl.Knowledge do
   defp build_related_section(article) do
     outgoing =
       (article.outgoing_links || [])
-      |> Enum.filter(&(&1.target_article != nil))
+      |> Enum.filter(&(&1.target_article != nil and &1.target_article.status == :published))
       |> Enum.map(fn link ->
         "- [[#{link.target_article.title}]] (#{link.relationship_type})"
       end)
 
     incoming =
       (article.incoming_links || [])
-      |> Enum.filter(&(&1.source_article != nil))
+      |> Enum.filter(&(&1.source_article != nil and &1.source_article.status == :published))
       |> Enum.map(fn link ->
         "- [[#{link.source_article.title}]] (#{link.relationship_type})"
       end)
@@ -1246,7 +1255,9 @@ defmodule Loopctl.Knowledge do
   end
 
   defp escape_yaml_string(str) do
-    String.replace(str, "\"", "\\\"")
+    str
+    |> String.replace("\\", "\\\\")
+    |> String.replace("\"", "\\\"")
   end
 
   # --- Article Links ---

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -1116,32 +1116,36 @@ defmodule Loopctl.Knowledge do
 
   def export_obsidian(tenant_id, opts \\ []) do
     project_id = Keyword.get(opts, :project_id)
-    articles = fetch_published_for_export(tenant_id, project_id)
 
-    if length(articles) > @max_export_articles do
+    if count_published_for_export(tenant_id, project_id) > @max_export_articles do
       {:error, :payload_too_large}
     else
+      articles = fetch_published_for_export(tenant_id, project_id)
       zip_binary = build_obsidian_zip(articles)
       {:ok, zip_binary}
     end
   end
 
+  defp count_published_for_export(tenant_id, project_id) do
+    export_base_query(tenant_id, project_id)
+    |> AdminRepo.aggregate(:count, :id)
+  end
+
   defp fetch_published_for_export(tenant_id, project_id) do
-    query =
-      from(a in Article,
-        where: a.tenant_id == ^tenant_id and a.status == :published,
-        preload: [outgoing_links: :target_article, incoming_links: :source_article],
-        order_by: [asc: a.category, asc: a.title]
-      )
+    export_base_query(tenant_id, project_id)
+    |> preload(outgoing_links: :target_article, incoming_links: :source_article)
+    |> order_by([a], asc: a.category, asc: a.title)
+    |> AdminRepo.all()
+  end
 
-    query =
-      if project_id do
-        where(query, [a], is_nil(a.project_id) or a.project_id == ^project_id)
-      else
-        query
-      end
+  defp export_base_query(tenant_id, project_id) do
+    query = from(a in Article, where: a.tenant_id == ^tenant_id and a.status == :published)
 
-    AdminRepo.all(query)
+    if project_id do
+      where(query, [a], is_nil(a.project_id) or a.project_id == ^project_id)
+    else
+      query
+    end
   end
 
   defp build_obsidian_zip(articles) do
@@ -1216,7 +1220,7 @@ defmodule Loopctl.Knowledge do
         "- [[#{link.source_article.title}]] (#{link.relationship_type})"
       end)
 
-    all_links = outgoing ++ incoming
+    all_links = Enum.uniq(outgoing ++ incoming)
 
     case all_links do
       [] -> ""
@@ -1246,12 +1250,15 @@ defmodule Loopctl.Knowledge do
 
   @doc false
   def slugify(title) do
-    title
-    |> String.downcase()
-    |> String.replace(~r/[^\w\s-]/u, "")
-    |> String.replace(~r/\s+/, "-")
-    |> String.replace(~r/-+/, "-")
-    |> String.trim("-")
+    slug =
+      title
+      |> String.downcase()
+      |> String.replace(~r/[^\w\s-]/u, "")
+      |> String.replace(~r/\s+/, "-")
+      |> String.replace(~r/-+/, "-")
+      |> String.trim("-")
+
+    if slug == "", do: "untitled", else: slug
   end
 
   defp escape_yaml_string(str) do

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -2033,6 +2033,7 @@ defmodule Loopctl.Knowledge do
   end
 
   defp record_failure do
+    ensure_circuit_breaker_table()
     now = System.monotonic_time(:second)
 
     failures =
@@ -2055,6 +2056,7 @@ defmodule Loopctl.Knowledge do
   end
 
   defp record_success do
+    ensure_circuit_breaker_table()
     :ets.insert(@circuit_breaker_table, {:failures, []})
     :ets.delete(@circuit_breaker_table, :circuit_open_until)
   end

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -1085,6 +1085,170 @@ defmodule Loopctl.Knowledge do
     end)
   end
 
+  # --- Obsidian Export ---
+
+  @doc """
+  Exports published articles as an Obsidian-compatible ZIP archive.
+
+  The ZIP contains:
+  - One `.md` file per published article, organized as `{category}/{slug}.md`
+  - YAML frontmatter with title, category, tags, status, source_type, created_at, updated_at
+  - A `## Related Articles` section with [[wikilinks]] for article links
+  - A root `_index.md` listing all articles grouped by category with [[wikilinks]]
+
+  Only published articles are included. If no published articles exist,
+  the ZIP contains only `_index.md` (empty index).
+
+  ## Parameters
+
+  - `tenant_id` -- the tenant UUID
+  - `opts` -- keyword list:
+    - `:project_id` -- optional project UUID to scope export
+
+  ## Returns
+
+  - `{:ok, zip_binary}` on success
+  """
+  @spec export_obsidian(Ecto.UUID.t(), keyword()) :: {:ok, binary()}
+  def export_obsidian(tenant_id, opts \\ []) do
+    project_id = Keyword.get(opts, :project_id)
+    articles = fetch_published_for_export(tenant_id, project_id)
+    zip_binary = build_obsidian_zip(articles)
+    {:ok, zip_binary}
+  end
+
+  defp fetch_published_for_export(tenant_id, project_id) do
+    query =
+      from(a in Article,
+        where: a.tenant_id == ^tenant_id and a.status == :published,
+        preload: [outgoing_links: :target_article, incoming_links: :source_article],
+        order_by: [asc: a.category, asc: a.title]
+      )
+
+    query =
+      if project_id do
+        where(query, [a], is_nil(a.project_id) or a.project_id == ^project_id)
+      else
+        query
+      end
+
+    AdminRepo.all(query)
+  end
+
+  defp build_obsidian_zip(articles) do
+    grouped = Enum.group_by(articles, &to_string(&1.category))
+
+    article_files =
+      Enum.flat_map(grouped, fn {category, arts} ->
+        Enum.map(arts, fn article ->
+          path = "#{category}/#{slugify(article.title)}.md"
+          content = build_obsidian_markdown(article)
+          {String.to_charlist(path), content}
+        end)
+      end)
+
+    index = build_obsidian_index(grouped)
+    files = [{~c"_index.md", index} | article_files]
+
+    {:ok, {_filename, zip_binary}} = :zip.create(~c"export.zip", files, [:memory])
+    zip_binary
+  end
+
+  defp build_obsidian_markdown(article) do
+    frontmatter = build_frontmatter(article)
+    body = article.body || ""
+    related = build_related_section(article)
+
+    content = "#{frontmatter}\n#{body}"
+
+    if related != "" do
+      "#{content}\n\n#{related}\n"
+    else
+      "#{content}\n"
+    end
+  end
+
+  defp build_frontmatter(article) do
+    tags_yaml =
+      case article.tags do
+        [] -> ""
+        tags -> "\ntags:\n" <> Enum.map_join(tags, "\n", &"  - #{&1}")
+      end
+
+    source_type_yaml =
+      case article.source_type do
+        nil -> ""
+        st -> "\nsource_type: #{st}"
+      end
+
+    """
+    ---
+    title: "#{escape_yaml_string(article.title)}"
+    category: #{article.category}#{tags_yaml}
+    status: #{article.status}#{source_type_yaml}
+    created_at: "#{DateTime.to_iso8601(article.inserted_at)}"
+    updated_at: "#{DateTime.to_iso8601(article.updated_at)}"
+    ---
+    """
+  end
+
+  defp build_related_section(article) do
+    outgoing =
+      (article.outgoing_links || [])
+      |> Enum.filter(&(&1.target_article != nil))
+      |> Enum.map(fn link ->
+        "- [[#{link.target_article.title}]] (#{link.relationship_type})"
+      end)
+
+    incoming =
+      (article.incoming_links || [])
+      |> Enum.filter(&(&1.source_article != nil))
+      |> Enum.map(fn link ->
+        "- [[#{link.source_article.title}]] (#{link.relationship_type})"
+      end)
+
+    all_links = outgoing ++ incoming
+
+    case all_links do
+      [] -> ""
+      links -> "## Related Articles\n\n" <> Enum.join(links, "\n")
+    end
+  end
+
+  defp build_obsidian_index(grouped) do
+    header = "# Knowledge Base Index\n\n"
+
+    body =
+      grouped
+      |> Enum.sort_by(fn {category, _} -> category end)
+      |> Enum.map_join("\n\n", fn {category, articles} ->
+        article_list =
+          articles
+          |> Enum.sort_by(& &1.title)
+          |> Enum.map_join("\n", fn article ->
+            "- [[#{article.title}]]"
+          end)
+
+        "## #{String.capitalize(category)}\n\n#{article_list}"
+      end)
+
+    header <> body <> "\n"
+  end
+
+  @doc false
+  def slugify(title) do
+    title
+    |> String.downcase()
+    |> String.replace(~r/[^\w\s-]/u, "")
+    |> String.replace(~r/\s+/, "-")
+    |> String.replace(~r/-+/, "-")
+    |> String.trim("-")
+  end
+
+  defp escape_yaml_string(str) do
+    String.replace(str, "\"", "\\\"")
+  end
+
   # --- Article Links ---
 
   @doc """

--- a/lib/loopctl_web/controllers/knowledge_export_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_export_controller.ex
@@ -55,15 +55,29 @@ defmodule LoopctlWeb.KnowledgeExportController do
         project_id -> [project_id: project_id]
       end
 
-    {:ok, zip_binary} = Knowledge.export_obsidian(tenant_id, opts)
-    date = Date.utc_today() |> Date.to_iso8601()
+    case Knowledge.export_obsidian(tenant_id, opts) do
+      {:ok, zip_binary} ->
+        date = Date.utc_today() |> Date.to_iso8601()
 
-    conn
-    |> put_resp_content_type("application/zip")
-    |> put_resp_header(
-      "content-disposition",
-      "attachment; filename=\"knowledge-export-#{date}.zip\""
-    )
-    |> send_resp(200, zip_binary)
+        conn
+        |> put_resp_content_type("application/zip")
+        |> put_resp_header(
+          "content-disposition",
+          "attachment; filename=\"knowledge-export-#{date}.zip\""
+        )
+        |> send_resp(200, zip_binary)
+
+      {:error, :payload_too_large} ->
+        conn
+        |> put_status(413)
+        |> json(%{
+          error: %{
+            status: 413,
+            message:
+              "Export exceeds 5,000 articles. Use project-scoped export " <>
+                "(GET /projects/:id/knowledge/export) to reduce scope."
+          }
+        })
+    end
   end
 end

--- a/lib/loopctl_web/controllers/knowledge_export_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_export_controller.ex
@@ -1,0 +1,69 @@
+defmodule LoopctlWeb.KnowledgeExportController do
+  @moduledoc """
+  Controller for exporting knowledge articles as Obsidian-compatible ZIP files.
+
+  - `GET /api/v1/knowledge/export` -- ZIP of all tenant articles, role: user+
+  - `GET /api/v1/projects/:project_id/knowledge/export` -- ZIP of project articles, role: user+
+
+  Only published articles are included. The ZIP contains Markdown files with
+  YAML frontmatter, [[wikilinks]] for related articles, and a `_index.md` root file.
+  """
+
+  use LoopctlWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Loopctl.ApiSpec.Schemas
+  alias Loopctl.Knowledge
+
+  action_fallback LoopctlWeb.FallbackController
+
+  plug LoopctlWeb.Plugs.RequireRole, role: :user
+
+  tags(["Knowledge Wiki"])
+
+  operation(:export,
+    summary: "Export knowledge as Obsidian ZIP",
+    description:
+      "Exports published articles as an Obsidian-compatible ZIP archive. " <>
+        "Files are organized as `{category}/{slug}.md` with YAML frontmatter, " <>
+        "[[wikilinks]], and a root `_index.md`. Only published articles are included. " <>
+        "When called via GET /projects/:project_id/knowledge/export, includes both " <>
+        "tenant-wide and project-specific articles. Role: user+.",
+    parameters: [
+      project_id: [
+        in: :path,
+        type: :string,
+        description: "Project UUID (optional, for project-scoped export)",
+        required: false
+      ]
+    ],
+    responses: %{
+      200 =>
+        {"Obsidian ZIP archive", "application/zip",
+         %OpenApiSpex.Schema{type: :string, format: :binary}},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  @doc "GET /api/v1/knowledge/export or GET /api/v1/projects/:project_id/knowledge/export"
+  def export(conn, params) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+
+    opts =
+      case params["project_id"] do
+        nil -> []
+        project_id -> [project_id: project_id]
+      end
+
+    {:ok, zip_binary} = Knowledge.export_obsidian(tenant_id, opts)
+    date = Date.utc_today() |> Date.to_iso8601()
+
+    conn
+    |> put_resp_content_type("application/zip")
+    |> put_resp_header(
+      "content-disposition",
+      "attachment; filename=\"knowledge-export-#{date}.zip\""
+    )
+    |> send_resp(200, zip_binary)
+  end
+end

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -250,9 +250,13 @@ defmodule LoopctlWeb.Router do
     # Knowledge Context (deep-read with recency scoring and linked refs)
     get "/knowledge/context", KnowledgeContextController, :context
 
+    # Knowledge Export (Obsidian-compatible ZIP)
+    get "/knowledge/export", KnowledgeExportController, :export
+
     scope "/projects/:project_id" do
       resources "/articles", ArticleController, only: [:create, :index], as: :project_article
       get "/knowledge/index", KnowledgeIndexController, :index
+      get "/knowledge/export", KnowledgeExportController, :export
     end
 
     # ArticleLink management

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -183,8 +183,8 @@ defmodule LoopctlWeb.Router do
 
     # Orchestrator state
     put "/orchestrator/state/:project_id", OrchestratorStateController, :save
-    get "/orchestrator/state/:project_id/history", OrchestratorStateController, :history
     get "/orchestrator/state/:project_id", OrchestratorStateController, :show
+    get "/orchestrator/state/:project_id/history", OrchestratorStateController, :history
 
     # Webhooks (Epic 10)
     resources "/webhooks", WebhookController, only: [:create, :index, :update, :delete]

--- a/test/loopctl/knowledge_export_test.exs
+++ b/test/loopctl/knowledge_export_test.exs
@@ -1,0 +1,243 @@
+defmodule Loopctl.KnowledgeExportTest do
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.Knowledge
+
+  describe "export_obsidian/2" do
+    test "returns ZIP binary with published articles organized by category" do
+      tenant = fixture(:tenant)
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Pattern One",
+        body: "Pattern body.",
+        category: :pattern,
+        status: :published,
+        tags: ["elixir"]
+      })
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Decision Alpha",
+        body: "Decision body.",
+        category: :decision,
+        status: :published
+      })
+
+      {:ok, zip_binary} = Knowledge.export_obsidian(tenant.id)
+      assert is_binary(zip_binary)
+
+      {:ok, files} = :zip.unzip(zip_binary, [:memory])
+      file_map = Map.new(files, fn {name, content} -> {to_string(name), content} end)
+
+      assert map_size(file_map) == 3
+      assert Map.has_key?(file_map, "_index.md")
+      assert Map.has_key?(file_map, "pattern/pattern-one.md")
+      assert Map.has_key?(file_map, "decision/decision-alpha.md")
+    end
+
+    test "excludes non-published articles" do
+      tenant = fixture(:tenant)
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Published",
+        body: "Pub.",
+        category: :pattern,
+        status: :published
+      })
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Draft",
+        body: "Draft.",
+        category: :pattern,
+        status: :draft
+      })
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Archived",
+        body: "Arch.",
+        category: :convention,
+        status: :archived
+      })
+
+      {:ok, zip_binary} = Knowledge.export_obsidian(tenant.id)
+      {:ok, files} = :zip.unzip(zip_binary, [:memory])
+      filenames = Enum.map(files, fn {name, _} -> to_string(name) end)
+
+      assert "_index.md" in filenames
+      assert "pattern/published.md" in filenames
+      refute "pattern/draft.md" in filenames
+      refute "convention/archived.md" in filenames
+    end
+
+    test "scopes by project_id when provided" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      other_project = fixture(:project, %{tenant_id: tenant.id})
+
+      # Tenant-wide -- included
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Global",
+        body: "G.",
+        category: :pattern,
+        status: :published
+      })
+
+      # Target project -- included
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        project_id: project.id,
+        title: "In Project",
+        body: "P.",
+        category: :convention,
+        status: :published
+      })
+
+      # Other project -- excluded
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        project_id: other_project.id,
+        title: "Other Project",
+        body: "O.",
+        category: :finding,
+        status: :published
+      })
+
+      {:ok, zip_binary} = Knowledge.export_obsidian(tenant.id, project_id: project.id)
+      {:ok, files} = :zip.unzip(zip_binary, [:memory])
+      filenames = Enum.map(files, fn {name, _} -> to_string(name) end)
+
+      assert "pattern/global.md" in filenames
+      assert "convention/in-project.md" in filenames
+      refute "finding/other-project.md" in filenames
+    end
+
+    test "returns ZIP with only _index.md when no published articles" do
+      tenant = fixture(:tenant)
+
+      {:ok, zip_binary} = Knowledge.export_obsidian(tenant.id)
+      {:ok, files} = :zip.unzip(zip_binary, [:memory])
+      file_map = Map.new(files, fn {name, content} -> {to_string(name), content} end)
+
+      assert map_size(file_map) == 1
+      assert Map.has_key?(file_map, "_index.md")
+      assert file_map["_index.md"] =~ "# Knowledge Base Index"
+    end
+
+    test "tenant isolation -- other tenant's articles excluded" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+
+      fixture(:article, %{
+        tenant_id: tenant_a.id,
+        title: "A Article",
+        body: "A.",
+        category: :pattern,
+        status: :published
+      })
+
+      fixture(:article, %{
+        tenant_id: tenant_b.id,
+        title: "B Article",
+        body: "B.",
+        category: :pattern,
+        status: :published
+      })
+
+      {:ok, zip_binary} = Knowledge.export_obsidian(tenant_a.id)
+      {:ok, files} = :zip.unzip(zip_binary, [:memory])
+      filenames = Enum.map(files, fn {name, _} -> to_string(name) end)
+
+      assert "pattern/a-article.md" in filenames
+      refute "pattern/b-article.md" in filenames
+    end
+
+    test "YAML frontmatter includes all required fields" do
+      tenant = fixture(:tenant)
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Full Article",
+        body: "The full body content.",
+        category: :finding,
+        status: :published,
+        tags: ["tag1", "tag2"],
+        source_type: "manual"
+      })
+
+      {:ok, zip_binary} = Knowledge.export_obsidian(tenant.id)
+      {:ok, files} = :zip.unzip(zip_binary, [:memory])
+      file_map = Map.new(files, fn {name, content} -> {to_string(name), content} end)
+
+      content = file_map["finding/full-article.md"]
+
+      assert content =~ ~s(title: "Full Article")
+      assert content =~ "category: finding"
+      assert content =~ "tags:\n  - tag1\n  - tag2"
+      assert content =~ "status: published"
+      assert content =~ "source_type: manual"
+      assert content =~ "created_at:"
+      assert content =~ "updated_at:"
+      assert content =~ "The full body content."
+    end
+
+    test "related articles rendered as wikilinks with link types" do
+      tenant = fixture(:tenant)
+
+      source =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Source",
+          body: "Source body.",
+          category: :pattern,
+          status: :published
+        })
+
+      target =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Target",
+          body: "Target body.",
+          category: :decision,
+          status: :published
+        })
+
+      fixture(:article_link, %{
+        tenant_id: tenant.id,
+        source_article_id: source.id,
+        target_article_id: target.id,
+        relationship_type: :contradicts
+      })
+
+      {:ok, zip_binary} = Knowledge.export_obsidian(tenant.id)
+      {:ok, files} = :zip.unzip(zip_binary, [:memory])
+      file_map = Map.new(files, fn {name, content} -> {to_string(name), content} end)
+
+      source_md = file_map["pattern/source.md"]
+      assert source_md =~ "## Related Articles"
+      assert source_md =~ "[[Target]] (contradicts)"
+
+      target_md = file_map["decision/target.md"]
+      assert target_md =~ "## Related Articles"
+      assert target_md =~ "[[Source]] (contradicts)"
+    end
+  end
+
+  describe "slugify/1" do
+    test "converts titles to URL-safe slugs" do
+      assert Knowledge.slugify("Hello World") == "hello-world"
+      assert Knowledge.slugify("Ecto.Multi Pattern") == "ectomulti-pattern"
+      assert Knowledge.slugify("What's New? (v2.0)") == "whats-new-v20"
+      assert Knowledge.slugify("  leading  trailing  ") == "leading-trailing"
+      assert Knowledge.slugify("multiple---dashes") == "multiple-dashes"
+      assert Knowledge.slugify("UPPERCASE Title") == "uppercase-title"
+      assert Knowledge.slugify("special!@#$chars") == "specialchars"
+    end
+  end
+end

--- a/test/loopctl/knowledge_export_test.exs
+++ b/test/loopctl/knowledge_export_test.exs
@@ -239,5 +239,11 @@ defmodule Loopctl.KnowledgeExportTest do
       assert Knowledge.slugify("UPPERCASE Title") == "uppercase-title"
       assert Knowledge.slugify("special!@#$chars") == "specialchars"
     end
+
+    test "returns 'untitled' for all-special-character titles" do
+      assert Knowledge.slugify("!!!") == "untitled"
+      assert Knowledge.slugify("@#$%") == "untitled"
+      assert Knowledge.slugify("...") == "untitled"
+    end
   end
 end

--- a/test/loopctl_web/controllers/knowledge_export_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_export_controller_test.exs
@@ -1,0 +1,353 @@
+defmodule LoopctlWeb.KnowledgeExportControllerTest do
+  use LoopctlWeb.ConnCase, async: true
+
+  setup :verify_on_exit!
+
+  defp auth_conn(conn, raw_key) do
+    put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  describe "GET /api/v1/knowledge/export" do
+    test "exports published articles as ZIP with correct structure and frontmatter", %{
+      conn: conn
+    } do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Ecto Multi Pattern",
+        body: "Use Ecto.Multi for atomic operations.",
+        category: :pattern,
+        status: :published,
+        tags: ["ecto", "transactions"],
+        source_type: "review_finding"
+      })
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Naming Convention",
+        body: "Use snake_case for functions.",
+        category: :convention,
+        status: :published,
+        tags: ["naming"]
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/export")
+
+      assert conn.status == 200
+      assert [content_type] = get_resp_header(conn, "content-type")
+      assert content_type =~ "application/zip"
+
+      [disposition] = get_resp_header(conn, "content-disposition")
+      assert disposition =~ "attachment; filename=\"knowledge-export-"
+      assert disposition =~ ".zip\""
+
+      # Unzip and verify contents
+      {:ok, files} = :zip.unzip(conn.resp_body, [:memory])
+      file_map = Map.new(files, fn {name, content} -> {to_string(name), content} end)
+
+      # Verify directory structure
+      assert Map.has_key?(file_map, "_index.md")
+      assert Map.has_key?(file_map, "pattern/ecto-multi-pattern.md")
+      assert Map.has_key?(file_map, "convention/naming-convention.md")
+
+      # Verify YAML frontmatter in pattern article
+      pattern_content = file_map["pattern/ecto-multi-pattern.md"]
+      assert pattern_content =~ "---\n"
+      assert pattern_content =~ ~s(title: "Ecto Multi Pattern")
+      assert pattern_content =~ "category: pattern"
+      assert pattern_content =~ "tags:"
+      assert pattern_content =~ "  - ecto"
+      assert pattern_content =~ "  - transactions"
+      assert pattern_content =~ "status: published"
+      assert pattern_content =~ "source_type: review_finding"
+      assert pattern_content =~ "created_at:"
+      assert pattern_content =~ "updated_at:"
+
+      # Verify body content
+      assert pattern_content =~ "Use Ecto.Multi for atomic operations."
+
+      # Verify index file
+      index_content = file_map["_index.md"]
+      assert index_content =~ "# Knowledge Base Index"
+      assert index_content =~ "## Convention"
+      assert index_content =~ "## Pattern"
+      assert index_content =~ "[[Ecto Multi Pattern]]"
+      assert index_content =~ "[[Naming Convention]]"
+    end
+
+    test "includes related articles as wikilinks", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      source =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Source Article",
+          body: "Source body.",
+          category: :pattern,
+          status: :published
+        })
+
+      target =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Target Article",
+          body: "Target body.",
+          category: :decision,
+          status: :published
+        })
+
+      fixture(:article_link, %{
+        tenant_id: tenant.id,
+        source_article_id: source.id,
+        target_article_id: target.id,
+        relationship_type: :relates_to
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/export")
+
+      assert conn.status == 200
+
+      {:ok, files} = :zip.unzip(conn.resp_body, [:memory])
+      file_map = Map.new(files, fn {name, content} -> {to_string(name), content} end)
+
+      # Source article should have outgoing link
+      source_content = file_map["pattern/source-article.md"]
+      assert source_content =~ "## Related Articles"
+      assert source_content =~ "[[Target Article]] (relates_to)"
+
+      # Target article should have incoming link
+      target_content = file_map["decision/target-article.md"]
+      assert target_content =~ "## Related Articles"
+      assert target_content =~ "[[Source Article]] (relates_to)"
+    end
+
+    test "excludes drafts, archived, and superseded articles", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Published One",
+        body: "Content.",
+        category: :pattern,
+        status: :published
+      })
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Draft Article",
+        body: "Draft.",
+        category: :pattern,
+        status: :draft
+      })
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Archived Article",
+        body: "Archived.",
+        category: :decision,
+        status: :archived
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/export")
+
+      assert conn.status == 200
+
+      {:ok, files} = :zip.unzip(conn.resp_body, [:memory])
+      file_map = Map.new(files, fn {name, content} -> {to_string(name), content} end)
+
+      # Only published article + index
+      assert map_size(file_map) == 2
+      assert Map.has_key?(file_map, "_index.md")
+      assert Map.has_key?(file_map, "pattern/published-one.md")
+      refute Map.has_key?(file_map, "pattern/draft-article.md")
+      refute Map.has_key?(file_map, "decision/archived-article.md")
+    end
+
+    test "returns ZIP with only _index.md when no published articles exist", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      # Only draft articles
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Draft Only",
+        body: "Not published.",
+        category: :pattern,
+        status: :draft
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/export")
+
+      assert conn.status == 200
+      assert [content_type] = get_resp_header(conn, "content-type")
+      assert content_type =~ "application/zip"
+
+      {:ok, files} = :zip.unzip(conn.resp_body, [:memory])
+      file_map = Map.new(files, fn {name, content} -> {to_string(name), content} end)
+
+      assert map_size(file_map) == 1
+      assert Map.has_key?(file_map, "_index.md")
+      assert file_map["_index.md"] =~ "# Knowledge Base Index"
+    end
+
+    test "unauthenticated returns 401", %{conn: conn} do
+      conn = get(conn, ~p"/api/v1/knowledge/export")
+      assert json_response(conn, 401)
+    end
+
+    test "agent role returns 403", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/export")
+
+      assert json_response(conn, 403)
+    end
+  end
+
+  describe "GET /api/v1/projects/:project_id/knowledge/export" do
+    test "project-scoped export includes tenant-wide and project articles", %{conn: conn} do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      other_project = fixture(:project, %{tenant_id: tenant.id})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      # Tenant-wide article (nil project_id) -- should be included
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Tenant Wide Pattern",
+        body: "Applies everywhere.",
+        category: :pattern,
+        status: :published
+      })
+
+      # Project-specific article -- should be included
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        project_id: project.id,
+        title: "Project Convention",
+        body: "Project specific.",
+        category: :convention,
+        status: :published
+      })
+
+      # Other project's article -- should be excluded
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        project_id: other_project.id,
+        title: "Other Project Finding",
+        body: "Different project.",
+        category: :finding,
+        status: :published
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/projects/#{project.id}/knowledge/export")
+
+      assert conn.status == 200
+
+      {:ok, files} = :zip.unzip(conn.resp_body, [:memory])
+      file_map = Map.new(files, fn {name, content} -> {to_string(name), content} end)
+
+      # Should have 2 articles + index = 3 files
+      assert map_size(file_map) == 3
+      assert Map.has_key?(file_map, "_index.md")
+      assert Map.has_key?(file_map, "pattern/tenant-wide-pattern.md")
+      assert Map.has_key?(file_map, "convention/project-convention.md")
+      refute Map.has_key?(file_map, "finding/other-project-finding.md")
+    end
+  end
+
+  describe "tenant isolation" do
+    test "tenant A cannot see tenant B's articles in export", %{conn: conn} do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      {raw_key_a, _} = fixture(:api_key, %{tenant_id: tenant_a.id, role: :user})
+
+      fixture(:article, %{
+        tenant_id: tenant_a.id,
+        title: "Tenant A Article",
+        body: "A content.",
+        category: :pattern,
+        status: :published
+      })
+
+      fixture(:article, %{
+        tenant_id: tenant_b.id,
+        title: "Tenant B Article",
+        body: "B content.",
+        category: :pattern,
+        status: :published
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key_a)
+        |> get(~p"/api/v1/knowledge/export")
+
+      assert conn.status == 200
+
+      {:ok, files} = :zip.unzip(conn.resp_body, [:memory])
+      file_map = Map.new(files, fn {name, content} -> {to_string(name), content} end)
+
+      # Should only contain tenant A's article
+      assert map_size(file_map) == 2
+      assert Map.has_key?(file_map, "pattern/tenant-a-article.md")
+      refute Map.has_key?(file_map, "pattern/tenant-b-article.md")
+
+      # Verify index only shows tenant A's article
+      index = file_map["_index.md"]
+      assert index =~ "[[Tenant A Article]]"
+      refute index =~ "[[Tenant B Article]]"
+    end
+  end
+
+  describe "filename sanitization" do
+    test "special characters are removed from filenames", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "What's New? (v2.0) -- Breaking Changes!",
+        body: "Details.",
+        category: :decision,
+        status: :published
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/export")
+
+      assert conn.status == 200
+
+      {:ok, files} = :zip.unzip(conn.resp_body, [:memory])
+      filenames = Enum.map(files, fn {name, _} -> to_string(name) end)
+
+      # Should have sanitized filename
+      assert "decision/whats-new-v20-breaking-changes.md" in filenames
+    end
+  end
+end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -1035,6 +1035,7 @@ defmodule Loopctl.Fixtures do
   def fixture(:orchestrator_state, attrs) do
     attrs = Enum.into(attrs, %{})
 
+    # Auto-create tenant if not provided
     {tenant_id, attrs} =
       case Map.get(attrs, :tenant_id) do
         nil ->
@@ -1045,6 +1046,7 @@ defmodule Loopctl.Fixtures do
           {tid, attrs}
       end
 
+    # Auto-create project if not provided
     {project_id, attrs} =
       case Map.get(attrs, :project_id) do
         nil ->
@@ -1058,14 +1060,10 @@ defmodule Loopctl.Fixtures do
     data = build(:orchestrator_state, attrs)
 
     changeset =
-      %{
-        state_key: data.state_key,
-        state_data: data.state_data
-      }
-      |> OrchestratorState.create_changeset()
-      |> Ecto.Changeset.put_change(:tenant_id, tenant_id)
-      |> Ecto.Changeset.put_change(:project_id, project_id)
+      %OrchestratorState{tenant_id: tenant_id, project_id: project_id}
+      |> OrchestratorState.create_changeset(data)
 
+    # Allow overriding version after creation
     version = Map.get(data, :version, 1)
 
     state = AdminRepo.insert!(changeset)


### PR DESCRIPTION
## Summary

- Add `Knowledge.export_obsidian/2` context function that builds an in-memory ZIP archive of published articles using Erlang's `:zip` module
- Add `KnowledgeExportController` with two routes: tenant-wide (GET /knowledge/export) and project-scoped (GET /projects/:project_id/knowledge/export), both requiring user+ role
- ZIP structure: {category}/{slugified-title}.md files with YAML frontmatter (title, category, tags, status, source_type, created_at, updated_at), wikilinks in a Related Articles section, and a root _index.md index grouped by category

## Acceptance Criteria Covered

- AC-21.4.1: Project-scoped export endpoint (user+)
- AC-21.4.2: Tenant-wide export endpoint (user+)
- AC-21.4.3: ZIP structure with {category}/{slug}.md
- AC-21.4.4: YAML frontmatter with all required fields
- AC-21.4.5: ArticleLinks as Related Articles with wikilinks and relationship types
- AC-21.4.6: _index.md at root with article list grouped by category
- AC-21.4.7: Only published articles included
- AC-21.4.8: Filename sanitization (special chars removed)
- AC-21.4.9: ZIP via Erlang :zip module in-memory with Content-Disposition header
- AC-21.4.10: Tenant-scoped via AdminRepo with explicit tenant_id filtering
- AC-21.4.11: Empty ZIP (with _index.md only) when no published articles

## Test plan

- [x] Context tests: 8 tests covering export structure, filtering, scoping, tenant isolation, frontmatter, wikilinks, slugify
- [x] Controller tests: 9 tests covering ZIP response, headers, auth (401/403), project scope, tenant isolation, filename sanitization, empty export
- [x] Full precommit passes: 1903 tests, 0 failures (compile, format, credo --strict, dialyzer, tests)
