### PR TITLE
docs: Epic 27 (knowledge scale hardening) user stories — #175 + #176

### DIFF
--- a/docs/user_stories/epic_27_knowledge_scale_hardening/README.md
+++ b/docs/user_stories/epic_27_knowledge_scale_hardening/README.md
@@ -1,0 +1,70 @@
+# Epic 27 — Knowledge Subsystem Performance & Scale Hardening
+
+Decomposition of GitHub Epic **#175** (+ export issue **#176**) into 20 user stories.
+Authored with the `user-story-writer` skill and refined through **two rounds of multi-agent
+enhanced review** (Opus analyst / architect / adversarial), every finding verified against the
+live code.
+
+## How to implement (autonomous, zero manual intervention until the end)
+
+```
+/implement-plan --epic docs/user_stories/epic_27_knowledge_scale_hardening
+```
+
+Epic mode reads these story JSONs, **topologically sorts by each story's `dependencies`**, and drives
+each through an un-skippable cycle: implement → 7-agent enhanced review → zero-deferrals fix →
+`mix precommit` gate → CI-gated squash-merge → next. WIP=1, dependency-blocked. **No separate plan
+doc is needed** — this folder is the input.
+
+### Quality gates — none are sacrificed; scale/prod verification is deferred to the end
+
+Gates split into two kinds:
+
+| Gate | When it runs | Automatable mid-loop? |
+|------|--------------|-----------------------|
+| `mix precommit` (async unit suite) | every story | ✅ yes (the loop's merge gate) |
+| 7-agent enhanced review + zero-deferral fix | every story | ✅ yes |
+| CI checks (Lint/Security/Dialyzer/Test/GitGuardian) | every PR | ✅ yes |
+| `@tag :scale` suite (committed ~80k corpus) | **terminal story US-27.17** | ⛔ excluded from `mix precommit` |
+| Prod live-build verification (fly EXPLAIN / repro ids / logs) | **terminal story US-27.17** | ⛔ needs the deployed build |
+
+The `@tag :scale` tests and the prod checks are **excluded from `mix precommit` by design**, so the
+loop never blocks on them — every implementation story (27.1–27.16) merges on code + unit + review +
+CI. The deferred verification is **owned and executed by US-27.17**, which runs DEAD LAST (it depends
+on every leaf story): it seeds the ~80k corpus, runs the whole `@tag :scale` suite epic-wide,
+remediates any scale failure, and runs the prod EXPLAIN/repro-id/log checks **autonomously via the
+authenticated `fly` CLI** (the proven #172 method). The operator's only involvement is **reviewing the
+final report** — never a mid-stream gate.
+
+> Alternative (heavier, per-PR scale enforcement): wire the scale suite into CI as a job and run with
+> `--gate "mix precommit && SCALE_TESTS=1 mix test --only scale"`. Costs an ~80k seed per PR; the
+> US-27.17 terminal model is the lighter, autonomy-first default.
+
+### Before launching — one thing to confirm
+
+The WIP=1 loop auto-merges each PR once CI is green. It only **stalls** if the base branch
+(`master`) requires a **human PR approval** (`required_approving_review_count > 0`). loopctl's
+`master` has required *checks* but not required *approvals* (PRs this session merged without human
+approval), so the loop should run unattended. If that changes, pass `--auto` and expect a per-PR
+approval, or relax the approval requirement.
+
+## Topological build order (what the loop will follow)
+
+```
+27.14 → 27.1 → 27.3 → 27.11 → 27.2 → 27.12 → 27.4 → 27.9a → 27.6a → 27.5 →
+27.10 → 27.16 → 27.9b → 27.7b → 27.6b → 27.7a → 27.15 → 27.8 → 27.13 → 27.17
+```
+(Note: dependency order, not numeric — e.g. 27.11 is built before 27.4 because 27.4's
+statement_timeout mechanism depends on the pool work.)
+
+## Stories by theme
+
+- **Theme 1 — scale testing + observability:** 27.1 fixture · 27.2 plan-assertion (real query, no forced planner) · 27.3 SQLSTATE→structured errors · 27.4 statement_timeout + slow-query log · 27.5 staging gate + prod runbook
+- **Theme 2 — index-correct vector layer:** 27.6a/6b kNN helper + recall/under-fill · 27.7a/7b migrate (and the `distant_pairs`/`novelty` non-fits) · 27.8 per-endpoint index + latency gates
+- **Theme 3 — cursor pagination:** 27.9a/9b keyset + integrity + rollout · 27.10 cursor contract + bounded `include_body`
+- **Theme 4 — pool + bulk:** 27.11 pool sizing / heavy-read pool · 27.12 set-based bulk (FK-`:restrict`-correct, atomic, bounded)
+- **Cross-cutting:** 27.13 remediation · 27.14 HNSW index-name reconcile (decided) · 27.15 telemetry/alerting · 27.16 streamed export (#176) · **27.17 terminal scale + prod verification**
+
+Grounding incidents across the set: the 4-attempt `suggested_links` saga, the `enable_seqscan=off`
+false-confidence trap, the 3-conn pool starvation, the ~4,000-DELETE cleanup, the 5,000-article
+export cap. Tenant-isolation ACs on every BYPASSRLS path; prod-verification consolidated in US-27.17.

--- a/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.1.json
+++ b/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.1.json
@@ -1,0 +1,144 @@
+{
+  "id": "US-27.1",
+  "title": "Large-corpus scale fixture (committed, ANALYZEd, ≥ prod size) for representative testing",
+  "epic": {
+    "id": "epic_27",
+    "name": "Knowledge Subsystem Performance & Scale Hardening"
+  },
+  "priority": "high",
+  "phase": "scale_observability",
+  "background": {
+    "reference": "GitHub Epic #175, Theme 1; incident: suggested_links #168→#170→#172→#173 (4 attempts)",
+    "includes": "The prod KB has ~76k published articles with vector(1536) embeddings + an HNSW cosine index. The test DB holds a handful of rows, so the planner never makes the cost-based choices (HNSW index vs Seq Scan) that only appear at scale. Three CI-green, enhanced-reviewed fixes shipped broken because of this gap."
+  },
+  "priority_note": "Theme 1 first: without reproduce-at-scale, every later perf story is a blind guess. Unblocks US-27.2 and the Theme 2 index guards.",
+  "story": {
+    "as_a": "loopctl platform engineer",
+    "i_want_to": "seed a representative large corpus (default ≥ current prod published-article count, with embeddings and inter-article links) as a COMMITTED dataset (not inside the rolled-back async sandbox), with ANALYZE run so the planner has real statistics",
+    "so_that": "vector and enumeration endpoints can be exercised on data large enough — and statistically fresh enough — that the query planner behaves as it does in production, instead of passing on a 6-row sandbox table that can never reproduce a full-scan timeout"
+  },
+  "rationale": "The root cause of the four-attempt suggested_links saga was a non-representative test environment: a fix is proven on a toy DB, ships 'green', and the real prod planner behavior is invisible until the live endpoint is hit. A reusable, committed, ANALYZEd large-corpus fixture makes scale-dependent regressions reproducible in an automated gate, which is the precondition for honestly verifying every other story in this epic.",
+  "acceptance_criteria": [
+    {
+      "id": "AC-27.1.1",
+      "description": "A seeding helper (Loopctl.Knowledge.ScaleSeed.seed/2 and/or a `mix loopctl.seed_scale` task) inserts a configurable N published articles for a tenant_id, each with a non-null vector(1536) embedding, using AdminRepo.insert_all in batches (e.g. 1_000/batch) so seeding the default N completes within a documented budget (target < 3 min on CI hardware).",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.1.2",
+      "description": "Seeded embeddings are deterministic from the row index (e.g. a phash2-seeded float list, L2-normalized) so runs are reproducible without Math.random/Date.now, AND spread across the vector space so cosine ordering is meaningful (vector for index i differs from i+1).",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.1.3",
+      "description": "The helper seeds inter-article links (article_links) at a configurable density (default ~5 links/article among nearest neighbors) so the already-linked anti-join path and 'densely-linked hub' recall behavior are exercised at scale.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.1.4",
+      "description": "Seeding COMMITS its rows (it does NOT run inside the DataCase async sandbox transaction, which would roll back and leave the planner seeing 0 rows). The scale-seed path runs against a dedicated DB with async: false; an explicit guard/comment prevents accidental use inside the sandbox.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.1.5",
+      "description": "After bulk insert, the helper runs `ANALYZE articles` (and article_links) and BLOCKS until complete, then verifies pg_stat_user_tables.n_live_tup/last_analyze for articles reflects the seeded corpus — so no plan assertion ever runs against stale (n≈0) statistics (a false RED/GREEN source).",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.1.6",
+      "description": "The default seed count for the scale gate is pinned to ≥ the current prod published-article count (recorded as a dated constant, e.g. PROD_ARTICLE_FLOOR with the date/source), and the gate fails loudly if asked to assert at a seed count below that floor. A documented step bumps the floor as prod grows.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.1.7",
+      "description": "The HNSW index is detected by capability (querying pg_indexes for an HNSW index on articles.embedding, e.g. via amname='hnsw'), NOT by a hard-coded name — tolerating the prod/migration name drift (articles_embedding_hnsw_idx vs articles_embedding_idx). Seeding asserts an HNSW index is present before scale assertions are meaningful.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.1.8",
+      "description": "Scale seeding is OPT-IN and tagged (e.g. @tag :scale / SCALE_TESTS env) so the default async unit suite is untouched; the large corpus is never created in a normal `mix test` run. Teardown is documented.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.1.9",
+      "description": "Tenant isolation: the seed inserts only under the given tenant_id, sets tenant_id programmatically (never via cast), and a second tenant seeded in the same DB remains isolated (tenant A's corpus is invisible to tenant B).",
+      "status": "pending"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "TC-27.1.1",
+      "name": "Seeds the requested number of embedded published articles, committed and analyzed",
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant)"
+      ],
+      "steps": [
+        "Loopctl.Knowledge.ScaleSeed.seed(tenant.id, count: 1_000) on the dedicated (non-sandbox) DB"
+      ],
+      "expected_results": [
+        "AdminRepo count of published embedded articles for tenant.id == 1_000",
+        "All embeddings dimension 1536",
+        "pg_stat_user_tables shows articles analyzed with n_live_tup reflecting the rows"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.1.2",
+      "name": "Seeded links connect near-neighbors at the configured density",
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant)",
+        "Loopctl.Knowledge.ScaleSeed.seed(tenant.id, count: 500, link_density: 3)"
+      ],
+      "steps": [
+        "Aggregate count of article_links for tenant.id"
+      ],
+      "expected_results": [
+        "~500*3 links (within tolerance); every link's source and target belong to tenant.id"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.1.3",
+      "name": "Asserting below the prod floor fails loudly",
+      "type": "integration",
+      "preconditions": [
+        "PROD_ARTICLE_FLOOR pinned (e.g. 80_000)"
+      ],
+      "steps": [
+        "Invoke the scale gate configured to seed fewer than the floor"
+      ],
+      "expected_results": [
+        "It raises/fails with a clear 'seed below prod floor' error rather than silently asserting on an under-scale corpus"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.1.4",
+      "name": "Scale seed is tenant-isolated and deterministic",
+      "type": "integration",
+      "preconditions": [
+        "tenant_a, tenant_b; seed tenant_a count: 200"
+      ],
+      "steps": [
+        "Count tenant_b embedded articles; regenerate the vector for index 5 twice"
+      ],
+      "expected_results": [
+        "tenant_b has 0; tenant_a has 200; index-5 vector identical across calls; differs from index-6"
+      ],
+      "status": "pending"
+    }
+  ],
+  "technical_notes": [
+    "Helper: Loopctl.Knowledge.ScaleSeed (test/support) + optional `mix loopctl.seed_scale`.",
+    "CRITICAL FOOT-GUN: ANALYZE needs committed rows. DataCase (async: true) wraps each test in a rolled-back transaction, so insert_all + ANALYZE there is defeated. Scale seed must run async: false against a dedicated DB and COMMIT.",
+    "Bulk insert via AdminRepo.insert_all in batches; never per-row. inserted_at is utc_datetime_usec and a batch shares one timestamp — relevant to US-27.9's (inserted_at, id) keyset.",
+    "Deterministic vectors from row index (phash2 → float list → L2-normalize); no Math.random/Date.now.",
+    "Index detection by capability: SELECT indexname FROM pg_indexes ... or join pg_am amname='hnsw'; do NOT hard-code a name (prod drift).",
+    "PROD_ARTICLE_FLOOR: a dated constant (~80k as of 2026-06); raise as prod grows. Tie to US-27.8 AC for gate calibration.",
+    "tenant_id set programmatically on every row, never cast."
+  ],
+  "dependencies": [],
+  "estimated_hours": 14
+}

--- a/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.10.json
+++ b/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.10.json
@@ -1,0 +1,110 @@
+{
+  "id": "US-27.10",
+  "title": "Document the cursor contract in meta + bounded opt-in include_body",
+  "epic": {
+    "id": "epic_27",
+    "name": "Knowledge Subsystem Performance & Scale Hardening"
+  },
+  "priority": "medium",
+  "phase": "pagination",
+  "background": {
+    "reference": "GitHub Epic #175, Theme 3; #166 body-less default; ChunkedEncodingError on large full-body pages",
+    "includes": "Full-body list responses produced 100KB+ payloads and ChunkedEncodingError; #166 made body-less the default. The cursor contract must be self-describing so agents can consume it without out-of-band knowledge."
+  },
+  "priority_note": "Completes Theme 3's acceptance ('meta documents the cursor contract') and prevents the large-payload streaming failures from returning via an unbounded include_body.",
+  "story": {
+    "as_a": "an agent consuming knowledge enumeration responses",
+    "i_want_to": "the response meta to fully describe the pagination contract (next_cursor, has_more, effective limit) and to be able to opt into article bodies only within a bounded, safe page size",
+    "so_that": "I can drive pagination purely from the response (no guessing) and never trigger a 100KB+ streaming failure by accidentally requesting full bodies for a large page"
+  },
+  "rationale": "An opaque cursor is only usable if the response tells the consumer how to use it; self-describing meta is what makes agent-native iteration robust. Equally, include_body must be bounded so the body-less-default win from #166 can't be undone by a caller requesting bodies for thousands of rows and reproducing the ChunkedEncodingError — the limit and the contract together make enumeration both consumable and safe at scale.",
+  "acceptance_criteria": [
+    {
+      "id": "AC-27.10.1",
+      "description": "Enumeration responses include a meta block documenting the cursor contract: next_cursor (string|null), has_more (bool), limit (effective), and (where meaningful) count for the current page; the field semantics are documented in the OpenAPI spec.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.10.2",
+      "description": "Body-less remains the default (per #166). include_body=true is opt-in and honored ONLY for limit <= 25 (a pinned constant @max_include_body_page); limit > 25 with include_body=true returns 400, never a silent 100KB+ chunked response. (Test: limit 25 + include_body passes, limit 26 + include_body returns 400.)",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.10.3",
+      "description": "With include_body=false (default) the response carries no article body fields, keeping payloads small and avoiding the ChunkedEncodingError class.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.10.4",
+      "description": "The OpenApiSpex schema for the enumeration endpoints reflects next_cursor/has_more/limit and the include_body bound, so the contract is discoverable via the API docs.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.10.5",
+      "description": "Tenant isolation and visibility scoping are unaffected; include_body never exposes a body the caller could not already read.",
+      "status": "pending"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "TC-27.10.1",
+      "name": "Meta fully describes the cursor contract",
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant)",
+        "{raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})",
+        "Seed enough articles for >1 page"
+      ],
+      "steps": [
+        "Request the first page"
+      ],
+      "expected_results": [
+        "meta has next_cursor (non-null), has_more=true, and an effective limit",
+        "Following next_cursor eventually yields next_cursor=null, has_more=false"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.10.2",
+      "name": "include_body is bounded",
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant)",
+        "{raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})"
+      ],
+      "steps": [
+        "Request the list with include_body=true and limit beyond the include_body max"
+      ],
+      "expected_results": [
+        "400 (or explicit clamp signaled in meta); never a silent oversized chunked response"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.10.3",
+      "name": "Default response is body-less",
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant)",
+        "{raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})",
+        "Seed articles with bodies"
+      ],
+      "steps": [
+        "Request the list without include_body"
+      ],
+      "expected_results": [
+        "No body field in any item; payload is small"
+      ],
+      "status": "pending"
+    }
+  ],
+  "technical_notes": [
+    "Builds directly on US-27.9a (the cursor itself). This story is the contract/limits/docs layer.",
+    "Reuse the existing meta conventions (count/total_count/has_more already used by pairs); add next_cursor and the include_body bound.",
+    "include_body max should be a config constant (e.g. @max_include_body_page), well below the relevance page size.",
+    "Update the OpenApiSpex operation schemas for the enumeration endpoints.",
+    "Do not reintroduce total_count where it forces a full-corpus COUNT at scale (that itself can be slow) — prefer has_more derived from fetching limit+1."
+  ],
+  "dependencies": ["US-27.9a"],
+  "estimated_hours": 6
+}

