### PR TITLE
fix(knowledge): MOC — exclude residual structural/provenance tags found on prod

### DIFF
--- a/lib/loopctl/workers/knowledge_moc_worker.ex
+++ b/lib/loopctl/workers/knowledge_moc_worker.ex
@@ -56,9 +56,14 @@ defmodule Loopctl.Workers.KnowledgeMocWorker do
     web web-article webpage url file pdf md markdown html htm xml docx txt text
     epub csv json yaml image png jpg jpeg gif svg video audio youtube newsletter
     manual agent session_log session-log skill ingestion review_finding review-finding
+    readme gdrive gdoc gsheet onedrive dropbox notion confluence chunk page
   )
 
-  @excluded_prefixes ~w(yt- doc- repo- url- book- img- file- vid- web- chunk-)
+  # Provenance-id and chunk-coordinate prefixes (`yt-<id>`, `pp-1-12` = pages 1–12,
+  # `chunk-7`, …) — these identify WHERE in a source an article came from, never a
+  # topic. Kept to concrete observed patterns: a broad `p-` would wrongly drop real
+  # hyphenated topics (`p-value`, …).
+  @excluded_prefixes ~w(yt- doc- repo- url- book- img- file- vid- web- chunk- pp-)
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"mode" => "all_tenants"}}) do

--- a/test/loopctl/workers/knowledge_moc_worker_test.exs
+++ b/test/loopctl/workers/knowledge_moc_worker_test.exs
@@ -113,15 +113,20 @@ defmodule Loopctl.Workers.KnowledgeMocWorkerTest do
 
       for n <- 1..3 do
         published(tenant.id, "Doc #{n}", ["pdf"])
+        published(tenant.id, "Readme #{n}", ["readme"])
         published(tenant.id, "Vid #{n}", ["yt-abc123"])
+        published(tenant.id, "Pages #{n}", ["pp-1-12"])
         published(tenant.id, "Rust #{n}", ["rust"])
       end
 
       assert :ok = run(tenant.id)
 
-      # `pdf` (structural) and `yt-abc123` (per-source provenance) get no MOC...
+      # Structural/format tags get no MOC...
       refute moc_hub(tenant.id, "pdf")
+      refute moc_hub(tenant.id, "readme")
+      # ...nor do per-source provenance / chunk-coordinate tags...
       refute moc_hub(tenant.id, "yt-abc123")
+      refute moc_hub(tenant.id, "pp-1-12")
       # ...but a genuine topic does.
       assert moc_hub(tenant.id, "rust")
     end


### PR DESCRIPTION
Post-deploy verification of #217 against the live 77k corpus confirmed structural tags (reference/pdf/document/book/youtube/synology-*) are now excluded and topical domains win (elixir, programming, architecture, phoenix, testing, ...).

But three residual non-topical tags still made the SELECTED set:

| tag | why it's not a topic |
|---|---|
| `pp-1-12` | page-range provenance fragment ('pages 1-12') |
| `gdrive` | a source SYSTEM, like `synology-docs` |
| `readme` | a file type |

Same defect class as #217. Tightened:
- `@structural_tags` += `readme gdrive gdoc gsheet onedrive dropbox notion confluence chunk page`
- `@excluded_prefixes` += `pp-` (page-range chunks). Deliberately **not** a broad `p-` — that would wrongly drop real hyphenated topics (`p-value`, ...).

Test extended: `readme` + `pp-1-12` get no MOC; a topic still does. Full gate green locally (3017 tests, 0 failures).