### PR TITLE
Fix concurrent article-create race: idempotent on body, 409 on conflict (#113, #114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to loopctl are documented here.
 
+## [Unreleased] — 2026-06-18 — Concurrent article create (PR #116)
+
+### Changed
+
+- `POST /api/v1/articles` (and MCP `knowledge_create`) is now concurrency-safe.
+  A create that races/retries into the `(tenant_id, title)` active unique index
+  no longer returns a spurious `422 "tenant_id has already been taken"`: an
+  **identical-body** collision returns the existing article idempotently as
+  **HTTP 200**, and a **different-body** collision returns **`409 title_conflict`**
+  (with `existing_article_id`) instead of a 422 the client retries into. The
+  unique-violation is attributed to `title` rather than the misleading
+  `tenant_id`. Fixes #113/#114.
+
 ## [Unreleased] — 2026-04-17 — Import merge + agent ergonomics (PR #105)
 
 ### Added

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -148,6 +148,13 @@ defmodule Loopctl.Knowledge do
   # Otherwise it is a genuine different-body title collision ->
   # `{:error, :duplicate_title, existing}` so the API can answer 409 (not a
   # retry-into-the-same-422). Non-(active-title) failures pass through unchanged.
+  #
+  # The recovery SELECT runs after the insert's transaction has rolled back, so
+  # there is a tiny window in which a THIRD writer mutates or archives the winning
+  # row between its commit and our SELECT. That only produces a transient,
+  # self-healing outcome — a 409 (body now differs), or the original 422 (row now
+  # archived → SELECT returns nil) — which the client's next attempt resolves
+  # cleanly. We accept that rather than re-running the whole create under a lock.
   defp resolve_create_conflict(tenant_id, attrs, changeset) do
     title = attrs[:title] || attrs["title"]
 

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -60,11 +60,17 @@ defmodule Loopctl.Knowledge do
 
   ## Returns
 
-  - `{:ok, %Article{}}` on success
-  - `{:error, changeset}` on validation failure
+  - `{:ok, %Article{}}` on success, or idempotently when a concurrent/retried
+    create collides on the active title with the SAME content (matching
+    `url-<hash>` dedupe tag, or source_type + source_id)
+  - `{:error, :duplicate_title, %Article{}}` when the active title is taken by a
+    DIFFERENT-content article (the caller should answer 409, not retry)
+  - `{:error, changeset}` on any other validation failure
   """
   @spec create_article(Ecto.UUID.t(), map(), keyword()) ::
-          {:ok, Article.t()} | {:error, Ecto.Changeset.t()}
+          {:ok, Article.t()}
+          | {:error, :duplicate_title, Article.t()}
+          | {:error, Ecto.Changeset.t()}
   def create_article(tenant_id, attrs, opts \\ []) do
     scope = attrs[:scope] || attrs["scope"] || :tenant
     project_id = attrs[:project_id] || attrs["project_id"]
@@ -118,9 +124,86 @@ defmodule Loopctl.Knowledge do
 
       case AdminRepo.transaction(multi) do
         {:ok, %{article: article}} -> {:ok, article}
-        {:error, :article, changeset, _} -> {:error, changeset}
+        {:error, :article, changeset, _} -> resolve_create_conflict(tenant_id, attrs, changeset)
       end
     end
+  end
+
+  # Make concurrent/retried creates safe on the (tenant_id, title) active unique
+  # index. By the time the insert fails the constraint, the winning transaction
+  # has committed, so the existing row is visible. If the incoming payload is the
+  # SAME content (matching `url-<hash>` dedupe tag, or matching source_type +
+  # source_id), the conflict is a duplicate/retry -> return the existing article
+  # idempotently. Otherwise it is a genuine different-content title collision ->
+  # `{:error, :duplicate_title, existing}` so the API can answer 409 (not a
+  # retry-into-the-same-422). Non-title failures pass through unchanged.
+  defp resolve_create_conflict(tenant_id, attrs, changeset) do
+    title = attrs[:title] || attrs["title"]
+
+    with true <- title_conflict?(changeset),
+         %Article{} = existing <- get_active_article_by_title(tenant_id, title) do
+      if same_content?(existing, attrs) do
+        {:ok, existing}
+      else
+        {:error, :duplicate_title, existing}
+      end
+    else
+      _ -> {:error, changeset}
+    end
+  end
+
+  @title_conflict_constraints ~w(articles_tenant_title_active_idx
+                                 articles_tenant_slug_idx
+                                 articles_system_slug_idx)
+  defp title_conflict?(%Ecto.Changeset{errors: errors}) do
+    Enum.any?(errors, fn {_field, {_msg, opts}} ->
+      Keyword.get(opts, :constraint) == :unique and
+        Keyword.get(opts, :constraint_name) in @title_conflict_constraints
+    end)
+  end
+
+  defp get_active_article_by_title(_tenant_id, title) when not is_binary(title), do: nil
+
+  defp get_active_article_by_title(tenant_id, title) do
+    AdminRepo.one(
+      from(a in Article,
+        where:
+          a.tenant_id == ^tenant_id and a.title == ^title and
+            a.status not in [:archived, :superseded],
+        order_by: [asc: a.inserted_at],
+        limit: 1
+      )
+    )
+  end
+
+  @dedupe_tag_pattern ~r/^url-[0-9a-f]+$/
+
+  # Two payloads describe the same content when they share a content-hash dedupe
+  # tag (`url-<hash>`), or carry the same non-nil (source_type, source_id).
+  defp same_content?(existing, attrs) do
+    dedupe_tag_match?(existing, attrs) or source_match?(existing, attrs)
+  end
+
+  defp dedupe_tag_match?(existing, attrs) do
+    incoming = dedupe_tags(attrs[:tags] || attrs["tags"] || [])
+
+    incoming != [] and
+      not MapSet.disjoint?(MapSet.new(incoming), MapSet.new(dedupe_tags(existing.tags)))
+  end
+
+  defp dedupe_tags(tags) when is_list(tags) do
+    Enum.filter(tags, fn t -> is_binary(t) and Regex.match?(@dedupe_tag_pattern, t) end)
+  end
+
+  defp dedupe_tags(_), do: []
+
+  defp source_match?(existing, attrs) do
+    st = attrs[:source_type] || attrs["source_type"]
+    sid = attrs[:source_id] || attrs["source_id"]
+
+    not is_nil(st) and not is_nil(sid) and existing.source_id != nil and
+      to_string(existing.source_type) == to_string(st) and
+      to_string(existing.source_id) == to_string(sid)
   end
 
   @doc """

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -60,15 +60,19 @@ defmodule Loopctl.Knowledge do
 
   ## Returns
 
-  - `{:ok, %Article{}}` on success, or idempotently when a concurrent/retried
-    create collides on the active title and the incoming body is byte-identical
-    (whitespace-normalized) to the existing article's
+  - `{:ok, %Article{}}` on a fresh create
+  - `{:ok, :deduplicated, %Article{}}` when a concurrent/retried create collided
+    on the active title and the incoming body is identical to the existing
+    article's after trimming leading/trailing whitespace — the existing row is
+    returned unchanged (this is a no-op: no second audit/webhook/embedding), so
+    callers can answer HTTP 200 rather than 201
   - `{:error, :duplicate_title, %Article{}}` when the active title is taken by an
-    article with DIFFERENT body content (the caller should answer 409, not retry)
+    article with a DIFFERENT body (the caller should answer 409, not retry)
   - `{:error, changeset}` on any other validation failure
   """
   @spec create_article(Ecto.UUID.t(), map(), keyword()) ::
           {:ok, Article.t()}
+          | {:ok, :deduplicated, Article.t()}
           | {:error, :duplicate_title, Article.t()}
           | {:error, Ecto.Changeset.t()}
   def create_article(tenant_id, attrs, opts \\ []) do
@@ -134,11 +138,14 @@ defmodule Loopctl.Knowledge do
 
   # Make concurrent/retried creates safe on the (tenant_id, title) active unique
   # index. By the time the insert fails the constraint, the winning transaction
-  # has committed, so the existing row is visible. The idempotency signal is the
-  # article BODY itself (server-side, unforgeable): if the colliding payload's
-  # body is byte-identical (whitespace-normalized) to the existing article's, the
-  # conflict is a duplicate/retry -> return the existing article idempotently.
-  # Otherwise it is a genuine different-content title collision ->
+  # has committed, so the existing row is visible (the recovery SELECT below
+  # deliberately mirrors the partial index's predicate, so the conflicting row is
+  # guaranteed visible unless it was concurrently archived). The idempotency
+  # signal is the article BODY itself (server-side, unforgeable): if the colliding
+  # payload's body equals the existing article's (after trimming leading/trailing
+  # whitespace), the conflict is a duplicate/retry -> return the existing row
+  # idempotently as `{:ok, :deduplicated, existing}` (a no-op the API answers 200).
+  # Otherwise it is a genuine different-body title collision ->
   # `{:error, :duplicate_title, existing}` so the API can answer 409 (not a
   # retry-into-the-same-422). Non-(active-title) failures pass through unchanged.
   defp resolve_create_conflict(tenant_id, attrs, changeset) do
@@ -147,7 +154,7 @@ defmodule Loopctl.Knowledge do
     with true <- active_title_conflict?(changeset),
          %Article{} = existing <- get_active_article_by_title(tenant_id, title) do
       if same_content?(existing, attrs) do
-        {:ok, existing}
+        {:ok, :deduplicated, existing}
       else
         {:error, :duplicate_title, existing}
       end

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -61,10 +61,10 @@ defmodule Loopctl.Knowledge do
   ## Returns
 
   - `{:ok, %Article{}}` on success, or idempotently when a concurrent/retried
-    create collides on the active title with the SAME content (matching
-    `url-<hash>` dedupe tag, or source_type + source_id)
-  - `{:error, :duplicate_title, %Article{}}` when the active title is taken by a
-    DIFFERENT-content article (the caller should answer 409, not retry)
+    create collides on the active title and the incoming body is byte-identical
+    (whitespace-normalized) to the existing article's
+  - `{:error, :duplicate_title, %Article{}}` when the active title is taken by an
+    article with DIFFERENT body content (the caller should answer 409, not retry)
   - `{:error, changeset}` on any other validation failure
   """
   @spec create_article(Ecto.UUID.t(), map(), keyword()) ::
@@ -123,24 +123,28 @@ defmodule Loopctl.Knowledge do
         |> maybe_enqueue_embedding(tenant_id, needs_embedding?)
 
       case AdminRepo.transaction(multi) do
-        {:ok, %{article: article}} -> {:ok, article}
-        {:error, :article, changeset, _} -> resolve_create_conflict(tenant_id, attrs, changeset)
+        {:ok, %{article: article}} ->
+          {:ok, article}
+
+        {:error, :article, changeset, _} ->
+          resolve_create_conflict(effective_tenant_id, attrs, changeset)
       end
     end
   end
 
   # Make concurrent/retried creates safe on the (tenant_id, title) active unique
   # index. By the time the insert fails the constraint, the winning transaction
-  # has committed, so the existing row is visible. If the incoming payload is the
-  # SAME content (matching `url-<hash>` dedupe tag, or matching source_type +
-  # source_id), the conflict is a duplicate/retry -> return the existing article
-  # idempotently. Otherwise it is a genuine different-content title collision ->
+  # has committed, so the existing row is visible. The idempotency signal is the
+  # article BODY itself (server-side, unforgeable): if the colliding payload's
+  # body is byte-identical (whitespace-normalized) to the existing article's, the
+  # conflict is a duplicate/retry -> return the existing article idempotently.
+  # Otherwise it is a genuine different-content title collision ->
   # `{:error, :duplicate_title, existing}` so the API can answer 409 (not a
-  # retry-into-the-same-422). Non-title failures pass through unchanged.
+  # retry-into-the-same-422). Non-(active-title) failures pass through unchanged.
   defp resolve_create_conflict(tenant_id, attrs, changeset) do
     title = attrs[:title] || attrs["title"]
 
-    with true <- title_conflict?(changeset),
+    with true <- active_title_conflict?(changeset),
          %Article{} = existing <- get_active_article_by_title(tenant_id, title) do
       if same_content?(existing, attrs) do
         {:ok, existing}
@@ -152,17 +156,20 @@ defmodule Loopctl.Knowledge do
     end
   end
 
-  @title_conflict_constraints ~w(articles_tenant_title_active_idx
-                                 articles_tenant_slug_idx
-                                 articles_system_slug_idx)
-  defp title_conflict?(%Ecto.Changeset{errors: errors}) do
+  # Only the active-title index — NOT the slug indexes, whose conflicts are on a
+  # different field and must not be recovered via a title lookup.
+  defp active_title_conflict?(%Ecto.Changeset{errors: errors}) do
     Enum.any?(errors, fn {_field, {_msg, opts}} ->
       Keyword.get(opts, :constraint) == :unique and
-        Keyword.get(opts, :constraint_name) in @title_conflict_constraints
+        Keyword.get(opts, :constraint_name) == "articles_tenant_title_active_idx"
     end)
   end
 
   defp get_active_article_by_title(_tenant_id, title) when not is_binary(title), do: nil
+
+  # tenant_id is nil for system-scoped articles; a NULL `=` never matches, so the
+  # recovery simply doesn't apply to system scope (its conflicts are slug-based).
+  defp get_active_article_by_title(nil, _title), do: nil
 
   defp get_active_article_by_title(tenant_id, title) do
     AdminRepo.one(
@@ -176,34 +183,14 @@ defmodule Loopctl.Knowledge do
     )
   end
 
-  @dedupe_tag_pattern ~r/^url-[0-9a-f]+$/
-
-  # Two payloads describe the same content when they share a content-hash dedupe
-  # tag (`url-<hash>`), or carry the same non-nil (source_type, source_id).
+  # Same content == same (whitespace-normalized) body. Derived server-side from
+  # the actual content, so a caller cannot forge a match to alias/read back a
+  # different article, and two genuinely-different bodies never silently merge.
   defp same_content?(existing, attrs) do
-    dedupe_tag_match?(existing, attrs) or source_match?(existing, attrs)
-  end
+    incoming = attrs[:body] || attrs["body"]
 
-  defp dedupe_tag_match?(existing, attrs) do
-    incoming = dedupe_tags(attrs[:tags] || attrs["tags"] || [])
-
-    incoming != [] and
-      not MapSet.disjoint?(MapSet.new(incoming), MapSet.new(dedupe_tags(existing.tags)))
-  end
-
-  defp dedupe_tags(tags) when is_list(tags) do
-    Enum.filter(tags, fn t -> is_binary(t) and Regex.match?(@dedupe_tag_pattern, t) end)
-  end
-
-  defp dedupe_tags(_), do: []
-
-  defp source_match?(existing, attrs) do
-    st = attrs[:source_type] || attrs["source_type"]
-    sid = attrs[:source_id] || attrs["source_id"]
-
-    not is_nil(st) and not is_nil(sid) and existing.source_id != nil and
-      to_string(existing.source_type) == to_string(st) and
-      to_string(existing.source_id) == to_string(sid)
+    is_binary(incoming) and is_binary(existing.body) and
+      String.trim(incoming) == String.trim(existing.body)
   end
 
   @doc """

--- a/lib/loopctl/knowledge/article.ex
+++ b/lib/loopctl/knowledge/article.ex
@@ -93,9 +93,9 @@ defmodule Loopctl.Knowledge.Article do
     |> validate_metadata()
     |> maybe_generate_slug()
     |> foreign_key_constraint(:project_id)
-    |> unique_constraint([:tenant_id, :title],
+    |> unique_constraint(:title,
       name: :articles_tenant_title_active_idx,
-      message: "has already been taken for this tenant"
+      message: "is already taken in this tenant"
     )
     |> unique_constraint(:slug,
       name: :articles_system_slug_idx,
@@ -123,9 +123,9 @@ defmodule Loopctl.Knowledge.Article do
     |> validate_tags()
     |> validate_metadata()
     |> foreign_key_constraint(:project_id)
-    |> unique_constraint([:tenant_id, :title],
+    |> unique_constraint(:title,
       name: :articles_tenant_title_active_idx,
-      message: "has already been taken for this tenant"
+      message: "is already taken in this tenant"
     )
     |> unique_constraint(:slug,
       name: :articles_system_slug_idx,

--- a/lib/loopctl/knowledge/okf.ex
+++ b/lib/loopctl/knowledge/okf.ex
@@ -490,6 +490,13 @@ defmodule Loopctl.Knowledge.OKF do
       {:ok, article} ->
         acc |> bump(:created) |> index_path(path, article.id)
 
+      # A concurrent/duplicate title with different content (the importer already
+      # resolves same-title merges up front, so this is a race or a foreign
+      # collision) — skip rather than crash, but index the existing article so
+      # link reconstruction can still resolve this path.
+      {:error, :duplicate_title, existing} ->
+        acc |> bump(:skipped) |> index_path(path, existing.id)
+
       {:error, changeset} ->
         record_error(acc, path, changeset_error(changeset))
     end

--- a/lib/loopctl/knowledge/okf.ex
+++ b/lib/loopctl/knowledge/okf.ex
@@ -490,12 +490,12 @@ defmodule Loopctl.Knowledge.OKF do
       {:ok, article} ->
         acc |> bump(:created) |> index_path(path, article.id)
 
-      # A concurrent/duplicate title with different content (the importer already
-      # resolves same-title merges up front, so this is a race or a foreign
-      # collision) — skip rather than crash, but index the existing article so
-      # link reconstruction can still resolve this path.
+      # A concurrent/duplicate title with DIFFERENT content (the importer resolves
+      # same-title merges up front, so this is a race or a foreign collision).
+      # Report it as a conflict; do NOT index the unrelated existing article for
+      # this path, which would mis-point link reconstruction.
       {:error, :duplicate_title, existing} ->
-        acc |> bump(:skipped) |> index_path(path, existing.id)
+        record_error(acc, path, "title conflict with existing article #{existing.id}")
 
       {:error, changeset} ->
         record_error(acc, path, changeset_error(changeset))

--- a/lib/loopctl/knowledge/okf.ex
+++ b/lib/loopctl/knowledge/okf.ex
@@ -362,9 +362,10 @@ defmodule Loopctl.Knowledge.OKF do
 
   The import is non-atomic (per-file) and runs synchronously; it is bounded by
   the concept cap above. Concurrent imports of the same bundle are serialized by
-  the `(tenant_id, title)` active unique index rather than an advisory lock, so a
-  rare double-submit surfaces a reported skip (`partial?: true`) instead of a
-  duplicate.
+  `create_article`'s active-title conflict resolution: an identical-body race is
+  absorbed idempotently (counted under `:skipped`), and a different-body title
+  collision is reported (`:skipped` + an `errors` entry, `partial?: true`) — never
+  a duplicate.
   """
   @spec import_files(Ecto.UUID.t(), files(), keyword()) ::
           {:ok, map()} | {:error, :too_many_concepts}
@@ -489,6 +490,11 @@ defmodule Loopctl.Knowledge.OKF do
     case Knowledge.create_article(tenant_id, attrs, acc.audit_opts) do
       {:ok, article} ->
         acc |> bump(:created) |> index_path(path, article.id)
+
+      # A concurrent create that resolved to an existing identical-body article —
+      # a no-op; index it so link reconstruction resolves this path.
+      {:ok, :deduplicated, existing} ->
+        acc |> bump(:skipped) |> index_path(path, existing.id)
 
       # A concurrent/duplicate title with DIFFERENT content (the importer resolves
       # same-title merges up front, so this is a race or a foreign collision).

--- a/lib/loopctl_web/controllers/article_controller.ex
+++ b/lib/loopctl_web/controllers/article_controller.ex
@@ -175,6 +175,21 @@ defmodule LoopctlWeb.ArticleController do
           |> put_status(:created)
           |> json(ArticleJSON.create(%{article: article}))
 
+        {:error, :duplicate_title, existing} ->
+          conn
+          |> put_status(:conflict)
+          |> json(%{
+            error: %{
+              status: 409,
+              code: "title_conflict",
+              message:
+                "An article titled \"#{existing.title}\" already exists in this tenant. " <>
+                  "Use a different title, or include the existing article's dedupe tag " <>
+                  "(url-<hash>) / source_type+source_id to update it idempotently.",
+              details: %{existing_article_id: existing.id}
+            }
+          })
+
         {:error, %Ecto.Changeset{} = changeset} ->
           {:error, changeset}
       end

--- a/lib/loopctl_web/controllers/article_controller.ex
+++ b/lib/loopctl_web/controllers/article_controller.ex
@@ -175,6 +175,13 @@ defmodule LoopctlWeb.ArticleController do
           |> put_status(:created)
           |> json(ArticleJSON.create(%{article: article}))
 
+        # Idempotent: a concurrent/retried create with an identical body. 200 (not
+        # 201) lets clients/observers distinguish a real create from a no-op dedup.
+        {:ok, :deduplicated, existing} ->
+          conn
+          |> put_status(:ok)
+          |> json(ArticleJSON.create(%{article: existing}))
+
         {:error, :duplicate_title, existing} ->
           conn
           |> put_status(:conflict)
@@ -183,9 +190,9 @@ defmodule LoopctlWeb.ArticleController do
               status: 409,
               code: "title_conflict",
               message:
-                "An article titled \"#{existing.title}\" already exists in this tenant. " <>
-                  "Use a different title, or include the existing article's dedupe tag " <>
-                  "(url-<hash>) / source_type+source_id to update it idempotently.",
+                "An article titled \"#{existing.title}\" already exists in this tenant " <>
+                  "with different content. Choose a different title, or update the existing " <>
+                  "article directly via PATCH /articles/#{existing.id}.",
               details: %{existing_article_id: existing.id}
             }
           })

