### PR TITLE
docs: add Epic 25 knowledge wiki attribution stories

### DIFF
--- a/docs/user_stories/epic_25_knowledge_wiki_attribution/us_25.1.json
+++ b/docs/user_stories/epic_25_knowledge_wiki_attribution/us_25.1.json
@@ -1,0 +1,249 @@
+{
+  "id": "US-25.1",
+  "title": "Wiki Access Event Attribution — Schema & Ingestion",
+  "epic": {
+    "id": "epic_25",
+    "name": "Knowledge Wiki Attribution & Analytics"
+  },
+  "priority": "high",
+  "phase": "observability",
+  "story": {
+    "as_a": "tenant administrator",
+    "i_want_to": "have every knowledge wiki access event tagged with the project and story the caller was working on at the time of the read",
+    "so_that": "I can answer 'which projects rely on the wiki?' and 'which stories triggered the most research?' after the fact, without needing to correlate through audit logs or guess from timestamps"
+  },
+  "rationale": "Today knowledge_access_events stores only tenant_id, article_id, api_key_id, access_type, and a jsonb metadata blob. That is enough to know *when* something was read, but not *what work it was in service of*. Stories and projects are the natural attribution dimensions — they are what a human operator actually wants to slice by when deciding whether the wiki is earning its keep. Recording these at ingest time is the only way to answer those questions honestly; reconstructing after the fact requires fragile heuristics. This story plumbs the context through from the API surface to the event row, keeping tenant isolation exactly as it is (tenant_id remains the hard boundary).",
+  "acceptance_criteria": [
+    {
+      "id": "AC-25.1.1",
+      "description": "A migration adds two nullable columns to knowledge_access_events: project_id (uuid, FK to projects.id, ON DELETE SET NULL) and story_id (uuid, FK to stories.id, ON DELETE SET NULL). Both are nullable so rows written before this story remain valid and so callers without context can still record reads.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-25.1.2",
+      "description": "Two btree indexes are created: knowledge_access_events_project_id_inserted_at_idx on (tenant_id, project_id, inserted_at DESC) and knowledge_access_events_story_id_inserted_at_idx on (tenant_id, story_id, inserted_at DESC). Indexes include tenant_id as the first column to match RLS query shapes.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-25.1.3",
+      "description": "RLS policy on knowledge_access_events is unchanged — tenant_id remains the sole isolation boundary. The new project_id and story_id columns are not referenced in any RLS predicate. A cross-tenant project_id or story_id passed by a caller will fail validation before the insert (see AC-25.1.7), not fall through RLS.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-25.1.4",
+      "description": "Loopctl.Knowledge.Analytics.record_access/5 is extended with a new 6th positional argument `context` defaulting to %{} that accepts %{project_id: uuid | nil, story_id: uuid | nil}. When present, those values are written to the new columns. Existing 5-arity callers continue to work (bitwise default). The function preserves its fire-and-forget async semantics.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-25.1.5",
+      "description": "Loopctl.Knowledge.Analytics.record_search_access/5 and record_context_access/4 are similarly extended to accept and persist the context map. The event row stores the same project_id/story_id for every article in a batch search/context access.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-25.1.6",
+      "description": "Loopctl.Knowledge.get_article/3, search_articles/3, get_context/3, and list_index/2 accept opts[:project_id] and opts[:story_id]. When present, they are forwarded to the Analytics.record_* call. When absent, the event is recorded with NULL columns (no behavior change).",
+      "status": "pending"
+    },
+    {
+      "id": "AC-25.1.7",
+      "description": "Validation: if opts[:project_id] is provided, the Knowledge context verifies the project belongs to the caller's tenant by querying Loopctl.Projects.get_project/2 before recording. On mismatch the read still succeeds but the attribution is silently dropped (logged at :warning level via Logger) — the wiki read must never 500 because a caller mis-tagged context. Same for story_id against Loopctl.WorkBreakdown.get_story/2.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-25.1.8",
+      "description": "When story_id is provided and project_id is not, the server derives project_id from story.project_id and records both. This keeps the common orchestrator case ('I am working on story X') ergonomic and never under-attributes.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-25.1.9",
+      "description": "Tenant isolation test: tenant A passes tenant B's project_id to a knowledge read. The read succeeds, but the inserted knowledge_access_events row has project_id = NULL (validation rejected it). Tenant B's analytics queries never see the read.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-25.1.10",
+      "description": "No query path in this story reads the new columns. All analytics changes (filtering, grouping, aggregation) are deferred to US-25.2. This story ships the ingestion layer only.",
+      "status": "pending"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "TC-25.1.1",
+      "name": "Migration adds columns and indexes with correct tenant-first index shape",
+      "type": "integration",
+      "preconditions": [
+        "Fresh test database",
+        "Migration priv/repo/migrations/<ts>_add_attribution_to_knowledge_access_events.exs"
+      ],
+      "steps": [
+        "Run mix ecto.migrate",
+        "Query pg_indexes for tables knowledge_access_events",
+        "Query information_schema.columns for knowledge_access_events"
+      ],
+      "expected_results": [
+        "columns project_id (uuid, nullable, FK on projects) and story_id (uuid, nullable, FK on stories) exist",
+        "Index knowledge_access_events_project_id_inserted_at_idx exists with columns (tenant_id, project_id, inserted_at DESC)",
+        "Index knowledge_access_events_story_id_inserted_at_idx exists with columns (tenant_id, story_id, inserted_at DESC)",
+        "RLS policy unchanged from before the migration"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-25.1.2",
+      "name": "record_access writes project_id and story_id when context is provided",
+      "type": "unit",
+      "preconditions": [
+        "tenant = fixture(:tenant)",
+        "project = fixture(:project, tenant: tenant)",
+        "story = fixture(:story, tenant: tenant, project: project)",
+        "api_key = fixture(:api_key, tenant: tenant, role: :agent)",
+        "article = fixture(:article, tenant: tenant, status: :published)"
+      ],
+      "steps": [
+        "Call Loopctl.Knowledge.Analytics.record_access(tenant.id, article.id, api_key.id, \"get\", %{}, %{project_id: project.id, story_id: story.id})",
+        "Wait for the async task to finish (use Task.Supervisor.async sync in test mode or sync_stream)",
+        "Query knowledge_access_events where tenant_id = tenant.id and article_id = article.id"
+      ],
+      "expected_results": [
+        "A row exists",
+        "row.project_id == project.id",
+        "row.story_id == story.id",
+        "row.api_key_id == api_key.id",
+        "row.access_type == \"get\""
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-25.1.3",
+      "name": "get_article forwards project_id/story_id from opts to record_access",
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant)",
+        "project = fixture(:project, tenant: tenant)",
+        "story = fixture(:story, tenant: tenant, project: project)",
+        "api_key = fixture(:api_key, tenant: tenant, role: :agent)",
+        "article = fixture(:article, tenant: tenant, status: :published)"
+      ],
+      "steps": [
+        "Call Loopctl.Knowledge.get_article(tenant.id, article.id, api_key_id: api_key.id, project_id: project.id, story_id: story.id)",
+        "Flush async tasks",
+        "Query knowledge_access_events"
+      ],
+      "expected_results": [
+        "{:ok, article} returned",
+        "Event row has project_id = project.id and story_id = story.id"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-25.1.4",
+      "name": "Deriving project_id from story_id when project_id omitted",
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant)",
+        "project = fixture(:project, tenant: tenant)",
+        "story = fixture(:story, tenant: tenant, project: project)",
+        "api_key = fixture(:api_key, tenant: tenant, role: :agent)",
+        "article = fixture(:article, tenant: tenant, status: :published)"
+      ],
+      "steps": [
+        "Call Loopctl.Knowledge.get_article(tenant.id, article.id, api_key_id: api_key.id, story_id: story.id)",
+        "Flush async tasks",
+        "Query knowledge_access_events"
+      ],
+      "expected_results": [
+        "Event row has project_id == project.id (derived from story)",
+        "Event row has story_id == story.id"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-25.1.5",
+      "name": "Cross-tenant project_id is rejected and attribution is dropped (not 500)",
+      "type": "integration",
+      "preconditions": [
+        "tenant_a = fixture(:tenant)",
+        "tenant_b = fixture(:tenant)",
+        "project_b = fixture(:project, tenant: tenant_b)",
+        "api_key_a = fixture(:api_key, tenant: tenant_a, role: :agent)",
+        "article = fixture(:article, tenant: tenant_a, status: :published)",
+        "capture_log(fn -> ... end)"
+      ],
+      "steps": [
+        "Call Loopctl.Knowledge.get_article(tenant_a.id, article.id, api_key_id: api_key_a.id, project_id: project_b.id)",
+        "Flush async tasks",
+        "Query knowledge_access_events where tenant_id = tenant_a.id"
+      ],
+      "expected_results": [
+        "{:ok, article} returned (read succeeds)",
+        "Event row exists with project_id = NULL",
+        "A warning log line mentioning \"cross-tenant project_id dropped\" or similar",
+        "No rows visible in tenant_b's analytics (RLS unchanged)"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-25.1.6",
+      "name": "Omitting context still records the event with NULL columns (backward compat)",
+      "type": "unit",
+      "preconditions": [
+        "tenant = fixture(:tenant)",
+        "api_key = fixture(:api_key, tenant: tenant, role: :agent)",
+        "article = fixture(:article, tenant: tenant, status: :published)"
+      ],
+      "steps": [
+        "Call Loopctl.Knowledge.Analytics.record_access(tenant.id, article.id, api_key.id, \"search\", %{})",
+        "Flush async tasks",
+        "Query knowledge_access_events"
+      ],
+      "expected_results": [
+        "Row exists with project_id = nil and story_id = nil",
+        "No errors raised"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-25.1.7",
+      "name": "Batch search_access records the same project_id/story_id for every article in the batch",
+      "type": "unit",
+      "preconditions": [
+        "tenant = fixture(:tenant)",
+        "project = fixture(:project, tenant: tenant)",
+        "story = fixture(:story, tenant: tenant, project: project)",
+        "api_key = fixture(:api_key, tenant: tenant, role: :agent)",
+        "article_1 = fixture(:article, tenant: tenant, status: :published)",
+        "article_2 = fixture(:article, tenant: tenant, status: :published)",
+        "article_3 = fixture(:article, tenant: tenant, status: :published)"
+      ],
+      "steps": [
+        "Call Loopctl.Knowledge.Analytics.record_search_access(tenant.id, [article_1.id, article_2.id, article_3.id], api_key.id, \"csv import\", %{}, %{project_id: project.id, story_id: story.id})",
+        "Flush async tasks",
+        "Query knowledge_access_events"
+      ],
+      "expected_results": [
+        "3 rows exist (one per article)",
+        "All 3 rows have project_id = project.id and story_id = story.id",
+        "All 3 rows have access_type = \"search\""
+      ],
+      "status": "pending"
+    }
+  ],
+  "technical_notes": [
+    "Schema module: Loopctl.Knowledge.AccessEvent (or wherever the existing schema lives — verify in lib/loopctl/knowledge/analytics.ex)",
+    "Context module: Loopctl.Knowledge (lib/loopctl/knowledge.ex)",
+    "Analytics module: Loopctl.Knowledge.Analytics (lib/loopctl/knowledge/analytics.ex) — record_access/5, record_search_access/5, record_context_access/4",
+    "Migration file: priv/repo/migrations/<ts>_add_attribution_to_knowledge_access_events.exs",
+    "Use ENABLE ROW LEVEL SECURITY (not FORCE) — the production role schema_admin owns the table",
+    "Fire-and-forget semantics: the existing do_record_async/4 in Analytics uses Task.Supervisor. Do not change that — keep the validation + insert inside the async task. Validation failures log but never raise.",
+    "Cross-tenant validation: use Loopctl.Projects.get_project(tenant_id, project_id) which already scopes by tenant. A {:error, :not_found} means either the project does not exist or belongs to another tenant — either way, drop the attribution silently.",
+    "Story-to-project derivation: Loopctl.WorkBreakdown.get_story(tenant_id, story_id) returns a %Story{} with project_id preloaded in the base query. If not preloaded, add a select-only query that returns %{id, project_id} to avoid loading ACs/metadata.",
+    "Test async safety: this file uses async: true via DataCase. Use Mox.set_mox_from_context(tags) and ensure the Task.Supervisor flush pattern used elsewhere in loopctl tests (see existing knowledge tests for the pattern).",
+    "No changes to the API surface (controllers) in this story — the opts plumbing stops at the context module. Controller wiring is part of US-25.3 via the MCP tool surface.",
+    "Do NOT expand RLS policy to include project_id. Tenant_id is the boundary; project_id is a reporting dimension.",
+    "Index naming follows the existing convention: <table>_<cols>_idx with DESC on inserted_at for timeline queries."
+  ],
+  "dependencies": [
+    "US-22.1",
+    "US-22.3"
+  ],
+  "estimated_hours": 5
+}

--- a/docs/user_stories/epic_25_knowledge_wiki_attribution/us_25.2.json
+++ b/docs/user_stories/epic_25_knowledge_wiki_attribution/us_25.2.json
@@ -1,0 +1,282 @@
+{
+  "id": "US-25.2",
+  "title": "Wiki Access Analytics — Project & Logical-Agent Slicing",
+  "epic": {
+    "id": "epic_25",
+    "name": "Knowledge Wiki Attribution & Analytics"
+  },
+  "priority": "high",
+  "phase": "observability",
+  "story": {
+    "as_a": "tenant orchestrator or administrator",
+    "i_want_to": "query wiki access analytics rolled up by project or by logical agent (not just by api_key credential), and filter top-articles by project",
+    "so_that": "I can answer 'which projects are getting value from the wiki?', 'which agents are actually reading the docs before coding?', and 'what are the hot articles for HomeCareBilling specifically?' from a single endpoint call"
+  },
+  "rationale": "US-25.1 gives us attribution data in the events table; this story turns that data into answers. Today knowledge_analytics_top only groups by article, and knowledge_agent_usage only accepts an api_keys.id — it cannot aggregate across all keys belonging to a logical agent and cannot filter by project at all. The orchestrator running loopctl across multiple SaaS projects needs to see per-project rollups to decide where to invest in more articles, and needs logical-agent rollups because api_keys rotate while agent identities do not. Without these slices, the wiki analytics surface is effectively single-dimensional and cannot drive investment decisions.",
+  "acceptance_criteria": [
+    {
+      "id": "AC-25.2.1",
+      "description": "GET /api/v1/knowledge/analytics/top-articles accepts an optional project_id query parameter. When present, events are filtered to WHERE project_id = ? before aggregation. When absent, behavior is unchanged (aggregate across all events in the tenant).",
+      "status": "pending"
+    },
+    {
+      "id": "AC-25.2.2",
+      "description": "GET /api/v1/knowledge/analytics/top-articles accepts an optional group_by query parameter with values 'article' (default, current behavior), 'project', or 'agent'. When group_by=project, each row is %{project_id, project_name, access_count, unique_articles, unique_api_keys}. When group_by=agent, each row is %{agent_id, agent_name, agent_type, access_count, unique_articles, api_key_count} where agent_id is the logical agents.id joined via api_keys.agent_id.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-25.2.3",
+      "description": "GET /api/v1/knowledge/analytics/agents/:id accepts the URL path parameter as EITHER an api_keys.id (current behavior) OR an agents.id. The controller first attempts to match api_keys.id; if no rows, it falls back to treating the id as agents.id and JOINs api_keys WHERE agent_id = :id to sum reads across every key belonging to that logical agent. The response envelope includes a new field resolved_as: 'api_key' | 'agent' so callers can tell which branch ran.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-25.2.4",
+      "description": "A new endpoint GET /api/v1/knowledge/analytics/projects/:id/usage (role: orchestrator+) returns a per-project rollup: %{project_id, project_name, total_reads, unique_articles, unique_api_keys, unique_agents, access_by_type, top_articles (limit 20), daily_series (array of %{date, read_count} for the last since_days)}. The since_days query parameter defaults to 7 and caps at 365.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-25.2.5",
+      "description": "All new and extended queries enforce tenant isolation at the SQL level via tenant_id = ? predicates layered on top of existing RLS. No new RLS policies required. Cross-tenant project_id or agent_id in the URL path returns 404 not_found (not 403), consistent with existing loopctl conventions.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-25.2.6",
+      "description": "All new and extended query paths use the existing since_days parameter (minimum 1, maximum 365, default 7 for agent_usage / top_articles, default 30 for any future windowed endpoints). Queries are bounded by inserted_at >= now() - since_days.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-25.2.7",
+      "description": "Queries that group by agent MUST join api_keys with a LEFT JOIN so events whose api_key has since been revoked still contribute to the rollup (group under a sentinel 'revoked' agent_name). Revoked-key events never appear in the 'live' breakdown but are still counted in total_reads.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-25.2.8",
+      "description": "Query performance: the new group-by and filter paths must use the indexes added in US-25.1. A query plan check (EXPLAIN) for the most common call (top-articles with project_id filter) must show Index Scan on knowledge_access_events_project_id_inserted_at_idx, not Seq Scan.",
+      "status": "pending"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "TC-25.2.1",
+      "name": "top-articles with project_id filter returns only that project's reads",
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant)",
+        "project_a = fixture(:project, tenant: tenant)",
+        "project_b = fixture(:project, tenant: tenant)",
+        "api_key = fixture(:api_key, tenant: tenant, role: :orchestrator)",
+        "article_1 = fixture(:article, tenant: tenant, status: :published)",
+        "article_2 = fixture(:article, tenant: tenant, status: :published)",
+        "3 events for article_1 tagged with project_a",
+        "2 events for article_2 tagged with project_b",
+        "1 event for article_1 with project_id = NULL"
+      ],
+      "steps": [
+        "GET /api/v1/knowledge/analytics/top-articles?project_id=<project_a.id>",
+        "Authorization: Bearer <orchestrator key>"
+      ],
+      "expected_results": [
+        "200 response",
+        "data contains only article_1 with access_count = 3",
+        "article_2 is not present",
+        "The NULL-tagged event for article_1 is NOT counted (project filter excludes NULLs)"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-25.2.2",
+      "name": "top-articles group_by=project rolls up per project",
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant)",
+        "project_a = fixture(:project, tenant: tenant, name: \"HomeCareBilling\")",
+        "project_b = fixture(:project, tenant: tenant, name: \"Balic Tracker\")",
+        "api_key = fixture(:api_key, tenant: tenant, role: :orchestrator)",
+        "10 events across 4 articles tagged project_a",
+        "3 events across 2 articles tagged project_b"
+      ],
+      "steps": [
+        "GET /api/v1/knowledge/analytics/top-articles?group_by=project"
+      ],
+      "expected_results": [
+        "200 response",
+        "data contains 2 rows, sorted by access_count DESC",
+        "First row: %{project_id: project_a.id, project_name: \"HomeCareBilling\", access_count: 10, unique_articles: 4, unique_api_keys: 1}",
+        "Second row: %{project_id: project_b.id, project_name: \"Balic Tracker\", access_count: 3, unique_articles: 2, unique_api_keys: 1}"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-25.2.3",
+      "name": "top-articles group_by=agent aggregates across all keys belonging to one logical agent",
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant)",
+        "agent_record = fixture(:agent, tenant: tenant, name: \"orchestrator\", agent_type: \"orchestrator\")",
+        "api_key_1 = fixture(:api_key, tenant: tenant, agent_id: agent_record.id, role: :orchestrator)",
+        "api_key_2 = fixture(:api_key, tenant: tenant, agent_id: agent_record.id, role: :orchestrator)",
+        "api_key_solo = fixture(:api_key, tenant: tenant, role: :agent)",
+        "5 events recorded under api_key_1",
+        "7 events recorded under api_key_2",
+        "2 events recorded under api_key_solo"
+      ],
+      "steps": [
+        "GET /api/v1/knowledge/analytics/top-articles?group_by=agent"
+      ],
+      "expected_results": [
+        "data contains 2 rows (one per logical agent)",
+        "Row for agent_record: %{agent_id: agent_record.id, agent_name: \"orchestrator\", access_count: 12, api_key_count: 2}",
+        "Row for the solo key's agent: access_count: 2, api_key_count: 1"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-25.2.4",
+      "name": "agent_usage resolves api_keys.id when id matches a key",
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant)",
+        "api_key = fixture(:api_key, tenant: tenant, role: :orchestrator)",
+        "3 events recorded under api_key",
+        "orchestrator_api_key = fixture(:api_key, tenant: tenant, role: :orchestrator)"
+      ],
+      "steps": [
+        "GET /api/v1/knowledge/analytics/agents/<api_key.id>",
+        "Authorization: Bearer <orchestrator_api_key>"
+      ],
+      "expected_results": [
+        "200 response",
+        "body.resolved_as == \"api_key\"",
+        "body.total_reads == 3"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-25.2.5",
+      "name": "agent_usage resolves agents.id by joining api_keys when id matches no api_key",
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant)",
+        "agent_record = fixture(:agent, tenant: tenant, name: \"orchestrator\")",
+        "api_key_1 = fixture(:api_key, tenant: tenant, agent_id: agent_record.id, role: :orchestrator)",
+        "api_key_2 = fixture(:api_key, tenant: tenant, agent_id: agent_record.id, role: :orchestrator)",
+        "4 events recorded under api_key_1",
+        "6 events recorded under api_key_2",
+        "caller_key = fixture(:api_key, tenant: tenant, role: :orchestrator)"
+      ],
+      "steps": [
+        "GET /api/v1/knowledge/analytics/agents/<agent_record.id>",
+        "Authorization: Bearer <caller_key>"
+      ],
+      "expected_results": [
+        "200 response",
+        "body.resolved_as == \"agent\"",
+        "body.total_reads == 10",
+        "body.api_key_count == 2"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-25.2.6",
+      "name": "projects/:id/usage returns per-project rollup with daily series",
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant)",
+        "project = fixture(:project, tenant: tenant, name: \"HomeCareBilling\")",
+        "api_key = fixture(:api_key, tenant: tenant, role: :orchestrator)",
+        "15 events tagged with project.id across 10 articles, spread over 3 consecutive days"
+      ],
+      "steps": [
+        "GET /api/v1/knowledge/analytics/projects/<project.id>/usage?since_days=7"
+      ],
+      "expected_results": [
+        "200 response",
+        "body.project_id == project.id",
+        "body.project_name == \"HomeCareBilling\"",
+        "body.total_reads == 15",
+        "body.unique_articles == 10",
+        "body.top_articles is an array (limit 20)",
+        "body.daily_series is an array of 7 entries (one per day in window), zero-filled on quiet days",
+        "The 3 days with events have the correct counts"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-25.2.7",
+      "name": "Tenant isolation: cross-tenant project_id returns 404",
+      "type": "integration",
+      "preconditions": [
+        "tenant_a = fixture(:tenant)",
+        "tenant_b = fixture(:tenant)",
+        "project_b = fixture(:project, tenant: tenant_b)",
+        "api_key_a = fixture(:api_key, tenant: tenant_a, role: :orchestrator)"
+      ],
+      "steps": [
+        "GET /api/v1/knowledge/analytics/projects/<project_b.id>/usage",
+        "Authorization: Bearer <api_key_a>"
+      ],
+      "expected_results": [
+        "404 not_found",
+        "No data leaked from tenant_b"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-25.2.8",
+      "name": "Revoked api_keys are aggregated under a sentinel 'revoked' name but still counted",
+      "type": "unit",
+      "preconditions": [
+        "tenant = fixture(:tenant)",
+        "api_key = fixture(:api_key, tenant: tenant, role: :agent)",
+        "5 events recorded under api_key",
+        "Loopctl.Auth.revoke_api_key(api_key)"
+      ],
+      "steps": [
+        "Call Loopctl.Knowledge.Analytics.top_articles(tenant.id, since_days: 30, group_by: :agent)"
+      ],
+      "expected_results": [
+        "Returns a row with agent_name like \"revoked\" or api_key_id suffix",
+        "access_count for that row == 5"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-25.2.9",
+      "name": "EXPLAIN plan uses the project_id index (not a seq scan)",
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant)",
+        "project = fixture(:project, tenant: tenant)",
+        "10,000 events inserted across 5 projects (2000 per project)",
+        "Analyze run on knowledge_access_events"
+      ],
+      "steps": [
+        "Run EXPLAIN (FORMAT JSON) for: SELECT count(*) FROM knowledge_access_events WHERE tenant_id = ? AND project_id = ? AND inserted_at >= now() - interval '7 days'"
+      ],
+      "expected_results": [
+        "Plan uses Index Scan on knowledge_access_events_project_id_inserted_at_idx",
+        "No Seq Scan node in the plan tree"
+      ],
+      "status": "pending"
+    }
+  ],
+  "technical_notes": [
+    "Context module: Loopctl.Knowledge.Analytics (lib/loopctl/knowledge/analytics.ex) — extend top_articles/2 and get_agent_usage/3, add get_project_usage/3",
+    "Controller: LoopctlWeb.KnowledgeAnalyticsController (lib/loopctl_web/controllers/knowledge_analytics_controller.ex) — existing actions top_articles/2, agent_usage/2; new action project_usage/2",
+    "Router: lib/loopctl_web/router.ex — existing scope mounts at /api/v1/knowledge/analytics. Add get \"/projects/:id/usage\", KnowledgeAnalyticsController, :project_usage under the same role plug.",
+    "Role gate: all new and existing analytics endpoints use LoopctlWeb.Plugs.RequireRole with role: :orchestrator. Do not relax.",
+    "JSON view: LoopctlWeb.KnowledgeAnalyticsJSON — add project_usage/2, extend top_articles/2 to handle the three group_by variants.",
+    "Agent-id-or-api-key-id resolution in agent_usage: first SELECT 1 FROM api_keys WHERE id = ? AND tenant_id = ?. If matched, run the existing query. If not, SELECT 1 FROM agents WHERE id = ? AND tenant_id = ?. If matched, JOIN api_keys WHERE agent_id = ? and aggregate. If neither, 404.",
+    "Left join for revoked keys: in the group_by=agent aggregation, LEFT JOIN api_keys ON events.api_key_id = api_keys.id. Rows where api_keys.id IS NULL (deleted key) or api_keys.revoked_at IS NOT NULL collapse into a synthetic {agent_id: nil, agent_name: \"revoked\", ...} row.",
+    "Daily series: use generate_series(now() - since_days::interval, now(), '1 day'::interval) LEFT JOIN the aggregated events subquery to get zero-filled days. This is Postgres-specific.",
+    "Tenant-first index use: the queries must have tenant_id = ? as the first predicate to hit the composite index. Do not rely on RLS to add it — the query planner needs the literal.",
+    "Guard against unbounded windows: clamp since_days to the range [1, 365] at the controller level before forwarding to Analytics.",
+    "OpenAPI spec: add the new query params and the new endpoint to lib/loopctl/api_spec/schemas.ex and the KnowledgeAnalyticsController operation specs (existing uses OpenApiSpex.ControllerSpecs).",
+    "Test convention: this epic's tests live in test/loopctl/knowledge/analytics_test.exs (unit) and test/loopctl_web/controllers/knowledge_analytics_controller_test.exs (integration). Both use DataCase/ConnCase with async: true, Mox.set_mox_from_context, and fixture/2.",
+    "The analytics MCP surface (mcp__loopctl__knowledge_analytics_top, knowledge_agent_usage, etc.) is updated in US-25.3 — this story ships the HTTP API only. Curl-based verification is acceptable for the ConnCase tests."
+  ],
+  "dependencies": [
+    "US-25.1"
+  ],
+  "estimated_hours": 6
+}

