### PR TITLE
fix(token-usage): route report_story through shared skill-version ownership + budget threshold guards

### DIFF
--- a/lib/loopctl/progress.ex
+++ b/lib/loopctl/progress.ex
@@ -24,6 +24,7 @@ defmodule Loopctl.Progress do
   alias Loopctl.Capabilities
   alias Loopctl.Dispatches
   alias Loopctl.Tenants
+  alias Loopctl.TokenUsage
   alias Loopctl.Webhooks.EventGenerator
   alias Loopctl.Webhooks.WebhookEvent
   alias Loopctl.WorkBreakdown.Epic
@@ -506,8 +507,22 @@ defmodule Loopctl.Progress do
   - `{:error, %Ecto.Changeset{}}` if artifact validation fails
   """
   @spec report_story(Ecto.UUID.t(), Ecto.UUID.t(), keyword(), map() | nil) ::
-          {:ok, Story.t()} | {:error, atom() | {:invalid_transition, map()} | Ecto.Changeset.t()}
+          {:ok, Story.t()}
+          | {:error, atom() | {:invalid_transition, map()} | Ecto.Changeset.t()}
+          | {:error, :unprocessable_entity, String.t()}
   def report_story(tenant_id, story_id, opts \\ [], artifact_params \\ nil) do
+    token_usage_params = Keyword.get(opts, :token_usage)
+
+    # Enforce skill_version tenant-ownership BEFORE the report transaction, the
+    # SAME guard the standalone TokenUsage.create_report/3 path runs. A
+    # cross-tenant (or non-existent) skill_version_id is rejected here, so no
+    # report row is ever stored. The 3-tuple maps to a 422 via FallbackController.
+    with :ok <- validate_token_usage_ownership(tenant_id, token_usage_params) do
+      do_report_story(tenant_id, story_id, opts, artifact_params)
+    end
+  end
+
+  defp do_report_story(tenant_id, story_id, opts, artifact_params) do
     agent_id = Keyword.get(opts, :agent_id)
     actor_id = Keyword.get(opts, :actor_id)
     actor_label = Keyword.get(opts, :actor_label)
@@ -582,15 +597,58 @@ defmodule Loopctl.Progress do
       end)
 
     case AdminRepo.transaction(multi) do
-      {:ok, %{story: updated}} -> {:ok, updated}
-      {:error, :lock, reason, _} -> {:error, reason}
-      {:error, :validate, reason, _} -> {:error, reason}
-      {:error, :consume_cap, reason, _} -> {:error, reason}
-      {:error, :story, changeset, _} -> {:error, changeset}
-      {:error, :artifact, changeset, _} -> {:error, changeset}
-      {:error, :token_usage_report, changeset, _} -> {:error, changeset}
+      {:ok, %{story: updated} = results} ->
+        # Run budget threshold checks AFTER commit, through the SAME shared
+        # entry point the standalone create_report path uses — firing budget
+        # warning/exceeded webhooks + threshold_crossed audit entries and
+        # flipping warning_fired/exceeded_fired. No-op when no token usage
+        # was reported.
+        maybe_check_token_budget_thresholds(tenant_id, results)
+        {:ok, updated}
+
+      {:error, :lock, reason, _} ->
+        {:error, reason}
+
+      {:error, :validate, reason, _} ->
+        {:error, reason}
+
+      {:error, :consume_cap, reason, _} ->
+        {:error, reason}
+
+      {:error, :story, changeset, _} ->
+        {:error, changeset}
+
+      {:error, :artifact, changeset, _} ->
+        {:error, changeset}
+
+      {:error, :token_usage_report, changeset, _} ->
+        {:error, changeset}
     end
   end
+
+  # Enforce skill_version tenant-ownership on the report_story path, mirroring
+  # the standalone TokenUsage.create_report/3 guard. Reads skill_version_id out
+  # of the raw token_usage params (JSON string keys), treating "" as absent.
+  defp validate_token_usage_ownership(_tenant_id, nil), do: :ok
+
+  defp validate_token_usage_ownership(tenant_id, params) when is_map(params) do
+    skill_version_id =
+      case Map.get(params, "skill_version_id", Map.get(params, :skill_version_id)) do
+        "" -> nil
+        id -> id
+      end
+
+    TokenUsage.validate_skill_version_ownership(tenant_id, skill_version_id)
+  end
+
+  # Fires budget threshold alerting for the freshly-created token usage report
+  # (if any) via the shared TokenUsage entry point. No-op when the report
+  # transaction created no token usage report.
+  defp maybe_check_token_budget_thresholds(tenant_id, %{token_usage_report: report}) do
+    TokenUsage.check_budget_thresholds_for_report(tenant_id, report)
+  end
+
+  defp maybe_check_token_budget_thresholds(_tenant_id, _results), do: :ok
 
   @doc """
   Signals that the assigned agent has finished implementation and requests review.
