### PR TITLE
docs: sync MCP tool count to 57 + add new tools to README table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,7 +200,7 @@ mix ecto.reset         # Drop, create, migrate
 - **User Stories**: `docs/user_stories/epic_N_name/us_N.M.json` — 60 stories across 15 epics
 - **Skills**: `skills/loopctl-*.md` — 6 orchestration skills
 - **Orchestration Guide**: `docs/orchestration-guide.md` — methodology: loop, trust model, checkpointing
-- **MCP Server**: `mcp-server/` — 55 typed tools for Claude Code agents (no curl needed), published as `loopctl-mcp-server` on npm
+- **MCP Server**: `mcp-server/` — 57 typed tools for Claude Code agents (no curl needed), published as `loopctl-mcp-server` on npm
 - **Build Status**: memory-keeper key `build_status`, channel `loopctl`
 
 ## MCP Server
@@ -211,7 +211,7 @@ Claude Code agents should use the loopctl MCP tools instead of curl. Install via
 {"mcpServers": {"loopctl": {"command": "npx", "args": ["loopctl-mcp-server"], "env": {"LOOPCTL_SERVER": "https://loopctl.com", "LOOPCTL_ORCH_KEY": "...", "LOOPCTL_AGENT_KEY": "..."}}}}
 ```
 
-Tools: `mcp__loopctl__list_projects`, `mcp__loopctl__list_stories`, `mcp__loopctl__verify_story`, etc. (55 total). See `mcp-server/README.md` for the full list.
+Tools: `mcp__loopctl__list_projects`, `mcp__loopctl__list_stories`, `mcp__loopctl__verify_story`, etc. (57 total). See `mcp-server/README.md` for the full list.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -775,7 +775,7 @@ cd mcp-server && npm install
 
 Keys must be in the `env` block — the MCP server process does not inherit the shell environment.
 
-### Available Tools (55)
+### Available Tools (57)
 
 Full descriptions live in [`mcp-server/README.md`](mcp-server/README.md); summary:
 
@@ -813,19 +813,21 @@ Full descriptions live in [`mcp-server/README.md`](mcp-server/README.md); summar
 | `knowledge_search` | Search knowledge wiki by topic | agent |
 | `knowledge_get` | Get full article content by ID | agent |
 | `knowledge_context` | Get relevance-ranked articles for a task query | agent |
-| `knowledge_create` | Create an article (published by default; `draft: true` to stage) | agent |
+| `knowledge_list` | List articles (full fields, lag-free, all-status) — filter by tag/source_type/source_id/idempotency_key for dedup/enumerate/repair | agent |
+| `knowledge_create` | Create an article (published by default; `draft: true` to stage; `idempotency_key` for idempotent capture) | agent |
 | `knowledge_publish` | Publish an existing draft article | orchestrator |
-| `knowledge_bulk_publish` | Atomically publish up to 100 drafts | user |
+| `knowledge_bulk_publish` | Publish drafts, partial-success (per-id results, idempotent, no 100-cap) | user |
 | `knowledge_unpublish` | Revert a published article back to draft | user |
 | `knowledge_archive` | Soft-delete an article (retained for audit) | user |
 | `knowledge_delete` | Alias for archive (DELETE verb archives) | user |
+| `knowledge_bulk_delete` | Bulk soft-delete (archive), partial-success — by id-list, source, or tag+confirm | user |
 | `knowledge_drafts` | List draft (unpublished) articles | orchestrator |
 | `knowledge_lint` | Lint check for stale or low-coverage articles | orchestrator |
 | `knowledge_export` | Export all articles as a ZIP archive | orchestrator |
 | `knowledge_okf_export` | Export the wiki as an OKF v0.1 bundle | user |
 | `knowledge_okf_import` | Import an OKF v0.1 bundle from a directory | user |
-| `knowledge_ingest` | Submit a URL/content for knowledge extraction | orchestrator |
-| `knowledge_ingest_batch` | Submit up to 50 ingestion items | orchestrator |
+| `knowledge_ingest` | Submit a URL/content for knowledge extraction (draft by default; `publish: true` to publish) | orchestrator |
+| `knowledge_ingest_batch` | Submit up to 50 ingestion items (per-item / batch `publish`) | orchestrator |
 | `knowledge_ingestion_jobs` | List recent ingestion jobs | orchestrator |
 | `knowledge_analytics_top` | Top accessed articles | orchestrator |
 | `knowledge_article_stats` | Per-article usage stats | orchestrator |

--- a/lib/loopctl_web/controllers/page_html/docs.html.heex
+++ b/lib/loopctl_web/controllers/page_html/docs.html.heex
@@ -998,7 +998,7 @@
           <h2 class="font-display text-xl font-semibold text-slate-100">MCP Tools</h2>
           <div class="mt-4 space-y-4 text-sm text-slate-400">
             <p>
-              The loopctl MCP server provides 55 typed tools for Claude Code agents.
+              The loopctl MCP server provides 57 typed tools for Claude Code agents.
               Install via
               <span class="font-mono text-slate-300">npm install loopctl-mcp-server</span>
               and configure in <span class="font-mono text-slate-300">.mcp.json</span>.
@@ -1208,7 +1208,7 @@
           </h3>
           <div class="mt-4 space-y-4 text-sm text-slate-400">
             <p>
-              The full set of 55 tools covers projects, stories, epics, verification,
+              The full set of 57 tools covers projects, stories, epics, verification,
               artifacts, orchestrator state, webhooks, skills, token usage, analytics,
               knowledge, OKF interchange, and the Chain of Custody v2 dispatch /
               capability-token flow (`dispatch`, `recover_cap`, `get_sth`). See the

--- a/lib/loopctl_web/controllers/page_html/home.html.heex
+++ b/lib/loopctl_web/controllers/page_html/home.html.heex
@@ -282,7 +282,7 @@
                   MCP Integration
                 </dt>
                 <dd class="mt-1.5 text-slate-400">
-                  51 typed tools for AI coding agents. No curl needed — agents interact through the MCP server.
+                  57 typed tools for AI coding agents. No curl needed — agents interact through the MCP server.
                 </dd>
               </div>
 
@@ -811,7 +811,7 @@
                   Install via
                   <span class="text-slate-400 font-mono">npm install loopctl-mcp-server</span>
                   or run with <span class="text-slate-400 font-mono">npx loopctl-mcp-server</span>.
-                  51 typed tools for AI coding agents.
+                  57 typed tools for AI coding agents.
                 </p>
               </div>
             </div>


### PR DESCRIPTION
Docs-only follow-up to #132–#138. Adds the two net-new MCP tools (`knowledge_list`, `knowledge_bulk_delete`) to the root README tool table, corrects stale `knowledge_bulk_publish`/`knowledge_ingest` descriptions, and fixes the tool count everywhere (README/CLAUDE/docs were 55, landing page was 51 → all 57, verified against the TOOLS array). No code/behavior change.