### PR TITLE
fix(prod outage): HeavyReadRepo pgbouncer 08P01 — statement_timeout via SET LOCAL, not startup :parameters (US-27.13)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,6 +344,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y pgbouncer
+          # The apt package enables/starts a default pgbouncer (own /etc/pgbouncer.ini on
+          # :6432 with no loopctl_test db). Stop it so OUR instance owns the port.
+          sudo systemctl stop pgbouncer 2>/dev/null || true
           printf '"postgres" "postgres"\n' > /tmp/userlist.txt
           cat > /tmp/pgbouncer.ini <<'INI'
           [databases]
@@ -357,7 +360,10 @@ jobs:
           pool_mode = transaction
           max_client_conn = 50
           default_pool_size = 10
+          pidfile = /tmp/pgbouncer.pid
+          logfile = /tmp/pgbouncer.log
           INI
+          # `-d` (daemonize) REQUIRES a pidfile (FATAL otherwise).
           pgbouncer -d /tmp/pgbouncer.ini
           # Wait for pgbouncer to accept connections through to Postgres.
           for i in $(seq 1 15); do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,13 +365,17 @@ jobs:
           INI
           # `-d` (daemonize) REQUIRES a pidfile (FATAL otherwise).
           pgbouncer -d /tmp/pgbouncer.ini
-          # Wait for pgbouncer to accept connections through to Postgres.
+          # Wait for pgbouncer to accept connections through to Postgres. Fail LOUDLY if it
+          # never comes up, so the job reports "pgbouncer never started" rather than a
+          # confusing downstream Postgrex error from the test.
+          up=""
           for i in $(seq 1 15); do
             if PGPASSWORD=postgres psql "host=127.0.0.1 port=6432 dbname=loopctl_test user=postgres" -tAc "SELECT 1" >/dev/null 2>&1; then
-              echo "pgbouncer up"; break
+              echo "pgbouncer up"; up=1; break
             fi
             echo "waiting for pgbouncer ($i)"; sleep 1
           done
+          if [ -z "$up" ]; then echo "pgbouncer failed to come up"; cat /tmp/pgbouncer.log || true; exit 1; fi
 
       - name: Run the pgbouncer e2e (reproduces 08P01 + proves the SET LOCAL fix)
         run: mix test --include pgbouncer test/loopctl/pgbouncer_startup_params_test.exs
@@ -513,7 +517,10 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    needs: [lint, test, security, dialyzer]
+    # pgbouncer-e2e gates deploy (US-27.13): it is the only check that exercises the pgbouncer
+    # layer, so a reintroduced pgbouncer-incompatible config must block the deploy, not just
+    # go red advisorily.
+    needs: [lint, test, security, dialyzer, pgbouncer-e2e]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,7 +299,14 @@ jobs:
     # crash-looping the HeavyReadRepo pool) was invisible in CI. This job stands up a REAL
     # pgbouncer (transaction pooling) in front of Postgres and runs the :pgbouncer e2e, which
     # reproduces the rejection and proves the SET LOCAL fix enforces through the proxy.
+    #
+    # This job GATES deploy (deploy `needs:` it). To keep a transient apt/infra hiccup from
+    # blocking emergency deploys, the install step retries and the whole job is time-bounded;
+    # a genuine RED here (a real pgbouncer-incompatible regression) still blocks deploy. If an
+    # apt outage ever blocks an urgent deploy, re-run the job or temporarily detach the gate
+    # with sign-off — a test failure and an infra failure are different signals.
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     services:
       postgres:
         image: pgvector/pgvector:pg16
@@ -342,8 +349,12 @@ jobs:
 
       - name: Install and start pgbouncer (transaction pooling) in front of Postgres
         run: |
-          sudo apt-get update
-          sudo apt-get install -y pgbouncer
+          # Retry the install so a transient apt-mirror hiccup doesn't block a deploy.
+          for attempt in 1 2 3; do
+            sudo apt-get update && sudo apt-get install -y pgbouncer && break
+            echo "apt install attempt $attempt failed; retrying"; sleep 5
+          done
+          command -v pgbouncer >/dev/null || { echo "pgbouncer install failed after retries"; exit 1; }
           # The apt package enables/starts a default pgbouncer (own /etc/pgbouncer.ini on
           # :6432 with no loopctl_test db). Stop it so OUR instance owns the port.
           sudo systemctl stop pgbouncer 2>/dev/null || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,6 +292,86 @@ jobs:
         env:
           DATABASE_URL: ecto://postgres:postgres@localhost/loopctl_test
 
+  pgbouncer-e2e:
+    name: Pgbouncer e2e (US-27.13)
+    # The default Test job connects to DIRECT Postgres, which ACCEPTS a statement_timeout
+    # startup parameter — so the US-27.13 outage (pgbouncer rejecting it with 08P01 and
+    # crash-looping the HeavyReadRepo pool) was invisible in CI. This job stands up a REAL
+    # pgbouncer (transaction pooling) in front of Postgres and runs the :pgbouncer e2e, which
+    # reproduces the rejection and proves the SET LOCAL fix enforces through the proxy.
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: erlef/setup-beam@v1
+        with:
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+          otp-version: ${{ env.OTP_VERSION }}
+
+      - name: Restore dependencies cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-mix-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ hashFiles('mix.lock', 'config/*.exs') }}
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Compile
+        run: mix compile
+
+      - name: Create the loopctl_test database (the e2e only needs the DB to exist)
+        run: PGPASSWORD=postgres psql -h localhost -U postgres -c "CREATE DATABASE loopctl_test;"
+
+      - name: Install and start pgbouncer (transaction pooling) in front of Postgres
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pgbouncer
+          printf '"postgres" "postgres"\n' > /tmp/userlist.txt
+          cat > /tmp/pgbouncer.ini <<'INI'
+          [databases]
+          loopctl_test = host=localhost port=5432 dbname=loopctl_test user=postgres password=postgres
+
+          [pgbouncer]
+          listen_addr = 127.0.0.1
+          listen_port = 6432
+          auth_type = trust
+          auth_file = /tmp/userlist.txt
+          pool_mode = transaction
+          max_client_conn = 50
+          default_pool_size = 10
+          INI
+          pgbouncer -d /tmp/pgbouncer.ini
+          # Wait for pgbouncer to accept connections through to Postgres.
+          for i in $(seq 1 15); do
+            if PGPASSWORD=postgres psql "host=127.0.0.1 port=6432 dbname=loopctl_test user=postgres" -tAc "SELECT 1" >/dev/null 2>&1; then
+              echo "pgbouncer up"; break
+            fi
+            echo "waiting for pgbouncer ($i)"; sleep 1
+          done
+
+      - name: Run the pgbouncer e2e (reproduces 08P01 + proves the SET LOCAL fix)
+        run: mix test --include pgbouncer test/loopctl/pgbouncer_startup_params_test.exs
+        env:
+          PGBOUNCER_URL: postgres://postgres:postgres@127.0.0.1:6432/loopctl_test
+
   scale-nightly:
     name: Scale Nightly (${{ matrix.scale_file }})
     # Runs nightly to assert every heavy endpoint's planner path at PROD_ARTICLE_FLOOR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to loopctl are documented here.
 
+## [Unreleased] — 2026-06-25 — heavy-read pgbouncer outage fix (US-27.13)
+
+### Fixed
+
+- **HeavyReadRepo pgbouncer `08P01` outage (US-27.13):** the dedicated heavy-read pool
+  carried a `statement_timeout` connection STARTUP parameter (`parameters:` in
+  `config/runtime.exs`), which Fly MPG's pgbouncer rejects with
+  `FATAL 08P01 unsupported startup parameter`, crash-looping the pool so it never
+  established a connection — every heavy vector/enumeration endpoint (`suggested_links`,
+  semantic search, `distant_pairs`, `novelty`, heavy enumeration) hung then `503/504`'d.
+  It was invisible to CI because the suite connects to direct Postgres (which accepts the
+  startup param) and aliases heavy reads to `AdminRepo`. The server-side `statement_timeout`
+  is now applied per-read via `SET LOCAL` inside a transaction (the pgbouncer-safe mechanism).
+
+### Changed
+
+- **Heavy-read `statement_timeout` configuration:** set via `HEAVY_READ_STATEMENT_TIMEOUT_MS`
+  (default 10s) and the per-endpoint `:heavy_read_statement_timeout_overrides` map, applied
+  per-read via `SET LOCAL` — **NOT** a connection startup `:parameters` value
+  (pgbouncer-incompatible). A server GUC that must persist at connect is set via `ALTER ROLE`
+  (the documented `hnsw.ef_search` lever), never a startup parameter.
+
+### Added
+
+- **Recurrence guards:** `config_pgbouncer_safe_parameters_test.exs` (scans the config
+  source — incl. `runtime.exs` — and fails on any pgbouncer-incompatible repo `:parameters`)
+  and a pgbouncer-layer e2e (`pgbouncer_startup_params_test.exs` + a CI `pgbouncer-e2e` job
+  that gates deploy) which reproduces the `08P01` rejection and proves `SET LOCAL` enforces
+  through the proxy.
+
 ## [Unreleased] — 2026-06-22 — knowledge wiki harvest-hardening (#132–#138)
 
 A batch of Knowledge Wiki API changes for reliable agent/harvest workflows.

--- a/config/config.exs
+++ b/config/config.exs
@@ -31,10 +31,11 @@ config :loopctl,
   # handler. Tunable in config/env without a code change.
   slow_query_threshold_ms: 1_000,
   # US-27.4: optional per-endpoint SERVER-SIDE statement_timeout overrides (ms) for
-  # heavy reads, e.g. %{suggested_links: 5_000}. Endpoints absent here use the
-  # pool-level statement_timeout (HEAVY_READ_STATEMENT_TIMEOUT_MS, default 10s) with
-  # no per-request transaction. Keys: :suggested_links, :semantic_search,
-  # :distant_pairs, :novelty, :enumeration, :change_feed. NOTE: :distant_pairs,
+  # heavy reads, e.g. %{suggested_links: 5_000}. Endpoints absent here use the default
+  # per-read SET LOCAL statement_timeout (HEAVY_READ_STATEMENT_TIMEOUT_MS, default 10s;
+  # US-27.13 — NOT a startup :parameters value, which pgbouncer rejects). Keys:
+  # :suggested_links, :semantic_search, :distant_pairs, :novelty, :enumeration,
+  # :change_feed, :vector_search. NOTE: :distant_pairs,
   # :semantic_search, and :enumeration each issue TWO reads (count + data); setting an
   # override for any of them wraps EACH read in its own separate transaction, doubling
   # the brief checkout count on the heavy pool. :change_feed (US-27.9b) is the

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -21,8 +21,10 @@ config :loopctl, Loopctl.AdminRepo,
   pool_size: 3
 
 # HeavyReadRepo — same credentials/database in dev (BYPASSRLS role in production).
-# Small pool in dev; a real statement_timeout :parameters is configured in prod
-# (runtime.exs). See Loopctl.HeavyReadRepo.
+# Small pool in dev. The server-side statement_timeout is applied per-read via SET LOCAL
+# (Loopctl.HeavyRead.opts/1), defaulting to 10s in dev since `:heavy_read_statement_timeout_ms`
+# is unset here. It is NOT a startup `:parameters` value (pgbouncer rejects that — 08P01,
+# US-27.13). See Loopctl.HeavyReadRepo.
 config :loopctl, Loopctl.HeavyReadRepo,
   username: "postgres",
   password: "postgres",

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -107,10 +107,12 @@ if config_env() == :prod do
   #   deploy at 2 nodes = 42 + 21 (overlap node) + 4 ops = 67 < 100 (max ~3 nodes).
   # K (HeavyReadRepo, default 8): ~6 concurrent sub-2s heavy vector reads + ~2 reserved
   # for long-held streamed-export checkouts (US-27.16), a different profile than fast reads.
-  # Parse to an integer so a garbage/typo value (e.g. "10s", "10,000") fails LOUDLY at
-  # boot rather than being sent verbatim and rejected by Postgres per-connection (which
-  # would fail the whole pool's startup). Postgres reads a bare integer as milliseconds,
-  # matching the `_MS` env name; re-stringified for the startup packet.
+  # Parse to an integer so a garbage/typo value (e.g. "10s", "10,000") fails LOUDLY at boot
+  # (a deploy-time misconfiguration guard) rather than silently degrading. Postgres reads a
+  # bare integer as milliseconds, matching the `_MS` env name. NB: this value is now applied
+  # per-read via `SET LOCAL` (US-27.13), NOT a startup packet — `HeavyRead.opts/1` reads it
+  # and `HeavyRead.default_statement_timeout/0` additionally fails SOFT (falls back to 10s) on
+  # a bad app-env value, so the boot-raise here is the strict outer guard.
   heavy_read_statement_timeout_ms =
     String.to_integer(System.get_env("HEAVY_READ_STATEMENT_TIMEOUT_MS") || "10000")
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -85,13 +85,20 @@ if config_env() == :prod do
 
   # HeavyReadRepo (US-27.11) — dedicated BYPASSRLS pool for heavy vector/enumeration
   # reads, isolated from the small AdminRepo pool so a slow read can't starve light
