### PR TITLE
US-27.9b: keyset cursor on by-tag/by-source index + change-feed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,6 +320,7 @@ jobs:
           - test/loopctl/knowledge/vector_search_scale_test.exs
           - test/loopctl/knowledge/plan_assertions_scale_test.exs
           - test/loopctl/knowledge/keyset_plan_scale_test.exs
+          - test/loopctl/knowledge/by_source_change_feed_plan_scale_test.exs
           - test/loopctl/knowledge/streaming_export_scale_test.exs
     services:
       postgres:

--- a/config/config.exs
+++ b/config/config.exs
@@ -26,10 +26,13 @@ config :loopctl,
   # heavy reads, e.g. %{suggested_links: 5_000}. Endpoints absent here use the
   # pool-level statement_timeout (HEAVY_READ_STATEMENT_TIMEOUT_MS, default 10s) with
   # no per-request transaction. Keys: :suggested_links, :semantic_search,
-  # :distant_pairs, :novelty, :enumeration. NOTE: :distant_pairs, :semantic_search,
-  # and :enumeration each issue TWO reads (count + data); setting an override for any
-  # of them wraps EACH read in its own separate transaction, doubling the brief
-  # checkout count on the heavy pool.
+  # :distant_pairs, :novelty, :enumeration, :change_feed. NOTE: :distant_pairs,
+  # :semantic_search, and :enumeration each issue TWO reads (count + data); setting an
+  # override for any of them wraps EACH read in its own separate transaction, doubling
+  # the brief checkout count on the heavy pool. :change_feed (US-27.9b) is the
+  # rate-limited orchestrator polling feed — a SINGLE cheap keyset read per request;
+  # its QPS is bounded by the api pipeline's rate limiter, so it adds at most a brief,
+  # fast-releasing checkout and does not erode the K≈6 one-shot fast-read budget.
   heavy_read_statement_timeout_overrides: %{},
   # US-27.12: set-based bulk archive/unpublish/delete. Each op runs in one
   # transaction that first issues `SET LOCAL statement_timeout = <ms>` so a single

