### PR TITLE
Add #148 A2-A4: AND-tag filtering + count/facets endpoints (+ MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -775,7 +775,7 @@ cd mcp-server && npm install
 
 Keys must be in the `env` block — the MCP server process does not inherit the shell environment.
 
-### Available Tools (57)
+### Available Tools (59)
 
 Full descriptions live in [`mcp-server/README.md`](mcp-server/README.md); summary:
 

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -698,7 +698,7 @@ defmodule Loopctl.Knowledge do
     base =
       base
       |> maybe_filter_by_category(Keyword.get(opts, :category))
-      |> maybe_filter_by_tags(Keyword.get(opts, :tags))
+      |> maybe_filter_by_tags(Keyword.get(opts, :tags), Keyword.get(opts, :match, :any))
 
     total_count = AdminRepo.aggregate(base, :count, :id)
 
@@ -806,6 +806,92 @@ defmodule Loopctl.Knowledge do
     total = by_status |> Map.values() |> Enum.sum()
 
     %{total: total, by_category: by_category, by_status: by_status}
+  end
+
+  @doc """
+  Counts articles matching the given filters **without** returning any rows.
+
+  Accepts the same filters as `list_articles/2` (`:project_id`, `:category`,
+  `:status`, `:tags` + `:match`, `:source_type`, `:source_id`,
+  `:idempotency_key`), so a single call answers "how many *published* articles
+  tagged both X and Y" (status + `tags` + `match: :all`) without enumerating rows.
+
+  ## Returns
+
+  - `non_neg_integer()`
+  """
+  @spec count_articles(Ecto.UUID.t(), keyword()) :: non_neg_integer()
+  def count_articles(tenant_id, opts \\ []) do
+    from(a in Article, where: a.tenant_id == ^tenant_id)
+    |> apply_article_filters(opts)
+    |> AdminRepo.aggregate(:count, :id)
+  end
+
+  @doc """
+  Counts articles grouped by each distinct tag (a tag facet).
+
+  Unnests `tags` over the filtered article set and counts articles per tag, so
+  callers can get a **distinct-tag count** and per-tag totals without paginating
+  rows. Honors the same filters as `count_articles/2` (including `:status` and
+  `:tags`/`:match`), plus an optional `:tag_prefix` to restrict to a tag family
+  (e.g. `"book-"` to count distinct books). Ordered by descending count.
+
+  ## Parameters
+
+  - `opts` -- `list_articles/2` filters, plus:
+    - `:tag_prefix` -- only tags starting with this literal prefix (LIKE-escaped)
+    - `:limit` -- cap the number of facet rows returned (default all)
+
+  ## Returns
+
+  - `%{facets: [%{tag: String.t(), count: pos_integer()}], distinct_count: non_neg_integer()}`
+  """
+  @spec tag_facets(Ecto.UUID.t(), keyword()) :: %{
+          facets: [%{tag: String.t(), count: non_neg_integer()}],
+          distinct_count: non_neg_integer()
+        }
+  def tag_facets(tenant_id, opts \\ []) do
+    base =
+      from(a in Article, where: a.tenant_id == ^tenant_id)
+      |> apply_article_filters(opts)
+
+    unnested = from(a in subquery(base), select: %{tag: fragment("unnest(?)", a.tags)})
+
+    facet_query =
+      from(t in subquery(unnested),
+        group_by: t.tag,
+        select: %{tag: t.tag, count: count(t.tag)},
+        order_by: [desc: count(t.tag), asc: t.tag]
+      )
+
+    facet_query =
+      case Keyword.get(opts, :tag_prefix) do
+        prefix when is_binary(prefix) and prefix != "" ->
+          pattern = like_escape(prefix) <> "%"
+          where(facet_query, [t], like(t.tag, ^pattern))
+
+        _ ->
+          facet_query
+      end
+
+    facet_query =
+      case Keyword.get(opts, :limit) do
+        n when is_integer(n) and n > 0 -> limit(facet_query, ^n)
+        _ -> facet_query
+      end
+
+    facets = AdminRepo.all(facet_query)
+    %{facets: facets, distinct_count: length(facets)}
+  end
+
+  # Escapes LIKE metacharacters (\\, %, _) in a literal prefix so a caller-supplied
+  # `tag_prefix` is matched literally (no wildcard injection). Postgres LIKE uses
+  # backslash as the default escape character.
+  defp like_escape(value) do
+    value
+    |> String.replace("\\", "\\\\")
+    |> String.replace("%", "\\%")
+    |> String.replace("_", "\\_")
   end
 
   # COUNT(*) GROUP BY <field>, returning a dense %{string_value => count} map
@@ -1242,7 +1328,7 @@ defmodule Loopctl.Knowledge do
     |> maybe_filter_by_status(status)
     |> maybe_filter_by_project_id(Keyword.get(opts, :project_id))
     |> maybe_filter_by_category(Keyword.get(opts, :category))
-    |> maybe_filter_by_tags(Keyword.get(opts, :tags))
+    |> maybe_filter_by_tags(Keyword.get(opts, :tags), Keyword.get(opts, :match, :any))
   end
 
   # Fire-and-forget recording of search access for the result list.
@@ -2521,7 +2607,7 @@ defmodule Loopctl.Knowledge do
     |> maybe_filter_by_project_id(Keyword.get(opts, :project_id))
     |> maybe_filter_by_category(Keyword.get(opts, :category))
     |> maybe_filter_by_status(Keyword.get(opts, :status))
-    |> maybe_filter_by_tags(Keyword.get(opts, :tags))
+    |> maybe_filter_by_tags(Keyword.get(opts, :tags), Keyword.get(opts, :match, :any))
     |> maybe_filter_by_source_type(Keyword.get(opts, :source_type))
     |> maybe_filter_by_source_id(Keyword.get(opts, :source_id))
     |> maybe_filter_by_idempotency_key(Keyword.get(opts, :idempotency_key))
@@ -2545,10 +2631,16 @@ defmodule Loopctl.Knowledge do
     where(query, [a], a.status == ^status)
   end
 
-  defp maybe_filter_by_tags(query, nil), do: query
-  defp maybe_filter_by_tags(query, []), do: query
+  # `match` is `:any` (array overlap `&&`, the back-compat OR semantics) or
+  # `:all` (array contains `@>` — articles carrying EVERY listed tag).
+  defp maybe_filter_by_tags(query, nil, _match), do: query
+  defp maybe_filter_by_tags(query, [], _match), do: query
 
-  defp maybe_filter_by_tags(query, tags) when is_list(tags) do
+  defp maybe_filter_by_tags(query, tags, :all) when is_list(tags) do
+    where(query, [a], fragment("? @> ?", a.tags, ^tags))
+  end
+
+  defp maybe_filter_by_tags(query, tags, _any) when is_list(tags) do
     where(query, [a], fragment("? && ?", a.tags, ^tags))
   end
 

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -79,6 +79,12 @@ defmodule Loopctl.Knowledge do
   @spec max_relevance_page_size() :: pos_integer()
   def max_relevance_page_size, do: @max_relevance_page_size
 
+  # Default/maximum number of facet rows (distinct tags) returned by `tag_facets/2`.
+  # An omitted `:limit` is bounded by this (not "all"), so a tenant with tens of
+  # thousands of distinct tags can't force an unbounded response; `distinct_count`
+  # still reports the true cardinality and `truncated` flags when rows were capped.
+  @max_facet_rows 1000
+
   # Byte budget for full-content (`include_body: true`) list reads. An article
   # `body` is up to 100 KB, so a 1000-row full-body page could be ~100 MB — an
   # agent-callable memory/DoS vector. Full-content pages therefore return as many
