### PR TITLE
US-27.10: self-describing keyset cursor contract + bounded opt-in include_body

### DIFF
--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -1541,7 +1541,11 @@ defmodule Loopctl.Knowledge do
     within `full_content_byte_budget/0` (always keeping ≥1 row for progress). The
     ≤25-row cap alone permits 25 × `Article` `@max_body_bytes` (500 KB) = 12.5 MB
     worst case; the byte budget keeps the keyset full-content page consistent with
-    the offset path (~5.5 MB worst case). If the trim drops rows, `next_cursor` is
+    the offset path (~5.5 MB worst case *returned*). NB: unlike the offset path's
+    sized pre-query, this trims IN MEMORY, so it transiently FETCHES up to
+    `(max_include_body_page/0 + 1) × @max_body_bytes` (~13 MB) before trimming — a
+    bounded cost justified at the 25-row cap (see the body comment). If the trim drops
+    rows, `next_cursor` is
     recomputed from the LAST KEPT row (so the walk resumes over the dropped rows —
     drift-free by construction), `has_more` is forced `true`, and `byte_truncated`
     is `true`. When not trimmed (or body-less), `byte_truncated` is `false` and
@@ -1576,8 +1580,27 @@ defmodule Loopctl.Knowledge do
 
     # US-27.10: when bodies are included, bound the (≤25-row) page by the
     # serialized-body byte budget so it can't balloon past the offset path's cap.
-    # The page rows already carry `body`, so this is in-memory — no second query.
+    # The page rows already carry `body`, so this is an IN-MEMORY trim — no second
+    # query. This deliberately diverges from `paginate_with_body_budget/4` (the offset
+    # path), which runs a sized pre-query (`octet_length(body)`) so it never fetches a
+    # body it will trim. The divergence is intentional and bounded: the offset path can
+    # serve up to `@max_page_size` (1000) rows — a pre-query is essential there (else
+    # ~500 MB fetched). The keyset path is HARD-capped at `@max_include_body_page` (25),
+    # so the worst-case transient fetch is (25+1) × `@max_body_bytes` ≈ 13 MB per request,
+    # naturally backpressured by the dedicated HeavyRead pool (HEAVY_READ_POOL_SIZE, ~8)
+    # and its statement_timeout. At that bound the pre-query's saved bytes don't justify a
+    # second query + read-only transaction per page, so the simpler in-memory trim wins.
     {page, has_more?, byte_truncated?} = maybe_byte_trim(page, has_more?, include_body?)
+
+    # Surface budget truncation for ops tuning of `:full_content_byte_budget` (it is
+    # otherwise only visible in the per-response `meta.byte_truncated`).
+    if byte_truncated? do
+      :telemetry.execute(
+        [:loopctl, :knowledge, :keyset_byte_truncated],
+        %{returned: length(page)},
+        %{tenant_id: tenant_id}
+      )
+    end
 
     next_cursor = keyset_next_cursor(page, has_more?)
 

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -62,6 +62,14 @@ defmodule Loopctl.Knowledge do
   # path fetches `@default_page_size + 1` to detect a next page without a COUNT.
   @default_page_size 20
 
+  # Maximum effective page size for which the keyset enumeration path will honor
+  # `include_body: true` (US-27.10). Body-less is the default (#166); opting into
+  # full bodies is bounded WELL below `@max_page_size` so a caller can't request
+  # bodies for thousands of rows and reproduce the 100KB+ ChunkedEncodingError.
+  # A request for `include_body: true` with a requested `limit` above this is
+  # rejected by the HTTP layer with 400 (never a silent oversized response).
+  @max_include_body_page 25
+
   @doc """
   The maximum page size (`limit`) honored by the **enumeration** paths
   (`list_articles/2`, `list_filtered/2`, `list_keyset/2`, `list_drafts/2`,
@@ -72,6 +80,18 @@ defmodule Loopctl.Knowledge do
   """
   @spec max_page_size() :: pos_integer()
   def max_page_size, do: @max_page_size
+
+  @doc """
+  The maximum effective page size for which the keyset enumeration path honors
+  `include_body: true` (US-27.10).
+
+  Body-less is the default (#166); opting into full bodies is bounded to this so
+  a caller can't request bodies for thousands of rows and reproduce the large
+  chunked-payload failure. The HTTP layer rejects an `include_body: true` request
+  whose requested `limit` exceeds this with a 400 — it is NOT silently clamped.
+  """
+  @spec max_include_body_page() :: pos_integer()
+  def max_include_body_page, do: @max_include_body_page
 
   # Maximum result count for the **relevance** search modes (keyword / semantic /
   # combined). These return a ranked top-N, not an exhaustive enumeration, so
@@ -1498,27 +1518,41 @@ defmodule Loopctl.Knowledge do
     - `:project_id`, `:category`, `:tags`, `:match`, `:memory_types`, `:agents`,
       `:conversation_id`, `:visibility_agent_id` -- same filters as `list_filtered/2`
 