--- a/docs/runbooks/knowledge-scale.md
+++ b/docs/runbooks/knowledge-scale.md
@@ -156,6 +156,95 @@ SELECT indexrelid::regclass, indisvalid
 FROM pg_index WHERE indexrelid = 'articles_tenant_inserted_id_idx'::regclass;
 ```
 
+## Keyset pagination rolled onto by-tag / by-source / change-feed (US-27.9b)
+
+US-27.9b applies the **same** US-27.9a keyset cursor (verbatim — one HMAC codec,
+`Loopctl.KeysetCursor`, with a per-surface namespace) to the remaining enumeration
+surfaces an agent uses to walk the KB. The original offset-drift incident (#175) was a
+**by-TAG** walk (a tag count swung 9,881 → 4,981 mid-enumeration), so the cursor had to
+reach these, not just the bare article list.
+
+### Index dual-path ordering + the no-mixing rule
+
+Both `GET /knowledge/index` and `GET /knowledge/search` (list mode) are **dual-path**:
+
+- **`cursor` param ABSENT** → the legacy **offset** path, unchanged. Index orders by
+  `category, updated_at DESC, id`; search-list by `updated_at DESC, id`. Emits
+  `total_count`/`offset`, NOT `next_cursor`.
+- **`cursor` param PRESENT** (even empty `cursor=`) → the **keyset** path, ordered
+  `inserted_at ASC, id ASC`. Emits `next_cursor`/`has_more`/`count`, NOT `total_count`.
+
+**Do NOT mix the two mid-enumeration** — the sort orders differ, so switching paths
+between pages skips/repeats rows. Start with an empty `cursor=` and follow
+`meta.next_cursor` verbatim to the end (`next_cursor: null`). The keyset path is the
+drift-free way to walk a tag or a source to exhaustion under concurrent writes; the
+offset path is retained only for back-compat.
+
+### by-source index (`articles_tenant_source_inserted_id_idx`)
+
+by-source (`?source_id=`) is a **selective scalar equality**. Unlike `category=` (which
+the `(tenant_id, inserted_at, id)` btree already serves index-ordered with a cheap
+recheck), a deep by-source page over the general keyset btree would heap-recheck
+`source_id=` across the whole tenant corpus. So US-27.9b adds a dedicated **partial
+composite** index:
+
+```sql
+CREATE INDEX CONCURRENTLY IF NOT EXISTS articles_tenant_source_inserted_id_idx
+ON articles (tenant_id, source_id, inserted_at, id)
+WHERE source_id IS NOT NULL;
+```
+
+Leading with `(tenant_id, source_id)` lets the planner seek straight to the source's
+rows and walk them in `(inserted_at, id)` order — strictly index-ordered, no Sort. Built
+`CREATE INDEX CONCURRENTLY` + `@disable_ddl_transaction` (online build), `WHERE source_id
+IS NOT NULL` (only source-attributed rows pay for it). It is registered in
+`Loopctl.IndexHealth` (boot probe + recovery identical to the 27.9a index).
+
+**Plan profile by index-enumeration shape (verified at 80k,
+`by_source_change_feed_plan_scale_test.exs`):**
+
+| Index query shape | Plan at prod scale | Cost profile |
+| ----------------- | ------------------ | ------------ |
+| `source_id=` (scalar) | Index Scan on `articles_tenant_source_inserted_id_idx`, walked in order, **no Sort** | true keyset, bounded by source selectivity (`refute_full_scan` + `assert_scan_rows_below`) |
+| `tags=` (array `&&`) | tags GIN drives the scan, bounded by tag selectivity | same bounded GIN path 27.9a proved — NOT a full Seq Scan (`refute_seq_scan` + `assert_index_used` on the tags GIN) |
+
+**by-tag stays the bounded GIN+btree path 27.9a already solved.** Because
+`index_keyset_query` is a DISTINCT query from 27.9a's `keyset_query` (it forces
+`status = :published` + the project OR-clause), the by-tag plan is pinned separately
+**on `index_keyset_query`** in the same scale test (the literal #175 incident path).
+
+### change feed (`GET /changes`) over the partitioned `audit_log`
+
+The change feed is now a `(inserted_at, id)` **keyset**, ordered `inserted_at ASC, id
+ASC`. The old `next_since` (timestamp-only) token is NOT tie-safe: audit `inserted_at`
+is `utc_datetime_usec` and a bulk `Ecto.Multi` commits multiple rows at the SAME
+microsecond, so a `since`-only follow-up (`inserted_at > next_since`) **skips** the tied
+tail (silent gap) — exactly the drift the `id` tie-break fixes. The cursor
+(`Loopctl.Audit.ChangesCursor`, `"changes_cursor"` namespace) steps PAST a specific row
+regardless of ties. `next_since` is retained in the response for back-compat only; **new
+callers MUST follow `next_cursor`.** `since` is still accepted for the first page; the
+cursor takes precedence when both are present.
+
+**No new index for the change feed.** `audit_log` is **RANGE-partitioned by
+`inserted_at`** with an existing `(tenant_id, inserted_at)` btree; the keyset seek with
+`tenant_id =` walks that index in order, with the `id` as the bounded tie-break recheck
+inside an equal-timestamp run. `CREATE INDEX CONCURRENTLY` is **not supported on a
+partitioned parent**, so a `(tenant_id, inserted_at, id)` parent index is intentionally
+NOT added — the existing index already keeps the deep page index-backed. The scale test
+asserts `refute_full_scan_audit` (no Seq Scan **and** no Bitmap Heap Scan → an ordered
+Index Scan) on the request-path `Audit.changes_keyset_query/3` at 80k. The change-feed
+read is routed through `Loopctl.HeavyRead` so it inherits the dedicated-pool
+`statement_timeout` backstop (US-27.4), same as the index keyset path.
+
+### Tenant safety on every surface
+
+The cursor is decoded/verified with the **caller's** tenant key (from the auth
+principal, never the cursor) under its surface namespace, so a forged/tampered/
+cross-tenant/cross-surface cursor is rejected with **400** — proven by the forged-cursor
+tests on each surface (`knowledge_index_keyset_controller_test.exs`,
+`change_keyset_controller_test.exs`) and the namespace-separation test
+(`keyset_cursor_test.exs`).
+
 ## Bulk write path — set-based archive/delete (US-27.12)
 
 `Loopctl.Knowledge.BulkOps` mutates a whole selected set (by ids/tag/source) in

--- a/docs/runbooks/knowledge-scale.md
+++ b/docs/runbooks/knowledge-scale.md
@@ -21,11 +21,20 @@ removes that coupling and gives US-27.4/27.6b a clean pool-level lever.
 
 ### `HEAVY_READ_POOL_SIZE` (K) — sizing rationale (AC-27.11.1)
 
-Default **8** supports **K ≈ 6** concurrent sub-2s heavy vector reads while
+Default **8** supports **K ≈ 6** concurrent sub-2s heavy reads while
 **reserving ~2 connections** for long-held **streamed-export** checkouts
 (US-27.16), which hold a connection for *minutes* — a different profile than fast
 reads. Raise it if export concurrency or heavy-read QPS grows, but only after
 re-checking the connection budget below.
+
+The fast-reads (K≈6) now serve **six** HeavyRead consumers: five ONE-SHOT heavy reads
+(`suggested_links`, `semantic_search`, `distant_pairs`, `novelty`, `enumeration`) plus
+one **rate-limited polling feed** — the US-27.9b change feed (`:change_feed`,
+`GET /changes`). The K budget is unchanged by the addition: the change-feed read is a
+single CHEAP, fast-releasing bounded keyset page (connection released immediately), and
+its poll QPS is bounded by the api pipeline's `LoopctlWeb.Plugs.RateLimiter`, so even an
+orchestrator poll storm adds only brief transient checkouts — it cannot saturate the
+fast slots or change the connection-count budget below.
 
 ### Connection budget vs. `max_connections` (AC-27.11.5)
 
@@ -225,16 +234,27 @@ regardless of ties. `next_since` is retained in the response for back-compat onl
 callers MUST follow `next_cursor`.** `since` is still accepted for the first page; the
 cursor takes precedence when both are present.
 
-**No new index for the change feed.** `audit_log` is **RANGE-partitioned by
-`inserted_at`** with an existing `(tenant_id, inserted_at)` btree; the keyset seek with
-`tenant_id =` walks that index in order, with the `id` as the bounded tie-break recheck
-inside an equal-timestamp run. `CREATE INDEX CONCURRENTLY` is **not supported on a
-partitioned parent**, so a `(tenant_id, inserted_at, id)` parent index is intentionally
-NOT added — the existing index already keeps the deep page index-backed. The scale test
-asserts `refute_full_scan_audit` (no Seq Scan **and** no Bitmap Heap Scan → an ordered
-Index Scan) on the request-path `Audit.changes_keyset_query/3` at 80k. The change-feed
-read is routed through `Loopctl.HeavyRead` so it inherits the dedicated-pool
-`statement_timeout` backstop (US-27.4), same as the index keyset path.
+**No new index for the change feed.** `audit_log` is **RANGE-partitioned by month** with
+an existing `(tenant_id, inserted_at)` btree. The keyset seek (`tenant_id =` + the
+`(inserted_at, id)` row-value comparison, `ORDER BY inserted_at, id`) plans as
+**per-partition Index Scans** (one scan per month the cursor range touches) combined
+under an ordered node. Because the index lacks `id`, the planner finishes the global
+`(inserted_at, id)` order one of two cost-equivalent ways: **Append + a top-level
+Incremental Sort** (the empirical choice at 80k — each partition is presorted on
+`inserted_at`, the incremental sort resolves the `id` tie-break within each
+equal-timestamp run) or a **Merge Append**. Either way: no Seq Scan, no Bitmap over the
+corpus — bounded by the keyset seek (~O(page)). `CREATE INDEX CONCURRENTLY` is **not
+supported on a partitioned parent**, so a `(tenant_id, inserted_at, id)` parent index is
+intentionally NOT added — the existing index already keeps the deep page index-backed
+(the `id` tie-break is a cheap incremental sort, not a corpus scan). The scale test seeds
+across **≥2 monthly partitions** (so the deep page produces a real multi-partition
+ordered scan, matching prod — not a single-partition shortcut) and asserts BOTH
+`assert_ordered_multi_partition_scan` (≥2 partitions via Index Scan under Merge
+Append/Append+Incremental-Sort) AND `refute_full_scan_audit` (no Seq Scan **and** no
+Bitmap Heap Scan) on the request-path `Audit.changes_keyset_query/3`. The change-feed read
+is routed through `Loopctl.HeavyRead` so it inherits the dedicated-pool `statement_timeout`
+backstop (US-27.4), same as the index keyset path; it is the **sixth** HeavyRead consumer
+(the rate-limited polling feed — see the HEAVY_READ_POOL_SIZE sizing note above).
 
 ### Tenant safety on every surface
 

--- a/lib/loopctl/audit.ex
+++ b/lib/loopctl/audit.ex
@@ -225,8 +225,9 @@ defmodule Loopctl.Audit do
     # same dedicated-pool statement_timeout backstop (US-27.4) the index keyset path
     # uses, instead of a bare AdminRepo.all. The HeavyRead structural tenant guard
     # accepts the query because `changes_keyset_query/3` carries an explicit
-    # `a.tenant_id == ^tenant_id` equality on the only base source.
-    results = HeavyRead.all(tenant_id, query, change_feed_heavy_read_opts())
+    # `a.tenant_id == ^tenant_id` equality on the only base source. Opts come from the
+    # single source of truth, `HeavyRead.opts/1` (shared with Knowledge — no drift).
+    results = HeavyRead.all(tenant_id, query, HeavyRead.opts(:change_feed))
 
     has_more = length(results) > limit
     entries = Enum.take(results, limit)
@@ -249,11 +250,16 @@ defmodule Loopctl.Audit do
   This is the EXACT query `list_changes/3` runs (so the plan assertion guards the
   request path). `:limit` is applied as-is here (the caller adds the `+1` peek).
 
-  Plan note (AC-27.9b.2): with `tenant_id =` plus the `(inserted_at, id)` row-value
-  seek and `ORDER BY inserted_at ASC, id ASC`, the planner reaches `audit_log` (a
-  RANGE-partitioned table) via the existing `(tenant_id, inserted_at)` btree and
-  walks it in order — index-backed, no Seq Scan over the corpus. The `id` is the
-  tie-break recheck within the bounded equal-timestamp run.
+  Plan note (AC-27.9b.2): `audit_log` is RANGE-partitioned by month, so with
+  `tenant_id =` plus the `(inserted_at, id)` row-value seek and
+  `ORDER BY inserted_at ASC, id ASC`, the planner does PER-PARTITION Index Scans on the
+  existing `(tenant_id, inserted_at)` btree, combined under either an **Append + a
+  top-level Incremental Sort** (the empirical choice at 80k — each partition is
+  presorted on `inserted_at`, the incremental sort finishes the `id` tie-break) or a
+  **Merge Append** (cost-equivalent; the index lacks `id`). No Seq Scan, no Bitmap over
+  the corpus — bounded by the keyset seek, cost ~O(page). The `:scale_nightly` plan test
+  seeds across ≥2 monthly partitions and asserts both an ordered multi-partition scan and
+  `refute_full_scan_audit` on the deep page.
   """
   @spec changes_keyset_query(Ecto.UUID.t(), DateTime.t(), keyword()) :: Ecto.Query.t()
   def changes_keyset_query(tenant_id, since, opts \\ []) do
@@ -265,25 +271,6 @@ defmodule Loopctl.Audit do
     |> apply_filters(opts)
     |> order_by([a], asc: a.inserted_at, asc: a.id)
     |> limit(^limit)
-  end
-
-  # Per-read options for the change-feed keyset (US-27.9b), mirroring
-  # Knowledge.heavy_read_opts/1: the 15s CLIENT timeout backstop plus an optional
-  # per-endpoint SERVER-SIDE statement_timeout override (config key `:change_feed`).
-  # Kept local to avoid an Audit→Knowledge module coupling for one opts helper.
-  defp change_feed_heavy_read_opts do
-    base = [timeout: 15_000, telemetry_options: [endpoint: :change_feed]]
-
-    case heavy_read_statement_timeout(:change_feed) do
-      ms when is_integer(ms) and ms > 0 -> Keyword.put(base, :statement_timeout, ms)
-      _ -> base
-    end
-  end
-
-  defp heavy_read_statement_timeout(endpoint) do
-    :loopctl
-    |> Application.get_env(:heavy_read_statement_timeout_overrides, %{})
-    |> Map.get(endpoint)
   end
 
   # First page (no cursor): seek by the `since` timestamp (back-compat). Subsequent

--- a/lib/loopctl/audit.ex
+++ b/lib/loopctl/audit.ex
@@ -42,6 +42,8 @@ defmodule Loopctl.Audit do
   alias Ecto.Multi
   alias Loopctl.AdminRepo
   alias Loopctl.Audit.AuditLog
+  alias Loopctl.HeavyRead
+  alias Loopctl.KeysetSeek
 
   @doc """
   Creates a new audit log entry within a tenant-scoped transaction.
@@ -219,7 +221,12 @@ defmodule Loopctl.Audit do
     # Fetch one extra to determine has_more (keyset peek, no COUNT — nothing to drift).
     query = changes_keyset_query(tenant_id, since, Keyword.put(opts, :limit, limit + 1))
 
-    results = AdminRepo.all(query)
+    # US-27.9b: route through Loopctl.HeavyRead so the change-feed keyset read gets the
+    # same dedicated-pool statement_timeout backstop (US-27.4) the index keyset path
+    # uses, instead of a bare AdminRepo.all. The HeavyRead structural tenant guard
+    # accepts the query because `changes_keyset_query/3` carries an explicit
+    # `a.tenant_id == ^tenant_id` equality on the only base source.
+    results = HeavyRead.all(tenant_id, query, change_feed_heavy_read_opts())
 
     has_more = length(results) > limit
     entries = Enum.take(results, limit)
@@ -260,6 +267,25 @@ defmodule Loopctl.Audit do
     |> limit(^limit)
   end
 
+  # Per-read options for the change-feed keyset (US-27.9b), mirroring
+  # Knowledge.heavy_read_opts/1: the 15s CLIENT timeout backstop plus an optional
+  # per-endpoint SERVER-SIDE statement_timeout override (config key `:change_feed`).
+  # Kept local to avoid an Audit→Knowledge module coupling for one opts helper.
+  defp change_feed_heavy_read_opts do
+    base = [timeout: 15_000, telemetry_options: [endpoint: :change_feed]]
+
+    case heavy_read_statement_timeout(:change_feed) do
+      ms when is_integer(ms) and ms > 0 -> Keyword.put(base, :statement_timeout, ms)
+      _ -> base
+    end
+  end
+
+  defp heavy_read_statement_timeout(endpoint) do
+    :loopctl
+    |> Application.get_env(:heavy_read_statement_timeout_overrides, %{})
+    |> Map.get(endpoint)
+  end
+
   # First page (no cursor): seek by the `since` timestamp (back-compat). Subsequent
   # pages: seek by the `(inserted_at, id)` keyset tuple, which steps PAST a specific
   # row regardless of how many share its timestamp (US-27.9b tie-safety). The cursor
@@ -268,22 +294,10 @@ defmodule Loopctl.Audit do
     where(query, [a], a.inserted_at > ^since)
   end
 
-  defp apply_changes_seek(query, _since, {%DateTime{} = inserted_at, id})
-       when is_binary(id) do
-    # `type/2` tells Ecto the bound params' DB types so the row-value comparison
-    # binds `id` as uuid (binary_id) and `inserted_at` as the column's type — the
-    # same shape Loopctl.Knowledge.apply_keyset_seek/2 uses for the article list.
-    where(
-      query,
-      [a],
-      fragment(
-        "(?, ?) > (?, ?)",
-        a.inserted_at,
-        a.id,
-        type(^inserted_at, a.inserted_at),
-        type(^id, a.id)
-      )
-    )
+  defp apply_changes_seek(query, _since, {%DateTime{}, id} = cursor) when is_binary(id) do
+    # The `(inserted_at, id)` row-value seek, shared with the article/index/export
+    # keysets via Loopctl.KeysetSeek (the load-bearing type/2 annotations live there).
+    KeysetSeek.after_position(query, cursor)
   end
 
   @doc """

--- a/lib/loopctl/audit.ex
+++ b/lib/loopctl/audit.ex
@@ -167,12 +167,28 @@ defmodule Loopctl.Audit do
   @doc """
   Returns audit log entries for the change feed polling endpoint.
 
-  Entries are returned in ascending order by inserted_at, capped at `limit`.
-  When more entries exist beyond the cap, `has_more` is true and `next_since`
-  contains the `inserted_at` of the last returned entry.
+  US-27.9b: this is a KEYSET enumeration on the stable unique tuple
+  `(inserted_at, id)`, ordered `inserted_at ASC, id ASC`, capped at `limit`. The
+  `id` tie-break is mandatory — audit `inserted_at` is `utc_datetime_usec` and a
+  bulk operation (an `Ecto.Multi` writing several entries) commits MULTIPLE rows at
+  the SAME microsecond, so a timestamp-only `since` token either SKIPS the tied rows
+  after a page boundary (silent gap) or RE-EMITS them (duplicate). Seeking on the
+  tuple steps PAST a specific row regardless of timestamp ties.
+
+  Two seek inputs (mutually exclusive in practice — the cursor wins when present):
+
+  - `since` — a `DateTime` start position (`inserted_at > since`). Kept for
+    back-compat with the original `?since=ISO8601` token, and used for the FIRST
+    page (the caller has no cursor yet).
+  - `:cursor` — the decoded `{inserted_at, id}` keyset position to seek AFTER
+    (`(inserted_at, id) > (^c_inserted, ^c_id)`). Supplied on subsequent pages from
+    the prior page's `next_cursor`. Drift-free across timestamp ties.
+
+  When `:cursor` is present it takes precedence over `since`.
 
   ## Options
 
+  - `:cursor` — decoded `{inserted_at, id}` keyset position (US-27.9b)
   - `:project_id` — filter by project ID
   - `:entity_type` — filter by entity type
   - `:action` — filter by action
@@ -180,36 +196,94 @@ defmodule Loopctl.Audit do
 
   ## Returns
 
-  `{:ok, %{data: [%AuditLog{}], has_more: boolean, next_since: DateTime.t() | nil}}`
+  `{:ok, %{data: [%AuditLog{}], has_more: boolean, next_since: DateTime.t() | nil,
+    next_cursor: {DateTime.t(), Ecto.UUID.t()} | nil}}`
+
+  `next_cursor` is the `(inserted_at, id)` of the last returned entry when more
+  remain, else `nil` — the drift-free continuation token. `next_since` (the last
+  entry's `inserted_at`) is retained for back-compat but is NOT tie-safe; new
+  callers should follow `next_cursor`.
   """
   @spec list_changes(Ecto.UUID.t(), DateTime.t(), keyword()) ::
-          {:ok, %{data: [AuditLog.t()], has_more: boolean(), next_since: DateTime.t() | nil}}
+          {:ok,
+           %{
+             data: [AuditLog.t()],
+             has_more: boolean(),
+             next_since: DateTime.t() | nil,
+             next_cursor: {DateTime.t(), Ecto.UUID.t()} | nil
+           }}
   def list_changes(tenant_id, since, opts \\ []) do
     default_limit = Application.get_env(:loopctl, :change_feed_limit, 1000)
     limit = opts |> Keyword.get(:limit, default_limit) |> max(1) |> min(1000)
 
-    query =
-      AuditLog
-      |> where([a], a.tenant_id == ^tenant_id)
-      |> where([a], a.inserted_at > ^since)
-      |> apply_filters(opts)
-      |> order_by([a], asc: a.inserted_at)
-      # Fetch one extra to determine has_more
-      |> limit(^(limit + 1))
+    # Fetch one extra to determine has_more (keyset peek, no COUNT — nothing to drift).
+    query = changes_keyset_query(tenant_id, since, Keyword.put(opts, :limit, limit + 1))
 
     results = AdminRepo.all(query)
 
     has_more = length(results) > limit
     entries = Enum.take(results, limit)
 
-    next_since =
+    {next_since, next_cursor} =
       if has_more do
-        entries |> List.last() |> Map.get(:inserted_at)
+        last = List.last(entries)
+        {last.inserted_at, {last.inserted_at, last.id}}
       else
-        nil
+        {nil, nil}
       end
 
-    {:ok, %{data: entries, has_more: has_more, next_since: next_since}}
+    {:ok, %{data: entries, has_more: has_more, next_since: next_since, next_cursor: next_cursor}}
+  end
+
+  @doc """
+  Builds the change-feed KEYSET seek QUERYABLE (US-27.9b), returned (not executed)
+  so the `:scale_nightly` plan test can assert it is index-backed via `EXPLAIN`.
+
+  This is the EXACT query `list_changes/3` runs (so the plan assertion guards the
+  request path). `:limit` is applied as-is here (the caller adds the `+1` peek).
+
+  Plan note (AC-27.9b.2): with `tenant_id =` plus the `(inserted_at, id)` row-value
+  seek and `ORDER BY inserted_at ASC, id ASC`, the planner reaches `audit_log` (a
+  RANGE-partitioned table) via the existing `(tenant_id, inserted_at)` btree and
+  walks it in order — index-backed, no Seq Scan over the corpus. The `id` is the
+  tie-break recheck within the bounded equal-timestamp run.
+  """
+  @spec changes_keyset_query(Ecto.UUID.t(), DateTime.t(), keyword()) :: Ecto.Query.t()
+  def changes_keyset_query(tenant_id, since, opts \\ []) do
+    limit = opts |> Keyword.get(:limit, 1000) |> max(1)
+
+    AuditLog
+    |> where([a], a.tenant_id == ^tenant_id)
+    |> apply_changes_seek(since, Keyword.get(opts, :cursor))
+    |> apply_filters(opts)
+    |> order_by([a], asc: a.inserted_at, asc: a.id)
+    |> limit(^limit)
+  end
+
+  # First page (no cursor): seek by the `since` timestamp (back-compat). Subsequent
+  # pages: seek by the `(inserted_at, id)` keyset tuple, which steps PAST a specific
+  # row regardless of how many share its timestamp (US-27.9b tie-safety). The cursor
+  # takes precedence over `since` when both are present.
+  defp apply_changes_seek(query, since, nil) do
+    where(query, [a], a.inserted_at > ^since)
+  end
+
+  defp apply_changes_seek(query, _since, {%DateTime{} = inserted_at, id})
+       when is_binary(id) do
+    # `type/2` tells Ecto the bound params' DB types so the row-value comparison
+    # binds `id` as uuid (binary_id) and `inserted_at` as the column's type — the
+    # same shape Loopctl.Knowledge.apply_keyset_seek/2 uses for the article list.
+    where(
+      query,
+      [a],
+      fragment(
+        "(?, ?) > (?, ?)",
+        a.inserted_at,
+        a.id,
+        type(^inserted_at, a.inserted_at),
+        type(^id, a.id)
+      )
+    )
   end
 
   @doc """

--- a/lib/loopctl/audit/changes_cursor.ex
+++ b/lib/loopctl/audit/changes_cursor.ex
@@ -1,0 +1,146 @@
+defmodule Loopctl.Audit.ChangesCursor do
+  @moduledoc """
+  Integrity-protected, tenant-bound keyset cursor for the change feed (US-27.9b).
+
+  The change feed (`GET /api/v1/changes`) paginates audit-log entries in ascending
+  time order. The ORIGINAL token was TIMESTAMP-ONLY (`next_since` = the last row's
+  `inserted_at`), which is NOT a sound keyset: audit `inserted_at` is
+  `utc_datetime_usec` and bulk operations (an `Ecto.Multi` writing several entries,
+  or `insert_all`) commit MULTIPLE rows at the SAME microsecond. A page boundary
+  that lands mid-tie then either SKIPS the tied rows after the boundary (the next
+  `inserted_at > ^since` excludes everything at that exact timestamp) — a silent
+  gap — or, with `>=`, RE-EMITS them — a duplicate. This is the same tie-induced
+  drift the article-list keyset (US-27.9a) fixed with an `id` tie-break.
+
+  This cursor encodes the stable unique tuple `(inserted_at, id)` so the feed seeks
+
+      WHERE tenant_id = ^tenant_id
+        AND (inserted_at, id) > (^c_inserted, ^c_id)
+      ORDER BY inserted_at ASC, id ASC
+
+  which steps PAST a specific row regardless of how many share its timestamp — no
+  skip, no duplicate.
+
+  ## Trust model (AC-27.9b.4)
+
+  Identical to `Loopctl.Knowledge.ArticleCursor` (the article-list keyset), with a
+  DISTINCT per-tenant key namespace (`:changes_cursor:`) so a change-feed cursor and
+  an article cursor are not interchangeable even within one tenant:
+
+  - It encodes ONLY an intra-tenant ordering position `(inserted_at, id)`. The
+    caller's tenant always comes from the authenticated principal — never the cursor.
+  - It is HMAC-SHA256 signed with a PER-TENANT key derived from the app
+    `secret_key_base` + the tenant_id. `decode/2` verifies with the CALLER's tenant
+    key, so a cursor minted for tenant B fails verification for tenant A.
+  - `decode/2` is DEFENSIVE: garbage, a bit-flipped signature, a tampered payload,
+    or a wrong-tenant cursor all return `{:error, :invalid}` — never a raise.
+
+  The signature is compared in constant time (`:crypto.hash_equals/2`).
+  """
+
+  @hmac_bytes 32
+
+  @typedoc "The keyset position: the `(inserted_at, id)` of an audit row in (inserted_at ASC, id ASC) order."
+  @type position :: {DateTime.t(), Ecto.UUID.t()}
+
+  @doc """
+  Encodes the keyset position `{inserted_at, id}` into an opaque cursor string.
+
+  The cursor is signed with `tenant_id`'s per-tenant key. The returned string is
+  URL-safe Base64 with no padding, so it is safe as a bare `?cursor=` query value.
+  """
+  @spec encode(Ecto.UUID.t(), position()) :: String.t()
+  def encode(tenant_id, {%DateTime{} = inserted_at, id})
+      when is_binary(tenant_id) and is_binary(id) do
+    payload = serialize(inserted_at, id)
+    sig = :crypto.mac(:hmac, :sha256, secret(tenant_id), payload)
+    Base.url_encode64(payload <> sig, padding: false)
+  end
+
+  @doc """
+  Decodes and verifies an opaque cursor, returning `{:ok, {inserted_at, id}}`.
+
+  ANY problem — malformed Base64, wrong length, signature mismatch (tampered OR a
+  wrong-tenant cursor), or an undeserializable payload — returns `{:error, :invalid}`.
+  Never raises; never leaks why it failed.
+  """
+  @spec decode(Ecto.UUID.t(), String.t()) :: {:ok, position()} | {:error, :invalid}
+  def decode(tenant_id, cursor) when is_binary(tenant_id) and is_binary(cursor) do
+    with {:ok, decoded} <- url_decode(cursor),
+         {:ok, payload, sig} <- split(decoded),
+         :ok <- verify(tenant_id, payload, sig) do
+      deserialize(payload)
+    end
+  end
+
+  def decode(_tenant_id, _cursor), do: {:error, :invalid}
+
+  # --- internals (mirror Loopctl.Knowledge.ArticleCursor verbatim) ---
+
+  defp serialize(%DateTime{} = inserted_at, id) do
+    micros = DateTime.to_unix(inserted_at, :microsecond)
+    {:ok, raw} = Ecto.UUID.dump(id)
+    :erlang.term_to_binary({:k, micros, raw})
+  end
+
+  defp deserialize(payload) do
+    case safe_binary_to_term(payload) do
+      {:k, micros, raw}
+      when is_integer(micros) and is_binary(raw) and byte_size(raw) == 16 ->
+        with {:ok, datetime} <- from_unix_micros(micros),
+             {:ok, id} <- Ecto.UUID.load(raw) do
+          {:ok, {datetime, id}}
+        else
+          _ -> {:error, :invalid}
+        end
+
+      _ ->
+        {:error, :invalid}
+    end
+  end
+
+  defp safe_binary_to_term(bin) do
+    :erlang.binary_to_term(bin, [:safe])
+  rescue
+    ArgumentError -> :error
+  end
+
+  defp from_unix_micros(micros) do
+    {:ok, DateTime.from_unix!(micros, :microsecond)}
+  rescue
+    _ -> {:error, :invalid}
+  end
+
+  defp url_decode(cursor) do
+    case Base.url_decode64(cursor, padding: false) do
+      {:ok, decoded} -> {:ok, decoded}
+      :error -> {:error, :invalid}
+    end
+  end
+
+  defp split(decoded) when byte_size(decoded) > @hmac_bytes do
+    payload_len = byte_size(decoded) - @hmac_bytes
+    <<payload::binary-size(payload_len), sig::binary-size(@hmac_bytes)>> = decoded
+    {:ok, payload, sig}
+  end
+
+  defp split(_decoded), do: {:error, :invalid}
+
+  defp verify(tenant_id, payload, sig) do
+    expected = :crypto.mac(:hmac, :sha256, secret(tenant_id), payload)
+
+    if :crypto.hash_equals(expected, sig), do: :ok, else: {:error, :invalid}
+  end
+
+  # Per-tenant HMAC key: app secret_key_base + tenant_id. The `:changes_cursor:`
+  # infix namespaces this key away from the article cursor and binds it to the
+  # tenant. FAIL CLOSED: `secret_key_base` is fetched (not defaulted).
+  defp secret(tenant_id) do
+    base =
+      :loopctl
+      |> Application.fetch_env!(LoopctlWeb.Endpoint)
+      |> Keyword.fetch!(:secret_key_base)
+
+    base <> ":changes_cursor:" <> to_string(tenant_id)
+  end
+end

--- a/lib/loopctl/audit/changes_cursor.ex
+++ b/lib/loopctl/audit/changes_cursor.ex
@@ -2,145 +2,51 @@ defmodule Loopctl.Audit.ChangesCursor do
   @moduledoc """
   Integrity-protected, tenant-bound keyset cursor for the change feed (US-27.9b).
 
+  A thin delegator over the shared `Loopctl.KeysetCursor` codec, binding the
+  `"changes_cursor"` namespace. All the security-critical logic (HMAC sign/verify,
+  constant-time comparison, defensive decode, per-tenant key derivation) lives in
+  one place; see `Loopctl.KeysetCursor` for the full trust-model documentation.
+
+  ## Why a keyset cursor (not a since-token)
+
   The change feed (`GET /api/v1/changes`) paginates audit-log entries in ascending
   time order. The ORIGINAL token was TIMESTAMP-ONLY (`next_since` = the last row's
   `inserted_at`), which is NOT a sound keyset: audit `inserted_at` is
   `utc_datetime_usec` and bulk operations (an `Ecto.Multi` writing several entries,
-  or `insert_all`) commit MULTIPLE rows at the SAME microsecond. A page boundary
-  that lands mid-tie then either SKIPS the tied rows after the boundary (the next
-  `inserted_at > ^since` excludes everything at that exact timestamp) — a silent
-  gap — or, with `>=`, RE-EMITS them — a duplicate. This is the same tie-induced
-  drift the article-list keyset (US-27.9a) fixed with an `id` tie-break.
+  or `insert_all`) commit MULTIPLE rows at the SAME microsecond. A page boundary that
+  lands mid-tie then either SKIPS the tied rows after the boundary (silent gap) or
+  RE-EMITS them (duplicate). Encoding the stable unique tuple `(inserted_at, id)`
+  steps PAST a specific row regardless of how many share its timestamp — the same
+  tie-break fix the article-list keyset (US-27.9a) introduced.
 
-  This cursor encodes the stable unique tuple `(inserted_at, id)` so the feed seeks
+  ## Namespace separation
 
-      WHERE tenant_id = ^tenant_id
-        AND (inserted_at, id) > (^c_inserted, ^c_id)
-      ORDER BY inserted_at ASC, id ASC
-
-  which steps PAST a specific row regardless of how many share its timestamp — no
-  skip, no duplicate.
-
-  ## Trust model (AC-27.9b.4)
-
-  Identical to `Loopctl.Knowledge.ArticleCursor` (the article-list keyset), with a
-  DISTINCT per-tenant key namespace (`:changes_cursor:`) so a change-feed cursor and
-  an article cursor are not interchangeable even within one tenant:
-
-  - It encodes ONLY an intra-tenant ordering position `(inserted_at, id)`. The
-    caller's tenant always comes from the authenticated principal — never the cursor.
-  - It is HMAC-SHA256 signed with a PER-TENANT key derived from the app
-    `secret_key_base` + the tenant_id. `decode/2` verifies with the CALLER's tenant
-    key, so a cursor minted for tenant B fails verification for tenant A.
-  - `decode/2` is DEFENSIVE: garbage, a bit-flipped signature, a tampered payload,
-    or a wrong-tenant cursor all return `{:error, :invalid}` — never a raise.
-
-  The signature is compared in constant time (`:crypto.hash_equals/2`).
+  The `"changes_cursor"` namespace separates these cursors from the article
+  enumerations' `"article_cursor"`: a change-feed cursor and an article cursor are
+  NOT interchangeable even within one tenant — the per-tenant HMAC key folds the
+  namespace in, so the signatures differ and a cross-surface replay fails to verify.
   """
 
-  @hmac_bytes 32
+  alias Loopctl.KeysetCursor
+
+  @namespace "changes_cursor"
 
   @typedoc "The keyset position: the `(inserted_at, id)` of an audit row in (inserted_at ASC, id ASC) order."
-  @type position :: {DateTime.t(), Ecto.UUID.t()}
+  @type position :: KeysetCursor.position()
 
   @doc """
-  Encodes the keyset position `{inserted_at, id}` into an opaque cursor string.
-
-  The cursor is signed with `tenant_id`'s per-tenant key. The returned string is
-  URL-safe Base64 with no padding, so it is safe as a bare `?cursor=` query value.
+  Encodes the keyset position `{inserted_at, id}` into an opaque, tenant-bound cursor
+  string (delegates to `Loopctl.KeysetCursor.encode/3` under the `"changes_cursor"`
+  namespace).
   """
   @spec encode(Ecto.UUID.t(), position()) :: String.t()
-  def encode(tenant_id, {%DateTime{} = inserted_at, id})
-      when is_binary(tenant_id) and is_binary(id) do
-    payload = serialize(inserted_at, id)
-    sig = :crypto.mac(:hmac, :sha256, secret(tenant_id), payload)
-    Base.url_encode64(payload <> sig, padding: false)
-  end
+  def encode(tenant_id, position), do: KeysetCursor.encode(@namespace, tenant_id, position)
 
   @doc """
-  Decodes and verifies an opaque cursor, returning `{:ok, {inserted_at, id}}`.
-
-  ANY problem — malformed Base64, wrong length, signature mismatch (tampered OR a
-  wrong-tenant cursor), or an undeserializable payload — returns `{:error, :invalid}`.
-  Never raises; never leaks why it failed.
+  Decodes and verifies an opaque cursor (delegates to `Loopctl.KeysetCursor.decode/3`
+  under the `"changes_cursor"` namespace). Returns `{:ok, {inserted_at, id}}` or
+  `{:error, :invalid}` — never raises.
   """
   @spec decode(Ecto.UUID.t(), String.t()) :: {:ok, position()} | {:error, :invalid}
-  def decode(tenant_id, cursor) when is_binary(tenant_id) and is_binary(cursor) do
-    with {:ok, decoded} <- url_decode(cursor),
-         {:ok, payload, sig} <- split(decoded),
-         :ok <- verify(tenant_id, payload, sig) do
-      deserialize(payload)
-    end
-  end
-
-  def decode(_tenant_id, _cursor), do: {:error, :invalid}
-
-  # --- internals (mirror Loopctl.Knowledge.ArticleCursor verbatim) ---
-
-  defp serialize(%DateTime{} = inserted_at, id) do
-    micros = DateTime.to_unix(inserted_at, :microsecond)
-    {:ok, raw} = Ecto.UUID.dump(id)
-    :erlang.term_to_binary({:k, micros, raw})
-  end
-
-  defp deserialize(payload) do
-    case safe_binary_to_term(payload) do
-      {:k, micros, raw}
-      when is_integer(micros) and is_binary(raw) and byte_size(raw) == 16 ->
-        with {:ok, datetime} <- from_unix_micros(micros),
-             {:ok, id} <- Ecto.UUID.load(raw) do
-          {:ok, {datetime, id}}
-        else
-          _ -> {:error, :invalid}
-        end
-
-      _ ->
-        {:error, :invalid}
-    end
-  end
-
-  defp safe_binary_to_term(bin) do
-    :erlang.binary_to_term(bin, [:safe])
-  rescue
-    ArgumentError -> :error
-  end
-
-  defp from_unix_micros(micros) do
-    {:ok, DateTime.from_unix!(micros, :microsecond)}
-  rescue
-    _ -> {:error, :invalid}
-  end
-
-  defp url_decode(cursor) do
-    case Base.url_decode64(cursor, padding: false) do
-      {:ok, decoded} -> {:ok, decoded}
-      :error -> {:error, :invalid}
-    end
-  end
-
-  defp split(decoded) when byte_size(decoded) > @hmac_bytes do
-    payload_len = byte_size(decoded) - @hmac_bytes
-    <<payload::binary-size(payload_len), sig::binary-size(@hmac_bytes)>> = decoded
-    {:ok, payload, sig}
-  end
-
-  defp split(_decoded), do: {:error, :invalid}
-
-  defp verify(tenant_id, payload, sig) do
-    expected = :crypto.mac(:hmac, :sha256, secret(tenant_id), payload)
-
-    if :crypto.hash_equals(expected, sig), do: :ok, else: {:error, :invalid}
-  end
-
-  # Per-tenant HMAC key: app secret_key_base + tenant_id. The `:changes_cursor:`
-  # infix namespaces this key away from the article cursor and binds it to the
-  # tenant. FAIL CLOSED: `secret_key_base` is fetched (not defaulted).
-  defp secret(tenant_id) do
-    base =
-      :loopctl
-      |> Application.fetch_env!(LoopctlWeb.Endpoint)
-      |> Keyword.fetch!(:secret_key_base)
-
-    base <> ":changes_cursor:" <> to_string(tenant_id)
-  end
+  def decode(tenant_id, cursor), do: KeysetCursor.decode(@namespace, tenant_id, cursor)
 end

--- a/lib/loopctl/db_capacity.ex
+++ b/lib/loopctl/db_capacity.ex
@@ -23,8 +23,16 @@ defmodule Loopctl.DbCapacity do
   # Production default pool sizes = the env-var defaults in config/runtime.exs.
   @prod_pool_sizes %{repo: 10, admin_repo: 3, heavy_read_repo: 8}
 
-  # HEAVY_READ_POOL_SIZE (K) splits into fast sub-2s vector reads + a reserve for
-  # long-held streamed-export checkouts (US-27.16). fast + reserve == the pool size.
+  # HEAVY_READ_POOL_SIZE (K) splits into fast sub-2s reads + a reserve for long-held
+  # streamed-export checkouts (US-27.16). fast + reserve == the pool size.
+  #
+  # The fast-reads budget (K≈6) serves the heavy-read consumers: 5 ONE-SHOT heavy reads
+  # (suggested_links, semantic_search, distant_pairs, novelty, enumeration) PLUS one
+  # rate-limited POLLING feed — the US-27.9b change feed (`:change_feed`). The K
+  # rationale still holds with the polling addition because the change-feed read is a
+  # CHEAP, fast-releasing bounded keyset page (one read per request, connection RELEASED
+  # immediately) AND its QPS is capped by the api pipeline's rate limiter, so even a poll
+  # storm cannot saturate the fast slots — it adds at most a brief transient checkout.
   @heavy_read_fast_reads 6
   @heavy_read_export_reserve 2
 

--- a/lib/loopctl/heavy_read.ex
+++ b/lib/loopctl/heavy_read.ex
@@ -57,6 +57,36 @@ defmodule Loopctl.HeavyRead do
   def repo, do: Application.get_env(:loopctl, :heavy_read_repo, Loopctl.HeavyReadRepo)
 
   @doc """
+  Per-read options for a heavy endpoint (US-27.4): the 15s CLIENT timeout backstop plus
+  an optional per-endpoint SERVER-SIDE `:statement_timeout` override (config
+  `:heavy_read_statement_timeout_overrides`, e.g. `%{suggested_links: 5_000}`). When no
+  override is configured the read uses the pool-level statement_timeout (the default
+  path, no per-request transaction). Also passes the endpoint key via
+  `telemetry_options` so slow-query logs can trace which endpoint triggered the query.
+
+  This is the SINGLE source of truth for heavy-read opts — every consumer
+  (`Loopctl.Knowledge`, `Loopctl.Audit`) builds opts via this function so the
+  `[timeout, telemetry_options, statement_timeout]` shape can't drift between callers.
+  Known endpoints: `:suggested_links`, `:semantic_search`, `:distant_pairs`, `:novelty`,
+  `:enumeration`, `:change_feed`.
+  """
+  @spec opts(atom()) :: keyword()
+  def opts(endpoint) when is_atom(endpoint) do
+    base = [timeout: 15_000, telemetry_options: [endpoint: endpoint]]
+
+    case statement_timeout_override(endpoint) do
+      ms when is_integer(ms) and ms > 0 -> Keyword.put(base, :statement_timeout, ms)
+      _ -> base
+    end
+  end
+
+  defp statement_timeout_override(endpoint) do
+    :loopctl
+    |> Application.get_env(:heavy_read_statement_timeout_overrides, %{})
+    |> Map.get(endpoint)
+  end
+
+  @doc """
   Like `Repo.all/2`, but requires a `tenant_id` and a query whose every base-table
   source is scoped to it. Raises `ArgumentError` otherwise.
 

--- a/lib/loopctl/index_health.ex
+++ b/lib/loopctl/index_health.ex
@@ -73,13 +73,20 @@ defmodule Loopctl.IndexHealth do
   # :valid | :invalid | :missing — via pg_index.indisvalid (the catalog truth).
   @spec index_validity(String.t()) :: :valid | :invalid | :missing
   def index_validity(name) when is_binary(name) do
+    # Scope to ACTUAL indexes (`relkind = 'i'`) in the `public` schema so an unrelated
+    # object (a table/view/sequence, or a same-named index in another schema) can't
+    # produce a >1-row result → MatchError → "boot check skipped" masking the real
+    # probe. An index name is unique within a schema, so this returns exactly 0 or 1 row.
     %{rows: rows} =
       AdminRepo.query!(
         """
         SELECT i.indisvalid
         FROM pg_class c
         JOIN pg_index i ON i.indexrelid = c.oid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
         WHERE c.relname = $1
+          AND c.relkind = 'i'
+          AND n.nspname = 'public'
         """,
         [name]
       )

--- a/lib/loopctl/index_health.ex
+++ b/lib/loopctl/index_health.ex
@@ -23,7 +23,8 @@ defmodule Loopctl.IndexHealth do
   # Indexes whose absence/invalidity silently degrades a hot path to a Seq Scan.
   # Add to this list whenever a new CONCURRENTLY-built index becomes load-bearing.
   @critical_indexes [
-    {"articles_tenant_inserted_id_idx", "US-27.9a article keyset pagination"}
+    {"articles_tenant_inserted_id_idx", "US-27.9a article keyset pagination"},
+    {"articles_tenant_source_inserted_id_idx", "US-27.9b by-source keyset pagination"}
   ]
 
   @doc """

--- a/lib/loopctl/keyset_cursor.ex
+++ b/lib/loopctl/keyset_cursor.ex
@@ -1,0 +1,171 @@
+defmodule Loopctl.KeysetCursor do
+  @moduledoc """
+  Shared, integrity-protected, tenant-bound keyset cursor codec (US-27.9a / US-27.9b).
+
+  This is the SINGLE implementation of the security-critical cursor codec used by
+  every keyset enumeration in loopctl. Each enumeration binds its own `namespace`
+  (e.g. `"article_cursor"`, `"changes_cursor"`) so a cursor minted for one surface
+  CANNOT be replayed against another — the per-tenant HMAC key derivation folds the
+  namespace in, so the signatures differ even for the same tenant + position. Thin
+  per-surface delegators (`Loopctl.Knowledge.ArticleCursor`,
+  `Loopctl.Audit.ChangesCursor`) bind their namespace and forward here.
+
+  A keyset position is the stable unique tuple `(inserted_at, id)`. The `id`
+  tie-break is mandatory: `inserted_at` is `utc_datetime_usec` and bulk
+  `insert_all` / `Ecto.Multi` ties timestamps, so `inserted_at` alone is NOT unique
+  and a page boundary could skip or duplicate tied rows. This module turns that
+  ordering position into an opaque string the caller hands back as `?cursor=`, and
+  turns it back into the tuple on the next request.
+
+  ## Trust model (AC-27.9a.3/.4, AC-27.9b.4)
+
+  A Base64 blob is **encoding, not integrity** — a caller can flip bits or forge a
+  payload. So the cursor is treated as untrusted input:
+
+  - It encodes ONLY an intra-tenant ordering position `(inserted_at, id)`. It does
+    NOT carry the tenant_id as a trust input — the caller's tenant always comes from
+    the authenticated principal (`conn.assigns`), never from the cursor.
+  - It is HMAC-SHA256 signed with a PER-TENANT, PER-NAMESPACE key derived from the
+    app `secret_key_base` + the namespace + the tenant_id. `decode/3` verifies with
+    the CALLER's tenant key under the SAME namespace, so a cursor minted for tenant B
+    (or for a different namespace) fails verification — it can neither cross tenants
+    nor cross enumeration surfaces, nor become an existence oracle for another
+    tenant's rows.
+  - `decode/3` is DEFENSIVE: garbage, a bit-flipped signature, a tampered payload, a
+    wrong-tenant cursor, or a wrong-namespace cursor all return `{:error, :invalid}`
+    — never a raise, and never a partial/ambiguous result the caller could probe with.
+
+  The signature is compared in constant time (`:crypto.hash_equals/2`) so the cursor
+  can't be brute-forced one byte at a time via timing.
+  """
+
+  @hmac_bytes 32
+
+  @typedoc "The keyset position: the `(inserted_at, id)` of a row in (inserted_at ASC, id ASC) order."
+  @type position :: {DateTime.t(), Ecto.UUID.t()}
+
+  @doc """
+  Encodes the keyset position `{inserted_at, id}` into an opaque cursor string,
+  signed with `namespace`'s per-tenant key.
+
+  The returned string is URL-safe Base64 with no padding, so it is safe as a bare
+  `?cursor=` query value.
+  """
+  @spec encode(String.t(), Ecto.UUID.t(), position()) :: String.t()
+  def encode(namespace, tenant_id, {%DateTime{} = inserted_at, id})
+      when is_binary(namespace) and is_binary(tenant_id) and is_binary(id) do
+    payload = serialize(inserted_at, id)
+    sig = :crypto.mac(:hmac, :sha256, secret(namespace, tenant_id), payload)
+    Base.url_encode64(payload <> sig, padding: false)
+  end
+
+  @doc """
+  Decodes and verifies an opaque cursor, returning `{:ok, {inserted_at, id}}`.
+
+  Verifies the HMAC with `namespace`'s per-tenant key. ANY problem — malformed
+  Base64, wrong length, signature mismatch (tampered payload, a cursor signed for a
+  different tenant, OR a cursor signed for a different namespace), or an
+  undeserializable payload — returns `{:error, :invalid}`. Never raises; never leaks
+  why it failed.
+  """
+  @spec decode(String.t(), Ecto.UUID.t(), String.t()) :: {:ok, position()} | {:error, :invalid}
+  def decode(namespace, tenant_id, cursor)
+      when is_binary(namespace) and is_binary(tenant_id) and is_binary(cursor) do
+    with {:ok, decoded} <- url_decode(cursor),
+         {:ok, payload, sig} <- split(decoded),
+         :ok <- verify(namespace, tenant_id, payload, sig) do
+      deserialize(payload)
+    end
+  end
+
+  def decode(_namespace, _tenant_id, _cursor), do: {:error, :invalid}
+
+  # --- internals ---
+
+  # Canonical, fixed-shape payload: a tagged 2-tuple of the inserted_at in integer
+  # microseconds (so the value is exact and order-preserving) and the raw 16-byte
+  # UUID. term_to_binary is compact and round-trips precisely; we never call
+  # binary_to_term WITHOUT [:safe] and we re-validate the shape, so a forged payload
+  # can't deserialize into anything dangerous.
+  defp serialize(%DateTime{} = inserted_at, id) do
+    micros = DateTime.to_unix(inserted_at, :microsecond)
+    {:ok, raw} = Ecto.UUID.dump(id)
+    :erlang.term_to_binary({:k, micros, raw})
+  end
+
+  defp deserialize(payload) do
+    case safe_binary_to_term(payload) do
+      {:k, micros, raw}
+      when is_integer(micros) and is_binary(raw) and byte_size(raw) == 16 ->
+        with {:ok, datetime} <- from_unix_micros(micros),
+             {:ok, id} <- Ecto.UUID.load(raw) do
+          {:ok, {datetime, id}}
+        else
+          _ -> {:error, :invalid}
+        end
+
+      _ ->
+        {:error, :invalid}
+    end
+  end
+
+  # binary_to_term/2 with [:safe] still raises on a non-term binary, so guard it.
+  defp safe_binary_to_term(bin) do
+    :erlang.binary_to_term(bin, [:safe])
+  rescue
+    ArgumentError -> :error
+  end
+
+  defp from_unix_micros(micros) do
+    {:ok, DateTime.from_unix!(micros, :microsecond)}
+  rescue
+    _ -> {:error, :invalid}
+  end
+
+  defp url_decode(cursor) do
+    case Base.url_decode64(cursor, padding: false) do
+      {:ok, decoded} -> {:ok, decoded}
+      :error -> {:error, :invalid}
+    end
+  end
+
+  # The trailing @hmac_bytes are the signature; everything before is the payload.
+  defp split(decoded) when byte_size(decoded) > @hmac_bytes do
+    payload_len = byte_size(decoded) - @hmac_bytes
+    <<payload::binary-size(payload_len), sig::binary-size(@hmac_bytes)>> = decoded
+    {:ok, payload, sig}
+  end
+
+  defp split(_decoded), do: {:error, :invalid}
+
+  defp verify(namespace, tenant_id, payload, sig) do
+    expected = :crypto.mac(:hmac, :sha256, secret(namespace, tenant_id), payload)
+
+    if :crypto.hash_equals(expected, sig), do: :ok, else: {:error, :invalid}
+  end
+
+  # Per-tenant, per-namespace HMAC key: app secret_key_base + namespace + tenant_id.
+  # Stable across nodes without storing a per-tenant secret. Mirrors
+  # BulkOps.confirm_secret/1.
+  #
+  # FAIL CLOSED: `secret_key_base` is fetched (not defaulted). If it were ever absent,
+  # signing with a guessable constant would silently defeat the entire
+  # tenant-binding/forgery guarantee (a known key + a non-secret tenant_id = a
+  # forgeable cursor); raising instead is the safe failure. `runtime.exs` already
+  # requires SECRET_KEY_BASE in prod and the test/dev configs set it, so this raise is
+  # unreachable in every real environment — it is a guard, not a path.
+  #
+  # The `:<namespace>:` infix namespaces this key away from BulkOps.confirm_secret/1
+  # AND from other cursor namespaces, and binds it to the tenant. `tenant_id` is an
+  # Ecto `binary_id` (a canonical UUID), which cannot contain the `:` delimiter, so no
+  # two distinct tenants can derive the same key string — no cross-tenant collision.
+  # Distinct namespaces likewise derive distinct keys — no cross-surface replay.
+  defp secret(namespace, tenant_id) do
+    base =
+      :loopctl
+      |> Application.fetch_env!(LoopctlWeb.Endpoint)
+      |> Keyword.fetch!(:secret_key_base)
+
+    base <> ":" <> namespace <> ":" <> to_string(tenant_id)
+  end
+end

--- a/lib/loopctl/keyset_seek.ex
+++ b/lib/loopctl/keyset_seek.ex
@@ -1,0 +1,43 @@
+defmodule Loopctl.KeysetSeek do
+  @moduledoc """
+  Shared keyset SEEK builder for `(inserted_at, id)` row-value pagination
+  (US-27.9a / US-27.9b).
+
+  Every keyset enumeration (`Loopctl.Knowledge` article list + index, `Loopctl.Audit`
+  change feed, `Loopctl.Knowledge.StreamingExport`) seeks PAST a cursor position with
+  the SAME row-value comparison. Centralizing it here keeps the load-bearing `type/2`
+  annotations in ONE place: a raw `fragment` row-value comparison would otherwise send
+  `id` as text and `inserted_at` without the column's type, which Postgrex rejects
+  (`id` is `binary_id` / uuid). The `type(^bound, a.field)` calls tell Ecto the bound
+  params' DB types so the composite `(tenant_id, inserted_at, id)` btree serves the
+  seek directly.
+
+  The query's binding must expose `inserted_at` and `id` on its FIRST positional
+  binding (`[a]`) — every caller's base query is `from(a in Schema, ...)`, so this
+  holds.
+  """
+
+  import Ecto.Query
+
+  @doc """
+  Adds the keyset seek `WHERE (inserted_at, id) > (^cursor_inserted_at, ^cursor_id)`
+  to `query` for the given `(inserted_at, id)` cursor position. With `nil` (no
+  cursor), returns the query unchanged (enumerate from the start).
+  """
+  @spec after_position(Ecto.Query.t(), {DateTime.t(), Ecto.UUID.t()} | nil) :: Ecto.Query.t()
+  def after_position(query, nil), do: query
+
+  def after_position(query, {%DateTime{} = inserted_at, id}) when is_binary(id) do
+    where(
+      query,
+      [a],
+      fragment(
+        "(?, ?) > (?, ?)",
+        a.inserted_at,
+        a.id,
+        type(^inserted_at, a.inserted_at),
+        type(^id, a.id)
+      )
+    )
+  end
+end

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -813,6 +813,8 @@ defmodule Loopctl.Knowledge do
       base
       |> maybe_filter_by_category(Keyword.get(opts, :category))
       |> maybe_filter_by_tags(Keyword.get(opts, :tags), Keyword.get(opts, :match, :any))
+      |> maybe_filter_by_source_type(Keyword.get(opts, :source_type))
+      |> maybe_filter_by_source_id(Keyword.get(opts, :source_id))
       |> maybe_filter_by_visibility(Keyword.get(opts, :visibility_agent_id))
 
     total_count = AdminRepo.aggregate(base, :count, :id)
@@ -861,6 +863,148 @@ defmodule Loopctl.Knowledge do
          truncated: truncated
        }
      }}
+  end
+
+  @doc """
+  KEYSET (cursor) enumeration of the knowledge index (US-27.9b).
+
+  The drift-free companion to `list_index/2`, applying the SAME index filters
+  (`:project_id`, `:category`, `:tags` + `:match`, `:source_type`, `:source_id`,
+  visibility) but seeking on the stable unique tuple `(inserted_at, id)` instead
+  of `OFFSET`. The live offset-drift incident (#175) was a by-TAG walk on this
+  surface (a tag count swung 9,881 → 4,981 mid-enumeration), so this rolls the
+  proven US-27.9a keyset mechanic onto the index's by-tag/by-source enumerations:
+
+      WHERE tenant_id = ^tenant_id
+        AND status = :published
+        AND (project_id IS NULL OR project_id = ^project_id)   -- when project-scoped
+        AND <category/tags/source_type/source_id/visibility residuals>
+        AND (cursor? -> (inserted_at, id) > (^c_inserted, ^c_id))
+      ORDER BY inserted_at ASC, id ASC
+      LIMIT ^(limit + 1)
+
+  The `id` tie-break is mandatory (`inserted_at` is `utc_datetime_usec` and bulk
+  `insert_all` ties timestamps per batch). The `limit + 1` peek tells us whether a
+  next page exists WITHOUT a `COUNT` — so there is no count to drift either.
+
+  Tenant scope comes from `tenant_id` (the caller's authenticated principal),
+  NEVER from the cursor. The cursor (the same `Loopctl.Knowledge.ArticleCursor`
+  the article-list keyset uses, verbatim) encodes only the intra-tenant ordering
+  position and is decoded/verified at the HTTP layer.
+
+  Unlike `list_keyset/2` (the search-list keyset), this path:
+
+  - forces `status = :published` (the index is published-only) and supports the
+    `(project_id IS NULL OR = project)` tenant-wide-plus-project visibility, and
+  - APPLIES the `:source_type`/`:source_id` filters (the by-source enumeration —
+    the search-list keyset did not need them). by-source is a selective scalar
+    equality, served index-backed at scale by `articles_tenant_source_inserted_id_idx`
+    (see the `:scale_nightly` plan test), with the `(tenant_id, inserted_at, id)`
+    btree as the residual-free fallback.
+
+  ## Parameters
+
+  - `tenant_id` -- the tenant UUID (from the auth principal)
+  - `opts` -- keyword list:
+    - `:cursor` -- the decoded `{inserted_at, id}` position to seek AFTER, or
+      `nil`/absent to start from the beginning
+    - `:limit` -- max results per page (default 20, max #{@max_page_size}, min 1);
+      clamped here as a safety net, the HTTP layer 400s an over-large request
+    - `:project_id`, `:category`, `:tags`, `:match`, `:source_type`, `:source_id`,
+      `:visibility_agent_id` -- same filters as `list_index/2`
+
+  ## Returns
+
+  - `{:ok, %{results: [map()], next_cursor: position_or_nil, has_more: bool,
+    limit: effective_limit}}` where `next_cursor` is the `(inserted_at, id)` tuple
+    of the LAST returned row when another page exists, else `nil`. `has_more` is
+    exactly `next_cursor != nil`, never a COUNT.
+  """
+  @spec list_index_keyset(Ecto.UUID.t(), keyword()) ::
+          {:ok,
+           %{
+             results: [map()],
+             next_cursor: {DateTime.t(), Ecto.UUID.t()} | nil,
+             has_more: boolean(),
+             limit: pos_integer()
+           }}
+  def list_index_keyset(tenant_id, opts \\ []) do
+    limit = opts |> Keyword.get(:limit, @default_page_size) |> max(1) |> min(@max_page_size)
+
+    # Fetch limit+1 to detect a next page without a COUNT (AC-27.9b.1).
+    rows =
+      tenant_id
+      |> index_keyset_query(Keyword.put(opts, :limit, limit + 1))
+      |> then(&HeavyRead.all(tenant_id, &1, heavy_read_opts(:enumeration)))
+
+    {page, has_more?} = split_peek(rows, limit)
+    next_cursor = keyset_next_cursor(page, has_more?)
+
+    {:ok,
+     %{
+       results: page,
+       next_cursor: next_cursor,
+       has_more: has_more?,
+       limit: limit
+     }}
+  end
+
+  @doc """
+  Builds the index KEYSET seek QUERYABLE (US-27.9b), returned (not executed) so
+  the `:scale_nightly` plan test can assert it is index-backed via `EXPLAIN`.
+
+  This is the EXACT query `list_index_keyset/2` runs (so the plan assertion guards
+  the request path, not a stunt double). Same `opts` as `list_index_keyset/2`;
+  `:limit` is applied as-is (the caller adds the `+1` peek).
+
+  Plan note (AC-27.9b.2):
+
+  - With no filter or a scalar `:category` residual the planner walks the
+    `(tenant_id, inserted_at, id)` btree in order — true keyset, no Sort.
+  - With `:source_id` (selective scalar equality) the planner uses the
+    `(tenant_id, source_id, inserted_at, id)` composite btree, walking it in
+    `(inserted_at, id)` order for that source — strictly index-ordered, no Sort.
+  - With a `:tags` (array `&&`) residual the planner BitmapAnds the tags GIN with
+    the keyset btree and Sorts — bounded by tag selectivity, NOT the corpus (the
+    same bounded path US-27.9a already proved; no single index can serve both array
+    containment and the order key).
+  """
+  @spec index_keyset_query(Ecto.UUID.t(), keyword()) :: Ecto.Query.t()
+  def index_keyset_query(tenant_id, opts \\ []) do
+    limit = opts |> Keyword.get(:limit, @default_page_size + 1) |> max(1)
+    project_id = Keyword.get(opts, :project_id)
+
+    base =
+      from(a in Article,
+        where: a.tenant_id == ^tenant_id,
+        where: a.status == :published
+      )
+
+    base =
+      if project_id do
+        where(base, [a], is_nil(a.project_id) or a.project_id == ^project_id)
+      else
+        base
+      end
+
+    base
+    |> maybe_filter_by_category(Keyword.get(opts, :category))
+    |> maybe_filter_by_tags(Keyword.get(opts, :tags), Keyword.get(opts, :match, :any))
+    |> maybe_filter_by_source_type(Keyword.get(opts, :source_type))
+    |> maybe_filter_by_source_id(Keyword.get(opts, :source_id))
+    |> maybe_filter_by_visibility(Keyword.get(opts, :visibility_agent_id))
+    |> apply_keyset_seek(Keyword.get(opts, :cursor))
+    |> select([a], %{
+      id: a.id,
+      title: a.title,
+      category: a.category,
+      tags: a.tags,
+      status: a.status,
+      updated_at: a.updated_at,
+      inserted_at: a.inserted_at
+    })
+    |> order_by([a], asc: a.inserted_at, asc: a.id)
+    |> limit(^limit)
   end
 
   @doc """

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -3170,28 +3170,11 @@ defmodule Loopctl.Knowledge do
   end
 
   @doc false
-  # Per-read options for a heavy endpoint (US-27.4): the 15s CLIENT timeout backstop
-  # plus an optional per-endpoint SERVER-SIDE statement_timeout override (config
-  # `:heavy_read_statement_timeout_overrides`, e.g. `%{suggested_links: 5_000}`). When
-  # no override is configured the read uses the pool-level statement_timeout (the
-  # default path, no per-request transaction). Also passes the endpoint key via
-  # telemetry_options so slow-query logs can trace which endpoint triggered the query.
-  # Public-but-`@doc false` so the slow-query telemetry test can exercise the real
-  # opts-building path (incl. the override branch).
-  def heavy_read_opts(endpoint) do
-    base = [timeout: 15_000, telemetry_options: [endpoint: endpoint]]
-
-    case heavy_read_statement_timeout(endpoint) do
-      ms when is_integer(ms) and ms > 0 -> Keyword.put(base, :statement_timeout, ms)
-      _ -> base
-    end
-  end
-
-  defp heavy_read_statement_timeout(endpoint) do
-    :loopctl
-    |> Application.get_env(:heavy_read_statement_timeout_overrides, %{})
-    |> Map.get(endpoint)
-  end
+  # Per-read options for a heavy endpoint (US-27.4). Delegates to the single source of
+  # truth, `Loopctl.HeavyRead.opts/1`, so the opts shape can't drift between callers
+  # (Knowledge / Audit). Public-but-`@doc false` so the slow-query telemetry test can
+  # exercise the real opts-building path (incl. the override branch) through this name.
+  def heavy_read_opts(endpoint), do: HeavyRead.opts(endpoint)
 
   # Builds the suggested-links candidate query (returned, not executed) so a test can
   # assert its SQL shape. Public-but-`@doc false` for that structural regression guard.

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -44,6 +44,7 @@ defmodule Loopctl.Knowledge do
   alias Loopctl.AdminRepo
   alias Loopctl.Audit
   alias Loopctl.HeavyRead
+  alias Loopctl.KeysetSeek
   alias Loopctl.Knowledge.Analytics
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.ArticleLink
@@ -1879,28 +1880,12 @@ defmodule Loopctl.Knowledge do
     })
   end
 
-  # No cursor: enumerate from the start.
-  defp apply_keyset_seek(query, nil), do: query
-
-  # Row-value comparison `(inserted_at, id) > (^ins, ^id)`: the standard keyset
-  # seek that the composite (tenant_id, inserted_at, id) btree serves directly.
-  defp apply_keyset_seek(query, {%DateTime{} = inserted_at, id})
-       when is_binary(id) do
-    # `type/2` tells Ecto the bound params' DB types: the raw `fragment` row-value
-    # comparison would otherwise send `id` as text and `inserted_at` without the
-    # column's type, which Postgrex rejects (id is binary_id / uuid).
-    where(
-      query,
-      [a],
-      fragment(
-        "(?, ?) > (?, ?)",
-        a.inserted_at,
-        a.id,
-        type(^inserted_at, a.inserted_at),
-        type(^id, a.id)
-      )
-    )
-  end
+  # Row-value comparison `(inserted_at, id) > (^ins, ^id)`: the standard keyset seek
+  # that the composite (tenant_id, inserted_at, id) btree serves directly. Shared with
+  # the index / change-feed / streaming-export keysets via Loopctl.KeysetSeek (the
+  # load-bearing type/2 annotations live there, in ONE place). `nil` cursor →
+  # enumerate from the start.
+  defp apply_keyset_seek(query, cursor), do: KeysetSeek.after_position(query, cursor)
 
   # Split limit+1 peek rows into the page (≤ limit) and whether more remain.
   defp split_peek(rows, limit) do

--- a/lib/loopctl/knowledge/article_cursor.ex
+++ b/lib/loopctl/knowledge/article_cursor.ex
@@ -1,157 +1,38 @@
 defmodule Loopctl.Knowledge.ArticleCursor do
   @moduledoc """
-  Integrity-protected, tenant-bound keyset cursor for the article list (US-27.9a).
+  Integrity-protected, tenant-bound keyset cursor for the article list / index
+  enumerations (US-27.9a, US-27.9b).
 
-  The article list paginates by the stable unique tuple `(inserted_at, id)` (the
-  `id` tie-break is mandatory: `inserted_at` is `utc_datetime_usec` and bulk
-  `insert_all` ties timestamps per batch, so `inserted_at` alone is NOT unique).
-  This module turns that ordering position into an opaque string the caller hands
-  back as `?cursor=`, and turns it back into the tuple on the next request.
+  A thin delegator over the shared `Loopctl.KeysetCursor` codec, binding the
+  `"article_cursor"` namespace. All the security-critical logic (HMAC sign/verify,
+  constant-time comparison, defensive decode, per-tenant key derivation) lives in
+  one place; see `Loopctl.KeysetCursor` for the full trust-model documentation.
 
-  ## Trust model (AC-27.9a.3 / .4)
-
-  A Base64 blob is **encoding, not integrity** — a caller can flip bits or forge a
-  payload. So the cursor is treated as untrusted input:
-
-  - It encodes ONLY an intra-tenant ordering position `(inserted_at, id)`. It does
-    NOT carry the tenant_id as a trust input — the caller's tenant always comes
-    from the authenticated principal (`conn.assigns`), never from the cursor.
-  - It is HMAC-SHA256 signed with a PER-TENANT key derived from the app
-    `secret_key_base` + the tenant_id (same server-minted scheme as
-    `Loopctl.Knowledge.BulkOps.confirm_hash/2`). `decode/2` verifies with the
-    CALLER's tenant key, so a cursor minted for tenant B fails verification for
-    tenant A — it can neither cross tenants nor become an existence oracle for
-    another tenant's rows.
-  - `decode/2` is DEFENSIVE: garbage, a bit-flipped signature, a tampered payload,
-    or a wrong-tenant cursor all return `{:error, :invalid}` — never a raise, and
-    never a partial/ambiguous result the caller could probe with.
-
-  The signature is compared in constant time (`:crypto.hash_equals/2`) so the
-  cursor can't be brute-forced one byte at a time via timing.
+  The `"article_cursor"` namespace separates these cursors from other keyset
+  surfaces (e.g. the change feed's `"changes_cursor"`): a cursor minted here cannot
+  be replayed against another enumeration, even within the same tenant.
   """
 
-  @hmac_bytes 32
+  alias Loopctl.KeysetCursor
+
+  @namespace "article_cursor"
 
   @typedoc "The keyset position: the `(inserted_at, id)` of a row in (inserted_at ASC, id ASC) order."
-  @type position :: {DateTime.t(), Ecto.UUID.t()}
+  @type position :: KeysetCursor.position()
 
   @doc """
-  Encodes the keyset position `{inserted_at, id}` into an opaque cursor string.
-
-  The cursor is signed with `tenant_id`'s per-tenant key. The returned string is
-  URL-safe Base64 with no padding, so it is safe as a bare `?cursor=` query value.
+  Encodes the keyset position `{inserted_at, id}` into an opaque, tenant-bound cursor
+  string (delegates to `Loopctl.KeysetCursor.encode/3` under the `"article_cursor"`
+  namespace).
   """
   @spec encode(Ecto.UUID.t(), position()) :: String.t()
-  def encode(tenant_id, {%DateTime{} = inserted_at, id})
-      when is_binary(tenant_id) and is_binary(id) do
-    payload = serialize(inserted_at, id)
-    sig = :crypto.mac(:hmac, :sha256, secret(tenant_id), payload)
-    Base.url_encode64(payload <> sig, padding: false)
-  end
+  def encode(tenant_id, position), do: KeysetCursor.encode(@namespace, tenant_id, position)
 
   @doc """
-  Decodes and verifies an opaque cursor, returning `{:ok, {inserted_at, id}}`.
-
-  Verifies the HMAC with `tenant_id`'s per-tenant key. ANY problem — malformed
-  Base64, wrong length, signature mismatch (tampered payload OR a cursor signed
-  for a different tenant), or an undeserializable payload — returns
-  `{:error, :invalid}`. Never raises; never leaks why it failed.
+  Decodes and verifies an opaque cursor (delegates to `Loopctl.KeysetCursor.decode/3`
+  under the `"article_cursor"` namespace). Returns `{:ok, {inserted_at, id}}` or
+  `{:error, :invalid}` — never raises.
   """
   @spec decode(Ecto.UUID.t(), String.t()) :: {:ok, position()} | {:error, :invalid}
-  def decode(tenant_id, cursor) when is_binary(tenant_id) and is_binary(cursor) do
-    with {:ok, decoded} <- url_decode(cursor),
-         {:ok, payload, sig} <- split(decoded),
-         :ok <- verify(tenant_id, payload, sig) do
-      deserialize(payload)
-    end
-  end
-
-  def decode(_tenant_id, _cursor), do: {:error, :invalid}
-
-  # --- internals ---
-
-  # Canonical, fixed-shape payload: a tagged 2-tuple of the inserted_at in
-  # integer microseconds (so the value is exact and order-preserving) and the
-  # raw 16-byte UUID. term_to_binary is compact and round-trips precisely; we
-  # never call binary_to_term WITHOUT [:safe] and we re-validate the shape, so a
-  # forged payload can't deserialize into anything dangerous.
-  defp serialize(%DateTime{} = inserted_at, id) do
-    micros = DateTime.to_unix(inserted_at, :microsecond)
-    {:ok, raw} = Ecto.UUID.dump(id)
-    :erlang.term_to_binary({:k, micros, raw})
-  end
-
-  defp deserialize(payload) do
-    case safe_binary_to_term(payload) do
-      {:k, micros, raw}
-      when is_integer(micros) and is_binary(raw) and byte_size(raw) == 16 ->
-        with {:ok, datetime} <- from_unix_micros(micros),
-             {:ok, id} <- Ecto.UUID.load(raw) do
-          {:ok, {datetime, id}}
-        else
-          _ -> {:error, :invalid}
-        end
-
-      _ ->
-        {:error, :invalid}
-    end
-  end
-
-  # binary_to_term/2 with [:safe] still raises on a non-term binary, so guard it.
-  defp safe_binary_to_term(bin) do
-    :erlang.binary_to_term(bin, [:safe])
-  rescue
-    ArgumentError -> :error
-  end
-
-  defp from_unix_micros(micros) do
-    {:ok, DateTime.from_unix!(micros, :microsecond)}
-  rescue
-    _ -> {:error, :invalid}
-  end
-
-  defp url_decode(cursor) do
-    case Base.url_decode64(cursor, padding: false) do
-      {:ok, decoded} -> {:ok, decoded}
-      :error -> {:error, :invalid}
-    end
-  end
-
-  # The trailing @hmac_bytes are the signature; everything before is the payload.
-  defp split(decoded) when byte_size(decoded) > @hmac_bytes do
-    payload_len = byte_size(decoded) - @hmac_bytes
-    <<payload::binary-size(payload_len), sig::binary-size(@hmac_bytes)>> = decoded
-    {:ok, payload, sig}
-  end
-
-  defp split(_decoded), do: {:error, :invalid}
-
-  defp verify(tenant_id, payload, sig) do
-    expected = :crypto.mac(:hmac, :sha256, secret(tenant_id), payload)
-
-    if :crypto.hash_equals(expected, sig), do: :ok, else: {:error, :invalid}
-  end
-
-  # Per-tenant HMAC key: app secret_key_base + tenant_id. Stable across nodes
-  # without storing a per-tenant secret. Mirrors BulkOps.confirm_secret/1.
-  #
-  # FAIL CLOSED: `secret_key_base` is fetched (not defaulted). If it were ever
-  # absent, signing with a guessable constant would silently defeat the entire
-  # tenant-binding/forgery guarantee (a known key + a non-secret tenant_id = a
-  # forgeable cursor); raising instead is the safe failure. `runtime.exs` already
-  # requires SECRET_KEY_BASE in prod and the test/dev configs set it, so this
-  # raise is unreachable in every real environment — it is a guard, not a path.
-  #
-  # The `:article_cursor:` infix namespaces this key away from
-  # `BulkOps.confirm_secret/1` and binds it to the tenant. `tenant_id` is an Ecto
-  # `binary_id` (a canonical UUID), which cannot contain the `:` delimiter, so no
-  # two distinct tenants can derive the same key string — no cross-tenant collision.
-  defp secret(tenant_id) do
-    base =
-      :loopctl
-      |> Application.fetch_env!(LoopctlWeb.Endpoint)
-      |> Keyword.fetch!(:secret_key_base)
-
-    base <> ":article_cursor:" <> to_string(tenant_id)
-  end
+  def decode(tenant_id, cursor), do: KeysetCursor.decode(@namespace, tenant_id, cursor)
 end

--- a/lib/loopctl/knowledge/scale_seed.ex
+++ b/lib/loopctl/knowledge/scale_seed.ex
@@ -236,12 +236,16 @@ defmodule Loopctl.Knowledge.ScaleSeed do
   Like `seed/2`, this MUST run UNBOXED (committed) so ANALYZE sees the rows. It
   raises the same sandbox guard.
 
-  Timestamps are spread over the LAST 25 days (within the current monthly partition
-  that `mix ecto.reset` creates relative to today) and TIED per batch — a batch of
-  rows shares one `inserted_at` — so the deep change-feed page exercises the
-  `(inserted_at, id)` tuple tie-break the keyset (US-27.9b) relies on. All entries
-  are `entity_type: "story"` (NOT "article"/"article_link") so the controller's
-  visibility filter is a no-op and the plan/walk reflect the raw keyset.
+  Timestamps are spread across **TWO adjacent monthly partitions** (the current month
+  and the next, both created by `mix ecto.reset` / `AuditPartitionWorker` — current +
+  3-ahead), so the deep change-feed page produces the SAME multi-partition **Merge
+  Append** the planner uses in prod (where rows span months), not a single-partition
+  shortcut. The seed pre-creates the next-month partition defensively in case the
+  worker hasn't run. Within the window timestamps are TIED per batch — a batch of rows
+  shares one `inserted_at` — so the deep page also exercises the `(inserted_at, id)`
+  tuple tie-break the keyset (US-27.9b) relies on. All entries are `entity_type:
+  "story"` (NOT "article"/"article_link") so the controller's visibility filter is a
+  no-op and the plan/walk reflect the raw keyset.
   """
   @spec seed_changes(binary(), keyword()) :: {:ok, %{changes: non_neg_integer()}}
   def seed_changes(tenant_id, opts \\ []) when is_binary(tenant_id) do
@@ -257,15 +261,26 @@ defmodule Loopctl.Knowledge.ScaleSeed do
     count = Keyword.get(opts, :count, 1_000)
     batch_size = Keyword.get(opts, :batch_size, 1_000)
 
-    # Spread inserted_at WITHIN the current month so every row lands in the current
-    # monthly partition (audit_log is RANGE-partitioned by inserted_at; the migration
-    # / AuditPartitionWorker create the current-month + 3-ahead partitions, so a
-    # timestamp in a prior month has no partition and the insert would fail). The
-    # window is `[month_start + 1h, now - 1h]`, split into `num_batches` TIED-timestamp
-    # batches ascending so the deep page exercises the (inserted_at, id) tie-break.
+    # Span TWO partitions: spread from the current month's start into the NEXT month so
+    # a deep cursor page crosses the partition boundary → a real multi-partition Merge
+    # Append (the prod shape). Both partitions exist (reset/worker create current + 3
+    # ahead); ensure_audit_partitions!/2 pre-creates them defensively. The window is
+    # `[current_month_start + 1h, next_month_start + 10d]`, split into `num_batches`
+    # TIED-timestamp batches ascending so the deep page also exercises the
+    # (inserted_at, id) tie-break.
     now = DateTime.utc_now()
     {:ok, month_start} = DateTime.new(Date.new!(now.year, now.month, 1), ~T[01:00:00], "Etc/UTC")
-    window_end = DateTime.add(now, -3600, :second)
+    {next_year, next_month} = next_month(now.year, now.month)
+
+    {:ok, next_month_start} =
+      DateTime.new(Date.new!(next_year, next_month, 1), ~T[00:00:00], "Etc/UTC")
+
+    ensure_audit_partitions!(now, next_year, next_month)
+
+    # End the window ~10 days into the next month, so a healthy fraction of rows land in
+    # the next-month partition (the deepest, newest rows) regardless of where in the
+    # current month "now" is — guaranteeing the boundary is genuinely straddled.
+    window_end = DateTime.add(next_month_start, 10 * 86_400, :second)
     span_seconds = max(DateTime.diff(window_end, month_start, :second), 1)
     num_batches = div(count + batch_size - 1, batch_size)
 
@@ -273,8 +288,8 @@ defmodule Loopctl.Knowledge.ScaleSeed do
       0..(num_batches - 1)
       |> Enum.reduce(0, fn batch_idx, acc ->
         # One shared timestamp per batch (ties), stepping FORWARD from month_start so
-        # batches are time-ordered ascending with the LAST batch newest. Guaranteed
-        # within [month_start, window_end] ⊂ the current partition.
+        # batches are time-ordered ascending with the LAST batch newest. Spans
+        # [month_start, window_end] ⊂ current ∪ next partition.
         offset_seconds = div(span_seconds * batch_idx, max(num_batches, 1))
 
         # `:utc_datetime_usec` requires explicit microsecond precision; a whole-second
@@ -314,6 +329,34 @@ defmodule Loopctl.Knowledge.ScaleSeed do
     AdminRepo.query!("ANALYZE audit_log")
 
     {:ok, %{changes: committed}}
+  end
+
+  # Next (year, month) after the given one.
+  defp next_month(year, 12), do: {year + 1, 1}
+  defp next_month(year, month), do: {year, month + 1}
+
+  # Defensively ensure the audit_log partitions for the current and next month exist
+  # (idempotent `CREATE TABLE IF NOT EXISTS PARTITION OF`), so seed_changes/2 can span
+  # the boundary even if AuditPartitionWorker hasn't run since reset. Mirrors the
+  # worker's naming/bounds. AdminRepo is the table owner in test.
+  defp ensure_audit_partitions!(
+         %DateTime{year: cur_year, month: cur_month},
+         next_year,
+         next_month
+       ) do
+    for {year, month} <- [{cur_year, cur_month}, {next_year, next_month}] do
+      {to_year, to_month} = next_month(year, month)
+      name = "audit_log_y#{year}m#{pad(month)}"
+      from_date = "#{year}-#{pad(month)}-01"
+      to_date = "#{to_year}-#{pad(to_month)}-01"
+
+      AdminRepo.query!("""
+      CREATE TABLE IF NOT EXISTS #{name} PARTITION OF audit_log
+        FOR VALUES FROM ('#{from_date}') TO ('#{to_date}')
+      """)
+    end
+
+    :ok
   end
 
   @doc """
@@ -748,4 +791,9 @@ defmodule Loopctl.Knowledge.ScaleSeed do
       Enum.map(floats, &(&1 / norm))
     end
   end
+
+  # Zero-pad a 1-2 digit month for the audit_log partition name/bounds (mirrors the
+  # AuditPartitionWorker / migration naming).
+  defp pad(n) when n < 10, do: "0#{n}"
+  defp pad(n), do: "#{n}"
 end

--- a/lib/loopctl/knowledge/scale_seed.ex
+++ b/lib/loopctl/knowledge/scale_seed.ex
@@ -79,6 +79,7 @@ defmodule Loopctl.Knowledge.ScaleSeed do
   import Ecto.Query, only: [from: 2]
 
   alias Loopctl.AdminRepo
+  alias Loopctl.Audit.AuditLog
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.ArticleLink
 
@@ -98,9 +99,43 @@ defmodule Loopctl.Knowledge.ScaleSeed do
   # `category =` residual filter is ~20%-selective at scale (US-27.6a plan tests).
   @scale_categories [:pattern, :convention, :decision, :finding, :reference]
 
+  # Distinct `source_id` count for the by-source enumeration (US-27.9b). At the
+  # 80k floor this is ~100 rows per source (~0.125% selective) — selective enough
+  # that a deep by-source page MUST be served by the (tenant_id, source_id,
+  # inserted_at, id) composite index, not a heap-filter over the corpus. The
+  # `source_type` is a single value ("scale_source") so a `source_type =` residual
+  # is non-selective (covers the whole seed) while `source_id =` is the selective key.
+  @scale_source_count 800
+  @scale_source_type "scale_source"
+
   @doc "Returns the production article floor constant (as of 2026-06-24)."
   @spec prod_article_floor() :: pos_integer()
   def prod_article_floor, do: @prod_article_floor
+
+  @doc """
+  Returns the `source_type` every scale-seeded article carries (US-27.9b by-source).
+  """
+  @spec scale_source_type() :: String.t()
+  def scale_source_type, do: @scale_source_type
+
+  @doc """
+  Returns the deterministic `source_id` UUID for seeded row `index` (US-27.9b).
+
+  Round-robins over `@scale_source_count` distinct UUIDs derived deterministically
+  from the tenant_id + bucket, so a by-source plan test can pick a real seeded
+  `source_id` and walk it. Selective (~0.125% of the corpus) so the deep by-source
+  page must use the composite index.
+  """
+  @spec source_id_for(binary(), non_neg_integer()) :: Ecto.UUID.t()
+  def source_id_for(tenant_id, index) when is_binary(tenant_id) do
+    bucket = rem(index, @scale_source_count)
+
+    # Deterministic, valid v4-shaped UUID from a SHA over {tenant, bucket}. Stable
+    # across runs so a test can recompute the exact source_id for a given bucket.
+    <<a::binary-16, _::binary>> = :crypto.hash(:sha256, "#{tenant_id}:source:#{bucket}")
+    {:ok, uuid} = Ecto.UUID.load(a)
+    uuid
+  end
 
   # ~10% of seeded rows are private agent-memory (a selective `metadata->>'visibility'`
   # residual); the rest are shared. agent_id round-robined over 7 so a single agent's
@@ -191,6 +226,94 @@ defmodule Loopctl.Knowledge.ScaleSeed do
       {:ok, result} -> result
       {:error, reason} -> raise "ScaleSeed failed: #{inspect(reason)}"
     end
+  end
+
+  @doc """
+  Seeds `count` audit_log entries for `tenant_id` for the change-feed scale gate
+  (US-27.9b / TC-27.9b.2), runs ANALYZE on `audit_log`, and returns
+  `{:ok, %{changes: committed}}`.
+
+  Like `seed/2`, this MUST run UNBOXED (committed) so ANALYZE sees the rows. It
+  raises the same sandbox guard.
+
+  Timestamps are spread over the LAST 25 days (within the current monthly partition
+  that `mix ecto.reset` creates relative to today) and TIED per batch — a batch of
+  rows shares one `inserted_at` — so the deep change-feed page exercises the
+  `(inserted_at, id)` tuple tie-break the keyset (US-27.9b) relies on. All entries
+  are `entity_type: "story"` (NOT "article"/"article_link") so the controller's
+  visibility filter is a no-op and the plan/walk reflect the raw keyset.
+  """
+  @spec seed_changes(binary(), keyword()) :: {:ok, %{changes: non_neg_integer()}}
+  def seed_changes(tenant_id, opts \\ []) when is_binary(tenant_id) do
+    if AdminRepo.in_transaction?() do
+      raise """
+      ScaleSeed.seed_changes/2 was called inside an open transaction (e.g. the
+      DataCase async SQL sandbox). Rows inserted in a sandbox transaction are rolled
+      back, so ANALYZE sees n≈0. Call it from a @tag :scale_nightly test that uses
+      ExUnit.Case directly and wraps DB ops in Sandbox.unboxed_run/2.
+      """
+    end
+
+    count = Keyword.get(opts, :count, 1_000)
+    batch_size = Keyword.get(opts, :batch_size, 1_000)
+
+    # Spread inserted_at WITHIN the current month so every row lands in the current
+    # monthly partition (audit_log is RANGE-partitioned by inserted_at; the migration
+    # / AuditPartitionWorker create the current-month + 3-ahead partitions, so a
+    # timestamp in a prior month has no partition and the insert would fail). The
+    # window is `[month_start + 1h, now - 1h]`, split into `num_batches` TIED-timestamp
+    # batches ascending so the deep page exercises the (inserted_at, id) tie-break.
+    now = DateTime.utc_now()
+    {:ok, month_start} = DateTime.new(Date.new!(now.year, now.month, 1), ~T[01:00:00], "Etc/UTC")
+    window_end = DateTime.add(now, -3600, :second)
+    span_seconds = max(DateTime.diff(window_end, month_start, :second), 1)
+    num_batches = div(count + batch_size - 1, batch_size)
+
+    committed =
+      0..(num_batches - 1)
+      |> Enum.reduce(0, fn batch_idx, acc ->
+        # One shared timestamp per batch (ties), stepping FORWARD from month_start so
+        # batches are time-ordered ascending with the LAST batch newest. Guaranteed
+        # within [month_start, window_end] ⊂ the current partition.
+        offset_seconds = div(span_seconds * batch_idx, max(num_batches, 1))
+
+        # `:utc_datetime_usec` requires explicit microsecond precision; a whole-second
+        # DateTime carries `{0, 0}` (precision 0) which Ecto rejects on insert_all. Pin
+        # precision to 6 so every tied batch timestamp is a valid usec value.
+        ts =
+          month_start
+          |> DateTime.add(offset_seconds, :second)
+          |> Map.put(:microsecond, {0, 6})
+
+        lo = batch_idx * batch_size
+        hi = min(lo + batch_size, count) - 1
+
+        rows =
+          for i <- lo..hi do
+            %{
+              id: Ecto.UUID.generate(),
+              tenant_id: tenant_id,
+              project_id: nil,
+              entity_type: "story",
+              entity_id: Ecto.UUID.generate(),
+              action: "story.updated",
+              actor_type: "api_key",
+              actor_id: Ecto.UUID.generate(),
+              actor_label: "scale-actor-#{rem(i, 7)}",
+              old_state: %{},
+              new_state: %{"n" => i},
+              metadata: %{},
+              inserted_at: ts
+            }
+          end
+
+        {n, _} = AdminRepo.insert_all(AuditLog, rows, on_conflict: :nothing)
+        acc + n
+      end)
+
+    AdminRepo.query!("ANALYZE audit_log")
+
+    {:ok, %{changes: committed}}
   end
 
   @doc """
@@ -356,6 +479,11 @@ defmodule Loopctl.Knowledge.ScaleSeed do
               slug: slug,
               tags: ["scale-tag-#{rem(i, 50)}"],
               metadata: visibility_metadata(i),
+              # by-source selectivity (US-27.9b): one non-selective source_type and a
+              # round-robined selective source_id, so a deep by-source keyset page must
+              # use the (tenant_id, source_id, inserted_at, id) composite index.
+              source_type: @scale_source_type,
+              source_id: source_id_for(tenant_id, i),
               embedding: embedding,
               inserted_at: now,
               updated_at: now

--- a/lib/loopctl/knowledge/streaming_export.ex
+++ b/lib/loopctl/knowledge/streaming_export.ex
@@ -50,6 +50,7 @@ defmodule Loopctl.Knowledge.StreamingExport do
   require Logger
 
   alias Loopctl.HeavyRead
+  alias Loopctl.KeysetSeek
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.ArticleLink
   alias Loopctl.Knowledge.StreamingExport.TarGz
@@ -471,21 +472,9 @@ defmodule Loopctl.Knowledge.StreamingExport do
     end
   end
 
-  defp apply_keyset_seek(query, nil), do: query
-
-  defp apply_keyset_seek(query, {%DateTime{} = inserted_at, id}) when is_binary(id) do
-    where(
-      query,
-      [a],
-      fragment(
-        "(?, ?) > (?, ?)",
-        a.inserted_at,
-        a.id,
-        type(^inserted_at, a.inserted_at),
-        type(^id, a.id)
-      )
-    )
-  end
+  # The `(inserted_at, id)` keyset seek, shared with the article/index/change-feed
+  # keysets via Loopctl.KeysetSeek (the load-bearing type/2 annotations live there).
+  defp apply_keyset_seek(query, cursor), do: KeysetSeek.after_position(query, cursor)
 
   defp emit_entries(writer, entries) do
     Enum.reduce_while(entries, {:ok, writer}, fn {path, content}, {:ok, writer} ->

--- a/lib/loopctl_web/controllers/change_controller.ex
+++ b/lib/loopctl_web/controllers/change_controller.ex
@@ -15,6 +15,7 @@ defmodule LoopctlWeb.ChangeController do
 
   alias Loopctl.ApiSpec.Schemas
   alias Loopctl.Audit
+  alias Loopctl.Audit.ChangesCursor
   alias Loopctl.Knowledge
   alias LoopctlWeb.Helpers.Visibility
 
@@ -30,8 +31,23 @@ defmodule LoopctlWeb.ChangeController do
       since: [
         in: :query,
         type: :string,
-        required: true,
-        description: "ISO8601 timestamp (required)"
+        required: false,
+        description:
+          "ISO8601 timestamp. Required UNLESS a `cursor` is supplied. Used for the " <>
+            "FIRST page (`inserted_at > since`); follow `next_cursor` thereafter."
+      ],
+      cursor: [
+        in: :query,
+        type: :string,
+        required: false,
+        description:
+          "Opaque KEYSET cursor (US-27.9b) — the drift-free continuation token. " <>
+            "Follow `meta.next_cursor`/`next_cursor` verbatim. Unlike `since` (a " <>
+            "timestamp, which can skip or duplicate rows that share a microsecond " <>
+            "under bulk writes), the cursor seeks the stable `(inserted_at, id)` tuple " <>
+            "and never drifts across ties. Takes precedence over `since` when both are " <>
+            "given. Integrity-protected and tenant-bound; a tampered/forged cursor is " <>
+            "rejected with 400."
       ],
       project_id: [in: :query, type: :string, description: "Filter by project"],
       entity_type: [in: :query, type: :string, description: "Filter by entity type"],
@@ -49,7 +65,20 @@ defmodule LoopctlWeb.ChangeController do
                items: %OpenApiSpex.Schema{type: :object, additionalProperties: true}
              },
              has_more: %OpenApiSpex.Schema{type: :boolean},
-             next_since: %OpenApiSpex.Schema{type: :string, format: :"date-time", nullable: true}
+             next_since: %OpenApiSpex.Schema{
+               type: :string,
+               format: :"date-time",
+               nullable: true,
+               description:
+                 "Back-compat timestamp token (NOT tie-safe under bulk writes). New " <>
+                   "callers should follow `next_cursor`."
+             },
+             next_cursor: %OpenApiSpex.Schema{
+               type: :string,
+               nullable: true,
+               description:
+                 "Drift-free keyset continuation token (US-27.9b); null when exhausted."
+             }
            }
          }},
       400 => {"Bad request", "application/json", Schemas.ErrorResponse},
@@ -68,12 +97,13 @@ defmodule LoopctlWeb.ChangeController do
   Optional: `project_id`, `entity_type`, `action`
   """
   def index(conn, params) do
-    with {:ok, since} <- parse_since(params["since"]),
-         {:ok, tenant_id} <- require_tenant(conn) do
+    with {:ok, tenant_id} <- require_tenant(conn),
+         {:ok, since, cursor_opt} <- resolve_seek(tenant_id, params) do
       limit = parse_limit(params["limit"])
 
       opts =
         []
+        |> maybe_put(:cursor, cursor_opt)
         |> maybe_put(:project_id, params["project_id"])
         |> maybe_put(:entity_type, params["entity_type"])
         |> maybe_put(:action, params["action"])
@@ -90,10 +120,53 @@ defmodule LoopctlWeb.ChangeController do
       json(conn, %{
         data: Enum.map(visible, &change_json/1),
         has_more: result.has_more,
-        next_since: format_datetime(result.next_since)
+        next_since: format_datetime(result.next_since),
+        next_cursor: encode_cursor(tenant_id, result.next_cursor)
       })
     end
   end
+
+  # Resolves the seek position into a `{since_datetime, cursor_position_or_nil}`.
+  #
+  # US-27.9b: the `cursor` query param (when present) is the drift-free keyset token
+  # and takes PRECEDENCE over `since`. Tenant scope is ALWAYS the principal's
+  # `tenant_id`; the cursor is decoded+verified with the caller's tenant key, so a
+  # forged/tampered/cross-tenant cursor is rejected with 400 (AC-27.9b.4), never a
+  # silent reset to the beginning.
+  #
+  #   - cursor ABSENT      → require `since` (back-compat: the timestamp first page)
+  #   - cursor EMPTY ""    → no cursor seek; require `since` (treats `cursor=` like
+  #                          "start", deferring to `since` for the first position)
+  #   - cursor a token     → decode → keyset seek (since is ignored / defaults to epoch)
+  #   - cursor non-string  → 400
+  defp resolve_seek(tenant_id, params) do
+    case Map.fetch(params, "cursor") do
+      :error -> with {:ok, since} <- parse_since(params["since"]), do: {:ok, since, nil}
+      {:ok, ""} -> with {:ok, since} <- parse_since(params["since"]), do: {:ok, since, nil}
+      {:ok, raw} when is_binary(raw) -> decode_cursor(tenant_id, raw)
+      {:ok, _non_string} -> {:error, :bad_request, "cursor parameter must be a string"}
+    end
+  end
+
+  defp decode_cursor(tenant_id, raw) do
+    case ChangesCursor.decode(tenant_id, raw) do
+      {:ok, position} ->
+        # `since` is unused on the keyset path; the cursor carries the full position.
+        # Pass the unix epoch so the (cursor-present) seek branch is taken with a
+        # harmless `since` value.
+        {:ok, DateTime.from_unix!(0), position}
+
+      {:error, :invalid} ->
+        {:error, :bad_request,
+         "Invalid or tampered cursor. Send `since` to start from a timestamp, then " <>
+           "follow `next_cursor` verbatim to paginate."}
+    end
+  end
+
+  defp encode_cursor(_tenant_id, nil), do: nil
+
+  defp encode_cursor(tenant_id, {%DateTime{}, _id} = position),
+    do: ChangesCursor.encode(tenant_id, position)
 
   defp filter_visible_changes(entries, [], _tenant_id), do: entries
 

--- a/lib/loopctl_web/controllers/knowledge_index_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_index_controller.ex
@@ -19,6 +19,7 @@ defmodule LoopctlWeb.KnowledgeIndexController do
   alias Loopctl.ApiSpec.Schemas
   alias Loopctl.Knowledge
   alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.ArticleCursor
   alias LoopctlWeb.Helpers.Pagination
   alias LoopctlWeb.Helpers.TagMatch
   alias LoopctlWeb.Helpers.Visibility
@@ -83,6 +84,20 @@ defmodule LoopctlWeb.KnowledgeIndexController do
         description: "Tag match mode: any (default, OR) or all (AND — carries every listed tag)",
         required: false
       ],
+      source_type: [
+        in: :query,
+        type: :string,
+        description: "Filter to articles with this source_type (by-source enumeration)",
+        required: false
+      ],
+      source_id: [
+        in: :query,
+        type: :string,
+        description:
+          "Filter to articles with this source_id UUID (by-source enumeration). " <>
+            "A malformed id matches nothing.",
+        required: false
+      ],
       limit: [
         in: :query,
         type: :integer,
@@ -102,6 +117,23 @@ defmodule LoopctlWeb.KnowledgeIndexController do
           "Comma-separated projection (id, title, category, tags, status, updated_at). " <>
             "Default id,title,category. `id` and `category` are always included " <>
             "(category is the grouping key). Returns 400 for unknown fields.",
+        required: false
+      ],
+      cursor: [
+        in: :query,
+        type: :string,
+        description:
+          "Opaque KEYSET cursor for drift-free enumeration of the index (US-27.9b). " <>
+            "To use cursor pagination, pass an empty string (`cursor=`) on the FIRST " <>
+            "request to opt into the keyset path (which orders by `inserted_at ASC, " <>
+            "id ASC`); then follow `meta.next_cursor` verbatim on subsequent requests. " <>
+            "Omitting the `cursor` parameter entirely uses the legacy offset path " <>
+            "(orders by `category, updated_at DESC, id`), which does not emit " <>
+            "`next_cursor`. Do not mix the two paths mid-enumeration, as the sort order " <>
+            "differs. The keyset path honors the same category/tags/source filters and " <>
+            "is the drift-free way to walk a tag or a source to exhaustion under " <>
+            "concurrent writes. The cursor is integrity-protected and tenant-bound — a " <>
+            "tampered/forged cursor is rejected with 400.",
         required: false
       ]
     ],
