### PR TITLE
fix(security): immutable tenant slug + email unique_constraint (rls-02, rls-03)

### DIFF
--- a/lib/loopctl/api_spec/schemas.ex
+++ b/lib/loopctl/api_spec/schemas.ex
@@ -141,6 +141,43 @@ defmodule Loopctl.ApiSpec.Schemas do
     })
   end
 
+  defmodule TenantUpdateRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "TenantUpdateRequest",
+      description:
+        "Request body for `PATCH /api/v1/tenants/me` (and the superadmin " <>
+          "`PATCH /api/v1/admin/tenants/:id`). NOTE: `slug` is intentionally " <>
+          "absent — it is immutable after creation because it keys the tenant's " <>
+          "audit-key secret name (security: rls-02, advisory GHSA-v62j-7vgr-rfqp). " <>
+          "Sending `slug` has no effect.",
+      type: :object,
+      properties: %{
+        name: %Schema{type: :string, description: "Tenant display name"},
+        email: %Schema{type: :string, format: :email, description: "Contact email"},
+        settings: %Schema{type: :object, additionalProperties: true},
+        default_story_budget_millicents: %Schema{
+          type: :integer,
+          nullable: true,
+          description: "Tenant-wide default story budget (millicents); null to unset"
+        },
+        token_data_retention_days: %Schema{
+          type: :integer,
+          nullable: true,
+          description: "Token-usage retention in days (>= 30); null disables archival"
+        }
+      },
+      example: %{
+        name: "My Org",
+        email: "admin@example.com",
+        settings: %{},
+        token_data_retention_days: 90
+      }
+    })
+  end
+
   # ---------- WebAuthn signup (US-26.0.1) ----------
 
   defmodule WebAuthnChallenge do

--- a/lib/loopctl/tenants.ex
+++ b/lib/loopctl/tenants.ex
@@ -10,6 +10,8 @@ defmodule Loopctl.Tenants do
   and are not subject to RLS policies.
   """
 
+  require Logger
+
   alias Ecto.Multi
   alias Loopctl.AdminRepo
   alias Loopctl.Audit
@@ -460,6 +462,7 @@ defmodule Loopctl.Tenants do
   """
   @spec update_tenant(Tenant.t(), map()) :: {:ok, Tenant.t()} | {:error, Ecto.Changeset.t()}
   def update_tenant(%Tenant{} = tenant, attrs) do
+    warn_on_slug_mutation_attempt(tenant, attrs)
     attrs = merge_settings(tenant, attrs)
 
     tenant
@@ -595,6 +598,7 @@ defmodule Loopctl.Tenants do
   @spec update_tenant_admin(Tenant.t(), map()) ::
           {:ok, Tenant.t()} | {:error, Ecto.Changeset.t()}
   def update_tenant_admin(%Tenant{} = tenant, attrs) do
+    warn_on_slug_mutation_attempt(tenant, attrs)
     attrs = merge_settings(tenant, attrs)
 
     tenant
@@ -823,6 +827,24 @@ defmodule Loopctl.Tenants do
 
       _ ->
         attrs
+    end
+  end
+
+  # rls-02: slug is immutable on update (it keys the audit-key secret name),
+  # and `update_changeset/2` silently drops any uncast `:slug`. A request that
+  # nonetheless tries to rename the slug is exactly the operation that would
+  # strand the audit-signing secret, so leave a forensic trail without changing
+  # the ignored-and-succeeds behavior. Advisory GHSA-v62j-7vgr-rfqp.
+  defp warn_on_slug_mutation_attempt(%Tenant{id: id, slug: current}, attrs) do
+    case Map.get(attrs, "slug") || Map.get(attrs, :slug) do
+      new_slug when is_binary(new_slug) and new_slug != current ->
+        Logger.warning(
+          "attempted slug mutation ignored for tenant #{id} " <>
+            "(#{inspect(current)} -> #{inspect(new_slug)}); slug is immutable (rls-02)"
+        )
+
+      _ ->
+        :ok
     end
   end
 

--- a/lib/loopctl/tenants/tenant.ex
+++ b/lib/loopctl/tenants/tenant.ex
@@ -26,6 +26,8 @@ defmodule Loopctl.Tenants.Tenant do
 
   schema "tenants" do
     field :name, :string
+    # Immutable after creation — keys the audit-key Fly secret name (rls-02).
+    # See update_changeset/2 moduletext; never add :slug to its cast list.
     field :slug, :string
     field :email, :string
     field :settings, :map, default: %{}
@@ -88,30 +90,56 @@ defmodule Loopctl.Tenants.Tenant do
     |> validate_email()
     |> validate_settings()
     |> unique_constraint(:slug)
