### PR TITLE
feat(knowledge): LLM reclassification engine (P3 stages 2-3)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -258,6 +258,17 @@ config :loopctl, Loopctl.Vault,
 # DI: Content extractor for knowledge ingestion
 config :loopctl, :content_extractor, Loopctl.Knowledge.ClaudeContentExtractor
 
+# DI: Article category classifier for the reclassification backfill
+# (KnowledgeReclassifyWorker). Overridden in test env.
+config :loopctl, :category_classifier, Loopctl.Knowledge.ClaudeCategoryClassifier
+
+# Reclassification backfill tunables (KnowledgeReclassifyWorker). Query-shaped,
+# so they can also be passed per-kick in the job args.
+config :loopctl,
+  knowledge_reclassify_batch_size: 100,
+  knowledge_reclassify_max_per_run: 1_000,
+  knowledge_reclassify_min_confidence: 0.75
+
 # DI: WebAuthn adapter — defaults to Wax (overridden in test env)
 config :loopctl, :webauthn_adapter, Loopctl.WebAuthn.Wax
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -177,6 +177,9 @@ config :loopctl, :knowledge_extractor, Loopctl.MockExtractor
 # DI: Use mock content extractor in tests
 config :loopctl, :content_extractor, Loopctl.MockContentExtractor
 
+# DI: Use mock category classifier in tests
+config :loopctl, :category_classifier, Loopctl.MockCategoryClassifier
+
 # DI: Use mock WebAuthn adapter in tests
 config :loopctl, :webauthn_adapter, Loopctl.MockWebAuthn
 

--- a/lib/loopctl/knowledge/classifier_behaviour.ex
+++ b/lib/loopctl/knowledge/classifier_behaviour.ex
@@ -1,0 +1,20 @@
+defmodule Loopctl.Knowledge.ClassifierBehaviour do
+  @moduledoc """
+  Behaviour for classifying a knowledge article into a single category.
+
+  Used by `Loopctl.Workers.KnowledgeReclassifyWorker` to move the existing
+  corpus onto the expanded taxonomy. An implementation receives an article's
+  title and body and returns the best ACTIVE category
+  (`Loopctl.Knowledge.Categories.active/0`) plus a confidence in `[0.0, 1.0]`.
+
+  The worker only WRITES a change when confidence clears the configured
+  threshold AND the proposed category differs from the current one, so a
+  low-confidence or uncertain classification is a safe no-op. An `{:error, _}`
+  return means "leave this article alone".
+  """
+
+  @type result :: %{required(:category) => atom(), required(:confidence) => float()}
+
+  @callback classify(title :: String.t(), body :: String.t()) ::
+              {:ok, result()} | {:error, term()}
+end

