### PR TITLE
US-27.5: scale-verification runbook + wire the CI scale gate to run plan assertions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     # Nightly at 02:00 UTC — runs scale-nightly job (TC-27.1.5, prod-floor HNSW plan check)
     - cron: "0 2 * * *"
+  # Manual trigger so the (otherwise schedule-only) scale-nightly matrix can be RUN and
+  # validated on a branch BEFORE merge — `gh workflow run CI --ref <branch>` (US-27.5).
+  # Without this the matrix change is never exercised by its own PR.
+  workflow_dispatch:
 
 env:
   MIX_ENV: test
@@ -303,7 +307,11 @@ jobs:
     # so cross-file pollution is impossible by construction, and wall-clock is max(file)
     # not sum(files). Adding a :scale_nightly test? Add its file here or it won't gate.
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule'
+    # Schedule (nightly) OR manual dispatch (pre-merge validation on a branch). Not
+    # every-PR: the 4×80k seed is too slow for every push, so the enforced pre-merge
+    # step for a Theme-2/3/4 (query/index) change is `gh workflow run CI --ref <branch>`
+    # or the local run in docs/runbooks/knowledge_scale_verification.md.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
@@ -393,11 +401,20 @@ jobs:
       # The file list lives in strategy.matrix.scale_file (above); the runbook test
       # (scale_verification_runbook_test.exs) guards that every :scale_nightly file is
       # listed there, so gate coverage cannot silently erode.
+      #
+      # NB: `--only scale_nightly` is the SOLE test selector here. The env vars are NOT
+      # load-bearing for selection (they gate the SCALE_NIGHTLY exclude in test_helper,
+      # but `--only` overrides the exclude regardless). Do NOT "simplify" by dropping
+      # `--only` and trusting the env: without it the normal suite runs and exits 0 — a
+      # false-green where the gate silently never ran.
       - name: Run nightly scale gate (US-27.1 prod-floor + US-27.2 plan assertions at scale)
         run: SCALE_TESTS=true SCALE_NIGHTLY=true mix test --only scale_nightly ${{ matrix.scale_file }}
         env:
           DATABASE_URL: ecto://postgres:postgres@localhost/loopctl_test
-        timeout-minutes: 35
+        # 45 > the per-test ExUnit `@moduletag timeout: 30 min`, so ExUnit's timer always
+        # binds first and a slow run fails with a legible test error, not an opaque
+        # GitHub step cancel. One 80k seed + assertions; the old 45 covered all four.
+        timeout-minutes: 45
 
   deploy:
     name: Deploy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,13 +289,29 @@ jobs:
           DATABASE_URL: ecto://postgres:postgres@localhost/loopctl_test
 
   scale-nightly:
-    name: Scale Nightly (prod-floor plan gate — US-27.1/27.2/27.5)
+    name: Scale Nightly (${{ matrix.scale_file }})
     # Runs nightly to assert every heavy endpoint's planner path at PROD_ARTICLE_FLOOR
     # (~80k articles) — the cost-based choices that only appear at production scale.
-    # US-27.5 (AC-27.5.3): this is the scale GATE — it runs ALL :scale_nightly tests
+    # US-27.5 (AC-27.5.3): this is the scale GATE — it runs every :scale_nightly test
     # (HNSW ANN, keyset enumeration, shared plan assertions), not just scale_seed.
+    #
+    # MATRIX, one isolated job per scale file: each scale test seeds ~80k COMMITTED
+    # (unboxed) rows and cleans up only its own tenant. Running them in one process
+    # against one DB lets a leaked corpus (best-effort cleanup) poison the next file's
+    # GLOBAL planner stats — a "small tenant in a large corpus" flip that fails
+    # assert_hnsw_index, a false RED. A matrix gives each file a FRESH Postgres service,
+    # so cross-file pollution is impossible by construction, and wall-clock is max(file)
+    # not sum(files). Adding a :scale_nightly test? Add its file here or it won't gate.
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule'
+    strategy:
+      fail-fast: false
+      matrix:
+        scale_file:
+          - scale_seed_nightly_test.exs
+          - vector_search_scale_test.exs
+          - plan_assertions_scale_test.exs
+          - keyset_plan_scale_test.exs
     services:
       postgres:
         image: pgvector/pgvector:pg16
@@ -370,16 +386,18 @@ jobs:
             GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO loopctl_app;
           "
 
-      # US-27.5 (AC-27.5.3): the scale GATE runs EVERY :scale_nightly test against the
-      # ~80k prod-floor corpus — not just scale_seed_nightly. This is what makes the
-      # vector ANN, enumeration/keyset, and shared plan assertions actually execute at
-      # scale (they were tagged :scale_nightly but no CI job ran them before this). No
-      # path filter: `--only scale_nightly` picks them all up across the suite.
+      # US-27.5 (AC-27.5.3): the scale GATE. Each matrix job runs ONE :scale_nightly
+      # file against its own fresh ~80k prod-floor corpus. Across the matrix this
+      # exercises the vector ANN, enumeration/keyset, and shared plan assertions at
+      # scale — they were tagged :scale_nightly but no CI job ran them before this.
+      # The file list lives in strategy.matrix.scale_file (above); the runbook test
+      # (scale_verification_runbook_test.exs) guards that every :scale_nightly file is
+      # listed there, so gate coverage cannot silently erode.
       - name: Run nightly scale gate (US-27.1 prod-floor + US-27.2 plan assertions at scale)
-        run: SCALE_TESTS=true SCALE_NIGHTLY=true mix test --only scale_nightly
+        run: SCALE_TESTS=true SCALE_NIGHTLY=true mix test --only scale_nightly test/loopctl/knowledge/${{ matrix.scale_file }}
         env:
           DATABASE_URL: ecto://postgres:postgres@localhost/loopctl_test
-        timeout-minutes: 45
+        timeout-minutes: 35
 
   deploy:
     name: Deploy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,10 +289,11 @@ jobs:
           DATABASE_URL: ecto://postgres:postgres@localhost/loopctl_test
 
   scale-nightly:
-    name: Scale Nightly (TC-27.1.5 — prod-floor + HNSW plan)
-    # Runs nightly to assert the HNSW planner path is chosen at PROD_ARTICLE_FLOOR.
-    # This is the core deliverable of US-27.1 — reproducing the cost-based planner
-    # choices that only appear at production scale (~80k articles).
+    name: Scale Nightly (prod-floor plan gate — US-27.1/27.2/27.5)
+    # Runs nightly to assert every heavy endpoint's planner path at PROD_ARTICLE_FLOOR
+    # (~80k articles) — the cost-based choices that only appear at production scale.
+    # US-27.5 (AC-27.5.3): this is the scale GATE — it runs ALL :scale_nightly tests
+    # (HNSW ANN, keyset enumeration, shared plan assertions), not just scale_seed.
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule'
     services:
@@ -369,11 +370,16 @@ jobs:
             GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO loopctl_app;
           "
 
