### PR TITLE
Security: require attributable reviewer identity on review-complete

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,31 @@ Ask these questions:
 - `LOOPCTL_REVIEWER_KEY` — separate agent identity, used ONLY via curl by review agents (never in the same MCP server as the agent key)
 - `LOOPCTL_USER_KEY` — user role, used ONLY via curl for destructive/admin operations
 
+### Reviews Require Attributable Reviewer Identity
+
+Every `POST /api/v1/stories/:id/review-complete` call must carry a non-nil
+reviewer agent id that (a) belongs to the caller's tenant and (b) is
+different from the story's `assigned_agent_id`. There is NO nil
+short-circuit: if the caller can't declare who reviewed the work, the
+review is rejected.
+
+**How the reviewer id is determined**:
+1. If the request body contains `reviewer_agent_id`, that value is used.
+2. Otherwise, the calling api_key's `agent_id` is used.
+3. If neither is available, the request is rejected with 422.
+
+**User-role keys** must explicitly declare `reviewer_agent_id` in the
+request body unless they happen to also have an `agent_id` bound to
+their api_key. This preserves the legitimate "human admin records a
+manual review" use case while eliminating the nil bypass.
+
+**Why**: a previous implementation returned `:ok` when the reviewer id
+was nil, on the theory that "no agent identity → cannot self-review".
+That default was wrong — it accepted reviews with no attribution, which
+let a user-role caller bypass the self-review check by never having an
+agent_id at all. The correct default is to reject when identity is
+unknown.
+
 ## Dependency Injection — Config-Based (NOT Opts-Based)
 
 **All external dependencies use behaviours + config-based DI:**

--- a/lib/loopctl/progress.ex
+++ b/lib/loopctl/progress.ex
@@ -1439,8 +1439,10 @@ defmodule Loopctl.Progress do
     end
   end
 
-  # nil reviewer_agent_id: no agent identity to compare — cannot self-review
-  defp validate_not_self_review(_story, nil), do: :ok
+  # nil reviewer_agent_id: no attributable reviewer — default to rejecting.
+  # The controller must enforce non-nil upstream; this is defense-in-depth
+  # for any future code path that calls record_review/4 directly.
+  defp validate_not_self_review(_story, nil), do: {:error, :self_review_blocked}
 
   defp validate_not_self_review(story, reviewer_agent_id) do
     if not is_nil(story.assigned_agent_id) and story.assigned_agent_id == reviewer_agent_id do

--- a/lib/loopctl_web/controllers/review_record_controller.ex
+++ b/lib/loopctl_web/controllers/review_record_controller.ex
@@ -13,6 +13,7 @@ defmodule LoopctlWeb.ReviewRecordController do
   use LoopctlWeb, :controller
   use OpenApiSpex.ControllerSpecs
 
+  alias Loopctl.Agents
   alias Loopctl.ApiSpec.Schemas
   alias Loopctl.Progress
   alias LoopctlWeb.AuditContext
@@ -69,6 +70,18 @@ defmodule LoopctlWeb.ReviewRecordController do
              description:
                "When the review completed (defaults to now). Must be after reported_done_at.",
              example: "2026-03-30T01:44:41Z"
+           },
+           reviewer_agent_id: %OpenApiSpex.Schema{
+             type: :string,
+             format: :uuid,
+             description:
+               "Optional explicit reviewer agent id. Required when the calling API key " <>
+                 "does not have an agent_id set (e.g., user-role keys recording a manual " <>
+                 "review on behalf of a human reviewer). Must belong to the caller's tenant " <>
+                 "and must differ from the story's assigned implementer. When the caller's " <>
+                 "API key already has an agent_id, this field defaults to that value and " <>
+                 "must not be set to the same value explicitly.",
+             example: "09429bc4-1234-5678-90ab-cdef12345678"
            }
          }
        }},
@@ -89,16 +102,62 @@ defmodule LoopctlWeb.ReviewRecordController do
   def create(conn, %{"id" => story_id} = params) do
     api_key = conn.assigns.current_api_key
     tenant_id = api_key.tenant_id
-    reviewer_agent_id = api_key.agent_id
 
