### PR TITLE
fix(security): shared SSRF egress guard for webhook delivery + content ingestion

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -306,6 +306,12 @@ config :loopctl, knowledge_moc_min_tag_count: 2
 # the DNS-rebinding tests override it with Mox.expect/3 to return a private address.
 config :loopctl, :dns_resolver, Loopctl.MockDnsResolver
 
+# Bounded DNS resolution (FIX B): the guard resolves under this timeout and fails
+# closed if it elapses. Tests use the Mox resolver so this only affects the
+# Loopctl.Net.DnsResolver.Default unit test; keep it short so any accidental real
+# lookup can't hang the suite.
+config :loopctl, :dns_resolve_timeout_ms, 2_000
+
 # DI: swap ArticleLinkingWorker's similarity lookup for a Mox mock so the worker's
 # linking logic (relates_to / potential_conflict thresholds, dedup, audit, idempotency)
 # is unit-tested with deterministic candidate lists — never through the real pgvector kNN,

--- a/config/test.exs
+++ b/config/test.exs
@@ -312,6 +312,11 @@ config :loopctl, :dns_resolver, Loopctl.MockDnsResolver
 # lookup can't hang the suite.
 config :loopctl, :dns_resolve_timeout_ms, 2_000
 
+# Batch ingestion per-item validation deadline (FIX 2). Short in tests so the
+# validation_timeout path (a stubbed slow/failing resolver) is exercised in
+# ~200ms instead of the 5s production default. Config-based DI — no put_env.
+config :loopctl, :batch_item_validation_timeout_ms, 200
+
 # DI: swap ArticleLinkingWorker's similarity lookup for a Mox mock so the worker's
 # linking logic (relates_to / potential_conflict thresholds, dedup, audit, idempotency)
 # is unit-tested with deterministic candidate lists — never through the real pgvector kNN,

--- a/config/test.exs
+++ b/config/test.exs
@@ -298,6 +298,14 @@ config :loopctl, :rls_role, "loopctl_app"
 # KnowledgeMocWorker: low tag threshold so tests need only a few tagged articles.
 config :loopctl, knowledge_moc_min_tag_count: 2
 
+# SSRF egress guard DNS resolution DI (ie-02 / worker-01). The UrlGuard resolves
+# bare hostnames through this; in tests we swap in a Mox mock so no real network
+# DNS is hit. IP-literal test cases (169.254.169.254, ::1, fdaa::1, 2130706433, …)
+# bypass DNS entirely via :inet.parse_address. DataCase default-stubs `resolve/1`
+# to a public IP so existing example.com-based webhook/ingestion tests keep passing;
+# the DNS-rebinding tests override it with Mox.expect/3 to return a private address.
+config :loopctl, :dns_resolver, Loopctl.MockDnsResolver
+
 # DI: swap ArticleLinkingWorker's similarity lookup for a Mox mock so the worker's
 # linking logic (relates_to / potential_conflict thresholds, dedup, audit, idempotency)
 # is unit-tested with deterministic candidate lists — never through the real pgvector kNN,

--- a/lib/loopctl/net/dns_resolver/behaviour.ex
+++ b/lib/loopctl/net/dns_resolver/behaviour.ex
@@ -1,0 +1,18 @@
+defmodule Loopctl.Net.DnsResolver.Behaviour do
+  @moduledoc """
+  Behaviour for resolving a hostname to its IP addresses.
+
+  Extracted so the SSRF egress guard (`Loopctl.Net.UrlGuard`) can be tested
+  deterministically without real network DNS. Production resolves via
+  `:inet.getaddrs/2`; tests swap in a Mox mock via config-based DI.
+  """
+
+  @doc """
+  Resolves `host` to a non-empty list of A (IPv4) and AAAA (IPv6) addresses.
+
+  Returns `{:ok, [ip_address]}` on success or `{:error, reason}` when the host
+  does not resolve.
+  """
+  @callback resolve(host :: String.t()) ::
+              {:ok, [:inet.ip_address()]} | {:error, term()}
+end

--- a/lib/loopctl/net/dns_resolver/default.ex
+++ b/lib/loopctl/net/dns_resolver/default.ex
@@ -1,0 +1,31 @@
+defmodule Loopctl.Net.DnsResolver.Default do
+  @moduledoc """
+  Production DNS resolver backed by `:inet.getaddrs/2`.
+
+  Resolves both A (IPv4) and AAAA (IPv6) records and returns the union, so the
+  egress guard can reject a hostname that resolves to a private address over
+  either address family.
+  """
+
+  @behaviour Loopctl.Net.DnsResolver.Behaviour
+
+  @impl true
+  def resolve(host) when is_binary(host) do
+    charlist = String.to_charlist(host)
+
+    v4 = getaddrs(charlist, :inet)
+    v6 = getaddrs(charlist, :inet6)
+
+    case v4 ++ v6 do
+      [] -> {:error, :nxdomain}
+      ips -> {:ok, ips}
+    end
+  end
+
+  defp getaddrs(charlist, family) do
+    case :inet.getaddrs(charlist, family) do
+      {:ok, addrs} -> addrs
+      {:error, _reason} -> []
+    end
+  end
+end

--- a/lib/loopctl/net/dns_resolver/default.ex
+++ b/lib/loopctl/net/dns_resolver/default.ex
@@ -1,31 +1,53 @@
 defmodule Loopctl.Net.DnsResolver.Default do
   @moduledoc """
-  Production DNS resolver backed by `:inet.getaddrs/2`.
+  Production DNS resolver backed by `:inet.getaddrs/3`.
 
   Resolves both A (IPv4) and AAAA (IPv6) records and returns the union, so the
   egress guard can reject a hostname that resolves to a private address over
   either address family.
+
+  ## Bounded resolution (fail closed)
+
+  Resolution runs under a bounded timeout — `:dns_resolve_timeout_ms` (default
+  3000ms) — because `validate_egress`/`pin` run synchronously in the caller's
+  process: web request processes (webhook changeset, ingestion enqueue, and the
+  batch endpoint which validates items serially) and Oban jobs on shared
+  concurrency-limited queues. An attacker-controlled nameserver that never
+  answers would otherwise hang those slots for *all* tenants.
+
+  Any resolution failure — NXDOMAIN, a socket error, OR a `:inet.getaddrs/3`
+  timeout — collapses to `{:error, :unresolved}`, which the guard treats as a
+  blocked host (fail closed). Both families must fail for the host to be
+  considered unresolved.
   """
 
   @behaviour Loopctl.Net.DnsResolver.Behaviour
 
+  @default_timeout_ms 3_000
+
   @impl true
   def resolve(host) when is_binary(host) do
     charlist = String.to_charlist(host)
+    timeout = timeout_ms()
 
-    v4 = getaddrs(charlist, :inet)
-    v6 = getaddrs(charlist, :inet6)
+    addrs = lookup(charlist, :inet, timeout) ++ lookup(charlist, :inet6, timeout)
 
-    case v4 ++ v6 do
-      [] -> {:error, :nxdomain}
+    case addrs do
+      [] -> {:error, :unresolved}
       ips -> {:ok, ips}
     end
   end
 
-  defp getaddrs(charlist, family) do
-    case :inet.getaddrs(charlist, family) do
+  # Any getaddrs error (NXDOMAIN, socket error, or a runtime timeout the OTP
+  # typespec omits) yields no addresses for that family — fail closed.
+  defp lookup(charlist, family, timeout) do
+    case :inet.getaddrs(charlist, family, timeout) do
       {:ok, addrs} -> addrs
       {:error, _reason} -> []
     end
+  end
+
+  defp timeout_ms do
+    Application.get_env(:loopctl, :dns_resolve_timeout_ms, @default_timeout_ms)
   end
 end

--- a/lib/loopctl/net/url_guard.ex
+++ b/lib/loopctl/net/url_guard.ex
@@ -1,0 +1,158 @@
+defmodule Loopctl.Net.UrlGuard do
+  @moduledoc """
+  Shared SSRF egress guard for every outbound HTTP request loopctl makes on
+  behalf of a tenant (webhook delivery, knowledge content ingestion).
+
+  A tenant supplies a URL; without a guard a tenant can point loopctl at
+  internal infrastructure — the cloud metadata endpoint (`169.254.169.254`),
+  Fly 6PN private networking (`fdaa::/16`), loopback, link-local, or any host
+  that *resolves* to a private address — and read the response back out. This
+  module closes that class of attack.
+
+  Closes two private advisories:
+
+    * ie-02 (GHSA-jh42-wf7g-f5rg) — webhook delivery: the old IPv4 string-prefix
+      blocklist missed IPv6, decimal/hex/octal IPv4, `0.0.0.0`, and did no DNS
+      resolution, and delivery followed redirects.
+    * worker-01 (GHSA-j7m9-ffmr-pwhm) — content ingestion fetched a raw
+      user-supplied URL with no validation.
+
+  ## Defense layers
+
+    1. **Scheme allowlist** — only `http`/`https` (override via `:schemes`).
+    2. **Real DNS resolution** — a bare host that is not already an IP literal is
+       resolved (A *and* AAAA) via `Loopctl.Net.DnsResolver`; a hostname that
+       resolves to a private address is blocked. IP-literal forms (dotted v4,
+       decimal/hex IPv4, and IPv6 literals) are parsed directly with
+       `:inet.parse_address/1`.
+    3. **Private-range blocklist for BOTH families** — v4: `0.0.0.0/8`,
+       `10.0.0.0/8`, `100.64.0.0/10` (CGNAT), `127.0.0.0/8`, `169.254.0.0/16`
+       (cloud metadata), `172.16.0.0/12`, `192.168.0.0/16`; v6: `::`, `::1`,
+       `fe80::/10` (link-local), `fc00::/7` (ULA incl. Fly `fdaa::`), and
+       IPv4-mapped `::ffff:0:0/96` (the embedded v4 is decoded and re-checked
+       against the v4 rules). If a host resolves to *multiple* addresses and
+       *any* one is blocked, the whole URL is rejected.
+
+  Callers MUST re-validate on every request (DNS rebinding / TOCTOU), not only at
+  submission time, and MUST disable redirect following (`redirect: false`) so a
+  302 hop can't re-enter an unvalidated URL.
+  """
+
+  import Bitwise
+
+  @default_schemes ~w(http https)
+
+  @type reason ::
+          :invalid_url
+          | :invalid_scheme
+          | :missing_host
+          | :dns_resolution_failed
+          | :blocked_ip
+
+  @doc """
+  Validates that `url` is safe to fetch from a server-side context.
+
+  Returns `{:ok, %URI{}}` when the URL uses an allowed scheme and every address
+  it resolves to is a public, routable address. Returns `{:error, reason}`
+  otherwise, where `reason` is one of `t:reason/0`.
+
+  ## Options
+
+    * `:schemes` — list of allowed URI schemes (default `["http", "https"]`).
+  """
+  @spec validate_egress(String.t(), keyword()) :: {:ok, URI.t()} | {:error, reason()}
+  def validate_egress(url, opts \\ [])
+
+  def validate_egress(url, opts) when is_binary(url) do
+    schemes = Keyword.get(opts, :schemes, @default_schemes)
+    uri = URI.parse(url)
+
+    with :ok <- check_scheme(uri, schemes),
+         {:ok, host} <- host(uri),
+         {:ok, ips} <- resolve(host),
+         :ok <- check_ips(ips) do
+      {:ok, uri}
+    end
+  end
+
+  def validate_egress(_url, _opts), do: {:error, :invalid_url}
+
+  # --- scheme / host ---
+
+  defp check_scheme(%URI{scheme: scheme}, schemes) when is_binary(scheme) do
+    if scheme in schemes, do: :ok, else: {:error, :invalid_scheme}
+  end
+
+  defp check_scheme(_uri, _schemes), do: {:error, :invalid_scheme}
+
+  defp host(%URI{host: host}) when is_binary(host) and host != "" do
+    {:ok, host}
+  end
+
+  defp host(_uri), do: {:error, :missing_host}
+
+  # --- Resolution: IP literal first, else DNS ---
+
+  defp resolve(host) do
+    normalized = strip_brackets(host)
+
+    case :inet.parse_address(String.to_charlist(normalized)) do
+      {:ok, ip} ->
+        {:ok, [ip]}
+
+      {:error, _} ->
+        case dns_resolver().resolve(normalized) do
+          {:ok, [_ | _] = ips} -> {:ok, ips}
+          {:ok, []} -> {:error, :dns_resolution_failed}
+          {:error, _} -> {:error, :dns_resolution_failed}
+        end
+    end
+  end
+
+  defp strip_brackets(host) do
+    host
+    |> String.replace_prefix("[", "")
+    |> String.replace_suffix("]", "")
+  end
+
+  # --- Blocklist ---
+
+  # Any blocked address in the resolved set fails the whole URL.
+  defp check_ips(ips) do
+    if Enum.any?(ips, &blocked?/1), do: {:error, :blocked_ip}, else: :ok
+  end
+
+  # --- IPv4 ---
+  defp blocked?({a, b, _c, _d}), do: blocked_ipv4?(a, b)
+
+  # IPv4-mapped IPv6 (::ffff:0:0/96): decode the embedded v4's first two octets
+  # (all blocked ranges are determined by them) and re-check against the v4 rules.
+  defp blocked?({0, 0, 0, 0, 0, 0xFFFF, g6, _g7}) do
+    blocked_ipv4?(g6 >>> 8, g6 &&& 0xFF)
+  end
+
+  # IPv4-compatible IPv6 (::0.0.0.0/96, incl. :: and ::1): decode the embedded v4
+  # and re-check. Covers ::1 (→ 0.0.0.1, blocked by 0.0.0.0/8) and :: as well.
+  defp blocked?({0, 0, 0, 0, 0, 0, g6, _g7}) do
+    blocked_ipv4?(g6 >>> 8, g6 &&& 0xFF)
+  end
+
+  # --- IPv6 ---
+  # fe80::/10 link-local, fc00::/7 ULA (includes Fly fdaa::/16)
+  defp blocked?({h0, _, _, _, _, _, _, _}) do
+    (h0 &&& 0xFFC0) == 0xFE80 or (h0 &&& 0xFE00) == 0xFC00
+  end
+
+  defp blocked_ipv4?(0, _b), do: true
+  defp blocked_ipv4?(10, _b), do: true
+  defp blocked_ipv4?(127, _b), do: true
+  defp blocked_ipv4?(169, 254), do: true
+  defp blocked_ipv4?(192, 168), do: true
+  defp blocked_ipv4?(172, b), do: b in 16..31
+  defp blocked_ipv4?(100, b), do: b in 64..127
+  defp blocked_ipv4?(_a, _b), do: false
+
+  defp dns_resolver do
+    Application.get_env(:loopctl, :dns_resolver, Loopctl.Net.DnsResolver.Default)
+  end
+end

