### PR TITLE
US-27.8: per-endpoint vector scale gates + cosine-reintroduction lint (#168/#170/#172 standing guard)

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -1,0 +1,242 @@
+# This file contains the configuration for Credo and you are probably reading
+# this after creating it with `mix credo.gen.config`.
+#
+# If you find anything wrong or unclear in this file, please report an
+# issue on GitHub: https://github.com/rrrene/credo/issues
+#
+%{
+  #
+  # You can have as many configs as you like in the `configs:` field.
+  configs: [
+    %{
+      #
+      # Run any config using `mix credo -C <name>`. If no config name is given
+      # "default" is used.
+      #
+      name: "default",
+      #
+      # These are the files included in the analysis:
+      files: %{
+        #
+        # You can give explicit globs or simply directories.
+        # In the latter case `**/*.{ex,exs}` will be used.
+        #
+        included: [
+          "lib/",
+          "src/",
+          "test/",
+          "web/",
+          "apps/*/lib/",
+          "apps/*/src/",
+          "apps/*/test/",
+          "apps/*/web/"
+        ],
+        excluded: [~r"/_build/", ~r"/deps/", ~r"/node_modules/"]
+      },
+      #
+      # Load and configure plugins here:
+      #
+      plugins: [],
+      #
+      # If you create your own checks, you must specify the source files for
+      # them here, so they can be loaded by Credo before running the analysis.
+      #
+      # US-27.8 (AC-27.8.5): the cosine-`<=>` reintroduction guard lives OUTSIDE
+      # `lib/` so `mix compile` (any env, incl. `MIX_ENV=prod`) never drags it into
+      # the release — Credo `require`s it here, at Credo runtime (after compile).
+      #
+      # `mix credo` does NOT boot the app, so the app's compiled beams are NOT on the
+      # Credo VM code path (a runtime `Code.ensure_loaded` of an app module returns
+      # `:nofile`). The check reads its allowlist from
+      # `Loopctl.Knowledge.CosineLintExceptions`, so we `require` THAT source too — it
+      # is stdlib-only (no app deps), so Credo compiles+loads it standalone into its
+      # VM. Order matters: the registry source must precede the check.
+      requires: [
+        "lib/loopctl/knowledge/cosine_lint_exceptions.ex",
+        ".credo/checks/cosine_query_reintroduction.ex"
+      ],
+      #
+      # If you want to enforce a style guide and need a more traditional linting
+      # experience, you can change `strict` to `true` below:
+      #
+      strict: false,
+      #
+      # To modify the timeout for parsing files, change this value:
+      #
+      parse_timeout: 5000,
+      #
+      # If you want to use uncolored output by default, you can change `color`
+      # to `false` below:
+      #
+      color: true,
+      #
+      # You can customize the parameters of any check by adding a second element
+      # to the tuple.
+      #
+      # To disable a check put `false` as second element:
+      #
+      #     {Credo.Check.Design.DuplicatedCode, false}
+      #
+      checks: %{
+        enabled: [
+          #
+          ## Consistency Checks
+          #
+          {Credo.Check.Consistency.ExceptionNames, []},
+          {Credo.Check.Consistency.LineEndings, []},
+          {Credo.Check.Consistency.ParameterPatternMatching, []},
+          {Credo.Check.Consistency.SpaceAroundOperators, []},
+          {Credo.Check.Consistency.SpaceInParentheses, []},
+          {Credo.Check.Consistency.TabsOrSpaces, []},
+
+          #
+          ## Design Checks
+          #
+          # You can customize the priority of any check
+          # Priority values are: `low, normal, high, higher`
+          #
+          {Credo.Check.Design.AliasUsage,
+           [priority: :low, if_nested_deeper_than: 2, if_called_more_often_than: 0]},
+          {Credo.Check.Design.TagFIXME, []},
+          # You can also customize the exit_status of each check.
+          # If you don't want TODO comments to cause `mix credo` to fail, just
+          # set this value to 0 (zero).
+          #
+          {Credo.Check.Design.TagTODO, [exit_status: 2]},
+
+          #
+          ## Readability Checks
+          #
+          {Credo.Check.Readability.AliasOrder, []},
+          {Credo.Check.Readability.FunctionNames, []},
+          {Credo.Check.Readability.LargeNumbers, []},
+          {Credo.Check.Readability.MaxLineLength, [priority: :low, max_length: 120]},
+          {Credo.Check.Readability.ModuleAttributeNames, []},
+          {Credo.Check.Readability.ModuleDoc, []},
+          {Credo.Check.Readability.ModuleNames, []},
+          {Credo.Check.Readability.ParenthesesInCondition, []},
+          {Credo.Check.Readability.ParenthesesOnZeroArityDefs, []},
+          {Credo.Check.Readability.PipeIntoAnonymousFunctions, []},
+          {Credo.Check.Readability.PredicateFunctionNames, []},
+          {Credo.Check.Readability.PreferImplicitTry, []},
+          {Credo.Check.Readability.RedundantBlankLines, []},
+          {Credo.Check.Readability.Semicolons, []},
+          {Credo.Check.Readability.SpaceAfterCommas, []},
+          {Credo.Check.Readability.StringSigils, []},
+          {Credo.Check.Readability.TrailingBlankLine, []},
+          {Credo.Check.Readability.TrailingWhiteSpace, []},
+          {Credo.Check.Readability.UnnecessaryAliasExpansion, []},
+          {Credo.Check.Readability.VariableNames, []},
+          {Credo.Check.Readability.WithSingleClause, []},
+
+          #
+          ## Refactoring Opportunities
+          #
+          {Credo.Check.Refactor.Apply, []},
+          {Credo.Check.Refactor.CondStatements, []},
+          {Credo.Check.Refactor.CyclomaticComplexity, []},
+          {Credo.Check.Refactor.FilterCount, []},
+          {Credo.Check.Refactor.FilterFilter, []},
+          {Credo.Check.Refactor.FunctionArity, []},
+          {Credo.Check.Refactor.LongQuoteBlocks, []},
+          {Credo.Check.Refactor.MapJoin, []},
+          {Credo.Check.Refactor.MatchInCondition, []},
+          {Credo.Check.Refactor.NegatedConditionsInUnless, []},
+          {Credo.Check.Refactor.NegatedConditionsWithElse, []},
+          {Credo.Check.Refactor.Nesting, []},
+          {Credo.Check.Refactor.RedundantWithClauseResult, []},
+          {Credo.Check.Refactor.RejectReject, []},
+          {Credo.Check.Refactor.UnlessWithElse, []},
+          {Credo.Check.Refactor.WithClauses, []},
+
+          #
+          ## Warnings
+          #
+          {Credo.Check.Warning.ApplicationConfigInModuleAttribute, []},
+          {Credo.Check.Warning.BoolOperationOnSameValues, []},
+          {Credo.Check.Warning.Dbg, []},
+          {Credo.Check.Warning.ExpensiveEmptyEnumCheck, []},
+          {Credo.Check.Warning.IExPry, []},
+          {Credo.Check.Warning.IoInspect, []},
+          {Credo.Check.Warning.MissedMetadataKeyInLoggerConfig, []},
+          {Credo.Check.Warning.OperationOnSameValues, []},
+          {Credo.Check.Warning.OperationWithConstantResult, []},
+          {Credo.Check.Warning.RaiseInsideRescue, []},
+          {Credo.Check.Warning.SpecWithStruct, []},
+          {Credo.Check.Warning.StructFieldAmount, []},
+          {Credo.Check.Warning.UnsafeExec, []},
+          {Credo.Check.Warning.UnusedEnumOperation, []},
+          {Credo.Check.Warning.UnusedFileOperation, []},
+          {Credo.Check.Warning.UnusedKeywordOperation, []},
+          {Credo.Check.Warning.UnusedListOperation, []},
+          {Credo.Check.Warning.UnusedMapOperation, []},
+          {Credo.Check.Warning.UnusedPathOperation, []},
+          {Credo.Check.Warning.UnusedRegexOperation, []},
+          {Credo.Check.Warning.UnusedStringOperation, []},
+          {Credo.Check.Warning.UnusedTupleOperation, []},
+          {Credo.Check.Warning.WrongTestFilename, []},
+
+          #
+          ## Custom checks (US-27.8) — the cosine-`<=>` reintroduction guard.
+          ## Sourced via `requires:` above; ADDED to the full default set (no default
+          ## check is dropped or weakened — `mix credo --strict` runs every check it
+          ## ran before PLUS this one).
+          #
+          {Loopctl.Credo.Check.CosineQueryReintroduction, []}
+        ],
+        disabled: [
+          #
+          # Checks scheduled for next check update (opt-in for now)
+          {Credo.Check.Refactor.UtcNowTruncate, []},
+
+          #
+          # Controversial and experimental checks (opt-in, just move the check to `:enabled`
+          #   and be sure to use `mix credo --strict` to see low priority checks)
+          #
+          {Credo.Check.Consistency.MultiAliasImportRequireUse, []},
+          {Credo.Check.Consistency.UnusedVariableNames, []},
+          {Credo.Check.Design.DuplicatedCode, []},
+          {Credo.Check.Design.SkipTestWithoutComment, []},
+          {Credo.Check.Readability.AliasAs, []},
+          {Credo.Check.Readability.BlockPipe, []},
+          {Credo.Check.Readability.ImplTrue, []},
+          {Credo.Check.Readability.MultiAlias, []},
+          {Credo.Check.Readability.NestedFunctionCalls, []},
+          {Credo.Check.Readability.OneArityFunctionInPipe, []},
+          {Credo.Check.Readability.OnePipePerLine, []},
+          {Credo.Check.Readability.SeparateAliasRequire, []},
+          {Credo.Check.Readability.SingleFunctionToBlockPipe, []},
+          {Credo.Check.Readability.SinglePipe, []},
+          {Credo.Check.Readability.Specs, []},
+          {Credo.Check.Readability.StrictModuleLayout, []},
+          {Credo.Check.Readability.WithCustomTaggedTuple, []},
+          {Credo.Check.Refactor.ABCSize, []},
+          {Credo.Check.Refactor.AppendSingleItem, []},
+          {Credo.Check.Refactor.CondInsteadOfIfElse, []},
+          {Credo.Check.Refactor.DoubleBooleanNegation, []},
+          {Credo.Check.Refactor.FilterReject, []},
+          {Credo.Check.Refactor.IoPuts, []},
+          {Credo.Check.Refactor.MapMap, []},
+          {Credo.Check.Refactor.ModuleDependencies, []},
+          {Credo.Check.Refactor.NegatedIsNil, []},
+          {Credo.Check.Refactor.PassAsyncInTestCases, []},
+          {Credo.Check.Refactor.PipeChainStart, []},
+          {Credo.Check.Refactor.RejectFilter, []},
+          {Credo.Check.Refactor.VariableRebinding, []},
+          {Credo.Check.Warning.LazyLogging, []},
+          {Credo.Check.Warning.LeakyEnvironment, []},
+          {Credo.Check.Warning.MapGetUnsafePass, []},
+          {Credo.Check.Warning.MixEnv, []},
+          {Credo.Check.Warning.UnsafeToAtom, []}
+          # {Credo.Check.Warning.UnusedOperation, [{MyMagicModule, [:fun1, :fun2]}]}
+
+          # {Credo.Check.Refactor.MapInto, []},
+
+          #
+          # Custom checks can be created using `mix credo.gen.check`.
+          #
+        ]
+      }
+    }
+  ]
+}

--- a/.credo/checks/cosine_query_reintroduction.ex
+++ b/.credo/checks/cosine_query_reintroduction.ex
@@ -1,0 +1,283 @@
+defmodule Loopctl.Credo.Check.CosineQueryReintroduction do
+  @moduledoc """
+  Custom Credo check (US-27.8, AC-27.8.5): the cosine-`<=>` reintroduction guard.
+
+  ## What it catches
+
+  The `suggested_links` 500 shipped three times (#168/#170/#172) because a
+  hand-rolled cosine `ORDER BY embedding <=> $const` / distance query defeated the
+  HNSW index at prod scale. US-27.7a routed every single-target top-k through the
+  ONE sanctioned helper, `Loopctl.Knowledge.VectorSearch`, whose SQL shape is
+  scale-gated. This check makes "no new hand-rolled cosine site outside the helper"
+  a STANDING CI property: if a future edit reintroduces a raw `<=>` somewhere new,
+  `mix credo --strict` fails — at PR time, not in prod.
+
+  ## How it detects (pure AST, no process, no DB)
+
+  A cosine `<=>` only ever appears in loopctl source inside a **string literal**
+  passed to `fragment(...)` / raw SQL (e.g. `"? <=> ?"`, `"(? <=> ?) BETWEEN ..."`,
+  `"MIN(? <=> ?::vector)"`). So the check walks the source AST (`Credo.Code.prewalk`
+  is NOT used directly; we descend manually to keep each `<=>` attributed to its
+  ENCLOSING `def`/`defp`) and collects every binary-string node whose value contains
+  `"<=>"`, resolving for each:
+
+    * the enclosing `def`/`defp` **name + arity** (the nearest such ancestor — loopctl
+      never nests `def`s, so attribution is unambiguous), and
+    * the **module** (the file's `defmodule`).
+
+  ## Exemptions (the allowlist exempts the LINT, never the scale gate)
+
+  1. The whole `Loopctl.Knowledge.VectorSearch` module — it IS the sanctioned home of
+     the top-k `<=>` literal (`candidate_pool_query/4` + the two `pool_select/3`
+     similarity projections), so every `<=>` there is expected.
+  2. Any `{module, fun, arity}` registered in
+     `Loopctl.Knowledge.CosineLintExceptions` with a NON-EMPTY rationale — the
+     auditable list of the deliberately-different shapes that cannot route through
+     `nearest/4` (`do_distant_pairs/7` column-to-column self-join,
+     `novelty_distance_query/4` MIN-aggregate, and `nearest_prior_distance/4` its
+     documented owner).
+
+  This check reads the allowlist as **data** — `CosineLintExceptions.exceptions/0`
+  folded into a MapSet once per `run/2` — rather than calling `registered?/3` per site,
+  so there is no fragile runtime-call-from-a-check assumption (the constant is read at
+  Credo runtime, after `mix compile`, when the module is loaded). The non-empty-rationale
+  rule is honored: a blank rationale does NOT suppress (the entry never enters the set).
+
+  CRITICAL: this allowlist exempts only the LINT location. It does NOT exempt a bad
+  query shape from the scale plan-gate — an index-defeating change inside an allowlisted
+  function still fails `PlanAssertions.refute_full_scan`/`refute_seq_scan` at 80k
+  (proven by `cosine_lint_vs_scale_gate_scale_test.exs`).
+
+  Anything else → an issue naming the offending `M.f/a`, telling the author to route it
+  through `Loopctl.Knowledge.VectorSearch` or, if it is a justified exception, register
+  it (with a rationale) in `Loopctl.Knowledge.CosineLintExceptions`.
+  """
+
+  use Credo.Check,
+    id: "LOOPCTL_COSINE_REINTRODUCTION",
+    category: :warning,
+    base_priority: :high,
+    explanations: [
+      check: """
+      A hand-rolled cosine `<=>` distance / ORDER BY outside the shared
+      `Loopctl.Knowledge.VectorSearch` helper is forbidden: that exact SQL shape is
+      what defeated the HNSW index and shipped the `suggested_links` 500 three times
+      (#168/#170/#172). Route single-target top-k similarity through
+      `Loopctl.Knowledge.VectorSearch` (its shape is scale-gated). If the site is a
+      genuinely-different shape that cannot use `nearest/4` (a column-to-column
+      self-join, or a MIN aggregate), register it — with a one-line rationale — in
+      `Loopctl.Knowledge.CosineLintExceptions`, which this check reads as its allowlist.
+      """
+    ]
+
+  alias Loopctl.Knowledge.CosineLintExceptions
+
+  # The module that legitimately HOSTS the top-k `<=>` literal — exempt wholesale.
+  @vector_search_module Loopctl.Knowledge.VectorSearch
+
+  @doc false
+  def run(%Credo.SourceFile{} = source_file, params \\ []) do
+    if lib_source?(source_file) do
+      run_on_lib_source(source_file, params)
+    else
+      # The guard governs PRODUCTION query paths (`lib/`). `test/` builds deliberate
+      # raw probe queries (e.g. the under-fill gate's index-ordered `<=>` scan that
+      # models the exact rows the ANN draws) — those are test scaffolding, not the
+      # production rot this guard prevents, so they are out of scope.
+      []
+    end
+  end
+
+  # Only `lib/` source files are governed (AC-27.8.5 targets `lib/loopctl`). Match on
+  # the path so `test/`, `priv/`, `.credo/`, etc. are skipped. The check's own source
+  # lives under `.credo/` and is excluded here too (it would otherwise self-flag the
+  # `@sql_call_names`/doc `<=>` text — though detection is fragment-scoped, this is an
+  # explicit belt-and-braces).
+  defp lib_source?(%Credo.SourceFile{filename: filename}) when is_binary(filename) do
+    normalized = String.replace(filename, "\\", "/")
+    String.starts_with?(normalized, "lib/") or String.contains?(normalized, "/lib/")
+  end
+
+  defp lib_source?(_), do: false
+
+  defp run_on_lib_source(source_file, params) do
+    issue_meta = IssueMeta.for(source_file, params)
+    allowlist = allowlisted_mfa_set()
+
+    case Credo.Code.ast(source_file) do
+      {:ok, ast} ->
+        module = defmodule_name(ast)
+
+        if module == @vector_search_module do
+          # The helper's home — every `<=>` here is the sanctioned shape.
+          []
+        else
+          ast
+          |> cosine_sites(module)
+          |> Enum.reject(fn site ->
+            MapSet.member?(allowlist, {site.module, site.fun, site.arity})
+          end)
+          |> Enum.map(&issue_for(issue_meta, &1))
+        end
+
+      # An unparseable file is another check's problem (Credo reports the parse
+      # error itself); we simply find nothing to flag here.
+      _ ->
+        []
+    end
+  end
+
+  # The set of `{module, fun, arity}` whose rationale is non-empty — read from the
+  # auditable registry as DATA (no per-site runtime call). Mirrors
+  # `CosineLintExceptions.registered?/3`'s non-empty-rationale rule so a blank
+  # rationale can never silently suppress.
+  defp allowlisted_mfa_set do
+    # `mix credo` does not boot the app, so the compiled registry beam is on the code
+    # path but not yet loaded — `ensure_loaded/1` loads it from `_build`. It is plain
+    # `lib/` code (no app start needed), so this is safe and process-free. If it could
+    # NOT be loaded (it always can in dev/test), we FAIL CLOSED by raising rather than
+    # returning an empty set that would mis-flag the registered exceptions.
+    case Code.ensure_loaded(CosineLintExceptions) do
+      {:module, _} ->
+        CosineLintExceptions.exceptions()
+        |> Enum.filter(&non_empty_rationale?/1)
+        |> Enum.map(fn %{module: m, function: f, arity: a} -> {m, f, a} end)
+        |> MapSet.new()
+
+      {:error, reason} ->
+        raise "#{inspect(__MODULE__)} could not load " <>
+                "#{inspect(CosineLintExceptions)} (the cosine-lint allowlist): " <>
+                "#{inspect(reason)}. The check cannot run without its allowlist."
+    end
+  end
+
+  defp non_empty_rationale?(%{rationale: r}) when is_binary(r), do: String.trim(r) != ""
+  defp non_empty_rationale?(_), do: false
+
+  # The file's `defmodule` name (loopctl is one-module-per-file). nil if none.
+  defp defmodule_name(ast) do
+    {_, found} =
+      Macro.prewalk(ast, nil, fn
+        {:defmodule, _, [{:__aliases__, _, parts} | _]} = node, nil when is_list(parts) ->
+          {node, Module.concat(parts)}
+
+        node, acc ->
+          {node, acc}
+      end)
+
+    found
+  end
+
+  # Collect every cosine `<=>` site, attributed to its ENCLOSING `def`/`defp` (name +
+  # arity). We descend manually (NOT `prewalk`-flatten) so each site keeps its function
+  # scope AND the line of its enclosing call.
+  #
+  # DETECTION IS SCOPED TO SQL-BEARING CALLS — a binary containing `<=>` is flagged
+  # ONLY when it is the (first) argument of a `fragment(...)` call or a `*.query!`/
+  # `query`/`explain` raw-SQL call. This is deliberate: a `<=>` in a `@moduledoc`,
+  # `@doc`, comment, rationale-data string, or a Regex is documentation/data, NOT a
+  # hand-rolled query, and must NOT be flagged (those are how the allowlist, the plan
+  # assertions, and this very check DESCRIBE the operator). loopctl's every real cosine
+  # query goes through `fragment/_`, so this is both precise and complete for the rot
+  # the guard targets. A `<=>` site outside any `def` is still reported (`fun: nil`).
+  defp cosine_sites(ast, module) do
+    do_collect(ast, module, nil, nil, [])
+    |> Enum.reverse()
+  end
+
+  # SQL-bearing call names whose string arguments are real query text (where a `<=>`
+  # is a hand-rolled cosine site), as opposed to docstrings / data / regex literals.
+  @sql_call_names [:fragment, :query, :query!, :explain]
+
+  # State threaded down the walk:
+  #   * `scope` — the current `{fun, arity}` (nil at module level), set on `def`/`defp`.
+  #   * `line`  — the nearest ancestor call node's `meta[:line]`, stamped on a site.
+  defp do_collect({op, meta, [head | _] = args}, module, _scope, _line, acc)
+       when op in [:def, :defp] do
+    new_scope = def_scope(head)
+    new_line = meta[:line]
+
+    Enum.reduce(args, acc, fn child, inner ->
+      do_collect(child, module, new_scope, new_line, inner)
+    end)
+  end
+
+  # A SQL-bearing call: `fragment("…<=>…", …)`, `Repo.query!("…<=>…", …)`, etc. The
+  # call name may be bare (`{:fragment, _, args}`) or qualified
+  # (`{{:., _, [_mod, :query!]}, _, args}`). If ANY string arg holds `<=>`, record one
+  # site (the call's line), then keep descending so nested cosine fragments are caught.
+  defp do_collect({form, meta, children} = node, module, scope, line, acc)
+       when is_list(children) do
+    call_line = meta[:line] || line
+
+    acc =
+      if sql_call?(form) and Enum.any?(children, &cosine_string?/1) do
+        {fun, arity} = scope || {nil, nil}
+        [%{module: module, fun: fun, arity: arity, line: call_line, trigger: "<=>"} | acc]
+      else
+        acc
+      end
+
+    children = elem(node, 2)
+
+    Enum.reduce(children, acc, fn child, inner ->
+      do_collect(child, module, scope, call_line, inner)
+    end)
+  end
+
+  defp do_collect({left, right}, module, scope, line, acc) do
+    acc
+    |> then(&do_collect(left, module, scope, line, &1))
+    |> then(&do_collect(right, module, scope, line, &1))
+  end
+
+  defp do_collect(list, module, scope, line, acc) when is_list(list) do
+    Enum.reduce(list, acc, fn child, inner -> do_collect(child, module, scope, line, inner) end)
+  end
+
+  defp do_collect(_other, _module, _scope, _line, acc), do: acc
+
+  # A bare call name (`fragment`) or a qualified one (`Repo.query!`) whose final name
+  # is in @sql_call_names.
+  defp sql_call?(name) when is_atom(name), do: name in @sql_call_names
+  defp sql_call?({:., _, [_target, name]}) when is_atom(name), do: name in @sql_call_names
+  defp sql_call?(_), do: false
+
+  # True for a binary AST literal containing the cosine operator. (String literals are
+  # plain binaries in quoted AST; interpolated strings are `{:<<>>, …}` and never carry
+  # a raw `<=>` segment for our SQL purposes — fragment SQL is always a plain literal.)
+  defp cosine_string?(node) when is_binary(node), do: String.contains?(node, "<=>")
+  defp cosine_string?(_), do: false
+
+  # Resolve a `def`/`defp` head to `{name, arity}`. Handles guard heads
+  # (`def f(x) when g`), zero-arity (`def f`/`def f()`), and the parenthesised forms.
+  defp def_scope({:when, _, [inner | _]}), do: def_scope(inner)
+  defp def_scope({name, _, args}) when is_atom(name) and is_list(args), do: {name, length(args)}
+  defp def_scope({name, _, ctx}) when is_atom(name) and is_atom(ctx), do: {name, 0}
+  defp def_scope(_), do: {nil, nil}
+
+  defp issue_for(issue_meta, %{module: module, fun: fun, arity: arity} = site) do
+    mfa = format_mfa(module, fun, arity)
+
+    message =
+      "hand-rolled cosine `<=>` in #{mfa} outside Loopctl.Knowledge.VectorSearch — " <>
+        "route single-target top-k similarity through the shared helper " <>
+        "(Loopctl.Knowledge.VectorSearch), or, if it is a justified exception " <>
+        "(column-to-column self-join / MIN aggregate), register it with a rationale " <>
+        "in Loopctl.Knowledge.CosineLintExceptions."
+
+    opts =
+      [message: message, trigger: site.trigger]
+      |> maybe_put_line(site.line)
+
+    format_issue(issue_meta, opts)
+  end
+
+  defp maybe_put_line(opts, line) when is_integer(line), do: Keyword.put(opts, :line_no, line)
+  defp maybe_put_line(opts, _), do: opts
+
+  defp format_mfa(module, nil, _arity), do: "#{inspect(module)} (module-level)"
+
+  defp format_mfa(module, fun, arity),
+    do: "#{inspect(module)}.#{fun}/#{arity}"
+end

--- a/.credo/checks/cosine_query_reintroduction.ex
+++ b/.credo/checks/cosine_query_reintroduction.ex
@@ -14,30 +14,40 @@ defmodule Loopctl.Credo.Check.CosineQueryReintroduction do
 
   ## How it detects (pure AST, no process, no DB)
 
-  A cosine `<=>` reaches the database only inside a SQL string passed to `fragment(...)`
-  / a raw `query`/`query!`/`explain` call. So the check walks the source AST (descending
-  manually to keep each `<=>` attributed to its enclosing module + `def`/`defp`) and, for
-  every SQL-bearing call, DEEP-WALKS its argument subtrees for ANY binary literal
-  containing `"<=>"`. The deep walk is deliberate: the `<=>` may be a plain literal
-  (`fragment("? <=> ?", …)`), an INTERPOLATED string (`fragment("\#{col} <=> ?", …)` — the
-  `<=>` lives in a `{:<<>>, …}` segment), or a CONCATENATION (`fragment("? <=>" <> "?", …)`
-  — a `{:<>, …}` node). A shallow direct-child check would MISS the interpolated/concat
-  forms (the rot can be written with one interpolated token), so we recurse through the
-  arg trees. For each site it resolves:
+  A pgvector distance reaches the database only inside a SQL string passed to `fragment(...)`
+  or a raw-SQL call (`query`/`query!`/`query_many`/`query_many!`/`stream`/`explain`, bare or
+  qualified like `Repo.query!`). So the check walks the source AST (descending manually to
+  keep each site attributed to its enclosing module + `def`/`defp`) and, for every SQL-bearing
+  call, scans its SQL-template argument subtree(s) for ANY binary literal containing a pgvector
+  DISTANCE TOKEN — not just the `<=>` operator but the whole family `@distance_tokens`
+  (`<=>` / `<->` / `<#>` and the `cosine_distance(` / `l2_distance(` / `inner_product(`
+  function spellings), since each defeats the cosine HNSW index the same way (review F1). The
+  scan is a DEEP walk, deliberately: the token may be a plain literal (`fragment("? <=> ?", …)`),
+  an INTERPOLATED string (`fragment("\#{col} <=> ?", …)` — the token lives in a `{:<<>>, …}`
+  segment), or a CONCATENATION (`fragment("? <=>" <> "?", …)` — a `{:<>, …}` node). A shallow
+  direct-child check would MISS the interpolated/concat forms (the rot can be written with one
+  interpolated token), so we recurse through the arg trees. For `fragment` the SQL is ALWAYS
+  arg 1 (the rest are bound VALUES), so only arg 1 is scanned — a token in a value arg
+  (`fragment("?", "a <=> b")`) is NOT flagged (review F3); for the raw-SQL calls the SQL may be
+  arg 1 or arg 2, so all args are scanned. For each site it resolves:
 
     * the enclosing `def`/`defp` **name + arity** (the nearest such ancestor), and
     * the **enclosing module** — tracked through `defmodule` nodes during the walk, so a
       site in a NESTED module gets its own full name (`Outer.Inner`) and is exempted on its
       own module (the VectorSearch whole-module exemption can never wholesale-suppress a
-      rogue `<=>` in an unrelated module merely nested inside an exempt one).
+      rogue distance op in an unrelated module merely nested inside an exempt one).
 
   ### Residual boundary (documented)
 
