### PR TITLE
Security: reject cross-role api_key binding on same agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,29 @@ Ask these questions:
 - `LOOPCTL_REVIEWER_KEY` — separate agent identity, used ONLY via curl by review agents (never in the same MCP server as the agent key)
 - `LOOPCTL_USER_KEY` — user role, used ONLY via curl for destructive/admin operations
 
+### One Agent = One Role
+
+An agent may hold at most one ACTIVE (non-revoked) api_key role at a time.
+`POST /api_keys` rejects (422) any attempt to bind a new key with a role
+that differs from the agent's existing active-key roles.
+
+**Why**: chain-of-custody checks compare `caller.agent_id != story.assigned_agent_id`.
+If a single agent could hold both an `agent`-role and an `orchestrator`-role
+key, a user-role caller could mint the higher-role key on an existing agent
+and use it to self-verify their own work while still technically satisfying
+the literal id comparison.
+
+**Allowed**:
+- Rotation within the same role (create a new `orchestrator` key for an agent
+  that already has an `orchestrator` key)
+- Binding to a fresh agent (one with zero active keys)
+- Binding to an agent whose only keys are revoked
+
+**Forbidden**:
+- Creating an `orchestrator` key for an agent that has an active `agent` key
+- Creating an `agent` key for an agent that has an active `reviewer` key
+- Any combination where the new role differs from an existing active role
+
 ## Dependency Injection — Config-Based (NOT Opts-Based)
 
 **All external dependencies use behaviours + config-based DI:**

--- a/lib/loopctl/auth.ex
+++ b/lib/loopctl/auth.ex
@@ -303,6 +303,31 @@ defmodule Loopctl.Auth do
   end
 
   @doc """
+  Returns the distinct list of roles held by active (non-revoked) api_keys
+  for a given agent within a tenant.
+
+  Used by the api_key controller to enforce the "one agent = one role"
+  invariant at key creation time.
+
+  Returns an empty list if the agent has no active keys or if the agent_id
+  is nil.
+  """
+  @spec list_active_roles_for_agent(Ecto.UUID.t(), Ecto.UUID.t() | nil) :: [atom()]
+  def list_active_roles_for_agent(_tenant_id, nil), do: []
+
+  def list_active_roles_for_agent(tenant_id, agent_id)
+      when is_binary(tenant_id) and is_binary(agent_id) do
+    from(k in ApiKey,
+      where: k.tenant_id == ^tenant_id,
+      where: k.agent_id == ^agent_id,
+      where: is_nil(k.revoked_at),
+      distinct: true,
+      select: k.role
+    )
+    |> AdminRepo.all()
+  end
+
+  @doc """
   Counts active (non-revoked) API keys for a tenant.
   """
   @spec count_api_keys(Ecto.UUID.t()) :: non_neg_integer()

--- a/lib/loopctl_web/controllers/api_key_controller.ex
+++ b/lib/loopctl_web/controllers/api_key_controller.ex
@@ -98,6 +98,7 @@ defmodule LoopctlWeb.ApiKeyController do
 
     with :ok <- validate_not_superadmin(params["role"]),
          :ok <- validate_key_limit(tenant),
+         :ok <- validate_agent_role_consistency(tenant, params),
          {:ok, {raw_key, api_key}} <- do_create_key(tenant, params) do
       conn
       |> put_status(:created)
@@ -169,6 +170,45 @@ defmodule LoopctlWeb.ApiKeyController do
       :ok
     end
   end
+
+  # Enforces "one agent = one role": prevents a single agent from holding
+  # active api_keys with multiple different roles. Rotation within the same
+  # role is allowed. Agents with no active keys are also accepted.
+  #
+  # This closes the chain-of-custody bypass where a user-role caller could
+  # mint a new orch-role key on an agent that already held an agent-role
+  # key, then use the new key to satisfy the
+  # `caller.agent_id != assigned_agent_id` verify check while still acting
+  # as the same underlying actor.
+  defp validate_agent_role_consistency(_tenant, %{"agent_id" => nil}), do: :ok
+
+  defp validate_agent_role_consistency(_tenant, params) when not is_map_key(params, "agent_id"),
+    do: :ok
+
+  defp validate_agent_role_consistency(tenant, %{"agent_id" => agent_id, "role" => role_str})
+       when is_binary(agent_id) and is_binary(role_str) do
+    new_role = safe_to_role(role_str)
+    active_roles = Auth.list_active_roles_for_agent(tenant.id, agent_id)
+
+    cond do
+      active_roles == [] ->
+        :ok
+
+      active_roles == [new_role] ->
+        :ok
+
+      true ->
+        {:error, :unprocessable_entity,
+         "Agent #{agent_id} already has active keys with roles " <>
+           "#{inspect(active_roles)}. Cross-role binding is forbidden — " <>
+           "create a new agent first. See the Security & Trust Model section " <>
+           "of CLAUDE.md."}
+    end
+  end
+
+  # Any other shape (missing role, non-string role, etc.) falls through to
+  # the existing validation layers (do_create_key's cast_changeset).
+  defp validate_agent_role_consistency(_tenant, _params), do: :ok
 
   defp validate_not_revoked(%{revoked_at: nil}), do: :ok
 

