### PR TITLE
feat(knowledge): MOC worker — per-domain navigation hubs

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -238,6 +238,7 @@ config :loopctl, Oban,
        {"0 3 * * *", Loopctl.Workers.WebhookCleanupWorker},
        {"0 3 * * 0", Loopctl.Workers.TokenDataArchivalWorker},
        {"0 4 * * *", Loopctl.Workers.KnowledgeLintWorker, args: %{"mode" => "all_tenants"}},
+       {"0 5 * * 0", Loopctl.Workers.KnowledgeMocWorker, args: %{"mode" => "all_tenants"}},
        {"*/5 * * * *", Loopctl.Workers.PendingEnrollmentCleanupWorker},
        {"* * * * *", Loopctl.Workers.ComputeSthWorker, args: %{"mode" => "all_tenants"}},
        {"* * * * *", Loopctl.Workers.RevokeExpiredDispatchesWorker}

--- a/config/test.exs
+++ b/config/test.exs
@@ -286,3 +286,6 @@ config :loopctl, :analytics_recording_mode, :sync
 # RLS: Switch to non-superuser role within transactions so RLS is enforced
 # The loopctl_app role must exist and have access to all tables.
 config :loopctl, :rls_role, "loopctl_app"
+
+# KnowledgeMocWorker: low tag threshold so tests need only a few tagged articles.
+config :loopctl, knowledge_moc_min_tag_count: 2

