### PR TITLE
Bulk delete (archive) + harden 429 Retry-After/docs (#136)

### DIFF
--- a/lib/loopctl/api_spec/schemas.ex
+++ b/lib/loopctl/api_spec/schemas.ex
@@ -50,7 +50,13 @@ defmodule Loopctl.ApiSpec.Schemas do
 
     OpenApiSpex.schema(%{
       title: "RateLimitError",
-      description: "Rate limit exceeded response",
+      description:
+        "Rate limit exceeded. Default limits: 300 requests/minute per API key and 3x that " <>
+          "per tenant (superadmin keys are exempt; per-tenant overrides via the " <>
+          "`rate_limit_requests_per_minute` setting). Back off using the response headers: " <>
+          "`Retry-After` (seconds until the window resets, always >= 1), plus `X-RateLimit-Limit`, " <>
+          "`X-RateLimit-Remaining`, and `X-RateLimit-Reset` (Unix epoch seconds), which are set " <>
+          "on every response.",
       type: :object,
       properties: %{
         error: %Schema{
@@ -60,16 +66,10 @@ defmodule Loopctl.ApiSpec.Schemas do
             status: %Schema{type: :integer, example: 429},
             message: %Schema{type: :string, example: "Rate limit exceeded"}
           }
-        },
-        retry_after: %Schema{
-          type: :integer,
-          description: "Seconds until rate limit resets",
-          example: 45
         }
       },
       example: %{
-        error: %{status: 429, message: "Rate limit exceeded"},
-        retry_after: 45
+        error: %{status: 429, message: "Rate limit exceeded"}
       }
     })
   end

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -1866,10 +1866,12 @@ defmodule Loopctl.Knowledge do
   end
 
   @doc """
-  Returns the ids of active (draft/published) articles matching `opts`
-  (`:source_type`/`:source_id`/`:tags`/`:category`/`:project_id`) for a
-  selector-based bulk archive. Bounded: returns `{:error, :too_many}` when the
-  match set exceeds #{@bulk_publish_max} (the caller should narrow the selector).
+  Returns the ids of active (draft/published) articles matching `opts` (the same
+  filters as `list_articles/2` — `:source_type`/`:source_id`/`:tags`/`:category`/
+  `:project_id`) for a selector-based bulk archive. The bulk-delete endpoint
+  currently drives it with the source and tag filters. Bounded: returns
+  `{:error, :too_many}` when the match set exceeds #{@bulk_publish_max} (the
+  caller should narrow the selector).
   """
   @spec list_archivable_ids(Ecto.UUID.t(), keyword()) ::
           {:ok, [Ecto.UUID.t()]} | {:error, :too_many}

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -1521,19 +1521,8 @@ defmodule Loopctl.Knowledge do
   end
 
   defp do_bulk_publish(tenant_id, article_ids, opts) do
-    # Only well-formed UUIDs can be looked up; a malformed string would raise on
-    # the `id in ^ids` cast, so keep it out of the query — it resolves to a clean
-    # "not_found" via the absent `existing` entry below.
-    queryable_ids = Enum.filter(article_ids, &valid_uuid?/1)
-
     # Load every requested article once, keyed by id (lag-free, DB-of-record).
-    existing =
-      from(a in Article,
-        where: a.tenant_id == ^tenant_id,
-        where: a.id in ^queryable_ids
-      )
-      |> AdminRepo.all()
-      |> Map.new(&{&1.id, &1})
+    existing = load_existing_by_ids(tenant_id, article_ids)
 
     drafts =
       for id <- article_ids,
@@ -1541,8 +1530,20 @@ defmodule Loopctl.Knowledge do
           do: Map.fetch!(existing, id)
 
     # Publish drafts in bounded chunks; collect what actually published and any
-    # ids whose chunk failed unexpectedly.
-    {published, errored_ids} = publish_drafts_in_chunks(tenant_id, drafts, opts)
+    # ids whose chunk failed unexpectedly. Embeddings are enqueued AFTER each
+    # chunk commits (post-commit), only for rows that actually published — Oban
+    # runs on a separate repo/pool from AdminRepo, so enqueuing inside the
+    # transaction would leak jobs for rolled-back rows.
+    {published, errored_ids} =
+      transition_in_chunks(
+        tenant_id,
+        drafts,
+        :published,
+        "article.published",
+        opts,
+        &enqueue_bulk_embeddings(tenant_id, &1)
+      )
+
     published_ids = MapSet.new(published, & &1.id)
     errored_set = MapSet.new(errored_ids)
 
@@ -1595,62 +1596,71 @@ defmodule Loopctl.Knowledge do
     end
   end
 
-  defp publish_drafts_in_chunks(tenant_id, drafts, opts) do
-    drafts
+  # Shared bulk status-transition runner (used by bulk_publish -> :published and
+  # bulk_archive -> :archived). Processes `articles` in bounded chunks; returns
+  # `{transitioned, errored_ids}`. `post_commit` runs after each chunk's
+  # transaction commits, with the rows that actually transitioned (publish uses
+  # it to enqueue embeddings; archive passes a no-op).
+  defp transition_in_chunks(tenant_id, articles, target_status, audit_action, opts, post_commit) do
+    articles
     |> Enum.chunk_every(@bulk_publish_chunk_size)
