### PR TITLE
Update landing page, docs, and route discovery

### DIFF
--- a/lib/loopctl_web/controllers/page_html/docs.html.heex
+++ b/lib/loopctl_web/controllers/page_html/docs.html.heex
@@ -176,6 +176,22 @@
                 Project Setup
               </a>
             </li>
+            <li>
+              <a
+                href="#endpoints"
+                class="text-slate-400 hover:text-slate-200 transition-colors"
+              >
+                API Endpoints
+              </a>
+            </li>
+            <li>
+              <a
+                href="#mcp-tools"
+                class="text-slate-400 hover:text-slate-200 transition-colors"
+              >
+                MCP Tools
+              </a>
+            </li>
           </ul>
         </nav>
       </aside>
@@ -664,6 +680,193 @@
                 Getting Started guide
               </a>
               on the home page for the full setup sequence.
+            </p>
+          </div>
+        </section>
+
+        <%!-- ============================================================ --%>
+        <%!-- 7. API Endpoints --%>
+        <%!-- ============================================================ --%>
+        <section id="endpoints" class="mt-14 scroll-mt-20">
+          <h2 class="font-display text-xl font-semibold text-slate-100">API Endpoints</h2>
+          <div class="mt-4 space-y-4 text-sm text-slate-400">
+            <p>
+              All endpoints live under <span class="font-mono text-slate-300">/api/v1</span>.
+              Authentication is via Bearer token in the
+              <span class="font-mono text-slate-300">Authorization</span>
+              header. The full OpenAPI 3.0 spec is available at <a
+                href="/swaggerui"
+                class="text-accent-400 hover:text-accent-300 transition-colors"
+              >
+                /swaggerui
+              </a>.
+            </p>
+          </div>
+
+          <h3 class="mt-8 text-sm font-semibold text-accent-400 uppercase tracking-wider text-xs">
+            Knowledge Wiki
+          </h3>
+          <div class="mt-4 space-y-3">
+            <div class="bg-slate-800 border border-slate-700 rounded-md p-3">
+              <p class="font-mono text-xs text-slate-300">
+                <span class="text-accent-400">GET</span> /api/v1/knowledge/lint
+              </p>
+              <p class="mt-1.5 text-sm text-slate-400">
+                Knowledge wiki health check. Returns stale articles, orphaned content, contradiction clusters, and coverage gaps. Supports configurable thresholds via query params: <span class="font-mono text-slate-300">stale_days</span>, <span class="font-mono text-slate-300">min_links</span>.
+              </p>
+            </div>
+            <div class="bg-slate-800 border border-slate-700 rounded-md p-3">
+              <p class="font-mono text-xs text-slate-300">
+                <span class="text-accent-400">GET</span>
+                /api/v1/projects/:project_id/knowledge/lint
+              </p>
+              <p class="mt-1.5 text-sm text-slate-400">
+                Project-scoped lint report. Same output as the tenant-wide lint endpoint but filtered to articles belonging to a specific project.
+              </p>
+            </div>
+            <div class="bg-slate-800 border border-slate-700 rounded-md p-3">
+              <p class="font-mono text-xs text-slate-300">
+                <span class="text-accent-400">GET</span> /api/v1/knowledge/pipeline
+              </p>
+              <p class="mt-1.5 text-sm text-slate-400">
+                Self-learning pipeline status. Returns extraction health metrics: total articles, draft/published/archived counts, publish rate, recent extractions, and pipeline activity over time.
+              </p>
+            </div>
+          </div>
+
+          <h3 class="mt-8 text-sm font-semibold text-accent-400 uppercase tracking-wider text-xs">
+            Additional Knowledge Endpoints
+          </h3>
+          <div class="mt-4 space-y-3">
+            <div class="bg-slate-800 border border-slate-700 rounded-md p-3">
+              <p class="font-mono text-xs text-slate-300">
+                <span class="text-accent-400">GET</span> /api/v1/knowledge/search?q=...
+              </p>
+              <p class="mt-1.5 text-sm text-slate-400">
+                Unified search across knowledge articles. Supports
+                <span class="font-mono text-slate-300">mode=keyword|semantic|combined</span>
+                for full-text search, pgvector embeddings, or both.
+              </p>
+            </div>
+            <div class="bg-slate-800 border border-slate-700 rounded-md p-3">
+              <p class="font-mono text-xs text-slate-300">
+                <span class="text-accent-400">GET</span> /api/v1/knowledge/context?q=...
+              </p>
+              <p class="mt-1.5 text-sm text-slate-400">
+                Deep-read context endpoint. Returns articles with recency scoring and linked references -- designed for agent consumption during implementation.
+              </p>
+            </div>
+            <div class="bg-slate-800 border border-slate-700 rounded-md p-3">
+              <p class="font-mono text-xs text-slate-300">
+                <span class="text-accent-400">GET</span> /api/v1/knowledge/export
+              </p>
+              <p class="mt-1.5 text-sm text-slate-400">
+                Export the entire knowledge wiki as an Obsidian-compatible ZIP file with Markdown articles, backlinks, and an index file.
+              </p>
+            </div>
+            <div class="bg-slate-800 border border-slate-700 rounded-md p-3">
+              <p class="font-mono text-xs text-slate-300">
+                <span class="text-accent-400">GET</span> /api/v1/knowledge/drafts
+              </p>
+              <p class="mt-1.5 text-sm text-slate-400">
+                List draft articles awaiting review and publication. Supports
+                <span class="font-mono text-slate-300">limit</span>
+                and <span class="font-mono text-slate-300">offset</span>
+                pagination.
+              </p>
+            </div>
+            <div class="bg-slate-800 border border-slate-700 rounded-md p-3">
+              <p class="font-mono text-xs text-slate-300">
+                <span class="text-accent-400">POST</span> /api/v1/knowledge/bulk-publish
+              </p>
+              <p class="mt-1.5 text-sm text-slate-400">
+                Publish multiple draft articles in a single request. Accepts an array of article IDs.
+              </p>
+            </div>
+            <div class="bg-slate-800 border border-slate-700 rounded-md p-3">
+              <p class="font-mono text-xs text-slate-300">
+                <span class="text-accent-400">GET</span> /api/v1/knowledge/index
+              </p>
+              <p class="mt-1.5 text-sm text-slate-400">
+                Lightweight catalog of all published articles with titles, tags, and category metadata.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <%!-- ============================================================ --%>
+        <%!-- 8. MCP Tools --%>
+        <%!-- ============================================================ --%>
+        <section id="mcp-tools" class="mt-14 scroll-mt-20">
+          <h2 class="font-display text-xl font-semibold text-slate-100">MCP Tools</h2>
+          <div class="mt-4 space-y-4 text-sm text-slate-400">
+            <p>
+              The loopctl MCP server provides 33 typed tools for Claude Code agents.
+              Install via
+              <span class="font-mono text-slate-300">npm install loopctl-mcp-server</span>
+              and configure in <span class="font-mono text-slate-300">.mcp.json</span>.
+              Agents should use MCP tools instead of raw curl to preserve chain-of-custody.
+            </p>
+          </div>
+
+          <h3 class="mt-8 text-sm font-semibold text-accent-400 uppercase tracking-wider text-xs">
+            Knowledge Wiki Tools
+          </h3>
+          <div class="mt-4 space-y-3">
+            <div class="bg-slate-800 border border-slate-700 rounded-md p-3">
+              <p class="font-mono text-xs text-slate-300">
+                <span class="text-accent-400">knowledge_publish</span>
+              </p>
+              <p class="mt-1.5 text-sm text-slate-400">
+                Publish a draft article to the knowledge wiki. Requires the article ID. Transitions the article from
+                <span class="font-mono text-slate-300">draft</span>
+                to <span class="font-mono text-slate-300">published</span>
+                status.
+              </p>
+            </div>
+            <div class="bg-slate-800 border border-slate-700 rounded-md p-3">
+              <p class="font-mono text-xs text-slate-300">
+                <span class="text-accent-400">knowledge_drafts</span>
+              </p>
+              <p class="mt-1.5 text-sm text-slate-400">
+                List draft articles awaiting review. Returns titles, tags, source metadata, and creation timestamps. Supports pagination.
+              </p>
+            </div>
+            <div class="bg-slate-800 border border-slate-700 rounded-md p-3">
+              <p class="font-mono text-xs text-slate-300">
+                <span class="text-accent-400">knowledge_lint</span>
+              </p>
+              <p class="mt-1.5 text-sm text-slate-400">
+                Run a health check on the knowledge wiki. Reports stale articles, orphaned content, contradiction clusters, and coverage gaps with configurable thresholds.
+              </p>
+            </div>
+            <div class="bg-slate-800 border border-slate-700 rounded-md p-3">
+              <p class="font-mono text-xs text-slate-300">
+                <span class="text-accent-400">knowledge_export</span>
+              </p>
+              <p class="mt-1.5 text-sm text-slate-400">
+                Export the knowledge wiki as an Obsidian-compatible ZIP file. Contains Markdown articles with YAML frontmatter, backlinks between articles, and an index file.
+              </p>
+            </div>
+          </div>
+
+          <h3 class="mt-8 text-sm font-semibold text-accent-400 uppercase tracking-wider text-xs">
+            Other Notable Tools
+          </h3>
+          <div class="mt-4 space-y-4 text-sm text-slate-400">
+            <p>
+              The full set of 33 tools covers projects, stories, epics, verification,
+              artifacts, orchestrator state, webhooks, skills, token usage, analytics,
+              and knowledge. See the
+              <a
+                href="https://www.npmjs.com/package/loopctl-mcp-server"
+                class="text-accent-400 hover:text-accent-300 transition-colors"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                npm package README
+              </a>
+              for the complete list.
             </p>
           </div>
         </section>

