### PR TITLE
feat(api): paginate analytics rankings (offset) — no top-N cap

### DIFF
--- a/lib/loopctl/knowledge/analytics.ex
+++ b/lib/loopctl/knowledge/analytics.ex
@@ -299,20 +299,24 @@ defmodule Loopctl.Knowledge.Analytics do
   @spec list_top_articles(Ecto.UUID.t(), keyword()) :: [map()]
   def list_top_articles(tenant_id, opts \\ []) do
     limit = opts |> Keyword.get(:limit, 20) |> max(1) |> min(100)
+    offset = opts |> Keyword.get(:offset, 0) |> max(0)
     since = Keyword.get(opts, :since) || default_since()
     access_type = Keyword.get(opts, :access_type)
     project_id = Keyword.get(opts, :project_id)
     group_by = Keyword.get(opts, :group_by, :article)
 
     case group_by do
-      :project -> list_top_by_project(tenant_id, since, access_type, project_id, limit)
-      :agent -> list_top_by_agent(tenant_id, since, access_type, project_id, limit)
-      _ -> list_top_by_article(tenant_id, since, access_type, project_id, limit)
+      :project -> list_top_by_project(tenant_id, since, access_type, project_id, limit, offset)
+      :agent -> list_top_by_agent(tenant_id, since, access_type, project_id, limit, offset)
+      _ -> list_top_by_article(tenant_id, since, access_type, project_id, limit, offset)
     end
   end
 
