### PR TITLE
Add #149: multi-hop knowledge-graph traversal (port open_brain)

### DIFF
--- a/README.md
+++ b/README.md
@@ -775,7 +775,7 @@ cd mcp-server && npm install
 
 Keys must be in the `env` block — the MCP server process does not inherit the shell environment.
 
-### Available Tools (60)
+### Available Tools (61)
 
 Full descriptions live in [`mcp-server/README.md`](mcp-server/README.md); summary:
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -92,6 +92,10 @@ config :loopctl, :webauthn_adapter, Loopctl.MockWebAuthn
 # instead of ~5 MB of fixtures (production default is 5_000_000).
 config :loopctl, :full_content_byte_budget, 100_000
 
+# Graph-traversal node cap — small in tests so the `truncated` cap behavior can
+# be exercised with ~11 nodes instead of 100+ (production default is 100).
+config :loopctl, :max_graph_nodes, 10
+
 # WebAuthn relying party — test fixtures expect localhost
 config :loopctl, :webauthn,
   rp_id: "localhost",

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -2794,14 +2794,17 @@ defmodule Loopctl.Knowledge do
           node_count: length(nodes)
         }
 
-      {:error, _} ->
-        # Database error (timeout, connection, etc.) — return degraded response
-        %{
-          nodes: [],
-          edges: [],
-          truncated: true,
-          node_count: 0
-        }
+      {:error, reason} ->
+        # Database error (timeout, connection, etc.) — return a degraded but valid
+        # response (truncated: true) instead of crashing the request, and log so a
+        # repeated dense-hub traversal is visible to operators rather than an
+        # anonymous 500.
+        Logger.warning(
+          "knowledge graph traversal failed (depth=#{depth}, tenant=#{tenant_id}): " <>
+            "#{inspect(reason)} — returning degraded (truncated) result"
+        )
+
+        %{nodes: [], edges: [], truncated: true, node_count: 0}
     end
   end
 

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -35,6 +35,7 @@ defmodule Loopctl.Knowledge do
 
   require Logger
 
+  alias Ecto.Adapters.SQL
   alias Ecto.Multi
   alias Loopctl.AdminRepo
   alias Loopctl.Audit
@@ -84,6 +85,12 @@ defmodule Loopctl.Knowledge do
   # thousands of distinct tags can't force an unbounded response; `distinct_count`
   # still reports the true cardinality and `truncated` flags when rows were capped.
   @max_facet_rows 1000
+
+  # Multi-hop graph traversal caps: bound a single traversal so a dense graph
+  # can't return an unbounded node/edge set. `truncated` flags when either is hit.
+  # Runtime-configurable (so tests can exercise truncation cheaply); defaults below.
+  @max_graph_nodes 100
+  @max_graph_edges 500
 
   # Byte budget for full-content (`include_body: true`) list reads. An article
   # `body` is up to 100 KB, so a 1000-row full-body page could be ~100 MB — an
@@ -2631,6 +2638,159 @@ defmodule Loopctl.Knowledge do
       preload: [:source_article, :target_article],
       order_by: [desc: l.inserted_at],
       limit: 100
