### PR TITLE
Fix article 500s and knowledge role requirements

### DIFF
--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -153,6 +153,34 @@ defmodule Loopctl.Knowledge do
   end
 
   @doc """
+  Fetches a single article by tenant and ID, including the embedding vector.
+
+  The `embedding` field uses `load_in_query: false` to avoid loading the
+  (potentially large) vector on every query. This function explicitly
+  selects the embedding for callers that need it (e.g., embedding and
+  linking workers).
+
+  ## Returns
+
+  - `{:ok, %Article{}}` with the `embedding` field populated
+  - `{:error, :not_found}` if not found or belongs to another tenant
+  """
+  @spec get_article_with_embedding(Ecto.UUID.t(), Ecto.UUID.t()) ::
+          {:ok, Article.t()} | {:error, :not_found}
+  def get_article_with_embedding(tenant_id, article_id) do
+    query =
+      from(a in Article,
+        where: a.id == ^article_id and a.tenant_id == ^tenant_id,
+        select_merge: %{embedding: a.embedding}
+      )
+
+    case AdminRepo.one(query) do
+      nil -> {:error, :not_found}
+      article -> {:ok, article}
+    end
+  end
+
+  @doc """
   Lists articles for a tenant with optional filtering and pagination.
 
   ## Parameters

--- a/lib/loopctl/knowledge/article.ex
+++ b/lib/loopctl/knowledge/article.ex
@@ -48,7 +48,7 @@ defmodule Loopctl.Knowledge.Article do
     field :source_id, :binary_id
     field :metadata, :map, default: %{}
 
-    field :embedding, Pgvector.Ecto.Vector
+    field :embedding, Pgvector.Ecto.Vector, load_in_query: false
 
     has_many :outgoing_links, Loopctl.Knowledge.ArticleLink, foreign_key: :source_article_id
     has_many :incoming_links, Loopctl.Knowledge.ArticleLink, foreign_key: :target_article_id

--- a/lib/loopctl/workers/article_linking_worker.ex
+++ b/lib/loopctl/workers/article_linking_worker.ex
@@ -53,21 +53,22 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
 
   alias Loopctl.AdminRepo
   alias Loopctl.Audit
+  alias Loopctl.Knowledge
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.ArticleLink
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"article_id" => article_id, "tenant_id" => tenant_id}}) do
-    case AdminRepo.get_by(Article, id: article_id, tenant_id: tenant_id) do
-      nil ->
+    case Knowledge.get_article_with_embedding(tenant_id, article_id) do
+      {:error, :not_found} ->
         # Article deleted -- no-op
         :ok
 
-      %Article{embedding: nil} ->
+      {:ok, %Article{embedding: nil}} ->
         # No embedding yet -- no-op
         :ok
 
-      %Article{} = article ->
+      {:ok, %Article{} = article} ->
         threshold = Application.get_env(:loopctl, :article_link_threshold, 0.8)
         max_comparisons = Application.get_env(:loopctl, :article_link_max_comparisons, 50)
         find_and_link_similar(article, tenant_id, threshold, max_comparisons)

--- a/lib/loopctl_web/controllers/article_workflow_controller.ex
+++ b/lib/loopctl_web/controllers/article_workflow_controller.ex
@@ -2,11 +2,11 @@ defmodule LoopctlWeb.ArticleWorkflowController do
   @moduledoc """
   Controller for article publish workflow operations.
 
-  - `POST /api/v1/articles/:id/publish` -- publish a draft article (user+)
+  - `POST /api/v1/articles/:id/publish` -- publish a draft article (orchestrator+)
   - `POST /api/v1/articles/:id/unpublish` -- unpublish a published article (user+)
   - `POST /api/v1/articles/:id/archive` -- archive an article (user+)
   - `POST /api/v1/knowledge/bulk-publish` -- bulk publish drafts (user+)
-  - `GET /api/v1/knowledge/drafts` -- list draft articles (user+)
+  - `GET /api/v1/knowledge/drafts` -- list draft articles (orchestrator+)
   """
 
   use LoopctlWeb, :controller
@@ -19,7 +19,10 @@ defmodule LoopctlWeb.ArticleWorkflowController do
 
   action_fallback LoopctlWeb.FallbackController
 
-  plug LoopctlWeb.Plugs.RequireRole, role: :user
+  plug LoopctlWeb.Plugs.RequireRole, [role: :orchestrator] when action in [:drafts, :publish]
+
+  plug LoopctlWeb.Plugs.RequireRole,
+       [role: :user] when action in [:unpublish, :archive, :bulk_publish]
 
   tags(["Knowledge Wiki"])
 
@@ -27,7 +30,7 @@ defmodule LoopctlWeb.ArticleWorkflowController do
     summary: "Publish article",
     description:
       "Transitions article from draft to published. " <>
-        "Returns 422 if the transition is invalid. Role: user+.",
+        "Returns 422 if the transition is invalid. Role: orchestrator+.",
     parameters: [id: [in: :path, type: :string, description: "Article UUID"]],
     responses: %{
       200 =>
@@ -111,7 +114,7 @@ defmodule LoopctlWeb.ArticleWorkflowController do
     summary: "List draft articles",
     description:
       "Lists draft articles ordered by inserted_at desc. " <>
-        "Includes source_type and source_id for review queue visibility. Role: user+.",
+        "Includes source_type and source_id for review queue visibility. Role: orchestrator+.",
     parameters: [
       project_id: [in: :query, type: :string, description: "Filter by project UUID"],
       limit: [in: :query, type: :integer, description: "Max results (default 20, max 100)"],

--- a/lib/loopctl_web/controllers/knowledge_lint_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_lint_controller.ex
@@ -2,8 +2,8 @@ defmodule LoopctlWeb.KnowledgeLintController do
   @moduledoc """
   Controller for the knowledge lint operation.
 
