### PR TITLE
Docs sweep: reconcile all docs with current functionality (55 tools, new endpoints)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,7 +200,7 @@ mix ecto.reset         # Drop, create, migrate
 - **User Stories**: `docs/user_stories/epic_N_name/us_N.M.json` — 60 stories across 15 epics
 - **Skills**: `skills/loopctl-*.md` — 6 orchestration skills
 - **Orchestration Guide**: `docs/orchestration-guide.md` — methodology: loop, trust model, checkpointing
-- **MCP Server**: `mcp-server/` — 42 typed tools for Claude Code agents (no curl needed), published as `loopctl-mcp-server` on npm
+- **MCP Server**: `mcp-server/` — 55 typed tools for Claude Code agents (no curl needed), published as `loopctl-mcp-server` on npm
 - **Build Status**: memory-keeper key `build_status`, channel `loopctl`
 
 ## MCP Server
@@ -211,7 +211,7 @@ Claude Code agents should use the loopctl MCP tools instead of curl. Install via
 {"mcpServers": {"loopctl": {"command": "npx", "args": ["loopctl-mcp-server"], "env": {"LOOPCTL_SERVER": "https://loopctl.com", "LOOPCTL_ORCH_KEY": "...", "LOOPCTL_AGENT_KEY": "..."}}}}
 ```
 
-Tools: `mcp__loopctl__list_projects`, `mcp__loopctl__list_stories`, `mcp__loopctl__verify_story`, etc. (41 total). See `mcp-server/README.md` for the full list.
+Tools: `mcp__loopctl__list_projects`, `mcp__loopctl__list_stories`, `mcp__loopctl__verify_story`, etc. (55 total). See `mcp-server/README.md` for the full list.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -775,18 +775,24 @@ cd mcp-server && npm install
 
 Keys must be in the `env` block — the MCP server process does not inherit the shell environment.
 
-### Available Tools (33)
+### Available Tools (55)
+
+Full descriptions live in [`mcp-server/README.md`](mcp-server/README.md); summary:
 
 | Tool | Description | API Key Used |
 |------|------------|-------------|
 | `get_tenant` | Verify connectivity (current tenant info) | orchestrator |
 | `list_projects` | List all projects | orchestrator |
 | `create_project` | Create a new project | orchestrator |
+| `delete_project` | Delete a project and all dependents (irreversible) | user |
 | `get_progress` | Project progress summary (supports `include_cost`) | orchestrator |
-| `import_stories` | Import epics and stories | orchestrator |
+| `import_stories` | Import epics and stories (supports `merge`) | orchestrator |
 | `list_stories` | List stories with filters (supports `include_token_totals`) | orchestrator |
 | `list_ready_stories` | Stories ready for work | orchestrator |
 | `get_story` | Get story details | orchestrator |
+| `create_story` | Create a single story in an existing epic | orchestrator |
+| `get_acceptance_criteria` | Story acceptance criteria with verification status | orchestrator |
+| `backfill_story` | Mark a story verified for work done outside loopctl | orchestrator |
 | `contract_story` | Contract a story | agent |
 | `claim_story` | Claim a story | agent |
 | `start_story` | Start implementation | agent |
@@ -802,16 +808,33 @@ Keys must be in the `env` block — the MCP server process does not inherit the 
 | `get_story_token_usage` | Token usage records for a story | orchestrator |
 | `get_cost_anomalies` | Cost anomaly alerts | orchestrator |
 | `set_token_budget` | Set token budget for a scope | orchestrator |
-| `knowledge_index` | Load knowledge wiki catalog | agent |
+| `knowledge_index` | Load knowledge wiki catalog (per-category, `fields` projection) | agent |
 | `knowledge_stats` | Aggregate article counts (total, by_category, by_status) | agent |
 | `knowledge_search` | Search knowledge wiki by topic | agent |
 | `knowledge_get` | Get full article content by ID | agent |
 | `knowledge_context` | Get relevance-ranked articles for a task query | agent |
-| `knowledge_create` | Create a knowledge article (draft by default; `publish: true` for create-and-publish, orchestrator role) | agent |
+| `knowledge_create` | Create an article (draft by default; `publish: true`, orchestrator) | agent |
 | `knowledge_publish` | Publish a draft article | orchestrator |
+| `knowledge_bulk_publish` | Atomically publish up to 100 drafts | user |
+| `knowledge_unpublish` | Revert a published article back to draft | user |
+| `knowledge_archive` | Soft-delete an article (retained for audit) | user |
+| `knowledge_delete` | Alias for archive (DELETE verb archives) | user |
 | `knowledge_drafts` | List draft (unpublished) articles | orchestrator |
 | `knowledge_lint` | Lint check for stale or low-coverage articles | orchestrator |
-| `knowledge_export` | Export all articles as ZIP archive | orchestrator |
+| `knowledge_export` | Export all articles as a ZIP archive | orchestrator |
+| `knowledge_okf_export` | Export the wiki as an OKF v0.1 bundle | user |
+| `knowledge_okf_import` | Import an OKF v0.1 bundle from a directory | user |
+| `knowledge_ingest` | Submit a URL/content for knowledge extraction | orchestrator |
+| `knowledge_ingest_batch` | Submit up to 50 ingestion items | orchestrator |
+| `knowledge_ingestion_jobs` | List recent ingestion jobs | orchestrator |
+| `knowledge_analytics_top` | Top accessed articles | orchestrator |
+| `knowledge_article_stats` | Per-article usage stats | orchestrator |
+| `knowledge_agent_usage` | Per-agent knowledge usage | orchestrator |
+| `knowledge_unused_articles` | Published articles with zero accesses | orchestrator |
+| `get_system_articles` | List/fetch system-scoped wiki articles (public) | none |
+| `dispatch` | Mint an ephemeral key for a sub-agent dispatch (Chain of Custody v2) | orchestrator |
+| `recover_cap` | Re-mint a capability token after a session crash | agent |
+| `get_sth` | Get the latest Signed Tree Head for the audit chain (public) | none |
 | `list_routes` | Discover all API endpoints | orchestrator |
 
 Agents call tools directly: `mcp__loopctl__get_tenant()`, `mcp__loopctl__list_projects()`, `mcp__loopctl__create_project({name: "MyApp", slug: "myapp"})`. No curl or bash needed.

--- a/lib/loopctl_web/controllers/page_html/docs.html.heex
+++ b/lib/loopctl_web/controllers/page_html/docs.html.heex
@@ -850,6 +850,100 @@
               </p>
             </div>
           </div>
+
+          <h3 class="mt-8 text-sm font-semibold text-accent-400 uppercase tracking-wider text-xs">
+            Chain of Custody v2 &amp; Dispatch
+          </h3>
+          <div class="mt-4 space-y-3">
+            <div class="bg-slate-800 border border-slate-700 rounded-md p-3">
+              <p class="font-mono text-xs text-slate-300">
+                <span class="text-accent-400">POST</span> /api/v1/dispatches
+              </p>
+              <p class="mt-1.5 text-sm text-slate-400">
+                Mint a per-dispatch ephemeral, scoped API key carrying its lineage path
+                (root → self). The raw key is returned once and has a bounded TTL — this
+                replaces long-lived env-var keys for sub-agent dispatch. See <span class="font-mono text-slate-300">docs/chain-of-custody-v2.md</span>.
+              </p>
+            </div>
+            <div class="bg-slate-800 border border-slate-700 rounded-md p-3">
+              <p class="font-mono text-xs text-slate-300">
+                <span class="text-accent-400">POST</span> /api/v1/stories/:id/recover-cap
+              </p>
+              <p class="mt-1.5 text-sm text-slate-400">
+                Re-mint a capability token for a story you're assigned to after a session
+                crash — recovery without breaking the custody chain.
+              </p>
+            </div>
+            <div class="bg-slate-800 border border-slate-700 rounded-md p-3">
+              <p class="font-mono text-xs text-slate-300">
+                <span class="text-accent-400">GET</span> /api/v1/audit/sth/:tenant_id
+              </p>
+              <p class="mt-1.5 text-sm text-slate-400">
+                Latest Signed Tree Head for a tenant's tamper-evident audit chain. Public
+                (no auth) so external verifiers can detect divergence.
+              </p>
+            </div>
+          </div>
+
+          <h3 class="mt-8 text-sm font-semibold text-accent-400 uppercase tracking-wider text-xs">
+            Orchestration &amp; Observability
+          </h3>
+          <div class="mt-4 space-y-3">
+            <div class="bg-slate-800 border border-slate-700 rounded-md p-3">
+              <p class="font-mono text-xs text-slate-300">
+                <span class="text-accent-400">PUT</span> /api/v1/orchestrator/state/:project_id
+                · <span class="text-accent-400">GET</span> .../state/:project_id[/history]
+              </p>
+              <p class="mt-1.5 text-sm text-slate-400">
+                Persist and read orchestrator session state (phase, last verified story,
+                decision context) with optimistic locking — enables crash recovery and
+                session handoff.
+              </p>
+            </div>
+            <div class="bg-slate-800 border border-slate-700 rounded-md p-3">
+              <p class="font-mono text-xs text-slate-300">
+                <span class="text-accent-400">GET</span> /api/v1/changes?since=...
+              </p>
+              <p class="mt-1.5 text-sm text-slate-400">
+                Cursor-based change feed of all state transitions across a project —
+                external dashboards and alerting poll this without parsing session logs.
+              </p>
+            </div>
+            <div class="bg-slate-800 border border-slate-700 rounded-md p-3">
+              <p class="font-mono text-xs text-slate-300">
+                <span class="text-accent-400">GET</span> /api/v1/stories/:id/history
+                · <span class="text-accent-400">GET</span> /api/v1/projects/:id/dependency_graph
+              </p>
+              <p class="mt-1.5 text-sm text-slate-400">
+                Immutable per-story event log (replay the decision chain) and the project
+                dependency graph; <span class="font-mono text-slate-300">GET /stories/ready</span>
+                and <span class="font-mono text-slate-300">/stories/blocked</span>
+                expose the
+                ready/blocked queues.
+              </p>
+            </div>
+            <div class="bg-slate-800 border border-slate-700 rounded-md p-3">
+              <p class="font-mono text-xs text-slate-300">
+                <span class="text-accent-400">POST</span> /api/v1/webhooks
+                · <span class="text-accent-400">GET</span> /api/v1/webhooks/:id/deliveries
+              </p>
+              <p class="mt-1.5 text-sm text-slate-400">
+                Subscribe to lifecycle events (story transitions, <span class="font-mono text-slate-300">article.*</span>,
+                etc.) with signed delivery and a per-subscription delivery log.
+              </p>
+            </div>
+            <div class="bg-slate-800 border border-slate-700 rounded-md p-3">
+              <p class="font-mono text-xs text-slate-300">
+                <span class="text-accent-400">GET</span> /api/v1/knowledge/okf/export
+                · <span class="text-accent-400">POST</span> /api/v1/knowledge/okf/import
+              </p>
+              <p class="mt-1.5 text-sm text-slate-400">
+                Portable Open Knowledge Format (OKF v0.1) interchange — export the wiki as a
+                markdown bundle and re-import it (with <span class="font-mono text-slate-300">merge</span>),
+                preserving unknown frontmatter.
+              </p>
+            </div>
+          </div>
         </section>
 
         <%!-- ============================================================ --%>
@@ -859,7 +953,7 @@
           <h2 class="font-display text-xl font-semibold text-slate-100">MCP Tools</h2>
           <div class="mt-4 space-y-4 text-sm text-slate-400">
             <p>
-              The loopctl MCP server provides 51 typed tools for Claude Code agents.
+              The loopctl MCP server provides 55 typed tools for Claude Code agents.
               Install via
               <span class="font-mono text-slate-300">npm install loopctl-mcp-server</span>
               and configure in <span class="font-mono text-slate-300">.mcp.json</span>.
@@ -1068,9 +1162,10 @@
           </h3>
           <div class="mt-4 space-y-4 text-sm text-slate-400">
             <p>
-              The full set of 50 tools covers projects, stories, epics, verification,
+              The full set of 55 tools covers projects, stories, epics, verification,
               artifacts, orchestrator state, webhooks, skills, token usage, analytics,
-              and knowledge. See the
+              knowledge, OKF interchange, and the Chain of Custody v2 dispatch /
+              capability-token flow (`dispatch`, `recover_cap`, `get_sth`). See the
               <a
                 href="https://www.npmjs.com/package/loopctl-mcp-server"
                 class="text-accent-400 hover:text-accent-300 transition-colors"

--- a/lib/loopctl_web/controllers/page_html/docs.html.heex
+++ b/lib/loopctl_web/controllers/page_html/docs.html.heex
@@ -746,6 +746,10 @@
                 Unified search across knowledge articles. Supports
                 <span class="font-mono text-slate-300">mode=keyword|semantic|combined</span>
                 for full-text search, pgvector embeddings, or both.
+                <span class="font-mono text-slate-300">meta.total_count_scope</span>
+                says what <span class="font-mono text-slate-300">total_count</span>
+                counts for
+                the mode (it is not a corpus total — use list mode or <span class="font-mono text-slate-300">/knowledge/stats</span>).
               </p>
             </div>
             <div class="bg-slate-800 border border-slate-700 rounded-md p-3">
@@ -830,6 +834,19 @@
                 <span class="font-mono text-slate-300">COUNT(*) GROUP BY</span>
                 — no article
                 metadata loaded. Answers "how many articles are here?" without paging the index.
+              </p>
+            </div>
+            <div class="bg-slate-800 border border-slate-700 rounded-md p-3">
+              <p class="font-mono text-xs text-slate-300">
+                <span class="text-accent-400">POST</span> /api/v1/articles
+              </p>
+              <p class="mt-1.5 text-sm text-slate-400">
+                Create an article. Created as a
+                <span class="font-mono text-slate-300">draft</span>
+                (NOT visible in search/index/context) — the response
+                <span class="font-mono text-slate-300">note</span>
+                says so. Pass <span class="font-mono text-slate-300">publish: true</span>
+                to create-and-publish in one call (requires orchestrator role).
               </p>
             </div>
           </div>

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -2,7 +2,7 @@
 
 MCP (Model Context Protocol) server for [loopctl](https://loopctl.com) -- structural trust for AI development loops.
 
-Wraps the loopctl REST API into 47 typed MCP tools so AI coding agents (Claude Code, etc.) can interact with loopctl without writing curl commands.
+Wraps the loopctl REST API into 55 typed MCP tools so AI coding agents (Claude Code, etc.) can interact with loopctl without writing curl commands.
 
 ## Installation
 
@@ -66,7 +66,7 @@ Or if installed locally:
 
 Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_KEY`.
 
