### PR TITLE
fix(knowledge): MOC — detect member hubs by "hub" tag, not "moc" (Market-On-Close collision)

### DIFF
--- a/lib/loopctl/workers/knowledge_moc_worker.ex
+++ b/lib/loopctl/workers/knowledge_moc_worker.ex
@@ -150,8 +150,11 @@ defmodule Loopctl.Workers.KnowledgeMocWorker do
         status: :published,
         limit: @max_members
       ).data
-      # Never list MOCs inside a MOC.
-      |> Enum.reject(fn a -> "moc" in (a.tags || []) end)
+      # Never list MOC hubs inside a MOC. Detect a hub by its `"hub"` marker tag,
+      # NOT by `"moc"` — `moc` is also a legit content tag (Market-On-Close in
+      # trading), and keying on it would wrongly drop those articles from their
+      # real topic hub.
+      |> Enum.reject(fn a -> "hub" in (a.tags || []) end)
 
     body = build_body(tag, count, members)
     moc_tags = ["hub", "moc", tag]

--- a/test/loopctl/workers/knowledge_moc_worker_test.exs
+++ b/test/loopctl/workers/knowledge_moc_worker_test.exs
@@ -108,6 +108,21 @@ defmodule Loopctl.Workers.KnowledgeMocWorkerTest do
       refute hub.body =~ "Index: topic — `"
     end
 
+    test "lists a content article tagged \"moc\" (Market-On-Close) in its topic hub" do
+      tenant = fixture(:tenant)
+      # `moc` is also a legit content tag — hub detection must key on "hub", not "moc",
+      # or these trading articles would be dropped from their real topic hub.
+      published(tenant.id, "MOC exit strategy", ["trading", "moc"])
+      published(tenant.id, "Ichimoku entry", ["trading"])
+
+      assert :ok = run(tenant.id)
+
+      hub = moc_hub(tenant.id, "trading")
+      assert hub
+      assert hub.body =~ "MOC exit strategy"
+      assert hub.body =~ "Ichimoku entry"
+    end
+
     test "indexes only topical tags — excludes structural/format and provenance-prefix tags" do
       tenant = fixture(:tenant)
 


### PR DESCRIPTION
Prod end-to-end run of the worker surfaced this: `upsert_moc/3` rejected member articles tagged `moc` to avoid listing hubs-inside-hubs — but `moc` is also a legit **content** tag (Market-On-Close in trading; e.g. *'5-Minute Ichimoku Cloud Bull Bar Entry with MOC Exit'*). Keying hub-detection on `moc` wrongly drops those trading articles from their real topic hub.

Real hubs always carry the `hub` marker tag, so detect by that instead. Self-reference guard still holds (hubs have `hub`).

Regression test added (`moc`-tagged content article appears in its topic hub). Full gate green (3018 tests, 0 failures).