--- a/lib/loopctl/net/url_guard.ex
+++ b/lib/loopctl/net/url_guard.ex
@@ -138,8 +138,11 @@ defmodule Loopctl.Net.UrlGuard do
   def pinned_request_opts(pinned, extra_headers \\ [])
 
   def pinned_request_opts(%{uri: uri, host: host, ip: ip}, extra_headers) do
+    # Map-update (not %URI{uri | ...}) — `uri` arrives via a plain map pattern
+    # so Elixir 1.19's stricter struct-update type check rejects the struct
+    # form under --warnings-as-errors; the map update preserves the URI struct.
     connect_url =
-      %URI{uri | host: ip_literal(ip), authority: nil}
+      %{uri | host: ip_literal(ip), authority: nil}
       |> URI.to_string()
 
     host_header = {"host", host_header_value(host, uri.scheme, uri.port)}

--- a/lib/loopctl/net/url_guard.ex
+++ b/lib/loopctl/net/url_guard.ex
@@ -120,18 +120,47 @@ defmodule Loopctl.Net.UrlGuard do
   Builds Req options that connect to the pinned IP while preserving the original
   host for the `Host` header, TLS SNI, and certificate verification.
 
-  Returns `[url: connect_url, connect_options: [hostname: original_host]]`, where
-  `connect_url` has its authority rewritten to the validated IP literal (IPv6 is
-  bracketed). Merge this with the caller's method/body/headers and
-  `redirect: false`.
+  Returns `[url: connect_url, connect_options: [hostname: original_host],
+  headers: [{"host", host_header} | extra_headers]]`, where `connect_url` has its
+  authority rewritten to the validated IP literal (IPv6 bracketed).
+
+  The `Host` header is set EXPLICITLY rather than relying on Mint's default: for
+  an IPv6-pinned target, `Req.Finch.run/1` pre-injects `host` = the bracketed IPv6
+  *literal* (because the rewritten URL host contains `:` and `:inet6` is unset),
+  which would win over Mint's `put_new` Host and break vhost routing. Setting the
+  header here makes Req's `put_new_header` a no-op. The value mirrors Mint's
+  `default_host_header/1` (port suffix only when non-default for the scheme).
+
+  Pass the caller's own headers as `extra_headers`; they are appended after the
+  `Host` header. Merge the result with the caller's method/body/`redirect: false`.
   """
-  @spec pinned_request_opts(pinned()) :: keyword()
-  def pinned_request_opts(%{uri: uri, host: host, ip: ip}) do
+  @spec pinned_request_opts(pinned(), [{String.t(), String.t()}]) :: keyword()
+  def pinned_request_opts(pinned, extra_headers \\ [])
+
+  def pinned_request_opts(%{uri: uri, host: host, ip: ip}, extra_headers) do
     connect_url =
       %URI{uri | host: ip_literal(ip), authority: nil}
       |> URI.to_string()
 
-    [url: connect_url, connect_options: [hostname: host]]
+    host_header = {"host", host_header_value(host, uri.scheme, uri.port)}
+
+    [
+      url: connect_url,
+      connect_options: [hostname: host],
+      headers: [host_header | extra_headers]
+    ]
+  end
+
+  # Mirrors Mint.HTTP1.default_host_header/1: host only when the port is the
+  # scheme default, else "host:port". An IPv6-literal original host is bracketed.
+  defp host_header_value(host, scheme, port) do
+    bracketed = if String.contains?(host, ":"), do: "[" <> host <> "]", else: host
+
+    if URI.default_port(scheme) == port do
+      bracketed
+    else
+      "#{bracketed}:#{port}"
+    end
   end
 
   # --- scheme / host ---

--- a/lib/loopctl/net/url_guard.ex
+++ b/lib/loopctl/net/url_guard.ex
@@ -20,22 +20,36 @@ defmodule Loopctl.Net.UrlGuard do
   ## Defense layers
 
     1. **Scheme allowlist** — only `http`/`https` (override via `:schemes`).
-    2. **Real DNS resolution** — a bare host that is not already an IP literal is
-       resolved (A *and* AAAA) via `Loopctl.Net.DnsResolver`; a hostname that
-       resolves to a private address is blocked. IP-literal forms (dotted v4,
-       decimal/hex IPv4, and IPv6 literals) are parsed directly with
-       `:inet.parse_address/1`.
+    2. **Real DNS resolution (bounded)** — a bare host that is not already an IP
+       literal is resolved (A *and* AAAA) via `Loopctl.Net.DnsResolver` under a
+       bounded timeout (fail closed on timeout); a hostname that resolves to a
+       private address is blocked. IP-literal forms (dotted v4, decimal/hex IPv4,
+       and IPv6 literals) are parsed directly with `:inet.parse_address/1`.
     3. **Private-range blocklist for BOTH families** — v4: `0.0.0.0/8`,
        `10.0.0.0/8`, `100.64.0.0/10` (CGNAT), `127.0.0.0/8`, `169.254.0.0/16`
        (cloud metadata), `172.16.0.0/12`, `192.168.0.0/16`; v6: `::`, `::1`,
-       `fe80::/10` (link-local), `fc00::/7` (ULA incl. Fly `fdaa::`), and
-       IPv4-mapped `::ffff:0:0/96` (the embedded v4 is decoded and re-checked
-       against the v4 rules). If a host resolves to *multiple* addresses and
-       *any* one is blocked, the whole URL is rejected.
+       `fe80::/10` (link-local), `fc00::/7` (ULA incl. Fly `fdaa::`), and every
+       v4-in-v6 embedding that could smuggle a private v4 past the v6 rules —
+       IPv4-mapped `::ffff:0:0/96`, IPv4-compatible `::/96`, NAT64
+       `64:ff9b::/96` (RFC 6052), 6to4 `2002::/16` (RFC 3056), and Teredo
+       `2001:0::/32` (RFC 4380). For every embedding the inner v4 is decoded and
+       re-checked against the v4 rules. If a host resolves to *multiple*
+       addresses and *any* one is blocked, the whole URL is rejected.
 
-  Callers MUST re-validate on every request (DNS rebinding / TOCTOU), not only at
-  submission time, and MUST disable redirect following (`redirect: false`) so a
-  302 hop can't re-enter an unvalidated URL.
+  ## Connecting safely — pin the validated IP
+
+  Re-validating a hostname before a request is NOT sufficient on its own: an HTTP
+  client re-resolves the hostname at connect time (a *separate* DNS lookup), so a
+  TTL=0 attacker can answer the validation lookup with a public IP and the connect
+  lookup with a private one (DNS rebinding / TOCTOU). To close that window,
+  connection sites use `pin/1` + `pinned_request_opts/1`: the URL authority is
+  rewritten to the *single* validated IP while the original hostname is preserved
+  for the `Host` header, TLS SNI, and certificate verification (via Mint's
+  `:hostname` connect option). The client therefore connects to exactly the IP the
+  guard vetted — there is no second resolution to rebind.
+
+  Callers MUST also disable redirect following (`redirect: false`) so a 302 hop
+  can't re-enter an unvalidated URL.
   """
 
   import Bitwise
@@ -49,6 +63,12 @@ defmodule Loopctl.Net.UrlGuard do
           | :dns_resolution_failed
           | :blocked_ip
 
+  @typedoc """
+  A validated URL together with the single IP it was pinned to and the original
+  host to preserve for `Host`/SNI/cert verification.
+  """
+  @type pinned :: %{uri: URI.t(), host: String.t(), ip: :inet.ip_address()}
+
   @doc """
   Validates that `url` is safe to fetch from a server-side context.
 
@@ -56,14 +76,33 @@ defmodule Loopctl.Net.UrlGuard do
   it resolves to is a public, routable address. Returns `{:error, reason}`
   otherwise, where `reason` is one of `t:reason/0`.
 
+  Use this at submission/enqueue time (changeset, controller). At connection time
+  prefer `pin/2` + `pinned_request_opts/1` to also close the DNS-rebinding window.
+
   ## Options
 
     * `:schemes` — list of allowed URI schemes (default `["http", "https"]`).
   """
   @spec validate_egress(String.t(), keyword()) :: {:ok, URI.t()} | {:error, reason()}
