### PR TITLE
US-27.2: plan-assertion helper (real query, planner's natural choice)

### DIFF
--- a/test/loopctl/knowledge/plan_assertions_scale_test.exs
+++ b/test/loopctl/knowledge/plan_assertions_scale_test.exs
@@ -80,24 +80,36 @@ defmodule Loopctl.Knowledge.PlanAssertionsScaleTest do
       built =
         Knowledge.suggestion_candidates_query(tenant.id, target.id, target.embedding, 0.5, 5, nil)
 
-      {built_sql, _} = SQL.to_sql(:all, AdminRepo, built)
+      {built_sql, built_params} = SQL.to_sql(:all, AdminRepo, built)
 
-      # AC-27.2.4: the query we assert on is byte-identical to the one the request path
-      # actually emits (no independently re-constructed stunt double).
+      # AC-27.2.4: capture the SQL+PARAMS the request path actually emits.
       captured =
         PlanAssertions.capture_repo_queries(fn ->
           Knowledge.suggest_links(tenant.id, target.id, threshold: 0.5, limit: 5)
         end)
 
-      {emitted_sql, _} =
+      {emitted_sql, emitted_params} =
         PlanAssertions.only_query_matching(captured, ~r/<=>.*article_links|article_links.*<=>/s)
 
+      # Byte-identical SQL *and* params — the planner's choice for a `LIMIT $n` / `<=> $vec`
+      # query can depend on param values, so SQL parity alone is not enough.
       assert emitted_sql == built_sql,
              "Plan-assertion query and request-path query must be byte-identical (AC-27.2.4)."
 
-      # AC-27.2.7: planner's NATURAL choice (no enable_seqscan/sort=off) at 80k must reach
-      # articles via the HNSW index — not a full Seq Scan + Sort (the #172 prod 500).
-      assert :ok = PlanAssertions.assert_hnsw_index(built)
+      assert emitted_params == built_params,
+             "Request-path params must match the asserted params (AC-27.2.4)."
+
+      # AC-27.2.7: assert on the CAPTURED request-path {sql, params} (not a re-built stunt
+      # double). Planner's NATURAL choice (no enable_seqscan/sort=off) at 80k must reach
+      # `articles` via exactly one HNSW Index Scan — never a Seq/Bitmap full-corpus read.
+      #
+      # NOTE (optimistic case): this seeds ONE tenant owning the whole corpus, so the
+      # tenant predicate is non-selective and HNSW is the obvious win. A *small* tenant
+      # within a large multi-tenant corpus is more adversarial (HNSW can't pre-filter by
+      # tenant), and the planner may correctly prefer a tenant-btree + sort there — which
+      # is fine for a small tenant. Prod's hot path (second-brain) IS the single large
+      # tenant, which this models.
+      assert :ok = PlanAssertions.assert_hnsw_index({emitted_sql, emitted_params})
     end)
   end
 end