--- a/lib/loopctl/workers/knowledge_moc_worker.ex
+++ b/lib/loopctl/workers/knowledge_moc_worker.ex
@@ -1,0 +1,190 @@
+defmodule Loopctl.Workers.KnowledgeMocWorker do
+  @moduledoc """
+  Generates and maintains **Maps of Content** (MOCs) — per-domain index hubs that
+  let agents navigate the corpus by domain instead of brute-force search
+  (Karpathy llm-wiki rule #7: navigate by index at scale).
+
+  Design principle: the KB does only MECHANICAL work; intelligence lives at
+  consumption. So a MOC body is a deterministic, grouped, cross-linked index —
+  **no LLM narrative** (which the killed "session memory compiler" idea showed is
+  brittle without an eval loop). An agent reads the hub and `knowledge_get`s the
+  entries it needs; the smart synthesis happens in the consuming session.
+
+  ## What it does (per tenant)
+
+  1. `tag_facets/2` → tags carrying at least `:knowledge_moc_min_tag_count`
+     articles (the structural `hub`/`moc` tags excluded), top
+     `:knowledge_moc_max_tags` by count.
+  2. For each tag, upsert an `Index: <tag>` hub article:
+     - `idempotency_key: "moc:<tag>"` so re-runs UPDATE the same hub rather than
+       duplicating; the body is refreshed each run as the corpus grows.
+     - `category: reference`, `tags: ["hub", "moc", <tag>]`, published.
+     - body = the tag's published members grouped by category, each as
+       `title — <id>` (capped per category), other MOCs excluded.
+  3. Emit a `knowledge.moc_generated` audit event.
+
+  Scheduled weekly. Additive only (creates/refreshes hubs) — it never mutates
+  member articles, so there's no corruption risk.
+  """
+
+  use Oban.Worker,
+    queue: :knowledge,
+    max_attempts: 3,
+    unique: [fields: [:worker, :args], period: 300]
+
+  require Logger
+
+  import Ecto.Query
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Audit
+  alias Loopctl.Knowledge
+  alias Loopctl.Tenants.Tenant
+
+  @default_min_tag_count 25
+  @default_max_tags 50
+  @max_members 300
+  @max_per_category 40
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"mode" => "all_tenants"}}) do
+    from(t in Tenant, where: t.status == :active, select: t.id)
+    |> AdminRepo.all()
+    |> Enum.each(fn tenant_id ->
+      %{"tenant_id" => tenant_id} |> __MODULE__.new() |> Oban.insert()
+    end)
+
+    :ok
+  end
+
+  def perform(%Oban.Job{args: %{"tenant_id" => tenant_id}}) do
+    min_count =
+      Application.get_env(:loopctl, :knowledge_moc_min_tag_count, @default_min_tag_count)
+
+    max_tags = Application.get_env(:loopctl, :knowledge_moc_max_tags, @default_max_tags)
+
+    %{facets: facets} = Knowledge.tag_facets(tenant_id, limit: 1000)
+
+    tags =
+      facets
+      |> Enum.reject(fn %{tag: tag} -> tag in ["hub", "moc"] end)
+      |> Enum.filter(fn %{count: count} -> count >= min_count end)
+      |> Enum.sort_by(fn %{count: count} -> count end, :desc)
+      |> Enum.take(max_tags)
+
+    generated =
+      Enum.count(tags, fn %{tag: tag, count: count} ->
+        upsert_moc(tenant_id, tag, count) == :ok
+      end)
+
+    log_audit(tenant_id, generated, length(tags))
+
+    Logger.info(
+      "KnowledgeMocWorker: tenant=#{tenant_id} maintained #{generated}/#{length(tags)} MOC hubs"
+    )
+
+    :ok
+  end
+
+  # --- Private ---
+
+  defp upsert_moc(tenant_id, tag, count) do
+    members =
+      Knowledge.list_articles(tenant_id,
+        tags: [tag],
+        match: :any,
+        status: :published,
+        limit: @max_members
+      ).data
+      # Never list MOCs inside a MOC.
+      |> Enum.reject(fn a -> "moc" in (a.tags || []) end)
+
+    body = build_body(tag, count, members)
+    moc_tags = ["hub", "moc", tag]
+
+    attrs = %{
+      title: "Index: #{tag}",
+      body: body,
+      category: :reference,
+      status: :published,
+      tags: moc_tags,
+      idempotency_key: "moc:#{tag}"
+    }
+
+    # create_article ensures the hub exists; update then refreshes its body as
+    # the corpus grows. `status` is set on CREATE only — re-publishing an
+    # already-published article is a no-op the changeset rejects.
+    with {:ok, id} <- ensure_hub(tenant_id, attrs),
+         {:ok, _} <-
+           Knowledge.update_article(
+             tenant_id,
+             id,
+             %{body: body, tags: moc_tags},
+             actor_type: "system",
+             actor_label: "worker:knowledge_moc"
+           ) do
+      :ok
+    else
+      other ->
+        Logger.warning("KnowledgeMocWorker: upsert failed for tag=#{tag}: #{inspect(other)}")
+        :error
+    end
+  end
+
+  # create_article returns `{:ok, article}` on a fresh create and
+  # `{:ok, :deduplicated, article}` (or another reason tuple) when the
+  # idempotency_key already exists — normalize both to the hub id.
+  defp ensure_hub(tenant_id, attrs) do
+    case Knowledge.create_article(tenant_id, attrs) do
+      {:ok, %{id: id}} -> {:ok, id}
+      {:ok, _reason, %{id: id}} -> {:ok, id}
+      other -> other
+    end
+  end
+
+  defp build_body(tag, count, members) do
+    sections =
+      members
+      |> Enum.group_by(fn a -> to_string(a.category) end)
+      |> Enum.sort_by(fn {category, _} -> category end)
+      |> Enum.map_join("\n\n", &render_section/1)
+
+    """
+    # Index: #{tag}
+
+    Map of content for the **#{tag}** domain — #{count} articles, grouped by \
+    category. Auto-generated; fetch any entry with its id.
+
+    #{sections}
+    """
+  end
+
+  defp render_section({category, articles}) do
+    rows =
+      articles
+      |> Enum.sort_by(& &1.title)
+      |> Enum.take(@max_per_category)
+      |> Enum.map_join("\n", fn a -> "- #{a.title} — `#{a.id}`" end)
+
+    overflow =
+      if length(articles) > @max_per_category do
+        "\n- … +#{length(articles) - @max_per_category} more"
+      else
+        ""
+      end
+
+    "## #{category} (#{length(articles)})\n#{rows}#{overflow}"
+  end
+
+  defp log_audit(tenant_id, generated, qualifying) do
+    Audit.create_log_entry(tenant_id, %{
+      entity_type: "knowledge_moc",
+      entity_id: tenant_id,
+      action: "knowledge.moc_generated",
+      actor_type: "system",
+      actor_id: nil,
+      actor_label: "worker:knowledge_moc",
+      new_state: %{"generated" => generated, "qualifying_tags" => qualifying}
+    })
+  end
+end