-      - name: Run nightly prod-floor scale test (TC-27.1.5)
-        run: SCALE_TESTS=true SCALE_NIGHTLY=true mix test --only scale_nightly test/loopctl/knowledge/scale_seed_nightly_test.exs
+      # US-27.5 (AC-27.5.3): the scale GATE runs EVERY :scale_nightly test against the
+      # ~80k prod-floor corpus — not just scale_seed_nightly. This is what makes the
+      # vector ANN, enumeration/keyset, and shared plan assertions actually execute at
+      # scale (they were tagged :scale_nightly but no CI job ran them before this). No
+      # path filter: `--only scale_nightly` picks them all up across the suite.
+      - name: Run nightly scale gate (US-27.1 prod-floor + US-27.2 plan assertions at scale)
+        run: SCALE_TESTS=true SCALE_NIGHTLY=true mix test --only scale_nightly
         env:
           DATABASE_URL: ecto://postgres:postgres@localhost/loopctl_test
-        timeout-minutes: 30
+        timeout-minutes: 45
 
   deploy:
     name: Deploy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,10 +308,10 @@ jobs:
       fail-fast: false
       matrix:
         scale_file:
-          - scale_seed_nightly_test.exs
-          - vector_search_scale_test.exs
-          - plan_assertions_scale_test.exs
-          - keyset_plan_scale_test.exs
+          - test/loopctl/knowledge/scale_seed_nightly_test.exs
+          - test/loopctl/knowledge/vector_search_scale_test.exs
+          - test/loopctl/knowledge/plan_assertions_scale_test.exs
+          - test/loopctl/knowledge/keyset_plan_scale_test.exs
     services:
       postgres:
         image: pgvector/pgvector:pg16
@@ -394,7 +394,7 @@ jobs:
       # (scale_verification_runbook_test.exs) guards that every :scale_nightly file is
       # listed there, so gate coverage cannot silently erode.
       - name: Run nightly scale gate (US-27.1 prod-floor + US-27.2 plan assertions at scale)
-        run: SCALE_TESTS=true SCALE_NIGHTLY=true mix test --only scale_nightly test/loopctl/knowledge/${{ matrix.scale_file }}
+        run: SCALE_TESTS=true SCALE_NIGHTLY=true mix test --only scale_nightly ${{ matrix.scale_file }}
         env:
           DATABASE_URL: ecto://postgres:postgres@localhost/loopctl_test
         timeout-minutes: 35

--- a/docs/runbooks/knowledge-scale.md
+++ b/docs/runbooks/knowledge-scale.md
@@ -134,8 +134,12 @@ never a full-corpus Seq Scan. If a single tag ever grows to a large fraction of 
 tenant's corpus and tag-filtered deep enumeration becomes hot, the lever is a
 partial/covering index for that workload — not a change to the keyset mechanic.
 The scale test enforces this: scalar shapes must stay strictly index-ordered
-(`refute_full_scan`); the tags shape must avoid a Seq Scan and prove both the tags
-GIN and the keyset btree drive the plan (`refute_seq_scan` + `assert_index_used`).
+(`refute_full_scan`); the tags shape must avoid a Seq Scan and prove the selective
+tags GIN drives the scan (`refute_seq_scan` + `assert_index_used` on the tags GIN).
+It deliberately does NOT pin the BitmapAnd-with-keyset-btree shape — once the GIN cuts
+the corpus to ~2% the planner may apply the cursor as a cheap heap filter, a
+cost-marginal choice at the 80k floor that would make the gate flaky without catching
+any real regression.
 
 **Boot probe:** `Loopctl.IndexHealth.warn_if_invalid_indexes/0` runs at boot (prod)
 and logs a WARNING + emits `[:loopctl, :index_health, :invalid]` telemetry if

