### PR TITLE
fix(security): harden verification runner against SHA/URL injection

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -260,6 +260,12 @@ config :loopctl, Loopctl.Vault,
 # DI: Content extractor for knowledge ingestion
 config :loopctl, :content_extractor, Loopctl.Knowledge.ClaudeContentExtractor
 
+# L3 local test runner (Loopctl.Verification.TestRunner). DISABLED by default:
+# it clones a tenant-supplied repo and runs `mix deps.get`/`mix test` on it
+# (untrusted-code execution) and is subject to a clone-time DNS-rebinding SSRF
+# residual. Enable ONLY inside an egress-restricted, ephemeral sandbox.
+config :loopctl, :enable_local_test_runner, false
+
 # DI: Article category classifier for the reclassification backfill
 # (KnowledgeReclassifyWorker). Overridden in test env.
 config :loopctl, :category_classifier, Loopctl.Knowledge.ClaudeCategoryClassifier

--- a/config/test.exs
+++ b/config/test.exs
@@ -52,6 +52,13 @@ config :loopctl, Loopctl.HeavyReadRepo,
 # tests stay sub-second.
 config :loopctl, :heavy_read_statement_timeout_ms, 250
 
+# Keep the L3 local test runner DISABLED in tests (it clones repos + runs
+# `mix test` on untrusted code). TestRunner's tests exercise the disabled path
+# and the validation-rejection paths WITHOUT ever cloning a real repo; input
+# validation runs before this gate, so validation-rejection is asserted
+# independently of the flag.
+config :loopctl, :enable_local_test_runner, false
+
 # DI (US-27.11): route Loopctl.HeavyRead's heavy reads to AdminRepo in tests, so
 # they see the same sandbox transaction that fixtures write to. Prod/dev default to
 # the dedicated Loopctl.HeavyReadRepo pool.

--- a/lib/loopctl/verification.ex
+++ b/lib/loopctl/verification.ex
@@ -8,8 +8,12 @@ defmodule Loopctl.Verification do
 
   import Ecto.Query
 
+  require Logger
+
+  alias Ecto.Multi
   alias Loopctl.AdminRepo
   alias Loopctl.Verification.VerificationRun
+  alias Loopctl.Workers.VerificationRunnerWorker
 
   @doc "Creates a new verification run for a story."
   @spec create_run(Ecto.UUID.t(), Ecto.UUID.t(), map()) ::
@@ -18,6 +22,47 @@ defmodule Loopctl.Verification do
     %VerificationRun{tenant_id: tenant_id, story_id: story_id}
     |> VerificationRun.changeset(attrs)
     |> AdminRepo.insert()
+  end
+
+  @doc """
+  Atomically creates a verification run AND enqueues its runner job.
+
+  The run row and the Oban job are inserted in a single `Ecto.Multi`
+  transaction: either both commit or neither does. This guarantees a run row is
+  never left in `"pending"` with no job to execute it (and no job is ever
+  enqueued for a run that failed to insert).
+
+  Returns `{:ok, run}` or `{:error, reason}`. A raised DB exception during the
+  transaction (e.g. a transient `Postgrex`/`DBConnection` error) is caught and
+  returned as `{:error, exception}` — the transaction has already rolled back,
+  so there is no orphaned run — letting the caller surface the failure instead
+  of leaking an uncaught 500.
+  """
+  @spec create_run_and_enqueue(Ecto.UUID.t(), Ecto.UUID.t(), map()) ::
+          {:ok, VerificationRun.t()} | {:error, term()}
+  def create_run_and_enqueue(tenant_id, story_id, attrs \\ %{}) do
+    run_changeset =
+      %VerificationRun{tenant_id: tenant_id, story_id: story_id}
+      |> VerificationRun.changeset(attrs)
+
+    Multi.new()
+    |> Multi.insert(:run, run_changeset)
+    |> Oban.insert(:job, fn %{run: run} ->
+      VerificationRunnerWorker.new(%{"run_id" => run.id, "tenant_id" => tenant_id})
+    end)
+    |> AdminRepo.transaction()
+    |> case do
+      {:ok, %{run: run}} -> {:ok, run}
+      {:error, _step, reason, _changes} -> {:error, reason}
+    end
+  rescue
+    exception ->
+      Logger.error(
+        "Verification.create_run_and_enqueue crashed for story #{story_id} " <>
+          "(tenant #{tenant_id}): #{Exception.message(exception)}"
+      )
+
+      {:error, exception}
   end
 
   @doc "Gets a verification run by ID, tenant-scoped."

--- a/lib/loopctl/verification/test_runner.ex
+++ b/lib/loopctl/verification/test_runner.ex
@@ -12,16 +12,28 @@ defmodule Loopctl.Verification.TestRunner do
   ## Untrusted-code execution (advisory ie-03, GHSA-38cj-97f6-r82q)
 
   This runner clones a tenant-supplied repo and runs `mix deps.get` + `mix test`
-  against it — i.e. it executes **third-party code**. It is NOT a sandbox. The
-  current containment rests on two things:
+  against it — i.e. it executes **third-party code**. It is NOT a sandbox.
 
-    1. The production release image ships no `git` and no `mix`, so the
-       `System.cmd/3` calls raise `:enoent` and the runner is effectively inert
-       in prod today.
-    2. The input validation in this module and in
+  Because of that, it is **disabled by default** and only runs when an operator
+  explicitly opts in with:
+
+      config :loopctl, :enable_local_test_runner, true
+
+  When the flag is off (the default in every environment, including prod),
+  `run_tests/2` returns `{:error, :runner_disabled}` before any clone or
+  subprocess runs. Turn it on ONLY inside an egress-restricted, ephemeral
+  sandbox — enabling it on a host with outbound network + `git`/`mix` exposes
+  the untrusted-code-exec and clone-time SSRF surface described below.
+
+  The remaining containment, in order of strength:
+
+    1. **Off by default** (the flag above) — the primary mitigation.
+    2. **Input validation** in this module and in
        `Loopctl.Verification.VerificationRun` — a `commit_sha` is constrained to
        a hex git object id and a `repo_url` to a well-formed `http(s)` URL — so
        neither can inject a subprocess argument or escape the temp directory.