-  # admin ops (and vice-versa). Its `:parameters` carry a pool-level, server-side
-  # `statement_timeout` (a CORE GUC, settable via the startup packet) — the clean
-  # fast-fail lever US-27.4 builds on, with no per-request transaction. A long-held
-  # US-27.16 export overrides it per-transaction via SET LOCAL (see Loopctl.HeavyRead
-  # `transaction/2` `:statement_timeout`). `ef_search` is NOT set here (pgvector custom
-  # GUC, rejected via :parameters on managed PG); see docs/runbooks/knowledge-scale.md
-  # for the ALTER ROLE mechanism if it must be raised.
+  # admin ops (and vice-versa).
+  #
+  # The server-side `statement_timeout` is applied PER-READ via `SET LOCAL` inside the
+  # HeavyRead transaction path (Loopctl.HeavyRead.opts/1 → all/one → transaction/2),
+  # NOT as a connection startup `:parameter`. This is load-bearing: Fly MPG fronts
+  # Postgres with pgbouncer, which allows only an allowlisted set of startup parameters
+  # and REJECTS a `statement_timeout` startup parameter with
+  # `FATAL 08P01 unsupported startup parameter: statement_timeout`. Setting it via
+  # `:parameters` crash-loops EVERY HeavyReadRepo connection (the pool never establishes
+  # one) and 503/504s every heavy endpoint (suggested_links, semantic search,
+  # distant_pairs, novelty, heavy enumeration). `SET LOCAL` inside a transaction is the
+  # pgbouncer-safe path and is verified to enforce against the live pool. Likewise
+  # `ef_search` is NOT settable via :parameters on managed PG (a pgvector custom GUC);
+  # see docs/runbooks/knowledge-scale.md for the ALTER ROLE mechanism if it must change.
   #
   # Pool sizes here MUST stay in lockstep with `Loopctl.DbCapacity` (which models the
   # connection budget and is asserted in db_capacity_test.exs). Sizing (AC-27.11.1/.5),
@@ -106,6 +113,11 @@ if config_env() == :prod do
   # matching the `_MS` env name; re-stringified for the startup packet.
   heavy_read_statement_timeout_ms =
     String.to_integer(System.get_env("HEAVY_READ_STATEMENT_TIMEOUT_MS") || "10000")
+
+  # Consumed by Loopctl.HeavyRead.opts/1 as the DEFAULT server-side statement_timeout
+  # for any heavy endpoint without a per-endpoint override — applied via SET LOCAL on
+  # the read path (pgbouncer-safe), replacing the rejected startup `:parameters` lever.
+  config :loopctl, :heavy_read_statement_timeout_ms, heavy_read_statement_timeout_ms
 
   # Slow-query logging threshold (US-27.4). Parse to integer for the same reason —
   # garbage values fail loudly at boot. Default 1000ms.
@@ -160,8 +172,11 @@ if config_env() == :prod do
     socket_options: maybe_ipv6,
     connect_timeout: 15_000,
     queue_target: 5_000,
-    queue_interval: 10_000,
-    parameters: [statement_timeout: "#{heavy_read_statement_timeout_ms}"]
+    queue_interval: 10_000
+
+  # NOTE: no `parameters: [statement_timeout: ...]` here — pgbouncer rejects it (08P01).
+  # The timeout is enforced per-read via SET LOCAL (HeavyRead.opts/1). See the comment
+  # above and config_pgbouncer_safe_parameters_test.exs (the regression guard).
 
   # OpenAI embedding provider for semantic search (Knowledge Wiki)
   if openai_key = System.get_env("OPENAI_API_KEY") do

--- a/config/test.exs
+++ b/config/test.exs
@@ -26,12 +26,18 @@ config :loopctl, Loopctl.AdminRepo,
   # Allow the unboxed connection to be held long enough for the prod-floor seed.
   ownership_timeout: :timer.minutes(30)
 
-# HeavyReadRepo (US-27.11) — sandbox mode for tests, with a deliberately LOW
-# pool-level statement_timeout (250ms) so the mechanism tests (SHOW + fast-fire)
-# are fast and deterministic. Nothing in the default suite routes heavy DATA reads
-# here — `:heavy_read_repo` below points heavy reads at AdminRepo so they share the
-# sandbox connection fixtures insert through; only the dedicated HeavyReadRepo pool
-# tests touch this repo directly.
+# HeavyReadRepo (US-27.11) — sandbox mode for tests. Nothing in the default suite routes
+# heavy DATA reads here — `:heavy_read_repo` below points heavy reads at AdminRepo so they
+# share the sandbox connection fixtures insert through; only the dedicated HeavyReadRepo
+# pool tests touch this repo directly.
+#
+# NO `parameters: [statement_timeout: ...]` here — the test config must MIRROR prod, which
+# CANNOT carry that startup parameter: Fly MPG fronts Postgres with pgbouncer, which rejects
+# a `statement_timeout` startup parameter with `08P01 unsupported startup parameter` and
+# crash-loops the whole pool (the US-27.13 outage). The original param "passed" in CI only
+# because the suite connects to DIRECT Postgres (which accepts it) — the exact false
+# confidence that hid the bug. The server-side timeout is now applied per-read via SET LOCAL;
+# config_pgbouncer_safe_parameters_test.exs blocks any repo from re-adding an incompatible key.
 config :loopctl, Loopctl.HeavyReadRepo,
   username: "postgres",
   password: "postgres",
@@ -39,11 +45,12 @@ config :loopctl, Loopctl.HeavyReadRepo,
   database: "loopctl_test#{System.get_env("MIX_TEST_PARTITION")}",
   pool: Ecto.Adapters.SQL.Sandbox,
   pool_size: System.schedulers_online() * 2,
-  ownership_timeout: :timer.minutes(30),
-  # Bare-integer ms (the format the prod path ships, validated in runtime.exs); a low
-  # 250ms so the fast-fire mechanism tests are sub-second. Postgres normalizes the
-  # display to "250ms" (asserted in heavy_read_repo_test).
-  parameters: [statement_timeout: "250"]
+  ownership_timeout: :timer.minutes(30)
+
+# The pool-wide DEFAULT server-side statement_timeout (US-27.13), applied via SET LOCAL on
+# the heavy-read path (HeavyRead.opts/1). Low (250ms) in test so the fast-fire mechanism
+# tests stay sub-second.
+config :loopctl, :heavy_read_statement_timeout_ms, 250
 
 # DI (US-27.11): route Loopctl.HeavyRead's heavy reads to AdminRepo in tests, so
 # they see the same sandbox transaction that fixtures write to. Prod/dev default to

--- a/config/test.exs
+++ b/config/test.exs
@@ -56,13 +56,16 @@ config :loopctl, :heavy_read_statement_timeout_ms, 250
 # they see the same sandbox transaction that fixtures write to. Prod/dev default to
 # the dedicated Loopctl.HeavyReadRepo pool.
 #
-# CAUTION (US-27.13): do NOT assert statement_timeout CANCELLATION via the AdminRepo-routed
-# path (`HeavyRead.all/one`). Under Sandbox, the routed `transaction/2` opens a SAVEPOINT
-# inside the test's outer transaction, and Postgres `SET LOCAL` is scoped to the TOP-LEVEL
-# transaction (not the savepoint) — so a low SET LOCAL would escape to the whole sandbox
-# transaction and spuriously cancel later queries (flaky). Assert cancellation only against
-# the dedicated `Loopctl.HeavyReadRepo` pool directly (top-level transaction), as
-# heavy_read_repo_test.exs / heavy_read_pool_isolation_test.exs do.
+# CAUTION (US-27.13 — SET LOCAL scoping under Sandbox): prefer asserting statement_timeout
+# behavior against the dedicated `Loopctl.HeavyReadRepo` pool directly (as
+# heavy_read_repo_test.exs / heavy_read_pool_isolation_test.exs do), NOT the AdminRepo-routed
+# `HeavyRead.all/one` path. Under Sandbox the routed `transaction/2` runs as a SAVEPOINT
+# inside the test's outer transaction, and `SET LOCAL` is scoped to the TOP-LEVEL
+# transaction. A CANCELLATION is self-cleaning (the query raises, the savepoint rolls back,
+# and the SET LOCAL is undone — so `heavy_read_statement_timeout_test.exs` is stable). The
+# real hazard is a SUCCESSFUL low-timeout routed read: its savepoint COMMITS, so the SET
+# LOCAL persists to the enclosing sandbox transaction and could spuriously cancel a later
+# query in the SAME test. Keep timeout assertions on the dedicated pool to avoid that.
 config :loopctl, :heavy_read_repo, Loopctl.AdminRepo
 
 # US-27.4: TC-27.4.1 integration test — set a low statement_timeout override

--- a/config/test.exs
+++ b/config/test.exs
@@ -55,6 +55,14 @@ config :loopctl, :heavy_read_statement_timeout_ms, 250
 # DI (US-27.11): route Loopctl.HeavyRead's heavy reads to AdminRepo in tests, so
 # they see the same sandbox transaction that fixtures write to. Prod/dev default to
 # the dedicated Loopctl.HeavyReadRepo pool.
+#
+# CAUTION (US-27.13): do NOT assert statement_timeout CANCELLATION via the AdminRepo-routed
+# path (`HeavyRead.all/one`). Under Sandbox, the routed `transaction/2` opens a SAVEPOINT
+# inside the test's outer transaction, and Postgres `SET LOCAL` is scoped to the TOP-LEVEL
+# transaction (not the savepoint) — so a low SET LOCAL would escape to the whole sandbox
+# transaction and spuriously cancel later queries (flaky). Assert cancellation only against
+# the dedicated `Loopctl.HeavyReadRepo` pool directly (top-level transaction), as
+# heavy_read_repo_test.exs / heavy_read_pool_isolation_test.exs do.
 config :loopctl, :heavy_read_repo, Loopctl.AdminRepo
 
 # US-27.4: TC-27.4.1 integration test — set a low statement_timeout override

