### PR TITLE
ci: bump OTP 28.0 -> 28.5.0.2 to unblock Hex 2.5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,12 @@ on:
 env:
   MIX_ENV: test
   ELIXIR_VERSION: "1.19.5"
-  OTP_VERSION: "28.0"
+  # OTP 28.5.0.2 (latest 28.x). Hex 2.5.0 calls :re.import/2, which only exists on
+  # OTP >= 28.1; on the previous pin (28.0) `mix deps.get` crashed with an :undef
+  # the moment Hex 2.5.0 shipped (2026-06-29). Elixir 1.19 requires OTP 28.1+, so
+  # 28.0 was below its own floor. Keep Elixir at 1.19.5 (current 1.19, satisfies
+  # mix.exs `~> 1.18`); only the OTP line moves forward to a working, current patch.
+  OTP_VERSION: "28.5.0.2"
 
 jobs:
   lint:


### PR DESCRIPTION
## Problem

CI went all-red on every PR (and master's own 06-29 scheduled run) starting 2026-06-29. Root cause is a **toolchain regression, not code**: Hex **2.5.0** shipped that day and calls `:re.import/2`, which only exists on **Erlang/OTP >= 28.1**. CI pinned **OTP 28.0**, so `mix deps.get` crashes immediately:

```
** (MatchError) no match of right hand side value:
   {:error, {:hex, {{:shutdown, {:failed_to_start_child, Hex.State,
   {:undef, [{:re, :import, [...]}]}}}, ...}}}
   (hex 2.5.0) lib/hex.ex:5: Hex.start/0
```

06-27 and 06-28 were green on the same pins — only Hex changed under us. Elixir 1.19 also officially requires **OTP 28.1+**, so the 28.0 pin was already below its own floor.

## Fix

Bump `OTP_VERSION` **28.0 → 28.5.0.2** (latest 28.x build available for the Ubuntu runner). Elixir stays at **1.19.5** (current 1.19, satisfies mix.exs `~> 1.18`). The single env var flows into every job's `setup-beam` and the mix/PLT cache keys, so this also busts the stale OTP-28.0 caches.

## Verification

This PR's own CI run is the verification — `mix deps.get` must now succeed and the full matrix go green. Once merged, PR #204 (KnowledgeLintWorker) rebases on top to clear its (identical, toolchain-induced) red.