### PR TITLE
US-27.13 (census): calibrated remediation-matrix scale gate (AC-27.13.1/.4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,6 +328,7 @@ jobs:
           - test/loopctl/knowledge/cosine_lint_vs_scale_gate_scale_test.exs
           - test/loopctl/knowledge/scale_calibration_mismatch_scale_test.exs
           - test/loopctl/knowledge/vector_endpoint_e2e_latency_scale_test.exs
+          - test/loopctl/knowledge/remediation_matrix_scale_test.exs
     services:
       postgres:
         image: pgvector/pgvector:pg16

--- a/lib/loopctl/knowledge/scale_seed.ex
+++ b/lib/loopctl/knowledge/scale_seed.ex
@@ -674,10 +674,14 @@ defmodule Loopctl.Knowledge.ScaleSeed do
     # Tenant-scoped committed row count gives an exact assertion that THIS
     # seed's rows reached the planner — table-wide n_live_tup can pass
     # spuriously on shared/re-used DBs where other tenants have rows.
+    # Count ALL statuses: `inserted_count` is every seeded row, so under
+    # `status_mix: true` (~20% draft/archived) a published-only count would be
+    # below inserted_count and spuriously trip the safety-net (defeating it). For an
+    # all-published corpus this is identical to the old published-only count.
     actual_count =
       AdminRepo.one!(
         from a in Article,
-          where: a.tenant_id == ^tenant_id and a.status == :published,
+          where: a.tenant_id == ^tenant_id,
           select: count(a.id)
       )
 

--- a/test/loopctl/knowledge/remediation_matrix_scale_test.exs
+++ b/test/loopctl/knowledge/remediation_matrix_scale_test.exs
@@ -64,8 +64,17 @@ defmodule Loopctl.Knowledge.RemediationMatrixScaleTest do
           |> AdminRepo.insert()
 
         # link_density: 5 (the prod-floor default) — enough links for the suggested_links
-        # anti-join + distant_pairs to be real, the same seed shape topk_endpoints uses.
-        ScaleSeed.seed(t.id, count: ScaleSeed.prod_article_floor(), link_density: 5)
+        # anti-join + distant_pairs to be real. `status_mix: true` interleaves ~20%
+        # non-published rows so the enumeration endpoints' `status = :published` residual has
+        # REAL selectivity (matching keyset_plan_scale_test.exs's corpus, not an all-published
+        # no-op — architect review F1); the vector endpoints still see ~64k published embedded
+        # rows, ample for the HNSW path. More prod-representative for the whole census.
+        ScaleSeed.seed(t.id,
+          count: ScaleSeed.prod_article_floor(),
+          link_density: 5,
+          status_mix: true
+        )
+
         t
       end)
 
@@ -89,7 +98,14 @@ defmodule Loopctl.Knowledge.RemediationMatrixScaleTest do
 
     # CI records the census as the AC-27.13.1 remediation work-list (the matrix IS the
     # work-list). Print BEFORE asserting so a RED endpoint's reason is in the log.
-    IO.puts("\n=== US-27.13 remediation matrix ===\n" <> RemediationMatrix.to_json(matrix))
+    json = RemediationMatrix.to_json(matrix)
+    IO.puts("\n=== US-27.13 remediation matrix ===\n" <> json)
+
+    # The rendered census is valid JSON that round-trips to the recorded shape (exercises the
+    # pretty-printer across every result/coverage variant — engineer review LOW-2).
+    decoded = JSON.decode!(json)
+    assert is_map(decoded["calibration"]) and is_list(decoded["endpoints"])
+    assert decoded["certified"] == true and decoded["work_list"] == []
 
     # AC-27.13.4a: calibration provenance — seed >= prod floor AND a readable ef_search.
     assert matrix.calibration.calibrated? == true,

