### PR TITLE
Reconcile the HNSW index-name drift between migration and prod (+ migration-safety)

### DIFF
--- a/priv/repo/migrations/20260410022906_add_embedding_hnsw_index.exs
+++ b/priv/repo/migrations/20260410022906_add_embedding_hnsw_index.exs
@@ -4,20 +4,43 @@ defmodule Loopctl.Repo.Migrations.AddEmbeddingHnswIndex do
   @disable_ddl_transaction true
   @disable_migration_lock true
 
-  def change do
+  def up do
     # Only create the HNSW index if the embedding column exists (pgvector was enabled)
-    execute(
-      """
-      DO $$
-      BEGIN
-        IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'articles' AND column_name = 'embedding') THEN
-          IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'articles_embedding_idx') THEN
-            CREATE INDEX articles_embedding_idx ON articles USING hnsw (embedding vector_cosine_ops);
-          END IF;
+    execute("""
+    DO $$
+    BEGIN
+      IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'articles' AND column_name = 'embedding') THEN
+        IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'articles_embedding_idx') THEN
+          CREATE INDEX articles_embedding_idx ON articles USING hnsw (embedding vector_cosine_ops);
         END IF;
-      END $$;
-      """,
-      "DROP INDEX IF EXISTS articles_embedding_idx"
-    )
+      END IF;
+    END $$;
+    """)
+  end
+
+  def down do
+    # AC-27.14.2: drop WHICHEVER hnsw index is actually present on
+    # articles(embedding), detected by access method (amname='hnsw'), NOT by
+    # a hard-coded name. The original down-step was
+    # `DROP INDEX IF EXISTS articles_embedding_idx`, which silently NO-OPs
+    # against prod's out-of-band `articles_embedding_hnsw_idx` — a rollback
+    # that would leave the live index orphaned. This handles either name.
+    execute("""
+    DO $$
+    DECLARE idx text;
+    BEGIN
+      SELECT i.relname INTO idx
+      FROM pg_index x
+      JOIN pg_class i ON i.oid = x.indexrelid
+      JOIN pg_class t ON t.oid = x.indrelid
+      JOIN pg_am    am ON am.oid = i.relam
+      WHERE t.relname = 'articles' AND am.amname = 'hnsw'
+      LIMIT 1;
+
+      IF idx IS NOT NULL THEN
+        EXECUTE format('DROP INDEX IF EXISTS %I', idx);
+      END IF;
+    END $$;
+    """)
   end
 end

--- a/priv/repo/migrations/20260410022906_add_embedding_hnsw_index.exs
+++ b/priv/repo/migrations/20260410022906_add_embedding_hnsw_index.exs
@@ -5,12 +5,29 @@ defmodule Loopctl.Repo.Migrations.AddEmbeddingHnswIndex do
   @disable_migration_lock true
 
   def up do