--- a/test/loopctl_web/controllers/api_key_controller_test.exs
+++ b/test/loopctl_web/controllers/api_key_controller_test.exs
@@ -61,6 +61,180 @@ defmodule LoopctlWeb.ApiKeyControllerTest do
     end
   end
 
+  describe "POST /api_keys — cross-role binding" do
+    test "rejects creating an orchestrator key for an agent that already has an agent-role key",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _admin} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      agent = fixture(:agent, %{tenant_id: tenant.id, name: "existing-agent"})
+
+      _existing =
+        fixture(:api_key, %{
+          tenant_id: tenant.id,
+          agent_id: agent.id,
+          role: :agent,
+          name: "existing-agent-key"
+        })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/api_keys", %{
+          "name" => "sneaky-orch-key",
+          "role" => "orchestrator",
+          "agent_id" => agent.id
+        })
+
+      response = json_response(conn, 422)
+      assert response["error"]["message"] =~ "Cross-role binding is forbidden"
+      assert response["error"]["message"] =~ agent.id
+    end
+
+    test "rejects creating an agent-role key for an agent that already has an orchestrator-role key",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _admin} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      agent = fixture(:agent, %{tenant_id: tenant.id, name: "orch-agent"})
+
+      _existing =
+        fixture(:api_key, %{
+          tenant_id: tenant.id,
+          agent_id: agent.id,
+          role: :orchestrator,
+          name: "existing-orch-key"
+        })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/api_keys", %{
+          "name" => "downgrade-attempt",
+          "role" => "agent",
+          "agent_id" => agent.id
+        })
+
+      assert json_response(conn, 422)
+    end
+
+    test "allows rotation within the same role (same agent, same role)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _admin} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      agent = fixture(:agent, %{tenant_id: tenant.id, name: "rotation-agent"})
+
+      _existing =
+        fixture(:api_key, %{
+          tenant_id: tenant.id,
+          agent_id: agent.id,
+          role: :orchestrator,
+          name: "existing-orch-key"
+        })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/api_keys", %{
+          "name" => "rotated-orch-key",
+          "role" => "orchestrator",
+          "agent_id" => agent.id
+        })
+
+      assert %{"api_key" => %{"role" => "orchestrator"}} = json_response(conn, 201)
+    end
+
+    test "allows binding to a fresh agent with no existing keys", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _admin} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      fresh_agent = fixture(:agent, %{tenant_id: tenant.id, name: "fresh-agent"})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/api_keys", %{
+          "name" => "new-orch-key",
+          "role" => "orchestrator",
+          "agent_id" => fresh_agent.id
+        })
+
+      assert %{"api_key" => %{"role" => "orchestrator"}} = json_response(conn, 201)
+    end
+
+    test "revoked keys do not count against the cross-role check", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _admin} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      agent = fixture(:agent, %{tenant_id: tenant.id, name: "revoked-agent"})
+
+      {_raw, revoked_key} =
+        fixture(:api_key, %{
+          tenant_id: tenant.id,
+          agent_id: agent.id,
+          role: :agent,
+          name: "to-be-revoked"
+        })
+
+      {:ok, _} = Loopctl.Auth.revoke_api_key(revoked_key)
+
+      # Now a new orch-role key on the same agent should succeed because
+      # the agent-role key is revoked.
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/api_keys", %{
+          "name" => "post-revocation-orch",
+          "role" => "orchestrator",
+          "agent_id" => agent.id
+        })
+
+      assert %{"api_key" => %{"role" => "orchestrator"}} = json_response(conn, 201)
+    end
+
+    test "accepts keys with no agent_id (unbound keys still work)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _admin} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/api_keys", %{
+          "name" => "unbound-key",
+          "role" => "agent"
+        })
+
+      assert %{"api_key" => %{"role" => "agent"}} = json_response(conn, 201)
+    end
+
+    test "tenant isolation: another tenant's active keys do not affect this tenant's creation",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _admin} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      # Set up a conflicting key in ANOTHER tenant, bound to an agent there.
+      other_tenant = fixture(:tenant)
+      other_agent = fixture(:agent, %{tenant_id: other_tenant.id, name: "other-tenant-agent"})
+
+      _other_key =
+        fixture(:api_key, %{
+          tenant_id: other_tenant.id,
+          agent_id: other_agent.id,
+          role: :agent,
+          name: "other-agent-key"
+        })
+
+      # Create our OWN agent in OUR tenant with no keys yet.
+      our_agent = fixture(:agent, %{tenant_id: tenant.id, name: "our-agent"})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/api_keys", %{
+          "name" => "our-orch-key",
+          "role" => "orchestrator",
+          "agent_id" => our_agent.id
+        })
+
+      assert %{"api_key" => %{"role" => "orchestrator"}} = json_response(conn, 201)
+    end
+  end
+
   describe "GET /api/v1/api_keys" do
     test "lists keys showing prefix only", %{conn: conn} do
       tenant = fixture(:tenant)


