### PR TITLE
MCP knowledge_list + lag-free source/idempotency filters (#134, #135)

### DIFF
--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -376,6 +376,8 @@ defmodule Loopctl.Knowledge do
     - `:status` -- filter by status atom (optional)
     - `:tags` -- filter by tag overlap, articles matching ANY tag (optional)
     - `:source_type` -- filter by source_type string (optional)
+    - `:source_id` -- filter by source_id (optional; a malformed id matches nothing)
+    - `:idempotency_key` -- filter by exact idempotency_key (optional)
     - `:limit` -- max records to return (default 20, max 100)
     - `:offset` -- records to skip for pagination (default 0)
 
@@ -2190,6 +2192,8 @@ defmodule Loopctl.Knowledge do
     |> maybe_filter_by_status(Keyword.get(opts, :status))
     |> maybe_filter_by_tags(Keyword.get(opts, :tags))
     |> maybe_filter_by_source_type(Keyword.get(opts, :source_type))
+    |> maybe_filter_by_source_id(Keyword.get(opts, :source_id))
+    |> maybe_filter_by_idempotency_key(Keyword.get(opts, :idempotency_key))
   end
 
   defp maybe_filter_by_project_id(query, nil), do: query
@@ -2221,6 +2225,24 @@ defmodule Loopctl.Knowledge do
 
   defp maybe_filter_by_source_type(query, source_type) do
     where(query, [a], a.source_type == ^source_type)
+  end
+
+  defp maybe_filter_by_source_id(query, nil), do: query
+
+  defp maybe_filter_by_source_id(query, source_id) do
+    # source_id is a binary_id; a malformed value would raise on cast, so match
+    # nothing instead (a clean "exists? no" rather than a 500).
+    if valid_uuid?(source_id) do
+      where(query, [a], a.source_id == ^source_id)
+    else
+      where(query, [a], false)
+    end
+  end
+
+  defp maybe_filter_by_idempotency_key(query, nil), do: query
+
+  defp maybe_filter_by_idempotency_key(query, key) do
+    where(query, [a], a.idempotency_key == ^key)
   end
 
   defp validate_articles_exist(tenant_id, source_id, target_id) do

--- a/lib/loopctl_web/controllers/article_controller.ex
+++ b/lib/loopctl_web/controllers/article_controller.ex
@@ -110,6 +110,10 @@ defmodule LoopctlWeb.ArticleController do
     description:
       "Lists articles with optional filters and pagination. " <>
         "When called via GET /projects/:project_id/articles, project_id is set from path. " <>
+        "Unlike search (which ranks and returns **published** articles only and lags writes " <>
+        "while embeddings index), this is the **lag-free, all-status** read of the DB of " <>
+        "record — use it for dedup/idempotency/repair (\"does an article with this tag/" <>
+        "source/idempotency_key exist?\"). `meta.total_count` is the exact filtered count. " <>
         "Role: agent+.",
     parameters: [
       category: [in: :query, type: :string, description: "Filter by category"],
@@ -117,7 +121,14 @@ defmodule LoopctlWeb.ArticleController do
       tags: [
         in: :query,
         type: :string,
-        description: "Filter by tags (comma-separated)"
+        description: "Filter by tags (comma-separated, ANY match)"
+      ],
+      source_type: [in: :query, type: :string, description: "Filter by source_type"],
+      source_id: [in: :query, type: :string, description: "Filter by source_id"],
+      idempotency_key: [
+        in: :query,
+        type: :string,
+        description: "Filter by exact idempotency_key (lag-free existence check)"
       ],
       limit: [in: :query, type: :integer, description: "Max results (default 20, max 100)"],
       offset: [in: :query, type: :integer, description: "Records to skip"]
@@ -260,6 +271,9 @@ defmodule LoopctlWeb.ArticleController do
       |> maybe_add_opt(:category, params["category"])
       |> maybe_add_opt(:status, params["status"])
       |> maybe_add_opt(:tags, parse_tags(params["tags"]))
+      |> maybe_add_opt(:source_type, params["source_type"])
+      |> maybe_add_opt(:source_id, params["source_id"])
+      |> maybe_add_opt(:idempotency_key, params["idempotency_key"])
       |> maybe_add_opt(:limit, parse_int(params["limit"]))
       |> maybe_add_opt(:offset, parse_int(params["offset"]))
 

--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to `loopctl-mcp-server` are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 2.11.0 — 2026-06-22 (knowledge_list: lag-free enumeration)
+
+### Added
+
+- New `knowledge_list` tool: lists articles with full fields (status, tags,
+  source_type, source_id, idempotency_key, timestamps), filtered by
+  tags/status/source_type/source_id/idempotency_key/category and paginated. It
+  wraps `GET /api/v1/articles` — the lag-free, all-status read of the DB of
+  record — so MCP-only clients can enumerate/dedup/repair and run idempotency/
+  existence checks reliably right after a write, instead of the ranked,
+  published-only, write-lagging `knowledge_search`. (loopctl #134, #135)
+- `GET /api/v1/articles` now also filters by `source_type`, `source_id`, and
+  `idempotency_key`.
+
 ## 2.10.0 — 2026-06-22 (knowledge_create idempotency_key + provenance)
 
 ### Added

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -2,7 +2,7 @@
 
 MCP (Model Context Protocol) server for [loopctl](https://loopctl.com) -- structural trust for AI development loops.
 
-Wraps the loopctl REST API into 55 typed MCP tools so AI coding agents (Claude Code, etc.) can interact with loopctl without writing curl commands.
+Wraps the loopctl REST API into 56 typed MCP tools so AI coding agents (Claude Code, etc.) can interact with loopctl without writing curl commands.
 
 ## Installation
 
@@ -66,7 +66,7 @@ Or if installed locally:
 
 Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_KEY`.
 
-## Tools (55)
+## Tools (56)
 
 ### Project Tools
 
@@ -137,6 +137,7 @@ Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_K
 | `knowledge_index` | Browse/paginate the knowledge wiki catalog grouped by category. Honors `category`, `tags`, `offset`, `limit` with deterministic ordering so every article is reachable (`meta.categories` reports per-category totals over the whole filtered set). Use `fields` (default `id,title,category`; request `tags`/`status`/`updated_at` explicitly; `id` and `category` are always included) to keep the payload small. Optional: `project_id`, `story_id`, `category`, `tags`, `offset`, `limit`, `fields`. |
 | `knowledge_stats` | Aggregate article counts (`total`, `by_category`, `by_status`) via cheap `COUNT(*) GROUP BY` — no article metadata loaded. The right tool for "how many articles are in this project?" (`knowledge_index` pages metadata; `knowledge_search`'s `total_count` is query-dependent). Counts span all statuses. Optional: `project_id`. |
 | `knowledge_search` | Search the knowledge wiki by topic (keyword, semantic, or combined). Returns snippets. `q` is optional when `tags`/`category` are supplied — that **list mode** returns the complete filtered set paginated via `offset`/`limit` over `meta.total_count`, so you can enumerate every article carrying a tag/category. `meta.total_count` is mode-dependent — read `meta.total_count_scope` (`keyword_matches`/`ranked_corpus`/`merged_candidates`/`filtered_set`) and don't use a relevance-mode count to size the wiki (use list mode or `knowledge_stats`). Optional: `project_id`, `story_id` for attribution. |
+| `knowledge_list` | List articles with **full fields** (incl. `status`, `tags`, `source_type`, `source_id`, `idempotency_key`, timestamps), filtered + paginated. **Lag-free, all-status** read of the DB of record — unlike `knowledge_search` (ranked, published-only, lags writes) and `knowledge_index` (id/title/category only). The right tool to enumerate/dedup/repair and for idempotency/existence checks: filter by `tags`, `source_type`+`source_id`, or `idempotency_key` and read `meta.total_count` (exact). Optional: `project_id`, `category`, `status`, `tags`, `source_type`, `source_id`, `idempotency_key`, `offset`, `limit`. |
 | `knowledge_get` | Get full article content by ID. Use after search to read an article in detail. Optional: `project_id`, `story_id` for attribution. |
 | `knowledge_context` | Get relevance-and-recency-ranked full articles for a task query. Best knowledge for your current context. Optional: `project_id`, `story_id` for attribution. |
 | `knowledge_create` | Create a new knowledge article. File findings, document patterns, or record decisions. **Published immediately by default** (visible to agents in search/index/context) for every role — the response `note` says which outcome occurred. Pass `draft: true` to stage it for later review instead (publish afterwards with `knowledge_publish`). Pass `idempotency_key` for idempotent capture (re-creating with the same key is a no-op returning the existing article — no partial duplicates). Optional: `category`, `tags`, `project_id`, `draft`, `idempotency_key`, `source_type`, `source_id`. |

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -132,11 +132,20 @@ Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_K
 
 ### Knowledge Wiki Tools (agent key)
 
+**Which read tool?**
+
+| Need | Use |
+|---|---|
+| How many articles? (counts only) | `knowledge_stats` |
+| Browse the catalog (lightweight id/title/category) | `knowledge_index` |
+| Find by topic / relevance (ranked, published-only, lags writes) | `knowledge_search` |
+| Enumerate / dedup / repair, or "does X exist?" (full fields, lag-free, all-status) | `knowledge_list` |
+
 | Tool | Description |
 |---|---|
 | `knowledge_index` | Browse/paginate the knowledge wiki catalog grouped by category. Honors `category`, `tags`, `offset`, `limit` with deterministic ordering so every article is reachable (`meta.categories` reports per-category totals over the whole filtered set). Use `fields` (default `id,title,category`; request `tags`/`status`/`updated_at` explicitly; `id` and `category` are always included) to keep the payload small. Optional: `project_id`, `story_id`, `category`, `tags`, `offset`, `limit`, `fields`. |
 | `knowledge_stats` | Aggregate article counts (`total`, `by_category`, `by_status`) via cheap `COUNT(*) GROUP BY` — no article metadata loaded. The right tool for "how many articles are in this project?" (`knowledge_index` pages metadata; `knowledge_search`'s `total_count` is query-dependent). Counts span all statuses. Optional: `project_id`. |
-| `knowledge_search` | Search the knowledge wiki by topic (keyword, semantic, or combined). Returns snippets. `q` is optional when `tags`/`category` are supplied — that **list mode** returns the complete filtered set paginated via `offset`/`limit` over `meta.total_count`, so you can enumerate every article carrying a tag/category. `meta.total_count` is mode-dependent — read `meta.total_count_scope` (`keyword_matches`/`ranked_corpus`/`merged_candidates`/`filtered_set`) and don't use a relevance-mode count to size the wiki (use list mode or `knowledge_stats`). Optional: `project_id`, `story_id` for attribution. |
+| `knowledge_search` | Search the knowledge wiki by topic (keyword, semantic, or combined). Returns snippets. **Ranked, published-only, and LAGS writes by minutes while embeddings index — do NOT use for existence/idempotency/dedup checks (a fresh write false-negatives); use `knowledge_list` for that.** `q` is optional when `tags`/`category` are supplied — that **list mode** returns the complete filtered set paginated via `offset`/`limit` over `meta.total_count`. `meta.total_count` is mode-dependent — read `meta.total_count_scope` (`keyword_matches`/`ranked_corpus`/`merged_candidates`/`filtered_set`) and don't use a relevance-mode count to size the wiki (use `knowledge_list` or `knowledge_stats`). Optional: `project_id`, `story_id` for attribution. |
 | `knowledge_list` | List articles with **full fields** (incl. `status`, `tags`, `source_type`, `source_id`, `idempotency_key`, timestamps), filtered + paginated. **Lag-free, all-status** read of the DB of record — unlike `knowledge_search` (ranked, published-only, lags writes) and `knowledge_index` (id/title/category only). The right tool to enumerate/dedup/repair and for idempotency/existence checks: filter by `tags`, `source_type`+`source_id`, or `idempotency_key` and read `meta.total_count` (exact). Optional: `project_id`, `category`, `status`, `tags`, `source_type`, `source_id`, `idempotency_key`, `offset`, `limit`. |
 | `knowledge_get` | Get full article content by ID. Use after search to read an article in detail. Optional: `project_id`, `story_id` for attribution. |
 | `knowledge_context` | Get relevance-and-recency-ranked full articles for a task query. Best knowledge for your current context. Optional: `project_id`, `story_id` for attribution. |

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -1845,10 +1845,11 @@ const TOOLS = [
       "source_id, idempotency_key, timestamps), filtered and paginated. Unlike knowledge_search " +
       "(ranked, PUBLISHED-only, and lags writes while embeddings index) and knowledge_index " +
       "(lightweight id/title/category only), this is the LAG-FREE, ALL-STATUS read of the DB of " +
-      "record — the right tool to enumerate, dedup, or repair. Use it for idempotency/existence " +
-      "checks: filter by `tags`, `source_type`+`source_id`, or `idempotency_key` and read " +
-      "`meta.total_count` (exact) to answer \"does an article for X already exist?\" reliably " +
-      "right after a write. Paginate via offset/limit.",
+      "record — the right tool to enumerate, dedup, or repair. Returns articles in all statuses " +
+      "(draft, published, archived, superseded visible) — intended for dedup/repair tooling. Use " +
+      "for idempotency/existence checks: filter by `tags`, `source_type`+`source_id`, or " +
+      "`idempotency_key` and read `meta.total_count` (exact) to answer \"does an article for X " +
+      "already exist?\" reliably right after a write. Paginate via offset/limit.",
     inputSchema: {
       type: "object",
       properties: {
@@ -1921,7 +1922,10 @@ const TOOLS = [
   {
     name: "knowledge_search",
     description:
-      "Search the knowledge wiki by topic. Returns snippets. " +
+      "Search the knowledge wiki by topic. Returns snippets. Ranked, and returns PUBLISHED " +
+      "articles only; it LAGS writes by minutes while embeddings index. Do NOT use it for " +
+      "existence/idempotency/dedup checks ('already captured?') — a freshly-written article will " +
+      "false-negative. Use knowledge_list (lag-free, all-status, exact meta.total_count) for that. " +
       "q is optional when tags and/or category are supplied: in that list mode it returns the " +
       "COMPLETE filtered set (no relevance ranking) paginated via offset/limit over " +
       "meta.total_count, so you can enumerate every article carrying a tag/category. " +

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -631,6 +631,37 @@ async function knowledgeSearch({ q, project_id, story_id, category, tags, mode, 
   return toContent(result);
 }
 
+async function knowledgeList({
+  project_id,
+  category,
+  status,
+  tags,
+  source_type,
+  source_id,
+  idempotency_key,
+  limit,
+  offset,
+}) {
+  const params = new URLSearchParams();
+  if (project_id) params.set("project_id", project_id);
+  if (category) params.set("category", category);
+  if (status) params.set("status", status);
+  if (tags) params.set("tags", tags);
+  if (source_type) params.set("source_type", source_type);
+  if (source_id) params.set("source_id", source_id);
+  if (idempotency_key) params.set("idempotency_key", idempotency_key);
+  if (limit != null) params.set("limit", String(limit));
+  if (offset != null) params.set("offset", String(offset));
+
+  const result = await apiCall(
+    "GET",
+    `/api/v1/articles?${params}`,
+    null,
+    process.env.LOOPCTL_AGENT_KEY,
+  );
+  return toContent(result);
+}
+
 async function knowledgeGet({ article_id, project_id, story_id }) {
   const params = new URLSearchParams();
   if (project_id) params.set("project_id", project_id);
@@ -1808,6 +1839,63 @@ const TOOLS = [
     },
   },
   {
+    name: "knowledge_list",
+    description:
+      "List articles with FULL fields (id, title, body, category, status, tags, source_type, " +
+      "source_id, idempotency_key, timestamps), filtered and paginated. Unlike knowledge_search " +
+      "(ranked, PUBLISHED-only, and lags writes while embeddings index) and knowledge_index " +
+      "(lightweight id/title/category only), this is the LAG-FREE, ALL-STATUS read of the DB of " +
+      "record — the right tool to enumerate, dedup, or repair. Use it for idempotency/existence " +
+      "checks: filter by `tags`, `source_type`+`source_id`, or `idempotency_key` and read " +
+      "`meta.total_count` (exact) to answer \"does an article for X already exist?\" reliably " +
+      "right after a write. Paginate via offset/limit.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        project_id: {
+          type: "string",
+          format: "uuid",
+          description: "Optional: scope to a project UUID.",
+        },
+        category: {
+          type: "string",
+          description: "Optional: filter by category.",
+        },
+        status: {
+          type: "string",
+          description: "Optional: filter by status (draft, published, archived, superseded).",
+        },
+        tags: {
+          type: "string",
+          description: "Optional: comma-separated tags; matches articles carrying ANY of them.",
+        },
+        source_type: {
+          type: "string",
+          description: "Optional: filter by source_type.",
+        },
+        source_id: {
+          type: "string",
+          description: "Optional: filter by source_id (a malformed id matches nothing).",
+        },
+        idempotency_key: {
+          type: "string",
+          description:
+            "Optional: filter by exact idempotency_key — the lag-free existence check for a " +
+            "prior capture.",
+        },
+        offset: {
+          type: "integer",
+          description: "Optional: rows to skip for pagination (default 0).",
+        },
+        limit: {
+          type: "integer",
+          description: "Optional: max articles per page (default 20, max 100).",
+        },
+      },
+      required: [],
+    },
+  },
+  {
     name: "knowledge_stats",
     description:
       "Get aggregate article counts for the wiki without pulling any article metadata. " +
@@ -2665,6 +2753,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     case "knowledge_search":
       return await knowledgeSearch(args);
+
+    case "knowledge_list":
+      return await knowledgeList(args);
 
     case "knowledge_get":
       return await knowledgeGet(args);

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "MCP server for loopctl — structural trust for AI development loops",
   "type": "module",
   "main": "index.js",

--- a/mcp-server/test/knowledge_tools.test.js
+++ b/mcp-server/test/knowledge_tools.test.js
@@ -118,6 +118,36 @@ async function knowledgeStats({ project_id }) {
   return toContent(result);
 }
 
+async function knowledgeList({
+  project_id,
+  category,
+  status,
+  tags,
+  source_type,
+  source_id,
+  idempotency_key,
+  limit,
+  offset,
+}) {
+  const params = new URLSearchParams();
+  if (project_id) params.set("project_id", project_id);
+  if (category) params.set("category", category);
+  if (status) params.set("status", status);
+  if (tags) params.set("tags", tags);
+  if (source_type) params.set("source_type", source_type);
+  if (source_id) params.set("source_id", source_id);
+  if (idempotency_key) params.set("idempotency_key", idempotency_key);
+  if (limit != null) params.set("limit", String(limit));
+  if (offset != null) params.set("offset", String(offset));
+  const result = await apiCall(
+    "GET",
+    `/api/v1/articles?${params}`,
+    null,
+    process.env.LOOPCTL_AGENT_KEY,
+  );
+  return toContent(result);
+}
+
 async function knowledgeSearch({ q, project_id, story_id, category, tags, mode, limit, offset }) {
   const params = new URLSearchParams();
   if (q != null && q !== "") params.set("q", q);
@@ -896,5 +926,60 @@ describe("knowledge_create: publish-on-create by default (#133)", () => {
     assert.equal(result.isError, undefined, "default publish-on-create must not error");
     assert.equal(calls.length, 1);
     assert.equal(calls[0].options.headers.Authorization, `Bearer ${AGENT_KEY}`);
+  });
+});
+
+describe("knowledge_list: lag-free enumeration (#134/#135)", () => {
+  test("routes to GET /api/v1/articles on the agent key", async () => {
+    setupEnv();
+    const calls = mockFetch({ data: [], meta: { total_count: 0 } });
+
+    await knowledgeList({});
+
+    assert.equal(calls.length, 1);
+    const { url, options } = calls[0];
+    assert.equal(new URL(url).pathname, "/api/v1/articles");
+    assert.equal(options.method, "GET");
+    assert.equal(options.headers.Authorization, `Bearer ${AGENT_KEY}`);
+  });
+
+  test("forwards every filter as a query param (no dropped params)", async () => {
+    setupEnv();
+    const calls = mockFetch({ data: [], meta: { total_count: 0 } });
+
+    await knowledgeList({
+      project_id: "b50c9e38-aebe-4bbe-b8e6-bf2cb2b8afd0",
+      category: "reference",
+      status: "published",
+      tags: "a,b",
+      source_type: "web_article",
+      source_id: "11111111-1111-1111-1111-111111111111",
+      idempotency_key: "ik-1",
+      limit: 50,
+      offset: 100,
+    });
+
+    const q = new URL(calls[0].url).searchParams;
+    assert.equal(q.get("project_id"), "b50c9e38-aebe-4bbe-b8e6-bf2cb2b8afd0");
+    assert.equal(q.get("category"), "reference");
+    assert.equal(q.get("status"), "published");
+    assert.equal(q.get("tags"), "a,b");
+    assert.equal(q.get("source_type"), "web_article");
+    assert.equal(q.get("source_id"), "11111111-1111-1111-1111-111111111111");
+    assert.equal(q.get("idempotency_key"), "ik-1");
+    assert.equal(q.get("limit"), "50");
+    assert.equal(q.get("offset"), "100");
+  });
+
+  test("omits unset filters", async () => {
+    setupEnv();
+    const calls = mockFetch({ data: [], meta: { total_count: 0 } });
+
+    await knowledgeList({ idempotency_key: "only-this" });
+
+    const q = new URL(calls[0].url).searchParams;
+    assert.equal(q.get("idempotency_key"), "only-this");
+    assert.equal(q.get("source_type"), null);
+    assert.equal(q.get("status"), null);
   });
 });

--- a/test/loopctl/knowledge_test.exs
+++ b/test/loopctl/knowledge_test.exs
@@ -225,6 +225,71 @@ defmodule Loopctl.KnowledgeTest do
 
   # --- TC-19.3.2: List with tag overlap filtering ---
 
+  describe "list_articles/2 source + idempotency filters (#134)" do
+    test "filters by source_type, source_id, and idempotency_key" do
+      %{tenant: tenant} = setup_tenant()
+      src = Ecto.UUID.generate()
+
+      {:ok, _a} =
+        Knowledge.create_article(tenant.id, %{
+          title: "From Source",
+          body: "b",
+          category: :reference,
+          source_type: "web_article",
+          source_id: src,
+          idempotency_key: "ik-1"
+        })
+
+      {:ok, _b} =
+        Knowledge.create_article(tenant.id, %{title: "Other", body: "b", category: :reference})
+
+      assert %{meta: %{total_count: 1}} =
+               Knowledge.list_articles(tenant.id, source_type: "web_article")
+
+      assert %{meta: %{total_count: 1}} = Knowledge.list_articles(tenant.id, source_id: src)
+
+      assert %{meta: %{total_count: 1}} =
+               Knowledge.list_articles(tenant.id, idempotency_key: "ik-1")
+    end
+
+    test "a well-formed but absent source_id returns zero (the common 'exists? no')" do
+      %{tenant: tenant} = setup_tenant()
+
+      {:ok, _} =
+        Knowledge.create_article(tenant.id, %{title: "X", body: "b", category: :reference})
+
+      assert %{meta: %{total_count: 0}} =
+               Knowledge.list_articles(tenant.id, source_id: Ecto.UUID.generate())
+    end
+
+    test "a malformed source_id matches nothing (no raise)" do
+      %{tenant: tenant} = setup_tenant()
+
+      {:ok, _} =
+        Knowledge.create_article(tenant.id, %{title: "X", body: "b", category: :reference})
+
+      assert %{meta: %{total_count: 0}} =
+               Knowledge.list_articles(tenant.id, source_id: "not-a-uuid")
+    end
+
+    test "source/idempotency filters are tenant-scoped (no cross-tenant leak)" do
+      %{tenant: tenant_a} = setup_tenant()
+      %{tenant: tenant_b} = setup_tenant()
+
+      {:ok, _} =
+        Knowledge.create_article(tenant_b.id, %{
+          title: "B's",
+          body: "b",
+          category: :reference,
+          idempotency_key: "shared-key"
+        })
+
+      # Tenant A cannot see tenant B's article by the shared key.
+      assert %{meta: %{total_count: 0}} =
+               Knowledge.list_articles(tenant_a.id, idempotency_key: "shared-key")
+    end
+  end
+
   describe "list_articles/2 tag filtering" do
     test "filters articles by tag overlap (ANY match)" do
       %{tenant: tenant} = setup_tenant()

--- a/test/loopctl_web/controllers/article_controller_test.exs
+++ b/test/loopctl_web/controllers/article_controller_test.exs
@@ -521,6 +521,67 @@ defmodule LoopctlWeb.ArticleControllerTest do
   end
 
   describe "GET /api/v1/articles" do
+    test "filters by source_type, source_id, and idempotency_key (lag-free existence check)", %{
+      conn: conn
+    } do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      src = Ecto.UUID.generate()
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "From Source",
+        source_type: "web_article",
+        source_id: src,
+        idempotency_key: "ik-1"
+      })
+
+      fixture(:article, %{tenant_id: tenant.id, title: "Unrelated"})
+
+      # by source_type
+      body =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/articles?source_type=web_article")
+        |> json_response(200)
+
+      assert body["meta"]["total_count"] == 1
+      assert hd(body["data"])["title"] == "From Source"
+
+      # by source_id
+      body2 =
+        build_conn()
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/articles?source_id=#{src}")
+        |> json_response(200)
+
+      assert body2["meta"]["total_count"] == 1
+
+      # by idempotency_key — the canonical existence check
+      body3 =
+        build_conn()
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/articles?idempotency_key=ik-1")
+        |> json_response(200)
+
+      assert body3["meta"]["total_count"] == 1
+      assert hd(body3["data"])["idempotency_key"] == "ik-1"
+    end
+
+    test "a malformed source_id matches nothing (no 500)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      fixture(:article, %{tenant_id: tenant.id, title: "X"})
+
+      body =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/articles?source_id=not-a-uuid")
+        |> json_response(200)
+
+      assert body["meta"]["total_count"] == 0
+    end
+
     test "lists articles with category and tags filters", %{conn: conn} do
       tenant = fixture(:tenant)
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})


### PR DESCRIPTION
## What

Adds a lag-free article enumeration primitive over MCP and the filters that make it a reliable dedup/idempotency check. Closes **#135** and **#134**.

## Why

The "search index lags writes" report (#134) is mostly that `knowledge_search` ranks and returns **published** articles only and lags while embeddings index, whereas `GET /api/v1/articles` is the **lag-free, all-status** read of the DB of record. MCP-only clients had no lag-free enumeration tool (#135), so they dropped to raw HTTP with hand-managed STH headers.

## Changes

- **New MCP `knowledge_list`** wrapping `GET /api/v1/articles`: full fields (status, tags, source_type, source_id, idempotency_key, timestamps), filtered + paginated, exact `meta.total_count`. The right tool for enumerate/dedup/repair and idempotency/existence checks right after a write — vs the ranked, published-only, write-lagging `knowledge_search`.
- **`GET /api/v1/articles` now filters by `source_type`, `source_id`, `idempotency_key`** (a malformed `source_id` matches nothing rather than 500ing).
- Documented search-vs-list (ranked/published-only/lagging vs lag-free/all-status) in the index OpenAPI description and the MCP tool descriptions — addressing #134's "document the lag."
- MCP bumped to `2.11.0` (+ CHANGELOG, README, tool count 56).
- Tests for each filter + the malformed-id no-500 path.

## Verification

`mix precommit` green: format, credo --strict, dialyzer, 2387 tests, 0 failures. MCP 35/35.

_Draft until enhanced review completes._
