### PR TITLE
Add delete_project MCP tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,7 @@ mix ecto.reset         # Drop, create, migrate
 - **User Stories**: `docs/user_stories/epic_N_name/us_N.M.json` — 60 stories across 15 epics
 - **Skills**: `skills/loopctl-*.md` — 6 orchestration skills
 - **Orchestration Guide**: `docs/orchestration-guide.md` — methodology: loop, trust model, checkpointing
-- **MCP Server**: `mcp-server/` — 41 typed tools for Claude Code agents (no curl needed), published as `loopctl-mcp-server` on npm
+- **MCP Server**: `mcp-server/` — 42 typed tools for Claude Code agents (no curl needed), published as `loopctl-mcp-server` on npm
 - **Build Status**: memory-keeper key `build_status`, channel `loopctl`
 
 ## MCP Server

--- a/lib/loopctl_web/controllers/page_html/docs.html.heex
+++ b/lib/loopctl_web/controllers/page_html/docs.html.heex
@@ -980,7 +980,7 @@
           </h3>
           <div class="mt-4 space-y-4 text-sm text-slate-400">
             <p>
-              The full set of 41 tools covers projects, stories, epics, verification,
+              The full set of 42 tools covers projects, stories, epics, verification,
               artifacts, orchestrator state, webhooks, skills, token usage, analytics,
               and knowledge. See the
               <a

--- a/lib/loopctl_web/controllers/page_html/home.html.heex
+++ b/lib/loopctl_web/controllers/page_html/home.html.heex
@@ -282,7 +282,7 @@
                   MCP Integration
                 </dt>
                 <dd class="mt-1.5 text-slate-400">
-                  41 typed tools for AI coding agents. No curl needed — agents interact through the MCP server.
+                  42 typed tools for AI coding agents. No curl needed — agents interact through the MCP server.
                 </dd>
               </div>
 
@@ -796,7 +796,7 @@
                   Install via
                   <span class="text-slate-400 font-mono">npm install loopctl-mcp-server</span>
                   or run with <span class="text-slate-400 font-mono">npx loopctl-mcp-server</span>.
-                  41 typed tools for AI coding agents.
+                  42 typed tools for AI coding agents.
                 </p>
               </div>
             </div>

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -169,6 +169,16 @@ async function createProject({ name, slug, repo_url, description, tech_stack, mi
   return toContent(result);
 }
 
+async function deleteProject({ project_id }) {
+  const result = await apiCall(
+    "DELETE",
+    `/api/v1/projects/${project_id}`,
+    null,
+    process.env.LOOPCTL_USER_KEY
+  );
+  return toContent(result);
+}
+
 async function getProgress({ project_id, include_cost }) {
   const params = new URLSearchParams();
   if (include_cost) params.set("include_cost", "true");
@@ -645,6 +655,21 @@ const TOOLS = [
         },
       },
       required: ["name", "slug"],
+    },
+  },
+  {
+    name: "delete_project",
+    description:
+      "Delete a project and all of its dependent resources (epics, stories, audit entries scoped to it). REQUIRES LOOPCTL_USER_KEY to be set in the MCP server env (user role — orchestrator role is NOT sufficient for this destructive operation). The deletion is irreversible.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        project_id: {
+          type: "string",
+          description: "The UUID of the project to delete.",
+        },
+      },
+      required: ["project_id"],
     },
   },
   {
@@ -1635,6 +1660,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     case "create_project":
       return await createProject(args);
+
+    case "delete_project":
+      return await deleteProject(args);
 
     case "get_progress":
       return await getProgress(args);


### PR DESCRIPTION
## Summary
- Wraps `DELETE /api/v1/projects/:id` as a typed MCP tool
- Requires `LOOPCTL_USER_KEY` (user role) — same pattern as `knowledge_bulk_publish`
- Closes a structural gap where the orchestrator-guardrail correctly blocks bare curl to loopctl, but no MCP tool wrapped the destructive endpoint, leaving no way to clean up test projects from an agent session
- Tool count: 41 → 42 (updated in CLAUDE.md, docs page, home page)

## Test plan
- [x] `mix precommit` clean (2073 tests, dialyzer + credo green — no Elixir code changed, only docs)
- [x] `node -c mcp-server/index.js` syntax check
- [ ] After v1.6.1 npm publish + session restart: call `delete_project` to remove the test project `6b190140-ffb7-4efc-9f9e-9ad2a59a3d7f` (the one created earlier today to verify the mission round-trip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)