+    3. In production the release image also ships no `git`/`mix`, so even if the
+       flag were flipped there the `System.cmd/3` calls would raise `:enoent`.
 
   True isolation (running each verification in an ephemeral, network-restricted
   container with a CPU/memory/time budget) is the intended future hardening and
@@ -31,15 +43,34 @@ defmodule Loopctl.Verification.TestRunner do
 
     * `commit_sha` is re-validated here (defence in depth — the schema already
       validates it) before it is used in `git checkout` or a path. A hex-only
-      value cannot be a `-`-leading git flag nor contain `/` or `..`.
+      value (`[0-9a-f]{7,64}`) cannot be a `-`-leading git flag nor contain `/`
+      or `..`.
     * `repo_url` is validated to an `http(s)` URL with a real host, closing the
       `ext::sh -c '…'` / `file://` / local-path / `-`-leading remote-helper RCE
-      vectors, and is additionally screened by the shared SSRF egress guard.
-    * The clone/checkout commands pass `--` before positional args so a value
-      can never be reinterpreted as a flag.
+      vectors.
+    * `git clone` passes `--` before its positional args (`clone --depth 1 --
+      <repo_url> <work_dir>`) so a `-`-leading URL can't be read as a flag.
+      `git checkout <commit_sha>` does **not** use `--` (that would make git
+      treat the value as a *pathspec* rather than a revision); it is safe purely
+      because `commit_sha` is validated to `[0-9a-f]{7,64}` and so can never be a
+      flag.
     * The working directory uses a random, non-user-derived name, and cleanup
       (`File.rm_rf/1`) only ever fires against a path provably inside the system
       temp directory.
+
+  ### Clone-time SSRF is only partially mitigated
+
+  `repo_url` is also screened by the shared SSRF egress guard
+  (`Loopctl.Net.UrlGuard`) just before the clone, but that guard resolves DNS
+  once. `git clone` is a separate subprocess that **re-resolves the hostname at
+  connect time** and cannot be pinned to the validated IP the way a `Req`
+  request can (there is no SNI/`Host`/connect-IP override via the git CLI). A
+  hostile authoritative server answering with TTL=0 can therefore return a
+  public address to the guard and a private one to `git` (DNS rebinding), so the
+  guard does **not** fully close clone-time SSRF. The syntactic rejections
+  (`ext::`/`file://`/leading-dash/non-http scheme) ARE fully effective; the
+  DNS-rebinding residual is the reason this runner must only be enabled inside an
+  egress-restricted sandbox (see the disable flag above).
   """
 
   require Logger
@@ -66,9 +97,14 @@ defmodule Loopctl.Verification.TestRunner do
   @spec run_tests(String.t(), String.t()) :: {:ok, map()} | {:error, term()}
   def run_tests(repo_url, commit_sha) do
     # Validate BEFORE building a path or spawning any subprocess. A bad SHA or
-    # URL must never reach `git`, `mix`, or `File.rm_rf/1`.
+    # URL must never reach `git`, `mix`, or `File.rm_rf/1`. The runner-enabled
+    # gate is checked AFTER validation (validation is pure and side-effect-free)
+    # but still BEFORE any clone/exec, so a disabled runner never touches the
+    # network or filesystem.
     with :ok <- validate_commit_sha(commit_sha),
-         :ok <- validate_repo_url(repo_url) do
+         :ok <- validate_repo_url_syntax(repo_url),
+         :ok <- check_runner_enabled(),
+         :ok <- validate_repo_url_egress(repo_url) do
       work_dir = build_work_dir()
 
       try do
@@ -127,6 +163,19 @@ defmodule Loopctl.Verification.TestRunner do
   def within_tmp?(_path), do: false
 
   @doc """
+  Returns whether the local test runner is enabled.
+
+  Disabled by default — the runner executes untrusted third-party code and is
+  subject to a clone-time DNS-rebinding SSRF residual, so it must be explicitly
+  opted in (and run inside an egress-restricted sandbox) via
+  `config :loopctl, :enable_local_test_runner, true`.
+  """
+  @spec enabled?() :: boolean()
+  def enabled? do
+    Application.get_env(:loopctl, :enable_local_test_runner, false) == true
+  end
+
+  @doc """
   Checks whether specific named tests ran and passed.
   Used for AC bindings of type "test".
   """
@@ -139,6 +188,10 @@ defmodule Loopctl.Verification.TestRunner do
 
   # --- Private ---
 
+  defp check_runner_enabled do
+    if enabled?(), do: :ok, else: {:error, :runner_disabled}
+  end
+
   defp validate_commit_sha(commit_sha) do
     if VerificationRun.valid_commit_sha?(commit_sha) do
       :ok
@@ -147,15 +200,23 @@ defmodule Loopctl.Verification.TestRunner do
     end
   end
 
-  defp validate_repo_url(repo_url) do
-    # Syntactic guard first (fast, and closes the RCE/arg-injection vectors),
-    # then the shared SSRF egress guard so the clone can't be aimed at internal
-    # infrastructure (cloud metadata, Fly 6PN, loopback, …).
-    with true <- safe_repo_url?(repo_url),
-         {:ok, _uri} <- UrlGuard.validate_egress(repo_url) do
-      :ok
-    else
-      _ -> {:error, :invalid_repo_url}
+  # Pure syntactic guard: closes the RCE/arg-injection vectors (ext::/file://,
+  # non-http scheme, missing host, leading dash). No network I/O — runs before
+  # the enable gate so a syntactically bad URL is rejected even when the runner
+  # is disabled.
+  defp validate_repo_url_syntax(repo_url) do
+    if safe_repo_url?(repo_url), do: :ok, else: {:error, :invalid_repo_url}
+  end
+
+  # SSRF egress guard (resolves DNS). Runs ONLY after the enable gate and only
+  # just before the clone, so a disabled runner performs no network I/O. NOTE:
+  # this does not fully close clone-time SSRF — `git clone` re-resolves DNS at
+  # connect time and can't be IP-pinned (see the moduledoc's DNS-rebinding
+  # note); it is defence in depth, not a complete barrier.
+  defp validate_repo_url_egress(repo_url) do
+    case UrlGuard.validate_egress(repo_url) do
+      {:ok, _uri} -> :ok
+      {:error, _reason} -> {:error, :invalid_repo_url}
     end
   end
 

--- a/lib/loopctl/verification/test_runner.ex
+++ b/lib/loopctl/verification/test_runner.ex
@@ -8,9 +8,46 @@ defmodule Loopctl.Verification.TestRunner do
   This is the core lazy-bastard defense — the verifier does not trust
   the implementer's self-report. The tests run in a clean subprocess
   that the implementer cannot reach.
+
+  ## Untrusted-code execution (advisory ie-03, GHSA-38cj-97f6-r82q)
+
+  This runner clones a tenant-supplied repo and runs `mix deps.get` + `mix test`
+  against it — i.e. it executes **third-party code**. It is NOT a sandbox. The
+  current containment rests on two things:
+
+    1. The production release image ships no `git` and no `mix`, so the
+       `System.cmd/3` calls raise `:enoent` and the runner is effectively inert
+       in prod today.
+    2. The input validation in this module and in
+       `Loopctl.Verification.VerificationRun` — a `commit_sha` is constrained to
+       a hex git object id and a `repo_url` to a well-formed `http(s)` URL — so
+       neither can inject a subprocess argument or escape the temp directory.
+
+  True isolation (running each verification in an ephemeral, network-restricted
+  container with a CPU/memory/time budget) is the intended future hardening and
+  is deliberately out of scope for this change.
+
+  ## Input hardening (advisory ie-04, GHSA-pv74-gwwh-g92x)
+
+    * `commit_sha` is re-validated here (defence in depth — the schema already
+      validates it) before it is used in `git checkout` or a path. A hex-only
+      value cannot be a `-`-leading git flag nor contain `/` or `..`.
+    * `repo_url` is validated to an `http(s)` URL with a real host, closing the
+      `ext::sh -c '…'` / `file://` / local-path / `-`-leading remote-helper RCE
+      vectors, and is additionally screened by the shared SSRF egress guard.
+    * The clone/checkout commands pass `--` before positional args so a value
+      can never be reinterpreted as a flag.
+    * The working directory uses a random, non-user-derived name, and cleanup
+      (`File.rm_rf/1`) only ever fires against a path provably inside the system
+      temp directory.
   """
 
   require Logger
