### PR TITLE
fix(token-usage): cost-worker review fixes — anomaly-notify race, period normalization, range cap, scoped retry

### DIFF
--- a/lib/loopctl/workers/cost_anomaly_worker.ex
+++ b/lib/loopctl/workers/cost_anomaly_worker.ex
@@ -17,7 +17,13 @@ defmodule Loopctl.Workers.CostAnomalyWorker do
   - Suspiciously low: 0.1x average
   """
 
-  use Oban.Worker, queue: :analytics, max_attempts: 3
+  # `unique` on the period args so that repeated enqueues within the window
+  # (e.g. a CostRollupWorker retry re-chaining the same period) collapse to ONE
+  # job instead of running concurrently on the :analytics queue (FIX1a).
+  use Oban.Worker,
+    queue: :analytics,
+    max_attempts: 3,
+    unique: [period: 600, fields: [:worker, :args], keys: [:period_start, :period_end]]
 
   require Logger
 
@@ -37,6 +43,9 @@ defmodule Loopctl.Workers.CostAnomalyWorker do
 
   @high_cost_threshold Decimal.new("3.0")
   @low_cost_threshold Decimal.new("0.1")
+
+  # Matches CostRollupWorker: reject/clamp a pathological period range.
+  @max_backfill_days 90
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: args}) do
@@ -170,58 +179,77 @@ defmodule Loopctl.Workers.CostAnomalyWorker do
           existing
       end
     else
-      changeset =
-        %CostAnomaly{tenant_id: tenant_id, story_id: story_id}
-        |> CostAnomaly.create_changeset(%{
-          anomaly_type: anomaly_type,
-          story_cost_millicents: story_cost,
-          reference_avg_millicents: epic_avg,
-          deviation_factor: Decimal.round(factor, 2)
-        })
+      now = DateTime.utc_now()
 
-      # Use on_conflict: :nothing to gracefully handle a race with the unique
-      # partial index (cost_anomalies_unresolved_unique) -- ADV-3.
-      case AdminRepo.insert(changeset,
+      entry = %{
+        id: Ecto.UUID.generate(),
+        tenant_id: tenant_id,
+        story_id: story_id,
+        anomaly_type: anomaly_type,
+        story_cost_millicents: story_cost,
+        reference_avg_millicents: epic_avg,
+        deviation_factor: Decimal.round(factor, 2),
+        resolved: false,
+        archived: false,
+        metadata: %{},
+        inserted_at: now,
+        updated_at: now
+      }
+
+      # insert_all + on_conflict: :nothing reports the REAL number of rows
+      # written against the unique partial index
+      # (cost_anomalies_unresolved_unique): 1 = we genuinely inserted (notify),
+      # 0 = a concurrent run won the race and already notified (skip). This
+      # closes the check-then-insert race: AdminRepo.insert/2 with
+      # on_conflict: :nothing returns {:ok, struct} carrying a client-generated,
+      # UNPERSISTED id on conflict, so the losing run would emit an audit entry +
+      # token.anomaly_detected webhook for an anomaly_id that was never persisted
+      # (FIX1c).
+      case AdminRepo.insert_all(CostAnomaly, [entry],
              on_conflict: :nothing,
              conflict_target:
                {:unsafe_fragment,
-                ~s|("tenant_id","story_id","anomaly_type") WHERE resolved = false|}
+                ~s|("tenant_id","story_id","anomaly_type") WHERE resolved = false|},
+             returning: true
            ) do
-        {:ok, anomaly} ->
-          # Emit change feed + audit log entry for the newly detected anomaly (AC-21.8.3, AC-21.8.5)
-          Audit.create_log_entry(tenant_id, %{
-            entity_type: "cost_anomaly",
-            entity_id: anomaly.id,
-            action: "detected",
-            actor_type: "system",
-            new_state: %{
-              "anomaly_type" => to_string(anomaly.anomaly_type),
-              "story_id" => anomaly.story_id,
-              "deviation_factor" => Decimal.to_string(anomaly.deviation_factor),
-              "story_cost_millicents" => anomaly.story_cost_millicents,
-              "reference_avg_millicents" => anomaly.reference_avg_millicents
-            },
-            metadata: %{
-              "anomaly_id" => anomaly.id,
-              "story_id" => anomaly.story_id,
-              "anomaly_type" => to_string(anomaly.anomaly_type),
-              "deviation_factor" => Decimal.to_string(anomaly.deviation_factor)
-            }
-          })
-
-          # Fire token.anomaly_detected webhook event (AC-21.7.7)
-          fire_anomaly_webhook(tenant_id, anomaly)
-
+        {1, [anomaly]} ->
+          notify_new_anomaly(tenant_id, anomaly)
           anomaly
 
-        {:error, changeset} ->
-          Logger.warning(
-            "CostAnomalyWorker: failed to insert anomaly for story #{story_id}: #{inspect(changeset.errors)}"
-          )
-
+        {0, _} ->
+          # Lost the race: the concurrent inserter already emitted audit + webhook.
           nil
       end
     end
+  end
+
+  # Emits the audit log entry (AC-21.8.3, AC-21.8.5) and fires the
+  # token.anomaly_detected webhook (AC-21.7.7). Called ONLY for a genuinely
+  # persisted anomaly, never for a conflict/no-op insert.
+  defp notify_new_anomaly(tenant_id, anomaly) do
+    Audit.create_log_entry(tenant_id, %{
+      entity_type: "cost_anomaly",
+      entity_id: anomaly.id,
+      action: "detected",
+      actor_type: "system",
+      new_state: %{
+        "anomaly_type" => to_string(anomaly.anomaly_type),
+        "story_id" => anomaly.story_id,
+        "deviation_factor" => Decimal.to_string(anomaly.deviation_factor),
+        "story_cost_millicents" => anomaly.story_cost_millicents,
+        "reference_avg_millicents" => anomaly.reference_avg_millicents
+      },
+      metadata: %{
+        "anomaly_id" => anomaly.id,
+        "story_id" => anomaly.story_id,
+        "anomaly_type" => to_string(anomaly.anomaly_type),
+        "deviation_factor" => Decimal.to_string(anomaly.deviation_factor)
+      }
+    })
+
+    fire_anomaly_webhook(tenant_id, anomaly)
+
+    :ok
   end
 
   # Fires a token.anomaly_detected webhook for newly created anomalies.
@@ -329,7 +357,7 @@ defmodule Loopctl.Workers.CostAnomalyWorker do
               yesterday
           end
 
-        {start_date, end_date}
+        normalize_and_cap(start_date, end_date)
 
       other ->
         Logger.warning(
@@ -338,6 +366,31 @@ defmodule Loopctl.Workers.CostAnomalyWorker do
 
         yesterday = Date.add(Date.utc_today(), -1)
         {yesterday, yesterday}
+    end
+  end
+
+  # Normalize a (possibly reversed) parsed range and cap its width, matching
+  # CostRollupWorker. A reversed range (start > end) is swapped -- otherwise the
+  # candidate-epic query (period_start >= start and <= end) would match NOTHING
+  # and silently skip anomaly detection for the whole range (FIX2). A range wider
+  # than @max_backfill_days is clamped (FIX3).
+  defp normalize_and_cap(start_date, end_date) do
+    {s, e} =
+      if Date.compare(start_date, end_date) == :gt,
+        do: {end_date, start_date},
+        else: {start_date, end_date}
+
+    if Date.diff(e, s) > @max_backfill_days do
+      capped_end = Date.add(s, @max_backfill_days)
+
+      Logger.warning(
+        "CostAnomalyWorker: period range #{Date.to_iso8601(s)}..#{Date.to_iso8601(e)} " <>
+          "exceeds #{@max_backfill_days} days; clamping end to #{Date.to_iso8601(capped_end)}"
+      )
+
+      {s, capped_end}
+    else
+      {s, e}
     end
   end
 

--- a/lib/loopctl/workers/cost_anomaly_worker.ex
+++ b/lib/loopctl/workers/cost_anomaly_worker.ex
@@ -130,7 +130,13 @@ defmodule Loopctl.Workers.CostAnomalyWorker do
     end)
   end
 
-  defp check_and_flag_anomaly(tenant_id, story_id, story_cost, epic_avg) when epic_avg > 0 do
+  # `story_cost >= 0` mirrors the `epic_avg > 0` guard: a story whose net
+  # cumulative cost is negative (an over-correction) is not a meaningful
+  # deviation -- it would always fall below the low-cost threshold and produce a
+  # bogus :suspiciously_low anomaly. Excluding it here stops the negative anomaly
+  # at the source, before create_anomaly (FIX A.1).
+  defp check_and_flag_anomaly(tenant_id, story_id, story_cost, epic_avg)
+       when epic_avg > 0 and story_cost >= 0 do
     factor = Decimal.div(Decimal.new(story_cost), Decimal.new(epic_avg))
 
     cond do
@@ -179,47 +185,79 @@ defmodule Loopctl.Workers.CostAnomalyWorker do
           existing
       end
     else
-      now = DateTime.utc_now()
+      # Enforce the SAME invariants the changeset would (create == update
+      # symmetry): insert_all bypasses CostAnomaly.create_changeset/2, so we run
+      # the changeset here to validate (e.g. non-negative story_cost/reference_avg)
+      # and BAIL on invalid input -- no insert, no notify (FIX A.2). The source
+      # guard already rejects negative story_cost; this is defense in depth so a
+      # future caller can't reach insert_all with values the changeset rejects.
+      changeset =
+        CostAnomaly.create_changeset(
+          %CostAnomaly{tenant_id: tenant_id, story_id: story_id},
+          %{
+            anomaly_type: anomaly_type,
+            story_cost_millicents: story_cost,
+            reference_avg_millicents: epic_avg,
+            deviation_factor: Decimal.round(factor, 2)
+          }
+        )
 
-      entry = %{
-        id: Ecto.UUID.generate(),
-        tenant_id: tenant_id,
-        story_id: story_id,
-        anomaly_type: anomaly_type,
-        story_cost_millicents: story_cost,
-        reference_avg_millicents: epic_avg,
-        deviation_factor: Decimal.round(factor, 2),
-        resolved: false,
-        archived: false,
-        metadata: %{},
-        inserted_at: now,
-        updated_at: now
-      }
+      if changeset.valid? do
+        insert_new_anomaly(tenant_id, changeset)
+      else
+        Logger.warning(
+          "CostAnomalyWorker: invalid anomaly for story #{story_id}, skipping: " <>
+            "#{inspect(changeset.errors)}"
+        )
 
-      # insert_all + on_conflict: :nothing reports the REAL number of rows
-      # written against the unique partial index
-      # (cost_anomalies_unresolved_unique): 1 = we genuinely inserted (notify),
-      # 0 = a concurrent run won the race and already notified (skip). This
-      # closes the check-then-insert race: AdminRepo.insert/2 with
-      # on_conflict: :nothing returns {:ok, struct} carrying a client-generated,
-      # UNPERSISTED id on conflict, so the losing run would emit an audit entry +
-      # token.anomaly_detected webhook for an anomaly_id that was never persisted
-      # (FIX1c).
-      case AdminRepo.insert_all(CostAnomaly, [entry],
-             on_conflict: :nothing,
-             conflict_target:
-               {:unsafe_fragment,
-                ~s|("tenant_id","story_id","anomaly_type") WHERE resolved = false|},
-             returning: true
-           ) do
-        {1, [anomaly]} ->
-          notify_new_anomaly(tenant_id, anomaly)
-          anomaly
-
-        {0, _} ->
-          # Lost the race: the concurrent inserter already emitted audit + webhook.
-          nil
+        nil
       end
+    end
+  end
+
+  # Derives the insert_all row from the VALIDATED changeset (so every NOT NULL
+  # column + defaults are set exactly as the changeset would set them) and writes
+  # it race-safely. insert_all + on_conflict: :nothing reports the REAL number of
+  # rows written against the unique partial index
+  # (cost_anomalies_unresolved_unique): 1 = we genuinely inserted (notify), 0 = a
+  # concurrent run won the race and already notified (skip). This closes the
+  # check-then-insert race that AdminRepo.insert/2 with on_conflict: :nothing had,
+  # where it returned {:ok, struct} carrying a client-generated, UNPERSISTED id on
+  # conflict, so the losing run would emit an audit entry + token.anomaly_detected
+  # webhook for an anomaly_id that was never persisted (FIX1c).
+  defp insert_new_anomaly(tenant_id, changeset) do
+    now = DateTime.utc_now()
+
+    entry =
+      changeset
+      |> Ecto.Changeset.apply_changes()
+      |> Map.take([
+        :tenant_id,
+        :story_id,
+        :anomaly_type,
+        :story_cost_millicents,
+        :reference_avg_millicents,
+        :deviation_factor,
+        :resolved,
+        :archived,
+        :metadata
+      ])
+      |> Map.merge(%{id: Ecto.UUID.generate(), inserted_at: now, updated_at: now})
+
+    case AdminRepo.insert_all(CostAnomaly, [entry],
+           on_conflict: :nothing,
+           conflict_target:
+             {:unsafe_fragment,
+              ~s|("tenant_id","story_id","anomaly_type") WHERE resolved = false|},
+           returning: true
+         ) do
+      {1, [anomaly]} ->
+        notify_new_anomaly(tenant_id, anomaly)
+        anomaly
+
+      {0, _} ->
+        # Lost the race: the concurrent inserter already emitted audit + webhook.
+        nil
     end
   end
 

--- a/lib/loopctl/workers/cost_rollup_worker.ex
+++ b/lib/loopctl/workers/cost_rollup_worker.ex
@@ -36,6 +36,17 @@ defmodule Loopctl.Workers.CostRollupWorker do
                     Loopctl.TokenUsage.DefaultRollup
                   )
 
+  # A backfill wider than this is almost certainly a typo (a normal nightly run
+  # is one day; a legitimate backfill is a few weeks). The per-day loop is
+  # O(tenants x days), so an unbounded range would monopolize one of the few
+  # :analytics queue slots. Clamp instead of running unbounded (tokens-03/FIX3).
+  @max_backfill_days 90
+
+  # Backstop timeout so a pathological range can never occupy an :analytics slot
+  # indefinitely (the queue is shared with CostAnomalyWorker + CoT sanity work).
+  @impl Oban.Worker
+  def timeout(_job), do: :timer.minutes(10)
+
   @impl Oban.Worker
   def perform(%Oban.Job{args: args}) do
     # Allow overriding the period for testing/backfills
@@ -72,33 +83,80 @@ defmodule Loopctl.Workers.CostRollupWorker do
       end
 
     # Chain the anomaly worker regardless of partial failures so that
-    # successful tenants still get anomaly detection (ADV-11). Both the upsert
-    # and the chained job are idempotent, so a retry of this job re-runs them
-    # safely.
+    # successful tenants still get anomaly detection (ADV-11). The chained job
+    # is deduplicated (CostAnomalyWorker is `unique` on the period args), so a
+    # retry of this job does not multiply anomaly jobs or their notifications.
     chain_anomaly_worker(period_start, period_end)
 
-    handle_failures(failures)
+    handle_failures(failures, args)
   end
 
   # A failed tenant/day rollup (e.g. a transient DB timeout or connection drop)
   # must NOT be reported as success -- Oban treats :ok as done and would never
   # retry, permanently losing that day's cost_summaries (tokens-08). Succeeded
-  # tenant/days are already persisted via the idempotent upsert, so returning an
-  # error only re-computes identical rows for them on retry while giving the
-  # failed ones another attempt. Failed tenant ids are surfaced for observability.
-  defp handle_failures([]), do: :ok
+  # tenant/days are already persisted via the idempotent upsert.
+  defp handle_failures([], _args), do: :ok
 
-  defp handle_failures(failures) do
+  defp handle_failures(failures, args) do
     failed_tenant_ids =
       failures |> Enum.map(fn {tenant_id, _day, _reason} -> tenant_id end) |> Enum.uniq()
 
-    Logger.warning(
-      "CostRollupWorker: #{length(failures)} tenant/day rollup(s) failed across " <>
-        "#{length(failed_tenant_ids)} tenant(s); returning error so Oban retries"
-    )
+    if scoped_retry?(args) do
+      # This job is ALREADY a scoped follow-up. Do NOT re-enqueue another (that
+      # would be an unbounded loop) -- return an error and let Oban's bounded
+      # retry (max_attempts + backoff) handle it (FIX4).
+      Logger.warning(
+        "CostRollupWorker: scoped retry still failing for tenant(s) " <>
+          "#{inspect(failed_tenant_ids)}; returning error for Oban retry"
+      )
 
-    {:error, {:rollup_failed, failed_tenant_ids}}
+      {:error, {:rollup_failed, failed_tenant_ids}}
+    else
+      # Top-level batch: re-enqueue a NARROW follow-up scoped to only the failed
+      # tenant/day pairs so healthy tenants/days are not re-computed, then report
+      # success so Oban doesn't re-run the whole batch (FIX4). If enqueueing the
+      # scoped retry itself fails, fall back to a bounded whole-batch retry so the
+      # failure is never silently dropped.
+      case enqueue_scoped_retries(failures) do
+        :ok ->
+          :ok
+
+        {:error, reason} ->
+          Logger.error(
+            "CostRollupWorker: could not enqueue scoped retry (#{inspect(reason)}); " <>
+              "falling back to whole-batch retry"
+          )
+
+          {:error, {:rollup_failed, failed_tenant_ids}}
+      end
+    end
   end
+
+  # Re-enqueue one narrow follow-up job per failed day, carrying only that day's
+  # failed tenant ids. Tagged `scoped_retry` so the follow-up uses Oban's native
+  # bounded retry instead of re-enqueueing again.
+  defp enqueue_scoped_retries(failures) do
+    failures
+    |> Enum.group_by(
+      fn {_tenant_id, day, _reason} -> day end,
+      fn {tenant_id, _day, _reason} -> tenant_id end
+    )
+    |> Enum.reduce_while(:ok, fn {day, tenant_ids}, :ok ->
+      args = %{
+        "tenant_ids" => Enum.uniq(tenant_ids),
+        "period_start" => Date.to_iso8601(day),
+        "period_end" => Date.to_iso8601(day),
+        "scoped_retry" => true
+      }
+
+      case args |> new() |> Oban.insert() do
+        {:ok, _job} -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  defp scoped_retry?(args), do: Map.get(args, "scoped_retry", false) == true
 
   @doc false
   def rollup_tenant(tenant_id, period_start, period_end) do
@@ -179,7 +237,7 @@ defmodule Loopctl.Workers.CostRollupWorker do
               yesterday
           end
 
-        {start_date, end_date}
+        normalize_and_cap(start_date, end_date)
 
       other ->
         Logger.warning(
@@ -188,6 +246,30 @@ defmodule Loopctl.Workers.CostRollupWorker do
 
         yesterday = Date.add(Date.utc_today(), -1)
         {yesterday, yesterday}
+    end
+  end
+
+  # Normalize a (possibly reversed) parsed range and cap its width. A reversed
+  # range (start > end) is swapped so `Date.range/2` never produces a descending
+  # range (which would emit a warning and, in the anomaly worker, silently match
+  # no summaries) (FIX2). A range wider than @max_backfill_days is clamped (FIX3).
+  defp normalize_and_cap(start_date, end_date) do
+    {s, e} =
+      if Date.compare(start_date, end_date) == :gt,
+        do: {end_date, start_date},
+        else: {start_date, end_date}
+
+    if Date.diff(e, s) > @max_backfill_days do
+      capped_end = Date.add(s, @max_backfill_days)
+
+      Logger.warning(
+        "CostRollupWorker: backfill range #{Date.to_iso8601(s)}..#{Date.to_iso8601(e)} " <>
+          "exceeds #{@max_backfill_days} days; clamping end to #{Date.to_iso8601(capped_end)}"
+      )
+
+      {s, capped_end}
+    else
+      {s, e}
     end
   end
 
@@ -208,12 +290,26 @@ defmodule Loopctl.Workers.CostRollupWorker do
   end
 
   defp chain_anomaly_worker(period_start, period_end) do
-    %{
-      "period_start" => Date.to_iso8601(period_start),
-      "period_end" => Date.to_iso8601(period_end)
-    }
-    |> CostAnomalyWorker.new(scheduled_at: scheduled_anomaly_time())
-    |> Oban.insert()
+    case %{
+           "period_start" => Date.to_iso8601(period_start),
+           "period_end" => Date.to_iso8601(period_end)
+         }
+         |> CostAnomalyWorker.new(scheduled_at: scheduled_anomaly_time())
+         |> Oban.insert() do
+      # A unique conflict returns {:ok, job} (conflict? true) -- that is the
+      # dedup working, not an error.
+      {:ok, _job} ->
+        :ok
+
+      {:error, reason} ->
+        # Don't lose anomaly detection silently: log a failed enqueue (FIX1b).
+        Logger.error(
+          "CostRollupWorker: failed to enqueue CostAnomalyWorker for " <>
+            "#{Date.to_iso8601(period_start)}..#{Date.to_iso8601(period_end)}: #{inspect(reason)}"
+        )
+
+        :ok
+    end
   end
 
   # Schedule the anomaly worker 5 minutes after the rollup

--- a/test/loopctl/workers/cost_anomaly_worker_test.exs
+++ b/test/loopctl/workers/cost_anomaly_worker_test.exs
@@ -4,6 +4,7 @@ defmodule Loopctl.Workers.CostAnomalyWorkerTest do
   setup :verify_on_exit!
 
   import Ecto.Query
+  import ExUnit.CaptureLog
 
   alias Loopctl.AdminRepo
   alias Loopctl.Audit.AuditLog
@@ -74,6 +75,25 @@ defmodule Loopctl.Workers.CostAnomalyWorkerTest do
     end
 
     report
+  end
+
+  # Adds a (possibly over-correcting) negative correction report that references
+  # a live original, so the story's net cumulative cost can be driven negative.
+  defp add_correction(tenant, story, agent, epic, original_id, cost_millicents) do
+    %Report{
+      tenant_id: tenant.id,
+      story_id: story.id,
+      agent_id: agent.id,
+      project_id: epic.project_id,
+      corrects_report_id: original_id
+    }
+    |> Report.correction_changeset(%{
+      input_tokens: 0,
+      output_tokens: 0,
+      model_name: "claude-opus-4",
+      cost_millicents: cost_millicents
+    })
+    |> AdminRepo.insert!()
   end
 
   # Inserts the epic cost summary the rollup would have written for `period`.
@@ -387,6 +407,118 @@ defmodule Loopctl.Workers.CostAnomalyWorkerTest do
       # Still exactly one anomaly row, and NO new "detected" audit entry.
       assert length(AdminRepo.all(CostAnomaly)) == 1
       assert detected_audit_count(ctx.tenant.id, expensive.id) == 0
+    end
+
+    # FIX A: a story whose net cumulative cost is negative (over-correction) must
+    # NOT be flagged suspiciously_low (and thus never persisted/notified), while a
+    # genuinely low-but-nonnegative story still IS flagged.
+    test "does not flag a net-negative story, but still flags a genuinely low positive story" do
+      ctx = setup_tenant_with_epic()
+      period = Date.utc_today()
+
+      # Normal stories keep the epic average positive.
+      for _ <- 1..3, do: create_story_with_reports(ctx.tenant, ctx.epic, ctx.agent, 30_000)
+
+      # A genuinely low (but non-negative) story -> SHOULD be flagged.
+      low = create_story_with_reports(ctx.tenant, ctx.epic, ctx.agent, 100)
+
+      # A story driven net-negative by an over-correction (+5k then -20k = -15k).
+      negative = create_bare_story(ctx.tenant, ctx.epic)
+      original = add_report(ctx.tenant, negative, ctx.agent, ctx.epic, 5_000, 0)
+      add_correction(ctx.tenant, negative, ctx.agent, ctx.epic, original.id, -20_000)
+
+      insert_epic_summary(ctx, period, 15_000)
+
+      assert :ok = CostAnomalyWorker.perform(%Oban.Job{args: period_args(period)})
+
+      anomalies = AdminRepo.all(CostAnomaly)
+
+      low_anomalies = Enum.filter(anomalies, &(&1.anomaly_type == :suspiciously_low))
+      assert length(low_anomalies) == 1
+      assert hd(low_anomalies).story_id == low.id
+
+      # The negative story produced no anomaly at all...
+      refute Enum.any?(anomalies, &(&1.story_id == negative.id))
+      # ...no negative cost was ever persisted...
+      assert Enum.all?(anomalies, &(&1.story_cost_millicents >= 0))
+      # ...and no audit/notify fired for it.
+      assert detected_audit_count(ctx.tenant.id, negative.id) == 0
+    end
+
+    # FIX A (create == update symmetry): the shared changeset that the insert_all
+    # path now validates through rejects negative costs, so insert_all can never
+    # persist what create_changeset would reject.
+    test "create_changeset rejects negative costs (the invariant the insert path enforces)" do
+      changeset =
+        CostAnomaly.create_changeset(
+          %CostAnomaly{tenant_id: Ecto.UUID.generate(), story_id: Ecto.UUID.generate()},
+          %{
+            anomaly_type: :suspiciously_low,
+            story_cost_millicents: -15_000,
+            reference_avg_millicents: 15_000,
+            deviation_factor: Decimal.new("-1.0")
+          }
+        )
+
+      refute changeset.valid?
+      assert Keyword.has_key?(changeset.errors, :story_cost_millicents)
+    end
+
+    # FIX B: a reversed period range must still detect anomalies (the swap). The
+    # candidate-epic query (period_start >= start and <= end) matches ZERO epics
+    # for a reversed range, so without the swap detection is silently skipped.
+    test "detects anomalies even when the period range is reversed" do
+      ctx = setup_tenant_with_epic()
+      today = Date.utc_today()
+
+      for _ <- 1..3, do: create_story_with_reports(ctx.tenant, ctx.epic, ctx.agent, 10_000)
+      expensive = create_story_with_reports(ctx.tenant, ctx.epic, ctx.agent, 100_000)
+
+      insert_epic_summary(ctx, today, 32_500)
+
+      # period_start AFTER period_end (reversed on purpose).
+      args = %{
+        "period_start" => Date.to_iso8601(Date.add(today, 1)),
+        "period_end" => Date.to_iso8601(Date.add(today, -1))
+      }
+
+      assert :ok = CostAnomalyWorker.perform(%Oban.Job{args: args})
+
+      high = Enum.filter(AdminRepo.all(CostAnomaly), &(&1.anomaly_type == :high_cost))
+      assert length(high) == 1
+      assert hd(high).story_id == expensive.id
+    end
+
+    # FIX B: an over-cap period range is clamped, so an epic rolled up beyond the
+    # 90-day cap is not scanned (bounds the work). Without the cap the far epic
+    # would be a candidate and its story flagged.
+    test "clamps an over-cap period range, excluding epics beyond the cap" do
+      ctx = setup_tenant_with_epic()
+      start_date = ~D[2026-01-01]
+      # Epic summary rolled up ~200 days in -> beyond the 90-day cap.
+      far_day = Date.add(start_date, 200)
+
+      for _ <- 1..3, do: create_story_with_reports(ctx.tenant, ctx.epic, ctx.agent, 10_000)
+      _expensive = create_story_with_reports(ctx.tenant, ctx.epic, ctx.agent, 100_000)
+
+      insert_epic_summary(ctx, far_day, 32_500)
+
+      log =
+        capture_log(fn ->
+          assert :ok =
+                   CostAnomalyWorker.perform(%Oban.Job{
+                     args: %{
+                       "period_start" => Date.to_iso8601(start_date),
+                       # ~1 year -> clamped to start + 90 days
+                       "period_end" => Date.to_iso8601(Date.add(start_date, 364))
+                     }
+                   })
+        end)
+
+      # The clamp ran...
+      assert log =~ "exceeds 90 days; clamping end"
+      # ...and the far epic (day 200, outside [start, start+90]) was NOT scanned.
+      assert AdminRepo.all(CostAnomaly) == []
     end
 
     test "succeeds when no tenants exist" do

--- a/test/loopctl/workers/cost_anomaly_worker_test.exs
+++ b/test/loopctl/workers/cost_anomaly_worker_test.exs
@@ -6,10 +6,21 @@ defmodule Loopctl.Workers.CostAnomalyWorkerTest do
   import Ecto.Query
 
   alias Loopctl.AdminRepo
+  alias Loopctl.Audit.AuditLog
   alias Loopctl.TokenUsage.CostAnomaly
   alias Loopctl.TokenUsage.CostSummary
   alias Loopctl.TokenUsage.Report
   alias Loopctl.Workers.CostAnomalyWorker
+
+  defp detected_audit_count(tenant_id, story_id) do
+    from(a in AuditLog,
+      where:
+        a.tenant_id == ^tenant_id and a.entity_type == "cost_anomaly" and
+          a.action == "detected" and
+          fragment("?->>'story_id' = ?", a.metadata, ^story_id)
+    )
+    |> AdminRepo.aggregate(:count)
+  end
 
   defp setup_tenant_with_epic do
     tenant = fixture(:tenant)
@@ -340,6 +351,42 @@ defmodule Loopctl.Workers.CostAnomalyWorkerTest do
       anomalies = AdminRepo.all(CostAnomaly)
       assert length(anomalies) == 1
       assert hd(anomalies).story_id == expensive.id
+
+      # Exactly ONE "detected" audit entry across the repeated runs -- notify
+      # fires only on the genuine insert, never on the subsequent update/no-op
+      # runs (FIX1: persisted-only notification).
+      assert detected_audit_count(ctx.tenant.id, expensive.id) == 1
+    end
+
+    # FIX1c: when an unresolved anomaly already exists for a story (as a
+    # concurrent winner would have written), a run must UPDATE it in place and
+    # NOT emit a second "detected" audit entry -- i.e. never notify for a
+    # non-newly-persisted anomaly.
+    test "does not emit a second detected audit entry when the anomaly already exists" do
+      ctx = setup_tenant_with_epic()
+      period = Date.utc_today()
+
+      for _ <- 1..3, do: create_story_with_reports(ctx.tenant, ctx.epic, ctx.agent, 10_000)
+      expensive = create_story_with_reports(ctx.tenant, ctx.epic, ctx.agent, 100_000)
+
+      # Pre-existing unresolved anomaly (as though a concurrent run already
+      # inserted + notified for it).
+      fixture(:cost_anomaly, %{
+        tenant_id: ctx.tenant.id,
+        story_id: expensive.id,
+        anomaly_type: :high_cost,
+        story_cost_millicents: 90_000,
+        reference_avg_millicents: 30_000,
+        deviation_factor: Decimal.new("3.0")
+      })
+
+      insert_epic_summary(ctx, period, 32_500)
+
+      assert :ok = CostAnomalyWorker.perform(%Oban.Job{args: period_args(period)})
+
+      # Still exactly one anomaly row, and NO new "detected" audit entry.
+      assert length(AdminRepo.all(CostAnomaly)) == 1
+      assert detected_audit_count(ctx.tenant.id, expensive.id) == 0
     end
 
     test "succeeds when no tenants exist" do

--- a/test/loopctl/workers/cost_rollup_worker_test.exs
+++ b/test/loopctl/workers/cost_rollup_worker_test.exs
@@ -1,5 +1,6 @@
 defmodule Loopctl.Workers.CostRollupWorkerTest do
   use Loopctl.DataCase, async: true
+  use Oban.Testing, repo: Loopctl.Repo
 
   setup :verify_on_exit!
 
@@ -120,10 +121,12 @@ defmodule Loopctl.Workers.CostRollupWorkerTest do
       assert hd(summaries).total_cost_millicents == 15_000
     end
 
-    # tokens-08: a transient per-tenant failure must NOT be swallowed into :ok
-    # (Oban would never retry, permanently losing that day's summaries). The job
-    # must return an error so Oban retries, while succeeded tenants stay persisted.
-    test "returns an error (so Oban retries) when a tenant rollup fails, still persisting succeeded tenants" do
+    # tokens-08 + FIX4: a transient per-tenant failure must NOT be swallowed into
+    # a plain success with no follow-up (Oban would never retry, permanently
+    # losing that day's summaries). The batch re-enqueues a NARROW follow-up
+    # scoped to only the failed tenant/day, so healthy tenants are not
+    # re-computed, and succeeded tenants stay persisted.
+    test "re-enqueues a scoped retry for the failed tenant only, persisting succeeded tenants" do
       good_tenant = fixture(:tenant)
       bad_tenant = fixture(:tenant)
       project = fixture(:project, %{tenant_id: good_tenant.id})
@@ -131,6 +134,8 @@ defmodule Loopctl.Workers.CostRollupWorkerTest do
       good_tenant_id = good_tenant.id
       bad_tenant_id = bad_tenant.id
 
+      # Exactly TWO aggregate calls (good + bad) during the batch. The scoped
+      # retry is only ENQUEUED (manual mode), so it does not re-invoke aggregate.
       expect(Loopctl.MockCostRollup, :aggregate, 2, fn tenant_id, _start, _end ->
         cond do
           tenant_id == good_tenant_id ->
@@ -154,18 +159,30 @@ defmodule Loopctl.Workers.CostRollupWorkerTest do
       end)
 
       result =
-        CostRollupWorker.perform(%Oban.Job{
-          args: %{
-            "period_start" => "2026-04-02",
-            "period_end" => "2026-04-02",
-            "tenant_ids" => [good_tenant.id, bad_tenant.id]
-          }
-        })
+        Oban.Testing.with_testing_mode(:manual, fn ->
+          CostRollupWorker.perform(%Oban.Job{
+            args: %{
+              "period_start" => "2026-04-02",
+              "period_end" => "2026-04-02",
+              "tenant_ids" => [good_tenant.id, bad_tenant.id]
+            }
+          })
+        end)
 
-      # Not :ok -> Oban will retry the job
-      assert {:error, {:rollup_failed, failed_ids}} = result
-      assert bad_tenant.id in failed_ids
-      refute good_tenant.id in failed_ids
+      # Batch reports success but the failure is NOT lost -- it is re-enqueued.
+      assert result == :ok
+
+      # A scoped follow-up job is enqueued for ONLY the failed tenant/day, so
+      # healthy tenants are not re-computed on the retry.
+      scoped_jobs =
+        all_enqueued(worker: CostRollupWorker)
+        |> Enum.filter(&(&1.args["scoped_retry"] == true))
+
+      assert length(scoped_jobs) == 1
+      scoped = hd(scoped_jobs)
+      assert scoped.args["tenant_ids"] == [bad_tenant.id]
+      assert scoped.args["period_start"] == "2026-04-02"
+      assert scoped.args["period_end"] == "2026-04-02"
 
       import Ecto.Query
 
@@ -181,6 +198,140 @@ defmodule Loopctl.Workers.CostRollupWorkerTest do
         from(c in CostSummary, where: c.tenant_id == ^bad_tenant.id) |> AdminRepo.all()
 
       assert bad_summaries == []
+    end
+
+    # FIX4: a scoped retry job that fails again does NOT re-enqueue (which would
+    # loop) -- it returns an error so Oban's bounded retry takes over.
+    test "a scoped retry that fails again returns an error instead of re-enqueueing" do
+      bad_tenant = fixture(:tenant)
+
+      expect(Loopctl.MockCostRollup, :aggregate, fn _tenant_id, _start, _end ->
+        {:error, "still timing out"}
+      end)
+
+      result =
+        Oban.Testing.with_testing_mode(:manual, fn ->
+          CostRollupWorker.perform(%Oban.Job{
+            args: %{
+              "period_start" => "2026-04-02",
+              "period_end" => "2026-04-02",
+              "tenant_ids" => [bad_tenant.id],
+              "scoped_retry" => true
+            }
+          })
+        end)
+
+      assert {:error, {:rollup_failed, failed_ids}} = result
+      assert bad_tenant.id in failed_ids
+
+      # It must NOT have re-enqueued another scoped retry (no unbounded loop).
+      assert all_enqueued(worker: CostRollupWorker) == []
+    end
+
+    # FIX2: a reversed period range is normalized (swapped), not silently skipped.
+    test "normalizes a reversed period range instead of skipping it" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+
+      d1 = ~D[2026-04-01]
+      d2 = ~D[2026-04-02]
+
+      # period_start AFTER period_end -> must be swapped to [d1, d2] and roll up
+      # BOTH days (2 aggregate calls), not zero.
+      expect(Loopctl.MockCostRollup, :aggregate, 2, fn _tenant_id, start_date, end_date ->
+        assert start_date == end_date
+        assert start_date in [d1, d2]
+
+        {:ok,
+         [
+           %{
+             scope_type: :project,
+             scope_id: project.id,
+             total_input_tokens: 0,
+             total_output_tokens: 0,
+             total_cost_millicents: 100,
+             report_count: 1,
+             model_breakdown: %{},
+             avg_cost_per_story_millicents: nil
+           }
+         ]}
+      end)
+
+      assert :ok =
+               CostRollupWorker.perform(%Oban.Job{
+                 args: %{
+                   # reversed on purpose
+                   "period_start" => Date.to_iso8601(d2),
+                   "period_end" => Date.to_iso8601(d1),
+                   "tenant_ids" => [tenant.id]
+                 }
+               })
+
+      import Ecto.Query
+
+      summaries =
+        from(c in CostSummary, where: c.tenant_id == ^tenant.id, order_by: c.period_start)
+        |> AdminRepo.all()
+
+      assert Enum.map(summaries, & &1.period_start) == [d1, d2]
+    end
+
+    # FIX3: an over-cap backfill range is clamped (not run unbounded).
+    test "clamps a backfill range wider than the max to the cap" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+
+      start_date = ~D[2026-01-01]
+      # ~1 year -> must be clamped to 90 days (91 daily rows: day 0..90 inclusive).
+      end_date = ~D[2026-12-31]
+      expected_last = Date.add(start_date, 90)
+
+      expect(Loopctl.MockCostRollup, :aggregate, 91, fn _tenant_id, day, day2 ->
+        assert day == day2
+        assert Date.compare(day, start_date) != :lt
+        assert Date.compare(day, expected_last) != :gt
+
+        {:ok,
+         [
+           %{
+             scope_type: :project,
+             scope_id: project.id,
+             total_input_tokens: 0,
+             total_output_tokens: 0,
+             total_cost_millicents: 1,
+             report_count: 1,
+             model_breakdown: %{},
+             avg_cost_per_story_millicents: nil
+           }
+         ]}
+      end)
+
+      assert :ok =
+               CostRollupWorker.perform(%Oban.Job{
+                 args: %{
+                   "period_start" => Date.to_iso8601(start_date),
+                   "period_end" => Date.to_iso8601(end_date),
+                   "tenant_ids" => [tenant.id]
+                 }
+               })
+
+      import Ecto.Query
+
+      count =
+        from(c in CostSummary, where: c.tenant_id == ^tenant.id) |> AdminRepo.aggregate(:count)
+
+      # 91 daily rows (start .. start+90 inclusive), NOT 365.
+      assert count == 91
+
+      last_day =
+        from(c in CostSummary,
+          where: c.tenant_id == ^tenant.id,
+          order_by: [desc: c.period_start],
+          limit: 1
+        )
+        |> AdminRepo.one()
+
+      assert last_day.period_start == expected_last
     end
 
     # tokens-09: a multi-day backfill (period_start..period_end) must produce ONE

--- a/test/loopctl/workers/cost_rollup_worker_test.exs
+++ b/test/loopctl/workers/cost_rollup_worker_test.exs
@@ -229,7 +229,10 @@ defmodule Loopctl.Workers.CostRollupWorkerTest do
     end
 
     # FIX2: a reversed period range is normalized (swapped), not silently skipped.
-    test "normalizes a reversed period range instead of skipping it" do
+    # Strengthened so it FAILS without the swap: the chained CostAnomalyWorker
+    # must receive the EARLIER date as period_start (without the swap it would
+    # carry the later date and the anomaly candidate query would match nothing).
+    test "normalizes a reversed period range and chains anomaly detection with the earlier date first" do
       tenant = fixture(:tenant)
       project = fixture(:project, %{tenant_id: tenant.id})
 
@@ -257,15 +260,22 @@ defmodule Loopctl.Workers.CostRollupWorkerTest do
          ]}
       end)
 
-      assert :ok =
-               CostRollupWorker.perform(%Oban.Job{
-                 args: %{
-                   # reversed on purpose
-                   "period_start" => Date.to_iso8601(d2),
-                   "period_end" => Date.to_iso8601(d1),
-                   "tenant_ids" => [tenant.id]
-                 }
-               })
+      {result, anomaly_jobs} =
+        Oban.Testing.with_testing_mode(:manual, fn ->
+          r =
+            CostRollupWorker.perform(%Oban.Job{
+              args: %{
+                # reversed on purpose
+                "period_start" => Date.to_iso8601(d2),
+                "period_end" => Date.to_iso8601(d1),
+                "tenant_ids" => [tenant.id]
+              }
+            })
+
+          {r, all_enqueued(worker: Loopctl.Workers.CostAnomalyWorker)}
+        end)
+
+      assert result == :ok
 
       import Ecto.Query
 
@@ -274,6 +284,11 @@ defmodule Loopctl.Workers.CostRollupWorkerTest do
         |> AdminRepo.all()
 
       assert Enum.map(summaries, & &1.period_start) == [d1, d2]
+
+      # The chained anomaly worker gets the normalized (earlier-first) range.
+      assert [anomaly_job] = anomaly_jobs
+      assert anomaly_job.args["period_start"] == Date.to_iso8601(d1)
+      assert anomaly_job.args["period_end"] == Date.to_iso8601(d2)
     end
 
     # FIX3: an over-cap backfill range is clamped (not run unbounded).


### PR DESCRIPTION
## Summary

Follow-up to PR #271 (cost-workers, merged as `45f0beb`). Addresses the 4 findings from the Sonnet-5/xhigh review gate. Single commit `bf228be` on top of current `master`.

> Note: #271 was merged before these review fixes could be added to it, so they land here as a separate PR.

### FIX1 (HIGH) — retry re-enqueued a non-unique anomaly job + widened a notify race
- **(a)** `CostAnomalyWorker` is now `unique` on the period args (`period: 600, keys: [:period_start, :period_end]`) so repeated enqueues within the window (e.g. a `CostRollupWorker` retry re-chaining the same period) collapse to one job instead of running concurrently on the `:analytics` queue.
- **(b)** `chain_anomaly_worker` now handles the `Oban.insert` result — a failed enqueue is logged instead of silently dropping anomaly detection (`{:ok, job}` covers the unique-conflict/dedup case).
- **(c)** `create_anomaly` no longer emits an audit entry + `token.anomaly_detected` webhook for a **non-persisted** anomaly. `AdminRepo.insert/2` with `on_conflict: :nothing` returns `{:ok, struct}` carrying a client-generated, UNPERSISTED id on conflict, so a losing concurrent run would notify for an `anomaly_id` that never existed. Replaced with `insert_all` + `returning`, keyed on the unique partial index: notify **only** when the affected-row count is `1` (genuine insert); a `0`-count conflict skips notification.

### FIX2 (MEDIUM) — reversed period silently skipped detection
`resolve_period` in **both** workers now normalizes a reversed range (`period_start > period_end`) by swapping. Previously `Date.range/2` produced a descending range (with a warning) and the anomaly worker's candidate-epic predicate (`period_start >= start and <= end`) matched **nothing**, silently skipping detection for the whole range.

### FIX3 (MEDIUM) — unbounded backfill range monopolizes the queue
`resolve_period` caps the range at 90 days (clamp + log) and `CostRollupWorker` gains an Oban `timeout/1` backstop (10 min). A typo'd huge range can no longer run the O(tenants × days) per-day loop unbounded in one of the few shared `:analytics` slots.

### FIX4 (LOW) — narrow the retry
A partial batch failure now re-enqueues a **narrow** follow-up scoped to only the failed tenant/day pairs (returning `:ok` for the batch) so healthy tenants are not re-computed on retry. The follow-up is tagged `scoped_retry`; if IT fails it returns an error for Oban's bounded native retry (max_attempts + backoff) rather than re-enqueueing again (no loop). If the scoped enqueue itself fails, falls back to a bounded whole-batch retry so a failure is never dropped.

## Tests
- Repeated anomaly detection creates exactly one row + one `detected` audit entry (persisted-only notify); a pre-existing anomaly yields no second notify.
- Reversed range is normalized (both days rolled up); an over-cap range is clamped to 91 daily rows.
- A partial failure re-enqueues a scoped retry for the failed tenant only (manual Oban mode); a scoped retry that fails again returns an error without re-enqueueing.

Full `mix precommit` gate green (compile `--warnings-as-errors`, format, credo `--strict`, dialyzer 0, `3358 tests, 0 failures`) on Elixir 1.19 / OTP 28.

## Trust-model checklist
No role/RLS/chain-of-custody surface touched. Both workers run under `AdminRepo` (BYPASSRLS) as before; the anomaly query is tenant-scoped; `insert_all` sets `tenant_id` programmatically (never via `cast`).