--- a/docs/runbooks/knowledge-scale.md
+++ b/docs/runbooks/knowledge-scale.md
@@ -141,6 +141,48 @@ and `request_id=` empty. Lower the threshold to surface a trend before it become
 config :loopctl, :slow_query_threshold_ms, 500
 ```
 
+## pgbouncer compatibility (US-27.13 — the heavy-read outage)
+
+Fly Managed Postgres fronts Postgres with **pgbouncer**. The US-27.13 outage was a
+`statement_timeout` connection STARTUP parameter on `HeavyReadRepo` that pgbouncer rejected
+(`FATAL 08P01 unsupported startup parameter`), crash-looping the pool so every heavy endpoint
+503/504'd. It was invisible to CI because CI uses **direct Postgres** (which accepts the
+param). Hard-won rules for anything touching the DB layer behind pgbouncer:
+
+- **No GUC via connection `:parameters`.** A server GUC is applied per-read via `SET LOCAL`
+  inside a transaction (`Loopctl.HeavyRead`); a GUC that must persist at connect goes via
+  `ALTER ROLE` (the `hnsw.ef_search` lever). The config-lint
+  (`config_pgbouncer_safe_parameters_test.exs`) blocks a re-added startup `:parameters` GUC —
+  but that is ONLY the startup-parameter member of the class. It does NOT guard the other
+  pgbouncer-sensitive paths below; those depend on the **pool mode**.
+- **`prepare: :unnamed` on all three repos.** Under pgbouncer **transaction** pooling, named
+  prepared statements cached on one server connection break when the next transaction lands on
+  another (`26000`/`42P05`). All repos set `prepare: :unnamed`; the `pgbouncer-e2e` job proves
+  a query reused across `pool_size: 2` transactions succeeds.
+- **Pool-mode-sensitive paths NOT covered by the config-lint:** Oban's Postgres notifier
+  (LISTEN/NOTIFY) and any `Repo.stream` without an enclosing transaction silently misbehave
+  under transaction pooling. Keep them in mind for any new feature.
+- **VERIFY the live pgbouncer config** (the single most important setting for this whole
+  design, currently NOT pinned in-repo): run `SHOW CONFIG` via the pgbouncer admin console (or
+  Fly support) and record `pool_mode` and `ignore_startup_parameters` here with a "last
+  verified" date — same discipline as `max_connections`. Fly MPG documents **session mode** as
+  the default; the CI `pgbouncer-e2e` deliberately runs the STRICTER **transaction** mode (the
+  08P01 rejection is pool-mode-independent, and transaction mode is the harder case for
+  prepared statements), so a green e2e is a conservative superset, not an exact prod mirror.
+
+### Per-read transaction hold-time (re-verify under load — M1)
+
+US-27.13 changed each heavy read from a single autocommit `SELECT` to a short
+`BEGIN; SET LOCAL statement_timeout; SELECT; COMMIT` (~3 server round-trips, connection held
+BEGIN→COMMIT). `Loopctl.DbCapacity` models connection **count**, not hold-time, so the K≈6
+fast-read budget is now slightly more contended per the same concurrency. The per-read
+`statement_timeout` makes the pool **self-drain** (a runaway read is canceled), so this is a
+latency/throughput risk, not a deadlock — but per the "verify against prod scale" practice,
+re-check heavy-read p95 + pool queue-wait under load after deploy (the #172 incident proves
+this pool is the real contention point). Measured prod baselines at ~77k (deployed fix):
+`suggested_links` ~59ms, semantic ~45ms, novelty ~1.4s, distant_pairs ~7.9s (the slowest —
+within the 10s cap but worth watching as the corpus grows).
+
 ## Keyset pagination index (US-27.9a)
 
 The article keyset cursor seeks on `(tenant_id, inserted_at, id)`, backed by

--- a/docs/runbooks/knowledge-scale.md
+++ b/docs/runbooks/knowledge-scale.md
@@ -68,20 +68,33 @@ headroom). If you raise any pool size or node count, re-run the above and confir
 `Loopctl.DbCapacity.fits?(live_max, nodes)` stays true (the boot check logs a warning
 otherwise).
 
-## Server-side `statement_timeout` (US-27.11 → US-27.4)
+## Server-side `statement_timeout` (US-27.11 → US-27.4 → US-27.13)
 
-`Loopctl.HeavyReadRepo` carries a **pool-level** `statement_timeout` via the repo
-`:parameters` (a CORE GUC, settable in the startup packet — verified). Default
-**10s**, override with `HEAVY_READ_STATEMENT_TIMEOUT_MS`. Every query on the heavy
-pool fast-fails at this timeout (Postgres `57014`, surfaced as
-`db_statement_timeout` by US-27.3) and releases the connection promptly — no
-per-request transaction needed. So even a fully-saturated heavy pool self-drains
-within `statement_timeout`.
+Every heavy read gets a server-side `statement_timeout`, applied **per-read via
+`SET LOCAL` inside a short transaction** by `Loopctl.HeavyRead` (`opts/1` → `all/one` →
+`transaction/2`). Default **10s**, set with `HEAVY_READ_STATEMENT_TIMEOUT_MS`. A query that
+exceeds it fast-fails (Postgres `57014`, surfaced as `db_statement_timeout` by US-27.3) and
+the transaction commits/releases the connection promptly — so even a fully-saturated heavy
+pool self-drains within `statement_timeout`.
 
-Verify live:
+> **⚠ Do NOT set this as a connection startup `:parameters` value (US-27.13 outage).** Fly
+> MPG fronts Postgres with **pgbouncer**, which rejects a `statement_timeout` startup
+> parameter with `FATAL 08P01 unsupported startup parameter` and **crash-loops the entire
+> HeavyReadRepo pool** — every heavy endpoint then 503/504s. (It "works" against direct
+> Postgres, which is why CI didn't catch it; `config_pgbouncer_safe_parameters_test.exs` +
+> the `pgbouncer-e2e` CI job now guard this.) `SET LOCAL` inside a transaction is the only
+> pgbouncer-safe way to set a server GUC; a GUC that must persist at connect goes via
+> `ALTER ROLE` (the `hnsw.ef_search` lever), never `:parameters`.
+
+Verify the per-read timeout live (it is NOT a session/pool GUC, so a bare `SHOW` reads the
+server default — read it INSIDE the SET LOCAL transaction):
 
 ```sh
