### PR TITLE
Refine MCP tools to close 4 gaps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,7 @@ mix ecto.reset         # Drop, create, migrate
 - **User Stories**: `docs/user_stories/epic_N_name/us_N.M.json` — 60 stories across 15 epics
 - **Skills**: `skills/loopctl-*.md` — 6 orchestration skills
 - **Orchestration Guide**: `docs/orchestration-guide.md` — methodology: loop, trust model, checkpointing
-- **MCP Server**: `mcp-server/` — 33 typed tools for Claude Code agents (no curl needed), published as `loopctl-mcp-server` on npm
+- **MCP Server**: `mcp-server/` — 37 typed tools for Claude Code agents (no curl needed), published as `loopctl-mcp-server` on npm
 - **Build Status**: memory-keeper key `build_status`, channel `loopctl`
 
 ## MCP Server
@@ -190,7 +190,7 @@ Claude Code agents should use the loopctl MCP tools instead of curl. Install via
 {"mcpServers": {"loopctl": {"command": "npx", "args": ["loopctl-mcp-server"], "env": {"LOOPCTL_SERVER": "https://loopctl.com", "LOOPCTL_ORCH_KEY": "...", "LOOPCTL_AGENT_KEY": "..."}}}}
 ```
 
-Tools: `mcp__loopctl__list_projects`, `mcp__loopctl__list_stories`, `mcp__loopctl__verify_story`, etc. (33 total). See `mcp-server/README.md` for the full list.
+Tools: `mcp__loopctl__list_projects`, `mcp__loopctl__list_stories`, `mcp__loopctl__verify_story`, etc. (37 total). See `mcp-server/README.md` for the full list.
 
 ---
 

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -2176,6 +2176,8 @@ defmodule Loopctl.Knowledge do
   @all_categories [:pattern, :convention, :decision, :finding, :reference]
   @default_stale_days 90
   @default_min_coverage 3
+  @default_max_per_category 50
+  @hard_max_per_category 500
 
   @doc """
   Analyzes published articles and returns a structured lint report.
@@ -2195,6 +2197,9 @@ defmodule Loopctl.Knowledge do
     - `:project_id` — scope to a specific project (includes tenant-wide articles)
     - `:stale_days` — threshold in days for stale detection (default 90)
     - `:min_coverage` — minimum published articles per category (default 3)
+    - `:max_per_category` — cap for items returned in each issue array (default 50,
+      max 500). Total counts before capping are returned in the summary under
+      `:total_per_category`, and per-category truncation flags under `:truncated`.
 
   ## Returns
 
@@ -2207,6 +2212,12 @@ defmodule Loopctl.Knowledge do
     stale_days = Keyword.get(opts, :stale_days, @default_stale_days)
     min_coverage = Keyword.get(opts, :min_coverage, @default_min_coverage)
 
+    max_per_category =
+      opts
+      |> Keyword.get(:max_per_category, @default_max_per_category)
+      |> max(1)
+      |> min(@hard_max_per_category)
+
     # Base query for published articles scoped to tenant (+ optional project)
     base = published_base_query(tenant_id, project_id)
 
@@ -2218,6 +2229,36 @@ defmodule Loopctl.Knowledge do
 
     total_articles = AdminRepo.one(from(a in base, select: count(a.id)))
 
+    # Capture totals BEFORE capping so callers know the true size.
+    total_per_category = %{
+      stale_articles: length(stale),
+      orphan_articles: length(orphans),
+      contradiction_clusters: length(contradictions),
+      coverage_gaps: length(gaps),
+      broken_sources: length(broken)
+    }
+
+    truncated = %{
+      stale_articles: length(stale) > max_per_category,
+      orphan_articles: length(orphans) > max_per_category,
+      contradiction_clusters: length(contradictions) > max_per_category,
+      coverage_gaps: length(gaps) > max_per_category,
+      broken_sources: length(broken) > max_per_category
+    }
+
+    stale_capped = Enum.take(stale, max_per_category)
+    orphans_capped = Enum.take(orphans, max_per_category)
+    contradictions_capped = Enum.take(contradictions, max_per_category)
+    gaps_capped = Enum.take(gaps, max_per_category)
+    broken_capped = Enum.take(broken, max_per_category)
+
+    # total_issues reflects the TRUE total before capping, so callers know the
+    # full issue count even when arrays are truncated.
+    total_issues =
+      total_per_category.stale_articles + total_per_category.orphan_articles +
+        total_per_category.contradiction_clusters + total_per_category.coverage_gaps +
+        total_per_category.broken_sources
+
     all_issues = stale ++ orphans ++ contradictions ++ gaps ++ broken
 
     issues_by_severity =
@@ -2227,18 +2268,20 @@ defmodule Loopctl.Knowledge do
 
     summary = %{
       total_articles: total_articles,
-      total_issues: length(all_issues),
+      total_issues: total_issues,
       issues_by_severity: issues_by_severity,
+      total_per_category: total_per_category,
+      truncated: truncated,
       generated_at: DateTime.utc_now() |> DateTime.to_iso8601()
     }
 
     {:ok,
      %{
-       stale_articles: stale,
-       orphan_articles: orphans,
-       contradiction_clusters: contradictions,
-       coverage_gaps: gaps,
-       broken_sources: broken,
+       stale_articles: stale_capped,
+       orphan_articles: orphans_capped,
+       contradiction_clusters: contradictions_capped,
+       coverage_gaps: gaps_capped,
+       broken_sources: broken_capped,
        summary: summary
      }}
   end

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -95,52 +95,86 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   def create(conn, params) do
     tenant_id = conn.assigns.current_api_key.tenant_id
 
-    url = params["url"]
-    content = params["content"]
-    source_type = params["source_type"]
-    project_id = params["project_id"]
-    metadata = params["metadata"]
+    case enqueue_item(tenant_id, params) do
+      {:ok, :queued, %{job: job, content_hash: content_hash, source_type: source_type}} ->
+        conn
+        |> put_status(202)
+        |> json(
+          LoopctlWeb.KnowledgeIngestionJSON.queued(%{
+            job: job,
+            content_hash: content_hash,
+            source_type: source_type
+          })
+        )
 
-    with :ok <- validate_content_source(url, content),
-         :ok <- validate_source_type(source_type) do
-      content_hash = compute_content_hash(url || content)
+      {:ok, :already_queued, %{job: job, content_hash: content_hash}} ->
+        conn
+        |> put_status(200)
+        |> json(
+          LoopctlWeb.KnowledgeIngestionJSON.already_queued(%{
+            content_hash: content_hash,
+            job: job
+          })
+        )
 
-      job_args =
-        %{
-          "tenant_id" => tenant_id,
-          "content_hash" => content_hash,
-          "source_type" => source_type
-        }
-        |> maybe_put("url", url)
-        |> maybe_put("content", content)
-        |> maybe_put("project_id", project_id)
-        |> maybe_put("metadata", metadata)
+      # Pass validation / changeset errors through to the FallbackController
+      # which renders 4xx responses with the provided message.
+      {:error, _status, _message} = err ->
+        err
 
-      case ContentIngestionWorker.new(job_args) |> Oban.insert() do
-        {:ok, %Oban.Job{conflict?: true} = job} ->
-          conn
-          |> put_status(200)
-          |> json(
-            LoopctlWeb.KnowledgeIngestionJSON.already_queued(%{
-              content_hash: content_hash,
-              job: job
-            })
-          )
+      {:error, %Ecto.Changeset{}} = err ->
+        err
+    end
+  end
 
-        {:ok, job} ->
-          conn
-          |> put_status(202)
-          |> json(
-            LoopctlWeb.KnowledgeIngestionJSON.queued(%{
-              job: job,
-              content_hash: content_hash,
-              source_type: source_type
-            })
-          )
+  operation(:create_batch,
+    summary: "Batch ingest content for knowledge extraction",
+    description:
+      "Submit multiple URLs or raw content items for knowledge extraction in a single " <>
+        "request. Each item is validated and enqueued independently. " <>
+        "Max 50 items per batch. Role: orchestrator+.",
+    request_body:
+      {"Batch ingestion request", "application/json",
+       %OpenApiSpex.Schema{
+         type: :object,
+         properties: %{
+           items: %OpenApiSpex.Schema{
+             type: :array,
+             description:
+               "Array of ingestion items (max 50). Each item has the same shape as " <>
+                 "POST /knowledge/ingest: url or content, source_type (required), " <>
+                 "project_id (optional), metadata (optional).",
+             maxItems: 50
+           }
+         },
+         required: ["items"]
+       }},
+    responses: %{
+      200 =>
+        {"Batch ingestion results", "application/json",
+         %OpenApiSpex.Schema{
+           type: :object,
+           properties: %{
+             data: %OpenApiSpex.Schema{
+               type: :array,
+               description: "Per-item results, one entry per submitted item."
+             }
+           }
+         }},
+      401 => {"Unauthorized", "application/json", Schemas.ErrorResponse},
+      422 => {"Validation error", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
 
-        {:error, changeset} ->
-          {:error, changeset}
-      end
+  @doc "POST /api/v1/knowledge/ingest/batch"
+  def create_batch(conn, params) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+    items = params["items"]
+
+    with :ok <- validate_batch_items(items) do
+      results = Enum.map(items, &enqueue_item_result(tenant_id, &1))
+      json(conn, LoopctlWeb.KnowledgeIngestionJSON.batch(results))
     end
   end
 
@@ -175,6 +209,109 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   end
 
   # --- Private ---
+
+  # Max batch size for POST /knowledge/ingest/batch
+  @batch_max 50
+
+  defp validate_batch_items(items) when is_list(items) and items != [] do
+    if length(items) > @batch_max do
+      {:error, :unprocessable_entity,
+       "Batch exceeds max of #{@batch_max} items (got #{length(items)})"}
+    else
+      :ok
+    end
+  end
+
+  defp validate_batch_items([]) do
+    {:error, :unprocessable_entity, "'items' must be a non-empty array"}
+  end
+
+  defp validate_batch_items(_) do
+    {:error, :unprocessable_entity, "'items' must be a non-empty array"}
+  end
+
+  # Enqueue a single item and return {:ok, :queued | :already_queued, map} or
+  # {:error, ...}. Used by both single-item create/2 and batch create_batch/2.
+  defp enqueue_item(tenant_id, params) do
+    url = params["url"]
+    content = params["content"]
+    source_type = params["source_type"]
+    project_id = params["project_id"]
+    metadata = params["metadata"]
+
+    with :ok <- validate_content_source(url, content),
+         :ok <- validate_source_type(source_type) do
+      content_hash = compute_content_hash(url || content)
+
+      job_args =
+        %{
+          "tenant_id" => tenant_id,
+          "content_hash" => content_hash,
+          "source_type" => source_type
+        }
+        |> maybe_put("url", url)
+        |> maybe_put("content", content)
+        |> maybe_put("project_id", project_id)
+        |> maybe_put("metadata", metadata)
+
+      case ContentIngestionWorker.new(job_args) |> Oban.insert() do
+        {:ok, %Oban.Job{conflict?: true} = job} ->
+          {:ok, :already_queued, %{job: job, content_hash: content_hash}}
+
+        {:ok, job} ->
+          {:ok, :queued, %{job: job, content_hash: content_hash, source_type: source_type}}
+
+        {:error, changeset} ->
+          {:error, changeset}
+      end
+    end
+  end
+
+  # Wrap enqueue_item/2 to always return a per-item result map for batch mode.
+  # Batch mode never fails the whole request for a single invalid item — every
+  # item gets a result entry so the caller sees exactly what happened.
+  defp enqueue_item_result(tenant_id, params) when is_map(params) do
+    case enqueue_item(tenant_id, params) do
+      {:ok, :queued, %{job: job, content_hash: content_hash, source_type: source_type}} ->
+        %{
+          status: "queued",
+          id: job.id,
+          content_hash: content_hash,
+          source_type: source_type,
+          inserted_at: job.inserted_at
+        }
+
+      {:ok, :already_queued, %{job: job, content_hash: content_hash}} ->
+        %{
+          status: "already_queued",
+          id: job.id,
+          content_hash: content_hash
+        }
+
+      {:error, :unprocessable_entity, message} ->
+        %{status: "error", error: message}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        %{status: "error", error: format_changeset_errors(changeset)}
+
+      {:error, other} ->
+        %{status: "error", error: inspect(other)}
+    end
+  end
+
+  defp enqueue_item_result(_tenant_id, _params) do
+    %{status: "error", error: "item must be an object"}
+  end
+
+  defp format_changeset_errors(changeset) do
+    changeset
+    |> Ecto.Changeset.traverse_errors(fn {msg, opts} ->
+      Enum.reduce(opts, msg, fn {k, v}, acc ->
+        String.replace(acc, "%{#{k}}", to_string(v))
+      end)
+    end)
+    |> Enum.map_join("; ", fn {field, errors} -> "#{field}: #{Enum.join(errors, ", ")}" end)
+  end
 
   defp validate_content_source(nil, nil) do
     {:error, :unprocessable_entity, "Exactly one of 'url' or 'content' is required"}

--- a/lib/loopctl_web/controllers/knowledge_ingestion_json.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_json.ex
@@ -34,6 +34,36 @@ defmodule LoopctlWeb.KnowledgeIngestionJSON do
     }
   end
 
+  @doc """
+  Renders a batch ingestion response. `results` is a list of per-item result
+  maps produced by `KnowledgeIngestionController.enqueue_item_result/2`.
+  """
+  def batch(results) when is_list(results) do
+    %{data: Enum.map(results, &render_batch_result/1)}
+  end
+
+  defp render_batch_result(%{status: "queued"} = r) do
+    %{
+      status: "queued",
+      id: r.id,
+      content_hash: r.content_hash,
+      source_type: r.source_type,
+      inserted_at: r.inserted_at
+    }
+  end
+
+  defp render_batch_result(%{status: "already_queued"} = r) do
+    %{
+      status: "already_queued",
+      id: r.id,
+      content_hash: r.content_hash
+    }
+  end
+
+  defp render_batch_result(%{status: "error", error: error}) do
+    %{status: "error", error: error}
+  end
+
   defp render_job(job) do
     args = job.args || %{}
 

--- a/lib/loopctl_web/controllers/knowledge_lint_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_lint_controller.ex
@@ -52,6 +52,14 @@ defmodule LoopctlWeb.KnowledgeLintController do
         description:
           "Minimum published articles per category to avoid a coverage gap (default 3)",
         required: false
+      ],
+      max_per_category: [
+        in: :query,
+        type: :integer,
+        description:
+          "Maximum items returned per issue category (default 50, max 500). " <>
+            "Totals before capping are returned in summary.total_per_category.",
+        required: false
       ]
     ],
     responses: %{
@@ -99,8 +107,9 @@ defmodule LoopctlWeb.KnowledgeLintController do
         project_id -> Keyword.put(opts, :project_id, project_id)
       end
 
-    with {:ok, opts} <- parse_stale_days(params, opts) do
-      parse_min_coverage(params, opts)
+    with {:ok, opts} <- parse_stale_days(params, opts),
+         {:ok, opts} <- parse_min_coverage(params, opts) do
+      parse_max_per_category(params, opts)
     end
   end
 
@@ -143,4 +152,29 @@ defmodule LoopctlWeb.KnowledgeLintController do
   end
 
   defp parse_min_coverage(_params, opts), do: {:ok, opts}
+
+  @max_per_category_ceiling 500
+
+  defp parse_max_per_category(%{"max_per_category" => raw}, opts) when is_binary(raw) do
+    case Integer.parse(raw) do
+      {n, ""} when n > 0 and n <= @max_per_category_ceiling ->
+        {:ok, Keyword.put(opts, :max_per_category, n)}
+
+      _ ->
+        {:error, :bad_request,
+         "max_per_category must be a positive integer <= #{@max_per_category_ceiling}"}
+    end
+  end
+
+  defp parse_max_per_category(%{"max_per_category" => n}, opts)
+       when is_integer(n) and n > 0 and n <= @max_per_category_ceiling do
+    {:ok, Keyword.put(opts, :max_per_category, n)}
+  end
+
+  defp parse_max_per_category(%{"max_per_category" => _}, _opts) do
+    {:error, :bad_request,
+     "max_per_category must be a positive integer <= #{@max_per_category_ceiling}"}
+  end
+
+  defp parse_max_per_category(_params, opts), do: {:ok, opts}
 end

--- a/lib/loopctl_web/controllers/knowledge_lint_json.ex
+++ b/lib/loopctl_web/controllers/knowledge_lint_json.ex
@@ -26,6 +26,8 @@ defmodule LoopctlWeb.KnowledgeLintJSON do
         total_articles: summary.total_articles,
         total_issues: summary.total_issues,
         issues_by_severity: summary.issues_by_severity,
+        total_per_category: Map.get(summary, :total_per_category, %{}),
+        truncated: Map.get(summary, :truncated, %{}),
         generated_at: summary.generated_at
       }
     }

--- a/lib/loopctl_web/controllers/page_html/home.html.heex
+++ b/lib/loopctl_web/controllers/page_html/home.html.heex
@@ -282,7 +282,7 @@
                   MCP Integration
                 </dt>
                 <dd class="mt-1.5 text-slate-400">
-                  33 typed tools for AI coding agents. No curl needed — agents interact through the MCP server.
+                  37 typed tools for AI coding agents. No curl needed — agents interact through the MCP server.
                 </dd>
               </div>
 
@@ -796,7 +796,7 @@
                   Install via
                   <span class="text-slate-400 font-mono">npm install loopctl-mcp-server</span>
                   or run with <span class="text-slate-400 font-mono">npx loopctl-mcp-server</span>.
-                  33 typed tools for AI coding agents.
+                  37 typed tools for AI coding agents.
                 </p>
               </div>
             </div>

--- a/lib/loopctl_web/controllers/route_discovery_controller.ex
+++ b/lib/loopctl_web/controllers/route_discovery_controller.ex
@@ -523,6 +523,13 @@ defmodule LoopctlWeb.RouteDiscoveryController do
             "Params: url (or content), source_type (required), project_id (optional)"
       },
       %{
+        method: "POST",
+        path: "/api/v1/knowledge/ingest/batch",
+        description:
+          "Batch-submit up to 50 ingestion items in a single request. " <>
+            "Each item has the same shape as /knowledge/ingest. Returns per-item results."
+      },
+      %{
         method: "GET",
         path: "/api/v1/knowledge/ingestion-jobs",
         description: "List recent ingestion jobs (last 7 days, max 50)"

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -261,6 +261,7 @@ defmodule LoopctlWeb.Router do
 
     # Knowledge Ingestion (content extraction pipeline)
     post "/knowledge/ingest", KnowledgeIngestionController, :create
+    post "/knowledge/ingest/batch", KnowledgeIngestionController, :create_batch
     get "/knowledge/ingestion-jobs", KnowledgeIngestionController, :index
 
     scope "/projects/:project_id" do

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -2,7 +2,7 @@
 
 MCP (Model Context Protocol) server for [loopctl](https://loopctl.com) -- structural trust for AI development loops.
 
-Wraps the loopctl REST API into 35 typed MCP tools so AI coding agents (Claude Code, etc.) can interact with loopctl without writing curl commands.
+Wraps the loopctl REST API into 37 typed MCP tools so AI coding agents (Claude Code, etc.) can interact with loopctl without writing curl commands.
 
 ## Installation
 
@@ -62,10 +62,11 @@ Or if installed locally:
 | `LOOPCTL_API_KEY` | Global API key override (if set, always used) | -- |
 | `LOOPCTL_ORCH_KEY` | Orchestrator role API key (verify, reject, review, import) | -- |
 | `LOOPCTL_AGENT_KEY` | Agent role API key (contract, claim, start, request-review) | -- |
+| `LOOPCTL_USER_KEY` | User role API key. Required ONLY for destructive admin tools like `knowledge_bulk_publish`. Leave unset if you don't use those tools. | -- |
 
 Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_KEY`.
 