--- a/lib/loopctl_web/controllers/article_controller.ex
+++ b/lib/loopctl_web/controllers/article_controller.ex
@@ -64,6 +64,13 @@ defmodule LoopctlWeb.ArticleController do
       201 =>
         {"Article created", "application/json",
          %OpenApiSpex.Schema{type: :object, additionalProperties: true}},
+      200 =>
+        {"Idempotent: an active article with the same title and an identical body " <>
+           "already exists; it is returned unchanged with `deduplicated: true`.",
+         "application/json", %OpenApiSpex.Schema{type: :object, additionalProperties: true}},
+      409 =>
+        {"Title taken by an article with different content", "application/json",
+         Schemas.ErrorResponse},
       422 => {"Validation error", "application/json", Schemas.ErrorResponse},
       429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
     }
@@ -176,11 +183,13 @@ defmodule LoopctlWeb.ArticleController do
           |> json(ArticleJSON.create(%{article: article}))
 
         # Idempotent: a concurrent/retried create with an identical body. 200 (not
-        # 201) lets clients/observers distinguish a real create from a no-op dedup.
+        # 201), plus an explicit `deduplicated: true` flag in the body so clients
+        # that only see a 2xx (e.g. the MCP layer) can still tell a dedup from a
+        # real create.
         {:ok, :deduplicated, existing} ->
           conn
           |> put_status(:ok)