-    |> Enum.reduce({[], []}, fn chunk, {pub_acc, err_acc} ->
-      {published, errored_ids} = publish_chunk_isolating_failures(tenant_id, chunk, opts)
-      # Embeddings are enqueued AFTER the publish transaction commits, and only
-      # for rows that actually published — Oban runs on a separate repo/pool from
-      # AdminRepo, so enqueuing inside the transaction would leak jobs for rows
-      # that rolled back.
-      enqueue_bulk_embeddings(tenant_id, published)
-      {pub_acc ++ published, err_acc ++ errored_ids}
+    |> Enum.reduce({[], []}, fn chunk, {ok_acc, err_acc} ->
+      {done, errored_ids} =
+        transition_chunk_isolating_failures(tenant_id, chunk, target_status, audit_action, opts)
+
+      post_commit.(done)
+      {ok_acc ++ done, err_acc ++ errored_ids}
     end)
   end
 
-  # Publish a chunk in one transaction; if it fails, retry each draft alone so a
+  # Transition a chunk in one transaction; if it fails, retry each row alone so a
   # single bad row doesn't sink the whole chunk (true partial success). The retry
   # is bounded: at most @bulk_publish_max single-row transactions per request
   # (50 chunks x 100), so a pathological all-failing request can't run unbounded.
   #
-  # NB: a draft -> published status update has no validation that can fail for a
-  # well-formed draft, so the `{:error, _}` branch is a defensive fallback for
-  # genuine DB-level failures (serialization, connection loss, a constraint
-  # regression). It is therefore not exercised by the integration tests without
-  # fault injection (which this codebase has no DI seam for) — the partial-success
-  # accounting around it (counts/results) is what the tests cover.
-  defp publish_chunk_isolating_failures(tenant_id, chunk, opts) do
-    case execute_bulk_publish(tenant_id, chunk, opts) do
-      {:ok, published} ->
-        {published, []}
+  # NB: a draft->published / draft|published->archived update has no validation
+  # that can fail for a well-formed row, so the `{:error, _}` branch is a
+  # defensive fallback for genuine DB-level failures (serialization, connection
+  # loss, a constraint regression). It is therefore not exercised by the
+  # integration tests without fault injection (which this codebase has no DI seam
+  # for) — the partial-success accounting around it (counts/results) is tested.
+  defp transition_chunk_isolating_failures(tenant_id, chunk, target_status, audit_action, opts) do
+    case execute_bulk_transition(tenant_id, chunk, target_status, audit_action, opts) do
+      {:ok, done} ->
+        {done, []}
 
       {:error, _changeset} ->
-        {pub, err} = Enum.reduce(chunk, {[], []}, &publish_one_isolated(tenant_id, &1, opts, &2))
-        log_chunk_failures(chunk, err)
-        {pub, err}
+        {ok, err} =
+          Enum.reduce(
+            chunk,
+            {[], []},
+            &transition_one_isolated(tenant_id, &1, target_status, audit_action, opts, &2)
+          )
+
+        log_chunk_failures(audit_action, chunk, err)
+        {ok, err}
     end
   end
 
-  defp publish_one_isolated(tenant_id, article, opts, {pub, err}) do
-    case execute_bulk_publish(tenant_id, [article], opts) do
-      {:ok, published} -> {pub ++ published, err}
-      {:error, _cs} -> {pub, err ++ [article.id]}
+  defp transition_one_isolated(tenant_id, article, target_status, audit_action, opts, {ok, err}) do
+    case execute_bulk_transition(tenant_id, [article], target_status, audit_action, opts) do
+      {:ok, done} -> {ok ++ done, err}
+      {:error, _cs} -> {ok, err ++ [article.id]}
     end
   end
 
   # One aggregated log line per failing chunk (not one per row) so a systemic
   # failure of a large request can't flood the logs with thousands of lines.
-  defp log_chunk_failures(_chunk, []), do: :ok
+  defp log_chunk_failures(_audit_action, _chunk, []), do: :ok
 
-  defp log_chunk_failures(chunk, errored_ids) do
+  defp log_chunk_failures(audit_action, chunk, errored_ids) do
     Logger.error(
-      "bulk_publish: #{length(errored_ids)}/#{length(chunk)} drafts failed to publish: " <>
+      "#{audit_action}: #{length(errored_ids)}/#{length(chunk)} rows failed: " <>
         Enum.join(errored_ids, ", ")
     )
   end
 
-  defp execute_bulk_publish(tenant_id, articles, opts) do
+  defp execute_bulk_transition(tenant_id, articles, target_status, audit_action, opts) do
     actor_id = Keyword.get(opts, :actor_id)
     actor_label = Keyword.get(opts, :actor_label)
     actor_type = Keyword.get(opts, :actor_type, "api_key")
@@ -1662,19 +1672,26 @@ defmodule Loopctl.Knowledge do
     multi =
       indexed_articles
       |> Enum.reduce(Multi.new(), fn {article, idx}, multi ->
-        changeset = Article.update_changeset(article, %{status: :published})
-        Multi.update(multi, {:publish, idx}, changeset)
+        changeset = Article.update_changeset(article, %{status: target_status})
+        Multi.update(multi, {:item, idx}, changeset)
       end)
-      |> add_bulk_audit_entries(tenant_id, indexed_articles, actor_id, actor_label, actor_type)
+      |> add_bulk_audit_entries(
+        tenant_id,
+        indexed_articles,
+        audit_action,
+        actor_id,
+        actor_label,
+        actor_type
+      )
 
     case AdminRepo.transaction(multi) do
       {:ok, results} ->
-        published =
+        done =
           indexed_articles
-          |> Enum.map(fn {_article, idx} -> Map.get(results, {:publish, idx}) end)
+          |> Enum.map(fn {_article, idx} -> Map.get(results, {:item, idx}) end)
           |> Enum.reject(&is_nil/1)
 
-        {:ok, published}
+        {:ok, done}
 
       {:error, _key, changeset, _completed} ->
         {:error, changeset}
@@ -1707,27 +1724,167 @@ defmodule Loopctl.Knowledge do
          multi,
          tenant_id,
          indexed_articles,
+         audit_action,
          actor_id,
          actor_label,
          actor_type
        ) do
