### PR TITLE
fix(knowledge): lint worker orphan self-heal did nothing on real data

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -269,6 +269,14 @@ config :loopctl,
   knowledge_reclassify_max_per_run: 1_000,
   knowledge_reclassify_min_confidence: 0.75
 
+# KnowledgeLintWorker orphan self-heal. Orphans (zero links) re-link at a LOWER
+# threshold than the global 0.6: their nearest neighbor is typically a near-miss
+# of 0.6, so re-linking at 0.6 would leave them isolated forever.
+# max_orphan_relink caps how many orphans one nightly run acts on.
+config :loopctl,
+  knowledge_lint_orphan_link_threshold: 0.5,
+  knowledge_lint_max_orphan_relink: 500
+
 # DI: WebAuthn adapter — defaults to Wax (overridden in test env)
 config :loopctl, :webauthn_adapter, Loopctl.WebAuthn.Wax
 

--- a/lib/loopctl/workers/article_linking_worker.ex
+++ b/lib/loopctl/workers/article_linking_worker.ex
@@ -71,7 +71,7 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
   alias Loopctl.Knowledge.VectorSearch
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"article_id" => article_id, "tenant_id" => tenant_id}}) do
+  def perform(%Oban.Job{args: %{"article_id" => article_id, "tenant_id" => tenant_id} = args}) do
     case Knowledge.get_article_with_embedding(tenant_id, article_id) do
       {:error, :not_found} ->
         # Article deleted -- no-op
@@ -82,9 +82,20 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
         :ok
 
       {:ok, %Article{} = article} ->
-        threshold = Application.get_env(:loopctl, :article_link_threshold, 0.6)
+        threshold = resolve_threshold(args)
         max_comparisons = clamped_max_comparisons()
         find_and_link_similar(article, tenant_id, threshold, max_comparisons)
+    end
+  end
+
+  # Optional per-job threshold override (query-shaped, so it lives in args, not
+  # config DI). KnowledgeLintWorker uses a LOWER threshold when re-linking orphans
+  # so a totally-isolated article connects to its nearest neighbor instead of
+  # near-missing the default cutoff forever. Falls back to the global config.
+  defp resolve_threshold(args) do
+    case Map.get(args, "threshold") do
+      t when is_number(t) and t >= 0 -> t / 1
+      _ -> Application.get_env(:loopctl, :article_link_threshold, 0.6)
     end
   end
 

--- a/lib/loopctl/workers/knowledge_lint_worker.ex
+++ b/lib/loopctl/workers/knowledge_lint_worker.ex
@@ -57,13 +57,20 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   alias Loopctl.AdminRepo
   alias Loopctl.Audit
   alias Loopctl.Knowledge
+  alias Loopctl.Knowledge.Article
   alias Loopctl.Tenants.Tenant
+  alias Loopctl.Workers.ArticleEmbeddingWorker
   alias Loopctl.Workers.ArticleLinkingWorker
 
   # Ask lint for the ceiling so we act on as many orphans per run as the engine
   # will return; the true (pre-cap) totals still come back in the summary.
   @lint_max_per_category 500
   @default_max_orphan_relink 500
+  # Orphans are, by definition, totally unlinked. Their nearest neighbor often
+  # sits just UNDER the global 0.6 link threshold (a near-miss), so re-linking at
+  # 0.6 leaves them isolated forever. Re-link orphans at a LOWER threshold so an
+  # isolated article connects to its closest relative rather than dangling.
+  @default_orphan_link_threshold 0.5
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"mode" => "all_tenants"}}) do
@@ -83,12 +90,12 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   def perform(%Oban.Job{args: %{"tenant_id" => tenant_id}}) do
     {:ok, report} = Knowledge.lint(tenant_id, max_per_category: @lint_max_per_category)
 
-    relinked = enqueue_orphan_relinks(tenant_id, report)
-    log_audit_event(tenant_id, report, relinked)
+    action = act_on_orphans(tenant_id, report)
+    log_audit_event(tenant_id, report, action)
 
     Logger.info(
-      "KnowledgeLintWorker: tenant=#{tenant_id} " <>
-        "issues=#{report.summary.total_issues} orphans_relinked=#{relinked}"
+      "KnowledgeLintWorker: tenant=#{tenant_id} issues=#{report.summary.total_issues} " <>
+        "orphans_relinked=#{action.relinked} orphans_embedding_enqueued=#{action.embedding_enqueued}"
     )
 
     :ok
@@ -96,30 +103,67 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
 
   # --- Private ---
 
-  defp enqueue_orphan_relinks(tenant_id, report) do
+  # Orphans split two ways:
+  #   * has an embedding -> re-link at the lenient orphan threshold (its nearest
+  #     neighbor is usually a near-miss of the default 0.6 cutoff).
+  #   * no embedding -> it can NEVER link until it has one, so enqueue the
+  #     embedding worker (which chains to linking on success). These are the
+  #     articles a plain re-link silently no-ops on.
+  defp act_on_orphans(tenant_id, report) do
     max_relink =
       Application.get_env(:loopctl, :knowledge_lint_max_orphan_relink, @default_max_orphan_relink)
 