-  A `<=>` SQL string assembled in a VARIABLE and then piped into `query!` (`sql = "… <=>
-  …"; Repo.query!(sql, …)`) is NOT caught — the call's argument is a var node, not a
-  literal, and tracking it would require data-flow analysis. loopctl builds every real
-  cosine query via `fragment` literals, so this boundary is currently empty; if a raw-SQL
-  var path is ever introduced, register it explicitly (or route it through the helper).
+  A distance SQL string that has no LITERAL at the call site is NOT caught — the AST has
+  nothing to scan there. Two forms: a string assembled in a VARIABLE then piped into a call
+  (`sql = "… <=> …"; Repo.query!(sql, …)`), or one held in a module ATTRIBUTE (`@q "… <=> …"`)
+  then referenced. Closing either needs data-flow analysis. loopctl builds every real cosine
+  query via `fragment` literals, so this boundary is currently empty in `lib/loopctl`; it is
+  backstopped COARSELY by the test-side file-set tripwire (a NEW lib file carrying a distance
+  token — including a var/attr literal — expands the discovered set and fails the regression
+  guard, forcing review). If a raw-SQL var/attr path is ever introduced, register it
+  explicitly or route it through the helper.
 
   ## Exemptions (the allowlist exempts the LINT, never the scale gate)
 
@@ -122,6 +132,9 @@ defmodule Loopctl.Credo.Check.CosineQueryReintroduction do
       {:ok, ast} ->
         ast
         |> cosine_sites()
+        # A nested distance fragment matches at both the outer + inner call → ONE logical
+        # site, so collapse duplicates by {module, fun, arity, line} (review F5).
+        |> Enum.uniq_by(fn s -> {s.module, s.fun, s.arity, s.line} end)
         |> Enum.reject(fn site -> exempt?(site, allowlist) end)
         |> Enum.map(&issue_for(issue_meta, &1))
 
@@ -184,9 +197,26 @@ defmodule Loopctl.Credo.Check.CosineQueryReintroduction do
     |> Enum.reverse()
   end
 
-  # SQL-bearing call names whose string arguments are real query text (where a `<=>`
-  # is a hand-rolled cosine site), as opposed to docstrings / data / regex literals.
-  @sql_call_names [:fragment, :query, :query!, :explain]
+  # SQL-bearing call names whose string arguments are real query text (where a distance
+  # site lives), as opposed to docstrings / data / regex literals. Covers every raw-SQL
+  # Ecto/Postgrex entrypoint (`query_many`/`stream` included — review SQL-1/SQL-2: those
+  # send arbitrary SQL too and a cosine ORDER BY through them must NOT slip past).
+  @sql_call_names [
+    :fragment,
+    :query,
+    :query!,
+    :query_many,
+    :query_many!,
+    :stream,
+    :explain
+  ]
+
+  # The pgvector distance spellings a hand-rolled site can use — ALL defeat the (cosine)
+  # HNSW index when put in an ORDER BY / distance filter outside the helper. The guard is
+  # NOT just the `<=>` OPERATOR: `cosine_distance(a,b)` is the SAME operation (review F1),
+  # and `<->` / `<#>` (and their function spellings) are the other pgvector distance ops
+  # that would equally full-scan since only the cosine HNSW index exists.
+  @distance_tokens ["<=>", "<->", "<#>", "cosine_distance(", "l2_distance(", "inner_product("]
 
   # State threaded down the walk:
   #   * `module` — the current enclosing module (nil before the first `defmodule`).
@@ -233,9 +263,9 @@ defmodule Loopctl.Credo.Check.CosineQueryReintroduction do
     call_line = meta[:line] || line
 
     acc =
-      if sql_call?(form) and Enum.any?(children, &arg_has_cosine?/1) do
+      if sql_call?(form) and cosine_in_sql_args?(form, children) do
         {fun, arity} = scope || {nil, nil}
-        [%{module: module, fun: fun, arity: arity, line: call_line, trigger: "<=>"} | acc]
+        [%{module: module, fun: fun, arity: arity, line: call_line, trigger: "distance"} | acc]
       else
         acc
       end
@@ -265,13 +295,29 @@ defmodule Loopctl.Credo.Check.CosineQueryReintroduction do
   defp sql_call?({:., _, [_target, name]}) when is_atom(name), do: name in @sql_call_names
   defp sql_call?(_), do: false
 
