### PR TITLE
fix(token-usage): correction/archival lifecycle integrity (tokens-02..05)

### DIFF
--- a/lib/loopctl/token_usage.ex
+++ b/lib/loopctl/token_usage.ex
@@ -352,7 +352,8 @@ defmodule Loopctl.TokenUsage do
     # Progress.validate_token_usage_ownership/2.
     with :ok <-
            validate_skill_version_ownership(tenant_id, correction_skill_version_id(attrs)),
-         {:ok, original} <- get_report(tenant_id, original_report_id) do
+         {:ok, original} <- get_report(tenant_id, original_report_id),
+         :ok <- validate_correctable(original) do
       correction_input_tokens = Map.get(attrs, :input_tokens, 0)
       correction_output_tokens = Map.get(attrs, :output_tokens, 0)
 
@@ -434,8 +435,21 @@ defmodule Loopctl.TokenUsage do
     end
   end
 
-  # Namespace for the per-story correction advisory lock (tokens-02).
-  @correction_lock_namespace 2_113_002
+  # Forbids correcting a correction (tokens-03 retention gap). Corrections may
+  # only target ORIGINAL reports (`corrects_report_id IS NULL`). Allowing chains
+  # (A <- B <- C ...) would let each new leaf perpetually block hard-delete of
+  # its parent — tokens-03's skip-if-referenced guard keys on the immediate
+  # successor — deferring the whole lineage (incl. the original) past retention
+  # forever. Bounding the chain to depth 1 (original <- correction) means the
+  # original is freed for hard-delete once its single correction expires.
+  defp validate_correctable(%Report{corrects_report_id: nil}), do: :ok
+
+  defp validate_correctable(%Report{}),
+    do: {:error, :unprocessable_entity, "cannot correct a correction"}
+
+  # Fixed 8-byte namespace tag folded into the correction lock key so a future,
+  # different-purpose advisory lock on the same story can't collide with this one.
+  @correction_lock_tag <<0x21, 0x13, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00>>
 
   # Serializes concurrent corrections for the SAME story so the "totals never go
   # negative" invariant holds under concurrency (tokens-02). Without it, two
@@ -448,12 +462,42 @@ defmodule Loopctl.TokenUsage do
   # pg_advisory_xact_lock is held until the transaction commits/rolls back, so
   # the second correction blocks until the first commits, then re-reads the
   # now-updated total and is correctly rejected (422) if it would over-subtract.
-  # Keyed on a fixed namespace + hash({tenant_id, story_id}); phash2/1 is bounded
-  # to 2^27-1 which fits a PostgreSQL int4 lock key.
   defp acquire_story_correction_lock(repo, tenant_id, story_id) do
-    key = :erlang.phash2({tenant_id, story_id})
-    repo.query!("SELECT pg_advisory_xact_lock($1, $2)", [@correction_lock_namespace, key])
+    key = correction_lock_key(tenant_id, story_id)
+    repo.query!("SELECT pg_advisory_xact_lock($1)", [key])
     {:ok, :locked}
+  end
+
+  @doc """
+  Derives the STABLE, release-independent signed 64-bit PostgreSQL advisory
+  lock key used to serialize concurrent corrections for a `(tenant_id,
+  story_id)` (tokens-02).
+
+  Public so tests can prove the exact key serializes across two real DB sessions.
+
+  NOT `:erlang.phash2` — its hashing can change across OTP releases, so during a
+  rolling deploy that bumps OTP two nodes could compute different keys for the
+  same story and fail to serialize. Byte XOR of the two decoded UUIDs (folded
+  with a fixed namespace tag) is pure and identical on every node/release.
+  """
+  @spec correction_lock_key(Ecto.UUID.t(), Ecto.UUID.t()) :: integer()
+  def correction_lock_key(tenant_id, story_id) do
+    <<story8::binary-8, _::binary>> = uuid_bytes(story_id)
+    <<tenant8::binary-8, _::binary>> = uuid_bytes(tenant_id)
+
+    <<signed::signed-64>> =
+      story8
+      |> :crypto.exor(tenant8)
+      |> :crypto.exor(@correction_lock_tag)
+
+    signed
+  end
+
+  defp uuid_bytes(uuid) do
+    case Ecto.UUID.dump(uuid) do
+      {:ok, bin} -> bin
+      :error -> <<0::128>>
+    end
   end
 
   # Validates that the sum of story totals + correction values >= 0.
@@ -1245,24 +1289,19 @@ defmodule Loopctl.TokenUsage do
   # Base query for reports that count toward story/epic/project totals and spend.
   #
   # A report counts when it is NOT soft-deleted AND, if it is a correction
-  # (`corrects_report_id` set), its original report is also NOT soft-deleted.
-  # The LEFT JOIN on the original (at most one row per correction, so sums do
-  # not fan out) lets a single predicate exclude a negative correction whose
-  # original was soft-deleted or expired — otherwise the surviving negative
-  # correction would strand and drive story/epic/project totals negative
-  # (tokens-04). Originals (`corrects_report_id IS NULL`) always count when live.
+  # (`corrects_report_id` set), its original report is also NOT soft-deleted —
+  # otherwise a surviving negative correction would strand and drive
+  # story/epic/project totals negative (tokens-04). The correction/original
+  # consistency predicate is centralized in
+  # `Report.exclude_stranded_corrections/1` (the single reusable builder shared
+  # with the analytics, rollup, and anomaly total queries) so no query drifts.
   defp countable_reports(tenant_id) do
     from(r in Report,
       as: :report,
-      left_join: orig in Report,
-      as: :original,
-      on: orig.id == r.corrects_report_id,
       where: r.tenant_id == ^tenant_id,
-      where: is_nil(r.deleted_at),
-      where:
-        is_nil(r.corrects_report_id) or
-          (not is_nil(orig.id) and is_nil(orig.deleted_at))
+      where: is_nil(r.deleted_at)
     )
+    |> Report.exclude_stranded_corrections()
   end
 
   defp spend_query(tenant_id, :story, scope_id) do

--- a/lib/loopctl/token_usage.ex
+++ b/lib/loopctl/token_usage.ex
@@ -201,10 +201,10 @@ defmodule Loopctl.TokenUsage do
            }}
   def get_story_totals(tenant_id, story_id) do
     query =