+
+  alias Loopctl.Net.UrlGuard
+  alias Loopctl.Verification.VerificationRun
+
+  @allowed_repo_schemes ~w(https http)
 
   @doc """
   Executes tests for a commit SHA in the given repo.
@@ -28,19 +65,66 @@ defmodule Loopctl.Verification.TestRunner do
   """
   @spec run_tests(String.t(), String.t()) :: {:ok, map()} | {:error, term()}
   def run_tests(repo_url, commit_sha) do
-    work_dir = Path.join(System.tmp_dir!(), "loopctl_verify_#{commit_sha}")
+    # Validate BEFORE building a path or spawning any subprocess. A bad SHA or
+    # URL must never reach `git`, `mix`, or `File.rm_rf/1`.
+    with :ok <- validate_commit_sha(commit_sha),
+         :ok <- validate_repo_url(repo_url) do
+      work_dir = build_work_dir()
 
-    try do
-      with :ok <- clone_repo(repo_url, commit_sha, work_dir),
-           {:ok, output} <- execute_mix_test(work_dir) do
-        results = parse_test_output(output)
-        {:ok, results}
+      try do
+        with :ok <- clone_repo(repo_url, commit_sha, work_dir),
+             {:ok, output} <- execute_mix_test(work_dir) do
+          results = parse_test_output(output)
+          {:ok, results}
+        end
+      after
+        # Always clean up the clone — but only ever inside the temp dir.
+        safe_rm_rf(work_dir)
       end
-    after
-      # Always clean up the clone
-      File.rm_rf(work_dir)
     end
   end