--- a/test/loopctl/workers/knowledge_moc_worker_test.exs
+++ b/test/loopctl/workers/knowledge_moc_worker_test.exs
@@ -1,0 +1,144 @@
+defmodule Loopctl.Workers.KnowledgeMocWorkerTest do
+  use Loopctl.DataCase, async: true
+  use Oban.Testing, repo: Loopctl.Repo
+
+  setup :verify_on_exit!
+
+  import Ecto.Query
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Workers.KnowledgeMocWorker
+
+  # min_tag_count is 2 in config/test.exs.
+
+  defp published(tenant_id, title, tags, category \\ :pattern) do
+    fixture(:article, %{
+      tenant_id: tenant_id,
+      title: title,
+      body: "Body for #{title}.",
+      category: category,
+      tags: tags
+    })
+    |> Ecto.Changeset.change(%{status: :published})
+    |> AdminRepo.update!()
+  end
+
+  defp moc_hub(tenant_id, tag) do
+    from(a in Article,
+      where: a.tenant_id == ^tenant_id,
+      where: fragment("? = ?", a.idempotency_key, ^"moc:#{tag}")
+    )
+    |> AdminRepo.one()
+  end
+
+  defp run(tenant_id),
+    do: KnowledgeMocWorker.perform(%Oban.Job{args: %{"tenant_id" => tenant_id}})
+
+  describe "per-tenant MOC generation" do
+    test "builds an index hub for a tag at/above the threshold, grouped by category" do
+      tenant = fixture(:tenant)
+      published(tenant.id, "Supervisors 101", ["elixir"], :pattern)
+      published(tenant.id, "GenServer pitfalls", ["elixir"], :finding)
+      published(tenant.id, "Deploy steps", ["elixir"], :playbook)
+
+      assert :ok = run(tenant.id)
+
+      hub = moc_hub(tenant.id, "elixir")
+      assert hub
+      assert hub.title == "Index: elixir"
+      assert hub.category == :reference
+      assert hub.status == :published
+      assert "hub" in hub.tags and "moc" in hub.tags and "elixir" in hub.tags
+
+      # Mechanical, grouped-by-category body that lists the members.
+      assert hub.body =~ "Map of content for the **elixir**"
+      assert hub.body =~ "## pattern"
+      assert hub.body =~ "## finding"
+      assert hub.body =~ "## playbook"
+      assert hub.body =~ "Supervisors 101"
+      assert hub.body =~ "GenServer pitfalls"
+    end
+
+    test "does not build a MOC for a tag below the threshold" do
+      tenant = fixture(:tenant)
+      published(tenant.id, "Lonely note", ["rare-tag"], :pattern)
+
+      assert :ok = run(tenant.id)
+      refute moc_hub(tenant.id, "rare-tag")
+    end
+
+    test "is idempotent and refreshes the body — re-run updates, never duplicates" do
+      tenant = fixture(:tenant)
+      published(tenant.id, "First", ["topic"])
+      published(tenant.id, "Second", ["topic"])
+
+      assert :ok = run(tenant.id)
+      hub1 = moc_hub(tenant.id, "topic")
+      refute hub1.body =~ "Third"
+
+      # Corpus grows, then re-run.
+      published(tenant.id, "Third", ["topic"])
+      assert :ok = run(tenant.id)
+
+      # Same hub (no duplicate), body now includes the new member.
+      count =
+        from(a in Article,
+          where: a.tenant_id == ^tenant.id,
+          where: fragment("? = ?", a.idempotency_key, ^"moc:topic")
+        )
+        |> AdminRepo.aggregate(:count)
+
+      assert count == 1
+      hub2 = moc_hub(tenant.id, "topic")
+      assert hub2.id == hub1.id
+      assert hub2.body =~ "Third"
+    end
+
+    test "does not list MOC hubs inside other MOCs" do
+      tenant = fixture(:tenant)
+      published(tenant.id, "A", ["topic"])
+      published(tenant.id, "B", ["topic"])
+      assert :ok = run(tenant.id)
+
+      # The hub carries the "topic" tag, so a naive re-run could list itself.
+      assert :ok = run(tenant.id)
+      hub = moc_hub(tenant.id, "topic")
+      refute hub.body =~ "Index: topic\n- "
+      refute hub.body =~ "Index: topic — `"
+    end
+  end
+
+  describe "all_tenants fan-out" do
+    test "generates MOCs for each active tenant, skipping suspended" do
+      active = fixture(:tenant)
+      suspended = fixture(:tenant, %{status: :suspended})
+      published(active.id, "X", ["shared"])
+      published(active.id, "Y", ["shared"])
+      published(suspended.id, "Z1", ["shared"])
+      published(suspended.id, "Z2", ["shared"])
+
+      assert :ok = KnowledgeMocWorker.perform(%Oban.Job{args: %{"mode" => "all_tenants"}})
+
+      assert moc_hub(active.id, "shared")
+      refute moc_hub(suspended.id, "shared")
+    end
+  end
+
+  describe "tenant isolation" do
+    test "a MOC only indexes the caller tenant's articles" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      published(tenant_a.id, "A-only", ["dom"])
+      published(tenant_a.id, "A-two", ["dom"])
+      published(tenant_b.id, "B-secret", ["dom"])
+
+      assert :ok = run(tenant_a.id)
+
+      hub = moc_hub(tenant_a.id, "dom")
+      assert hub.body =~ "A-only"
+      refute hub.body =~ "B-secret"
+      refute moc_hub(tenant_b.id, "dom")
+    end
+  end
+end


