### PR TITLE
fix(token-usage): cost-worker data-loss, backfill, and anomaly-comparison bugs (tokens-06/08/09)

### DIFF
--- a/lib/loopctl/token_usage/default_rollup.ex
+++ b/lib/loopctl/token_usage/default_rollup.ex
@@ -14,6 +14,8 @@ defmodule Loopctl.TokenUsage.DefaultRollup do
 
   import Ecto.Query
 
+  require Logger
+
   alias Loopctl.AdminRepo
   alias Loopctl.TokenUsage.Report
   alias Loopctl.WorkBreakdown.Story
@@ -30,7 +32,20 @@ defmodule Loopctl.TokenUsage.DefaultRollup do
 
     {:ok, agent_rows ++ epic_rows ++ project_rows}
   rescue
-    e -> {:error, Exception.message(e)}
+    e ->
+      # Isolate the failure to this tenant/day (don't crash the whole batch),
+      # but surface it as {:error} so CostRollupWorker returns an error and Oban
+      # retries -- a transient DB error must not be swallowed into a success
+      # that permanently loses this day's summaries (tokens-08). Log with the
+      # stacktrace so a genuine (non-transient) bug is still observable rather
+      # than masked behind blanket retries.
+      Logger.error(
+        "DefaultRollup.aggregate failed for tenant #{tenant_id} " <>
+          "(#{Date.to_iso8601(period_start)}..#{Date.to_iso8601(period_end)}): " <>
+          Exception.format(:error, e, __STACKTRACE__)
+      )
+
+      {:error, Exception.message(e)}
   end
 
   # --- Agent scope ---

--- a/lib/loopctl/workers/cost_anomaly_worker.ex
+++ b/lib/loopctl/workers/cost_anomaly_worker.ex
@@ -53,37 +53,37 @@ defmodule Loopctl.Workers.CostAnomalyWorker do
   end
 
   defp detect_anomalies(tenant_id, period_start, period_end) do
-    # Get epic summaries for this period that have an avg cost
-    epic_summaries =
+    # Which epics to (re-)evaluate this run: those that were rolled up in the
+    # period. The rollup writes DAILY epic summaries (period_start == period_end
+    # == day), so a backfill range D1..D3 is covered by matching any summary
+    # whose period_start falls within [period_start, period_end] rather than an
+    # exact (start, end) pair (tokens-09 consistency).
+    epic_ids =
       CostSummary
       |> where([cs], cs.tenant_id == ^tenant_id)
       |> where([cs], cs.scope_type == :epic)
-      |> where([cs], cs.period_start == ^period_start)
-      |> where([cs], cs.period_end == ^period_end)
-      |> where([cs], not is_nil(cs.avg_cost_per_story_millicents))
-      |> where([cs], cs.avg_cost_per_story_millicents > 0)
+      |> where([cs], cs.period_start >= ^period_start and cs.period_start <= ^period_end)
+      |> select([cs], cs.scope_id)
+      |> distinct(true)
       |> AdminRepo.all()
 
-    if epic_summaries == [] do
-      :ok
-    else
-      # Build a map of epic_id => avg_cost_per_story_millicents for fast lookup
-      epic_avg_map =
-        Map.new(epic_summaries, fn cs -> {cs.scope_id, cs.avg_cost_per_story_millicents} end)
-
-      epic_ids = Map.keys(epic_avg_map)
-      check_all_epic_stories(tenant_id, epic_ids, epic_avg_map, period_start, period_end)
+    if epic_ids != [] do
+      check_all_epic_stories(tenant_id, epic_ids)
     end
 
     :ok
   end
 
