### PR TITLE
Article usage tracking and analytics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,7 @@ mix ecto.reset         # Drop, create, migrate
 - **User Stories**: `docs/user_stories/epic_N_name/us_N.M.json` — 60 stories across 15 epics
 - **Skills**: `skills/loopctl-*.md` — 6 orchestration skills
 - **Orchestration Guide**: `docs/orchestration-guide.md` — methodology: loop, trust model, checkpointing
-- **MCP Server**: `mcp-server/` — 37 typed tools for Claude Code agents (no curl needed), published as `loopctl-mcp-server` on npm
+- **MCP Server**: `mcp-server/` — 41 typed tools for Claude Code agents (no curl needed), published as `loopctl-mcp-server` on npm
 - **Build Status**: memory-keeper key `build_status`, channel `loopctl`
 
 ## MCP Server
@@ -190,7 +190,7 @@ Claude Code agents should use the loopctl MCP tools instead of curl. Install via
 {"mcpServers": {"loopctl": {"command": "npx", "args": ["loopctl-mcp-server"], "env": {"LOOPCTL_SERVER": "https://loopctl.com", "LOOPCTL_ORCH_KEY": "...", "LOOPCTL_AGENT_KEY": "..."}}}}
 ```
 
-Tools: `mcp__loopctl__list_projects`, `mcp__loopctl__list_stories`, `mcp__loopctl__verify_story`, etc. (37 total). See `mcp-server/README.md` for the full list.
+Tools: `mcp__loopctl__list_projects`, `mcp__loopctl__list_stories`, `mcp__loopctl__verify_story`, etc. (41 total). See `mcp-server/README.md` for the full list.
 
 ---
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -93,6 +93,10 @@ config :loopctl, :webhook_req_plug, {Req.Test, Loopctl.Webhooks.ReqDelivery}
 # DI: Use Req.Test plug for CLI HTTP client in tests
 config :loopctl, :cli_req_plug, {Req.Test, Loopctl.CLI.Client}
 
+# Knowledge analytics: record access events synchronously in tests so the
+# inserts run inside the test process and share its sandbox connection.
+config :loopctl, :analytics_recording_mode, :sync
+
 # RLS: Switch to non-superuser role within transactions so RLS is enforced
 # The loopctl_app role must exist and have access to all tables.
 config :loopctl, :rls_role, "loopctl_app"

--- a/lib/loopctl/application.ex
+++ b/lib/loopctl/application.ex
@@ -14,6 +14,7 @@ defmodule Loopctl.Application do
       Loopctl.AdminRepo,
       {DNSCluster, query: Application.get_env(:loopctl, :dns_cluster_query) || :ignore},
       {Phoenix.PubSub, name: Loopctl.PubSub},
+      {Task.Supervisor, name: Loopctl.TaskSupervisor},
       {Oban, Application.fetch_env!(:loopctl, Oban)},
       Loopctl.RateLimiter.Server,
       LoopctlWeb.Endpoint

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -36,6 +36,7 @@ defmodule Loopctl.Knowledge do
   alias Ecto.Multi
   alias Loopctl.AdminRepo
   alias Loopctl.Audit
+  alias Loopctl.Knowledge.Analytics
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.ArticleLink
   alias Loopctl.Projects.Project
@@ -124,19 +125,24 @@ defmodule Loopctl.Knowledge do
   Preloads outgoing links (with target articles) and incoming links
   (with source articles).
 
+  Records a `"get"` access event when an `:api_key_id` is supplied
+  via `opts`. Recording is fire-and-forget and never affects the read.
+
   ## Parameters
 
   - `tenant_id` -- the tenant UUID
   - `article_id` -- the article UUID
+  - `opts` -- keyword list with optional `:api_key_id` for access tracking
+    and `:access_metadata` for extra context attached to the event
 
   ## Returns
 
   - `{:ok, %Article{}}` with preloaded links
   - `{:error, :not_found}` if not found or belongs to another tenant
   """
-  @spec get_article(Ecto.UUID.t(), Ecto.UUID.t()) ::
+  @spec get_article(Ecto.UUID.t(), Ecto.UUID.t(), keyword()) ::
           {:ok, Article.t()} | {:error, :not_found}
-  def get_article(tenant_id, article_id) do
+  def get_article(tenant_id, article_id, opts \\ []) do
     case AdminRepo.get_by(Article, id: article_id, tenant_id: tenant_id) do
       nil ->
         {:error, :not_found}
@@ -147,6 +153,14 @@ defmodule Loopctl.Knowledge do
             outgoing_links: :target_article,
             incoming_links: :source_article
           )
+
+        Analytics.record_access(
+          tenant_id,
+          article.id,
+          Keyword.get(opts, :api_key_id),
+          "get",
+          Keyword.get(opts, :access_metadata, %{})
+        )
 
         {:ok, article}
     end
@@ -367,18 +381,38 @@ defmodule Loopctl.Knowledge do
     limit = opts |> Keyword.get(:limit, 5) |> max(1) |> min(20)
     recency_weight = opts |> Keyword.get(:recency_weight, 0.3) |> max(0.0) |> min(1.0)
     status = Keyword.get(opts, :status, :published)
+    api_key_id = Keyword.get(opts, :api_key_id)
 
-    # Run combined search with a wider internal limit to get candidate pool
+    # Run combined search with a wider internal limit to get candidate pool.
+    # Suppress sub-search recording so context access is recorded once with
+    # access_type="context" rather than duplicating as "search".
     search_opts =
       opts
       |> Keyword.take([:project_id])
-      |> Keyword.merge(limit: limit * 3, offset: 0, status: status)
+      |> Keyword.merge(
+        limit: limit * 3,
+        offset: 0,
+        status: status,
+        _skip_record_access: true
+      )
 
     {search_result, fallback?} = run_context_search(tenant_id, query_string, search_opts)
 
     case search_result do
       {:ok, search} ->
-        build_context_results(tenant_id, search, limit, recency_weight, fallback?)
+        {:ok, context} =
+          build_context_results(tenant_id, search, limit, recency_weight, fallback?)
+
+        context_ids = Enum.map(context.results, & &1.id)
+
+        Analytics.record_context_access(
+          tenant_id,
+          context_ids,
+          api_key_id,
+          %{"query" => query_string}
+        )
+
+        {:ok, context}
 
       {:error, reason} ->
         {:error, reason}
@@ -614,6 +648,8 @@ defmodule Loopctl.Knowledge do
           |> offset(^offset)
           |> AdminRepo.all()
 
+        maybe_record_search_access(tenant_id, results, query_string, opts, "keyword")
+
         {:ok,
          %{results: results, meta: %{total_count: total_count, limit: limit, offset: offset}}}
     end
@@ -625,6 +661,39 @@ defmodule Loopctl.Knowledge do
     |> maybe_filter_by_project_id(Keyword.get(opts, :project_id))
     |> maybe_filter_by_category(Keyword.get(opts, :category))
     |> maybe_filter_by_tags(Keyword.get(opts, :tags))
+  end
+
+  # Fire-and-forget recording of search access for the result list.
+  # Skips when there is no api_key_id, no results, or the caller passed
+  # `_skip_record_access: true` (used by combined search to dedupe).
+  defp maybe_record_search_access(tenant_id, results, query_string, opts, mode) do
+    cond do
+      Keyword.get(opts, :_skip_record_access, false) ->
+        :ok
+
+      results in [nil, []] ->
+        :ok
+
+      is_nil(Keyword.get(opts, :api_key_id)) ->
+        :ok
+
+      true ->
+        api_key_id = Keyword.fetch!(opts, :api_key_id)
+
+        article_ids =
+          results
+          |> Enum.map(fn r -> r[:id] || Map.get(r, :id) end)
+          |> Enum.reject(&is_nil/1)
+          |> Enum.take(20)
+
+        Analytics.record_search_access(
+          tenant_id,
+          article_ids,
+          api_key_id,
+          query_string,
+          %{"mode" => mode}
+        )
+    end
   end
 
   @doc """
@@ -1823,6 +1892,8 @@ defmodule Loopctl.Knowledge do
       |> offset(^offset)
       |> AdminRepo.all()
 
+    maybe_record_search_access(tenant_id, results, nil, opts, "semantic")
+
     {:ok,
      %{
        results: results,
@@ -1907,8 +1978,13 @@ defmodule Loopctl.Knowledge do
   end
 
   defp do_combined_search(tenant_id, query_string, keyword_weight, semantic_weight, opts) do
-    # Use wide limits for sub-searches to get comprehensive score pools
-    sub_opts = Keyword.merge(opts, limit: 50, offset: 0)
+    # Use wide limits for sub-searches to get comprehensive score pools.
+    # Suppress sub-search access recording so we only record once at the
+    # merged result (otherwise each article would be tracked twice).
+    sub_opts =
+      opts
+      |> Keyword.merge(limit: 50, offset: 0)
+      |> Keyword.put(:_skip_record_access, true)
 
     keyword_result = search_keyword(tenant_id, query_string, sub_opts)
     embedding_result = try_generate_embedding(query_string)
@@ -1916,11 +1992,30 @@ defmodule Loopctl.Knowledge do
     case {keyword_result, embedding_result} do
       {{:ok, kw}, {:ok, embedding}} ->
         {:ok, semantic} = search_semantic(tenant_id, embedding, sub_opts)
-        merge_results(kw, semantic, keyword_weight, semantic_weight, opts)
+
+        {:ok, merged} = merge_results(kw, semantic, keyword_weight, semantic_weight, opts)
+
+        maybe_record_search_access(
+          tenant_id,
+          merged.results,
+          query_string,
+          opts,
+          "combined"
+        )
+
+        {:ok, merged}
 
       {{:ok, kw}, {:error, _reason}} ->
         # Fallback to keyword-only
         paginated = paginate_results(kw.results, opts)
+
+        maybe_record_search_access(
+          tenant_id,
+          paginated.results,
+          query_string,
+          opts,
+          "combined_fallback"
+        )
 
         {:ok,
          %{
@@ -2693,5 +2788,73 @@ defmodule Loopctl.Knowledge do
           "Source entity was deleted; consider updating or removing source reference"
       }
     end)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Analytics — article usage tracking
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Records a fire-and-forget article access event.
+
+  See `Loopctl.Knowledge.Analytics.record_access/5` for full semantics.
+  """
+  @spec record_access(
+          Ecto.UUID.t(),
+          Ecto.UUID.t() | nil,
+          Ecto.UUID.t() | nil,
+          String.t(),
+          map()
+        ) :: :ok
+  def record_access(tenant_id, article_id, api_key_id, access_type, metadata \\ %{}) do
+    Analytics.record_access(tenant_id, article_id, api_key_id, access_type, metadata)
+  end
+
+  @doc """
+  Records fire-and-forget search access for a list of article ids.
+  """
+  @spec record_search_access(
+          Ecto.UUID.t(),
+          [Ecto.UUID.t()],
+          Ecto.UUID.t() | nil,
+          String.t() | nil,
+          map()
+        ) :: :ok
+  def record_search_access(tenant_id, article_ids, api_key_id, query, metadata \\ %{}) do
+    Analytics.record_search_access(tenant_id, article_ids, api_key_id, query, metadata)
+  end
+
+  @doc """
+  Returns aggregated usage statistics for a single article.
+
+  See `Loopctl.Knowledge.Analytics.get_article_stats/2` for the response shape.
+  """
+  @spec get_article_stats(Ecto.UUID.t(), Ecto.UUID.t()) :: map()
+  def get_article_stats(tenant_id, article_id) do
+    Analytics.get_article_stats(tenant_id, article_id)
+  end
+
+  @doc """
+  Returns the top accessed articles for a tenant in a time window.
+  """
+  @spec list_top_articles(Ecto.UUID.t(), keyword()) :: [map()]
+  def list_top_articles(tenant_id, opts \\ []) do
+    Analytics.list_top_articles(tenant_id, opts)
+  end
+
+  @doc """
+  Returns usage statistics for a single api_key (agent identity).
+  """
+  @spec get_agent_usage(Ecto.UUID.t(), Ecto.UUID.t(), keyword()) :: map()
+  def get_agent_usage(tenant_id, api_key_id, opts \\ []) do
+    Analytics.get_agent_usage(tenant_id, api_key_id, opts)
+  end
+
+  @doc """
+  Returns published articles with zero accesses in the configured window.
+  """
+  @spec list_unused_articles(Ecto.UUID.t(), keyword()) :: [map()]
+  def list_unused_articles(tenant_id, opts \\ []) do
+    Analytics.list_unused_articles(tenant_id, opts)
   end
 end

--- a/lib/loopctl/knowledge/analytics.ex
+++ b/lib/loopctl/knowledge/analytics.ex
@@ -1,0 +1,465 @@
+defmodule Loopctl.Knowledge.Analytics do
+  @moduledoc """
+  Analytics for the Knowledge Wiki.
+
+  Provides article usage tracking via `record_access/5` and aggregate
+  reporting functions consumed by the analytics endpoints.
+
+  ## Recording access
+
+  `record_access/5` and `record_search_access/5` are fire-and-forget:
+  they spawn a `Task` that inserts the event row(s) and never raise
+  back to the caller. This guarantees that read operations cannot fail
+  because of analytics writes.
+
+  ## Tenant scoping
+
+  All analytics queries are scoped by `tenant_id` and use `AdminRepo`
+  (BYPASSRLS) following the same pattern as the rest of the
+  `Loopctl.Knowledge` context.
+  """
+
+  import Ecto.Query
+
+  require Logger
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.ArticleAccessEvent
+
+  @valid_access_types ~w(search get context index)
+
+  @typedoc """
+  Optional metadata stored alongside the access event. Free-form map.
+  Common keys: `"query"`, `"rank"`, `"score"`, `"mode"`.
+  """
+  @type metadata :: map()
+
+  # ---------------------------------------------------------------------------
+  # Recording
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Fire-and-forget recording of a single article access.
+
+  Spawns an unsupervised `Task` to insert the event row. Any error
+  (including a missing article, missing api_key, or DB connectivity
+  issues) is logged but never propagated to the caller.
+
+  Returns `:ok` immediately.
+  """
+  @spec record_access(
+          Ecto.UUID.t(),
+          Ecto.UUID.t() | nil,
+          Ecto.UUID.t() | nil,
+          String.t(),
+          metadata()
+        ) :: :ok
+  def record_access(tenant_id, article_id, api_key_id, access_type, metadata \\ %{})
+
+  def record_access(_tenant_id, nil, _api_key_id, _access_type, _metadata), do: :ok
+  def record_access(_tenant_id, _article_id, nil, _access_type, _metadata), do: :ok
+
+  def record_access(tenant_id, article_id, api_key_id, access_type, metadata)
+      when is_binary(article_id) and is_binary(api_key_id) and access_type in @valid_access_types do
+    do_record_async([{article_id, metadata}], tenant_id, api_key_id, access_type)
+    :ok
+  end
+
+  def record_access(_tenant_id, _article_id, _api_key_id, _access_type, _metadata), do: :ok
+
+  @doc """
+  Fire-and-forget recording of search access for a list of article ids.
+
+  Inserts one event per article id with `access_type: "search"` and
+  the supplied query (and any extra metadata) attached. Each event also
+  receives a `"rank"` key (1-based) reflecting the position in the
+  results list.
+  """
+  @spec record_search_access(
+          Ecto.UUID.t(),
+          [Ecto.UUID.t()],
+          Ecto.UUID.t() | nil,
+          String.t() | nil,
+          metadata()
+        ) :: :ok
+  def record_search_access(tenant_id, article_ids, api_key_id, query, metadata \\ %{})
+
+  def record_search_access(_tenant_id, _ids, nil, _query, _metadata), do: :ok
+  def record_search_access(_tenant_id, [], _api_key_id, _query, _metadata), do: :ok
+
+  def record_search_access(tenant_id, article_ids, api_key_id, query, metadata)
+      when is_list(article_ids) and is_binary(api_key_id) do
+    base_meta =
+      metadata
+      |> ensure_map()
+      |> maybe_put_query(query)
+
+    items =
+      article_ids
+      |> Enum.with_index(1)
+      |> Enum.flat_map(fn
+        {id, rank} when is_binary(id) -> [{id, Map.put(base_meta, "rank", rank)}]
+        _ -> []
+      end)
+
+    do_record_async(items, tenant_id, api_key_id, "search")
+    :ok
+  end
+
+  def record_search_access(_tenant_id, _ids, _api_key_id, _query, _metadata), do: :ok
+
+  @doc """
+  Fire-and-forget recording of context access for a list of article ids.
+
+  Inserts one event per article id with `access_type: "context"`.
+  Each event also receives a 1-based `"rank"` reflecting position
+  in the context result set.
+  """
+  @spec record_context_access(
+          Ecto.UUID.t(),
+          [Ecto.UUID.t()],
+          Ecto.UUID.t() | nil,
+          metadata()
+        ) :: :ok
+  def record_context_access(tenant_id, article_ids, api_key_id, metadata \\ %{})
+
+  def record_context_access(_tenant_id, _ids, nil, _metadata), do: :ok
+  def record_context_access(_tenant_id, [], _api_key_id, _metadata), do: :ok
+
+  def record_context_access(tenant_id, article_ids, api_key_id, metadata)
+      when is_list(article_ids) and is_binary(api_key_id) do
+    base_meta = ensure_map(metadata)
+
+    items =
+      article_ids
+      |> Enum.with_index(1)
+      |> Enum.flat_map(fn
+        {id, rank} when is_binary(id) -> [{id, Map.put(base_meta, "rank", rank)}]
+        _ -> []
+      end)
+
+    do_record_async(items, tenant_id, api_key_id, "context")
+    :ok
+  end
+
+  def record_context_access(_tenant_id, _ids, _api_key_id, _metadata), do: :ok
+
+  # ---------------------------------------------------------------------------
+  # Per-article stats
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Returns aggregated access statistics for a single article.
+
+  ## Returns
+
+  A map with:
+
+  - `:total_accesses` -- total event count
+  - `:unique_agents` -- distinct `api_key_id` count
+  - `:last_accessed_at` -- most recent `accessed_at` (or nil)
+  - `:accesses_by_type` -- `%{"search" => N, "get" => N, ...}`
+  - `:recent_accesses` -- last 10 events as plain maps
+  """
+  @spec get_article_stats(Ecto.UUID.t(), Ecto.UUID.t()) :: map()
+  def get_article_stats(tenant_id, article_id) do
+    base =
+      from(e in ArticleAccessEvent,
+        where: e.tenant_id == ^tenant_id and e.article_id == ^article_id
+      )
+
+    total = AdminRepo.aggregate(base, :count, :id)
+
+    unique_agents =
+      from(e in base, select: count(e.api_key_id, :distinct))
+      |> AdminRepo.one()
+      |> Kernel.||(0)
+
+    last_accessed_at =
+      from(e in base, select: max(e.accessed_at))
+      |> AdminRepo.one()
+
+    accesses_by_type =
+      from(e in base, group_by: e.access_type, select: {e.access_type, count(e.id)})
+      |> AdminRepo.all()
+      |> Map.new()
+
+    recent_accesses =
+      from(e in base,
+        order_by: [desc: e.accessed_at],
+        limit: 10,
+        select: %{
+          id: e.id,
+          api_key_id: e.api_key_id,
+          access_type: e.access_type,
+          metadata: e.metadata,
+          accessed_at: e.accessed_at
+        }
+      )
+      |> AdminRepo.all()
+
+    %{
+      article_id: article_id,
+      total_accesses: total,
+      unique_agents: unique_agents,
+      last_accessed_at: last_accessed_at,
+      accesses_by_type: accesses_by_type,
+      recent_accesses: recent_accesses
+    }
+  end
+
+  # ---------------------------------------------------------------------------
+  # Top articles
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Returns the top accessed articles for a tenant in a time window.
+
+  ## Options
+
+  - `:limit` -- max rows to return (default 20, max 100)
+  - `:since` -- DateTime lower bound (default 7 days ago)
+  - `:access_type` -- restrict to a single access type (optional)
+
+  Each row is a map with `:article_id`, `:title`, `:category`,
+  `:access_count`, and `:unique_agents`.
+  """
+  @spec list_top_articles(Ecto.UUID.t(), keyword()) :: [map()]
+  def list_top_articles(tenant_id, opts \\ []) do
+    limit = opts |> Keyword.get(:limit, 20) |> max(1) |> min(100)
+    since = Keyword.get(opts, :since) || default_since()
+    access_type = Keyword.get(opts, :access_type)
+
+    query =
+      from(e in ArticleAccessEvent,
+        join: a in Article,
+        on: a.id == e.article_id and a.tenant_id == ^tenant_id,
+        where: e.tenant_id == ^tenant_id,
+        where: e.accessed_at >= ^since,
+        group_by: [a.id, a.title, a.category],
+        order_by: [desc: count(e.id)],
+        limit: ^limit,
+        select: %{
+          article_id: a.id,
+          title: a.title,
+          category: a.category,
+          access_count: count(e.id),
+          unique_agents: count(e.api_key_id, :distinct)
+        }
+      )
+
+    query
+    |> maybe_filter_access_type(access_type)
+    |> AdminRepo.all()
+    |> Enum.map(fn row -> Map.update!(row, :category, &category_to_string/1) end)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Per-agent usage
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Returns usage statistics for a single api_key (agent identity).
+
+  ## Options
+
+  - `:limit` -- max top articles to return (default 20, max 100)
+  - `:since` -- DateTime lower bound (default 7 days ago)
+
+  ## Returns
+
+  A map with:
+
+  - `:api_key_id`
+  - `:total_reads` -- total events for this agent
+  - `:unique_articles` -- distinct articles read
+  - `:access_by_type` -- `%{"search" => N, ...}`
+  - `:top_articles` -- top N read articles with counts
+  """
+  @spec get_agent_usage(Ecto.UUID.t(), Ecto.UUID.t(), keyword()) :: map()
+  def get_agent_usage(tenant_id, api_key_id, opts \\ []) do
+    limit = opts |> Keyword.get(:limit, 20) |> max(1) |> min(100)
+    since = Keyword.get(opts, :since) || default_since()
+
+    base =
+      from(e in ArticleAccessEvent,
+        where: e.tenant_id == ^tenant_id,
+        where: e.api_key_id == ^api_key_id,
+        where: e.accessed_at >= ^since
+      )
+
+    total_reads = AdminRepo.aggregate(base, :count, :id)
+
+    unique_articles =
+      from(e in base, select: count(e.article_id, :distinct))
+      |> AdminRepo.one()
+      |> Kernel.||(0)
+
+    access_by_type =
+      from(e in base, group_by: e.access_type, select: {e.access_type, count(e.id)})
+      |> AdminRepo.all()
+      |> Map.new()
+
+    top_articles =
+      from(e in ArticleAccessEvent,
+        join: a in Article,
+        on: a.id == e.article_id and a.tenant_id == ^tenant_id,
+        where: e.tenant_id == ^tenant_id,
+        where: e.api_key_id == ^api_key_id,
+        where: e.accessed_at >= ^since,
+        group_by: [a.id, a.title, a.category],
+        order_by: [desc: count(e.id)],
+        limit: ^limit,
+        select: %{
+          article_id: a.id,
+          title: a.title,
+          category: a.category,
+          access_count: count(e.id)
+        }
+      )
+      |> AdminRepo.all()
+      |> Enum.map(fn row -> Map.update!(row, :category, &category_to_string/1) end)
+
+    %{
+      api_key_id: api_key_id,
+      total_reads: total_reads,
+      unique_articles: unique_articles,
+      access_by_type: access_by_type,
+      top_articles: top_articles
+    }
+  end
+
+  # ---------------------------------------------------------------------------
+  # Unused articles
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Returns published articles with zero accesses in the configured window.
+
+  ## Options
+
+  - `:days_unused` -- window length in days (default 30)
+  - `:limit` -- max rows to return (default 50, max 200)
+  """
+  @spec list_unused_articles(Ecto.UUID.t(), keyword()) :: [map()]
+  def list_unused_articles(tenant_id, opts \\ []) do
+    days_unused = opts |> Keyword.get(:days_unused, 30) |> max(1)
+    limit = opts |> Keyword.get(:limit, 50) |> max(1) |> min(200)
+    cutoff = DateTime.add(DateTime.utc_now(), -days_unused * 86_400, :second)
+
+    # Subquery: article ids that HAVE been accessed since the cutoff
+    accessed_ids =
+      from(e in ArticleAccessEvent,
+        where: e.tenant_id == ^tenant_id,
+        where: e.accessed_at >= ^cutoff,
+        distinct: true,
+        select: e.article_id
+      )
+
+    query =
+      from(a in Article,
+        where: a.tenant_id == ^tenant_id,
+        where: a.status == :published,
+        where: a.id not in subquery(accessed_ids),
+        order_by: [asc: a.inserted_at],
+        limit: ^limit,
+        select: %{
+          article_id: a.id,
+          title: a.title,
+          category: a.category,
+          tags: a.tags,
+          inserted_at: a.inserted_at,
+          updated_at: a.updated_at
+        }
+      )
+
+    query
+    |> AdminRepo.all()
+    |> Enum.map(fn row -> Map.update!(row, :category, &category_to_string/1) end)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Internals
+  # ---------------------------------------------------------------------------
+
+  defp do_record_async([], _tenant_id, _api_key_id, _access_type), do: :ok
+
+  defp do_record_async(items, tenant_id, api_key_id, access_type) do
+    case Application.get_env(:loopctl, :analytics_recording_mode, :async) do
+      :sync ->
+        do_record_sync(items, tenant_id, api_key_id, access_type)
+
+      _async ->
+        Task.Supervisor.start_child(
+          Loopctl.TaskSupervisor,
+          fn -> do_record_sync(items, tenant_id, api_key_id, access_type) end
+        )
+
+        :ok
+    end
+  rescue
+    error ->
+      Logger.warning(
+        "Knowledge.Analytics async record failed to spawn: #{Exception.message(error)}"
+      )
+
+      :ok
+  end
+
+  @doc false
+  # Synchronous insertion path used by both the async task and tests.
+  def do_record_sync(items, tenant_id, api_key_id, access_type) do
+    now = DateTime.utc_now()
+
+    rows =
+      Enum.map(items, fn {article_id, meta} ->
+        %{
+          id: Ecto.UUID.generate(),
+          tenant_id: tenant_id,
+          article_id: article_id,
+          api_key_id: api_key_id,
+          access_type: access_type,
+          metadata: ensure_map(meta),
+          accessed_at: now
+        }
+      end)
+
+    case AdminRepo.insert_all(ArticleAccessEvent, rows) do
+      {_count, _} ->
+        :ok
+    end
+  rescue
+    error ->
+      Logger.debug(
+        "Knowledge.Analytics record failed (silently ignored): " <>
+          Exception.message(error)
+      )
+
+      :ok
+  end
+
+  defp default_since do
+    DateTime.add(DateTime.utc_now(), -7 * 86_400, :second)
+  end
+
+  defp ensure_map(map) when is_map(map), do: map
+  defp ensure_map(_), do: %{}
+
+  defp maybe_put_query(map, nil), do: map
+  defp maybe_put_query(map, ""), do: map
+  defp maybe_put_query(map, query) when is_binary(query), do: Map.put(map, "query", query)
+  defp maybe_put_query(map, _), do: map
+
+  defp maybe_filter_access_type(query, nil), do: query
+
+  defp maybe_filter_access_type(query, type) when type in @valid_access_types do
+    from([e, _a] in query, where: e.access_type == ^type)
+  end
+
+  defp maybe_filter_access_type(query, _), do: query
+
+  defp category_to_string(nil), do: nil
+  defp category_to_string(atom) when is_atom(atom), do: Atom.to_string(atom)
+  defp category_to_string(other), do: to_string(other)
+end

--- a/lib/loopctl/knowledge/article_access_event.ex
+++ b/lib/loopctl/knowledge/article_access_event.ex
@@ -1,0 +1,69 @@
+defmodule Loopctl.Knowledge.ArticleAccessEvent do
+  @moduledoc """
+  Schema for the `article_access_events` table.
+
+  Article access events are immutable facts that record every read access
+  to an article in the knowledge wiki. They power the analytics endpoints
+  that surface which articles agents actually use, which agents read what,
+  and which articles are dead weight.
+
+  ## Access types
+
+  - `"search"` -- recorded for top-N article ids returned by search results
+  - `"get"` -- recorded for direct GET /articles/:id reads
+  - `"context"` -- recorded for each article returned by GET /knowledge/context
+  - `"index"` -- reserved (currently NOT recorded; index listings are too noisy)
+
+  ## Fields
+
+  - `tenant_id` -- the tenant that owns the article and the api_key
+  - `article_id` -- the article that was accessed
+  - `api_key_id` -- the api_key (and therefore the agent identity) that accessed it
+  - `access_type` -- one of the access types above
+  - `metadata` -- free-form context (e.g., search query, rank, score)
+  - `accessed_at` -- when the access happened (microsecond precision)
+
+  Access events are immutable: there are no updates and no `updated_at`
+  column. Only `accessed_at` is stored.
+  """
+
+  use Loopctl.Schema
+
+  @type t :: %__MODULE__{}
+
+  @access_types ~w(search get context index)
+
+  schema "article_access_events" do
+    tenant_field()
+    belongs_to :article, Loopctl.Knowledge.Article
+    belongs_to :api_key, Loopctl.Auth.ApiKey
+
+    field :access_type, :string
+    field :metadata, :map, default: %{}
+    field :accessed_at, :utc_datetime_usec
+
+    # No timestamps() — accessed_at is the only timestamp.
+  end
+
+  @doc """
+  Returns the list of valid `access_type` values.
+  """
+  @spec access_types() :: [String.t()]
+  def access_types, do: @access_types
+
+  @doc """
+  Changeset for creating a new article access event.
+
+  `tenant_id` is set programmatically and must not appear in attrs.
+  All four positional fields are required; metadata is optional.
+  """
+  @spec create_changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
+  def create_changeset(struct \\ %__MODULE__{}, attrs) do
+    struct
+    |> cast(attrs, [:article_id, :api_key_id, :access_type, :metadata, :accessed_at])
+    |> validate_required([:article_id, :api_key_id, :access_type, :accessed_at])
+    |> validate_inclusion(:access_type, @access_types)
+    |> foreign_key_constraint(:article_id)
+    |> foreign_key_constraint(:api_key_id)
+  end
+end

--- a/lib/loopctl_web/controllers/article_controller.ex
+++ b/lib/loopctl_web/controllers/article_controller.ex
@@ -186,8 +186,9 @@ defmodule LoopctlWeb.ArticleController do
   @doc "GET /api/v1/articles/:id"
   def show(conn, %{"id" => article_id}) do
     tenant_id = conn.assigns.current_api_key.tenant_id
+    api_key_id = conn.assigns.current_api_key.id
 
-    case Knowledge.get_article(tenant_id, article_id) do
+    case Knowledge.get_article(tenant_id, article_id, api_key_id: api_key_id) do
       {:ok, article} ->
         json(conn, ArticleJSON.show(%{article: article}))
 

--- a/lib/loopctl_web/controllers/knowledge_analytics_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_analytics_controller.ex
@@ -1,0 +1,231 @@
+defmodule LoopctlWeb.KnowledgeAnalyticsController do
+  @moduledoc """
+  Controller for knowledge analytics endpoints.
+
+  All endpoints require `orchestrator+` role and surface aggregated
+  article usage data captured by `Loopctl.Knowledge.Analytics`.
+
+  - `GET /api/v1/knowledge/analytics/top-articles` -- top accessed articles
+  - `GET /api/v1/knowledge/articles/:id/stats` -- per-article usage stats
+  - `GET /api/v1/knowledge/analytics/agents/:agent_id` -- per-agent usage
+  - `GET /api/v1/knowledge/analytics/unused-articles` -- unused published articles
+  """
+
+  use LoopctlWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Loopctl.ApiSpec.Schemas
+  alias Loopctl.Knowledge
+
+  action_fallback LoopctlWeb.FallbackController
+
+  plug LoopctlWeb.Plugs.RequireRole, role: :orchestrator
+
+  tags(["Knowledge Analytics"])
+
+  @max_limit 100
+  @max_unused_limit 200
+  @valid_access_types ~w(search get context index)
+
+  operation(:top_articles,
+    summary: "Top accessed knowledge articles",
+    description:
+      "Returns the top accessed articles for the tenant in a time window. " <>
+        "Role: orchestrator+.",
+    parameters: [
+      limit: [
+        in: :query,
+        type: :integer,
+        description: "Max rows to return (default 20, max 100)",
+        required: false
+      ],
+      since_days: [
+        in: :query,
+        type: :integer,
+        description: "Look back this many days (default 7)",
+        required: false
+      ],
+      access_type: [
+        in: :query,
+        type: :string,
+        description: "Restrict to a single access type (search, get, context, index)",
+        required: false
+      ]
+    ],
+    responses: %{
+      200 =>
+        {"Top articles", "application/json",
+         %OpenApiSpex.Schema{type: :object, additionalProperties: true}},
+      400 => {"Bad request", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  @doc "GET /api/v1/knowledge/analytics/top-articles"
+  def top_articles(conn, params) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+
+    opts =
+      []
+      |> put_limit(params["limit"], 20, @max_limit)
+      |> put_since(params["since_days"], 7)
+      |> put_access_type(params["access_type"])
+
+    rows = Knowledge.list_top_articles(tenant_id, opts)
+    json(conn, LoopctlWeb.KnowledgeAnalyticsJSON.top_articles(rows, opts))
+  end
+
+  operation(:article_stats,
+    summary: "Per-article usage statistics",
+    description: "Returns aggregated access counts for a single article. Role: orchestrator+.",
+    parameters: [
+      id: [in: :path, type: :string, description: "Article UUID", required: true]
+    ],
+    responses: %{
+      200 =>
+        {"Article stats", "application/json",
+         %OpenApiSpex.Schema{type: :object, additionalProperties: true}},
+      404 => {"Not found", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  @doc "GET /api/v1/knowledge/articles/:id/stats"
+  def article_stats(conn, %{"id" => article_id}) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+
+    case Knowledge.get_article(tenant_id, article_id) do
+      {:ok, article} ->
+        stats = Knowledge.get_article_stats(tenant_id, article.id)
+        json(conn, LoopctlWeb.KnowledgeAnalyticsJSON.article_stats(article, stats))
+
+      {:error, :not_found} ->
+        {:error, :not_found}
+    end
+  end
+
+  operation(:agent_usage,
+    summary: "Per-agent knowledge usage",
+    description:
+      "Returns the reads, top articles, and access type breakdown for a specific " <>
+        "api_key (agent identity). Role: orchestrator+.",
+    parameters: [
+      agent_id: [
+        in: :path,
+        type: :string,
+        description: "API key UUID identifying the agent",
+        required: true
+      ],
+      limit: [
+        in: :query,
+        type: :integer,
+        description: "Max top articles to return (default 20, max 100)",
+        required: false
+      ],
+      since_days: [
+        in: :query,
+        type: :integer,
+        description: "Look back this many days (default 7)",
+        required: false
+      ]
+    ],
+    responses: %{
+      200 =>
+        {"Agent usage", "application/json",
+         %OpenApiSpex.Schema{type: :object, additionalProperties: true}},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  @doc "GET /api/v1/knowledge/analytics/agents/:agent_id"
+  def agent_usage(conn, %{"agent_id" => api_key_id} = params) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+
+    opts =
+      []
+      |> put_limit(params["limit"], 20, @max_limit)
+      |> put_since(params["since_days"], 7)
+
+    usage = Knowledge.get_agent_usage(tenant_id, api_key_id, opts)
+    json(conn, LoopctlWeb.KnowledgeAnalyticsJSON.agent_usage(usage, opts))
+  end
+
+  operation(:unused_articles,
+    summary: "Unused published articles",
+    description:
+      "Returns published articles with zero access events in the configured window. " <>
+        "Role: orchestrator+.",
+    parameters: [
+      days_unused: [
+        in: :query,
+        type: :integer,
+        description: "Window length in days (default 30)",
+        required: false
+      ],
+      limit: [
+        in: :query,
+        type: :integer,
+        description: "Max rows to return (default 50, max 200)",
+        required: false
+      ]
+    ],
+    responses: %{
+      200 =>
+        {"Unused articles", "application/json",
+         %OpenApiSpex.Schema{type: :object, additionalProperties: true}},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  @doc "GET /api/v1/knowledge/analytics/unused-articles"
+  def unused_articles(conn, params) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+
+    opts =
+      []
+      |> put_int(:days_unused, params["days_unused"], 30, 1, 365)
+      |> put_limit(params["limit"], 50, @max_unused_limit)
+
+    rows = Knowledge.list_unused_articles(tenant_id, opts)
+    json(conn, LoopctlWeb.KnowledgeAnalyticsJSON.unused_articles(rows, opts))
+  end
+
+  # ---------------------------------------------------------------------------
+  # Internals
+  # ---------------------------------------------------------------------------
+
+  defp put_limit(opts, value, default, max_value) do
+    Keyword.put(opts, :limit, parse_int(value, default) |> max(1) |> min(max_value))
+  end
+
+  defp put_since(opts, value, default_days) do
+    days = parse_int(value, default_days) |> max(1) |> min(365)
+    since = DateTime.add(DateTime.utc_now(), -days * 86_400, :second)
+    Keyword.put(opts, :since, since)
+  end
+
+  defp put_access_type(opts, nil), do: opts
+  defp put_access_type(opts, ""), do: opts
+
+  defp put_access_type(opts, value) when value in @valid_access_types do
+    Keyword.put(opts, :access_type, value)
+  end
+
+  defp put_access_type(opts, _), do: opts
+
+  defp put_int(opts, key, value, default, min_value, max_value) do
+    Keyword.put(opts, key, parse_int(value, default) |> max(min_value) |> min(max_value))
+  end
+
+  defp parse_int(nil, default), do: default
+  defp parse_int(int, _default) when is_integer(int), do: int
+
+  defp parse_int(str, default) when is_binary(str) do
+    case Integer.parse(str) do
+      {n, _} -> n
+      :error -> default
+    end
+  end
+
+  defp parse_int(_, default), do: default
+end

--- a/lib/loopctl_web/controllers/knowledge_analytics_json.ex
+++ b/lib/loopctl_web/controllers/knowledge_analytics_json.ex
@@ -1,0 +1,112 @@
+defmodule LoopctlWeb.KnowledgeAnalyticsJSON do
+  @moduledoc """
+  JSON rendering helpers for `LoopctlWeb.KnowledgeAnalyticsController`.
+  """
+
+  alias Loopctl.Knowledge.Article
+
+  @doc "Top accessed articles response."
+  def top_articles(rows, opts) do
+    %{
+      data: Enum.map(rows, &render_top_row/1),
+      meta: %{
+        count: length(rows),
+        limit: Keyword.get(opts, :limit),
+        since: encode_dt(Keyword.get(opts, :since)),
+        access_type: Keyword.get(opts, :access_type)
+      }
+    }
+  end
+
+  @doc "Per-article stats response."
+  def article_stats(%Article{} = article, stats) do
+    %{
+      data: %{
+        article_id: article.id,
+        title: article.title,
+        category: to_string(article.category),
+        status: to_string(article.status),
+        tags: article.tags || [],
+        total_accesses: stats.total_accesses,
+        unique_agents: stats.unique_agents,
+        last_accessed_at: encode_dt(stats.last_accessed_at),
+        accesses_by_type: stats.accesses_by_type,
+        recent_accesses: Enum.map(stats.recent_accesses, &render_recent/1)
+      }
+    }
+  end
+
+  @doc "Per-agent usage response."
+  def agent_usage(usage, opts) do
+    %{
+      data: %{
+        api_key_id: usage.api_key_id,
+        total_reads: usage.total_reads,
+        unique_articles: usage.unique_articles,
+        access_by_type: usage.access_by_type,
+        top_articles: Enum.map(usage.top_articles, &render_top_row/1)
+      },
+      meta: %{
+        limit: Keyword.get(opts, :limit),
+        since: encode_dt(Keyword.get(opts, :since))
+      }
+    }
+  end
+
+  @doc "Unused articles response."
+  def unused_articles(rows, opts) do
+    %{
+      data: Enum.map(rows, &render_unused_row/1),
+      meta: %{
+        count: length(rows),
+        days_unused: Keyword.get(opts, :days_unused),
+        limit: Keyword.get(opts, :limit)
+      }
+    }
+  end
+
+  # ---------------------------------------------------------------------------
+
+  defp render_top_row(row) do
+    %{
+      article_id: row.article_id,
+      title: row.title,
+      category: row.category,
+      access_count: row.access_count,
+      unique_agents: Map.get(row, :unique_agents)
+    }
+    |> compact()
+  end
+
+  defp render_unused_row(row) do
+    %{
+      article_id: row.article_id,
+      title: row.title,
+      category: row.category,
+      tags: row.tags || [],
+      inserted_at: encode_dt(row.inserted_at),
+      updated_at: encode_dt(row.updated_at)
+    }
+  end
+
+  defp render_recent(event) do
+    %{
+      id: event.id,
+      api_key_id: event.api_key_id,
+      access_type: event.access_type,
+      metadata: event.metadata || %{},
+      accessed_at: encode_dt(event.accessed_at)
+    }
+  end
+
+  defp encode_dt(nil), do: nil
+  defp encode_dt(%DateTime{} = dt), do: DateTime.to_iso8601(dt)
+  defp encode_dt(%NaiveDateTime{} = dt), do: NaiveDateTime.to_iso8601(dt)
+  defp encode_dt(other), do: other
+
+  defp compact(map) do
+    map
+    |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+    |> Map.new()
+  end
+end

--- a/lib/loopctl_web/controllers/knowledge_context_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_context_controller.ex
@@ -101,10 +101,11 @@ defmodule LoopctlWeb.KnowledgeContextController do
   @doc "GET /api/v1/knowledge/context"
   def context(conn, params) do
     tenant_id = conn.assigns.current_api_key.tenant_id
+    api_key_id = conn.assigns.current_api_key.id
     role = conn.assigns.current_api_key.role
 
     with {:ok, query} <- validate_query(params) do
-      opts = build_opts(params, role)
+      opts = params |> build_opts(role) |> Keyword.put(:api_key_id, api_key_id)
 
       case Knowledge.get_context(tenant_id, query, opts) do
         {:ok, result} ->

--- a/lib/loopctl_web/controllers/knowledge_search_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_search_controller.ex
@@ -120,10 +120,13 @@ defmodule LoopctlWeb.KnowledgeSearchController do
   @doc "GET /api/v1/knowledge/search"
   def search(conn, params) do
     tenant_id = conn.assigns.current_api_key.tenant_id
+    api_key_id = conn.assigns.current_api_key.id
 
     with {:ok, q} <- validate_query(params),
          {:ok, mode} <- validate_mode(params),
-         {:ok, opts} <- build_opts(params) do
+         {:ok, base_opts} <- build_opts(params) do
+      opts = Keyword.put(base_opts, :api_key_id, api_key_id)
+
       case execute_search(tenant_id, q, mode, opts) do
         {:ok, result} ->
           json(conn, LoopctlWeb.KnowledgeSearchJSON.search(result, mode))

--- a/lib/loopctl_web/controllers/page_html/docs.html.heex
+++ b/lib/loopctl_web/controllers/page_html/docs.html.heex
@@ -825,7 +825,7 @@
           <h2 class="font-display text-xl font-semibold text-slate-100">MCP Tools</h2>
           <div class="mt-4 space-y-4 text-sm text-slate-400">
             <p>
-              The loopctl MCP server provides 37 typed tools for Claude Code agents.
+              The loopctl MCP server provides 41 typed tools for Claude Code agents.
               Install via
               <span class="font-mono text-slate-300">npm install loopctl-mcp-server</span>
               and configure in <span class="font-mono text-slate-300">.mcp.json</span>.
@@ -909,11 +909,78 @@
           </div>
 
           <h3 class="mt-8 text-sm font-semibold text-accent-400 uppercase tracking-wider text-xs">
+            Knowledge Analytics Tools
+          </h3>
+          <div class="mt-4 space-y-3">
+            <p class="text-sm text-slate-400">
+              Article usage tracking surfaces which knowledge agents actually
+              read. Every search hit, direct fetch, and context retrieval is
+              recorded as an immutable access event. Analytics endpoints
+              aggregate those events into top-articles, per-article stats,
+              per-agent usage, and unused-articles reports. All four endpoints
+              and MCP tools require <span class="font-mono text-slate-300">orchestrator+</span>.
+            </p>
+            <div class="bg-slate-800 border border-slate-700 rounded-md p-3">
+              <p class="font-mono text-xs text-slate-300">
+                <span class="text-accent-400">knowledge_analytics_top</span>
+              </p>
+              <p class="mt-1.5 text-sm text-slate-400">
+                <span class="font-mono text-slate-300">
+                  GET /api/v1/knowledge/analytics/top-articles
+                </span>
+                — Top accessed articles for the tenant. Optional params:
+                <span class="font-mono text-slate-300">limit</span>
+                (default 20, max 100), <span class="font-mono text-slate-300">since_days</span>
+                (default 7), <span class="font-mono text-slate-300">access_type</span>
+                (search, get, context, index).
+              </p>
+            </div>
+            <div class="bg-slate-800 border border-slate-700 rounded-md p-3">
+              <p class="font-mono text-xs text-slate-300">
+                <span class="text-accent-400">knowledge_article_stats</span>
+              </p>
+              <p class="mt-1.5 text-sm text-slate-400">
+                <span class="font-mono text-slate-300">
+                  GET /api/v1/knowledge/articles/:id/stats
+                </span>
+                — Per-article counts: total accesses, unique agents, by-type
+                breakdown, last access time, and the 10 most recent events.
+              </p>
+            </div>
+            <div class="bg-slate-800 border border-slate-700 rounded-md p-3">
+              <p class="font-mono text-xs text-slate-300">
+                <span class="text-accent-400">knowledge_agent_usage</span>
+              </p>
+              <p class="mt-1.5 text-sm text-slate-400">
+                <span class="font-mono text-slate-300">
+                  GET /api/v1/knowledge/analytics/agents/:agent_id
+                </span>
+                — What a specific api_key reads: total reads, unique articles,
+                access type breakdown, and top read articles.
+              </p>
+            </div>
+            <div class="bg-slate-800 border border-slate-700 rounded-md p-3">
+              <p class="font-mono text-xs text-slate-300">
+                <span class="text-accent-400">knowledge_unused_articles</span>
+              </p>
+              <p class="mt-1.5 text-sm text-slate-400">
+                <span class="font-mono text-slate-300">
+                  GET /api/v1/knowledge/analytics/unused-articles
+                </span>
+                — Published articles with zero accesses in the window. Optional
+                params: <span class="font-mono text-slate-300">days_unused</span>
+                (default 30), <span class="font-mono text-slate-300">limit</span>
+                (default 50, max 200).
+              </p>
+            </div>
+          </div>
+
+          <h3 class="mt-8 text-sm font-semibold text-accent-400 uppercase tracking-wider text-xs">
             Other Notable Tools
           </h3>
           <div class="mt-4 space-y-4 text-sm text-slate-400">
             <p>
-              The full set of 37 tools covers projects, stories, epics, verification,
+              The full set of 41 tools covers projects, stories, epics, verification,
               artifacts, orchestrator state, webhooks, skills, token usage, analytics,
               and knowledge. See the
               <a

--- a/lib/loopctl_web/controllers/page_html/home.html.heex
+++ b/lib/loopctl_web/controllers/page_html/home.html.heex
@@ -282,7 +282,7 @@
                   MCP Integration
                 </dt>
                 <dd class="mt-1.5 text-slate-400">
-                  37 typed tools for AI coding agents. No curl needed — agents interact through the MCP server.
+                  41 typed tools for AI coding agents. No curl needed — agents interact through the MCP server.
                 </dd>
               </div>
 
@@ -796,7 +796,7 @@
                   Install via
                   <span class="text-slate-400 font-mono">npm install loopctl-mcp-server</span>
                   or run with <span class="text-slate-400 font-mono">npx loopctl-mcp-server</span>.
-                  37 typed tools for AI coding agents.
+                  41 typed tools for AI coding agents.
                 </p>
               </div>
             </div>

--- a/lib/loopctl_web/controllers/route_discovery_controller.ex
+++ b/lib/loopctl_web/controllers/route_discovery_controller.ex
@@ -535,6 +535,32 @@ defmodule LoopctlWeb.RouteDiscoveryController do
         description: "List recent ingestion jobs (last 7 days, max 50)"
       },
 
+      # Knowledge Analytics (orchestrator+)
+      %{
+        method: "GET",
+        path: "/api/v1/knowledge/analytics/top-articles",
+        description:
+          "Top accessed articles for the tenant. " <>
+            "Params: limit, since_days, access_type. Role: orchestrator+."
+      },
+      %{
+        method: "GET",
+        path: "/api/v1/knowledge/articles/:id/stats",
+        description: "Per-article usage stats (counts, unique agents, recent events)"
+      },
+      %{
+        method: "GET",
+        path: "/api/v1/knowledge/analytics/agents/:agent_id",
+        description:
+          "Per-agent (api_key) knowledge usage. Params: limit, since_days. Role: orchestrator+."
+      },
+      %{
+        method: "GET",
+        path: "/api/v1/knowledge/analytics/unused-articles",
+        description:
+          "Published articles with zero accesses. Params: days_unused, limit. Role: orchestrator+."
+      },
+
       # Knowledge Wiki — project-scoped
       %{
         method: "GET",

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -264,6 +264,23 @@ defmodule LoopctlWeb.Router do
     post "/knowledge/ingest/batch", KnowledgeIngestionController, :create_batch
     get "/knowledge/ingestion-jobs", KnowledgeIngestionController, :index
 
+    # Knowledge Analytics (article usage tracking — orchestrator+)
+    get "/knowledge/analytics/top-articles",
+        KnowledgeAnalyticsController,
+        :top_articles
+
+    get "/knowledge/analytics/unused-articles",
+        KnowledgeAnalyticsController,
+        :unused_articles
+
+    get "/knowledge/analytics/agents/:agent_id",
+        KnowledgeAnalyticsController,
+        :agent_usage
+
+    get "/knowledge/articles/:id/stats",
+        KnowledgeAnalyticsController,
+        :article_stats
+
     scope "/projects/:project_id" do
       resources "/articles", ArticleController, only: [:create, :index], as: :project_article
       get "/knowledge/index", KnowledgeIndexController, :index

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -2,7 +2,7 @@
 
 MCP (Model Context Protocol) server for [loopctl](https://loopctl.com) -- structural trust for AI development loops.
 
-Wraps the loopctl REST API into 37 typed MCP tools so AI coding agents (Claude Code, etc.) can interact with loopctl without writing curl commands.
+Wraps the loopctl REST API into 41 typed MCP tools so AI coding agents (Claude Code, etc.) can interact with loopctl without writing curl commands.
 
 ## Installation
 
@@ -66,7 +66,7 @@ Or if installed locally:
 
 Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_KEY`.
 
