### PR TITLE
fix(crypto): real challenge-bound WebAuthn reauth for audit-key rotation (GHSA-c3cw-5f7p-g76r)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -233,6 +233,7 @@ config :loopctl, Oban,
      crontab: [
        {"0 * * * *", Loopctl.Workers.IdempotencyCleanupWorker},
        {"0 * * * *", Loopctl.Workers.BulkDeleteTokenCleanupWorker},
+       {"0 * * * *", Loopctl.Workers.ReauthChallengeCleanupWorker},
        {"0 2 * * *", Loopctl.Workers.AuditPartitionWorker},
        {"0 2 * * *", Loopctl.Workers.CostRollupWorker},
        {"0 3 * * *", Loopctl.Workers.WebhookCleanupWorker},

--- a/lib/loopctl/api_spec/schemas.ex
+++ b/lib/loopctl/api_spec/schemas.ex
@@ -291,6 +291,121 @@ defmodule Loopctl.ApiSpec.Schemas do
     })
   end
 
+  defmodule ReauthChallengeResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "ReauthChallengeResponse",
+      description:
+        "Step 1 of the audit-key rotation reauth ceremony (crypto-01). The " <>
+          "server-minted, single-use `challenge_id` must be echoed back in the " <>
+          "assertion step. All binary fields are base64url encoded.",
+      type: :object,
+      required: [:data],
+      properties: %{
+        data: %Schema{
+          type: :object,
+          required: [:challenge_id, :challenge, :allowed_credentials],
+          properties: %{
+            challenge_id: %Schema{
+              type: :string,
+              format: :uuid,
+              description: "Opaque single-use handle for the stored challenge"
+            },
+            challenge: %Schema{
+              type: :string,
+              description:
+                "Base64url-encoded challenge bytes to feed into navigator.credentials.get()"
+            },
+            allowed_credentials: %Schema{
+              type: :array,
+              items: %Schema{type: :string},
+              description: "Base64url credential ids the client may assert with"
+            },
+            rp_id: %Schema{type: :string, description: "Relying party id"},
+            expires_at: %Schema{type: :string, format: :"date-time"}
+          }
+        }
+      }
+    })
+  end
+
+  defmodule WebAuthnAssertion do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "WebAuthnAssertion",
+      description:
+        "Assertion produced by `navigator.credentials.get()`, posted back to " <>
+          "verify a reauth challenge. All binary fields are base64url encoded and " <>
+          "are SEPARATE values (never one blob reused for all fields).",
+      type: :object,
+      required: [
+        :challenge_id,
+        :credential_id,
+        :authenticator_data,
+        :signature,
+        :client_data_json
+      ],
+      properties: %{
+        challenge_id: %Schema{
+          type: :string,
+          format: :uuid,
+          description: "The `challenge_id` returned by the challenge step"
+        },
+        credential_id: %Schema{type: :string, description: "Base64url asserting credential id"},
+        authenticator_data: %Schema{type: :string, description: "Base64url authenticator data"},
+        signature: %Schema{type: :string, description: "Base64url assertion signature"},
+        client_data_json: %Schema{type: :string, description: "Base64url raw client data JSON"}
+      }
+    })
+  end
+
+  defmodule RotateAuditKeyRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "RotateAuditKeyRequest",
+      description:
+        "Step 2 of the reauth ceremony. Carries the WebAuthn assertion that is " <>
+          "verified against the STORED challenge from step 1 before rotation.",
+      type: :object,
+      required: [:webauthn_assertion],
+      properties: %{
+        webauthn_assertion: WebAuthnAssertion
+      }
+    })
+  end
+
+  defmodule AuditKeyResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "AuditKeyResponse",
+      description: "Result of an audit-key rotation or bootstrap.",
+      type: :object,
+      required: [:data],
+      properties: %{
+        data: %Schema{
+          type: :object,
+          properties: %{
+            tenant_id: %Schema{type: :string, format: :uuid},
+            audit_signing_public_key: %Schema{
+              type: :string,
+              description: "Base64-encoded ed25519 public key"
+            },
+            rotated_at: %Schema{type: :string, format: :"date-time", nullable: true},
+            message: %Schema{type: :string}
+          }
+        }
+      }
+    })
+  end
+
   # ---------- API Keys ----------
 
   defmodule ApiKeyCreateRequest do

--- a/lib/loopctl/web_authn/reauth.ex
+++ b/lib/loopctl/web_authn/reauth.ex
@@ -89,13 +89,19 @@ defmodule Loopctl.WebAuthn.Reauth do
   defp do_issue_challenge(tenant_id, purpose, authenticators) do
     rp_opts = WebAuthn.rp_opts()
 
-    allow_credentials =
-      Enum.map(authenticators, fn auth -> {auth.credential_id, auth.public_key} end)
-
-    challenge =
-      rp_opts
-      |> Keyword.put(:allow_credentials, allow_credentials)
-      |> WebAuthn.new_authentication_challenge()
+    # crypto-01: do NOT embed :allow_credentials in the PERSISTED challenge. The
+    # stored `public_key` is raw `:erlang.term_to_binary(cose_map)` bytes; embedding
+    # those verbatim into `%Wax.Challenge{}.allow_credentials` makes Wax use the raw
+    # binary AS the COSE key (its non-empty allow_credentials branch wins over the
+    # correctly-decoded 6th-arg credentials), so `Wax.CoseKey.verify` hits its
+    # unsupported-algorithm catch-all and ALWAYS rejects — even a valid signature.
+    # The enrolled credentials are supplied (decoded) ONLY at verify time via the
+    # adapter's `:allow_credentials` opt, which is Wax's documented
+    # self-discoverable-credentials contract (the 6th arg is consulted exactly when
+    # `challenge.allow_credentials == []`). The client still receives the allowed
+    # credential ids below — built independently from `authenticators`, NOT from the
+    # challenge struct.
+    challenge = WebAuthn.new_authentication_challenge(rp_opts)
 
     expires_at =
       DateTime.utc_now() |> DateTime.add(@challenge_ttl_seconds, :second)
@@ -169,7 +175,6 @@ defmodule Loopctl.WebAuthn.Reauth do
              challenge,
              allow_credentials: [{authenticator.credential_id, authenticator.public_key}]
            ),
-         :ok <- check_counter(authenticator.sign_count, new_count),
          {:ok, updated} <- persist_counter(authenticator, new_count) do
       {:ok, %{signature: signature, sign_count: new_count, authenticator: updated}}
     else
@@ -209,22 +214,33 @@ defmodule Loopctl.WebAuthn.Reauth do
 
   defp assert_consumed(_repo, _changes), do: {:error, :challenge_not_found}
 
-  # WebAuthn §7.2 step 17: reject cloned/replayed authenticators. A counter
-  # of 0/0 means the authenticator does not implement a signature counter,
-  # which the spec permits; otherwise the new counter must strictly exceed
-  # the stored one.
-  defp check_counter(stored, new) when is_integer(stored) and is_integer(new) do
-    cond do
-      new == 0 and stored == 0 -> :ok
-      new > stored -> :ok
-      true -> {:error, :counter_regression}
-    end
-  end
+  # crypto-01: ATOMIC counter check-and-persist. A single conditional UPDATE both
+  # enforces monotonicity and persists the new counter, closing the TOCTOU where
+  # two concurrent assertions from a cloned/replayed authenticator both read the
+  # old counter, both pass a separate check, and both rotate. 0 rows affected ⇒
+  # the counter did not strictly advance (clone/replay) ⇒ reject.
+  #
+  # WebAuthn §7.2 step 21: a stored/new counter of 0/0 means the authenticator
+  # implements no signature counter, which the spec permits — the `sign_count == 0`
+  # branch accepts that (and touches `last_used_at`) while still rejecting a drop
+  # from a previously-nonzero counter back to 0 (clone signal).
+  defp persist_counter(%RootAuthenticator{} = authenticator, new_count)
+       when is_integer(new_count) and new_count >= 0 do
+    now = DateTime.utc_now()
 
-  defp persist_counter(%RootAuthenticator{} = authenticator, new_count) do
-    authenticator
-    |> RootAuthenticator.touch_changeset(new_count)
-    |> AdminRepo.update()
+    query =
+      if new_count == 0 do
+        from(a in RootAuthenticator, where: a.id == ^authenticator.id and a.sign_count == 0)
+      else
+        from(a in RootAuthenticator,
+          where: a.id == ^authenticator.id and a.sign_count < ^new_count
+        )
+      end
+
+    case AdminRepo.update_all(query, set: [sign_count: new_count, last_used_at: now]) do
+      {1, _} -> {:ok, %{authenticator | sign_count: new_count, last_used_at: now}}
+      {0, _} -> {:error, :counter_regression}
+    end
   end
 
   defp fetch_uuid(params, key) do

