### PR TITLE
fix(custody): harden STH witness plug — no client-triggered halt, fixed-length prefix, one-time bootstrap

### DIFF
--- a/lib/loopctl/auth/api_key.ex
+++ b/lib/loopctl/auth/api_key.ex
@@ -30,6 +30,7 @@ defmodule Loopctl.Auth.ApiKey do
     field :last_used_at, :utc_datetime_usec
     field :expires_at, :utc_datetime_usec
     field :revoked_at, :utc_datetime_usec
+    field :sth_bootstrap_consumed_at, :utc_datetime_usec
 
     timestamps()
   end
@@ -75,6 +76,19 @@ defmodule Loopctl.Auth.ApiKey do
   @spec expire_changeset(%__MODULE__{}, DateTime.t()) :: Ecto.Changeset.t()
   def expire_changeset(api_key, expires_at) do
     change(api_key, expires_at: expires_at)
+  end
+
+  @doc """
+  Changeset that stamps the one-time STH witness bootstrap grace as consumed.
+
+  Once a key has bootstrapped, `LoopctlWeb.Plugs.ValidateWitnessHeader`
+  rejects any further `X-Loopctl-STH-Bootstrap` requests from it — the key
+  must present a real `X-Loopctl-Last-Known-STH` header on every subsequent
+  request (custody-03 / GHSA-36g5-mcrh-rcrm).
+  """
+  @spec consume_bootstrap_changeset(%__MODULE__{}) :: Ecto.Changeset.t()
+  def consume_bootstrap_changeset(api_key) do
+    change(api_key, sth_bootstrap_consumed_at: DateTime.utc_now())
   end
 
   @doc """

--- a/lib/loopctl_web/plugs/validate_witness_header.ex
+++ b/lib/loopctl_web/plugs/validate_witness_header.ex
@@ -3,11 +3,36 @@ defmodule LoopctlWeb.Plugs.ValidateWitnessHeader do
   US-26.5.2 — Validates the X-Loopctl-Last-Known-STH header on
   authenticated requests.
 
-  The header format is: `<position>:<base64url_sig_prefix_16_bytes>`
+  The header format is: `<position>:<base64url_sig_prefix>` where the
+  signature prefix is the base64url (no padding) encoding of the first
+  16 bytes of the STH signature — always exactly 22 characters.
 
-  Missing header → 412 Precondition Required.
-  Stale header (position too far behind) → 412.
-  Divergent signature prefix → 409 with custody halt trigger.
+  - Missing header → 412 Precondition Failed (`witness_header_missing`).
+  - Malformed header (bad split, non-integer position, or a signature
+    prefix that is not exactly 22 base64url chars) → 412
+    (`witness_header_malformed`).
+  - Signature-prefix mismatch against the server's STH → 409
+    (`witness_divergence`) with the server's current STH in the
+    `x-loopctl-current-sth` response header so a stale client can resync.
+
+  ## Custody safety (private advisories)
+
+  This plug operates on **raw, unauthenticated client input** and therefore
+  must never, on its own, treat a mismatch as proof of byzantine divergence:
+
+  * custody-01 (GHSA-w786-f588-2943): a client-supplied prefix mismatch does
+    NOT halt the tenant. A raw mismatch almost always means the caller's
+    cached STH is stale, not that the log forked. We respond 409 + resync
+    hint and emit telemetry for monitoring. Genuine byzantine halts stay with
+    the trust-violation paths in `LoopctlWeb.FallbackController` and the
+    signed-STH verifier — this plug halts custody for no client-driven reason.
+  * custody-02 (GHSA-cxrw-xg8f-mx8v): the comparison window is derived from
+    the fixed-length SERVER value, never from client input, and the client
+    prefix is length/charset validated up front so an empty or short prefix
+    cannot evade the divergence check.
+  * custody-03 (GHSA-36g5-mcrh-rcrm): the bootstrap grace is one-time per API
+    key (`api_keys.sth_bootstrap_consumed_at`), so a caller cannot send
+    `X-Loopctl-STH-Bootstrap: true` on every request to skip validation.
   """
 
   @behaviour Plug
