### PR TITLE
feat(knowledge): conflict resolution — agent annotates, nightly executor applies (agents' KB #4)

### DIFF
--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -52,6 +52,7 @@ defmodule Loopctl.Knowledge do
   alias Loopctl.Knowledge.Analytics
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.ArticleLink
+  alias Loopctl.Knowledge.ConflictResolution
   alias Loopctl.Knowledge.VectorSearch
   alias Loopctl.Projects.Project
   alias Loopctl.Webhooks.EventGenerator
@@ -607,6 +608,7 @@ defmodule Loopctl.Knowledge do
               incoming_links: :source_article
             )
             |> filter_visible_links(vis)
+            |> drop_resolved_conflict_links(tenant_id)
 
           Analytics.record_access(
             tenant_id,
@@ -652,6 +654,49 @@ defmodule Loopctl.Knowledge do
 
   defp link_side_visible?(%Article{} = far_side, vis), do: visible_to_caller?(far_side, vis)
   defp link_side_visible?(_not_loaded, _vis), do: false
+
+  # Route-the-findings (#4): a `:potential_conflict` link whose pair already has a
+  # resolution (dismissed/superseded/etc.) is no longer an OPEN conflict — drop it from
+  # the surfaced links so `article_data_with_links`' `potential_conflicts` field shows
+  # only conflicts still awaiting a decision. Other link types are untouched.
+  defp drop_resolved_conflict_links(article, tenant_id) do
+    peers =
+      (article.outgoing_links ++ article.incoming_links)
+      |> Enum.filter(&(&1.relationship_type == :potential_conflict))
+      |> Enum.flat_map(&[&1.source_article_id, &1.target_article_id])
+      |> Enum.uniq()
+
+    resolved = resolved_peer_ids(tenant_id, article.id, peers)
+
+    %{
+      article
+      | outgoing_links: reject_resolved(article.outgoing_links, article.id, resolved),
+        incoming_links: reject_resolved(article.incoming_links, article.id, resolved)
+    }
+  end
+
+  defp resolved_peer_ids(_tenant_id, _article_id, []), do: MapSet.new()
+
+  defp resolved_peer_ids(tenant_id, article_id, _peers) do
+    from(r in ConflictResolution,
+      where: r.tenant_id == ^tenant_id,
+      where: r.source_article_id == ^article_id or r.target_article_id == ^article_id,
+      select: {r.source_article_id, r.target_article_id}
+    )
+    |> AdminRepo.all()
+    |> Enum.flat_map(fn {s, t} -> [s, t] end)
+    |> Enum.reject(&(&1 == article_id))
+    |> MapSet.new()
+  end
+
+  defp reject_resolved(links, article_id, resolved) do
+    Enum.reject(links, fn l ->
+      l.relationship_type == :potential_conflict and
+        (MapSet.member?(resolved, l.source_article_id) or
+           MapSet.member?(resolved, l.target_article_id)) and
+        (l.source_article_id == article_id or l.target_article_id == article_id)
+    end)
+  end
 
   # Extracts the attribution context map from the caller's opts. Returns
   # an empty map when neither `:project_id` nor `:story_id` was provided.
@@ -3180,10 +3225,24 @@ defmodule Loopctl.Knowledge do
     limit = opts |> Keyword.get(:limit, 50) |> max(1) |> min(@max_page_size)
     offset = opts |> Keyword.get(:offset, 0) |> max(0)
 
+    # The queue shows OPEN conflicts only — a pair a retrieving agent has already
+    # ruled on (a `conflict_resolutions` row, either direction) drops out.
     base =
       from(l in ArticleLink,
+        as: :link,
         where: l.tenant_id == ^tenant_id,
-        where: l.relationship_type == :potential_conflict
+        where: l.relationship_type == :potential_conflict,
+        where:
+          not exists(
+            from(r in ConflictResolution,
+              where:
+                r.tenant_id == parent_as(:link).tenant_id and
+                  ((r.source_article_id == parent_as(:link).source_article_id and
+                      r.target_article_id == parent_as(:link).target_article_id) or
+                     (r.source_article_id == parent_as(:link).target_article_id and
+                        r.target_article_id == parent_as(:link).source_article_id))
+            )
+          )
       )
 
     total_count = AdminRepo.aggregate(base, :count, :id)
@@ -3215,6 +3274,144 @@ defmodule Loopctl.Knowledge do
       end)
 
     %{data: data, meta: %{limit: limit, offset: offset, total_count: total_count}}
