### PR TITLE
feat(knowledge): reclassify run hardening — concurrency, configurable model, outage snooze

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -267,7 +267,8 @@ config :loopctl, :category_classifier, Loopctl.Knowledge.ClaudeCategoryClassifie
 config :loopctl,
   knowledge_reclassify_batch_size: 100,
   knowledge_reclassify_max_per_run: 1_000,
-  knowledge_reclassify_min_confidence: 0.75
+  knowledge_reclassify_min_confidence: 0.75,
+  knowledge_reclassify_max_concurrency: 10
 
 # KnowledgeLintWorker orphan self-heal. Orphans (zero links) re-link at a LOWER
 # threshold than the global 0.6: their nearest neighbor is typically a near-miss

--- a/config/config.exs
+++ b/config/config.exs
@@ -268,7 +268,11 @@ config :loopctl,
   knowledge_reclassify_batch_size: 100,
   knowledge_reclassify_max_per_run: 1_000,
   knowledge_reclassify_min_confidence: 0.75,
-  knowledge_reclassify_max_concurrency: 10
+  knowledge_reclassify_max_concurrency: 10,
+  # Outage resilience: snooze (retry same cursor) when >= this fraction of a
+  # batch fails to classify, instead of advancing past unreclassified articles.
+  knowledge_reclassify_snooze_error_rate: 0.5,
+  knowledge_reclassify_snooze_seconds: 60
 
 # KnowledgeLintWorker orphan self-heal. Orphans (zero links) re-link at a LOWER
 # threshold than the global 0.6: their nearest neighbor is typically a near-miss

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -198,6 +198,14 @@ if config_env() == :prod do
     }
   end
 
+  # Optional override for the reclassification classifier model, independent of
+  # the extraction model above. Set ANTHROPIC_CLASSIFIER_MODEL to e.g. a Sonnet id
+  # for a higher-accuracy one-time 77k reclassification; unset = the shared
+  # provider model (Haiku).
+  if classifier_model = System.get_env("ANTHROPIC_CLASSIFIER_MODEL") do
+    config :loopctl, :knowledge_classifier_model, classifier_model
+  end
+
   # The secret key base is used to sign/encrypt cookies and other secrets.
   # A default value is used in config/dev.exs and config/test.exs but you
   # want to use a different value for prod and you most likely don't want

--- a/lib/loopctl/knowledge/categories.ex
+++ b/lib/loopctl/knowledge/categories.ex
@@ -58,16 +58,19 @@ defmodule Loopctl.Knowledge.Categories do
   @retired [:convention]
 
   @definitions %{
-    pattern: "a reusable solution shape (how this kind of problem is generally solved)",
+    pattern:
+      "a reusable solution shape or recurring structure (the general approach), as opposed to a specific step-by-step procedure",
     decision: "a specific choice that was made and why (ADR-style: options, tradeoff, the call)",
     finding:
       "an empirical discovery — a gotcha, a measured result, the outcome of an investigation",
     reference:
       "factual lookup material — a spec, an API shape, a pointer to an external resource",
-    playbook: "a concrete, ordered procedure to accomplish a task (the steps, not the shape)",
-    insight: "a durable principle or mental model that generalizes beyond one situation",
+    playbook:
+      "a how-to with EXPLICIT, ORDERED STEPS to accomplish a task — not a one-line tip, a general principle, or a recurring shape",
+    insight:
+      "a durable principle, mental model, or realization that generalizes — the 'why' behind things, not a how-to",
     entity: "a person, company, tool, or product (the graph backbone other articles reference)",
-    idea: "a venture, opportunity, or thing to build or try",
+    idea: "a venture, opportunity, or concrete thing to build or try",
     quote: "a notable verbatim quote worth preserving, with attribution",
     question: "an open question or known-unknown to investigate later"
   }

--- a/lib/loopctl/knowledge/claude_category_classifier.ex
+++ b/lib/loopctl/knowledge/claude_category_classifier.ex
@@ -43,7 +43,14 @@ defmodule Loopctl.Knowledge.ClaudeCategoryClassifier do
 
   defp call_anthropic(title, body, config) do
     base_url = config[:base_url] || "https://api.anthropic.com/v1"