--- a/test/loopctl/knowledge/remediation_matrix_scale_test.exs
+++ b/test/loopctl/knowledge/remediation_matrix_scale_test.exs
@@ -1,0 +1,227 @@
+defmodule Loopctl.Knowledge.RemediationMatrixScaleTest do
+  @moduledoc """
+  US-27.13 remediation-matrix scale gate (AC-27.13.1/.2/.4/.5): ONE calibrated,
+  certified census that aggregates every per-endpoint vector/enumeration plan gate
+  into a single pass/fail matrix WITH calibration provenance.
+
+  This closes the detect→fix seam (BA review C1): the US-27.6b/27.7a/27.8/27.9a/27.9b
+  gates already PROVE each endpoint is index-correct at >= prod scale, making the
+  remediation work-list empty. AC-27.13.4 makes that all-green outcome VALID only when
+  the matrix records its calibration provenance (seed count >= `prod_article_floor` AND
+  the effective `hnsw.ef_search`) and REJECTS an uncalibrated run as INVALID rather than
+  rubber-stamping it green. The live-build confirmation on `suggested_links`
+  (AC-27.13.4b) is run separately against prod per the US-27.5 runbook — not here.
+
+  Three tests:
+
+    * **Test A (happy census)** — build the matrix against the committed 80k corpus,
+      `IO.puts` the JSON (CI records it as the AC-27.13.1 work-list), and assert it is
+      calibrated, work-list-empty, certified, every asserted endpoint passed, and the
+      census is COMPLETE (no endpoint silently dropped).
+    * **Test B (anti-rubber-stamp / INVALID path)** — prove a calibration failure yields
+      `certified? == false`, NOT a green pass, by driving the REAL `certified?/1` with an
+      injected sub-floor / nil-ef calibration map (mirroring how
+      `scale_calibration_mismatch_scale_test.exs` drives the shared assertion in both
+      directions). No sub-floor reseed (too slow).
+    * **Test C (tenant isolation)** — a SECOND tiny tenant's rows do not bleed into the
+      first tenant's `seed_count` (the census's calibration count is tenant-scoped).
+
+  Seeds ~80k committed rows via `Loopctl.Knowledge.ScaleSeed`, so it is `:scale_nightly`
+  (nightly/scale gate, NOT the default async suite) and is wired into
+  `.github/workflows/ci.yml`'s `scale_file` matrix (enforced by
+  `scale_verification_runbook_test.exs`).
+  """
+  use ExUnit.Case, async: false
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.ScaleSeed
+  alias Loopctl.RemediationMatrix
+  alias Loopctl.Tenants.Tenant
+
+  import Ecto.Query
+
+  @moduletag :scale_nightly
+  @moduletag timeout: :timer.minutes(30)
+
+  defp unboxed(fun), do: Sandbox.unboxed_run(AdminRepo, fun)
+
+  setup do
+    tenant =
+      unboxed(fn ->
+        slug = "remediation-matrix-scale-#{:erlang.phash2(Ecto.UUID.generate())}"
+
+        {:ok, t} =
+          %Tenant{}
+          |> Tenant.create_changeset(%{
+            name: "Remediation Matrix Scale #{slug}",
+            slug: slug,
+            email: "#{slug}@example.com",
+            settings: %{},
+            status: :active
+          })
+          |> AdminRepo.insert()
+
+        # link_density: 5 (the prod-floor default) — enough links for the suggested_links
+        # anti-join + distant_pairs to be real, the same seed shape topk_endpoints uses.
+        ScaleSeed.seed(t.id, count: ScaleSeed.prod_article_floor(), link_density: 5)
+        t
+      end)
+
+    on_exit(fn ->
+      try do
+        unboxed(fn ->
+          AdminRepo.delete_all(from(a in Article, where: a.tenant_id == ^tenant.id))
+          AdminRepo.delete_all(from(t in Tenant, where: t.id == ^tenant.id))
+        end)
+      rescue
+        _ -> :ok
+      end
+    end)
+
+    {:ok, tenant: tenant}
+  end
+
+  test "the remediation matrix is calibrated, complete, work-list-empty, and certified at prod scale",
+       %{tenant: tenant} do
+    matrix = unboxed(fn -> RemediationMatrix.build(tenant.id) end)
+
+    # CI records the census as the AC-27.13.1 remediation work-list (the matrix IS the
+    # work-list). Print BEFORE asserting so a RED endpoint's reason is in the log.
+    IO.puts("\n=== US-27.13 remediation matrix ===\n" <> RemediationMatrix.to_json(matrix))
+
+    # AC-27.13.4a: calibration provenance — seed >= prod floor AND a readable ef_search.
+    assert matrix.calibration.calibrated? == true,
+           "matrix must be calibrated (seed >= prod_floor AND ef_search read): " <>
+             inspect(matrix.calibration)
+
+    assert matrix.calibration.seed_count >= matrix.calibration.prod_floor
+    assert is_binary(matrix.calibration.effective_ef_search)
+
+    # AC-27.13.1/.2: the work-list (asserted endpoints whose plan assertion RAISED) is
+    # empty — every endpoint the gate proves is index-correct at scale.
+    assert matrix.work_list == [],
+           "remediation work-list must be empty; RED endpoints: #{inspect(matrix.work_list)}"
+
+    # AC-27.13.4: certified == calibrated AND work-list empty.
+    assert matrix.certified? == true
+
+    # Every ASSERTED endpoint passed (delegated ones are :delegated, not :pass).
+    for ep <- matrix.endpoints, ep.coverage == :asserted do
+      assert ep.result == :pass,
+             "asserted endpoint #{ep.name} must pass; got #{inspect(ep.result)}"
+    end
+
+    # The two delegated endpoints are present, honestly marked :delegated (NOT :pass) —
+    # covered by their own dedicated gate, visible here for COMPLETE coverage.
+    delegated = Enum.filter(matrix.endpoints, &match?({:delegated, _}, &1.coverage))
+    assert length(delegated) == 2
+
+    for ep <- delegated do
+      assert ep.result == :delegated,
+             "delegated endpoint #{ep.name} must be :delegated (never falsely :pass)"
+    end
+
+    # COMPLETENESS (AC-27.13.1): the census must cover the canonical endpoint set
+    # EXACTLY — a silently-dropped endpoint (gap in coverage) fails the test.
+    actual_names = matrix.endpoints |> Enum.map(& &1.name) |> MapSet.new()
+    expected_names = MapSet.new(RemediationMatrix.canonical_endpoint_names())
+
+    assert MapSet.equal?(actual_names, expected_names),
+           "census coverage drifted from the canonical set.\n" <>
+             "Missing: #{inspect(MapSet.to_list(MapSet.difference(expected_names, actual_names)))}\n" <>
+             "Unexpected: #{inspect(MapSet.to_list(MapSet.difference(actual_names, expected_names)))}"
+  end
+
+  test "an UNCALIBRATED matrix is REJECTED as invalid (certified? == false), not rubber-stamped green",
+       %{tenant: tenant} do
+    # Build the REAL matrix (calibrated, certified) once.
+    matrix = unboxed(fn -> RemediationMatrix.build(tenant.id) end)
+
+    assert matrix.certified? == true,
+           "precondition: the real matrix is certified before we inject miscalibration.\n" <>
+             RemediationMatrix.to_json(matrix)
+
+    floor = matrix.calibration.prod_floor
+
+    # AC-27.13.4a — anti-rubber-stamp. Drive the SAME `certified?/1` the build uses
+    # (not a re-implemented copy) with injected calibration failures, proving each
+    # yields certified? == false EVEN THOUGH the work-list is empty. This is the
+    # INVALID rejection that stops a mis-calibrated CI run certifying green.
+
+    # 1. Sub-floor seed count (a half-scale / unseeded gate).
+    sub_floor_cal = %{matrix.calibration | seed_count: floor - 1, calibrated?: false}
+
+    refute RemediationMatrix.certified?(%{matrix | calibration: sub_floor_cal}),
+           "a sub-floor matrix must be REJECTED as invalid, not certified green"
+
+    # 2. No readable ef_search (uncalibrated GUC) — also INVALID.
+    nil_ef_cal = %{matrix.calibration | effective_ef_search: nil, calibrated?: false}
+
+    refute RemediationMatrix.certified?(%{matrix | calibration: nil_ef_cal}),
+           "a matrix with no effective ef_search must be REJECTED as invalid"
+
+    # Control: an empty work-list ALONE (still calibrated) IS certified — proving it's
+    # the calibration that gates, and we didn't just break certified? unconditionally.
+    assert RemediationMatrix.certified?(%{matrix | work_list: []})
+
+    # And a calibrated matrix with a NON-empty work-list (a real RED endpoint) is also
+    # rejected — certified? requires BOTH calibration AND a clean work-list.
+    refute RemediationMatrix.certified?(%{matrix | work_list: ["suggested_links"]}),
+           "a calibrated matrix with a RED endpoint must NOT certify"
+  end
+
+  test "the matrix calibration count is tenant-scoped (isolation, AC-27.13.5)", %{tenant: tenant} do
+    # Seed a SECOND, tiny tenant. Its rows must NOT inflate the first tenant's seed_count
+    # — the census's calibration count carries the tenant_id filter.
+    other =
+      unboxed(fn ->
+        slug = "remediation-iso-#{:erlang.phash2(Ecto.UUID.generate())}"
+
+        {:ok, t} =
+          %Tenant{}
+          |> Tenant.create_changeset(%{
+            name: "Remediation Iso #{slug}",
+            slug: slug,
+            email: "#{slug}@example.com",
+            settings: %{},
+            status: :active
+          })
+          |> AdminRepo.insert()
+
+        # A handful of rows — enough to prove the count is scoped, cheap to seed.
+        ScaleSeed.seed(t.id, count: 25, link_density: 1)
+        t
+      end)
+
+    on_exit(fn ->
+      try do
+        unboxed(fn ->
+          AdminRepo.delete_all(from(a in Article, where: a.tenant_id == ^other.id))
+          AdminRepo.delete_all(from(t in Tenant, where: t.id == ^other.id))
+        end)
+      rescue
+        _ -> :ok
+      end
+    end)
+
+    floor = ScaleSeed.prod_article_floor()
+
+    # The first tenant's calibration count reflects ONLY its own ~80k corpus — the
+    # second tenant's 25 rows are invisible to it.
+    primary = unboxed(fn -> RemediationMatrix.build(tenant.id) end)
+    assert primary.calibration.seed_count >= floor
+
+    # The second tenant's count is its own 25 rows — NOT the first tenant's (it is far
+    # below the floor), proving the count query is tenant-scoped, not corpus-wide.
+    secondary = unboxed(fn -> RemediationMatrix.build(other.id) end)
+    assert secondary.calibration.seed_count == 25
+    assert secondary.calibration.seed_count < floor
+
+    # A sub-floor tenant is (correctly) NOT calibrated, so NOT certified — the gate
+    # would refuse to rubber-stamp a run against that tenant.
+    assert secondary.calibration.calibrated? == false
+    assert secondary.certified? == false
+  end
+end