+    - `:include_body` -- when `true`, each result map carries the article `body`
+      (US-27.10). Defaults to `false` (body-less summary projection, #166). The
+      HTTP layer bounds this to `max_include_body_page/0`; the context honors it
+      as passed so direct callers stay in control.
+
   ## Returns
 
-  - `{:ok, %{results: [map()], next_cursor: position_or_nil, limit: effective_limit}}`
-    where `next_cursor` is the `(inserted_at, id)` tuple of the LAST returned row
-    when another page exists, else `nil`. The HTTP layer encodes it back into an
-    opaque cursor string.
+  - `{:ok, %{results: [map()], next_cursor: position_or_nil, has_more: bool,
+    limit: effective_limit, include_body: bool}}` where `next_cursor` is the
+    `(inserted_at, id)` tuple of the LAST returned row when another page exists,
+    else `nil`. `has_more?` is derived from the keyset peek (it is exactly
+    `next_cursor != nil`), never a COUNT. The HTTP layer encodes `next_cursor`
+    back into an opaque cursor string.
   """
   @spec list_keyset(Ecto.UUID.t(), keyword()) ::
           {:ok,
            %{
              results: [map()],
              next_cursor: {DateTime.t(), Ecto.UUID.t()} | nil,
-             limit: pos_integer()
+             has_more: boolean(),
+             limit: pos_integer(),
+             include_body: boolean()
            }}
   def list_keyset(tenant_id, opts \\ []) do
     limit = opts |> Keyword.get(:limit, @default_page_size) |> max(1) |> min(@max_page_size)
+    include_body? = Keyword.get(opts, :include_body, false) == true
 
     # Fetch limit+1 to detect a next page without a COUNT (AC-27.9a.1).
     rows =
       tenant_id
-      |> keyset_query(Keyword.put(opts, :limit, limit + 1))
+      |> keyset_query(
+        opts
+        |> Keyword.put(:limit, limit + 1)
+        |> Keyword.put(:include_body, include_body?)
+      )
       |> then(&HeavyRead.all(tenant_id, &1, heavy_read_opts(:enumeration)))
 
     {page, has_more?} = split_peek(rows, limit)
@@ -1531,7 +1565,14 @@ defmodule Loopctl.Knowledge do
 
     maybe_record_search_access(tenant_id, page, "", opts, "list_keyset")
 
-    {:ok, %{results: page, next_cursor: next_cursor, limit: limit}}
+    {:ok,
+     %{
+       results: page,
+       next_cursor: next_cursor,
+       has_more: has_more?,
+       limit: limit,
+       include_body: include_body?
+     }}
   end
 
   @doc """
@@ -1542,6 +1583,13 @@ defmodule Loopctl.Knowledge do
   Same `opts` as `list_keyset/2`; `:limit` is applied as-is here (the caller adds
   the `+1` peek). This is the EXACT query `list_keyset/2` runs, so the plan
   assertion guards the request path, not a stunt double.
+
+  `:include_body` (default `false`) controls whether the `select` map carries the
+  potentially-huge `body` column (US-27.10). Body-less is the default so `body` is
+  never transferred from Postgres for enumeration reads; `include_body: true` adds
+  it (the HTTP layer bounds that to `max_include_body_page/0`). Tenant scope and
+  visibility filtering are applied BEFORE the projection, so a `body` is only ever
+  selected for a row the caller could already read.
 
   Plan note: with no filter or a scalar `:category` filter the planner walks the
   `(tenant_id, inserted_at, id)` btree in order (true keyset, no Sort). With a
@@ -1563,7 +1611,15 @@ defmodule Loopctl.Knowledge do
     base
     |> apply_search_filters(status, opts)
     |> apply_keyset_seek(Keyword.get(opts, :cursor))
-    |> select([a], %{
+    |> keyset_select(Keyword.get(opts, :include_body, false) == true)
+    |> order_by([a], asc: a.inserted_at, asc: a.id)
+    |> limit(^limit)
+  end
+
+  # Body-less projection (the default, #166): `body` is never transferred from
+  # Postgres for enumeration reads, keeping payloads small.
+  defp keyset_select(query, false) do
+    select(query, [a], %{
       id: a.id,
       tenant_id: a.tenant_id,
       project_id: a.project_id,
@@ -1574,8 +1630,23 @@ defmodule Loopctl.Knowledge do
       inserted_at: a.inserted_at,
       updated_at: a.updated_at
     })
-    |> order_by([a], asc: a.inserted_at, asc: a.id)
-    |> limit(^limit)
+  end
+
+  # Full-content projection (US-27.10, `include_body: true`): same summary fields
+  # plus the `body` column. Bounded to `max_include_body_page/0` by the HTTP layer.
+  defp keyset_select(query, true) do
+    select(query, [a], %{
+      id: a.id,
+      tenant_id: a.tenant_id,
+      project_id: a.project_id,
+      title: a.title,
+      category: a.category,
+      status: a.status,
+      tags: a.tags,
+      body: a.body,
+      inserted_at: a.inserted_at,
+      updated_at: a.updated_at
+    })
   end
 
   # No cursor: enumerate from the start.

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -65,9 +65,11 @@ defmodule Loopctl.Knowledge do
   # Maximum effective page size for which the keyset enumeration path will honor
   # `include_body: true` (US-27.10). Body-less is the default (#166); opting into
   # full bodies is bounded WELL below `@max_page_size` so a caller can't request
-  # bodies for thousands of rows and reproduce the 100KB+ ChunkedEncodingError.
-  # A request for `include_body: true` with a requested `limit` above this is
-  # rejected by the HTTP layer with 400 (never a silent oversized response).
+  # bodies for thousands of rows. Bodies are up to 500KB (see @max_body_bytes),
+  # so 25 rows max × 500KB is a 12.5MB worst case, trimmed by the 5MB
+  # full_content_byte_budget in the view. A request for `include_body: true` with
+  # a requested `limit` above this is rejected by the HTTP layer with 400 (never
+  # a silent oversized response).
   @max_include_body_page 25
 
   @doc """
@@ -143,13 +145,14 @@ defmodule Loopctl.Knowledge do
   @max_idea_text_bytes 4 * 1024 * 1024
 
   # Byte budget for full-content (`include_body: true`) list reads. An article
-  # `body` is up to 100 KB, so a 1000-row full-body page could be ~100 MB — an
+  # `body` is up to 500 KB, so a 1000-row full-body page could be ~500 MB — an
   # agent-callable memory/DoS vector. Full-content pages therefore return as many
   # rows as fit within this serialized-body budget (always ≥1 for progress), plus
-  # `meta.next_offset`/`meta.has_more`/`meta.byte_truncated` to continue. Bounds
-  # the response regardless of the requested `limit` or per-row body size.
-  # Worst case per page is ~budget + one body: the always-take-≥1 rule can include
-  # one row beyond the budget, and `body` is byte-validated (≤500_000 bytes, see
+  # `meta.next_offset`/`meta.has_more`/`meta.byte_truncated` to continue (offset
+  # path) or early page termination (keyset path, US-27.10). Bounds the response
+  # regardless of the requested `limit` or per-row body size. Worst case per page
+  # is ~budget + one body: the always-take-≥1 rule can include one row beyond the
+  # budget, and `body` is byte-validated (≤500_000 bytes, see
   # Article @max_body_bytes), so worst case is ≤ ~5.5 MB total here.
   # Enumeration that doesn't need bodies should use the body-less summary
   # (the default) or `GET /knowledge/index`.
@@ -1521,16 +1524,29 @@ defmodule Loopctl.Knowledge do
     - `:include_body` -- when `true`, each result map carries the article `body`
       (US-27.10). Defaults to `false` (body-less summary projection, #166). The
       HTTP layer bounds this to `max_include_body_page/0`; the context honors it
-      as passed so direct callers stay in control.
+      as passed so direct callers stay in control. When `true`, the returned page
+      is ALSO bounded by `full_content_byte_budget/0` (the same serialized-body
+      budget the offset full-content path uses) — see Returns.
 
   ## Returns
 
   - `{:ok, %{results: [map()], next_cursor: position_or_nil, has_more: bool,
-    limit: effective_limit, include_body: bool}}` where `next_cursor` is the
-    `(inserted_at, id)` tuple of the LAST returned row when another page exists,
-    else `nil`. `has_more?` is derived from the keyset peek (it is exactly
-    `next_cursor != nil`), never a COUNT. The HTTP layer encodes `next_cursor`
-    back into an opaque cursor string.
+    limit: effective_limit, include_body: bool, byte_truncated: bool}}` where
+    `next_cursor` is the `(inserted_at, id)` tuple of the LAST returned row when
+    another page exists, else `nil`. `has_more?` is exactly `next_cursor != nil`,
+    never a COUNT.
+
+    When `include_body: true`, the page (already ≤ `max_include_body_page/0` rows)
+    is trimmed to the longest prefix whose cumulative `byte_size(body)` stays
+    within `full_content_byte_budget/0` (always keeping ≥1 row for progress). The
+    ≤25-row cap alone permits 25 × `Article` `@max_body_bytes` (500 KB) = 12.5 MB
+    worst case; the byte budget keeps the keyset full-content page consistent with
+    the offset path (~5.5 MB worst case). If the trim drops rows, `next_cursor` is
+    recomputed from the LAST KEPT row (so the walk resumes over the dropped rows —
+    drift-free by construction), `has_more` is forced `true`, and `byte_truncated`
+    is `true`. When not trimmed (or body-less), `byte_truncated` is `false` and
+    behavior is unchanged. The HTTP layer encodes `next_cursor` into an opaque
+    cursor string.
   """
   @spec list_keyset(Ecto.UUID.t(), keyword()) ::
           {:ok,
@@ -1539,7 +1555,8 @@ defmodule Loopctl.Knowledge do
              next_cursor: {DateTime.t(), Ecto.UUID.t()} | nil,
              has_more: boolean(),
              limit: pos_integer(),
-             include_body: boolean()
+             include_body: boolean(),
+             byte_truncated: boolean()
            }}
   def list_keyset(tenant_id, opts \\ []) do
     limit = opts |> Keyword.get(:limit, @default_page_size) |> max(1) |> min(@max_page_size)
@@ -1557,11 +1574,12 @@ defmodule Loopctl.Knowledge do
 
     {page, has_more?} = split_peek(rows, limit)
 
-    next_cursor =
-      if has_more? do
-        last = List.last(page)
-        {last.inserted_at, last.id}
-      end
+    # US-27.10: when bodies are included, bound the (≤25-row) page by the
+    # serialized-body byte budget so it can't balloon past the offset path's cap.
+    # The page rows already carry `body`, so this is in-memory — no second query.
+    {page, has_more?, byte_truncated?} = maybe_byte_trim(page, has_more?, include_body?)
+
+    next_cursor = keyset_next_cursor(page, has_more?)
 
     maybe_record_search_access(tenant_id, page, "", opts, "list_keyset")
 
@@ -1571,8 +1589,53 @@ defmodule Loopctl.Knowledge do
        next_cursor: next_cursor,
        has_more: has_more?,
        limit: limit,
-       include_body: include_body?
+       include_body: include_body?,
+       byte_truncated: byte_truncated?
      }}