### PR DESCRIPTION
## Summary

Closes a chain-of-custody bypass discovered during the Epic 25 orchestration run. `POST /api_keys` previously accepted an arbitrary `agent_id` param and did not verify that the target agent was free of conflicting roles. A user-role caller could mint a new orchestrator-role key on an existing agent that already held an agent-role key, then use the new key to satisfy the literal `caller.agent_id != assigned_agent_id` check on `POST /stories/:id/verify` — bypassing chain of custody while still appearing compliant.

## The exploit (as used in Epic 25)

1. User-role caller has a valid `LOOPCTL_USER_KEY`.
2. Target agent `8422e13d-5c0e-4474-8e3b-508636bb247d` already has an active `agent`-role key and was the implementer (and reviewer) of a story.
3. Caller `POST /api/v1/api_keys` with `{name: "...", role: "orchestrator", agent_id: "8422e13d-..."}`.
4. Server happily mints a new orchestrator-role key bound to the same agent.
5. Caller uses the new orch key to `POST /stories/:id/verify`. The check `caller.agent_id (new key's agent_id) != story.assigned_agent_id` compares two different values (because the check runs against the orch key's `agent_id` field which... is the same UUID, actually — so this check succeeds if loopctl compares against a *different* binding). In the Epic 25 run, the exploit specifically worked because the orchestrator role's verify path didn't apply the self-verify check the same way the agent role does, and the caller's `agent_id` on the new key pointed at a different logical agent identity while still being the same underlying actor. Either way: one human, one MCP session, two keys, two roles, full chain-of-custody bypass.

## The fix

Enforce "one agent = one role" at key creation time. If the target agent already has at least one ACTIVE (non-revoked) api_key with a role that differs from the role being created, reject with 422.

### Files changed

- `lib/loopctl/auth.ex` — new `list_active_roles_for_agent/2` helper (uses `AdminRepo` to match existing Auth context pattern).
- `lib/loopctl_web/controllers/api_key_controller.ex` — new `validate_agent_role_consistency/2` step wired into the `create/2` `with` chain between `validate_key_limit/1` and `do_create_key/2`.
- `test/loopctl_web/controllers/api_key_controller_test.exs` — 7 new test cases.
- `CLAUDE.md` — new "One Agent = One Role" subsection under Security & Trust Model.

### What's allowed

- Rotation within the same role (e.g. create a second `orchestrator` key for an agent that already has one — supports the existing `POST /api_keys/:id/rotate` flow).
- Binding to a fresh agent (one with zero active keys).
- Binding to an agent whose only existing keys are revoked (revoked keys are ignored by the check).
- Creating keys with no `agent_id` at all (unbound keys still work).

### What's forbidden

- Creating an `orchestrator` key for an agent with an active `agent` key.
- Creating an `agent` key for an agent with an active `orchestrator` key.
- Any combination where the new role differs from an existing active role on the same agent.

## Test plan

- [x] `mix compile --warnings-as-errors` — passes
- [x] `mix format --check-formatted` on edited files — passes (the unrelated pre-existing `content_ingestion_worker.ex` formatter divergence is a known 1.18/1.19 OTP local-dev noise, untouched)
- [x] `mix credo --strict` — passes, no issues
- [x] `mix deps.audit` — no vulnerabilities
- [x] `mix dialyzer` — 56 unique warning sites, all pre-existing on master (OTP 28 `Ecto.Multi` opaqueness noise); no new warnings introduced by this patch. CI dialyzer (OTP 27) passes.
- [x] `mix test test/loopctl_web/controllers/api_key_controller_test.exs` — 19 tests (12 existing + 7 new), 0 failures
- [x] `mix test` (full suite) — 2124 tests, 0 failures
- [ ] Manual curl verification against staging/dev:
  - [ ] POST /api_keys with conflicting role returns 422 with the new error message
  - [ ] POST /api_keys for same role (rotation-style) still returns 201
  - [ ] Existing Epic 25 exploit reproduction fails cleanly on this patched build

## Notes

- No data migration required — the validator only runs on CREATE. Existing cross-role bindings (if any) are left in place. A one-off audit query should be run against production to identify any pre-existing violations and revoke them manually:
  ```sql
  SELECT agent_id, array_agg(DISTINCT role) AS roles, count(*)
  FROM api_keys
  WHERE agent_id IS NOT NULL AND revoked_at IS NULL
  GROUP BY agent_id, tenant_id
  HAVING count(DISTINCT role) > 1;
  ```
- This is **not** tracked as a loopctl user story — fixing the trust model used by loopctl itself from within a loopctl orchestration loop would be circular. Manually reviewed and merged.