--- a/test/loopctl/knowledge/remediation_matrix_scale_test.exs
+++ b/test/loopctl/knowledge/remediation_matrix_scale_test.exs
@@ -107,6 +107,36 @@ defmodule Loopctl.Knowledge.RemediationMatrixScaleTest do
     assert is_map(decoded["calibration"]) and is_list(decoded["endpoints"])
     assert decoded["certified"] == true and decoded["work_list"] == []
 
+    # Unit assertion: the pretty-printer handles all result variants, including :fail with
+    # tricky reason strings (newlines, quotes, braces). Synthetic matrix needed since the
+    # real gate only produces green/delegated.
+    synthetic_fail_reason =
+      "plan rejected: EXPLAIN { plan:\n  \"node\": \"Seq Scan\",\n  \"rows\": 80000 }\n quote: \""
+
+    synthetic_matrix = %{
+      calibration: matrix.calibration,
+      endpoints: [
+        %{
+          name: "test_endpoint",
+          dimension: :vector,
+          coverage: :asserted,
+          result: {:fail, synthetic_fail_reason}
+        }
+      ],
+      certified?: false,
+      work_list: ["test_endpoint"]
+    }
+
+    synthetic_json = RemediationMatrix.to_json(synthetic_matrix)
+    synthetic_decoded = JSON.decode!(synthetic_json)
+    assert is_map(synthetic_decoded["calibration"])
+    assert is_list(synthetic_decoded["endpoints"])
+
+    assert Enum.any?(synthetic_decoded["endpoints"], fn ep ->
+             ep["name"] == "test_endpoint" and ep["result"]["status"] == "fail" and
+               ep["result"]["reason"] =~ "Seq Scan"
+           end)
+
     # AC-27.13.4a: calibration provenance — seed >= prod floor AND a readable ef_search.
     assert matrix.calibration.calibrated? == true,
            "matrix must be calibrated (seed >= prod_floor AND ef_search read): " <>
@@ -239,5 +269,26 @@ defmodule Loopctl.Knowledge.RemediationMatrixScaleTest do
     # would refuse to rubber-stamp a run against that tenant.
     assert secondary.calibration.calibrated? == false
     assert secondary.certified? == false
+  end
+
+  test "calibration derivation logic covers all four corners (F3 / no-deferrals)" do
+    # F3: the nil-ef case must be testable independently. Unit test the extracted
+    # pure function `calibrated_from_values?/3` for all four corners.
+    floor = ScaleSeed.prod_article_floor()
+    sub_floor = floor - 1
+    ef_readable = "40"
+    ef_nil = nil
+
+    # Corner 1: floor + readable ef → calibrated
+    assert RemediationMatrix.calibrated_from_values?(floor, floor, ef_readable) == true
+
+    # Corner 2: floor + nil ef → NOT calibrated (ef check fails)
+    assert RemediationMatrix.calibrated_from_values?(floor, floor, ef_nil) == false
+
+    # Corner 3: sub-floor + readable ef → NOT calibrated (count check fails)
+    assert RemediationMatrix.calibrated_from_values?(sub_floor, floor, ef_readable) == false
+
+    # Corner 4: sub-floor + nil ef → NOT calibrated (both checks fail)
+    assert RemediationMatrix.calibrated_from_values?(sub_floor, floor, ef_nil) == false
   end
 end

--- a/test/loopctl/knowledge/remediation_matrix_test.exs
+++ b/test/loopctl/knowledge/remediation_matrix_test.exs
@@ -1,0 +1,33 @@
+defmodule Loopctl.RemediationMatrixTest do
+  @moduledoc """
+  Pure unit tests for `Loopctl.RemediationMatrix`'s calibration derivation (US-27.13,
+  AC-27.13.4a) — no DB, no 80k seed. The end-to-end census runs in
+  `remediation_matrix_scale_test.exs` (`:scale_nightly`); this file pins the anti-rubber-stamp
+  BOOLEAN derivation in isolation so all four corners are proven, including the nil-ef case
+  that the scale test's injected-calibration path never makes the deciding factor (adversarial
+  review F3).
+  """
+  use ExUnit.Case, async: true
+
+  alias Loopctl.RemediationMatrix
+
+  describe "calibrated_from_values?/3 — the anti-rubber-stamp derivation" do
+    test "calibrated ONLY when seed >= floor AND ef_search is a readable (binary) value" do
+      floor = 80_000
+
+      # at/above floor + readable ef → calibrated
+      assert RemediationMatrix.calibrated_from_values?(floor, floor, "40")
+      assert RemediationMatrix.calibrated_from_values?(floor + 1, floor, "40")
+
+      # at/above floor but ef NOT readable (nil) → NOT calibrated.
+      # This is the corner the scale test never makes the deciding factor: a regression that
+      # dropped the ef-search check from the derivation would be caught HERE.
+      refute RemediationMatrix.calibrated_from_values?(floor, floor, nil)
+
+      # sub-floor → NOT calibrated, regardless of ef readability
+      refute RemediationMatrix.calibrated_from_values?(floor - 1, floor, "40")
+      refute RemediationMatrix.calibrated_from_values?(floor - 1, floor, nil)
+      refute RemediationMatrix.calibrated_from_values?(0, floor, "40")
+    end
+  end
+end