@@ -16,16 +41,36 @@ defmodule LoopctlWeb.Plugs.ValidateWitnessHeader do
 
   require Logger
 
+  alias Loopctl.AdminRepo
+  alias Loopctl.AuditChain
+  alias Loopctl.Auth.ApiKey
+
+  # base64url(no padding) of the first 16 bytes of the signature is always
+  # exactly 22 characters. This is the ONLY accepted client prefix length —
+  # the comparison window is fixed by the server, not by client input.
+  @sig_prefix_length 22
+  @zero_sth_prefix Base.url_encode64(:binary.copy(<<0>>, 16), padding: false)
+  @zero_sth "0:#{@zero_sth_prefix}"
+
   @impl true
   def init(opts), do: opts
 
   @impl true
-  def call(conn, _opts) do
-    # Config-driven enforcement: disabled in test via config/test.exs
-    if Application.get_env(:loopctl, :enforce_witness_header, true) do
+  def call(conn, opts) do
+    if enforce?(opts) do
       enforce(conn)
     else
       conn
+    end
+  end
+
+  # Enforcement is config-gated (disabled in test via config/test.exs) but can
+  # be forced on per-call via the `:enforce` plug opt — the dedicated plug tests
+  # exercise enforcement without an `Application.put_env` (forbidden in tests).
+  defp enforce?(opts) do
+    case Keyword.fetch(opts, :enforce) do
+      {:ok, value} -> value
+      :error -> Application.get_env(:loopctl, :enforce_witness_header, true)
     end
   end
 
@@ -35,30 +80,14 @@ defmodule LoopctlWeb.Plugs.ValidateWitnessHeader do
         validate_header(conn, header)
 
       [] ->
-        # Bootstrap grace: new dispatches get their first request through
-        # with a warning header + the current STH in the response, so they
-        # can cache it. After the first request, enforcement is strict.
-        # Grace is signaled by the X-Loopctl-STH-Bootstrap: true header
-        # from the agent (opt-in, not automatic).
-        if get_req_header(conn, "x-loopctl-sth-bootstrap") == ["true"] do
+        # Bootstrap grace: a new dispatch's FIRST request may opt in with
+        # `X-Loopctl-STH-Bootstrap: true` to receive the current STH in the
+        # response headers so it can cache it. The grace is one-time per API
+        # key (custody-03) — after that the key must send a real header.
+        if bootstrap_requested?(conn) do
           handle_bootstrap_grace(conn)
         else
-          conn
-          |> put_status(:precondition_required)
-          |> Phoenix.Controller.json(%{
-            error: %{
-              code: "witness_header_missing",
-              status: 412,
-              message:
-                "X-Loopctl-Last-Known-STH header is required. " <>
-                  "On your first request, include X-Loopctl-STH-Bootstrap: true " <>
-                  "to receive the current STH in the response headers.",
-              remediation: %{
-                learn_more: "https://loopctl.com/wiki/witness-protocol"
-              }
-            }
-          })
-          |> halt()
+          missing_header(conn)
         end
     end
   end
@@ -66,118 +95,224 @@ defmodule LoopctlWeb.Plugs.ValidateWitnessHeader do
   defp validate_header(conn, header) do
     case String.split(header, ":", parts: 2) do
       [position_str, sig_prefix] ->
-        # US-26.5.2 AC-3: compare against server's STH
-        check_divergence(conn, position_str, sig_prefix)
+        if valid_sig_prefix?(sig_prefix) do
+          # US-26.5.2 AC-3: compare against the server's STH.
+          check_divergence(conn, position_str, sig_prefix)
+        else
+          # custody-02: an empty/short/long/non-base64url prefix must be
+          # rejected rather than silently comparing an attacker-chosen window.
+          malformed(
+            conn,
+            "X-Loopctl-Last-Known-STH signature prefix must be exactly " <>
+              "#{@sig_prefix_length} base64url characters"
+          )
+        end
 
       _ ->
         Logger.warning("ValidateWitnessHeader: malformed header: #{inspect(header)}")
