### PR TITLE
Fix dispatch 500 and add audit key routes to discovery

### DIFF
--- a/lib/loopctl_web/controllers/dispatch_controller.ex
+++ b/lib/loopctl_web/controllers/dispatch_controller.ex
@@ -7,6 +7,8 @@ defmodule LoopctlWeb.DispatchController do
 
   alias Loopctl.Dispatches
 
+  action_fallback LoopctlWeb.FallbackController
+
   plug LoopctlWeb.Plugs.RequireRole, [role: :orchestrator] when action in [:create]
   plug LoopctlWeb.Plugs.RequireRole, [role: :agent] when action in [:show, :index]
 

--- a/lib/loopctl_web/controllers/route_discovery_controller.ex
+++ b/lib/loopctl_web/controllers/route_discovery_controller.ex
@@ -21,6 +21,21 @@ defmodule LoopctlWeb.RouteDiscoveryController do
         path: "/api/v1/tenants/me",
         description: "Update current tenant (settings.knowledge_auto_extract, etc.)"
       },
+      %{
+        method: "POST",
+        path: "/api/v1/tenants/:id/rotate-audit-key",
+        description: "Rotate tenant audit signing keypair (requires WebAuthn)"
+      },
+      %{
+        method: "POST",
+        path: "/api/v1/tenants/:id/bootstrap-audit-key",
+        description: "Generate initial audit keypair for legacy tenants (user role + ownership)"
+      },
+      %{
+        method: "GET",
+        path: "/api/v1/tenants/:id/audit_public_key",
+        description: "Public endpoint — tenant Ed25519 audit signing public key (PEM or JWK)"
+      },
 
       # API key management
       %{


### PR DESCRIPTION
## Summary
- Dispatch controller was missing `action_fallback` — changeset errors (FK violation on non-existent agent_id) crashed with RuntimeError instead of 422
- Added `rotate-audit-key`, `bootstrap-audit-key`, and `audit_public_key` to the route discovery list (GET /api/v1/routes)

## Test plan
- [x] 2263 tests pass
- [ ] `POST /dispatches` with non-existent agent_id → 422 (not 500)
- [ ] `GET /api/v1/routes` includes bootstrap-audit-key

🤖 Generated with [Claude Code](https://claude.com/claude-code)