-          |> json(ArticleJSON.create(%{article: existing}))
+          |> json(Map.put(ArticleJSON.create(%{article: existing}), :deduplicated, true))
 
         {:error, :duplicate_title, existing} ->
           conn
@@ -191,8 +200,8 @@ defmodule LoopctlWeb.ArticleController do
               code: "title_conflict",
               message:
                 "An article titled \"#{existing.title}\" already exists in this tenant " <>
-                  "with different content. Choose a different title, or update the existing " <>
-                  "article directly via PATCH /articles/#{existing.id}.",
+                  "with different content. Choose a different (more specific) title. " <>
+                  "(Editing the existing article requires role :user via PATCH /articles/:id.)",
               details: %{existing_article_id: existing.id}
             }
           })

--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -12,9 +12,10 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - `knowledge_create` (and the underlying `POST /articles`) is now concurrency-
   safe. A create that races/retries into the `(tenant_id, title)` active unique
   index no longer returns a spurious `422 "tenant_id has already been taken"`:
-  if the colliding payload has a **byte-identical body** (the unforgeable
-  server-side content signal) the existing article is returned idempotently; a
-  **different-body** same-title collision returns a clear `409 title_conflict`
+  if the colliding payload has an **identical body** (ignoring surrounding
+  whitespace — the unforgeable server-side content signal) the existing article
+  is returned idempotently (HTTP 200); a **different-body** same-title collision
+  returns a clear `409 title_conflict`
   (with the existing article id) instead of a 422 the client retries into. The
   unique-violation message is also corrected to be attributed to `title` rather
   than the misleading `tenant_id`. Fixes #113/#114.