-  - `GET /api/v1/knowledge/lint` -- tenant-wide lint report (user+)
-  - `GET /api/v1/projects/:project_id/knowledge/lint` -- project-scoped lint report (user+)
+  - `GET /api/v1/knowledge/lint` -- tenant-wide lint report (orchestrator+)
+  - `GET /api/v1/projects/:project_id/knowledge/lint` -- project-scoped lint report (orchestrator+)
 
   Analyzes published articles and returns a structured report of potential
   issues: stale articles, orphaned articles, contradiction clusters,
@@ -20,7 +20,7 @@ defmodule LoopctlWeb.KnowledgeLintController do
 
   action_fallback LoopctlWeb.FallbackController
 
-  plug LoopctlWeb.Plugs.RequireRole, role: :user
+  plug LoopctlWeb.Plugs.RequireRole, role: :orchestrator
 
   tags(["Knowledge Wiki"])
 
@@ -31,7 +31,7 @@ defmodule LoopctlWeb.KnowledgeLintController do
         "issues including stale articles, orphaned articles, contradiction clusters, " <>
         "coverage gaps, and broken source references. Read-only operation. " <>
         "When called via GET /projects/:project_id/knowledge/lint, scopes analysis " <>
-        "to project-specific and tenant-wide articles. Role: user+.",
+        "to project-specific and tenant-wide articles. Role: orchestrator+.",
     parameters: [
       project_id: [
         in: :path,

--- a/lib/loopctl_web/controllers/knowledge_pipeline_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_pipeline_controller.ex
@@ -2,7 +2,7 @@ defmodule LoopctlWeb.KnowledgePipelineController do
   @moduledoc """
   Controller for the knowledge pipeline status endpoint.
 
-  - `GET /api/v1/knowledge/pipeline` -- pipeline status (user+)
+  - `GET /api/v1/knowledge/pipeline` -- pipeline status (orchestrator+)
 
   Returns metrics about the self-learning knowledge extraction pipeline:
   pending extractions, recent drafts, publish rate, extraction errors,
@@ -17,7 +17,7 @@ defmodule LoopctlWeb.KnowledgePipelineController do
 
   action_fallback LoopctlWeb.FallbackController
 
-  plug LoopctlWeb.Plugs.RequireRole, role: :user
+  plug LoopctlWeb.Plugs.RequireRole, role: :orchestrator
 
   tags(["Knowledge Wiki"])
 
@@ -26,7 +26,7 @@ defmodule LoopctlWeb.KnowledgePipelineController do
     description:
       "Returns metrics about the self-learning knowledge extraction pipeline " <>
         "including pending extractions, recent drafts, publish rate, extraction " <>
-        "errors, and the auto_extract_enabled setting. Role: user+.",
+        "errors, and the auto_extract_enabled setting. Role: orchestrator+.",
     responses: %{
       200 =>
         {"Pipeline status", "application/json",

--- a/test/loopctl/knowledge_embedding_test.exs
+++ b/test/loopctl/knowledge_embedding_test.exs
@@ -29,8 +29,8 @@ defmodule Loopctl.KnowledgeEmbeddingTest do
       assert updated.id == article.id
       assert updated.embedding != nil
 
-      # Reload from DB to verify the stored vector has correct dimensions
-      assert {:ok, reloaded} = Knowledge.get_article(tenant.id, article.id)
+      # Reload from DB with embedding explicitly selected (load_in_query: false)
+      assert {:ok, reloaded} = Knowledge.get_article_with_embedding(tenant.id, article.id)
       stored = Pgvector.to_list(reloaded.embedding)
       assert length(stored) == 1536
       assert Enum.all?(stored, &(abs(&1 - 0.1) < 0.001))
@@ -66,8 +66,8 @@ defmodule Loopctl.KnowledgeEmbeddingTest do
       assert {:ok, _} = Knowledge.update_embedding(tenant.id, article.id, first_embedding)
       assert {:ok, _} = Knowledge.update_embedding(tenant.id, article.id, second_embedding)
 
-      # Reload from DB to verify the overwritten value
-      assert {:ok, reloaded} = Knowledge.get_article(tenant.id, article.id)
+      # Reload from DB with embedding explicitly selected (load_in_query: false)
+      assert {:ok, reloaded} = Knowledge.get_article_with_embedding(tenant.id, article.id)
       stored = Pgvector.to_list(reloaded.embedding)
       assert Enum.all?(stored, &(abs(&1 - 0.9) < 0.001))
     end
@@ -127,8 +127,8 @@ defmodule Loopctl.KnowledgeEmbeddingTest do
 
       assert updated.title == "Updated Title"
 
-      # Reload to verify embedding is preserved
-      assert {:ok, reloaded} = Knowledge.get_article(tenant.id, article.id)
+      # Reload with embedding explicitly selected (load_in_query: false)
+      assert {:ok, reloaded} = Knowledge.get_article_with_embedding(tenant.id, article.id)
       assert reloaded.embedding != nil
       assert length(Pgvector.to_list(reloaded.embedding)) == 1536
     end

--- a/test/loopctl/workers/article_embedding_worker_test.exs
+++ b/test/loopctl/workers/article_embedding_worker_test.exs
@@ -59,8 +59,8 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorkerTest do
                  args: %{"article_id" => article.id, "tenant_id" => tenant.id}
                })
 
-      # Verify embedding was stored
-      {:ok, updated} = Knowledge.get_article(tenant.id, article.id)
+      # Verify embedding was stored (use explicit select since load_in_query: false)
+      {:ok, updated} = Knowledge.get_article_with_embedding(tenant.id, article.id)
       assert updated.embedding != nil
     end
   end
@@ -129,7 +129,7 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorkerTest do
         })
 
       # In inline mode, the job executes synchronously. Verify embedding was stored.
-      {:ok, loaded} = Knowledge.get_article(tenant.id, article.id)
+      {:ok, loaded} = Knowledge.get_article_with_embedding(tenant.id, article.id)
       assert loaded.embedding != nil
     end
 
@@ -145,7 +145,7 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorkerTest do
           status: :draft
         })
 
-      {:ok, loaded} = Knowledge.get_article(tenant.id, article.id)
+      {:ok, loaded} = Knowledge.get_article_with_embedding(tenant.id, article.id)
       assert loaded.embedding == nil
     end
   end
@@ -294,7 +294,7 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorkerTest do
 
       # Verify tenant_a's article embedding was NOT modified by the wrong-tenant worker.
       # The embedding from create_published_article should remain unchanged.
-      {:ok, loaded} = Knowledge.get_article(tenant_a.id, article.id)
+      {:ok, loaded} = Knowledge.get_article_with_embedding(tenant_a.id, article.id)
       assert loaded.embedding != nil
     end
   end


### PR DESCRIPTION
## Summary

- **Fix article 500s in production**: The `embedding` column on the `articles` table causes all article queries to fail when pgvector is not installed. Added `load_in_query: false` to exclude the embedding from default SELECT queries. Added `Knowledge.get_article_with_embedding/2` for workers that need explicit embedding access. Updated `ArticleLinkingWorker` to use the new function.

- **Fix knowledge endpoint 403s for orchestrators**: Lowered role requirements on knowledge workflow endpoints so orchestrators can manage the self-learning pipeline:
  - `ArticleWorkflowController`: `drafts` and `publish` actions now require `orchestrator+` (was `user+`). Destructive actions (`unpublish`, `archive`, `bulk_publish`) remain `user+`.
  - `KnowledgeLintController`: Now requires `orchestrator+` (read-only lint report).
  - `KnowledgePipelineController`: Now requires `orchestrator+` (read-only pipeline status).

## Security review

Per the CLAUDE.md security checklist:
1. **Chain-of-custody**: Not affected -- these are knowledge management endpoints, not story verification.
2. **Destructive capabilities**: Preserved -- `unpublish`, `archive`, `bulk_publish` remain `user+`.
3. **Trust boundaries**: Maintained -- orchestrators need these for the self-learning pipeline. Read-only endpoints (lint, pipeline) and workflow actions (drafts, publish) are safe at orchestrator level.
4. **RLS**: Not affected -- no schema or migration changes.

## Test plan

- [x] All 1966 tests pass (0 failures)
- [x] `mix precommit` passes (compile, format, credo --strict, dialyzer, test)
- [x] Embedding tests updated to use `get_article_with_embedding/2` for explicit embedding verification
- [x] Linking worker tests pass with the new `get_article_with_embedding/2` integration
- [ ] Verify in production: article list/show endpoints return 200 (not 500)
- [ ] Verify in production: orchestrator can call `/knowledge/drafts`, `/articles/:id/publish`, `/knowledge/lint`, `/knowledge/pipeline`