### PR TITLE
Fix #155: honest story-list pagination in MCP (no silent 20-cap)

### DIFF
--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to `loopctl-mcp-server` are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 2.20.1 — 2026-06-24 (honest story pagination)
+
+### Fixed
+
+- **`list_stories` / `list_ready_stories`** no longer silently clamp `limit` to 20.
+  They default to 20 but now honor an explicit `limit` up to the server's max (500),
+  so paging by advancing `offset` no longer skips stories. Tool schemas document the
+  `default 20, max 500` contract. (#155)
+
 ## 2.20.0 — 2026-06-23 (creativity primitives)
 
 ### Added

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -139,9 +139,12 @@ function toContent(result) {
 /**
  * Compact variant for list endpoints — strips acceptance_criteria and
  * description (use get_story for full details). Keeps all other fields.
- * Enforces a max page size to prevent MCP response token overflow.
+ * A modest DEFAULT page size keeps unprompted responses small, but an explicit
+ * `limit` is honored up to the server's max (500) so story enumeration paginates
+ * honestly instead of silently capping at 20 and skipping rows on offset advance.
  */
-const MAX_PAGE_SIZE = 20;
+const DEFAULT_STORY_PAGE_SIZE = 20;
+const SERVER_MAX_STORY_PAGE_SIZE = 500;
 
 function toContentCompact(result) {
   if (result && result.error === true) return toContent(result);
@@ -367,7 +370,10 @@ async function listStories({ project_id, agent_status, verified_status, epic_id,
   if (agent_status) params.set("agent_status", agent_status);
   if (verified_status) params.set("verified_status", verified_status);
   if (epic_id) params.set("epic_id", epic_id);
-  params.set("limit", String(Math.min(limit ?? MAX_PAGE_SIZE, MAX_PAGE_SIZE)));
+  params.set(
+    "limit",
+    String(Math.min(limit ?? DEFAULT_STORY_PAGE_SIZE, SERVER_MAX_STORY_PAGE_SIZE)),
+  );
   if (offset != null) params.set("offset", String(offset));
   if (include_token_totals) params.set("include_token_totals", "true");
 
@@ -377,7 +383,10 @@ async function listStories({ project_id, agent_status, verified_status, epic_id,
 
 async function listReadyStories({ project_id, limit }) {
   const params = new URLSearchParams({ project_id });
-  params.set("limit", String(Math.min(limit ?? MAX_PAGE_SIZE, MAX_PAGE_SIZE)));
+  params.set(
+    "limit",
+    String(Math.min(limit ?? DEFAULT_STORY_PAGE_SIZE, SERVER_MAX_STORY_PAGE_SIZE)),
+  );
 
   const result = await apiCall("GET", `/api/v1/stories/ready?${params}`);
   return toContentCompact(result);
@@ -1526,8 +1535,8 @@ const TOOLS = [
     description:
       "List stories for a project, optionally filtered by agent_status, verified_status, or epic_id. " +
       "Returns compact results (no acceptance_criteria/description) — use get_story for full details. " +
-      "Max 20 per page. Use offset to paginate (response includes total_count). " +
-      "Filter by epic_id or agent_status to reduce result size.",
+      "Defaults to 20 per page; pass `limit` up to 500 to page larger. Use offset to paginate " +
+      "(response includes total_count). Filter by epic_id or agent_status to reduce result size.",
     inputSchema: {
       type: "object",
       properties: {
@@ -1550,7 +1559,7 @@ const TOOLS = [
         },
         limit: {
           type: "integer",
-          description: "Maximum number of stories to return.",
+          description: "Maximum number of stories to return (default 20, max 500).",
         },
         offset: {
           type: "integer",
@@ -1569,7 +1578,7 @@ const TOOLS = [
     description:
       "List stories that are ready to be worked on (contracted, dependencies met). " +
       "Returns compact results — use get_story for full details. " +
-      "Max 20 per page. Response includes total_count for pagination.",
+      "Defaults to 20 per page; pass `limit` up to 500 to page larger. Response includes total_count.",
     inputSchema: {
       type: "object",
       properties: {
@@ -1579,7 +1588,7 @@ const TOOLS = [
         },
         limit: {
           type: "integer",
-          description: "Maximum number of stories to return.",
+          description: "Maximum number of stories to return (default 20, max 500).",
         },
       },
       required: ["project_id"],

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.20.0",
+  "version": "2.20.1",
   "description": "MCP server for loopctl — structural trust for AI development loops",
   "type": "module",
   "main": "index.js",

--- a/mcp-server/test/story_tools.test.js
+++ b/mcp-server/test/story_tools.test.js
@@ -1,0 +1,61 @@
+/**
+ * Regression tests for #155: list_stories / list_ready_stories must NOT silently
+ * clamp the requested limit to 20. They default to 20 but honor an explicit limit
+ * up to the server max (500).
+ *
+ * Uses Node.js built-in test runner (node:test). Run: node --test test/
+ *
+ * The handler functions in index.js are not exported (server entry point with
+ * top-level await), so we mirror the exact limit computation here and also assert
+ * the source no longer uses the old 20-cap, keeping the test resilient yet faithful.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const DEFAULT_STORY_PAGE_SIZE = 20;
+const SERVER_MAX_STORY_PAGE_SIZE = 500;
+
+// Mirrors index.js: params.set("limit", String(Math.min(limit ?? DEFAULT, SERVER_MAX)))
+function resolvedLimit(limit) {
+  return Math.min(limit ?? DEFAULT_STORY_PAGE_SIZE, SERVER_MAX_STORY_PAGE_SIZE);
+}
+
+describe("#155 story-list limit handling", () => {
+  test("defaults to 20 when limit is omitted", () => {
+    assert.equal(resolvedLimit(undefined), 20);
+    assert.equal(resolvedLimit(null), 20);
+  });
+
+  test("honors an explicit limit up to the server max (no 20-cap)", () => {
+    assert.equal(resolvedLimit(50), 50);
+    assert.equal(resolvedLimit(200), 200);
+    assert.equal(resolvedLimit(500), 500);
+  });
+
+  test("clamps above the server max to 500", () => {
+    assert.equal(resolvedLimit(1000), 500);
+  });
+
+  test("source no longer caps story listing at 20 (MAX_PAGE_SIZE removed)", () => {
+    const indexPath = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "..",
+      "index.js",
+    );
+    const src = readFileSync(indexPath, "utf8");
+    // The old constant that silently capped story pages at 20 must be gone.
+    assert.ok(
+      !/const MAX_PAGE_SIZE = 20/.test(src),
+      "index.js still defines the 20-row MAX_PAGE_SIZE cap",
+    );
+    // The story handlers must use the server-max constant.
+    assert.ok(
+      /SERVER_MAX_STORY_PAGE_SIZE = 500/.test(src),
+      "index.js should define SERVER_MAX_STORY_PAGE_SIZE = 500",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #155. `list_stories` / `list_ready_stories` silently clamped `limit` to 20 (`Math.min(limit ?? 20, 20)`), so an agent requesting up to the server's documented max (500) received only 20 rows — and a loop advancing `offset` by the requested limit silently skipped stories. Same class as the #148a knowledge-enumeration clamp.

## Change

- Honor an explicit `limit` up to the server max (**500**); default **20** when unspecified (keeps unprompted MCP responses compact). The server already clamps to 500 / defaults to 100.
- Document `default 20, max 500` in both `list_stories` and `list_ready_stories` tool schemas.
- Regression test `test/story_tools.test.js`: default → 20, explicit 50/200/500 honored, 1000 → 500, and the old `MAX_PAGE_SIZE = 20` constant is gone.

MCP server **2.20.1**. MCP tests 45/45.