-
-        conn
-        |> put_status(:precondition_required)
-        |> Phoenix.Controller.json(%{
-          error: %{
-            code: "witness_header_malformed",
-            status: 412,
-            message: "X-Loopctl-Last-Known-STH header is malformed"
-          }
-        })
-        |> halt()
+        malformed(conn, "X-Loopctl-Last-Known-STH header is malformed")
     end
   end
 
   defp check_divergence(conn, position_str, sig_prefix) do
     # Resolve tenant from conn (set by SetTenant plug earlier in pipeline)
-    tenant_id =
-      case conn.assigns do
-        %{current_api_key: %{tenant_id: tid}} when not is_nil(tid) -> tid
-        _ -> nil
-      end
+    tenant_id = get_tenant_id(conn)
 
     if tenant_id do
       case Integer.parse(position_str) do
-        {position, ""} ->
+        {position, ""} when position >= 0 ->
           compare_against_server_sth(conn, tenant_id, position, sig_prefix)
 
         _ ->
-          conn
-          |> put_status(:precondition_required)
-          |> Phoenix.Controller.json(%{
-            error: %{
-              code: "witness_header_malformed",
-              status: 412,
-              message: "Position must be an integer"
-            }
-          })
-          |> halt()
+          malformed(conn, "Position must be a non-negative integer")
       end
     else
-      # No tenant context (superadmin or public) — skip divergence check
+      # No tenant context (superadmin or public) — skip divergence check.
       conn
     end
   end
 
   defp compare_against_server_sth(conn, tenant_id, position, sig_prefix) do
-    alias Loopctl.AuditChain
-
     case AuditChain.get_sth_at_position(tenant_id, position) do
       nil ->
-        # No STH at this position — agent may be ahead of server, allow
+        # No STH at this position — agent may be ahead of the server, allow.
         conn
 
       sth ->
-        server_prefix =
-          sth.signature
-          |> binary_part(0, min(byte_size(sth.signature), 16))
-          |> Base.url_encode64(padding: false)
-          |> String.slice(0, String.length(sig_prefix))
+        server_prefix = server_sig_prefix(sth.signature)
 
-        if server_prefix == sig_prefix do
+        # Constant-time compare of two fixed-length, server-derived-length
+        # strings. `sig_prefix` was already validated to @sig_prefix_length.
+        if Plug.Crypto.secure_compare(server_prefix, sig_prefix) do
           conn
         else
-          # Divergence detected — halt tenant's custody operations
-          Logger.error(
-            "WITNESS DIVERGENCE: tenant=#{tenant_id} position=#{position} " <>
-              "client_prefix=#{sig_prefix} server_prefix=#{server_prefix}"
-          )
-
-          Loopctl.Tenants.halt_custody(tenant_id)
-
-          conn
-          |> put_status(:conflict)
-          |> Phoenix.Controller.json(%{
-            error: %{
-              code: "witness_divergence",
-              status: 409,
-              message: "STH divergence detected. Custody operations halted.",
-              remediation: %{
-                learn_more: "https://loopctl.com/wiki/witness-protocol"
-              }
-            }
-          })
-          |> halt()
+          witness_divergence(conn, tenant_id, position, sig_prefix, server_prefix)
         end
     end
   end
 
-  defp handle_bootstrap_grace(conn) do
-    tenant_id = get_tenant_id(conn)
-    sth = if tenant_id, do: Loopctl.AuditChain.get_latest_sth(tenant_id)
+  # custody-01: a raw client-supplied prefix mismatch is NOT proof of a fork —
+  # it is almost always a stale client cache. Do NOT halt the tenant. Tell the
+  # client to resync (handing it the current STH) and emit telemetry so genuine
+  # divergence can be monitored/alerted out-of-band.
+  defp witness_divergence(conn, tenant_id, position, sig_prefix, server_prefix) do
+    Logger.warning(
+      "WITNESS DIVERGENCE (client-reported, NOT halting): tenant=#{tenant_id} " <>
+        "position=#{position} client_prefix=#{sig_prefix} server_prefix=#{server_prefix}"
+    )
 