--- a/lib/loopctl/web_authn/reauth.ex
+++ b/lib/loopctl/web_authn/reauth.ex
@@ -1,0 +1,283 @@
+defmodule Loopctl.WebAuthn.Reauth do
+  @moduledoc """
+  crypto-01 (GHSA-c3cw-5f7p-g76r) — challenge-bound WebAuthn
+  reauthentication for chain-of-custody-critical operations.
+
+  This replaces the placeholder that generated a brand-new server-side
+  challenge and immediately "verified" the same raw blob against an empty
+  authenticator list (no challenge binding, no signature check). The real
+  ceremony is two-step and mirrors the signup registration ceremony:
+
+    1. `issue_challenge/2` generates an authentication challenge via the
+       configured `Loopctl.WebAuthn` adapter, binds the tenant's enrolled
+       `RootAuthenticator` credentials to it (`allow_credentials`), stores
+       it server-side (`ReauthChallenge`, short TTL, single-use) and hands
+       the opaque `challenge_id` + allowed credential ids to the client.
+
+    2. `verify_and_consume/3` atomically consumes the STORED challenge
+       (single-use — a racing/duplicate attempt sees zero rows), looks up
+       the enrolled authenticator for THIS tenant by `credential_id`
+       (rejecting unknown/foreign credentials), verifies the assertion
+       against the stored challenge and the authenticator's stored COSE
+       public key (origin + RP-ID + signature), rejects sign-counter
+       regression, and persists the new counter on success.
+
+  Every function fails CLOSED: any decode error, missing/expired/reused
+  challenge, unknown credential, invalid signature, or counter regression
+  returns `{:error, reason}` and rotates nothing.
+
+  All queries run on `Loopctl.AdminRepo` and are explicitly scoped by
+  `tenant_id`, matching `Loopctl.Tenants.RootAuthenticators`.
+  """
+
+  import Ecto.Query
+
+  require Logger
+
+  alias Ecto.Multi
+  alias Loopctl.AdminRepo
+  alias Loopctl.Tenants.RootAuthenticator
+  alias Loopctl.Tenants.RootAuthenticators
+  alias Loopctl.WebAuthn
+  alias Loopctl.WebAuthn.ReauthChallenge
+
+  # Reauth challenges are short-lived — the operator has just clicked
+  # "rotate" and is expected to touch their authenticator immediately.
+  @challenge_ttl_seconds 300
+
+  @type issue_result :: %{
+          challenge_id: Ecto.UUID.t(),
+          challenge: String.t(),
+          allowed_credentials: [String.t()],
+          rp_id: String.t() | nil,
+          expires_at: DateTime.t()
+        }
+
+  @type assertion_params :: %{
+          optional(String.t()) => String.t()
+        }
+
+  @doc "TTL (seconds) applied to freshly issued reauth challenges."
+  @spec challenge_ttl_seconds() :: pos_integer()
+  def challenge_ttl_seconds, do: @challenge_ttl_seconds
+
+  @doc """
+  Issues a reauth challenge bound to `tenant_id` for `purpose`.
+
+  Loads the tenant's enrolled root authenticators, embeds them as
+  `allow_credentials` in a fresh authentication challenge, persists the
+  challenge server-side (single-use, TTL-bounded), and returns the opaque
+  handle plus the base64url credential ids the client should offer to
+  `navigator.credentials.get()`.
+
+  Returns `{:error, :no_authenticators}` when the tenant has enrolled no
+  root authenticator (nothing could authorize the ceremony).
+  """
+  @spec issue_challenge(Ecto.UUID.t(), String.t()) ::
+          {:ok, issue_result()} | {:error, term()}
+  def issue_challenge(tenant_id, purpose)
+      when is_binary(tenant_id) and is_binary(purpose) do
+    case RootAuthenticators.list_by_tenant(tenant_id) do
+      [] ->
+        {:error, :no_authenticators}
+
+      authenticators ->
+        do_issue_challenge(tenant_id, purpose, authenticators)
+    end
+  end
+
+  defp do_issue_challenge(tenant_id, purpose, authenticators) do
+    rp_opts = WebAuthn.rp_opts()
+
+    allow_credentials =
+      Enum.map(authenticators, fn auth -> {auth.credential_id, auth.public_key} end)
+
+    challenge =
+      rp_opts
+      |> Keyword.put(:allow_credentials, allow_credentials)
+      |> WebAuthn.new_authentication_challenge()
+
+    expires_at =
+      DateTime.utc_now() |> DateTime.add(@challenge_ttl_seconds, :second)
+
+    attrs = %{
+      purpose: purpose,
+      challenge: :erlang.term_to_binary(challenge),
+      expires_at: expires_at
+    }
+
+    case %ReauthChallenge{tenant_id: tenant_id}
+         |> ReauthChallenge.create_changeset(attrs)
+         |> AdminRepo.insert() do
+      {:ok, stored} ->
+        {:ok,
+         %{
+           challenge_id: stored.id,
+           challenge: encode_challenge_bytes(challenge),
+           allowed_credentials:
+             Enum.map(authenticators, &Base.url_encode64(&1.credential_id, padding: false)),
+           rp_id: Keyword.get(rp_opts, :rp_id),
+           expires_at: expires_at
+         }}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
+  end
+
+  @doc """
+  Verifies a WebAuthn assertion against a previously issued, STORED
+  challenge and consumes that challenge (single-use).
+
+  `params` is the raw request body for the assertion, with base64url
+  string values under the keys:
+
+    - `"challenge_id"`      — the opaque handle from `issue_challenge/2`
+    - `"credential_id"`     — the asserting credential id
+    - `"authenticator_data"`— raw authenticator data
+    - `"signature"`         — the assertion signature
+    - `"client_data_json"`  — the raw client data JSON
+
+  On success returns `{:ok, %{signature: binary(), sign_count: n,
+  authenticator: %RootAuthenticator{}}}` — `signature` is the genuinely
+  verified assertion signature, suitable for persistence as the rotation
+  proof. On any failure returns `{:error, reason}` and rotates nothing;
+  the challenge is consumed regardless (one challenge authorizes at most
+  one attempt).
+  """
+  @spec verify_and_consume(Ecto.UUID.t(), String.t(), map()) ::
+          {:ok, %{signature: binary(), sign_count: non_neg_integer(), authenticator: term()}}
+          | {:error, term()}
+  def verify_and_consume(tenant_id, purpose, params)
+      when is_binary(tenant_id) and is_binary(purpose) and is_map(params) do
+    with {:ok, challenge_id} <- fetch_uuid(params, "challenge_id"),
+         {:ok, credential_id} <- fetch_b64(params, "credential_id"),
+         {:ok, authenticator_data} <- fetch_b64(params, "authenticator_data"),
+         {:ok, signature} <- fetch_b64(params, "signature"),
+         {:ok, client_data_json} <- fetch_b64(params, "client_data_json"),
+         {:ok, challenge} <- consume_challenge(tenant_id, purpose, challenge_id),
+         {:ok, authenticator} <-
+           RootAuthenticators.get_by_credential_id(tenant_id, credential_id),
+         {:ok, %{sign_count: new_count}} <-
+           WebAuthn.verify_authentication(
+             %{
+               credential_id: credential_id,
+               authenticator_data: authenticator_data,
+               signature: signature,
+               client_data_json: client_data_json
+             },
+             challenge,
+             allow_credentials: [{authenticator.credential_id, authenticator.public_key}]
+           ),
+         :ok <- check_counter(authenticator.sign_count, new_count),
+         {:ok, updated} <- persist_counter(authenticator, new_count) do
+      {:ok, %{signature: signature, sign_count: new_count, authenticator: updated}}
+    else
+      {:error, reason} = error ->
+        Logger.info("WebAuthn reauth rejected (#{purpose}): #{inspect(reason)}")
+        error
+    end
+  end
+
+  # Atomic single-use consume: a guarded `update_all` stamps `used_at`
+  # ONLY when the row is unused, unexpired, and in-tenant for this
+  # purpose, and the same statement's RETURNING (`select: c.challenge`)
+  # hands back the serialized challenge. A double-spend loser sees 0 rows.
+  defp consume_challenge(tenant_id, purpose, challenge_id) do
+    now = DateTime.utc_now()
+
+    consume_query =
+      from(c in ReauthChallenge,
+        where:
+          c.id == ^challenge_id and c.tenant_id == ^tenant_id and c.purpose == ^purpose and
+            is_nil(c.used_at) and c.expires_at > ^now,
+        select: c.challenge
+      )
+
+    Multi.new()
+    |> Multi.update_all(:consume, consume_query, set: [used_at: now])
+    |> Multi.run(:assert_consumed, &assert_consumed/2)
+    |> AdminRepo.transaction()
+    |> case do
+      {:ok, %{assert_consumed: challenge}} -> {:ok, challenge}
+      {:error, _step, reason, _changes} -> {:error, reason}
+    end
+  end
+
+  defp assert_consumed(_repo, %{consume: {1, [serialized]}}),
+    do: deserialize_challenge(serialized)
+
+  defp assert_consumed(_repo, _changes), do: {:error, :challenge_not_found}
+
+  # WebAuthn §7.2 step 17: reject cloned/replayed authenticators. A counter
+  # of 0/0 means the authenticator does not implement a signature counter,
+  # which the spec permits; otherwise the new counter must strictly exceed
+  # the stored one.
+  defp check_counter(stored, new) when is_integer(stored) and is_integer(new) do
+    cond do
+      new == 0 and stored == 0 -> :ok
+      new > stored -> :ok
+      true -> {:error, :counter_regression}
+    end
+  end
+
+  defp persist_counter(%RootAuthenticator{} = authenticator, new_count) do
+    authenticator
+    |> RootAuthenticator.touch_changeset(new_count)
+    |> AdminRepo.update()
+  end
+
+  defp fetch_uuid(params, key) do
+    case Map.get(params, key) do
+      value when is_binary(value) ->
+        case Ecto.UUID.cast(value) do
+          {:ok, uuid} -> {:ok, uuid}
+          :error -> {:error, {:invalid_field, key}}
+        end
+
+      _ ->
+        {:error, {:missing_field, key}}
+    end
+  end
+
+  defp fetch_b64(params, key) do
+    case Map.get(params, key) do
+      value when is_binary(value) and value != "" ->
+        decode_b64url(value, key)
+
+      _ ->
+        {:error, {:missing_field, key}}
+    end
+  end
+
+  defp decode_b64url(value, key) do
+    case Base.url_decode64(value, padding: false) do
+      {:ok, decoded} ->
+        {:ok, decoded}
+
+      :error ->
+        case Base.decode64(value, padding: false) do
+          {:ok, decoded} -> {:ok, decoded}
+          :error -> {:error, {:invalid_field, key}}
+        end
+    end
+  end
+
+  # The stored blob is our own `term_to_binary` output, not user input.
+  # `[:safe]` still guards against decoding funs/new atoms if the row were
+  # ever tampered with. A corrupt/undecodable blob fails CLOSED rather than
+  # letting a nil challenge reach the adapter.
+  defp deserialize_challenge(serialized) when is_binary(serialized) do
+    {:ok, :erlang.binary_to_term(serialized, [:safe])}
+  rescue
+    _ -> {:error, :challenge_corrupt}
+  end
+
+  defp encode_challenge_bytes(%{bytes: bytes}) when is_binary(bytes),
+    do: Base.url_encode64(bytes, padding: false)
+
+  defp encode_challenge_bytes(bytes) when is_binary(bytes),
+    do: Base.url_encode64(bytes, padding: false)
+
+  defp encode_challenge_bytes(_), do: ""
+end

--- a/lib/loopctl/web_authn/reauth_challenge.ex
+++ b/lib/loopctl/web_authn/reauth_challenge.ex
@@ -1,0 +1,61 @@
+defmodule Loopctl.WebAuthn.ReauthChallenge do
+  @moduledoc """
+  Schema for the `webauthn_reauth_challenges` table (crypto-01,
+  GHSA-c3cw-5f7p-g76r).
+
+  A reauth challenge is the server-minted, single-use, TTL-bounded handle
+  that makes WebAuthn reauthentication (currently audit-key rotation)
+  challenge-bound. The challenge-issuance step generates an authentication
+  challenge via the configured `Loopctl.WebAuthn.Behaviour` adapter,
+  serializes it into `challenge`, and returns the row `id` to the client.
+  The assertion step loads the row by `(id AND tenant_id AND purpose)`,
+  refuses it if missing/expired/used, atomically stamps `used_at`
+  (single-use), and verifies the client's assertion against the STORED
+  challenge — never a freshly generated one.
+
+  ## Tenant isolation (NOT via RLS here)
+
+  Every query runs on `Loopctl.AdminRepo` (BYPASSRLS), so the table's RLS
+  policy is never evaluated on this path. Isolation rests solely on the
+  explicit `tenant_id` predicates in `Loopctl.WebAuthn.Reauth`.
+
+  ## Fields
+
+  - `id`         -- binary UUID primary key; the opaque challenge handle
+  - `tenant_id`  -- FK to tenants (set programmatically, never cast)
+  - `purpose`    -- ceremony label, e.g. `"rotate_audit_key"`
+  - `challenge`  -- Erlang-term-binary encoded adapter challenge
+  - `expires_at` -- TTL boundary; a challenge past this is refused
+  - `used_at`    -- single-use stamp; non-nil ⇒ already consumed, refused
+  - `inserted_at`-- creation timestamp (no `updated_at`)
+  """
+
+  use Loopctl.Schema
+
+  @type t :: %__MODULE__{}
+
+  schema "webauthn_reauth_challenges" do
+    tenant_field()
+
+    field :purpose, :string
+    field :challenge, :binary
+    field :expires_at, :utc_datetime_usec
+    field :used_at, :utc_datetime_usec
+
+    timestamps(updated_at: false)
+  end
+
+  @cast_fields [:purpose, :challenge, :expires_at]
+
+  @doc """
+  Changeset for minting a new reauth challenge.
+
+  `tenant_id` is set programmatically and must not appear in attrs.
+  """
+  @spec create_changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
+  def create_changeset(challenge \\ %__MODULE__{}, attrs) do
+    challenge
+    |> cast(attrs, @cast_fields)
+    |> validate_required([:purpose, :challenge, :expires_at])
+  end
+end

