### PR TITLE
Add #150: suggest_links — read-only typed-link candidates (port open_brain)

### DIFF
--- a/README.md
+++ b/README.md
@@ -775,7 +775,7 @@ cd mcp-server && npm install
 
 Keys must be in the `env` block — the MCP server process does not inherit the shell environment.
 
-### Available Tools (61)
+### Available Tools (62)
 
 Full descriptions live in [`mcp-server/README.md`](mcp-server/README.md); summary:
 

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -2644,6 +2644,99 @@ defmodule Loopctl.Knowledge do
     |> AdminRepo.all()
   end
 
+  @default_suggestion_limit 5
+
+  @doc """
+  Suggests **typed link candidates** for an article by embedding similarity —
+  **read-only**, creates nothing.
+
+  Returns published articles most similar to `article_id` (cosine over the
+  embedding) that are not already linked to it, so a caller can review them and
+  POST a *typed* link (`relates_to`/`derived_from`/`contradicts`/`supersedes`) —
+  unlike the auto-linker, which only ever creates ambient `relates_to`.
+
+  Excludes the article itself and **any already-linked article** (either
+  direction, any relationship type). Only embedded, `published` articles are
+  considered. Honors `:threshold` (cosine similarity floor, default from
+  `:suggestion_similarity_threshold` config or 0.5) and `:limit` (default
+  #{@default_suggestion_limit}), ordered most-similar first. Tenant-scoped.
+
+  ## Returns
+
+  - `{:ok, [%{id, title, category, similarity_score}]}` (highest similarity first)
+  - `{:ok, []}` when the article has no embedding yet
+  - `{:error, :not_found}` when the article doesn't exist / isn't published
+  - `{:error, :invalid_threshold}` when `:threshold` is outside 0.0–1.0
+  """
+  @spec suggest_links(Ecto.UUID.t(), Ecto.UUID.t(), keyword()) ::
+          {:ok, [map()]} | {:error, :not_found} | {:error, :invalid_threshold}
+  def suggest_links(tenant_id, article_id, opts \\ []) do
+    threshold = Keyword.get(opts, :threshold) || default_suggestion_threshold()
+
+    limit =
+      opts
+      |> Keyword.get(:limit, @default_suggestion_limit)
+      |> max(1)
+      |> min(@max_relevance_page_size)
+
+    with :ok <- validate_threshold(threshold) do
+      case fetch_article_embedding(tenant_id, article_id) do
+        nil ->
+          {:error, :not_found}
+
+        %{embedding: nil} ->
+          {:ok, []}
+
+        %{embedding: embedding} ->
+          {:ok, suggestion_candidates(tenant_id, article_id, embedding, threshold, limit)}
+      end
+    end
+  end
+
+  defp default_suggestion_threshold,
+    do: Application.get_env(:loopctl, :suggestion_similarity_threshold, 0.5)
+
+  defp validate_threshold(t) when is_number(t) and t >= 0.0 and t <= 1.0, do: :ok
+  defp validate_threshold(_), do: {:error, :invalid_threshold}
+
+  # Lightweight fetch — only the embedding (skips body/metadata). A non-UUID or a
+  # missing/non-published article yields nil → {:error, :not_found}.
+  defp fetch_article_embedding(tenant_id, article_id) do
+    if valid_uuid?(article_id) do
+      from(a in Article,
+        where: a.tenant_id == ^tenant_id and a.id == ^article_id and a.status == :published,
+        select: %{embedding: a.embedding}
+      )
+      |> AdminRepo.one()
+    end
+  end
+
+  defp suggestion_candidates(tenant_id, article_id, embedding, threshold, limit) do
+    from(a in Article,
+      where: a.tenant_id == ^tenant_id and a.status == :published,
+      where: not is_nil(a.embedding),
+      where: a.id != ^article_id,
+      # Exclude any article already linked to the target (either direction, any type).
+      left_join: l in ArticleLink,
+      on:
+        l.tenant_id == ^tenant_id and
+          ((l.source_article_id == ^article_id and l.target_article_id == a.id) or
+             (l.target_article_id == ^article_id and l.source_article_id == a.id)),
+      where: is_nil(l.id),
+      where:
+        fragment("GREATEST(0, 1 - (? <=> ?::vector)) > ?", a.embedding, ^embedding, ^threshold),
+      order_by: [asc: fragment("? <=> ?::vector", a.embedding, ^embedding)],
+      limit: ^limit,
+      select: %{
+        id: a.id,
+        title: a.title,
+        category: a.category,
+        similarity_score: fragment("GREATEST(0, 1 - (? <=> ?::vector))", a.embedding, ^embedding)
+      }
+    )
+    |> AdminRepo.all(timeout: 5_000)
+  end
+
   @doc """
   Multi-hop traversal of the published article-link graph from a starting article.
 

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -2646,6 +2646,10 @@ defmodule Loopctl.Knowledge do
 
   @default_suggestion_limit 5
 
+  @doc "Default number of link suggestions when `:limit` is omitted."
+  @spec default_suggestion_limit() :: pos_integer()
+  def default_suggestion_limit, do: @default_suggestion_limit
+
   @doc """
   Suggests **typed link candidates** for an article by embedding similarity —
   **read-only**, creates nothing.