-  def validate_egress(url, opts \\ [])
+  def validate_egress(url, opts \\ []) do
+    case pin(url, opts) do
+      {:ok, %{uri: uri}} -> {:ok, uri}
+      {:error, _reason} = err -> err
+    end
+  end
 
-  def validate_egress(url, opts) when is_binary(url) do
+  @doc """
+  Validates `url` and returns the single IP to pin the connection to.
+
+  Same checks as `validate_egress/2`, but on success returns
+  `{:ok, %{uri: uri, host: host, ip: ip}}` where `ip` is the first (already
+  vetted) resolved address. Feed the result to `pinned_request_opts/1` to build
+  Req options that connect to that exact IP.
+  """
+  @spec pin(String.t(), keyword()) :: {:ok, pinned()} | {:error, reason()}
+  def pin(url, opts \\ [])
+
+  def pin(url, opts) when is_binary(url) do
     schemes = Keyword.get(opts, :schemes, @default_schemes)
     uri = URI.parse(url)
 
@@ -71,11 +110,29 @@ defmodule Loopctl.Net.UrlGuard do
          {:ok, host} <- host(uri),
          {:ok, ips} <- resolve(host),
          :ok <- check_ips(ips) do
-      {:ok, uri}
+      {:ok, %{uri: uri, host: strip_brackets(host), ip: hd(ips)}}
     end
   end
 
-  def validate_egress(_url, _opts), do: {:error, :invalid_url}
+  def pin(_url, _opts), do: {:error, :invalid_url}
+
+  @doc """
+  Builds Req options that connect to the pinned IP while preserving the original
+  host for the `Host` header, TLS SNI, and certificate verification.
+
+  Returns `[url: connect_url, connect_options: [hostname: original_host]]`, where
+  `connect_url` has its authority rewritten to the validated IP literal (IPv6 is
+  bracketed). Merge this with the caller's method/body/headers and
+  `redirect: false`.
+  """
+  @spec pinned_request_opts(pinned()) :: keyword()
+  def pinned_request_opts(%{uri: uri, host: host, ip: ip}) do
+    connect_url =
+      %URI{uri | host: ip_literal(ip), authority: nil}
+      |> URI.to_string()
+
+    [url: connect_url, connect_options: [hostname: host]]
+  end
 
   # --- scheme / host ---
 
@@ -115,6 +172,9 @@ defmodule Loopctl.Net.UrlGuard do
     |> String.replace_suffix("]", "")
   end
 
+  # `:inet.ntoa/1` yields the bare address; URI.to_string/1 re-brackets IPv6.
+  defp ip_literal(ip), do: ip |> :inet.ntoa() |> List.to_string()
+
   # --- Blocklist ---
 
   # Any blocked address in the resolved set fails the whole URL.
@@ -125,16 +185,32 @@ defmodule Loopctl.Net.UrlGuard do
   # --- IPv4 ---
   defp blocked?({a, b, _c, _d}), do: blocked_ipv4?(a, b)
 
-  # IPv4-mapped IPv6 (::ffff:0:0/96): decode the embedded v4's first two octets
-  # (all blocked ranges are determined by them) and re-check against the v4 rules.
+  # --- v4-in-v6 embeddings: decode the inner v4 and re-check the v4 rules ---
+
+  # IPv4-mapped (::ffff:0:0/96)
   defp blocked?({0, 0, 0, 0, 0, 0xFFFF, g6, _g7}) do
     blocked_ipv4?(g6 >>> 8, g6 &&& 0xFF)
   end
 
-  # IPv4-compatible IPv6 (::0.0.0.0/96, incl. :: and ::1): decode the embedded v4
-  # and re-check. Covers ::1 (→ 0.0.0.1, blocked by 0.0.0.0/8) and :: as well.
+  # IPv4-compatible (::0.0.0.0/96, incl. :: and ::1 → 0.0.0.1)
   defp blocked?({0, 0, 0, 0, 0, 0, g6, _g7}) do
     blocked_ipv4?(g6 >>> 8, g6 &&& 0xFF)
+  end
+
+  # NAT64 well-known prefix (64:ff9b::/96, RFC 6052)
+  defp blocked?({0x0064, 0xFF9B, 0, 0, 0, 0, g6, _g7}) do
+    blocked_ipv4?(g6 >>> 8, g6 &&& 0xFF)
+  end
+
+  # 6to4 (2002::/16, RFC 3056): inner v4 in groups 1..2
+  defp blocked?({0x2002, w, _x, _, _, _, _, _}) do
+    blocked_ipv4?(w >>> 8, w &&& 0xFF)
+  end
+
+  # Teredo (2001:0::/32, RFC 4380): client v4 is the low 32 bits XOR 0xFFFFFFFF
+  defp blocked?({0x2001, 0, _, _, _, _, s6, s7}) do
+    v4 = bnot(s6 <<< 16 ||| s7) &&& 0xFFFFFFFF
+    blocked_ipv4?(v4 >>> 24, v4 >>> 16 &&& 0xFF)
   end
 
   # --- IPv6 ---

--- a/lib/loopctl/webhooks/req_delivery.ex
+++ b/lib/loopctl/webhooks/req_delivery.ex
@@ -24,12 +24,14 @@ defmodule Loopctl.Webhooks.ReqDelivery do
   end
 
   defp do_deliver(pinned, body, headers) do
+    # Fold the caller's headers into pinned_request_opts so the explicit `Host`
+    # header it sets is preserved (a plain `Keyword.merge(headers: ...)` would
+    # clobber it).
     req_opts =
-      UrlGuard.pinned_request_opts(pinned)
+      UrlGuard.pinned_request_opts(pinned, headers)
       |> Keyword.merge(
         method: :post,
         body: body,
-        headers: headers,
         receive_timeout: 10_000,
         retry: false,
         # Never follow redirects — a 302 hop would re-enter an unvalidated URL,

--- a/lib/loopctl/webhooks/req_delivery.ex
+++ b/lib/loopctl/webhooks/req_delivery.ex
@@ -12,19 +12,21 @@ defmodule Loopctl.Webhooks.ReqDelivery do
 
   @impl true
   def deliver(url, body, headers) do
-    # Re-validate at delivery time, not just at changeset time, to defend against
-    # DNS rebinding / TOCTOU: a host that resolved public when the webhook was
-    # created may now resolve to an internal address (ie-02 / GHSA-jh42-wf7g-f5rg).
-    case UrlGuard.validate_egress(url) do
-      {:ok, _uri} -> do_deliver(url, body, headers)
+    # Validate AND pin at delivery time (not just at changeset time) to defend
+    # against DNS rebinding / TOCTOU (ie-02 / GHSA-jh42-wf7g-f5rg): pin/1 resolves
+    # the host ONCE, and pinned_request_opts/1 makes Req connect to that exact IP
+    # while keeping the original host for Host/SNI/cert — so there is no second
+    # resolution for an attacker to rebind.
+    case UrlGuard.pin(url) do
+      {:ok, pinned} -> do_deliver(pinned, body, headers)
       {:error, reason} -> {:error, "blocked_url: #{reason}"}
     end
   end
 
-  defp do_deliver(url, body, headers) do
+  defp do_deliver(pinned, body, headers) do
     req_opts =
-      [
-        url: url,
+      UrlGuard.pinned_request_opts(pinned)
+      |> Keyword.merge(
         method: :post,
         body: body,
         headers: headers,
@@ -33,7 +35,7 @@ defmodule Loopctl.Webhooks.ReqDelivery do
         # Never follow redirects — a 302 hop would re-enter an unvalidated URL,
         # bypassing the egress guard above (ie-02 / GHSA-jh42-wf7g-f5rg).
         redirect: false
-      ]
+      )
       |> maybe_add_plug()
 
     case Req.request(req_opts) do

--- a/lib/loopctl/webhooks/req_delivery.ex
+++ b/lib/loopctl/webhooks/req_delivery.ex
@@ -8,8 +8,20 @@ defmodule Loopctl.Webhooks.ReqDelivery do
 
   @behaviour Loopctl.Webhooks.DeliveryBehaviour
 
+  alias Loopctl.Net.UrlGuard
+
   @impl true
   def deliver(url, body, headers) do
+    # Re-validate at delivery time, not just at changeset time, to defend against
+    # DNS rebinding / TOCTOU: a host that resolved public when the webhook was
+    # created may now resolve to an internal address (ie-02 / GHSA-jh42-wf7g-f5rg).
+    case UrlGuard.validate_egress(url) do
+      {:ok, _uri} -> do_deliver(url, body, headers)
+      {:error, reason} -> {:error, "blocked_url: #{reason}"}
+    end
+  end
+
+  defp do_deliver(url, body, headers) do
     req_opts =
       [
         url: url,
@@ -17,7 +29,10 @@ defmodule Loopctl.Webhooks.ReqDelivery do
         body: body,
         headers: headers,
         receive_timeout: 10_000,
-        retry: false
+        retry: false,
+        # Never follow redirects — a 302 hop would re-enter an unvalidated URL,
+        # bypassing the egress guard above (ie-02 / GHSA-jh42-wf7g-f5rg).
+        redirect: false
       ]
       |> maybe_add_plug()
 

--- a/lib/loopctl/webhooks/webhook.ex
+++ b/lib/loopctl/webhooks/webhook.ex
@@ -114,7 +114,8 @@ defmodule Loopctl.Webhooks.Webhook do
         {:error, :invalid_scheme} -> [url: "must use HTTPS or HTTP scheme"]
         {:error, :missing_host} -> [url: "must have a valid host"]
         {:error, :invalid_url} -> [url: "must be a valid URL"]
-        {:error, _blocked} -> [url: "must not target a private or loopback address"]
+        {:error, :dns_resolution_failed} -> [url: "host could not be resolved"]
+        {:error, :blocked_ip} -> [url: "must not target a private or loopback address"]
       end
     end)
   end

--- a/lib/loopctl/webhooks/webhook.ex
+++ b/lib/loopctl/webhooks/webhook.ex
@@ -19,6 +19,8 @@ defmodule Loopctl.Webhooks.Webhook do
 
   use Loopctl.Schema
 