-  # Issues ONE query for per-story costs across ALL epics, then processes in memory.
-  defp check_all_epic_stories(tenant_id, epic_ids, epic_avg_map, period_start, period_end) do
-    start_dt = NaiveDateTime.new!(period_start, ~T[00:00:00])
-    end_dt = NaiveDateTime.new!(period_end, ~T[23:59:59.999999])
-
-    # Single query: per-story costs grouped by (story_id, epic_id) for all epics
+  # Anomaly detection compares LIKE-FOR-LIKE: a story's CUMULATIVE lifetime cost
+  # against the epic's per-story average of those same cumulative totals
+  # (tokens-06). Using a single day's slice both (a) missed multi-day-expensive
+  # stories whose per-day cost stayed under threshold, and (b) produced false
+  # `suspiciously_low` flags when an already-counted story got a tiny follow-up
+  # report on a later day. There is deliberately NO inserted_at window here.
+  #
+  # Issues ONE query for per-story lifetime costs across ALL epics, then
+  # processes in memory.
+  defp check_all_epic_stories(tenant_id, epic_ids) do
     story_costs =
       Report
       |> join(:inner, [r], s in Story, on: r.story_id == s.id)
@@ -91,7 +91,6 @@ defmodule Loopctl.Workers.CostAnomalyWorker do
       |> where([r, _s], is_nil(r.deleted_at))
       |> Report.exclude_stranded_corrections()
       |> where([_r, s], s.epic_id in ^epic_ids)
-      |> where([r, _s], r.inserted_at >= ^start_dt and r.inserted_at <= ^end_dt)
       |> group_by([r, s], [r.story_id, s.epic_id])
       |> select([r, s], %{
         story_id: r.story_id,
@@ -100,10 +99,25 @@ defmodule Loopctl.Workers.CostAnomalyWorker do
       })
       |> AdminRepo.all()
 
+    epic_avg_map = build_epic_avg_map(story_costs)
+
     Enum.each(story_costs, fn %{story_id: story_id, epic_id: epic_id, total_cost: total_cost} ->
       epic_avg = Map.get(epic_avg_map, epic_id)
       cost = to_int(total_cost)
       check_and_flag_anomaly(tenant_id, story_id, cost, epic_avg)
+    end)
+  end
+
+  # Epic per-story-total average, computed from the same cumulative story totals
+  # we compare against (each story counted once).
+  defp build_epic_avg_map(story_costs) do
+    story_costs
+    |> Enum.group_by(& &1.epic_id)
+    |> Map.new(fn {epic_id, stories} ->
+      totals = Enum.map(stories, &to_int(&1.total_cost))
+      count = length(totals)
+      avg = if count > 0, do: div(Enum.sum(totals), count), else: 0
+      {epic_id, avg}
     end)
   end
 

--- a/lib/loopctl/workers/cost_rollup_worker.ex
+++ b/lib/loopctl/workers/cost_rollup_worker.ex
@@ -41,33 +41,63 @@ defmodule Loopctl.Workers.CostRollupWorker do
     # Allow overriding the period for testing/backfills
     {period_start, period_end} = resolve_period(args)
 
+    # cost_summaries are DAILY-granularity rows keyed on the unique index
+    # (tenant_id, scope_type, scope_id, period_start). A multi-day range is a
+    # backfill: roll up and upsert EACH day independently (each day is the
+    # window [day, day]) so daily summaries stay correct and a range never
+    # collapses into a single overwriting row at period_start (tokens-09).
+    days = Date.range(period_start, period_end)
+
     tenants = list_active_tenants(args)
-    Logger.info("CostRollupWorker: starting rollup for #{length(tenants)} tenants")
 
-    results =
-      Enum.map(tenants, fn tenant ->
-        case rollup_tenant(tenant.id, period_start, period_end) do
-          :ok ->
-            :ok
+    Logger.info(
+      "CostRollupWorker: starting rollup for #{length(tenants)} tenant(s) over #{Enum.count(days)} day(s)"
+    )
 
-          {:error, reason} ->
-            Logger.warning("CostRollupWorker: failed for tenant #{tenant.id}: #{inspect(reason)}")
+    failures =
+      for tenant <- tenants, day <- days, reduce: [] do
+        acc ->
+          case rollup_tenant(tenant.id, day, day) do
+            :ok ->
+              acc
 
-            {:error, tenant.id, reason}
-        end
-      end)
+            {:error, reason} ->
+              Logger.warning(
+                "CostRollupWorker: failed for tenant #{tenant.id} on #{Date.to_iso8601(day)}: " <>
+                  "#{inspect(reason)}"
+              )
 