--- a/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.11.json
+++ b/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.11.json
@@ -1,0 +1,110 @@
+{
+  "id": "US-27.11",
+  "title": "Connection-pool sizing / dedicated heavy-read pool (with tenant-isolation + pool-level params)",
+  "epic": {
+    "id": "epic_27",
+    "name": "Knowledge Subsystem Performance & Scale Hardening"
+  },
+  "priority": "high",
+  "phase": "pool_bulk",
+  "background": {
+    "reference": "GitHub Epic #175, Theme 4; reviews: 27.4/27.6 are shaped around this story's absence",
+    "includes": "ADMIN_POOL_SIZE defaults to 3; the transaction-based first #172 fix caused pool starvation on it (caught in adversarial review). Heavy analytical/vector reads run on AdminRepo (BYPASSRLS). A pool-level `statement_timeout`/`hnsw.ef_search` parameter is the clean lever US-27.4 and US-27.6b need."
+  },
+  "priority_note": "Bumped to HIGH (was medium): two high-priority stories (US-27.4 timeout mechanism, US-27.6a's no-per-request-transaction constraint) are shaped around the 3-conn pool. Sizing it removes that constraint and unblocks them.",
+  "story": {
+    "as_a": "loopctl operator",
+    "i_want_to": "the admin/BYPASSRLS read workload sized appropriately (or a dedicated heavy-read pool added with pool-level statement_timeout/ef_search parameters), without breaking tenant isolation or exhausting the DB",
+    "so_that": "concurrent heavy vector/enumeration reads don't starve each other or other admin ops, and US-27.4/27.6b get a safe place to set server-side timeouts and ef_search without a per-request transaction"
+  },
+  "rationale": "A 3-connection admin pool lets three concurrent heavy reads monopolize all admin DB capacity (it already distorted the #172 fix). Right-sizing it — or isolating heavy reads on a dedicated pool whose `:parameters` carry the server-side statement_timeout and ef_search — removes that hidden coupling and is the clean mechanism for the timeout (US-27.4) and recall (US-27.6b) levers. A second BYPASSRLS pool is itself a tenant-isolation surface, so isolation must be re-proven on it.",
+  "acceptance_criteria": [
+    {
+      "id": "AC-27.11.1",
+      "description": "The admin/heavy-read pool is sized to a TESTABLE target: it supports K concurrent heavy reads (K = documented expected concurrency) plus light admin ops without DBConnection checkout/queue timeouts (verified in TC-27.11.1); the chosen size and the K it supports are documented (no vague 'justified value'). The K budget EXPLICITLY accounts for long-held streamed-export checkouts (US-27.16) — which occupy a connection for minutes, a different profile than sub-2s reads — not only fast vector reads.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.11.2",
+      "description": "Pool size stays env-configurable (ADMIN_POOL_SIZE / a new heavy-read pool size) with the new default + rationale documented in config and the US-27.5 runbook.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.11.3",
+      "description": "Server-side defaults are set by the CORRECT mechanism per GUC type: `statement_timeout` is a CORE GUC and IS settable via the repo `:parameters` (startup packet) — verified. `hnsw.ef_search` is a pgvector CUSTOM GUC that does NOT exist until the extension loads per-session, so a Postgrex `:parameters` startup entry is commonly REJECTED on managed PG (fly mpg/RDS: 'unrecognized configuration parameter'). If ef_search must be raised, use `ALTER ROLE <heavy_read_role> SET hnsw.ef_search = N` (or ALTER DATABASE), applied per-session after extension load — NOT `:parameters`. A test connects through the pool and asserts `SHOW hnsw.ef_search` returns N; the working mechanism is recorded in the US-27.5 runbook. If NO mechanism reliably applies on fly mpg, ef_search stays at the default (40) and recall is handled by over-fetch + the US-27.6b under-fill signal (do not over-promise a lever that doesn't work).",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.11.4",
+      "description": "Tenant isolation on the new surface is STRUCTURAL, not just per-query-tested: a dedicated heavy-read repo is fronted by a wrapper/context that REQUIRES a tenant_id argument and injects the predicate (or a Credo/test guard flags any direct HeavyReadRepo.all/one/stream whose query lacks a tenant_id filter), so a new heavy read (incl. the 27.16 export stream and 27.12 bulk paths if they route through it) cannot forget tenant scoping by construction. Plus a tenant-isolation test proving tenant A cannot read tenant B's rows through the new pool.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.11.5",
+      "description": "The sum of all configured pools fits within the LIVE managed-Postgres max_connections with headroom for migrations/console — verified against the actual DB setting (or a runbook step to re-verify post-deploy), not only a documented constant.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.11.6",
+      "description": "After sizing, US-27.4's timeout mechanism is (re-)verified against the new pool (so 27.4 isn't validated under the old 3-conn assumption and then changed underneath).",
+      "status": "pending"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "TC-27.11.1",
+      "name": "K concurrent heavy reads don't starve other admin ops",
+      "type": "integration",
+      "preconditions": [
+        "Loopctl.Knowledge.ScaleSeed.seed(tenant.id, count: PROD_FLOOR)",
+        "Pool sized per this story; K defined"
+      ],
+      "steps": [
+        "Issue K concurrent heavy vector reads while issuing a light admin read"
+      ],
+      "expected_results": [
+        "The light admin read does not fail with a checkout/queue timeout; no cascade of 500s"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.11.2",
+      "name": "Heavy-read pool is tenant-isolated",
+      "type": "integration",
+      "preconditions": [
+        "tenant_a, tenant_b with embedded articles; heavy-read repo configured"
+      ],
+      "steps": [
+        "Run a heavy read for tenant_a through the new pool"
+      ],
+      "expected_results": [
+        "No tenant_b rows returned; explicit tenant_id predicate enforced"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.11.3",
+      "name": "Configured pools fit within LIVE max_connections",
+      "type": "integration",
+      "preconditions": [
+        "Config loaded; live DB reachable (or runbook step)"
+      ],
+      "steps": [
+        "Sum configured pool sizes; compare to the live SHOW max_connections"
+      ],
+      "expected_results": [
+        "Total + headroom <= live max_connections"
+      ],
+      "status": "pending"
+    }
+  ],
+  "technical_notes": [
+    "Config: config/runtime.exs ADMIN_POOL_SIZE (default 3) + main Repo (10). AdminRepo is BYPASSRLS.",
+    "Option A: raise ADMIN_POOL_SIZE. Option B: Loopctl.HeavyReadRepo with its own pool + `:parameters` (statement_timeout, hnsw.ef_search). B isolates better AND gives 27.4/27.6b their clean lever; document the trade-off.",
+    "fly mpg max_connections is finite and can change out-of-band — AC-27.11.5 must check the LIVE value, not a constant; TC-27.11.3 should query SHOW max_connections.",
+    "A new BYPASSRLS repo MUST keep explicit tenant_id on every query (CLAUDE.md: every context fn takes tenant_id; every test has a tenant-isolation case).",
+    "This removes the constraint that forced the #172 fix to avoid a per-request transaction; US-27.4/27.6b depend on the outcome."
+  ],
+  "dependencies": ["US-27.1"],
+  "estimated_hours": 8
+}

--- a/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.12.json
+++ b/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.12.json
@@ -1,0 +1,158 @@
+{
+  "id": "US-27.12",
+  "title": "Set-based bulk archive/delete/unpublish (by ids/tag/source) — bounded, atomic, FK-correct",
+  "epic": {
+    "id": "epic_27",
+    "name": "Knowledge Subsystem Performance & Scale Hardening"
+  },
+  "priority": "medium",
+  "phase": "pool_bulk",
+  "background": {
+    "reference": "GitHub Epic #175, Theme 4; reviews: FK-restrict + blast-radius + atomicity findings",
+    "includes": "A KB cleanup issued ~4,000 individual DELETEs (no set-based bulk-by-tag). VERIFIED: article_links FKs to articles are on_delete: :restrict (NOT cascade) — so hard-deleting a linked article raises an FK violation unless its links are deleted first. Destructive ops are role: :user."
+  },
+  "priority_note": "Fixes the O(n)-round-trip anti-pattern, but must NOT swing to the opposite failure: an unbounded delete_all over a 76k tag on the 3-conn pool is a new outage. Bounded + atomic + FK-correct.",
+  "story": {
+    "as_a": "a user-role operator maintaining the knowledge base",
+    "i_want_to": "archive/delete/unpublish many articles in bounded set-based statements selected by ids, tag, or source — correctly handling the :restrict FK to article_links, atomically, with a blast-radius cap and a safe dry-run",
+    "so_that": "cleaning up a source/tag is a bounded, all-or-nothing operation that doesn't take thousands of round-trips, doesn't FK-abort, and doesn't starve the pool or surprise me with the blast radius"
+  },
+  "rationale": "Per-row mutation (~4,000 DELETEs) is slow and pool-hostile and scales linearly; set-based is the fix. But a single unbounded delete_all over tens of thousands of rows plus its link cleanup, holding one of three admin connections, is the same pool-starvation class on the write path. And because article_links FKs are :restrict, the delete order is load-bearing (links first, both directions, or the statement FK-aborts). The operation must be bounded, atomic, FK-correct, and previewable.",
+  "acceptance_criteria": [
+    {
+      "id": "AC-27.12.1",
+      "description": "Bulk archive/delete/unpublish accept a selector — a list of ids, a tag (tags && ^[tag]), or a source id — and mutate via set-based update_all/delete_all (WHERE), never per-row.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.12.2",
+      "description": "FK-correct DELETE: the FK inventory to articles was AUDITED — only two references exist: article_links (×2, on_delete: :restrict) and article_access_events (on_delete: :delete_all). The DELETE variant MUST delete_all matching links FIRST — both directions (source_article_id IN ^ids OR target_article_id IN ^ids) AND carrying l.tenant_id == ^tenant_id — within the same transaction, or the :restrict FK aborts; article_access_events cascades automatically (no pre-delete needed). A schema-introspection guard test asserts no NEW :restrict FK to articles is added without updating the delete order. (Archive/unpublish leave links intact.)",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.12.3",
+      "description": "ARCHIVE/UNPUBLISH semantics documented: links to now-archived articles are left intact but become INERT in graph/bridge traversal (graph_traversal/distant_pairs traverse published-only middles); this is the defined behavior, distinct from delete.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.12.4",
+      "description": "Atomicity: the mutation + its dependent-link handling + the single audit event are ONE transaction — all rows handled with the audit recorded, or none. A timed-out/interrupted op leaves a defined state (all-or-nothing per batch), no orphaned links, no partially-archived source a retry can't safely resume.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.12.5",
+      "description": "Blast-radius bound: a bulk op runs under an explicit statement_timeout and either caps affected rows per statement and iterates in bounded, individually-atomic batches, OR documents+tests the worst-case duration for the largest realistic selector (biggest prod source/tag) against the US-27.11 pool. The accounting INCLUDES cascaded `article_access_events` rows: that FK is on_delete: :delete_all, so a hard-delete also cascade-deletes potentially many access-event rows in the same statement (often the larger row count for a hot article) — part of the statement cost and connection-hold time. The cap and timeout are config-driven; this must NOT reintroduce pool starvation on the write path.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.12.6",
+      "description": "Tenant isolation: every WHERE (articles AND the link cleanup) carries tenant_id; an ids selector ANDs with tenant_id so foreign ids are filtered out, never touched; a cross-tenant id/tag/source cannot affect another tenant's rows.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.12.7",
+      "description": "Authorization: bulk destructive ops require role: :user (anything that REMOVES data stays :user); agents/orchestrators get 403. Verified by a role test.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.12.8",
+      "description": "Affected-count return + idempotency: returns the affected count; re-running archive/delete on already-handled rows is a no-op (idempotent). The bulk emits ONE audit event (selector + count + actor), never per-row.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.12.9",
+      "description": "Safe preview (no TOCTOU surprise): a dry-run (e.g. ?dry_run=true) returns {would_affect: N} and mutates nothing; for the IRREVERSIBLE delete variant, either the op is archive-first with a documented restore path, OR the dry-run returns a frozen-set token and the real run requires it. The frozen-set token is INTEGRITY-PROTECTED (HMAC or server-minted, same trust model as the US-27.9a cursor — NEVER trusted from the client so a forged token can't target a different in-tenant id-set), single-use, TTL-bounded, and the stored id-set is SIZE-bounded (a selector exceeding the bound refuses the frozen-token path and uses re-confirm-on-drift instead). The dry-run COUNT is bounded (not an O(corpus) COUNT).",
+      "status": "pending"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "TC-27.12.1",
+      "name": "Bulk archive by tag is set-based and tenant-scoped",
+      "type": "integration",
+      "preconditions": [
+        "tenant_a, tenant_b; {user_key,_} = fixture(:api_key, %{tenant_id: tenant_a.id, role: :user})",
+        "Seed tagged articles in BOTH tenants with the same tag"
+      ],
+      "steps": [
+        "Bulk-archive by tag for tenant_a"
+      ],
+      "expected_results": [
+        "All tenant_a tagged articles archived; affected count returned; one update_all (assertable via query instrumentation)",
+        "tenant_b's same-tag articles untouched"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.12.2",
+      "name": "Hard delete of a LINKED article succeeds (links pre-deleted), not FK-abort",
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant); {user_key,_} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})",
+        "An article with inbound AND outbound links"
+      ],
+      "steps": [
+        "Bulk-delete by ids including that article"
+      ],
+      "expected_results": [
+        "Links (both directions) deleted first; article deleted; NO FK violation; one audit event"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.12.3",
+      "name": "Agent/orchestrator cannot invoke bulk destructive ops",
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant); {agent_key,_} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})"
+      ],
+      "steps": [
+        "Attempt bulk-delete-by-tag with the agent key"
+      ],
+      "expected_results": [
+        "403 (role: :user required)"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.12.4",
+      "name": "Atomic rollback on mid-op failure",
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant); a selector matching several articles+links; a seam to force a failure mid-transaction"
+      ],
+      "steps": [
+        "Run the bulk op so it fails partway"
+      ],
+      "expected_results": [
+        "Full rollback: no articles archived/deleted, no links removed, no audit event (all-or-nothing per batch)"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.12.5",
+      "name": "Dry-run previews without mutating; frozen-set guards TOCTOU for delete",
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant); {user_key,_} = fixture(:api_key, %{tenant_id: tenant.id, role: :user}); seed N tagged"
+      ],
+      "steps": [
+        "Dry-run bulk-delete by tag; then insert another matching article; then execute with the dry-run token"
+      ],
+      "expected_results": [
+        "Dry-run returns would_affect: N and mutates nothing; the real run operates on the frozen N (or re-confirms and refuses on drift), not N+1"
+      ],
+      "status": "pending"
+    }
+  ],
+  "technical_notes": [
+    "VERIFIED: priv/repo/migrations/*create_article_links* — both article FKs are on_delete: :restrict. There is NO cascade to rely on; delete order (links-first, both directions, tenant-scoped) is load-bearing or the statement FK-aborts.",
+    "Use Ecto.Multi: link delete_all -> article delete_all/update_all -> single Audit insert, all in one transaction (atomicity AC-27.12.4). The audit event is O(1), not O(rows).",
+    "Blast-radius: prefer bounded batches (each batch its own atomic Multi) under a statement_timeout so one giant statement can't hold a connection on the 3-conn pool indefinitely (coordinate with US-27.11).",
+    "Extend prior bulk work (epic 13; #136/#144/#146) with by-tag + cascade-by-source selectors; reuse the body-less summary (#146).",
+    "Dry-run COUNT must be bounded (the COUNT-at-scale hazard flagged in US-27.10); a frozen id-set token avoids both an O(corpus) count and the TOCTOU window.",
+    "delete is irreversible — prefer archive-first with restore, or the frozen-token guard, for the delete variant."
+  ],
+  "dependencies": ["US-27.1", "US-27.11"],
+  "estimated_hours": 14
+}