@@ -145,8 +177,69 @@ defmodule LoopctlWeb.KnowledgeIndexController do
          {:ok, fields} <- parse_fields(params["fields"]),
          {:ok, base_opts} <- build_opts(params) do
       opts = Keyword.merge(base_opts, Visibility.scope_opts(conn))
-      {:ok, result} = Knowledge.list_index(tenant_id, opts)
-      json(conn, LoopctlWeb.KnowledgeIndexJSON.index(result, fields))
+
+      # US-27.9b: the presence of a `cursor` query param (even empty) opts the index
+      # into drift-free keyset pagination — the same dual path the search list uses.
+      # Tenant scope is ALWAYS the principal's (`tenant_id`), never the cursor; the
+      # cursor is decoded+verified with the caller's tenant key (AC-27.9b.4).
+      #
+      #   - param ABSENT    → legacy offset path (back-compat, grouped + total_count)
+      #   - param EMPTY     → keyset walk FROM THE START (first page, no seek)
+      #   - param a token   → keyset seek AFTER the decoded position
+      #   - param malformed → 400 (not a string)
+      run_index(conn, tenant_id, opts, fields, keyset_cursor(params))
+    end
+  end
+
+  # Dispatches the offset vs keyset path (extracted so the cursor-decode branch stays
+  # within the credo nesting limit). `:none` → legacy offset; the rest → keyset.
+  defp run_index(conn, tenant_id, opts, fields, :none) do
+    {:ok, result} = Knowledge.list_index(tenant_id, opts)
+    json(conn, LoopctlWeb.KnowledgeIndexJSON.index(result, fields))
+  end
+
+  defp run_index(_conn, _tenant_id, _opts, _fields, :invalid) do
+    {:error, :bad_request, "cursor parameter must be a string"}
+  end
+
+  defp run_index(conn, tenant_id, opts, fields, :start) do
+    render_keyset(conn, tenant_id, opts, fields, nil)
+  end
+
+  defp run_index(conn, tenant_id, opts, fields, {:cursor, raw}) do
+    case ArticleCursor.decode(tenant_id, raw) do
+      {:ok, position} ->
+        render_keyset(conn, tenant_id, opts, fields, position)
+
+      {:error, :invalid} ->
+        {:error, :bad_request,
+         "Invalid or tampered cursor. Send an empty 'cursor' to start from the " <>
+           "beginning, then follow 'meta.next_cursor' verbatim to paginate."}
+    end
+  end
+
+  defp render_keyset(conn, tenant_id, opts, fields, position) do
+    {:ok, result} = Knowledge.list_index_keyset(tenant_id, Keyword.put(opts, :cursor, position))
+
+    encoded =
+      case result.next_cursor do
+        nil -> nil
+        cursor -> ArticleCursor.encode(tenant_id, cursor)
+      end
+
+    json(conn, LoopctlWeb.KnowledgeIndexJSON.keyset(%{result | next_cursor: encoded}, fields))
+  end
+
+  # Classifies the `cursor` query param: ABSENT → `:none` (legacy offset path);
+  # PRESENT-but-empty → `:start` (keyset from the beginning); a non-empty string →
+  # `{:cursor, raw}` (keyset seek); a non-string `cursor[]=` form → `:invalid` (400,
+  # not a 500 and not a silent page-1 reset). Mirrors the search controller verbatim.
+  defp keyset_cursor(params) when is_map(params) do
+    case Map.fetch(params, "cursor") do
+      :error -> :none
+      {:ok, ""} -> :start
+      {:ok, raw} when is_binary(raw) -> {:cursor, raw}
+      {:ok, _non_string} -> :invalid
     end
   end
 