@@ -2125,8 +2183,6 @@ defmodule Loopctl.Progress do
   defp maybe_create_token_usage_report(multi, _tenant_id, _story_id, _agent_id, nil), do: multi
 
   defp maybe_create_token_usage_report(multi, tenant_id, story_id, agent_id, params) do
-    alias Loopctl.TokenUsage
-
     Multi.run(multi, :token_usage_report, fn _repo, %{lock: story} ->
       attrs =
         params

--- a/lib/loopctl/token_usage.ex
+++ b/lib/loopctl/token_usage.ex
@@ -125,17 +125,11 @@ defmodule Loopctl.TokenUsage do
           })
 
           # Check budget thresholds after report creation (AC-21.8.2).
-          # Wrapped in try/rescue so a DB failure during threshold checking
-          # does not crash the report creation flow (the report is committed).
-          try do
-            check_budget_thresholds(tenant_id, report)
-          rescue
-            e ->
-              Logger.warning(
-                "Budget threshold check failed for report #{report.id}: " <>
-                  Exception.message(e)
-              )
-          end
+          # Shared entry point used by BOTH creation paths (this standalone
+          # path and Progress.report_story/4) so neither can bypass budget
+          # alerting. Non-fatal: a DB failure during threshold checking does
+          # not crash the report creation flow (the report is committed).
+          check_budget_thresholds_for_report(tenant_id, report)
 
           {:ok, report}
 
@@ -866,6 +860,32 @@ defmodule Loopctl.TokenUsage do
 
   # --- Budget threshold check (AC-21.8.2, AC-21.7.5, AC-21.7.6) ---
 
+  @doc """
+  Runs budget threshold checks for a freshly-created token usage report.
+
+  Fires any `token.budget_warning` / `token.budget_exceeded` webhooks, writes
+  the `threshold_crossed` audit entries, and flips the budget
+  `warning_fired` / `exceeded_fired` flags — exactly the alerting behaviour of
+  the standalone `create_report/3` path.
+
+  This is the single entry point used by BOTH token-usage report creation paths
+  (`create_report/3` and `Progress.report_story/4`) so neither can bypass budget
+  alerting. Non-fatal: wrapped so a DB failure during threshold checking never
+  crashes the caller's flow (the report is already committed when this runs).
+  """
+  @spec check_budget_thresholds_for_report(Ecto.UUID.t(), Report.t()) :: :ok
+  def check_budget_thresholds_for_report(tenant_id, %Report{} = report) do
+    check_budget_thresholds(tenant_id, report)
+    :ok
+  rescue
+    e ->
+      Logger.warning(
+        "Budget threshold check failed for report #{report.id}: " <> Exception.message(e)
+      )
+
+      :ok
+  end
+
   # After a token usage report is created, check all applicable budgets
   # and emit threshold_crossed audit entries and webhook events for any
   # that have been crossed. Deduplication is enforced via warning_fired
@@ -1037,13 +1057,22 @@ defmodule Loopctl.TokenUsage do
 
   # --- Private helpers ---
 
-  # Validates that skill_version_id (if provided) exists and belongs to the tenant.
-  # The ownership chain is: skill_versions -> skills -> tenant_id.
+  @doc """
+  Validates that `skill_version_id` (if provided) exists and belongs to the tenant.
+
+  The ownership chain is: `skill_versions -> skills -> tenant_id`. A
+  cross-tenant or non-existent `skill_version_id` returns
+  `{:error, :unprocessable_entity, message}`.
+
+  Public so BOTH token-usage report creation paths (`create_report/3` and
+  `Progress.report_story/4`) enforce the SAME tenant-ownership guard and neither
+  can drift.
+  """
   @spec validate_skill_version_ownership(Ecto.UUID.t(), Ecto.UUID.t() | nil) ::
           :ok | {:error, :unprocessable_entity, String.t()}
-  defp validate_skill_version_ownership(_tenant_id, nil), do: :ok
+  def validate_skill_version_ownership(_tenant_id, nil), do: :ok
 
-  defp validate_skill_version_ownership(tenant_id, skill_version_id) do
+  def validate_skill_version_ownership(tenant_id, skill_version_id) do
     exists =
       SkillVersion
       |> join(:inner, [sv], s in Skill, on: sv.skill_id == s.id)

