### PR TITLE
US-27.7b: distant_pairs/novelty index-correct on their own shapes + lint exceptions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,6 +322,7 @@ jobs:
           - test/loopctl/knowledge/keyset_plan_scale_test.exs
           - test/loopctl/knowledge/by_source_change_feed_plan_scale_test.exs
           - test/loopctl/knowledge/streaming_export_scale_test.exs
+          - test/loopctl/knowledge/distant_pairs_novelty_scale_test.exs
     services:
       postgres:
         image: pgvector/pgvector:pg16

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -3865,7 +3865,8 @@ defmodule Loopctl.Knowledge do
   # is `to_embedding_list/1`, which normalizes the const to a plain `[float()]` param —
   # the SAME value shape `nearest/4` binds — so the `::vector` cast never re-interpolates a
   # stored `%Pgvector{}` struct (the #168 production 500). The query stays tenant-scoped
-  # (`a.tenant_id == ^tenant_id`) and bounded by the `tags &&` GIN residual, never the corpus.
+  # (`a.tenant_id == ^tenant_id`) and is bounded by prior-tag selectivity — NEVER a
+  # full-corpus read (the verified plan shape is documented on novelty_distance_query/4).
   defp nearest_prior_distance(tenant_id, embedding, prior_tag, vis) do
     tenant_id
     |> novelty_distance_query(embedding, prior_tag, vis)
@@ -3878,8 +3879,17 @@ defmodule Loopctl.Knowledge do
   # (it executes inside a `Task.async_stream`, off the test process, so it can't be captured
   # in-process). The const is normalized to a plain `[float()]` via `to_embedding_list/1`
   # — the SAME value shape `nearest/4` binds — so the `::vector` cast never re-interpolates
-  # a stored `%Pgvector{}` (the #168 prod 500). Tenant-scoped + bounded by the `tags &&` GIN
-  # residual; NOT a top-k helper (registered in `Loopctl.Knowledge.CosineLintExceptions`).
+  # a stored `%Pgvector{}` (the #168 prod 500). NOT a top-k helper (registered in
+  # `Loopctl.Knowledge.CosineLintExceptions` — this function holds the `<=>` literal).
+  #
+  # BOUND (verified at 80k via EXPLAIN ANALYZE): tenant-scoped and bounded by prior-tag
+  # selectivity, NEVER a full-corpus read. Postgres rewrites `MIN(embedding <=> $const)` into
+  # `ORDER BY (embedding <=> $const) LIMIT 1` and serves it from the HNSW index
+  # (`articles_embedding_hnsw_idx`) with `tags &&` as a Filter (~0.3ms / 676 buffers); for a
+  # less-HNSW-friendly target/stats it may instead intersect the `tags &&` GIN
+  # (`articles_tags_index`) bitmap. The planner picks by cost — both are bounded; the
+  # invariant the scale test asserts is "bounded by prior-tag selectivity, not Seq Scan",
+  # accepting EITHER plan (it does NOT pin the node type).
   @doc false
   def novelty_distance_query(tenant_id, embedding, prior_tag, vis) do
     target = to_embedding_list(embedding)

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -3511,6 +3511,13 @@ defmodule Loopctl.Knowledge do
     Application.get_env(:loopctl, :max_pair_candidates, @max_pair_candidates)
   end
 
+  # Column-to-column self-join: `(a.embedding <=> b.embedding) BETWEEN $min AND $max` over
+  # a `LIMIT max_pair_candidates()` SAMPLED subquery. There is NO `$const` target vector
+  # here (both operands are stored columns), so pgvector's HNSW index cannot apply BY
+  # NATURE — this is NOT (and must not become) a `VectorSearch.nearest/4` call (US-27.7b —
+  # registered in `Loopctl.Knowledge.CosineLintExceptions`). It is bounded by the
+  # `max_pair_candidates()` sample LIMIT (NOT an O(n²) scan over the whole 80k corpus) and
+  # stays tenant-scoped (`a.tenant_id`/`b.tenant_id` filtered) via HeavyRead's structural guard.
   defp do_distant_pairs(tenant_id, min_d, max_d, limit, offset, bridge?, vis) do
     candidates =
       from(a in Article,
@@ -3850,16 +3857,40 @@ defmodule Loopctl.Knowledge do
 
   # Min cosine distance from the idea embedding to any prior proposal; nil when there
   # are no embedded priors (distinguishable from a genuine high score).
+  #
+  # This is a `MIN(? <=> $const::vector)` AGGREGATE over the prior-tag-scoped set, NOT a
+  # top-k `ORDER BY <=> LIMIT k`, so it is NOT (and must not become) a `VectorSearch.nearest/4`
+  # call: top-k-then-min ≠ the true MIN over the set (US-27.7b — registered in
+  # `Loopctl.Knowledge.CosineLintExceptions`). The only helper it shares with `nearest/4`
+  # is `to_embedding_list/1`, which normalizes the const to a plain `[float()]` param —
+  # the SAME value shape `nearest/4` binds — so the `::vector` cast never re-interpolates a
+  # stored `%Pgvector{}` struct (the #168 production 500). The query stays tenant-scoped
+  # (`a.tenant_id == ^tenant_id`) and bounded by the `tags &&` GIN residual, never the corpus.
   defp nearest_prior_distance(tenant_id, embedding, prior_tag, vis) do
+    tenant_id
+    |> novelty_distance_query(embedding, prior_tag, vis)
+    # Heavy vector aggregate — dedicated pool via Loopctl.HeavyRead (US-27.11).
+    |> then(&HeavyRead.one(tenant_id, &1, heavy_read_opts(:novelty)))
+  end
+
+  # The `MIN(embedding <=> $const::vector)` aggregate query, scoped to the prior-tag set.
+  # Extracted so the US-27.7b scale gate can EXPLAIN the EXACT query the request path runs
+  # (it executes inside a `Task.async_stream`, off the test process, so it can't be captured
+  # in-process). The const is normalized to a plain `[float()]` via `to_embedding_list/1`
+  # — the SAME value shape `nearest/4` binds — so the `::vector` cast never re-interpolates
+  # a stored `%Pgvector{}` (the #168 prod 500). Tenant-scoped + bounded by the `tags &&` GIN
+  # residual; NOT a top-k helper (registered in `Loopctl.Knowledge.CosineLintExceptions`).
+  @doc false
+  def novelty_distance_query(tenant_id, embedding, prior_tag, vis) do
+    target = to_embedding_list(embedding)
+
     from(a in Article,
       where:
         a.tenant_id == ^tenant_id and a.status == :published and not is_nil(a.embedding) and
           fragment("? && ?", a.tags, ^[prior_tag]),
-      select: fragment("MIN(? <=> ?::vector)", a.embedding, ^embedding)
+      select: fragment("MIN(? <=> ?::vector)", a.embedding, ^target)
     )
     |> maybe_filter_by_visibility(vis)
-    # Heavy vector aggregate — dedicated pool via Loopctl.HeavyRead (US-27.11).
-    |> then(&HeavyRead.one(tenant_id, &1, heavy_read_opts(:novelty)))
   end
 
   # --- Embeddings ---

--- a/lib/loopctl/knowledge/cosine_lint_exceptions.ex
+++ b/lib/loopctl/knowledge/cosine_lint_exceptions.ex
@@ -11,7 +11,7 @@ defmodule Loopctl.Knowledge.CosineLintExceptions do
   the HNSW index). US-27.8 introduces a "no hand-rolled cosine ORDER BY/distance outside
   the helper" source-lint to prevent that shape from being reintroduced ad hoc.
 
-  Two functions in `Loopctl.Knowledge` legitimately compute a cosine `<=>` distance WITHOUT
+  Some functions in `Loopctl.Knowledge` legitimately compute a cosine `<=>` distance WITHOUT
   going through (and MUST NOT be routed through) `nearest/4`, because neither is a
   top-k-against-a-constant — forcing them onto `nearest/4` would CHANGE their semantics:
 
@@ -19,20 +19,34 @@ defmodule Loopctl.Knowledge.CosineLintExceptions do
       (`a.embedding <=> b.embedding`). There is no `$const` target vector, so HNSW cannot
       apply by nature; it is instead bounded by a `LIMIT max_pair_candidates()` sampled
       subquery.
-    * `nearest_prior_distance/4` — a `MIN(embedding <=> $const::vector)` AGGREGATE.
+    * `novelty_distance_query/4` — builds a `MIN(embedding <=> $const::vector)` AGGREGATE.
       Top-k-then-min ≠ the true MIN over the prior-tag-scoped set, so a top-k helper would
