### PR TITLE
fix(knowledge): MOC — exclude non-topical sentinel tags (unknown, untagged, misc)

### DIFF
--- a/lib/loopctl/workers/knowledge_moc_worker.ex
+++ b/lib/loopctl/workers/knowledge_moc_worker.ex
@@ -61,7 +61,8 @@ defmodule Loopctl.Workers.KnowledgeMocWorker do
   # MOCs index TOPICAL domains. The highest-count tags are usually structural —
   # format/source-type descriptors (`pdf`, `document`, `youtube`, …) that say how
   # an article arrived, not what it's about — so a MOC for them is useless noise.
-  # Exclude them, plus the per-source provenance-id tags (`yt-…`, `doc-…`, …).
+  # Exclude them, plus the per-source provenance-id tags (`yt-…`, `doc-…`, …) and
+  # non-topical sentinels (`unknown`, `untagged`, `misc`, …).
   # Corpus-specific source collections are added via `:knowledge_moc_excluded_tags`.
   @structural_tags ~w(
     hub moc reference document documents doc book books code repo repository
@@ -69,6 +70,7 @@ defmodule Loopctl.Workers.KnowledgeMocWorker do
     epub csv json yaml image png jpg jpeg gif svg video audio youtube newsletter
     manual agent session_log session-log skill ingestion review_finding review-finding
     readme gdrive gdoc gsheet onedrive dropbox notion confluence chunk page
+    unknown untagged uncategorized misc miscellaneous general other none na tbd todo
   )
 
   # Provenance-id and chunk-coordinate prefixes (`yt-<id>`, `pp-1-12` = pages 1–12,

--- a/test/loopctl/workers/knowledge_moc_worker_test.exs
+++ b/test/loopctl/workers/knowledge_moc_worker_test.exs
@@ -118,6 +118,7 @@ defmodule Loopctl.Workers.KnowledgeMocWorkerTest do
         published(tenant.id, "Pages #{n}", ["pp-1-12"])
         published(tenant.id, "Byline #{n}", ["chris-mccord-bruce-tate-jos-valim"])
         published(tenant.id, "Source #{n}", ["medium-com"])
+        published(tenant.id, "Sentinel #{n}", ["unknown"])
         published(tenant.id, "Rust #{n}", ["rust"])
         published(tenant.id, "SoC #{n}", ["separation-of-concerns"])
       end
@@ -133,6 +134,8 @@ defmodule Loopctl.Workers.KnowledgeMocWorkerTest do
       # ...nor machine-derived slugs: over-long bylines or URL/domain-shaped tags...
       refute moc_hub(tenant.id, "chris-mccord-bruce-tate-jos-valim")
       refute moc_hub(tenant.id, "medium-com")
+      # ...nor non-topical sentinels...
+      refute moc_hub(tenant.id, "unknown")
       # ...but genuine topics do, including a legit 3-segment one.
       assert moc_hub(tenant.id, "rust")
       assert moc_hub(tenant.id, "separation-of-concerns")


### PR DESCRIPTION
Final prod-corpus check after #219: the top-25 selected MOC tags are now clean topical domains (`elixir`, `programming`, `architecture`, `phoenix`, `ecto`, `erlang`, `security`, `debugging`, ...) — bylines, title-slugs, and URL domains all gone.

One sentinel remained: `unknown:1131`, a placeholder for *uncategorized* articles, not a topic. Added the catch-all sentinel set (`unknown`/`untagged`/`uncategorized`/`misc`/`miscellaneous`/`general`/`other`/`none`/`na`/`tbd`/`todo`) to the structural denylist.

Test asserts `unknown` gets no MOC. Full gate green locally (3017 tests, 0 failures).

Closes the MOC tag-quality work (#217 → #218 → #219 → this).