-  # Default grouping — per article.
-  defp list_top_by_article(tenant_id, since, access_type, project_id, limit) do
+  # Default grouping — per article. `offset` enables paging the ranking to
+  # completeness (it is ranked by access count — a cheap btree aggregate, not a
+  # vector scan — so deep offset is safe). A secondary `a.id` order keeps paging
+  # stable across rows with equal counts.
+  defp list_top_by_article(tenant_id, since, access_type, project_id, limit, offset) do
     query =
       from(e in ArticleAccessEvent,
         as: :event,
@@ -321,8 +325,9 @@ defmodule Loopctl.Knowledge.Analytics do
         where: e.tenant_id == ^tenant_id,
         where: e.accessed_at >= ^since,
         group_by: [a.id, a.title, a.category],
-        order_by: [desc: count(e.id)],
+        order_by: [desc: count(e.id), asc: a.id],
         limit: ^limit,
+        offset: ^offset,
         select: %{
           article_id: a.id,
           title: a.title,
@@ -342,7 +347,7 @@ defmodule Loopctl.Knowledge.Analytics do
   # Group by project — only events with a non-NULL project_id contribute
   # (the filter explicitly excludes NULL-tagged events so rollup totals
   # stay tied to actual projects).
-  defp list_top_by_project(tenant_id, since, access_type, project_id, limit) do
+  defp list_top_by_project(tenant_id, since, access_type, project_id, limit, offset) do
     query =
       from(e in ArticleAccessEvent,
         as: :event,
@@ -352,8 +357,9 @@ defmodule Loopctl.Knowledge.Analytics do
         where: e.accessed_at >= ^since,
         where: not is_nil(e.project_id),
         group_by: [p.id, p.name],
-        order_by: [desc: count(e.id)],
+        order_by: [desc: count(e.id), asc: p.id],
         limit: ^limit,
+        offset: ^offset,
         select: %{
           project_id: p.id,
           project_name: p.name,
@@ -373,7 +379,7 @@ defmodule Loopctl.Knowledge.Analytics do
   # agent link, then LEFT JOIN agents so keys without a linked agent
   # still appear (bucketed under `agent_id: nil`, `agent_name: "unassigned"`).
   # Revoked keys are handled in a separate sentinel rollup below.
-  defp list_top_by_agent(tenant_id, since, access_type, project_id, limit) do
+  defp list_top_by_agent(tenant_id, since, access_type, project_id, limit, offset) do
     # Live keys — keys that exist AND are not revoked.
     live_query =
       from(e in ArticleAccessEvent,
@@ -428,6 +434,7 @@ defmodule Loopctl.Knowledge.Analytics do
 
     (live_rows ++ List.wrap(revoked_row))
     |> Enum.sort_by(& &1.access_count, :desc)
+    |> Enum.drop(offset)
     |> Enum.take(limit)
   end
 
@@ -846,6 +853,7 @@ defmodule Loopctl.Knowledge.Analytics do
   def list_unused_articles(tenant_id, opts \\ []) do
     days_unused = opts |> Keyword.get(:days_unused, 30) |> max(1)
     limit = opts |> Keyword.get(:limit, 50) |> max(1) |> min(200)
+    offset = opts |> Keyword.get(:offset, 0) |> max(0)
     cutoff = DateTime.add(DateTime.utc_now(), -days_unused * 86_400, :second)
 
     # Subquery: article ids that HAVE been accessed since the cutoff
@@ -862,8 +870,9 @@ defmodule Loopctl.Knowledge.Analytics do
         where: a.tenant_id == ^tenant_id,
         where: a.status == :published,
         where: a.id not in subquery(accessed_ids),
-        order_by: [asc: a.inserted_at],
+        order_by: [asc: a.inserted_at, asc: a.id],
         limit: ^limit,
+        offset: ^offset,
         select: %{
           article_id: a.id,
           title: a.title,

--- a/lib/loopctl_web/controllers/knowledge_analytics_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_analytics_controller.ex
@@ -39,7 +39,13 @@ defmodule LoopctlWeb.KnowledgeAnalyticsController do
       limit: [
         in: :query,
         type: :integer,
-        description: "Max rows to return (default 20, max 100)",
+        description: "Max rows per page (default 20, max 100). Clamped, never rejected.",
+        required: false
+      ],
+      offset: [
+        in: :query,
+        type: :integer,
+        description: "Rows to skip — page the ranking to completeness (default 0)",
         required: false
       ],
       since_days: [
@@ -85,6 +91,7 @@ defmodule LoopctlWeb.KnowledgeAnalyticsController do
     opts =
       []
       |> put_limit(params["limit"], 20, @max_limit)
+      |> put_offset(params["offset"])
       |> put_since(params["since_days"], 7)
       |> put_access_type(params["access_type"])
       |> put_project_id(params["project_id"])
@@ -241,7 +248,13 @@ defmodule LoopctlWeb.KnowledgeAnalyticsController do
       limit: [
         in: :query,
         type: :integer,
-        description: "Max rows to return (default 50, max 200)",
+        description: "Max rows per page (default 50, max 200). Clamped, never rejected.",
+        required: false
+      ],
+      offset: [
+        in: :query,
+        type: :integer,
+        description: "Rows to skip — page the full unused set to completeness (default 0)",
         required: false
       ]
     ],
@@ -261,6 +274,7 @@ defmodule LoopctlWeb.KnowledgeAnalyticsController do
       []
       |> put_int(:days_unused, params["days_unused"], 30, 1, 365)
       |> put_limit(params["limit"], 50, @max_unused_limit)
+      |> put_offset(params["offset"])
 
     rows = Knowledge.list_unused_articles(tenant_id, opts)
     json(conn, LoopctlWeb.KnowledgeAnalyticsJSON.unused_articles(rows, opts))
@@ -272,6 +286,13 @@ defmodule LoopctlWeb.KnowledgeAnalyticsController do
 
   defp put_limit(opts, value, default, max_value) do
     Keyword.put(opts, :limit, parse_int(value, default) |> max(1) |> min(max_value))
+  end
+
+  # Offset enables paging the ranking past the first page — never rejected, so a
+  # caller can enumerate to completeness (the rankings are access-count aggregates,
+  # not vector scans, so deep offset is cheap).
+  defp put_offset(opts, value) do
+    Keyword.put(opts, :offset, parse_int(value, 0) |> max(0))
   end
 
   defp put_since(opts, value, default_days) do

--- a/lib/loopctl_web/controllers/knowledge_analytics_json.ex
+++ b/lib/loopctl_web/controllers/knowledge_analytics_json.ex
@@ -22,6 +22,7 @@ defmodule LoopctlWeb.KnowledgeAnalyticsJSON do
       meta: %{
         count: length(rows),
         limit: Keyword.get(opts, :limit),
+        offset: Keyword.get(opts, :offset, 0),
         since: encode_dt(Keyword.get(opts, :since)),
         access_type: Keyword.get(opts, :access_type),
         project_id: Keyword.get(opts, :project_id),
@@ -124,7 +125,8 @@ defmodule LoopctlWeb.KnowledgeAnalyticsJSON do
       meta: %{
         count: length(rows),
         days_unused: Keyword.get(opts, :days_unused),
-        limit: Keyword.get(opts, :limit)
+        limit: Keyword.get(opts, :limit),
+        offset: Keyword.get(opts, :offset, 0)
       }
     }
   end

--- a/test/loopctl_web/controllers/knowledge_analytics_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_analytics_controller_test.exs
@@ -105,6 +105,35 @@ defmodule LoopctlWeb.KnowledgeAnalyticsControllerTest do
       [row] = body["data"]
       assert row["access_count"] == 1
     end
+
+    test "offset pages the ranking to completeness (no imposed top-N cap)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {orch_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+      {_raw, agent} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      a = fixture(:article, %{tenant_id: tenant.id, title: "AAA", status: :published})
+      b = fixture(:article, %{tenant_id: tenant.id, title: "BBB", status: :published})
+      c = fixture(:article, %{tenant_id: tenant.id, title: "CCC", status: :published})
+      for _ <- 1..3, do: Knowledge.record_access(tenant.id, a.id, agent.id, "get")
+      for _ <- 1..2, do: Knowledge.record_access(tenant.id, b.id, agent.id, "get")
+      Knowledge.record_access(tenant.id, c.id, agent.id, "get")
+
+      titles =
+        for off <- 0..2 do
+          body =
+            build_conn()
+            |> auth_conn(orch_key)
+            |> get(~p"/api/v1/knowledge/analytics/top-articles?limit=1&offset=#{off}")
+            |> json_response(200)
+
+          assert body["meta"]["offset"] == off
+          assert length(body["data"]) == 1
+          hd(body["data"])["title"]
+        end
+
+      # Each page returns the next-ranked article — the full ranking is reachable.
+      assert titles == ["AAA", "BBB", "CCC"]
+    end
   end
 
   describe "GET /api/v1/knowledge/articles/:id/stats" do
@@ -194,6 +223,32 @@ defmodule LoopctlWeb.KnowledgeAnalyticsControllerTest do
       assert "Unused" in titles
       refute "Used" in titles
       assert body["meta"]["days_unused"] == 7
+    end
+
+    test "offset pages the full unused set to completeness (no imposed cap)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {orch_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      # Three never-accessed published articles → all unused (ordered by inserted_at asc).
+      for n <- 1..3 do
+        fixture(:article, %{tenant_id: tenant.id, title: "Unused #{n}", status: :published})
+      end
+
+      seen =
+        for off <- 0..2 do
+          body =
+            build_conn()
+            |> auth_conn(orch_key)
+            |> get(~p"/api/v1/knowledge/analytics/unused-articles?limit=1&offset=#{off}")
+            |> json_response(200)
+
+          assert body["meta"]["offset"] == off
+          assert length(body["data"]) == 1
+          hd(body["data"])["article_id"]
+        end
+
+      # Three distinct articles across the three offset pages — all reachable.
+      assert length(Enum.uniq(seen)) == 3
     end
   end
 


### PR DESCRIPTION
Last of the 'no imposed limits' offenders: the analytics ranking endpoints capped at the top N (top-articles 100, unused-articles 200) with **no offset** to reach the rest.

## Change
- `list_top_articles` (all 3 `group_by` paths — article / project / agent) and `list_unused_articles` accept `:offset`. SQL paths add `offset` + a stable `id` tiebreaker; the in-memory agent path uses `Enum.drop/take`.
- These rankings are **access-count aggregates** (cheap btree), not vector scans — deep offset is safe, no Epic 27 scale concern.
- Controllers accept `offset` (clamped ≥ 0, never rejected); `meta` now reports `offset` so a client pages until a short page.

## Tests
`offset` walks the top-articles ranking (AAA→BBB→CCC across pages) and the unused set (3 distinct articles across 3 offset pages). Full suite **3010**, credo + dialyzer clean.

## Scope note
`agents/:id` and `projects/:id/usage` embed a top-articles *widget* inside a usage **summary object** (a dashboard, not an enumeration endpoint) — left bounded by design, consistent with leaving vector-ranked endpoints bounded.