### PR TITLE
US-27.6b: kNN over-fetch config + observable (non-silent) under-fill signal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,6 +318,7 @@ jobs:
         scale_file:
           - test/loopctl/knowledge/scale_seed_nightly_test.exs
           - test/loopctl/knowledge/vector_search_scale_test.exs
+          - test/loopctl/knowledge/vector_search_under_fill_scale_test.exs
           - test/loopctl/knowledge/plan_assertions_scale_test.exs
           - test/loopctl/knowledge/keyset_plan_scale_test.exs
           - test/loopctl/knowledge/by_source_change_feed_plan_scale_test.exs

--- a/config/test.exs
+++ b/config/test.exs
@@ -55,6 +55,21 @@ config :loopctl, :heavy_read_repo, Loopctl.AdminRepo
 # for normal tests (the timeout is much longer than any real query).
 config :loopctl, :heavy_read_statement_timeout_overrides, %{suggested_links: 5_000}
 
+# US-27.6b: the over-fetch pool sizing knobs (`Loopctl.Knowledge.VectorSearch.pool_size/2`).
+# In the DEFAULT async suite we shrink floor/cap to 6 so the under-fill detection can be
+# exercised deterministically with a handful of seeded rows (filling a 6-row pool needs ~6
+# articles, not 100). 6 is kept >= the `k=5` used across the existing fast tests so the
+# floor-at-k invariant doesn't perturb their `pool == max_pool()` assertions. The SCALE
+# gate (`SCALE_NIGHTLY`/`SCALE_TESTS`) leaves the PROD defaults (factor 5 / floor 100 / cap
+# 500) so the dense-hub + cost-bound scale tests stay prod-shaped. This is config-based DI
+# — NO Application.put_env in any test body; the unit `pool_size/2` tests pass explicit
+# knob args, so they are independent of this value.
+unless System.get_env("SCALE_NIGHTLY") || System.get_env("SCALE_TESTS") do
+  config :loopctl, :vector_pool_factor, 5
+  config :loopctl, :vector_pool_floor, 6
+  config :loopctl, :max_vector_pool, 6
+end
+
 # We don't run a server during test. If one is required,
 # you can enable the server option below.
 config :loopctl, LoopctlWeb.Endpoint,

--- a/docs/runbooks/knowledge-scale.md
+++ b/docs/runbooks/knowledge-scale.md
@@ -310,3 +310,34 @@ Then confirm through the pool:
 ```sh
 fly ssh console -a loopctl -C "/app/bin/loopctl rpc 'IO.inspect(Loopctl.HeavyReadRepo.query!(\"SHOW hnsw.ef_search\").rows)'"
 ```
