### PR TITLE
Fix discovery npm_version Docker path resolution

### DIFF
--- a/lib/loopctl_web/controllers/well_known_controller.ex
+++ b/lib/loopctl_web/controllers/well_known_controller.ex
@@ -12,7 +12,10 @@ defmodule LoopctlWeb.WellKnownController do
   @base_url "https://loopctl.com"
 
   # Read the MCP server version from package.json at compile time.
-  @external_resource mcp_package = Path.join([__DIR__, "../../../../mcp-server/package.json"])
+  # Use project root (File.cwd!) rather than __DIR__ traversal — the latter
+  # breaks in Docker where __DIR__ is /app/lib/loopctl_web/controllers and
+  # ../../../../ resolves outside the /app WORKDIR.
+  @external_resource mcp_package = Path.join(File.cwd!(), "mcp-server/package.json")
   @mcp_version (case File.read(mcp_package) do
                   {:ok, contents} ->
                     contents |> Jason.decode!() |> Map.get("version", "0.0.0")


### PR DESCRIPTION
## Summary
- `@external_resource` path used `__DIR__/../../../../` which resolves outside Docker WORKDIR
- Changed to `File.cwd!/0` which resolves to project root in both dev and Docker
- Discovery endpoint will now show `"npm_version": "2.0.1"` instead of `"0.0.0"`

## Test plan
- [x] 2263 tests pass
- [ ] After deploy: `GET /.well-known/loopctl` shows `npm_version: "2.0.1"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)