--- a/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.13.json
+++ b/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.13.json
@@ -1,0 +1,88 @@
+{
+  "id": "US-27.13",
+  "title": "Remediate every vector/enumeration endpoint the scale gate proves broken",
+  "epic": {
+    "id": "epic_27",
+    "name": "Knowledge Subsystem Performance & Scale Hardening"
+  },
+  "priority": "high",
+  "phase": "vector_layer",
+  "background": {
+    "reference": "GitHub Epic #175; BA review C1 (the detect→fix seam)",
+    "includes": "US-27.1/27.2/27.8 build the apparatus to DETECT a full-scan/over-budget endpoint at scale; US-27.6a/27.7a re-route the fitting endpoints. But once the harness exists and is run at ≥prod scale, some endpoint (e.g. a path not covered by the helper, or one only 'proven' on search_semantic) may go RED — and no other story OWNS fixing it. That is the green-but-broken trap one level up."
+  },
+  "priority_note": "Without this, the epic can pass its own gates and still ship a broken endpoint with no owner. This is the epic's whole reason for existing.",
+  "story": {
+    "as_a": "loopctl engineer",
+    "i_want_to": "a contracted remediation pass that takes every endpoint the new scale gate (US-27.8) proves full-scanning or over-budget at ≥prod scale and fixes it (via the kNN helper or its own correct shape) until the gate and the live-build confirmation pass",
+    "so_that": "the alarm built by Theme 1/2 is actually acted on — the epic delivers WORKING endpoints at scale, not just a red light next to broken ones"
+  },
+  "rationale": "Building an excellent alarm and an excellent replacement part is worthless if nothing is contracted to act when the alarm fires on an endpoint the replacement part didn't fully fix. This story closes the detect→fix seam: it enumerates the gate's RED endpoints and owns their correction, each verified at scale AND on the live deployed build per the US-27.5 checklist.",
+  "acceptance_criteria": [
+    {
+      "id": "AC-27.13.1",
+      "description": "Run the US-27.8 scale gate against the ≥prod corpus across ALL vector + enumeration endpoints and record the full pass/fail matrix (plan + latency) as the remediation work-list.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.13.2",
+      "description": "For every endpoint that fails the plan assertion (full Seq Scan) or the latency budget, the query is corrected (via US-27.6a helper or its own index-correct shape) until the gate passes; the fix is behavior/contract-preserving.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.13.3",
+      "description": "Each remediated endpoint gets the US-27.5 live-build confirmation: EXPLAIN ANALYZE under the timeout on the deployed build + the live endpoint returns 200 (and correct results) on representative inputs — not 'verified' on CI alone.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.13.4",
+      "description": "If the gate matrix is all-green from the outset, that is a valid outcome — BUT only when (a) the matrix records its calibration provenance (seed count >= PROD_ARTICLE_FLOOR and the effective ef_search), rejecting any matrix that can't confirm calibration as INVALID rather than 'all-green' (so a mis-calibrated CI run can't rubber-stamp); AND (b) the US-27.5 live-build confirmation is still run on at least the historically-broken endpoint (suggested_links) — an empty work-list is proven against prod, not just against the same author's CI gate.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.13.5",
+      "description": "Tenant isolation and external contracts are preserved for every remediated endpoint.",
+      "status": "pending"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "TC-27.13.1",
+      "name": "Scale gate matrix recorded and all endpoints green",
+      "type": "integration",
+      "preconditions": [
+        "Loopctl.Knowledge.ScaleSeed.seed(tenant.id, count: PROD_FLOOR, link_density: 5)"
+      ],
+      "steps": [
+        "Run the US-27.8 plan+latency assertions for every vector/enumeration endpoint"
+      ],
+      "expected_results": [
+        "Every endpoint passes (or each failure has a recorded fix that then passes)"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.13.2",
+      "name": "A remediated endpoint is confirmed on the live build",
+      "type": "integration",
+      "preconditions": [
+        "A previously-RED endpoint, fixed and deployed"
+      ],
+      "steps": [
+        "Per US-27.5 runbook: prod EXPLAIN ANALYZE + hit the live endpoint"
+      ],
+      "expected_results": [
+        "Index-backed + under timeout on prod; live endpoint returns 200 with correct results"
+      ],
+      "status": "pending"
+    }
+  ],
+  "technical_notes": [
+    "This story is gated by the harness (US-27.8) and the helper (US-27.6a/27.7a/27.7b) existing; it is the 'act on the alarm' step.",
+    "Likely candidates to go RED at scale: any endpoint not routed through the helper, the auto-link worker, or an enumeration without the keyset index — but the matrix (AC-27.13.1) is the source of truth, not speculation.",
+    "Use the US-27.5 closing checklist as the definition of done per endpoint.",
+    "No-deferrals: a RED endpoint is fixed here, not filed for later."
+  ],
+  "dependencies": ["US-27.8", "US-27.6a", "US-27.7a", "US-27.7b", "US-27.5"],
+  "estimated_hours": 12
+}

--- a/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.14.json
+++ b/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.14.json
@@ -1,0 +1,85 @@
+{
+  "id": "US-27.14",
+  "title": "Reconcile the HNSW index-name drift between migration and prod (+ migration-safety)",
+  "epic": {
+    "id": "epic_27",
+    "name": "Knowledge Subsystem Performance & Scale Hardening"
+  },
+  "priority": "medium",
+  "phase": "scale_observability",
+  "status": "pending",
+  "background": {
+    "reference": "GitHub Epic #175; BA C2, architect + adversarial F11",
+    "includes": "Migration 20260410022906 creates `articles_embedding_idx`; prod's live index is `articles_embedding_hnsw_idx` (created out-of-band). Three stories TOLERATE the drift via name-agnostic detection. Latent hazard: the migration's down-step `DROP INDEX IF EXISTS articles_embedding_idx` silently NO-OPS against prod's `_hnsw_idx` name — a rollback that wouldn't actually drop the live index."
+  },
+  "priority_note": "DECIDED (user sign-off 2026-06-24): RECONCILE — make prod and the migration agree on one canonical HNSW index name, then tighten the test tolerance. Prefer a metadata-only ALTER INDEX RENAME; if a same-definition index doesn't already exist under the canonical name, schedule a CONCURRENT recreate on ~76k rows. The down-migration no-op hazard is fixed regardless.",
+  "story": {
+    "as_a": "loopctl operator",
+    "i_want_to": "the deployed HNSW index name and the migration to agree on one canonical name (or the drift to be an explicitly-recorded, migration-safe decision), and the down-migration to handle whichever index name is actually present",
+    "so_that": "future migrations and rollbacks operate on the real index, the plan-assertion tolerance can be tightened, and no engineer wastes a session 'fixing' a drift that was meant to be permanent"
+  },
+  "rationale": "Permanently working around an environment drift in every test helper is tech-debt that can mask a real problem (e.g. the wrong index being live, or a down-migration that no-ops). Resolving the drift — or consciously recording it as permanent with migration-safety — removes a standing version-skew hazard. Because renaming/recreating an HNSW index on 76k rows has a real cost, the reconcile-vs-tolerate choice is a USER business decision, not a default.",
+  "acceptance_criteria": [
+    {
+      "id": "AC-27.14.1",
+      "description": "RECONCILE (decided): inspect prod first (detect by amname='hnsw' on articles(embedding), not by name). If an HNSW index exists under a non-canonical name → `ALTER INDEX … RENAME TO` the canonical name (metadata-only, brief ACCESS EXCLUSIVE, no rewrite — a transactional migration). If NO usable HNSW index exists → a SEPARATE migration with `@disable_ddl_transaction true`/`@disable_migration_lock true` that `CREATE INDEX CONCURRENTLY` the canonical name then drops the old. These are TWO distinct migration shapes (RENAME wants the DDL transaction; CONCURRENT forbids it) — the impl picks one after inspecting prod; both are idempotent (no-op if already canonical) and verified on the live build.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.14.2",
+      "description": "Regardless of (a)/(b): the migration down-step is made safe — it drops/handles whichever HNSW index name is actually present (not a hard-coded name that silently no-ops against prod), so a rollback cannot leave an orphaned index or fail to drop the live one.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.14.3",
+      "description": "After the rename/recreate, the plan-assertion (US-27.2) and helpers are tightened from the `(_hnsw)?_idx` tolerance to the canonical name (still asserting amname='hnsw'); the change is verified on the live build (index present, queries still index-backed). Until this migration lands, US-27.1/27.2/27.5 keep the name-agnostic detection.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.14.4",
+      "description": "The canonical detection snippet (e.g. `SELECT indexname FROM pg_indexes WHERE tablename='articles' AND indexdef ILIKE '%hnsw%'`, or join on amname='hnsw') is documented so detection is robust regardless of the decision.",
+      "status": "pending"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "TC-27.14.1",
+      "name": "Down-migration drops the actually-present HNSW index",
+      "type": "integration",
+      "preconditions": [
+        "A DB where the HNSW index exists under a non-migration name"
+      ],
+      "steps": [
+        "Run the (fixed) down-migration"
+      ],
+      "expected_results": [
+        "The live HNSW index is dropped (not a silent no-op); up-migration recreates the canonical one"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.14.2",
+      "name": "Queries remain index-backed after reconciliation (canonical name, either migration path)",
+      "type": "integration",
+      "preconditions": [
+        "Loopctl.Knowledge.ScaleSeed.seed(tenant.id, count: PROD_FLOOR)",
+        "Index reconciled to the canonical name"
+      ],
+      "steps": [
+        "refute_full_scan + assert_hnsw_index on the suggested_links query"
+      ],
+      "expected_results": [
+        "Still index-backed via the canonical amname='hnsw' index"
+      ],
+      "status": "pending"
+    }
+  ],
+  "technical_notes": [
+    "DECIDED: reconcile (user sign-off 2026-06-24).",
+    "ALTER INDEX ... RENAME TO is metadata-only (fast) IF a same-definition index already exists under the other name; a true recreate (DROP+CREATE hnsw) on 76k rows is expensive and must be CONCURRENT/scheduled. Inspect prod first to choose the path.",
+    "The existing down-migration `DROP INDEX IF EXISTS articles_embedding_idx` is the latent bug — it no-ops against prod's `articles_embedding_hnsw_idx`; fix it to handle whichever name is present.",
+    "Verify on the live build (fly): SELECT indexname, indexdef FROM pg_indexes WHERE tablename='articles'."
+  ],
+  "dependencies": [],
+  "estimated_hours": 5
+}

--- a/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.15.json
+++ b/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.15.json
@@ -1,0 +1,84 @@
+{
+  "id": "US-27.15",
+  "title": "Telemetry metrics + alerting for vector latency, db_statement_timeout, and recall under-fill",
+  "epic": {
+    "id": "epic_27",
+    "name": "Knowledge Subsystem Performance & Scale Hardening"
+  },
+  "priority": "medium",
+  "phase": "scale_observability",
+  "status": "pending",
+  "background": {
+    "reference": "GitHub Epic #175, Theme 1 observability; BA L2, adversarial F8",
+    "includes": "US-27.3/27.4 produce structured LOGS (sqlstate, slow-query duration); US-27.6b emits an under-fill telemetry event. But 'recurring slow queries are visible before they become incidents' is hard to satisfy with grep-the-logs alone — there is no metric/dashboard/alert. loopctl has no Sentry; logs go to stdout (fly logs)."
+  },
+  "priority_note": "Turns the logs/events from 27.3/27.4/27.6b into watchable metrics + alerts. Mildly beyond the epic's literal 'logged structured errors' acceptance — confirm scope (could be a fast-follow) — but directly serves the 'visible before incidents' promise.",
+  "story": {
+    "as_a": "loopctl operator",
+    "i_want_to": "the structured signals this epic emits (db_statement_timeout, slow-query duration, vector-query latency, recall under-fill) exposed as :telemetry metrics with at least a threshold-based alert path",
+    "so_that": "I can SEE a degradation trend (rising timeouts, creeping latency, frequent under-fill) before it becomes an incident, instead of discovering it by grepping logs after users complain"
+  },
+  "rationale": "The whole epic exists because a real degradation was invisible until users hit it. Logs make the cause discoverable AFTER you know to look; metrics + alerts make the trend visible BEFORE the cliff. Aggregating the already-emitted telemetry into counters/histograms with an alert threshold is the difference between 'observable in hindsight' and 'caught early', which is the operational intent behind Theme 1.",
+  "acceptance_criteria": [
+    {
+      "id": "AC-27.15.1",
+      "description": "A telemetry/metrics layer aggregates: a counter of db_statement_timeout (57014) by endpoint; a histogram of vector-query and enumeration latency by endpoint; a counter of recall under-fill (from US-27.6b) by endpoint — emitted as :telemetry metrics (Telemetry.Metrics) consumable by a reporter.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.15.2",
+      "description": "At least one alert path exists (e.g. a log-based alert rule, or a metrics reporter threshold) that fires when timeout rate, p95 latency, or under-fill rate crosses a configurable threshold over a window — documented in the runbook (US-27.5).",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.15.3",
+      "description": "Metrics carry safe dimensions only (endpoint, status/sqlstate) — NO vector literals, bodies, or params. Cardinality is CONCRETELY bounded: tenant_id is a label ONLY when total tenants <= a documented cap (e.g. 1000) and even then only on counters, NOT histograms (endpoint × tenant × buckets blows up in a multi-tenant SaaS); above the cap, tenant_id is dropped from labels (per-tenant attribution falls back to logs). A test asserts the label set cannot grow unboundedly (no per-article-id label; tenant label gated by the cap).",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.15.4",
+      "description": "Scope is confirmed with the USER: if a full dashboard/alerting stack is out of scope for this epic, the minimum (telemetry metric emission + a documented threshold) ships here and the dashboard is recorded as a backlog item with sign-off — not silently dropped (the story narrative promises 'visible before incidents').",
+      "status": "pending"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "TC-27.15.1",
+      "name": "Timeout and under-fill increment their counters",
+      "type": "integration",
+      "preconditions": [
+        "Telemetry metrics attached; seams to force a 57014 and an under-fill"
+      ],
+      "steps": [
+        "Trigger one statement timeout and one under-fill"
+      ],
+      "expected_results": [
+        "db_statement_timeout counter += 1 (labeled by endpoint); under_fill counter += 1"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.15.2",
+      "name": "Metrics carry no sensitive content and bounded cardinality",
+      "type": "unit",
+      "preconditions": [
+        "Metric definitions"
+      ],
+      "steps": [
+        "Inspect the metric tags"
+      ],
+      "expected_results": [
+        "Tags are endpoint/tenant_id/status only; no vectors/bodies/params; no per-article-id label"
+      ],
+      "status": "pending"
+    }
+  ],
+  "technical_notes": [
+    "Hook: the US-27.4 repo :telemetry handler + the US-27.6b under-fill event + the US-27.3 timeout mapping all already emit events — this story aggregates them via Telemetry.Metrics.",
+    "Reporter: whatever loopctl already uses (or a simple LoggerMetrics reporter) — full Prometheus/Grafana may be out of scope; ship metric emission + a threshold at minimum.",
+    "Bounded cardinality: never label by article_id or raw vector; tenant_id is acceptable if tenant count is bounded.",
+    "Confirm scope with USER (AC-27.15.4) — this may be a fast-follow rather than in-epic; record the decision."
+  ],
+  "dependencies": ["US-27.3", "US-27.4", "US-27.6b"],
+  "estimated_hours": 6
+}

--- a/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.16.json
+++ b/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.16.json
@@ -1,0 +1,161 @@
+{
+  "id": "US-27.16",
+  "title": "Bounded-memory knowledge export (no 5,000 cap) — keyset-streamed, fail-closed, pool-safe",
+  "epic": {
+    "id": "epic_27",
+    "name": "Knowledge Subsystem Performance & Scale Hardening"
+  },
+  "priority": "high",
+  "phase": "streaming_export",
+  "background": {
+    "reference": "GitHub issue #176 (linked under Epic #175); export 413-caps at 5,000 articles",
+    "includes": "Both export endpoints 413 above 5,000 (knowledge_export_controller.ex / okf_controller.ex). VERIFIED: build_obsidian_zip (knowledge.ex:2523) and OKF.to_zip (okf.ex:128) both call :zip.create(_, [:memory]) — materializing every body. The 5,000 cap is a MEMORY guard, not a user limit. Project export's real WHERE is `tenant_id=? AND status=:published AND (project_id IS NULL OR project_id=?)` (export_base_query/2) — it already bundles tenant-wide (null-project) articles."
+  },
+  "priority_note": "Export's job is full-KB backup/migration and it is unusable above 5,000. Highest-risk NEW story: it streams over BYPASSRLS AdminRepo, can hold a scarce admin connection for minutes, and a chunked-response error can ship a partial bundle. Bounded memory + fail-closed + pool-safe are mandatory.",
+  "story": {
+    "as_a": "a user-role operator backing up or migrating a large knowledge base",
+    "i_want_to": "export the full KB (both OKF and Obsidian formats) with bounded server memory and no article-count cap, generated incrementally from short keyset reads, failing CLOSED on any mid-stream error",
+    "so_that": "I can back up a 76k+ article KB in one request without OOMing a node, starving the admin pool, or silently producing a truncated bundle that a restore would treat as complete"
+  },
+  "rationale": "A backup feature that fails on exactly the KBs large enough to need backups is broken. The 5,000 cap guards a materialize-everything implementation, so the fix bounds MEMORY — but naively (single long Repo.stream transaction over BYPASSRLS AdminRepo) it would hold one of three admin connections for the whole download and could ship a partial bundle on error. Incremental keyset reads + a fail-closed contract + a concurrency bound make the export safe at scale, consistent with the epic's stream-don't-materialize and pool-safety direction.",
+  "acceptance_criteria": [
+    {
+      "id": "AC-27.16.1",
+      "description": "Both exports (OKF and Obsidian) produce the bundle with BOUNDED peak memory and no article-count cap. Default mechanism is INCREMENTAL keyset reads (the US-27.9a cursor) — short transaction-per-page reads that RELEASE the admin connection between pages — NOT a single long-lived Repo.stream transaction. :zip.create(_, [:memory]) is forbidden. The wire format is the implementer's choice among: (a) streamed `.tar.gz` via :erl_tar + send_chunked (with the importer/round-trip extended to tar), (b) a vetted streaming-zip dep added to mix.exs with a test proving per-entry flush (no central-directory buffering of all bodies), or (c) the async object-storage job (AC-27.16.6). The content-type/content-disposition match what is actually produced (don't advertise application/zip while emitting tar).",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.16.2",
+      "description": "The 5,000 article-count hard cap (413) is REMOVED. Any remaining limit is a documented memory/time budget (max stream duration under the heavy-read statement_timeout, or chunk backpressure), NOT an article count; the 413 'narrow your scope' message is gone.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.16.3",
+      "description": "Memory is bounded as a RATIO, not an absolute: peak VM memory (:erlang.memory(:total)/:binary delta, measured across the real chunked HTTP transport — NOT Phoenix.ConnTest's inline conn) for a 50k export is within a small constant (e.g. <=2x) of a 500-article export (sub-linear in N), AND the producer never holds more than `chunk_size` articles in memory at once (proven by instrumenting max in-flight batch). The bound holds for the WORST-CASE single entry: a max-body article and a dense-hub article whose link preload fans out — the link preload is itself bounded/streamed, never materialized into one chunk. Reuse the existing @full_content_byte_budget precedent.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.16.4",
+      "description": "Fail-closed on mid-stream error: send_chunked commits 200 before the body, so a Repo/timeout/connection error partway MUST NOT present as a complete export — the response is aborted/closed without a valid end-of-archive marker, OR a documented trailer/sentinel marks incompleteness, so an automated backup pipeline can DETECT truncation (no silent restore data-loss). The partial bytes never contain SQL, params, vector literals, or a stack trace (US-27.3 sanitization applies to the streaming path). A test injects a mid-stream failure and asserts the consumer detects incompleteness and sees no internal text.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.16.5",
+      "description": "Tenant/project scoping under BYPASSRLS: the streaming path runs on AdminRepo (BYPASSRLS — RLS does NOT enforce scope), so EVERY page query AND the link preload carry an explicit `tenant_id == ^principal_tenant` predicate, with tenant from conn.assigns (never a param). The streamed query's WHERE is byte-identical to the current export_base_query/2 (tenant_id + status + the `project_id IS NULL OR project_id=?` disjunction); a scale test asserts the streamed bundle's id-set equals the current fetch_published_for_export/2 id-set for the same (tenant, project). Visibility scoping and the existing export role are preserved (no auth downgrade).",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.16.6",
+      "description": "Pool-safe, UNCONDITIONALLY (no 'offered' deferral): the export EITHER (a) uses incremental keyset reads that release the connection between pages AND enforces a hard cap on concurrent in-flight exports (per-tenant + global) with a bounded max stream duration under the heavy-read statement_timeout, OR (b) runs as an async Oban job building to object storage (returns {job_id, status} then a signed download URL), off the request path and off the shared admin pool. A test asserts N concurrent full-KB exports do not starve a light admin read (mirror TC-27.11.1 on the export path). US-27.11's concurrency budget explicitly accounts for these long-held export checkouts.",
+      "status": "pending"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "TC-27.16.1",
+      "name": "Export of a >5,000-article corpus succeeds; memory flat vs N",
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant); project = fixture(:project, tenant: tenant)",
+        "{user_key,_} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})",
+        "Loopctl.Knowledge.ScaleSeed.seed(tenant.id, count: 50_000) under the project",
+        "Drive the REAL chunked transport (HTTP client against a test endpoint), not Phoenix.ConnTest inline conn"
+      ],
+      "steps": [
+        "Export OKF and Obsidian for 50k and (separately) 500 articles; record :erlang.memory(:total)/:binary delta and max in-flight batch"
+      ],
+      "expected_results": [
+        "200 chunked, not 413; valid bundle with all articles",
+        "50k peak memory within ~2x of 500; max in-flight batch <= chunk_size"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.16.2",
+      "name": "Worst-case single entry stays bounded",
+      "type": "integration",
+      "preconditions": [
+        "A corpus including one max-body article and one dense-hub article (many links)"
+      ],
+      "steps": [
+        "Export and observe per-chunk memory around those entries"
+      ],
+      "expected_results": [
+        "No memory spike scaling with the hub's link fan-out; link preload bounded"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.16.3",
+      "name": "Mid-stream failure fails closed (no complete-looking partial, no leak)",
+      "type": "integration",
+      "preconditions": [
+        "A seam to force a Repo/timeout error after the first chunk"
+      ],
+      "steps": [
+        "Start an export that errors mid-stream; inspect the received bytes"
+      ],
+      "expected_results": [
+        "The bundle is detectably incomplete (no valid end-of-archive / explicit incomplete sentinel)",
+        "No SQL/params/vector/stack text in the bytes"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.16.4",
+      "name": "Streamed id-set == current export id-set (no contract drift) + tenant-scoped",
+      "type": "integration",
+      "preconditions": [
+        "tenant_a project (with null-project tenant-wide articles too); tenant_b articles"
+      ],
+      "steps": [
+        "Export tenant_a's project; compare the bundle id-set to fetch_published_for_export/2"
+      ],
+      "expected_results": [
+        "Identical id-set (incl. the project_id IS NULL disjunction); zero tenant_b content"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.16.5",
+      "name": "Concurrent full-KB exports don't starve the admin pool",
+      "type": "integration",
+      "preconditions": [
+        "Loopctl.Knowledge.ScaleSeed.seed(tenant.id, count: 50_000); pool per US-27.11"
+      ],
+      "steps": [
+        "Fire N concurrent full-KB exports + a light admin read"
+      ],
+      "expected_results": [
+        "The light read does not hit a checkout/queue timeout; concurrency cap enforced"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.16.6",
+      "name": "Auth unchanged",
+      "type": "integration",
+      "preconditions": [
+        "{key,_} = fixture(:api_key, %{role: <below export role>})"
+      ],
+      "steps": [
+        "Attempt the export"
+      ],
+      "expected_results": [
+        "Authorization unchanged from current behavior"
+      ],
+      "status": "pending"
+    }
+  ],
+  "technical_notes": [
+    "Controllers: knowledge_export_controller.ex (cap ~:77, content-type application/zip ~:63), okf_controller.ex (~:158). Context: build_obsidian_zip (knowledge.ex:2523), OKF.to_zip (okf.ex:128) — both :zip.create(_, [:memory]); remove the 5,000 gate.",
+    "NO stdlib streaming-zip exists; :zip.create materializes. Viable: :erl_tar streamed .tar.gz (changes format — extend importer/round-trip), a vetted streaming-zip dep (prove per-entry flush), or async-to-object-storage.",
+    "Repo.stream REQUIRES a transaction and would hold one of 3 AdminRepo (BYPASSRLS) connections for the whole client-paced download — the exact pool-starvation the knowledge.ex:2873-2883 comment warns about, and it pins xmin (blocks vacuum on a churning 76k table). Use the US-27.9a keyset cursor (page-sized reads, connection released between pages) as the default; reserve Repo.stream for the async Oban job on the US-27.11 heavy-read pool.",
+    "Memory test: measure :erlang.memory(:total)/:binary across the VM (article bodies are refc binaries off-process, so process_info(self()) misses them); compare 50k vs 500 (flat-vs-N), and drive the real chunked HTTP transport.",
+    "BYPASSRLS: explicit tenant_id on every page AND the outgoing/incoming link preload; tenant from conn.assigns.",
+    "object-storage async: fly has no built-in object store — needs S3/R2 config; the async path is only 'done' if that config exists.",
+    "Both formats reduce to 'iterate articles -> emit a file'; share a streaming core."
+  ],
+  "dependencies": ["US-27.1", "US-27.9a", "US-27.11"],
+  "estimated_hours": 16
+}

--- a/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.17.json
+++ b/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.17.json
@@ -1,0 +1,89 @@
+{
+  "id": "US-27.17",
+  "title": "Terminal epic verification: execute the full scale gate + prod live-build checks (deferred verification, run last)",
+  "epic": {
+    "id": "epic_27",
+    "name": "Knowledge Subsystem Performance & Scale Hardening"
+  },
+  "priority": "high",
+  "phase": "terminal_verification",
+  "background": {
+    "reference": "GitHub Epic #175; consolidation of the scale + prod-verification gates that the autonomous build loop (mix precommit + enhanced review + CI) cannot run mid-stream",
+    "includes": "The @tag :scale tests are excluded from `mix precommit` (they need a committed ~80k-row corpus + a non-sandbox DB), and the prod live-build verification needs the deployed build (fly). So per-story merges happen on code+unit+review+CI; the scale/prod execution is DEFERRED here, deliberately, so the whole epic builds autonomously with no manual gate mid-stream and verification is one consolidated terminal pass."
+  },
+  "priority_note": "This is the single end-of-epic verification story. It runs DEAD LAST (depends on every leaf story) and executes every scale/live-build AC the implementation stories wrote-but-deferred. Itself automatable: the scale suite runs as the agent's work; the prod checks run via the authenticated fly CLI.",
+  "story": {
+    "as_a": "the autonomous build loop (and the operator reviewing the final result)",
+    "i_want_to": "run the complete scale gate (seeded ~80k corpus) across every vector/enumeration/export/bulk endpoint AND the prod live-build verification once, at the very end, remediating any failures, and produce a single verification report",
+    "so_that": "the epic is implemented with ZERO manual intervention mid-stream, every quality gate is still honored, and the scale + prod verification (the gates that caught #172) happen once at the end instead of per-story"
+  },
+  "rationale": "Deferring scale/prod verification to the very end lets the whole epic build autonomously (each story on its automatable gates) without a human in the loop, while still honoring those gates — they are executed here, comprehensively, rather than skipped. Consolidating them into one terminal pass is the accepted trade for full autonomy; the enhanced review per story still catches logic/structural defects en route, and this story catches the scale-only and prod-only failures at the end.",
+  "acceptance_criteria": [
+    {
+      "id": "AC-27.17.1",
+      "description": "Seed the ~80k (>= PROD_ARTICLE_FLOOR) committed corpus (US-27.1) and run the ENTIRE @tag :scale suite — every per-endpoint plan assertion (US-27.2/27.8), the keyset deep-page assertions (US-27.9a/9b), the bulk blast-radius (US-27.12), and the export memory bound (US-27.16) — recording the full pass/fail matrix with calibration provenance (seed count, ef_search).",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.17.2",
+      "description": "Remediate every scale failure in this pass (the US-27.13 detect→fix loop applied epic-wide, not just vector endpoints): any endpoint that full-scans or blows its budget at scale is corrected via the shared helper / its own bounded shape until the scale gate is all-green. No deferrals.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.17.3",
+      "description": "After the final merge deploys, run the PROD live-build verification (US-27.5 runbook) AUTONOMOUSLY via the authenticated fly CLI: prod EXPLAIN ANALYZE under the statement_timeout for each heavy endpoint (index-backed, no Seq Scan), the repro-id 200 checks (incl. the original suggested_links ids), and a fly-logs scan for new 57014/timeouts. No user action required — the operator only reviews the produced report.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.17.4",
+      "description": "Produce a single terminal verification report: the scale matrix (all-green, with provenance) + the prod EXPLAIN/repro/log evidence per endpoint, mapping each deferred scale/live-build AC across the epic to its execution result here. The epic is 'verified' only when this report is all-green on both the scale gate and prod.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.17.5",
+      "description": "If the prod environment is unreachable from the run context, the scale-gate portion (AC-27.17.1/2/4) still completes autonomously and the report explicitly flags the prod portion (AC-27.17.3) as the single remaining check — so the only possible manual touch is a 5-minute operator confirmation, never mid-stream work.",
+      "status": "pending"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "TC-27.17.1",
+      "name": "Full scale suite green at >= prod floor with provenance",
+      "type": "integration",
+      "preconditions": [
+        "Loopctl.Knowledge.ScaleSeed.seed(tenant.id, count: PROD_FLOOR, link_density: 5)"
+      ],
+      "steps": [
+        "Run the entire @tag :scale suite across all endpoints"
+      ],
+      "expected_results": [
+        "All green; matrix records seed >= floor and the ef_search used; any failure triggers remediation (AC-27.17.2) then re-runs to green"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.17.2",
+      "name": "Prod live-build verification runs via fly and reports",
+      "type": "integration",
+      "preconditions": [
+        "Epic fully merged + deployed"
+      ],
+      "steps": [
+        "Via fly ssh rpc: AdminRepo.explain(:all, q, analyze: true) for each heavy endpoint; hit repro ids; scan fly logs"
+      ],
+      "expected_results": [
+        "Each heavy endpoint index-backed + under timeout on prod; repro ids return 200; no new 57014; report produced"
+      ],
+      "status": "pending"
+    }
+  ],
+  "technical_notes": [
+    "RUN LAST: depends on every leaf story so the loop schedules it after the whole epic is implemented + deployed.",
+    "Scale execution is the agent's WORK (seed + `SCALE_TESTS=1 mix test --only scale`), NOT the per-story merge gate (which stays `mix precommit`). Remediations are code that passes precommit + enhanced review + CI like any story.",
+    "Prod verification reuses the proven #172 method: `fly ssh console -a loopctl -C \"/app/bin/loopctl rpc '<Elixir>'\"` for EXPLAIN ANALYZE, `fly logs` for the SQLSTATE. fly is authenticated in the run context.",
+    "This story makes the per-story 'verified at scale / live build' ACs (27.5/27.8/27.13/27.16 etc.) honest: they are EXECUTED here, once, comprehensively — not skipped, not per-story-manual.",
+    "If you instead want per-PR scale enforcement (no end-consolidation), wire the scale suite into CI as a job and run the epic with `--gate \"mix precommit && SCALE_TESTS=1 mix test --only scale\"` — at the cost of an ~80k seed per PR. The terminal-story model here is the lighter, autonomy-first choice."
+  ],
+  "dependencies": ["US-27.13", "US-27.15", "US-27.10", "US-27.12", "US-27.16", "US-27.9b", "US-27.14"],
+  "estimated_hours": 10
+}

--- a/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.2.json
+++ b/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.2.json
@@ -1,0 +1,123 @@
+{
+  "id": "US-27.2",
+  "title": "Plan-assertion helper on the CONTROLLER'S actual query — fails on full-corpus Seq Scan, no forced planner",
+  "epic": {
+    "id": "epic_27",
+    "name": "Knowledge Subsystem Performance & Scale Hardening"
+  },
+  "priority": "high",
+  "phase": "scale_observability",
+  "background": {
+    "reference": "GitHub Epic #175, Theme 1; incident: the EXPLAIN enable_seqscan=off guard added in #172/#173 proved index ELIGIBILITY on a join-free shape, not that the real query uses the index",
+    "includes": "The #172 guard forced enable_seqscan/sort=off, which hides the real cost-based decision. Equally dangerous: a guard that asserts on a re-built query object rather than the query the controller actually runs. Wiki bd4a26b6 captures the pattern."
+  },
+  "priority_note": "Directly addresses the test that gave false confidence three times. Depends on US-27.1 (needs a committed, analyzed, ≥prod corpus for prod-like planner choices).",
+  "story": {
+    "as_a": "loopctl platform engineer",
+    "i_want_to": "a reusable assertion that runs EXPLAIN on the SAME query the controller/worker actually executes (joins, filters, derived limit/threshold/pool, visibility — all included), WITHOUT forcing the planner, against the large corpus, and fails if articles is reached by a full Seq Scan",
+    "so_that": "a regression that re-introduces a full-corpus scan fails CI on the real request path — not on a detached stunt-double query, and not hidden behind enable_seqscan=off"
+  },
+  "rationale": "Two distinct false-confidence traps shipped or nearly shipped: (a) forcing the planner (enable_seqscan=off) proves eligibility, not usage; (b) asserting on an independently re-constructed query proves the query builder, not the request path. A future filter added in suggest_links/3 (not the query builder) would sail past a stunt-double guard. Asserting the unforced plan of the controller's exact emitted SQL+params on a representative corpus is the only guard that would have caught all three prior misses.",
+  "acceptance_criteria": [
+    {
+      "id": "AC-27.2.1",
+      "description": "A helper (Loopctl.PlanAssertions.refute_full_scan/1, assert_hnsw_index/1) runs `EXPLAIN` WITHOUT setting enable_seqscan/enable_sort — the planner's natural choice on the current (analyzed) data.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.2.2",
+      "description": "The PRIMARY failure signal is the literal `Seq Scan on articles` node (case-insensitive). A `Sort` node is NOT itself a failure (the verified suggested_links shape legitimately sorts the small post-ANN pool); Sort is advisory-only, flagged only if its input row estimate ≈ the seeded corpus size.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.2.3",
+      "description": "The success signal requires an `Index Scan using <hnsw index>` reaching articles, AND the matched index is verified to be an HNSW index (amname='hnsw'), not merely a name match — so a btree that happens to match the name regex can't pass.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.2.4",
+      "description": "The query under test is obtained from the SAME code path the controller/worker invokes (e.g. a `*_query/n` function the action itself calls, or by capturing emitted SQL+params via a Repo telemetry/explain seam on a real `conn` request) — NOT by independently re-constructing args. A test asserts the controller's effective SQL+params equals the asserted query's SQL+params (byte-identical).",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.2.5",
+      "description": "Before asserting, the helper requires fresh statistics (the US-27.1 ANALYZE guard) — a plan assertion against an unanalyzed `articles` aborts with a clear error rather than producing a misleading pass/fail.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.2.6",
+      "description": "On failure the helper reports the offending plan text (truncated, vector literals elided) so a red CI run shows the Seq Scan node, not just a boolean.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.2.7",
+      "description": "An accompanying scale test exercises the production suggested_links query shape (anti-join + threshold) through the helper at ≥prod scale and proves it is index-backed — the exact #172 regression class guarded on the real shape.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.2.8",
+      "description": "The scale plan-assertions are tagged/opt-in (scale gate, not the default async suite) and documented as the canonical way to guard a vector endpoint.",
+      "status": "pending"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "TC-27.2.1",
+      "name": "Helper fails on an index-defeating shape at scale",
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant); Loopctl.Knowledge.ScaleSeed.seed(tenant.id, count: PROD_FLOOR)"
+      ],
+      "steps": [
+        "Build a deliberately index-defeating query (e.g. anti-join inside the ORDER BY, the #170 shape)",
+        "Loopctl.PlanAssertions.refute_full_scan(query)"
+      ],
+      "expected_results": [
+        "Raises; message includes the `Seq Scan on articles` node"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.2.2",
+      "name": "Controller's effective query == asserted query (no stunt double)",
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant); {key,_} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})",
+        "An embedded target article"
+      ],
+      "steps": [
+        "Capture the SQL+params the controller emits for GET suggested_links (telemetry seam)",
+        "Compare to the query the scale assertion runs"
+      ],
+      "expected_results": [
+        "SQL strings and param lists are identical"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.2.3",
+      "name": "Production suggested_links shape is index-backed at scale (HNSW, not name-only)",
+      "type": "integration",
+      "preconditions": [
+        "Loopctl.Knowledge.ScaleSeed.seed(tenant.id, count: PROD_FLOOR, link_density: 5)"
+      ],
+      "steps": [
+        "Run refute_full_scan + assert_hnsw_index on the real suggested_links query"
+      ],
+      "expected_results": [
+        "No Seq Scan on articles; reached via an amname='hnsw' index"
+      ],
+      "status": "pending"
+    }
+  ],
+  "technical_notes": [
+    "Helper: Loopctl.PlanAssertions (test/support). Use Repo.explain(:all, query) (preserves real param binding). EXPLAIN (not ANALYZE) suffices for shape; ANALYZE optional for runtime.",
+    "CRITICAL: do NOT SET enable_seqscan=off/enable_sort=off here — forcing the planner is exactly what produced false confidence in #172.",
+    "Same-query guarantee: the strongest form captures SQL via a :telemetry handler on a real ConnCase request and feeds THAT to EXPLAIN, so a filter added in the controller (not the builder) is included.",
+    "amname check: join pg_class/pg_am or `SELECT am.amname FROM pg_index ... ` for the index used; assert 'hnsw'.",
+    "Sort cardinality parsing from EXPLAIN text is flaky — keep `Seq Scan on articles` as the deterministic primary signal; Sort is advisory.",
+    "Meaningful only at scale (6 rows seq-scans happily) — hence the US-27.1 dependency. Tie into US-27.8 per-endpoint guards."
+  ],
+  "dependencies": ["US-27.1"],
+  "estimated_hours": 10
+}

--- a/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.3.json
+++ b/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.3.json
@@ -1,0 +1,128 @@
+{
+  "id": "US-27.3",
+  "title": "Structured DB-error surfacing: map SQLSTATE to safe, logged errors instead of a blanket 500",
+  "epic": {
+    "id": "epic_27",
+    "name": "Knowledge Subsystem Performance & Scale Hardening"
+  },
+  "priority": "high",
+  "phase": "scale_observability",
+  "background": {
+    "reference": "GitHub Epic #175, Theme 1; incident: the 57014 statement_timeout hidden behind a generic 500 for the entire suggested_links saga",
+    "includes": "Throughout #168→#173 the real cause (Postgrex.Error 57014 query_canceled / statement timeout) was invisible to anyone hitting the API — it surfaced only as a generic 500. The diagnosis required fly logs access that the fixing session initially believed it lacked."
+  },
+  "priority_note": "Observability half of Theme 1. Without surfacing the real SQLSTATE, operators and future fixers debug blind — the documented reason the misses took four attempts.",
+  "story": {
+    "as_a": "loopctl operator (and the next engineer debugging a prod incident)",
+    "i_want_to": "database exceptions (statement timeout, serialization failure, etc.) to be mapped to a structured, logged error response that carries the real SQLSTATE and a safe message, instead of every DB failure collapsing into an opaque 500",
+    "so_that": "I can see WHY an endpoint failed (e.g. 57014 statement timeout on a vector scan) from logs/responses without shelling into the box to read raw stack traces"
+  },
+  "rationale": "A blanket 500 erases the single most useful diagnostic signal — the SQLSTATE — which is precisely why the suggested_links timeout took four attempts to pin down. Mapping known DB error classes to logged, structured responses turns 'it 500s sometimes' into 'it cancels with 57014 after the statement timeout', which is directly actionable and prevents future blind fixes. The mapping must not leak internal query text or stack traces to API clients.",
+  "acceptance_criteria": [
+    {
+      "id": "AC-27.3.1",
+      "description": "A central handler (FallbackController clause and/or a plug) catches Postgrex.Error / DBConnection.ConnectionError and inspects the SQLSTATE, mapping to a SINGLE pinned status per class: 57014 (query_canceled / statement timeout) -> 504 with code \"db_statement_timeout\"; serialization/deadlock (40001/40P01) -> 503 retryable with a Retry-After header; others -> 500. ALL are logged with the SQLSTATE and code. Tests assert the EXACT status per class.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.3.2",
+      "description": "The client-facing JSON body never contains raw SQL, query parameters, vector literals, or an Elixir stack trace; it contains only {error: {status, code, message}} with a safe message.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.3.3",
+      "description": "Every mapped DB error is logged at error level with structured fields: sqlstate, mapped_code, endpoint/controller+action, tenant_id (if available), and request_id — so a log search can correlate the response to the real cause.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.3.4",
+      "description": "The 57014 timeout path returns a distinct, documented error code (e.g. \"db_statement_timeout\") so clients/monitoring can distinguish a timeout from a logic 500 and so the suggested_links class of failure is self-identifying in logs.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.3.5",
+      "description": "Tenant isolation/security: the error mapping does not change which tenant's data is touched and does not become an existence oracle (a cross-tenant or missing resource still returns 404, not a DB error).",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.3.6",
+      "description": "Existing non-DB FallbackController behavior (:not_found→404, :invalid_threshold→400, changeset→422, etc.) is unchanged; only previously-unhandled DB exceptions gain structured handling.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.3.7",
+      "description": "Anti-oracle, scoped honestly: the STATUS-CODE boundary is non-distinguishing — the error-class response is identical regardless of whether the target row exists or belongs to another tenant (cross-tenant/missing still 404, never a DB-error code), so an attacker can't use 504-vs-200 to infer another tenant's state. SEPARATELY: wall-clock timing side-channels (a tenant-B-sized operation simply takes longer, even at 200) are an acknowledged residual — mitigated only by a concrete rate-limit-by-cost control (define it in an AC + test, or record the residual with USER sign-off). Do NOT assert 'same rate limiting' against a control that isn't specified.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.3.8",
+      "description": "Log sanitization: no structured log field contains a raw embedding/vector literal, an article body, or the full bound-parameter list; vectors are elided to dimensionality and params truncated. (Logs are reachable via fly logs — this is both noise and disclosure control.)",
+      "status": "pending"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "TC-27.3.1",
+      "name": "Statement timeout maps to a logged structured timeout, not a bare 500",
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant)",
+        "{raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})",
+        "A controller/test seam that forces a Postgrex.Error with sqlstate 57014 (e.g. a stubbed repo or `SET LOCAL statement_timeout` + pg_sleep on a test route)"
+      ],
+      "steps": [
+        "Issue the request that triggers the 57014"
+      ],
+      "expected_results": [
+        "Response status is the mapped timeout code (e.g. 503/504), not 500",
+        "Response body is {error: {status, code: \"db_statement_timeout\", message: ...}} with no SQL/stack trace",
+        "An error log line exists with sqlstate=57014 and the request_id"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.3.2",
+      "name": "Unknown DB error still maps to a logged 500 without leaking internals",
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant)",
+        "A seam that raises a Postgrex.Error with an unmapped sqlstate"
+      ],
+      "steps": [
+        "Issue the request"
+      ],
+      "expected_results": [
+        "Status 500",
+        "Body contains a safe generic message, no SQL/stack trace",
+        "Log line carries the real sqlstate"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.3.3",
+      "name": "Existing error-atom handling is unchanged",
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant)",
+        "{raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})"
+      ],
+      "steps": [
+        "Request a non-existent article's suggested_links"
+      ],
+      "expected_results": [
+        "404 (unchanged), not a DB-error code"
+      ],
+      "status": "pending"
+    }
+  ],
+  "technical_notes": [
+    "Hook point: LoopctlWeb.FallbackController (already maps error atoms/changesets) plus possibly an Endpoint-level rescue for exceptions raised outside the with-chain. Phoenix renders unhandled exceptions via the error view → ensure the SQLSTATE is logged before that.",
+    "Postgrex.Error exposes %Postgrex.Error{postgres: %{code: :query_canceled, ...}} — match on the atom/code; DBConnection.ConnectionError covers pool checkout/connection-drop timeouts.",
+    "Do NOT inadvertently catch-and-swallow errors that should crash; only translate known DB error classes to responses + logs.",
+    "Coordinate with US-27.4 (statement_timeout): the 57014 path is the expected fast-fail when a heavy endpoint exceeds its budget.",
+    "Logging: use Logger with structured metadata (Logger.metadata or a structured logger) — loopctl logs JSON to stdout (no Sentry); fly logs is the exception history, so the SQLSTATE MUST be in the log line.",
+    "Security: never echo query text/params to clients (information disclosure); the security-adversary review of this epic will check this."
+  ],
+  "dependencies": [],
+  "estimated_hours": 8
+}