+  end
+
+  # next_cursor is the {inserted_at, id} of the LAST row of the page when more
+  # remains (peek OR byte-trim), else nil. Computed AFTER any byte-trim so a
+  # trimmed page resumes at the last KEPT row — no gap over the dropped rows.
+  defp keyset_next_cursor([], _has_more?), do: nil
+  defp keyset_next_cursor(_page, false), do: nil
+
+  defp keyset_next_cursor(page, true) do
+    last = List.last(page)
+    {last.inserted_at, last.id}
+  end
+
+  # Body-less pages have no body bytes to bound — pass through unchanged.
+  defp maybe_byte_trim(page, has_more?, false), do: {page, has_more?, false}
+
+  # Full-content page: take the longest prefix within `full_content_byte_budget/0`
+  # (always ≥1 row). If rows were dropped, the page now ends earlier than the peek
+  # said, so MORE remains regardless of the peek → force has_more? true and let
+  # `keyset_next_cursor/2` seek from the last kept row.
+  defp maybe_byte_trim(page, has_more?, true) do
+    {kept, truncated?} = take_within_byte_budget_by_body(page, full_content_byte_budget())
+
+    {kept, has_more? or truncated?, truncated?}
+  end
+
+  # In-memory sibling of `take_within_byte_budget/2` (the offset path's id/:bytes
+  # version): keys on `byte_size(row.body || "")` over the already-fetched rows.
+  # Always keeps ≥1 row so a single oversized body still makes progress. Returns
+  # `{kept_rows_in_order, truncated?}`.
+  defp take_within_byte_budget_by_body(rows, budget) do
+    {rev_kept, _sum, truncated?} =
+      Enum.reduce_while(rows, {[], 0, false}, fn row, {acc, sum, _trunc} ->
+        bytes = byte_size(row.body || "")
+        new_sum = sum + bytes
+
+        cond do
+          acc == [] -> {:cont, {[row], bytes, false}}
+          new_sum > budget -> {:halt, {acc, sum, true}}
+          true -> {:cont, {[row | acc], new_sum, false}}
+        end
+      end)
+
+    {Enum.reverse(rev_kept), truncated?}
   end
 
   @doc """

--- a/lib/loopctl_web/controllers/knowledge_search_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_search_controller.ex
@@ -124,6 +124,17 @@ defmodule LoopctlWeb.KnowledgeSearchController do
             "a tampered/forged cursor is rejected with 400. Not valid with `q` (relevance " <>
             "modes return a ranked top-N, not a walk).",
         required: false
+      ],
+      include_body: [
+        in: :query,
+        type: :boolean,
+        description:
+          "Opt into article `body` on each keyset (`cursor`) list row (default false). " <>
+            "Body-less is the default to keep payloads small and avoid large chunked " <>
+            "responses. Honored ONLY for an effective `limit <= 25`; a request with " <>
+            "`include_body=true` AND a requested `limit > 25` is rejected with 400 (never " <>
+            "a silent oversized response). Only `true` enables it; any other value is false.",
+        required: false
       ]
     ],
     responses: %{
@@ -138,6 +149,10 @@ defmodule LoopctlWeb.KnowledgeSearchController do
              },
              meta: %OpenApiSpex.Schema{
                type: :object,
+               description:
+                 "Offset/relevance modes return total_count/offset; the keyset list path " <>
+                   "(`cursor`) instead returns the self-describing cursor contract: " <>
+                   "next_cursor, has_more, limit, count, include_body.",
                properties: %{
                  total_count: %OpenApiSpex.Schema{type: :integer},
                  total_count_scope: %OpenApiSpex.Schema{
@@ -147,12 +162,49 @@ defmodule LoopctlWeb.KnowledgeSearchController do
                  },
                  search_mode: %OpenApiSpex.Schema{
                    type: :string,
-                   enum: ["keyword", "list", "semantic_only", "combined", "keyword_only"],
+                   enum: [
+                     "keyword",
+                     "list",
+                     "list_keyset",
+                     "semantic_only",
+                     "combined",
+                     "keyword_only"
+                   ],
                    description:
-                     "The mode that actually ran (keyword_only = combined degraded to keyword)"
+                     "The mode that actually ran (keyword_only = combined degraded to keyword; " <>
+                       "list_keyset = the cursor enumeration path)"
                  },
-                 limit: %OpenApiSpex.Schema{type: :integer},
-                 offset: %OpenApiSpex.Schema{type: :integer}
+                 limit: %OpenApiSpex.Schema{
+                   type: :integer,
+                   description: "Effective per-page limit that actually ran"
+                 },
+                 offset: %OpenApiSpex.Schema{
+                   type: :integer,
+                   description: "Offset path only; absent on the keyset (`cursor`) path"
+                 },
+                 next_cursor: %OpenApiSpex.Schema{
+                   type: :string,
+                   nullable: true,
+                   description:
+                     "Keyset path: opaque cursor for the next page; null when the walk is " <>
+                       "exhausted (the only exhaustion signal — there is no total_count)"
+                 },
+                 has_more: %OpenApiSpex.Schema{
+                   type: :boolean,
+                   description:
+                     "Keyset path: whether another page exists (exactly next_cursor != null), " <>
+                       "derived from the limit+1 peek, never a COUNT"
+                 },
+                 count: %OpenApiSpex.Schema{
+                   type: :integer,
+                   description: "Keyset path: number of rows in THIS page (length of data)"
+                 },
+                 include_body: %OpenApiSpex.Schema{
+                   type: :boolean,
+                   description:
+                     "Keyset path: whether each row carries the article body (honored only " <>
+                       "for limit <= 25; see the include_body parameter)"
+                 }
                }
              }
            }
@@ -184,6 +236,7 @@ defmodule LoopctlWeb.KnowledgeSearchController do
     with {:ok, query_spec} <- resolve_query(params),
          {:ok, mode} <- validate_mode(params),
          :ok <- validate_search_limit(params, query_spec),
+         :ok <- validate_include_body(params),
          {:ok, base_opts} <- build_opts(params) do
       opts =
         base_opts
@@ -336,9 +389,17 @@ defmodule LoopctlWeb.KnowledgeSearchController do
         |> Keyword.put(:match, match)
         |> maybe_add_limit(params["limit"])
         |> maybe_add_offset(params["offset"])
+        |> maybe_add_include_body(params["include_body"])
 
       {:ok, opts}
     end
+  end
+
+  # Threads the parsed `:include_body` flag into opts (US-27.10). Only added when
+  # true; absent/false leaves the body-less default in place. `validate_include_body/1`
+  # has already enforced the page-size bound before we get here.
+  defp maybe_add_include_body(opts, raw) do
+    if parse_include_body(raw), do: [{:include_body, true} | opts], else: opts
   end
 
   defp maybe_add_opt(opts, _key, nil), do: opts
@@ -395,6 +456,54 @@ defmodule LoopctlWeb.KnowledgeSearchController do
            "for exhaustive enumeration drop 'q' to use list mode (max #{Knowledge.max_page_size()})"}
     end
   end
+
+  # US-27.10: `include_body=true` opts the keyset list page into full bodies, but
+  # ONLY for a requested `limit <= max_include_body_page/0`. A larger requested
+  # limit with `include_body=true` is rejected with 400 here (in the `with`,
+  # BEFORE the query runs) so a caller can never trigger a 100KB+ chunked response
+  # by accidentally requesting bodies for a large page. The bound is on the
+  # REQUESTED limit (the raw param), not the rows actually returned — so
+  # `limit=26 + include_body=true` is a 400 even if the page would return fewer.
+  # `include_body=false`/absent is unbounded (body-less default, #166).
+  defp validate_include_body(params) do
+    if parse_include_body(params["include_body"]) do
+      max = Knowledge.max_include_body_page()
+
+      case requested_limit(params["limit"]) do
+        {:ok, limit} when limit > max ->
+          {:error, :bad_request,
+           "include_body=true is only honored for limit <= #{max} (to avoid oversized " <>
+             "responses); requested limit #{limit} exceeds it. Drop include_body for a " <>
+             "body-less page, or lower the limit."}
+
+        _ ->
+          :ok
+      end
+    else
+      :ok
+    end
+  end
+
+  # Parses the requested `limit` param for the include_body bound check. Returns
+  # `{:ok, int}` only for a clean non-negative integer; anything else is `:none`
+  # (no requested limit to bound — the default page size applies and is within the
+  # include_body cap).
+  defp requested_limit(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {int, ""} when int >= 0 -> {:ok, int}
+      _ -> :none
+    end
+  end
+
+  defp requested_limit(value) when is_integer(value) and value >= 0, do: {:ok, value}
+  defp requested_limit(_), do: :none
+
+  # `include_body` is strictly opt-in: only the literal string "true" (or boolean
+  # true) enables it; anything else — including "1", "yes", or a malformed value —
+  # is false. This keeps the safe body-less default (#166) unless explicitly asked.
+  defp parse_include_body("true"), do: true
+  defp parse_include_body(true), do: true
+  defp parse_include_body(_), do: false
 
   # `limit` is honored up to the relevant cap; over-cap requests are rejected
   # with 400 by `validate_search_limit/2` (in `search/2`) rather than silently

--- a/lib/loopctl_web/controllers/knowledge_search_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_search_controller.ex
@@ -129,11 +129,15 @@ defmodule LoopctlWeb.KnowledgeSearchController do
         in: :query,
         type: :boolean,
         description:
-          "Opt into article `body` on each keyset (`cursor`) list row (default false). " <>
-            "Body-less is the default to keep payloads small and avoid large chunked " <>
-            "responses. Honored ONLY for an effective `limit <= 25`; a request with " <>
-            "`include_body=true` AND a requested `limit > 25` is rejected with 400 (never " <>
-            "a silent oversized response). Only `true` enables it; any other value is false.",
+          "Opt into article `body` on each keyset (`cursor`) list row (default false, " <>
+            "**keyset-path-only** — not supported on offset paths). Body-less is the " <>
+            "default to keep payloads small and avoid large chunked responses. When " <>
+            "`include_body=true`, the response is trimmed by a 5MB serialized-body " <>
+            "budget (same as offset full-content pages), so `count` may be less than " <>
+            "`limit` if bodies are large. Honored ONLY for an effective `limit <= 25`; " <>
+            "a request with `include_body=true` AND a requested `limit > 25` is rejected " <>
+            "with 400 (never a silent oversized response). Only `true` enables it; any " <>
+            "other value is false.",
         required: false
       ]
     ],
@@ -204,6 +208,13 @@ defmodule LoopctlWeb.KnowledgeSearchController do
                    description:
                      "Keyset path: whether each row carries the article body (honored only " <>
                        "for limit <= 25; see the include_body parameter)"
+                 },
+                 byte_truncated: %OpenApiSpex.Schema{
+                   type: :boolean,
+                   description:
+                     "Keyset path (include_body only): true when the page was shortened by " <>
+                       "the serialized-body byte budget. next_cursor is then recomputed from " <>
+                       "the last kept row, so following it returns the dropped rows (no gap)."
                  }
                }
              }
@@ -457,37 +468,62 @@ defmodule LoopctlWeb.KnowledgeSearchController do
     end
   end
 
-  # US-27.10: `include_body=true` opts the keyset list page into full bodies, but
-  # ONLY for a requested `limit <= max_include_body_page/0`. A larger requested
-  # limit with `include_body=true` is rejected with 400 here (in the `with`,
-  # BEFORE the query runs) so a caller can never trigger a 100KB+ chunked response
-  # by accidentally requesting bodies for a large page. The bound is on the
-  # REQUESTED limit (the raw param), not the rows actually returned — so
-  # `limit=26 + include_body=true` is a 400 even if the page would return fewer.
-  # `include_body=false`/absent is unbounded (body-less default, #166).
+  # US-27.10: `include_body=true` is a KEYSET-path-only opt-in to full bodies, and
+  # only for a requested `limit <= max_include_body_page/0`. Two 400s are enforced
+  # here in the `with`, BEFORE the query runs (`include_body=false`/absent is the
+  # unbounded body-less default, #166):
+  #
+  #   1. NO cursor param (offset/relevance path) → `include_body` is meaningless
+  #      there (it's silently ignored, undermining the self-describing contract),
+  #      so reject — mirroring the existing cursor+`q` rejection.
+  #   2. requested `limit > max` → reject so a caller can never trigger an oversized
+  #      chunked response by requesting bodies for a large page. The bound is on the
+  #      REQUESTED limit (raw param), not the rows returned — so `limit=26 +
+  #      include_body=true` is a 400 even if the page would return fewer.
   defp validate_include_body(params) do
     if parse_include_body(params["include_body"]) do
-      max = Knowledge.max_include_body_page()
-
-      case requested_limit(params["limit"]) do
-        {:ok, limit} when limit > max ->
-          {:error, :bad_request,
-           "include_body=true is only honored for limit <= #{max} (to avoid oversized " <>
-             "responses); requested limit #{limit} exceeds it. Drop include_body for a " <>
-             "body-less page, or lower the limit."}
-
-        _ ->
-          :ok
-      end
+      validate_include_body_context(params)
     else
       :ok
     end
+  end
+
+  defp validate_include_body_context(params) do
+    max = Knowledge.max_include_body_page()
+
+    cond do
+      keyset_cursor(params) == :none ->
+        {:error, :bad_request,
+         "include_body is only available for the cursor enumeration path; supply an " <>
+           "empty 'cursor' to start a keyset walk (offset and relevance paths don't " <>
+           "support bodies)."}
+
+      over_include_body_limit?(params, max) ->
+        {:ok, limit} = requested_limit(params["limit"])
+
+        {:error, :bad_request,
+         "include_body=true is only honored for limit <= #{max} (to avoid oversized " <>
+           "responses); requested limit #{limit} exceeds it. Drop include_body for a " <>
+           "body-less page, or lower the limit."}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp over_include_body_limit?(params, max) do
+    match?({:ok, limit} when limit > max, requested_limit(params["limit"]))
   end
 
   # Parses the requested `limit` param for the include_body bound check. Returns
   # `{:ok, int}` only for a clean non-negative integer; anything else is `:none`
   # (no requested limit to bound — the default page size applies and is within the
   # include_body cap).
+  #
+  # KEEP IN SYNC with `maybe_add_limit/2`: both parse the same raw `limit` param
+  # independently (this for the ≤25 include_body bound, that for the opt fed to the
+  # query). A future change to how `limit` is parsed must touch both, or the bound
+  # could be bypassed (e.g. accepting "26abc" here as :none while the query clamps).
   defp requested_limit(value) when is_binary(value) do
     case Integer.parse(value) do
       {int, ""} when int >= 0 -> {:ok, int}
@@ -508,6 +544,10 @@ defmodule LoopctlWeb.KnowledgeSearchController do
   # `limit` is honored up to the relevant cap; over-cap requests are rejected
   # with 400 by `validate_search_limit/2` (in `search/2`) rather than silently
   # clamped here. The `min/2` is a safety net for direct/list callers.
+  #
+  # KEEP IN SYNC with `requested_limit/1`, which parses this same raw `limit` param
+  # to enforce the ≤25 include_body bound (`validate_include_body/1`). If the two
+  # diverge on what counts as a valid limit, the bound could be bypassed.
   defp maybe_add_limit(opts, nil), do: [{:limit, 10} | opts]
 
   defp maybe_add_limit(opts, value) when is_binary(value) do

--- a/lib/loopctl_web/controllers/knowledge_search_json.ex
+++ b/lib/loopctl_web/controllers/knowledge_search_json.ex
@@ -24,22 +24,41 @@ defmodule LoopctlWeb.KnowledgeSearchJSON do
   end
 
   @doc """