-## Tools (35)
+## Tools (37)
 
 ### Project Tools
 
@@ -140,10 +141,12 @@ Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_K
 | Tool | Description |
 |---|---|
 | `knowledge_publish` | Publish a draft article, making it visible to all agents. Required: `article_id`. |
-| `knowledge_drafts` | List all draft (unpublished) knowledge articles. Optional: `limit`, `offset`. |
-| `knowledge_lint` | Run a lint check on the knowledge wiki to identify stale or low-coverage articles. Optional: `project_id`, `stale_days`, `min_coverage`. |
+| `knowledge_bulk_publish` | **Requires `LOOPCTL_USER_KEY`.** Atomically publish up to 100 drafts in a single call. Required: `article_ids` (array). |
+| `knowledge_drafts` | List draft (unpublished) knowledge articles with pagination. Optional: `limit` (default 20, max 20), `offset` (default 0), `project_id`. Returns `meta.total_count`. |
+| `knowledge_lint` | Run a lint check on the knowledge wiki to identify stale or low-coverage articles. Optional: `project_id`, `stale_days`, `min_coverage`, `max_per_category` (default 50, max 500). True totals returned in `summary.total_per_category`. |
 | `knowledge_export` | Export all knowledge articles as a ZIP archive. Returns a curl command for direct download (ZIP binary cannot be returned as MCP content). Optional: `project_id`. |
 | `knowledge_ingest` | Submit a URL or raw content for knowledge extraction. Enqueues an Oban job. Required: `source_type`. One of: `url` or `content`. Optional: `project_id`. |