-  # Deep-walk an argument subtree for ANY binary literal containing `<=>` — so the cosine
-  # operator is caught whether the SQL string is a plain literal, an INTERPOLATED string
-  # (a `{:<<>>,…}` node with a `" <=> ?"` segment), or a CONCATENATION (`{:<>,…}`). Gated by
-  # `sql_call?` at the call site, so doc/comment/regex/data strings (never SQL-call args)
-  # are not examined. A var-held SQL string (not a literal) is the documented residual
-  # boundary — there is no literal to find.
-  defp arg_has_cosine?(node) when is_binary(node), do: String.contains?(node, "<=>")
+  # Which args carry the SQL TEMPLATE to scan for a distance token:
+  #   * `fragment` — the SQL is ALWAYS the FIRST arg; the rest are bound VALUES. Scan ONLY
+  #     arg 1, so a distance token appearing in a bound value (`fragment("?", "a <=> b")`)
+  #     is NOT a false-positive (review F3). `fragment` never carries SQL in a later arg.
+  #   * raw-SQL calls (`query`/`query!`/`query_many`/`stream`/`explain`, bare or qualified)
+  #     — the SQL can be arg 1 (`Repo.query(sql, …)`) OR arg 2 (`SQL.query(repo, sql, …)`),
+  #     so scan ALL args (favoring no-false-NEGATIVE over the rare false-positive of a
+  #     non-Ecto same-named call — review F4, a documented accepted edge).
+  defp cosine_in_sql_args?(:fragment, [template | _]), do: arg_has_cosine?(template)
+  defp cosine_in_sql_args?(:fragment, []), do: false
+  defp cosine_in_sql_args?(_other, children), do: Enum.any?(children, &arg_has_cosine?/1)
+
+  # Deep-walk an argument subtree for ANY binary literal containing a pgvector DISTANCE
+  # token (`@distance_tokens` — the `<=>`/`<->`/`<#>` operators AND the `cosine_distance(`/
+  # `l2_distance(`/`inner_product(` function spellings; review F1). Caught whether the SQL
+  # string is a plain literal, an INTERPOLATED string (a `{:<<>>,…}` node with the token in a
+  # segment), or a literal CONCATENATION (`{:<>,…}`). Gated by `sql_call?` + the template-arg
+  # selection above, so doc/comment/regex/value-data strings are not examined. RESIDUAL
+  # (documented, requires data-flow to close — currently empty in lib/loopctl): a distance
+  # token held in a VARIABLE or a module ATTRIBUTE then passed to the call — there is no
+  # literal at the call site to find.
+  defp arg_has_cosine?(node) when is_binary(node),
+    do: Enum.any?(@distance_tokens, &String.contains?(node, &1))
 
   defp arg_has_cosine?({_, _, children}) when is_list(children),
     do: Enum.any?(children, &arg_has_cosine?/1)
@@ -291,9 +337,9 @@ defmodule Loopctl.Credo.Check.CosineQueryReintroduction do
     mfa = format_mfa(module, fun, arity)
 
     message =
-      "hand-rolled cosine `<=>` in #{mfa} outside Loopctl.Knowledge.VectorSearch — " <>
-        "route single-target top-k similarity through the shared helper " <>
-        "(Loopctl.Knowledge.VectorSearch), or, if it is a justified exception " <>
+      "hand-rolled pgvector distance (`<=>`/`cosine_distance(`/…) in #{mfa} outside " <>
+        "Loopctl.Knowledge.VectorSearch — route single-target top-k similarity through the " <>
+        "shared helper (Loopctl.Knowledge.VectorSearch), or, if it is a justified exception " <>
         "(column-to-column self-join / MIN aggregate), register it with a rationale " <>
         "in Loopctl.Knowledge.CosineLintExceptions."
 

--- a/.credo/checks/cosine_query_reintroduction.ex
+++ b/.credo/checks/cosine_query_reintroduction.ex
@@ -14,16 +14,30 @@ defmodule Loopctl.Credo.Check.CosineQueryReintroduction do
 
   ## How it detects (pure AST, no process, no DB)
 
-  A cosine `<=>` only ever appears in loopctl source inside a **string literal**
-  passed to `fragment(...)` / raw SQL (e.g. `"? <=> ?"`, `"(? <=> ?) BETWEEN ..."`,
-  `"MIN(? <=> ?::vector)"`). So the check walks the source AST (`Credo.Code.prewalk`
-  is NOT used directly; we descend manually to keep each `<=>` attributed to its
-  ENCLOSING `def`/`defp`) and collects every binary-string node whose value contains
-  `"<=>"`, resolving for each:
+  A cosine `<=>` reaches the database only inside a SQL string passed to `fragment(...)`
+  / a raw `query`/`query!`/`explain` call. So the check walks the source AST (descending
+  manually to keep each `<=>` attributed to its enclosing module + `def`/`defp`) and, for
+  every SQL-bearing call, DEEP-WALKS its argument subtrees for ANY binary literal
+  containing `"<=>"`. The deep walk is deliberate: the `<=>` may be a plain literal
+  (`fragment("? <=> ?", …)`), an INTERPOLATED string (`fragment("\#{col} <=> ?", …)` — the
+  `<=>` lives in a `{:<<>>, …}` segment), or a CONCATENATION (`fragment("? <=>" <> "?", …)`
+  — a `{:<>, …}` node). A shallow direct-child check would MISS the interpolated/concat
+  forms (the rot can be written with one interpolated token), so we recurse through the
+  arg trees. For each site it resolves:
 
-    * the enclosing `def`/`defp` **name + arity** (the nearest such ancestor — loopctl
-      never nests `def`s, so attribution is unambiguous), and
-    * the **module** (the file's `defmodule`).
+    * the enclosing `def`/`defp` **name + arity** (the nearest such ancestor), and
+    * the **enclosing module** — tracked through `defmodule` nodes during the walk, so a
+      site in a NESTED module gets its own full name (`Outer.Inner`) and is exempted on its
+      own module (the VectorSearch whole-module exemption can never wholesale-suppress a
+      rogue `<=>` in an unrelated module merely nested inside an exempt one).
+
+  ### Residual boundary (documented)
+
+  A `<=>` SQL string assembled in a VARIABLE and then piped into `query!` (`sql = "… <=>
+  …"; Repo.query!(sql, …)`) is NOT caught — the call's argument is a var node, not a
+  literal, and tracking it would require data-flow analysis. loopctl builds every real
+  cosine query via `fragment` literals, so this boundary is currently empty; if a raw-SQL
+  var path is ever introduced, register it explicitly (or route it through the helper).
 
   ## Exemptions (the allowlist exempts the LINT, never the scale gate)
 
@@ -106,25 +120,24 @@ defmodule Loopctl.Credo.Check.CosineQueryReintroduction do
 
     case Credo.Code.ast(source_file) do
       {:ok, ast} ->
-        module = defmodule_name(ast)
-
-        if module == @vector_search_module do
-          # The helper's home — every `<=>` here is the sanctioned shape.
-          []
-        else
-          ast
-          |> cosine_sites(module)
-          |> Enum.reject(fn site ->
-            MapSet.member?(allowlist, {site.module, site.fun, site.arity})
-          end)
-          |> Enum.map(&issue_for(issue_meta, &1))
-        end
+        ast
+        |> cosine_sites()
+        |> Enum.reject(fn site -> exempt?(site, allowlist) end)
+        |> Enum.map(&issue_for(issue_meta, &1))
 
       # An unparseable file is another check's problem (Credo reports the parse
       # error itself); we simply find nothing to flag here.
       _ ->
         []
     end
+  end
+
+  # A site is exempt iff its ENCLOSING module is the sanctioned VectorSearch helper
+  # (per-MODULE, not per-file — a rogue `<=>` in a module merely nested inside an exempt
+  # one is still flagged), OR its `{module, fun, arity}` is in the auditable allowlist.
+  defp exempt?(site, allowlist) do
+    site.module == @vector_search_module or
+      MapSet.member?(allowlist, {site.module, site.fun, site.arity})
   end
 
   # The set of `{module, fun, arity}` whose rationale is non-empty — read from the
@@ -154,34 +167,20 @@ defmodule Loopctl.Credo.Check.CosineQueryReintroduction do
   defp non_empty_rationale?(%{rationale: r}) when is_binary(r), do: String.trim(r) != ""
   defp non_empty_rationale?(_), do: false
 
-  # The file's `defmodule` name (loopctl is one-module-per-file). nil if none.
-  defp defmodule_name(ast) do
-    {_, found} =
-      Macro.prewalk(ast, nil, fn
-        {:defmodule, _, [{:__aliases__, _, parts} | _]} = node, nil when is_list(parts) ->
-          {node, Module.concat(parts)}
-
-        node, acc ->
-          {node, acc}
-      end)
-
-    found
-  end
-
-  # Collect every cosine `<=>` site, attributed to its ENCLOSING `def`/`defp` (name +
-  # arity). We descend manually (NOT `prewalk`-flatten) so each site keeps its function
-  # scope AND the line of its enclosing call.
+  # Collect every cosine `<=>` site, attributed to its ENCLOSING module + `def`/`defp`
+  # (name + arity). We descend manually (NOT `prewalk`-flatten) so each site keeps its
+  # module + function scope AND the line of its enclosing call.
   #
-  # DETECTION IS SCOPED TO SQL-BEARING CALLS — a binary containing `<=>` is flagged
-  # ONLY when it is the (first) argument of a `fragment(...)` call or a `*.query!`/
-  # `query`/`explain` raw-SQL call. This is deliberate: a `<=>` in a `@moduledoc`,
-  # `@doc`, comment, rationale-data string, or a Regex is documentation/data, NOT a
-  # hand-rolled query, and must NOT be flagged (those are how the allowlist, the plan
-  # assertions, and this very check DESCRIBE the operator). loopctl's every real cosine
-  # query goes through `fragment/_`, so this is both precise and complete for the rot
-  # the guard targets. A `<=>` site outside any `def` is still reported (`fun: nil`).
-  defp cosine_sites(ast, module) do
-    do_collect(ast, module, nil, nil, [])
+  # DETECTION IS SCOPED TO SQL-BEARING CALLS — a `<=>` is flagged ONLY when it appears in
+  # an argument subtree of a `fragment(...)` / `*.query!`/`query`/`explain` raw-SQL call.
+  # This is deliberate: a `<=>` in a `@moduledoc`, `@doc`, comment, rationale-data string,
+  # or a Regex is documentation/data, NOT a hand-rolled query, and must NOT be flagged
+  # (those are how the allowlist, the plan assertions, and this very check DESCRIBE the
+  # operator). loopctl's every real cosine query goes through `fragment/_`, so this is both
+  # precise and complete for the rot the guard targets. A `<=>` site outside any `def` is
+  # still reported (`fun: nil`).
+  defp cosine_sites(ast) do
+    do_collect(ast, nil, nil, nil, [])
     |> Enum.reverse()
   end
 
@@ -190,8 +189,30 @@ defmodule Loopctl.Credo.Check.CosineQueryReintroduction do
   @sql_call_names [:fragment, :query, :query!, :explain]
 
   # State threaded down the walk:
-  #   * `scope` — the current `{fun, arity}` (nil at module level), set on `def`/`defp`.
-  #   * `line`  — the nearest ancestor call node's `meta[:line]`, stamped on a site.
+  #   * `module` — the current enclosing module (nil before the first `defmodule`).
+  #   * `scope`  — the current `{fun, arity}` (nil at module level), set on `def`/`defp`.
+  #   * `line`   — the nearest ancestor call node's `meta[:line]`, stamped on a site.
+
+  # Entering a (possibly nested) module sets the module for its body — a NESTED module
+  # gets the full concatenated name (`Outer.Inner`) so its sites are attributed and
+  # exempted on their OWN module, never wholesale-suppressed by an enclosing exempt one.
+  # A new module resets the def scope.
+  defp do_collect(
+         {:defmodule, _meta, [{:__aliases__, _, parts} | rest]},
+         module,
+         _scope,
+         line,
+         acc
+       )
+       when is_list(parts) do
+    new_module = if module, do: Module.concat([module | parts]), else: Module.concat(parts)
+
+    Enum.reduce(rest, acc, fn child, inner ->
+      do_collect(child, new_module, nil, line, inner)
+    end)
+  end
+
+  # A `def`/`defp` sets the `{fun, arity}` scope for its body.
   defp do_collect({op, meta, [head | _] = args}, module, _scope, _line, acc)
        when op in [:def, :defp] do
     new_scope = def_scope(head)
@@ -202,16 +223,17 @@ defmodule Loopctl.Credo.Check.CosineQueryReintroduction do
     end)
   end
 
-  # A SQL-bearing call: `fragment("…<=>…", …)`, `Repo.query!("…<=>…", …)`, etc. The
-  # call name may be bare (`{:fragment, _, args}`) or qualified
-  # (`{{:., _, [_mod, :query!]}, _, args}`). If ANY string arg holds `<=>`, record one
-  # site (the call's line), then keep descending so nested cosine fragments are caught.
+  # A SQL-bearing call: `fragment("…<=>…", …)`, `Repo.query!("…<=>…", …)`, etc. (bare or
+  # qualified). Record ONE site if ANY argument SUBTREE contains a `<=>` binary —
+  # DEEP-WALKED, so an interpolated (`{:<<>>,…}`) or concatenated (`{:<>,…}`) SQL string is
+  # caught, not just a plain direct-child literal. Then keep descending so nested cosine
+  # fragments are still found.
   defp do_collect({form, meta, children} = node, module, scope, line, acc)
        when is_list(children) do
     call_line = meta[:line] || line
 
     acc =
-      if sql_call?(form) and Enum.any?(children, &cosine_string?/1) do
+      if sql_call?(form) and Enum.any?(children, &arg_has_cosine?/1) do
         {fun, arity} = scope || {nil, nil}
         [%{module: module, fun: fun, arity: arity, line: call_line, trigger: "<=>"} | acc]
       else
@@ -243,11 +265,20 @@ defmodule Loopctl.Credo.Check.CosineQueryReintroduction do
   defp sql_call?({:., _, [_target, name]}) when is_atom(name), do: name in @sql_call_names
   defp sql_call?(_), do: false
 
-  # True for a binary AST literal containing the cosine operator. (String literals are
-  # plain binaries in quoted AST; interpolated strings are `{:<<>>, …}` and never carry
-  # a raw `<=>` segment for our SQL purposes — fragment SQL is always a plain literal.)
-  defp cosine_string?(node) when is_binary(node), do: String.contains?(node, "<=>")
-  defp cosine_string?(_), do: false
+  # Deep-walk an argument subtree for ANY binary literal containing `<=>` — so the cosine
+  # operator is caught whether the SQL string is a plain literal, an INTERPOLATED string
+  # (a `{:<<>>,…}` node with a `" <=> ?"` segment), or a CONCATENATION (`{:<>,…}`). Gated by
+  # `sql_call?` at the call site, so doc/comment/regex/data strings (never SQL-call args)
+  # are not examined. A var-held SQL string (not a literal) is the documented residual
+  # boundary — there is no literal to find.
+  defp arg_has_cosine?(node) when is_binary(node), do: String.contains?(node, "<=>")
+
+  defp arg_has_cosine?({_, _, children}) when is_list(children),
+    do: Enum.any?(children, &arg_has_cosine?/1)
+
+  defp arg_has_cosine?({left, right}), do: arg_has_cosine?(left) or arg_has_cosine?(right)
+  defp arg_has_cosine?(list) when is_list(list), do: Enum.any?(list, &arg_has_cosine?/1)
+  defp arg_has_cosine?(_), do: false
 
   # Resolve a `def`/`defp` head to `{name, arity}`. Handles guard heads
   # (`def f(x) when g`), zero-arity (`def f`/`def f()`), and the parenthesised forms.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,6 +325,9 @@ jobs:
           - test/loopctl/knowledge/by_source_change_feed_plan_scale_test.exs
           - test/loopctl/knowledge/streaming_export_scale_test.exs
           - test/loopctl/knowledge/distant_pairs_novelty_scale_test.exs
+          - test/loopctl/knowledge/cosine_lint_vs_scale_gate_scale_test.exs
+          - test/loopctl/knowledge/scale_calibration_mismatch_scale_test.exs
+          - test/loopctl/knowledge/vector_endpoint_e2e_latency_scale_test.exs
     services:
       postgres:
         image: pgvector/pgvector:pg16

--- a/config/config.exs
+++ b/config/config.exs
@@ -19,6 +19,14 @@ config :loopctl,
   # 0.8+ is only useful for near-duplicate detection.
   article_link_threshold: 0.6,
   article_link_max_comparisons: 50,
+  # US-27.8 (AC-27.8.4/.6): ADVISORY end-to-end wall-clock budget (ms) for the vector
+  # scale gate's timed HTTP requests (suggested_links / semantic search) at the prod
+  # floor. SECONDARY to the deterministic plan assertion (index-backed, no full-corpus
+  # Sort), which is the real gate; this generous budget catches a serialize/round-trip
+  # blow-up without flaking on shared CI hardware. 2000 = the Theme-2 "<2s" target. Tune
+  # UP as prod grows beyond the current ScaleSeed floor (a documented step, like bumping
+  # @prod_article_floor) — never silently.
+  scale_latency_budget_ms: 2_000,
   # US-27.4: log any query slower than this (ms) via the SlowQueryLogger telemetry
   # handler. Tunable in config/env without a code change.
   slow_query_threshold_ms: 1_000,

