### PR TITLE
US-24.5: Knowledge Lint Operation

### DIFF
--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -2097,4 +2097,357 @@ defmodule Loopctl.Knowledge do
       end
     end)
   end
+
+  # --- Lint ---
+
+  @all_categories [:pattern, :convention, :decision, :finding, :reference]
+  @default_stale_days 90
+  @default_min_coverage 3
+
+  @doc """
+  Analyzes published articles and returns a structured lint report.
+
+  The lint operation is read-only — no data is modified. It identifies:
+
+  - **stale_articles** — articles not updated in N days (configurable via `:stale_days`)
+  - **orphan_articles** — published articles with zero ArticleLinks (neither source nor target)
+  - **contradiction_clusters** — groups of articles linked with `contradicts` relationship
+  - **coverage_gaps** — categories with fewer than N published articles (configurable via `:min_coverage`)
+  - **broken_sources** — articles whose `source_id` references a deleted entity
+
+  ## Parameters
+
+  - `tenant_id` — the tenant UUID
+  - `opts` — keyword list with:
+    - `:project_id` — scope to a specific project (includes tenant-wide articles)
+    - `:stale_days` — threshold in days for stale detection (default 90)
+    - `:min_coverage` — minimum published articles per category (default 3)
+
+  ## Returns
+
+  - `{:ok, map()}` with `:stale_articles`, `:orphan_articles`, `:contradiction_clusters`,
+    `:coverage_gaps`, `:broken_sources`, and `:summary`
+  """
+  @spec lint(Ecto.UUID.t(), keyword()) :: {:ok, map()}
+  def lint(tenant_id, opts \\ []) do
+    project_id = Keyword.get(opts, :project_id)
+    stale_days = Keyword.get(opts, :stale_days, @default_stale_days)
+    min_coverage = Keyword.get(opts, :min_coverage, @default_min_coverage)
+
+    # Base query for published articles scoped to tenant (+ optional project)
+    base = published_base_query(tenant_id, project_id)
+
+    stale = find_stale_articles(base, stale_days)
+    orphans = find_orphan_articles(base, tenant_id, project_id)
+    contradictions = find_contradiction_clusters(tenant_id, project_id)
+    gaps = find_coverage_gaps(base, min_coverage)
+    broken = find_broken_sources(base)
+
+    total_articles = AdminRepo.one(from(a in base, select: count(a.id)))
+
+    all_issues = stale ++ orphans ++ contradictions ++ gaps ++ broken
+
+    issues_by_severity =
+      all_issues
+      |> Enum.group_by(& &1.severity)
+      |> Map.new(fn {severity, items} -> {severity, length(items)} end)
+
+    summary = %{
+      total_articles: total_articles,
+      total_issues: length(all_issues),
+      issues_by_severity: issues_by_severity,
+      generated_at: DateTime.utc_now() |> DateTime.to_iso8601()
+    }
+
+    {:ok,
+     %{
+       stale_articles: stale,
+       orphan_articles: orphans,
+       contradiction_clusters: contradictions,
+       coverage_gaps: gaps,
+       broken_sources: broken,
+       summary: summary
+     }}
+  end
+
+  defp published_base_query(tenant_id, nil) do
+    from(a in Article,
+      where: a.tenant_id == ^tenant_id,
+      where: a.status == :published
+    )
+  end
+
+  defp published_base_query(tenant_id, project_id) do
+    from(a in Article,
+      where: a.tenant_id == ^tenant_id,
+      where: a.status == :published,
+      where: is_nil(a.project_id) or a.project_id == ^project_id
+    )
+  end
+
+  defp find_stale_articles(base, stale_days) do
+    cutoff = DateTime.utc_now() |> DateTime.add(-stale_days * 86_400, :second)
+
+    query =
+      from(a in base,
+        where: a.updated_at < ^cutoff,
+        select: %{
+          id: a.id,
+          title: a.title,
+          updated_at: a.updated_at
+        },
+        order_by: [asc: a.updated_at]
+      )
+
+    now = DateTime.utc_now()
+
+    AdminRepo.all(query)
+    |> Enum.map(fn article ->
+      days_since = DateTime.diff(now, article.updated_at, :day)
+
+      %{
+        article_id: article.id,
+        title: article.title,
+        last_updated: article.updated_at,
+        days_since_update: days_since,
+        severity: "warning",
+        suggested_action: "Review and update or archive this article"
+      }
+    end)
+  end
+
+  defp find_orphan_articles(base, tenant_id, project_id) do
+    # Subquery: article IDs that appear in any link (source or target)
+    linked_ids_subquery =
+      from(al in ArticleLink,
+        where: al.tenant_id == ^tenant_id,
+        select: %{id: al.source_article_id}
+      )
+      |> maybe_scope_links_to_project(project_id)
+
+    linked_target_ids_subquery =
+      from(al in ArticleLink,
+        where: al.tenant_id == ^tenant_id,
+        select: %{id: al.target_article_id}
+      )
+      |> maybe_scope_links_to_project(project_id)
+
+    query =
+      from(a in base,
+        where: a.id not in subquery(linked_ids_subquery),
+        where: a.id not in subquery(linked_target_ids_subquery),
+        select: %{
+          id: a.id,
+          title: a.title,
+          category: a.category
+        },
+        order_by: [asc: a.title]
+      )
+
+    AdminRepo.all(query)
+    |> Enum.map(fn article ->
+      %{
+        article_id: article.id,
+        title: article.title,
+        category: to_string(article.category),
+        severity: "info",
+        suggested_action: "Consider linking to related articles or reviewing for relevance"
+      }
+    end)
+  end
+
+  defp maybe_scope_links_to_project(query, nil), do: query
+
+  defp maybe_scope_links_to_project(query, _project_id) do
+    # Links don't have project_id — we keep all links within the tenant.
+    # The orphan check is scoped via the base query (published articles for
+    # the project). A link to/from articles outside this project scope is
+    # still valid and means the article is NOT orphaned.
+    query
+  end
+
+  defp find_contradiction_clusters(tenant_id, project_id) do
+    # Find all :contradicts links within the tenant
+    links_query =
+      from(al in ArticleLink,
+        where: al.tenant_id == ^tenant_id,
+        where: al.relationship_type == :contradicts,
+        join: src in Article,
+        on: src.id == al.source_article_id and src.status == :published,
+        join: tgt in Article,
+        on: tgt.id == al.target_article_id and tgt.status == :published,
+        select: %{
+          link_id: al.id,
+          source_article_id: al.source_article_id,
+          source_title: src.title,
+          target_article_id: al.target_article_id,
+          target_title: tgt.title
+        }
+      )
+
+    links_query =
+      if project_id do
+        from([al, src, tgt] in links_query,
+          where:
+            (is_nil(src.project_id) or src.project_id == ^project_id) and
+              (is_nil(tgt.project_id) or tgt.project_id == ^project_id)
+        )
+      else
+        links_query
+      end
+
+    links = AdminRepo.all(links_query)
+
+    # Build clusters using union-find approach (group connected articles)
+    build_contradiction_clusters(links)
+  end
+
+  defp build_contradiction_clusters([]), do: []
+
+  defp build_contradiction_clusters(links) do
+    # Group links into connected clusters via a simple union-find
+    {clusters, _parent} =
+      Enum.reduce(links, {%{}, %{}}, fn link, {clusters, parent} ->
+        src_id = link.source_article_id
+        tgt_id = link.target_article_id
+
+        src_root = find_root(parent, src_id)
+        tgt_root = find_root(parent, tgt_id)
+
+        # Merge into the same cluster
+        root = min(src_root, tgt_root)
+        parent = Map.put(parent, src_root, root)
+        parent = Map.put(parent, tgt_root, root)
+        parent = Map.put(parent, src_id, root)
+        parent = Map.put(parent, tgt_id, root)
+
+        # Track link in cluster keyed by root
+        cluster_links = Map.get(clusters, root, [])
+        clusters = Map.put(clusters, root, [link | cluster_links])
+
+        # Re-key any existing clusters to new root
+        clusters =
+          if src_root != root and Map.has_key?(clusters, src_root) do
+            existing = Map.get(clusters, src_root, [])
+            clusters = Map.delete(clusters, src_root)
+            Map.update(clusters, root, existing, &(existing ++ &1))
+          else
+            clusters
+          end
+
+        clusters =
+          if tgt_root != root and Map.has_key?(clusters, tgt_root) do
+            existing = Map.get(clusters, tgt_root, [])
+            clusters = Map.delete(clusters, tgt_root)
+            Map.update(clusters, root, existing, &(existing ++ &1))
+          else
+            clusters
+          end
+
+        {clusters, parent}
+      end)
+
+    # Normalize clusters: re-root all entries using current parent map
+    normalized =
+      Enum.reduce(clusters, %{}, fn {_key, links}, acc ->
+        all_ids =
+          links
+          |> Enum.flat_map(fn l -> [l.source_article_id, l.target_article_id] end)
+          |> Enum.uniq()
+
+        root = Enum.min(all_ids)
+        Map.update(acc, root, links, &(links ++ &1))
+      end)
+
+    normalized
+    |> Enum.map(fn {_root, links} ->
+      links = Enum.uniq_by(links, & &1.link_id)
+
+      # Collect all unique articles in the cluster
+      articles =
+        links
+        |> Enum.flat_map(fn l ->
+          [
+            %{id: l.source_article_id, title: l.source_title},
+            %{id: l.target_article_id, title: l.target_title}
+          ]
+        end)
+        |> Enum.uniq_by(& &1.id)
+
+      %{
+        article_ids: Enum.map(articles, & &1.id),
+        titles: Enum.map(articles, & &1.title),
+        link_ids: Enum.map(links, & &1.link_id),
+        severity: "warning",
+        suggested_action: "Resolve contradiction by updating or superseding one article"
+      }
+    end)
+  end
+
+  defp find_root(parent, id) do
+    case Map.get(parent, id) do
+      nil -> id
+      ^id -> id
+      other -> find_root(parent, other)
+    end
+  end
+
+  defp find_coverage_gaps(base, min_coverage) do
+    # Count published articles per category
+    counts_query =
+      from(a in base,
+        group_by: a.category,
+        select: {a.category, count(a.id)}
+      )
+
+    counts = AdminRepo.all(counts_query) |> Map.new()
+
+    @all_categories
+    |> Enum.filter(fn cat -> Map.get(counts, cat, 0) < min_coverage end)
+    |> Enum.map(fn cat ->
+      current = Map.get(counts, cat, 0)
+
+      %{
+        category: to_string(cat),
+        current_count: current,
+        threshold: min_coverage,
+        severity: "info",
+        suggested_action: "Add more articles in this category"
+      }
+    end)
+  end
+
+  defp find_broken_sources(base) do
+    # Find articles with source_type "review_finding" whose source_id
+    # no longer exists in the review_records table
+    alias Loopctl.Artifacts.ReviewRecord
+
+    query =
+      from(a in base,
+        where: a.source_type == "review_finding" and not is_nil(a.source_id),
+        left_join: rr in ReviewRecord,
+        on: rr.id == a.source_id,
+        where: is_nil(rr.id),
+        select: %{
+          id: a.id,
+          title: a.title,
+          source_type: a.source_type,
+          source_id: a.source_id
+        },
+        order_by: [asc: a.title]
+      )
+
+    AdminRepo.all(query)
+    |> Enum.map(fn article ->
+      %{
+        article_id: article.id,
+        title: article.title,
+        source_type: article.source_type,
+        source_id: article.source_id,
+        severity: "warning",
+        suggested_action:
+          "Source entity was deleted; consider updating or removing source reference"
+      }
+    end)
+  end
 end

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -2426,7 +2426,7 @@ defmodule Loopctl.Knowledge do
       from(a in base,
         where: a.source_type == "review_finding" and not is_nil(a.source_id),
         left_join: rr in ReviewRecord,
-        on: rr.id == a.source_id,
+        on: rr.id == a.source_id and rr.tenant_id == a.tenant_id,
         where: is_nil(rr.id),
         select: %{
           id: a.id,

--- a/lib/loopctl_web/controllers/knowledge_lint_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_lint_controller.ex
@@ -1,0 +1,146 @@
+defmodule LoopctlWeb.KnowledgeLintController do
+  @moduledoc """
+  Controller for the knowledge lint operation.
+
+  - `GET /api/v1/knowledge/lint` -- tenant-wide lint report (user+)
+  - `GET /api/v1/projects/:project_id/knowledge/lint` -- project-scoped lint report (user+)
+
+  Analyzes published articles and returns a structured report of potential
+  issues: stale articles, orphaned articles, contradiction clusters,
+  coverage gaps, and broken source references.
+
+  This endpoint is read-only -- no data is modified.
+  """
+
+  use LoopctlWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Loopctl.ApiSpec.Schemas
+  alias Loopctl.Knowledge
+
+  action_fallback LoopctlWeb.FallbackController
+
+  plug LoopctlWeb.Plugs.RequireRole, role: :user
+
+  tags(["Knowledge Wiki"])
+
+  operation(:lint,
+    summary: "Knowledge lint report",
+    description:
+      "Analyzes published articles and returns a structured report of potential " <>
+        "issues including stale articles, orphaned articles, contradiction clusters, " <>
+        "coverage gaps, and broken source references. Read-only operation. " <>
+        "When called via GET /projects/:project_id/knowledge/lint, scopes analysis " <>
+        "to project-specific and tenant-wide articles. Role: user+.",
+    parameters: [
+      project_id: [
+        in: :path,
+        type: :string,
+        description: "Project UUID (optional, for project-scoped lint)",
+        required: false
+      ],
+      stale_days: [
+        in: :query,
+        type: :integer,
+        description:
+          "Number of days without update before an article is considered stale (default 90)",
+        required: false
+      ],
+      min_coverage: [
+        in: :query,
+        type: :integer,
+        description:
+          "Minimum published articles per category to avoid a coverage gap (default 3)",
+        required: false
+      ]
+    ],
+    responses: %{
+      200 =>
+        {"Knowledge lint report", "application/json",
+         %OpenApiSpex.Schema{
+           type: :object,
+           properties: %{
+             data: %OpenApiSpex.Schema{
+               type: :object,
+               description: "Lint findings grouped by issue type"
+             },
+             summary: %OpenApiSpex.Schema{
+               type: :object,
+               properties: %{
+                 total_articles: %OpenApiSpex.Schema{type: :integer},
+                 total_issues: %OpenApiSpex.Schema{type: :integer},
+                 issues_by_severity: %OpenApiSpex.Schema{type: :object},
+                 generated_at: %OpenApiSpex.Schema{type: :string}
+               }
+             }
+           }
+         }},
+      400 => {"Bad request", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  @doc "GET /api/v1/knowledge/lint or GET /api/v1/projects/:project_id/knowledge/lint"
+  def lint(conn, params) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+
+    with {:ok, opts} <- parse_lint_params(params) do
+      {:ok, result} = Knowledge.lint(tenant_id, opts)
+      json(conn, LoopctlWeb.KnowledgeLintJSON.lint(result))
+    end
+  end
+
+  defp parse_lint_params(params) do
+    opts = []
+
+    opts =
+      case params["project_id"] do
+        nil -> opts
+        project_id -> Keyword.put(opts, :project_id, project_id)
+      end
+
+    with {:ok, opts} <- parse_stale_days(params, opts) do
+      parse_min_coverage(params, opts)
+    end
+  end
+
+  defp parse_stale_days(%{"stale_days" => raw}, opts) when is_binary(raw) do
+    case Integer.parse(raw) do
+      {n, ""} when n > 0 ->
+        {:ok, Keyword.put(opts, :stale_days, n)}
+
+      _ ->
+        {:error, :bad_request, "stale_days must be a positive integer"}
+    end
+  end
+
+  defp parse_stale_days(%{"stale_days" => n}, opts) when is_integer(n) and n > 0 do
+    {:ok, Keyword.put(opts, :stale_days, n)}
+  end
+
+  defp parse_stale_days(%{"stale_days" => _}, _opts) do
+    {:error, :bad_request, "stale_days must be a positive integer"}
+  end
+
+  defp parse_stale_days(_params, opts), do: {:ok, opts}
+
+  defp parse_min_coverage(%{"min_coverage" => raw}, opts) when is_binary(raw) do
+    case Integer.parse(raw) do
+      {n, ""} when n > 0 ->
+        {:ok, Keyword.put(opts, :min_coverage, n)}
+
+      _ ->
+        {:error, :bad_request, "min_coverage must be a positive integer"}
+    end
+  end
+
+  defp parse_min_coverage(%{"min_coverage" => n}, opts) when is_integer(n) and n > 0 do
+    {:ok, Keyword.put(opts, :min_coverage, n)}
+  end
+
+  defp parse_min_coverage(%{"min_coverage" => _}, _opts) do
+    {:error, :bad_request, "min_coverage must be a positive integer"}
+  end
+
+  defp parse_min_coverage(_params, opts), do: {:ok, opts}
+end

--- a/lib/loopctl_web/controllers/knowledge_lint_json.ex
+++ b/lib/loopctl_web/controllers/knowledge_lint_json.ex
@@ -1,0 +1,85 @@
+defmodule LoopctlWeb.KnowledgeLintJSON do
+  @moduledoc """
+  JSON rendering helpers for the knowledge lint endpoint.
+
+  Renders the structured lint report with issue arrays and a top-level summary.
+  """
+
+  @doc "Renders the knowledge lint report."
+  def lint(%{
+        stale_articles: stale,
+        orphan_articles: orphans,
+        contradiction_clusters: contradictions,
+        coverage_gaps: gaps,
+        broken_sources: broken,
+        summary: summary
+      }) do
+    %{
+      data: %{
+        stale_articles: Enum.map(stale, &render_stale/1),
+        orphan_articles: Enum.map(orphans, &render_orphan/1),
+        contradiction_clusters: Enum.map(contradictions, &render_contradiction/1),
+        coverage_gaps: Enum.map(gaps, &render_coverage_gap/1),
+        broken_sources: Enum.map(broken, &render_broken_source/1)
+      },
+      summary: %{
+        total_articles: summary.total_articles,
+        total_issues: summary.total_issues,
+        issues_by_severity: summary.issues_by_severity,
+        generated_at: summary.generated_at
+      }
+    }
+  end
+
+  defp render_stale(item) do
+    %{
+      article_id: item.article_id,
+      title: item.title,
+      last_updated: item.last_updated,
+      days_since_update: item.days_since_update,
+      severity: item.severity,
+      suggested_action: item.suggested_action
+    }
+  end
+
+  defp render_orphan(item) do
+    %{
+      article_id: item.article_id,
+      title: item.title,
+      category: item.category,
+      severity: item.severity,
+      suggested_action: item.suggested_action
+    }
+  end
+
+  defp render_contradiction(item) do
+    %{
+      article_ids: item.article_ids,
+      titles: item.titles,
+      link_ids: item.link_ids,
+      severity: item.severity,
+      suggested_action: item.suggested_action
+    }
+  end
+
+  defp render_coverage_gap(item) do
+    %{
+      category: item.category,
+      current_count: item.current_count,
+      threshold: item.threshold,
+      severity: item.severity,
+      suggested_action: item.suggested_action
+    }
+  end
+
+  defp render_broken_source(item) do
+    %{
+      article_id: item.article_id,
+      title: item.title,
+      source_type: item.source_type,
+      source_id: item.source_id,
+      severity: item.severity,
+      suggested_action: item.suggested_action
+    }
+  end
+end

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -253,10 +253,14 @@ defmodule LoopctlWeb.Router do
     # Knowledge Export (Obsidian-compatible ZIP)
     get "/knowledge/export", KnowledgeExportController, :export
 
+    # Knowledge Lint (quality analysis report)
+    get "/knowledge/lint", KnowledgeLintController, :lint
+
     scope "/projects/:project_id" do
       resources "/articles", ArticleController, only: [:create, :index], as: :project_article
       get "/knowledge/index", KnowledgeIndexController, :index
       get "/knowledge/export", KnowledgeExportController, :export
+      get "/knowledge/lint", KnowledgeLintController, :lint
     end
 
     # ArticleLink management

--- a/test/loopctl/knowledge_lint_test.exs
+++ b/test/loopctl/knowledge_lint_test.exs
@@ -1,0 +1,386 @@
+defmodule Loopctl.KnowledgeLintTest do
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.Knowledge
+
+  describe "lint/2" do
+    test "returns all five analysis categories" do
+      tenant = fixture(:tenant)
+
+      {:ok, result} = Knowledge.lint(tenant.id)
+
+      assert is_list(result.stale_articles)
+      assert is_list(result.orphan_articles)
+      assert is_list(result.contradiction_clusters)
+      assert is_list(result.coverage_gaps)
+      assert is_list(result.broken_sources)
+      assert is_map(result.summary)
+    end
+
+    test "stale_articles finds articles older than stale_days" do
+      tenant = fixture(:tenant)
+
+      article =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Stale Article",
+          category: :pattern,
+          status: :published
+        })
+
+      # Make the article 200 days old
+      past = DateTime.utc_now() |> DateTime.add(-200 * 86_400, :second)
+
+      import Ecto.Query
+
+      Loopctl.AdminRepo.update_all(
+        from(a in Loopctl.Knowledge.Article, where: a.id == ^article.id),
+        set: [updated_at: past]
+      )
+
+      {:ok, result} = Knowledge.lint(tenant.id)
+
+      assert length(result.stale_articles) == 1
+      [stale] = result.stale_articles
+      assert stale.article_id == article.id
+      assert stale.days_since_update >= 200
+    end
+
+    test "stale_articles respects custom stale_days threshold" do
+      tenant = fixture(:tenant)
+
+      article =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Somewhat Old",
+          category: :pattern,
+          status: :published
+        })
+
+      # Make the article 30 days old
+      past = DateTime.utc_now() |> DateTime.add(-30 * 86_400, :second)
+
+      import Ecto.Query
+
+      Loopctl.AdminRepo.update_all(
+        from(a in Loopctl.Knowledge.Article, where: a.id == ^article.id),
+        set: [updated_at: past]
+      )
+
+      # Default 90 days: not stale
+      {:ok, result} = Knowledge.lint(tenant.id)
+      assert result.stale_articles == []
+
+      # 20 days: stale
+      {:ok, result} = Knowledge.lint(tenant.id, stale_days: 20)
+      assert length(result.stale_articles) == 1
+    end
+
+    test "orphan_articles finds articles with no links" do
+      tenant = fixture(:tenant)
+
+      orphan =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Orphan",
+          category: :pattern,
+          status: :published
+        })
+
+      connected =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Connected",
+          category: :convention,
+          status: :published
+        })
+
+      other =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Other",
+          category: :finding,
+          status: :published
+        })
+
+      fixture(:article_link, %{
+        tenant_id: tenant.id,
+        source_article_id: connected.id,
+        target_article_id: other.id,
+        relationship_type: :relates_to
+      })
+
+      {:ok, result} = Knowledge.lint(tenant.id)
+      orphan_ids = Enum.map(result.orphan_articles, & &1.article_id)
+
+      assert orphan.id in orphan_ids
+      refute connected.id in orphan_ids
+      refute other.id in orphan_ids
+    end
+
+    test "orphan_articles excludes draft articles" do
+      tenant = fixture(:tenant)
+
+      _draft =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Draft No Links",
+          category: :pattern,
+          status: :draft
+        })
+
+      {:ok, result} = Knowledge.lint(tenant.id)
+      # Draft should not appear as orphan because lint only looks at published articles
+      assert Enum.all?(result.orphan_articles, &(&1.title != "Draft No Links"))
+    end
+
+    test "contradiction_clusters groups contradicting articles" do
+      tenant = fixture(:tenant)
+
+      a =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "View A",
+          category: :decision,
+          status: :published
+        })
+
+      b =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "View B",
+          category: :decision,
+          status: :published
+        })
+
+      c =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "View C",
+          category: :decision,
+          status: :published
+        })
+
+      # A contradicts B, B contradicts C → one cluster of {A, B, C}
+      fixture(:article_link, %{
+        tenant_id: tenant.id,
+        source_article_id: a.id,
+        target_article_id: b.id,
+        relationship_type: :contradicts
+      })
+
+      fixture(:article_link, %{
+        tenant_id: tenant.id,
+        source_article_id: b.id,
+        target_article_id: c.id,
+        relationship_type: :contradicts
+      })
+
+      {:ok, result} = Knowledge.lint(tenant.id)
+
+      assert length(result.contradiction_clusters) == 1
+      [cluster] = result.contradiction_clusters
+      assert a.id in cluster.article_ids
+      assert b.id in cluster.article_ids
+      assert c.id in cluster.article_ids
+      assert length(cluster.link_ids) == 2
+    end
+
+    test "contradiction_clusters ignores non-published articles" do
+      tenant = fixture(:tenant)
+
+      published =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Published",
+          category: :decision,
+          status: :published
+        })
+
+      draft =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Draft",
+          category: :decision,
+          status: :draft
+        })
+
+      fixture(:article_link, %{
+        tenant_id: tenant.id,
+        source_article_id: published.id,
+        target_article_id: draft.id,
+        relationship_type: :contradicts
+      })
+
+      {:ok, result} = Knowledge.lint(tenant.id)
+      assert result.contradiction_clusters == []
+    end
+
+    test "coverage_gaps reports categories below min_coverage" do
+      tenant = fixture(:tenant)
+
+      # Create 5 pattern articles
+      for i <- 1..5 do
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Pattern #{i}",
+          category: :pattern,
+          status: :published
+        })
+      end
+
+      {:ok, result} = Knowledge.lint(tenant.id, min_coverage: 3)
+
+      gap_cats = Enum.map(result.coverage_gaps, & &1.category)
+      refute "pattern" in gap_cats
+      assert "convention" in gap_cats
+      assert "decision" in gap_cats
+      assert "finding" in gap_cats
+      assert "reference" in gap_cats
+
+      # Each gap entry has correct threshold
+      Enum.each(result.coverage_gaps, fn gap ->
+        assert gap.threshold == 3
+        assert gap.current_count < 3
+      end)
+    end
+
+    test "broken_sources finds articles with deleted source entities" do
+      tenant = fixture(:tenant)
+
+      broken_id = Ecto.UUID.generate()
+
+      article =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Broken Ref",
+          category: :finding,
+          status: :published,
+          source_type: "review_finding",
+          source_id: broken_id
+        })
+
+      {:ok, result} = Knowledge.lint(tenant.id)
+
+      assert length(result.broken_sources) == 1
+      [broken] = result.broken_sources
+      assert broken.article_id == article.id
+      assert broken.source_id == broken_id
+      assert broken.source_type == "review_finding"
+    end
+
+    test "broken_sources excludes valid review_finding references" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+      story = fixture(:story, %{tenant_id: tenant.id, epic_id: epic.id})
+
+      review_record =
+        fixture(:review_record, %{
+          tenant_id: tenant.id,
+          story_id: story.id
+        })
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Valid Ref",
+        category: :finding,
+        status: :published,
+        source_type: "review_finding",
+        source_id: review_record.id
+      })
+
+      {:ok, result} = Knowledge.lint(tenant.id)
+      assert result.broken_sources == []
+    end
+
+    test "summary contains correct totals" do
+      tenant = fixture(:tenant)
+
+      for i <- 1..4 do
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Article #{i}",
+          category: :pattern,
+          status: :published
+        })
+      end
+
+      {:ok, result} = Knowledge.lint(tenant.id)
+
+      assert result.summary.total_articles == 4
+      assert is_integer(result.summary.total_issues)
+      assert is_map(result.summary.issues_by_severity)
+      assert is_binary(result.summary.generated_at)
+    end
+
+    test "project_id scopes to project-specific and tenant-wide articles" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      other_project = fixture(:project, %{tenant_id: tenant.id})
+
+      # Tenant-wide article
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Tenant Wide",
+        category: :pattern,
+        status: :published
+      })
+
+      # Project-specific article
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        project_id: project.id,
+        title: "Project Art",
+        category: :pattern,
+        status: :published
+      })
+
+      # Other project's article
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        project_id: other_project.id,
+        title: "Other Project Art",
+        category: :pattern,
+        status: :published
+      })
+
+      {:ok, result} = Knowledge.lint(tenant.id, project_id: project.id)
+
+      # Should include tenant-wide + project-specific = 2
+      assert result.summary.total_articles == 2
+    end
+
+    test "tenant isolation: tenant A's lint does not include tenant B's data" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+
+      fixture(:article, %{
+        tenant_id: tenant_a.id,
+        title: "A's Article",
+        category: :pattern,
+        status: :published
+      })
+
+      fixture(:article, %{
+        tenant_id: tenant_b.id,
+        title: "B's Article",
+        category: :pattern,
+        status: :published
+      })
+
+      {:ok, result_a} = Knowledge.lint(tenant_a.id)
+
+      assert result_a.summary.total_articles == 1
+
+      orphan_titles = Enum.map(result_a.orphan_articles, & &1.title)
+
+      if orphan_titles != [] do
+        assert "A's Article" in orphan_titles
+        refute "B's Article" in orphan_titles
+      end
+    end
+  end
+end

