### PR TITLE
fix(custody): correct SQLSTATE log label + bootstrap-rescue regression test

### DIFF
--- a/lib/loopctl_web/plugs/validate_witness_header.ex
+++ b/lib/loopctl_web/plugs/validate_witness_header.ex
@@ -258,10 +258,12 @@ defmodule LoopctlWeb.Plugs.ValidateWitnessHeader do
   end
 
   # Never inspect/1 a raw DB exception: %Postgrex.Error{} carries the literal SQL
-  # statement in its :query field. Log only the struct name + SQLSTATE, matching
-  # the US-27.3 sanitized-logging convention used elsewhere.
-  defp sanitized_db_error(%Postgrex.Error{postgres: %{code: code}}),
-    do: "Postgrex.Error sqlstate=#{code}"
+  # statement in its :query field. Log only the struct name + the real SQLSTATE,
+  # reusing LoopctlWeb.DBError.sqlstate/1 (the US-27.3 single source of truth,
+  # which reads postgres.pg_code — the raw 5-char SQLSTATE — not the human atom)
+  # so this line correlates with the rest of the app's DB-error logs.
+  defp sanitized_db_error(%Postgrex.Error{} = exception),
+    do: "Postgrex.Error sqlstate=#{LoopctlWeb.DBError.sqlstate(exception) || "unknown"}"
 
   defp sanitized_db_error(exception), do: inspect(exception.__struct__)
 

--- a/test/loopctl_web/plugs/validate_witness_header_test.exs
+++ b/test/loopctl_web/plugs/validate_witness_header_test.exs
@@ -196,6 +196,27 @@ defmodule LoopctlWeb.Plugs.ValidateWitnessHeaderTest do
       assert %DateTime{} = reloaded.sth_bootstrap_consumed_at
     end
 
+    test "a DB error while consuming fails closed (412) with a sanitized, SQL-free log" do
+      # A malformed (non-UUID) api_key id makes Ecto raise while running the
+      # atomic consume, exercising the rescue path: Fix 2 (fail closed, grace not
+      # granted) + Fix 3 (sanitized logging, never the raw SQL query text).
+      bad_key = %ApiKey{id: "not-a-uuid", tenant_id: Ecto.UUID.generate()}
+
+      {conn, log} =
+        ExUnit.CaptureLog.with_log(fn ->
+          bad_key |> bootstrap_conn() |> ValidateWitnessHeader.call(@enforce)
+        end)
+
+      assert conn.halted
+      assert conn.status == 412
+      assert Jason.decode!(conn.resp_body)["error"]["code"] == "witness_header_missing"
+
+      # Log records the failure but leaks no SQL — struct name / sqlstate only.
+      assert log =~ "atomic bootstrap consume failed"
+      refute log =~ "query:"
+      refute log =~ ~r/SELECT|INSERT|UPDATE/
+    end
+
     test "a second bootstrap request from the same key is rejected 412" do
       {_raw, api_key} = fixture(:api_key, %{role: :agent})
 


### PR DESCRIPTION
Re-applies the two round-3 enhanced-review follow-ups that landed after #256 was merged (mid-gate), so they were stranded off master. Both are non-security quality fixes the gate itself prescribed:

- Sanitized bootstrap-consume log used `postgres.code` (human atom) mislabelled as `sqlstate`; now reuses `LoopctlWeb.DBError.sqlstate/1` (real 5-char `pg_code`) so it correlates with the rest of the app's DB-error logs. Still no query-text leak.
- Adds a plug regression test: a DB error during the atomic consume fails closed (412) with a SQL-free log — pins the fail-closed rescue + sanitized logging.

Full suite green (3122 tests, 0 failures); credo/dialyzer clean. These are the gate's own round-3 prescriptions, already reviewed when generated.