+
+  @doc """
+  Returns `true` when `repo_url` is a well-formed `http`/`https` URL with a real
+  host. Everything else — `ext::`, `file://`, `ssh://`, a bare local path, or a
+  `-`-leading value — is rejected so it can never reach `git clone`.
+  """
+  @spec safe_repo_url?(term()) :: boolean()
+  def safe_repo_url?(url) when is_binary(url) do
+    uri = URI.parse(url)
+
+    is_binary(uri.scheme) and String.downcase(uri.scheme) in @allowed_repo_schemes and
+      is_binary(uri.host) and uri.host != "" and
+      not String.starts_with?(url, "-")
+  end
+
+  def safe_repo_url?(_url), do: false
+
+  @doc """
+  Builds the clone working directory: `loopctl_verify_<random>` under the system
+  temp dir. The name is NOT derived from any user input, so it can never contain
+  `/` or `..` and therefore can never escape the temp directory.
+  """
+  @spec build_work_dir() :: String.t()
+  def build_work_dir do
+    unique = 16 |> :crypto.strong_rand_bytes() |> Base.url_encode64(padding: false)
+    Path.join(System.tmp_dir!(), "loopctl_verify_" <> unique)
+  end
+
+  @doc """
+  Returns `true` only when `path` resolves to a location strictly inside the
+  system temp directory. Used to fence `File.rm_rf/1` so a malformed or escaped
+  path can never delete an arbitrary directory.
+  """
+  @spec within_tmp?(term()) :: boolean()
+  def within_tmp?(path) when is_binary(path) do
+    tmp = Path.expand(System.tmp_dir!())
+    expanded = Path.expand(path)
+
+    expanded != tmp and String.starts_with?(expanded, tmp <> "/")
+  end
+
+  def within_tmp?(_path), do: false
 
   @doc """
   Checks whether specific named tests ran and passed.
@@ -55,8 +139,40 @@ defmodule Loopctl.Verification.TestRunner do
 
   # --- Private ---
 
+  defp validate_commit_sha(commit_sha) do
+    if VerificationRun.valid_commit_sha?(commit_sha) do
+      :ok
+    else
+      {:error, :invalid_commit_sha}
+    end
+  end
+
+  defp validate_repo_url(repo_url) do
+    # Syntactic guard first (fast, and closes the RCE/arg-injection vectors),
+    # then the shared SSRF egress guard so the clone can't be aimed at internal
+    # infrastructure (cloud metadata, Fly 6PN, loopback, …).
+    with true <- safe_repo_url?(repo_url),
+         {:ok, _uri} <- UrlGuard.validate_egress(repo_url) do
+      :ok
+    else
+      _ -> {:error, :invalid_repo_url}
+    end
+  end
+
+  defp safe_rm_rf(work_dir) do
+    if within_tmp?(work_dir) do
+      File.rm_rf(work_dir)
+    else
+      Logger.error("TestRunner: refusing to rm_rf path outside tmp: #{inspect(work_dir)}")
+      {:ok, []}
+    end
+  end
+
   defp clone_repo(repo_url, commit_sha, work_dir) do
-    case System.cmd("git", ["clone", "--depth", "1", repo_url, work_dir], stderr_to_stdout: true) do
+    # `--` before positional args: a `-`-leading repo_url can't become a flag.
+    case System.cmd("git", ["clone", "--depth", "1", "--", repo_url, work_dir],
+           stderr_to_stdout: true
+         ) do
       {_, 0} ->
         case System.cmd("git", ["checkout", commit_sha],
                cd: work_dir,

--- a/lib/loopctl/verification/verification_run.ex
+++ b/lib/loopctl/verification/verification_run.ex
@@ -12,6 +12,14 @@ defmodule Loopctl.Verification.VerificationRun do
 
   @statuses ~w(pending running pass fail error)
 
+  # A git object id: lowercase hex only, 7–64 chars (covers an abbreviated SHA,
+  # a full SHA-1 (40), and a full SHA-256 (64)). A hex-only value cannot contain
+  # `/`, `..`, or a leading `-`, which closes both the path-traversal and the
+  # `git checkout` argument-injection vectors when the SHA flows into
+  # `Loopctl.Verification.TestRunner`. Advisory ie-04 (GHSA-pv74-gwwh-g92x).
+  @commit_sha_format ~r/\A[0-9a-f]{7,64}\z/
+  @commit_sha_error "must be a lowercase hexadecimal git object id (7-64 chars)"
+
   @doc "Valid runner types for verification."
   def runner_types, do: ~w(ci_github ci_gitlab fly_machine manual)
 
@@ -46,5 +54,43 @@ defmodule Loopctl.Verification.VerificationRun do
       :machine_id
     ])
     |> validate_inclusion(:status, @statuses)
+    |> validate_commit_sha(attrs)
+  end
+
+  @doc """
+  Returns `true` when `sha` is a well-formed git object id (lowercase hex,
+  7-64 chars). Used both here and defensively in
+  `Loopctl.Verification.TestRunner` before the SHA is ever passed to a
+  subprocess or interpolated into a filesystem path.
+  """
+  @spec valid_commit_sha?(term()) :: boolean()
+  def valid_commit_sha?(sha) when is_binary(sha), do: Regex.match?(@commit_sha_format, sha)
+  def valid_commit_sha?(_sha), do: false
+
+  # A commit SHA is optional (a run may be created before a commit exists), so
+  # `nil`/absent is allowed. But any value that IS supplied must be a valid git
+  # object id — a blank string or a traversal/flag-shaped value is rejected so
+  # it never reaches the runner. `cast/3` drops `""` from the changes, so we
+  # inspect the raw attrs to distinguish "absent" from "explicitly blank".
+  defp validate_commit_sha(changeset, attrs) do
+    case commit_sha_input(attrs) do
+      {:present, sha} when not is_nil(sha) ->
+        if valid_commit_sha?(sha) do
+          changeset
+        else
+          add_error(changeset, :commit_sha, @commit_sha_error)
+        end
+
+      _absent_or_nil ->
+        changeset
+    end
+  end
+
+  defp commit_sha_input(attrs) do
+    cond do
+      Map.has_key?(attrs, :commit_sha) -> {:present, Map.get(attrs, :commit_sha)}
+      Map.has_key?(attrs, "commit_sha") -> {:present, Map.get(attrs, "commit_sha")}
+      true -> :absent
+    end
   end
 end

--- a/lib/loopctl_web/controllers/story_verification_controller.ex
+++ b/lib/loopctl_web/controllers/story_verification_controller.ex
@@ -13,10 +13,13 @@ defmodule LoopctlWeb.StoryVerificationController do
   use LoopctlWeb, :controller
   use OpenApiSpex.ControllerSpecs
 
+  require Logger
+
   alias Loopctl.ApiSpec.Schemas
   alias Loopctl.Artifacts
   alias Loopctl.Progress
   alias Loopctl.Verification
+  alias Loopctl.Verification.VerificationRun
   alias Loopctl.WorkBreakdown.Stories
   alias Loopctl.Workers.VerificationRunnerWorker
   alias LoopctlWeb.AuditContext
@@ -162,25 +165,34 @@ defmodule LoopctlWeb.StoryVerificationController do
   def verify(conn, %{"id" => story_id} = params) do
     api_key = conn.assigns.current_api_key
 
-    with :ok <- validate_orchestrator_agent_linked(api_key) do
+    # Validate a client-supplied commit_sha BEFORE Progress.verify_story mutates
+    # the story: a malformed sha must not flip the story to verified and then
+    # silently fail to enqueue the L3 run (which would return a misleading 202
+    # with run_id: null and leave no audit trail of the skipped re-execution).
+    with :ok <- validate_orchestrator_agent_linked(api_key),
+         :ok <- validate_commit_sha_param(params) do
       tenant_id = api_key.tenant_id
       opts = Keyword.merge(AuditContext.from_conn(conn), orchestrator_agent_id: api_key.agent_id)
 
       case Progress.verify_story(tenant_id, story_id, params, opts) do
         {:ok, story} ->
-          run_id = enqueue_verification_run(tenant_id, story_id, params)
+          {run_id, run_error} = enqueue_verification_run(tenant_id, story_id, params)
+
+          body =
+            %{
+              status: "verification_pending",
+              run_id: run_id,
+              story: story,
+              next_action: %{
+                description: "Poll GET /api/v1/stories/#{story_id}/verifications for results",
+                learn_more: "https://loopctl.com/wiki/verification-runs"
+              }
+            }
+            |> maybe_put_run_error(run_error)
 
           conn
           |> put_status(:accepted)
-          |> json(%{
-            status: "verification_pending",
-            run_id: run_id,
-            story: story,
-            next_action: %{
-              description: "Poll GET /api/v1/stories/#{story_id}/verifications for results",
-              learn_more: "https://loopctl.com/wiki/verification-runs"
-            }
-          })
+          |> json(body)
 
         {:error, :self_verify_blocked} ->
           {:error, :self_verify_blocked}
@@ -405,7 +417,31 @@ defmodule LoopctlWeb.StoryVerificationController do
 
   defp validate_orchestrator_agent_linked(_api_key), do: :ok
 
-  # US-26.4.4.1: enqueue a verification_run and return the run_id
+  # Reject a client-supplied `commit_sha` that isn't a valid git object id
+  # BEFORE any mutation. `commit_sha` is optional, so nil/absent passes through;
+  # a present-but-malformed value is surfaced as a 422 (never leaking the raw
+  # value back to the client verbatim).
+  defp validate_commit_sha_param(params) do
+    case Map.get(params, "commit_sha") do
+      nil ->
+        :ok
+
+      sha ->
+        if VerificationRun.valid_commit_sha?(sha) do
+          :ok
+        else
+          {:error, :unprocessable_entity,
+           "commit_sha must be a lowercase hexadecimal git object id (7-64 chars)"}
+        end
+    end
+  end
+
+  # US-26.4.4.1: enqueue a verification_run. Returns `{run_id, run_error}` where
+  # `run_error` is nil on success or a short, safe reason string on failure. A
+  # changeset failure here (commit_sha is pre-validated above, so this is
+  # normally a constraint/DB error) is logged AND surfaced in the response so
+  # the missing L3 re-execution is visible and auditable — never silently
+  # swallowed into a misleading 202 with run_id: null.
   defp enqueue_verification_run(tenant_id, story_id, params) do
     attrs = %{
       commit_sha: Map.get(params, "commit_sha"),
@@ -418,10 +454,30 @@ defmodule LoopctlWeb.StoryVerificationController do
         |> VerificationRunnerWorker.new()
         |> Oban.insert()
 
-        run.id
+        {run.id, nil}
 
-      _ ->
-        nil
+      {:error, %Ecto.Changeset{} = changeset} ->
+        fields = Keyword.keys(changeset.errors)
+
+        Logger.warning(
+          "VerificationRunner: failed to create verification_run for story " <>
+            "#{story_id} (tenant #{tenant_id}); invalid fields: #{inspect(fields)}. " <>
+            "L3 re-execution was NOT enqueued."
+        )
+
+        {nil, "verification_run_not_created: invalid #{inspect(fields)}"}
+
+      {:error, reason} ->
+        Logger.warning(
+          "VerificationRunner: failed to create verification_run for story " <>
+            "#{story_id} (tenant #{tenant_id}): #{inspect(reason)}. " <>
+            "L3 re-execution was NOT enqueued."
+        )
+
+        {nil, "verification_run_not_created"}
     end
   end
+
+  defp maybe_put_run_error(body, nil), do: body
+  defp maybe_put_run_error(body, error), do: Map.put(body, :verification_run_error, error)
 end

--- a/lib/loopctl_web/controllers/story_verification_controller.ex
+++ b/lib/loopctl_web/controllers/story_verification_controller.ex
@@ -21,7 +21,6 @@ defmodule LoopctlWeb.StoryVerificationController do
   alias Loopctl.Verification
   alias Loopctl.Verification.VerificationRun
   alias Loopctl.WorkBreakdown.Stories
-  alias Loopctl.Workers.VerificationRunnerWorker
   alias LoopctlWeb.AuditContext
 
   action_fallback LoopctlWeb.FallbackController
@@ -436,31 +435,29 @@ defmodule LoopctlWeb.StoryVerificationController do
     end
   end
 
-  # US-26.4.4.1: enqueue a verification_run. Returns `{run_id, run_error}` where
-  # `run_error` is nil on success or a short, safe reason string on failure. A
-  # changeset failure here (commit_sha is pre-validated above, so this is
-  # normally a constraint/DB error) is logged AND surfaced in the response so
-  # the missing L3 re-execution is visible and auditable — never silently
-  # swallowed into a misleading 202 with run_id: null.
+  # US-26.4.4.1: atomically create a verification_run AND enqueue its runner job
+  # (both commit or neither — see Verification.create_run_and_enqueue/3).
+  # Returns `{run_id, run_error}` where `run_error` is nil on success or a short,
+  # safe reason string on failure. commit_sha is pre-validated above, so a
+  # failure here is normally a constraint / transient DB error; it is logged AND
+  # surfaced in the response so the missing L3 re-execution is visible and
+  # auditable — never silently swallowed into a misleading 202 with run_id: null,
+  # and never left as an orphaned "pending" run with no job.
   defp enqueue_verification_run(tenant_id, story_id, params) do
     attrs = %{
       commit_sha: Map.get(params, "commit_sha"),
       runner_type: "ci_github"
     }
 
-    case Verification.create_run(tenant_id, story_id, attrs) do
+    case Verification.create_run_and_enqueue(tenant_id, story_id, attrs) do
       {:ok, run} ->
-        %{"run_id" => run.id, "tenant_id" => tenant_id}
-        |> VerificationRunnerWorker.new()
-        |> Oban.insert()
-
         {run.id, nil}
 
       {:error, %Ecto.Changeset{} = changeset} ->
         fields = Keyword.keys(changeset.errors)
 
         Logger.warning(
-          "VerificationRunner: failed to create verification_run for story " <>
+          "VerificationRunner: failed to create/enqueue verification_run for story " <>
             "#{story_id} (tenant #{tenant_id}); invalid fields: #{inspect(fields)}. " <>
             "L3 re-execution was NOT enqueued."
         )
@@ -469,7 +466,7 @@ defmodule LoopctlWeb.StoryVerificationController do
 
       {:error, reason} ->
         Logger.warning(
-          "VerificationRunner: failed to create verification_run for story " <>
+          "VerificationRunner: failed to create/enqueue verification_run for story " <>
             "#{story_id} (tenant #{tenant_id}): #{inspect(reason)}. " <>
             "L3 re-execution was NOT enqueued."
         )

--- a/test/loopctl/verification/test_runner_test.exs
+++ b/test/loopctl/verification/test_runner_test.exs
@@ -1,0 +1,97 @@
+defmodule Loopctl.Verification.TestRunnerTest do
+  @moduledoc """
+  Input hardening for the L3 verification runner — advisories ie-04
+  (GHSA-pv74-gwwh-g92x) and ie-03 (GHSA-38cj-97f6-r82q).
+
+  These tests exercise the validation helpers directly and assert that
+  `run_tests/2` refuses hostile input BEFORE it can spawn `git`/`mix` or run
+  `File.rm_rf/1`.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Loopctl.Verification.TestRunner
+
+  describe "safe_repo_url?/1" do
+    test "accepts http(s) URLs with a real host" do
+      assert TestRunner.safe_repo_url?("https://github.com/acme/app.git")
+      assert TestRunner.safe_repo_url?("http://example.com/repo.git")
+      assert TestRunner.safe_repo_url?("HTTPS://github.com/acme/app.git")
+    end
+
+    test "rejects remote-helper / file / ssh / local-path / flag-shaped forms" do
+      refute TestRunner.safe_repo_url?("ext::sh -c 'touch /tmp/pwned'")
+      refute TestRunner.safe_repo_url?("file:///etc/passwd")
+      refute TestRunner.safe_repo_url?("ssh://git@github.com/acme/app.git")
+      refute TestRunner.safe_repo_url?("git@github.com:acme/app.git")
+      refute TestRunner.safe_repo_url?("/etc/passwd")
+      refute TestRunner.safe_repo_url?("-oProxyCommand=evil")
+      refute TestRunner.safe_repo_url?("https://")
+      refute TestRunner.safe_repo_url?(nil)
+      refute TestRunner.safe_repo_url?(123)
+    end
+  end
+
+  describe "build_work_dir/0 and within_tmp?/1 (path fencing)" do
+    test "build_work_dir is unique and always inside the system temp dir" do
+      dir1 = TestRunner.build_work_dir()
+      dir2 = TestRunner.build_work_dir()
+
+      assert dir1 != dir2
+      assert TestRunner.within_tmp?(dir1)
+      assert TestRunner.within_tmp?(dir2)
+      assert String.starts_with?(Path.basename(dir1), "loopctl_verify_")
+    end
+
+    test "within_tmp? rejects traversal and outside-tmp paths" do
+      tmp = System.tmp_dir!()
+
+      refute TestRunner.within_tmp?(Path.join(tmp, "../../etc"))
+      refute TestRunner.within_tmp?("/etc")
+      refute TestRunner.within_tmp?("/")
+      # the temp dir itself must never be a deletion target
+      refute TestRunner.within_tmp?(tmp)
+      refute TestRunner.within_tmp?(nil)
+    end
+
+    test "a hostile SHA-shaped value can never produce a work_dir outside tmp" do
+      # work_dir is no longer derived from the SHA at all, so even an oversized /
+      # traversal-shaped value can't influence the path — every build stays in tmp.
+      Enum.each(1..50, fn _ ->
+        assert TestRunner.within_tmp?(TestRunner.build_work_dir())
+      end)
+    end
+  end
+
+  describe "run_tests/2 refuses invalid input before spawning a subprocess" do
+    @valid_sha String.duplicate("a", 40)
+    @valid_url "https://github.com/acme/app.git"
+
+    test "returns :invalid_commit_sha for a traversal SHA" do
+      assert {:error, :invalid_commit_sha} =
+               TestRunner.run_tests(@valid_url, "../../etc")
+    end
+
+    test "returns :invalid_commit_sha for a flag-shaped SHA" do
+      assert {:error, :invalid_commit_sha} = TestRunner.run_tests(@valid_url, "-o=x")
+    end
+
+    test "returns :invalid_commit_sha for a blank SHA" do
+      assert {:error, :invalid_commit_sha} = TestRunner.run_tests(@valid_url, "")
+    end
+
+    test "returns :invalid_repo_url for an ext:: remote-helper URL" do
+      assert {:error, :invalid_repo_url} =
+               TestRunner.run_tests("ext::sh -c 'id'", @valid_sha)
+    end
+
+    test "returns :invalid_repo_url for a file:// URL" do
+      assert {:error, :invalid_repo_url} =
+               TestRunner.run_tests("file:///etc/passwd", @valid_sha)
+    end
+
+    test "returns :invalid_repo_url for a bare local path" do
+      assert {:error, :invalid_repo_url} = TestRunner.run_tests("/tmp/evil", @valid_sha)
+    end
+  end
+end