-    # Agent and orchestrator keys must have an agent_id set for chain-of-custody enforcement.
-    # User-role keys may legitimately record reviews without an agent identity.
-    if api_key.role in [:agent, :orchestrator] and is_nil(reviewer_agent_id) do
-      {:error, :unprocessable_entity, "Agent ID required for chain-of-custody"}
-    else
+    # Determine the reviewer agent id:
+    #   - Prefer the explicit body param if provided. This is the path for
+    #     user-role keys that don't have an agent_id of their own (e.g.,
+    #     a human admin recording a manual review by a specific agent).
+    #   - Fall back to the caller's own agent_id.
+    #   - Reject if neither is available — reviews must always be attributable.
+    body_reviewer_id = params["reviewer_agent_id"]
+    reviewer_agent_id = body_reviewer_id || api_key.agent_id
+
+    with :ok <- validate_reviewer_identity_present(reviewer_agent_id),
+         :ok <- validate_reviewer_tenant(tenant_id, reviewer_agent_id),
+         :ok <- validate_reviewer_not_self_via_body(api_key, body_reviewer_id) do
       do_create_review(conn, tenant_id, reviewer_agent_id, story_id, params)
     end
   end
+
+  # Every review_complete call must have an attributable reviewer agent id.
+  # This eliminates the nil-bypass where a user-role key with no agent_id
+  # could record a review without ever triggering the self-review check.
+  defp validate_reviewer_identity_present(nil) do
+    {:error, :unprocessable_entity,
+     "reviewer_agent_id is required. Provide it in the request body or " <>
+       "authenticate with a key that has an agent_id set."}
+  end
+
+  defp validate_reviewer_identity_present(_), do: :ok
+
+  # The declared reviewer agent id must belong to the caller's tenant.
+  # This prevents a caller from claiming a review by an agent from another
+  # tenant (which would both 404 at read time AND pollute the review record).
+  defp validate_reviewer_tenant(tenant_id, reviewer_agent_id) do
+    case Agents.get_agent(tenant_id, reviewer_agent_id) do
+      {:ok, _agent} ->
+        :ok
+
+      {:error, :not_found} ->
+        {:error, :unprocessable_entity,
+         "reviewer_agent_id not found in tenant. The declared reviewer must " <>
+           "be an existing agent in the current tenant."}
+    end
+  end
+
+  # When a caller passes reviewer_agent_id in the body AND has their own
+  # agent_id on the key, the body value must not equal the caller's own
+  # agent — that's bypass theater ("I'm reviewing this, but I'm also the
+  # same agent that implemented it").
+  defp validate_reviewer_not_self_via_body(%{agent_id: caller_agent_id}, body_reviewer_id)
+       when not is_nil(caller_agent_id) and not is_nil(body_reviewer_id) and
+              caller_agent_id == body_reviewer_id do
+    {:error, :unprocessable_entity,
+     "reviewer_agent_id in request body must not match the caller's own agent_id. " <>
+       "Use a different agent or authenticate as that agent directly."}
+  end
+
+  defp validate_reviewer_not_self_via_body(_api_key, _body_reviewer_id), do: :ok
 
   defp do_create_review(conn, tenant_id, reviewer_agent_id, story_id, params) do
     opts =

--- a/test/loopctl/progress_test.exs
+++ b/test/loopctl/progress_test.exs
@@ -353,12 +353,14 @@ defmodule Loopctl.ProgressTest do
 
       other_agent = fixture(:agent, %{tenant_id: tenant.id, agent_type: :orchestrator})
 
-      # Create review_record first
+      # Create review_record first. Reviewer must be attributable and
+      # differ from the implementer.
       assert {:ok, _} =
                Progress.record_review(
                  tenant.id,
                  story.id,
-                 %{"review_type" => "enhanced", "summary" => "Review passed"}
+                 %{"review_type" => "enhanced", "summary" => "Review passed"},
+                 reviewer_agent_id: other_agent.id
                )
 
       assert {:ok, updated} =
@@ -547,12 +549,18 @@ defmodule Loopctl.ProgressTest do
           })
           |> Loopctl.AdminRepo.update!()
 
-        # Review record required for each story
+        # Review record required for each story. Reviewer must be
+        # attributable and differ from the implementer.
         assert {:ok, _} =
-                 Progress.record_review(tenant.id, story.id, %{
-                   "review_type" => "enhanced",
-                   "summary" => "Passed"
-                 })
+                 Progress.record_review(
+                   tenant.id,
+                   story.id,
+                   %{
+                     "review_type" => "enhanced",
+                     "summary" => "Passed"
+                   },
+                   reviewer_agent_id: orch_agent.id
+                 )
       end
 
       assert {:ok, result} =