-    errors = Enum.filter(results, &match?({:error, _, _}, &1))
-
-    if errors != [] do
-      Logger.warning("CostRollupWorker: #{length(errors)} tenant(s) failed")
-    end
+              [{tenant.id, day, reason} | acc]
+          end
+      end
 
     # Chain the anomaly worker regardless of partial failures so that
-    # successful tenants still get anomaly detection (ADV-11).
+    # successful tenants still get anomaly detection (ADV-11). Both the upsert
+    # and the chained job are idempotent, so a retry of this job re-runs them
+    # safely.
     chain_anomaly_worker(period_start, period_end)
 
-    :ok
+    handle_failures(failures)
+  end
+
+  # A failed tenant/day rollup (e.g. a transient DB timeout or connection drop)
+  # must NOT be reported as success -- Oban treats :ok as done and would never
+  # retry, permanently losing that day's cost_summaries (tokens-08). Succeeded
+  # tenant/days are already persisted via the idempotent upsert, so returning an
+  # error only re-computes identical rows for them on retry while giving the
+  # failed ones another attempt. Failed tenant ids are surfaced for observability.
+  defp handle_failures([]), do: :ok
+
+  defp handle_failures(failures) do
+    failed_tenant_ids =
+      failures |> Enum.map(fn {tenant_id, _day, _reason} -> tenant_id end) |> Enum.uniq()
+
+    Logger.warning(
+      "CostRollupWorker: #{length(failures)} tenant/day rollup(s) failed across " <>
+        "#{length(failed_tenant_ids)} tenant(s); returning error so Oban retries"
+    )
+
+    {:error, {:rollup_failed, failed_tenant_ids}}
   end
 
   @doc false

--- a/test/loopctl/token_usage_webhook_events_test.exs
+++ b/test/loopctl/token_usage_webhook_events_test.exs
@@ -59,6 +59,30 @@ defmodule Loopctl.TokenUsageWebhookEventsTest do
     |> AdminRepo.all()
   end
 
+  # Anomaly detection compares a story's cumulative total against the epic's
+  # per-story-total average (tokens-06), so a single expensive story is not
+  # anomalous relative to itself. Seed cheap sibling stories in the same epic so
+  # the target story is genuinely > 3x the epic average.
+  defp seed_cheap_siblings(tenant_id, project_id, epic_id, agent_id, count, cost_millicents) do
+    for _ <- 1..count do
+      sibling =
+        fixture(:story, %{tenant_id: tenant_id, epic_id: epic_id, project_id: project_id})
+
+      {:ok, _report} =
+        TokenUsage.create_report(tenant_id, %{
+          story_id: sibling.id,
+          agent_id: agent_id,
+          project_id: project_id,
+          input_tokens: 100,
+          output_tokens: 50,
+          model_name: "claude-opus-4",
+          cost_millicents: cost_millicents
+        })
+    end
+
+    :ok
+  end
+
   # --- AC-21.7.1: New event types are registered ---
 
   describe "valid event types (AC-21.7.1)" do
@@ -595,6 +619,10 @@ defmodule Loopctl.TokenUsageWebhookEventsTest do
           cost_millicents: 20_000
         })
 
+      # Cheap siblings so the 20k story is > 3x the epic per-story-total avg:
+      # (20k + 3*1k) / 4 = 5_750; 20k/5_750 = 3.48x.
+      seed_cheap_siblings(tenant.id, project.id, epic.id, agent.id, 3, 1_000)
+
       # Run the worker which will detect the anomaly from yesterday's rollup data
       # Since we're in Oban inline mode and the worker runs against yesterday's period,
       # we test via perform/1 with an explicit period matching today