-    orphans = Enum.take(report.orphan_articles, max_relink)
+    threshold =
+      Application.get_env(
+        :loopctl,
+        :knowledge_lint_orphan_link_threshold,
+        @default_orphan_link_threshold
+      )
+
+    orphan_ids = report.orphan_articles |> Enum.take(max_relink) |> Enum.map(& &1.article_id)
     true_total = report.summary.total_per_category.orphan_articles
 
-    if true_total > length(orphans) do
+    if true_total > length(orphan_ids) do
       Logger.warning(
         "KnowledgeLintWorker: tenant=#{tenant_id} has #{true_total} orphan articles; " <>
-          "re-linking #{length(orphans)} this run (cap=#{max_relink}). Remainder retried next run."
+          "acting on #{length(orphan_ids)} this run (cap=#{max_relink}). Remainder retried next run."
       )
     end
 
-    Enum.each(orphans, fn %{article_id: article_id} ->
-      %{"article_id" => article_id, "tenant_id" => tenant_id}
+    embedded = embedded_ids(tenant_id, orphan_ids)
+
+    {with_embedding, without_embedding} =
+      Enum.split_with(orphan_ids, &MapSet.member?(embedded, &1))
+
+    Enum.each(with_embedding, fn id ->
+      %{"article_id" => id, "tenant_id" => tenant_id, "threshold" => threshold}
       |> ArticleLinkingWorker.new()
       |> Oban.insert()
     end)
 
-    length(orphans)
+    Enum.each(without_embedding, fn id ->
+      %{"article_id" => id, "tenant_id" => tenant_id}
+      |> ArticleEmbeddingWorker.new()
+      |> Oban.insert()
+    end)
+
+    %{relinked: length(with_embedding), embedding_enqueued: length(without_embedding)}
   end
 
-  defp log_audit_event(tenant_id, report, relinked) do
+  defp embedded_ids(_tenant_id, []), do: MapSet.new()
+
+  defp embedded_ids(tenant_id, orphan_ids) do
+    from(a in Article,
+      where: a.tenant_id == ^tenant_id,
+      where: a.id in ^orphan_ids,
+      where: not is_nil(a.embedding),
+      select: a.id
+    )
+    |> AdminRepo.all()
+    |> MapSet.new()
+  end
+
+  defp log_audit_event(tenant_id, report, action) do
     Audit.create_log_entry(tenant_id, %{
       entity_type: "knowledge_lint",
       entity_id: tenant_id,
@@ -129,7 +173,8 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
       actor_label: "worker:knowledge_lint",
       new_state: %{
         "summary" => report.summary,
-        "orphans_relinked" => relinked
+        "orphans_relinked" => action.relinked,
+        "orphans_embedding_enqueued" => action.embedding_enqueued
       }
     })
   end

--- a/test/loopctl/workers/article_linking_worker_test.exs
+++ b/test/loopctl/workers/article_linking_worker_test.exs
@@ -58,6 +58,12 @@ defmodule Loopctl.Workers.ArticleLinkingWorkerTest do
     |> Kernel.++(List.duplicate(0.01, 768))
   end
 
+  # cos(similar_embedding, near_miss_embedding) = 1/sqrt(1 + 1.518^2) ~= 0.55 —
+  # a deliberate near-miss of the default 0.6 cutoff but above a lenient 0.5.
+  defp near_miss_embedding do
+    List.duplicate(1.0, 768) ++ List.duplicate(1.518, 768)
+  end
+
   # --- TC-21.2.1: Creates relates_to links for similar articles ---
 
   describe "perform/1 creates links" do
@@ -113,6 +119,47 @@ defmodule Loopctl.Workers.ArticleLinkingWorkerTest do
         |> AdminRepo.all()
 
       assert links == []
+    end
+
+    test "a per-job threshold override links a near-miss neighbor (orphan self-heal)" do
+      %{tenant: tenant} = setup_tenant()
+
+      # cos(source, near_miss) ~= 0.55: under the default 0.6, over a lenient 0.5.
+      source = create_article_with_embedding(tenant.id, similar_embedding())
+      near_miss = create_article_with_embedding(tenant.id, near_miss_embedding())
+
+      # Default threshold: no link (this is why orphans stay orphaned).
+      assert :ok =
+               ArticleLinkingWorker.perform(%Oban.Job{
+                 args: %{"article_id" => source.id, "tenant_id" => tenant.id}
+               })
+
+      assert [] ==
+               from(l in ArticleLink, where: l.source_article_id == ^source.id)
+               |> AdminRepo.all()
+
+      # Lenient threshold passed in args: the near-miss neighbor now links.
+      assert :ok =
+               ArticleLinkingWorker.perform(%Oban.Job{
+                 args: %{
+                   "article_id" => source.id,
+                   "tenant_id" => tenant.id,
+                   "threshold" => 0.5
+                 }
+               })
+
+      links =
+        from(l in ArticleLink,
+          where: l.tenant_id == ^tenant.id,
+          where:
+            (l.source_article_id == ^source.id and l.target_article_id == ^near_miss.id) or
+              (l.source_article_id == ^near_miss.id and l.target_article_id == ^source.id)
+        )
+        |> AdminRepo.all()
+
+      assert length(links) == 1
+      assert hd(links).metadata["similarity_score"] >= 0.5
+      assert hd(links).metadata["similarity_score"] < 0.6
     end
   end
 

--- a/test/loopctl/workers/knowledge_lint_worker_test.exs
+++ b/test/loopctl/workers/knowledge_lint_worker_test.exs
@@ -39,6 +39,19 @@ defmodule Loopctl.Workers.KnowledgeLintWorkerTest do
     |> Kernel.++(List.duplicate(0.01, 768))
   end
 
+  # A published orphan with NO embedding — the case a plain re-link no-ops on.
+  defp published_without_embedding(tenant_id) do
+    fixture(:article, %{
+      tenant_id: tenant_id,
+      title: "Article #{System.unique_integer([:positive])}",
+      body: "Test article body.",
+      category: :pattern,
+      tags: []
+    })
+    |> Ecto.Changeset.change(%{status: :published})
+    |> AdminRepo.update!()
+  end
+
   defp lint_audit_entries(tenant_id) do
     from(a in AuditLog,
       where: a.tenant_id == ^tenant_id,
@@ -62,6 +75,7 @@ defmodule Loopctl.Workers.KnowledgeLintWorkerTest do
       assert entry.new_state["summary"]["total_articles"] == 1
       assert is_integer(entry.new_state["summary"]["total_issues"])
       assert is_integer(entry.new_state["orphans_relinked"])
+      assert is_integer(entry.new_state["orphans_embedding_enqueued"])
     end
 
     test "re-links orphan articles against the current corpus" do
@@ -88,9 +102,28 @@ defmodule Loopctl.Workers.KnowledgeLintWorkerTest do
       assert length(links) == 1
 
       assert [entry] = lint_audit_entries(tenant.id)
-      # Both were orphans at lint time, so both were enqueued for re-link.
+      # Both were embedded orphans, so both were re-linked (not embedding-enqueued).
       assert entry.new_state["summary"]["total_per_category"]["orphan_articles"] == 2
       assert entry.new_state["orphans_relinked"] == 2
+      assert entry.new_state["orphans_embedding_enqueued"] == 0
+    end
+
+    test "embeds orphans that have no embedding (a plain re-link would no-op them)" do
+      tenant = fixture(:tenant)
+      orphan = published_without_embedding(tenant.id)
+
+      assert :ok =
+               KnowledgeLintWorker.perform(%Oban.Job{args: %{"tenant_id" => tenant.id}})
+
+      # The embedding worker ran inline (default Mox stub yields a 1536-dim vector)
+      # and stored an embedding, so the orphan is no longer un-embeddable.
+      reloaded = Loopctl.Knowledge.get_article_with_embedding(tenant.id, orphan.id)
+      assert {:ok, %{embedding: embedding}} = reloaded
+      refute is_nil(embedding)
+
+      assert [entry] = lint_audit_entries(tenant.id)
+      assert entry.new_state["orphans_relinked"] == 0
+      assert entry.new_state["orphans_embedding_enqueued"] == 1
     end
 
     test "handles a tenant with no published articles" do
@@ -102,6 +135,7 @@ defmodule Loopctl.Workers.KnowledgeLintWorkerTest do
       assert [entry] = lint_audit_entries(tenant.id)
       assert entry.new_state["summary"]["total_articles"] == 0
       assert entry.new_state["orphans_relinked"] == 0
+      assert entry.new_state["orphans_embedding_enqueued"] == 0
     end
   end
 


### PR DESCRIPTION
## What real-data verification found

Per the 'do the scheduled jobs actually work?' check, I ran `KnowledgeLintWorker` against the **prod 77k corpus**. Its orphan self-heal was effectively a no-op:

- **1,247 of 1,433** orphans have embeddings, but their nearest neighbor sits at **~0.55–0.59** — a *near-miss* of the global **0.6** link threshold. Re-linking at 0.6 produced **zero** links on every sampled orphan; they'd stay isolated forever.
- The other **186** orphans have **no embedding**, so `ArticleLinkingWorker` silently no-ops on them entirely.

Mocked unit tests passed; only real data exposed this — same lesson as the classifier bug.

## Fix

- `ArticleLinkingWorker` accepts an optional per-job `threshold` (query-shaped arg, falls back to global config).
- `KnowledgeLintWorker` now splits orphans:
  - **embedded** → re-link at a lenient `:knowledge_lint_orphan_link_threshold` (default **0.5**) so an isolated article connects to its closest relative instead of near-missing forever;
  - **un-embedded** → `ArticleEmbeddingWorker` (embeds, then chains to linking).
  - audit event now reports `orphans_relinked` **and** `orphans_embedding_enqueued`.

## Tests

A near-miss neighbor (cos ≈ 0.55) links **only** with the lenient override; the lint worker embeds an un-embedded orphan and re-links embedded ones. Full local gate green (2999 tests, credo, dialyzer 0).

## Note

0.5 is a contained default (orphans only — never global linking). Tune `:knowledge_lint_orphan_link_threshold` if you want stricter/looser orphan rescue.