-    model = config[:model] || "claude-haiku-4-5-20251001"
+
+    # Classification can use a STRONGER model than content extraction without
+    # changing extraction: :knowledge_classifier_model wins, else the shared
+    # provider model, else Haiku. Set ANTHROPIC_CLASSIFIER_MODEL in prod to
+    # override (e.g. a Sonnet id) for the one-time 77k reclassification.
+    model =
+      Application.get_env(:loopctl, :knowledge_classifier_model) ||
+        config[:model] || "claude-haiku-4-5-20251001"
 
     user_content = "Title: #{title}\n\nBody:\n#{String.slice(body || "", 0, @max_body_chars)}"
 

--- a/lib/loopctl/knowledge/claude_category_classifier.ex
+++ b/lib/loopctl/knowledge/claude_category_classifier.ex
@@ -21,10 +21,14 @@ defmodule Loopctl.Knowledge.ClaudeCategoryClassifier do
   @system_prompt """
   You classify one knowledge-base article into exactly one category. Allowed \
   categories: #{Enum.join(Categories.active_strings(), ", ")}. Their meanings: \
-  #{Categories.prompt_fragment()}. Reply with a single compact JSON object that \
-  has exactly two keys: "category" (one of the allowed values above) and \
-  "confidence" (a number from 0 to 1 for how sure you are). Output nothing \
-  except that JSON object.\
+  #{Categories.prompt_fragment()}. Choose the MOST SPECIFIC fit, and do not \
+  over-use 'playbook': pick 'playbook' only when the article actually lays out \
+  explicit ordered steps. If it states a principle, realization, or mental model, \
+  use 'insight'; if it describes a reusable shape or recurring structure, use \
+  'pattern'; if it proposes something to build or try, use 'idea'. Reply with a \
+  single compact JSON object that has exactly two keys: "category" (one of the \
+  allowed values above) and "confidence" (a number from 0 to 1 for how sure you \
+  are). Output nothing except that JSON object.\
   """
 
   @max_body_chars 16_000

--- a/lib/loopctl/workers/knowledge_reclassify_worker.ex
+++ b/lib/loopctl/workers/knowledge_reclassify_worker.ex
@@ -77,6 +77,10 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorker do
   @default_batch_size 100
   @default_max_per_run 1_000
   @default_min_confidence 0.75
+  # Concurrent LLM classify calls per batch (backpressure). Conservative vs the
+  # provider rate limit; tune via :knowledge_reclassify_max_concurrency.
+  @default_max_concurrency 10
+  @classify_timeout_ms 30_000
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"mode" => "all_tenants"} = args}) do
@@ -150,27 +154,48 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorker do
 
   # --- per-batch processing ---
 
+  # Classification is an LLM HTTP call per article — the batch bottleneck. Run
+  # those concurrently with backpressure (Task.async_stream) so a 100-article
+  # batch isn't 100 serial round-trips. Writes stay SERIAL (in the reduce, on the
+  # worker process) so the small BYPASSRLS admin pool is never hit by N
+  # concurrent updates.
   defp process_batch(batch, run_mode, min_confidence) do
-    empty = %{
-      processed: 0,
-      changed: 0,
-      unchanged: 0,
-      low_confidence: 0,
-      errors: 0,
-      by_transition: %{}
-    }
+    max_concurrency =
+      Application.get_env(
+        :loopctl,
+        :knowledge_reclassify_max_concurrency,
+        @default_max_concurrency
+      )
 
