### PR TITLE
US-27.7a: route single-target top-k vector endpoints through the kNN helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,6 +319,7 @@ jobs:
           - test/loopctl/knowledge/scale_seed_nightly_test.exs
           - test/loopctl/knowledge/vector_search_scale_test.exs
           - test/loopctl/knowledge/vector_search_under_fill_scale_test.exs
+          - test/loopctl/knowledge/topk_endpoints_scale_test.exs
           - test/loopctl/knowledge/plan_assertions_scale_test.exs
           - test/loopctl/knowledge/keyset_plan_scale_test.exs
           - test/loopctl/knowledge/by_source_change_feed_plan_scale_test.exs

--- a/config/test.exs
+++ b/config/test.exs
@@ -68,6 +68,13 @@ unless System.get_env("SCALE_NIGHTLY") || System.get_env("SCALE_TESTS") do
   config :loopctl, :vector_pool_factor, 5
   config :loopctl, :vector_pool_floor, 6
   config :loopctl, :max_vector_pool, 6
+
+  # US-27.7a `search_semantic` relevance-pool knobs, shrunk so the deep-offset /
+  # `pool_capped` truncation signal is exercisable with a handful of seeded rows (prod
+  # floor/cap are 200/1000). Existing semantic tests seed ≤ cap rows, so they are
+  # unaffected. The SCALE gate keeps the prod defaults. Config-based DI — no put_env.
+  config :loopctl, :semantic_result_pool_floor, 2
+  config :loopctl, :semantic_result_pool_cap, 5
 end
 
 # We don't run a server during test. If one is required,

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -4657,16 +4657,27 @@ defmodule Loopctl.Knowledge do
          # without an embedding are excluded). Use knowledge_stats for the
          # full wiki size.
          total_count_scope: "ranked_corpus",
-         # US-27.7a relevance-pool truncation signal (NOT silent — mirrors the
-         # `recall_truncated` / keyset `next_cursor: null` exhaustion conventions).
-         # Results are drawn from the top-`cap` relevance pool, so when the ranked
-         # corpus is larger than the cap, the tail beyond it is NOT reachable by a
-         # deeper `offset` (a page past the cap returns empty). `pool_capped: true`
-         # tells the consumer "there are more ranked results than relevance
-         # pagination can surface — switch to list mode for full enumeration."
-         pool_capped: total_count > semantic_result_pool_cap()
+         pool_capped: semantic_pool_capped?(total_count, length(results), limit, offset)
        }
      }}
+  end
+
+  # Relevance-pool truncation signal (US-27.7a — NOT silent; mirrors the suggested-links
+  # `recall_truncated` / keyset `next_cursor: null` exhaustion conventions). Results come
+  # from the top-`cap` relevance pool with the selective filters applied POST-ANN, so the
+  # ranked+filtered set may exceed what pagination can reach. Two truncation modes, both
+  # flagged (a `false` therefore means "this query's results are complete"):
+  #
+  #   * CAP truncation — `total_count > cap`: the corpus is larger than the reachable pool
+  #     (true regardless of `offset`, even on a full page).
+  #   * POOL/FILTER starvation — a SHORT page (`returned < limit`) while MORE filtered
+  #     results exist than were surfaced (`offset + returned < total_count`). This catches
+  #     the case a `total_count > cap`-only check MISSED: a selective filter whose matches
+  #     fall outside the top-`pool` nearest starves the page below the cap. (A genuine
+  #     last page — `offset + returned == total_count` — is NOT flagged.)
+  defp semantic_pool_capped?(total_count, returned, limit, offset) do
+    total_count > semantic_result_pool_cap() or
+      (returned < limit and offset + returned < total_count)
   end
 
   # Builds `search_semantic`'s paginated RESULTS query (returned, not executed) — the
@@ -4955,7 +4966,12 @@ defmodule Loopctl.Knowledge do
          # Size of the deduplicated UNION of a keyword and a semantic sub-search
          # (each capped at 100, so up to ~200 with no overlap), NOT a corpus total
          # or full match count. Use list mode or knowledge_stats to size the corpus.
-         total_count_scope: "merged_candidates"
+         total_count_scope: "merged_candidates",
+         # Carry the semantic sub-search's relevance-pool truncation forward (US-27.7a)
+         # — combined is the DEFAULT mode, so silently dropping the flag would hide
+         # truncation on the most-used path. `maybe_put` keeps the key absent unless the
+         # semantic half was actually pool-capped.
+         pool_capped: Map.get(semantic_result.meta, :pool_capped, false)
        }
      }}
   end

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -4656,7 +4656,15 @@ defmodule Loopctl.Knowledge do
          # set — NOT a match count, and <= the total published count (articles
          # without an embedding are excluded). Use knowledge_stats for the
          # full wiki size.
-         total_count_scope: "ranked_corpus"
+         total_count_scope: "ranked_corpus",
+         # US-27.7a relevance-pool truncation signal (NOT silent — mirrors the
+         # `recall_truncated` / keyset `next_cursor: null` exhaustion conventions).
+         # Results are drawn from the top-`cap` relevance pool, so when the ranked
+         # corpus is larger than the cap, the tail beyond it is NOT reachable by a
+         # deeper `offset` (a page past the cap returns empty). `pool_capped: true`
+         # tells the consumer "there are more ranked results than relevance
+         # pagination can surface — switch to list mode for full enumeration."
+         pool_capped: total_count > semantic_result_pool_cap()
        }
      }}
   end
@@ -4763,13 +4771,18 @@ defmodule Loopctl.Knowledge do
         @default_semantic_result_pool_floor
       )
 
-    cap =
-      Application.get_env(:loopctl, :semantic_result_pool_cap, @default_semantic_result_pool_cap)
-
     needed
     |> max(floor)
-    |> min(cap)
+    |> min(semantic_result_pool_cap())
   end