@@ -634,6 +642,8 @@ defmodule Loopctl.ProgressTest do
       %{tenant: tenant, story: story} =
         setup_story(%{agent_status: :reported_done, reported_done_at: DateTime.utc_now()})
 
+      reviewer = fixture(:agent, %{tenant_id: tenant.id, agent_type: :orchestrator})
+
       assert {:ok, review_record} =
                Progress.record_review(
                  tenant.id,
@@ -643,7 +653,8 @@ defmodule Loopctl.ProgressTest do
                    "findings_count" => 5,
                    "fixes_count" => 5,
                    "summary" => "Enhanced review completed. All findings fixed."
-                 }
+                 },
+                 reviewer_agent_id: reviewer.id
                )
 
       assert review_record.review_type == "enhanced"
@@ -930,7 +941,8 @@ defmodule Loopctl.ProgressTest do
         })
         |> Loopctl.AdminRepo.update!()
 
-      # Review completed after reported_done_at
+      # Review completed after reported_done_at. Reviewer must be
+      # attributable and differ from the implementer.
       assert {:ok, _} =
                Progress.record_review(
                  tenant.id,
@@ -938,7 +950,8 @@ defmodule Loopctl.ProgressTest do
                  %{
                    "review_type" => "enhanced",
                    "completed_at" => ~U[2026-03-30 01:00:00.000000Z]
-                 }
+                 },
+                 reviewer_agent_id: orch_agent.id
                )
 
       assert {:ok, updated} =