-    Enum.reduce(batch, empty, fn article, acc ->
-      acc = %{acc | processed: acc.processed + 1}
+    batch
+    |> Task.async_stream(
+      fn article -> {article, @classifier.classify(article.title, article.body)} end,
+      max_concurrency: max_concurrency,
+      timeout: @classify_timeout_ms,
+      on_timeout: :kill_task,
+      ordered: false
+    )
+    |> Enum.reduce(empty_tally(), &reduce_outcome(&1, &2, min_confidence, run_mode))
+  end
 
-      case @classifier.classify(article.title, article.body) do
-        {:ok, %{category: proposed, confidence: confidence}} ->
-          classify_outcome(acc, article, proposed, confidence, min_confidence, run_mode)
+  defp empty_tally do
+    %{processed: 0, changed: 0, unchanged: 0, low_confidence: 0, errors: 0, by_transition: %{}}
+  end
 
-        {:error, _reason} ->
-          %{acc | errors: acc.errors + 1}
-      end
-    end)
+  defp reduce_outcome({:ok, {article, {:ok, verdict}}}, acc, min_confidence, run_mode) do
+    %{category: proposed, confidence: confidence} = verdict
+    acc = %{acc | processed: acc.processed + 1}
+    classify_outcome(acc, article, proposed, confidence, min_confidence, run_mode)
+  end
+
+  defp reduce_outcome({:ok, {_article, {:error, _reason}}}, acc, _min_confidence, _run_mode) do
+    %{acc | processed: acc.processed + 1, errors: acc.errors + 1}
+  end
+
+  # A classification task that timed out or crashed -- count it processed+errored;
+  # its article is simply left for a later run (commit writes are idempotent).
+  defp reduce_outcome({:exit, _reason}, acc, _min_confidence, _run_mode) do
+    %{acc | processed: acc.processed + 1, errors: acc.errors + 1}
   end
 
   defp classify_outcome(acc, article, proposed, confidence, min_confidence, run_mode) do

--- a/lib/loopctl/workers/knowledge_reclassify_worker.ex
+++ b/lib/loopctl/workers/knowledge_reclassify_worker.ex
@@ -81,6 +81,10 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorker do
   # provider rate limit; tune via :knowledge_reclassify_max_concurrency.
   @default_max_concurrency 10
   @classify_timeout_ms 30_000
+  # Outage resilience: if >= this fraction of a batch fails to classify, snooze
+  # (retry same cursor) instead of advancing — an outage pauses, never skips.
+  @default_snooze_error_rate 0.5
+  @default_snooze_seconds 60
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"mode" => "all_tenants"} = args}) do
@@ -121,12 +125,54 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorker do
 
     batch = fetch_batch(tenant_id, cursor, batch_size)
     tally = process_batch(batch, run_mode, min_confidence)
-    log_audit(tenant_id, run_mode, tally, processed_so_far)
 
-    new_processed = processed_so_far + tally.processed
-    maybe_chain(batch, tenant_id, args, batch_size, max_per_run, new_processed)
+    if upstream_unavailable?(batch, tally) do
+      # A mostly/entirely failed batch means the classifier upstream (Anthropic,
+      # or this host's egress) is unreachable -- NOT that the articles are bad.
+      # Snooze: Oban re-runs THIS SAME job (same cursor) later WITHOUT consuming
+      # an attempt and WITHOUT advancing, so an outage pauses the migration and it
+      # resumes cleanly when connectivity returns -- no articles skipped, no audit
+      # spam. (The migration also runs on the Fly host, so a local outage at the
+      # operator's site never touches it.)
+      snooze =
+        Application.get_env(
+          :loopctl,
+          :knowledge_reclassify_snooze_seconds,
+          @default_snooze_seconds
+        )
 
-    :ok
+      Logger.warning(
+        "KnowledgeReclassifyWorker: tenant=#{tenant_id} batch failed to classify " <>
+          "(#{tally.errors}/#{tally.processed}); classifier upstream likely unreachable. " <>
+          "Snoozing #{snooze}s and retrying the same cursor (nothing skipped)."
+      )
+
+      {:snooze, snooze}
+    else
+      log_audit(tenant_id, run_mode, tally, processed_so_far)
+      new_processed = processed_so_far + tally.processed
+      maybe_chain(batch, tenant_id, args, batch_size, max_per_run, new_processed)
+      :ok
+    end
+  end
+
+  # True when a non-empty batch came back with an error RATE at or above the
+  # configured threshold -- the signal of an upstream/connectivity outage rather
+  # than a few unparseable articles. (With the JSON-parse fix, genuine per-article
+  # errors are rare, so a high rate almost always means the API is unreachable.)
+  defp upstream_unavailable?([], _tally), do: false
+
+  defp upstream_unavailable?(_batch, %{processed: 0}), do: false
+
+  defp upstream_unavailable?(_batch, %{processed: processed, errors: errors}) do
+    rate =
+      Application.get_env(
+        :loopctl,
+        :knowledge_reclassify_snooze_error_rate,
+        @default_snooze_error_rate
+      )
+
+    errors / processed >= rate
   end
 
   # --- batch fetch (keyset by id) ---