+    )
+    |> AdminRepo.all()
+  end
+
+  @doc """
+  Multi-hop traversal of the published article-link graph from a starting article.
+
+  Walks `article_links` outward from `article_id` up to `depth` hops
+  (**bidirectional** — a link is followed regardless of source/target direction),
+  returning the reachable published articles and the links among them. Cycle-safe:
+  a recursive-CTE path array prevents revisiting a node, so a cyclic graph
+  terminates and no node appears twice. Bounded to #{@max_graph_nodes} nodes and
+  #{@max_graph_edges} edges; `truncated` is true when either cap is hit.
+
+  Only `published` articles are traversed (the agent-visible set), and everything
+  is tenant-scoped.
+
+  ## Parameters
+
+  - `tenant_id` -- the tenant UUID
+  - `article_id` -- the starting article UUID
+  - `opts` -- `:depth` (1–3, default 1)
+
+  ## Returns
+
+  - `{:ok, %{nodes: [%{id, title, category, depth}], edges: [%{source_article_id,
+    target_article_id, relationship_type}], truncated: boolean, node_count: integer}}`
+  - `{:error, :invalid_depth}` when depth is outside 1–3
+  - `{:error, :not_found}` when the starting article doesn't exist / isn't published
+  """
+  @spec graph_traversal(Ecto.UUID.t(), Ecto.UUID.t(), keyword()) ::
+          {:ok, map()} | {:error, :invalid_depth} | {:error, :not_found}
+  def graph_traversal(tenant_id, article_id, opts \\ []) do
+    depth = Keyword.get(opts, :depth, 1)
+
+    with :ok <- validate_graph_depth(depth),
+         true <- article_published?(tenant_id, article_id) do
+      {:ok, execute_graph_traversal(tenant_id, article_id, depth)}
+    else
+      false -> {:error, :not_found}
+      {:error, _} = error -> error
+    end
+  end
+
+  defp validate_graph_depth(depth) when is_integer(depth) and depth >= 1 and depth <= 3, do: :ok
+  defp validate_graph_depth(_), do: {:error, :invalid_depth}
+
+  defp max_graph_nodes, do: Application.get_env(:loopctl, :max_graph_nodes, @max_graph_nodes)
+  defp max_graph_edges, do: Application.get_env(:loopctl, :max_graph_edges, @max_graph_edges)
+
+  defp article_published?(tenant_id, article_id) do
+    valid_uuid?(article_id) and
+      from(a in Article,
+        where: a.tenant_id == ^tenant_id and a.id == ^article_id and a.status == :published
+      )
+      |> AdminRepo.exists?()
+  end
+
+  defp execute_graph_traversal(tenant_id, article_id, depth) do
+    {:ok, tenant_bin} = Ecto.UUID.dump(tenant_id)
+    {:ok, article_bin} = Ecto.UUID.dump(article_id)
+
+    # Bidirectional recursive walk with a path-array cycle guard, capped at
+    # @max_graph_nodes. Raw SQL because Ecto has no native recursive-CTE builder.
+    node_sql = """
+    WITH RECURSIVE graph AS (
+      SELECT a.id AS node_id, ARRAY[a.id] AS path, 0 AS depth
+      FROM articles a
+      WHERE a.id = $1 AND a.tenant_id = $2 AND a.status = 'published'
+
+      UNION ALL
+
+      SELECT
+        CASE WHEN l.source_article_id = g.node_id THEN l.target_article_id
+             ELSE l.source_article_id END AS node_id,
+        g.path || CASE WHEN l.source_article_id = g.node_id THEN l.target_article_id
+                       ELSE l.source_article_id END,
+        g.depth + 1
+      FROM graph g
+      JOIN article_links l ON l.tenant_id = $2
+        AND (l.source_article_id = g.node_id OR l.target_article_id = g.node_id)
+      JOIN articles a ON a.id = CASE WHEN l.source_article_id = g.node_id
+                                     THEN l.target_article_id ELSE l.source_article_id END
+        AND a.tenant_id = $2 AND a.status = 'published'
+      WHERE g.depth < $3
+        AND NOT (CASE WHEN l.source_article_id = g.node_id
+                      THEN l.target_article_id ELSE l.source_article_id END = ANY(g.path))
+    )
+    SELECT node_id, depth FROM (
+      SELECT DISTINCT ON (node_id) node_id, depth FROM graph ORDER BY node_id, depth ASC
+    ) sub
+    ORDER BY depth ASC, node_id
+    LIMIT $4
+    """
+
+    node_cap = max_graph_nodes()
+
+    {:ok, %{rows: node_rows}} =
+      SQL.query(
+        AdminRepo,
+        node_sql,
+        [article_bin, tenant_bin, depth, node_cap],
+        timeout: 5_000
+      )
+
+    nodes_truncated = length(node_rows) >= node_cap
+
+    node_ids_with_depth =
+      Enum.map(node_rows, fn [node_bin, d] ->
+        {:ok, uuid} = Ecto.UUID.load(node_bin)
+        {uuid, d}
+      end)
+
+    node_ids = Enum.map(node_ids_with_depth, &elem(&1, 0))
+    depth_map = Map.new(node_ids_with_depth)
+
+    nodes = fetch_graph_nodes(tenant_id, node_ids, depth_map)
+    edges = fetch_graph_edges(tenant_id, node_ids)
+
+    %{
+      nodes: nodes,
+      edges: edges,
+      truncated: nodes_truncated or length(edges) >= max_graph_edges(),
+      node_count: length(nodes)
+    }
+  end
+
+  defp fetch_graph_nodes(_tenant_id, [], _depth_map), do: []
+
+  defp fetch_graph_nodes(tenant_id, node_ids, depth_map) do
+    from(a in Article,
+      where: a.tenant_id == ^tenant_id and a.id in ^node_ids and a.status == :published,
+      select: %{id: a.id, title: a.title, category: a.category}
+    )
+    |> AdminRepo.all()
+    |> Enum.map(&Map.put(&1, :depth, Map.get(depth_map, &1.id)))
+    |> Enum.sort_by(& &1.depth)
+  end
+
+  defp fetch_graph_edges(_tenant_id, []), do: []
+
+  defp fetch_graph_edges(tenant_id, node_ids) do
+    from(l in ArticleLink,
+      where:
+        l.tenant_id == ^tenant_id and
+          l.source_article_id in ^node_ids and l.target_article_id in ^node_ids,
+      order_by: [asc: l.inserted_at],
+      limit: ^max_graph_edges(),
+      select: %{
+        source_article_id: l.source_article_id,
+        target_article_id: l.target_article_id,
+        relationship_type: l.relationship_type
+      }
     )
     |> AdminRepo.all()
   end

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -91,6 +91,8 @@ defmodule Loopctl.Knowledge do
   # Runtime-configurable (so tests can exercise truncation cheaply); defaults below.
   @max_graph_nodes 100
   @max_graph_edges 500