--- a/lib/loopctl/web_authn/wax.ex
+++ b/lib/loopctl/web_authn/wax.ex
@@ -53,15 +53,36 @@ defmodule Loopctl.WebAuthn.Wax do
   end
 
   @impl true
-  def verify_authentication(payload, challenge, _opts) do
+  def verify_authentication(payload, challenge, opts) do
     credential_id = Map.fetch!(payload, :credential_id)
     auth_data = Map.fetch!(payload, :authenticator_data)
     signature = Map.fetch!(payload, :signature)
     client_data_json = Map.fetch!(payload, :client_data_json)
 
-    case Wax.authenticate(credential_id, auth_data, signature, client_data_json, challenge, []) do
-      {:ok, auth_data} -> {:ok, %{sign_count: auth_data.sign_count}}
-      {:error, _reason} -> {:error, :invalid_assertion}
+    # crypto-01: the enrolled credentials — `{credential_id, stored_public_key}`
+    # pairs — are threaded in via opts and their COSE keys decoded here so
+    # `Wax.authenticate/6` verifies the signature against a REAL enrolled key.
+    # Passing an empty list (the old placeholder) meant no key was ever loaded
+    # and the signature was never actually checked.
+    credentials =
+      opts
+      |> Keyword.get(:allow_credentials, [])
+      |> Enum.map(fn {cred_id, public_key} -> {cred_id, decode_cose_key(public_key)} end)
+
+    case Wax.authenticate(
+           credential_id,
+           auth_data,
+           signature,
+           client_data_json,
+           challenge,
+           credentials
+         ) do
+      {:ok, authenticator_data} ->
+        {:ok, %{sign_count: authenticator_data.sign_count}}
+
+      {:error, reason} ->
+        Logger.warning("WebAuthn authentication failed: #{inspect(reason)}")
+        {:error, :invalid_assertion}
     end
   end
 
@@ -86,5 +107,16 @@ defmodule Loopctl.WebAuthn.Wax do
   # round-trip without a second parser implementation.
   defp encode_cose_key(cose_key) when is_map(cose_key) do
     :erlang.term_to_binary(cose_key)
+  end
+
+  # Inverse of encode_cose_key/1. Already-decoded maps (e.g. supplied by a
+  # test double) pass through untouched. `[:safe]` guards against decoding
+  # funs / new atoms from a tampered row.
+  defp decode_cose_key(cose_key) when is_map(cose_key), do: cose_key
+
+  defp decode_cose_key(public_key) when is_binary(public_key) do
+    :erlang.binary_to_term(public_key, [:safe])
+  rescue
+    _ -> %{}
   end
 end

--- a/lib/loopctl/workers/reauth_challenge_cleanup_worker.ex
+++ b/lib/loopctl/workers/reauth_challenge_cleanup_worker.ex
@@ -1,0 +1,33 @@
+defmodule Loopctl.Workers.ReauthChallengeCleanupWorker do
+  @moduledoc """
+  crypto-01 — Oban worker that periodically deletes stale WebAuthn reauth
+  challenges.
+
+  Runs hourly via the Oban Cron plugin. Deletes every challenge past its
+  `expires_at` (which includes consumed ones, since a consumed challenge is
+  still TTL-bounded) to prevent unbounded table growth.
+  """
+
+  use Oban.Worker, queue: :cleanup, max_attempts: 3
+
+  import Ecto.Query
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.WebAuthn.ReauthChallenge
+
+  @impl Oban.Worker
+  def perform(_job) do
+    now = DateTime.utc_now()
+
+    {deleted_count, _} =
+      from(c in ReauthChallenge, where: c.expires_at < ^now or not is_nil(c.used_at))
+      |> AdminRepo.delete_all()
+
+    if deleted_count > 0 do
+      require Logger
+      Logger.info("ReauthChallengeCleanupWorker deleted #{deleted_count} stale challenges")
+    end
+
+    :ok
+  end
+end

--- a/lib/loopctl_web/controllers/tenant_audit_key_controller.ex
+++ b/lib/loopctl_web/controllers/tenant_audit_key_controller.ex
@@ -1,18 +1,51 @@
 defmodule LoopctlWeb.TenantAuditKeyController do
   @moduledoc """
-  US-26.0.2 — Public key retrieval and key rotation for tenant audit signing keys.
+  US-26.0.2 / crypto-01 — Public key retrieval and key rotation for tenant
+  audit signing keys.
 
   The public key endpoint is unauthenticated (intended for external
-  verification). The rotation endpoint requires WebAuthn + user role.
+  verification). Rotation is gated by a real, two-step, challenge-bound
+  WebAuthn reauthentication ceremony (GHSA-c3cw-5f7p-g76r):
+
+    1. `POST /tenants/:id/rotate-audit-key/challenge` issues an
+       authentication challenge bound to the tenant's enrolled root
+       authenticators and stores it server-side (single-use, short TTL).
+    2. `POST /tenants/:id/rotate-audit-key` verifies the client's assertion
+       against that STORED challenge (origin, RP-ID, signature against the
+       enrolled COSE key, sign-counter regression) before rotating.
+
+  Both steps require `user` role (enforced by the router pipeline + the
+  `RequireRole` plug) AND tenant ownership (checked here).
   """
 
   use LoopctlWeb, :controller
+  use OpenApiSpex.ControllerSpecs
 
+  alias Loopctl.ApiSpec.Schemas
   alias Loopctl.Tenants
-  alias Loopctl.WebAuthn
+  alias Loopctl.WebAuthn.Reauth
+
+  @rotate_purpose "rotate_audit_key"
 
   # Key management requires user role — agents must not rotate/bootstrap keys
-  plug LoopctlWeb.Plugs.RequireRole, [role: :user] when action in [:rotate, :bootstrap]
+  plug LoopctlWeb.Plugs.RequireRole,
+       [role: :user] when action in [:rotate, :bootstrap, :challenge]
+
+  tags(["Tenants"])
+
+  operation(:show,
+    summary: "Get tenant audit public key",
+    description:
+      "Returns the tenant's ed25519 audit signing public key as PEM (default) " <>
+        "or JWK (Accept: application/jwk+json). Public — no authentication required.",
+    parameters: [id: [in: :path, type: :string, description: "Tenant UUID"]],
+    security: [],
+    responses: %{
+      200 =>
+        {"Public key (PEM or JWK)", "application/x-pem-file", %OpenApiSpex.Schema{type: :string}},
+      404 => {"Not found", "application/json", Schemas.ErrorResponse}
+    }
+  )
 
   @doc """
   GET /api/v1/tenants/:id/audit_public_key
@@ -46,29 +79,102 @@ defmodule LoopctlWeb.TenantAuditKeyController do
     end
   end
 
+  operation(:challenge,
+    summary: "Issue an audit-key rotation reauth challenge",
+    description:
+      "Step 1 of the challenge-bound WebAuthn reauthentication ceremony. Issues " <>
+        "an authentication challenge bound to the tenant's enrolled root " <>
+        "authenticators, stores it server-side (single-use, short TTL) and returns " <>
+        "the opaque `challenge_id`, the base64url challenge bytes, and the allowed " <>
+        "credential ids. Requires user role and tenant ownership.",
+    parameters: [id: [in: :path, type: :string, description: "Tenant UUID"]],
+    responses: %{
+      200 => {"Reauth challenge", "application/json", Schemas.ReauthChallengeResponse},
+      403 => {"Forbidden", "application/json", Schemas.ErrorResponse},
+      422 => {"No enrolled authenticators", "application/json", Schemas.ErrorResponse}
+    }
+  )
+
+  @doc """
+  POST /api/v1/tenants/:id/rotate-audit-key/challenge
+
+  Step 1 of the reauth ceremony. Mints a server-side, single-use,
+  TTL-bounded authentication challenge bound to the caller's tenant and
+  returns the opaque handle plus allowed credential ids.
+  """
+  def challenge(conn, %{"id" => tenant_id}) do
+    if owns_tenant?(conn, tenant_id) do
+      case Reauth.issue_challenge(tenant_id, @rotate_purpose) do
+        {:ok, issued} ->
+          conn
+          |> put_status(:ok)
+          |> json(%{
+            data: %{
+              challenge_id: issued.challenge_id,
+              challenge: issued.challenge,
+              allowed_credentials: issued.allowed_credentials,
+              rp_id: issued.rp_id,
+              expires_at: issued.expires_at
+            }
+          })
+
+        {:error, :no_authenticators} ->
+          conn
+          |> put_status(:unprocessable_entity)
+          |> json(%{
+            error: %{
+              message: "Tenant has no enrolled root authenticator to authorize rotation",
+              code: "no_authenticators",
+              status: 422
+            }
+          })
+
+        {:error, _reason} ->
+          conn
+          |> put_status(:internal_server_error)
+          |> json(%{error: %{message: "Failed to issue reauth challenge", status: 500}})
+      end
+    else
+      forbidden(conn)
+    end
+  end
+
+  operation(:rotate,
+    summary: "Rotate the tenant audit signing key",
+    description:
+      "Step 2 of the challenge-bound WebAuthn reauthentication ceremony. Verifies " <>
+        "the assertion against the STORED challenge from step 1 (challenge binding, " <>
+        "origin, RP-ID, signature against the enrolled COSE key, sign-counter " <>
+        "regression) and, on success, rotates the ed25519 audit keypair. Requires " <>
+        "user role and tenant ownership.",
+    parameters: [id: [in: :path, type: :string, description: "Tenant UUID"]],
+    request_body: {"WebAuthn assertion", "application/json", Schemas.RotateAuditKeyRequest},
+    responses: %{
+      200 => {"Key rotated", "application/json", Schemas.AuditKeyResponse},
+      401 => {"WebAuthn required or failed", "application/json", Schemas.ErrorResponse},
+      403 => {"Forbidden", "application/json", Schemas.ErrorResponse},
+      404 => {"Not found", "application/json", Schemas.ErrorResponse},
+      422 => {"No audit key to rotate", "application/json", Schemas.ErrorResponse}
+    }
+  )
+
   @doc """
   POST /api/v1/tenants/:id/rotate-audit-key
 