--- a/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.4.json
+++ b/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.4.json
@@ -1,0 +1,115 @@
+{
+  "id": "US-27.4",
+  "title": "Per-endpoint statement_timeout fast-fail + slow-query logging",
+  "epic": {
+    "id": "epic_27",
+    "name": "Knowledge Subsystem Performance & Scale Hardening"
+  },
+  "priority": "high",
+  "phase": "scale_observability",
+  "background": {
+    "reference": "GitHub Epic #175, Theme 1",
+    "includes": "The prior suggested_links query held a connection for ~30s before the DB cancelled it (57014). There was no bounded fast-fail and no slow-query signal, so a single pathological request degraded the whole endpoint silently."
+  },
+  "priority_note": "Pairs with US-27.3: the statement_timeout produces the 57014 that US-27.3 surfaces. Together they bound the blast radius of a slow query.",
+  "story": {
+    "as_a": "loopctl operator",
+    "i_want_to": "heavy read endpoints to run under an explicit, configurable statement_timeout so a pathological query fails fast instead of holding a connection for tens of seconds, and to have slow queries (over a threshold) logged with their duration",
+    "so_that": "one bad request can't exhaust the connection pool or hang clients, and recurring slow queries are visible before they become incidents"
+  },
+  "rationale": "Without a bounded statement timeout, a planner mistake (like the suggested_links full scan) consumes a connection for the full client/pool timeout, amplifying one slow query into endpoint-wide degradation against the small admin pool (Theme 4). An explicit per-endpoint statement_timeout turns that into a clean, logged fast-fail, and slow-query logging surfaces the trend before the cliff — both are prerequisites for operating vector endpoints at scale.",
+  "acceptance_criteria": [
+    {
+      "id": "AC-27.4.1",
+      "description": "Heavy read endpoints (suggested_links, pairs, novelty, semantic search, enumeration) execute under an explicit SERVER-SIDE statement_timeout (default 10s, per-endpoint overridable in config, not hard-coded). NOTE there is no per-query server-side statement_timeout on a bare AdminRepo.all (Ecto's :timeout is the client-side DBConnection timeout — it cancels the checkout but the backend keeps running). The only real mechanisms are (a) `set_config('statement_timeout', ms, true)` inside a transaction (per-request transaction = pool-starvation risk on the 3-conn pool) or (b) a pool-level `statement_timeout` via the heavy-read pool's `:parameters` (US-27.11). Mechanism (b) is preferred; if (a) is chosen, US-27.11 MUST land first.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.4.2",
+      "description": "When the timeout fires, the request fails fast with the structured timeout error from US-27.3 (57014 → db_statement_timeout), and the connection is released promptly (not held to a longer client/pool timeout).",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.4.3",
+      "description": "The statement_timeout mechanism does NOT reintroduce the connection-pool-starvation anti-pattern: if it requires a transaction (SET LOCAL), the trade-off is evaluated against the admin pool size (see Theme 4 / the distant_pairs pool-starvation note) and justified, or a non-transaction mechanism is used.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.4.4",
+      "description": "Queries exceeding a configurable slow-query threshold (e.g. 1s) are logged at warn with the endpoint, duration_ms, tenant_id, and request_id (query text optional and sanitized) — without logging every fast query.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.4.5",
+      "description": "Slow-query logging is implemented via a Repo telemetry handler (e.g. on [:loopctl, :repo, :query]) so it covers the repos uniformly rather than being sprinkled per call site.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.4.6",
+      "description": "Defaults are documented; the timeout and slow-query threshold are tunable via application config / env without a code change.",
+      "status": "pending"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "TC-27.4.1",
+      "name": "A query exceeding the endpoint statement_timeout fast-fails with the structured timeout",
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant)",
+        "{raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})",
+        "config sets a very low statement_timeout for the test endpoint and a test seam runs a deliberately slow query (pg_sleep)"
+      ],
+      "steps": [
+        "Issue the request"
+      ],
+      "expected_results": [
+        "Response is the db_statement_timeout structured error (US-27.3), not a 30s hang",
+        "Total request time is bounded near the configured timeout"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.4.2",
+      "name": "Slow query over threshold is logged with duration",
+      "type": "integration",
+      "preconditions": [
+        "Slow-query threshold configured low for the test",
+        "A test query that exceeds it"
+      ],
+      "steps": [
+        "Run the query and capture logs"
+      ],
+      "expected_results": [
+        "A warn log line with duration_ms and the endpoint/context",
+        "A fast query under threshold produces NO slow-query log line"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.4.3",
+      "name": "Timeout mechanism does not hold a pooled connection beyond the budget",
+      "type": "integration",
+      "preconditions": [
+        "Configured statement_timeout",
+        "A slow query"
+      ],
+      "steps": [
+        "Trigger the slow query and observe connection checkout duration"
+      ],
+      "expected_results": [
+        "Connection is returned to the pool promptly after the timeout fires"
+      ],
+      "status": "pending"
+    }
+  ],
+  "technical_notes": [
+    "statement_timeout: `SELECT set_config('statement_timeout', '<ms>', true)` inside an AdminRepo.transaction is the SET LOCAL form, BUT a per-request transaction on the 3-connection admin pool risks starvation (the exact anti-pattern the round-1 #172 fix hit and the distant_pairs comment warns about). Prefer a non-transaction approach if possible, or sequence after Theme 4 pool sizing; document the decision.",
+    "Slow-query logging: attach a :telemetry handler to the Ecto repo query event ([:loopctl, :repo, :query]); read measurements.total_time / query_time; gate on a configurable threshold.",
+    "Config keys (config/runtime.exs): e.g. :knowledge_statement_timeout_ms, :slow_query_threshold_ms.",
+    "Coordinate the 57014 mapping with US-27.3 so the timeout produces the documented db_statement_timeout code.",
+    "Do not log raw vector literals or full SQL at info level (noise + disclosure); sanitize/truncate."
+  ],
+  "dependencies": ["US-27.3", "US-27.11"],
+  "estimated_hours": 8
+}

