### PR TITLE
Add publish opt-in to knowledge ingestion (completes #133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,57 @@
 
 All notable changes to loopctl are documented here.
 
+## [Unreleased] — 2026-06-22 — knowledge wiki harvest-hardening (#132–#138)
+
+A batch of Knowledge Wiki API changes for reliable agent/harvest workflows.
+(Supersedes the #120 draft-by-default + orchestrator-publish-gate notes below.)
+
+### Added
+
+- **Idempotency_key (#137):** `POST /api/v1/articles` accepts `idempotency_key`
+  (per-article, max 255). Re-creating with the same key is a no-op that returns
+  a reference to the existing article (`deduplicated: true`, id only — no body),
+  preventing partial duplicates on re-capture. Distinct from
+  `source_type`/`source_id` (a shared source identifier).
+- **Lag-free enumeration (#134/#135):** `GET /api/v1/articles` filters by
+  `source_type`, `source_id`, and `idempotency_key`; new MCP `knowledge_list`
+  wraps it. This is the lag-free, all-status read of record for
+  dedup/idempotency/repair — vs `knowledge_search`, which is ranked,
+  published-only, and lags writes.
+- **Bulk delete (#136):** `POST /api/v1/knowledge/bulk-delete` (role user) —
+  partial-success soft-delete by `article_ids`, `source_type`+`source_id`, or
+  `tag`+`confirm:true` (exactly one selector). MCP `knowledge_bulk_delete`.
+- **Ingest publish opt-in (#133):** `POST /api/v1/knowledge/ingest` + `/batch`
+  accept `publish: true`; extracted articles stay **draft by default**
+  (lower-trust LLM output) but can be published in one step.
+
+### Changed
+
+- **Publish-on-create is the default for every role, including agent (#133)** —
+  `POST /api/v1/articles` publishes immediately; draft is now the opt-in
+  (`draft: true` / `status: "draft"`). The orchestrator-only publish gate is
+  removed on the create path (publishing a wiki article is neither destructive
+  nor story chain-of-custody); the standalone publish endpoint and system-scope
+  gate are unchanged.
+- **Bulk-publish is partial-success + uncapped (#132, #138.3):** publishes every
+  valid draft and returns per-id outcomes (published/skipped/not_found/errored)
+  in `meta.results` instead of failing the whole call; already-published ids are
+  skipped (idempotent); the 100-id cap is gone (auto-chunked, ≤5000).
+- **Tag cap raised 20 → 50 (#138.2).**
+
+### Fixed
+
+- **Invalid `?status=`/`?category=` → 400 with allowed values (#138.1)** on
+  `GET /api/v1/articles` (was a 404/500 from an `Ecto.Enum` cast); malformed
+  list/map query params no longer 500.
+- **429 `Retry-After` is always ≥ 1s (#136)** (was `reset_at - now`, which could
+  be ≤ 0 at a window boundary); rate limits documented on `RateLimitError`.
+
+### Docs
+
+- Documented the witness/STH request-header workflow for non-MCP clients (#138.4)
+  and the search-vs-list distinction.
+
 ## [Unreleased] — 2026-06-19 — create-and-publish + draft note (#120)
 
 ### Added

--- a/lib/loopctl/workers/content_ingestion_worker.ex
+++ b/lib/loopctl/workers/content_ingestion_worker.ex
@@ -296,7 +296,10 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
       articles
       |> Enum.with_index()
       |> Enum.reduce(Multi.new(), fn {attrs, index}, multi ->
-        attrs = normalize_attrs(attrs)
+        # normalize_attrs already whitelists keys, but drop :status explicitly so
+        # the server-set status (above) can never be overridden by extractor
+        # output, independent of future normalize_attrs changes.
+        attrs = normalize_attrs(attrs) |> Map.delete(:status)
 
         article = %Article{
           tenant_id: tenant_id,
@@ -334,7 +337,11 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
             "source_type" => source_type,
             "url" => url,
             "article_count" => length(article_ids),
-            "article_ids" => article_ids
+            "article_ids" => article_ids,
+            # Record whether ingested articles went live (publish opt-in) or were
+            # staged as drafts, so an operator can tell auto-published content
+            # apart from review-staged content in the audit trail.
+            "status" => to_string(status)
           }
         }
       end)

--- a/lib/loopctl/workers/content_ingestion_worker.ex
+++ b/lib/loopctl/workers/content_ingestion_worker.ex
@@ -37,6 +37,7 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   alias Loopctl.Audit
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.ContentChunker
+  alias Loopctl.Workers.ArticleEmbeddingWorker
 
   @content_extractor Application.compile_env(
                        :loopctl,
@@ -64,6 +65,8 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
     url = args["url"]
     raw_content = args["content"]
     project_id = args["project_id"]
+    # Default draft; publish only when the ingest request opted in (#133).
+    publish = args["publish"] == true
 
     # Generate a deterministic source_id from the content_hash.
     # source_id must be a UUID (:binary_id), so we derive one from the hash.
@@ -72,7 +75,7 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
     with {:ok, content} <- resolve_content(url, raw_content),
          {:ok, raw_articles} <- extract_with_chunking(content, source_type) do
       articles = validate_and_filter(raw_articles)
-      insert_articles(tenant_id, source_id, source_type, project_id, articles, url)
+      insert_articles(tenant_id, source_id, source_type, project_id, articles, url, publish)
     end
   end
 
@@ -282,11 +285,13 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
     is_binary(tag) and String.length(tag) <= @max_tag_length and Regex.match?(@tag_pattern, tag)
   end
 
-  defp insert_articles(_tenant_id, _job_id, _source_type, _project_id, [], _url) do
+  defp insert_articles(_tenant_id, _job_id, _source_type, _project_id, [], _url, _publish) do
     :ok
   end
 
-  defp insert_articles(tenant_id, job_id, source_type, project_id, articles, url) do
+  defp insert_articles(tenant_id, job_id, source_type, project_id, articles, url, publish) do
+    status = if publish, do: :published, else: :draft
+
     multi =
       articles
       |> Enum.with_index()
@@ -296,7 +301,8 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
         article = %Article{
           tenant_id: tenant_id,
           source_type: source_type,
-          source_id: job_id
+          source_id: job_id,
+          status: status
         }
 
         article =
@@ -334,10 +340,16 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
       end)
 
     case AdminRepo.transaction(multi) do
-      {:ok, _changes} ->
+      {:ok, changes} ->
+        # Published articles need embeddings to be semantically searchable;
+        # enqueue AFTER commit (Oban runs on a separate repo/pool). Drafts get
+        # none. Best-effort: a transient enqueue failure must not fail the job
+        # (the rows are durably committed).
+        if publish, do: enqueue_embeddings(tenant_id, changes)
+
         Logger.info(
           "ContentIngestionWorker: extracted #{length(articles)} articles " <>
-            "(source_type=#{source_type}, url=#{url || "inline"})"
+            "(source_type=#{source_type}, url=#{url || "inline"}, publish=#{publish})"
         )
 
         :ok
@@ -350,6 +362,23 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
 
         {:error, {:insert_failed, step, changeset}}
     end
+  end
+
+  # Enqueue an embedding job for each just-inserted (published) article. Runs
+  # post-commit and is best-effort: a transient enqueue failure is logged, never
+  # raised, so it can't fail/retry the whole ingestion job.
+  defp enqueue_embeddings(tenant_id, changes) do
+    changes
+    |> Enum.filter(fn {key, _} -> match?({:article, _}, key) end)
+    |> Enum.each(fn {_key, article} ->
+      %{article_id: article.id, tenant_id: tenant_id}
+      |> ArticleEmbeddingWorker.new()
+      |> Oban.insert()
+    end)
+  rescue
+    e ->
+      Logger.error("ContentIngestionWorker: embedding enqueue failed: #{Exception.message(e)}")
+      :ok
   end
 
   defp normalize_attrs(attrs) when is_map(attrs) do

--- a/lib/loopctl_web/controllers/article_controller.ex
+++ b/lib/loopctl_web/controllers/article_controller.ex
@@ -65,7 +65,9 @@ defmodule LoopctlWeb.ArticleController do
                "Stage as a draft instead of publishing on create. Default false " <>
                  "(article is published immediately). Equivalent alias: status: \"draft\". " <>
                  "Publishing a staged draft afterwards (POST /articles/:id/publish) " <>
-                 "requires orchestrator role; publish-on-create does not."
+                 "requires orchestrator role; publish-on-create does not. (Note: the " <>
+                 "ingestion path has the OPPOSITE polarity — POST /knowledge/ingest is " <>
+                 "draft-by-default; pass publish: true there.)"
            },
            tags: %OpenApiSpex.Schema{type: :array, items: %OpenApiSpex.Schema{type: :string}},
            project_id: %OpenApiSpex.Schema{type: :string, format: :uuid, nullable: true},

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -23,7 +23,10 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     description:
       "Submit a URL or raw content for knowledge extraction. " <>
         "Enqueues an Oban job that fetches the content (if URL), extracts knowledge " <>
-        "articles via LLM, and inserts them as drafts. Role: orchestrator+.",
+        "articles via LLM, and inserts them. Extracted articles are created as " <>
+        "**drafts by default** (lower-trust LLM output, staged for review) — unlike " <>
+        "direct POST /articles which publishes by default. Pass `publish: true` to " <>
+        "publish them on extraction instead. Role: orchestrator+.",
     request_body:
       {"Ingestion request", "application/json",
        %OpenApiSpex.Schema{
@@ -45,6 +48,12 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
            project_id: %OpenApiSpex.Schema{
              type: :string,
              description: "Optional project UUID to scope extracted articles"
+           },
+           publish: %OpenApiSpex.Schema{
+             type: :boolean,
+             description:
+               "Publish extracted articles immediately instead of staging them as " <>
+                 "drafts. Default false (draft)."
            },
            metadata: %OpenApiSpex.Schema{
              type: :object,
@@ -143,7 +152,8 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
              description:
                "Array of ingestion items (max 50). Each item has the same shape as " <>
                  "POST /knowledge/ingest: url or content, source_type (required), " <>
-                 "project_id (optional), metadata (optional).",
+                 "project_id (optional), publish (optional, default false → draft), " <>
+                 "metadata (optional).",
              maxItems: 50
            }
          },
@@ -238,6 +248,11 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     source_type = params["source_type"]
     project_id = params["project_id"]
     metadata = params["metadata"]
+    # Ingested (LLM-extracted) articles stay DRAFT by default — they're
+    # lower-trust and meant for review. Opt in with publish: true to have the
+    # worker create them published (mirrors create-time publish, but off by
+    # default for ingest). Only true/"true" enables it; anything else is draft.
+    publish = params["publish"] == true or params["publish"] == "true"
 
     with :ok <- validate_content_source(url, content),
          :ok <- validate_source_type(source_type) do
@@ -253,6 +268,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
         |> maybe_put("content", content)
         |> maybe_put("project_id", project_id)
         |> maybe_put("metadata", metadata)
+        |> maybe_put("publish", if(publish, do: true))
 
       case ContentIngestionWorker.new(job_args) |> Oban.insert() do
         {:ok, %Oban.Job{conflict?: true} = job} ->

--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to `loopctl-mcp-server` are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 2.13.0 — 2026-06-22 (ingest publish opt-in)
+
+### Added
+
+- `knowledge_ingest` and `knowledge_ingest_batch` accept `publish: true` to
+  publish extracted articles immediately. Ingested (LLM-extracted) articles
+  remain **drafts by default** — lower-trust output staged for review, distinct
+  from `knowledge_create`'s publish-by-default — but can now be published in one
+  step. `knowledge_ingest_batch` supports a batch-level `publish` default and a
+  per-item override. Completes loopctl #133 (the ingest half).
+
 ## 2.12.0 — 2026-06-22 (knowledge_bulk_delete)
 
 ### Added

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -166,8 +166,8 @@ Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_K
 | `knowledge_drafts` | List draft (unpublished) knowledge articles with pagination. Optional: `limit` (default 20, max 20), `offset` (default 0), `project_id`. Returns `meta.total_count`. |
 | `knowledge_lint` | Run a lint check on the knowledge wiki to identify stale or low-coverage articles. Optional: `project_id`, `stale_days`, `min_coverage`, `max_per_category` (default 50, max 500). True totals returned in `summary.total_per_category`. |
 | `knowledge_export` | Export all knowledge articles as a ZIP archive. Returns a curl command for direct download (ZIP binary cannot be returned as MCP content). Optional: `project_id`. |
-| `knowledge_ingest` | Submit a URL or raw content for knowledge extraction. Enqueues an Oban job. Required: `source_type`. One of: `url` or `content`. Optional: `project_id`. |
-| `knowledge_ingest_batch` | Submit up to 50 ingestion items in a single request. Each item has the same shape as `knowledge_ingest`. Returns per-item results. Required: `items`. Optional: batch-level `project_id` default. |
+| `knowledge_ingest` | Submit a URL or raw content for knowledge extraction. Enqueues an Oban job. Extracted articles are **drafts by default** (lower-trust LLM output); pass `publish: true` to publish on extraction. Required: `source_type`. One of: `url` or `content`. Optional: `project_id`, `publish`. |
+| `knowledge_ingest_batch` | Submit up to 50 ingestion items in a single request. Each item has the same shape as `knowledge_ingest` (incl. `publish`). Returns per-item results. Required: `items`. Optional: batch-level `project_id` / `publish` defaults. |
 | `knowledge_ingestion_jobs` | List recent content ingestion jobs (last 7 days, max 50). |
 
 ### Knowledge Analytics Tools (orchestrator key)

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -843,24 +843,28 @@ async function knowledgeLint({ project_id, stale_days, min_coverage, max_per_cat
   return toContent(result);
 }
 
-async function knowledgeIngest({ url, content, source_type, project_id }) {
+async function knowledgeIngest({ url, content, source_type, project_id, publish }) {
   const body = { source_type };
   if (url) body.url = url;
   if (content) body.content = content;
   if (project_id) body.project_id = project_id;
+  if (publish) body.publish = true;
   const result = await apiCall("POST", "/api/v1/knowledge/ingest", body, process.env.LOOPCTL_ORCH_KEY);
   return toContent(result);
 }
 
-async function knowledgeIngestBatch({ items, project_id }) {
-  // If a batch-level project_id is supplied, apply it as a default to every
-  // item that doesn't already set its own.
+async function knowledgeIngestBatch({ items, project_id, publish }) {
+  // Apply batch-level project_id / publish as defaults to any item that doesn't
+  // set its own.
   const resolvedItems = Array.isArray(items)
-    ? items.map((item) =>
-        project_id && item && item.project_id == null
-          ? { ...item, project_id }
-          : item
-      )
+    ? items.map((item) => {
+        if (!item) return item;
+        let resolved = item;
+        if (project_id && resolved.project_id == null)
+          resolved = { ...resolved, project_id };
+        if (publish && resolved.publish == null) resolved = { ...resolved, publish: true };
+        return resolved;
+      })
     : items;
 
   const result = await apiCall(
@@ -2429,7 +2433,9 @@ const TOOLS = [
     description:
       "Submit a URL or raw content for knowledge extraction. " +
       "Enqueues an Oban job that fetches the content (if URL), extracts knowledge articles via LLM, " +
-      "and inserts them as draft articles. Requires orchestrator role.",
+      "and inserts them. Extracted articles are DRAFTS by default (lower-trust LLM output, staged " +
+      "for review) — unlike knowledge_create which publishes by default. Pass publish:true to " +
+      "publish them on extraction. Requires orchestrator role.",
     inputSchema: {
       type: "object",
       properties: {
@@ -2448,6 +2454,11 @@ const TOOLS = [
         project_id: {
           type: "string",
           description: "Optional: scope extracted articles to a specific project UUID.",
+        },
+        publish: {
+          type: "boolean",
+          description:
+            "Optional: publish extracted articles immediately instead of staging them as drafts (default false).",
         },
       },
       required: ["source_type"],
@@ -2487,6 +2498,11 @@ const TOOLS = [
                 type: "string",
                 description: "Optional: scope the item to a specific project UUID.",
               },
+              publish: {
+                type: "boolean",
+                description:
+                  "Optional: publish this item's extracted articles immediately (default false → draft).",
+              },
               metadata: {
                 type: "object",
                 description: "Optional metadata map.",
@@ -2498,6 +2514,10 @@ const TOOLS = [
         project_id: {
           type: "string",
           description: "Optional batch-level default project UUID applied to items that don't specify their own.",
+        },
+        publish: {
+          type: "boolean",
+          description: "Optional batch-level default publish flag applied to items that don't specify their own.",
         },
       },
       required: ["items"],

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "description": "MCP server for loopctl — structural trust for AI development loops",
   "type": "module",
   "main": "index.js",

--- a/test/loopctl/workers/content_ingestion_worker_test.exs
+++ b/test/loopctl/workers/content_ingestion_worker_test.exs
@@ -56,6 +56,37 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
       assert is_binary(article.source_id)
       assert article.tags == ["genserver", "otp"]
     end
+
+    test "publishes extracted articles when publish: true is set" do
+      %{tenant: tenant} = setup_tenant()
+
+      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _content, _opts ->
+        {:ok,
+         [
+           %{
+             title: "Published from ingest",
+             body: "Visible immediately.",
+             category: :pattern,
+             tags: ["x"]
+           }
+         ]}
+      end)
+
+      assert :ok =
+               ContentIngestionWorker.perform(%Oban.Job{
+                 id: 43,
+                 args: %{
+                   "tenant_id" => tenant.id,
+                   "content" => "raw",
+                   "content_hash" => "pub123",
+                   "source_type" => "newsletter",
+                   "publish" => true
+                 }
+               })
+
+      %{data: [article]} = Knowledge.list_articles(tenant.id, source_type: "newsletter")
+      assert article.status == :published
+    end
   end
 
   # --- Success: fetches URL and extracts ---

--- a/test/loopctl/workers/content_ingestion_worker_test.exs
+++ b/test/loopctl/workers/content_ingestion_worker_test.exs
@@ -55,6 +55,10 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
       # source_id is a deterministic UUID derived from the content_hash
       assert is_binary(article.source_id)
       assert article.tags == ["genserver", "otp"]
+
+      # Drafts are not embedded.
+      {:ok, with_embedding} = Knowledge.get_article_with_embedding(tenant.id, article.id)
+      assert is_nil(with_embedding.embedding)
     end
 
     test "publishes extracted articles when publish: true is set" do
@@ -86,6 +90,11 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
 
       %{data: [article]} = Knowledge.list_articles(tenant.id, source_type: "newsletter")
       assert article.status == :published
+
+      # Published articles are embedded (Oban runs :inline in tests, so the
+      # enqueued ArticleEmbeddingWorker has already populated the vector).
+      {:ok, with_embedding} = Knowledge.get_article_with_embedding(tenant.id, article.id)
+      refute is_nil(with_embedding.embedding)
     end
   end
 

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -1,10 +1,21 @@
 defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
   use LoopctlWeb.ConnCase, async: true
 
+  alias Loopctl.Knowledge
+
   setup :verify_on_exit!
 
   defp auth_conn(conn, raw_key) do
     put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  # Oban runs :inline in tests, so the ingestion worker executes within the
+  # request; stub the extractor to yield exactly one article so we can assert the
+  # resulting article's status (draft by default, published with publish: true).
+  defp expect_one_extracted_article(title) do
+    expect(Loopctl.MockContentExtractor, :extract_from_content, fn _content, _opts ->
+      {:ok, [%{title: title, body: "Body for #{title}.", category: :pattern, tags: ["t"]}]}
+    end)
   end
 
   # --- POST /api/v1/knowledge/ingest ---
@@ -44,6 +55,38 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       body = json_response(conn, 202)
       assert body["data"]["status"] == "queued"
       assert body["data"]["source_type"] == "newsletter"
+    end
+
+    test "extracted articles default to draft", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+      expect_one_extracted_article("Drafted by ingest")
+
+      conn
+      |> auth_conn(raw_key)
+      |> post(~p"/api/v1/knowledge/ingest", %{content: "raw", source_type: "newsletter"})
+      |> json_response(202)
+
+      %{data: [article]} = Knowledge.list_articles(tenant.id, source_type: "newsletter")
+      assert article.status == :draft
+    end
+
+    test "publish: true publishes the extracted articles", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+      expect_one_extracted_article("Published by ingest")
+
+      conn
+      |> auth_conn(raw_key)
+      |> post(~p"/api/v1/knowledge/ingest", %{
+        content: "raw",
+        source_type: "newsletter",
+        publish: true
+      })
+      |> json_response(202)
+
+      %{data: [article]} = Knowledge.list_articles(tenant.id, source_type: "newsletter")
+      assert article.status == :published
     end
 
     test "returns 422 when both url and content provided", %{conn: conn} do


### PR DESCRIPTION
## What

Adds a `publish` opt-in to the knowledge **ingestion** pipeline, completing #133 (the create-path half shipped in #139/#140).

## Why

`POST /api/v1/articles` publishes by default (#133), but the async ingestion pipeline (`knowledge_ingest`/`ingest_batch`) intentionally keeps extracted articles as **drafts** — LLM-extracted/URL content is lower-trust and meant for review (same rationale as OKF import, which also drafts). You chose "keep ingest draft-by-default, add a publish opt-in." This is that opt-in.

## Changes

- `POST /api/v1/knowledge/ingest` + `/ingest/batch` accept `publish: true` (default false → draft); the controller threads it into the Oban job args.
- `ContentIngestionWorker` creates articles `:published` when set, and enqueues embeddings **post-commit** for the published rows (so they're semantically searchable, matching the create path); drafts get neither.
- MCP `knowledge_ingest`/`knowledge_ingest_batch` gain a `publish` param (per-item + batch-level default). Bumped to `2.13.0` + CHANGELOG/README.
- OpenAPI specs document draft-by-default + the opt-in.
- Tests: worker publishes on `publish:true`; controller end-to-end draft (default) vs published.

## Verification

`mix precommit` green: format, credo --strict, dialyzer, 2414 tests, 0 failures. MCP 41/41.

_Draft until enhanced review completes. With this, all of #132–#138 are addressed._