-## Tools (47)
+## Tools (55)
 
 ### Project Tools
 
@@ -88,6 +88,7 @@ Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_K
 | `get_story` | Get full details for a single story by ID. |
 | `create_story` | Create a single story inside an existing epic. Use instead of wrapping a story in a bulk import. Accepts either `epic_id` (UUID) or (`project_id` + `epic_number`). |
 | `backfill_story` | **Bypasses the review/verify chain.** Marks a story as verified when the work was completed outside loopctl (e.g. before the project was onboarded). Refused for any story with `assigned_agent_id` set — those must go through the normal report → review → verify flow, not backfill. Also refused for already `:verified` or `:rejected` stories. Records provenance (`reason`, `evidence_url`, `pr_number`) in `metadata.backfill` and emits a `story.backfilled` webhook. |
+| `get_acceptance_criteria` | List a story's acceptance criteria with each one's verification status. Required: `story_id`. |
 
 ### Workflow Tools (agent key)
 
@@ -172,6 +173,17 @@ Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_K
 | Tool | Description |
 |---|---|
 | `list_routes` | List all available API routes on the loopctl server. |
+| `get_system_articles` | List or fetch system-scoped (global, cross-tenant) wiki articles. Public — no auth required. Optional: `slug` (fetch one), `category`. |
+
+### Dispatch & Chain of Custody (v2) Tools
+
+Key distribution for the dispatch pattern (Epic 26): per-dispatch ephemeral keys and capability-token recovery. See `docs/chain-of-custody-v2.md`.
+
+| Tool | Description |
+|---|---|
+| `dispatch` | Mint an ephemeral, scoped api_key for a sub-agent dispatch, carrying its lineage path. The `raw_key` is returned ONCE — pass it to the sub-agent's launch args, never store it in env vars; it expires after `expires_in_seconds` (default 3600, max 14400). Required: `role` (`agent`/`orchestrator`), `agent_id`. Optional: `parent_dispatch_id`, `story_id`. |
+| `recover_cap` | Re-mint a capability token for a story you're assigned to, after a session crash lost your cap. Required: `story_id`. Optional: `cap_type` (`start_cap`/`report_cap`, default `start_cap`), `lineage`. |
+| `get_sth` | Get the latest Signed Tree Head for a tenant's tamper-evident audit chain. Public — no auth required. Required: `tenant_id`. |
 
 ## Wiki Attribution
 