--- a/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.5.json
+++ b/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.5.json
@@ -1,0 +1,91 @@
+{
+  "id": "US-27.5",
+  "title": "Staging scale gate + runbook for retrieving the real prod error and verifying at scale",
+  "epic": {
+    "id": "epic_27",
+    "name": "Knowledge Subsystem Performance & Scale Hardening"
+  },
+  "priority": "high",
+  "phase": "scale_observability",
+  "background": {
+    "reference": "GitHub Epic #175, Theme 1; incident: fixes shipped without prod verification; fly logs + prod EXPLAIN were the only things that caught the broken #173 fix",
+    "includes": "The only reason the four-attempt suggested_links bug was finally pinned was a session that ran `fly logs` and `fly ssh ... rpc` EXPLAIN ANALYZE against the live corpus. That capability was ad hoc, not a documented, repeatable gate. The wiki article bd4a26b6 captured the pattern; this story institutionalizes the process."
+  },
+  "priority_note": "Closes Theme 1's acceptance: 'a runbook exists for retrieving the real prod error' and 'representative-scale corpus available to CI/staging'. Makes honest verification repeatable rather than heroic.",
+  "story": {
+    "as_a": "loopctl engineer shipping a scale/perf fix",
+    "i_want_to": "a documented, repeatable procedure (and a staging gate) for (a) reproducing an endpoint's plan/timing against a representative corpus and (b) retrieving the real prod exception/plan before I close a scale issue",
+    "so_that": "no scale or perf fix is ever again closed on 'CI-green + merged' alone — the standard is 'verified against representative scale and confirmed on the live deployed build', as the epic's workflow requires"
+  },
+  "rationale": "Three of the four suggested_links fixes were closed as 'resolved end-to-end' while still broken in prod, because there was no required, documented verification step beyond green CI. Institutionalizing the reproduce-and-verify procedure (the scale gate + a runbook for fly logs / prod EXPLAIN) converts the lesson of #172 into a standing process, so the whole epic's 'verified at scale' acceptance criterion is enforceable rather than aspirational.",
+  "acceptance_criteria": [
+    {
+      "id": "AC-27.5.1",
+      "description": "A runbook (docs/runbooks/knowledge_scale_verification.md) documents: how to run the US-27.1 scale fixture + US-27.2 plan assertions locally/in CI; how to read the real prod exception via `fly logs -a loopctl`; and how to run `AdminRepo.explain(:all, query, analyze: true)` against the live corpus via `fly ssh console -a loopctl -C \"/app/bin/loopctl rpc ...\"`.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.5.2",
+      "description": "The runbook states explicitly that loopctl uses NO Sentry — DB errors are in stdout via Logger, reachable through `fly logs` — so future sessions don't wrongly conclude they lack prod visibility.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.5.3",
+      "description": "A staging/CI 'scale gate' is defined (a tagged test run against the seeded large corpus) that exercises the vector + enumeration endpoints' plan assertions and per-endpoint timeouts; it is documented how to run it before merging a Theme 2/3/4 PR.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.5.4",
+      "description": "The runbook defines the closing checklist for a scale/perf issue: plan-assertion green at scale + EXPLAIN ANALYZE under the timeout on the live build + the live endpoint returns 200 on the reported repro ids — and states that an issue is not 'verified-in-prod' until these pass.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.5.5",
+      "description": "The runbook captures the index-name drift (articles_embedding_hnsw_idx vs articles_embedding_idx) and the canonical capability-based detection snippet (amname='hnsw' / indexdef ILIKE '%hnsw%'), and points to US-27.14 for the reconcile-vs-tolerate decision and the down-migration no-op hazard. It explicitly warns that `DROP INDEX IF EXISTS articles_embedding_idx` silently no-ops against the live `_hnsw_idx` name.",
+      "status": "pending"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "TC-27.5.1",
+      "name": "Runbook exists and references the concrete commands",
+      "type": "unit",
+      "preconditions": [
+        "Repo checkout"
+      ],
+      "steps": [
+        "Open docs/runbooks/knowledge_scale_verification.md"
+      ],
+      "expected_results": [
+        "It has the expected SECTIONS (assert on headings: 'Retrieving the prod error', 'Verifying at scale', 'Closing checklist', 'Index drift') rather than brittle exact-command strings, so a benign command edit doesn't break the test",
+        "Each section is non-empty"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.5.2",
+      "name": "Scale gate runs the plan assertions against the seeded corpus",
+      "type": "integration",
+      "preconditions": [
+        "Scale gate invoked (tagged run) with the US-27.1 fixture seeded"
+      ],
+      "steps": [
+        "Run the scale gate suite"
+      ],
+      "expected_results": [
+        "The vector-endpoint plan assertions (US-27.2) execute and pass at scale",
+        "The default unit suite is unaffected by the gate"
+      ],
+      "status": "pending"
+    }
+  ],
+  "technical_notes": [
+    "This is primarily a documentation + CI-wiring story; the executable pieces (fixture, plan assertions, timeouts) come from US-27.1/27.2/27.4.",
+    "Reference the existing wiki article 'pgvector HNSW: filter-after-ANN' (knowledge id bd4a26b6) and the memory feedback-verify-against-prod-scale.",
+    "fly access is via the authenticated CLI (the operator's account); the rpc form is `/app/bin/loopctl rpc \"<Elixir>\"` (release bin is /app/bin/loopctl).",
+    "Keep the runbook honest about the residual limitation: even a 50–100k staging corpus is an approximation of the 76k+ prod corpus; the live-build confirmation step is still required.",
+    "If a true staging environment isn't available, document the minimum: the scale fixture in CI + the live prod EXPLAIN/logs confirmation as the gate."
+  ],
+  "dependencies": ["US-27.1", "US-27.2", "US-27.4"],
+  "estimated_hours": 5
+}

--- a/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.6a.json
+++ b/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.6a.json
@@ -1,0 +1,141 @@
+{
+  "id": "US-27.6a",
+  "title": "Index-correct pure-ANN kNN helper (correct-by-construction, caller-cost-bounded)",
+  "epic": {
+    "id": "epic_27",
+    "name": "Knowledge Subsystem Performance & Scale Hardening"
+  },
+  "priority": "high",
+  "phase": "vector_layer",
+  "background": {
+    "reference": "GitHub Epic #175, Theme 2; wiki 'pgvector HNSW: filter-after-ANN' (bd4a26b6)",
+    "includes": "Each embedding endpoint hand-rolls its cosine query; search_semantic is the proven index shape; suggested_links had to be rewritten to 'pure ANN subquery + app-side filter'. No correct-by-construction path exists, so a new endpoint can reinvent the index-defeating mistake. Split from the original US-27.6 (16h) per review: this is the critical-path core helper; recall/over-fetch tuning is US-27.6b."
+  },
+  "priority_note": "Highest-leverage perf story — fixes the whole vector-query CLASS. Depends on US-27.1/27.2 so correctness is provable at scale. Unblocks US-27.7a.",
+  "story": {
+    "as_a": "loopctl engineer building or maintaining an embedding-backed endpoint",
+    "i_want_to": "a single shared kNN helper that performs an index-backed `ORDER BY embedding <=> $vec LIMIT k` over published-embedded articles with NO joins or distance-WHERE in the index-ordered query, applying post-filters (self/linked/tag/threshold/visibility) after the index fetch",
+    "so_that": "no endpoint can accidentally defeat the HNSW index, and every embedding endpoint shares one proven, scale-tested ANN path"
+  },
+  "rationale": "The repeated production failures share one root cause — a join or distance filter inside the index-ordered query defeats the HNSW index and forces a full-corpus scan. Encoding the correct shape once and routing every vector endpoint through it makes the failure mode structurally unreachable, far stronger than fixing endpoints one incident at a time.",
+  "acceptance_criteria": [
+    {
+      "id": "AC-27.6a.1",
+      "description": "Loopctl.Knowledge.VectorSearch.nearest/4 (and a `candidate_query/n` returning the queryable for plan tests) accepts tenant_id, a target embedding as a plain [float()] list (never a %Pgvector{} struct — reuse to_embedding_list/1), a k/limit, and opts; builds the pure index-eligible `ORDER BY embedding <=> $vec LIMIT pool` over published non-null-embedding articles, tenant-scoped; returns candidates with similarity_score = GREATEST(0, 1 - distance).",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.6a.2",
+      "description": "The helper NEVER places a JOIN or a distance-based WHERE inside the index-ordered query. Exclusions (self, already-linked either-direction, tag, threshold) and the visibility scope are applied either as index-safe residual filters (equality/membership/metadata, verified not to defeat the index) on the inner query OR in an outer query over the over-fetched pool — matching the verified suggested_links shape.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.6a.3",
+      "description": "The emitted query is index-backed at ≥prod scale: a US-27.2 plan assertion (refute_full_scan + assert_hnsw_index) on the helper's query — WITH the anti-join and threshold post-filters applied — passes (no Seq Scan on articles).",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.6a.4",
+      "description": "Caller-cost bound (OWASP A06 / insecure design): every caller-tunable parameter that affects query cost (k/limit, threshold, pool override, tag/category) has a documented, enforced upper bound; the helper's worst-case cost for the MAXIMUM permitted parameters (e.g. threshold=0, k=max, dense target) is measured at scale and completes under the heavy-read statement_timeout. The statement_timeout is a DESIGNED backstop, not the primary bound.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.6a.5",
+      "description": "Tenant isolation: tenant_id is enforced on every relation (candidate scan AND any anti-join); runs on AdminRepo (BYPASSRLS) with explicit tenant predicates; a tenant-isolation test proves tenant A never receives tenant B candidates.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.6a.6",
+      "description": "The helper does NOT wrap its query in a per-request transaction (the #172 round-1 pool-starvation anti-pattern on the 3-conn admin pool); it is a bare AdminRepo.all, matching search_semantic/distant_pairs.",
+      "status": "pending"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "TC-27.6a.1",
+      "name": "Returns nearest published candidates ranked by similarity, self excluded",
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant); target + neighbors at varying distances"
+      ],
+      "steps": [
+        "VectorSearch.nearest(tenant.id, target_embedding, 5, exclude_id: target.id)"
+      ],
+      "expected_results": [
+        "≤5 candidates, highest similarity first; target excluded; numeric similarity_score each"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.6a.2",
+      "name": "Post-filters applied over the pool, not inside the index query",
+      "type": "integration",
+      "preconditions": [
+        "target + 6 near-identical neighbors; 4 pre-linked to target"
+      ],
+      "steps": [
+        "VectorSearch.nearest(tenant.id, target_embedding, 2, exclude_id: target.id, exclude_linked: true, threshold: 0.5)"
+      ],
+      "expected_results": [
+        "Exactly the 2 unlinked above-threshold neighbors; none of the 4 linked appear"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.6a.3",
+      "name": "Index-backed at scale incl. post-filters",
+      "type": "integration",
+      "preconditions": [
+        "Loopctl.Knowledge.ScaleSeed.seed(tenant.id, count: PROD_FLOOR, link_density: 5)"
+      ],
+      "steps": [
+        "PlanAssertions.refute_full_scan(VectorSearch.candidate_query(tenant.id, vec, 5, exclude_linked: true, threshold: 0.5))"
+      ],
+      "expected_results": [
+        "No Seq Scan on articles; amname='hnsw' index used"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.6a.4",
+      "name": "Worst-case caller params complete under the statement timeout at scale",
+      "type": "integration",
+      "preconditions": [
+        "Loopctl.Knowledge.ScaleSeed.seed(tenant.id, count: PROD_FLOOR, link_density: 10)",
+        "A dense-hub target"
+      ],
+      "steps": [
+        "Call with threshold=0.0, k=max permitted"
+      ],
+      "expected_results": [
+        "Completes under the configured heavy-read statement_timeout"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.6a.5",
+      "name": "Tenant isolation",
+      "type": "integration",
+      "preconditions": [
+        "tenant_a, tenant_b; embedded articles in both"
+      ],
+      "steps": [
+        "VectorSearch.nearest(tenant_a.id, vec, 10)"
+      ],
+      "expected_results": [
+        "No tenant_b article appears"
+      ],
+      "status": "pending"
+    }
+  ],
+  "technical_notes": [
+    "Module: Loopctl.Knowledge.VectorSearch (new). Generalize the verified suggested_links subquery shape: inner pure-ANN (index-safe filters only) -> outer anti-join/threshold/limit over the pool.",
+    "Target = plain [float()] list via to_embedding_list/1 (%Pgvector{} -> Pgvector.to_list/1). Binding the struct was the #168 500.",
+    "AdminRepo (BYPASSRLS) + explicit tenant_id everywhere; NO per-request transaction (pool starvation, Theme 4).",
+    "Composable opts: exclude_id, exclude_linked (bidirectional), threshold, tags, category, visibility scope, k, pool override — each cost-bounded (AC-27.6a.4).",
+    "Over-fetch sizing + recall semantics + under-fill monitoring are split into US-27.6b. This story is the index-correct core + cost bounds + tenant isolation.",
+    "distant_pairs (column-to-column) and nearest_prior_distance (MIN aggregate) do NOT fit nearest/4 — handled in US-27.7b, not here."
+  ],
+  "dependencies": ["US-27.1", "US-27.2"],
+  "estimated_hours": 10
+}

--- a/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.6b.json
+++ b/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.6b.json
@@ -1,0 +1,115 @@
+{
+  "id": "US-27.6b",
+  "title": "kNN over-fetch/recall tuning + observable (non-silent) under-fill",
+  "epic": {
+    "id": "epic_27",
+    "name": "Knowledge Subsystem Performance & Scale Hardening"
+  },
+  "priority": "high",
+  "phase": "vector_layer",
+  "background": {
+    "reference": "GitHub Epic #175, Theme 2; split from original US-27.6; adversarial review F8",
+    "includes": "hnsw.ef_search is never SET (pgvector default ~40); post-filtering an over-fetched pool means a densely-linked hub can have its whole pool filtered out -> suggested_links returns [] while near neighbors exist. The epic exists because a real failure (timeout) was SILENT; a fast, index-backed query returning silently-incomplete results is the same failure class."
+  },
+  "priority_note": "Closes the 'fast-green-but-wrong' gap the adversarial review called the next likely incident. Depends on US-27.6a.",
+  "story": {
+    "as_a": "loopctl operator and agent consumer",
+    "i_want_to": "the kNN helper's over-fetch pool sized for good recall, the ef_search recall ceiling documented and consistent across envs, AND a structured signal emitted whenever the result under-fills (returns fewer than requested because the pool was exhausted by filters)",
+    "so_that": "silent recall incompleteness is observable and alertable — not a quiet wrong answer indistinguishable from 'no neighbors exist'"
+  },
+  "rationale": "Documenting a recall ceiling does not handle it — the whole epic exists because a silent failure shipped. A densely-linked hub returning empty suggestions while neighbors exist is exactly a fast-green-but-wrong result the latency/plan gates can't catch. Making under-fill emit a signal (and keeping ef_search consistent test-vs-prod) converts a silent quality regression into an observable, alertable event.",
+  "acceptance_criteria": [
+    {
+      "id": "AC-27.6b.1",
+      "description": "Over-fetch: the inner pool = max(k * factor, floor) capped by a config max, and ALWAYS floored at k (a misconfigured cap can never drop the pool below the requested k). The factor/floor/cap are config constants with documented defaults.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.6b.2",
+      "description": "When post-filters exhaust the pool such that fewer than k candidates are returned despite the pool being filled to the cap, the helper emits a structured signal (a :telemetry event + optional warn log) carrying tenant_id, endpoint, requested k, pool size, returned count, and exclusion counts — so under-fill is observable, not silent. A scale test asserts the signal fires on a dense-hub target.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.6b.3",
+      "description": "The recall ceiling is documented on VectorSearch AND its consumers: recall is bounded by hnsw.ef_search (default ~40) and the pool; under-fill is expected for densely-linked hubs. The doc states raising ef_search per-request requires a transaction (pool-starvation on the 3-conn pool) AND that ef_search is a custom GUC that CANNOT be set via a Postgrex startup `:parameters` entry (rejected before pgvector loads); the only safe non-transaction lever is `ALTER ROLE … SET hnsw.ef_search` (US-27.11), and only if verified to apply on fly mpg — otherwise recall stays at the default and is handled by over-fetch + the under-fill signal.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.6b.4",
+      "description": "ef_search parity: whatever ef_search value is effective (default, or an ALTER ROLE override from US-27.11) is identical in the scale gate and prod — asserted by `SHOW hnsw.ef_search` on the gate connection vs the prod-shaped connection (NOT comparing :parameters config blobs), so latency/recall don't diverge silently between gate and prod (ties to US-27.8).",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.6b.6",
+      "description": "Consumer-facing signal (not just operator telemetry): when under-fill occurs, the endpoint response `meta` carries a flag (e.g. `recall_truncated: true` / `pool_exhausted: true`) so the AGENT consumer can distinguish an incomplete result from a genuinely-empty one — converting the documented ceiling into a contract signal.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.6b.7",
+      "description": "After this story's pool-sizing cap (AC-27.6b.1) lands, US-27.6a's worst-case caller-cost bound (TC-27.6a.4) is RE-VERIFIED against the final cap (mirrors US-27.11 AC-27.11.6) — so 27.6a's cost proof isn't invalidated by 6b changing the cap underneath.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.6b.5",
+      "description": "The under-fill signal does not leak data (no vector literals/bodies; tenant_id is an id, not content) and does not itself become a per-row cost (one event per request, not per filtered candidate).",
+      "status": "pending"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "TC-27.6b.1",
+      "name": "Pool floor never below k",
+      "type": "unit",
+      "preconditions": [
+        "Config sets max_pool below k for the test"
+      ],
+      "steps": [
+        "Compute the pool for k=50 with a misconfigured cap of 10"
+      ],
+      "expected_results": [
+        "Pool >= 50 (floored at k), not 10"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.6b.2",
+      "name": "Under-fill emits a telemetry signal",
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant)",
+        "A target whose nearest pool neighbors are all already-linked (dense hub)"
+      ],
+      "steps": [
+        "Attach a telemetry handler; call VectorSearch.nearest with exclude_linked, k=5"
+      ],
+      "expected_results": [
+        "Fewer than 5 returned; a [:loopctl, :knowledge, :vector_search, :under_fill] event fired with requested=5, returned<5, pool, exclusion counts"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.6b.3",
+      "name": "Full result emits NO under-fill signal",
+      "type": "integration",
+      "preconditions": [
+        "A target with plenty of unlinked above-threshold neighbors"
+      ],
+      "steps": [
+        "Call with k=5"
+      ],
+      "expected_results": [
+        "5 returned; no under_fill event"
+      ],
+      "status": "pending"
+    }
+  ],
+  "technical_notes": [
+    "Pool: pool = k*factor |> max(floor) |> min(cap) |> max(k). Config: :vector_pool_factor, :vector_pool_floor, :max_vector_pool.",
+    "Under-fill detection: emit when length(results) < k AND the pool was filled to cap (i.e. the index returned >= pool candidates and filters cut below k) — distinguish from 'corpus simply has < k embedded articles'.",
+    "Telemetry event name + payload documented; pairs with US-27.15 (metrics/alerting) which aggregates it.",
+    "ef_search is currently never SET (default 40) — parity holds today; pin it so a future prod ef_search change can't silently diverge from the gate (US-27.8 AC).",
+    "Pool-level ef_search via a dedicated heavy-read pool's :parameters (US-27.11 Option B) is the safe way to raise recall without a per-request transaction."
+  ],
+  "dependencies": ["US-27.6a"],
+  "estimated_hours": 7
+}

--- a/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.7a.json
+++ b/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.7a.json
@@ -1,0 +1,109 @@
+{
+  "id": "US-27.7a",
+  "title": "Route the single-target top-k endpoints through the kNN helper",
+  "epic": {
+    "id": "epic_27",
+    "name": "Knowledge Subsystem Performance & Scale Hardening"
+  },
+  "priority": "high",
+  "phase": "vector_layer",
+  "background": {
+    "reference": "GitHub Epic #175, Theme 2; split from original US-27.7 per review (distant_pairs/novelty are a different shape — US-27.7b)",
+    "includes": "True single-target top-k consumers: semantic search, suggested_links, and the auto-link worker (find the nearest articles to link). These map cleanly onto VectorSearch.nearest/4."
+  },
+  "priority_note": "Realizes US-27.6a's value on the endpoints that actually fit the nearest/k shape. distant_pairs/nearest_prior_distance are handled separately (27.7b) because they are NOT top-k-against-a-constant.",
+  "story": {
+    "as_a": "loopctl engineer",
+    "i_want_to": "migrate semantic search, suggested_links, and the auto-link worker to use the shared kNN helper (US-27.6a) instead of their bespoke cosine queries",
+    "so_that": "the true top-k vector endpoints share one proven, index-correct, scale-tested path, and a future endpoint can't reintroduce a full scan there"
+  },
+  "rationale": "A shared helper only removes the failure class if the fitting endpoints adopt it. Migrating the three genuine single-target top-k consumers collapses duplicated cosine/over-fetch logic into one place and gives each the same scale guard for free, while leaving the genuinely-different shapes (pairs, novelty aggregate) to a separate, honest story.",
+  "acceptance_criteria": [
+    {
+      "id": "AC-27.7a.1",
+      "description": "suggested_links uses VectorSearch.nearest/candidate_query (its verified subquery shape becomes the helper's default path); behavior (excludes self/linked, threshold, limit, ordering) is preserved and its existing tests still pass.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.7a.2",
+      "description": "search_semantic is expressed via the helper (or the helper derived from it) without regressing its proven prod behavior, latency, or result shape (id/title/category/similarity_score + meta).",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.7a.3",
+      "description": "The auto-link worker's similarity lookup uses the helper so background linking cannot full-scan either.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.7a.4",
+      "description": "Behavior/contract preserving: each migrated endpoint's external JSON contract is identical (controllers unchanged); changes are limited to internal query construction; existing controller/context tests pass.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.7a.5",
+      "description": "Tenant isolation and visibility scoping preserved for each; tenant-isolation tests remain green.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.7a.6",
+      "description": "Contract-preserving means CONTRACT-preserving, not SLOW-preserving: if routing an endpoint through the helper does not by itself bring it under the US-27.8 budget at scale, the endpoint is corrected within this story (via the helper) until the scale gate passes — a migrated-but-still-slow endpoint is NOT done.",
+      "status": "pending"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "TC-27.7a.1",
+      "name": "suggested_links behavior preserved through the helper",
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant); {key,_} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})",
+        "target + neighbors + one pre-linked neighbor"
+      ],
+      "steps": [
+        "GET /api/v1/knowledge/articles/:id/suggested_links"
+      ],
+      "expected_results": [
+        "200; excludes self and linked; honors threshold/limit; ranked; identical observable behavior to pre-migration"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.7a.2",
+      "name": "semantic search results unchanged after migration",
+      "type": "integration",
+      "preconditions": [
+        "embedded articles with known relative distances"
+      ],
+      "steps": [
+        "Call semantic search with a query embedding"
+      ],
+      "expected_results": [
+        "Same ranked ids and meta shape; no ordering/score regression"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.7a.3",
+      "name": "Each migrated endpoint index-backed + under budget at scale",
+      "type": "integration",
+      "preconditions": [
+        "Loopctl.Knowledge.ScaleSeed.seed(tenant.id, count: PROD_FLOOR, link_density: 5)"
+      ],
+      "steps": [
+        "Run the US-27.8 plan + latency assertions for search, suggested_links, and the worker lookup"
+      ],
+      "expected_results": [
+        "All index-backed (no Seq Scan) and under budget"
+      ],
+      "status": "pending"
+    }
+  ],
+  "technical_notes": [
+    "Touch points: suggest_links/3 + suggestion_candidates_query/6, search_semantic/3, the auto-link Oban worker.",
+    "Land as one coherent PR; keep external JSON contracts identical.",
+    "The auto-link worker is a background path — its lookup must also be index-correct (a silently full-scanning worker is exactly the kind of rot this epic targets); guarded by US-27.8.",
+    "Preserve existing timeouts; run each endpoint's existing test file plus the US-27.2 scale plan-assertion."
+  ],
+  "dependencies": ["US-27.6a"],
+  "estimated_hours": 10
+}

--- a/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.7b.json
+++ b/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.7b.json
@@ -1,0 +1,98 @@
+{
+  "id": "US-27.7b",
+  "title": "Make distant_pairs & novelty index-correct on their own shapes (NOT nearest/4) + document them as the lint exceptions",
+  "epic": {
+    "id": "epic_27",
+    "name": "Knowledge Subsystem Performance & Scale Hardening"
+  },
+  "priority": "medium",
+  "phase": "vector_layer",
+  "background": {
+    "reference": "GitHub Epic #175, Theme 2; architect review (category-error finding)",
+    "includes": "distant_pairs (do_distant_pairs) is a column-to-column self-join `a.embedding <=> b.embedding` over a bounded sampled subquery — there is NO $const target, so HNSW cannot apply. nearest_prior_distance is `MIN(embedding <=> $const)` — an aggregate, not a top-k ORDER BY, also not HNSW-accelerable. Neither fits VectorSearch.nearest/4."
+  },
+  "priority_note": "Prevents a category error: forcing these onto nearest/4 would change their semantics. They share helpers where sensible and are the NAMED documented exceptions for the 'no hand-rolled cosine' lint.",
+  "story": {
+    "as_a": "loopctl engineer",
+    "i_want_to": "keep distant_pairs and novelty (nearest_prior_distance) on their correct, bounded shapes — reusing the helper's to_embedding_list and candidate-sampling where applicable — and register them explicitly as the documented exceptions to the 'no hand-rolled cosine ORDER BY outside the helper' guard",
+    "so_that": "their behavior and bounds are preserved (not regressed by a forced migration), and the lint (US-27.8) doesn't false-positive on two legitimately-different shapes"
+  },
+  "rationale": "distant_pairs is column-to-column and novelty is a MIN aggregate; neither is a top-k-against-a-constant, so neither can or should consume nearest/4 — routing them through it would change recall semantics. The honest design keeps their shapes, shares only the safe bits (vector list conversion, bounded candidate sampling), and names them up front as the guard's exceptions so the reintroduction-lint stays meaningful.",
+  "acceptance_criteria": [
+    {
+      "id": "AC-27.7b.1",
+      "description": "distant_pairs and nearest_prior_distance are NOT migrated to VectorSearch.nearest/4; the change is limited to sharing to_embedding_list/1 and (for pairs) the bounded candidate-sampling subquery. Their distance computation and outputs are unchanged (behavior-preserving).",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.7b.2",
+      "description": "Their existing bounds are preserved and verified: distant_pairs keeps max_pair_candidates() sampling + its timeout; novelty keeps its prior-set scoping + timeout. Outputs (pairs list/meta, novelty_scores) are identical to pre-change.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.7b.3",
+      "description": "Both are registered as the NAMED, documented exceptions to the US-27.8 'no hand-rolled cosine ORDER BY/distance outside the helper' guard, with a one-line rationale each (column-to-column self-join; MIN aggregate) — so the guard does not false-positive and the exceptions are auditable.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.7b.4",
+      "description": "Each remains tenant-scoped and within its documented latency at scale (US-27.8 covers them too); if either is found to full-scan at scale, it is corrected on its own shape (e.g. the pairs sampling bound) until the gate passes.",
+      "status": "pending"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "TC-27.7b.1",
+      "name": "distant_pairs output unchanged after sharing helpers",
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant); embedded articles at known distances"
+      ],
+      "steps": [
+        "Call distant_pairs before/after the change with the same inputs"
+      ],
+      "expected_results": [
+        "Identical pairs and meta; bounds (max_pair_candidates) preserved"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.7b.2",
+      "name": "novelty scores unchanged",
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant); priors tagged; an idea"
+      ],
+      "steps": [
+        "Call novelty_scores before/after"
+      ],
+      "expected_results": [
+        "Identical novelty_score values and prior_count"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.7b.3",
+      "name": "Lint treats them as known exceptions, not violations",
+      "type": "unit",
+      "preconditions": [
+        "The US-27.8 reintroduction guard"
+      ],
+      "steps": [
+        "Run the guard over the module"
+      ],
+      "expected_results": [
+        "do_distant_pairs and nearest_prior_distance are recognized as registered exceptions; no false-positive failure"
+      ],
+      "status": "pending"
+    }
+  ],
+  "technical_notes": [
+    "do_distant_pairs (knowledge.ex ~3220) — column-to-column BETWEEN over a LIMIT max_pair_candidates() sampled subquery; not HNSW-eligible by nature.",
+    "nearest_prior_distance (knowledge.ex ~3553) — MIN(embedding <=> $const::vector) aggregate; routing through a top-k helper would change recall semantics (top-k then min != true min over the set).",
+    "Share to_embedding_list/1 for the [float()] conversion; do NOT force the nearest/4 shape.",
+    "Register both in whatever mechanism US-27.8 uses for the 'no hand-rolled cosine' guard (an allowlist with rationale)."
+  ],
+  "dependencies": ["US-27.6a"],
+  "estimated_hours": 6
+}