--- a/test/loopctl/knowledge/plan_assertions_scale_test.exs
+++ b/test/loopctl/knowledge/plan_assertions_scale_test.exs
@@ -1,0 +1,103 @@
+defmodule Loopctl.Knowledge.PlanAssertionsScaleTest do
+  @moduledoc """
+  US-27.2 / AC-27.2.7: prove the production `suggested_links` query shape (cosine
+  ORDER BY + the article_links anti-join + threshold) is index-backed at >= prod
+  scale — the exact #172 regression class, guarded on the REAL query, with the
+  planner's natural choice (no enable_seqscan=off).
+
+  AC-27.2.4: the asserted query is byte-identical to the one the request path emits.
+
+  Seeds ~80k committed rows (Loopctl.Knowledge.ScaleSeed), so it is `:scale_nightly`
+  (runs on the nightly/scale gate, not the default async suite).
+  """
+  use ExUnit.Case, async: false
+
+  alias Ecto.Adapters.SQL
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.ScaleSeed
+  alias Loopctl.PlanAssertions
+  alias Loopctl.Tenants.Tenant
+
+  import Ecto.Query
+
+  @moduletag :scale_nightly
+  @moduletag timeout: :timer.minutes(30)
+
+  defp unboxed(fun), do: Sandbox.unboxed_run(AdminRepo, fun)
+
+  setup do
+    tenant =
+      unboxed(fn ->
+        slug = "plan-scale-#{:erlang.phash2(Ecto.UUID.generate())}"
+
+        {:ok, t} =
+          %Tenant{}
+          |> Tenant.create_changeset(%{
+            name: "Plan Scale #{slug}",
+            slug: slug,
+            email: "#{slug}@example.com",
+            settings: %{},
+            status: :active
+          })
+          |> AdminRepo.insert()
+
+        ScaleSeed.seed(t.id, count: ScaleSeed.prod_article_floor(), link_density: 5)
+        t
+      end)
+
+    on_exit(fn ->
+      # Best-effort cleanup: after a long (~90s) unboxed run the pooled connection can be
+      # idle-closed, and a failed cleanup must not fail the test (each run uses a fresh
+      # tenant, so leftover rows are harmless in the scale DB).
+      try do
+        unboxed(fn ->
+          AdminRepo.delete_all(from(a in Article, where: a.tenant_id == ^tenant.id))
+          AdminRepo.delete_all(from(t in Tenant, where: t.id == ^tenant.id))
+        end)
+      rescue
+        _ -> :ok
+      end
+    end)
+
+    {:ok, tenant: tenant}
+  end
+
+  test "suggested_links is HNSW-index-backed at prod scale, on the request-path query",
+       %{tenant: tenant} do
+    unboxed(fn ->
+      target =
+        AdminRepo.one(
+          from(a in Article,
+            where: a.tenant_id == ^tenant.id,
+            limit: 1,
+            select: %{id: a.id, embedding: a.embedding}
+          )
+        )
+
+      built =
+        Knowledge.suggestion_candidates_query(tenant.id, target.id, target.embedding, 0.5, 5, nil)
+
+      {built_sql, _} = SQL.to_sql(:all, AdminRepo, built)
+
+      # AC-27.2.4: the query we assert on is byte-identical to the one the request path
+      # actually emits (no independently re-constructed stunt double).
+      captured =
+        PlanAssertions.capture_repo_queries(fn ->
+          Knowledge.suggest_links(tenant.id, target.id, threshold: 0.5, limit: 5)
+        end)
+
+      {emitted_sql, _} =
+        PlanAssertions.only_query_matching(captured, ~r/<=>.*article_links|article_links.*<=>/s)
+
+      assert emitted_sql == built_sql,
+             "Plan-assertion query and request-path query must be byte-identical (AC-27.2.4)."
+
+      # AC-27.2.7: planner's NATURAL choice (no enable_seqscan/sort=off) at 80k must reach
+      # articles via the HNSW index — not a full Seq Scan + Sort (the #172 prod 500).
+      assert :ok = PlanAssertions.assert_hnsw_index(built)
+    end)
+  end
+end

--- a/test/loopctl/plan_assertions_test.exs
+++ b/test/loopctl/plan_assertions_test.exs
@@ -1,0 +1,54 @@
+defmodule Loopctl.PlanAssertionsTest do
+  @moduledoc """
+  Fast (non-scale) tests for the US-27.2 plan-assertion machinery: the query-capture
+  + match helpers (AC-27.2.4) and the HNSW capability check (AC-27.2.3). The
+  index-CHOICE assertions (refute_full_scan/assert_hnsw_index) are only meaningful at
+  prod scale (the planner Seq-Scans toy tables), so they live in the :scale_nightly
+  test; here we cover the pieces that are deterministic without an 80k corpus.
+  """
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.PlanAssertions
+
+  import Ecto.Query
+
+  describe "capture_repo_queries/1 + only_query_matching/2" do
+    test "captures the SQL the function emits and selects exactly one match" do
+      tenant = fixture(:tenant)
+      _article = fixture(:article, %{tenant_id: tenant.id, title: "Capture Me"})
+
+      captured =
+        PlanAssertions.capture_repo_queries(fn ->
+          AdminRepo.all(from(a in Loopctl.Knowledge.Article, where: a.tenant_id == ^tenant.id))
+        end)
+
+      assert captured != []
+      {sql, params} = PlanAssertions.only_query_matching(captured, "FROM \"articles\"")
+      assert sql =~ "articles"
+      assert is_list(params)
+    end
+
+    test "only_query_matching raises when zero match" do
+      captured = [{"SELECT 1", []}]
+
+      assert_raise ExUnit.AssertionError, ~r/No captured query matched/, fn ->
+        PlanAssertions.only_query_matching(captured, "no_such_table_xyz")
+      end
+    end
+
+    test "only_query_matching raises when more than one matches" do
+      captured = [{"SELECT a FROM t", []}, {"SELECT b FROM t", []}]
+
+      assert_raise ExUnit.AssertionError, ~r/Expected exactly one/, fn ->
+        PlanAssertions.only_query_matching(captured, "FROM t")
+      end
+    end
+  end
+
+  # NOTE: the fresh-stats guard (AC-27.2.5) is exercised in the :scale_nightly test —
+  # it must PASS after ScaleSeed runs ANALYZE. Its raise path can't be tested
+  # deterministically here because pg_stat_user_tables reflects the COMMITTED table
+  # (shared across the dev/test DB), not the rolled-back sandbox set, so n_live_tup /
+  # last_analyze are environment-dependent.
+end