+
+  # The hard reachability ceiling for relevance-search pagination (US-27.7a): results come
+  # from the top-`cap` relevance pool, so a consumer can page through at most `cap` ranked
+  # rows regardless of `offset`. Drives both the results pool's hard cap and the
+  # `meta.pool_capped` truncation signal. Config `:semantic_result_pool_cap`.
+  defp semantic_result_pool_cap,
+    do:
+      Application.get_env(:loopctl, :semantic_result_pool_cap, @default_semantic_result_pool_cap)
 
   @doc """
   Combined keyword + semantic search with configurable weighting.

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -114,6 +114,18 @@ defmodule Loopctl.Knowledge do
   @spec max_relevance_page_size() :: pos_integer()
   def max_relevance_page_size, do: @max_relevance_page_size
 
+  # US-27.7a `search_semantic` relevance-pool sizing. The results path over-fetches the
+  # top-`pool` ANN nearest, then post-filters + paginates within the pool (the inner ANN
+  # is the shared HNSW-index-safe `VectorSearch.candidate_pool_query/4`). The pool covers
+  # `offset + limit` floored/capped: the FLOOR keeps the common shallow page cheap-but-not
+  # under-fetched, the CAP keeps the inner HNSW scan bounded. The cap is well above the
+  # in-contract deepest page (`offset + limit` with `limit ≤ max_relevance_page_size`), so
+  # every valid page is fully served; only an unusually-deep offset beyond it is truncated
+  # (the documented post-ANN-filter recall tradeoff). Overridable via config
+  # `:semantic_result_pool_floor` / `:semantic_result_pool_cap`.
+  @default_semantic_result_pool_floor 200
+  @default_semantic_result_pool_cap 1_000
+
   # Default/maximum number of facet rows (distinct tags) returned by `tag_facets/2`.
   # An omitted `:limit` is bounded by this (not "all"), so a tenant with tens of
   # thousands of distinct tags can't force an unbounded response; `distinct_count`
@@ -3441,74 +3453,41 @@ defmodule Loopctl.Knowledge do
   # Builds the suggested-links candidate query (returned, not executed) so a test can
   # assert its SQL shape. Public-but-`@doc false` for that structural regression guard.
   #
-  # SHAPE IS LOAD-BEARING (verified with EXPLAIN against the ~76k-row prod corpus):
-  # pgvector's HNSW index (cosine) only accelerates a PURE `ORDER BY embedding <=> $const
-  # LIMIT k`. Adding the already-linked anti-join (a JOIN) OR a distance filter
-  # (`... <=> ... > threshold`) to that same query makes the planner abandon the index and
-  # Seq-Scan the entire corpus + Sort — the #172 / #170 production 500 (cost ~57k vs ~880).
-  #
-  # So this is split in two:
-  #   * INNER subquery — the pure top-`pool` nearest by cosine. Only index-safe filters
-  #     here (tenant, status, not-null, not-self, visibility — all verified to keep the
-  #     index). The target is a BOUND `^param` LIST of floats (`to_embedding_list/1`),
-  #     never the stored `%Pgvector{}` struct (that re-interpolation was the #168 500).
-  #   * OUTER query — applies the already-linked anti-join + the `similarity_score >
-  #     threshold` floor + the final `limit`, over just `pool` rows (cheap).
-  #
-  # `pool` over-fetches well beyond `limit` so the outer exclusions rarely starve the
-  # result; effective recall is additionally bounded by `hnsw.ef_search` (default 40),
-  # consistent with the `search_semantic` path. The caller has already confirmed the
-  # target exists / is published / is embedded / is visible.
+  # US-27.7a: this now routes through the shared, scale-tested kNN helper
+  # `Loopctl.Knowledge.VectorSearch.candidate_query/4` instead of a bespoke cosine query,
+  # so the index-correct shape is enforced in ONE place and a future edit here can't
+  # reintroduce the #170/#172 full scan. The verified shape is unchanged: the INNER pure
+  # ANN (`ORDER BY embedding <=> $const LIMIT pool`, only index-safe residual filters) is
+  # `VectorSearch.candidate_pool_query/4`, wrapped by an OUTER over-the-pool query carrying
+  # the already-linked anti-join (both directions), the `similarity_score > threshold`
+  # floor, the `order_by similarity desc`, and the final `limit`. The target is bound as a
+  # `[float()]` LIST param (never the stored `%Pgvector{}` struct — the #168 500). `pool` is
+  # the SAME `suggestion_candidate_pool/1` value as before (passed as `:pool`), so the
+  # over-fetch is byte-identical to the pre-migration sizing.
   @doc false
   def suggestion_candidates_query(tenant_id, article_id, embedding, threshold, limit, vis) do
-    pool = suggestion_candidate_pool(limit)
-    candidates = suggestion_candidates_inner(tenant_id, article_id, embedding, vis, pool)
-
-    from(c in subquery(candidates),
-      # Exclude any article already linked to the target (either direction, any type).
-      left_join: l in ArticleLink,
-      on:
-        l.tenant_id == ^tenant_id and
-          ((l.source_article_id == ^article_id and l.target_article_id == c.id) or
-             (l.target_article_id == ^article_id and l.source_article_id == c.id)),
-      where: is_nil(l.id),
-      where: c.similarity_score > ^threshold,
-      order_by: [desc: c.similarity_score],
-      limit: ^limit,
-      select: %{
-        id: c.id,
-        title: c.title,
-        category: c.category,
-        similarity_score: c.similarity_score
-      }
+    VectorSearch.candidate_query(tenant_id, embedding, limit,
+      exclude_id: article_id,
+      exclude_linked: true,
+      threshold: threshold,
+      visibility_agent_id: vis,
+      pool: suggestion_candidate_pool(limit)
     )
   end
 
   # The inner ANN top-`pool` subquery, SHARED by the main suggestion query and the
   # under-fill probe so their candidate set is identical BY CONSTRUCTION (no drift). It
-  # is the pure top-`pool` nearest-by-cosine with only index-safe filters (tenant /
-  # status / not-null / not-self / visibility) and the computed `similarity_score`. The
-  # anti-join + threshold + final `limit` are applied by the OUTER query (see the SHAPE
-  # IS LOAD-BEARING note above); the probe reuses this same inner set to count pool
-  # fullness and above-threshold neighbors without re-running the ANN scan twice with
-  # divergent predicates.
+  # delegates to the helper's `VectorSearch.candidate_pool_query/4` — the SAME inner
+  # `candidate_query/4` builds — so the probe counts over EXACTLY the rows the main
+  # suggestion query drew from (the US-27.6b under-fill invariant). It is the pure
+  # top-`pool` nearest-by-cosine with only index-safe filters (tenant / status /
+  # not-null / not-self / visibility) and the computed `similarity_score`. The
+  # anti-join + threshold + final `limit` are applied by the OUTER query.
   defp suggestion_candidates_inner(tenant_id, article_id, embedding, vis, pool) do
-    target = to_embedding_list(embedding)
-
-    from(a in Article,
-      where: a.tenant_id == ^tenant_id and a.status == :published,
-      where: not is_nil(a.embedding),
-      where: a.id != ^article_id,
-      order_by: [asc: fragment("? <=> ?", a.embedding, ^target)],
-      limit: ^pool,
-      select: %{
-        id: a.id,
-        title: a.title,
-        category: a.category,
-        similarity_score: fragment("GREATEST(0, 1 - (? <=> ?))", a.embedding, ^target)
-      }
+    VectorSearch.candidate_pool_query(tenant_id, embedding, pool,
+      exclude_id: article_id,
+      visibility_agent_id: vis
     )
-    |> maybe_filter_by_visibility(vis)
   end
 
   # Over-fetch factor for the inner ANN subquery: pull this many nearest candidates from
@@ -4630,38 +4609,37 @@ defmodule Loopctl.Knowledge do
     offset = opts |> Keyword.get(:offset, 0) |> max(0)
     status = Keyword.get(opts, :status, :published)
 
-    base_query =
-      from(a in Article,
-        where: a.tenant_id == ^tenant_id,
-        where: not is_nil(a.embedding),
-        select: %{
-          id: a.id,
-          tenant_id: a.tenant_id,
-          project_id: a.project_id,
-          title: a.title,
-          category: a.category,
-          status: a.status,
-          tags: a.tags,
-          inserted_at: a.inserted_at,
-          updated_at: a.updated_at,
-          similarity_score: fragment("1 - (embedding <=> ?)", ^query_embedding)
-        },
-        order_by: fragment("embedding <=> ?", ^query_embedding)
-      )
-
-    filtered_query = apply_search_filters(base_query, status, opts)
-
-    # Heavy vector reads via Loopctl.HeavyRead (US-27.11): dedicated pool, pool-level
-    # statement_timeout, isolated from the small AdminRepo pool. `filtered_query`
-    # filters `a.tenant_id`; the count's tenant predicate lives in its inner subquery.
-    count_query = from(q in subquery(filtered_query), select: count())
-    total_count = HeavyRead.one(tenant_id, count_query, heavy_read_opts(:semantic_search))
-
+    # RESULTS — relevance-pool model (US-27.7a, EXPLAIN-driven). The inner ANN is the
+    # shared, index-safe `VectorSearch.candidate_pool_query/4` (pure
+    # `ORDER BY embedding <=> $const LIMIT pool` on the HNSW index), and ALL selective
+    # filters (project/category/tags/memory-types/agents/conversation) are applied on the
+    # OUTER over-the-pool subquery, paginated within the pool. This is required because the
+    # pre-27.7a query applied those filters on the index-ordered scan itself, which at prod
+    # scale flipped the planner to a BitmapAnd + Sort over the corpus and ABANDONED HNSW
+    # (the #170/#172 shape — verified by EXPLAIN at 80k). status + visibility stay in the
+    # inner (both index-safe). The result shape/score (`1 - cosine_distance`) and field set
+    # are byte-for-byte the pre-27.7a contract (the `:semantic` pool select).
+    #
+    # RECALL/PAGINATION NOTE: results now come from the top-`pool` ANN that match the
+    # filters, not a full-corpus rank, so a page DEEPER than the pool returns empty. The
+    # pool is sized to comfortably cover `offset + limit` (and a config floor), so every
+    # in-contract page (limit ≤ #{@max_relevance_page_size}) is served; only an
+    # unusually-deep offset beyond the pool cap is affected — the documented post-ANN-filter
+    # tradeoff `VectorSearch` already carries (see its moduledoc).
     results =
-      filtered_query
-      |> limit(^limit)
-      |> offset(^offset)
+      tenant_id
+      |> semantic_results_query(query_embedding, opts)
       |> then(&HeavyRead.all(tenant_id, &1, heavy_read_opts(:semantic_search)))
+
+    # COUNT — kept as a SEPARATE full-corpus filtered `count(*)` so `total_count` PRESERVES
+    # its pre-27.7a meaning (the size of the whole embedded+filtered ranked corpus, NOT the
+    # pool). It carries NO `ORDER BY embedding <=> …`: a count needs no ordering, and the
+    # old subquery's ORDER BY forced a pointless full-corpus Seq Scan + Sort (~153ms at
+    # 80k). Without it the count is index-served by the filter indexes (a selective
+    # category+tags count is a BitmapAnd bounded by selectivity; the unfiltered count is a
+    # bounded tenant scan — inherently O(tenant rows) for a true `count(*)`).
+    count_query = semantic_count_query(tenant_id, query_embedding, status, opts)
+    total_count = HeavyRead.one(tenant_id, count_query, heavy_read_opts(:semantic_search))
 
     maybe_record_search_access(tenant_id, results, nil, opts, "semantic")
 
@@ -4681,6 +4659,116 @@ defmodule Loopctl.Knowledge do
          total_count_scope: "ranked_corpus"
        }
      }}
+  end
+
+  # Builds `search_semantic`'s paginated RESULTS query (returned, not executed) — the
+  # relevance-pool shape. Public-but-`@doc false` so the US-27.7a scale plan-assertion can
+  # assert the REAL request-path query (AC-27.2.4): the inner ANN is the shared,
+  # HNSW-index-safe `VectorSearch.candidate_pool_query/4` (`:semantic` projection), the
+  # selective filters live on the OUTER over-the-pool subquery, and the page is taken
+  # within the pool. See `search_semantic/3` for the full rationale + recall note.
+  @doc false
+  def semantic_results_query(tenant_id, query_embedding, opts) do
+    limit = opts |> Keyword.get(:limit, 10) |> max(1) |> min(@max_relevance_page_size)
+    offset = opts |> Keyword.get(:offset, 0) |> max(0)
+    status = Keyword.get(opts, :status, :published)
+    pool = semantic_result_pool(offset + limit)
+
+    inner_pool =
+      VectorSearch.candidate_pool_query(tenant_id, query_embedding, pool,
+        select: :semantic,
+        status: status,
+        visibility_agent_id: Keyword.get(opts, :visibility_agent_id)
+      )
+
+    from(c in subquery(inner_pool),
+      order_by: [desc: c.similarity_score],
+      select: %{
+        id: c.id,
+        tenant_id: c.tenant_id,
+        project_id: c.project_id,
+        title: c.title,
+        category: c.category,
+        status: c.status,
+        tags: c.tags,
+        inserted_at: c.inserted_at,
+        updated_at: c.updated_at,
+        similarity_score: c.similarity_score
+      }
+    )
+    |> apply_semantic_pool_filters(opts)
+    |> limit(^limit)
+    |> offset(^offset)
+  end
+
+  # The full-corpus filtered `count(*)` for `search_semantic`'s `total_count` — NO
+  # `embedding <=> …` ordering (a count is order-independent; the ordering only forced a
+  # full-corpus Seq Scan + Sort pre-27.7a). The filter set is IDENTICAL to the results
+  # path (status + visibility + project/category/tags/memory-types/agents/conversation),
+  # so the count is the true size of the embedded+filtered ranked corpus. The tenant
+  # predicate on the base `articles` source satisfies the `HeavyRead` guard directly.
+  # Public-but-`@doc false` so the scale plan-assertion can assert the real count query.
+  @doc false
+  def semantic_count_query(tenant_id, query_embedding, status, opts) do
+    _ = query_embedding
+
+    base =
+      from(a in Article,
+        where: a.tenant_id == ^tenant_id,
+        where: not is_nil(a.embedding)
+      )
+
+    base
+    |> apply_search_filters(status, opts)
+    |> select([_a], count())
+  end
+
+  # Selective post-ANN filters for the semantic results pool, applied on the OUTER
+  # subquery (`c` binding) over the ≤`pool` rows — NEVER the inner index-ordered ANN
+  # (project/category/tags/`metadata @>` all have GIN/btree indexes and would defeat HNSW
+  # there). status + visibility are already applied in the inner pool (index-safe), so they
+  # are intentionally NOT re-applied here. Reuses the same equality/overlap/containment
+  # predicate helpers as the keyword/list path against the `[c]` binding (whose subquery
+  # select carries `project_id`/`category`/`tags`/`metadata`).
+  defp apply_semantic_pool_filters(query, opts) do
+    query
+    |> maybe_filter_by_project_id(Keyword.get(opts, :project_id))
+    |> maybe_filter_by_category(Keyword.get(opts, :category))
+    |> maybe_filter_by_tags(Keyword.get(opts, :tags), Keyword.get(opts, :match, :any))
+    |> maybe_filter_by_memory_types(Keyword.get(opts, :memory_types))
+    |> maybe_filter_by_agents(Keyword.get(opts, :agents))
+    |> maybe_filter_by_conversation_id(Keyword.get(opts, :conversation_id))
+  end
+
+  # Over-fetch pool for the semantic relevance results (US-27.7a). Sized to cover the
+  # requested `offset + limit` page, floored for the common shallow page and HARD-capped so
+  # the inner HNSW scan cost is BOUNDED regardless of caller input. Config:
+  #   * `:semantic_result_pool_floor` (default #{@default_semantic_result_pool_floor})
+  #   * `:semantic_result_pool_cap`   (default #{@default_semantic_result_pool_cap})
+  #
+  # The cap is a HARD ceiling — it is the last clamp, so it ALWAYS binds (AC-27.6a.4: every
+  # caller-tunable cost parameter has an enforced upper bound). `offset` is NOT bounded by
+  # the caller/controller (only floored at 0), so a final `max(needed)` would let a large
+  # `offset` drive the inner `ORDER BY <=> LIMIT pool` to an arbitrary size — an unbounded
+  # scan. We deliberately do NOT do that: a page whose `offset + limit` exceeds the cap is
+  # served from the top-`cap` relevance pool and truncates (empty/partial) beyond it — the
+  # documented post-ANN relevance tradeoff (deep enumeration is the keyset list path's job,
+  # US-27.9a, not relevance search). The floor (≥ the `max_relevance_page_size` limit) keeps
+  # every in-cap page fully served under the default config.
+  defp semantic_result_pool(needed) when is_integer(needed) and needed > 0 do
+    floor =
+      Application.get_env(
+        :loopctl,
+        :semantic_result_pool_floor,
+        @default_semantic_result_pool_floor
+      )
+
+    cap =
+      Application.get_env(:loopctl, :semantic_result_pool_cap, @default_semantic_result_pool_cap)
+
+    needed
+    |> max(floor)
+    |> min(cap)
   end
 
   @doc """