-      change recall semantics; it is bounded by the `tags &&` GIN residual.
+      change recall semantics. Bounded by prior-tag selectivity (NOT a full-corpus read):
+      Postgres serves the MIN via an HNSW `ORDER BY <=> LIMIT 1` rewrite (verified at 80k)
+      OR a `tags &&` GIN-bounded scan — the planner picks by cost; either way bounded.
+      `nearest_prior_distance/4` is its logical owner (the caller that runs it through
+      `HeavyRead`) and is registered too for documentation, but the `<=>` literal lives in
+      `novelty_distance_query/4` after the US-27.7b extraction.
 
-  This module is the SINGLE, programmatic source of truth the US-27.8 lint reads so it
-  does NOT false-positive on these two legitimately-different shapes — and so the set of
-  exceptions stays auditable (each carries a one-line rationale; adding a new exception is
-  a visible, reviewable diff here, not a scattered inline comment the lint can't see).
+  ## How the US-27.8 lint consumes this (the mapping is NOT free)
+
+  The lint scans the source for a hand-rolled cosine `<=>` site, then resolves that site to
+  its ENCLOSING `def`/`defp` and arity (e.g. via the AST / `Macro` env) BEFORE calling
+  `registered?/3`. So the function that must appear in this allowlist is the one whose body
+  TEXTUALLY CONTAINS the `<=>` operator — `do_distant_pairs/7` and `novelty_distance_query/4`
+  — not necessarily the logical/owning caller. (Registering only the owner would let the
+  lint false-positive on the extracted builder that actually holds the literal.)
+
+  This module is the SINGLE, programmatic source of truth that lint reads so it does NOT
+  false-positive on these legitimately-different shapes — and so the set of exceptions stays
+  auditable (each carries a non-empty one-line rationale; adding a new exception is a
+  visible, reviewable diff here, not a scattered inline comment the lint can't see).
 
   ## Shape
 
-  `exceptions/0` returns a list of `%{module, function, arity, rationale}` maps. A future
-  lint matches a flagged hand-rolled-cosine site against `{module, function, arity}` and
-  skips it iff there is a registered exception whose `rationale` is non-empty.
+  `exceptions/0` returns a list of `%{module, function, arity, rationale}` maps.
+  `registered?/3` returns true only for a registered `{module, function, arity}` whose
+  rationale is NON-EMPTY — a blank justification can never silently suppress the lint.
   """
 
   @typedoc """
@@ -58,11 +72,21 @@ defmodule Loopctl.Knowledge.CosineLintExceptions do
     },
     %{
       module: Loopctl.Knowledge,
+      function: :novelty_distance_query,
+      arity: 4,
+      rationale:
+        "builds MIN(embedding <=> $const::vector) — the `<=>` literal lives here after the " <>
+          "US-27.7b extraction; top-k then min ≠ true min over the set; bounded by prior-tag " <>
+          "selectivity (HNSW ORDER-BY-LIMIT-1 rewrite OR a tags && GIN scan), never full-corpus"
+    },
+    %{
+      module: Loopctl.Knowledge,
       function: :nearest_prior_distance,
       arity: 4,
       rationale:
-        "MIN(embedding <=> $const::vector) aggregate — top-k then min ≠ true min over " <>
-          "the set; bounded by the prior-tag (tags &&) GIN residual"
+        "logical owner of the novelty MIN aggregate (runs novelty_distance_query/4 through " <>
+          "HeavyRead) — documented for auditability; the cosine literal itself is in " <>
+          "novelty_distance_query/4 (also registered)"
     }
   ]
 
@@ -77,17 +101,20 @@ defmodule Loopctl.Knowledge.CosineLintExceptions do
   def exceptions, do: @exceptions
 
   @doc """
-  Returns true iff `{module, function, arity}` is a registered exception.
+  Returns true iff `{module, function, arity}` is a registered exception **with a
+  non-empty rationale**.
 
   Intended for the US-27.8 lint: a flagged hand-rolled-cosine site is a violation UNLESS
-  this returns true for its enclosing function.
+  this returns true for its enclosing function. The non-empty-rationale requirement means a
+  registry entry with a blank justification can never silently suppress the lint — it would
+  still be reported, forcing a real rationale to be written.
   """
   @spec registered?(module(), atom(), arity()) :: boolean()
   def registered?(module, function, arity)
       when is_atom(module) and is_atom(function) and is_integer(arity) do
-    Enum.any?(
-      @exceptions,
-      &(&1.module == module and &1.function == function and &1.arity == arity)
-    )
+    Enum.any?(@exceptions, fn exc ->
+      exc.module == module and exc.function == function and exc.arity == arity and
+        is_binary(exc.rationale) and String.trim(exc.rationale) != ""
+    end)
   end
 end

--- a/lib/loopctl/knowledge/cosine_lint_exceptions.ex
+++ b/lib/loopctl/knowledge/cosine_lint_exceptions.ex
@@ -5,11 +5,27 @@ defmodule Loopctl.Knowledge.CosineLintExceptions do
 
   ## Why this exists
 
