### PR TITLE
fix(security): gate destructive knowledge-wiki ops behind :user + verify real conflicts

### DIFF
--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -3327,63 +3327,93 @@ defmodule Loopctl.Knowledge do
   (default `:medium`). Returns `{:ok, %ConflictResolution{}}` or `{:error, changeset}`.
   """
   @spec annotate_conflict(Ecto.UUID.t(), map(), keyword()) ::
-          {:ok, ConflictResolution.t()} | {:error, Ecto.Changeset.t()}
+          {:ok, ConflictResolution.t()}
+          | {:error, Ecto.Changeset.t() | :no_potential_conflict}
   def annotate_conflict(tenant_id, attrs, opts \\ []) do
     get = fn key -> attrs[key] || attrs[to_string(key)] end
     {src, tgt} = canonical_pair(get.(:source_article_id), get.(:target_article_id))
-    disposition = get.(:disposition)
-    now = DateTime.utc_now()
 
-    row_attrs = %{
-      source_article_id: src,
-      target_article_id: tgt,
-      authoritative_article_id: get.(:authoritative_article_id),
-      classification: get.(:classification),
-      disposition: disposition,
-      confidence: get.(:confidence) || :medium,
-      evidence: get.(:evidence),
-      annotated_by: Keyword.get(opts, :actor_label) || Keyword.get(opts, :actor_id),
-      annotated_at: now,
-      # A dismiss is complete on record; supersede/merge defer to the executor.
-      executed_at: if(to_string(disposition) == "dismiss", do: now, else: nil),
-      execution_result: %{}
-    }
+    # kb-02 (GHSA-9gqg-9r6p-658v): a verdict may only be recorded against a REAL,
+    # system-flagged conflict. Without this guard an agent could fabricate a verdict
+    # on ANY two in-tenant articles and have the nightly executor retire/merge one of
+    # them. Require a `:potential_conflict` ArticleLink for the pair (the linker/lint
+    # sweep flags these; stored in either direction) BEFORE accepting any disposition.
+    with :ok <- validate_potential_conflict_exists(tenant_id, src, tgt) do
+      disposition = get.(:disposition)
+      now = DateTime.utc_now()
 
-    changeset =
-      %ConflictResolution{tenant_id: tenant_id}
-      |> ConflictResolution.changeset(row_attrs)
+      row_attrs = %{
+        source_article_id: src,
+        target_article_id: tgt,
+        authoritative_article_id: get.(:authoritative_article_id),
+        classification: get.(:classification),
+        disposition: disposition,
+        confidence: get.(:confidence) || :medium,
+        evidence: get.(:evidence),
+        annotated_by: Keyword.get(opts, :actor_label) || Keyword.get(opts, :actor_id),
+        annotated_at: now,
+        # A dismiss is complete on record; supersede/merge defer to the executor.
+        executed_at: if(to_string(disposition) == "dismiss", do: now, else: nil),
+        execution_result: %{}
+      }
 
-    result =
-      AdminRepo.insert(changeset,
-        on_conflict:
-          {:replace,
-           [
-             :authoritative_article_id,
-             :classification,
-             :disposition,
-             :confidence,
-             :evidence,
-             :annotated_by,
-             :annotated_at,
-             :executed_at,
-             :execution_result,
-             :updated_at
-           ]},
-        conflict_target: [:tenant_id, :source_article_id, :target_article_id]
-      )
+      changeset =
+        %ConflictResolution{tenant_id: tenant_id}
+        |> ConflictResolution.changeset(row_attrs)
 
-    with {:ok, %ConflictResolution{disposition: :dismiss} = res} <- result do
-      log_resolution(
-        tenant_id,
-        res,
-        "dismiss",
-        "dismissed as #{res.classification || "not-a-conflict"}",
-        [res.source_article_id, res.target_article_id]
-      )
+      result =
+        AdminRepo.insert(changeset,
+          on_conflict:
+            {:replace,
+             [
+               :authoritative_article_id,
+               :classification,
+               :disposition,
+               :confidence,
+               :evidence,
+               :annotated_by,
+               :annotated_at,
+               :executed_at,
+               :execution_result,
+               :updated_at
+             ]},
+          conflict_target: [:tenant_id, :source_article_id, :target_article_id]
+        )
+
+      with {:ok, %ConflictResolution{disposition: :dismiss} = res} <- result do
+        log_resolution(
+          tenant_id,
+          res,
+          "dismiss",
+          "dismissed as #{res.classification || "not-a-conflict"}",
+          [res.source_article_id, res.target_article_id]
+        )
+      end
+
+      result
     end
-
-    result
   end
+
+  # kb-02: true only when the linker/lint sweep actually flagged this pair as a
+  # potential conflict (link stored in either direction). When an id is missing we
+  # return :ok and defer to the changeset's required-field validation (surfaces as a
+  # 422) rather than masking a malformed request as "no conflict".
+  defp validate_potential_conflict_exists(tenant_id, src, tgt)
+       when is_binary(src) and is_binary(tgt) do
+    exists? =
+      from(l in ArticleLink,
+        where: l.tenant_id == ^tenant_id,
+        where: l.relationship_type == :potential_conflict,
+        where:
+          (l.source_article_id == ^src and l.target_article_id == ^tgt) or
+            (l.source_article_id == ^tgt and l.target_article_id == ^src)
+      )
+      |> AdminRepo.exists?()
+
+    if exists?, do: :ok, else: {:error, :no_potential_conflict}
+  end
+
+  defp validate_potential_conflict_exists(_tenant_id, _src, _tgt), do: :ok
 
   @doc """
   Nightly executor for conflict resolutions (route-the-findings #4). Applies only

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -3143,6 +3143,14 @@ defmodule Loopctl.Knowledge do
   @spec create_link(Ecto.UUID.t(), map(), keyword()) ::
           {:ok, ArticleLink.t()} | {:error, Ecto.Changeset.t() | :target_not_found}
   def create_link(tenant_id, attrs, opts \\ []) do
+    # kb-02 DEFENSE IN DEPTH: provenance/score flags are SYSTEM-authored only. Strip them
+    # from any caller-supplied metadata before building the changeset so no create_link
+    # path (the public API controller AND direct callers like OKF import) can plant the
+    # `auto_generated`/`similarity_score` markers that promote_conflicts/1 and
+    # validate_potential_conflict_exists/3 trust. System conflict-writers
+    # (ArticleLinkingWorker, promote_conflicts) insert via AdminRepo directly, NOT through
+    # create_link, so this stripping never touches legitimate system provenance.
+    attrs = strip_system_metadata(attrs)
     source_id = attrs[:source_article_id] || attrs["source_article_id"]
     target_id = attrs[:target_article_id] || attrs["target_article_id"]
     rel_type = attrs[:relationship_type] || attrs["relationship_type"]
@@ -3261,6 +3269,9 @@ defmodule Loopctl.Knowledge do
         as: :link,
         where: l.tenant_id == ^tenant_id,
         where: l.relationship_type == :potential_conflict,
+        # kb-02: only surface SYSTEM-flagged conflicts as resolvable evidence, so a stray
+        # or legacy non-system potential_conflict row is never presented to a :user.
+        where: fragment("(?->>'auto_generated') = 'true'", l.metadata),
         where:
           not exists(
             from(r in ConflictResolution,
@@ -5077,6 +5088,31 @@ defmodule Loopctl.Knowledge do
   end
 
   defp maybe_supersede_target(multi, _tenant_id, _target_id, _rel_type), do: multi
+
+  # kb-02: metadata keys reserved for system provenance. Callers of create_link/3 must
+  # never set these (both string- and atom-key forms are dropped). Referencing the atoms
+  # literally keeps them as existing atoms — no String.to_atom on input.
+  @reserved_metadata_keys [
+    "auto_generated",
+    "similarity_score",
+    :auto_generated,
+    :similarity_score
+  ]
+
+  defp strip_system_metadata(attrs) when is_map(attrs) do
+    cond do
+      is_map(attrs[:metadata]) ->
+        Map.put(attrs, :metadata, Map.drop(attrs[:metadata], @reserved_metadata_keys))
+
+      is_map(attrs["metadata"]) ->
+        Map.put(attrs, "metadata", Map.drop(attrs["metadata"], @reserved_metadata_keys))
+
+      true ->
+        attrs
+    end
+  end
+
+  defp strip_system_metadata(attrs), do: attrs
 
   defp build_link_audit(tenant_id, changes, opts) do
     actor_id = Keyword.get(opts, :actor_id)

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -3353,7 +3353,9 @@ defmodule Loopctl.Knowledge do
         annotated_by: Keyword.get(opts, :actor_label) || Keyword.get(opts, :actor_id),
         annotated_at: now,
         # A dismiss is complete on record; supersede/merge defer to the executor.
-        executed_at: if(to_string(disposition) == "dismiss", do: now, else: nil),
+        # Compare without to_string/1 so a non-scalar disposition (e.g. a JSON object)
+        # can't raise here — it falls through to the changeset's inclusion validation.
+        executed_at: if(disposition in ["dismiss", :dismiss], do: now, else: nil),
         execution_result: %{}
       }
 
@@ -3398,12 +3400,21 @@ defmodule Loopctl.Knowledge do
   # potential conflict (link stored in either direction). When an id is missing we
   # return :ok and defer to the changeset's required-field validation (surfaces as a
   # 422) rather than masking a malformed request as "no conflict".
+  #
+  # PROVENANCE (kb-02 FIX A, defense in depth): require the flag to be SYSTEM-generated
+  # (`metadata.auto_generated == true`), the marker both writer sites set —
+  # `KnowledgeLintWorker.promote_conflicts/1` and `ArticleLinkingWorker`. Presence of a
+  # `:potential_conflict` link alone is NOT sufficient evidence: even though the public
+  # link controller now refuses to create that type, requiring the provenance marker
+  # means no future/alternate path that plants such a link can be leveraged to fabricate
+  # a destructive verdict.
   defp validate_potential_conflict_exists(tenant_id, src, tgt)
        when is_binary(src) and is_binary(tgt) do
     exists? =
       from(l in ArticleLink,
         where: l.tenant_id == ^tenant_id,
         where: l.relationship_type == :potential_conflict,
+        where: fragment("(?->>'auto_generated') = 'true'", l.metadata),
         where:
           (l.source_article_id == ^src and l.target_article_id == ^tgt) or
             (l.source_article_id == ^tgt and l.target_article_id == ^src)
@@ -3447,10 +3458,29 @@ defmodule Loopctl.Knowledge do
     end)
   end
 
-  defp apply_resolution(tenant_id, %ConflictResolution{disposition: :supersede} = r),
+  # kb-02 FIX B (TOCTOU): the flag is checked at annotate time, but a :user may DELETE
+  # the potential_conflict link (retracting a mistaken flag) after the verdict is
+  # recorded and before the nightly run. Re-validate the SYSTEM flag still exists right
+  # before acting; if it was retracted, noop (audited) instead of retiring/merging.
+  defp apply_resolution(tenant_id, %ConflictResolution{} = r) do
+    case validate_potential_conflict_exists(tenant_id, r.source_article_id, r.target_article_id) do
+      :ok ->
+        apply_disposition(tenant_id, r)
+
+      {:error, :no_potential_conflict} ->
+        mark_resolution_executed(r, %{
+          "action" => "noop",
+          "reason" => "potential_conflict flag retracted"
+        })
+
+        false
+    end
+  end
+
+  defp apply_disposition(tenant_id, %ConflictResolution{disposition: :supersede} = r),
     do: apply_supersede(tenant_id, r)
 
-  defp apply_resolution(tenant_id, %ConflictResolution{disposition: :merge} = r),
+  defp apply_disposition(tenant_id, %ConflictResolution{disposition: :merge} = r),
     do: apply_merge(tenant_id, r)
 
   # The conflict pair is unordered; store it canonically (source <= target by UUID

--- a/lib/loopctl/workers/knowledge_lint_worker.ex
+++ b/lib/loopctl/workers/knowledge_lint_worker.ex
@@ -176,6 +176,15 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
         as: :rel,
         where: l.tenant_id == ^tenant_id,
         where: l.relationship_type == :relates_to,
+        # PROVENANCE (kb-02): only promote relates_to links that a SYSTEM writer
+        # authored (ArticleLinkingWorker stamps auto_generated:true + a real cosine
+        # similarity_score). Without this, an agent could POST a relates_to link with a
+        # forged similarity_score and launder it into a system-stamped potential_conflict
+        # here — which would then satisfy validate_potential_conflict_exists and let a
+        # fabricated pair be resolved into a supersede. The public link controller now
+        # strips these keys from caller input, so a genuine agent link never carries a
+        # score; this filter is the second, independent barrier at the promotion site.
+        where: fragment("(?->>'auto_generated') = 'true'", l.metadata),
         where: fragment("(?->>'similarity_score')::float >= ?", l.metadata, ^threshold),
         where:
           not exists(

--- a/lib/loopctl_web/controllers/article_link_controller.ex
+++ b/lib/loopctl_web/controllers/article_link_controller.ex
@@ -11,6 +11,7 @@ defmodule LoopctlWeb.ArticleLinkController do
   use OpenApiSpex.ControllerSpecs
 
   alias Loopctl.ApiSpec.Schemas
+  alias Loopctl.Auth.Role
   alias Loopctl.Knowledge
   alias LoopctlWeb.ArticleLinkJSON
   alias LoopctlWeb.AuditContext
@@ -33,7 +34,9 @@ defmodule LoopctlWeb.ArticleLinkController do
     description:
       "Creates a directed link between two articles in the same tenant. " <>
         "When relationship_type is 'supersedes', the target article's status " <>
-        "is set to 'superseded'. Role: agent+.",
+        "is set to 'superseded' (retired), so that destructive relationship_type " <>
+        "requires role: user+. Non-destructive types (relates_to, derived_from, " <>
+        "contradicts) are agent+.",
     request_body:
       {"ArticleLink params", "application/json",
        %OpenApiSpex.Schema{
@@ -89,7 +92,29 @@ defmodule LoopctlWeb.ArticleLinkController do
 
   @doc "POST /api/v1/article_links"
   def create(conn, params) do
-    tenant_id = conn.assigns.current_api_key.tenant_id
+    api_key = conn.assigns.current_api_key
+    rel_type = params["relationship_type"] || params[:relationship_type]
+
+    # kb-01 (GHSA-9g2g-cm9x-9r2p): a "supersedes" link retires the TARGET article
+    # (published -> superseded), hiding it from every default published read
+    # (search/graph/context all default status: :published). That is a DESTRUCTIVE
+    # op, so — consistent with archive/unpublish — it requires role: :user. The other
+    # relationship types (relates_to, derived_from, contradicts) are non-destructive
+    # and stay at :agent. This is an in-action check (not a static RequireRole plug)
+    # because destructiveness depends on the body param relationship_type.
+    if destructive_relationship?(rel_type) and
+         not Role.role_at_least?(api_key.role, :user) do
+      forbidden(
+        conn,
+        "Creating a 'supersedes' link retires the target article, which removes it " <>
+          "from published reads. This destructive operation requires the user role or higher."
+      )
+    else
+      do_create(conn, api_key.tenant_id, params)
+    end
+  end
+
+  defp do_create(conn, tenant_id, params) do
     opts = AuditContext.from_conn(conn) ++ Visibility.scope_opts(conn)
 
     case Knowledge.create_link(tenant_id, params, opts) do
@@ -104,6 +129,16 @@ defmodule LoopctlWeb.ArticleLinkController do
       {:error, :target_not_found} ->
         {:error, :not_found}
     end
+  end
+
+  # A "supersedes" link is the one relationship_type that retires (hides) its target.
+  defp destructive_relationship?(rel_type), do: to_string(rel_type) == "supersedes"
+
+  # 403 body matches the RequireRole plug / FallbackController shape.
+  defp forbidden(conn, message) do
+    conn
+    |> put_status(:forbidden)
+    |> json(%{error: %{status: 403, message: message}})
   end
 
   @doc "DELETE /api/v1/article_links/:id"

--- a/lib/loopctl_web/controllers/article_link_controller.ex
+++ b/lib/loopctl_web/controllers/article_link_controller.ex
@@ -56,7 +56,12 @@ defmodule LoopctlWeb.ArticleLinkController do
       201 =>
         {"Link created", "application/json",
          %OpenApiSpex.Schema{type: :object, additionalProperties: true}},
-      422 => {"Validation error", "application/json", Schemas.ErrorResponse},
+      403 =>
+        {"Forbidden (a 'supersedes' link requires role: user+)", "application/json",
+         Schemas.ErrorResponse},
+      422 =>
+        {"Validation error (incl. a non-public/unknown relationship_type)", "application/json",
+         Schemas.ErrorResponse},
       429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
     }
   )
@@ -90,27 +95,43 @@ defmodule LoopctlWeb.ArticleLinkController do
 
   # --- Actions ---
 
+  # Only these relationship types are publicly creatable via this controller.
+  # `:potential_conflict` is SYSTEM-generated ONLY (planted directly by
+  # KnowledgeLintWorker.promote_conflicts/1 and ArticleLinkingWorker via AdminRepo,
+  # bypassing this controller) — letting an agent create one here would forge the
+  # "system flagged this pair" evidence that the conflict-resolution guard trusts
+  # (kb-02). Anything outside this set (incl. potential_conflict and junk) is a 422.
+  @public_relationship_types ~w(relates_to derived_from contradicts supersedes)
+
   @doc "POST /api/v1/article_links"
   def create(conn, params) do
     api_key = conn.assigns.current_api_key
     rel_type = params["relationship_type"] || params[:relationship_type]
 
-    # kb-01 (GHSA-9g2g-cm9x-9r2p): a "supersedes" link retires the TARGET article
-    # (published -> superseded), hiding it from every default published read
-    # (search/graph/context all default status: :published). That is a DESTRUCTIVE
-    # op, so — consistent with archive/unpublish — it requires role: :user. The other
-    # relationship types (relates_to, derived_from, contradicts) are non-destructive
-    # and stay at :agent. This is an in-action check (not a static RequireRole plug)
-    # because destructiveness depends on the body param relationship_type.
-    if destructive_relationship?(rel_type) and
-         not Role.role_at_least?(api_key.role, :user) do
-      forbidden(
-        conn,
-        "Creating a 'supersedes' link retires the target article, which removes it " <>
-          "from published reads. This destructive operation requires the user role or higher."
-      )
-    else
-      do_create(conn, api_key.tenant_id, params)
+    cond do
+      # kb-02 FIX A: refuse system-only / unknown relationship types at the boundary.
+      # There is no OpenApiSpex CastAndValidate plug wired here, so the operation enum
+      # is documentation-only — this check is the actual enforcement.
+      not public_relationship?(rel_type) ->
+        {:error, :unprocessable_entity,
+         "relationship_type must be one of: relates_to, derived_from, contradicts, supersedes."}
+
+      # kb-01 (GHSA-9g2g-cm9x-9r2p): a "supersedes" link retires the TARGET article
+      # (published -> superseded), hiding it from every default published read
+      # (search/graph/context all default status: :published). That is a DESTRUCTIVE
+      # op, so — consistent with archive/unpublish — it requires role: :user. The other
+      # relationship types (relates_to, derived_from, contradicts) are non-destructive
+      # and stay at :agent. In-action check (not a static RequireRole plug) because
+      # destructiveness depends on the body param relationship_type.
+      destructive_relationship?(rel_type) and not Role.role_at_least?(api_key.role, :user) ->
+        forbidden(
+          conn,
+          "Creating a 'supersedes' link retires the target article, which removes it " <>
+            "from published reads. This destructive operation requires the user role or higher."
+        )
+
+      true ->
+        do_create(conn, api_key.tenant_id, params)
     end
   end
 
@@ -131,8 +152,18 @@ defmodule LoopctlWeb.ArticleLinkController do
     end
   end
 
+  # Guarded against non-scalar JSON values (e.g. a map/list body) so to_string/1 can't
+  # raise a 500 (kb-02 FIX C) — a non-binary/atom value simply isn't a public type.
+  defp public_relationship?(rel_type) when is_binary(rel_type) or is_atom(rel_type),
+    do: to_string(rel_type) in @public_relationship_types
+
+  defp public_relationship?(_), do: false
+
   # A "supersedes" link is the one relationship_type that retires (hides) its target.
-  defp destructive_relationship?(rel_type), do: to_string(rel_type) == "supersedes"
+  defp destructive_relationship?(rel_type) when is_binary(rel_type) or is_atom(rel_type),
+    do: to_string(rel_type) == "supersedes"
+
+  defp destructive_relationship?(_), do: false
 
   # 403 body matches the RequireRole plug / FallbackController shape.
   defp forbidden(conn, message) do

--- a/lib/loopctl_web/controllers/article_workflow_controller.ex
+++ b/lib/loopctl_web/controllers/article_workflow_controller.ex
@@ -293,7 +293,12 @@ defmodule LoopctlWeb.ArticleWorkflowController do
       201 =>
         {"Recorded", "application/json",
          %OpenApiSpex.Schema{type: :object, additionalProperties: true}},
-      422 => {"Validation error", "application/json", Schemas.ErrorResponse},
+      403 =>
+        {"Forbidden (destructive supersede/merge dispositions require role: user+)",
+         "application/json", Schemas.ErrorResponse},
+      422 =>
+        {"Validation error, or no system-flagged potential_conflict for the pair",
+         "application/json", Schemas.ErrorResponse},
       429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
     }
   )
@@ -769,7 +774,13 @@ defmodule LoopctlWeb.ArticleWorkflowController do
 
   # supersede/merge lead the nightly executor to retire (and, for merge, synthesize
   # over) an article — the destructive dispositions. dismiss is non-destructive.
-  defp destructive_disposition?(disposition), do: to_string(disposition) in ["supersede", "merge"]
+  # Guarded against non-scalar JSON values so to_string/1 can't raise a 500
+  # (kb-02 FIX C); a non-binary/atom disposition falls through to the changeset's
+  # inclusion validation (422).
+  defp destructive_disposition?(disposition) when is_binary(disposition) or is_atom(disposition),
+    do: to_string(disposition) in ["supersede", "merge"]
+
+  defp destructive_disposition?(_), do: false
 
   # 403 body matches the RequireRole plug / FallbackController shape.
   defp forbidden(conn, message) do

--- a/lib/loopctl_web/controllers/article_workflow_controller.ex
+++ b/lib/loopctl_web/controllers/article_workflow_controller.ex
@@ -14,6 +14,7 @@ defmodule LoopctlWeb.ArticleWorkflowController do
   use OpenApiSpex.ControllerSpecs
 
   alias Loopctl.ApiSpec.Schemas
+  alias Loopctl.Auth.Role
   alias Loopctl.Knowledge
   alias Loopctl.Knowledge.BulkOps
   alias LoopctlWeb.ArticleJSON
@@ -263,7 +264,10 @@ defmodule LoopctlWeb.ArticleWorkflowController do
         "takes effect immediately; `supersede` (with authoritative_article_id) is applied by " <>
         "the nightly executor at confidence \"high\" — it creates a supersedes link and " <>
         "retires the loser (reversible, audited); `merge` is recorded for the later LLM step. " <>
-        "The KB never re-judges — it acts on your verdict. Last-write-wins per pair. Role: agent+.",
+        "The KB never re-judges — it acts on your verdict. Last-write-wins per pair. Only " <>
+        "pairs the system flagged (GET /knowledge/conflicts) may be resolved; an unknown pair " <>
+        "returns 422. `dismiss` is agent+; the destructive `supersede`/`merge` dispositions " <>
+        "require user+.",
     request_body:
       {"Resolution", "application/json",
        %OpenApiSpex.Schema{
@@ -698,7 +702,33 @@ defmodule LoopctlWeb.ArticleWorkflowController do
 
   @doc "POST /api/v1/knowledge/conflicts/resolve"
   def resolve_conflict(conn, params) do
-    tenant_id = conn.assigns.current_api_key.tenant_id
+    api_key = conn.assigns.current_api_key
+    disposition = params["disposition"]
+
+    # kb-02 (GHSA-9gqg-9r6p-658v): `supersede` (retire the loser) and `merge` (retire +
+    # LLM-synthesize) are the DESTRUCTIVE dispositions — the nightly executor applies
+    # them by transitioning an article out of published. Consistent with archive/
+    # unpublish, recording such a verdict requires role: :user. `dismiss` (a false
+    # positive) is non-destructive and stays at :agent, preserving the intended
+    # agent-annotates flow. This is an in-action check (not a static RequireRole plug)
+    # because destructiveness depends on the body param disposition. Enforcing at the
+    # boundary means no agent-originated destructive verdict is ever PERSISTED, so the
+    # executor can never act on one (the ConflictResolution row carries no originating
+    # role, making the controller the only place with the caller's role in hand).
+    if destructive_disposition?(disposition) and
+         not Role.role_at_least?(api_key.role, :user) do
+      forbidden(
+        conn,
+        "Resolving a conflict as '#{disposition}' retires or merges an article, which " <>
+          "removes it from published reads. This destructive disposition requires the " <>
+          "user role or higher. Agents may 'dismiss' a false positive."
+      )
+    else
+      do_resolve_conflict(conn, api_key.tenant_id, params)
+    end
+  end
+
+  defp do_resolve_conflict(conn, tenant_id, params) do
     audit_opts = AuditContext.from_conn(conn)
 
     attrs = %{
@@ -725,9 +755,27 @@ defmodule LoopctlWeb.ArticleWorkflowController do
           note: resolution_note(resolution)
         })
 
+      # kb-02: no system-flagged :potential_conflict link exists for this pair — the
+      # caller may not fabricate a verdict on an arbitrary pair.
+      {:error, :no_potential_conflict} ->
+        {:error, :unprocessable_entity,
+         "No potential-conflict link exists for this article pair. Only pairs the system " <>
+           "flagged as potential conflicts (see GET /api/v1/knowledge/conflicts) can be resolved."}
+
       {:error, %Ecto.Changeset{} = changeset} ->
         {:error, changeset}
     end
+  end
+
+  # supersede/merge lead the nightly executor to retire (and, for merge, synthesize
+  # over) an article — the destructive dispositions. dismiss is non-destructive.
+  defp destructive_disposition?(disposition), do: to_string(disposition) in ["supersede", "merge"]
+
+  # 403 body matches the RequireRole plug / FallbackController shape.
+  defp forbidden(conn, message) do
+    conn
+    |> put_status(:forbidden)
+    |> json(%{error: %{status: 403, message: message}})
   end
 
   defp resolution_note(%{disposition: :dismiss}),

--- a/test/loopctl/knowledge/kb_curation_test.exs
+++ b/test/loopctl/knowledge/kb_curation_test.exs
@@ -117,6 +117,16 @@ defmodule Loopctl.Knowledge.KbCurationTest do
       a = fixture(:article, %{tenant_id: t.id, status: :published})
       b = fixture(:article, %{tenant_id: t.id, status: :published})
 
+      # kb-02: a verdict is only accepted for a real system-flagged conflict.
+      %ArticleLink{tenant_id: t.id}
+      |> ArticleLink.changeset(%{
+        source_article_id: a.id,
+        target_article_id: b.id,
+        relationship_type: :potential_conflict,
+        metadata: %{"similarity_score" => 0.95}
+      })
+      |> AdminRepo.insert!()
+
       {:ok, _} =
         Knowledge.annotate_conflict(t.id, %{
           "source_article_id" => a.id,

--- a/test/loopctl/knowledge/kb_curation_test.exs
+++ b/test/loopctl/knowledge/kb_curation_test.exs
@@ -91,7 +91,7 @@ defmodule Loopctl.Knowledge.KbCurationTest do
         source_article_id: a.id,
         target_article_id: b.id,
         relationship_type: :potential_conflict,
-        metadata: %{"similarity_score" => 0.98}
+        metadata: %{"auto_generated" => true, "similarity_score" => 0.98}
       })
       |> AdminRepo.insert!()
 
@@ -117,13 +117,13 @@ defmodule Loopctl.Knowledge.KbCurationTest do
       a = fixture(:article, %{tenant_id: t.id, status: :published})
       b = fixture(:article, %{tenant_id: t.id, status: :published})
 
-      # kb-02: a verdict is only accepted for a real system-flagged conflict.
+      # kb-02: a verdict is only accepted for a real, system-flagged conflict.
       %ArticleLink{tenant_id: t.id}
       |> ArticleLink.changeset(%{
         source_article_id: a.id,
         target_article_id: b.id,
         relationship_type: :potential_conflict,
-        metadata: %{"similarity_score" => 0.95}
+        metadata: %{"auto_generated" => true, "similarity_score" => 0.95}
       })
       |> AdminRepo.insert!()
 

--- a/test/loopctl/knowledge/potential_conflicts_test.exs
+++ b/test/loopctl/knowledge/potential_conflicts_test.exs
@@ -232,6 +232,61 @@ defmodule Loopctl.Knowledge.PotentialConflictsTest do
 
       assert %{authoritative_article_id: _} = errors_on(changeset)
     end
+
+    # kb-02 (GHSA-9gqg-9r6p-658v) primary fix: a verdict may only be recorded against a
+    # REAL, system-flagged potential-conflict pair. Two arbitrary articles with no
+    # potential_conflict link cannot be resolved — this closes the fabrication path
+    # where an agent picks any two articles and has the executor retire one.
+    test "rejects a verdict on a pair with no potential_conflict link (no row created)", ctx do
+      %{tenant: t} = ctx
+      x = published(t.id, "X")
+      y = published(t.id, "Y")
+
+      assert {:error, :no_potential_conflict} =
+               Knowledge.annotate_conflict(t.id, %{
+                 "source_article_id" => x.id,
+                 "target_article_id" => y.id,
+                 "disposition" => "supersede",
+                 "authoritative_article_id" => x.id,
+                 "confidence" => "high"
+               })
+
+      # Nothing persisted for the fabricated pair, so the executor retires nothing.
+      assert 0 == Knowledge.execute_conflict_resolutions(t.id)
+      assert AdminRepo.get(Loopctl.Knowledge.Article, x.id).status == :published
+      assert AdminRepo.get(Loopctl.Knowledge.Article, y.id).status == :published
+    end
+
+    # A dismiss verdict is likewise only accepted for a real flagged pair.
+    test "rejects a dismiss on a pair with no potential_conflict link", ctx do
+      %{tenant: t} = ctx
+      x = published(t.id, "X")
+      y = published(t.id, "Y")
+
+      assert {:error, :no_potential_conflict} =
+               Knowledge.annotate_conflict(t.id, %{
+                 "source_article_id" => x.id,
+                 "target_article_id" => y.id,
+                 "disposition" => "dismiss"
+               })
+    end
+
+    # Tenant isolation: tenant B's flag does not authorize resolving tenant A's pair.
+    test "a potential_conflict link in another tenant does not authorize this tenant", ctx do
+      %{a: a, b: b} = ctx
+      other = fixture(:tenant)
+
+      # The real flag lives in the setup tenant. Resolving the SAME article ids under a
+      # different tenant must not find it.
+      assert {:error, :no_potential_conflict} =
+               Knowledge.annotate_conflict(other.id, %{
+                 "source_article_id" => a.id,
+                 "target_article_id" => b.id,
+                 "disposition" => "supersede",
+                 "authoritative_article_id" => a.id,
+                 "confidence" => "high"
+               })
+    end
   end
 
   describe "merge executor (#4 step 2)" do

--- a/test/loopctl/knowledge/potential_conflicts_test.exs
+++ b/test/loopctl/knowledge/potential_conflicts_test.exs
@@ -257,6 +257,62 @@ defmodule Loopctl.Knowledge.PotentialConflictsTest do
       assert AdminRepo.get(Loopctl.Knowledge.Article, y.id).status == :published
     end
 
+    # kb-02 FIX B (TOCTOU): retracting the flag after the verdict is recorded stops the
+    # executor — it noops instead of retiring the loser.
+    test "executor noops when the potential_conflict flag was retracted after the verdict", ctx do
+      %{tenant: t, a: a, b: b} = ctx
+
+      {:ok, _} =
+        Knowledge.annotate_conflict(t.id, %{
+          "source_article_id" => a.id,
+          "target_article_id" => b.id,
+          "disposition" => "supersede",
+          "authoritative_article_id" => a.id,
+          "confidence" => "high"
+        })
+
+      # A :user retracts the mistaken flag (DELETE link) before the nightly run.
+      link =
+        AdminRepo.get_by(ArticleLink, tenant_id: t.id, relationship_type: :potential_conflict)
+
+      {:ok, _} = Knowledge.delete_link(t.id, link.id)
+
+      # Executor must NOT retire the loser; it records a noop.
+      assert 0 == Knowledge.execute_conflict_resolutions(t.id)
+      assert AdminRepo.get(Loopctl.Knowledge.Article, b.id).status == :published
+
+      row = AdminRepo.get_by(Loopctl.Knowledge.ConflictResolution, tenant_id: t.id)
+      refute is_nil(row.executed_at)
+      assert row.execution_result["reason"] == "potential_conflict flag retracted"
+    end
+
+    # kb-02 FIX A provenance: a :potential_conflict link WITHOUT the system
+    # `auto_generated` marker is not accepted as evidence (a forged/non-system flag).
+    test "rejects a verdict when the potential_conflict link is not system-generated", ctx do
+      %{tenant: t} = ctx
+      x = published(t.id, "X")
+      y = published(t.id, "Y")
+
+      # A flag lacking the auto_generated provenance marker (as if planted by a non-system path).
+      %ArticleLink{tenant_id: t.id}
+      |> ArticleLink.changeset(%{
+        source_article_id: x.id,
+        target_article_id: y.id,
+        relationship_type: :potential_conflict,
+        metadata: %{"similarity_score" => 0.99}
+      })
+      |> AdminRepo.insert!()
+
+      assert {:error, :no_potential_conflict} =
+               Knowledge.annotate_conflict(t.id, %{
+                 "source_article_id" => x.id,
+                 "target_article_id" => y.id,
+                 "disposition" => "supersede",
+                 "authoritative_article_id" => x.id,
+                 "confidence" => "high"
+               })
+    end
+
     # A dismiss verdict is likewise only accepted for a real flagged pair.
     test "rejects a dismiss on a pair with no potential_conflict link", ctx do
       %{tenant: t} = ctx

--- a/test/loopctl/knowledge_test.exs
+++ b/test/loopctl/knowledge_test.exs
@@ -667,6 +667,36 @@ defmodule Loopctl.KnowledgeTest do
       assert audit.tenant_id == tenant.id
     end
 
+    # kb-02: caller-supplied provenance/score flags are SYSTEM-reserved and must be
+    # stripped so a link created via create_link can never be laundered into a
+    # system-stamped potential_conflict by the nightly promote_conflicts pass.
+    test "strips system-reserved metadata keys from caller input" do
+      %{tenant: tenant} = setup_tenant()
+
+      {:ok, source} =
+        Knowledge.create_article(tenant.id, %{title: "S", body: "B", category: :pattern})
+
+      {:ok, target} =
+        Knowledge.create_article(tenant.id, %{title: "T", body: "B", category: :pattern})
+
+      assert {:ok, %ArticleLink{} = link} =
+               Knowledge.create_link(tenant.id, %{
+                 source_article_id: source.id,
+                 target_article_id: target.id,
+                 relationship_type: :relates_to,
+                 metadata: %{
+                   "auto_generated" => true,
+                   "similarity_score" => 0.99,
+                   "reason" => "kept"
+                 }
+               })
+
+      refute Map.has_key?(link.metadata, "auto_generated")
+      refute Map.has_key?(link.metadata, "similarity_score")
+      # Non-reserved keys are preserved.
+      assert link.metadata["reason"] == "kept"
+    end
+
     test "rejects link when source article belongs to different tenant" do
       tenant_a = fixture(:tenant)
       tenant_b = fixture(:tenant)

--- a/test/loopctl/workers/knowledge_lint_worker_test.exs
+++ b/test/loopctl/workers/knowledge_lint_worker_test.exs
@@ -252,6 +252,67 @@ defmodule Loopctl.Workers.KnowledgeLintWorkerTest do
       assert [] == conflict_links(tenant.id, a.id, b.id)
     end
 
+    # kb-02: a relates_to link WITHOUT the system auto_generated marker (the agent-forged
+    # case, even at a very high similarity_score) is NOT promoted — this closes the
+    # laundering path where an agent plants a relates_to+score to mint a system-stamped
+    # potential_conflict.
+    test "does NOT promote a relates_to link that is not system-authored" do
+      tenant = fixture(:tenant)
+      a = published_article_with_embedding(tenant.id, similar_embedding())
+      b = published_article_with_embedding(tenant.id, near_similar_embedding())
+
+      # No "auto_generated" marker — as if planted by an agent via the public API.
+      %ArticleLink{tenant_id: tenant.id}
+      |> ArticleLink.changeset(%{
+        source_article_id: a.id,
+        target_article_id: b.id,
+        relationship_type: :relates_to,
+        metadata: %{"similarity_score" => 0.99}
+      })
+      |> AdminRepo.insert!()
+
+      assert :ok = KnowledgeLintWorker.perform(%Oban.Job{args: %{"tenant_id" => tenant.id}})
+
+      assert [] == conflict_links(tenant.id, a.id, b.id)
+      assert [entry] = lint_audit_entries(tenant.id)
+      assert entry.new_state["conflicts_promoted"] == 0
+    end
+
+    # kb-02 end-to-end: an agent-created relates_to link (metadata stripped by
+    # create_link) cannot be laundered into a resolvable potential_conflict, even at
+    # similarity 0.99 — the pair never becomes system-flagged, so a verdict is refused.
+    test "an agent-created relates_to link cannot be laundered into a resolvable conflict" do
+      tenant = fixture(:tenant)
+      a = published_article_with_embedding(tenant.id, similar_embedding())
+      b = published_article_with_embedding(tenant.id, near_similar_embedding())
+
+      # Model the agent's API POST (which routes through create_link): forged provenance
+      # + score. create_link strips the reserved keys.
+      {:ok, link} =
+        Loopctl.Knowledge.create_link(tenant.id, %{
+          source_article_id: a.id,
+          target_article_id: b.id,
+          relationship_type: :relates_to,
+          metadata: %{"auto_generated" => true, "similarity_score" => 0.99}
+        })
+
+      refute Map.has_key?(link.metadata, "auto_generated")
+
+      # Nightly promotion must NOT mint a potential_conflict from the forged link.
+      assert :ok = KnowledgeLintWorker.perform(%Oban.Job{args: %{"tenant_id" => tenant.id}})
+      assert [] == conflict_links(tenant.id, a.id, b.id)
+
+      # And a resolution verdict for the pair is refused (no system flag).
+      assert {:error, :no_potential_conflict} =
+               Loopctl.Knowledge.annotate_conflict(tenant.id, %{
+                 "source_article_id" => a.id,
+                 "target_article_id" => b.id,
+                 "disposition" => "supersede",
+                 "authoritative_article_id" => a.id,
+                 "confidence" => "high"
+               })
+    end
+
     test "is idempotent — a second run promotes nothing new" do
       tenant = fixture(:tenant)
       a = published_article_with_embedding(tenant.id, similar_embedding())

--- a/test/loopctl_web/controllers/article_link_controller_test.exs
+++ b/test/loopctl_web/controllers/article_link_controller_test.exs
@@ -161,6 +161,39 @@ defmodule LoopctlWeb.ArticleLinkControllerTest do
       assert json_response(conn, 422)
     end
 
+    # kb-02: system-reserved provenance/score metadata is stripped from caller input, so
+    # an agent cannot plant the auto_generated/similarity_score markers via the API.
+    test "strips system-reserved metadata keys from an agent-created link", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      a = fixture(:article, %{tenant_id: tenant.id})
+      b = fixture(:article, %{tenant_id: tenant.id})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/article_links", %{
+          "source_article_id" => a.id,
+          "target_article_id" => b.id,
+          "relationship_type" => "relates_to",
+          "metadata" => %{
+            "auto_generated" => true,
+            "similarity_score" => 0.99,
+            "reason" => "kept"
+          }
+        })
+
+      body = json_response(conn, 201)
+      refute Map.has_key?(body["data"]["metadata"], "auto_generated")
+      refute Map.has_key?(body["data"]["metadata"], "similarity_score")
+      assert body["data"]["metadata"]["reason"] == "kept"
+
+      # Confirm at the persistence layer too.
+      link = Loopctl.AdminRepo.get(Loopctl.Knowledge.ArticleLink, body["data"]["id"])
+      refute Map.has_key?(link.metadata, "auto_generated")
+      refute Map.has_key?(link.metadata, "similarity_score")
+    end
+
     # kb-02 FIX C: a non-scalar relationship_type must 422, not crash to_string/1 (500).
     test "a non-scalar relationship_type value is a 422, not a 500 crash", %{conn: conn} do
       tenant = fixture(:tenant)