--- a/test/loopctl/verification/test_runner_test.exs
+++ b/test/loopctl/verification/test_runner_test.exs
@@ -54,12 +54,22 @@ defmodule Loopctl.Verification.TestRunnerTest do
       refute TestRunner.within_tmp?(nil)
     end
 
-    test "a hostile SHA-shaped value can never produce a work_dir outside tmp" do
-      # work_dir is no longer derived from the SHA at all, so even an oversized /
-      # traversal-shaped value can't influence the path — every build stays in tmp.
+    test "build_work_dir/0 takes no input, so no SHA can ever reach the path" do
+      # This documents the design, it does NOT feed a SHA into build_work_dir/0
+      # (which is zero-arity): the path is derived from random bytes alone, so a
+      # hostile commit_sha value has no channel to influence it. Every build
+      # lands strictly inside the system temp dir.
       Enum.each(1..50, fn _ ->
         assert TestRunner.within_tmp?(TestRunner.build_work_dir())
       end)
+    end
+  end
+
+  describe "enabled?/0 (runner gate, default off — advisory ie-03)" do
+    test "is disabled in the test environment" do
+      # config/test.exs keeps :enable_local_test_runner false; the runner
+      # executes untrusted code and must be opt-in per environment.
+      refute TestRunner.enabled?()
     end
   end
 
