### PR TITLE
Fix #172 for real: subquery filter-after-ANN (planner now uses the HNSW index at scale)

### DIFF
--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -2880,51 +2880,72 @@ defmodule Loopctl.Knowledge do
   # Builds the suggested-links candidate query (returned, not executed) so a test can
   # assert its SQL shape. Public-but-`@doc false` for that structural regression guard.
   #
-  # Ranks candidates by cosine similarity to the target. The target embedding (already
-  # fetched by the caller, `fetch_article_embedding`) is passed as a BOUND `^param`
-  # LIST of floats — exactly the form `search_semantic` ships in production. This is the
-  # HNSW-indexable shape `ORDER BY embedding <=> $const LIMIT k`
-  # (`articles_embedding_idx`, vector_cosine_ops), so the planner does an approximate-NN
-  # index scan instead of a per-row cosine + full sort over every published article.
+  # SHAPE IS LOAD-BEARING (verified with EXPLAIN against the ~76k-row prod corpus):
+  # pgvector's HNSW index (cosine) only accelerates a PURE `ORDER BY embedding <=> $const
+  # LIMIT k`. Adding the already-linked anti-join (a JOIN) OR a distance filter
+  # (`... <=> ... > threshold`) to that same query makes the planner abandon the index and
+  # Seq-Scan the entire corpus + Sort — the #172 / #170 production 500 (cost ~57k vs ~880).
   #
-  # Two regressions are deliberately avoided here:
-  #   * #168 — NEVER bind the *stored* `%Pgvector{}` struct as a param (that
-  #     re-interpolation was the original 500). We convert it to a plain list first
-  #     (`to_embedding_list/1`), the same value shape `search_semantic` binds.
-  #   * #172 — NEVER self-join `articles` to read the target vector as a *column*
-  #     (`a.embedding <=> t.embedding`). A column right-operand defeats the HNSW index
-  #     and forces a full-corpus scan + sort, which timed out at prod scale (~76k
-  #     published articles) → 500. The bound `^param` left-vs-const form is indexable.
+  # So this is split in two:
+  #   * INNER subquery — the pure top-`pool` nearest by cosine. Only index-safe filters
+  #     here (tenant, status, not-null, not-self, visibility — all verified to keep the
+  #     index). The target is a BOUND `^param` LIST of floats (`to_embedding_list/1`),
+  #     never the stored `%Pgvector{}` struct (that re-interpolation was the #168 500).
+  #   * OUTER query — applies the already-linked anti-join + the `similarity_score >
+  #     threshold` floor + the final `limit`, over just `pool` rows (cheap).
   #
-  # The caller has already confirmed the target exists / is published / is embedded /
-  # is visible. Bounded by `status`, `limit`, and a 15s timeout (matching the other
-  # vector paths, `nearest_prior_distance`/`distant_pairs`).
+  # `pool` over-fetches well beyond `limit` so the outer exclusions rarely starve the
+  # result; effective recall is additionally bounded by `hnsw.ef_search` (default 40),
+  # consistent with the `search_semantic` path. The caller has already confirmed the
+  # target exists / is published / is embedded / is visible.
   @doc false
   def suggestion_candidates_query(tenant_id, article_id, embedding, threshold, limit, vis) do
     target = to_embedding_list(embedding)
+    pool = suggestion_candidate_pool(limit)
 
