### PR TITLE
fix(pagination): stable ordering + batched blocking-dep fetch (wb-01/wb-02/tokens-07)

### DIFF
--- a/lib/loopctl/token_usage/analytics.ex
+++ b/lib/loopctl/token_usage/analytics.ex
@@ -98,7 +98,8 @@ defmodule Loopctl.TokenUsage.Analytics do
             r.story_id,
             r.cost_millicents,
             r.story_id
-          )
+          ),
+        asc: r.agent_id
       )
       |> limit(^page_size)
       |> offset(^offset)

--- a/lib/loopctl/work_breakdown/queries.ex
+++ b/lib/loopctl/work_breakdown/queries.ex
@@ -93,7 +93,7 @@ defmodule Loopctl.WorkBreakdown.Queries do
 
     stories =
       ready_query
-      |> order_by([s], asc: s.sort_key)
+      |> order_by([s], asc: s.sort_key, asc: s.id)
       |> limit(^page_size)
       |> offset(^offset)
       |> AdminRepo.all()
@@ -162,16 +162,23 @@ defmodule Loopctl.WorkBreakdown.Queries do
 
     stories =
       blocked_query
-      |> order_by([s], asc: s.sort_key)
+      |> order_by([s], asc: s.sort_key, asc: s.id)
       |> limit(^page_size)
       |> offset(^offset)
       |> AdminRepo.all()
 