--- a/lib/loopctl/token_usage.ex
+++ b/lib/loopctl/token_usage.ex
@@ -140,42 +140,6 @@ defmodule Loopctl.TokenUsage do
   end
 
   @doc """
-  Creates a token usage report within an Ecto.Multi pipeline.
-
-  Used by `Progress.report_story/4` to atomically create a token usage
-  report alongside a status transition.
-
-  ## Parameters
-
-  - `multi` -- the Ecto.Multi struct
-  - `name` -- the step name in the multi
-  - `tenant_id` -- the tenant UUID
-  - `attrs` -- map of report attributes (story_id, agent_id, project_id, etc.)
-
-  ## Returns
-
-  The updated Ecto.Multi struct.
-  """
-  @spec create_report_in_multi(Ecto.Multi.t(), atom(), Ecto.UUID.t(), map()) :: Ecto.Multi.t()
-  def create_report_in_multi(multi, name, tenant_id, attrs) do
-    attrs = normalize_attrs(attrs)
-
-    story_id = Map.get(attrs, :story_id)
-    agent_id = Map.get(attrs, :agent_id)
-    project_id = Map.get(attrs, :project_id)
-
-    Ecto.Multi.insert(multi, name, fn _changes ->
-      %Report{
-        tenant_id: tenant_id,
-        story_id: story_id,
-        agent_id: agent_id,
-        project_id: project_id
-      }
-      |> Report.create_changeset(attrs)
-    end)
-  end
-
-  @doc """
   Lists all token usage reports for a story, ordered by inserted_at descending.
 
   Includes pagination and total count.
@@ -381,7 +345,14 @@ defmodule Loopctl.TokenUsage do
   def create_correction(tenant_id, original_report_id, attrs, opts \\ []) do
     attrs = normalize_attrs(attrs)
 
-    with {:ok, original} <- get_report(tenant_id, original_report_id) do
+    # Enforce skill_version tenant-ownership (tokens-10), the SAME guard the
+    # create_report/3 and Progress.report_story/4 paths run. A cross-tenant (or
+    # non-existent / malformed) skill_version_id is rejected BEFORE the changeset
+    # is built, so no correction row is stored. "" is treated as absent, mirroring
+    # Progress.validate_token_usage_ownership/2.
+    with :ok <-
+           validate_skill_version_ownership(tenant_id, correction_skill_version_id(attrs)),
+         {:ok, original} <- get_report(tenant_id, original_report_id) do
       correction_input_tokens = Map.get(attrs, :input_tokens, 0)
       correction_output_tokens = Map.get(attrs, :output_tokens, 0)
 
@@ -424,7 +395,8 @@ defmodule Loopctl.TokenUsage do
               "input_tokens" => correction.input_tokens,
               "output_tokens" => correction.output_tokens,
               "cost_millicents" => correction.cost_millicents,
-              "model_name" => correction.model_name
+              "model_name" => correction.model_name,
+              "skill_version_id" => correction.skill_version_id
             },
             metadata: %{
               "corrects_report_id" => original.id,
@@ -432,7 +404,8 @@ defmodule Loopctl.TokenUsage do
               "project_id" => correction.project_id,
               "input_tokens" => correction_input_tokens,
               "output_tokens" => correction_output_tokens,
-              "cost_millicents" => Map.get(attrs, :cost_millicents, 0)
+              "cost_millicents" => Map.get(attrs, :cost_millicents, 0),
+              "skill_version_id" => correction.skill_version_id
             }
           }
         end)
@@ -1061,29 +1034,48 @@ defmodule Loopctl.TokenUsage do
   Validates that `skill_version_id` (if provided) exists and belongs to the tenant.
 
   The ownership chain is: `skill_versions -> skills -> tenant_id`. A
-  cross-tenant or non-existent `skill_version_id` returns
+  cross-tenant, non-existent, or malformed (non-UUID) `skill_version_id` returns
   `{:error, :unprocessable_entity, message}`.
 
-  Public so BOTH token-usage report creation paths (`create_report/3` and
-  `Progress.report_story/4`) enforce the SAME tenant-ownership guard and neither
-  can drift.
+  Public so ALL THREE token-usage report creation paths (`create_report/3`,
+  `create_correction/4`, and `Progress.report_story/4`) enforce the SAME
+  tenant-ownership guard and none can drift.
+
+  A malformed value is UUID-validated up front so it yields a clean 422 rather
+  than raising `Ecto.Query.CastError` (an unhandled 500) inside the query.
   """
   @spec validate_skill_version_ownership(Ecto.UUID.t(), Ecto.UUID.t() | nil) ::
           :ok | {:error, :unprocessable_entity, String.t()}
   def validate_skill_version_ownership(_tenant_id, nil), do: :ok
 
   def validate_skill_version_ownership(tenant_id, skill_version_id) do
