### PR TITLE
Lower article link threshold from 0.8 to 0.6

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -11,7 +11,10 @@ config :loopctl,
   ecto_repos: [Loopctl.Repo],
   generators: [timestamp_type: :utc_datetime, binary_id: true],
   embedding_dimensions: 1536,
-  article_link_threshold: 0.8,
+  # Cosine similarity threshold for auto-linking articles.
+  # 0.6 is calibrated for relationship discovery (related topics).
+  # 0.8+ is only useful for near-duplicate detection.
+  article_link_threshold: 0.6,
   article_link_max_comparisons: 50
 
 # AdminRepo shares the same database but uses a role with BYPASSRLS in production.

--- a/lib/loopctl/workers/article_linking_worker.ex
+++ b/lib/loopctl/workers/article_linking_worker.ex
@@ -30,7 +30,7 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
 
   ## Threshold (AC-21.2.4)
 
-  Configurable via `Application.get_env(:loopctl, :article_link_threshold, 0.8)`.
+  Configurable via `Application.get_env(:loopctl, :article_link_threshold, 0.6)`.
   Only articles with cosine similarity >= threshold get linked.
 
   ## Retry Strategy (AC-21.2.13)
@@ -69,7 +69,7 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
         :ok
 
       {:ok, %Article{} = article} ->
-        threshold = Application.get_env(:loopctl, :article_link_threshold, 0.8)
+        threshold = Application.get_env(:loopctl, :article_link_threshold, 0.6)
         max_comparisons = Application.get_env(:loopctl, :article_link_max_comparisons, 50)
         find_and_link_similar(article, tenant_id, threshold, max_comparisons)
     end

--- a/test/loopctl/workers/article_linking_worker_test.exs
+++ b/test/loopctl/workers/article_linking_worker_test.exs
@@ -86,7 +86,7 @@ defmodule Loopctl.Workers.ArticleLinkingWorkerTest do
       link = hd(links)
       assert link.metadata["auto_generated"] == true
       assert is_float(link.metadata["similarity_score"])
-      assert link.metadata["similarity_score"] >= 0.8
+      assert link.metadata["similarity_score"] >= 0.6
     end
   end
 


### PR DESCRIPTION
Our content is diverse (avg similarity 0.30). 0.8 was too strict — only 7 links across 409 articles. 0.6 enables genuine relationship discovery while still filtering unrelated content.