--- a/test/support/remediation_matrix.ex
+++ b/test/support/remediation_matrix.ex
@@ -88,6 +88,13 @@ defmodule Loopctl.RemediationMatrix do
   # prior_tag and the by-tag keyset residual so the `tags &&` GIN is selective at
   # prod scale. SAME value `distant_pairs_novelty_scale_test.exs` (`@prior_tag`)
   # and the keyset tests ("scale-tag-7") use.
+  #
+  # INVARIANT under `status_mix: true` (review LOW): `index_keyset_query` forces
+  # `status = :published`, and ScaleSeed marks row i archived/draft when `i mod 10 ∈ {0, 5}`.
+  # The by-tag/by-source selective index MUST land on published rows or the deep-page
+  # assertion runs against an EMPTY set and passes vacuously. Both 3 and 7 are safe: a tag
+  # index t selects rows `i ≡ t (mod 50)`, so `i mod 10 = t mod 10`; the source bucket b
+  # (of 800, also ÷10) selects `i mod 10 = b mod 10`. Keep tag/bucket indices ≢ 0,5 (mod 10).
   @prior_tag "scale-tag-3"
   @keyset_tag "scale-tag-7"
 
@@ -212,8 +219,14 @@ defmodule Loopctl.RemediationMatrix do
       seed_count: seed_count,
       prod_floor: prod_floor,
       effective_ef_search: effective_ef_search,
-      calibrated?: seed_count >= prod_floor and is_binary(effective_ef_search)
+      calibrated?: calibrated_from_values?(seed_count, prod_floor, effective_ef_search)
     }
+  end
+
+  # Pure derivation of the calibration boolean — extracted for unit testability (all four corners).
+  @spec calibrated_from_values?(non_neg_integer(), non_neg_integer(), binary() | nil) :: boolean()
+  def calibrated_from_values?(seed_count, prod_floor, effective_ef_search) do
+    seed_count >= prod_floor and is_binary(effective_ef_search)
   end
 
   # Committed count of THIS tenant's articles (an actual count(*), like
@@ -228,10 +241,8 @@ defmodule Loopctl.RemediationMatrix do
     n || 0
   end
 
-  # The effective `hnsw.ef_search` GUC on the gate connection. Touch a vector op first
-  # (pgvector lazily registers the GUC on first vector use in a session), THEN `SHOW`.
+  # The effective `hnsw.ef_search` GUC on the gate connection.
   defp effective_ef_search do
-    AdminRepo.query!("SELECT '[1,2,3]'::vector")
     %{rows: [[v]]} = AdminRepo.query!("SHOW hnsw.ef_search")
     v
   end

