### PR TITLE
#148c review fix: body-less bulk-unpublish load + tenant-isolation test

### DIFF
--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -1743,7 +1743,9 @@ defmodule Loopctl.Knowledge do
   end
 
   defp do_bulk_unpublish(tenant_id, article_ids, opts) do
-    existing = load_existing_by_ids(tenant_id, article_ids)
+    # Body-less load: bulk-unpublish renders summaries and only flips status, so
+    # it never needs the article bodies (bounds memory for a 5000-id batch).
+    existing = load_existing_by_ids(tenant_id, article_ids, false)
 
     published =
       for id <- article_ids,
@@ -2265,13 +2267,22 @@ defmodule Loopctl.Knowledge do
   # Load the requested articles once, keyed by id. Malformed (non-UUID) ids are
   # kept out of the `id in ^ids` query (which would raise on cast) so they
   # resolve to a clean "not_found" via the absent map entry.
-  defp load_existing_by_ids(tenant_id, article_ids) do
+  # `include_body: false` projects every field except the (potentially large)
+  # `body`, so a bulk op that never echoes the body (e.g. bulk-unpublish, which
+  # renders body-less summaries) doesn't pull up to 5000 full bodies into memory
+  # just to flip a status. The status transition and audit only need id/status.
+  defp load_existing_by_ids(tenant_id, article_ids, include_body \\ true) do
     queryable_ids = Enum.filter(article_ids, &valid_uuid?/1)
 
-    from(a in Article,
-      where: a.tenant_id == ^tenant_id,
-      where: a.id in ^queryable_ids
-    )
+    base =
+      from(a in Article,
+        where: a.tenant_id == ^tenant_id,
+        where: a.id in ^queryable_ids
+      )
+
+    query = if include_body, do: base, else: from(a in base, select: struct(a, ^@summary_fields))
+
+    query
     |> AdminRepo.all()
     |> Map.new(&{&1.id, &1})
   end

--- a/test/loopctl_web/controllers/article_workflow_controller_test.exs
+++ b/test/loopctl_web/controllers/article_workflow_controller_test.exs
@@ -499,6 +499,24 @@ defmodule LoopctlWeb.ArticleWorkflowControllerTest do
 
       assert json_response(conn, 400)
     end
+
+    test "tenant isolation: cannot unpublish another tenant's article", %{conn: conn} do
+      tenant_a = fixture(:tenant)
+      {key_a, _} = fixture(:api_key, %{tenant_id: tenant_a.id, role: :user})
+      tenant_b = fixture(:tenant)
+      b_article = fixture(:article, %{tenant_id: tenant_b.id, status: :published})
+
+      body =
+        conn
+        |> auth_conn(key_a)
+        |> post(~p"/api/v1/knowledge/bulk-unpublish", %{"article_ids" => [b_article.id]})
+        |> json_response(200)
+
+      # B's id is invisible to tenant A → resolves to not_found, stays published.
+      assert body["meta"]["counts"]["not_found"] == 1
+      assert body["meta"]["counts"]["unpublished"] == 0
+      assert AdminRepo.get!(Article, b_article.id).status == :published
+    end
   end
 
   describe "POST /api/v1/knowledge/bulk-delete" do


### PR DESCRIPTION
Follow-up to #157 (merged) applying the security review's actionable finding.

- **bulk-unpublish loads articles body-less** (`load_existing_by_ids` gains an `include_body` flag, default true; bulk-unpublish passes false). It renders body-less summaries and only flips status, so it no longer pulls up to 5000 full bodies into memory. bulk_publish/bulk_delete unchanged (default true).
- **Tenant-isolation test** for bulk-unpublish (tenant A cannot unpublish tenant B's article → not_found, stays published).

The security + engineer reviews verified auth, tenant isolation, reversibility, idempotency, and the partial-success machinery clean; this addresses the one actionable MEDIUM (memory load) for the new endpoint. Filed #158 for the pre-existing shared concern (bulk_publish/bulk_delete still load+return full bodies — changing their merged response contract is out of scope here).

Refs #148