-## Tools (37)
+## Tools (41)
 
 ### Project Tools
 
@@ -148,6 +148,15 @@ Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_K
 | `knowledge_ingest` | Submit a URL or raw content for knowledge extraction. Enqueues an Oban job. Required: `source_type`. One of: `url` or `content`. Optional: `project_id`. |
 | `knowledge_ingest_batch` | Submit up to 50 ingestion items in a single request. Each item has the same shape as `knowledge_ingest`. Returns per-item results. Required: `items`. Optional: batch-level `project_id` default. |
 | `knowledge_ingestion_jobs` | List recent content ingestion jobs (last 7 days, max 50). |
+
+### Knowledge Analytics Tools (orchestrator key)
+
+| Tool | Description |
+|---|---|
+| `knowledge_analytics_top` | Top accessed knowledge articles for the tenant. Optional: `limit` (default 20, max 100), `since_days` (default 7), `access_type` (`search`, `get`, `context`, `index`). |
+| `knowledge_article_stats` | Per-article usage stats: total accesses, unique agents, by-type breakdown, recent events. Required: `article_id`. |
+| `knowledge_agent_usage` | Per-agent (api_key) knowledge usage: total reads, unique articles, top read articles. Required: `agent_id`. Optional: `limit`, `since_days`. |
+| `knowledge_unused_articles` | Published articles with zero accesses in the window. Optional: `days_unused` (default 30), `limit` (default 50, max 200). |
 
 ### Discovery Tools
 

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -528,6 +528,55 @@ async function knowledgeIngestionJobs() {
   return toContent(result);
 }
 