+| `knowledge_ingest_batch` | Submit up to 50 ingestion items in a single request. Each item has the same shape as `knowledge_ingest`. Returns per-item results. Required: `items`. Optional: batch-level `project_id` default. |
 | `knowledge_ingestion_jobs` | List recent content ingestion jobs (last 7 days, max 50). |
 
 ### Discovery Tools

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -457,20 +457,34 @@ async function knowledgePublish({ article_id }) {
   return toContent(result);
 }
 
-async function knowledgeDrafts({ limit, offset }) {
+async function knowledgeBulkPublish({ article_ids }) {
+  const result = await apiCall(
+    "POST",
+    "/api/v1/knowledge/bulk-publish",
+    { article_ids },
+    process.env.LOOPCTL_USER_KEY
+  );
+  return toContent(result);
+}
+
+async function knowledgeDrafts({ limit, offset, project_id }) {
   const params = new URLSearchParams();
-  if (limit != null) params.set("limit", String(limit));
+  params.set(
+    "limit",
+    String(Math.min(limit ?? MAX_PAGE_SIZE, MAX_PAGE_SIZE))
+  );
   if (offset != null) params.set("offset", String(offset));
-  const qs = params.toString();
-  const path = qs ? `/api/v1/knowledge/drafts?${qs}` : "/api/v1/knowledge/drafts";
+  if (project_id) params.set("project_id", project_id);
+  const path = `/api/v1/knowledge/drafts?${params.toString()}`;
   const result = await apiCall("GET", path, null, process.env.LOOPCTL_ORCH_KEY);
   return toContent(result);
 }
 
-async function knowledgeLint({ project_id, stale_days, min_coverage }) {
+async function knowledgeLint({ project_id, stale_days, min_coverage, max_per_category }) {
   const params = new URLSearchParams();
   if (stale_days != null) params.set("stale_days", String(stale_days));
   if (min_coverage != null) params.set("min_coverage", String(min_coverage));
+  if (max_per_category != null) params.set("max_per_category", String(max_per_category));
   const qs = params.toString();
   const basePath = project_id
     ? `/api/v1/projects/${project_id}/knowledge/lint`
@@ -486,6 +500,26 @@ async function knowledgeIngest({ url, content, source_type, project_id }) {
   if (content) body.content = content;
   if (project_id) body.project_id = project_id;
   const result = await apiCall("POST", "/api/v1/knowledge/ingest", body, process.env.LOOPCTL_ORCH_KEY);
+  return toContent(result);
+}
+
+async function knowledgeIngestBatch({ items, project_id }) {
+  // If a batch-level project_id is supplied, apply it as a default to every
+  // item that doesn't already set its own.
+  const resolvedItems = Array.isArray(items)
+    ? items.map((item) =>
+        project_id && item && item.project_id == null
+          ? { ...item, project_id }
+          : item
+      )
+    : items;
+
+  const result = await apiCall(
+    "POST",
+    "/api/v1/knowledge/ingest/batch",
+    { items: resolvedItems },
+    process.env.LOOPCTL_ORCH_KEY
+  );
   return toContent(result);
 }
 
@@ -1209,19 +1243,50 @@ const TOOLS = [
     },
   },
   {
+    name: "knowledge_bulk_publish",
+    description:
+      "Atomically publish up to 100 draft articles in a single call. " +
+      "REQUIRES LOOPCTL_USER_KEY to be set in the MCP server env (user role — " +
+      "orchestrator role is NOT sufficient for this destructive operation). " +
+      "All articles must be drafts belonging to the tenant; if any fail validation, " +
+      "the entire operation rolls back.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        article_ids: {
+          type: "array",
+          items: { type: "string" },
+          description: "List of draft article UUIDs to publish (max 100).",
+          maxItems: 100,
+        },
+      },
+      required: ["article_ids"],
+    },
+  },
+  {
     name: "knowledge_drafts",
     description:
-      "List all draft (unpublished) knowledge articles. Requires orchestrator role. Use to review pending articles before publishing.",
+      "List draft (unpublished) knowledge articles. Requires orchestrator role. " +
+      "Returns paginated drafts with total_count in meta. Max 20 per page.",
     inputSchema: {
       type: "object",
       properties: {
         limit: {
           type: "integer",
-          description: "Optional: maximum number of drafts to return.",
+          description: "Max drafts per page. Default 20, hard max 20.",
+          default: 20,
+          minimum: 1,
+          maximum: 20,
         },
         offset: {
           type: "integer",
-          description: "Optional: pagination offset.",
+          description: "Pagination offset. Default 0.",
+          default: 0,
+          minimum: 0,
+        },
+        project_id: {
+          type: "string",
+          description: "Optional: filter drafts to a specific project UUID.",
         },
       },
       required: [],
@@ -1231,7 +1296,9 @@ const TOOLS = [
     name: "knowledge_lint",
     description:
       "Run a lint check on the knowledge wiki to identify stale, low-coverage, or broken articles. " +
-      "Requires orchestrator role. Optionally scoped to a project.",
+      "Requires orchestrator role. Optionally scoped to a project. " +
+      "Each issue category is capped at max_per_category (default 50) with true totals " +
+      "exposed in summary.total_per_category and per-category truncated flags.",
     inputSchema: {
       type: "object",
       properties: {
@@ -1244,10 +1311,18 @@ const TOOLS = [
           description: "Optional: flag articles not updated in this many days as stale.",
         },
         min_coverage: {
-          type: "number",
-          description: "Optional: minimum required coverage score (0.0-1.0) to flag under-covered articles.",
-          minimum: 0,
-          maximum: 1,
+          type: "integer",
+          description:
+            "Optional: minimum published articles per category below which a coverage gap is reported (default 3).",
+          minimum: 1,
+        },
+        max_per_category: {
+          type: "integer",
+          description:
+            "Max items per category to return. Default 50, max 500. True totals are still reported in summary.total_per_category.",
+          default: 50,
+          minimum: 1,
+          maximum: 500,
         },
       },
       required: [],
@@ -1298,6 +1373,56 @@ const TOOLS = [
         },
       },
       required: ["source_type"],
+    },
+  },
+  {
+    name: "knowledge_ingest_batch",
+    description:
+      "Submit up to 50 ingestion items in a single request. Each item follows the same " +
+      "shape as knowledge_ingest (url OR content, source_type required). Returns a " +
+      "per-item result array — individual failures do not abort the batch. " +
+      "Requires orchestrator role.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        items: {
+          type: "array",
+          description: "Array of ingestion items (1-50). Each item must include source_type and exactly one of url or content.",
+          minItems: 1,
+          maxItems: 50,
+          items: {
+            type: "object",
+            properties: {
+              url: {
+                type: "string",
+                description: "URL to fetch content from (exactly one of url or content required).",
+              },
+              content: {
+                type: "string",
+                description: "Raw content to extract from (exactly one of url or content required).",
+              },
+              source_type: {
+                type: "string",
+                description: "Source type (e.g., newsletter, skill, web_article, ingestion). Required.",
+              },
+              project_id: {
+                type: "string",
+                description: "Optional: scope the item to a specific project UUID.",
+              },
+              metadata: {
+                type: "object",
+                description: "Optional metadata map.",
+              },
+            },
+            required: ["source_type"],
+          },
+        },
+        project_id: {
+          type: "string",
+          description: "Optional batch-level default project UUID applied to items that don't specify their own.",
+        },
+      },
+      required: ["items"],
     },
   },
   {
@@ -1442,6 +1567,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     case "knowledge_publish":
       return await knowledgePublish(args);
 
+    case "knowledge_bulk_publish":
+      return await knowledgeBulkPublish(args);
+
     case "knowledge_drafts":
       return await knowledgeDrafts(args);
 
@@ -1454,6 +1582,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     // Knowledge Ingestion Tools
     case "knowledge_ingest":
       return await knowledgeIngest(args);
+
+    case "knowledge_ingest_batch":
+      return await knowledgeIngestBatch(args);
 
     case "knowledge_ingestion_jobs":
       return await knowledgeIngestionJobs();

--- a/test/loopctl/knowledge_lint_test.exs
+++ b/test/loopctl/knowledge_lint_test.exs
@@ -353,6 +353,73 @@ defmodule Loopctl.KnowledgeLintTest do
       assert result.summary.total_articles == 2
     end
 
+    test "max_per_category caps each issue array but preserves totals in summary" do
+      tenant = fixture(:tenant)
+
+      # Create 5 stale articles (each orphaned and will land in orphan_articles
+      # and stale_articles buckets).
+      past = DateTime.utc_now() |> DateTime.add(-200 * 86_400, :second)
+
+      for i <- 1..5 do
+        article =
+          fixture(:article, %{
+            tenant_id: tenant.id,
+            title: "Stale #{i}",
+            category: :pattern,
+            status: :published
+          })
+
+        import Ecto.Query
+
+        Loopctl.AdminRepo.update_all(
+          from(a in Loopctl.Knowledge.Article, where: a.id == ^article.id),
+          set: [updated_at: past]
+        )
+      end
+
+      {:ok, result} = Knowledge.lint(tenant.id, max_per_category: 2)
+
+      # Capped to 2
+      assert length(result.stale_articles) == 2
+      assert length(result.orphan_articles) == 2
+
+      # Summary records true totals BEFORE capping
+      assert result.summary.total_per_category.stale_articles == 5
+      assert result.summary.total_per_category.orphan_articles == 5
+      assert result.summary.truncated.stale_articles == true
+      assert result.summary.truncated.orphan_articles == true
+      # No items in these categories -> not truncated
+      assert result.summary.truncated.contradiction_clusters == false
+      assert result.summary.truncated.broken_sources == false
+    end
+
+    test "max_per_category does not truncate when count is below the cap" do
+      tenant = fixture(:tenant)
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Only Article",
+        category: :pattern,
+        status: :published
+      })
+
+      {:ok, result} = Knowledge.lint(tenant.id, max_per_category: 50)
+
+      assert result.summary.truncated.stale_articles == false
+      assert result.summary.truncated.orphan_articles == false
+      assert result.summary.total_per_category.stale_articles == 0
+    end
+
+    test "max_per_category clamps to [1, 500]" do
+      tenant = fixture(:tenant)
+
+      # 0 -> clamped to 1 (still succeeds; just caps arrays hard)
+      {:ok, _result} = Knowledge.lint(tenant.id, max_per_category: 0)
+
+      # Very large -> clamped to 500 (no crash)
+      {:ok, _result} = Knowledge.lint(tenant.id, max_per_category: 10_000)
+    end
+
     test "tenant isolation: tenant A's lint does not include tenant B's data" do
       tenant_a = fixture(:tenant)
       tenant_b = fixture(:tenant)

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -152,6 +152,168 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
     end
   end
 
