### PR TITLE
Fix deploy: graceful pgvector migrations for managed Postgres

### DIFF
--- a/priv/repo/migrations/20260410022854_enable_pgvector_and_add_embedding.exs
+++ b/priv/repo/migrations/20260410022854_enable_pgvector_and_add_embedding.exs
@@ -2,18 +2,41 @@ defmodule Loopctl.Repo.Migrations.EnablePgvectorAndAddEmbedding do
   use Ecto.Migration
 
   def up do
-    execute "CREATE EXTENSION IF NOT EXISTS vector"
+    # pgvector requires superuser to CREATE EXTENSION. On Fly.io Managed Postgres,
+    # file a support ticket to enable it, then re-run migrations.
+    # This migration skips gracefully if the extension is not available.
+    execute """
+    DO $$
+    BEGIN
+      CREATE EXTENSION IF NOT EXISTS vector;
+    EXCEPTION
+      WHEN insufficient_privilege THEN
+        RAISE WARNING 'pgvector: insufficient privilege to CREATE EXTENSION vector. Skipping embedding column. File a Fly.io support ticket to enable pgvector.';
+        RETURN;
+    END $$;
+    """
 
-    alter table(:articles) do
-      add :embedding, :"vector(1536)", null: true
-    end
+    # Only add the column if the extension was successfully created
+    execute """
+    DO $$
+    BEGIN
+      IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'vector') THEN
+        IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'articles' AND column_name = 'embedding') THEN
+          ALTER TABLE articles ADD COLUMN embedding vector(1536);
+        END IF;
+      END IF;
+    END $$;
+    """
   end
 
   def down do
-    alter table(:articles) do
-      remove :embedding
-    end
-
-    execute "DROP EXTENSION IF EXISTS vector"
+    execute """
+    DO $$
+    BEGIN
+      IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'articles' AND column_name = 'embedding') THEN
+        ALTER TABLE articles DROP COLUMN embedding;
+      END IF;
+    END $$;
+    """
   end
 end

--- a/priv/repo/migrations/20260410022906_add_embedding_hnsw_index.exs
+++ b/priv/repo/migrations/20260410022906_add_embedding_hnsw_index.exs
@@ -5,8 +5,18 @@ defmodule Loopctl.Repo.Migrations.AddEmbeddingHnswIndex do
   @disable_migration_lock true
 
   def change do
+    # Only create the HNSW index if the embedding column exists (pgvector was enabled)
     execute(
-      "CREATE INDEX CONCURRENTLY IF NOT EXISTS articles_embedding_idx ON articles USING hnsw (embedding vector_cosine_ops)",
+      """
+      DO $$
+      BEGIN
+        IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'articles' AND column_name = 'embedding') THEN
+          IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'articles_embedding_idx') THEN
+            CREATE INDEX articles_embedding_idx ON articles USING hnsw (embedding vector_cosine_ops);
+          END IF;
+        END IF;
+      END $$;
+      """,
       "DROP INDEX IF EXISTS articles_embedding_idx"
     )
   end


### PR DESCRIPTION
## Summary
- Fly.io MPG uses `schema_admin` role without superuser privileges
- `CREATE EXTENSION vector` fails with `permission denied`
- Both pgvector migrations now skip gracefully when extension can't be created
- Embedding column and HNSW index only created if vector extension is available

## Action Required
File a Fly.io support ticket to enable pgvector on the `loopctl-db` MPG cluster. Once enabled, re-run migrations to create the embedding column and HNSW index.

## Test plan
- [x] 1904 tests passing locally
- [x] Migration skips without error when extension unavailable
- [x] Migration creates column normally when extension available (dev/test)