### PR TITLE
fix(custody): close witness-plug bootstrap race, future-position bypass, oversized-position crash

### DIFF
--- a/lib/loopctl/audit_chain.ex
+++ b/lib/loopctl/audit_chain.ex
@@ -216,10 +216,29 @@ defmodule Loopctl.AuditChain do
     |> AdminRepo.one()
   end
 
+  # Postgres bigint (int8) upper bound. `chain_position` is a bigint, so a
+  # position outside 0..max cannot exist in the chain AND would raise
+  # DBConnection.EncodeError if handed to Postgrex — out-of-range lookups
+  # short-circuit to nil instead. Single source of truth for callers that guard
+  # the input up front (e.g. the witness plug).
+  @max_chain_position 9_223_372_036_854_775_807
+
+  @doc "The maximum valid chain position (Postgres bigint upper bound)."
+  @spec max_chain_position() :: pos_integer()
+  def max_chain_position, do: @max_chain_position
+
   @doc """
   Returns the smallest STH with chain_position >= the given position.
+
+  Defensively returns `nil` for a non-integer or out-of-bigint-range position, so
+  no caller (including the public, unauthenticated STH endpoint) can hand an
+  unencodable value to Postgrex.
   """
-  @spec get_sth_at_position(Ecto.UUID.t(), non_neg_integer()) :: SignedTreeHead.t() | nil
+  @spec get_sth_at_position(Ecto.UUID.t(), integer()) :: SignedTreeHead.t() | nil
+  def get_sth_at_position(_tenant_id, position)
+      when not is_integer(position) or position < 0 or position > @max_chain_position,
+      do: nil
+
   def get_sth_at_position(tenant_id, position) do
     from(s in SignedTreeHead,
       where: s.tenant_id == ^tenant_id and s.chain_position >= ^position,

--- a/lib/loopctl/auth/api_key.ex
+++ b/lib/loopctl/auth/api_key.ex
@@ -78,18 +78,11 @@ defmodule Loopctl.Auth.ApiKey do
     change(api_key, expires_at: expires_at)
   end
 
-  @doc """
-  Changeset that stamps the one-time STH witness bootstrap grace as consumed.
-
-  Once a key has bootstrapped, `LoopctlWeb.Plugs.ValidateWitnessHeader`
-  rejects any further `X-Loopctl-STH-Bootstrap` requests from it — the key
-  must present a real `X-Loopctl-Last-Known-STH` header on every subsequent
-  request (custody-03 / GHSA-36g5-mcrh-rcrm).
-  """
-  @spec consume_bootstrap_changeset(%__MODULE__{}) :: Ecto.Changeset.t()
-  def consume_bootstrap_changeset(api_key) do
-    change(api_key, sth_bootstrap_consumed_at: DateTime.utc_now())
-  end
+  # NOTE: the one-time STH bootstrap grace (custody-03) is consumed via an
+  # atomic conditional `UPDATE ... WHERE sth_bootstrap_consumed_at IS NULL`
+  # in `LoopctlWeb.Plugs.ValidateWitnessHeader` — NOT via a changeset — so the
+  # NULL guard is evaluated by Postgres and two concurrent first-requests
+  # cannot both win. See that plug for the single-winner logic.
 
   @doc """
   Returns the list of valid roles.

--- a/lib/loopctl_web/plugs/validate_witness_header.ex
+++ b/lib/loopctl_web/plugs/validate_witness_header.ex
@@ -53,7 +53,8 @@ defmodule LoopctlWeb.Plugs.ValidateWitnessHeader do
   # chain_position is a Postgres bigint; reject anything outside the signed
   # 64-bit range up front so an oversized (arbitrary-precision) Elixir int
   # never reaches the query and raises a DBConnection.EncodeError (custody-03b).
-  @max_chain_position 9_223_372_036_854_775_807
+  # Single source of truth: AuditChain also enforces this bound defensively.
+  @max_chain_position AuditChain.max_chain_position()
   @zero_sth_prefix Base.url_encode64(:binary.copy(<<0>>, 16), padding: false)
   @zero_sth "0:#{@zero_sth_prefix}"
 
@@ -220,30 +221,49 @@ defmodule LoopctlWeb.Plugs.ValidateWitnessHeader do
   end
 
   defp atomic_consume_bootstrap(conn, id, tenant_id) do
+    # Read the STH the client will cache BEFORE consuming the one-time grace.
+    # This lookup is read-only and idempotent, so doing it first means a
+    # transient read failure raises here — with the grace NOT yet consumed
+    # (rescued to a retryable missing_header) — instead of AFTER the UPDATE has
+    # already burned the grace, which would permanently strand the key.
+    sth_value = current_sth_value(tenant_id)
+
     {count, _} =
       from(a in ApiKey, where: a.id == ^id and is_nil(a.sth_bootstrap_consumed_at))
       |> AdminRepo.update_all(set: [sth_bootstrap_consumed_at: DateTime.utc_now()])
 
     case count do
-      1 -> put_bootstrap_headers(conn, tenant_id)
+      # Winner: grant the grace. Only pure response-header setting remains after
+      # the committed UPDATE, so nothing here can fail and strand the client.
+      1 -> grant_bootstrap_grace(conn, sth_value)
       0 -> bootstrap_already_consumed(conn)
     end
   rescue
     exception ->
-      # Fail closed on a DB error: never grant an unbounded (repeatable) grace.
+      # Fail closed on a DB error BEFORE the grace is consumed (the STH read or
+      # the UPDATE itself): never grant an unbounded/repeatable grace, and never
+      # burn the one-time grace on a transient failure — this path is retryable.
       Logger.warning(
         "ValidateWitnessHeader: atomic bootstrap consume failed for " <>
-          "api_key=#{id}: #{inspect(exception)}"
+          "api_key=#{id}: #{sanitized_db_error(exception)}"
       )
 
       missing_header(conn)
   end
 
-  defp put_bootstrap_headers(conn, tenant_id) do
+  defp grant_bootstrap_grace(conn, sth_value) do
     conn
-    |> put_resp_header("x-loopctl-current-sth", current_sth_value(tenant_id))
+    |> put_resp_header("x-loopctl-current-sth", sth_value)
     |> put_resp_header("x-loopctl-sth-warning", "missing_header_bootstrap_grace")
   end
+
+  # Never inspect/1 a raw DB exception: %Postgrex.Error{} carries the literal SQL
+  # statement in its :query field. Log only the struct name + SQLSTATE, matching
+  # the US-27.3 sanitized-logging convention used elsewhere.
+  defp sanitized_db_error(%Postgrex.Error{postgres: %{code: code}}),
+    do: "Postgrex.Error sqlstate=#{code}"
+
+  defp sanitized_db_error(exception), do: inspect(exception.__struct__)
 
   defp bootstrap_already_consumed(conn) do
     conn

--- a/lib/loopctl_web/plugs/validate_witness_header.ex
+++ b/lib/loopctl_web/plugs/validate_witness_header.ex
@@ -37,6 +37,7 @@ defmodule LoopctlWeb.Plugs.ValidateWitnessHeader do
 
   @behaviour Plug
 
+  import Ecto.Query, only: [from: 2]
   import Plug.Conn
 
   require Logger
@@ -49,6 +50,10 @@ defmodule LoopctlWeb.Plugs.ValidateWitnessHeader do
   # exactly 22 characters. This is the ONLY accepted client prefix length —
   # the comparison window is fixed by the server, not by client input.
   @sig_prefix_length 22
+  # chain_position is a Postgres bigint; reject anything outside the signed
+  # 64-bit range up front so an oversized (arbitrary-precision) Elixir int
+  # never reaches the query and raises a DBConnection.EncodeError (custody-03b).
+  @max_chain_position 9_223_372_036_854_775_807
   @zero_sth_prefix Base.url_encode64(:binary.copy(<<0>>, 16), padding: false)
   @zero_sth "0:#{@zero_sth_prefix}"
 
@@ -120,11 +125,17 @@ defmodule LoopctlWeb.Plugs.ValidateWitnessHeader do
 
     if tenant_id do
       case Integer.parse(position_str) do
-        {position, ""} when position >= 0 ->
+        {position, ""} when position >= 0 and position <= @max_chain_position ->
           compare_against_server_sth(conn, tenant_id, position, sig_prefix)
 
         _ ->
-          malformed(conn, "Position must be a non-negative integer")
+          # custody-03b: rejects negatives, non-integers, AND values beyond the
+          # Postgres bigint range BEFORE the query, so an oversized position
+          # yields a 412 rather than a 500 from Postgrex.
+          malformed(
+            conn,
+            "Position must be a non-negative integer within the signed 64-bit range"
+          )
       end
     else
       # No tenant context (superadmin or public) — skip divergence check.
@@ -135,8 +146,11 @@ defmodule LoopctlWeb.Plugs.ValidateWitnessHeader do
   defp compare_against_server_sth(conn, tenant_id, position, sig_prefix) do
     case AuditChain.get_sth_at_position(tenant_id, position) do
       nil ->
-        # No STH at this position — agent may be ahead of the server, allow.
-        conn
+        # custody-02: NO pass-through. The server is the SOLE source of STHs, so
+        # a position beyond the tenant's latest sealed STH is not something an
+        # honest agent can know (its cached position is always <= latest sealed).
+        # Treat it as resync-required, never a silent bypass.
+        resync_required(conn, tenant_id, position, sig_prefix, "future_position")
 
       sth ->
         server_prefix = server_sig_prefix(sth.signature)
@@ -146,25 +160,27 @@ defmodule LoopctlWeb.Plugs.ValidateWitnessHeader do
         if Plug.Crypto.secure_compare(server_prefix, sig_prefix) do
           conn
         else
-          witness_divergence(conn, tenant_id, position, sig_prefix, server_prefix)
+          resync_required(conn, tenant_id, position, sig_prefix, "prefix_mismatch")
         end
     end
   end
 
-  # custody-01: a raw client-supplied prefix mismatch is NOT proof of a fork —
-  # it is almost always a stale client cache. Do NOT halt the tenant. Tell the
-  # client to resync (handing it the current STH) and emit telemetry so genuine
-  # divergence can be monitored/alerted out-of-band.
-  defp witness_divergence(conn, tenant_id, position, sig_prefix, server_prefix) do
+  # custody-01/02: a raw client-supplied prefix mismatch OR an unverifiable
+  # (future) position is NOT proof of a fork — it is almost always a stale
+  # client cache. Do NOT halt the tenant. Tell the client to resync (handing it
+  # the current STH) and emit telemetry so genuine divergence can be
+  # monitored/alerted out-of-band. Shared by the prefix-mismatch and
+  # future-position cases so they return the identical 409 + resync response.
+  defp resync_required(conn, tenant_id, position, sig_prefix, reason) do
     Logger.warning(
       "WITNESS DIVERGENCE (client-reported, NOT halting): tenant=#{tenant_id} " <>
-        "position=#{position} client_prefix=#{sig_prefix} server_prefix=#{server_prefix}"
+        "position=#{position} reason=#{reason} client_prefix=#{sig_prefix}"
     )
 
     :telemetry.execute(
       [:loopctl, :witness, :divergence],
       %{count: 1},
-      %{tenant_id: tenant_id, position: position}
+      %{tenant_id: tenant_id, position: position, reason: reason}
     )
 
     conn
@@ -185,45 +201,42 @@ defmodule LoopctlWeb.Plugs.ValidateWitnessHeader do
     |> halt()
   end
 
-  # custody-03: one-time bootstrap grace, keyed on the resolved API key.
+  # custody-03: one-time bootstrap grace, made ATOMIC and DB-authoritative to
+  # close a read-then-write TOCTOU race — the in-memory struct's nil is NOT
+  # trusted. A single conditional UPDATE guarded by the NULL predicate decides
+  # the winner: exactly one concurrent first-request flips the column (count 1)
+  # and is granted; every other (count 0) is already consumed and rejected.
   defp handle_bootstrap_grace(conn) do
     case conn.assigns[:current_api_key] do
-      %ApiKey{sth_bootstrap_consumed_at: nil} = api_key ->
-        grant_bootstrap_grace(conn, api_key)
-
-      %ApiKey{} ->
-        # Already bootstrapped once — must present a real witness header now.
-        bootstrap_already_consumed(conn)
+      %ApiKey{id: id, tenant_id: tenant_id} when is_binary(id) ->
+        atomic_consume_bootstrap(conn, id, tenant_id)
 
       _ ->
-        # No resolved API key row to record consumption on (defensive: the
-        # authenticated pipeline sets current_api_key before this plug). Grant
-        # the grace without stamping rather than crashing.
-        put_bootstrap_headers(conn, get_tenant_id(conn))
-    end
-  end
-
-  defp grant_bootstrap_grace(conn, %ApiKey{} = api_key) do
-    case stamp_bootstrap_consumed(api_key) do
-      {:ok, _updated} ->
-        put_bootstrap_headers(conn, api_key.tenant_id)
-
-      {:error, reason} ->
-        # Fail closed: if we cannot record consumption we must not grant an
-        # unbounded (repeatable) grace. Fall back to requiring the header.
-        Logger.warning(
-          "ValidateWitnessHeader: failed to stamp bootstrap consumption for " <>
-            "api_key=#{api_key.id}: #{inspect(reason)}"
-        )
-
+        # No resolved API key row to record consumption on — cannot grant a
+        # bounded one-time grace, so require the real header (fail closed).
+        # Defensive: the authenticated pipeline sets current_api_key first.
         missing_header(conn)
     end
   end
 
-  defp stamp_bootstrap_consumed(%ApiKey{} = api_key) do
-    api_key
-    |> ApiKey.consume_bootstrap_changeset()
-    |> AdminRepo.update()
+  defp atomic_consume_bootstrap(conn, id, tenant_id) do
+    {count, _} =
+      from(a in ApiKey, where: a.id == ^id and is_nil(a.sth_bootstrap_consumed_at))
+      |> AdminRepo.update_all(set: [sth_bootstrap_consumed_at: DateTime.utc_now()])
+
+    case count do
+      1 -> put_bootstrap_headers(conn, tenant_id)
+      0 -> bootstrap_already_consumed(conn)
+    end
+  rescue
+    exception ->
+      # Fail closed on a DB error: never grant an unbounded (repeatable) grace.
+      Logger.warning(
+        "ValidateWitnessHeader: atomic bootstrap consume failed for " <>
+          "api_key=#{id}: #{inspect(exception)}"
+      )
+
+      missing_header(conn)
   end
 
   defp put_bootstrap_headers(conn, tenant_id) do

--- a/test/loopctl_web/controllers/audit_sth_controller_test.exs
+++ b/test/loopctl_web/controllers/audit_sth_controller_test.exs
@@ -1,0 +1,80 @@
+defmodule LoopctlWeb.AuditSthControllerTest do
+  @moduledoc """
+  Tests for the public, unauthenticated STH endpoint. In particular the `at`
+  param must never hand an out-of-bigint-range value to Postgrex (which would
+  raise DBConnection.EncodeError -> uncaught 500 on an anonymous, unrate-limited
+  route).
+  """
+  use LoopctlWeb.ConnCase, async: true
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.AuditChain.SignedTreeHead
+
+  defp insert_sth(tenant_id, position) do
+    %SignedTreeHead{tenant_id: tenant_id}
+    |> SignedTreeHead.changeset(%{
+      chain_position: position,
+      merkle_root: :crypto.strong_rand_bytes(32),
+      signed_at: DateTime.utc_now(),
+      signature: :crypto.strong_rand_bytes(64)
+    })
+    |> AdminRepo.insert!()
+  end
+
+  describe "GET /api/v1/audit/sth/:tenant_id" do
+    test "returns the latest STH", %{conn: conn} do
+      tenant = fixture(:tenant)
+      insert_sth(tenant.id, 1)
+      insert_sth(tenant.id, 5)
+
+      body = conn |> get(~p"/api/v1/audit/sth/#{tenant.id}") |> json_response(200)
+      assert body["data"]["chain_position"] == 5
+      assert body["data"]["tenant_id"] == tenant.id
+    end
+
+    test "returns the smallest STH at/after a position", %{conn: conn} do
+      tenant = fixture(:tenant)
+      insert_sth(tenant.id, 1)
+      insert_sth(tenant.id, 5)
+
+      body = conn |> get(~p"/api/v1/audit/sth/#{tenant.id}?#{[at: 3]}") |> json_response(200)
+      assert body["data"]["chain_position"] == 5
+    end
+
+    test "404 when the tenant has no STH", %{conn: conn} do
+      tenant = fixture(:tenant)
+      assert conn |> get(~p"/api/v1/audit/sth/#{tenant.id}") |> json_response(404)
+    end
+
+    test "rejects an oversized `at` with 404 instead of a Postgrex encode 500", %{conn: conn} do
+      tenant = fixture(:tenant)
+      insert_sth(tenant.id, 1)
+
+      # > 2^63-1: arbitrary-precision Elixir int that would crash Postgrex's int8
+      # encoder if it reached the query. The AuditChain bound short-circuits to
+      # nil -> 404.
+      body =
+        conn
+        |> get(~p"/api/v1/audit/sth/#{tenant.id}?#{[at: "99999999999999999999999999999"]}")
+        |> json_response(404)
+
+      assert body["error"]["status"] == 404
+    end
+
+    test "rejects a negative `at` with 404", %{conn: conn} do
+      tenant = fixture(:tenant)
+      insert_sth(tenant.id, 1)
+
+      assert conn |> get(~p"/api/v1/audit/sth/#{tenant.id}?#{[at: "-5"]}") |> json_response(404)
+    end
+
+    test "non-numeric `at` yields 404 (not a crash)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      insert_sth(tenant.id, 1)
+
+      assert conn
+             |> get(~p"/api/v1/audit/sth/#{tenant.id}?#{[at: "notanumber"]}")
+             |> json_response(404)
+    end
+  end
+end

--- a/test/loopctl_web/plugs/validate_witness_header_test.exs
+++ b/test/loopctl_web/plugs/validate_witness_header_test.exs
@@ -214,14 +214,90 @@ defmodule LoopctlWeb.Plugs.ValidateWitnessHeaderTest do
                "witness_bootstrap_already_consumed"
     end
 
-    test "no resolved api key (superadmin/absent) does not crash and grants grace" do
+    test "atomic consume is single-winner even when the in-memory struct still shows nil (TOCTOU)" do
+      {_raw, api_key} = fixture(:api_key, %{role: :agent})
+      assert is_nil(api_key.sth_bootstrap_consumed_at)
+
+      # Both requests carry the SAME pre-fetched nil struct — exactly what two
+      # concurrent first-requests would read before either writes. The old
+      # read-then-write logic granted BOTH; the atomic conditional UPDATE must
+      # let exactly one win and reject the other 412.
+      conn1 = api_key |> bootstrap_conn() |> ValidateWitnessHeader.call(@enforce)
+      conn2 = api_key |> bootstrap_conn() |> ValidateWitnessHeader.call(@enforce)
+
+      conns = [conn1, conn2]
+      granted = Enum.count(conns, fn c -> not c.halted end)
+
+      rejected =
+        Enum.count(conns, fn c ->
+          c.halted and c.status == 412 and
+            Jason.decode!(c.resp_body)["error"]["code"] == "witness_bootstrap_already_consumed"
+        end)
+
+      assert granted == 1
+      assert rejected == 1
+
+      # And the DB reflects a single consumption stamp.
+      reloaded = AdminRepo.get!(ApiKey, api_key.id)
+      assert %DateTime{} = reloaded.sth_bootstrap_consumed_at
+    end
+
+    test "no resolved api key (absent) cannot bootstrap — 412 missing header, no crash" do
       conn =
         base_conn()
         |> put_req_header("x-loopctl-sth-bootstrap", "true")
         |> ValidateWitnessHeader.call(@enforce)
 
-      refute conn.halted
-      assert [_sth] = get_resp_header(conn, "x-loopctl-current-sth")
+      assert conn.halted
+      assert conn.status == 412
+      assert Jason.decode!(conn.resp_body)["error"]["code"] == "witness_header_missing"
+    end
+  end
+
+  describe "FIX 2 — a future position cannot skip the divergence check" do
+    test "position beyond the latest sealed STH returns 409 resync, no pass-through, no halt" do
+      {_raw, api_key} = fixture(:api_key, %{role: :agent})
+      tenant_id = api_key.tenant_id
+      # Latest sealed STH is at position 5; nothing exists at/after 999_999_999.
+      insert_sth(tenant_id, 5)
+
+      conn =
+        base_conn()
+        |> put_req_header("x-loopctl-last-known-sth", "999999999:#{@other_prefix}")
+        |> with_api_key(api_key)
+        |> ValidateWitnessHeader.call(@enforce)
+
+      # Must NOT pass through — it is halted with the resync 409.
+      assert conn.halted
+      assert conn.status == 409
+      assert Jason.decode!(conn.resp_body)["error"]["code"] == "witness_divergence"
+
+      assert [hint] = get_resp_header(conn, "x-loopctl-current-sth")
+      assert hint =~ ~r/\A\d+:[A-Za-z0-9_-]{22}\z/
+
+      # And custody is NOT halted by this raw client input.
+      {:ok, tenant} = Tenants.get_tenant(tenant_id)
+      refute Tenants.custody_halted?(tenant)
+    end
+  end
+
+  describe "FIX 3 — oversized position is rejected, not a 500" do
+    test "a position larger than bigint max returns 412 malformed (no Postgrex encode 500)" do
+      {_raw, api_key} = fixture(:api_key, %{role: :agent})
+      insert_sth(api_key.tenant_id, 5)
+
+      conn =
+        base_conn()
+        |> put_req_header(
+          "x-loopctl-last-known-sth",
+          "99999999999999999999999999:#{@other_prefix}"
+        )
+        |> with_api_key(api_key)
+        |> ValidateWitnessHeader.call(@enforce)
+
+      assert conn.halted
+      assert conn.status == 412
+      assert Jason.decode!(conn.resp_body)["error"]["code"] == "witness_header_malformed"
     end
   end
 end


### PR DESCRIPTION
## Summary

Closes three chain-of-custody defects in the STH witness plug that were **merged to master via #254 before the enhanced-review gate's fixes landed** (the gate reproduced all three empirically). Private advisories: `GHSA-w786-f588-2943`, `GHSA-cxrw-xg8f-mx8v`, `GHSA-36g5-mcrh-rcrm`.

## Fixes

- **High — bootstrap grace TOCTOU race.** One-time bootstrap consumption was read-then-write, so two concurrent first requests for the same key both got the grace. Now atomic: a single conditional `UPDATE ... WHERE sth_bootstrap_consumed_at IS NULL`, granting only when the row count is 1, else 412 `witness_bootstrap_already_consumed`.
- **High — divergence check skippable via a future position.** Claiming a chain position beyond the tenant's latest sealed STH made `get_sth_at_position` return nil, and the nil branch passed through with **no comparison at all**. A future/unverifiable position now returns the same 409 resync response (with the current-STH header), never a silent pass. The server is the sole STH source, so an honest agent can never legitimately hold a position beyond the latest — no false positives.
- **Medium — oversized position crash.** A position beyond bigint range reached the query and raised a Postgrex encode error (500). Now range-checked before the query → 412 malformed.

## Tests

14 plug tests including the atomic single-winner bootstrap, future-position 409 resync (tenant not halted), and oversized-position 412. Full suite green (3115 tests, 0 failures); credo/dialyzer clean.