--- a/lib/loopctl/knowledge/vector_search.ex
+++ b/lib/loopctl/knowledge/vector_search.ex
@@ -281,6 +281,15 @@ defmodule Loopctl.Knowledge.VectorSearch do
       * `:category` — category equality (`=`) filter applied **AFTER the ANN fetch**
         over the pool. This is a post-ANN filter, not a tag-scoped kNN; recall
         depends on whether matching articles are in the top-`pool` nearest.
+      * `:project_id` — project equality (`=`) filter applied **AFTER the ANN
+        fetch** over the pool (the `articles(tenant_id, project_id, category)`
+        btree means a selective `project_id =` on the INNER ANN would defeat HNSW,
+        so it lives on the outer pool like `:category`). `nil` is ignored. This is
+        the strict-equality form `search_semantic` uses.
+      * `:project_or_global` — like `:project_id` but matches the given project
+        UUID **OR** tenant-wide (`project_id IS NULL`) rows — the auto-link
+        worker's "same-project plus tenant-wide" scope. Also a post-ANN outer
+        filter; `nil` is ignored.
       * `:visibility_agent_id` — the agent visibility scope (same metadata
         predicate as the other knowledge reads).
       * `:pool` — override the over-fetch pool (still clamped by `max_pool/0` and
@@ -294,7 +303,6 @@ defmodule Loopctl.Knowledge.VectorSearch do
   @spec candidate_query(Ecto.UUID.t(), target_embedding(), pos_integer(), keyword()) ::
           Ecto.Query.t()
   def candidate_query(tenant_id, target_embedding, k, opts \\ []) when is_binary(tenant_id) do
-    target = to_embedding_list(target_embedding)
     k = clamp_k(k)
     pool = candidate_pool(k, Keyword.get(opts, :pool))
     threshold = clamp_threshold(Keyword.get(opts, :threshold, 0.0))
@@ -303,49 +311,124 @@ defmodule Loopctl.Knowledge.VectorSearch do
     exclude_linked? = Keyword.get(opts, :exclude_linked, false) and is_binary(exclude_id)
     tags = clamp_tags(Keyword.get(opts, :tags))
     category = Keyword.get(opts, :category)
-    vis = Keyword.get(opts, :visibility_agent_id)
+    project_id = Keyword.get(opts, :project_id)
+    project_or_global = Keyword.get(opts, :project_or_global)
 
-    # INNER: pure index-ordered ANN. ONLY filters that are verified (at 80k scale,
-    # vector_search_scale_test) to keep the HNSW Index Scan: tenant/status/not-null
-    # equalities, the single-row self-exclusion, and the visibility metadata->>
-    # Filter. Visibility is index-safe by OPERATOR CLASS, not by selectivity: the
-    # `metadata->>'key' = ...` / COALESCE form cannot be served by the articles
-    # `jsonb_ops` GIN (it only answers @>/?), and there is no btree expression index on
-    # it — so the planner can ONLY apply it as a Filter-after-HNSW-index, at ANY
-    # selectivity (same as the prod-verified suggested_links inner query). DO NOT add a
-    # btree/expression index on the visibility/agent_id metadata path or rewrite this to
-    # a GIN-servable `metadata @> ...` form — that would let a selective scope flip the
-    # planner off HNSW. `tags`/`category` are DELIBERATELY NOT here: they HAVE GIN/btree
-    # indexes, so a selective tags&&/category= predicate makes the planner
-    # BitmapAnd-then-Sort and ABANDON the HNSW index (the #170/#172 failure mode —
-    # proven by EXPLAIN at scale). They are applied on the OUTER pool instead.
-    candidates =
-      from(a in Article,
-        where: a.tenant_id == ^tenant_id and a.status == :published,
-        where: not is_nil(a.embedding),
-        order_by: [asc: fragment("? <=> ?", a.embedding, ^target)],
-        limit: ^pool,
-        select: %{
-          id: a.id,
-          title: a.title,
-          category: a.category,
-          tags: a.tags,
-          similarity_score: fragment("GREATEST(0, 1 - (? <=> ?))", a.embedding, ^target)
-        }
-      )
-      |> maybe_exclude_self(exclude_id)
-      |> maybe_filter_by_visibility(vis)
+    # INNER: the pure index-ordered ANN top-`pool` (shared with the suggested_links
+    # under-fill probe via candidate_pool_query/4 so their candidate set is identical
+    # by construction — no drift). It carries ONLY index-safe residual filters; see
+    # candidate_pool_query/4 for the load-bearing rationale.
+    candidates = candidate_pool_query(tenant_id, target_embedding, pool, opts)
 
-    # OUTER: over the materialized ≤pool rows — tags/category here are trivial filters
-    # on a tiny result set (no corpus scan), so they cannot defeat the index.
+    # OUTER: over the materialized ≤pool rows — tags/category/project here are trivial
+    # filters on a tiny result set (no corpus scan), so they cannot defeat the index.
     candidates
     |> outer_query()
     |> maybe_exclude_linked(tenant_id, exclude_id, exclude_linked?)
     |> maybe_filter_by_tags(tags)
     |> maybe_filter_by_category(category)
+    |> maybe_filter_by_project(project_id)
+    |> maybe_filter_by_project_or_global(project_or_global)
     |> where([c], c.similarity_score > ^threshold)
     |> order_by([c], desc: c.similarity_score)
     |> limit(^k)
+  end
+
+  # Builds the INNER index-ordered ANN top-`pool` subquery (returned, NOT executed).
+  #
+  # This is the pure `ORDER BY embedding <=> $const LIMIT pool` with ONLY index-safe
+  # residual filters, exposed as its own (@doc false) public function so the live
+  # `suggested_links` path's under-fill probe (`Loopctl.Knowledge.under_fill_probe/6`)
+  # and the main `candidate_query/4` build the EXACT SAME inner by construction — the
+  # probe's `ann_candidates`/`above_threshold` counts are then over the identical
+  # candidate set the main query drew from, with zero risk of drift. `search_semantic`
+  # shares this same inner too (US-27.7a), so a future edit there can't reintroduce a
+  # full scan.
+  #
+  # WHAT MAY LIVE HERE (LOAD-BEARING — verified with EXPLAIN at 80k scale): ONLY filters
+  # verified to keep the HNSW Index Scan — tenant/status/not-null equalities, the
+  # single-row self-exclusion (`:exclude_id`), and the visibility `metadata->>` Filter
+  # (`:visibility_agent_id`). Visibility is index-safe by OPERATOR CLASS, not selectivity:
+  # the `metadata->>'key' = ...` / COALESCE form cannot be served by the articles
+  # `jsonb_ops` GIN (it only answers @>/?), and there is no btree expression index on it —
+  # so the planner can ONLY apply it as a Filter-after-HNSW-index, at ANY selectivity. DO
+  # NOT add a btree/expression index on the visibility/agent_id metadata path or rewrite
+  # this to a GIN-servable `metadata @> ...` form — that would let a selective scope flip
+  # the planner off HNSW. `tags`/`category`/`project_id` are DELIBERATELY NOT here: they
+  # HAVE GIN/btree indexes, so a selective `tags &&` / `category =` / `project_id =`
+  # predicate makes the planner BitmapAnd-then-Sort and ABANDON the HNSW index (the
+  # #170/#172 failure mode — proven by EXPLAIN at scale). They are applied on the OUTER
+  # pool instead (see `candidate_query/4`).
+  #
+  # SELECT SHAPE: chosen by the `:select` opt (the SELECT list does NOT affect HNSW usage
+  # — only the WHERE/ORDER BY/LIMIT do — so the two shapes share the SAME index-safe core):
+  #   * `:knn` (default) — `%{id, title, category, tags, project_id, similarity_score}` with
+  #     `similarity_score = GREATEST(0, 1 - cosine_distance)` (the suggested_links / worker
+  #     shape). `tags`/`project_id` are carried so the outer over-the-pool query can
+  #     post-filter on them without a second `articles` reference.
+  #   * `:semantic` — `search_semantic`'s richer projection: adds `tenant_id`, `status`,
+  #     `inserted_at`, `updated_at`, and `metadata` (so the outer pool can apply the
+  #     GIN-servable `metadata @>` memory-type/agent/conversation filters — which CANNOT
+  #     go in the inner without defeating HNSW), and uses the RAW
+  #     `similarity_score = 1 - cosine_distance` (not GREATEST-clamped) to preserve the
+  #     pre-US-27.7a semantic-search contract exactly.
+  #
+  # RECOGNIZED opts: `:exclude_id` (single-row index-safe self-exclusion),
+  # `:visibility_agent_id` (index-safe metadata scope), `:status` (index-safe status
+  # equality, default `:published`), `:select` (`:knn` | `:semantic`, default `:knn`).
+  # Cost-affecting opts (`:tags`/`:category`/`:project_id`/`:threshold`/`:pool`) are
+  # IGNORED here — they belong on the outer query in `candidate_query/4` (or the
+  # search_semantic outer pool).
+  @doc false
+  @spec candidate_pool_query(Ecto.UUID.t(), target_embedding(), pos_integer(), keyword()) ::
+          Ecto.Query.t()
+  def candidate_pool_query(tenant_id, target_embedding, pool, opts \\ [])
+      when is_binary(tenant_id) and is_integer(pool) do
+    target = to_embedding_list(target_embedding)
+    exclude_id = Keyword.get(opts, :exclude_id)
+    vis = Keyword.get(opts, :visibility_agent_id)
+    status = Keyword.get(opts, :status, :published)
+
+    base =
+      from(a in Article,
+        where: a.tenant_id == ^tenant_id and a.status == ^status,
+        where: not is_nil(a.embedding),
+        order_by: [asc: fragment("? <=> ?", a.embedding, ^target)],
+        limit: ^pool
+      )
+      |> maybe_exclude_self(exclude_id)
+      |> maybe_filter_by_visibility(vis)
+
+    pool_select(base, Keyword.get(opts, :select, :knn), target)
+  end
+
+  # The index-safe inner's SELECT list. Varies by consumer but NEVER touches the
+  # HNSW-load-bearing WHERE/ORDER BY/LIMIT above.
+  defp pool_select(base, :knn, target) do
+    select(base, [a], %{
+      id: a.id,
+      title: a.title,
+      category: a.category,
+      tags: a.tags,
+      project_id: a.project_id,
+      similarity_score: fragment("GREATEST(0, 1 - (? <=> ?))", a.embedding, ^target)
+    })
+  end
+
+  defp pool_select(base, :semantic, target) do
+    select(base, [a], %{
+      id: a.id,
+      tenant_id: a.tenant_id,
+      project_id: a.project_id,
+      title: a.title,
+      category: a.category,
+      status: a.status,
+      tags: a.tags,
+      metadata: a.metadata,
+      inserted_at: a.inserted_at,
+      updated_at: a.updated_at,
+      similarity_score: fragment("1 - (? <=> ?)", a.embedding, ^target)
+    })
   end
 
   # The outer query over the over-fetched pool. Kept as its own clause so the
@@ -387,6 +470,27 @@ defmodule Loopctl.Knowledge.VectorSearch do
       query
     end
   end
+
+  # Strict project equality on the OUTER pool (the `search_semantic` form, mirroring
+  # Loopctl.Knowledge.maybe_filter_by_project_id/2). On the over-the-pool `c` binding,
+  # never the inner ANN — `project_id` is part of the
+  # `articles(tenant_id, project_id, category)` btree, so a selective `project_id =` on
+  # the index-ordered subquery would defeat HNSW (same class as tags/category).
+  defp maybe_filter_by_project(query, nil), do: query
+
+  defp maybe_filter_by_project(query, project_id) when is_binary(project_id),
+    do: where(query, [c], c.project_id == ^project_id)
+
+  # "Same-project OR tenant-wide" project scope on the OUTER pool — the auto-link
+  # worker's `scope_by_project/2` semantics (US-21.2.3): a project-scoped source
+  # compares against same-project AND tenant-wide (`project_id IS NULL`) rows. `nil`
+  # (a tenant-wide source) is a no-op (compare against everything), matching the
+  # worker's nil clause exactly. Applied over the pool for the same btree reason as
+  # `maybe_filter_by_project/2`.
+  defp maybe_filter_by_project_or_global(query, nil), do: query
+
+  defp maybe_filter_by_project_or_global(query, project_id) when is_binary(project_id),
+    do: where(query, [c], c.project_id == ^project_id or is_nil(c.project_id))
 
   # Same agent-visibility metadata predicate as the other knowledge reads
   # (Loopctl.Knowledge.maybe_filter_by_visibility/2), on the `[a]` binding.

--- a/lib/loopctl/knowledge/vector_search.ex
+++ b/lib/loopctl/knowledge/vector_search.ex
@@ -391,16 +391,29 @@ defmodule Loopctl.Knowledge.VectorSearch do
 
     base =
       from(a in Article,
-        where: a.tenant_id == ^tenant_id and a.status == ^status,
+        where: a.tenant_id == ^tenant_id,
         where: not is_nil(a.embedding),
         order_by: [asc: fragment("? <=> ?", a.embedding, ^target)],
         limit: ^pool
       )
+      |> maybe_filter_by_status(status)
       |> maybe_exclude_self(exclude_id)
       |> maybe_filter_by_visibility(vis)
 
     pool_select(base, Keyword.get(opts, :select, :knn), target)
   end
+
+  # Status equality on the inner ANN (index-safe, like the tenant/not-null filters).
+  # NIL-SKIPPING to match `Loopctl.Knowledge.maybe_filter_by_status/2` and the
+  # search_semantic COUNT path: `status: nil` means "all statuses" (no filter), so the
+  # inner pool and the separate full-corpus count stay over the SAME population — without
+  # this, `status == ^nil` would match nothing and a `status: nil` semantic search would
+  # return empty results against a non-zero total_count. Suggested-links / the worker pass
+  # no `:status`, so they keep the default `:published`.
+  defp maybe_filter_by_status(query, nil), do: query
+
+  defp maybe_filter_by_status(query, status),
+    do: where(query, [a], a.status == ^status)
 
   # The index-safe inner's SELECT list. Varies by consumer but NEVER touches the
   # HNSW-load-bearing WHERE/ORDER BY/LIMIT above.

--- a/lib/loopctl/workers/article_linking_worker.ex
+++ b/lib/loopctl/workers/article_linking_worker.ex
@@ -34,7 +34,11 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
 
   Configurable max comparisons via
   `Application.get_env(:loopctl, :article_link_max_comparisons, 50)`.
-  Logs a warning when candidate count exceeds the limit.
+  Logs a warning when candidate count exceeds the limit. Since US-27.7a the lookup
+  runs through `VectorSearch.nearest/4`, whose `k` is clamped to
+  `VectorSearch.max_k/0` (default 100), so a configured value above that ceiling is
+  capped (a documented kNN cost bound); the default 50 is unaffected, and a clamp is
+  logged once per job.
 
   ## Threshold (AC-21.2.4)
 
@@ -79,8 +83,27 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
 
       {:ok, %Article{} = article} ->
         threshold = Application.get_env(:loopctl, :article_link_threshold, 0.6)
-        max_comparisons = Application.get_env(:loopctl, :article_link_max_comparisons, 50)
+        max_comparisons = clamped_max_comparisons()
         find_and_link_similar(article, tenant_id, threshold, max_comparisons)
+    end
+  end
+
+  # `max_comparisons` flows to the kNN helper as `k`, which is clamped to
+  # `VectorSearch.max_k/0` (US-27.7a cost bound). Surface that clamp once so an operator
+  # who configured a higher value isn't silently capped (default 50 is well under it).
+  defp clamped_max_comparisons do
+    configured = Application.get_env(:loopctl, :article_link_max_comparisons, 50)
+    max_k = VectorSearch.max_k()
+
+    if configured > max_k do
+      Logger.warning(
+        "article_link_max_comparisons=#{configured} exceeds VectorSearch.max_k=#{max_k}; " <>
+          "capping similarity comparisons at #{max_k}"
+      )
+
+      max_k
+    else
+      configured
     end
   end
 
@@ -129,11 +152,15 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
   # BEHAVIOR PRESERVED: self exclusion, published-only, and the project scope
   # ("same-project OR tenant-wide" for a project-scoped source; no project filter for a
   # tenant-wide one) are unchanged — the latter via the helper's `:project_or_global` opt,
-  # which mirrors the old `scope_by_project/2` exactly. The threshold boundary is also
-  # preserved EXACTLY: we ask the helper for `threshold: 0.0` (no floor in the indexed
-  # query) and keep the INCLUSIVE `sim >= threshold` filter in memory here — the helper's
-  # own floor is strict `>`, so leaving the boundary check here is what keeps a candidate
-  # whose similarity equals the threshold linkable, identical to the pre-migration code.
+  # which mirrors the old `scope_by_project/2` exactly. The threshold boundary is
+  # preserved for any POSITIVE `threshold`: we ask the helper for `threshold: 0.0` (no
+  # floor in the indexed query) and keep the INCLUSIVE `sim >= threshold` filter in memory
+  # here — the helper's own floor is strict `>`, so leaving the boundary check here keeps a
+  # candidate whose similarity equals the (positive) threshold linkable, identical to the
+  # pre-migration code. (Edge: at `threshold == 0.0` the helper's `> 0.0` floor — over the
+  # `GREATEST(0, 1 - distance)` score — additionally drops exactly-orthogonal candidates
+  # the old in-memory `>= 0.0` kept. This is a deliberate, harmless tightening for
+  # auto-linking: a 0.0-similarity "relates_to" link is noise; the default threshold is 0.6.)
   #
   # RECALL NOTE (post-ANN-filter tradeoff): because the project scope now runs on the
   # OUTER pool (it must, to keep HNSW), the worker links among the GLOBAL-nearest `pool`

--- a/lib/loopctl/workers/article_linking_worker.ex
+++ b/lib/loopctl/workers/article_linking_worker.ex
@@ -22,6 +22,14 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
     tenant-wide articles (project_id IS NULL).
   - Tenant-wide articles compare against all articles in the tenant.
 
+  Since US-27.7a the similarity lookup runs through the shared
+  `Loopctl.Knowledge.VectorSearch.nearest/4` (the index-correct HNSW kNN path on
+  the HeavyRead pool), with the project scope applied as a post-ANN filter over the
+  over-fetch pool. The worker therefore links among the GLOBAL-nearest pool that
+  match the project, not the nearest-WITHIN-project — the documented post-ANN-filter
+  tradeoff (see `find_similar_articles/4`). For the worker's small `max_comparisons`
+  (default 50) against a generously sized pool the two are equivalent.
+
   ## Limits (AC-21.2.8 / AC-21.2.15)
 
   Configurable max comparisons via
@@ -56,6 +64,7 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
   alias Loopctl.Knowledge
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.ArticleLink
+  alias Loopctl.Knowledge.VectorSearch
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"article_id" => article_id, "tenant_id" => tenant_id}}) do
@@ -108,38 +117,44 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
     :ok
   end
 
