### PR TITLE
Fix #158: bulk publish/delete load + return body-less summaries

### DIFF
--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -1998,7 +1998,9 @@ defmodule Loopctl.Knowledge do
 
   defp do_bulk_publish(tenant_id, article_ids, opts) do
     # Load every requested article once, keyed by id (lag-free, DB-of-record).
-    existing = load_existing_by_ids(tenant_id, article_ids)
+    # Body-less: the publish transition + audit only need id/status, and the
+    # response is body-less summaries — never materialize up to 5000 bodies (#158).
+    existing = load_existing_by_ids(tenant_id, article_ids, false)
 
     drafts =
       for id <- article_ids,
@@ -2267,7 +2269,9 @@ defmodule Loopctl.Knowledge do
   end
 
   defp do_bulk_archive(tenant_id, article_ids, opts) do
-    existing = load_existing_by_ids(tenant_id, article_ids)
+    # Body-less load: the archive transition + audit need only id/status, and the
+    # response is body-less summaries — never materialize up to 5000 bodies (#158).
+    existing = load_existing_by_ids(tenant_id, article_ids, false)
 
     archivable =
       for id <- article_ids,
@@ -2331,10 +2335,12 @@ defmodule Loopctl.Knowledge do
   # kept out of the `id in ^ids` query (which would raise on cast) so they
   # resolve to a clean "not_found" via the absent map entry.
   # `include_body: false` projects every field except the (potentially large)
-  # `body`, so a bulk op that never echoes the body (e.g. bulk-unpublish, which
-  # renders body-less summaries) doesn't pull up to 5000 full bodies into memory
-  # just to flip a status. The status transition and audit only need id/status.
-  defp load_existing_by_ids(tenant_id, article_ids, include_body \\ true) do
+  # `body`, so a bulk op that never echoes the body (all of bulk publish/unpublish/
+  # archive render body-less summaries) doesn't pull up to 5000 full bodies into
+  # memory just to flip a status. The status transition and audit only need
+  # id/status. Callers pass `include_body` explicitly (no default — every current
+  # caller is body-less; pass `true` if a future caller needs full bodies).
+  defp load_existing_by_ids(tenant_id, article_ids, include_body) do
     queryable_ids = Enum.filter(article_ids, &valid_uuid?/1)
 
     base =

--- a/lib/loopctl_web/controllers/article_workflow_controller.ex
+++ b/lib/loopctl_web/controllers/article_workflow_controller.ex
@@ -289,7 +289,9 @@ defmodule LoopctlWeb.ArticleWorkflowController do
 
     with {:ok, result} <- Knowledge.bulk_publish(tenant_id, article_ids, audit_opts) do
       json(conn, %{
-        data: Enum.map(result.published, &ArticleJSON.article_data/1),
+        # Body-less summaries: the affected set as confirmation; the actionable
+        # per-id detail is in meta.results (consistent with bulk-unpublish, #158).
+        data: Enum.map(result.published, &ArticleJSON.article_summary/1),
         meta: %{
           # `count` kept for backward compatibility = number actually published.
           count: result.counts.published,
@@ -331,7 +333,9 @@ defmodule LoopctlWeb.ArticleWorkflowController do
     with {:ok, ids} <- resolve_bulk_delete_ids(tenant_id, params),
          {:ok, result} <- Knowledge.bulk_archive(tenant_id, ids, audit_opts) do
       json(conn, %{
-        data: Enum.map(result.archived, &ArticleJSON.article_data/1),
+        # Body-less summaries (consistent with bulk-unpublish, #158); per-id detail
+        # is in meta.results.
+        data: Enum.map(result.archived, &ArticleJSON.article_summary/1),
         meta: %{
           # `count` = number actually archived.
           count: result.counts.archived,

--- a/test/loopctl_web/controllers/article_workflow_controller_test.exs
+++ b/test/loopctl_web/controllers/article_workflow_controller_test.exs
@@ -219,6 +219,10 @@ defmodule LoopctlWeb.ArticleWorkflowControllerTest do
       assert body["meta"]["count"] == 3
       assert length(body["data"]) == 3
 
+      # data carries body-less summaries — never the full bodies (#158).
+      assert Enum.all?(body["data"], &(not Map.has_key?(&1, "body")))
+      assert Enum.all?(body["data"], &Map.has_key?(&1, "id"))
+
       # Verify all published in DB
       for id <- [a1.id, a2.id, a3.id] do
         article = AdminRepo.get!(Article, id)
@@ -555,6 +559,10 @@ defmodule LoopctlWeb.ArticleWorkflowControllerTest do
       assert AdminRepo.get!(Article, draft.id).status == :archived
       assert AdminRepo.get!(Article, published.id).status == :archived
       assert AdminRepo.get!(Article, superseded.id).status == :superseded
+
+      # data carries body-less summaries — never the full bodies (#158).
+      assert Enum.all?(body["data"], &(not Map.has_key?(&1, "body")))
+      assert Enum.all?(body["data"], &Map.has_key?(&1, "id"))
     end
 
     test "supplying more than one selector is rejected (no silent confirm bypass)", %{conn: conn} do


### PR DESCRIPTION
## Summary

Closes #158. `bulk_publish` and `bulk_delete` (archive) loaded full `%Article{}` structs (incl. `body`, ~500KB each) for up to 5000 ids and rendered the affected set with `article_data` (full body) — the same payload/memory vector #148a bounded for `GET /articles`. `bulk_unpublish` was hardened to body-less in #148c; this brings its two siblings into line so all three bulk ops behave identically.

## Change

- `do_bulk_publish` / `do_bulk_archive` load via `load_existing_by_ids(..., false)` (body-less). The status transition, audit, and embedding enqueue need only `id`/`status` — `enqueue_bulk_embeddings` uses `article.id` and the `ArticleEmbeddingWorker` re-loads the full body itself, so nothing downstream needs the in-memory body.
- `bulk_publish` / `bulk_delete` controllers render `ArticleJSON.article_summary` (body-less), consistent with `bulk_unpublish`. Per-id outcomes in `meta.results` are unchanged.
- `load_existing_by_ids` drops its `\\ true` default (all three callers are now body-less).

## Contract change

`POST /knowledge/bulk-publish` and `POST /knowledge/bulk-delete` `data[]` entries **no longer include `body`** (they were full articles; now body-less summaries — `id`, `title`, `category`, `status`, `tags`, source/idempotency fields, `metadata`, timestamps). `meta.results` (the actionable per-id breakdown) is unchanged. This matches `bulk-unpublish` and the #148a body-less-by-default direction.

## Tests

Added body-less assertions to both the bulk-publish and bulk-delete tests (mirroring the existing bulk-unpublish assertion). Full suite green (2500), `mix precommit` clean.