--- a/docs/runbooks/knowledge-scale.md
+++ b/docs/runbooks/knowledge-scale.md
@@ -568,3 +568,63 @@ _time:1h "mapped_code=db_statement_timeout" "tenant_id=<TENANT_UUID>"
 For slow-read latency by tenant, query the US-27.4 `slow_query` lines
 (`"slow_query" "tenant_id=<TENANT_UUID>"`). Lower `:slow_query_threshold_ms` to widen what
 the logs capture if needed (see the slow-query section above).
+
+## Standing vector-endpoint CI gates (US-27.8)
+
+US-27.8 turns "ALL vector endpoints index-backed + under budget at prod scale" into
+**standing CI properties** so a future regression fails CI, not prod. There are two kinds
+of gate, and they are independent:
+
+### 1. The cosine-`<=>` reintroduction lint (runs in the `lint` CI job)
+
+`mix credo --strict` runs a custom check,
+`Loopctl.Credo.Check.CosineQueryReintroduction`, that FAILS the build if a NEW hand-rolled
+cosine `<=>` (in a `fragment(...)` / raw SQL) appears in `lib/loopctl` **outside** the
+sanctioned helper `Loopctl.Knowledge.VectorSearch` and **not** in the auditable allowlist
+`Loopctl.Knowledge.CosineLintExceptions`.
+
+- The check lives in `.credo/checks/cosine_query_reintroduction.ex` (OUTSIDE `lib/`, so
+  `MIX_ENV=prod mix compile` never drags it into the release) and is loaded by Credo via
+  `.credo.exs` `requires:`. `.credo.exs` is the full `mix credo.gen.config` default set
+  PLUS this one check — no default check is dropped or weakened.
+- **Adding a legitimately-different cosine shape?** Register `{module, function, arity}`
+  (with a non-empty one-line rationale) in `Loopctl.Knowledge.CosineLintExceptions` — a
+  visible, reviewable diff — instead of an inline comment the lint can't see.
+- **CRITICAL:** the allowlist exempts only the LINT location. It does NOT exempt a bad
+  query SHAPE from the scale plan-gate — an index-defeating change inside an allowlisted
+  function STILL fails `refute_full_scan`/`refute_seq_scan` at 80k (proven by
+  `cosine_lint_vs_scale_gate_scale_test.exs`).
+
+### 2. The per-endpoint scale gates (run in the `Scale Nightly` matrix)
+
+Every vector path carries an 80k index-usage gate on its REAL request-path query:
+`suggested_links` + `search_semantic` (results + count) + the auto-link worker
+(`topk_endpoints_scale_test.exs`), `distant_pairs` + `novelty`
+(`distant_pairs_novelty_scale_test.exs`). Each `:scale_nightly` file is in the
+`.github/workflows/ci.yml` `scale_file` matrix; `scale_verification_runbook_test.exs`
+enforces set-equality so coverage can't silently erode.
+
+**End-to-end wall-clock latency (`vector_endpoint_e2e_latency_scale_test.exs`).** The
+PRIMARY signal is the deterministic plan assertion (index-backed, no full-corpus Sort).
+SECONDARY/ADVISORY is a wall-clock budget measured through the REAL HTTP endpoint (a timed
+`Phoenix.ConnTest` request: auth + RLS + query + serialize + render) for `suggested_links`
+and `semantic` search:
+
+- Budget config: **`:scale_latency_budget_ms`** (default **2000ms** — the Theme-2 "<2s"
+  target). Deliberately generous so it does not flake on shared CI hardware; the plan gate
+  is the real arbiter. **Tune it UP** as prod grows beyond the floor — a documented step,
+  never a silent default (AC-27.8.6).
+
+**Calibration is asserted, not assumed (`scale_calibration_mismatch_scale_test.exs`).**
+
+- **Seed floor.** The vector gates call `PlanAssertions.assert_scale_floor!/1`, which
+  RAISES a clear calibration error if the seeded tenant has fewer than
+  `Loopctl.Knowledge.ScaleSeed.prod_article_floor/0` (currently **80_000**) committed
+  articles — a sub-floor gate is theatre (the planner Seq-Scans happily at toy scale and an
+  index-usage assertion false-greens). **Bumping the floor** as prod grows = update
+  `@prod_article_floor` in `Loopctl.Knowledge.ScaleSeed` (a documented step).
+- **`hnsw.ef_search` parity.** The under-fill gate asserts the EFFECTIVE `ef_search`
+  (`SHOW hnsw.ef_search`) is identical on the gate connection and a prod-shaped one; the
+  calibration test proves the FAILURE direction (a divergent value RAISES). When US-27.11's
+  `ALTER ROLE … SET hnsw.ef_search = N` lands a non-default value, update the `== "40"` pin
+  in `vector_search_under_fill_scale_test.exs` to the new value.

--- a/docs/runbooks/knowledge_scale_verification.md
+++ b/docs/runbooks/knowledge_scale_verification.md
@@ -98,9 +98,21 @@ which is the distinction that produced the false-green in #172.
   ADVISORY end-to-end wall-clock budget measured through the real HTTP conn
   (`vector_endpoint_e2e_latency_scale_test.exs`, `:scale_latency_budget_ms` default 2000ms).
   Calibration is asserted, not assumed: a sub-floor seed or `ef_search` mismatch FAILS
-  loudly (`scale_calibration_mismatch_scale_test.exs`). See the **Standing vector-endpoint
-  CI gates (US-27.8)** section of [`knowledge-scale.md`](knowledge-scale.md) for the lint
-  guard, the latency-budget/seed-floor knobs, and the floor-bump step.
+  loudly (`scale_calibration_mismatch_scale_test.exs`) — and the `ef_search` failure
+  direction now drives a REAL `SET LOCAL hnsw.ef_search` session divergence (read back via
+  `SHOW`), not a synthetic string compare, so the parity gate is proven against the actual
+  pgvector GUC. See the **Standing vector-endpoint CI gates (US-27.8)** section of
+  [`knowledge-scale.md`](knowledge-scale.md) for the lint guard, the latency-budget/seed-floor
+  knobs, and the floor-bump step.
+  - **PARTIAL COVERAGE (AC-27.8.4) — know exactly what the e2e timing does NOT cover.** In
+    `:test` the heavy-read DI routes through `AdminRepo`, NOT the dedicated `HeavyReadRepo`
+    pool, so the `vector_endpoint_e2e_latency_scale_test.exs` wall-clock does **not** exercise
+    the heavy-pool checkout / pool-level `statement_timeout` dimension. That dimension is
+    covered SEPARATELY by the per-request-timeout assertions on the worst-case ANN and deep
+    keyset page (the bullet above; `topk_endpoints_scale_test.exs`). The e2e test's distinct
+    value is the full HTTP path (auth → RLS context → query → serialize → render) wall-clock;
+    do not read a green e2e budget as evidence the heavy pool behaves under load — that is the
+    timeout bullet's job.
 - **No cosine-`<=>` reintroduction (US-27.8, the `lint` job)** — `mix credo --strict` runs
   the `Loopctl.Credo.Check.CosineQueryReintroduction` custom check, which fails the build
   if a NEW hand-rolled cosine `<=>` appears in `lib/loopctl` outside
@@ -114,15 +126,25 @@ It runs in two places:
   schedule, as a **matrix — one isolated job per scale file** (each with a fresh Postgres,
   so a committed-row corpus from one file can't pollute another's global planner stats).
   Each leg runs `SCALE_TESTS=true SCALE_NIGHTLY=true mix test --only scale_nightly <file>`.
-  Across the matrix it covers `scale_seed_nightly_test.exs`, `vector_search_scale_test.exs`,
-  `plan_assertions_scale_test.exs`, and `keyset_plan_scale_test.exs`. The matrix list is
-  kept in lock-step with the tagged files by `scale_verification_runbook_test.exs` (set-equality).
-- **Before merging any Theme 2/3/4 (vector / timeout / pagination) PR** — the gate is
-  schedule-only in CI (4×80k seeds is too slow for every PR, and there is no always-on
-  staging env), so a perf PR is verified pre-merge by EITHER:
+  The matrix covers **every `:scale_nightly`-tagged file** (the US-27.1 seed-floor check, the
+  HNSW ANN / keyset / shared-assertion plan gates, and the US-27.8 per-endpoint index-usage,
+  e2e-latency, and calibration-mismatch gates). The exact list is NOT enumerated here on
+  purpose — it is kept in lock-step with the tagged files by `scale_verification_runbook_test.exs`
+  (set-equality, both directions), so this prose can't go stale as files are added.
+- **Don't confuse the per-PR `Scale Tests` job with the nightly plan GATE (E3).** A separate
+  job, **`Scale Tests (US-27.1)`**, DOES run on every push/PR — but it runs only
+  `--only scale .../scale_seed_test.exs`: it proves the seed/fixture machinery (and its
+  `OwnershipError`-class regressions) still works, NOT the 80k planner paths. The
+  `:scale_nightly` plan gate (index-backed shape, per-request timeout, e2e latency,
+  calibration) is **schedule/dispatch-only** — a green `Scale Tests ✓` on your PR is **not**
+  evidence the plan gates ran. Tag discipline: a new 80k plan assertion must be `:scale_nightly`
+  (so the matrix + set-equality test pick it up), not `:scale`.
+- **Before merging any Theme 2/3/4 (vector / timeout / pagination) PR** — the plan gate is
+  schedule-only in CI (each leg reseeds ~80k committed rows — too slow for every PR, and there
+  is no always-on staging env), so a perf PR is verified pre-merge by EITHER:
   1. **triggering the gate on your branch** — `gh workflow run CI --ref <your-branch>`