@@ -655,6 +683,9 @@ defmodule Loopctl.TokenUsageWebhookEventsTest do
           cost_millicents: 20_000
         })
 
+      # (20k + 3*1k) / 4 = 5_750; 20k/5_750 = 3.48x -> high_cost.
+      seed_cheap_siblings(tenant.id, project.id, epic.id, agent.id, 3, 1_000)
+
       job_args = %{
         "period_start" => Date.to_iso8601(period),
         "period_end" => Date.to_iso8601(period)
@@ -703,6 +734,9 @@ defmodule Loopctl.TokenUsageWebhookEventsTest do
           model_name: "claude-opus-4",
           cost_millicents: 20_000
         })
+
+      # (20k + 3*1k) / 4 = 5_750; 20k/5_750 = 3.48x -> high_cost.
+      seed_cheap_siblings(tenant.id, project.id, epic.id, agent.id, 3, 1_000)
 
       job_args = %{
         "period_start" => Date.to_iso8601(period),
@@ -841,6 +875,9 @@ defmodule Loopctl.TokenUsageWebhookEventsTest do
           model_name: "claude-opus-4",
           cost_millicents: 20_000
         })
+
+      # (20k + 3*1k) / 4 = 5_750; 20k/5_750 = 3.48x -> high_cost for tenant A.
+      seed_cheap_siblings(tenant_a.id, project_a.id, epic_a.id, agent_a.id, 3, 1_000)
 
       job_args = %{
         "period_start" => Date.to_iso8601(period),

--- a/test/loopctl/workers/cost_anomaly_worker_test.exs
+++ b/test/loopctl/workers/cost_anomaly_worker_test.exs
@@ -3,9 +3,12 @@ defmodule Loopctl.Workers.CostAnomalyWorkerTest do
 
   setup :verify_on_exit!
 
+  import Ecto.Query
+
   alias Loopctl.AdminRepo
   alias Loopctl.TokenUsage.CostAnomaly
   alias Loopctl.TokenUsage.CostSummary
+  alias Loopctl.TokenUsage.Report
   alias Loopctl.Workers.CostAnomalyWorker
 
   defp setup_tenant_with_epic do
@@ -18,12 +21,7 @@ defmodule Loopctl.Workers.CostAnomalyWorkerTest do
   end
 
   defp create_story_with_reports(tenant, epic, agent, cost_millicents) do
-    story =
-      fixture(:story, %{
-        tenant_id: tenant.id,
-        epic_id: epic.id,
-        project_id: epic.project_id
-      })
+    story = create_bare_story(tenant, epic)
 
     # Insert a token usage report directly for this story
     fixture(:token_usage_report, %{
@@ -35,6 +33,58 @@ defmodule Loopctl.Workers.CostAnomalyWorkerTest do
     })
 
     story
+  end
+
+  defp create_bare_story(tenant, epic) do
+    fixture(:story, %{
+      tenant_id: tenant.id,
+      epic_id: epic.id,
+      project_id: epic.project_id
+    })
+  end
+
+  # Adds a report to a story, optionally backdated `days_ago` days so we can
+  # model a story whose cost is spread across multiple days.
+  defp add_report(tenant, story, agent, epic, cost_millicents, days_ago) do
+    report =
+      fixture(:token_usage_report, %{
+        tenant_id: tenant.id,
+        story_id: story.id,
+        agent_id: agent.id,
+        project_id: epic.project_id,
+        cost_millicents: cost_millicents
+      })
+
+    if days_ago > 0 do
+      ts = DateTime.add(DateTime.utc_now(), -days_ago, :day)
+
+      from(r in Report, where: r.id == ^report.id)
+      |> AdminRepo.update_all(set: [inserted_at: ts])
+    end
+
+    report
+  end
+
+  # Inserts the epic cost summary the rollup would have written for `period`.
+  # Only its existence (scope_type + period) marks the epic as a candidate; the
+  # comparison baseline is recomputed from cumulative story totals, so `avg` here
+  # only matters for the pre-fix (single-day-slice) behavior.
+  defp insert_epic_summary(ctx, period, avg) do
+    %CostSummary{tenant_id: ctx.tenant.id}
+    |> CostSummary.changeset(%{
+      scope_type: :epic,
+      scope_id: ctx.epic.id,
+      period_start: period,
+      period_end: period,
+      total_cost_millicents: avg,
+      report_count: 1,
+      avg_cost_per_story_millicents: avg
+    })
+    |> AdminRepo.insert!()
+  end
+
+  defp period_args(period) do
+    %{"period_start" => Date.to_iso8601(period), "period_end" => Date.to_iso8601(period)}
   end
 
   describe "perform/1" do
@@ -164,6 +214,12 @@ defmodule Loopctl.Workers.CostAnomalyWorkerTest do
       period_start = Date.utc_today()
       period_end = Date.utc_today()
 
+      # 3 normal + 1 expensive story so the expensive one is genuinely > 3x the
+      # epic per-story-total average: (10k + 10k + 10k + 100k) / 4 = 32_500;
+      # 100_000 / 32_500 = 3.07x.
+      _normal1 = create_story_with_reports(ctx.tenant, ctx.epic, ctx.agent, 10_000)
+      _normal2 = create_story_with_reports(ctx.tenant, ctx.epic, ctx.agent, 10_000)
+      _normal3 = create_story_with_reports(ctx.tenant, ctx.epic, ctx.agent, 10_000)
       expensive = create_story_with_reports(ctx.tenant, ctx.epic, ctx.agent, 100_000)
 
       # Pre-existing anomaly for this story
@@ -183,9 +239,9 @@ defmodule Loopctl.Workers.CostAnomalyWorkerTest do
         scope_id: ctx.epic.id,
         period_start: period_start,
         period_end: period_end,
-        total_cost_millicents: 100_000,
-        report_count: 1,
-        avg_cost_per_story_millicents: 25_000
+        total_cost_millicents: 130_000,
+        report_count: 4,
+        avg_cost_per_story_millicents: 32_500
       })
       |> AdminRepo.insert!()
 
