### PR TITLE
feat(mcp): offset on analytics ranking tools (v2.24.0)

### DIFF
--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to `loopctl-mcp-server` are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 2.24.0 — 2026-06-30 (pagination: analytics rankings offset)
+
+### Added
+
+- `offset` on the analytics ranking tools, now that the server endpoints support
+  it — page the ranking past the first page:
+  - **`knowledge_analytics_top`** — `offset`
+  - **`knowledge_unused_articles`** — `offset`
+
+  (`knowledge_agent_usage` / project-usage are bounded summary widgets server-side,
+  not enumeration endpoints, so they intentionally take no `offset`.)
+
 ## 2.23.0 — 2026-06-30 (pagination: no imposed limits on list tools)
 
 ### Fixed

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -1097,9 +1097,10 @@ async function knowledgeIngestionJobs({ limit, offset, since_days } = {}) {
 
 // --- Knowledge Analytics Tools (orch key) ---
 
-async function knowledgeAnalyticsTop({ limit, since_days, access_type } = {}) {
+async function knowledgeAnalyticsTop({ limit, offset, since_days, access_type } = {}) {
   const params = new URLSearchParams();
   if (limit != null) params.set("limit", String(limit));
+  if (offset != null) params.set("offset", String(offset));
   if (since_days != null) params.set("since_days", String(since_days));
   if (access_type) params.set("access_type", access_type);
   const qs = params.toString();
@@ -1187,10 +1188,11 @@ async function knowledgeAgentUsage({ api_key_id, agent_id, limit, since_days } =
   return toContent(result);
 }
 
-async function knowledgeUnusedArticles({ days_unused, limit } = {}) {
+async function knowledgeUnusedArticles({ days_unused, limit, offset } = {}) {
   const params = new URLSearchParams();
   if (days_unused != null) params.set("days_unused", String(days_unused));
   if (limit != null) params.set("limit", String(limit));
+  if (offset != null) params.set("offset", String(offset));
   const qs = params.toString();
   const path = qs
     ? `/api/v1/knowledge/analytics/unused-articles?${qs}`
@@ -3102,9 +3104,14 @@ const TOOLS = [
       properties: {
         limit: {
           type: "integer",
-          description: "Max rows to return. Default 20, max 100.",
+          description: "Max rows per page. Default 20, max 100.",
           minimum: 1,
           maximum: 100,
+        },
+        offset: {
+          type: "integer",
+          description: "Rows to skip — page the ranking past the first page. Default 0.",
+          minimum: 0,
         },
         since_days: {
           type: "integer",
@@ -3188,9 +3195,14 @@ const TOOLS = [
         },
         limit: {
           type: "integer",
-          description: "Max rows to return. Default 50, max 200.",
+          description: "Max rows per page. Default 50, max 200.",
           minimum: 1,
           maximum: 200,
+        },
+        offset: {
+          type: "integer",
+          description: "Rows to skip — page the full unused set to completeness. Default 0.",
+          minimum: 0,
         },
       },
       required: [],

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.23.0",
+  "version": "2.24.0",
   "description": "MCP server for loopctl — structural trust for AI development loops",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
Completes the MCP side of 'no imposed limits'. Now that #214 added server-side `offset` to `/knowledge/analytics/top-articles` and `/unused-articles`, expose it on the matching MCP tools so an agent can page the ranking past the first page:
- `knowledge_analytics_top` → `offset`
- `knowledge_unused_articles` → `offset`

`knowledge_agent_usage` / project-usage embed a bounded top-list **summary widget** (not an enumeration endpoint), so they take no `offset` — matching the server's deliberate scoping.

`node --test`: 48 pass. **v2.24.0** auto-publishes to npm on merge.