-     (the `workflow_dispatch` trigger runs the full matrix on the branch; confirm all four
-     legs go green), OR
+     (the `workflow_dispatch` trigger runs the full matrix on the branch; confirm EVERY
+     leg goes green), OR
   2. **running it locally** against the seed:
 
   ```sh

--- a/docs/runbooks/knowledge_scale_verification.md
+++ b/docs/runbooks/knowledge_scale_verification.md
@@ -91,6 +91,22 @@ which is the distinction that produced the false-green in #172.
   **overrides** (`:heavy_read_statement_timeout_overrides`) are unit-tested
   (`heavy_read_statement_timeout_test.exs`), NOT scale-tested — the scale gate covers the
   backstop that actually protects prod, not every override permutation.
+- **Per-endpoint index-usage + END-TO-END latency (US-27.8)** — every vector path
+  (`suggested_links`, `semantic` search results + count, `distant_pairs`, `novelty`, AND
+  the auto-link worker) carries an 80k index-usage gate on its REAL request-path query
+  (`topk_endpoints_scale_test.exs`, `distant_pairs_novelty_scale_test.exs`), plus an
+  ADVISORY end-to-end wall-clock budget measured through the real HTTP conn
+  (`vector_endpoint_e2e_latency_scale_test.exs`, `:scale_latency_budget_ms` default 2000ms).
+  Calibration is asserted, not assumed: a sub-floor seed or `ef_search` mismatch FAILS
+  loudly (`scale_calibration_mismatch_scale_test.exs`). See the **Standing vector-endpoint
+  CI gates (US-27.8)** section of [`knowledge-scale.md`](knowledge-scale.md) for the lint
+  guard, the latency-budget/seed-floor knobs, and the floor-bump step.
+- **No cosine-`<=>` reintroduction (US-27.8, the `lint` job)** — `mix credo --strict` runs
+  the `Loopctl.Credo.Check.CosineQueryReintroduction` custom check, which fails the build
+  if a NEW hand-rolled cosine `<=>` appears in `lib/loopctl` outside
+  `Loopctl.Knowledge.VectorSearch` and not in the `Loopctl.Knowledge.CosineLintExceptions`
+  allowlist. The allowlist exempts the LINT location only — never a bad SHAPE from the plan
+  gate above.
 
 It runs in two places:
 

--- a/lib/loopctl/knowledge/cosine_lint_exceptions.ex
+++ b/lib/loopctl/knowledge/cosine_lint_exceptions.ex
@@ -12,20 +12,20 @@ defmodule Loopctl.Knowledge.CosineLintExceptions do
   prevent that shape from being reintroduced ad hoc.
 
   This registry is NOT a claim that no other `<=>` exists in the codebase — it is the
-  auditable list of the TWO US-27.7b-owned exceptions (distant_pairs + novelty). The broader
-  cosine-site inventory and the lint's full exemption policy are US-27.8's design. For
-  context, the other known cosine sites the US-27.8 lint must account for (NOT registered
-  here — out of US-27.7b's scope) are:
+  auditable list of the cosine exceptions in `Loopctl.Knowledge` (distant_pairs + novelty).
+  The US-27.8 lint (`Loopctl.Credo.Check.CosineQueryReintroduction`) is now LIVE and reads
+  this registry as its allowlist. Its full exemption policy — DECIDED in US-27.8 — is:
 
     * `Loopctl.Knowledge.VectorSearch`'s own query builders (e.g. `candidate_query/4`) —
       they necessarily CONTAIN the `<=>` literal because that module IS the sanctioned top-k
-      helper; US-27.8 will exempt the whole `VectorSearch` module as its home, not via this
-      per-function registry.
-    * `Loopctl.Knowledge.suggestion_candidates_query/6` — a known, intentional INLINE top-k
-      `ORDER BY embedding <=> $const LIMIT pool` whose own comment frames the inline split as
-      the #170/#172 prod-500 FIX (the index-defeating anti-join/threshold was moved to the
-      OUTER query so the inner ANN stays HNSW-eligible). Its lint disposition is a US-27.8
-      decision, deliberately left out of this US-27.7b registry.
+      helper; the US-27.8 lint exempts the WHOLE `VectorSearch` module as its home (matched
+      by module name), NOT via this per-function registry. (Decision made — no longer
+      deferred.)
+    * `Loopctl.Knowledge.suggestion_candidates_query/6` — post-US-27.7a this DELEGATES to
+      `VectorSearch.candidate_query/4` and carries NO inline `<=>` literal, so the lint never
+      sees a site there: it is not a lint target and needs no registry entry. (The earlier
+      inline `ORDER BY embedding <=> $const LIMIT pool` — the #170/#172 prod-500 FIX — has
+      since been routed through the shared helper; decision made — no longer deferred.)
 
   Some functions in `Loopctl.Knowledge` legitimately compute a cosine `<=>` distance WITHOUT
   going through (and MUST NOT be routed through) `nearest/4`, because neither is a

--- a/lib/loopctl/knowledge/cosine_lint_exceptions.ex
+++ b/lib/loopctl/knowledge/cosine_lint_exceptions.ex
@@ -58,6 +58,17 @@ defmodule Loopctl.Knowledge.CosineLintExceptions do
   auditable (each carries a non-empty one-line rationale; adding a new exception is a
   visible, reviewable diff here, not a scattered inline comment the lint can't see).
 
+  Two rules when adding an entry:
+
+    * **Register at the HEAD-slot (maximum) arity.** The lint computes arity from the
+      `def` head's argument count, so a function with default args (`def f(x \\ 1)` —
+      callable at /1 AND /2) is flagged at /2 (the head slot). Register the head-slot arity
+      or the exemption silently won't match. (All current entries are default-arg-free.)
+    * **`nearest_prior_distance/4` holds NO `<=>` literal** (it delegates to
+      `novelty_distance_query/4`). It is registered for AUDIT/documentation only — the lint
+      never produces a site there, so this entry is inert-but-harmless (it documents the
+      logical owner of the MIN-distance novelty path).
+
   ## Shape
 
   `exceptions/0` returns a list of `%{module, function, arity, rationale}` maps.

--- a/test/loopctl/credo/cosine_query_reintroduction_test.exs
+++ b/test/loopctl/credo/cosine_query_reintroduction_test.exs
@@ -72,7 +72,7 @@ defmodule Loopctl.Credo.Check.CosineQueryReintroductionTest do
         assert issue.message =~ "My.Rogue.Search.nearest/2"
         assert issue.message =~ "Loopctl.Knowledge.VectorSearch"
         assert issue.message =~ "CosineLintExceptions"
-        assert issue.trigger == "<=>"
+        assert issue.trigger == "distance"
       end)
     end
 
@@ -128,7 +128,7 @@ defmodule Loopctl.Credo.Check.CosineQueryReintroductionTest do
       |> run_check(CosineQueryReintroduction)
       |> assert_issue(fn issue ->
         assert issue.message =~ "My.Rogue.Interp.nearest/2"
-        assert issue.trigger == "<=>"
+        assert issue.trigger == "distance"
       end)
     end
 
@@ -168,6 +168,105 @@ defmodule Loopctl.Credo.Check.CosineQueryReintroductionTest do
       |> assert_issue(fn issue ->
         assert issue.message =~ "My.Outer.Inner.nearest/1"
       end)
+    end
+  end
+
+  describe "flags alternate distance spellings + raw-SQL entrypoints (review F1/SQL-1/SQL-2)" do
+    test "the `cosine_distance(...)` FUNCTION spelling is flagged — same op as `<=>` (review F1)" do
+      """
+      defmodule My.Rogue.FnSpelling do
+        import Ecto.Query
+
+        def nearest(t) do
+          from(a in Article, order_by: fragment("cosine_distance(embedding, ?)", ^t))
+        end
+      end
+      """
+      |> to_source_file("lib/my/rogue/fn_spelling.ex")
+      |> run_check(CosineQueryReintroduction)
+      |> assert_issue(fn issue -> assert issue.message =~ "My.Rogue.FnSpelling.nearest/1" end)
+    end
+
+    test "a raw `Repo.query_many!` cosine SQL is flagged (review SQL-1)" do
+      """
+      defmodule My.Rogue.QueryMany do
+        def topk(target, k) do
+          Repo.query_many!(
+            "SELECT id FROM articles ORDER BY embedding <=> $1 LIMIT $2",
+            [target, k]
+          )
+        end
+      end
+      """
+      |> to_source_file("lib/my/rogue/query_many.ex")
+      |> run_check(CosineQueryReintroduction)
+      |> assert_issue(fn issue -> assert issue.message =~ "My.Rogue.QueryMany.topk/2" end)
+    end
+
+    test "a raw `Repo.stream` cosine SQL is flagged (review SQL-2)" do
+      """
+      defmodule My.Rogue.Stream do
+        def each(target) do
+          Repo.stream("SELECT id FROM articles ORDER BY embedding <=> $1", [target])
+        end
+      end
+      """
+      |> to_source_file("lib/my/rogue/stream.ex")
+      |> run_check(CosineQueryReintroduction)
+      |> assert_issue(fn issue -> assert issue.message =~ "My.Rogue.Stream.each/1" end)
+    end
+  end
+
+  describe "precision + documented residuals (review F3 false-pos, var-pipe residual)" do
+    test "a distance token in a fragment VALUE arg (not the SQL template) is NOT flagged (review F3)" do
+      # `<=>` here is BOUND DATA, not the SQL template — fragment's SQL is arg 1 only, so a
+      # token in a later (value) arg must not false-positive.
+      """
+      defmodule My.Fine.ValueArg do
+        import Ecto.Query
+
+        def f(t) do
+          from(a in Article, where: fragment("? = ?", a.name, "prefix <=> suffix") and a.id == ^t)
+        end
+      end
+      """
+      |> to_source_file("lib/my/fine/value_arg.ex")
+      |> run_check(CosineQueryReintroduction)
+      |> refute_issues()
+    end
+
+    test "a var-held cosine SQL string piped to query! is the DOCUMENTED residual (NOT caught)" do
+      # No literal at the call site → the AST can't see it (closing this needs data-flow
+      # analysis). Pinned so the boundary is DELIBERATE + visible; loopctl never builds a
+      # cosine query this way (the coarse file-set guard backstops a new-file occurrence).
+      """
+      defmodule My.Residual.VarPipe do
+        def f(t) do
+          sql = "SELECT id FROM articles ORDER BY embedding <=> $1"
+          Repo.query!(sql, [t])
+        end
+      end
+      """
+      |> to_source_file("lib/my/residual/var_pipe.ex")
+      |> run_check(CosineQueryReintroduction)
+      |> refute_issues()
+    end
+
+    test "a cosine SQL string held in a MODULE ATTRIBUTE then referenced is the DOCUMENTED residual (NOT caught)" do
+      # The `@cosine_sql "…<=>…"` definition is an `@` attribute node, NOT a SQL-bearing call,
+      # and the usage `Repo.query!(@cosine_sql, …)` passes an attribute REFERENCE (no literal at
+      # the call). Like the var-pipe, closing this needs data-flow; pinned as a deliberate, visible
+      # boundary. The file-set tripwire backstops it: the `<=>` literal in the @attr def lands in
+      # the discovered set, so a NEW file shaped this way fails the regression guard.
+      """
+      defmodule My.Residual.AttrRef do
+        @cosine_sql "SELECT id FROM articles ORDER BY embedding <=> $1"
+        def f(t), do: Repo.query!(@cosine_sql, [t])
+      end
+      """
+      |> to_source_file("lib/my/residual/attr_ref.ex")
+      |> run_check(CosineQueryReintroduction)
+      |> refute_issues()
     end
   end
 
@@ -308,31 +407,119 @@ defmodule Loopctl.Credo.Check.CosineQueryReintroductionTest do
     end
   end
 
-  describe "REGRESSION — the real lib/loopctl cosine sites all pass (TC-27.8.4)" do
-    @real_cosine_files [
-      "lib/loopctl/knowledge/vector_search.ex",
-      "lib/loopctl/knowledge.ex",
-      "lib/loopctl/knowledge/cosine_lint_exceptions.ex"
-    ]
+  describe "REGRESSION — every real lib distance-token file passes the check (TC-27.8.4)" do
+    # The SAME distance tokens the check itself scans for. Kept in sync deliberately: if the
+    # check learns a new spelling, this discovery must learn it too (else a new family of
+    # hand-rolled distance query could land in a file this guard never inspects).
+    @distance_tokens ["<=>", "<->", "<#>", "cosine_distance(", "l2_distance(", "inner_product("]
 
-    test "every real cosine-bearing lib file reports ZERO issues (helper + registered exempt)" do
-      for path <- @real_cosine_files do
-        source = File.read!(path)
+    # DISCOVERED at compile time: every lib/ source that textually carries ANY distance token
+    # (real query, or doc/comment prose). Computed, not hardcoded, so a NEW cosine-bearing file
+    # is automatically pulled into the per-file check below.
+    @lib_distance_files Path.wildcard("lib/**/*.ex")
+                        |> Enum.filter(fn p ->
+                          src = File.read!(p)
+                          Enum.any?(@distance_tokens, &String.contains?(src, &1))
+                        end)
+                        |> Enum.sort()
 
-        source
+    # The ALLOWLISTED set of files permitted to carry a distance token today, each annotated.
+    # A diff to this list is a visible, reviewable decision — exactly the tripwire that closes
+    # the documented var-pipe residual at FILE granularity: a `<=>` literal assembled into a
+    # variable still lands its string in the file, so a NEW file carrying it expands the
+    # discovered set and trips the set-equality test, forcing review even though the per-site
+    # check (which needs a literal AT the call) can't see it.
+    @allowed_distance_files [
+                              # real cosine query sites:
+                              "lib/loopctl/knowledge.ex",
+                              "lib/loopctl/knowledge/vector_search.ex",
+                              # registry rationale strings quote the operators (data, not query):
+                              "lib/loopctl/knowledge/cosine_lint_exceptions.ex",
+                              # doc-only tokens (a `<->` arrow in prose / a `<=>` inside a comment):
+                              "lib/loopctl/knowledge/okf.ex",
+                              "lib/loopctl/workers/article_linking_worker.ex"
+                            ]
+                            |> Enum.sort()
+
+    test "every lib file carrying a distance token reports ZERO issues (helper + registered + docs exempt)" do
+      # Covers the real cosine sites AND the doc-only files: a real hand-rolled query later
+      # added to ANY of them (e.g. okf.ex / the worker) would be flagged, because only
+      # VectorSearch + the registered fns are exempt — doc prose is not.
+      for path <- @lib_distance_files do
+        path
+        |> File.read!()
         |> to_source_file(path)
         |> run_check(CosineQueryReintroduction)
         |> refute_issues()
       end
     end
 
-    test "the real files genuinely CONTAIN `<=>` (the regression test isn't vacuous)" do
-      # Guard against a future refactor that removes all `<=>` from these files and
-      # makes the zero-issue assertion meaningless: at least one real file must still
-      # carry the operator (in a fragment), so the exemption is actually exercised.
-      assert Enum.any?(@real_cosine_files, fn path ->
-               File.read!(path) =~ "<=>"
-             end)
+    test "the discovered distance-token file set EQUALS the reviewed allowlist (file-set tripwire)" do
+      # Set-equality (not subset): a NEW file carrying a distance token trips this (review it —
+      # route a real query through VectorSearch or register it; if doc-only, add it here with a
+      # note). Removal also trips it (the regression could have gone vacuous). This is the coarse
+      # backstop for the var-pipe residual that the per-site AST check structurally cannot catch.
+      assert @lib_distance_files == @allowed_distance_files,
+             "lib distance-token files drifted from the reviewed allowlist.\n" <>
+               "  discovered: #{inspect(@lib_distance_files)}\n" <>
+               "  allowed:    #{inspect(@allowed_distance_files)}\n" <>
+               "A new file here means a hand-rolled distance op (or a var-assembled cosine SQL " <>
+               "string) landed outside VectorSearch — route it through the helper / register it, " <>
+               "or (if it's doc-only) add it to @allowed_distance_files with a one-line reason."
+    end
+
+    test "at least one allowed file genuinely CONTAINS a real `<=>` (the regression isn't vacuous)" do
+      assert Enum.any?(@allowed_distance_files, fn path -> File.read!(path) =~ "<=>" end)
+    end
+  end
+
+  describe "WIRING — the check is actually enabled in .credo.exs and not inline-disabled (E1/DISABLE-1)" do
+    @credo_config File.read!(".credo.exs")
+
+    test "`.credo.exs` ENABLES the cosine check and REQUIRES both its source + the registry (E1)" do
+      # If a future edit drops the check from the enabled set or stops `requires:`-ing it, the
+      # guard silently stops running (`mix credo --strict` would pass without it). Pin both.
+      assert @credo_config =~ "Loopctl.Credo.Check.CosineQueryReintroduction",
+             "the cosine reintroduction check is no longer listed in .credo.exs — it must stay " <>
+               "in the enabled `checks` so `mix credo --strict` runs it on every PR"
+
+      assert @credo_config =~ ".credo/checks/cosine_query_reintroduction.ex",
+             "`.credo.exs` must `require` the out-of-lib check source (it lives outside lib/ so " <>
+               "it isn't auto-compiled; dropping the require makes the check a no-op)"
+
+      assert @credo_config =~ "lib/loopctl/knowledge/cosine_lint_exceptions.ex",
+             "`.credo.exs` must `require` the allowlist registry — the check reads it at load " <>
+               "time and fails-closed (:nofile) without it (DISPROVED architect F2; load-bearing)"
+    end
+
+    test "no lib/ source DISABLES the cosine check inline (DISABLE-1)" do
+      # A `# credo:disable-...CosineQueryReintroduction` (named) OR a blanket file-level disable
+      # in one of the cosine-bearing files would silently re-open the regression. Forbid both.
+      named_disables =
+        Path.wildcard("lib/**/*.ex")
+        |> Enum.filter(fn p ->
+          src = File.read!(p)
+          src =~ ~r/credo:disable[^\n]*CosineQueryReintroduction/
+        end)
+
+      assert named_disables == [],
+             "found an inline `credo:disable` targeting the cosine check in: " <>
+               "#{inspect(named_disables)} — that re-opens the #168/#170/#172 regression silently. " <>
+               "Register a real exception in CosineLintExceptions instead."
+
+      blanket_disables_in_cosine_files =
+        @allowed_distance_files
+        |> Enum.filter(fn p ->
+          # a disable with NO check name (directive ENDS the line) disables ALL checks — incl.
+          # ours — for that file/line. A NAMED one (`… this-file Credo.Check.X`) is fine: the
+          # check name follows, so `\s*$` won't match. `/m` makes `$` an end-of-LINE anchor.
+          File.read!(p) =~ ~r/credo:disable-for-(this-file|next-line|lines:\d+)\s*$/m
+        end)
+
+      assert blanket_disables_in_cosine_files == [],
+             "found a blanket (un-named) `credo:disable` in a cosine-bearing file: " <>
+               "#{inspect(blanket_disables_in_cosine_files)} — it would disable the cosine guard " <>
+               "too. Scope the disable to the specific unrelated check by name."
     end
   end
 end