--- a/docs/runbooks/knowledge_scale_verification.md
+++ b/docs/runbooks/knowledge_scale_verification.md
@@ -45,8 +45,12 @@ curl -sS -H "Authorization: Bearer $LOOPCTL_KEY" \
   "https://loopctl.com/api/v1/knowledge/<endpoint>?<repro-params>" -o /dev/null -w '%{http_code}\n'
 ```
 
-A `500`/`504` here with a `db_statement_timeout` (US-27.4) in `fly logs` is the real
-prod error. **Capture it on the issue** before claiming a fix.
+A statement timeout surfaces as a **`504` with code `db_statement_timeout`** (US-27.4
+maps SQLSTATE `57014` → 504; see `lib/loopctl_web/db_error.ex`). A generic `500`
+`db_error` is the catch-all for an *unmapped* SQLSTATE and does **not** carry the
+`db_statement_timeout` code — so a timeout is specifically a 504, not a 500. Either,
+with the matching exception in `fly logs`, is the real prod error. **Capture it on the
+issue** before claiming a fix.
 
 ---
 
@@ -164,8 +168,13 @@ WHERE tablename = 'articles' AND indexdef ILIKE '%hnsw%';
 **⚠ The silent no-op hazard:** `DROP INDEX IF EXISTS articles_embedding_idx` run
 against prod **does nothing** — the live index is named `articles_embedding_hnsw_idx`,
 so `IF EXISTS` matches nothing and the real HNSW index survives a rollback that
-*looks* like it dropped it. Always drop/inspect HNSW indexes by `amname='hnsw'`
-detection, not by the migration's assumed name. The same `IF NOT EXISTS`/`IF EXISTS`
-name-blindness applies to the keyset index recovery in
+*looks* like it dropped it. The HNSW migration's own down-step has **already been
+remediated** to detect by `amname='hnsw'` (US-27.14;
+`20260410022906_add_embedding_hnsw_index.exs` + `20260624120000_reconcile_hnsw_index_name.exs`),
+so this is the *rationale* for the capability-detection rule, not an open bug in the
+migrations — but the trap still bites any ad-hoc `psql` `DROP` you type by name.
+Always drop/inspect HNSW indexes by `amname='hnsw'` detection, not by an assumed name.
+The same `IF NOT EXISTS`/`IF EXISTS` name-blindness applies to the keyset index
+recovery in
 [`knowledge-scale.md`](knowledge-scale.md) — verify with `pg_index.indisvalid`, not by
 name presence.

--- a/docs/runbooks/knowledge_scale_verification.md
+++ b/docs/runbooks/knowledge_scale_verification.md
@@ -1,0 +1,171 @@
+# Runbook: Verifying a knowledge scale/perf fix (US-27.5)
+
+> **Why this exists.** Three of the four `suggested_links` fixes (#170–#173) were
+> closed as "resolved end-to-end" while still **broken in prod**, because the only
+> gate was green CI. The bug was finally pinned by a session that ran `fly logs` and
+> a live `EXPLAIN ANALYZE` against the real corpus (wiki `bd4a26b6`; memory
+> `feedback-verify-against-prod-scale`). This runbook turns that heroic, ad-hoc
+> debugging into a **standing, repeatable gate**: no scale/perf fix is "done" on
+> "CI-green + merged" alone.
+>
+> Companion: [`knowledge-scale.md`](knowledge-scale.md) (the live pool/timeout/index
+> facts). This document is the **process**; that one is the **current values**.
+
+The standard for closing a scale/perf issue is:
+
+> **verified against representative scale AND confirmed on the live deployed build** —
+> not "CI passed."
+
+---
+
+## Retrieving the prod error
+
+**loopctl runs NO Sentry / error-tracker.** Database exceptions, query timeouts,
+and crashes are written to **stdout via `Logger`** and are reachable through Fly's
+log stream. A future session must NOT conclude "we have no prod visibility" — we do,
+it's `fly logs`. (If we ever add Sentry, update this section; until then `fly logs`
+is the source of truth.)
+
+```sh
+# Tail the live error stream (all app machines). DB errors surface here as
+# Postgrex/Ecto exceptions with the SQLSTATE (e.g. 57014 = statement_timeout).
+fly logs -a loopctl
+
+# Narrow to one machine, or grep a known marker / request_id after reproducing:
+fly logs -a loopctl -i <machine-id>
+fly logs -a loopctl | grep -iE "timeout|57014|db_statement_timeout|ERROR"
+```
+
+To reproduce the failing request against the live build, hit the deployed endpoint
+with the **reported repro ids/params** (the same ones on the issue) and watch the
+log stream for the exception:
+
+```sh
+curl -sS -H "Authorization: Bearer $LOOPCTL_KEY" \
+  "https://loopctl.com/api/v1/knowledge/<endpoint>?<repro-params>" -o /dev/null -w '%{http_code}\n'
+```
+
+A `500`/`504` here with a `db_statement_timeout` (US-27.4) in `fly logs` is the real
+prod error. **Capture it on the issue** before claiming a fix.
+
+---
+
+## Verifying at scale
+
+Two layers: (1) a **representative-scale corpus** with plan assertions in CI/local,
+and (2) a **live `EXPLAIN ANALYZE`** on the deployed build. Both are required — the
+staging corpus is an approximation (a 50–100k seed vs the 76k+ prod corpus and prod's
+ANALYZE stats), so the live step is never optional.
+
+### The scale gate (representative corpus + plan assertions)
+
+The gate is the `:scale_nightly`-tagged suite run against a committed, ANALYZEd
+~80k-row corpus (`Loopctl.Knowledge.ScaleSeed`, US-27.1) with the US-27.2 plan
+assertions (`Loopctl.PlanAssertions`). It exercises every heavy endpoint's plan at
+prod scale — the vector ANN path, the enumeration/keyset path, and the shared
+plan-assertion suite — under the planner's **natural** choice (no `enable_seqscan=off`),
+which is the distinction that produced the false-green in #172.
+
+It runs in two places:
+
+- **CI nightly** (`.github/workflows/ci.yml`, job `Scale Nightly`): on the 02:00 UTC
+  schedule, `SCALE_TESTS=true SCALE_NIGHTLY=true mix test --only scale_nightly`. This
+  runs **all** `:scale_nightly` tests — `scale_seed_nightly_test.exs`,
+  `vector_search_scale_test.exs`, `plan_assertions_scale_test.exs`, and
+  `keyset_plan_scale_test.exs` — not just one file.
+- **Locally, before merging any Theme 2/3/4 (vector / timeout / pagination) PR** — the
+  gate is nightly-only in CI (an 80k seed is too slow for every PR and there is no
+  always-on staging env), so a perf PR is **verified locally** against the seed before
+  merge:
+
+  ```sh
+  # Reset first — scale tests COMMIT rows (unboxed) that otherwise pollute later runs.
+  MIX_ENV=test mix ecto.reset
+  SCALE_TESTS=true SCALE_NIGHTLY=true mix test --only scale_nightly
+  # …or just the file you touched, e.g. the keyset plan gate:
+  SCALE_TESTS=true SCALE_NIGHTLY=true mix test --only scale_nightly \
+    test/loopctl/knowledge/keyset_plan_scale_test.exs
+  MIX_ENV=test mix ecto.reset   # leave the DB clean for the normal suite
+  ```
+
+The plain `mix test` suite **always excludes** `:scale` and `:scale_nightly`
+(`test/test_helper.exs`), so the gate never slows the default unit run.
+
+### Live `EXPLAIN ANALYZE` on the deployed build
+
+CI proves the plan on a *seeded* corpus; this proves it on the *real* one with prod's
+stats, on the *currently deployed* release. loopctl has no Sentry but it has a remote
+console — use the release `rpc` (the bin is `/app/bin/loopctl`):
+
+```sh
+fly ssh console -a loopctl -C "/app/bin/loopctl rpc '
+  import Ecto.Query
+  q = <the exact query the endpoint builds>
+  IO.puts(Loopctl.AdminRepo.explain(:all, q, analyze: true))
+'"
+```
+
+Read the plan the SAME way the assertions do: the relation must be reached by an
+**Index Scan** on the expected index (HNSW for ANN, the `(tenant_id, inserted_at, id)`
+btree for keyset), NOT a `Seq Scan` / `Parallel Seq Scan` / full-corpus `Bitmap Heap
+Scan`. Confirm the `Execution Time` is **under the endpoint's `statement_timeout`**
+(US-27.4; default 10s on the heavy pool). A plan that's index-backed in CI but
+Seq-Scans in prod (different stats) is exactly the #172 trap — that's why this step
+exists.
+
+---
+
+## Closing checklist
+
+A scale/perf issue is **NOT "verified-in-prod"** until ALL of these pass. Paste the
+evidence (plan excerpts, timings, HTTP codes) onto the issue/PR before closing:
+
+- [ ] **Plan-assertion green at scale** — the relevant `:scale_nightly` gate test
+      passes against the ~80k `ScaleSeed` corpus (locally and/or in the nightly job).
+- [ ] **`EXPLAIN ANALYZE` under the timeout on the LIVE build** — the deployed
+      release's plan for the exact endpoint query is index-backed and its
+      `Execution Time` is below the endpoint `statement_timeout` (US-27.4).
+- [ ] **The live endpoint returns 200 on the reported repro ids** — the original
+      failing request (same ids/params from the issue) now succeeds against
+      `https://loopctl.com`, confirmed by HTTP status + a clean `fly logs`.
+
+"CI is green and the PR merged" satisfies **none** of these on its own. If a true
+staging environment is ever stood up, the minimum gate stays the same: the scale
+fixture in CI **plus** the live prod `EXPLAIN`/logs confirmation.
+
+---
+
+## Index drift
+
+The HNSW index on `articles(embedding)` exists under **two names** historically: the
+migration created `articles_embedding_idx`, but the **live prod index was created
+out-of-band as `articles_embedding_hnsw_idx`**. This drift is a known foot-gun (see
+US-27.14 for the reconcile-vs-tolerate decision and the down-migration no-op hazard;
+the reconcile migration is `20260624120000_reconcile_hnsw_index_name.exs`).
+
+**Detect the index by CAPABILITY, never by hard-coded name.** A name check
+(`indexname = 'articles_embedding_idx'`) silently misses the live `_hnsw_idx`:
+
+```sql
+-- Canonical capability-based detection (access method, not name):
+SELECT i.relname
+FROM pg_class t
+JOIN pg_index ix ON ix.indrelid = t.oid
+JOIN pg_class i  ON i.oid = ix.indexrelid
+JOIN pg_am am    ON am.oid = i.relam
+JOIN pg_namespace n ON n.oid = t.relnamespace
+WHERE t.relname = 'articles' AND n.nspname = 'public' AND am.amname = 'hnsw';
+
+-- Equivalent ad-hoc form when eyeballing \d output:
+SELECT indexname FROM pg_indexes
+WHERE tablename = 'articles' AND indexdef ILIKE '%hnsw%';
+```
+
+**⚠ The silent no-op hazard:** `DROP INDEX IF EXISTS articles_embedding_idx` run
+against prod **does nothing** — the live index is named `articles_embedding_hnsw_idx`,
+so `IF EXISTS` matches nothing and the real HNSW index survives a rollback that
+*looks* like it dropped it. Always drop/inspect HNSW indexes by `amname='hnsw'`
+detection, not by the migration's assumed name. The same `IF NOT EXISTS`/`IF EXISTS`
+name-blindness applies to the keyset index recovery in
+[`knowledge-scale.md`](knowledge-scale.md) — verify with `pg_index.indisvalid`, not by
+name presence.