+  # --- POST /api/v1/knowledge/ingest/batch ---
+
+  describe "POST /api/v1/knowledge/ingest/batch" do
+    test "queues all three items successfully", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      items = [
+        %{content: "Batch item one content", source_type: "newsletter"},
+        %{content: "Batch item two content", source_type: "newsletter"},
+        %{content: "Batch item three content", source_type: "newsletter"}
+      ]
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{items: items})
+
+      body = json_response(conn, 200)
+      assert is_list(body["data"])
+      assert length(body["data"]) == 3
+      assert Enum.all?(body["data"], fn r -> r["status"] == "queued" end)
+      assert Enum.all?(body["data"], fn r -> is_binary(r["content_hash"]) end)
+    end
+
+    test "returns per-item results for duplicate items within the same batch", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      items = [
+        %{content: "Duplicate content", source_type: "newsletter"},
+        %{content: "Duplicate content", source_type: "newsletter"},
+        %{content: "Unique content", source_type: "newsletter"}
+      ]
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{items: items})
+
+      body = json_response(conn, 200)
+      assert length(body["data"]) == 3
+
+      statuses = Enum.map(body["data"], & &1["status"])
+      # In inline test mode jobs complete synchronously, so Oban uniqueness
+      # (which excludes completed jobs) cannot flag duplicates within the same
+      # request. The important batch-endpoint guarantee we assert here is that
+      # every item receives a per-item result (queued or already_queued), never
+      # error, and that duplicate content_hashes produce identical hashes.
+      assert Enum.all?(statuses, &(&1 in ["queued", "already_queued"]))
+
+      hashes =
+        body["data"]
+        |> Enum.take(2)
+        |> Enum.map(& &1["content_hash"])
+
+      [h1, h2] = hashes
+      assert h1 == h2
+    end
+
+    test "returns 422 when batch exceeds 50 items", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      items =
+        Enum.map(1..51, fn i ->
+          %{content: "Item #{i}", source_type: "newsletter"}
+        end)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{items: items})
+
+      body = json_response(conn, 422)
+      assert body["error"]["message"] =~ "50"
+    end
+
+    test "returns 422 when items is empty", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{items: []})
+
+      assert json_response(conn, 422)
+    end
+
+    test "mixed valid and invalid items produce per-item results", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      items = [
+        %{content: "Valid content", source_type: "newsletter"},
+        # missing source_type
+        %{content: "Invalid — no source_type"},
+        # neither url nor content
+        %{source_type: "newsletter"}
+      ]
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{items: items})
+
+      body = json_response(conn, 200)
+      assert length(body["data"]) == 3
+
+      statuses = Enum.map(body["data"], & &1["status"])
+      assert "queued" in statuses
+      assert Enum.count(statuses, &(&1 == "error")) == 2
+    end
+
+    test "agent role is rejected (requires orchestrator)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{
+          items: [%{content: "x", source_type: "newsletter"}]
+        })
+
+      assert json_response(conn, 403)
+    end
+
+    test "tenant isolation: tenant A cannot see tenant B's batch jobs", %{conn: conn} do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      {raw_key_a, _} = fixture(:api_key, %{tenant_id: tenant_a.id, role: :orchestrator})
+      {raw_key_b, _} = fixture(:api_key, %{tenant_id: tenant_b.id, role: :orchestrator})
+
+      # Tenant B batches two items
+      build_conn()
+      |> auth_conn(raw_key_b)
+      |> post(~p"/api/v1/knowledge/ingest/batch", %{
+        items: [
+          %{content: "B batch 1", source_type: "newsletter"},
+          %{content: "B batch 2", source_type: "newsletter"}
+        ]
+      })
+
+      # Tenant A should not see tenant B's jobs
+      conn =
+        conn
+        |> auth_conn(raw_key_a)
+        |> get(~p"/api/v1/knowledge/ingestion-jobs")
+
+      body = json_response(conn, 200)
+
+      tenant_b_jobs =
+        Enum.filter(body["data"], fn job ->
+          job["args"]["tenant_id"] == tenant_b.id
+        end)
+
+      assert tenant_b_jobs == []
+    end
+  end
+
   # --- GET /api/v1/knowledge/ingestion-jobs ---
 
   describe "GET /api/v1/knowledge/ingestion-jobs" do