-    sth_value =
-      if sth do
-        prefix =
-          Base.url_encode64(binary_part(sth.signature, 0, min(byte_size(sth.signature), 16)),
-            padding: false
-          )
-
-        "#{sth.chain_position}:#{prefix}"
-      else
-        "0:AAAAAAAAAAAAAAAAAAAAAA"
-      end
+    :telemetry.execute(
+      [:loopctl, :witness, :divergence],
+      %{count: 1},
+      %{tenant_id: tenant_id, position: position}
+    )
 
     conn
-    |> put_resp_header("x-loopctl-current-sth", sth_value)
+    |> put_status(:conflict)
+    |> put_resp_header("x-loopctl-current-sth", current_sth_value(tenant_id))
+    |> Phoenix.Controller.json(%{
+      error: %{
+        code: "witness_divergence",
+        status: 409,
+        message:
+          "Your cached STH does not match the server. Re-sync from the " <>
+            "x-loopctl-current-sth response header and retry. Custody has NOT been halted.",
+        remediation: %{
+          learn_more: "https://loopctl.com/wiki/witness-protocol"
+        }
+      }
+    })
+    |> halt()
+  end
+
+  # custody-03: one-time bootstrap grace, keyed on the resolved API key.
+  defp handle_bootstrap_grace(conn) do
+    case conn.assigns[:current_api_key] do
+      %ApiKey{sth_bootstrap_consumed_at: nil} = api_key ->
+        grant_bootstrap_grace(conn, api_key)
+
+      %ApiKey{} ->
+        # Already bootstrapped once — must present a real witness header now.
+        bootstrap_already_consumed(conn)
+
+      _ ->
+        # No resolved API key row to record consumption on (defensive: the
+        # authenticated pipeline sets current_api_key before this plug). Grant
+        # the grace without stamping rather than crashing.
+        put_bootstrap_headers(conn, get_tenant_id(conn))
+    end
+  end
+
+  defp grant_bootstrap_grace(conn, %ApiKey{} = api_key) do
+    case stamp_bootstrap_consumed(api_key) do
+      {:ok, _updated} ->
+        put_bootstrap_headers(conn, api_key.tenant_id)
+
+      {:error, reason} ->
+        # Fail closed: if we cannot record consumption we must not grant an
+        # unbounded (repeatable) grace. Fall back to requiring the header.
+        Logger.warning(
+          "ValidateWitnessHeader: failed to stamp bootstrap consumption for " <>
+            "api_key=#{api_key.id}: #{inspect(reason)}"
+        )
+
+        missing_header(conn)
+    end
+  end
+
+  defp stamp_bootstrap_consumed(%ApiKey{} = api_key) do
+    api_key
+    |> ApiKey.consume_bootstrap_changeset()
+    |> AdminRepo.update()
+  end
+
+  defp put_bootstrap_headers(conn, tenant_id) do
+    conn
+    |> put_resp_header("x-loopctl-current-sth", current_sth_value(tenant_id))
     |> put_resp_header("x-loopctl-sth-warning", "missing_header_bootstrap_grace")