### PR DESCRIPTION
**Program piece toward an agents' KB (#5: navigate by index at 77k scale, Karpathy llm-wiki rule #7).**

Maps of Content: per-tag `Index: <tag>` hubs so an agent navigates by domain instead of brute-force search.

Per the **intelligence-at-consumption** principle, the hub body is **mechanical** — the tag's published members grouped by category, each `title — <id>`, **no LLM narrative** (which the killed 'session memory compiler' idea showed is brittle without an eval loop). The agent reads the hub and `knowledge_get`s what it needs; synthesis happens in the consuming session.

## What
- `KnowledgeMocWorker` (`:knowledge` queue): `all_tenants` fan-out → per tenant, `tag_facets` → tags ≥ `:knowledge_moc_min_tag_count` (default 25, top 50; structural `hub`/`moc` tags excluded) → upsert an `Index: <tag>` hub.
- Upsert via `idempotency_key: moc:<tag>` (re-runs **update**, never duplicate) + refresh body as the corpus grows. Handles both `{:ok, article}` and `{:ok, :deduplicated, article}` return shapes. Other MOCs excluded from members.
- **Additive only** — never mutates member articles, zero corruption risk. Scheduled **weekly** (`0 5 * * 0`). Emits `knowledge.moc_generated` audit.

## Tests
Grouped hub for a qualifying tag, sub-threshold skip, **idempotent + refresh on re-run** (the `{:ok,:deduplicated}` path), MOCs-excluded-from-MOCs, `all_tenants` (skips suspended), tenant isolation. Full suite **3016**, credo + dialyzer clean.

Next in the program: **#1 novelty-gated write-back** (the differentiator), then #4 route-the-findings, #3 retrieval metric, #2 ripple (parked).