-    exists =
-      SkillVersion
-      |> join(:inner, [sv], s in Skill, on: sv.skill_id == s.id)
-      |> where([sv, s], sv.id == ^skill_version_id and s.tenant_id == ^tenant_id)
-      |> AdminRepo.exists?()
+    case Ecto.UUID.cast(skill_version_id) do
+      :error ->
+        {:error, :unprocessable_entity,
+         "skill_version_id does not exist or belongs to a different tenant"}
 
-    if exists do
-      :ok
-    else
-      {:error, :unprocessable_entity,
-       "skill_version_id does not exist or belongs to a different tenant"}
+      {:ok, uuid} ->
+        exists =
+          SkillVersion
+          |> join(:inner, [sv], s in Skill, on: sv.skill_id == s.id)
+          |> where([sv, s], sv.id == ^uuid and s.tenant_id == ^tenant_id)
+          |> AdminRepo.exists?()
+
+        if exists do
+          :ok
+        else
+          {:error, :unprocessable_entity,
+           "skill_version_id does not exist or belongs to a different tenant"}
+        end
+    end
+  end
+
+  # Extracts the skill_version_id from correction attrs (already normalized to
+  # atom keys), treating "" as absent — mirrors Progress.validate_token_usage_ownership/2.
+  defp correction_skill_version_id(attrs) do
+    case Map.get(attrs, :skill_version_id) do
+      "" -> nil
+      id -> id
     end
   end
 

--- a/lib/loopctl_web/controllers/story_status_controller.ex
+++ b/lib/loopctl_web/controllers/story_status_controller.ex
@@ -350,6 +350,10 @@ defmodule LoopctlWeb.StoryStatusController do
       {:error, :not_found} ->
         {:error, :not_found}
 
+      # Cross-tenant / non-existent token_usage skill_version_id (tokens-10).
+      {:error, :unprocessable_entity, message} ->
+        {:error, :unprocessable_entity, message}
+
       {:error, %Ecto.Changeset{} = changeset} ->
         {:error, changeset}
     end

--- a/test/loopctl_web/controllers/story_status_controller_test.exs
+++ b/test/loopctl_web/controllers/story_status_controller_test.exs
@@ -4,11 +4,92 @@ defmodule LoopctlWeb.StoryStatusControllerTest do
   import Ecto.Query
 
   alias Ecto.Adapters.SQL.Sandbox
+  alias Loopctl.AdminRepo
+  alias Loopctl.Audit.AuditLog
+  alias Loopctl.Skills
+  alias Loopctl.TokenUsage
+  alias Loopctl.TokenUsage.Budget
+  alias Loopctl.TokenUsage.Report
+  alias Loopctl.Webhooks
+  alias Loopctl.Webhooks.WebhookEvent
 
   setup :verify_on_exit!
 
   defp auth_conn(conn, raw_key) do
     put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  # Puts a story into :implementing (assigned to the implementer) and mints a
+  # DIFFERENT reviewer agent + key so cross-agent report calls succeed
+  # (chain-of-custody). Returns the base context plus :reviewer / :reviewer_key.
+  defp implementing_story_with_reviewer(attrs \\ %{}) do
+    ctx = setup_story_with_agent(attrs)
+
+    story =
+      ctx.story
+      |> Ecto.Changeset.change(%{
+        agent_status: :implementing,
+        assigned_agent_id: ctx.agent.id,
+        assigned_at: DateTime.utc_now()
+      })
+      |> AdminRepo.update!()
+
+    reviewer = fixture(:agent, %{tenant_id: ctx.tenant.id, agent_type: :implementer})
+
+    {reviewer_key, _} =
+      fixture(:api_key, %{tenant_id: ctx.tenant.id, role: :agent, agent_id: reviewer.id})
+
+    ctx
+    |> Map.put(:story, story)
+    |> Map.put(:reviewer, reviewer)
+    |> Map.put(:reviewer_key, reviewer_key)
+  end
+
+  defp token_usage_payload(overrides) do
+    Map.merge(
+      %{
+        "input_tokens" => 1000,
+        "output_tokens" => 500,
+        "model_name" => "claude-opus-4",
+        "cost_millicents" => 8_500
+      },
+      overrides
+    )
+  end
+
+  defp create_webhook_for_events(tenant_id, events) do
+    {:ok, %{webhook: webhook}} =
+      Webhooks.create_webhook(tenant_id, %{
+        "url" => "https://example.com/hooks/#{System.unique_integer([:positive])}",
+        "events" => events
+      })
+
+    webhook
+  end
+
+  defp find_webhook_events(tenant_id, event_type) do
+    WebhookEvent
+    |> where([e], e.tenant_id == ^tenant_id and e.event_type == ^event_type)
+    |> AdminRepo.all()
+  end
+
+  defp threshold_crossed_entries(tenant_id, budget_id, threshold_type) do
+    AuditLog
+    |> where([a], a.tenant_id == ^tenant_id and a.entity_type == "token_budget")
+    |> where([a], a.action == "threshold_crossed" and a.entity_id == ^budget_id)
+    |> AdminRepo.all()
+    |> Enum.filter(fn e -> e.metadata["threshold_type"] == threshold_type end)
+  end
+
+  defp same_tenant_skill_version(tenant_id) do
+    skill =
+      fixture(:skill, %{
+        tenant_id: tenant_id,
+        name: "skill-#{System.unique_integer([:positive])}"
+      })
+
+    {:ok, version} = Skills.get_version(tenant_id, skill.id, 1)
+    version
   end
 
   defp setup_story_with_agent(attrs \\ %{}) do