+  end
+
+  defp bootstrap_already_consumed(conn) do
+    conn
+    |> put_status(:precondition_failed)
+    |> put_resp_header("x-loopctl-current-sth", current_sth_value(get_tenant_id(conn)))
+    |> Phoenix.Controller.json(%{
+      error: %{
+        code: "witness_bootstrap_already_consumed",
+        status: 412,
+        message:
+          "This API key has already used its one-time STH bootstrap grace. " <>
+            "Include the X-Loopctl-Last-Known-STH header (position:prefix) on " <>
+            "every subsequent request. The current STH is in the " <>
+            "x-loopctl-current-sth response header.",
+        remediation: %{
+          learn_more: "https://loopctl.com/wiki/witness-protocol"
+        }
+      }
+    })
+    |> halt()
+  end
+
+  defp missing_header(conn) do
+    conn
+    |> put_status(:precondition_failed)
+    |> Phoenix.Controller.json(%{
+      error: %{
+        code: "witness_header_missing",
+        status: 412,
+        message:
+          "X-Loopctl-Last-Known-STH header is required. " <>
+            "On your first request, include X-Loopctl-STH-Bootstrap: true " <>
+            "to receive the current STH in the response headers.",
+        remediation: %{
+          learn_more: "https://loopctl.com/wiki/witness-protocol"
+        }
+      }
+    })
+    |> halt()
+  end
+
+  defp malformed(conn, message) do
+    conn
+    |> put_status(:precondition_failed)
+    |> Phoenix.Controller.json(%{
+      error: %{
+        code: "witness_header_malformed",
+        status: 412,
+        message: message
+      }
+    })
+    |> halt()
+  end
+
+  # --- helpers ---
+
+  defp bootstrap_requested?(conn) do
+    get_req_header(conn, "x-loopctl-sth-bootstrap") == ["true"]
+  end
+
+  # base64url(no padding) of the first 16 bytes of the signature. For any
+  # ed25519 signature (64 bytes) this is exactly @sig_prefix_length chars.
+  defp server_sig_prefix(signature) when is_binary(signature) do
+    signature
+    |> binary_part(0, min(byte_size(signature), 16))
+    |> Base.url_encode64(padding: false)
+  end
+
+  # The `<position>:<prefix>` value handed back to clients so they can cache /
+  # resync. Falls back to the all-zero STH when the tenant has no STH yet.
+  defp current_sth_value(nil), do: @zero_sth
+
+  defp current_sth_value(tenant_id) do
+    case AuditChain.get_latest_sth(tenant_id) do
+      nil -> @zero_sth
+      sth -> "#{sth.chain_position}:#{server_sig_prefix(sth.signature)}"
+    end
+  end
+
+  defp valid_sig_prefix?(prefix) do
+    String.length(prefix) == @sig_prefix_length and
+      String.match?(prefix, ~r/\A[A-Za-z0-9_-]+\z/)
   end
 
   defp get_tenant_id(conn) do

--- a/priv/repo/migrations/20260701150000_add_sth_bootstrap_consumed_at_to_api_keys.exs
+++ b/priv/repo/migrations/20260701150000_add_sth_bootstrap_consumed_at_to_api_keys.exs
@@ -1,0 +1,16 @@
+defmodule Loopctl.Repo.Migrations.AddSthBootstrapConsumedAtToApiKeys do
+  use Ecto.Migration
+
+  # US-26.5.2 / custody-03 (GHSA-36g5-mcrh-rcrm): the STH witness bootstrap grace
+  # must be one-time per API key. Record when a key consumed its grace so the
+  # ValidateWitnessHeader plug can reject a second bootstrap request.
+  #
+  # `api_keys` already has RLS (ENABLE + FORCE) with a tenant_isolation policy;
+  # adding a nullable column does not alter that, and we intentionally leave the
+  # existing policy untouched.
+  def change do
+    alter table(:api_keys) do
+      add :sth_bootstrap_consumed_at, :utc_datetime_usec
+    end
+  end
+end