@@ -67,7 +77,7 @@ defmodule Loopctl.Verification.TestRunnerTest do
     @valid_sha String.duplicate("a", 40)
     @valid_url "https://github.com/acme/app.git"
 
-    test "returns :invalid_commit_sha for a traversal SHA" do
+    test "returns :invalid_commit_sha for a traversal SHA (before the enable gate)" do
       assert {:error, :invalid_commit_sha} =
                TestRunner.run_tests(@valid_url, "../../etc")
     end
@@ -92,6 +102,12 @@ defmodule Loopctl.Verification.TestRunnerTest do
 
     test "returns :invalid_repo_url for a bare local path" do
       assert {:error, :invalid_repo_url} = TestRunner.run_tests("/tmp/evil", @valid_sha)
+    end
+
+    test "returns :runner_disabled for valid input when the runner is off (no clone)" do
+      # Valid SHA + URL pass validation, then hit the default-off gate: the
+      # runner never clones or executes anything.
+      assert {:error, :runner_disabled} = TestRunner.run_tests(@valid_url, @valid_sha)
     end
   end
 end

--- a/test/loopctl/verification/verification_run_test.exs
+++ b/test/loopctl/verification/verification_run_test.exs
@@ -1,0 +1,95 @@
+defmodule Loopctl.Verification.VerificationRunTest do
+  @moduledoc """
+  commit_sha validation — advisory ie-04 (GHSA-pv74-gwwh-g92x).
+
+  A hex-only git object id cannot contain `/`, `..`, or a leading `-`, which
+  closes the path-traversal and `git checkout` argument-injection vectors before
+  the value ever reaches `Loopctl.Verification.TestRunner`.
+  """
+
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.Verification.VerificationRun
+
+  setup :verify_on_exit!
+
+  describe "changeset/2 commit_sha validation" do
+    test "accepts a full SHA-1 (40 hex)" do
+      sha = String.duplicate("a", 40)
+      changeset = VerificationRun.changeset(%{commit_sha: sha})
+
+      assert changeset.valid?
+      assert get_change(changeset, :commit_sha) == sha
+    end
+
+    test "accepts a full SHA-256 (64 hex)" do
+      sha = String.duplicate("0", 60) <> "beef"
+      assert VerificationRun.changeset(%{commit_sha: sha}).valid?
+    end
+
+    test "accepts an abbreviated 7-hex SHA" do
+      assert VerificationRun.changeset(%{commit_sha: "deadbee"}).valid?
+    end
+
+    test "rejects a path-traversal value" do
+      changeset = VerificationRun.changeset(%{commit_sha: "../../etc"})
+
+      refute changeset.valid?
+      assert %{commit_sha: [_ | _]} = errors_on(changeset)
+    end
+
+    test "rejects a flag-shaped value" do
+      refute VerificationRun.changeset(%{commit_sha: "-o=x"}).valid?
+    end
+
+    test "rejects a non-hex value" do
+      refute VerificationRun.changeset(%{commit_sha: "deadbeefZZ"}).valid?
+    end
+
+    test "rejects an uppercase-hex value" do
+      refute VerificationRun.changeset(%{commit_sha: String.duplicate("A", 40)}).valid?
+    end
+
+    test "rejects a too-short (6 hex) value" do
+      refute VerificationRun.changeset(%{commit_sha: "abc123"}).valid?
+    end
+
+    test "rejects an oversized (65 hex) value" do
+      refute VerificationRun.changeset(%{commit_sha: String.duplicate("a", 65)}).valid?
+    end
+
+    test "rejects an explicitly blank commit_sha" do
+      changeset = VerificationRun.changeset(%{commit_sha: ""})
+
+      refute changeset.valid?
+      assert %{commit_sha: [_ | _]} = errors_on(changeset)
+    end
+
+    test "allows an absent commit_sha (run created before a commit exists)" do
+      assert VerificationRun.changeset(%{status: "pending"}).valid?
+    end
+
+    test "allows an explicit nil commit_sha" do
+      assert VerificationRun.changeset(%{commit_sha: nil, status: "pending"}).valid?
+    end
+  end
+
+  describe "valid_commit_sha?/1" do
+    test "true only for lowercase hex, 7-64 chars" do
+      assert VerificationRun.valid_commit_sha?(String.duplicate("a", 40))
+      assert VerificationRun.valid_commit_sha?(String.duplicate("f", 64))
+      assert VerificationRun.valid_commit_sha?("deadbee")
+    end
+
+    test "false for traversal, flag, blank, non-binary and out-of-range values" do
+      refute VerificationRun.valid_commit_sha?("../../etc")
+      refute VerificationRun.valid_commit_sha?("-o=x")
+      refute VerificationRun.valid_commit_sha?("deadbeefZZ")
+      refute VerificationRun.valid_commit_sha?("")
+      refute VerificationRun.valid_commit_sha?("abc123")
+      refute VerificationRun.valid_commit_sha?(String.duplicate("a", 65))
+      refute VerificationRun.valid_commit_sha?(nil)
+      refute VerificationRun.valid_commit_sha?(:not_a_string)
+    end
+  end
+end