--- a/test/loopctl_web/controllers/article_link_controller_test.exs
+++ b/test/loopctl_web/controllers/article_link_controller_test.exs
@@ -33,9 +33,12 @@ defmodule LoopctlWeb.ArticleLinkControllerTest do
       assert body["data"]["inserted_at"] != nil
     end
 
-    test ":supersedes link sets target article status to :superseded", %{conn: conn} do
+    # kb-01 (GHSA-9g2g-cm9x-9r2p): a "supersedes" link retires (hides) the target, so
+    # it is a destructive op — creating one requires role: user+ (was previously agent+,
+    # which let any agent hide an arbitrary published article).
+    test ":supersedes link at user role sets target article status to :superseded", %{conn: conn} do
       tenant = fixture(:tenant)
-      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
       article_a = fixture(:article, %{tenant_id: tenant.id, title: "New Version"})
 
       article_b =
@@ -55,6 +58,59 @@ defmodule LoopctlWeb.ArticleLinkControllerTest do
       # Verify the target article is now superseded
       {:ok, updated_target} = Loopctl.Knowledge.get_article(tenant.id, article_b.id)
       assert updated_target.status == :superseded
+    end
+
+    test "an agent creating a :supersedes link is forbidden (403), target stays published",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      article_a = fixture(:article, %{tenant_id: tenant.id, title: "New Version"})
+
+      article_b =
+        fixture(:article, %{tenant_id: tenant.id, title: "Old Version", status: :published})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/article_links", %{
+          "source_article_id" => article_a.id,
+          "target_article_id" => article_b.id,
+          "relationship_type" => "supersedes"
+        })
+
+      body = json_response(conn, 403)
+      assert body["error"]["status"] == 403
+
+      # The target must NOT have been hidden — still published/visible.
+      {:ok, target} = Loopctl.Knowledge.get_article(tenant.id, article_b.id)
+      assert target.status == :published
+
+      # And no supersedes link was created.
+      refute Loopctl.AdminRepo.get_by(Loopctl.Knowledge.ArticleLink,
+               tenant_id: tenant.id,
+               source_article_id: article_a.id,
+               target_article_id: article_b.id,
+               relationship_type: :supersedes
+             )
+    end
+
+    test "an agent can still create a non-destructive link (derived_from) (201)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      article_a = fixture(:article, %{tenant_id: tenant.id, title: "Derived"})
+      article_b = fixture(:article, %{tenant_id: tenant.id, title: "Source"})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/article_links", %{
+          "source_article_id" => article_a.id,
+          "target_article_id" => article_b.id,
+          "relationship_type" => "derived_from"
+        })
+
+      body = json_response(conn, 201)
+      assert body["data"]["relationship_type"] == "derived_from"
     end
 
     test "rejects self-link (422)", %{conn: conn} do