+
+### Recall ceiling + the under-fill signal (US-27.6b)
+
+Recall on every kNN/`suggested_links` read is bounded by **two** things: `hnsw.ef_search`
+(default ~40 — the breadth above) AND the over-fetch `pool` (`pool_size/2`:
+`k * :vector_pool_factor |> max(:vector_pool_floor) |> min(:max_vector_pool) |> max(k)`,
+defaults 5 / 100 / 500). For a **densely-linked hub**, the nearest pool can be almost
+entirely already-linked or below threshold, so `suggested_links` legitimately returns
+**fewer than the requested limit** even though more-distant unlinked neighbors exist.
+**This is expected, not a bug** — it is the price of the index-correct path. The hazard
+is that it looks identical to "no neighbors exist", so it is made **observable**:
+
+- **Operator signal:** `Loopctl.Knowledge.suggest_links_with_meta/3` emits a
+  `[:loopctl, :knowledge, :vector_search, :under_fill]` telemetry event (id-only payload:
+  `tenant_id`, `endpoint`, `requested`, `returned`, `pool`, `available`,
+  `excluded_by_filters` — NO vector literals/bodies) **once per request**, ONLY when the
+  pool was filled to cap but the post-ANN filters cut the result below the limit. It does
+  NOT fire for a genuinely-small corpus (`available < pool`). Aggregated by US-27.15.
+- **Consumer signal:** the `suggested_links` response `meta` carries
+  `recall_truncated`/`pool_exhausted` (same flag) so an agent distinguishes an INCOMPLETE
+  result from an empty one.
+
+Detecting "pool was full" costs **one bounded extra read** (a `SELECT count(*)` over the
+candidate subquery, `LIMIT pool` — so it touches at most `:max_vector_pool` rows, ≤500),
+issued ONLY on the `returned < limit` path (zero added cost on the common full-result
+path), on the same dedicated heavy-read pool.
+
+**Raising recall** is the `ALTER ROLE … SET hnsw.ef_search` lever above (US-27.11), never a
+per-request `:parameters` or `SET LOCAL` (the latter needs a transaction and re-introduces
+the #172 small-pool starvation). Until ef_search is raised (and verified on fly mpg),
+recall stays at the default and is handled by over-fetch + this under-fill signal.

--- a/docs/runbooks/knowledge-scale.md
+++ b/docs/runbooks/knowledge-scale.md
@@ -317,25 +317,37 @@ Recall on every kNN/`suggested_links` read is bounded by **two** things: `hnsw.e
 (default ~40 — the breadth above) AND the over-fetch `pool` (`pool_size/2`:
 `k * :vector_pool_factor |> max(:vector_pool_floor) |> min(:max_vector_pool) |> max(k)`,
 defaults 5 / 100 / 500). For a **densely-linked hub**, the nearest pool can be almost
-entirely already-linked or below threshold, so `suggested_links` legitimately returns
-**fewer than the requested limit** even though more-distant unlinked neighbors exist.
-**This is expected, not a bug** — it is the price of the index-correct path. The hazard
-is that it looks identical to "no neighbors exist", so it is made **observable**:
+entirely already-linked, so `suggested_links` legitimately returns **fewer than the
+requested limit** even though near (above-threshold) unlinked neighbors would exist if
+not already linked. **This is expected, not a bug** — it is the price of the
+index-correct path. The hazard is that it looks identical to "no neighbors exist", so it
+is made **observable**:
 
 - **Operator signal:** `Loopctl.Knowledge.suggest_links_with_meta/3` emits a
   `[:loopctl, :knowledge, :vector_search, :under_fill]` telemetry event (id-only payload:
-  `tenant_id`, `endpoint`, `requested`, `returned`, `pool`, `available`,
-  `excluded_by_filters` — NO vector literals/bodies) **once per request**, ONLY when the
-  pool was filled to cap but the post-ANN filters cut the result below the limit. It does
-  NOT fire for a genuinely-small corpus (`available < pool`). Aggregated by US-27.15.
+  `tenant_id`, `endpoint`, `requested`, `returned`, `pool`, `ann_candidates`,
+  `above_threshold`, `excluded_by_link` — NO vector literals/bodies) **once per request**,
+  ONLY when above-threshold neighbors the ANN surfaced were hidden by the already-linked
+  anti-join (`above_threshold > returned`). It does NOT fire for a **sparse region** whose
+  whole ANN pool is below the similarity threshold (`above_threshold == returned`) — that
+  is correct emptiness, not recall loss. The detector is **ef_search-independent**: under
+  HNSW the ANN delivers only `~ef_search` (~40) candidates, so the old `ann_candidates >=
+  pool` "pool full" gate was degenerate (never true at scale, silently suppressed the
+  signal) and was removed. `excluded_by_link = above_threshold - returned` is the
+  un-conflated count of above-threshold neighbors the anti-join removed; `ann_candidates`
+  is the ef_search-bounded recall-breadth diagnostic. Aggregated by US-27.15.
 - **Consumer signal:** the `suggested_links` response `meta` carries
   `recall_truncated`/`pool_exhausted` (same flag) so an agent distinguishes an INCOMPLETE
   result from an empty one.
 
-Detecting "pool was full" costs **one bounded extra read** (a `SELECT count(*)` over the
-candidate subquery, `LIMIT pool` — so it touches at most `:max_vector_pool` rows, ≤500),
-issued ONLY on the `returned < limit` path (zero added cost on the common full-result
-path), on the same dedicated heavy-read pool.
+Detecting under-fill costs **one bounded extra read** — a single aggregate
+(`COUNT(*)` for `ann_candidates` plus a `COUNT(*) FILTER (similarity > threshold)` for
+`above_threshold`) over the **same inner ANN top-`pool` subquery** the main query draws
+from (`LIMIT pool`, so it touches at most `:max_vector_pool` rows, ≤500) — issued ONLY on
+the `returned < limit` path (zero added cost on the common full-result path), on the same
+dedicated heavy-read pool. It is an ANN-class read (same plan shape as the main query). A
+connectivity/timeout fault on this advisory probe is fail-soft: the suggestions are still
+returned with no truncation signal rather than failing the request.
 
 **Raising recall** is the `ALTER ROLE … SET hnsw.ef_search` lever above (US-27.11), never a
 per-request `:parameters` or `SET LOCAL` (the latter needs a transaction and re-introduces

--- a/lib/loopctl/db_capacity.ex
+++ b/lib/loopctl/db_capacity.ex
@@ -26,13 +26,19 @@ defmodule Loopctl.DbCapacity do
   # HEAVY_READ_POOL_SIZE (K) splits into fast sub-2s reads + a reserve for long-held
   # streamed-export checkouts (US-27.16). fast + reserve == the pool size.
   #
-  # The fast-reads budget (K≈6) serves the heavy-read consumers: 5 ONE-SHOT heavy reads
+  # The fast-reads budget (K≈6) serves the heavy-read consumers: 5 fast heavy reads
   # (suggested_links, semantic_search, distant_pairs, novelty, enumeration) PLUS one
-  # rate-limited POLLING feed — the US-27.9b change feed (`:change_feed`). The K
-  # rationale still holds with the polling addition because the change-feed read is a
-  # CHEAP, fast-releasing bounded keyset page (one read per request, connection RELEASED
-  # immediately) AND its QPS is capped by the api pipeline's rate limiter, so even a poll
-  # storm cannot saturate the fast slots — it adds at most a brief transient checkout.
+  # rate-limited POLLING feed — the US-27.9b change feed (`:change_feed`). Each is a
+  # bounded, fast-releasing read whose connection is released before the next checkout;
+  # `suggested_links` additionally issues a SECOND bounded read on the under-fill path
+  # (US-27.6b) — the under-fill probe, an ANN-class read bounded by `LIMIT pool` — but the
+  # two reads are STRICTLY SEQUENTIAL (the probe runs only after the main read's connection
+  # is released), so peak CONCURRENT checkouts per request stays 1 and the K budget is
+  # unaffected; it only adds throughput demand on the truncated path, itself capped by the
+  # api rate limiter. The K rationale
+  # likewise holds for the change-feed poll (one bounded keyset page, rate-limited), so
+  # even a poll storm cannot saturate the fast slots — it adds at most a brief transient
+  # checkout.
   @heavy_read_fast_reads 6
   @heavy_read_export_reserve 2
 

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -3274,12 +3274,25 @@ defmodule Loopctl.Knowledge do
       if pool_exhausted? do
         :telemetry.execute(
           Loopctl.TelemetryEvents.vector_search_under_fill(),
-          %{requested: limit, returned: returned, pool: pool, available: available},
+          %{
+            requested: limit,
+            returned: returned,
+            pool: pool,
+            available: available,
+            # TOTAL post-ANN exclusions: how many of the FULL pool the post-ANN filters
+            # (already-linked anti-join + similarity threshold, COMBINED) cut away to land
+            # at `returned`. This is intentionally the aggregate, not a per-reason split:
+            # separating anti-join drops from threshold drops would require an ADDITIONAL
+            # bounded read per request (the current flow knows neither component count —
+            # the main query returns only survivors and `available` is the pre-filter
+            # eligible count), which the AC-27.6b.5 one-bounded-read cost bound discourages.
+            # The per-reason breakdown is deferred to US-27.15's metrics aggregation, which
+            # consumes this event. See `Loopctl.TelemetryEvents.vector_search_under_fill/0`.
+            excluded_total: max(pool - returned, 0)
+          },
           %{
             tenant_id: tenant_id,
-            endpoint: :suggested_links,
-            # how many of the full pool the post-ANN filters cut away to land at `returned`
-            excluded_by_filters: max(pool - returned, 0)
+            endpoint: :suggested_links
           }
         )
 

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -3243,7 +3243,16 @@ defmodule Loopctl.Knowledge do
     returned = length(suggestions)
 
     meta =
-      maybe_signal_under_fill(tenant_id, article_id, embedding, vis, limit, pool, returned)
+      maybe_signal_under_fill(
+        tenant_id,
+        article_id,
+        embedding,
+        threshold,
+        vis,
+        limit,
+        pool,
+        returned
+      )
 
     {suggestions, meta}
   end
@@ -3251,88 +3260,175 @@ defmodule Loopctl.Knowledge do
   # Under-fill signal (US-27.6b AC-27.6b.2/.5/.6). Builds the response `meta` and —
   # only when recall is genuinely truncated — emits ONE telemetry event per request.
   #
-  # THE KEY DISTINCTION (the whole point of the story): emit ONLY when the inner ANN
-  # pool was actually FILLED to its cap and the post-ANN filters (the already-linked
-  # anti-join + the similarity threshold) cut the result below `limit`. We do NOT emit
-  # when the corpus simply has fewer than `limit` eligible candidates — that is a
-  # genuinely-empty result, not a recall incident.
+  # THE KEY DISTINCTION (the whole point of the story, per its background: "returns []
+  # while near neighbors EXIST"): the recall incident is when above-threshold (near)
+  # neighbors the ANN surfaced were hidden by the already-linked anti-join. We emit when:
   #
-  #   under_fill      = returned < limit AND available >= pool   (pool full, filters cut)
-  #   NOT under_fill  = returned < limit AND available <  pool   (corpus genuinely small)
+  #   recall_truncated = returned < limit
+  #                      AND above_threshold > returned
   #
-  # `available` is the count of the INNER candidate set (the same tenant / published /
-  # embedded / not-self / visible rows the ANN draws from), capped at `pool` — see
-  # `available_candidate_count/5`. When `returned >= limit` there is nothing to detect,
-  # so we skip the extra read entirely (zero added cost on the common full-result path).
-  defp maybe_signal_under_fill(tenant_id, article_id, embedding, vis, limit, pool, returned) do
+  # where `above_threshold` is how many of the candidates the inner ANN delivered clear
+  # the similarity bar (IGNORING link status). Because the signal only fires when
+  # `returned < limit` (so the outer LIMIT never bound and every unlinked above-threshold
+  # candidate WAS returned), `above_threshold > returned` means above-threshold neighbors
+  # were cut by the ANTI-JOIN specifically — a true recall incident.
+  #
+  # This is what stops the signal crying wolf on a SPARSE article whose whole ANN pool is
+  # below the similarity threshold: that is correct emptiness (nothing clears the bar), so
+  # `above_threshold == returned == 0` and we do NOT fire. The earlier `available >= pool`
+  # gate was abandoned: under HNSW the inner ANN only inspects ~`ef_search` (~40) graph
+  # nodes, so it delivers FEWER than `pool` (e.g. 100) candidates even on a huge corpus —
+  # an `ann_candidates >= pool` check is therefore degenerate (essentially never true at
+  # the default ef_search) and silently SUPPRESSED the signal at prod scale. The
+  # above-threshold detector is ef_search-independent: it compares two counts over the
+  # exact set the ANN actually surfaced.
+  #
+  # Both counts come from ONE bounded probe over the SAME inner ANN pool the main query
+  # drew from — see `under_fill_probe/6`. When `returned >= limit` there is nothing to
+  # detect, so we skip the probe entirely (zero added cost on the common full path).
+  defp maybe_signal_under_fill(
+         tenant_id,
+         article_id,
+         embedding,
+         threshold,
+         vis,
+         limit,
+         pool,
+         returned
+       ) do
     base = %{requested: limit, returned: returned, pool: pool}
+    not_truncated = Map.merge(base, %{pool_exhausted: false, recall_truncated: false})
 
     if returned < limit do
-      available = available_candidate_count(tenant_id, article_id, embedding, vis, pool)
-      pool_exhausted? = available >= pool
+      case under_fill_probe(tenant_id, article_id, embedding, threshold, vis, pool) do
+        # The probe is ADVISORY: its read failing (connection drop / statement_timeout)
+        # must NOT fail a request whose suggestions are already in hand. Degrade to "no
+        # truncation signal" rather than discarding a valid result (security review,
+        # AREA-5 fail-soft).
+        :error ->
+          not_truncated
 
-      if pool_exhausted? do
-        :telemetry.execute(
-          Loopctl.TelemetryEvents.vector_search_under_fill(),
-          %{
-            requested: limit,
-            returned: returned,
-            pool: pool,
-            available: available,
-            # TOTAL post-ANN exclusions: how many of the FULL pool the post-ANN filters
-            # (already-linked anti-join + similarity threshold, COMBINED) cut away to land
-            # at `returned`. This is intentionally the aggregate, not a per-reason split:
-            # separating anti-join drops from threshold drops would require an ADDITIONAL
-            # bounded read per request (the current flow knows neither component count —
-            # the main query returns only survivors and `available` is the pre-filter
-            # eligible count), which the AC-27.6b.5 one-bounded-read cost bound discourages.
-            # The per-reason breakdown is deferred to US-27.15's metrics aggregation, which
-            # consumes this event. See `Loopctl.TelemetryEvents.vector_search_under_fill/0`.
-            excluded_total: max(pool - returned, 0)
-          },
-          %{
-            tenant_id: tenant_id,
-            endpoint: :suggested_links
-          }
-        )
-
-        Logger.warning(
-          "knowledge.vector_search under_fill endpoint=suggested_links tenant_id=#{tenant_id} " <>
-            "requested=#{limit} returned=#{returned} pool=#{pool} available=#{available}"
-        )
+        {ann_candidates, above_threshold} ->
+          resolve_under_fill(
+            base,
+            tenant_id,
+            limit,
+            pool,
+            returned,
+            ann_candidates,
+            above_threshold
+          )
       end
-
-      Map.merge(base, %{pool_exhausted: pool_exhausted?, recall_truncated: pool_exhausted?})
     else
-      Map.merge(base, %{pool_exhausted: false, recall_truncated: false})
+      not_truncated
     end
   end
 
-  # Bounded "was the pool full?" probe (US-27.6b). Counts the INNER candidate set —
-  # the exact rows the ANN subquery draws from (tenant + published + embedded +
-  # not-self + visible) — but **capped at `pool`** via an inner `LIMIT pool`, so the
-  # count is `min(true_count, pool)` and the read touches at most `pool` rows (≤ the
-  # `max_vector_pool` cap, 500 by default). It runs on the SAME dedicated heavy-read
-  # pool (one bounded extra read, only on the `returned < limit` path) and carries NO
-  # vector / body data. We deliberately do NOT add the cosine ORDER BY here: order is
-  # irrelevant to "is the candidate set at least `pool` large", and omitting it keeps
-  # this a cheap index-filtered count rather than a second ANN scan.
-  defp available_candidate_count(tenant_id, article_id, embedding, vis, pool) do
-    _ = embedding
+  # The truncated-path verdict: recall is genuinely truncated when above-threshold (near)
+  # neighbors the ANN surfaced outnumber what was returned (`above_threshold > returned`)
+  # — i.e. the anti-join hid real neighbors, NOT a sparse region. Emits the signal exactly
+  # once when so, and returns the consumer-facing `meta`.
+  defp resolve_under_fill(base, tenant_id, limit, pool, returned, ann_candidates, above_threshold) do
+    recall_truncated? = above_threshold > returned
 
-    inner =
-      from(a in Article,
-        where: a.tenant_id == ^tenant_id and a.status == :published,
-        where: not is_nil(a.embedding),
-        where: a.id != ^article_id,
-        select: %{id: a.id},
-        limit: ^pool
+    if recall_truncated? do
+      emit_under_fill(tenant_id, limit, pool, returned, ann_candidates, above_threshold)
+    end
+
+    Map.merge(base, %{pool_exhausted: recall_truncated?, recall_truncated: recall_truncated?})
+  end
+
+  # ONE telemetry event + warn log per truncated request (AC-27.6b.2/.5). When
+  # `returned < limit` the outer LIMIT never bound, so EVERY unlinked above-threshold
+  # candidate in the pool WAS returned; therefore `above_threshold - returned` is EXACTLY
+  # the above-threshold neighbors the already-linked anti-join hid — an UN-CONFLATED
+  # recall-loss count (no extra read, no separate threshold component to disentangle).
+  # This is the metric US-27.15 aggregates; see
+  # `Loopctl.TelemetryEvents.vector_search_under_fill/0`. `ann_candidates` is the
+  # ef_search-bounded count the ANN delivered — a recall-breadth diagnostic.
+  defp emit_under_fill(tenant_id, limit, pool, returned, ann_candidates, above_threshold) do
+    excluded_by_link = above_threshold - returned
+
+    :telemetry.execute(
+      Loopctl.TelemetryEvents.vector_search_under_fill(),
+      %{
+        requested: limit,
+        returned: returned,
+        pool: pool,
+        ann_candidates: ann_candidates,
+        above_threshold: above_threshold,
+        excluded_by_link: excluded_by_link
+      },
+      %{
+        tenant_id: tenant_id,
+        endpoint: :suggested_links
+      }
+    )
+
+    Logger.warning(
+      "knowledge.vector_search under_fill endpoint=suggested_links tenant_id=#{tenant_id} " <>
+        "requested=#{limit} returned=#{returned} pool=#{pool} ann_candidates=#{ann_candidates} " <>
+        "above_threshold=#{above_threshold} excluded_by_link=#{excluded_by_link}"
+    )
+  end
+
+  # Bounded under-fill probe (US-27.6b). Over the SAME inner ANN top-`pool` subquery the
+  # main query draws from (so the candidate set is identical by construction), it returns
+  # in ONE read:
+  #
+  #   * `ann_candidates`  = COUNT(*) of the rows the inner ANN actually delivered — bounded
+  #     by `LIMIT pool` AND, under HNSW, by `~ef_search` (~40), so it doubles as a
+  #     recall-breadth diagnostic (NOT a `>= pool` pool-full gate — see
+  #     `maybe_signal_under_fill/8`). Touches at most `pool` rows (≤ `max_vector_pool`).
+  #   * `above_threshold` = COUNT(*) FILTER (similarity_score > threshold) over that same
+  #     delivered set — "do near (above-the-relevance-bar) neighbors actually exist?" — the
+  #     signal that separates a real recall incident from a genuinely-sparse region
+  #     (AC-27.6b.6).
+  #
+  # Runs on the SAME dedicated heavy-read pool, ONLY on the `returned < limit` path (one
+  # bounded extra ANN-class read; the full-result path issues none), and carries NO vector
+  # / body data. Returns `:error` (NOT raising) on a DB connectivity / timeout fault so the
+  # caller can fail-soft — a genuine query bug still surfaces (we re-raise non-cancel
+  # Postgrex errors).
+  defp under_fill_probe(tenant_id, article_id, embedding, threshold, vis, pool) do
+    candidates = suggestion_candidates_inner(tenant_id, article_id, embedding, vis, pool)
+
+    probe =
+      from(c in subquery(candidates),
+        select: %{
+          ann_candidates: count(c.id),
+          above_threshold:
+            fragment("COUNT(*) FILTER (WHERE ? > ?)", c.similarity_score, ^threshold)
+        }
       )
-      |> maybe_filter_by_visibility(vis)
 
-    count_query = from(c in subquery(inner), select: count(c.id))
+    case HeavyRead.one(tenant_id, probe, heavy_read_opts(:suggested_links)) do
+      %{ann_candidates: a, above_threshold: t} -> {a || 0, t || 0}
+      nil -> {0, 0}
+    end
+  rescue
+    e in DBConnection.ConnectionError ->
+      Logger.warning(
+        "knowledge.vector_search under_fill probe degraded (connection); suggestions returned: " <>
+          Exception.message(e)
+      )
 
-    HeavyRead.one(tenant_id, count_query, heavy_read_opts(:suggested_links)) || 0
+      :error
+
+    e in Postgrex.Error ->
+      # Degrade ONLY on a server-side cancel (statement_timeout); re-raise anything else
+      # (e.g. a malformed query) so genuine bugs surface in tests instead of silently
+      # becoming a missing signal.
+      if match?(%{postgres: %{code: :query_canceled}}, e) do
+        Logger.warning(
+          "knowledge.vector_search under_fill probe degraded (timeout); suggestions returned: " <>
+            Exception.message(e)
+        )
+
+        :error
+      else
+        reraise(e, __STACKTRACE__)
+      end
   end
 
   @doc false
@@ -3365,24 +3461,8 @@ defmodule Loopctl.Knowledge do
   # target exists / is published / is embedded / is visible.
   @doc false
   def suggestion_candidates_query(tenant_id, article_id, embedding, threshold, limit, vis) do
-    target = to_embedding_list(embedding)
     pool = suggestion_candidate_pool(limit)
-
-    candidates =
-      from(a in Article,
-        where: a.tenant_id == ^tenant_id and a.status == :published,
-        where: not is_nil(a.embedding),
-        where: a.id != ^article_id,
-        order_by: [asc: fragment("? <=> ?", a.embedding, ^target)],
-        limit: ^pool,
-        select: %{
-          id: a.id,
-          title: a.title,
-          category: a.category,
-          similarity_score: fragment("GREATEST(0, 1 - (? <=> ?))", a.embedding, ^target)
-        }
-      )
-      |> maybe_filter_by_visibility(vis)
+    candidates = suggestion_candidates_inner(tenant_id, article_id, embedding, vis, pool)
 
     from(c in subquery(candidates),
       # Exclude any article already linked to the target (either direction, any type).
@@ -3402,6 +3482,33 @@ defmodule Loopctl.Knowledge do
         similarity_score: c.similarity_score
       }
     )
+  end
+
+  # The inner ANN top-`pool` subquery, SHARED by the main suggestion query and the
+  # under-fill probe so their candidate set is identical BY CONSTRUCTION (no drift). It
+  # is the pure top-`pool` nearest-by-cosine with only index-safe filters (tenant /
+  # status / not-null / not-self / visibility) and the computed `similarity_score`. The
+  # anti-join + threshold + final `limit` are applied by the OUTER query (see the SHAPE
+  # IS LOAD-BEARING note above); the probe reuses this same inner set to count pool
+  # fullness and above-threshold neighbors without re-running the ANN scan twice with
+  # divergent predicates.
+  defp suggestion_candidates_inner(tenant_id, article_id, embedding, vis, pool) do
+    target = to_embedding_list(embedding)
+
+    from(a in Article,
+      where: a.tenant_id == ^tenant_id and a.status == :published,
+      where: not is_nil(a.embedding),
+      where: a.id != ^article_id,
+      order_by: [asc: fragment("? <=> ?", a.embedding, ^target)],
+      limit: ^pool,
+      select: %{
+        id: a.id,
+        title: a.title,
+        category: a.category,
+        similarity_score: fragment("GREATEST(0, 1 - (? <=> ?))", a.embedding, ^target)
+      }
+    )
+    |> maybe_filter_by_visibility(vis)
   end
 
   # Over-fetch factor for the inner ANN subquery: pull this many nearest candidates from

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -48,6 +48,7 @@ defmodule Loopctl.Knowledge do
   alias Loopctl.Knowledge.Analytics
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.ArticleLink
+  alias Loopctl.Knowledge.VectorSearch
   alias Loopctl.Projects.Project
   alias Loopctl.Webhooks.EventGenerator
   alias Loopctl.Workers.ArticleEmbeddingWorker
@@ -3102,8 +3103,21 @@ defmodule Loopctl.Knowledge do
   Consequence: for a densely-linked "hub" whose nearest neighbors are almost all
   already linked, the result may contain fewer than `:limit` suggestions (or be
   empty) even though more-distant unlinked candidates exist — by design, the price of
-  the indexed path. Recall is additionally bounded by `hnsw.ef_search`, as in
-  semantic search.
+  the indexed path.
+
+  ## Recall ceiling + the under-fill signal (US-27.6b)
+
+  Recall is bounded by `hnsw.ef_search` (pgvector **default ~40**) AND the over-fetch
+  pool — see the `Loopctl.Knowledge.VectorSearch` moduledoc for the full ceiling
+  discussion (why `ef_search` can't be raised via Postgrex `:parameters`, and that
+  `ALTER ROLE … SET hnsw.ef_search` is the only safe non-transaction lever, US-27.11).
+  Until that is verified on fly mpg, recall stays at the default and under-fill is made
+  **observable**: use `suggest_links_with_meta/3` (the variant the endpoint calls) — it
+  returns a `meta` flag `recall_truncated`/`pool_exhausted` AND emits a
+  `[:loopctl, :knowledge, :vector_search, :under_fill]` telemetry event (once per
+  request) whenever the nearest pool was filled to cap but the anti-join / threshold cut
+  the result below `:limit`. That distinguishes an INCOMPLETE result from a
+  genuinely-empty corpus — the silent-recall failure this story closes.
 
   ## Returns
 
@@ -3116,6 +3130,48 @@ defmodule Loopctl.Knowledge do
   @spec suggest_links(Ecto.UUID.t(), Ecto.UUID.t(), keyword()) ::
           {:ok, [map()]} | {:error, :not_found} | {:error, :invalid_threshold}
   def suggest_links(tenant_id, article_id, opts \\ []) do
+    # Back-compat 2-tuple shape (the original contract). Delegates to the
+    # meta-bearing variant and drops the meta — callers that don't need the
+    # under-fill signal (and the plan/EXPLAIN scale tests) keep `{:ok, list}`.
+    case suggest_links_with_meta(tenant_id, article_id, opts) do
+      {:ok, suggestions, _meta} -> {:ok, suggestions}
+      other -> other
+    end
+  end
+
+  @doc """
+  Like `suggest_links/3`, but also returns a `meta` map describing recall
+  completeness for the consumer (US-27.6b AC-27.6b.6).
+
+  The endpoint controller calls THIS so an agent can distinguish an *incomplete*
+  result (the densely-linked-hub case: the nearest pool was filled to cap but the
+  already-linked anti-join / threshold cut it below the requested limit) from a
+  *genuinely-empty* one (the corpus simply has fewer than `limit` eligible
+  neighbors). The same condition emits the
+  `[:loopctl, :knowledge, :vector_search, :under_fill]` telemetry event exactly
+  once per request (see `suggestion_candidates/6`).
+
+  ## Returns
+
+    * `{:ok, [%{id, title, category, similarity_score}], meta}` where `meta` is:
+
+          %{
+            requested: limit,         # the requested limit (post-clamp)
+            returned: length(result), # how many candidates came back
+            pool: pool_size,          # the inner over-fetch pool
+            # true when returned < requested AND the pool was filled to cap
+            # (filters exhausted a FULL pool) — i.e. recall is incomplete:
+            pool_exhausted: boolean,
+            recall_truncated: boolean # alias of pool_exhausted (consumer-facing name)
+          }
+
+    * `{:ok, [], meta}` when the article has no embedding yet (`pool_exhausted: false`)
+    * `{:error, :not_found}` / `{:error, :invalid_threshold}` as `suggest_links/3`
+  """
+  @impl Loopctl.Knowledge.SuggestLinksBehaviour
+  @spec suggest_links_with_meta(Ecto.UUID.t(), Ecto.UUID.t(), keyword()) ::
+          {:ok, [map()], map()} | {:error, :not_found} | {:error, :invalid_threshold}
+  def suggest_links_with_meta(tenant_id, article_id, opts \\ []) do
     threshold = Keyword.get(opts, :threshold) || default_suggestion_threshold()
     vis = Keyword.get(opts, :visibility_agent_id)
 
@@ -3131,12 +3187,27 @@ defmodule Loopctl.Knowledge do
           {:error, :not_found}
 
         %{embedding: nil} ->
-          {:ok, []}
+          {:ok, [], empty_suggestion_meta(limit)}
 
         %{embedding: embedding} ->
-          {:ok, suggestion_candidates(tenant_id, article_id, embedding, threshold, limit, vis)}
+          {suggestions, meta} =
+            suggestion_candidates(tenant_id, article_id, embedding, threshold, limit, vis)
+
+          {:ok, suggestions, meta}
       end
     end
+  end
+
+  # Meta for the no-embedding short-circuit: a 0-result is NOT under-fill (there is
+  # no pool to fill), so the consumer must see `pool_exhausted: false`.
+  defp empty_suggestion_meta(limit) do
+    %{
+      requested: limit,
+      returned: 0,
+      pool: suggestion_candidate_pool(limit),
+      pool_exhausted: false,
+      recall_truncated: false
+    }
   end
 
   defp default_suggestion_threshold,
@@ -3166,7 +3237,89 @@ defmodule Loopctl.Knowledge do
     # tenant predicate lives in this query's inner subquery. The 15s client timeout
     # is a backstop above the server-side statement_timeout.
     query = suggestion_candidates_query(tenant_id, article_id, embedding, threshold, limit, vis)
-    HeavyRead.all(tenant_id, query, heavy_read_opts(:suggested_links))
+    suggestions = HeavyRead.all(tenant_id, query, heavy_read_opts(:suggested_links))
+
+    pool = suggestion_candidate_pool(limit)
+    returned = length(suggestions)
+
+    meta =
+      maybe_signal_under_fill(tenant_id, article_id, embedding, vis, limit, pool, returned)
+
+    {suggestions, meta}
+  end
+
+  # Under-fill signal (US-27.6b AC-27.6b.2/.5/.6). Builds the response `meta` and —
+  # only when recall is genuinely truncated — emits ONE telemetry event per request.
+  #
+  # THE KEY DISTINCTION (the whole point of the story): emit ONLY when the inner ANN
+  # pool was actually FILLED to its cap and the post-ANN filters (the already-linked
+  # anti-join + the similarity threshold) cut the result below `limit`. We do NOT emit
+  # when the corpus simply has fewer than `limit` eligible candidates — that is a
+  # genuinely-empty result, not a recall incident.
+  #
+  #   under_fill      = returned < limit AND available >= pool   (pool full, filters cut)
+  #   NOT under_fill  = returned < limit AND available <  pool   (corpus genuinely small)
+  #
+  # `available` is the count of the INNER candidate set (the same tenant / published /
+  # embedded / not-self / visible rows the ANN draws from), capped at `pool` — see
+  # `available_candidate_count/5`. When `returned >= limit` there is nothing to detect,
+  # so we skip the extra read entirely (zero added cost on the common full-result path).
+  defp maybe_signal_under_fill(tenant_id, article_id, embedding, vis, limit, pool, returned) do
+    base = %{requested: limit, returned: returned, pool: pool}
+
+    if returned < limit do
+      available = available_candidate_count(tenant_id, article_id, embedding, vis, pool)
+      pool_exhausted? = available >= pool
+
+      if pool_exhausted? do
+        :telemetry.execute(
+          Loopctl.TelemetryEvents.vector_search_under_fill(),
+          %{requested: limit, returned: returned, pool: pool, available: available},
+          %{
+            tenant_id: tenant_id,
+            endpoint: :suggested_links,
+            # how many of the full pool the post-ANN filters cut away to land at `returned`
+            excluded_by_filters: max(pool - returned, 0)
+          }
+        )
+
+        Logger.warning(
+          "knowledge.vector_search under_fill endpoint=suggested_links tenant_id=#{tenant_id} " <>
+            "requested=#{limit} returned=#{returned} pool=#{pool} available=#{available}"
+        )
+      end
+
+      Map.merge(base, %{pool_exhausted: pool_exhausted?, recall_truncated: pool_exhausted?})
+    else
+      Map.merge(base, %{pool_exhausted: false, recall_truncated: false})
+    end
+  end
+
+  # Bounded "was the pool full?" probe (US-27.6b). Counts the INNER candidate set —
+  # the exact rows the ANN subquery draws from (tenant + published + embedded +
+  # not-self + visible) — but **capped at `pool`** via an inner `LIMIT pool`, so the
+  # count is `min(true_count, pool)` and the read touches at most `pool` rows (≤ the
+  # `max_vector_pool` cap, 500 by default). It runs on the SAME dedicated heavy-read
+  # pool (one bounded extra read, only on the `returned < limit` path) and carries NO
+  # vector / body data. We deliberately do NOT add the cosine ORDER BY here: order is
+  # irrelevant to "is the candidate set at least `pool` large", and omitting it keeps
+  # this a cheap index-filtered count rather than a second ANN scan.
+  defp available_candidate_count(tenant_id, article_id, embedding, vis, pool) do
+    _ = embedding
+
+    inner =
+      from(a in Article,
+        where: a.tenant_id == ^tenant_id and a.status == :published,
+        where: not is_nil(a.embedding),
+        where: a.id != ^article_id,
+        select: %{id: a.id},
+        limit: ^pool
+      )
+      |> maybe_filter_by_visibility(vis)
+
+    count_query = from(c in subquery(inner), select: count(c.id))
+
+    HeavyRead.one(tenant_id, count_query, heavy_read_opts(:suggested_links)) || 0
   end
 
   @doc false
@@ -3242,12 +3395,15 @@ defmodule Loopctl.Knowledge do
   # the HNSW index before the outer query applies the anti-join + threshold and trims to
   # `limit`. Scales with `limit` (headroom for exclusions), floored for the common small
   # `limit`, and capped so the index scan stays cheap.
+  #
+  # The factor/floor/cap are the SAME config constants the shared `VectorSearch` helper
+  # reads (US-27.6b AC-27.6b.1), so the live `suggested_links` path and the shared kNN
+  # helper never size their pools differently. `:max_suggestion_candidate_pool` is still
+  # honored as a back-compat alias for the cap when set.
   defp suggestion_candidate_pool(limit) do
-    max(limit * 5, 100)
-    |> min(Application.get_env(:loopctl, :max_suggestion_candidate_pool, 500))
-    # Never let a misconfigured cap drop the pool below `limit` — that would truncate the
-    # candidate set before the outer exclusions even run.
-    |> max(limit)
+    VectorSearch.pool_size(limit,
+      cap: Application.get_env(:loopctl, :max_suggestion_candidate_pool)
+    )
   end
 
   # The HNSW-indexable cosine form binds the target as a plain `[float()]` list (the

--- a/lib/loopctl/knowledge/suggest_links_behaviour.ex
+++ b/lib/loopctl/knowledge/suggest_links_behaviour.ex
@@ -11,6 +11,11 @@ defmodule Loopctl.Knowledge.SuggestLinksBehaviour do
   #170/#172 incident was hard to diagnose).
 
   `Loopctl.Knowledge` implements this callback directly; production uses it.
+
+  The endpoint controller calls `suggest_links_with_meta/3` (US-27.6b) — the
+  meta-bearing variant carrying the recall-completeness flag. The original
+  `suggest_links/3` 2-tuple callback is retained for back-compat callers / tests
+  that don't need the under-fill signal.
   """
 
   @callback suggest_links(
@@ -19,4 +24,11 @@ defmodule Loopctl.Knowledge.SuggestLinksBehaviour do
               opts :: keyword()
             ) ::
               {:ok, [map()]} | {:error, :not_found} | {:error, :invalid_threshold}
+
+  @callback suggest_links_with_meta(
+              tenant_id :: Ecto.UUID.t(),
+              article_id :: Ecto.UUID.t(),
+              opts :: keyword()
+            ) ::
+              {:ok, [map()], map()} | {:error, :not_found} | {:error, :invalid_threshold}
 end

--- a/lib/loopctl/knowledge/vector_search.ex
+++ b/lib/loopctl/knowledge/vector_search.ex
@@ -64,6 +64,9 @@ defmodule Loopctl.Knowledge.VectorSearch do
   emits a `[:loopctl, :knowledge, :vector_search, :under_fill]` telemetry event and
   a response-`meta` flag when the pool was filled to cap but filters cut it below
   `k` (see that function + `Loopctl.TelemetryEvents.vector_search_under_fill/0`).
+  The event's `excluded_total` measurement is the COMBINED post-ANN exclusion count
+  (anti-join + threshold); a per-reason split is deferred to US-27.15 because
+  separating the two would cost an extra per-request read (AC-27.6b.5 cost bound).
 
   **Raising recall is deliberately NOT done per-request here.** `hnsw.ef_search` is
   a pgvector **custom GUC** that does not exist until the extension loads per

--- a/lib/loopctl/knowledge/vector_search.ex
+++ b/lib/loopctl/knowledge/vector_search.ex
@@ -42,10 +42,39 @@ defmodule Loopctl.Knowledge.VectorSearch do
   are post-ANN filters applied to the ≤500-row pool** and can severely under-fill:
   a selective tag matching <1% of the corpus will rarely survive the pool's
   top-`pool`-by-cosine approximation, returning 0 results even when k matching
-  articles exist corpus-wide. This is a known limitation of post-ANN filters;
-  recall-tuning (e.g., raising pool for selective filters) is handled in US-27.6b
-  telemetry + response meta. This module is the index-correct core + caller-cost
-  bounds + tenant isolation.
+  articles exist corpus-wide. This is a known limitation of post-ANN filters.
+  This module is the index-correct core + caller-cost bounds + tenant isolation.
+
+  ## Recall ceiling + the under-fill signal (US-27.6b)
+
+  Recall is bounded by **two** things, not one:
+
+    1. `hnsw.ef_search` — pgvector's per-query search breadth, **default ~40**. The
+       inner ANN only inspects ~`ef_search` graph nodes, so even before any filter
+       the "nearest pool" is an *approximation* of the true top-`pool`.
+    2. the over-fetch `pool` itself — the post-ANN filters (anti-join / threshold /
+       tags / category) run over only those `pool` rows.
+
+  **Under-fill is EXPECTED for a densely-linked hub:** when a hub's nearest pool is
+  almost entirely already-linked (or below threshold), the result legitimately
+  returns fewer than `k` even though more-distant unlinked candidates exist. That is
+  the price of the indexed path — NOT a bug. The danger is that this looks
+  *identical* to "no neighbors exist" (a genuinely-empty corpus). So under-fill is
+  made **observable, not silent**: `Loopctl.Knowledge.suggest_links_with_meta/3`
+  emits a `[:loopctl, :knowledge, :vector_search, :under_fill]` telemetry event and
+  a response-`meta` flag when the pool was filled to cap but filters cut it below
+  `k` (see that function + `Loopctl.TelemetryEvents.vector_search_under_fill/0`).
+
+  **Raising recall is deliberately NOT done per-request here.** `hnsw.ef_search` is
+  a pgvector **custom GUC** that does not exist until the extension loads per
+  session, so it **cannot** be set via a Postgrex startup `:parameters` entry
+  (managed PG rejects it: *"unrecognized configuration parameter"* — see
+  `docs/runbooks/knowledge-scale.md`). Setting it per-request would require a
+  `SET LOCAL` inside a transaction, re-introducing the #172 pool-starvation
+  anti-pattern on the small heavy-read pool. The only safe non-transaction lever is
+  `ALTER ROLE <heavy_read_role> SET hnsw.ef_search = N` (US-27.11), and only if
+  verified to apply on fly mpg. Until then recall stays at the default and is
+  handled by **over-fetch + the under-fill signal**.
 
   ## Caller-cost bounds (AC-27.6a.4 — OWASP A06, insecure design)
 
@@ -54,8 +83,11 @@ defmodule Loopctl.Knowledge.VectorSearch do
   backstop, NOT the primary bound:
 
     * `k` / limit — clamped to `[1, max_k/0]` (default 100).
-    * the over-fetch `pool` — `max(k*5, 100) |> min(max_pool/0) |> max(k)`
-      (default cap 500), so the index scan stays cheap regardless of `k`.
+    * the over-fetch `pool` — `pool_size/2`:
+      `k * pool_factor/0 |> max(pool_floor/0) |> min(max_pool/0) |> max(k)`
+      (default factor 5, floor 100, cap 500), so the index scan stays cheap
+      regardless of `k`, and a misconfigured `cap < k` can never starve the pool
+      below `k` (US-27.6b AC-27.6b.1).
     * `:threshold` — clamped into `[0.0, 1.0]`.
     * `:tags` — truncated to `max_tags/0` (default 50) entries; an empty/`nil`
       list is ignored.
@@ -112,6 +144,15 @@ defmodule Loopctl.Knowledge.VectorSearch do
   # before the outer exclusions trim to `k`. Mirrors `:max_suggestion_candidate_pool`.
   @default_max_pool 500
 
+  # Over-fetch pool sizing (US-27.6b AC-27.6b.1). The inner pool is
+  # `k * factor |> max(floor) |> min(cap) |> max(k)`. Each knob is a config
+  # constant with a documented default; the FINAL `|> max(k)` is load-bearing —
+  # it guarantees a misconfigured `cap < k` can NEVER drop the pool below the
+  # requested `k`, so the cap can only ever ENLARGE the over-fetch, never starve
+  # the result before the outer post-ANN filters run.
+  @default_pool_factor 5
+  @default_pool_floor 100
+
   # Maximum number of tag values accepted in a `:tags` overlap filter, so a caller
   # can't pass an unbounded array literal into the index-residual `&&` predicate.
   @default_max_tags 50
@@ -125,13 +166,66 @@ defmodule Loopctl.Knowledge.VectorSearch do
   @spec max_k() :: pos_integer()
   def max_k, do: Application.get_env(:loopctl, :vector_search_max_k, @default_max_k)
 
-  @doc "Maximum over-fetch pool (config `:vector_search_max_pool`, default #{@default_max_pool})."
+  @doc """
+  Maximum over-fetch pool (config `:max_vector_pool`, default #{@default_max_pool}).
+
+  `:max_vector_pool` is the canonical key (US-27.6b AC-27.6b.1). The pre-27.6b
+  `:vector_search_max_pool` key is still honored as a fallback so an existing
+  override keeps working.
+  """
   @spec max_pool() :: pos_integer()
-  def max_pool, do: Application.get_env(:loopctl, :vector_search_max_pool, @default_max_pool)
+  def max_pool do
+    Application.get_env(
+      :loopctl,
+      :max_vector_pool,
+      Application.get_env(:loopctl, :vector_search_max_pool, @default_max_pool)
+    )
+  end
 
   @doc "Maximum number of `:tags` accepted (config `:vector_search_max_tags`, default #{@default_max_tags})."
   @spec max_tags() :: pos_integer()
   def max_tags, do: Application.get_env(:loopctl, :vector_search_max_tags, @default_max_tags)
+
+  @doc "Over-fetch pool multiplier on `k` (config `:vector_pool_factor`, default #{@default_pool_factor})."
+  @spec pool_factor() :: pos_integer()
+  def pool_factor, do: Application.get_env(:loopctl, :vector_pool_factor, @default_pool_factor)
+
+  @doc "Minimum over-fetch pool for small `k` (config `:vector_pool_floor`, default #{@default_pool_floor})."
+  @spec pool_floor() :: pos_integer()
+  def pool_floor, do: Application.get_env(:loopctl, :vector_pool_floor, @default_pool_floor)
+
+  @doc """
+  Computes the over-fetch pool for a requested `k` (US-27.6b AC-27.6b.1):
+
+      pool = k * factor |> max(floor) |> min(cap) |> max(k)
+
+  The factor/floor/cap default to the `:vector_pool_factor` / `:vector_pool_floor`
+  / `:max_vector_pool` config (defaults #{@default_pool_factor} / #{@default_pool_floor}
+  / #{@default_max_pool}). The final `|> max(k)` is the AC-27.6b.1 invariant: a
+  misconfigured `cap < k` can never truncate the pool below `k`.
+
+  `opts` lets a caller pass explicit knob values (used by the unit test to assert
+  the floor-at-`k` wins without mutating global config, and by the live
+  `suggested_links` path's back-compat `:max_suggestion_candidate_pool` cap alias).
+  A `nil` opt falls back to the configured/default value.
+
+    * `:factor` — multiplier (default `pool_factor/0`)
+    * `:floor` — small-`k` floor (default `pool_floor/0`)
+    * `:cap` — upper bound (default `max_pool/0`)
+  """
+  @spec pool_size(pos_integer(), keyword()) :: pos_integer()
+  def pool_size(k, opts \\ []) when is_integer(k) and k > 0 do
+    factor = Keyword.get(opts, :factor) || pool_factor()
+    floor = Keyword.get(opts, :floor) || pool_floor()
+    cap = Keyword.get(opts, :cap) || max_pool()
+
+    (k * factor)
+    |> max(floor)
+    |> min(cap)
+    # LOAD-BEARING: the cap can only ever ENLARGE the over-fetch, never drop the
+    # pool below the requested k (a misconfigured cap < k is overridden here).
+    |> max(k)
+  end
 
   @doc """
   Executes the index-correct kNN query and returns up to `k` candidate maps,
@@ -320,21 +414,21 @@ defmodule Loopctl.Knowledge.VectorSearch do
   defp clamp_k(k) when is_integer(k), do: k |> max(1) |> min(max_k())
   defp clamp_k(_), do: 1
 
-  # Over-fetch factor for the inner ANN subquery (mirrors Knowledge.suggestion_candidate_pool/1):
-  # scale with `k`, floor for the common small `k`, cap so the index scan stays cheap,
-  # and never below `k` (a misconfigured cap must not truncate before the outer filters).
-  defp candidate_pool(k, override) do
-    base = override_pool(override, k)
-
-    base
-    |> max(100)
+  # Over-fetch pool for the inner ANN subquery. A `:pool` override (when a positive
+  # integer) replaces the `k * factor` base but is STILL clamped by the floor/cap and
+  # floored at `k` (so an override can't bust the cap or starve below `k`). With no
+  # override it is the config-driven `pool_size/2` (k*factor |> max(floor) |> min(cap)
+  # |> max(k)) — the SAME sizing as the live `suggested_links` path.
+  defp candidate_pool(k, override) when is_integer(override) and override > 0 do
+    # An explicit override acts as the base (in place of k*factor): floor it for the
+    # small-k case, cap it, and never let it drop below k.
+    override
+    |> max(pool_floor())
     |> min(max_pool())
     |> max(k)
   end
 
-  defp override_pool(nil, k), do: k * 5
-  defp override_pool(p, _k) when is_integer(p) and p > 0, do: p
-  defp override_pool(_p, k), do: k * 5
+  defp candidate_pool(k, _override), do: pool_size(k)
 
   defp clamp_threshold(t) when is_number(t), do: t |> max(0.0) |> min(1.0) |> :erlang.float()
   defp clamp_threshold(_), do: 0.0

--- a/lib/loopctl/knowledge/vector_search.ex
+++ b/lib/loopctl/knowledge/vector_search.ex
@@ -62,11 +62,15 @@ defmodule Loopctl.Knowledge.VectorSearch do
   *identical* to "no neighbors exist" (a genuinely-empty corpus). So under-fill is
   made **observable, not silent**: `Loopctl.Knowledge.suggest_links_with_meta/3`
   emits a `[:loopctl, :knowledge, :vector_search, :under_fill]` telemetry event and
-  a response-`meta` flag when the pool was filled to cap but filters cut it below
-  `k` (see that function + `Loopctl.TelemetryEvents.vector_search_under_fill/0`).
-  The event's `excluded_total` measurement is the COMBINED post-ANN exclusion count
-  (anti-join + threshold); a per-reason split is deferred to US-27.15 because
-  separating the two would cost an extra per-request read (AC-27.6b.5 cost bound).
+  a response-`meta` flag when above-threshold (near) neighbors the ANN surfaced were
+  hidden by the already-linked anti-join (`above_threshold > returned`) — NOT for a
+  sparse region whose whole ANN pool is below the threshold (correct emptiness, see
+  that function + `Loopctl.TelemetryEvents.vector_search_under_fill/0`). The detector
+  is ef_search-independent (it compares counts over the set the ANN actually
+  delivered, never a degenerate `ann_candidates >= pool` gate). The event's
+  `excluded_by_link` measurement (`above_threshold - returned`) is the un-conflated
+  count of above-threshold neighbors the anti-join removed — the recall-loss metric
+  US-27.15 aggregates, computed from the single bounded under-fill probe.
 
   **Raising recall is deliberately NOT done per-request here.** `hnsw.ef_search` is
   a pgvector **custom GUC** that does not exist until the extension loads per

--- a/lib/loopctl/telemetry_events.ex
+++ b/lib/loopctl/telemetry_events.ex
@@ -45,21 +45,30 @@ defmodule Loopctl.TelemetryEvents do
 
   @doc """
   A vector-search read under-filled (US-27.6b): it returned fewer than the
-  requested `k` candidates DESPITE the inner ANN pool being filled to its cap —
-  i.e. the post-ANN filters (already-linked anti-join / similarity threshold)
-  cut the full pool below `k`, not a genuinely-small corpus. Emitted at most
-  ONCE per request.
+  requested `k` candidates AND above-threshold (near) neighbors the inner ANN
+  surfaced were hidden by the already-linked anti-join — `above_threshold >
+  returned`. NOT fired for a genuinely-sparse region whose whole ANN pool is
+  below the similarity threshold (correct emptiness, not recall loss, so
+  `above_threshold == returned`). Emitted at most ONCE per request.
 
   ## Payload (id-only — NEVER a vector literal or article body, AC-27.6b.5)
 
-    * `measurements`: `%{requested, returned, pool, available, excluded_total}`
-      where `excluded_total = pool - returned` is the **TOTAL** post-ANN
-      exclusion count — the anti-join drops and the below-threshold drops
-      COMBINED, NOT a per-reason split. A per-reason breakdown (anti-join vs
-      threshold) is intentionally **deferred to US-27.15** (the metrics
-      aggregation that consumes this event): computing the two components
-      separately would cost an ADDITIONAL bounded read per request, which the
-      AC-27.6b.5 one-bounded-read cost bound discourages.
+    * `measurements`: `%{requested, returned, pool, ann_candidates,
+      above_threshold, excluded_by_link}` where
+        - `pool` = the REQUESTED over-fetch ceiling (`pool_size/2`).
+        - `ann_candidates` = how many rows the inner ANN actually delivered —
+          bounded by `LIMIT pool` AND, under HNSW, by `~ef_search` (~40), so it
+          is typically `< pool`. A recall-BREADTH diagnostic, NOT a pool-full
+          gate (an `ann_candidates >= pool` check is degenerate under HNSW).
+        - `above_threshold` = how many of `ann_candidates` clear the similarity
+          bar — the near neighbors that actually exist.
+        - `excluded_by_link` = `above_threshold - returned` — the above-threshold
+          neighbors the already-linked anti-join HID. Because the signal only
+          fires when `returned < limit` (so the outer LIMIT never bound and every
+          unlinked above-threshold candidate WAS returned), this is an
+          UN-CONFLATED recall-loss count — purely anti-join drops, with the
+          below-threshold (sparse) drops already excluded. No extra read is
+          needed to disentangle the two.
     * `metadata`: `%{tenant_id, endpoint}` — `tenant_id` is an id, not content.
 
   Aggregated by US-27.15 metrics/alerting.

--- a/lib/loopctl/telemetry_events.ex
+++ b/lib/loopctl/telemetry_events.ex
@@ -43,6 +43,17 @@ defmodule Loopctl.TelemetryEvents do
   @doc "Audit log entry written"
   def audit_log_write, do: [:loopctl, :audit, :write]
 
+  @doc """
+  A vector-search read under-filled (US-27.6b): it returned fewer than the
+  requested `k` candidates DESPITE the inner ANN pool being filled to its cap —
+  i.e. the post-ANN filters (already-linked anti-join / similarity threshold)
+  cut the full pool below `k`, not a genuinely-small corpus. Emitted at most
+  ONCE per request. Carries an id-only payload (tenant_id, endpoint, requested,
+  pool, returned, available, excluded_by_filters) — NEVER a vector literal or
+  article body (AC-27.6b.5). Aggregated by US-27.15 metrics/alerting.
+  """
+  def vector_search_under_fill, do: [:loopctl, :knowledge, :vector_search, :under_fill]
+
   @doc "Returns all defined event names for attachment"
   def all_events do
     [
@@ -53,7 +64,8 @@ defmodule Loopctl.TelemetryEvents do
       webhook_delivery_start(),
       webhook_delivery_stop(),
       webhook_delivery_exception(),
-      audit_log_write()
+      audit_log_write(),
+      vector_search_under_fill()
     ]
   end
 end

--- a/lib/loopctl/telemetry_events.ex
+++ b/lib/loopctl/telemetry_events.ex
@@ -48,9 +48,21 @@ defmodule Loopctl.TelemetryEvents do
   requested `k` candidates DESPITE the inner ANN pool being filled to its cap —
   i.e. the post-ANN filters (already-linked anti-join / similarity threshold)
   cut the full pool below `k`, not a genuinely-small corpus. Emitted at most
-  ONCE per request. Carries an id-only payload (tenant_id, endpoint, requested,
-  pool, returned, available, excluded_by_filters) — NEVER a vector literal or
-  article body (AC-27.6b.5). Aggregated by US-27.15 metrics/alerting.
+  ONCE per request.
+
+  ## Payload (id-only — NEVER a vector literal or article body, AC-27.6b.5)
+
+    * `measurements`: `%{requested, returned, pool, available, excluded_total}`
+      where `excluded_total = pool - returned` is the **TOTAL** post-ANN
+      exclusion count — the anti-join drops and the below-threshold drops
+      COMBINED, NOT a per-reason split. A per-reason breakdown (anti-join vs
+      threshold) is intentionally **deferred to US-27.15** (the metrics
+      aggregation that consumes this event): computing the two components
+      separately would cost an ADDITIONAL bounded read per request, which the
+      AC-27.6b.5 one-bounded-read cost bound discourages.
+    * `metadata`: `%{tenant_id, endpoint}` — `tenant_id` is an id, not content.
+
+  Aggregated by US-27.15 metrics/alerting.
   """
   def vector_search_under_fill, do: [:loopctl, :knowledge, :vector_search, :under_fill]
 

--- a/lib/loopctl_web/controllers/knowledge_suggest_links_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_suggest_links_controller.ex
@@ -37,7 +37,12 @@ defmodule LoopctlWeb.KnowledgeSuggestLinksController do
         "over the embedding index: exclusions (already-linked / below-threshold) are " <>
         "applied to the nearest candidate pool, so a densely-linked article may return " <>
         "fewer than `limit` (or none) even if more-distant unlinked articles exist. " <>
-        "Role: agent+.",
+        "When that happens the response `meta` carries `recall_truncated: true` " <>
+        "(alias `pool_exhausted: true`) so you can tell an INCOMPLETE result " <>
+        "(nearest pool was full but filters cut it below `limit`) apart from a " <>
+        "genuinely-empty one (no eligible neighbors). Recall is bounded by " <>
+        "`hnsw.ef_search` (pgvector default ~40) plus the over-fetch pool; " <>
+        "under-fill is expected for densely-linked hubs. Role: agent+.",
     parameters: [
       id: [in: :path, type: :string, description: "Article UUID"],
       limit: [in: :query, type: :integer, description: "Max candidates (default 5)"],
@@ -52,7 +57,30 @@ defmodule LoopctlWeb.KnowledgeSuggestLinksController do
         {"Suggested links", "application/json",
          %OpenApiSpex.Schema{
            type: :object,
-           properties: %{data: %OpenApiSpex.Schema{type: :array}}
+           properties: %{
+             data: %OpenApiSpex.Schema{type: :array},
+             meta: %OpenApiSpex.Schema{
+               type: :object,
+               description:
+                 "Recall-completeness signal (US-27.6b). `recall_truncated`/" <>
+                   "`pool_exhausted` are the same flag: true ⇒ the nearest candidate " <>
+                   "pool was filled but the already-linked/threshold filters cut the " <>
+                   "result below `requested`, so more (more-distant) neighbors may " <>
+                   "exist — distinct from a genuinely-empty result.",
+               properties: %{
+                 requested: %OpenApiSpex.Schema{
+                   type: :integer,
+                   description: "The requested limit"
+                 },
+                 returned: %OpenApiSpex.Schema{
+                   type: :integer,
+                   description: "How many candidates were returned"
+                 },
+                 recall_truncated: %OpenApiSpex.Schema{type: :boolean},
+                 pool_exhausted: %OpenApiSpex.Schema{type: :boolean}
+               }
+             }
+           }
          }},
       400 => {"Bad request", "application/json", Schemas.ErrorResponse},
       404 => {"Article not found", "application/json", Schemas.ErrorResponse},
@@ -73,13 +101,17 @@ defmodule LoopctlWeb.KnowledgeSuggestLinksController do
 
     with {:ok, threshold} <- parse_threshold(params["threshold"]),
          {:ok, limit} <- parse_limit(params["limit"]),
-         {:ok, suggestions} <-
+         {:ok, suggestions, meta} <-
            suggest_links_guarded(
              tenant_id,
              article_id,
              [threshold: threshold, limit: limit] ++ Visibility.scope_opts(conn)
            ) do
-      json(conn, %{data: suggestions})
+      # US-27.6b: `meta` lets the agent distinguish an INCOMPLETE result (a
+      # densely-linked hub whose nearest pool was filled but cut below `limit` by
+      # the already-linked anti-join / threshold — `recall_truncated: true`) from a
+      # genuinely-empty one. `recall_truncated`/`pool_exhausted` are the same flag.
+      json(conn, %{data: suggestions, meta: render_meta(meta)})
     else
       {:error, :invalid_threshold} ->
         {:error, :bad_request, "threshold must be a number between 0 and 1"}
@@ -113,13 +145,25 @@ defmodule LoopctlWeb.KnowledgeSuggestLinksController do
   # hard to reproduce). Production resolves to `Loopctl.Knowledge` itself, which
   # implements `Loopctl.Knowledge.SuggestLinksBehaviour`.
   defp suggest_links_guarded(tenant_id, article_id, opts) do
-    knowledge().suggest_links(tenant_id, article_id, opts)
+    knowledge().suggest_links_with_meta(tenant_id, article_id, opts)
   rescue
     e in [Postgrex.Error, DBConnection.ConnectionError] -> {:error, e}
   end
 
   defp knowledge do
     Application.get_env(:loopctl, :knowledge_suggest_links, Knowledge)
+  end
+
+  # Render the recall-completeness meta (US-27.6b AC-27.6b.6). Both
+  # `recall_truncated` (the consumer-facing name) and `pool_exhausted` (the
+  # operator/telemetry name) carry the SAME flag so a caller can key on either.
+  defp render_meta(meta) do
+    %{
+      requested: meta.requested,
+      returned: meta.returned,
+      recall_truncated: meta.recall_truncated,
+      pool_exhausted: meta.pool_exhausted
+    }
   end
 
   # Absent → nil (context applies the default). A present value must parse to a

--- a/test/loopctl/knowledge/vector_search_scale_test.exs
+++ b/test/loopctl/knowledge/vector_search_scale_test.exs
@@ -171,6 +171,17 @@ defmodule Loopctl.Knowledge.VectorSearchScaleTest do
 
       assert is_list(results)
       assert length(results) <= VectorSearch.max_k()
+
+      # US-27.6b AC-27.6b.7: re-verify the worst-case cost bound against the FINAL,
+      # NOW-CONFIG-DRIVEN pool cap. 6b moved the cap to the `:max_vector_pool` config
+      # constant; pin that the worst-case (k = max_k) pool is exactly that cap so a
+      # future cap change can't silently invalidate this cost proof. The scale gate
+      # runs with the prod defaults (config/test.exs leaves them untouched under
+      # SCALE_NIGHTLY), so this is the real 500-row cap, read from the same constant.
+      assert VectorSearch.pool_size(VectorSearch.max_k()) == VectorSearch.max_pool(),
+             "worst-case pool must equal the configured :max_vector_pool cap " <>
+               "(pool_size(max_k)=#{VectorSearch.pool_size(VectorSearch.max_k())}, " <>
+               "max_pool=#{VectorSearch.max_pool()})"
     end)
   end
 end

--- a/test/loopctl/knowledge/vector_search_test.exs
+++ b/test/loopctl/knowledge/vector_search_test.exs
@@ -378,6 +378,39 @@ defmodule Loopctl.Knowledge.VectorSearchTest do
     end
   end
 
+  describe "pool_size/2 — config-driven over-fetch, always floored at k (TC-27.6b.1, AC-27.6b.1)" do
+    test "PROD-default sizing is k*factor floored/capped (explicit knobs, env-independent)" do
+      # Pin the documented prod defaults explicitly so this is independent of the test
+      # config's shrunken pool (config/test.exs lowers the async-suite floor/cap to 6).
+      prod = [factor: 5, floor: 100, cap: 500]
+      # k=5 → 5*5=25 → max(floor 100)=100 → min(cap 500)=100 → max(k)=100
+      assert VectorSearch.pool_size(5, prod) == 100
+      # k=40 → 200 → max(100)=200 → min(500)=200 → max(40)=200
+      assert VectorSearch.pool_size(40, prod) == 200
+      # k=200 → 1000 → max(100)=1000 → min(500)=500 → max(200)=500 (cap wins)
+      assert VectorSearch.pool_size(200, prod) == 500
+    end
+
+    test "a misconfigured cap BELOW k can never drop the pool below k (the floor-at-k invariant)" do
+      # The crux of AC-27.6b.1: k=50 with a configured cap of 10 → the final |> max(k)
+      # overrides the too-small cap, so the pool is >= 50, NOT 10. We pass the cap as an
+      # explicit arg (no Application.put_env) so the invariant is proven on the pure
+      # sizing function directly.
+      assert VectorSearch.pool_size(50, cap: 10) == 50
+      assert VectorSearch.pool_size(50, cap: 10) >= 50
+
+      # Even with floor + cap both below k, k wins.
+      assert VectorSearch.pool_size(50, floor: 5, cap: 10) == 50
+    end
+
+    test "explicit factor/floor knobs compose, then k floors" do
+      # k=2, factor=3, floor=4, cap=1000 → 6 → max(4)=6 → min(1000)=6 → max(2)=6
+      assert VectorSearch.pool_size(2, factor: 3, floor: 4, cap: 1000) == 6
+      # k=10, factor=1, floor=1, cap=3 → 10 → max(1)=10 → min(3)=3 → max(10)=10 (k wins)
+      assert VectorSearch.pool_size(10, factor: 1, floor: 1, cap: 3) == 10
+    end
+  end
+
   # Resolve a `LIMIT $n` expression to its bound integer value.
   defp limit_value({:^, _, [idx]}, params), do: elem(Enum.at(params, idx), 0)
   defp limit_value(value, _params) when is_integer(value), do: value

--- a/test/loopctl/knowledge/vector_search_under_fill_scale_test.exs
+++ b/test/loopctl/knowledge/vector_search_under_fill_scale_test.exs
@@ -1,0 +1,208 @@
+defmodule Loopctl.Knowledge.VectorSearchUnderFillScaleTest do
+  @moduledoc """
+  US-27.6b scale gate (TC-27.6b.2 at scale + AC-27.6b.2 / AC-27.6b.4):
+
+    * **Dense-hub under-fill at prod scale** — on a real ~80k-row, densely-linked
+      corpus (the conditions that produce the silent fast-green-but-wrong empty
+      result the epic exists to fix), a hub whose nearest pool is filled but mostly
+      already-linked must (a) return fewer than the requested limit AND (b) fire the
+      `[:loopctl, :knowledge, :vector_search, :under_fill]` telemetry signal with a
+      full pool — proving the detection works against the real planner + HNSW recall,
+      not only the small async-suite pool.
+
+    * **ef_search parity (AC-27.6b.4)** — whatever `hnsw.ef_search` is EFFECTIVE must
+      be identical on the scale-gate connection and a prod-shaped connection, asserted
+      by `SHOW hnsw.ef_search` on each (NOT by comparing `:parameters` config blobs).
+      ef_search is never SET today (pgvector default 40); this pins it so a future
+      `ALTER ROLE … SET hnsw.ef_search` on prod (US-27.11) can't silently diverge from
+      the gate (ties to US-27.8).
+
+  Seeds ~80k committed rows via `Loopctl.Knowledge.ScaleSeed`, so it is
+  `:scale_nightly` and wired into `.github/workflows/ci.yml`'s `scale_file` matrix
+  (enforced by `scale_verification_runbook_test.exs`).
+  """
+  use ExUnit.Case, async: false
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Loopctl.AdminRepo
+  alias Loopctl.HeavyReadRepo
+  alias Loopctl.Knowledge
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.ArticleLink
+  alias Loopctl.Knowledge.ScaleSeed
+  alias Loopctl.Knowledge.VectorSearch
+  alias Loopctl.TelemetryEvents
+  alias Loopctl.Tenants.Tenant
+
+  import Ecto.Query
+
+  @moduletag :scale_nightly
+  @moduletag timeout: :timer.minutes(30)
+
+  defp unboxed(fun), do: Sandbox.unboxed_run(AdminRepo, fun)
+
+  setup do
+    tenant =
+      unboxed(fn ->
+        slug = "vuf-scale-#{:erlang.phash2(Ecto.UUID.generate())}"
+
+        {:ok, t} =
+          %Tenant{}
+          |> Tenant.create_changeset(%{
+            name: "VUF Scale #{slug}",
+            slug: slug,
+            email: "#{slug}@example.com",
+            settings: %{},
+            status: :active
+          })
+          |> AdminRepo.insert()
+
+        # link_density: 10 → a dense, linked corpus so a hub's nearest pool is heavily
+        # pre-linked (the adversarial anti-join that produces under-fill).
+        ScaleSeed.seed(t.id, count: ScaleSeed.prod_article_floor(), link_density: 10)
+        t
+      end)
+
+    on_exit(fn ->
+      try do
+        unboxed(fn ->
+          AdminRepo.delete_all(from(a in Article, where: a.tenant_id == ^tenant.id))
+          AdminRepo.delete_all(from(t in Tenant, where: t.id == ^tenant.id))
+        end)
+      rescue
+        _ -> :ok
+      end
+    end)
+
+    {:ok, tenant: tenant}
+  end
+
+  test "dense hub under-fills AND fires the under_fill signal at prod scale (TC-27.6b.2, AC-27.6b.2)",
+       %{tenant: tenant} do
+    unboxed(fn ->
+      # A dense-hub target deep in the seeded corpus. The ambient seed links each article
+      # to only ~link_density neighbors, which can't exhaust a 500-row pool — so to model a
+      # GENUINE dense hub (the real fast-green-but-wrong failure: a hub whose whole nearest
+      # pool is already linked), we explicitly link the target to EVERY one of its top-pool
+      # nearest neighbors. The anti-join then removes the entire pool, while the eligible
+      # candidate count (ignoring links) still >= pool → under-fill must fire.
+      target =
+        AdminRepo.one(
+          from(a in Article,
+            where: a.tenant_id == ^tenant.id and not is_nil(a.embedding),
+            order_by: [asc: a.inserted_at, asc: a.id],
+            offset: 100,
+            limit: 1,
+            select: %{id: a.id, embedding: a.embedding}
+          )
+        )
+
+      pool = VectorSearch.pool_size(5)
+      target_vec = VectorSearch.to_embedding_list(target.embedding)
+
+      # The target's top-`pool` nearest neighbor ids (the exact rows the inner ANN draws
+      # on) — a raw index-ordered scan (NOT `nearest/4`, whose k is clamped to max_k=100,
+      # which would leave most of the 500-pool unlinked). Then link the target to ALL of
+      # them so the anti-join exhausts the full pool.
+      nearest_ids =
+        AdminRepo.all(
+          from(a in Article,
+            where: a.tenant_id == ^tenant.id and a.status == :published,
+            where: not is_nil(a.embedding) and a.id != ^target.id,
+            order_by: [asc: fragment("? <=> ?", a.embedding, ^target_vec)],
+            limit: ^pool,
+            select: a.id
+          )
+        )
+
+      now = DateTime.utc_now()
+
+      link_rows =
+        Enum.map(nearest_ids, fn nid ->
+          %{
+            id: Ecto.UUID.generate(),
+            tenant_id: tenant.id,
+            source_article_id: target.id,
+            target_article_id: nid,
+            relationship_type: :relates_to,
+            metadata: %{},
+            inserted_at: now
+          }
+        end)
+
+      {_n, _} = AdminRepo.insert_all(ArticleLink, link_rows)
+
+      test_pid = self()
+      handler_id = "under-fill-scale-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler_id,
+        TelemetryEvents.vector_search_under_fill(),
+        fn _e, measurements, metadata, _ ->
+          send(test_pid, {:under_fill, measurements, metadata})
+        end,
+        nil
+      )
+
+      try do
+        # threshold: 0.0 so the under-fill is driven purely by the anti-join (the dense
+        # hub's whole nearest pool is already-linked), not the similarity floor — the
+        # cleanest demonstration that filters exhausting a FULL pool fire the signal.
+        {:ok, suggestions, meta} =
+          Knowledge.suggest_links_with_meta(tenant.id, target.id,
+            limit: 5,
+            threshold: 0.0
+          )
+
+        assert length(suggestions) < 5,
+               "expected a dense hub to under-fill (returned #{length(suggestions)} of 5)"
+
+        assert meta.recall_truncated == true
+        assert meta.pool_exhausted == true
+
+        assert_received {:under_fill, measurements, metadata}
+        assert measurements.requested == 5
+        assert measurements.returned < 5
+        # Pool was filled to the configured cap at prod scale.
+        assert measurements.pool == VectorSearch.pool_size(5)
+        assert measurements.available >= measurements.pool
+        assert metadata.tenant_id == tenant.id
+        assert metadata.endpoint == :suggested_links
+
+        # No content leak in the payload (AC-27.6b.5).
+        flat = inspect({measurements, metadata})
+        refute flat =~ "::vector"
+        refute flat =~ "embedding"
+      after
+        :telemetry.detach(handler_id)
+      end
+    end)
+  end
+
+  test "ef_search is identical on the scale-gate connection and a prod-shaped connection (AC-27.6b.4)" do
+    # Read the EFFECTIVE value via `SHOW` on each connection (NOT a :parameters config
+    # compare). Touch a vector op first so pgvector's custom GUC is registered for the
+    # session, then read it. ef_search is never SET today, so both must report the
+    # pgvector default — pinned so a future prod ALTER ROLE can't diverge from the gate.
+    gate_ef =
+      unboxed(fn ->
+        AdminRepo.query!("SELECT '[1,2,3]'::vector")
+        %{rows: [[v]]} = AdminRepo.query!("SHOW hnsw.ef_search")
+        v
+      end)
+
+    prod_ef =
+      Sandbox.unboxed_run(HeavyReadRepo, fn ->
+        HeavyReadRepo.query!("SELECT '[1,2,3]'::vector")
+        %{rows: [[v]]} = HeavyReadRepo.query!("SHOW hnsw.ef_search")
+        v
+      end)
+
+    assert gate_ef == prod_ef,
+           "ef_search diverged: gate=#{inspect(gate_ef)} prod=#{inspect(prod_ef)} " <>
+             "(SHOW hnsw.ef_search must match between the scale gate and the prod-shaped pool)"
+
+    # And it is the pgvector default (40) until US-27.11's ALTER ROLE lever is applied.
+    assert gate_ef == "40"
+  end
+end

--- a/test/loopctl/knowledge/vector_search_under_fill_scale_test.exs
+++ b/test/loopctl/knowledge/vector_search_under_fill_scale_test.exs
@@ -163,9 +163,20 @@ defmodule Loopctl.Knowledge.VectorSearchUnderFillScaleTest do
         assert_received {:under_fill, measurements, metadata}
         assert measurements.requested == 5
         assert measurements.returned < 5
-        # Pool was filled to the configured cap at prod scale.
         assert measurements.pool == VectorSearch.pool_size(5)
-        assert measurements.available >= measurements.pool
+        # The ANN delivered candidates (bounded by ef_search ~40, so typically < pool —
+        # which is exactly why the old `>= pool` pool-full gate was degenerate and is gone).
+        assert measurements.ann_candidates > 0
+        # Near neighbors genuinely EXIST among what the ANN surfaced (threshold 0.0 → the
+        # nearest are all above the bar) but the anti-join hid them — this is what separates
+        # a real recall incident from a sparse region whose pool is below threshold, and it
+        # holds REGARDLESS of ef_search (the bug prod-scale verification caught).
+        assert measurements.above_threshold > measurements.returned
+
+        assert measurements.excluded_by_link ==
+                 measurements.above_threshold - measurements.returned
+
+        assert measurements.excluded_by_link >= 1
         assert metadata.tenant_id == tenant.id
         assert metadata.endpoint == :suggested_links
 

--- a/test/loopctl/knowledge/vector_search_under_fill_scale_test.exs
+++ b/test/loopctl/knowledge/vector_search_under_fill_scale_test.exs
@@ -184,6 +184,21 @@ defmodule Loopctl.Knowledge.VectorSearchUnderFillScaleTest do
     # compare). Touch a vector op first so pgvector's custom GUC is registered for the
     # session, then read it. ef_search is never SET today, so both must report the
     # pgvector default — pinned so a future prod ALTER ROLE can't diverge from the gate.
+    #
+    # SHARED-ROLE ASSUMPTION (the one scenario this guard could go silently green while
+    # prod diverges — document it so a future reader knows when to revisit):
+    #   (a) The `gate == prod` parity check assumes AdminRepo and HeavyReadRepo connect
+    #       as ONE Postgres role (true in prod today — both use admin_database_url's
+    #       BYPASSRLS role). `hnsw.ef_search` is set per-ROLE via `ALTER ROLE … SET`
+    #       (US-27.11), so a single ALTER ROLE moves BOTH pools together → parity holds
+    #       by construction even after an override.
+    #   (b) IF those repos are ever split onto DIFFERENT Postgres roles, an ALTER ROLE on
+    #       one role would NOT move the other, and THIS test is the only thing that would
+    #       catch the silent gate-vs-prod divergence — so it MUST be revisited then
+    #       (read ef_search on each role explicitly, not assume one ALTER ROLE covers both).
+    #   (c) The `== "40"` pin below is a deliberate tripwire for "still pgvector default".
+    #       When US-27.11 lands a non-default `ALTER ROLE … SET hnsw.ef_search = N`, this
+    #       pin MUST be updated to the new value (and (a)'s shared-role reasoning re-checked).
     gate_ef =
       unboxed(fn ->
         AdminRepo.query!("SELECT '[1,2,3]'::vector")

--- a/test/loopctl/knowledge/vector_search_under_fill_test.exs
+++ b/test/loopctl/knowledge/vector_search_under_fill_test.exs
@@ -1,0 +1,288 @@
+defmodule Loopctl.Knowledge.VectorSearchUnderFillTest do
+  @moduledoc """
+  US-27.6b: the observable (non-silent) under-fill signal for the `suggested_links`
+  vector read (TC-27.6b.2 / TC-27.6b.3, AC-27.6b.2/.5/.6).
+
+  The crux distinction this proves:
+
+    * **under_fill**  — the nearest pool was FILLED to cap but the post-ANN filters
+      (already-linked anti-join / threshold) cut the result below `limit`. A
+      `[:loopctl, :knowledge, :vector_search, :under_fill]` event fires AND
+      `meta.recall_truncated` is true (TC-27.6b.2).
+    * **NOT under_fill** — the corpus simply has plenty of unlinked above-threshold
+      neighbors and the full `limit` is returned: NO event, `meta.recall_truncated`
+      false (TC-27.6b.3). And the genuinely-small-corpus case (returned < limit but
+      the pool was NEVER full) is also NOT under_fill.
+
+  The async suite shrinks the over-fetch pool to 6 (config/test.exs) so the pool can
+  be deterministically FILLED with a handful of seeded rows — no 100-row corpus and
+  no `Application.put_env` in a test body. The dense-hub assertion is ALSO proven at
+  prod scale in `vector_search_under_fill_scale_test.exs` (`:scale_nightly`).
+  """
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.Knowledge
+  alias Loopctl.Knowledge.VectorSearch
+  alias Loopctl.TelemetryEvents
+
+  @dims 1536
+
+  # A sparse-prefix embedding (rest zero-filled). Cosine is magnitude-independent, so
+  # e([1.0]) vs e([1.0]) = 1.0 (identical direction) — every candidate here is a near
+  # neighbor of the target, which is exactly what makes the anti-join the only thing
+  # that can cut the result (isolating the under-fill condition).
+  defp e(prefix), do: prefix ++ List.duplicate(0.0, @dims - length(prefix))
+
+  defp embedded(tenant_id, title, prefix) do
+    a = fixture(:article, %{tenant_id: tenant_id, title: title, status: :published})
+    {:ok, _} = Knowledge.update_embedding(tenant_id, a.id, e(prefix))
+    a
+  end
+
+  defp link!(tenant_id, source_id, target_id) do
+    fixture(:article_link, %{
+      tenant_id: tenant_id,
+      source_article_id: source_id,
+      target_article_id: target_id,
+      relationship_type: :relates_to
+    })
+  end
+
+  # Attach a telemetry handler that forwards under_fill events to `self()`, with
+  # guaranteed detach (try/after). The handler is process-GLOBAL, so we scope it to
+  # events emitted from THIS test process (`self()` inside a telemetry handler is the
+  # emitting process, and our `suggest_links_with_meta/3` call runs synchronously in
+  # the test process) — otherwise a concurrent async test's under_fill could leak a
+  # false event into our mailbox and break `refute_received`.
+  defp with_under_fill_handler(fun) do
+    test_pid = self()
+    handler_id = "under-fill-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach(
+      handler_id,
+      TelemetryEvents.vector_search_under_fill(),
+      fn event, measurements, metadata, _ ->
+        if self() == test_pid do
+          send(test_pid, {:under_fill, event, measurements, metadata})
+        end
+      end,
+      nil
+    )
+
+    try do
+      fun.()
+    after
+      :telemetry.detach(handler_id)
+    end
+  end
+
+  describe "under-fill emits a telemetry signal + meta flag (TC-27.6b.2, AC-27.6b.2/.6)" do
+    test "dense hub: nearest pool full but all near neighbors already-linked → signal fires" do
+      tenant = fixture(:tenant)
+      target = embedded(tenant.id, "Hub", [1.0, 0.0])
+
+      # Fill the (test) 6-row pool: 6 near-identical neighbors so the inner ANN returns
+      # a FULL pool. Pre-link ALL of them so the anti-join cuts the result below limit=5.
+      neighbors = for i <- 1..6, do: embedded(tenant.id, "N#{i}", [1.0, 0.0])
+      for n <- neighbors, do: link!(tenant.id, target.id, n.id)
+
+      # Sanity: the pool is exactly the count we filled (so available >= pool holds).
+      assert VectorSearch.pool_size(5) == 6
+
+      {result, meta} =
+        with_under_fill_handler(fn ->
+          {:ok, suggestions, meta} =
+            Knowledge.suggest_links_with_meta(tenant.id, target.id, limit: 5, threshold: 0.5)
+
+          {suggestions, meta}
+        end)
+
+      # Fewer than the requested 5 (the anti-join exhausted the full pool).
+      assert length(result) < 5
+
+      # The structured signal fired exactly once, with id-only, non-content payload.
+      assert_received {:under_fill, event, measurements, metadata}
+      assert event == [:loopctl, :knowledge, :vector_search, :under_fill]
+      assert measurements.requested == 5
+      assert measurements.returned == length(result)
+      assert measurements.returned < 5
+      assert measurements.pool == 6
+      assert measurements.available >= measurements.pool
+      assert metadata.tenant_id == tenant.id
+      assert metadata.endpoint == :suggested_links
+      assert metadata.excluded_by_filters >= 1
+
+      # Exactly ONE event (AC-27.6b.5: one per request, not per filtered candidate).
+      refute_received {:under_fill, _, _, _}
+
+      # No content leaks in the payload (AC-27.6b.5): no vector literals, no bodies.
+      flat = inspect({measurements, metadata})
+      refute flat =~ "1.0"
+      refute flat =~ "embedding"
+      refute flat =~ "::vector"
+
+      # Consumer-facing meta carries the recall-truncated flag (AC-27.6b.6).
+      assert meta.recall_truncated == true
+      assert meta.pool_exhausted == true
+      assert meta.requested == 5
+      assert meta.returned == length(result)
+    end
+  end
+
+  describe "a full result emits NO under-fill signal (TC-27.6b.3)" do
+    test "plenty of unlinked above-threshold neighbors → k returned, no event, meta false" do
+      tenant = fixture(:tenant)
+      target = embedded(tenant.id, "Target", [1.0, 0.0])
+
+      # 6 unlinked near-identical neighbors → the full limit of 5 is returned.
+      for i <- 1..6, do: embedded(tenant.id, "Free#{i}", [1.0, 0.0])
+
+      {result, meta} =
+        with_under_fill_handler(fn ->
+          {:ok, suggestions, meta} =
+            Knowledge.suggest_links_with_meta(tenant.id, target.id, limit: 5, threshold: 0.5)
+
+          {suggestions, meta}
+        end)
+
+      assert length(result) == 5
+      refute_received {:under_fill, _, _, _}
+      assert meta.recall_truncated == false
+      assert meta.pool_exhausted == false
+      assert meta.returned == 5
+    end
+  end
+
+  describe "a genuinely-small corpus is NOT under-fill (AC-27.6b.2 — the key distinction)" do
+    test "returned < limit but the pool was NEVER full → no event, meta false" do
+      tenant = fixture(:tenant)
+      target = embedded(tenant.id, "Target", [1.0, 0.0])
+
+      # Only 2 eligible neighbors exist corpus-wide — fewer than the 6-row pool. This
+      # returns < limit (5) but it is a genuinely-empty-ish corpus, NOT a recall
+      # incident: the pool was never filled, so NO signal must fire.
+      _c1 = embedded(tenant.id, "C1", [1.0, 0.0])
+      _c2 = embedded(tenant.id, "C2", [1.0, 0.0])
+
+      {result, meta} =
+        with_under_fill_handler(fn ->
+          {:ok, suggestions, meta} =
+            Knowledge.suggest_links_with_meta(tenant.id, target.id, limit: 5, threshold: 0.5)
+
+          {suggestions, meta}
+        end)
+
+      assert length(result) == 2
+      assert length(result) < 5
+
+      # Crucially: NO under_fill event despite returned < limit (available < pool).
+      refute_received {:under_fill, _, _, _}
+      assert meta.recall_truncated == false
+      assert meta.pool_exhausted == false
+    end
+
+    test "no-embedding target → empty result is NOT under-fill" do
+      tenant = fixture(:tenant)
+
+      target =
+        fixture(:article, %{tenant_id: tenant.id, title: "No Embedding", status: :published})
+
+      {result, meta} =
+        with_under_fill_handler(fn ->
+          {:ok, suggestions, meta} =
+            Knowledge.suggest_links_with_meta(tenant.id, target.id, limit: 5)
+
+          {suggestions, meta}
+        end)
+
+      assert result == []
+      refute_received {:under_fill, _, _, _}
+      assert meta.recall_truncated == false
+    end
+  end
+
+  describe "the under-fill probe is a single bounded extra read, gated on the truncated path (AC-27.6b.5)" do
+    test "a FULL result issues NO available-count probe; the truncated path adds exactly one" do
+      # When returned >= limit there is nothing to detect, so the bounded `count(*)` probe
+      # must not run at all. We isolate the probe by counting ONLY the count-aggregate
+      # query (its source is the `articles` candidate subquery; the `SELECT count(...)`
+      # SQL is the discriminator) — not raw repo events, which carry sandbox noise. Two
+      # ISOLATED tenants so each hub's pool contains only its own neighbors.
+      t_full = fixture(:tenant)
+      target = embedded(t_full.id, "Target", [1.0, 0.0])
+      for i <- 1..6, do: embedded(t_full.id, "Free#{i}", [1.0, 0.0])
+
+      full_probes =
+        count_probe_queries(fn ->
+          {:ok, r, _m} = Knowledge.suggest_links_with_meta(t_full.id, target.id, limit: 5)
+          assert length(r) == 5
+        end)
+
+      # A separate tenant whose hub has ONLY already-linked neighbors → probe DOES run.
+      t_hub = fixture(:tenant)
+      hub = embedded(t_hub.id, "Hub", [1.0, 0.0])
+      linked = for i <- 1..6, do: embedded(t_hub.id, "L#{i}", [1.0, 0.0])
+      for n <- linked, do: link!(t_hub.id, hub.id, n.id)
+
+      under_probes =
+        count_probe_queries(fn ->
+          with_under_fill_handler(fn ->
+            {:ok, r, _m} = Knowledge.suggest_links_with_meta(t_hub.id, hub.id, limit: 5)
+            assert length(r) < 5
+          end)
+        end)
+
+      # The hot (full) path runs ZERO probes; the truncated path runs EXACTLY ONE — a
+      # single bounded extra read, never per-candidate.
+      assert full_probes == 0, "full-result path must issue no count probe (got #{full_probes})"
+
+      assert under_probes == 1,
+             "truncated path must issue exactly one count probe (got #{under_probes})"
+    end
+  end
+
+  # Count ONLY the under-fill `available_candidate_count` probe queries during `fun`.
+  # The probe is the lone `SELECT count(...)` over the candidate subquery on the heavy
+  # pool (AdminRepo in test); we discriminate by the decoded SQL. CRITICAL for an async
+  # suite: the telemetry handler is process-GLOBAL, so we ALSO scope to queries issued
+  # from THIS test process — the handler runs synchronously in the emitting process, so
+  # `self()` inside it is the query-issuing process. Without this, a concurrent test's
+  # `count(... articles ...)` query would leak into the count and make this flaky.
+  defp count_probe_queries(fun) do
+    test_pid = self()
+    ref = make_ref()
+    handler_id = "probe-count-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach(
+      handler_id,
+      [:loopctl, :admin_repo, :query],
+      fn _e, _m, meta, _ ->
+        sql = to_string(meta[:query] || "")
+
+        if self() == test_pid and sql =~ ~r/SELECT count\(/i and sql =~ ~r/FROM\b/i and
+             sql =~ "articles" do
+          send(test_pid, {ref, :probe})
+        end
+      end,
+      nil
+    )
+
+    try do
+      fun.()
+    after
+      :telemetry.detach(handler_id)
+    end
+
+    drain(ref, 0)
+  end
+
+  defp drain(ref, acc) do
+    receive do
+      {^ref, :probe} -> drain(ref, acc + 1)
+    after
+      0 -> acc
+    end
+  end
+end

--- a/test/loopctl/knowledge/vector_search_under_fill_test.exs
+++ b/test/loopctl/knowledge/vector_search_under_fill_test.exs
@@ -110,9 +110,12 @@ defmodule Loopctl.Knowledge.VectorSearchUnderFillTest do
       assert measurements.returned < 5
       assert measurements.pool == 6
       assert measurements.available >= measurements.pool
+      # excluded_total is the COMBINED post-ANN exclusion count (anti-join + threshold),
+      # a measurement (numeric), NOT a per-reason split (deferred to US-27.15).
+      assert measurements.excluded_total == measurements.pool - measurements.returned
+      assert measurements.excluded_total >= 1
       assert metadata.tenant_id == tenant.id
       assert metadata.endpoint == :suggested_links
-      assert metadata.excluded_by_filters >= 1
 
       # Exactly ONE event (AC-27.6b.5: one per request, not per filtered candidate).
       refute_received {:under_fill, _, _, _}

--- a/test/loopctl/knowledge/vector_search_under_fill_test.exs
+++ b/test/loopctl/knowledge/vector_search_under_fill_test.exs
@@ -5,14 +5,20 @@ defmodule Loopctl.Knowledge.VectorSearchUnderFillTest do
 
   The crux distinction this proves:
 
-    * **under_fill**  — the nearest pool was FILLED to cap but the post-ANN filters
-      (already-linked anti-join / threshold) cut the result below `limit`. A
+    * **under_fill**  — above-threshold (near) neighbors the ANN surfaced were hidden by
+      the already-linked anti-join (`returned < limit AND above_threshold > returned`). A
       `[:loopctl, :knowledge, :vector_search, :under_fill]` event fires AND
-      `meta.recall_truncated` is true (TC-27.6b.2).
-    * **NOT under_fill** — the corpus simply has plenty of unlinked above-threshold
-      neighbors and the full `limit` is returned: NO event, `meta.recall_truncated`
-      false (TC-27.6b.3). And the genuinely-small-corpus case (returned < limit but
-      the pool was NEVER full) is also NOT under_fill.
+      `meta.recall_truncated` is true (TC-27.6b.2). The detector is ef_search-independent
+      — it compares counts over the set the ANN actually delivered, never a degenerate
+      `ann_candidates >= pool` gate (the bug prod-scale verification caught).
+    * **NOT under_fill** — three distinct non-incidents, none of which fire:
+        - a full result (plenty of unlinked above-threshold neighbors, full `limit`
+          returned) — TC-27.6b.3;
+        - a genuinely-small corpus (returned < limit but every above-threshold neighbor
+          the ANN surfaced WAS returned, `above_threshold == returned`);
+        - a **sparse region** (the ANN pool IS surfaced, but every neighbor is below the
+          similarity threshold, `above_threshold == returned == 0`) — correct
+          emptiness, NOT recall loss (AC-27.6b.6; adversarial F1 regression).
 
   The async suite shrinks the over-fetch pool to 6 (config/test.exs) so the pool can
   be deterministically FILLED with a handful of seeded rows — no 100-row corpus and
@@ -88,7 +94,7 @@ defmodule Loopctl.Knowledge.VectorSearchUnderFillTest do
       neighbors = for i <- 1..6, do: embedded(tenant.id, "N#{i}", [1.0, 0.0])
       for n <- neighbors, do: link!(tenant.id, target.id, n.id)
 
-      # Sanity: the pool is exactly the count we filled (so available >= pool holds).
+      # Sanity: the pool is exactly the count we filled (the ANN surfaces all 6).
       assert VectorSearch.pool_size(5) == 6
 
       {result, meta} =
@@ -109,11 +115,17 @@ defmodule Loopctl.Knowledge.VectorSearchUnderFillTest do
       assert measurements.returned == length(result)
       assert measurements.returned < 5
       assert measurements.pool == 6
-      assert measurements.available >= measurements.pool
-      # excluded_total is the COMBINED post-ANN exclusion count (anti-join + threshold),
-      # a measurement (numeric), NOT a per-reason split (deferred to US-27.15).
-      assert measurements.excluded_total == measurements.pool - measurements.returned
-      assert measurements.excluded_total >= 1
+      # ann_candidates = how many the ANN delivered (here the whole 6-row pool, since
+      # pool 6 < ef_search ~40) — a recall-breadth diagnostic, NOT a pool-full gate.
+      assert measurements.ann_candidates == 6
+      # above_threshold = the near neighbors that exist: all 6 are similarity 1.0 (> the
+      # 0.5 threshold), so they cleared the bar but were hidden by the anti-join — this is
+      # what separates real recall loss from a sparse region.
+      assert measurements.above_threshold == 6
+      # excluded_by_link = above_threshold - returned: the un-conflated count of
+      # above-threshold neighbors the already-linked anti-join removed.
+      assert measurements.excluded_by_link == measurements.above_threshold - measurements.returned
+      assert measurements.excluded_by_link >= 1
       assert metadata.tenant_id == tenant.id
       assert metadata.endpoint == :suggested_links
 
@@ -159,13 +171,14 @@ defmodule Loopctl.Knowledge.VectorSearchUnderFillTest do
   end
 
   describe "a genuinely-small corpus is NOT under-fill (AC-27.6b.2 — the key distinction)" do
-    test "returned < limit but the pool was NEVER full → no event, meta false" do
+    test "returned < limit but no above-threshold neighbor was hidden → no event, meta false" do
       tenant = fixture(:tenant)
       target = embedded(tenant.id, "Target", [1.0, 0.0])
 
-      # Only 2 eligible neighbors exist corpus-wide — fewer than the 6-row pool. This
-      # returns < limit (5) but it is a genuinely-empty-ish corpus, NOT a recall
-      # incident: the pool was never filled, so NO signal must fire.
+      # Only 2 eligible neighbors exist corpus-wide, BOTH unlinked + above threshold. This
+      # returns < limit (5), but it is NOT a recall incident: every above-threshold
+      # neighbor the ANN surfaced WAS returned (`above_threshold == returned == 2`), so the
+      # anti-join hid nothing — NO signal must fire.
       _c1 = embedded(tenant.id, "C1", [1.0, 0.0])
       _c2 = embedded(tenant.id, "C2", [1.0, 0.0])
 
@@ -180,7 +193,7 @@ defmodule Loopctl.Knowledge.VectorSearchUnderFillTest do
       assert length(result) == 2
       assert length(result) < 5
 
-      # Crucially: NO under_fill event despite returned < limit (available < pool).
+      # Crucially: NO under_fill event despite returned < limit (above_threshold == returned).
       refute_received {:under_fill, _, _, _}
       assert meta.recall_truncated == false
       assert meta.pool_exhausted == false
@@ -206,8 +219,41 @@ defmodule Loopctl.Knowledge.VectorSearchUnderFillTest do
     end
   end
 
+  describe "a sparse region is NOT under-fill (adversarial F1 regression, AC-27.6b.6)" do
+    test "pool FULL but every neighbor is below threshold → genuinely empty, no event, meta false" do
+      tenant = fixture(:tenant)
+
+      # Target points along axis 1; all neighbors point along an ORTHOGONAL axis, so
+      # cosine similarity = 0 (< the 0.5 threshold). The ANN STILL surfaces all 6 neighbors
+      # (ann_candidates = 6), but NONE clear the relevance bar — this is correct emptiness,
+      # not recall loss. The original `available >= pool`-only rule fired here FALSELY
+      # (crying wolf on every thin-corpus article, contradicting AC-27.6b.6's
+      # "distinguish an incomplete result from a genuinely-empty one"); the threshold-aware
+      # probe (`above_threshold == returned == 0`) must NOT fire.
+      target = embedded(tenant.id, "Target", [1.0, 0.0])
+      for i <- 1..6, do: embedded(tenant.id, "Orthogonal#{i}", [0.0, 1.0])
+
+      {result, meta} =
+        with_under_fill_handler(fn ->
+          {:ok, suggestions, meta} =
+            Knowledge.suggest_links_with_meta(tenant.id, target.id, limit: 5, threshold: 0.5)
+
+          {suggestions, meta}
+        end)
+
+      # Nothing clears the bar → empty result, even though the pool was full.
+      assert result == []
+
+      # Crucially: NO under_fill event despite returned (0) < limit (5) AND a FULL pool —
+      # because above_threshold == 0, no near neighbors were hidden by the anti-join.
+      refute_received {:under_fill, _, _, _}
+      assert meta.recall_truncated == false
+      assert meta.pool_exhausted == false
+    end
+  end
+
   describe "the under-fill probe is a single bounded extra read, gated on the truncated path (AC-27.6b.5)" do
-    test "a FULL result issues NO available-count probe; the truncated path adds exactly one" do
+    test "a FULL result issues NO under-fill probe; the truncated path adds exactly one" do
       # When returned >= limit there is nothing to detect, so the bounded `count(*)` probe
       # must not run at all. We isolate the probe by counting ONLY the count-aggregate
       # query (its source is the `articles` candidate subquery; the `SELECT count(...)`
@@ -246,7 +292,7 @@ defmodule Loopctl.Knowledge.VectorSearchUnderFillTest do
     end
   end
 
-  # Count ONLY the under-fill `available_candidate_count` probe queries during `fun`.
+  # Count ONLY the under-fill `under_fill_probe` queries during `fun`.
   # The probe is the lone `SELECT count(...)` over the candidate subquery on the heavy
   # pool (AdminRepo in test); we discriminate by the decoded SQL. CRITICAL for an async
   # suite: the telemetry handler is process-GLOBAL, so we ALSO scope to queries issued

--- a/test/loopctl_web/controllers/knowledge_suggest_links_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_suggest_links_controller_test.exs
@@ -244,6 +244,60 @@ defmodule LoopctlWeb.KnowledgeSuggestLinksControllerTest do
       assert after_count == 0
     end
 
+    # US-27.6b AC-27.6b.6: the response carries a `meta` recall-completeness block so
+    # an agent can tell an INCOMPLETE result (densely-linked hub) from an empty one.
+    test "response meta carries recall_truncated=true for a densely-linked hub", %{conn: conn} do
+      {tenant, key} = setup_tenant_key()
+      hub = embedded(tenant.id, "Hub", [1.0, 0.0])
+      # Fill the test 6-row pool with 6 near neighbors, all already-linked → the
+      # anti-join exhausts the full pool below the default limit of 5.
+      neighbors = for i <- 1..6, do: embedded(tenant.id, "N#{i}", [1.0, 0.0])
+
+      for n <- neighbors do
+        fixture(:article_link, %{
+          tenant_id: tenant.id,
+          source_article_id: hub.id,
+          target_article_id: n.id,
+          relationship_type: :relates_to
+        })
+      end
+
+      body = suggest(conn, key, hub.id)
+
+      assert length(body["data"]) < 5
+      assert body["meta"]["recall_truncated"] == true
+      assert body["meta"]["pool_exhausted"] == true
+      assert body["meta"]["requested"] == 5
+      assert body["meta"]["returned"] == length(body["data"])
+    end
+
+    test "response meta carries recall_truncated=false for a full result", %{conn: conn} do
+      {tenant, key} = setup_tenant_key()
+      target = embedded(tenant.id, "Target", [1.0, 0.0])
+      for i <- 1..6, do: embedded(tenant.id, "Free#{i}", [1.0, 0.0])
+
+      body = suggest(conn, key, target.id, %{limit: 5})
+
+      assert length(body["data"]) == 5
+      assert body["meta"]["recall_truncated"] == false
+      assert body["meta"]["pool_exhausted"] == false
+      assert body["meta"]["returned"] == 5
+    end
+
+    test "response meta is recall_truncated=false for a genuinely-empty result (not under-fill)",
+         %{conn: conn} do
+      {tenant, key} = setup_tenant_key()
+      # No embedding → empty result; this is NOT a recall incident.
+      target =
+        fixture(:article, %{tenant_id: tenant.id, title: "No Embedding", status: :published})
+
+      body = suggest(conn, key, target.id)
+
+      assert body["data"] == []
+      assert body["meta"]["recall_truncated"] == false
+      assert body["meta"]["pool_exhausted"] == false
+    end
+
     test "honors limit and threshold", %{conn: conn} do
       {tenant, key} = setup_tenant_key()
       target = embedded(tenant.id, "Target", [1.0])
@@ -354,7 +408,7 @@ defmodule LoopctlWeb.KnowledgeSuggestLinksControllerTest do
       {tenant, key} = setup_tenant_key()
       target = embedded(tenant.id, "Target", [1.0, 0.0])
 
-      expect(Loopctl.MockSuggestLinks, :suggest_links, fn _tenant, _article, _opts ->
+      expect(Loopctl.MockSuggestLinks, :suggest_links_with_meta, fn _tenant, _article, _opts ->
         raise statement_timeout_error()
       end)
 
@@ -409,7 +463,7 @@ defmodule LoopctlWeb.KnowledgeSuggestLinksControllerTest do
       {tenant, key} = setup_tenant_key()
       target = embedded(tenant.id, "Target", [1.0, 0.0])
 
-      expect(Loopctl.MockSuggestLinks, :suggest_links, fn _t, _a, _o ->
+      expect(Loopctl.MockSuggestLinks, :suggest_links_with_meta, fn _t, _a, _o ->
         raise %Postgrex.Error{
           postgres: %{
             code: :undefined_table,
@@ -444,7 +498,7 @@ defmodule LoopctlWeb.KnowledgeSuggestLinksControllerTest do
       {tenant, key} = setup_tenant_key()
       target = embedded(tenant.id, "Target", [1.0, 0.0])
 
-      expect(Loopctl.MockSuggestLinks, :suggest_links, fn _t, _a, _o ->
+      expect(Loopctl.MockSuggestLinks, :suggest_links_with_meta, fn _t, _a, _o ->
         raise %Postgrex.Error{
           postgres: %{
             code: :serialization_failure,
@@ -477,7 +531,7 @@ defmodule LoopctlWeb.KnowledgeSuggestLinksControllerTest do
       {tenant, key} = setup_tenant_key()
       target = embedded(tenant.id, "Target", [1.0, 0.0])
 
-      expect(Loopctl.MockSuggestLinks, :suggest_links, fn _t, _a, _o ->
+      expect(Loopctl.MockSuggestLinks, :suggest_links_with_meta, fn _t, _a, _o ->
         raise %DBConnection.ConnectionError{message: "tcp closed"}
       end)
 
@@ -538,7 +592,7 @@ defmodule LoopctlWeb.KnowledgeSuggestLinksControllerTest do
       # The DI seam runs the REAL override→timeout path: a tight 50ms SET LOCAL
       # statement_timeout on a deliberately slow, tenant-scoped query → genuine
       # query_canceled (57014), bounded near 50ms (never the full 1s sleep).
-      expect(Loopctl.MockSuggestLinks, :suggest_links, fn t, _a, _o ->
+      expect(Loopctl.MockSuggestLinks, :suggest_links_with_meta, fn t, _a, _o ->
         slow =
           from(a in Loopctl.Knowledge.Article,
             where: a.tenant_id == ^t,

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -167,6 +167,13 @@ defmodule Loopctl.DataCase do
       Loopctl.Knowledge.suggest_links(tenant_id, article_id, opts)
     end)
 
+    # US-27.6b: the controller calls the meta-bearing variant. Default stub
+    # delegates to the real context so the endpoint exercises the genuine
+    # under-fill detection unless a test overrides it with Mox.expect/3.
+    Mox.stub(Loopctl.MockSuggestLinks, :suggest_links_with_meta, fn tenant_id, article_id, opts ->
+      Loopctl.Knowledge.suggest_links_with_meta(tenant_id, article_id, opts)
+    end)
+
     # US-27.3: the DBErrorBackstop test seam (Loopctl.Test.BackstopRouter) is a
     # REAL plug wired via config/test.exs that delegates to LoopctlWeb.Router for
     # every request and only raises when an opt-in `x-test-raise-db-error` header


### PR DESCRIPTION
## US-27.6b — kNN over-fetch/recall tuning + observable (non-silent) under-fill signal

Converts the vector layer's **silent** recall incompleteness into an observable, alertable
event, building on US-27.6a. The epic exists because a real failure (a densely-linked hub
returning `[]` while near neighbors exist) was indistinguishable from "no neighbors exist"
— a fast-green-but-wrong result the latency/plan gates can't catch.

### What changed

- **Config-driven over-fetch pool** (AC-27.6b.1): `pool = k*factor |> max(floor) |> min(cap)
  |> max(k)` via `:vector_pool_factor` / `:vector_pool_floor` / `:max_vector_pool`. The final
  `max(k)` guarantees a misconfigured cap can never drop the pool below the requested `k`.
  Shared `VectorSearch.pool_size/2` so the helper and the live `suggested_links` path can't
  size differently.

- **Observable under-fill signal** (AC-27.6b.2/.5/.6): when above-threshold (near) neighbors
  the ANN surfaced are hidden by the already-linked anti-join, `suggest_links_with_meta/3`
  emits ONE `[:loopctl, :knowledge, :vector_search, :under_fill]` telemetry event (+ warn log)
  per request — id-only payload `%{requested, returned, pool, ann_candidates, above_threshold,
  excluded_by_link}` + `%{tenant_id, endpoint}`, no vectors/bodies — and the response `meta`
  carries `recall_truncated`/`pool_exhausted` so an agent distinguishes an incomplete result
  from a genuinely-empty one.

  **Detector** (`returned < limit AND above_threshold > returned`): `above_threshold` counts
  how many ANN-delivered candidates clear the similarity bar; because the signal only fires
  when the LIMIT didn't bind, `excluded_by_link = above_threshold - returned` is the
  un-conflated count of above-threshold neighbors the anti-join hid. The detector is
  **ef_search-independent** — it compares counts over the set the ANN actually delivered, so
  it does NOT falsely fire on a sparse region whose whole pool is below threshold (correct
  emptiness, not recall loss). One bounded ANN-class probe over the SAME inner subquery the
  main query draws from, issued ONLY on the truncated path (zero added cost on the common
  full-result path) and fail-soft on a probe-only DB fault.

- **ef_search recall ceiling documented + pinned** (AC-27.6b.3/.4): the pgvector default (~40)
  cannot be set via Postgrex `:parameters`; the only safe non-transaction lever is `ALTER ROLE
  … SET hnsw.ef_search` (US-27.11). A scale test asserts `SHOW hnsw.ef_search` parity between
  the gate and a prod-shaped connection. Re-verified US-27.6a's worst-case cost bound against
  the config-driven cap (AC-27.6b.7).

### Enhanced review — fully addressed (both rounds, zero deferrals)

- **R1 (team — `fbca4b8`)**: `excluded_*` moved to a numeric measurement; ef_search shared-role
  comment.
- **R2 (adversarial — `e87490c`)**: the architect found that the original `available`-based
  signal **cried wolf on every sparse article** (fired `recall_truncated: true` on a
  genuinely-empty result — the opposite of AC-27.6b.6). Re-derived the threshold-aware,
  ef_search-independent detector above (resolves architect F1/F3 + security AREA-7, kills the
  US-27.15 per-reason-split deferral). Made the advisory probe **fail-soft** (security AREA-5),
  corrected the `db_capacity` "one-shot" budget note (architect F2), and fixed a stale runbook
  key (engineer F1). **Prod-scale verification caught a real bug in the fix's first cut** — an
  `ann_candidates >= pool` gate is degenerate under HNSW (the ANN delivers ~ef_search < pool),
  silently suppressing the signal at 80k; dropped it. The redundant-flag finding (F4) was
  disproved: AC-27.6b.6 names `recall_truncated`/`pool_exhausted` as alternative names for one
  flag.

### Verification

- `mix precommit` green (2882 tests, 23 scale excluded) on a clean DB.
- `vector_search_under_fill_test.exs` (6 tests, incl. the sparse-region regression) green.
- `vector_search_under_fill_scale_test.exs` green at a **fresh 80k-row corpus** (the dense-hub
  fires; ef_search parity holds) — the gate that caught the degenerate-pool-full bug.

Closes US-27.6b.
