### PR TITLE
Apply #139 enhanced-review fixes (publish-by-default follow-ups)

### DIFF
--- a/README.md
+++ b/README.md
@@ -813,8 +813,8 @@ Full descriptions live in [`mcp-server/README.md`](mcp-server/README.md); summar
 | `knowledge_search` | Search knowledge wiki by topic | agent |
 | `knowledge_get` | Get full article content by ID | agent |
 | `knowledge_context` | Get relevance-ranked articles for a task query | agent |
-| `knowledge_create` | Create an article (draft by default; `publish: true`, orchestrator) | agent |
-| `knowledge_publish` | Publish a draft article | orchestrator |
+| `knowledge_create` | Create an article (published by default; `draft: true` to stage) | agent |
+| `knowledge_publish` | Publish an existing draft article | orchestrator |
 | `knowledge_bulk_publish` | Atomically publish up to 100 drafts | user |
 | `knowledge_unpublish` | Revert a published article back to draft | user |
 | `knowledge_archive` | Soft-delete an article (retained for audit) | user |

--- a/lib/loopctl/knowledge/article.ex
+++ b/lib/loopctl/knowledge/article.ex
@@ -82,11 +82,14 @@ defmodule Loopctl.Knowledge.Article do
 
   NOTE: `:status` is castable here and is **trusted from `attrs`** — this
   changeset does NOT enforce who may create a `:published` (or
-  `:archived`/`:superseded`) article. Publish authorization is the caller's
-  responsibility: `LoopctlWeb.ArticleController.create/2` gates it at
-  orchestrator+ and sets the status server-side, and `Loopctl.Knowledge.OKF`
-  forces `:draft`. A future caller of `create_article/3` MUST likewise sanitize
-  `:status` (or gate the role) rather than pass an unvalidated caller value.
+  `:archived`/`:superseded`) article. Setting the create-time status is the
+  caller's responsibility: `LoopctlWeb.ArticleController.create/2` sets it
+  server-side (published by default, or draft when the caller opts in) and never
+  trusts a caller-supplied `:status` beyond the draft opt-in, and
+  `Loopctl.Knowledge.OKF` forces `:draft`. A future caller of `create_article/3`
+  MUST likewise sanitize `:status` (or gate the role) rather than pass an
+  unvalidated caller value. (Publishing is no longer gated on the create path;
+  publishing an EXISTING draft via the workflow endpoints remains role-gated.)
   """
   @spec create_changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
   def create_changeset(article \\ %__MODULE__{}, attrs) do

--- a/lib/loopctl_web/controllers/article_controller.ex
+++ b/lib/loopctl_web/controllers/article_controller.ex
@@ -59,7 +59,9 @@ defmodule LoopctlWeb.ArticleController do
              type: :boolean,
              description:
                "Stage as a draft instead of publishing on create. Default false " <>
-                 "(article is published immediately)."
+                 "(article is published immediately). Equivalent alias: status: \"draft\". " <>
+                 "Publishing a staged draft afterwards (POST /articles/:id/publish) " <>
+                 "requires orchestrator role; publish-on-create does not."
            },
            tags: %OpenApiSpex.Schema{type: :array, items: %OpenApiSpex.Schema{type: :string}},
            project_id: %OpenApiSpex.Schema{type: :string, format: :uuid, nullable: true},
@@ -194,11 +196,11 @@ defmodule LoopctlWeb.ArticleController do
         |> maybe_merge_project_id(params["project_id"])
         |> put_create_status(draft?)
 
-      create_article(conn, tenant_id, attrs, audit_opts)
+      create_article(conn, tenant_id, attrs, audit_opts, draft?)
     end
   end
 
-  defp create_article(conn, tenant_id, attrs, audit_opts) do
+  defp create_article(conn, tenant_id, attrs, audit_opts, draft?) do
     case Knowledge.create_article(tenant_id, attrs, audit_opts) do
       {:ok, article} ->
         conn
@@ -211,12 +213,16 @@ defmodule LoopctlWeb.ArticleController do
       # real create.
       {:ok, :deduplicated, existing} ->
         # The article already existed (identical title+body) — dedup is a pure
-        # no-op, so the note must NOT claim it was "created" or "published" now.
+        # no-op (it never flips a draft to published), so the note must NOT claim
+        # it was "created" or "published" now. `draft?` is the caller's intent on
+        # THIS request, so a publish-intent create that lands on a pre-existing
+        # draft gets an accurate, agent-reachable explanation rather than a
+        # dead-end "publish it (orchestrator)" message.
         response =
           %{article: existing}
           |> ArticleJSON.create()
           |> Map.put(:deduplicated, true)
-          |> Map.put(:note, dedup_note(existing))
+          |> Map.put(:note, dedup_note(existing, draft?))
 
         conn
         |> put_status(:ok)
@@ -355,22 +361,38 @@ defmodule LoopctlWeb.ArticleController do
     do:
       "Created as a draft (status: \"draft\"). It is NOT yet visible to agents in " <>
         "search/index/context. Publish it via POST /articles/:id/publish (MCP " <>
-        "knowledge_publish), or omit `draft` to publish on create."
+        "knowledge_publish, orchestrator role), or omit `draft` to publish on create " <>
+        "(no orchestrator role needed for publish-on-create)."
 
   # Note for the deduplicated (no-op) case. The article already existed and was
   # returned unchanged, so nothing was created OR published in this call —
-  # spelled out per existing status so the caller isn't misled by a
-  # "Created…"/"published…" message.
-  defp dedup_note(%{status: :published}),
+  # spelled out per existing status (and the caller's draft/publish intent) so
+  # the caller isn't misled by a "Created…"/"published…" message.
+  defp dedup_note(%{status: :published}, _draft?),
     do:
       "An identical published article already existed and was returned unchanged (already visible to agents)."
 
-  defp dedup_note(%{status: :draft}),
+  # Caller explicitly asked to stage a draft and an identical draft already
+  # exists — the intent is satisfied, nothing to do.
+  defp dedup_note(%{status: :draft}, true),
     do:
       "An identical draft already existed and was returned unchanged. It is a draft " <>
-        "(NOT visible to agents); publish it via POST /articles/:id/publish."
+        "(NOT visible to agents); publish it via POST /articles/:id/publish (MCP " <>
+        "knowledge_publish, orchestrator role)."
 
-  defp dedup_note(_existing),
+  # Caller asked to publish-on-create, but an identical article already exists as
+  # a draft someone staged earlier. Dedup never auto-publishes a staged draft, so
+  # the publish intent did not apply — say so honestly with the real remedy (an
+  # existing draft is published by orchestrator/user, not the agent).
+  defp dedup_note(%{status: :draft}, false),
+    do:
+      "An identical article already exists as a DRAFT that was staged earlier, so it " <>
+        "is NOT visible to agents and your publish-on-create did not change it (dedup " <>
+        "never auto-publishes a staged draft). To make it visible, an orchestrator/user " <>
+        "must publish it via POST /articles/:id/publish (MCP knowledge_publish), or " <>
+        "unpublish/edit it via PATCH /articles/:id."
+
+  defp dedup_note(_existing, _draft?),
     do: "An identical article already existed and was returned unchanged."
 
   defp maybe_merge_project_id(attrs, nil), do: attrs

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -147,7 +147,7 @@ Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_K
 
 | Tool | Description |
 |---|---|
-| `knowledge_publish` | Publish a draft article, making it visible to all agents. Required: `article_id`. |
+| `knowledge_publish` | **Requires `LOOPCTL_ORCH_KEY` (orchestrator role).** Publish an existing draft article, making it visible to all agents. (Note: `knowledge_create` publishes on create by default with no orchestrator key needed — this tool is for publishing a draft staged earlier.) Required: `article_id`. |
 | `knowledge_bulk_publish` | **Requires `LOOPCTL_USER_KEY`.** Atomically publish up to 100 drafts in a single call. Required: `article_ids` (array). |
 | `knowledge_unpublish` | **Requires `LOOPCTL_USER_KEY`.** Revert a published article back to draft (hidden from search/context, not deleted). Required: `article_id`. |
 | `knowledge_archive` | **Requires `LOOPCTL_USER_KEY`.** Soft-delete an article (draft or published). Row retained for audit; hidden from all reads. Required: `article_id`. |

--- a/mcp-server/test/knowledge_tools.test.js
+++ b/mcp-server/test/knowledge_tools.test.js
@@ -152,32 +152,23 @@ async function knowledgeContext({ query, project_id, story_id, limit, recency_we
   return toContent(result);
 }
 
-async function knowledgeCreate({ title, body, category, tags, project_id, publish }) {
+async function knowledgeCreate({ title, body, category, tags, project_id, draft }) {
   const payload = { title, body };
   if (category) payload.category = category;
   if (tags) payload.tags = tags;
   if (project_id) payload.project_id = project_id;
 
-  let key = process.env.LOOPCTL_AGENT_KEY;
-  if (publish) {
-    if (!process.env.LOOPCTL_ORCH_KEY && !process.env.LOOPCTL_API_KEY) {
-      return {
-        content: [
-          {
-            type: "text",
-            text:
-              "Publishing on create requires orchestrator role: set LOOPCTL_ORCH_KEY, or omit " +
-              "publish to create a draft and have an orchestrator publish it via knowledge_publish.",
-          },
-        ],
-        isError: true,
-      };
-    }
-    payload.publish = true;
-    key = process.env.LOOPCTL_ORCH_KEY;
-  }
+  // Articles publish on create by default for every role (including agent), so a
+  // plain create routes through the agent key and is immediately visible. Pass
+  // draft:true to stage it for later review instead.
+  if (draft) payload.draft = true;
 
-  const result = await apiCall("POST", "/api/v1/articles", payload, key);
+  const result = await apiCall(
+    "POST",
+    "/api/v1/articles",
+    payload,
+    process.env.LOOPCTL_AGENT_KEY,
+  );
   return toContent(result);
 }
 
@@ -852,10 +843,10 @@ describe("Issue #118: knowledge_stats", () => {
   });
 });
 
-describe("Issue #120: knowledge_create publish routing", () => {
-  test("a plain create uses the agent key and sends no publish flag", async () => {
+describe("knowledge_create: publish-on-create by default (#133)", () => {
+  test("a default create uses the agent key and sends no draft/publish flag", async () => {
     setupEnv();
-    const calls = mockFetch({ data: { status: "draft" }, note: "draft" });
+    const calls = mockFetch({ data: { status: "published" }, note: "published" });
 
     await knowledgeCreate({ title: "T", body: "B", category: "pattern" });
 
@@ -863,31 +854,47 @@ describe("Issue #120: knowledge_create publish routing", () => {
     const { url, options } = calls[0];
     assert.equal(new URL(url).pathname, "/api/v1/articles");
     assert.equal(options.headers.Authorization, `Bearer ${AGENT_KEY}`);
-    assert.equal(JSON.parse(options.body).publish, undefined);
+    const sent = JSON.parse(options.body);
+    assert.equal(sent.draft, undefined);
+    assert.equal(sent.publish, undefined, "the removed publish flag must never be sent");
   });
 
-  test("publish: true routes through the orchestrator key and sets publish in the payload", async () => {
+  test("draft: true stages a draft on the agent key (no orchestrator key consulted)", async () => {
     setupEnv();
-    const calls = mockFetch({ data: { status: "published" } });
+    const calls = mockFetch({ data: { status: "draft" }, note: "draft" });
 
-    await knowledgeCreate({ title: "T", body: "B", category: "pattern", publish: true });
+    await knowledgeCreate({ title: "T", body: "B", category: "pattern", draft: true });
 
     assert.equal(calls.length, 1);
     const { options } = calls[0];
-    assert.equal(options.headers.Authorization, `Bearer ${ORCH_KEY}`);
-    assert.equal(JSON.parse(options.body).publish, true);
+    assert.equal(options.headers.Authorization, `Bearer ${AGENT_KEY}`);
+    const sent = JSON.parse(options.body);
+    assert.equal(sent.draft, true);
+    assert.equal(sent.publish, undefined);
   });
 
-  test("publish: true on an agent-only install returns a helpful error, not a keyless request", async () => {
+  test("draft: false is the same as omitting it — publishes on the agent key", async () => {
+    setupEnv();
+    const calls = mockFetch({ data: { status: "published" } });
+
+    await knowledgeCreate({ title: "T", body: "B", category: "pattern", draft: false });
+
+    assert.equal(calls.length, 1);
+    const { options } = calls[0];
+    assert.equal(options.headers.Authorization, `Bearer ${AGENT_KEY}`);
+    assert.equal(JSON.parse(options.body).draft, undefined);
+  });
+
+  test("publishing on create needs no orchestrator key (agent-only install works)", async () => {
     setupEnv();
     delete process.env.LOOPCTL_ORCH_KEY;
     delete process.env.LOOPCTL_API_KEY;
-    const calls = mockFetch({ data: {} });
+    const calls = mockFetch({ data: { status: "published" } });
 
-    const result = await knowledgeCreate({ title: "T", body: "B", publish: true });
+    const result = await knowledgeCreate({ title: "T", body: "B", category: "pattern" });
 
-    assert.equal(result.isError, true);
-    assert.match(result.content[0].text, /orchestrator role/);
-    assert.equal(calls.length, 0, "no HTTP request should be made without an orchestrator key");
+    assert.equal(result.isError, undefined, "default publish-on-create must not error");
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].options.headers.Authorization, `Bearer ${AGENT_KEY}`);
   });
 });

--- a/test/loopctl_web/controllers/article_controller_test.exs
+++ b/test/loopctl_web/controllers/article_controller_test.exs
@@ -98,7 +98,37 @@ defmodule LoopctlWeb.ArticleControllerTest do
 
       assert resp["deduplicated"] == true
       assert resp["data"]["status"] == "draft"
+      # The note honestly explains the publish intent did not apply (an identical
+      # draft was staged earlier) and gives an actually-reachable remedy.
+      assert resp["note"] =~ "did not change it"
       assert resp["note"] =~ "publish"
+      refute resp["note"] =~ "Created"
+    end
+
+    test "draft: true that dedups onto an existing draft says the intent is satisfied", %{
+      conn: conn
+    } do
+      tenant = fixture(:tenant)
+      {agent_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      payload = %{
+        "title" => "Dedup Draft Intent",
+        "body" => "identical staged body",
+        "category" => "pattern",
+        "draft" => true
+      }
+
+      conn |> auth_conn(agent_key) |> post(~p"/api/v1/articles", payload) |> json_response(201)
+
+      resp =
+        build_conn()
+        |> auth_conn(agent_key)
+        |> post(~p"/api/v1/articles", payload)
+        |> json_response(200)
+
+      assert resp["deduplicated"] == true
+      assert resp["data"]["status"] == "draft"
+      assert resp["note"] =~ "already existed"
     end
 
     test "dedup onto an existing published article does not claim it was 'created' now", %{
@@ -194,6 +224,49 @@ defmodule LoopctlWeb.ArticleControllerTest do
       # the server ignores them and applies the publish-on-create default.
       body = json_response(conn, 201)
       assert body["data"]["status"] == "published"
+    end
+
+    test "a legacy publish: true payload is harmless — it just publishes (the default)", %{
+      conn: conn
+    } do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/articles", %{
+          "title" => "Legacy Publish Flag",
+          "body" => "old clients still send publish: true",
+          "category" => "pattern",
+          "publish" => true
+        })
+
+      # The `publish` flag is dropped server-side; the article publishes by default
+      # anyway, so an old client gets a sensible result (no 403, no draft).
+      body = json_response(conn, 201)
+      assert body["data"]["status"] == "published"
+    end
+
+    test "status: \"draft\" wins over draft: false (explicit stage beats the absent opt-in)", %{
+      conn: conn
+    } do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/articles", %{
+          "title" => "Draft Precedence",
+          "body" => "status draft is an explicit stage request; draft:false is not an opt-out",
+          "category" => "pattern",
+          "status" => "draft",
+          "draft" => false
+        })
+
+      body = json_response(conn, 201)
+      assert body["data"]["status"] == "draft"
     end
 
     test "returns 422 on invalid input", %{conn: conn} do


### PR DESCRIPTION
## What

Lands the enhanced-review fixes for **#139** (publish-on-create default). #139 was merged before these fixes were pushed, so master currently has the gaps below. This PR applies them against master.

Follow-up to #139 (issue #133).

## Review findings fixed

**From team review (round 1):**
- create_note/dedup_note + OpenAPI `draft` property now state that publishing a *staged draft* (`POST /articles/:id/publish`) requires orchestrator role, while publish-on-create does not — removing the dead-end an agent hits after staging.
- OpenAPI `draft` property documents the `status:"draft"` alias.
- MCP README `knowledge_publish` row flags the orchestrator-role requirement.
- Added regression test: a legacy `publish: true` payload now harmlessly publishes.

**From adversarial review (round 2):**
- **HIGH** — root `README.md` still advertised "draft by default; `publish: true`, orchestrator". Corrected.
- **HIGH** — `mcp-server/test/knowledge_tools.test.js` still tested the *removed* `publish`/orch-key routing (false-green; the new `draft` routing was untested). Rewritten to assert the shipped behaviour (default publish on agent key, `draft:true` staging, agent-only-install publish path).
- **MED** — a publish-intent create that dedups onto a pre-existing draft returned a misleading orchestrator-only note. Now returns an accurate, agent-reachable explanation. It deliberately does **not** auto-publish the staged draft — that would be a backdoor around the ingest-stays-draft policy and would override deliberate staging (architect + security reviewers confirmed dedup-never-flips is correct).
- **LOW** — stale `create_changeset` docstring (claimed the controller gates publish at orchestrator+) corrected.

**Disproved / dropped:** publish-by-default trust relaxation is the authorized design (architect + security: no auth-bypass, tenant-leak, or info-disclosure introduced; dedup never flips status; embedding enqueue bounded). Security F1 (per-tenant publish quota) is a separate quota-policy decision, tracked separately.

## Verification

`mix precommit` green: format, credo --strict, dialyzer, 2373 tests, 0 failures. MCP suite: 35/35.

> Note: please hold auto-merge until review is acknowledged — this PR *is* the review output for #139.
