### PR TITLE
feat(mcp): pagination on list tools — no imposed limits (v2.23.0)

### DIFF
--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to `loopctl-mcp-server` are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 2.23.0 — 2026-06-30 (pagination: no imposed limits on list tools)
+
+### Fixed
+
+- **`list_ready_stories`** sent a `limit` param, but `GET /stories/ready`
+  paginates by `page`/`page_size` — so `limit` was silently ignored and callers
+  were stuck on the first page with no way past it. Now forwards `page`/`page_size`.
+
+### Added
+
+- Pagination params on list tools that previously exposed none (so an agent can
+  enumerate past the first page):
+  - **`list_projects`** — `page`/`page_size`
+  - **`get_cost_anomalies`** — `page`/`page_size`
+  - **`get_story_token_usage`** — `page`/`page_size`
+  - **`knowledge_ingestion_jobs`** — `limit`/`offset`/`since_days` (the server-side
+    endpoint is now paginated over full history instead of a hard 50-row / 7-day cap)
+
 ## 2.22.0 — 2026-06-24 (bulk-delete: set-based + irreversible hard delete)
 
 ### Added

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -178,8 +178,12 @@ async function getTenant() {
   return toContent(result);
 }
 
-async function listProjects() {
-  const result = await apiCall("GET", "/api/v1/projects");
+async function listProjects({ page, page_size } = {}) {
+  const params = new URLSearchParams();
+  if (page != null) params.set("page", String(page));
+  if (page_size != null) params.set("page_size", String(page_size));
+  const query = params.toString() ? `?${params}` : "";
+  const result = await apiCall("GET", `/api/v1/projects${query}`);
   return toContent(result);
 }
 
@@ -381,12 +385,13 @@ async function listStories({ project_id, agent_status, verified_status, epic_id,
   return toContentCompact(result);
 }
 
-async function listReadyStories({ project_id, limit }) {
+async function listReadyStories({ project_id, page, page_size }) {
+  // /stories/ready paginates by page/page_size — the old `limit` param was
+  // silently ignored by the server, capping callers at the first page.
   const params = new URLSearchParams({ project_id });
-  params.set(
-    "limit",
-    String(Math.min(limit ?? DEFAULT_STORY_PAGE_SIZE, SERVER_MAX_STORY_PAGE_SIZE)),
-  );
+  if (page != null) params.set("page", String(page));
+  if (page_size != null)
+    params.set("page_size", String(Math.min(page_size, SERVER_MAX_STORY_PAGE_SIZE)));
 
   const result = await apiCall("GET", `/api/v1/stories/ready?${params}`);
   return toContentCompact(result);
@@ -559,14 +564,20 @@ async function getCostSummary({ project_id, breakdown }) {
   return toContent(result);
 }
 
-async function getStoryTokenUsage({ story_id }) {
-  const result = await apiCall("GET", `/api/v1/stories/${story_id}/token-usage`);
+async function getStoryTokenUsage({ story_id, page, page_size }) {
+  const params = new URLSearchParams();
+  if (page != null) params.set("page", String(page));
+  if (page_size != null) params.set("page_size", String(page_size));
+  const query = params.toString() ? `?${params}` : "";
+  const result = await apiCall("GET", `/api/v1/stories/${story_id}/token-usage${query}`);
   return toContent(result);
 }
 
-async function getCostAnomalies({ project_id }) {
+async function getCostAnomalies({ project_id, page, page_size }) {
   const params = new URLSearchParams();
   if (project_id) params.set("project_id", project_id);
+  if (page != null) params.set("page", String(page));
+  if (page_size != null) params.set("page_size", String(page_size));
 
   const query = params.toString() ? `?${params}` : "";
   const result = await apiCall("GET", `/api/v1/cost-anomalies${query}`);
@@ -1069,8 +1080,18 @@ async function knowledgeIngestBatch({ items, project_id, publish }) {
   return toContent(result);
 }
 
-async function knowledgeIngestionJobs() {
-  const result = await apiCall("GET", "/api/v1/knowledge/ingestion-jobs", null, process.env.LOOPCTL_ORCH_KEY);
+async function knowledgeIngestionJobs({ limit, offset, since_days } = {}) {
+  const params = new URLSearchParams();
+  if (limit != null) params.set("limit", String(limit));
+  if (offset != null) params.set("offset", String(offset));
+  if (since_days != null) params.set("since_days", String(since_days));
+  const query = params.toString() ? `?${params}` : "";
+  const result = await apiCall(
+    "GET",
+    `/api/v1/knowledge/ingestion-jobs${query}`,
+    null,
+    process.env.LOOPCTL_ORCH_KEY,
+  );
   return toContent(result);
 }
 
@@ -1401,10 +1422,15 @@ const TOOLS = [
   },
   {
     name: "list_projects",
-    description: "List all projects in the current tenant.",
+    description:
+      "List projects in the current tenant. Paginated (page/page_size); advance " +
+      "`page` to enumerate all projects. Response includes pagination meta.",
     inputSchema: {
       type: "object",
-      properties: {},
+      properties: {
+        page: { type: "integer", description: "Page number (default 1)." },
+        page_size: { type: "integer", description: "Items per page (default 20)." },
+      },
       required: [],
     },
   },
@@ -1608,7 +1634,8 @@ const TOOLS = [
     description:
       "List stories that are ready to be worked on (contracted, dependencies met). " +
       "Returns compact results — use get_story for full details. " +
-      "Defaults to 20 per page; pass `limit` up to 500 to page larger. Response includes total_count.",
+      "Paginated (page/page_size); advance `page` to enumerate all ready stories. " +
+      "Response includes total_count.",
     inputSchema: {
       type: "object",
       properties: {
@@ -1616,9 +1643,10 @@ const TOOLS = [
           type: "string",
           description: "The UUID of the project.",
         },
-        limit: {
+        page: { type: "integer", description: "Page number (default 1)." },
+        page_size: {
           type: "integer",
-          description: "Maximum number of stories to return (default 20, max 500).",
+          description: "Stories per page (default 100, max 500).",
         },
       },
       required: ["project_id"],
@@ -1963,7 +1991,9 @@ const TOOLS = [
   },
   {
     name: "get_story_token_usage",
-    description: "Get token usage records for a single story.",
+    description:
+      "Get token usage records for a single story. Paginated (page/page_size); " +
+      "advance `page` to enumerate all records.",
     inputSchema: {
       type: "object",
       properties: {
@@ -1971,6 +2001,8 @@ const TOOLS = [
           type: "string",
           description: "The UUID of the story.",
         },
+        page: { type: "integer", description: "Page number (default 1)." },
+        page_size: { type: "integer", description: "Records per page (default 20)." },
       },
       required: ["story_id"],
     },
@@ -1979,7 +2011,8 @@ const TOOLS = [
     name: "get_cost_anomalies",
     description:
       "Get cost anomaly alerts — stories or agents that exceed expected token budgets. " +
-      "Optionally filter by project.",
+      "Optionally filter by project. Paginated (page/page_size); advance `page` to " +
+      "enumerate all anomalies.",
     inputSchema: {
       type: "object",
       properties: {
@@ -1987,6 +2020,8 @@ const TOOLS = [
           type: "string",
           description: "Optional: filter anomalies to a specific project UUID.",
         },
+        page: { type: "integer", description: "Page number (default 1)." },
+        page_size: { type: "integer", description: "Anomalies per page (default 20)." },
       },
       required: [],
     },
@@ -3038,11 +3073,20 @@ const TOOLS = [
   {
     name: "knowledge_ingestion_jobs",
     description:
-      "List recent content ingestion jobs for the current tenant. " +
-      "Returns jobs from the last 7 days, max 50 results. Requires orchestrator role.",
+      "List content ingestion jobs for the current tenant, newest first. " +
+      "Paginated (limit/offset over the full history; advance `offset` by `meta.limit` " +
+      "to enumerate to completeness). Optional `since_days` narrows to a recent window. " +
+      "Requires orchestrator role.",
     inputSchema: {
       type: "object",
-      properties: {},
+      properties: {
+        limit: { type: "integer", description: "Jobs per page (default 20)." },
+        offset: { type: "integer", description: "Rows to skip (default 0)." },
+        since_days: {
+          type: "integer",
+          description: "Optional: only jobs from the last N days (default: all history).",
+        },
+      },
       required: [],
     },
   },

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.22.0",
+  "version": "2.23.0",
   "description": "MCP server for loopctl — structural trust for AI development loops",
   "type": "module",
   "main": "index.js",

--- a/mcp-server/test/story_tools.test.js
+++ b/mcp-server/test/story_tools.test.js
@@ -59,3 +59,27 @@ describe("#155 story-list limit handling", () => {
     );
   });
 });
+
+describe("list_ready_stories pagination (page/page_size, not the ignored `limit`)", () => {
+  const indexPath = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+    "index.js",
+  );
+
+  // /stories/ready paginates by page/page_size; the old handler forwarded `limit`,
+  // which the server ignores — capping callers at the first page with no way past it.
+  test("listReadyStories forwards page/page_size and not a `limit` param", () => {
+    const src = readFileSync(indexPath, "utf8");
+    const start = src.indexOf("async function listReadyStories");
+    assert.ok(start !== -1, "listReadyStories handler must exist");
+    const body = src.slice(start, start + 500);
+
+    assert.ok(/page_size/.test(body), "listReadyStories must forward page_size");
+    assert.ok(/"page"/.test(body), "listReadyStories must forward page");
+    assert.ok(
+      !/params\.set\(\s*["']limit["']/.test(body),
+      "listReadyStories must NOT send the server-ignored `limit` param",
+    );
+  });
+});


### PR DESCRIPTION
Make the MCP list tools paginate to completeness — no agent stuck on page 1.

## Fixed
- **`list_ready_stories`** forwarded a `limit` param, but `GET /stories/ready` paginates by **page/page_size** — so `limit` was silently ignored and a caller could never page past the first ~100 ready stories. Now forwards `page`/`page_size`.

## Added (pagination params where there were none)
- `list_projects` → `page`/`page_size`
- `get_cost_anomalies` → `page`/`page_size`
- `get_story_token_usage` → `page`/`page_size`
- `knowledge_ingestion_jobs` → `limit`/`offset`/`since_days` (pairs with #212, which paginated that endpoint over full history instead of the hard 50-row / 7-day cap)

## Tests
Source-grep regression that `list_ready_stories` forwards page/page_size and no longer sends the ignored `limit`. `node --test`: **48 pass**. Bumped to **2.23.0** — the auto-publish workflow (mcp-autopublish.yml) ships it to npm on merge.

Note: MCP tools for the analytics endpoints (top/unused/agent/usage) are deferred to the analytics-pagination API PR, since those server endpoints need offset pagination first.