--- a/test/loopctl/verification_test.exs
+++ b/test/loopctl/verification_test.exs
@@ -23,12 +23,14 @@ defmodule Loopctl.VerificationTest do
     test "creates a pending verification run" do
       %{tenant: tenant, story: story} = setup_ctx()
 
+      sha = String.duplicate("a", 40)
+
       assert {:ok, run} =
-               Verification.create_run(tenant.id, story.id, %{commit_sha: "abc123"})
+               Verification.create_run(tenant.id, story.id, %{commit_sha: sha})
 
       assert run.status == "pending"
       assert run.story_id == story.id
-      assert run.commit_sha == "abc123"
+      assert run.commit_sha == sha
     end
   end
 

--- a/test/loopctl/verification_test.exs
+++ b/test/loopctl/verification_test.exs
@@ -7,7 +7,9 @@ defmodule Loopctl.VerificationTest do
 
   import Loopctl.Fixtures
 
+  alias Loopctl.AdminRepo
   alias Loopctl.Verification
+  alias Loopctl.Verification.VerificationRun
 
   setup :verify_on_exit!
 
@@ -31,6 +33,37 @@ defmodule Loopctl.VerificationTest do
       assert run.status == "pending"
       assert run.story_id == story.id
       assert run.commit_sha == sha
+    end
+  end
+
+  describe "create_run_and_enqueue/3 (atomic run row + Oban job)" do
+    test "creates the run and returns {:ok, run}" do
+      %{tenant: tenant, story: story} = setup_ctx()
+      sha = String.duplicate("a", 40)
+
+      assert {:ok, run} =
+               Verification.create_run_and_enqueue(tenant.id, story.id, %{commit_sha: sha})
+
+      assert run.commit_sha == sha
+      # The run row is persisted (committed with its enqueued job).
+      assert AdminRepo.get(VerificationRun, run.id)
+    end
+
+    test "rolls back atomically on failure — no orphaned 'pending' run row" do
+      %{tenant: tenant, story: story} = setup_ctx()
+
+      # An invalid commit_sha makes the :run insert step fail. Because the run
+      # insert and the Oban job insert share ONE transaction, a failure in
+      # either step rolls back the whole thing — so there is never an orphaned
+      # "pending" run left behind with no job to execute it (nor a job with no
+      # run). This is the atomicity guarantee that replaces the old
+      # create_run + discarded Oban.insert two-step.
+      assert {:error, %Ecto.Changeset{}} =
+               Verification.create_run_and_enqueue(tenant.id, story.id, %{
+                 commit_sha: "../../etc"
+               })
+
+      assert AdminRepo.all(from(r in VerificationRun, where: r.story_id == ^story.id)) == []
     end
   end
 