-  Rotates the tenant's audit signing keypair. Requires:
-  1. Authenticated with user-role key (enforced by router pipeline)
+  Step 2 of the reauth ceremony. Rotates the tenant's audit signing
+  keypair. Requires:
+  1. Authenticated with a user-role key (enforced by router pipeline)
   2. Caller owns the target tenant (checked here)
-  3. Valid WebAuthn assertion in the request body
+  3. A WebAuthn assertion verified against a STORED challenge from step 1
   """
   def rotate(conn, %{"id" => tenant_id} = params) do
-    # Ownership check: caller must own the target tenant
-    caller_tenant_id =
-      case conn.assigns do
-        %{current_api_key: %{tenant_id: tid}} -> tid
-        _ -> nil
-      end
+    assertion = Map.get(params, "webauthn_assertion")
 
     cond do
-      caller_tenant_id != tenant_id ->
-        conn
-        |> put_status(:forbidden)
-        |> json(%{error: %{message: "Forbidden", status: 403}})
+      not owns_tenant?(conn, tenant_id) ->
+        forbidden(conn)
 
-      is_nil(Map.get(params, "webauthn_assertion")) ->
+      not is_map(assertion) ->
         conn
         |> put_status(:unauthorized)
         |> json(%{
@@ -80,57 +186,21 @@ defmodule LoopctlWeb.TenantAuditKeyController do
         })
 
       true ->
-        do_rotate(conn, tenant_id, params)
+        do_rotate(conn, tenant_id, assertion)
     end
   end
 
-  defp do_rotate(conn, tenant_id, params) do
-    assertion_b64 = Map.fetch!(params, "webauthn_assertion")
-    assertion_bytes = decode_assertion(assertion_b64)
+  defp do_rotate(conn, tenant_id, assertion) do
+    # Verify the assertion against the STORED challenge and the tenant's
+    # enrolled authenticator (challenge binding, signature, counter). The
+    # ceremony is single-use: the challenge is consumed here regardless of
+    # outcome. On success `verified.signature` is the genuinely verified
+    # assertion signature, persisted as the rotation proof.
+    case Reauth.verify_and_consume(tenant_id, @rotate_purpose, assertion) do
+      {:ok, verified} ->
+        rotate_after_reauth(conn, tenant_id, verified.signature)
 
-    # Verify the WebAuthn assertion against the tenant's enrolled authenticators
-    case verify_webauthn_assertion(tenant_id, assertion_bytes) do
-      {:ok, _} ->
-        case Tenants.rotate_audit_key(tenant_id, assertion_bytes) do
-          {:ok, tenant} ->
-            conn
-            |> put_status(:ok)
-            |> json(%{
-              data: %{
-                tenant_id: tenant.id,
-                audit_signing_public_key: Base.encode64(tenant.audit_signing_public_key),
-                rotated_at: tenant.audit_key_rotated_at
-              }
-            })
-
-          {:error, :not_found} ->
-            conn
-            |> put_status(:not_found)
-            |> json(%{error: %{message: "Not found", status: 404}})
-
-          {:error, :no_existing_key} ->
-            conn
-            |> put_status(:unprocessable_entity)
-            |> json(%{error: %{message: "No audit key to rotate", status: 422}})
-
-          {:error, {:audit_key_storage_failed, _reason}} ->
-            conn
-            |> put_status(:internal_server_error)
-            |> json(%{
-              error: %{
-                message: "Failed to store the new audit key. Please retry.",
-                code: "audit_key_storage_failed",
-                status: 500
-              }
-            })
-
-          {:error, _reason} ->
-            conn
-            |> put_status(:internal_server_error)
-            |> json(%{error: %{message: "Key rotation failed", status: 500}})
-        end
-
-      {:error, _} ->
+      {:error, _reason} ->
         conn
         |> put_status(:unauthorized)
         |> json(%{
@@ -143,22 +213,61 @@ defmodule LoopctlWeb.TenantAuditKeyController do
     end
   end
 
-  defp verify_webauthn_assertion(tenant_id, assertion_bytes) do
-    # Use the WebAuthn adapter to verify the assertion. For now,
-    # we pass the assertion as a payload map that the adapter expects.
-    challenge = WebAuthn.new_authentication_challenge([])
+  defp rotate_after_reauth(conn, tenant_id, rotation_signature) do
+    case Tenants.rotate_audit_key(tenant_id, rotation_signature) do
+      {:ok, tenant} ->
+        conn
+        |> put_status(:ok)
+        |> json(%{
+          data: %{
+            tenant_id: tenant.id,
+            audit_signing_public_key: Base.encode64(tenant.audit_signing_public_key),
+            rotated_at: tenant.audit_key_rotated_at
+          }
+        })
 
-    WebAuthn.verify_authentication(
-      %{
-        credential_id: assertion_bytes,
-        authenticator_data: assertion_bytes,
-        signature: assertion_bytes,
-        client_data_json: assertion_bytes
-      },
-      challenge,
-      tenant_id: tenant_id
-    )
+      {:error, :not_found} ->
+        conn
+        |> put_status(:not_found)
+        |> json(%{error: %{message: "Not found", status: 404}})
+
+      {:error, :no_existing_key} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{error: %{message: "No audit key to rotate", status: 422}})
+
+      {:error, {:audit_key_storage_failed, _reason}} ->
+        conn
+        |> put_status(:internal_server_error)
+        |> json(%{
+          error: %{
+            message: "Failed to store the new audit key. Please retry.",
+            code: "audit_key_storage_failed",
+            status: 500
+          }
+        })
+
+      {:error, _reason} ->
+        conn
+        |> put_status(:internal_server_error)
+        |> json(%{error: %{message: "Key rotation failed", status: 500}})
+    end
   end
+
+  operation(:bootstrap,
+    summary: "Bootstrap an audit signing keypair for a legacy tenant",
+    description:
+      "Generates the initial ed25519 audit keypair for a tenant that predates the " <>
+        "Chain of Custody v2 signup ceremony. Requires user role and tenant " <>
+        "ownership. Refuses (409) if a key already exists — use rotate-audit-key.",
+    parameters: [id: [in: :path, type: :string, description: "Tenant UUID"]],
+    responses: %{
+      200 => {"Audit keypair bootstrapped", "application/json", Schemas.AuditKeyResponse},
+      403 => {"Forbidden", "application/json", Schemas.ErrorResponse},
+      404 => {"Not found", "application/json", Schemas.ErrorResponse},
+      409 => {"Key already exists", "application/json", Schemas.ErrorResponse}
+    }
+  )
 
   @doc """
   POST /api/v1/tenants/:id/bootstrap-audit-key
