### PR TITLE
US-27.9a: keyset cursor for the article list (composite index + HMAC integrity)

### DIFF
--- a/docs/runbooks/knowledge-scale.md
+++ b/docs/runbooks/knowledge-scale.md
@@ -113,6 +113,22 @@ and `request_id=` empty. Lower the threshold to surface a trend before it become
 config :loopctl, :slow_query_threshold_ms, 500
 ```
 
+## Keyset pagination index (US-27.9a)
+
+The article keyset cursor seeks on `(tenant_id, inserted_at, id)`, backed by
+`articles_tenant_inserted_id_idx` (built `CREATE INDEX CONCURRENTLY`,
+`@disable_ddl_transaction`). **Operational note:** if the concurrent build is
+interrupted, Postgres can leave an **INVALID** index behind, and the migration's
+`IF NOT EXISTS` re-run will NOT rebuild it (it sees the name and no-ops). The query
+still returns correct rows (it degrades to a Seq Scan — slower, not wrong). Recovery
+is manual: `DROP INDEX CONCURRENTLY IF EXISTS articles_tenant_inserted_id_idx;` then
+re-run the migration. Verify validity after deploy:
+
+```sql
+SELECT indexrelid::regclass, indisvalid
+FROM pg_index WHERE indexrelid = 'articles_tenant_inserted_id_idx'::regclass;
+```
+
 ## Bulk write path — set-based archive/delete (US-27.12)
 
 `Loopctl.Knowledge.BulkOps` mutates a whole selected set (by ids/tag/source) in

--- a/docs/runbooks/knowledge-scale.md
+++ b/docs/runbooks/knowledge-scale.md
@@ -117,7 +117,30 @@ config :loopctl, :slow_query_threshold_ms, 500
 
 The article keyset cursor seeks on `(tenant_id, inserted_at, id)`, backed by
 `articles_tenant_inserted_id_idx` (built `CREATE INDEX CONCURRENTLY`,
-`@disable_ddl_transaction`). **Operational note:** if the concurrent build is
+`@disable_ddl_transaction`).
+
+**Plan profile by filter shape (verified at 80k, `keyset_plan_scale_test.exs`):**
+
+| List query shape | Plan at prod scale | Cost profile |
+| ---------------- | ------------------ | ------------ |
+| no filter / `category=` (scalar) | Index Scan on the keyset btree, walked in order, **no Sort** | true keyset — O(page) per page |
+| `tags=` (array `&&`) | **BitmapAnd**(tags GIN ∩ keyset btree) → Bitmap Heap Scan → **Sort** | bounded by **tag selectivity**, not corpus |
+
+The array (`tags`) path Sorts because no btree can serve BOTH array containment
+(needs GIN) AND `(inserted_at, id)` order. This is **expected and non-regressive** —
+a tag-filtered *offset* query used the same GIN+Sort plan; the keyset version adds
+drift-freedom on top. It is bounded by how many rows carry the tag (the GIN driver),
+never a full-corpus Seq Scan. If a single tag ever grows to a large fraction of a
+tenant's corpus and tag-filtered deep enumeration becomes hot, the lever is a
+partial/covering index for that workload — not a change to the keyset mechanic.
+The scale test enforces this: scalar shapes must stay strictly index-ordered
+(`refute_full_scan`); the tags shape must avoid a Seq Scan and prove both the tags
+GIN and the keyset btree drive the plan (`refute_seq_scan` + `assert_index_used`).
+
+**Boot probe:** `Loopctl.IndexHealth.warn_if_invalid_indexes/0` runs at boot (prod)
+and logs a WARNING + emits `[:loopctl, :index_health, :invalid]` telemetry if
+`articles_tenant_inserted_id_idx` is missing or INVALID — so the recovery below is
+triggered by an alert, not a latency incident. **Operational note:** if the concurrent build is
 interrupted, Postgres can leave an **INVALID** index behind, and the migration's
 `IF NOT EXISTS` re-run will NOT rebuild it (it sees the name and no-ops). The query
 still returns correct rows (it degrades to a Seq Scan — slower, not wrong). Recovery

--- a/lib/loopctl/application.ex
+++ b/lib/loopctl/application.ex
@@ -38,6 +38,12 @@ defmodule Loopctl.Application do
     # log-only, never blocks boot.
     if Application.get_env(:loopctl, :env) == :prod, do: Loopctl.DbCapacity.warn_if_over_budget()
 
+    # US-27.9a: warn if a CONCURRENTLY-built critical index (e.g. the article keyset
+    # index) is missing/INVALID after an interrupted build — silent Seq-Scan degradation
+    # otherwise. Prod only, log + telemetry, never blocks boot.
+    if Application.get_env(:loopctl, :env) == :prod,
+      do: Loopctl.IndexHealth.warn_if_invalid_indexes()
+
     result
   end
 

--- a/lib/loopctl/index_health.ex
+++ b/lib/loopctl/index_health.ex
@@ -1,0 +1,100 @@
+defmodule Loopctl.IndexHealth do
+  @moduledoc """
+  Boot-time validity probe for performance-critical indexes (US-27.9a hardening).
+
+  A `CREATE INDEX CONCURRENTLY` that is interrupted (deploy timeout, dropped
+  connection) leaves an **INVALID** index behind. A migration re-run with
+  `IF NOT EXISTS` then no-ops (it sees the name), so the invalid index silently
+  persists and the planner ignores it — every query that relied on it degrades to a
+  Seq Scan. At scale that is a latent latency/DoS amplifier that no existing check
+  surfaces until users complain (see `docs/runbooks/knowledge-scale.md`).
+
+  This module checks, at boot, that each critical index exists AND is `indisvalid`,
+  logging a WARNING and emitting a `[:loopctl, :index_health, :invalid]` telemetry
+  event for any that is missing or invalid — so the documented manual recovery
+  (`DROP INDEX CONCURRENTLY ...; re-run the migration`) is triggered by an alert
+  rather than by a production incident. It is log-only and never blocks boot.
+  """
+
+  require Logger
+
+  alias Loopctl.AdminRepo
+
+  # Indexes whose absence/invalidity silently degrades a hot path to a Seq Scan.
+  # Add to this list whenever a new CONCURRENTLY-built index becomes load-bearing.
+  @critical_indexes [
+    {"articles_tenant_inserted_id_idx", "US-27.9a article keyset pagination"}
+  ]
+
+  @doc """
+  Checks every critical index and warns (log + telemetry) on any that is missing or
+  INVALID. Returns `:ok` always; wrapped in a rescue so a probe failure never blocks
+  boot. `which/0` lets a health endpoint or test inspect the configured list.
+  """
+  @spec warn_if_invalid_indexes() :: :ok
+  def warn_if_invalid_indexes do
+    Enum.each(@critical_indexes, fn {name, purpose} ->
+      case index_validity(name) do
+        :valid ->
+          :ok
+
+        :invalid ->
+          emit(name, purpose, :invalid)
+
+          Logger.warning(
+            "IndexHealth: index #{name} (#{purpose}) is INVALID — a failed " <>
+              "CREATE INDEX CONCURRENTLY left it unusable; the planner will Seq Scan. " <>
+              "Recover: DROP INDEX CONCURRENTLY IF EXISTS #{name}; then re-run the migration."
+          )
+
+        :missing ->
+          emit(name, purpose, :missing)
+
+          Logger.warning(
+            "IndexHealth: index #{name} (#{purpose}) is MISSING — the supporting " <>
+              "migration has not run (or the index was dropped); the dependent query " <>
+              "path will Seq Scan at scale."
+          )
+      end
+    end)
+
+    :ok
+  rescue
+    e ->
+      Logger.warning("IndexHealth boot check skipped: #{Exception.message(e)}")
+      :ok
+  end
+
+  @doc "The configured critical-index list (name + purpose), for health endpoints/tests."
+  @spec which() :: [{String.t(), String.t()}]
+  def which, do: @critical_indexes
+
+  # :valid | :invalid | :missing — via pg_index.indisvalid (the catalog truth).
+  @spec index_validity(String.t()) :: :valid | :invalid | :missing
+  def index_validity(name) when is_binary(name) do
+    %{rows: rows} =
+      AdminRepo.query!(
+        """
+        SELECT i.indisvalid
+        FROM pg_class c
+        JOIN pg_index i ON i.indexrelid = c.oid
+        WHERE c.relname = $1
+        """,
+        [name]
+      )
+
+    case rows do
+      [[true]] -> :valid
+      [[false]] -> :invalid
+      [] -> :missing
+    end
+  end
+
+  defp emit(name, purpose, state) do
+    :telemetry.execute(
+      [:loopctl, :index_health, :invalid],
+      %{count: 1},
+      %{index: name, purpose: purpose, state: state}
+    )
+  end
+end

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -58,6 +58,10 @@ defmodule Loopctl.Knowledge do
   # caused callers advancing `offset` by the requested limit to skip rows).
   @max_page_size 1000
 
+  # Default enumeration page size when the caller passes no `:limit`. The keyset
+  # path fetches `@default_page_size + 1` to detect a next page without a COUNT.
+  @default_page_size 20
+
   @doc """
   The maximum page size (`limit`) honored by the **enumeration** paths
   (`list_articles/2`, `list_filtered/2`, `list_keyset/2`, `list_drafts/2`,
@@ -1509,7 +1513,7 @@ defmodule Loopctl.Knowledge do
              limit: pos_integer()
            }}
   def list_keyset(tenant_id, opts \\ []) do
-    limit = opts |> Keyword.get(:limit, 20) |> max(1) |> min(@max_page_size)
+    limit = opts |> Keyword.get(:limit, @default_page_size) |> max(1) |> min(@max_page_size)
 
     # Fetch limit+1 to detect a next page without a COUNT (AC-27.9a.1).
     rows =
@@ -1538,10 +1542,20 @@ defmodule Loopctl.Knowledge do
   Same `opts` as `list_keyset/2`; `:limit` is applied as-is here (the caller adds
   the `+1` peek). This is the EXACT query `list_keyset/2` runs, so the plan
   assertion guards the request path, not a stunt double.
+
+  Plan note: with no filter or a scalar `:category` filter the planner walks the
+  `(tenant_id, inserted_at, id)` btree in order (true keyset, no Sort). With a
+  `:tags` (array `&&`) filter it BitmapAnds the tags GIN with the keyset btree and
+  Sorts — bounded by tag selectivity, NOT the corpus, since no single index can serve
+  both array containment and the order key. This is expected and non-regressive; do
+  NOT try to "fix" the Sort away (see `keyset_plan_scale_test.exs` and
+  docs/runbooks/knowledge-scale.md).
   """
   @spec keyset_query(Ecto.UUID.t(), keyword()) :: Ecto.Query.t()
   def keyset_query(tenant_id, opts \\ []) do
-    limit = opts |> Keyword.get(:limit, 21) |> max(1)
+    # Default mirrors list_keyset/2's page (@default_page_size) + 1 peek row, so the
+    # :scale_nightly plan test exercises the same shape the request path runs.
+    limit = opts |> Keyword.get(:limit, @default_page_size + 1) |> max(1)
     status = Keyword.get(opts, :status, :published)
 
     base = from(a in Article, where: a.tenant_id == ^tenant_id)

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -60,7 +60,8 @@ defmodule Loopctl.Knowledge do
 
   @doc """
   The maximum page size (`limit`) honored by the **enumeration** paths
-  (`list_articles/2`, `list_filtered/2`, `list_drafts/2`, `list_index/2`).
+  (`list_articles/2`, `list_filtered/2`, `list_keyset/2`, `list_drafts/2`,
+  `list_index/2`).
 
   Exposed so the controller can reject an over-large requested `limit` with a
   400 instead of silently clamping it.
@@ -1456,6 +1457,143 @@ defmodule Loopctl.Knowledge do
          total_count_scope: "filtered_set"
        }
      }}
+  end
+
+  @doc """
+  KEYSET (cursor) enumeration of the filtered article set (US-27.9a).
+
+  The additive, drift-free companion to `list_filtered/2`. Where `list_filtered/2`
+  uses `OFFSET` (which drifts under the concurrent writes this KB sees — a tag
+  count was observed swinging 9,881 → 4,981 mid-enumeration), this seeks on the
+  stable unique tuple `(inserted_at, id)`:
+
+      WHERE tenant_id = ^tenant_id
+        AND (cursor? -> (inserted_at, id) > (^c_inserted, ^c_id))
+      ORDER BY inserted_at ASC, id ASC
+      LIMIT ^(limit + 1)
+
+  The `id` tie-break is mandatory: `inserted_at` is `utc_datetime_usec` and bulk
+  `insert_all` ties timestamps per batch, so `inserted_at` alone is not unique and
+  a page boundary could land mid-batch. The `limit + 1` "peek" tells us whether a
+  next page exists WITHOUT a `COUNT` — so there is no count to drift either.
+
+  Tenant scope comes from `tenant_id` (the caller's authenticated principal),
+  NEVER from the cursor. The cursor encodes only the intra-tenant ordering
+  position and is decoded/verified at the HTTP layer
+  (`Loopctl.Knowledge.ArticleCursor`).
+
+  ## Parameters
+
+  - `tenant_id` -- the tenant UUID (from the auth principal)
+  - `opts` -- keyword list:
+    - `:cursor` -- the decoded `{inserted_at, id}` position to seek AFTER, or
+      `nil`/absent to start from the beginning
+    - `:limit` -- max results per page (default 20, max #{@max_page_size}, min 1);
+      clamped here as a safety net, the HTTP layer 400s an over-large request
+    - `:status` -- filter by status atom (default `:published`)
+    - `:project_id`, `:category`, `:tags`, `:match`, `:memory_types`, `:agents`,
+      `:conversation_id`, `:visibility_agent_id` -- same filters as `list_filtered/2`
+
+  ## Returns
+
+  - `{:ok, %{results: [map()], next_cursor: position_or_nil, limit: effective_limit}}`
+    where `next_cursor` is the `(inserted_at, id)` tuple of the LAST returned row
+    when another page exists, else `nil`. The HTTP layer encodes it back into an
+    opaque cursor string.
+  """
+  @spec list_keyset(Ecto.UUID.t(), keyword()) ::
+          {:ok,
+           %{
+             results: [map()],
+             next_cursor: {DateTime.t(), Ecto.UUID.t()} | nil,
+             limit: pos_integer()
+           }}
+  def list_keyset(tenant_id, opts \\ []) do
+    limit = opts |> Keyword.get(:limit, 20) |> max(1) |> min(@max_page_size)
+
+    # Fetch limit+1 to detect a next page without a COUNT (AC-27.9a.1).
+    rows =
+      tenant_id
+      |> keyset_query(Keyword.put(opts, :limit, limit + 1))
+      |> then(&HeavyRead.all(tenant_id, &1, heavy_read_opts(:enumeration)))
+
+    {page, has_more?} = split_peek(rows, limit)
+
+    next_cursor =
+      if has_more? do
+        last = List.last(page)
+        {last.inserted_at, last.id}
+      end
+
+    maybe_record_search_access(tenant_id, page, "", opts, "list_keyset")
+
+    {:ok, %{results: page, next_cursor: next_cursor, limit: limit}}
+  end
+
+  @doc """
+  Builds the keyset seek QUERYABLE for the article list (US-27.9a), returned (not
+  executed) so the `:scale_nightly` plan test can assert it is index-backed
+  (`(tenant_id, inserted_at, id)`, no Seq Scan) via `EXPLAIN`.
+
+  Same `opts` as `list_keyset/2`; `:limit` is applied as-is here (the caller adds
+  the `+1` peek). This is the EXACT query `list_keyset/2` runs, so the plan
+  assertion guards the request path, not a stunt double.
+  """
+  @spec keyset_query(Ecto.UUID.t(), keyword()) :: Ecto.Query.t()
+  def keyset_query(tenant_id, opts \\ []) do
+    limit = opts |> Keyword.get(:limit, 21) |> max(1)
+    status = Keyword.get(opts, :status, :published)
+
+    base = from(a in Article, where: a.tenant_id == ^tenant_id)
+
+    base
+    |> apply_search_filters(status, opts)
+    |> apply_keyset_seek(Keyword.get(opts, :cursor))
+    |> select([a], %{
+      id: a.id,
+      tenant_id: a.tenant_id,
+      project_id: a.project_id,
+      title: a.title,
+      category: a.category,
+      status: a.status,
+      tags: a.tags,
+      inserted_at: a.inserted_at,
+      updated_at: a.updated_at
+    })
+    |> order_by([a], asc: a.inserted_at, asc: a.id)
+    |> limit(^limit)
+  end
+
+  # No cursor: enumerate from the start.
+  defp apply_keyset_seek(query, nil), do: query
+
+  # Row-value comparison `(inserted_at, id) > (^ins, ^id)`: the standard keyset
+  # seek that the composite (tenant_id, inserted_at, id) btree serves directly.
+  defp apply_keyset_seek(query, {%DateTime{} = inserted_at, id})
+       when is_binary(id) do
+    # `type/2` tells Ecto the bound params' DB types: the raw `fragment` row-value
+    # comparison would otherwise send `id` as text and `inserted_at` without the
+    # column's type, which Postgrex rejects (id is binary_id / uuid).
+    where(
+      query,
+      [a],
+      fragment(
+        "(?, ?) > (?, ?)",
+        a.inserted_at,
+        a.id,
+        type(^inserted_at, a.inserted_at),
+        type(^id, a.id)
+      )
+    )
+  end
+
+  # Split limit+1 peek rows into the page (≤ limit) and whether more remain.
+  defp split_peek(rows, limit) do
+    if length(rows) > limit do
+      {Enum.take(rows, limit), true}
+    else
+      {rows, false}
+    end
   end
 
   defp apply_search_filters(query, status, opts) do

--- a/lib/loopctl/knowledge/article_cursor.ex
+++ b/lib/loopctl/knowledge/article_cursor.ex
@@ -134,11 +134,23 @@ defmodule Loopctl.Knowledge.ArticleCursor do
 
   # Per-tenant HMAC key: app secret_key_base + tenant_id. Stable across nodes
   # without storing a per-tenant secret. Mirrors BulkOps.confirm_secret/1.
+  #
+  # FAIL CLOSED: `secret_key_base` is fetched (not defaulted). If it were ever
+  # absent, signing with a guessable constant would silently defeat the entire
+  # tenant-binding/forgery guarantee (a known key + a non-secret tenant_id = a
+  # forgeable cursor); raising instead is the safe failure. `runtime.exs` already
+  # requires SECRET_KEY_BASE in prod and the test/dev configs set it, so this
+  # raise is unreachable in every real environment — it is a guard, not a path.
+  #
+  # The `:article_cursor:` infix namespaces this key away from
+  # `BulkOps.confirm_secret/1` and binds it to the tenant. `tenant_id` is an Ecto
+  # `binary_id` (a canonical UUID), which cannot contain the `:` delimiter, so no
+  # two distinct tenants can derive the same key string — no cross-tenant collision.
   defp secret(tenant_id) do
     base =
       :loopctl
-      |> Application.get_env(LoopctlWeb.Endpoint, [])
-      |> Keyword.get(:secret_key_base, "loopctl-article-cursor")
+      |> Application.fetch_env!(LoopctlWeb.Endpoint)
+      |> Keyword.fetch!(:secret_key_base)
 
     base <> ":article_cursor:" <> to_string(tenant_id)
   end

--- a/lib/loopctl/knowledge/article_cursor.ex
+++ b/lib/loopctl/knowledge/article_cursor.ex
@@ -1,0 +1,145 @@
+defmodule Loopctl.Knowledge.ArticleCursor do
+  @moduledoc """
+  Integrity-protected, tenant-bound keyset cursor for the article list (US-27.9a).
+
+  The article list paginates by the stable unique tuple `(inserted_at, id)` (the
+  `id` tie-break is mandatory: `inserted_at` is `utc_datetime_usec` and bulk
+  `insert_all` ties timestamps per batch, so `inserted_at` alone is NOT unique).
+  This module turns that ordering position into an opaque string the caller hands
+  back as `?cursor=`, and turns it back into the tuple on the next request.
+
+  ## Trust model (AC-27.9a.3 / .4)
+
+  A Base64 blob is **encoding, not integrity** — a caller can flip bits or forge a
+  payload. So the cursor is treated as untrusted input:
+
+  - It encodes ONLY an intra-tenant ordering position `(inserted_at, id)`. It does
+    NOT carry the tenant_id as a trust input — the caller's tenant always comes
+    from the authenticated principal (`conn.assigns`), never from the cursor.
+  - It is HMAC-SHA256 signed with a PER-TENANT key derived from the app
+    `secret_key_base` + the tenant_id (same server-minted scheme as
+    `Loopctl.Knowledge.BulkOps.confirm_hash/2`). `decode/2` verifies with the
+    CALLER's tenant key, so a cursor minted for tenant B fails verification for
+    tenant A — it can neither cross tenants nor become an existence oracle for
+    another tenant's rows.
+  - `decode/2` is DEFENSIVE: garbage, a bit-flipped signature, a tampered payload,
+    or a wrong-tenant cursor all return `{:error, :invalid}` — never a raise, and
+    never a partial/ambiguous result the caller could probe with.
+
+  The signature is compared in constant time (`:crypto.hash_equals/2`) so the
+  cursor can't be brute-forced one byte at a time via timing.
+  """
+
+  @hmac_bytes 32
+
+  @typedoc "The keyset position: the `(inserted_at, id)` of a row in (inserted_at ASC, id ASC) order."
+  @type position :: {DateTime.t(), Ecto.UUID.t()}
+
+  @doc """
+  Encodes the keyset position `{inserted_at, id}` into an opaque cursor string.
+
+  The cursor is signed with `tenant_id`'s per-tenant key. The returned string is
+  URL-safe Base64 with no padding, so it is safe as a bare `?cursor=` query value.
+  """
+  @spec encode(Ecto.UUID.t(), position()) :: String.t()
+  def encode(tenant_id, {%DateTime{} = inserted_at, id})
+      when is_binary(tenant_id) and is_binary(id) do
+    payload = serialize(inserted_at, id)
+    sig = :crypto.mac(:hmac, :sha256, secret(tenant_id), payload)
+    Base.url_encode64(payload <> sig, padding: false)
+  end
+
+  @doc """
+  Decodes and verifies an opaque cursor, returning `{:ok, {inserted_at, id}}`.
+
+  Verifies the HMAC with `tenant_id`'s per-tenant key. ANY problem — malformed
+  Base64, wrong length, signature mismatch (tampered payload OR a cursor signed
+  for a different tenant), or an undeserializable payload — returns
+  `{:error, :invalid}`. Never raises; never leaks why it failed.
+  """
+  @spec decode(Ecto.UUID.t(), String.t()) :: {:ok, position()} | {:error, :invalid}
+  def decode(tenant_id, cursor) when is_binary(tenant_id) and is_binary(cursor) do
+    with {:ok, decoded} <- url_decode(cursor),
+         {:ok, payload, sig} <- split(decoded),
+         :ok <- verify(tenant_id, payload, sig) do
+      deserialize(payload)
+    end
+  end
+
+  def decode(_tenant_id, _cursor), do: {:error, :invalid}
+
+  # --- internals ---
+
+  # Canonical, fixed-shape payload: a tagged 2-tuple of the inserted_at in
+  # integer microseconds (so the value is exact and order-preserving) and the
+  # raw 16-byte UUID. term_to_binary is compact and round-trips precisely; we
+  # never call binary_to_term WITHOUT [:safe] and we re-validate the shape, so a
+  # forged payload can't deserialize into anything dangerous.
+  defp serialize(%DateTime{} = inserted_at, id) do
+    micros = DateTime.to_unix(inserted_at, :microsecond)
+    {:ok, raw} = Ecto.UUID.dump(id)
+    :erlang.term_to_binary({:k, micros, raw})
+  end
+
+  defp deserialize(payload) do
+    case safe_binary_to_term(payload) do
+      {:k, micros, raw}
+      when is_integer(micros) and is_binary(raw) and byte_size(raw) == 16 ->
+        with {:ok, datetime} <- from_unix_micros(micros),
+             {:ok, id} <- Ecto.UUID.load(raw) do
+          {:ok, {datetime, id}}
+        else
+          _ -> {:error, :invalid}
+        end
+
+      _ ->
+        {:error, :invalid}
+    end
+  end
+
+  # binary_to_term/2 with [:safe] still raises on a non-term binary, so guard it.
+  defp safe_binary_to_term(bin) do
+    :erlang.binary_to_term(bin, [:safe])
+  rescue
+    ArgumentError -> :error
+  end
+
+  defp from_unix_micros(micros) do
+    {:ok, DateTime.from_unix!(micros, :microsecond)}
+  rescue
+    _ -> {:error, :invalid}
+  end
+
+  defp url_decode(cursor) do
+    case Base.url_decode64(cursor, padding: false) do
+      {:ok, decoded} -> {:ok, decoded}
+      :error -> {:error, :invalid}
+    end
+  end
+
+  # The trailing @hmac_bytes are the signature; everything before is the payload.
+  defp split(decoded) when byte_size(decoded) > @hmac_bytes do
+    payload_len = byte_size(decoded) - @hmac_bytes
+    <<payload::binary-size(payload_len), sig::binary-size(@hmac_bytes)>> = decoded
+    {:ok, payload, sig}
+  end
+
+  defp split(_decoded), do: {:error, :invalid}
+
+  defp verify(tenant_id, payload, sig) do
+    expected = :crypto.mac(:hmac, :sha256, secret(tenant_id), payload)
+
+    if :crypto.hash_equals(expected, sig), do: :ok, else: {:error, :invalid}
+  end
+
+  # Per-tenant HMAC key: app secret_key_base + tenant_id. Stable across nodes
+  # without storing a per-tenant secret. Mirrors BulkOps.confirm_secret/1.
+  defp secret(tenant_id) do
+    base =
+      :loopctl
+      |> Application.get_env(LoopctlWeb.Endpoint, [])
+      |> Keyword.get(:secret_key_base, "loopctl-article-cursor")
+
+    base <> ":article_cursor:" <> to_string(tenant_id)
+  end
+end

--- a/lib/loopctl/knowledge/bulk_ops.ex
+++ b/lib/loopctl/knowledge/bulk_ops.ex
@@ -695,10 +695,16 @@ defmodule Loopctl.Knowledge.BulkOps do
   # Per-tenant confirm secret for the re-confirm-on-drift hash. Derived from the
   # app secret_key_base + tenant_id so it's stable across nodes without storing a
   # separate per-tenant key. NEVER trusted as a delete target — only compared.
+  #
+  # FAIL CLOSED: `secret_key_base` is fetched, not defaulted — signing a confirm
+  # hash with a guessable constant would let a caller forge a drift-confirm. The
+  # raise is unreachable in every real env (runtime.exs requires SECRET_KEY_BASE;
+  # test/dev configs set it). Mirrors `Loopctl.Knowledge.ArticleCursor.secret/1`.
   defp confirm_secret(tenant_id) do
     base =
-      Application.get_env(:loopctl, LoopctlWeb.Endpoint, [])
-      |> Keyword.get(:secret_key_base, "loopctl-bulk-delete-confirm")
+      :loopctl
+      |> Application.fetch_env!(LoopctlWeb.Endpoint)
+      |> Keyword.fetch!(:secret_key_base)
 
     base <> ":" <> to_string(tenant_id)
   end

--- a/lib/loopctl/knowledge/scale_seed.ex
+++ b/lib/loopctl/knowledge/scale_seed.ex
@@ -110,6 +110,17 @@ defmodule Loopctl.Knowledge.ScaleSeed do
 
   defp visibility_metadata(_i), do: %{"visibility" => "shared"}
 
+  # Status distribution. Default: all `:published` (US-27.1/27.2/27.6a scale tests
+  # assume a fully-published corpus, so this must not change for them). With
+  # `status_mix: true` (US-27.9a keyset plan test), interleave ~20% non-published
+  # (~10% `:archived`, ~10% `:draft`) so the keyset query's `status = :published`
+  # residual has REAL selectivity — the walk must then skip index entries that don't
+  # match, exercising the deep-page cost the all-published seed hides.
+  defp seed_status(_i, false), do: :published
+  defp seed_status(i, true) when rem(i, 10) == 0, do: :archived
+  defp seed_status(i, true) when rem(i, 10) == 5, do: :draft
+  defp seed_status(_i, true), do: :published
+
   @doc """
   Seeds `count` published articles for `tenant_id`, seeds inter-article links,
   runs ANALYZE, and verifies statistics.
@@ -160,9 +171,11 @@ defmodule Loopctl.Knowledge.ScaleSeed do
     count = Keyword.get(opts, :count, 1_000)
     link_density = Keyword.get(opts, :link_density, 5)
     batch_size = Keyword.get(opts, :batch_size, 1_000)
+    status_mix = Keyword.get(opts, :status_mix, false)
 
     with :ok <- assert_hnsw_index_present!(),
-         {:ok, article_ids} <- insert_articles_in_batches(tenant_id, count, batch_size),
+         {:ok, article_ids} <-
+           insert_articles_in_batches(tenant_id, count, batch_size, status_mix),
          {:ok, link_count} <- seed_links(tenant_id, article_ids, link_density),
          :ok <- analyze_and_verify(tenant_id, length(article_ids)) do
       {:ok, %{articles: length(article_ids), links: link_count}}
@@ -301,7 +314,7 @@ defmodule Loopctl.Knowledge.ScaleSeed do
     end
   end
 
-  defp insert_articles_in_batches(tenant_id, total_count, batch_size) do
+  defp insert_articles_in_batches(tenant_id, total_count, batch_size, status_mix) do
     article_ids =
       0..(total_count - 1)
       |> Enum.chunk_every(batch_size)
@@ -339,7 +352,7 @@ defmodule Loopctl.Knowledge.ScaleSeed do
               # ~10% private memory. NB: suggested_links / US-27.1 / US-27.2 scale tests
               # don't filter on these, so the variation doesn't change their plans.
               category: Enum.at(@scale_categories, rem(i, length(@scale_categories))),
-              status: :published,
+              status: seed_status(i, status_mix),
               slug: slug,
               tags: ["scale-tag-#{rem(i, 50)}"],
               metadata: visibility_metadata(i),

--- a/lib/loopctl_web/controllers/knowledge_search_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_search_controller.ex
@@ -19,6 +19,7 @@ defmodule LoopctlWeb.KnowledgeSearchController do
   alias Loopctl.ApiSpec.Schemas
   alias Loopctl.Knowledge
   alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.ArticleCursor
   alias LoopctlWeb.Helpers.Pagination
   alias LoopctlWeb.Helpers.TagMatch
   alias LoopctlWeb.Helpers.Visibility
@@ -108,6 +109,17 @@ defmodule LoopctlWeb.KnowledgeSearchController do
         type: :integer,
         description: "Results to skip for pagination (default 0)",
         required: false
+      ],
+      cursor: [
+        in: :query,
+        type: :string,
+        description:
+          "Opaque KEYSET cursor for drift-free list enumeration (list mode only). " <>
+            "Omit to start from the beginning, then follow `meta.next_cursor` " <>
+            "verbatim until it is null. The cursor is integrity-protected and " <>
+            "tenant-bound — a tampered/forged cursor is rejected with 400. Not " <>
+            "valid with `q` (relevance modes return a ranked top-N, not a walk).",
+        required: false
       ]
     ],
     responses: %{
@@ -174,21 +186,93 @@ defmodule LoopctlWeb.KnowledgeSearchController do
         |> Keyword.put(:api_key_id, api_key_id)
         |> Keyword.merge(Visibility.scope_opts(conn))
 
-      case execute_search(tenant_id, query_spec, mode, opts) do
-        {:ok, result} ->
-          json(conn, LoopctlWeb.KnowledgeSearchJSON.search(result, mode))
+      # US-27.9a: the presence of a `cursor` query param (even empty) opts the
+      # LIST path into drift-free keyset pagination. Tenant scope is the
+      # principal's (`tenant_id`), never the cursor; the cursor is
+      # decoded+verified with the caller's tenant key.
+      #
+      #   - param ABSENT  → legacy offset list path (back-compat, unchanged)
+      #   - param EMPTY   → keyset walk FROM THE START (first page, no seek)
+      #   - param a token → keyset seek AFTER the decoded position
+      case keyset_cursor(params) do
+        :none ->
+          run_search(conn, tenant_id, query_spec, mode, opts)
 
-        {:error, :embedding_unavailable} ->
-          conn
-          |> put_status(503)
-          |> json(%{error: %{status: 503, message: "Embedding service unavailable"}})
-
-        {:error, :empty_query} ->
-          {:error, :bad_request, "Query parameter 'q' is required and cannot be empty"}
-
-        {:error, :bad_request, msg} ->
-          {:error, :bad_request, msg}
+        cursor_mode ->
+          run_keyset(conn, tenant_id, query_spec, cursor_mode, opts)
       end
+    end
+  end
+
+  defp run_search(conn, tenant_id, query_spec, mode, opts) do
+    case execute_search(tenant_id, query_spec, mode, opts) do
+      {:ok, result} ->
+        json(conn, LoopctlWeb.KnowledgeSearchJSON.search(result, mode))
+
+      {:error, :embedding_unavailable} ->
+        conn
+        |> put_status(503)
+        |> json(%{error: %{status: 503, message: "Embedding service unavailable"}})
+
+      {:error, :empty_query} ->
+        {:error, :bad_request, "Query parameter 'q' is required and cannot be empty"}
+
+      {:error, :bad_request, msg} ->
+        {:error, :bad_request, msg}
+    end
+  end
+
+  # The keyset cursor is a LIST-mode (enumeration) concept; pairing it with a
+  # relevance `q` is a client error (the relevance modes return a ranked top-N,
+  # not a stable-tuple walk), so reject rather than silently ignore one of them.
+  defp run_keyset(_conn, _tenant_id, {:search, _q}, _cursor_mode, _opts) do
+    {:error, :bad_request,
+     "cursor pagination is only available for list enumeration; drop 'q' " <>
+       "(supply 'tags' and/or 'category' to enumerate the filtered set)"}
+  end
+
+  # Empty cursor → start the walk from the beginning (no seek position).
+  defp run_keyset(conn, tenant_id, :list, :start, opts) do
+    render_keyset(conn, tenant_id, opts, nil)
+  end
+
+  # Token cursor → defensive decode (garbage / bit-flipped / wrong-tenant → 400,
+  # never a 500 and never a silent reset to page 1, AC-27.9a.4). Tenant scope is
+  # ALWAYS the principal's `tenant_id`; the cursor only carries a position.
+  defp run_keyset(conn, tenant_id, :list, {:cursor, raw}, opts) do
+    case ArticleCursor.decode(tenant_id, raw) do
+      {:ok, position} ->
+        render_keyset(conn, tenant_id, opts, position)
+
+      {:error, :invalid} ->
+        {:error, :bad_request,
+         "Invalid or tampered cursor. Send an empty 'cursor' to start from the " <>
+           "beginning, then follow 'meta.next_cursor' verbatim to paginate."}
+    end
+  end
+
+  defp render_keyset(conn, tenant_id, opts, position) do
+    {:ok, result} = Knowledge.list_keyset(tenant_id, Keyword.put(opts, :cursor, position))
+
+    encoded =
+      case result.next_cursor do
+        nil -> nil
+        cursor -> ArticleCursor.encode(tenant_id, cursor)
+      end
+
+    json(conn, LoopctlWeb.KnowledgeSearchJSON.keyset(%{result | next_cursor: encoded}))
+  end
+
+  # Classifies the `cursor` query param: ABSENT → `:none` (legacy offset path);
+  # PRESENT-but-empty → `:start` (keyset from the beginning); a non-empty string →
+  # `{:cursor, raw}` (keyset seek). A non-string `cursor[]=` form is `:start`
+  # (opt into keyset, start position) rather than a 500.
+  defp keyset_cursor(params) when is_map(params) do
+    case Map.fetch(params, "cursor") do
+      :error -> :none
+      {:ok, ""} -> :start
+      {:ok, raw} when is_binary(raw) -> {:cursor, raw}
+      {:ok, _non_string} -> :start
     end
   end
 

--- a/lib/loopctl_web/controllers/knowledge_search_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_search_controller.ex
@@ -115,10 +115,14 @@ defmodule LoopctlWeb.KnowledgeSearchController do
         type: :string,
         description:
           "Opaque KEYSET cursor for drift-free list enumeration (list mode only). " <>
-            "Omit to start from the beginning, then follow `meta.next_cursor` " <>
-            "verbatim until it is null. The cursor is integrity-protected and " <>
-            "tenant-bound — a tampered/forged cursor is rejected with 400. Not " <>
-            "valid with `q` (relevance modes return a ranked top-N, not a walk).",
+            "To use cursor pagination, pass an empty string (`cursor=`) on the FIRST request " <>
+            "to opt into the keyset path (which orders by `inserted_at ASC, id ASC`); then " <>
+            "follow `meta.next_cursor` verbatim on subsequent requests. Omitting the `cursor` " <>
+            "parameter entirely uses the legacy offset path (orders by `updated_at DESC`), " <>
+            "which does not emit `next_cursor`. Do not mix the two paths mid-enumeration, " <>
+            "as the sort order differs. The cursor is integrity-protected and tenant-bound — " <>
+            "a tampered/forged cursor is rejected with 400. Not valid with `q` (relevance " <>
+            "modes return a ranked top-N, not a walk).",
         required: false
       ]
     ],
@@ -191,12 +195,16 @@ defmodule LoopctlWeb.KnowledgeSearchController do
       # principal's (`tenant_id`), never the cursor; the cursor is
       # decoded+verified with the caller's tenant key.
       #
-      #   - param ABSENT  → legacy offset list path (back-compat, unchanged)
-      #   - param EMPTY   → keyset walk FROM THE START (first page, no seek)
-      #   - param a token → keyset seek AFTER the decoded position
+      #   - param ABSENT      → legacy offset list path (back-compat, unchanged)
+      #   - param EMPTY       → keyset walk FROM THE START (first page, no seek)
+      #   - param a token     → keyset seek AFTER the decoded position
+      #   - param malformed   → 400 (not a string)
       case keyset_cursor(params) do
         :none ->
           run_search(conn, tenant_id, query_spec, mode, opts)
+
+        :invalid ->
+          {:error, :bad_request, "cursor parameter must be a string"}
 
         cursor_mode ->
           run_keyset(conn, tenant_id, query_spec, cursor_mode, opts)
@@ -265,14 +273,14 @@ defmodule LoopctlWeb.KnowledgeSearchController do
 
   # Classifies the `cursor` query param: ABSENT → `:none` (legacy offset path);
   # PRESENT-but-empty → `:start` (keyset from the beginning); a non-empty string →
-  # `{:cursor, raw}` (keyset seek). A non-string `cursor[]=` form is `:start`
-  # (opt into keyset, start position) rather than a 500.
+  # `{:cursor, raw}` (keyset seek); a non-string `cursor[]=` form → `:invalid` (400,
+  # not a 500 and not a silent page-1 reset).
   defp keyset_cursor(params) when is_map(params) do
     case Map.fetch(params, "cursor") do
       :error -> :none
       {:ok, ""} -> :start
       {:ok, raw} when is_binary(raw) -> {:cursor, raw}
-      {:ok, _non_string} -> :start
+      {:ok, _non_string} -> :invalid
     end
   end
 

--- a/lib/loopctl_web/controllers/knowledge_search_json.ex
+++ b/lib/loopctl_web/controllers/knowledge_search_json.ex
@@ -23,6 +23,37 @@ defmodule LoopctlWeb.KnowledgeSearchJSON do
     }
   end
 
+  @doc """
+  Renders a KEYSET (cursor) list page (US-27.9a).
+
+  Unlike `search/2`, the keyset list path carries no relevance score/snippet, and
+  its `meta` documents `next_cursor` (the opaque, already-encoded cursor for the
+  next page, or `null` when the walk is exhausted) and the effective `limit`
+  instead of an offset/total_count. `next_cursor` is encoded by the controller
+  (it needs the tenant key), so this view receives it as a ready string or `nil`.
+  """
+  def keyset(%{results: results, next_cursor: next_cursor, limit: limit}) do
+    %{
+      data: Enum.map(results, &render_list_row/1),
+      meta: %{
+        # The cursor walk is drift-free precisely BECAUSE it carries no
+        # total_count to drift; `next_cursor: null` is the exhaustion signal.
+        next_cursor: next_cursor,
+        limit: limit,
+        search_mode: "list_keyset"
+      }
+    }
+  end
+
+  defp render_list_row(result) do
+    %{
+      id: result[:id] || result.id,
+      title: result[:title] || result.title,
+      category: to_string(result[:category] || result.category),
+      tags: result[:tags] || result.tags || []
+    }
+  end
+
   defp render_result(result, mode) do
     base = %{
       id: result[:id] || result.id,

--- a/lib/loopctl_web/controllers/knowledge_search_json.ex
+++ b/lib/loopctl_web/controllers/knowledge_search_json.ex
@@ -45,12 +45,17 @@ defmodule LoopctlWeb.KnowledgeSearchJSON do
     }
   end
 
+  # Keyset rows always arrive as plain atom-keyed maps from `Knowledge.keyset_query/2`'s
+  # `select` (every field present; `tags` is a non-null `{:array}` default `[]`), so
+  # direct field access is correct — and a missing field SHOULD crash loudly rather than
+  # silently degrade. (`render_result/1` keeps the dual accessor because search results
+  # may be structs.)
   defp render_list_row(result) do
     %{
-      id: result[:id] || result.id,
-      title: result[:title] || result.title,
-      category: to_string(result[:category] || result.category),
-      tags: result[:tags] || result.tags || []
+      id: result.id,
+      title: result.title,
+      category: to_string(result.category),
+      tags: result.tags
     }
   end
 

--- a/priv/repo/migrations/20260624150000_add_articles_keyset_index.exs
+++ b/priv/repo/migrations/20260624150000_add_articles_keyset_index.exs
@@ -1,0 +1,31 @@
+defmodule Loopctl.Repo.Migrations.AddArticlesKeysetIndex do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  @moduledoc false
+  # Composite btree index backing the article-list KEYSET cursor (US-27.9a):
+  #   WHERE tenant_id = $1 AND (inserted_at, id) > ($2, $3)
+  #   ORDER BY inserted_at ASC, id ASC LIMIT n+1
+  #
+  # The cursor key MUST be the (inserted_at, id) TUPLE — `inserted_at` is
+  # utc_datetime_usec and bulk insert_all ties timestamps per batch, and the PK
+  # is a random binary_id (no monotonic bigint to fall back on). This index lets
+  # the planner seek straight to a deep page instead of Seq-Scanning the corpus
+  # (AC-27.9a.2; proven by the :scale_nightly refute_full_scan/1 plan test).
+  #
+  # Built CONCURRENTLY (outside a ddl transaction) so the build does not block
+  # writes to the ~76k-row articles table online.
+
+  def up do
+    execute("""
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS articles_tenant_inserted_id_idx
+    ON articles (tenant_id, inserted_at, id)
+    """)
+  end
+
+  def down do
+    execute("DROP INDEX CONCURRENTLY IF EXISTS articles_tenant_inserted_id_idx")
+  end
+end

--- a/test/loopctl/index_health_test.exs
+++ b/test/loopctl/index_health_test.exs
@@ -1,0 +1,52 @@
+defmodule Loopctl.IndexHealthTest do
+  @moduledoc """
+  US-27.9a: the boot-time critical-index validity probe. In the test DB the keyset
+  index is created by the migration and is valid; a bogus name is `:missing`.
+  """
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.IndexHealth
+
+  describe "index_validity/1" do
+    test "reports :valid for the real keyset index (migration-created, valid)" do
+      assert IndexHealth.index_validity("articles_tenant_inserted_id_idx") == :valid
+    end
+
+    test "reports :missing for an index that does not exist" do
+      assert IndexHealth.index_validity(
+               "definitely_not_an_index_#{System.unique_integer([:positive])}"
+             ) ==
+               :missing
+    end
+  end
+
+  describe "which/0" do
+    test "includes the keyset index in the critical list" do
+      names = Enum.map(IndexHealth.which(), fn {name, _purpose} -> name end)
+      assert "articles_tenant_inserted_id_idx" in names
+    end
+  end
+
+  describe "warn_if_invalid_indexes/0" do
+    test "returns :ok and emits no telemetry when all critical indexes are valid" do
+      ref = make_ref()
+      test_pid = self()
+      handler_id = {__MODULE__, ref}
+
+      :telemetry.attach(
+        handler_id,
+        [:loopctl, :index_health, :invalid],
+        fn _e, _m, meta, _ -> send(test_pid, {ref, meta}) end,
+        nil
+      )
+
+      try do
+        assert IndexHealth.warn_if_invalid_indexes() == :ok
+      after
+        :telemetry.detach(handler_id)
+      end
+
+      refute_received {^ref, _meta}
+    end
+  end
+end

--- a/test/loopctl/knowledge/article_cursor_test.exs
+++ b/test/loopctl/knowledge/article_cursor_test.exs
@@ -1,0 +1,120 @@
+defmodule Loopctl.Knowledge.ArticleCursorTest do
+  @moduledoc """
+  Unit tests for the integrity-protected, tenant-bound keyset cursor (US-27.9a).
+
+  These exercise the trust boundary directly: round-trip fidelity, wrong-tenant
+  rejection (AC-27.9a.3), tamper rejection (AC-27.9a.4), and that decode NEVER
+  raises — garbage in always yields `{:error, :invalid}`.
+  """
+  use ExUnit.Case, async: true
+
+  alias Loopctl.Knowledge.ArticleCursor
+
+  defp tenant_id, do: Ecto.UUID.generate()
+
+  defp position do
+    # utc_datetime_usec precision: the cursor must preserve microseconds exactly.
+    {DateTime.truncate(DateTime.utc_now(), :microsecond), Ecto.UUID.generate()}
+  end
+
+  describe "encode/2 + decode/2 round-trip" do
+    test "round-trips the (inserted_at, id) tuple exactly" do
+      tid = tenant_id()
+      {inserted_at, id} = position()
+
+      cursor = ArticleCursor.encode(tid, {inserted_at, id})
+      assert is_binary(cursor)
+
+      assert {:ok, {decoded_inserted_at, decoded_id}} = ArticleCursor.decode(tid, cursor)
+      assert decoded_id == id
+      assert DateTime.compare(decoded_inserted_at, inserted_at) == :eq
+    end
+
+    test "preserves sub-second microsecond precision (batch-tied timestamps)" do
+      tid = tenant_id()
+      # Two rows in the same insert_all batch share a timestamp to the microsecond.
+      inserted_at = ~U[2026-06-24 12:00:00.123456Z]
+      id = Ecto.UUID.generate()
+
+      cursor = ArticleCursor.encode(tid, {inserted_at, id})
+      assert {:ok, {decoded, ^id}} = ArticleCursor.decode(tid, cursor)
+      assert decoded == inserted_at
+    end
+
+    test "produces a URL-safe value (no +, /, or = padding)" do
+      cursor = ArticleCursor.encode(tenant_id(), position())
+      refute cursor =~ "+"
+      refute cursor =~ "/"
+      refute cursor =~ "="
+    end
+  end
+
+  describe "tenant binding (AC-27.9a.3)" do
+    test "a cursor minted for tenant B fails verification for tenant A" do
+      tenant_a = tenant_id()
+      tenant_b = tenant_id()
+      pos = position()
+
+      cursor_b = ArticleCursor.encode(tenant_b, pos)
+
+      # Same position, but tenant A's key does not verify tenant B's signature.
+      assert {:error, :invalid} = ArticleCursor.decode(tenant_a, cursor_b)
+      # And tenant B can still read its own cursor.
+      assert {:ok, _} = ArticleCursor.decode(tenant_b, cursor_b)
+    end
+  end
+
+  describe "tamper resistance (AC-27.9a.4)" do
+    test "a bit-flipped cursor fails verification" do
+      tid = tenant_id()
+      cursor = ArticleCursor.encode(tid, position())
+
+      tampered = flip_a_bit(cursor)
+      assert tampered != cursor
+      assert {:error, :invalid} = ArticleCursor.decode(tid, tampered)
+    end
+
+    test "a truncated cursor fails verification" do
+      tid = tenant_id()
+      cursor = ArticleCursor.encode(tid, position())
+
+      assert {:error, :invalid} = ArticleCursor.decode(tid, String.slice(cursor, 0..-5//1))
+    end
+  end
+
+  describe "defensive decode — never raises, never an oracle" do
+    test "garbage strings return {:error, :invalid}" do
+      tid = tenant_id()
+
+      for junk <- ["", "garbage", "!!!not-base64!!!", "a", String.duplicate("x", 500)] do
+        assert {:error, :invalid} = ArticleCursor.decode(tid, junk)
+      end
+    end
+
+    test "valid base64 but undersized payload returns {:error, :invalid}" do
+      tid = tenant_id()
+      short = Base.url_encode64("tooshort", padding: false)
+      assert {:error, :invalid} = ArticleCursor.decode(tid, short)
+    end
+
+    test "valid base64 of an arbitrary (correctly-sized) blob fails the HMAC" do
+      tid = tenant_id()
+      # 48 bytes = a plausible payload+sig length, but random → HMAC mismatch.
+      forged = Base.url_encode64(:crypto.strong_rand_bytes(48), padding: false)
+      assert {:error, :invalid} = ArticleCursor.decode(tid, forged)
+    end
+
+    test "non-binary cursor returns {:error, :invalid}" do
+      assert {:error, :invalid} = ArticleCursor.decode(tenant_id(), nil)
+      assert {:error, :invalid} = ArticleCursor.decode(tenant_id(), 123)
+    end
+  end
+
+  # Flip the lowest bit of the first decoded byte (the payload region), so the
+  # signature no longer matches the (now-altered) payload.
+  defp flip_a_bit(cursor) do
+    decoded = Base.url_decode64!(cursor, padding: false)
+    <<first, rest::binary>> = decoded
+    Base.url_encode64(<<Bitwise.bxor(first, 1), rest::binary>>, padding: false)
+  end
+end

--- a/test/loopctl/knowledge/keyset_plan_scale_test.exs
+++ b/test/loopctl/knowledge/keyset_plan_scale_test.exs
@@ -8,6 +8,28 @@ defmodule Loopctl.Knowledge.KeysetPlanScaleTest do
   index scan, so this asserts `PlanAssertions.refute_full_scan/1` (no full-corpus
   node), NOT `assert_hnsw_index/1`.
 
+  CRITICAL — residual coverage: `list_keyset/2` runs `apply_search_filters/3`, so
+  the production keyset query is NOT just `status = :published + cursor`; the HTTP
+  callers walk WITH `?tags=`/`?category=` filters. A selective residual inside an
+  index-ordered query is exactly the BitmapAnd+Sort hazard that shipped the
+  #170/#172 prod-500s, so this test asserts the plan for EVERY production shape, with
+  the assertion that matches what each shape can physically achieve:
+
+  - SCALAR shapes (residual-free, `+category`) MUST be strictly index-ordered — the
+    `(tenant_id, inserted_at, id)` btree walked in order, no Sort, no Bitmap
+    (`refute_full_scan/1`). This is the core keyset promise.
+  - ARRAY shape (`+tags`, `+tags+category`): `tags &&` is served by a GIN index and
+    no btree can provide both array containment AND `(inserted_at, id)` order, so the
+    planner BitmapAnds the tags GIN with the keyset btree and Sorts. That is bounded
+    by TAG SELECTIVITY, not the corpus, and is non-regressive vs the tag-filtered
+    OFFSET query. We assert the catastrophe-guard (`refute_seq_scan/1` — no unbounded
+    full-corpus read) plus `assert_index_used/2` for BOTH the selective tags GIN and
+    the keyset btree, proving the bound is real. See docs/runbooks/knowledge-scale.md.
+
+  The corpus is seeded with a realistic ~20% non-published `status_mix` so the
+  `status = :published` residual itself has selectivity (the walk must skip
+  non-matching index entries).
+
   Seeds ~80k committed rows (Loopctl.Knowledge.ScaleSeed), so it is
   `:scale_nightly` (runs on the nightly/scale gate, not the default async suite).
   """
@@ -44,7 +66,14 @@ defmodule Loopctl.Knowledge.KeysetPlanScaleTest do
           })
           |> AdminRepo.insert()
 
-        ScaleSeed.seed(t.id, count: ScaleSeed.prod_article_floor(), link_density: 5)
+        # status_mix: ~20% non-published so the `status = :published` residual has
+        # real selectivity (the deep page must skip filtered index entries).
+        ScaleSeed.seed(t.id,
+          count: ScaleSeed.prod_article_floor(),
+          link_density: 5,
+          status_mix: true
+        )
+
         t
       end)
 
@@ -62,18 +91,26 @@ defmodule Loopctl.Knowledge.KeysetPlanScaleTest do
     {:ok, tenant: tenant}
   end
 
-  test "keyset seek for a DEEP page is index-backed (no Seq Scan) at prod scale",
+  test "keyset seek for a DEEP page is index-backed for EVERY production residual shape at prod scale",
        %{tenant: tenant} do
     unboxed(fn ->
-      # Pick a position deep in (inserted_at ASC, id ASC) order — ~90% through the
-      # corpus — so the seek is a genuinely late page, the #148 offset-drift /
-      # deep-page-cost scenario the index must serve.
-      deep_offset = trunc(ScaleSeed.prod_article_floor() * 0.9)
+      # Pick a position deep in (inserted_at ASC, id ASC) order among PUBLISHED rows
+      # — ~90% through the published corpus — so the seek is a genuinely late page,
+      # the #148 offset-drift / deep-page-cost scenario the index must serve.
+      published_count =
+        AdminRepo.one(
+          from(a in Article,
+            where: a.tenant_id == ^tenant.id and a.status == :published,
+            select: count(a.id)
+          )
+        )
+
+      deep_offset = trunc(published_count * 0.9)
 
       deep =
         AdminRepo.one(
           from(a in Article,
-            where: a.tenant_id == ^tenant.id,
+            where: a.tenant_id == ^tenant.id and a.status == :published,
             order_by: [asc: a.inserted_at, asc: a.id],
             offset: ^deep_offset,
             limit: 1,
@@ -81,20 +118,58 @@ defmodule Loopctl.Knowledge.KeysetPlanScaleTest do
           )
         )
 
-      assert deep, "expected a deep row at offset #{deep_offset}"
+      assert deep, "expected a deep published row at offset #{deep_offset}"
 
-      # Build the EXACT request-path query list_keyset/2 runs for that deep cursor.
-      query =
-        Knowledge.keyset_query(tenant.id,
-          status: :published,
-          cursor: {deep.inserted_at, deep.id},
-          limit: 21
-        )
+      cursor = {deep.inserted_at, deep.id}
 
-      # AC-27.9a.2 / TC-27.9a.4: the planner's NATURAL choice (no enable_seqscan=off)
-      # at 80k must reach `articles` via the (tenant_id, inserted_at, id) btree —
-      # never a Seq/Bitmap full-corpus scan.
-      assert :ok = PlanAssertions.refute_full_scan(query)
+      # Every shape below is the EXACT request-path query list_keyset/2 runs
+      # (keyset_query/2), for a deep cursor, under the planner's NATURAL choice
+      # (no enable_seqscan=off) at 80k.
+      #
+      # SCALAR paths (no filter, or `category =`) must be STRICTLY index-ordered:
+      # the planner reaches `articles` via the (tenant_id, inserted_at, id) btree and
+      # walks in order with NO Sort and NO Bitmap (refute_full_scan). This is the core
+      # keyset promise (AC-27.9a.2 / TC-27.9a.4) and the primary enumeration path.
+      for {label, opts} <- [
+            {"residual-free", [status: :published, cursor: cursor, limit: 21]},
+            {"+category", [status: :published, cursor: cursor, limit: 21, category: :pattern]}
+          ] do
+        query = Knowledge.keyset_query(tenant.id, opts)
+
+        assert :ok = PlanAssertions.refute_full_scan(query),
+               "scalar keyset plan for shape #{label} must be strictly index-ordered at prod scale"
+      end
+
+      # ARRAY path (`tags &&`, served by the GIN index): no btree can provide BOTH
+      # array containment AND `(inserted_at, id)` order, so the planner intersects the
+      # tags GIN with the keyset btree (BitmapAnd) and Sorts the result. That is bounded
+      # by TAG SELECTIVITY (not the corpus) and is the same plan a tag-filtered OFFSET
+      # query already used (non-regressive) — see docs/runbooks/knowledge-scale.md. We
+      # therefore assert the catastrophe-guard (no unbounded Seq Scan) AND that the bound
+      # is real: both the selective tags GIN and the keyset btree (which applies the
+      # cursor) drive the scan via the index, not a heap filter over the corpus.
+      for {label, opts} <- [
+            {"+tags", [status: :published, cursor: cursor, limit: 21, tags: ["scale-tag-7"]]},
+            {"+tags+category",
+             [
+               status: :published,
+               cursor: cursor,
+               limit: 21,
+               tags: ["scale-tag-7"],
+               category: :pattern
+             ]}
+          ] do
+        query = Knowledge.keyset_query(tenant.id, opts)
+
+        assert :ok = PlanAssertions.refute_seq_scan(query),
+               "tag-filtered keyset plan for #{label} must not Seq-Scan the corpus at prod scale"
+
+        assert :ok = PlanAssertions.assert_index_used(query, "articles_tags_index"),
+               "tag-filtered keyset plan for #{label} must be bounded by the selective tags GIN"
+
+        assert :ok = PlanAssertions.assert_index_used(query, "articles_tenant_inserted_id_idx"),
+               "tag-filtered keyset plan for #{label} must apply the cursor via the keyset btree"
+      end
     end)
   end
 end

--- a/test/loopctl/knowledge/keyset_plan_scale_test.exs
+++ b/test/loopctl/knowledge/keyset_plan_scale_test.exs
@@ -1,0 +1,100 @@
+defmodule Loopctl.Knowledge.KeysetPlanScaleTest do
+  @moduledoc """
+  US-27.9a / AC-27.9a.2 + TC-27.9a.4: prove the article-list KEYSET seek for a
+  DEEP page is index-backed at >= prod scale via the new
+  `(tenant_id, inserted_at, id)` composite index — no Seq Scan / full-corpus read.
+
+  Unlike the suggested_links plan test (HNSW), the keyset seek is a plain btree
+  index scan, so this asserts `PlanAssertions.refute_full_scan/1` (no full-corpus
+  node), NOT `assert_hnsw_index/1`.
+
+  Seeds ~80k committed rows (Loopctl.Knowledge.ScaleSeed), so it is
+  `:scale_nightly` (runs on the nightly/scale gate, not the default async suite).
+  """
+  use ExUnit.Case, async: false
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.ScaleSeed
+  alias Loopctl.PlanAssertions
+  alias Loopctl.Tenants.Tenant
+
+  import Ecto.Query
+
+  @moduletag :scale_nightly
+  @moduletag timeout: :timer.minutes(30)
+
+  defp unboxed(fun), do: Sandbox.unboxed_run(AdminRepo, fun)
+
+  setup do
+    tenant =
+      unboxed(fn ->
+        slug = "keyset-scale-#{:erlang.phash2(Ecto.UUID.generate())}"
+
+        {:ok, t} =
+          %Tenant{}
+          |> Tenant.create_changeset(%{
+            name: "Keyset Scale #{slug}",
+            slug: slug,
+            email: "#{slug}@example.com",
+            settings: %{},
+            status: :active
+          })
+          |> AdminRepo.insert()
+
+        ScaleSeed.seed(t.id, count: ScaleSeed.prod_article_floor(), link_density: 5)
+        t
+      end)
+
+    on_exit(fn ->
+      try do
+        unboxed(fn ->
+          AdminRepo.delete_all(from(a in Article, where: a.tenant_id == ^tenant.id))
+          AdminRepo.delete_all(from(t in Tenant, where: t.id == ^tenant.id))
+        end)
+      rescue
+        _ -> :ok
+      end
+    end)
+
+    {:ok, tenant: tenant}
+  end
+
+  test "keyset seek for a DEEP page is index-backed (no Seq Scan) at prod scale",
+       %{tenant: tenant} do
+    unboxed(fn ->
+      # Pick a position deep in (inserted_at ASC, id ASC) order — ~90% through the
+      # corpus — so the seek is a genuinely late page, the #148 offset-drift /
+      # deep-page-cost scenario the index must serve.
+      deep_offset = trunc(ScaleSeed.prod_article_floor() * 0.9)
+
+      deep =
+        AdminRepo.one(
+          from(a in Article,
+            where: a.tenant_id == ^tenant.id,
+            order_by: [asc: a.inserted_at, asc: a.id],
+            offset: ^deep_offset,
+            limit: 1,
+            select: %{id: a.id, inserted_at: a.inserted_at}
+          )
+        )
+
+      assert deep, "expected a deep row at offset #{deep_offset}"
+
+      # Build the EXACT request-path query list_keyset/2 runs for that deep cursor.
+      query =
+        Knowledge.keyset_query(tenant.id,
+          status: :published,
+          cursor: {deep.inserted_at, deep.id},
+          limit: 21
+        )
+
+      # AC-27.9a.2 / TC-27.9a.4: the planner's NATURAL choice (no enable_seqscan=off)
+      # at 80k must reach `articles` via the (tenant_id, inserted_at, id) btree —
+      # never a Seq/Bitmap full-corpus scan.
+      assert :ok = PlanAssertions.refute_full_scan(query)
+    end)
+  end
+end

--- a/test/loopctl/knowledge/list_keyset_test.exs
+++ b/test/loopctl/knowledge/list_keyset_test.exs
@@ -1,0 +1,240 @@
+defmodule Loopctl.Knowledge.ListKeysetTest do
+  @moduledoc """
+  Context-level tests for `Loopctl.Knowledge.list_keyset/2` (US-27.9a).
+
+  Proves the keyset walk is gap-free, duplicate-free, and drift-free under
+  concurrent inserts/archives (AC-27.9a.1), that the `(inserted_at, id)` TUPLE
+  tie-break walks batch-tied timestamps correctly, and that every query is
+  tenant-scoped (the cross-tenant isolation case).
+  """
+  use Loopctl.DataCase, async: true
+
+  alias Ecto.Adapters.SQL
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge
+  alias Loopctl.Knowledge.Article
+
+  # Walk a tenant's articles page-by-page via list_keyset, collecting ids. The
+  # `mutate` callback runs BETWEEN pages so we can prove stability under
+  # concurrent writes. Returns the ordered list of ids seen across the walk.
+  defp walk(tenant_id, page_limit, opts, mutate \\ fn _page -> :ok end) do
+    do_walk(tenant_id, page_limit, opts, mutate, nil, [], 0)
+  end
+
+  defp do_walk(_tid, _limit, _opts, _mutate, _cursor, _acc, n) when n > 10_000 do
+    flunk("keyset walk did not terminate — possible infinite loop")
+  end
+
+  defp do_walk(tenant_id, page_limit, opts, mutate, cursor, acc, n) do
+    walk_opts =
+      opts
+      |> Keyword.put(:limit, page_limit)
+      |> Keyword.put(:cursor, cursor)
+
+    {:ok, %{results: results, next_cursor: next_cursor, limit: limit}} =
+      Knowledge.list_keyset(tenant_id, walk_opts)
+
+    assert limit == page_limit
+    assert length(results) <= page_limit
+
+    acc = acc ++ Enum.map(results, & &1.id)
+
+    if next_cursor do
+      mutate.(results)
+      do_walk(tenant_id, page_limit, opts, mutate, next_cursor, acc, n + 1)
+    else
+      acc
+    end
+  end
+
+  describe "list_keyset/2 — ordering and shape" do
+    test "orders by (inserted_at ASC, id ASC) and returns the metadata shape" do
+      tenant = fixture(:tenant)
+
+      for i <- 1..5 do
+        fixture(:article, %{tenant_id: tenant.id, status: :published, title: "A#{i}"})
+      end
+
+      {:ok, %{results: results, next_cursor: next_cursor, limit: limit}} =
+        Knowledge.list_keyset(tenant.id, status: :published, limit: 20)
+
+      assert limit == 20
+      assert is_nil(next_cursor)
+      assert length(results) == 5
+
+      inserted_ats = Enum.map(results, & &1.inserted_at)
+      assert inserted_ats == Enum.sort(inserted_ats, DateTime)
+    end
+
+    test "limit is clamped to max_page_size as an internal safety net" do
+      tenant = fixture(:tenant)
+      fixture(:article, %{tenant_id: tenant.id, status: :published})
+
+      {:ok, %{limit: limit}} =
+        Knowledge.list_keyset(tenant.id, limit: 10_000)
+
+      assert limit == Knowledge.max_page_size()
+    end
+  end
+
+  describe "list_keyset/2 — gap-free walk (AC-27.9a.1 / TC-27.9a.1)" do
+    test "walks all rows exactly once with next_cursor null at the end" do
+      tenant = fixture(:tenant)
+
+      ids =
+        for i <- 1..23 do
+          a = fixture(:article, %{tenant_id: tenant.id, status: :published, title: "n#{i}"})
+          a.id
+        end
+
+      seen = walk(tenant.id, 5, status: :published)
+
+      assert Enum.sort(seen) == Enum.sort(ids)
+      assert length(seen) == length(Enum.uniq(seen)), "no duplicates across pages"
+      assert length(seen) == 23
+    end
+
+    test "is stable under concurrent inserts AND archives between pages" do
+      tenant = fixture(:tenant)
+
+      original_ids =
+        for i <- 1..20 do
+          a = fixture(:article, %{tenant_id: tenant.id, status: :published, title: "orig#{i}"})
+          a.id
+        end
+
+      # Between every page: archive one already-seen row (must still not reappear)
+      # and insert a brand-new published row AT THE END of the order (a fresh
+      # inserted_at, so it sorts after the cursor — it may or may not be seen,
+      # which is fine; what matters is no dup and no gap for rows present the
+      # whole walk).
+      mutate = fn page ->
+        # Archive the first row of this page (already returned → must not recur).
+        first = List.first(page)
+
+        Article
+        |> where([a], a.id == ^first.id)
+        |> AdminRepo.update_all(set: [status: :archived])
+
+        # Insert a new published row (appears later in the order than the cursor).
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :published,
+          title: "late-#{System.unique_integer([:positive])}"
+        })
+      end
+
+      seen = walk(tenant.id, 4, [status: :published], mutate)
+
+      # Every ORIGINAL row appears exactly once (no offset drift skipped any, and
+      # archiving an already-seen row did not duplicate or skip a neighbor).
+      for id <- original_ids do
+        count = Enum.count(seen, &(&1 == id))
+        assert count == 1, "original id #{id} seen #{count} times (expected exactly 1)"
+      end
+
+      assert length(seen) == length(Enum.uniq(seen)), "no duplicates in the whole walk"
+    end
+  end
+
+  describe "list_keyset/2 — batch-tied timestamps (TUPLE tie-break, AC-27.9a.2)" do
+    test "walks rows that share an identical inserted_at via the id tie-break" do
+      tenant = fixture(:tenant)
+
+      ids =
+        for i <- 1..10 do
+          a = fixture(:article, %{tenant_id: tenant.id, status: :published, title: "tie#{i}"})
+          a.id
+        end
+
+      # Force ALL ten rows to the SAME inserted_at (what bulk insert_all does per
+      # batch). Now inserted_at alone is non-unique; only the (inserted_at, id)
+      # tuple keyset can walk them gap-free.
+      tied = ~U[2026-06-24 09:00:00.000000Z]
+
+      Article
+      |> where([a], a.id in ^ids)
+      |> AdminRepo.update_all(set: [inserted_at: tied])
+
+      # Page size 3 forces multiple page boundaries to land WITHIN the tied batch.
+      seen = walk(tenant.id, 3, status: :published)
+
+      assert Enum.sort(seen) == Enum.sort(ids)
+      assert length(seen) == 10
+      assert length(seen) == length(Enum.uniq(seen))
+    end
+  end
+
+  describe "list_keyset/2 — tenant isolation" do
+    test "only returns the caller-tenant's rows" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+
+      a_ids =
+        for _ <- 1..4 do
+          a = fixture(:article, %{tenant_id: tenant_a.id, status: :published})
+          a.id
+        end
+
+      for _ <- 1..4 do
+        fixture(:article, %{tenant_id: tenant_b.id, status: :published})
+      end
+
+      seen = walk(tenant_a.id, 2, status: :published)
+
+      assert Enum.sort(seen) == Enum.sort(a_ids)
+      assert length(seen) == 4
+    end
+
+    test "applies status/category/tags filters like list_filtered" do
+      tenant = fixture(:tenant)
+
+      published =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :published,
+          category: :pattern,
+          tags: ["keep"]
+        })
+
+      # Drafts and non-matching category/tags are excluded.
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        status: :draft,
+        category: :pattern,
+        tags: ["keep"]
+      })
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        status: :published,
+        category: :decision,
+        tags: ["other"]
+      })
+
+      {:ok, %{results: results}} =
+        Knowledge.list_keyset(tenant.id,
+          status: :published,
+          category: :pattern,
+          tags: ["keep"],
+          limit: 50
+        )
+
+      assert Enum.map(results, & &1.id) == [published.id]
+    end
+  end
+
+  describe "keyset_query/2 — request-path query shape" do
+    test "is the query list_keyset runs, and is tenant-scoped" do
+      tenant = fixture(:tenant)
+      fixture(:article, %{tenant_id: tenant.id, status: :published})
+
+      query = Knowledge.keyset_query(tenant.id, status: :published, limit: 21)
+      {sql, _params} = SQL.to_sql(:all, AdminRepo, query)
+
+      assert sql =~ "tenant_id"
+      assert sql =~ ~r/order by.*inserted_at.*id/i
+      assert sql =~ ~r/limit/i
+    end
+  end
+end

--- a/test/loopctl/knowledge/list_keyset_test.exs
+++ b/test/loopctl/knowledge/list_keyset_test.exs
@@ -135,6 +135,40 @@ defmodule Loopctl.Knowledge.ListKeysetTest do
 
       assert length(seen) == length(Enum.uniq(seen)), "no duplicates in the whole walk"
     end
+
+    # BA gap: the symmetric drift case — a row that sorts AFTER the cursor is archived
+    # BEFORE the walk reaches it. A forward-only keyset walk must then simply not
+    # return it (it correctly vanishes), with no error and no gap for its neighbors.
+    test "a row archived before the walk reaches it vanishes, leaving no gap" do
+      tenant = fixture(:tenant)
+
+      ids =
+        for i <- 1..20 do
+          a = fixture(:article, %{tenant_id: tenant.id, status: :published, title: "orig#{i}"})
+          a.id
+        end
+
+      # The last-inserted row has the latest inserted_at, so it sorts LAST. Archiving
+      # it after every page (idempotent) removes it after page 1 — long before the
+      # cursor (page size 4) reaches it near page 5.
+      future_id = List.last(ids)
+
+      mutate = fn _page ->
+        Article
+        |> where([a], a.id == ^future_id)
+        |> AdminRepo.update_all(set: [status: :archived])
+      end
+
+      seen = walk(tenant.id, 4, [status: :published], mutate)
+
+      refute future_id in seen, "a row archived before being reached must not appear"
+
+      # Its disappearance created no gap: every other original is still seen once.
+      for id <- List.delete(ids, future_id) do
+        assert Enum.count(seen, &(&1 == id)) == 1,
+               "neighbor #{id} should appear exactly once after a future row was archived"
+      end
+    end
   end
 
   describe "list_keyset/2 — batch-tied timestamps (TUPLE tie-break, AC-27.9a.2)" do

--- a/test/loopctl_web/controllers/knowledge_keyset_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_keyset_controller_test.exs
@@ -1,0 +1,305 @@
+defmodule LoopctlWeb.KnowledgeKeysetControllerTest do
+  @moduledoc """
+  HTTP integration tests for the KEYSET cursor on the article list endpoint
+  (US-27.9a), exercised through `GET /api/v1/knowledge/search` in list mode with
+  `?cursor=`.
+
+  Covers the cursor walk to exhaustion under concurrent writes (TC-27.9a.1), the
+  forged cross-tenant cursor (TC-27.9a.2), tampered/garbage cursors → 400
+  (TC-27.9a.3), and the limit-honoring contract (AC-27.9a.5).
+  """
+  use LoopctlWeb.ConnCase, async: true
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.ArticleCursor
+
+  import Ecto.Query
+
+  setup :verify_on_exit!
+
+  defp auth_conn(conn, raw_key) do
+    put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  # Walk the keyset list endpoint to exhaustion, collecting ids. `mutate` runs
+  # between pages. Returns the ids seen in order.
+  defp walk_http(conn, raw_key, base_params, mutate \\ fn -> :ok end) do
+    # Seed the walk with an EMPTY cursor → keyset path from the start.
+    do_walk_http(conn, raw_key, base_params, mutate, "", [], 0)
+  end
+
+  defp do_walk_http(_conn, _key, _params, _mutate, _cursor, _acc, n) when n > 1_000 do
+    flunk("HTTP keyset walk did not terminate")
+  end
+
+  defp do_walk_http(conn, raw_key, base_params, mutate, cursor, acc, n) do
+    params = Map.put(base_params, "cursor", cursor)
+
+    resp =
+      conn
+      |> auth_conn(raw_key)
+      |> get(~p"/api/v1/knowledge/search", params)
+      |> json_response(200)
+
+    # meta.limit is always present and documents the effective limit (AC-27.9a.5).
+    assert resp["meta"]["limit"]
+
+    acc = acc ++ Enum.map(resp["data"], & &1["id"])
+    next = resp["meta"]["next_cursor"]
+
+    if next do
+      mutate.()
+      do_walk_http(conn, raw_key, base_params, mutate, next, acc, n + 1)
+    else
+      acc
+    end
+  end
+
+  describe "cursor walk (AC-27.9a.1 / TC-27.9a.1)" do
+    test "walks the full list exactly once, ending with next_cursor null", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      ids =
+        for i <- 1..17 do
+          a =
+            fixture(:article, %{
+              tenant_id: tenant.id,
+              status: :published,
+              category: :pattern,
+              tags: ["walk"],
+              title: "w#{i}"
+            })
+
+          a.id
+        end
+
+      seen = walk_http(conn, raw_key, %{"tags" => "walk", "limit" => "5"})
+
+      assert Enum.sort(seen) == Enum.sort(ids)
+      assert length(seen) == length(Enum.uniq(seen))
+    end
+
+    test "is gap-free under concurrent inserts and archives between pages", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      original =
+        for i <- 1..16 do
+          a =
+            fixture(:article, %{
+              tenant_id: tenant.id,
+              status: :published,
+              tags: ["mix"],
+              title: "orig#{i}"
+            })
+
+          a.id
+        end
+
+      # Between pages: archive the earliest still-published row (already seen) and
+      # insert a new published row. Neither should cause a dup or a skipped row.
+      counter = :counters.new(1, [])
+
+      mutate = fn ->
+        :counters.add(counter, 1, 1)
+        n = :counters.get(counter, 1)
+
+        earliest =
+          Article
+          |> where([a], a.tenant_id == ^tenant.id and a.status == :published)
+          |> order_by([a], asc: a.inserted_at, asc: a.id)
+          |> limit(1)
+          |> AdminRepo.one()
+
+        if earliest do
+          earliest
+          |> Ecto.Changeset.change(status: :archived)
+          |> AdminRepo.update!()
+        end
+
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :published,
+          tags: ["mix"],
+          title: "new-#{n}"
+        })
+      end
+
+      seen = walk_http(conn, raw_key, %{"tags" => "mix", "limit" => "4"}, mutate)
+
+      # Rows present BEFORE the cursor passed them are returned exactly once.
+      # (A row archived before the walk reached it may legitimately not appear;
+      # the invariant is: never twice, and never skip a row that was still ahead.)
+      assert length(seen) == length(Enum.uniq(seen)), "no duplicates"
+      # At minimum every original id seen is unique and from the original set or new inserts.
+      assert Enum.all?(seen, &is_binary/1)
+      # Sanity: we saw a meaningful chunk of the originals.
+      assert seen != []
+      assert Enum.any?(original, fn id -> id in seen end)
+    end
+  end
+
+  describe "forged cross-tenant cursor (AC-27.9a.3 / TC-27.9a.2)" do
+    test "tenant A using a cursor forged with tenant B's key never sees tenant B rows",
+         %{conn: conn} do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      {raw_key_a, _} = fixture(:api_key, %{tenant_id: tenant_a.id, role: :agent})
+
+      # Tenant B has its own articles; capture a real (inserted_at, id) of B's.
+      b_article =
+        fixture(:article, %{tenant_id: tenant_b.id, status: :published, tags: ["x"]})
+
+      for i <- 1..3 do
+        fixture(:article, %{
+          tenant_id: tenant_a.id,
+          status: :published,
+          tags: ["x"],
+          title: "a#{i}"
+        })
+      end
+
+      # Forge a cursor that embeds tenant B's position, signed with B's key.
+      forged = ArticleCursor.encode(tenant_b.id, {b_article.inserted_at, b_article.id})
+
+      resp =
+        conn
+        |> auth_conn(raw_key_a)
+        |> get(~p"/api/v1/knowledge/search", %{"tags" => "x", "cursor" => forged})
+
+      # AC-27.9a.2 allows EITHER 400 (HMAC rejects) OR tenant-A-only rows; here the
+      # per-tenant HMAC rejects B's cursor for A → 400. Never a tenant_b row.
+      assert resp.status == 400
+      body = json_response(resp, 400)
+      assert body["error"]["message"] =~ "cursor" or body["errors"]
+
+      # And a forged cursor must not leak whether tenant B's row exists: the error
+      # is identical to a pure-garbage cursor (no existence oracle).
+      garbage_resp =
+        conn
+        |> auth_conn(raw_key_a)
+        |> get(~p"/api/v1/knowledge/search", %{"tags" => "x", "cursor" => "garbage"})
+
+      assert json_response(garbage_resp, 400) == body
+    end
+  end
+
+  describe "tampered / garbage cursor → 400 (AC-27.9a.4 / TC-27.9a.3)" do
+    test "garbage cursor returns 400, not 500 and not page 1", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      fixture(:article, %{tenant_id: tenant.id, status: :published, tags: ["g"]})
+
+      resp =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{"tags" => "g", "cursor" => "not-a-cursor!!!"})
+
+      assert resp.status == 400
+      assert json_response(resp, 400)["error"]["message"] =~ "cursor"
+    end
+
+    test "bit-flipped valid cursor returns 400", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      article = fixture(:article, %{tenant_id: tenant.id, status: :published, tags: ["g"]})
+      valid = ArticleCursor.encode(tenant.id, {article.inserted_at, article.id})
+
+      # Flip a bit in the payload region.
+      decoded = Base.url_decode64!(valid, padding: false)
+      <<first, rest::binary>> = decoded
+      tampered = Base.url_encode64(<<Bitwise.bxor(first, 1), rest::binary>>, padding: false)
+
+      resp =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{"tags" => "g", "cursor" => tampered})
+
+      assert resp.status == 400
+      assert json_response(resp, 400)["error"]["message"] =~ "cursor"
+    end
+  end
+
+  describe "limit contract (AC-27.9a.5)" do
+    test "honors limit up to max and reports effective limit in meta", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      for i <- 1..3 do
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :published,
+          tags: ["lim"],
+          title: "l#{i}"
+        })
+      end
+
+      resp =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{"tags" => "lim", "limit" => "2", "cursor" => ""})
+        |> json_response(200)
+
+      assert resp["meta"]["limit"] == 2
+      assert length(resp["data"]) == 2
+      assert resp["meta"]["next_cursor"]
+    end
+
+    test "over-max limit is rejected with 400, never silently clamped", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      fixture(:article, %{tenant_id: tenant.id, status: :published, tags: ["lim"]})
+
+      resp =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{
+          "tags" => "lim",
+          "limit" => "5000",
+          "cursor" => "x"
+        })
+
+      # The limit cap is enforced BEFORE cursor decode (validate_search_limit runs
+      # in the `with`), so an over-max request is a 400 regardless of the cursor.
+      assert resp.status == 400
+    end
+  end
+
+  describe "cursor + relevance query is rejected" do
+    test "supplying both q and cursor returns 400", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      article = fixture(:article, %{tenant_id: tenant.id, status: :published})
+      valid = ArticleCursor.encode(tenant.id, {article.inserted_at, article.id})
+
+      resp =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{"q" => "anything", "cursor" => valid})
+
+      assert resp.status == 400
+      assert json_response(resp, 400)["error"]["message"] =~ "list enumeration"
+    end
+  end
+
+  describe "first page without a cursor" do
+    test "list mode without cursor still works (offset back-compat path)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      fixture(:article, %{tenant_id: tenant.id, status: :published, tags: ["bc"]})
+
+      resp =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{"tags" => "bc"})
+        |> json_response(200)
+
+      # No cursor → existing offset list path (offset/total_count meta), unchanged.
+      assert resp["meta"]["offset"] == 0
+      assert is_list(resp["data"])
+    end
+  end
+end

--- a/test/loopctl_web/controllers/knowledge_keyset_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_keyset_controller_test.exs
@@ -23,8 +23,8 @@ defmodule LoopctlWeb.KnowledgeKeysetControllerTest do
   end
 
   # Walk the keyset list endpoint to exhaustion, collecting ids. `mutate` runs
-  # between pages. Returns the ids seen in order.
-  defp walk_http(conn, raw_key, base_params, mutate \\ fn -> :ok end) do
+  # between pages with the current page data. Returns the ids seen in order.
+  defp walk_http(conn, raw_key, base_params, mutate \\ fn _data -> :ok end) do
     # Seed the walk with an EMPTY cursor → keyset path from the start.
     do_walk_http(conn, raw_key, base_params, mutate, "", [], 0)
   end
@@ -49,7 +49,7 @@ defmodule LoopctlWeb.KnowledgeKeysetControllerTest do
     next = resp["meta"]["next_cursor"]
 
     if next do
-      mutate.()
+      mutate.(resp["data"])
       do_walk_http(conn, raw_key, base_params, mutate, next, acc, n + 1)
     else
       acc
@@ -85,7 +85,7 @@ defmodule LoopctlWeb.KnowledgeKeysetControllerTest do
       tenant = fixture(:tenant)
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
 
-      original =
+      original_ids =
         for i <- 1..16 do
           a =
             fixture(:article, %{
@@ -98,46 +98,49 @@ defmodule LoopctlWeb.KnowledgeKeysetControllerTest do
           a.id
         end
 
-      # Between pages: archive the earliest still-published row (already seen) and
-      # insert a new published row. Neither should cause a dup or a skipped row.
-      counter = :counters.new(1, [])
+      # Between pages: archive an already-seen row and insert a new published row.
+      # (The context-level test `list_keyset_test.exs` thoroughly exercises the
+      # gap-free invariant; here we exercise it at the HTTP layer to verify the
+      # keyset cursor walk returns no duplicates under concurrent mutations.)
+      {:ok, seen_tracker} = Agent.start_link(fn -> [] end)
 
-      mutate = fn ->
-        :counters.add(counter, 1, 1)
-        n = :counters.get(counter, 1)
+      mutate = fn data ->
+        # Archive the first row of this page (already returned in previous pages).
+        first_id = List.first(data)["id"]
 
-        earliest =
-          Article
-          |> where([a], a.tenant_id == ^tenant.id and a.status == :published)
-          |> order_by([a], asc: a.inserted_at, asc: a.id)
-          |> limit(1)
-          |> AdminRepo.one()
+        Article
+        |> where([a], a.id == ^first_id)
+        |> AdminRepo.update_all(set: [status: :archived])
 
-        if earliest do
-          earliest
-          |> Ecto.Changeset.change(status: :archived)
-          |> AdminRepo.update!()
-        end
+        # Track which rows have been returned so far.
+        Agent.update(seen_tracker, fn seen_list -> seen_list ++ [first_id] end)
 
+        # Insert a new published row (appears later in the order than the cursor).
         fixture(:article, %{
           tenant_id: tenant.id,
           status: :published,
           tags: ["mix"],
-          title: "new-#{n}"
+          title: "new-#{System.unique_integer([:positive])}"
         })
       end
 
       seen = walk_http(conn, raw_key, %{"tags" => "mix", "limit" => "4"}, mutate)
 
-      # Rows present BEFORE the cursor passed them are returned exactly once.
-      # (A row archived before the walk reached it may legitimately not appear;
-      # the invariant is: never twice, and never skip a row that was still ahead.)
+      # No duplicates in the whole walk (the headline invariant at the HTTP layer).
       assert length(seen) == length(Enum.uniq(seen)), "no duplicates"
-      # At minimum every original id seen is unique and from the original set or new inserts.
-      assert Enum.all?(seen, &is_binary/1)
+
+      # Rows that were returned and then archived don't reappear later.
+      seen_and_returned = Agent.get(seen_tracker, fn state -> state end)
+
+      for returned_id <- seen_and_returned do
+        count = Enum.count(seen, &(&1 == returned_id))
+        assert count == 1, "row #{returned_id} returned then archived appeared #{count} times"
+      end
+
       # Sanity: we saw a meaningful chunk of the originals.
-      assert seen != []
-      assert Enum.any?(original, fn id -> id in seen end)
+      assert Enum.any?(original_ids, fn id -> id in seen end)
+
+      Agent.stop(seen_tracker)
     end
   end
 
@@ -217,6 +220,23 @@ defmodule LoopctlWeb.KnowledgeKeysetControllerTest do
         conn
         |> auth_conn(raw_key)
         |> get(~p"/api/v1/knowledge/search", %{"tags" => "g", "cursor" => tampered})
+
+      assert resp.status == 400
+      assert json_response(resp, 400)["error"]["message"] =~ "cursor"
+    end
+
+    test "non-string cursor (e.g., array form) returns 400", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      fixture(:article, %{tenant_id: tenant.id, status: :published, tags: ["g"]})
+
+      # Simulate a malformed ?cursor[]=value param (which decodes to a list).
+      # The controller should 400, not silently reset to page 1.
+      conn = conn |> auth_conn(raw_key)
+
+      resp =
+        conn
+        |> get(~p"/api/v1/knowledge/search?tags=g&cursor[]=malformed", %{})
 
       assert resp.status == 400
       assert json_response(resp, 400)["error"]["message"] =~ "cursor"

--- a/test/loopctl_web/controllers/knowledge_keyset_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_keyset_controller_test.exs
@@ -321,5 +321,65 @@ defmodule LoopctlWeb.KnowledgeKeysetControllerTest do
       assert resp["meta"]["offset"] == 0
       assert is_list(resp["data"])
     end
+
+    # BA gap: the over-max-limit 400 (the #148 no-silent-clamp fix) must also hold on
+    # the LEGACY offset path, not only the keyset path. `validate_search_limit` runs
+    # before cursor branching, but pin it on the no-cursor path so a future refactor
+    # can't reintroduce a silent clamp there.
+    test "offset path (no cursor) rejects over-max limit with 400, never clamps", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      fixture(:article, %{tenant_id: tenant.id, status: :published, tags: ["bc"]})
+
+      resp =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{"tags" => "bc", "limit" => "5000"})
+
+      assert resp.status == 400
+    end
+  end
+
+  describe "exact-multiple page boundary (split_peek)" do
+    # BA gap: when the row count is an exact multiple of the page size, the FINAL full
+    # page must signal exhaustion (next_cursor null) and NOT emit a cursor that fetches
+    # an empty phantom page. Exercises split_peek's `length == limit` (no-more) branch.
+    test "final full page has next_cursor null, no phantom empty page", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      for i <- 1..8 do
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :published,
+          tags: ["em"],
+          title: "em#{i}"
+        })
+      end
+
+      # Page 1 of 2 (8 rows, page size 4): a full page, more remains.
+      page1 =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{"tags" => "em", "limit" => "4", "cursor" => ""})
+        |> json_response(200)
+
+      assert length(page1["data"]) == 4
+      assert page1["meta"]["next_cursor"]
+
+      # Page 2 of 2: the final full page — exhaustion, next_cursor must be null.
+      page2 =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{
+          "tags" => "em",
+          "limit" => "4",
+          "cursor" => page1["meta"]["next_cursor"]
+        })
+        |> json_response(200)
+
+      assert length(page2["data"]) == 4
+      refute page2["meta"]["next_cursor"]
+    end
   end
 end

--- a/test/support/plan_assertions.ex
+++ b/test/support/plan_assertions.ex
@@ -62,6 +62,63 @@ defmodule Loopctl.PlanAssertions do
   end
 
   @doc """
+  Weaker than `refute_full_scan/1`: asserts `articles` is not read by a `Seq Scan`
+  or `Parallel Seq Scan` (the genuinely UNBOUNDED full-corpus shapes), while ALLOWING
+  a `Bitmap Heap Scan` driven by a selective index.
+
+  This is for query shapes that legitimately cannot be served by a single ordered
+  index — specifically a keyset walk combined with an ARRAY-membership residual
+  (`tags &&`, served by a GIN index). No btree can provide both array containment AND
+  the `(inserted_at, id)` order, so the planner intersects the GIN bitmap with the
+  keyset btree (a `BitmapAnd`) and Sorts the (selective) result. That is bounded by
+  the residual's selectivity — NOT the corpus — and is the same plan a tag-filtered
+  OFFSET query already used; it is therefore non-regressive, just not true-keyset-cheap.
+  Pair this with `assert_index_used/2` for the selective driver to prove the bound.
+  """
+  def refute_seq_scan(queryable_or_sql) do
+    assert_fresh_stats!()
+    {root, raw} = explain_json(queryable_or_sql)
+    scans = article_scan_nodes(root)
+    bad = Enum.filter(scans, &(&1.node_type == "Seq Scan"))
+
+    cond do
+      scans == [] ->
+        raise ExUnit.AssertionError,
+          message:
+            "Plan never reaches the `articles` relation — cannot judge scan shape. Plan:\n#{elide(raw)}"
+
+      bad != [] ->
+        raise ExUnit.AssertionError,
+          message:
+            "Expected no Seq Scan on `articles` (unbounded full-corpus read), but one is present. " <>
+              "Plan:\n#{elide(raw)}"
+
+      true ->
+        :ok
+    end
+  end
+
+  @doc """
+  Asserts the plan reaches `articles` via the given index `name` somewhere (an
+  `Index Scan`, `Index Only Scan`, or `Bitmap Index Scan` naming it). Proves a
+  selective index actually drives the scan (e.g. the `tags` GIN bounds a tag-filtered
+  keyset query, and the keyset btree applies the cursor) rather than the planner
+  reading the corpus and filtering in the heap.
+  """
+  def assert_index_used(queryable_or_sql, name) when is_binary(name) do
+    {root, raw} = explain_json(queryable_or_sql)
+
+    if name in index_names(root) do
+      :ok
+    else
+      raise ExUnit.AssertionError,
+        message:
+          "Expected the plan to use index #{inspect(name)}, but it does not appear. " <>
+            "Plan:\n#{elide(raw)}"
+    end
+  end
+
+  @doc """
   Asserts `articles` is reached by EXACTLY ONE scan node, which is an `Index Scan`
   (or `Index Only Scan`) on an HNSW index (`pg_am.amname='hnsw'`, verified via catalog,
   not a name match). A sibling/outer full-scan on `articles` therefore cannot hide
@@ -246,6 +303,19 @@ defmodule Loopctl.PlanAssertions do
       node
       |> Map.get("Plans", [])
       |> Enum.flat_map(&article_scan_nodes/1)
+
+    here ++ children
+  end
+
+  # Collect every "Index Name" anywhere in the plan tree (Index Scan, Index Only Scan,
+  # Bitmap Index Scan — the last has no "Relation Name", only "Index Name").
+  defp index_names(node) when is_map(node) do
+    here = if name = node["Index Name"], do: [name], else: []
+
+    children =
+      node
+      |> Map.get("Plans", [])
+      |> Enum.flat_map(&index_names/1)
 
     here ++ children
   end


### PR DESCRIPTION
Implements **US-27.9a** (Epic #175, Theme 3) — a keyset cursor for the article list: stable under concurrent writes, backed by a real composite index, HMAC-integrity-protected, tenant scope from the auth principal (never the cursor).

### What's here
- **`list_keyset/2`** + `keyset_query/2`: `WHERE tenant_id = ? AND (inserted_at, id) > (?, ?) ORDER BY inserted_at ASC, id ASC LIMIT n+1` — a true row-value comparison; the `n+1` peek gives `has_more` with **no COUNT** (so nothing drifts). The `(inserted_at, id)` **tuple** keyset is mandatory: `insert_all` ties timestamps per batch, and the `id` tie-break walks same-timestamp rows. Opt-in via the `cursor` param (absent → legacy offset path preserved; existing list tests unchanged).
- **Migration**: `CREATE INDEX CONCURRENTLY articles_tenant_inserted_id_idx (tenant_id, inserted_at, id)` with `@disable_ddl_transaction`.
- **`Loopctl.Knowledge.ArticleCursor`**: per-tenant HMAC-SHA256 over the `(inserted_at_usec, raw-uuid)` tuple. `decode` verifies the HMAC with the **caller's** tenant key **before** deserializing (so `binary_to_term [:safe]` only ever runs on a server-signed payload), shape re-validated, constant-time compare. Garbage/tampered/wrong-tenant → `{:error, :invalid}` — never raises, no existence oracle.
- **Controller**: `?cursor=` → keyset; invalid → **400** (not 500, not silent page 1); `meta.next_cursor` (null when exhausted) + `meta.limit`. `limit` honored up to max via the #148 `Pagination` helper (400 over max, never silent-clamp). `cursor` + relevance `q` → 400.

### Acceptance criteria
AC-27.9a.1 (cursor + next_cursor, gap-free walk under concurrent writes), .2 (composite index + deep-page index-backed at scale, tuple keyset), .3 (tenant from principal, never cursor), .4 (HMAC integrity, defensive 400, no oracle), .5 (limit honored to max, never silent-clamp, meta.limit).

### Verification
`mix precommit` green: format, credo --strict (no issues), sobelow, dialyzer (0 errors), **2728 tests, 0 failures**. Tests: cursor encode/decode + wrong-tenant/tampered/garbage (never raises), gap-free walk with concurrent insert+archive incl. batch-tied timestamps, forged-cross-tenant (no tenant-B row), 400-not-500-not-page-1, limit contract. **Deep-page keyset plan test verified locally at 80k** (index-backed via the composite index, no Seq Scan).

First-draft by a delegated engineer agent to a design-locked spec; independently verified (incl. the 80k plan check) + under enhanced review. Rolling the cursor onto other enumerations is US-27.9b.

Refs #175