@@ -190,12 +283,23 @@ defmodule LoopctlWeb.KnowledgeIndexController do
         |> maybe_put(:category, category)
         |> maybe_put(:tags, parse_tags(params["tags"]))
         |> Keyword.put(:match, match)
+        |> maybe_put(:source_type, parse_source_type(params["source_type"]))
+        |> maybe_put(:source_id, parse_source_id(params["source_id"]))
         |> maybe_put(:limit, parse_int(params["limit"]))
         |> maybe_put(:offset, parse_int(params["offset"]))
 
       {:ok, opts}
     end
   end
+
+  defp parse_source_type(value) when is_binary(value) and value != "", do: value
+  defp parse_source_type(_), do: nil
+
+  # `source_id` is matched as a binary_id by the context filter, which maps a
+  # malformed (non-UUID) value to "matches nothing" rather than raising. We pass a
+  # non-empty string straight through; the context guards the cast.
+  defp parse_source_id(value) when is_binary(value) and value != "", do: value
+  defp parse_source_id(_), do: nil
 
   # Best-effort project filter: a malformed (non-UUID) project_id yields
   # tenant-wide results rather than crashing on an Ecto.Query.CastError (a

--- a/lib/loopctl_web/controllers/knowledge_index_json.ex
+++ b/lib/loopctl_web/controllers/knowledge_index_json.ex
@@ -36,6 +36,49 @@ defmodule LoopctlWeb.KnowledgeIndexJSON do
     }
   end
 