+// --- Knowledge Analytics Tools (orch key) ---
+
+async function knowledgeAnalyticsTop({ limit, since_days, access_type } = {}) {
+  const params = new URLSearchParams();
+  if (limit != null) params.set("limit", String(limit));
+  if (since_days != null) params.set("since_days", String(since_days));
+  if (access_type) params.set("access_type", access_type);
+  const qs = params.toString();
+  const path = qs
+    ? `/api/v1/knowledge/analytics/top-articles?${qs}`
+    : "/api/v1/knowledge/analytics/top-articles";
+  const result = await apiCall("GET", path, null, process.env.LOOPCTL_ORCH_KEY);
+  return toContent(result);
+}
+
+async function knowledgeArticleStats({ article_id }) {
+  const result = await apiCall(
+    "GET",
+    `/api/v1/knowledge/articles/${article_id}/stats`,
+    null,
+    process.env.LOOPCTL_ORCH_KEY
+  );
+  return toContent(result);
+}
+
+async function knowledgeAgentUsage({ agent_id, limit, since_days } = {}) {
+  const params = new URLSearchParams();
+  if (limit != null) params.set("limit", String(limit));
+  if (since_days != null) params.set("since_days", String(since_days));
+  const qs = params.toString();
+  const path = qs
+    ? `/api/v1/knowledge/analytics/agents/${agent_id}?${qs}`
+    : `/api/v1/knowledge/analytics/agents/${agent_id}`;
+  const result = await apiCall("GET", path, null, process.env.LOOPCTL_ORCH_KEY);
+  return toContent(result);
+}
+
+async function knowledgeUnusedArticles({ days_unused, limit } = {}) {
+  const params = new URLSearchParams();
+  if (days_unused != null) params.set("days_unused", String(days_unused));
+  if (limit != null) params.set("limit", String(limit));
+  const qs = params.toString();
+  const path = qs
+    ? `/api/v1/knowledge/analytics/unused-articles?${qs}`
+    : "/api/v1/knowledge/analytics/unused-articles";
+  const result = await apiCall("GET", path, null, process.env.LOOPCTL_ORCH_KEY);
+  return toContent(result);
+}
+
 async function knowledgeExport({ project_id }) {
   const basePath = project_id
     ? `/api/v1/projects/${project_id}/knowledge/export`
@@ -1437,6 +1486,106 @@ const TOOLS = [
     },
   },
 