-    # For each blocked story, fetch its blocking dependencies (story + epic level)
+    # Batch-fetch blocking dependencies for all stories at once (avoids N+1).
+    # Two queries total regardless of page size, instead of two per story.
+    story_ids = Enum.map(stories, & &1.id)
+    epic_ids = stories |> Enum.map(& &1.epic_id) |> Enum.uniq()
+
+    story_blockers_by_story = fetch_blocking_story_dependencies_batch(story_ids)
+    epic_blockers_by_epic = fetch_blocking_epic_dependencies_batch(epic_ids)
+
     data =
       Enum.map(stories, fn story ->
-        story_blockers = fetch_blocking_story_dependencies(story.id)
-        epic_blockers = fetch_blocking_epic_dependencies(story.epic_id)
+        story_blockers = Map.get(story_blockers_by_story, story.id, [])
+        epic_blockers = Map.get(epic_blockers_by_epic, story.epic_id, [])
 
         %{
           story: story,
@@ -279,12 +286,17 @@ defmodule Loopctl.WorkBreakdown.Queries do
     end
   end
 
-  defp fetch_blocking_story_dependencies(story_id) do
+  # Batch-fetch story-level blocking dependencies for many stories in one query.
+  # Returns %{story_id => [dependency_map, ...]} (avoids the N+1 pattern).
+  defp fetch_blocking_story_dependencies_batch([] = _story_ids), do: %{}
+
+  defp fetch_blocking_story_dependencies_batch(story_ids) do
     from(sd in StoryDependency,
       join: dep in Story,
       on: dep.id == sd.depends_on_story_id,
-      where: sd.story_id == ^story_id and dep.verified_status != :verified,
+      where: sd.story_id in ^story_ids and dep.verified_status != :verified,
       select: %{
+        story_id: sd.story_id,
         id: dep.id,
         number: dep.number,
         title: dep.title,
@@ -293,15 +305,21 @@ defmodule Loopctl.WorkBreakdown.Queries do
       }
     )
     |> AdminRepo.all()
+    |> Enum.group_by(& &1.story_id, &Map.delete(&1, :story_id))
   end
 
-  defp fetch_blocking_epic_dependencies(epic_id) do
+  # Batch-fetch epic-level blocking dependencies for many epics in one query.
+  # Returns %{epic_id => [dependency_map, ...]} (avoids the N+1 pattern).
+  defp fetch_blocking_epic_dependencies_batch([] = _epic_ids), do: %{}
+
+  defp fetch_blocking_epic_dependencies_batch(epic_ids) do
     # Find unverified stories in prerequisite epics (via epic_dependencies)
     from(ed in EpicDependency,
       join: prereq_story in Story,
       on: prereq_story.epic_id == ed.depends_on_epic_id,
-      where: ed.epic_id == ^epic_id and prereq_story.verified_status != :verified,
+      where: ed.epic_id in ^epic_ids and prereq_story.verified_status != :verified,
       select: %{
+        epic_id: ed.epic_id,
         id: prereq_story.id,
         number: prereq_story.number,
         title: prereq_story.title,
@@ -310,5 +328,6 @@ defmodule Loopctl.WorkBreakdown.Queries do
       }
     )
     |> AdminRepo.all()
+    |> Enum.group_by(& &1.epic_id, &Map.delete(&1, :epic_id))
   end
 end

--- a/test/loopctl/token_usage/analytics_test.exs
+++ b/test/loopctl/token_usage/analytics_test.exs
@@ -202,6 +202,61 @@ defmodule Loopctl.TokenUsage.AnalyticsTest do
       {:ok, own_result} = Analytics.agent_metrics(ctx.tenant.id)
       assert own_result.total == 2
     end
+
+    test "efficiency_rank is deterministic across runs when costs tie (tokens-07)" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+
+      # Several agents sharing an IDENTICAL avg cost per story (a rank tie):
+      # each has exactly one story and one report of the same cost.
+      agent_ids =
+        for i <- 1..6 do
+          agent = fixture(:agent, %{tenant_id: tenant.id, name: "tie-agent-#{i}"})
+
+          story =
+            fixture(:story, %{
+              tenant_id: tenant.id,
+              epic_id: epic.id,
+              project_id: project.id,
+              number: "1.#{i}",
+              assigned_agent_id: agent.id
+            })
+
+          fixture(:token_usage_report, %{
+            tenant_id: tenant.id,
+            story_id: story.id,
+            agent_id: agent.id,
+            project_id: project.id,
+            cost_millicents: 1000,
+            input_tokens: 100,
+            output_tokens: 50
+          })
+
+          agent.id
+        end
+
+      ranks_of = fn ->
+        {:ok, result} = Analytics.agent_metrics(tenant.id, page_size: 100)
+        Map.new(result.data, &{&1.agent_id, &1.efficiency_rank})
+      end
+
+      first = ranks_of.()
+      second = ranks_of.()
+
+      # All six agents tie on avg cost per story, yet ranks are a full 1..6 set.
+      assert map_size(first) == 6
+      assert Enum.sort(Map.values(first)) == Enum.to_list(1..6)
+
+      # The secondary agent_id sort makes the tie-break stable across calls.
+      assert first == second,
+             "efficiency_rank was non-deterministic for tied agents: #{inspect(first)} vs #{inspect(second)}"
+
+      for aid <- agent_ids do
+        assert Map.fetch!(first, aid) == Map.fetch!(second, aid),
+               "agent #{aid} changed efficiency_rank between identical runs"
+      end
+    end
   end
 
   # ---------------------------------------------------------------------------

--- a/test/loopctl/work_breakdown/queries_test.exs
+++ b/test/loopctl/work_breakdown/queries_test.exs
@@ -3,12 +3,24 @@ defmodule Loopctl.WorkBreakdown.QueriesTest do
 
   setup :verify_on_exit!
 
+  import Loopctl.PlanAssertions, only: [capture_repo_queries: 1]
+
+  alias Loopctl.AdminRepo
   alias Loopctl.WorkBreakdown.Queries
+  alias Loopctl.WorkBreakdown.Story
 
   defp setup_project do
     tenant = fixture(:tenant)
     project = fixture(:project, %{tenant_id: tenant.id})
     %{tenant: tenant, project: project}
+  end
+
+  # sort_key is computed from the story number (not castable). To create the
+  # duplicate-sort_key condition that destabilizes pagination, force a constant
+  # sort_key directly on the given story ids.
+  defp force_sort_key(story_ids, value) do
+    from(s in Story, where: s.id in ^story_ids)
+    |> AdminRepo.update_all(set: [sort_key: value])
   end
 
   describe "list_ready_stories/2" do
@@ -355,6 +367,271 @@ defmodule Loopctl.WorkBreakdown.QueriesTest do
       {:ok, result} = Queries.list_blocked_stories(tenant.id, page_size: 500)
 
       assert result.page_size == 500
+    end
+  end
+
+  # --- wb-01 (#245): stable pagination with duplicate sort_key values ---
+
+  describe "list_ready_stories/2 pagination stability (wb-01)" do
+    test "paginates deterministically across pages when sort_key ties" do
+      %{tenant: tenant, project: project} = setup_project()
+      epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+
+      # 100 ready stories (pending, no deps), all sharing an identical sort_key.
+      story_ids =
+        for i <- 1..100 do
+          story =
+            fixture(:story, %{
+              tenant_id: tenant.id,
+              epic_id: epic.id,
+              project_id: project.id,
+              number: "1.#{i}",
+              agent_status: :pending
+            })
+
+          story.id
+        end
+
+      force_sort_key(story_ids, 0)
+
+      collected =
+        for page <- 1..10 do
+          {:ok, result} =
+            Queries.list_ready_stories(tenant.id,
+              project_id: project.id,
+              page: page,
+              page_size: 10
+            )
+
+          assert result.total == 100,
+                 "expected total 100 on page #{page}, got #{result.total}"
+
+          assert length(result.data) == 10,
+                 "expected 10 rows on page #{page}, got #{length(result.data)}"
+
+          Enum.map(result.data, & &1.id)
+        end
+
+      all_ids = List.flatten(collected)
+
+      assert length(all_ids) == 100,
+             "expected 100 rows total across pages, got #{length(all_ids)}"
+
+      unique_ids = Enum.uniq(all_ids)
+
+      assert length(unique_ids) == 100,
+             "duplicate/skipped rows across pages: #{length(all_ids) - length(unique_ids)} duplicates"
+
+      assert MapSet.new(unique_ids) == MapSet.new(story_ids),
+             "paginated ids did not exactly cover the created stories (skips or duplicates)"
+    end
+
+    test "page order is stable across repeated runs when sort_key ties" do
+      %{tenant: tenant, project: project} = setup_project()
+      epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+
+      story_ids =
+        for i <- 1..30 do
+          story =
+            fixture(:story, %{
+              tenant_id: tenant.id,
+              epic_id: epic.id,
+              project_id: project.id,
+              number: "2.#{i}",
+              agent_status: :pending
+            })
+
+          story.id
+        end
+
+      force_sort_key(story_ids, 0)
+
+      fetch_all =
+        fn ->
+          for page <- 1..3 do
+            {:ok, result} =
+              Queries.list_ready_stories(tenant.id,
+                project_id: project.id,
+                page: page,
+                page_size: 10
+              )
+
+            Enum.map(result.data, & &1.id)
+          end
+          |> List.flatten()
+        end
+
+      assert fetch_all.() == fetch_all.(),
+             "row ordering was not stable across identical queries"
+    end
+  end
+
+  describe "list_blocked_stories/2 pagination stability (wb-01)" do
+    test "paginates deterministically across pages when sort_key ties" do
+      %{tenant: tenant, project: project} = setup_project()
+      prereq_epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id, number: 1})
+      blocked_epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id, number: 2})
+
+      # blocked_epic depends on prereq_epic, which has an unverified story:
+      # every story in blocked_epic is therefore blocked at the epic level.
+      fixture(:epic_dependency, %{
+        tenant_id: tenant.id,
+        epic_id: blocked_epic.id,
+        depends_on_epic_id: prereq_epic.id
+      })
+
+      fixture(:story, %{
+        tenant_id: tenant.id,
+        epic_id: prereq_epic.id,
+        project_id: project.id,
+        number: "1.1",
+        agent_status: :implementing,
+        verified_status: :unverified
+      })
+
+      story_ids =
+        for i <- 1..100 do
+          story =
+            fixture(:story, %{
+              tenant_id: tenant.id,
+              epic_id: blocked_epic.id,
+              project_id: project.id,
+              number: "2.#{i}",
+              agent_status: :pending
+            })
+
+          story.id
+        end
+
+      force_sort_key(story_ids, 0)
+
+      collected =
+        for page <- 1..10 do
+          {:ok, result} =
+            Queries.list_blocked_stories(tenant.id,
+              project_id: project.id,
+              page: page,
+              page_size: 10
+            )
+
+          assert result.total == 100,
+                 "expected total 100 on page #{page}, got #{result.total}"
+
+          assert length(result.data) == 10,
+                 "expected 10 rows on page #{page}, got #{length(result.data)}"
+
+          Enum.map(result.data, & &1.story.id)
+        end
+
+      all_ids = List.flatten(collected)
+
+      assert length(all_ids) == 100,
+             "expected 100 rows total across pages, got #{length(all_ids)}"
+
+      unique_ids = Enum.uniq(all_ids)
+
+      assert length(unique_ids) == 100,
+             "duplicate/skipped rows across pages: #{length(all_ids) - length(unique_ids)} duplicates"
+
+      assert MapSet.new(unique_ids) == MapSet.new(story_ids),
+             "paginated ids did not exactly cover the created blocked stories (skips or duplicates)"
+    end
+  end
+
+  # --- wb-02 (#246): batched blocking-dependency fetch (no N+1) ---
+
+  describe "list_blocked_stories/2 query count (wb-02)" do
+    setup do
+      %{tenant: tenant, project: project} = setup_project()
+      prereq_epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id, number: 1})
+      blocked_epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id, number: 2})
+
+      fixture(:epic_dependency, %{
+        tenant_id: tenant.id,
+        epic_id: blocked_epic.id,
+        depends_on_epic_id: prereq_epic.id
+      })
+
+      # A story-level blocker too, so both batch queries return rows.
+      blocker =
+        fixture(:story, %{
+          tenant_id: tenant.id,
+          epic_id: prereq_epic.id,
+          project_id: project.id,
+          number: "1.1",
+          agent_status: :implementing,
+          verified_status: :unverified
+        })
+
+      %{tenant: tenant, project: project, blocked_epic: blocked_epic, blocker: blocker}
+    end
+
+    defp seed_blocked(ctx, %Range{} = range) do
+      for i <- range do
+        story =
+          fixture(:story, %{
+            tenant_id: ctx.tenant.id,
+            epic_id: ctx.blocked_epic.id,
+            project_id: ctx.project.id,
+            number: "2.#{i}",
+            agent_status: :pending
+          })
+
+        fixture(:story_dependency, %{
+          tenant_id: ctx.tenant.id,
+          story_id: story.id,
+          depends_on_story_id: ctx.blocker.id
+        })
+      end
+
+      :ok
+    end
+
+    test "issues a constant number of queries regardless of story count", ctx do
+      seed_blocked(ctx, 1..50)
+
+      queries =
+        capture_repo_queries(fn ->
+          {:ok, result} =
+            Queries.list_blocked_stories(ctx.tenant.id,
+              project_id: ctx.project.id,
+              page_size: 100
+            )
+
+          assert result.total == 50
+          assert length(result.data) == 50
+          # Every story reports its blockers (story-level + epic-level).
+          assert Enum.all?(result.data, &(&1.blocking_dependencies != []))
+        end)
+
+      count = length(queries)
+
+      # count aggregate + main list + batch story deps + batch epic deps == 4.
+      # The buggy version issued 2 extra queries PER story (100+ for 50 stories).
+      assert count < 10,
+             "expected a small constant query count, got #{count} (N+1 regression?)"
+    end
+
+    test "query count does not scale with the number of blocked stories", ctx do
+      seed_blocked(ctx, 1..5)
+
+      small =
+        capture_repo_queries(fn ->
+          Queries.list_blocked_stories(ctx.tenant.id, project_id: ctx.project.id, page_size: 100)
+        end)
+        |> length()
+
+      # Add many more blocked stories to the same dataset.
+      seed_blocked(ctx, 6..50)
+
+      large =
+        capture_repo_queries(fn ->
+          Queries.list_blocked_stories(ctx.tenant.id, project_id: ctx.project.id, page_size: 100)
+        end)
+        |> length()
+
+      assert small == large,
+             "query count scaled with story count (#{small} for 5 stories vs #{large} for 50) — N+1 regression"
     end
   end
 end


