### PR TITLE
Fix dispatch and verify 500 errors

### DIFF
--- a/lib/loopctl/auth/api_key.ex
+++ b/lib/loopctl/auth/api_key.ex
@@ -47,6 +47,10 @@ defmodule Loopctl.Auth.ApiKey do
     |> validate_required([:name, :role])
     |> validate_inclusion(:role, @roles)
     |> validate_tenant_for_role()
+    |> unique_constraint([:tenant_id, :agent_id],
+      name: :api_keys_one_role_per_agent_idx,
+      message: "agent already has an active key with this role"
+    )
   end
 
   @doc """

--- a/lib/loopctl_web/controllers/story_verification_controller.ex
+++ b/lib/loopctl_web/controllers/story_verification_controller.ex
@@ -156,6 +156,9 @@ defmodule LoopctlWeb.StoryVerificationController do
         {:error, :review_not_conducted} ->
           {:error, :review_not_conducted}
 
+        {:error, :missing_capability} ->
+          {:error, :missing_capability}
+
         {:error, {:invalid_transition, _ctx} = err} ->
           {:error, err}
 
@@ -164,6 +167,9 @@ defmodule LoopctlWeb.StoryVerificationController do
 
         {:error, :not_found} ->
           {:error, :not_found}
+
+        {:error, other} ->
+          {:error, other}
       end
     end
   end


### PR DESCRIPTION
## Summary
Two 500 errors found by the independent verification agent:

- **Dispatch 500**: `POST /dispatches` crashed with `Postgrex.Error` when agent already had an active key (unique constraint `api_keys_one_role_per_agent_idx` not declared in changeset). Now returns 422 with field error.
- **Verify 500**: `POST /stories/:id/verify` crashed with `CaseClauseError` when tenant has audit key but no capability token provided (`:missing_capability` not handled). Added catch-all error propagation to fallback controller.

## Test plan
- [x] 2263 tests pass, dialyzer clean
- [ ] `POST /stories/:id/verify` on verified story → informative error (not 500)
- [ ] `POST /dispatches` with existing agent → 422 (not 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)