### PR TITLE
Fix #172: suggested_links 500 — HNSW approximate-NN, not a full-corpus self-join scan

### DIFF
--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -2805,6 +2805,11 @@ defmodule Loopctl.Knowledge do
   `:suggestion_similarity_threshold` config or 0.5) and `:limit` (default
   #{@default_suggestion_limit}), ordered most-similar first. Tenant-scoped.
 
+  Ranking is approximate nearest-neighbor over the HNSW embedding index
+  (`articles_embedding_idx`, cosine), with pgvector iterative scan so the
+  already-linked exclusion can't starve the result below `:limit` when an
+  article's nearest neighbors are mostly already linked.
+
   ## Returns
 
   - `{:ok, [%{id, title, category, similarity_score}]}` (highest similarity first)
@@ -2858,8 +2863,29 @@ defmodule Loopctl.Knowledge do
   end
 
   defp suggestion_candidates(tenant_id, article_id, embedding, threshold, limit, vis) do
-    suggestion_candidates_query(tenant_id, article_id, embedding, threshold, limit, vis)
-    |> AdminRepo.all(timeout: 15_000)
+    query = suggestion_candidates_query(tenant_id, article_id, embedding, threshold, limit, vis)
+
+    {:ok, rows} =
+      AdminRepo.transaction(
+        fn ->
+          # Iterative HNSW scan (pgvector ≥ 0.8): keep pulling index neighbors until `limit`
+          # candidates survive the anti-join (already-linked) + threshold post-filters,
+          # rather than stopping after a single `ef_search` (default 40) batch. Links are
+          # created BETWEEN similar articles, so a densely-linked hub's nearest neighbors are
+          # exactly the ones the anti-join removes — without iterative scan it could return
+          # fewer than `limit` suggestions even when qualifying ones exist just past the
+          # first batch. `strict_order` preserves the "most-similar first" ordering, and the
+          # scan stays bounded by pgvector's `max_scan_tuples`, so it never degrades to the
+          # #172 full-corpus scan. SET LOCAL is transaction-scoped (resets on commit), the
+          # same mechanism the RLS tenant GUC uses; pgvector reconciles it when the query's
+          # `<=>` ops load the extension.
+          AdminRepo.query!("SET LOCAL hnsw.iterative_scan = 'strict_order'")
+          AdminRepo.all(query, timeout: 15_000)
+        end,
+        timeout: 15_000
+      )
+
+    rows
   end
 
   # Builds the suggested-links candidate query (returned, not executed) so a test can

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -2832,8 +2832,8 @@ defmodule Loopctl.Knowledge do
         %{embedding: nil} ->
           {:ok, []}
 
-        %{embedding: _embedding} ->
-          {:ok, suggestion_candidates(tenant_id, article_id, threshold, limit, vis)}
+        %{embedding: embedding} ->
+          {:ok, suggestion_candidates(tenant_id, article_id, embedding, threshold, limit, vis)}
       end
     end
   end
@@ -2857,32 +2857,38 @@ defmodule Loopctl.Knowledge do
     end
   end
 
-  defp suggestion_candidates(tenant_id, article_id, threshold, limit, vis) do
-    suggestion_candidates_query(tenant_id, article_id, threshold, limit, vis)
-    |> AdminRepo.all(timeout: 5_000)
+  defp suggestion_candidates(tenant_id, article_id, embedding, threshold, limit, vis) do
+    suggestion_candidates_query(tenant_id, article_id, embedding, threshold, limit, vis)
+    |> AdminRepo.all(timeout: 15_000)
   end
 
   # Builds the suggested-links candidate query (returned, not executed) so a test can
   # assert its SQL shape. Public-but-`@doc false` for that structural regression guard.
   #
-  # Ranks candidates by cosine similarity to the target. The target's vector is
-  # referenced COLUMN-to-column via a self-join (`a.embedding <=> t.embedding`), NEVER
-  # round-tripped back in as a `^param`/`::vector` cast — that re-interpolation of a
-  # stored `%Pgvector{}` was the #168 production 500. This mirrors `distant_pairs`,
-  # whose column-to-column cosine works in production. The caller has already confirmed
-  # the target exists / is published / is embedded / is visible (fetch_article_embedding).
+  # Ranks candidates by cosine similarity to the target. The target embedding (already
+  # fetched by the caller, `fetch_article_embedding`) is passed as a BOUND `^param`
+  # LIST of floats — exactly the form `search_semantic` ships in production. This is the
+  # HNSW-indexable shape `ORDER BY embedding <=> $const LIMIT k`
+  # (`articles_embedding_idx`, vector_cosine_ops), so the planner does an approximate-NN
+  # index scan instead of a per-row cosine + full sort over every published article.
   #
-  # Perf tradeoff (#168): because the right operand is a COLUMN (`t.embedding`), the
-  # HNSW index (`articles_embedding_idx`, vector_cosine_ops) — which only accelerates
-  # `ORDER BY embedding <=> CONSTANT LIMIT k` — is intentionally not used; the query is
-  # a published-candidate scan + per-row cosine + sort, bounded by `status`, `limit`,
-  # and a 5s timeout. Negligible at current scale and consistent with the already-
-  # shipped `distant_pairs`; revisit if a tenant grows to tens of thousands of articles.
+  # Two regressions are deliberately avoided here:
+  #   * #168 — NEVER bind the *stored* `%Pgvector{}` struct as a param (that
+  #     re-interpolation was the original 500). We convert it to a plain list first
+  #     (`to_embedding_list/1`), the same value shape `search_semantic` binds.
+  #   * #172 — NEVER self-join `articles` to read the target vector as a *column*
+  #     (`a.embedding <=> t.embedding`). A column right-operand defeats the HNSW index
+  #     and forces a full-corpus scan + sort, which timed out at prod scale (~76k
+  #     published articles) → 500. The bound `^param` left-vs-const form is indexable.
+  #
+  # The caller has already confirmed the target exists / is published / is embedded /
+  # is visible. Bounded by `status`, `limit`, and a 15s timeout (matching the other
+  # vector paths, `nearest_prior_distance`/`distant_pairs`).
   @doc false
-  def suggestion_candidates_query(tenant_id, article_id, threshold, limit, vis) do
+  def suggestion_candidates_query(tenant_id, article_id, embedding, threshold, limit, vis) do
+    target = to_embedding_list(embedding)
+
     from(a in Article,
-      join: t in Article,
-      on: t.id == ^article_id and t.tenant_id == ^tenant_id,
       where: a.tenant_id == ^tenant_id and a.status == :published,
       where: not is_nil(a.embedding),
       where: a.id != ^article_id,
@@ -2893,18 +2899,24 @@ defmodule Loopctl.Knowledge do
           ((l.source_article_id == ^article_id and l.target_article_id == a.id) or
              (l.target_article_id == ^article_id and l.source_article_id == a.id)),
       where: is_nil(l.id),
-      where: fragment("GREATEST(0, 1 - (? <=> ?)) > ?", a.embedding, t.embedding, ^threshold),
-      order_by: [asc: fragment("? <=> ?", a.embedding, t.embedding)],
+      where: fragment("GREATEST(0, 1 - (? <=> ?)) > ?", a.embedding, ^target, ^threshold),
+      order_by: [asc: fragment("? <=> ?", a.embedding, ^target)],
       limit: ^limit,
       select: %{
         id: a.id,
         title: a.title,
         category: a.category,
-        similarity_score: fragment("GREATEST(0, 1 - (? <=> ?))", a.embedding, t.embedding)
+        similarity_score: fragment("GREATEST(0, 1 - (? <=> ?))", a.embedding, ^target)
       }
     )
     |> maybe_filter_by_visibility(vis)
   end
+
+  # The HNSW-indexable cosine form binds the target as a plain `[float()]` list (the
+  # same value shape `search_semantic` binds), NEVER the stored `%Pgvector{}` struct —
+  # re-interpolating that struct was the #168 production 500.
+  defp to_embedding_list(%Pgvector{} = vector), do: Pgvector.to_list(vector)
+  defp to_embedding_list(vector) when is_list(vector), do: vector
 
   @doc """
   Multi-hop traversal of the published article-link graph from a starting article.

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -2806,9 +2806,12 @@ defmodule Loopctl.Knowledge do
   #{@default_suggestion_limit}), ordered most-similar first. Tenant-scoped.
 
   Ranking is approximate nearest-neighbor over the HNSW embedding index
-  (`articles_embedding_idx`, cosine), with pgvector iterative scan so the
-  already-linked exclusion can't starve the result below `:limit` when an
-  article's nearest neighbors are mostly already linked.
+  (`articles_embedding_idx`, cosine), bounded by the index search list
+  (`hnsw.ef_search`) exactly like the semantic-search path. In the rare case
+  that an article's nearest neighbors are almost all already linked, the result
+  may contain fewer than `:limit` suggestions — by design, consistent with
+  semantic search; deeper recall is intentionally not traded for holding an
+  AdminRepo connection on this hot, pool-constrained endpoint.
 
   ## Returns
 
@@ -2863,29 +2866,15 @@ defmodule Loopctl.Knowledge do
   end
 
   defp suggestion_candidates(tenant_id, article_id, embedding, threshold, limit, vis) do
-    query = suggestion_candidates_query(tenant_id, article_id, embedding, threshold, limit, vis)
-
-    {:ok, rows} =
-      AdminRepo.transaction(
-        fn ->
-          # Iterative HNSW scan (pgvector ≥ 0.8): keep pulling index neighbors until `limit`
-          # candidates survive the anti-join (already-linked) + threshold post-filters,
-          # rather than stopping after a single `ef_search` (default 40) batch. Links are
-          # created BETWEEN similar articles, so a densely-linked hub's nearest neighbors are
-          # exactly the ones the anti-join removes — without iterative scan it could return
-          # fewer than `limit` suggestions even when qualifying ones exist just past the
-          # first batch. `strict_order` preserves the "most-similar first" ordering, and the
-          # scan stays bounded by pgvector's `max_scan_tuples`, so it never degrades to the
-          # #172 full-corpus scan. SET LOCAL is transaction-scoped (resets on commit), the
-          # same mechanism the RLS tenant GUC uses; pgvector reconciles it when the query's
-          # `<=>` ops load the extension.
-          AdminRepo.query!("SET LOCAL hnsw.iterative_scan = 'strict_order'")
-          AdminRepo.all(query, timeout: 15_000)
-        end,
-        timeout: 15_000
-      )
-
-    rows
+    # Bare AdminRepo.all (NO transaction) — deliberately mirrors `search_semantic` and
+    # `distant_pairs`, which avoid holding an AdminRepo connection. The prod admin pool is
+    # only 3 (`ADMIN_POOL_SIZE`), shared by every cross-tenant read, so wrapping this hot
+    # endpoint in a per-request transaction would risk pool starvation under concurrent
+    # agent load — the exact pattern the `distant_pairs` note (below in this module) was
+    # written to avoid. The HNSW-indexable query returns in single-digit ms; the 15s
+    # timeout is a backstop, matching `nearest_prior_distance`/`distant_pairs`.
+    suggestion_candidates_query(tenant_id, article_id, embedding, threshold, limit, vis)
+    |> AdminRepo.all(timeout: 15_000)
   end
 
   # Builds the suggested-links candidate query (returned, not executed) so a test can

--- a/test/loopctl_web/controllers/knowledge_suggest_links_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_suggest_links_controller_test.exs
@@ -79,10 +79,12 @@ defmodule LoopctlWeb.KnowledgeSuggestLinksControllerTest do
   end
 
   describe "GET /api/v1/knowledge/articles/:id/suggested_links (#150)" do
-    # #168 regression: the endpoint 500'd in production because the target's stored
-    # vector was round-tripped back in as a `^param::vector`. The query now does the
-    # cosine column-to-column via a self-join. This guards the end-to-end HTTP path
-    # (controller → query → JSON) returns 200 with the documented candidate shape.
+    # #168/#172 regression: the endpoint 500'd in production. #168 was re-interpolating
+    # the stored `%Pgvector{}` as a `^param::vector`; #172 was the self-join that read the
+    # target vector as a column, forcing a full-corpus scan. The query now binds the target
+    # as a plain list param (HNSW-indexable `ORDER BY embedding <=> $const LIMIT k`). This
+    # guards the end-to-end HTTP path (controller → query → JSON) returns 200 with the
+    # documented candidate shape.
     test "returns 200 with ranked candidate shape (no 500) — #168", %{conn: conn} do
       {tenant, key} = setup_tenant_key()
       target = embedded(tenant.id, "Target168", [1.0, 0.0])
@@ -147,6 +149,38 @@ defmodule LoopctlWeb.KnowledgeSuggestLinksControllerTest do
       assert target.id not in ids(body)
       assert linked.id not in ids(body)
       assert free.id in ids(body)
+    end
+
+    # #172 follow-up: the result must not under-fill below `limit` when the target's
+    # nearest neighbors are mostly already-linked. Links cluster among similar articles,
+    # so the anti-join removes exactly the closest candidates — pgvector iterative scan
+    # has to keep pulling neighbors until `limit` UNLINKED ones survive. (At test scale
+    # the planner seq-scans so this is exact regardless; the assertion guards the
+    # exclusion-under-limit contract that iterative scan preserves at prod scale.)
+    test "fills up to limit with unlinked candidates even when nearer ones are linked",
+         %{conn: conn} do
+      {tenant, key} = setup_tenant_key()
+      target = embedded(tenant.id, "Target", [1.0])
+      # Six equally-similar candidates; pre-link four so only two remain unlinked.
+      linked = for i <- 1..4, do: embedded(tenant.id, "Linked#{i}", [1.0])
+      free1 = embedded(tenant.id, "Free1", [1.0])
+      free2 = embedded(tenant.id, "Free2", [1.0])
+
+      for l <- linked do
+        fixture(:article_link, %{
+          tenant_id: tenant.id,
+          source_article_id: target.id,
+          target_article_id: l.id,
+          relationship_type: :relates_to
+        })
+      end
+
+      returned = ids(suggest(conn, key, target.id, %{limit: 2}))
+
+      # Exactly the two unlinked candidates — none of the four linked ones leak through,
+      # and the result is not starved below the requested limit.
+      assert Enum.sort(returned) == Enum.sort([free1.id, free2.id])
+      for l <- linked, do: assert(l.id not in returned)
     end
 
     test "is read-only — creates no links", %{conn: conn} do

--- a/test/loopctl_web/controllers/knowledge_suggest_links_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_suggest_links_controller_test.exs
@@ -52,8 +52,9 @@ defmodule LoopctlWeb.KnowledgeSuggestLinksControllerTest do
     #   * #168: that bound param is a plain LIST of floats, NEVER the stored `%Pgvector{}`
     #     struct (binding the struct was the original 500).
     #
-    # A literal 76k-row seed is infeasible in an async unit test, so the indexable
-    # SQL shape is the durable, non-flaky proxy for "does not full-scan at scale."
+    # A literal 76k-row seed is infeasible in an async unit test, so this fast SQL-shape
+    # check is the first guard; the EXPLAIN test below is the stronger one — it asserts the
+    # planner can actually use the HNSW index (the real "does not full-scan" property).
     test "binds the target as a list param (HNSW-indexable), with no full-corpus self-join" do
       {tenant, _key} = setup_tenant_key()
       target = embedded(tenant.id, "T", [1.0, 0.0])
@@ -75,6 +76,42 @@ defmodule LoopctlWeb.KnowledgeSuggestLinksControllerTest do
       assert sql =~ "<=>"
       assert length(Regex.scan(~r/"articles"/, sql)) == 1
       assert sql =~ ~r/order by .*<=>/i
+    end
+
+    # The SQL-shape check above guards the self-join specifically; this guards the broader
+    # #172 regression CLASS — "the ORDER BY can use the HNSW index" — which a shape regex
+    # can't see. Disabling seq-scan AND sort forces the planner onto the only ordered path:
+    # if `ORDER BY embedding <=> $const` is index-matchable it satisfies it via
+    # `articles_embedding_idx` with NO Sort node; an index-INELIGIBLE rewrite (a self-join
+    # column operand like #170, a wrapped/computed order expr, or a dropped index) cannot,
+    # so the plan is forced to a (disabled-cost) Sort — failing this test. Catches a
+    # reintroduced full-corpus scan that every behavioral test (which seq-scans at test
+    # scale) would miss. Deterministic at any row count — asserts index ELIGIBILITY, not the
+    # planner's cost-based choice at scale.
+    test "EXPLAIN: the suggestion query is HNSW-index-eligible (no Sort / full-corpus scan)" do
+      {tenant, _key} = setup_tenant_key()
+      target = embedded(tenant.id, "Target", [1.0, 0.0])
+      for i <- 1..5, do: embedded(tenant.id, "C#{i}", [1.0, 0.0])
+
+      query =
+        Knowledge.suggestion_candidates_query(tenant.id, target.id, e([1.0, 0.0]), 0.5, 5, nil)
+
+      {sql, params} = SQL.to_sql(:all, AdminRepo, query)
+
+      {:ok, plan} =
+        AdminRepo.transaction(fn ->
+          # Force the planner past cost-based choices so the assertion reflects index
+          # ELIGIBILITY, not whether HNSW happens to win at 6 rows.
+          AdminRepo.query!("SET LOCAL enable_seqscan = off")
+          AdminRepo.query!("SET LOCAL enable_sort = off")
+          %{rows: rows} = AdminRepo.query!("EXPLAIN " <> sql, params)
+          Enum.map_join(rows, "\n", &Enum.join(&1, " "))
+        end)
+
+      # Uses the HNSW index for the ordering...
+      assert plan =~ "articles_embedding_idx"
+      # ...and therefore needs no Sort node (a full-corpus scan + sort would have one).
+      refute plan =~ ~r/\bSort\b/
     end
   end
 
@@ -151,13 +188,11 @@ defmodule LoopctlWeb.KnowledgeSuggestLinksControllerTest do
       assert free.id in ids(body)
     end
 
-    # #172 follow-up: the result must not under-fill below `limit` when the target's
-    # nearest neighbors are mostly already-linked. Links cluster among similar articles,
-    # so the anti-join removes exactly the closest candidates — pgvector iterative scan
-    # has to keep pulling neighbors until `limit` UNLINKED ones survive. (At test scale
-    # the planner seq-scans so this is exact regardless; the assertion guards the
-    # exclusion-under-limit contract that iterative scan preserves at prod scale.)
-    test "fills up to limit with unlinked candidates even when nearer ones are linked",
+    # Exclusion-under-limit contract: every already-linked near-neighbor is removed and
+    # none leaks through, and the result is filled from the remaining unlinked candidates
+    # rather than truncated by the anti-join. (Exact at test scale; the prod recall ceiling
+    # is documented on `suggest_links/3` — approximate-NN bounded by HNSW `ef_search`.)
+    test "excludes all already-linked near-neighbors and fills from the unlinked remainder",
          %{conn: conn} do
       {tenant, key} = setup_tenant_key()
       target = embedded(tenant.id, "Target", [1.0])

--- a/test/loopctl_web/controllers/knowledge_suggest_links_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_suggest_links_controller_test.exs
@@ -38,28 +38,43 @@ defmodule LoopctlWeb.KnowledgeSuggestLinksControllerTest do
 
   defp ids(body), do: Enum.map(body["data"], & &1["id"])
 
-  describe "suggestion query shape (#168 RED→GREEN structural guard)" do
-    # The production 500 couldn't be reproduced in the test DB (the column is
-    # vector(1536) and PostgrexTypes is shared across envs, so the stored-vector
-    # re-interpolation encodes fine locally). This guard instead asserts the QUERY
-    # SHAPE that caused it is gone: the target vector must NOT be a bound parameter,
-    # and the cosine must be computed between two embedding COLUMNS. Both assertions
-    # FAIL on the pre-fix query (which bound `^embedding::vector`) and PASS on the fix.
-    test "does not re-interpolate the target vector as a query parameter" do
+  describe "suggestion query shape (#168 + #172 RED→GREEN structural guard)" do
+    # Neither production 500 reproduces in the test DB: #168 (re-interpolating a stored
+    # %Pgvector{}) encodes fine locally, and #172 (a full-corpus scan + sort) only times
+    # out at prod scale (~76k published articles) — a handful of test rows never exhibit
+    # it. This guard asserts the QUERY SHAPE instead, catching BOTH regressions:
+    #
+    #   * #172: the target embedding is a BOUND list parameter and the `articles` table
+    #     appears EXACTLY ONCE — there is no self-join to read the target vector as a
+    #     column. The bound-`^param` left-vs-const form is what the HNSW index
+    #     (`articles_embedding_idx`, vector_cosine_ops) accelerates; the old self-join
+    #     forced a per-row cosine + full sort over the whole corpus.
+    #   * #168: that bound param is a plain LIST of floats, NEVER the stored `%Pgvector{}`
+    #     struct (binding the struct was the original 500).
+    #
+    # A literal 76k-row seed is infeasible in an async unit test, so the indexable
+    # SQL shape is the durable, non-flaky proxy for "does not full-scan at scale."
+    test "binds the target as a list param (HNSW-indexable), with no full-corpus self-join" do
       {tenant, _key} = setup_tenant_key()
       target = embedded(tenant.id, "T", [1.0, 0.0])
 
-      query = Knowledge.suggestion_candidates_query(tenant.id, target.id, 0.5, 5, nil)
+      query =
+        Knowledge.suggestion_candidates_query(tenant.id, target.id, e([1.0, 0.0]), 0.5, 5, nil)
+
       {sql, params} = SQL.to_sql(:all, AdminRepo, query)
 
-      # No parameter is a vector/list — only ids, threshold, limit. The #168 bug
-      # bound the stored target vector here.
-      refute Enum.any?(params, fn p -> is_list(p) or match?(%Pgvector{}, p) end)
+      # #172: the target vector is a BOUND parameter (a list), enabling the indexable
+      # `ORDER BY embedding <=> $const LIMIT k` form.
+      assert Enum.any?(params, &is_list/1)
 
-      # The distance is computed between two `embedding` COLUMNS (the candidate's and
-      # the self-joined target's) — not a column vs a parameter.
+      # #168: that param is a plain list, NEVER the stored %Pgvector{} struct.
+      refute Enum.any?(params, &match?(%Pgvector{}, &1))
+
+      # #172: exactly one `articles` table reference — no self-join driving a
+      # full-corpus scan. (The only other table is the `article_links` exclusion join.)
       assert sql =~ "<=>"
-      assert length(Regex.scan(~r/\."embedding"/, sql)) >= 2
+      assert length(Regex.scan(~r/"articles"/, sql)) == 1
+      assert sql =~ ~r/order by .*<=>/i
     end
   end
 


### PR DESCRIPTION
## Summary

Fixes #172 — `GET /api/v1/knowledge/articles/:id/suggested_links` still 500'd in prod after #170.

**Root cause (corrected from #170):** #170 removed the `%Pgvector{}` re-interpolation (the original #168 500) but rewrote the query to a column-to-column **self-join** that read the target vector as a *column* (`a.embedding <=> t.embedding`). A column right-operand can't use the HNSW index, so the query did a per-row cosine + full `ORDER BY ... <=>` sort over **every** published-embedded article. Negligible on a handful of test rows; at prod scale (~76k articles) it exceeds the statement timeout → generic 500 on 100% of calls.

**Fix:** pass the already-fetched target embedding as a **bound `[float()]` list param** — the exact shape `search_semantic` and `distant_pairs` ship in production. `ORDER BY embedding <=> $const LIMIT k` is the HNSW-indexable form (`articles_embedding_idx`, `vector_cosine_ops`), so the planner does an approximate-NN index scan instead of a full-corpus sort. Converting the stored `%Pgvector{}` to a plain list (not binding the struct) keeps the #168 fix intact.

The query stays a **bare `AdminRepo.all`** — no transaction, matching `search_semantic`/`distant_pairs`, which deliberately avoid holding one of the 3 `AdminRepo` connections (see the `distant_pairs` pool-starvation note in the same module).

## Enhanced review (team + adversarial, Opus)

Both rounds ran; every agent claim was independently verified against the code/tests.

- **Round 1 (team):** flagged that a single HNSW `ef_search` batch could let the already-linked anti-join under-fill the result below `limit`. An initial fix added `SET LOCAL hnsw.iterative_scan` in a transaction.
- **Round 2 (adversarial):** three independent reviewers (security, architect, skeptical-BA) converged that the transaction wrapper was **worse than the bug it fixed** — pool starvation on the 3-connection admin pool (the hottest knowledge endpoint), a 20k-tuple `max_scan_tuples` walk on the common sparse-article case, and a new `SET LOCAL` failure surface. **Resolution: reverted it.** The under-fill it targeted is by-design and identical to the production-proven `search_semantic` (architect-rated LOW in both rounds; negligible at the default limit 5 vs `ef_search` 40), now documented honestly on `suggest_links/3`.
- Disproven adversarial attacks (verified empirically, not fixed): MatchError on the transaction result (raises propagate; only `rollback` yields `{:error}`); "version-skew 500" (Postgres treats two-part GUC names as placeholders → graceful no-op). Both moot after the revert.

## Tests

- **EXPLAIN index-eligibility guard** (the issue's "test that exhibits scale" ask): with seq-scan and sort disabled, the plan *must* satisfy the ORDER BY via `articles_embedding_idx` with no Sort node — catches the broad "reintroduced full-corpus scan" regression class (self-join column-operand, wrapped order expr, dropped index) that a small-data behavioral test can't, deterministically at any row count.
- Structural SQL-shape guard (bound list param, single `articles` table, no self-join).
- Behavioral ACs: 200 + ranked candidates; excludes self + already-linked (either direction); honors `threshold`/`limit`; exclusion-under-limit (linked near-neighbors excluded, result filled from the unlinked remainder); published-only; tenant isolation; read-only.

Gate: `compile --warnings-as-errors`, `format`, `credo --strict`, `dialyzer`, 2532 tests — all green.

## Post-deploy verification (operator gate before marking #172 fully verified)

The prod-only 500 can't be reproduced at test scale, so before closing #172 as verified-in-prod, on the deployed build: hit the 5 repro ids from the issue and confirm 200 + ranked candidates, and (optionally) capture a prod `EXPLAIN ANALYZE` showing the index scan. These need production access and are not deferrals of any code change.

Closes #172