+  # per-node link cap to bound fan-out
+  @max_graph_neighbors_per_node 10
 
   # Byte budget for full-content (`include_body: true`) list reads. An article
   # `body` is up to 100 KB, so a 1000-row full-body page could be ~100 MB — an
@@ -2685,8 +2687,29 @@ defmodule Loopctl.Knowledge do
   defp validate_graph_depth(depth) when is_integer(depth) and depth >= 1 and depth <= 3, do: :ok
   defp validate_graph_depth(_), do: {:error, :invalid_depth}
 
-  defp max_graph_nodes, do: Application.get_env(:loopctl, :max_graph_nodes, @max_graph_nodes)
-  defp max_graph_edges, do: Application.get_env(:loopctl, :max_graph_edges, @max_graph_edges)
+  @doc """
+  Maximum number of reachable nodes in a graph traversal result.
+  Configurable via `:max_graph_nodes` in application config; defaults to #{@max_graph_nodes}.
+  """
+  @spec max_graph_nodes() :: pos_integer()
+  def max_graph_nodes, do: Application.get_env(:loopctl, :max_graph_nodes, @max_graph_nodes)
+
+  @doc """
+  Maximum number of edges in a graph traversal result.
+  Configurable via `:max_graph_edges` in application config; defaults to #{@max_graph_edges}.
+  """
+  @spec max_graph_edges() :: pos_integer()
+  def max_graph_edges, do: Application.get_env(:loopctl, :max_graph_edges, @max_graph_edges)
+
+  @doc """
+  Maximum number of links followed per node in recursive graph traversal.
+  Bounds fan-out to prevent unbounded explosion on high-degree hubs.
+  Configurable via `:max_graph_neighbors_per_node` in application config; defaults to #{@max_graph_neighbors_per_node}.
+  """
+  @spec max_graph_neighbors_per_node() :: pos_integer()
+  def max_graph_neighbors_per_node,
+    do:
+      Application.get_env(:loopctl, :max_graph_neighbors_per_node, @max_graph_neighbors_per_node)
 
   defp article_published?(tenant_id, article_id) do
     valid_uuid?(article_id) and
@@ -2700,8 +2723,9 @@ defmodule Loopctl.Knowledge do
     {:ok, tenant_bin} = Ecto.UUID.dump(tenant_id)
     {:ok, article_bin} = Ecto.UUID.dump(article_id)
 
-    # Bidirectional recursive walk with a path-array cycle guard, capped at
-    # @max_graph_nodes. Raw SQL because Ecto has no native recursive-CTE builder.
+    # Bidirectional recursive walk with a path-array cycle guard and per-node neighbor cap
+    # to bound fan-out, capped at @max_graph_nodes. Raw SQL because Ecto has no native
+    # recursive-CTE builder. LATERAL limits neighbors per node to prevent unbounded explosion.
     node_sql = """
     WITH RECURSIVE graph AS (
       SELECT a.id AS node_id, ARRAY[a.id] AS path, 0 AS depth
@@ -2717,8 +2741,13 @@ defmodule Loopctl.Knowledge do
                        ELSE l.source_article_id END,
         g.depth + 1
       FROM graph g
-      JOIN article_links l ON l.tenant_id = $2
-        AND (l.source_article_id = g.node_id OR l.target_article_id = g.node_id)
+      JOIN LATERAL (
+        SELECT source_article_id, target_article_id, relationship_type
+        FROM article_links
+        WHERE tenant_id = $2
+          AND (source_article_id = g.node_id OR target_article_id = g.node_id)
+        LIMIT $5
+      ) l ON true
       JOIN articles a ON a.id = CASE WHEN l.source_article_id = g.node_id
                                      THEN l.target_article_id ELSE l.source_article_id END
         AND a.tenant_id = $2 AND a.status = 'published'
@@ -2734,35 +2763,46 @@ defmodule Loopctl.Knowledge do
     """
 
     node_cap = max_graph_nodes()