### PR DESCRIPTION
Documentation sweep — reconcile **all** docs with current functionality.

Started as a follow-up to #117–#120 and expanded into a full audit of MCP tools
(`mcp-server/index.js`) and API routes (`router.ex`) against every doc surface.

## Tool count: actually **55** (was drifted everywhere)

| File | Was | Now |
|---|---|---|
| `mcp-server/README.md` (2×) | 47 | 55 |
| `README.md` table header | 33 | 55 |
| `CLAUDE.md` | 42 typed / 41 total | 55 |
| `docs.html.heex` | 51 (and "50 tools" blurb) | 55 |

## MCP README — 5 tools were missing from the tables

`get_acceptance_criteria` (Story), `get_system_articles` (Discovery, public),
and a new **Dispatch & Chain of Custody (v2)** section for `dispatch`,
`recover_cap`, `get_sth`. (The audit's claim that `knowledge_okf_export/import`
and `knowledge_unpublish` were missing was a false positive — they're already
present; verified.)

## Root README — completed the tool table

Replaced the partial 34-row table with the full 55-tool table (adds
`delete_project`, `create_story`, `backfill_story`, `get_acceptance_criteria`,
the knowledge bulk/unpublish/archive/delete + ingest + analytics + OKF tools,
and `dispatch`/`recover_cap`/`get_sth`/`get_system_articles`).

## docs.html.heex — new endpoint cards for absent capability areas

Plus the original #117–#120 items (index `fields`, `/knowledge/stats`, search
`total_count_scope`, `POST /articles` publish/draft). Added cards for:
**Chain of Custody v2** (`POST /dispatches`, `POST /stories/:id/recover-cap`,
`GET /audit/sth/:tenant_id`), **orchestrator state**, the **`/changes` feed**,
**story history + dependency graph**, **webhooks**, and **OKF export/import**.
Every documented path was verified against the router.

## Swagger / OpenAPI

Generated live from the router + `operation` specs — **verified** it already
contains every endpoint and the #117–#120 field/param/response changes. No
static spec to regenerate.

## Verification

`mix precommit` green (compile --warnings-as-errors, format, credo --strict,
deps.audit, dialyzer 0 errors, 2371 tests / 0 failures); MCP suite 34/0.
