### PR TITLE
feat(knowledge): expand category taxonomy + single source of truth (P3 stage 1)

### DIFF
--- a/lib/loopctl/knowledge/article.ex
+++ b/lib/loopctl/knowledge/article.ex
@@ -2,15 +2,16 @@ defmodule Loopctl.Knowledge.Article do
   @moduledoc """
   Schema for the `articles` table.
 
-  Articles are the core knowledge units in the Knowledge Wiki. Each article
-  represents a reusable pattern, convention, decision, finding, or reference
-  within a tenant's knowledge base.
+  Articles are the core knowledge units in the Knowledge Wiki. Each article is
+  classified by `category` (pattern, decision, finding, reference, playbook,
+  insight, entity, idea, quote, question — plus the retired `convention`). The
+  canonical taxonomy lives in `Loopctl.Knowledge.Categories`.
 
   ## Fields
 
   - `title` -- article title, unique per tenant among non-archived/superseded
   - `body` -- full article content (text, max 100KB)
-  - `category` -- knowledge type: pattern, convention, decision, finding, reference
+  - `category` -- knowledge type; see `Loopctl.Knowledge.Categories`
   - `status` -- lifecycle state: draft, published, archived, superseded
   - `tags` -- array of alphanumeric tag strings for categorization
   - `source_type` -- advisory origin type: "review_finding", "manual", "agent", "session_log"
@@ -28,7 +29,10 @@ defmodule Loopctl.Knowledge.Article do
 
   @type t :: %__MODULE__{}
 
-  @category_values [:pattern, :convention, :decision, :finding, :reference]
+  # Canonical taxonomy lives in Loopctl.Knowledge.Categories (single source of
+  # truth). `all/0` includes the retired `convention` value so existing rows
+  # still load during the reclassification backfill.
+  @category_values Loopctl.Knowledge.Categories.all()
   @status_values [:draft, :published, :archived, :superseded]
   @scope_values [:tenant, :system]
   @known_source_types ~w(review_finding manual agent session_log newsletter skill web_article ingestion)

--- a/lib/loopctl/knowledge/categories.ex
+++ b/lib/loopctl/knowledge/categories.ex
@@ -1,0 +1,109 @@
+defmodule Loopctl.Knowledge.Categories do
+  @moduledoc """
+  Single source of truth for knowledge-article categories.
+
+  Before this module the category list was duplicated in six places (the
+  `Article` schema, both LLM extractor prompts + their `@valid_categories`
+  guards, and two ingestion workers), which silently drifts. Everything now
+  derives from here.
+
+  ## Taxonomy (US — second-brain taxonomy expansion)
+
+  **Active** categories — what new articles should be classified as:
+
+  - `pattern`   — a reusable solution *shape*: how this kind of problem is
+    generally solved (the structure, not the steps).
+  - `decision`  — a specific choice that was made and *why* (ADR-style):
+    options considered, tradeoff, the call.
+  - `finding`   — an empirical discovery: a gotcha, a measured result, the
+    outcome of an investigation ("X turned out to be true").
+  - `reference` — factual lookup material: a spec, an API shape, a pointer to
+    an external resource. Stable, not opinionated.
+  - `playbook`  — a concrete, ordered *procedure* to accomplish a task (the
+    steps), as opposed to `pattern` (the shape).
+  - `insight`   — a durable principle or mental model that generalizes beyond
+    one situation (the "why" that keeps paying off).
+  - `entity`    — a person, company, tool, or product. The graph backbone —
+    the nodes other articles reference.
+  - `idea`      — a venture, opportunity, or thing to build/try.
+  - `quote`     — a notable verbatim quote worth preserving, with attribution.
+  - `question`  — an open question or known-unknown to investigate later.
+
+  **Retired** categories — still valid in the DB so existing rows load and the
+  reclassification backfill can read them, but new content should NOT use them:
+
+  - `convention` — a team/project norm. Being reclassified into
+    `pattern`/`playbook`/`insight`; will be dropped once the 77k backfill
+    completes.
+
+  Keeping a retired value in the enum (rather than deleting it) is deliberate:
+  the `category` column is a plain string and ~13% of the corpus is currently
+  `convention`; dropping the enum value before the backfill would make every
+  one of those rows fail to load.
+  """
+
+  @active [
+    :pattern,
+    :decision,
+    :finding,
+    :reference,
+    :playbook,
+    :insight,
+    :entity,
+    :idea,
+    :quote,
+    :question
+  ]
+
+  @retired [:convention]
+
+  @definitions %{
+    pattern: "a reusable solution shape (how this kind of problem is generally solved)",
+    decision: "a specific choice that was made and why (ADR-style: options, tradeoff, the call)",
+    finding:
+      "an empirical discovery — a gotcha, a measured result, the outcome of an investigation",
+    reference:
+      "factual lookup material — a spec, an API shape, a pointer to an external resource",
+    playbook: "a concrete, ordered procedure to accomplish a task (the steps, not the shape)",
+    insight: "a durable principle or mental model that generalizes beyond one situation",
+    entity: "a person, company, tool, or product (the graph backbone other articles reference)",
+    idea: "a venture, opportunity, or thing to build or try",
+    quote: "a notable verbatim quote worth preserving, with attribution",
+    question: "an open question or known-unknown to investigate later"
+  }
+
+  @doc "All categories valid in the database (active + retired). Use for enum/validation."
+  @spec all() :: [atom()]
+  def all, do: @active ++ @retired
+
+  @doc "Active categories — what new content should be classified as (excludes retired)."
+  @spec active() :: [atom()]
+  def active, do: @active
+
+  @doc "Retired categories — valid in the DB but not for new content."
+  @spec retired() :: [atom()]
+  def retired, do: @retired
+
+  @doc "All categories as lowercase strings (active + retired)."
+  @spec all_strings() :: [String.t()]
+  def all_strings, do: Enum.map(all(), &Atom.to_string/1)
+
+  @doc "Active categories as lowercase strings."
+  @spec active_strings() :: [String.t()]
+  def active_strings, do: Enum.map(@active, &Atom.to_string/1)
+
+  @doc "One-line definition for an active category (nil for unknown/retired)."
+  @spec definition(atom()) :: String.t() | nil
+  def definition(category), do: Map.get(@definitions, category)
+
+  @doc """
+  A prompt fragment listing the active categories with their definitions, for
+  use in LLM extraction/classification prompts so new articles use the full
+  taxonomy. Retired categories are intentionally excluded so the model never
+  emits them for new content.
+  """
+  @spec prompt_fragment() :: String.t()
+  def prompt_fragment do
+    Enum.map_join(@active, "; ", fn cat -> "#{cat} (#{Map.fetch!(@definitions, cat)})" end)
+  end
+end

--- a/lib/loopctl/knowledge/claude_content_extractor.ex
+++ b/lib/loopctl/knowledge/claude_content_extractor.ex
@@ -20,14 +20,18 @@ defmodule Loopctl.Knowledge.ClaudeContentExtractor do
 
   require Logger
 
+  alias Loopctl.Knowledge.Categories
+
   @system_prompt """
   You are a knowledge extraction assistant. Given raw content (web article, \
   newsletter, skill template, etc.), extract reusable knowledge articles. \
   Return a JSON array of articles, each with: title (string), body (string, \
-  markdown), category (one of: pattern, convention, decision, finding, reference), \
-  tags (array of short lowercase strings). Extract only genuinely reusable \
-  knowledge -- skip promotional content, navigation, boilerplate. Max 10 articles \
-  per input. Return ONLY the JSON array, no surrounding text or markdown fences.\
+  markdown), category, and tags (array of short lowercase strings). The category \
+  must be one of: #{Enum.join(Categories.active_strings(), ", ")}. Choose it by \
+  these definitions -- #{Categories.prompt_fragment()}. Extract only genuinely \
+  reusable knowledge -- skip promotional content, navigation, boilerplate. Max 10 \
+  articles per input. Return ONLY the JSON array, no surrounding text or markdown \
+  fences.\
   """
 
   @impl true
@@ -123,7 +127,9 @@ defmodule Loopctl.Knowledge.ClaudeContentExtractor do
     end
   end
 
-  @valid_categories ~w(pattern convention decision finding reference)
+  # Accept any DB-valid category (active + retired) so a stray `convention` from
+  # the model isn't dropped; the prompt only offers active categories.
+  @valid_categories Categories.all_strings()
 
   defp normalize_article(article) when is_map(article) do
     title = article["title"]

--- a/lib/loopctl/knowledge/llm_extractor.ex
+++ b/lib/loopctl/knowledge/llm_extractor.ex
@@ -25,15 +25,18 @@ defmodule Loopctl.Knowledge.LlmExtractor do
 
   require Logger
 
+  alias Loopctl.Knowledge.Categories
+
   @system_prompt """
   You are a code review knowledge extractor. Given a code review context \
   (review type, findings count, fixes count, summary), extract reusable \