--- a/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.8.json
+++ b/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.8.json
@@ -1,0 +1,124 @@
+{
+  "id": "US-27.8",
+  "title": "Per-endpoint index-usage + latency scale gates for ALL vector endpoints (incl. the auto-link worker)",
+  "epic": {
+    "id": "epic_27",
+    "name": "Knowledge Subsystem Performance & Scale Hardening"
+  },
+  "priority": "high",
+  "phase": "vector_layer",
+  "background": {
+    "reference": "GitHub Epic #175, Theme 2 acceptance ('ALL vector endpoints <2s with a per-endpoint index-usage test')",
+    "includes": "Reviews: the worker was migrated (27.7a) but had no guard; a latency gate at 50k vs 76k+ prod, with ef_search unpinned and measured via EXPLAIN-not-HTTP, is theatre; and a guard on a re-built query is a stunt double."
+  },
+  "priority_note": "Turns Theme 2's acceptance into standing CI gates so a future regression fails CI, not prod. Depends on the scale fixture, the same-query plan helper, and the migrated endpoints.",
+  "story": {
+    "as_a": "loopctl engineer",
+    "i_want_to": "each vector endpoint AND the auto-link worker to carry a scale gate that asserts (a) the CONTROLLER'S ACTUAL query is index-backed (no full Seq Scan) at ≥prod scale, and (b) it returns under a latency budget — with ef_search pinned identical to prod and latency measured end-to-end",
+    "so_that": "any change that defeats the HNSW index or blows the budget fails CI on the real request path, calibrated at/above prod, not on a detached query at half-scale"
+  },
+  "rationale": "The four-attempt history proves index-correctness and latency at scale must be continuously enforced, not verified once — and that the verification must exercise the real request at real scale. A guard on a re-built query, at sub-prod scale, with divergent ef_search, measured via EXPLAIN, would repeat the exact false-confidence that shipped three broken fixes. This story makes the real invariant a permanent, honestly-calibrated CI property.",
+  "acceptance_criteria": [
+    {
+      "id": "AC-27.8.1",
+      "description": "suggested_links, semantic search, distant_pairs, novelty, AND the auto-link worker each have a tagged scale test using the US-27.2 plan assertion that fails if the controller/worker's actual (unforced) query reaches articles via a full Seq Scan + Sort. The auto-link worker (a background path) is explicitly covered — a silently full-scanning worker is exactly the rot this epic targets.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.8.2",
+      "description": "The query under each plan assertion is the controller/worker's ACTUAL emitted query (per US-27.2 AC-27.2.4 — captured from the real path / asserted SQL+params-identical), not independently re-constructed args.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.8.3",
+      "description": "Scale calibration: the gate seeds ≥ PROD_ARTICLE_FLOOR (US-27.1 AC-27.1.6) and `hnsw.ef_search` is set identically (or explicitly left default) in the gate and prod runtime config — asserted by a test; a seed below floor or an ef_search mismatch FAILS the gate.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.8.4",
+      "description": "Latency: the PRIMARY signal is deterministic — the plan is index-backed and the index node returns <= pool rows with no full-corpus Sort. A wall-clock budget (default 2s) is measured END-TO-END through the HTTP endpoint (timed conn call, including checkout/serialize/render), not only via EXPLAIN ANALYZE; the wall-clock check is documented as advisory/secondary so it doesn't get skipped on a flake.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.8.5",
+      "description": "A reintroduction guard (Credo custom check or a test) flags any NEW cosine `ORDER BY embedding <=> ...` / distance computation outside the shared helper, with an explicit allowlist of the documented exceptions (do_distant_pairs, nearest_prior_distance from US-27.7b). CRITICAL: the allowlist exempts only the LINT, NOT the scale plan-gate — any cosine query, allowlisted or not, must still pass refute_full_scan at scale. A test asserts that an index-defeating change INSIDE an allowlisted function still fails the scale gate (the allowlist exempts the location from the lint, not a bad shape from the gate).",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.8.6",
+      "description": "Latency budgets and the seed floor are configurable/documented so the gate is tuned as prod grows beyond the current floor; bumping the floor is a documented step, not a silent default.",
+      "status": "pending"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "TC-27.8.1",
+      "name": "Every vector path (incl. worker) index-backed at ≥prod scale on its real query",
+      "type": "integration",
+      "preconditions": [
+        "Loopctl.Knowledge.ScaleSeed.seed(tenant.id, count: PROD_FLOOR, link_density: 5)"
+      ],
+      "steps": [
+        "For each endpoint + the worker: capture its actual query and run refute_full_scan/1"
+      ],
+      "expected_results": [
+        "All pass (Index Scan, no Seq Scan on articles)"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.8.2",
+      "name": "End-to-end latency budget at scale",
+      "type": "integration",
+      "preconditions": [
+        "Loopctl.Knowledge.ScaleSeed.seed(tenant.id, count: PROD_FLOOR)"
+      ],
+      "steps": [
+        "Time HTTP requests (conn) for suggested_links / search / pairs / novelty for representative inputs"
+      ],
+      "expected_results": [
+        "Each completes under the configured budget end-to-end; plan signal deterministically index-backed"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.8.3",
+      "name": "ef_search / seed-floor mismatch fails the gate",
+      "type": "integration",
+      "preconditions": [
+        "Gate configured with ef_search differing from prod config, or seed < floor"
+      ],
+      "steps": [
+        "Run the gate"
+      ],
+      "expected_results": [
+        "Fails loudly with a clear calibration error"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.8.4",
+      "name": "A new hand-rolled cosine ORDER BY is flagged; known exceptions are not",
+      "type": "unit",
+      "preconditions": [
+        "A fixture introducing a cosine ORDER BY outside the helper"
+      ],
+      "steps": [
+        "Run the guard"
+      ],
+      "expected_results": [
+        "The new bypass is reported; do_distant_pairs/nearest_prior_distance (allowlisted) are not"
+      ],
+      "status": "pending"
+    }
+  ],
+  "technical_notes": [
+    "Reuse Loopctl.PlanAssertions (US-27.2, same-query form) and Loopctl.Knowledge.ScaleSeed (US-27.1).",
+    "Capture the worker's query the same way as controllers (telemetry/explain seam) — the worker has no conn, so expose its query builder for assertion.",
+    "Lead with the deterministic plan signal; keep wall-clock advisory + generous (run on the scale gate, async: false) so it doesn't flake the default suite.",
+    "ef_search parity: assert the gate's and prod's :parameters/runtime ef_search match (or both default).",
+    "Allowlist mechanism for the reintroduction guard names do_distant_pairs + nearest_prior_distance (US-27.7b)."
+  ],
+  "dependencies": ["US-27.2", "US-27.7a", "US-27.7b", "US-27.5"],
+  "estimated_hours": 9
+}

--- a/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.9a.json
+++ b/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.9a.json
@@ -1,0 +1,119 @@
+{
+  "id": "US-27.9a",
+  "title": "Keyset cursor mechanic + supporting index migration + cursor integrity (article list)",
+  "epic": {
+    "id": "epic_27",
+    "name": "Knowledge Subsystem Performance & Scale Hardening"
+  },
+  "priority": "medium",
+  "phase": "pagination",
+  "background": {
+    "reference": "GitHub Epic #175, Theme 3; split from original US-27.9; reviews: missing index + cursor-integrity findings",
+    "includes": "Offset drift observed live (a tag count swung 9,881 -> 4,981 mid-write). The articles table has NO (tenant_id, inserted_at, id) index today (only [:tenant_id], GIN tags, [:tenant_id, project_id, category]). inserted_at is utc_datetime_usec and bulk insert_all ties timestamps per batch, so the keyset MUST be the (inserted_at, id) tuple. The PK is a random UUID (binary_id) — there is NO monotonic bigint to fall back on."
+  },
+  "priority_note": "The cursor mechanic + its required index + its integrity are the critical path; rolling it onto other enumerations is US-27.9b.",
+  "story": {
+    "as_a": "an agent or external observer enumerating the knowledge base",
+    "i_want_to": "a keyset cursor for the article list that is stable under concurrent writes, backed by a real composite index, with the cursor's tenant scope derived from my auth principal (never trusted from the cursor) and the cursor integrity-protected",
+    "so_that": "I can iterate a large list to exhaustion with no offset drift, deep pages stay index-backed, and a forged/tampered cursor can neither cross tenants nor become an existence oracle"
+  },
+  "rationale": "Offset pagination drifts under the concurrent writes this KB sees — observed as a tag count swinging mid-enumeration — so an agent cannot reliably consume the KB. Keyset on a stable unique key fixes that, but only if (a) a supporting index actually exists (it does not today) and (b) the cursor is not a trust boundary: a Base64 blob is encoding, not integrity, so tenant scope must come from the authenticated principal and the cursor must be tamper-evident.",
+  "acceptance_criteria": [
+    {
+      "id": "AC-27.9a.1",
+      "description": "The article list accepts a `cursor` param and returns `meta.next_cursor` (null when exhausted), ordered by the stable unique tuple (inserted_at, id); walking via next_cursor returns every row present for the whole walk exactly once under concurrent inserts/archives (no gaps, no duplicates, no offset drift).",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.9a.2",
+      "description": "A migration creates the composite index `(tenant_id, inserted_at, id)` on articles (CREATE INDEX CONCURRENTLY, outside a ddl transaction) supporting the keyset seek; AC's plan assertion (US-27.2) confirms deep pages are index-backed (no Seq Scan) at ≥prod scale. The keyset uses the (inserted_at, id) TUPLE (timestamps tie under batch inserts); there is NO monotonic-id fallback (PK is a random UUID).",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.9a.3",
+      "description": "Tenant scope is derived EXCLUSIVELY from the authenticated principal, NEVER from the cursor payload; the cursor encodes only an intra-tenant ordering position. A test forges a cursor carrying tenant B's key tuple and proves tenant A's request still returns only tenant A rows.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.9a.4",
+      "description": "The cursor is integrity-protected (HMAC-signed or a server-minted opaque token mapped server-side); a tampered/garbage cursor returns 400 with a clear message — never a 500 and never a silent reset to page 1, and a forged cursor cannot become an existence oracle for another tenant's rows or out-of-range positions.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.9a.5",
+      "description": "limit is honored up to a documented max and never silently clamped down without signaling it (addresses the #148 silent-clamp regression); meta documents the effective limit.",
+      "status": "pending"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "TC-27.9a.1",
+      "name": "Cursor walk complete and gap-free under concurrent inserts",
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant); seed N articles"
+      ],
+      "steps": [
+        "Walk via cursor pages; between pages insert and archive additional articles; collect ids"
+      ],
+      "expected_results": [
+        "Every article present for the whole walk appears exactly once; final next_cursor null"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.9a.2",
+      "name": "Forged cursor cannot cross tenants",
+      "type": "integration",
+      "preconditions": [
+        "tenant_a, tenant_b; a cursor crafted to embed tenant_b's (inserted_at,id)"
+      ],
+      "steps": [
+        "Request the list as tenant_a using the forged cursor"
+      ],
+      "expected_results": [
+        "Either 400 (HMAC rejects) or tenant_a-only rows (cursor key clamped); NEVER any tenant_b row"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.9a.3",
+      "name": "Tampered/garbage cursor -> 400, not 500 or page 1",
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant); {key,_} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})"
+      ],
+      "steps": [
+        "Request with cursor=garbage and with a bit-flipped valid cursor"
+      ],
+      "expected_results": [
+        "400 clear error both times; not 500, not page 1"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.9a.4",
+      "name": "Deep pagination index-backed at scale",
+      "type": "integration",
+      "preconditions": [
+        "Loopctl.Knowledge.ScaleSeed.seed(tenant.id, count: PROD_FLOOR)"
+      ],
+      "steps": [
+        "Build the keyset query for a late page; refute_full_scan/1"
+      ],
+      "expected_results": [
+        "Index-backed via (tenant_id, inserted_at, id); no Seq Scan for deep pages"
+      ],
+      "status": "pending"
+    }
+  ],
+  "technical_notes": [
+    "Keyset seek: WHERE tenant_id = ? AND (inserted_at, id) > (?, ?) ORDER BY inserted_at, id LIMIT n+1 (n+1 for has_more without a COUNT). No OFFSET on the cursor path.",
+    "Migration: CREATE INDEX CONCURRENTLY articles_tenant_inserted_id_idx ON articles (tenant_id, inserted_at, id); @disable_ddl_transaction true; on 76k rows confirm it's online.",
+    "Cursor integrity: HMAC the (inserted_at, id) tuple with an app secret, or mint a server-side opaque token; decode defensively -> 400. Tenant is ALWAYS from conn.assigns principal, never the cursor.",
+    "Reuse LoopctlWeb.Helpers.Pagination if present; keep body-less default (#166); include_body bounds in US-27.10.",
+    "inserted_at is utc_datetime_usec (ties under insert_all) -> the tuple key is necessary; drop any 'monotonic bigint id' idea (no such column)."
+  ],
+  "dependencies": ["US-27.1", "US-27.2"],
+  "estimated_hours": 12
+}