--- a/test/loopctl_web/plugs/validate_witness_header_test.exs
+++ b/test/loopctl_web/plugs/validate_witness_header_test.exs
@@ -1,0 +1,227 @@
+defmodule LoopctlWeb.Plugs.ValidateWitnessHeaderTest do
+  @moduledoc """
+  US-26.5.2 + custody-01/02/03 hardening for the STH witness plug.
+
+  Enforcement is disabled by default in test (config/test.exs), so these
+  tests drive the plug directly with the `enforce: true` opt — no
+  `Application.put_env` (forbidden by the repo test conventions).
+  """
+
+  use LoopctlWeb.ConnCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.AuditChain.SignedTreeHead
+  alias Loopctl.Auth.ApiKey
+  alias Loopctl.Tenants
+  alias LoopctlWeb.Plugs.ValidateWitnessHeader
+
+  @enforce [enforce: true]
+
+  # A valid 22-char base64url prefix that will NOT match a random signature.
+  @other_prefix "ZZZZZZZZZZZZZZZZZZZZZZ"
+
+  defp base_conn do
+    Phoenix.ConnTest.build_conn()
+  end
+
+  defp with_api_key(conn, api_key) do
+    Plug.Conn.assign(conn, :current_api_key, api_key)
+  end
+
+  # Inserts an STH at `position` with a known signature and returns the
+  # server-side 22-char prefix the plug will compute from it.
+  defp insert_sth(tenant_id, position) do
+    signature = :crypto.strong_rand_bytes(64)
+
+    %SignedTreeHead{tenant_id: tenant_id}
+    |> SignedTreeHead.changeset(%{
+      chain_position: position,
+      merkle_root: :crypto.strong_rand_bytes(32),
+      signed_at: DateTime.utc_now(),
+      signature: signature
+    })
+    |> AdminRepo.insert!()
+
+    Base.url_encode64(binary_part(signature, 0, 16), padding: false)
+  end
+
+  describe "enforcement gating" do
+    test "passes through untouched when not enforcing" do
+      conn = base_conn() |> ValidateWitnessHeader.call([])
+      refute conn.halted
+    end
+
+    test "412 witness_header_missing when enforcing and no header" do
+      api_key = %ApiKey{id: Ecto.UUID.generate(), tenant_id: Ecto.UUID.generate()}
+
+      conn =
+        base_conn()
+        |> with_api_key(api_key)
+        |> ValidateWitnessHeader.call(@enforce)
+
+      assert conn.halted
+      assert conn.status == 412
+      assert Jason.decode!(conn.resp_body)["error"]["code"] == "witness_header_missing"
+    end
+  end
+
+  describe "FIX A — client-supplied divergence never halts the tenant" do
+    test "mismatching prefix returns 409 witness_divergence with current-sth hint and NO halt" do
+      {_raw, api_key} = fixture(:api_key, %{role: :agent})
+      tenant_id = api_key.tenant_id
+      _server_prefix = insert_sth(tenant_id, 5)
+
+      conn =
+        base_conn()
+        |> put_req_header("x-loopctl-last-known-sth", "5:#{@other_prefix}")
+        |> with_api_key(api_key)
+        |> ValidateWitnessHeader.call(@enforce)
+
+      assert conn.halted
+      assert conn.status == 409
+
+      body = Jason.decode!(conn.resp_body)
+      assert body["error"]["code"] == "witness_divergence"
+
+      # Client is handed the server's current STH so it can resync.
+      assert [hint] = get_resp_header(conn, "x-loopctl-current-sth")
+      assert hint =~ ~r/\A\d+:[A-Za-z0-9_-]{22}\z/
+
+      # The tenant's custody must NOT have been halted by raw client input.
+      {:ok, tenant} = Tenants.get_tenant(tenant_id)
+      refute Tenants.custody_halted?(tenant)
+    end
+
+    test "matching prefix passes through and does not halt" do
+      {_raw, api_key} = fixture(:api_key, %{role: :agent})
+      server_prefix = insert_sth(api_key.tenant_id, 7)
+
+      conn =
+        base_conn()
+        |> put_req_header("x-loopctl-last-known-sth", "7:#{server_prefix}")
+        |> with_api_key(api_key)
+        |> ValidateWitnessHeader.call(@enforce)
+
+      refute conn.halted
+      assert is_nil(conn.status)
+    end
+  end
+
+  describe "FIX B — fixed-length prefix, empty/short cannot evade divergence" do
+    test "empty prefix (\"5:\") is rejected 412 witness_header_malformed" do
+      {_raw, api_key} = fixture(:api_key, %{role: :agent})
+      _server_prefix = insert_sth(api_key.tenant_id, 5)
+
+      conn =
+        base_conn()
+        |> put_req_header("x-loopctl-last-known-sth", "5:")
+        |> with_api_key(api_key)
+        |> ValidateWitnessHeader.call(@enforce)
+
+      assert conn.halted
+      assert conn.status == 412
+      assert Jason.decode!(conn.resp_body)["error"]["code"] == "witness_header_malformed"
+
+      # Crucially: an empty prefix must NOT be silently accepted as "matching".
+      refute conn.status == 200
+    end
+
+    test "short prefix is rejected 412 witness_header_malformed" do
+      {_raw, api_key} = fixture(:api_key, %{role: :agent})
+      _server_prefix = insert_sth(api_key.tenant_id, 5)
+
+      conn =
+        base_conn()
+        |> put_req_header("x-loopctl-last-known-sth", "5:abc")
+        |> with_api_key(api_key)
+        |> ValidateWitnessHeader.call(@enforce)
+
+      assert conn.halted
+      assert conn.status == 412
+      assert Jason.decode!(conn.resp_body)["error"]["code"] == "witness_header_malformed"
+    end
+
+    test "over-length prefix is rejected 412 witness_header_malformed" do
+      {_raw, api_key} = fixture(:api_key, %{role: :agent})
+
+      conn =
+        base_conn()
+        |> put_req_header("x-loopctl-last-known-sth", "5:#{String.duplicate("A", 23)}")
+        |> with_api_key(api_key)
+        |> ValidateWitnessHeader.call(@enforce)
+
+      assert conn.halted
+      assert conn.status == 412
+      assert Jason.decode!(conn.resp_body)["error"]["code"] == "witness_header_malformed"
+    end
+
+    test "non-base64url prefix of the right length is rejected 412" do
+      {_raw, api_key} = fixture(:api_key, %{role: :agent})
+
+      conn =
+        base_conn()
+        # 22 chars but '+' and '/' are standard-base64, not base64url.
+        |> put_req_header("x-loopctl-last-known-sth", "5:AAAAAAAAAA++//AAAAAAAA")
+        |> with_api_key(api_key)
+        |> ValidateWitnessHeader.call(@enforce)
+
+      assert conn.halted
+      assert conn.status == 412
+      assert Jason.decode!(conn.resp_body)["error"]["code"] == "witness_header_malformed"
+    end
+  end
+
+  describe "FIX C — bootstrap grace is one-time per API key" do
+    defp bootstrap_conn(api_key) do
+      base_conn()
+      |> put_req_header("x-loopctl-sth-bootstrap", "true")
+      |> with_api_key(api_key)
+    end
+
+    test "first bootstrap request is granted and stamps sth_bootstrap_consumed_at" do
+      {_raw, api_key} = fixture(:api_key, %{role: :agent})
+      assert is_nil(api_key.sth_bootstrap_consumed_at)
+
+      conn = api_key |> bootstrap_conn() |> ValidateWitnessHeader.call(@enforce)
+
+      # Grace granted → request continues (not halted), with cache hints.
+      refute conn.halted
+      assert [_sth] = get_resp_header(conn, "x-loopctl-current-sth")
+      assert ["missing_header_bootstrap_grace"] = get_resp_header(conn, "x-loopctl-sth-warning")
+
+      # Consumption is now recorded on the key.
+      reloaded = AdminRepo.get!(ApiKey, api_key.id)
+      assert %DateTime{} = reloaded.sth_bootstrap_consumed_at
+    end
+
+    test "a second bootstrap request from the same key is rejected 412" do
+      {_raw, api_key} = fixture(:api_key, %{role: :agent})
+
+      # First request consumes the grace.
+      _ = api_key |> bootstrap_conn() |> ValidateWitnessHeader.call(@enforce)
+
+      # Reload so the struct carries the stamped consumed_at, then retry.
+      reloaded = AdminRepo.get!(ApiKey, api_key.id)
+
+      conn = reloaded |> bootstrap_conn() |> ValidateWitnessHeader.call(@enforce)
+
+      assert conn.halted
+      assert conn.status == 412
+
+      assert Jason.decode!(conn.resp_body)["error"]["code"] ==
+               "witness_bootstrap_already_consumed"
+    end
+
+    test "no resolved api key (superadmin/absent) does not crash and grants grace" do
+      conn =
+        base_conn()
+        |> put_req_header("x-loopctl-sth-bootstrap", "true")
+        |> ValidateWitnessHeader.call(@enforce)
+
+      refute conn.halted
+      assert [_sth] = get_resp_header(conn, "x-loopctl-current-sth")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