--- a/docs/user_stories/epic_25_knowledge_wiki_attribution/us_25.3.json
+++ b/docs/user_stories/epic_25_knowledge_wiki_attribution/us_25.3.json
@@ -1,0 +1,232 @@
+{
+  "id": "US-25.3",
+  "title": "MCP Tool Context Parameters & agent_id Disambiguation",
+  "epic": {
+    "id": "epic_25",
+    "name": "Knowledge Wiki Attribution & Analytics"
+  },
+  "priority": "high",
+  "phase": "observability",
+  "story": {
+    "as_a": "AI implementation agent working on a loopctl-tracked story",
+    "i_want_to": "pass the project_id and story_id I am working on when calling the knowledge wiki MCP tools, and receive a non-ambiguous parameter name when querying agent usage analytics",
+    "so_that": "my wiki reads are attributed to the correct project and story without the orchestrator having to correlate timestamps, and I do not hit a silent 'zero results' bug because I passed an agents.id when the tool wanted an api_keys.id"
+  },
+  "rationale": "The HTTP API gains attribution in US-25.1 and analytics slices in US-25.2, but the MCP server surface is still what implementation agents actually call. Today mcp__loopctl__knowledge_search, knowledge_get, knowledge_context, and knowledge_index have no way to pass project_id or story_id — they just forward q and filters. And mcp__loopctl__knowledge_agent_usage advertises a parameter named agent_id but actually expects api_keys.id, which caused real confusion while debugging HomeCareBilling wiki usage in April 2026 (we silently got zero results and blamed the agent, when the agent had 31 reads). This story fixes both: it plumbs project_id/story_id through the MCP tool call to the HTTP body, and it reshapes the agent_usage tool to accept either flavor of id with a clear parameter name.",
+  "acceptance_criteria": [
+    {
+      "id": "AC-25.3.1",
+      "description": "mcp__loopctl__knowledge_search gains two optional string parameters: project_id and story_id. When present, they are forwarded as query params on the underlying GET /api/v1/knowledge/search request. The tool description is updated to recommend always passing story_id when the agent is working on a loopctl story.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-25.3.2",
+      "description": "mcp__loopctl__knowledge_get gains the same project_id and story_id optional parameters, forwarded to GET /api/v1/articles/:id as query params.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-25.3.3",
+      "description": "mcp__loopctl__knowledge_context gains the same two optional parameters, forwarded to the underlying context endpoint. When the MCP caller has already specified a story_id at the top level of the call (some context tools accept it for other reasons), the top-level value takes precedence and no error is raised.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-25.3.4",
+      "description": "mcp__loopctl__knowledge_index gains the same two optional parameters, forwarded as query params.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-25.3.5",
+      "description": "mcp__loopctl__knowledge_agent_usage replaces its single agent_id parameter with a disambiguated signature. The new tool accepts exactly one of: api_key_id (string, uuid, the api_keys.id credential) OR agent_id (string, uuid, the agents.id logical identity). Passing both returns a validation error before hitting the HTTP API. Passing neither returns a validation error. The tool description explicitly explains the difference and links to the chain-of-custody doc.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-25.3.6",
+      "description": "Backward compatibility shim: for one release cycle, the old signature {agent_id: <uuid>} continues to work by routing to the server's dual-resolution endpoint (US-25.2 AC-25.2.3). The tool emits a deprecation warning in the tool response's metadata field when only the ambiguous old-shape argument is used, pointing users at api_key_id / agent_id.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-25.3.7",
+      "description": "The MCP server's README (mcp-server/README.md) gains a 'Wiki Attribution' section explaining: (a) pass project_id and story_id on every wiki read so analytics can attribute your work; (b) the difference between api_key_id and agent_id in knowledge_agent_usage; (c) the old agent_id behavior is deprecated.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-25.3.8",
+      "description": "Example usage snippets in mcp-server/README.md show a typical implementation agent workflow: get_story -> knowledge_search with story_id passed -> knowledge_get with story_id passed. The snippets use realistic UUIDs and make clear that story_id is optional but strongly recommended.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-25.3.9",
+      "description": "The tool description text for all four read tools (search, get, context, index) includes the same one-line nudge: 'Pass story_id when working on a loopctl story so reads attribute correctly.' This text is the primary mechanism by which agents learn to pass the parameter, so it must be concise and appear in the default tool listing Claude Code shows.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-25.3.10",
+      "description": "No schema or HTTP API changes in this story — all server-side work is done in US-25.1 and US-25.2. This is a pure mcp-server package update, shippable as a patch release of loopctl-mcp-server on npm.",
+      "status": "pending"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "TC-25.3.1",
+      "name": "knowledge_search forwards project_id and story_id to the HTTP call",
+      "type": "unit",
+      "preconditions": [
+        "Nock or a mock HTTP transport intercepting loopctl API calls",
+        "LOOPCTL_SERVER = http://localhost:4000",
+        "LOOPCTL_AGENT_KEY = lc_test_key"
+      ],
+      "steps": [
+        "Invoke the MCP tool handler for knowledge_search with args: {q: 'csv import', project_id: 'b50c9e38-aebe-4bbe-b8e6-bf2cb2b8afd0', story_id: '89aa0c48-5cf5-4925-b164-21684ef79c4d'}",
+        "Capture the outbound HTTP request"
+      ],
+      "expected_results": [
+        "Request URL contains project_id=b50c9e38-... and story_id=89aa0c48-... as query params",
+        "Authorization header set from LOOPCTL_AGENT_KEY",
+        "Request method is GET"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-25.3.2",
+      "name": "knowledge_search omits project_id/story_id when not passed",
+      "type": "unit",
+      "preconditions": [
+        "Mock HTTP transport"
+      ],
+      "steps": [
+        "Invoke knowledge_search with args: {q: 'csv import'}",
+        "Capture outbound request"
+      ],
+      "expected_results": [
+        "Request URL has no project_id or story_id query params",
+        "Request succeeds (backward compatible)"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-25.3.3",
+      "name": "knowledge_agent_usage with api_key_id routes to credential query",
+      "type": "unit",
+      "preconditions": [
+        "Mock HTTP transport"
+      ],
+      "steps": [
+        "Invoke knowledge_agent_usage with args: {api_key_id: 'b977c90c-061b-4e42-8afa-26a5efde51ad', since_days: 7}",
+        "Capture outbound request"
+      ],
+      "expected_results": [
+        "Request URL is /api/v1/knowledge/analytics/agents/b977c90c-061b-4e42-8afa-26a5efde51ad",
+        "Query contains since_days=7",
+        "No deprecation warning in the tool response metadata"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-25.3.4",
+      "name": "knowledge_agent_usage with agent_id routes to logical-agent query",
+      "type": "unit",
+      "preconditions": [
+        "Mock HTTP transport"
+      ],
+      "steps": [
+        "Invoke knowledge_agent_usage with args: {agent_id: '09429bc4-328f-42f4-acec-db48b40849b2', since_days: 7}",
+        "Capture outbound request"
+      ],
+      "expected_results": [
+        "Request URL is /api/v1/knowledge/analytics/agents/09429bc4-328f-42f4-acec-db48b40849b2",
+        "Server-side dual-resolution (US-25.2) will figure out this is an agents.id",
+        "No deprecation warning in the tool response metadata"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-25.3.5",
+      "name": "knowledge_agent_usage errors when both api_key_id and agent_id are passed",
+      "type": "unit",
+      "preconditions": [
+        "None"
+      ],
+      "steps": [
+        "Invoke knowledge_agent_usage with args: {api_key_id: '<uuid>', agent_id: '<uuid>'}"
+      ],
+      "expected_results": [
+        "Tool returns a validation error before any HTTP request",
+        "Error message mentions 'pass exactly one of api_key_id or agent_id'",
+        "No outbound HTTP traffic"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-25.3.6",
+      "name": "knowledge_agent_usage errors when neither api_key_id nor agent_id is passed",
+      "type": "unit",
+      "preconditions": [
+        "None"
+      ],
+      "steps": [
+        "Invoke knowledge_agent_usage with args: {since_days: 7}"
+      ],
+      "expected_results": [
+        "Tool returns a validation error",
+        "Error message mentions the required parameters",
+        "No outbound HTTP traffic"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-25.3.7",
+      "name": "Deprecation warning for legacy single-parameter shape",
+      "type": "unit",
+      "preconditions": [
+        "Mock HTTP transport",
+        "Mock response body with valid agent_usage payload"
+      ],
+      "steps": [
+        "Invoke knowledge_agent_usage using the LEGACY shape accepted by the old tool: the server-side tool accepts {agent_id: <uuid>} but the new validator treats this as ambiguous. For one release, this still routes to the dual-resolution endpoint but surfaces a deprecation warning.",
+        "Inspect the tool response metadata"
+      ],
+      "expected_results": [
+        "The HTTP call still succeeds",
+        "The tool response metadata contains a deprecation_warning field",
+        "Warning text points at api_key_id vs agent_id split"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-25.3.8",
+      "name": "README includes Wiki Attribution section with usage snippets",
+      "type": "unit",
+      "preconditions": [
+        "mcp-server/README.md exists"
+      ],
+      "steps": [
+        "Read mcp-server/README.md"
+      ],
+      "expected_results": [
+        "File contains a heading 'Wiki Attribution'",
+        "Section explains project_id / story_id context params",
+        "Section explains api_key_id vs agent_id disambiguation",
+        "File contains a JSON example for knowledge_search with story_id"
+      ],
+      "status": "pending"
+    }
+  ],
+  "technical_notes": [
+    "MCP server source: mcp-server/index.js (published as loopctl-mcp-server on npm)",
+    "Tool definitions live in the ListToolsResponse of mcp-server/index.js. Search for 'knowledge_search', 'knowledge_get', 'knowledge_context', 'knowledge_index', 'knowledge_agent_usage' to find their current shapes.",
+    "HTTP client layer in mcp-server uses fetch — project_id and story_id become URLSearchParams entries when present. Use a helper like appendIfDefined(params, 'project_id', args.project_id) to keep the code clean.",
+    "The MCP protocol returns validation errors by throwing an InputValidationError-shaped object or returning { isError: true, content: [...] }. Follow the existing pattern in mcp-server for how other tools signal validation failures.",
+    "Deprecation warning delivery: MCP tool responses have a content array and a metadata object. Put the deprecation note in metadata so it does not pollute the tool output Claude Code renders to the user. Example: { metadata: { deprecation_warning: 'knowledge_agent_usage: agent_id is deprecated, use api_key_id or the new logical agent_id semantics' } }.",
+    "Bump loopctl-mcp-server to a new minor version in mcp-server/package.json. Add a changelog entry under mcp-server/CHANGELOG.md (or the equivalent file) documenting the new params and the deprecation.",
+    "The tool description text is what Claude Code surfaces when the tool is first introduced via ToolSearch. Keep it under 300 characters so it does not get truncated in the listing.",
+    "Cross-reference US-25.1 AC-25.1.7 (cross-tenant attribution dropped silently) — the MCP tool should NOT validate tenant ownership of project_id/story_id client-side. The server handles that. The tool just forwards whatever the agent passes.",
+    "No code changes to lib/loopctl_web or lib/loopctl are required by this story — all server-side plumbing is already in US-25.1 and US-25.2. This is a pure mcp-server update.",
+    "Testing convention for mcp-server: the test file lives at mcp-server/test/knowledge_tools.test.js (or .ts depending on repo convention). Use vitest or node:test per the existing mcp-server test setup. Mock the fetch transport; do not hit a live loopctl instance in unit tests.",
+    "The .mcp.json example file (added in PR #84) does not need to change — this story is about what agents pass as tool arguments, not about what env vars they set."
+  ],
+  "dependencies": [
+    "US-25.1",
+    "US-25.2"
+  ],
+  "estimated_hours": 4
+}


### PR DESCRIPTION
## Summary

Adds 3 user stories for Epic 25 (Knowledge Wiki Attribution & Analytics) — a vertical slice that lets loopctl analytics slice wiki usage by project and by logical agent.

### Why

While debugging HomeCareBilling wiki attribution on 2026-04-11, we discovered:

1. The implementing agent had 31 real wiki reads across 29 articles in the session, but \`knowledge_access_events\` only carries \`api_key_id\` — no project or story context. Cannot answer "which projects use the wiki?" without fragile audit log correlation.
2. The MCP tool \`knowledge_agent_usage\` has a parameter named \`agent_id\` that actually requires \`api_keys.id\`, not \`agents.id\`. A caller passing a story's \`assigned_agent_id\` gets a silent "zero reads" result and wrongly concludes the agent is not using the wiki.

This epic fixes both without changing the auth model.

### Stories

| Story | Title | Hours | ACs | TCs |
|---|---|---:|---:|---:|
| US-25.1 | Wiki Access Event Attribution — Schema & Ingestion | 5 | 10 | 7 |
| US-25.2 | Wiki Access Analytics — Project & Logical-Agent Slicing | 6 | 8 | 9 |
| US-25.3 | MCP Tool Context Parameters & agent_id Disambiguation | 4 | 10 | 8 |

**Total:** 15 hours, 28 acceptance criteria, 24 test cases.

### Design guardrails baked into the stories

- **No auth model changes.** Tenant_id stays the sole RLS boundary; keys stay one-per-role-per-tenant.
- **Attribution is additive.** Nullable columns, backward-compatible context plumbing, cross-tenant project_id/story_id is silently dropped (read still succeeds).
- **story_id → project_id derivation** so orchestrators only have to pass one.
- **Dual-resolution endpoint** — \`knowledge_agent_usage\` accepts either flavor of id and returns \`resolved_as\` so callers can tell which branch ran.
- **Deprecation window** for the legacy MCP tool shape (one release cycle).
- **Revoked-key events** still contribute to rollups under a synthetic \`\"revoked\"\` row (LEFT JOIN), so analytics don't silently lose history when keys rotate.

## Test plan

- [ ] Valid JSON for all three story files
- [ ] Each story has rationale, acceptance_criteria, test_cases, technical_notes, dependencies, estimated_hours
- [ ] Docs-only change — CI should be a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)