-    # Only create the HNSW index if the embedding column exists (pgvector was enabled)
+    # Only create the HNSW index if the embedding column exists (pgvector was
+    # enabled). AC-27.14.2: the existence guard is capability-based (ANY hnsw
+    # index on articles already present), symmetric with down/0's amname-based
+    # detection — NOT a hard-coded `indexname = 'articles_embedding_idx'`
+    # check. The old name-based guard only saw the migration's own name, so
+    # from prod's drift state {articles_embedding_hnsw_idx} this up-step would
+    # create a SECOND, redundant hnsw index. By skipping when any hnsw index on
+    # articles(embedding) exists (detected by am.amname='hnsw', the same
+    # pg_index/pg_am join down/0 and the reconcile migration use), the two-index
+    # state can never arise.
     execute("""
     DO $$
     BEGIN
       IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'articles' AND column_name = 'embedding') THEN
-        IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'articles_embedding_idx') THEN
+        IF NOT EXISTS (
+          SELECT 1
+          FROM pg_index x
+          JOIN pg_class i ON i.oid = x.indexrelid
+          JOIN pg_class t ON t.oid = x.indrelid
+          JOIN pg_namespace n ON n.oid = t.relnamespace
+          JOIN pg_am    am ON am.oid = i.relam
+          WHERE t.relname = 'articles' AND n.nspname = 'public' AND am.amname = 'hnsw'
+        ) THEN
           CREATE INDEX articles_embedding_idx ON articles USING hnsw (embedding vector_cosine_ops);
         END IF;
       END IF;
@@ -19,27 +36,29 @@ defmodule Loopctl.Repo.Migrations.AddEmbeddingHnswIndex do
   end
 
   def down do
-    # AC-27.14.2: drop WHICHEVER hnsw index is actually present on
-    # articles(embedding), detected by access method (amname='hnsw'), NOT by
-    # a hard-coded name. The original down-step was
-    # `DROP INDEX IF EXISTS articles_embedding_idx`, which silently NO-OPs
-    # against prod's out-of-band `articles_embedding_hnsw_idx` — a rollback
-    # that would leave the live index orphaned. This handles either name.
+    # AC-27.14.2: drop ALL hnsw indexes actually present on articles(embedding),
+    # detected by access method (amname='hnsw'), NOT by a hard-coded name. The
+    # original down-step was `DROP INDEX IF EXISTS articles_embedding_idx`,
+    # which silently NO-OPs against prod's out-of-band
+    # `articles_embedding_hnsw_idx` — a rollback that would leave the live index
+    # orphaned. Iterating over EVERY hnsw index (rather than `LIMIT 1`) means
+    # that even if multiple hnsw indexes somehow coexist, the down-step leaves
+    # none orphaned.
     execute("""
     DO $$
     DECLARE idx text;
     BEGIN
-      SELECT i.relname INTO idx
-      FROM pg_index x
-      JOIN pg_class i ON i.oid = x.indexrelid
-      JOIN pg_class t ON t.oid = x.indrelid
-      JOIN pg_am    am ON am.oid = i.relam
-      WHERE t.relname = 'articles' AND am.amname = 'hnsw'
-      LIMIT 1;
-
-      IF idx IS NOT NULL THEN
+      FOR idx IN
+        SELECT i.relname
+        FROM pg_index x
+        JOIN pg_class i ON i.oid = x.indexrelid
+        JOIN pg_class t ON t.oid = x.indrelid
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        JOIN pg_am    am ON am.oid = i.relam
+        WHERE t.relname = 'articles' AND n.nspname = 'public' AND am.amname = 'hnsw'
+      LOOP
         EXECUTE format('DROP INDEX IF EXISTS %I', idx);
-      END IF;
+      END LOOP;
     END $$;
     """)
   end

--- a/priv/repo/migrations/20260624120000_reconcile_hnsw_index_name.exs
+++ b/priv/repo/migrations/20260624120000_reconcile_hnsw_index_name.exs
@@ -1,0 +1,102 @@
+defmodule Loopctl.Repo.Migrations.ReconcileHnswIndexName do
+  use Ecto.Migration
+
+  # NO @disable_ddl_transaction — `ALTER INDEX ... RENAME` is metadata-only
+  # (a brief ACCESS EXCLUSIVE lock, no table rewrite), so it WANTS the DDL
+  # transaction. The rename + the idempotency guard run atomically.
+  #
+  # (Contrast: the CONCURRENT-recreate path — only needed if NO hnsw index
+  # exists — would FORBID the transaction and require
+  # `@disable_ddl_transaction true` / `@disable_migration_lock true`. Prod
+  # was inspected before writing this migration: it already has a single
+  # hnsw index named `articles_embedding_hnsw_idx`, so the RENAME path is
+  # the correct, cheap, no-rewrite choice on the ~76k-row index.)
+
+  @moduledoc """
+  US-27.14 — Reconcile the HNSW index-name drift between the migration and prod.
+
+  ## The problem
+
+  Migration `20260410022906_add_embedding_hnsw_index.exs` creates the HNSW
+  index on `articles(embedding)` as `articles_embedding_idx`. In PROD the
+  live index was created out-of-band as `articles_embedding_hnsw_idx`. Three
+  sibling stories tolerated this with name-agnostic detection
+  (`articles_embedding(_hnsw)?_idx`), which masked a latent rollback bug:
+  the old migration's down-step `DROP INDEX IF EXISTS articles_embedding_idx`
+  silently NO-OPs against prod's differently-named index.
+
+  ## The decision (USER sign-off 2026-06-24): RECONCILE to ONE canonical name
+
+  Canonical name = `articles_embedding_hnsw_idx` (= whatever prod already
+  uses, so the common path is a cheap, metadata-only RENAME and the live
+  ~76k-row index is never rebuilt).
+
+  This migration is **idempotent**:
+
+    * If the canonical `articles_embedding_hnsw_idx` already exists → no-op
+      (the prod case, and the case where this migration was already applied).
+    * Else, if ANY hnsw index on `articles(embedding)` exists under a
+      non-canonical name (e.g. the test DB, where the old migration created
+      `articles_embedding_idx`) → `ALTER INDEX ... RENAME TO` the canonical
+      name. Detection is by `am.amname = 'hnsw'`, NOT by a hard-coded name.
+    * Else (no hnsw index at all, e.g. a build without pgvector) → no-op.
+
+  After this lands, US-27.1/27.2/27.5 tighten the `(_hnsw)?_idx` tolerance to
+  the single canonical name (still asserting `amname = 'hnsw'`).
+
+  ## Canonical detection snippet (AC-27.14.4)
+
+  Robust, name-independent detection of the HNSW index on `articles`:
+
+      -- Simplest (by index definition):
+      SELECT indexname
+      FROM pg_indexes
+      WHERE tablename = 'articles' AND indexdef ILIKE '%hnsw%';
+
+      -- Or by access method (what this migration uses), exact:
+      SELECT i.relname
+      FROM pg_index x
+      JOIN pg_class i ON i.oid = x.indexrelid
+      JOIN pg_class t ON t.oid = x.indrelid
+      JOIN pg_am    am ON am.oid = i.relam
+      WHERE t.relname = 'articles' AND am.amname = 'hnsw';
+  """
+
+  def up do
+    execute("""
+    DO $$
+    DECLARE idx text;
+    BEGIN
+      -- Already canonical (prod, or this migration already ran): no-op.
+      IF EXISTS (SELECT 1 FROM pg_class WHERE relname = 'articles_embedding_hnsw_idx') THEN
+        RETURN;
+      END IF;
+
+      -- Find whichever hnsw index on articles is present, by access method
+      -- (not by name) so we catch the test-DB `articles_embedding_idx` and
+      -- any other out-of-band name.
+      SELECT i.relname INTO idx
+      FROM pg_index x
+      JOIN pg_class i ON i.oid = x.indexrelid
+      JOIN pg_class t ON t.oid = x.indrelid
+      JOIN pg_am    am ON am.oid = i.relam
+      WHERE t.relname = 'articles' AND am.amname = 'hnsw'
+      LIMIT 1;
+
+      IF idx IS NOT NULL THEN
+        EXECUTE format('ALTER INDEX %I RENAME TO articles_embedding_hnsw_idx', idx);
+      END IF;
+      -- No hnsw index present (e.g. pgvector disabled): nothing to reconcile.
+    END $$;
+    """)
+  end
+
+  # The reconcile is a forward-only normalization; there is no destructive
+  # rollback. Renaming the canonical index back to the old migration name
+  # would only re-introduce the drift this story exists to remove, and the
+  # old name is no longer referenced anywhere after AC-27.14.3. So `down` is
+  # a deliberate no-op. (The orphaned-index / silent-no-op hazard that this
+  # story fixes lives in the OLD migration's down-step, which is patched
+  # separately per AC-27.14.2.)
+  def down, do: :ok
+end

--- a/priv/repo/migrations/20260624120000_reconcile_hnsw_index_name.exs
+++ b/priv/repo/migrations/20260624120000_reconcile_hnsw_index_name.exs
@@ -5,6 +5,18 @@ defmodule Loopctl.Repo.Migrations.ReconcileHnswIndexName do
   # (a brief ACCESS EXCLUSIVE lock, no table rewrite), so it WANTS the DDL
   # transaction. The rename + the idempotency guard run atomically.
   #
+  # NO @disable_migration_lock either — and that is deliberate, not an
+  # oversight. This migration runs inside Ecto's default
+  # `pg_advisory_xact_lock` migration lock, which is acceptable here because:
+  #
+  #   1. On PROD the canonical `articles_embedding_hnsw_idx` already exists,
+  #      so the up-step RETURNs at the idempotency guard BEFORE any DDL — no
+  #      lock is ever held against the live ~76k-row index.
+  #   2. Where it DOES fire (e.g. the test DB renaming `articles_embedding_idx`),
+  #      `ALTER INDEX ... RENAME` is metadata-only: a brief ACCESS EXCLUSIVE
+  #      lock with no rewrite, so holding the migration lock for its duration
+  #      is cheap and safe.
+  #
   # (Contrast: the CONCURRENT-recreate path — only needed if NO hnsw index
   # exists — would FORBID the transaction and require
   # `@disable_ddl_transaction true` / `@disable_migration_lock true`. Prod
@@ -68,7 +80,23 @@ defmodule Loopctl.Repo.Migrations.ReconcileHnswIndexName do
     DECLARE idx text;
     BEGIN
       -- Already canonical (prod, or this migration already ran): no-op.
-      IF EXISTS (SELECT 1 FROM pg_class WHERE relname = 'articles_embedding_hnsw_idx') THEN
+      -- Use the SAME predicate as the detection query below — the canonical
+      -- hnsw index on `articles` already present — rather than a bare
+      -- relname match. A bare `pg_class.relname` check is unqualified by
+      -- relkind/access-method/namespace, so an unrelated object squatting
+      -- the name (table, view, sequence, or an index of another AM, in ANY
+      -- schema) would RETURN early and silently skip reconciliation, leaving
+      -- the very drift this migration exists to fix.
+      IF EXISTS (
+        SELECT 1
+        FROM pg_index x
+        JOIN pg_class i ON i.oid = x.indexrelid
+        JOIN pg_class t ON t.oid = x.indrelid
+        JOIN pg_am    am ON am.oid = i.relam
+        WHERE t.relname = 'articles'
+          AND am.amname = 'hnsw'
+          AND i.relname = 'articles_embedding_hnsw_idx'
+      ) THEN
         RETURN;
       END IF;
 

--- a/priv/repo/migrations/20260624120000_reconcile_hnsw_index_name.exs
+++ b/priv/repo/migrations/20260624120000_reconcile_hnsw_index_name.exs
@@ -65,13 +65,15 @@ defmodule Loopctl.Repo.Migrations.ReconcileHnswIndexName do
       FROM pg_indexes
       WHERE tablename = 'articles' AND indexdef ILIKE '%hnsw%';
 
-      -- Or by access method (what this migration uses), exact:
+      -- Or by access method (what this migration uses), exact and
+      -- schema-qualified to the public `articles`:
       SELECT i.relname
       FROM pg_index x
       JOIN pg_class i ON i.oid = x.indexrelid
       JOIN pg_class t ON t.oid = x.indrelid
+      JOIN pg_namespace n ON n.oid = t.relnamespace
       JOIN pg_am    am ON am.oid = i.relam
-      WHERE t.relname = 'articles' AND am.amname = 'hnsw';
+      WHERE t.relname = 'articles' AND n.nspname = 'public' AND am.amname = 'hnsw';
   """
 
   def up do
@@ -84,16 +86,25 @@ defmodule Loopctl.Repo.Migrations.ReconcileHnswIndexName do
       -- hnsw index on `articles` already present — rather than a bare
       -- relname match. A bare `pg_class.relname` check is unqualified by
       -- relkind/access-method/namespace, so an unrelated object squatting
-      -- the name (table, view, sequence, or an index of another AM, in ANY
+      -- the name (table, view, sequence, or an index of another AM, in any
       -- schema) would RETURN early and silently skip reconciliation, leaving
-      -- the very drift this migration exists to fix.
+      -- the very drift this migration exists to fix. The `n.nspname = 'public'`
+      -- join below makes that namespace-safety claim TRUE: in a hypothetical
+      -- multi-schema (schema-per-tenant) deployment with more than one
+      -- `articles` relation, this predicate matches only the one in `public`,
+      -- so neither the guard nor the RENAME below can touch a same-named
+      -- relation in another schema. (loopctl is single-schema RLS today, so in
+      -- practice exactly one `articles` exists — but the predicate is correct
+      -- ahead of any future schema-per-tenant move.)
       IF EXISTS (
         SELECT 1
         FROM pg_index x
         JOIN pg_class i ON i.oid = x.indexrelid
         JOIN pg_class t ON t.oid = x.indrelid
+        JOIN pg_namespace n ON n.oid = t.relnamespace
         JOIN pg_am    am ON am.oid = i.relam
         WHERE t.relname = 'articles'
+          AND n.nspname = 'public'
           AND am.amname = 'hnsw'
           AND i.relname = 'articles_embedding_hnsw_idx'
       ) THEN
@@ -102,13 +113,15 @@ defmodule Loopctl.Repo.Migrations.ReconcileHnswIndexName do
 
       -- Find whichever hnsw index on articles is present, by access method
       -- (not by name) so we catch the test-DB `articles_embedding_idx` and
-      -- any other out-of-band name.
+      -- any other out-of-band name. Same `public`-schema qualification as the
+      -- guard above, so the RENAME target is always the public `articles`.
       SELECT i.relname INTO idx
       FROM pg_index x
       JOIN pg_class i ON i.oid = x.indexrelid
       JOIN pg_class t ON t.oid = x.indrelid
+      JOIN pg_namespace n ON n.oid = t.relnamespace
       JOIN pg_am    am ON am.oid = i.relam
-      WHERE t.relname = 'articles' AND am.amname = 'hnsw'
+      WHERE t.relname = 'articles' AND n.nspname = 'public' AND am.amname = 'hnsw'
       LIMIT 1;
 
       IF idx IS NOT NULL THEN

--- a/test/loopctl/knowledge_embedding_test.exs
+++ b/test/loopctl/knowledge_embedding_test.exs
@@ -171,11 +171,15 @@ defmodule Loopctl.KnowledgeEmbeddingTest do
   end
 
   # TC-20.2.7: HNSW index exists
+  # US-27.14: reconciled to the single canonical name `articles_embedding_hnsw_idx`
+  # (matches prod). The reconcile migration renames the old migration's
+  # `articles_embedding_idx` to this name in every env, so the assertion is now
+  # exact rather than name-agnostic (still asserting the hnsw access method).
   describe "HNSW index" do
-    test "articles_embedding_idx exists on articles table" do
+    test "articles_embedding_hnsw_idx exists on articles table" do
       result =
         Loopctl.AdminRepo.query!(
-          "SELECT indexname, indexdef FROM pg_indexes WHERE tablename = 'articles' AND indexname = 'articles_embedding_idx'"
+          "SELECT indexname, indexdef FROM pg_indexes WHERE tablename = 'articles' AND indexname = 'articles_embedding_hnsw_idx'"
         )
 
       assert length(result.rows) == 1

--- a/test/loopctl/repo/reconcile_hnsw_index_migration_test.exs
+++ b/test/loopctl/repo/reconcile_hnsw_index_migration_test.exs
@@ -116,4 +116,30 @@ defmodule Loopctl.Repo.ReconcileHnswIndexMigrationTest do
     run_migration(ReconcileHnswIndexName, :up)
     assert hnsw_index_names() == [@canonical]
   end
+
+  test "guard does not treat a non-hnsw object squatting the canonical name as 'already reconciled'" do
+    # Failure mode the tightened idempotency guard fixes: a bare
+    # `pg_class.relname = 'articles_embedding_hnsw_idx'` check matches ANY
+    # relation of that name (table, view, sequence, or an index of another AM)
+    # and RETURNs early, silently reporting success while the real hnsw index
+    # still sits under a non-canonical name — leaving the very drift this
+    # migration exists to remove.
+    #
+    # Set up exactly that: the real hnsw index lives under the non-canonical
+    # name, and an UNRELATED table squats the canonical name. Postgres puts
+    # tables and indexes in the same relation namespace, so reconciliation
+    # legitimately cannot complete (the RENAME target is occupied). The CORRECT
+    # behavior is to surface that conflict by raising — NOT to short-circuit at
+    # the guard and report a false success. The old bare-relname guard would
+    # have hidden the drift by returning early; the amname='hnsw' guard does
+    # not, so the migration proceeds to the RENAME and raises on the collision.
+    AdminRepo.query!("ALTER INDEX #{@canonical} RENAME TO #{@noncanonical}")
+    AdminRepo.query!("CREATE TABLE #{@canonical} (id int)")
+
+    assert hnsw_index_names() == [@noncanonical]
+
+    assert_raise Postgrex.Error, fn ->
+      run_migration(ReconcileHnswIndexName, :up)
+    end
+  end
 end

--- a/test/loopctl/repo/reconcile_hnsw_index_migration_test.exs
+++ b/test/loopctl/repo/reconcile_hnsw_index_migration_test.exs
@@ -18,8 +18,19 @@ defmodule Loopctl.Repo.ReconcileHnswIndexMigrationTest do
   canonical index intact for every other test (the index DDL here is
   non-concurrent, so it runs happily inside a transaction). It does NOT touch
   `schema_migrations`; it invokes the migration modules' `up/0` / `down/0`
-  directly via `Ecto.Migration.Runner`, which is exactly the code path
-  `Ecto.Migrator` uses.
+  directly via `Ecto.Migration.Runner.run/8`.
+
+  Scope of what this exercises: `Runner.run/8` starts the runner Agent and
+  calls `perform_operation/3` — it executes the migrations' SQL and detection
+  logic, which is what this test validates. It does NOT manage transactions or
+  consult `@disable_ddl_transaction` / `@disable_migration_lock`; that logic
+  lives one layer up in `Ecto.Migrator.run_maybe_in_transaction/4`, which this
+  test deliberately bypasses. Consequently the old `AddEmbeddingHnswIndex`
+  migration's `@disable_ddl_transaction true` is NOT honored here: its DDL runs
+  on the sandbox connection INSIDE the test transaction (which is exactly what
+  makes the test safe and self-cleaning), rather than outside a transaction as
+  it would under the real migrator. This test therefore proves the SQL /
+  detection behavior, not the disable-ddl-transaction behavior.
 
   `async: false` because it mutates a shared, table-level index whose name
   other (async) tests assert on — the sandbox isolates the data, but the
@@ -94,6 +105,35 @@ defmodule Loopctl.Repo.ReconcileHnswIndexMigrationTest do
 
     run_migration(ReconcileHnswIndexName, :up)
     assert hnsw_index_names() == [@canonical]
+  end
+
+  test "old up-step does not create a duplicate hnsw index from the prod drift state (AC-27.14.2)" do
+    # Reproduce prod's drift: the single hnsw index lives under the out-of-band
+    # name `articles_embedding_hnsw_idx`, NOT the migration's `articles_embedding_idx`.
+    assert hnsw_index_names() == [@canonical]
+
+    # The amname-aware up-guard must see the existing hnsw index and SKIP, so
+    # no second redundant hnsw index is created. (The old name-based guard
+    # `indexname = 'articles_embedding_idx'` would have created a duplicate.)
+    run_migration(AddEmbeddingHnswIndex, :up)
+
+    assert hnsw_index_names() == [@canonical],
+           "up-step must not create a duplicate hnsw index when one already exists under a different name"
+  end
+
+  test "down-step drops ALL hnsw indexes, leaving none orphaned (AC-27.14.2)" do
+    # Force the (normally unreachable) two-index state to prove the down-step
+    # iterates over every hnsw index rather than dropping only one (LIMIT 1).
+    AdminRepo.query!(
+      "CREATE INDEX articles_embedding_idx ON articles USING hnsw (embedding vector_cosine_ops)"
+    )
+
+    assert Enum.sort(hnsw_index_names()) == Enum.sort([@canonical, @noncanonical])
+
+    run_migration(AddEmbeddingHnswIndex, :down)
+
+    assert hnsw_index_names() == [],
+           "down-step must drop every hnsw index, leaving none orphaned"
   end
 
   test "reconcile migration renames a non-canonical hnsw index to the canonical name" do

--- a/test/loopctl/repo/reconcile_hnsw_index_migration_test.exs
+++ b/test/loopctl/repo/reconcile_hnsw_index_migration_test.exs
@@ -1,0 +1,119 @@
+defmodule Loopctl.Repo.ReconcileHnswIndexMigrationTest do
+  @moduledoc """
+  US-27.14 / TC-27.14.1 — integration test for the HNSW index-name reconcile.
+
+  Exercises the REAL migration modules (`AddEmbeddingHnswIndex` and
+  `ReconcileHnswIndexName`) against the live AdminRepo connection, proving:
+
+    * the OLD migration's fixed `down/0` drops WHICHEVER hnsw index is present
+      (by `amname='hnsw'`, not a hard-coded name) — so a rollback against a DB
+      where the index lives under a non-migration name (prod's
+      `articles_embedding_hnsw_idx`, or any out-of-band name) actually drops it
+      instead of silently no-opping; and
+    * the reconcile migration is idempotent and renames any non-canonical hnsw
+      index up to the canonical `articles_embedding_hnsw_idx`.
+
+  Runs inside the SQL sandbox transaction so the index DDL it performs is
+  fully rolled back at the end of each test, leaving the shared test DB's
+  canonical index intact for every other test (the index DDL here is
+  non-concurrent, so it runs happily inside a transaction). It does NOT touch
+  `schema_migrations`; it invokes the migration modules' `up/0` / `down/0`
+  directly via `Ecto.Migration.Runner`, which is exactly the code path
+  `Ecto.Migrator` uses.
+
+  `async: false` because it mutates a shared, table-level index whose name
+  other (async) tests assert on — the sandbox isolates the data, but the
+  index rename must not race those assertions.
+  """
+  use ExUnit.Case, async: false
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Ecto.Migration.Runner
+  alias Loopctl.AdminRepo
+
+  # Migration files in priv/repo/migrations are not compiled into the app, so
+  # load the two we exercise by path (idempotent — guarded against re-loading
+  # when the test module is recompiled).
+  @migrations_path "priv/repo/migrations"
+  unless Code.ensure_loaded?(Loopctl.Repo.Migrations.AddEmbeddingHnswIndex) do
+    Code.require_file("#{@migrations_path}/20260410022906_add_embedding_hnsw_index.exs")
+  end
+
+  unless Code.ensure_loaded?(Loopctl.Repo.Migrations.ReconcileHnswIndexName) do
+    Code.require_file("#{@migrations_path}/20260624120000_reconcile_hnsw_index_name.exs")
+  end
+
+  alias Loopctl.Repo.Migrations.AddEmbeddingHnswIndex
+  alias Loopctl.Repo.Migrations.ReconcileHnswIndexName
+
+  @canonical "articles_embedding_hnsw_idx"
+  @noncanonical "articles_embedding_idx"
+
+  setup do
+    pid = Sandbox.start_owner!(AdminRepo, shared: true)
+    on_exit(fn -> Sandbox.stop_owner(pid) end)
+    :ok
+  end
+
+  defp hnsw_index_names do
+    AdminRepo.query!("""
+    SELECT i.relname
+    FROM pg_index x
+    JOIN pg_class i ON i.oid = x.indexrelid
+    JOIN pg_class t ON t.oid = x.indrelid
+    JOIN pg_am    am ON am.oid = i.relam
+    WHERE t.relname = 'articles' AND am.amname = 'hnsw'
+    """).rows
+    |> List.flatten()
+  end
+
+  defp run_migration(module, op) do
+    Runner.run(AdminRepo, [], 0, module, :forward, op, op, log: false)
+  end
+
+  test "down-migration drops the actually-present HNSW index (non-migration name)" do
+    # Precondition: a DB where the hnsw index exists under a NON-migration
+    # name — i.e. exactly prod's situation. Rename the canonical test index
+    # to a foreign name so the only hnsw index is not what the old migration
+    # hard-coded.
+    AdminRepo.query!("ALTER INDEX #{@canonical} RENAME TO articles_embedding_out_of_band_idx")
+
+    assert hnsw_index_names() == ["articles_embedding_out_of_band_idx"]
+
+    # The FIXED down-step must drop it by amname, not silently no-op on a
+    # hard-coded `articles_embedding_idx`.
+    run_migration(AddEmbeddingHnswIndex, :down)
+
+    assert hnsw_index_names() == [],
+           "down-migration must drop the present hnsw index, not no-op against a foreign name"
+
+    # And the up-step recreates it (under the old migration's name), which the
+    # reconcile migration then renames to the canonical name.
+    run_migration(AddEmbeddingHnswIndex, :up)
+    assert hnsw_index_names() == [@noncanonical]
+
+    run_migration(ReconcileHnswIndexName, :up)
+    assert hnsw_index_names() == [@canonical]
+  end
+
+  test "reconcile migration renames a non-canonical hnsw index to the canonical name" do
+    # Simulate a fresh test DB: only the old migration's name is present.
+    AdminRepo.query!("ALTER INDEX #{@canonical} RENAME TO #{@noncanonical}")
+    assert hnsw_index_names() == [@noncanonical]
+
+    run_migration(ReconcileHnswIndexName, :up)
+    assert hnsw_index_names() == [@canonical]
+  end
+
+  test "reconcile migration is idempotent — re-running it is a no-op" do
+    assert hnsw_index_names() == [@canonical]
+
+    # Already canonical: first run is a no-op...
+    run_migration(ReconcileHnswIndexName, :up)
+    assert hnsw_index_names() == [@canonical]
+
+    # ...and a second run is also a no-op (the guard short-circuits).
+    run_migration(ReconcileHnswIndexName, :up)
+    assert hnsw_index_names() == [@canonical]
+  end
+end

--- a/test/loopctl_web/controllers/knowledge_suggest_links_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_suggest_links_controller_test.exs
@@ -47,8 +47,8 @@ defmodule LoopctlWeb.KnowledgeSuggestLinksControllerTest do
     #   * #172: the target embedding is a BOUND list parameter and the `articles` table
     #     appears EXACTLY ONCE — there is no self-join to read the target vector as a
     #     column. The bound-`^param` left-vs-const form is what the HNSW index
-    #     (`articles_embedding_idx`, vector_cosine_ops) accelerates; the old self-join
-    #     forced a per-row cosine + full sort over the whole corpus.
+    #     (`articles_embedding_hnsw_idx`, vector_cosine_ops) accelerates; the old
+    #     self-join forced a per-row cosine + full sort over the whole corpus.
     #   * #168: that bound param is a plain LIST of floats, NEVER the stored `%Pgvector{}`
     #     struct (binding the struct was the original 500).
     #
@@ -85,7 +85,7 @@ defmodule LoopctlWeb.KnowledgeSuggestLinksControllerTest do
     # scale the planner seq-scans 6 rows happily; only at prod scale (~76k rows) does the
     # Seq Scan + Sort blow the statement timeout. Verified against the real prod corpus,
     # the fix is a subquery: the inner ANN (`ORDER BY embedding <=> $const LIMIT pool`) uses
-    # `articles_embedding_idx`; the anti-join + threshold live in the OUTER query (each
+    # `articles_embedding_hnsw_idx`; the anti-join + threshold live in the OUTER query (each
     # would defeat the index if pushed inside). With seq-scan disabled the planner must
     # reach `articles` via that index — so the plan names the HNSW index and contains NO
     # `Seq Scan on articles`. (An outer Sort over the small candidate pool is expected and
@@ -114,10 +114,10 @@ defmodule LoopctlWeb.KnowledgeSuggestLinksControllerTest do
         end)
 
       # The corpus is read through the HNSW index as an INDEX SCAN for the ordering
-      # (not merely the index name appearing somewhere). Tolerates the index-name drift
-      # between envs (`articles_embedding_idx` in test, `articles_embedding_hnsw_idx` in
-      # prod) — both are the HNSW cosine index.
-      assert plan =~ ~r/Index Scan using articles_embedding(_hnsw)?_idx/
+      # (not merely the index name appearing somewhere). US-27.14 reconciled the
+      # index name to the single canonical `articles_embedding_hnsw_idx` in every env
+      # (test + prod), so this assertion is now exact rather than name-agnostic.
+      assert plan =~ ~r/Index Scan using articles_embedding_hnsw_idx/
       # ...never a full-corpus Seq Scan (the #170/#172 production 500).
       refute plan =~ ~r/Seq Scan on articles\b/i
     end


### PR DESCRIPTION
## US-27.14 — Reconcile HNSW index-name drift (migration + migration-safety)

### Problem
Migration `20260410022906_add_embedding_hnsw_index.exs` creates the HNSW index on `articles(embedding)` as `articles_embedding_idx`. In PROD the live index was created out-of-band as `articles_embedding_hnsw_idx`. Sibling stories tolerated the drift with name-agnostic `(_hnsw)?_idx` detection, which masked a latent rollback bug: the old migration down-step `DROP INDEX IF EXISTS articles_embedding_idx` silently NO-OPs against prod's differently-named index — a rollback that would orphan the live index.

### Prod inspection (done before writing the migration)
Queried `loopctl-db` (fly managed Postgres) — `articles` has exactly one HNSW index, named `articles_embedding_hnsw_idx`, and NO `articles_embedding_idx`. So the cheap, no-rewrite **RENAME path** is correct; canonical name = `articles_embedding_hnsw_idx`.

### Changes
- **New migration `ReconcileHnswIndexName`** (transactional, idempotent): renames whichever HNSW index is present (detected by `amname='hnsw'`, not by name) up to the canonical `articles_embedding_hnsw_idx`. No-ops when already canonical or when no HNSW index exists (pgvector disabled). `down/0` is a deliberate, documented no-op. **(AC-27.14.1)**
- **Fixed the down-step** of the historical `AddEmbeddingHnswIndex` migration (converted `change` → explicit `up`/`down`): `down` now drops whichever HNSW index is present by access method, instead of the hard-coded name that no-ops against prod. **(AC-27.14.2)**
- **Tightened the `(_hnsw)?_idx` tolerance** to the canonical name in `knowledge_embedding_test.exs` and the suggested_links EXPLAIN plan assertion; refreshed the drift comments. **(AC-27.14.3)**
- **Documented the canonical detection snippet** in the new migration `@moduledoc`. **(AC-27.14.4)**
- **New integration test (TC-27.14.1)** drives the real migration modules via `Ecto.Migration.Runner`: the fixed down-step drops a foreign-named HNSW index; up recreates it; the reconcile renames it to canonical; plus rename and idempotency cases.

### Verification
- `mix precommit` green: credo (no issues), dialyzer (0 errors), 2575 tests / 0 failures.
- Reconcile migration applied to the test DB → index now `articles_embedding_hnsw_idx`.
- Idempotency proven (re-run = no-op) by test + the `pg_class` guard.
- Post-merge: verify prod shows the single canonical `articles_embedding_hnsw_idx` and the suggested_links query stays index-backed.