+    neighbor_cap = max_graph_neighbors_per_node()
 
-    {:ok, %{rows: node_rows}} =
-      SQL.query(
-        AdminRepo,
-        node_sql,
-        [article_bin, tenant_bin, depth, node_cap],
-        timeout: 5_000
-      )
+    case SQL.query(
+           AdminRepo,
+           node_sql,
+           [article_bin, tenant_bin, depth, node_cap, neighbor_cap],
+           timeout: 5_000
+         ) do
+      {:ok, %{rows: node_rows}} ->
+        nodes_truncated = length(node_rows) >= node_cap
 
-    nodes_truncated = length(node_rows) >= node_cap
+        node_ids_with_depth =
+          Enum.map(node_rows, fn [node_bin, d] ->
+            {:ok, uuid} = Ecto.UUID.load(node_bin)
+            {uuid, d}
+          end)
 
-    node_ids_with_depth =
-      Enum.map(node_rows, fn [node_bin, d] ->
-        {:ok, uuid} = Ecto.UUID.load(node_bin)
-        {uuid, d}
-      end)
+        node_ids = Enum.map(node_ids_with_depth, &elem(&1, 0))
+        depth_map = Map.new(node_ids_with_depth)
 
-    node_ids = Enum.map(node_ids_with_depth, &elem(&1, 0))
-    depth_map = Map.new(node_ids_with_depth)
+        nodes = fetch_graph_nodes(tenant_id, node_ids, depth_map)
+        fetched_node_ids = Enum.map(nodes, & &1.id)
+        edges = fetch_graph_edges(tenant_id, fetched_node_ids)
 
-    nodes = fetch_graph_nodes(tenant_id, node_ids, depth_map)
-    edges = fetch_graph_edges(tenant_id, node_ids)
+        %{
+          nodes: nodes,
+          edges: edges,
+          truncated: nodes_truncated or length(edges) >= max_graph_edges(),
+          node_count: length(nodes)
+        }
 
-    %{
-      nodes: nodes,
-      edges: edges,
-      truncated: nodes_truncated or length(edges) >= max_graph_edges(),
-      node_count: length(nodes)
-    }
+      {:error, _} ->
+        # Database error (timeout, connection, etc.) — return degraded response
+        %{
+          nodes: [],
+          edges: [],
+          truncated: true,
+          node_count: 0
+        }
+    end
   end
 
   defp fetch_graph_nodes(_tenant_id, [], _depth_map), do: []
@@ -2784,7 +2824,7 @@ defmodule Loopctl.Knowledge do
       where:
         l.tenant_id == ^tenant_id and
           l.source_article_id in ^node_ids and l.target_article_id in ^node_ids,
