### PR TITLE
fix(knowledge): MOC worker indexes topical tags only (exclude structural/provenance)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -283,6 +283,11 @@ config :loopctl,
   knowledge_lint_orphan_link_threshold: 0.5,
   knowledge_lint_max_orphan_relink: 500
 
+# KnowledgeMocWorker: corpus-specific tags to exclude from Map-of-Content
+# generation (on top of the worker's generic structural/format/provenance list).
+# These are source COLLECTIONS, not topics, so a per-tag MOC for them is noise.
+config :loopctl, :knowledge_moc_excluded_tags, ~w(synology-docs synology-netbackup)
+
 # DI: WebAuthn adapter — defaults to Wax (overridden in test env)
 config :loopctl, :webauthn_adapter, Loopctl.WebAuthn.Wax
 

--- a/lib/loopctl/workers/knowledge_moc_worker.ex
+++ b/lib/loopctl/workers/knowledge_moc_worker.ex
@@ -46,6 +46,20 @@ defmodule Loopctl.Workers.KnowledgeMocWorker do
   @max_members 300
   @max_per_category 40
 
+  # MOCs index TOPICAL domains. The highest-count tags are usually structural —
+  # format/source-type descriptors (`pdf`, `document`, `youtube`, …) that say how
+  # an article arrived, not what it's about — so a MOC for them is useless noise.
+  # Exclude them, plus the per-source provenance-id tags (`yt-…`, `doc-…`, …).
+  # Corpus-specific source collections are added via `:knowledge_moc_excluded_tags`.
+  @structural_tags ~w(
+    hub moc reference document documents doc book books code repo repository
+    web web-article webpage url file pdf md markdown html htm xml docx txt text
+    epub csv json yaml image png jpg jpeg gif svg video audio youtube newsletter
+    manual agent session_log session-log skill ingestion review_finding review-finding
+  )
+
+  @excluded_prefixes ~w(yt- doc- repo- url- book- img- file- vid- web- chunk-)
+
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"mode" => "all_tenants"}}) do
     from(t in Tenant, where: t.status == :active, select: t.id)
@@ -63,12 +77,17 @@ defmodule Loopctl.Workers.KnowledgeMocWorker do
 
     max_tags = Application.get_env(:loopctl, :knowledge_moc_max_tags, @default_max_tags)
 
-    %{facets: facets} = Knowledge.tag_facets(tenant_id, limit: 1000)
+    excluded =
+      (@structural_tags ++ Application.get_env(:loopctl, :knowledge_moc_excluded_tags, []))
+      |> MapSet.new()
+
+    %{facets: facets} = Knowledge.tag_facets(tenant_id, limit: 2000)
 
     tags =
       facets
-      |> Enum.reject(fn %{tag: tag} -> tag in ["hub", "moc"] end)
-      |> Enum.filter(fn %{count: count} -> count >= min_count end)
+      |> Enum.filter(fn %{tag: tag, count: count} ->
+        count >= min_count and topical_tag?(tag, excluded)
+      end)
       |> Enum.sort_by(fn %{count: count} -> count end, :desc)
       |> Enum.take(max_tags)
 
@@ -87,6 +106,13 @@ defmodule Loopctl.Workers.KnowledgeMocWorker do
   end
 
   # --- Private ---
+
+  # A tag earns a MOC only if it's neither a structural/format/source tag nor a
+  # per-source provenance id (`yt-…`, `doc-…`, …) — i.e. it names a topic.
+  defp topical_tag?(tag, excluded) do
+    not MapSet.member?(excluded, tag) and
+      not Enum.any?(@excluded_prefixes, &String.starts_with?(tag, &1))
+  end
 
   defp upsert_moc(tenant_id, tag, count) do
     members =

--- a/test/loopctl/workers/knowledge_moc_worker_test.exs
+++ b/test/loopctl/workers/knowledge_moc_worker_test.exs
@@ -107,6 +107,24 @@ defmodule Loopctl.Workers.KnowledgeMocWorkerTest do
       refute hub.body =~ "Index: topic\n- "
       refute hub.body =~ "Index: topic — `"
     end
+
+    test "indexes only topical tags — excludes structural/format and provenance-prefix tags" do
+      tenant = fixture(:tenant)
+
+      for n <- 1..3 do
+        published(tenant.id, "Doc #{n}", ["pdf"])
+        published(tenant.id, "Vid #{n}", ["yt-abc123"])
+        published(tenant.id, "Rust #{n}", ["rust"])
+      end
+
+      assert :ok = run(tenant.id)
+
+      # `pdf` (structural) and `yt-abc123` (per-source provenance) get no MOC...
+      refute moc_hub(tenant.id, "pdf")
+      refute moc_hub(tenant.id, "yt-abc123")
+      # ...but a genuine topic does.
+      assert moc_hub(tenant.id, "rust")
+    end
   end
 
   describe "all_tenants fan-out" do


### PR DESCRIPTION
## What

The KnowledgeMocWorker (agents' KB #5, merged in #216) builds per-tag Map-of-Content hubs for the highest-count tags. Prod verification on the live 77k-article corpus revealed those top tags are **structural**, not topical:

| tag | count | kind |
|---|---|---|
| reference | 58k | category/format |
| document | 39k | source-type |
| pdf | 23k | format |
| book | 21k | source-type |
| synology-docs | 14k | source collection |
| youtube | 13k | source-type |
| newsletter | 9k | source-type |
| md | 6k | format |
| **elixir** | **11k** | **topic** |
| **programming** | **8k** | **topic** |

As merged, the weekly cron would have generated ~50 junk hubs (`Index: pdf` over 23k members) while the genuinely useful domain hubs (`elixir`, `programming`, `rust`, ...) got buried.

## Fix

A tag earns a MOC only if `topical_tag?/2` — neither a structural/format/source descriptor nor a per-source provenance id. Excluded:

- **generic structural denylist** (`@structural_tags`): format + source-type + the `source_type` values + the KB's own `hub`/`moc`/`reference` tags;
- **per-source provenance prefixes** (`@excluded_prefixes`): `yt-`, `doc-`, `repo-`, `url-`, `book-`, `img-`, `file-`, `vid-`, `web-`, `chunk-`;
- **corpus-specific source COLLECTIONS** via new `:knowledge_moc_excluded_tags` config (`synology-docs`, `synology-netbackup`) — extendable per deployment, not hardcoded in the worker.

So MOCs index genuine domains and skip the descriptors of how an article arrived.

## Test

New case: with `pdf` (structural), `yt-abc123` (provenance), and `rust` (topic) all above threshold → only `rust` gets a hub.

Full gate green locally: format, credo --strict, dialyzer, `3017 tests, 0 failures`.