--- a/test/support/remediation_matrix.ex
+++ b/test/support/remediation_matrix.ex
@@ -1,0 +1,512 @@
+defmodule Loopctl.RemediationMatrix do
+  @moduledoc """
+  US-27.13 remediation-matrix scale gate: ONE calibrated, certified census that
+  aggregates the per-endpoint plan gates (US-27.6b/27.7a/27.7b/27.8/27.9a/27.9b)
+  into a single pass/fail matrix with calibration PROVENANCE.
+
+  This is the "act on the alarm" layer (BA review C1, the detect→fix seam): the
+  individual gates already PROVE each endpoint is index-correct at >= prod scale,
+  but no single artifact OWNS the question "is EVERY endpoint green, AND was the
+  run honestly calibrated?". A green matrix is only a valid `certified?` outcome
+  when (AC-27.13.4a):
+
+    * the seed is AT OR ABOVE `ScaleSeed.prod_article_floor/0`, AND
+    * the effective `hnsw.ef_search` was actually read (a calibrated GUC), AND
+    * the work-list (asserted endpoints whose plan assertion RAISED) is empty.
+
+  An UNCALIBRATED matrix (sub-floor seed, or no readable ef_search) is rejected as
+  INVALID — `certified?/1` returns `false` — rather than being allowed to
+  rubber-stamp a green-but-mis-calibrated CI run. `certified?/1` is the SHARED
+  function the gate test drives in BOTH directions (a real calibrated build →
+  true; an injected sub-floor/nil-ef calibration map → false), mirroring how
+  `scale_calibration_mismatch_scale_test.exs` drives the shared parity assertion.
+
+  ## Coverage honesty
+
+  Every endpoint that this census can re-verify in-process against the
+  `ScaleSeed.seed/2` corpus runs its REAL request-path query builder (NOT a
+  re-built stunt double — AC-27.2.4) through `Loopctl.PlanAssertions`. Two
+  endpoints are `:delegated` — they are covered by a DEDICATED `:scale_nightly`
+  gate but cannot be honestly re-run here:
+
+    * `change_feed` reads the RANGE-partitioned `audit_log`, which `ScaleSeed.seed/2`
+      does NOT populate (it needs `seed_changes/2` + multi-partition straddling);
+      re-running its assertion here would need bespoke audit seeding. Owned by
+      `by_source_change_feed_plan_scale_test.exs`.
+    * `streaming_export` is an HTTP MEMORY-bound dimension (constant-memory chunked
+      streaming), not a plan assertion. Owned by `streaming_export_scale_test.exs`.
+
+  `:delegated` endpoints DO appear in the census (so coverage is complete and
+  visible) but do NOT count toward `work_list` and do NOT block `certified?` —
+  they have their own CI gate. They are NEVER reported as `:pass`, because the
+  census did not run them; `:delegated` is an honest third result value.
+
+  This is TEST SUPPORT (it calls `Loopctl.PlanAssertions`, itself test-support),
+  not a test. The gate that drives it is
+  `test/loopctl/knowledge/remediation_matrix_scale_test.exs`.
+
+  Run everything inside `Sandbox.unboxed_run(AdminRepo, ...)` (HeavyRead routes to
+  AdminRepo in test) against the committed, ANALYZEd corpus.
+  """
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.ScaleSeed
+  alias Loopctl.Knowledge.VectorSearch
+  alias Loopctl.PlanAssertions
+
+  import Ecto.Query
+
+  @typedoc "A single endpoint census row."
+  @type endpoint :: %{
+          name: String.t(),
+          dimension: :vector | :enumeration,
+          coverage: :asserted | {:delegated, String.t()},
+          result: :pass | :delegated | :uncalibrated | {:fail, String.t()}
+        }
+
+  @typedoc "The calibration provenance of the run."
+  @type calibration :: %{
+          seed_count: non_neg_integer(),
+          prod_floor: pos_integer(),
+          effective_ef_search: String.t() | nil,
+          calibrated?: boolean()
+        }
+
+  @typedoc "The full remediation matrix."
+  @type matrix :: %{
+          calibration: calibration(),
+          endpoints: [endpoint()],
+          work_list: [String.t()],
+          certified?: boolean()
+        }
+
+  # The tag ScaleSeed stamps on ~2% of rows (one of 50) — used as the novelty
+  # prior_tag and the by-tag keyset residual so the `tags &&` GIN is selective at
+  # prod scale. SAME value `distant_pairs_novelty_scale_test.exs` (`@prior_tag`)
+  # and the keyset tests ("scale-tag-7") use.
+  @prior_tag "scale-tag-3"
+  @keyset_tag "scale-tag-7"
+
+  # The canonical, COMPLETE set of endpoint names this census must cover. The gate
+  # asserts the built matrix's endpoint names equal this set, so a silently-dropped
+  # endpoint FAILS the test (it cannot quietly vanish from coverage). Each entry is
+  # `{name, dimension, coverage}` — the SINGLE source of truth shared by the calibrated
+  # census (which runs the assertions) and the uncalibrated census (which marks the
+  # asserted ones `:uncalibrated`), so the two paths can never drift in coverage.
+  @endpoint_specs [
+    {"suggested_links", :vector, :asserted},
+    {"search_semantic_results", :vector, :asserted},
+    {"search_semantic_count", :vector, :asserted},
+    {"auto_link_worker", :vector, :asserted},
+    {"distant_pairs", :vector, :asserted},
+    {"novelty", :vector, :asserted},
+    {"keyset_enumeration", :enumeration, :asserted},
+    {"by_source_keyset", :enumeration, :asserted},
+    {"by_tag_keyset", :enumeration, :asserted},
+    {"change_feed", :enumeration, {:delegated, "by_source_change_feed_plan_scale_test.exs"}},
+    {"streaming_export", :enumeration, {:delegated, "streaming_export_scale_test.exs"}}
+  ]
+
+  @canonical_endpoints Enum.map(@endpoint_specs, fn {name, _dim, _cov} -> name end)
+
+  @doc """
+  The canonical, complete set of endpoint names the census must cover (the gate
+  asserts the built matrix matches this exactly, so coverage can't silently rot).
+  """
+  @spec canonical_endpoint_names() :: [String.t()]
+  def canonical_endpoint_names, do: @canonical_endpoints
+
+  @doc """
+  Builds the full remediation matrix for `tenant_id` against the committed,
+  ANALYZEd `ScaleSeed.seed/2` corpus.
+
+  Reads calibration provenance, runs ONE representative plan assertion per asserted
+  endpoint (capturing `:pass` / `{:fail, reason}`), records the two `:delegated`
+  endpoints, computes the `work_list` (failed asserted endpoints), and derives
+  `certified?` via `certified?/1`.
+
+  MUST be called inside `Sandbox.unboxed_run(AdminRepo, fn -> ... end)`.
+  """
+  @spec build(binary()) :: matrix()
+  def build(tenant_id) when is_binary(tenant_id) do
+    calibration = calibration(tenant_id)
+
+    # The per-endpoint census ASSUMES a >= prod-floor corpus — every plan assertion is
+    # theatre at sub-floor scale (the planner Seq-Scans happily, so it would false-GREEN
+    # OR crash on a too-small corpus, e.g. no row at offset 100 for `a_target`). So an
+    # UNCALIBRATED run does NOT run the census: it records each endpoint as `:uncalibrated`
+    # (a not-run marker, NEVER `:pass`) and stays un-certified. This is the AC-27.13.4a
+    # INVALID outcome — honest coverage with no rubber-stamp — and keeps `build/2` safe to
+    # call on a sub-floor tenant (the isolation test).
+    endpoints =
+      if calibration.calibrated? do
+        census(tenant_id)
+      else
+        uncalibrated_census()
+      end
+
+    work_list =
+      endpoints
+      |> Enum.filter(fn ep -> match?({:fail, _}, ep.result) end)
+      |> Enum.map(& &1.name)
+
+    matrix = %{
+      calibration: calibration,
+      endpoints: endpoints,
+      work_list: work_list,
+      certified?: false
+    }
+
+    %{matrix | certified?: certified?(matrix)}
+  end
+
+  @doc """
+  A matrix is CERTIFIED iff it was honestly calibrated AND its work-list is empty.
+
+  This is the anti-rubber-stamp gate (AC-27.13.4a): an UNCALIBRATED matrix (sub-floor
+  seed or no readable ef_search) is rejected as INVALID — returns `false` — even when
+  the work-list is empty, so a mis-calibrated green CI run cannot certify. The gate
+  test drives THIS function in both directions (real calibrated build → true; injected
+  sub-floor/nil-ef calibration → false), so the INVALID rejection is the actual code
+  path, not a re-implemented copy.
+  """
+  @spec certified?(matrix()) :: boolean()
+  def certified?(%{calibration: %{calibrated?: calibrated?}, work_list: work_list}) do
+    calibrated? and work_list == []
+  end
+
+  @doc """
+  Renders the matrix as pretty-printed JSON (stdlib `JSON`, Elixir 1.18) for CI to
+  record (AC-27.13.1 — the matrix IS the recorded remediation work-list).
+
+  Tuple results (`{:fail, reason}`, `{:delegated, file}`) are normalized to JSON-
+  encodable shapes so the rendered census is a faithful, machine-readable artifact.
+  """
+  @spec to_json(matrix()) :: String.t()
+  def to_json(matrix) do
+    matrix
+    |> jsonable()
+    |> JSON.encode!()
+    |> pretty()
+  end
+
+  # --- calibration provenance ---
+
+  @spec calibration(binary()) :: calibration()
+  defp calibration(tenant_id) do
+    prod_floor = ScaleSeed.prod_article_floor()
+    seed_count = tenant_article_count(tenant_id)
+    effective_ef_search = effective_ef_search()
+
+    %{
+      seed_count: seed_count,
+      prod_floor: prod_floor,
+      effective_ef_search: effective_ef_search,
+      calibrated?: seed_count >= prod_floor and is_binary(effective_ef_search)
+    }
+  end
+
+  # Committed count of THIS tenant's articles (an actual count(*), like
+  # PlanAssertions.assert_scale_floor!/1 — not the autovacuum estimate). Tenant-scoped
+  # because each scale test seeds its OWN ~80k tenant.
+  defp tenant_article_count(tenant_id) do
+    %{rows: [[n]]} =
+      AdminRepo.query!("SELECT count(*) FROM articles WHERE tenant_id = $1", [
+        Ecto.UUID.dump!(tenant_id)
+      ])
+
+    n || 0
+  end
+
+  # The effective `hnsw.ef_search` GUC on the gate connection. Touch a vector op first
+  # (pgvector lazily registers the GUC on first vector use in a session), THEN `SHOW`.
+  defp effective_ef_search do
+    AdminRepo.query!("SELECT '[1,2,3]'::vector")
+    %{rows: [[v]]} = AdminRepo.query!("SHOW hnsw.ef_search")
+    v
+  end
+
+  # --- per-endpoint census ---
+
+  @spec census(binary()) :: [endpoint()]
+  defp census(tenant_id) do
+    target = a_target(tenant_id)
+    qemb = VectorSearch.to_embedding_list(target.embedding)
+    max_comparisons = Application.get_env(:loopctl, :article_link_max_comparisons, 50)
+    prod_floor = ScaleSeed.prod_article_floor()
+    cursor = deep_published_cursor(tenant_id)
+    source_id = ScaleSeed.source_id_for(tenant_id, 7)
+
+    [
+      # ---- vector endpoints (asserted) ----
+      asserted("suggested_links", :vector, fn ->
+        query =
+          Knowledge.suggestion_candidates_query(
+            tenant_id,
+            target.id,
+            target.embedding,
+            0.5,
+            5,
+            nil
+          )
+
+        PlanAssertions.refute_full_scan(query)
+        PlanAssertions.assert_hnsw_index(query)
+      end),
+      asserted("search_semantic_results", :vector, fn ->
+        query = Knowledge.semantic_results_query(tenant_id, qemb, [])
+        PlanAssertions.refute_full_scan(query)
+        PlanAssertions.assert_hnsw_index(query)
+      end),
+      asserted("search_semantic_count", :vector, fn ->
+        query = Knowledge.semantic_count_query(tenant_id, qemb, :published, [])
+        PlanAssertions.refute_sort(query)
+      end),
+      asserted("auto_link_worker", :vector, fn ->
+        query =
+          VectorSearch.candidate_query(tenant_id, target.embedding, max_comparisons,
+            exclude_id: target.id,
+            project_or_global: nil,
+            threshold: 0.0,
+            pool: VectorSearch.pool_size(max_comparisons)
+          )
+
+        PlanAssertions.refute_full_scan(query)
+        PlanAssertions.assert_hnsw_index(query)
+      end),
+      asserted("distant_pairs", :vector, fn ->
+        captured =
+          PlanAssertions.capture_repo_queries(fn ->
+            {:ok, _} = Knowledge.distant_pairs(tenant_id)
+          end)
+
+        between =
+          Enum.filter(captured, fn {sql, _} -> sql =~ ~r/BETWEEN/i end)
+
+        if between == [] do
+          raise ExUnit.AssertionError,
+            message: "distant_pairs emitted no BETWEEN (band) query to assert on"
+        end
+
+        for {sql, params} <- between do
+          PlanAssertions.refute_seq_scan({sql, params})
+        end
+      end),
+      asserted("novelty", :vector, fn ->
+        query =
+          Knowledge.novelty_distance_query(tenant_id, ScaleSeed.embedding_for(0), @prior_tag, nil)
+
+        PlanAssertions.refute_seq_scan(query)
+        PlanAssertions.assert_actual_scan_rows_below(query, div(prod_floor, 8))
+      end),
+
+      # ---- enumeration endpoints (asserted) ----
+      asserted("keyset_enumeration", :enumeration, fn ->
+        query = Knowledge.keyset_query(tenant_id, status: :published, cursor: cursor, limit: 21)
+        PlanAssertions.refute_full_scan(query)
+      end),
+      asserted("by_source_keyset", :enumeration, fn ->
+        # The real by-source request path forces status/project internally and carries
+        # the non-selective source_type alongside the SELECTIVE source_id.
+        query =
+          Knowledge.index_keyset_query(tenant_id,
+            source_type: ScaleSeed.scale_source_type(),
+            source_id: source_id,
+            cursor: nil,
+            limit: 21
+          )
+
+        PlanAssertions.refute_full_scan(query)
+      end),
+      asserted("by_tag_keyset", :enumeration, fn ->
+        query =
+          Knowledge.index_keyset_query(tenant_id, tags: [@keyset_tag], cursor: cursor, limit: 21)
+
+        # The tags `&&` residual on a deep keyset page has TWO legitimate bounded plans the
+        # cost-based planner picks between AT the 80k floor (a cost margin a small stats
+        # shift flips — see keyset_plan_scale_test.exs):
+        #   * the tags GIN (`articles_tags_index`) BitmapAnd'd with the keyset btree, OR
+        #   * the keyset btree (`articles_tenant_inserted_id_idx`) walked from the deep
+        #     cursor with `tags &&` applied as a cheap heap Filter on the already-tiny tail.
+        # Pinning EITHER index would false-RED the other (the matrix runs on every fresh
+        # seed, so it WILL hit both branches). The honest, planner-agnostic invariant is the
+        # one that actually matters: no unbounded Seq Scan over the corpus, AND every
+        # `articles` scan stays BOUNDED (well below corpus/8) — which both bounded plans
+        # satisfy and a heap-filter-over-corpus regression trips.
+        PlanAssertions.refute_seq_scan(query)
+        PlanAssertions.assert_scan_rows_below(query, div(prod_floor, 8))
+      end),
+
+      # ---- delegated endpoints (covered by dedicated gates, not re-run here) ----
+      delegated(
+        "change_feed",
+        :enumeration,
+        "by_source_change_feed_plan_scale_test.exs"
+      ),
+      delegated(
+        "streaming_export",
+        :enumeration,
+        "streaming_export_scale_test.exs"
+      )
+    ]
+  end
+
+  # The census for an UNCALIBRATED run: the COMPLETE canonical set (so coverage stays
+  # visible) with every ASSERTED endpoint marked `:uncalibrated` (a not-run marker, never
+  # `:pass`) and the delegated ones still `:delegated`. No plan assertion is run (it would
+  # be theatre at sub-floor scale) and the work-list is empty by construction — but the
+  # matrix stays un-certified because `calibrated? == false` (the AC-27.13.4a INVALID
+  # outcome). Shares `@endpoint_specs` with `census/1`, so the two paths can't drift.
+  @spec uncalibrated_census() :: [endpoint()]
+  defp uncalibrated_census do
+    Enum.map(@endpoint_specs, fn
+      {name, dimension, {:delegated, _} = coverage} ->
+        %{name: name, dimension: dimension, coverage: coverage, result: :delegated}
+
+      {name, dimension, :asserted} ->
+        %{name: name, dimension: dimension, coverage: :asserted, result: :uncalibrated}
+    end)
+  end
+
+  # Run an endpoint's representative plan assertion(s). `:pass` if the closure
+  # returns normally (assertions returned :ok); `{:fail, message}` if it raised an
+  # `ExUnit.AssertionError` (the plan assertion tripped). Other exceptions are NOT
+  # swallowed — they signal a broken census, not a RED endpoint.
+  @spec asserted(String.t(), :vector | :enumeration, (-> any())) :: endpoint()
+  defp asserted(name, dimension, fun) do
+    result =
+      try do
+        fun.()
+        :pass
+      rescue
+        e in ExUnit.AssertionError -> {:fail, Exception.message(e)}
+      end
+
+    %{name: name, dimension: dimension, coverage: :asserted, result: result}
+  end
+
+  @spec delegated(String.t(), :vector | :enumeration, String.t()) :: endpoint()
+  defp delegated(name, dimension, gate_file) do
+    %{
+      name: name,
+      dimension: dimension,
+      coverage: {:delegated, gate_file},
+      result: :delegated
+    }
+  end
+
+  # The representative target article: an embedded row at offset 100 in
+  # (inserted_at, id) order — the SAME pick the gate tests' `a_target/1` uses.
+  defp a_target(tenant_id) do
+    AdminRepo.one(
+      from(a in Article,
+        where: a.tenant_id == ^tenant_id and not is_nil(a.embedding),
+        order_by: [asc: a.inserted_at, asc: a.id],
+        offset: 100,
+        limit: 1,
+        select: %{id: a.id, embedding: a.embedding}
+      )
+    )
+  end
+
+  # A genuinely-deep keyset cursor: the published row ~90% through (inserted_at, id)
+  # order, so the seek is a late page (the #148 deep-page scenario), mirroring how
+  # keyset_plan_scale_test.exs builds its cursor.
+  defp deep_published_cursor(tenant_id) do
+    published_count =
+      AdminRepo.one(
+        from(a in Article,
+          where: a.tenant_id == ^tenant_id and a.status == :published,
+          select: count(a.id)
+        )
+      )
+
+    deep_offset = trunc((published_count || 0) * 0.9)
+
+    deep =
+      AdminRepo.one(
+        from(a in Article,
+          where: a.tenant_id == ^tenant_id and a.status == :published,
+          order_by: [asc: a.inserted_at, asc: a.id],
+          offset: ^deep_offset,
+          limit: 1,
+          select: %{id: a.id, inserted_at: a.inserted_at}
+        )
+      )
+
+    {deep.inserted_at, deep.id}
+  end
+
+  # --- JSON rendering ---
+
+  # Normalize the matrix into a JSON-encodable map (tuples → maps, atoms → strings).
+  defp jsonable(matrix) do
+    %{
+      "calibration" => %{
+        "seed_count" => matrix.calibration.seed_count,
+        "prod_floor" => matrix.calibration.prod_floor,
+        "effective_ef_search" => matrix.calibration.effective_ef_search,
+        "calibrated" => matrix.calibration.calibrated?
+      },
+      "endpoints" => Enum.map(matrix.endpoints, &jsonable_endpoint/1),
+      "work_list" => matrix.work_list,
+      "certified" => matrix.certified?
+    }
+  end
+
+  defp jsonable_endpoint(ep) do
+    %{
+      "name" => ep.name,
+      "dimension" => Atom.to_string(ep.dimension),
+      "coverage" => jsonable_coverage(ep.coverage),
+      "result" => jsonable_result(ep.result)
+    }
+  end
+
+  defp jsonable_coverage(:asserted), do: %{"kind" => "asserted"}
+
+  defp jsonable_coverage({:delegated, file}),
+    do: %{"kind" => "delegated", "gate" => file}
+
+  defp jsonable_result(:pass), do: %{"status" => "pass"}
+  defp jsonable_result(:delegated), do: %{"status" => "delegated"}
+  defp jsonable_result(:uncalibrated), do: %{"status" => "uncalibrated"}
+  defp jsonable_result({:fail, reason}), do: %{"status" => "fail", "reason" => reason}
+
+  # stdlib JSON has no pretty-printer; round-trip through decode + a tiny indenter so
+  # the recorded artifact is human-readable in CI logs without adding a dependency.
+  defp pretty(json) do
+    json
+    |> JSON.decode!()
+    |> indent(0)
+  end
+
+  defp indent(map, depth) when is_map(map) and map_size(map) > 0 do
+    pad = String.duplicate("  ", depth + 1)
+    close = String.duplicate("  ", depth)
+
+    body =
+      map
+      |> Enum.sort_by(fn {k, _} -> k end)
+      |> Enum.map_join(",\n", fn {k, v} ->
+        "#{pad}#{JSON.encode!(k)}: #{indent(v, depth + 1)}"
+      end)
+
+    "{\n#{body}\n#{close}}"
+  end
+
+  defp indent(map, _depth) when is_map(map), do: "{}"
+
+  defp indent([], _depth), do: "[]"
+
+  defp indent(list, depth) when is_list(list) do
+    pad = String.duplicate("  ", depth + 1)
+    close = String.duplicate("  ", depth)
+    body = Enum.map_join(list, ",\n", fn v -> "#{pad}#{indent(v, depth + 1)}" end)
+    "[\n#{body}\n#{close}]"
+  end
+
+  defp indent(scalar, _depth), do: JSON.encode!(scalar)
+end