-    Enum.reduce(indexed_articles, multi, fn {_article, idx}, multi ->
+    Enum.reduce(indexed_articles, multi, fn {article, idx}, multi ->
+      old_status = to_string(article.status)
+
       Audit.log_in_multi(multi, {:audit, idx}, fn changes ->
-        updated = Map.get(changes, {:publish, idx})
+        updated = Map.get(changes, {:item, idx})
 
         %{
           tenant_id: tenant_id,
           entity_type: "article",
           entity_id: updated.id,
-          action: "article.published",
+          action: audit_action,
           actor_type: actor_type,
           actor_id: actor_id,
           actor_label: actor_label,
-          old_state: %{"status" => "draft"},
+          old_state: %{"status" => old_status},
           new_state: %{"status" => to_string(updated.status)}
         }
       end)
     end)
+  end
+
+  @doc """
+  Archives articles in bulk (soft delete), **partial-success** style — the
+  delete analogue of `bulk_publish/3`.
+
+  Each requested id resolves to one of:
+
+  - `"archived"` -- it was draft/published and is now archived
+  - `"skipped"` -- already archived (idempotent no-op), or superseded
+    (`reason` says which)
+  - `"not_found"` -- no such article in this tenant
+  - `"errored"` -- the archive transaction failed unexpectedly
+
+  Duplicate ids are de-duplicated; malformed ids resolve to `"not_found"`.
+  Bounded to #{@bulk_publish_max} ids per call (auto-chunked). Returns
+  `{:ok, %{archived: [...], results: [...], counts: %{...}}}` or
+  `{:error, :bad_request, msg}` when `article_ids` is empty/over the cap.
+  """
+  @spec bulk_archive(Ecto.UUID.t(), [Ecto.UUID.t()], keyword()) ::
+          {:ok, %{archived: [Article.t()], results: [map()], counts: map()}}
+          | {:error, :bad_request, String.t()}
+  def bulk_archive(_tenant_id, article_ids, _opts) when article_ids in [nil, []] do
+    {:error, :bad_request, "article_ids must not be empty"}
+  end
+
+  def bulk_archive(tenant_id, article_ids, opts) do
+    ids = article_ids |> List.wrap() |> Enum.filter(&is_binary/1) |> Enum.uniq()
+
+    cond do
+      ids == [] ->
+        {:error, :bad_request, "article_ids must contain at least one UUID string"}
+
+      length(ids) > @bulk_publish_max ->
+        {:error, :bad_request,
+         "Maximum #{@bulk_publish_max} article ids per bulk delete; split into smaller calls"}
+
+      true ->
+        {:ok, do_bulk_archive(tenant_id, ids, opts)}
+    end
+  end
+
+  defp do_bulk_archive(tenant_id, article_ids, opts) do
+    existing = load_existing_by_ids(tenant_id, article_ids)
+
+    archivable =
+      for id <- article_ids,
+          match?(%Article{status: s} when s in [:draft, :published], Map.get(existing, id)),
+          do: Map.fetch!(existing, id)
+
+    # Archiving has no post-commit side effect (archived rows are hidden from
+    # search, so no embedding work is needed).
+    {archived, errored_ids} =
+      transition_in_chunks(tenant_id, archivable, :archived, "article.archived", opts, fn _ ->
+        :ok
+      end)
+
+    archived_ids = MapSet.new(archived, & &1.id)
+    errored_set = MapSet.new(errored_ids)
+
+    results = Enum.map(article_ids, &bulk_archive_result(&1, existing, archived_ids, errored_set))
+    by_outcome = Enum.frequencies_by(results, & &1.outcome)
+
+    %{
+      archived: archived,
+      results: results,
+      counts: %{
+        requested: length(article_ids),
+        archived: Map.get(by_outcome, "archived", 0),
+        skipped: Map.get(by_outcome, "skipped", 0),
+        not_found: Map.get(by_outcome, "not_found", 0),
+        errored: Map.get(by_outcome, "errored", 0)
+      }
+    }
+  end
+
+  defp bulk_archive_result(id, existing, archived_ids, errored_set) do
+    cond do
+      MapSet.member?(errored_set, id) ->
+        %{id: id, outcome: "errored", reason: "archive_failed"}
+
+      MapSet.member?(archived_ids, id) ->
+        %{id: id, outcome: "archived", status: "archived"}
+
+      true ->
+        case Map.get(existing, id) do
+          nil ->
+            %{id: id, outcome: "not_found"}
+
+          %Article{status: :archived} ->
+            %{id: id, outcome: "skipped", reason: "already_archived", status: "archived"}
+
+          %Article{status: status} ->
+            %{
+              id: id,
+              outcome: "skipped",
+              reason: "not_archivable_from_#{status}",
+              status: to_string(status)
+            }
+        end
+    end
+  end
+
+  # Load the requested articles once, keyed by id. Malformed (non-UUID) ids are
+  # kept out of the `id in ^ids` query (which would raise on cast) so they
+  # resolve to a clean "not_found" via the absent map entry.
+  defp load_existing_by_ids(tenant_id, article_ids) do
+    queryable_ids = Enum.filter(article_ids, &valid_uuid?/1)
+
+    from(a in Article,
+      where: a.tenant_id == ^tenant_id,
+      where: a.id in ^queryable_ids
+    )
+    |> AdminRepo.all()
+    |> Map.new(&{&1.id, &1})
+  end
+
+  @doc """
+  Returns the ids of active (draft/published) articles matching `opts`
+  (`:source_type`/`:source_id`/`:tags`/`:category`/`:project_id`) for a
+  selector-based bulk archive. Bounded: returns `{:error, :too_many}` when the
+  match set exceeds #{@bulk_publish_max} (the caller should narrow the selector).
+  """
+  @spec list_archivable_ids(Ecto.UUID.t(), keyword()) ::
+          {:ok, [Ecto.UUID.t()]} | {:error, :too_many}
+  def list_archivable_ids(tenant_id, opts) do
+    ids =
+      from(a in Article,
+        where: a.tenant_id == ^tenant_id,
+        where: a.status in [:draft, :published],
+        select: a.id,
+        limit: ^(@bulk_publish_max + 1)
+      )
+      |> apply_article_filters(opts)
+      |> AdminRepo.all()
+
+    if length(ids) > @bulk_publish_max, do: {:error, :too_many}, else: {:ok, ids}
   end
 
   # --- Obsidian Export ---

--- a/lib/loopctl_web/controllers/article_workflow_controller.ex
+++ b/lib/loopctl_web/controllers/article_workflow_controller.ex
@@ -123,14 +123,19 @@ defmodule LoopctlWeb.ArticleWorkflowController do
   operation(:bulk_delete,
     summary: "Bulk delete (archive) articles",
     description:
-      "Soft-deletes (archives) articles **partial-success** style. Provide exactly one " <>
-        "selector: `article_ids` (explicit list), `source_type` + `source_id` (every active " <>
-        "article from that source — clean dedup cleanup), or `tag` + `confirm: true` (every " <>
-        "active article carrying the tag — high blast radius, so `confirm: true` is required). " <>
+      "Soft-deletes (archives) articles **partial-success** style. Provide **exactly one** " <>
+        "selector (supplying more than one is a 400): `article_ids` (explicit list), " <>
+        "`source_type` + `source_id` (every active article from that source — clean dedup " <>
+        "cleanup; not confirm-gated, can be large), or `tag` + `confirm: true` (every active " <>
+        "article carrying the tag — high blast radius, so `confirm: true` is required). " <>
         "Honors soft-delete: rows move to `archived`, not dropped. Each id gets a per-id " <>
         "`outcome` (`archived`; `skipped` with `already_archived`/`not_archivable_from_superseded`; " <>
         "`not_found`; `errored`). `meta.count` = number archived; `meta.counts`/`meta.results` " <>
-        "give the breakdown. Bounded to 5000 per call. Role: user+.",
+        "give the breakdown. A 200 does not imply everything archived — inspect `meta.counts`. " <>
+        "Bounded to 5000 per call; a `source_type`/`tag` selector matching more than 5000 active " <>
+        "articles returns 400 (narrow the selector). An `article_ids` request with zero matches " <>
+        "still returns 200 (per-id `not_found`); a `source`/`tag` selector matching nothing " <>
+        "returns 400. Role: user+.",
     request_body:
       {"Bulk delete selector", "application/json",
        %OpenApiSpex.Schema{
@@ -264,20 +269,61 @@ defmodule LoopctlWeb.ArticleWorkflowController do
     end
   end
 
-  # Resolve the bulk-delete selector to a concrete id list. Exactly one of:
+  # Resolve the bulk-delete selector to a concrete id list. EXACTLY ONE selector
+  # must be supplied (enforced — not first-match-wins — so a stray second
+  # selector can't silently win and, e.g., bypass the by-tag confirm gate):
   #   - article_ids: [..]                  (explicit list)
   #   - source_type + source_id            (every active article from that source)
   #   - tag + confirm: true                (every active article carrying the tag;
   #                                         confirm required — high blast radius)
-  defp resolve_bulk_delete_ids(_tenant_id, %{"article_ids" => ids}) when is_list(ids),
-    do: {:ok, ids}
+  defp resolve_bulk_delete_ids(tenant_id, params) do
+    # `source_type`/`source_id` count as one selector ("source"); supplying only
+    # one half still selects "source" so the pairing error fires (not the generic
+    # one).
+    present =
+      [
+        {:article_ids, params["article_ids"]},
+        {:source, params["source_type"] || params["source_id"]},
+        {:tag, params["tag"]}
+      ]
+      |> Enum.filter(fn {_k, v} -> not is_nil(v) end)
+      |> Enum.map(&elem(&1, 0))
 
-  defp resolve_bulk_delete_ids(tenant_id, %{"source_type" => type, "source_id" => src})
+    case present do
+      [:article_ids] ->
+        resolve_ids_selector(params["article_ids"])
+
+      [:source] ->
+        resolve_source_selector(tenant_id, params)
+
+      [:tag] ->
+        resolve_tag_selector(tenant_id, params)
+
+      [] ->
+        {:error, :bad_request, selector_help()}
+
+      _ ->
+        {:error, :bad_request, "Provide exactly ONE selector (got several). " <> selector_help()}
+    end
+  end
+
+  defp selector_help do
+    "Selectors: article_ids (list), source_type + source_id, or tag + confirm: true."
+  end
+
+  defp resolve_ids_selector(ids) when is_list(ids), do: {:ok, ids}
+  defp resolve_ids_selector(_), do: {:error, :bad_request, "article_ids must be a JSON array."}
+
+  defp resolve_source_selector(tenant_id, %{"source_type" => type, "source_id" => src})
        when is_binary(type) and is_binary(src) do
     archivable_ids_or_error(tenant_id, source_type: type, source_id: src)
   end
 
-  defp resolve_bulk_delete_ids(tenant_id, %{"tag" => tag} = params) when is_binary(tag) do
+  defp resolve_source_selector(_tenant_id, _params) do
+    {:error, :bad_request, "source_type and source_id must be provided together."}
+  end
+
+  defp resolve_tag_selector(tenant_id, %{"tag" => tag} = params) when is_binary(tag) do
     if truthy?(params["confirm"]) do
       archivable_ids_or_error(tenant_id, tags: [tag])
     else
@@ -286,9 +332,8 @@ defmodule LoopctlWeb.ArticleWorkflowController do
     end
   end
 
-  defp resolve_bulk_delete_ids(_tenant_id, _params) do
-    {:error, :bad_request,
-     "Provide exactly one selector: article_ids (list), source_type + source_id, or tag + confirm: true."}
+  defp resolve_tag_selector(_tenant_id, _params) do
+    {:error, :bad_request, "tag must be a string."}
   end
 
   defp archivable_ids_or_error(tenant_id, filters) do

--- a/lib/loopctl_web/controllers/article_workflow_controller.ex
+++ b/lib/loopctl_web/controllers/article_workflow_controller.ex
@@ -6,6 +6,7 @@ defmodule LoopctlWeb.ArticleWorkflowController do
   - `POST /api/v1/articles/:id/unpublish` -- unpublish a published article (user+)
   - `POST /api/v1/articles/:id/archive` -- archive an article (user+)
   - `POST /api/v1/knowledge/bulk-publish` -- bulk publish drafts (user+)
+  - `POST /api/v1/knowledge/bulk-delete` -- bulk archive/soft-delete (user+)
   - `GET /api/v1/knowledge/drafts` -- list draft articles (orchestrator+)
   """
 
@@ -22,7 +23,7 @@ defmodule LoopctlWeb.ArticleWorkflowController do
   plug LoopctlWeb.Plugs.RequireRole, [role: :orchestrator] when action in [:drafts, :publish]
 
   plug LoopctlWeb.Plugs.RequireRole,
-       [role: :user] when action in [:unpublish, :archive, :bulk_publish]
+       [role: :user] when action in [:unpublish, :archive, :bulk_publish, :bulk_delete]
 
   tags(["Knowledge Wiki"])
 
@@ -119,6 +120,53 @@ defmodule LoopctlWeb.ArticleWorkflowController do
     }
   )
 
+  operation(:bulk_delete,
+    summary: "Bulk delete (archive) articles",
+    description:
+      "Soft-deletes (archives) articles **partial-success** style. Provide exactly one " <>
+        "selector: `article_ids` (explicit list), `source_type` + `source_id` (every active " <>
+        "article from that source — clean dedup cleanup), or `tag` + `confirm: true` (every " <>
+        "active article carrying the tag — high blast radius, so `confirm: true` is required). " <>
+        "Honors soft-delete: rows move to `archived`, not dropped. Each id gets a per-id " <>
+        "`outcome` (`archived`; `skipped` with `already_archived`/`not_archivable_from_superseded`; " <>
+        "`not_found`; `errored`). `meta.count` = number archived; `meta.counts`/`meta.results` " <>
+        "give the breakdown. Bounded to 5000 per call. Role: user+.",
+    request_body:
+      {"Bulk delete selector", "application/json",
+       %OpenApiSpex.Schema{
+         type: :object,
+         properties: %{
+           article_ids: %OpenApiSpex.Schema{
+             type: :array,
+             items: %OpenApiSpex.Schema{type: :string, format: :uuid}
+           },
+           source_type: %OpenApiSpex.Schema{type: :string},
+           source_id: %OpenApiSpex.Schema{type: :string, format: :uuid},
+           tag: %OpenApiSpex.Schema{type: :string},
+           confirm: %OpenApiSpex.Schema{
+             type: :boolean,
+             description: "Required (true) when deleting by tag."
+           }
+         }
+       }},
+    responses: %{
+      200 =>
+        {"Bulk delete result (partial success; see meta.results / meta.counts)",
+         "application/json",
+         %OpenApiSpex.Schema{
+           type: :object,
+           properties: %{
+             data: %OpenApiSpex.Schema{type: :array},
+             meta: %OpenApiSpex.Schema{type: :object}
+           }
+         }},
+      400 =>
+        {"Bad request (no/ambiguous selector, tag without confirm, empty match, or over cap)",
+         "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
   operation(:drafts,
     summary: "List draft articles",
     description:
@@ -196,6 +244,69 @@ defmodule LoopctlWeb.ArticleWorkflowController do
       })
     end
   end
+
+  @doc "POST /api/v1/knowledge/bulk-delete"
+  def bulk_delete(conn, params) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+    audit_opts = AuditContext.from_conn(conn)
+
+    with {:ok, ids} <- resolve_bulk_delete_ids(tenant_id, params),
+         {:ok, result} <- Knowledge.bulk_archive(tenant_id, ids, audit_opts) do
+      json(conn, %{
+        data: Enum.map(result.archived, &ArticleJSON.article_data/1),
+        meta: %{
+          # `count` = number actually archived.
+          count: result.counts.archived,
+          counts: result.counts,
+          results: result.results
+        }
+      })
+    end
+  end
+
+  # Resolve the bulk-delete selector to a concrete id list. Exactly one of:
+  #   - article_ids: [..]                  (explicit list)
+  #   - source_type + source_id            (every active article from that source)
+  #   - tag + confirm: true                (every active article carrying the tag;
+  #                                         confirm required — high blast radius)
+  defp resolve_bulk_delete_ids(_tenant_id, %{"article_ids" => ids}) when is_list(ids),
+    do: {:ok, ids}
+
+  defp resolve_bulk_delete_ids(tenant_id, %{"source_type" => type, "source_id" => src})
+       when is_binary(type) and is_binary(src) do
+    archivable_ids_or_error(tenant_id, source_type: type, source_id: src)
+  end
+
+  defp resolve_bulk_delete_ids(tenant_id, %{"tag" => tag} = params) when is_binary(tag) do
+    if truthy?(params["confirm"]) do
+      archivable_ids_or_error(tenant_id, tags: [tag])
+    else
+      {:error, :bad_request,
+       "Deleting by tag archives every active article carrying it — pass confirm: true to proceed."}
+    end
+  end
+
+  defp resolve_bulk_delete_ids(_tenant_id, _params) do
+    {:error, :bad_request,
+     "Provide exactly one selector: article_ids (list), source_type + source_id, or tag + confirm: true."}
+  end
+
+  defp archivable_ids_or_error(tenant_id, filters) do
+    case Knowledge.list_archivable_ids(tenant_id, filters) do
+      {:ok, []} ->
+        {:error, :bad_request, "No active articles match the selector."}
+
+      {:ok, ids} ->
+        {:ok, ids}
+
+      {:error, :too_many} ->
+        {:error, :bad_request, "Selector matches too many articles; narrow it."}
+    end
+  end
+
+  defp truthy?(true), do: true
+  defp truthy?("true"), do: true
+  defp truthy?(_), do: false
 
   @doc "GET /api/v1/knowledge/drafts"
   def drafts(conn, params) do

--- a/lib/loopctl_web/plugs/rate_limiter.ex
+++ b/lib/loopctl_web/plugs/rate_limiter.ex
@@ -75,9 +75,13 @@ defmodule LoopctlWeb.Plugs.RateLimiter do
   end
 
   defp deny_response(conn, limit, reset_at) do
+    # Seconds until the window resets; always >= 1 so a client at the window
+    # boundary still backs off rather than hot-looping on a 0/negative value.
+    retry_after = max(1, reset_at - System.system_time(:second))
+
     conn
     |> put_rate_limit_headers(limit, 0, reset_at)
-    |> put_resp_header("retry-after", to_string(reset_at - System.system_time(:second)))
+    |> put_resp_header("retry-after", to_string(retry_after))
     |> put_status(:too_many_requests)
     |> Phoenix.Controller.json(%{
       error: %{status: 429, message: "Rate limit exceeded"}

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -288,8 +288,9 @@ defmodule LoopctlWeb.Router do
     post "/articles/:id/archive", ArticleWorkflowController, :archive
     resources "/articles", ArticleController, except: [:new, :edit]
 
-    # Knowledge bulk-publish and drafts queue
+    # Knowledge bulk-publish, bulk-delete, and drafts queue
     post "/knowledge/bulk-publish", ArticleWorkflowController, :bulk_publish
+    post "/knowledge/bulk-delete", ArticleWorkflowController, :bulk_delete
     get "/knowledge/drafts", ArticleWorkflowController, :drafts
 
     # Knowledge Index (lightweight catalog)

--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to `loopctl-mcp-server` are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 2.12.0 — 2026-06-22 (knowledge_bulk_delete)
+
+### Added
+
+- New `knowledge_bulk_delete` tool (requires `LOOPCTL_USER_KEY`): bulk
+  soft-delete (archive), partial-success. Selectors: `article_ids`,
+  `source_type`+`source_id` (dedup cleanup), or `tag`+`confirm:true`
+  (high-blast-radius, confirm required). Per-id outcomes
+  (archived/skipped/not_found/errored) in `meta.results`; idempotent
+  (already-archived skipped); auto-chunked, ≤5000/call; emits a warning when
+  the run is partial. Wraps the new `POST /api/v1/knowledge/bulk-delete`. (loopctl #136)
+
+### Note
+
+- 429 responses carry a `Retry-After` header (always ≥1s) plus
+  `X-RateLimit-*`; default limit 300 req/min/key (3x/tenant). (loopctl #136)
+
 ## 2.11.0 — 2026-06-22 (knowledge_list: lag-free enumeration)
 
 ### Added

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -2,7 +2,7 @@
 
 MCP (Model Context Protocol) server for [loopctl](https://loopctl.com) -- structural trust for AI development loops.
 
-Wraps the loopctl REST API into 56 typed MCP tools so AI coding agents (Claude Code, etc.) can interact with loopctl without writing curl commands.
+Wraps the loopctl REST API into 57 typed MCP tools so AI coding agents (Claude Code, etc.) can interact with loopctl without writing curl commands.
 
 ## Installation
 
@@ -66,7 +66,7 @@ Or if installed locally:
 
 Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_KEY`.
 
-## Tools (56)
+## Tools (57)
 
 ### Project Tools
 
@@ -162,6 +162,7 @@ Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_K
 | `knowledge_unpublish` | **Requires `LOOPCTL_USER_KEY`.** Revert a published article back to draft (hidden from search/context, not deleted). Required: `article_id`. |
 | `knowledge_archive` | **Requires `LOOPCTL_USER_KEY`.** Soft-delete an article (draft or published). Row retained for audit; hidden from all reads. Required: `article_id`. |
 | `knowledge_delete` | **Requires `LOOPCTL_USER_KEY`.** Alias for `knowledge_archive` — DELETE verb on the REST API archives under the hood. Required: `article_id`. |
+| `knowledge_bulk_delete` | **Requires `LOOPCTL_USER_KEY`.** Bulk soft-delete (archive), partial-success. Provide exactly one selector: `article_ids` (list), `source_type`+`source_id` (every active article from a source — dedup cleanup), or `tag`+`confirm:true` (every active article with the tag — high blast radius). Per-id outcomes (archived/skipped/not_found/errored) in `meta.results`; `meta.count`=archived; idempotent (already-archived skipped); no 100-cap (auto-chunked, ≤5000). |
 | `knowledge_drafts` | List draft (unpublished) knowledge articles with pagination. Optional: `limit` (default 20, max 20), `offset` (default 0), `project_id`. Returns `meta.total_count`. |
 | `knowledge_lint` | Run a lint check on the knowledge wiki to identify stale or low-coverage articles. Optional: `project_id`, `stale_days`, `min_coverage`, `max_per_category` (default 50, max 500). True totals returned in `summary.total_per_category`. |
 | `knowledge_export` | Export all knowledge articles as a ZIP archive. Returns a curl command for direct download (ZIP binary cannot be returned as MCP content). Optional: `project_id`. |

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -779,6 +779,37 @@ async function knowledgeDelete({ article_id }) {
   return toContent(result);
 }
 
+async function knowledgeBulkDelete({ article_ids, source_type, source_id, tag, confirm }) {
+  const payload = {};
+  if (article_ids) payload.article_ids = article_ids;
+  if (source_type) payload.source_type = source_type;
+  if (source_id) payload.source_id = source_id;
+  if (tag) payload.tag = tag;
+  if (confirm) payload.confirm = confirm;
+
+  const result = await apiCall(
+    "POST",
+    "/api/v1/knowledge/bulk-delete",
+    payload,
+    process.env.LOOPCTL_USER_KEY,
+  );
+
+  // Partial success returns 200 even when some ids didn't archive — surface a
+  // warning so the agent doesn't treat not_found/errored as success.
+  const counts = result?.meta?.counts;
+  if (counts && (counts.not_found > 0 || counts.errored > 0)) {
+    const warning =
+      `WARNING: bulk-delete was partial — archived ${counts.archived}, ` +
+      `skipped ${counts.skipped}, not_found ${counts.not_found}, errored ${counts.errored} ` +
+      `(of ${counts.requested}). Inspect meta.results; not_found/errored ids were NOT archived.`;
+    return {
+      content: [{ type: "text", text: warning }, ...toContent(result).content],
+    };
+  }
+
+  return toContent(result);
+}
+
 async function knowledgeDrafts({ limit, offset, project_id }) {
   const params = new URLSearchParams();
   params.set(
@@ -2209,6 +2240,46 @@ const TOOLS = [
     },
   },
   {
+    name: "knowledge_bulk_delete",
+    description:
+      "Bulk soft-delete (archive) articles, partial-success style. REQUIRES LOOPCTL_USER_KEY " +
+      "(user role — orchestrator is NOT sufficient). Provide EXACTLY ONE selector: " +
+      "article_ids (explicit list), source_type + source_id (every active article from that " +
+      "source — clean dedup cleanup), or tag + confirm:true (every active article carrying the " +
+      "tag — high blast radius, so confirm:true is required). Honors soft-delete (rows move to " +
+      "archived, never dropped). Each id gets a per-id outcome (archived / skipped / not_found / " +
+      "errored); meta.count = archived, meta.counts/meta.results give the breakdown. Already-" +
+      "archived ids are skipped (idempotent). Bounded to 5000 per call. Safe to retry.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        article_ids: {
+          type: "array",
+          items: { type: "string" },
+          description: "Explicit article UUIDs to archive (selector 1).",
+        },
+        source_type: {
+          type: "string",
+          description: "With source_id: archive every active article from this source (selector 2).",
+        },
+        source_id: {
+          type: "string",
+          description: "With source_type: the source entity UUID (selector 2).",
+        },
+        tag: {
+          type: "string",
+          description:
+            "Archive every active article carrying this tag (selector 3). Requires confirm:true.",
+        },
+        confirm: {
+          type: "boolean",
+          description: "Required (true) when deleting by tag — guards the high blast radius.",
+        },
+      },
+      required: [],
+    },
+  },
+  {
     name: "knowledge_drafts",
     description:
       "List draft (unpublished) knowledge articles. Requires orchestrator role. " +
@@ -2785,6 +2856,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     case "knowledge_delete":
       return await knowledgeDelete(args);
+
+    case "knowledge_bulk_delete":
+      return await knowledgeBulkDelete(args);
 
     case "knowledge_drafts":
       return await knowledgeDrafts(args);

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -794,10 +794,16 @@ async function knowledgeBulkDelete({ article_ids, source_type, source_id, tag, c
     process.env.LOOPCTL_USER_KEY,
   );
 
-  // Partial success returns 200 even when some ids didn't archive — surface a
-  // warning so the agent doesn't treat not_found/errored as success.
+  // Partial success returns 200 even when some/none archived — surface a warning
+  // so the agent doesn't treat not_found/errored, or a nothing-archived run, as
+  // success.
   const counts = result?.meta?.counts;
-  if (counts && (counts.not_found > 0 || counts.errored > 0)) {
+  if (
+    counts &&
+    (counts.not_found > 0 ||
+      counts.errored > 0 ||
+      (counts.archived === 0 && counts.requested > 0))
+  ) {
     const warning =
       `WARNING: bulk-delete was partial — archived ${counts.archived}, ` +
       `skipped ${counts.skipped}, not_found ${counts.not_found}, errored ${counts.errored} ` +

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "description": "MCP server for loopctl — structural trust for AI development loops",
   "type": "module",
   "main": "index.js",

--- a/mcp-server/test/knowledge_tools.test.js
+++ b/mcp-server/test/knowledge_tools.test.js
@@ -118,6 +118,28 @@ async function knowledgeStats({ project_id }) {
   return toContent(result);
 }
 
+async function knowledgeBulkDelete({ article_ids, source_type, source_id, tag, confirm }) {
+  const payload = {};
+  if (article_ids) payload.article_ids = article_ids;
+  if (source_type) payload.source_type = source_type;
+  if (source_id) payload.source_id = source_id;
+  if (tag) payload.tag = tag;
+  if (confirm) payload.confirm = confirm;
+  const result = await apiCall(
+    "POST",
+    "/api/v1/knowledge/bulk-delete",
+    payload,
+    process.env.LOOPCTL_USER_KEY,
+  );
+  const counts = result?.meta?.counts;
+  if (counts && (counts.not_found > 0 || counts.errored > 0)) {
+    return {
+      content: [{ type: "text", text: "WARNING: partial" }, ...toContent(result).content],
+    };
+  }
+  return toContent(result);
+}
+
 async function knowledgeList({
   project_id,
   category,
@@ -981,5 +1003,51 @@ describe("knowledge_list: lag-free enumeration (#134/#135)", () => {
     assert.equal(q.get("idempotency_key"), "only-this");
     assert.equal(q.get("source_type"), null);
     assert.equal(q.get("status"), null);
+  });
+});
+
+describe("knowledge_bulk_delete (#136)", () => {
+  test("routes to POST /api/v1/knowledge/bulk-delete on the user key with article_ids", async () => {
+    setupEnv();
+    process.env.LOOPCTL_USER_KEY = "lc_test_user_key";
+    const calls = mockFetch({ data: [], meta: { count: 0, counts: {}, results: [] } });
+
+    await knowledgeBulkDelete({ article_ids: ["11111111-1111-1111-1111-111111111111"] });
+
+    assert.equal(calls.length, 1);
+    const { url, options } = calls[0];
+    assert.equal(new URL(url).pathname, "/api/v1/knowledge/bulk-delete");
+    assert.equal(options.method, "POST");
+    assert.equal(options.headers.Authorization, "Bearer lc_test_user_key");
+    assert.deepEqual(JSON.parse(options.body).article_ids, [
+      "11111111-1111-1111-1111-111111111111",
+    ]);
+  });
+
+  test("forwards the source and tag selectors", async () => {
+    setupEnv();
+    process.env.LOOPCTL_USER_KEY = "lc_test_user_key";
+    const calls = mockFetch({ data: [], meta: { count: 0, counts: {}, results: [] } });
+
+    await knowledgeBulkDelete({ source_type: "web_article", source_id: "s", tag: "t", confirm: true });
+
+    const sent = JSON.parse(calls[0].options.body);
+    assert.equal(sent.source_type, "web_article");
+    assert.equal(sent.source_id, "s");
+    assert.equal(sent.tag, "t");
+    assert.equal(sent.confirm, true);
+    assert.equal(sent.article_ids, undefined);
+  });
+
+  test("prepends a warning when the run is partial (not_found/errored > 0)", async () => {
+    setupEnv();
+    process.env.LOOPCTL_USER_KEY = "lc_test_user_key";
+    mockFetch({
+      data: [],
+      meta: { count: 0, counts: { archived: 0, skipped: 0, not_found: 1, errored: 0 }, results: [] },
+    });
+
+    const result = await knowledgeBulkDelete({ article_ids: ["x"] });
+    assert.match(result.content[0].text, /WARNING/);
   });
 });

--- a/test/loopctl/knowledge_test.exs
+++ b/test/loopctl/knowledge_test.exs
@@ -223,6 +223,76 @@ defmodule Loopctl.KnowledgeTest do
     end
   end
 
+  describe "bulk_archive/3 (#136)" do
+    test "archives draft/published, skips archived/superseded, reports not_found, partial-success" do
+      %{tenant: tenant} = setup_tenant()
+      d = fixture(:article, %{tenant_id: tenant.id, status: :draft})
+      p = fixture(:article, %{tenant_id: tenant.id, status: :published})
+      arch = fixture(:article, %{tenant_id: tenant.id, status: :archived})
+      missing = Ecto.UUID.generate()
+
+      assert {:ok, result} =
+               Knowledge.bulk_archive(tenant.id, [d.id, p.id, arch.id, missing], [])
+
+      assert result.counts == %{requested: 4, archived: 2, skipped: 1, not_found: 1, errored: 0}
+      assert AdminRepo.get!(Article, d.id).status == :archived
+      assert AdminRepo.get!(Article, p.id).status == :archived
+    end
+
+    test "empty / over-cap article_ids are rejected" do
+      %{tenant: tenant} = setup_tenant()
+      assert {:error, :bad_request, _} = Knowledge.bulk_archive(tenant.id, [], [])
+    end
+
+    test "is tenant-scoped (cannot archive another tenant's article)" do
+      %{tenant: tenant_a} = setup_tenant()
+      %{tenant: tenant_b} = setup_tenant()
+      b = fixture(:article, %{tenant_id: tenant_b.id, status: :published})
+
+      assert {:ok, result} = Knowledge.bulk_archive(tenant_a.id, [b.id], [])
+      assert result.counts.not_found == 1
+      assert AdminRepo.get!(Article, b.id).status == :published
+    end
+
+    test "list_archivable_ids returns active matches and is tenant-scoped" do
+      %{tenant: tenant} = setup_tenant()
+      %{tenant: other} = setup_tenant()
+      src = Ecto.UUID.generate()
+
+      keep =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :published,
+          source_type: "web_article",
+          source_id: src
+        })
+
+      _archived =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :archived,
+          source_type: "web_article",
+          source_id: src
+        })
+
+      _other =
+        fixture(:article, %{
+          tenant_id: other.id,
+          status: :published,
+          source_type: "web_article",
+          source_id: src
+        })
+
+      assert {:ok, ids} =
+               Knowledge.list_archivable_ids(tenant.id,
+                 source_type: "web_article",
+                 source_id: src
+               )
+
+      assert ids == [keep.id]
+    end
+  end
+
   # --- TC-19.3.2: List with tag overlap filtering ---
 
   describe "list_articles/2 source + idempotency filters (#134)" do

--- a/test/loopctl_web/controllers/article_workflow_controller_test.exs
+++ b/test/loopctl_web/controllers/article_workflow_controller_test.exs
@@ -568,6 +568,37 @@ defmodule LoopctlWeb.ArticleWorkflowControllerTest do
       assert body["error"]["message"] =~ "Selectors"
     end
 
+    test "an empty article_ids list returns 400 (not a no-op 200)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      body =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/bulk-delete", %{"article_ids" => []})
+        |> json_response(400)
+
+      assert body["error"]["message"] =~ "empty"
+    end
+
+    test "an empty tag with confirm archives nothing (zero-match 400, not everything)", %{
+      conn: conn
+    } do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      a = fixture(:article, %{tenant_id: tenant.id, status: :published, tags: ["real"]})
+
+      body =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/bulk-delete", %{"tag" => "", "confirm" => true})
+        |> json_response(400)
+
+      assert body["error"]["message"] =~ "No active articles"
+      # An empty-tag selector must NOT archive real articles.
+      assert AdminRepo.get!(Article, a.id).status == :published
+    end
+
     test "agent role is forbidden (destructive, user+)", %{conn: conn} do
       tenant = fixture(:tenant)
       {agent_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})

--- a/test/loopctl_web/controllers/article_workflow_controller_test.exs
+++ b/test/loopctl_web/controllers/article_workflow_controller_test.exs
@@ -412,29 +412,66 @@ defmodule LoopctlWeb.ArticleWorkflowControllerTest do
       draft = fixture(:article, %{tenant_id: tenant.id, status: :draft})
       published = fixture(:article, %{tenant_id: tenant.id, status: :published})
       already = fixture(:article, %{tenant_id: tenant.id, status: :archived})
+      superseded = fixture(:article, %{tenant_id: tenant.id, status: :superseded})
       missing = Ecto.UUID.generate()
 
       conn =
         conn
         |> auth_conn(raw_key)
         |> post(~p"/api/v1/knowledge/bulk-delete", %{
-          "article_ids" => [draft.id, published.id, already.id, missing]
+          "article_ids" => [draft.id, published.id, already.id, superseded.id, missing]
         })
 
       body = json_response(conn, 200)
       assert body["meta"]["count"] == 2
       assert body["meta"]["counts"]["archived"] == 2
-      assert body["meta"]["counts"]["skipped"] == 1
+      assert body["meta"]["counts"]["skipped"] == 2
       assert body["meta"]["counts"]["not_found"] == 1
 
-      outcomes = Map.new(body["meta"]["results"], &{&1["id"], &1["outcome"]})
-      assert outcomes[draft.id] == "archived"
-      assert outcomes[published.id] == "archived"
-      assert outcomes[already.id] == "skipped"
-      assert outcomes[missing] == "not_found"
+      by_id = Map.new(body["meta"]["results"], &{&1["id"], &1})
+      assert by_id[draft.id]["outcome"] == "archived"
+      assert by_id[published.id]["outcome"] == "archived"
+      assert by_id[already.id]["outcome"] == "skipped"
+      assert by_id[already.id]["reason"] == "already_archived"
+      assert by_id[superseded.id]["outcome"] == "skipped"
+      assert by_id[superseded.id]["reason"] == "not_archivable_from_superseded"
+      assert by_id[missing]["outcome"] == "not_found"
 
       assert AdminRepo.get!(Article, draft.id).status == :archived
       assert AdminRepo.get!(Article, published.id).status == :archived
+      assert AdminRepo.get!(Article, superseded.id).status == :superseded
+    end
+
+    test "supplying more than one selector is rejected (no silent confirm bypass)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      a = fixture(:article, %{tenant_id: tenant.id, status: :published, tags: ["dupe"]})
+
+      body =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/bulk-delete", %{
+          "article_ids" => [a.id],
+          "tag" => "dupe",
+          "confirm" => true
+        })
+        |> json_response(400)
+
+      assert body["error"]["message"] =~ "exactly ONE"
+      assert AdminRepo.get!(Article, a.id).status == :published
+    end
+
+    test "a half-specified source selector returns a clear pairing error", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      body =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/bulk-delete", %{"source_type" => "web_article"})
+        |> json_response(400)
+
+      assert body["error"]["message"] =~ "provided together"
     end
 
     test "already-archived ids are idempotent (skipped, not errored)", %{conn: conn} do
@@ -528,7 +565,7 @@ defmodule LoopctlWeb.ArticleWorkflowControllerTest do
         |> post(~p"/api/v1/knowledge/bulk-delete", %{})
         |> json_response(400)
 
-      assert body["error"]["message"] =~ "selector"
+      assert body["error"]["message"] =~ "Selectors"
     end
 
     test "agent role is forbidden (destructive, user+)", %{conn: conn} do

--- a/test/loopctl_web/controllers/article_workflow_controller_test.exs
+++ b/test/loopctl_web/controllers/article_workflow_controller_test.exs
@@ -404,6 +404,163 @@ defmodule LoopctlWeb.ArticleWorkflowControllerTest do
     end
   end
 
+  describe "POST /api/v1/knowledge/bulk-delete" do
+    test "archives valid ids and reports per-id outcomes for the rest", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      draft = fixture(:article, %{tenant_id: tenant.id, status: :draft})
+      published = fixture(:article, %{tenant_id: tenant.id, status: :published})
+      already = fixture(:article, %{tenant_id: tenant.id, status: :archived})
+      missing = Ecto.UUID.generate()
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/bulk-delete", %{
+          "article_ids" => [draft.id, published.id, already.id, missing]
+        })
+
+      body = json_response(conn, 200)
+      assert body["meta"]["count"] == 2
+      assert body["meta"]["counts"]["archived"] == 2
+      assert body["meta"]["counts"]["skipped"] == 1
+      assert body["meta"]["counts"]["not_found"] == 1
+
+      outcomes = Map.new(body["meta"]["results"], &{&1["id"], &1["outcome"]})
+      assert outcomes[draft.id] == "archived"
+      assert outcomes[published.id] == "archived"
+      assert outcomes[already.id] == "skipped"
+      assert outcomes[missing] == "not_found"
+
+      assert AdminRepo.get!(Article, draft.id).status == :archived
+      assert AdminRepo.get!(Article, published.id).status == :archived
+    end
+
+    test "already-archived ids are idempotent (skipped, not errored)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      archived = fixture(:article, %{tenant_id: tenant.id, status: :archived})
+
+      body =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/bulk-delete", %{"article_ids" => [archived.id]})
+        |> json_response(200)
+
+      assert body["meta"]["count"] == 0
+      [r] = body["meta"]["results"]
+      assert r["outcome"] == "skipped"
+      assert r["reason"] == "already_archived"
+    end
+
+    test "deletes by source_type + source_id", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      src = Ecto.UUID.generate()
+
+      a =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :published,
+          source_type: "web_article",
+          source_id: src
+        })
+
+      b =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :draft,
+          source_type: "web_article",
+          source_id: src
+        })
+
+      other = fixture(:article, %{tenant_id: tenant.id, status: :published})
+
+      body =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/bulk-delete", %{
+          "source_type" => "web_article",
+          "source_id" => src
+        })
+        |> json_response(200)
+
+      assert body["meta"]["count"] == 2
+      assert AdminRepo.get!(Article, a.id).status == :archived
+      assert AdminRepo.get!(Article, b.id).status == :archived
+      assert AdminRepo.get!(Article, other.id).status == :published
+    end
+
+    test "delete by tag requires confirm: true", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      tagged = fixture(:article, %{tenant_id: tenant.id, status: :published, tags: ["dupe"]})
+
+      # Without confirm → 400, nothing archived.
+      refused =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/bulk-delete", %{"tag" => "dupe"})
+        |> json_response(400)
+
+      assert refused["error"]["message"] =~ "confirm"
+      assert AdminRepo.get!(Article, tagged.id).status == :published
+
+      # With confirm → archived.
+      ok =
+        build_conn()
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/bulk-delete", %{"tag" => "dupe", "confirm" => true})
+        |> json_response(200)
+
+      assert ok["meta"]["count"] == 1
+      assert AdminRepo.get!(Article, tagged.id).status == :archived
+    end
+
+    test "an ambiguous/empty selector returns 400", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      body =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/bulk-delete", %{})
+        |> json_response(400)
+
+      assert body["error"]["message"] =~ "selector"
+    end
+
+    test "agent role is forbidden (destructive, user+)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {agent_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      a = fixture(:article, %{tenant_id: tenant.id, status: :published})
+
+      conn
+      |> auth_conn(agent_key)
+      |> post(~p"/api/v1/knowledge/bulk-delete", %{"article_ids" => [a.id]})
+      |> json_response(403)
+
+      assert AdminRepo.get!(Article, a.id).status == :published
+    end
+
+    test "cannot archive another tenant's articles (reported not_found)", %{conn: conn} do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      {key_a, _} = fixture(:api_key, %{tenant_id: tenant_a.id, role: :user})
+      b_article = fixture(:article, %{tenant_id: tenant_b.id, status: :published})
+
+      body =
+        conn
+        |> auth_conn(key_a)
+        |> post(~p"/api/v1/knowledge/bulk-delete", %{"article_ids" => [b_article.id]})
+        |> json_response(200)
+
+      assert body["meta"]["counts"]["not_found"] == 1
+      assert AdminRepo.get!(Article, b_article.id).status == :published
+    end
+  end
+
   # --- TC-21.3.5: Drafts listing excludes published, includes source info ---
 
   describe "GET /api/v1/knowledge/drafts" do


### PR DESCRIPTION
## What

Adds bulk delete (soft-delete/archive) and hardens 429 backoff. Closes #136.

## Why

Cleaning up a duplicate capture (~695 articles) meant ~695 individual `DELETE`s, and 429s came back without a usable `Retry-After`.

## Changes

- **`POST /api/v1/knowledge/bulk-delete`** (role `:user`) — partial-success soft-delete, the delete analogue of bulk-publish. Exactly one selector:
  - `article_ids` (explicit list)
  - `source_type` + `source_id` (every active article from that source — clean dedup cleanup)
  - `tag` + `confirm: true` (every active article with the tag — high blast radius, so `confirm` is required)
  - Per-id outcomes (`archived`/`skipped`/`not_found`/`errored`), idempotent (already-archived → `skipped`), auto-chunked (≤5000), tenant-scoped, honors soft-delete (rows → `archived`, never dropped).
- **Refactor:** generalized the #132 partial-success machinery into a shared status-transition runner used by both `bulk_publish` (→ published, post-commit embeddings) and `bulk_archive` (→ archived, no post-commit). `bulk_publish` behavior is unchanged — its full test suite passes.
- **429 hardening:** `Retry-After` is now always ≥ 1s (was `reset_at - now`, which could be ≤ 0 at a window boundary). Documented the limits (300/key/min, 3×/tenant) + headers (`Retry-After`, `X-RateLimit-*`) on the `RateLimitError` schema.
- **MCP `knowledge_bulk_delete`** (USER key) with a partial-run warning; README + CHANGELOG, bumped to `2.12.0` (57 tools).
- Tests: context (`bulk_archive` partial success, tenant isolation, `list_archivable_ids`), controller (all 3 selectors, confirm gate, ambiguous→400, agent forbidden, cross-tenant `not_found`), MCP.

## Verification

`mix precommit` green: format, credo --strict, dialyzer, 2402 tests, 0 failures. MCP 41/41.

_Draft until enhanced review completes._