+  # US-27.7a: route the similarity lookup through the shared, scale-tested kNN helper
+  # (`Loopctl.Knowledge.VectorSearch.nearest/4`) on the dedicated HeavyRead pool instead
+  # of a bespoke `AdminRepo` cosine query. The helper's index-correct shape guarantees a
+  # background link pass can never silently full-scan the corpus at prod scale (the rot
+  # this epic targets) — the inner ANN is the pure `ORDER BY <=> LIMIT pool` HNSW path,
+  # and the project scope is applied on the OUTER pool (`project_id` is in the
+  # `articles(tenant_id, project_id, category)` btree, so an inner predicate would defeat
+  # HNSW).
+  #
+  # BEHAVIOR PRESERVED: self exclusion, published-only, and the project scope
+  # ("same-project OR tenant-wide" for a project-scoped source; no project filter for a
+  # tenant-wide one) are unchanged — the latter via the helper's `:project_or_global` opt,
+  # which mirrors the old `scope_by_project/2` exactly. The threshold boundary is also
+  # preserved EXACTLY: we ask the helper for `threshold: 0.0` (no floor in the indexed
+  # query) and keep the INCLUSIVE `sim >= threshold` filter in memory here — the helper's
+  # own floor is strict `>`, so leaving the boundary check here is what keeps a candidate
+  # whose similarity equals the threshold linkable, identical to the pre-migration code.
+  #
+  # RECALL NOTE (post-ANN-filter tradeoff): because the project scope now runs on the
+  # OUTER pool (it must, to keep HNSW), the worker links among the GLOBAL-nearest `pool`
+  # rows that THEN match the project — not the nearest-WITHIN-project. With a generously
+  # sized pool (`pool_size(max_comparisons)`) this is equivalent for the small
+  # `max_comparisons` (default 50) the worker uses; in a pathological corpus where a
+  # project's matches all fall outside the global top-pool it could under-fill, the same
+  # documented post-ANN-filter limitation `VectorSearch` carries for `tags`/`category`.
   defp find_similar_articles(article, tenant_id, threshold, max_comparisons) do