+  end
+
+  @doc """
+  Record a retrieving agent's VERDICT on a potential-conflict pair (route-the-findings
+  #4). The agent judges with live context; the KB never re-judges. Non-destructive: this
+  writes only a `conflict_resolutions` row (last-write-wins per pair), so it's safe at
+  agent role.
+
+  Dispositions:
+
+    * `:dismiss` — a false positive (the two don't actually conflict). Takes effect
+      immediately: the pair drops out of the conflict queue and the nightly sweep won't
+      re-surface it.
+    * `:supersede` — one article wins; the loser should be retired. Requires
+      `authoritative_article_id` (the winner, one of the pair). Applied by the nightly
+      executor when `confidence: :high` — it creates a `supersedes` link and transitions
+      the loser to `:superseded` (reversible + audited).
+    * `:merge` — recorded for the later LLM-synthesis step; not executed here.
+
+  `attrs`: `source_article_id`, `target_article_id` (any order), `disposition`, and
+  optionally `authoritative_article_id`, `classification`, `evidence`, `confidence`
+  (default `:medium`). Returns `{:ok, %ConflictResolution{}}` or `{:error, changeset}`.
+  """
+  @spec annotate_conflict(Ecto.UUID.t(), map(), keyword()) ::
+          {:ok, ConflictResolution.t()} | {:error, Ecto.Changeset.t()}
+  def annotate_conflict(tenant_id, attrs, opts \\ []) do
+    get = fn key -> attrs[key] || attrs[to_string(key)] end
+    {src, tgt} = canonical_pair(get.(:source_article_id), get.(:target_article_id))
+    disposition = get.(:disposition)
+    now = DateTime.utc_now()
+
+    row_attrs = %{
+      source_article_id: src,
+      target_article_id: tgt,
+      authoritative_article_id: get.(:authoritative_article_id),
+      classification: get.(:classification),
+      disposition: disposition,
+      confidence: get.(:confidence) || :medium,
+      evidence: get.(:evidence),
+      annotated_by: Keyword.get(opts, :actor_label) || Keyword.get(opts, :actor_id),
+      annotated_at: now,
+      # A dismiss is complete on record; supersede/merge defer to the executor.
+      executed_at: if(to_string(disposition) == "dismiss", do: now, else: nil),
+      execution_result: %{}
+    }
+
+    changeset =
+      %ConflictResolution{tenant_id: tenant_id}
+      |> ConflictResolution.changeset(row_attrs)
+
+    AdminRepo.insert(changeset,
+      on_conflict:
+        {:replace,
+         [
+           :authoritative_article_id,
+           :classification,
+           :disposition,
+           :confidence,
+           :evidence,
+           :annotated_by,
+           :annotated_at,
+           :executed_at,
+           :execution_result,
+           :updated_at
+         ]},
+      conflict_target: [:tenant_id, :source_article_id, :target_article_id]
+    )
+  end
+
+  @doc """
+  Nightly executor for `:supersede` resolutions (route-the-findings #4, step 1). Applies
+  only high-confidence, not-yet-executed supersedes — reversible and audited: reuses
+  `create_link/3` to create a `supersedes` link (winner → loser) and transition the loser
+  to `:superseded`. Bounded per run via `opts[:limit]`. `:dismiss` needs no execution
+  (recorded complete); `:merge` is left for the LLM step. Returns the count applied.
+  """
+  @spec execute_conflict_resolutions(Ecto.UUID.t(), keyword()) :: non_neg_integer()
+  def execute_conflict_resolutions(tenant_id, opts \\ []) do
+    limit = Keyword.get(opts, :limit, 200)
+
+    rows =
+      from(r in ConflictResolution,
+        where: r.tenant_id == ^tenant_id,
+        where: is_nil(r.executed_at),
+        where: r.disposition == :supersede,
+        where: r.confidence == :high,
+        limit: ^limit
+      )
+      |> AdminRepo.all()
+
+    Enum.reduce(rows, 0, fn r, count ->
+      if apply_supersede(tenant_id, r), do: count + 1, else: count
+    end)
+  end
+
+  # The conflict pair is unordered; store it canonically (source <= target by UUID
+  # string) so one row covers (A,B) and (B,A).
+  defp canonical_pair(a, b) when is_binary(a) and is_binary(b) and a > b, do: {b, a}
+  defp canonical_pair(a, b), do: {a, b}
+
+  defp apply_supersede(tenant_id, %ConflictResolution{} = r) do
+    winner = r.authoritative_article_id
+    loser = if winner == r.source_article_id, do: r.target_article_id, else: r.source_article_id
+
+    result =
+      create_link(
+        tenant_id,
+        %{
+          source_article_id: winner,
+          target_article_id: loser,
+          relationship_type: "supersedes"
+        },
+        actor_type: "system",
+        actor_label: "worker:conflict_executor"
+      )
+
+    case result do
+      {:ok, _link} ->
+        mark_resolution_executed(r, %{
+          "action" => "superseded",
+          "winner" => winner,
+          "loser" => loser
+        })
+
+        true
+
+      # Already superseded / link exists → the disposition is effectively done; record
+      # and stop retrying. Any other error also stops (bad annotation), captured for review.
+      {:error, reason} ->
+        mark_resolution_executed(r, %{"action" => "noop", "reason" => inspect(reason)})
+        false
+    end
+  end
+
+  defp mark_resolution_executed(%ConflictResolution{} = r, execution_result) do
+    r
+    |> Ecto.Changeset.change(executed_at: DateTime.utc_now(), execution_result: execution_result)
+    |> AdminRepo.update()
   end
 
   @doc """

--- a/lib/loopctl/knowledge/conflict_resolution.ex
+++ b/lib/loopctl/knowledge/conflict_resolution.ex
@@ -1,0 +1,111 @@
+defmodule Loopctl.Knowledge.ConflictResolution do
+  @moduledoc """
+  A retrieving agent's VERDICT on a `:potential_conflict` article pair (route-the-findings
+  #4, step 1). The agent judges — with the live context the nightly job lacks — and records
+  it here; a nightly executor applies `:supersede` (create a `supersedes` link + retire the
+  loser), while `:dismiss` takes effect immediately (the pair drops out of the conflict
+  queue). `:merge` is recorded but executed later (the LLM-synthesis step, #4 step 2).
+
+  The KB/executor never re-judges: it acts only on what a grounded agent recorded. One row
+  per canonical (sorted) article pair — re-annotation upserts (last-write-wins), so the
+  freshest grounded judgment governs.
+
+  `tenant_id` is set programmatically, never cast.
+  """
+
+  use Loopctl.Schema
+
+  @type t :: %__MODULE__{}
+
+  @classification_values [:redundant, :complementary, :contradictory]
+  @disposition_values [:dismiss, :supersede, :merge]
+  @confidence_values [:high, :medium, :low]
+
+  schema "conflict_resolutions" do
+    tenant_field()
+
+    belongs_to :source_article, Loopctl.Knowledge.Article
+    belongs_to :target_article, Loopctl.Knowledge.Article
+    belongs_to :authoritative_article, Loopctl.Knowledge.Article
+
+    field :classification, Ecto.Enum, values: @classification_values
+    field :disposition, Ecto.Enum, values: @disposition_values
+    field :confidence, Ecto.Enum, values: @confidence_values, default: :medium
+    field :evidence, :string
+    field :annotated_by, :string
+    field :annotated_at, :utc_datetime_usec
+    field :executed_at, :utc_datetime_usec
+    field :execution_result, :map, default: %{}
+
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  @cast_fields [
+    :source_article_id,
+    :target_article_id,
+    :authoritative_article_id,
+    :classification,
+    :disposition,
+    :confidence,
+    :evidence,
+    :annotated_by,
+    :annotated_at,
+    :executed_at,
+    :execution_result
+  ]
+
+  @doc """
+  Changeset for an agent-recorded resolution. `tenant_id` is set on the struct, not cast.
+  Requires a canonical (sorted) pair and a disposition; `:supersede`/`:merge` require the
+  `authoritative_article_id` to be one of the two pair members.
+  """
+  @spec changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
+  def changeset(resolution \\ %__MODULE__{}, attrs) do
+    resolution
+    |> cast(attrs, @cast_fields)
+    |> validate_required([:source_article_id, :target_article_id, :disposition, :annotated_at])
+    |> validate_inclusion(:disposition, @disposition_values)
+    |> validate_pair_order()
+    |> validate_authoritative_in_pair()
+    |> foreign_key_constraint(:source_article_id)
+    |> foreign_key_constraint(:target_article_id)
+    |> unique_constraint([:tenant_id, :source_article_id, :target_article_id],
+      name: :conflict_resolutions_tenant_pair_index
+    )
+  end
+
+  # The pair is unordered; store it canonically (source < target by UUID string) so the
+  # unique index collapses (A,B) and (B,A) to one row.
+  defp validate_pair_order(changeset) do
+    src = get_field(changeset, :source_article_id)
+    tgt = get_field(changeset, :target_article_id)
+
+    cond do
+      is_nil(src) or is_nil(tgt) -> changeset
+      src == tgt -> add_error(changeset, :target_article_id, "must differ from source")
+      src <= tgt -> changeset
+      true -> add_error(changeset, :source_article_id, "pair must be sorted (source <= target)")
+    end
+  end
+
+  defp validate_authoritative_in_pair(changeset) do
+    disposition = get_field(changeset, :disposition)
+    auth = get_field(changeset, :authoritative_article_id)
+    src = get_field(changeset, :source_article_id)
+    tgt = get_field(changeset, :target_article_id)
+
+    cond do
+      disposition in [:supersede, :merge] and is_nil(auth) ->
+        add_error(changeset, :authoritative_article_id, "is required for #{disposition}")
+
+      not is_nil(auth) and auth not in [src, tgt] ->
+        add_error(changeset, :authoritative_article_id, "must be one of the pair")
+
+      true ->
+        changeset
+    end
+  end
+
+  @doc "Allowed disposition values."
+  def dispositions, do: @disposition_values
+end

--- a/lib/loopctl/workers/audit_partition_worker.ex
+++ b/lib/loopctl/workers/audit_partition_worker.ex
@@ -30,22 +30,29 @@ defmodule Loopctl.Workers.AuditPartitionWorker do
   end
 
   @doc """
-  Idempotently ensure the audit_log partitions for the current month + lookahead exist.
+  Idempotently ensure audit_log partitions exist for a window around the current month.
 
-  Exposed so non-Oban contexts can guarantee partitions without the full worker run
-  (e.g. test-suite startup, where the DB only ran migrations — whose partition window
-  is frozen at migration time and elapses as the wall clock advances).
+  `:back` months (default 0) and `:forward` months (default the worker's lookahead) —
+  both inclusive of the current month. Exposed so non-Oban contexts can guarantee
+  partitions without the full worker run (e.g. test-suite startup, where the DB only ran
+  migrations — whose partition window is both frozen at migration time AND anchored to
+  when the migration happened to run, so fixed-date test rows in a recent PAST month may
+  land outside it. Tests pass `back:` to cover those.)
   """
-  @spec ensure_partitions() :: :ok
-  def ensure_partitions do
-    create_future_partitions()
+  @spec ensure_partitions(keyword()) :: :ok
+  def ensure_partitions(opts \\ []) do
+    back = Keyword.get(opts, :back, 0)
+    forward = Keyword.get(opts, :forward, @future_months)
+    create_partitions(-back..forward)
     :ok
   end
 
-  defp create_future_partitions do
+  defp create_future_partitions, do: create_partitions(0..@future_months)
+
+  defp create_partitions(offset_range) do
     now = DateTime.utc_now()
 
-    for offset <- 0..@future_months do
+    for offset <- offset_range do
       {year, month} = month_offset(now.year, now.month, offset)
       {next_year, next_month} = month_offset(year, month, 1)
 

--- a/lib/loopctl/workers/audit_partition_worker.ex
+++ b/lib/loopctl/workers/audit_partition_worker.ex
@@ -29,6 +29,19 @@ defmodule Loopctl.Workers.AuditPartitionWorker do
     :ok
   end
 
+  @doc """
+  Idempotently ensure the audit_log partitions for the current month + lookahead exist.
+
+  Exposed so non-Oban contexts can guarantee partitions without the full worker run
+  (e.g. test-suite startup, where the DB only ran migrations — whose partition window
+  is frozen at migration time and elapses as the wall clock advances).
+  """
+  @spec ensure_partitions() :: :ok
+  def ensure_partitions do
+    create_future_partitions()
+    :ok
+  end
+
   defp create_future_partitions do
     now = DateTime.utc_now()
 

--- a/lib/loopctl/workers/knowledge_lint_worker.ex
+++ b/lib/loopctl/workers/knowledge_lint_worker.ex
@@ -94,12 +94,13 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
 
     action = act_on_orphans(tenant_id, report)
     promoted = promote_conflicts(tenant_id)
-    log_audit_event(tenant_id, report, action, promoted)
+    resolutions_applied = Knowledge.execute_conflict_resolutions(tenant_id)
+    log_audit_event(tenant_id, report, action, promoted, resolutions_applied)
 
     Logger.info(
       "KnowledgeLintWorker: tenant=#{tenant_id} issues=#{report.summary.total_issues} " <>
         "orphans_relinked=#{action.relinked} orphans_embedding_enqueued=#{action.embedding_enqueued} " <>
-        "conflicts_promoted=#{promoted}"
+        "conflicts_promoted=#{promoted} resolutions_applied=#{resolutions_applied}"
     )
 
     :ok
@@ -232,7 +233,7 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
     |> MapSet.new()
   end
 
-  defp log_audit_event(tenant_id, report, action, promoted) do
+  defp log_audit_event(tenant_id, report, action, promoted, resolutions_applied) do
     Audit.create_log_entry(tenant_id, %{
       entity_type: "knowledge_lint",
       entity_id: tenant_id,
@@ -244,7 +245,8 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
         "summary" => report.summary,
         "orphans_relinked" => action.relinked,
         "orphans_embedding_enqueued" => action.embedding_enqueued,
-        "conflicts_promoted" => promoted
+        "conflicts_promoted" => promoted,
+        "resolutions_applied" => resolutions_applied
       }
     })
   end

--- a/lib/loopctl_web/controllers/article_workflow_controller.ex
+++ b/lib/loopctl_web/controllers/article_workflow_controller.ex
@@ -256,6 +256,44 @@ defmodule LoopctlWeb.ArticleWorkflowController do
     }
   )
 
+  operation(:resolve_conflict,
+    summary: "Record a verdict on a potential-conflict pair",
+    description:
+      "Record how a potential-conflict pair should be resolved. `dismiss` (false positive) " <>
+        "takes effect immediately; `supersede` (with authoritative_article_id) is applied by " <>
+        "the nightly executor at confidence \"high\" — it creates a supersedes link and " <>
+        "retires the loser (reversible, audited); `merge` is recorded for the later LLM step. " <>
+        "The KB never re-judges — it acts on your verdict. Last-write-wins per pair. Role: agent+.",
+    request_body:
+      {"Resolution", "application/json",
+       %OpenApiSpex.Schema{
+         type: :object,
+         required: [:source_article_id, :target_article_id, :disposition],
+         properties: %{
+           source_article_id: %OpenApiSpex.Schema{type: :string},
+           target_article_id: %OpenApiSpex.Schema{type: :string},
+           disposition: %OpenApiSpex.Schema{
+             type: :string,
+             enum: ["dismiss", "supersede", "merge"]
+           },
+           authoritative_article_id: %OpenApiSpex.Schema{type: :string},
+           classification: %OpenApiSpex.Schema{
+             type: :string,
+             enum: ["redundant", "complementary", "contradictory"]
+           },
+           evidence: %OpenApiSpex.Schema{type: :string},
+           confidence: %OpenApiSpex.Schema{type: :string, enum: ["high", "medium", "low"]}
+         }
+       }},
+    responses: %{
+      201 =>
+        {"Recorded", "application/json",
+         %OpenApiSpex.Schema{type: :object, additionalProperties: true}},
+      422 => {"Validation error", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
   operation(:bulk_unpublish,
     summary: "Bulk unpublish articles",
     description:
@@ -657,6 +695,56 @@ defmodule LoopctlWeb.ArticleWorkflowController do
       json(conn, result)
     end
   end
+
+  @doc "POST /api/v1/knowledge/conflicts/resolve"
+  def resolve_conflict(conn, params) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+    audit_opts = AuditContext.from_conn(conn)
+
+    attrs = %{
+      "source_article_id" => params["source_article_id"],
+      "target_article_id" => params["target_article_id"],
+      "disposition" => params["disposition"],
+      "authoritative_article_id" => params["authoritative_article_id"],
+      "classification" => params["classification"],
+      "evidence" => params["evidence"],
+      "confidence" => params["confidence"]
+    }
+
+    case Knowledge.annotate_conflict(tenant_id, attrs, audit_opts) do
+      {:ok, resolution} ->
+        conn
+        |> put_status(:created)
+        |> json(%{
+          data: %{
+            id: resolution.id,
+            disposition: to_string(resolution.disposition),
+            confidence: to_string(resolution.confidence),
+            executed: not is_nil(resolution.executed_at)
+          },
+          note: resolution_note(resolution)
+        })
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:error, changeset}
+    end
+  end
+
+  defp resolution_note(%{disposition: :dismiss}),
+    do: "Dismissed as a false positive — the pair is removed from the conflict queue."
+
+  defp resolution_note(%{disposition: :supersede, confidence: :high}),
+    do:
+      "Recorded. The nightly executor will supersede the loser (create a supersedes link " <>
+        "and retire it) — reversible and audited."
+
+  defp resolution_note(%{disposition: :supersede}),
+    do:
+      "Recorded, but NOT auto-applied: supersede executes only at confidence \"high\". " <>
+        "Left for review at the current confidence."
+
+  defp resolution_note(%{disposition: :merge}),
+    do: "Recorded for the merge (LLM-synthesis) step — not applied by the nightly executor yet."
 
   # --- Private helpers ---
 

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -295,6 +295,7 @@ defmodule LoopctlWeb.Router do
     post "/knowledge/bulk-delete", ArticleWorkflowController, :bulk_delete
     get "/knowledge/drafts", ArticleWorkflowController, :drafts
     get "/knowledge/conflicts", ArticleWorkflowController, :conflicts
+    post "/knowledge/conflicts/resolve", ArticleWorkflowController, :resolve_conflict
 
     # Knowledge Index (lightweight catalog)
     get "/knowledge/index", KnowledgeIndexController, :index

--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to `loopctl-mcp-server` are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 2.27.0 — 2026-06-30 (route-the-findings: conflict resolution)
+
+### Added
+
+- **`knowledge_resolve_conflict`** — record your verdict on a potential-conflict pair.
+  You have the live context the KB lacks; it acts on what you record, never re-judges.
+  `dismiss` (false positive) takes effect immediately; `supersede` (with
+  `authoritative_article_id`) is applied by the nightly executor at `confidence: "high"`
+  (creates a supersedes link + retires the loser, reversible + audited); `merge` is
+  recorded for the later synthesis step. Non-destructive at agent role — you record
+  intent, the privileged nightly job executes. Last-write-wins per pair.
+
 ## 2.26.0 — 2026-06-30 (route-the-findings: conflict review surface)
 
 ### Added

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -1050,6 +1050,29 @@ async function knowledgeConflicts({ limit, offset }) {
   return toContent(result);
 }
 
+async function knowledgeResolveConflict({
+  source_article_id,
+  target_article_id,
+  disposition,
+  authoritative_article_id,
+  classification,
+  evidence,
+  confidence,
+}) {
+  const payload = { source_article_id, target_article_id, disposition };
+  if (authoritative_article_id) payload.authoritative_article_id = authoritative_article_id;
+  if (classification) payload.classification = classification;
+  if (evidence) payload.evidence = evidence;
+  if (confidence) payload.confidence = confidence;
+  const result = await apiCall(
+    "POST",
+    "/api/v1/knowledge/conflicts/resolve",
+    payload,
+    process.env.LOOPCTL_AGENT_KEY,
+  );
+  return toContent(result);
+}
+
 async function knowledgeLint({ project_id, stale_days, min_coverage, max_per_category }) {
   const params = new URLSearchParams();
   if (stale_days != null) params.set("stale_days", String(stale_days));
@@ -2926,6 +2949,69 @@ const TOOLS = [
     },
   },
   {
+    name: "knowledge_resolve_conflict",
+    description:
+      "Record YOUR verdict on a potential-conflict pair (from knowledge_conflicts or an " +
+      "article's potential_conflicts). You have the live context the KB lacks — it never " +
+      "re-judges, it acts on what you record. Dispositions: 'dismiss' (a false positive — " +
+      "the two don't actually conflict; drops out of the queue immediately); 'supersede' " +
+      "(one article wins — pass authoritative_article_id, the winner; the nightly executor " +
+      "creates a supersedes link and retires the loser, but ONLY at confidence:\"high\" — " +
+      "reversible and audited); 'merge' (recorded for the later merge step). Non-destructive " +
+      "at agent role — you record intent; the privileged nightly job executes it. " +
+      "Last-write-wins per pair, so re-recording with fresher ground truth overrides. " +
+      "Resolve only conflicts material to your current task; adjudicate against the actual " +
+      "system, and if you can't tell which is right, leave it (or record low confidence) " +
+      "rather than guessing.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        source_article_id: {
+          type: "string",
+          description: "One article of the conflict pair (UUID). Order does not matter.",
+        },
+        target_article_id: {
+          type: "string",
+          description: "The other article of the conflict pair (UUID).",
+        },
+        disposition: {
+          type: "string",
+          enum: ["dismiss", "supersede", "merge"],
+          description:
+            "dismiss = false positive; supersede = one wins (set authoritative_article_id); " +
+            "merge = combine (recorded for the later merge step).",
+        },
+        authoritative_article_id: {
+          type: "string",
+          description:
+            "For supersede/merge: the WINNING article (must be one of the pair). The other " +
+            "is the loser to retire/merge into the winner.",
+        },
+        classification: {
+          type: "string",
+          enum: ["redundant", "complementary", "contradictory"],
+          description:
+            "Your judgment of the relationship: redundant (same claim), complementary (same " +
+            "topic, different facets — usually a dismiss), or contradictory (can't both be true).",
+        },
+        evidence: {
+          type: "string",
+          description:
+            "Why you're sure — ideally a ground-truth reference (commit, file:line, URL, or the " +
+            "observed behavior). Recorded for audit and for a human reviewing low-confidence calls.",
+        },
+        confidence: {
+          type: "string",
+          enum: ["high", "medium", "low"],
+          description:
+            "high, medium, or low. supersede auto-executes only at 'high'; lower confidence is " +
+            "recorded but left for review. Default medium.",
+        },
+      },
+      required: ["source_article_id", "target_article_id", "disposition"],
+    },
+  },
+  {
     name: "knowledge_lint",
     description:
       "Run a lint check on the knowledge wiki to identify stale, low-coverage, or broken articles. " +
@@ -3547,6 +3633,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     case "knowledge_conflicts":
       return await knowledgeConflicts(args);
+
+    case "knowledge_resolve_conflict":
+      return await knowledgeResolveConflict(args);
 
     case "knowledge_lint":
       return await knowledgeLint(args);

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.26.0",
+  "version": "2.27.0",
   "description": "MCP server for loopctl — structural trust for AI development loops",
   "type": "module",
   "main": "index.js",

--- a/mcp-server/test/knowledge_tools.test.js
+++ b/mcp-server/test/knowledge_tools.test.js
@@ -1133,6 +1133,55 @@ async function knowledgeConflicts({ limit, offset } = {}) {
   return await apiCall("GET", path, null, process.env.LOOPCTL_AGENT_KEY);
 }
 
+async function knowledgeResolveConflict({
+  source_article_id,
+  target_article_id,
+  disposition,
+  authoritative_article_id,
+  classification,
+  evidence,
+  confidence,
+} = {}) {
+  const payload = { source_article_id, target_article_id, disposition };
+  if (authoritative_article_id) payload.authoritative_article_id = authoritative_article_id;
+  if (classification) payload.classification = classification;
+  if (evidence) payload.evidence = evidence;
+  if (confidence) payload.confidence = confidence;
+  return await apiCall(
+    "POST",
+    "/api/v1/knowledge/conflicts/resolve",
+    payload,
+    process.env.LOOPCTL_AGENT_KEY,
+  );
+}
+
+describe("knowledge_resolve_conflict (verdict passthrough)", () => {
+  test("POSTs the verdict with the agent key and only the provided fields", async () => {
+    setupEnv();
+    const calls = mockFetch({ data: { id: "r1", disposition: "supersede", executed: false } }, 201);
+
+    await knowledgeResolveConflict({
+      source_article_id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+      target_article_id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+      disposition: "supersede",
+      authoritative_article_id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+      confidence: "high",
+    });
+
+    const { url, options } = calls[0];
+    assert.equal(options.method, "POST");
+    assert.equal(new URL(url).pathname, "/api/v1/knowledge/conflicts/resolve");
+    assert.equal(options.headers.Authorization, `Bearer ${AGENT_KEY}`);
+    const sent = JSON.parse(options.body);
+    assert.equal(sent.disposition, "supersede");
+    assert.equal(sent.authoritative_article_id, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    assert.equal(sent.confidence, "high");
+    // Omitted optionals aren't sent.
+    assert.equal(sent.evidence, undefined);
+    assert.equal(sent.classification, undefined);
+  });
+});
+
 describe("knowledge_conflicts (route-the-findings review surface)", () => {
   test("GETs the conflicts endpoint with the agent key and forwards pagination", async () => {
     setupEnv();

--- a/priv/repo/migrations/20260630180000_create_conflict_resolutions.exs
+++ b/priv/repo/migrations/20260630180000_create_conflict_resolutions.exs
@@ -1,0 +1,51 @@
+defmodule Loopctl.Repo.Migrations.CreateConflictResolutions do
+  use Ecto.Migration
+  import Loopctl.Repo.RlsHelpers
+
+  # Route-the-findings #4, step 1: a retrieving agent (which has live context) records
+  # its VERDICT on a potential-conflict pair here — the KB/executor never re-judges.
+  # A nightly executor applies dismiss/supersede from these rows. Kept separate from
+  # article_links because links are immutable by design; this row is mutable
+  # (last-write-wins on re-annotation; executor stamps executed_at).
+  def change do
+    create table(:conflict_resolutions, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :tenant_id, references(:tenants, type: :binary_id, on_delete: :delete_all), null: false
+
+      # Canonical (sorted) article pair — one resolution per unordered pair.
+      add :source_article_id, references(:articles, type: :binary_id, on_delete: :delete_all),
+        null: false
+
+      add :target_article_id, references(:articles, type: :binary_id, on_delete: :delete_all),
+        null: false
+
+      add :classification, :string
+      add :disposition, :string, null: false
+      # The winning article for :supersede / :merge (loser is the other pair member).
+      add :authoritative_article_id,
+          references(:articles, type: :binary_id, on_delete: :nilify_all)
+
+      add :evidence, :text
+      add :confidence, :string, null: false, default: "medium"
+      add :annotated_by, :string
+      add :annotated_at, :utc_datetime_usec, null: false
+      add :executed_at, :utc_datetime_usec
+      add :execution_result, :map, null: false, default: %{}
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    # One resolution per (tenant, canonical pair). Re-annotation upserts (last-write-wins).
+    create unique_index(
+             :conflict_resolutions,
+             [:tenant_id, :source_article_id, :target_article_id],
+             name: :conflict_resolutions_tenant_pair_index
+           )
+
+    create index(:conflict_resolutions, [:tenant_id])
+    # Executor scan: unexecuted rows.
+    create index(:conflict_resolutions, [:tenant_id, :executed_at])
+
+    enable_rls(:conflict_resolutions)
+  end
+end

--- a/test/loopctl/knowledge/potential_conflicts_test.exs
+++ b/test/loopctl/knowledge/potential_conflicts_test.exs
@@ -93,4 +93,144 @@ defmodule Loopctl.Knowledge.PotentialConflictsTest do
       assert json.potential_conflicts == []
     end
   end
+
+  describe "annotate_conflict/3 + executor" do
+    setup do
+      tenant = fixture(:tenant)
+      a = published(tenant.id, "Winner")
+      b = published(tenant.id, "Loser")
+      conflict_link(tenant.id, a, b, 0.95)
+      %{tenant: tenant, a: a, b: b}
+    end
+
+    test "dismiss takes effect immediately and drops the pair from the queue", ctx do
+      %{tenant: t, a: a, b: b} = ctx
+
+      assert %{meta: %{total_count: 1}} = Knowledge.list_potential_conflicts(t.id)
+
+      assert {:ok, res} =
+               Knowledge.annotate_conflict(
+                 t.id,
+                 %{
+                   "source_article_id" => a.id,
+                   "target_article_id" => b.id,
+                   "disposition" => "dismiss",
+                   "classification" => "complementary"
+                 },
+                 actor_label: "agent:x"
+               )
+
+      assert res.disposition == :dismiss
+      # Immediate.
+      refute is_nil(res.executed_at)
+      # Queue now excludes it.
+      assert %{meta: %{total_count: 0}, data: []} = Knowledge.list_potential_conflicts(t.id)
+    end
+
+    test "supersede at high confidence is applied by the executor (loser retired)", ctx do
+      %{tenant: t, a: a, b: b} = ctx
+
+      assert {:ok, res} =
+               Knowledge.annotate_conflict(t.id, %{
+                 "source_article_id" => b.id,
+                 "target_article_id" => a.id,
+                 "disposition" => "supersede",
+                 "authoritative_article_id" => a.id,
+                 "confidence" => "high"
+               })
+
+      # Deferred — not executed on record.
+      assert is_nil(res.executed_at)
+      # Loser still published until the executor runs.
+      assert Loopctl.AdminRepo.get(Loopctl.Knowledge.Article, b.id).status == :published
+
+      assert 1 == Knowledge.execute_conflict_resolutions(t.id)
+
+      # Loser retired; a supersedes link points winner -> loser.
+      assert Loopctl.AdminRepo.get(Loopctl.Knowledge.Article, b.id).status == :superseded
+
+      assert Loopctl.AdminRepo.get_by(ArticleLink,
+               tenant_id: t.id,
+               source_article_id: a.id,
+               target_article_id: b.id,
+               relationship_type: :supersedes
+             )
+    end
+
+    test "supersede below high confidence is NOT auto-applied", ctx do
+      %{tenant: t, a: a, b: b} = ctx
+
+      {:ok, _} =
+        Knowledge.annotate_conflict(t.id, %{
+          "source_article_id" => a.id,
+          "target_article_id" => b.id,
+          "disposition" => "supersede",
+          "authoritative_article_id" => a.id,
+          "confidence" => "medium"
+        })
+
+      assert 0 == Knowledge.execute_conflict_resolutions(t.id)
+      assert Loopctl.AdminRepo.get(Loopctl.Knowledge.Article, b.id).status == :published
+    end
+
+    test "last-write-wins: re-annotating the same pair (any order) upserts", ctx do
+      %{tenant: t, a: a, b: b} = ctx
+
+      {:ok, _} =
+        Knowledge.annotate_conflict(t.id, %{
+          "source_article_id" => a.id,
+          "target_article_id" => b.id,
+          "disposition" => "dismiss"
+        })
+
+      # Re-annotate with the pair in the OTHER order and a different verdict.
+      {:ok, res2} =
+        Knowledge.annotate_conflict(t.id, %{
+          "source_article_id" => b.id,
+          "target_article_id" => a.id,
+          "disposition" => "supersede",
+          "authoritative_article_id" => a.id,
+          "confidence" => "high"
+        })
+
+      assert res2.disposition == :supersede
+      # Exactly one row for the pair.
+      assert 1 ==
+               Loopctl.AdminRepo.aggregate(
+                 Loopctl.Knowledge.ConflictResolution,
+                 :count,
+                 :id
+               )
+    end
+
+    test "get_article drops a resolved conflict from its surfaced conflicts", ctx do
+      %{tenant: t, a: a, b: b} = ctx
+
+      {:ok, before} = Knowledge.get_article(t.id, a.id)
+      assert [_] = ArticleJSON.article_data_with_links(before).potential_conflicts
+
+      {:ok, _} =
+        Knowledge.annotate_conflict(t.id, %{
+          "source_article_id" => a.id,
+          "target_article_id" => b.id,
+          "disposition" => "dismiss"
+        })
+
+      {:ok, loaded} = Knowledge.get_article(t.id, a.id)
+      assert ArticleJSON.article_data_with_links(loaded).potential_conflicts == []
+    end
+
+    test "requires the authoritative article for supersede", ctx do
+      %{tenant: t, a: a, b: b} = ctx
+
+      assert {:error, changeset} =
+               Knowledge.annotate_conflict(t.id, %{
+                 "source_article_id" => a.id,
+                 "target_article_id" => b.id,
+                 "disposition" => "supersede"
+               })
+
+      assert %{authoritative_article_id: _} = errors_on(changeset)
+    end
+  end
 end

--- a/test/loopctl_web/controllers/article_workflow_controller_test.exs
+++ b/test/loopctl_web/controllers/article_workflow_controller_test.exs
@@ -1289,4 +1289,71 @@ defmodule LoopctlWeb.ArticleWorkflowControllerTest do
       assert length(pair["articles"]) == 2
     end
   end
+
+  describe "POST /api/v1/knowledge/conflicts/resolve" do
+    setup %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      a = fixture(:article, %{tenant_id: tenant.id, title: "A", status: :published})
+      b = fixture(:article, %{tenant_id: tenant.id, title: "B", status: :published})
+
+      %ArticleLink{tenant_id: tenant.id}
+      |> ArticleLink.changeset(%{
+        source_article_id: a.id,
+        target_article_id: b.id,
+        relationship_type: :potential_conflict,
+        metadata: %{"auto_generated" => true, "similarity_score" => 0.95}
+      })
+      |> AdminRepo.insert!()
+
+      %{conn: auth_conn(conn, raw_key), tenant: tenant, a: a, b: b}
+    end
+
+    test "an agent can dismiss a conflict (takes effect immediately)", ctx do
+      %{conn: conn, a: a, b: b} = ctx
+
+      conn =
+        post(conn, ~p"/api/v1/knowledge/conflicts/resolve", %{
+          "source_article_id" => a.id,
+          "target_article_id" => b.id,
+          "disposition" => "dismiss",
+          "classification" => "complementary"
+        })
+
+      body = json_response(conn, 201)
+      assert body["data"]["disposition"] == "dismiss"
+      assert body["data"]["executed"] == true
+    end
+
+    test "records a high-confidence supersede (deferred to the executor)", ctx do
+      %{conn: conn, a: a, b: b} = ctx
+
+      conn =
+        post(conn, ~p"/api/v1/knowledge/conflicts/resolve", %{
+          "source_article_id" => a.id,
+          "target_article_id" => b.id,
+          "disposition" => "supersede",
+          "authoritative_article_id" => a.id,
+          "confidence" => "high"
+        })
+
+      body = json_response(conn, 201)
+      assert body["data"]["disposition"] == "supersede"
+      assert body["data"]["executed"] == false
+      assert body["note"] =~ "nightly executor"
+    end
+
+    test "422 when supersede omits the authoritative article", ctx do
+      %{conn: conn, a: a, b: b} = ctx
+
+      conn =
+        post(conn, ~p"/api/v1/knowledge/conflicts/resolve", %{
+          "source_article_id" => a.id,
+          "target_article_id" => b.id,
+          "disposition" => "supersede"
+        })
+
+      assert json_response(conn, 422)
+    end
+  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,6 +2,14 @@ ExUnit.start()
 Ecto.Adapters.SQL.Sandbox.mode(Loopctl.Repo, :manual)
 Ecto.Adapters.SQL.Sandbox.mode(Loopctl.AdminRepo, :manual)
 
+# audit_log is time-partitioned. The create_audit_log migration seeds partitions for a
+# fixed window (its month + 3), which ELAPSES as the wall clock advances — so after a
+# month rollover the test DB has no partition for "now" and every audit insert fails
+# (prod is unaffected: the nightly AuditPartitionWorker keeps the window ahead). Ensure
+# the current + lookahead partitions exist here (idempotent CREATE IF NOT EXISTS DDL) so
+# the suite doesn't depend on when the migration happened to run.
+Loopctl.Workers.AuditPartitionWorker.ensure_partitions()
+
 # Scale tests (US-27.1) are opt-in: they seed large corpora, commit rows
 # directly to the DB, and run ANALYZE. They must NEVER run inside the normal
 # async sandbox suite — doing so would silently produce n≈0 statistics.

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -3,12 +3,15 @@ Ecto.Adapters.SQL.Sandbox.mode(Loopctl.Repo, :manual)
 Ecto.Adapters.SQL.Sandbox.mode(Loopctl.AdminRepo, :manual)
 
 # audit_log is time-partitioned. The create_audit_log migration seeds partitions for a
-# fixed window (its month + 3), which ELAPSES as the wall clock advances — so after a
-# month rollover the test DB has no partition for "now" and every audit insert fails
-# (prod is unaffected: the nightly AuditPartitionWorker keeps the window ahead). Ensure
-# the current + lookahead partitions exist here (idempotent CREATE IF NOT EXISTS DDL) so
-# the suite doesn't depend on when the migration happened to run.
-Loopctl.Workers.AuditPartitionWorker.ensure_partitions()
+# window anchored to WHEN IT RAN (its month + 3). A fresh CI DB migrated today therefore
+# has no partition for the FIXED past-dated rows many tests insert (e.g. ~U[2026-06-24]),
+# nor for future months as time advances — so audit inserts fail with "no partition".
+# (Prod is unaffected: the nightly AuditPartitionWorker keeps the window ahead.) Ensure a
+# generous window here. It must be COMMITTED DDL, so run it unboxed — a plain query would
+# execute inside the sandbox transaction and be rolled back before any test sees it.
+Ecto.Adapters.SQL.Sandbox.unboxed_run(Loopctl.Repo, fn ->
+  Loopctl.Workers.AuditPartitionWorker.ensure_partitions(back: 12)
+end)
 
 # Scale tests (US-27.1) are opt-in: they seed large corpora, commit rows
 # directly to the DB, and run ANALYZE. They must NEVER run inside the normal


### PR DESCRIPTION
## What — route-the-findings step 1: conflict *resolution*

#224/#225 detect and surface conflicts. This closes the loop: the **retrieving agent** (which has the live context the nightly job lacks) records a **verdict**; a **trusted nightly executor** applies it. Judgment stays with the grounded agent — the KB never re-judges. **No LLM** (`dismiss`/`supersede` only; `merge` is the later LLM step).

## Design

- **Separate `conflict_resolutions` table** — `article_links` are immutable by design, so the verdict lives in a new *mutable* row. One row per **canonical (sorted) pair**; re-annotation **upserts** = last-write-wins, so the freshest grounded judgment governs.
- **`annotate_conflict/3`** (agent, non-destructive → agent role): `dismiss` | `supersede` | `merge`, with `authoritative_article_id` (winner) for supersede/merge, plus `classification` / `evidence` / `confidence`. `dismiss` takes effect immediately (pair drops from the queue + the article surface); supersede/merge defer.
- **`execute_conflict_resolutions/2`** (nightly, in `KnowledgeLintWorker`, system-privileged): applies only **high-confidence** supersedes — reuses `create_link(:supersedes)` to link winner→loser and transition the loser to `:superseded` (**reversible + audited**). Bounded. Lower confidence / `merge` left for review / the LLM step.
- **Queue + `get_article` field now exclude resolved pairs** — the conflict queue shows only OPEN conflicts.

This is the division we agreed on: agent judges (cheap, in-context, non-destructive), privileged batch executes (reversible-only, above a confidence bar), humans get the rest.

## Surface

- `POST /api/v1/knowledge/conflicts/resolve` (agent+).
- MCP **v2.27.0** `knowledge_resolve_conflict`. RLS on the new table.

## Tests (+9 Elixir, +1 MCP)

dismiss-immediate + queue-drop; high-conf supersede applied (loser `:superseded` + `:supersedes` link created); sub-high not applied; last-write-wins across pair order; `get_article` drops resolved; supersede requires authoritative; controller dismiss/supersede/422; MCP plumbing.

Full gate green: format, credo --strict, dialyzer, **3057 tests, 0 failures**; 53 MCP tests. Migration runs on deploy via `release_command`.

## What's still open (honest)

- **`merge`** disposition is recorded but not executed — that's #4 step 2 (the isolated LLM-synthesis increment, drafts-only, behind the confidence gate).
- The tool-description pointers + a wiki playbook article (the "when you see a conflict, here's the protocol" instruction) are a small follow-up.