--- a/test/loopctl_web/controllers/article_link_controller_test.exs
+++ b/test/loopctl_web/controllers/article_link_controller_test.exs
@@ -113,6 +113,73 @@ defmodule LoopctlWeb.ArticleLinkControllerTest do
       assert body["data"]["relationship_type"] == "derived_from"
     end
 
+    # kb-02 FIX A: potential_conflict is SYSTEM-generated only. An agent must not be able
+    # to plant the "system flagged this pair" evidence the conflict-resolution guard trusts.
+    test "an agent creating a :potential_conflict link is rejected (422), no link created",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      a = fixture(:article, %{tenant_id: tenant.id})
+      b = fixture(:article, %{tenant_id: tenant.id})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/article_links", %{
+          "source_article_id" => a.id,
+          "target_article_id" => b.id,
+          "relationship_type" => "potential_conflict"
+        })
+
+      body = json_response(conn, 422)
+      assert body["error"]["status"] == 422
+
+      refute Loopctl.AdminRepo.get_by(Loopctl.Knowledge.ArticleLink,
+               tenant_id: tenant.id,
+               source_article_id: a.id,
+               target_article_id: b.id,
+               relationship_type: :potential_conflict
+             )
+    end
+
+    test "even a user cannot create a :potential_conflict link (system-only, 422)",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      a = fixture(:article, %{tenant_id: tenant.id})
+      b = fixture(:article, %{tenant_id: tenant.id})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/article_links", %{
+          "source_article_id" => a.id,
+          "target_article_id" => b.id,
+          "relationship_type" => "potential_conflict"
+        })
+
+      assert json_response(conn, 422)
+    end
+
+    # kb-02 FIX C: a non-scalar relationship_type must 422, not crash to_string/1 (500).
+    test "a non-scalar relationship_type value is a 422, not a 500 crash", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      a = fixture(:article, %{tenant_id: tenant.id})
+      b = fixture(:article, %{tenant_id: tenant.id})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/article_links", %{
+          "source_article_id" => a.id,
+          "target_article_id" => b.id,
+          "relationship_type" => %{"nested" => "object"}
+        })
+
+      assert json_response(conn, 422)
+    end
+
     test "rejects self-link (422)", %{conn: conn} do
       tenant = fixture(:tenant)
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})