@@ -202,9 +258,88 @@ defmodule Loopctl.Workers.CostAnomalyWorkerTest do
       assert length(anomalies) == 1
       anomaly = hd(anomalies)
       assert anomaly.id == existing.id
-      # Updated with new figures
+      # Updated with the recomputed cumulative-total figures.
       assert anomaly.story_cost_millicents == 100_000
-      assert anomaly.reference_avg_millicents == 25_000
+      assert anomaly.reference_avg_millicents == 32_500
+    end
+
+    # tokens-06(a): a story that is expensive CUMULATIVELY but cheap on any
+    # single day must still be flagged. The old per-day-slice comparison missed
+    # it because no individual day crossed the threshold.
+    test "flags a story whose cumulative cost across multiple days exceeds 3x the epic average" do
+      ctx = setup_tenant_with_epic()
+      period = Date.utc_today()
+
+      # 5 normal stories, each a single 10k report today.
+      for _ <- 1..5, do: create_story_with_reports(ctx.tenant, ctx.epic, ctx.agent, 10_000)
+
+      # One expensive story: 60k total spread across 3 days (20k each). No single
+      # day's slice (20k) trips the comparison; only the cumulative total does.
+      expensive = create_bare_story(ctx.tenant, ctx.epic)
+      add_report(ctx.tenant, expensive, ctx.agent, ctx.epic, 20_000, 0)
+      add_report(ctx.tenant, expensive, ctx.agent, ctx.epic, 20_000, 5)
+      add_report(ctx.tenant, expensive, ctx.agent, ctx.epic, 20_000, 10)
+
+      # Epic per-story-total avg = (5*10k + 60k) / 6 = 18_333; 60k/18_333 = 3.27x.
+      insert_epic_summary(ctx, period, 18_333)
+
+      assert :ok = CostAnomalyWorker.perform(%Oban.Job{args: period_args(period)})
+
+      high = AdminRepo.all(CostAnomaly) |> Enum.filter(&(&1.anomaly_type == :high_cost))
+      assert length(high) == 1
+      anomaly = hd(high)
+      assert anomaly.story_id == expensive.id
+      # Full cumulative cost, not a single day's slice.
+      assert anomaly.story_cost_millicents == 60_000
+    end
+
+    # tokens-06(b): a completed story that gets a tiny follow-up report on a
+    # later day must NOT be flagged suspiciously_low -- its cumulative total is
+    # normal even though the follow-up day's slice alone is minuscule.
+    test "does not flag a completed story as suspiciously_low when it gets a small later follow-up" do
+      ctx = setup_tenant_with_epic()
+      period = Date.utc_today()
+
+      # 3 normal stories, each 30k today.
+      for _ <- 1..3, do: create_story_with_reports(ctx.tenant, ctx.epic, ctx.agent, 30_000)
+
+      # A story that already cost 30k earlier (backdated, out of today's window)
+      # and gets a tiny 100mc follow-up today. Cumulative total = 30_100 (normal),
+      # even though today's slice alone is only 100mc.
+      completed = create_bare_story(ctx.tenant, ctx.epic)
+      add_report(ctx.tenant, completed, ctx.agent, ctx.epic, 30_000, 7)
+      add_report(ctx.tenant, completed, ctx.agent, ctx.epic, 100, 0)
+
+      # Per-story-total avg = (3*30k + 30_100) / 4 = 30_025; 30_100/30_025 ≈ 1.0x.
+      insert_epic_summary(ctx, period, 30_025)
+
+      assert :ok = CostAnomalyWorker.perform(%Oban.Job{args: period_args(period)})
+
+      anomalies = AdminRepo.all(CostAnomaly)
+      refute Enum.any?(anomalies, &(&1.anomaly_type == :suspiciously_low))
+      assert anomalies == []
+    end
+
+    # tokens-06(c): repeated nightly runs over an unchanged total must not pile
+    # up duplicate anomaly rows.
+    test "does not create duplicate anomaly rows across repeated runs for the same unchanged total" do
+      ctx = setup_tenant_with_epic()
+      period = Date.utc_today()
+
+      for _ <- 1..3, do: create_story_with_reports(ctx.tenant, ctx.epic, ctx.agent, 10_000)
+      expensive = create_story_with_reports(ctx.tenant, ctx.epic, ctx.agent, 100_000)
+
+      # Per-story-total avg = (3*10k + 100k) / 4 = 32_500; 100k/32_500 = 3.07x.
+      insert_epic_summary(ctx, period, 32_500)
+
+      job = %Oban.Job{args: period_args(period)}
+      assert :ok = CostAnomalyWorker.perform(job)
+      assert :ok = CostAnomalyWorker.perform(job)
+      assert :ok = CostAnomalyWorker.perform(job)
+
+      anomalies = AdminRepo.all(CostAnomaly)
+      assert length(anomalies) == 1
+      assert hd(anomalies).story_id == expensive.id
     end
 
     test "succeeds when no tenants exist" do

