### PR TITLE
fix(knowledge): classifier silently no-op'd every article (echoed-template + brittle parse)

### DIFF
--- a/lib/loopctl/knowledge/claude_category_classifier.ex
+++ b/lib/loopctl/knowledge/claude_category_classifier.ex
@@ -19,12 +19,12 @@ defmodule Loopctl.Knowledge.ClaudeCategoryClassifier do
   alias Loopctl.Knowledge.Categories
 
   @system_prompt """
-  You classify one knowledge-base article into exactly one category. The \
-  categories and their meanings are: #{Categories.prompt_fragment()}. Respond \
-  with ONLY a JSON object of the form \
-  {"category": "<one of: #{Enum.join(Categories.active_strings(), ", ")}>", \
-  "confidence": <number between 0 and 1>}. `confidence` is how sure you are of \
-  the category. No prose, no markdown fences.\
+  You classify one knowledge-base article into exactly one category. Allowed \
+  categories: #{Enum.join(Categories.active_strings(), ", ")}. Their meanings: \
+  #{Categories.prompt_fragment()}. Reply with a single compact JSON object that \
+  has exactly two keys: "category" (one of the allowed values above) and \
+  "confidence" (a number from 0 to 1 for how sure you are). Output nothing \
+  except that JSON object.\
   """
 
   @max_body_chars 16_000
@@ -61,21 +61,47 @@ defmodule Loopctl.Knowledge.ClaudeCategoryClassifier do
              {"anthropic-version", "2023-06-01"}
            ]
          ) do
-      {:ok, %{status: 200, body: resp}} -> parse_response(resp)
-      {:ok, %{status: status}} -> {:error, {:http_status, status}}
-      {:error, reason} -> {:error, reason}
+      {:ok, %{status: 200, body: resp}} ->
+        parse_text(get_in(resp, ["content", Access.at(0), "text"]))
+
+      {:ok, %{status: status}} ->
+        {:error, {:http_status, status}}
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
-  defp parse_response(resp) do
-    with text when is_binary(text) <- get_in(resp, ["content", Access.at(0), "text"]),
-         {:ok, decoded} <- Jason.decode(String.trim(text)),
-         %{"category" => category, "confidence" => confidence} <- decoded,
+  @doc """
+  Parses an LLM response into a validated classification.
+
+  Tolerant of the common ways a model wraps its JSON — markdown fences, a
+  preamble, or trailing prose — by extracting the first `{...}` object from the
+  text. Returns `{:error, :unparseable_classification}` for anything that isn't
+  a JSON object with a valid active `category` and a numeric `confidence`
+  (including the failure mode where the model echoes a `"<one of: ...>"`
+  template literally). Public so the validation is unit-testable without HTTP.
+  """
+  @spec parse_text(String.t() | nil) ::
+          {:ok, Loopctl.Knowledge.ClassifierBehaviour.result()}
+          | {:error, :unparseable_classification}
+  def parse_text(text) when is_binary(text) do
+    with {:ok, json} <- extract_json_object(text),
+         %{"category" => category, "confidence" => confidence} <- json,
          true <- category in Categories.active_strings(),
          true <- is_number(confidence) do
       {:ok, %{category: String.to_existing_atom(category), confidence: confidence / 1}}
     else
       _ -> {:error, :unparseable_classification}
+    end
+  end
+
+  def parse_text(_), do: {:error, :unparseable_classification}
+
+  defp extract_json_object(text) do
+    case Regex.run(~r/\{.*\}/s, String.trim(text)) do
+      [json] -> Jason.decode(json)
+      _ -> :error
     end
   end
 end

--- a/test/loopctl/knowledge/claude_category_classifier_test.exs
+++ b/test/loopctl/knowledge/claude_category_classifier_test.exs
@@ -13,4 +13,57 @@ defmodule Loopctl.Knowledge.ClaudeCategoryClassifierTest do
                ClaudeCategoryClassifier.classify("Some title", "Some body")
     end
   end
+
+  describe "parse_text/1" do
+    test "parses a clean compact JSON object" do
+      assert {:ok, %{category: :playbook, confidence: 0.9}} =
+               ClaudeCategoryClassifier.parse_text(~s({"category":"playbook","confidence":0.9}))
+    end
+
+    test "tolerates a markdown ```json fence" do
+      text = "```json\n{\"category\": \"insight\", \"confidence\": 0.8}\n```"
+
+      assert {:ok, %{category: :insight, confidence: 0.8}} =
+               ClaudeCategoryClassifier.parse_text(text)
+    end
+
+    test "tolerates a prose preamble and trailing text around the object" do
+      text = ~s(Here is the classification: {"category":"entity","confidence":0.7}. Done.)
+
+      assert {:ok, %{category: :entity, confidence: 0.7}} =
+               ClaudeCategoryClassifier.parse_text(text)
+    end
+
+    test "coerces an integer confidence to a float" do
+      assert {:ok, %{category: :pattern, confidence: 1.0}} =
+               ClaudeCategoryClassifier.parse_text(~s({"category":"pattern","confidence":1}))
+    end
+
+    test "rejects an echoed prompt template (the original prod failure mode)" do
+      # The model echoing the literal format example -- '<one of: ...>' is not
+      # valid JSON and must be rejected, not crash.
+      text =
+        ~s({"category": "<one of: pattern, decision>", "confidence": <number between 0 and 1>})
+
+      assert {:error, :unparseable_classification} = ClaudeCategoryClassifier.parse_text(text)
+    end
+
+    test "rejects a category that is not active (e.g. the retired convention)" do
+      assert {:error, :unparseable_classification} =
+               ClaudeCategoryClassifier.parse_text(~s({"category":"convention","confidence":0.9}))
+
+      assert {:error, :unparseable_classification} =
+               ClaudeCategoryClassifier.parse_text(~s({"category":"banana","confidence":0.9}))
+    end
+
+    test "rejects a non-numeric confidence and non-JSON / nil input" do
+      assert {:error, :unparseable_classification} =
+               ClaudeCategoryClassifier.parse_text(~s({"category":"pattern","confidence":"high"}))
+
+      assert {:error, :unparseable_classification} =
+               ClaudeCategoryClassifier.parse_text("I think this is a pattern.")
+
+      assert {:error, :unparseable_classification} = ClaudeCategoryClassifier.parse_text(nil)
+    end
+  end
 end


### PR DESCRIPTION
## The bug

Dry-running the reclassification classifier against **real prod articles before** committing the 77k migration revealed every call returned `{:error, :unparseable_classification}`. The worker treats an error as a no-op, so a blind `commit` run would have 'completed' having **changed nothing** — the exact 'does nothing at all' failure mode.

Mocked unit tests passed; only a real-data dry-run caught it.

## Causes + fixes

1. The system prompt contained a literal JSON template `{"category": "<one of: ...>"}`. Haiku echoed it verbatim, and `<one of: ...>` isn't valid JSON. Reworded to describe the two keys without an echo-able brace template.
2. Parsing required the *entire* trimmed response to be pure JSON. Replaced with **`parse_text/1`** — a pure, unit-testable function that extracts the first `{...}` object (tolerating markdown fences / preamble / trailing prose) and validates an active category + numeric confidence.

## Tests

`parse_text/1`: clean JSON, ```json fence, prose-wrapped, integer confidence, **the echoed-template failure mode**, retired/unknown category rejection, non-numeric confidence, non-JSON/nil. Full local gate green (3004 tests, credo, dialyzer 0).