--- a/test/loopctl/credo/cosine_query_reintroduction_test.exs
+++ b/test/loopctl/credo/cosine_query_reintroduction_test.exs
@@ -1,0 +1,279 @@
+defmodule Loopctl.Credo.Check.CosineQueryReintroductionTest do
+  @moduledoc """
+  US-27.8 TC-27.8.4: unit tests for the cosine-`<=>` reintroduction Credo guard.
+
+  Proves the check is a REAL anti-regression guard, not a no-op:
+
+    * it FLAGS a new hand-rolled `fragment("… <=> …")` outside the shared helper, and
+      the issue message NAMES the offending `M.f/a`;
+    * it EXEMPTS the whole `Loopctl.Knowledge.VectorSearch` module (the helper's home);
+    * it EXEMPTS a registered `CosineLintExceptions` function (`do_distant_pairs/7`,
+      `novelty_distance_query/4`) — the allowlist works;
+    * it is PRECISE — a `<=>` in a `@moduledoc`/`@doc`/comment/Regex/data string is NOT
+      flagged (those are documentation, not a query);
+    * REGRESSION: the REAL cosine-bearing `lib/loopctl` sources pass the check with ZERO
+      issues, i.e. every existing `<=>` (the 3 `VectorSearch` helper sites + the 3
+      registered `Loopctl.Knowledge` exceptions) is correctly exempt and nothing leaks.
+
+  The check lives under `.credo/` (outside `lib/`, so `MIX_ENV=prod mix compile` can't
+  drag it into the release) and is loaded by Credo via `.credo.exs` `requires:`. For the
+  unit test we `Code.require_file/1` it explicitly.
+  """
+  use Credo.Test.Case, async: true
+
+  @check_path Path.expand("../../../.credo/checks/cosine_query_reintroduction.ex", __DIR__)
+
+  # Load the out-of-lib check source into the test VM once. `CosineLintExceptions` is
+  # ordinary `lib/` code (compiled in :test), so it's already available for the check's
+  # allowlist read.
+  Code.require_file(@check_path)
+
+  alias Loopctl.Credo.Check.CosineQueryReintroduction
+
+  # Credo is a `runtime: false` dep, so its application (which supervises the
+  # `Credo.Service.*` GenServers that `Credo.Test.Case`'s `to_source_file/2` and
+  # `run_check/2` talk to) is not auto-started. Boot it for this test module. In the FULL
+  # suite another test may have started it already, so accept `:already_started` (this is
+  # NOT `Application.ensure_all_started/1`, which would itself need the runtime started —
+  # we go straight to `Application.start/1` and treat already-running as success).
+  setup_all do
+    # `ensure_all_started/1` pulls in credo's deps (:bunt, :file_system, …). In the full
+    # suite credo may already be up (another `Credo.Test.Case` user, or a prior run in the
+    # same VM), in which case the supervisor reports `:already_started` — treat that as
+    # success rather than letting a `{:ok, _}` match crash the whole module's setup_all.
+    case Application.ensure_all_started(:credo) do
+      {:ok, _started} -> :ok
+      {:error, {:credo, {{:already_started, _pid}, _}}} -> :ok
+      {:error, {_app, {:already_started, _pid}}} -> :ok
+      {:error, reason} -> raise "could not start :credo for the lint test: #{inspect(reason)}"
+    end
+
+    :ok
+  end
+
+  describe "flags a NEW hand-rolled cosine site outside the helper (AC-27.8.5)" do
+    test "a fragment(\"… <=> …\") ORDER BY in a non-helper module is reported once, naming the M.f/a" do
+      """
+      defmodule My.Rogue.Search do
+        import Ecto.Query
+
+        def nearest(tenant_id, target) do
+          from(a in Article,
+            where: a.tenant_id == ^tenant_id,
+            order_by: [asc: fragment("? <=> ?", a.embedding, ^target)],
+            limit: 10
+          )
+        end
+      end
+      """
+      |> to_source_file("lib/my/rogue/search.ex")
+      |> run_check(CosineQueryReintroduction)
+      |> assert_issue(fn issue ->
+        assert issue.message =~ "My.Rogue.Search.nearest/2"
+        assert issue.message =~ "Loopctl.Knowledge.VectorSearch"
+        assert issue.message =~ "CosineLintExceptions"
+        assert issue.trigger == "<=>"
+      end)
+    end
+
+    test "a MIN(<=>) aggregate in an UN-registered function is reported" do
+      """
+      defmodule My.Rogue.Novelty do
+        import Ecto.Query
+
+        def min_distance(tenant_id, target) do
+          from(a in Article,
+            where: a.tenant_id == ^tenant_id,
+            select: fragment("MIN(? <=> ?::vector)", a.embedding, ^target)
+          )
+        end
+      end
+      """
+      |> to_source_file("lib/my/rogue/novelty.ex")
+      |> run_check(CosineQueryReintroduction)
+      |> assert_issue(fn issue ->
+        assert issue.message =~ "My.Rogue.Novelty.min_distance/2"
+      end)
+    end
+
+    test "a cosine fragment OUTSIDE any def (module level) is still reported (no hiding spot)" do
+      """
+      defmodule My.Rogue.ModuleLevel do
+        import Ecto.Query
+        @bad from(a in Article, order_by: fragment("? <=> ?", a.embedding, a.embedding))
+      end
+      """
+      |> to_source_file("lib/my/rogue/module_level.ex")
+      |> run_check(CosineQueryReintroduction)
+      |> assert_issue(fn issue ->
+        assert issue.message =~ "My.Rogue.ModuleLevel"
+        assert issue.message =~ "module-level"
+      end)
+    end
+  end
+
+  describe "exempts the helper module and the registered allowlist (AC-27.8.5)" do
+    test "the whole Loopctl.Knowledge.VectorSearch module is exempt (its home)" do
+      # Same forbidden shape as above, but the file IS the helper module → no issue.
+      """
+      defmodule Loopctl.Knowledge.VectorSearch do
+        import Ecto.Query
+
+        def candidate_pool_query(tenant_id, target) do
+          from(a in Article,
+            where: a.tenant_id == ^tenant_id,
+            order_by: [asc: fragment("? <=> ?", a.embedding, ^target)]
+          )
+        end
+      end
+      """
+      |> to_source_file("lib/loopctl/knowledge/vector_search.ex")
+      |> run_check(CosineQueryReintroduction)
+      |> refute_issues()
+    end
+
+    test "a registered exception (Loopctl.Knowledge.do_distant_pairs/7) is exempt" do
+      # The EXACT registered {module, fun, arity}: Loopctl.Knowledge.do_distant_pairs/7.
+      """
+      defmodule Loopctl.Knowledge do
+        import Ecto.Query
+
+        defp do_distant_pairs(tenant_id, min_d, max_d, limit, offset, bridge?, vis) do
+          from(a in Article,
+            join: b in Article,
+            on: a.id < b.id,
+            where: fragment("(? <=> ?) BETWEEN ? AND ?", a.embedding, b.embedding, ^min_d, ^max_d)
+          )
+        end
+      end
+      """
+      |> to_source_file("lib/loopctl/knowledge.ex")
+      |> run_check(CosineQueryReintroduction)
+      |> refute_issues()
+    end
+
+    test "a registered exception (Loopctl.Knowledge.novelty_distance_query/4) is exempt" do
+      """
+      defmodule Loopctl.Knowledge do
+        import Ecto.Query
+
+        def novelty_distance_query(tenant_id, embedding, prior_tag, vis) do
+          from(a in Article,
+            where: a.tenant_id == ^tenant_id,
+            select: fragment("MIN(? <=> ?::vector)", a.embedding, ^embedding)
+          )
+        end
+      end
+      """
+      |> to_source_file("lib/loopctl/knowledge.ex")
+      |> run_check(CosineQueryReintroduction)
+      |> refute_issues()
+    end
+
+    test "the SAME function name but the WRONG arity is NOT exempt (the allowlist is mfa-keyed)" do
+      # do_distant_pairs registered at /7; a /2 with the same name is a different fn and
+      # must be flagged — proving the allowlist matches on arity, not just name.
+      """
+      defmodule Loopctl.Knowledge do
+        import Ecto.Query
+
+        defp do_distant_pairs(tenant_id, target) do
+          from(a in Article,
+            where: a.tenant_id == ^tenant_id,
+            order_by: fragment("? <=> ?", a.embedding, ^target)
+          )
+        end
+      end
+      """
+      |> to_source_file("lib/loopctl/knowledge.ex")
+      |> run_check(CosineQueryReintroduction)
+      |> assert_issue(fn issue ->
+        assert issue.message =~ "Loopctl.Knowledge.do_distant_pairs/2"
+      end)
+    end
+
+    test "the registered name in a DIFFERENT module is NOT exempt (allowlist is module-keyed)" do
+      # novelty_distance_query/4 is registered for Loopctl.Knowledge ONLY; the same
+      # name+arity in another module is a fresh hand-rolled site and must be flagged.
+      """
+      defmodule Some.Other.Module do
+        import Ecto.Query
+
+        def novelty_distance_query(tenant_id, embedding, prior_tag, vis) do
+          from(a in Article, select: fragment("MIN(? <=> ?::vector)", a.embedding, ^embedding))
+        end
+      end
+      """
+      |> to_source_file("lib/some/other/module.ex")
+      |> run_check(CosineQueryReintroduction)
+      |> assert_issue(fn issue ->
+        assert issue.message =~ "Some.Other.Module.novelty_distance_query/4"
+      end)
+    end
+  end
+
+  describe "precision — documentation/data `<=>` is NOT a query (no false positives)" do
+    test "a `<=>` in a @moduledoc / @doc / comment / data string is not flagged" do
+      """
+      defmodule My.Documented do
+        @moduledoc "Discusses the cosine `<=>` operator at length."
+
+        @exceptions [%{rationale: "uses ? <=> ? in a self-join"}]
+
+        @doc "Returns nothing. Mentions ? <=> ? only in prose."
+        def noop do
+          # a <=> b would be a cosine distance, but this is a comment
+          _regex = ~r/\\? <=> \\?/
+          :ok
+        end
+      end
+      """
+      |> to_source_file("lib/my/documented.ex")
+      |> run_check(CosineQueryReintroduction)
+      |> refute_issues()
+    end
+
+    test "a non-SQL function call whose string arg contains `<=>` is not flagged" do
+      # Only fragment/query!/query/explain calls bear SQL. A plain IO.puts of a string
+      # that happens to contain `<=>` is documentation/logging, not a query.
+      """
+      defmodule My.Logger do
+        def log do
+          IO.puts("computed ? <=> ? distance")
+        end
+      end
+      """
+      |> to_source_file("lib/my/logger.ex")
+      |> run_check(CosineQueryReintroduction)
+      |> refute_issues()
+    end
+  end
+
+  describe "REGRESSION — the real lib/loopctl cosine sites all pass (TC-27.8.4)" do
+    @real_cosine_files [
+      "lib/loopctl/knowledge/vector_search.ex",
+      "lib/loopctl/knowledge.ex",
+      "lib/loopctl/knowledge/cosine_lint_exceptions.ex"
+    ]
+
+    test "every real cosine-bearing lib file reports ZERO issues (helper + registered exempt)" do
+      for path <- @real_cosine_files do
+        source = File.read!(path)
+
+        source
+        |> to_source_file(path)
+        |> run_check(CosineQueryReintroduction)
+        |> refute_issues()
+      end
+    end
+
+    test "the real files genuinely CONTAIN `<=>` (the regression test isn't vacuous)" do
+      # Guard against a future refactor that removes all `<=>` from these files and
+      # makes the zero-issue assertion meaningless: at least one real file must still
+      # carry the operator (in a fragment), so the exemption is actually exercised.
+      assert Enum.any?(@real_cosine_files, fn path ->
+               File.read!(path) =~ "<=>"
+             end)
+    end
+  end
+end

--- a/test/loopctl/credo/cosine_query_reintroduction_test.exs
+++ b/test/loopctl/credo/cosine_query_reintroduction_test.exs
@@ -110,6 +110,65 @@ defmodule Loopctl.Credo.Check.CosineQueryReintroductionTest do
         assert issue.message =~ "module-level"
       end)
     end
+
+    test "an INTERPOLATED fragment string is flagged (`<=>` lives in a `<<>>` node) — review FN-1" do
+      # The `\#{col}` is escaped so the FIXTURE source carries a literal interpolated
+      # `fragment("#{col} <=> ?", …)`. A shallow direct-child check missed this (the `<=>`
+      # is not a direct plain-binary arg); the deep arg-walk now catches it.
+      """
+      defmodule My.Rogue.Interp do
+        import Ecto.Query
+
+        def nearest(col, target) do
+          from(a in Article, order_by: fragment("\#{col} <=> ?", ^target))
+        end
+      end
+      """
+      |> to_source_file("lib/my/rogue/interp.ex")
+      |> run_check(CosineQueryReintroduction)
+      |> assert_issue(fn issue ->
+        assert issue.message =~ "My.Rogue.Interp.nearest/2"
+        assert issue.trigger == "<=>"
+      end)
+    end
+
+    test "a CONCATENATED fragment string is flagged (`<=>` inside a `<>` node) — review FN-2" do
+      """
+      defmodule My.Rogue.Concat do
+        import Ecto.Query
+
+        def nearest(target) do
+          from(a in Article, order_by: fragment("? <=>" <> " ?", ^target))
+        end
+      end
+      """
+      |> to_source_file("lib/my/rogue/concat.ex")
+      |> run_check(CosineQueryReintroduction)
+      |> assert_issue(fn issue ->
+        assert issue.message =~ "My.Rogue.Concat.nearest/1"
+      end)
+    end
+
+    test "a NESTED-module site is attributed to its OWN module (not the outer one)" do
+      # Guards the per-module exemption: a rogue `<=>` in a module nested inside an exempt
+      # one must still be flagged on its own full name, not wholesale-suppressed.
+      """
+      defmodule My.Outer do
+        defmodule Inner do
+          import Ecto.Query
+
+          def nearest(target) do
+            from(a in Article, order_by: fragment("? <=> ?", a.embedding, ^target))
+          end
+        end
+      end
+      """
+      |> to_source_file("lib/my/outer.ex")
+      |> run_check(CosineQueryReintroduction)
+      |> assert_issue(fn issue ->
+        assert issue.message =~ "My.Outer.Inner.nearest/1"
+      end)
+    end
   end
 
   describe "exempts the helper module and the registered allowlist (AC-27.8.5)" do

--- a/test/loopctl/knowledge/cosine_lint_vs_scale_gate_scale_test.exs
+++ b/test/loopctl/knowledge/cosine_lint_vs_scale_gate_scale_test.exs
@@ -1,0 +1,122 @@
+defmodule Loopctl.Knowledge.CosineLintVsScaleGateScaleTest do
+  @moduledoc """
+  US-27.8 AC-27.8.5 (CRITICAL): the allowlist exempts the LINT, NOT the scale plan-gate.
+
+  `Loopctl.Knowledge.CosineLintExceptions` lets a function (`do_distant_pairs/7`,
+  `novelty_distance_query/4`) hand-roll a cosine `<=>` WITHOUT tripping the source lint
+  (`Loopctl.Credo.Check.CosineQueryReintroduction`). This test proves that exemption is
+  ONLY a source-location exemption — it grants NO protection from the plan gate:
+
+    * A deliberately index-DEFEATING variant of an allowlisted-shape query (a
+      `novelty`-flavored `MIN(embedding <=> $const)` with a corpus-scanning residual that
+      makes the planner abandon the bounded path for a Seq Scan over the whole 80k corpus)
+      STILL FAILS `PlanAssertions.refute_seq_scan/1` at scale. The allowlist did not save it.
+
+  This is the anti-false-confidence guard the AC demands: nobody can hide an O(n) cosine
+  regression behind the lint allowlist — the scale gate judges the SHAPE, independently of
+  whether the SITE is lint-exempt.
+
+  To keep the proof honest we ALSO show the genuine `novelty_distance_query/4` shape (the
+  registered, bounded one) PASSES `refute_seq_scan/1` on the same corpus — so the test is
+  not merely asserting "everything Seq-Scans at 80k" (which would be vacuous). The contrast
+  is the point: same lint-exempt FUNCTION FAMILY, bounded shape passes, bad shape fails.
+
+  Seeds ~80k committed rows, so `:scale_nightly`; wired into the CI `scale_file` matrix
+  (enforced by `scale_verification_runbook_test.exs`).
+  """
+  use ExUnit.Case, async: false
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.ScaleSeed
+  alias Loopctl.PlanAssertions
+  alias Loopctl.Tenants.Tenant
+
+  import Ecto.Query
+
+  @moduletag :scale_nightly
+  @moduletag timeout: :timer.minutes(30)
+
+  # The ~2% tag ScaleSeed stamps, so the genuine (bounded) novelty shape is selective.
+  @prior_tag "scale-tag-3"
+
+  defp unboxed(fun), do: Sandbox.unboxed_run(AdminRepo, fun)
+
+  setup do
+    tenant =
+      unboxed(fn ->
+        slug = "lint-vs-gate-#{:erlang.phash2(Ecto.UUID.generate())}"
+
+        {:ok, t} =
+          %Tenant{}
+          |> Tenant.create_changeset(%{
+            name: "Lint vs Gate #{slug}",
+            slug: slug,
+            email: "#{slug}@example.com",
+            settings: %{},
+            status: :active
+          })
+          |> AdminRepo.insert()
+
+        ScaleSeed.seed(t.id, count: ScaleSeed.prod_article_floor(), link_density: 5)
+        t
+      end)
+
+    unboxed(fn -> PlanAssertions.assert_scale_floor!(tenant.id) end)
+
+    on_exit(fn ->
+      try do
+        unboxed(fn ->
+          AdminRepo.delete_all(from(a in Article, where: a.tenant_id == ^tenant.id))
+          AdminRepo.delete_all(from(t in Tenant, where: t.id == ^tenant.id))
+        end)
+      rescue
+        _ -> :ok
+      end
+    end)
+
+    {:ok, tenant: tenant}
+  end
+
+  test "an index-defeating variant of an allowlisted (novelty) shape STILL fails the scale gate",
+       %{tenant: tenant} do
+    unboxed(fn ->
+      idea_vec = ScaleSeed.embedding_for(0)
+
+      # The GENUINE registered novelty shape — bounded by the ~2% prior tag. This is
+      # lint-exempt (novelty_distance_query/4 is registered) AND index-bounded, so it
+      # passes the gate. Establishes the non-vacuous baseline.
+      good = Knowledge.novelty_distance_query(tenant.id, idea_vec, @prior_tag, nil)
+      assert :ok = PlanAssertions.refute_seq_scan(good)
+
+      # The INDEX-DEFEATING variant: the SAME cosine-`<=>`-to-a-`$const` FAMILY as the
+      # registered novelty shape, but expressed as a `WHERE (embedding <=> $const) <
+      # threshold` RANGE predicate over the whole tenant corpus. pgvector's HNSW serves an
+      # `ORDER BY <=> LIMIT k` (the bounded MIN-rewrite the real novelty query uses) — it
+      # CANNOT serve a `<=>` RANGE filter, so the planner must compute the distance per row
+      # in a full-corpus `Seq Scan on articles` (verified at 80k: the exact #168/#172 rot the
+      # gate exists to catch). If this site were registered in the allowlist it would be
+      # LINT-clean, yet the plan gate must STILL reject it.
+      bad =
+        from(a in Article,
+          where:
+            a.tenant_id == ^tenant.id and a.status == :published and not is_nil(a.embedding) and
+              fragment("(? <=> ?::vector) < ?", a.embedding, ^idea_vec, 0.9),
+          select: count()
+        )
+
+      # The allowlist exempts the SITE from the lint; it does NOT exempt this SHAPE from the
+      # plan gate. `refute_seq_scan/1` must RAISE on the full-corpus scan (its message names
+      # the unbounded Seq Scan on `articles`).
+      error =
+        assert_raise ExUnit.AssertionError, fn ->
+          PlanAssertions.refute_seq_scan(bad)
+        end
+
+      assert error.message =~ "Seq Scan on `articles`"
+      assert error.message =~ "unbounded full-corpus read"
+    end)
+  end
+end

--- a/test/loopctl/knowledge/distant_pairs_novelty_scale_test.exs
+++ b/test/loopctl/knowledge/distant_pairs_novelty_scale_test.exs
@@ -92,6 +92,10 @@ defmodule Loopctl.Knowledge.DistantPairsNoveltyScaleTest do
         t
       end)
 