+  alias Loopctl.Net.UrlGuard
+
   @type t :: %__MODULE__{}
 
   @valid_event_types ~w(
@@ -99,54 +101,22 @@ defmodule Loopctl.Webhooks.Webhook do
     |> foreign_key_constraint(:project_id)
   end
 
-  @private_ip_prefixes ~w(
-    10.
-    172.16.
-    172.17.
-    172.18.
-    172.19.
-    172.20.
-    172.21.
-    172.22.
-    172.23.
-    172.24.
-    172.25.
-    172.26.
-    172.27.
-    172.28.
-    172.29.
-    172.30.
-    172.31.
-    192.168.
-    169.254.
-    127.
-  )
-
+  # SSRF egress guard (ie-02 / GHSA-jh42-wf7g-f5rg). Delegates to the shared
+  # Loopctl.Net.UrlGuard, which does scheme allowlisting, real DNS resolution,
+  # and a private/loopback/link-local/metadata blocklist for BOTH IPv4 and IPv6
+  # (the old @private_ip_prefixes string blocklist missed IPv6, numeric IPv4,
+  # 0.0.0.0, and did no DNS resolution). Re-validated again at delivery time in
+  # Loopctl.Webhooks.ReqDelivery to defend against DNS rebinding.
   defp validate_url(changeset) do
     validate_change(changeset, :url, fn :url, url ->
-      uri = URI.parse(url)
-
-      cond do
-        uri.scheme not in ["https", "http"] ->
-          [url: "must use HTTPS or HTTP scheme"]
-
-        is_nil(uri.host) or uri.host == "" ->
-          [url: "must have a valid host"]
-
-        private_host?(uri.host) ->
-          [url: "must not target a private or loopback address"]
-
-        true ->
-          []
+      case UrlGuard.validate_egress(url) do
+        {:ok, _uri} -> []
+        {:error, :invalid_scheme} -> [url: "must use HTTPS or HTTP scheme"]
+        {:error, :missing_host} -> [url: "must have a valid host"]
+        {:error, :invalid_url} -> [url: "must be a valid URL"]
+        {:error, _blocked} -> [url: "must not target a private or loopback address"]
       end
     end)
-  end
-
-  defp private_host?(host) do
-    normalized = String.downcase(host)
-
-    normalized in ["localhost", "::1"] or
-      Enum.any?(@private_ip_prefixes, &String.starts_with?(normalized, &1))
   end
 
   defp validate_events(changeset) do

--- a/lib/loopctl/workers/content_ingestion_worker.ex
+++ b/lib/loopctl/workers/content_ingestion_worker.ex
@@ -37,6 +37,7 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   alias Loopctl.Audit
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.ContentChunker
+  alias Loopctl.Net.UrlGuard
   alias Loopctl.Workers.ArticleEmbeddingWorker
 
   @content_extractor Application.compile_env(
@@ -170,8 +171,37 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   end
 
   defp resolve_content(url, _content) when is_binary(url) do
+    # SSRF egress guard (worker-01 / GHSA-j7m9-ffmr-pwhm). Re-validate the
+    # user-supplied URL immediately before fetching (the controller also validates
+    # at enqueue time; re-checking here defends against DNS rebinding / TOCTOU).
+    case UrlGuard.validate_egress(url) do
+      {:ok, _uri} -> fetch_url(url)
+      {:error, reason} -> blocked_url(url, reason)
+    end
+  end
+
+  defp resolve_content(nil, _), do: {:error, :no_content}
+
+  defp blocked_url(url, reason) do
+    Logger.warning(
+      "ContentIngestionWorker: refusing to fetch blocked URL " <>
+        "(url=#{url}, reason=#{reason})"
+    )
+
+    {:error, {:url_blocked, reason}}
+  end
+
+  defp fetch_url(url) do
     req_opts =
-      [url: url, receive_timeout: 15_000, retry: :transient, max_retries: 1]
+      [
+        url: url,
+        receive_timeout: 15_000,
+        retry: :transient,
+        max_retries: 1,
+        # Do not follow redirects — a redirect hop would re-enter an unvalidated
+        # URL and bypass the egress guard (worker-01 / GHSA-j7m9-ffmr-pwhm).
+        redirect: false
+      ]
       |> maybe_add_plug()
 
     case Req.get(req_opts) do
@@ -195,8 +225,6 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
         {:error, {:url_fetch_error, reason}}
     end
   end
-
-  defp resolve_content(nil, _), do: {:error, :no_content}
 
   defp derive_source_id(content_hash) do
     # Derive a deterministic UUID from the content hash.

--- a/lib/loopctl/workers/content_ingestion_worker.ex
+++ b/lib/loopctl/workers/content_ingestion_worker.ex
@@ -86,6 +86,12 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
     trunc(:math.pow(attempt, 4) + 15 + :rand.uniform(30) * attempt)
   end
 
+  # Hard per-job wall-clock cap (backstop to the bounded DNS resolve + Req
+  # receive_timeout). A hostile/slow endpoint can't pin a :knowledge queue slot
+  # indefinitely (worker-01 / GHSA-j7m9-ffmr-pwhm).
+  @impl Oban.Worker
+  def timeout(_job), do: :timer.seconds(30)
+
   # --- Private ---
 
   defp extract_with_chunking(content, source_type) do
@@ -171,11 +177,12 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   end
 
   defp resolve_content(url, _content) when is_binary(url) do
-    # SSRF egress guard (worker-01 / GHSA-j7m9-ffmr-pwhm). Re-validate the
+    # SSRF egress guard (worker-01 / GHSA-j7m9-ffmr-pwhm). Validate AND pin the
     # user-supplied URL immediately before fetching (the controller also validates
-    # at enqueue time; re-checking here defends against DNS rebinding / TOCTOU).
-    case UrlGuard.validate_egress(url) do
-      {:ok, _uri} -> fetch_url(url)
+    # at enqueue time). pin/1 resolves once and the connection targets that exact
+    # IP, closing the DNS-rebinding / TOCTOU window.
+    case UrlGuard.pin(url) do
+      {:ok, pinned} -> fetch_url(url, pinned)
       {:error, reason} -> blocked_url(url, reason)
     end
   end
@@ -191,17 +198,17 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
     {:error, {:url_blocked, reason}}
   end
 
-  defp fetch_url(url) do
+  defp fetch_url(url, pinned) do
     req_opts =
-      [
-        url: url,
+      UrlGuard.pinned_request_opts(pinned)
+      |> Keyword.merge(
         receive_timeout: 15_000,
         retry: :transient,
         max_retries: 1,
         # Do not follow redirects — a redirect hop would re-enter an unvalidated
         # URL and bypass the egress guard (worker-01 / GHSA-j7m9-ffmr-pwhm).
         redirect: false
-      ]
+      )
       |> maybe_add_plug()
 
     case Req.get(req_opts) do

--- a/lib/loopctl/workers/webhook_delivery_worker.ex
+++ b/lib/loopctl/workers/webhook_delivery_worker.ex
@@ -49,6 +49,12 @@ defmodule Loopctl.Workers.WebhookDeliveryWorker do
 
   def backoff_seconds(_attempt), do: List.last(@backoff_schedule)
 
+  # Hard per-job wall-clock cap (backstop to the bounded DNS resolve in the egress
+  # guard + Req receive_timeout). A hostile/slow webhook target can't pin a
+  # :webhooks queue slot indefinitely (ie-02 / GHSA-jh42-wf7g-f5rg).
+  @impl Oban.Worker
+  def timeout(_job), do: :timer.seconds(30)
+
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"webhook_event_id" => event_id, "tenant_id" => tenant_id}}) do
     with {:ok, event} <- load_event(tenant_id, event_id),

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -10,6 +10,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   use OpenApiSpex.ControllerSpecs
 
   alias Loopctl.ApiSpec.Schemas
+  alias Loopctl.Net.UrlGuard
   alias Loopctl.Workers.ContentIngestionWorker
   alias LoopctlWeb.Helpers.Pagination
 
@@ -284,7 +285,8 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     publish = params["publish"] == true or params["publish"] == "true"
 
     with :ok <- validate_content_source(url, content),
-         :ok <- validate_source_type(source_type) do
+         :ok <- validate_source_type(source_type),
+         :ok <- validate_url_egress(url) do
       content_hash = compute_content_hash(url || content)
 
       job_args =
@@ -383,6 +385,32 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
 
   defp validate_source_type(""), do: {:error, :unprocessable_entity, "'source_type' is required"}
   defp validate_source_type(_), do: :ok
+
+  # SSRF egress guard (worker-01 / GHSA-j7m9-ffmr-pwhm). Reject a URL that points
+  # at a private / loopback / link-local / cloud-metadata address up front (4xx)
+  # so a bad URL never reaches the worker. Content-only ingests (url == nil) skip
+  # this. The worker re-validates before fetching to defend against DNS rebinding.
+  defp validate_url_egress(nil), do: :ok
+
+  defp validate_url_egress(url) when is_binary(url) do
+    case UrlGuard.validate_egress(url) do
+      {:ok, _uri} ->
+        :ok
+
+      {:error, :invalid_scheme} ->
+        {:error, :unprocessable_entity, "'url' must use the http or https scheme"}
+
+      {:error, :invalid_url} ->
+        {:error, :unprocessable_entity, "'url' is not a valid URL"}
+
+      {:error, :missing_host} ->
+        {:error, :unprocessable_entity, "'url' must have a valid host"}
+
+      {:error, _blocked} ->
+        {:error, :unprocessable_entity,
+         "'url' must not target a private, loopback, or metadata address"}
+    end
+  end
 
   defp compute_content_hash(input) when is_binary(input) do
     :crypto.hash(:sha256, input) |> Base.encode16(case: :lower)

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -9,6 +9,8 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   use LoopctlWeb, :controller
   use OpenApiSpex.ControllerSpecs
 
+  require Logger
+
   alias Loopctl.ApiSpec.Schemas
   alias Loopctl.Net.UrlGuard
   alias Loopctl.Workers.ContentIngestionWorker
@@ -193,17 +195,25 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # Bound the aggregate request time (worker-01 / GHSA-j7m9-ffmr-pwhm). Each item
   # does bounded per-item DNS validation (A+AAAA), but a serial Enum.map over up
   # to @batch_max (50) items could still tie up a web worker for minutes on
-  # unresponsive nameservers. Task.async_stream caps concurrency AND imposes a
-  # per-item wall-clock deadline; a hung item is killed and mapped to a
-  # validation_timeout error, so the whole request is bounded regardless of any
-  # single hanging item. Ordering + per-item result shape are preserved.
+  # unresponsive nameservers. async_stream caps concurrency AND imposes a per-item
+  # wall-clock deadline; a hung item is killed and mapped to a validation_timeout
+  # error, so the whole request is bounded regardless of any single hanging item.
+  # Ordering + per-item result shape are preserved.
+  #
+  # We use the NOLINK Task.Supervisor variant (monitors, not links) so a genuine
+  # (non-timeout) raise in one item — e.g. an Oban.insert pool checkout-timeout
+  # under the 10-way intra-request concurrency — is caught and returned as a
+  # per-item {:exit, reason} error instead of killing the whole request (Bandit's
+  # HTTP/2 stream process does not trap exits). This preserves the "one bad item
+  # never fails the whole batch" invariant.
   #
   # tenant_id is passed explicitly into each task (no process-dict/RLS state is
   # relied on); Ecto Sandbox + Mox resolve via the `$callers` chain that
-  # Task.async_stream propagates.
+  # Task.Supervisor.async_stream_nolink propagates.
   defp process_batch_items(tenant_id, items) do