--- a/test/loopctl_web/controllers/article_workflow_controller_test.exs
+++ b/test/loopctl_web/controllers/article_workflow_controller_test.exs
@@ -1293,7 +1293,8 @@ defmodule LoopctlWeb.ArticleWorkflowControllerTest do
   describe "POST /api/v1/knowledge/conflicts/resolve" do
     setup %{conn: conn} do
       tenant = fixture(:tenant)
-      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      {agent_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      {user_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
       a = fixture(:article, %{tenant_id: tenant.id, title: "A", status: :published})
       b = fixture(:article, %{tenant_id: tenant.id, title: "B", status: :published})
 
@@ -1306,7 +1307,13 @@ defmodule LoopctlWeb.ArticleWorkflowControllerTest do
       })
       |> AdminRepo.insert!()
 
-      %{conn: auth_conn(conn, raw_key), tenant: tenant, a: a, b: b}
+      %{
+        conn: auth_conn(conn, agent_key),
+        user_conn: auth_conn(conn, user_key),
+        tenant: tenant,
+        a: a,
+        b: b
+      }
     end
 
     test "an agent can dismiss a conflict (takes effect immediately)", ctx do
@@ -1325,8 +1332,11 @@ defmodule LoopctlWeb.ArticleWorkflowControllerTest do
       assert body["data"]["executed"] == true
     end
 