-      Report
-      |> where([r], r.tenant_id == ^tenant_id and r.story_id == ^story_id)
-      |> where([r], is_nil(r.deleted_at))
-      |> select([r], %{
+      tenant_id
+      |> countable_reports()
+      |> where([report: r], r.story_id == ^story_id)
+      |> select([report: r], %{
         total_input_tokens: coalesce(sum(r.input_tokens), 0),
         total_output_tokens: coalesce(sum(r.output_tokens), 0),
         total_tokens: coalesce(sum(r.input_tokens), 0) + coalesce(sum(r.output_tokens), 0),
@@ -376,6 +376,9 @@ defmodule Loopctl.TokenUsage do
 
       multi =
         Multi.new()
+        |> Multi.run(:lock_story, fn repo, _changes ->
+          acquire_story_correction_lock(repo, tenant_id, original.story_id)
+        end)
         |> Multi.run(:validate_totals, fn _repo, _changes ->
           validate_correction_totals(tenant_id, original, attrs)
         end)
@@ -429,6 +432,28 @@ defmodule Loopctl.TokenUsage do
           {:error, error}
       end
     end
+  end
+
+  # Namespace for the per-story correction advisory lock (tokens-02).
+  @correction_lock_namespace 2_113_002
+
+  # Serializes concurrent corrections for the SAME story so the "totals never go
+  # negative" invariant holds under concurrency (tokens-02). Without it, two
+  # concurrent corrections (double-submit / retry) each read the pre-correction
+  # total under READ COMMITTED, both pass validate_correction_totals, and both
+  # commit — driving the story total negative (and with it any epic/project
+  # rollup, which is just a sum of per-story totals, so a non-negative story
+  # total guarantees non-negative epic/project totals).
+  #
+  # pg_advisory_xact_lock is held until the transaction commits/rolls back, so
+  # the second correction blocks until the first commits, then re-reads the
+  # now-updated total and is correctly rejected (422) if it would over-subtract.
+  # Keyed on a fixed namespace + hash({tenant_id, story_id}); phash2/1 is bounded
+  # to 2^27-1 which fits a PostgreSQL int4 lock key.
+  defp acquire_story_correction_lock(repo, tenant_id, story_id) do
+    key = :erlang.phash2({tenant_id, story_id})
+    repo.query!("SELECT pg_advisory_xact_lock($1, $2)", [@correction_lock_namespace, key])
+    {:ok, :locked}
   end
 
   # Validates that the sum of story totals + correction values >= 0.
@@ -875,70 +900,88 @@ defmodule Loopctl.TokenUsage do
       utilization_pct =
         if budget.budget_millicents > 0, do: div(spend * 100, budget.budget_millicents), else: 0
 
-      # Fire warning and exceeded independently so both fire when a single
-      # report pushes past both thresholds at once.
-      if utilization_pct >= budget.alert_threshold_pct do
+      # Warning and exceeded are evaluated independently so a single report that
+      # crosses both thresholds at once fires both. The SAME warning_fired /
+      # exceeded_fired CAS that dedups the webhook now ALSO gates the
+      # threshold_crossed AUDIT write, so the audit row is written exactly ONCE
+      # per real crossing (the below -> at/over transition), not on every report
+      # while already over budget (tokens-05). A genuine NEW crossing — e.g.
+      # crossing 100% after previously only crossing the warning threshold —
+      # still claims its own flag and writes its audit row once.
+      if utilization_pct >= budget.alert_threshold_pct and
+           claim_budget_threshold(budget, :warning) do
         emit_threshold_crossed(tenant_id, budget, utilization_pct, "warning")
-        maybe_fire_warning_webhook(tenant_id, budget, spend, utilization_pct, report)
+        fire_warning_webhook(tenant_id, budget, spend, utilization_pct, report)
       end
 
-      if utilization_pct >= 100 do
+      if utilization_pct >= 100 and claim_budget_threshold(budget, :exceeded) do
         emit_threshold_crossed(tenant_id, budget, utilization_pct, "exceeded")
-        maybe_fire_exceeded_webhook(tenant_id, budget, spend, utilization_pct, report)
+        fire_exceeded_webhook(tenant_id, budget, spend, utilization_pct, report)
       end
     end)
   end
 
-  # Fires a budget_warning webhook event using atomic CAS to prevent duplicate
-  # fires under concurrent requests. The UPDATE ... WHERE warning_fired = false
-  # atomically claims the right to fire; only the winner (count == 1) proceeds.
-  defp maybe_fire_warning_webhook(tenant_id, budget, spend, utilization_pct, report) do
+  # Atomically claims the right to emit a budget threshold crossing (the audit
+  # row AND the webhook) exactly once, via compare-and-swap on the
+  # warning_fired / exceeded_fired flag. UPDATE ... WHERE <flag> = false claims
+  # the below -> at/over transition; only the winner (count == 1) proceeds, so
+  # concurrent reports can't double-fire. The flags are reset by
+  # reset_budget_flags_if_needed/2 (spend drops) and update_budget/4 (budget
+  # changes), so a genuine re-crossing claims again.
+  defp claim_budget_threshold(budget, :warning) do
     {count, _} =
       Budget
       |> where([b], b.id == ^budget.id and b.warning_fired == false)
       |> AdminRepo.update_all(set: [warning_fired: true, updated_at: DateTime.utc_now()])
 
-    if count == 1 do
-      payload = %{
-        "budget_id" => budget.id,
-        "scope_type" => to_string(budget.scope_type),
-        "scope_id" => budget.scope_id,
-        "budget_millicents" => budget.budget_millicents,
-        "current_spend_millicents" => spend,
-        "utilization_pct" => utilization_pct,
-        "alert_threshold_pct" => budget.alert_threshold_pct,
-        "triggering_report_id" => report.id
-      }
-
-      fire_budget_event(tenant_id, "token.budget_warning", report.project_id, payload)
-    end
+    count == 1
   end
 
-  # Fires a budget_exceeded webhook event using atomic CAS to prevent duplicate
-  # fires under concurrent requests. Same pattern as warning above.
-  defp maybe_fire_exceeded_webhook(tenant_id, budget, spend, utilization_pct, report) do
+  defp claim_budget_threshold(budget, :exceeded) do
     {count, _} =
       Budget
       |> where([b], b.id == ^budget.id and b.exceeded_fired == false)
       |> AdminRepo.update_all(set: [exceeded_fired: true, updated_at: DateTime.utc_now()])
 
-    if count == 1 do
-      overage = max(spend - budget.budget_millicents, 0)
+    count == 1
+  end
 
-      payload = %{
-        "budget_id" => budget.id,
-        "scope_type" => to_string(budget.scope_type),
-        "scope_id" => budget.scope_id,
-        "budget_millicents" => budget.budget_millicents,
-        "current_spend_millicents" => spend,
-        "utilization_pct" => utilization_pct,
-        "alert_threshold_pct" => budget.alert_threshold_pct,
-        "triggering_report_id" => report.id,
-        "overage_millicents" => overage
-      }
+  # Fires a budget_warning webhook event. Deduplication is handled by the
+  # claim_budget_threshold/2 CAS at the call site, so this only builds the
+  # payload and enqueues the event.
+  defp fire_warning_webhook(tenant_id, budget, spend, utilization_pct, report) do
+    payload = %{
+      "budget_id" => budget.id,
+      "scope_type" => to_string(budget.scope_type),
+      "scope_id" => budget.scope_id,
+      "budget_millicents" => budget.budget_millicents,
+      "current_spend_millicents" => spend,
+      "utilization_pct" => utilization_pct,
+      "alert_threshold_pct" => budget.alert_threshold_pct,
+      "triggering_report_id" => report.id
+    }
 
-      fire_budget_event(tenant_id, "token.budget_exceeded", report.project_id, payload)
-    end
+    fire_budget_event(tenant_id, "token.budget_warning", report.project_id, payload)
+  end
+
+  # Fires a budget_exceeded webhook event. Deduplication is handled by the
+  # claim_budget_threshold/2 CAS at the call site.
+  defp fire_exceeded_webhook(tenant_id, budget, spend, utilization_pct, report) do
+    overage = max(spend - budget.budget_millicents, 0)
+
+    payload = %{
+      "budget_id" => budget.id,
+      "scope_type" => to_string(budget.scope_type),
+      "scope_id" => budget.scope_id,
+      "budget_millicents" => budget.budget_millicents,
+      "current_spend_millicents" => spend,
+      "utilization_pct" => utilization_pct,
+      "alert_threshold_pct" => budget.alert_threshold_pct,
+      "triggering_report_id" => report.id,
+      "overage_millicents" => overage
+    }
+
+    fire_budget_event(tenant_id, "token.budget_exceeded", report.project_id, payload)
   end
 
   # Creates webhook events for matching subscriptions. Passes project_id so
@@ -1199,26 +1242,49 @@ defmodule Loopctl.TokenUsage do
     where(query, [b], b.scope_id == ^value)
   end
 
+  # Base query for reports that count toward story/epic/project totals and spend.
+  #
+  # A report counts when it is NOT soft-deleted AND, if it is a correction
+  # (`corrects_report_id` set), its original report is also NOT soft-deleted.
+  # The LEFT JOIN on the original (at most one row per correction, so sums do
+  # not fan out) lets a single predicate exclude a negative correction whose
+  # original was soft-deleted or expired — otherwise the surviving negative
+  # correction would strand and drive story/epic/project totals negative
+  # (tokens-04). Originals (`corrects_report_id IS NULL`) always count when live.
+  defp countable_reports(tenant_id) do
+    from(r in Report,
+      as: :report,
+      left_join: orig in Report,
+      as: :original,
+      on: orig.id == r.corrects_report_id,
+      where: r.tenant_id == ^tenant_id,
+      where: is_nil(r.deleted_at),
+      where:
+        is_nil(r.corrects_report_id) or
+          (not is_nil(orig.id) and is_nil(orig.deleted_at))
+    )
+  end
+
   defp spend_query(tenant_id, :story, scope_id) do
-    Report
-    |> where([r], r.tenant_id == ^tenant_id and r.story_id == ^scope_id)
-    |> where([r], is_nil(r.deleted_at))
-    |> select([r], coalesce(sum(r.cost_millicents), 0))
+    tenant_id
+    |> countable_reports()
+    |> where([report: r], r.story_id == ^scope_id)
+    |> select([report: r], coalesce(sum(r.cost_millicents), 0))
   end
 
   defp spend_query(tenant_id, :epic, scope_id) do
-    Report
-    |> join(:inner, [r], s in Story, on: r.story_id == s.id)
-    |> where([r, s], r.tenant_id == ^tenant_id and s.epic_id == ^scope_id)
-    |> where([r, _s], is_nil(r.deleted_at))
-    |> select([r, _s], coalesce(sum(r.cost_millicents), 0))
+    tenant_id
+    |> countable_reports()
+    |> join(:inner, [report: r], s in Story, as: :story, on: r.story_id == s.id)
+    |> where([story: s], s.epic_id == ^scope_id)
+    |> select([report: r], coalesce(sum(r.cost_millicents), 0))
   end
 
   defp spend_query(tenant_id, :project, scope_id) do
-    Report
-    |> where([r], r.tenant_id == ^tenant_id and r.project_id == ^scope_id)
-    |> where([r], is_nil(r.deleted_at))
-    |> select([r], coalesce(sum(r.cost_millicents), 0))
+    tenant_id
+    |> countable_reports()
+    |> where([report: r], r.project_id == ^scope_id)
+    |> select([report: r], coalesce(sum(r.cost_millicents), 0))
   end
 
   # Batch computes spend for all budgets in at most 3 queries (one per scope type)
@@ -1246,32 +1312,32 @@ defmodule Loopctl.TokenUsage do
   end
 
   defp batch_spend_query(tenant_id, :story, scope_ids) do
-    Report
-    |> where([r], r.tenant_id == ^tenant_id and r.story_id in ^scope_ids)
-    |> where([r], is_nil(r.deleted_at))
-    |> group_by([r], r.story_id)
-    |> select([r], {r.story_id, coalesce(sum(r.cost_millicents), 0)})
+    tenant_id
+    |> countable_reports()
+    |> where([report: r], r.story_id in ^scope_ids)
+    |> group_by([report: r], r.story_id)
+    |> select([report: r], {r.story_id, coalesce(sum(r.cost_millicents), 0)})
     |> AdminRepo.all()
     |> Enum.map(fn {scope_id, spend} -> {{:story, scope_id}, decimal_to_int(spend)} end)
   end
 
   defp batch_spend_query(tenant_id, :epic, scope_ids) do
-    Report
-    |> join(:inner, [r], s in Story, on: r.story_id == s.id)
-    |> where([r, s], r.tenant_id == ^tenant_id and s.epic_id in ^scope_ids)
-    |> where([r, _s], is_nil(r.deleted_at))
-    |> group_by([r, s], s.epic_id)
-    |> select([r, s], {s.epic_id, coalesce(sum(r.cost_millicents), 0)})
+    tenant_id
+    |> countable_reports()
+    |> join(:inner, [report: r], s in Story, as: :story, on: r.story_id == s.id)
+    |> where([story: s], s.epic_id in ^scope_ids)
+    |> group_by([story: s], s.epic_id)
+    |> select([report: r, story: s], {s.epic_id, coalesce(sum(r.cost_millicents), 0)})
     |> AdminRepo.all()
     |> Enum.map(fn {scope_id, spend} -> {{:epic, scope_id}, decimal_to_int(spend)} end)
   end
 
   defp batch_spend_query(tenant_id, :project, scope_ids) do
-    Report
-    |> where([r], r.tenant_id == ^tenant_id and r.project_id in ^scope_ids)
-    |> where([r], is_nil(r.deleted_at))
-    |> group_by([r], r.project_id)
-    |> select([r], {r.project_id, coalesce(sum(r.cost_millicents), 0)})
+    tenant_id
+    |> countable_reports()
+    |> where([report: r], r.project_id in ^scope_ids)
+    |> group_by([report: r], r.project_id)
+    |> select([report: r], {r.project_id, coalesce(sum(r.cost_millicents), 0)})
     |> AdminRepo.all()
     |> Enum.map(fn {scope_id, spend} -> {{:project, scope_id}, decimal_to_int(spend)} end)
   end

--- a/lib/loopctl/token_usage/analytics.ex
+++ b/lib/loopctl/token_usage/analytics.ex
@@ -67,6 +67,7 @@ defmodule Loopctl.TokenUsage.Analytics do
       |> where([r], r.tenant_id == ^tenant_id)
       |> where([r], is_nil(r.deleted_at))
       |> where([r], not is_nil(r.agent_id))
+      |> Report.exclude_stranded_corrections()
       |> apply_date_filters(opts)
       |> apply_project_filter(opts)
 
@@ -243,6 +244,7 @@ defmodule Loopctl.TokenUsage.Analytics do
           Report
           |> where([r], r.tenant_id == ^tenant_id and r.project_id == ^project_id)
           |> where([r], is_nil(r.deleted_at))
+          |> Report.exclude_stranded_corrections()
           |> select([r], %{
             total_input_tokens: coalesce(sum(r.input_tokens), 0),
             total_output_tokens: coalesce(sum(r.output_tokens), 0),
@@ -311,6 +313,7 @@ defmodule Loopctl.TokenUsage.Analytics do
       Report
       |> where([r], r.tenant_id == ^tenant_id)
       |> where([r], is_nil(r.deleted_at))
+      |> Report.exclude_stranded_corrections()
       |> apply_date_filters(opts)
       |> apply_project_filter(opts)
 
@@ -401,6 +404,7 @@ defmodule Loopctl.TokenUsage.Analytics do
       Report
       |> where([r], r.tenant_id == ^tenant_id)
       |> where([r], is_nil(r.deleted_at))
+      |> Report.exclude_stranded_corrections()
       |> apply_date_filters(opts)
       |> apply_project_filter(opts)
 
@@ -500,6 +504,7 @@ defmodule Loopctl.TokenUsage.Analytics do
       Report
       |> where([r], r.tenant_id == ^tenant_id)
       |> where([r], is_nil(r.deleted_at))
+      |> Report.exclude_stranded_corrections()
       |> apply_date_filters(opts)
       |> apply_project_filter(opts)
       |> apply_agent_filter(opts)
@@ -638,6 +643,7 @@ defmodule Loopctl.TokenUsage.Analytics do
     Report
     |> where([r], r.tenant_id == ^tenant_id and r.agent_id in ^agent_ids)
     |> where([r], is_nil(r.deleted_at))
+    |> Report.exclude_stranded_corrections()
     |> apply_date_filters(opts)
     |> apply_project_filter(opts)
     |> group_by([r], [r.agent_id, r.model_name])
@@ -664,6 +670,7 @@ defmodule Loopctl.TokenUsage.Analytics do
     |> join(:inner, [r], s in Story, on: r.story_id == s.id)
     |> where([r, _s], r.tenant_id == ^tenant_id)
     |> where([r, _s], is_nil(r.deleted_at))
+    |> Report.exclude_stranded_corrections()
     |> where([_r, s], s.epic_id in ^epic_ids)
     |> group_by([_r, s], s.epic_id)
     |> select([r, s], %{
@@ -714,6 +721,7 @@ defmodule Loopctl.TokenUsage.Analytics do
     |> join(:inner, [r], s in Story, on: r.story_id == s.id)
     |> where([r, _s], r.tenant_id == ^tenant_id)
     |> where([r, _s], is_nil(r.deleted_at))
+    |> Report.exclude_stranded_corrections()
     |> where([_r, s], s.epic_id in ^epic_ids)
     |> group_by([r, s], [s.epic_id, r.model_name])
     |> select([r, s], %{
@@ -754,6 +762,7 @@ defmodule Loopctl.TokenUsage.Analytics do
     Report
     |> where([r], r.tenant_id == ^tenant_id and r.project_id == ^project_id)
     |> where([r], is_nil(r.deleted_at))
+    |> Report.exclude_stranded_corrections()
     |> group_by([r], r.phase)
     |> select([r], %{
       phase: r.phase,
@@ -767,6 +776,7 @@ defmodule Loopctl.TokenUsage.Analytics do
     Report
     |> where([r], r.tenant_id == ^tenant_id and r.project_id == ^project_id)
     |> where([r], is_nil(r.deleted_at))
+    |> Report.exclude_stranded_corrections()
     |> group_by([r], r.model_name)
     |> select([r], %{
       model_name: r.model_name,
@@ -826,6 +836,7 @@ defmodule Loopctl.TokenUsage.Analytics do
       Report
       |> where([r], r.tenant_id == ^tenant_id and r.agent_id == ^agent_id)
       |> where([r], is_nil(r.deleted_at))
+      |> Report.exclude_stranded_corrections()
       |> apply_date_filters(opts)
       |> apply_project_filter(opts)
 
@@ -984,6 +995,7 @@ defmodule Loopctl.TokenUsage.Analytics do
       |> where([r, _s], r.tenant_id == ^tenant_id)
       |> where([r, _s], is_nil(r.deleted_at))
       |> where([r, _s], not is_nil(r.agent_id))
+      |> Report.exclude_stranded_corrections()
       |> apply_model_date_filters(opts)
       |> apply_model_project_filter(opts)
       |> group_by([r, _s], r.agent_id)

--- a/lib/loopctl/token_usage/default_archival.ex
+++ b/lib/loopctl/token_usage/default_archival.ex
@@ -106,14 +106,29 @@ defmodule Loopctl.TokenUsage.DefaultArchival do
 
   # Hard-delete pass: permanently remove reports deleted > grace_days ago.
   # Uses a subquery (WHERE id IN (...)) to apply batched delete.
+  #
+  # Skip-if-referenced (tokens-03): an expired original that is STILL referenced
+  # by a correction (via `corrects_report_id`) is excluded from the delete set.
+  # `corrects_report_id` has no ON DELETE cascade/nullify, so hard-deleting a
+  # referenced original raises an FK violation that would crash the archival
+  # worker and wedge archival for every tenant in the run. Corrections are
+  # created later than their originals, so a correction survives the cutoff after
+  # its original expires — we skip the original until the correction ALSO expires
+  # and is hard-deleted (corrections are leaves: nothing references them, so they
+  # are removed first). This preserves total attribution: we never null out a
+  # correction's `corrects_report_id`. The batch loop still terminates because a
+  # permanently-referenced original is never selected (count reaches 0).
   defp do_hard_delete_batch(tenant_id, grace_cutoff, total_deleted) do
     result =
       Repo.with_tenant(tenant_id, fn ->
         subq =
           from(r in Report,
+            as: :expired,
             where: r.tenant_id == ^tenant_id,
             where: not is_nil(r.deleted_at),
             where: r.deleted_at < ^grace_cutoff,
+            where:
+              not exists(from(c in Report, where: c.corrects_report_id == parent_as(:expired).id)),
             select: r.id,
             limit: @batch_size
           )

--- a/lib/loopctl/token_usage/default_rollup.ex
+++ b/lib/loopctl/token_usage/default_rollup.ex
@@ -39,6 +39,7 @@ defmodule Loopctl.TokenUsage.DefaultRollup do
       Report
       |> where([r], r.tenant_id == ^tenant_id)
       |> where([r], is_nil(r.deleted_at))
+      |> Report.exclude_stranded_corrections()
       |> where([r], r.inserted_at >= ^start_dt and r.inserted_at <= ^end_dt)
       |> where([r], not is_nil(r.agent_id))
       |> group_by([r], r.agent_id)
@@ -75,6 +76,7 @@ defmodule Loopctl.TokenUsage.DefaultRollup do
       |> join(:inner, [r], s in Story, on: r.story_id == s.id)
       |> where([r, _s], r.tenant_id == ^tenant_id)
       |> where([r, _s], is_nil(r.deleted_at))
+      |> Report.exclude_stranded_corrections()
       |> where([r, _s], r.inserted_at >= ^start_dt and r.inserted_at <= ^end_dt)
       |> group_by([_r, s], s.epic_id)
       |> select([r, s], %{
@@ -115,6 +117,7 @@ defmodule Loopctl.TokenUsage.DefaultRollup do
       Report
       |> where([r], r.tenant_id == ^tenant_id)
       |> where([r], is_nil(r.deleted_at))
+      |> Report.exclude_stranded_corrections()
       |> where([r], r.inserted_at >= ^start_dt and r.inserted_at <= ^end_dt)
       |> where([r], not is_nil(r.project_id))
       |> group_by([r], r.project_id)
@@ -179,6 +182,7 @@ defmodule Loopctl.TokenUsage.DefaultRollup do
     |> where([r], r.agent_id in ^scope_ids)
     |> where([r], r.tenant_id == ^tenant_id)
     |> where([r], is_nil(r.deleted_at))
+    |> Report.exclude_stranded_corrections()
     |> where([r], r.inserted_at >= ^start_dt and r.inserted_at <= ^end_dt)
     |> group_by([r], [r.agent_id, r.model_name, r.phase])
     |> select([r], %{
@@ -196,6 +200,7 @@ defmodule Loopctl.TokenUsage.DefaultRollup do
     |> join(:inner, [r], s in Story, on: r.story_id == s.id)
     |> where([r, _s], r.tenant_id == ^tenant_id)
     |> where([r, _s], is_nil(r.deleted_at))
+    |> Report.exclude_stranded_corrections()
     |> where([r, _s], r.inserted_at >= ^start_dt and r.inserted_at <= ^end_dt)
     |> where([_r, s], s.epic_id in ^scope_ids)
     |> group_by([r, s], [s.epic_id, r.model_name, r.phase])
@@ -214,6 +219,7 @@ defmodule Loopctl.TokenUsage.DefaultRollup do
     |> where([r], r.project_id in ^scope_ids)
     |> where([r], r.tenant_id == ^tenant_id)
     |> where([r], is_nil(r.deleted_at))
+    |> Report.exclude_stranded_corrections()
     |> where([r], r.inserted_at >= ^start_dt and r.inserted_at <= ^end_dt)
     |> group_by([r], [r.project_id, r.model_name, r.phase])
     |> select([r], %{

--- a/lib/loopctl/token_usage/report.ex
+++ b/lib/loopctl/token_usage/report.ex
@@ -23,6 +23,8 @@ defmodule Loopctl.TokenUsage.Report do
 
   use Loopctl.Schema, soft_delete: true
 
+  import Ecto.Query, only: [where: 3]
+
   @type t :: %__MODULE__{}
 
   @phases ~w(planning implementing reviewing other)
@@ -144,6 +146,43 @@ defmodule Loopctl.TokenUsage.Report do
     |> foreign_key_constraint(:project_id)
     |> foreign_key_constraint(:skill_version_id)
     |> foreign_key_constraint(:corrects_report_id)
+  end
+
+  @doc """
+  Composable query builder that excludes "stranded" correction rows from any
+  `token_usage_reports` aggregate/total query (tokens-04).
+
+  A report counts toward a total only when it is NOT a correction, OR its
+  referenced original is still live (present and not soft-deleted). Without
+  this, a negative correction survives after its original is soft-deleted or
+  expired and drives story/epic/project totals — and any derived spend/rollup —
+  negative.
+
+  This is the SINGLE reusable predicate every total-computing query pipes
+  through, so no query drifts back to a bare `is_nil(deleted_at)` filter. It is
+  expressed as a `where` on the FIRST query binding (a `token_usage_reports`
+  row) via a correlated `EXISTS`, so it composes onto any query — with or
+  without joins — without shifting positional bindings or fanning out sums.
+
+  The correlated subquery is tenant-scoped (`o.tenant_id = r.tenant_id`) as
+  defense-in-depth so it can never count against a cross-tenant original, even
+  under `AdminRepo` (BYPASSRLS).
+
+  Callers must still apply their own `is_nil(r.deleted_at)` filter; this only
+  adds the correction/original consistency predicate.
+  """
+  @spec exclude_stranded_corrections(Ecto.Queryable.t()) :: Ecto.Query.t()
+  def exclude_stranded_corrections(query) do
+    where(
+      query,
+      [r],
+      is_nil(r.corrects_report_id) or
+        fragment(
+          "EXISTS (SELECT 1 FROM token_usage_reports o WHERE o.id = ? AND o.tenant_id = ? AND o.deleted_at IS NULL)",
+          r.corrects_report_id,
+          r.tenant_id
+        )
+    )
   end
 
   @metadata_max_bytes 65_536

--- a/lib/loopctl/workers/cost_anomaly_worker.ex
+++ b/lib/loopctl/workers/cost_anomaly_worker.ex
@@ -89,6 +89,7 @@ defmodule Loopctl.Workers.CostAnomalyWorker do
       |> join(:inner, [r], s in Story, on: r.story_id == s.id)
       |> where([r, _s], r.tenant_id == ^tenant_id)
       |> where([r, _s], is_nil(r.deleted_at))
+      |> Report.exclude_stranded_corrections()
       |> where([_r, s], s.epic_id in ^epic_ids)
       |> where([r, _s], r.inserted_at >= ^start_dt and r.inserted_at <= ^end_dt)
       |> group_by([r, s], [r.story_id, s.epic_id])

--- a/lib/loopctl/workers/token_data_archival_worker.ex
+++ b/lib/loopctl/workers/token_data_archival_worker.ex
@@ -60,12 +60,30 @@ defmodule Loopctl.Workers.TokenDataArchivalWorker do
     tenants = list_active_tenants(args)
     Logger.info("TokenDataArchivalWorker: processing #{length(tenants)} tenants")
 
-    Enum.each(tenants, &process_tenant/1)
+    Enum.each(tenants, &process_tenant_safe/1)
 
     :ok
   end
 
   # --- Private helpers ---
+
+  # Per-tenant fault isolation (tokens-03): a failure processing ONE tenant must
+  # NOT abort the whole run for the others. Any RAISED error (e.g. an unexpected
+  # DB/FK error while hard-deleting) is caught and logged so archival still runs
+  # for every other tenant — one tenant's data can never wedge global archival.
+  # Expected `{:error, _}` returns from the archival service are already handled
+  # non-fatally inside run_soft_delete/run_hard_delete/run_archive_anomalies.
+  defp process_tenant_safe(%Tenant{id: tenant_id} = tenant) do
+    process_tenant(tenant)
+  rescue
+    e ->
+      Logger.error(
+        "TokenDataArchivalWorker: tenant #{tenant_id} failed, skipping to next tenant: " <>
+          Exception.message(e)
+      )
+
+      :ok
+  end
 
   defp process_tenant(%Tenant{id: tenant_id, token_data_retention_days: retention_days}) do
     # Hard-delete pass runs for ALL tenants (clears previously soft-deleted reports)

--- a/priv/repo/migrations/20260702000000_add_corrects_report_id_index.exs
+++ b/priv/repo/migrations/20260702000000_add_corrects_report_id_index.exs
@@ -1,0 +1,18 @@
+defmodule Loopctl.Repo.Migrations.AddCorrectsReportIdIndex do
+  use Ecto.Migration
+
+  # Supports the tokens-03 archival "skip-if-referenced" guard, whose
+  # `NOT EXISTS (... WHERE corrects_report_id = <original>.id)` self-join
+  # otherwise triggers a full table scan on every hard-delete batch, for every
+  # tenant, every weekly run. Partial index (only correction rows carry a
+  # non-null corrects_report_id) keeps it small. Also supports the tokens-04
+  # "count a correction only if its original is live" lookups.
+  #
+  # Index only — no RLS change needed.
+  def change do
+    create index(:token_usage_reports, [:corrects_report_id],
+             where: "corrects_report_id IS NOT NULL",
+             name: :token_usage_reports_corrects_report_id_idx
+           )
+  end
+end

--- a/test/loopctl/token_usage/correction_lock_test.exs
+++ b/test/loopctl/token_usage/correction_lock_test.exs
@@ -1,0 +1,95 @@
+defmodule Loopctl.TokenUsage.CorrectionLockTest do
+  @moduledoc """
+  Deterministic proof that the per-story correction advisory lock (tokens-02)
+  genuinely SERIALIZES concurrent corrections across separate DB sessions — the
+  guarantee that closes the double-submit race, not the fast re-validation.
+
+  A true two-`Task.async` `create_correction/4` race cannot distinguish "lock
+  present" from "lock absent" under `Ecto.Adapters.SQL.Sandbox`: the sandbox
+  multiplexes every allowed process onto ONE checked-out connection, so
+  connection-level serialization alone already makes the loser re-read the
+  winner's committed total (verified empirically — removing the lock leaves that
+  invariant test green). So the lock is proven in two deterministic parts:
+
+    1. `token_usage_corrections_test.exs` asserts (via query telemetry) that
+       `create_correction/4` actually issues `pg_advisory_xact_lock` with
+       `correction_lock_key/2` — fails if the lock step is removed.
+    2. THIS test proves that lock, on the exact key, blocks a SECOND real DB
+       session (not re-entrant on one connection) — using two `sandbox: false`
+       connections so they are genuinely independent.
+
+  Uses real (committing) connections, so `async: false`.
+  """
+
+  use ExUnit.Case, async: false
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Loopctl.AdminRepo
+  alias Loopctl.TokenUsage
+
+  describe "correction_lock_key/2 (tokens-02, FIX 6)" do
+    test "is deterministic, scoped to (tenant, story), and in signed 64-bit range" do
+      tenant = Ecto.UUID.generate()
+      story = Ecto.UUID.generate()
+
+      key = TokenUsage.correction_lock_key(tenant, story)
+
+      assert is_integer(key)
+      # Release-independent: same inputs always yield the same key.
+      assert TokenUsage.correction_lock_key(tenant, story) == key
+      # Scoped: a different story or tenant yields a different key.
+      refute TokenUsage.correction_lock_key(tenant, Ecto.UUID.generate()) == key
+      refute TokenUsage.correction_lock_key(Ecto.UUID.generate(), story) == key
+      # Fits a PostgreSQL bigint advisory lock key.
+      assert key >= -0x8000_0000_0000_0000
+      assert key <= 0x7FFF_FFFF_FFFF_FFFF
+    end
+  end
+
+  describe "advisory lock serialization across sessions (tokens-02)" do
+    test "the per-story lock blocks a second real session while held, and frees on release" do
+      tenant = Ecto.UUID.generate()
+      story = Ecto.UUID.generate()
+      key = TokenUsage.correction_lock_key(tenant, story)
+
+      parent = self()
+
+      # Holder: an independent real session that grabs the xact lock inside an
+      # open transaction and waits, so the lock stays held.
+      holder =
+        Task.async(fn ->
+          :ok = Sandbox.checkout(AdminRepo, sandbox: false)
+
+          AdminRepo.transaction(fn ->
+            AdminRepo.query!("SELECT pg_advisory_xact_lock($1)", [key])
+            send(parent, :locked)
+
+            receive do
+              :release -> :ok
+            end
+          end)
+        end)
+
+      assert_receive :locked, 2_000
+
+      # A DIFFERENT real session must NOT be able to take the same xact lock
+      # while the holder's transaction holds it. If the lock were a no-op or
+      # re-entrant per-connection, this try would wrongly succeed.
+      :ok = Sandbox.checkout(AdminRepo, sandbox: false)
+
+      %{rows: [[got_while_held]]} =
+        AdminRepo.query!("SELECT pg_try_advisory_xact_lock($1)", [key])
+
+      refute got_while_held
+
+      # Release the holder; the lock frees so a fresh session can take it.
+      send(holder.pid, :release)
+      Task.await(holder, 2_000)
+
+      %{rows: [[got_after_release]]} =
+        AdminRepo.query!("SELECT pg_try_advisory_xact_lock($1)", [key])
+
+      assert got_after_release
+    end
+  end
+end

--- a/test/loopctl/token_usage/default_archival_test.exs
+++ b/test/loopctl/token_usage/default_archival_test.exs
@@ -129,6 +129,29 @@ defmodule Loopctl.TokenUsage.DefaultArchivalTest do
     report
   end
 
+  # Insert a correction referencing an original report via Repo.with_tenant.
+  defp insert_correction(ctx, original) do
+    {:ok, correction} =
+      Repo.with_tenant(ctx.tenant.id, fn ->
+        %Report{
+          tenant_id: ctx.tenant.id,
+          story_id: ctx.story.id,
+          agent_id: ctx.agent.id,
+          project_id: ctx.project.id,
+          corrects_report_id: original.id
+        }
+        |> Report.correction_changeset(%{
+          input_tokens: -10,
+          output_tokens: -5,
+          model_name: "claude-opus-4",
+          cost_millicents: -50
+        })
+        |> Repo.insert!()
+      end)
+
+    correction
+  end
+
   # Backdate a report's inserted_at
   defp backdate_report(report, days_ago) do
     past = DateTime.add(DateTime.utc_now(), -days_ago * 86_400, :second)
@@ -276,6 +299,50 @@ defmodule Loopctl.TokenUsage.DefaultArchivalTest do
         Repo.with_tenant(ctx_b.tenant.id, fn -> Repo.get(Report, report_b.id) end)
 
       assert fetched_b != nil
+    end
+  end
+
+  describe "hard_delete_expired_reports/1 with corrections (tokens-03)" do
+    test "does NOT hard-delete an expired original still referenced by a live correction (no FK crash)" do
+      ctx = make_context()
+      original = insert_report(ctx)
+      # A live correction (recent) referencing the original survives the cutoff.
+      correction = insert_correction(ctx, original)
+
+      # Original soft-deleted > 30 days ago (past the grace cutoff).
+      soft_delete_report(original, 31)
+
+      # Must NOT raise an FK violation and must NOT delete the referenced original.
+      assert {:ok, 0} = DefaultArchival.hard_delete_expired_reports(ctx.tenant.id)
+
+      assert Repo.get(Report, original.id) != nil
+      assert Repo.get(Report, correction.id) != nil
+    end
+
+    test "hard-deletes both when correction and original have expired (correction first, FK-safe)" do
+      ctx = make_context()
+      original = insert_report(ctx)
+      correction = insert_correction(ctx, original)
+
+      # Both soft-deleted past the grace cutoff.
+      soft_delete_report(original, 31)
+      soft_delete_report(correction, 31)
+
+      # One run removes both — the correction (a leaf) first, then the now
+      # unreferenced original — FK-safe and crash-free.
+      assert {:ok, 2} = DefaultArchival.hard_delete_expired_reports(ctx.tenant.id)
+
+      assert Repo.get(Report, original.id) == nil
+      assert Repo.get(Report, correction.id) == nil
+    end
+
+    test "still hard-deletes an expired original that has NO corrections" do
+      ctx = make_context()
+      original = insert_report(ctx)
+      soft_delete_report(original, 31)
+
+      assert {:ok, 1} = DefaultArchival.hard_delete_expired_reports(ctx.tenant.id)
+      assert Repo.get(Report, original.id) == nil
     end
   end
 

--- a/test/loopctl/token_usage/stranded_correction_totals_test.exs
+++ b/test/loopctl/token_usage/stranded_correction_totals_test.exs
@@ -1,0 +1,224 @@
+defmodule Loopctl.TokenUsage.StrandedCorrectionTotalsTest do
+  @moduledoc """
+  Cross-module regression for tokens-04: after an ORIGINAL report is
+  soft-deleted, its surviving negative correction must NOT be stranded into any
+  total-computing query. Every analytics endpoint, the cost-summary rollup, and
+  the cost-anomaly per-story cost must exclude the stranded correction so no
+  total goes negative (or skews low).
+
+  Guards against regressions where a query filters only `is_nil(deleted_at)`
+  without routing through `Report.exclude_stranded_corrections/1`.
+  """
+
+  use Loopctl.DataCase, async: true
+
+  import Ecto.Query
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.TokenUsage
+  alias Loopctl.TokenUsage.Analytics
+  alias Loopctl.TokenUsage.CostAnomaly
+  alias Loopctl.TokenUsage.CostSummary
+  alias Loopctl.TokenUsage.DefaultRollup
+  alias Loopctl.Workers.CostAnomalyWorker
+
+  setup :verify_on_exit!
+
+  defp setup_stranded do
+    tenant = fixture(:tenant)
+    project = fixture(:project, %{tenant_id: tenant.id})
+    epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+    agent = fixture(:agent, %{tenant_id: tenant.id})
+
+    story =
+      fixture(:story, %{tenant_id: tenant.id, epic_id: epic.id, project_id: project.id})
+
+    {:ok, original} =
+      TokenUsage.create_report(tenant.id, %{
+        story_id: story.id,
+        agent_id: agent.id,
+        project_id: project.id,
+        input_tokens: 1000,
+        output_tokens: 500,
+        model_name: "claude-opus-4",
+        cost_millicents: 2500
+      })
+
+    {:ok, _correction} =
+      TokenUsage.create_correction(tenant.id, original.id, %{
+        input_tokens: -100,
+        output_tokens: -50,
+        cost_millicents: -250
+      })
+
+    # Remove the positive original, leaving only the negative correction.
+    {:ok, _} = TokenUsage.delete_report(tenant.id, original.id)
+
+    %{tenant: tenant, project: project, epic: epic, agent: agent, story: story}
+  end
+
+  test "story totals never go negative after the original is soft-deleted" do
+    %{tenant: tenant, story: story} = setup_stranded()
+
+    {:ok, totals} = TokenUsage.get_story_totals(tenant.id, story.id)
+    assert totals.total_cost_millicents == 0
+    assert totals.total_input_tokens == 0
+    assert totals.total_output_tokens == 0
+  end
+
+  test "project_metrics excludes the stranded correction" do
+    %{tenant: tenant, project: project} = setup_stranded()
+
+    {:ok, m} = Analytics.project_metrics(tenant.id, project.id)
+    assert m.total_cost_millicents == 0
+    assert m.total_input_tokens == 0
+    assert m.total_output_tokens == 0
+    assert m.total_cost_millicents >= 0
+  end
+
+  test "epic_metrics excludes the stranded correction" do
+    %{tenant: tenant, epic: epic} = setup_stranded()
+
+    {:ok, %{data: data}} = Analytics.epic_metrics(tenant.id)
+    entry = Enum.find(data, &(&1.epic_id == epic.id))
+
+    assert entry.total_cost_millicents == 0
+    assert Enum.all?(data, &(&1.total_cost_millicents >= 0))
+  end
+
+  test "agent_metrics never returns a negative agent total" do
+    %{tenant: tenant, agent: agent} = setup_stranded()
+
+    {:ok, %{data: data}} = Analytics.agent_metrics(tenant.id)
+
+    assert Enum.all?(data, &(&1.total_cost_millicents >= 0))
+
+    case Enum.find(data, &(&1.agent_id == agent.id)) do
+      nil -> :ok
+      entry -> assert entry.total_cost_millicents == 0
+    end
+  end
+
+  test "model_metrics never returns a negative model total" do
+    %{tenant: tenant} = setup_stranded()
+
+    {:ok, %{data: data}} = Analytics.model_metrics(tenant.id)
+    assert Enum.all?(data, &(&1.total_cost_millicents >= 0))
+  end
+
+  test "trend_metrics never returns a negative period total" do
+    %{tenant: tenant} = setup_stranded()
+
+    {:ok, %{data: data}} = Analytics.trend_metrics(tenant.id)
+    assert Enum.all?(data, &(&1.total_cost_millicents >= 0))
+  end
+
+  test "model_mix matrix and comparative never go negative" do
+    %{tenant: tenant} = setup_stranded()
+
+    {:ok, %{matrix: matrix, comparative: comparative}} = Analytics.model_mix(tenant.id)
+
+    assert Enum.all?(matrix, &(&1.total_cost_millicents >= 0))
+
+    for group <- [comparative.mixed_model, comparative.single_model] do
+      case group.avg_cost_per_story_millicents do
+        nil -> :ok
+        avg -> assert avg >= 0
+      end
+    end
+  end
+
+  test "agent_model_profile excludes the stranded correction" do
+    %{tenant: tenant, agent: agent} = setup_stranded()
+
+    {:ok, profile} = Analytics.agent_model_profile(tenant.id, agent.id)
+    assert profile.total_cost_millicents == 0
+    assert Enum.all?(profile.usage, &(&1.total_cost_millicents >= 0))
+  end
+
+  test "cost-summary rollup never produces a negative scope total" do
+    %{tenant: tenant, epic: epic, project: project, agent: agent} = setup_stranded()
+
+    today = Date.utc_today()
+    {:ok, rows} = DefaultRollup.aggregate(tenant.id, today, today)
+
+    assert Enum.all?(rows, &(&1.total_cost_millicents >= 0))
+
+    for {scope_type, scope_id} <- [
+          {:epic, epic.id},
+          {:project, project.id},
+          {:agent, agent.id}
+        ] do
+      case Enum.find(rows, &(&1.scope_type == scope_type and &1.scope_id == scope_id)) do
+        nil -> :ok
+        row -> assert row.total_cost_millicents == 0
+      end
+    end
+  end
+
+  test "cost-anomaly per-story cost excludes the stranded correction (no false anomaly)" do
+    %{tenant: tenant, epic: epic, story: story} = setup_stranded()
+
+    today = Date.utc_today()
+
+    # Epic average so the worker has a reference. A stranded per-story cost of
+    # -250 would be far below 0.1x this average and (pre-fix) flag a false
+    # `suspiciously_low` anomaly. With the fix the story has no countable
+    # reports, so it never enters the per-story cost scan.
+    %CostSummary{tenant_id: tenant.id}
+    |> CostSummary.changeset(%{
+      scope_type: :epic,
+      scope_id: epic.id,
+      period_start: today,
+      period_end: today,
+      total_cost_millicents: 10_000,
+      story_count: 2,
+      avg_cost_per_story_millicents: 5_000
+    })
+    |> AdminRepo.insert!()
+
+    job_args = %{
+      "period_start" => Date.to_iso8601(today),
+      "period_end" => Date.to_iso8601(today)
+    }
+
+    assert :ok = CostAnomalyWorker.perform(%Oban.Job{args: job_args, id: 1})
+
+    anomalies =
+      CostAnomaly
+      |> where([a], a.tenant_id == ^tenant.id and a.story_id == ^story.id)
+      |> AdminRepo.all()
+
+    assert anomalies == []
+  end
+
+  test "a correction whose original is LIVE still counts across analytics" do
+    tenant = fixture(:tenant)
+    project = fixture(:project, %{tenant_id: tenant.id})
+    epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+    agent = fixture(:agent, %{tenant_id: tenant.id})
+    story = fixture(:story, %{tenant_id: tenant.id, epic_id: epic.id, project_id: project.id})
+
+    {:ok, original} =
+      TokenUsage.create_report(tenant.id, %{
+        story_id: story.id,
+        agent_id: agent.id,
+        project_id: project.id,
+        input_tokens: 1000,
+        output_tokens: 500,
+        model_name: "claude-opus-4",
+        cost_millicents: 2500
+      })
+
+    {:ok, _} =
+      TokenUsage.create_correction(tenant.id, original.id, %{
+        input_tokens: -100,
+        output_tokens: -50,
+        cost_millicents: -250
+      })
+
+    # Original live -> both the original and its correction count: 2500 - 250.
+    {:ok, m} = Analytics.project_metrics(tenant.id, project.id)
+    assert m.total_cost_millicents == 2250
+  end
+end

--- a/test/loopctl/token_usage_corrections_test.exs
+++ b/test/loopctl/token_usage_corrections_test.exs
@@ -72,6 +72,12 @@ defmodule Loopctl.TokenUsageCorrectionsTest do
     |> AdminRepo.all()
   end
 
+  defp count_threshold_audits(tenant_id, threshold_type) do
+    tenant_id
+    |> find_audit_entries("token_budget", "threshold_crossed")
+    |> Enum.count(&(&1.metadata["threshold_type"] == threshold_type))
+  end
+
   # ---------------------------------------------------------------------------
   # AC-21.13.1: Soft delete
   # ---------------------------------------------------------------------------
@@ -590,6 +596,259 @@ defmodule Loopctl.TokenUsageCorrectionsTest do
 
       other_tenant = fixture(:tenant)
       assert {:error, :not_found} = TokenUsage.get_report(other_tenant.id, report.id)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # tokens-02: concurrent correction validation cannot drive totals negative
+  # ---------------------------------------------------------------------------
+
+  describe "create_correction/4 concurrency safety (tokens-02)" do
+    test "takes a per-story advisory lock so concurrent corrections serialize" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+      original = create_report(tenant.id, story, agent, project)
+
+      test_pid = self()
+      handler_id = "tokens-02-lock-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler_id,
+        [:loopctl, :admin_repo, :query],
+        fn _event, _measurements, %{query: query}, _config ->
+          if query =~ "pg_advisory_xact_lock" do
+            send(test_pid, {:advisory_lock_query, query})
+          end
+        end,
+        nil
+      )
+
+      try do
+        assert {:ok, _correction} =
+                 TokenUsage.create_correction(tenant.id, original.id, %{
+                   input_tokens: -100,
+                   output_tokens: -50,
+                   cost_millicents: -250
+                 })
+      after
+        :telemetry.detach(handler_id)
+      end
+
+      # The correction transaction MUST acquire the per-story advisory xact lock
+      # that serializes concurrent corrections. If the lock step is removed, no
+      # such query runs under READ COMMITTED and two racing corrections could
+      # both pass validation — this assertion fails, catching that regression.
+      assert_receive {:advisory_lock_query, _}, 500
+    end
+
+    test "serialized over-subtraction is rejected; the story total never goes negative" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+      # story total: cost 2500, input 1000, output 500
+      original = create_report(tenant.id, story, agent, project)
+
+      # First correction zeroes the story out -> total 0.
+      assert {:ok, _} =
+               TokenUsage.create_correction(tenant.id, original.id, %{
+                 input_tokens: -1000,
+                 output_tokens: -500,
+                 cost_millicents: -2500
+               })
+
+      {:ok, after_first} = TokenUsage.get_story_totals(tenant.id, story.id)
+      assert after_first.total_cost_millicents == 0
+
+      # A SECOND correction (the double-submit/retry twin) that would subtract the
+      # same amount again must re-read the now-updated total and be rejected. The
+      # advisory lock forces this re-read under concurrency, so exactly one of two
+      # racing corrections wins and the total can never be driven negative.
+      assert {:error, :unprocessable_entity, message} =
+               TokenUsage.create_correction(tenant.id, original.id, %{
+                 input_tokens: 0,
+                 output_tokens: 0,
+                 cost_millicents: -2500
+               })
+
+      assert message =~ "cost_millicents"
+
+      {:ok, final} = TokenUsage.get_story_totals(tenant.id, story.id)
+      assert final.total_cost_millicents == 0
+      assert final.total_cost_millicents >= 0
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # tokens-04: soft-deleting an original must not strand its negative correction
+  # ---------------------------------------------------------------------------
+
+  describe "soft-delete total consistency (tokens-04)" do
+    test "soft-deleting an original excludes its negative correction (total never negative)" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+      # original: cost 2500, input 1000, output 500
+      original = create_report(tenant.id, story, agent, project)
+
+      {:ok, _correction} =
+        TokenUsage.create_correction(tenant.id, original.id, %{
+          input_tokens: -100,
+          output_tokens: -50,
+          cost_millicents: -250
+        })
+
+      # Both live: 2500 - 250 = 2250
+      {:ok, before} = TokenUsage.get_story_totals(tenant.id, story.id)
+      assert before.total_cost_millicents == 2250
+
+      # Soft-delete the ORIGINAL. Its surviving negative correction must NOT be
+      # counted on its own — that would strand it and drive the total to -250.
+      {:ok, _} = TokenUsage.delete_report(tenant.id, original.id)
+
+      {:ok, after_delete} = TokenUsage.get_story_totals(tenant.id, story.id)
+      assert after_delete.total_cost_millicents == 0
+      assert after_delete.total_input_tokens == 0
+      assert after_delete.total_output_tokens == 0
+      assert after_delete.total_cost_millicents >= 0
+      # The correction is excluded from the count as well.
+      assert after_delete.report_count == 0
+    end
+
+    test "a correction whose original is live still counts normally" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+      original = create_report(tenant.id, story, agent, project)
+
+      {:ok, _correction} =
+        TokenUsage.create_correction(tenant.id, original.id, %{
+          input_tokens: -100,
+          output_tokens: -50,
+          cost_millicents: -250
+        })
+
+      {:ok, totals} = TokenUsage.get_story_totals(tenant.id, story.id)
+      assert totals.total_cost_millicents == 2250
+      assert totals.total_input_tokens == 900
+      assert totals.total_output_tokens == 450
+      assert totals.report_count == 2
+    end
+
+    test "story/epic/project scope spend all exclude a stranded correction" do
+      %{tenant: tenant, story: story, agent: agent, project: project, epic: epic} =
+        setup_context()
+
+      original = create_report(tenant.id, story, agent, project)
+
+      {:ok, _} =
+        TokenUsage.create_correction(tenant.id, original.id, %{
+          input_tokens: 0,
+          output_tokens: 0,
+          cost_millicents: -250
+        })
+
+      {:ok, _} = TokenUsage.delete_report(tenant.id, original.id)
+
+      assert TokenUsage.get_scope_spend(tenant.id, :story, story.id) == 0
+      assert TokenUsage.get_scope_spend(tenant.id, :epic, epic.id) == 0
+      assert TokenUsage.get_scope_spend(tenant.id, :project, project.id) == 0
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # tokens-05: threshold_crossed audit rows are deduplicated per real crossing
+  # ---------------------------------------------------------------------------
+
+  describe "threshold_crossed audit dedup (tokens-05)" do
+    test "first warning crossing writes ONE audit; subsequent over-warning reports write none" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+
+      {:ok, _budget} =
+        TokenUsage.create_budget(tenant.id, %{
+          scope_type: :story,
+          scope_id: story.id,
+          budget_millicents: 10_000,
+          alert_threshold_pct: 80
+        })
+
+      # First report crosses the warning threshold (8500/10000 = 85%).
+      create_report(tenant.id, story, agent, project, %{cost_millicents: 8_500})
+      assert count_threshold_audits(tenant.id, "warning") == 1
+
+      # Further reports while STILL over the warning threshold must NOT write
+      # another threshold_crossed audit row (the bug wrote one on every report).
+      create_report(tenant.id, story, agent, project, %{cost_millicents: 200})
+      create_report(tenant.id, story, agent, project, %{cost_millicents: 200})
+      assert count_threshold_audits(tenant.id, "warning") == 1
+    end
+
+    test "crossing 100% after only warning writes the exceeded audit exactly once" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+
+      {:ok, _budget} =
+        TokenUsage.create_budget(tenant.id, %{
+          scope_type: :story,
+          scope_id: story.id,
+          budget_millicents: 10_000,
+          alert_threshold_pct: 80
+        })
+
+      # Cross warning only (85%).
+      create_report(tenant.id, story, agent, project, %{cost_millicents: 8_500})
+      assert count_threshold_audits(tenant.id, "warning") == 1
+      assert count_threshold_audits(tenant.id, "exceeded") == 0
+
+      # Now cross 100% — a GENUINE new crossing writes the exceeded audit once.
+      create_report(tenant.id, story, agent, project, %{cost_millicents: 3_000})
+      assert count_threshold_audits(tenant.id, "exceeded") == 1
+      assert count_threshold_audits(tenant.id, "warning") == 1
+
+      # A further over-100% report writes NO additional audit rows.
+      create_report(tenant.id, story, agent, project, %{cost_millicents: 500})
+      assert count_threshold_audits(tenant.id, "exceeded") == 1
+      assert count_threshold_audits(tenant.id, "warning") == 1
+    end
+
+    test "a single report crossing BOTH thresholds writes one warning and one exceeded" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+
+      {:ok, _budget} =
+        TokenUsage.create_budget(tenant.id, %{
+          scope_type: :story,
+          scope_id: story.id,
+          budget_millicents: 5_000,
+          alert_threshold_pct: 80
+        })
+
+      # 6000/5000 = 120% crosses warning AND exceeded at once.
+      create_report(tenant.id, story, agent, project, %{cost_millicents: 6_000})
+      assert count_threshold_audits(tenant.id, "warning") == 1
+      assert count_threshold_audits(tenant.id, "exceeded") == 1
+
+      create_report(tenant.id, story, agent, project, %{cost_millicents: 500})
+      assert count_threshold_audits(tenant.id, "warning") == 1
+      assert count_threshold_audits(tenant.id, "exceeded") == 1
+    end
+
+    test "reset semantics: after spend drops below threshold, a re-crossing writes a new audit" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+
+      {:ok, _budget} =
+        TokenUsage.create_budget(tenant.id, %{
+          scope_type: :story,
+          scope_id: story.id,
+          budget_millicents: 10_000,
+          alert_threshold_pct: 80
+        })
+
+      report = create_report(tenant.id, story, agent, project, %{cost_millicents: 8_500})
+      assert count_threshold_audits(tenant.id, "warning") == 1
+
+      # Drop spend far below the warning threshold via a correction — this resets
+      # warning_fired (same reset path the webhook dedup uses).
+      {:ok, _} =
+        TokenUsage.create_correction(tenant.id, report.id, %{
+          input_tokens: 0,
+          output_tokens: 0,
+          cost_millicents: -8_000
+        })
+
+      # Re-cross the warning threshold — a NEW crossing writes another audit row.
+      create_report(tenant.id, story, agent, project, %{cost_millicents: 8_000})
+      assert count_threshold_audits(tenant.id, "warning") == 2
     end
   end
 end

--- a/test/loopctl/token_usage_corrections_test.exs
+++ b/test/loopctl/token_usage_corrections_test.exs
@@ -603,7 +603,91 @@ defmodule Loopctl.TokenUsageCorrectionsTest do
   # tokens-02: concurrent correction validation cannot drive totals negative
   # ---------------------------------------------------------------------------
 
+  # ---------------------------------------------------------------------------
+  # tokens-03 retention gap: correction chains are bounded to depth 1
+  # ---------------------------------------------------------------------------
+
+  describe "create_correction/4 forbids correcting a correction (tokens-03)" do
+    test "correcting an ORIGINAL report succeeds" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+      original = create_report(tenant.id, story, agent, project)
+
+      assert {:ok, _correction} =
+               TokenUsage.create_correction(tenant.id, original.id, %{
+                 input_tokens: -100,
+                 output_tokens: -50,
+                 cost_millicents: -250
+               })
+    end
+
+    test "correcting a CORRECTION returns 422 (bounds the chain to depth 1)" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+      original = create_report(tenant.id, story, agent, project)
+
+      {:ok, correction} =
+        TokenUsage.create_correction(tenant.id, original.id, %{
+          input_tokens: -100,
+          output_tokens: -50,
+          cost_millicents: -250
+        })
+
+      # A correction-of-a-correction would create an unbounded lineage
+      # (A <- B <- C ...) that defers hard-delete of the whole chain past
+      # retention forever. It must be rejected.
+      assert {:error, :unprocessable_entity, message} =
+               TokenUsage.create_correction(tenant.id, correction.id, %{
+                 input_tokens: -10,
+                 output_tokens: -5,
+                 cost_millicents: -25
+               })
+
+      assert message == "cannot correct a correction"
+
+      # No second-level correction row was written.
+      corrections_of_correction =
+        Report
+        |> where([r], r.corrects_report_id == ^correction.id)
+        |> AdminRepo.all()
+
+      assert corrections_of_correction == []
+    end
+  end
+
   describe "create_correction/4 concurrency safety (tokens-02)" do
+    test "concurrent corrections on the same story: exactly one wins, total never negative" do
+      %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
+      # story total: cost 2500. Two racing corrections of -2000 each would each
+      # pass validation against the PRE-correction total (2500 - 2000 = 500 >= 0)
+      # but together (2500 - 4000) are impossible. The per-story advisory lock
+      # serializes them so the loser re-reads the winner's committed total and is
+      # rejected — the total can never be driven negative.
+      original = create_report(tenant.id, story, agent, project)
+
+      corr = fn ->
+        TokenUsage.create_correction(tenant.id, original.id, %{
+          input_tokens: 0,
+          output_tokens: 0,
+          cost_millicents: -2000
+        })
+      end
+
+      # Task.async propagates $callers, so the sandbox connection is shared with
+      # the racing tasks (mirrors orchestrator_test.exs optimistic-locking race).
+      results =
+        [Task.async(corr), Task.async(corr)]
+        |> Task.await_many(5_000)
+
+      successes = Enum.filter(results, &match?({:ok, _}, &1))
+      rejects = Enum.filter(results, &match?({:error, :unprocessable_entity, _}, &1))
+
+      assert length(successes) == 1
+      assert length(rejects) == 1
+
+      {:ok, totals} = TokenUsage.get_story_totals(tenant.id, story.id)
+      assert totals.total_cost_millicents == 500
+      assert totals.total_cost_millicents >= 0
+    end
+
     test "takes a per-story advisory lock so concurrent corrections serialize" do
       %{tenant: tenant, story: story, agent: agent, project: project} = setup_context()
       original = create_report(tenant.id, story, agent, project)

--- a/test/loopctl/workers/token_data_archival_worker_test.exs
+++ b/test/loopctl/workers/token_data_archival_worker_test.exs
@@ -150,6 +150,39 @@ defmodule Loopctl.Workers.TokenDataArchivalWorkerTest do
       assert log_entry.new_state["retention_days"] == 90
     end
 
+    @tag :capture_log
+    test "per-tenant fault isolation: one tenant raising does not abort the run (tokens-03)" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      tenant_ids = [tenant_a.id, tenant_b.id]
+
+      tenant_a_id = tenant_a.id
+
+      table_name = :"archival_faulted_#{System.unique_integer([:positive])}"
+      processed = :ets.new(table_name, [:set, :public])
+
+      # tenant_a's hard-delete RAISES (simulating an unexpected DB/FK error).
+      # tenant_b must still be processed and perform/1 must still return :ok —
+      # one tenant's failure can never wedge the whole run.
+      expect(Loopctl.MockTokenArchival, :hard_delete_expired_reports, 2, fn tid ->
+        :ets.insert(processed, {tid, true})
+
+        if tid == tenant_a_id do
+          raise "simulated archival failure for one tenant"
+        else
+          {:ok, 0}
+        end
+      end)
+
+      assert :ok = TokenDataArchivalWorker.perform(%Oban.Job{args: %{"tenant_ids" => tenant_ids}})
+
+      # Both tenants were attempted despite tenant_a raising.
+      assert :ets.member(processed, tenant_a_id)
+      assert :ets.member(processed, tenant_b.id)
+
+      :ets.delete(processed)
+    end
+
     test "tenant isolation: each tenant processed independently" do
       tenant_a = fixture(:tenant)
       tenant_b = fixture(:tenant)


### PR DESCRIPTION
## Summary

Fixes four correction/archival-lifecycle integrity bugs in token-usage reporting. All four are data-integrity defects around the correction (`corrects_report_id`) and retention/archival paths.

## The four fixes

### tokens-02 (HIGH, race) — non-atomic correction validation drives totals negative
`create_correction/4` validated story totals inside `Multi.run` under READ COMMITTED. Two concurrent corrections (double-submit / retry) each read the *pre-correction* total, both passed `validate_correction_totals`, and both committed — driving the story total negative.

**Fix:** serialize corrections per story with a `pg_advisory_xact_lock(namespace, hash(tenant_id, story_id))` acquired as the first `Multi` step, before validation. The lock is held for the whole transaction, so the second correction blocks until the first commits, re-reads the now-updated total, and is rejected (422) if it would over-subtract. Story-level non-negativity implies epic/project rollups (sums of per-story totals) stay non-negative, so a per-story lock is sufficient.

### tokens-03 (HIGH, crash) — archival hard-delete FK violation wedges the worker for ALL tenants
The hard-delete pass deleted expired originals; a still-live correction referencing such an original (via `corrects_report_id`, which has no cascade/nullify) raised an FK violation that crashed `TokenDataArchivalWorker`, failing every tenant in that run.

**Fix (two layers):**
- `DefaultArchival` hard-delete now **skips-if-referenced** (`NOT EXISTS` a correction), so a referenced original is never hard-deleted. Corrections are leaves (nothing references them), so they are removed first; the now-unreferenced original is removed in the same batched loop — FK-safe, and total attribution is preserved (we never null out `corrects_report_id`).
- The worker wraps per-tenant processing in a `rescue` (`process_tenant_safe/1`) so any one tenant's error is logged and can never abort the run for the others.

### tokens-04 (MEDIUM, wrong-calc) — soft-deleting an original strands its negative correction
When an original was soft-deleted / expired but its newer negative correction survived, total/spend queries excluded the original yet still counted the negative correction → negative totals.

**Fix:** a shared `countable_reports/1` base query `LEFT JOIN`s the original and excludes a correction whose original is soft-deleted (or gone). Applied uniformly to `get_story_totals` and all `spend`/`batch_spend` queries (story/epic/project), so totals stay consistent regardless of how the original was removed (user delete or retention soft-delete).

### tokens-05 (MEDIUM, wrong-calc) — threshold_crossed audit rows written on every over-budget report
`check_budget_thresholds` called `emit_threshold_crossed` unconditionally; only the webhook was gated by the `warning_fired`/`exceeded_fired` CAS, so every report while at/over budget wrote another `threshold_crossed` audit row (log bloat + misleading repeated crossings). PR #269 routed `report_story` through this same check, so it fired on both paths.

**Fix:** the audit write is now gated by the same CAS as the webhook (`claim_budget_threshold/2`), so a `threshold_crossed` row is written exactly once per real crossing (below → at/over transition). A genuine new crossing (e.g. 100% after only warning) still writes its row; reset semantics match the webhook.

## Testing

- **tokens-02:** telemetry-based proof the correction transaction executes `pg_advisory_xact_lock` (fails if the lock step is removed) + invariant test that a serialized over-subtraction is rejected (422) and the total never goes negative. (A true two-connection race is not reproducible under `Ecto.Adapters.SQL.Sandbox`, which multiplexes onto one connection — same limitation this repo documents for `HeavyReadPoolIsolationTest`; the lock is production-correct and the telemetry assertion is the deterministic regression guard.)
- **tokens-03:** an expired original with a live correction is NOT hard-deleted and does not crash; both are removed FK-safely when both expire; an un-corrected expired original is still deleted. Worker test: one tenant raising does not abort the run — the other tenant is still processed and `perform/1` returns `:ok`.
- **tokens-04:** soft-deleting an original with a negative correction leaves the story total at 0 (never negative) across story/epic/project spend; a correction whose original is live still counts.
- **tokens-05:** first warning crossing writes one audit and subsequent over-warning reports write none; crossing 100% writes the exceeded audit once; a single report crossing both writes one of each; reset-then-recross writes a new audit.

No migration was required (the skip-if-referenced approach avoids nulling `corrects_report_id`).

## Quality gate

`mix precommit` green: compile `--warnings-as-errors`, format, `credo --strict`, deps checks, dialyzer (fresh PLT, 0 unnecessary skips), full test **3334 tests, 0 failures**.
