### PR TITLE
Add #148 M3 bulk-unpublish + document update endpoint (A5); confirm A6

### DIFF
--- a/README.md
+++ b/README.md
@@ -775,7 +775,7 @@ cd mcp-server && npm install
 
 Keys must be in the `env` block — the MCP server process does not inherit the shell environment.
 
-### Available Tools (59)
+### Available Tools (60)
 
 Full descriptions live in [`mcp-server/README.md`](mcp-server/README.md); summary:
 

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -1696,6 +1696,121 @@ defmodule Loopctl.Knowledge do
   end
 
   @doc """
+  Unpublishes (published → draft) articles, **partial-success** style.
+
+  The mirror of `bulk_publish/3` for cleanup passes: every currently-published id
+  is moved back to `:draft` (records the `article.unpublished` audit event) and
+  the rest get a per-id outcome instead of failing the whole call:
+
+  - `"unpublished"` -- it was published and is now a draft
+  - `"skipped"` -- already a draft (idempotent no-op), or archived/superseded
+    (`reason` says which)
+  - `"not_found"` -- no such article in this tenant
+  - `"errored"` -- the transition failed unexpectedly (chunk retried row-by-row)
+
+  Duplicate ids are de-duplicated, malformed ids resolve to `"not_found"`, ids are
+  processed in chunks of #{@bulk_publish_chunk_size} (each its own transaction),
+  and a request is bounded to #{@bulk_publish_max} ids. Partial-success: a
+  `{:ok, _}` does NOT imply everything unpublished — inspect `counts`.
+
+  ## Returns
+
+  - `{:ok, %{unpublished: [%Article{}], results: [map()], counts: map()}}`
+  - `{:error, :bad_request, message}` when `article_ids` is empty/nil or exceeds
+    #{@bulk_publish_max}
+  """
+  @spec bulk_unpublish(Ecto.UUID.t(), [Ecto.UUID.t()], keyword()) ::
+          {:ok, %{unpublished: [Article.t()], results: [map()], counts: map()}}
+          | {:error, :bad_request, String.t()}
+  def bulk_unpublish(_tenant_id, article_ids, _opts) when article_ids in [nil, []] do
+    {:error, :bad_request, "article_ids must not be empty"}
+  end
+
+  def bulk_unpublish(tenant_id, article_ids, opts) do
+    ids = article_ids |> List.wrap() |> Enum.filter(&is_binary/1) |> Enum.uniq()
+
+    cond do
+      ids == [] ->
+        {:error, :bad_request, "article_ids must contain at least one UUID string"}
+
+      length(ids) > @bulk_publish_max ->
+        {:error, :bad_request,
+         "Maximum #{@bulk_publish_max} article ids per bulk unpublish; split into smaller calls"}
+
+      true ->
+        {:ok, do_bulk_unpublish(tenant_id, ids, opts)}
+    end
+  end
+
+  defp do_bulk_unpublish(tenant_id, article_ids, opts) do
+    existing = load_existing_by_ids(tenant_id, article_ids)
+
+    published =
+      for id <- article_ids,
+          match?(%Article{status: :published}, Map.get(existing, id)),
+          do: Map.fetch!(existing, id)
+
+    # Unpublishing keeps the embedding (the body is unchanged), so no post-commit
+    # re-embedding is needed — unlike bulk_publish.
+    {unpublished, errored_ids} =
+      transition_in_chunks(
+        tenant_id,
+        published,
+        :draft,
+        "article.unpublished",
+        opts,
+        fn _done -> :ok end
+      )
+
+    unpublished_ids = MapSet.new(unpublished, & &1.id)
+    errored_set = MapSet.new(errored_ids)
+
+    results =
+      Enum.map(article_ids, &bulk_unpublish_result(&1, existing, unpublished_ids, errored_set))
+
+    by_outcome = Enum.frequencies_by(results, & &1.outcome)
+
+    %{
+      unpublished: unpublished,
+      results: results,
+      counts: %{
+        requested: length(article_ids),
+        unpublished: Map.get(by_outcome, "unpublished", 0),
+        skipped: Map.get(by_outcome, "skipped", 0),
+        not_found: Map.get(by_outcome, "not_found", 0),
+        errored: Map.get(by_outcome, "errored", 0)
+      }
+    }
+  end
+
+  defp bulk_unpublish_result(id, existing, unpublished_ids, errored_set) do
+    cond do
+      MapSet.member?(errored_set, id) ->
+        %{id: id, outcome: "errored", reason: "unpublish_failed"}
+
+      MapSet.member?(unpublished_ids, id) ->
+        %{id: id, outcome: "unpublished", status: "draft"}
+
+      true ->
+        case Map.get(existing, id) do
+          nil ->
+            %{id: id, outcome: "not_found"}
+
+          %Article{status: :draft} ->
+            %{id: id, outcome: "skipped", reason: "already_draft", status: "draft"}
+
+          %Article{status: status} ->
+            %{
+              id: id,
+              outcome: "skipped",
+              reason: "not_unpublishable_from_#{status}",
+              status: to_string(status)
+            }
+        end
+    end
+  end
+
+  @doc """
   Lists draft articles for a tenant, ordered by inserted_at desc.
 
   Returns source_type and source_id for review queue visibility.

--- a/lib/loopctl_web/controllers/article_controller.ex
+++ b/lib/loopctl_web/controllers/article_controller.ex
@@ -207,7 +207,13 @@ defmodule LoopctlWeb.ArticleController do
 
   operation(:update,
     summary: "Update article",
-    description: "Updates article fields. Role: user+.",
+    description:
+      "**PATCH /api/v1/articles/:id** — updates an existing article in place. Send only " <>
+        "the fields to change; supported keys are `title`, `body`, `tags` (replaces the " <>
+        "whole array), `category`, `status`, `metadata`, and `project_id`. Partial updates " <>
+        "are supported (e.g. body-only to tidy a hub, or tags-only). `tenant_id` is never " <>
+        "accepted from the body. Returns the full updated article. A changed `body`/`tags` " <>
+        "re-triggers embedding/linking. Role: user+ (distinct from create, which is agent+).",
     parameters: [id: [in: :path, type: :string, description: "Article UUID"]],
     request_body:
       {"Update params", "application/json",

--- a/lib/loopctl_web/controllers/article_workflow_controller.ex
+++ b/lib/loopctl_web/controllers/article_workflow_controller.ex
@@ -24,7 +24,8 @@ defmodule LoopctlWeb.ArticleWorkflowController do
   plug LoopctlWeb.Plugs.RequireRole, [role: :orchestrator] when action in [:drafts, :publish]
 
   plug LoopctlWeb.Plugs.RequireRole,
-       [role: :user] when action in [:unpublish, :archive, :bulk_publish, :bulk_delete]
+       [role: :user]
+       when action in [:unpublish, :archive, :bulk_publish, :bulk_unpublish, :bulk_delete]
 
   tags(["Knowledge Wiki"])
 
@@ -203,6 +204,50 @@ defmodule LoopctlWeb.ArticleWorkflowController do
     }
   )
 
+  operation(:bulk_unpublish,
+    summary: "Bulk unpublish articles",
+    description:
+      "Unpublishes (published → draft) articles **partial-success** style — the " <>
+        "mirror of bulk-publish, for cleanup passes. Every currently-published id is " <>
+        "moved back to draft; each other id gets a per-id `outcome`: `unpublished`; " <>
+        "`skipped` (with `reason` `already_draft` — idempotent — or " <>
+        "`not_unpublishable_from_archived`/`not_unpublishable_from_superseded`); " <>
+        "`not_found`; or `errored` (`reason` `unpublish_failed`). **A 200 does NOT " <>
+        "mean everything unpublished** — inspect `meta.counts`. Duplicate ids " <>
+        "de-duplicated; auto-chunked server-side (each chunk its own transaction, " <>
+        "failing chunk retried row-by-row); bounded to 5000 ids (400 above). " <>
+        "`meta.count` = number actually unpublished; `meta.counts` has " <>
+        "requested/unpublished/skipped/not_found/errored; `meta.results` is the per-id " <>
+        "breakdown in request order. `data` is the body-less summaries of the affected " <>
+        "articles. Role: user+.",
+    request_body:
+      {"Bulk unpublish params", "application/json",
+       %OpenApiSpex.Schema{
+         type: :object,
+         required: [:article_ids],
+         properties: %{
+           article_ids: %OpenApiSpex.Schema{
+             type: :array,
+             items: %OpenApiSpex.Schema{type: :string, format: :uuid}
+           }
+         }
+       }},
+    responses: %{
+      200 =>
+        {"Bulk unpublish result (partial success; see meta.results / meta.counts)",
+         "application/json",
+         %OpenApiSpex.Schema{
+           type: :object,
+           properties: %{
+             data: %OpenApiSpex.Schema{type: :array},
+             meta: %OpenApiSpex.Schema{type: :object}
+           }
+         }},
+      400 => {"Bad request (empty article_ids)", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
   # --- Actions ---
 
   @doc "POST /api/v1/articles/:id/publish"
@@ -251,6 +296,27 @@ defmodule LoopctlWeb.ArticleWorkflowController do
           counts: result.counts,
           # Per-id breakdown so a partial run is actionable (published / skipped /
           # not_found / errored), in request order.
+          results: result.results
+        }
+      })
+    end
+  end
+
+  @doc "POST /api/v1/knowledge/bulk-unpublish"
+  def bulk_unpublish(conn, params) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+    audit_opts = AuditContext.from_conn(conn)
+    article_ids = params["article_ids"] || []
+
+    with {:ok, result} <- Knowledge.bulk_unpublish(tenant_id, article_ids, audit_opts) do
+      json(conn, %{
+        # Body-less summaries: the affected set as confirmation; the actionable
+        # per-id detail is in meta.results.
+        data: Enum.map(result.unpublished, &ArticleJSON.article_summary/1),
+        meta: %{
+          # `count` = number actually unpublished (partial-success: inspect counts).
+          count: result.counts.unpublished,
+          counts: result.counts,
           results: result.results
         }
       })

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -290,6 +290,7 @@ defmodule LoopctlWeb.Router do
 
     # Knowledge bulk-publish, bulk-delete, and drafts queue
     post "/knowledge/bulk-publish", ArticleWorkflowController, :bulk_publish
+    post "/knowledge/bulk-unpublish", ArticleWorkflowController, :bulk_unpublish
     post "/knowledge/bulk-delete", ArticleWorkflowController, :bulk_delete
     get "/knowledge/drafts", ArticleWorkflowController, :drafts
 

--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to `loopctl-mcp-server` are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 2.16.0 — 2026-06-23 (bulk unpublish)
+
+### Added
+
+- **`knowledge_bulk_unpublish`** — revert published articles to draft in bulk,
+  partial-success style (the mirror of `knowledge_bulk_publish`). REQUIRES
+  `LOOPCTL_USER_KEY`. Per-id outcomes (`unpublished`/`skipped`/`not_found`/
+  `errored`), de-duplicated, auto-chunked, ≤5000/call; surfaces a warning when the
+  run is partial. Articles are not deleted (re-publish to restore; use
+  `knowledge_bulk_delete` to archive). Completes #148 M3. (#148 A6/M3)
+
 ## 2.15.0 — 2026-06-23 (AND-tag filtering + count/facets)
 
 ### Added

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -2,7 +2,7 @@
 
 MCP (Model Context Protocol) server for [loopctl](https://loopctl.com) -- structural trust for AI development loops.
 
-Wraps the loopctl REST API into 59 typed MCP tools so AI coding agents (Claude Code, etc.) can interact with loopctl without writing curl commands.
+Wraps the loopctl REST API into 60 typed MCP tools so AI coding agents (Claude Code, etc.) can interact with loopctl without writing curl commands.
 
 ## Installation
 
@@ -66,7 +66,7 @@ Or if installed locally:
 
 Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_KEY`.
 
-## Tools (59)
+## Tools (60)
 
 ### Project Tools
 
@@ -162,6 +162,7 @@ Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_K
 | `knowledge_publish` | **Requires `LOOPCTL_ORCH_KEY` (orchestrator role).** Publish an existing draft article, making it visible to all agents. (Note: `knowledge_create` publishes on create by default with no orchestrator key needed — this tool is for publishing a draft staged earlier.) Required: `article_id`. |
 | `knowledge_bulk_publish` | **Requires `LOOPCTL_USER_KEY`.** Publish drafts, partial-success style: every valid draft publishes; others are reported per-id as `skipped` (already published — idempotent — or archived/superseded), `not_found`, or `errored`. No 100-id cap (auto-chunked); duplicates ignored; safe to retry. `meta.count` = published; `meta.counts`/`meta.results` give the breakdown. Required: `article_ids` (array). |
 | `knowledge_unpublish` | **Requires `LOOPCTL_USER_KEY`.** Revert a published article back to draft (hidden from search/context, not deleted). Required: `article_id`. |
+| `knowledge_bulk_unpublish` | **Requires `LOOPCTL_USER_KEY`.** Revert published articles to draft in bulk, partial-success style (mirror of `knowledge_bulk_publish`): per-id `unpublished`/`skipped` (already draft, or archived/superseded)/`not_found`/`errored`. No 100-id cap (auto-chunked, ≤5000); duplicates ignored; safe to retry. Not deleted (re-publish to restore; `knowledge_bulk_delete` to archive). `meta.count`/`meta.counts`/`meta.results` give the breakdown. Required: `article_ids` (array). |
 | `knowledge_archive` | **Requires `LOOPCTL_USER_KEY`.** Soft-delete an article (draft or published). Row retained for audit; hidden from all reads. Required: `article_id`. |
 | `knowledge_delete` | **Requires `LOOPCTL_USER_KEY`.** Alias for `knowledge_archive` — DELETE verb on the REST API archives under the hood. Required: `article_id`. |
 | `knowledge_bulk_delete` | **Requires `LOOPCTL_USER_KEY`.** Bulk soft-delete (archive), partial-success. Provide exactly one selector: `article_ids` (list), `source_type`+`source_id` (every active article from a source — dedup cleanup), or `tag`+`confirm:true` (every active article with the tag — high blast radius). Per-id outcomes (archived/skipped/not_found/errored) in `meta.results`; `meta.count`=archived; idempotent (already-archived skipped); no 100-cap (auto-chunked, ≤5000). |

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -809,6 +809,31 @@ async function knowledgeBulkPublish({ article_ids }) {
   return toContent(result);
 }
 
+async function knowledgeBulkUnpublish({ article_ids }) {
+  const result = await apiCall(
+    "POST",
+    "/api/v1/knowledge/bulk-unpublish",
+    { article_ids },
+    process.env.LOOPCTL_USER_KEY
+  );
+
+  // Partial success returns 200 even when nothing unpublished. Surface a warning
+  // so the agent doesn't treat not_found/errored ids as success.
+  const counts = result?.meta?.counts;
+  if (counts && (counts.not_found > 0 || counts.errored > 0)) {
+    const warning =
+      `WARNING: bulk-unpublish was partial — unpublished ${counts.unpublished}, ` +
+      `skipped ${counts.skipped}, not_found ${counts.not_found}, errored ${counts.errored} ` +
+      `(of ${counts.requested} requested). Inspect meta.results for per-id outcomes; ` +
+      `not_found/errored ids were NOT unpublished.`;
+    return {
+      content: [{ type: "text", text: warning }, ...toContent(result).content],
+    };
+  }
+
+  return toContent(result);
+}
+
 async function knowledgeUnpublish({ article_id }) {
   const result = await apiCall(
     "POST",
@@ -2346,6 +2371,31 @@ const TOOLS = [
     },
   },
   {
+    name: "knowledge_bulk_unpublish",
+    description:
+      "Unpublish (published → draft) articles in bulk, partial-success style — the mirror " +
+      "of knowledge_bulk_publish, for cleanup passes. REQUIRES LOOPCTL_USER_KEY (user role). " +
+      "Every currently-published id is reverted to draft; each other id gets a per-id outcome: " +
+      "unpublished, skipped (already draft — idempotent — or archived/superseded), not_found, " +
+      "or errored. Duplicate ids de-duplicated; no 100-id cap (auto-chunked server-side, " +
+      "bounded to 5000/call). meta.count = number actually unpublished; meta.counts has the " +
+      "full breakdown; meta.results is the per-id list in request order. Safe to retry — " +
+      "already-draft ids are skipped, not errored. Articles are NOT deleted (re-publish with " +
+      "knowledge_bulk_publish); to archive/soft-delete use knowledge_bulk_delete.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        article_ids: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Article UUIDs to unpublish. Any length (auto-chunked); duplicates ignored.",
+        },
+      },
+      required: ["article_ids"],
+    },
+  },
+  {
     name: "knowledge_unpublish",
     description:
       "Revert a published article back to draft state. The article stops being visible " +
@@ -3033,6 +3083,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     case "knowledge_bulk_publish":
       return await knowledgeBulkPublish(args);
+
+    case "knowledge_bulk_unpublish":
+      return await knowledgeBulkUnpublish(args);
 
     case "knowledge_unpublish":
       return await knowledgeUnpublish(args);

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "description": "MCP server for loopctl — structural trust for AI development loops",
   "type": "module",
   "main": "index.js",

--- a/test/loopctl_web/controllers/article_workflow_controller_test.exs
+++ b/test/loopctl_web/controllers/article_workflow_controller_test.exs
@@ -404,6 +404,103 @@ defmodule LoopctlWeb.ArticleWorkflowControllerTest do
     end
   end
 
+  describe "POST /api/v1/knowledge/bulk-unpublish (#148 M3)" do
+    test "unpublishes published articles and reports per-id outcomes for the rest", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      published = fixture(:article, %{tenant_id: tenant.id, status: :published})
+      already_draft = fixture(:article, %{tenant_id: tenant.id, status: :draft})
+      archived = fixture(:article, %{tenant_id: tenant.id, status: :archived})
+      missing = Ecto.UUID.generate()
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/bulk-unpublish", %{
+          "article_ids" => [published.id, already_draft.id, archived.id, missing]
+        })
+
+      body = json_response(conn, 200)
+
+      assert body["meta"]["count"] == 1
+      assert body["meta"]["counts"]["unpublished"] == 1
+      assert body["meta"]["counts"]["skipped"] == 2
+      assert body["meta"]["counts"]["not_found"] == 1
+      assert body["meta"]["counts"]["requested"] == 4
+
+      outcomes = Map.new(body["meta"]["results"], &{&1["id"], &1["outcome"]})
+      assert outcomes[published.id] == "unpublished"
+      assert outcomes[already_draft.id] == "skipped"
+      assert outcomes[archived.id] == "skipped"
+      assert outcomes[missing] == "not_found"
+
+      # The published article is now a draft; the rest are untouched.
+      assert AdminRepo.get!(Article, published.id).status == :draft
+      assert AdminRepo.get!(Article, already_draft.id).status == :draft
+      assert AdminRepo.get!(Article, archived.id).status == :archived
+
+      # data carries body-less summaries of the affected set.
+      [summary] = body["data"]
+      assert summary["id"] == published.id
+      refute Map.has_key?(summary, "body")
+
+      # Audit event recorded.
+      audit_count =
+        AuditLog
+        |> where([a], a.tenant_id == ^tenant.id and a.action == "article.unpublished")
+        |> AdminRepo.aggregate(:count, :id)
+
+      assert audit_count == 1
+    end
+
+    test "already-draft ids are an idempotent no-op (skipped)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      draft = fixture(:article, %{tenant_id: tenant.id, status: :draft})
+
+      body =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/bulk-unpublish", %{"article_ids" => [draft.id]})
+        |> json_response(200)
+
+      assert body["meta"]["count"] == 0
+      assert body["meta"]["counts"]["skipped"] == 1
+      [result] = body["meta"]["results"]
+      assert result["outcome"] == "skipped"
+      assert result["reason"] == "already_draft"
+    end
+
+    test "requires user role (agent forbidden)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {agent_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      published = fixture(:article, %{tenant_id: tenant.id, status: :published})
+
+      conn =
+        conn
+        |> auth_conn(agent_key)
+        |> post(~p"/api/v1/knowledge/bulk-unpublish", %{"article_ids" => [published.id]})
+
+      assert json_response(conn, 403)
+      # Unchanged.
+      assert AdminRepo.get!(Article, published.id).status == :published
+    end
+
+    test "empty article_ids returns 400", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/bulk-unpublish", %{"article_ids" => []})
+
+      assert json_response(conn, 400)
+    end
+  end
+
   describe "POST /api/v1/knowledge/bulk-delete" do
     test "archives valid ids and reports per-id outcomes for the rest", %{conn: conn} do
       tenant = fixture(:tenant)


### PR DESCRIPTION
Add #148 M3 bulk-unpublish + document update endpoint (A5); confirm A6

Third and final PR for #148.

- **M3 bulk-unpublish (new).** `POST /api/v1/knowledge/bulk-unpublish` (role :user) +
  `Knowledge.bulk_unpublish/3` + MCP `knowledge_bulk_unpublish`. The mirror of
  bulk-publish for cleanup passes: published → draft, **partial-success** with per-id
  outcomes (`unpublished`/`skipped`/`not_found`/`errored`), de-duplicated, auto-chunked
  (each chunk its own transaction, failing chunk retried row-by-row), bounded to 5000/call,
  records `article.unpublished` audit events. Reuses the existing `transition_in_chunks`
  machinery (no re-embedding — the body is unchanged). `data` returns body-less summaries;
  `meta.results`/`meta.counts` give the actionable breakdown. MCP 2.15.0 → 2.16.0 (tool 59→60).

- **A5 update endpoint documented.** Filled in the sparse `PATCH /articles/:id` OpenAPI
  description: which fields are updatable (`title`/`body`/`tags`/`category`/`status`/
  `metadata`/`project_id`), partial updates supported (body-only / tags-only), `tenant_id`
  never accepted, returns the updated article, role :user (vs create's agent+).

- **A6 confirmed.** Bulk archive-by-ids with per-id partial success already shipped
  (`POST /knowledge/bulk-delete`, #136) and 429s carry `Retry-After` (rate_limiter.ex) —
  no code change; documented as the archive path (bulk-unpublish reverts to draft, bulk-delete
  archives/soft-deletes).

Tests: bulk-unpublish partial success (unpublished/skipped/not_found), already-draft
idempotent skip, user-role gate (agent → 403), empty ids → 400, body-less summary data,
audit event recorded.

Refs #148