@@ -390,6 +471,248 @@ defmodule LoopctlWeb.StoryStatusControllerTest do
 
       body = json_response(conn, 422)
       assert body["error"]["status"] == 422
+    end
+  end
+
+  # --- tokens-01: budget thresholds fire on the report_story path ---
+
+  describe "POST /api/v1/stories/:id/report with token_usage — budget alerting (tokens-01)" do
+    test "story budget: crossing alert_threshold_pct fires warning (only) + audit + flag",
+         %{conn: conn} do
+      ctx = implementing_story_with_reviewer()
+
+      _webhook =
+        create_webhook_for_events(ctx.tenant.id, [
+          "token.budget_warning",
+          "token.budget_exceeded"
+        ])
+
+      {:ok, budget} =
+        TokenUsage.create_budget(ctx.tenant.id, %{
+          scope_type: :story,
+          scope_id: ctx.story.id,
+          budget_millicents: 10_000,
+          alert_threshold_pct: 80
+        })
+
+      # 8,500 / 10,000 = 85% -> warning fires, exceeded does NOT
+      conn =
+        conn
+        |> auth_conn(ctx.reviewer_key)
+        |> post(~p"/api/v1/stories/#{ctx.story.id}/report", %{
+          "token_usage" => token_usage_payload(%{"cost_millicents" => 8_500})
+        })
+
+      assert json_response(conn, 200)
+
+      assert [_warning_event] = find_webhook_events(ctx.tenant.id, "token.budget_warning")
+      assert [] == find_webhook_events(ctx.tenant.id, "token.budget_exceeded")
+
+      assert [_] = threshold_crossed_entries(ctx.tenant.id, budget.id, "warning")
+      assert [] == threshold_crossed_entries(ctx.tenant.id, budget.id, "exceeded")
+
+      reloaded = AdminRepo.get!(Budget, budget.id)
+      assert reloaded.warning_fired == true
+      assert reloaded.exceeded_fired == false
+    end
+
+    test "story budget: exceeding 100% fires BOTH warning and exceeded + audit + flags",
+         %{conn: conn} do
+      ctx = implementing_story_with_reviewer()
+
+      _webhook =
+        create_webhook_for_events(ctx.tenant.id, [
+          "token.budget_warning",
+          "token.budget_exceeded"
+        ])
+
+      {:ok, budget} =
+        TokenUsage.create_budget(ctx.tenant.id, %{
+          scope_type: :story,
+          scope_id: ctx.story.id,
+          budget_millicents: 5_000,
+          alert_threshold_pct: 80
+        })
+
+      # 6,000 / 5,000 = 120% -> both warning and exceeded fire
+      conn =
+        conn
+        |> auth_conn(ctx.reviewer_key)
+        |> post(~p"/api/v1/stories/#{ctx.story.id}/report", %{
+          "token_usage" => token_usage_payload(%{"cost_millicents" => 6_000})
+        })
+
+      assert json_response(conn, 200)
+
+      assert [warning_event] = find_webhook_events(ctx.tenant.id, "token.budget_warning")
+      assert [exceeded_event] = find_webhook_events(ctx.tenant.id, "token.budget_exceeded")
+
+      assert warning_event.payload["scope_type"] == "story"
+      assert exceeded_event.payload["overage_millicents"] == 1_000
+
+      assert [_] = threshold_crossed_entries(ctx.tenant.id, budget.id, "warning")
+      assert [_] = threshold_crossed_entries(ctx.tenant.id, budget.id, "exceeded")
+
+      reloaded = AdminRepo.get!(Budget, budget.id)
+      assert reloaded.warning_fired == true
+      assert reloaded.exceeded_fired == true
+    end
+
+    test "epic and project budgets also fire on the report_story path", %{conn: conn} do
+      ctx = implementing_story_with_reviewer()
+
+      _webhook =
+        create_webhook_for_events(ctx.tenant.id, ["token.budget_exceeded"])
+
+      {:ok, epic_budget} =
+        TokenUsage.create_budget(ctx.tenant.id, %{
+          scope_type: :epic,
+          scope_id: ctx.epic.id,
+          budget_millicents: 5_000,
+          alert_threshold_pct: 80
+        })
+
+      {:ok, project_budget} =
+        TokenUsage.create_budget(ctx.tenant.id, %{
+          scope_type: :project,
+          scope_id: ctx.project.id,
+          budget_millicents: 5_000,
+          alert_threshold_pct: 80
+        })
+
+      conn =
+        conn
+        |> auth_conn(ctx.reviewer_key)
+        |> post(~p"/api/v1/stories/#{ctx.story.id}/report", %{
+          "token_usage" => token_usage_payload(%{"cost_millicents" => 6_000})
+        })
+
+      assert json_response(conn, 200)
+
+      # Both epic-scope and project-scope budgets produce exceeded events
+      assert Enum.count(find_webhook_events(ctx.tenant.id, "token.budget_exceeded")) == 2
+
+      assert [_] = threshold_crossed_entries(ctx.tenant.id, epic_budget.id, "exceeded")
+      assert [_] = threshold_crossed_entries(ctx.tenant.id, project_budget.id, "exceeded")
+
+      assert AdminRepo.get!(Budget, epic_budget.id).exceeded_fired == true
+      assert AdminRepo.get!(Budget, project_budget.id).exceeded_fired == true
+    end
+
+    test "a report under threshold fires nothing", %{conn: conn} do
+      ctx = implementing_story_with_reviewer()
+
+      _webhook =
+        create_webhook_for_events(ctx.tenant.id, [
+          "token.budget_warning",
+          "token.budget_exceeded"
+        ])
+
+      {:ok, budget} =
+        TokenUsage.create_budget(ctx.tenant.id, %{
+          scope_type: :story,
+          scope_id: ctx.story.id,
+          budget_millicents: 100_000,
+          alert_threshold_pct: 80
+        })
+
+      conn =
+        conn
+        |> auth_conn(ctx.reviewer_key)
+        |> post(~p"/api/v1/stories/#{ctx.story.id}/report", %{
+          "token_usage" => token_usage_payload(%{"cost_millicents" => 1_000})
+        })
+
+      assert json_response(conn, 200)
+
+      assert [] == find_webhook_events(ctx.tenant.id, "token.budget_warning")
+      assert [] == find_webhook_events(ctx.tenant.id, "token.budget_exceeded")
+      assert [] == threshold_crossed_entries(ctx.tenant.id, budget.id, "warning")
+      assert [] == threshold_crossed_entries(ctx.tenant.id, budget.id, "exceeded")
+
+      reloaded = AdminRepo.get!(Budget, budget.id)
+      assert reloaded.warning_fired == false
+      assert reloaded.exceeded_fired == false
+    end
+  end
+
+  # --- tokens-10: cross-tenant skill_version_id rejected on the report path ---
+
+  describe "POST /api/v1/stories/:id/report with token_usage — skill_version ownership (tokens-10)" do
+    test "cross-tenant skill_version_id is rejected 422, no report stored, nothing leaked",
+         %{conn: conn} do
+      ctx = implementing_story_with_reviewer()
+
+      # A skill_version owned by a DIFFERENT tenant.
+      other_tenant = fixture(:tenant)
+      foreign_version = same_tenant_skill_version(other_tenant.id)
+
+      conn =
+        conn
+        |> auth_conn(ctx.reviewer_key)
+        |> post(~p"/api/v1/stories/#{ctx.story.id}/report", %{
+          "token_usage" => token_usage_payload(%{"skill_version_id" => foreign_version.id})
+        })
+
+      body = json_response(conn, 422)
+      assert body["error"]["status"] == 422
+      assert body["error"]["message"] =~ "skill_version_id"
+
+      # No report row was stored for the story.
+      assert 0 ==
+               Report
+               |> where([r], r.story_id == ^ctx.story.id)
+               |> AdminRepo.aggregate(:count, :id)
+
+      # And nothing leaks through the read endpoint.
+      index_conn =
+        build_conn()
+        |> auth_conn(ctx.reviewer_key)
+        |> get(~p"/api/v1/stories/#{ctx.story.id}/token-usage")
+
+      index_body = json_response(index_conn, 200)
+      assert index_body["data"] == []
+      assert index_body["meta"]["total_count"] == 0
+    end
+
+    test "same-tenant skill_version_id still works", %{conn: conn} do
+      ctx = implementing_story_with_reviewer()
+      version = same_tenant_skill_version(ctx.tenant.id)
+
+      conn =
+        conn
+        |> auth_conn(ctx.reviewer_key)
+        |> post(~p"/api/v1/stories/#{ctx.story.id}/report", %{
+          "token_usage" => token_usage_payload(%{"skill_version_id" => version.id})
+        })
+
+      assert json_response(conn, 200)
+
+      report =
+        Report
+        |> where([r], r.story_id == ^ctx.story.id)
+        |> AdminRepo.one()
+
+      assert report.skill_version_id == version.id
+    end
+
+    test "nonexistent skill_version_id is rejected 422 with no report stored", %{conn: conn} do
+      ctx = implementing_story_with_reviewer()
+
+      conn =
+        conn
+        |> auth_conn(ctx.reviewer_key)
+        |> post(~p"/api/v1/stories/#{ctx.story.id}/report", %{
+          "token_usage" => token_usage_payload(%{"skill_version_id" => Ecto.UUID.generate()})
+        })
+
+      body = json_response(conn, 422)
+      assert body["error"]["status"] == 422
+
+      assert 0 ==
+               Report
+               |> where([r], r.story_id == ^ctx.story.id)
+               |> AdminRepo.aggregate(:count, :id)
     end
   end
 