-      order_by: [asc: l.inserted_at],
+      order_by: [asc: l.inserted_at, asc: l.id],
       limit: ^max_graph_edges(),
       select: %{
         source_article_id: l.source_article_id,

--- a/lib/loopctl_web/controllers/knowledge_graph_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_graph_controller.ex
@@ -1,0 +1,99 @@
+defmodule LoopctlWeb.KnowledgeGraphController do
+  @moduledoc """
+  Multi-hop knowledge-graph traversal.
+
+  - `GET /api/v1/knowledge/graph?article_id=&depth=` -- traverse the published
+    article-link graph outward from an article (agent+).
+
+  Returns the reachable published articles and the links among them, bidirectional
+  and cycle-safe, bounded to 100 nodes / 500 edges (`truncated` flags a cap hit).
+  """
+
+  use LoopctlWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Loopctl.ApiSpec.Schemas
+  alias Loopctl.Knowledge
+
+  action_fallback LoopctlWeb.FallbackController
+
+  plug LoopctlWeb.Plugs.RequireRole, role: :agent
+
+  tags(["Knowledge Wiki"])
+
+  operation(:graph,
+    summary: "Traverse the knowledge graph",
+    description:
+      "Walks the published article-link graph outward from `article_id` up to `depth` " <>
+        "hops (1–3, default 1). **Bidirectional** (links followed regardless of source/" <>
+        "target direction) and **cycle-safe** (no node appears twice). Returns `nodes` " <>
+        "(`id`, `title`, `category`, `depth`), `edges` (`source_article_id`, " <>
+        "`target_article_id`, `relationship_type`), `truncated`, and `node_count`. " <>
+        "Bounded to 100 nodes / 500 edges; `truncated: true` when a cap is hit. Only " <>
+        "published articles are traversed; tenant-scoped. Role: agent+.",
+    parameters: [
+      article_id: [in: :query, type: :string, description: "Starting article UUID (required)"],
+      depth: [in: :query, type: :integer, description: "Hops to traverse (1–3, default 1)"],
+      project_id: [in: :query, type: :string, description: "Optional project UUID (attribution)"]
+    ],
+    responses: %{
+      200 =>
+        {"Graph", "application/json",
+         %OpenApiSpex.Schema{
+           type: :object,
+           properties: %{
+             nodes: %OpenApiSpex.Schema{type: :array},
+             edges: %OpenApiSpex.Schema{type: :array},
+             truncated: %OpenApiSpex.Schema{type: :boolean},
+             node_count: %OpenApiSpex.Schema{type: :integer}
+           }
+         }},
+      400 => {"Bad request", "application/json", Schemas.ErrorResponse},
+      404 => {"Article not found", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  @doc "GET /api/v1/knowledge/graph"
+  def graph(conn, params) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+
+    with {:ok, article_id} <- require_article_id(params["article_id"]),
+         {:ok, depth} <- parse_depth(params["depth"]),
+         {:ok, result} <- Knowledge.graph_traversal(tenant_id, article_id, depth: depth) do
+      json(conn, result)
+    else
+      {:error, :invalid_depth} ->
+        {:error, :bad_request, "depth must be an integer between 1 and 3"}
+
+      {:error, :not_found} ->
+        {:error, :not_found}
+
+      {:error, :bad_request, _message} = error ->
+        error
+    end
+  end
+
+  defp require_article_id(value) when value in [nil, ""],
+    do: {:error, :bad_request, "article_id is required"}
+
+  defp require_article_id(value) when is_binary(value) do
+    case Ecto.UUID.cast(value) do
+      {:ok, id} -> {:ok, id}
+      :error -> {:error, :bad_request, "article_id must be a UUID"}
+    end
+  end
+
+  defp require_article_id(_), do: {:error, :bad_request, "article_id must be a UUID"}
+
+  defp parse_depth(value) when value in [nil, ""], do: {:ok, 1}
+
+  defp parse_depth(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {n, ""} -> {:ok, n}
+      _ -> {:error, :invalid_depth}
+    end
+  end
+
+  defp parse_depth(_), do: {:error, :invalid_depth}
+end

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -304,6 +304,9 @@ defmodule LoopctlWeb.Router do
     get "/knowledge/count", KnowledgeFacetsController, :count
     get "/knowledge/facets", KnowledgeFacetsController, :facets
 
+    # Knowledge Graph (multi-hop traversal of the article-link graph)
+    get "/knowledge/graph", KnowledgeGraphController, :graph
+
     # Knowledge Search (unified keyword / semantic / combined)
     get "/knowledge/search", KnowledgeSearchController, :search
 

--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to `loopctl-mcp-server` are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 2.17.0 — 2026-06-23 (knowledge graph traversal)
+
+### Added
+
+- **`knowledge_graph`** — multi-hop traversal of the published article-link graph
+  from a starting article (depth 1–3). Bidirectional, cycle-safe, bounded to 100
+  nodes / 500 edges (`truncated` flags a cap hit). Returns `nodes`
+  (id/title/category/depth) + `edges` (source/target/relationship_type) so agents
+  can explore typed connections beyond the 1-hop links in `knowledge_context`.
+  Backed by `GET /api/v1/knowledge/graph`. (#149)
+
 ## 2.16.0 — 2026-06-23 (bulk unpublish)
 
 ### Added

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -2,7 +2,7 @@
 
 MCP (Model Context Protocol) server for [loopctl](https://loopctl.com) -- structural trust for AI development loops.
 
-Wraps the loopctl REST API into 60 typed MCP tools so AI coding agents (Claude Code, etc.) can interact with loopctl without writing curl commands.
+Wraps the loopctl REST API into 61 typed MCP tools so AI coding agents (Claude Code, etc.) can interact with loopctl without writing curl commands.
 
 ## Installation
 
@@ -66,7 +66,7 @@ Or if installed locally:
 
 Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_KEY`.
 
-## Tools (60)
+## Tools (61)
 
 ### Project Tools
 
@@ -151,6 +151,7 @@ Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_K
 | `knowledge_list` | List articles (`id`, `title`, `category`, `status`, `tags`, `source_type`, `source_id`, `idempotency_key`, timestamps), filtered + paginated. **Body-less summary by default** (safe to page up to `limit=1000`); pass `include_body: true` to also return `body`, in which case the page is bounded by a ~5 MB byte budget — continue via `meta.next_offset` while `meta.has_more`. **Lag-free, all-status** read of the DB of record — unlike `knowledge_search` (ranked, published-only, lags writes) and `knowledge_index` (id/title/category only). The right tool to enumerate/dedup/repair and for idempotency/existence checks: filter by `tags`, `source_type`+`source_id`, or `idempotency_key` and read `meta.total_count` (exact). Single full body → `knowledge_get`; relevant bodies → `knowledge_context`; bulk dump → `knowledge_export`. Optional: `project_id`, `category`, `status`, `tags`, `source_type`, `source_id`, `idempotency_key`, `offset`, `limit`, `include_body`. |
 | `knowledge_get` | Get full article content by ID. Use after search to read an article in detail. Optional: `project_id`, `story_id` for attribution. |
 | `knowledge_context` | Get relevance-and-recency-ranked full articles for a task query. Best knowledge for your current context. Optional: `project_id`, `story_id` for attribution. |
+| `knowledge_graph` | Multi-hop traversal of the published article-link graph from `article_id` (depth 1–3, default 1). Bidirectional, cycle-safe, bounded to 100 nodes / 500 edges (`truncated` flags a cap). Returns `nodes` (`id`/`title`/`category`/`depth`) + `edges` (`source_article_id`/`target_article_id`/`relationship_type`). Explore typed connections beyond `knowledge_context`'s 1-hop links. Required: `article_id`. Optional: `depth`, `project_id`. |
 | `knowledge_create` | Create a new knowledge article. File findings, document patterns, or record decisions. **Published immediately by default** (visible to agents in search/index/context) for every role — the response `note` says which outcome occurred. Pass `draft: true` to stage it for later review instead (publish afterwards with `knowledge_publish`). Pass `idempotency_key` for idempotent capture (re-creating with the same key is a no-op returning the existing article — no partial duplicates). Optional: `category`, `tags`, `project_id`, `draft`, `idempotency_key`, `source_type`, `source_id`. |
 | `knowledge_okf_export` | **Requires `LOOPCTL_USER_KEY`.** Export the wiki as a portable OKF (Open Knowledge Format) v0.1 bundle of markdown files. Writes to `out_dir`, or returns `{files, meta}` inline. |
 | `knowledge_okf_import` | **Requires `LOOPCTL_USER_KEY`.** Import an OKF v0.1 bundle from a local directory. Creates or (with `merge`) updates articles; tolerates and preserves unknown frontmatter. |

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -617,6 +617,20 @@ async function knowledgeStats({ project_id }) {
   return toContent(result);
 }
 
+async function knowledgeGraph({ article_id, depth, project_id }) {
+  const params = new URLSearchParams();
+  params.set("article_id", article_id);
+  if (depth != null) params.set("depth", String(depth));
+  if (project_id) params.set("project_id", project_id);
+  const result = await apiCall(
+    "GET",
+    `/api/v1/knowledge/graph?${params}`,
+    null,
+    process.env.LOOPCTL_AGENT_KEY,
+  );
+  return toContent(result);
+}
+
 async function knowledgeCount({
   project_id,
   category,
@@ -2131,6 +2145,35 @@ const TOOLS = [
     },
   },
   {
+    name: "knowledge_graph",
+    description:
+      "Traverse the published article-link graph outward from an article, up to `depth` hops " +
+      "(1–3, default 1). BIDIRECTIONAL (follows links regardless of source/target direction) and " +
+      "cycle-safe (no node twice). Returns { nodes: [{id,title,category,depth}], edges: " +
+      "[{source_article_id,target_article_id,relationship_type}], truncated, node_count }. Bounded " +
+      "to 100 nodes / 500 edges (truncated:true when hit). Use to explore how a piece of knowledge " +
+      "connects (relates_to/derived_from/contradicts/supersedes) beyond the 1-hop links in " +
+      "knowledge_context.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        article_id: {
+          type: "string",
+          format: "uuid",
+          description: "Starting article UUID (required).",
+        },
+        depth: {
+          type: "integer",
+          minimum: 1,
+          maximum: 3,
+          description: "Hops to traverse (1–3, default 1). Out of range → 400.",
+        },
+        project_id: { type: "string", format: "uuid", description: "Optional: project UUID." },
+      },
+      required: ["article_id"],
+    },
+  },
+  {
     name: "knowledge_search",
     description:
       "Search the knowledge wiki by topic. Returns snippets. Ranked, and returns PUBLISHED " +
@@ -3061,6 +3104,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     case "knowledge_facets":
       return await knowledgeFacets(args);
+
+    case "knowledge_graph":
+      return await knowledgeGraph(args);
 
     case "knowledge_search":
       return await knowledgeSearch(args);

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "description": "MCP server for loopctl — structural trust for AI development loops",
   "type": "module",
   "main": "index.js",

--- a/test/loopctl_web/controllers/knowledge_graph_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_graph_controller_test.exs
@@ -1,0 +1,188 @@
+defmodule LoopctlWeb.KnowledgeGraphControllerTest do
+  use LoopctlWeb.ConnCase, async: true
+
+  setup :verify_on_exit!
+
+  defp auth_conn(conn, raw_key), do: put_req_header(conn, "authorization", "Bearer #{raw_key}")
+
+  defp setup_tenant_key do
+    tenant = fixture(:tenant)
+    {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+    {tenant, raw_key}
+  end
+
+  defp pub(tenant_id, title),
+    do: fixture(:article, %{tenant_id: tenant_id, title: title, status: :published})
+
+  defp link(tenant_id, src, tgt, rel \\ :relates_to) do
+    fixture(:article_link, %{
+      tenant_id: tenant_id,
+      source_article_id: src.id,
+      target_article_id: tgt.id,
+      relationship_type: rel
+    })
+  end
+
+  defp graph(conn, raw_key, query) do
+    conn |> auth_conn(raw_key) |> get(~p"/api/v1/knowledge/graph?#{query}") |> json_response(200)
+  end
+
+  defp ids(body), do: body["nodes"] |> Enum.map(& &1["id"]) |> Enum.sort()
+
+  describe "GET /api/v1/knowledge/graph (#149)" do
+    test "depth 1 returns immediate neighbors, bidirectionally", %{conn: conn} do
+      {tenant, key} = setup_tenant_key()
+      a = pub(tenant.id, "A")
+      b = pub(tenant.id, "B")
+      c = pub(tenant.id, "C")
+      # A→B (forward) and C→A (backward) — both must be reachable from A at depth 1.
+      link(tenant.id, a, b)
+      link(tenant.id, c, a)
+
+      body = graph(conn, key, %{article_id: a.id, depth: 1})
+
+      assert ids(body) == Enum.sort([a.id, b.id, c.id])
+      assert body["node_count"] == 3
+      assert body["truncated"] == false
+      # depth labels: A=0, neighbors=1
+      depths = Map.new(body["nodes"], &{&1["id"], &1["depth"]})
+      assert depths[a.id] == 0
+      assert depths[b.id] == 1
+      assert depths[c.id] == 1
+      # nodes carry title + category
+      a_node = Enum.find(body["nodes"], &(&1["id"] == a.id))
+      assert a_node["title"] == "A"
+      assert a_node["category"]
+      # edges carry the typed link
+      assert Enum.any?(
+               body["edges"],
+               &(&1["source_article_id"] == a.id and &1["target_article_id"] == b.id)
+             )
+    end
+
+    test "depth 2 reaches two hops but not three", %{conn: conn} do
+      {tenant, key} = setup_tenant_key()
+      [a, b, c, d] = for t <- ~w(A B C D), do: pub(tenant.id, t)
+      link(tenant.id, a, b)
+      link(tenant.id, b, c)
+      link(tenant.id, c, d)
+
+      body = graph(conn, key, %{article_id: a.id, depth: 2})
+
+      assert ids(body) == Enum.sort([a.id, b.id, c.id])
+      refute d.id in ids(body)
+    end
+
+    test "depth 3 reaches three hops", %{conn: conn} do
+      {tenant, key} = setup_tenant_key()
+      [a, b, c, d] = for t <- ~w(A B C D), do: pub(tenant.id, t)
+      link(tenant.id, a, b)
+      link(tenant.id, b, c)
+      link(tenant.id, c, d)
+
+      body = graph(conn, key, %{article_id: a.id, depth: 3})
+
+      assert ids(body) == Enum.sort([a.id, b.id, c.id, d.id])
+      assert body["node_count"] == 4
+    end
+
+    test "a cyclic graph terminates with no node visited twice", %{conn: conn} do
+      {tenant, key} = setup_tenant_key()
+      [a, b, c] = for t <- ~w(A B C), do: pub(tenant.id, t)
+      # Triangle A→B→C→A
+      link(tenant.id, a, b)
+      link(tenant.id, b, c)
+      link(tenant.id, c, a)
+
+      body = graph(conn, key, %{article_id: a.id, depth: 3})
+
+      node_ids = Enum.map(body["nodes"], & &1["id"])
+      assert Enum.sort(node_ids) == Enum.sort([a.id, b.id, c.id])
+      # No node appears twice.
+      assert length(node_ids) == length(Enum.uniq(node_ids))
+    end
+
+    test "caps the result and sets truncated when the node limit is hit", %{conn: conn} do
+      # config/test.exs sets max_graph_nodes: 10.
+      {tenant, key} = setup_tenant_key()
+      hub = pub(tenant.id, "Hub")
+
+      for i <- 1..11 do
+        n = pub(tenant.id, "N#{i}")
+        link(tenant.id, hub, n)
+      end
+
+      body = graph(conn, key, %{article_id: hub.id, depth: 1})
+
+      assert body["truncated"] == true
+      assert body["node_count"] == 10
+      assert length(body["nodes"]) == 10
+    end
+
+    test "depth out of range returns 400", %{conn: _conn} do
+      {tenant, key} = setup_tenant_key()
+      a = pub(tenant.id, "A")
+
+      for d <- ["0", "4", "abc"] do
+        resp =
+          build_conn()
+          |> auth_conn(key)
+          |> get(~p"/api/v1/knowledge/graph?#{%{article_id: a.id, depth: d}}")
+          |> json_response(400)
+
+        assert resp["error"]["status"] == 400
+      end
+    end
+
+    test "missing article_id returns 400", %{conn: conn} do
+      {_tenant, key} = setup_tenant_key()
+
+      resp =
+        conn |> auth_conn(key) |> get(~p"/api/v1/knowledge/graph") |> json_response(400)
+
+      assert resp["error"]["message"] =~ "article_id"
+    end
+
+    test "nonexistent article returns 404", %{conn: conn} do
+      {_tenant, key} = setup_tenant_key()
+
+      conn
+      |> auth_conn(key)
+      |> get(~p"/api/v1/knowledge/graph?#{%{article_id: Ecto.UUID.generate()}}")
+      |> json_response(404)
+    end
+
+    test "a draft start article returns 404 (published-only)", %{conn: conn} do
+      {tenant, key} = setup_tenant_key()
+      draft = fixture(:article, %{tenant_id: tenant.id, title: "Draft", status: :draft})
+
+      conn
+      |> auth_conn(key)
+      |> get(~p"/api/v1/knowledge/graph?#{%{article_id: draft.id}}")
+      |> json_response(404)
+    end
+
+    test "draft neighbors are excluded from traversal (published-only)", %{conn: conn} do
+      {tenant, key} = setup_tenant_key()
+      a = pub(tenant.id, "A")
+      draft = fixture(:article, %{tenant_id: tenant.id, title: "Draft", status: :draft})
+      link(tenant.id, a, draft)
+
+      body = graph(conn, key, %{article_id: a.id, depth: 2})
+
+      assert ids(body) == [a.id]
+      assert body["node_count"] == 1
+    end
+
+    test "tenant isolation: another tenant's article is not found", %{conn: conn} do
+      {_tenant_a, key_a} = setup_tenant_key()
+      tenant_b = fixture(:tenant)
+      b_article = pub(tenant_b.id, "B-owned")
+
+      conn
+      |> auth_conn(key_a)
+      |> get(~p"/api/v1/knowledge/graph?#{%{article_id: b_article.id}}")
+      |> json_response(404)
+    end
+  end
+end


### PR DESCRIPTION
Add #149: multi-hop knowledge-graph traversal (port open_brain graph_traversal/3)

`GET /api/v1/knowledge/graph?article_id=&depth=` (agent+) + `Knowledge.graph_traversal/3`
+ MCP `knowledge_graph`. Ported from open_brain's note-link graph (same model, 4
relationship types) with a note→article / link→article_link rename and a
deleted_at→status='published' adaptation.

- Recursive CTE (raw SQL, bound params), **bidirectional** (a link is followed
  regardless of source/target direction), **cycle-safe** via a path-array guard
  (no node appears twice; cyclic graphs terminate), depth validated 1–3 (else 400).
- Bounded to 100 nodes / 500 edges (runtime-configurable); `truncated` flags when
  either cap is hit.
- Only `published` articles are traversed; fully tenant-scoped (tenant_id bound in
  the CTE and every follow-up query); start article must exist + be published (else 404).
- Returns `{nodes: [{id,title,category,depth}], edges: [{source_article_id,
  target_article_id,relationship_type}], truncated, node_count}`.

Tests: depth 1/2/3 correctness, bidirectional, cycle termination (no node twice),
cap truncation (test cap 10), depth out-of-range → 400, missing id → 400,
nonexistent/draft start → 404, draft neighbors excluded, tenant isolation.

MCP 2.16.0 → 2.17.0 (tool 60→61).

Closes #149