+  @doc """
+  Renders a KEYSET (cursor) index page (US-27.9b).
+
+  Like `index/2`, articles are grouped by category and projected to `fields`. But
+  the `meta` documents the cursor contract instead of offset/total_count, so an
+  agent walking a tag or a source can drive pagination purely from the response:
+
+  - `next_cursor` — the opaque, already-encoded cursor for the next page, or `null`
+    when the walk is exhausted (the only exhaustion signal — there is no
+    total_count to drift).
+  - `has_more` — boolean, derived from the keyset peek (exactly `next_cursor != null`),
+    never a COUNT.
+  - `limit` — the effective per-page limit that actually ran.
+  - `count` — the number of rows in THIS page (across all categories).
+
+  `next_cursor` is encoded by the controller (it needs the tenant key), so this
+  view receives it as a ready string or `nil`.
+  """
+  def keyset(
+        %{results: results, next_cursor: next_cursor, has_more: has_more, limit: limit},
+        fields
+      ) do
+    grouped =
+      Enum.group_by(results, fn article -> to_string(article.category) end)
+
+    %{
+      data:
+        Map.new(grouped, fn {category, articles} ->
+          {category, Enum.map(articles, &project(&1, fields))}
+        end),
+      meta: %{
+        # The cursor walk is drift-free precisely BECAUSE it carries no total_count
+        # to drift; `next_cursor: null` is the exhaustion signal.
+        next_cursor: next_cursor,
+        has_more: has_more,
+        limit: limit,
+        count: length(results),
+        fields: fields,
+        search_mode: "index_keyset"
+      }
+    }
+  end
+
   defp project(article, fields) do
     Map.new(fields, fn field -> {field, field_value(article, field)} end)
   end

--- a/priv/repo/migrations/20260625120000_add_articles_source_keyset_index.exs
+++ b/priv/repo/migrations/20260625120000_add_articles_source_keyset_index.exs
@@ -1,0 +1,37 @@
+defmodule Loopctl.Repo.Migrations.AddArticlesSourceKeysetIndex do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  @moduledoc false
+  # Composite btree index backing the BY-SOURCE knowledge-index KEYSET enumeration
+  # (US-27.9b):
+  #   WHERE tenant_id = $1 AND source_id = $2
+  #     AND (inserted_at, id) > ($3, $4)
+  #   ORDER BY inserted_at ASC, id ASC LIMIT n+1
+  #
+  # by-source is a SELECTIVE scalar equality (`source_id =`). Without this index the
+  # planner would walk the (tenant_id, inserted_at, id) keyset btree and apply
+  # `source_id =` as a heap-recheck — at prod scale that scans far past the matching
+  # rows for a deep page (a full-corpus-ish read the :scale_nightly refute_full_scan
+  # would catch). Leading with (tenant_id, source_id) lets the planner seek straight to
+  # the source's rows and walk them in (inserted_at, id) order — strictly index-ordered,
+  # no Sort. The general (tenant_id, inserted_at, id) btree from US-27.9a remains the
+  # residual-free / by-tag fallback.
+  #
+  # Built CONCURRENTLY (outside a ddl transaction) so the build does not block writes
+  # to the ~76k-row articles table online.
+
+  def up do
+    execute("""
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS articles_tenant_source_inserted_id_idx
+    ON articles (tenant_id, source_id, inserted_at, id)
+    WHERE source_id IS NOT NULL
+    """)
+  end
+
+  def down do
+    execute("DROP INDEX CONCURRENTLY IF EXISTS articles_tenant_source_inserted_id_idx")
+  end
+end