--- a/test/support/remediation_matrix.ex
+++ b/test/support/remediation_matrix.ex
@@ -11,7 +11,9 @@ defmodule Loopctl.RemediationMatrix do
   when (AC-27.13.4a):
 
     * the seed is AT OR ABOVE `ScaleSeed.prod_article_floor/0`, AND
-    * the effective `hnsw.ef_search` was actually read (a calibrated GUC), AND
+    * the effective `hnsw.ef_search` is READABLE (non-nil) on the heavy-read connection —
+      a calibration-provenance signal, not a parity-with-prod claim (parity is owned by the
+      under-fill gate's `assert_ef_search_parity!`), AND
     * the work-list (asserted endpoints whose plan assertion RAISED) is empty.
 
   An UNCALIBRATED matrix (sub-floor seed, or no readable ef_search) is rejected as
@@ -88,6 +90,12 @@ defmodule Loopctl.RemediationMatrix do
   # and the keyset tests ("scale-tag-7") use.
   @prior_tag "scale-tag-3"
   @keyset_tag "scale-tag-7"
+
+  # The sampled-candidate LIMIT that bounds the distant_pairs self-join (SAME source as
+  # distant_pairs_novelty_scale_test.exs `@max_pair_candidates`). The genuine bound is this
+  # `Limit ≤ cap` on the candidate subquery — `refute_seq_scan` alone does NOT prove the
+  # O(n²) self-join is sample-bounded (the scan node's pre-LIMIT estimate ≈ corpus).
+  @max_pair_candidates Application.compile_env(:loopctl, :max_pair_candidates, 1_000)
 
   # The canonical, COMPLETE set of endpoint names this census must cover. The gate
   # asserts the built matrix's endpoint names equal this set, so a silently-dropped
@@ -256,9 +264,15 @@ defmodule Loopctl.RemediationMatrix do
         PlanAssertions.assert_hnsw_index(query)
       end),
       asserted("search_semantic_results", :vector, fn ->
-        query = Knowledge.semantic_results_query(tenant_id, qemb, [])
-        PlanAssertions.refute_full_scan(query)
-        PlanAssertions.assert_hnsw_index(query)
+        # No-filter baseline AND the selective category+tags regression case — pre-27.7a a
+        # selective filter flipped the index-ordered scan to BitmapAnd+Sort, abandoning HNSW.
+        # Same scenarios the owning topk gate covers, so the census row means the same thing
+        # (BA review LOW-2). The inner ANN must STILL be a single HNSW Index Scan under both.
+        for opts <- [[], [category: :decision, tags: [@prior_tag]]] do
+          query = Knowledge.semantic_results_query(tenant_id, qemb, opts)
+          PlanAssertions.refute_full_scan(query)
+          PlanAssertions.assert_hnsw_index(query)
+        end
       end),
       asserted("search_semantic_count", :vector, fn ->
         query = Knowledge.semantic_count_query(tenant_id, qemb, :published, [])
@@ -285,13 +299,20 @@ defmodule Loopctl.RemediationMatrix do
         between =
           Enum.filter(captured, fn {sql, _} -> sql =~ ~r/BETWEEN/i end)
 
-        if between == [] do
+        # BOTH emitted band queries (count + paginated pairs) must be present and bounded —
+        # matching the owning gate exactly so the census row's `:pass` means the same thing.
+        if length(between) != 2 do
           raise ExUnit.AssertionError,
-            message: "distant_pairs emitted no BETWEEN (band) query to assert on"
+            message:
+              "distant_pairs expected 2 BETWEEN (band) queries (count + pairs), got #{length(between)}"
         end
 
         for {sql, params} <- between do
+          # No unbounded corpus read AND the genuine sample bound: the candidate subquery is
+          # dominated by a `Limit ≤ max_pair_candidates` (refute_seq_scan alone wouldn't prove
+          # the O(n²) self-join stays sampled — architect review F2 / BA LOW-1).
           PlanAssertions.refute_seq_scan({sql, params})
+          PlanAssertions.assert_article_scans_capped_by_limit({sql, params}, @max_pair_candidates)
         end
       end),
       asserted("novelty", :vector, fn ->

--- a/test/support/remediation_matrix.ex
+++ b/test/support/remediation_matrix.ex
@@ -138,7 +138,7 @@ defmodule Loopctl.RemediationMatrix do
     # OR crash on a too-small corpus, e.g. no row at offset 100 for `a_target`). So an
     # UNCALIBRATED run does NOT run the census: it records each endpoint as `:uncalibrated`
     # (a not-run marker, NEVER `:pass`) and stays un-certified. This is the AC-27.13.4a
-    # INVALID outcome — honest coverage with no rubber-stamp — and keeps `build/2` safe to
+    # INVALID outcome — honest coverage with no rubber-stamp — and keeps `build/1` safe to
     # call on a sub-floor tenant (the isolation test).
     endpoints =
       if calibration.calibrated? do


### PR DESCRIPTION
## US-27.13 (census half): the calibrated remediation-matrix scale gate

US-27.13 is "remediate every vector/enumeration endpoint the scale gate proves broken." The **remediation** itself shipped in #199 (the HeavyReadRepo pgbouncer outage fix — which broke *every* heavy endpoint). This PR adds the other half: **AC-27.13.1/.4** — a single calibrated census that aggregates every endpoint's plan gate and certifies the all-green outcome *only when the run is provably calibrated*, so a mis-calibrated CI run can't rubber-stamp.

### What it adds
- **`Loopctl.RemediationMatrix`** (test support) — `build/1` runs one representative plan assertion per vector + enumeration endpoint and returns a structured matrix: `calibration` (seed_count vs `prod_article_floor`, effective `hnsw.ef_search`, `calibrated?`), per-endpoint `result` (`:pass | :delegated | :uncalibrated | {:fail, reason}`), the `work_list` (failing endpoints), and `certified?` (= calibrated AND work_list empty). An uncalibrated run short-circuits to an honest `uncalibrated_census` (never `:pass`).
- **`remediation_matrix_scale_test.exs`** (`:scale_nightly`) — seeds 80k, asserts the census is calibrated + certified + complete (every canonical endpoint present), proves the anti-rubber-stamp (an uncalibrated matrix is rejected), and checks tenant isolation. Wired into the CI `scale_file` matrix.

### Outcome
The work-list is **empty** at 80k (the 27.6b/27.7a routing + 27.8 gates already made every endpoint index-backed), and the live-build confirmation in #199 verified every heavy endpoint returns correct results in prod. This PR institutionalizes that as a calibrated, non-rubber-stampable gate.

`mix precommit` green (2970 tests, 0 failures); the matrix gate passes at a fresh 80k corpus (work_list `[]`, certified).