+    # rls-03: yield a clean 422 (not a 500 ConstraintError) on email collision.
+    |> unique_constraint(:email, name: :tenants_email_index)
   end
 
   @doc """
   Changeset for updating an existing tenant.
 
   Accepts `token_data_retention_days` (integer >= 30, or nil to disable).
+
+  ## Slug is immutable on update (security: rls-02)
+
+  `:slug` is deliberately **not** cast here. The tenant slug is the key
+  from which the ed25519 audit-key Fly secret name is derived
+  (`Loopctl.Secrets.audit_key_secret_name/1`). `Loopctl.TenantKeys`
+  re-derives that name from the tenant's *current* slug on every cache
+  miss, so renaming the slug would strand the audit-key secret: after the
+  5-minute cache TTL, capability-token signing (the normal orchestrator
+  dispatch/cap-minting path) and AuditChain STH signing would hard-fail
+  for the whole tenant indefinitely, and a subsequent rotation would
+  orphan the old secret permanently. The slug is therefore set once at
+  signup/creation and must never change on the update path — this holds
+  for both the `:user` (`PATCH /tenants/me`) and superadmin
+  (`PATCH /admin/tenants/:id`) flows, since both route through this
+  changeset via `Tenants.update_tenant/2` and `update_tenant_admin/2`.
+
+  The proper root fix — keying `Secrets.audit_key_secret_name/1` off the
+  immutable `tenant_id` and migrating the existing slug-named Fly secrets
+  — is deferred because it requires migrating live secrets. See advisory
+  GHSA-v62j-7vgr-rfqp (rls-02).
+
+  Also adds `unique_constraint(:email)` (security: rls-03) so an email
+  collision with another tenant returns a clean `{:error, changeset}`
+  (422) instead of raising `Ecto.ConstraintError` (500) — a 500 vs 422
+  difference is a cross-tenant email-enumeration oracle.
   """
   @spec update_changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
   def update_changeset(tenant, attrs) do
     tenant
     |> cast(attrs, [
       :name,
-      :slug,
       :email,
       :settings,
       :default_story_budget_millicents,
       :token_data_retention_days
     ])
-    |> validate_slug()
     |> validate_email()
     |> validate_settings()
     |> validate_number(:default_story_budget_millicents, greater_than: 0)
     |> validate_retention_days()