--- a/lib/loopctl/knowledge/claude_category_classifier.ex
+++ b/lib/loopctl/knowledge/claude_category_classifier.ex
@@ -1,0 +1,81 @@
+defmodule Loopctl.Knowledge.ClaudeCategoryClassifier do
+  @moduledoc """
+  Anthropic Claude-backed implementation of `Loopctl.Knowledge.ClassifierBehaviour`.
+
+  Reuses the shared `:anthropic_provider` config (same key as the extractors).
+  When no API key is configured it returns `{:error, :not_configured}` so the
+  reclassification backfill degrades gracefully (it never mutates data with a
+  placeholder verdict) in environments without Anthropic access.
+
+  Only ACTIVE categories are ever returned — the model is never offered the
+  retired `convention`, so a reclassification can only move an article ONTO the
+  current taxonomy.
+  """
+
+  @behaviour Loopctl.Knowledge.ClassifierBehaviour
+
+  require Logger
+
+  alias Loopctl.Knowledge.Categories
+
+  @system_prompt """
+  You classify one knowledge-base article into exactly one category. The \
+  categories and their meanings are: #{Categories.prompt_fragment()}. Respond \
+  with ONLY a JSON object of the form \
+  {"category": "<one of: #{Enum.join(Categories.active_strings(), ", ")}>", \
+  "confidence": <number between 0 and 1>}. `confidence` is how sure you are of \
+  the category. No prose, no markdown fences.\
+  """
+
+  @max_body_chars 16_000
+
+  @impl true
+  def classify(title, body) do
+    config = Application.get_env(:loopctl, :anthropic_provider, %{})
+    api_key = config[:api_key] || ""
+
+    if api_key == "" do
+      {:error, :not_configured}
+    else
+      call_anthropic(title, body, config)
+    end
+  end
+
+  defp call_anthropic(title, body, config) do
+    base_url = config[:base_url] || "https://api.anthropic.com/v1"
+    model = config[:model] || "claude-haiku-4-5-20251001"
+
+    user_content = "Title: #{title}\n\nBody:\n#{String.slice(body || "", 0, @max_body_chars)}"
+
+    req_body = %{
+      model: model,
+      max_tokens: 100,
+      system: @system_prompt,
+      messages: [%{role: "user", content: user_content}]
+    }
+
+    case Req.post("#{base_url}/messages",
+           json: req_body,
+           headers: [
+             {"x-api-key", config[:api_key]},
+             {"anthropic-version", "2023-06-01"}
+           ]
+         ) do
+      {:ok, %{status: 200, body: resp}} -> parse_response(resp)
+      {:ok, %{status: status}} -> {:error, {:http_status, status}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp parse_response(resp) do
+    with text when is_binary(text) <- get_in(resp, ["content", Access.at(0), "text"]),
+         {:ok, decoded} <- Jason.decode(String.trim(text)),
+         %{"category" => category, "confidence" => confidence} <- decoded,
+         true <- category in Categories.active_strings(),
+         true <- is_number(confidence) do
+      {:ok, %{category: String.to_existing_atom(category), confidence: confidence / 1}}
+    else
+      _ -> {:error, :unparseable_classification}
+    end
+  end
+end

--- a/lib/loopctl/workers/knowledge_reclassify_worker.ex
+++ b/lib/loopctl/workers/knowledge_reclassify_worker.ex
@@ -1,0 +1,277 @@
+defmodule Loopctl.Workers.KnowledgeReclassifyWorker do
+  @moduledoc """
+  Backfill worker that reclassifies the existing corpus onto the expanded
+  taxonomy (see `Loopctl.Knowledge.Categories`).
+
+  This is the engine for the one-time 77k reclassification. It is **not**
+  scheduled — it is kicked on demand (see "Kicking" below) because it calls an
+  LLM per article and has a real cost.
+
+  ## Modes
+
+  - `run_mode: "dry_run"` (default) — classifies every article but **writes
+    nothing**. Each batch emits a `knowledge.reclassify_batch` audit event with
+    a tally of what *would* change (including a `by_transition` breakdown such
+    as `"convention->playbook" => 42`). Run this first and read the audit feed
+    before committing.
+  - `run_mode: "commit"` — actually updates `category` for articles where the
+    classifier is confident AND the proposed category differs from the current
+    one.
+
+  ## Write-on-confident-change
+
+  A write happens only when `confidence >= min_confidence` AND
+  `proposed != current`. Low-confidence or same-category verdicts are no-ops, so
+  the pass cannot regress an already-correct label on a coin-flip. Because the
+  classifier only ever returns ACTIVE categories, every `convention` row that
+  clears the threshold is moved off `convention` (the retired value), which is
+  the point of the backfill.
+
+  Re-running is safe and convergent: once an article is moved, a later pass sees
+  `proposed == current` and writes nothing.
+
+  ## Scale + cost bounds
+
+  Processes the corpus in keyset batches (`batch_size`, default 100), chaining
+  the next batch via a cursor so each job is bounded. `max_per_run` (default
+  1000) caps how many articles a single *kick* will process before stopping;
+  the next kick resumes from where it left off (forward by id). When the ceiling
+  is hit mid-corpus that is logged, never silent.
+
+  ## Kicking
+
+      # tenant-wide dry run, default tunables:
+      %{"mode" => "all_tenants", "run_mode" => "dry_run"}
+      |> Loopctl.Workers.KnowledgeReclassifyWorker.new()
+      |> Oban.insert()
+
+      # a single tenant, committing, bigger ceiling:
+      %{"tenant_id" => tid, "run_mode" => "commit", "max_per_run" => 80_000}
+      |> Loopctl.Workers.KnowledgeReclassifyWorker.new()
+      |> Oban.insert()
+
+  `batch_size` / `max_per_run` / `min_confidence` are query-shaped tunables and
+  may be passed in args (falling back to config, then to the defaults here).
+  """
+
+  use Oban.Worker,
+    queue: :knowledge,
+    max_attempts: 3,
+    unique: [fields: [:worker, :args], period: 30]
+
+  require Logger
+
+  import Ecto.Query
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Audit
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Tenants.Tenant
+
+  @classifier Application.compile_env(
+                :loopctl,
+                :category_classifier,
+                Loopctl.Knowledge.ClaudeCategoryClassifier
+              )
+
+  @default_batch_size 100
+  @default_max_per_run 1_000
+  @default_min_confidence 0.75
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"mode" => "all_tenants"} = args}) do
+    tenant_ids =
+      from(t in Tenant, where: t.status == :active, select: t.id)
+      |> AdminRepo.all()
+
+    for tenant_id <- tenant_ids do
+      args
+      |> Map.drop(["mode"])
+      |> Map.put("tenant_id", tenant_id)
+      |> __MODULE__.new()
+      |> Oban.insert()
+    end
+
+    :ok
+  end
+
+  def perform(%Oban.Job{args: %{"tenant_id" => tenant_id} = args}) do
+    run_mode = Map.get(args, "run_mode", "dry_run")
+
+    batch_size =
+      tunable_int(args, "batch_size", :knowledge_reclassify_batch_size, @default_batch_size)
+
+    max_per_run =
+      tunable_int(args, "max_per_run", :knowledge_reclassify_max_per_run, @default_max_per_run)
+
+    min_confidence =
+      tunable_float(
+        args,
+        "min_confidence",
+        :knowledge_reclassify_min_confidence,
+        @default_min_confidence
+      )
+
+    cursor = Map.get(args, "cursor")
+    processed_so_far = Map.get(args, "processed", 0)
+
+    batch = fetch_batch(tenant_id, cursor, batch_size)
+    tally = process_batch(batch, run_mode, min_confidence)
+    log_audit(tenant_id, run_mode, tally, processed_so_far)
+
+    new_processed = processed_so_far + tally.processed
+    maybe_chain(batch, tenant_id, args, batch_size, max_per_run, new_processed)
+
+    :ok
+  end
+
+  # --- batch fetch (keyset by id) ---
+
+  defp fetch_batch(tenant_id, cursor, batch_size) do
+    from(a in Article,
+      where: a.tenant_id == ^tenant_id,
+      where: a.status == :published,
+      order_by: [asc: a.id],
+      limit: ^batch_size,
+      select: %{
+        id: a.id,
+        title: a.title,
+        body: a.body,
+        category: a.category,
+        metadata: a.metadata
+      }
+    )
+    |> after_cursor(cursor)
+    |> AdminRepo.all()
+  end
+
+  defp after_cursor(query, nil), do: query
+  defp after_cursor(query, cursor), do: where(query, [a], a.id > ^cursor)
+
+  # --- per-batch processing ---
+
+  defp process_batch(batch, run_mode, min_confidence) do
+    empty = %{
+      processed: 0,
+      changed: 0,
+      unchanged: 0,
+      low_confidence: 0,
+      errors: 0,
+      by_transition: %{}
+    }
+
+    Enum.reduce(batch, empty, fn article, acc ->
+      acc = %{acc | processed: acc.processed + 1}
+
+      case @classifier.classify(article.title, article.body) do
+        {:ok, %{category: proposed, confidence: confidence}} ->
+          classify_outcome(acc, article, proposed, confidence, min_confidence, run_mode)
+
+        {:error, _reason} ->
+          %{acc | errors: acc.errors + 1}
+      end
+    end)
+  end
+
+  defp classify_outcome(acc, article, proposed, confidence, min_confidence, run_mode) do
+    current = article.category
+
+    cond do
+      confidence < min_confidence ->
+        %{acc | low_confidence: acc.low_confidence + 1}
+
+      proposed == current ->
+        %{acc | unchanged: acc.unchanged + 1}
+
+      true ->
+        if run_mode == "commit", do: write_category(article, proposed, confidence)
+        key = "#{current}->#{proposed}"
+
+        %{
+          acc
+          | changed: acc.changed + 1,
+            by_transition: Map.update(acc.by_transition, key, 1, &(&1 + 1))
+        }
+    end
+  end
+
+  defp write_category(article, proposed, confidence) do
+    metadata =
+      (article.metadata || %{})
+      |> Map.put("reclassified_from", to_string(article.category))
+      |> Map.put("reclassify_confidence", confidence)
+
+    from(a in Article, where: a.id == ^article.id)
+    |> AdminRepo.update_all(
+      set: [category: proposed, metadata: metadata, updated_at: DateTime.utc_now()]
+    )
+  end
+
+  # --- chaining (forward by id, bounded by max_per_run) ---
+
+  defp maybe_chain(batch, tenant_id, args, batch_size, max_per_run, new_processed) do
+    cond do
+      length(batch) < batch_size ->
+        # Last batch for this tenant — nothing more to do.
+        :ok
+
+      new_processed >= max_per_run ->
+        Logger.info(
+          "KnowledgeReclassifyWorker: tenant=#{tenant_id} reached max_per_run=#{max_per_run}; " <>
+            "stopping this kick. Re-kick to resume forward from the last processed article."
+        )
+
+      true ->
+        last_id = batch |> List.last() |> Map.fetch!(:id)
+
+        args
+        |> Map.put("cursor", last_id)
+        |> Map.put("processed", new_processed)
+        |> __MODULE__.new()
+        |> Oban.insert()
+    end
+  end
+
+  # --- audit ---
+
+  defp log_audit(tenant_id, run_mode, tally, processed_so_far) do
+    Audit.create_log_entry(tenant_id, %{
+      entity_type: "knowledge_reclassify",
+      entity_id: tenant_id,
+      action: "knowledge.reclassify_batch",
+      actor_type: "system",
+      actor_id: nil,
+      actor_label: "worker:knowledge_reclassify",
+      new_state: %{
+        "run_mode" => run_mode,
+        "processed_before_this_batch" => processed_so_far,
+        "batch" => %{
+          "processed" => tally.processed,
+          "changed" => tally.changed,
+          "unchanged" => tally.unchanged,
+          "low_confidence" => tally.low_confidence,
+          "errors" => tally.errors,
+          "by_transition" => tally.by_transition
+        }
+      }
+    })
+  end
+
+  # --- tunables (args override config, which overrides the module default) ---
+
+  defp tunable_int(args, arg_key, config_key, default) do
+    case Map.get(args, arg_key) do
+      n when is_integer(n) and n > 0 -> n
+      _ -> config(config_key, default)
+    end
+  end
+
+  defp tunable_float(args, arg_key, config_key, default) do
+    case Map.get(args, arg_key) do
+      n when is_number(n) -> n / 1
+      _ -> config(config_key, default)
+    end
+  end
+
+  defp config(key, default), do: Application.get_env(:loopctl, key, default)
+end