--- a/test/loopctl_web/controllers/story_verification_controller_test.exs
+++ b/test/loopctl_web/controllers/story_verification_controller_test.exs
@@ -6,6 +6,7 @@ defmodule LoopctlWeb.StoryVerificationControllerTest do
   alias Ecto.Adapters.SQL.Sandbox
   alias Loopctl.Artifacts.VerificationResult
   alias Loopctl.Progress
+  alias Loopctl.Verification.VerificationRun
 
   setup :verify_on_exit!
 
@@ -98,6 +99,55 @@ defmodule LoopctlWeb.StoryVerificationControllerTest do
       assert result.summary == "All artifacts present, tests pass"
       assert result.review_type == "enhanced_review"
       assert result.orchestrator_agent_id == orch_agent.id
+    end
+
+    test "enqueues a verification_run and returns run_id for a valid commit_sha", %{conn: conn} do
+      %{story: story, orch_key: orch_key} = setup_reported_story()
+      sha = String.duplicate("a", 40)
+
+      conn =
+        conn
+        |> auth_conn(orch_key)
+        |> post(~p"/api/v1/stories/#{story.id}/verify", %{
+          "summary" => "All good",
+          "review_type" => "enhanced",
+          "commit_sha" => sha
+        })
+
+      body = json_response(conn, 202)
+      assert body["run_id"] != nil
+      refute Map.has_key?(body, "verification_run_error")
+
+      run = Loopctl.AdminRepo.get(VerificationRun, body["run_id"])
+      assert run.commit_sha == sha
+    end
+
+    test "rejects a malformed commit_sha with 422 and does NOT verify the story", %{conn: conn} do
+      %{story: story, orch_key: orch_key} = setup_reported_story()
+
+      conn =
+        conn
+        |> auth_conn(orch_key)
+        |> post(~p"/api/v1/stories/#{story.id}/verify", %{
+          "summary" => "All good",
+          "review_type" => "enhanced",
+          "commit_sha" => "../../etc/passwd"
+        })
+
+      body = json_response(conn, 422)
+      assert body["error"]["message"] =~ "commit_sha"
+      # The raw malicious value is not echoed back verbatim.
+      refute body["error"]["message"] =~ "passwd"
+
+      # The chain-of-custody state was NOT mutated: no misleading "verified" +
+      # no orphaned/missing verification_run.
+      reloaded = Loopctl.AdminRepo.get(Loopctl.WorkBreakdown.Story, story.id)
+      assert reloaded.verified_status == :unverified
+
+      runs =
+        Loopctl.AdminRepo.all(from(r in VerificationRun, where: r.story_id == ^story.id))
+
+      assert runs == []
     end
 
     test "verifies with result=partial", %{conn: conn} do


### PR DESCRIPTION
## Summary

The L3 verification test runner (`Loopctl.Verification.TestRunner`) passed a tenant-supplied `commit_sha` and `repo_url` straight into filesystem paths and `git`/`mix` subprocess arguments with no validation. This closes two private advisories.

### ie-04 — GHSA-pv74-gwwh-g92x (HIGH)
`commit_sha` flowed into `Path.join(tmp, "loopctl_verify_#{commit_sha}")` — a value like `x/../../app` escaped tmp, and the `try/after`'s `File.rm_rf/1` then deleted an arbitrary directory as the app user. It also flowed into `git checkout <sha>` — a `-`-leading value became a git flag (argument injection).

### ie-03 — GHSA-38cj-97f6-r82q (LOW)
The runner clones a repo and runs `mix deps.get` + `mix test` on it — untrusted-code execution with no sandbox. Latent in prod (the release image ships no git/mix), but the inputs are hardened regardless.

## Changes

- **commit_sha validation** — strict git object id `\A[0-9a-f]{7,64}\z` (covers SHA-1/40 and SHA-256/64). Enforced in `VerificationRun.changeset` **and** re-checked defensively in `TestRunner.run_tests` before any use. A hex-only value cannot contain `/`, `..`, or a leading `-`, closing both the traversal and the `git checkout` arg-injection vectors. A blank string is rejected; `nil`/absent stays allowed (a run may be created before a commit exists).
- **Path fencing** — `work_dir` is now built from a random, non-user-derived name (`loopctl_verify_<random>`) so it can never escape tmp, and `File.rm_rf/1` is fenced behind `within_tmp?/1` so cleanup only ever targets a path provably inside the system temp dir.
- **repo_url validation** — must be a well-formed `http(s)` URL with a real host; `ext::`, `file://`, ssh, local-path and `-`-leading remote-helper forms are rejected, and the URL is additionally screened through the shared SSRF egress guard (`UrlGuard`). The clone command passes `--` before its positional args so a `-`-leading URL can't become a flag.
- **moduledoc** — documents that the runner executes third-party code and relies on (a) the prod image lacking git/mix and (b) these input validations, with ephemeral-container isolation as the intended future hardening.

## Tests

New `test/loopctl/verification/verification_run_test.exs` and `test/loopctl/verification/test_runner_test.exs`:
- changeset accepts 40-hex/64-hex/7-hex; rejects `../../etc`, `-o=x`, `deadbeefZZ`, `""`, uppercase, 6-hex, 65-hex; allows absent/nil.
- `safe_repo_url?/1`, `within_tmp?/1`, `build_work_dir/0` unit-tested directly.
- `run_tests/2` returns `:invalid_commit_sha` / `:invalid_repo_url` for hostile input **before** any `git`/`mix`/`rm_rf` runs.

Full suite green (3185 tests, 0 failures) via the pre-commit hook (compile `--warnings-as-errors`, format, credo `--strict`, dialyzer 0, full test).

Refs private advisories GHSA-pv74-gwwh-g92x, GHSA-38cj-97f6-r82q.