+  // Knowledge Analytics Tools (orchestrator key)
+  {
+    name: "knowledge_analytics_top",
+    description:
+      "Return the top accessed knowledge articles for the tenant. " +
+      "Use to identify which articles agents actually read. Requires orchestrator role.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        limit: {
+          type: "integer",
+          description: "Max rows to return. Default 20, max 100.",
+          minimum: 1,
+          maximum: 100,
+        },
+        since_days: {
+          type: "integer",
+          description: "Look back this many days. Default 7.",
+          minimum: 1,
+          maximum: 365,
+        },
+        access_type: {
+          type: "string",
+          enum: ["search", "get", "context", "index"],
+          description: "Optional: restrict to a single access type.",
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: "knowledge_article_stats",
+    description:
+      "Return per-article usage statistics: total accesses, unique agents, " +
+      "by-type breakdown, and the 10 most recent events. Requires orchestrator role.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        article_id: {
+          type: "string",
+          description: "The UUID of the article to inspect.",
+        },
+      },
+      required: ["article_id"],
+    },
+  },
+  {
+    name: "knowledge_agent_usage",
+    description:
+      "Return knowledge usage for a specific agent (api_key): total reads, " +
+      "unique articles, access type breakdown, and top read articles. " +
+      "Requires orchestrator role.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        agent_id: {
+          type: "string",
+          description: "API key UUID identifying the agent identity.",
+        },
+        limit: {
+          type: "integer",
+          description: "Max top articles to return. Default 20, max 100.",
+          minimum: 1,
+          maximum: 100,
+        },
+        since_days: {
+          type: "integer",
+          description: "Look back this many days. Default 7.",
+          minimum: 1,
+          maximum: 365,
+        },
+      },
+      required: ["agent_id"],
+    },
+  },
+  {
+    name: "knowledge_unused_articles",
+    description:
+      "Return published articles that have not been accessed in the configured " +
+      "time window. Use to identify dead-weight knowledge. Requires orchestrator role.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        days_unused: {
+          type: "integer",
+          description: "Window length in days. Default 30.",
+          minimum: 1,
+          maximum: 365,
+        },
+        limit: {
+          type: "integer",
+          description: "Max rows to return. Default 50, max 200.",
+          minimum: 1,
+          maximum: 200,
+        },
+      },
+      required: [],
+    },
+  },
+
   // Discovery Tools
   {
     name: "list_routes",
@@ -1588,6 +1737,19 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     case "knowledge_ingestion_jobs":
       return await knowledgeIngestionJobs();
+
+    // Knowledge Analytics Tools
+    case "knowledge_analytics_top":
+      return await knowledgeAnalyticsTop(args);
+
+    case "knowledge_article_stats":
+      return await knowledgeArticleStats(args);
+
+    case "knowledge_agent_usage":
+      return await knowledgeAgentUsage(args);
+
+    case "knowledge_unused_articles":
+      return await knowledgeUnusedArticles(args);
 
     // Discovery Tools
     case "list_routes":

--- a/priv/repo/migrations/20260410201009_create_article_access_events.exs
+++ b/priv/repo/migrations/20260410201009_create_article_access_events.exs
@@ -1,0 +1,55 @@
+defmodule Loopctl.Repo.Migrations.CreateArticleAccessEvents do
+  use Ecto.Migration
+  import Loopctl.Repo.RlsHelpers
+
+  def change do
+    create table(:article_access_events, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      add :tenant_id, references(:tenants, type: :binary_id, on_delete: :delete_all), null: false
+
+      add :article_id, references(:articles, type: :binary_id, on_delete: :delete_all),
+        null: false
+
+      add :api_key_id, references(:api_keys, type: :binary_id, on_delete: :delete_all),
+        null: false
+
+      add :access_type, :string, null: false
+      add :metadata, :map, null: false, default: %{}
+      add :accessed_at, :utc_datetime_usec, null: false
+
+      # No timestamps() — access events are immutable facts.
+      # `accessed_at` is the only timestamp on this row.
+    end
+
+    # Per-article stats: usage trends and counts for a given article over time
+    create index(:article_access_events, [:tenant_id, :article_id, :accessed_at],
+             name: :article_access_events_tenant_article_time_idx
+           )
+
+    # Per-agent usage: what each api_key reads, ordered by recency
+    create index(:article_access_events, [:tenant_id, :api_key_id, :accessed_at],
+             name: :article_access_events_tenant_apikey_time_idx
+           )
+
+    # Recent activity feed across the tenant
+    create index(:article_access_events, [:tenant_id, :accessed_at],
+             name: :article_access_events_tenant_time_idx
+           )
+
+    # Filtered queries by access type (e.g., only "search" or only "context")
+    create index(:article_access_events, [:tenant_id, :access_type, :accessed_at],
+             name: :article_access_events_tenant_type_time_idx
+           )
+
+    # Enforce DESC ordering on the time-ordered indexes via fragment.
+    # PostgreSQL can use forward indexes for ORDER BY DESC, but explicit
+    # DESC indexes optimize the common "recent first" access pattern.
+    execute(
+      "CREATE INDEX article_access_events_recent_idx ON article_access_events (tenant_id, accessed_at DESC)",
+      "DROP INDEX IF EXISTS article_access_events_recent_idx"
+    )
+
+    enable_rls(:article_access_events)
+  end
+end

--- a/test/loopctl/knowledge/article_access_event_test.exs
+++ b/test/loopctl/knowledge/article_access_event_test.exs
@@ -1,0 +1,80 @@
+defmodule Loopctl.Knowledge.ArticleAccessEventTest do
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.Knowledge.ArticleAccessEvent
+
+  describe "create_changeset/2" do
+    test "valid changeset with all required fields" do
+      changeset =
+        ArticleAccessEvent.create_changeset(%ArticleAccessEvent{}, %{
+          article_id: Ecto.UUID.generate(),
+          api_key_id: Ecto.UUID.generate(),
+          access_type: "get",
+          accessed_at: DateTime.utc_now()
+        })
+
+      assert changeset.valid?
+      assert get_field(changeset, :metadata) == %{}
+    end
+
+    test "metadata defaults to empty map and accepts free-form values" do
+      changeset =
+        ArticleAccessEvent.create_changeset(%ArticleAccessEvent{}, %{
+          article_id: Ecto.UUID.generate(),
+          api_key_id: Ecto.UUID.generate(),
+          access_type: "search",
+          metadata: %{"query" => "elixir genserver", "rank" => 1},
+          accessed_at: DateTime.utc_now()
+        })
+
+      assert changeset.valid?
+      assert get_field(changeset, :metadata) == %{"query" => "elixir genserver", "rank" => 1}
+    end
+
+    test "rejects missing required fields" do
+      changeset = ArticleAccessEvent.create_changeset(%ArticleAccessEvent{}, %{})
+
+      refute changeset.valid?
+      errors = errors_on(changeset)
+      assert errors[:article_id]
+      assert errors[:api_key_id]
+      assert errors[:access_type]
+      assert errors[:accessed_at]
+    end
+
+    for type <- ~w(search get context index) do
+      test "accepts access_type=#{type}" do
+        changeset =
+          ArticleAccessEvent.create_changeset(%ArticleAccessEvent{}, %{
+            article_id: Ecto.UUID.generate(),
+            api_key_id: Ecto.UUID.generate(),
+            access_type: unquote(type),
+            accessed_at: DateTime.utc_now()
+          })
+
+        assert changeset.valid?
+      end
+    end
+
+    test "rejects invalid access_type values" do
+      changeset =
+        ArticleAccessEvent.create_changeset(%ArticleAccessEvent{}, %{
+          article_id: Ecto.UUID.generate(),
+          api_key_id: Ecto.UUID.generate(),
+          access_type: "delete",
+          accessed_at: DateTime.utc_now()
+        })
+
+      refute changeset.valid?
+      assert errors_on(changeset)[:access_type]
+    end
+  end
+
+  describe "access_types/0" do
+    test "returns all supported types" do
+      assert ArticleAccessEvent.access_types() == ~w(search get context index)
+    end
+  end
+end

--- a/test/loopctl/knowledge_analytics_test.exs
+++ b/test/loopctl/knowledge_analytics_test.exs
@@ -1,0 +1,364 @@
+defmodule Loopctl.KnowledgeAnalyticsTest do
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge
+  alias Loopctl.Knowledge.ArticleAccessEvent
+
+  defp setup_tenant_with_agent do
+    tenant = fixture(:tenant)
+    {_raw, api_key} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+    {tenant, api_key}
+  end
+
+  describe "record_access/5" do
+    test "creates a single event row with given access_type" do
+      {tenant, api_key} = setup_tenant_with_agent()
+
+      article =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :published
+        })
+
+      assert :ok =
+               Knowledge.record_access(
+                 tenant.id,
+                 article.id,
+                 api_key.id,
+                 "get",
+                 %{"source" => "controller"}
+               )
+
+      events = AdminRepo.all(ArticleAccessEvent)
+      assert length(events) == 1
+      [event] = events
+      assert event.tenant_id == tenant.id
+      assert event.article_id == article.id
+      assert event.api_key_id == api_key.id
+      assert event.access_type == "get"
+      assert event.metadata == %{"source" => "controller"}
+      assert %DateTime{} = event.accessed_at
+    end
+
+    test "is a no-op when article_id is nil" do
+      {tenant, api_key} = setup_tenant_with_agent()
+
+      assert :ok = Knowledge.record_access(tenant.id, nil, api_key.id, "get")
+      assert AdminRepo.aggregate(ArticleAccessEvent, :count, :id) == 0
+    end
+
+    test "is a no-op when api_key_id is nil" do
+      tenant = fixture(:tenant)
+      article = fixture(:article, %{tenant_id: tenant.id})
+
+      assert :ok = Knowledge.record_access(tenant.id, article.id, nil, "get")
+      assert AdminRepo.aggregate(ArticleAccessEvent, :count, :id) == 0
+    end
+
+    test "never raises if article does not exist (fire-and-forget)" do
+      {tenant, api_key} = setup_tenant_with_agent()
+      missing_article_id = Ecto.UUID.generate()
+
+      assert :ok =
+               Knowledge.record_access(
+                 tenant.id,
+                 missing_article_id,
+                 api_key.id,
+                 "get"
+               )
+
+      # Insertion fails the FK check, but the call returns :ok regardless.
+      assert AdminRepo.aggregate(ArticleAccessEvent, :count, :id) == 0
+    end
+  end
+
+  describe "record_search_access/5" do
+    test "inserts one event per article id with rank metadata" do
+      {tenant, api_key} = setup_tenant_with_agent()
+
+      a1 = fixture(:article, %{tenant_id: tenant.id, status: :published})
+      a2 = fixture(:article, %{tenant_id: tenant.id, status: :published})
+      a3 = fixture(:article, %{tenant_id: tenant.id, status: :published})
+
+      assert :ok =
+               Knowledge.record_search_access(
+                 tenant.id,
+                 [a1.id, a2.id, a3.id],
+                 api_key.id,
+                 "ecto multi"
+               )
+
+      events =
+        ArticleAccessEvent
+        |> AdminRepo.all()
+        |> Enum.sort_by(& &1.metadata["rank"])
+
+      assert length(events) == 3
+      assert Enum.all?(events, &(&1.access_type == "search"))
+      assert Enum.all?(events, &(&1.metadata["query"] == "ecto multi"))
+      assert Enum.map(events, & &1.metadata["rank"]) == [1, 2, 3]
+      assert Enum.map(events, & &1.article_id) == [a1.id, a2.id, a3.id]
+    end
+
+    test "no-op for empty list of ids" do
+      {tenant, api_key} = setup_tenant_with_agent()
+
+      assert :ok = Knowledge.record_search_access(tenant.id, [], api_key.id, "anything")
+      assert AdminRepo.aggregate(ArticleAccessEvent, :count, :id) == 0
+    end
+  end
+
+  describe "get_article_stats/2" do
+    test "returns total, unique agents, by-type and recent rows" do
+      tenant = fixture(:tenant)
+      {_raw, agent_a} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent, name: "a"})
+      {_raw, agent_b} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent, name: "b"})
+
+      article = fixture(:article, %{tenant_id: tenant.id, status: :published})
+
+      :ok = Knowledge.record_access(tenant.id, article.id, agent_a.id, "get")
+      :ok = Knowledge.record_access(tenant.id, article.id, agent_a.id, "search")
+      :ok = Knowledge.record_access(tenant.id, article.id, agent_b.id, "context")
+
+      stats = Knowledge.get_article_stats(tenant.id, article.id)
+
+      assert stats.article_id == article.id
+      assert stats.total_accesses == 3
+      assert stats.unique_agents == 2
+      assert stats.accesses_by_type == %{"get" => 1, "search" => 1, "context" => 1}
+      assert is_struct(stats.last_accessed_at, DateTime)
+      assert length(stats.recent_accesses) == 3
+    end
+
+    test "returns zero counts when there are no events" do
+      tenant = fixture(:tenant)
+      article = fixture(:article, %{tenant_id: tenant.id, status: :published})
+
+      stats = Knowledge.get_article_stats(tenant.id, article.id)
+
+      assert stats.total_accesses == 0
+      assert stats.unique_agents == 0
+      assert stats.accesses_by_type == %{}
+      assert stats.last_accessed_at == nil
+      assert stats.recent_accesses == []
+    end
+  end
+
+  describe "list_top_articles/2" do
+    test "orders by access count descending and respects the time window" do
+      tenant = fixture(:tenant)
+      {_raw, agent} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      hot = fixture(:article, %{tenant_id: tenant.id, title: "Hot", status: :published})
+      cold = fixture(:article, %{tenant_id: tenant.id, title: "Cold", status: :published})
+
+      for _ <- 1..3 do
+        Knowledge.record_access(tenant.id, hot.id, agent.id, "get")
+      end
+
+      Knowledge.record_access(tenant.id, cold.id, agent.id, "get")
+
+      rows = Knowledge.list_top_articles(tenant.id, since: hours_ago(1))
+
+      assert [%{title: "Hot", access_count: 3} = top | _] = rows
+      assert top.unique_agents == 1
+      titles = Enum.map(rows, & &1.title)
+      assert "Cold" in titles
+    end
+
+    test "filters by access_type" do
+      tenant = fixture(:tenant)
+      {_raw, agent} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      article = fixture(:article, %{tenant_id: tenant.id, status: :published})
+
+      Knowledge.record_access(tenant.id, article.id, agent.id, "get")
+      Knowledge.record_access(tenant.id, article.id, agent.id, "search")
+      Knowledge.record_access(tenant.id, article.id, agent.id, "search")
+
+      [row] = Knowledge.list_top_articles(tenant.id, since: hours_ago(1), access_type: "search")
+      assert row.access_count == 2
+    end
+
+    test "ignores events older than :since" do
+      tenant = fixture(:tenant)
+      {_raw, agent} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      article = fixture(:article, %{tenant_id: tenant.id, status: :published})
+
+      Knowledge.record_access(tenant.id, article.id, agent.id, "get")
+
+      # Backdate the event 14 days
+      old = DateTime.add(DateTime.utc_now(), -14 * 86_400, :second)
+      AdminRepo.update_all(ArticleAccessEvent, set: [accessed_at: old])
+
+      rows = Knowledge.list_top_articles(tenant.id, since: hours_ago(1))
+      assert rows == []
+    end
+  end
+
+  describe "get_agent_usage/3" do
+    test "scopes results to a single api_key" do
+      tenant = fixture(:tenant)
+      {_raw, agent_a} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent, name: "a"})
+      {_raw, agent_b} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent, name: "b"})
+
+      a1 = fixture(:article, %{tenant_id: tenant.id, status: :published})
+      a2 = fixture(:article, %{tenant_id: tenant.id, status: :published})
+
+      Knowledge.record_access(tenant.id, a1.id, agent_a.id, "get")
+      Knowledge.record_access(tenant.id, a1.id, agent_a.id, "search")
+      Knowledge.record_access(tenant.id, a2.id, agent_a.id, "context")
+      Knowledge.record_access(tenant.id, a1.id, agent_b.id, "get")
+
+      usage = Knowledge.get_agent_usage(tenant.id, agent_a.id, since: hours_ago(1))
+
+      assert usage.api_key_id == agent_a.id
+      assert usage.total_reads == 3
+      assert usage.unique_articles == 2
+      assert usage.access_by_type == %{"get" => 1, "search" => 1, "context" => 1}
+      assert length(usage.top_articles) == 2
+    end
+  end
+
+  describe "list_unused_articles/2" do
+    test "returns published articles with zero accesses in the window" do
+      tenant = fixture(:tenant)
+      {_raw, agent} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      used = fixture(:article, %{tenant_id: tenant.id, title: "Used", status: :published})
+      _unused = fixture(:article, %{tenant_id: tenant.id, title: "Unused", status: :published})
+
+      _draft =
+        fixture(:article, %{tenant_id: tenant.id, title: "Draft Only", status: :draft})
+
+      Knowledge.record_access(tenant.id, used.id, agent.id, "get")
+
+      rows = Knowledge.list_unused_articles(tenant.id, days_unused: 7)
+      titles = Enum.map(rows, & &1.title)
+
+      assert "Unused" in titles
+      refute "Used" in titles
+      refute "Draft Only" in titles
+    end
+
+    test "an article that was accessed long ago counts as unused" do
+      tenant = fixture(:tenant)
+      {_raw, agent} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      article = fixture(:article, %{tenant_id: tenant.id, status: :published})
+
+      Knowledge.record_access(tenant.id, article.id, agent.id, "get")
+
+      old = DateTime.add(DateTime.utc_now(), -90 * 86_400, :second)
+      AdminRepo.update_all(ArticleAccessEvent, set: [accessed_at: old])
+
+      rows = Knowledge.list_unused_articles(tenant.id, days_unused: 30)
+      assert Enum.any?(rows, &(&1.article_id == article.id))
+    end
+  end
+
+  describe "tenant isolation" do
+    test "tenant A cannot see tenant B's stats, top, agent usage, or unused" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+
+      {_raw, agent_a} = fixture(:api_key, %{tenant_id: tenant_a.id, role: :agent})
+      {_raw, agent_b} = fixture(:api_key, %{tenant_id: tenant_b.id, role: :agent})
+
+      article_a = fixture(:article, %{tenant_id: tenant_a.id, status: :published})
+      article_b = fixture(:article, %{tenant_id: tenant_b.id, status: :published})
+
+      Knowledge.record_access(tenant_a.id, article_a.id, agent_a.id, "get")
+      Knowledge.record_access(tenant_b.id, article_b.id, agent_b.id, "get")
+
+      stats_a_from_b = Knowledge.get_article_stats(tenant_b.id, article_a.id)
+      assert stats_a_from_b.total_accesses == 0
+
+      top_a = Knowledge.list_top_articles(tenant_a.id, since: hours_ago(1))
+      assert Enum.all?(top_a, &(&1.article_id == article_a.id))
+
+      usage_b_from_a = Knowledge.get_agent_usage(tenant_a.id, agent_b.id, since: hours_ago(1))
+      assert usage_b_from_a.total_reads == 0
+
+      unused_a = Knowledge.list_unused_articles(tenant_a.id, days_unused: 30)
+      refute Enum.any?(unused_a, &(&1.article_id == article_b.id))
+    end
+  end
+
+  describe "integration with reads" do
+    test "Knowledge.get_article/3 records a get event when api_key_id is supplied" do
+      {tenant, api_key} = setup_tenant_with_agent()
+      article = fixture(:article, %{tenant_id: tenant.id, status: :published})
+
+      {:ok, _} = Knowledge.get_article(tenant.id, article.id, api_key_id: api_key.id)
+
+      [event] = AdminRepo.all(ArticleAccessEvent)
+      assert event.access_type == "get"
+      assert event.article_id == article.id
+      assert event.api_key_id == api_key.id
+    end
+
+    test "Knowledge.search_keyword/3 records search events for results" do
+      {tenant, api_key} = setup_tenant_with_agent()
+
+      _article =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Ecto Multi Pattern",
+          body: "Use Ecto.Multi for atomic operations",
+          status: :published
+        })
+
+      {:ok, %{results: results}} =
+        Knowledge.search_keyword(tenant.id, "Ecto", api_key_id: api_key.id)
+
+      assert results != []
+
+      events = AdminRepo.all(ArticleAccessEvent)
+      assert events != []
+      assert Enum.all?(events, &(&1.access_type == "search"))
+      assert Enum.all?(events, &(&1.metadata["query"] == "Ecto"))
+    end
+
+    test "Knowledge.get_context/3 records context events for returned articles" do
+      {tenant, api_key} = setup_tenant_with_agent()
+
+      _article =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Context Recording",
+          body: "Body about context recording for analytics integration tests.",
+          status: :published
+        })
+
+      {:ok, %{results: results}} =
+        Knowledge.get_context(tenant.id, "context recording", api_key_id: api_key.id)
+
+      if results != [] do
+        events = AdminRepo.all(ArticleAccessEvent)
+        # Only "context" events should be present (sub-search recordings suppressed)
+        assert Enum.all?(events, &(&1.access_type == "context"))
+        assert events != []
+      end
+    end
+
+    test "search results without api_key_id record nothing" do
+      tenant = fixture(:tenant)
+
+      _article =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Anonymous Read",
+          body: "Body for anonymous access test",
+          status: :published
+        })
+
+      {:ok, _} = Knowledge.search_keyword(tenant.id, "Anonymous")
+
+      assert AdminRepo.aggregate(ArticleAccessEvent, :count, :id) == 0
+    end
+  end
+
+  defp hours_ago(n), do: DateTime.add(DateTime.utc_now(), -n * 3600, :second)
+end