-    items
-    |> Task.async_stream(
+    Loopctl.TaskSupervisor
+    |> Task.Supervisor.async_stream_nolink(
+      items,
       fn item -> enqueue_item_result(tenant_id, item) end,
       max_concurrency: 10,
       timeout: batch_item_timeout_ms(),
@@ -211,9 +221,16 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
       ordered: true
     )
     |> Enum.map(fn
-      {:ok, result} -> result
-      {:exit, :timeout} -> %{status: "error", error: "validation_timeout"}
-      {:exit, _reason} -> %{status: "error", error: "validation_failed"}
+      {:ok, result} ->
+        result
+
+      {:exit, :timeout} ->
+        Logger.warning("batch item validation timeout")
+        %{status: "error", error: "validation_timeout"}
+
+      {:exit, reason} ->
+        Logger.warning("batch item validation crashed: #{inspect(reason)}")
+        %{status: "error", error: "validation_failed"}
     end)
   end
 

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -406,7 +406,10 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
       {:error, :missing_host} ->
         {:error, :unprocessable_entity, "'url' must have a valid host"}
 
-      {:error, _blocked} ->
+      {:error, :dns_resolution_failed} ->
+        {:error, :unprocessable_entity, "'url' host could not be resolved"}
+
+      {:error, :blocked_ip} ->
         {:error, :unprocessable_entity,
          "'url' must not target a private, loopback, or metadata address"}
     end

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -185,9 +185,47 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     items = params["items"]
 
     with :ok <- validate_batch_items(items) do
-      results = Enum.map(items, &enqueue_item_result(tenant_id, &1))
+      results = process_batch_items(tenant_id, items)
       json(conn, LoopctlWeb.KnowledgeIngestionJSON.batch(results))
     end
+  end
+
+  # Bound the aggregate request time (worker-01 / GHSA-j7m9-ffmr-pwhm). Each item
+  # does bounded per-item DNS validation (A+AAAA), but a serial Enum.map over up
+  # to @batch_max (50) items could still tie up a web worker for minutes on
+  # unresponsive nameservers. Task.async_stream caps concurrency AND imposes a
+  # per-item wall-clock deadline; a hung item is killed and mapped to a
+  # validation_timeout error, so the whole request is bounded regardless of any
+  # single hanging item. Ordering + per-item result shape are preserved.
+  #
+  # tenant_id is passed explicitly into each task (no process-dict/RLS state is
+  # relied on); Ecto Sandbox + Mox resolve via the `$callers` chain that
+  # Task.async_stream propagates.
+  defp process_batch_items(tenant_id, items) do
+    items
+    |> Task.async_stream(
+      fn item -> enqueue_item_result(tenant_id, item) end,
+      max_concurrency: 10,
+      timeout: batch_item_timeout_ms(),
+      on_timeout: :kill_task,
+      ordered: true
+    )
+    |> Enum.map(fn
+      {:ok, result} -> result
+      {:exit, :timeout} -> %{status: "error", error: "validation_timeout"}
+      {:exit, _reason} -> %{status: "error", error: "validation_failed"}
+    end)
+  end
+
+  # Per-item wall-clock deadline for batch validation. Config-based DI so the
+  # timeout path is testable deterministically without a multi-second wait.
+  @default_batch_item_timeout_ms 5_000
+  defp batch_item_timeout_ms do
+    Application.get_env(
+      :loopctl,
+      :batch_item_validation_timeout_ms,
+      @default_batch_item_timeout_ms
+    )
   end
 
   operation(:index,

--- a/test/loopctl/net/dns_resolver/default_test.exs
+++ b/test/loopctl/net/dns_resolver/default_test.exs
@@ -1,0 +1,31 @@
+defmodule Loopctl.Net.DnsResolver.DefaultTest do
+  @moduledoc """
+  Unit tests for the production DNS resolver.
+
+  Uses IP-literal inputs so `:inet.getaddrs/3` returns immediately without a
+  network lookup — the union/error logic and the bounded arity-3 call are
+  exercised deterministically. The security-critical *fail-closed on timeout*
+  behavior is proven at the guard level in `Loopctl.Net.UrlGuardTest` via the
+  injected mock resolver (a real network timeout would be flaky to unit-test).
+  """
+  use ExUnit.Case, async: true
+
+  alias Loopctl.Net.DnsResolver.Default
+
+  test "resolves an IPv4 literal to itself (A family), no network" do
+    assert {:ok, addrs} = Default.resolve("127.0.0.1")
+    assert {127, 0, 0, 1} in addrs
+  end
+
+  test "resolves an IPv6 literal to itself (AAAA family), no network" do
+    assert {:ok, addrs} = Default.resolve("::1")
+    assert {0, 0, 0, 0, 0, 0, 0, 1} in addrs
+  end
+
+  test "honors the configured resolve timeout" do
+    # A short timeout still resolves a literal immediately (proves the arity-3
+    # :inet.getaddrs/3 timeout path is wired without hanging).
+    assert Application.get_env(:loopctl, :dns_resolve_timeout_ms) == 2_000
+    assert {:ok, _addrs} = Default.resolve("127.0.0.1")
+  end
+end

--- a/test/loopctl/net/pinned_host_header_test.exs
+++ b/test/loopctl/net/pinned_host_header_test.exs
@@ -20,6 +20,22 @@ defmodule Loopctl.Net.PinnedHostHeaderTest do
   @ipv4_loopback {127, 0, 0, 1}
   @ipv6_loopback {0, 0, 0, 0, 0, 0, 0, 1}
 
+  setup context do
+    # Skip IPv6 tests on systems without IPv6 loopback bindability
+    if context[:requires_ipv6] do
+      case :gen_udp.open(0, [:inet6, {:ip, @ipv6_loopback}]) do
+        {:ok, socket} ->
+          :gen_udp.close(socket)
+          :ok
+
+        {:error, _reason} ->
+          {:skip, "IPv6 loopback not available on this system"}
+      end
+    else
+      :ok
+    end
+  end
+
   test "IPv4-pinned request sends the original hostname as Host" do
     port = start_echo_server(@ipv4_loopback, :echo_v4)
 
@@ -27,6 +43,7 @@ defmodule Loopctl.Net.PinnedHostHeaderTest do
              "webhook.example.com:#{port}"
   end
 
+  @tag :requires_ipv6
   test "IPv6-pinned request sends the original hostname as Host, not [::1] (FIX 1)" do
     port = start_echo_server(@ipv6_loopback, :echo_v6)
 

--- a/test/loopctl/net/pinned_host_header_test.exs
+++ b/test/loopctl/net/pinned_host_header_test.exs
@@ -1,0 +1,76 @@
+defmodule Loopctl.Net.PinnedHostHeaderTest do
+  @moduledoc """
+  Real Req/Finch round-trip test for the IP-pinning `Host` header (FIX 1).
+
+  This CANNOT use `Req.Test` — that stub adapter bypasses `Req.Finch.run/1`,
+  which is exactly where the bug lived: for an IPv6-pinned target the rewritten
+  URL host contains `:`, so Req pre-injects `host` = the bracketed IPv6 literal
+  and (before the fix) it won over Mint's default. We therefore stand up a real
+  loopback HTTP server (IPv4 and IPv6) and assert the SERVER-OBSERVED `Host`
+  header is the original hostname, not the pinned IP.
+
+  Both `Loopctl.Webhooks.ReqDelivery` and the content-ingestion worker build their
+  request via the same `UrlGuard.pinned_request_opts/2`, so exercising that opts
+  builder end-to-end covers both call sites.
+  """
+  use ExUnit.Case, async: true
+
+  alias Loopctl.Net.UrlGuard
+
+  @ipv4_loopback {127, 0, 0, 1}
+  @ipv6_loopback {0, 0, 0, 0, 0, 0, 0, 1}
+
+  test "IPv4-pinned request sends the original hostname as Host" do
+    port = start_echo_server(@ipv4_loopback, :echo_v4)
+
+    assert observed_host("webhook.example.com", @ipv4_loopback, port) ==
+             "webhook.example.com:#{port}"
+  end
+
+  test "IPv6-pinned request sends the original hostname as Host, not [::1] (FIX 1)" do
+    port = start_echo_server(@ipv6_loopback, :echo_v6)
+
+    observed = observed_host("webhook.example.com", @ipv6_loopback, port)
+
+    assert observed == "webhook.example.com:#{port}"
+    # The regression: before the fix the server saw the bracketed IPv6 literal.
+    refute observed =~ "::1"
+    refute observed =~ "["
+  end
+
+  # Build the request exactly as the delivery/ingestion paths do — via
+  # UrlGuard.pinned_request_opts/2 — but pointed at a loopback IP the guard would
+  # normally block, so we assemble the `pinned` struct directly. Then make a REAL
+  # request (no Req.Test plug) so Req.Finch.run/1 runs.
+  defp observed_host(original_host, ip, port) do
+    pinned = %{
+      uri: URI.parse("http://#{original_host}:#{port}/"),
+      host: original_host,
+      ip: ip
+    }
+
+    req_opts =
+      UrlGuard.pinned_request_opts(pinned)
+      |> Keyword.merge(method: :get, retry: false, redirect: false, receive_timeout: 2_000)
+
+    {:ok, %Req.Response{status: 200, body: body}} = Req.request(req_opts)
+    body
+  end
+
+  defp start_echo_server(ip, id) do
+    transport_options = [ip: ip] ++ if(tuple_size(ip) == 8, do: [:inet6], else: [])
+
+    pid =
+      start_supervised!(
+        {Bandit,
+         plug: Loopctl.Test.EchoHostPlug,
+         scheme: :http,
+         port: 0,
+         thousand_island_options: [transport_options: transport_options]},
+        id: id
+      )
+
+    {:ok, {_ip, port}} = ThousandIsland.listener_info(pid)
+    port
+  end
+end

--- a/test/loopctl/net/url_guard_test.exs
+++ b/test/loopctl/net/url_guard_test.exs
@@ -51,6 +51,29 @@ defmodule Loopctl.Net.UrlGuardTest do
     end
   end
 
+  # v4-in-v6 transition embeddings that smuggle a private v4 (ie-02 follow-up).
+  describe "validate_egress/2 blocks v4-in-v6 transition embeddings" do
+    for {label, host} <- [
+          # NAT64 well-known 64:ff9b::/96 (RFC 6052)
+          {"NAT64 loopback", "[64:ff9b::7f00:1]"},
+          {"NAT64 metadata", "[64:ff9b::a9fe:a9fe]"},
+          {"NAT64 private-10", "[64:ff9b::a00:1]"},
+          # 6to4 2002::/16 (RFC 3056)
+          {"6to4 loopback", "[2002:7f00:1::]"},
+          {"6to4 metadata", "[2002:a9fe:a9fe::]"},
+          {"6to4 private-10", "[2002:a00:1::]"},
+          # Teredo 2001:0::/32 (RFC 4380) — client v4 = low 32 bits XOR 0xFFFFFFFF
+          {"Teredo loopback", "[2001:0:0:0:0:0:80ff:fffe]"},
+          {"Teredo metadata", "[2001:0:0:0:0:0:5601:5601]"},
+          {"Teredo private-10", "[2001:0:0:0:0:0:f5ff:fffe]"}
+        ] do
+      test "blocks #{label} (#{host})" do
+        assert {:error, :blocked_ip} =
+                 UrlGuard.validate_egress("https://#{unquote(host)}/path")
+      end
+    end
+  end
+
   describe "validate_egress/2 with a public address" do
     test "allows a public IPv4 literal (no DNS)" do
       assert {:ok, %URI{host: "93.184.216.34"}} =
@@ -131,6 +154,67 @@ defmodule Loopctl.Net.UrlGuardTest do
 
       assert {:error, :dns_resolution_failed} =
                UrlGuard.validate_egress("https://nope.example.com/x")
+    end
+  end
+
+  # A hostile/unresponsive nameserver must not hang the caller — a bounded
+  # resolve that times out fails CLOSED (blocked), never open (FIX B).
+  describe "validate_egress/2 fails closed on DNS timeout" do
+    test "a resolver timeout blocks the URL" do
+      expect(Loopctl.MockDnsResolver, :resolve, fn _host ->
+        {:error, :timeout}
+      end)
+
+      assert {:error, :dns_resolution_failed} =
+               UrlGuard.validate_egress("https://slow.example.com/x")
+    end
+  end
+
+  # pin/1 + pinned_request_opts/1 resolve ONCE and make the client connect to
+  # that exact IP, so there is no second lookup to rebind (FIX C).
+  describe "pin/2 and pinned_request_opts/1 (DNS-rebinding defense)" do
+    test "pins the connection to the validated IP while preserving the host" do
+      expect(Loopctl.MockDnsResolver, :resolve, fn "hooks.example.com" ->
+        {:ok, [{93, 184, 216, 34}]}
+      end)
+
+      assert {:ok, pinned} = UrlGuard.pin("https://hooks.example.com:8443/deliver?q=1")
+      assert pinned.host == "hooks.example.com"
+      assert pinned.ip == {93, 184, 216, 34}
+
+      opts = UrlGuard.pinned_request_opts(pinned)
+      # The connection target is the validated IP literal, NOT the hostname —
+      # so the HTTP client cannot re-resolve and be rebound to a private IP.
+      assert opts[:url] == "https://93.184.216.34:8443/deliver?q=1"
+      # ...but the original host is preserved for Host header / TLS SNI / cert.
+      assert opts[:connect_options] == [hostname: "hooks.example.com"]
+    end
+
+    test "resolves the host exactly once (nothing left to rebind)" do
+      # Mox verifies the arity-1 expectation was called exactly once on exit.
+      expect(Loopctl.MockDnsResolver, :resolve, 1, fn _host ->
+        {:ok, [{93, 184, 216, 34}]}
+      end)
+
+      assert {:ok, _pinned} = UrlGuard.pin("https://once.example.com/x")
+    end
+
+    test "pins a public IPv6 literal with brackets" do
+      assert {:ok, pinned} = UrlGuard.pin("https://[2606:2800:220:1::1]/x")
+      opts = UrlGuard.pinned_request_opts(pinned)
+      assert opts[:url] == "https://[2606:2800:220:1::1]/x"
+      assert opts[:connect_options] == [hostname: "2606:2800:220:1::1"]
+    end
+
+    test "an IP-literal URL pins to itself" do
+      assert {:ok, pinned} = UrlGuard.pin("https://93.184.216.34/hooks")
+      opts = UrlGuard.pinned_request_opts(pinned)
+      assert opts[:url] == "https://93.184.216.34/hooks"
+      assert opts[:connect_options] == [hostname: "93.184.216.34"]
+    end
+
+    test "pin/1 rejects a blocked host (same checks as validate_egress)" do
+      assert {:error, :blocked_ip} = UrlGuard.pin("http://169.254.169.254/latest")
     end
   end
 end

--- a/test/loopctl/net/url_guard_test.exs
+++ b/test/loopctl/net/url_guard_test.exs
@@ -188,6 +188,43 @@ defmodule Loopctl.Net.UrlGuardTest do
       assert opts[:url] == "https://93.184.216.34:8443/deliver?q=1"
       # ...but the original host is preserved for Host header / TLS SNI / cert.
       assert opts[:connect_options] == [hostname: "hooks.example.com"]
+      # Explicit Host header (non-default port → suffix) so Req's put_new_header
+      # can't inject the IP literal.
+      assert opts[:headers] == [{"host", "hooks.example.com:8443"}]
+    end
+
+    test "sets an explicit Host header with no suffix on the default port" do
+      expect(Loopctl.MockDnsResolver, :resolve, fn "hooks.example.com" ->
+        {:ok, [{93, 184, 216, 34}]}
+      end)
+
+      assert {:ok, pinned} = UrlGuard.pin("https://hooks.example.com/deliver")
+      opts = UrlGuard.pinned_request_opts(pinned)
+      assert opts[:headers] == [{"host", "hooks.example.com"}]
+    end
+
+    test "IPv6-pinned target keeps the original hostname in the Host header (FIX 1)" do
+      # Regression: a hostname resolving to an IPv6-only address must NOT send
+      # `Host: [::1]`-style IP literals. Host header stays the hostname.
+      expect(Loopctl.MockDnsResolver, :resolve, fn "v6only.example.com" ->
+        {:ok, [{0x2606, 0x2800, 0x220, 1, 0, 0, 0, 1}]}
+      end)
+
+      assert {:ok, pinned} = UrlGuard.pin("https://v6only.example.com/deliver")
+      opts = UrlGuard.pinned_request_opts(pinned)
+      # Connect to the pinned v6 literal (bracketed in the URL)...
+      assert opts[:url] == "https://[2606:2800:220:1::1]/deliver"
+      # ...but Host header + SNI stay the hostname.
+      assert opts[:connect_options] == [hostname: "v6only.example.com"]
+      assert opts[:headers] == [{"host", "v6only.example.com"}]
+    end
+
+    test "appends caller headers after the Host header" do
+      expect(Loopctl.MockDnsResolver, :resolve, fn _ -> {:ok, [{93, 184, 216, 34}]} end)
+
+      assert {:ok, pinned} = UrlGuard.pin("https://hooks.example.com/x")
+      opts = UrlGuard.pinned_request_opts(pinned, [{"x-sig", "abc"}])
+      assert opts[:headers] == [{"host", "hooks.example.com"}, {"x-sig", "abc"}]
     end
 
     test "resolves the host exactly once (nothing left to rebind)" do
@@ -204,6 +241,8 @@ defmodule Loopctl.Net.UrlGuardTest do
       opts = UrlGuard.pinned_request_opts(pinned)
       assert opts[:url] == "https://[2606:2800:220:1::1]/x"
       assert opts[:connect_options] == [hostname: "2606:2800:220:1::1"]
+      # An IPv6-literal original host is bracketed in the Host header too.
+      assert opts[:headers] == [{"host", "[2606:2800:220:1::1]"}]
     end
 
     test "an IP-literal URL pins to itself" do
@@ -211,6 +250,7 @@ defmodule Loopctl.Net.UrlGuardTest do
       opts = UrlGuard.pinned_request_opts(pinned)
       assert opts[:url] == "https://93.184.216.34/hooks"
       assert opts[:connect_options] == [hostname: "93.184.216.34"]
+      assert opts[:headers] == [{"host", "93.184.216.34"}]
     end
 
     test "pin/1 rejects a blocked host (same checks as validate_egress)" do

--- a/test/loopctl/net/url_guard_test.exs
+++ b/test/loopctl/net/url_guard_test.exs
@@ -1,0 +1,136 @@
+defmodule Loopctl.Net.UrlGuardTest do
+  @moduledoc """
+  Unit tests for the shared SSRF egress guard.
+
+  Closes ie-02 (GHSA-jh42-wf7g-f5rg) and worker-01 (GHSA-j7m9-ffmr-pwhm).
+
+  IP-literal / numeric cases exercise the blocklist directly through
+  `:inet.parse_address/1` and need no DNS. The DNS-rebinding cases inject the
+  `Loopctl.MockDnsResolver` to prove a bare hostname is actually resolved and its
+  resolved address is what gets checked.
+  """
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.Net.UrlGuard
+
+  describe "validate_egress/2 blocks private / loopback / metadata IPv4 literals" do
+    for {label, host} <- [
+          {"cloud metadata", "169.254.169.254"},
+          {"loopback", "127.0.0.1"},
+          {"private 10/8", "10.0.0.5"},
+          {"private 192.168/16", "192.168.1.1"},
+          {"private 172.16/12", "172.16.0.1"},
+          {"unspecified 0.0.0.0", "0.0.0.0"},
+          {"CGNAT 100.64/10", "100.64.0.1"},
+          {"decimal loopback", "2130706433"},
+          {"hex loopback", "0x7f000001"}
+        ] do
+      test "blocks #{label} (#{host})" do
+        assert {:error, :blocked_ip} =
+                 UrlGuard.validate_egress("http://#{unquote(host)}/path")
+      end
+    end
+  end
+
+  describe "validate_egress/2 blocks private / loopback / metadata IPv6 literals" do
+    for {label, host} <- [
+          {"loopback ::1", "[::1]"},
+          {"unspecified ::", "[::]"},
+          {"Fly ULA fdaa::1", "[fdaa::1]"},
+          {"link-local fe80::1", "[fe80::1]"},
+          {"IPv4-mapped loopback", "[::ffff:127.0.0.1]"},
+          {"IPv4-mapped metadata", "[::ffff:169.254.169.254]"},
+          {"IPv4-compatible loopback", "[::127.0.0.1]"}
+        ] do
+      test "blocks #{label} (#{host})" do
+        assert {:error, :blocked_ip} =
+                 UrlGuard.validate_egress("https://#{unquote(host)}/path")
+      end
+    end
+  end
+
+  describe "validate_egress/2 with a public address" do
+    test "allows a public IPv4 literal (no DNS)" do
+      assert {:ok, %URI{host: "93.184.216.34"}} =
+               UrlGuard.validate_egress("https://93.184.216.34/hooks")
+    end
+
+    test "allows a public IPv6 literal" do
+      assert {:ok, %URI{}} = UrlGuard.validate_egress("https://[2606:2800:220:1::1]/x")
+    end
+  end
+
+  describe "validate_egress/2 scheme allowlist" do
+    test "rejects a non-http(s) scheme" do
+      assert {:error, :invalid_scheme} =
+               UrlGuard.validate_egress("ftp://93.184.216.34/x")
+    end
+
+    test "rejects file:// scheme" do
+      assert {:error, :invalid_scheme} =
+               UrlGuard.validate_egress("file:///etc/passwd")
+    end
+
+    test "honors a custom :schemes allowlist" do
+      assert {:error, :invalid_scheme} =
+               UrlGuard.validate_egress("http://93.184.216.34/x", schemes: ["https"])
+    end
+
+    test "rejects a URL with no host" do
+      assert {:error, :missing_host} = UrlGuard.validate_egress("https:///path")
+    end
+
+    test "rejects a non-binary url" do
+      assert {:error, :invalid_url} = UrlGuard.validate_egress(nil)
+    end
+  end
+
+  describe "validate_egress/2 DNS resolution (rebinding defense)" do
+    test "blocks a hostname that resolves to a private address" do
+      expect(Loopctl.MockDnsResolver, :resolve, fn "rebind.example.com" ->
+        {:ok, [{169, 254, 169, 254}]}
+      end)
+
+      assert {:error, :blocked_ip} =
+               UrlGuard.validate_egress("https://rebind.example.com/steal")
+    end
+
+    test "blocks a hostname whose AAAA record is a private IPv6" do
+      expect(Loopctl.MockDnsResolver, :resolve, fn "fly-internal.example.com" ->
+        {:ok, [{0xFDAA, 0, 0, 0, 0, 0, 0, 1}]}
+      end)
+
+      assert {:error, :blocked_ip} =
+               UrlGuard.validate_egress("https://fly-internal.example.com/x")
+    end
+
+    test "blocks when ANY of several resolved addresses is private" do
+      expect(Loopctl.MockDnsResolver, :resolve, fn _host ->
+        {:ok, [{93, 184, 216, 34}, {10, 0, 0, 1}]}
+      end)
+
+      assert {:error, :blocked_ip} =
+               UrlGuard.validate_egress("https://mixed.example.com/x")
+    end
+
+    test "allows a hostname that resolves only to public addresses" do
+      expect(Loopctl.MockDnsResolver, :resolve, fn "good.example.com" ->
+        {:ok, [{93, 184, 216, 34}]}
+      end)
+
+      assert {:ok, %URI{host: "good.example.com"}} =
+               UrlGuard.validate_egress("https://good.example.com/x")
+    end
+
+    test "rejects a hostname that does not resolve" do
+      expect(Loopctl.MockDnsResolver, :resolve, fn _host ->
+        {:error, :nxdomain}
+      end)
+
+      assert {:error, :dns_resolution_failed} =
+               UrlGuard.validate_egress("https://nope.example.com/x")
+    end
+  end
+end

--- a/test/loopctl/webhooks/req_delivery_test.exs
+++ b/test/loopctl/webhooks/req_delivery_test.exs
@@ -1,0 +1,67 @@
+defmodule Loopctl.Webhooks.ReqDeliveryTest do
+  @moduledoc """
+  Tests the SSRF egress guard on the webhook delivery path
+  (ie-02 / GHSA-jh42-wf7g-f5rg): re-validation at delivery time and
+  `redirect: false`.
+  """
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.Webhooks.ReqDelivery
+
+  describe "deliver/3 re-validates the URL (DNS rebinding / TOCTOU)" do
+    test "refuses a metadata IPv4 literal without making a request" do
+      assert {:error, message} =
+               ReqDelivery.deliver("http://169.254.169.254/latest/meta-data/", "{}", [])
+
+      assert message =~ "blocked_url"
+    end
+
+    test "refuses a Fly 6PN IPv6 literal" do
+      assert {:error, message} = ReqDelivery.deliver("http://[fdaa::1]/x", "{}", [])
+      assert message =~ "blocked_url"
+    end
+
+    test "refuses a hostname that now resolves to a private address" do
+      expect(Loopctl.MockDnsResolver, :resolve, fn _host ->
+        {:ok, [{10, 0, 0, 1}]}
+      end)
+
+      assert {:error, message} =
+               ReqDelivery.deliver("https://rebind.example.com/hooks", "{}", [])
+
+      assert message =~ "blocked_url"
+    end
+  end
+
+  describe "deliver/3 does not follow redirects" do
+    test "a 302 to an internal target is NOT followed (redirect: false)" do
+      # Public IP literal passes the guard (no DNS). The plug returns a 302 whose
+      # Location points at the metadata IP. With redirect: false the 302 is
+      # returned as-is (a non-2xx), so delivery fails instead of silently hopping
+      # to 169.254.169.254 and reading it back.
+      Req.Test.stub(Loopctl.Webhooks.ReqDelivery, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("location", "http://169.254.169.254/")
+        |> Plug.Conn.send_resp(302, "redirecting")
+      end)
+
+      assert {:error, message} =
+               ReqDelivery.deliver("https://93.184.216.34/hooks", "{}", [])
+
+      assert message =~ "302"
+    end
+  end
+
+  describe "deliver/3 happy path" do
+    test "delivers to a public URL" do
+      Req.Test.stub(Loopctl.Webhooks.ReqDelivery, fn conn ->
+        Req.Test.json(conn, %{"ok" => true})
+      end)
+
+      assert {:ok, %{status: 200}} =
+               ReqDelivery.deliver("https://93.184.216.34/hooks", "{}", [])
+    end
+  end
+end

--- a/test/loopctl/webhooks/req_delivery_test.exs
+++ b/test/loopctl/webhooks/req_delivery_test.exs
@@ -63,5 +63,21 @@ defmodule Loopctl.Webhooks.ReqDeliveryTest do
       assert {:ok, %{status: 200}} =
                ReqDelivery.deliver("https://93.184.216.34/hooks", "{}", [])
     end
+
+    test "a legit hostname-based delivery still succeeds through the pinned path" do
+      # Resolve ONCE to a public IP; the connection is pinned to that IP while the
+      # original host is preserved for Host/SNI/cert (proves pinning didn't break
+      # normal delivery — FIX C).
+      expect(Loopctl.MockDnsResolver, :resolve, 1, fn "hooks.example.com" ->
+        {:ok, [{93, 184, 216, 34}]}
+      end)
+
+      Req.Test.stub(Loopctl.Webhooks.ReqDelivery, fn conn ->
+        Req.Test.json(conn, %{"ok" => true})
+      end)
+
+      assert {:ok, %{status: 200}} =
+               ReqDelivery.deliver("https://hooks.example.com/hooks", "{}", [])
+    end
   end
 end

--- a/test/loopctl/webhooks/webhooks_test.exs
+++ b/test/loopctl/webhooks/webhooks_test.exs
@@ -144,6 +144,23 @@ defmodule Loopctl.WebhooksTest do
       assert "must not target a private or loopback address" in errors_on(changeset).url
     end
 
+    test "reports an unresolvable host distinctly from a private address" do
+      tenant = fixture(:tenant)
+
+      expect(Loopctl.MockDnsResolver, :resolve, fn _host ->
+        {:error, :nxdomain}
+      end)
+
+      {:error, changeset} =
+        Webhooks.create_webhook(tenant.id, %{
+          "url" => "https://does-not-resolve.example.com/hooks",
+          "events" => ["story.status_changed"]
+        })
+
+      assert "host could not be resolved" in errors_on(changeset).url
+      refute "must not target a private or loopback address" in errors_on(changeset).url
+    end
+
     test "enforces max_webhooks limit" do
       tenant = fixture(:tenant, %{settings: %{"max_webhooks" => 2}})
 

--- a/test/loopctl/webhooks/webhooks_test.exs
+++ b/test/loopctl/webhooks/webhooks_test.exs
@@ -89,6 +89,61 @@ defmodule Loopctl.WebhooksTest do
       assert errors_on(changeset).url
     end
 
+    # SSRF egress guard (ie-02 / GHSA-jh42-wf7g-f5rg). IP-literal URLs bypass DNS,
+    # so these assert the changeset blocklist directly, no DNS stub required.
+    for {label, url} <- [
+          {"cloud metadata IPv4", "http://169.254.169.254/latest/meta-data/"},
+          {"loopback IPv4", "http://127.0.0.1/hooks"},
+          {"private 10/8", "https://10.0.0.5/hooks"},
+          {"private 192.168/16", "https://192.168.1.10/hooks"},
+          {"unspecified 0.0.0.0", "http://0.0.0.0/hooks"},
+          {"decimal-encoded loopback", "http://2130706433/hooks"},
+          {"hex-encoded loopback", "http://0x7f000001/hooks"},
+          {"IPv6 loopback", "http://[::1]/hooks"},
+          {"Fly 6PN ULA", "http://[fdaa::1]/hooks"},
+          {"IPv4-mapped loopback", "http://[::ffff:127.0.0.1]/hooks"}
+        ] do
+      test "rejects a webhook targeting #{label}" do
+        tenant = fixture(:tenant)
+
+        {:error, changeset} =
+          Webhooks.create_webhook(tenant.id, %{
+            "url" => unquote(url),
+            "events" => ["story.status_changed"]
+          })
+
+        assert "must not target a private or loopback address" in errors_on(changeset).url
+      end
+    end
+
+    test "rejects a non-http(s) scheme" do
+      tenant = fixture(:tenant)
+
+      {:error, changeset} =
+        Webhooks.create_webhook(tenant.id, %{
+          "url" => "ftp://93.184.216.34/hooks",
+          "events" => ["story.status_changed"]
+        })
+
+      assert "must use HTTPS or HTTP scheme" in errors_on(changeset).url
+    end
+
+    test "rejects a hostname that resolves to a private address (DNS rebinding)" do
+      tenant = fixture(:tenant)
+
+      expect(Loopctl.MockDnsResolver, :resolve, fn _host ->
+        {:ok, [{169, 254, 169, 254}]}
+      end)
+
+      {:error, changeset} =
+        Webhooks.create_webhook(tenant.id, %{
+          "url" => "https://rebind.example.com/hooks",
+          "events" => ["story.status_changed"]
+        })
+
+      assert "must not target a private or loopback address" in errors_on(changeset).url
+    end
+
     test "enforces max_webhooks limit" do
       tenant = fixture(:tenant, %{settings: %{"max_webhooks" => 2}})
 

--- a/test/loopctl/workers/content_ingestion_worker_test.exs
+++ b/test/loopctl/workers/content_ingestion_worker_test.exs
@@ -145,6 +145,52 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
     end
   end
 
+  # --- SSRF egress guard (worker-01 / GHSA-j7m9-ffmr-pwhm) ---
+
+  describe "perform/1 refuses blocked URLs (SSRF)" do
+    test "refuses to fetch the cloud metadata endpoint" do
+      %{tenant: tenant} = setup_tenant()
+
+      # The extractor must never be reached — the guard short-circuits before
+      # any HTTP fetch or extraction.
+      Req.Test.stub(ContentIngestionWorker, fn _conn ->
+        flunk("SSRF guard should have blocked the request before Req.get/1")
+      end)
+
+      assert {:error, {:url_blocked, :blocked_ip}} =
+               ContentIngestionWorker.perform(%Oban.Job{
+                 id: 200,
+                 args: %{
+                   "tenant_id" => tenant.id,
+                   "url" => "http://169.254.169.254/latest/meta-data/",
+                   "content_hash" => "ssrf1",
+                   "source_type" => "web_article"
+                 }
+               })
+
+      assert %{data: []} = Knowledge.list_articles(tenant.id, source_type: "web_article")
+    end
+
+    test "refuses a hostname that resolves to a private address (DNS rebinding)" do
+      %{tenant: tenant} = setup_tenant()
+
+      expect(Loopctl.MockDnsResolver, :resolve, fn _host ->
+        {:ok, [{10, 0, 0, 5}]}
+      end)
+
+      assert {:error, {:url_blocked, :blocked_ip}} =
+               ContentIngestionWorker.perform(%Oban.Job{
+                 id: 201,
+                 args: %{
+                   "tenant_id" => tenant.id,
+                   "url" => "https://rebind.example.com/x",
+                   "content_hash" => "ssrf2",
+                   "source_type" => "web_article"
+                 }
+               })
+    end
+  end
+
   # --- Validation filters invalid articles ---
 
   describe "perform/1 validation" do

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -170,6 +170,40 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       assert json_response(conn, 422)["error"]["message"] =~ "private, loopback, or metadata"
     end
 
+    test "returns 422 for a v4-in-v6 NAT64-embedded metadata URL", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest", %{
+          url: "http://[64:ff9b::a9fe:a9fe]/latest/meta-data/",
+          source_type: "web_article"
+        })
+
+      assert json_response(conn, 422)["error"]["message"] =~ "private, loopback, or metadata"
+    end
+
+    test "returns 422 with a distinct message when the host cannot be resolved", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      expect(Loopctl.MockDnsResolver, :resolve, fn _host -> {:error, :nxdomain} end)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest", %{
+          url: "https://does-not-resolve.example.com/x",
+          source_type: "web_article"
+        })
+
+      message = json_response(conn, 422)["error"]["message"]
+      assert message =~ "could not be resolved"
+      refute message =~ "private, loopback, or metadata"
+    end
+
     test "agent role is rejected (requires orchestrator)", %{conn: conn} do
       tenant = fixture(:tenant)
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -421,6 +421,43 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       assert Enum.all?(body["data"], &(&1["error"] == "validation_timeout"))
     end
 