--- a/test/loopctl_web/controllers/knowledge_lint_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_lint_controller_test.exs
@@ -576,6 +576,97 @@ defmodule LoopctlWeb.KnowledgeLintControllerTest do
       body = json_response(conn, 400)
       assert body["error"]["message"] =~ "min_coverage must be a positive integer"
     end
+
+    test "invalid max_per_category returns 400", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/lint?max_per_category=abc")
+
+      body = json_response(conn, 400)
+      assert body["error"]["message"] =~ "max_per_category"
+    end
+
+    test "zero max_per_category returns 400", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/lint?max_per_category=0")
+
+      body = json_response(conn, 400)
+      assert body["error"]["message"] =~ "max_per_category"
+    end
+
+    test "negative max_per_category returns 400", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/lint?max_per_category=-1")
+
+      body = json_response(conn, 400)
+      assert body["error"]["message"] =~ "max_per_category"
+    end
+
+    test "max_per_category over ceiling returns 400", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/lint?max_per_category=501")
+
+      body = json_response(conn, 400)
+      assert body["error"]["message"] =~ "max_per_category"
+    end
+
+    test "max_per_category caps returned arrays and exposes truncated flags", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      # Create 4 stale orphan articles
+      past = DateTime.utc_now() |> DateTime.add(-200 * 86_400, :second)
+
+      for i <- 1..4 do
+        article =
+          fixture(:article, %{
+            tenant_id: tenant.id,
+            title: "Stale Orphan #{i}",
+            category: :pattern,
+            status: :published
+          })
+
+        import Ecto.Query
+
+        Loopctl.AdminRepo.update_all(
+          from(a in Loopctl.Knowledge.Article, where: a.id == ^article.id),
+          set: [updated_at: past]
+        )
+      end
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/lint?max_per_category=2")
+
+      body = json_response(conn, 200)
+
+      assert length(body["data"]["stale_articles"]) == 2
+      assert length(body["data"]["orphan_articles"]) == 2
+      assert body["summary"]["total_per_category"]["stale_articles"] == 4
+      assert body["summary"]["total_per_category"]["orphan_articles"] == 4
+      assert body["summary"]["truncated"]["stale_articles"] == true
+      assert body["summary"]["truncated"]["orphan_articles"] == true
+    end
   end
 
   describe "summary (AC-21.5.8)" do