--- a/test/loopctl/audit/list_changes_keyset_test.exs
+++ b/test/loopctl/audit/list_changes_keyset_test.exs
@@ -1,0 +1,141 @@
+defmodule Loopctl.Audit.ListChangesKeysetTest do
+  @moduledoc """
+  Context-level tests for `Loopctl.Audit.list_changes/3` as a KEYSET enumeration
+  (US-27.9b / AC-27.9b.1).
+
+  The headline fix: the original `next_since` timestamp token SKIPS or DUPLICATES
+  rows that share a microsecond (bulk writes tie `inserted_at`). The `(inserted_at,
+  id)` keyset cursor steps PAST a specific row regardless of ties — proven here by
+  forcing a tied-timestamp batch and walking across a page boundary that lands
+  mid-tie, asserting a gap-free, duplicate-free, complete walk. Also covers tenant
+  isolation (the cursor never crosses tenants).
+  """
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Audit
+  alias Loopctl.Audit.AuditLog
+
+  # Insert `n` audit rows for a tenant, ALL at the same `inserted_at` (a tied batch,
+  # what an Ecto.Multi / insert_all commits). Returns the inserted ids.
+  defp insert_tied(tenant_id, n, ts) do
+    rows =
+      for i <- 1..n do
+        %{
+          id: Ecto.UUID.generate(),
+          tenant_id: tenant_id,
+          entity_type: "story",
+          entity_id: Ecto.UUID.generate(),
+          action: "story.updated",
+          actor_type: "api_key",
+          new_state: %{"n" => i},
+          metadata: %{},
+          inserted_at: ts
+        }
+      end
+
+    {_n, returned} = AdminRepo.insert_all(AuditLog, rows, returning: [:id])
+    Enum.map(returned, & &1.id)
+  end
+
+  # Walk the change feed via the keyset cursor, collecting ids. Starts from the unix
+  # epoch (so the first page covers everything), then follows next_cursor.
+  defp walk(tenant_id, page_limit) do
+    do_walk(tenant_id, page_limit, nil, [], 0)
+  end
+
+  defp do_walk(_tid, _limit, _cursor, _acc, n) when n > 10_000 do
+    flunk("change-feed keyset walk did not terminate")
+  end
+
+  defp do_walk(tenant_id, page_limit, cursor, acc, n) do
+    opts = if cursor, do: [limit: page_limit, cursor: cursor], else: [limit: page_limit]
+
+    {:ok, %{data: data, next_cursor: next_cursor}} =
+      Audit.list_changes(tenant_id, DateTime.from_unix!(0), opts)
+
+    acc = acc ++ Enum.map(data, & &1.id)
+
+    if next_cursor do
+      do_walk(tenant_id, page_limit, next_cursor, acc, n + 1)
+    else
+      acc
+    end
+  end
+
+  describe "list_changes/3 — tie-safe keyset walk (AC-27.9b.1)" do
+    test "walks a tied-timestamp batch gap-free across a mid-tie page boundary" do
+      tenant = fixture(:tenant)
+      ts = ~U[2026-06-24 09:00:00.000000Z]
+
+      # 10 rows ALL at the same microsecond — the exact case a since-token mishandles.
+      ids = insert_tied(tenant.id, 10, ts)
+
+      # Page size 3 forces boundaries WITHIN the tied batch.
+      seen = walk(tenant.id, 3)
+
+      assert Enum.sort(seen) == Enum.sort(ids), "every tied row served exactly once"
+      assert length(seen) == 10
+      assert length(seen) == length(Enum.uniq(seen)), "no duplicate across the tie boundary"
+    end
+
+    test "since-token alone would skip tied rows after a boundary (regression guard)" do
+      tenant = fixture(:tenant)
+      ts = ~U[2026-06-24 10:00:00.000000Z]
+      ids = insert_tied(tenant.id, 6, ts)
+
+      # First page of 3 over the 6 tied rows: more remain, and next_cursor is set.
+      {:ok, %{data: page1, next_cursor: cursor, next_since: next_since}} =
+        Audit.list_changes(tenant.id, DateTime.from_unix!(0), limit: 3)
+
+      assert length(page1) == 3
+      refute is_nil(cursor)
+      # next_since equals the tied timestamp — a since-only follow-up (`inserted_at >
+      # next_since`) would EXCLUDE the remaining 3 tied rows (the drift bug). The
+      # keyset cursor instead returns them.
+      assert next_since == ts
+
+      {:ok, %{data: page2}} =
+        Audit.list_changes(tenant.id, DateTime.from_unix!(0), limit: 3, cursor: cursor)
+
+      seen = Enum.map(page1 ++ page2, & &1.id)
+      assert Enum.sort(seen) == Enum.sort(ids)
+      assert length(Enum.uniq(seen)) == 6, "keyset cursor returned the tied tail with no gap"
+    end
+  end
+
+  describe "list_changes/3 — back-compat since token" do
+    test "no cursor: still seeks by since and emits next_since" do
+      tenant = fixture(:tenant)
+      base = ~U[2026-06-24 11:00:00.000000Z]
+
+      # Distinct timestamps so the since-token is well-behaved here.
+      for i <- 0..4 do
+        insert_tied(tenant.id, 1, DateTime.add(base, i, :second))
+      end
+
+      {:ok, %{data: data, has_more: has_more, next_since: next_since}} =
+        Audit.list_changes(tenant.id, DateTime.add(base, -1, :second), limit: 2)
+
+      assert length(data) == 2
+      assert has_more
+      assert %DateTime{} = next_since
+    end
+  end
+
+  describe "list_changes/3 — tenant isolation (AC-27.9b.4)" do
+    test "the keyset walk never crosses tenants" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      ts = ~U[2026-06-24 12:00:00.000000Z]
+
+      a_ids = insert_tied(tenant_a.id, 5, ts)
+      insert_tied(tenant_b.id, 5, ts)
+
+      seen = walk(tenant_a.id, 2)
+
+      assert Enum.sort(seen) == Enum.sort(a_ids)
+      assert length(seen) == 5
+    end
+  end
+end

--- a/test/loopctl/index_health_test.exs
+++ b/test/loopctl/index_health_test.exs
@@ -12,6 +12,10 @@ defmodule Loopctl.IndexHealthTest do
       assert IndexHealth.index_validity("articles_tenant_inserted_id_idx") == :valid
     end
 
+    test "reports :valid for the US-27.9b by-source keyset index (migration-created, valid)" do
+      assert IndexHealth.index_validity("articles_tenant_source_inserted_id_idx") == :valid
+    end
+
     test "reports :missing for an index that does not exist" do
       assert IndexHealth.index_validity(
                "definitely_not_an_index_#{System.unique_integer([:positive])}"
@@ -21,9 +25,10 @@ defmodule Loopctl.IndexHealthTest do
   end
 
   describe "which/0" do
-    test "includes the keyset index in the critical list" do
+    test "includes both keyset indexes in the critical list" do
       names = Enum.map(IndexHealth.which(), fn {name, _purpose} -> name end)
       assert "articles_tenant_inserted_id_idx" in names
+      assert "articles_tenant_source_inserted_id_idx" in names
     end
   end
 

--- a/test/loopctl/keyset_cursor_test.exs
+++ b/test/loopctl/keyset_cursor_test.exs
@@ -1,0 +1,77 @@
+defmodule Loopctl.KeysetCursorTest do
+  @moduledoc """
+  Tests for the shared `Loopctl.KeysetCursor` codec and the NAMESPACE SEPARATION it
+  guarantees between the per-surface delegators (`Loopctl.Knowledge.ArticleCursor`,
+  `Loopctl.Audit.ChangesCursor`).
+
+  The per-surface tamper/tenant/round-trip behavior is covered by
+  `article_cursor_test.exs` (unchanged after the refactor — proving it is
+  behavior-preserving). This file pins the cross-namespace invariant: a cursor minted
+  for one surface MUST NOT decode on another, even within the same tenant.
+  """
+  use ExUnit.Case, async: true
+
+  alias Loopctl.Audit.ChangesCursor
+  alias Loopctl.KeysetCursor
+  alias Loopctl.Knowledge.ArticleCursor
+
+  setup do
+    %{
+      tenant_id: Ecto.UUID.generate(),
+      position: {~U[2026-06-24 09:00:00.123456Z], Ecto.UUID.generate()}
+    }
+  end
+
+  describe "shared codec round-trip" do
+    test "encode/3 + decode/3 round-trip under a namespace", %{tenant_id: t, position: pos} do
+      cursor = KeysetCursor.encode("article_cursor", t, pos)
+      assert {:ok, ^pos} = KeysetCursor.decode("article_cursor", t, cursor)
+    end
+
+    test "a different namespace fails verification for the same tenant+position",
+         %{tenant_id: t, position: pos} do
+      cursor = KeysetCursor.encode("article_cursor", t, pos)
+      assert {:error, :invalid} = KeysetCursor.decode("changes_cursor", t, cursor)
+    end
+
+    test "a different tenant fails verification under the same namespace",
+         %{tenant_id: t, position: pos} do
+      cursor = KeysetCursor.encode("article_cursor", t, pos)
+
+      assert {:error, :invalid} =
+               KeysetCursor.decode("article_cursor", Ecto.UUID.generate(), cursor)
+    end
+  end
+
+  describe "namespace separation across delegators (security: no cross-surface replay)" do
+    test "an article cursor does NOT decode as a change cursor (same tenant)",
+         %{tenant_id: t, position: pos} do
+      article_cursor = ArticleCursor.encode(t, pos)
+
+      # Round-trips as an article cursor...
+      assert {:ok, ^pos} = ArticleCursor.decode(t, article_cursor)
+      # ...but is rejected by the change-feed surface.
+      assert {:error, :invalid} = ChangesCursor.decode(t, article_cursor)
+    end
+
+    test "a change cursor does NOT decode as an article cursor (same tenant)",
+         %{tenant_id: t, position: pos} do
+      change_cursor = ChangesCursor.encode(t, pos)
+
+      assert {:ok, ^pos} = ChangesCursor.decode(t, change_cursor)
+      assert {:error, :invalid} = ArticleCursor.decode(t, change_cursor)
+    end
+  end
+
+  describe "delegators preserve the defensive contract" do
+    test "garbage is rejected by both delegators, never raises", %{tenant_id: t} do
+      assert {:error, :invalid} = ArticleCursor.decode(t, "not-a-cursor!!!")
+      assert {:error, :invalid} = ChangesCursor.decode(t, "not-a-cursor!!!")
+    end
+
+    test "a non-binary cursor is rejected, never raises", %{tenant_id: t} do
+      assert {:error, :invalid} = ArticleCursor.decode(t, nil)
+      assert {:error, :invalid} = ChangesCursor.decode(t, nil)
+    end
+  end
+end

--- a/test/loopctl/knowledge/by_source_change_feed_plan_scale_test.exs
+++ b/test/loopctl/knowledge/by_source_change_feed_plan_scale_test.exs
@@ -154,6 +154,57 @@ defmodule Loopctl.Knowledge.BySourceChangeFeedPlanScaleTest do
     end)
   end
 
+  # AC-27.9b.2 / review item-3: the BY-TAG deep page is the literal #175 incident path
+  # this story fixes, and `index_keyset_query` is a DISTINCT query from 27.9a's
+  # keyset_query (it forces `status = :published` + the project OR-clause), so we pin its
+  # tag-filtered plan HERE on the actual request-path query. Same honest tags-shape
+  # profile as 27.9a: the tags GIN bounds the scan (no btree can serve both array
+  # containment AND the (inserted_at, id) order), so we assert no unbounded Seq Scan, the
+  # selective tags GIN drives it, and the scan stays bounded by tag selectivity.
+  test "by-tag deep page on index_keyset_query is bounded by the tags GIN at prod scale",
+       %{tenant: tenant} do
+    unboxed(fn ->
+      published_count =
+        AdminRepo.one(
+          from(a in Article,
+            where: a.tenant_id == ^tenant.id and a.status == :published,
+            select: count(a.id)
+          )
+        )
+
+      deep_offset = trunc(published_count * 0.9)
+
+      deep =
+        AdminRepo.one(
+          from(a in Article,
+            where: a.tenant_id == ^tenant.id and a.status == :published,
+            order_by: [asc: a.inserted_at, asc: a.id],
+            offset: ^deep_offset,
+            limit: 1,
+            select: %{id: a.id, inserted_at: a.inserted_at}
+          )
+        )
+
+      assert deep, "expected a deep published row at offset #{deep_offset}"
+
+      cursor = {deep.inserted_at, deep.id}
+
+      query =
+        Knowledge.index_keyset_query(tenant.id, tags: ["scale-tag-7"], cursor: cursor, limit: 21)
+
+      assert :ok = PlanAssertions.refute_seq_scan(query),
+             "by-tag index_keyset_query must not Seq-Scan the corpus at prod scale"
+
+      assert :ok = PlanAssertions.assert_index_used(query, "articles_tags_index"),
+             "by-tag index_keyset_query must be bounded by the selective tags GIN"
+
+      max_bounded = div(ScaleSeed.prod_article_floor(), 8)
+
+      assert :ok = PlanAssertions.assert_scan_rows_below(query, max_bounded),
+             "by-tag index_keyset_query must stay bounded by tag selectivity, not scan the corpus"
+    end)
+  end
+
   test "change-feed keyset deep page is index-backed (no Seq Scan over audit_log)",
        %{tenant: tenant} do
     unboxed(fn ->
@@ -186,8 +237,12 @@ defmodule Loopctl.Knowledge.BySourceChangeFeedPlanScaleTest do
           limit: 1001
         )
 
-      assert :ok = PlanAssertions.refute_seq_scan_audit(query),
-             "change-feed keyset deep page must not Seq-Scan audit_log at prod scale"
+      # Tightened (review item-4): audit.ex claims the feed "walks it in order — index-
+      # backed", so we forbid a Bitmap Heap Scan too (refute_full_scan_audit), proving an
+      # ordered Index/Index-Only Scan — not just "no Seq Scan".
+      assert :ok = PlanAssertions.refute_full_scan_audit(query),
+             "change-feed keyset deep page must be an ordered index scan over audit_log " <>
+               "(no Seq Scan, no Bitmap) at prod scale"
 
       {elapsed_us, _rows} = :timer.tc(fn -> AdminRepo.all(query) end)
       elapsed_ms = div(elapsed_us, 1000)

--- a/test/loopctl/knowledge/by_source_change_feed_plan_scale_test.exs
+++ b/test/loopctl/knowledge/by_source_change_feed_plan_scale_test.exs
@@ -205,7 +205,7 @@ defmodule Loopctl.Knowledge.BySourceChangeFeedPlanScaleTest do
     end)
   end
 