--- a/lib/loopctl_web/controllers/page_html/home.html.heex
+++ b/lib/loopctl_web/controllers/page_html/home.html.heex
@@ -645,6 +645,71 @@
         </div>
       </section>
 
+      <%!-- Knowledge Intelligence Section --%>
+      <section
+        id="knowledge-intelligence"
+        class="bg-slate-950 py-16 sm:py-24 border-t border-slate-800/50"
+      >
+        <div class="max-w-5xl mx-auto px-6">
+          <h2 class="text-sm font-semibold text-accent-400">Knowledge Intelligence</h2>
+          <p class="mt-2 font-display text-3xl font-semibold tracking-tight text-slate-100 sm:text-4xl">
+            Your codebase gets smarter with every review
+          </p>
+          <p class="mt-4 text-base text-slate-400 max-w-2xl">
+            loopctl captures patterns, conventions, and decisions from code reviews and organizes them into a searchable knowledge wiki. The wiki compounds automatically -- every review makes the next one smarter.
+          </p>
+
+          <div class="mt-10 grid grid-cols-1 gap-x-8 gap-y-8 sm:grid-cols-2 lg:grid-cols-4">
+            <div class="bg-slate-900 border border-slate-700 rounded-md p-4">
+              <p class="text-xs font-mono text-slate-500">feature</p>
+              <p class="mt-1.5 text-sm font-semibold text-slate-200">
+                Self-Learning Pipeline
+              </p>
+              <p class="mt-1.5 text-sm text-slate-400">
+                Code reviews automatically extract reusable knowledge articles. Patterns, conventions, and decisions are captured as draft articles, then published to the wiki after review.
+              </p>
+            </div>
+
+            <div class="bg-slate-900 border border-slate-700 rounded-md p-4">
+              <p class="text-xs font-mono text-slate-500">feature</p>
+              <p class="mt-1.5 text-sm font-semibold text-slate-200">
+                Semantic + Keyword Search
+              </p>
+              <p class="mt-1.5 text-sm text-slate-400">
+                Find knowledge by meaning, not just words. Combined search uses pgvector embeddings and PostgreSQL full-text search to surface the most relevant articles for any task.
+              </p>
+            </div>
+
+            <div class="bg-slate-900 border border-slate-700 rounded-md p-4">
+              <p class="text-xs font-mono text-slate-500">feature</p>
+              <p class="mt-1.5 text-sm font-semibold text-slate-200">
+                Knowledge Health Monitoring
+              </p>
+              <p class="mt-1.5 text-sm text-slate-400">
+                Lint reports surface stale articles, orphaned content, contradiction clusters, and coverage gaps. Pipeline status shows extraction health and publish rates.
+              </p>
+            </div>
+
+            <div class="bg-slate-900 border border-slate-700 rounded-md p-4">
+              <p class="text-xs font-mono text-slate-500">feature</p>
+              <p class="mt-1.5 text-sm font-semibold text-slate-200">
+                Obsidian-Compatible Export
+              </p>
+              <p class="mt-1.5 text-sm text-slate-400">
+                Export the entire wiki as an Obsidian-compatible ZIP with Markdown articles, backlinks, and an index file. Works with any Markdown-based knowledge tool.
+              </p>
+            </div>
+          </div>
+
+          <%!-- Value proposition callout --%>
+          <div class="mt-8 bg-slate-900 border border-slate-700 rounded-md p-5">
+            <p class="text-sm font-mono text-accent-400">
+              "Review findings become reusable knowledge. Knowledge improves future reviews. The loop compounds."
+            </p>
+          </div>
+        </div>
+      </section>
+
       <%!-- Getting Started Section --%>
       <section id="get-started" class="bg-slate-950 py-16 sm:py-24 border-t border-slate-800/50">
         <div class="max-w-5xl mx-auto px-6">