--- a/test/loopctl_web/controllers/knowledge_lint_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_lint_controller_test.exs
@@ -1,0 +1,693 @@
+defmodule LoopctlWeb.KnowledgeLintControllerTest do
+  use LoopctlWeb.ConnCase, async: true
+
+  setup :verify_on_exit!
+
+  defp auth_conn(conn, raw_key) do
+    put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  describe "GET /api/v1/knowledge/lint" do
+    test "returns lint report with all sections and summary", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      # Create a few published articles so we get some coverage gaps
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Pattern A",
+        category: :pattern,
+        status: :published
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/lint")
+
+      body = json_response(conn, 200)
+
+      # Verify structure
+      assert is_map(body["data"])
+      assert is_list(body["data"]["stale_articles"])
+      assert is_list(body["data"]["orphan_articles"])
+      assert is_list(body["data"]["contradiction_clusters"])
+      assert is_list(body["data"]["coverage_gaps"])
+      assert is_list(body["data"]["broken_sources"])
+
+      # Verify summary
+      assert is_map(body["summary"])
+      assert body["summary"]["total_articles"] == 1
+      assert is_integer(body["summary"]["total_issues"])
+      assert is_map(body["summary"]["issues_by_severity"])
+      assert is_binary(body["summary"]["generated_at"])
+    end
+
+    test "returns empty report (except coverage gaps) when no published articles exist",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/lint")
+
+      body = json_response(conn, 200)
+
+      assert body["data"]["stale_articles"] == []
+      assert body["data"]["orphan_articles"] == []
+      assert body["data"]["contradiction_clusters"] == []
+      assert body["data"]["broken_sources"] == []
+      assert body["summary"]["total_articles"] == 0
+
+      # All 5 categories are below default min_coverage=3, so 5 coverage gaps exist
+      assert length(body["data"]["coverage_gaps"]) == 5
+      assert body["summary"]["total_issues"] == 5
+    end
+
+    test "requires user role (agent gets 403)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/lint")
+
+      assert json_response(conn, 403)
+    end
+
+    test "unauthenticated returns 401", %{conn: conn} do
+      conn = get(conn, ~p"/api/v1/knowledge/lint")
+      assert json_response(conn, 401)
+    end
+  end
+
+  describe "stale articles (AC-21.5.3)" do
+    test "reports articles not updated within stale_days threshold", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      article =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Stale Pattern",
+          category: :pattern,
+          status: :published
+        })
+
+      # Make the article appear stale (100 days old)
+      past = DateTime.utc_now() |> DateTime.add(-100 * 86_400, :second)
+
+      import Ecto.Query
+
+      Loopctl.AdminRepo.update_all(
+        from(a in Loopctl.Knowledge.Article, where: a.id == ^article.id),
+        set: [updated_at: past]
+      )
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/lint")
+
+      body = json_response(conn, 200)
+      stale = body["data"]["stale_articles"]
+      assert length(stale) == 1
+      [entry] = stale
+      assert entry["article_id"] == article.id
+      assert entry["title"] == "Stale Pattern"
+      assert entry["days_since_update"] >= 100
+      assert entry["severity"] == "warning"
+      assert entry["suggested_action"] =~ "Review and update"
+      assert entry["last_updated"]
+    end
+
+    test "configurable stale_days via query param", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      article =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Recent Article",
+          category: :pattern,
+          status: :published
+        })
+
+      # Make the article 10 days old -- stale if stale_days=5, not stale if stale_days=90
+      past = DateTime.utc_now() |> DateTime.add(-10 * 86_400, :second)
+
+      import Ecto.Query
+
+      Loopctl.AdminRepo.update_all(
+        from(a in Loopctl.Knowledge.Article, where: a.id == ^article.id),
+        set: [updated_at: past]
+      )
+
+      # Default stale_days=90 → not stale
+      conn1 =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/lint")
+
+      body1 = json_response(conn1, 200)
+      assert body1["data"]["stale_articles"] == []
+
+      # stale_days=5 → stale
+      conn2 =
+        build_conn()
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/lint?stale_days=5")
+
+      body2 = json_response(conn2, 200)
+      assert length(body2["data"]["stale_articles"]) == 1
+    end
+  end
+
+  describe "orphan articles (AC-21.5.4)" do
+    test "reports published articles with zero links", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      orphan =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Orphan Article",
+          category: :finding,
+          status: :published
+        })
+
+      linked_source =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Linked Source",
+          category: :pattern,
+          status: :published
+        })
+
+      linked_target =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Linked Target",
+          category: :convention,
+          status: :published
+        })
+
+      # Create a link between linked_source and linked_target
+      fixture(:article_link, %{
+        tenant_id: tenant.id,
+        source_article_id: linked_source.id,
+        target_article_id: linked_target.id,
+        relationship_type: :relates_to
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/lint")
+
+      body = json_response(conn, 200)
+      orphans = body["data"]["orphan_articles"]
+
+      # Only the orphan should appear -- linked_source and linked_target are linked
+      orphan_ids = Enum.map(orphans, & &1["article_id"])
+      assert orphan.id in orphan_ids
+      refute linked_source.id in orphan_ids
+      refute linked_target.id in orphan_ids
+
+      orphan_entry = Enum.find(orphans, &(&1["article_id"] == orphan.id))
+      assert orphan_entry["title"] == "Orphan Article"
+      assert orphan_entry["category"] == "finding"
+      assert orphan_entry["severity"] == "info"
+      assert orphan_entry["suggested_action"] =~ "linking"
+    end
+  end
+
+  describe "contradiction clusters (AC-21.5.5)" do
+    test "groups articles linked with contradicts relationship", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      art_a =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Approach A",
+          category: :decision,
+          status: :published
+        })
+
+      art_b =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Approach B",
+          category: :decision,
+          status: :published
+        })
+
+      link =
+        fixture(:article_link, %{
+          tenant_id: tenant.id,
+          source_article_id: art_a.id,
+          target_article_id: art_b.id,
+          relationship_type: :contradicts
+        })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/lint")
+
+      body = json_response(conn, 200)
+      clusters = body["data"]["contradiction_clusters"]
+      assert length(clusters) == 1
+      [cluster] = clusters
+      assert art_a.id in cluster["article_ids"]
+      assert art_b.id in cluster["article_ids"]
+      assert link.id in cluster["link_ids"]
+      assert cluster["severity"] == "warning"
+      assert cluster["suggested_action"] =~ "Resolve contradiction"
+      assert "Approach A" in cluster["titles"]
+      assert "Approach B" in cluster["titles"]
+    end
+
+    test "no contradictions returns empty array", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "No Conflicts",
+        category: :pattern,
+        status: :published
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/lint")
+
+      body = json_response(conn, 200)
+      assert body["data"]["contradiction_clusters"] == []
+    end
+  end
+
+  describe "coverage gaps (AC-21.5.6)" do
+    test "reports categories with fewer than min_coverage published articles", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      # Create 3 pattern articles (meets default min_coverage=3)
+      for i <- 1..3 do
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Pattern #{i}",
+          category: :pattern,
+          status: :published
+        })
+      end
+
+      # Only 1 convention article (below default min_coverage=3)
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Convention 1",
+        category: :convention,
+        status: :published
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/lint")
+
+      body = json_response(conn, 200)
+      gaps = body["data"]["coverage_gaps"]
+
+      # convention (1), decision (0), finding (0), reference (0) should be gaps
+      # pattern (3) should NOT be a gap
+      gap_categories = Enum.map(gaps, & &1["category"])
+      refute "pattern" in gap_categories
+      assert "convention" in gap_categories
+      assert "decision" in gap_categories
+      assert "finding" in gap_categories
+      assert "reference" in gap_categories
+
+      convention_gap = Enum.find(gaps, &(&1["category"] == "convention"))
+      assert convention_gap["current_count"] == 1
+      assert convention_gap["threshold"] == 3
+      assert convention_gap["severity"] == "info"
+      assert convention_gap["suggested_action"] =~ "Add more articles"
+    end
+
+    test "configurable min_coverage via query param", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Single Pattern",
+        category: :pattern,
+        status: :published
+      })
+
+      # min_coverage=1 → pattern is not a gap
+      conn1 =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/lint?min_coverage=1")
+
+      body1 = json_response(conn1, 200)
+      gap_categories = Enum.map(body1["data"]["coverage_gaps"], & &1["category"])
+      refute "pattern" in gap_categories
+
+      # min_coverage=2 → pattern IS a gap
+      conn2 =
+        build_conn()
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/lint?min_coverage=2")
+
+      body2 = json_response(conn2, 200)
+      gap_categories2 = Enum.map(body2["data"]["coverage_gaps"], & &1["category"])
+      assert "pattern" in gap_categories2
+    end
+  end
+
+  describe "broken sources (AC-21.5.7)" do
+    test "reports articles with source_id referencing deleted entity", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      # Create an article with a non-existent source_id
+      broken_source_id = Ecto.UUID.generate()
+
+      article =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Broken Source Article",
+          category: :finding,
+          status: :published,
+          source_type: "review_finding",
+          source_id: broken_source_id
+        })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/lint")
+
+      body = json_response(conn, 200)
+      broken = body["data"]["broken_sources"]
+      assert length(broken) == 1
+      [entry] = broken
+      assert entry["article_id"] == article.id
+      assert entry["title"] == "Broken Source Article"
+      assert entry["source_type"] == "review_finding"
+      assert entry["source_id"] == broken_source_id
+      assert entry["severity"] == "warning"
+      assert entry["suggested_action"] =~ "Source entity was deleted"
+    end
+
+    test "articles with valid source_id are not reported", %{conn: conn} do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+      story = fixture(:story, %{tenant_id: tenant.id, epic_id: epic.id})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      # Create a real review record
+      review_record =
+        fixture(:review_record, %{
+          tenant_id: tenant.id,
+          story_id: story.id
+        })
+
+      # Create an article pointing to a valid review record
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Valid Source Article",
+        category: :finding,
+        status: :published,
+        source_type: "review_finding",
+        source_id: review_record.id
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/lint")
+
+      body = json_response(conn, 200)
+      assert body["data"]["broken_sources"] == []
+    end
+
+    test "articles with other source_types are not checked", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      # Create an article with source_type "manual" and a random source_id
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Manual Source Article",
+        category: :finding,
+        status: :published,
+        source_type: "manual",
+        source_id: Ecto.UUID.generate()
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/lint")
+
+      body = json_response(conn, 200)
+      # Manual source articles should not appear in broken_sources
+      assert body["data"]["broken_sources"] == []
+    end
+  end
+
+  describe "project-scoped lint (AC-21.5.1)" do
+    test "GET /api/v1/projects/:project_id/knowledge/lint scopes to project", %{conn: conn} do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      other_project = fixture(:project, %{tenant_id: tenant.id})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      # Tenant-wide article (nil project_id) — should be included
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Tenant Wide",
+        category: :pattern,
+        status: :published
+      })
+
+      # Project-specific article — should be included
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        project_id: project.id,
+        title: "Project Specific",
+        category: :convention,
+        status: :published
+      })
+
+      # Other project's article — should be excluded
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        project_id: other_project.id,
+        title: "Other Project",
+        category: :decision,
+        status: :published
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/projects/#{project.id}/knowledge/lint")
+
+      body = json_response(conn, 200)
+
+      # Should include tenant-wide + project-specific = 2 total
+      assert body["summary"]["total_articles"] == 2
+    end
+  end
+
+  describe "parameter validation (AC-21.5.11)" do
+    test "invalid stale_days returns 400", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/lint?stale_days=abc")
+
+      body = json_response(conn, 400)
+      assert body["error"]["message"] =~ "stale_days must be a positive integer"
+    end
+
+    test "zero stale_days returns 400", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/lint?stale_days=0")
+
+      body = json_response(conn, 400)
+      assert body["error"]["message"] =~ "stale_days must be a positive integer"
+    end
+
+    test "negative stale_days returns 400", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/lint?stale_days=-5")
+
+      body = json_response(conn, 400)
+      assert body["error"]["message"] =~ "stale_days must be a positive integer"
+    end
+
+    test "invalid min_coverage returns 400", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/lint?min_coverage=xyz")
+
+      body = json_response(conn, 400)
+      assert body["error"]["message"] =~ "min_coverage must be a positive integer"
+    end
+
+    test "zero min_coverage returns 400", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/lint?min_coverage=0")
+
+      body = json_response(conn, 400)
+      assert body["error"]["message"] =~ "min_coverage must be a positive integer"
+    end
+  end
+
+  describe "summary (AC-21.5.8)" do
+    test "summary includes correct issue counts by severity", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      # Create a stale article (warning)
+      article =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Old Pattern",
+          category: :pattern,
+          status: :published
+        })
+
+      past = DateTime.utc_now() |> DateTime.add(-100 * 86_400, :second)
+
+      import Ecto.Query
+
+      Loopctl.AdminRepo.update_all(
+        from(a in Loopctl.Knowledge.Article, where: a.id == ^article.id),
+        set: [updated_at: past]
+      )
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/lint")
+
+      body = json_response(conn, 200)
+      summary = body["summary"]
+
+      assert summary["total_articles"] == 1
+
+      # At minimum: 1 stale (warning) + orphan (info, since no links) + coverage gaps (info)
+      assert summary["total_issues"] > 0
+      assert is_map(summary["issues_by_severity"])
+
+      # The stale article is a warning
+      assert summary["issues_by_severity"]["warning"] >= 1
+    end
+  end
+
+  describe "tenant isolation (AC-21.5.10)" do
+    test "tenant A cannot see tenant B's articles in lint report", %{conn: conn} do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      {raw_key_a, _} = fixture(:api_key, %{tenant_id: tenant_a.id, role: :user})
+
+      # Create articles for both tenants
+      fixture(:article, %{
+        tenant_id: tenant_a.id,
+        title: "Tenant A Article",
+        category: :pattern,
+        status: :published
+      })
+
+      fixture(:article, %{
+        tenant_id: tenant_b.id,
+        title: "Tenant B Article",
+        category: :pattern,
+        status: :published
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key_a)
+        |> get(~p"/api/v1/knowledge/lint")
+
+      body = json_response(conn, 200)
+
+      # Only tenant A's article should count
+      assert body["summary"]["total_articles"] == 1
+
+      # If orphan articles show up, they should only be tenant A's
+      orphan_titles =
+        body["data"]["orphan_articles"]
+        |> Enum.map(& &1["title"])
+
+      if orphan_titles != [] do
+        assert "Tenant A Article" in orphan_titles
+        refute "Tenant B Article" in orphan_titles
+      end
+    end
+  end
+
+  describe "read-only operation (AC-21.5.9)" do
+    test "lint does not modify any articles", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      article =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Immutable Article",
+          category: :pattern,
+          status: :published
+        })
+
+      original_updated_at = article.updated_at
+
+      _conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/lint")
+
+      # Re-fetch the article and verify it's unchanged
+      {:ok, refetched} = Loopctl.Knowledge.get_article(tenant.id, article.id)
+      assert refetched.updated_at == original_updated_at
+      assert refetched.title == "Immutable Article"
+      assert refetched.status == :published
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add read-only knowledge lint endpoints that analyze published articles for quality issues
- `GET /api/v1/knowledge/lint` (tenant-wide) and `GET /api/v1/projects/:project_id/knowledge/lint` (project-scoped)
- Reports five issue categories: stale articles, orphan articles, contradiction clusters, coverage gaps, broken source references
- Configurable thresholds via `?stale_days=N` and `?min_coverage=N` query params with validation (400 on invalid)
- Role requirement: `user+` (management-level operation)
- 36 new tests covering all 11 acceptance criteria, tenant isolation, and parameter validation
- All 1940 tests passing, precommit clean (credo --strict, dialyzer, formatter)

## Test plan

- [x] Tenant-wide lint returns structured report with all 5 sections and summary
- [x] Project-scoped lint includes tenant-wide + project-specific articles only
- [x] Stale articles detected with configurable `stale_days` threshold
- [x] Orphan articles (zero links) correctly identified
- [x] Contradiction clusters group articles linked with `:contradicts`
- [x] Coverage gaps report categories below `min_coverage` threshold
- [x] Broken sources detect `review_finding` articles with deleted source entities
- [x] Summary includes correct totals, severity breakdown, and ISO 8601 timestamp
- [x] Invalid query params return 400 with descriptive error
- [x] Agent role gets 403, unauthenticated gets 401
- [x] Tenant isolation verified (tenant A cannot see tenant B data)
- [x] Read-only operation verified (no data modified)

Story: d4fb0d78-9fcb-4445-81ed-ee4d4760fe72

🤖 Generated with [Claude Code](https://claude.com/claude-code)