-  knowledge articles about patterns, conventions, or decisions that would \
-  help future code reviews. Return a JSON array of articles, each with: \
-  title (string), body (string, markdown), category (one of: pattern, \
-  convention, decision, finding, reference), tags (array of short lowercase \
-  strings). Extract only genuinely reusable knowledge. Max 5 articles per \
-  review. Return ONLY the JSON array, no surrounding text or markdown fences.\
+  knowledge articles that would help future code reviews. Return a JSON array \
+  of articles, each with: title (string), body (string, markdown), category, \
+  and tags (array of short lowercase strings). The category must be one of: \
+  #{Enum.join(Categories.active_strings(), ", ")}. Choose it by these \
+  definitions -- #{Categories.prompt_fragment()}. Extract only genuinely \
+  reusable knowledge. Max 5 articles per review. Return ONLY the JSON array, \
+  no surrounding text or markdown fences.\
   """
 
   @impl true
@@ -128,7 +131,8 @@ defmodule Loopctl.Knowledge.LlmExtractor do
     end
   end
 
-  @valid_categories ~w(pattern convention decision finding reference)
+  # Accept any DB-valid category (active + retired); the prompt only offers active.
+  @valid_categories Categories.all_strings()
 
   defp normalize_article(article) when is_map(article) do
     title = article["title"]

--- a/lib/loopctl/workers/content_ingestion_worker.ex
+++ b/lib/loopctl/workers/content_ingestion_worker.ex
@@ -47,7 +47,8 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
 
   @max_articles 10
   @max_body_length 100_000
-  @valid_categories ~w(pattern convention decision finding reference)a
+  # Single source of truth: the canonical taxonomy (avoids drift).
+  @valid_categories Loopctl.Knowledge.Categories.all()
   @tag_pattern ~r/^[a-zA-Z0-9_-]+$/
   # Single source of truth: the Article schema's tag cap (avoids drift).
   @max_tags Loopctl.Knowledge.Article.max_tags()

--- a/lib/loopctl/workers/review_knowledge_worker.ex
+++ b/lib/loopctl/workers/review_knowledge_worker.ex
@@ -48,7 +48,8 @@ defmodule Loopctl.Workers.ReviewKnowledgeWorker do
 
   @max_articles 5
   @max_body_length 100_000
-  @valid_categories ~w(pattern convention decision finding reference)a
+  # Single source of truth: the canonical taxonomy (avoids drift).
+  @valid_categories Loopctl.Knowledge.Categories.all()
   @tag_pattern ~r/^[a-zA-Z0-9_-]+$/
   # Single source of truth: the Article schema's tag cap (avoids drift).
   @max_tags Loopctl.Knowledge.Article.max_tags()

--- a/test/loopctl/knowledge/article_test.exs
+++ b/test/loopctl/knowledge/article_test.exs
@@ -4,6 +4,7 @@ defmodule Loopctl.Knowledge.ArticleTest do
   setup :verify_on_exit!
 
   alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.Categories
 
   describe "agent-memory metadata conventions (#151)" do
     defp memory_changeset(metadata) do
@@ -178,6 +179,33 @@ defmodule Loopctl.Knowledge.ArticleTest do
 
       refute changeset.valid?
       assert errors_on(changeset)[:category]
+    end
+
+    test "accepts every category in the canonical taxonomy (active + retired)" do
+      for category <- Categories.all() do
+        changeset =
+          Article.create_changeset(%Article{}, %{
+            title: "Title for #{category}",
+            body: "Valid body",
+            category: category
+          })
+
+        assert changeset.valid?, "expected category #{inspect(category)} to be valid"
+      end
+    end
+
+    test "accepts the expanded taxonomy values (playbook/insight/entity/idea/quote/question)" do
+      for category <- [:playbook, :insight, :entity, :idea, :quote, :question] do
+        changeset =
+          Article.create_changeset(%Article{}, %{
+            title: "Title for #{category}",
+            body: "Valid body",
+            category: category
+          })
+
+        assert changeset.valid?, "expected expanded category #{inspect(category)} to be valid"
+        assert get_field(changeset, :category) == category
+      end
     end
 
     test "defaults status to :draft when not provided" do

--- a/test/loopctl/knowledge/categories_test.exs
+++ b/test/loopctl/knowledge/categories_test.exs
@@ -1,0 +1,73 @@
+defmodule Loopctl.Knowledge.CategoriesTest do
+  use ExUnit.Case, async: true
+
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.Categories
+
+  describe "taxonomy composition" do
+    test "all/0 is active ++ retired with no overlap" do
+      assert Categories.all() == Categories.active() ++ Categories.retired()
+      assert MapSet.disjoint?(MapSet.new(Categories.active()), MapSet.new(Categories.retired()))
+    end
+
+    test "active set is the expanded taxonomy and excludes the retired convention" do
+      assert Enum.sort(Categories.active()) ==
+               Enum.sort([
+                 :pattern,
+                 :decision,
+                 :finding,
+                 :reference,
+                 :playbook,
+                 :insight,
+                 :entity,
+                 :idea,
+                 :quote,
+                 :question
+               ])
+
+      refute :convention in Categories.active()
+    end
+
+    test "convention is retired but still DB-valid (so existing rows load)" do
+      assert :convention in Categories.retired()
+      assert :convention in Categories.all()
+    end
+  end
+
+  describe "string helpers" do
+    test "all_strings/0 and active_strings/0 mirror the atom lists" do
+      assert Categories.all_strings() == Enum.map(Categories.all(), &Atom.to_string/1)
+      assert Categories.active_strings() == Enum.map(Categories.active(), &Atom.to_string/1)
+    end
+  end
+
+  describe "definitions and prompt fragment" do
+    test "every active category has a definition" do
+      for category <- Categories.active() do
+        assert is_binary(Categories.definition(category)),
+               "missing definition for active category #{inspect(category)}"
+      end
+    end
+
+    test "retired categories are not offered a definition (not for new content)" do
+      assert Categories.definition(:convention) == nil
+    end
+
+    test "prompt_fragment lists every active category and no retired one" do
+      fragment = Categories.prompt_fragment()
+
+      for category <- Categories.active() do
+        assert fragment =~ Atom.to_string(category)
+      end
+
+      refute fragment =~ "convention"
+    end
+  end
+
+  test "the Article enum is backed by the canonical taxonomy" do
+    # Ecto stores the enum mappings; assert it matches Categories.all/0 exactly,
+    # so the schema can never drift from the source of truth.
+    enum_values = Ecto.Enum.values(Article, :category)
+    assert Enum.sort(enum_values) == Enum.sort(Categories.all())
+  end
+end

--- a/test/loopctl/knowledge_test.exs
+++ b/test/loopctl/knowledge_test.exs
@@ -8,6 +8,7 @@ defmodule Loopctl.KnowledgeTest do
   alias Loopctl.Knowledge
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.ArticleLink
+  alias Loopctl.Knowledge.Categories
 
   defp setup_tenant do
     tenant = fixture(:tenant)
@@ -986,14 +987,15 @@ defmodule Loopctl.KnowledgeTest do
 
       assert stats.total == 3
 
-      # Dense maps: all 5 categories and all 4 statuses present, 0 when none.
-      assert stats.by_category == %{
-               "pattern" => 2,
-               "convention" => 0,
-               "decision" => 0,
-               "finding" => 0,
-               "reference" => 1
-             }
+      # Dense maps: every category (canonical taxonomy) and all 4 statuses
+      # present, 0 when none. Derived from Categories so adding a category can't
+      # silently break this expectation.
+      expected_by_category =
+        Categories.all_strings()
+        |> Map.new(&{&1, 0})
+        |> Map.merge(%{"pattern" => 2, "reference" => 1})
+
+      assert stats.by_category == expected_by_category
 
       assert stats.by_status == %{
                "draft" => 1,
@@ -1008,13 +1010,7 @@ defmodule Loopctl.KnowledgeTest do
 
       assert Knowledge.stats(tenant.id) == %{
                total: 0,
-               by_category: %{
-                 "pattern" => 0,
-                 "convention" => 0,
-                 "decision" => 0,
-                 "finding" => 0,
-                 "reference" => 0
-               },
+               by_category: Map.new(Categories.all_strings(), &{&1, 0}),
                by_status: %{
                  "draft" => 0,
                  "published" => 0,

--- a/test/loopctl_web/controllers/knowledge_stats_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_stats_controller_test.exs
@@ -1,6 +1,8 @@
 defmodule LoopctlWeb.KnowledgeStatsControllerTest do
   use LoopctlWeb.ConnCase, async: true
 
+  alias Loopctl.Knowledge.Categories
+
   setup :verify_on_exit!
 
   defp auth_conn(conn, raw_key) do
@@ -27,14 +29,15 @@ defmodule LoopctlWeb.KnowledgeStatsControllerTest do
 
       assert body["total"] == 5
 
-      # Dense maps: every category/status present, 0 when none match.
-      assert body["by_category"] == %{
-               "pattern" => 2,
-               "convention" => 2,
-               "decision" => 0,
-               "finding" => 1,
-               "reference" => 0
-             }
+      # Dense maps: every category (canonical taxonomy) / status present, 0 when
+      # none match. Derived from Categories so a taxonomy change can't silently
+      # break this expectation.
+      expected_by_category =
+        Categories.all_strings()
+        |> Map.new(&{&1, 0})
+        |> Map.merge(%{"pattern" => 2, "convention" => 2, "finding" => 1})
+
+      assert body["by_category"] == expected_by_category
 
       assert body["by_status"] == %{
                "draft" => 1,
@@ -56,13 +59,7 @@ defmodule LoopctlWeb.KnowledgeStatsControllerTest do
       body = json_response(conn, 200)
       assert body["total"] == 0
       # Keys are still present (0), so a client never gets nil for a known key.
-      assert body["by_category"] == %{
-               "pattern" => 0,
-               "convention" => 0,
-               "decision" => 0,
-               "finding" => 0,
-               "reference" => 0
-             }
+      assert body["by_category"] == Map.new(Categories.all_strings(), &{&1, 0})
 
       assert body["by_status"] == %{
                "draft" => 0,


### PR DESCRIPTION
## What

P3 **stage 1** of the second-brain taxonomy work: expand the category set and centralize it as a single source of truth.

The corpus only had 5 categories (`pattern/convention/decision/finding/reference`). This adds the richer taxonomy you approved and — just as importantly — kills the **6-way duplication** of the category list that was silently drifting.

## Taxonomy

New module `Loopctl.Knowledge.Categories` is canonical:

- **`active/0`** — `pattern, decision, finding, reference, playbook, insight, entity, idea, quote, question` (the 4 kept + 6 new). What new content is classified as.
- **`retired/0`** — `convention`. Still DB-valid (the `category` column is a plain string and ~13% of the corpus is `convention`; dropping the enum value before the reclassification backfill would make those rows fail to load), but **not** offered to new content.
- **`definition/1` + `prompt_fragment/0`** — per-category definitions injected into the LLM extraction prompts so the model classifies into the full taxonomy correctly (e.g. *playbook* = the steps vs *pattern* = the shape).

## Wired through (drift eliminated)

| Before (own copy of the list) | After |
|---|---|
| `Article.@category_values` | `Categories.all()` (Ecto.Enum can't drift) |
| `ClaudeContentExtractor` prompt + `@valid_categories` | prompt rebuilt from `Categories` at compile time; gate → `Categories.all_strings()` |
| `LlmExtractor` prompt + `@valid_categories` | same |
| `ReviewKnowledgeWorker.@valid_categories` | `Categories.all()` |
| `ContentIngestionWorker.@valid_categories` | `Categories.all()` |

`scale_seed.ex` is intentionally left alone — it's synthetic scale-test data whose category round-robin feeds index-selectivity gates; changing its list length is orthogonal to the product taxonomy and would risk scale-gate flakiness.

**No DB migration**: `category` is a `:string` column, so new enum values need no schema change.

## Tests

- New `categories_test.exs`: composition (`all = active ++ retired`, disjoint), the expanded active set, string helpers, definitions cover every active category, prompt fragment includes all active / excludes retired, and an **enum-vs-canonical drift guard** (`Ecto.Enum.values(Article, :category) == Categories.all()`).
- `article_test.exs`: changeset accepts every new category.
- `knowledge_test.exs` + `knowledge_stats_controller_test.exs`: the dense `by_category` stats maps grew from 5→11 keys (correct — stats derives the dense map from the enum). Updated the expectations to **derive from `Categories`** rather than re-hardcode, so a future taxonomy change can't silently break them again.

Full local gate green: format, credo --strict, dialyzer (0 errors), **2987 tests / 0 failures**.

## Next P3 stages (separate PRs)

1. `CategoryClassifier` behaviour + config-DI (Claude-backed) + Mox.
2. Resumable, cost-ceilinged, **dry-run-first** backfill worker over the 77k corpus: write-on-confident-change, always reclassify `convention`; emits a proposed-distribution report before committing.
3. Cross-repo: `synth.py` / `publish.py` category enum (claude-config) + user `CLAUDE.md` category list.
4. After the backfill drains `convention` to 0, a follow-up drops it from `active`/`retired`.
