### PR TITLE
Fix 2 adversarial review findings for PR #43

### DIFF
--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -1403,7 +1403,8 @@ defmodule Loopctl.Knowledge do
       where: l.tenant_id == ^tenant_id,
       where: l.source_article_id == ^article_id or l.target_article_id == ^article_id,
       preload: [:source_article, :target_article],
-      order_by: [desc: l.inserted_at]
+      order_by: [desc: l.inserted_at],
+      limit: 100
     )
     |> AdminRepo.all()
   end

--- a/lib/loopctl/knowledge/article_link.ex
+++ b/lib/loopctl/knowledge/article_link.ex
@@ -57,6 +57,7 @@ defmodule Loopctl.Knowledge.ArticleLink do
     |> cast(attrs, @cast_fields)
     |> validate_required([:source_article_id, :target_article_id, :relationship_type])
     |> validate_no_self_link()
+    |> validate_metadata()
     |> foreign_key_constraint(:source_article_id)
     |> foreign_key_constraint(:target_article_id)
     |> unique_constraint(
@@ -64,6 +65,16 @@ defmodule Loopctl.Knowledge.ArticleLink do
       name: :article_links_tenant_src_tgt_rel_index,
       message: "link already exists between these articles with this relationship type"
     )
+  end
+
+  defp validate_metadata(changeset) do
+    validate_change(changeset, :metadata, fn :metadata, value ->
+      if is_map(value) and not is_struct(value) do
+        []
+      else
+        [metadata: "must be a map"]
+      end
+    end)
   end
 
   defp validate_no_self_link(changeset) do


### PR DESCRIPTION
## Summary

- **list_links_for_article/2 unbounded query (Medium)**: Added `limit: 100` cap to prevent unbounded result sets. The function returns all links for an article with 2 preloads (`source_article`, `target_article`), which could produce large payloads without a limit.
- **ArticleLink changeset missing metadata validation (Low)**: Added `validate_metadata/1` private function matching the existing pattern in `Article` schema — ensures metadata is a plain map, not a struct.

## Test plan

- [x] `mix precommit` passes (compile, format, credo --strict, dialyzer, 1965 tests, 0 failures)
- [x] No changes to test files — existing test coverage validates both paths