+    # FIX 1: a genuine (non-timeout) raise in ONE item must not crash the whole
+    # request. async_stream_nolink monitors (not links) the task, so the raise
+    # becomes a per-item validation_failed error while other items still succeed
+    # and the request returns 200. Under the old bare Task.async_stream this
+    # raise would have killed the request.
+    @tag :capture_log
+    test "a raising item yields validation_failed; other items still return 200",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      # One host makes the resolver raise; everything else resolves public.
+      stub(Loopctl.MockDnsResolver, :resolve, fn
+        "boom.example.com" -> raise "resolver boom"
+        _host -> {:ok, [{93, 184, 216, 34}]}
+      end)
+
+      items = [
+        %{url: "https://boom.example.com/x", source_type: "web_article"},
+        %{content: "Valid inline content", source_type: "newsletter"}
+      ]
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{items: items})
+
+      body = json_response(conn, 200)
+      assert length(body["data"]) == 2
+
+      [first, second] = body["data"]
+      # Ordering is preserved (ordered: true): item 1 crashed, item 2 queued.
+      assert first["status"] == "error"
+      assert first["error"] == "validation_failed"
+      assert second["status"] == "queued"
+    end
+
     test "tenant isolation: tenant A cannot see tenant B's batch jobs", %{conn: conn} do
       tenant_a = fixture(:tenant)
       tenant_b = fixture(:tenant)

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -136,6 +136,40 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       assert body["error"]["message"] =~ "source_type"
     end
 