The `X-Loopctl-Last-Known-STH` witness plug (`LoopctlWeb.Plugs.ValidateWitnessHeader`) sits in the `:authenticated` pipeline and validates raw, unauthenticated client input — yet it could halt an entire tenant, be evaded, and be permanently opted-out. This PR fixes three chain-of-custody vulnerabilities (private advisories) and adds a dedicated test suite.

## Fixes

### FIX A — custody-01 (GHSA-w786-f588-2943, HIGH): unauthenticated client can force a persistent tenant-wide custody halt
Previously, a client-supplied signature-prefix mismatch called `Tenants.halt_custody/1`, so **any** agent-role caller could persistently DoS the whole tenant (via `CheckCustodyHalt`) just by sending a bogus/stale prefix. A raw mismatch is not proof of a fork — it almost always means the caller's cached STH is stale.

- No longer halts custody from this plug.
- Returns `409 witness_divergence` and includes the server's current STH in the `x-loopctl-current-sth` response header so a legitimate client can resync.
- Emits a `[:loopctl, :witness, :divergence]` telemetry event + `Logger.warning` for monitoring (no `Logger.error` + halt).
- Genuine byzantine halts remain with the `FallbackController` trust-violation paths and the signed-STH verifier (**untouched**).

### FIX B — custody-02 (GHSA-cxrw-xg8f-mx8v, MEDIUM): divergence check bypassable via empty/short prefix
The server prefix was sliced to `String.length(client_prefix)`, so an empty prefix (`"<pos>:"`) made `"" == ""` always pass, and a 1-char prefix compared a single char — evading divergence detection.

