### PR TITLE
chore: pin local toolchain to Elixir 1.19.5 / OTP 28.5.0.2 (match CI)

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+erlang 28.5.0.2
+elixir 1.19.5-otp-28


### PR DESCRIPTION
Adds `.tool-versions` so local asdf matches CI's setup-beam (Elixir 1.19.5 / OTP 28.5.0.2). Previously local ran 1.18/OTP-27, so the pre-commit hook couldn't catch Elixir 1.19-only `--warnings-as-errors` failures (e.g. the stricter struct-update type check) — they only surfaced on CI. Config-only; CI uses its own version env so this file is inert to CI. Verified: full precommit (compile/format/credo/dialyzer/3160 tests) passes locally on 1.19/OTP-28.