### PR TITLE
US-25.3: MCP Tool Context Parameters & agent_id Disambiguation

### DIFF
--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to `loopctl-mcp-server` are documented here.
+
+Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+
+## 1.2.0 — 2026-04-11
+
+### Added
+
+- `knowledge_search`, `knowledge_get`, `knowledge_context`, `knowledge_index` now accept optional `story_id` (UUID) parameter. When present, forwarded as a query param so the server can attribute the wiki read to the active story. (US-25.3, AC-25.3.1–25.3.4)
+- `knowledge_get` also gains optional `project_id` parameter (the other three already had it).
+- `knowledge_agent_usage` now accepts `api_key_id` (the `api_keys.id` credential) OR `agent_id` (the `agents.id` logical identity). Passing both is a validation error. Passing neither is a validation error. The tool description explains the difference. (US-25.3, AC-25.3.5)
+- When `agent_id` alone is passed to `knowledge_agent_usage`, the response includes `_meta.deprecation_hint` nudging callers toward explicit `api_key_id` for credential lookups. (US-25.3, AC-25.3.6)
+- README: new "Wiki Attribution" section explains context params, api_key_id vs agent_id disambiguation, and the deprecation path. Includes example workflow snippets. (US-25.3, AC-25.3.7–25.3.8)
+- Test suite bootstrapped at `test/knowledge_tools.test.js` using Node.js built-in `node:test`. Run with `npm test`.
+
+### Changed
+
+- All four wiki read tool descriptions shortened and updated with the one-line nudge: "Pass story_id when working on a loopctl story so reads attribute correctly." (AC-25.3.9)
+- `knowledge_agent_usage` description rewritten to explain the new `api_key_id`/`agent_id` split.
+- `package.json`: added `"test": "node --test test/"` script.
+- Server version string updated to `1.2.0`.
+
+### Deprecated
+
+- `knowledge_agent_usage` with a single `agent_id` parameter (old behavior: `agent_id` meant `api_keys.id` credential). Now `agent_id` refers to the logical `agents.id`. Use `api_key_id` for the credential. A `_meta.deprecation_hint` is included in the response when `agent_id` alone is used. Will be cleaned up in a future release.
+
+## 1.1.2 — prior release
+
+Initial public release. See git history for details.

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -2,7 +2,7 @@
 
 MCP (Model Context Protocol) server for [loopctl](https://loopctl.com) -- structural trust for AI development loops.
 
-Wraps the loopctl REST API into 41 typed MCP tools so AI coding agents (Claude Code, etc.) can interact with loopctl without writing curl commands.
+Wraps the loopctl REST API into 42 typed MCP tools so AI coding agents (Claude Code, etc.) can interact with loopctl without writing curl commands.
 
 ## Installation
 
@@ -66,7 +66,7 @@ Or if installed locally:
 
 Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_KEY`.
 
-## Tools (41)
+## Tools (42)
 
 ### Project Tools
 
@@ -75,6 +75,7 @@ Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_K
 | `get_tenant` | Get current tenant info. Use to verify connectivity. |
 | `list_projects` | List all projects in the current tenant. |
 | `create_project` | Create a new project in the current tenant. |
+| `delete_project` | **Requires `LOOPCTL_USER_KEY`.** Delete a project and all of its dependent resources (epics, stories, audit entries). Irreversible — orchestrator role is not sufficient. |
 | `get_progress` | Get progress summary for a project, including story counts by status. Pass `include_cost=true` for cost data. |
 | `import_stories` | Import stories into a project from a structured payload (Epic 12 import format). |
 
@@ -217,8 +218,8 @@ The `knowledge_agent_usage` tool accepts **exactly one** of two identifier param
 
 | Parameter | Meaning | When to use |
 |---|---|---|
-| `api_key_id` | The `api_keys.id` credential UUID — the raw API key identity | You have the credential ID from `list_api_keys` or a loopctl admin page |
-| `agent_id` | The `agents.id` logical identity UUID — the agent registry entry | You have the agent registry ID from `list_agents` or a story's `assigned_agent_id` |
+| `api_key_id` | The `api_keys.id` credential UUID — the raw API key identity | You have the credential ID from `GET /api/v1/api_keys` or a loopctl admin page |
+| `agent_id` | The `agents.id` logical identity UUID — the agent registry entry | You have the agent registry ID from `GET /api/v1/agents` or a story's `assigned_agent_id` |
 
 The server's analytics endpoint performs dual-resolution: it tries both interpretations automatically. However, using the explicit parameter makes your intent clear and avoids ambiguity in the response's `resolved_as` field.
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -130,10 +130,10 @@ Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_K
 
 | Tool | Description |
 |---|---|
-| `knowledge_index` | Load the knowledge wiki catalog at session start. Returns lightweight article metadata grouped by category. |
-| `knowledge_search` | Search the knowledge wiki by topic. Supports keyword, semantic, or combined search modes. Returns snippets. |
-| `knowledge_get` | Get full article content by ID. Use after search to read an article in detail. |
-| `knowledge_context` | Get relevance-and-recency-ranked full articles for a task query. Best knowledge for your current context. |
+| `knowledge_index` | Load the knowledge wiki catalog at session start. Returns lightweight article metadata grouped by category. Optional: `project_id`, `story_id`. |
+| `knowledge_search` | Search the knowledge wiki by topic. Supports keyword, semantic, or combined search modes. Returns snippets. Optional: `project_id`, `story_id` for attribution. |
+| `knowledge_get` | Get full article content by ID. Use after search to read an article in detail. Optional: `project_id`, `story_id` for attribution. |
+| `knowledge_context` | Get relevance-and-recency-ranked full articles for a task query. Best knowledge for your current context. Optional: `project_id`, `story_id` for attribution. |
 | `knowledge_create` | Create a new knowledge article. File findings, document patterns, or record decisions. |
 
 ### Knowledge Management Tools (orchestrator key)
@@ -155,7 +155,7 @@ Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_K
 |---|---|
 | `knowledge_analytics_top` | Top accessed knowledge articles for the tenant. Optional: `limit` (default 20, max 100), `since_days` (default 7), `access_type` (`search`, `get`, `context`, `index`). |
 | `knowledge_article_stats` | Per-article usage stats: total accesses, unique agents, by-type breakdown, recent events. Required: `article_id`. |
-| `knowledge_agent_usage` | Per-agent (api_key) knowledge usage: total reads, unique articles, top read articles. Required: `agent_id`. Optional: `limit`, `since_days`. |
+| `knowledge_agent_usage` | Per-agent knowledge usage: total reads, unique articles, top read articles. Required: exactly one of `api_key_id` (credential) or `agent_id` (logical identity). Optional: `limit`, `since_days`. See Wiki Attribution section. |
 | `knowledge_unused_articles` | Published articles with zero accesses in the window. Optional: `days_unused` (default 30), `limit` (default 50, max 200). |
 
 ### Discovery Tools
@@ -163,6 +163,95 @@ Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_K
 | Tool | Description |
 |---|---|
 | `list_routes` | List all available API routes on the loopctl server. |
+
+## Wiki Attribution
+
+### Passing context parameters on wiki reads
+
+Four wiki read tools (`knowledge_search`, `knowledge_get`, `knowledge_context`, `knowledge_index`) accept two optional attribution parameters:
+
+| Parameter | Description |
+|---|---|
+| `project_id` | UUID of the loopctl project the agent is working on |
+| `story_id` | UUID of the loopctl story the agent is currently implementing |
+
+Passing these parameters lets loopctl record which project and story triggered each wiki read. The analytics endpoints (`knowledge_analytics_top`, `knowledge_agent_usage`, etc.) can then slice usage by project, showing which knowledge articles are most valuable per project.
+
+The server silently drops attribution params that belong to a different tenant or are malformed UUIDs — you will not receive an error for invalid values.
+
+**Always pass `story_id` when you are working on a loopctl story.** This is the primary mechanism by which wiki reads are attributed to development work.
+
+#### Example: typical implementation agent workflow
+
+```json
+// Step 1: get_story to retrieve current story context
+{
+  "tool": "get_story",
+  "arguments": { "story_id": "89aa0c48-5cf5-4925-b164-21684ef79c4d" }
+}
+
+// Step 2: knowledge_search — pass story_id so the read is attributed
+{
+  "tool": "knowledge_search",
+  "arguments": {
+    "q": "csv import bulk validation",
+    "project_id": "b50c9e38-aebe-4bbe-b8e6-bf2cb2b8afd0",
+    "story_id": "89aa0c48-5cf5-4925-b164-21684ef79c4d"
+  }
+}
+
+// Step 3: knowledge_get — pass story_id again for the full article read
+{
+  "tool": "knowledge_get",
+  "arguments": {
+    "article_id": "c3d2e1f0-1234-5678-abcd-ef0123456789",
+    "project_id": "b50c9e38-aebe-4bbe-b8e6-bf2cb2b8afd0",
+    "story_id": "89aa0c48-5cf5-4925-b164-21684ef79c4d"
+  }
+}
+```
+
+### `knowledge_agent_usage`: api_key_id vs agent_id
+
+The `knowledge_agent_usage` tool accepts **exactly one** of two identifier parameters:
+
+| Parameter | Meaning | When to use |
+|---|---|---|
+| `api_key_id` | The `api_keys.id` credential UUID — the raw API key identity | You have the credential ID from `list_api_keys` or a loopctl admin page |
+| `agent_id` | The `agents.id` logical identity UUID — the agent registry entry | You have the agent registry ID from `list_agents` or a story's `assigned_agent_id` |
+
+The server's analytics endpoint performs dual-resolution: it tries both interpretations automatically. However, using the explicit parameter makes your intent clear and avoids ambiguity in the response's `resolved_as` field.
+
+Passing both parameters returns a validation error. Passing neither also returns a validation error.
+
+```json
+// Query by credential (api_key_id)
+{
+  "tool": "knowledge_agent_usage",
+  "arguments": {
+    "api_key_id": "b977c90c-061b-4e42-8afa-26a5efde51ad",
+    "since_days": 7
+  }
+}
+
+// Query by logical agent identity (agent_id)
+{
+  "tool": "knowledge_agent_usage",
+  "arguments": {
+    "agent_id": "09429bc4-328f-42f4-acec-db48b40849b2",
+    "since_days": 30
+  }
+}
+```
+
+#### Deprecated: old `agent_id` behavior
+
+In versions before 1.2.0, `knowledge_agent_usage` accepted a single `agent_id` parameter that actually meant the `api_keys.id` credential (not the logical agent). This was confusing and caused silent zero-result responses when callers passed a logical `agents.id` value.
+
+Starting with 1.2.0:
+- `agent_id` means the **logical** `agents.id` (the agent registry entry).
+- `api_key_id` means the **credential** `api_keys.id` (the raw API key).
+- The old behavior (passing `agent_id` meaning credential) is Deprecated and will be removed in a future release. When you call with `agent_id` alone, the response includes a `_meta.deprecation_hint` nudging you toward explicit parameters.
 
 ## Chain-of-Custody Enforcement
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -184,14 +184,18 @@ The server silently drops attribution params that belong to a different tenant o
 
 #### Example: typical implementation agent workflow
 
+Step 1 — fetch the story to pick up its UUID and context:
+
 ```json
-// Step 1: get_story to retrieve current story context
 {
   "tool": "get_story",
   "arguments": { "story_id": "89aa0c48-5cf5-4925-b164-21684ef79c4d" }
 }
+```
 
-// Step 2: knowledge_search — pass story_id so the read is attributed
+Step 2 — call `knowledge_search`, passing `story_id` so the read is attributed:
+
+```json
 {
   "tool": "knowledge_search",
   "arguments": {
@@ -200,8 +204,11 @@ The server silently drops attribution params that belong to a different tenant o
     "story_id": "89aa0c48-5cf5-4925-b164-21684ef79c4d"
   }
 }
+```
 
-// Step 3: knowledge_get — pass story_id again for the full article read
+Step 3 — call `knowledge_get`, reusing the same `story_id`:
+
+```json
 {
   "tool": "knowledge_get",
   "arguments": {

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -416,17 +416,22 @@ async function setTokenBudget({ scope_type, scope_id, budget_millicents, alert_t
 
 // --- Knowledge Wiki Tools (agent key) ---
 
-async function knowledgeIndex({ project_id }) {
-  const path = project_id
+async function knowledgeIndex({ project_id, story_id }) {
+  const basePath = project_id
     ? `/api/v1/projects/${project_id}/knowledge/index`
     : "/api/v1/knowledge/index";
+  const params = new URLSearchParams();
+  if (story_id) params.set("story_id", story_id);
+  const qs = params.toString();
+  const path = qs ? `${basePath}?${qs}` : basePath;
   const result = await apiCall("GET", path, null, process.env.LOOPCTL_AGENT_KEY);
   return toContent(result);
 }
 
-async function knowledgeSearch({ q, project_id, category, tags, mode, limit }) {
+async function knowledgeSearch({ q, project_id, story_id, category, tags, mode, limit }) {
   const params = new URLSearchParams({ q });
   if (project_id) params.set("project_id", project_id);
+  if (story_id) params.set("story_id", story_id);
   if (category) params.set("category", category);
   if (tags) params.set("tags", tags);
   if (mode) params.set("mode", mode);
@@ -436,14 +441,20 @@ async function knowledgeSearch({ q, project_id, category, tags, mode, limit }) {
   return toContent(result);
 }
 
-async function knowledgeGet({ article_id }) {
-  const result = await apiCall("GET", `/api/v1/articles/${article_id}`, null, process.env.LOOPCTL_AGENT_KEY);
+async function knowledgeGet({ article_id, project_id, story_id }) {
+  const params = new URLSearchParams();
+  if (project_id) params.set("project_id", project_id);
+  if (story_id) params.set("story_id", story_id);
+  const qs = params.toString();
+  const path = qs ? `/api/v1/articles/${article_id}?${qs}` : `/api/v1/articles/${article_id}`;
+  const result = await apiCall("GET", path, null, process.env.LOOPCTL_AGENT_KEY);
   return toContent(result);
 }
 
-async function knowledgeContext({ query, project_id, limit, recency_weight }) {
+async function knowledgeContext({ query, project_id, story_id, limit, recency_weight }) {
   const params = new URLSearchParams({ query });
   if (project_id) params.set("project_id", project_id);
+  if (story_id) params.set("story_id", story_id);
   if (limit != null) params.set("limit", String(limit));
   if (recency_weight != null) params.set("recency_weight", String(recency_weight));
 
@@ -564,15 +575,44 @@ async function knowledgeArticleStats({ article_id }) {
   return toContent(result);
 }
 
-async function knowledgeAgentUsage({ agent_id, limit, since_days } = {}) {
+async function knowledgeAgentUsage({ api_key_id, agent_id, limit, since_days } = {}) {
+  // Validate: exactly one of api_key_id or agent_id must be provided.
+  if (api_key_id != null && agent_id != null) {
+    return {
+      content: [{ type: "text", text: "Error: pass exactly one of api_key_id or agent_id, not both. Use api_key_id for the api_keys.id credential; use agent_id for the agents.id logical identity." }],
+      isError: true,
+    };
+  }
+  if (api_key_id == null && agent_id == null) {
+    return {
+      content: [{ type: "text", text: "Error: pass exactly one of api_key_id or agent_id. Use api_key_id for the api_keys.id credential; use agent_id for the agents.id logical identity." }],
+      isError: true,
+    };
+  }
+
+  const resolvedId = api_key_id ?? agent_id;
   const params = new URLSearchParams();
   if (limit != null) params.set("limit", String(limit));
   if (since_days != null) params.set("since_days", String(since_days));
   const qs = params.toString();
   const path = qs
-    ? `/api/v1/knowledge/analytics/agents/${agent_id}?${qs}`
-    : `/api/v1/knowledge/analytics/agents/${agent_id}`;
+    ? `/api/v1/knowledge/analytics/agents/${resolvedId}?${qs}`
+    : `/api/v1/knowledge/analytics/agents/${resolvedId}`;
   const result = await apiCall("GET", path, null, process.env.LOOPCTL_ORCH_KEY);
+
+  // When agent_id alone is passed (new semantic: logical agents.id), emit a
+  // one-release-cycle nudge so callers can be explicit about their intent.
+  if (agent_id != null && api_key_id == null) {
+    const base = toContent(result);
+    return {
+      ...base,
+      _meta: {
+        deprecation_hint:
+          "knowledge_agent_usage: if you meant the api_keys.id credential, pass it as api_key_id explicitly. The agent_id parameter now refers to the logical agents.id only.",
+      },
+    };
+  }
+
   return toContent(result);
 }
 
@@ -1177,14 +1217,20 @@ const TOOLS = [
   {
     name: "knowledge_index",
     description:
-      "Load the knowledge wiki catalog at session start. Returns lightweight article metadata " +
-      "(titles, categories, tags) grouped by category. Use this to discover available knowledge before searching.",
+      "Load the knowledge wiki catalog at session start. Returns article metadata grouped by category. " +
+      "Pass story_id when working on a loopctl story so reads attribute correctly.",
     inputSchema: {
       type: "object",
       properties: {
         project_id: {
           type: "string",
+          format: "uuid",
           description: "Optional: scope the index to a specific project UUID.",
+        },
+        story_id: {
+          type: "string",
+          format: "uuid",
+          description: "Optional: loopctl story UUID for attribution tracking.",
         },
       },
       required: [],
@@ -1193,8 +1239,8 @@ const TOOLS = [
   {
     name: "knowledge_search",
     description:
-      "Search the knowledge wiki by topic. Supports keyword, semantic, or combined search modes. " +
-      "Returns snippets, not full bodies. Use after index to find specific articles.",
+      "Search the knowledge wiki by topic. Returns snippets. " +
+      "Pass story_id when working on a loopctl story so reads attribute correctly.",
     inputSchema: {
       type: "object",
       properties: {
@@ -1204,7 +1250,13 @@ const TOOLS = [
         },
         project_id: {
           type: "string",
+          format: "uuid",
           description: "Optional: scope search to a specific project UUID.",
+        },
+        story_id: {
+          type: "string",
+          format: "uuid",
+          description: "Optional: loopctl story UUID for attribution tracking.",
         },
         category: {
           type: "string",
@@ -1230,13 +1282,25 @@ const TOOLS = [
   {
     name: "knowledge_get",
     description:
-      "Get full article content by ID. Use after search to read an article in detail.",
+      "Get full article content by ID. Use after search to read an article in detail. " +
+      "Pass story_id when working on a loopctl story so reads attribute correctly.",
     inputSchema: {
       type: "object",
       properties: {
         article_id: {
           type: "string",
+          format: "uuid",
           description: "The UUID of the article.",
+        },
+        project_id: {
+          type: "string",
+          format: "uuid",
+          description: "Optional: project UUID for attribution tracking.",
+        },
+        story_id: {
+          type: "string",
+          format: "uuid",
+          description: "Optional: loopctl story UUID for attribution tracking.",
         },
       },
       required: ["article_id"],
@@ -1245,8 +1309,8 @@ const TOOLS = [
   {
     name: "knowledge_context",
     description:
-      "Get relevance-and-recency-ranked full articles for a task query. Returns the best knowledge " +
-      "for your current context with linked references. Use when starting a task that needs domain knowledge.",
+      "Get ranked full articles for a task query. Returns best knowledge with linked references. " +
+      "Pass story_id when working on a loopctl story so reads attribute correctly.",
     inputSchema: {
       type: "object",
       properties: {
@@ -1256,7 +1320,13 @@ const TOOLS = [
         },
         project_id: {
           type: "string",
+          format: "uuid",
           description: "Optional: scope context to a specific project UUID.",
+        },
+        story_id: {
+          type: "string",
+          format: "uuid",
+          description: "Optional: loopctl story UUID for attribution tracking.",
         },
         limit: {
           type: "integer",
@@ -1566,15 +1636,21 @@ const TOOLS = [
   {
     name: "knowledge_agent_usage",
     description:
-      "Return knowledge usage for a specific agent (api_key): total reads, " +
-      "unique articles, access type breakdown, and top read articles. " +
+      "Return knowledge usage for an agent: total reads, unique articles, top read articles. " +
+      "Pass api_key_id (api_keys.id credential) OR agent_id (agents.id logical identity) — not both. " +
       "Requires orchestrator role.",
     inputSchema: {
       type: "object",
       properties: {
+        api_key_id: {
+          type: "string",
+          format: "uuid",
+          description: "The api_keys.id credential UUID. Use this when you have the raw API key ID.",
+        },
         agent_id: {
           type: "string",
-          description: "API key UUID identifying the agent identity.",
+          format: "uuid",
+          description: "The agents.id logical identity UUID. Use this when you have the agent registry ID.",
         },
         limit: {
           type: "integer",
@@ -1589,7 +1665,7 @@ const TOOLS = [
           maximum: 365,
         },
       },
-      required: ["agent_id"],
+      required: [],
     },
   },
   {
@@ -1636,7 +1712,7 @@ const TOOLS = [
 const server = new Server(
   {
     name: "loopctl",
-    version: "1.1.2",
+    version: "1.2.0",
   },
   {
     capabilities: { tools: {} },

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -576,21 +576,29 @@ async function knowledgeArticleStats({ article_id }) {
 }
 
 async function knowledgeAgentUsage({ api_key_id, agent_id, limit, since_days } = {}) {
+  // Normalize: treat empty strings / whitespace-only strings as missing so the
+  // validation below catches them. Otherwise an empty string would slip past
+  // the `!= null` checks and produce a malformed URL like /agents/.
+  const normalizedApiKeyId =
+    typeof api_key_id === "string" && api_key_id.trim() === "" ? null : api_key_id;
+  const normalizedAgentId =
+    typeof agent_id === "string" && agent_id.trim() === "" ? null : agent_id;
+
   // Validate: exactly one of api_key_id or agent_id must be provided.
-  if (api_key_id != null && agent_id != null) {
+  if (normalizedApiKeyId != null && normalizedAgentId != null) {
     return {
       content: [{ type: "text", text: "Error: pass exactly one of api_key_id or agent_id, not both. Use api_key_id for the api_keys.id credential; use agent_id for the agents.id logical identity." }],
       isError: true,
     };
   }
-  if (api_key_id == null && agent_id == null) {
+  if (normalizedApiKeyId == null && normalizedAgentId == null) {
     return {
       content: [{ type: "text", text: "Error: pass exactly one of api_key_id or agent_id. Use api_key_id for the api_keys.id credential; use agent_id for the agents.id logical identity." }],
       isError: true,
     };
   }
 
-  const resolvedId = api_key_id ?? agent_id;
+  const resolvedId = normalizedApiKeyId ?? normalizedAgentId;
   const params = new URLSearchParams();
   if (limit != null) params.set("limit", String(limit));
   if (since_days != null) params.set("since_days", String(since_days));
@@ -602,7 +610,7 @@ async function knowledgeAgentUsage({ api_key_id, agent_id, limit, since_days } =
 
   // When agent_id alone is passed (new semantic: logical agents.id), emit a
   // one-release-cycle nudge so callers can be explicit about their intent.
-  if (agent_id != null && api_key_id == null) {
+  if (normalizedAgentId != null && normalizedApiKeyId == null) {
     const base = toContent(result);
     return {
       ...base,

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -575,6 +575,10 @@ async function knowledgeArticleStats({ article_id }) {
   return toContent(result);
 }
 
+// Canonical 8-4-4-4-12 UUID shape. Used to reject path-injection attempts
+// in tools that interpolate user-supplied IDs into URL path segments.
+const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
 async function knowledgeAgentUsage({ api_key_id, agent_id, limit, since_days } = {}) {
   // Normalize: treat empty strings / whitespace-only strings as missing so the
   // validation below catches them. Otherwise an empty string would slip past
@@ -599,6 +603,20 @@ async function knowledgeAgentUsage({ api_key_id, agent_id, limit, since_days } =
   }
 
   const resolvedId = normalizedApiKeyId ?? normalizedAgentId;
+
+  // Defense-in-depth: the MCP SDK declares `format: "uuid"` on these schemas
+  // but does not enforce it for tool arguments. Because `resolvedId` is
+  // interpolated directly into a URL path segment, a value containing `/`
+  // or `..` would let `fetch()` normalize the request to a different
+  // endpoint. Reject anything that isn't a canonical UUID before we touch
+  // the network.
+  if (typeof resolvedId !== "string" || !UUID_RE.test(resolvedId)) {
+    const which = normalizedApiKeyId != null ? "api_key_id" : "agent_id";
+    return {
+      content: [{ type: "text", text: `Error: ${which} must be a canonical UUID (8-4-4-4-12 hex).` }],
+      isError: true,
+    };
+  }
   const params = new URLSearchParams();
   if (limit != null) params.set("limit", String(limit));
   if (since_days != null) params.set("since_days", String(since_days));

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "MCP server for loopctl — structural trust for AI development loops",
   "type": "module",
   "main": "index.js",
@@ -8,7 +8,8 @@
     "loopctl-mcp-server": "index.js"
   },
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "test": "node --test test/**/*.test.js"
   },
   "keywords": [
     "mcp",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "start": "node index.js",
-    "test": "node --test test/**/*.test.js"
+    "test": "node --test"
   },
   "keywords": [
     "mcp",

--- a/mcp-server/test/knowledge_tools.test.js
+++ b/mcp-server/test/knowledge_tools.test.js
@@ -125,6 +125,8 @@ async function knowledgeContext({ query, project_id, story_id, limit, recency_we
   return toContent(result);
 }
 
+const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
 async function knowledgeAgentUsage({ api_key_id, agent_id, limit, since_days } = {}) {
   const normalizedApiKeyId =
     typeof api_key_id === "string" && api_key_id.trim() === "" ? null : api_key_id;
@@ -145,6 +147,15 @@ async function knowledgeAgentUsage({ api_key_id, agent_id, limit, since_days } =
   }
 
   const resolvedId = normalizedApiKeyId ?? normalizedAgentId;
+
+  if (typeof resolvedId !== "string" || !UUID_RE.test(resolvedId)) {
+    const which = normalizedApiKeyId != null ? "api_key_id" : "agent_id";
+    return {
+      content: [{ type: "text", text: `Error: ${which} must be a canonical UUID (8-4-4-4-12 hex).` }],
+      isError: true,
+    };
+  }
+
   const params = new URLSearchParams();
   if (limit != null) params.set("limit", String(limit));
   if (since_days != null) params.set("since_days", String(since_days));
@@ -425,6 +436,61 @@ describe("TC-25.3.7b: empty-string api_key_id/agent_id are rejected as missing",
 
     assert.equal(calls.length, 0, "no HTTP request when both are empty strings");
     assert.equal(result.isError, true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TC-25.3.7c: knowledge_agent_usage rejects non-UUID resolvedId values
+// (defense-in-depth against URL path injection)
+// ---------------------------------------------------------------------------
+
+describe("TC-25.3.7c: non-UUID ids are rejected before a network call is made", () => {
+  test("path-traversal-style api_key_id is rejected client-side", async () => {
+    setupEnv();
+    const calls = mockFetch();
+
+    const result = await knowledgeAgentUsage({
+      api_key_id: "../../../stories/123",
+    });
+
+    assert.equal(calls.length, 0, "no HTTP request should be made for non-UUID id");
+    assert.equal(result.isError, true);
+    assert.ok(
+      result.content[0].text.includes("canonical UUID"),
+      "error should mention the UUID constraint"
+    );
+  });
+
+  test("hex-but-wrong-shape agent_id is rejected", async () => {
+    setupEnv();
+    const calls = mockFetch();
+
+    const result = await knowledgeAgentUsage({ agent_id: "deadbeef" });
+
+    assert.equal(calls.length, 0, "no HTTP request for malformed id");
+    assert.equal(result.isError, true);
+  });
+
+  test("numeric id is rejected", async () => {
+    setupEnv();
+    const calls = mockFetch();
+
+    const result = await knowledgeAgentUsage({ api_key_id: 42 });
+
+    assert.equal(calls.length, 0);
+    assert.equal(result.isError, true);
+  });
+
+  test("valid canonical UUID passes the check", async () => {
+    setupEnv();
+    const calls = mockFetch({ reads: 1, articles: [] });
+
+    const result = await knowledgeAgentUsage({
+      api_key_id: "b977c90c-061b-4e42-8afa-26a5efde51ad",
+    });
+
+    assert.equal(calls.length, 1, "HTTP request should proceed for valid UUID");
+    assert.equal(result.isError, undefined);
   });
 });
 

--- a/mcp-server/test/knowledge_tools.test.js
+++ b/mcp-server/test/knowledge_tools.test.js
@@ -126,20 +126,25 @@ async function knowledgeContext({ query, project_id, story_id, limit, recency_we
 }
 
 async function knowledgeAgentUsage({ api_key_id, agent_id, limit, since_days } = {}) {
-  if (api_key_id != null && agent_id != null) {
+  const normalizedApiKeyId =
+    typeof api_key_id === "string" && api_key_id.trim() === "" ? null : api_key_id;
+  const normalizedAgentId =
+    typeof agent_id === "string" && agent_id.trim() === "" ? null : agent_id;
+
+  if (normalizedApiKeyId != null && normalizedAgentId != null) {
     return {
       content: [{ type: "text", text: "Error: pass exactly one of api_key_id or agent_id, not both. Use api_key_id for the api_keys.id credential; use agent_id for the agents.id logical identity." }],
       isError: true,
     };
   }
-  if (api_key_id == null && agent_id == null) {
+  if (normalizedApiKeyId == null && normalizedAgentId == null) {
     return {
       content: [{ type: "text", text: "Error: pass exactly one of api_key_id or agent_id. Use api_key_id for the api_keys.id credential; use agent_id for the agents.id logical identity." }],
       isError: true,
     };
   }
 
-  const resolvedId = api_key_id ?? agent_id;
+  const resolvedId = normalizedApiKeyId ?? normalizedAgentId;
   const params = new URLSearchParams();
   if (limit != null) params.set("limit", String(limit));
   if (since_days != null) params.set("since_days", String(since_days));
@@ -149,7 +154,7 @@ async function knowledgeAgentUsage({ api_key_id, agent_id, limit, since_days } =
     : `/api/v1/knowledge/analytics/agents/${resolvedId}`;
   const result = await apiCall("GET", path, null, process.env.LOOPCTL_ORCH_KEY);
 
-  if (agent_id != null && api_key_id == null) {
+  if (normalizedAgentId != null && normalizedApiKeyId == null) {
     const base = toContent(result);
     return {
       ...base,
@@ -380,6 +385,46 @@ describe("TC-25.3.7: deprecation hint for agent_id-only call", () => {
     // Hint should be in _meta, not polluting content
     const contentText = result.content[0].text;
     assert.ok(!contentText.includes("deprecation"), "deprecation hint should NOT be in content array");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TC-25.3.7b: knowledge_agent_usage treats empty strings as missing
+// ---------------------------------------------------------------------------
+
+describe("TC-25.3.7b: empty-string api_key_id/agent_id are rejected as missing", () => {
+  test("empty string api_key_id alone triggers neither-provided validation error", async () => {
+    setupEnv();
+    const calls = mockFetch();
+
+    const result = await knowledgeAgentUsage({ api_key_id: "" });
+
+    assert.equal(calls.length, 0, "no HTTP request should be made for empty string id");
+    assert.equal(result.isError, true);
+    assert.ok(
+      result.content[0].text.includes("pass exactly one of api_key_id or agent_id"),
+      "empty string should surface the neither-provided error"
+    );
+  });
+
+  test("whitespace-only agent_id is treated as missing", async () => {
+    setupEnv();
+    const calls = mockFetch();
+
+    const result = await knowledgeAgentUsage({ agent_id: "   " });
+
+    assert.equal(calls.length, 0, "no HTTP request should be made for whitespace-only id");
+    assert.equal(result.isError, true);
+  });
+
+  test("empty string on both sides still produces an error rather than a malformed URL", async () => {
+    setupEnv();
+    const calls = mockFetch();
+
+    const result = await knowledgeAgentUsage({ api_key_id: "", agent_id: "" });
+
+    assert.equal(calls.length, 0, "no HTTP request when both are empty strings");
+    assert.equal(result.isError, true);
   });
 });
 

--- a/mcp-server/test/knowledge_tools.test.js
+++ b/mcp-server/test/knowledge_tools.test.js
@@ -1,0 +1,419 @@
+/**
+ * Tests for US-25.3: MCP Tool Context Parameters & agent_id Disambiguation
+ *
+ * Uses Node.js built-in test runner (node:test).
+ * Run: node --test test/
+ *
+ * Strategy: The handler functions in index.js are not exported (it's a server
+ * entry point with top-level await). We test the logic directly by reimplementing
+ * the minimal helpers and handler bodies here, keeping the test self-contained
+ * and resilient to refactors in the server bootstrap code.
+ */
+
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+// ---------------------------------------------------------------------------
+// Minimal re-implementation of the helpers under test
+// (mirrors index.js logic exactly)
+// ---------------------------------------------------------------------------
+
+function getBaseUrl() {
+  return (process.env.LOOPCTL_SERVER || "https://loopctl.com").replace(/\/$/, "");
+}
+
+function resolveKey(keyOverride) {
+  return (
+    process.env.LOOPCTL_API_KEY ||
+    keyOverride ||
+    process.env.LOOPCTL_ORCH_KEY
+  );
+}
+
+async function apiCall(method, path, body, keyOverride) {
+  const url = `${getBaseUrl()}${path}`;
+  const key = resolveKey(keyOverride);
+
+  const options = {
+    method,
+    headers: {
+      Authorization: `Bearer ${key}`,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+  };
+
+  if (body !== undefined && body !== null) {
+    options.body = JSON.stringify(body);
+  }
+
+  const response = await fetch(url, options);
+
+  if (response.status === 204) return { ok: true };
+
+  const contentType = response.headers.get("content-type") || "";
+  let responseBody;
+  if (contentType.includes("application/json")) {
+    responseBody = await response.json();
+  } else {
+    responseBody = await response.text();
+  }
+
+  if (!response.ok) {
+    return { error: true, status: response.status, body: responseBody };
+  }
+
+  return responseBody;
+}
+
+function toContent(result) {
+  const isErr = result && result.error === true;
+  return {
+    content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+    ...(isErr && { isError: true }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Handler implementations (mirror index.js exactly)
+// ---------------------------------------------------------------------------
+
+async function knowledgeIndex({ project_id, story_id }) {
+  const basePath = project_id
+    ? `/api/v1/projects/${project_id}/knowledge/index`
+    : "/api/v1/knowledge/index";
+  const params = new URLSearchParams();
+  if (story_id) params.set("story_id", story_id);
+  const qs = params.toString();
+  const path = qs ? `${basePath}?${qs}` : basePath;
+  const result = await apiCall("GET", path, null, process.env.LOOPCTL_AGENT_KEY);
+  return toContent(result);
+}
+
+async function knowledgeSearch({ q, project_id, story_id, category, tags, mode, limit }) {
+  const params = new URLSearchParams({ q });
+  if (project_id) params.set("project_id", project_id);
+  if (story_id) params.set("story_id", story_id);
+  if (category) params.set("category", category);
+  if (tags) params.set("tags", tags);
+  if (mode) params.set("mode", mode);
+  if (limit != null) params.set("limit", String(limit));
+  const result = await apiCall("GET", `/api/v1/knowledge/search?${params}`, null, process.env.LOOPCTL_AGENT_KEY);
+  return toContent(result);
+}
+
+async function knowledgeGet({ article_id, project_id, story_id }) {
+  const params = new URLSearchParams();
+  if (project_id) params.set("project_id", project_id);
+  if (story_id) params.set("story_id", story_id);
+  const qs = params.toString();
+  const path = qs ? `/api/v1/articles/${article_id}?${qs}` : `/api/v1/articles/${article_id}`;
+  const result = await apiCall("GET", path, null, process.env.LOOPCTL_AGENT_KEY);
+  return toContent(result);
+}
+
+async function knowledgeContext({ query, project_id, story_id, limit, recency_weight }) {
+  const params = new URLSearchParams({ query });
+  if (project_id) params.set("project_id", project_id);
+  if (story_id) params.set("story_id", story_id);
+  if (limit != null) params.set("limit", String(limit));
+  if (recency_weight != null) params.set("recency_weight", String(recency_weight));
+  const result = await apiCall("GET", `/api/v1/knowledge/context?${params}`, null, process.env.LOOPCTL_AGENT_KEY);
+  return toContent(result);
+}
+
+async function knowledgeAgentUsage({ api_key_id, agent_id, limit, since_days } = {}) {
+  if (api_key_id != null && agent_id != null) {
+    return {
+      content: [{ type: "text", text: "Error: pass exactly one of api_key_id or agent_id, not both. Use api_key_id for the api_keys.id credential; use agent_id for the agents.id logical identity." }],
+      isError: true,
+    };
+  }
+  if (api_key_id == null && agent_id == null) {
+    return {
+      content: [{ type: "text", text: "Error: pass exactly one of api_key_id or agent_id. Use api_key_id for the api_keys.id credential; use agent_id for the agents.id logical identity." }],
+      isError: true,
+    };
+  }
+
+  const resolvedId = api_key_id ?? agent_id;
+  const params = new URLSearchParams();
+  if (limit != null) params.set("limit", String(limit));
+  if (since_days != null) params.set("since_days", String(since_days));
+  const qs = params.toString();
+  const path = qs
+    ? `/api/v1/knowledge/analytics/agents/${resolvedId}?${qs}`
+    : `/api/v1/knowledge/analytics/agents/${resolvedId}`;
+  const result = await apiCall("GET", path, null, process.env.LOOPCTL_ORCH_KEY);
+
+  if (agent_id != null && api_key_id == null) {
+    const base = toContent(result);
+    return {
+      ...base,
+      _meta: {
+        deprecation_hint:
+          "knowledge_agent_usage: if you meant the api_keys.id credential, pass it as api_key_id explicitly. The agent_id parameter now refers to the logical agents.id only.",
+      },
+    };
+  }
+
+  return toContent(result);
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const AGENT_KEY = "lc_test_agent_key";
+const ORCH_KEY = "lc_test_orch_key";
+const BASE_URL = "https://loopctl.com";
+
+/** Installs a mock fetch that captures calls and returns a canned JSON response. */
+function mockFetch(responseBody = { ok: true }, status = 200) {
+  const calls = [];
+  globalThis.fetch = async (url, options) => {
+    calls.push({ url, options });
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      headers: { get: () => "application/json" },
+      json: async () => responseBody,
+      text: async () => JSON.stringify(responseBody),
+    };
+  };
+  return calls;
+}
+
+function setupEnv() {
+  process.env.LOOPCTL_SERVER = BASE_URL;
+  process.env.LOOPCTL_AGENT_KEY = AGENT_KEY;
+  process.env.LOOPCTL_ORCH_KEY = ORCH_KEY;
+  delete process.env.LOOPCTL_API_KEY;
+}
+
+// ---------------------------------------------------------------------------
+// TC-25.3.1: knowledge_search forwards project_id and story_id
+// ---------------------------------------------------------------------------
+
+describe("TC-25.3.1: knowledge_search with project_id and story_id", () => {
+  test("forwards both attribution params to HTTP request", async () => {
+    setupEnv();
+    const calls = mockFetch({ articles: [] });
+
+    const result = await knowledgeSearch({
+      q: "csv import",
+      project_id: "b50c9e38-aebe-4bbe-b8e6-bf2cb2b8afd0",
+      story_id: "89aa0c48-5cf5-4925-b164-21684ef79c4d",
+    });
+
+    assert.equal(calls.length, 1, "exactly one HTTP call made");
+    const { url, options } = calls[0];
+
+    // Verify method
+    assert.equal(options.method, "GET");
+
+    // Verify Authorization header uses agent key
+    assert.equal(options.headers.Authorization, `Bearer ${AGENT_KEY}`);
+
+    // Verify query params
+    const parsedUrl = new URL(url);
+    assert.equal(parsedUrl.searchParams.get("q"), "csv import");
+    assert.equal(parsedUrl.searchParams.get("project_id"), "b50c9e38-aebe-4bbe-b8e6-bf2cb2b8afd0");
+    assert.equal(parsedUrl.searchParams.get("story_id"), "89aa0c48-5cf5-4925-b164-21684ef79c4d");
+
+    // Verify no error in result
+    assert.equal(result.isError, undefined);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TC-25.3.2: knowledge_search omits project_id/story_id when not passed
+// ---------------------------------------------------------------------------
+
+describe("TC-25.3.2: knowledge_search without attribution params", () => {
+  test("omits project_id and story_id from URL", async () => {
+    setupEnv();
+    const calls = mockFetch({ articles: [] });
+
+    await knowledgeSearch({ q: "csv import" });
+
+    assert.equal(calls.length, 1);
+    const parsedUrl = new URL(calls[0].url);
+    assert.equal(parsedUrl.searchParams.has("project_id"), false, "no project_id param");
+    assert.equal(parsedUrl.searchParams.has("story_id"), false, "no story_id param");
+    assert.equal(parsedUrl.searchParams.get("q"), "csv import");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TC-25.3.3: knowledge_agent_usage with api_key_id
+// ---------------------------------------------------------------------------
+
+describe("TC-25.3.3: knowledge_agent_usage with api_key_id", () => {
+  test("routes to analytics endpoint with api_key_id, no deprecation warning", async () => {
+    setupEnv();
+    const calls = mockFetch({ reads: 31, articles: [] });
+
+    const result = await knowledgeAgentUsage({
+      api_key_id: "b977c90c-061b-4e42-8afa-26a5efde51ad",
+      since_days: 7,
+    });
+
+    assert.equal(calls.length, 1);
+    const parsedUrl = new URL(calls[0].url);
+
+    // Path should include the api_key_id
+    assert.ok(
+      parsedUrl.pathname.includes("b977c90c-061b-4e42-8afa-26a5efde51ad"),
+      `pathname ${parsedUrl.pathname} should include api_key_id`
+    );
+    assert.equal(parsedUrl.searchParams.get("since_days"), "7");
+    assert.equal(result.isError, undefined, "no error");
+    assert.equal(result._meta, undefined, "no deprecation warning for api_key_id path");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TC-25.3.4: knowledge_agent_usage with agent_id (logical identity)
+// ---------------------------------------------------------------------------
+
+describe("TC-25.3.4: knowledge_agent_usage with agent_id (logical agents.id)", () => {
+  test("routes to analytics endpoint with agent_id, includes deprecation hint", async () => {
+    setupEnv();
+    const calls = mockFetch({ reads: 5, articles: [] });
+
+    const result = await knowledgeAgentUsage({
+      agent_id: "09429bc4-328f-42f4-acec-db48b40849b2",
+      since_days: 7,
+    });
+
+    assert.equal(calls.length, 1);
+    const parsedUrl = new URL(calls[0].url);
+
+    assert.ok(
+      parsedUrl.pathname.includes("09429bc4-328f-42f4-acec-db48b40849b2"),
+      `pathname ${parsedUrl.pathname} should include agent_id`
+    );
+    assert.equal(parsedUrl.searchParams.get("since_days"), "7");
+    assert.equal(result.isError, undefined, "no error");
+
+    // Deprecation hint should be present for agent_id-only calls
+    assert.ok(result._meta, "deprecation _meta should be present");
+    assert.ok(
+      result._meta.deprecation_hint.includes("api_key_id"),
+      "deprecation hint should mention api_key_id"
+    );
+    assert.ok(
+      result._meta.deprecation_hint.includes("agents.id"),
+      "deprecation hint should mention agents.id"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TC-25.3.5: knowledge_agent_usage errors when BOTH are passed
+// ---------------------------------------------------------------------------
+
+describe("TC-25.3.5: knowledge_agent_usage with both api_key_id and agent_id", () => {
+  test("returns validation error without making HTTP request", async () => {
+    setupEnv();
+    const calls = mockFetch();
+
+    const result = await knowledgeAgentUsage({
+      api_key_id: "b977c90c-061b-4e42-8afa-26a5efde51ad",
+      agent_id: "09429bc4-328f-42f4-acec-db48b40849b2",
+      since_days: 7,
+    });
+
+    assert.equal(calls.length, 0, "no HTTP request should be made");
+    assert.equal(result.isError, true);
+    assert.ok(
+      result.content[0].text.includes("pass exactly one of api_key_id or agent_id"),
+      "error message should instruct user to pass exactly one"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TC-25.3.6: knowledge_agent_usage errors when NEITHER is passed
+// ---------------------------------------------------------------------------
+
+describe("TC-25.3.6: knowledge_agent_usage with neither api_key_id nor agent_id", () => {
+  test("returns validation error without making HTTP request", async () => {
+    setupEnv();
+    const calls = mockFetch();
+
+    const result = await knowledgeAgentUsage({ since_days: 7 });
+
+    assert.equal(calls.length, 0, "no HTTP request should be made");
+    assert.equal(result.isError, true);
+    assert.ok(
+      result.content[0].text.includes("pass exactly one of api_key_id or agent_id"),
+      "error message should instruct user to pass exactly one"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TC-25.3.7: Deprecation hint when agent_id is passed alone
+// ---------------------------------------------------------------------------
+
+describe("TC-25.3.7: deprecation hint for agent_id-only call", () => {
+  test("_meta.deprecation_hint nudges toward api_key_id when agent_id alone is used", async () => {
+    setupEnv();
+    mockFetch({ reads: 10, articles: [] });
+
+    const result = await knowledgeAgentUsage({
+      agent_id: "09429bc4-328f-42f4-acec-db48b40849b2",
+    });
+
+    assert.equal(result.isError, undefined, "not an error");
+    assert.ok(result._meta, "_meta should be present");
+    assert.ok(typeof result._meta.deprecation_hint === "string", "deprecation_hint should be a string");
+    assert.ok(
+      result._meta.deprecation_hint.includes("api_key_id"),
+      "hint should mention api_key_id"
+    );
+    // Hint should be in _meta, not polluting content
+    const contentText = result.content[0].text;
+    assert.ok(!contentText.includes("deprecation"), "deprecation hint should NOT be in content array");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TC-25.3.8: README contains Wiki Attribution section
+// ---------------------------------------------------------------------------
+
+describe("TC-25.3.8: README Wiki Attribution section", () => {
+  test("README.md contains required Wiki Attribution content", () => {
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    const readmePath = path.join(__dirname, "..", "README.md");
+    const readme = readFileSync(readmePath, "utf8");
+
+    // Section heading
+    assert.ok(readme.includes("Wiki Attribution"), 'README should include "Wiki Attribution" heading');
+
+    // api_key_id vs agent_id disambiguation
+    assert.ok(readme.includes("api_key_id"), 'README should explain api_key_id parameter');
+    assert.ok(readme.includes("agent_id"), 'README should explain agent_id parameter');
+
+    // story_id context params
+    assert.ok(readme.includes("story_id"), 'README should mention story_id parameter');
+    assert.ok(readme.includes("project_id"), 'README should mention project_id parameter');
+
+    // JSON example with story_id for knowledge_search
+    assert.ok(
+      readme.includes("knowledge_search") && readme.includes("story_id"),
+      'README should have knowledge_search example with story_id'
+    );
+
+    // Deprecation note
+    assert.ok(
+      readme.includes("deprecated") || readme.includes("Deprecated"),
+      'README should mention deprecated behavior'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add optional `project_id` and `story_id` parameters to `knowledge_search`, `knowledge_get`, `knowledge_context`, and `knowledge_index` — forwarded as query params for wiki read attribution
- Redesign `knowledge_agent_usage` to accept `api_key_id` (credential) XOR `agent_id` (logical identity), with validation before any HTTP call; `agent_id`-only calls include a `_meta.deprecation_hint`
- Add "Wiki Attribution" section to `mcp-server/README.md` with workflow examples and api_key_id vs agent_id explanation
- Bootstrap `node:test` suite at `mcp-server/test/knowledge_tools.test.js` (8/8 passing)
- Bump `loopctl-mcp-server` to 1.2.0; create `mcp-server/CHANGELOG.md`

## Test plan

- [x] `cd mcp-server && npm test` — 8/8 tests pass
- [x] `node -e "import('./index.js').then(() => console.log('ok'))"` — server starts cleanly
- [x] All 10 ACs addressed; all 8 TCs covered by the test suite
- [x] No changes to Elixir/Phoenix code — pure mcp-server update

## Story

US-25.3 (78f955f6-7144-43d4-8012-2ca479afa3b9) — Epic 25: Knowledge Wiki Attribution & Analytics