+    # SSRF egress guard (worker-01 / GHSA-j7m9-ffmr-pwhm): a URL pointing at a
+    # private / loopback / cloud-metadata address is rejected 4xx up front, before
+    # any job is enqueued or fetched.
+    test "returns 422 for a URL targeting the cloud metadata endpoint", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest", %{
+          url: "http://169.254.169.254/latest/meta-data/",
+          source_type: "web_article"
+        })
+
+      body = json_response(conn, 422)
+      assert body["error"]["message"] =~ "private, loopback, or metadata"
+    end
+
+    test "returns 422 for a decimal-encoded loopback URL", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest", %{
+          url: "http://2130706433/secret",
+          source_type: "web_article"
+        })
+
+      assert json_response(conn, 422)["error"]["message"] =~ "private, loopback, or metadata"
+    end
+
     test "agent role is rejected (requires orchestrator)", %{conn: conn} do
       tenant = fixture(:tenant)
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -392,6 +392,35 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       assert json_response(conn, 403)
     end
 
+    # FIX 2 (worker-01 / GHSA-j7m9-ffmr-pwhm): a batch of URL items pointing at an
+    # unresponsive nameserver must NOT tie up the request. Task.async_stream caps
+    # each item at the (test-configured, short) per-item deadline and maps a hung
+    # item to a validation_timeout error instead of hanging the whole batch.
+    test "bounds the batch when the resolver hangs (validation_timeout, no hang)",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      # Resolver never returns → each item's pin exceeds the per-item deadline and
+      # is killed. (Reaches the task via the $callers chain async_stream sets.)
+      stub(Loopctl.MockDnsResolver, :resolve, fn _host -> Process.sleep(:infinity) end)
+
+      items = [
+        %{url: "https://slow-a.example.com/x", source_type: "web_article"},
+        %{url: "https://slow-b.example.com/x", source_type: "web_article"}
+      ]
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{items: items})
+
+      body = json_response(conn, 200)
+      assert length(body["data"]) == 2
+      assert Enum.all?(body["data"], &(&1["status"] == "error"))
+      assert Enum.all?(body["data"], &(&1["error"] == "validation_timeout"))
+    end
+
     test "tenant isolation: tenant A cannot see tenant B's batch jobs", %{conn: conn} do
       tenant_a = fixture(:tenant)
       tenant_b = fixture(:tenant)

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -214,6 +214,14 @@ defmodule Loopctl.DataCase do
       []
     end)
 