--- a/test/loopctl/knowledge/claude_category_classifier_test.exs
+++ b/test/loopctl/knowledge/claude_category_classifier_test.exs
@@ -1,0 +1,16 @@
+defmodule Loopctl.Knowledge.ClaudeCategoryClassifierTest do
+  use ExUnit.Case, async: true
+
+  alias Loopctl.Knowledge.ClaudeCategoryClassifier
+
+  describe "classify/2 graceful degradation" do
+    test "returns {:error, :not_configured} when no Anthropic API key is set" do
+      # No :anthropic_provider key is configured in the test env, so the real
+      # classifier must degrade rather than attempt a live HTTP call. This is
+      # what keeps the reclassification backfill from mutating data with a
+      # placeholder verdict in environments without Anthropic access.
+      assert {:error, :not_configured} =
+               ClaudeCategoryClassifier.classify("Some title", "Some body")
+    end
+  end
+end

--- a/test/loopctl/workers/knowledge_reclassify_worker_test.exs
+++ b/test/loopctl/workers/knowledge_reclassify_worker_test.exs
@@ -1,0 +1,195 @@
+defmodule Loopctl.Workers.KnowledgeReclassifyWorkerTest do
+  use Loopctl.DataCase, async: true
+  use Oban.Testing, repo: Loopctl.Repo
+
+  setup :verify_on_exit!
+
+  import Ecto.Query
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Audit.AuditLog
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Workers.KnowledgeReclassifyWorker
+
+  # Published article via the proven create-then-publish path (status transitions
+  # are applied after creation, mirroring the other knowledge-worker tests).
+  defp published(tenant_id, category) do
+    fixture(:article, %{
+      tenant_id: tenant_id,
+      category: category,
+      title: "Article #{System.unique_integer([:positive])}",
+      body: "Body content."
+    })
+    |> Ecto.Changeset.change(%{status: :published})
+    |> AdminRepo.update!()
+  end
+
+  defp reload(id), do: AdminRepo.get!(Article, id)
+
+  defp verdict(category, confidence) do
+    Mox.stub(Loopctl.MockCategoryClassifier, :classify, fn _title, _body ->
+      {:ok, %{category: category, confidence: confidence}}
+    end)
+  end
+
+  defp reclassify_audits(tenant_id) do
+    from(a in AuditLog,
+      where: a.tenant_id == ^tenant_id,
+      where: a.action == "knowledge.reclassify_batch",
+      order_by: [asc: a.inserted_at]
+    )
+    |> AdminRepo.all()
+  end
+
+  defp run(tenant_id, extra_args) do
+    args = Map.merge(%{"tenant_id" => tenant_id}, extra_args)
+    KnowledgeReclassifyWorker.perform(%Oban.Job{args: args})
+  end
+
+  describe "dry_run mode" do
+    test "classifies but writes nothing; audit tallies what would change" do
+      tenant = fixture(:tenant)
+      a = published(tenant.id, :convention)
+      b = published(tenant.id, :pattern)
+      verdict(:playbook, 0.9)
+
+      assert :ok = run(tenant.id, %{"run_mode" => "dry_run"})
+
+      # No writes in dry-run.
+      assert reload(a.id).category == :convention
+      assert reload(b.id).category == :pattern
+
+      assert [entry] = reclassify_audits(tenant.id)
+      assert entry.new_state["run_mode"] == "dry_run"
+      assert entry.new_state["batch"]["changed"] == 2
+      assert entry.new_state["batch"]["by_transition"]["convention->playbook"] == 1
+      assert entry.new_state["batch"]["by_transition"]["pattern->playbook"] == 1
+    end
+  end
+
+  describe "commit mode write-on-confident-change" do
+    test "rewrites category and records provenance when confident and different" do
+      tenant = fixture(:tenant)
+      a = published(tenant.id, :convention)
+      verdict(:playbook, 0.9)
+
+      assert :ok = run(tenant.id, %{"run_mode" => "commit"})
+
+      reloaded = reload(a.id)
+      assert reloaded.category == :playbook
+      assert reloaded.metadata["reclassified_from"] == "convention"
+      assert reloaded.metadata["reclassify_confidence"] == 0.9
+    end
+
+    test "leaves the article alone when confidence is below threshold" do
+      tenant = fixture(:tenant)
+      a = published(tenant.id, :convention)
+      verdict(:playbook, 0.5)
+
+      assert :ok = run(tenant.id, %{"run_mode" => "commit", "min_confidence" => 0.75})
+
+      assert reload(a.id).category == :convention
+      assert [entry] = reclassify_audits(tenant.id)
+      assert entry.new_state["batch"]["low_confidence"] == 1
+      assert entry.new_state["batch"]["changed"] == 0
+    end
+
+    test "no-op when the proposed category equals the current one" do
+      tenant = fixture(:tenant)
+      a = published(tenant.id, :pattern)
+      verdict(:pattern, 0.99)
+
+      assert :ok = run(tenant.id, %{"run_mode" => "commit"})
+
+      assert reload(a.id).category == :pattern
+      assert [entry] = reclassify_audits(tenant.id)
+      assert entry.new_state["batch"]["unchanged"] == 1
+      assert entry.new_state["batch"]["changed"] == 0
+    end
+
+    test "always moves a retired convention row off convention when confident" do
+      tenant = fixture(:tenant)
+      a = published(tenant.id, :convention)
+      verdict(:insight, 0.8)
+
+      assert :ok = run(tenant.id, %{"run_mode" => "commit"})
+
+      assert reload(a.id).category == :insight
+    end
+
+    test "an unparseable/errored classification leaves the article alone" do
+      tenant = fixture(:tenant)
+      a = published(tenant.id, :convention)
+
+      Mox.stub(Loopctl.MockCategoryClassifier, :classify, fn _t, _b ->
+        {:error, :unparseable_classification}
+      end)
+
+      assert :ok = run(tenant.id, %{"run_mode" => "commit"})
+
+      assert reload(a.id).category == :convention
+      assert [entry] = reclassify_audits(tenant.id)
+      assert entry.new_state["batch"]["errors"] == 1
+    end
+  end
+
+  describe "cost ceiling + batch chaining" do
+    test "stops after max_per_run, leaving the remainder for the next kick" do
+      tenant = fixture(:tenant)
+      a = published(tenant.id, :convention)
+      b = published(tenant.id, :convention)
+      c = published(tenant.id, :convention)
+      verdict(:playbook, 0.9)
+
+      # batch_size 1 forces chaining; max_per_run 2 stops after two articles.
+      assert :ok =
+               run(tenant.id, %{
+                 "run_mode" => "commit",
+                 "batch_size" => 1,
+                 "max_per_run" => 2
+               })
+
+      categories = Enum.map([a, b, c], &reload(&1.id).category)
+      assert Enum.count(categories, &(&1 == :playbook)) == 2
+      assert Enum.count(categories, &(&1 == :convention)) == 1
+    end
+  end
+
+  describe "all_tenants fan-out" do
+    test "reclassifies each active tenant, skipping suspended ones" do
+      active_a = fixture(:tenant)
+      active_b = fixture(:tenant)
+      suspended = fixture(:tenant, %{status: :suspended})
+
+      a = published(active_a.id, :convention)
+      b = published(active_b.id, :convention)
+      s = published(suspended.id, :convention)
+      verdict(:playbook, 0.9)
+
+      assert :ok =
+               KnowledgeReclassifyWorker.perform(%Oban.Job{
+                 args: %{"mode" => "all_tenants", "run_mode" => "commit"}
+               })
+
+      assert reload(a.id).category == :playbook
+      assert reload(b.id).category == :playbook
+      assert reload(s.id).category == :convention
+    end
+  end
+
+  describe "tenant isolation" do
+    test "only the caller tenant's articles are touched" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      a = published(tenant_a.id, :convention)
+      b = published(tenant_b.id, :convention)
+      verdict(:playbook, 0.9)
+
+      assert :ok = run(tenant_a.id, %{"run_mode" => "commit"})
+
+      assert reload(a.id).category == :playbook
+      assert reload(b.id).category == :convention
+      assert [] == reclassify_audits(tenant_b.id)
+    end
+  end
+end

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -113,6 +113,12 @@ defmodule Loopctl.DataCase do
       {:ok, []}
     end)
 