--- a/test/loopctl_web/controllers/knowledge_analytics_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_analytics_controller_test.exs
@@ -1,0 +1,264 @@
+defmodule LoopctlWeb.KnowledgeAnalyticsControllerTest do
+  use LoopctlWeb.ConnCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.Knowledge
+
+  defp auth_conn(conn, raw_key) do
+    put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  describe "auth" do
+    test "agent role is rejected (orchestrator+ required) on top-articles", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/analytics/top-articles")
+
+      assert json_response(conn, 403)
+    end
+
+    test "agent role is rejected on article stats", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      article = fixture(:article, %{tenant_id: tenant.id, status: :published})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/articles/#{article.id}/stats")
+
+      assert json_response(conn, 403)
+    end
+
+    test "agent role is rejected on agent usage", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, agent_key} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/analytics/agents/#{agent_key.id}")
+
+      assert json_response(conn, 403)
+    end
+
+    test "agent role is rejected on unused articles", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/analytics/unused-articles")
+
+      assert json_response(conn, 403)
+    end
+  end
+
+  describe "GET /api/v1/knowledge/analytics/top-articles" do
+    test "returns rows ordered by access count", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {orch_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+      {_raw, agent} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      hot = fixture(:article, %{tenant_id: tenant.id, title: "Hot", status: :published})
+      cold = fixture(:article, %{tenant_id: tenant.id, title: "Cold", status: :published})
+
+      for _ <- 1..3, do: Knowledge.record_access(tenant.id, hot.id, agent.id, "get")
+      Knowledge.record_access(tenant.id, cold.id, agent.id, "get")
+
+      conn =
+        conn
+        |> auth_conn(orch_key)
+        |> get(~p"/api/v1/knowledge/analytics/top-articles")
+
+      body = json_response(conn, 200)
+      assert is_list(body["data"])
+
+      [first | _] = body["data"]
+      assert first["title"] == "Hot"
+      assert first["access_count"] == 3
+      assert first["unique_agents"] == 1
+      assert is_map(body["meta"])
+    end
+
+    test "filters by access_type query param", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {orch_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+      {_raw, agent} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      article = fixture(:article, %{tenant_id: tenant.id, status: :published})
+
+      Knowledge.record_access(tenant.id, article.id, agent.id, "search")
+      Knowledge.record_access(tenant.id, article.id, agent.id, "get")
+
+      conn =
+        conn
+        |> auth_conn(orch_key)
+        |> get(~p"/api/v1/knowledge/analytics/top-articles?access_type=search")
+
+      body = json_response(conn, 200)
+      [row] = body["data"]
+      assert row["access_count"] == 1
+    end
+  end
+
+  describe "GET /api/v1/knowledge/articles/:id/stats" do
+    test "returns 200 with aggregated stats", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {orch_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+      {_raw, agent} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      article = fixture(:article, %{tenant_id: tenant.id, status: :published})
+
+      Knowledge.record_access(tenant.id, article.id, agent.id, "get")
+      Knowledge.record_access(tenant.id, article.id, agent.id, "search")
+
+      conn =
+        conn
+        |> auth_conn(orch_key)
+        |> get(~p"/api/v1/knowledge/articles/#{article.id}/stats")
+
+      data = json_response(conn, 200)["data"]
+      assert data["article_id"] == article.id
+      assert data["title"] == article.title
+      assert data["total_accesses"] == 2
+      assert data["unique_agents"] == 1
+      assert data["accesses_by_type"] == %{"get" => 1, "search" => 1}
+      assert is_list(data["recent_accesses"])
+    end
+
+    test "returns 404 for missing article", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {orch_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      conn =
+        conn
+        |> auth_conn(orch_key)
+        |> get(~p"/api/v1/knowledge/articles/#{Ecto.UUID.generate()}/stats")
+
+      assert json_response(conn, 404)
+    end
+  end
+
+  describe "GET /api/v1/knowledge/analytics/agents/:agent_id" do
+    test "scopes to a single api_key", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {orch_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+      {_raw, agent_a} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent, name: "a"})
+      {_raw, agent_b} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent, name: "b"})
+
+      article = fixture(:article, %{tenant_id: tenant.id, status: :published})
+
+      Knowledge.record_access(tenant.id, article.id, agent_a.id, "get")
+      Knowledge.record_access(tenant.id, article.id, agent_a.id, "get")
+      Knowledge.record_access(tenant.id, article.id, agent_b.id, "get")
+
+      conn =
+        conn
+        |> auth_conn(orch_key)
+        |> get(~p"/api/v1/knowledge/analytics/agents/#{agent_a.id}")
+
+      data = json_response(conn, 200)["data"]
+      assert data["api_key_id"] == agent_a.id
+      assert data["total_reads"] == 2
+      assert data["unique_articles"] == 1
+      assert is_list(data["top_articles"])
+    end
+  end
+
+  describe "GET /api/v1/knowledge/analytics/unused-articles" do
+    test "returns articles never accessed in the window", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {orch_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+      {_raw, agent} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      used = fixture(:article, %{tenant_id: tenant.id, title: "Used", status: :published})
+
+      _unused =
+        fixture(:article, %{tenant_id: tenant.id, title: "Unused", status: :published})
+
+      Knowledge.record_access(tenant.id, used.id, agent.id, "get")
+
+      conn =
+        conn
+        |> auth_conn(orch_key)
+        |> get(~p"/api/v1/knowledge/analytics/unused-articles?days_unused=7")
+
+      body = json_response(conn, 200)
+      titles = Enum.map(body["data"], & &1["title"])
+      assert "Unused" in titles
+      refute "Used" in titles
+      assert body["meta"]["days_unused"] == 7
+    end
+  end
+
+  describe "integration: real read endpoints record events" do
+    test "GET /articles/:id records a get event", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, agent_key} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      article = fixture(:article, %{tenant_id: tenant.id, status: :published})
+
+      conn
+      |> auth_conn(raw_key)
+      |> get(~p"/api/v1/articles/#{article.id}")
+      |> json_response(200)
+
+      events = Loopctl.AdminRepo.all(Loopctl.Knowledge.ArticleAccessEvent)
+      assert length(events) == 1
+      [event] = events
+      assert event.access_type == "get"
+      assert event.api_key_id == agent_key.id
+      assert event.article_id == article.id
+    end
+
+    test "GET /knowledge/search records search events", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _agent} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      _article =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Genserver Patterns",
+          body: "GenServer is the OTP behaviour for stateful processes.",
+          status: :published
+        })
+
+      conn
+      |> auth_conn(raw_key)
+      |> get(~p"/api/v1/knowledge/search?q=GenServer&mode=keyword")
+      |> json_response(200)
+
+      events = Loopctl.AdminRepo.all(Loopctl.Knowledge.ArticleAccessEvent)
+      assert events != []
+      assert Enum.all?(events, &(&1.access_type == "search"))
+    end
+
+    test "GET /knowledge/context records context events", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _agent} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      _article =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Context Tracking",
+          body: "Body about analytics context tracking via the api endpoint.",
+          status: :published
+        })
+
+      conn
+      |> auth_conn(raw_key)
+      |> get(~p"/api/v1/knowledge/context?query=context+tracking")
+      |> json_response(200)
+
+      events = Loopctl.AdminRepo.all(Loopctl.Knowledge.ArticleAccessEvent)
+
+      if events != [] do
+        assert Enum.all?(events, &(&1.access_type == "context"))
+      end
+    end
+  end
+end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -17,6 +17,7 @@ defmodule Loopctl.Fixtures do
   alias Loopctl.Audit.AuditLog
   alias Loopctl.Auth
   alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.ArticleAccessEvent
   alias Loopctl.Knowledge.ArticleLink
   alias Loopctl.Orchestrator.OrchestratorState
   alias Loopctl.Projects.Project