+    # US-27.8 AC-27.8.3: calibration guard — the distant_pairs/novelty bounds below assume
+    # a >= prod-floor corpus for THIS tenant; fail loudly on a sub-floor seed.
+    unboxed(fn -> PlanAssertions.assert_scale_floor!(tenant.id) end)
+
     on_exit(fn ->
       try do
         unboxed(fn ->

--- a/test/loopctl/knowledge/scale_calibration_mismatch_scale_test.exs
+++ b/test/loopctl/knowledge/scale_calibration_mismatch_scale_test.exs
@@ -109,28 +109,15 @@ defmodule Loopctl.Knowledge.ScaleCalibrationMismatchScaleTest do
     # connection and a prod-shaped one (`SHOW hnsw.ef_search`). Here we drive the FAILURE
     # direction with two deliberately-divergent effective values and assert the SAME parity
     # form raises — so a real prod-vs-gate divergence cannot pass green.
-    gate_ef = "40"
-    prod_ef = "80"
-
+    # Drive the SHARED `PlanAssertions.assert_ef_search_parity!/2` (the SAME assertion the
+    # under-fill scale gate uses for the success direction) with two deliberately-divergent
+    # effective values — so this failure path exercises the REAL comparison + message, not a
+    # duplicated local copy that could silently drift from the real gate.
     assert_raise ExUnit.AssertionError, ~r/ef_search diverged/, fn ->
-      assert_ef_search_parity!(gate_ef, prod_ef)
+      PlanAssertions.assert_ef_search_parity!("40", "80")
     end
 
     # And it does NOT raise when they match (the success direction the real gate asserts).
-    assert :ok = assert_ef_search_parity!("40", "40")
-  end
-
-  # The exact parity form the under-fill scale gate uses (gate vs prod ef_search), factored
-  # so the FAILURE direction is testable without an actual `ALTER ROLE` on the test DB. The
-  # real gate reads each side via `SHOW hnsw.ef_search`; this asserts on the read values.
-  defp assert_ef_search_parity!(gate_ef, prod_ef) do
-    if gate_ef == prod_ef do
-      :ok
-    else
-      raise ExUnit.AssertionError,
-        message:
-          "ef_search diverged: gate=#{inspect(gate_ef)} prod=#{inspect(prod_ef)} " <>
-            "(SHOW hnsw.ef_search must match between the scale gate and the prod-shaped pool)"
-    end
+    assert :ok = PlanAssertions.assert_ef_search_parity!("40", "40")
   end
 end

--- a/test/loopctl/knowledge/scale_calibration_mismatch_scale_test.exs
+++ b/test/loopctl/knowledge/scale_calibration_mismatch_scale_test.exs
@@ -104,20 +104,61 @@ defmodule Loopctl.Knowledge.ScaleCalibrationMismatchScaleTest do
     end)
   end
 
-  test "an ef_search MISMATCH fails the gate-vs-prod parity assertion (failure direction, TC-27.8.3)" do
+  test "a REAL ef_search session divergence fails the gate-vs-prod parity assertion (failure direction, TC-27.8.3)" do
     # The under-fill gate asserts the EFFECTIVE `hnsw.ef_search` is identical on the gate
     # connection and a prod-shaped one (`SHOW hnsw.ef_search`). Here we drive the FAILURE
-    # direction with two deliberately-divergent effective values and assert the SAME parity
-    # form raises — so a real prod-vs-gate divergence cannot pass green.
-    # Drive the SHARED `PlanAssertions.assert_ef_search_parity!/2` (the SAME assertion the
-    # under-fill scale gate uses for the success direction) with two deliberately-divergent
-    # effective values — so this failure path exercises the REAL comparison + message, not a
-    # duplicated local copy that could silently drift from the real gate.
+    # direction with a REAL pgvector GUC divergence end-to-end (not synthetic string literals,
+    # review BA 4.1): inside ONE transaction we `SET LOCAL hnsw.ef_search = 80` and read it
+    # back via `SHOW`, producing a genuinely-divergent effective value, then feed that REAL
+    # read + a baseline read into the SAME shared `PlanAssertions.assert_ef_search_parity!/2`
+    # the gate uses, and assert it raises. This proves the parity gate would actually catch a
+    # prod `ALTER ROLE … SET hnsw.ef_search = N` drift — exercising the real GUC + SHOW path,
+    # the real comparison, and the real message, with no duplicated local copy that could drift.
+
+    # Baseline effective value on an untouched connection (pgvector default today, "40").
+    baseline_ef =
+      unboxed(fn ->
+        AdminRepo.query!("SELECT '[1,2,3]'::vector")
+        %{rows: [[v]]} = AdminRepo.query!("SHOW hnsw.ef_search")
+        v
+      end)
+
+    # A REAL divergent read: `SET LOCAL` is TRANSACTION-scoped (auto-reverts at commit), and
+    # all queries in one transaction share the connection, so the `SHOW` observes the override.
+    diverged_ef =
+      unboxed(fn ->
+        {:ok, v} =
+          AdminRepo.transaction(fn ->
+            AdminRepo.query!("SET LOCAL hnsw.ef_search = 80")
+            %{rows: [[val]]} = AdminRepo.query!("SHOW hnsw.ef_search")
+            val
+          end)
+
+        v
+      end)
+
+    # The override actually took effect (real divergence, not a no-op) and differs from baseline.
+    assert diverged_ef == "80"
+    assert diverged_ef != baseline_ef
+
+    # The SHARED parity assertion (the SAME one the under-fill gate drives in the success
+    # direction) RAISES on the real divergent-vs-baseline reads — so a real prod/gate ef_search
+    # drift cannot pass green.
     assert_raise ExUnit.AssertionError, ~r/ef_search diverged/, fn ->
-      PlanAssertions.assert_ef_search_parity!("40", "80")
+      PlanAssertions.assert_ef_search_parity!(diverged_ef, baseline_ef)
     end
 
-    # And it does NOT raise when they match (the success direction the real gate asserts).
-    assert :ok = PlanAssertions.assert_ef_search_parity!("40", "40")
+    # `SET LOCAL` reverted at the transaction boundary — a fresh read is back to baseline, so
+    # this failure-direction probe left NO session pollution on the pooled connection, and the
+    # matched reads pass (the success direction the real gate asserts).
+    post_ef =
+      unboxed(fn ->
+        AdminRepo.query!("SELECT '[1,2,3]'::vector")
+        %{rows: [[v]]} = AdminRepo.query!("SHOW hnsw.ef_search")
+        v
+      end)
+
+    assert post_ef == baseline_ef
+    assert :ok = PlanAssertions.assert_ef_search_parity!(post_ef, baseline_ef)
   end
 end

--- a/test/loopctl/knowledge/scale_calibration_mismatch_scale_test.exs
+++ b/test/loopctl/knowledge/scale_calibration_mismatch_scale_test.exs
@@ -1,0 +1,136 @@
+defmodule Loopctl.Knowledge.ScaleCalibrationMismatchScaleTest do
+  @moduledoc """
+  US-27.8 AC-27.8.3 / TC-27.8.3: the scale gate FAILS LOUDLY on miscalibration.
+
+  A scale gate is only meaningful if it is honestly calibrated — seeded at/above the prod
+  floor and running with prod's effective `hnsw.ef_search`. A sub-floor seed or a divergent
+  ef_search would make an index-usage assertion false-GREEN (the planner Seq-Scans happily
+  at toy scale; recall differs under a different ef_search). This test proves BOTH
+  miscalibrations are caught with a clear error rather than silently passing:
+
+    * **Sub-floor seed** — seeding BELOW `ScaleSeed.prod_article_floor/0` makes
+      `PlanAssertions.assert_scale_floor!/1` RAISE a clear calibration error (it does NOT
+      silently proceed as `assert_fresh_stats!/0` — non-empty + analyzed — would).
+
+    * **ef_search mismatch (failure direction)** — the under-fill gate already asserts
+      gate-vs-prod ef_search PARITY (`SHOW hnsw.ef_search` equal). Here we prove the FAILURE
+      direction: a deliberately-mismatched effective value makes the same parity assertion
+      RAISE — so a future prod `ALTER ROLE … SET hnsw.ef_search = N` that the gate didn't
+      track cannot slip through green.
+
+  The sub-floor case seeds only a HANDFUL of rows (it is asserting the FLOOR guard fires,
+  not a plan), so it is fast; it is still `:scale_nightly` because it exercises the
+  committed-corpus calibration machinery and must run on the scale gate, never the default
+  async suite. Wired into the CI `scale_file` matrix (enforced by
+  `scale_verification_runbook_test.exs`).
+  """
+  use ExUnit.Case, async: false
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.ScaleSeed
+  alias Loopctl.PlanAssertions
+  alias Loopctl.Tenants.Tenant
+
+  import Ecto.Query
+
+  @moduletag :scale_nightly
+  @moduletag timeout: :timer.minutes(30)
+
+  defp unboxed(fun), do: Sandbox.unboxed_run(AdminRepo, fun)
+
+  setup do
+    tenant =
+      unboxed(fn ->
+        slug = "calib-#{:erlang.phash2(Ecto.UUID.generate())}"
+
+        {:ok, t} =
+          %Tenant{}
+          |> Tenant.create_changeset(%{
+            name: "Calib #{slug}",
+            slug: slug,
+            email: "#{slug}@example.com",
+            settings: %{},
+            status: :active
+          })
+          |> AdminRepo.insert()
+
+        t
+      end)
+
+    on_exit(fn ->
+      try do
+        unboxed(fn ->
+          AdminRepo.delete_all(from(a in Article, where: a.tenant_id == ^tenant.id))
+          AdminRepo.delete_all(from(t in Tenant, where: t.id == ^tenant.id))
+        end)
+      rescue
+        _ -> :ok
+      end
+    end)
+
+    {:ok, tenant: tenant}
+  end
+
+  test "a SUB-FLOOR seed FAILS the calibration guard loudly (AC-27.8.3)", %{tenant: tenant} do
+    floor = ScaleSeed.prod_article_floor()
+    # Deliberately tiny — far below the floor — to model a half-scale (or unseeded) gate.
+    sub_floor = 25
+
+    unboxed(fn ->
+      ScaleSeed.seed(tenant.id, count: sub_floor, link_density: 1)
+    end)
+
+    # The floor guard must RAISE with a clear, actionable calibration error that names the
+    # actual-vs-required counts and points at the documented floor-bump step (AC-27.8.6) —
+    # NOT pass the way assert_fresh_stats!/0 (non-empty + analyzed) would on this corpus.
+    error =
+      assert_raise ExUnit.AssertionError, fn ->
+        unboxed(fn -> PlanAssertions.assert_scale_floor!(tenant.id) end)
+      end
+
+    assert error.message =~ "sub-floor seed"
+    assert error.message =~ to_string(floor)
+    assert error.message =~ "prod_article_floor"
+    # And points at the AC-27.8.6 floor-bump step so the operator knows the remedy.
+    assert error.message =~ "@prod_article_floor"
+
+    # Contrast: assert_fresh_stats!/0 (the WEAKER precondition) is satisfied by this same
+    # corpus — proving the floor guard catches a miscalibration the fresh-stats check can't.
+    unboxed(fn ->
+      AdminRepo.query!("ANALYZE articles")
+      assert :ok = PlanAssertions.assert_fresh_stats!()
+    end)
+  end
+
+  test "an ef_search MISMATCH fails the gate-vs-prod parity assertion (failure direction, TC-27.8.3)" do
+    # The under-fill gate asserts the EFFECTIVE `hnsw.ef_search` is identical on the gate
+    # connection and a prod-shaped one (`SHOW hnsw.ef_search`). Here we drive the FAILURE
+    # direction with two deliberately-divergent effective values and assert the SAME parity
+    # form raises — so a real prod-vs-gate divergence cannot pass green.
+    gate_ef = "40"
+    prod_ef = "80"
+
+    assert_raise ExUnit.AssertionError, ~r/ef_search diverged/, fn ->
+      assert_ef_search_parity!(gate_ef, prod_ef)
+    end
+
+    # And it does NOT raise when they match (the success direction the real gate asserts).
+    assert :ok = assert_ef_search_parity!("40", "40")
+  end
+
+  # The exact parity form the under-fill scale gate uses (gate vs prod ef_search), factored
+  # so the FAILURE direction is testable without an actual `ALTER ROLE` on the test DB. The
+  # real gate reads each side via `SHOW hnsw.ef_search`; this asserts on the read values.
+  defp assert_ef_search_parity!(gate_ef, prod_ef) do
+    if gate_ef == prod_ef do
+      :ok
+    else
+      raise ExUnit.AssertionError,
+        message:
+          "ef_search diverged: gate=#{inspect(gate_ef)} prod=#{inspect(prod_ef)} " <>
+            "(SHOW hnsw.ef_search must match between the scale gate and the prod-shaped pool)"
+    end
+  end
+end

--- a/test/loopctl/knowledge/topk_endpoints_scale_test.exs
+++ b/test/loopctl/knowledge/topk_endpoints_scale_test.exs
@@ -62,6 +62,11 @@ defmodule Loopctl.Knowledge.TopkEndpointsScaleTest do
         t
       end)
 