--- a/test/loopctl/workers/knowledge_reclassify_worker_test.exs
+++ b/test/loopctl/workers/knowledge_reclassify_worker_test.exs
@@ -117,19 +117,46 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorkerTest do
       assert reload(a.id).category == :insight
     end
 
-    test "an unparseable/errored classification leaves the article alone" do
+    test "a few errored classifications (below the snooze rate) leave those articles alone but proceed" do
       tenant = fixture(:tenant)
-      a = published(tenant.id, :convention)
+      # 3 articles: one errors (33% < 50% snooze rate), two classify fine.
+      bad = published(tenant.id, :convention)
+      good_a = published(tenant.id, :convention)
+      good_b = published(tenant.id, :convention)
 
-      Mox.stub(Loopctl.MockCategoryClassifier, :classify, fn _t, _b ->
-        {:error, :unparseable_classification}
+      Mox.stub(Loopctl.MockCategoryClassifier, :classify, fn title, _body ->
+        if title == bad.title,
+          do: {:error, :unparseable_classification},
+          else: {:ok, %{category: :playbook, confidence: 0.9}}
       end)
 
       assert :ok = run(tenant.id, %{"run_mode" => "commit"})
 
-      assert reload(a.id).category == :convention
+      assert reload(bad.id).category == :convention
+      assert reload(good_a.id).category == :playbook
+      assert reload(good_b.id).category == :playbook
       assert [entry] = reclassify_audits(tenant.id)
       assert entry.new_state["batch"]["errors"] == 1
+      assert entry.new_state["batch"]["changed"] == 2
+    end
+  end
+
+  describe "outage resilience" do
+    test "snoozes and retries the same cursor when the whole batch fails (upstream down)" do
+      tenant = fixture(:tenant)
+      a = published(tenant.id, :convention)
+
+      # Every classify errors -> 100% error rate -> upstream is unreachable.
+      Mox.stub(Loopctl.MockCategoryClassifier, :classify, fn _t, _b ->
+        {:error, :econnrefused}
+      end)
+
+      assert {:snooze, seconds} = run(tenant.id, %{"run_mode" => "commit"})
+      assert is_integer(seconds) and seconds > 0
+
+      # Nothing written and NO audit/advance — it will retry the same cursor.
+      assert reload(a.id).category == :convention
+      assert [] == reclassify_audits(tenant.id)
     end
   end
 


### PR DESCRIPTION
Tuning/hardening the reclassification engine for the real 77k run (found via prod verification).

## 1. Concurrent batch classification
`process_batch` now classifies a batch **concurrently** via `Task.async_stream` (`:knowledge_reclassify_max_concurrency`, default 10; 30s per-call timeout, `on_timeout: :kill_task`). Writes stay **serial** on the worker process so the small BYPASSRLS admin pool is never hit by N concurrent updates. Turns a ~16h sequential 77k pass into ~1–2h.

## 2. Configurable classifier model
`:knowledge_classifier_model` (`ANTHROPIC_CLASSIFIER_MODEL` in prod) overrides the classifier model independently of content extraction — so a one-time high-accuracy reclassification can use a stronger model (e.g. Sonnet) without changing extraction. Falls back to the shared provider model (Haiku 4.5).

## 3. Outage resilience (snooze, never skip)
If a batch comes back with an error rate ≥ `:knowledge_reclassify_snooze_error_rate` (default 0.5) — i.e. the classifier upstream is unreachable — `perform` returns `{:snooze, seconds}` instead of advancing. Oban re-runs the **same cursor** later without consuming an attempt or logging audit, so an outage **pauses** the migration and it resumes cleanly — **no skipped articles**. (The migration runs on the Fly host, so a local operator outage never touches it; this covers the Anthropic/egress side.)

## Tests
Concurrent path (Mox `$callers` covers the spawned tasks); 100%-error batch snoozes and writes/audits nothing; 1-of-3 error batch (below the rate) proceeds and reclassifies the good ones. Full local gate green (3007 tests, credo, dialyzer 0).