--- a/test/support/plan_assertions.ex
+++ b/test/support/plan_assertions.ex
@@ -1,0 +1,215 @@
+defmodule Loopctl.PlanAssertions do
+  @moduledoc """
+  Query-plan assertions for scale tests (US-27.2).
+
+  The point of this module is to catch the exact false-green that shipped the
+  `suggested_links` 500 three times: a query whose ORDER BY is index-*eligible* but
+  which the planner does NOT actually use at prod scale (it Seq-Scans the whole
+  corpus + Sorts, then times out).
+
+  CRITICAL: these assertions run `EXPLAIN` WITHOUT forcing the planner
+  (`enable_seqscan`/`enable_sort` are left at their defaults). Forcing the planner
+  proves index *eligibility*, not that the planner *chooses* the index — that
+  distinction is precisely what produced false confidence in #172. So these are
+  meaningful ONLY against a committed, ANALYZEd, ≥prod-scale corpus
+  (`Loopctl.Knowledge.ScaleSeed`); at toy scale the planner Seq-Scans happily and
+  the assertion would be a lie. `assert_fresh_stats!/0` enforces that precondition.
+
+  Failure signal is the literal `Seq Scan on articles` node (AC-27.2.2). A `Sort`
+  node is NOT itself a failure — the verified suggested_links shape legitimately
+  sorts the small post-ANN candidate pool — so Sort is advisory only.
+  """
+
+  alias Ecto.Adapters.SQL
+  alias Loopctl.AdminRepo
+
+  @articles_seq_scan ~r/Seq Scan on articles\b/i
+
+  @doc """
+  Asserts the planner does NOT reach `articles` via a full `Seq Scan` for the given
+  query — i.e. the corpus is read through an index (the HNSW path for cosine ORDER BY).
+
+  Accepts an Ecto queryable or a `{sql, params}` tuple (the latter lets a caller pass
+  the controller's captured SQL+params, AC-27.2.4). Raises `ExUnit.AssertionError`
+  with the offending plan (vector literals elided) when a `Seq Scan on articles`
+  appears. Runs against the planner's natural choice — no `enable_seqscan=off`.
+  """
+  def refute_full_scan(queryable_or_sql) do
+    assert_fresh_stats!()
+    plan = explain(queryable_or_sql)
+
+    if Regex.match?(@articles_seq_scan, plan) do
+      raise ExUnit.AssertionError,
+        message:
+          "Expected `articles` to be read via an index, but the plan contains a full " <>
+            "`Seq Scan on articles` (the #170/#172 prod-500 shape). Plan:\n#{elide(plan)}"
+    end
+
+    :ok
+  end
+
+  @doc """
+  Asserts the plan reaches `articles` via an `Index Scan using <idx>` where `<idx>` is
+  an HNSW index (`pg_am.amname = 'hnsw'`) — not merely a name that looks right
+  (AC-27.2.3). Implies `refute_full_scan/1`.
+  """
+  def assert_hnsw_index(queryable_or_sql) do
+    refute_full_scan(queryable_or_sql)
+    plan = explain(queryable_or_sql)
+
+    index_name =
+      case Regex.run(~r/Index Scan using (\S+) on articles\b/i, plan) do
+        [_, name] -> name
+        _ -> nil
+      end
+
+    unless index_name && hnsw_index?(index_name) do
+      raise ExUnit.AssertionError,
+        message:
+          "Expected an `Index Scan using <hnsw index> on articles` (amname='hnsw'), " <>
+            "got index=#{inspect(index_name)} (hnsw? #{index_name && hnsw_index?(index_name)}). " <>
+            "Plan:\n#{elide(plan)}"
+    end
+
+    :ok
+  end
+
+  @doc """
+  Raises unless `articles` has fresh planner statistics reflecting a real corpus —
+  `n_live_tup > 0` and `last_analyze`/`last_autoanalyze` set (US-27.1's ANALYZE).
+  Prevents a plan assertion from producing a misleading pass/fail against an
+  unanalyzed (n≈0) table (AC-27.2.5).
+  """
+  def assert_fresh_stats! do
+    %{rows: [[live, last_analyze, last_autoanalyze]]} =
+      AdminRepo.query!(
+        "SELECT n_live_tup, last_analyze, last_autoanalyze FROM pg_stat_user_tables WHERE relname = 'articles'"
+      )
+
+    cond do
+      is_nil(live) or live <= 0 ->
+        raise ExUnit.AssertionError,
+          message:
+            "Plan assertion ran against `articles` with n_live_tup=#{inspect(live)} — the " <>
+              "corpus is not seeded/committed. Seed via Loopctl.Knowledge.ScaleSeed (unboxed) first."
+
+      is_nil(last_analyze) and is_nil(last_autoanalyze) ->
+        raise ExUnit.AssertionError,
+          message:
+            "Plan assertion ran against an UNANALYZED `articles` (no last_analyze). " <>
+              "ScaleSeed runs ANALYZE; run it before asserting, or stats are stale (n≈0 planner)."
+
+      true ->
+        :ok
+    end
+  end
+
+  @doc """
+  Captures the SQL+params of every AdminRepo/Repo query emitted while `fun` runs, by
+  attaching a one-shot `[:loopctl, :repo, :query]` (and AdminRepo) telemetry handler.
+  Returns `[{sql, params}, ...]` in execution order. Use it to obtain the controller's
+  ACTUAL query and prove a plan assertion runs the SAME SQL+params the request path
+  emits — not an independently re-constructed query (AC-27.2.4).
+  """
+  def capture_repo_queries(fun) when is_function(fun, 0) do
+    ref = make_ref()
+    test_pid = self()
+    handler_id = {__MODULE__, ref}
+
+    events = [
+      [:loopctl, :repo, :query],
+      [:loopctl, :admin_repo, :query]
+    ]
+
+    # Query telemetry fires in the process that issued the query. Capture ONLY queries
+    # from the current process (the test, or the inline ConnTest request) — otherwise a
+    # global handler also grabs concurrent async tests' queries (flaky "got 2").
+    :telemetry.attach_many(
+      handler_id,
+      events,
+      fn _event, _measure, meta, _ ->
+        if self() == test_pid, do: send(test_pid, {ref, meta.query, meta.params})
+      end,
+      nil
+    )
+
+    try do
+      fun.()
+    after
+      :telemetry.detach(handler_id)
+    end
+
+    drain(ref, [])
+  end
+
+  defp drain(ref, acc) do
+    receive do
+      {^ref, sql, params} -> drain(ref, [{sql, params} | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
+  end
+
+  @doc """
+  From captured queries, returns the single one whose SQL matches `pattern` (a Regex or
+  substring). Raises if zero or more than one match — the caller wants exactly the
+  query under test (e.g. the cosine ORDER BY with the article_links anti-join).
+  """
+  def only_query_matching(captured, pattern) do
+    matches =
+      Enum.filter(captured, fn {sql, _} ->
+        case pattern do
+          %Regex{} -> Regex.match?(pattern, sql)
+          s when is_binary(s) -> String.contains?(sql, s)
+        end
+      end)
+
+    case matches do
+      [one] ->
+        one
+
+      [] ->
+        raise ExUnit.AssertionError,
+          message: "No captured query matched #{inspect(pattern)} (captured #{length(captured)})"
+
+      many ->
+        raise ExUnit.AssertionError,
+          message: "Expected exactly one query matching #{inspect(pattern)}, got #{length(many)}"
+    end
+  end
+
+  # --- internals ---
+
+  defp explain({sql, params}) when is_binary(sql) and is_list(params) do
+    %{rows: rows} = AdminRepo.query!("EXPLAIN " <> sql, params)
+    Enum.map_join(rows, "\n", fn [line] -> line end)
+  end
+
+  defp explain(queryable) do
+    {sql, params} = SQL.to_sql(:all, AdminRepo, queryable)
+    explain({sql, params})
+  end
+
+  # Is `name` an HNSW index? Verify via pg_am, not the name string (AC-27.2.3).
+  defp hnsw_index?(name) do
+    %{rows: rows} =
+      AdminRepo.query!(
+        """
+        SELECT am.amname
+        FROM pg_class i
+        JOIN pg_am am ON am.oid = i.relam
+        WHERE i.relname = $1
+        """,
+        [name]
+      )
+
+    match?([["hnsw"]], rows)
+  end
+
+  # Elide 1536-float vector literals so a failing plan is readable and leaks no embedding.
+  defp elide(plan) do
+    plan
+    |> String.replace(~r/'\[[-0-9eE.,\s]+\]'::vector/, "'[…]'::vector")
+    |> String.slice(0, 4_000)
+  end
+end

--- a/test/support/plan_assertions.ex
+++ b/test/support/plan_assertions.ex
@@ -4,100 +4,57 @@ defmodule Loopctl.PlanAssertions do
 
   The point of this module is to catch the exact false-green that shipped the
   `suggested_links` 500 three times: a query whose ORDER BY is index-*eligible* but
-  which the planner does NOT actually use at prod scale (it Seq-Scans the whole
-  corpus + Sorts, then times out).
+  which the planner does NOT actually use at prod scale (it reads the whole corpus +
+  Sorts, then times out).
 
   CRITICAL: these assertions run `EXPLAIN` WITHOUT forcing the planner
   (`enable_seqscan`/`enable_sort` are left at their defaults). Forcing the planner
   proves index *eligibility*, not that the planner *chooses* the index — that
   distinction is precisely what produced false confidence in #172. So these are
   meaningful ONLY against a committed, ANALYZEd, ≥prod-scale corpus
-  (`Loopctl.Knowledge.ScaleSeed`); at toy scale the planner Seq-Scans happily and
-  the assertion would be a lie. `assert_fresh_stats!/0` enforces that precondition.
+  (`Loopctl.Knowledge.ScaleSeed`); at toy scale the planner Seq-Scans happily and the
+  assertion would be a lie. `assert_fresh_stats!/0` enforces that precondition.
 
-  Failure signal is the literal `Seq Scan on articles` node (AC-27.2.2). A `Sort`
-  node is NOT itself a failure — the verified suggested_links shape legitimately
-  sorts the small post-ANN candidate pool — so Sort is advisory only.
+  We parse `EXPLAIN (FORMAT JSON)` and walk the node tree rather than regex the text
+  form, so the assertions key on the *property* "how is `articles` reached" — not on a
+  single spelling of a bad node. A regression that reaches the full corpus via
+  `Seq Scan`, `Parallel Seq Scan`, OR `Bitmap Heap Scan` (all the #172 shapes) is
+  caught; and `assert_hnsw_index` requires `articles` to be reached by EXACTLY ONE
+  scan, an Index Scan on an `amname='hnsw'` index (no sibling full-scan can hide).
   """
 
   alias Ecto.Adapters.SQL
   alias Loopctl.AdminRepo
 
-  @articles_seq_scan ~r/Seq Scan on articles\b/i
+  # Node types that read the whole `articles` relation (the #172 timeout shape).
+  # "Seq Scan" covers Parallel Seq Scan (same Node Type, Parallel Aware flag).
+  @full_scan_types ["Seq Scan", "Bitmap Heap Scan"]
 
   @doc """
-  Asserts the planner does NOT reach `articles` via a full `Seq Scan` for the given
-  query — i.e. the corpus is read through an index (the HNSW path for cosine ORDER BY).
-
-  Accepts an Ecto queryable or a `{sql, params}` tuple (the latter lets a caller pass
-  the controller's captured SQL+params, AC-27.2.4). Raises `ExUnit.AssertionError`
-  with the offending plan (vector literals elided) when a `Seq Scan on articles`
-  appears. Runs against the planner's natural choice — no `enable_seqscan=off`.
+  Asserts the planner does NOT reach `articles` via a full-corpus scan (`Seq Scan`,
+  `Parallel Seq Scan`, or `Bitmap Heap Scan`) for the given query. Accepts an Ecto
+  queryable or a `{sql, params}` tuple (the latter lets a caller assert on the request
+  path's captured SQL+params — AC-27.2.4). Raises with the offending plan (vectors
+  elided) on a full scan. Runs the planner's natural choice — no `enable_seqscan=off`.
   """
   def refute_full_scan(queryable_or_sql) do
     assert_fresh_stats!()
-    plan = explain(queryable_or_sql)
+    {root, raw} = explain_json(queryable_or_sql)
+    scans = article_scan_nodes(root)
 
-    if Regex.match?(@articles_seq_scan, plan) do
-      raise ExUnit.AssertionError,
-        message:
-          "Expected `articles` to be read via an index, but the plan contains a full " <>
-            "`Seq Scan on articles` (the #170/#172 prod-500 shape). Plan:\n#{elide(plan)}"
-    end
-
-    :ok
-  end
-
-  @doc """
-  Asserts the plan reaches `articles` via an `Index Scan using <idx>` where `<idx>` is
-  an HNSW index (`pg_am.amname = 'hnsw'`) — not merely a name that looks right
-  (AC-27.2.3). Implies `refute_full_scan/1`.
-  """
-  def assert_hnsw_index(queryable_or_sql) do
-    refute_full_scan(queryable_or_sql)
-    plan = explain(queryable_or_sql)
-
-    index_name =
-      case Regex.run(~r/Index Scan using (\S+) on articles\b/i, plan) do
-        [_, name] -> name
-        _ -> nil
-      end
-
-    unless index_name && hnsw_index?(index_name) do
-      raise ExUnit.AssertionError,
-        message:
-          "Expected an `Index Scan using <hnsw index> on articles` (amname='hnsw'), " <>
-            "got index=#{inspect(index_name)} (hnsw? #{index_name && hnsw_index?(index_name)}). " <>
-            "Plan:\n#{elide(plan)}"
-    end
-
-    :ok
-  end
-
-  @doc """
-  Raises unless `articles` has fresh planner statistics reflecting a real corpus —
-  `n_live_tup > 0` and `last_analyze`/`last_autoanalyze` set (US-27.1's ANALYZE).
-  Prevents a plan assertion from producing a misleading pass/fail against an
-  unanalyzed (n≈0) table (AC-27.2.5).
-  """
-  def assert_fresh_stats! do
-    %{rows: [[live, last_analyze, last_autoanalyze]]} =
-      AdminRepo.query!(
-        "SELECT n_live_tup, last_analyze, last_autoanalyze FROM pg_stat_user_tables WHERE relname = 'articles'"
-      )
+    bad = Enum.filter(scans, &(&1.node_type in @full_scan_types))
 
     cond do
-      is_nil(live) or live <= 0 ->
+      scans == [] ->
         raise ExUnit.AssertionError,
           message:
-            "Plan assertion ran against `articles` with n_live_tup=#{inspect(live)} — the " <>
-              "corpus is not seeded/committed. Seed via Loopctl.Knowledge.ScaleSeed (unboxed) first."
+            "Plan never reaches the `articles` relation — cannot judge full-scan vs index. Plan:\n#{elide(raw)}"
 
-      is_nil(last_analyze) and is_nil(last_autoanalyze) ->
+      bad != [] ->
         raise ExUnit.AssertionError,
           message:
-            "Plan assertion ran against an UNANALYZED `articles` (no last_analyze). " <>
-              "ScaleSeed runs ANALYZE; run it before asserting, or stats are stale (n≈0 planner)."
+            "Expected `articles` reached via an index, but a full-corpus scan node is present: " <>
+              "#{inspect(Enum.map(bad, & &1.node_type))} (the #170/#172 prod-500 shape). Plan:\n#{elide(raw)}"
 
       true ->
         :ok
@@ -105,25 +62,98 @@ defmodule Loopctl.PlanAssertions do
   end
 
   @doc """
-  Captures the SQL+params of every AdminRepo/Repo query emitted while `fun` runs, by
-  attaching a one-shot `[:loopctl, :repo, :query]` (and AdminRepo) telemetry handler.
-  Returns `[{sql, params}, ...]` in execution order. Use it to obtain the controller's
-  ACTUAL query and prove a plan assertion runs the SAME SQL+params the request path
-  emits — not an independently re-constructed query (AC-27.2.4).
+  Asserts `articles` is reached by EXACTLY ONE scan node, which is an `Index Scan`
+  (or `Index Only Scan`) on an HNSW index (`pg_am.amname='hnsw'`, verified via catalog,
+  not a name match). A sibling/outer full-scan on `articles` therefore cannot hide
+  behind a present-but-unused HNSW node (AC-27.2.2/.3). Implies `refute_full_scan/1`.
+  """
+  def assert_hnsw_index(queryable_or_sql) do
+    assert_fresh_stats!()
+    {root, raw} = explain_json(queryable_or_sql)
+    scans = article_scan_nodes(root)
+
+    case scans do
+      [%{node_type: type, index_name: idx}] when type in ["Index Scan", "Index Only Scan"] ->
+        unless idx && hnsw_index?(idx) do
+          raise ExUnit.AssertionError,
+            message:
+              "Expected the single `articles` scan to be an Index Scan on an HNSW index " <>
+                "(amname='hnsw'); got index=#{inspect(idx)}. Plan:\n#{elide(raw)}"
+        end
+
+        :ok
+
+      [] ->
+        raise ExUnit.AssertionError,
+          message: "Plan never reaches `articles`. Plan:\n#{elide(raw)}"
+
+      [one] ->
+        raise ExUnit.AssertionError,
+          message:
+            "Expected the `articles` scan to be an HNSW Index Scan, got #{inspect(one.node_type)}. " <>
+              "Plan:\n#{elide(raw)}"
+
+      many ->
+        raise ExUnit.AssertionError,
+          message:
+            "Expected EXACTLY ONE scan on `articles` (the HNSW index), got #{length(many)}: " <>
+              "#{inspect(Enum.map(many, & &1.node_type))} — a sibling full-scan could hide a " <>
+              "full-corpus read. Plan:\n#{elide(raw)}"
+    end
+  end
+
+  @doc """
+  Raises unless `articles` holds real, analyzed rows — verified by an ACTUAL
+  `count(*)` (reflecting committed reality, not autovacuum's lazy/sticky/cross-tenant
+  `n_live_tup` estimate, which is blind to stale-high) AND a non-null `last_analyze`.
+  Prevents a plan assertion from running against an unseeded/empty or unanalyzed corpus
+  (AC-27.2.5). ScaleSeed already asserts `last_analyze` ADVANCED for the current run.
+  """
+  def assert_fresh_stats! do
+    %{rows: [[real_count]]} = AdminRepo.query!("SELECT count(*) FROM articles")
+
+    %{rows: [[last_analyze, last_autoanalyze]]} =
+      AdminRepo.query!(
+        "SELECT last_analyze, last_autoanalyze FROM pg_stat_user_tables WHERE relname = 'articles'"
+      )
+
+    cond do
+      is_nil(real_count) or real_count <= 0 ->
+        raise ExUnit.AssertionError,
+          message:
+            "Plan assertion ran against an EMPTY `articles` (committed count=#{inspect(real_count)}). " <>
+              "Seed via Loopctl.Knowledge.ScaleSeed (unboxed, committed) first."
+
+      is_nil(last_analyze) and is_nil(last_autoanalyze) ->
+        raise ExUnit.AssertionError,
+          message:
+            "Plan assertion ran against an UNANALYZED `articles` (no last_analyze). " <>
+              "ScaleSeed runs + verifies ANALYZE; run it before asserting."
+
+      true ->
+        :ok
+    end
+  end
+
+  @doc """
+  Captures the SQL+params of every AdminRepo/Repo query emitted while `fun` runs, via a
+  `[:loopctl, :repo, :query]` / `[:loopctl, :admin_repo, :query]` telemetry handler.
+  Returns `[{sql, params}, ...]` in execution order. Use it to obtain the request path's
+  ACTUAL query and prove a plan assertion runs the SAME SQL+params it emits — not an
+  independently re-constructed query (AC-27.2.4).
+
+  Capture is scoped to the CURRENT process: query telemetry fires in the process that
+  issued the query, so a direct context call and an inline `Phoenix.ConnTest` request
+  (which runs in the test process) are captured, while concurrent async tests' queries
+  are dropped. If the query under test ever runs off-process (a `Task`, a spawned job),
+  nothing is captured and `only_query_matching/2` raises (fails closed, never silent).
   """
   def capture_repo_queries(fun) when is_function(fun, 0) do
     ref = make_ref()
     test_pid = self()
     handler_id = {__MODULE__, ref}
+    events = [[:loopctl, :repo, :query], [:loopctl, :admin_repo, :query]]
 
-    events = [
-      [:loopctl, :repo, :query],
-      [:loopctl, :admin_repo, :query]
-    ]
-
-    # Query telemetry fires in the process that issued the query. Capture ONLY queries
-    # from the current process (the test, or the inline ConnTest request) — otherwise a
-    # global handler also grabs concurrent async tests' queries (flaky "got 2").
     :telemetry.attach_many(
       handler_id,
       events,
@@ -151,9 +181,9 @@ defmodule Loopctl.PlanAssertions do
   end
 
   @doc """
-  From captured queries, returns the single one whose SQL matches `pattern` (a Regex or
-  substring). Raises if zero or more than one match — the caller wants exactly the
-  query under test (e.g. the cosine ORDER BY with the article_links anti-join).
+  From captured queries, returns the single `{sql, params}` whose SQL matches `pattern`
+  (a Regex or substring). Raises if zero or more than one match — the caller wants
+  exactly the query under test (e.g. the cosine ORDER BY with the article_links anti-join).
   """
   def only_query_matching(captured, pattern) do
     matches =
@@ -180,14 +210,44 @@ defmodule Loopctl.PlanAssertions do
 
   # --- internals ---
 
-  defp explain({sql, params}) when is_binary(sql) and is_list(params) do
-    %{rows: rows} = AdminRepo.query!("EXPLAIN " <> sql, params)
-    Enum.map_join(rows, "\n", fn [line] -> line end)
+  # Runs EXPLAIN (FORMAT JSON) and returns {root_plan_node_map, raw_text_for_messages}.
+  defp explain_json({sql, params}) when is_binary(sql) and is_list(params) do
+    %{rows: rows} = AdminRepo.query!("EXPLAIN (FORMAT JSON) " <> sql, params)
+    # FORMAT JSON returns a single row whose first column is a JSON array [{"Plan": {...}}].
+    decoded =
+      rows
+      |> List.first()
+      |> List.first()
+      |> decode_json()
+
+    root = decoded |> List.first() |> Map.fetch!("Plan")
+    {root, Jason.encode!(decoded)}
   end
 
-  defp explain(queryable) do
+  defp explain_json(queryable) do
     {sql, params} = SQL.to_sql(:all, AdminRepo, queryable)
-    explain({sql, params})
+    explain_json({sql, params})
+  end
+
+  defp decode_json(v) when is_binary(v), do: Jason.decode!(v)
+  defp decode_json(v), do: v
+
+  # Walk the plan tree; collect every node that scans the `articles` relation, with its
+  # Node Type and (if any) Index Name. Covers Seq/Index/Index Only/Bitmap Heap scans.
+  defp article_scan_nodes(node) when is_map(node) do
+    here =
+      if node["Relation Name"] == "articles" do
+        [%{node_type: node["Node Type"], index_name: node["Index Name"]}]
+      else
+        []
+      end
+
+    children =
+      node
+      |> Map.get("Plans", [])
+      |> Enum.flat_map(&article_scan_nodes/1)
+
+    here ++ children
   end
 
   # Is `name` an HNSW index? Verify via pg_am, not the name string (AC-27.2.3).
@@ -206,10 +266,12 @@ defmodule Loopctl.PlanAssertions do
     match?([["hnsw"]], rows)
   end
 
-  # Elide 1536-float vector literals so a failing plan is readable and leaks no embedding.
+  # Elide vector literals so a failing plan is readable and leaks no embedding. Covers
+  # `'[...]'::vector` and `::vector(1536)` casts; params are bound so the normal path has
+  # no inline vector at all.
   defp elide(plan) do
     plan
-    |> String.replace(~r/'\[[-0-9eE.,\s]+\]'::vector/, "'[…]'::vector")
+    |> String.replace(~r/'\[[-0-9eE.,\s]+\]'(::(?:half)?vector(?:\(\d+\))?)?/, "'[…]'\\1")
     |> String.slice(0, 4_000)
   end
 end


### PR DESCRIPTION
Implements **US-27.2** (Epic #175, Theme 1) — `Loopctl.PlanAssertions`, the standing guard against the #172 false-green-at-scale class.

- `refute_full_scan/1` + `assert_hnsw_index/1`: run `EXPLAIN` with the planner's **natural choice** (no `enable_seqscan/sort=off` — forcing it proves *eligibility*, not the choice that shipped broken 3×). Failure = literal `Seq Scan on articles`; a Sort over the small post-ANN pool is advisory. Chosen index verified `amname='hnsw'` via `pg_am`, not a name match (AC-27.2.1/.2/.3).
- `assert_fresh_stats!/0`: refuses to assert against an unanalyzed/empty `articles` (AC-27.2.5).
- `capture_repo_queries/1` + `only_query_matching/2`: grab the request path's **actual** emitted SQL via `:telemetry` (scoped to the current process so concurrent async tests don't leak in); the scale test asserts it is **byte-identical** to the builder — no stunt-double query (AC-27.2.4).
- Plan text elides vector literals on failure (AC-27.2.6).

`:scale_nightly` test seeds ≥80k and proves the production `suggested_links` shape (cosine ORDER BY + `article_links` anti-join + threshold) is HNSW-index-backed on the request-path query — **verified locally (88s)**. Runs on US-27.1's Scale Nightly CI job, not the default async suite (AC-27.2.7/.8). Fast unit tests cover the capture/match machinery.

Built on US-27.1 (`ScaleSeed`, `prod_article_floor`). Implemented directly (not via the loop) with review.

Refs #175