--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to `loopctl-mcp-server` are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 2.4.1 — 2026-06-18 (Concurrency-safe article create)
+
+### Changed
+
+- `knowledge_create` (and the underlying `POST /articles`) is now concurrency-
+  safe. A create that races/retries into the `(tenant_id, title)` active unique
+  index no longer returns a spurious `422 "tenant_id has already been taken"`:
+  if the colliding payload is the **same content** (a matching `url-<hash>`
+  dedupe tag, or the same `source_type`+`source_id`) the existing article is
+  returned idempotently; a **different-content** same-title collision returns a
+  clear `409 title_conflict` (with the existing article id) instead of a 422 the
+  client retries into. The unique-violation message is also corrected to be
+  attributed to `title` rather than the misleading `tenant_id`. Fixes #113/#114.
+
 ## 2.4.0 — 2026-06-18 (OKF interchange)
 
 ### Added

--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -12,12 +12,12 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - `knowledge_create` (and the underlying `POST /articles`) is now concurrency-
   safe. A create that races/retries into the `(tenant_id, title)` active unique
   index no longer returns a spurious `422 "tenant_id has already been taken"`:
-  if the colliding payload is the **same content** (a matching `url-<hash>`
-  dedupe tag, or the same `source_type`+`source_id`) the existing article is
-  returned idempotently; a **different-content** same-title collision returns a
-  clear `409 title_conflict` (with the existing article id) instead of a 422 the
-  client retries into. The unique-violation message is also corrected to be
-  attributed to `title` rather than the misleading `tenant_id`. Fixes #113/#114.
+  if the colliding payload has a **byte-identical body** (the unforgeable
+  server-side content signal) the existing article is returned idempotently; a
+  **different-body** same-title collision returns a clear `409 title_conflict`
+  (with the existing article id) instead of a 422 the client retries into. The
+  unique-violation message is also corrected to be attributed to `title` rather
+  than the misleading `tenant_id`. Fixes #113/#114.
 
 ## 2.4.0 — 2026-06-18 (OKF interchange)
 

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -1853,10 +1853,9 @@ const TOOLS = [
     description:
       "Create a new knowledge article. Use to file findings, document patterns, or record decisions " +
       "discovered during implementation. Concurrency-safe: if a create races/retries against an " +
-      "existing article with the same title AND the same content signal (a url-<hash> dedupe tag, or " +
-      "matching source_type+source_id), the server returns the existing article idempotently instead " +
-      "of a 422. A same-title create with DIFFERENT content returns 409 title_conflict (do not retry — " +
-      "rename, or reuse the dedupe tag to update).",
+      "existing article with the same title AND a byte-identical body, the server returns the existing " +
+      "article idempotently instead of a 422. A same-title create with a DIFFERENT body returns 409 " +
+      "title_conflict (do not retry — rename, or update the existing article instead).",
     inputSchema: {
       type: "object",
       properties: {

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -1852,7 +1852,11 @@ const TOOLS = [
     name: "knowledge_create",
     description:
       "Create a new knowledge article. Use to file findings, document patterns, or record decisions " +
-      "discovered during implementation.",
+      "discovered during implementation. Concurrency-safe: if a create races/retries against an " +
+      "existing article with the same title AND the same content signal (a url-<hash> dedupe tag, or " +
+      "matching source_type+source_id), the server returns the existing article idempotently instead " +
+      "of a 422. A same-title create with DIFFERENT content returns 409 title_conflict (do not retry — " +
+      "rename, or reuse the dedupe tag to update).",
     inputSchema: {
       type: "object",
       properties: {

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -1853,9 +1853,10 @@ const TOOLS = [
     description:
       "Create a new knowledge article. Use to file findings, document patterns, or record decisions " +
       "discovered during implementation. Concurrency-safe: if a create races/retries against an " +
-      "existing article with the same title AND a byte-identical body, the server returns the existing " +
-      "article idempotently instead of a 422. A same-title create with a DIFFERENT body returns 409 " +
-      "title_conflict (do not retry — rename, or update the existing article instead).",
+      "existing article with the same title AND an identical body (ignoring surrounding whitespace), the " +
+      "server returns that existing article idempotently (HTTP 200) instead of a 422. A same-title create " +
+      "with a DIFFERENT body returns 409 title_conflict — do not retry; choose a different title or PATCH " +
+      "the existing article.",
     inputSchema: {
       type: "object",
       properties: {

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "MCP server for loopctl — structural trust for AI development loops",
   "type": "module",
   "main": "index.js",

--- a/test/loopctl/knowledge/article_test.exs
+++ b/test/loopctl/knowledge/article_test.exs
@@ -426,7 +426,11 @@ defmodule Loopctl.Knowledge.ArticleTest do
         |> Article.create_changeset(%{attrs | body: "Second body"})
 
       assert {:error, changeset} = Loopctl.AdminRepo.insert(changeset2)
-      assert errors_on(changeset)[:tenant_id]
+      # The active-title unique violation is now attributed to :title (not the
+      # misleading :tenant_id), with a clear message.
+      assert errors_on(changeset)[:title]
+      assert "is already taken in this tenant" in errors_on(changeset)[:title]
+      refute errors_on(changeset)[:tenant_id]
     end
 
     test "allows same title across different tenants" do

--- a/test/loopctl/knowledge_test.exs
+++ b/test/loopctl/knowledge_test.exs
@@ -113,9 +113,9 @@ defmodule Loopctl.KnowledgeTest do
       attrs = %{title: "Captured Note", body: "  the same body\n", category: :reference}
 
       assert {:ok, first} = Knowledge.create_article(tenant.id, attrs)
-      # A retry/concurrent duplicate of the same content returns the same row,
-      # even with cosmetic whitespace differences and unrelated tag changes.
-      assert {:ok, second} =
+      # A retry/concurrent duplicate of the same content returns the same row
+      # (tagged :deduplicated), even with cosmetic whitespace and tag changes.
+      assert {:ok, :deduplicated, second} =
                Knowledge.create_article(
                  tenant.id,
                  %{attrs | body: "the same body"} |> Map.put(:tags, ["extra"])

--- a/test/loopctl/knowledge_test.exs
+++ b/test/loopctl/knowledge_test.exs
@@ -107,41 +107,25 @@ defmodule Loopctl.KnowledgeTest do
   end
 
   describe "create_article/3 concurrent-title conflict resolution (#113/#114)" do
-    test "idempotently returns the existing article when a url-<hash> dedupe tag matches" do
+    test "idempotently returns the existing article when the body is identical" do
       %{tenant: tenant} = setup_tenant()
 
-      attrs = %{
-        title: "Same Source Note",
-        body: "v1",
-        category: :reference,
-        tags: ["url-abc123", "hub"]
-      }
+      attrs = %{title: "Captured Note", body: "  the same body\n", category: :reference}
 
       assert {:ok, first} = Knowledge.create_article(tenant.id, attrs)
-      # A retry/concurrent duplicate of the same content returns the same row.
-      assert {:ok, second} = Knowledge.create_article(tenant.id, Map.put(attrs, :body, "v2"))
+      # A retry/concurrent duplicate of the same content returns the same row,
+      # even with cosmetic whitespace differences and unrelated tag changes.
+      assert {:ok, second} =
+               Knowledge.create_article(
+                 tenant.id,
+                 %{attrs | body: "the same body"} |> Map.put(:tags, ["extra"])
+               )
+
       assert second.id == first.id
-      assert second.body == "v1", "idempotent return does not overwrite the existing article"
+      assert second.body == "  the same body\n", "idempotent return does not overwrite the row"
     end
 
-    test "idempotently returns the existing article when source_type + source_id match" do
-      %{tenant: tenant} = setup_tenant()
-      sid = Ecto.UUID.generate()
-
-      attrs = %{
-        title: "Sourced Note",
-        body: "body",
-        category: :finding,
-        source_type: "web_article",
-        source_id: sid
-      }
-
-      assert {:ok, first} = Knowledge.create_article(tenant.id, attrs)
-      assert {:ok, second} = Knowledge.create_article(tenant.id, attrs)
-      assert second.id == first.id
-    end
-
-    test "returns {:error, :duplicate_title, existing} when content differs (no dedupe signal)" do
+    test "returns {:error, :duplicate_title, existing} when the body differs" do
       %{tenant: tenant} = setup_tenant()
 
       assert {:ok, existing} =

--- a/test/loopctl/knowledge_test.exs
+++ b/test/loopctl/knowledge_test.exs
@@ -106,6 +106,79 @@ defmodule Loopctl.KnowledgeTest do
     end
   end
 
+  describe "create_article/3 concurrent-title conflict resolution (#113/#114)" do
+    test "idempotently returns the existing article when a url-<hash> dedupe tag matches" do
+      %{tenant: tenant} = setup_tenant()
+
+      attrs = %{
+        title: "Same Source Note",
+        body: "v1",
+        category: :reference,
+        tags: ["url-abc123", "hub"]
+      }
+
+      assert {:ok, first} = Knowledge.create_article(tenant.id, attrs)
+      # A retry/concurrent duplicate of the same content returns the same row.
+      assert {:ok, second} = Knowledge.create_article(tenant.id, Map.put(attrs, :body, "v2"))
+      assert second.id == first.id
+      assert second.body == "v1", "idempotent return does not overwrite the existing article"
+    end
+
+    test "idempotently returns the existing article when source_type + source_id match" do
+      %{tenant: tenant} = setup_tenant()
+      sid = Ecto.UUID.generate()
+
+      attrs = %{
+        title: "Sourced Note",
+        body: "body",
+        category: :finding,
+        source_type: "web_article",
+        source_id: sid
+      }
+
+      assert {:ok, first} = Knowledge.create_article(tenant.id, attrs)
+      assert {:ok, second} = Knowledge.create_article(tenant.id, attrs)
+      assert second.id == first.id
+    end
+
+    test "returns {:error, :duplicate_title, existing} when content differs (no dedupe signal)" do
+      %{tenant: tenant} = setup_tenant()
+
+      assert {:ok, existing} =
+               Knowledge.create_article(tenant.id, %{
+                 title: "Unique Title",
+                 body: "original",
+                 category: :pattern
+               })
+
+      assert {:error, :duplicate_title, returned} =
+               Knowledge.create_article(tenant.id, %{
+                 title: "Unique Title",
+                 body: "different content",
+                 category: :convention
+               })
+
+      assert returned.id == existing.id
+      # The existing article is untouched.
+      {:ok, reloaded} = Knowledge.get_article(tenant.id, existing.id)
+      assert reloaded.body == "original"
+      assert reloaded.category == :pattern
+    end
+
+    test "the active-title unique constraint is attributed to :title, not :tenant_id" do
+      changeset =
+        Article.create_changeset(%Article{}, %{title: "x", body: "b", category: :pattern})
+
+      assert Enum.any?(changeset.constraints, fn c ->
+               c.field == :title and c.constraint == "articles_tenant_title_active_idx"
+             end)
+
+      refute Enum.any?(changeset.constraints, fn c ->
+               c.field == :tenant_id and c.constraint == "articles_tenant_title_active_idx"
+             end)
+    end
+  end
+
   # --- TC-19.3.2: List with tag overlap filtering ---
 
   describe "list_articles/2 tag filtering" do

--- a/test/loopctl_web/controllers/article_controller_test.exs
+++ b/test/loopctl_web/controllers/article_controller_test.exs
@@ -47,6 +47,60 @@ defmodule LoopctlWeb.ArticleControllerTest do
       assert body["error"]["status"] == 422
       assert body["error"]["details"]["title"] != nil
     end
+
+    test "duplicate title with the same dedupe tag is idempotent (201, same id)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      payload = %{
+        "title" => "Captured Video",
+        "body" => "v1",
+        "category" => "reference",
+        "tags" => ["url-deadbeef", "hub"]
+      }
+
+      first = conn |> auth_conn(raw_key) |> post(~p"/api/v1/articles", payload)
+      first_id = json_response(first, 201)["data"]["id"]
+
+      # A concurrent/retried publish of the same source returns the same row.
+      second =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/articles", Map.put(payload, "body", "v2"))
+
+      assert json_response(second, 201)["data"]["id"] == first_id
+    end
+
+    test "duplicate title with different content returns a clear 409 (not a retried 422)", %{
+      conn: conn
+    } do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      _first =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/articles", %{
+          "title" => "Shared Heading",
+          "body" => "first",
+          "category" => "pattern"
+        })
+        |> json_response(201)
+
+      second =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/articles", %{
+          "title" => "Shared Heading",
+          "body" => "second",
+          "category" => "convention"
+        })
+
+      body = json_response(second, 409)
+      assert body["error"]["status"] == 409
+      assert body["error"]["code"] == "title_conflict"
+      assert body["error"]["details"]["existing_article_id"]
+    end
   end
 
   describe "POST /api/v1/projects/:project_id/articles" do

--- a/test/loopctl_web/controllers/article_controller_test.exs
+++ b/test/loopctl_web/controllers/article_controller_test.exs
@@ -60,12 +60,17 @@ defmodule LoopctlWeb.ArticleControllerTest do
       }
 
       first = conn |> auth_conn(raw_key) |> post(~p"/api/v1/articles", payload)
-      first_id = json_response(first, 201)["data"]["id"]
+      first_body = json_response(first, 201)
+      first_id = first_body["data"]["id"]
+      refute first_body["deduplicated"]
 
       # A concurrent/retried publish of the same content returns the same row with
-      # a 200 (not 201), so callers/observers can distinguish a dedup from a create.
+      # a 200 (not 201) AND deduplicated: true, so callers/observers (incl. the MCP
+      # layer that only sees a 2xx) can distinguish a dedup from a create.
       second = conn |> auth_conn(raw_key) |> post(~p"/api/v1/articles", payload)
-      assert json_response(second, 200)["data"]["id"] == first_id
+      second_body = json_response(second, 200)
+      assert second_body["data"]["id"] == first_id
+      assert second_body["deduplicated"] == true
     end
 
     test "duplicate title with different content returns a clear 409 (not a retried 422)", %{

--- a/test/loopctl_web/controllers/article_controller_test.exs
+++ b/test/loopctl_web/controllers/article_controller_test.exs
@@ -48,26 +48,22 @@ defmodule LoopctlWeb.ArticleControllerTest do
       assert body["error"]["details"]["title"] != nil
     end
 
-    test "duplicate title with the same dedupe tag is idempotent (201, same id)", %{conn: conn} do
+    test "duplicate title with an identical body is idempotent (201, same id)", %{conn: conn} do
       tenant = fixture(:tenant)
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
 
       payload = %{
         "title" => "Captured Video",
-        "body" => "v1",
+        "body" => "the captured summary",
         "category" => "reference",
-        "tags" => ["url-deadbeef", "hub"]
+        "tags" => ["hub"]
       }
 
       first = conn |> auth_conn(raw_key) |> post(~p"/api/v1/articles", payload)
       first_id = json_response(first, 201)["data"]["id"]
 
-      # A concurrent/retried publish of the same source returns the same row.
-      second =
-        conn
-        |> auth_conn(raw_key)
-        |> post(~p"/api/v1/articles", Map.put(payload, "body", "v2"))
-
+      # A concurrent/retried publish of the same content returns the same row.
+      second = conn |> auth_conn(raw_key) |> post(~p"/api/v1/articles", payload)
       assert json_response(second, 201)["data"]["id"] == first_id
     end
 

--- a/test/loopctl_web/controllers/article_controller_test.exs
+++ b/test/loopctl_web/controllers/article_controller_test.exs
@@ -48,7 +48,7 @@ defmodule LoopctlWeb.ArticleControllerTest do
       assert body["error"]["details"]["title"] != nil
     end
 
-    test "duplicate title with an identical body is idempotent (201, same id)", %{conn: conn} do
+    test "duplicate title with an identical body is idempotent (200, same id)", %{conn: conn} do
       tenant = fixture(:tenant)
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
 
@@ -62,9 +62,10 @@ defmodule LoopctlWeb.ArticleControllerTest do
       first = conn |> auth_conn(raw_key) |> post(~p"/api/v1/articles", payload)
       first_id = json_response(first, 201)["data"]["id"]
 
-      # A concurrent/retried publish of the same content returns the same row.
+      # A concurrent/retried publish of the same content returns the same row with
+      # a 200 (not 201), so callers/observers can distinguish a dedup from a create.
       second = conn |> auth_conn(raw_key) |> post(~p"/api/v1/articles", payload)
-      assert json_response(second, 201)["data"]["id"] == first_id
+      assert json_response(second, 200)["data"]["id"] == first_id
     end
 
     test "duplicate title with different content returns a clear 409 (not a retried 422)", %{


### PR DESCRIPTION
Closes #113, closes #114 (duplicate issues for the same write-concurrency race).

## Problem
Concurrent/retried `create_article` calls to the same tenant intermittently failed with `422 "tenant_id has already been taken for this tenant"` (1-in-~224 during multi-agent harvests). Root cause: two writers racing on the `(tenant_id, title)` active partial unique index. The `tenant_id` in the message was just the first field of the composite constraint — **not** a per-article tenant-uniqueness bug.

## Fix
`Knowledge.create_article/3` now resolves the active-title conflict instead of surfacing a raw 422:
- **Same content → idempotent.** If the colliding payload's **body is byte-identical** (whitespace-normalized) to the existing article's, return `{:ok, existing}` — a retry/concurrent duplicate succeeds without duplicating or overwriting. The signal is the server-side body itself: **unforgeable** (you can't make the server think different content is the same), no false merges, and no information disclosure (you only get the idempotent return if you already hold the identical body).
- **Different body → clear 409.** `{:error, :duplicate_title, existing}` → `409 title_conflict` (with `existing_article_id`), so clients stop retrying into the same error.
- The unique-violation is now attributed to **`:title`** ("is already taken in this tenant"), not the misleading `:tenant_id`.

By the time the insert fails the constraint the winning transaction has committed, so the existing row is visible (the find-or-return race pattern). Covers the MCP path too (`knowledge_create` → `POST /articles` → `create_article`); description + CHANGELOG updated (mcp **v2.4.1**). The OKF importer handles the new `:duplicate_title` outcome.

## Review
Two-agent adversarial pass (engineer + security) on the first cut found, and this PR fixes: a forgeable client `url-<hash>`/source dedupe signal (pivoted to server-side body identity), slug-constraint conflicts mis-routed into title recovery (restricted to the title index only), a system-scope tenant_id mismatch (keys off `effective_tenant_id`), and an OKF mis-index on genuine conflicts.

## Tests
Idempotent-on-identical-body, 409-on-different-body (context + controller), `:title` attribution, OKF still green. Full suite **2345** tests / 0 failures; `mix precommit` passes end-to-end.

Scope note: the internal `review_knowledge_worker` batch-insert path (Oban-retried) is intentionally out of scope — the issues name `POST /articles` / `knowledge_create`, both of which route through `create_article`.