@@ -840,49 +846,74 @@ defmodule Loopctl.Knowledge do
 
   - `opts` -- `list_articles/2` filters, plus:
     - `:tag_prefix` -- only tags starting with this literal prefix (LIKE-escaped)
-    - `:limit` -- cap the number of facet rows returned (default all)
+    - `:limit` -- cap the number of facet rows (distinct tags) returned. Defaults
+      to and is capped at #{@max_facet_rows} (never unbounded). `count` is the
+      number of distinct articles carrying the tag (robust to duplicate tags in an
+      article's array).
+
+  Cost note: this unnests `tags` over the **whole filtered article set** and
+  groups — the tags GIN index does not accelerate the unnest/group/sort. On large
+  tenants narrow the scan with `:tag_prefix`, `:category`, `:status`, or
+  `:project_id` rather than calling it unfiltered.
 
   ## Returns
 
-  - `%{facets: [%{tag: String.t(), count: pos_integer()}], distinct_count: non_neg_integer()}`
+  - `%{facets: [%{tag: String.t(), count: non_neg_integer()}],
+      distinct_count: non_neg_integer(), truncated: boolean()}` --
+    `distinct_count` is the TRUE number of distinct tags (independent of `:limit`);
+    `truncated` is true when the row `:limit` returned fewer facet rows than that.
   """
   @spec tag_facets(Ecto.UUID.t(), keyword()) :: %{
           facets: [%{tag: String.t(), count: non_neg_integer()}],
-          distinct_count: non_neg_integer()
+          distinct_count: non_neg_integer(),
+          truncated: boolean()
         }
   def tag_facets(tenant_id, opts \\ []) do
     base =
       from(a in Article, where: a.tenant_id == ^tenant_id)
       |> apply_article_filters(opts)
 
-    unnested = from(a in subquery(base), select: %{tag: fragment("unnest(?)", a.tags)})
+    unnested =
+      from(a in subquery(base), select: %{tag: fragment("unnest(?)", a.tags), article_id: a.id})
 
-    facet_query =
-      from(t in subquery(unnested),
-        group_by: t.tag,
-        select: %{tag: t.tag, count: count(t.tag)},
-        order_by: [desc: count(t.tag), asc: t.tag]
-      )
-
-    facet_query =
+    # The unnested (article_id, tag) rows after the optional tag-family prefix
+    # filter. Both the true distinct count and the per-tag facet derive from this,
+    # so the prefix is applied exactly once.
+    tag_rows =
       case Keyword.get(opts, :tag_prefix) do
         prefix when is_binary(prefix) and prefix != "" ->
           pattern = like_escape(prefix) <> "%"
-          where(facet_query, [t], like(t.tag, ^pattern))
+          from(t in subquery(unnested), where: like(t.tag, ^pattern))
 
         _ ->
-          facet_query
+          from(t in subquery(unnested))
       end
 
-    facet_query =
-      case Keyword.get(opts, :limit) do
-        n when is_integer(n) and n > 0 -> limit(facet_query, ^n)
-        _ -> facet_query
-      end
+    # True distinct-tag cardinality over the filtered/prefixed set — independent
+    # of the row `:limit`, so a capped result still reports the real total.
+    distinct_count =
+      from(t in subquery(tag_rows), select: fragment("count(distinct ?)", t.tag))
+      |> AdminRepo.one()
+      |> Kernel.||(0)
 
-    facets = AdminRepo.all(facet_query)
-    %{facets: facets, distinct_count: length(facets)}
+    row_limit = facet_row_limit(Keyword.get(opts, :limit))
+
+    facets =
+      from(t in subquery(tag_rows),
+        group_by: t.tag,
+        select: %{tag: t.tag, count: fragment("count(distinct ?)", t.article_id)},
+        order_by: [desc: fragment("count(distinct ?)", t.article_id), asc: t.tag],
+        limit: ^row_limit
+      )
+      |> AdminRepo.all()
+
+    %{facets: facets, distinct_count: distinct_count, truncated: length(facets) < distinct_count}
   end
+
+  # An explicit positive `:limit` is honored up to @max_facet_rows; an omitted or
+  # non-positive limit defaults to @max_facet_rows (never unbounded).
+  defp facet_row_limit(n) when is_integer(n) and n > 0, do: min(n, @max_facet_rows)
+  defp facet_row_limit(_), do: @max_facet_rows
 
   # Escapes LIKE metacharacters (\\, %, _) in a literal prefix so a caller-supplied
   # `tag_prefix` is matched literally (no wildcard injection). Postgres LIKE uses

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -889,13 +889,6 @@ defmodule Loopctl.Knowledge do
           from(t in subquery(unnested))
       end
 
-    # True distinct-tag cardinality over the filtered/prefixed set — independent
-    # of the row `:limit`, so a capped result still reports the real total.
-    distinct_count =
-      from(t in subquery(tag_rows), select: fragment("count(distinct ?)", t.tag))
-      |> AdminRepo.one()
-      |> Kernel.||(0)
-
     row_limit = facet_row_limit(Keyword.get(opts, :limit))
 
     facets =
@@ -907,7 +900,21 @@ defmodule Loopctl.Knowledge do
       )
       |> AdminRepo.all()
 
-    %{facets: facets, distinct_count: distinct_count, truncated: length(facets) < distinct_count}
+    returned = length(facets)
+
+    # The facet rows ARE the complete distinct-tag set unless we hit the row cap —
+    # only then is a second (count distinct) pass needed for the true total. This
+    # avoids the extra unnest/aggregate scan on the common (un-truncated) path.
+    distinct_count =
+      if returned < row_limit do
+        returned
+      else
+        from(t in subquery(tag_rows), select: fragment("count(distinct ?)", t.tag))
+        |> AdminRepo.one()
+        |> Kernel.||(0)
+      end
+
+    %{facets: facets, distinct_count: distinct_count, truncated: returned < distinct_count}
   end
 
   # An explicit positive `:limit` is honored up to @max_facet_rows; an omitted or

--- a/lib/loopctl_web/controllers/article_controller.ex
+++ b/lib/loopctl_web/controllers/article_controller.ex
@@ -20,6 +20,7 @@ defmodule LoopctlWeb.ArticleController do
   alias LoopctlWeb.ArticleJSON
   alias LoopctlWeb.AuditContext
   alias LoopctlWeb.Helpers.Pagination
+  alias LoopctlWeb.Helpers.TagMatch
 
   action_fallback LoopctlWeb.FallbackController
 
@@ -140,7 +141,14 @@ defmodule LoopctlWeb.ArticleController do
       tags: [
         in: :query,
         type: :string,
-        description: "Filter by tags (comma-separated, ANY match)"
+        description: "Filter by tags (comma-separated). Match mode set by `match` (default ANY)."
+      ],
+      match: [
+        in: :query,
+        type: :string,
+        description:
+          "Tag match mode: `any` (default, OR — overlaps any listed tag) or `all` " <>
+            "(AND — carries every listed tag, e.g. tags=book,hub&match=all = \"book hubs\")."
       ],
       source_type: [in: :query, type: :string, description: "Filter by source_type"],
       source_id: [in: :query, type: :string, description: "Filter by source_id"],
@@ -305,13 +313,15 @@ defmodule LoopctlWeb.ArticleController do
     # (400 with the allowed values), not a 404/500 from an Ecto.Enum cast failure.
     with :ok <- validate_enum(params["status"], @valid_statuses, "status"),
          :ok <- validate_enum(params["category"], @valid_categories, "category"),
-         :ok <- Pagination.validate_limit(params) do
+         :ok <- Pagination.validate_limit(params),
+         {:ok, match} <- TagMatch.parse(params) do
       opts =
         []
         |> maybe_add_opt(:project_id, string_param(params["project_id"]))
         |> maybe_add_opt(:category, params["category"])
         |> maybe_add_opt(:status, params["status"])
         |> maybe_add_opt(:tags, parse_tags(params["tags"]))
+        |> maybe_add_opt(:match, match)
         |> maybe_add_opt(:source_type, string_param(params["source_type"]))
         |> maybe_add_opt(:source_id, string_param(params["source_id"]))
         |> maybe_add_opt(:idempotency_key, string_param(params["idempotency_key"]))

--- a/lib/loopctl_web/controllers/knowledge_facets_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_facets_controller.ex
@@ -92,7 +92,12 @@ defmodule LoopctlWeb.KnowledgeFacetsController do
       tags: [in: :query, type: :string, description: "Filter by tags (comma-separated)"],
       match: [in: :query, type: :string, description: "Tag match mode: any (default) or all"],
       project_id: [in: :query, type: :string, description: "Filter by project UUID"],
-      limit: [in: :query, type: :integer, description: "Max facet rows (default all, max 1000)"]
+      limit: [
+        in: :query,
+        type: :integer,
+        description:
+          "Max distinct tags in the facet result (default all, max 1000; values above 1000 rejected with 400)"
+      ]
     ],
     responses: %{
       200 =>

--- a/lib/loopctl_web/controllers/knowledge_facets_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_facets_controller.ex
@@ -1,0 +1,207 @@
+defmodule LoopctlWeb.KnowledgeFacetsController do
+  @moduledoc """
+  Server-side counting and faceting over the article set.
+
+  - `GET /api/v1/knowledge/count` -- count articles matching filters, no rows (agent+)
+  - `GET /api/v1/knowledge/facets` -- count articles grouped by distinct tag (agent+)
+
+  These remove large client-side enumerations: a caller can answer "how many
+  *published* articles tagged both X and Y" (`count` with `status`+`tags`+`match=all`)
+  or "how many distinct `book-*` books exist" (`facets?group_by=tag&tag_prefix=book-`)
+  without paging any article rows.
+  """
+
+  use LoopctlWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Loopctl.ApiSpec.Schemas
+  alias Loopctl.Knowledge
+  alias Loopctl.Knowledge.Article
+  alias LoopctlWeb.Helpers.Pagination
+  alias LoopctlWeb.Helpers.TagMatch
+
+  action_fallback LoopctlWeb.FallbackController
+
+  plug LoopctlWeb.Plugs.RequireRole, role: :agent
+
+  tags(["Knowledge Wiki"])
+
+  @valid_statuses Article |> Ecto.Enum.values(:status) |> Enum.map(&to_string/1)
+  @valid_categories Article |> Ecto.Enum.values(:category) |> Enum.map(&to_string/1)
+
+  operation(:count,
+    summary: "Count articles (no rows)",
+    description:
+      "Returns the count of articles matching the filters, without returning any " <>
+        "rows. Accepts the same filters as the article list (`category`, `status`, " <>
+        "`tags`, `match`, `source_type`, `source_id`, `idempotency_key`, `project_id`). " <>
+        "With `tags=a,b&match=all` it counts articles carrying BOTH tags; combine with " <>
+        "`status=published` for \"how many published articles tagged both\". Role: agent+.",
+    parameters: [
+      category: [in: :query, type: :string, description: "Filter by category"],
+      status: [in: :query, type: :string, description: "Filter by status"],
+      tags: [in: :query, type: :string, description: "Filter by tags (comma-separated)"],
+      match: [
+        in: :query,
+        type: :string,
+        description: "Tag match mode: any (default, OR) or all (AND)"
+      ],
+      source_type: [in: :query, type: :string, description: "Filter by source_type"],
+      source_id: [in: :query, type: :string, description: "Filter by source_id"],
+      idempotency_key: [in: :query, type: :string, description: "Filter by idempotency_key"],
+      project_id: [in: :query, type: :string, description: "Filter by project UUID"]
+    ],
+    responses: %{
+      200 =>
+        {"Count", "application/json",
+         %OpenApiSpex.Schema{
+           type: :object,
+           properties: %{count: %OpenApiSpex.Schema{type: :integer}}
+         }},
+      400 => {"Bad request", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  @doc "GET /api/v1/knowledge/count"
+  def count(conn, params) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+
+    with :ok <- validate_enum(params["status"], @valid_statuses, "status"),
+         :ok <- validate_enum(params["category"], @valid_categories, "category"),
+         {:ok, match} <- TagMatch.parse(params) do
+      count = Knowledge.count_articles(tenant_id, build_opts(params, match))
+      json(conn, %{count: count})
+    end
+  end
+
+  operation(:facets,
+    summary: "Tag facets (count by distinct tag)",
+    description:
+      "Counts articles grouped by each distinct tag over the filtered set, so a " <>
+        "caller gets a distinct-tag count and per-tag totals without paging rows. " <>
+        "`tag_prefix` restricts to a tag family (e.g. `book-`) to count distinct " <>
+        "members of that family. Honors the same filters as `count` (including " <>
+        "`status` and `tags`/`match`). `group_by=tag` is the only mode today. " <>
+        "Role: agent+.",
+    parameters: [
+      group_by: [in: :query, type: :string, description: "Facet dimension (only `tag`)"],
+      tag_prefix: [in: :query, type: :string, description: "Only tags starting with this prefix"],
+      category: [in: :query, type: :string, description: "Filter by category"],
+      status: [in: :query, type: :string, description: "Filter by status"],
+      tags: [in: :query, type: :string, description: "Filter by tags (comma-separated)"],
+      match: [in: :query, type: :string, description: "Tag match mode: any (default) or all"],
+      project_id: [in: :query, type: :string, description: "Filter by project UUID"],
+      limit: [in: :query, type: :integer, description: "Max facet rows (default all, max 1000)"]
+    ],
+    responses: %{
+      200 =>
+        {"Tag facets", "application/json",
+         %OpenApiSpex.Schema{
+           type: :object,
+           properties: %{
+             data: %OpenApiSpex.Schema{type: :object, description: "tag => count"},
+             meta: %OpenApiSpex.Schema{
+               type: :object,
+               properties: %{
+                 group_by: %OpenApiSpex.Schema{type: :string},
+                 distinct_count: %OpenApiSpex.Schema{type: :integer},
+                 tag_prefix: %OpenApiSpex.Schema{type: :string, nullable: true}
+               }
+             }
+           }
+         }},
+      400 => {"Bad request", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  @doc "GET /api/v1/knowledge/facets"
+  def facets(conn, params) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+
+    with :ok <- validate_group_by(params["group_by"]),
+         :ok <- validate_enum(params["status"], @valid_statuses, "status"),
+         :ok <- validate_enum(params["category"], @valid_categories, "category"),
+         :ok <- Pagination.validate_limit(params),
+         {:ok, match} <- TagMatch.parse(params) do
+      opts =
+        params
+        |> build_opts(match)
+        |> maybe_put(:tag_prefix, string_param(params["tag_prefix"]))
+        |> maybe_put(:limit, parse_int(params["limit"]))
+
+      %{facets: facets, distinct_count: distinct_count} = Knowledge.tag_facets(tenant_id, opts)
+
+      data = Map.new(facets, fn %{tag: tag, count: count} -> {tag, count} end)
+
+      json(conn, %{
+        data: data,
+        meta: %{
+          group_by: "tag",
+          distinct_count: distinct_count,
+          tag_prefix: string_param(params["tag_prefix"])
+        }
+      })
+    end
+  end
+
+  # --- Helpers ---
+
+  defp build_opts(params, match) do
+    []
+    |> maybe_put(:project_id, string_param(params["project_id"]))
+    |> maybe_put(:category, params["category"])
+    |> maybe_put(:status, params["status"])
+    |> maybe_put(:tags, parse_tags(params["tags"]))
+    |> maybe_put(:match, match)
+    |> maybe_put(:source_type, string_param(params["source_type"]))
+    |> maybe_put(:source_id, string_param(params["source_id"]))
+    |> maybe_put(:idempotency_key, string_param(params["idempotency_key"]))
+  end
+
+  defp validate_group_by(nil), do: :ok
+  defp validate_group_by(""), do: :ok
+  defp validate_group_by("tag"), do: :ok
+  defp validate_group_by(_), do: {:error, :bad_request, "Invalid group_by. Allowed values: tag."}
+
+  defp validate_enum(nil, _allowed, _field), do: :ok
+  defp validate_enum("", _allowed, _field), do: :ok
+
+  defp validate_enum(value, allowed, field) do
+    if value in allowed,
+      do: :ok,
+      else:
+        {:error, :bad_request, "Invalid #{field}. Allowed values: #{Enum.join(allowed, ", ")}."}
+  end
+
+  defp maybe_put(opts, _key, nil), do: opts
+  defp maybe_put(opts, _key, ""), do: opts
+  defp maybe_put(opts, _key, []), do: opts
+  defp maybe_put(opts, key, value), do: Keyword.put(opts, key, value)
+
+  defp string_param(value) when is_binary(value), do: value
+  defp string_param(_), do: nil
+
+  defp parse_tags(tags) when is_binary(tags) do
+    tags
+    |> String.split(",", trim: true)
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+    |> case do
+      [] -> nil
+      parsed -> parsed
+    end
+  end
+
+  defp parse_tags(_), do: nil
+
+  defp parse_int(val) when is_binary(val) do
+    case Integer.parse(val) do
+      {n, ""} -> n
+      _ -> nil
+    end
+  end
+
+  defp parse_int(_), do: nil
+end

--- a/lib/loopctl_web/controllers/knowledge_facets_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_facets_controller.ex
@@ -69,6 +69,7 @@ defmodule LoopctlWeb.KnowledgeFacetsController do
 
     with :ok <- validate_enum(params["status"], @valid_statuses, "status"),
          :ok <- validate_enum(params["category"], @valid_categories, "category"),
+         :ok <- validate_project_id(params),
          {:ok, match} <- TagMatch.parse(params) do
       count = Knowledge.count_articles(tenant_id, build_opts(params, match))
       json(conn, %{count: count})
@@ -81,9 +82,13 @@ defmodule LoopctlWeb.KnowledgeFacetsController do
       "Counts articles grouped by each distinct tag over the filtered set, so a " <>
         "caller gets a distinct-tag count and per-tag totals without paging rows. " <>
         "`tag_prefix` restricts to a tag family (e.g. `book-`) to count distinct " <>
-        "members of that family. Honors the same filters as `count` (including " <>
-        "`status` and `tags`/`match`). `group_by=tag` is the only mode today. " <>
-        "Role: agent+.",
+        "members of that family. `meta.distinct_count` is the TRUE number of distinct " <>
+        "tags (independent of `limit`); `meta.truncated` flags when `limit` returned " <>
+        "fewer rows. Per-tag `count` is the number of distinct articles carrying the " <>
+        "tag. Honors the same filters as `count` (including `status` and `tags`/`match`). " <>
+        "Cost: unnests tags over the whole filtered set (the GIN index doesn't help the " <>
+        "unnest/group); on large tenants narrow with `tag_prefix`/`category`/`status`/" <>
+        "`project_id`. `group_by=tag` is the only mode today. Role: agent+.",
     parameters: [
       group_by: [in: :query, type: :string, description: "Facet dimension (only `tag`)"],
       tag_prefix: [in: :query, type: :string, description: "Only tags starting with this prefix"],
@@ -110,7 +115,14 @@ defmodule LoopctlWeb.KnowledgeFacetsController do
                type: :object,
                properties: %{
                  group_by: %OpenApiSpex.Schema{type: :string},
-                 distinct_count: %OpenApiSpex.Schema{type: :integer},
+                 distinct_count: %OpenApiSpex.Schema{
+                   type: :integer,
+                   description: "True distinct-tag count, independent of limit"
+                 },
+                 truncated: %OpenApiSpex.Schema{
+                   type: :boolean,
+                   description: "True when limit returned fewer facet rows than distinct_count"
+                 },
                  tag_prefix: %OpenApiSpex.Schema{type: :string, nullable: true}
                }
              }
@@ -128,6 +140,7 @@ defmodule LoopctlWeb.KnowledgeFacetsController do
     with :ok <- validate_group_by(params["group_by"]),
          :ok <- validate_enum(params["status"], @valid_statuses, "status"),
          :ok <- validate_enum(params["category"], @valid_categories, "category"),
+         :ok <- validate_project_id(params),
          :ok <- Pagination.validate_limit(params),
          {:ok, match} <- TagMatch.parse(params) do
       opts =
@@ -136,7 +149,8 @@ defmodule LoopctlWeb.KnowledgeFacetsController do
         |> maybe_put(:tag_prefix, string_param(params["tag_prefix"]))
         |> maybe_put(:limit, parse_int(params["limit"]))
 
-      %{facets: facets, distinct_count: distinct_count} = Knowledge.tag_facets(tenant_id, opts)
+      %{facets: facets, distinct_count: distinct_count, truncated: truncated} =
+        Knowledge.tag_facets(tenant_id, opts)
 
       data = Map.new(facets, fn %{tag: tag, count: count} -> {tag, count} end)
 
@@ -145,6 +159,7 @@ defmodule LoopctlWeb.KnowledgeFacetsController do
         meta: %{
           group_by: "tag",
           distinct_count: distinct_count,
+          truncated: truncated,
           tag_prefix: string_param(params["tag_prefix"])
         }
       })
@@ -163,6 +178,26 @@ defmodule LoopctlWeb.KnowledgeFacetsController do
     |> maybe_put(:source_type, string_param(params["source_type"]))
     |> maybe_put(:source_id, string_param(params["source_id"]))
     |> maybe_put(:idempotency_key, string_param(params["idempotency_key"]))
+  end
+
+  # Reject a malformed project_id with 400 rather than letting a non-UUID reach
+  # the binary_id query and raise Ecto.Query.CastError (a 500). Requires the
+  # canonical 36-char dashed form so a 16-char junk segment can't coerce into a
+  # bogus-but-valid UUID (mirrors KnowledgeStatsController.project_opts/1).
+  defp validate_project_id(params) do
+    case params["project_id"] do
+      value when value in [nil, ""] ->
+        :ok
+
+      value when is_binary(value) and byte_size(value) == 36 ->
+        case Ecto.UUID.cast(value) do
+          {:ok, _} -> :ok
+          :error -> {:error, :bad_request, "Invalid project_id. Must be a UUID."}
+        end
+
+      _ ->
+        {:error, :bad_request, "Invalid project_id. Must be a UUID."}
+    end
   end
 
   defp validate_group_by(nil), do: :ok

--- a/lib/loopctl_web/controllers/knowledge_index_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_index_controller.ex
@@ -19,6 +19,7 @@ defmodule LoopctlWeb.KnowledgeIndexController do
   alias Loopctl.Knowledge
   alias Loopctl.Knowledge.Article
   alias LoopctlWeb.Helpers.Pagination
+  alias LoopctlWeb.Helpers.TagMatch
 
   action_fallback LoopctlWeb.FallbackController
 
@@ -69,7 +70,13 @@ defmodule LoopctlWeb.KnowledgeIndexController do
       tags: [
         in: :query,
         type: :string,
-        description: "Comma-separated tags; matches articles carrying ANY of them",
+        description: "Comma-separated tags (match mode set by `match`, default ANY)",
+        required: false
+      ],
+      match: [
+        in: :query,
+        type: :string,
+        description: "Tag match mode: any (default, OR) or all (AND — carries every listed tag)",
         required: false
       ],
       limit: [
@@ -170,12 +177,14 @@ defmodule LoopctlWeb.KnowledgeIndexController do
   defp parse_fields(_), do: {:error, :bad_request, "fields must be a comma-separated string"}
 
   defp build_opts(params) do
-    with {:ok, category} <- validate_category(params["category"]) do
+    with {:ok, category} <- validate_category(params["category"]),
+         {:ok, match} <- TagMatch.parse(params) do
       opts =
         []
         |> maybe_put(:project_id, parse_project_id(params["project_id"]))
         |> maybe_put(:category, category)
         |> maybe_put(:tags, parse_tags(params["tags"]))
+        |> Keyword.put(:match, match)
         |> maybe_put(:limit, parse_int(params["limit"]))
         |> maybe_put(:offset, parse_int(params["offset"]))
 

--- a/lib/loopctl_web/controllers/knowledge_search_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_search_controller.ex
@@ -20,6 +20,7 @@ defmodule LoopctlWeb.KnowledgeSearchController do
   alias Loopctl.Knowledge
   alias Loopctl.Knowledge.Article
   alias LoopctlWeb.Helpers.Pagination
+  alias LoopctlWeb.Helpers.TagMatch
 
   action_fallback LoopctlWeb.FallbackController
 
@@ -81,7 +82,13 @@ defmodule LoopctlWeb.KnowledgeSearchController do
       tags: [
         in: :query,
         type: :string,
-        description: "Comma-separated tags to filter by",
+        description: "Comma-separated tags to filter by (match mode set by `match`)",
+        required: false
+      ],
+      match: [
+        in: :query,
+        type: :string,
+        description: "Tag match mode: any (default, OR) or all (AND — carries every listed tag)",
         required: false
       ],
       limit: [
@@ -223,12 +230,14 @@ defmodule LoopctlWeb.KnowledgeSearchController do
   defp validate_mode(_), do: {:ok, "combined"}
 
   defp build_opts(params) do
-    with {:ok, category} <- validate_category(params["category"]) do
+    with {:ok, category} <- validate_category(params["category"]),
+         {:ok, match} <- TagMatch.parse(params) do
       opts =
         []
         |> maybe_add_opt(:project_id, params["project_id"])
         |> maybe_add_opt(:category, category)
         |> maybe_add_tags(params["tags"])
+        |> Keyword.put(:match, match)
         |> maybe_add_limit(params["limit"])
         |> maybe_add_offset(params["offset"])
 

--- a/lib/loopctl_web/helpers/tag_match.ex
+++ b/lib/loopctl_web/helpers/tag_match.ex
@@ -1,0 +1,26 @@
+defmodule LoopctlWeb.Helpers.TagMatch do
+  @moduledoc """
+  Parses the `match` query param for tag filtering.
+
+  `tags` filtering defaults to OR semantics (an article matching ANY of the
+  listed tags). `match=all` switches to AND semantics (an article carrying EVERY
+  listed tag — e.g. "book hubs" = `tags=book,hub&match=all`). `match=any` is the
+  explicit default. An unknown value is a 400 rather than a silent fallback.
+  """
+
+  @doc """
+  Returns `{:ok, :any | :all}` for a valid (or absent) `match`, or
+  `{:error, :bad_request, message}` — the shape `LoopctlWeb.FallbackController`
+  renders as a 400 — for an unknown value.
+  """
+  @spec parse(map()) :: {:ok, :any | :all} | {:error, :bad_request, String.t()}
+  def parse(params) when is_map(params) do
+    case params["match"] do
+      nil -> {:ok, :any}
+      "" -> {:ok, :any}
+      "any" -> {:ok, :any}
+      "all" -> {:ok, :all}
+      _other -> {:error, :bad_request, "Invalid match. Allowed values: any, all."}
+    end
+  end
+end

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -299,6 +299,10 @@ defmodule LoopctlWeb.Router do
     # Knowledge Stats (aggregate counts by category/status)
     get "/knowledge/stats", KnowledgeStatsController, :stats
 
+    # Knowledge Count + Facets (filtered counts and count-by-tag, no rows)
+    get "/knowledge/count", KnowledgeFacetsController, :count
+    get "/knowledge/facets", KnowledgeFacetsController, :facets
+
     # Knowledge Search (unified keyword / semantic / combined)
     get "/knowledge/search", KnowledgeSearchController, :search
 

--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to `loopctl-mcp-server` are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 2.15.0 — 2026-06-23 (AND-tag filtering + count/facets)
+
+### Added
+
+- **`knowledge_count`** — count articles matching filters (category, status, tags,
+  `match`, source/idempotency, project) **without returning rows**. With
+  `tags` + `match: "all"` (+ `status`) it answers "how many published articles
+  tagged both X and Y" in one call. (#148 A2/A4)
+- **`knowledge_facets`** — count articles grouped by distinct tag, with an
+  optional `tag_prefix` to get the **distinct count of a tag family** (e.g. how
+  many distinct `book-*` books) plus per-member totals, no row enumeration. (#148 A3)
+- **`match` param** on `knowledge_list`, `knowledge_index`, and `knowledge_search`:
+  `any` (default, OR — back-compat) or `all` (AND — articles carrying every listed
+  tag). Lets agents ask for "book hubs" (`tags: "book,hub", match: "all"`) instead
+  of the union. (#148 A2 / M1)
+
 ## 2.14.0 — 2026-06-23 (lag-free enumeration honors large pages)
 
 ### ⚠️ Breaking Change

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -2,7 +2,7 @@
 
 MCP (Model Context Protocol) server for [loopctl](https://loopctl.com) -- structural trust for AI development loops.
 
-Wraps the loopctl REST API into 57 typed MCP tools so AI coding agents (Claude Code, etc.) can interact with loopctl without writing curl commands.
+Wraps the loopctl REST API into 59 typed MCP tools so AI coding agents (Claude Code, etc.) can interact with loopctl without writing curl commands.
 
 ## Installation
 
@@ -66,7 +66,7 @@ Or if installed locally:
 
 Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_KEY`.
 
-## Tools (57)
+## Tools (59)
 
 ### Project Tools
 
@@ -145,6 +145,8 @@ Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_K
 |---|---|
 | `knowledge_index` | Browse/paginate the knowledge wiki catalog grouped by category. Honors `category`, `tags`, `offset`, `limit` with deterministic ordering so every article is reachable (`meta.categories` reports per-category totals over the whole filtered set). Use `fields` (default `id,title,category`; request `tags`/`status`/`updated_at` explicitly; `id` and `category` are always included) to keep the payload small. Optional: `project_id`, `story_id`, `category`, `tags`, `offset`, `limit`, `fields`. |
 | `knowledge_stats` | Aggregate article counts (`total`, `by_category`, `by_status`) via cheap `COUNT(*) GROUP BY` — no article metadata loaded. The right tool for "how many articles are in this project?" (`knowledge_index` pages metadata; `knowledge_search`'s `total_count` is query-dependent). Counts span all statuses. Optional: `project_id`. |
+| `knowledge_count` | Count articles matching filters **without returning rows**. Same filters as `knowledge_list` (`category`, `status`, `tags`, `match`, `source_type`, `source_id`, `idempotency_key`, `project_id`). With `tags`+`match: all` (+`status`) → "how many published articles tagged both X and Y". Returns `{ count }`. |
+| `knowledge_facets` | Count articles grouped by **distinct tag**, no rows. `tag_prefix` (e.g. `book-`) gives the distinct count of a tag family plus per-member totals. Returns `{ data: { tag: count }, meta: { distinct_count } }`. Optional: `category`, `status`, `tags`, `match`, `project_id`, `limit`. |
 | `knowledge_search` | Search the knowledge wiki by topic (keyword, semantic, or combined). Returns snippets. **Ranked, published-only, and LAGS writes by minutes while embeddings index — do NOT use for existence/idempotency/dedup checks (a fresh write false-negatives); use `knowledge_list` for that.** `q` is optional when `tags`/`category` are supplied — that **list mode** returns the complete filtered set paginated via `offset`/`limit` over `meta.total_count`. `meta.total_count` is mode-dependent — read `meta.total_count_scope` (`keyword_matches`/`ranked_corpus`/`merged_candidates`/`filtered_set`) and don't use a relevance-mode count to size the wiki (use `knowledge_list` or `knowledge_stats`). Optional: `project_id`, `story_id` for attribution. |
 | `knowledge_list` | List articles (`id`, `title`, `category`, `status`, `tags`, `source_type`, `source_id`, `idempotency_key`, timestamps), filtered + paginated. **Body-less summary by default** (safe to page up to `limit=1000`); pass `include_body: true` to also return `body`, in which case the page is bounded by a ~5 MB byte budget — continue via `meta.next_offset` while `meta.has_more`. **Lag-free, all-status** read of the DB of record — unlike `knowledge_search` (ranked, published-only, lags writes) and `knowledge_index` (id/title/category only). The right tool to enumerate/dedup/repair and for idempotency/existence checks: filter by `tags`, `source_type`+`source_id`, or `idempotency_key` and read `meta.total_count` (exact). Single full body → `knowledge_get`; relevant bodies → `knowledge_context`; bulk dump → `knowledge_export`. Optional: `project_id`, `category`, `status`, `tags`, `source_type`, `source_id`, `idempotency_key`, `offset`, `limit`, `include_body`. |
 | `knowledge_get` | Get full article content by ID. Use after search to read an article in detail. Optional: `project_id`, `story_id` for attribution. |

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -579,7 +579,7 @@ async function setTokenBudget({ scope_type, scope_id, budget_millicents, alert_t
 
 // --- Knowledge Wiki Tools (agent key) ---
 
-async function knowledgeIndex({ project_id, story_id, category, tags, offset, limit, fields }) {
+async function knowledgeIndex({ project_id, story_id, category, tags, match, offset, limit, fields }) {
   if (project_id && !UUID_RE.test(project_id)) {
     return {
       content: [{ type: "text", text: "Error: project_id must be a canonical UUID (8-4-4-4-12 hex)." }],
@@ -593,6 +593,7 @@ async function knowledgeIndex({ project_id, story_id, category, tags, offset, li
   if (story_id) params.set("story_id", story_id);
   if (category) params.set("category", category);
   if (tags) params.set("tags", tags);
+  if (match) params.set("match", match);
   if (offset != null) params.set("offset", String(offset));
   if (limit != null) params.set("limit", String(limit));
   if (fields) params.set("fields", Array.isArray(fields) ? fields.join(",") : fields);
@@ -616,13 +617,66 @@ async function knowledgeStats({ project_id }) {
   return toContent(result);
 }
 
-async function knowledgeSearch({ q, project_id, story_id, category, tags, mode, limit, offset }) {
+async function knowledgeCount({
+  project_id,
+  category,
+  status,
+  tags,
+  match,
+  source_type,
+  source_id,
+  idempotency_key,
+}) {
+  const params = new URLSearchParams();
+  if (project_id) params.set("project_id", project_id);
+  if (category) params.set("category", category);
+  if (status) params.set("status", status);
+  if (tags) params.set("tags", tags);
+  if (match) params.set("match", match);
+  if (source_type) params.set("source_type", source_type);
+  if (source_id) params.set("source_id", source_id);
+  if (idempotency_key) params.set("idempotency_key", idempotency_key);
+  const qs = params.toString();
+  const path = qs ? `/api/v1/knowledge/count?${qs}` : "/api/v1/knowledge/count";
+  const result = await apiCall("GET", path, null, process.env.LOOPCTL_AGENT_KEY);
+  return toContent(result);
+}
+
+async function knowledgeFacets({
+  project_id,
+  category,
+  status,
+  tags,
+  match,
+  tag_prefix,
+  limit,
+}) {
+  const params = new URLSearchParams();
+  params.set("group_by", "tag");
+  if (project_id) params.set("project_id", project_id);
+  if (category) params.set("category", category);
+  if (status) params.set("status", status);
+  if (tags) params.set("tags", tags);
+  if (match) params.set("match", match);
+  if (tag_prefix) params.set("tag_prefix", tag_prefix);
+  if (limit != null) params.set("limit", String(limit));
+  const result = await apiCall(
+    "GET",
+    `/api/v1/knowledge/facets?${params}`,
+    null,
+    process.env.LOOPCTL_AGENT_KEY,
+  );
+  return toContent(result);
+}
+
+async function knowledgeSearch({ q, project_id, story_id, category, tags, match, mode, limit, offset }) {
   const params = new URLSearchParams();
   if (q != null && q !== "") params.set("q", q);
   if (project_id) params.set("project_id", project_id);
   if (story_id) params.set("story_id", story_id);
   if (category) params.set("category", category);
   if (tags) params.set("tags", tags);
+  if (match) params.set("match", match);
   if (mode) params.set("mode", mode);
   if (limit != null) params.set("limit", String(limit));
   if (offset != null) params.set("offset", String(offset));
@@ -636,6 +690,7 @@ async function knowledgeList({
   category,
   status,
   tags,
+  match,
   source_type,
   source_id,
   idempotency_key,
@@ -648,6 +703,7 @@ async function knowledgeList({
   if (category) params.set("category", category);
   if (status) params.set("status", status);
   if (tags) params.set("tags", tags);
+  if (match) params.set("match", match);
   if (source_type) params.set("source_type", source_type);
   if (source_id) params.set("source_id", source_id);
   if (idempotency_key) params.set("idempotency_key", idempotency_key);
@@ -1862,6 +1918,11 @@ const TOOLS = [
           type: "string",
           description: "Optional: comma-separated tags; matches articles carrying ANY of them.",
         },
+        match: {
+          type: "string",
+          enum: ["any", "all"],
+          description: "Optional: tag match mode — 'any' (default, OR) or 'all' (AND, every tag).",
+        },
         offset: {
           type: "integer",
           description: "Optional: rows to skip for pagination (default 0).",
@@ -1918,6 +1979,11 @@ const TOOLS = [
         tags: {
           type: "string",
           description: "Optional: comma-separated tags; matches articles carrying ANY of them.",
+        },
+        match: {
+          type: "string",
+          enum: ["any", "all"],
+          description: "Optional: tag match mode — 'any' (default, OR) or 'all' (AND, every tag).",
         },
         source_type: {
           type: "string",
@@ -1980,6 +2046,62 @@ const TOOLS = [
     },
   },
   {
+    name: "knowledge_count",
+    description:
+      "Count articles matching filters WITHOUT returning any rows. Accepts the same filters " +
+      "as knowledge_list (category, status, tags, match, source_type, source_id, " +
+      "idempotency_key, project_id). With tags + match:'all' it counts articles carrying ALL " +
+      "the tags; add status:'published' to answer \"how many PUBLISHED articles tagged both X " +
+      "and Y\". Removes the need to paginate rows just to count. Returns { count }.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        project_id: { type: "string", format: "uuid", description: "Optional: scope to a project UUID." },
+        category: { type: "string", description: "Optional: filter by category." },
+        status: { type: "string", description: "Optional: filter by status." },
+        tags: { type: "string", description: "Optional: comma-separated tags." },
+        match: {
+          type: "string",
+          enum: ["any", "all"],
+          description: "Tag match mode: 'any' (default, OR) or 'all' (AND — carries every tag).",
+        },
+        source_type: { type: "string", description: "Optional: filter by source_type." },
+        source_id: { type: "string", description: "Optional: filter by source_id." },
+        idempotency_key: { type: "string", description: "Optional: filter by idempotency_key." },
+      },
+      required: [],
+    },
+  },
+  {
+    name: "knowledge_facets",
+    description:
+      "Count articles grouped by each distinct tag, over the filtered set, WITHOUT returning " +
+      "rows. Returns { data: { tag: count }, meta: { distinct_count } }. Pass tag_prefix to " +
+      "restrict to a tag family (e.g. 'book-') so you get the DISTINCT count of that family " +
+      "(how many distinct books) plus per-member totals — without dragging tens of thousands " +
+      "of rows through context. Honors the same filters as knowledge_count (status, tags, match).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        project_id: { type: "string", format: "uuid", description: "Optional: scope to a project UUID." },
+        category: { type: "string", description: "Optional: filter by category." },
+        status: { type: "string", description: "Optional: filter by status." },
+        tags: { type: "string", description: "Optional: comma-separated tags." },
+        match: {
+          type: "string",
+          enum: ["any", "all"],
+          description: "Tag match mode: 'any' (default, OR) or 'all' (AND).",
+        },
+        tag_prefix: {
+          type: "string",
+          description: "Optional: only tags starting with this literal prefix (e.g. 'book-').",
+        },
+        limit: { type: "integer", description: "Optional: max facet rows (default all, max 1000)." },
+      },
+      required: [],
+    },
+  },
+  {
     name: "knowledge_search",
     description:
       "Search the knowledge wiki by topic. Returns snippets. Ranked, and returns PUBLISHED " +
@@ -2022,6 +2144,11 @@ const TOOLS = [
         tags: {
           type: "string",
           description: "Optional: comma-separated tags to filter by.",
+        },
+        match: {
+          type: "string",
+          enum: ["any", "all"],
+          description: "Optional: tag match mode — 'any' (default, OR) or 'all' (AND, every tag).",
         },
         mode: {
           type: "string",
@@ -2874,6 +3001,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     case "knowledge_stats":
       return await knowledgeStats(args);
+
+    case "knowledge_count":
+      return await knowledgeCount(args);
+
+    case "knowledge_facets":
+      return await knowledgeFacets(args);
 
     case "knowledge_search":
       return await knowledgeSearch(args);

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -2096,7 +2096,7 @@ const TOOLS = [
           type: "string",
           description: "Optional: only tags starting with this literal prefix (e.g. 'book-').",
         },
-        limit: { type: "integer", description: "Optional: max facet rows (default all, max 1000)." },
+        limit: { type: "integer", description: "Optional: max distinct tags in the result (default all, max 1000; values above 1000 are rejected with 400)." },
       },
       required: [],
     },

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -2076,10 +2076,14 @@ const TOOLS = [
     name: "knowledge_facets",
     description:
       "Count articles grouped by each distinct tag, over the filtered set, WITHOUT returning " +
-      "rows. Returns { data: { tag: count }, meta: { distinct_count } }. Pass tag_prefix to " +
-      "restrict to a tag family (e.g. 'book-') so you get the DISTINCT count of that family " +
-      "(how many distinct books) plus per-member totals — without dragging tens of thousands " +
-      "of rows through context. Honors the same filters as knowledge_count (status, tags, match).",
+      "rows. Returns { data: { tag: count }, meta: { distinct_count, truncated } }. " +
+      "meta.distinct_count is the TRUE number of distinct tags (independent of limit); " +
+      "meta.truncated flags when limit capped the rows. Each `count` is the number of distinct " +
+      "articles carrying that tag. Pass tag_prefix to restrict to a tag family (e.g. 'book-') " +
+      "so you get the DISTINCT count of that family (how many distinct books) plus per-member " +
+      "totals — without dragging tens of thousands of rows through context. Honors the same " +
+      "filters as knowledge_count (status, tags, match). Cost: unnests tags over the whole " +
+      "filtered set; on large tenants narrow with tag_prefix/category/status/project_id.",
     inputSchema: {
       type: "object",
       properties: {

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "description": "MCP server for loopctl — structural trust for AI development loops",
   "type": "module",
   "main": "index.js",

--- a/test/loopctl_web/controllers/article_controller_test.exs
+++ b/test/loopctl_web/controllers/article_controller_test.exs
@@ -702,6 +702,48 @@ defmodule LoopctlWeb.ArticleControllerTest do
       assert body_tags["meta"]["total_count"] == 1
       assert hd(body_tags["data"])["title"] == "Pattern A"
     end
+
+    test "match=all ANDs tags; default ORs them (#148 A2)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      fixture(:article, %{tenant_id: tenant.id, title: "Book Hub", tags: ["book", "hub"]})
+      fixture(:article, %{tenant_id: tenant.id, title: "Book Only", tags: ["book"]})
+      fixture(:article, %{tenant_id: tenant.id, title: "Hub Only", tags: ["hub"]})
+
+      # AND: only the article carrying BOTH tags
+      and_body =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/articles?tags=book,hub&match=all")
+        |> json_response(200)
+
+      assert and_body["meta"]["total_count"] == 1
+      assert hd(and_body["data"])["title"] == "Book Hub"
+
+      # OR (default): the union of all three
+      or_body =
+        build_conn()
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/articles?tags=book,hub")
+        |> json_response(200)
+
+      assert or_body["meta"]["total_count"] == 3
+    end
+
+    test "rejects an invalid match with 400 (#148 A2)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      resp =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/articles?tags=book&match=nonsense")
+        |> json_response(400)
+
+      assert resp["error"]["status"] == 400
+      assert resp["error"]["message"] =~ "match"
+    end
   end
 
   describe "GET /api/v1/articles — pagination limit (#148 A1)" do

--- a/test/loopctl_web/controllers/knowledge_facets_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_facets_controller_test.exs
@@ -1,0 +1,154 @@
+defmodule LoopctlWeb.KnowledgeFacetsControllerTest do
+  use LoopctlWeb.ConnCase, async: true
+
+  setup :verify_on_exit!
+
+  defp auth_conn(conn, raw_key) do
+    put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  defp setup_tenant_key do
+    tenant = fixture(:tenant)
+    {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+    {tenant, raw_key}
+  end
+
+  describe "GET /api/v1/knowledge/count (#148 A2/A4)" do
+    test "counts articles matching status + AND-tags without returning rows", %{conn: conn} do
+      {tenant, raw_key} = setup_tenant_key()
+
+      # Two articles tagged both book+hub (one draft), one tagged only book.
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "BH1",
+        status: :published,
+        tags: ["book", "hub"]
+      })
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "BH2",
+        status: :draft,
+        tags: ["book", "hub"]
+      })
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "B only",
+        status: :published,
+        tags: ["book"]
+      })
+
+      # AND-tag: both book and hub → 2 (any status)
+      both =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/count?tags=book,hub&match=all")
+        |> json_response(200)
+
+      assert both["count"] == 2
+
+      # status + AND-tag: published AND tagged both → 1
+      pub_both =
+        build_conn()
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/count?tags=book,hub&match=all&status=published")
+        |> json_response(200)
+
+      assert pub_both["count"] == 1
+
+      # OR (default) tags=book,hub → all 3 (union)
+      union =
+        build_conn()
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/count?tags=book,hub")
+        |> json_response(200)
+
+      assert union["count"] == 3
+    end
+
+    test "rejects an invalid match with 400", %{conn: conn} do
+      {_tenant, raw_key} = setup_tenant_key()
+
+      resp =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/count?tags=book&match=bogus")
+        |> json_response(400)
+
+      assert resp["error"]["status"] == 400
+      assert resp["error"]["message"] =~ "match"
+    end
+
+    test "tenant isolation: count only sees the caller's tenant", %{conn: conn} do
+      {tenant_a, raw_key_a} = setup_tenant_key()
+      tenant_b = fixture(:tenant)
+
+      fixture(:article, %{tenant_id: tenant_a.id, title: "A", tags: ["shared"]})
+      fixture(:article, %{tenant_id: tenant_b.id, title: "B", tags: ["shared"]})
+
+      resp =
+        conn
+        |> auth_conn(raw_key_a)
+        |> get(~p"/api/v1/knowledge/count?tags=shared")
+        |> json_response(200)
+
+      assert resp["count"] == 1
+    end
+  end
+
+  describe "GET /api/v1/knowledge/facets (#148 A3)" do
+    test "counts distinct tags with a prefix filter, no rows", %{conn: conn} do
+      {tenant, raw_key} = setup_tenant_key()
+
+      fixture(:article, %{tenant_id: tenant.id, title: "b1", tags: ["book-aaa", "hub"]})
+      fixture(:article, %{tenant_id: tenant.id, title: "b2", tags: ["book-aaa"]})
+      fixture(:article, %{tenant_id: tenant.id, title: "b3", tags: ["book-bbb"]})
+      fixture(:article, %{tenant_id: tenant.id, title: "n1", tags: ["notabook"]})
+
+      resp =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/facets?group_by=tag&tag_prefix=book-")
+        |> json_response(200)
+
+      # Two distinct book-* tags; book-aaa carried by 2 articles, book-bbb by 1.
+      assert resp["meta"]["distinct_count"] == 2
+      assert resp["meta"]["group_by"] == "tag"
+      assert resp["data"]["book-aaa"] == 2
+      assert resp["data"]["book-bbb"] == 1
+      refute Map.has_key?(resp["data"], "hub")
+      refute Map.has_key?(resp["data"], "notabook")
+    end
+
+    test "prefix is matched literally (LIKE wildcards escaped)", %{conn: conn} do
+      {tenant, raw_key} = setup_tenant_key()
+
+      fixture(:article, %{tenant_id: tenant.id, title: "p", tags: ["a_b"]})
+      fixture(:article, %{tenant_id: tenant.id, title: "q", tags: ["axb"]})
+
+      # "a_" must match only the literal "a_b", not "axb" (underscore is a LIKE wildcard).
+      resp =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/facets?group_by=tag&tag_prefix=a_")
+        |> json_response(200)
+
+      assert Map.has_key?(resp["data"], "a_b")
+      refute Map.has_key?(resp["data"], "axb")
+    end
+
+    test "rejects an invalid group_by with 400", %{conn: conn} do
+      {_tenant, raw_key} = setup_tenant_key()
+
+      resp =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/facets?group_by=author")
+        |> json_response(400)
+
+      assert resp["error"]["status"] == 400
+      assert resp["error"]["message"] =~ "group_by"
+    end
+  end
+end

--- a/test/loopctl_web/controllers/knowledge_facets_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_facets_controller_test.exs
@@ -150,5 +150,71 @@ defmodule LoopctlWeb.KnowledgeFacetsControllerTest do
       assert resp["error"]["status"] == 400
       assert resp["error"]["message"] =~ "group_by"
     end
+
+    test "counts distinct articles, not tag occurrences (duplicate tags in an array)", %{
+      conn: conn
+    } do
+      {tenant, raw_key} = setup_tenant_key()
+
+      # A single article whose array stores the same tag twice must count once.
+      fixture(:article, %{tenant_id: tenant.id, title: "dup", tags: ["dup", "dup"]})
+
+      resp =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/facets?group_by=tag&tag_prefix=dup")
+        |> json_response(200)
+
+      assert resp["data"]["dup"] == 1
+      assert resp["meta"]["distinct_count"] == 1
+    end
+
+    test "limit caps facet rows; distinct_count stays true and truncated flags it", %{conn: conn} do
+      {tenant, raw_key} = setup_tenant_key()
+
+      for t <- ["t-a", "t-b", "t-c"] do
+        fixture(:article, %{tenant_id: tenant.id, title: t, tags: [t]})
+      end
+
+      resp =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/facets?group_by=tag&tag_prefix=t-&limit=2")
+        |> json_response(200)
+
+      # Only 2 facet rows returned, but distinct_count reflects the true 3, and
+      # truncated tells the caller the family was capped.
+      assert map_size(resp["data"]) == 2
+      assert resp["meta"]["distinct_count"] == 3
+      assert resp["meta"]["truncated"] == true
+    end
+
+    test "rejects a non-UUID project_id with 400 (not a 500)", %{conn: conn} do
+      {_tenant, raw_key} = setup_tenant_key()
+
+      resp =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/facets?group_by=tag&project_id=not-a-uuid")
+        |> json_response(400)
+
+      assert resp["error"]["status"] == 400
+      assert resp["error"]["message"] =~ "project_id"
+    end
+  end
+
+  describe "GET /api/v1/knowledge/count — project_id validation (#148)" do
+    test "rejects a non-UUID project_id with 400 (not a 500)", %{conn: conn} do
+      {_tenant, raw_key} = setup_tenant_key()
+
+      resp =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/count?project_id=not-a-uuid")
+        |> json_response(400)
+
+      assert resp["error"]["status"] == 400
+      assert resp["error"]["message"] =~ "project_id"
+    end
   end
 end


### PR DESCRIPTION
Add #148 A2-A4: AND-tag filtering + count/facets endpoints (+ MCP)

Second of three PRs for #148. Additive — no behavior change to existing OR-tag callers.

- **A2 AND-tag.** A `match` query param (`any` default = OR overlap, back-compat;
  `all` = AND via array contains `@>`) on the article list, knowledge search, and
  knowledge index endpoints, so callers can ask for "book hubs"
  (`tags=book,hub&match=all`) instead of the union. Unknown `match` → 400.
- **A3 facets/count.**
  - `GET /knowledge/count` — count articles matching filters with NO rows.
  - `GET /knowledge/facets?group_by=tag&tag_prefix=book-` — count by distinct tag
    (with a literal, LIKE-escaped prefix), returning `{tag: count}` + `distinct_count`,
    so a distinct-book count needs no row enumeration.
- **A4 status×tag count.** Falls out: `GET /knowledge/count?tags=a,b&match=all&status=published`.
- **M1 AND-tag / M2 faceting (MCP).** New `knowledge_count` + `knowledge_facets`
  tools; `match` param added to `knowledge_list`/`knowledge_index`/`knowledge_search`.
  MCP 2.14.0 → 2.15.0 (+ CHANGELOG, README, tool count 57→59).

Context: `Knowledge.count_articles/2`, `Knowledge.tag_facets/2`, and a `match`-aware
`maybe_filter_by_tags/3` threaded through `apply_article_filters`/`apply_search_filters`/
`list_index`. Shared `LoopctlWeb.Helpers.TagMatch.parse/1`. `tag_prefix` is LIKE-escaped
to prevent wildcard injection.

Tests: AND vs OR counts, status×AND-tag, distinct-tag facets, literal-prefix (underscore
not treated as a wildcard), invalid match/group_by → 400, tenant isolation.

Refs #148
