### PR TITLE
feat(api): no-block limit contract + paginate ingestion-jobs

### DIFF
--- a/lib/loopctl_web/controllers/article_controller.ex
+++ b/lib/loopctl_web/controllers/article_controller.ex
@@ -163,7 +163,7 @@ defmodule LoopctlWeb.ArticleController do
         type: :integer,
         description:
           "Max results per page (default 20, max 1000). A limit above the max is " <>
-            "rejected with 400 — not silently clamped — so offset pagination stays complete."
+            "clamped to the maximum — never rejected — so offset pagination stays complete."
       ],
       offset: [in: :query, type: :integer, description: "Records to skip"],
       include_body: [
@@ -374,7 +374,7 @@ defmodule LoopctlWeb.ArticleController do
     # (400 with the allowed values), not a 404/500 from an Ecto.Enum cast failure.
     with :ok <- validate_enum(params["status"], @valid_statuses, "status"),
          :ok <- validate_enum(params["category"], @valid_categories, "category"),
-         :ok <- Pagination.validate_limit(params),
+         {:ok, effective_limit} <- Pagination.validate_limit(params),
          {:ok, match} <- TagMatch.parse(params) do
       opts =
         []
@@ -386,7 +386,7 @@ defmodule LoopctlWeb.ArticleController do
         |> maybe_add_opt(:source_type, string_param(params["source_type"]))
         |> maybe_add_opt(:source_id, string_param(params["source_id"]))
         |> maybe_add_opt(:idempotency_key, string_param(params["idempotency_key"]))
-        |> maybe_add_opt(:limit, parse_int(params["limit"]))
+        |> maybe_add_opt(:limit, effective_limit)
         |> maybe_add_opt(:offset, parse_int(params["offset"]))
         # Body-less summary by default; opt into full bodies (byte-budget bounded)
         # with ?include_body=true.
@@ -396,10 +396,6 @@ defmodule LoopctlWeb.ArticleController do
       result = Knowledge.list_articles(tenant_id, opts)
       json(conn, ArticleJSON.index(%{articles: result.data, meta: result.meta}))
     else
-      # Over-large `limit` — delegate to the fallback controller's 400 renderer.
-      {:error, :bad_request, _message} = error ->
-        error
-
       {:error, field, allowed} ->
         conn
         |> put_status(:bad_request)

--- a/lib/loopctl_web/controllers/article_workflow_controller.ex
+++ b/lib/loopctl_web/controllers/article_workflow_controller.ex
@@ -207,7 +207,7 @@ defmodule LoopctlWeb.ArticleWorkflowController do
         type: :integer,
         description:
           "Max results per page (default 20, max 1000). A limit above the max is " <>
-            "rejected with 400 — not silently clamped."
+            "clamped to the maximum — never rejected — so pagination stays complete."
       ],
       offset: [in: :query, type: :integer, description: "Records to skip"]
     ],
@@ -595,11 +595,11 @@ defmodule LoopctlWeb.ArticleWorkflowController do
   def drafts(conn, params) do
     tenant_id = conn.assigns.current_api_key.tenant_id
 
-    with :ok <- Pagination.validate_limit(params) do
+    with {:ok, effective_limit} <- Pagination.validate_limit(params) do
       opts =
         []
         |> maybe_add_opt(:project_id, params["project_id"])
-        |> maybe_add_opt(:limit, parse_int(params["limit"]))
+        |> maybe_add_opt(:limit, effective_limit)
         |> maybe_add_opt(:offset, parse_int(params["offset"]))
 
       result = Knowledge.list_drafts(tenant_id, opts)

--- a/lib/loopctl_web/controllers/knowledge_facets_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_facets_controller.ex
@@ -109,7 +109,8 @@ defmodule LoopctlWeb.KnowledgeFacetsController do
         in: :query,
         type: :integer,
         description:
-          "Max distinct tags in the facet result (default all, max 1000; values above 1000 rejected with 400)"
+          "Max distinct tags in the facet result (default all, max 1000). A limit above the max is " <>
+            "clamped to the maximum — never rejected — so pagination stays complete."
       ]
     ],
     responses: %{
@@ -149,7 +150,7 @@ defmodule LoopctlWeb.KnowledgeFacetsController do
          :ok <- validate_enum(params["status"], @valid_statuses, "status"),
          :ok <- validate_enum(params["category"], @valid_categories, "category"),
          :ok <- validate_project_id(params),
-         :ok <- Pagination.validate_limit(params),
+         {:ok, _effective_limit} <- Pagination.validate_limit(params),
          {:ok, match} <- TagMatch.parse(params) do
       opts =
         params

--- a/lib/loopctl_web/controllers/knowledge_index_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_index_controller.ex
@@ -101,7 +101,9 @@ defmodule LoopctlWeb.KnowledgeIndexController do
       limit: [
         in: :query,
         type: :integer,
-        description: "Max articles to return (default 1000, max 1000)",
+        description:
+          "Max articles to return (default 1000, max 1000). A limit above the max is " <>
+            "clamped to the maximum — never rejected — so pagination stays complete.",
         required: false
       ],
       offset: [
@@ -173,7 +175,7 @@ defmodule LoopctlWeb.KnowledgeIndexController do
   def index(conn, params) do
     tenant_id = conn.assigns.current_api_key.tenant_id
 
-    with :ok <- Pagination.validate_limit(params),
+    with {:ok, _effective_limit} <- Pagination.validate_limit(params),
          {:ok, fields} <- parse_fields(params["fields"]),
          {:ok, base_opts} <- build_opts(params) do
       opts = Keyword.merge(base_opts, Visibility.scope_opts(conn))

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -11,6 +11,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
 
   alias Loopctl.ApiSpec.Schemas
   alias Loopctl.Workers.ContentIngestionWorker
+  alias LoopctlWeb.Helpers.Pagination
 
   action_fallback LoopctlWeb.FallbackController
 
@@ -189,10 +190,32 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   end
 
   operation(:index,
-    summary: "List recent ingestion jobs",
+    summary: "List ingestion jobs",
     description:
-      "Returns recent content ingestion jobs for the current tenant. " <>
-        "Limited to last 7 days, max 50 results. Role: orchestrator+.",
+      "Returns content ingestion jobs for the current tenant, newest first, with " <>
+        "offset/limit pagination over the full history (advance `offset` by " <>
+        "`meta.limit` to enumerate to completeness). Optional `since_days` narrows " <>
+        "to a recent window. Role: orchestrator+.",
+    parameters: [
+      limit: [
+        in: :query,
+        type: :integer,
+        description: "Max jobs per page (default 20). A larger value is clamped, never rejected.",
+        required: false
+      ],
+      offset: [
+        in: :query,
+        type: :integer,
+        description: "Rows to skip (default 0)",
+        required: false
+      ],
+      since_days: [
+        in: :query,
+        type: :integer,
+        description: "Optional: only jobs from the last N days (default: all history)",
+        required: false
+      ]
+    ],
     responses: %{
       200 =>
         {"Ingestion jobs list", "application/json",
@@ -201,8 +224,9 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
            properties: %{
              data: %OpenApiSpex.Schema{
                type: :array,
-               description: "List of recent ingestion jobs"
-             }
+               description: "Page of ingestion jobs"
+             },
+             meta: Schemas.PaginationMeta
            }
          }},
       401 => {"Unauthorized", "application/json", Schemas.ErrorResponse},
@@ -211,11 +235,16 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   )
 
   @doc "GET /api/v1/knowledge/ingestion-jobs"
-  def index(conn, _params) do
+  def index(conn, params) do
     tenant_id = conn.assigns.current_api_key.tenant_id
-    jobs = list_ingestion_jobs(tenant_id)
+    {:ok, limit} = Pagination.validate_limit(params)
+    offset = parse_offset(params["offset"])
+    since = parse_since_days(params["since_days"])
 
-    json(conn, LoopctlWeb.KnowledgeIngestionJSON.index(jobs))
+    %{data: jobs, meta: meta} =
+      list_ingestion_jobs(tenant_id, limit: limit, offset: offset, since: since)
+
+    json(conn, LoopctlWeb.KnowledgeIngestionJSON.index(jobs, meta))
   end
 
   # --- Private ---
@@ -362,29 +391,71 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)
 