### PR DESCRIPTION
## Summary

While ingesting 48 domain skills into the knowledge wiki, we hit 4 MCP gaps that forced drops to python/curl. This PR closes them.

### Gap 1: `knowledge_bulk_publish` MCP tool
- Wraps existing `POST /knowledge/bulk-publish` (requires `role: :user`).
- Uses `LOOPCTL_USER_KEY` from env — documented as optional env var.

### Gap 2: Improved `knowledge_drafts` MCP tool
- Exposes pagination (`limit` default 20, max 20; `offset` default 0) and `project_id` filter via the MCP schema.
- Shares `MAX_PAGE_SIZE=20` with `list_stories`.

### Gap 3: `max_per_category` for knowledge lint
- Adds `max_per_category` option (default 50, max 500) to `Knowledge.lint/2`.
- Summary now includes `total_per_category` (true totals before capping) and per-category `truncated` flags.
- Controller accepts and validates the query param (400 on invalid).
- JSON renderer emits the new summary fields.
- MCP tool schema exposes the new parameter.

### Gap 4: Batch ingestion endpoint
- New `POST /knowledge/ingest/batch` accepting `{items: [...]}` up to 50 items.
- Per-item results (`queued` / `already_queued` / `error`) — individual failures do not abort the batch.
- 422 when batch exceeds 50 or is empty.
- Reuses the single-item validation pipeline via a shared `enqueue_item/2` helper.
- New MCP tool `knowledge_ingest_batch` with optional batch-level `project_id` default.
- Route added to router and `route_discovery_controller`.

### Count updates
- MCP tool count: 35 -> 37 (`mcp-server/README.md`, `CLAUDE.md`, `home.html.heex`).

## Test plan

- [x] `mix precommit` green (credo strict, dialyzer 0 errors, 2007 tests, 0 failures)
- [x] New tests for `Knowledge.lint/2` max_per_category capping, totals, and truncated flags
- [x] New controller tests for `max_per_category` param validation (negative, zero, over-ceiling, non-integer) and end-to-end truncation
- [x] New controller tests for batch ingest: 3 items queued, duplicates, 51-item 422, empty 422, mixed valid/invalid per-item results, agent role rejection, tenant isolation
- [x] `node --check mcp-server/index.js` passes
- [x] Existing knowledge-lint and ingestion tests still pass