-  The shared `VectorSearch.nearest/4` helper is the ONLY place a top-k
-  `ORDER BY embedding <=> $const LIMIT k` should be written — its exact SQL shape is
-  load-bearing (the #168/#170/#172 production 500s came from variations that defeated
-  the HNSW index). US-27.8 introduces a "no hand-rolled cosine ORDER BY/distance outside
-  the helper" source-lint to prevent that shape from being reintroduced ad hoc.
+  The shared `Loopctl.Knowledge.VectorSearch` module is the sanctioned home for top-k
+  `ORDER BY embedding <=> $const LIMIT k` — its exact SQL shape is load-bearing (the
+  #168/#170/#172 production 500s came from variations that defeated the HNSW index). US-27.8
+  introduces a "no hand-rolled cosine ORDER BY/distance outside the helper" source-lint to
+  prevent that shape from being reintroduced ad hoc.
+
+  This registry is NOT a claim that no other `<=>` exists in the codebase — it is the
+  auditable list of the TWO US-27.7b-owned exceptions (distant_pairs + novelty). The broader
+  cosine-site inventory and the lint's full exemption policy are US-27.8's design. For
+  context, the other known cosine sites the US-27.8 lint must account for (NOT registered
+  here — out of US-27.7b's scope) are:
+
+    * `Loopctl.Knowledge.VectorSearch`'s own query builders (e.g. `candidate_query/4`) —
+      they necessarily CONTAIN the `<=>` literal because that module IS the sanctioned top-k
+      helper; US-27.8 will exempt the whole `VectorSearch` module as its home, not via this
+      per-function registry.
+    * `Loopctl.Knowledge.suggestion_candidates_query/6` — a known, intentional INLINE top-k
+      `ORDER BY embedding <=> $const LIMIT pool` whose own comment frames the inline split as
+      the #170/#172 prod-500 FIX (the index-defeating anti-join/threshold was moved to the
+      OUTER query so the inner ANN stays HNSW-eligible). Its lint disposition is a US-27.8
+      decision, deliberately left out of this US-27.7b registry.
 
   Some functions in `Loopctl.Knowledge` legitimately compute a cosine `<=>` distance WITHOUT
   going through (and MUST NOT be routed through) `nearest/4`, because neither is a
@@ -112,9 +128,29 @@ defmodule Loopctl.Knowledge.CosineLintExceptions do
   @spec registered?(module(), atom(), arity()) :: boolean()
   def registered?(module, function, arity)
       when is_atom(module) and is_atom(function) and is_integer(arity) do
-    Enum.any?(@exceptions, fn exc ->
-      exc.module == module and exc.function == function and exc.arity == arity and
-        is_binary(exc.rationale) and String.trim(exc.rationale) != ""
+    registered_in?(@exceptions, module, function, arity)
+  end
+
+  @doc """
+  Pure form of `registered?/3` that takes the exception list explicitly: true iff
+  `{module, function, arity}` matches an entry in `exceptions` whose rationale is non-empty.
+
+  Extracted so the rationale-rejection branch (an entry with a blank/nil rationale does NOT
+  suppress the lint) is reachable by tests — the compile-time `@exceptions` constant is
+  all-non-empty by construction, so without this seam that branch would be untestable.
+  """
+  @spec registered_in?([exception()] | [map()], module(), atom(), arity()) :: boolean()
+  def registered_in?(exceptions, module, function, arity)
+      when is_list(exceptions) and is_atom(module) and is_atom(function) and is_integer(arity) do
+    Enum.any?(exceptions, fn exc ->
+      exc[:module] == module and exc[:function] == function and exc[:arity] == arity and
+        non_empty_rationale?(exc[:rationale])
     end)
+  end
+
+  # A rationale suppresses the lint only when it is a present, non-blank string. A nil or
+  # whitespace-only rationale must NOT suppress — it forces a real justification to be written.
+  defp non_empty_rationale?(rationale) do
+    is_binary(rationale) and String.trim(rationale) != ""
   end
 end

--- a/lib/loopctl/knowledge/cosine_lint_exceptions.ex
+++ b/lib/loopctl/knowledge/cosine_lint_exceptions.ex
@@ -1,0 +1,93 @@
+defmodule Loopctl.Knowledge.CosineLintExceptions do
+  @moduledoc """
+  The auditable allowlist of functions that legitimately hand-roll a cosine
+  distance/ORDER BY **outside** the shared `Loopctl.Knowledge.VectorSearch` helper.
+
+  ## Why this exists
+
+  The shared `VectorSearch.nearest/4` helper is the ONLY place a top-k
+  `ORDER BY embedding <=> $const LIMIT k` should be written — its exact SQL shape is
+  load-bearing (the #168/#170/#172 production 500s came from variations that defeated
+  the HNSW index). US-27.8 introduces a "no hand-rolled cosine ORDER BY/distance outside
+  the helper" source-lint to prevent that shape from being reintroduced ad hoc.
+
+  Two functions in `Loopctl.Knowledge` legitimately compute a cosine `<=>` distance WITHOUT
+  going through (and MUST NOT be routed through) `nearest/4`, because neither is a
+  top-k-against-a-constant — forcing them onto `nearest/4` would CHANGE their semantics:
+
+    * `do_distant_pairs/7` — a column-to-column self-join
+      (`a.embedding <=> b.embedding`). There is no `$const` target vector, so HNSW cannot
+      apply by nature; it is instead bounded by a `LIMIT max_pair_candidates()` sampled
+      subquery.
+    * `nearest_prior_distance/4` — a `MIN(embedding <=> $const::vector)` AGGREGATE.
+      Top-k-then-min ≠ the true MIN over the prior-tag-scoped set, so a top-k helper would
+      change recall semantics; it is bounded by the `tags &&` GIN residual.
+
+  This module is the SINGLE, programmatic source of truth the US-27.8 lint reads so it
+  does NOT false-positive on these two legitimately-different shapes — and so the set of
+  exceptions stays auditable (each carries a one-line rationale; adding a new exception is
+  a visible, reviewable diff here, not a scattered inline comment the lint can't see).
+
+  ## Shape
+
+  `exceptions/0` returns a list of `%{module, function, arity, rationale}` maps. A future
+  lint matches a flagged hand-rolled-cosine site against `{module, function, arity}` and
+  skips it iff there is a registered exception whose `rationale` is non-empty.
+  """
+
+  @typedoc """
+  A single registered exception: the `{module, function, arity}` of a function that
+  hand-rolls a cosine `<=>` distance outside `VectorSearch`, plus a one-line `rationale`
+  the lint surfaces when it skips that site.
+  """
+  @type exception :: %{
+          module: module(),
+          function: atom(),
+          arity: arity(),
+          rationale: String.t()
+        }
+
+  @exceptions [
+    %{
+      module: Loopctl.Knowledge,
+      function: :do_distant_pairs,
+      arity: 7,
+      rationale:
+        "column-to-column self-join (a.embedding <=> b.embedding) — no $const target, " <>
+          "HNSW N/A; bounded by the max_pair_candidates() sampled subquery"
+    },
+    %{
+      module: Loopctl.Knowledge,
+      function: :nearest_prior_distance,
+      arity: 4,
+      rationale:
+        "MIN(embedding <=> $const::vector) aggregate — top-k then min ≠ true min over " <>
+          "the set; bounded by the prior-tag (tags &&) GIN residual"
+    }
+  ]
+
+  @doc """
+  Returns the full list of registered cosine-lint exceptions.
+
+  Each entry is a `t:exception/0`. The list is the auditable source of truth the US-27.8
+  guard consumes — extend it (with a non-empty rationale) when a genuinely-different
+  cosine shape is added, rather than suppressing the lint inline.
+  """
+  @spec exceptions() :: [exception()]
+  def exceptions, do: @exceptions
+
+  @doc """
+  Returns true iff `{module, function, arity}` is a registered exception.
+
+  Intended for the US-27.8 lint: a flagged hand-rolled-cosine site is a violation UNLESS
+  this returns true for its enclosing function.
+  """
+  @spec registered?(module(), atom(), arity()) :: boolean()
+  def registered?(module, function, arity)
+      when is_atom(module) and is_atom(function) and is_integer(arity) do
+    Enum.any?(
+      @exceptions,
+      &(&1.module == module and &1.function == function and &1.arity == arity)
+    )
+  end
+end

--- a/test/loopctl/knowledge/cosine_lint_exceptions_test.exs
+++ b/test/loopctl/knowledge/cosine_lint_exceptions_test.exs
@@ -1,0 +1,73 @@
+defmodule Loopctl.Knowledge.CosineLintExceptionsTest do
+  @moduledoc """
+  US-27.7b TC-27.7b.3: the NAMED, auditable allowlist of hand-rolled-cosine sites that
+  legitimately live OUTSIDE `VectorSearch` (the future US-27.8 "no hand-rolled cosine"
+  guard reads this registry so it does not false-positive on these two shapes).
+
+  Asserts BOTH `do_distant_pairs` and `nearest_prior_distance` are registered, each with a
+  non-empty rationale, and that the registry is the programmatic source of exceptions
+  (`registered?/3` matches exactly the documented `{module, function, arity}` triples).
+  """
+  use ExUnit.Case, async: true
+
+  alias Loopctl.Knowledge.CosineLintExceptions
+
+  describe "exceptions/0 — the auditable allowlist (AC-27.7b.3)" do
+    test "registers BOTH distant_pairs and nearest_prior_distance" do
+      registered =
+        CosineLintExceptions.exceptions()
+        |> Enum.map(&{&1.module, &1.function, &1.arity})
+
+      assert {Loopctl.Knowledge, :do_distant_pairs, 7} in registered
+      assert {Loopctl.Knowledge, :nearest_prior_distance, 4} in registered
+    end
+
+    test "every exception carries a non-empty one-line rationale" do
+      for exc <- CosineLintExceptions.exceptions() do
+        assert is_binary(exc.rationale)
+
+        assert String.trim(exc.rationale) != "",
+               "exception #{inspect({exc.module, exc.function, exc.arity})} has an empty rationale"
+      end
+    end
+
+    test "distant_pairs rationale names the column-to-column / no-$const reason" do
+      rationale = rationale_for(:do_distant_pairs, 7)
+      assert rationale =~ "column-to-column"
+      assert rationale =~ ~r/\$const|HNSW/
+    end
+
+    test "nearest_prior_distance rationale names the MIN-aggregate reason" do
+      rationale = rationale_for(:nearest_prior_distance, 4)
+      assert rationale =~ "MIN"
+      assert rationale =~ ~r/aggregate|min/
+    end
+
+    test "the registry is the programmatic source (each entry has a well-formed shape)" do
+      for exc <- CosineLintExceptions.exceptions() do
+        assert is_atom(exc.module)
+        assert is_atom(exc.function)
+        assert is_integer(exc.arity) and exc.arity >= 0
+      end
+    end
+  end
+
+  describe "registered?/3 — what the US-27.8 guard calls (AC-27.7b.3)" do
+    test "true for both registered exceptions" do
+      assert CosineLintExceptions.registered?(Loopctl.Knowledge, :do_distant_pairs, 7)
+      assert CosineLintExceptions.registered?(Loopctl.Knowledge, :nearest_prior_distance, 4)
+    end
+
+    test "false for a non-registered function (the guard would still flag it)" do
+      refute CosineLintExceptions.registered?(Loopctl.Knowledge, :search_semantic, 3)
+      refute CosineLintExceptions.registered?(Loopctl.Knowledge, :do_distant_pairs, 99)
+      refute CosineLintExceptions.registered?(SomeOther.Module, :do_distant_pairs, 7)
+    end
+  end
+
+  defp rationale_for(function, arity) do
+    CosineLintExceptions.exceptions()
+    |> Enum.find(&(&1.function == function and &1.arity == arity))
+    |> Map.fetch!(:rationale)
+  end
+end

--- a/test/loopctl/knowledge/cosine_lint_exceptions_test.exs
+++ b/test/loopctl/knowledge/cosine_lint_exceptions_test.exs
@@ -4,21 +4,31 @@ defmodule Loopctl.Knowledge.CosineLintExceptionsTest do
   legitimately live OUTSIDE `VectorSearch` (the future US-27.8 "no hand-rolled cosine"
   guard reads this registry so it does not false-positive on these two shapes).
 
-  Asserts BOTH `do_distant_pairs` and `nearest_prior_distance` are registered, each with a
-  non-empty rationale, and that the registry is the programmatic source of exceptions
-  (`registered?/3` matches exactly the documented `{module, function, arity}` triples).
+  Asserts the `<=>`-bearing functions (`do_distant_pairs/7` and `novelty_distance_query/4`,
+  the function the US-27.7b extraction moved the cosine literal into) AND the logical owner
+  `nearest_prior_distance/4` are registered, each with a non-empty rationale, and that the
+  registry is the programmatic source of exceptions (`registered?/3` matches exactly the
+  documented `{module, function, arity}` triples AND requires a non-empty rationale).
   """
   use ExUnit.Case, async: true
 
   alias Loopctl.Knowledge.CosineLintExceptions
 
   describe "exceptions/0 — the auditable allowlist (AC-27.7b.3)" do
-    test "registers BOTH distant_pairs and nearest_prior_distance" do
+    test "registers the `<=>`-bearing functions AND the logical owner" do
       registered =
         CosineLintExceptions.exceptions()
         |> Enum.map(&{&1.module, &1.function, &1.arity})
 
+      # do_distant_pairs/7 textually contains its `a.embedding <=> b.embedding`.
       assert {Loopctl.Knowledge, :do_distant_pairs, 7} in registered
+
+      # novelty_distance_query/4 is where the US-27.7b extraction PUT the `MIN(<=>)` literal,
+      # so a US-27.8 lint that maps a flagged `<=>` site to its enclosing def lands HERE —
+      # it MUST be registered or the lint false-positives.
+      assert {Loopctl.Knowledge, :novelty_distance_query, 4} in registered
+
+      # nearest_prior_distance/4 is the logical owner (kept for documentation).
       assert {Loopctl.Knowledge, :nearest_prior_distance, 4} in registered
     end
 
@@ -37,10 +47,19 @@ defmodule Loopctl.Knowledge.CosineLintExceptionsTest do
       assert rationale =~ ~r/\$const|HNSW/
     end
 
-    test "nearest_prior_distance rationale names the MIN-aggregate reason" do
-      rationale = rationale_for(:nearest_prior_distance, 4)
+    test "novelty_distance_query rationale names the MIN-aggregate reason + the bound" do
+      rationale = rationale_for(:novelty_distance_query, 4)
       assert rationale =~ "MIN"
-      assert rationale =~ ~r/aggregate|min/
+      assert rationale =~ ~r/<=>|aggregate|min/
+      # Bound is honestly stated as prior-tag selectivity / never full-corpus.
+      assert rationale =~ "prior-tag"
+      assert rationale =~ "never full-corpus"
+    end
+
+    test "nearest_prior_distance rationale marks it the logical owner" do
+      rationale = rationale_for(:nearest_prior_distance, 4)
+      assert rationale =~ ~r/owner/i
+      assert rationale =~ "novelty_distance_query"
     end
 
     test "the registry is the programmatic source (each entry has a well-formed shape)" do
@@ -53,8 +72,9 @@ defmodule Loopctl.Knowledge.CosineLintExceptionsTest do
   end
 
   describe "registered?/3 — what the US-27.8 guard calls (AC-27.7b.3)" do
-    test "true for both registered exceptions" do
+    test "true for every registered exception, including the `<=>`-bearing builder" do
       assert CosineLintExceptions.registered?(Loopctl.Knowledge, :do_distant_pairs, 7)
+      assert CosineLintExceptions.registered?(Loopctl.Knowledge, :novelty_distance_query, 4)
       assert CosineLintExceptions.registered?(Loopctl.Knowledge, :nearest_prior_distance, 4)
     end
 
@@ -62,6 +82,17 @@ defmodule Loopctl.Knowledge.CosineLintExceptionsTest do
       refute CosineLintExceptions.registered?(Loopctl.Knowledge, :search_semantic, 3)
       refute CosineLintExceptions.registered?(Loopctl.Knowledge, :do_distant_pairs, 99)
       refute CosineLintExceptions.registered?(SomeOther.Module, :do_distant_pairs, 7)
+    end
+
+    test "every registered entry's rationale is non-empty, so registered?/3 actually suppresses" do
+      # registered?/3 requires a non-empty rationale; this proves no real entry is suppressed
+      # by accident AND documents the contract that a blank rationale would NOT suppress.
+      for exc <- CosineLintExceptions.exceptions() do
+        assert CosineLintExceptions.registered?(exc.module, exc.function, exc.arity),
+               "#{inspect({exc.module, exc.function, exc.arity})} must be recognized by registered?/3"
+
+        assert String.trim(exc.rationale) != ""
+      end
     end
   end
 

--- a/test/loopctl/knowledge/cosine_lint_exceptions_test.exs
+++ b/test/loopctl/knowledge/cosine_lint_exceptions_test.exs
@@ -96,6 +96,38 @@ defmodule Loopctl.Knowledge.CosineLintExceptionsTest do
     end
   end
 
+  describe "registered_in?/4 — the rationale-rejection branch (AC-27.7b.3)" do
+    # @exceptions is all-non-empty by construction, so the rejection branch is unreachable
+    # via registered?/3. registered_in?/4 takes the list explicitly, letting us PROVE the
+    # gate REJECTS a blank/nil/whitespace rationale (a blank justification must not suppress).
+    test "a present, non-blank rationale suppresses (true)" do
+      list = [%{module: Foo, function: :bar, arity: 1, rationale: "real reason"}]
+      assert CosineLintExceptions.registered_in?(list, Foo, :bar, 1)
+    end
+
+    test "an empty-string rationale does NOT suppress (false)" do
+      list = [%{module: Foo, function: :bar, arity: 1, rationale: ""}]
+      refute CosineLintExceptions.registered_in?(list, Foo, :bar, 1)
+    end
+
+    test "a whitespace-only rationale does NOT suppress (false)" do
+      list = [%{module: Foo, function: :bar, arity: 1, rationale: "   \t\n"}]
+      refute CosineLintExceptions.registered_in?(list, Foo, :bar, 1)
+    end
+
+    test "a nil rationale does NOT suppress (false)" do
+      list = [%{module: Foo, function: :bar, arity: 1, rationale: nil}]
+      refute CosineLintExceptions.registered_in?(list, Foo, :bar, 1)
+    end
+
+    test "a non-matching {module, function, arity} does NOT suppress even with a good rationale" do
+      list = [%{module: Foo, function: :bar, arity: 1, rationale: "real reason"}]
+      refute CosineLintExceptions.registered_in?(list, Foo, :bar, 2)
+      refute CosineLintExceptions.registered_in?(list, Foo, :baz, 1)
+      refute CosineLintExceptions.registered_in?([], Foo, :bar, 1)
+    end
+  end
+
   defp rationale_for(function, arity) do
     CosineLintExceptions.exceptions()
     |> Enum.find(&(&1.function == function and &1.arity == arity))

--- a/test/loopctl/knowledge/distant_pairs_novelty_scale_test.exs
+++ b/test/loopctl/knowledge/distant_pairs_novelty_scale_test.exs
@@ -1,0 +1,162 @@
+defmodule Loopctl.Knowledge.DistantPairsNoveltyScaleTest do
+  @moduledoc """
+  US-27.7b AC-27.7b.4 scale gate: prove the two cosine shapes that are deliberately NOT
+  `VectorSearch.nearest/4` (see `Loopctl.Knowledge.CosineLintExceptions`) do NOT full-scan
+  the corpus at >= prod scale, each on its OWN bounded shape:
+
+    * `distant_pairs` — the column-to-column self-join reads `articles` ONLY through the
+      `LIMIT max_pair_candidates()` SAMPLED subquery, so every base-table scan is bounded
+      by the sample cap (NOT an O(n²)/Seq read over the whole 80k corpus).
+    * `novelty` (`nearest_prior_distance`) — the `MIN(<=>)` aggregate is scoped by the
+      `tags &&` GIN residual (`articles_tags_index`), so it reaches `articles` via a
+      Bitmap Index Scan bounded by the tag's selectivity, NOT a Seq Scan over 80k.
+
+  We assert on the ACTUAL SQL+params the request path emits (captured via
+  `PlanAssertions.capture_repo_queries/1`), not an independently reconstructed query, then
+  EXPLAIN it under the planner's NATURAL choice (no enable_seqscan=off) against the
+  committed, ANALYZEd ~80k corpus from `Loopctl.Knowledge.ScaleSeed`.
+
+  Seeds ~80k committed rows, so this is `:scale_nightly` (runs on the nightly/scale gate,
+  NOT the default async suite which has no seeded corpus).
+  """
+  use ExUnit.Case, async: false
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.ScaleSeed
+  alias Loopctl.PlanAssertions
+  alias Loopctl.Tenants.Tenant
+
+  import Ecto.Query
+
+  @moduletag :scale_nightly
+  @moduletag timeout: :timer.minutes(30)
+
+  # The operator-tunable candidate cap (config/test.exs sets it to 25). The sampled
+  # candidate subquery — and therefore every `articles` base-table scan in distant_pairs —
+  # must read no more than this (with generous headroom for the planner's row estimate).
+  @max_pair_candidates Application.compile_env(:loopctl, :max_pair_candidates, 1_000)
+
+  # The tag ScaleSeed stamps on ~2% of rows (one of 50). Used as the novelty prior_tag so
+  # the `tags &&` residual is genuinely selective at 80k.
+  @prior_tag "scale-tag-3"
+
+  defp unboxed(fun), do: Sandbox.unboxed_run(AdminRepo, fun)
+
+  # `async: false` + a stub the off-process `Task.async_stream` novelty workers must see:
+  # `set_mox_global` makes the embedding stub visible from any process (not just the test
+  # pid's `$callers` chain). No `expect`/`verify_on_exit!` — we only `stub`.
+  setup_all do
+    Mox.set_mox_global()
+    # The deterministic idea embedding the novelty test scores against (a real seeded
+    # vector). Stubbed in THIS (the global-owner) process — global mode only lets the
+    # owner set stubs, and the off-process Task.async_stream workers read it globally.
+    Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _text ->
+      {:ok, ScaleSeed.embedding_for(0)}
+    end)
+
+    :ok
+  end
+
+  setup do
+    tenant =
+      unboxed(fn ->
+        slug = "dp-novelty-scale-#{:erlang.phash2(Ecto.UUID.generate())}"
+
+        {:ok, t} =
+          %Tenant{}
+          |> Tenant.create_changeset(%{
+            name: "DP/Novelty Scale #{slug}",
+            slug: slug,
+            email: "#{slug}@example.com",
+            settings: %{},
+            status: :active
+          })
+          |> AdminRepo.insert()
+
+        ScaleSeed.seed(t.id, count: ScaleSeed.prod_article_floor(), link_density: 10)
+        t
+      end)
+
+    on_exit(fn ->
+      try do
+        unboxed(fn ->
+          AdminRepo.delete_all(from(a in Article, where: a.tenant_id == ^tenant.id))
+          AdminRepo.delete_all(from(t in Tenant, where: t.id == ^tenant.id))
+        end)
+      rescue
+        _ -> :ok
+      end
+    end)
+
+    {:ok, tenant: tenant}
+  end
+
+  test "distant_pairs reads articles ONLY through the bounded sample (no full corpus scan)",
+       %{tenant: tenant} do
+    unboxed(fn ->
+      # Capture the ACTUAL count + pairs SQL the request path emits (US-27.11 HeavyRead is
+      # pointed at AdminRepo in test, so the queries run in-process and are captured).
+      captured =
+        PlanAssertions.capture_repo_queries(fn ->
+          {:ok, _} = Knowledge.distant_pairs(tenant.id)
+        end)
+
+      # BOTH emitted queries (the count and the paginated pairs) are the self-join with the
+      # `<=>` BETWEEN band; assert the bound on EACH.
+      between_queries =
+        Enum.filter(captured, fn {sql, _} -> sql =~ ~r/BETWEEN/i end)
+
+      assert length(between_queries) == 2
+
+      for {sql, params} <- between_queries do
+        # No Seq Scan over the corpus: the candidate subquery is reached via an Index Scan.
+        assert :ok = PlanAssertions.refute_seq_scan({sql, params})
+
+        # The genuine bound is the `ORDER BY id LIMIT max_pair_candidates()` on the sampled
+        # candidate subquery — verified at 80k the candidate `Index Scan` is dominated by a
+        # `Limit rows=25` (actual consumed ≤25, ~1.7ms / ~1657 buffers — NOT an O(n²) corpus
+        # read; the scan node's pre-LIMIT `Plan Rows ≈ corpus` is just an estimate, so
+        # `assert_scan_rows_below` does NOT fit this shape). A regression that dropped the
+        # sample LIMIT leaves the scan with no dominating `Limit ≤ cap`, tripping this.
+        assert :ok =
+                 PlanAssertions.assert_article_scans_capped_by_limit(
+                   {sql, params},
+                   @max_pair_candidates
+                 )
+      end
+    end)
+  end
+
+  test "novelty (nearest_prior_distance) is index-bounded, not a Seq Scan over 80k",
+       %{tenant: tenant} do
+    unboxed(fn ->
+      # First confirm the request path actually scores against a non-trivial, BOUNDED prior
+      # set at 80k (the ~2% tag), so the plan we assert below is the one it really runs.
+      # The idea embedding is the global stub set in setup_all (ScaleSeed.embedding_for(0)).
+      idea_vec = ScaleSeed.embedding_for(0)
+
+      {:ok, [_scored], prior_count} =
+        Knowledge.novelty_scores(tenant.id, [%{text: "scale idea"}], prior_tag: @prior_tag)
+
+      assert prior_count > 0
+
+      # The MIN(<=>) aggregate executes inside a `Task.async_stream` (off the test process),
+      # so capture_repo_queries can't see it. EXPLAIN the EXACT query builder the request
+      # path uses (`novelty_distance_query/4`) with the SAME const + tag — same SQL+params.
+      query = Knowledge.novelty_distance_query(tenant.id, idea_vec, @prior_tag, nil)
+
+      # FINDING (verified at 80k via EXPLAIN ANALYZE): Postgres rewrites `MIN(embedding <=>
+      # $const)` into `ORDER BY (embedding <=> $const) LIMIT 1` and serves it from the HNSW
+      # index (`articles_embedding_hnsw_idx`), applying `tags &&` as an in-line Filter — a
+      # SINGLE Index Scan, ~0.3ms / 676 buffers. So the bound here is the HNSW LIMIT-1
+      # rewrite, NOT the `tags &&` GIN bitmap the story hypothesized; either way it is
+      # bounded and tenant-scoped, never a Seq/Bitmap full-corpus read. `refute_full_scan`
+      # (forbids Seq Scan, Parallel Seq Scan, AND Bitmap Heap Scan, and requires the relation
+      # to actually be reached) is the precise guard for that.
+      assert :ok = PlanAssertions.refute_full_scan(query)
+    end)
+  end
+end

--- a/test/loopctl/knowledge/distant_pairs_novelty_scale_test.exs
+++ b/test/loopctl/knowledge/distant_pairs_novelty_scale_test.exs
@@ -7,9 +7,14 @@ defmodule Loopctl.Knowledge.DistantPairsNoveltyScaleTest do
     * `distant_pairs` — the column-to-column self-join reads `articles` ONLY through the
       `LIMIT max_pair_candidates()` SAMPLED subquery, so every base-table scan is bounded
       by the sample cap (NOT an O(n²)/Seq read over the whole 80k corpus).
-    * `novelty` (`nearest_prior_distance`) — the `MIN(<=>)` aggregate is scoped by the
-      `tags &&` GIN residual (`articles_tags_index`), so it reaches `articles` via a
-      Bitmap Index Scan bounded by the tag's selectivity, NOT a Seq Scan over 80k.
+    * `novelty` (`nearest_prior_distance` → `novelty_distance_query/4`) — the `MIN(<=>)`
+      aggregate is bounded by prior-tag selectivity, NOT a full-corpus read. The planner
+      picks by cost between TWO bounded plans: an HNSW `ORDER BY <=> LIMIT 1` rewrite of the
+      MIN (verified at 80k — `articles_embedding_hnsw_idx`, `tags &&` as a Filter) OR a
+      `tags &&` GIN-bounded scan (`articles_tags_index`). The test asserts the structural
+      invariant (no unbounded Seq Scan + the `articles` scan estimate stays below a small
+      multiple of the tag's ~2% selectivity), accepting EITHER plan — it does NOT pin the
+      node type, so a legitimate planner switch to the GIN bitmap can't false-RED it.
 
   We assert on the ACTUAL SQL+params the request path emits (captured via
   `PlanAssertions.capture_repo_queries/1`), not an independently reconstructed query, then
@@ -148,15 +153,28 @@ defmodule Loopctl.Knowledge.DistantPairsNoveltyScaleTest do
       # path uses (`novelty_distance_query/4`) with the SAME const + tag — same SQL+params.
       query = Knowledge.novelty_distance_query(tenant.id, idea_vec, @prior_tag, nil)
 
-      # FINDING (verified at 80k via EXPLAIN ANALYZE): Postgres rewrites `MIN(embedding <=>
-      # $const)` into `ORDER BY (embedding <=> $const) LIMIT 1` and serves it from the HNSW
-      # index (`articles_embedding_hnsw_idx`), applying `tags &&` as an in-line Filter — a
-      # SINGLE Index Scan, ~0.3ms / 676 buffers. So the bound here is the HNSW LIMIT-1
-      # rewrite, NOT the `tags &&` GIN bitmap the story hypothesized; either way it is
-      # bounded and tenant-scoped, never a Seq/Bitmap full-corpus read. `refute_full_scan`
-      # (forbids Seq Scan, Parallel Seq Scan, AND Bitmap Heap Scan, and requires the relation
-      # to actually be reached) is the precise guard for that.
-      assert :ok = PlanAssertions.refute_full_scan(query)
+      # The REAL invariant is "bounded by prior-tag selectivity, NOT a full-corpus read" —
+      # and there are TWO legitimate bounded plans the cost-based planner may pick, so we must
+      # NOT pin the node type (that is the architect's HIGH finding):
+      #
+      #   * verified at 80k: Postgres rewrites `MIN(embedding <=> $const)` into
+      #     `ORDER BY (embedding <=> $const) LIMIT 1` and serves it from the HNSW index
+      #     (`articles_embedding_hnsw_idx`), `tags &&` as an in-line Filter — a single Index
+      #     Scan, ~0.3ms / 676 buffers, scan estimate ≈ the tag-filtered ~1.6k rows; OR
+      #   * for a less-HNSW-friendly target/stats, a `tags &&` GIN bitmap
+      #     (`articles_tags_index`) — a Bitmap Heap Scan, also bounded by the ~2% tag.
+      #
+      # `refute_full_scan` would FALSE-RED the second (legitimately bounded) plan because it
+      # forbids Bitmap Heap Scan. So instead assert the STRUCTURAL bound, accepting either:
+      #   1. no unbounded Seq Scan (a bounded bitmap is allowed), AND
+      #   2. every `articles` scan estimate is below a small multiple of the tag selectivity
+      #      (~2% ⇒ ~1.6k at 80k) — comfortably below the corpus, so a full-corpus scan trips
+      #      it while both bounded plans (HNSW ~1.6k, GIN bitmap ~1.6k) pass.
+      # Ceiling = floor/8 = 10_000 (≫ the ~1.6k tag set, ≪ the 80k corpus).
+      ceiling = div(ScaleSeed.prod_article_floor(), 8)
+
+      assert :ok = PlanAssertions.refute_seq_scan(query)
+      assert :ok = PlanAssertions.assert_scan_rows_below(query, ceiling)
     end)
   end
 end

--- a/test/loopctl/knowledge/distant_pairs_novelty_scale_test.exs
+++ b/test/loopctl/knowledge/distant_pairs_novelty_scale_test.exs
@@ -12,14 +12,21 @@ defmodule Loopctl.Knowledge.DistantPairsNoveltyScaleTest do
       picks by cost between TWO bounded plans: an HNSW `ORDER BY <=> LIMIT 1` rewrite of the
       MIN (verified at 80k — `articles_embedding_hnsw_idx`, `tags &&` as a Filter) OR a
       `tags &&` GIN-bounded scan (`articles_tags_index`). The test asserts the structural
-      invariant (no unbounded Seq Scan + the `articles` scan estimate stays below a small
-      multiple of the tag's ~2% selectivity), accepting EITHER plan — it does NOT pin the
-      node type, so a legitimate planner switch to the GIN bitmap can't false-RED it.
+      invariant (no unbounded Seq Scan + every `articles` scan touches fewer than a small
+      multiple of the tag's ~2% selectivity in ACTUAL rows, via EXPLAIN ANALYZE), accepting
+      EITHER plan — it does NOT pin the node type, so a legitimate planner switch to the GIN
+      bitmap can't false-RED it, while a low-estimate/high-actual full-corpus regression IS
+      caught by real rows.
 
-  We assert on the ACTUAL SQL+params the request path emits (captured via
-  `PlanAssertions.capture_repo_queries/1`), not an independently reconstructed query, then
-  EXPLAIN it under the planner's NATURAL choice (no enable_seqscan=off) against the
-  committed, ANALYZEd ~80k corpus from `Loopctl.Knowledge.ScaleSeed`.
+  The bounds are checked under the planner's NATURAL choice (no enable_seqscan=off) against
+  the committed, ANALYZEd ~80k corpus from `Loopctl.Knowledge.ScaleSeed`:
+
+    * distant_pairs: EXPLAIN on the ACTUAL count + pairs SQL the request path emits (captured
+      via `PlanAssertions.capture_repo_queries/1`), asserting the `Limit ≤ max_pair_candidates`
+      sample cap dominates every `articles` scan.
+    * novelty: EXPLAIN ANALYZE on `novelty_distance_query/4` (the MIN runs inside a
+      `Task.async_stream`, off the test process, so capture can't see it — the builder emits
+      the identical SQL+params), asserting ACTUAL `articles` rows stay bounded.
 
   Seeds ~80k committed rows, so this is `:scale_nightly` (runs on the nightly/scale gate,
   NOT the default async suite which has no seeded corpus).
@@ -155,26 +162,29 @@ defmodule Loopctl.Knowledge.DistantPairsNoveltyScaleTest do
 
       # The REAL invariant is "bounded by prior-tag selectivity, NOT a full-corpus read" —
       # and there are TWO legitimate bounded plans the cost-based planner may pick, so we must
-      # NOT pin the node type (that is the architect's HIGH finding):
+      # NOT pin the node type (the prior HIGH finding):
       #
-      #   * verified at 80k: Postgres rewrites `MIN(embedding <=> $const)` into
-      #     `ORDER BY (embedding <=> $const) LIMIT 1` and serves it from the HNSW index
+      #   * verified at 80k via EXPLAIN ANALYZE: Postgres rewrites `MIN(embedding <=> $const)`
+      #     into `ORDER BY (embedding <=> $const) LIMIT 1` and serves it from the HNSW index
       #     (`articles_embedding_hnsw_idx`), `tags &&` as an in-line Filter — a single Index
-      #     Scan, ~0.3ms / 676 buffers, scan estimate ≈ the tag-filtered ~1.6k rows; OR
+      #     Scan, ~0.3ms / 676 buffers, ~0 ACTUAL rows touched on the articles node; OR
       #   * for a less-HNSW-friendly target/stats, a `tags &&` GIN bitmap
-      #     (`articles_tags_index`) — a Bitmap Heap Scan, also bounded by the ~2% tag.
+      #     (`articles_tags_index`) — a Bitmap Heap Scan, also bounded by the ~2% tag
+      #     (≤ ~1.6k ACTUAL rows at 80k).
       #
       # `refute_full_scan` would FALSE-RED the second (legitimately bounded) plan because it
-      # forbids Bitmap Heap Scan. So instead assert the STRUCTURAL bound, accepting either:
+      # forbids Bitmap Heap Scan. So assert the STRUCTURAL bound, accepting either plan:
       #   1. no unbounded Seq Scan (a bounded bitmap is allowed), AND
-      #   2. every `articles` scan estimate is below a small multiple of the tag selectivity
-      #      (~2% ⇒ ~1.6k at 80k) — comfortably below the corpus, so a full-corpus scan trips
-      #      it while both bounded plans (HNSW ~1.6k, GIN bitmap ~1.6k) pass.
+      #   2. every `articles` scan produced fewer than corpus/8 ACTUAL rows — via
+      #      EXPLAIN ANALYZE, NOT the planner ESTIMATE, so a low-estimate/high-actual
+      #      regression that heap-rechecks the whole corpus at runtime (the #168/#172 shape)
+      #      is caught by REAL rows. Both bounded plans (HNSW ~0, GIN bitmap ~1.6k) pass;
+      #      a full-corpus scan (~80k actual) trips it.
       # Ceiling = floor/8 = 10_000 (≫ the ~1.6k tag set, ≪ the 80k corpus).
       ceiling = div(ScaleSeed.prod_article_floor(), 8)
 
       assert :ok = PlanAssertions.refute_seq_scan(query)
-      assert :ok = PlanAssertions.assert_scan_rows_below(query, ceiling)
+      assert :ok = PlanAssertions.assert_actual_scan_rows_below(query, ceiling)
     end)
   end
 end

--- a/test/loopctl/knowledge/distant_pairs_novelty_test.exs
+++ b/test/loopctl/knowledge/distant_pairs_novelty_test.exs
@@ -1,0 +1,148 @@
+defmodule Loopctl.Knowledge.DistantPairsNoveltyTest do
+  @moduledoc """
+  US-27.7b TC-27.7b.1 / TC-27.7b.2: behavior-preservation coverage for the two cosine
+  shapes that are NOT (and must not become) `VectorSearch.nearest/4` — `distant_pairs`
+  (column-to-column self-join) and `novelty_scores` (`MIN(<=>)` aggregate).
+
+  The 27.7b change is limited to routing `nearest_prior_distance`'s const through
+  `to_embedding_list/1` (so the bound `^param` is a `[float()]`, exactly like `nearest/4`).
+  That is behavior-preserving, so the outputs here pin the EXACT post-change values at
+  known cosine distances — a regression that altered the distance computation or the
+  bounds (sample cap / prior-tag scoping) would change them.
+  """
+  use Loopctl.DataCase, async: true
+
+  import Mox
+
+  setup :verify_on_exit!
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge
+
+  # Cosine measures DIRECTION. Two halves: a "base" axis and an "orthogonal" axis. A unit
+  # vector at angle θ from base is `[cos θ on base-half, sin θ on orth-half]`. Cosine
+  # distance between two such vectors is `1 - cos(θ_a - θ_b)`.
+  # The `articles.embedding` column is a fixed 1536-dim pgvector, so each half is 768.
+  @half 768
+
+  # Unit vector at `theta` radians from the base axis (distributed across each half so the
+  # vector norm is independent of θ — keeps `<=>` a pure function of the angle).
+  defp embedding_at(theta) do
+    base = :math.cos(theta) / :math.sqrt(@half)
+    orth = :math.sin(theta) / :math.sqrt(@half)
+    List.duplicate(base, @half) ++ List.duplicate(orth, @half)
+  end
+
+  # PUBLISHED article with a known embedding, written directly (bypasses the Oban cascade).
+  defp article_with_embedding(tenant_id, embedding, attrs) do
+    base = %{title: "A#{System.unique_integer([:positive])}", body: "b", category: :pattern}
+
+    fixture(:article, Map.merge(base, Map.put(attrs, :tenant_id, tenant_id)))
+    |> Ecto.Changeset.change(%{status: :published, embedding: embedding})
+    |> AdminRepo.update!()
+  end
+
+  describe "distant_pairs — output unchanged after sharing helpers (TC-27.7b.1)" do
+    setup do
+      tenant = fixture(:tenant)
+
+      # Three articles at 0, 60°, 90° from base.
+      #   cos-dist(0, 60°)  = 1 - cos(60°) = 0.5   → in the default [0.3, 0.7] band
+      #   cos-dist(0, 90°)  = 1 - cos(90°) = 1.0   → OUTSIDE the band
+      #   cos-dist(60°, 90°) = 1 - cos(30°) ≈ 0.134 → OUTSIDE the band
+      a0 = article_with_embedding(tenant.id, embedding_at(0.0), %{})
+      a60 = article_with_embedding(tenant.id, embedding_at(:math.pi() / 3), %{})
+      a90 = article_with_embedding(tenant.id, embedding_at(:math.pi() / 2), %{})
+
+      {:ok, tenant: tenant, a0: a0, a60: a60, a90: a90}
+    end
+
+    test "returns exactly the in-band pair with the correct distance and meta", ctx do
+      assert {:ok, %{pairs: [pair], total_count: 1, has_more: false}} =
+               Knowledge.distant_pairs(ctx.tenant.id)
+
+      # The single in-band pair is {a0, a60} (cos-dist 0.5). Ordered a.id < b.id.
+      {lo, hi} = Enum.min_max([ctx.a0.id, ctx.a60.id])
+      assert pair.a.id == lo
+      assert pair.b.id == hi
+      assert_in_delta pair.distance, 0.5, 1.0e-4
+    end
+
+    test "is tenant-scoped — never sees another tenant's pairs (AC-27.7b.4)", ctx do
+      other = fixture(:tenant)
+      article_with_embedding(other.id, embedding_at(0.0), %{})
+      article_with_embedding(other.id, embedding_at(:math.pi() / 3), %{})
+
+      assert {:ok, %{pairs: pairs, total_count: total}} =
+               Knowledge.distant_pairs(ctx.tenant.id)
+
+      # Still exactly this tenant's single in-band pair, never the other tenant's.
+      assert total == 1
+      ids = Enum.flat_map(pairs, &[&1.a.id, &1.b.id])
+      assert Enum.sort(ids) == Enum.sort([ctx.a0.id, ctx.a60.id])
+    end
+
+    test "honors a tightened band (no in-band pair → empty)", ctx do
+      assert {:ok, %{pairs: [], total_count: 0, has_more: false}} =
+               Knowledge.distant_pairs(ctx.tenant.id, min_distance: 0.8, max_distance: 0.9)
+    end
+
+    test "invalid band is rejected (unchanged contract)", ctx do
+      assert {:error, :invalid_distance} =
+               Knowledge.distant_pairs(ctx.tenant.id, min_distance: 0.7, max_distance: 0.3)
+    end
+  end
+
+  describe "novelty_scores — scores unchanged after to_embedding_list normalization (TC-27.7b.2)" do
+    setup do
+      tenant = fixture(:tenant)
+
+      # Two embedded priors tagged "proposal": at base (0) and at 90°.
+      article_with_embedding(tenant.id, embedding_at(0.0), %{tags: ["proposal"]})
+      article_with_embedding(tenant.id, embedding_at(:math.pi() / 2), %{tags: ["proposal"]})
+
+      {:ok, tenant: tenant}
+    end
+
+    test "novelty_score is the MIN cosine distance to any prior; prior_count is correct",
+         %{tenant: tenant} do
+      # The idea embeds (mock) to a vector 30° from base:
+      #   dist to base-prior  = 1 - cos(30°) ≈ 0.1340
+      #   dist to 90°-prior   = 1 - cos(60°) = 0.5
+      # MIN ⇒ ≈ 0.1340 (this is the aggregate that must NOT degrade to top-k-then-min).
+      idea_vec = embedding_at(:math.pi() / 6)
+
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _text -> {:ok, idea_vec} end)
+
+      assert {:ok, [scored], prior_count} =
+               Knowledge.novelty_scores(tenant.id, [%{text: "an idea"}])
+
+      assert prior_count == 2
+      assert_in_delta scored.novelty_score, 1.0 - :math.cos(:math.pi() / 6), 1.0e-4
+    end
+
+    test "nil score (no embedded priors) when prior_tag matches nothing", %{tenant: tenant} do
+      # No priors tagged "nonesuch": novelty_scores short-circuits, no embedding call.
+      assert {:ok, [scored], 0} =
+               Knowledge.novelty_scores(tenant.id, [%{text: "x"}], prior_tag: "nonesuch")
+
+      assert scored.novelty_score == nil
+    end
+
+    test "is tenant-scoped — another tenant's priors don't count (AC-27.7b.4)", %{tenant: tenant} do
+      other = fixture(:tenant)
+      article_with_embedding(other.id, embedding_at(0.0), %{tags: ["proposal"]})
+
+      # This tenant still has exactly its own 2 priors, not the other tenant's.
+      idea_vec = embedding_at(0.0)
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _text -> {:ok, idea_vec} end)
+
+      assert {:ok, [scored], prior_count} =
+               Knowledge.novelty_scores(tenant.id, [%{text: "y"}])
+
+      assert prior_count == 2
+      # Idea identical to the base-prior ⇒ MIN distance ≈ 0.
+      assert_in_delta scored.novelty_score, 0.0, 1.0e-4
+    end
+  end
+end

--- a/test/loopctl/repo/reconcile_hnsw_index_migration_test.exs
+++ b/test/loopctl/repo/reconcile_hnsw_index_migration_test.exs
@@ -38,6 +38,12 @@ defmodule Loopctl.Repo.ReconcileHnswIndexMigrationTest do
   """
   use ExUnit.Case, async: false
 
+  # Building a real HNSW index (CREATE INDEX ... USING hnsw) over the test corpus
+  # legitimately takes ~60-70s on a loaded machine — over ExUnit's 60s default — which
+  # intermittently RED-flaked `mix precommit` and the CI Test job. Give the index DDL
+  # ample headroom so this is a deterministic pass, not a timing race. (Test-infra only.)
+  @moduletag timeout: :timer.minutes(5)
+
   alias Ecto.Adapters.SQL.Sandbox
   alias Ecto.Migration.Runner
   alias Loopctl.AdminRepo

--- a/test/support/plan_assertions.ex
+++ b/test/support/plan_assertions.ex
@@ -301,6 +301,51 @@ defmodule Loopctl.PlanAssertions do
   end
 
   @doc """
+  Like `assert_scan_rows_below/2` but bounds on **ACTUAL** rows, not the planner's
+  estimate — it runs `EXPLAIN (ANALYZE, FORMAT JSON)` (which EXECUTES the query) and
+  asserts every `articles` scan node produced fewer than `max_rows` rows in reality
+  (`Actual Rows × Actual Loops`, so a nested-loop inner scan's per-loop figure is
+  totalled correctly).
+
+  Why a separate, ANALYZE-based variant (US-27.7b novelty MIN guard): the estimate-based
+  `assert_scan_rows_below/2` reads `Plan Rows`, which a #168/#172-class regression can keep
+  artificially LOW while heap-rechecking the whole corpus at runtime (low-estimate /
+  high-actual). For the novelty `MIN(<=>)` aggregate — bounded by prior-tag selectivity via
+  EITHER an HNSW `ORDER BY <=> LIMIT 1` rewrite OR a `tags &&` GIN bitmap — both legitimate
+  bounded plans read few ACTUAL rows (~1.6k at the ~2% tag), so a generous `max_rows` ceiling
+  (e.g. corpus/8) passes both while a genuine full-corpus scan (~80k actual) trips it.
+
+  EXPLAIN ANALYZE executes the query, so this is for `:scale_nightly` tests against the
+  committed corpus only (the bounded plans are sub-millisecond there). `assert_scan_rows_below/2`
+  is deliberately left untouched (US-27.9a's keyset tags-shape scale assertion depends on the
+  estimate-based form).
+  """
+  def assert_actual_scan_rows_below(queryable_or_sql, max_rows) when is_integer(max_rows) do
+    assert_fresh_stats!()
+    {root, raw} = explain_analyze_json(queryable_or_sql)
+    actuals = article_actual_scan_rows(root)
+
+    over = Enum.filter(actuals, &(is_number(&1) and &1 >= max_rows))
+
+    cond do
+      actuals == [] ->
+        raise ExUnit.AssertionError,
+          message:
+            "Plan never reaches `articles` — cannot judge ACTUAL scan rows. Plan:\n#{elide(raw)}"
+
+      over != [] ->
+        raise ExUnit.AssertionError,
+          message:
+            "Expected every `articles` scan to produce < #{max_rows} ACTUAL rows (bounded by " <>
+              "residual selectivity), but got #{inspect(over)} — a runtime full-corpus scan " <>
+              "(the low-estimate/high-actual #168/#172 shape). Plan:\n#{elide(raw)}"
+
+      true ->
+        :ok
+    end
+  end
+
+  @doc """
   Asserts the plan reaches `articles` via the given index `name` somewhere (an
   `Index Scan`, `Index Only Scan`, or `Bitmap Index Scan` naming it). Proves a
   selective index actually drives the scan (e.g. the `tags` GIN bounds a tag-filtered
@@ -544,6 +589,47 @@ defmodule Loopctl.PlanAssertions do
   defp explain_json(queryable) do
     {sql, params} = SQL.to_sql(:all, AdminRepo, queryable)
     explain_json({sql, params})
+  end
+
+  # Like `explain_json/1` but with ANALYZE — EXECUTES the query and returns the plan with
+  # per-node `Actual Rows`/`Actual Loops`. :scale_nightly-only (it runs the query for real).
+  defp explain_analyze_json({sql, params}) when is_binary(sql) and is_list(params) do
+    %{rows: rows} = AdminRepo.query!("EXPLAIN (ANALYZE, FORMAT JSON) " <> sql, params)
+
+    decoded =
+      rows
+      |> List.first()
+      |> List.first()
+      |> decode_json()
+
+    root = decoded |> List.first() |> Map.fetch!("Plan")
+    {root, Jason.encode!(decoded)}
+  end
+
+  defp explain_analyze_json(queryable) do
+    {sql, params} = SQL.to_sql(:all, AdminRepo, queryable)
+    explain_analyze_json({sql, params})
+  end
+
+  # Walk an ANALYZEd plan; for every `articles` scan node return the TOTAL actual rows it
+  # produced = `Actual Rows` × `Actual Loops` (Postgres reports `Actual Rows` per loop, so a
+  # nested-loop inner scan's true total is the product). nil-safe.
+  defp article_actual_scan_rows(node) when is_map(node) do
+    here =
+      if node["Relation Name"] == "articles" do
+        rows = node["Actual Rows"]
+        loops = node["Actual Loops"] || 1
+        if is_number(rows) and is_number(loops), do: [rows * loops], else: []
+      else
+        []
+      end
+
+    children =
+      node
+      |> Map.get("Plans", [])
+      |> Enum.flat_map(&article_actual_scan_rows/1)
+
+    here ++ children
   end
 
   defp decode_json(v) when is_binary(v), do: Jason.decode!(v)

--- a/test/support/plan_assertions.ex
+++ b/test/support/plan_assertions.ex
@@ -321,6 +321,64 @@ defmodule Loopctl.PlanAssertions do
   end
 
   @doc """
+  Asserts every scan on `articles` is DOMINATED by a `Limit` node whose `Plan Rows`
+  is `<= max_rows` (US-27.7b distant_pairs: the SAMPLED candidate subquery
+  `... ORDER BY id LIMIT max_pair_candidates()`).
+
+  This is the right bound for a sample-capped shape where `assert_scan_rows_below/2` does
+  NOT apply: the candidate `Index Scan` legitimately reports the pre-LIMIT estimate
+  (`Plan Rows ≈ corpus`) on the scan node itself, while the enclosing `Limit` caps how many
+  rows are actually consumed (verified at 80k: `Limit rows=25` over the scan, ~1.7ms /
+  ~1657 buffers — NOT an O(n²) corpus read). A regression that dropped the sample LIMIT
+  (reintroducing the unbounded self-join) leaves the scan with no dominating `Limit ≤ max`,
+  tripping this.
+  """
+  def assert_article_scans_capped_by_limit(queryable_or_sql, max_rows)
+      when is_integer(max_rows) do
+    assert_fresh_stats!()
+    {root, raw} = explain_json(queryable_or_sql)
+    # `capped_limit?` (current node sits under a Limit whose Plan Rows ≤ max) starts false:
+    # the root itself has no ancestor Limit.
+    uncapped = uncapped_article_scans(root, false, max_rows)
+
+    cond do
+      article_scan_nodes(root) == [] ->
+        raise ExUnit.AssertionError,
+          message:
+            "Plan never reaches `articles` — cannot judge the sample cap. Plan:\n#{elide(raw)}"
+
+      uncapped != [] ->
+        raise ExUnit.AssertionError,
+          message:
+            "Expected every `articles` scan to be capped by a `Limit ≤ #{max_rows}` (the " <>
+              "max_pair_candidates() sample), but #{length(uncapped)} scan(s) are NOT — an " <>
+              "unbounded self-join over the corpus. Plan:\n#{elide(raw)}"
+
+      true ->
+        :ok
+    end
+  end
+
+  # Walk the tree tracking whether we are under a `Limit` node whose Plan Rows ≤ max.
+  # Returns the `articles` scan nodes that are NOT so dominated.
+  defp uncapped_article_scans(node, capped?, max) when is_map(node) do
+    capped_here? =
+      capped? or
+        (node["Node Type"] == "Limit" and is_number(node["Plan Rows"]) and
+           node["Plan Rows"] <= max)
+
+    here =
+      if node["Relation Name"] == "articles" and not capped_here?, do: [node], else: []
+
+    children =
+      node
+      |> Map.get("Plans", [])
+      |> Enum.flat_map(&uncapped_article_scans(&1, capped_here?, max))
+
+    here ++ children
+  end
+
+  @doc """
   Asserts `articles` is reached by EXACTLY ONE scan node, which is an `Index Scan`
   (or `Index Only Scan`) on an HNSW index (`pg_am.amname='hnsw'`, verified via catalog,
   not a name match). A sibling/outer full-scan on `articles` therefore cannot hide


### PR DESCRIPTION
## US-27.7b: keep distant_pairs & novelty on their correct shapes + register as the cosine-lint exceptions

distant_pairs (column-to-column self-join) and nearest_prior_distance (MIN aggregate) are NOT top-k-against-a-const, so they are deliberately **not** migrated to `VectorSearch.nearest/4` (that would change recall semantics). Behavior-preserving:

- `nearest_prior_distance` normalizes its const via `to_embedding_list/1` (the same `[float()]` shape `nearest/4` binds — also guards the #168 Pgvector-vs-list 500); the MIN query is extracted to `novelty_distance_query/4` so the scale gate can `EXPLAIN` the exact request-path query.
- New `Loopctl.Knowledge.CosineLintExceptions` registry names both `<=>`-bearing functions as the auditable, documented exceptions (with rationale) the future US-27.8 "no hand-rolled cosine" lint will consume.
- Bounds proven: behavior-preservation tests at known cosine distances (identical pairs/meta + true `MIN`); a `:scale_nightly` gate at 80k shows distant_pairs bounded by the `max_pair_candidates` sample (`Limit`-dominated) and novelty bounded on **actual rows** (`EXPLAIN ANALYZE`) — accepting either the HNSW `LIMIT-1` rewrite or a tag-GIN scan, never a full-corpus read.

Two enhanced-review rounds (team + adversarial). The multi-lens panel caught real issues both rounds: R1 — a plan-coupled assertion + a false bound-mechanism rationale; R2 — an estimate-vs-actual-rows soundness gap + a registry doc overclaim. All fixed. Includes an incidental test-infra fix (a 5-min timeout on the US-27.14 reconcile-HNSW test whose ~66s DDL was exceeding ExUnit's 60s default and intermittently flaking CI).

`mix precommit` green (2868 tests); scale gate green.