--- a/lib/loopctl_web/controllers/knowledge_suggest_links_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_suggest_links_controller.ex
@@ -91,8 +91,8 @@ defmodule LoopctlWeb.KnowledgeSuggestLinksController do
 
   defp parse_threshold(_), do: {:error, :invalid_threshold}
 
-  # Absent → use the context default (5). A present value must be a positive integer.
-  defp parse_limit(value) when value in [nil, ""], do: {:ok, 5}
+  # Absent → the context default. A present value must be a positive integer.
+  defp parse_limit(value) when value in [nil, ""], do: {:ok, Knowledge.default_suggestion_limit()}
 
   defp parse_limit(value) when is_binary(value) do
     case Integer.parse(value) do

--- a/lib/loopctl_web/controllers/knowledge_suggest_links_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_suggest_links_controller.ex
@@ -1,0 +1,105 @@
+defmodule LoopctlWeb.KnowledgeSuggestLinksController do
+  @moduledoc """
+  Read-only typed-link suggestions.
+
+  - `GET /api/v1/knowledge/articles/:id/suggested_links?limit=&threshold=` (agent+)
+
+  Returns ranked link *candidates* (by embedding similarity) for an article
+  **without creating anything**, so a caller can review them and POST a typed link
+  (`relates_to`/`derived_from`/`contradicts`/`supersedes`) via the create-link API.
+  """
+
+  use LoopctlWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Loopctl.ApiSpec.Schemas
+  alias Loopctl.Knowledge
+
+  action_fallback LoopctlWeb.FallbackController
+
+  plug LoopctlWeb.Plugs.RequireRole, role: :agent
+
+  tags(["Knowledge Wiki"])
+
+  operation(:suggest,
+    summary: "Suggest typed link candidates",
+    description:
+      "Returns ranked link CANDIDATES for an article by embedding similarity, " <>
+        "**read-only — creates nothing**. Excludes the article itself and any " <>
+        "already-linked article (either direction, any relationship type); only " <>
+        "embedded, published articles are considered. Each candidate is " <>
+        "`{id, title, category, similarity_score}`, highest similarity first — POST " <>
+        "the one you want as a **typed** link (relates_to/derived_from/contradicts/" <>
+        "supersedes) via the article_links API. `threshold` (0–1, default 0.5) is the " <>
+        "cosine floor; `limit` (default 5) caps results. Role: agent+.",
+    parameters: [
+      id: [in: :path, type: :string, description: "Article UUID"],
+      limit: [in: :query, type: :integer, description: "Max candidates (default 5)"],
+      threshold: [
+        in: :query,
+        type: :number,
+        description: "Cosine similarity floor 0–1 (default 0.5)"
+      ]
+    ],
+    responses: %{
+      200 =>
+        {"Suggested links", "application/json",
+         %OpenApiSpex.Schema{
+           type: :object,
+           properties: %{data: %OpenApiSpex.Schema{type: :array}}
+         }},
+      400 => {"Bad request", "application/json", Schemas.ErrorResponse},
+      404 => {"Article not found", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  @doc "GET /api/v1/knowledge/articles/:id/suggested_links"
+  def suggest(conn, %{"id" => article_id} = params) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+
+    with {:ok, threshold} <- parse_threshold(params["threshold"]),
+         {:ok, limit} <- parse_limit(params["limit"]),
+         {:ok, suggestions} <-
+           Knowledge.suggest_links(tenant_id, article_id,
+             threshold: threshold,
+             limit: limit
+           ) do
+      json(conn, %{data: suggestions})
+    else
+      {:error, :invalid_threshold} ->
+        {:error, :bad_request, "threshold must be a number between 0 and 1"}
+
+      {:error, :invalid_limit} ->
+        {:error, :bad_request, "limit must be a positive integer"}
+
+      {:error, :not_found} ->
+        {:error, :not_found}
+    end
+  end
+
+  # Absent → nil (context applies the default). A present value must parse to a
+  # number; range (0–1) is validated by the context (→ :invalid_threshold).
+  defp parse_threshold(value) when value in [nil, ""], do: {:ok, nil}
+
+  defp parse_threshold(value) when is_binary(value) do
+    case Float.parse(value) do
+      {n, ""} -> {:ok, n}
+      _ -> {:error, :invalid_threshold}
+    end
+  end
+
+  defp parse_threshold(_), do: {:error, :invalid_threshold}
+
+  # Absent → use the context default (5). A present value must be a positive integer.
+  defp parse_limit(value) when value in [nil, ""], do: {:ok, 5}
+
+  defp parse_limit(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {n, ""} when n > 0 -> {:ok, n}
+      _ -> {:error, :invalid_limit}
+    end
+  end
+
+  defp parse_limit(_), do: {:error, :invalid_limit}
+end

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -364,6 +364,11 @@ defmodule LoopctlWeb.Router do
     # ArticleLink management
     resources "/article_links", ArticleLinkController, only: [:create, :delete]
     get "/articles/:article_id/links", ArticleLinkController, :index
+
+    # Suggested typed-link candidates (read-only; embedding similarity)
+    get "/knowledge/articles/:id/suggested_links",
+        KnowledgeSuggestLinksController,
+        :suggest
   end
 
   # Superadmin endpoints (Epic 11)

--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to `loopctl-mcp-server` are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 2.18.0 — 2026-06-23 (suggest typed links)
+
+### Added
+
+- **`knowledge_suggest_links`** — ranked typed-link *candidates* for an article by
+  embedding similarity, **read-only** (creates nothing). Excludes the article itself
+  and any already-linked article (either direction, any type); only embedded
+  published articles. Returns `{id, title, category, similarity_score}` highest-first
+  so the caller can create a *typed* link (relates_to/derived_from/contradicts/
+  supersedes) — unlike the auto-linker's ambient `relates_to`. Optional `threshold`
+  (cosine floor, default 0.5) and `limit` (default 5). Backed by
+  `GET /api/v1/knowledge/articles/:id/suggested_links`. (#150)
+
 ## 2.17.0 — 2026-06-23 (knowledge graph traversal)
 
 ### Added

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -2,7 +2,7 @@
 
 MCP (Model Context Protocol) server for [loopctl](https://loopctl.com) -- structural trust for AI development loops.
 
-Wraps the loopctl REST API into 61 typed MCP tools so AI coding agents (Claude Code, etc.) can interact with loopctl without writing curl commands.
+Wraps the loopctl REST API into 62 typed MCP tools so AI coding agents (Claude Code, etc.) can interact with loopctl without writing curl commands.
 
 ## Installation
 
@@ -66,7 +66,7 @@ Or if installed locally:
 
 Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_KEY`.
 
-## Tools (61)
+## Tools (62)
 
 ### Project Tools
 
@@ -152,6 +152,7 @@ Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_K
 | `knowledge_get` | Get full article content by ID. Use after search to read an article in detail. Optional: `project_id`, `story_id` for attribution. |
 | `knowledge_context` | Get relevance-and-recency-ranked full articles for a task query. Best knowledge for your current context. Optional: `project_id`, `story_id` for attribution. |
 | `knowledge_graph` | Multi-hop traversal of the published article-link graph from `article_id` (depth 1–3, default 1). Bidirectional, cycle-safe, bounded to 100 nodes / 500 edges (`truncated` flags a cap). Returns `nodes` (`id`/`title`/`category`/`depth`) + `edges` (`source_article_id`/`target_article_id`/`relationship_type`). Explore typed connections beyond `knowledge_context`'s 1-hop links. Required: `article_id`. Optional: `depth`, `project_id`. |
+| `knowledge_suggest_links` | Ranked typed-link **candidates** for an article by embedding similarity — **read-only** (creates nothing). Excludes the article itself + any already-linked article (either direction, any type); only embedded published. Returns `{id, title, category, similarity_score}` highest-first, to create as a **typed** link (relates_to/derived_from/contradicts/supersedes). Required: `article_id`. Optional: `threshold` (cosine floor 0–1, default 0.5), `limit` (default 5). |
 | `knowledge_create` | Create a new knowledge article. File findings, document patterns, or record decisions. **Published immediately by default** (visible to agents in search/index/context) for every role — the response `note` says which outcome occurred. Pass `draft: true` to stage it for later review instead (publish afterwards with `knowledge_publish`). Pass `idempotency_key` for idempotent capture (re-creating with the same key is a no-op returning the existing article — no partial duplicates). Optional: `category`, `tags`, `project_id`, `draft`, `idempotency_key`, `source_type`, `source_id`. |
 | `knowledge_okf_export` | **Requires `LOOPCTL_USER_KEY`.** Export the wiki as a portable OKF (Open Knowledge Format) v0.1 bundle of markdown files. Writes to `out_dir`, or returns `{files, meta}` inline. |
 | `knowledge_okf_import` | **Requires `LOOPCTL_USER_KEY`.** Import an OKF v0.1 bundle from a local directory. Creates or (with `merge`) updates articles; tolerates and preserves unknown frontmatter. |

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -631,6 +631,21 @@ async function knowledgeGraph({ article_id, depth, project_id }) {
   return toContent(result);
 }
 
+async function knowledgeSuggestLinks({ article_id, limit, threshold }) {
+  const params = new URLSearchParams();
+  if (limit != null) params.set("limit", String(limit));
+  if (threshold != null) params.set("threshold", String(threshold));
+  const qs = params.toString();
+  const base = `/api/v1/knowledge/articles/${article_id}/suggested_links`;
+  const result = await apiCall(
+    "GET",
+    qs ? `${base}?${qs}` : base,
+    null,
+    process.env.LOOPCTL_AGENT_KEY,
+  );
+  return toContent(result);
+}
+
 async function knowledgeCount({
   project_id,
   category,
@@ -2174,6 +2189,35 @@ const TOOLS = [
     },
   },
   {
+    name: "knowledge_suggest_links",
+    description:
+      "Suggest ranked typed-link CANDIDATES for an article by embedding similarity — " +
+      "READ-ONLY, creates nothing. Excludes the article itself and any already-linked " +
+      "article (either direction, any relationship type); only embedded published articles. " +
+      "Returns { data: [{id, title, category, similarity_score}] } highest-similarity first. " +
+      "Review them and create the one you want as a TYPED link (relates_to/derived_from/" +
+      "contradicts/supersedes) — unlike the auto-linker which only makes ambient relates_to. " +
+      "Optional: threshold (cosine floor 0–1, default 0.5), limit (default 5).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        article_id: {
+          type: "string",
+          format: "uuid",
+          description: "The article to suggest links for (required).",
+        },
+        limit: { type: "integer", description: "Max candidates (default 5)." },
+        threshold: {
+          type: "number",
+          minimum: 0,
+          maximum: 1,
+          description: "Cosine similarity floor (default 0.5).",
+        },
+      },
+      required: ["article_id"],
+    },
+  },
+  {
     name: "knowledge_search",
     description:
       "Search the knowledge wiki by topic. Returns snippets. Ranked, and returns PUBLISHED " +
@@ -3107,6 +3151,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     case "knowledge_graph":
       return await knowledgeGraph(args);
+
+    case "knowledge_suggest_links":
+      return await knowledgeSuggestLinks(args);
 
     case "knowledge_search":
       return await knowledgeSearch(args);

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.17.0",
+  "version": "2.18.0",
   "description": "MCP server for loopctl — structural trust for AI development loops",
   "type": "module",
   "main": "index.js",

--- a/test/loopctl_web/controllers/knowledge_suggest_links_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_suggest_links_controller_test.exs
@@ -1,0 +1,169 @@
+defmodule LoopctlWeb.KnowledgeSuggestLinksControllerTest do
+  use LoopctlWeb.ConnCase, async: true
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge
+  alias Loopctl.Knowledge.ArticleLink
+
+  import Ecto.Query
+
+  setup :verify_on_exit!
+
+  defp auth_conn(conn, raw_key), do: put_req_header(conn, "authorization", "Bearer #{raw_key}")
+
+  defp setup_tenant_key do
+    tenant = fixture(:tenant)
+    {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+    {tenant, raw_key}
+  end
+
+  # 1536-dim vector from a sparse prefix (rest zero-filled). Cosine is magnitude-
+  # independent: e([1.0]) vs e([1.0]) = 1; vs e([1.0, 1.0]) = 1/√2 ≈ 0.707; vs
+  # e([0.0, 1.0]) = 0.
+  defp e(prefix), do: prefix ++ List.duplicate(0.0, 1536 - length(prefix))
+
+  defp embedded(tenant_id, title, vector, status \\ :published) do
+    a = fixture(:article, %{tenant_id: tenant_id, title: title, status: status})
+    {:ok, _} = Knowledge.update_embedding(tenant_id, a.id, e(vector))
+    a
+  end
+
+  defp suggest(conn, key, id, query \\ %{}) do
+    conn
+    |> auth_conn(key)
+    |> get(~p"/api/v1/knowledge/articles/#{id}/suggested_links?#{query}")
+    |> json_response(200)
+  end
+
+  defp ids(body), do: Enum.map(body["data"], & &1["id"])
+
+  describe "GET /api/v1/knowledge/articles/:id/suggested_links (#150)" do
+    test "returns candidates ranked by similarity, highest first, excluding below-threshold",
+         %{conn: conn} do
+      {tenant, key} = setup_tenant_key()
+      target = embedded(tenant.id, "Target", [1.0])
+      identical = embedded(tenant.id, "Identical", [1.0])
+      medium = embedded(tenant.id, "Medium", [1.0, 1.0])
+      _orthogonal = embedded(tenant.id, "Orthogonal", [0.0, 1.0])
+
+      body = suggest(conn, key, target.id)
+
+      # orthogonal (cosine 0) is below the 0.5 default threshold → excluded.
+      assert ids(body) == [identical.id, medium.id]
+      # similarity_score present and descending; carries id/title/category.
+      [first, second] = body["data"]
+      assert first["similarity_score"] >= second["similarity_score"]
+      assert first["title"] == "Identical"
+      assert first["category"]
+    end
+
+    test "excludes the article itself and any already-linked article (either direction)",
+         %{conn: conn} do
+      {tenant, key} = setup_tenant_key()
+      target = embedded(tenant.id, "Target", [1.0])
+      linked = embedded(tenant.id, "Linked", [1.0])
+      free = embedded(tenant.id, "Free", [1.0])
+
+      # Existing link target→linked (any type) must exclude `linked`.
+      fixture(:article_link, %{
+        tenant_id: tenant.id,
+        source_article_id: target.id,
+        target_article_id: linked.id,
+        relationship_type: :derived_from
+      })
+
+      body = suggest(conn, key, target.id)
+
+      assert target.id not in ids(body)
+      assert linked.id not in ids(body)
+      assert free.id in ids(body)
+    end
+
+    test "is read-only — creates no links", %{conn: conn} do
+      {tenant, key} = setup_tenant_key()
+      target = embedded(tenant.id, "Target", [1.0])
+      _candidate = embedded(tenant.id, "Candidate", [1.0])
+
+      before =
+        AdminRepo.aggregate(from(l in ArticleLink, where: l.tenant_id == ^tenant.id), :count, :id)
+
+      _ = suggest(conn, key, target.id)
+
+      after_count =
+        AdminRepo.aggregate(from(l in ArticleLink, where: l.tenant_id == ^tenant.id), :count, :id)
+
+      assert before == 0
+      assert after_count == 0
+    end
+
+    test "honors limit and threshold", %{conn: conn} do
+      {tenant, key} = setup_tenant_key()
+      target = embedded(tenant.id, "Target", [1.0])
+      embedded(tenant.id, "C1", [1.0])
+      embedded(tenant.id, "C2", [1.0])
+      embedded(tenant.id, "C3", [1.0])
+
+      assert length(ids(suggest(conn, key, target.id, %{limit: 1}))) == 1
+
+      # threshold 0.99 still keeps the identical (cosine 1) candidates.
+      assert length(ids(suggest(conn, key, target.id, %{threshold: "0.99"}))) == 3
+    end
+
+    test "excludes draft candidates (published-only)", %{conn: conn} do
+      {tenant, key} = setup_tenant_key()
+      target = embedded(tenant.id, "Target", [1.0])
+      _draft = embedded(tenant.id, "Draft Candidate", [1.0], :draft)
+
+      assert ids(suggest(conn, key, target.id)) == []
+    end
+
+    test "a published article with no embedding returns an empty list", %{conn: conn} do
+      {tenant, key} = setup_tenant_key()
+
+      target =
+        fixture(:article, %{tenant_id: tenant.id, title: "No Embedding", status: :published})
+
+      assert ids(suggest(conn, key, target.id)) == []
+    end
+
+    test "nonexistent or draft target returns 404", %{conn: conn} do
+      {tenant, key} = setup_tenant_key()
+
+      conn
+      |> auth_conn(key)
+      |> get(~p"/api/v1/knowledge/articles/#{Ecto.UUID.generate()}/suggested_links")
+      |> json_response(404)
+
+      draft = fixture(:article, %{tenant_id: tenant.id, title: "Draft", status: :draft})
+
+      build_conn()
+      |> auth_conn(key)
+      |> get(~p"/api/v1/knowledge/articles/#{draft.id}/suggested_links")
+      |> json_response(404)
+    end
+
+    test "invalid threshold returns 400", %{conn: conn} do
+      {tenant, key} = setup_tenant_key()
+      target = embedded(tenant.id, "Target", [1.0])
+
+      resp =
+        conn
+        |> auth_conn(key)
+        |> get(~p"/api/v1/knowledge/articles/#{target.id}/suggested_links?threshold=2")
+        |> json_response(400)
+
+      assert resp["error"]["message"] =~ "threshold"
+    end
+
+    test "tenant isolation: another tenant's article is not found", %{conn: conn} do
+      {_tenant_a, key_a} = setup_tenant_key()
+      tenant_b = fixture(:tenant)
+      b = embedded(tenant_b.id, "B", [1.0])
+
+      conn
+      |> auth_conn(key_a)
+      |> get(~p"/api/v1/knowledge/articles/#{b.id}/suggested_links")
+      |> json_response(404)
+    end
+  end
+end


### PR DESCRIPTION
Add #150: suggest_links — read-only typed-link candidates (port open_brain)

`GET /api/v1/knowledge/articles/:id/suggested_links?limit=&threshold=` (agent+) +
`Knowledge.suggest_links/3` + MCP `knowledge_suggest_links`. Ported from open_brain's
suggest_links/3 (note→article rename) — exposes the "suggest, the caller picks the
typed relationship" half the auto-linker lacks.

- **Read-only — creates nothing.** Returns ranked candidates by embedding cosine
  similarity for the caller to POST as a TYPED link (relates_to/derived_from/
  contradicts/supersedes), unlike the auto-linker's ambient relates_to.
- Excludes the article itself and **any already-linked article** (either direction,
  any relationship type, via a left-join + is_nil filter). Only embedded, published
  articles are considered; tenant-scoped; agent-gated.
- Honors `threshold` (cosine floor, default 0.5 from `:suggestion_similarity_threshold`
  config; out of 0–1 → 400) and `limit` (default 5), ordered most-similar first.
- Returns `[{id, title, category, similarity_score}]`; `{:ok, []}` when the article
  has no embedding yet; 404 when missing/not-published.

Tests: similarity ordering + below-threshold exclusion, already-linked exclusion
(either direction), read-only (no links created), limit/threshold honored, draft
candidates excluded, no-embedding → empty, nonexistent/draft target → 404, invalid
threshold → 400, tenant isolation.

MCP 2.17.0 → 2.18.0 (tool 61→62).

Closes #150