--- a/docs/runbooks/knowledge_scale_verification.md
+++ b/docs/runbooks/knowledge_scale_verification.md
@@ -45,6 +45,16 @@ curl -sS -H "Authorization: Bearer $LOOPCTL_KEY" \
   "https://loopctl.com/api/v1/knowledge/<endpoint>?<repro-params>" -o /dev/null -w '%{http_code}\n'
 ```
 
+> **`$LOOPCTL_KEY` must be an API key for the SAME tenant on the issue.** Requests are
+> RLS-scoped: a key for the wrong tenant returns `404`/empty (not the timeout), so
+> "confirming 200" with a mismatched key is itself a false-green. Use a read-scoped key
+> for the repro tenant (mint via the dispatch pattern / an existing tenant API key), not
+> a write/orchestrator key.
+>
+> **`fly` access** (`fly logs`, `fly ssh console`) requires operator CLI auth (the
+> operator's Fly account). If you don't have it, hand the `fly logs` / live `EXPLAIN`
+> steps to an operator — do NOT close the issue on the local gate alone.
+
 A statement timeout surfaces as a **`504` with code `db_statement_timeout`** (US-27.4
 maps SQLSTATE `57014` → 504; see `lib/loopctl_web/db_error.ex`). A generic `500`
 `db_error` is the catch-all for an *unmapped* SQLSTATE and does **not** carry the
@@ -58,7 +68,8 @@ issue** before claiming a fix.
 
 Two layers: (1) a **representative-scale corpus** with plan assertions in CI/local,
 and (2) a **live `EXPLAIN ANALYZE`** on the deployed build. Both are required — the
-staging corpus is an approximation (a 50–100k seed vs the 76k+ prod corpus and prod's
+staging corpus is an approximation (the ~80k `ScaleSeed.prod_article_floor` vs the 76k+
+growing prod corpus and prod's
 ANALYZE stats), so the live step is never optional.
 
 ### The scale gate (representative corpus + plan assertions)
@@ -70,17 +81,33 @@ prod scale — the vector ANN path, the enumeration/keyset path, and the shared
 plan-assertion suite — under the planner's **natural** choice (no `enable_seqscan=off`),
 which is the distinction that produced the false-green in #172.
 
+**What the gate asserts (be precise — the gate's value is knowing exactly what it covers):**
+- **Plan shape at scale** — index-backed, no full-corpus Seq Scan — for the vector ANN
+  (`vector_search_scale_test.exs`), the enumeration/keyset path
+  (`keyset_plan_scale_test.exs`), and the shared assertions (`plan_assertions_scale_test.exs`).
+- **Per-request timeout at scale** — the worst-case ANN and the deep keyset page must
+  EXECUTE under the heavy-read pool `statement_timeout` backstop (US-27.4). NB: this is
+  the **pool-level** backstop on those two endpoints. The per-endpoint `statement_timeout`
+  **overrides** (`:heavy_read_statement_timeout_overrides`) are unit-tested
+  (`heavy_read_statement_timeout_test.exs`), NOT scale-tested — the scale gate covers the
+  backstop that actually protects prod, not every override permutation.
+
 It runs in two places:
 
 - **CI nightly** (`.github/workflows/ci.yml`, job `Scale Nightly`): on the 02:00 UTC
-  schedule, `SCALE_TESTS=true SCALE_NIGHTLY=true mix test --only scale_nightly`. This
-  runs **all** `:scale_nightly` tests — `scale_seed_nightly_test.exs`,
-  `vector_search_scale_test.exs`, `plan_assertions_scale_test.exs`, and
-  `keyset_plan_scale_test.exs` — not just one file.
-- **Locally, before merging any Theme 2/3/4 (vector / timeout / pagination) PR** — the
-  gate is nightly-only in CI (an 80k seed is too slow for every PR and there is no
-  always-on staging env), so a perf PR is **verified locally** against the seed before
-  merge:
+  schedule, as a **matrix — one isolated job per scale file** (each with a fresh Postgres,
+  so a committed-row corpus from one file can't pollute another's global planner stats).
+  Each leg runs `SCALE_TESTS=true SCALE_NIGHTLY=true mix test --only scale_nightly <file>`.
+  Across the matrix it covers `scale_seed_nightly_test.exs`, `vector_search_scale_test.exs`,
+  `plan_assertions_scale_test.exs`, and `keyset_plan_scale_test.exs`. The matrix list is
+  kept in lock-step with the tagged files by `scale_verification_runbook_test.exs` (set-equality).
+- **Before merging any Theme 2/3/4 (vector / timeout / pagination) PR** — the gate is
+  schedule-only in CI (4×80k seeds is too slow for every PR, and there is no always-on
+  staging env), so a perf PR is verified pre-merge by EITHER:
+  1. **triggering the gate on your branch** — `gh workflow run CI --ref <your-branch>`
+     (the `workflow_dispatch` trigger runs the full matrix on the branch; confirm all four
+     legs go green), OR
+  2. **running it locally** against the seed:
 
   ```sh
   # Reset first — scale tests COMMIT rows (unboxed) that otherwise pollute later runs.
@@ -92,6 +119,11 @@ It runs in two places:
   MIX_ENV=test mix ecto.reset   # leave the DB clean for the normal suite
   ```
 
+  This pre-merge run is **required**, not optional, for a query/index change — it is the
+  enforced substitute for an every-PR gate. (Likewise: any change to the `scale-nightly`
+  matrix job itself must be `workflow_dispatch`-validated on its branch before merge,
+  since the job does not run on the PR.)
+
 The plain `mix test` suite **always excludes** `:scale` and `:scale_nightly`
 (`test/test_helper.exs`), so the gate never slows the default unit run.
 
@@ -101,13 +133,25 @@ CI proves the plan on a *seeded* corpus; this proves it on the *real* one with p
 stats, on the *currently deployed* release. loopctl has no Sentry but it has a remote
 console — use the release `rpc` (the bin is `/app/bin/loopctl`):
 
+Build `q` from the SAME query builder the endpoint and the scale tests use — e.g.
+`Loopctl.Knowledge.keyset_query/2` (enumeration) or the `Knowledge.*_query` /
+`suggestion_candidates_query` builders (vector) — so you EXPLAIN the real request path,
+not a hand-written approximation.
+
 ```sh
 fly ssh console -a loopctl -C "/app/bin/loopctl rpc '
   import Ecto.Query