--- a/lib/loopctl_web/controllers/route_discovery_controller.ex
+++ b/lib/loopctl_web/controllers/route_discovery_controller.ex
@@ -11,29 +11,99 @@ defmodule LoopctlWeb.RouteDiscoveryController do
 
   def index(conn, _params) do
     routes = [
+      # Route discovery
       %{method: "GET", path: "/api/v1/routes", description: "This endpoint — list all routes"},
+
+      # Tenant management
+      %{method: "GET", path: "/api/v1/tenants/me", description: "Current tenant info"},
+      %{
+        method: "PATCH",
+        path: "/api/v1/tenants/me",
+        description: "Update current tenant (settings.knowledge_auto_extract, etc.)"
+      },
+
+      # API key management
+      %{
+        method: "GET",
+        path: "/api/v1/api_keys",
+        description: "List API keys for current tenant"
+      },
+      %{method: "POST", path: "/api/v1/api_keys", description: "Create API key"},
+      %{method: "DELETE", path: "/api/v1/api_keys/:id", description: "Delete API key"},
+      %{method: "POST", path: "/api/v1/api_keys/:id/rotate", description: "Rotate API key"},
+
+      # Audit & change feed
+      %{
+        method: "GET",
+        path: "/api/v1/audit",
+        description: "Audit log for current tenant"
+      },
+      %{
+        method: "GET",
+        path: "/api/v1/changes",
+        description: "Change feed (supports ?since= timestamp)"
+      },
+
+      # Agent management
+      %{method: "POST", path: "/api/v1/agents/register", description: "Register agent"},
+      %{method: "GET", path: "/api/v1/agents", description: "List registered agents"},
+      %{method: "GET", path: "/api/v1/agents/:id", description: "Get agent"},
+
+      # Project management
       %{method: "GET", path: "/api/v1/projects", description: "List projects"},
       %{method: "POST", path: "/api/v1/projects", description: "Create project"},
       %{method: "GET", path: "/api/v1/projects/:id", description: "Get project"},
       %{method: "PATCH", path: "/api/v1/projects/:id", description: "Update project"},
       %{method: "DELETE", path: "/api/v1/projects/:id", description: "Delete project"},
       %{method: "GET", path: "/api/v1/projects/:id/progress", description: "Project progress"},
+
+      # Import/Export
       %{
         method: "POST",
         path: "/api/v1/projects/:id/import",
         description: "Import epics and stories (orchestrator, user, or superadmin role)"
       },
+      %{method: "GET", path: "/api/v1/projects/:id/export", description: "Export project"},
+
+      # Epic management
       %{
         method: "GET",
-        path: "/api/v1/projects/:id/export",
-        description: "Export project"
+        path: "/api/v1/projects/:project_id/epics",
+        description: "List epics in project"
       },
+      %{
+        method: "POST",
+        path: "/api/v1/projects/:project_id/epics",
+        description: "Create epic in project"
+      },
+      %{method: "GET", path: "/api/v1/epics/:id", description: "Get epic"},
+      %{method: "PATCH", path: "/api/v1/epics/:id", description: "Update epic"},
+      %{method: "DELETE", path: "/api/v1/epics/:id", description: "Delete epic"},
+      %{method: "GET", path: "/api/v1/epics/:id/progress", description: "Epic progress"},
+
+      # Story management
       %{
         method: "GET",
         path: "/api/v1/stories",
         description:
           "List stories (requires project_id). Filters: agent_status, verified_status, epic_id, limit (alias: page_size), offset"
       },
+      %{
+        method: "GET",
+        path: "/api/v1/epics/:epic_id/stories",
+        description:
+          "List stories in epic. Filters: page, page_size (alias: limit), agent_status, verified_status"
+      },
+      %{
+        method: "POST",
+        path: "/api/v1/epics/:epic_id/stories",
+        description: "Create story in epic"
+      },
+      %{method: "GET", path: "/api/v1/stories/:id", description: "Get story details"},
+      %{method: "PATCH", path: "/api/v1/stories/:id", description: "Update story metadata"},
+      %{method: "DELETE", path: "/api/v1/stories/:id", description: "Delete story"},
+
+      # Dependency graph
       %{
         method: "GET",
         path: "/api/v1/stories/ready",
@@ -44,9 +114,47 @@ defmodule LoopctlWeb.RouteDiscoveryController do
         path: "/api/v1/stories/blocked",
         description: "Stories blocked by unmet dependencies"
       },
-      %{method: "GET", path: "/api/v1/stories/:id", description: "Get story details"},
-      %{method: "PATCH", path: "/api/v1/stories/:id", description: "Update story metadata"},
-      %{method: "DELETE", path: "/api/v1/stories/:id", description: "Delete story"},
+      %{
+        method: "GET",
+        path: "/api/v1/projects/:id/dependency_graph",
+        description: "Full dependency graph for project (epics and stories)"
+      },
+
+      # Epic dependencies
+      %{
+        method: "POST",
+        path: "/api/v1/epic_dependencies",
+        description: "Create epic dependency"
+      },
+      %{
+        method: "DELETE",
+        path: "/api/v1/epic_dependencies/:id",
+        description: "Delete epic dependency"
+      },
+      %{
+        method: "GET",
+        path: "/api/v1/projects/:id/epic_dependencies",
+        description: "List epic dependencies for project"
+      },
+
+      # Story dependencies
+      %{
+        method: "POST",
+        path: "/api/v1/story_dependencies",
+        description: "Create story dependency"
+      },
+      %{
+        method: "DELETE",
+        path: "/api/v1/story_dependencies/:id",
+        description: "Delete story dependency"
+      },
+      %{
+        method: "GET",
+        path: "/api/v1/epics/:id/story_dependencies",
+        description: "List story dependencies for epic"
+      },
+
+      # Story status transitions
       %{
         method: "POST",
         path: "/api/v1/stories/:id/contract",
@@ -60,6 +168,11 @@ defmodule LoopctlWeb.RouteDiscoveryController do
       },
       %{
         method: "POST",
+        path: "/api/v1/stories/:id/start-work",
+        description: "Alias for /start"
+      },
+      %{
+        method: "POST",
         path: "/api/v1/stories/:id/request-review",
         description:
           "Signal implementation is ready for review (assigned agent only). " <>
@@ -69,9 +182,16 @@ defmodule LoopctlWeb.RouteDiscoveryController do
         method: "POST",
         path: "/api/v1/stories/:id/report",
         description:
-          "Confirm implementation done (chain-of-custody: caller must be a DIFFERENT agent from implementer). Alias: /report-done"
+          "Confirm implementation done (chain-of-custody: caller must be a DIFFERENT agent from implementer)"
+      },
+      %{
+        method: "POST",
+        path: "/api/v1/stories/:id/report-done",
+        description: "Alias for /report"
       },
       %{method: "POST", path: "/api/v1/stories/:id/unclaim", description: "Unclaim story"},
+
+      # Review pipeline
       %{
         method: "POST",
         path: "/api/v1/stories/:id/review-complete",
@@ -79,6 +199,8 @@ defmodule LoopctlWeb.RouteDiscoveryController do
           "Record review completion (call AFTER reported_done, BEFORE verify). " <>
             "Required params: review_type. Optional: findings_count, fixes_count, summary, completed_at."
       },
+
+      # Story verification
       %{
         method: "POST",
         path: "/api/v1/stories/:id/verify",
@@ -92,12 +214,28 @@ defmodule LoopctlWeb.RouteDiscoveryController do
         description: "Reject story (requires reason)"
       },
       %{
+        method: "GET",
+        path: "/api/v1/stories/:story_id/verifications",
+        description: "List verifications for story"
+      },
+      %{
+        method: "POST",
+        path: "/api/v1/stories/:id/force-unclaim",
+        description: "Force-unclaim a story (orchestrator/user only)"
+      },
+
+      # Artifact reports
+      %{
         method: "POST",
         path: "/api/v1/stories/:id/artifacts",
         description: "Post artifact report for story"
       },
       %{method: "GET", path: "/api/v1/stories/:id/artifacts", description: "List artifacts"},
+
+      # Story history
       %{method: "GET", path: "/api/v1/stories/:id/history", description: "Story audit history"},
+
+      # Bulk operations
       %{
         method: "POST",
         path: "/api/v1/stories/bulk/claim",
@@ -123,38 +261,8 @@ defmodule LoopctlWeb.RouteDiscoveryController do
         path: "/api/v1/epics/:id/verify-all",
         description: "Verify all reported-done stories in epic"
       },
-      %{
-        method: "GET",
-        path: "/api/v1/epics/:epic_id/stories",
-        description:
-          "List stories in epic. Filters: page, page_size (alias: limit), agent_status, verified_status"
-      },
-      %{
-        method: "POST",
-        path: "/api/v1/epics/:epic_id/stories",
-        description: "Create story in epic"
-      },
-      %{method: "GET", path: "/api/v1/epics/:id", description: "Get epic"},
-      %{method: "PATCH", path: "/api/v1/epics/:id", description: "Update epic"},
-      %{method: "DELETE", path: "/api/v1/epics/:id", description: "Delete epic"},
-      %{method: "GET", path: "/api/v1/epics/:id/progress", description: "Epic progress"},
-      %{
-        method: "GET",
-        path: "/api/v1/projects/:project_id/epics",
-        description: "List epics in project"
-      },
-      %{method: "GET", path: "/api/v1/tenants/me", description: "Current tenant info"},
-      %{method: "PATCH", path: "/api/v1/tenants/me", description: "Update current tenant"},
-      %{
-        method: "GET",
-        path: "/api/v1/audit",
-        description: "Audit log for current tenant"
-      },
-      %{
-        method: "GET",
-        path: "/api/v1/changes",
-        description: "Change feed (supports ?since= timestamp)"
-      },
+
+      # Orchestrator state
       %{
         method: "GET",
         path: "/api/v1/orchestrator/state/:project_id",
@@ -170,26 +278,145 @@ defmodule LoopctlWeb.RouteDiscoveryController do
         path: "/api/v1/orchestrator/state/:project_id/history",
         description: "Orchestrator checkpoint history"
       },
+
+      # Webhooks
+      %{method: "POST", path: "/api/v1/webhooks", description: "Create webhook subscription"},
+      %{method: "GET", path: "/api/v1/webhooks", description: "List webhook subscriptions"},
+      %{method: "PATCH", path: "/api/v1/webhooks/:id", description: "Update webhook"},
+      %{method: "DELETE", path: "/api/v1/webhooks/:id", description: "Delete webhook"},
+      %{
+        method: "POST",
+        path: "/api/v1/webhooks/:id/test",
+        description: "Send test delivery to webhook"
+      },
       %{
         method: "GET",
-        path: "/api/v1/agents",
-        description: "List registered agents"
+        path: "/api/v1/webhooks/:id/deliveries",
+        description: "List webhook delivery history"
+      },
+
+      # Skills
+      %{method: "POST", path: "/api/v1/skills", description: "Create skill"},
+      %{method: "GET", path: "/api/v1/skills", description: "List skills"},
+      %{method: "GET", path: "/api/v1/skills/:id", description: "Get skill"},
+      %{method: "PATCH", path: "/api/v1/skills/:id", description: "Update skill"},
+      %{method: "DELETE", path: "/api/v1/skills/:id", description: "Delete skill"},
+      %{
+        method: "POST",
+        path: "/api/v1/skills/import",
+        description: "Bulk import skills from external source"
       },
       %{
         method: "POST",
-        path: "/api/v1/agents/register",
-        description: "Register agent"
+        path: "/api/v1/skills/:id/versions",
+        description: "Create skill version"
       },
-      %{method: "GET", path: "/api/v1/agents/:id", description: "Get agent"},
       %{
         method: "GET",
-        path: "/api/v1/api_keys",
-        description: "List API keys for current tenant"
+        path: "/api/v1/skills/:id/versions",
+        description: "List skill versions"
       },
-      %{method: "POST", path: "/api/v1/api_keys", description: "Create API key"},
-      %{method: "DELETE", path: "/api/v1/api_keys/:id", description: "Delete API key"},
-      %{method: "POST", path: "/api/v1/api_keys/:id/rotate", description: "Rotate API key"},
-      %{method: "GET", path: "/api/openapi", description: "Full OpenAPI 3.0 spec (Swagger)"},
+      %{
+        method: "GET",
+        path: "/api/v1/skills/:id/versions/:version",
+        description: "Get specific skill version"
+      },
+      %{
+        method: "GET",
+        path: "/api/v1/skills/:id/stats",
+        description: "Skill usage statistics"
+      },
+      %{
+        method: "GET",
+        path: "/api/v1/skills/:id/versions/:version/results",
+        description: "Results for specific skill version"
+      },
+      %{
+        method: "GET",
+        path: "/api/v1/skills/:id/cost-performance",
+        description: "Skill cost performance (token usage per version)"
+      },
+
+      # Skill results
+      %{method: "POST", path: "/api/v1/skill_results", description: "Record skill result"},
+
+      # Token usage
+      %{method: "POST", path: "/api/v1/token-usage", description: "Report token usage"},
+      %{
+        method: "DELETE",
+        path: "/api/v1/token-usage/:id",
+        description: "Delete token usage record"
+      },
+      %{
+        method: "POST",
+        path: "/api/v1/token-usage/:id/correction",
+        description: "Submit correction for token usage record"
+      },
+      %{
+        method: "GET",
+        path: "/api/v1/stories/:story_id/token-usage",
+        description: "List token usage for story"
+      },
+
+      # Token budgets
+      %{method: "POST", path: "/api/v1/token-budgets", description: "Create token budget"},
+      %{method: "GET", path: "/api/v1/token-budgets", description: "List token budgets"},
+      %{method: "GET", path: "/api/v1/token-budgets/:id", description: "Get token budget"},
+      %{method: "PATCH", path: "/api/v1/token-budgets/:id", description: "Update token budget"},
+      %{
+        method: "DELETE",
+        path: "/api/v1/token-budgets/:id",
+        description: "Delete token budget"
+      },
+
+      # Cost anomalies
+      %{
+        method: "GET",
+        path: "/api/v1/cost-anomalies",
+        description: "List cost anomalies. Filters: status, severity, agent_id, project_id"
+      },
+      %{
+        method: "PATCH",
+        path: "/api/v1/cost-anomalies/:id",
+        description: "Update cost anomaly (resolve, dismiss, etc.)"
+      },
+
+      # Token analytics
+      %{
+        method: "GET",
+        path: "/api/v1/analytics/agents",
+        description: "Per-agent token usage analytics"
+      },
+      %{
+        method: "GET",
+        path: "/api/v1/analytics/epics",
+        description: "Per-epic token usage analytics"
+      },
+      %{
+        method: "GET",
+        path: "/api/v1/analytics/projects/:id",
+        description: "Project-level token analytics"
+      },
+      %{
+        method: "GET",
+        path: "/api/v1/analytics/models",
+        description: "Per-model token usage analytics"
+      },
+      %{
+        method: "GET",
+        path: "/api/v1/analytics/trends",
+        description: "Token usage trends over time"
+      },
+      %{
+        method: "GET",
+        path: "/api/v1/analytics/model-mix",
+        description: "Model mix breakdown across agents/projects"
+      },
+      %{
+        method: "GET",
+        path: "/api/v1/analytics/agents/:id/model-profile",
+        description: "Model usage profile for specific agent"
+      },
 
       # UI Test Runs (project-level QA)
       %{
@@ -216,6 +443,159 @@ defmodule LoopctlWeb.RouteDiscoveryController do
         method: "POST",
         path: "/api/v1/projects/:project_id/ui-tests/:id/complete",
         description: "Complete a UI test run (pass/fail)"
+      },
+
+      # Knowledge Wiki — articles
+      %{method: "GET", path: "/api/v1/articles", description: "List articles"},
+      %{method: "POST", path: "/api/v1/articles", description: "Create article"},
+      %{method: "GET", path: "/api/v1/articles/:id", description: "Get article"},
+      %{method: "PATCH", path: "/api/v1/articles/:id", description: "Update article"},
+      %{method: "DELETE", path: "/api/v1/articles/:id", description: "Delete article"},
+
+      # Knowledge Wiki — publish workflow
+      %{
+        method: "POST",
+        path: "/api/v1/articles/:id/publish",
+        description: "Publish a draft article"
+      },
+      %{
+        method: "POST",
+        path: "/api/v1/articles/:id/unpublish",
+        description: "Unpublish an article (revert to draft)"
+      },
+      %{
+        method: "POST",
+        path: "/api/v1/articles/:id/archive",
+        description: "Archive an article"
+      },
+      %{
+        method: "POST",
+        path: "/api/v1/knowledge/bulk-publish",
+        description: "Publish multiple draft articles at once"
+      },
+      %{
+        method: "GET",
+        path: "/api/v1/knowledge/drafts",
+        description: "List draft articles awaiting review"
+      },
+
+      # Knowledge Wiki — search, context, index, export
+      %{
+        method: "GET",
+        path: "/api/v1/knowledge/index",
+        description: "Lightweight catalog of published articles"
+      },
+      %{
+        method: "GET",
+        path: "/api/v1/knowledge/search",
+        description:
+          "Unified knowledge search. Params: q, mode (keyword|semantic|combined), limit, offset"
+      },
+      %{
+        method: "GET",
+        path: "/api/v1/knowledge/context",
+        description: "Deep-read context with recency scoring and linked refs (agent consumption)"
+      },
+      %{
+        method: "GET",
+        path: "/api/v1/knowledge/export",
+        description: "Export wiki as Obsidian-compatible ZIP"
+      },
+
+      # Knowledge Wiki — lint and pipeline
+      %{
+        method: "GET",
+        path: "/api/v1/knowledge/lint",
+        description: "Knowledge wiki health check. Params: stale_days, min_links"
+      },
+      %{
+        method: "GET",
+        path: "/api/v1/knowledge/pipeline",
+        description: "Self-learning pipeline status (extraction health, publish rates)"
+      },
+
+      # Knowledge Wiki — project-scoped
+      %{
+        method: "GET",
+        path: "/api/v1/projects/:project_id/articles",
+        description: "List articles scoped to project"
+      },
+      %{
+        method: "POST",
+        path: "/api/v1/projects/:project_id/articles",
+        description: "Create article in project"
+      },
+      %{
+        method: "GET",
+        path: "/api/v1/projects/:project_id/knowledge/index",
+        description: "Project-scoped knowledge index"
+      },
+      %{
+        method: "GET",
+        path: "/api/v1/projects/:project_id/knowledge/export",
+        description: "Project-scoped knowledge export"
+      },
+      %{
+        method: "GET",
+        path: "/api/v1/projects/:project_id/knowledge/lint",
+        description: "Project-scoped knowledge lint"
+      },
+
+      # Article links
+      %{
+        method: "POST",
+        path: "/api/v1/article_links",
+        description: "Create link between articles"
+      },
+      %{
+        method: "DELETE",
+        path: "/api/v1/article_links/:id",
+        description: "Delete article link"
+      },
+      %{
+        method: "GET",
+        path: "/api/v1/articles/:article_id/links",
+        description: "List links for article"
+      },
+
+      # OpenAPI spec
+      %{method: "GET", path: "/api/openapi", description: "Full OpenAPI 3.0 spec (Swagger)"},
+
+      # Superadmin endpoints
+      %{
+        method: "GET",
+        path: "/api/v1/admin/tenants",
+        description: "List all tenants (superadmin only)"
+      },
+      %{
+        method: "GET",
+        path: "/api/v1/admin/tenants/:id",
+        description: "Get tenant details (superadmin only)"
+      },
+      %{
+        method: "PATCH",
+        path: "/api/v1/admin/tenants/:id",
+        description: "Update tenant (superadmin only)"
+      },
+      %{
+        method: "POST",
+        path: "/api/v1/admin/tenants/:id/suspend",
+        description: "Suspend tenant (superadmin only)"
+      },
+      %{
+        method: "POST",
+        path: "/api/v1/admin/tenants/:id/activate",
+        description: "Activate tenant (superadmin only)"
+      },
+      %{
+        method: "GET",
+        path: "/api/v1/admin/stats",
+        description: "System-wide statistics (superadmin only)"
+      },
+      %{
+        method: "GET",
+        path: "/api/v1/admin/audit",
+        description: "Cross-tenant audit log (superadmin only)"
       }
     ]
 