@@ -106,6 +107,17 @@ defmodule Loopctl.Fixtures do
       %{
         relationship_type: :relates_to,
         metadata: %{}
+      },
+      Enum.into(attrs, %{})
+    )
+  end
+
+  def build(:article_access_event, attrs) do
+    Map.merge(
+      %{
+        access_type: "get",
+        metadata: %{},
+        accessed_at: DateTime.utc_now()
       },
       Enum.into(attrs, %{})
     )
@@ -477,6 +489,57 @@ defmodule Loopctl.Fixtures do
         target_article_id: target_article_id,
         relationship_type: data.relationship_type,
         metadata: data.metadata
+      })
+
+    AdminRepo.insert!(changeset)
+  end
+
+  def fixture(:article_access_event, attrs) do
+    attrs = Enum.into(attrs, %{})
+
+    # Auto-create a tenant if not provided
+    {tenant_id, attrs} =
+      case Map.get(attrs, :tenant_id) do
+        nil ->
+          tenant = fixture(:tenant)
+          {tenant.id, Map.put(attrs, :tenant_id, tenant.id)}
+
+        tid ->
+          {tid, attrs}
+      end
+
+    # Auto-create the article if not provided
+    {article_id, attrs} =
+      case Map.get(attrs, :article_id) do
+        nil ->
+          article = fixture(:article, %{tenant_id: tenant_id})
+          {article.id, Map.put(attrs, :article_id, article.id)}
+
+        id ->
+          {id, attrs}
+      end
+
+    # Auto-create the api_key if not provided
+    {api_key_id, attrs} =
+      case Map.get(attrs, :api_key_id) do
+        nil ->
+          {_raw, api_key} = fixture(:api_key, %{tenant_id: tenant_id, role: :agent})
+          {api_key.id, Map.put(attrs, :api_key_id, api_key.id)}
+
+        id ->
+          {id, attrs}
+      end
+
+    data = build(:article_access_event, attrs)
+
+    changeset =
+      %ArticleAccessEvent{tenant_id: tenant_id}
+      |> ArticleAccessEvent.create_changeset(%{
+        article_id: article_id,
+        api_key_id: api_key_id,
+        access_type: data.access_type,
+        metadata: data.metadata,
+        accessed_at: data.accessed_at
       })
 
     AdminRepo.insert!(changeset)