--- a/test/loopctl/workers/cost_rollup_worker_test.exs
+++ b/test/loopctl/workers/cost_rollup_worker_test.exs
@@ -120,22 +120,130 @@ defmodule Loopctl.Workers.CostRollupWorkerTest do
       assert hd(summaries).total_cost_millicents == 15_000
     end
 
-    test "handles rollup service errors gracefully" do
-      tenant = fixture(:tenant)
+    # tokens-08: a transient per-tenant failure must NOT be swallowed into :ok
+    # (Oban would never retry, permanently losing that day's summaries). The job
+    # must return an error so Oban retries, while succeeded tenants stay persisted.
+    test "returns an error (so Oban retries) when a tenant rollup fails, still persisting succeeded tenants" do
+      good_tenant = fixture(:tenant)
+      bad_tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: good_tenant.id})
 
-      expect(Loopctl.MockCostRollup, :aggregate, fn _, _, _ ->
-        {:error, "database timeout"}
+      good_tenant_id = good_tenant.id
+      bad_tenant_id = bad_tenant.id
+
+      expect(Loopctl.MockCostRollup, :aggregate, 2, fn tenant_id, _start, _end ->
+        cond do
+          tenant_id == good_tenant_id ->
+            {:ok,
+             [
+               %{
+                 scope_type: :project,
+                 scope_id: project.id,
+                 total_input_tokens: 1_000,
+                 total_output_tokens: 500,
+                 total_cost_millicents: 2_000,
+                 report_count: 2,
+                 model_breakdown: %{},
+                 avg_cost_per_story_millicents: 1_000
+               }
+             ]}
+
+          tenant_id == bad_tenant_id ->
+            {:error, "database timeout"}
+        end
       end)
 
-      # Should still return :ok (logs errors but doesn't fail job)
+      result =
+        CostRollupWorker.perform(%Oban.Job{
+          args: %{
+            "period_start" => "2026-04-02",
+            "period_end" => "2026-04-02",
+            "tenant_ids" => [good_tenant.id, bad_tenant.id]
+          }
+        })
+
+      # Not :ok -> Oban will retry the job
+      assert {:error, {:rollup_failed, failed_ids}} = result
+      assert bad_tenant.id in failed_ids
+      refute good_tenant.id in failed_ids
+
+      import Ecto.Query
+
+      # The good tenant's summary was still written despite the other's failure.
+      good_summaries =
+        from(c in CostSummary, where: c.tenant_id == ^good_tenant.id) |> AdminRepo.all()
+
+      assert length(good_summaries) == 1
+      assert hd(good_summaries).total_cost_millicents == 2_000
+
+      # The failed tenant wrote nothing.
+      bad_summaries =
+        from(c in CostSummary, where: c.tenant_id == ^bad_tenant.id) |> AdminRepo.all()
+
+      assert bad_summaries == []
+    end
+
+    # tokens-09: a multi-day backfill (period_start..period_end) must produce ONE
+    # daily summary row PER DAY, not a single collapsed row at period_start.
+    test "backfill over a date range writes one daily summary row per day" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+
+      d1 = ~D[2026-04-01]
+      d2 = ~D[2026-04-02]
+      d3 = ~D[2026-04-03]
+
+      # Each day rolls up its OWN totals; the worker must call aggregate once per
+      # day with a single-day window (period_start == period_end == day).
+      day_cost = fn
+        ^d1 -> 1_000
+        ^d2 -> 2_000
+        ^d3 -> 3_000
+      end
+
+      expect(Loopctl.MockCostRollup, :aggregate, 3, fn _tenant_id, start_date, end_date ->
+        assert start_date == end_date
+
+        {:ok,
+         [
+           %{
+             scope_type: :project,
+             scope_id: project.id,
+             total_input_tokens: 0,
+             total_output_tokens: 0,
+             total_cost_millicents: day_cost.(start_date),
+             report_count: 1,
+             model_breakdown: %{},
+             avg_cost_per_story_millicents: nil
+           }
+         ]}
+      end)
+
       assert :ok =
                CostRollupWorker.perform(%Oban.Job{
                  args: %{
-                   "period_start" => "2026-04-02",
-                   "period_end" => "2026-04-02",
+                   "period_start" => Date.to_iso8601(d1),
+                   "period_end" => Date.to_iso8601(d3),
                    "tenant_ids" => [tenant.id]
                  }
                })
+
+      import Ecto.Query
+
+      summaries =
+        from(c in CostSummary,
+          where: c.tenant_id == ^tenant.id,
+          order_by: c.period_start
+        )
+        |> AdminRepo.all()
+
+      # THREE daily rows, not one collapsed row at d1.
+      assert length(summaries) == 3
+
+      assert Enum.map(summaries, & &1.period_start) == [d1, d2, d3]
+      # Each row is a single-day period with its own totals.
+      assert Enum.all?(summaries, fn s -> s.period_start == s.period_end end)
+      assert Enum.map(summaries, & &1.total_cost_millicents) == [1_000, 2_000, 3_000]
     end
 
     test "defaults period to yesterday when not provided" do


### PR DESCRIPTION
## Summary

Fixes three defects in the daily cost-rollup / anomaly-detection pipeline (`CostRollupWorker`, `CostAnomalyWorker`, `DefaultRollup`).

### tokens-08 - data loss: rollup swallowed per-tenant failures and reported success
`CostRollupWorker.perform` collected `{:error, ...}` per tenant into a log warning, then returned `:ok` regardless. Oban treats `:ok` as success, so **no retry** happens, and a tenant whose aggregate/upsert hit a transient error (DB timeout, connection drop) **permanently lost that day's `cost_summaries`**.

- `perform` now returns `{:error, {:rollup_failed, tenant_ids}}` when any tenant/day rollup failed, so Oban retries. Succeeded tenant/days are already persisted via the idempotent `ON CONFLICT` upsert, so a retry safely re-computes identical rows for them while retrying the failed ones. Failed tenant ids are surfaced in the error for observability.
- `DefaultRollup.aggregate` keeps isolating a failure to one tenant/day (does not crash the batch) but now logs the exception **with its stacktrace** before returning `{:error}`, so the error propagates to trigger the retry AND a genuine (non-transient) bug is observable rather than masked behind blanket retries.

### tokens-09 - wrong calc: multi-day backfill collapsed the range into one row
A backfill (`period_start=D1, period_end=D7`) produced **one** summary row keyed on `period_start` (the unique index), writing the 7-day SUM at D1, overwriting D1's correct daily row and never writing D2..D7.

- `perform` now iterates the range day-by-day (`Date.range/2`), rolling up and upserting each day independently (each day is the window `[day, day]`), preserving the DAILY-granularity invariant of `cost_summaries`. A range backfill re-computes each day's row.

### tokens-06 - wrong calc: anomaly detection compared single-day slices, not story totals
`CostAnomalyWorker` computed per-story cost from a **single day's** report slice and compared it to the epic's daily average. Consequences: (a) a story expensive *cumulatively* but cheap per-day evaded detection; (b) a small follow-up report on an already-counted story was compared as if it were the story's whole cost, giving a false `suspiciously_low`.

- Detection now compares a story's **cumulative lifetime total** (via the stranded-correction-safe `Report.exclude_stranded_corrections/1`) against the epic's **per-story-total average**, recomputed from those same totals - like-for-like. Candidate epics come from the daily epic summaries in the period (range-aware). The existing unresolved-anomaly dedup (partial unique index + update-in-place without re-emitting audit/webhook) prevents duplicate rows across repeated runs.

## Tests
- **Rollup**: partial-failure returns an error (Oban retries) while succeeded tenants persist; multi-day backfill writes one daily row per day.
- **Anomaly**: multi-day-expensive story IS flagged; small follow-up on a completed story does NOT create a false `suspiciously_low`; repeated runs do not duplicate anomaly rows.
- Updated the single-story anomaly + webhook tests: under cumulative-total comparison a lone story is not anomalous relative to itself, so they now seed cheap sibling stories to make the target genuinely anomalous.

Full `mix precommit` gate green (compile `--warnings-as-errors`, format, credo `--strict`, dialyzer 0, `3354 tests, 0 failures`) on Elixir 1.19 / OTP 28.

## Trust-model checklist
No role/RLS/chain-of-custody surface touched. Both workers run under `AdminRepo` (BYPASSRLS) as before; the cumulative-total anomaly query is tenant-scoped, and `exclude_stranded_corrections` carries its own `tenant_id` correlation. No changeset `cast` of `tenant_id`.