-    from(a in Article,
-      where: a.tenant_id == ^tenant_id and a.status == :published,
-      where: not is_nil(a.embedding),
-      where: a.id != ^article_id,
+    candidates =
+      from(a in Article,
+        where: a.tenant_id == ^tenant_id and a.status == :published,
+        where: not is_nil(a.embedding),
+        where: a.id != ^article_id,
+        order_by: [asc: fragment("? <=> ?", a.embedding, ^target)],
+        limit: ^pool,
+        select: %{
+          id: a.id,
+          title: a.title,
+          category: a.category,
+          similarity_score: fragment("GREATEST(0, 1 - (? <=> ?))", a.embedding, ^target)
+        }
+      )
+      |> maybe_filter_by_visibility(vis)
+
+    from(c in subquery(candidates),
       # Exclude any article already linked to the target (either direction, any type).
       left_join: l in ArticleLink,
       on:
         l.tenant_id == ^tenant_id and
-          ((l.source_article_id == ^article_id and l.target_article_id == a.id) or
-             (l.target_article_id == ^article_id and l.source_article_id == a.id)),
+          ((l.source_article_id == ^article_id and l.target_article_id == c.id) or
+             (l.target_article_id == ^article_id and l.source_article_id == c.id)),
       where: is_nil(l.id),
-      where: fragment("GREATEST(0, 1 - (? <=> ?)) > ?", a.embedding, ^target, ^threshold),
-      order_by: [asc: fragment("? <=> ?", a.embedding, ^target)],
+      where: c.similarity_score > ^threshold,
+      order_by: [desc: c.similarity_score],
       limit: ^limit,
       select: %{
-        id: a.id,
-        title: a.title,
-        category: a.category,
-        similarity_score: fragment("GREATEST(0, 1 - (? <=> ?))", a.embedding, ^target)
+        id: c.id,
+        title: c.title,
+        category: c.category,
+        similarity_score: c.similarity_score
       }
     )
-    |> maybe_filter_by_visibility(vis)
+  end
+
+  # Over-fetch factor for the inner ANN subquery: pull this many nearest candidates from
+  # the HNSW index before the outer query applies the anti-join + threshold and trims to
+  # `limit`. Scales with `limit` (headroom for exclusions), floored for the common small
+  # `limit`, and capped so the index scan stays cheap.
+  defp suggestion_candidate_pool(limit) do
+    max(limit * 5, 100)
+    |> min(Application.get_env(:loopctl, :max_suggestion_candidate_pool, 500))
   end
 
   # The HNSW-indexable cosine form binds the target as a plain `[float()]` list (the

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -2805,13 +2805,18 @@ defmodule Loopctl.Knowledge do
   `:suggestion_similarity_threshold` config or 0.5) and `:limit` (default
   #{@default_suggestion_limit}), ordered most-similar first. Tenant-scoped.
 
-  Ranking is approximate nearest-neighbor over the HNSW embedding index
-  (`articles_embedding_idx`, cosine), bounded by the index search list
-  (`hnsw.ef_search`) exactly like the semantic-search path. In the rare case
-  that an article's nearest neighbors are almost all already linked, the result
-  may contain fewer than `:limit` suggestions — by design, consistent with
-  semantic search; deeper recall is intentionally not traded for holding an
-  AdminRepo connection on this hot, pool-constrained endpoint.
+  Ranking is approximate nearest-neighbor over the HNSW embedding index, like the
+  semantic-search path. Mechanically: the query pulls the nearest *candidate pool*
+  (≈ `limit × 5`, min 100) via the index, then excludes the article's already-linked
+  neighbors and any below-`threshold` and returns the top `:limit`. The
+  already-linked exclusion is applied to that pool — NOT the whole corpus — because
+  pushing the exclusion (or the distance floor) into the index scan defeats the HNSW
+  index and forces a full-corpus Seq Scan (the #170/#172 prod 500; EXPLAIN-verified).
+  Consequence: for a densely-linked "hub" whose nearest neighbors are almost all
+  already linked, the result may contain fewer than `:limit` suggestions (or be
+  empty) even though more-distant unlinked candidates exist — by design, the price of
+  the indexed path. Recall is additionally bounded by `hnsw.ef_search`, as in
+  semantic search.
 
   ## Returns
 
@@ -2946,6 +2951,9 @@ defmodule Loopctl.Knowledge do
   defp suggestion_candidate_pool(limit) do
     max(limit * 5, 100)
     |> min(Application.get_env(:loopctl, :max_suggestion_candidate_pool, 500))
+    # Never let a misconfigured cap drop the pool below `limit` — that would truncate the
+    # candidate set before the outer exclusions even run.
+    |> max(limit)
   end
 
   # The HNSW-indexable cosine form binds the target as a plain `[float()]` list (the

--- a/lib/loopctl_web/controllers/knowledge_suggest_links_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_suggest_links_controller.ex
@@ -33,7 +33,11 @@ defmodule LoopctlWeb.KnowledgeSuggestLinksController do
         "`{id, title, category, similarity_score}`, highest similarity first — POST " <>
         "the one you want as a **typed** link (relates_to/derived_from/contradicts/" <>
         "supersedes) via the article_links API. `threshold` (0–1, default 0.5) is the " <>
-        "cosine floor; `limit` (default 5) caps results. Role: agent+.",
+        "cosine floor; `limit` (default 5) caps results. Suggestions are approximate-NN " <>
+        "over the embedding index: exclusions (already-linked / below-threshold) are " <>
+        "applied to the nearest candidate pool, so a densely-linked article may return " <>
+        "fewer than `limit` (or none) even if more-distant unlinked articles exist. " <>
+        "Role: agent+.",
     parameters: [
       id: [in: :path, type: :string, description: "Article UUID"],
       limit: [in: :query, type: :integer, description: "Max candidates (default 5)"],

--- a/test/loopctl_web/controllers/knowledge_suggest_links_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_suggest_links_controller_test.exs
@@ -113,8 +113,11 @@ defmodule LoopctlWeb.KnowledgeSuggestLinksControllerTest do
           Enum.map_join(rows, "\n", &Enum.join(&1, " "))
         end)
 
-      # The corpus is read through the HNSW index...
-      assert plan =~ "articles_embedding_idx"
+      # The corpus is read through the HNSW index as an INDEX SCAN for the ordering
+      # (not merely the index name appearing somewhere). Tolerates the index-name drift
+      # between envs (`articles_embedding_idx` in test, `articles_embedding_hnsw_idx` in
+      # prod) — both are the HNSW cosine index.
+      assert plan =~ ~r/Index Scan using articles_embedding(_hnsw)?_idx/
       # ...never a full-corpus Seq Scan (the #170/#172 production 500).
       refute plan =~ ~r/Seq Scan on articles\b/i
     end

--- a/test/loopctl_web/controllers/knowledge_suggest_links_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_suggest_links_controller_test.exs
@@ -79,16 +79,20 @@ defmodule LoopctlWeb.KnowledgeSuggestLinksControllerTest do
     end
 
     # The SQL-shape check above guards the self-join specifically; this guards the broader
-    # #172 regression CLASS — "the ORDER BY can use the HNSW index" — which a shape regex
-    # can't see. Disabling seq-scan AND sort forces the planner onto the only ordered path:
-    # if `ORDER BY embedding <=> $const` is index-matchable it satisfies it via
-    # `articles_embedding_idx` with NO Sort node; an index-INELIGIBLE rewrite (a self-join
-    # column operand like #170, a wrapped/computed order expr, or a dropped index) cannot,
-    # so the plan is forced to a (disabled-cost) Sort — failing this test. Catches a
-    # reintroduced full-corpus scan that every behavioral test (which seq-scans at test
-    # scale) would miss. Deterministic at any row count — asserts index ELIGIBILITY, not the
-    # planner's cost-based choice at scale.
-    test "EXPLAIN: the suggestion query is HNSW-index-eligible (no Sort / full-corpus scan)" do
+    # #172 regression CLASS — "the corpus is reached through the HNSW index, never a full
+    # Seq Scan + Sort" — which a shape regex can't see. This is THE bug that shipped twice
+    # (#170, then the first #172 attempt): both passed every behavioral test because at test
+    # scale the planner seq-scans 6 rows happily; only at prod scale (~76k rows) does the
+    # Seq Scan + Sort blow the statement timeout. Verified against the real prod corpus,
+    # the fix is a subquery: the inner ANN (`ORDER BY embedding <=> $const LIMIT pool`) uses
+    # `articles_embedding_idx`; the anti-join + threshold live in the OUTER query (each
+    # would defeat the index if pushed inside). With seq-scan disabled the planner must
+    # reach `articles` via that index — so the plan names the HNSW index and contains NO
+    # `Seq Scan on articles`. (An outer Sort over the small candidate pool is expected and
+    # fine — it is NOT a full-corpus sort.) An index-defeating rewrite (anti-join/threshold
+    # back inside, a self-join column operand, a dropped index) reintroduces `Seq Scan on
+    # articles`, failing this. Deterministic at any row count.
+    test "EXPLAIN: corpus reached via the HNSW index, never a full Seq Scan on articles" do
       {tenant, _key} = setup_tenant_key()
       target = embedded(tenant.id, "Target", [1.0, 0.0])
       for i <- 1..5, do: embedded(tenant.id, "C#{i}", [1.0, 0.0])
@@ -100,18 +104,19 @@ defmodule LoopctlWeb.KnowledgeSuggestLinksControllerTest do
 
       {:ok, plan} =
         AdminRepo.transaction(fn ->
-          # Force the planner past cost-based choices so the assertion reflects index
-          # ELIGIBILITY, not whether HNSW happens to win at 6 rows.
+          # Disable seq-scan AND sort so the inner ANN must reach `articles` through the
+          # HNSW index — reflecting whether it CAN, not whether HNSW wins the cost model at
+          # 6 rows. (The outer sort over the small candidate pool is unaffected/expected.)
           AdminRepo.query!("SET LOCAL enable_seqscan = off")
           AdminRepo.query!("SET LOCAL enable_sort = off")
           %{rows: rows} = AdminRepo.query!("EXPLAIN " <> sql, params)
           Enum.map_join(rows, "\n", &Enum.join(&1, " "))
         end)
 
-      # Uses the HNSW index for the ordering...
+      # The corpus is read through the HNSW index...
       assert plan =~ "articles_embedding_idx"
-      # ...and therefore needs no Sort node (a full-corpus scan + sort would have one).
-      refute plan =~ ~r/\bSort\b/
+      # ...never a full-corpus Seq Scan (the #170/#172 production 500).
+      refute plan =~ ~r/Seq Scan on articles\b/i
     end
   end
 


### PR DESCRIPTION
## Summary

The merged #172 fix (`089d592`) **was deployed and still 500'd in production** — I verified this against the live system rather than trusting the green CI:

- `fly logs`: `ERROR 57014 (query_canceled) "canceling statement"` in `suggest_links/3`, firing *after* the deploy.
- `EXPLAIN` on the real ~76k-row corpus: **`Seq Scan on articles` + Sort, cost ~57,000** — the HNSW index was never chosen. The prior EXPLAIN test only proved index *eligibility* (a forced plan with sort disabled), never that the planner *picks* the index at scale. That gap is exactly what the skeptical-BA reviewer flagged and I closed #172 without prod verification. Owned.

**Root cause (EXPLAIN-verified on prod):** pgvector's HNSW index only accelerates a *pure* `ORDER BY embedding <=> $const LIMIT k`. The already-linked anti-join (a JOIN) **and** the `> threshold` distance filter, in the same query, make the planner abandon the index and full-scan. (`search_semantic` has neither — that's why it's fast.) Confirmed by isolating each: anti-join alone → Seq Scan (cost 105k); threshold alone → Seq Scan; pure ANN → `Index Scan using articles_embedding_hnsw_idx` (cost 742).

## Fix

Split into a subquery (the standard pgvector filter-after-ANN pattern, already used by `do_distant_pairs`):
- **INNER**: pure top-`pool` nearest by cosine — only index-safe filters (tenant / status / not-null / not-self / visibility, each EXPLAIN-verified on prod to keep the index).
- **OUTER**: the anti-join + threshold + final `limit`, over just `pool` rows.

**Verified on the real prod corpus, including the agent visibility filter (the actual failing path): `EXPLAIN ANALYZE` = 73 ms, `Index Scan using articles_embedding_hnsw_idx`, no Seq Scan on articles.**

`pool = max(limit×5, 100)` capped 500, floored at `limit`.

## Enhanced review (team round 1 already in branch history; focused adversarial round 2 here)

Security + engineer (Opus), every claim verified against code/prod:
- Sound: tenant isolation, visibility (filter forced onto the inner subquery), bidirectional anti-join, ordering, DoS bounds — all disproven as attacks.
- **Recall change (documented):** exclusions now apply to the candidate pool, not the whole corpus, so a densely-linked hub may return fewer than `limit`. The alternative (anti-join inside the index scan) is **prod-disproven** (Seq Scan, cost 105k) — the ceiling is intrinsic to the indexed path. Documented on `suggest_links/3` + the OpenAPI description.
- Pool floored at `limit` (operator-misconfig hardening); EXPLAIN guard strengthened to require an actual `Index Scan using` the HNSW index.

## Test that would have caught this

The EXPLAIN guard now asserts the corpus is reached via an `Index Scan using articles_embedding(_hnsw)?_idx` with **no `Seq Scan on articles`** (an outer sort over the small pool is expected) — the invariant that both #170 and the first #172 attempt violated. (Caveat: small-DB CI still can't reproduce the planner's *cost-based* choice at 76k rows — see the architectural note below.)

## Notes for the operator

- **Migration drift:** prod's index is `articles_embedding_hnsw_idx`, but migration `20260410022906` creates `articles_embedding_idx`. Both are HNSW cosine; the query uses whichever exists. Worth reconciling.
- **Verification gap:** this class of bug (planner choice at scale) is invisible to the test suite. The durable fix is a scale-representative test/staging env + surfacing the real SQLSTATE instead of a generic 500 — proposed as a follow-up architectural track.

Gate: compile --warnings-as-errors, format, credo --strict, dialyzer, 2532 tests — all green.

Fixes #172