-    embedding = article.embedding
-
-    base_query =
-      from(a in Article,
-        where: a.tenant_id == ^tenant_id,
-        where: a.id != ^article.id,
-        where: not is_nil(a.embedding),
-        where: a.status == :published,
-        select: %{
-          id: a.id,
-          similarity: fragment("1 - (? <=> ?)", a.embedding, ^embedding)
-        },
-        order_by: [asc: fragment("? <=> ?", a.embedding, ^embedding)],
-        limit: ^max_comparisons
-      )
-
-    query = scope_by_project(base_query, article.project_id)
-
-    query
-    |> AdminRepo.all()
+    tenant_id
+    |> VectorSearch.nearest(article.embedding, max_comparisons,
+      exclude_id: article.id,
+      project_or_global: article.project_id,
+      threshold: 0.0,
+      pool: VectorSearch.pool_size(max_comparisons)
+    )
+    # The helper returns `%{id, title, category, similarity_score}`; the linking path
+    # keys on `:id` + `:similarity`, so map the score across and keep the inclusive
+    # `>= threshold` boundary in memory (see the threshold note above).
+    |> Enum.map(fn %{id: id, similarity_score: score} -> %{id: id, similarity: score} end)
     |> Enum.filter(fn %{similarity: sim} -> sim >= threshold end)