+    # Default stub for category classifier -- zero confidence, so the
+    # reclassification backfill is a no-op unless a test sets its own verdict.
+    Mox.stub(Loopctl.MockCategoryClassifier, :classify, fn _title, _body ->
+      {:ok, %{category: :pattern, confidence: 0.0}}
+    end)
+
     # Default Req.Test stub for content ingestion URL fetching
     Req.Test.stub(Loopctl.Workers.ContentIngestionWorker, fn conn ->
       Req.Test.text(conn, "Default ingestion stub content")

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -6,6 +6,7 @@ Mox.defmock(Loopctl.MockTokenArchival, for: Loopctl.TokenUsage.ArchivalBehaviour
 Mox.defmock(Loopctl.MockEmbeddingClient, for: Loopctl.Knowledge.EmbeddingBehaviour)
 Mox.defmock(Loopctl.MockExtractor, for: Loopctl.Knowledge.ExtractorBehaviour)
 Mox.defmock(Loopctl.MockContentExtractor, for: Loopctl.Knowledge.ContentExtractorBehaviour)
+Mox.defmock(Loopctl.MockCategoryClassifier, for: Loopctl.Knowledge.ClassifierBehaviour)
 Mox.defmock(Loopctl.MockWebAuthn, for: Loopctl.WebAuthn.Behaviour)
 Mox.defmock(Loopctl.MockSecrets, for: Loopctl.Secrets.Behaviour)
 Mox.defmock(Loopctl.MockSuggestLinks, for: Loopctl.Knowledge.SuggestLinksBehaviour)


### PR DESCRIPTION
feat(knowledge): LLM reclassification engine (P3 stages 2-3)

The backfill that moves the existing corpus onto the expanded taxonomy. Built
dry-run-first and cost-bounded so the 77k run is safe and reviewable.

Stage 2 -- classifier (config-based DI):
- ClassifierBehaviour: classify(title, body) -> {:ok, %{category, confidence}}.
- ClaudeCategoryClassifier: Anthropic-backed, reuses :anthropic_provider config,
  only ever returns an ACTIVE category (never the retired convention), and
  returns {:error, :not_configured} with no API key so it never mutates data with
  a placeholder verdict. DI via :category_classifier (mock in test).

Stage 3 -- KnowledgeReclassifyWorker (:knowledge queue, not scheduled -- kicked
on demand because it costs per-article LLM calls):
- run_mode "dry_run" (default): classifies everything, writes NOTHING, and emits
  a knowledge.reclassify_batch audit event per batch with a tally + by_transition
  breakdown (e.g. "convention->playbook" => 42). Run first, read the feed, then
  commit.
- run_mode "commit": writes category ONLY when confidence >= min_confidence AND
  proposed != current (write-on-confident-change), recording reclassified_from /
  reclassify_confidence in metadata. Low-confidence or same-category verdicts are
  no-ops, so an already-correct label can't be regressed. Because the classifier
  only returns active categories, every confident convention row is moved off
  convention -- the point of the backfill. Re-runs are convergent.
- Scale/cost bounds: keyset batches (batch_size, default 100) chained by cursor;
  max_per_run (default 1000) caps a single kick and the remainder resumes next
  kick (logged when hit). all_tenants fan-out mirrors the other knowledge workers
  (active tenants only). batch_size/max_per_run/min_confidence are query-shaped
  tunables, settable per-kick in args (falling back to config, then defaults).

Tests: dry-run writes nothing + tallies; commit write-on-confident-change;
below-threshold no-op; proposed==current no-op; convention always moved; errored
classification left alone; cost-ceiling stop-and-resume; all_tenants fan-out
(skips suspended); tenant isolation; classifier not-configured degradation.
Full local gate green (format, credo --strict, dialyzer 0 errors).

The actual 77k run is an operator step (needs prod Anthropic access + a cost
decision): kick a dry_run, review the by_transition audit feed, then kick commit.