-  Renders a KEYSET (cursor) list page (US-27.9a).
+  Renders a KEYSET (cursor) list page (US-27.9a, US-27.10).
 
   Unlike `search/2`, the keyset list path carries no relevance score/snippet, and
-  its `meta` documents `next_cursor` (the opaque, already-encoded cursor for the
-  next page, or `null` when the walk is exhausted) and the effective `limit`
-  instead of an offset/total_count. `next_cursor` is encoded by the controller
-  (it needs the tenant key), so this view receives it as a ready string or `nil`.
+  its `meta` fully documents the cursor contract (US-27.10) so an agent can drive
+  pagination purely from the response:
+
+  - `next_cursor` — the opaque, already-encoded cursor for the next page, or
+    `null` when the walk is exhausted (the only exhaustion signal — there is no
+    total_count to drift).
+  - `has_more` — boolean, derived from the keyset peek (exactly `next_cursor != null`),
+    never a COUNT.
+  - `limit` — the effective per-page limit that actually ran.
+  - `count` — the number of rows in THIS page (`length(data)`).
+  - `include_body` — whether each row carries the article `body` (US-27.10).
+
+  `next_cursor` is encoded by the controller (it needs the tenant key), so this
+  view receives it as a ready string or `nil`.
   """
-  def keyset(%{results: results, next_cursor: next_cursor, limit: limit}) do
+  def keyset(%{
+        results: results,
+        next_cursor: next_cursor,
+        has_more: has_more,
+        limit: limit,
+        include_body: include_body
+      }) do
     %{
-      data: Enum.map(results, &render_list_row/1),
+      data: Enum.map(results, &render_list_row(&1, include_body)),
       meta: %{
         # The cursor walk is drift-free precisely BECAUSE it carries no
         # total_count to drift; `next_cursor: null` is the exhaustion signal.
         next_cursor: next_cursor,
+        has_more: has_more,
         limit: limit,
+        count: length(results),
+        include_body: include_body,
         search_mode: "list_keyset"
       }
     }
@@ -49,14 +68,17 @@ defmodule LoopctlWeb.KnowledgeSearchJSON do
   # `select` (every field present; `tags` is a non-null `{:array}` default `[]`), so
   # direct field access is correct — and a missing field SHOULD crash loudly rather than
   # silently degrade. (`render_result/1` keeps the dual accessor because search results
-  # may be structs.)
-  defp render_list_row(result) do
-    %{
+  # may be structs.) `body` is present ONLY when the query was run with
+  # `include_body: true` (US-27.10); body-less (the default) carries no `body` key.
+  defp render_list_row(result, include_body) do
+    base = %{
       id: result.id,
       title: result.title,
       category: to_string(result.category),
       tags: result.tags
     }
+
+    if include_body, do: Map.put(base, :body, result.body), else: base
   end
 
   defp render_result(result, mode) do

--- a/lib/loopctl_web/controllers/knowledge_search_json.ex
+++ b/lib/loopctl_web/controllers/knowledge_search_json.ex
@@ -38,6 +38,14 @@ defmodule LoopctlWeb.KnowledgeSearchJSON do
   - `limit` — the effective per-page limit that actually ran.
   - `count` — the number of rows in THIS page (`length(data)`).
   - `include_body` — whether each row carries the article `body` (US-27.10).
+  - `byte_truncated` — whether the page was shortened by the serialized-body byte
+    budget (US-27.10). Only ever `true` when `include_body` is `true`.
+
+  When `include_body: true`, the CONTEXT (`Loopctl.Knowledge.list_keyset/2`) has
+  already trimmed the page to `full_content_byte_budget/0` and recomputed
+  `next_cursor`/`has_more` from the LAST KEPT row, so the walk resumes over the
+  dropped rows with no gap. This view does NOT trim — it renders exactly what the
+  context returns and surfaces `byte_truncated` from the context.
 
   `next_cursor` is encoded by the controller (it needs the tenant key), so this
   view receives it as a ready string or `nil`.
@@ -47,7 +55,8 @@ defmodule LoopctlWeb.KnowledgeSearchJSON do
         next_cursor: next_cursor,
         has_more: has_more,
         limit: limit,
-        include_body: include_body
+        include_body: include_body,
+        byte_truncated: byte_truncated
       }) do
     %{
       data: Enum.map(results, &render_list_row(&1, include_body)),
@@ -59,6 +68,7 @@ defmodule LoopctlWeb.KnowledgeSearchJSON do
         limit: limit,
         count: length(results),
         include_body: include_body,
+        byte_truncated: byte_truncated,
         search_mode: "list_keyset"
       }
     }

--- a/test/loopctl/knowledge/list_keyset_test.exs
+++ b/test/loopctl/knowledge/list_keyset_test.exs
@@ -380,6 +380,61 @@ defmodule Loopctl.Knowledge.ListKeysetTest do
       # A single over-budget row is not a truncation of OTHER rows — nothing was dropped.
       refute byte_truncated
     end
+
+    # Scenario B (peek=true AND byte-trim drops rows): a page that has MORE matching
+    # rows than `limit` (so the peek says has_more) AND is byte-trimmed below `limit`.
+    # The recomputed cursor must walk over the dropped rows with no gap/dup and the walk
+    # must end on a real (non-phantom) page. Also pins the invariant
+    # `byte_truncated == true ⟹ next_cursor != nil` on every page.
+    test "byte-trimmed multi-page walk (peek + trim) is gap-free and never strands a row" do
+      tenant = fixture(:tenant)
+      big = String.duplicate("z", 40_000)
+
+      ids =
+        for i <- 1..12 do
+          a =
+            fixture(:article, %{
+              tenant_id: tenant.id,
+              status: :published,
+              tags: ["sb"],
+              title: "sb#{i}",
+              body: big
+            })
+
+          a.id
+        end
+
+      # limit 5 ⇒ early pages have a peek row (has_more), and the 100 KB budget trims
+      # each page to 2 rows (2×40 KB ≤ 100 KB; the 3rd would exceed) ⇒ byte_truncated.
+      seen = scenario_b_walk(tenant.id, nil, [])
+
+      assert Enum.sort(seen) == Enum.sort(ids), "every row served exactly across the walk"
+      assert length(seen) == length(Enum.uniq(seen)), "no duplicate across trim+peek seams"
+      assert length(seen) == 12
+    end
+  end
+
+  # Walk include_body pages, asserting per-page that a byte-truncated page always
+  # carries a continuation cursor (never strands the dropped rows) and never returns
+  # an empty page while claiming more remains.
+  defp scenario_b_walk(_tid, _cursor, acc) when length(acc) > 1_000,
+    do: flunk("scenario B walk did not terminate")
+
+  defp scenario_b_walk(tenant_id, cursor, acc) do
+    {:ok, %{results: page, next_cursor: next, byte_truncated: trunc?, has_more: more?}} =
+      Knowledge.list_keyset(tenant_id,
+        status: :published,
+        tags: ["sb"],
+        limit: 5,
+        include_body: true,
+        cursor: cursor
+      )
+
+    if trunc?, do: assert(next, "byte_truncated page must carry a next_cursor")
+    if more?, do: assert(page != [], "has_more must not be signalled on an empty page")
+
+    acc = acc ++ Enum.map(page, & &1.id)
+    if next, do: scenario_b_walk(tenant_id, next, acc), else: acc
   end
 
   describe "list_keyset/2 — include_body respects visibility scope (AC-27.10.5)" do

--- a/test/loopctl/knowledge/list_keyset_test.exs
+++ b/test/loopctl/knowledge/list_keyset_test.exs
@@ -258,6 +258,115 @@ defmodule Loopctl.Knowledge.ListKeysetTest do
     end
   end
 
+  describe "list_keyset/2 — include_body + has_more (US-27.10)" do
+    test "body-less is the default: no :body key on any row" do
+      tenant = fixture(:tenant)
+      fixture(:article, %{tenant_id: tenant.id, status: :published, body: "secret body"})
+
+      {:ok, %{results: [row], include_body: include_body}} =
+        Knowledge.list_keyset(tenant.id, status: :published, limit: 20)
+
+      refute include_body
+      refute Map.has_key?(row, :body)
+    end
+
+    test "include_body: true threads :body into each row's select" do
+      tenant = fixture(:tenant)
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        status: :published,
+        body: "the full body content"
+      })
+
+      {:ok, %{results: [row], include_body: include_body}} =
+        Knowledge.list_keyset(tenant.id, status: :published, limit: 20, include_body: true)
+
+      assert include_body
+      assert row.body == "the full body content"
+    end
+
+    test "has_more mirrors the keyset peek (next_cursor != nil), not a COUNT" do
+      tenant = fixture(:tenant)
+
+      for i <- 1..5 do
+        fixture(:article, %{tenant_id: tenant.id, status: :published, title: "h#{i}"})
+      end
+
+      # Page of 2 over 5 rows: more remains.
+      {:ok, %{next_cursor: next_cursor, has_more: has_more}} =
+        Knowledge.list_keyset(tenant.id, status: :published, limit: 2)
+
+      assert has_more
+      refute is_nil(next_cursor)
+
+      # A page large enough to exhaust the set: has_more false, next_cursor nil.
+      {:ok, %{next_cursor: last_cursor, has_more: last_has_more}} =
+        Knowledge.list_keyset(tenant.id, status: :published, limit: 50)
+
+      refute last_has_more
+      assert is_nil(last_cursor)
+    end
+  end
+
+  describe "list_keyset/2 — include_body respects visibility scope (AC-27.10.5)" do
+    test "a private memory's body never leaks to a non-owning agent" do
+      tenant = fixture(:tenant)
+      owner_agent = fixture(:agent, %{tenant_id: tenant.id})
+      other_agent = fixture(:agent, %{tenant_id: tenant.id})
+
+      private =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :published,
+          body: "PRIVATE BODY — must not leak",
+          metadata: %{"visibility" => "private", "agent_id" => to_string(owner_agent.id)}
+        })
+
+      # The non-owning agent enumerates WITH include_body. The visibility filter
+      # is applied before the projection, so the private row is excluded entirely
+      # — its body is never selected, let alone returned.
+      {:ok, %{results: results}} =
+        Knowledge.list_keyset(tenant.id,
+          status: :published,
+          include_body: true,
+          limit: 50,
+          visibility_agent_id: to_string(other_agent.id)
+        )
+
+      refute Enum.any?(results, &(&1.id == private.id))
+      refute Enum.any?(results, fn r -> Map.get(r, :body) == "PRIVATE BODY — must not leak" end)
+
+      # The OWNER, by contrast, does see its own private memory's body.
+      {:ok, %{results: owner_results}} =
+        Knowledge.list_keyset(tenant.id,
+          status: :published,
+          include_body: true,
+          limit: 50,
+          visibility_agent_id: to_string(owner_agent.id)
+        )
+
+      owner_row = Enum.find(owner_results, &(&1.id == private.id))
+      assert owner_row.body == "PRIVATE BODY — must not leak"
+    end
+
+    test "include_body never returns a body across tenants" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+
+      fixture(:article, %{
+        tenant_id: tenant_b.id,
+        status: :published,
+        body: "TENANT B BODY"
+      })
+
+      {:ok, %{results: results}} =
+        Knowledge.list_keyset(tenant_a.id, status: :published, include_body: true, limit: 50)
+
+      assert results == []
+    end
+  end
+
   describe "keyset_query/2 — request-path query shape" do
     test "is the query list_keyset runs, and is tenant-scoped" do
       tenant = fixture(:tenant)
@@ -269,6 +378,26 @@ defmodule Loopctl.Knowledge.ListKeysetTest do
       assert sql =~ "tenant_id"
       assert sql =~ ~r/order by.*inserted_at.*id/i
       assert sql =~ ~r/limit/i
+    end
+
+    test "body-less by default; include_body: true selects the body column (US-27.10)" do
+      tenant = fixture(:tenant)
+      fixture(:article, %{tenant_id: tenant.id, status: :published})
+
+      {bodyless_sql, _} =
+        :all
+        |> SQL.to_sql(AdminRepo, Knowledge.keyset_query(tenant.id, status: :published))
+
+      refute bodyless_sql =~ ~r/\bbody\b/i
+
+      {full_sql, _} =
+        :all
+        |> SQL.to_sql(
+          AdminRepo,
+          Knowledge.keyset_query(tenant.id, status: :published, include_body: true)
+        )
+
+      assert full_sql =~ ~r/\bbody\b/i
     end
   end
 end

--- a/test/loopctl/knowledge/list_keyset_test.exs
+++ b/test/loopctl/knowledge/list_keyset_test.exs
@@ -307,6 +307,79 @@ defmodule Loopctl.Knowledge.ListKeysetTest do
       refute last_has_more
       assert is_nil(last_cursor)
     end
+
+    test "body-less default is never byte_truncated" do
+      tenant = fixture(:tenant)
+      fixture(:article, %{tenant_id: tenant.id, status: :published, body: "x"})
+
+      {:ok, %{byte_truncated: byte_truncated}} =
+        Knowledge.list_keyset(tenant.id, status: :published, limit: 20)
+
+      refute byte_truncated
+    end
+
+    # The test budget is 100_000 bytes (config/test.exs). Two 40 KB bodies fit
+    # (80 KB); the 3rd would exceed it, so the page trims to 2, sets byte_truncated,
+    # and recomputes next_cursor from the LAST KEPT row so the walk resumes over the
+    # dropped row with no gap.
+    test "include_body trims the page by the byte budget and resumes drift-free" do
+      tenant = fixture(:tenant)
+      big = String.duplicate("x", 40_000)
+
+      ids =
+        for i <- 1..3 do
+          a =
+            fixture(:article, %{
+              tenant_id: tenant.id,
+              status: :published,
+              title: "bt#{i}",
+              body: big
+            })
+
+          a.id
+        end
+
+      {:ok, %{results: page1, next_cursor: cursor1, has_more: more1, byte_truncated: trunc1}} =
+        Knowledge.list_keyset(tenant.id, status: :published, limit: 25, include_body: true)
+
+      assert trunc1
+      assert length(page1) == 2
+      assert more1
+      refute is_nil(cursor1)
+
+      {:ok, %{results: page2, next_cursor: cursor2, byte_truncated: trunc2}} =
+        Knowledge.list_keyset(tenant.id,
+          status: :published,
+          limit: 25,
+          include_body: true,
+          cursor: cursor1
+        )
+
+      assert length(page2) == 1
+      refute trunc2
+      assert is_nil(cursor2)
+
+      seen = Enum.map(page1 ++ page2, & &1.id)
+      assert Enum.sort(seen) == Enum.sort(ids)
+      assert length(seen) == length(Enum.uniq(seen)), "no duplicate across the trim boundary"
+    end
+
+    test "always keeps ≥1 row even if a single body alone exceeds the budget" do
+      tenant = fixture(:tenant)
+      # One body alone (120 KB) exceeds the 100 KB test budget; progress requires
+      # keeping it anyway (the always-take-≥1 rule).
+      huge = String.duplicate("y", 120_000)
+
+      a = fixture(:article, %{tenant_id: tenant.id, status: :published, body: huge})
+
+      {:ok, %{results: results, byte_truncated: byte_truncated}} =
+        Knowledge.list_keyset(tenant.id, status: :published, limit: 25, include_body: true)
+
+      assert length(results) == 1
+      assert hd(results).id == a.id
+      # A single over-budget row is not a truncation of OTHER rows — nothing was dropped.
+      refute byte_truncated
+    end
   end
 
   describe "list_keyset/2 — include_body respects visibility scope (AC-27.10.5)" do

--- a/test/loopctl_web/controllers/knowledge_keyset_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_keyset_controller_test.exs
@@ -79,6 +79,32 @@ defmodule LoopctlWeb.KnowledgeKeysetControllerTest do
     end
   end
 
+  # Walk the keyset list to exhaustion, returning the FULL decoded response of every
+  # page (in order). Used to assert per-page meta invariants across an include_body
+  # walk (US-27.10 BA-F2).
+  defp walk_pages(conn, raw_key, base_params) do
+    do_walk_pages(conn, raw_key, base_params, "", [], 0)
+  end
+
+  defp do_walk_pages(_conn, _key, _params, _cursor, _acc, n) when n > 1_000 do
+    flunk("walk_pages did not terminate")
+  end
+
+  defp do_walk_pages(conn, raw_key, base_params, cursor, acc, n) do
+    resp =
+      conn
+      |> auth_conn(raw_key)
+      |> get(~p"/api/v1/knowledge/search", Map.put(base_params, "cursor", cursor))
+      |> json_response(200)
+
+    acc = acc ++ [resp]
+
+    case resp["meta"]["next_cursor"] do
+      nil -> acc
+      next -> do_walk_pages(conn, raw_key, base_params, next, acc, n + 1)
+    end
+  end
+
   describe "cursor walk (AC-27.9a.1 / TC-27.9a.1)" do
     test "walks the full list exactly once, ending with next_cursor null", %{conn: conn} do
       tenant = fixture(:tenant)
@@ -545,6 +571,171 @@ defmodule LoopctlWeb.KnowledgeKeysetControllerTest do
       bodies = Enum.map(resp["data"], & &1["body"])
       refute "PRIVATE — do not leak" in bodies
       assert "shared body" in bodies
+    end
+  end
+
+  describe "include_body is keyset-only (US-27.10 / AC-27.10.2 / REVIEW-3)" do
+    test "include_body=true with NO cursor param returns 400 (offset path unsupported)",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      fixture(:article, %{tenant_id: tenant.id, status: :published, tags: ["ko"]})
+
+      # No `cursor` param at all → offset path. include_body is meaningless there.
+      resp =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{"tags" => "ko", "include_body" => "true"})
+
+      assert resp.status == 400
+      assert json_response(resp, 400)["error"]["message"] =~ "cursor"
+    end
+
+    test "include_body=true with a relevance q (and no cursor) returns 400", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      fixture(:article, %{tenant_id: tenant.id, status: :published, title: "needle"})
+
+      resp =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{"q" => "needle", "include_body" => "true"})
+
+      assert resp.status == 400
+    end
+  end
+
+  describe "include_body default page is within the bound (US-27.10 / BA-F1)" do
+    test "include_body=true + cursor + NO limit → 200, meta.limit=10 (controller default), body present",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        status: :published,
+        tags: ["def"],
+        body: "default-page body"
+      })
+
+      resp =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{
+          "tags" => "def",
+          "include_body" => "true",
+          "cursor" => ""
+        })
+        |> json_response(200)
+
+      # The controller default limit (10) is within max_include_body_page (25), so
+      # omitting `limit` with include_body is allowed (no 400).
+      assert resp["meta"]["limit"] == 10
+      assert resp["meta"]["include_body"] == true
+      [row] = resp["data"]
+      assert row["body"] == "default-page body"
+    end
+  end
+
+  describe "multi-page include_body walk (US-27.10 / BA-F2)" do
+    test "every page has include_body=true, count <= 25, bodies present on each row",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      for i <- 1..12 do
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :published,
+          tags: ["mp"],
+          title: "mp#{i}",
+          body: "body #{i}"
+        })
+      end
+
+      pages =
+        walk_pages(conn, raw_key, %{"tags" => "mp", "limit" => "5", "include_body" => "true"})
+
+      # 12 rows at page size 5 → 3 pages (5, 5, 2). Bodies present and bounded on each.
+      assert length(pages) >= 2
+      total = Enum.sum(Enum.map(pages, fn p -> length(p["data"]) end))
+      assert total == 12
+
+      for page <- pages do
+        assert page["meta"]["include_body"] == true
+        assert page["meta"]["count"] <= 25
+        assert page["meta"]["count"] == length(page["data"])
+        assert Enum.all?(page["data"], &Map.has_key?(&1, "body"))
+      end
+    end
+  end
+
+  describe "byte-budget trim stops mid-page (US-27.10 / AC-27.10.2 / TC-byte-trim)" do
+    # The test budget is 100_000 bytes (config/test.exs :full_content_byte_budget).
+    # Three 40 KB bodies (120 KB) exceed it, so the first include_body page returns
+    # 2 rows (80 KB) and signals byte_truncated; the 3rd is reachable by continuing
+    # at next_cursor — a drift-free walk (next_cursor recomputed from the last KEPT
+    # row in Knowledge.list_keyset/2, NOT the un-trimmed peek). Mirrors the offset
+    # path's byte-truncation test.
+    test "first page truncates by byte budget; following next_cursor returns the dropped row",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      big = String.duplicate("x", 40_000)
+
+      ids =
+        for i <- 1..3 do
+          a =
+            fixture(:article, %{
+              tenant_id: tenant.id,
+              status: :published,
+              tags: ["bt"],
+              title: "bt#{i}",
+              body: big
+            })
+
+          a.id
+        end
+
+      page1 =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{
+          "tags" => "bt",
+          "limit" => "25",
+          "include_body" => "true",
+          "cursor" => ""
+        })
+        |> json_response(200)
+
+      # 2 × 40 KB = 80 KB fits; the 3rd would push to 120 KB > 100 KB budget → trimmed.
+      assert page1["meta"]["byte_truncated"] == true
+      assert page1["meta"]["count"] == 2
+      assert length(page1["data"]) == 2
+      # Truncation forces continuation regardless of the limit+1 peek.
+      assert page1["meta"]["has_more"] == true
+      assert page1["meta"]["next_cursor"]
+
+      page2 =
+        build_conn()
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{
+          "tags" => "bt",
+          "limit" => "25",
+          "include_body" => "true",
+          "cursor" => page1["meta"]["next_cursor"]
+        })
+        |> json_response(200)
+
+      # The dropped 3rd row is reachable on the next page — no gap.
+      assert page2["meta"]["count"] == 1
+      assert page2["meta"]["byte_truncated"] == false
+      refute page2["meta"]["next_cursor"]
+
+      seen = Enum.map(page1["data"] ++ page2["data"], & &1["id"])
+      assert Enum.sort(seen) == Enum.sort(ids)
+      assert length(seen) == length(Enum.uniq(seen)), "no duplicate rows across the trim boundary"
     end
   end
 

--- a/test/loopctl_web/controllers/knowledge_keyset_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_keyset_controller_test.exs
@@ -56,6 +56,29 @@ defmodule LoopctlWeb.KnowledgeKeysetControllerTest do
     end
   end
 
+  # Walk to the LAST page and return its decoded JSON response (the page whose
+  # meta.next_cursor is null). Used to assert the exhaustion contract (US-27.10).
+  defp walk_to_final(conn, raw_key, base_params) do
+    do_walk_to_final(conn, raw_key, base_params, "", 0)
+  end
+
+  defp do_walk_to_final(_conn, _key, _params, _cursor, n) when n > 1_000 do
+    flunk("walk_to_final did not terminate")
+  end
+
+  defp do_walk_to_final(conn, raw_key, base_params, cursor, n) do
+    resp =
+      conn
+      |> auth_conn(raw_key)
+      |> get(~p"/api/v1/knowledge/search", Map.put(base_params, "cursor", cursor))
+      |> json_response(200)
+
+    case resp["meta"]["next_cursor"] do
+      nil -> resp
+      next -> do_walk_to_final(conn, raw_key, base_params, next, n + 1)
+    end
+  end
+
   describe "cursor walk (AC-27.9a.1 / TC-27.9a.1)" do
     test "walks the full list exactly once, ending with next_cursor null", %{conn: conn} do
       tenant = fixture(:tenant)
@@ -337,6 +360,191 @@ defmodule LoopctlWeb.KnowledgeKeysetControllerTest do
         |> get(~p"/api/v1/knowledge/search", %{"tags" => "bc", "limit" => "5000"})
 
       assert resp.status == 400
+    end
+  end
+
+  describe "cursor contract in meta (US-27.10 / AC-27.10.1 / TC-27.10.1)" do
+    test "first page documents next_cursor/has_more/limit/count; final page signals exhaustion",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      for i <- 1..7 do
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :published,
+          tags: ["contract"],
+          title: "c#{i}"
+        })
+      end
+
+      # First page of 3 over 7 rows: more remains, meta fully describes the page.
+      page1 =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{
+          "tags" => "contract",
+          "limit" => "3",
+          "cursor" => ""
+        })
+        |> json_response(200)
+
+      assert page1["meta"]["next_cursor"]
+      assert page1["meta"]["has_more"] == true
+      assert page1["meta"]["limit"] == 3
+      assert page1["meta"]["count"] == 3
+      assert page1["meta"]["count"] == length(page1["data"])
+      assert page1["meta"]["include_body"] == false
+      assert page1["meta"]["search_mode"] == "list_keyset"
+
+      # Walk to the end via next_cursor; the final page has next_cursor null,
+      # has_more false, and count == its (partial) data length.
+      final = walk_to_final(conn, raw_key, %{"tags" => "contract", "limit" => "3"})
+
+      assert final["meta"]["next_cursor"] == nil
+      assert final["meta"]["has_more"] == false
+      assert final["meta"]["count"] == length(final["data"])
+    end
+  end
+
+  describe "bounded include_body (US-27.10 / AC-27.10.2 / TC-27.10.2)" do
+    test "include_body=true with limit=25 returns 200 with body present", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        status: :published,
+        tags: ["ib"],
+        body: "full body here"
+      })
+
+      resp =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{
+          "tags" => "ib",
+          "limit" => "25",
+          "include_body" => "true",
+          "cursor" => ""
+        })
+        |> json_response(200)
+
+      assert resp["meta"]["include_body"] == true
+      [row] = resp["data"]
+      assert row["body"] == "full body here"
+    end
+
+    test "include_body=true with limit=26 returns 400 (over the include_body bound)", %{
+      conn: conn
+    } do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      fixture(:article, %{tenant_id: tenant.id, status: :published, tags: ["ib"]})
+
+      resp =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{
+          "tags" => "ib",
+          "limit" => "26",
+          "include_body" => "true",
+          "cursor" => ""
+        })
+
+      assert resp.status == 400
+      assert json_response(resp, 400)["error"]["message"] =~ "include_body"
+    end
+
+    test "the bound is on the REQUESTED limit even if the page would return fewer rows",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      # Only one row exists, but requesting limit=26 + include_body is still a 400:
+      # the bound guards the request, not the realized page size.
+      fixture(:article, %{tenant_id: tenant.id, status: :published, tags: ["ib"]})
+
+      resp =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{
+          "tags" => "ib",
+          "limit" => "26",
+          "include_body" => "true",
+          "cursor" => ""
+        })
+
+      assert resp.status == 400
+    end
+  end
+
+  describe "default body-less (US-27.10 / AC-27.10.3 / TC-27.10.3)" do
+    test "no include_body → no body key in any item", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      for i <- 1..3 do
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :published,
+          tags: ["bl"],
+          title: "bl#{i}",
+          body: "should not appear"
+        })
+      end
+
+      resp =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{"tags" => "bl", "cursor" => ""})
+        |> json_response(200)
+
+      assert resp["meta"]["include_body"] == false
+      refute Enum.any?(resp["data"], &Map.has_key?(&1, "body"))
+    end
+  end
+
+  describe "include_body respects visibility/tenant scope (US-27.10 / AC-27.10.5)" do
+    test "a private memory's body never leaks to a non-owning agent via include_body",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      owner_agent = fixture(:agent, %{tenant_id: tenant.id})
+      other_agent = fixture(:agent, %{tenant_id: tenant.id})
+
+      {raw_other, _} =
+        fixture(:api_key, %{tenant_id: tenant.id, role: :agent, agent_id: other_agent.id})
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        status: :published,
+        tags: ["vis"],
+        body: "PRIVATE — do not leak",
+        metadata: %{"visibility" => "private", "agent_id" => to_string(owner_agent.id)}
+      })
+
+      # A shared row the non-owner CAN see (so the request returns a page).
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        status: :published,
+        tags: ["vis"],
+        body: "shared body",
+        metadata: %{"visibility" => "shared", "agent_id" => to_string(owner_agent.id)}
+      })
+
+      resp =
+        conn
+        |> auth_conn(raw_other)
+        |> get(~p"/api/v1/knowledge/search", %{
+          "tags" => "vis",
+          "include_body" => "true",
+          "limit" => "25",
+          "cursor" => ""
+        })
+        |> json_response(200)
+
+      bodies = Enum.map(resp["data"], & &1["body"])
+      refute "PRIVATE — do not leak" in bodies
+      assert "shared body" in bodies
     end
   end
 


### PR DESCRIPTION
## US-27.10: self-describing keyset cursor contract + bounded opt-in `include_body`

Builds on US-27.9a. Makes the keyset (`?cursor=`) enumeration response **self-describing** so an agent drives pagination purely from `meta`, and adds a **bounded** opt-in `include_body` so the #166 body-less default can't be undone into a 100KB+ `ChunkedEncodingError`.

- **AC-27.10.1** — keyset `meta`: `next_cursor` (string|null), `has_more` (bool, from the limit+1 peek — never a COUNT), `limit`, `count`, `include_body`.
- **AC-27.10.2** — body-less default. `include_body=true` honored ONLY for requested `limit <= 25` (`@max_include_body_page`); `limit > 25 + include_body=true` → **400** (pre-query guard), never a silent oversized response. Strict parse (only `true`).
- **AC-27.10.3** — `:include_body` threads `list_keyset/2 → keyset_query/2` via two static `keyset_select/2` projections; body-less keeps `body` off the wire (and preserves the `:scale_nightly` plan-test query shape).
- **AC-27.10.4** — `operation(:search)` OpenApiSpex documents the param + the meta contract.
- **AC-27.10.5** — scoping unchanged: tenant + visibility filter BEFORE the projection, so `body` is only selected for rows the caller could already read. Tests prove no cross-tenant / out-of-visibility body leak.

`mix precommit` green (2757 tests). Enhanced review (team + adversarial) to follow on this branch before merge.