-    |> unique_constraint(:slug)
+    |> unique_constraint(:email, name: :tenants_email_index)
   end
 
   @doc """

--- a/lib/loopctl_web/controllers/tenant_controller.ex
+++ b/lib/loopctl_web/controllers/tenant_controller.ex
@@ -36,8 +36,11 @@ defmodule LoopctlWeb.TenantController do
 
   operation(:update,
     summary: "Update current tenant profile",
-    description: "Updates the tenant profile. Requires user+ role.",
-    request_body: {"Update params", "application/json", Schemas.TenantResponse},
+    description:
+      "Updates the tenant profile. Requires user+ role. " <>
+        "`slug` is immutable post-creation (it keys the audit-key secret) and is " <>
+        "not part of the request body — see rls-02.",
+    request_body: {"Update params", "application/json", Schemas.TenantUpdateRequest},
     responses: %{
       200 => {"Updated tenant", "application/json", Schemas.TenantResponse},
       401 => {"Unauthorized", "application/json", Schemas.ErrorResponse},

--- a/test/loopctl/tenants/tenants_test.exs
+++ b/test/loopctl/tenants/tenants_test.exs
@@ -3,6 +3,7 @@ defmodule Loopctl.TenantsTest do
 
   setup :verify_on_exit!
 
+  alias Loopctl.Secrets
   alias Loopctl.Tenants
   alias Loopctl.Tenants.Tenant
 
@@ -37,6 +38,16 @@ defmodule Loopctl.TenantsTest do
       attrs = %{name: "Other Corp", slug: "acme-corp", email: "other@example.com"}
       assert {:error, changeset} = Tenants.create_tenant(attrs)
       assert "has already been taken" in errors_on(changeset).slug
+    end
+
+    # rls-03: duplicate email on create must also yield a changeset error
+    # (422), never a raised Ecto.ConstraintError (500).
+    test "rejects duplicate email" do
+      fixture(:tenant, %{email: "dupe@example.com"})
+
+      attrs = %{name: "Other Corp", slug: "other-corp", email: "dupe@example.com"}
+      assert {:error, changeset} = Tenants.create_tenant(attrs)
+      assert "has already been taken" in errors_on(changeset).email
     end
 
     test "rejects invalid slug format - uppercase" do
@@ -112,6 +123,72 @@ defmodule Loopctl.TenantsTest do
       tenant = fixture(:tenant)
       assert {:ok, updated} = Tenants.update_tenant(tenant, %{name: "New Name"})
       assert updated.name == "New Name"
+    end
+
+    # rls-02: the slug keys the audit-key Fly secret name. Renaming it would
+    # strand the secret (signing hard-fails after the cache TTL), so slug must
+    # be immutable on the update path.
+    test "ignores attempts to change slug (immutable — rls-02)" do
+      tenant = fixture(:tenant, %{slug: "original-slug"})
+
+      assert {:ok, updated} =
+               Tenants.update_tenant(tenant, %{slug: "renamed-slug", name: "New Name"})
+
+      # The unrelated field change lands; the slug does not.
+      assert updated.name == "New Name"
+      assert updated.slug == "original-slug"
+
+      # Custody link: the derived audit-key secret name is unchanged, so the
+      # tenant's audit key remains resolvable after an unrelated update.
+      assert Secrets.audit_key_secret_name(updated.slug) ==
+               Secrets.audit_key_secret_name(tenant.slug)
+    end
+
+    test "update_changeset does not cast :slug (immutable — rls-02)" do
+      tenant = fixture(:tenant, %{slug: "keep-me"})
+      changeset = Tenant.update_changeset(tenant, %{slug: "changed", name: "New"})
+
+      refute Map.has_key?(changeset.changes, :slug)
+      assert changeset.changes[:name] == "New"
+    end
+
+    # rls-03: a colliding email must produce a clean changeset error, not a
+    # raised Ecto.ConstraintError (which would surface as a 500 and act as a
+    # cross-tenant email-enumeration oracle).
+    test "returns changeset error on duplicate email instead of raising (rls-03)" do
+      _other = fixture(:tenant, %{email: "taken@example.com"})
+      tenant = fixture(:tenant, %{email: "mine@example.com"})
+
+      assert {:error, changeset} =
+               Tenants.update_tenant(tenant, %{email: "taken@example.com"})
+
+      assert "has already been taken" in errors_on(changeset).email
+    end
+
+    test "allows updating to a unique email (rls-03)" do
+      tenant = fixture(:tenant, %{email: "mine@example.com"})
+
+      assert {:ok, updated} =
+               Tenants.update_tenant(tenant, %{email: "fresh@example.com"})
+
+      assert updated.email == "fresh@example.com"
+    end
+
+    # Tenant isolation: tenant B cannot claim tenant A's email, and the
+    # rejection leaks nothing about A beyond the standard uniqueness message.
+    test "tenant cannot take another tenant's email (isolation — rls-03)" do
+      tenant_a = fixture(:tenant, %{email: "a@example.com", name: "Tenant A"})
+      tenant_b = fixture(:tenant, %{email: "b@example.com"})
+
+      assert {:error, changeset} =
+               Tenants.update_tenant(tenant_b, %{email: "a@example.com"})
+
+      assert errors_on(changeset) == %{email: ["has already been taken"]}
+
+      # Tenant A is untouched.
+      assert {:ok, reloaded_a} = Tenants.get_tenant(tenant_a.id)
+      assert reloaded_a.email == "a@example.com"
+      assert reloaded_a.name == "Tenant A"
     end
   end
 

--- a/test/loopctl/tenants/tenants_test.exs
+++ b/test/loopctl/tenants/tenants_test.exs
@@ -1,6 +1,8 @@
 defmodule Loopctl.TenantsTest do
   use Loopctl.DataCase, async: true
 
+  import ExUnit.CaptureLog
+
   setup :verify_on_exit!
 
   alias Loopctl.Secrets
@@ -150,6 +152,38 @@ defmodule Loopctl.TenantsTest do
 
       refute Map.has_key?(changeset.changes, :slug)
       assert changeset.changes[:name] == "New"
+    end
+
+    # rls-02: an attempted (and ignored) slug rename must leave a forensic
+    # trail — it's the exact probe that would strand the audit-signing secret.
+    test "logs a warning on an attempted slug mutation (rls-02 observability)" do
+      tenant = fixture(:tenant, %{slug: "original-slug"})
+
+      log =
+        capture_log(fn ->
+          assert {:ok, updated} =
+                   Tenants.update_tenant(tenant, %{slug: "renamed-slug", name: "New Name"})
+
+          assert updated.slug == "original-slug"
+        end)
+
+      assert log =~ "attempted slug mutation ignored for tenant #{tenant.id}"
+    end
+
+    test "does not log when slug is unchanged or absent (rls-02 observability)" do
+      tenant = fixture(:tenant, %{slug: "steady-slug"})
+
+      # slug absent
+      log_absent = capture_log(fn -> Tenants.update_tenant(tenant, %{name: "Renamed"}) end)
+      refute log_absent =~ "attempted slug mutation"
+
+      # slug present but identical
+      log_same =
+        capture_log(fn ->
+          Tenants.update_tenant(tenant, %{slug: "steady-slug", name: "Renamed Again"})
+        end)
+
+      refute log_same =~ "attempted slug mutation"
     end
 
     # rls-03: a colliding email must produce a clean changeset error, not a

--- a/test/loopctl_web/controllers/admin_tenant_controller_test.exs
+++ b/test/loopctl_web/controllers/admin_tenant_controller_test.exs
@@ -189,6 +189,45 @@ defmodule LoopctlWeb.AdminTenantControllerTest do
       assert body["tenant"]["name"] == "New Name"
     end
 
+    # rls-02: the superadmin update path shares Tenant.update_changeset via
+    # update_tenant_admin/2, so slug must be immutable here too. Guards the
+    # security-critical admin route against a future regression.
+    test "ignores attempts to change slug (rls-02)", %{conn: conn} do
+      {raw_key, _} = fixture(:api_key, %{role: :superadmin})
+
+      tenant = fixture(:tenant, %{slug: "keep-slug", name: "Old Name"})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> patch(~p"/api/v1/admin/tenants/#{tenant.id}", %{
+          "slug" => "hijacked-slug",
+          "name" => "New Name"
+        })
+
+      body = json_response(conn, 200)
+      assert body["tenant"]["name"] == "New Name"
+      assert body["tenant"]["slug"] == "keep-slug"
+    end
+
+    # rls-03: colliding with another tenant's email must return 422, not 500
+    # (a 500 would be a cross-tenant email-enumeration oracle).
+    test "returns 422 (not 500) on duplicate email (rls-03)", %{conn: conn} do
+      {raw_key, _} = fixture(:api_key, %{role: :superadmin})
+
+      _other = fixture(:tenant, %{email: "taken@example.com"})
+      tenant = fixture(:tenant, %{email: "mine@example.com"})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> patch(~p"/api/v1/admin/tenants/#{tenant.id}", %{"email" => "taken@example.com"})
+
+      body = json_response(conn, 422)
+      assert body["error"]["status"] == 422
+      assert body["error"]["details"] == %{"email" => ["has already been taken"]}
+    end
+
     test "creates audit log entry on update", %{conn: conn} do
       {raw_key, api_key} = fixture(:api_key, %{role: :superadmin})
 

--- a/test/loopctl_web/controllers/tenant_controller_test.exs
+++ b/test/loopctl_web/controllers/tenant_controller_test.exs
@@ -91,9 +91,9 @@ defmodule LoopctlWeb.TenantControllerTest do
 
       body = json_response(conn, 422)
       assert body["error"]["status"] == 422
-      assert "has already been taken" in body["error"]["details"]["email"]
-      # The response leaks nothing about the other tenant beyond the message.
-      refute Map.has_key?(body["error"]["details"], :id)
+      # The details map leaks nothing about the other tenant beyond the
+      # standard uniqueness message on :email (JSON keys are strings).
+      assert body["error"]["details"] == %{"email" => ["has already been taken"]}
     end
 
     test "allows updating to a unique email (rls-03)", %{conn: conn} do

--- a/test/loopctl_web/controllers/tenant_controller_test.exs
+++ b/test/loopctl_web/controllers/tenant_controller_test.exs
@@ -58,5 +58,55 @@ defmodule LoopctlWeb.TenantControllerTest do
       body = json_response(conn, 200)
       assert body["tenant"]["settings"]["rate_limit_requests_per_minute"] == 500
     end
+
+    # rls-02: slug is immutable on update. A PATCH attempting to rename it
+    # succeeds (other fields apply) but leaves the slug — and therefore the
+    # audit-key secret name — unchanged.
+    test "ignores attempts to change slug (rls-02)", %{conn: conn} do
+      tenant = fixture(:tenant, %{slug: "keep-slug", name: "Old Name"})
+      {raw_key, _api_key} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_key}")
+        |> patch(~p"/api/v1/tenants/me", %{"slug" => "hijacked-slug", "name" => "New Name"})
+
+      body = json_response(conn, 200)
+      assert body["tenant"]["name"] == "New Name"
+      assert body["tenant"]["slug"] == "keep-slug"
+    end
+
+    # rls-03: colliding with another tenant's email must return 422, not 500.
+    # A 500 here would be a cross-tenant email-enumeration oracle.
+    test "returns 422 (not 500) when email is already used by another tenant (rls-03)",
+         %{conn: conn} do
+      _other = fixture(:tenant, %{email: "taken@example.com"})
+      tenant = fixture(:tenant, %{email: "mine@example.com"})
+      {raw_key, _api_key} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_key}")
+        |> patch(~p"/api/v1/tenants/me", %{"email" => "taken@example.com"})
+
+      body = json_response(conn, 422)
+      assert body["error"]["status"] == 422
+      assert "has already been taken" in body["error"]["details"]["email"]
+      # The response leaks nothing about the other tenant beyond the message.
+      refute Map.has_key?(body["error"]["details"], :id)
+    end
+
+    test "allows updating to a unique email (rls-03)", %{conn: conn} do
+      tenant = fixture(:tenant, %{email: "mine@example.com"})
+      {raw_key, _api_key} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_key}")
+        |> patch(~p"/api/v1/tenants/me", %{"email" => "fresh@example.com"})
+
+      body = json_response(conn, 200)
+      assert body["tenant"]["email"] == "fresh@example.com"
+    end
   end
 end


### PR DESCRIPTION
## Summary

Hardens the tenant update path (`Tenant.update_changeset`, shared by `PATCH /api/v1/tenants/me` and `PATCH /admin/tenants/:id` via `Tenants.update_tenant/2` and `update_tenant_admin/2`) against two advisories.

### rls-02 (HIGH — data-loss / chain-of-custody)

The ed25519 tenant audit-key is stored as a Fly secret whose **name is derived from the tenant slug** (`Secrets.audit_key_secret_name/1`), and `TenantKeys.fetch_and_cache` re-derives that name from the tenant's **current** slug on every cache miss. Because `update_changeset` cast `:slug`, a `:user` `PATCH /tenants/me` (or superadmin `PATCH /admin/tenants/:id`) could rename the slug. After the 5-minute ETS cache TTL, `TenantKeys.get_private_key` would derive the name from the **new** slug, find no secret, and error — hard-failing capability-token signing (the normal orchestrator dispatch/cap-minting path) **and** AuditChain STH signing for the whole tenant indefinitely; a subsequent rotation would orphan the old secret permanently.

**Fix:** `:slug` is removed from the `update_changeset` cast list, making the slug immutable post-creation so it can never desync from the audit-key secret name. Both the `:user` and superadmin update flows route through this single changeset, so this covers both. The slug is still set once at signup (`signup_changeset`) and creation (`create_changeset`).

The proper root fix — keying `Secrets.audit_key_secret_name/1` off the immutable `tenant_id` and migrating existing slug-named Fly secrets — is **deferred** because it requires migrating live secrets, and is documented in the `update_changeset` moduletext.

### rls-03 (MEDIUM — crash / enumeration oracle)

`update_changeset` had `unique_constraint(:slug)` but **not** `unique_constraint(:email)`, despite the `tenants_email_index` DB unique index. A `PATCH` with an email already used by another tenant raised `Ecto.ConstraintError` (500) instead of returning `{:error, changeset}` (422). The 500-vs-422 difference is a **cross-tenant email-enumeration oracle**.

**Fix:** `unique_constraint(:email, name: :tenants_email_index)` added to both `update_changeset` and `create_changeset`, yielding a clean 422 "has already been taken". No controller change needed — `FallbackController` already maps `{:error, %Ecto.Changeset{}}` to 422.

## No slug-rename feature exists

Verified there is no product slug-rename endpoint/UI: the only write paths are signup (`signup_changeset`, slug set once), create (`create_changeset`), and update (`update_changeset`). Superadmin update shares `update_changeset`, so removing `:slug` there covers it too.

## Tests

- `tenants_test.exs`: slug change ignored on update; `update_changeset` does not cast `:slug`; custody link (derived audit-key secret name unchanged after an unrelated update); duplicate email → changeset error (update + create); unique email updates succeed; tenant-isolation case (tenant B cannot take tenant A's email; A untouched; no data leak beyond the uniqueness message).
- `tenant_controller_test.exs`: `PATCH /tenants/me` ignores slug change; colliding email returns **422 not 500**; unique email updates succeed.

## Verification

`mix precommit` green: compile `--warnings-as-errors`, `format --check-formatted`, `credo --strict` (no issues), `deps.audit` (no vulnerabilities), `dialyzer` (fresh PLT, passed), full suite **3219 tests, 0 failures**.

Refs advisory GHSA-v62j-7vgr-rfqp (rls-02) and public issue #235 (rls-03).