+    # SSRF egress guard (ie-02 / worker-01): default-resolve any bare hostname to a
+    # public, routable IP so existing example.com-based webhook and content-ingestion
+    # tests pass unchanged. IP-literal cases bypass DNS entirely; the DNS-rebinding
+    # tests override this with Mox.expect/3 to return a private address.
+    Mox.stub(Loopctl.MockDnsResolver, :resolve, fn _host ->
+      {:ok, [{93, 184, 216, 34}]}
+    end)
+
     # US-27.3: the DBErrorBackstop test seam (Loopctl.Test.BackstopRouter) is a
     # REAL plug wired via config/test.exs that delegates to LoopctlWeb.Router for
     # every request and only raises when an opt-in `x-test-raise-db-error` header

--- a/test/support/echo_host_plug.ex
+++ b/test/support/echo_host_plug.ex
@@ -1,0 +1,24 @@
+defmodule Loopctl.Test.EchoHostPlug do
+  @moduledoc """
+  Test-only Plug that echoes the `Host` request header it observed back in the
+  response body. Used by the real Req/Finch round-trip test that verifies IP
+  pinning sends the original hostname (not the pinned IP literal) as `Host`.
+  """
+  @behaviour Plug
+
+  import Plug.Conn
+
+  @impl true
+  def init(opts), do: opts
+
+  @impl true
+  def call(conn, _opts) do
+    host =
+      case get_req_header(conn, "host") do
+        [value | _] -> value
+        [] -> ""
+      end
+
+    send_resp(conn, 200, host)
+  end
+end

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -25,6 +25,12 @@ Mox.defmock(Loopctl.MockArticleSimilaritySearch,
 # worker tests keep working, while the ScaleAlerts tests override deliver/3 directly.
 Mox.defmock(Loopctl.MockDelivery, for: Loopctl.Webhooks.DeliveryBehaviour)
 
+# SSRF egress guard (ie-02 / worker-01) DNS resolution DI. Lets UrlGuard tests
+# feed deterministic A/AAAA records for a bare hostname without touching real DNS.
+# DataCase default-stubs `resolve/1` to a public IP so hostname-based webhook and
+# ingestion tests pass; DNS-rebinding tests override it to return a private address.
+Mox.defmock(Loopctl.MockDnsResolver, for: Loopctl.Net.DnsResolver.Behaviour)
+
 # US-27.3: the DBErrorBackstop test seam is a REAL plug (Loopctl.Test.BackstopRouter,
 # wired via config/test.exs), NOT a Mox mock — so the production router stays on
 # the hot path for every request and the catch/log/sanitize path is exercised by

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -40,4 +40,22 @@ nightly_excluded = if System.get_env("SCALE_NIGHTLY"), do: [], else: [:scale_nig
 #   PGBOUNCER_URL=postgres://postgres:postgres@127.0.0.1:6432/loopctl_test \
 #     mix test --include pgbouncer test/loopctl/pgbouncer_startup_params_test.exs
 pgbouncer_excluded = if System.get_env("PGBOUNCER_URL"), do: [], else: [:pgbouncer]
-ExUnit.configure(exclude: scale_excluded ++ nightly_excluded ++ pgbouncer_excluded)
+
+# :requires_ipv6 — the SSRF IP-pinning Host-header regression test stands up a
+# loopback HTTP server bound to ::1 (the ONLY way to exercise Req.Finch.run/1's
+# IPv6 host-injection path). Probe ::1 bindability once; skip (not error) the
+# tagged test on environments lacking IPv6 loopback, while keeping full coverage
+# where IPv6 exists (local dev, ubuntu-latest CI). IPv4 round-trip stays always-on.
+ipv6_excluded =
+  case :gen_tcp.listen(0, [:inet6, ip: {0, 0, 0, 0, 0, 0, 0, 1}, active: false]) do
+    {:ok, socket} ->
+      :gen_tcp.close(socket)
+      []
+
+    {:error, _reason} ->
+      [:requires_ipv6]
+  end
+
+ExUnit.configure(
+  exclude: scale_excluded ++ nightly_excluded ++ pgbouncer_excluded ++ ipv6_excluded
+)


### PR DESCRIPTION
## Summary

Closes two High-severity SSRF advisories with **one shared egress guard**, `Loopctl.Net.UrlGuard`, used by every server-side HTTP fetch loopctl makes on behalf of a tenant.

- **ie-02 (GHSA-jh42-wf7g-f5rg)** — webhook delivery. The old `private_host?/1` was an IPv4-only string-prefix blocklist: it missed IPv6 (Fly 6PN `fdaa::/16`, `fe80::/10`, `::1`, IPv4-mapped `::ffff:127.0.0.1`), decimal/hex/octal IPv4 (`2130706433`, `0x7f000001`), `0.0.0.0`, and did **no DNS resolution** (a hostname resolving to a private IP passed). Delivery also did not set `redirect: false`, so Req followed a 302 into an internal target after validation.
- **worker-01 (GHSA-j7m9-ffmr-pwhm)** — content ingestion fetched a raw user-supplied URL with **no validation** (the controller only checked presence). A `role:orchestrator` tenant could fetch `169.254.169.254` / internal hosts and store the body as a retrievable article.

## The guard — `Loopctl.Net.UrlGuard`

`validate_egress(url, opts \\ []) :: {:ok, URI.t()} | {:error, reason}`

1. **Scheme allowlist** — `http`/`https` only.
2. **Real DNS resolution** — a bare host is resolved (A **and** AAAA) via `Loopctl.Net.DnsResolver`; a hostname that resolves to a private address is blocked. IP-literal / decimal / hex / IPv6 forms parse directly via `:inet.parse_address/1`.
3. **Private/loopback/link-local/metadata blocklist for BOTH families**:
   - v4: `0.0.0.0/8`, `10/8`, `100.64/10` (CGNAT), `127/8`, `169.254/16` (cloud metadata), `172.16/12`, `192.168/16`
   - v6: `::`, `::1`, `fe80::/10`, `fc00::/7` (ULA incl. Fly `fdaa::`), IPv4-mapped `::ffff:0:0/96` **and** IPv4-compatible `::0.0.0.0/96` (embedded v4 decoded and re-checked)
   - If a host resolves to multiple addresses and **any** is blocked, the whole URL is rejected.

## Call sites

- `webhook.ex` — `validate_url` delegates to `UrlGuard` (keeps the friendly changeset error).
- `req_delivery.ex` — **re-validates at delivery time** (DNS rebinding / TOCTOU) and adds `redirect: false`.
- `content_ingestion_worker.ex` — validates immediately before `Req.get` and adds `redirect: false`.
- `knowledge_ingestion_controller.ex` — validates at enqueue time so a bad URL is rejected 4xx up front.

## DNS resolution / testability

DNS is injected via config-based DI (`Loopctl.Net.DnsResolver.Behaviour` → `Default` in prod, `Loopctl.MockDnsResolver` in test, default-stubbed to a public IP in DataCase). IP-literal test cases need no network; dedicated tests use the Mox mock to prove hostname→private is blocked (rebinding defense).

## Tests

- `UrlGuard` unit tests: blocks `169.254.169.254`, `127.0.0.1`, `10.x`, `192.168.x`, `172.16.x`, `0.0.0.0`, CGNAT, decimal `2130706433`, hex `0x7f000001`, `::1`, `::`, `fdaa::1`, `fe80::1`, `::ffff:127.0.0.1`, `::ffff:169.254.169.254`, `::127.0.0.1`; allows public literals; rejects non-http(s) schemes; DNS-rebinding block/allow/nxdomain.
- Webhook changeset rejects private/metadata/scheme/rebinding URLs.
- `ReqDelivery` re-validates and does **not** follow redirects (302→internal fails).
- Content ingestion: controller rejects metadata/decimal URLs at enqueue; worker refuses to fetch a blocked URL (and never hits Req).

## Quality gates

- `mix compile --warnings-as-errors`: clean
- `mix format`: clean
- `mix credo --strict`: no issues
- `mix dialyzer`: 0 errors
- `mix test`: **3171 tests, 0 failures, 40 excluded**

Refs private advisories GHSA-jh42-wf7g-f5rg, GHSA-j7m9-ffmr-pwhm.