### PR DESCRIPTION
## Summary

Three deterministic-ordering / query-efficiency fixes across the work-breakdown and token-usage query layers. All are read-only query optimizations — no schema migrations, no changeset changes.

### wb-01 (#245) — Unstable pagination in `list_ready_stories` / `list_blocked_stories`
Both queries ordered only by `sort_key`. When multiple stories share a `sort_key` (common at 0.0 / equal priority), row order was non-deterministic across pages, causing skips and duplicates. Added `id ASC` as a secondary tiebreaker to both queries.

### wb-02 (#246) — N+1 query pattern in `list_blocked_stories`
For each blocked story the code issued two extra SELECTs (`fetch_blocking_story_dependencies/1`, `fetch_blocking_epic_dependencies/1`) — 100+ queries for 50 blocked stories. Replaced with two batched helpers that fetch all blockers in one query each and group by id:
- `fetch_blocking_story_dependencies_batch/1` → `%{story_id => [deps]}`
- `fetch_blocking_epic_dependencies_batch/1` → `%{epic_id => [deps]}`

Query count is now constant regardless of page size.

### tokens-07 (#242) — Non-deterministic efficiency ranking in `agent_metrics`
The ORDER BY sorted by avg cost per story with no secondary sort, so tied agents received non-deterministic `efficiency_rank` across runs. Added `agent_id ASC` as a stable tiebreaker.

## Tests
- **Pagination stability** (wb-01): 100 stories with identical `sort_key`, paginated at `page_size=10` — asserts no skips, no duplicates, exact coverage of created stories. Covers both `list_ready_stories` and `list_blocked_stories`, plus a repeat-run ordering-stability check.
- **Query count** (wb-02): proves `list_blocked_stories` issues a small constant number of queries with 50 blocked stories, and that the count does not grow between a 5-story and 50-story dataset (definitive N+1 guard).
- **Efficiency rank determinism** (tokens-07): six agents tied on avg cost per story — asserts `efficiency_rank` is a full 1..6 set and identical across repeated calls.

## Verification
`mix precommit` green: compile `--warnings-as-errors`, `format --check-formatted`, `credo --strict` (no issues), `deps.audit`, `dialyzer` (passed), and full suite — 3368 tests, 0 failures.