-  end
-
-  defp scope_by_project(query, nil) do
-    # Tenant-wide article: compare against all articles in the tenant
-    query
-  end
-
-  defp scope_by_project(query, project_id) do
-    # Project-scoped article: compare against same project + tenant-wide
-    where(query, [a], is_nil(a.project_id) or a.project_id == ^project_id)
   end
 
   defp log_if_exceeds_limit(article, tenant_id, max_comparisons) do
@@ -159,6 +174,16 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
           "for article #{article.id}"
       )
     end
+  end
+
+  # Candidate-COUNT scoping for the over-limit warning only (a plain `count(*)`, NOT the
+  # vector scan — the kNN lookup itself routes through `VectorSearch.nearest/4`). Mirrors
+  # the historical scope: a tenant-wide article counts against the whole tenant; a
+  # project-scoped one against same-project plus tenant-wide (`project_id IS NULL`).
+  defp scope_by_project(query, nil), do: query
+
+  defp scope_by_project(query, project_id) do
+    where(query, [a], is_nil(a.project_id) or a.project_id == ^project_id)
   end
 
   defp get_existing_link_pairs(article_id, tenant_id) do

--- a/lib/loopctl_web/controllers/knowledge_search_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_search_controller.ex
@@ -189,9 +189,12 @@ defmodule LoopctlWeb.KnowledgeSearchController do
                  pool_capped: %OpenApiSpex.Schema{
                    type: :boolean,
                    description:
-                     "Semantic relevance mode only: true when the ranked corpus exceeds the " <>
-                       "relevance pool cap, so results beyond the cap are NOT reachable by a " <>
-                       "deeper `offset` — switch to list mode for full enumeration."
+                     "Relevance modes (semantic / combined): true when the ranked+filtered " <>
+                       "results may be INCOMPLETE — either the corpus exceeds the relevance " <>
+                       "pool cap, or a selective filter starved the pool below the cap. " <>
+                       "`false` means this query's results are complete; `total_count` can " <>
+                       "exceed what relevance pagination reaches, so on `pool_capped: true` " <>
+                       "switch to list mode (`cursor`) for full enumeration."
                  },
                  next_cursor: %OpenApiSpex.Schema{
                    type: :string,
@@ -570,20 +573,27 @@ defmodule LoopctlWeb.KnowledgeSearchController do
 
   defp maybe_add_limit(opts, _), do: [{:limit, 10} | opts]
 
+  # Upper bound on `offset` so an absurd value (e.g. `offset=99999999999999999999`) is
+  # clamped rather than reaching the DB and raising a Postgres bigint-range error as a 500.
+  # Well above any legitimate offset page; deep enumeration uses the keyset (`cursor`) path.
+  @max_offset 1_000_000
+
   defp maybe_add_offset(opts, nil), do: [{:offset, 0} | opts]
 
   defp maybe_add_offset(opts, value) when is_binary(value) do
     case Integer.parse(value) do
-      {int, ""} -> [{:offset, max(int, 0)} | opts]
+      {int, ""} -> [{:offset, clamp_offset(int)} | opts]
       _ -> [{:offset, 0} | opts]
     end
   end
 
   defp maybe_add_offset(opts, value) when is_integer(value) do
-    [{:offset, max(value, 0)} | opts]
+    [{:offset, clamp_offset(value)} | opts]
   end
 
   defp maybe_add_offset(opts, _), do: [{:offset, 0} | opts]
+
+  defp clamp_offset(value), do: value |> max(0) |> min(@max_offset)
 
   # List mode: query-less enumeration of the filtered set, regardless of `mode`.
   defp execute_search(tenant_id, :list, _mode, opts) do

--- a/lib/loopctl_web/controllers/knowledge_search_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_search_controller.ex
@@ -186,6 +186,13 @@ defmodule LoopctlWeb.KnowledgeSearchController do
                    type: :integer,
                    description: "Offset path only; absent on the keyset (`cursor`) path"
                  },
