### PR TITLE
fix(knowledge): MOC — exclude machine-derived slug tags (bylines, title-slugs, URL domains)

### DIFF
--- a/lib/loopctl/workers/knowledge_moc_worker.ex
+++ b/lib/loopctl/workers/knowledge_moc_worker.ex
@@ -46,6 +46,18 @@ defmodule Loopctl.Workers.KnowledgeMocWorker do
   @max_members 300
   @max_per_category 40
 
+  # A curated topic tag is short (`elixir`, `api-design`, `separation-of-concerns`).
+  # Machine-derived tags — author bylines (`chris-mccord-bruce-tate-jos-valim`),
+  # company names (`datavideo-technologies-co-ltd`), truncated title-slugs
+  # (`2222-location-reporting-sometimes-goes-w`) — run long. Verified against the
+  # live corpus: every tag with more than this many hyphen-segments was junk.
+  @default_max_segments 3
+
+  # URL/domain-shaped tags (`medium-com`, `elixir-lang-org`, `www-erlang-solutions-com`)
+  # name a SOURCE, not a topic — same noise class as `gdrive`. Detected by a
+  # `www-` prefix (below) or a trailing TLD segment.
+  @url_suffixes ~w(com org net edu gov)
+
   # MOCs index TOPICAL domains. The highest-count tags are usually structural —
   # format/source-type descriptors (`pdf`, `document`, `youtube`, …) that say how
   # an article arrived, not what it's about — so a MOC for them is useless noise.
@@ -63,7 +75,7 @@ defmodule Loopctl.Workers.KnowledgeMocWorker do
   # `chunk-7`, …) — these identify WHERE in a source an article came from, never a
   # topic. Kept to concrete observed patterns: a broad `p-` would wrongly drop real
   # hyphenated topics (`p-value`, …).
-  @excluded_prefixes ~w(yt- doc- repo- url- book- img- file- vid- web- chunk- pp-)
+  @excluded_prefixes ~w(yt- doc- repo- url- book- img- file- vid- web- chunk- pp- www-)
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"mode" => "all_tenants"}}) do
@@ -86,12 +98,15 @@ defmodule Loopctl.Workers.KnowledgeMocWorker do
       (@structural_tags ++ Application.get_env(:loopctl, :knowledge_moc_excluded_tags, []))
       |> MapSet.new()
 
+    max_segments =
+      Application.get_env(:loopctl, :knowledge_moc_max_tag_segments, @default_max_segments)
+
     %{facets: facets} = Knowledge.tag_facets(tenant_id, limit: 2000)
 
     tags =
       facets
       |> Enum.filter(fn %{tag: tag, count: count} ->
-        count >= min_count and topical_tag?(tag, excluded)
+        count >= min_count and topical_tag?(tag, excluded, max_segments)
       end)
       |> Enum.sort_by(fn %{count: count} -> count end, :desc)
       |> Enum.take(max_tags)
@@ -112,11 +127,17 @@ defmodule Loopctl.Workers.KnowledgeMocWorker do
 
   # --- Private ---
 
-  # A tag earns a MOC only if it's neither a structural/format/source tag nor a
-  # per-source provenance id (`yt-…`, `doc-…`, …) — i.e. it names a topic.
-  defp topical_tag?(tag, excluded) do
+  # A tag earns a MOC only if it names a topic: not a structural/format/source tag,
+  # not a per-source provenance id (`yt-…`, `doc-…`, …), and not a machine-derived
+  # slug — an over-long hyphenated string (author lists, title slugs) or a
+  # URL/domain-shaped tag (`medium-com`).
+  defp topical_tag?(tag, excluded, max_segments) do
+    segments = String.split(tag, "-")
+
     not MapSet.member?(excluded, tag) and
-      not Enum.any?(@excluded_prefixes, &String.starts_with?(tag, &1))
+      not Enum.any?(@excluded_prefixes, &String.starts_with?(tag, &1)) and
+      length(segments) <= max_segments and
+      List.last(segments) not in @url_suffixes
   end
 
   defp upsert_moc(tenant_id, tag, count) do

--- a/test/loopctl/workers/knowledge_moc_worker_test.exs
+++ b/test/loopctl/workers/knowledge_moc_worker_test.exs
@@ -116,7 +116,10 @@ defmodule Loopctl.Workers.KnowledgeMocWorkerTest do
         published(tenant.id, "Readme #{n}", ["readme"])
         published(tenant.id, "Vid #{n}", ["yt-abc123"])
         published(tenant.id, "Pages #{n}", ["pp-1-12"])
+        published(tenant.id, "Byline #{n}", ["chris-mccord-bruce-tate-jos-valim"])
+        published(tenant.id, "Source #{n}", ["medium-com"])
         published(tenant.id, "Rust #{n}", ["rust"])
+        published(tenant.id, "SoC #{n}", ["separation-of-concerns"])
       end
 
       assert :ok = run(tenant.id)
@@ -124,11 +127,15 @@ defmodule Loopctl.Workers.KnowledgeMocWorkerTest do
       # Structural/format tags get no MOC...
       refute moc_hub(tenant.id, "pdf")
       refute moc_hub(tenant.id, "readme")
-      # ...nor do per-source provenance / chunk-coordinate tags...
+      # ...nor per-source provenance / chunk-coordinate tags...
       refute moc_hub(tenant.id, "yt-abc123")
       refute moc_hub(tenant.id, "pp-1-12")
-      # ...but a genuine topic does.
+      # ...nor machine-derived slugs: over-long bylines or URL/domain-shaped tags...
+      refute moc_hub(tenant.id, "chris-mccord-bruce-tate-jos-valim")
+      refute moc_hub(tenant.id, "medium-com")
+      # ...but genuine topics do, including a legit 3-segment one.
       assert moc_hub(tenant.id, "rust")
+      assert moc_hub(tenant.id, "separation-of-concerns")
     end
   end
 


### PR DESCRIPTION
## What

Third and final tightening of the MOC tag selector. After #217 (structural) and #218 (residual structural/provenance), a prod-corpus check of the **hyphen-segment distribution** revealed two more junk classes still being selected as "topics":

| band | count | verdict |
|---|---|---|
| ≥4 hyphen-segments | 27 tags | **100% junk** — author lists (`andrea-leopardi-jeffrey-matthias`), companies (`datavideo-technologies-co-ltd`), title-slugs (`2222-location-reporting-sometimes-goes-w`) |
| URL/domain-shaped | — | `medium-com`, `elixir-lang-org`, `www-erlang-solutions-com` — a **source**, not a topic (same class as `gdrive`) |
| legit short topics | — | `elixir`, `api-design`, `separation-of-concerns` (≤3 segs, no TLD) — kept |

## Fix — two structural rules (generative cause, not a denylist)

- Exclude tags with more than `:knowledge_moc_max_tag_segments` hyphen-segments (default **3**).
- Exclude URL/domain shape: `www-` prefix or a trailing TLD segment (`com`/`org`/`net`/`edu`/`gov`).

## Deliberately conservative

- `max_segments` stays at **3** so real 3-word concepts (`separation-of-concerns`, `go-to-market`) survive.
- Left `-io`/`-co` out of the TLD list — they collide with `socket-io` and real words.
- 3-segment author bylines (`bruce-a-tate`) are a residual long tail: catching personal names needs NER, which is **consumption-side intelligence, not mechanical KB work** (per the KB's design principle). Not in scope for the worker.

Test: byline (`chris-mccord-bruce-tate-jos-valim`) + `medium-com` get no MOC; `rust` + `separation-of-concerns` do. Full gate green locally (format, credo, dialyzer, 3017 tests).