@@ -168,18 +277,10 @@ defmodule LoopctlWeb.TenantAuditKeyController do
   the target tenant. Refuses if a key already exists.
   """
   def bootstrap(conn, %{"id" => tenant_id}) do
-    caller_tenant_id =
-      case conn.assigns do
-        %{current_api_key: %{tenant_id: tid}} -> tid
-        _ -> nil
-      end
-
-    if caller_tenant_id != tenant_id do
-      conn
-      |> put_status(:forbidden)
-      |> json(%{error: %{message: "Forbidden", status: 403}})
-    else
+    if owns_tenant?(conn, tenant_id) do
       do_bootstrap(conn, tenant_id)
+    else
+      forbidden(conn)
     end
   end
 
@@ -249,12 +350,19 @@ defmodule LoopctlWeb.TenantAuditKeyController do
     }
   end
 
-  defp decode_assertion(assertion) when is_binary(assertion) do
-    case Base.decode64(assertion) do
-      {:ok, bytes} -> bytes
-      :error -> assertion
+  # Ownership check: the caller's user-role key must belong to the target
+  # tenant. This is the authorization gate that sits alongside (never
+  # replaces) the WebAuthn crypto layer.
+  defp owns_tenant?(conn, tenant_id) do
+    case conn.assigns do
+      %{current_api_key: %{tenant_id: tid}} -> tid == tenant_id
+      _ -> false
     end
   end
 
-  defp decode_assertion(_), do: <<>>
+  defp forbidden(conn) do
+    conn
+    |> put_status(:forbidden)
+    |> json(%{error: %{message: "Forbidden", status: 403}})
+  end
 end

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -116,6 +116,7 @@ defmodule LoopctlWeb.Router do
 
     get "/tenants/me", TenantController, :show
     patch "/tenants/me", TenantController, :update
+    post "/tenants/:id/rotate-audit-key/challenge", TenantAuditKeyController, :challenge
     post "/tenants/:id/rotate-audit-key", TenantAuditKeyController, :rotate
     post "/tenants/:id/bootstrap-audit-key", TenantAuditKeyController, :bootstrap
 

--- a/priv/repo/migrations/20260702120000_create_webauthn_reauth_challenges.exs
+++ b/priv/repo/migrations/20260702120000_create_webauthn_reauth_challenges.exs
@@ -1,0 +1,56 @@
+defmodule Loopctl.Repo.Migrations.CreateWebauthnReauthChallenges do
+  @moduledoc """
+  crypto-01 (GHSA-c3cw-5f7p-g76r) — creates `webauthn_reauth_challenges`.
+
+  Backs the two-step, challenge-bound WebAuthn reauthentication ceremony
+  that gates chain-of-custody-critical operations (currently audit-key
+  rotation). The rotate endpoint's challenge-issuance step mints a row
+  here whose server-generated `id` IS the opaque handle returned to the
+  client; the client echoes it on the assertion step, and the assertion
+  is verified against the STORED challenge (never a self-generated one).
+
+  Single-use (`used_at`) and TTL-bounded (`expires_at`), mirroring the
+  `knowledge_bulk_delete_tokens` frozen-token pattern.
+
+  ## Tenant isolation (NOT via RLS here)
+
+  Every query against this table runs on `Loopctl.AdminRepo` (BYPASSRLS),
+  so the RLS policy enabled below is NEVER evaluated on the live path and
+  is not an active backstop — tenant isolation rests solely on the
+  explicit `tenant_id` predicates in `Loopctl.WebAuthn.Reauth`. The policy
+  is kept for defense-in-depth / future RLS-repo use.
+  """
+
+  use Ecto.Migration
+  import Loopctl.Repo.RlsHelpers
+
+  def change do
+    create table(:webauthn_reauth_challenges, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      add :tenant_id,
+          references(:tenants, type: :binary_id, on_delete: :delete_all),
+          null: false
+
+      # Ceremony this challenge authorizes, e.g. "rotate_audit_key".
+      add :purpose, :string, null: false
+
+      # Opaque, adapter-produced authentication challenge, stored as
+      # Erlang-term-binary so it round-trips back to the WebAuthn adapter
+      # for verification (bytes + rp_id + origin + timeout).
+      add :challenge, :bytea, null: false
+
+      add :expires_at, :utc_datetime_usec, null: false
+      add :used_at, :utc_datetime_usec
+
+      # Only `inserted_at` — challenges are immutable except for the
+      # single-use `used_at` stamp, so no `updated_at`.
+      timestamps(type: :utc_datetime_usec, updated_at: false)
+    end
+
+    create index(:webauthn_reauth_challenges, [:tenant_id])
+    create index(:webauthn_reauth_challenges, [:expires_at])
+
+    enable_rls(:webauthn_reauth_challenges)
+  end
+end

--- a/test/loopctl/web_authn/reauth_test.exs
+++ b/test/loopctl/web_authn/reauth_test.exs
@@ -1,0 +1,233 @@
+defmodule Loopctl.WebAuthn.ReauthTest do
+  @moduledoc """
+  crypto-01 (GHSA-c3cw-5f7p-g76r) — challenge-bound WebAuthn reauth.
+
+  Verifies the two-step ceremony: a challenge is issued + stored, and an
+  assertion is only accepted against that STORED, unexpired, single-use
+  challenge for an enrolled, in-tenant credential — with sign-counter
+  regression rejected. The WebAuthn adapter is stubbed via `MockWebAuthn`
+  (config/test.exs), never `Application.put_env`.
+  """
+
+  use Loopctl.DataCase, async: true
+
+  import Loopctl.Fixtures
+  import Mox
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Tenants.RootAuthenticators
+  alias Loopctl.WebAuthn.Reauth
+  alias Loopctl.WebAuthn.ReauthChallenge
+
+  setup :verify_on_exit!
+
+  @purpose "rotate_audit_key"
+
+  defp assertion_params(challenge_id, credential_id, overrides \\ %{}) do
+    Map.merge(
+      %{
+        "challenge_id" => challenge_id,
+        "credential_id" => Base.url_encode64(credential_id, padding: false),
+        "authenticator_data" => Base.url_encode64(:crypto.strong_rand_bytes(37), padding: false),
+        "signature" => Base.url_encode64(:crypto.strong_rand_bytes(64), padding: false),
+        "client_data_json" => Base.url_encode64(~s({"type":"webauthn.get"}), padding: false)
+      },
+      overrides
+    )
+  end
+
+  describe "issue_challenge/2" do
+    test "stores a single-use challenge bound to the tenant and returns credential ids" do
+      tenant = fixture(:tenant)
+      auth = fixture(:root_authenticator, tenant_id: tenant.id)
+
+      assert {:ok, issued} = Reauth.issue_challenge(tenant.id, @purpose)
+      assert is_binary(issued.challenge_id)
+      assert issued.challenge != ""
+
+      assert Base.url_encode64(auth.credential_id, padding: false) in issued.allowed_credentials
+
+      assert DateTime.compare(issued.expires_at, DateTime.utc_now()) == :gt
+    end
+
+    test "refuses when the tenant has no enrolled authenticator" do
+      tenant = fixture(:tenant)
+      assert {:error, :no_authenticators} = Reauth.issue_challenge(tenant.id, @purpose)
+    end
+  end
+
+  describe "verify_and_consume/3 — happy path" do
+    test "verifies against the stored challenge and persists the new counter" do
+      tenant = fixture(:tenant)
+      auth = fixture(:root_authenticator, tenant_id: tenant.id, sign_count: 0)
+
+      {:ok, issued} = Reauth.issue_challenge(tenant.id, @purpose)
+
+      expect(Loopctl.MockWebAuthn, :verify_authentication, fn payload, _challenge, opts ->
+        # The enrolled credential + its stored COSE key must be threaded in
+        # (never an empty allow list — that was the placeholder bug).
+        assert [{cred_id, pub}] = Keyword.fetch!(opts, :allow_credentials)
+        assert cred_id == auth.credential_id
+        assert pub == auth.public_key
+        assert payload.credential_id == auth.credential_id
+        {:ok, %{sign_count: 7}}
+      end)
+
+      params = assertion_params(issued.challenge_id, auth.credential_id)
+
+      assert {:ok, result} = Reauth.verify_and_consume(tenant.id, @purpose, params)
+      assert result.sign_count == 7
+      assert is_binary(result.signature)
+
+      {:ok, reloaded} = RootAuthenticators.get_by_credential_id(tenant.id, auth.credential_id)
+      assert reloaded.sign_count == 7
+      assert reloaded.last_used_at != nil
+    end
+
+    test "a challenge is single-use — replay is rejected" do
+      tenant = fixture(:tenant)
+      auth = fixture(:root_authenticator, tenant_id: tenant.id, sign_count: 0)
+      {:ok, issued} = Reauth.issue_challenge(tenant.id, @purpose)
+
+      stub(Loopctl.MockWebAuthn, :verify_authentication, fn _p, _c, _o ->
+        {:ok, %{sign_count: 3}}
+      end)
+
+      params = assertion_params(issued.challenge_id, auth.credential_id)
+
+      assert {:ok, _} = Reauth.verify_and_consume(tenant.id, @purpose, params)
+      # Same challenge again → consumed, refused.
+      assert {:error, :challenge_not_found} =
+               Reauth.verify_and_consume(tenant.id, @purpose, params)
+    end
+  end
+
+  describe "verify_and_consume/3 — rejections" do
+    test "rejects when no challenge was ever issued" do
+      tenant = fixture(:tenant)
+      auth = fixture(:root_authenticator, tenant_id: tenant.id)
+
+      params = assertion_params(Ecto.UUID.generate(), auth.credential_id)
+
+      assert {:error, :challenge_not_found} =
+               Reauth.verify_and_consume(tenant.id, @purpose, params)
+    end
+
+    test "rejects an expired challenge" do
+      tenant = fixture(:tenant)
+      auth = fixture(:root_authenticator, tenant_id: tenant.id)
+      {:ok, issued} = Reauth.issue_challenge(tenant.id, @purpose)
+
+      # Backdate the stored challenge past its TTL.
+      import Ecto.Query
+
+      from(c in ReauthChallenge, where: c.id == ^issued.challenge_id)
+      |> AdminRepo.update_all(set: [expires_at: DateTime.add(DateTime.utc_now(), -1, :second)])
+
+      params = assertion_params(issued.challenge_id, auth.credential_id)
+
+      assert {:error, :challenge_not_found} =
+               Reauth.verify_and_consume(tenant.id, @purpose, params)
+    end
+
+    test "fails closed on a corrupt stored challenge (never a nil challenge to the adapter)" do
+      tenant = fixture(:tenant)
+      auth = fixture(:root_authenticator, tenant_id: tenant.id)
+
+      # Insert a challenge whose blob is NOT valid term_to_binary output.
+      {:ok, stored} =
+        %ReauthChallenge{tenant_id: tenant.id}
+        |> ReauthChallenge.create_changeset(%{
+          purpose: @purpose,
+          challenge: <<0, 1, 2, 3>>,
+          expires_at: DateTime.add(DateTime.utc_now(), 300, :second)
+        })
+        |> AdminRepo.insert()
+
+      params = assertion_params(stored.id, auth.credential_id)
+
+      assert {:error, :challenge_corrupt} =
+               Reauth.verify_and_consume(tenant.id, @purpose, params)
+    end
+
+    test "rejects an unknown / unenrolled credential id" do
+      tenant = fixture(:tenant)
+      _auth = fixture(:root_authenticator, tenant_id: tenant.id)
+      {:ok, issued} = Reauth.issue_challenge(tenant.id, @purpose)
+
+      params = assertion_params(issued.challenge_id, :crypto.strong_rand_bytes(16))
+
+      assert {:error, :not_found} = Reauth.verify_and_consume(tenant.id, @purpose, params)
+    end
+
+    test "rejects sign-counter regression and does NOT bump the stored counter" do
+      tenant = fixture(:tenant)
+      auth = fixture(:root_authenticator, tenant_id: tenant.id, sign_count: 10)
+      {:ok, issued} = Reauth.issue_challenge(tenant.id, @purpose)
+
+      expect(Loopctl.MockWebAuthn, :verify_authentication, fn _p, _c, _o ->
+        {:ok, %{sign_count: 3}}
+      end)
+
+      params = assertion_params(issued.challenge_id, auth.credential_id)
+
+      assert {:error, :counter_regression} =
+               Reauth.verify_and_consume(tenant.id, @purpose, params)
+
+      {:ok, reloaded} = RootAuthenticators.get_by_credential_id(tenant.id, auth.credential_id)
+      assert reloaded.sign_count == 10
+    end
+
+    test "rejects an invalid signature and does NOT bump the stored counter" do
+      tenant = fixture(:tenant)
+      auth = fixture(:root_authenticator, tenant_id: tenant.id, sign_count: 4)
+      {:ok, issued} = Reauth.issue_challenge(tenant.id, @purpose)
+
+      expect(Loopctl.MockWebAuthn, :verify_authentication, fn _p, _c, _o ->
+        {:error, :invalid_assertion}
+      end)
+
+      params = assertion_params(issued.challenge_id, auth.credential_id)
+
+      assert {:error, :invalid_assertion} =
+               Reauth.verify_and_consume(tenant.id, @purpose, params)
+
+      {:ok, reloaded} = RootAuthenticators.get_by_credential_id(tenant.id, auth.credential_id)
+      assert reloaded.sign_count == 4
+    end
+  end
+
+  describe "tenant isolation" do
+    test "tenant B cannot consume tenant A's challenge, even with a valid-looking assertion" do
+      tenant_a = fixture(:tenant, %{slug: "reauth-a"})
+      tenant_b = fixture(:tenant, %{slug: "reauth-b"})
+
+      auth_a = fixture(:root_authenticator, tenant_id: tenant_a.id)
+      # tenant B has its own authenticator, unrelated to A's challenge.
+      _auth_b = fixture(:root_authenticator, tenant_id: tenant_b.id)
+
+      {:ok, issued} = Reauth.issue_challenge(tenant_a.id, @purpose)
+
+      # Tenant B replays A's challenge_id → the consume query is scoped by
+      # tenant_id, so it finds nothing.
+      params = assertion_params(issued.challenge_id, auth_a.credential_id)
+
+      assert {:error, :challenge_not_found} =
+               Reauth.verify_and_consume(tenant_b.id, @purpose, params)
+    end
+
+    test "issue_challenge only offers the calling tenant's credentials" do
+      tenant_a = fixture(:tenant, %{slug: "reauth-c"})
+      tenant_b = fixture(:tenant, %{slug: "reauth-d"})
+
+      auth_a = fixture(:root_authenticator, tenant_id: tenant_a.id)
+      auth_b = fixture(:root_authenticator, tenant_id: tenant_b.id)
+
+      {:ok, issued} = Reauth.issue_challenge(tenant_a.id, @purpose)
+
+      assert Base.url_encode64(auth_a.credential_id, padding: false) in issued.allowed_credentials
+
+      refute Base.url_encode64(auth_b.credential_id, padding: false) in issued.allowed_credentials
+    end
+  end
+end

--- a/test/loopctl/web_authn/reauth_test.exs
+++ b/test/loopctl/web_authn/reauth_test.exs
@@ -355,6 +355,58 @@ defmodule Loopctl.WebAuthn.ReauthTest do
       {:ok, r3} = RootAuthenticators.get_by_credential_id(tenant.id, auth.credential_id)
       assert r3.sign_count == 6
     end
+
+    test "an asserted counter of 0 against a NONZERO stored counter is rejected (FIDO2 clone signal)" do
+      # The exact §7.2 clone signal: an authenticator that previously reported a
+      # counter of 10 now reports 0. This must be refused and the stored counter
+      # must NOT be clobbered to 0. Guards the `new_count == 0` branch: collapsing
+      # it (e.g. to `sign_count == ^id` with no counter predicate) would silently
+      # readmit the clone while the rest of the suite stayed green.
+      tenant = fixture(:tenant)
+      auth = fixture(:root_authenticator, tenant_id: tenant.id, sign_count: 10)
+
+      stub(Loopctl.MockWebAuthn, :verify_authentication, fn _p, _c, _o ->
+        {:ok, %{sign_count: 0}}
+      end)
+
+      {:ok, issued} = Reauth.issue_challenge(tenant.id, @purpose)
+
+      assert {:error, :counter_regression} =
+               Reauth.verify_and_consume(
+                 tenant.id,
+                 @purpose,
+                 assertion_params(issued.challenge_id, auth.credential_id)
+               )
+
+      # Counter unchanged — NOT clobbered to 0.
+      {:ok, reloaded} = RootAuthenticators.get_by_credential_id(tenant.id, auth.credential_id)
+      assert reloaded.sign_count == 10
+    end
+
+    test "a 0/0 counter (authenticator without a counter) is accepted per spec" do
+      # Symmetric guard for the other collapse direction: folding the 0-branch into
+      # a bare `sign_count < new_count` would reject legitimate no-counter (0/0)
+      # authenticators. Stored 0 + asserted 0 must succeed.
+      tenant = fixture(:tenant)
+      auth = fixture(:root_authenticator, tenant_id: tenant.id, sign_count: 0)
+
+      stub(Loopctl.MockWebAuthn, :verify_authentication, fn _p, _c, _o ->
+        {:ok, %{sign_count: 0}}
+      end)
+
+      {:ok, issued} = Reauth.issue_challenge(tenant.id, @purpose)
+
+      assert {:ok, %{sign_count: 0}} =
+               Reauth.verify_and_consume(
+                 tenant.id,
+                 @purpose,
+                 assertion_params(issued.challenge_id, auth.credential_id)
+               )
+
+      {:ok, reloaded} = RootAuthenticators.get_by_credential_id(tenant.id, auth.credential_id)
+      assert reloaded.sign_count == 0
+      assert reloaded.last_used_at != nil
+    end
   end
 
   describe "tenant isolation" do

--- a/test/loopctl/web_authn/reauth_test.exs
+++ b/test/loopctl/web_authn/reauth_test.exs
@@ -18,6 +18,7 @@ defmodule Loopctl.WebAuthn.ReauthTest do
   alias Loopctl.Tenants.RootAuthenticators
   alias Loopctl.WebAuthn.Reauth
   alias Loopctl.WebAuthn.ReauthChallenge
+  alias Loopctl.WebAuthn.Wax, as: WaxAdapter
 
   setup :verify_on_exit!
 
@@ -34,6 +35,38 @@ defmodule Loopctl.WebAuthn.ReauthTest do
       },
       overrides
     )
+  end
+
+  # Builds a REAL FIDO2 assertion: syntactically valid authenticator_data +
+  # client_data_json bound to `challenge_bytes`, signed over
+  # `authData <> SHA256(clientDataJSON)` with the ES256 private key — exactly what
+  # Wax.authenticate/6 verifies. rp_id/origin match config/test.exs (localhost).
+  defp signed_assertion(challenge_id, credential_id, priv, challenge_bytes, sign_count) do
+    rp_id = "localhost"
+    origin = "http://localhost:4002"
+
+    # rp_id_hash(32) <> flags(UP|UV = 0x05) <> sign_count(4, big-endian). No
+    # attested credential data on an assertion, so the AT flag stays 0.
+    auth_data =
+      :crypto.hash(:sha256, rp_id) <> <<0x05>> <> <<sign_count::unsigned-big-integer-size(32)>>
+
+    client_data_json =
+      Jason.encode!(%{
+        "type" => "webauthn.get",
+        "challenge" => Base.url_encode64(challenge_bytes, padding: false),
+        "origin" => origin
+      })
+
+    message = auth_data <> :crypto.hash(:sha256, client_data_json)
+    signature = :crypto.sign(:ecdsa, :sha256, message, [priv, :secp256r1])
+
+    %{
+      "challenge_id" => challenge_id,
+      "credential_id" => Base.url_encode64(credential_id, padding: false),
+      "authenticator_data" => Base.url_encode64(auth_data, padding: false),
+      "signature" => Base.url_encode64(signature, padding: false),
+      "client_data_json" => Base.url_encode64(client_data_json, padding: false)
+    }
   end
 
   describe "issue_challenge/2" do
@@ -194,6 +227,133 @@ defmodule Loopctl.WebAuthn.ReauthTest do
 
       {:ok, reloaded} = RootAuthenticators.get_by_credential_id(tenant.id, auth.credential_id)
       assert reloaded.sign_count == 4
+    end
+  end
+
+  describe "verify_and_consume/3 — real Wax adapter (end-to-end crypto)" do
+    # Delegate the mock to the REAL Loopctl.WebAuthn.Wax adapter for this block so
+    # the full FIDO2 verification runs against genuine ES256 crypto — WITHOUT
+    # Application.put_env. This is the class of bug a mock-only suite cannot catch
+    # (crypto-01 CRITICAL): with the pre-fix code (raw COSE key embedded in the
+    # challenge's allow_credentials) every one of these {:ok, _} assertions FAILS.
+    setup do
+      stub(Loopctl.MockWebAuthn, :new_authentication_challenge, fn opts ->
+        WaxAdapter.new_authentication_challenge(opts)
+      end)
+
+      stub(Loopctl.MockWebAuthn, :verify_authentication, fn payload, challenge, opts ->
+        WaxAdapter.verify_authentication(payload, challenge, opts)
+      end)
+
+      # Synthetic P-256 / ES256 keypair enrolled exactly as production stores it.
+      {pub_point, priv} = :crypto.generate_key(:ecdh, :secp256r1)
+      <<4, x::binary-size(32), y::binary-size(32)>> = pub_point
+      cose_key = %{1 => 2, 3 => -7, -1 => 1, -2 => x, -3 => y}
+
+      tenant = fixture(:tenant)
+      credential_id = :crypto.strong_rand_bytes(16)
+
+      fixture(:root_authenticator,
+        tenant_id: tenant.id,
+        credential_id: credential_id,
+        public_key: :erlang.term_to_binary(cose_key),
+        sign_count: 0
+      )
+
+      %{tenant: tenant, credential_id: credential_id, priv: priv}
+    end
+
+    test "accepts a genuine ES256 signature and persists the counter", ctx do
+      {:ok, issued} = Reauth.issue_challenge(ctx.tenant.id, @purpose)
+      challenge_bytes = Base.url_decode64!(issued.challenge, padding: false)
+
+      params =
+        signed_assertion(issued.challenge_id, ctx.credential_id, ctx.priv, challenge_bytes, 1)
+
+      assert {:ok, result} = Reauth.verify_and_consume(ctx.tenant.id, @purpose, params)
+      assert result.sign_count == 1
+
+      {:ok, reloaded} = RootAuthenticators.get_by_credential_id(ctx.tenant.id, ctx.credential_id)
+      assert reloaded.sign_count == 1
+    end
+
+    test "rejects a signature from the wrong key (tampered), key not rotated", ctx do
+      {:ok, issued} = Reauth.issue_challenge(ctx.tenant.id, @purpose)
+      challenge_bytes = Base.url_decode64!(issued.challenge, padding: false)
+
+      # A well-formed DER signature from a DIFFERENT key — fails verification cleanly.
+      {_wrong_pub, wrong_priv} = :crypto.generate_key(:ecdh, :secp256r1)
+
+      params =
+        signed_assertion(issued.challenge_id, ctx.credential_id, wrong_priv, challenge_bytes, 1)
+
+      assert {:error, _} = Reauth.verify_and_consume(ctx.tenant.id, @purpose, params)
+
+      {:ok, reloaded} = RootAuthenticators.get_by_credential_id(ctx.tenant.id, ctx.credential_id)
+      assert reloaded.sign_count == 0
+    end
+
+    test "rejects a valid signature bound to the WRONG challenge", ctx do
+      {:ok, issued} = Reauth.issue_challenge(ctx.tenant.id, @purpose)
+
+      # Sign over random challenge bytes that don't match the stored challenge.
+      wrong_bytes = :crypto.strong_rand_bytes(32)
+
+      params =
+        signed_assertion(issued.challenge_id, ctx.credential_id, ctx.priv, wrong_bytes, 1)
+
+      assert {:error, _} = Reauth.verify_and_consume(ctx.tenant.id, @purpose, params)
+    end
+  end
+
+  describe "atomic sign-counter enforcement" do
+    test "a replayed counter is rejected while a strictly-increasing one persists" do
+      tenant = fixture(:tenant)
+      auth = fixture(:root_authenticator, tenant_id: tenant.id, sign_count: 0)
+
+      stub(Loopctl.MockWebAuthn, :verify_authentication, fn _p, _c, _o ->
+        {:ok, %{sign_count: 5}}
+      end)
+
+      {:ok, i1} = Reauth.issue_challenge(tenant.id, @purpose)
+
+      assert {:ok, _} =
+               Reauth.verify_and_consume(
+                 tenant.id,
+                 @purpose,
+                 assertion_params(i1.challenge_id, auth.credential_id)
+               )
+
+      {:ok, r1} = RootAuthenticators.get_by_credential_id(tenant.id, auth.credential_id)
+      assert r1.sign_count == 5
+
+      # Second assertion carrying the SAME counter (replay/clone) — the atomic
+      # conditional UPDATE matches 0 rows (5 < 5 is false) and rejects.
+      {:ok, i2} = Reauth.issue_challenge(tenant.id, @purpose)
+
+      assert {:error, :counter_regression} =
+               Reauth.verify_and_consume(
+                 tenant.id,
+                 @purpose,
+                 assertion_params(i2.challenge_id, auth.credential_id)
+               )
+
+      # A strictly-greater counter is accepted and persisted.
+      stub(Loopctl.MockWebAuthn, :verify_authentication, fn _p, _c, _o ->
+        {:ok, %{sign_count: 6}}
+      end)
+
+      {:ok, i3} = Reauth.issue_challenge(tenant.id, @purpose)
+
+      assert {:ok, _} =
+               Reauth.verify_and_consume(
+                 tenant.id,
+                 @purpose,
+                 assertion_params(i3.challenge_id, auth.credential_id)
+               )
+
+      {:ok, r3} = RootAuthenticators.get_by_credential_id(tenant.id, auth.credential_id)
+      assert r3.sign_count == 6
     end
   end
 

--- a/test/loopctl_web/controllers/tenant_audit_key_controller_test.exs
+++ b/test/loopctl_web/controllers/tenant_audit_key_controller_test.exs
@@ -9,6 +9,18 @@ defmodule LoopctlWeb.TenantAuditKeyControllerTest do
 
   setup :verify_on_exit!
 
+  # Builds the assertion request object with SEPARATE base64url fields
+  # (never one blob reused for all four values — that was the placeholder bug).
+  defp assertion_body(challenge_id, credential_id) do
+    %{
+      "challenge_id" => challenge_id,
+      "credential_id" => Base.url_encode64(credential_id, padding: false),
+      "authenticator_data" => Base.url_encode64(:crypto.strong_rand_bytes(37), padding: false),
+      "signature" => Base.url_encode64(:crypto.strong_rand_bytes(64), padding: false),
+      "client_data_json" => Base.url_encode64(~s({"type":"webauthn.get"}), padding: false)
+    }
+  end
+
   describe "GET /api/v1/tenants/:id/audit_public_key" do
     test "returns PEM format by default", %{conn: conn} do
       pub_key = :crypto.strong_rand_bytes(32)
@@ -97,24 +109,182 @@ defmodule LoopctlWeb.TenantAuditKeyControllerTest do
       assert json_response(conn, 403)["error"]["message"] == "Forbidden"
     end
 
-    test "rotates key when assertion is provided by tenant owner", %{conn: conn} do
+    test "rotates key via the two-step challenge-bound ceremony", %{conn: conn} do
       pub_key = :crypto.strong_rand_bytes(32)
       tenant = fixture(:tenant, %{audit_signing_public_key: pub_key})
+      auth = fixture(:root_authenticator, tenant_id: tenant.id, sign_count: 0)
       {raw_key, _api_key} = fixture(:api_key, tenant_id: tenant.id, role: :user)
 
       Mox.expect(Loopctl.MockSecrets, :set, fn _name, _value -> :ok end)
+
+      Mox.expect(Loopctl.MockWebAuthn, :verify_authentication, fn _payload, _challenge, opts ->
+        # Real enrolled credential threaded in — NOT an empty allow list.
+        assert [{cred_id, _pub}] = Keyword.fetch!(opts, :allow_credentials)
+        assert cred_id == auth.credential_id
+        {:ok, %{sign_count: 9}}
+      end)
+
+      authed = put_req_header(conn, "authorization", "Bearer #{raw_key}")
+
+      # Step 1: issue a challenge.
+      challenge_conn =
+        post(authed, ~p"/api/v1/tenants/#{tenant.id}/rotate-audit-key/challenge", %{})
+
+      challenge_data = json_response(challenge_conn, 200)["data"]
+      assert challenge_data["challenge_id"]
+
+      assert Base.url_encode64(auth.credential_id, padding: false) in challenge_data[
+               "allowed_credentials"
+             ]
+
+      # Step 2: assert against the stored challenge.
+      rotate_conn =
+        authed
+        |> post(~p"/api/v1/tenants/#{tenant.id}/rotate-audit-key", %{
+          "webauthn_assertion" =>
+            assertion_body(challenge_data["challenge_id"], auth.credential_id)
+        })
+
+      resp = json_response(rotate_conn, 200)
+      assert resp["data"]["tenant_id"] == tenant.id
+      assert resp["data"]["audit_signing_public_key"] != Base.encode64(pub_key)
+      assert resp["data"]["rotated_at"] != nil
+    end
+
+    test "rejects an assertion with no prior stored challenge", %{conn: conn} do
+      tenant = fixture(:tenant, %{audit_signing_public_key: :crypto.strong_rand_bytes(32)})
+      auth = fixture(:root_authenticator, tenant_id: tenant.id)
+      {raw_key, _api_key} = fixture(:api_key, tenant_id: tenant.id, role: :user)
 
       conn =
         conn
         |> put_req_header("authorization", "Bearer #{raw_key}")
         |> post(~p"/api/v1/tenants/#{tenant.id}/rotate-audit-key", %{
-          "webauthn_assertion" => Base.encode64(:crypto.strong_rand_bytes(64))
+          "webauthn_assertion" => assertion_body(Ecto.UUID.generate(), auth.credential_id)
         })
 
-      resp = json_response(conn, 200)
-      assert resp["data"]["tenant_id"] == tenant.id
-      assert resp["data"]["audit_signing_public_key"] != Base.encode64(pub_key)
-      assert resp["data"]["rotated_at"] != nil
+      assert json_response(conn, 401)["error"]["code"] == "webauthn_failed"
+    end
+
+    test "a challenge is single-use — the second attempt fails", %{conn: conn} do
+      tenant = fixture(:tenant, %{audit_signing_public_key: :crypto.strong_rand_bytes(32)})
+      auth = fixture(:root_authenticator, tenant_id: tenant.id, sign_count: 0)
+      {raw_key, _api_key} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+
+      Mox.stub(Loopctl.MockSecrets, :set, fn _name, _value -> :ok end)
+
+      Mox.stub(Loopctl.MockWebAuthn, :verify_authentication, fn _p, _c, _o ->
+        {:ok, %{sign_count: 2}}
+      end)
+
+      authed = put_req_header(conn, "authorization", "Bearer #{raw_key}")
+
+      challenge_data =
+        authed
+        |> post(~p"/api/v1/tenants/#{tenant.id}/rotate-audit-key/challenge", %{})
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      body = assertion_body(challenge_data["challenge_id"], auth.credential_id)
+
+      assert authed
+             |> post(~p"/api/v1/tenants/#{tenant.id}/rotate-audit-key", %{
+               "webauthn_assertion" => body
+             })
+             |> json_response(200)
+
+      # Replaying the same challenge is refused.
+      assert authed
+             |> post(~p"/api/v1/tenants/#{tenant.id}/rotate-audit-key", %{
+               "webauthn_assertion" => body
+             })
+             |> json_response(401)
+    end
+
+    test "rejects a foreign tenant's credential (tenant isolation)", %{conn: conn} do
+      tenant = fixture(:tenant, %{audit_signing_public_key: :crypto.strong_rand_bytes(32)})
+      _auth = fixture(:root_authenticator, tenant_id: tenant.id)
+      {raw_key, _api_key} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+
+      other = fixture(:tenant, %{slug: "other-ct"})
+      foreign_auth = fixture(:root_authenticator, tenant_id: other.id)
+
+      authed = put_req_header(conn, "authorization", "Bearer #{raw_key}")
+
+      challenge_data =
+        authed
+        |> post(~p"/api/v1/tenants/#{tenant.id}/rotate-audit-key/challenge", %{})
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      conn =
+        post(authed, ~p"/api/v1/tenants/#{tenant.id}/rotate-audit-key", %{
+          "webauthn_assertion" =>
+            assertion_body(challenge_data["challenge_id"], foreign_auth.credential_id)
+        })
+
+      assert json_response(conn, 401)["error"]["code"] == "webauthn_failed"
+    end
+
+    test "rejects sign-counter regression and does NOT rotate", %{conn: conn} do
+      pub_key = :crypto.strong_rand_bytes(32)
+      tenant = fixture(:tenant, %{audit_signing_public_key: pub_key})
+      auth = fixture(:root_authenticator, tenant_id: tenant.id, sign_count: 20)
+      {raw_key, _api_key} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+
+      Mox.stub(Loopctl.MockWebAuthn, :verify_authentication, fn _p, _c, _o ->
+        {:ok, %{sign_count: 5}}
+      end)
+
+      authed = put_req_header(conn, "authorization", "Bearer #{raw_key}")
+
+      challenge_data =
+        authed
+        |> post(~p"/api/v1/tenants/#{tenant.id}/rotate-audit-key/challenge", %{})
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      conn =
+        post(authed, ~p"/api/v1/tenants/#{tenant.id}/rotate-audit-key", %{
+          "webauthn_assertion" =>
+            assertion_body(challenge_data["challenge_id"], auth.credential_id)
+        })
+
+      assert json_response(conn, 401)["error"]["code"] == "webauthn_failed"
+
+      # Key unchanged.
+      {:ok, reloaded} = Loopctl.Tenants.get_tenant(tenant.id)
+      assert reloaded.audit_signing_public_key == pub_key
+    end
+
+    test "rejects an invalid signature and does NOT rotate", %{conn: conn} do
+      pub_key = :crypto.strong_rand_bytes(32)
+      tenant = fixture(:tenant, %{audit_signing_public_key: pub_key})
+      auth = fixture(:root_authenticator, tenant_id: tenant.id)
+      {raw_key, _api_key} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+
+      Mox.stub(Loopctl.MockWebAuthn, :verify_authentication, fn _p, _c, _o ->
+        {:error, :invalid_assertion}
+      end)
+
+      authed = put_req_header(conn, "authorization", "Bearer #{raw_key}")
+
+      challenge_data =
+        authed
+        |> post(~p"/api/v1/tenants/#{tenant.id}/rotate-audit-key/challenge", %{})
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      conn =
+        post(authed, ~p"/api/v1/tenants/#{tenant.id}/rotate-audit-key", %{
+          "webauthn_assertion" =>
+            assertion_body(challenge_data["challenge_id"], auth.credential_id)
+        })
+
+      assert json_response(conn, 401)["error"]["code"] == "webauthn_failed"
+
+      {:ok, reloaded} = Loopctl.Tenants.get_tenant(tenant.id)
+      assert reloaded.audit_signing_public_key == pub_key
     end
 
     test "rejects agent-role keys", %{conn: conn} do
@@ -142,6 +312,66 @@ defmodule LoopctlWeb.TenantAuditKeyControllerTest do
 
       conn2 = get(conn, "/api/v1/admin/tenants/#{Ecto.UUID.generate()}/secrets")
       assert conn2.status in [404, 400]
+    end
+  end
+
+  describe "POST /api/v1/tenants/:id/rotate-audit-key/challenge" do
+    test "issues a challenge for the tenant owner", %{conn: conn} do
+      tenant = fixture(:tenant, %{audit_signing_public_key: :crypto.strong_rand_bytes(32)})
+      auth = fixture(:root_authenticator, tenant_id: tenant.id)
+      {raw_key, _api_key} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_key}")
+        |> post(~p"/api/v1/tenants/#{tenant.id}/rotate-audit-key/challenge", %{})
+
+      data = json_response(conn, 200)["data"]
+      assert data["challenge_id"]
+      assert data["challenge"] != ""
+
+      assert Base.url_encode64(auth.credential_id, padding: false) in data["allowed_credentials"]
+    end
+
+    test "returns 422 when the tenant has no enrolled authenticator", %{conn: conn} do
+      tenant = fixture(:tenant, %{audit_signing_public_key: :crypto.strong_rand_bytes(32)})
+      {raw_key, _api_key} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_key}")
+        |> post(~p"/api/v1/tenants/#{tenant.id}/rotate-audit-key/challenge", %{})
+
+      assert json_response(conn, 422)["error"]["code"] == "no_authenticators"
+    end
+
+    test "rejects a caller who does not own the target tenant", %{conn: conn} do
+      tenant_a = fixture(:tenant, %{slug: "chal-a"})
+      tenant_b = fixture(:tenant, %{slug: "chal-b"})
+      _auth = fixture(:root_authenticator, tenant_id: tenant_b.id)
+      {raw_key, _api_key} = fixture(:api_key, tenant_id: tenant_a.id, role: :user)
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_key}")
+        |> post(~p"/api/v1/tenants/#{tenant_b.id}/rotate-audit-key/challenge", %{})
+
+      assert json_response(conn, 403)["error"]["message"] == "Forbidden"
+    end
+
+    test "rejects agent-role keys", %{conn: conn} do
+      tenant = fixture(:tenant, %{audit_signing_public_key: :crypto.strong_rand_bytes(32)})
+      agent = fixture(:agent, tenant_id: tenant.id)
+
+      {raw_key, _api_key} =
+        fixture(:api_key, tenant_id: tenant.id, agent_id: agent.id, role: :agent)
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_key}")
+        |> post(~p"/api/v1/tenants/#{tenant.id}/rotate-audit-key/challenge", %{})
+
+      assert json_response(conn, 403)
     end
   end
 end

--- a/test/loopctl_web/controllers/tenant_audit_key_controller_test.exs
+++ b/test/loopctl_web/controllers/tenant_audit_key_controller_test.exs
@@ -7,6 +7,9 @@ defmodule LoopctlWeb.TenantAuditKeyControllerTest do
 
   import Loopctl.Fixtures
 
+  alias Loopctl.Tenants
+  alias Loopctl.Tenants.RootAuthenticators
+
   setup :verify_on_exit!
 
   # Builds the assertion request object with SEPARATE base64url fields
@@ -253,8 +256,46 @@ defmodule LoopctlWeb.TenantAuditKeyControllerTest do
       assert json_response(conn, 401)["error"]["code"] == "webauthn_failed"
 
       # Key unchanged.
-      {:ok, reloaded} = Loopctl.Tenants.get_tenant(tenant.id)
+      {:ok, reloaded} = Tenants.get_tenant(tenant.id)
       assert reloaded.audit_signing_public_key == pub_key
+    end
+
+    test "rejects a counter-drop-to-zero (clone signal) and does NOT rotate", %{conn: conn} do
+      pub_key = :crypto.strong_rand_bytes(32)
+      tenant = fixture(:tenant, %{audit_signing_public_key: pub_key})
+      auth = fixture(:root_authenticator, tenant_id: tenant.id, sign_count: 10)
+      {raw_key, _api_key} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+
+      # Authenticator that previously reported counter 10 now reports 0 — the
+      # FIDO2 §7.2 clone signal. Must be refused; the key must NOT rotate.
+      Mox.stub(Loopctl.MockWebAuthn, :verify_authentication, fn _p, _c, _o ->
+        {:ok, %{sign_count: 0}}
+      end)
+
+      authed = put_req_header(conn, "authorization", "Bearer #{raw_key}")
+
+      challenge_data =
+        authed
+        |> post(~p"/api/v1/tenants/#{tenant.id}/rotate-audit-key/challenge", %{})
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      conn =
+        post(authed, ~p"/api/v1/tenants/#{tenant.id}/rotate-audit-key", %{
+          "webauthn_assertion" =>
+            assertion_body(challenge_data["challenge_id"], auth.credential_id)
+        })
+
+      assert json_response(conn, 401)["error"]["code"] == "webauthn_failed"
+
+      # Audit key unchanged, and the stored counter was NOT clobbered to 0.
+      {:ok, reloaded} = Tenants.get_tenant(tenant.id)
+      assert reloaded.audit_signing_public_key == pub_key
+
+      {:ok, reloaded_auth} =
+        RootAuthenticators.get_by_credential_id(tenant.id, auth.credential_id)
+
+      assert reloaded_auth.sign_count == 10
     end
 
     test "rejects an invalid signature and does NOT rotate", %{conn: conn} do
@@ -283,7 +324,7 @@ defmodule LoopctlWeb.TenantAuditKeyControllerTest do
 
       assert json_response(conn, 401)["error"]["code"] == "webauthn_failed"
 
-      {:ok, reloaded} = Loopctl.Tenants.get_tenant(tenant.id)
+      {:ok, reloaded} = Tenants.get_tenant(tenant.id)
       assert reloaded.audit_signing_public_key == pub_key
     end
 

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -25,6 +25,7 @@ defmodule Loopctl.Fixtures do
   alias Loopctl.Skills.Skill
   alias Loopctl.Skills.SkillResult
   alias Loopctl.Skills.SkillVersion
+  alias Loopctl.Tenants.RootAuthenticator
   alias Loopctl.Tenants.Tenant
   alias Loopctl.TokenUsage.Budget, as: TokenBudget
   alias Loopctl.TokenUsage.CostAnomaly
@@ -53,6 +54,24 @@ defmodule Loopctl.Fixtures do
         status: :active
       },
       Enum.into(attrs, %{})
+    )
+  end
+
+  def build(:root_authenticator, attrs) do
+    attrs = Enum.into(attrs, %{})
+
+    Map.merge(
+      %{
+        credential_id: :crypto.strong_rand_bytes(16),
+        # COSE public key persisted the same way the Wax adapter does —
+        # `:erlang.term_to_binary/1` of a COSE key map — so the reauth path
+        # can round-trip it. The mock WebAuthn adapter ignores it in tests.
+        public_key: :erlang.term_to_binary(%{1 => 2, 3 => -7}),
+        attestation_format: "none",
+        sign_count: 0,
+        friendly_name: "Test Authenticator #{System.unique_integer([:positive])}"
+      },
+      attrs
     )
   end
 
@@ -407,6 +426,24 @@ defmodule Loopctl.Fixtures do
     else
       tenant
     end
+  end
+
+  def fixture(:root_authenticator, attrs) do
+    attrs = Enum.into(attrs, %{})
+
+    {tenant_id, attrs} =
+      case Map.get(attrs, :tenant_id) do
+        nil ->
+          tenant = fixture(:tenant)
+          {tenant.id, Map.delete(attrs, :tenant_id)}
+
+        tid ->
+          {tid, Map.delete(attrs, :tenant_id)}
+      end
+
+    %RootAuthenticator{tenant_id: tenant_id}
+    |> RootAuthenticator.create_changeset(build(:root_authenticator, attrs))
+    |> AdminRepo.insert!()
   end
 
   def fixture(:agent, attrs) do


### PR DESCRIPTION
## Summary

Fixes the **placeholder** WebAuthn reauthentication that was supposed to gate
audit-key rotation (a chain-of-custody-critical operation) but performed **no
real crypto verification** — private advisory **GHSA-c3cw-5f7p-g76r** (crypto-01, HIGH).

### The vulnerability

`verify_webauthn_assertion/2` in `TenantAuditKeyController`:

- generated a **brand-new server-side challenge** (`new_authentication_challenge([])`)
  that was never sent to any client — no challenge binding;
- passed the **same raw assertion blob** as `credential_id`, `authenticator_data`,
  `signature`, *and* `client_data_json`;
- authenticated against an **EMPTY authenticator list**, so no enrolled
  `RootAuthenticator` was ever loaded, no signature was checked, no counter was
  checked.

An unverified blob was then stored as `rotation_signature`.

## The fix — a real, two-step, challenge-bound ceremony

Mirrors the existing signup registration ceremony.

**Step 1 — `POST /tenants/:id/rotate-audit-key/challenge`** (role `:user` + ownership)
issues an authentication challenge bound to the tenant's enrolled
`RootAuthenticator`s and **stores it server-side** in a new
`webauthn_reauth_challenges` table (single-use `used_at` stamp, short TTL,
tenant-scoped, `AdminRepo` — mirrors the `knowledge_bulk_delete_tokens`
frozen-token pattern). Returns the opaque `challenge_id` + allowed credential ids.

**Step 2 — `POST /tenants/:id/rotate-audit-key`** (role `:user` + ownership)
verifies the client's assertion **against the STORED challenge**:

- **atomic single-use consume** (guarded `update_all` stamping `used_at`; a
  double-spend loser sees 0 rows);
- looks up the enrolled authenticator by `(tenant_id, credential_id)` — rejects
  unknown / foreign-tenant credentials;
- the Wax adapter now calls `Wax.authenticate/6` with the **real
  `allow_credentials` list** (`{credential_id, stored COSE key}`), **not `[]`** —
  verifying origin + RP-ID + signature against the enrolled key;
- **rejects sign-counter regression** and persists the new counter on success;
- stores the **genuinely verified signature** as `rotation_signature`.

**Fails CLOSED** on any error (absent/expired/reused challenge, unknown credential,
invalid signature, counter regression, corrupt stored challenge) → `401`/`403`,
rotates nothing.

Existing `RequireRole :user` + tenant-ownership gates are preserved (this adds the
missing crypto layer). Adds an hourly Oban cleanup worker and OpenApiSpex docs for
the new endpoint + the real assertion body shape.

## Tests

- **happy path**: issue challenge → valid assertion (mocked adapter) against the
  STORED challenge + enrolled authenticator → rotation succeeds, counter persisted,
  real signature stored;
- **reject**: no prior / expired / reused challenge; unknown & foreign-tenant
  credential (**tenant isolation**: tenant A's authenticator can't authorize tenant
  B's rotation, and A's challenge can't be consumed by B); **counter regression**;
  **invalid signature** (mock error) → key NOT rotated; **challenge single-use**
  (replay fails); **corrupt stored challenge** fails closed;
- placeholder behavior gone (no self-generated-challenge path, no empty-authenticator
  call — a test asserts `allow_credentials` is non-empty and matches the enrolled key).

## Quality gate

`mix precommit` green locally: compile `--warnings-as-errors`, format,
`credo --strict`, `deps.audit`, dialyzer (0 new), **3244 tests, 0 failures**.

Refs private advisory GHSA-c3cw-5f7p-g76r.