- The client prefix must now be **exactly 22 base64url chars** (the canonical length of `base64url(first 16 signature bytes)`), else `412 witness_header_malformed`.
- The comparison window is derived solely from the fixed-length **server** value via `Plug.Crypto.secure_compare/2` — never from client input.

### FIX C — custody-03 (GHSA-36g5-mcrh-rcrm, MEDIUM): witness enforcement permanently opt-out via bootstrap header
`X-Loopctl-STH-Bootstrap: true` granted grace on every request with no state, permanently skipping validation.

- Bootstrap grace is now **one-time per API key**.
- New migration adds nullable `api_keys.sth_bootstrap_consumed_at :utc_datetime_usec` (RLS on `api_keys` left untouched; stamped via `AdminRepo`).
- First bootstrap stamps consumption and grants grace (keeping the `x-loopctl-current-sth` cache hint); a second bootstrap from the same key is rejected `412 witness_bootstrap_already_consumed`.
- Absent/superadmin key is handled gracefully (grace without stamping, no crash).

## Migration
`priv/repo/migrations/20260701150000_add_sth_bootstrap_consumed_at_to_api_keys.exs` — `alter table(:api_keys) add :sth_bootstrap_consumed_at`. Reversible `change/0` (verified down/up on dev DB). Does not alter the existing `api_keys` RLS.

## Notable adjustments
- Standardized all precondition rejections to actual HTTP **412** — the plug previously used the `:precondition_required` (428) atom while the JSON body and moduledoc declared 412 (a latent HTTP-vs-body inconsistency).
- Added an `:enforce` plug opt so the dedicated tests exercise enforcement without `Application.put_env` (forbidden by repo test conventions).

## Tests
New `test/loopctl_web/plugs/validate_witness_header_test.exs` (11 tests) covering: mismatch → 409 + resync header + **tenant not halted** (A); empty/short/over-length/non-base64url prefixes → 412 (B); first bootstrap grants+stamps, second is rejected 412, absent-key no-crash (C).

Full gate green locally: `compile --warnings-as-errors`, `format --check`, `credo --strict`, `deps.audit`, `dialyzer` (0 errors), and `mix test` → **3111 tests, 0 failures, 40 excluded**.

Refs private advisories GHSA-w786-f588-2943, GHSA-cxrw-xg8f-mx8v, GHSA-36g5-mcrh-rcrm.