+                 pool_capped: %OpenApiSpex.Schema{
+                   type: :boolean,
+                   description:
+                     "Semantic relevance mode only: true when the ranked corpus exceeds the " <>
+                       "relevance pool cap, so results beyond the cap are NOT reachable by a " <>
+                       "deeper `offset` — switch to list mode for full enumeration."
+                 },
                  next_cursor: %OpenApiSpex.Schema{
                    type: :string,
                    nullable: true,

--- a/lib/loopctl_web/controllers/knowledge_search_json.ex
+++ b/lib/loopctl_web/controllers/knowledge_search_json.ex
@@ -150,6 +150,10 @@ defmodule LoopctlWeb.KnowledgeSearchJSON do
     # surfaced only when combined mode degraded to keyword-only.
     |> maybe_put(:total_count_scope, meta[:total_count_scope])
     |> maybe_put(:search_mode, meta[:search_mode])
+    # `pool_capped` (semantic relevance mode, US-27.7a): true when the ranked corpus
+    # exceeds the relevance pool cap, so the tail is unreachable by deeper `offset` —
+    # the consumer should switch to list mode for full enumeration.
+    |> maybe_put(:pool_capped, meta[:pool_capped])
     |> maybe_put_fallback(meta[:fallback])
   end
 

--- a/test/loopctl/knowledge/topk_endpoints_scale_test.exs
+++ b/test/loopctl/knowledge/topk_endpoints_scale_test.exs
@@ -1,0 +1,206 @@
+defmodule Loopctl.Knowledge.TopkEndpointsScaleTest do
+  @moduledoc """
+  US-27.7a scale gate (TC-27.7a.3 / AC-27.7a.6): prove the three single-target top-k
+  vector endpoints — `suggested_links`, `search_semantic` (RESULTS + COUNT), and the
+  auto-link worker's similarity lookup — are each HNSW-index-backed (no unbounded full
+  scan) and under budget at the >= prod-floor 80k corpus, now that US-27.7a routed them
+  all through `Loopctl.Knowledge.VectorSearch`.
+
+  This is the gate that makes "migrated through the helper" mean "index-correct at scale,
+  proven by the planner's NATURAL choice" (no `enable_seqscan=off`). It asserts on the
+  REAL request-path query builders (`Knowledge.suggestion_candidates_query/6`,
+  `Knowledge.semantic_results_query/3`, `Knowledge.semantic_count_query/4`, and
+  `VectorSearch.candidate_query/4` as the worker invokes it), not re-built stunt doubles
+  (AC-27.2.4).
+
+  Seeds ~80k committed rows via `Loopctl.Knowledge.ScaleSeed`, so it is `:scale_nightly`
+  (runs on the nightly/scale gate, NOT the default async suite) and is wired into
+  `.github/workflows/ci.yml`'s `scale_file` matrix (enforced by
+  `scale_verification_runbook_test.exs`).
+  """
+  use ExUnit.Case, async: false
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.ScaleSeed
+  alias Loopctl.Knowledge.VectorSearch
+  alias Loopctl.PlanAssertions
+  alias Loopctl.Tenants.Tenant
+
+  import Ecto.Query
+
+  @moduletag :scale_nightly
+  @moduletag timeout: :timer.minutes(30)
+
+  # The pool-level heavy-read statement_timeout backstop (worst-case must beat it).
+  @heavy_read_statement_timeout_ms System.get_env("HEAVY_READ_STATEMENT_TIMEOUT_MS", "10000")
+                                   |> String.to_integer()
+
+  defp unboxed(fun), do: Sandbox.unboxed_run(AdminRepo, fun)
+
+  setup do
+    tenant =
+      unboxed(fn ->
+        slug = "topk-scale-#{:erlang.phash2(Ecto.UUID.generate())}"
+
+        {:ok, t} =
+          %Tenant{}
+          |> Tenant.create_changeset(%{
+            name: "Topk Scale #{slug}",
+            slug: slug,
+            email: "#{slug}@example.com",
+            settings: %{},
+            status: :active
+          })
+          |> AdminRepo.insert()
+
+        # link_density: 5 (the prod-floor default) — enough links for the suggested_links
+        # anti-join to be real without the 10-dense special-casing the under-fill gate needs.
+        ScaleSeed.seed(t.id, count: ScaleSeed.prod_article_floor(), link_density: 5)
+        t
+      end)
+
+    on_exit(fn ->
+      try do
+        unboxed(fn ->
+          AdminRepo.delete_all(from(a in Article, where: a.tenant_id == ^tenant.id))
+          AdminRepo.delete_all(from(t in Tenant, where: t.id == ^tenant.id))
+        end)
+      rescue
+        _ -> :ok
+      end
+    end)
+
+    {:ok, tenant: tenant}
+  end
+
+  defp a_target(tenant) do
+    AdminRepo.one(
+      from(a in Article,
+        where: a.tenant_id == ^tenant.id and not is_nil(a.embedding),
+        order_by: [asc: a.inserted_at, asc: a.id],
+        offset: 100,
+        limit: 1,
+        select: %{id: a.id, embedding: a.embedding}
+      )
+    )
+  end
+
+  # ---- suggested_links (AC-27.7a.1) ----
+
+  test "suggested_links is HNSW-index-backed at prod scale through the helper", %{tenant: tenant} do
+    unboxed(fn ->
+      target = a_target(tenant)
+
+      query =
+        Knowledge.suggestion_candidates_query(tenant.id, target.id, target.embedding, 0.5, 5, nil)
+
+      # Planner's NATURAL choice at 80k must reach `articles` via exactly one HNSW Index
+      # Scan — never a Seq/Bitmap full-corpus read (the #170/#172 shape).
+      assert :ok = PlanAssertions.refute_full_scan(query)
+      assert :ok = PlanAssertions.assert_hnsw_index(query)
+    end)
+  end
+
+  # ---- search_semantic RESULTS (AC-27.7a.2 / AC-27.7a.6) ----
+
+  test "search_semantic RESULTS stay HNSW-index-backed at scale — no-filter, deep offset, AND selective filters",
+       %{tenant: tenant} do
+    unboxed(fn ->
+      target = a_target(tenant)
+      qemb = VectorSearch.to_embedding_list(target.embedding)
+
+      scenarios = [
+        {"no filter", []},
+        {"deep offset", [offset: 200]},
+        # The regression case: a selective tags+category that pre-27.7a flipped the
+        # index-ordered scan to BitmapAnd + Sort (abandoning HNSW). Now applied on the
+        # OUTER pool, the inner ANN must STILL be a single HNSW Index Scan.
+        {"selective category+tags", [category: :decision, tags: ["scale-tag-3"]]}
+      ]
+
+      for {label, opts} <- scenarios do
+        query = Knowledge.semantic_results_query(tenant.id, qemb, opts)
+
+        assert :ok = PlanAssertions.refute_full_scan(query),
+               "search_semantic RESULTS (#{label}) must not full-scan at 80k"
+
+        assert :ok = PlanAssertions.assert_hnsw_index(query),
+               "search_semantic RESULTS (#{label}) must reach articles via one HNSW Index Scan"
+      end
+    end)
+  end
+
+  # ---- search_semantic COUNT (AC-27.7a.2 / AC-27.7a.6) ----
+
+  test "search_semantic COUNT is sort-free, and selective counts stay index-bounded (no Seq Scan)",
+       %{tenant: tenant} do
+    unboxed(fn ->
+      qemb = VectorSearch.to_embedding_list(a_target(tenant).embedding)
+
+      # No-filter count: counting the whole tenant's embedded corpus is inherently
+      # O(tenant rows) (a true `count(*)`), so a bounded tenant scan is correct — the
+      # REGRESSION we guard is the pre-27.7a pointless full-corpus Sort (the count used to
+      # wrap the results subquery's `ORDER BY embedding <=> …`). The corrected count carries
+      # no ordering → the plan must be Sort-FREE.
+      no_filter_count = Knowledge.semantic_count_query(tenant.id, qemb, :published, [])
+      assert :ok = PlanAssertions.refute_sort(no_filter_count)
+
+      # Selective category+tags count: must be served by the filter indexes (BitmapAnd),
+      # never an unbounded Seq Scan over the corpus, and bounded by the residual
+      # selectivity (well below the 80k corpus).
+      selective_count =
+        Knowledge.semantic_count_query(tenant.id, qemb, :published,
+          category: :decision,
+          tags: ["scale-tag-3"]
+        )
+
+      assert :ok = PlanAssertions.refute_sort(selective_count)
+      assert :ok = PlanAssertions.refute_seq_scan(selective_count)
+      assert :ok = PlanAssertions.assert_scan_rows_below(selective_count, 20_000)
+    end)
+  end
+
+  # ---- auto-link worker lookup (AC-27.7a.3) ----
+
+  test "the auto-link worker's similarity lookup is HNSW-index-backed at scale", %{tenant: tenant} do
+    unboxed(fn ->
+      target = a_target(tenant)
+      max_comparisons = Application.get_env(:loopctl, :article_link_max_comparisons, 50)
+
+      # The EXACT query the worker now builds (US-27.7a): VectorSearch.nearest/4 with the
+      # worker's project scope on the OUTER pool, threshold 0.0 (the worker keeps its
+      # inclusive >= filter in memory), and a generously-sized pool.
+      query =
+        VectorSearch.candidate_query(tenant.id, target.embedding, max_comparisons,
+          exclude_id: target.id,
+          project_or_global: nil,
+          threshold: 0.0,
+          pool: VectorSearch.pool_size(max_comparisons)
+        )
+
+      assert :ok = PlanAssertions.refute_full_scan(query)
+      assert :ok = PlanAssertions.assert_hnsw_index(query)
+
+      # And the worst case completes WELL under the heavy-read statement_timeout backstop.
+      {elapsed_us, results} =
+        :timer.tc(fn ->
+          VectorSearch.nearest(tenant.id, target.embedding, max_comparisons,
+            exclude_id: target.id,
+            project_or_global: nil,
+            threshold: 0.0,
+            pool: VectorSearch.pool_size(max_comparisons)
+          )
+        end)
+
+      elapsed_ms = div(elapsed_us, 1000)
+
+      assert elapsed_ms < @heavy_read_statement_timeout_ms,
+             "worker lookup took #{elapsed_ms}ms, expected < #{@heavy_read_statement_timeout_ms}ms"
+
+      assert is_list(results)
+    end)
+  end
+end

--- a/test/loopctl/knowledge_semantic_search_test.exs
+++ b/test/loopctl/knowledge_semantic_search_test.exs
@@ -726,4 +726,56 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
                Knowledge.search_combined(tenant.id, "fallback")
     end
   end
+
+  describe "search_semantic/3 - relevance-pool meta + truncation signal (US-27.7a, TC-27.7a.2)" do
+    test "small corpus: ranked results + full meta shape, pool_capped false" do
+      %{tenant: tenant} = setup_tenant()
+
+      a = create_article_with_embedding(tenant.id, %{title: "Aligned"}, :query)
+      _b = create_article_with_embedding(tenant.id, %{title: "Medium"}, :medium)
+      _c = create_article_with_embedding(tenant.id, %{title: "Far"}, :far)
+
+      {:ok, %{results: results, meta: meta}} =
+        Knowledge.search_semantic(tenant.id, make_embedding(:query))
+
+      # Ranked by similarity desc — the :query-aligned article is most similar.
+      assert length(results) == 3
+      assert hd(results).id == a.id
+
+      # Full meta contract preserved (TC-27.7a.2) + the additive truncation signal.
+      assert meta.total_count == 3
+      assert meta.limit == 10
+      assert meta.offset == 0
+      assert meta.search_mode == "semantic_only"
+      assert meta.total_count_scope == "ranked_corpus"
+      # 3 ranked rows <= the (test) relevance-pool cap of 5 → fully reachable, not capped.
+      assert meta.pool_capped == false
+    end
+
+    test "corpus larger than the relevance-pool cap: pool_capped true + deep offset truncates" do
+      %{tenant: tenant} = setup_tenant()
+
+      # Seed cap+2 near-identical embedded articles (test cap = 5, see config/test.exs).
+      for i <- 1..7, do: create_article_with_embedding(tenant.id, %{title: "Hub #{i}"}, :query)
+
+      {:ok, %{results: results, meta: meta}} =
+        Knowledge.search_semantic(tenant.id, make_embedding(:query), limit: 10)
+
+      # total_count is the FULL ranked corpus (a SEPARATE count, NOT pool-bounded) ...
+      assert meta.total_count == 7
+      # ... but the relevance pool only surfaces up to the cap, so the tail is unreachable
+      # by a deeper offset — and the signal flags it (not silent).
+      assert length(results) == 5
+      assert meta.pool_capped == true
+
+      # A page past the cap returns empty (documented relevance tradeoff); the signal
+      # still flags it so the consumer knows to switch to list mode for full enumeration.
+      {:ok, %{results: deep, meta: deep_meta}} =
+        Knowledge.search_semantic(tenant.id, make_embedding(:query), limit: 10, offset: 5)
+
+      assert deep == []
+      assert deep_meta.total_count == 7
+      assert deep_meta.pool_capped == true
+    end
+  end
 end

--- a/test/loopctl/knowledge_semantic_search_test.exs
+++ b/test/loopctl/knowledge_semantic_search_test.exs
@@ -778,4 +778,81 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
       assert deep_meta.pool_capped == true
     end
   end
+
+  describe "search_semantic/3 - relevance-pool R2 edges (filter starvation, status:nil)" do
+    test "selective filter whose matches fall outside the pool: pool_capped true (not a false negative)" do
+      %{tenant: tenant} = setup_tenant()
+
+      # Fill the (test) relevance pool (cap 5) with near-identical :reference articles, and
+      # put the ONLY :pattern match far away (orthogonal → similarity 0, ranked last), so it
+      # sits OUTSIDE the top-5 nearest. A category:pattern search then starves the pool below
+      # the cap. The honest signal must flag this — `total_count > cap` ALONE would miss it.
+      for i <- 1..5,
+          do:
+            create_article_with_embedding(
+              tenant.id,
+              %{title: "Ref #{i}", category: :reference},
+              :query
+            )
+
+      create_article_with_embedding(tenant.id, %{title: "Lone Pattern", category: :pattern}, :far)
+
+      {:ok, %{results: results, meta: meta}} =
+        Knowledge.search_semantic(tenant.id, make_embedding(:query),
+          category: :pattern,
+          limit: 10
+        )
+
+      # total_count is the full filtered corpus (1 :pattern article)...
+      assert meta.total_count == 1
+      # ...but it fell outside the top-5 nearest, so the page is starved (< total_count)
+      # and the signal flags incompleteness rather than lying "reachable".
+      assert length(results) < meta.total_count
+      assert meta.pool_capped == true
+    end
+
+    test "status: nil ('all statuses') ranks every status — results and count stay consistent" do
+      %{tenant: tenant} = setup_tenant()
+
+      _pub = create_article_with_embedding(tenant.id, %{title: "Pub", status: :published}, :query)
+      _draft = create_article_with_embedding(tenant.id, %{title: "Draft", status: :draft}, :query)
+
+      # status: nil must NOT force `status == NULL` on the inner (which would return empty
+      # against a non-zero count) — it means "all statuses", matching the count path.
+      {:ok, %{results: all_results, meta: all_meta}} =
+        Knowledge.search_semantic(tenant.id, make_embedding(:query), status: nil)
+
+      assert all_meta.total_count == 2
+      assert length(all_results) == 2
+      assert Enum.sort(Enum.map(all_results, & &1.status)) == [:draft, :published]
+
+      # Default (published) still excludes the draft — proving the nil-skip is scoped.
+      {:ok, %{results: pub_results}} =
+        Knowledge.search_semantic(tenant.id, make_embedding(:query))
+
+      assert length(pub_results) == 1
+      assert hd(pub_results).status == :published
+    end
+  end
+
+  describe "search_combined/3 - relevance-pool truncation propagation (US-27.7a)" do
+    test "combined carries the semantic half's pool_capped (default mode is not silent)" do
+      %{tenant: tenant} = setup_tenant()
+
+      # cap+2 embedded articles → the semantic sub-search is pool-capped; combined must
+      # surface that, not drop it (combined is the DEFAULT search mode).
+      for i <- 1..7, do: create_article_with_embedding(tenant.id, %{title: "Hub #{i}"}, :query)
+
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _text ->
+        {:ok, make_embedding(:query)}
+      end)
+
+      Knowledge.reset_circuit_breaker()
+
+      {:ok, %{meta: meta}} = Knowledge.search_combined(tenant.id, "hub")
+
+      assert meta.search_mode == "combined"
+      assert meta.pool_capped == true
+    end
+  end
 end