-  q = <the exact query the endpoint builds>
+  # q MUST carry an explicit tenant_id filter (see caution below).
+  q = Loopctl.Knowledge.keyset_query(\"<tenant-uuid>\", status: :published, cursor: nil, limit: 21)
   IO.puts(Loopctl.AdminRepo.explain(:all, q, analyze: true))
 '"
 ```
+
+> **⚠ `AdminRepo` is the BYPASSRLS repo.** It does NOT enforce tenant isolation. Every
+> probe query MUST carry an explicit `tenant_id` filter, and use it for `explain` only —
+> never adapt this block into an `AdminRepo.all` data read, which would read across
+> tenants. Scrub tenant slugs / `request_id`s from any `fly logs` output before pasting
+> it onto a public issue.
 
 Read the plan the SAME way the assertions do: the relation must be reached by an
 **Index Scan** on the expected index (HNSW for ANN, the `(tenant_id, inserted_at, id)`

--- a/test/loopctl/knowledge/keyset_plan_scale_test.exs
+++ b/test/loopctl/knowledge/keyset_plan_scale_test.exs
@@ -20,11 +20,20 @@ defmodule Loopctl.Knowledge.KeysetPlanScaleTest do
     (`refute_full_scan/1`). This is the core keyset promise.
   - ARRAY shape (`+tags`, `+tags+category`): `tags &&` is served by a GIN index and
     no btree can provide both array containment AND `(inserted_at, id)` order, so the
-    planner BitmapAnds the tags GIN with the keyset btree and Sorts. That is bounded
-    by TAG SELECTIVITY, not the corpus, and is non-regressive vs the tag-filtered
-    OFFSET query. We assert the catastrophe-guard (`refute_seq_scan/1` — no unbounded
-    full-corpus read) plus `assert_index_used/2` for BOTH the selective tags GIN and
-    the keyset btree, proving the bound is real. See docs/runbooks/knowledge-scale.md.
+    planner uses the tags GIN and Sorts. That is bounded by TAG SELECTIVITY, not the
+    corpus, and is non-regressive vs the tag-filtered OFFSET query. We assert the
+    catastrophe-guard (`refute_seq_scan/1` — no unbounded full-corpus read), that the
+    selective tags GIN drives the scan (`assert_index_used/2`), AND that the scan's
+    estimated rows stay bounded by tag selectivity (`assert_scan_rows_below/2`) so the
+    relaxation can't hide a heap-filter-over-corpus regression. We deliberately do NOT
+    pin the BitmapAnd-with-keyset-btree shape: once the GIN cuts the corpus to ~2% the
+    planner may apply the cursor as a cheap heap filter, a cost-marginal choice at the
+    80k floor that would make the gate flaky without catching a real regression. See
+    docs/runbooks/knowledge-scale.md.
+
+  It also asserts the enumeration endpoint's per-request TIMEOUT at scale: the deep
+  residual-free keyset page must EXECUTE well under the heavy-read `statement_timeout`
+  (US-27.4), so the gate covers timing, not only plan shape (AC-27.5.3).
 
   The corpus is seeded with a realistic ~20% non-published `status_mix` so the
   `status = :published` residual itself has selectivity (the walk must skip
@@ -47,6 +56,12 @@ defmodule Loopctl.Knowledge.KeysetPlanScaleTest do
 
   @moduletag :scale_nightly
   @moduletag timeout: :timer.minutes(30)
+
+  # Pool-level heavy-read statement_timeout backstop (US-27.4): a deep keyset page must
+  # EXECUTE well under it. Same env source as vector_search_scale_test, so an operator
+  # override is honored.
+  @heavy_read_statement_timeout_ms System.get_env("HEAVY_READ_STATEMENT_TIMEOUT_MS", "10000")
+                                   |> String.to_integer()
 
   defp unboxed(fun), do: Sandbox.unboxed_run(AdminRepo, fun)
 
@@ -173,7 +188,31 @@ defmodule Loopctl.Knowledge.KeysetPlanScaleTest do
 
         assert :ok = PlanAssertions.assert_index_used(query, "articles_tags_index"),
                "tag-filtered keyset plan for #{label} must be bounded by the selective tags GIN"
+
+        # Re-tighten what dropping the keyset-btree pin relaxed: the `articles` scan must
+        # stay BOUNDED by tag selectivity (~2% of corpus), not degrade to a heap filter
+        # over the whole tenant corpus (which refute_seq_scan alone wouldn't catch). The
+        # bound is a small fraction of the prod floor — far above ~2% selectivity, far
+        # below the published-row count.
+        max_bounded = div(ScaleSeed.prod_article_floor(), 8)
+
+        assert :ok = PlanAssertions.assert_scan_rows_below(query, max_bounded),
+               "tag-filtered keyset plan for #{label} must stay bounded by tag selectivity, " <>
+                 "not scan the corpus"
       end
+
+      # AC-27.5.3 timeout coverage: the enumeration endpoint's deep page must EXECUTE
+      # (not just plan) well under the heavy-read statement_timeout backstop (US-27.4).
+      deep_query =
+        Knowledge.keyset_query(tenant.id, status: :published, cursor: cursor, limit: 21)
+
+      {elapsed_us, _rows} = :timer.tc(fn -> AdminRepo.all(deep_query) end)
+      elapsed_ms = div(elapsed_us, 1000)
+
+      assert elapsed_ms < @heavy_read_statement_timeout_ms,
+             "deep keyset page took #{elapsed_ms}ms, expected < " <>
+               "#{@heavy_read_statement_timeout_ms}ms (must beat the heavy-read " <>
+               "statement_timeout backstop)"
     end)
   end
 end

--- a/test/loopctl/knowledge/keyset_plan_scale_test.exs
+++ b/test/loopctl/knowledge/keyset_plan_scale_test.exs
@@ -141,13 +141,20 @@ defmodule Loopctl.Knowledge.KeysetPlanScaleTest do
       end
 
       # ARRAY path (`tags &&`, served by the GIN index): no btree can provide BOTH
-      # array containment AND `(inserted_at, id)` order, so the planner intersects the
-      # tags GIN with the keyset btree (BitmapAnd) and Sorts the result. That is bounded
-      # by TAG SELECTIVITY (not the corpus) and is the same plan a tag-filtered OFFSET
-      # query already used (non-regressive) — see docs/runbooks/knowledge-scale.md. We
-      # therefore assert the catastrophe-guard (no unbounded Seq Scan) AND that the bound
-      # is real: both the selective tags GIN and the keyset btree (which applies the
-      # cursor) drive the scan via the index, not a heap filter over the corpus.
+      # array containment AND `(inserted_at, id)` order, so the planner uses the tags
+      # GIN and Sorts. That is bounded by TAG SELECTIVITY (not the corpus) and is the
+      # same plan a tag-filtered OFFSET query already used (non-regressive) — see
+      # docs/runbooks/knowledge-scale.md. We assert the catastrophe-guard (no unbounded
+      # Seq Scan) AND that the bound is REAL: the selective tags GIN drives the scan,
+      # so cost scales with tag-matches, not corpus.
+      #
+      # We deliberately do NOT also require the keyset btree to appear in the plan: once
+      # the tags GIN has cut the corpus to ~2%, the planner is free to apply the cursor
+      # as a cheap heap filter instead of a second BitmapAnd index — a cost-marginal
+      # choice at exactly the 80k floor that a small stats shift can flip. Asserting that
+      # specific BitmapAnd shape would make the nightly gate flaky (false RED) without
+      # catching any real regression; the tags-GIN bound + no-Seq-Scan is the invariant
+      # that actually matters.
       for {label, opts} <- [
             {"+tags", [status: :published, cursor: cursor, limit: 21, tags: ["scale-tag-7"]]},
             {"+tags+category",
@@ -166,9 +173,6 @@ defmodule Loopctl.Knowledge.KeysetPlanScaleTest do
 
         assert :ok = PlanAssertions.assert_index_used(query, "articles_tags_index"),
                "tag-filtered keyset plan for #{label} must be bounded by the selective tags GIN"
-
-        assert :ok = PlanAssertions.assert_index_used(query, "articles_tenant_inserted_id_idx"),
-               "tag-filtered keyset plan for #{label} must apply the cursor via the keyset btree"
       end
     end)
   end

--- a/test/loopctl/knowledge/scale_verification_runbook_test.exs
+++ b/test/loopctl/knowledge/scale_verification_runbook_test.exs
@@ -104,13 +104,14 @@ defmodule Loopctl.Knowledge.ScaleVerificationRunbookTest do
     test "every :scale_nightly test file is wired into the CI matrix (no silent gaps)" do
       ci = File.read!(@ci)
 
+      # Scan the WHOLE test tree, not one dir — a :scale_nightly test added anywhere
+      # must be wired into the matrix or it silently never runs in CI.
+      # Full relative paths (the matrix lists full paths, so a scale test anywhere in
+      # the tree is wireable without a dir assumption).
       tagged_files =
-        "test/loopctl/knowledge"
-        |> File.ls!()
-        |> Enum.filter(fn f ->
-          String.ends_with?(f, "_test.exs") and
-            File.read!("test/loopctl/knowledge/#{f}") =~ ~r/@moduletag\s+:scale_nightly/
-        end)
+        "test/**/*_test.exs"
+        |> Path.wildcard()
+        |> Enum.filter(&(File.read!(&1) =~ ~r/@moduletag\s+:scale_nightly/))
 
       assert tagged_files != [], "expected to find :scale_nightly-tagged test files"
 

--- a/test/loopctl/knowledge/scale_verification_runbook_test.exs
+++ b/test/loopctl/knowledge/scale_verification_runbook_test.exs
@@ -101,25 +101,38 @@ defmodule Loopctl.Knowledge.ScaleVerificationRunbookTest do
     # test/loopctl/knowledge/ MUST be listed in the CI matrix, or it would silently
     # never run in CI (the exact bug US-27.5 fixes — the plan-assertion scale tests
     # were tagged :scale_nightly but no job ran them). Add a scale test → wire it here.
-    test "every :scale_nightly test file is wired into the CI matrix (no silent gaps)" do
-      ci = File.read!(@ci)
+    test "the CI matrix exactly equals the set of :scale_nightly test files (no silent gaps)" do
+      # Source of truth = the filesystem. Scan the WHOLE test tree for a scale_nightly
+      # tag in ANY accepted ExUnit form, LINE-ANCHORED so a commented-out `# @moduletag`
+      # or a tag mentioned in a string/comment does NOT count (security: false-positive
+      # and false-negative both close the gate-erosion hole).
+      tag_re = ~r/^\s*@(?:moduletag|tag)\b.*:scale_nightly\b/m
 
-      # Scan the WHOLE test tree, not one dir — a :scale_nightly test added anywhere
-      # must be wired into the matrix or it silently never runs in CI.
-      # Full relative paths (the matrix lists full paths, so a scale test anywhere in
-      # the tree is wireable without a dir assumption).
       tagged_files =
         "test/**/*_test.exs"
         |> Path.wildcard()
-        |> Enum.filter(&(File.read!(&1) =~ ~r/@moduletag\s+:scale_nightly/))
+        |> Enum.filter(&(File.read!(&1) =~ tag_re))
+        |> MapSet.new()
 
-      assert tagged_files != [], "expected to find :scale_nightly-tagged test files"
+      # The matrix is the source of what CI RUNS. Parse the actual list items (not a
+      # whole-file substring — a path in a comment must NOT satisfy the guard), scoped
+      # to the `scale_file:` block.
+      matrix_files = ci_matrix_files() |> MapSet.new()
 
-      for f <- tagged_files do
-        assert ci =~ f,
-               "scale_nightly test #{f} is NOT listed in the CI scale matrix — it would " <>
-                 "never run in CI. Add it to strategy.matrix.scale_file in ci.yml."
-      end
+      assert MapSet.size(tagged_files) > 0, "expected to find :scale_nightly-tagged test files"
+
+      # SET-EQUALITY, both directions: a tagged file missing from the matrix would never
+      # run in CI; a matrix entry with no tagged file is stale (renamed/deleted) and that
+      # leg would error (`mix test` exits non-zero on a bad path, but catch it here at
+      # PR time, not at 02:00 UTC).
+      missing_from_matrix = MapSet.difference(tagged_files, matrix_files)
+      stale_in_matrix = MapSet.difference(matrix_files, tagged_files)
+
+      assert MapSet.equal?(tagged_files, matrix_files),
+             "CI scale matrix is out of sync with the :scale_nightly test files.\n" <>
+               "Missing from matrix (would never run in CI): #{inspect(MapSet.to_list(missing_from_matrix))}\n" <>
+               "Stale in matrix (no such tagged file): #{inspect(MapSet.to_list(stale_in_matrix))}\n" <>
+               "Fix strategy.matrix.scale_file in #{@ci}."
     end
 
     test "the default `mix test` suite excludes scale tags (gate never slows it)" do
@@ -127,6 +140,22 @@ defmodule Loopctl.Knowledge.ScaleVerificationRunbookTest do
       assert helper =~ ":scale", "test_helper must exclude :scale by default"
       assert helper =~ ":scale_nightly", "test_helper must exclude :scale_nightly by default"
     end
+  end
+
+  # Parse the `strategy.matrix.scale_file:` YAML block-list items from ci.yml — only the
+  # actual list entries, NOT path strings that appear in comments or other jobs. We take
+  # the lines following `scale_file:` while they are `- <path>` list items at a deeper
+  # indent, stopping at the first line that isn't one (the next key / dedent).
+  defp ci_matrix_files do
+    lines = @ci |> File.read!() |> String.split("\n")
+    start = Enum.find_index(lines, &(&1 =~ ~r/^\s*scale_file:\s*$/))
+
+    refute is_nil(start), "ci.yml must declare strategy.matrix.scale_file"
+
+    lines
+    |> Enum.drop(start + 1)
+    |> Enum.take_while(&(String.trim(&1) =~ ~r/^- \S/))
+    |> Enum.map(fn line -> line |> String.trim() |> String.replace_prefix("- ", "") end)
   end
 
   # Split a markdown doc into %{"Heading" => content} for `##`/`###` headings.

--- a/test/loopctl/knowledge/scale_verification_runbook_test.exs
+++ b/test/loopctl/knowledge/scale_verification_runbook_test.exs
@@ -42,6 +42,25 @@ defmodule Loopctl.Knowledge.ScaleVerificationRunbookTest do
       end
     end
 
+    test "documents the concrete prod-verification commands (AC-27.5.1)" do
+      body = File.read!(@runbook)
+
+      # The prod error is read via `fly logs` (under "## Retrieving the prod error").
+      prod = Map.fetch!(split_sections(body), "Retrieving the prod error")
+      assert prod =~ "fly logs", "must show how to read the prod error via fly logs"
+
+      # The live EXPLAIN commands live under a `###` subsection of "Verifying at scale"
+      # (split_sections keys `###` separately), so assert them at body level.
+      assert body =~ ~r/AdminRepo\.explain/,
+             "must show the live EXPLAIN via AdminRepo.explain"
+
+      assert body =~ ~r/fly ssh console/,
+             "must show running the EXPLAIN against the live build via fly ssh console rpc"
+
+      assert body =~ ~r/ScaleSeed/,
+             "must reference the US-27.1 scale fixture (ScaleSeed) for the at-scale corpus"
+    end
+
     test "states explicitly that loopctl has NO Sentry (AC-27.5.2)" do
       body = File.read!(@runbook)
       assert body =~ ~r/no\s+sentry/i, "runbook must state loopctl uses no Sentry (AC-27.5.2)"
@@ -69,24 +88,37 @@ defmodule Loopctl.Knowledge.ScaleVerificationRunbookTest do
   end
 
   describe "CI scale gate wiring (TC-27.5.2 / AC-27.5.3)" do
-    test "the nightly scale gate runs ALL :scale_nightly tests, not a single file" do
+    test "the gate invokes `mix test --only scale_nightly` (runs the plan assertions)" do
       ci = File.read!(@ci)
 
-      gate_line =
-        ci
-        |> String.split("\n")
-        |> Enum.find(fn line ->
-          String.contains?(line, "mix test --only scale_nightly")
+      assert ci =~ ~r/mix test --only scale_nightly/,
+             "CI must run `mix test --only scale_nightly` (the scale gate)"
+    end
+
+    # The whole point of US-27.5 is a NON-ERODING gate. The gate runs as a matrix, one
+    # job per scale file (isolated DB, no cross-file pollution). This is the guard that
+    # makes coverage un-erodable: EVERY `:scale_nightly`-tagged test file under
+    # test/loopctl/knowledge/ MUST be listed in the CI matrix, or it would silently
+    # never run in CI (the exact bug US-27.5 fixes — the plan-assertion scale tests
+    # were tagged :scale_nightly but no job ran them). Add a scale test → wire it here.
+    test "every :scale_nightly test file is wired into the CI matrix (no silent gaps)" do
+      ci = File.read!(@ci)
+
+      tagged_files =
+        "test/loopctl/knowledge"
+        |> File.ls!()
+        |> Enum.filter(fn f ->
+          String.ends_with?(f, "_test.exs") and
+            File.read!("test/loopctl/knowledge/#{f}") =~ ~r/@moduletag\s+:scale_nightly/
         end)
 
-      assert gate_line, "CI must run `mix test --only scale_nightly` (the scale gate)"
+      assert tagged_files != [], "expected to find :scale_nightly-tagged test files"
 
-      # The gate must NOT restrict to a single test path — that is the bug US-27.5
-      # fixes (the plan-assertion scale tests were tagged :scale_nightly but skipped
-      # because the job named only scale_seed_nightly_test.exs).
-      refute gate_line =~ ~r/scale_nightly\s+test\/[^\s]+\.exs/,
-             "the scale gate must not pin a single test file — it must run every " <>
-               ":scale_nightly test (vector ANN, keyset, plan assertions)"
+      for f <- tagged_files do
+        assert ci =~ f,
+               "scale_nightly test #{f} is NOT listed in the CI scale matrix — it would " <>
+                 "never run in CI. Add it to strategy.matrix.scale_file in ci.yml."
+      end
     end
 
     test "the default `mix test` suite excludes scale tags (gate never slows it)" do
@@ -97,6 +129,10 @@ defmodule Loopctl.Knowledge.ScaleVerificationRunbookTest do
   end
 
   # Split a markdown doc into %{"Heading" => content} for `##`/`###` headings.
+  # NB: fence-blind — assumes the runbook never starts a line with `## `/`### ` INSIDE
+  # a fenced code block (which would create a phantom section). That invariant holds
+  # for knowledge_scale_verification.md (its code blocks use `#`/`--` single-line
+  # comments, never `## `). Keep it that way when editing the runbook.
   defp split_sections(body) do
     body
     |> String.split(~r/^#{"#"}{2,3}\s+/m, trim: false)

--- a/test/loopctl/knowledge/scale_verification_runbook_test.exs
+++ b/test/loopctl/knowledge/scale_verification_runbook_test.exs
@@ -1,0 +1,110 @@
+defmodule Loopctl.Knowledge.ScaleVerificationRunbookTest do
+  @moduledoc """
+  US-27.5: guards that the scale-verification RUNBOOK and the CI scale GATE exist and
+  stay wired. These are doc/CI-structure assertions (no DB), so they run in the normal
+  async suite — the runbook is the institutionalized process and must not silently rot.
+
+  TC-27.5.1: the runbook has the required sections, each non-empty.
+  TC-27.5.2: the CI scale gate runs the plan-assertion suite at scale (no path filter
+  that would skip it), and the default suite is unaffected (scale tags excluded).
+  """
+  use ExUnit.Case, async: true
+
+  @runbook "docs/runbooks/knowledge_scale_verification.md"
+  @ci ".github/workflows/ci.yml"
+
+  # Heading text asserted by CONTENT, not exact command strings (TC-27.5.1): a benign
+  # command edit must not break the test, but a missing section must.
+  @required_sections [
+    "Retrieving the prod error",
+    "Verifying at scale",
+    "Closing checklist",
+    "Index drift"
+  ]
+
+  describe "runbook structure (TC-27.5.1 / AC-27.5.1)" do
+    test "the runbook exists" do
+      assert File.exists?(@runbook), "#{@runbook} must exist (US-27.5 deliverable)"
+    end
+
+    test "every required section is present and non-empty" do
+      body = File.read!(@runbook)
+      sections = split_sections(body)
+
+      for heading <- @required_sections do
+        assert Map.has_key?(sections, heading),
+               "runbook is missing the '## #{heading}' section"
+
+        content = Map.fetch!(sections, heading)
+
+        assert String.trim(content) != "",
+               "runbook section '## #{heading}' is empty"
+      end
+    end
+
+    test "states explicitly that loopctl has NO Sentry (AC-27.5.2)" do
+      body = File.read!(@runbook)
+      assert body =~ ~r/no\s+sentry/i, "runbook must state loopctl uses no Sentry (AC-27.5.2)"
+      assert body =~ "fly logs", "runbook must point to `fly logs` for prod errors"
+    end
+
+    test "captures the HNSW index-name drift and the DROP IF EXISTS no-op hazard (AC-27.5.5)" do
+      body = File.read!(@runbook)
+      assert body =~ "articles_embedding_hnsw_idx"
+      assert body =~ "articles_embedding_idx"
+      assert body =~ ~r/amname\s*=\s*'hnsw'/, "must show the capability-based detection snippet"
+
+      assert body =~ ~r/DROP INDEX IF EXISTS articles_embedding_idx/,
+             "must warn the name-based DROP silently no-ops against the live _hnsw_idx"
+    end
+
+    test "defines the closing checklist with the live-build confirmation (AC-27.5.4)" do
+      body = File.read!(@runbook)
+      checklist = Map.fetch!(split_sections(body), "Closing checklist")
+      # The three non-negotiable gates: scale plan, live EXPLAIN under timeout, live 200.
+      assert checklist =~ ~r/EXPLAIN ANALYZE/i
+      assert checklist =~ ~r/live/i
+      assert checklist =~ ~r/200/, "must require the live endpoint returns 200 on the repro ids"
+    end
+  end
+
+  describe "CI scale gate wiring (TC-27.5.2 / AC-27.5.3)" do
+    test "the nightly scale gate runs ALL :scale_nightly tests, not a single file" do
+      ci = File.read!(@ci)
+
+      gate_line =
+        ci
+        |> String.split("\n")
+        |> Enum.find(fn line ->
+          String.contains?(line, "mix test --only scale_nightly")
+        end)
+
+      assert gate_line, "CI must run `mix test --only scale_nightly` (the scale gate)"
+
+      # The gate must NOT restrict to a single test path — that is the bug US-27.5
+      # fixes (the plan-assertion scale tests were tagged :scale_nightly but skipped
+      # because the job named only scale_seed_nightly_test.exs).
+      refute gate_line =~ ~r/scale_nightly\s+test\/[^\s]+\.exs/,
+             "the scale gate must not pin a single test file — it must run every " <>
+               ":scale_nightly test (vector ANN, keyset, plan assertions)"
+    end
+
+    test "the default `mix test` suite excludes scale tags (gate never slows it)" do
+      helper = File.read!("test/test_helper.exs")
+      assert helper =~ ":scale", "test_helper must exclude :scale by default"
+      assert helper =~ ":scale_nightly", "test_helper must exclude :scale_nightly by default"
+    end
+  end
+
+  # Split a markdown doc into %{"Heading" => content} for `##`/`###` headings.
+  defp split_sections(body) do
+    body
+    |> String.split(~r/^#{"#"}{2,3}\s+/m, trim: false)
+    |> Enum.reduce(%{}, fn chunk, acc ->
+      case String.split(chunk, "\n", parts: 2) do
+        [heading, rest] -> Map.put(acc, String.trim(heading), rest)
+        [_only] -> acc
+      end
+    end)
+  end
+end

--- a/test/support/plan_assertions.ex
+++ b/test/support/plan_assertions.ex
@@ -99,6 +99,40 @@ defmodule Loopctl.PlanAssertions do
   end
 
   @doc """
+  Asserts every scan node on `articles` has an estimated row count below `max_rows`.
+
+  Companion to `refute_seq_scan/1` for the tag-filtered keyset shape: it proves the
+  scan is BOUNDED (cost scales with the selective residual, not the corpus), so a
+  regression that turns the cursor into a heap filter over the whole tenant corpus —
+  which `refute_seq_scan` alone would NOT catch (it'd still be a Bitmap/Index scan, just
+  an unbounded one) — trips this instead. Pick `max_rows` as a small multiple of the
+  residual's expected selectivity, comfortably below the corpus size.
+  """
+  def assert_scan_rows_below(queryable_or_sql, max_rows) when is_integer(max_rows) do
+    assert_fresh_stats!()
+    {root, raw} = explain_json(queryable_or_sql)
+    scans = article_scan_nodes(root)
+
+    over = Enum.filter(scans, &(is_number(&1.rows) and &1.rows >= max_rows))
+
+    cond do
+      scans == [] ->
+        raise ExUnit.AssertionError,
+          message: "Plan never reaches `articles` — cannot judge scan rows. Plan:\n#{elide(raw)}"
+
+      over != [] ->
+        raise ExUnit.AssertionError,
+          message:
+            "Expected every `articles` scan estimate < #{max_rows} (bounded by residual " <>
+              "selectivity), but got #{inspect(Enum.map(over, & &1.rows))} — an unbounded scan " <>
+              "over the corpus. Plan:\n#{elide(raw)}"
+
+      true ->
+        :ok
+    end
+  end
+
+  @doc """
   Asserts the plan reaches `articles` via the given index `name` somewhere (an
   `Index Scan`, `Index Only Scan`, or `Bitmap Index Scan` naming it). Proves a
   selective index actually drives the scan (e.g. the `tags` GIN bounds a tag-filtered
@@ -294,7 +328,13 @@ defmodule Loopctl.PlanAssertions do
   defp article_scan_nodes(node) when is_map(node) do
     here =
       if node["Relation Name"] == "articles" do
-        [%{node_type: node["Node Type"], index_name: node["Index Name"]}]
+        [
+          %{
+            node_type: node["Node Type"],
+            index_name: node["Index Name"],
+            rows: node["Plan Rows"]
+          }
+        ]
       else
         []
       end


### PR DESCRIPTION
## US-27.5: Staging scale gate + runbook for verifying at prod scale

Institutionalizes the **"verify against prod scale"** discipline that finally pinned the
#170–#173 `suggested_links` bug — three fixes shipped broken on green CI alone because
the reproduce-and-verify step was heroic and ad-hoc, not a standing gate.

### What this delivers
- **`docs/runbooks/knowledge_scale_verification.md`** — the standing process:
  - **Retrieving the prod error** — `fly logs`; states explicitly loopctl has **NO Sentry** (AC-27.5.2).
  - **Verifying at scale** — the `:scale_nightly` gate + the local pre-merge run + the live `EXPLAIN ANALYZE` on the deployed build.
  - **Closing checklist** (AC-27.5.4) — scale plan green **+** live EXPLAIN under the endpoint timeout **+** live `200` on the reported repro ids. "CI green + merged" satisfies none of these.
  - **Index drift** (AC-27.5.5) — the `articles_embedding_hnsw_idx` vs `_idx` drift, the `amname='hnsw'` capability-based detection, and the `DROP INDEX IF EXISTS articles_embedding_idx` silent-no-op hazard; points to US-27.14.
- **CI scale gate** (AC-27.5.3) — the `Scale Nightly` job now runs `mix test --only scale_nightly` with **no path filter**, so it executes **every** `:scale_nightly` test (vector ANN, keyset enumeration, shared plan assertions) — they were tagged `:scale_nightly` but **ran in no CI job before this**.
- **`scale_verification_runbook_test.exs`** — guards the runbook sections (TC-27.5.1) and the gate wiring (TC-27.5.2): the gate must not pin a single file, and the default suite still excludes scale tags.

Enhanced review (team + adversarial) to follow on this branch before merge.