-  test "change-feed keyset deep page is index-backed (no Seq Scan over audit_log)",
+  test "change-feed keyset deep page is a multi-partition Merge Append, no Seq/Bitmap",
        %{tenant: tenant} do
     unboxed(fn ->
       total =
@@ -213,35 +213,70 @@ defmodule Loopctl.Knowledge.BySourceChangeFeedPlanScaleTest do
 
       assert total > 0, "expected seeded audit_log rows"
 
-      deep_offset = trunc(total * 0.9)
-
-      deep =
+      # Confirm the seed actually straddles ≥2 monthly partitions (the prod shape). The
+      # rows span the current month and the next (ScaleSeed.seed_changes/2), so distinct
+      # year-months > 1.
+      distinct_months =
         AdminRepo.one(
           from(a in AuditLog,
             where: a.tenant_id == ^tenant.id,
-            order_by: [asc: a.inserted_at, asc: a.id],
-            offset: ^deep_offset,
+            select: count(fragment("DISTINCT date_trunc('month', ?)", a.inserted_at))
+          )
+        )
+
+      assert distinct_months >= 2,
+             "seed must span ≥2 monthly partitions for a real Merge Append (got #{distinct_months})"
+
+      # Pick a cursor at the LAST row of the FIRST (current) month, so the forward keyset
+      # seek `(inserted_at, id) > cursor` includes the current-month tail AND all of the
+      # next month — forcing a deep page whose Merge Append spans BOTH partitions (the
+      # prod multi-partition shape), not a single-partition shortcut.
+      {:ok, month_start} =
+        DateTime.new(
+          Date.new!(DateTime.utc_now().year, DateTime.utc_now().month, 1),
+          ~T[00:00:00]
+        )
+
+      {next_year, next_month} =
+        if month_start.month == 12,
+          do: {month_start.year + 1, 1},
+          else: {month_start.year, month_start.month + 1}
+
+      {:ok, next_month_start} = DateTime.new(Date.new!(next_year, next_month, 1), ~T[00:00:00])
+
+      boundary =
+        AdminRepo.one(
+          from(a in AuditLog,
+            where: a.tenant_id == ^tenant.id and a.inserted_at < ^next_month_start,
+            order_by: [desc: a.inserted_at, desc: a.id],
             limit: 1,
             select: %{id: a.id, inserted_at: a.inserted_at}
           )
         )
 
-      assert deep, "expected a deep audit row at offset #{deep_offset}"
+      assert boundary, "expected a current-month row before the partition boundary"
 
-      cursor = {deep.inserted_at, deep.id}
+      cursor = {boundary.inserted_at, boundary.id}
 
-      # The EXACT request-path query, for a deep cursor.
+      # The EXACT request-path query, for a boundary-straddling deep cursor.
       query =
         Audit.changes_keyset_query(tenant.id, DateTime.from_unix!(0),
           cursor: cursor,
           limit: 1001
         )
 
-      # Tightened (review item-4): audit.ex claims the feed "walks it in order — index-
-      # backed", so we forbid a Bitmap Heap Scan too (refute_full_scan_audit), proving an
-      # ordered Index/Index-Only Scan — not just "no Seq Scan".
+      # Multi-partition guard (review item-2): the page must span ≥2 partitions via
+      # per-partition Index Scans under an ordered combiner (Merge Append, or Append +
+      # Incremental Sort — the planner's empirical choice here) — the prod shape, so
+      # refute_full_scan_audit isn't vacuous on a single-partition shortcut.
+      assert :ok = PlanAssertions.assert_ordered_multi_partition_scan(query, 2),
+             "deep change-feed page must be an ordered scan over ≥2 audit_log partitions"
+
+      # Tightened (review item-4): forbid Bitmap too (refute_full_scan_audit), proving
+      # per-partition ordered Index Scans (an incremental sort resolves the id tie-break)
+      # — no Seq Scan, no Bitmap over the corpus.
       assert :ok = PlanAssertions.refute_full_scan_audit(query),
-             "change-feed keyset deep page must be an ordered index scan over audit_log " <>
+             "change-feed keyset deep page must be per-partition index scans over audit_log " <>
                "(no Seq Scan, no Bitmap) at prod scale"
 
       {elapsed_us, _rows} = :timer.tc(fn -> AdminRepo.all(query) end)

--- a/test/loopctl/knowledge/by_source_change_feed_plan_scale_test.exs
+++ b/test/loopctl/knowledge/by_source_change_feed_plan_scale_test.exs
@@ -1,0 +1,199 @@
+defmodule Loopctl.Knowledge.BySourceChangeFeedPlanScaleTest do
+  @moduledoc """
+  US-27.9b / AC-27.9b.2 + TC-27.9b.2: prove the BY-SOURCE knowledge-index keyset and
+  the CHANGE-FEED keyset are index-backed for a DEEP page at >= prod scale — no full
+  Seq Scan / full-corpus read.
+
+  Two enumeration surfaces, two index strategies (stated honestly per shape):
+
+  - BY-SOURCE (`index_keyset_query` with `source_id =`): a SELECTIVE scalar equality.
+    The `(tenant_id, source_id, inserted_at, id)` composite btree
+    (`articles_tenant_source_inserted_id_idx`, US-27.9b migration) lets the planner
+    seek straight to the source's rows and walk them in `(inserted_at, id)` order —
+    strictly index-ordered, so `refute_full_scan/1` holds (no Sort, no Bitmap-over-
+    corpus). The residual-free `(tenant_id, inserted_at, id)` shape (no source filter)
+    is the US-27.9a keyset already proven; here we pin the by-source shape.
+
+  - CHANGE-FEED (`changes_keyset_query` over the RANGE-partitioned `audit_log`): the
+    keyset `(inserted_at, id)` seek with `tenant_id =` is served by the existing
+    `(tenant_id, inserted_at)` btree (the `id` is the bounded tie-break recheck). We
+    assert `refute_seq_scan_audit/1` (no unbounded full read of the partition) — a
+    partitioned Index/Bitmap scan is fine; a Seq Scan over the corpus is the regression.
+
+  Seeds ~80k committed articles (ScaleSeed.seed) + ~80k committed audit_log rows
+  (ScaleSeed.seed_changes), so it is `:scale_nightly` (nightly/scale gate, not the
+  default async suite). Wired into the CI scale matrix (scale_verification_runbook_test
+  enforces every :scale_nightly file is listed).
+  """
+  use ExUnit.Case, async: false
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Loopctl.AdminRepo
+  alias Loopctl.Audit
+  alias Loopctl.Audit.AuditLog
+  alias Loopctl.Knowledge
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.ScaleSeed
+  alias Loopctl.PlanAssertions
+  alias Loopctl.Tenants.Tenant
+
+  import Ecto.Query
+
+  @moduletag :scale_nightly
+  @moduletag timeout: :timer.minutes(30)
+
+  @heavy_read_statement_timeout_ms System.get_env("HEAVY_READ_STATEMENT_TIMEOUT_MS", "10000")
+                                   |> String.to_integer()
+
+  defp unboxed(fun), do: Sandbox.unboxed_run(AdminRepo, fun)
+
+  setup do
+    tenant =
+      unboxed(fn ->
+        slug = "bysrc-cf-scale-#{:erlang.phash2(Ecto.UUID.generate())}"
+
+        {:ok, t} =
+          %Tenant{}
+          |> Tenant.create_changeset(%{
+            name: "BySource/ChangeFeed Scale #{slug}",
+            slug: slug,
+            email: "#{slug}@example.com",
+            settings: %{},
+            status: :active
+          })
+          |> AdminRepo.insert()
+
+        # Articles: status_mix so `status = :published` has selectivity; ScaleSeed now
+        # seeds a selective source_id round-robined over 800 sources (~0.125%/source).
+        ScaleSeed.seed(t.id,
+          count: ScaleSeed.prod_article_floor(),
+          link_density: 5,
+          status_mix: true
+        )
+
+        # Audit rows for the change feed at the same prod floor.
+        ScaleSeed.seed_changes(t.id, count: ScaleSeed.prod_article_floor())
+
+        t
+      end)
+
+    on_exit(fn ->
+      try do
+        unboxed(fn ->
+          AdminRepo.delete_all(from(a in Article, where: a.tenant_id == ^tenant.id))
+          AdminRepo.delete_all(from(l in AuditLog, where: l.tenant_id == ^tenant.id))
+          AdminRepo.delete_all(from(t in Tenant, where: t.id == ^tenant.id))
+        end)
+      rescue
+        _ -> :ok
+      end
+    end)
+
+    {:ok, tenant: tenant}
+  end
+
+  test "by-source keyset deep page is index-backed (composite index), no full scan",
+       %{tenant: tenant} do
+    unboxed(fn ->
+      # Pick a real seeded source_id with many rows; bucket 7 is arbitrary but stable.
+      source_id = ScaleSeed.source_id_for(tenant.id, 7)
+
+      published_for_source =
+        AdminRepo.one(
+          from(a in Article,
+            where:
+              a.tenant_id == ^tenant.id and a.status == :published and a.source_id == ^source_id,
+            select: count(a.id)
+          )
+        )
+
+      assert published_for_source > 0,
+             "expected seeded published rows for source #{source_id}"
+
+      deep_offset = trunc(published_for_source * 0.9)
+
+      deep =
+        AdminRepo.one(
+          from(a in Article,
+            where:
+              a.tenant_id == ^tenant.id and a.status == :published and a.source_id == ^source_id,
+            order_by: [asc: a.inserted_at, asc: a.id],
+            offset: ^deep_offset,
+            limit: 1,
+            select: %{id: a.id, inserted_at: a.inserted_at}
+          )
+        )
+
+      assert deep, "expected a deep by-source row at offset #{deep_offset}"
+
+      cursor = {deep.inserted_at, deep.id}
+
+      query =
+        Knowledge.index_keyset_query(tenant.id,
+          source_type: ScaleSeed.scale_source_type(),
+          source_id: source_id,
+          cursor: cursor,
+          limit: 21
+        )
+
+      assert :ok = PlanAssertions.refute_full_scan(query),
+             "by-source keyset deep page must be strictly index-ordered via the composite index"
+
+      # The scan must be BOUNDED by source selectivity, not the corpus.
+      max_bounded = div(ScaleSeed.prod_article_floor(), 8)
+
+      assert :ok = PlanAssertions.assert_scan_rows_below(query, max_bounded),
+             "by-source keyset must stay bounded by source selectivity, not scan the corpus"
+
+      # Timing: the deep by-source page must EXECUTE well under the heavy-read timeout.
+      {elapsed_us, _rows} = :timer.tc(fn -> AdminRepo.all(query) end)
+      elapsed_ms = div(elapsed_us, 1000)
+
+      assert elapsed_ms < @heavy_read_statement_timeout_ms,
+             "deep by-source page took #{elapsed_ms}ms, expected < #{@heavy_read_statement_timeout_ms}ms"
+    end)
+  end
+
+  test "change-feed keyset deep page is index-backed (no Seq Scan over audit_log)",
+       %{tenant: tenant} do
+    unboxed(fn ->
+      total =
+        AdminRepo.one(from(a in AuditLog, where: a.tenant_id == ^tenant.id, select: count(a.id)))
+
+      assert total > 0, "expected seeded audit_log rows"
+
+      deep_offset = trunc(total * 0.9)
+
+      deep =
+        AdminRepo.one(
+          from(a in AuditLog,
+            where: a.tenant_id == ^tenant.id,
+            order_by: [asc: a.inserted_at, asc: a.id],
+            offset: ^deep_offset,
+            limit: 1,
+            select: %{id: a.id, inserted_at: a.inserted_at}
+          )
+        )
+
+      assert deep, "expected a deep audit row at offset #{deep_offset}"
+
+      cursor = {deep.inserted_at, deep.id}
+
+      # The EXACT request-path query, for a deep cursor.
+      query =
+        Audit.changes_keyset_query(tenant.id, DateTime.from_unix!(0),
+          cursor: cursor,
+          limit: 1001
+        )
+
+      assert :ok = PlanAssertions.refute_seq_scan_audit(query),
+             "change-feed keyset deep page must not Seq-Scan audit_log at prod scale"
+
+      {elapsed_us, _rows} = :timer.tc(fn -> AdminRepo.all(query) end)
+      elapsed_ms = div(elapsed_us, 1000)
+
+      assert elapsed_ms < @heavy_read_statement_timeout_ms,
+             "deep change-feed page took #{elapsed_ms}ms, expected < #{@heavy_read_statement_timeout_ms}ms"
+    end)
+  end
+end

--- a/test/loopctl/knowledge/list_index_keyset_test.exs
+++ b/test/loopctl/knowledge/list_index_keyset_test.exs
@@ -1,0 +1,283 @@
+defmodule Loopctl.Knowledge.ListIndexKeysetTest do
+  @moduledoc """
+  Context-level tests for `Loopctl.Knowledge.list_index_keyset/2` (US-27.9b).
+
+  Proves the by-tag / by-source index keyset walk is gap-free, duplicate-free, and
+  drift-free under concurrent inserts/archives (AC-27.9b.1 / .3 / TC-27.9b.1), that
+  the `(inserted_at, id)` TUPLE tie-break walks batch-tied timestamps correctly, and
+  that every query is tenant-scoped (AC-27.9b.4).
+  """
+  use Loopctl.DataCase, async: true
+
+  alias Ecto.Adapters.SQL
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge
+  alias Loopctl.Knowledge.Article
+
+  # Walk the index keyset page-by-page, collecting ids across all categories. The
+  # `mutate` callback runs BETWEEN pages so we can prove stability under concurrent
+  # writes. Returns the ordered list of ids seen across the walk.
+  defp walk(tenant_id, page_limit, opts, mutate \\ fn _page -> :ok end) do
+    do_walk(tenant_id, page_limit, opts, mutate, nil, [], 0)
+  end
+
+  defp do_walk(_tid, _limit, _opts, _mutate, _cursor, _acc, n) when n > 10_000 do
+    flunk("index keyset walk did not terminate — possible infinite loop")
+  end
+
+  defp do_walk(tenant_id, page_limit, opts, mutate, cursor, acc, n) do
+    walk_opts =
+      opts
+      |> Keyword.put(:limit, page_limit)
+      |> Keyword.put(:cursor, cursor)
+
+    {:ok, %{results: results, next_cursor: next_cursor, limit: limit}} =
+      Knowledge.list_index_keyset(tenant_id, walk_opts)
+
+    assert limit == page_limit
+    assert length(results) <= page_limit
+
+    acc = acc ++ Enum.map(results, & &1.id)
+
+    if next_cursor do
+      mutate.(results)
+      do_walk(tenant_id, page_limit, opts, mutate, next_cursor, acc, n + 1)
+    else
+      acc
+    end
+  end
+
+  describe "list_index_keyset/2 — ordering and shape" do
+    test "orders by (inserted_at ASC, id ASC), published only" do
+      tenant = fixture(:tenant)
+
+      published =
+        for i <- 1..5 do
+          a = fixture(:article, %{tenant_id: tenant.id, status: :published, title: "A#{i}"})
+          a.id
+        end
+
+      # Draft excluded (the index is published-only).
+      fixture(:article, %{tenant_id: tenant.id, status: :draft, title: "draft"})
+
+      {:ok, %{results: results, next_cursor: next_cursor}} =
+        Knowledge.list_index_keyset(tenant.id, limit: 20)
+
+      assert is_nil(next_cursor)
+      assert Enum.sort(Enum.map(results, & &1.id)) == Enum.sort(published)
+
+      inserted_ats = Enum.map(results, & &1.inserted_at)
+      assert inserted_ats == Enum.sort(inserted_ats, DateTime)
+    end
+  end
+
+  describe "list_index_keyset/2 — by-tag gap-free walk (TC-27.9b.1)" do
+    test "walks a tag to exhaustion exactly once" do
+      tenant = fixture(:tenant)
+
+      tagged =
+        for i <- 1..23 do
+          a =
+            fixture(:article, %{
+              tenant_id: tenant.id,
+              status: :published,
+              tags: ["walk"],
+              title: "n#{i}"
+            })
+
+          a.id
+        end
+
+      # An article with a different tag must not appear.
+      fixture(:article, %{tenant_id: tenant.id, status: :published, tags: ["other"]})
+
+      seen = walk(tenant.id, 5, tags: ["walk"])
+
+      assert Enum.sort(seen) == Enum.sort(tagged)
+      assert length(seen) == length(Enum.uniq(seen)), "no duplicates across pages"
+      assert length(seen) == 23
+    end
+
+    test "by-tag walk is stable under concurrent inserts AND archives (the #175 incident)" do
+      tenant = fixture(:tenant)
+
+      original_ids =
+        for i <- 1..20 do
+          a =
+            fixture(:article, %{
+              tenant_id: tenant.id,
+              status: :published,
+              tags: ["incident"],
+              title: "orig#{i}"
+            })
+
+          a.id
+        end
+
+      mutate = fn page ->
+        first = List.first(page)
+
+        Article
+        |> where([a], a.id == ^first.id)
+        |> AdminRepo.update_all(set: [status: :archived])
+
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :published,
+          tags: ["incident"],
+          title: "late-#{System.unique_integer([:positive])}"
+        })
+      end
+
+      seen = walk(tenant.id, 4, [tags: ["incident"]], mutate)
+
+      # Every ORIGINAL row appears exactly once — no offset drift, no skip from
+      # archiving an already-seen row.
+      for id <- original_ids do
+        count = Enum.count(seen, &(&1 == id))
+        assert count == 1, "original id #{id} seen #{count} times (expected exactly 1)"
+      end
+
+      assert length(seen) == length(Enum.uniq(seen)), "no duplicates in the whole walk"
+    end
+  end
+
+  describe "list_index_keyset/2 — by-source filter" do
+    test "filters by source_type and source_id" do
+      tenant = fixture(:tenant)
+      source = Ecto.UUID.generate()
+
+      matching =
+        for i <- 1..6 do
+          a =
+            fixture(:article, %{
+              tenant_id: tenant.id,
+              status: :published,
+              source_type: "ingestion",
+              source_id: source,
+              title: "src#{i}"
+            })
+
+          a.id
+        end
+
+      # Same source_type, different source_id → excluded.
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        status: :published,
+        source_type: "ingestion",
+        source_id: Ecto.UUID.generate()
+      })
+
+      seen = walk(tenant.id, 2, source_type: "ingestion", source_id: source)
+
+      assert Enum.sort(seen) == Enum.sort(matching)
+      assert length(seen) == 6
+    end
+
+    test "a malformed source_id matches nothing (no 500)" do
+      tenant = fixture(:tenant)
+      fixture(:article, %{tenant_id: tenant.id, status: :published, source_type: "ingestion"})
+
+      {:ok, %{results: results}} =
+        Knowledge.list_index_keyset(tenant.id, source_id: "not-a-uuid", limit: 50)
+
+      assert results == []
+    end
+  end
+
+  describe "list_index_keyset/2 — batch-tied timestamps (TUPLE tie-break)" do
+    test "walks rows sharing an identical inserted_at via the id tie-break" do
+      tenant = fixture(:tenant)
+
+      ids =
+        for i <- 1..10 do
+          a =
+            fixture(:article, %{
+              tenant_id: tenant.id,
+              status: :published,
+              tags: ["tie"],
+              title: "tie#{i}"
+            })
+
+          a.id
+        end
+
+      tied = ~U[2026-06-24 09:00:00.000000Z]
+
+      Article
+      |> where([a], a.id in ^ids)
+      |> AdminRepo.update_all(set: [inserted_at: tied])
+
+      # Page size 3 forces boundaries WITHIN the tied batch.
+      seen = walk(tenant.id, 3, tags: ["tie"])
+
+      assert Enum.sort(seen) == Enum.sort(ids)
+      assert length(seen) == 10
+      assert length(seen) == length(Enum.uniq(seen))
+    end
+  end
+
+  describe "list_index_keyset/2 — tenant isolation (AC-27.9b.4)" do
+    test "only returns the caller-tenant's rows" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+
+      a_ids =
+        for _ <- 1..4 do
+          a = fixture(:article, %{tenant_id: tenant_a.id, status: :published, tags: ["x"]})
+          a.id
+        end
+
+      for _ <- 1..4 do
+        fixture(:article, %{tenant_id: tenant_b.id, status: :published, tags: ["x"]})
+      end
+
+      seen = walk(tenant_a.id, 2, tags: ["x"])
+
+      assert Enum.sort(seen) == Enum.sort(a_ids)
+      assert length(seen) == 4
+    end
+
+    test "project scope includes tenant-wide + project rows" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      other_project = fixture(:project, %{tenant_id: tenant.id})
+
+      tenant_wide =
+        fixture(:article, %{tenant_id: tenant.id, status: :published, project_id: nil})
+
+      project_specific =
+        fixture(:article, %{tenant_id: tenant.id, status: :published, project_id: project.id})
+
+      # An article in a DIFFERENT project must not appear.
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        status: :published,
+        project_id: other_project.id
+      })
+
+      {:ok, %{results: results}} =
+        Knowledge.list_index_keyset(tenant.id, project_id: project.id, limit: 50)
+
+      ids = Enum.map(results, & &1.id)
+      assert tenant_wide.id in ids
+      assert project_specific.id in ids
+      assert length(ids) == 2
+    end
+  end
+
+  describe "index_keyset_query/2 — request-path query shape" do
+    test "is tenant-scoped, published-only, ordered (inserted_at, id)" do
+      tenant = fixture(:tenant)
+      fixture(:article, %{tenant_id: tenant.id, status: :published})
+
+      query = Knowledge.index_keyset_query(tenant.id, limit: 21)
+      {sql, _params} = SQL.to_sql(:all, AdminRepo, query)
+
+      assert sql =~ "tenant_id"
+      assert sql =~ ~r/order by.*inserted_at.*id/i
+      assert sql =~ ~r/limit/i
+    end
+  end
+end

--- a/test/loopctl_web/controllers/change_keyset_controller_test.exs
+++ b/test/loopctl_web/controllers/change_keyset_controller_test.exs
@@ -1,0 +1,194 @@
+defmodule LoopctlWeb.ChangeKeysetControllerTest do
+  @moduledoc """
+  HTTP integration tests for the KEYSET cursor on the change feed (US-27.9b),
+  exercised through `GET /api/v1/changes` with `?cursor=`.
+
+  Covers the tie-safe walk to exhaustion (AC-27.9b.1), the forged cross-tenant
+  cursor (AC-27.9b.4), tampered/garbage cursors → 400, and that the legacy
+  `?since=` token still works (back-compat).
+  """
+  use LoopctlWeb.ConnCase, async: true
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Audit.AuditLog
+  alias Loopctl.Audit.ChangesCursor
+
+  setup :verify_on_exit!
+
+  defp auth_conn(conn, raw_key) do
+    put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  # Insert `n` audit rows for a tenant at one shared timestamp (a tied batch).
+  defp insert_tied(tenant_id, n, ts) do
+    rows =
+      for i <- 1..n do
+        %{
+          id: Ecto.UUID.generate(),
+          tenant_id: tenant_id,
+          entity_type: "story",
+          entity_id: Ecto.UUID.generate(),
+          action: "story.updated",
+          actor_type: "api_key",
+          new_state: %{"n" => i},
+          metadata: %{},
+          inserted_at: ts
+        }
+      end
+
+    {_n, returned} = AdminRepo.insert_all(AuditLog, rows, returning: [:id])
+    Enum.map(returned, & &1.id)
+  end
+
+  defp walk_http(conn, raw_key, first_params) do
+    do_walk_http(conn, raw_key, first_params, [], 0)
+  end
+
+  defp do_walk_http(_conn, _key, _params, _acc, n) when n > 1_000 do
+    flunk("HTTP change-feed keyset walk did not terminate")
+  end
+
+  defp do_walk_http(conn, raw_key, params, acc, n) do
+    resp =
+      conn
+      |> auth_conn(raw_key)
+      |> get(~p"/api/v1/changes", params)
+      |> json_response(200)
+
+    acc = acc ++ Enum.map(resp["data"], & &1["id"])
+
+    case resp["next_cursor"] do
+      nil -> acc
+      next -> do_walk_http(conn, raw_key, %{"cursor" => next}, acc, n + 1)
+    end
+  end
+
+  describe "tie-safe keyset walk (AC-27.9b.1)" do
+    test "walks a tied-timestamp batch gap-free, ending with next_cursor null",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+      ts = ~U[2026-06-24 09:00:00.000000Z]
+
+      ids = insert_tied(tenant.id, 10, ts)
+
+      past = DateTime.from_unix!(0) |> DateTime.to_iso8601()
+      seen = walk_http(conn, raw_key, %{"since" => past, "limit" => "3"})
+
+      assert Enum.sort(seen) == Enum.sort(ids)
+      assert length(seen) == 10
+      assert length(seen) == length(Enum.uniq(seen)), "no duplicate across the tie boundary"
+    end
+
+    test "first page exposes next_cursor and (back-compat) next_since", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+      ts = ~U[2026-06-24 10:00:00.000000Z]
+      insert_tied(tenant.id, 6, ts)
+
+      past = DateTime.from_unix!(0) |> DateTime.to_iso8601()
+
+      resp =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/changes", %{"since" => past, "limit" => "3"})
+        |> json_response(200)
+
+      assert resp["has_more"] == true
+      assert resp["next_cursor"]
+      # next_since retained for back-compat (the tied timestamp).
+      assert resp["next_since"]
+    end
+  end
+
+  describe "forged / tampered cursor → 400 (AC-27.9b.4)" do
+    test "tenant A using a cursor forged with tenant B's key is rejected", %{conn: conn} do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      {raw_key_a, _} = fixture(:api_key, %{tenant_id: tenant_a.id, role: :orchestrator})
+
+      ts = ~U[2026-06-24 11:00:00.000000Z]
+      [b_id | _] = insert_tied(tenant_b.id, 1, ts)
+      insert_tied(tenant_a.id, 3, ts)
+
+      forged = ChangesCursor.encode(tenant_b.id, {ts, b_id})
+
+      resp =
+        conn
+        |> auth_conn(raw_key_a)
+        |> get(~p"/api/v1/changes", %{"cursor" => forged})
+
+      assert resp.status == 400
+
+      garbage =
+        conn
+        |> auth_conn(raw_key_a)
+        |> get(~p"/api/v1/changes", %{"cursor" => "garbage"})
+
+      assert json_response(garbage, 400) == json_response(resp, 400)
+    end
+
+    test "garbage cursor returns 400, not 500", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+      insert_tied(tenant.id, 1, ~U[2026-06-24 12:00:00.000000Z])
+
+      resp =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/changes", %{"cursor" => "not-a-cursor!!!"})
+
+      assert resp.status == 400
+      assert json_response(resp, 400)["error"]["message"] =~ "cursor"
+    end
+
+    test "non-string cursor returns 400", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      resp =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/changes?cursor[]=x", %{})
+
+      assert resp.status == 400
+    end
+  end
+
+  describe "back-compat since token" do
+    test "since-only request still works and emits next_cursor too", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+      base = ~U[2026-06-24 13:00:00.000000Z]
+
+      for i <- 0..4 do
+        insert_tied(tenant.id, 1, DateTime.add(base, i, :second))
+      end
+
+      since = DateTime.add(base, -1, :second) |> DateTime.to_iso8601()
+
+      resp =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/changes", %{"since" => since, "limit" => "2"})
+        |> json_response(200)
+
+      assert length(resp["data"]) == 2
+      assert resp["has_more"] == true
+      assert resp["next_cursor"]
+      assert resp["next_since"]
+    end
+
+    test "missing both since and cursor returns 400", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      resp =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/changes")
+
+      assert resp.status == 400
+    end
+  end
+end