--- a/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.9b.json
+++ b/docs/user_stories/epic_27_knowledge_scale_hardening/us_27.9b.json
@@ -1,0 +1,83 @@
+{
+  "id": "US-27.9b",
+  "title": "Apply the keyset cursor to by-tag / by-source / change-feed enumerations",
+  "epic": {
+    "id": "epic_27",
+    "name": "Knowledge Subsystem Performance & Scale Hardening"
+  },
+  "priority": "medium",
+  "phase": "pagination",
+  "background": {
+    "reference": "GitHub Epic #175, Theme 3; split from original US-27.9",
+    "includes": "The original offset-drift evidence was a by-TAG enumeration (9,881 -> 4,981). The cursor mechanic (US-27.9a) must reach the enumerations agents actually use to walk the KB: by-tag, by-source, and change-feed-style listing."
+  },
+  "priority_note": "Mechanical rollout of US-27.9a's proven cursor to the remaining enumeration surfaces; each must stay index-backed and tenant-safe.",
+  "story": {
+    "as_a": "an agent walking a tag, a source, or the change feed",
+    "i_want_to": "the same stable keyset cursor applied to the by-tag, by-source, and change-feed enumerations",
+    "so_that": "every way I enumerate the KB is drift-free and complete under concurrent writes, not just the bare article list"
+  },
+  "rationale": "The live offset-drift incident was on a by-tag walk, so applying the cursor only to the article list would leave the actual failure surface unfixed. Rolling the proven mechanic onto the tag/source/change-feed enumerations delivers the epic's Theme 3 acceptance ('enumerate a tag to exhaustion under concurrent writes ... stable, complete set').",
+  "acceptance_criteria": [
+    {
+      "id": "AC-27.9b.1",
+      "description": "by-tag, by-source, and change-feed enumerations accept `cursor` and return `meta.next_cursor`, using the US-27.9a keyset mechanic + integrity + auth-derived tenant scope (no re-implementation of the cursor trust model).",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.9b.2",
+      "description": "Each enumeration's keyset query is index-backed at ≥prod scale (US-27.2 plan assertion: no full-corpus Seq Scan). NOTE a GIN array index CANNOT provide ordered output and Postgres uses one index per scan node, so by-tag is NOT 'GIN-for-filter + index-for-order' simultaneously. The honest strategy: small tags GIN-match then Sort over the (bounded) matched set; LARGE tags keyset-seek the btree (tenant_id, inserted_at, id) and apply `tags && ^[tag]` as a recheck filter (turns the O(tag²)-per-walk re-sort into a bounded index range scan). The story picks/states which per tag size; deep-page cost is bounded for the historical 9,881-row tag, accepting a bounded Sort over the matched set only when small.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.9b.3",
+      "description": "Walking a tag to exhaustion under concurrent writes returns a stable, complete set (the literal Theme 3 acceptance); verified by a concurrent-write test on the by-tag path.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-27.9b.4",
+      "description": "Tenant isolation holds on every enumeration (cursor tenant from auth principal); a forged cursor cannot cross tenants on any of them.",
+      "status": "pending"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "TC-27.9b.1",
+      "name": "by-tag walk complete under concurrent writes (the original incident)",
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant); seed many articles with a shared tag"
+      ],
+      "steps": [
+        "Walk the tag via cursor; concurrently insert/archive tagged articles"
+      ],
+      "expected_results": [
+        "Stable, complete set; no drift; no duplicates/gaps for rows present throughout"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-27.9b.2",
+      "name": "by-source / change-feed deep pages index-backed at scale",
+      "type": "integration",
+      "preconditions": [
+        "Loopctl.Knowledge.ScaleSeed.seed(tenant.id, count: PROD_FLOOR)"
+      ],
+      "steps": [
+        "refute_full_scan on a late by-source and change-feed page query"
+      ],
+      "expected_results": [
+        "Index-backed; no full Seq Scan"
+      ],
+      "status": "pending"
+    }
+  ],
+  "technical_notes": [
+    "Reuse US-27.9a's cursor helper verbatim; do not re-implement encode/decode/tenant rules.",
+    "by-tag: GIN tags index filters; (inserted_at, id) orders. by-source: ensure a (tenant_id, source_id, inserted_at, id) index if needed for index-backed deep pages.",
+    "change-feed: already an enumeration (GET /changes?since=...) — align it onto the cursor contract or document why it keeps a since-token (which is itself a keyset).",
+    "All tenant-scoped from the principal."
+  ],
+  "dependencies": ["US-27.9a"],
+  "estimated_hours": 8
+}