### PR DESCRIPTION
## Summary

- **Landing page**: Added Knowledge Intelligence section between Cost Intelligence and Getting Started. Four feature cards (self-learning pipeline, semantic + keyword search, health monitoring, Obsidian export) following the same terminal-aesthetic 4-card grid pattern as Cost Intelligence.
- **Docs page**: Added API Endpoints section covering knowledge lint, pipeline, search, context, export, drafts, bulk-publish, and index. Added MCP Tools section documenting the 4 new knowledge tools (knowledge_publish, knowledge_drafts, knowledge_lint, knowledge_export). Updated TOC sidebar with links to new sections.
- **Route discovery**: Expanded from 59 to 119 routes. Added all missing endpoints: webhooks, skills (CRUD + versions + stats + cost-performance + import), token usage (CRUD + correction), token budgets (CRUD), cost anomalies, analytics (agents, epics, projects, models, trends, model-mix, agent model profile), knowledge wiki (articles CRUD, publish/unpublish/archive, bulk-publish, drafts, index, search, context, export, lint, pipeline), project-scoped knowledge routes, article links, dependency graph, epic/story dependencies, story aliases (report-done, start-work), verifications, force-unclaim, and superadmin endpoints.

## Test plan

- [x] `mix precommit` passes (compile, format, credo --strict, dialyzer, 1966 tests)
- [ ] Visual review of Knowledge Intelligence section on landing page
- [ ] Visual review of API Endpoints and MCP Tools sections on docs page
- [ ] Verify GET /api/v1/routes returns complete route list with correct count