### PR TITLE
Fix 1 adversarial review finding for PR #56

### DIFF
--- a/lib/loopctl/workers/review_knowledge_worker.ex
+++ b/lib/loopctl/workers/review_knowledge_worker.ex
@@ -139,7 +139,7 @@ defmodule Loopctl.Workers.ReviewKnowledgeWorker do
 
   defp valid_title?(attrs) do
     title = Map.get(attrs, :title) || Map.get(attrs, "title")
-    is_binary(title) and title != ""
+    is_binary(title) and title != "" and String.length(title) <= 500
   end
 
   defp valid_body?(attrs) do

--- a/test/loopctl/workers/review_knowledge_worker_test.exs
+++ b/test/loopctl/workers/review_knowledge_worker_test.exs
@@ -289,6 +289,37 @@ defmodule Loopctl.Workers.ReviewKnowledgeWorkerTest do
       assert hd(articles).title == "Valid"
     end
 
+    test "skips articles with title exceeding 500 characters" do
+      %{tenant: tenant} = setup_tenant()
+      review_record = create_review_record(tenant.id)
+
+      expect(Loopctl.MockExtractor, :extract_articles, fn _ctx ->
+        {:ok,
+         [
+           %{title: "Valid", body: "Short body.", category: :pattern},
+           %{
+             title: String.duplicate("x", 501),
+             body: "Body for oversized title.",
+             category: :pattern
+           }
+         ]}
+      end)
+
+      assert :ok =
+               ReviewKnowledgeWorker.perform(%Oban.Job{
+                 args: %{
+                   "review_record_id" => review_record.id,
+                   "tenant_id" => tenant.id
+                 }
+               })
+
+      %{data: articles} =
+        Knowledge.list_articles(tenant.id, source_type: "review_finding")
+
+      assert length(articles) == 1
+      assert hd(articles).title == "Valid"
+    end
+
     test "skips articles with invalid tags" do
       %{tenant: tenant} = setup_tenant()
       review_record = create_review_record(tenant.id)


### PR DESCRIPTION
## Summary

- **Batch-poison pattern in ReviewKnowledgeWorker** (Medium): `valid_title?/1` validated that the title was a non-empty binary but did NOT check its length. The Article changeset enforces `validate_length(:title, max: 500)`. If the LLM extractor returned one article with a >500 character title, the changeset validation failed inside the `Ecto.Multi`, causing the entire batch to fail -- all valid articles in the batch were discarded.
- Added `String.length(title) <= 500` guard to `valid_title?/1` to filter oversized titles at the pre-validation stage, matching the existing pattern used by `valid_body?/1` with `@max_body_length`.
- Added test case verifying that articles with titles exceeding 500 characters are filtered out without affecting valid articles in the same batch.

## Test plan

- [x] Existing test suite passes (1966 tests, 0 failures)
- [x] New test: "skips articles with title exceeding 500 characters" -- verifies a 501-char title is filtered while a valid article is inserted
- [x] Full precommit gate passes (compile, format, credo --strict, dialyzer, tests)