### PR TITLE
fix(custody): close bulk_reject self-verify gap + harden verify/review guards (parity with #252)

### DIFF
--- a/lib/loopctl/artifacts/review_record.ex
+++ b/lib/loopctl/artifacts/review_record.ex
@@ -58,6 +58,9 @@ defmodule Loopctl.Artifacts.ReviewRecord do
 
   The `tenant_id`, `story_id`, and `reviewer_agent_id` are set
   programmatically, not via cast.
+
+  Validates that `completed_at` is not in the future (within 5 minutes tolerance)
+  and that it is after the story's `reported_done_at` timestamp.
   """
   @spec create_changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
   def create_changeset(record \\ %__MODULE__{}, attrs) do
@@ -75,7 +78,29 @@ defmodule Loopctl.Artifacts.ReviewRecord do
     |> validate_number(:findings_count, greater_than_or_equal_to: 0)
     |> validate_number(:fixes_count, greater_than_or_equal_to: 0)
     |> validate_number(:disproved_count, greater_than_or_equal_to: 0)
+    |> validate_completed_at_not_future()
     |> validate_findings_math()
+  end
+
+  # Validates that completed_at is not more than 5 minutes in the future
+  defp validate_completed_at_not_future(changeset) do
+    case Ecto.Changeset.get_field(changeset, :completed_at) do
+      nil ->
+        changeset
+
+      completed_at ->
+        max_future = DateTime.utc_now() |> DateTime.add(300, :second)
+
+        if DateTime.compare(completed_at, max_future) == :gt do
+          Ecto.Changeset.add_error(
+            changeset,
+            :completed_at,
+            "cannot be more than 5 minutes in the future"
+          )
+        else
+          changeset
+        end
+    end
   end
 
   defp validate_findings_math(changeset) do

--- a/lib/loopctl/artifacts/review_record.ex
+++ b/lib/loopctl/artifacts/review_record.ex
@@ -59,8 +59,9 @@ defmodule Loopctl.Artifacts.ReviewRecord do
   The `tenant_id`, `story_id`, and `reviewer_agent_id` are set
   programmatically, not via cast.
 
-  Validates that `completed_at` is not in the future (within 5 minutes tolerance)
-  and that it is after the story's `reported_done_at` timestamp.
+  Validates that `completed_at` is not more than 5 minutes in the future, so a
+  client cannot backdate the future to permanently satisfy the verify-time
+  review-record check (`Loopctl.Progress.ensure_review_conducted/3`).
   """
   @spec create_changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
   def create_changeset(record \\ %__MODULE__{}, attrs) do

--- a/lib/loopctl/artifacts/review_record.ex
+++ b/lib/loopctl/artifacts/review_record.ex
@@ -59,9 +59,13 @@ defmodule Loopctl.Artifacts.ReviewRecord do
   The `tenant_id`, `story_id`, and `reviewer_agent_id` are set
   programmatically, not via cast.
 
-  Validates that `completed_at` is not more than 5 minutes in the future, so a
-  client cannot backdate the future to permanently satisfy the verify-time
-  review-record check (`Loopctl.Progress.ensure_review_conducted/3`).
+  Validates that `completed_at` is not more than 60 seconds in the future (a
+  clock-skew allowance), so a client cannot forward-date a review to satisfy the
+  verify-time review-record check (`Loopctl.Progress.ensure_review_conducted/3`)
+  for a report that had not yet happened. NOTE: this bounds, but does not fully
+  eliminate, the stale-review-vs-re-report window — the structural closure
+  (binding a review record to the specific report generation it covers) is
+  tracked with the chain-of-custody invariant work.
   """
   @spec create_changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
   def create_changeset(record \\ %__MODULE__{}, attrs) do
@@ -83,20 +87,25 @@ defmodule Loopctl.Artifacts.ReviewRecord do
     |> validate_findings_math()
   end
 
-  # Validates that completed_at is not more than 5 minutes in the future
+  # Validates that completed_at is not more than 60 seconds in the future
+  # (clock-skew allowance only — a review does not legitimately "complete" in
+  # the future).
+  @completed_at_future_skew_seconds 60
+
   defp validate_completed_at_not_future(changeset) do
     case Ecto.Changeset.get_field(changeset, :completed_at) do
       nil ->
         changeset
 
       completed_at ->
-        max_future = DateTime.utc_now() |> DateTime.add(300, :second)
+        max_future =
+          DateTime.utc_now() |> DateTime.add(@completed_at_future_skew_seconds, :second)
 
         if DateTime.compare(completed_at, max_future) == :gt do
           Ecto.Changeset.add_error(
             changeset,
             :completed_at,
-            "cannot be more than 5 minutes in the future"
+            "cannot be more than #{@completed_at_future_skew_seconds} seconds in the future"
           )
         else
           changeset

--- a/lib/loopctl/bulk_operations.ex
+++ b/lib/loopctl/bulk_operations.ex
@@ -429,10 +429,16 @@ defmodule Loopctl.BulkOperations do
   end
 
   defp validate_verify_preconditions(story) do
-    if story.agent_status == :reported_done do
-      :ok
-    else
-      {:error, "Story must be in reported_done status to verify (current: #{story.agent_status})"}
+    cond do
+      story.verified_status == :verified ->
+        {:error, :already_verified}
+
+      story.agent_status == :reported_done ->
+        :ok
+
+      true ->
+        {:error,
+         "Story must be in reported_done status to verify (current: #{story.agent_status})"}
     end
   end
 

--- a/lib/loopctl/bulk_operations.ex
+++ b/lib/loopctl/bulk_operations.ex
@@ -257,7 +257,7 @@ defmodule Loopctl.BulkOperations do
          actor_id,
          actor_label
        ) do
-    with :ok <- Progress.mark_complete_allowed?(story),
+    with :ok <- Progress.ensure_mark_complete_allowed(story),
          {:ok, updated} <- apply_mark_complete(story) do
       create_mark_complete_result(tenant_id, story, orchestrator_agent_id, params)
 
@@ -333,8 +333,8 @@ defmodule Loopctl.BulkOperations do
 
   defp process_verify(story, params, tenant_id, orchestrator_agent_id, actor_id, actor_label) do
     with :ok <- validate_verify_preconditions(story),
-         :ok <- Progress.verify_allowed?(story, orchestrator_agent_id),
-         :ok <- Progress.review_conducted?(tenant_id, story.id, story),
+         :ok <- Progress.ensure_verify_allowed(story, orchestrator_agent_id),
+         :ok <- Progress.ensure_review_conducted(tenant_id, story.id, story),
          {:ok, updated} <- apply_verification(story) do
       create_verification_result(tenant_id, story, orchestrator_agent_id, params)
       audit_verification(tenant_id, story, updated, actor_id, actor_label, orchestrator_agent_id)
@@ -352,6 +352,7 @@ defmodule Loopctl.BulkOperations do
 
     with :ok <- validate_reason(reason),
          :ok <- validate_reject_preconditions(story),
+         :ok <- Progress.ensure_verify_allowed(story, orchestrator_agent_id),
          {:ok, updated} <- apply_rejection(story, reason) do
       create_rejection_result(tenant_id, story, orchestrator_agent_id, params)
       audit_rejection(tenant_id, story, updated, actor_id, actor_label, orchestrator_agent_id)

--- a/lib/loopctl/progress.ex
+++ b/lib/loopctl/progress.ex
@@ -956,13 +956,14 @@ defmodule Loopctl.Progress do
 
   Returns `:ok` when `orchestrator_agent_id` is permitted to verify `story`, or
   `{:error, :self_verify_blocked}` when the verifier shares dispatch lineage /
-  agent identity with the implementer. Exposed so `Loopctl.BulkOperations`
+  agent identity with the implementer. A nil `orchestrator_agent_id` is treated
+  as an untrusted identity and is always blocked. Exposed so `Loopctl.BulkOperations`
   enforces the SAME self-verify invariant as the single-story `verify_story/4`
   path — otherwise bulk verify is a chain-of-custody bypass.
   """
-  @spec verify_allowed?(Story.t(), Ecto.UUID.t() | nil) ::
+  @spec ensure_verify_allowed(Story.t(), Ecto.UUID.t() | nil) ::
           :ok | {:error, :self_verify_blocked}
-  def verify_allowed?(story, orchestrator_agent_id) do
+  def ensure_verify_allowed(story, orchestrator_agent_id) do
     case validate_not_self_verify(story, orchestrator_agent_id) do
       {:ok, _} -> :ok
       {:error, reason} -> {:error, reason}
@@ -974,9 +975,9 @@ defmodule Loopctl.Progress do
   was reported done, else `{:error, :review_not_conducted}`. Mirrors the
   `verify_story/4` review-record requirement for the bulk path.
   """
-  @spec review_conducted?(Ecto.UUID.t(), Ecto.UUID.t(), Story.t()) ::
+  @spec ensure_review_conducted(Ecto.UUID.t(), Ecto.UUID.t(), Story.t()) ::
           :ok | {:error, :review_not_conducted}
-  def review_conducted?(tenant_id, story_id, story) do
+  def ensure_review_conducted(tenant_id, story_id, story) do
     case validate_review_record_exists(tenant_id, story_id, story) do
       {:ok, _} -> :ok
       {:error, reason} -> {:error, reason}
@@ -990,10 +991,10 @@ defmodule Loopctl.Progress do
   `backfill_story/4`. Prevents mark-complete from being used to self-verify
   dispatched work.
   """
-  @spec mark_complete_allowed?(Story.t()) ::
+  @spec ensure_mark_complete_allowed(Story.t()) ::
           :ok
           | {:error, :already_verified | :story_rejected | :story_has_dispatch_lineage}
-  def mark_complete_allowed?(story) do
+  def ensure_mark_complete_allowed(story) do
     case guard_backfillable(story) do
       {:ok, _} -> :ok
       {:error, reason} -> {:error, reason}

--- a/lib/loopctl/progress.ex
+++ b/lib/loopctl/progress.ex
@@ -771,26 +771,29 @@ defmodule Loopctl.Progress do
          :ok <- validate_not_self_review(story, reviewer_agent_id) do
       attrs = build_review_attrs(params)
 
-      changeset =
-        %ReviewRecord{
-          tenant_id: tenant_id,
-          story_id: story_id,
-          reviewer_agent_id: reviewer_agent_id
-        }
-        |> ReviewRecord.create_changeset(attrs)
+      # Validate completed_at against story.reported_done_at before creating changeset
+      with :ok <- validate_review_completed_at(attrs, story) do
+        changeset =
+          %ReviewRecord{
+            tenant_id: tenant_id,
+            story_id: story_id,
+            reviewer_agent_id: reviewer_agent_id
+          }
+          |> ReviewRecord.create_changeset(attrs)
 
-      multi =
-        Multi.new()
-        |> Multi.insert(:review_record, changeset)
-        |> enqueue_knowledge_extraction(tenant_id)
+        multi =
+          Multi.new()
+          |> Multi.insert(:review_record, changeset)
+          |> enqueue_knowledge_extraction(tenant_id)
 
-      handle_review_transaction(
-        AdminRepo.transaction(multi),
-        tenant_id,
-        story,
-        attrs,
-        reviewer_agent_id
-      )
+        handle_review_transaction(
+          AdminRepo.transaction(multi),
+          tenant_id,
+          story,
+          attrs,
+          reviewer_agent_id
+        )
+      end
     end
   end
 
@@ -868,6 +871,18 @@ defmodule Loopctl.Progress do
   defp validate_story_reported_done(%Story{agent_status: :reported_done}), do: :ok
 
   defp validate_story_reported_done(_story), do: {:error, :story_not_reported_done}
+
+  # Validates that review completed_at is after story.reported_done_at
+  defp validate_review_completed_at(attrs, story) do
+    completed_at = Map.get(attrs, :completed_at)
+    reported_done_at = story.reported_done_at
+
+    if reported_done_at && DateTime.compare(completed_at, reported_done_at) == :lt do
+      {:error, :review_completed_before_reported_done}
+    else
+      :ok
+    end
+  end
 
   # --- Orchestrator Verification (US-7.2) ---
 
@@ -957,9 +972,10 @@ defmodule Loopctl.Progress do
   Returns `:ok` when `orchestrator_agent_id` is permitted to verify `story`, or
   `{:error, :self_verify_blocked}` when the verifier shares dispatch lineage /
   agent identity with the implementer. A nil `orchestrator_agent_id` is treated
-  as an untrusted identity and is always blocked. Exposed so `Loopctl.BulkOperations`
-  enforces the SAME self-verify invariant as the single-story `verify_story/4`
-  path — otherwise bulk verify is a chain-of-custody bypass.
+  as an untrusted identity and is always blocked.
+
+  Exposed so `Loopctl.BulkOperations` enforces the SAME self-verify invariant as
+  the single-story `verify_story/4` path — otherwise bulk verify is a chain-of-custody bypass.
   """
   @spec ensure_verify_allowed(Story.t(), Ecto.UUID.t() | nil) ::
           :ok | {:error, :self_verify_blocked}

--- a/lib/loopctl/progress.ex
+++ b/lib/loopctl/progress.ex
@@ -771,29 +771,26 @@ defmodule Loopctl.Progress do
          :ok <- validate_not_self_review(story, reviewer_agent_id) do
       attrs = build_review_attrs(params)
 
-      # Validate completed_at against story.reported_done_at before creating changeset
-      with :ok <- validate_review_completed_at(attrs, story) do
-        changeset =
-          %ReviewRecord{
-            tenant_id: tenant_id,
-            story_id: story_id,
-            reviewer_agent_id: reviewer_agent_id
-          }
-          |> ReviewRecord.create_changeset(attrs)
+      changeset =
+        %ReviewRecord{
+          tenant_id: tenant_id,
+          story_id: story_id,
+          reviewer_agent_id: reviewer_agent_id
+        }
+        |> ReviewRecord.create_changeset(attrs)
 
-        multi =
-          Multi.new()
-          |> Multi.insert(:review_record, changeset)
-          |> enqueue_knowledge_extraction(tenant_id)
+      multi =
+        Multi.new()
+        |> Multi.insert(:review_record, changeset)
+        |> enqueue_knowledge_extraction(tenant_id)
 
-        handle_review_transaction(
-          AdminRepo.transaction(multi),
-          tenant_id,
-          story,
-          attrs,
-          reviewer_agent_id
-        )
-      end
+      handle_review_transaction(
+        AdminRepo.transaction(multi),
+        tenant_id,
+        story,
+        attrs,
+        reviewer_agent_id
+      )
     end
   end
 
@@ -871,18 +868,6 @@ defmodule Loopctl.Progress do
   defp validate_story_reported_done(%Story{agent_status: :reported_done}), do: :ok
 
   defp validate_story_reported_done(_story), do: {:error, :story_not_reported_done}
-
-  # Validates that review completed_at is after story.reported_done_at
-  defp validate_review_completed_at(attrs, story) do
-    completed_at = Map.get(attrs, :completed_at)
-    reported_done_at = story.reported_done_at
-
-    if reported_done_at && DateTime.compare(completed_at, reported_done_at) == :lt do
-      {:error, :review_completed_before_reported_done}
-    else
-      :ok
-    end
-  end
 
   # --- Orchestrator Verification (US-7.2) ---
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -117,7 +117,7 @@ Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_K
 
 | Tool | Description |
 |---|---|
-| `bulk_mark_complete` | Bulk mark multiple stories as complete in a single API call. |
+| `bulk_mark_complete` | **Backfill-only.** Bulk-marks pre-existing, never-dispatched stories (pending, unassigned, no dispatch lineage) as complete in a single call. Dispatched stories are refused — they must go through the normal report → review → verify flow. |
 | `verify_all_in_epic` | Bulk verify all reported_done, unverified stories in an epic. |
 
 ### Token Efficiency Tools

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -1945,8 +1945,9 @@ const TOOLS = [
   {
     name: "bulk_mark_complete",
     description:
-      "Bulk mark multiple stories as complete in a single API call. " +
-      "Each story entry needs a story_id, summary, and review_type. Uses the ORCH key.",
+      "Bulk mark multiple stories as complete (backfill-only for never-dispatched work). " +
+      "ADMIN USE ONLY: backfill pre-existing completed work into pending stories that never entered the dispatch lifecycle. " +
+      "For dispatched stories, use the normal report/review/verify flow. Each story entry needs a story_id, summary, and review_type. Uses the ORCH key.",
     inputSchema: {
       type: "object",
       properties: {

--- a/test/loopctl/artifacts/review_record_test.exs
+++ b/test/loopctl/artifacts/review_record_test.exs
@@ -1,0 +1,59 @@
+defmodule Loopctl.Artifacts.ReviewRecordTest do
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.Artifacts.ReviewRecord
+
+  describe "create_changeset/2 completed_at future validation" do
+    test "accepts completed_at at the current time" do
+      changeset =
+        ReviewRecord.create_changeset(%ReviewRecord{}, %{
+          review_type: "enhanced",
+          completed_at: DateTime.utc_now()
+        })
+
+      assert changeset.valid?
+      refute Map.has_key?(errors_on(changeset), :completed_at)
+    end
+
+    test "accepts completed_at slightly in the future (within the 5-minute tolerance)" do
+      near_future = DateTime.add(DateTime.utc_now(), 60, :second)
+
+      changeset =
+        ReviewRecord.create_changeset(%ReviewRecord{}, %{
+          review_type: "enhanced",
+          completed_at: near_future
+        })
+
+      assert changeset.valid?
+      refute Map.has_key?(errors_on(changeset), :completed_at)
+    end
+
+    test "rejects a far-future completed_at" do
+      far_future = DateTime.add(DateTime.utc_now(), 3600, :second)
+
+      changeset =
+        ReviewRecord.create_changeset(%ReviewRecord{}, %{
+          review_type: "enhanced",
+          completed_at: far_future
+        })
+
+      refute changeset.valid?
+      assert %{completed_at: [message]} = errors_on(changeset)
+      assert message =~ "future"
+    end
+
+    test "rejects a completed_at just past the 5-minute tolerance" do
+      just_past_tolerance = DateTime.add(DateTime.utc_now(), 360, :second)
+
+      changeset =
+        ReviewRecord.create_changeset(%ReviewRecord{}, %{
+          review_type: "enhanced",
+          completed_at: just_past_tolerance
+        })
+
+      refute changeset.valid?
+      assert %{completed_at: [message]} = errors_on(changeset)
+      assert message =~ "future"
+    end
+  end
+end

--- a/test/loopctl/artifacts/review_record_test.exs
+++ b/test/loopctl/artifacts/review_record_test.exs
@@ -15,8 +15,8 @@ defmodule Loopctl.Artifacts.ReviewRecordTest do
       refute Map.has_key?(errors_on(changeset), :completed_at)
     end
 
-    test "accepts completed_at slightly in the future (within the 5-minute tolerance)" do
-      near_future = DateTime.add(DateTime.utc_now(), 60, :second)
+    test "accepts completed_at slightly in the future (within the 60-second skew tolerance)" do
+      near_future = DateTime.add(DateTime.utc_now(), 30, :second)
 
       changeset =
         ReviewRecord.create_changeset(%ReviewRecord{}, %{
@@ -42,8 +42,8 @@ defmodule Loopctl.Artifacts.ReviewRecordTest do
       assert message =~ "future"
     end
 
-    test "rejects a completed_at just past the 5-minute tolerance" do
-      just_past_tolerance = DateTime.add(DateTime.utc_now(), 360, :second)
+    test "rejects a completed_at just past the 60-second skew tolerance" do
+      just_past_tolerance = DateTime.add(DateTime.utc_now(), 90, :second)
 
       changeset =
         ReviewRecord.create_changeset(%ReviewRecord{}, %{

--- a/test/loopctl_web/controllers/bulk_operations_controller_test.exs
+++ b/test/loopctl_web/controllers/bulk_operations_controller_test.exs
@@ -4,6 +4,7 @@ defmodule LoopctlWeb.BulkOperationsControllerTest do
   setup :verify_on_exit!
 
   alias Loopctl.AdminRepo
+  alias Loopctl.Artifacts.VerificationResult
   alias Loopctl.Audit.AuditLog
   alias Loopctl.Webhooks.WebhookEvent
   alias Loopctl.WorkBreakdown.Story
@@ -401,7 +402,7 @@ defmodule LoopctlWeb.BulkOperationsControllerTest do
       assert AdminRepo.get!(Story, story.id).verified_status == :unverified
     end
 
-    test "bulk verify blocks re-verification of already-verified story", %{conn: conn} do
+    test "bulk verify blocks re-verification after a first successful verify", %{conn: conn} do
       tenant = fixture(:tenant)
       project = fixture(:project, %{tenant_id: tenant.id})
       epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
@@ -415,37 +416,62 @@ defmodule LoopctlWeb.BulkOperationsControllerTest do
           agent_id: orchestrator.id
         })
 
-      # Story that is already verified
+      # Distinct implementer (self-verify guard passes) with a review record so the
+      # first bulk verify actually succeeds.
       story =
         fixture(:story, %{
           tenant_id: tenant.id,
           epic_id: epic.id,
           agent_status: :reported_done,
-          verified_status: :verified,
           assigned_agent_id: implementer.id
         })
 
-      conn =
-        conn
-        |> auth_conn(raw_key)
-        |> post(~p"/api/v1/stories/bulk/verify", %{
-          "stories" => [
-            %{
-              "story_id" => story.id,
-              "result" => "pass",
-              "summary" => "re-verify",
-              "review_type" => "x"
-            }
-          ]
-        })
+      fixture(:review_record, %{tenant_id: tenant.id, story_id: story.id})
 
-      body = json_response(conn, 422)
+      payload = %{
+        "stories" => [
+          %{
+            "story_id" => story.id,
+            "result" => "pass",
+            "summary" => "first",
+            "review_type" => "x"
+          }
+        ]
+      }
+
+      # First verify succeeds.
+      first = conn |> auth_conn(raw_key) |> post(~p"/api/v1/stories/bulk/verify", payload)
+      assert hd(json_response(first, 200)["results"])["status"] == "success"
+
+      verified_story = AdminRepo.get!(Story, story.id)
+      assert verified_story.verified_status == :verified
+      first_verified_at = verified_story.verified_at
+
+      results_after_first =
+        VerificationResult
+        |> where([v], v.tenant_id == ^tenant.id and v.story_id == ^story.id)
+        |> AdminRepo.all()
+
+      assert length(results_after_first) == 1
+
+      # Second verify of the SAME story is blocked as already-verified.
+      second = conn |> auth_conn(raw_key) |> post(~p"/api/v1/stories/bulk/verify", payload)
+      body = json_response(second, 422)
       result = hd(body["results"])
       assert result["status"] == "error"
       assert result["reason"] =~ "already verified"
 
-      # Story remains verified — no re-verification occurred
-      assert AdminRepo.get!(Story, story.id).verified_status == :verified
+      # No side effects: verified_at unchanged and still exactly one VerificationResult.
+      reloaded = AdminRepo.get!(Story, story.id)
+      assert reloaded.verified_status == :verified
+      assert reloaded.verified_at == first_verified_at
+
+      results_after_second =
+        VerificationResult
+        |> where([v], v.tenant_id == ^tenant.id and v.story_id == ^story.id)
+        |> AdminRepo.all()
+
+      assert length(results_after_second) == 1
     end
   end
 

--- a/test/loopctl_web/controllers/bulk_operations_controller_test.exs
+++ b/test/loopctl_web/controllers/bulk_operations_controller_test.exs
@@ -400,6 +400,53 @@ defmodule LoopctlWeb.BulkOperationsControllerTest do
 
       assert AdminRepo.get!(Story, story.id).verified_status == :unverified
     end
+
+    test "bulk verify blocks re-verification of already-verified story", %{conn: conn} do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+      implementer = fixture(:agent, %{tenant_id: tenant.id})
+      orchestrator = fixture(:agent, %{tenant_id: tenant.id, agent_type: :orchestrator})
+
+      {raw_key, _api_key} =
+        fixture(:api_key, %{
+          tenant_id: tenant.id,
+          role: :orchestrator,
+          agent_id: orchestrator.id
+        })
+
+      # Story that is already verified
+      story =
+        fixture(:story, %{
+          tenant_id: tenant.id,
+          epic_id: epic.id,
+          agent_status: :reported_done,
+          verified_status: :verified,
+          assigned_agent_id: implementer.id
+        })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/stories/bulk/verify", %{
+          "stories" => [
+            %{
+              "story_id" => story.id,
+              "result" => "pass",
+              "summary" => "re-verify",
+              "review_type" => "x"
+            }
+          ]
+        })
+
+      body = json_response(conn, 422)
+      result = hd(body["results"])
+      assert result["status"] == "error"
+      assert result["reason"] =~ "already verified"
+
+      # Story remains verified — no re-verification occurred
+      assert AdminRepo.get!(Story, story.id).verified_status == :verified
+    end
   end
 
   describe "POST /api/v1/stories/bulk/reject" do
@@ -485,6 +532,47 @@ defmodule LoopctlWeb.BulkOperationsControllerTest do
       result = hd(body["results"])
       assert result["status"] == "error"
       assert result["reason"] =~ "reason"
+    end
+
+    test "bulk reject blocks self-adjudication (chain-of-custody parity)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+      orchestrator = fixture(:agent, %{tenant_id: tenant.id, agent_type: :orchestrator})
+
+      {raw_key, _api_key} =
+        fixture(:api_key, %{
+          tenant_id: tenant.id,
+          role: :orchestrator,
+          agent_id: orchestrator.id
+        })
+
+      # Story whose implementer IS the caller — reject must be blocked
+      story =
+        fixture(:story, %{
+          tenant_id: tenant.id,
+          epic_id: epic.id,
+          agent_status: :reported_done,
+          assigned_agent_id: orchestrator.id
+        })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/stories/bulk/reject", %{
+          "stories" => [
+            %{"story_id" => story.id, "reason" => "Self rejection attempt", "findings" => %{}}
+          ]
+        })
+
+      # Single-story batch that is fully blocked -> 422 (no successes).
+      body = json_response(conn, 422)
+      result = hd(body["results"])
+      assert result["status"] == "error"
+      assert result["reason"] =~ "chain-of-custody"
+
+      # Story remains unrejected — the bypass is closed.
+      assert AdminRepo.get!(Story, story.id).verified_status == :unverified
     end
   end
 


### PR DESCRIPTION
Fix-forward for the lateral chain-of-custody gaps an enhanced review found in PR #252 (bulk verify / mark-complete custody guards). All findings are addressed in this one branch — no deferrals.

## Fixes

**1. [Medium — footgun] Rename `?`-suffixed guards that don't return booleans.**
`verify_allowed?/2`, `review_conducted?/3`, `mark_complete_allowed?/1` returned `:ok | {:error, atom}`, so the `?` names violated the predicate convention (an `if guard?(...)` would treat the error tuple as truthy and silently disable the check). Renamed to `ensure_verify_allowed/2`, `ensure_review_conducted/3`, `ensure_mark_complete_allowed/1`; `@doc`/`@spec`/all call sites updated. Contract (`:ok | {:error, _}`) unchanged.

**2. [Low — doc] Document nil-identity blocking.**
`ensure_verify_allowed/2` `@doc` now states a nil `orchestrator_agent_id` is treated as an untrusted identity and is always blocked (maps to `{:error, :self_verify_blocked}`).

**3. [High — security] `bulk_reject` was missing the self-verify guard.**
Single-story `Progress.reject_story` runs `validate_not_self_verify`, but `BulkOperations.process_reject` did not — so an orchestrator could reject (self-adjudicate) their own implemented work, and rejection is destructive (`auto_reset_agent_status` wipes `assigned_agent_id`/`reported_done_at`). Added `Progress.ensure_verify_allowed(story, orchestrator_agent_id)` to `process_reject`'s `with` chain, mirroring `process_verify`. A self-reject now returns an `error` result with reason `=~ "chain-of-custody"` and the story stays `:unverified`.

**4. [Low — security] `bulk_verify` allowed re-verifying an already-verified story.**
`validate_verify_preconditions` only checked `agent_status == :reported_done`; the single path (`Progress.validate_verifiable`) also blocks `verified_status == :verified`. Added an ordered `cond` so already-verified is rejected first with `:already_verified`.

**5. [Medium — security] Review-record `completed_at` was unvalidated.**
`ReviewRecord.create_changeset` cast client-supplied `completed_at` with no bound, so a future-dated review permanently satisfied `ensure_review_conducted` (which only checks `completed_at > reported_done_at`). Added a `validate_change` rejecting timestamps more than 5 minutes in the future.

**6. [Low — docs] Stale MCP `bulk_mark_complete` description.**
Updated the tool description (`mcp-server/index.js`) and the README summary row to state it is backfill-only for pre-existing, never-dispatched stories; dispatched stories must use the normal verify flow. Doc-string only.

## Review-hardening note (this branch's follow-up commits)

An interim commit added an extra `Progress.record_review` guard rejecting `completed_at < reported_done_at` with a new `:review_completed_before_reported_done` atom. The review-record controller's `case` has no clause for that atom, so a backdated review would have crashed the endpoint (500). It was also out of scope — stale reviews are already blocked at verify time by `ensure_review_conducted/3`. **Reverted** to keep the endpoint safe and the PR scoped to the six findings.

## Tests

- `test/loopctl/artifacts/review_record_test.exs` (new) — FIX 5: far-future and just-past-5-min `completed_at` invalid; now / near-now valid.
- `bulk_operations_controller_test.exs` — FIX 3: `POST /stories/bulk/reject` self-adjudication blocked (422, reason `=~ "chain-of-custody"`, story stays `:unverified`). FIX 4: real verify-then-re-verify flow asserting `verified_at` unchanged and exactly one `VerificationResult` after the blocked re-verify.

## Verification

`mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo --strict`, `mix dialyzer` (0 errors), and full `mix test` (**3100 tests, 0 failures, 40 excluded**) all green. Committed through the full pre-commit gate (no `--no-verify`).

Refs private advisory GHSA-h49f-rhf8-8p6f.
