### PR TITLE
US-19.1: Update MCP tool count on landing page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,7 @@ mix ecto.reset         # Drop, create, migrate
 - **User Stories**: `docs/user_stories/epic_N_name/us_N.M.json` — 60 stories across 15 epics
 - **Skills**: `skills/loopctl-*.md` — 6 orchestration skills
 - **Orchestration Guide**: `docs/orchestration-guide.md` — methodology: loop, trust model, checkpointing
-- **MCP Server**: `mcp-server/` — 24 typed tools for Claude Code agents (no curl needed), published as `loopctl-mcp-server` on npm
+- **MCP Server**: `mcp-server/` — 33 typed tools for Claude Code agents (no curl needed), published as `loopctl-mcp-server` on npm
 - **Build Status**: memory-keeper key `build_status`, channel `loopctl`
 
 ## MCP Server
@@ -190,7 +190,7 @@ Claude Code agents should use the loopctl MCP tools instead of curl. Install via
 {"mcpServers": {"loopctl": {"command": "npx", "args": ["loopctl-mcp-server"], "env": {"LOOPCTL_SERVER": "https://loopctl.com", "LOOPCTL_ORCH_KEY": "...", "LOOPCTL_AGENT_KEY": "..."}}}}
 ```
 
-Tools: `mcp__loopctl__list_projects`, `mcp__loopctl__list_stories`, `mcp__loopctl__verify_story`, etc. (24 total). See `mcp-server/README.md` for the full list.
+Tools: `mcp__loopctl__list_projects`, `mcp__loopctl__list_stories`, `mcp__loopctl__verify_story`, etc. (33 total). See `mcp-server/README.md` for the full list.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -781,7 +781,7 @@ cd mcp-server && npm install
 
 Keys must be in the `env` block — the MCP server process does not inherit the shell environment.
 
-### Available Tools (24)
+### Available Tools (33)
 
 | Tool | Description | API Key Used |
 |------|------------|-------------|
@@ -808,6 +808,15 @@ Keys must be in the `env` block — the MCP server process does not inherit the 
 | `get_story_token_usage` | Token usage records for a story | orchestrator |
 | `get_cost_anomalies` | Cost anomaly alerts | orchestrator |
 | `set_token_budget` | Set token budget for a scope | orchestrator |
+| `knowledge_index` | Load knowledge wiki catalog | agent |
+| `knowledge_search` | Search knowledge wiki by topic | agent |
+| `knowledge_get` | Get full article content by ID | agent |
+| `knowledge_context` | Get relevance-ranked articles for a task query | agent |
+| `knowledge_create` | Create a new knowledge article | agent |
+| `knowledge_publish` | Publish a draft article | orchestrator |
+| `knowledge_drafts` | List draft (unpublished) articles | orchestrator |
+| `knowledge_lint` | Lint check for stale or low-coverage articles | orchestrator |
+| `knowledge_export` | Export all articles as ZIP archive | orchestrator |
 | `list_routes` | Discover all API endpoints | orchestrator |
 
 Agents call tools directly: `mcp__loopctl__get_tenant()`, `mcp__loopctl__list_projects()`, `mcp__loopctl__create_project({name: "MyApp", slug: "myapp"})`. No curl or bash needed.

--- a/lib/loopctl_web/controllers/page_html/home.html.heex
+++ b/lib/loopctl_web/controllers/page_html/home.html.heex
@@ -282,7 +282,7 @@
                   MCP Integration
                 </dt>
                 <dd class="mt-1.5 text-slate-400">
-                  24 typed tools for AI coding agents. No curl needed — agents interact through the MCP server.
+                  33 typed tools for AI coding agents. No curl needed — agents interact through the MCP server.
                 </dd>
               </div>
 
@@ -731,7 +731,7 @@
                   Install via
                   <span class="text-slate-400 font-mono">npm install loopctl-mcp-server</span>
                   or run with <span class="text-slate-400 font-mono">npx loopctl-mcp-server</span>.
-                  24 typed tools for AI coding agents.
+                  33 typed tools for AI coding agents.
                 </p>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Updates MCP tool count from 24 to 33 across landing page (`home.html.heex`, 2 occurrences) and `CLAUDE.md` (2 occurrences) to match actual published MCP server tool count.

## Test plan
- [x] `mix precommit` passes (1965 tests, 0 failures, credo clean, dialyzer clean)
- [x] Verified all four occurrences updated: landing page lines 285 and 734, CLAUDE.md lines 182 and 193