### PR TITLE
US-24.7: MCP Tools for Knowledge Write Operations

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -2,7 +2,7 @@
 
 MCP (Model Context Protocol) server for [loopctl](https://loopctl.com) -- structural trust for AI development loops.
 
-Wraps the loopctl REST API into 29 typed MCP tools so AI coding agents (Claude Code, etc.) can interact with loopctl without writing curl commands.
+Wraps the loopctl REST API into 33 typed MCP tools so AI coding agents (Claude Code, etc.) can interact with loopctl without writing curl commands.
 
 ## Installation
 
@@ -65,7 +65,7 @@ Or if installed locally:
 
 Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_KEY`.
 
-## Tools (29)
+## Tools (33)
 
 ### Project Tools
 
@@ -134,6 +134,15 @@ Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_K
 | `knowledge_get` | Get full article content by ID. Use after search to read an article in detail. |
 | `knowledge_context` | Get relevance-and-recency-ranked full articles for a task query. Best knowledge for your current context. |
 | `knowledge_create` | Create a new knowledge article. File findings, document patterns, or record decisions. |
+
+### Knowledge Management Tools (orchestrator key)
+
+| Tool | Description |
+|---|---|
+| `knowledge_publish` | Publish a draft article, making it visible to all agents. Required: `article_id`. |
+| `knowledge_drafts` | List all draft (unpublished) knowledge articles. Optional: `limit`, `offset`. |
+| `knowledge_lint` | Run a lint check on the knowledge wiki to identify stale or low-coverage articles. Optional: `project_id`, `stale_days`, `min_coverage`. |
+| `knowledge_export` | Export all knowledge articles as a ZIP archive. Returns a curl command for direct download (ZIP binary cannot be returned as MCP content). Optional: `project_id`. |
 
 ### Discovery Tools
 

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -450,6 +450,54 @@ async function knowledgeCreate({ title, body, category, tags, project_id }) {
   return toContent(result);
 }
 
+// --- Knowledge Management Tools (orch key) ---
+
+async function knowledgePublish({ article_id }) {
+  const result = await apiCall("POST", `/api/v1/articles/${article_id}/publish`, null, process.env.LOOPCTL_ORCH_KEY);
+  return toContent(result);
+}
+
+async function knowledgeDrafts({ limit, offset }) {
+  const params = new URLSearchParams();
+  if (limit != null) params.set("limit", String(limit));
+  if (offset != null) params.set("offset", String(offset));
+  const qs = params.toString();
+  const path = qs ? `/api/v1/knowledge/drafts?${qs}` : "/api/v1/knowledge/drafts";
+  const result = await apiCall("GET", path, null, process.env.LOOPCTL_ORCH_KEY);
+  return toContent(result);
+}
+
+async function knowledgeLint({ project_id, stale_days, min_coverage }) {
+  const params = new URLSearchParams();
+  if (stale_days != null) params.set("stale_days", String(stale_days));
+  if (min_coverage != null) params.set("min_coverage", String(min_coverage));
+  const qs = params.toString();
+  const basePath = project_id
+    ? `/api/v1/projects/${project_id}/knowledge/lint`
+    : "/api/v1/knowledge/lint";
+  const path = qs ? `${basePath}?${qs}` : basePath;
+  const result = await apiCall("GET", path, null, process.env.LOOPCTL_ORCH_KEY);
+  return toContent(result);
+}
+
+async function knowledgeExport({ project_id }) {
+  const basePath = project_id
+    ? `/api/v1/projects/${project_id}/knowledge/export`
+    : "/api/v1/knowledge/export";
+  const baseUrl = getBaseUrl();
+  const downloadCmd = `curl -H "Authorization: Bearer $LOOPCTL_ORCH_KEY" "${baseUrl}${basePath}" -o knowledge-export.zip`;
+  return {
+    content: [{
+      type: "text",
+      text: JSON.stringify({
+        message: "Knowledge export produces a ZIP file. Use the curl command below to download it directly.",
+        command: downloadCmd,
+        endpoint: `${baseUrl}${basePath}`,
+      }, null, 2),
+    }],
+  };
+}
+
 // --- Discovery Tools ---
 
 async function listRoutes() {
@@ -1130,6 +1178,84 @@ const TOOLS = [
     },
   },
 
+  // Knowledge Management Tools (orchestrator key)
+  {
+    name: "knowledge_publish",
+    description:
+      "Publish a draft knowledge article, making it visible to all agents. Requires orchestrator role.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        article_id: {
+          type: "string",
+          description: "The UUID of the draft article to publish.",
+        },
+      },
+      required: ["article_id"],
+    },
+  },
+  {
+    name: "knowledge_drafts",
+    description:
+      "List all draft (unpublished) knowledge articles. Requires orchestrator role. Use to review pending articles before publishing.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        limit: {
+          type: "integer",
+          description: "Optional: maximum number of drafts to return.",
+        },
+        offset: {
+          type: "integer",
+          description: "Optional: pagination offset.",
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: "knowledge_lint",
+    description:
+      "Run a lint check on the knowledge wiki to identify stale, low-coverage, or broken articles. " +
+      "Requires orchestrator role. Optionally scoped to a project.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        project_id: {
+          type: "string",
+          description: "Optional: scope lint to a specific project UUID.",
+        },
+        stale_days: {
+          type: "integer",
+          description: "Optional: flag articles not updated in this many days as stale.",
+        },
+        min_coverage: {
+          type: "number",
+          description: "Optional: minimum required coverage score (0.0-1.0) to flag under-covered articles.",
+          minimum: 0,
+          maximum: 1,
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: "knowledge_export",
+    description:
+      "Export all knowledge articles as a ZIP archive. Because ZIP binary cannot be returned as MCP content, " +
+      "this tool returns a curl command you can run directly to download the archive.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        project_id: {
+          type: "string",
+          description: "Optional: scope export to a specific project UUID.",
+        },
+      },
+      required: [],
+    },
+  },
+
   // Discovery Tools
   {
     name: "list_routes",
@@ -1255,6 +1381,19 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     case "knowledge_create":
       return await knowledgeCreate(args);
+
+    // Knowledge Management Tools
+    case "knowledge_publish":
+      return await knowledgePublish(args);
+
+    case "knowledge_drafts":
+      return await knowledgeDrafts(args);
+
+    case "knowledge_lint":
+      return await knowledgeLint(args);
+
+    case "knowledge_export":
+      return await knowledgeExport(args);
 
     // Discovery Tools
     case "list_routes":


### PR DESCRIPTION
## Summary

- Adds 4 knowledge management MCP tools to `mcp-server/index.js`, all using `LOOPCTL_ORCH_KEY`
- `knowledge_publish` — calls `POST /api/v1/articles/:id/publish`, required: `article_id`
- `knowledge_drafts` — calls `GET /api/v1/knowledge/drafts`, optional: `limit`, `offset`
- `knowledge_lint` — calls `GET /api/v1/knowledge/lint` (or project-scoped variant), optional: `project_id`, `stale_days`, `min_coverage`
- `knowledge_export` — returns a curl command for ZIP download (binary cannot be returned as MCP content)
- Updates README tool count from 29 to 33 and adds a Knowledge Management Tools section

## Test plan

- [x] `node --check mcp-server/index.js` passes (syntax valid)
- [x] Pre-commit hook passes: 1965 tests, 0 failures, credo clean, dialyzer clean
- [x] All 4 functions defined with correct signatures and ORCH_KEY
- [x] All 4 TOOLS entries have proper `inputSchema` with required vs optional params
- [x] All 4 switch cases wired in `callTool` handler
- [x] `knowledge_export` returns curl command, not raw binary
- [x] README updated: tool count 29 → 33, new table section added

Closes US-24.7 (story_id: 6c23b22e-76cc-4c33-877e-76c49bd06e2f)