### PR DESCRIPTION
## Summary

The knowledge wiki has 409 published articles but no way to know which ones agents actually read. This PR records every read access (search hits, direct gets, context retrievals) as an immutable event and exposes four orchestrator-only analytics endpoints to surface valuable vs dead-weight knowledge.

- New `article_access_events` table with composite indexes on `(tenant_id, article_id, accessed_at)`, `(tenant_id, api_key_id, accessed_at)`, `(tenant_id, accessed_at)`, and `(tenant_id, access_type, accessed_at)`. RLS enabled. No `updated_at` — events are immutable facts.
- `Loopctl.Knowledge.Analytics` module:
  - `record_access/5`, `record_search_access/5`, `record_context_access/4` — fire-and-forget (`Task.Supervisor` in prod, inline in tests via `:analytics_recording_mode` config so the insert shares the sandbox connection). Failures are logged and swallowed; reads never fail because of analytics writes.
  - `get_article_stats/2`, `list_top_articles/2`, `get_agent_usage/3`, `list_unused_articles/2` — aggregate reporting. All scoped by `tenant_id` and run via `AdminRepo`.
- `Knowledge.get_article/3`, `search_keyword/3`, `search_semantic/3`, `search_combined/3`, and `get_context/3` accept an `:api_key_id` opt and record access on success. `index_articles` is intentionally NOT tracked (too noisy). Combined search suppresses sub-search recording with a private `_skip_record_access` opt to avoid double-counting.
- `LoopctlWeb.KnowledgeAnalyticsController` (orchestrator+) exposes:
  - `GET /api/v1/knowledge/analytics/top-articles` — params: `limit`, `since_days`, `access_type`
  - `GET /api/v1/knowledge/articles/:id/stats`
  - `GET /api/v1/knowledge/analytics/agents/:agent_id` — params: `limit`, `since_days`
  - `GET /api/v1/knowledge/analytics/unused-articles` — params: `days_unused`, `limit`