-fly ssh console -a loopctl -C "/app/bin/loopctl rpc 'IO.inspect(Loopctl.HeavyReadRepo.query!(\"SHOW statement_timeout\").rows)'"
+fly ssh console -a loopctl -C "/app/bin/loopctl rpc '
+  {:ok, v} = Loopctl.HeavyReadRepo.transaction(fn ->
+    Loopctl.HeavyReadRepo.query!(\"SET LOCAL statement_timeout = 10000\")
+    Loopctl.HeavyReadRepo.query!(\"SHOW statement_timeout\").rows
+  end); IO.inspect(v)'"
 ```
 
 > **Note for US-27.16 (streamed export):** a minutes-long export must NOT inherit
@@ -93,29 +106,28 @@ fly ssh console -a loopctl -C "/app/bin/loopctl rpc 'IO.inspect(Loopctl.HeavyRea
 
 ## Per-endpoint `statement_timeout` + slow-query logging (US-27.4)
 
-**Default heavy-read timeout:** every heavy read runs under the pool-level
+**Default heavy-read timeout:** every heavy read runs under the per-read `SET LOCAL`
 `statement_timeout` (`HEAVY_READ_STATEMENT_TIMEOUT_MS`, default 10s — see above). When
 it fires, the request fast-fails as the structured **504 `db_statement_timeout`**
-(US-27.3) and the connection is released promptly — no 30s hang, no per-request
-transaction.
+(US-27.3) and the connection is released promptly — no 30s hang.
 
 **Per-endpoint override (optional):** to give one endpoint a tighter (or looser) bound,
 set `:heavy_read_statement_timeout_overrides` (ms) in config — keys
-`:suggested_links`, `:semantic_search`, `:distant_pairs`, `:novelty`:
+`:suggested_links`, `:semantic_search`, `:distant_pairs`, `:novelty`, `:vector_search`:
 
 ```elixir
 config :loopctl, :heavy_read_statement_timeout_overrides, %{suggested_links: 5_000}
 ```
 
-An override applies via `SET LOCAL` inside a transaction on the dedicated heavy pool
-(justified by the 8-conn sizing); endpoints with no override use the pool default (no
-transaction). Leave it empty unless an endpoint needs a different bound.
+An override (or the default) applies via `SET LOCAL` inside a short transaction on the
+dedicated heavy pool (justified by the 8-conn sizing). Leave the map empty unless an
+endpoint needs a bound different from the `HEAVY_READ_STATEMENT_TIMEOUT_MS` default.
 
 **Heavy-read endpoints** (those using `HeavyRead.all/one`): `:suggested_links`,
 `:semantic_search`, `:distant_pairs`, `:novelty`, `:enumeration`. The enumeration endpoint
 (`:knowledge_search_controller` list mode, `list_filtered/2`) now routes through HeavyRead to
-inherit the pool-level statement_timeout and optional per-endpoint override (matching the other
-four endpoints). Enumeration pages up to `limit: 1000` rows per request.
+inherit the per-read SET LOCAL statement_timeout and optional per-endpoint override (matching
+the other endpoints). Enumeration pages up to `limit: 1000` rows per request.
 
 **Slow-query logging:** `Loopctl.Telemetry.SlowQueryLogger` (attached at boot) logs any
 query slower than `:slow_query_threshold_ms` (default **1000**, tunable in config/env)

--- a/lib/loopctl/admin_repo.ex
+++ b/lib/loopctl/admin_repo.ex
@@ -16,5 +16,6 @@ defmodule Loopctl.AdminRepo do
 
   use Ecto.Repo,
     otp_app: :loopctl,
-    adapter: Ecto.Adapters.Postgres
+    adapter: Ecto.Adapters.Postgres,
+    prepare: :unnamed
 end

--- a/lib/loopctl/heavy_read.ex
+++ b/lib/loopctl/heavy_read.ex
@@ -168,6 +168,11 @@ defmodule Loopctl.HeavyRead do
   returned stream outside one raises), which is also what scopes a per-transaction
   `SET LOCAL statement_timeout`.
 
+  NB: the "every heavy read is timed" invariant applies to `all/3` / `one/3` (which
+  default the timeout). `stream/3` and a bare `transaction/2` do NOT auto-apply one — a
+  caller MUST pass `:statement_timeout` to `transaction/2` (this is the export lever) so the
+  enclosed `stream/3` reads run timed. Don't add an un-timed `transaction/2` heavy read.
+
   NOTE: the US-27.16 streamed EXPORT does NOT use this — it pages with the US-27.9a
   keyset cursor via `all/3` (short read per page, connection RELEASED between pages)
   precisely to AVOID holding one transaction (and `xmin`) for the whole client-paced

--- a/lib/loopctl/heavy_read.ex
+++ b/lib/loopctl/heavy_read.ex
@@ -44,9 +44,11 @@ defmodule Loopctl.HeavyRead do
   The test env points it at `Loopctl.AdminRepo` (config/test.exs) so heavy reads
   share the sandbox connection that fixtures insert through. The guard and tenant
   isolation are repo-agnostic and fully exercised regardless of which repo backs
-  it; the dedicated pool's `:parameters` (statement_timeout) are exercised directly
-  by `heavy_read_repo_test.exs` / `heavy_read_pool_isolation_test.exs` (incl. a real
-  Ecto query canceled by the pool timeout). True OS-level pool starvation is not
+  it; the per-read `SET LOCAL statement_timeout` mechanism is exercised directly on the
+  dedicated pool by `heavy_read_repo_test.exs` / `heavy_read_pool_isolation_test.exs` (incl.
+  a real Ecto query canceled by the timeout). (US-27.13: the timeout is applied per-read via
+  SET LOCAL, NOT a startup `:parameters` — pgbouncer rejects the latter with 08P01.) True
+  OS-level pool starvation is not
   reproducible under Sandbox, so TC-27.11.1's concurrency guarantee is structural
   (separate pools + bounded hold) and is re-verified under load per
   docs/runbooks/knowledge-scale.md.
@@ -74,7 +76,7 @@ defmodule Loopctl.HeavyRead do
   (`Loopctl.Knowledge`, `Loopctl.Audit`) builds opts via this function so the
   `[timeout, telemetry_options, statement_timeout]` shape can't drift between callers.
   Known endpoints: `:suggested_links`, `:semantic_search`, `:distant_pairs`, `:novelty`,
-  `:enumeration`, `:change_feed`.
+  `:enumeration`, `:change_feed`, `:vector_search` (the shared kNN helper path).
   """
   @spec opts(atom()) :: keyword()
   def opts(endpoint) when is_atom(endpoint) do
@@ -92,8 +94,14 @@ defmodule Loopctl.HeavyRead do
     end
   end
 
+  # The pool-wide default server-side statement_timeout (ms). Defensive: a missing or
+  # mis-typed (`nil`/0/negative) `:heavy_read_statement_timeout_ms` falls back to 10s rather
+  # than yielding a non-positive value that would defeat the always-timed invariant.
   defp default_statement_timeout do
-    Application.get_env(:loopctl, :heavy_read_statement_timeout_ms, 10_000)
+    case Application.get_env(:loopctl, :heavy_read_statement_timeout_ms, 10_000) do
+      ms when is_integer(ms) and ms > 0 -> ms
+      _ -> 10_000
+    end
   end
 
   defp statement_timeout_override(endpoint) do
@@ -114,30 +122,38 @@ defmodule Loopctl.HeavyRead do
   """
   @spec all(binary(), Ecto.Queryable.t(), keyword()) :: [term()]
   def all(tenant_id, queryable, opts \\ []) do
-    {st, opts} = Keyword.pop(opts, :statement_timeout)
+    # `Keyword.pop/3` with a default cleanly distinguishes "absent → pool default" from a
+    # PRESENT value (which is validated as a positive int below) — unlike `st || default`,
+    # which would silently treat an explicit `0` as truthy and an explicit `nil` as "use
+    # default", muddying the always-timed contract.
+    {st, opts} = Keyword.pop(opts, :statement_timeout, default_statement_timeout())
     query = guard!(tenant_id, queryable)
-    with_statement_timeout(st || default_statement_timeout(), fn -> repo().all(query, opts) end)
+    with_statement_timeout(st, fn -> repo().all(query, opts) end)
   end
 
   @doc "Like `Repo.one/2`, with the same tenant-scoping guard and `:statement_timeout` as `all/3`."
   @spec one(binary(), Ecto.Queryable.t(), keyword()) :: term() | nil
   def one(tenant_id, queryable, opts \\ []) do
-    {st, opts} = Keyword.pop(opts, :statement_timeout)
+    {st, opts} = Keyword.pop(opts, :statement_timeout, default_statement_timeout())
     query = guard!(tenant_id, queryable)
-    with_statement_timeout(st || default_statement_timeout(), fn -> repo().one(query, opts) end)
+    with_statement_timeout(st, fn -> repo().one(query, opts) end)
   end
 
-  # Run `fun` under a per-read SET LOCAL statement_timeout (when given) or directly
-  # (pool default). `nil` means "no override" — the common path, no transaction.
-  defp with_statement_timeout(nil, fun), do: fun.()
-
+  # Run `fun` under a per-read SET LOCAL statement_timeout. There is NO un-timed path:
+  # `all/one` always resolve a positive default, and a non-positive/`nil` value (an explicit
+  # mis-call) raises rather than silently running un-timed (US-27.13: every heavy read MUST
+  # carry a server-side timeout since the pgbouncer-rejected startup `:parameters` lever is gone).
   defp with_statement_timeout(ms, fun) when is_integer(ms) and ms > 0 do
     case transaction(fun, statement_timeout: ms) do
       {:ok, result} ->
         result
 
-      {:error, reason} ->
-        raise "heavy read aborted: #{inspect(reason)}"
+      # A heavy read aborts only via an explicit Repo.rollback (the timeout CANCEL itself is
+      # a raised Postgrex.Error that propagates as-is to the DBErrorBackstop). Keep the
+      # message opaque — never interpolate the rollback reason, which could carry raw SQL /
+      # vector text and defeat the US-27.3 sanitization contract.
+      {:error, _reason} ->
+        raise "heavy read aborted (transaction rolled back)"
     end
   end
 

--- a/lib/loopctl/heavy_read.ex
+++ b/lib/loopctl/heavy_read.ex
@@ -58,11 +58,17 @@ defmodule Loopctl.HeavyRead do
 
   @doc """
   Per-read options for a heavy endpoint (US-27.4): the 15s CLIENT timeout backstop plus
-  an optional per-endpoint SERVER-SIDE `:statement_timeout` override (config
-  `:heavy_read_statement_timeout_overrides`, e.g. `%{suggested_links: 5_000}`). When no
-  override is configured the read uses the pool-level statement_timeout (the default
-  path, no per-request transaction). Also passes the endpoint key via
-  `telemetry_options` so slow-query logs can trace which endpoint triggered the query.
+  the SERVER-SIDE `:statement_timeout` — the per-endpoint override (config
+  `:heavy_read_statement_timeout_overrides`, e.g. `%{suggested_links: 5_000}`) if set,
+  ELSE the pool-wide default (`:heavy_read_statement_timeout_ms`, 10s). It is ALWAYS
+  present, so every heavy read is wrapped in a `SET LOCAL statement_timeout` transaction.
+
+  This replaced a connection-startup `parameters: [statement_timeout: ...]` lever
+  (US-27.11) that Fly MPG's pgbouncer rejected with `08P01 unsupported startup
+  parameter`, crash-looping the whole HeavyReadRepo pool and 503ing every heavy endpoint
+  (US-27.13). `SET LOCAL` inside a transaction is the pgbouncer-safe way to set a
+  server-side statement_timeout. Also passes the endpoint key via `telemetry_options` so
+  slow-query logs can trace which endpoint triggered the query.
 
   This is the SINGLE source of truth for heavy-read opts — every consumer
   (`Loopctl.Knowledge`, `Loopctl.Audit`) builds opts via this function so the
@@ -73,11 +79,21 @@ defmodule Loopctl.HeavyRead do
   @spec opts(atom()) :: keyword()
   def opts(endpoint) when is_atom(endpoint) do
     base = [timeout: 15_000, telemetry_options: [endpoint: endpoint]]
+    Keyword.put(base, :statement_timeout, statement_timeout_for(endpoint))
+  end
 
+  # The per-endpoint override if a positive int, else the pool-wide default. Always a
+  # positive int → every heavy read runs under a SET LOCAL statement_timeout (the
+  # pgbouncer-safe replacement for the rejected startup `:parameters`).
+  defp statement_timeout_for(endpoint) do
     case statement_timeout_override(endpoint) do
-      ms when is_integer(ms) and ms > 0 -> Keyword.put(base, :statement_timeout, ms)
-      _ -> base
+      ms when is_integer(ms) and ms > 0 -> ms
+      _ -> default_statement_timeout()
     end
+  end
+
+  defp default_statement_timeout do
+    Application.get_env(:loopctl, :heavy_read_statement_timeout_ms, 10_000)
   end
 
   defp statement_timeout_override(endpoint) do
@@ -90,16 +106,17 @@ defmodule Loopctl.HeavyRead do
   Like `Repo.all/2`, but requires a `tenant_id` and a query whose every base-table
   source is scoped to it. Raises `ArgumentError` otherwise.
 
-  A per-endpoint `:statement_timeout` (positive ms) option overrides the pool-level
-  default for THIS read only, via a `SET LOCAL` inside a transaction (US-27.4). Omit
-  it to use the pool default (no per-request transaction — the common, preferred
-  path).
+  A `:statement_timeout` (positive ms) option sets the server-side timeout for THIS read
+  via a `SET LOCAL` inside a transaction (US-27.4). When omitted it defaults to the
+  pool-wide `:heavy_read_statement_timeout_ms` (10s) — so EVERY heavy read is protected
+  (there is no un-timed "pool default" path: pgbouncer rejects a startup-`:parameters`
+  statement_timeout, so the timeout MUST be applied per-read via SET LOCAL — US-27.13).
   """
   @spec all(binary(), Ecto.Queryable.t(), keyword()) :: [term()]
   def all(tenant_id, queryable, opts \\ []) do
     {st, opts} = Keyword.pop(opts, :statement_timeout)
     query = guard!(tenant_id, queryable)
-    with_statement_timeout(st, fn -> repo().all(query, opts) end)
+    with_statement_timeout(st || default_statement_timeout(), fn -> repo().all(query, opts) end)
   end
 
   @doc "Like `Repo.one/2`, with the same tenant-scoping guard and `:statement_timeout` as `all/3`."
@@ -107,7 +124,7 @@ defmodule Loopctl.HeavyRead do
   def one(tenant_id, queryable, opts \\ []) do
     {st, opts} = Keyword.pop(opts, :statement_timeout)
     query = guard!(tenant_id, queryable)
-    with_statement_timeout(st, fn -> repo().one(query, opts) end)
+    with_statement_timeout(st || default_statement_timeout(), fn -> repo().one(query, opts) end)
   end
 
   # Run `fun` under a per-read SET LOCAL statement_timeout (when given) or directly

--- a/lib/loopctl/heavy_read_repo.ex
+++ b/lib/loopctl/heavy_read_repo.ex
@@ -54,5 +54,6 @@ defmodule Loopctl.HeavyReadRepo do
 
   use Ecto.Repo,
     otp_app: :loopctl,
-    adapter: Ecto.Adapters.Postgres
+    adapter: Ecto.Adapters.Postgres,
+    prepare: :unnamed
 end

--- a/lib/loopctl/heavy_read_repo.ex
+++ b/lib/loopctl/heavy_read_repo.ex
@@ -7,23 +7,29 @@ defmodule Loopctl.HeavyReadRepo do
   Heavy vector/enumeration reads (semantic search, suggested-links candidates,
   distant-pairs, novelty) previously shared the tiny 3-connection `AdminRepo`
   pool with every other cross-tenant admin op. Three concurrent heavy reads
-  could monopolize all admin capacity — this already distorted the #172 fix,
-  which had to avoid a per-request transaction precisely to dodge starvation on
-  that pool.
+  could monopolize all admin capacity.
 
   Isolating heavy reads on their own pool (Theme 4):
 
   - removes that hidden coupling (a slow vector read can't starve light admin
     ops, and vice-versa — they are on physically separate pools), and
-  - gives US-27.4 (statement_timeout) and US-27.6b (recall) a clean, pool-level
-    lever via `:parameters`, with no per-request transaction.
+  - gives US-27.4 (statement_timeout) and US-27.6b (recall) a dedicated, bounded
+    pool whose per-read timeout self-drains it under load.
 
-  ## Pool-level server-side parameters
+  ## Server-side statement_timeout — per-read `SET LOCAL`, NOT `:parameters` (US-27.13)
 
-  This repo's `:parameters` (set in `config/runtime.exs`) carry a server-side
-  `statement_timeout` (a CORE GUC, settable via the startup packet — verified).
-  So every query on this pool fast-fails at the configured timeout and releases
-  the connection, instead of holding it for the full client/pool timeout.
+  The server-side `statement_timeout` is applied PER-READ via `SET LOCAL` inside the
+  `Loopctl.HeavyRead` transaction path (`opts/1` → `all/one` → `transaction/2`), so every
+  heavy read fast-fails at the configured timeout and releases the connection.
+
+  It is **deliberately NOT** carried as a connection startup `:parameters` value. Fly MPG
+  (and managed Postgres generally) fronts the database with **pgbouncer**, which rejects a
+  `statement_timeout` startup parameter with `FATAL 08P01 unsupported startup parameter` —
+  this crash-loops the whole pool so it never establishes a connection (the US-27.13
+  production outage). `SET LOCAL` inside a transaction is the pgbouncer-safe mechanism and is
+  verified to enforce against the live pool. A regression guard
+  (`config_pgbouncer_safe_parameters_test.exs`) blocks any repo from re-adding such a
+  startup parameter.
 
   `hnsw.ef_search` is a pgvector CUSTOM GUC that does not exist until the
   extension loads per-session, so it is NOT settable via `:parameters` on

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -6,8 +6,12 @@ defmodule Loopctl.Knowledge do
   are the core knowledge units — reusable patterns, conventions,
   decisions, findings, and references within a tenant's knowledge base.
 
-  All operations use AdminRepo (BYPASSRLS) with explicit `tenant_id`
-  scoping, following the same pattern as other loopctl contexts.
+  Most operations use AdminRepo (BYPASSRLS) with explicit `tenant_id`
+  scoping, following the same pattern as other loopctl contexts. The heavy
+  vector/enumeration reads (suggested_links, semantic search, distant_pairs,
+  novelty, enumeration) route through `Loopctl.HeavyRead` → the dedicated
+  `Loopctl.HeavyReadRepo` pool (also BYPASSRLS, same explicit `tenant_id`
+  scoping), isolated so a slow read can't starve light admin ops.
 
   ## Usage
 

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -1604,7 +1604,7 @@ defmodule Loopctl.Knowledge do
     filtered = apply_search_filters(base, status, opts)
 
     # US-27.4: Count and results both route through HeavyRead to inherit the
-    # pool-level statement_timeout and optional per-endpoint override.
+    # per-read SET LOCAL statement_timeout and optional per-endpoint override.
     count_query = from(a in filtered, select: count(a.id))
     total_count = HeavyRead.one(tenant_id, count_query, heavy_read_opts(:enumeration))
 
@@ -3243,9 +3243,9 @@ defmodule Loopctl.Knowledge do
 
   defp suggestion_candidates(tenant_id, article_id, embedding, threshold, limit, vis) do
     # Routed through Loopctl.HeavyRead (US-27.11): the dedicated heavy-read pool,
-    # isolated from the small AdminRepo pool and carrying a pool-level
-    # statement_timeout — no per-request transaction (the constraint that shaped the
-    # #172 fix). The wrapper structurally requires a tenant_id-filtered query; the
+    # isolated from the small AdminRepo pool, with a per-read SET LOCAL
+    # statement_timeout (US-27.13 — a short transaction, the connection released at
+    # commit). The wrapper structurally requires a tenant_id-filtered query; the
     # tenant predicate lives in this query's inner subquery. The 15s client timeout
     # is a backstop above the server-side statement_timeout.
     query = suggestion_candidates_query(tenant_id, article_id, embedding, threshold, limit, vis)
@@ -3815,9 +3815,10 @@ defmodule Loopctl.Knowledge do
       )
 
     # Fetch count and paginated pairs through Loopctl.HeavyRead (US-27.11): the
-    # dedicated heavy-read pool with a pool-level statement_timeout, isolated from the
-    # small AdminRepo pool so this O(n²) self-join can't starve light admin ops. No
-    # transaction hold (count may shift between queries — acceptable, by design). Both
+    # dedicated heavy-read pool with a per-read SET LOCAL statement_timeout (US-27.13),
+    # isolated from the small AdminRepo pool so this O(n²) self-join can't starve light
+    # admin ops. No SHARED transaction across the two reads — each is its own short
+    # SET LOCAL transaction, so the count may shift between them (acceptable, by design). Both
     # queries filter `a.tenant_id`/`b.tenant_id`, satisfying the wrapper's guard.
     total_count =
       count_query

--- a/lib/loopctl/knowledge/streaming_export.ex
+++ b/lib/loopctl/knowledge/streaming_export.ex
@@ -15,7 +15,9 @@ defmodule Loopctl.Knowledge.StreamingExport do
   download — pinning one of the few BYPASSRLS heavy-read connections AND `xmin`
   (blocking vacuum on a churning 76k-row table) for minutes. Instead we page with
   the keyset cursor on `(inserted_at, id)`: each page is a SHORT
-  `Loopctl.HeavyRead.all/3` read that RELEASES the connection between pages. The
+  `Loopctl.HeavyRead.all/3` read — a brief per-read `SET LOCAL statement_timeout`
+  transaction (US-27.13) that COMMITS and RELEASES the connection + `xmin` between
+  pages, NOT one long-held transaction across the whole download. The
   walk is drift-free (seeks the stable unique tuple, never an OFFSET).
 
   ## Tenant scoping under BYPASSRLS (AC-27.16.5)

--- a/lib/loopctl/knowledge/streaming_export.ex
+++ b/lib/loopctl/knowledge/streaming_export.ex
@@ -188,7 +188,8 @@ defmodule Loopctl.Knowledge.StreamingExport do
       |> group_by([a], a.category)
       |> select([a], %{category: a.category, count: count(a.id)})
 
-    HeavyRead.all(tenant_id, query)
+    # Export aggregations use the same extended 60s timeout as export pages.
+    HeavyRead.all(tenant_id, query, statement_timeout: 60_000)
   end
 
   # --- article pages (keyset walk) ---
@@ -287,7 +288,11 @@ defmodule Loopctl.Knowledge.StreamingExport do
       })
       |> limit(^(page_size + 1))
 
-    rows = HeavyRead.all(tenant_id, query)
+    # Export pages have a longer per-page timeout than fast reads: 60s instead of the
+    # 10s fast-read default. A single page read (even with `export_max_links_per_article: 100`
+    # and dense graph) should complete in well under 60s at realistic prod scale; this
+    # prevents a legitimate slow page from timing out mid-export.
+    rows = HeavyRead.all(tenant_id, query, statement_timeout: 60_000)
 
     if length(rows) > page_size do
       page = Enum.take(rows, page_size)
@@ -450,8 +455,9 @@ defmodule Loopctl.Knowledge.StreamingExport do
         }
       )
 
+    # Export link queries use the same extended 60s timeout as export pages.
     tenant_id
-    |> HeavyRead.all(query)
+    |> HeavyRead.all(query, statement_timeout: 60_000)
     |> Enum.map(&Map.put(&1, :direction, direction))
   end
 

--- a/lib/loopctl/knowledge/vector_search.ex
+++ b/lib/loopctl/knowledge/vector_search.ex
@@ -109,12 +109,16 @@ defmodule Loopctl.Knowledge.VectorSearch do
   — and `HeavyRead.all/3`'s structural guard rejects any query whose base-table
   sources aren't all bound to the passed tenant.
 
-  ## No per-request transaction (AC-27.6a.6)
+  ## Per-read SET LOCAL transaction (US-27.13; supersedes the AC-27.6a.6 "no transaction" note)
 
-  `nearest/4` is a bare `HeavyRead.all/3` (no `:statement_timeout` override), i.e.
-  a bare pool read with no enclosing transaction — matching
-  `search_semantic`/`distant_pairs`, and avoiding the #172 round-1 pool-starvation
-  anti-pattern on the small admin pool.
+  `nearest/4` runs through `HeavyRead.all/3`, which now wraps every heavy read in a SHORT
+  `SET LOCAL statement_timeout` transaction (`BEGIN; SET LOCAL; SELECT; COMMIT`). This is the
+  pgbouncer-safe way to apply a server-side timeout (a startup-`:parameters` statement_timeout
+  is rejected by pgbouncer — the US-27.13 outage). The transaction is per-read and short — the
+  connection is released at COMMIT — so it does NOT reintroduce the #172 round-1 long-held
+  pool-starvation anti-pattern; it is the opposite (a bounded, self-draining hold). The
+  earlier AC-27.6a.6 "bare pool read, no per-request transaction" guarantee is obsolete: a
+  per-read transaction is now unavoidable behind pgbouncer.
   """
 
   import Ecto.Query
@@ -163,11 +167,6 @@ defmodule Loopctl.Knowledge.VectorSearch do
   # Maximum number of tag values accepted in a `:tags` overlap filter, so a caller
   # can't pass an unbounded array literal into the index-residual `&&` predicate.
   @default_max_tags 50
-
-  # Client-side timeout backstop for the heavy read (US-27.4 pattern). The
-  # server-side statement_timeout (pool-level) is the real cap; this is a ceiling
-  # above it so a hung connection can't pin a process forever.
-  @client_timeout_ms 15_000
 
   @doc "Maximum permitted `k`/limit (config `:vector_search_max_k`, default #{@default_max_k})."
   @spec max_k() :: pos_integer()
@@ -238,8 +237,8 @@ defmodule Loopctl.Knowledge.VectorSearch do
   Executes the index-correct kNN query and returns up to `k` candidate maps,
   highest similarity first.
 
-  A bare `HeavyRead.all/3` (no `:statement_timeout` override) — a pool read with
-  NO per-request transaction (AC-27.6a.6).
+  Runs via `HeavyRead.all/3`, which applies the `:vector_search` server-side
+  statement_timeout per-read via a short `SET LOCAL` transaction (US-27.13).
 
   See `candidate_query/4` for the parameters and `opts`. All cost-affecting params
   are clamped to their documented bounds before the query is built (AC-27.6a.4).
@@ -569,10 +568,12 @@ defmodule Loopctl.Knowledge.VectorSearch do
   def to_embedding_list(%Pgvector{} = vector), do: Pgvector.to_list(vector)
   def to_embedding_list(vector) when is_list(vector), do: vector
 
-  # Per-read heavy-read options: the 15s CLIENT timeout backstop + the endpoint key
-  # for slow-query telemetry (US-27.4). NO `:statement_timeout` override → bare pool
-  # read, no per-request transaction (AC-27.6a.6).
+  # Per-read heavy-read options. Delegates to the SINGLE source of truth, `HeavyRead.opts/1`
+  # (US-27.13), so this read carries the `:vector_search` server-side statement_timeout
+  # (per-endpoint override else the pool default, applied via SET LOCAL) AND the endpoint key
+  # for slow-query telemetry — rather than hand-rolling a list that drifts from every other
+  # heavy consumer. `HeavyRead.opts/1` carries the 15s client-timeout backstop itself.
   defp heavy_read_opts do
-    [timeout: @client_timeout_ms, telemetry_options: [endpoint: :vector_search]]
+    HeavyRead.opts(:vector_search)
   end
 end

--- a/lib/loopctl/repo.ex
+++ b/lib/loopctl/repo.ex
@@ -24,7 +24,8 @@ defmodule Loopctl.Repo do
 
   use Ecto.Repo,
     otp_app: :loopctl,
-    adapter: Ecto.Adapters.Postgres
+    adapter: Ecto.Adapters.Postgres,
+    prepare: :unnamed
 
   alias Ecto.Adapters.SQL
 

--- a/lib/loopctl_web/controllers/knowledge_suggest_links_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_suggest_links_controller.ex
@@ -134,8 +134,9 @@ defmodule LoopctlWeb.KnowledgeSuggestLinksController do
   # Run the (possibly slow) vector-similarity query, translating a raised DB
   # exception into an `{:error, %Postgrex.Error{}}` / `{:error,
   # %DBConnection.ConnectionError{}}` tuple. Only DB exceptions are caught;
-  # anything else is re-raised (let-it-crash). The suggest_links query runs on
-  # AdminRepo — rescuing here does NOT change which tenant's data is touched.
+  # anything else is re-raised (let-it-crash). The suggest_links query runs on the
+  # dedicated HeavyReadRepo pool (via Loopctl.HeavyRead) — rescuing here does NOT
+  # change which tenant's data is touched.
   #
   # The executor is resolved via config-based DI (CLAUDE.md convention:
   # behaviour + Application.get_env, mock wired in config/test.exs) so a test can

--- a/test/loopctl/config_pgbouncer_safe_parameters_test.exs
+++ b/test/loopctl/config_pgbouncer_safe_parameters_test.exs
@@ -15,13 +15,18 @@ defmodule Loopctl.ConfigPgbouncerSafeParametersTest do
   the suite connects to DIRECT Postgres (which ACCEPTS the startup param) and aliases heavy
   reads to AdminRepo — the false confidence that hid it.
 
-  This guard scans the config SOURCE (so it covers `config/runtime.exs`, the PROD-only file
-  that `Application.get_env` never reflects during `mix test` — i.e. the exact file the bug
-  lived in) and fails the build if any `parameters: [...]` list carries a key outside the
-  pgbouncer-safe allowlist. A server-side `statement_timeout` (or any GUC) must instead be
-  applied per-read via `SET LOCAL` inside a transaction (`Loopctl.HeavyRead`), the
+  This guard parses the config SOURCE as an AST (so it covers `config/runtime.exs`, the
+  PROD-only file that `Application.get_env` never reflects during `mix test` — i.e. the exact
+  file the bug lived in) and fails the build if any `parameters: [...]` list carries a key
+  outside the pgbouncer-safe allowlist. A server-side `statement_timeout` (or any GUC) must
+  instead be applied per-read via `SET LOCAL` inside a transaction (`Loopctl.HeavyRead`), the
   pgbouncer-safe path; a connect-time GUC that must persist is set via `ALTER ROLE` (the
   documented `hnsw.ef_search` lever), NOT a startup parameter.
+
+  AST (not regex) parsing is deliberate: it extracts EVERY top-level key of a `:parameters`
+  list — including keys that follow a nested list value (e.g.
+  `parameters: [socket_options: [...], statement_timeout: ...]`), which a non-greedy
+  `parameters: [(.*?)\]` regex would miss by stopping at the first `]`.
 
   NB: there is NO startup-parameter escape hatch for a GUC behind pgbouncer. In particular
   `options` (`-c statement_timeout=...`) is NOT safe — Fly MPG's pgbouncer rejects a
@@ -72,7 +77,7 @@ defmodule Loopctl.ConfigPgbouncerSafeParametersTest do
     test "the scanner is NON-VACUOUS — it flags a synthetic forbidden parameter" do
       # Guard the guard: prove the parser actually extracts keys and would catch the exact
       # US-27.11 regression, so a future refactor can't silently neuter it into a no-op.
-      synthetic = ~s(  parameters: [statement_timeout: "10000"])
+      synthetic = ~S|config :loopctl, Foo, parameters: [statement_timeout: "10000"]|
       assert [{_inner, keys}] = scan_parameter_lists(synthetic)
       assert "statement_timeout" in keys
       assert "statement_timeout" not in @pgbouncer_safe_startup_params
@@ -82,49 +87,80 @@ defmodule Loopctl.ConfigPgbouncerSafeParametersTest do
       # pgbouncer rejects statement_timeout via `options` too (pgbouncer #907), and a GUC set
       # via the startup `options` packet leaks across clients under transaction pooling. The
       # allowlist must NOT bless `options`, or it re-opens the US-27.13 outage class.
-      smuggle = ~s(  parameters: [options: "-c statement_timeout=10000"])
+      smuggle = ~S|config :loopctl, Foo, parameters: [options: "-c statement_timeout=10000"]|
       assert [{_inner, keys}] = scan_parameter_lists(smuggle)
       assert "options" in keys
       assert "options" not in @pgbouncer_safe_startup_params
     end
 
-    test "the scanner IGNORES comment lines AND inline trailing comments (no false positive on docs)" do
-      # The config files DOCUMENT the forbidden shape in comments (e.g. "no
-      # `parameters: [statement_timeout: ...]` here"). Neither a whole-line comment nor an
-      # inline trailing comment that mentions the shape must trip the guard.
-      whole_line = ~s(  # NO parameters: [statement_timeout: ...] here — pgbouncer rejects it)
-      inline = ~s(  pool_size: 8  # legacy note: parameters: [statement_timeout: "10000"])
+    test "the scanner catches a forbidden parameter AFTER a nested list (no `socket_options: [...]` false-negative)" do
+      # Regression: a non-greedy `parameters: [(.*?)\]` regex would stop at the first `]`
+      # (end of the socket_options list) and MISS statement_timeout. AST parsing extracts
+      # every top-level key of the :parameters list regardless of nested-list values.
+      nested =
+        ~S|config :loopctl, Foo, parameters: [socket_options: [keepalive: true], statement_timeout: "10000"]|
+
+      assert [{_inner, keys}] = scan_parameter_lists(nested)
+
+      assert "statement_timeout" in keys,
+             "expected to find statement_timeout even after a nested list value"
+
+      assert "statement_timeout" not in @pgbouncer_safe_startup_params
+    end
+
+    test "the scanner IGNORES comments (no false positive on documentation)" do
+      # The config files DOCUMENT the forbidden shape in comments. AST parsing drops comments
+      # natively, so neither a whole-line nor an inline comment mentioning the shape can trip
+      # the guard.
+      whole_line = ~S|# NO parameters: [statement_timeout: ...] here — pgbouncer rejects it|
+
+      inline =
+        ~S|config :loopctl, Foo, pool_size: 8 # note: parameters: [statement_timeout: "10000"]|
+
       assert scan_parameter_lists(whole_line) == []
       assert scan_parameter_lists(inline) == []
     end
   end
 
-  # Extract every `parameters: [ ... ]` list from a config file (comments stripped) as
-  # `{inner_text, [key_strings]}`.
+  # Extract every `parameters: [...]` keyword list from config source. Returns
+  # `{rendered_keys, [key_strings]}` per `:parameters` declaration.
   defp parameter_lists(file) do
     file |> File.read!() |> scan_parameter_lists()
   end
 
+  # Parse the source to an AST and walk the WHOLE tree (Macro.prewalk) for any
+  # `{:parameters, list}` node — finding `:parameters` whether it sits inside a `config(...)`
+  # call (real files) or a bare snippet (the synthetic tests), and extracting ALL top-level
+  # keys including those after a nested-list value. config/*.exs is always valid Elixir; on a
+  # parse error there is simply nothing to scan (another check owns the syntax error).
   defp scan_parameter_lists(source) do
-    source
-    |> strip_comment_lines()
-    |> then(&Regex.scan(~r/parameters:\s*\[(.*?)\]/s, &1))
-    |> Enum.map(fn [_full, inner] ->
-      keys = ~r/(\w+):/ |> Regex.scan(inner) |> Enum.map(fn [_, key] -> key end)
-      {String.trim(inner), keys}
-    end)
+    case Code.string_to_quoted(source) do
+      {:ok, ast} ->
+        {_ast, found} =
+          Macro.prewalk(ast, [], fn
+            {:parameters, value} = node, acc when is_list(value) ->
+              {node, [{render_params(value), param_keys(value)} | acc]}
+
+            node, acc ->
+              {node, acc}
+          end)
+
+        Enum.reverse(found)
+
+      {:error, _reason} ->
+        []
+    end
   end
 
-  # Drop comments so documentation that mentions the forbidden shape can't false-positive:
-  # whole-line comments (`^\s*#`) are removed entirely, and an inline trailing comment is
-  # stripped from a whitespace-preceded `#` to end of line. The `#(?!\{)` negative lookahead
-  # preserves `#{...}` interpolation (e.g. the `statement_timeout = #{ms}` body is real code,
-  # not a comment). A false positive here merely fails the build loudly for a human — far
-  # safer than a false negative — so this conservative strip is sufficient.
-  defp strip_comment_lines(source) do
-    source
-    |> String.split("\n")
-    |> Enum.reject(&(&1 =~ ~r/^\s*#/))
-    |> Enum.map_join("\n", &Regex.replace(~r/\s#(?!\{).*$/, &1, ""))
+  # The TOP-LEVEL keyword keys of a `:parameters` list, as strings. Only the keys of THIS
+  # list — a nested-list value (e.g. `socket_options: [keepalive: true]`) contributes its own
+  # key (`socket_options`), never the inner `keepalive`: prewalk visits the inner
+  # `{:socket_options, [...]}` node separately, and it is not a `:parameters` node.
+  defp param_keys(value) do
+    for {k, _v} <- value, is_atom(k), do: Atom.to_string(k)
+  end
+
+  defp render_params(value) do
+    value |> param_keys() |> Enum.map_join(", ", &"#{&1}: ...")
   end
 end

--- a/test/loopctl/config_pgbouncer_safe_parameters_test.exs
+++ b/test/loopctl/config_pgbouncer_safe_parameters_test.exs
@@ -18,26 +18,31 @@ defmodule Loopctl.ConfigPgbouncerSafeParametersTest do
   This guard scans the config SOURCE (so it covers `config/runtime.exs`, the PROD-only file
   that `Application.get_env` never reflects during `mix test` — i.e. the exact file the bug
   lived in) and fails the build if any `parameters: [...]` list carries a key outside the
-  pgbouncer-safe allowlist. A server-side `statement_timeout` must instead be applied
-  per-read via `SET LOCAL` inside a transaction (`Loopctl.HeavyRead`), the pgbouncer-safe
-  path. The pgbouncer-safe escape hatch for a server GUC at connect is the `options` startup
-  parameter (allowlisted), not a bare GUC key.
+  pgbouncer-safe allowlist. A server-side `statement_timeout` (or any GUC) must instead be
+  applied per-read via `SET LOCAL` inside a transaction (`Loopctl.HeavyRead`), the
+  pgbouncer-safe path; a connect-time GUC that must persist is set via `ALTER ROLE` (the
+  documented `hnsw.ef_search` lever), NOT a startup parameter.
+
+  NB: there is NO startup-parameter escape hatch for a GUC behind pgbouncer. In particular
+  `options` (`-c statement_timeout=...`) is NOT safe — Fly MPG's pgbouncer rejects a
+  `statement_timeout` smuggled via `options` too (pgbouncer #907), and a GUC set via the
+  startup `options` packet leaks across clients under transaction pooling. So `options` is
+  deliberately NOT allowlisted.
   """
   use ExUnit.Case, async: true
 
-  # Startup parameters pgbouncer forwards/accepts (its default tracked set + the `options`
-  # escape hatch). Everything else — `statement_timeout`, `lock_timeout`,
-  # `idle_in_transaction_session_timeout`, any pgvector custom GUC like `hnsw.ef_search` —
-  # is rejected with 08P01 and MUST NOT appear in an Ecto repo `:parameters` list.
+  # Startup parameters pgbouncer forwards/accepts by DEFAULT (no pgbouncer-side config —
+  # which loopctl does not control on Fly MPG). This is the minimal libpq-negotiated set.
+  # Everything else — `statement_timeout`, `lock_timeout`,
+  # `idle_in_transaction_session_timeout`, any pgvector custom GUC like `hnsw.ef_search`,
+  # AND `options` (which can smuggle a GUC and is itself rejected) — is rejected with 08P01
+  # and MUST NOT appear in an Ecto repo `:parameters` list.
   @pgbouncer_safe_startup_params ~w(
     application_name
     client_encoding
     datestyle
     timezone
     standard_conforming_strings
-    extra_float_digits
-    search_path
-    options
   )
 
   @config_files Path.wildcard("config/*.exs")
@@ -73,11 +78,24 @@ defmodule Loopctl.ConfigPgbouncerSafeParametersTest do
       assert "statement_timeout" not in @pgbouncer_safe_startup_params
     end
 
-    test "the scanner IGNORES comment lines (no false positive on documentation)" do
+    test "the `options` GUC-smuggle is flagged — `options: \"-c statement_timeout=...\"` is NOT a safe escape hatch" do
+      # pgbouncer rejects statement_timeout via `options` too (pgbouncer #907), and a GUC set
+      # via the startup `options` packet leaks across clients under transaction pooling. The
+      # allowlist must NOT bless `options`, or it re-opens the US-27.13 outage class.
+      smuggle = ~s(  parameters: [options: "-c statement_timeout=10000"])
+      assert [{_inner, keys}] = scan_parameter_lists(smuggle)
+      assert "options" in keys
+      assert "options" not in @pgbouncer_safe_startup_params
+    end
+
+    test "the scanner IGNORES comment lines AND inline trailing comments (no false positive on docs)" do
       # The config files DOCUMENT the forbidden shape in comments (e.g. "no
-      # `parameters: [statement_timeout: ...]` here"). Those must not trip the guard.
-      commented = ~s(  # NO parameters: [statement_timeout: ...] here — pgbouncer rejects it)
-      assert scan_parameter_lists(commented) == []
+      # `parameters: [statement_timeout: ...]` here"). Neither a whole-line comment nor an
+      # inline trailing comment that mentions the shape must trip the guard.
+      whole_line = ~s(  # NO parameters: [statement_timeout: ...] here — pgbouncer rejects it)
+      inline = ~s(  pool_size: 8  # legacy note: parameters: [statement_timeout: "10000"])
+      assert scan_parameter_lists(whole_line) == []
+      assert scan_parameter_lists(inline) == []
     end
   end
 
@@ -97,13 +115,16 @@ defmodule Loopctl.ConfigPgbouncerSafeParametersTest do
     end)
   end
 
-  # Drop whole-line comments so documentation that mentions the forbidden shape can't
-  # false-positive. Inline trailing comments after real code are harmless: the `parameters`
-  # list closes before any `#`.
+  # Drop comments so documentation that mentions the forbidden shape can't false-positive:
+  # whole-line comments (`^\s*#`) are removed entirely, and an inline trailing comment is
+  # stripped from a whitespace-preceded `#` to end of line. The `#(?!\{)` negative lookahead
+  # preserves `#{...}` interpolation (e.g. the `statement_timeout = #{ms}` body is real code,
+  # not a comment). A false positive here merely fails the build loudly for a human — far
+  # safer than a false negative — so this conservative strip is sufficient.
   defp strip_comment_lines(source) do
     source
     |> String.split("\n")
     |> Enum.reject(&(&1 =~ ~r/^\s*#/))
-    |> Enum.join("\n")
+    |> Enum.map_join("\n", &Regex.replace(~r/\s#(?!\{).*$/, &1, ""))
   end
 end

--- a/test/loopctl/config_pgbouncer_safe_parameters_test.exs
+++ b/test/loopctl/config_pgbouncer_safe_parameters_test.exs
@@ -1,0 +1,109 @@
+defmodule Loopctl.ConfigPgbouncerSafeParametersTest do
+  @moduledoc """
+  US-27.13 regression guard: NO Ecto repo may carry a pgbouncer-INCOMPATIBLE startup
+  parameter in its `:parameters` config.
+
+  ## Why this exists (the outage it would have caught)
+
+  Production fronts Postgres with pgbouncer (Fly Managed Postgres). pgbouncer accepts only
+  a small allowlist of connection STARTUP parameters and REJECTS anything else with
+  `FATAL 08P01 (protocol_violation) unsupported startup parameter: <name>`. US-27.11 set
+  `config :loopctl, Loopctl.HeavyReadRepo, parameters: [statement_timeout: ...]` — a startup
+  parameter pgbouncer rejects — which crash-looped every HeavyReadRepo connection in prod
+  and 503'd every heavy vector/enumeration endpoint (suggested_links, semantic search,
+  distant_pairs, novelty, heavy enumeration). It was invisible to the test suite because
+  the suite connects to DIRECT Postgres (which ACCEPTS the startup param) and aliases heavy
+  reads to AdminRepo — the false confidence that hid it.
+
+  This guard scans the config SOURCE (so it covers `config/runtime.exs`, the PROD-only file
+  that `Application.get_env` never reflects during `mix test` — i.e. the exact file the bug
+  lived in) and fails the build if any `parameters: [...]` list carries a key outside the
+  pgbouncer-safe allowlist. A server-side `statement_timeout` must instead be applied
+  per-read via `SET LOCAL` inside a transaction (`Loopctl.HeavyRead`), the pgbouncer-safe
+  path. The pgbouncer-safe escape hatch for a server GUC at connect is the `options` startup
+  parameter (allowlisted), not a bare GUC key.
+  """
+  use ExUnit.Case, async: true
+
+  # Startup parameters pgbouncer forwards/accepts (its default tracked set + the `options`
+  # escape hatch). Everything else — `statement_timeout`, `lock_timeout`,
+  # `idle_in_transaction_session_timeout`, any pgvector custom GUC like `hnsw.ef_search` —
+  # is rejected with 08P01 and MUST NOT appear in an Ecto repo `:parameters` list.
+  @pgbouncer_safe_startup_params ~w(
+    application_name
+    client_encoding
+    datestyle
+    timezone
+    standard_conforming_strings
+    extra_float_digits
+    search_path
+    options
+  )
+
+  @config_files Path.wildcard("config/*.exs")
+
+  describe "Ecto repo :parameters across ALL config files (incl. runtime.exs)" do
+    test "no repo declares a pgbouncer-incompatible startup parameter" do
+      assert @config_files != [], "expected to find config/*.exs files to scan"
+
+      violations =
+        for file <- @config_files,
+            {param_list, keys} <- parameter_lists(file),
+            bad = keys -- @pgbouncer_safe_startup_params,
+            bad != [] do
+          {Path.relative_to_cwd(file), param_list, bad}
+        end
+
+      assert violations == [],
+             "Found pgbouncer-INCOMPATIBLE startup parameter(s) in Ecto repo `:parameters` — " <>
+               "these crash-loop the pool behind pgbouncer (08P01), the US-27.13 outage. " <>
+               "Apply a server-side statement_timeout via SET LOCAL (Loopctl.HeavyRead), not a " <>
+               "startup parameter:\n" <>
+               Enum.map_join(violations, "\n", fn {file, list, bad} ->
+                 "  #{file}: parameters: [#{list}] — forbidden key(s): #{inspect(bad)}"
+               end)
+    end
+
+    test "the scanner is NON-VACUOUS — it flags a synthetic forbidden parameter" do
+      # Guard the guard: prove the parser actually extracts keys and would catch the exact
+      # US-27.11 regression, so a future refactor can't silently neuter it into a no-op.
+      synthetic = ~s(  parameters: [statement_timeout: "10000"])
+      assert [{_inner, keys}] = scan_parameter_lists(synthetic)
+      assert "statement_timeout" in keys
+      assert "statement_timeout" not in @pgbouncer_safe_startup_params
+    end
+
+    test "the scanner IGNORES comment lines (no false positive on documentation)" do
+      # The config files DOCUMENT the forbidden shape in comments (e.g. "no
+      # `parameters: [statement_timeout: ...]` here"). Those must not trip the guard.
+      commented = ~s(  # NO parameters: [statement_timeout: ...] here — pgbouncer rejects it)
+      assert scan_parameter_lists(commented) == []
+    end
+  end
+
+  # Extract every `parameters: [ ... ]` list from a config file (comments stripped) as
+  # `{inner_text, [key_strings]}`.
+  defp parameter_lists(file) do
+    file |> File.read!() |> scan_parameter_lists()
+  end
+
+  defp scan_parameter_lists(source) do
+    source
+    |> strip_comment_lines()
+    |> then(&Regex.scan(~r/parameters:\s*\[(.*?)\]/s, &1))
+    |> Enum.map(fn [_full, inner] ->
+      keys = ~r/(\w+):/ |> Regex.scan(inner) |> Enum.map(fn [_, key] -> key end)
+      {String.trim(inner), keys}
+    end)
+  end
+
+  # Drop whole-line comments so documentation that mentions the forbidden shape can't
+  # false-positive. Inline trailing comments after real code are harmless: the `parameters`
+  # list closes before any `#`.
+  defp strip_comment_lines(source) do
+    source
+    |> String.split("\n")
+    |> Enum.reject(&(&1 =~ ~r/^\s*#/))
+    |> Enum.join("\n")
+  end
+end

--- a/test/loopctl/heavy_read_pool_isolation_test.exs
+++ b/test/loopctl/heavy_read_pool_isolation_test.exs
@@ -57,4 +57,38 @@ defmodule Loopctl.HeavyReadPoolIsolationTest do
 
     assert {:error, %Postgrex.Error{postgres: %{code: :query_canceled}}} = result
   end
+
+  test "SET LOCAL statement_timeout does NOT carry over between consecutive transactions" do
+    # Regression guard for F1: SET LOCAL is transaction-scoped, not connection-scoped. A
+    # statement_timeout set in one transaction must not affect the next transaction on the
+    # same reused connection. This test proves `SET LOCAL` ends at COMMIT and doesn't leak.
+    # If it leaked, the second transaction would also be subject to the 250ms timeout and
+    # would fail. Instead, it succeeds (the 1-second sleep completes).
+
+    # First transaction: set a short timeout and run pg_sleep(1), which gets canceled.
+    result1 =
+      HeavyReadRepo.transaction(fn ->
+        HeavyReadRepo.query!("SET LOCAL statement_timeout = 250")
+
+        case HeavyReadRepo.query("SELECT pg_sleep(1)") do
+          {:error, error} -> HeavyReadRepo.rollback(error)
+          ok -> ok
+        end
+      end)
+
+    assert {:error, %Postgrex.Error{postgres: %{code: :query_canceled}}} = result1
+
+    # Second transaction on the same connection: NO SET LOCAL. The 1-second sleep should
+    # complete without timing out, proving the first transaction's SET LOCAL didn't carry over.
+    result2 =
+      HeavyReadRepo.transaction(fn ->
+        # No SET LOCAL here — we're relying on the fact that the timeout from transaction 1
+        # should have been reset.
+        HeavyReadRepo.query!("SELECT pg_sleep(0.5)") |> Map.get(:rows)
+      end)
+
+    # pg_sleep returns the `void` type, which Postgrex decodes to the atom `:void`.
+    assert {:ok, [[:void]]} = result2,
+           "expected second transaction to complete without inheriting the 250ms timeout from the first"
+  end
 end

--- a/test/loopctl/heavy_read_pool_isolation_test.exs
+++ b/test/loopctl/heavy_read_pool_isolation_test.exs
@@ -4,8 +4,9 @@ defmodule Loopctl.HeavyReadPoolIsolationTest do
 
   The real protection is STRUCTURAL: `HeavyReadRepo` and `AdminRepo` are distinct
   Ecto repos with distinct, independently-sized DBConnection pools, so saturating
-  one cannot consume the other's connections; and the heavy pool's
-  `statement_timeout` bounds how long any heavy read can hold a connection, so even
+  one cannot consume the other's connections; and the per-read `statement_timeout`
+  (applied via SET LOCAL inside the heavy-read transaction path — US-27.13, the
+  pgbouncer-safe lever) bounds how long any heavy read can hold a connection, so even
   a fully-saturated heavy pool self-drains. (True OS-level pool starvation is not
   reproducible under `Ecto.Adapters.SQL.Sandbox`, which multiplexes a test's queries
   onto a single checked-out connection — so this asserts the structural guarantees
@@ -40,7 +41,20 @@ defmodule Loopctl.HeavyReadPoolIsolationTest do
   end
 
   test "statement_timeout self-drains the heavy pool: a long heavy read is canceled, not held" do
-    assert {:error, %Postgrex.Error{postgres: %{code: :query_canceled}}} =
-             HeavyReadRepo.query("SELECT pg_sleep(1)")
+    # US-27.13: the server-side statement_timeout is applied per-read via SET LOCAL inside a
+    # transaction (the read path; pgbouncer-safe), NOT a pool startup `:parameters`. A long
+    # heavy read under that SET LOCAL self-cancels (query_canceled) rather than holding the
+    # connection until the client timeout.
+    result =
+      HeavyReadRepo.transaction(fn ->
+        HeavyReadRepo.query!("SET LOCAL statement_timeout = 250")
+
+        case HeavyReadRepo.query("SELECT pg_sleep(1)") do
+          {:error, error} -> HeavyReadRepo.rollback(error)
+          ok -> ok
+        end
+      end)
+
+    assert {:error, %Postgrex.Error{postgres: %{code: :query_canceled}}} = result
   end
 end

--- a/test/loopctl/heavy_read_repo_test.exs
+++ b/test/loopctl/heavy_read_repo_test.exs
@@ -1,48 +1,77 @@
 defmodule Loopctl.HeavyReadRepoTest do
   @moduledoc """
-  Pool-level mechanism tests for the dedicated heavy-read pool (US-27.11):
-  the server-side `statement_timeout` carried by the repo `:parameters`
-  (AC-27.11.3/.6) and the `hnsw.ef_search` GUC reachability (AC-27.11.3).
+  Mechanism tests for the dedicated heavy-read pool (US-27.11/US-27.13): the server-side
+  `statement_timeout` applied PER-READ via `SET LOCAL` inside a transaction (AC-27.11.3/.6),
+  and the `hnsw.ef_search` GUC reachability (AC-27.11.3).
 
-  In the test env the pool's `statement_timeout` is set to a deliberately low
-  250ms (config/test.exs) so the fast-fire assertion is sub-second and
-  deterministic.
+  US-27.13: the timeout is NO LONGER carried by a connection-startup `:parameters` — Fly
+  MPG's pgbouncer rejects a `statement_timeout` startup parameter (`08P01`), which
+  crash-loops the whole pool in prod. The old `:parameters` tests "passed" only because the
+  test suite connects to DIRECT Postgres (which accepts the param) — the false confidence
+  that hid the outage. These tests now exercise the `SET LOCAL`-in-transaction path that is
+  pgbouncer-safe and is what the prod read path (`Loopctl.HeavyRead.opts/1` → all/one) uses.
+  In test the SET-LOCAL default is a low 250ms (config/test.exs) so the fast-fire assertion
+  is sub-second.
   """
   use Loopctl.DataCase, async: true
 
   alias Loopctl.HeavyReadRepo
-  alias Loopctl.Knowledge.Article
 
   import Ecto.Query
 
-  describe "pool-level statement_timeout via :parameters" do
-    test "SHOW statement_timeout reflects the configured pool parameter (AC-27.11.3)" do
-      %{rows: [[value]]} = HeavyReadRepo.query!("SHOW statement_timeout")
-      assert value == "250ms"
+  describe "per-read statement_timeout via SET LOCAL (pgbouncer-safe — US-27.13)" do
+    test "SET LOCAL statement_timeout inside a transaction takes effect (SHOW reflects it)" do
+      {:ok, shown} =
+        HeavyReadRepo.transaction(fn ->
+          HeavyReadRepo.query!("SET LOCAL statement_timeout = 250")
+          %{rows: [[value]]} = HeavyReadRepo.query!("SHOW statement_timeout")
+          value
+        end)
+
+      assert shown == "250ms"
     end
 
-    test "a query exceeding statement_timeout fast-fails with 57014 query_canceled (AC-27.11.6)" do
-      # The server cancels at 250ms, well before the client/pool timeout — proof the
-      # pool-level mechanism US-27.4 relies on actually fires and releases the conn.
-      assert {:error, %Postgrex.Error{postgres: %{code: :query_canceled}}} =
-               HeavyReadRepo.query("SELECT pg_sleep(1)")
+    test "a query exceeding the SET LOCAL statement_timeout fast-fails with 57014 query_canceled (AC-27.11.6)" do
+      # The server cancels at 250ms via the SET LOCAL applied inside the transaction —
+      # proof the timeout mechanism the read path relies on actually fires through the
+      # dedicated pool (the pgbouncer-safe replacement for the rejected startup param).
+      result =
+        HeavyReadRepo.transaction(fn ->
+          HeavyReadRepo.query!("SET LOCAL statement_timeout = 250")
+
+          case HeavyReadRepo.query("SELECT pg_sleep(1)") do
+            {:error, error} -> HeavyReadRepo.rollback(error)
+            ok -> ok
+          end
+        end)
+
+      assert {:error, %Postgrex.Error{postgres: %{code: :query_canceled}}} = result
     end
 
-    test "the pool statement_timeout cancels a real Ecto query, not just raw SQL" do
-      # Closes the DI-seam gap: routed reads run on AdminRepo in test, so prove the
-      # dedicated pool's timeout applies to an actual Ecto.Query (built → SQL → run),
-      # not only a raw HeavyReadRepo.query/1.
-      _ = Article
+    test "the SET LOCAL statement_timeout cancels a real Ecto query, not just raw SQL" do
+      # Prove the dedicated pool's SET-LOCAL timeout applies to an actual Ecto.Query
+      # (built → SQL → run), not only a raw HeavyReadRepo.query/1.
       slow = from(s in fragment("generate_series(1, 100000000)"), select: count())
-      err = assert_raise Postgrex.Error, fn -> HeavyReadRepo.all(slow) end
-      assert err.postgres.code == :query_canceled
+
+      result =
+        HeavyReadRepo.transaction(fn ->
+          HeavyReadRepo.query!("SET LOCAL statement_timeout = 250")
+
+          try do
+            HeavyReadRepo.all(slow)
+            :no_cancel
+          rescue
+            e in Postgrex.Error -> HeavyReadRepo.rollback(e)
+          end
+        end)
+
+      assert {:error, %Postgrex.Error{postgres: %{code: :query_canceled}}} = result
     end
 
-    test "SET LOCAL statement_timeout lifts the pool default within a transaction (export lever)" do
-      # US-27.16 streamed exports hold a connection for minutes — longer than the fast-
-      # read pool default. SET LOCAL inside the export's transaction scopes the override
-      # to that transaction only. A 400ms query (> 250ms pool default) survives under a
-      # 5s local override.
+    test "a higher SET LOCAL statement_timeout lifts the default within its transaction (export lever)" do
+      # US-27.16 streamed exports hold a connection for minutes — longer than the fast-read
+      # default. SET LOCAL inside the export's transaction scopes the override to that
+      # transaction only. A 400ms query (> the 250ms test default) survives under a 5s local.
       result =
         HeavyReadRepo.transaction(fn ->
           HeavyReadRepo.query!("SET LOCAL statement_timeout = 5000")

--- a/test/loopctl/pgbouncer_startup_params_test.exs
+++ b/test/loopctl/pgbouncer_startup_params_test.exs
@@ -1,0 +1,119 @@
+defmodule Loopctl.PgbouncerStartupParamsTest do
+  @moduledoc """
+  US-27.13 END-TO-END guard: exercises a connection through a REAL pgbouncer (the layer
+  Fly Managed Postgres puts in front of Postgres), which the rest of the suite never does.
+
+  The US-27.13 outage shipped because EVERY other test connects to DIRECT Postgres — which
+  ACCEPTS a `statement_timeout` connection startup parameter — while prod connects through
+  pgbouncer, which REJECTS it with `08P01 unsupported startup parameter` and crash-loops the
+  whole pool. No test exercised the pgbouncer layer, so the broken `parameters:` config was
+  green in CI and dead in prod.
+
+  This test closes that gap empirically. It is tagged `:pgbouncer` and EXCLUDED from the
+  default suite (no pgbouncer locally); it runs in the dedicated CI `pgbouncer-e2e` job
+  (postgres + pgbouncer services) and locally when you point `PGBOUNCER_URL` at a pgbouncer
+  in transaction-pooling mode. It asserts:
+
+    1. a connection carrying a `statement_timeout` STARTUP parameter cannot serve queries
+       through pgbouncer (reproduces the outage — would have RED-flagged the bad config);
+    2. a clean connection (no such startup param) works through pgbouncer; and
+    3. the FIX's mechanism — a server-side `statement_timeout` applied via `SET LOCAL`
+       inside a transaction — actually ENFORCES through pgbouncer (cancels a slow query).
+  """
+  use ExUnit.Case, async: false
+
+  @moduletag :pgbouncer
+
+  setup do
+    url =
+      System.get_env("PGBOUNCER_URL") ||
+        flunk(
+          "PGBOUNCER_URL must be set to run the :pgbouncer e2e (e.g. " <>
+            "postgres://postgres:postgres@127.0.0.1:6432/loopctl_test). It is wired in the " <>
+            "CI pgbouncer-e2e job; locally, start pgbouncer in transaction mode and export it."
+        )
+
+    {:ok, base: parse_url(url)}
+  end
+
+  test "a `statement_timeout` STARTUP parameter cannot serve queries through pgbouncer (reproduces US-27.13)",
+       %{base: base} do
+    # pgbouncer rejects the non-allowlisted startup parameter at connect (08P01), so the
+    # pool never establishes a usable connection — a checkout fails. Trap the linked exit so
+    # the rejection surfaces as a captured error rather than killing the test.
+    Process.flag(:trap_exit, true)
+    {:ok, conn} = Postgrex.start_link(base ++ [parameters: [statement_timeout: "10000"]])
+
+    result =
+      try do
+        Postgrex.query(conn, "SELECT 1", [], timeout: 4_000)
+      rescue
+        e -> {:error, e}
+      catch
+        :exit, reason -> {:exit, reason}
+      end
+
+    refute match?({:ok, _}, result),
+           "a statement_timeout STARTUP parameter must NOT yield a working connection through " <>
+             "pgbouncer — it is rejected with 08P01 (the US-27.13 outage). Got: #{inspect(result)}"
+  end
+
+  test "a clean connection (no statement_timeout startup param) works through pgbouncer", %{
+    base: base
+  } do
+    {:ok, conn} = Postgrex.start_link(base ++ [parameters: []])
+
+    assert {:ok, %Postgrex.Result{rows: [[1]]}} =
+             Postgrex.query(conn, "SELECT 1", [], timeout: 4_000)
+  end
+
+  test "SET LOCAL statement_timeout ENFORCES through pgbouncer (the fix's mechanism)", %{
+    base: base
+  } do
+    # The pgbouncer-safe way to get a server-side statement_timeout: SET LOCAL inside a
+    # transaction (HeavyRead.opts/1 → all/one). Prove it actually cancels a slow query
+    # through the proxy — so the fix is verified against the real layer, not just direct PG.
+    {:ok, conn} = Postgrex.start_link(base ++ [parameters: []])
+
+    outcome =
+      Postgrex.transaction(conn, fn c ->
+        Postgrex.query!(c, "SET LOCAL statement_timeout = 200", [])
+
+        case Postgrex.query(c, "SELECT pg_sleep(1)", []) do
+          {:error, %Postgrex.Error{postgres: %{code: code}}} -> Postgrex.rollback(c, code)
+          {:ok, _} -> Postgrex.rollback(c, :not_cancelled)
+        end
+      end)
+
+    assert outcome == {:error, :query_canceled},
+           "SET LOCAL statement_timeout must cancel an over-budget query through pgbouncer; got #{inspect(outcome)}"
+  end
+
+  # Parse a postgres:// URL into Postgrex start_link opts (fail-fast pool so a rejected
+  # connection errors quickly instead of queueing).
+  defp parse_url(url) do
+    uri = URI.parse(url)
+    {user, pass} = userinfo(uri.userinfo)
+
+    [
+      hostname: uri.host || "127.0.0.1",
+      port: uri.port || 6432,
+      username: user,
+      password: pass,
+      database: String.trim_leading(uri.path || "/loopctl_test", "/"),
+      backoff_type: :stop,
+      pool_size: 1,
+      queue_target: 300,
+      queue_interval: 600
+    ]
+  end
+
+  defp userinfo(nil), do: {"postgres", "postgres"}
+
+  defp userinfo(info) do
+    case String.split(info, ":", parts: 2) do
+      [u, p] -> {u, p}
+      [u] -> {u, nil}
+    end
+  end
+end

--- a/test/loopctl/pgbouncer_startup_params_test.exs
+++ b/test/loopctl/pgbouncer_startup_params_test.exs
@@ -89,6 +89,45 @@ defmodule Loopctl.PgbouncerStartupParamsTest do
            "SET LOCAL statement_timeout must cancel an over-budget query through pgbouncer; got #{inspect(outcome)}"
   end
 
+  test "prepared statements work correctly under transaction pooling with pool_size > 1 (no 26000/42P05 prepared-statement errors)",
+       %{base: base} do
+    # H1 guard: Under transaction pooling (pool_mode = transaction), prepared statements
+    # named on one server connection are invisible when the next transaction routes to a
+    # different server connection, causing a `26000 (prepared statement does not exist)` or
+    # `42P05 (already exists)` error. This test uses `pool_size: 2` so multiple transactions
+    # can route to different server connections, and proves that executing the same query
+    # twice across two separate transactions does NOT fail with prepared-statement errors.
+    #
+    # `prepare: :unnamed` mirrors the loopctl repos (repo.ex / admin_repo.ex /
+    # heavy_read_repo.ex). This proves the CONFIGURED fix is transaction-pooling-safe: the
+    # same prepared query reused across separate transactions (which may route to different
+    # server connections at pool_size: 2) must NOT raise 26000/42P05.
+    {:ok, conn} =
+      Postgrex.start_link(
+        base ++
+          [
+            parameters: [],
+            prepare: :unnamed,
+            pool_size: 2,
+            queue_target: 300,
+            queue_interval: 600
+          ]
+      )
+
+    # Execute the same query several times in separate transactions to maximize the chance
+    # of landing on different pooled server connections.
+    results =
+      for _ <- 1..6 do
+        Postgrex.transaction(conn, fn c -> Postgrex.query(c, "SELECT 1 AS test_val", []) end)
+      end
+
+    for {result, i} <- Enum.with_index(results, 1) do
+      assert {:ok, {:ok, %Postgrex.Result{rows: [[1]]}}} = result,
+             "transaction #{i} should succeed with no prepared-statement (26000/42P05) error " <>
+               "across pooled connections; got #{inspect(result)}"
+    end
+  end
+
   # Parse a postgres:// URL into Postgrex start_link opts (fail-fast pool so a rejected
   # connection errors quickly instead of queueing).
   defp parse_url(url) do

--- a/test/loopctl/telemetry/slow_query_logger_test.exs
+++ b/test/loopctl/telemetry/slow_query_logger_test.exs
@@ -97,12 +97,18 @@ defmodule Loopctl.Telemetry.SlowQueryLoggerTest do
     # routed heavy read uses — actually produces that telemetry_options[:endpoint] tag,
     # AND threads a configured per-endpoint statement_timeout override. Together they
     # cover the full endpoint-attribution chain deterministically (no flaky sleeps).
+    # An endpoint WITHOUT a per-endpoint override gets the pool-wide DEFAULT
+    # statement_timeout (US-27.13: every heavy read is timed via SET LOCAL, since the
+    # pgbouncer-rejected startup `:parameters` lever was removed — there is no un-timed
+    # "pool default" path). In :test no `:heavy_read_statement_timeout_ms` is configured,
+    # so opts/1 falls back to its 10s default.
     semantic = Knowledge.heavy_read_opts(:semantic_search)
     assert semantic[:telemetry_options] == [endpoint: :semantic_search]
     assert semantic[:timeout] == 15_000
-    refute Keyword.has_key?(semantic, :statement_timeout)
+    assert semantic[:statement_timeout] == 10_000
 
-    # :suggested_links has an override in test config → the SET LOCAL transaction path.
+    # :suggested_links has an override in test config → the SET LOCAL transaction path
+    # uses the override value rather than the default.
     suggested = Knowledge.heavy_read_opts(:suggested_links)
     assert suggested[:telemetry_options] == [endpoint: :suggested_links]
     assert suggested[:statement_timeout] == 5_000

--- a/test/loopctl/telemetry/slow_query_logger_test.exs
+++ b/test/loopctl/telemetry/slow_query_logger_test.exs
@@ -100,12 +100,12 @@ defmodule Loopctl.Telemetry.SlowQueryLoggerTest do
     # An endpoint WITHOUT a per-endpoint override gets the pool-wide DEFAULT
     # statement_timeout (US-27.13: every heavy read is timed via SET LOCAL, since the
     # pgbouncer-rejected startup `:parameters` lever was removed — there is no un-timed
-    # "pool default" path). In :test no `:heavy_read_statement_timeout_ms` is configured,
-    # so opts/1 falls back to its 10s default.
+    # "pool default" path). In :test `:heavy_read_statement_timeout_ms` is set to a low
+    # 250ms (config/test.exs) so the fast-fire mechanism tests stay sub-second.
     semantic = Knowledge.heavy_read_opts(:semantic_search)
     assert semantic[:telemetry_options] == [endpoint: :semantic_search]
     assert semantic[:timeout] == 15_000
-    assert semantic[:statement_timeout] == 10_000
+    assert semantic[:statement_timeout] == 250
 
     # :suggested_links has an override in test config → the SET LOCAL transaction path
     # uses the override value rather than the default.

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -22,4 +22,11 @@ Ecto.Adapters.SQL.Sandbox.mode(Loopctl.AdminRepo, :manual)
 # Plain `mix test` always excludes both :scale and :scale_nightly.
 scale_excluded = if System.get_env("SCALE_TESTS"), do: [], else: [:scale]
 nightly_excluded = if System.get_env("SCALE_NIGHTLY"), do: [], else: [:scale_nightly]
-ExUnit.configure(exclude: scale_excluded ++ nightly_excluded)
+
+# :pgbouncer e2e (US-27.13) needs a real pgbouncer in front of Postgres (no pgbouncer
+# locally / in the default CI Test job). It runs only when PGBOUNCER_URL is set — the
+# dedicated CI pgbouncer-e2e job, or locally against a transaction-mode pgbouncer:
+#   PGBOUNCER_URL=postgres://postgres:postgres@127.0.0.1:6432/loopctl_test \
+#     mix test --include pgbouncer test/loopctl/pgbouncer_startup_params_test.exs
+pgbouncer_excluded = if System.get_env("PGBOUNCER_URL"), do: [], else: [:pgbouncer]
+ExUnit.configure(exclude: scale_excluded ++ nightly_excluded ++ pgbouncer_excluded)


### PR DESCRIPTION
## 🔴 Production outage fix (US-27.13 remediation)

The dedicated `HeavyReadRepo` pool could not establish **any** connection in production. Fly Managed Postgres fronts Postgres with **pgbouncer**, which rejects a non-allowlisted connection startup parameter:

```
FATAL 08P01 (protocol_violation) unsupported startup parameter: statement_timeout
```

`config/runtime.exs` set `parameters: [statement_timeout: ...]` on `HeavyReadRepo` (US-27.11), so all 8 connections crash-looped and **every heavy endpoint** — `suggested_links`, semantic search (results + count), `distant_pairs`, `novelty`, heavy enumeration — hung ~14s on the checkout queue then 503/504'd.

**Why CI was green:** the test suite connects to **direct Postgres** (which *accepts* the startup param) and aliases `HeavyRead`→`AdminRepo`. No test exercised the pgbouncer layer. Only the US-27.13 live-build confirmation surfaced it.

### Fix
Drop the rejected `:parameters` startup param; apply the server-side `statement_timeout` per-read via the existing **`SET LOCAL`-in-transaction** path (`HeavyRead.opts/1` now always carries it — per-endpoint override else the pool-wide `:heavy_read_statement_timeout_ms` default; `all/one` default it when omitted). `SET LOCAL` is pgbouncer-safe and **verified to enforce against the live pool**.

### Verified in production
Deployed (v158) and confirmed on the live build: `HeavyReadRepo.query("SELECT 1")` → 6ms (was a 14s timeout); `suggest_links_with_meta` → 5 results in 40ms against the 77k-row prod corpus; zero 08P01 after cutover.

### Regression guards (the tests that would've caught it)
1. **`config_pgbouncer_safe_parameters_test.exs`** — scans the config *source* (incl. `runtime.exs`, the prod-only file `Application.get_env` never reflects in test — the exact file the bug lived in) and fails if any repo `:parameters` carries a pgbouncer-incompatible startup parameter. Proven to red-flag the re-added param.
2. **`pgbouncer_startup_params_test.exs`** (`:pgbouncer`, gated on `PGBOUNCER_URL`) + a CI **`pgbouncer-e2e`** job (postgres + a real pgbouncer in transaction mode) — reproduces the 08P01 rejection AND proves the `SET LOCAL` fix enforces through the proxy. Verified locally against a real pgbouncer.

Also migrates the pool-level `:parameters` mechanism tests to the `SET LOCAL` path and removes the same incompatible param from `config/test.exs` (mirroring prod).

`mix precommit` green (2963 tests, 0 failures; credo/sobelow/dialyzer clean). Pgbouncer e2e verified locally (3/3).

### Note
A separate, pre-existing boot-race log surfaced during the deploy (`ScaleMetrics.refresh_tenant_label_gate` telemetry poller running before `AdminRepo` finished starting — fired once, not recurring, unrelated to this change). Tracked separately, not in scope here.