--- a/test/loopctl_web/controllers/review_record_controller_test.exs
+++ b/test/loopctl_web/controllers/review_record_controller_test.exs
@@ -1,0 +1,196 @@
+defmodule LoopctlWeb.ReviewRecordControllerTest do
+  @moduledoc """
+  Tests for the explicit-reviewer-identity invariant on
+  POST /api/v1/stories/:id/review-complete.
+
+  These tests lock in the fix for the chain-of-custody bypass discovered
+  during the Epic 25 orchestration run: a user-role key with a nil
+  agent_id was able to record a review without ever triggering the
+  self-review check, because Progress.validate_not_self_review/2 had
+  a nil short-circuit that returned :ok.
+
+  The controller now requires an attributable reviewer agent id from
+  one of two sources: the `reviewer_agent_id` body param, or the
+  caller's own api_key.agent_id. If neither is available, the request
+  is rejected with 422.
+  """
+
+  use LoopctlWeb.ConnCase, async: true
+
+  setup :verify_on_exit!
+
+  defp auth_conn(conn, raw_key) do
+    put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  # Mirrors story_verification_controller_test.exs's :setup_reported_story
+  # shape (tenant, project, epic, implementer agent, story in reported_done
+  # with assigned_agent_id set to the implementer).
+  defp setup_reported_done_story(_ctx \\ %{}) do
+    tenant = fixture(:tenant)
+    project = fixture(:project, %{tenant_id: tenant.id})
+    epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+    impl_agent = fixture(:agent, %{tenant_id: tenant.id, agent_type: :implementer})
+
+    story =
+      fixture(:story, %{
+        tenant_id: tenant.id,
+        epic_id: epic.id,
+        agent_status: :reported_done
+      })
+
+    story =
+      story
+      |> Ecto.Changeset.change(%{
+        assigned_agent_id: impl_agent.id,
+        reported_done_at: DateTime.utc_now()
+      })
+      |> Loopctl.AdminRepo.update!()
+
+    %{tenant: tenant, project: project, epic: epic, impl_agent: impl_agent, story: story}
+  end
+
+  describe "POST /stories/:id/review-complete — explicit reviewer identity" do
+    test "rejects user-role key with no agent_id when reviewer_agent_id is not in body",
+         %{conn: conn} do
+      %{tenant: tenant, story: story} = setup_reported_done_story()
+
+      # User-role key without agent_id — this is the attack vector.
+      {user_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(user_key)
+        |> post(~p"/api/v1/stories/#{story.id}/review-complete", %{
+          "review_type" => "manual",
+          "findings_count" => 0,
+          "fixes_count" => 0,
+          "disproved_count" => 0
+        })
+
+      body = json_response(conn, 422)
+      assert body["error"]["message"] =~ "reviewer_agent_id is required"
+    end
+
+    test "accepts user-role key with nil agent_id when reviewer_agent_id in body is a valid tenant agent different from implementer",
+         %{conn: conn} do
+      %{tenant: tenant, story: story} = setup_reported_done_story()
+
+      reviewer_agent =
+        fixture(:agent, %{tenant_id: tenant.id, name: "human-reviewer"})
+
+      {user_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(user_key)
+        |> post(~p"/api/v1/stories/#{story.id}/review-complete", %{
+          "review_type" => "manual",
+          "findings_count" => 0,
+          "fixes_count" => 0,
+          "disproved_count" => 0,
+          "reviewer_agent_id" => reviewer_agent.id
+        })
+
+      body = json_response(conn, 201)
+      assert body["review_record"]["reviewer_agent_id"] == reviewer_agent.id
+      assert body["review_record"]["story_id"] == story.id
+    end
+
+    test "rejects when declared reviewer_agent_id matches the story's assigned_agent_id (self_review_blocked)",
+         %{conn: conn} do
+      %{tenant: tenant, story: story} = setup_reported_done_story()
+
+      {user_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      # Pass the implementer's own agent_id as the reviewer.
+      conn =
+        conn
+        |> auth_conn(user_key)
+        |> post(~p"/api/v1/stories/#{story.id}/review-complete", %{
+          "review_type" => "manual",
+          "findings_count" => 0,
+          "fixes_count" => 0,
+          "disproved_count" => 0,
+          "reviewer_agent_id" => story.assigned_agent_id
+        })
+
+      # self_review_blocked maps to 409 in the fallback controller.
+      body = json_response(conn, 409)
+      assert body["error"]["message"] =~ "Cannot review your own implementation"
+    end
+
+    test "rejects when body reviewer_agent_id belongs to another tenant", %{conn: conn} do
+      %{tenant: tenant, story: story} = setup_reported_done_story()
+
+      other_tenant = fixture(:tenant)
+
+      other_agent =
+        fixture(:agent, %{tenant_id: other_tenant.id, name: "cross-tenant-reviewer"})
+
+      {user_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(user_key)
+        |> post(~p"/api/v1/stories/#{story.id}/review-complete", %{
+          "review_type" => "manual",
+          "findings_count" => 0,
+          "fixes_count" => 0,
+          "disproved_count" => 0,
+          "reviewer_agent_id" => other_agent.id
+        })
+
+      body = json_response(conn, 422)
+      assert body["error"]["message"] =~ "not found in tenant"
+    end
+
+    test "rejects user-role key when body reviewer_agent_id equals the caller's own agent_id",
+         %{conn: conn} do
+      %{tenant: tenant, story: story} = setup_reported_done_story()
+
+      # A user-role key that also happens to be bound to an agent.
+      caller_agent = fixture(:agent, %{tenant_id: tenant.id, name: "caller-agent"})
+
+      {user_key, _} =
+        fixture(:api_key, %{tenant_id: tenant.id, role: :user, agent_id: caller_agent.id})
+
+      conn =
+        conn
+        |> auth_conn(user_key)
+        |> post(~p"/api/v1/stories/#{story.id}/review-complete", %{
+          "review_type" => "manual",
+          "findings_count" => 0,
+          "fixes_count" => 0,
+          "disproved_count" => 0,
+          "reviewer_agent_id" => caller_agent.id
+        })
+
+      body = json_response(conn, 422)
+      assert body["error"]["message"] =~ "must not match the caller's own agent_id"
+    end
+
+    test "orchestrator-role key with its own agent_id works without body reviewer_agent_id (backward compat)",
+         %{conn: conn} do
+      %{tenant: tenant, story: story} = setup_reported_done_story()
+
+      orch_agent = fixture(:agent, %{tenant_id: tenant.id, name: "orch-reviewer"})
+
+      {orch_key, _} =
+        fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator, agent_id: orch_agent.id})
+
+      conn =
+        conn
+        |> auth_conn(orch_key)
+        |> post(~p"/api/v1/stories/#{story.id}/review-complete", %{
+          "review_type" => "enhanced",
+          "findings_count" => 0,
+          "fixes_count" => 0,
+          "disproved_count" => 0
+        })
+
+      body = json_response(conn, 201)
+      assert body["review_record"]["reviewer_agent_id"] == orch_agent.id
+    end
+  end
+end

--- a/test/loopctl_web/controllers/story_verification_controller_test.exs
+++ b/test/loopctl_web/controllers/story_verification_controller_test.exs
@@ -615,8 +615,13 @@ defmodule LoopctlWeb.StoryVerificationControllerTest do
     test "verifies all reported_done unverified stories in an epic when review_records exist", %{
       conn: conn
     } do
-      %{tenant: tenant, epic: epic, impl_agent: impl_agent, orch_key: orch_key} =
-        setup_reported_story()
+      %{
+        tenant: tenant,
+        epic: epic,
+        impl_agent: impl_agent,
+        orch_agent: orch_agent,
+        orch_key: orch_key
+      } = setup_reported_story()
 
       # Create 2 more reported_done stories in the same epic, each with a review_record
       for _ <- 1..2 do
@@ -632,10 +637,15 @@ defmodule LoopctlWeb.StoryVerificationControllerTest do
           |> Loopctl.AdminRepo.update!()
 
         {:ok, _} =
-          Progress.record_review(tenant.id, story.id, %{
-            "review_type" => "enhanced",
-            "summary" => "Passed"
-          })
+          Progress.record_review(
+            tenant.id,
+            story.id,
+            %{
+              "review_type" => "enhanced",
+              "summary" => "Passed"
+            },
+            reviewer_agent_id: orch_agent.id
+          )
       end
 
       conn =
@@ -753,11 +763,21 @@ defmodule LoopctlWeb.StoryVerificationControllerTest do
       %{tenant: tenant, story: story} = setup_reported_story(%{with_review_record: false})
       {user_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
 
+      # User-role keys with nil agent_id must declare an explicit reviewer
+      # in the request body (per the Reviews Require Attributable Reviewer
+      # Identity invariant in CLAUDE.md).
+      reviewer_agent =
+        fixture(:agent, %{
+          tenant_id: tenant.id,
+          name: "human-reviewer-#{:erlang.unique_integer([:positive])}"
+        })
+
       conn =
         conn
         |> auth_conn(user_key)
         |> post(~p"/api/v1/stories/#{story.id}/review-complete", %{
-          "review_type" => "team"
+          "review_type" => "team",
+          "reviewer_agent_id" => reviewer_agent.id
         })
 
       assert json_response(conn, 201)

--- a/test/loopctl_web/controllers/verification_listing_test.exs
+++ b/test/loopctl_web/controllers/verification_listing_test.exs
@@ -63,9 +63,16 @@ defmodule LoopctlWeb.VerificationListingTest do
   end
 
   # Creates a fresh review_record so the next POST /verify succeeds.
-  defp create_review_record(tenant_id, story_id) do
+  # Reviewer must be attributable and differ from the implementer per the
+  # "Reviews Require Attributable Reviewer Identity" invariant.
+  defp create_review_record(tenant_id, story_id, reviewer_agent_id) do
     {:ok, _} =
-      Progress.record_review(tenant_id, story_id, %{"review_type" => "enhanced"})
+      Progress.record_review(
+        tenant_id,
+        story_id,
+        %{"review_type" => "enhanced"},
+        reviewer_agent_id: reviewer_agent_id
+      )
   end
 
   # --- Paginated verification listing ---
@@ -167,10 +174,11 @@ defmodule LoopctlWeb.VerificationListingTest do
 
   describe "iteration field auto-computation" do
     test "verify creates verification result with correct iteration number", %{conn: conn} do
-      %{tenant: tenant, story: story, orch_key: orch_key} = setup_verified_story()
+      %{tenant: tenant, story: story, orch_key: orch_key, orch_agent: orch_agent} =
+        setup_verified_story()
 
       # Create review record so first verify succeeds
-      create_review_record(tenant.id, story.id)
+      create_review_record(tenant.id, story.id, orch_agent.id)
 
       # First verification
       build_conn()
@@ -200,7 +208,7 @@ defmodule LoopctlWeb.VerificationListingTest do
       |> Loopctl.AdminRepo.update!()
 
       # Create a fresh review record so second verify succeeds
-      create_review_record(tenant.id, story.id)
+      create_review_record(tenant.id, story.id, orch_agent.id)
 
       # Second verification
       build_conn()
@@ -227,10 +235,11 @@ defmodule LoopctlWeb.VerificationListingTest do
 
   describe "verification result fields" do
     test "result enum includes pass, fail values", %{conn: conn} do
-      %{tenant: tenant, story: story, orch_key: orch_key} = setup_verified_story()
+      %{tenant: tenant, story: story, orch_key: orch_key, orch_agent: orch_agent} =
+        setup_verified_story()
 
       # Create review record so verify succeeds
-      create_review_record(tenant.id, story.id)
+      create_review_record(tenant.id, story.id, orch_agent.id)
 
       # Verify (pass)
       build_conn()


### PR DESCRIPTION
## Summary

Closes the second chain-of-custody bypass discovered during the Epic 25 orchestration run. Previously, `POST /api/v1/stories/:id/review-complete` had two problems that combined into a bypass:

1. `ReviewRecordController.create/2` allowed user-role keys to have a nil `agent_id`, passing nil through as `reviewer_agent_id`.
2. `Progress.validate_not_self_review/2` had an explicit nil short-circuit that returned `:ok` when the reviewer agent id was nil, documented as "no agent identity -> cannot self-review".

Combined, a user-role caller whose api_key had no `agent_id` could record a review on any story without ever triggering the self-review check.

## What Changed

- **`lib/loopctl/progress.ex`**: `validate_not_self_review/2` no longer short-circuits on nil. New default is `{:error, :self_review_blocked}` -- defense-in-depth for any future direct caller of `record_review/4`.
- **`lib/loopctl_web/controllers/review_record_controller.ex`**: `create/2` now requires `reviewer_agent_id` from one of two sources: (a) the request body via `"reviewer_agent_id"`, or (b) the calling api_key's own `agent_id`. If neither is present, 422. The declared reviewer must also belong to the caller's tenant and must differ from the caller's own `agent_id` when both are present.
- **`CLAUDE.md`**: New "Reviews Require Attributable Reviewer Identity" subsection under Security & Trust Model documenting the invariant.
- **Tests**:
  - New `test/loopctl_web/controllers/review_record_controller_test.exs` with 6 test cases locking in each path: missing reviewer, valid explicit reviewer, self-review via body, cross-tenant reviewer, self-aliasing via body, and backward-compat for orchestrator-role keys.
  - Updated `test/loopctl/progress_test.exs`, `test/loopctl_web/controllers/story_verification_controller_test.exs`, and `test/loopctl_web/controllers/verification_listing_test.exs` to pass explicit `reviewer_agent_id` where tests previously relied on the nil short-circuit.

## Backward Compatibility

Orchestrator-role and agent-role keys with `agent_id` set continue to work exactly as before without any body changes. Only user-role keys with nil `agent_id` now require the body param -- and they were the only path that could exploit the bypass.

The legitimate "human admin records manual review" use case is preserved: the admin uses a user-role key and declares a specific reviewer agent in the request body. The review_record is attributable to that agent.

No data migration required. Existing review_records with nil reviewer identity (if any) are left in place; a one-off audit query can surface them for manual review.

## Test Plan

- [x] `mix compile --warnings-as-errors` passes
- [x] `mix format --check-formatted` clean for all edited files
- [x] `mix credo --strict` clean (no new issues)
- [x] `mix test test/loopctl_web/controllers/review_record_controller_test.exs` — 6/6 new tests pass
- [x] `mix test test/loopctl/progress_test.exs` — 46/46 pass (includes existing self-review tests)
- [x] `mix test test/loopctl_web/controllers/story_verification_controller_test.exs` — 34/34 pass
- [x] `mix test` — full suite 2123/2123 pass
- [x] `mix dialyzer` — same 55 pre-existing `Ecto.Multi call_without_opaque` warnings as master (OTP 28 local-dev noise, unchanged count)

Known pre-existing issues ignored per spec:
- 55 pre-existing `Ecto.Multi` `call_without_opaque` dialyzer warnings (same as PR #89, unchanged after this patch)
- `content_ingestion_worker.ex` 1.18/1.19 formatter divergence (not touched)

Related: builds on the chain-of-custody hardening introduced by PR #89 ("one agent = one role"). This patch is independent and can be merged in either order.

Generated with [Claude Code](https://claude.com/claude-code)