--- a/test/support/plan_assertions.ex
+++ b/test/support/plan_assertions.ex
@@ -219,6 +219,30 @@ defmodule Loopctl.PlanAssertions do
     end
   end
 
+  @doc """
+  Asserts the plan contains NO `Sort` or `Incremental Sort` node anywhere (US-27.7a).
+
+  This is the regression guard for `search_semantic`'s `total_count` query: pre-27.7a it
+  wrapped the results subquery (carrying `ORDER BY embedding <=> $vec`) in a `count(*)`,
+  so the planner did a pointless full-corpus **Sort** (~153ms / 405k buffers at 80k) just
+  to discard the order. A `count(*)` is order-independent, so the corrected query carries
+  NO ordering and the plan must be sort-free. A regression that re-introduces the ORDER BY
+  (or any sort) into the count trips this. (Bounding the scan itself is the job of
+  `refute_seq_scan/1` / `assert_scan_rows_below/2` on the same query.)
+  """
+  def refute_sort(queryable_or_sql) do
+    {root, raw} = explain_json(queryable_or_sql)
+
+    if node_type_present?(root, "Sort") or node_type_present?(root, "Incremental Sort") do
+      raise ExUnit.AssertionError,
+        message:
+          "Expected NO Sort node (a count is order-independent), but the plan contains one — " <>
+            "the pre-US-27.7a ORDER BY-in-the-count regression. Plan:\n#{elide(raw)}"
+    else
+      :ok
+    end
+  end
+
   # True if any node anywhere in the plan tree has the given Node Type.
   defp node_type_present?(node, type) when is_map(node) do
     here = node["Node Type"] == type


### PR DESCRIPTION
## US-27.7a — Route single-target top-k vector endpoints through the kNN helper

Migrates the three genuine single-target top-k consumers — **`suggested_links`**, **`search_semantic`**, and the **auto-link Oban worker** — onto the shared, scale-tested `Loopctl.Knowledge.VectorSearch` index-correct path, so the #168/#170/#172 failure class (a selective filter inside the index-ordered scan flipping the planner off HNSW) is made *structurally unreachable* in one place. Contract-preserving, tenant-isolation-preserving, and gated at the 80k prod floor (AC-27.7a.6).

### What changed

- **Helper** (`vector_search.ex`): extracted the inner pure-ANN top-`pool` subquery into `candidate_pool_query/4` (the `ORDER BY embedding <=> $const LIMIT pool` HNSW core, only index-safe residual filters); `candidate_query/4` builds its outer from it, and the US-27.6b under-fill probe reuses the **same** inner (invariant preserved by construction). Added `:project_id` / `:project_or_global` **outer** filters and `:status` / `:select` opts. Selective filters (project/category/tags) stay on the outer pool — never the inner — because they're in the `articles(tenant_id, project_id, category)` btree / tags GIN and would defeat HNSW.
- **suggested_links**: `suggestion_candidates_query/6` and the under-fill inner now delegate to the helper; pool sizing + the exact result/meta contract unchanged.
- **search_semantic**: EXPLAIN at 80k showed the old query (a) flipped to BitmapAnd+Sort and abandoned HNSW under selective category+tags, and (b) ran a pointless full-corpus Seq Scan + Sort (~153ms) for `total_count`. Rewrote to a relevance-pool model: RESULTS run the shared HNSW inner with selective filters on the outer pool, paginated within the pool; `total_count` is a **separate** full-corpus filtered `count(*)` with no `ORDER BY <=>` (≈20ms, sort-free) — its `ranked_corpus` meaning + JSON shape preserved. Results/count filter sets are identical, so `total_count` matches the result basis.
- **auto-link worker**: the similarity lookup routes through `VectorSearch.nearest/4` on the HeavyRead pool (was a bespoke `AdminRepo` cosine query) — a background pass can no longer silently full-scan. Self-exclusion, published-only, the "same-project OR tenant-wide" scope, and the inclusive `>= threshold` boundary are preserved.
- **Scale gate** (`topk_endpoints_scale_test.exs`, wired into the CI `scale_file` matrix): proves at 80k that suggested_links, search_semantic (results — incl. deep offset AND selective filters — and the sort-free, index-bounded count), and the worker lookup are each HNSW-backed / no unbounded Seq Scan.

### Consumer-facing additions (additive, contract-safe)

- **`meta.pool_capped`** (semantic + combined relevance modes): the relevance-pool surfaces the top-`cap` results, so the ranked+filtered set can exceed what pagination reaches. `pool_capped: true` (NOT silent — mirrors `recall_truncated` / keyset `next_cursor: null`) flags both cap-truncation AND selective-filter pool-starvation, so a consumer knows to switch to list mode for full enumeration. `false` means this query's results are complete.

### Behavior nuance for operators (by-design, documented)

- **Project-scope recall**: `project_id` filtering moved to the outer pool (mandatory to keep HNSW), so the worker (and filtered semantic search) link/rank among the **global-nearest pool that matches the project**, not the nearest-*within*-project. Equivalent for the small `k` / generous pools used; a pathological corpus where a project's matches all fall outside the global top-pool could under-fill — the same post-ANN-filter limitation `VectorSearch` already documents for tags/category. Deep pagination of filtered relevance search is bounded by the pool cap (signalled via `pool_capped`); full enumeration is the keyset list path (US-27.9a).

### Enhanced review — fully addressed (both rounds, zero deferrals)

- **Team (`0b839b9`)**: architect APPROVED clean (HNSW correctness, under-fill invariant, results/count filter parity, tenant isolation, cost bounds). Added the `meta.pool_capped` deep-offset truncation signal (BA), scoped the worker threshold-0.0 comment + documented/warned the `max_comparisons → max_k(100)` clamp (engineer/BA).
- **Adversarial (`60b13d1`)**: made `pool_capped` honest under selective filters (a convergent finding — `total_count > cap` alone was a false negative when a filter starves the pool below the cap); fixed a `status: nil` parity break (the inner forced `status == NULL` → empty results vs a non-zero count); propagated `pool_capped` through combined mode; clamped `offset` so an absurd value can't 500. The `nil > cap` / flaky-`== 5` crash hypotheses were disproved (scalar `count(*)` is never nil; assertions taken on the outer capped pool are deterministic).

### Verification

- `mix precommit` green (2891 tests) on a clean DB.
- suggested_links / semantic / worker / under-fill / search-controller suites green and contract-identical.
- `topk_endpoints_scale_test` + `vector_search_under_fill_scale_test` green at a **fresh 80k corpus** (the under-fill invariant survives the migration; the status nil-skip restructure preserves HNSW) — re-run after each review round.

Closes US-27.7a.