--- a/test/loopctl_web/controllers/token_usage_corrections_controller_test.exs
+++ b/test/loopctl_web/controllers/token_usage_corrections_controller_test.exs
@@ -11,10 +11,23 @@ defmodule LoopctlWeb.TokenUsageCorrectionsControllerTest do
 
   use LoopctlWeb.ConnCase, async: true
 
+  alias Loopctl.Skills
+
   setup :verify_on_exit!
 
   defp auth_conn(conn, raw_key) do
     put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  defp same_tenant_skill_version(tenant_id) do
+    skill =
+      fixture(:skill, %{
+        tenant_id: tenant_id,
+        name: "skill-#{System.unique_integer([:positive])}"
+      })
+
+    {:ok, version} = Skills.get_version(tenant_id, skill.id, 1)
+    version
   end
 
   defp setup_with_user_key do
@@ -262,6 +275,101 @@ defmodule LoopctlWeb.TokenUsageCorrectionsControllerTest do
         })
 
       assert json_response(conn, 404)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # tokens-10: skill_version tenant-ownership on the correction path
+  # ---------------------------------------------------------------------------
+
+  describe "POST /api/v1/token-usage/:id/correction — skill_version ownership (tokens-10)" do
+    test "cross-tenant skill_version_id is rejected 422, no correction stored", %{conn: conn} do
+      %{user_key: user_key, agent_key: agent_key, story: story, report: report} =
+        setup_with_user_key()
+
+      # A skill_version owned by a DIFFERENT tenant — tenant isolation.
+      other_tenant = fixture(:tenant)
+      foreign_version = same_tenant_skill_version(other_tenant.id)
+
+      conn =
+        conn
+        |> auth_conn(user_key)
+        |> post(~p"/api/v1/token-usage/#{report.id}/correction", %{
+          "input_tokens" => -100,
+          "output_tokens" => -50,
+          "cost_millicents" => -250,
+          "skill_version_id" => foreign_version.id
+        })
+
+      body = json_response(conn, 422)
+      assert body["error"]["status"] == 422
+      assert body["error"]["message"] =~ "skill_version_id"
+
+      # No correction row stored: only the original report remains.
+      list_conn =
+        build_conn()
+        |> auth_conn(agent_key)
+        |> get(~p"/api/v1/stories/#{story.id}/token-usage")
+
+      assert json_response(list_conn, 200)["meta"]["total_count"] == 1
+    end
+
+    test "same-tenant skill_version_id creates the correction (201)", %{conn: conn} do
+      %{tenant: tenant, user_key: user_key, report: report} = setup_with_user_key()
+      version = same_tenant_skill_version(tenant.id)
+
+      conn =
+        conn
+        |> auth_conn(user_key)
+        |> post(~p"/api/v1/token-usage/#{report.id}/correction", %{
+          "input_tokens" => -100,
+          "output_tokens" => -50,
+          "cost_millicents" => -250,
+          "skill_version_id" => version.id
+        })
+
+      body = json_response(conn, 201)
+      assert body["token_usage_report"]["skill_version_id"] == version.id
+    end
+
+    test "nonexistent skill_version_id is rejected 422, no correction stored", %{conn: conn} do
+      %{user_key: user_key, agent_key: agent_key, story: story, report: report} =
+        setup_with_user_key()
+
+      conn =
+        conn
+        |> auth_conn(user_key)
+        |> post(~p"/api/v1/token-usage/#{report.id}/correction", %{
+          "input_tokens" => -100,
+          "output_tokens" => -50,
+          "cost_millicents" => -250,
+          "skill_version_id" => Ecto.UUID.generate()
+        })
+
+      assert json_response(conn, 422)["error"]["status"] == 422
+
+      list_conn =
+        build_conn()
+        |> auth_conn(agent_key)
+        |> get(~p"/api/v1/stories/#{story.id}/token-usage")
+
+      assert json_response(list_conn, 200)["meta"]["total_count"] == 1
+    end
+
+    test "malformed (non-UUID) skill_version_id yields 422, not 500", %{conn: conn} do
+      %{user_key: user_key, report: report} = setup_with_user_key()
+
+      conn =
+        conn
+        |> auth_conn(user_key)
+        |> post(~p"/api/v1/token-usage/#{report.id}/correction", %{
+          "input_tokens" => -100,
+          "output_tokens" => -50,
+          "cost_millicents" => -250,
+          "skill_version_id" => "not-a-uuid"
+        })
+
+      assert json_response(conn, 422)["error"]["status"] == 422
     end
   end
 end