### PR DESCRIPTION
## Summary

Decomposes **Epic #175** (knowledge subsystem performance & scale hardening) into **19 user stories** in the project's `docs/user_stories/epic_N/us_N.M.json` format, plus **#176** (streamed export). Planning artifacts only — no code change.

**19 stories · 113 ACs · 62 test cases · ~174h**, dependency-ordered Theme-1-first:

- **Theme 1 — scale testing + observability** (do first): `27.1` committed/ANALYZEd ≥prod-size fixture · `27.2` plan-assertion on the *controller's actual* query (no forced planner) · `27.3` SQLSTATE→structured errors · `27.4` statement_timeout + slow-query logging · `27.5` staging gate + prod-verification runbook
- **Theme 2 — index-correct vector layer**: `27.6a/6b` shared kNN helper + recall/under-fill · `27.7a/7b` migrate fitting endpoints (and keep `distant_pairs`/`novelty` on their own shapes) · `27.8` per-endpoint index + latency gates
- **Theme 3 — cursor pagination**: `27.9a/9b` keyset + integrity + rollout · `27.10` cursor contract + bounded `include_body`
- **Theme 4 — pool + bulk**: `27.11` pool sizing / heavy-read pool · `27.12` set-based bulk (FK-`:restrict`-correct, atomic, bounded)
- **Cross-cutting**: `27.13` remediation when the gate fires · `27.14` HNSW index-name reconcile (decided) · `27.15` telemetry/alerting · `27.16` streamed export (#176)

## How these were produced

Authored with the `user-story-writer` skill, then refined through **two rounds of multi-agent enhanced review** (Opus analyst / architect / adversarial — 6 reviews total), every finding VCA'd against the live code.

Round 2 caught two genuine technical falsehoods that round 1 missed and both are fixed:
- `hnsw.ef_search` is a pgvector custom GUC and **cannot** ride in a Postgrex `:parameters` startup entry (rejected before the extension loads on managed PG) → use `ALTER ROLE … SET`.
- Elixir has **no streaming-zip writer** (`:zip.create([:memory])` materializes — the actual #176 bug) → `27.16` requires bounded memory via keyset-streamed tar.gz / vetted dep / async object-storage, not a single long-lived `Repo.stream`.

Each story carries the session's grounding incidents (the 4-attempt `suggested_links` saga, the `enable_seqscan=off` false-confidence trap, the 3-conn pool starvation, the ~4,000-DELETE cleanup, the 5,000-article export cap), tenant-isolation ACs on every BYPASSRLS path, and prod-verification gates.

Refs #175, #176
