### PR TITLE
Handle oversized content in knowledge ingestion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,19 @@ erl_crash.dump
 .env
 deploy/certs/
 
+# OS files
+.DS_Store
+
 # MCP server
 mcp-server/node_modules/
 
 # Generated assets (built by esbuild/tailwind)
 /priv/static/assets/
+/priv/static/cache_manifest.json
+/priv/static/*.gz
+/priv/static/favicon-*.ico
+/priv/static/robots-*.txt
+/priv/static/robots-*.txt.gz
+
+# Design reference templates (not application code)
+/docs/tailwind/

--- a/lib/loopctl/knowledge/claude_content_extractor.ex
+++ b/lib/loopctl/knowledge/claude_content_extractor.ex
@@ -41,7 +41,7 @@ defmodule Loopctl.Knowledge.ClaudeContentExtractor do
 
     body = %{
       model: model,
-      max_tokens: 4096,
+      max_tokens: 16_384,
       system: @system_prompt,
       messages: [
         %{
@@ -106,9 +106,20 @@ defmodule Loopctl.Knowledge.ClaudeContentExtractor do
         {:ok, []}
 
       {:error, reason} ->
-        Logger.warning("ClaudeContentExtractor: JSON parse error (error=#{inspect(reason)})")
+        # Attempt truncated JSON recovery before giving up
+        case recover_truncated_json(text) do
+          {:ok, articles} ->
+            Logger.info(
+              "ClaudeContentExtractor: recovered #{length(articles)} articles from truncated JSON"
+            )
 
-        {:error, {:json_parse_error, reason}}
+            {:ok, articles}
+
+          :error ->
+            Logger.warning("ClaudeContentExtractor: JSON parse error (error=#{inspect(reason)})")
+
+            {:error, {:json_parse_error, reason}}
+        end
     end
   end
 
@@ -134,6 +145,59 @@ defmodule Loopctl.Knowledge.ClaudeContentExtractor do
   end
 
   defp normalize_article(_), do: nil
+
+  # Attempt to recover articles from truncated JSON by finding the last
+  # complete object in the array. Works when the LLM response was cut off
+  # mid-JSON due to max_tokens limit.
+  defp recover_truncated_json(text) do
+    # Find the last complete "}" that could end an article object
+    # by progressively trimming from the end until we get valid JSON
+    text = String.trim(text)
+
+    # Ensure it starts with [ (an array)
+    text =
+      if String.starts_with?(text, "[") do
+        text
+      else
+        # Maybe wrapped in {"articles": [...]}
+        case Regex.run(~r/\[.*$/s, text) do
+          [match] -> match
+          _ -> text
+        end
+      end
+
+    recover_by_closing_array(text)
+  end
+
+  defp recover_by_closing_array(text) do
+    # Find positions of all "}" characters (potential object endings)
+    # Try closing the array after each one, from last to first
+    brace_positions =
+      Regex.scan(~r/\}/, text, return: :index)
+      |> Enum.map(fn [{pos, _}] -> pos end)
+      |> Enum.reverse()
+
+    Enum.find_value(brace_positions, :error, fn pos ->
+      candidate = String.slice(text, 0, pos + 1) <> "]"
+      try_parse_candidate(candidate)
+    end)
+  end
+
+  defp try_parse_candidate(candidate) do
+    case JSON.decode(candidate) do
+      {:ok, articles} when is_list(articles) and articles != [] ->
+        normalized =
+          articles
+          |> Enum.take(10)
+          |> Enum.map(&normalize_article/1)
+          |> Enum.filter(&(&1 != nil))
+
+        if normalized != [], do: {:ok, normalized}
+
+      _ ->
+        nil
+    end
+  end
 
   # Strip markdown code fences that Claude often wraps JSON in
   defp strip_markdown_fences(text) do

--- a/lib/loopctl/knowledge/llm_extractor.ex
+++ b/lib/loopctl/knowledge/llm_extractor.ex
@@ -57,7 +57,7 @@ defmodule Loopctl.Knowledge.LlmExtractor do
 
     body = %{
       model: model,
-      max_tokens: 2048,
+      max_tokens: 16_384,
       system: @system_prompt,
       messages: [%{role: "user", content: user_message}]
     }

--- a/lib/loopctl/workers/content_ingestion_worker.ex
+++ b/lib/loopctl/workers/content_ingestion_worker.ex
@@ -68,8 +68,7 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
     source_id = derive_source_id(content_hash)
 
     with {:ok, content} <- resolve_content(url, raw_content),
-         {:ok, raw_articles} <-
-           @content_extractor.extract_from_content(content, source_type: source_type) do
+         {:ok, raw_articles} <- extract_with_chunking(content, source_type) do
       articles = validate_and_filter(raw_articles)
       insert_articles(tenant_id, source_id, source_type, project_id, articles, url)
     end
@@ -81,6 +80,86 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   end
 
   # --- Private ---
+
+  # Content chunking threshold: ~8KB. Content larger than this is split
+  # into chunks and each chunk is extracted separately to avoid LLM
+  # response truncation from max_tokens limits.
+  @chunk_threshold 8_000
+
+  defp extract_with_chunking(content, source_type) when byte_size(content) <= @chunk_threshold do
+    case @content_extractor.extract_from_content(content, source_type: source_type) do
+      {:ok, articles} -> {:ok, articles}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp extract_with_chunking(content, source_type) do
+    chunks = chunk_content(content)
+
+    Logger.info(
+      "ContentIngestionWorker: splitting #{byte_size(content)} bytes into #{length(chunks)} chunks"
+    )
+
+    {articles, errors} =
+      Enum.reduce(chunks, {[], []}, fn chunk, {arts, errs} ->
+        case @content_extractor.extract_from_content(chunk, source_type: source_type) do
+          {:ok, extracted} -> {arts ++ extracted, errs}
+          {:error, reason} -> {arts, [reason | errs]}
+        end
+      end)
+
+    cond do
+      articles != [] ->
+        # Got some articles — partial success is fine, log errors
+        if errors != [] do
+          Logger.warning(
+            "ContentIngestionWorker: #{length(errors)} of #{length(chunks)} chunks failed"
+          )
+        end
+
+        {:ok, Enum.take(articles, @max_articles)}
+
+      errors != [] ->
+        # All chunks failed — propagate the first error so Oban retries
+        {:error, List.first(errors)}
+
+      true ->
+        # No chunks produced anything but no errors either (empty content)
+        {:ok, []}
+    end
+  end
+
+  # Split content into chunks at logical boundaries (headings, blank lines).
+  # Each chunk stays under @chunk_threshold bytes.
+  defp chunk_content(content) do
+    # Split on markdown headings (## or #) as primary boundaries
+    sections =
+      content
+      |> String.split(~r/(?=^\#{1,3}\s)/m)
+      |> Enum.reject(&(String.trim(&1) == ""))
+
+    # Merge small sections together until we approach the threshold
+    merge_sections(sections, [], "")
+  end
+
+  defp merge_sections([], acc, current) do
+    if String.trim(current) != "" do
+      Enum.reverse([current | acc])
+    else
+      Enum.reverse(acc)
+    end
+  end
+
+  defp merge_sections([section | rest], acc, current) do
+    candidate = current <> "\n" <> section
+
+    if byte_size(candidate) > @chunk_threshold and String.trim(current) != "" do
+      # Current chunk is full, start a new one
+      merge_sections(rest, [current | acc], section)
+    else
+      merge_sections(rest, acc, candidate)
+    end
+  end
 
   defp resolve_content(nil, content) when is_binary(content) and content != "" do
     {:ok, content}

--- a/test/loopctl/workers/content_ingestion_worker_test.exs
+++ b/test/loopctl/workers/content_ingestion_worker_test.exs
@@ -248,7 +248,7 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
   # --- Extractor failure ---
 
   describe "perform/1 extractor failure" do
-    test "returns {:error, reason} when extractor fails" do
+    test "propagates error when extractor fails" do
       %{tenant: tenant} = setup_tenant()
 
       expect(Loopctl.MockContentExtractor, :extract_from_content, fn _content, _opts ->


### PR DESCRIPTION
Three-layer defense against LLM response truncation: max_tokens bump to 16384, content chunking at 8KB boundaries, truncated JSON recovery. Errors propagate when all chunks fail.