### PR DESCRIPTION
## Summary

Two token-usage-report creation paths existed and had drifted:

- **Standalone** `TokenUsage.create_report/3` (used by `POST /token-usage`) ran **skill-version tenant-ownership validation** AND **budget threshold checks**.
- The **documented-primary** `Progress.report_story/4` path (`POST /stories/:id/report`, which the MCP `report_story` tool uses to send `token_usage`) built `Report.create_changeset` **directly** and bypassed **both** guards.

This PR routes the `report_story` path through the **same** guards so no path can bypass or drift.

## Findings addressed

- **tokens-01 (HIGH, wrong-calc)** — Budget thresholds were never checked on the `report_story` path, so `token.budget_warning` / `token.budget_exceeded` webhooks never fired, no `threshold_crossed` audit entry was written, and `warning_fired` / `exceeded_fired` never flipped. Budget alerting was silently dead on the primary path.
- **tokens-10 (MEDIUM, tenant-leak)** — A `skill_version_id` belonging to another tenant (or a non-existent one) was accepted on the `report_story` path (the changeset only had a **global** `foreign_key_constraint`), stored, and later echoed on `GET /stories/:id/token-usage` and leaked into skill-performance analytics.

## How it was consolidated (single source of truth)

Extracted the two guards as public functions in `Loopctl.TokenUsage`, invoked by **both** paths:

- `validate_skill_version_ownership/2` — made public (was private). Joins `skill_versions -> skills` and checks `tenant_id`.
- `check_budget_thresholds_for_report/2` — **new** public wrapper around the private threshold check, carrying the non-fatal try/rescue semantics. `create_report/3` now calls this wrapper too (so the "don't crash report creation" behaviour lives in one place).

`Progress.report_story/4`:
- Validates skill-version ownership **before** the report transaction — a cross-tenant / non-existent `skill_version_id` returns `{:error, :unprocessable_entity, msg}`, so **no report row is ever stored**.
- Runs budget threshold alerting **after commit** via the shared entry point — identical webhooks + `threshold_crossed` audit + flag flips — for **story / epic / project** budgets.

### How a token-usage validation failure surfaces

The ownership guard returns `{:error, :unprocessable_entity, msg}`, which `StoryStatusController.report` passes through and `FallbackController` maps to a **422** with the message (already-supported error shape). The report transaction never runs, so the story stays `implementing` and nothing is persisted — matching the standalone endpoint's contract.

## Tests (API-level, `POST /stories/:id/report`)

Added to `story_status_controller_test.exs`:

- **tokens-01**: story-budget crossing `alert_threshold_pct` fires warning only (+ audit + flag); crossing 100% fires **both** warning and exceeded (+ overage payload + audit + flags); **epic and project** budgets also fire; a report **under threshold fires nothing**. Asserted via `WebhookEvent` rows, `threshold_crossed` audit-log query, and reloaded budget flags.
- **tokens-10**: a cross-tenant `skill_version_id` → **422**, **no report row stored**, and `GET /stories/:id/token-usage` returns empty (nothing leaked); a **same-tenant** id still works; a **non-existent** id → 422 with no row. Tenant isolation: caller in tenant A cannot reference tenant B's skill_version.

No regression: the standalone `create_report` / `POST /token-usage` suites and the existing budget-webhook suite pass unchanged.

## Verification (Elixir 1.19 / OTP 28)

`mix deps.get`; `compile --warnings-as-errors` clean; `mix format`; `credo --strict` 0 issues; `dialyzer` 0 real errors (fresh PLT); full `mix test` **3317 tests, 0 failures (40 excluded)** — via the pre-commit hook.

Refs public issue #231 (tokens-01) and advisory GHSA-4x7h-333h-37j4 (tokens-10).
