### PR TITLE
fix(custody): enforce self-verify + review-record guards on bulk verify/mark-complete

### DIFF
--- a/lib/loopctl/bulk_operations.ex
+++ b/lib/loopctl/bulk_operations.ex
@@ -21,6 +21,7 @@ defmodule Loopctl.BulkOperations do
   alias Loopctl.AdminRepo
   alias Loopctl.Artifacts.VerificationResult
   alias Loopctl.Audit
+  alias Loopctl.Progress
   alias Loopctl.Webhooks.EventGenerator
   alias Loopctl.Webhooks.WebhookEvent
   alias Loopctl.WorkBreakdown.Story
@@ -256,22 +257,22 @@ defmodule Loopctl.BulkOperations do
          actor_id,
          actor_label
        ) do
-    case apply_mark_complete(story) do
-      {:ok, updated} ->
-        create_mark_complete_result(tenant_id, story, orchestrator_agent_id, params)
+    with :ok <- Progress.mark_complete_allowed?(story),
+         {:ok, updated} <- apply_mark_complete(story) do
+      create_mark_complete_result(tenant_id, story, orchestrator_agent_id, params)
 
-        audit_mark_complete(
-          tenant_id,
-          story,
-          updated,
-          actor_id,
-          actor_label,
-          orchestrator_agent_id
-        )
+      audit_mark_complete(
+        tenant_id,
+        story,
+        updated,
+        actor_id,
+        actor_label,
+        orchestrator_agent_id
+      )
 
-        emit_mark_complete_event(tenant_id, updated, orchestrator_agent_id, params)
-        %{story_id: story.id, status: "success"}
-
+      emit_mark_complete_event(tenant_id, updated, orchestrator_agent_id, params)
+      %{story_id: story.id, status: "success"}
+    else
       {:error, reason} ->
         %{story_id: story.id, status: "error", reason: format_reason(reason)}
     end
@@ -332,6 +333,8 @@ defmodule Loopctl.BulkOperations do
 
   defp process_verify(story, params, tenant_id, orchestrator_agent_id, actor_id, actor_label) do
     with :ok <- validate_verify_preconditions(story),
+         :ok <- Progress.verify_allowed?(story, orchestrator_agent_id),
+         :ok <- Progress.review_conducted?(tenant_id, story.id, story),
          {:ok, updated} <- apply_verification(story) do
       create_verification_result(tenant_id, story, orchestrator_agent_id, params)
       audit_verification(tenant_id, story, updated, actor_id, actor_label, orchestrator_agent_id)
@@ -797,6 +800,21 @@ defmodule Loopctl.BulkOperations do
   # ===================================================================
 
   defp format_reason(:reason_required), do: "reason is required and cannot be blank"
+
+  defp format_reason(:self_verify_blocked),
+    do: "cannot verify your own implemented work (chain-of-custody)"
+
+  defp format_reason(:review_not_conducted),
+    do: "no independent review record exists for this story since it was reported done"
+
+  defp format_reason(:story_has_dispatch_lineage),
+    do: "story has dispatch lineage; use the normal verify flow, not mark-complete"
+
+  defp format_reason(:already_verified), do: "story is already verified"
+
+  defp format_reason(:story_rejected),
+    do: "story is rejected; investigate instead of marking it complete"
+
   defp format_reason(reason) when is_binary(reason), do: reason
   defp format_reason(reason), do: inspect(reason)
 end