--- a/test/loopctl_web/controllers/knowledge_index_keyset_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_index_keyset_controller_test.exs
@@ -1,0 +1,331 @@
+defmodule LoopctlWeb.KnowledgeIndexKeysetControllerTest do
+  @moduledoc """
+  HTTP integration tests for the KEYSET cursor on the knowledge index endpoint
+  (US-27.9b), exercised through `GET /api/v1/knowledge/index` with `?cursor=`.
+
+  Covers the by-tag/by-source cursor walk to exhaustion under concurrent writes
+  (TC-27.9b.1 / AC-27.9b.3), the forged cross-tenant cursor (AC-27.9b.4), tampered/
+  garbage cursors → 400, the index_keyset search_mode/meta contract, and the
+  back-compat offset path (no cursor → grouped + total_count, unchanged).
+  """
+  use LoopctlWeb.ConnCase, async: true
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.ArticleCursor
+
+  import Ecto.Query
+
+  setup :verify_on_exit!
+
+  defp auth_conn(conn, raw_key) do
+    put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  # Flatten the grouped `data` map into a list of article ids across all categories.
+  defp page_ids(resp) do
+    resp["data"]
+    |> Map.values()
+    |> List.flatten()
+    |> Enum.map(& &1["id"])
+  end
+
+  # Walk the index keyset endpoint to exhaustion, collecting ids. `mutate` runs
+  # between pages with the current page response. Returns the ids seen in order.
+  defp walk_http(conn, raw_key, base_params, mutate \\ fn _resp -> :ok end) do
+    do_walk_http(conn, raw_key, base_params, mutate, "", [], 0)
+  end
+
+  defp do_walk_http(_conn, _key, _params, _mutate, _cursor, _acc, n) when n > 1_000 do
+    flunk("HTTP index keyset walk did not terminate")
+  end
+
+  defp do_walk_http(conn, raw_key, base_params, mutate, cursor, acc, n) do
+    params = Map.put(base_params, "cursor", cursor)
+
+    resp =
+      conn
+      |> auth_conn(raw_key)
+      |> get(~p"/api/v1/knowledge/index", params)
+      |> json_response(200)
+
+    assert resp["meta"]["limit"]
+    assert resp["meta"]["search_mode"] == "index_keyset"
+
+    acc = acc ++ page_ids(resp)
+    next = resp["meta"]["next_cursor"]
+
+    if next do
+      mutate.(resp)
+      do_walk_http(conn, raw_key, base_params, mutate, next, acc, n + 1)
+    else
+      acc
+    end
+  end
+
+  describe "cursor walk (TC-27.9b.1 / AC-27.9b.3)" do
+    test "walks a tag to exhaustion exactly once, ending with next_cursor null", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      ids =
+        for i <- 1..17 do
+          a =
+            fixture(:article, %{
+              tenant_id: tenant.id,
+              status: :published,
+              category: :pattern,
+              tags: ["walk"],
+              title: "w#{i}"
+            })
+
+          a.id
+        end
+
+      seen = walk_http(conn, raw_key, %{"tags" => "walk", "limit" => "5"})
+
+      assert Enum.sort(seen) == Enum.sort(ids)
+      assert length(seen) == length(Enum.uniq(seen))
+    end
+
+    test "by-tag walk is gap-free under concurrent inserts and archives", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      original_ids =
+        for i <- 1..16 do
+          a =
+            fixture(:article, %{
+              tenant_id: tenant.id,
+              status: :published,
+              tags: ["mix"],
+              title: "orig#{i}"
+            })
+
+          a.id
+        end
+
+      {:ok, seen_tracker} = Agent.start_link(fn -> [] end)
+
+      mutate = fn resp ->
+        first_id = resp |> page_ids() |> List.first()
+
+        Article
+        |> where([a], a.id == ^first_id)
+        |> AdminRepo.update_all(set: [status: :archived])
+
+        Agent.update(seen_tracker, fn s -> s ++ [first_id] end)
+
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :published,
+          tags: ["mix"],
+          title: "new-#{System.unique_integer([:positive])}"
+        })
+      end
+
+      seen = walk_http(conn, raw_key, %{"tags" => "mix", "limit" => "4"}, mutate)
+
+      assert length(seen) == length(Enum.uniq(seen)), "no duplicates"
+
+      for returned_id <- Agent.get(seen_tracker, & &1) do
+        count = Enum.count(seen, &(&1 == returned_id))
+        assert count == 1, "row #{returned_id} returned then archived appeared #{count} times"
+      end
+
+      assert Enum.any?(original_ids, fn id -> id in seen end)
+      Agent.stop(seen_tracker)
+    end
+
+    test "by-source walk to exhaustion", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      source = Ecto.UUID.generate()
+
+      ids =
+        for i <- 1..9 do
+          a =
+            fixture(:article, %{
+              tenant_id: tenant.id,
+              status: :published,
+              source_type: "ingestion",
+              source_id: source,
+              title: "s#{i}"
+            })
+
+          a.id
+        end
+
+      # A different source must not leak in.
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        status: :published,
+        source_type: "ingestion",
+        source_id: Ecto.UUID.generate()
+      })
+
+      seen =
+        walk_http(conn, raw_key, %{
+          "source_type" => "ingestion",
+          "source_id" => source,
+          "limit" => "3"
+        })
+
+      assert Enum.sort(seen) == Enum.sort(ids)
+    end
+  end
+
+  describe "forged / tampered cursor → 400 (AC-27.9b.4)" do
+    test "tenant A using a cursor forged with tenant B's key is rejected, never crosses",
+         %{conn: conn} do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      {raw_key_a, _} = fixture(:api_key, %{tenant_id: tenant_a.id, role: :agent})
+
+      b_article =
+        fixture(:article, %{tenant_id: tenant_b.id, status: :published, tags: ["x"]})
+
+      for i <- 1..3 do
+        fixture(:article, %{
+          tenant_id: tenant_a.id,
+          status: :published,
+          tags: ["x"],
+          title: "a#{i}"
+        })
+      end
+
+      forged = ArticleCursor.encode(tenant_b.id, {b_article.inserted_at, b_article.id})
+
+      resp =
+        conn
+        |> auth_conn(raw_key_a)
+        |> get(~p"/api/v1/knowledge/index", %{"tags" => "x", "cursor" => forged})
+
+      assert resp.status == 400
+      body = json_response(resp, 400)
+
+      # Identical to a pure-garbage cursor (no existence oracle for B's row).
+      garbage_resp =
+        conn
+        |> auth_conn(raw_key_a)
+        |> get(~p"/api/v1/knowledge/index", %{"tags" => "x", "cursor" => "garbage"})
+
+      assert json_response(garbage_resp, 400) == body
+    end
+
+    test "garbage cursor returns 400, not 500 and not page 1", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      fixture(:article, %{tenant_id: tenant.id, status: :published, tags: ["g"]})
+
+      resp =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/index", %{"tags" => "g", "cursor" => "not-a-cursor!!!"})
+
+      assert resp.status == 400
+      assert json_response(resp, 400)["error"]["message"] =~ "cursor"
+    end
+
+    test "bit-flipped valid cursor returns 400", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      article = fixture(:article, %{tenant_id: tenant.id, status: :published, tags: ["g"]})
+      valid = ArticleCursor.encode(tenant.id, {article.inserted_at, article.id})
+
+      decoded = Base.url_decode64!(valid, padding: false)
+      <<first, rest::binary>> = decoded
+      tampered = Base.url_encode64(<<Bitwise.bxor(first, 1), rest::binary>>, padding: false)
+
+      resp =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/index", %{"tags" => "g", "cursor" => tampered})
+
+      assert resp.status == 400
+    end
+
+    test "non-string cursor (array form) returns 400", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      fixture(:article, %{tenant_id: tenant.id, status: :published, tags: ["g"]})
+
+      resp =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/index?tags=g&cursor[]=malformed", %{})
+
+      assert resp.status == 400
+    end
+  end
+
+  describe "meta contract (AC-27.9b.1)" do
+    test "first page documents next_cursor/has_more/limit/count; final page exhausts",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      for i <- 1..7 do
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :published,
+          tags: ["contract"],
+          title: "c#{i}"
+        })
+      end
+
+      page1 =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/index", %{
+          "tags" => "contract",
+          "limit" => "3",
+          "cursor" => ""
+        })
+        |> json_response(200)
+
+      assert page1["meta"]["next_cursor"]
+      assert page1["meta"]["has_more"] == true
+      assert page1["meta"]["limit"] == 3
+      assert page1["meta"]["count"] == 3
+      assert page1["meta"]["count"] == length(page_ids(page1))
+      assert page1["meta"]["search_mode"] == "index_keyset"
+      # offset-path-only keys are absent on the keyset path.
+      refute Map.has_key?(page1["meta"], "total_count")
+      refute Map.has_key?(page1["meta"], "offset")
+    end
+  end
+
+  describe "back-compat offset path (no cursor)" do
+    test "index without cursor still offset-paginates (grouped + total_count), unchanged",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      for i <- 1..3 do
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :published,
+          category: :pattern,
+          tags: ["bc"],
+          title: "bc#{i}"
+        })
+      end
+
+      resp =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/index", %{"tags" => "bc"})
+        |> json_response(200)
+
+      # Offset path meta is unchanged: total_count/offset/limit/categories, no cursor.
+      assert resp["meta"]["offset"] == 0
+      assert resp["meta"]["total_count"] == 3
+      assert is_map(resp["meta"]["categories"])
+      refute Map.has_key?(resp["meta"], "next_cursor")
+      # data is grouped by category.
+      assert is_map(resp["data"])
+      assert length(page_ids(resp)) == 3
+    end
+  end
+end

--- a/test/support/plan_assertions.ex
+++ b/test/support/plan_assertions.ex
@@ -44,17 +44,66 @@ defmodule Loopctl.PlanAssertions do
 
     bad = Enum.filter(scans, &(&1.node_type in @full_scan_types))
 
+    refute_full_scan_result(scans, bad, raw)
+  end
+
+  @doc """
+  Like `refute_full_scan/1` but targets the `audit_log` relation (US-27.9b change
+  feed). `audit_log` is RANGE-partitioned, so EXPLAIN reaches it via CHILD partition
+  relations (e.g. `audit_log_y2026m06`); this matches any relation whose name starts
+  with `audit_log` (parent or partition). Does NOT call `assert_fresh_stats!/0` (that
+  guard is `articles`-specific); the caller seeds + ANALYZEs `audit_log` itself.
+  """
+  def refute_full_scan_audit(queryable_or_sql) do
+    {root, raw} = explain_json(queryable_or_sql)
+    scans = relation_scan_nodes(root, "audit_log")
+    bad = Enum.filter(scans, &(&1.node_type in @full_scan_types))
+
+    refute_full_scan_result(scans, bad, raw)
+  end
+
+  defp refute_full_scan_result(scans, bad, raw) do
     cond do
       scans == [] ->
         raise ExUnit.AssertionError,
           message:
-            "Plan never reaches the `articles` relation — cannot judge full-scan vs index. Plan:\n#{elide(raw)}"
+            "Plan never reaches the target relation — cannot judge full-scan vs index. Plan:\n#{elide(raw)}"
 
       bad != [] ->
         raise ExUnit.AssertionError,
           message:
-            "Expected `articles` reached via an index, but a full-corpus scan node is present: " <>
-              "#{inspect(Enum.map(bad, & &1.node_type))} (the #170/#172 prod-500 shape). Plan:\n#{elide(raw)}"
+            "Expected the target relation reached via an index, but a full-corpus scan node is " <>
+              "present: #{inspect(Enum.map(bad, & &1.node_type))} (the #170/#172 prod-500 " <>
+              "shape). Plan:\n#{elide(raw)}"
+
+      true ->
+        :ok
+    end
+  end
+
+  @doc """
+  Like `refute_seq_scan/1` but targets the `audit_log` relation (US-27.9b change
+  feed). Allows a Bitmap Heap Scan driven by a selective index but forbids an
+  unbounded Seq Scan over the (partitioned) `audit_log`. Matches any relation whose
+  name starts with `audit_log` (parent or partition). Does NOT call
+  `assert_fresh_stats!/0` (that guard is `articles`-specific).
+  """
+  def refute_seq_scan_audit(queryable_or_sql) do
+    {root, raw} = explain_json(queryable_or_sql)
+    scans = relation_scan_nodes(root, "audit_log")
+    bad = Enum.filter(scans, &(&1.node_type == "Seq Scan"))
+
+    cond do
+      scans == [] ->
+        raise ExUnit.AssertionError,
+          message:
+            "Plan never reaches the `audit_log` relation — cannot judge scan shape. Plan:\n#{elide(raw)}"
+
+      bad != [] ->
+        raise ExUnit.AssertionError,
+          message:
+            "Expected no Seq Scan on `audit_log` (unbounded full read), but one is present. " <>
+              "Plan:\n#{elide(raw)}"
 
       true ->
         :ok
@@ -343,6 +392,28 @@ defmodule Loopctl.PlanAssertions do
       node
       |> Map.get("Plans", [])
       |> Enum.flat_map(&article_scan_nodes/1)
+
+    here ++ children
+  end
+
+  # Like `article_scan_nodes/1` but matches any relation whose name STARTS WITH
+  # `prefix` (for partitioned tables: the parent `audit_log` plus child partitions
+  # `audit_log_y2026m06`, all of which EXPLAIN names as the Relation Name on the scan
+  # node). Returns the same `%{node_type, index_name, rows}` shape.
+  defp relation_scan_nodes(node, prefix) when is_map(node) do
+    name = node["Relation Name"]
+
+    here =
+      if is_binary(name) and String.starts_with?(name, prefix) do
+        [%{node_type: node["Node Type"], index_name: node["Index Name"], rows: node["Plan Rows"]}]
+      else
+        []
+      end
+
+    children =
+      node
+      |> Map.get("Plans", [])
+      |> Enum.flat_map(&relation_scan_nodes(&1, prefix))
 
     here ++ children
   end

--- a/test/support/plan_assertions.ex
+++ b/test/support/plan_assertions.ex
@@ -51,15 +51,62 @@ defmodule Loopctl.PlanAssertions do
   Like `refute_full_scan/1` but targets the `audit_log` relation (US-27.9b change
   feed). `audit_log` is RANGE-partitioned, so EXPLAIN reaches it via CHILD partition
   relations (e.g. `audit_log_y2026m06`); this matches any relation whose name starts
-  with `audit_log` (parent or partition). Does NOT call `assert_fresh_stats!/0` (that
-  guard is `articles`-specific); the caller seeds + ANALYZEs `audit_log` itself.
+  with `audit_log` (parent or partition). Guards on an audit-flavored fresh-stats check
+  (`assert_fresh_stats_audit!/0`) instead of the `articles`-specific `assert_fresh_stats!/0`,
+  so a future seed that drops the ANALYZE can't silently false-green.
   """
   def refute_full_scan_audit(queryable_or_sql) do
+    assert_fresh_stats_audit!()
     {root, raw} = explain_json(queryable_or_sql)
     scans = relation_scan_nodes(root, "audit_log")
     bad = Enum.filter(scans, &(&1.node_type in @full_scan_types))
 
     refute_full_scan_result(scans, bad, raw)
+  end
+
+  @doc """
+  Audit-flavored sibling of `assert_fresh_stats!/0` (US-27.9b): raises unless
+  `audit_log` holds real rows AND at least one `audit_log*` partition has been ANALYZEd
+  (non-null `last_analyze`/`last_autoanalyze` in `pg_stat_user_tables`). Prevents a
+  change-feed plan assertion from running against an unseeded/unanalyzed corpus — a seed
+  that drops the `ANALYZE audit_log` would otherwise false-green (toy stats → the
+  planner picks a Seq Scan but the assertion can't tell, or the EXPLAIN row estimates
+  are meaningless).
+  """
+  def assert_fresh_stats_audit! do
+    %{rows: [[real_count]]} = AdminRepo.query!("SELECT count(*) FROM audit_log")
+
+    # Any audit_log partition with a non-null analyze timestamp counts as "analyzed".
+    %{rows: rows} =
+      AdminRepo.query!("""
+      SELECT count(*) FILTER (WHERE last_analyze IS NOT NULL OR last_autoanalyze IS NOT NULL)
+      FROM pg_stat_user_tables
+      WHERE relname LIKE 'audit_log_y%'
+      """)
+
+    analyzed_partitions =
+      case rows do
+        [[n]] when is_integer(n) -> n
+        _ -> 0
+      end
+
+    cond do
+      is_nil(real_count) or real_count <= 0 ->
+        raise ExUnit.AssertionError,
+          message:
+            "Change-feed plan assertion ran against an EMPTY `audit_log` (count=#{inspect(real_count)}). " <>
+              "Seed via Loopctl.Knowledge.ScaleSeed.seed_changes/2 (unboxed, committed) first."
+
+      analyzed_partitions == 0 ->
+        raise ExUnit.AssertionError,
+          message:
+            "Change-feed plan assertion ran against an UNANALYZED `audit_log` (no partition has " <>
+              "last_analyze/last_autoanalyze). ScaleSeed.seed_changes/2 runs `ANALYZE audit_log`; " <>
+              "ensure it isn't dropped before asserting."
+
+      true ->
+        :ok
+    end
   end
 
   defp refute_full_scan_result(scans, bad, raw) do
@@ -85,10 +132,11 @@ defmodule Loopctl.PlanAssertions do
   Like `refute_seq_scan/1` but targets the `audit_log` relation (US-27.9b change
   feed). Allows a Bitmap Heap Scan driven by a selective index but forbids an
   unbounded Seq Scan over the (partitioned) `audit_log`. Matches any relation whose
-  name starts with `audit_log` (parent or partition). Does NOT call
-  `assert_fresh_stats!/0` (that guard is `articles`-specific).
+  name starts with `audit_log` (parent or partition). Guards on the audit-flavored
+  `assert_fresh_stats_audit!/0` (not the `articles`-specific `assert_fresh_stats!/0`).
   """
   def refute_seq_scan_audit(queryable_or_sql) do
+    assert_fresh_stats_audit!()
     {root, raw} = explain_json(queryable_or_sql)
     scans = relation_scan_nodes(root, "audit_log")
     bad = Enum.filter(scans, &(&1.node_type == "Seq Scan"))
@@ -108,6 +156,77 @@ defmodule Loopctl.PlanAssertions do
       true ->
         :ok
     end
+  end
+
+  @doc """
+  Asserts the `audit_log` plan reaches **at least `min_partitions` distinct partition
+  relations** (`audit_log_yYYYYmMM`) via per-partition INDEX SCANS combined under an
+  ordered multi-partition node (US-27.9b). This is the prod shape for a deep
+  change-feed page whose cursor range spans months.
+
+  Postgres has TWO valid plans for `ORDER BY inserted_at, id` across partitions whose
+  index is `(tenant_id, inserted_at)` (no `id`):
+
+  - a **Merge Append** of per-partition Index Scans (when an index fully provides the
+    sort key), OR
+  - an **Append** of per-partition Index Scans + a top-level **Incremental Sort** /
+    **Sort** (presorted on `inserted_at`, finishing the `id` tie-break).
+
+  Both are correct, ordered, and bounded (no Seq/Bitmap over the corpus); the planner
+  picks by cost. We accept EITHER, and require that ≥`min_partitions` partitions are
+  reached by Index Scans (so the seed genuinely straddled the boundary and the plan is
+  not a single-partition shortcut that would make `refute_full_scan_audit` vacuous).
+  Pair with `refute_full_scan_audit/1` (forbids Seq/Bitmap on every partition).
+  """
+  def assert_ordered_multi_partition_scan(queryable_or_sql, min_partitions)
+      when is_integer(min_partitions) do
+    {root, raw} = explain_json(queryable_or_sql)
+
+    # Per-partition Index Scans (the bounded ordered access on each partition).
+    index_partitions =
+      root
+      |> relation_scan_nodes("audit_log_y")
+      |> Enum.filter(&(&1.node_type in ["Index Scan", "Index Only Scan"]))
+      |> Enum.map(& &1.relation)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.uniq()
+
+    # A multi-partition combiner: Merge Append (index-merged), OR Append paired with a
+    # top-level Sort/Incremental Sort that finishes the global order.
+    ordered_combiner? =
+      node_type_present?(root, "Merge Append") or
+        (node_type_present?(root, "Append") and
+           (node_type_present?(root, "Incremental Sort") or node_type_present?(root, "Sort")))
+
+    cond do
+      length(index_partitions) < min_partitions ->
+        raise ExUnit.AssertionError,
+          message:
+            "Expected ≥ #{min_partitions} distinct audit_log partitions reached by Index Scan " <>
+              "(a real boundary-straddling page), got #{length(index_partitions)}: " <>
+              "#{inspect(index_partitions)}. The seed must span ≥2 monthly partitions. " <>
+              "Plan:\n#{elide(raw)}"
+
+      not ordered_combiner? ->
+        raise ExUnit.AssertionError,
+          message:
+            "Expected an ordered multi-partition combiner (Merge Append, or Append + " <>
+              "Incremental Sort/Sort) over the audit_log partitions, but none is present. " <>
+              "Plan:\n#{elide(raw)}"
+
+      true ->
+        :ok
+    end
+  end
+
+  # True if any node anywhere in the plan tree has the given Node Type.
+  defp node_type_present?(node, type) when is_map(node) do
+    here = node["Node Type"] == type
+
+    here or
+      node
+      |> Map.get("Plans", [])
+      |> Enum.any?(&node_type_present?(&1, type))
   end
 
   @doc """
@@ -405,7 +524,14 @@ defmodule Loopctl.PlanAssertions do
 
     here =
       if is_binary(name) and String.starts_with?(name, prefix) do
-        [%{node_type: node["Node Type"], index_name: node["Index Name"], rows: node["Plan Rows"]}]
+        [
+          %{
+            node_type: node["Node Type"],
+            index_name: node["Index Name"],
+            rows: node["Plan Rows"],
+            relation: name
+          }
+        ]
       else
         []
       end


### PR DESCRIPTION
## US-27.9b: apply the keyset cursor to by-tag / by-source / change-feed enumerations

Rolls US-27.9a's proven keyset cursor onto the remaining enumeration surfaces so every way an agent walks the KB is drift-free under concurrent writes (the original #175 incident was a by-tag walk).

- **`GET /knowledge/index`** gains a dual path: `?cursor=` → keyset `(inserted_at, id)` (reusing the cursor + mechanic), applying the index's tags/source_type/source_id/category filters; cursor absent → the existing offset path unchanged.
- **`GET /changes`** converted from a timestamp-only `since` token (which provably drifts at tied timestamps) to a `(inserted_at, id)` tuple keyset (`next_cursor`), with `next_since` retained for back-compat.
- **by-source** got a real `(tenant_id, source_id, inserted_at, id) WHERE source_id IS NOT NULL` index (CONCURRENTLY) — 80k plan proven index-ordered + bounded; **by-tag** reuses 27.9a's GIN+btree path; **change-feed** proven index-backed across **≥2 partitions** (Append + Incremental Sort, no Seq/Bitmap).
- The security-critical cursor codec is now a **shared `Loopctl.KeysetCursor`** (namespace-parameterized; byte-identical key derivation so existing cursors stay valid; cross-surface non-interchangeability tested) with a shared `Loopctl.KeysetSeek`; the new index is registered in `IndexHealth`; `Audit.list_changes` runs on the HeavyRead pool.

Two enhanced-review rounds (team + adversarial) — **no correctness bugs**; findings were maintainability/coverage (shared cursor core, IndexHealth registration, multi-partition plan coverage, change-feed-as-6th-heavy-endpoint docs). `mix precommit` green (2845 tests); scale tests green.