-  defp list_ingestion_jobs(tenant_id) do
+  defp parse_offset(value) do
+    case parse_int_param(value) do
+      n when is_integer(n) and n > 0 -> n
+      _ -> 0
+    end
+  end
+
+  defp parse_since_days(value) do
+    case parse_int_param(value) do
+      n when is_integer(n) and n > 0 ->
+        DateTime.add(DateTime.utc_now(), -n * 86_400, :second)
+
+      _ ->
+        nil
+    end
+  end
+
+  defp parse_int_param(value) when is_integer(value), do: value
+
+  defp parse_int_param(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {n, ""} -> n
+      _ -> nil
+    end
+  end
+
+  defp parse_int_param(_), do: nil
+
+  # Offset/limit pagination over the tenant's ingestion jobs (newest first), with
+  # an `id` tiebreaker so the page is stable across equal timestamps. No hard cap
+  # and no fixed time window: a caller paginates to completeness via offset.
+  defp list_ingestion_jobs(tenant_id, opts) do
     import Ecto.Query
 
-    tenant_id_str = tenant_id
+    limit = Keyword.fetch!(opts, :limit)
+    offset = Keyword.get(opts, :offset, 0)
+    since = Keyword.get(opts, :since)
 
-    seven_days_ago = DateTime.add(DateTime.utc_now(), -7 * 24 * 3600, :second)
+    base =
+      from(j in "oban_jobs",
+        where:
+          fragment("? = 'Loopctl.Workers.ContentIngestionWorker'", j.worker) and
+            fragment("?->>'tenant_id' = ?", j.args, ^tenant_id)
+      )
 
-    from(j in "oban_jobs",
-      where:
-        fragment("? = 'Loopctl.Workers.ContentIngestionWorker'", j.worker) and
-          fragment("?->>'tenant_id' = ?", j.args, ^tenant_id_str) and
-          j.inserted_at > ^seven_days_ago,
-      order_by: [desc: j.inserted_at],
-      limit: 50,
-      select: %{
+    base = if since, do: where(base, [j], j.inserted_at > ^since), else: base
+
+    total =
+      base |> select([j], count(j.id)) |> Loopctl.Repo.one()
+
+    rows =
+      base
+      |> order_by([j], desc: j.inserted_at, desc: j.id)
+      |> limit(^limit)
+      |> offset(^offset)
+      |> select([j], %{
         id: j.id,
         state: j.state,
         args: j.args,
         inserted_at: j.inserted_at,
         completed_at: j.completed_at,
         errors: j.errors
-      }
-    )
-    |> Loopctl.Repo.all()
+      })
+      |> Loopctl.Repo.all()
+
+    %{data: rows, meta: %{limit: limit, offset: offset, total_count: total}}
   end
 end

--- a/lib/loopctl_web/controllers/knowledge_ingestion_json.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_json.ex
@@ -27,10 +27,11 @@ defmodule LoopctlWeb.KnowledgeIngestionJSON do
     }
   end
 
-  @doc "Renders the ingestion jobs index."
-  def index(jobs) do
+  @doc "Renders the ingestion jobs index with pagination meta."
+  def index(jobs, meta) do
     %{
-      data: Enum.map(jobs, &render_job/1)
+      data: Enum.map(jobs, &render_job/1),
+      meta: meta
     }
   end
 

--- a/lib/loopctl_web/controllers/knowledge_search_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_search_controller.ex
@@ -20,7 +20,6 @@ defmodule LoopctlWeb.KnowledgeSearchController do
   alias Loopctl.Knowledge
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.ArticleCursor
-  alias LoopctlWeb.Helpers.Pagination
   alias LoopctlWeb.Helpers.TagMatch
   alias LoopctlWeb.Helpers.Visibility
 
@@ -97,11 +96,12 @@ defmodule LoopctlWeb.KnowledgeSearchController do
         in: :query,
         type: :integer,
         description:
-          "Max results to return (default 10). The cap is mode-dependent and a limit " <>
-            "above it is rejected with 400 — never silently clamped. **List mode** (no " <>
-            "`q`, just `tags`/`category`) is exhaustive enumeration: max 1000, paginate " <>
-            "the complete filtered set via `offset`. **Relevance modes** (keyword / " <>
-            "semantic / combined) return a ranked top-N: max 100.",
+          "Max results to return (default 10). The cap is mode-dependent; a limit " <>
+            "above it is clamped (never rejected) and the effective value is returned " <>
+            "in `meta.limit`. **List mode** (no `q`, just `tags`/`category`) is " <>
+            "exhaustive enumeration: max 1000, paginate the complete filtered set via " <>
+            "`offset`. **Relevance modes** (keyword / semantic / combined) return a " <>
+            "ranked top-N: max 100 (drop `q` for full enumeration).",
         required: false
       ],
       offset: [
@@ -458,25 +458,12 @@ defmodule LoopctlWeb.KnowledgeSearchController do
     if tags == [], do: opts, else: [{:tags, tags} | opts]
   end
 
-  # List mode is exhaustive enumeration (cap: the shared max page size); the
-  # relevance modes return a ranked top-N (a much smaller cap). Validating the
-  # requested `limit` against the mode-appropriate cap — and 400-ing over it —
-  # keeps `meta.limit` honest in every mode (a relevance request for limit=200
-  # is rejected, never silently clamped to the ranked-pool size).
-  defp validate_search_limit(params, :list),
-    do: Pagination.validate_limit(params, Knowledge.max_page_size())
-
-  defp validate_search_limit(params, {:search, _q}) do
-    case Pagination.validate_limit(params, Knowledge.max_relevance_page_size()) do
-      :ok ->
-        :ok
-
-      {:error, :bad_request, _} ->
-        {:error, :bad_request,
-         "limit exceeds the relevance-mode maximum of #{Knowledge.max_relevance_page_size()}; " <>
-           "for exhaustive enumeration drop 'q' to use list mode (max #{Knowledge.max_page_size()})"}
-    end
-  end
+  # A requested `limit` is never rejected — it is CLAMPED downstream and the
+  # effective value is reported in `meta.limit`, so a caller is never blocked.
+  # List mode clamps to the shared max page size (via `maybe_add_limit/2`);
+  # relevance modes clamp to the ranked-pool cap in the context. Full enumeration
+  # of a relevance query is reached by dropping `q` (list mode + keyset cursor).
+  defp validate_search_limit(_params, _query_spec), do: :ok
 
   # US-27.10: `include_body=true` is a KEYSET-path-only opt-in to full bodies, and
   # only for a requested `limit <= max_include_body_page/0`. Two 400s are enforced

--- a/lib/loopctl_web/helpers/pagination.ex
+++ b/lib/loopctl_web/helpers/pagination.ex
@@ -4,42 +4,46 @@ defmodule LoopctlWeb.Helpers.Pagination do
 
   The knowledge enumeration/search endpoints (`GET /articles`,
   `GET /knowledge/search`, `GET /knowledge/drafts`) accept an `offset`/`limit`
-  pair and paginate to exhaustion over `meta.total_count`. A caller advancing
-  `offset` by the limit it *requested* must be able to trust that the server
-  returned (up to) that many rows — otherwise it silently skips the rows the
-  server dropped (see #148 A1, where a `limit=200` request returned 100 rows and
-  a by-tag cleanup scanned only half the data).
+  pair and paginate to exhaustion over `meta.total_count`.
 
-  To make that contract honest, an over-large `limit` is **rejected with 400**
-  rather than silently clamped. The context layer (`Loopctl.Knowledge`) still
-  clamps as an internal safety net, but the HTTP layer never returns fewer rows
-  than requested without an error.
+  A caller requesting an over-large `limit` is **clamped** to the maximum page
+  size, never rejected. The HTTP layer returns the **effective limit** in
+  `meta.limit` so the caller can trust it and advance `offset` by that amount
+  to paginate to completeness without skipping rows (see #148 A1, where silent
+  clamping used to cause row skips).
+
+  This is safe because:
+  - The context layer (`Loopctl.Knowledge`) also clamps as a safety net
+  - The client has `meta.limit` (the effective page size returned)
+  - Offset-based pagination works correctly when advancing by the effective limit
+  - Keyset-based pagination (via cursor) is the preferred unbounded path
   """
 
   alias Loopctl.Knowledge
 
   @doc """
-  Validates the requested `"limit"` query param against the maximum page size.
+  Clamps the requested `"limit"` query param to the maximum page size.
 
-  Returns `:ok` when `limit` is absent, malformed (treated as absent → server
-  default), or within range. Returns `{:error, :bad_request, message}` — the
-  shape `LoopctlWeb.FallbackController` renders as a 400 — when a parseable
-  integer limit exceeds the cap. Defaults the cap to
-  `Loopctl.Knowledge.max_page_size/0`.
+  Returns `{:ok, effective_limit}` where `effective_limit` is the
+  `min(parsed_limit, max)`. When `limit` is absent or malformed, returns
+  `{:ok, default_limit}` where `default_limit` is the context's default
+  (typically 20).
+
+  The returned effective limit should be passed to the context layer and
+  returned in `meta.limit` so the client can trust it and advance correctly.
   """
-  @spec validate_limit(map()) :: :ok | {:error, :bad_request, String.t()}
+  @spec validate_limit(map()) :: {:ok, pos_integer()} | {:error, :bad_request, String.t()}
   def validate_limit(params), do: validate_limit(params, Knowledge.max_page_size())
 
-  @spec validate_limit(map(), pos_integer()) :: :ok | {:error, :bad_request, String.t()}
+  @spec validate_limit(map(), pos_integer()) ::
+          {:ok, pos_integer()} | {:error, :bad_request, String.t()}
   def validate_limit(params, max) when is_map(params) and is_integer(max) do
     case parse_int(params["limit"]) do
-      n when is_integer(n) and n > max ->
-        {:error, :bad_request,
-         "limit exceeds the maximum page size of #{max}; " <>
-           "request limit <= #{max} and advance offset to paginate to completeness"}
+      n when is_integer(n) ->
+        {:ok, max(min(n, max), 1)}
 
       _ ->
-        :ok
+        {:ok, 20}
     end
   end
 

--- a/test/loopctl_web/controllers/article_controller_test.exs
+++ b/test/loopctl_web/controllers/article_controller_test.exs
@@ -794,7 +794,7 @@ defmodule LoopctlWeb.ArticleControllerTest do
       assert length(ids) == total
     end
 
-    test "rejects a limit above the maximum page size with 400 instead of silently clamping",
+    test "clamps a limit above the maximum page size (never rejects) and reports the effective limit",
          %{conn: conn} do
       tenant = fixture(:tenant)
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
@@ -803,10 +803,11 @@ defmodule LoopctlWeb.ArticleControllerTest do
         conn
         |> auth_conn(raw_key)
         |> get(~p"/api/v1/articles?limit=1001")
-        |> json_response(400)
+        |> json_response(200)
 
-      assert resp["error"]["status"] == 400
-      assert resp["error"]["message"] =~ "maximum page size"
+      # No 400 — clamped to the max page size, surfaced in meta.limit so the
+      # caller advances offset by the effective amount (no skipped rows).
+      assert resp["meta"]["limit"] == 1000
     end
 
     test "honors the maximum limit exactly (1000) without clamping", %{conn: conn} do

--- a/test/loopctl_web/controllers/article_workflow_controller_test.exs
+++ b/test/loopctl_web/controllers/article_workflow_controller_test.exs
@@ -1134,7 +1134,7 @@ defmodule LoopctlWeb.ArticleWorkflowControllerTest do
       assert length(body["data"]) == 2
     end
 
-    test "rejects a limit above the maximum page size with 400 (no silent clamp) (#148 A1)",
+    test "clamps a limit above the maximum page size (never rejects), reporting effective meta.limit (#148 A1)",
          %{conn: conn} do
       tenant = fixture(:tenant)
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
@@ -1143,10 +1143,9 @@ defmodule LoopctlWeb.ArticleWorkflowControllerTest do
         conn
         |> auth_conn(raw_key)
         |> get(~p"/api/v1/knowledge/drafts?limit=1001")
-        |> json_response(400)
+        |> json_response(200)
 
-      assert resp["error"]["status"] == 400
-      assert resp["error"]["message"] =~ "maximum page size"
+      assert resp["meta"]["limit"] == 1000
     end
 
     test "filters by project_id", %{conn: conn} do

--- a/test/loopctl_web/controllers/knowledge_index_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_index_controller_test.exs
@@ -8,7 +8,7 @@ defmodule LoopctlWeb.KnowledgeIndexControllerTest do
   end
 
   describe "GET /api/v1/knowledge/index" do
-    test "rejects a limit above the maximum page size with 400 (no silent clamp) (#148 A1)",
+    test "clamps a limit above the maximum page size (never rejects), reporting effective meta.limit (#148 A1)",
          %{conn: conn} do
       tenant = fixture(:tenant)
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
@@ -17,10 +17,9 @@ defmodule LoopctlWeb.KnowledgeIndexControllerTest do
         conn
         |> auth_conn(raw_key)
         |> get(~p"/api/v1/knowledge/index?limit=1001")
-        |> json_response(400)
+        |> json_response(200)
 
-      assert resp["error"]["status"] == 400
-      assert resp["error"]["message"] =~ "maximum page size"
+      assert resp["meta"]["limit"] == 1000
     end
 
     test "returns lightweight catalog grouped by category, drafts excluded", %{conn: conn} do

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -395,6 +395,57 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       # In inline mode, the job may have already completed, but it should still be in the list
     end
 
+    test "paginates with limit/offset + meta, and never caps or rejects (no hard 50)",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      # Insert ingestion-job rows directly (deterministic — no inline-cascade or
+      # timing dependence) with distinct inserted_at so paging order is stable.
+      now = DateTime.utc_now()
+
+      for n <- 1..3 do
+        %Oban.Job{
+          worker: "Loopctl.Workers.ContentIngestionWorker",
+          queue: "default",
+          state: "completed",
+          args: %{"tenant_id" => tenant.id, "source_type" => "newsletter", "n" => n},
+          inserted_at: DateTime.add(now, -n, :second)
+        }
+        |> Loopctl.Repo.insert!()
+      end
+
+      page1 =
+        build_conn()
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/ingestion-jobs?limit=2")
+        |> json_response(200)
+
+      assert page1["meta"]["limit"] == 2
+      assert page1["meta"]["offset"] == 0
+      assert page1["meta"]["total_count"] == 3
+      assert length(page1["data"]) == 2
+
+      # Offset reaches the remainder — completeness, no hard cap.
+      page2 =
+        build_conn()
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/ingestion-jobs?limit=2&offset=2")
+        |> json_response(200)
+
+      assert length(page2["data"]) == 1
+
+      # A huge limit is clamped to the max page size, never rejected (no hard
+      # 50-row cap, no 400).
+      big =
+        build_conn()
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/ingestion-jobs?limit=5000")
+        |> json_response(200)
+
+      assert big["meta"]["limit"] <= 1000
+    end
+
     test "agent role is rejected", %{conn: conn} do
       tenant = fixture(:tenant)
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})

--- a/test/loopctl_web/controllers/knowledge_keyset_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_keyset_controller_test.exs
@@ -375,7 +375,7 @@ defmodule LoopctlWeb.KnowledgeKeysetControllerTest do
     # the LEGACY offset path, not only the keyset path. `validate_search_limit` runs
     # before cursor branching, but pin it on the no-cursor path so a future refactor
     # can't reintroduce a silent clamp there.
-    test "offset path (no cursor) rejects over-max limit with 400, never clamps", %{conn: conn} do
+    test "offset path (no cursor) clamps an over-max limit (never rejects)", %{conn: conn} do
       tenant = fixture(:tenant)
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
       fixture(:article, %{tenant_id: tenant.id, status: :published, tags: ["bc"]})
@@ -385,7 +385,8 @@ defmodule LoopctlWeb.KnowledgeKeysetControllerTest do
         |> auth_conn(raw_key)
         |> get(~p"/api/v1/knowledge/search", %{"tags" => "bc", "limit" => "5000"})
 
-      assert resp.status == 400
+      assert resp.status == 200
+      assert json_response(resp, 200)["meta"]["limit"] == 1000
     end
   end
 

--- a/test/loopctl_web/controllers/knowledge_search_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_search_controller_test.exs
@@ -311,26 +311,23 @@ defmodule LoopctlWeb.KnowledgeSearchControllerTest do
       assert length(body["data"]) <= 2
     end
 
-    test "rejects a relevance-mode limit above the relevance cap with 400, not a silent clamp (#148 A1)",
+    test "clamps a relevance-mode limit above the relevance cap (never rejects) (#148 A1)",
          %{conn: conn} do
       tenant = fixture(:tenant)
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
 
-      # Relevance modes (here keyword) cap well below the 1000 enumeration cap.
-      # A limit between the relevance cap and the enumeration cap must 400 —
-      # otherwise it would be silently clamped to the ranked-pool size and
-      # meta.limit would under-report what was requested.
+      # Relevance modes (here keyword) return a ranked top-N. An over-large limit
+      # is clamped to the ranked-pool cap and surfaced in meta.limit — never
+      # rejected. Full enumeration is reached by dropping `q` (list mode).
       over = Loopctl.Knowledge.max_relevance_page_size() + 1
 
       resp =
         conn
         |> auth_conn(raw_key)
         |> get(~p"/api/v1/knowledge/search", %{q: "anything", mode: "keyword", limit: "#{over}"})
-        |> json_response(400)
+        |> json_response(200)
 
-      assert resp["error"]["status"] == 400
-      assert resp["error"]["message"] =~ "relevance-mode maximum"
-      assert resp["error"]["message"] =~ "exhaustive enumeration"
+      assert resp["meta"]["limit"] <= Loopctl.Knowledge.max_relevance_page_size()
     end
 
     test "honors a within-cap relevance limit (combined/default mode) (#148 A1)", %{conn: conn} do
@@ -477,7 +474,7 @@ defmodule LoopctlWeb.KnowledgeSearchControllerTest do
       assert length(body["data"]) == total
     end
 
-    test "rejects a limit above the maximum page size with 400 (no silent clamp) (#148 A1)",
+    test "clamps a list-mode limit above the maximum page size (never rejects) (#148 A1)",
          %{conn: conn} do
       tenant = fixture(:tenant)
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
@@ -486,10 +483,9 @@ defmodule LoopctlWeb.KnowledgeSearchControllerTest do
         conn
         |> auth_conn(raw_key)
         |> get(~p"/api/v1/knowledge/search", %{tags: "anything", limit: "1001"})
-        |> json_response(400)
+        |> json_response(200)
 
-      assert resp["error"]["status"] == 400
-      assert resp["error"]["message"] =~ "maximum page size"
+      assert resp["meta"]["limit"] == 1000
     end
 
     test "category filter without q enumerates the category", %{conn: conn} do


### PR DESCRIPTION
feat(api): no-block limit contract + paginate ingestion-jobs

Honor "no imposed limits, working pagination" for the knowledge list endpoints.

Limit contract (clamp, never reject):
- Pagination.validate_limit now CLAMPS an over-large `limit` to the max page size
  and returns the effective value (`{:ok, effective_limit}`), instead of 400-ing.
  Every list endpoint returns the effective `meta.limit`, so a caller advances
  `offset` by what it actually got — no 400 block AND no #148 silent-skip.
- Wired through /articles, /knowledge/drafts, /knowledge/index, /knowledge/facets,
  and /knowledge/search (list + relevance modes clamp to their respective caps;
  full enumeration of a relevance query is reached by dropping `q` → list mode +
  keyset cursor). The include_body and tampered-cursor 400s are unchanged (those
  are payload-safety / integrity guards, not usage limits).

Ingestion jobs — was a hard `LIMIT 50` over a fixed 7-day window with NO
pagination params (a caller with >50 jobs could never see the rest):
- GET /knowledge/ingestion-jobs now takes `limit`/`offset` (clamped, never
  rejected) over the FULL history, newest-first with an `id` tiebreaker for
  stable paging, optional `since_days` to narrow. Returns PaginationMeta
  (limit/offset/total_count) so it paginates to completeness.

Tests: the old "rejects over-max with 400" assertions across articles / index /
drafts / search (list + relevance) / keyset are updated to assert the clamp
contract (200 + effective meta.limit); new ingestion-jobs pagination test proves
limit/offset/meta and that a huge limit is clamped (no hard 50, no 400).
Full suite green (3008 tests), credo --strict + dialyzer clean.

Remaining (separate PRs): analytics endpoints (top/unused/agent/usage) need
offset pagination; MCP tools (list_ready_stories page/page_size bug + missing
pagination params on list_projects/cost_anomalies/token_usage/ingestion_jobs).