--- a/lib/loopctl/progress.ex
+++ b/lib/loopctl/progress.ex
@@ -952,6 +952,55 @@ defmodule Loopctl.Progress do
   end
 
   @doc """
+  Chain-of-custody guard for the bulk-verify path.
+
+  Returns `:ok` when `orchestrator_agent_id` is permitted to verify `story`, or
+  `{:error, :self_verify_blocked}` when the verifier shares dispatch lineage /
+  agent identity with the implementer. Exposed so `Loopctl.BulkOperations`
+  enforces the SAME self-verify invariant as the single-story `verify_story/4`
+  path — otherwise bulk verify is a chain-of-custody bypass.
+  """
+  @spec verify_allowed?(Story.t(), Ecto.UUID.t() | nil) ::
+          :ok | {:error, :self_verify_blocked}
+  def verify_allowed?(story, orchestrator_agent_id) do
+    case validate_not_self_verify(story, orchestrator_agent_id) do
+      {:ok, _} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc """
+  Returns `:ok` when an independent review record exists for `story` after it
+  was reported done, else `{:error, :review_not_conducted}`. Mirrors the
+  `verify_story/4` review-record requirement for the bulk path.
+  """
+  @spec review_conducted?(Ecto.UUID.t(), Ecto.UUID.t(), Story.t()) ::
+          :ok | {:error, :review_not_conducted}
+  def review_conducted?(tenant_id, story_id, story) do
+    case validate_review_record_exists(tenant_id, story_id, story) do
+      {:ok, _} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc """
+  Structural custody guard for the bulk mark-complete (backfill) path.
+
+  Returns `:ok` only when `story` never entered the dispatch lifecycle, matching
+  `backfill_story/4`. Prevents mark-complete from being used to self-verify
+  dispatched work.
+  """
+  @spec mark_complete_allowed?(Story.t()) ::
+          :ok
+          | {:error, :already_verified | :story_rejected | :story_has_dispatch_lineage}
+  def mark_complete_allowed?(story) do
+    case guard_backfillable(story) do
+      {:ok, _} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc """
   Backfills a story's status when the work was completed outside loopctl.
 
   Sets both `agent_status` and `verified_status` to fully-done values in one

--- a/test/loopctl_web/controllers/bulk_mark_complete_controller_test.exs
+++ b/test/loopctl_web/controllers/bulk_mark_complete_controller_test.exs
@@ -29,8 +29,10 @@ defmodule LoopctlWeb.BulkMarkCompleteControllerTest do
       epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
       {raw_key, _} = orchestrator_key(tenant.id)
 
+      # mark-complete is backfill for pre-existing (never-dispatched) work, so
+      # both stories are pending with no dispatch lineage.
       s1 = fixture(:story, %{tenant_id: tenant.id, epic_id: epic.id, agent_status: :pending})
-      s2 = fixture(:story, %{tenant_id: tenant.id, epic_id: epic.id, agent_status: :implementing})
+      s2 = fixture(:story, %{tenant_id: tenant.id, epic_id: epic.id, agent_status: :pending})
 
       conn =
         conn
@@ -214,6 +216,42 @@ defmodule LoopctlWeb.BulkMarkCompleteControllerTest do
 
       # validate_orchestrator_agent_linked returns bad_request
       json_response(conn, 400)
+    end
+
+    test "rejects mark-complete of a dispatched story (chain-of-custody)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+      implementer = fixture(:agent, %{tenant_id: tenant.id})
+      {raw_key, _} = orchestrator_key(tenant.id)
+
+      # A story that entered the dispatch lifecycle must NOT be force-completed
+      # via mark-complete (that would bypass report/review/verify).
+      dispatched =
+        fixture(:story, %{
+          tenant_id: tenant.id,
+          epic_id: epic.id,
+          agent_status: :implementing,
+          assigned_agent_id: implementer.id
+        })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/stories/bulk/mark-complete", %{
+          "stories" => [%{"story_id" => dispatched.id, "summary" => "should be blocked"}]
+        })
+
+      # Fully-blocked single-story batch -> 422 (no successes).
+      body = json_response(conn, 422)
+      result = hd(body["results"])
+      assert result["status"] == "error"
+      assert result["reason"] =~ "dispatch lineage"
+
+      # Untouched.
+      story_after = AdminRepo.get!(Story, dispatched.id)
+      assert story_after.agent_status == :implementing
+      assert story_after.verified_status == :unverified
     end
 
     test "cross-tenant isolation: cannot mark another tenant's stories", %{conn: conn} do

--- a/test/loopctl_web/controllers/bulk_operations_controller_test.exs
+++ b/test/loopctl_web/controllers/bulk_operations_controller_test.exs
@@ -189,6 +189,11 @@ defmodule LoopctlWeb.BulkOperationsControllerTest do
           agent_status: :reported_done
         })
 
+      # An independent review record must exist before verify (chain-of-custody
+      # parity with the single-story verify path).
+      fixture(:review_record, %{tenant_id: tenant.id, story_id: s1.id})
+      fixture(:review_record, %{tenant_id: tenant.id, story_id: s2.id})
+
       conn =
         conn
         |> auth_conn(raw_key)
@@ -274,6 +279,9 @@ defmodule LoopctlWeb.BulkOperationsControllerTest do
           agent_status: :reported_done
         })
 
+      fixture(:review_record, %{tenant_id: tenant.id, story_id: s1.id})
+      fixture(:review_record, %{tenant_id: tenant.id, story_id: s2.id})
+
       conn =
         conn
         |> auth_conn(raw_key)
@@ -302,6 +310,95 @@ defmodule LoopctlWeb.BulkOperationsControllerTest do
         |> AdminRepo.all()
 
       assert length(events) == 2
+    end
+
+    test "bulk verify blocks self-verification (chain-of-custody parity)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+      orchestrator = fixture(:agent, %{tenant_id: tenant.id, agent_type: :orchestrator})
+
+      {raw_key, _api_key} =
+        fixture(:api_key, %{
+          tenant_id: tenant.id,
+          role: :orchestrator,
+          agent_id: orchestrator.id
+        })
+
+      # Story whose implementer IS the caller — verify must be blocked even though
+      # a review record exists.
+      story =
+        fixture(:story, %{
+          tenant_id: tenant.id,
+          epic_id: epic.id,
+          agent_status: :reported_done,
+          assigned_agent_id: orchestrator.id
+        })
+
+      fixture(:review_record, %{tenant_id: tenant.id, story_id: story.id})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/stories/bulk/verify", %{
+          "stories" => [
+            %{
+              "story_id" => story.id,
+              "result" => "pass",
+              "summary" => "self",
+              "review_type" => "x"
+            }
+          ]
+        })
+
+      # Single-story batch that is fully blocked -> 422 (no successes).
+      body = json_response(conn, 422)
+      result = hd(body["results"])
+      assert result["status"] == "error"
+      assert result["reason"] =~ "chain-of-custody"
+
+      # Story remains unverified — the bypass is closed.
+      assert AdminRepo.get!(Story, story.id).verified_status == :unverified
+    end
+
+    test "bulk verify requires an independent review record", %{conn: conn} do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+      implementer = fixture(:agent, %{tenant_id: tenant.id})
+      orchestrator = fixture(:agent, %{tenant_id: tenant.id, agent_type: :orchestrator})
+
+      {raw_key, _api_key} =
+        fixture(:api_key, %{
+          tenant_id: tenant.id,
+          role: :orchestrator,
+          agent_id: orchestrator.id
+        })
+
+      # Distinct implementer (self-verify guard passes) but NO review record.
+      story =
+        fixture(:story, %{
+          tenant_id: tenant.id,
+          epic_id: epic.id,
+          agent_status: :reported_done,
+          assigned_agent_id: implementer.id
+        })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/stories/bulk/verify", %{
+          "stories" => [
+            %{"story_id" => story.id, "result" => "pass", "summary" => "ok", "review_type" => "x"}
+          ]
+        })
+
+      body = json_response(conn, 422)
+      result = hd(body["results"])
+      assert result["status"] == "error"
+      assert result["reason"] =~ "review"
+
+      assert AdminRepo.get!(Story, story.id).verified_status == :unverified
     end
   end
 


### PR DESCRIPTION
## Summary

Closes a chain-of-custody parity gap between the single-story and bulk story-completion paths (private advisory **GHSA-h49f-rhf8-8p6f**, finding `ie-01`, Critical).

The single-story `Progress.verify_story/4` blocks a caller from verifying its own implemented work (`self_verify_blocked`) and requires an independent review record. The bulk endpoints skipped both checks:

- `POST /api/v1/stories/bulk/verify` — verified with only a status check.
- `POST /api/v1/stories/bulk/mark-complete` — force-completed any story, including one still in the dispatch lifecycle.

Because an orchestrator identity can share an `agent_id` with the implementer it dispatched, either bulk path let it verify/complete its own work — defeating the core trust guarantee.

## Changes

- Expose three thin public guards from `Progress` (wrapping existing private logic): `verify_allowed?/2`, `review_conducted?/3`, `mark_complete_allowed?/1`.
- `bulk_verify` now runs the self-verify + review-record guards per story (parity with `verify_story/4`).
- `bulk_mark_complete` now enforces the same never-dispatched structural guard as `backfill_story/4`.
- Batch semantics unchanged: per-story failures are partial-success errors; a fully-blocked batch returns 422.

## Tests

Adds self-verify-block, missing-review-block, and dispatched-story mark-complete rejection cases; updates existing success-path tests to establish the required preconditions. Full suite green locally (3094 tests, 0 failures); credo --strict + dialyzer clean.