-    test "records a high-confidence supersede (deferred to the executor)", ctx do
-      %{conn: conn, a: a, b: b} = ctx
+    # kb-02: a user (destructive role) records a high-confidence supersede on a REAL
+    # potential conflict, and the nightly executor then retires the loser end-to-end.
+    test "a user records a high-confidence supersede applied by the executor (loser retired)",
+         ctx do
+      %{user_conn: conn, tenant: tenant, a: a, b: b} = ctx
 
       conn =
         post(conn, ~p"/api/v1/knowledge/conflicts/resolve", %{
@@ -1341,10 +1351,84 @@ defmodule LoopctlWeb.ArticleWorkflowControllerTest do
       assert body["data"]["disposition"] == "supersede"
       assert body["data"]["executed"] == false
       assert body["note"] =~ "nightly executor"
+
+      # Executor retires the loser.
+      assert 1 == Loopctl.Knowledge.execute_conflict_resolutions(tenant.id)
+      assert Loopctl.AdminRepo.get(Loopctl.Knowledge.Article, b.id).status == :superseded
+    end
+
+    # kb-02 (GHSA-9gqg-9r6p-658v): an :agent may NOT record a destructive verdict.
+    test "an agent recording a supersede is forbidden (403); no row, executor retires nothing",
+         ctx do
+      %{conn: conn, tenant: tenant, a: a, b: b} = ctx
+
+      conn =
+        post(conn, ~p"/api/v1/knowledge/conflicts/resolve", %{
+          "source_article_id" => a.id,
+          "target_article_id" => b.id,
+          "disposition" => "supersede",
+          "authoritative_article_id" => a.id,
+          "confidence" => "high"
+        })
+
+      body = json_response(conn, 403)
+      assert body["error"]["status"] == 403
+
+      # No verdict row was persisted, so the nightly executor has nothing to apply.
+      assert is_nil(
+               Loopctl.AdminRepo.get_by(Loopctl.Knowledge.ConflictResolution,
+                 tenant_id: tenant.id
+               )
+             )
+
+      assert 0 == Loopctl.Knowledge.execute_conflict_resolutions(tenant.id)
+      assert Loopctl.AdminRepo.get(Loopctl.Knowledge.Article, b.id).status == :published
+    end
+
+    # kb-02: an agent may not have the nightly executor MERGE (retire + synthesize) either.
+    test "an agent recording a merge is forbidden (403)", ctx do
+      %{conn: conn, a: a, b: b} = ctx
+
+      conn =
+        post(conn, ~p"/api/v1/knowledge/conflicts/resolve", %{
+          "source_article_id" => a.id,
+          "target_article_id" => b.id,
+          "disposition" => "merge",
+          "authoritative_article_id" => a.id,
+          "confidence" => "high"
+        })
+
+      assert json_response(conn, 403)
+    end
+
+    # kb-02: fabrication guard — resolving a pair the system never flagged is rejected,
+    # even for a privileged user, so no arbitrary pair can be retired via the executor.
+    test "422 when the pair has no potential-conflict link (fabricated pair)", ctx do
+      %{user_conn: conn, tenant: tenant} = ctx
+      x = fixture(:article, %{tenant_id: tenant.id, title: "X", status: :published})
+      y = fixture(:article, %{tenant_id: tenant.id, title: "Y", status: :published})
+
+      conn =
+        post(conn, ~p"/api/v1/knowledge/conflicts/resolve", %{
+          "source_article_id" => x.id,
+          "target_article_id" => y.id,
+          "disposition" => "supersede",
+          "authoritative_article_id" => x.id,
+          "confidence" => "high"
+        })
+
+      assert json_response(conn, 422)
+      # No verdict row for the fabricated pair.
+      assert 0 ==
+               Loopctl.AdminRepo.aggregate(
+                 Loopctl.Knowledge.ConflictResolution,
+                 :count,
+                 :id
+               )
     end
 
     test "422 when supersede omits the authoritative article", ctx do
-      %{conn: conn, a: a, b: b} = ctx
+      %{user_conn: conn, a: a, b: b} = ctx
 
       conn =
         post(conn, ~p"/api/v1/knowledge/conflicts/resolve", %{
@@ -1354,6 +1438,30 @@ defmodule LoopctlWeb.ArticleWorkflowControllerTest do
         })
 
       assert json_response(conn, 422)
+    end
+
+    # Tenant isolation: a user in tenant B cannot resolve tenant A's flagged pair —
+    # from B's perspective the potential_conflict link does not exist (422).
+    test "a caller in another tenant cannot resolve the pair (422)", ctx do
+      %{tenant: tenant_a, a: a, b: b, conn: base_conn} = ctx
+      tenant_b = fixture(:tenant)
+      {user_key_b, _} = fixture(:api_key, %{tenant_id: tenant_b.id, role: :user})
+
+      conn =
+        base_conn
+        |> auth_conn(user_key_b)
+        |> post(~p"/api/v1/knowledge/conflicts/resolve", %{
+          "source_article_id" => a.id,
+          "target_article_id" => b.id,
+          "disposition" => "supersede",
+          "authoritative_article_id" => a.id,
+          "confidence" => "high"
+        })
+
+      assert json_response(conn, 422)
+      # Tenant A's article is untouched.
+      assert Loopctl.AdminRepo.get(Loopctl.Knowledge.Article, b.id).status == :published
+      _ = tenant_a
     end
   end
 end

--- a/test/loopctl_web/controllers/article_workflow_controller_test.exs
+++ b/test/loopctl_web/controllers/article_workflow_controller_test.exs
@@ -1440,6 +1440,20 @@ defmodule LoopctlWeb.ArticleWorkflowControllerTest do
       assert json_response(conn, 422)
     end
 
+    # kb-02 FIX C: a non-scalar disposition must 422, not crash to_string/1 (500).
+    test "a non-scalar disposition is a 422, not a 500 crash", ctx do
+      %{user_conn: conn, a: a, b: b} = ctx
+
+      conn =
+        post(conn, ~p"/api/v1/knowledge/conflicts/resolve", %{
+          "source_article_id" => a.id,
+          "target_article_id" => b.id,
+          "disposition" => %{"nested" => "object"}
+        })
+
+      assert json_response(conn, 422)
+    end
+
     # Tenant isolation: a user in tenant B cannot resolve tenant A's flagged pair —
     # from B's perspective the potential_conflict link does not exist (422).
     test "a caller in another tenant cannot resolve the pair (422)", ctx do


### PR DESCRIPTION
## Summary

Closes two HIGH auth-bypass advisories in the Knowledge Wiki that let an `:agent` hide or retire arbitrary in-tenant published articles.

### kb-01 (GHSA-9g2g-cm9x-9r2p) — supersede-via-link privilege escalation
`POST /api/v1/article_links` was gated at `:agent`, but creating a `"supersedes"` link flips the **target** article to `:superseded` as a side effect, excluding it from every default published read (search/graph/context all default `status: :published`). An agent could thus hide any published article in its tenant.

**Fix:** the `"supersedes"` relationship_type now requires `:user` (consistent with archive/unpublish). Non-destructive types (`relates_to`, `derived_from`, `contradicts`) stay at `:agent`. Enforced by an in-action role check in `ArticleLinkController.create/2` (reads `current_api_key.role` via `Role.role_at_least?/2`) rather than a static plug, because destructiveness depends on the body param. `Knowledge.create_link/3` is left role-agnostic so the system-privileged nightly executor can still supersede.

### kb-02 (GHSA-9gqg-9r6p-658v) — fabricated conflict resolution
`resolve_conflict/2` was in no `RequireRole` plug, and `annotate_conflict/3` never verified a system-flagged conflict existed — so any role could fabricate a `"supersede"`/`"merge"` verdict on **any two** in-tenant articles and have the nightly `KnowledgeLintWorker` retire/merge one.

**Two guards:**
1. **Primary:** `annotate_conflict/3` now requires a real `:potential_conflict` `ArticleLink` for the pair (either direction) before accepting **any** disposition; otherwise `{:error, :no_potential_conflict}` -> 422. This closes fabrication for arbitrary pairs while still allowing annotation of real, system-detected conflicts.
2. **Role gate:** the destructive dispositions (`supersede`/`merge`, which the executor applies by retiring an article) now require `:user`, via an in-action check in `resolve_conflict/2`. `dismiss` (non-destructive) stays at `:agent`, preserving the intended agent-annotates flow. Enforcing at the boundary means no agent-originated destructive verdict is ever persisted, so the executor can never act on one (the `conflict_resolutions` row carries no originating role — the controller is the only place with the caller role in hand).

## Enforcement rationale
- **In-action checks, not static plugs:** for both advisories the destructive-ness depends on a body param (`relationship_type` / `disposition`), which a static `RequireRole` plug cannot branch on cleanly.
- **Context stays role-agnostic:** the nightly executor legitimately supersedes via `create_link/3`, so the gate lives at the HTTP boundary, not in the context.
- **Primary fix in the context** (`annotate_conflict/3`) so the `potential_conflict` existence check protects every caller, not just the controller.

## Tests
- **kb-01:** agent `supersedes` link -> 403 (target stays published, no link created); agent `relates_to`/`derived_from` still 201; user `supersedes` link supersedes the target.
- **kb-02:** agent `supersede`/`merge` resolve -> 403 (no row persisted, executor retires nothing); user `supersede` on a real conflict applied end-to-end by the executor; fabricated pair (no `potential_conflict` link) -> 422 (no row); tenant A cannot resolve tenant B's pair.
- **Context-level:** fabrication guard + tenant-isolation on `annotate_conflict/3`; verified `execute_conflict_resolutions/2` retires nothing for a fabricated/agent-originated verdict.

## Verification
`mix precommit` green: compile `--warnings-as-errors`, format, `credo --strict`, dialyzer (0), full suite **3200 tests, 0 failures**.

Refs private advisories GHSA-9g2g-cm9x-9r2p, GHSA-9gqg-9r6p-658v.