+    # US-27.8 AC-27.8.3: calibration guard — every assertion below assumes a >= prod-floor
+    # corpus for THIS tenant; a sub-floor seed would make the index-usage gate false-green,
+    # so fail loudly here instead.
+    unboxed(fn -> PlanAssertions.assert_scale_floor!(tenant.id) end)
+
     on_exit(fn ->
       try do
         unboxed(fn ->

--- a/test/loopctl/knowledge/vector_endpoint_e2e_latency_scale_test.exs
+++ b/test/loopctl/knowledge/vector_endpoint_e2e_latency_scale_test.exs
@@ -1,0 +1,215 @@
+defmodule Loopctl.Knowledge.VectorEndpointE2eLatencyScaleTest do
+  @moduledoc """
+  US-27.8 AC-27.8.4 / TC-27.8.2: END-TO-END wall-clock latency at prod scale, measured
+  through the REAL HTTP endpoint (a timed `Phoenix.ConnTest` request: auth + RLS context +
+  query + serialize + render), NOT only via `EXPLAIN`.
+
+  The PRIMARY signal stays the deterministic plan assertion (index-backed, no full-corpus
+  Sort) — already enforced by `topk_endpoints_scale_test.exs` /
+  `distant_pairs_novelty_scale_test.exs`. This test adds the SECONDARY, ADVISORY wall-clock
+  budget the AC calls for, measured the way prod actually experiences it — the full conn
+  call — so a regression that keeps the plan index-backed but blows the budget (serialization
+  bloat, an extra round-trip) is still surfaced.
+
+  ## Why advisory/secondary (and how it avoids flaking)
+
+  Wall-clock on shared CI hardware is noisy. So the budget is DELIBERATELY GENEROUS
+  (`:scale_latency_budget_ms`, default 2000ms — the Theme-2 acceptance target) and the
+  deterministic plan gate is the real arbiter. The budget is configurable per AC-27.8.6 so
+  it can be tuned as prod grows. A breach here is a signal to investigate, not a hair-trigger
+  red — but it is a REAL timed conn, so a true blow-up (e.g. a reintroduced full-corpus Sort
+  that the plan gate somehow missed) trips it.
+
+  ## How the conn sees the committed 80k corpus
+
+  The scale corpus, tenant, and an agent API key are seeded COMMITTED via
+  `Sandbox.unboxed_run(AdminRepo, …)`. The request path's DB reads are on `AdminRepo`
+  (auth `verify_api_key`, the vector heavy-reads via `HeavyRead`→AdminRepo in test) and
+  `Loopctl.Repo` (analytics). We take SHARED sandbox ownership of all three repos for the
+  test process; a shared-sandbox checkout SEES committed rows (verified), so the real conn —
+  running in the test process — reads the committed 80k corpus.
+
+  `:scale_nightly`, wired into the CI `scale_file` matrix (enforced by
+  `scale_verification_runbook_test.exs`).
+  """
+  use ExUnit.Case, async: false
+
+  import Plug.Conn
+  import Phoenix.ConnTest
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Loopctl.AdminRepo
+  alias Loopctl.Auth
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.ScaleSeed
+  alias Loopctl.PlanAssertions
+  alias Loopctl.Tenants.Tenant
+
+  import Ecto.Query
+
+  @endpoint LoopctlWeb.Endpoint
+
+  @moduletag :scale_nightly
+  @moduletag timeout: :timer.minutes(30)
+
+  # Advisory wall-clock budget (AC-27.8.4/.6), configurable so the gate is tuned as prod
+  # grows. Default 2000ms = the Theme-2 "<2s" acceptance target.
+  defp latency_budget_ms,
+    do: Application.get_env(:loopctl, :scale_latency_budget_ms, 2000)
+
+  defp unboxed(fun), do: Sandbox.unboxed_run(AdminRepo, fun)
+
+  setup do
+    # 1. Seed the corpus + tenant + an agent API key — all COMMITTED (unboxed) so the real
+    #    conn (which reads on AdminRepo) finds them.
+    {tenant, raw_key} =
+      unboxed(fn ->
+        slug = "e2e-lat-#{:erlang.phash2(Ecto.UUID.generate())}"
+
+        {:ok, t} =
+          %Tenant{}
+          |> Tenant.create_changeset(%{
+            name: "E2E Latency #{slug}",
+            slug: slug,
+            email: "#{slug}@example.com",
+            settings: %{},
+            status: :active
+          })
+          |> AdminRepo.insert()
+
+        ScaleSeed.seed(t.id, count: ScaleSeed.prod_article_floor(), link_density: 5)
+
+        {:ok, {raw, _api_key}} =
+          Auth.generate_api_key(%{
+            tenant_id: t.id,
+            name: "e2e-latency-agent",
+            role: :agent
+          })
+
+        {t, raw}
+      end)
+
+    unboxed(fn -> PlanAssertions.assert_scale_floor!(tenant.id) end)
+
+    # A real, embedded, published, SHARED target article for the suggested_links request.
+    # The endpoint applies the agent key's visibility scope (shared + own); pick a `shared`
+    # row so the agent can see it (ScaleSeed makes ~10% `private` — those would 404 for this
+    # agent, which is correct behavior, just not what we're timing).
+    target_id =
+      unboxed(fn ->
+        AdminRepo.one(
+          from(a in Article,
+            where:
+              a.tenant_id == ^tenant.id and a.status == :published and not is_nil(a.embedding) and
+                fragment("COALESCE(?->>'visibility', 'shared') = 'shared'", a.metadata),
+            order_by: [asc: a.inserted_at, asc: a.id],
+            offset: 100,
+            limit: 1,
+            select: a.id
+          )
+        )
+      end)
+
+    # 2. Take SHARED sandbox ownership for the test process on all three repos so the conn
+    #    request (running in this process) has connections; committed rows are visible to a
+    #    shared checkout. Drop ownership + clean up committed rows on exit.
+    repo_pid = Sandbox.start_owner!(Loopctl.Repo, shared: true)
+    admin_pid = Sandbox.start_owner!(AdminRepo, shared: true)
+    heavy_pid = Sandbox.start_owner!(Loopctl.HeavyReadRepo, shared: true)
+
+    # 3. The real request pipeline calls config-DI mock dependencies (clock, rate limiter,
+    #    health, embedding, …) that need their permissive default stubs. This is a plain
+    #    `ExUnit.Case` (not ConnCase), so install them explicitly. `set_mox_global` makes the
+    #    stubs visible from the request process (= the test process for ConnTest, and any
+    #    plug it calls). Then override the embedding stub with a real seeded vector so the
+    #    semantic ANN scores against the committed corpus.
+    Mox.set_mox_global()
+    Loopctl.DataCase.stub_all_defaults()
+
+    Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _text ->
+      {:ok, ScaleSeed.embedding_for(0)}
+    end)
+
+    on_exit(fn ->
+      Sandbox.stop_owner(repo_pid)
+      Sandbox.stop_owner(admin_pid)
+      Sandbox.stop_owner(heavy_pid)
+
+      try do
+        unboxed(fn ->
+          AdminRepo.delete_all(from(k in Loopctl.Auth.ApiKey, where: k.tenant_id == ^tenant.id))
+
+          AdminRepo.delete_all(from(a in Article, where: a.tenant_id == ^tenant.id))
+          AdminRepo.delete_all(from(t in Tenant, where: t.id == ^tenant.id))
+        end)
+      rescue
+        _ -> :ok
+      end
+    end)
+
+    {:ok, tenant: tenant, raw_key: raw_key, target_id: target_id}
+  end
+
+  defp auth_conn(raw_key) do
+    build_conn()
+    # The witness STH header the ValidateWitnessHeader plug expects (mirrors ConnCase).
+    |> put_req_header("x-loopctl-last-known-sth", "0:AAAAAAAAAAAAAAAAAAAAAA")
+    |> put_req_header("authorization", "Bearer #{raw_key}")
+  end
+
+  test "GET suggested_links completes end-to-end under the advisory latency budget at 80k",
+       %{raw_key: raw_key, target_id: target_id} do
+    {elapsed_us, conn} =
+      :timer.tc(fn ->
+        raw_key
+        |> auth_conn()
+        |> get("/api/v1/knowledge/articles/#{target_id}/suggested_links", %{
+          "limit" => "5",
+          "threshold" => "0.5"
+        })
+      end)
+
+    # Correctness first: a real 200 on the committed corpus (proves the conn truly exercised
+    # the request path against the 80k rows, not a 401/404/500 short-circuit).
+    body = json_response(conn, 200)
+    assert is_list(body["data"])
+    assert is_map(body["meta"])
+
+    elapsed_ms = div(elapsed_us, 1000)
+    budget = latency_budget_ms()
+
+    # ADVISORY/SECONDARY (AC-27.8.4): generous budget, the deterministic plan gate is the
+    # real arbiter. A breach is a signal to investigate a serialization/round-trip
+    # regression, surfaced as a legible failure (not a silent skip).
+    assert elapsed_ms <= budget,
+           "suggested_links end-to-end took #{elapsed_ms}ms, advisory budget #{budget}ms " <>
+             "(:scale_latency_budget_ms). The deterministic plan gate is primary; investigate " <>
+             "a serialize/render/round-trip regression."
+  end
+
+  test "GET semantic search completes end-to-end under the advisory latency budget at 80k",
+       %{raw_key: raw_key} do
+    {elapsed_us, conn} =
+      :timer.tc(fn ->
+        raw_key
+        |> auth_conn()
+        |> get("/api/v1/knowledge/search", %{
+          "q" => "scale idea",
+          "mode" => "semantic",
+          "limit" => "10"
+        })
+      end)
+
+    body = json_response(conn, 200)
+    assert is_list(body["data"])
+    assert is_map(body["meta"])
+
+    elapsed_ms = div(elapsed_us, 1000)
+    budget = latency_budget_ms()
+
+    assert elapsed_ms <= budget,
+           "semantic search end-to-end took #{elapsed_ms}ms, advisory budget #{budget}ms " <>
+             "(:scale_latency_budget_ms). The deterministic plan gate is primary; investigate " <>
+             "a serialize/render/round-trip regression."
+  end
+end

--- a/test/loopctl/knowledge/vector_endpoint_e2e_latency_scale_test.exs
+++ b/test/loopctl/knowledge/vector_endpoint_e2e_latency_scale_test.exs
@@ -20,6 +20,14 @@ defmodule Loopctl.Knowledge.VectorEndpointE2eLatencyScaleTest do
   red — but it is a REAL timed conn, so a true blow-up (e.g. a reintroduced full-corpus Sort
   that the plan gate somehow missed) trips it.
 
+  ## What this does NOT exercise (review note)
+
+  In `:test` the heavy-read DI routes through `AdminRepo`, not the dedicated `HeavyReadRepo`
+  pool — so this conn timing does NOT cover the heavy-pool checkout / `statement_timeout`
+  dimension; that is covered by the worker-latency + heavy-read-timeout assertions in
+  `topk_endpoints_scale_test.exs`. This test's distinct value is the full HTTP path
+  (auth / RLS / serialize / render) wall-clock.
+
   ## How the conn sees the committed 80k corpus
 
   The scale corpus, tenant, and an agent API key are seeded COMMITTED via

--- a/test/loopctl/knowledge/vector_search_under_fill_scale_test.exs
+++ b/test/loopctl/knowledge/vector_search_under_fill_scale_test.exs
@@ -31,6 +31,7 @@ defmodule Loopctl.Knowledge.VectorSearchUnderFillScaleTest do
   alias Loopctl.Knowledge.ArticleLink
   alias Loopctl.Knowledge.ScaleSeed
   alias Loopctl.Knowledge.VectorSearch
+  alias Loopctl.PlanAssertions
   alias Loopctl.TelemetryEvents
   alias Loopctl.Tenants.Tenant
 
@@ -224,9 +225,9 @@ defmodule Loopctl.Knowledge.VectorSearchUnderFillScaleTest do
         v
       end)
 
-    assert gate_ef == prod_ef,
-           "ef_search diverged: gate=#{inspect(gate_ef)} prod=#{inspect(prod_ef)} " <>
-             "(SHOW hnsw.ef_search must match between the scale gate and the prod-shaped pool)"
+    # The SHARED parity assertion (US-27.8) — the calibration-mismatch test drives the SAME
+    # function in the failure direction, so the gate and its failure-test can't drift.
+    assert :ok = PlanAssertions.assert_ef_search_parity!(gate_ef, prod_ef)
 
     # And it is the pgvector default (40) until US-27.11's ALTER ROLE lever is applied.
     assert gate_ef == "40"

--- a/test/support/plan_assertions.ex
+++ b/test/support/plan_assertions.ex
@@ -539,11 +539,36 @@ defmodule Loopctl.PlanAssertions do
   end
 
   @doc """
+  Raises unless the EFFECTIVE `hnsw.ef_search` is identical on the scale-gate connection
+  and a prod-shaped one (US-27.8 AC-27.8.3). Pass the two values each side reads via
+  `SHOW hnsw.ef_search`. This is the ONE parity assertion both the under-fill scale gate
+  (success direction — real two-connection read) and the calibration-mismatch test
+  (failure direction — injected divergent values) drive, so the failure path exercises the
+  REAL comparison + message rather than a duplicated local copy. An ef_search mismatch
+  between gate and prod silently skews recall/latency, so the gate must FAIL on it.
+  """
+  @spec assert_ef_search_parity!(String.t(), String.t()) :: :ok
+  def assert_ef_search_parity!(gate_ef, prod_ef) do
+    if gate_ef == prod_ef do
+      :ok
+    else
+      raise ExUnit.AssertionError,
+        message:
+          "ef_search diverged: gate=#{inspect(gate_ef)} prod=#{inspect(prod_ef)} " <>
+            "(SHOW hnsw.ef_search must match between the scale gate and the prod-shaped pool)"
+    end
+  end
+
+  @doc """
   Raises unless `articles` holds real, analyzed rows — verified by an ACTUAL
   `count(*)` (reflecting committed reality, not autovacuum's lazy/sticky/cross-tenant
   `n_live_tup` estimate, which is blind to stale-high) AND a non-null `last_analyze`.
   Prevents a plan assertion from running against an unseeded/empty or unanalyzed corpus
   (AC-27.2.5). ScaleSeed already asserts `last_analyze` ADVANCED for the current run.
+
+  NOTE: `assert_scale_floor!/1` is a COUNT precondition only — it does NOT check
+  freshness. Pair it with this (or a plan assertion that itself gates on fresh stats);
+  `ScaleSeed.seed/2` runs `ANALYZE articles`, so after seeding both hold.
   """
   def assert_fresh_stats! do
     %{rows: [[real_count]]} = AdminRepo.query!("SELECT count(*) FROM articles")

--- a/test/support/plan_assertions.ex
+++ b/test/support/plan_assertions.ex
@@ -25,6 +25,7 @@ defmodule Loopctl.PlanAssertions do
 
   alias Ecto.Adapters.SQL
   alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge.ScaleSeed
 
   # Node types that read the whole `articles` relation (the #172 timeout shape).
   # "Seq Scan" covers Parallel Seq Scan (same Node Type, Parallel Aware flag).
@@ -485,6 +486,55 @@ defmodule Loopctl.PlanAssertions do
             "Expected EXACTLY ONE scan on `articles` (the HNSW index), got #{length(many)}: " <>
               "#{inspect(Enum.map(many, & &1.node_type))} — a sibling full-scan could hide a " <>
               "full-corpus read. Plan:\n#{elide(raw)}"
+    end
+  end
+
+  @doc """
+  Raises unless the seeded corpus is AT OR ABOVE the production floor
+  (`Loopctl.Knowledge.ScaleSeed.prod_article_floor/0`, currently 80k) — the calibration
+  precondition for a vector scale gate (US-27.8 AC-27.8.3 / TC-27.8.3).
+
+  `assert_fresh_stats!/0` only proves the corpus is non-empty + analyzed; it does NOT
+  prove it is large enough for the planner's cost-based HNSW choice to be representative.
+  At sub-floor scale the planner Seq-Scans happily and an index-usage assertion is a LIE
+  (it would false-GREEN on a regression). This guard makes a sub-floor seed FAIL LOUDLY
+  with an explicit calibration error instead.
+
+  Counts the COMMITTED rows for `tenant_id` (an ACTUAL `count(*)`, like
+  `assert_fresh_stats!/0`, not the autovacuum estimate). Tenant-scoped because each scale
+  test seeds its OWN ~80k tenant; the floor is a per-tenant property of THAT seed.
+
+  Raises `ExUnit.AssertionError` naming the actual vs required count and pointing at the
+  documented floor-bump step (AC-27.8.6) when below floor.
+  """
+  def assert_scale_floor!(tenant_id) when is_binary(tenant_id) do
+    floor = ScaleSeed.prod_article_floor()
+
+    %{rows: [[real_count]]} =
+      AdminRepo.query!("SELECT count(*) FROM articles WHERE tenant_id = $1", [
+        Ecto.UUID.dump!(tenant_id)
+      ])
+
+    cond do
+      is_nil(real_count) or real_count <= 0 ->
+        raise ExUnit.AssertionError,
+          message:
+            "Scale calibration FAILED: tenant #{inspect(tenant_id)} has an EMPTY `articles` " <>
+              "(committed count=#{inspect(real_count)}). Seed via " <>
+              "Loopctl.Knowledge.ScaleSeed.seed(tenant_id, count: ScaleSeed.prod_article_floor()) first."
+
+      real_count < floor ->
+        raise ExUnit.AssertionError,
+          message:
+            "Scale calibration FAILED (sub-floor seed): tenant #{inspect(tenant_id)} has " <>
+              "#{real_count} committed articles, BELOW the prod floor of #{floor} " <>
+              "(Loopctl.Knowledge.ScaleSeed.prod_article_floor/0). A vector index-usage gate " <>
+              "at sub-floor scale is theatre — the planner Seq-Scans happily and the assertion " <>
+              "false-GREENs. Seed at least #{floor} rows; to raise the floor as prod grows, bump " <>
+              "@prod_article_floor in Loopctl.Knowledge.ScaleSeed (a documented step — AC-27.8.6)."
+
+      true ->
+        :ok
     end
   end
 


### PR DESCRIPTION
## US-27.8 — Standing per-endpoint vector scale gates + the cosine-`<=>` reintroduction lint

Makes "no index-defeating cosine query reaches prod" a **standing CI property**, closing the
class of regression that shipped the `suggested_links` 500 three times (#168/#170/#172).

### What ships
- **Custom Credo check** `Loopctl.Credo.Check.CosineQueryReintroduction` (lives under `.credo/`,
  excluded from the prod release; loaded via `.credo.exs` `requires:`): fails `mix credo --strict`
  if a NEW hand-rolled pgvector distance (`<=>`/`<->`/`<#>` or the `cosine_distance(`/`l2_distance(`/
  `inner_product(` spellings) appears in `lib/loopctl` outside the sanctioned
  `Loopctl.Knowledge.VectorSearch` helper and not in the auditable
  `Loopctl.Knowledge.CosineLintExceptions` allowlist. Detects plain / interpolated / concatenated
  fragment templates and the raw-SQL entrypoints (`query`/`query!`/`query_many`/`query_many!`/
  `stream`/`explain`); scopes `fragment` to its template arg so a value-arg token is not a false
  positive. The allowlist exempts the LINT location only — never a bad SHAPE from the plan gate.
- **Per-endpoint 80k index-usage gates** on every vector path (`suggested_links`, semantic search
  results+count, `distant_pairs`, `novelty`, the auto-link worker) on the REAL request-path query,
  plus an ADVISORY end-to-end wall-clock budget through the real HTTP conn.
- **Calibration gates that fail loudly**: a sub-floor seed or an `ef_search` mismatch FAILS the
  gate (the `ef_search` failure direction drives a REAL `SET LOCAL hnsw.ef_search` session
  divergence read, not a synthetic compare).
- **Runbook**: the `knowledge_scale_verification.md` gate section documents what each gate covers,
  the e2e-latency partial-coverage caveat (heavy-pool/`statement_timeout` dimension is covered
  separately), and the per-PR `Scale Tests` vs schedule-only `:scale_nightly` plan-gate distinction.

### Review
Full enhanced review applied (team + adversarial rounds, VCA each, zero deferrals):
- **R1 (team):** closed lint false-negatives (interpolated/concat fragments, nested-module
  misattribution), de-tautologized the `ef_search` parity test into the shared
  `PlanAssertions.assert_ef_search_parity!/2`.
- **R2 (adversarial):** broadened the distance-token family (F1) + raw-SQL entrypoints (SQL-1/2),
  fragment-arg scoping (F3), nested-fragment de-dup (F5); added the WIRING guard (E1: `.credo.exs`
  enables + requires the check and the load-bearing registry), the inline-`credo:disable` guard
  (DISABLE-1), and the file-set tripwire backstopping the documented var/@attr no-literal residuals;
  made the `ef_search` failure direction a real GUC divergence; institutionalized the e2e
  partial-coverage + per-PR-vs-nightly notes in the runbook.
- Architect F2 (drop the registry require) was DISPROVED — the require is load-bearing (the check
  fails closed without it); the cosmetic "redefining module" warning is benign and the check is
  proven live in `mix credo --strict` against a planted rogue site.

`mix precommit` green (2957 tests, 0 failures; credo 70 checks 0 issues; sobelow clean; dialyzer 0).
The touched `:scale_nightly` gates pass at a fresh 80k corpus.