- Article controller `show` now passes `api_key_id` from `conn.assigns.current_api_key.id` to `Knowledge.get_article/3`. Search and context controllers inject it into the opts list before calling the context.
- Four new MCP tools wired through to the new endpoints, all using `LOOPCTL_ORCH_KEY`:
  `knowledge_analytics_top`, `knowledge_article_stats`, `knowledge_agent_usage`, `knowledge_unused_articles`.
- Tool count bumped 37 -> 41 across `mcp-server/README.md`, `home.html.heex`, `docs.html.heex`, and `CLAUDE.md`. New "Knowledge Analytics Tools" section added to the docs page with one card per tool.
- New `Task.Supervisor` (`Loopctl.TaskSupervisor`) added to the application supervision tree for fire-and-forget recording in production.

## Test plan

- [x] `mix precommit` (compile --warnings-as-errors, format, credo --strict, deps.audit, dialyzer, test) — green, 2048 tests, 0 failures
- [x] `Loopctl.Knowledge.ArticleAccessEvent` changeset tests cover required fields, metadata defaults, and access_type enum validation
- [x] `Loopctl.KnowledgeAnalytics` context tests cover `record_access` (single + nil edge cases + missing FK), `record_search_access` (rank metadata), all four reporting queries (counts, ordering, time-window filtering, access_type filtering), and full tenant isolation
- [x] `LoopctlWeb.KnowledgeAnalyticsController` tests cover agent role rejection on every action, top-articles ordering and filtering, article stats success + 404, agent usage scoping, and unused-articles filtering
- [x] Integration tests verify that real `GET /articles/:id`, `GET /knowledge/search`, and `GET /knowledge/context` requests record the expected event rows
- [x] Existing knowledge wiki tests (article CRUD, links, lint, export, embedding, search controllers) remain green — get_article signature change is backwards-compatible via default opts

## Notes

- Recording is dispatched via `Task.Supervisor.start_child` in production. In tests, the new `:analytics_recording_mode, :sync` config flag runs inserts inline so they share the sandbox transaction. No Mox shenanigans required.
- Combined search suppresses sub-search recording so each user-facing combined query produces exactly one set of `"combined"`-tagged events (with the merged result list), not three sets (`keyword + semantic + combined`).
- Context endpoint records `"context"` events (not `"search"`) for the final ranked list — sub-searches inside `get_context/3` are suppressed via the same `_skip_record_access` flag.
- All metadata is free-form JSONB. Search events include `"query"`, `"rank"`, and `"mode"`. Context events include `"query"` and `"rank"`. Get events include any opt-supplied `:access_metadata`.