### PR TITLE
fix(pagination): unique tiebreakers + batch blocked-story blockers (wb-01, wb-02, tokens-07)

### DIFF
--- a/lib/loopctl/token_usage/analytics.ex
+++ b/lib/loopctl/token_usage/analytics.ex
@@ -174,7 +174,11 @@ defmodule Loopctl.TokenUsage.Analytics do
 
     epics =
       epic_base
-      |> order_by([e], asc: e.number)
+      # asc: e.id is a unique, deterministic tiebreaker. epic.number is only
+      # unique per (tenant_id, project_id); GET /analytics/epics without a
+      # project_id filter returns every project's epic #1/#2/... sharing a
+      # number, so OFFSET pagination would skip/duplicate epics without it.
+      |> order_by([e], asc: e.number, asc: e.id)
       |> limit(^page_size)
       |> offset(^offset)
       |> AdminRepo.all()

--- a/lib/loopctl/token_usage/analytics.ex
+++ b/lib/loopctl/token_usage/analytics.ex
@@ -98,7 +98,11 @@ defmodule Loopctl.TokenUsage.Analytics do
             r.story_id,
             r.cost_millicents,
             r.story_id
-          )
+          ),
+        # Unique deterministic tiebreaker (the group-by key). Integer division
+        # makes avg-cost ties common; without this, OFFSET pagination could
+        # skip/duplicate rows AND efficiency_rank would be nondeterministic.
+        asc: r.agent_id
       )
       |> limit(^page_size)
       |> offset(^offset)
@@ -333,7 +337,9 @@ defmodule Loopctl.TokenUsage.Analytics do
         total_cost_millicents: sum(r.cost_millicents),
         report_count: count(r.id)
       })
-      |> order_by([r], desc: sum(r.cost_millicents))
+      # Unique deterministic tiebreaker (the group-by key) so OFFSET pagination
+      # is stable and rank ordering is deterministic when total costs tie.
+      |> order_by([r], desc: sum(r.cost_millicents), asc: r.model_name)
       |> limit(^page_size)
       |> offset(^offset)
       |> AdminRepo.all()

--- a/lib/loopctl/work_breakdown/queries.ex
+++ b/lib/loopctl/work_breakdown/queries.ex
@@ -93,7 +93,10 @@ defmodule Loopctl.WorkBreakdown.Queries do
 
     stories =
       ready_query
-      |> order_by([s], asc: s.sort_key)
+      # asc: s.id is a unique, deterministic tiebreaker so OFFSET pagination
+      # never skips or duplicates rows sharing a sort_key (sort_key is NOT
+      # unique — especially across projects when no project_id filter is set).
+      |> order_by([s], asc: s.sort_key, asc: s.id)
       |> limit(^page_size)
       |> offset(^offset)
       |> AdminRepo.all()
@@ -162,16 +165,26 @@ defmodule Loopctl.WorkBreakdown.Queries do
 
     stories =
       blocked_query
-      |> order_by([s], asc: s.sort_key)
+      # asc: s.id is a unique, deterministic tiebreaker so OFFSET pagination
+      # never skips or duplicates rows sharing a sort_key.
+      |> order_by([s], asc: s.sort_key, asc: s.id)
       |> limit(^page_size)
       |> offset(^offset)
       |> AdminRepo.all()
 
-    # For each blocked story, fetch its blocking dependencies (story + epic level)
+    # Batch-fetch blocking dependencies for the whole page in O(1) queries
+    # (two total) instead of 2 per story, to avoid N+1 resource exhaustion on
+    # this agent-polled endpoint.
+    story_ids = Enum.map(stories, & &1.id)
+    epic_ids = stories |> Enum.map(& &1.epic_id) |> Enum.uniq()
+
+    story_blockers_by_story = fetch_blocking_story_dependencies(tenant_id, story_ids)
+    epic_blockers_by_epic = fetch_blocking_epic_dependencies(tenant_id, epic_ids)
+
     data =
       Enum.map(stories, fn story ->
-        story_blockers = fetch_blocking_story_dependencies(story.id)
-        epic_blockers = fetch_blocking_epic_dependencies(story.epic_id)
+        story_blockers = Map.get(story_blockers_by_story, story.id, [])
+        epic_blockers = Map.get(epic_blockers_by_epic, story.epic_id, [])
 
         %{
           story: story,
@@ -279,12 +292,20 @@ defmodule Loopctl.WorkBreakdown.Queries do
     end
   end
 
-  defp fetch_blocking_story_dependencies(story_id) do
+  # Batch-fetch story-level blockers for an entire page of blocked stories in a
+  # single query. Returns %{story_id => [blocker_map, ...]} so each story can be
+  # attached its own blockers in memory (O(1) queries per page, not O(page_size)).
+  defp fetch_blocking_story_dependencies(_tenant_id, [] = _story_ids), do: %{}
+
+  defp fetch_blocking_story_dependencies(tenant_id, story_ids) do
     from(sd in StoryDependency,
       join: dep in Story,
       on: dep.id == sd.depends_on_story_id,
-      where: sd.story_id == ^story_id and dep.verified_status != :verified,
+      where:
+        sd.tenant_id == ^tenant_id and sd.story_id in ^story_ids and
+          dep.verified_status != :verified,
       select: %{
+        story_id: sd.story_id,
         id: dep.id,
         number: dep.number,
         title: dep.title,
@@ -293,15 +314,23 @@ defmodule Loopctl.WorkBreakdown.Queries do
       }
     )
     |> AdminRepo.all()
+    |> Enum.group_by(& &1.story_id, &Map.delete(&1, :story_id))
   end
 
-  defp fetch_blocking_epic_dependencies(epic_id) do
+  # Batch-fetch epic-level blockers for an entire page in a single query.
+  # Returns %{epic_id => [blocker_map, ...]} keyed by the blocked story's epic.
+  defp fetch_blocking_epic_dependencies(_tenant_id, [] = _epic_ids), do: %{}
+
+  defp fetch_blocking_epic_dependencies(tenant_id, epic_ids) do
     # Find unverified stories in prerequisite epics (via epic_dependencies)
     from(ed in EpicDependency,
       join: prereq_story in Story,
       on: prereq_story.epic_id == ed.depends_on_epic_id,
-      where: ed.epic_id == ^epic_id and prereq_story.verified_status != :verified,
+      where:
+        ed.tenant_id == ^tenant_id and ed.epic_id in ^epic_ids and
+          prereq_story.verified_status != :verified,
       select: %{
+        epic_id: ed.epic_id,
         id: prereq_story.id,
         number: prereq_story.number,
         title: prereq_story.title,
@@ -310,5 +339,6 @@ defmodule Loopctl.WorkBreakdown.Queries do
       }
     )
     |> AdminRepo.all()
+    |> Enum.group_by(& &1.epic_id, &Map.delete(&1, :epic_id))
   end
 end

--- a/lib/loopctl/work_breakdown/stories.ex
+++ b/lib/loopctl/work_breakdown/stories.ex
@@ -246,7 +246,9 @@ defmodule Loopctl.WorkBreakdown.Stories do
 
     stories =
       base_query
-      |> order_by([s], asc: s.sort_key)
+      # asc: s.id is a unique, deterministic tiebreaker so OFFSET pagination
+      # never skips or duplicates rows sharing a sort_key.
+      |> order_by([s], asc: s.sort_key, asc: s.id)
       |> limit(^page_size)
       |> offset(^offset)
       |> AdminRepo.all()
@@ -292,7 +294,9 @@ defmodule Loopctl.WorkBreakdown.Stories do
 
     stories =
       base_query
-      |> order_by([s], asc: s.sort_key)
+      # asc: s.id is a unique, deterministic tiebreaker so OFFSET pagination
+      # never skips or duplicates rows sharing a sort_key.
+      |> order_by([s], asc: s.sort_key, asc: s.id)
       |> limit(^limit)
       |> offset(^offset)
       |> AdminRepo.all()

--- a/test/loopctl/token_usage/analytics_test.exs
+++ b/test/loopctl/token_usage/analytics_test.exs
@@ -537,11 +537,19 @@ defmodule Loopctl.TokenUsage.AnalyticsTest do
 
   # --- tokens-07: stable ranked/paginated metrics with a unique tiebreaker ---
   #
-  # agent_metrics ranks by integer avg-cost-per-story (SUM/COUNT) and model_metrics
-  # ranks by total cost. Both make ties common. Without a unique final sort term
-  # (agent_id / model_name), OFFSET pagination skips/duplicates tied rows across
-  # pages and efficiency_rank is nondeterministic run-to-run. These tests would
-  # fail on the pre-fix order_by.
+  # agent_metrics ranks by integer avg-cost-per-story (SUM/COUNT), model_metrics
+  # ranks by total cost, and epic_metrics paginates by epic.number (unique only
+  # per project). All three make ties/collisions common. Without a unique final
+  # sort term (agent_id / model_name / epic id), OFFSET pagination can
+  # skip/duplicate rows and efficiency_rank becomes nondeterministic.
+  #
+  # The `union covers once` / `deterministic across calls` tests are behavioral
+  # coverage but not reliable regression guards on their own — inside a sandbox
+  # transaction Postgres tends to return tied rows in insertion order, so the
+  # instability may not surface even without the tiebreaker. The authoritative
+  # guards are the `... ORDER BY tiebreaker (SQL guard)` tests, which assert on
+  # the emitted SQL and fail deterministically the moment the tiebreaker is
+  # dropped from the query's ORDER BY.
 
   describe "tokens-07: agent_metrics is stable when avg cost per story ties" do
     setup do
@@ -606,6 +614,13 @@ defmodule Loopctl.TokenUsage.AnalyticsTest do
       # Ranks are the contiguous 1..N with no gaps/dupes on ties.
       assert Enum.map(first.data, & &1.efficiency_rank) == [1, 2]
     end
+
+    test "ORDER BY ends with the unique agent_id tiebreaker (SQL guard)", %{tenant: tenant} do
+      assert_paginated_order_by_tiebreaker(
+        fn -> Analytics.agent_metrics(tenant.id, page_size: 10) end,
+        ~s|"agent_id"|
+      )
+    end
   end
 
   describe "tokens-07: model_metrics is stable when total cost ties" do
@@ -644,6 +659,108 @@ defmodule Loopctl.TokenUsage.AnalyticsTest do
       {:ok, second} = Analytics.model_metrics(tenant.id, page_size: 20)
 
       assert Enum.map(first.data, & &1.model_name) == Enum.map(second.data, & &1.model_name)
+    end
+
+    test "ORDER BY ends with the unique model_name tiebreaker (SQL guard)", %{tenant: tenant} do
+      assert_paginated_order_by_tiebreaker(
+        fn -> Analytics.model_metrics(tenant.id, page_size: 10) end,
+        ~s|"model_name"|
+      )
+    end
+  end
+
+  describe "tokens-07: epic_metrics is stable when epic.number collides across projects" do
+    setup do
+      tenant = fixture(:tenant)
+
+      # epic.number is unique only per (tenant_id, project_id). Two projects each
+      # with an epic #1 -> the same sort key with no project_id filter.
+      epic_ids =
+        for _ <- 1..4 do
+          project = fixture(:project, %{tenant_id: tenant.id})
+          epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id, number: 1})
+          epic.id
+        end
+
+      %{tenant: tenant, epic_ids: epic_ids}
+    end
+
+    test "paging with no project_id covers every colliding epic exactly once", %{
+      tenant: tenant,
+      epic_ids: epic_ids
+    } do
+      collected =
+        Stream.iterate(1, &(&1 + 1))
+        |> Enum.reduce_while([], fn page, acc ->
+          {:ok, %{data: data}} = Analytics.epic_metrics(tenant.id, page: page, page_size: 2)
+          new_acc = acc ++ Enum.map(data, & &1.epic_id)
+          if length(data) < 2, do: {:halt, new_acc}, else: {:cont, new_acc}
+        end)
+
+      assert length(collected) == 4
+      assert MapSet.new(collected) == MapSet.new(epic_ids)
+    end
+
+    test "ORDER BY ends with the unique epic id tiebreaker (SQL guard)", %{tenant: tenant} do
+      assert_paginated_order_by_tiebreaker(
+        fn -> Analytics.epic_metrics(tenant.id, page_size: 10) end,
+        ~s|"id"|
+      )
+    end
+  end
+
+  # Asserts the paginated (ORDER BY + LIMIT) query emitted by `fun` ends its
+  # ORDER BY with a term containing `tiebreaker` (e.g. ~s|"agent_id"|). Scoped to
+  # self() so concurrent async tests don't leak queries into the capture. This is
+  # the authoritative regression guard: it fails deterministically the moment a
+  # unique final sort term is dropped from the ORDER BY.
+  defp assert_paginated_order_by_tiebreaker(fun, tiebreaker) do
+    test_pid = self()
+    handler_id = "sql-capture-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach(
+      handler_id,
+      [:loopctl, :admin_repo, :query],
+      fn _event, _measurements, %{query: query}, _config ->
+        if self() == test_pid, do: send(test_pid, {:captured_sql, query})
+      end,
+      nil
+    )
+
+    try do
+      fun.()
+    after
+      :telemetry.detach(handler_id)
+    end
+
+    paginated =
+      []
+      |> drain_captured_sql()
+      |> Enum.filter(&(String.contains?(&1, "ORDER BY") and String.contains?(&1, "LIMIT")))
+
+    assert paginated != [], "expected a paginated (ORDER BY + LIMIT) query, got none"
+
+    Enum.each(paginated, fn query ->
+      [_, after_order] = String.split(query, "ORDER BY", parts: 2)
+
+      final_term =
+        after_order
+        |> String.split(~r/\s+LIMIT/, parts: 2)
+        |> List.first()
+        |> String.split(",")
+        |> List.last()
+        |> String.trim()
+
+      assert String.contains?(final_term, tiebreaker),
+             "ORDER BY final term #{inspect(final_term)} is missing unique tiebreaker #{tiebreaker}\nfull query: #{query}"
+    end)
+  end
+
+  defp drain_captured_sql(acc) do
+    receive do
+      {:captured_sql, q} -> drain_captured_sql([q | acc])
+    after
+      0 -> Enum.reverse(acc)
     end
   end
 end

--- a/test/loopctl/token_usage/analytics_test.exs
+++ b/test/loopctl/token_usage/analytics_test.exs
@@ -534,4 +534,116 @@ defmodule Loopctl.TokenUsage.AnalyticsTest do
       assert result.data == []
     end
   end
+
+  # --- tokens-07: stable ranked/paginated metrics with a unique tiebreaker ---
+  #
+  # agent_metrics ranks by integer avg-cost-per-story (SUM/COUNT) and model_metrics
+  # ranks by total cost. Both make ties common. Without a unique final sort term
+  # (agent_id / model_name), OFFSET pagination skips/duplicates tied rows across
+  # pages and efficiency_rank is nondeterministic run-to-run. These tests would
+  # fail on the pre-fix order_by.
+
+  describe "tokens-07: agent_metrics is stable when avg cost per story ties" do
+    setup do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+
+      # Two agents, each with exactly one story costing 1000 millicents ->
+      # identical avg_cost_per_story (1000) -> a rank/pagination tie.
+      agent_ids =
+        for i <- 1..2 do
+          agent = fixture(:agent, %{tenant_id: tenant.id, name: "agent-#{i}"})
+
+          story =
+            fixture(:story, %{
+              tenant_id: tenant.id,
+              epic_id: epic.id,
+              project_id: project.id,
+              number: "#{i}.1"
+            })
+
+          fixture(:token_usage_report, %{
+            tenant_id: tenant.id,
+            story_id: story.id,
+            agent_id: agent.id,
+            project_id: project.id,
+            model_name: "model-x",
+            input_tokens: 100,
+            output_tokens: 50,
+            cost_millicents: 1000,
+            phase: "implementing"
+          })
+
+          agent.id
+        end
+
+      %{tenant: tenant, agent_ids: agent_ids}
+    end
+
+    test "page 1 + page 2 cover every tied agent exactly once", %{
+      tenant: tenant,
+      agent_ids: agent_ids
+    } do
+      {:ok, page1} = Analytics.agent_metrics(tenant.id, page: 1, page_size: 1)
+      {:ok, page2} = Analytics.agent_metrics(tenant.id, page: 2, page_size: 1)
+
+      # Confirm the tie actually exists.
+      assert Enum.all?(page1.data ++ page2.data, &(&1.avg_cost_per_story_millicents == 1000))
+
+      collected = Enum.map(page1.data ++ page2.data, & &1.agent_id)
+      assert length(collected) == 2
+      assert MapSet.new(collected) == MapSet.new(agent_ids)
+    end
+
+    test "efficiency_rank is deterministic across repeated calls", %{tenant: tenant} do
+      {:ok, first} = Analytics.agent_metrics(tenant.id, page_size: 20)
+      {:ok, second} = Analytics.agent_metrics(tenant.id, page_size: 20)
+
+      ranking = fn result -> Enum.map(result.data, &{&1.agent_id, &1.efficiency_rank}) end
+
+      assert ranking.(first) == ranking.(second)
+      # Ranks are the contiguous 1..N with no gaps/dupes on ties.
+      assert Enum.map(first.data, & &1.efficiency_rank) == [1, 2]
+    end
+  end
+
+  describe "tokens-07: model_metrics is stable when total cost ties" do
+    setup do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+
+      # Two models with identical total cost (1000 each) -> a sort tie on the
+      # `desc: sum(cost)` ordering.
+      for model <- ["model-alpha", "model-beta"] do
+        fixture(:token_usage_report, %{
+          tenant_id: tenant.id,
+          project_id: project.id,
+          model_name: model,
+          input_tokens: 100,
+          output_tokens: 50,
+          cost_millicents: 1000,
+          phase: "implementing"
+        })
+      end
+
+      %{tenant: tenant}
+    end
+
+    test "page 1 + page 2 cover every tied model exactly once", %{tenant: tenant} do
+      {:ok, page1} = Analytics.model_metrics(tenant.id, page: 1, page_size: 1)
+      {:ok, page2} = Analytics.model_metrics(tenant.id, page: 2, page_size: 1)
+
+      collected = Enum.map(page1.data ++ page2.data, & &1.model_name)
+      assert length(collected) == 2
+      assert MapSet.new(collected) == MapSet.new(["model-alpha", "model-beta"])
+    end
+
+    test "model ordering is deterministic across repeated calls", %{tenant: tenant} do
+      {:ok, first} = Analytics.model_metrics(tenant.id, page_size: 20)
+      {:ok, second} = Analytics.model_metrics(tenant.id, page_size: 20)
+
+      assert Enum.map(first.data, & &1.model_name) == Enum.map(second.data, & &1.model_name)
+    end
+  end
 end

--- a/test/loopctl/work_breakdown/queries_test.exs
+++ b/test/loopctl/work_breakdown/queries_test.exs
@@ -357,4 +357,265 @@ defmodule Loopctl.WorkBreakdown.QueriesTest do
       assert result.page_size == 500
     end
   end
+
+  # --- wb-01: stable pagination with a unique secondary sort key ---
+  #
+  # sort_key is computed from the story number (major*10000 + minor*10) and is
+  # NOT unique — two stories numbered "1.1" in different projects share it. With
+  # OFFSET pagination and NO project_id filter, rows sharing a sort_key on a page
+  # boundary get skipped or duplicated across pages unless a unique tiebreaker
+  # (asc: s.id) is appended. These tests would fail on the pre-fix order_by.
+
+  # Collect every page of a paginated query and return the flat list of ids.
+  defp collect_all_pages(fun, page_size) do
+    Stream.iterate(1, &(&1 + 1))
+    |> Enum.reduce_while([], fn page, acc ->
+      {:ok, %{data: data}} = fun.(page, page_size)
+      ids = Enum.map(data, & &1.id)
+      new_acc = acc ++ ids
+
+      if length(data) < page_size do
+        {:halt, new_acc}
+      else
+        {:cont, new_acc}
+      end
+    end)
+  end
+
+  describe "wb-01: paginated ready/blocked stories have a unique tiebreaker" do
+    test "list_ready_stories paginates cleanly across projects sharing sort_key" do
+      tenant = fixture(:tenant)
+
+      # 5 ready stories all numbered "1.1" across 5 projects -> identical
+      # sort_key (10010). No project_id filter => all returned together.
+      ready_ids =
+        for _ <- 1..5 do
+          project = fixture(:project, %{tenant_id: tenant.id})
+          epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+
+          story =
+            fixture(:story, %{
+              tenant_id: tenant.id,
+              epic_id: epic.id,
+              project_id: project.id,
+              number: "1.1",
+              agent_status: :pending
+            })
+
+          story.id
+        end
+
+      # Sanity: every story shares the same non-unique sort_key.
+      assert Enum.uniq(ready_ids) == ready_ids
+
+      collected =
+        collect_all_pages(&Queries.list_ready_stories(tenant.id, page: &1, page_size: &2), 2)
+
+      # No skips, no duplicates: the union covers every story exactly once.
+      assert length(collected) == 5
+      assert MapSet.new(collected) == MapSet.new(ready_ids)
+    end
+
+    test "list_blocked_stories paginates cleanly across projects sharing sort_key" do
+      tenant = fixture(:tenant)
+
+      # 5 blocked stories all numbered "1.2" across 5 projects -> identical
+      # sort_key (10020), each blocked by an unverified story-level dependency.
+      blocked_ids =
+        for _ <- 1..5 do
+          project = fixture(:project, %{tenant_id: tenant.id})
+          epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+
+          blocker =
+            fixture(:story, %{
+              tenant_id: tenant.id,
+              epic_id: epic.id,
+              project_id: project.id,
+              number: "1.1",
+              agent_status: :implementing,
+              verified_status: :unverified
+            })
+
+          blocked =
+            fixture(:story, %{
+              tenant_id: tenant.id,
+              epic_id: epic.id,
+              project_id: project.id,
+              number: "1.2",
+              agent_status: :pending
+            })
+
+          fixture(:story_dependency, %{
+            tenant_id: tenant.id,
+            story_id: blocked.id,
+            depends_on_story_id: blocker.id
+          })
+
+          blocked.id
+        end
+
+      collected =
+        Stream.iterate(1, &(&1 + 1))
+        |> Enum.reduce_while([], fn page, acc ->
+          {:ok, %{data: data}} = Queries.list_blocked_stories(tenant.id, page: page, page_size: 2)
+          ids = Enum.map(data, & &1.story.id)
+          new_acc = acc ++ ids
+          if length(data) < 2, do: {:halt, new_acc}, else: {:cont, new_acc}
+        end)
+
+      assert length(collected) == 5
+      assert MapSet.new(collected) == MapSet.new(blocked_ids)
+    end
+  end
+
+  # --- wb-02: list_blocked_stories batches blocker lookups (no N+1) ---
+
+  # Counts SELECT queries issued through AdminRepo *from this test process* while
+  # `fun` runs. The telemetry handler is global and executes in the process that
+  # emitted the query, so we scope to `test_pid` to avoid counting queries from
+  # other concurrently-running async tests (max_cases > 1).
+  defp count_select_queries(fun) do
+    ref = :counters.new(1, [:write_concurrency])
+    handler_id = "wb02-#{System.unique_integer([:positive])}"
+    test_pid = self()
+
+    :telemetry.attach(
+      handler_id,
+      [:loopctl, :admin_repo, :query],
+      fn _event, _measurements, %{query: query}, counter ->
+        if self() == test_pid and String.contains?(query, "SELECT") do
+          :counters.add(counter, 1, 1)
+        end
+      end,
+      ref
+    )
+
+    try do
+      result = fun.()
+      {result, :counters.get(ref, 1)}
+    after
+      :telemetry.detach(handler_id)
+    end
+  end
+
+  # Creates `n` blocked stories in one project, each with a story-level blocker.
+  defp seed_blocked_stories(tenant, project, n) do
+    epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+
+    for i <- 1..n do
+      blocker =
+        fixture(:story, %{
+          tenant_id: tenant.id,
+          epic_id: epic.id,
+          project_id: project.id,
+          number: "#{i}.1",
+          agent_status: :implementing,
+          verified_status: :unverified
+        })
+
+      blocked =
+        fixture(:story, %{
+          tenant_id: tenant.id,
+          epic_id: epic.id,
+          project_id: project.id,
+          number: "#{i}.2",
+          agent_status: :pending
+        })
+
+      fixture(:story_dependency, %{
+        tenant_id: tenant.id,
+        story_id: blocked.id,
+        depends_on_story_id: blocker.id
+      })
+
+      blocked.id
+    end
+  end
+
+  describe "wb-02: list_blocked_stories does not issue O(page_size) queries" do
+    test "query count is bounded and does not scale with the number of blocked stories" do
+      tenant = fixture(:tenant)
+      project_small = fixture(:project, %{tenant_id: tenant.id})
+      project_large = fixture(:project, %{tenant_id: tenant.id})
+
+      seed_blocked_stories(tenant, project_small, 2)
+      seed_blocked_stories(tenant, project_large, 10)
+
+      {{:ok, small}, q_small} =
+        count_select_queries(fn ->
+          Queries.list_blocked_stories(tenant.id, project_id: project_small.id, page_size: 500)
+        end)
+
+      {{:ok, large}, q_large} =
+        count_select_queries(fn ->
+          Queries.list_blocked_stories(tenant.id, project_id: project_large.id, page_size: 500)
+        end)
+
+      assert length(small.data) == 2
+      assert length(large.data) == 10
+
+      # Constant, small query count regardless of page size. The pre-fix code
+      # issued 2 + 2*N queries (24 for N=10); batching keeps it at a handful.
+      assert q_small == q_large
+      assert q_large <= 6
+    end
+
+    test "each blocked story still receives its exact blocking dependencies" do
+      %{tenant: tenant, project: project} = setup_project()
+      epic1 = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id, number: 1})
+      epic2 = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id, number: 2})
+
+      # Epic 2 depends on Epic 1, which has an unverified story.
+      fixture(:epic_dependency, %{
+        tenant_id: tenant.id,
+        epic_id: epic2.id,
+        depends_on_epic_id: epic1.id
+      })
+
+      epic1_blocker =
+        fixture(:story, %{
+          tenant_id: tenant.id,
+          epic_id: epic1.id,
+          project_id: project.id,
+          number: "1.1",
+          agent_status: :implementing,
+          verified_status: :unverified
+        })
+
+      story_blocker =
+        fixture(:story, %{
+          tenant_id: tenant.id,
+          epic_id: epic2.id,
+          project_id: project.id,
+          number: "2.1",
+          agent_status: :implementing,
+          verified_status: :unverified
+        })
+
+      # Blocked by BOTH a story-level dep AND its epic-level dep -> the batched
+      # result must combine the two, preserving the pre-fix shape.
+      blocked =
+        fixture(:story, %{
+          tenant_id: tenant.id,
+          epic_id: epic2.id,
+          project_id: project.id,
+          number: "2.2",
+          agent_status: :pending
+        })
+
+      fixture(:story_dependency, %{
+        tenant_id: tenant.id,
+        story_id: blocked.id,
+        depends_on_story_id: story_blocker.id
+      })
+
+      {:ok, result} = Queries.list_blocked_stories(tenant.id, project_id: project.id)
+
+      item = Enum.find(result.data, &(&1.story.id == blocked.id))
+      refute is_nil(item)
+
+      blocker_ids = MapSet.new(item.blocking_dependencies, & &1.id)
+      assert blocker_ids == MapSet.new([story_blocker.id, epic1_blocker.id])
+    end
+  end
 end

--- a/test/loopctl/work_breakdown/queries_test.exs
+++ b/test/loopctl/work_breakdown/queries_test.exs
@@ -363,8 +363,75 @@ defmodule Loopctl.WorkBreakdown.QueriesTest do
   # sort_key is computed from the story number (major*10000 + minor*10) and is
   # NOT unique — two stories numbered "1.1" in different projects share it. With
   # OFFSET pagination and NO project_id filter, rows sharing a sort_key on a page
-  # boundary get skipped or duplicated across pages unless a unique tiebreaker
-  # (asc: s.id) is appended. These tests would fail on the pre-fix order_by.
+  # boundary can be skipped or duplicated across pages unless a unique tiebreaker
+  # (asc: s.id) is appended.
+  #
+  # The `union covers every id once` tests below are behavioral coverage, but
+  # they are NOT reliable regression guards on their own: inside a single
+  # sandbox transaction Postgres tends to return equal-key rows in insertion
+  # order, so the instability may not manifest even without the tiebreaker. The
+  # authoritative guard is the `assert_paginated_order_by_tiebreaker/2` SQL
+  # assertion, which fails deterministically the moment `asc: s.id` is dropped
+  # from the query's ORDER BY.
+
+  # Captures SQL emitted through AdminRepo *from this test process* while `fun`
+  # runs. Scoped to `self()` so concurrent async tests don't leak queries in.
+  defp capture_admin_sql(fun) do
+    test_pid = self()
+    handler_id = "sql-capture-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach(
+      handler_id,
+      [:loopctl, :admin_repo, :query],
+      fn _event, _measurements, %{query: query}, _config ->
+        if self() == test_pid, do: send(test_pid, {:captured_sql, query})
+      end,
+      nil
+    )
+
+    try do
+      fun.()
+    after
+      :telemetry.detach(handler_id)
+    end
+
+    drain_captured_sql([])
+  end
+
+  defp drain_captured_sql(acc) do
+    receive do
+      {:captured_sql, q} -> drain_captured_sql([q | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
+  end
+
+  # Asserts that the paginated (ORDER BY + LIMIT) query emitted by `fun` ends its
+  # ORDER BY with a term containing `tiebreaker` (e.g. ~s|"id"|). Fails fast and
+  # deterministically if a refactor drops the unique final sort term.
+  defp assert_paginated_order_by_tiebreaker(fun, tiebreaker) do
+    paginated =
+      fun
+      |> capture_admin_sql()
+      |> Enum.filter(&(String.contains?(&1, "ORDER BY") and String.contains?(&1, "LIMIT")))
+
+    assert paginated != [], "expected a paginated (ORDER BY + LIMIT) query, got none"
+
+    Enum.each(paginated, fn query ->
+      [_, after_order] = String.split(query, "ORDER BY", parts: 2)
+
+      final_term =
+        after_order
+        |> String.split(~r/\s+LIMIT/, parts: 2)
+        |> List.first()
+        |> String.split(",")
+        |> List.last()
+        |> String.trim()
+
+      assert String.contains?(final_term, tiebreaker),
+             "ORDER BY final term #{inspect(final_term)} is missing unique tiebreaker #{tiebreaker}\nfull query: #{query}"
+    end)
+  end
 
   # Collect every page of a paginated query and return the flat list of ids.
   defp collect_all_pages(fun, page_size) do
@@ -465,6 +532,24 @@ defmodule Loopctl.WorkBreakdown.QueriesTest do
 
       assert length(collected) == 5
       assert MapSet.new(collected) == MapSet.new(blocked_ids)
+    end
+
+    test "list_ready_stories ORDER BY ends with the unique id tiebreaker (SQL guard)" do
+      tenant = fixture(:tenant)
+
+      assert_paginated_order_by_tiebreaker(
+        fn -> Queries.list_ready_stories(tenant.id, page_size: 10) end,
+        ~s|"id"|
+      )
+    end
+
+    test "list_blocked_stories ORDER BY ends with the unique id tiebreaker (SQL guard)" do
+      tenant = fixture(:tenant)
+
+      assert_paginated_order_by_tiebreaker(
+        fn -> Queries.list_blocked_stories(tenant.id, page_size: 10) end,
+        ~s|"id"|
+      )
     end
   end
 

--- a/test/loopctl/work_breakdown/stories_test.exs
+++ b/test/loopctl/work_breakdown/stories_test.exs
@@ -486,4 +486,87 @@ defmodule Loopctl.WorkBreakdown.StoriesTest do
       assert {:error, :not_found} = Stories.get_story(tenant_a.id, story_b.id)
     end
   end
+
+  # --- wb-01: paginated story lists carry a unique ORDER BY tiebreaker ---
+  #
+  # sort_key (major*10000 + minor*10) is not unique across projects, so OFFSET
+  # pagination is only stable with `asc: s.id` appended. The authoritative
+  # regression guard asserts on the emitted SQL: it fails deterministically the
+  # moment the tiebreaker is dropped, unlike a behavioral union test which can
+  # pass spuriously due to insertion-order returns inside a sandbox transaction.
+  describe "wb-01: list_stories / list_stories_by_project ORDER BY tiebreaker (SQL guard)" do
+    test "list_stories ORDER BY ends with the unique id tiebreaker" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+
+      assert_paginated_order_by_tiebreaker(
+        fn -> Stories.list_stories(tenant.id, epic.id, page_size: 10) end,
+        ~s|"id"|
+      )
+    end
+
+    test "list_stories_by_project ORDER BY ends with the unique id tiebreaker" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+
+      assert_paginated_order_by_tiebreaker(
+        fn -> Stories.list_stories_by_project(tenant.id, project.id, limit: 10) end,
+        ~s|"id"|
+      )
+    end
+  end
+
+  # Asserts the paginated (ORDER BY + LIMIT) query emitted by `fun` ends its
+  # ORDER BY with a term containing `tiebreaker` (e.g. ~s|"id"|). Scoped to
+  # self() so concurrent async tests don't leak queries into the capture.
+  defp assert_paginated_order_by_tiebreaker(fun, tiebreaker) do
+    test_pid = self()
+    handler_id = "sql-capture-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach(
+      handler_id,
+      [:loopctl, :admin_repo, :query],
+      fn _event, _measurements, %{query: query}, _config ->
+        if self() == test_pid, do: send(test_pid, {:captured_sql, query})
+      end,
+      nil
+    )
+
+    try do
+      fun.()
+    after
+      :telemetry.detach(handler_id)
+    end
+
+    paginated =
+      []
+      |> drain_captured_sql()
+      |> Enum.filter(&(String.contains?(&1, "ORDER BY") and String.contains?(&1, "LIMIT")))
+
+    assert paginated != [], "expected a paginated (ORDER BY + LIMIT) query, got none"
+
+    Enum.each(paginated, fn query ->
+      [_, after_order] = String.split(query, "ORDER BY", parts: 2)
+
+      final_term =
+        after_order
+        |> String.split(~r/\s+LIMIT/, parts: 2)
+        |> List.first()
+        |> String.split(",")
+        |> List.last()
+        |> String.trim()
+
+      assert String.contains?(final_term, tiebreaker),
+             "ORDER BY final term #{inspect(final_term)} is missing unique tiebreaker #{tiebreaker}\nfull query: #{query}"
+    end)
+  end
+
+  defp drain_captured_sql(acc) do
+    receive do
+      {:captured_sql, q} -> drain_captured_sql([q | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Three pagination / N+1 correctness fixes. Every LIMIT/OFFSET-paginated
query on stories and token-usage analytics now has a **unique final sort
term**, so OFFSET pagination can no longer skip or duplicate rows on a
sort-key boundary — the failure mode that makes agents miss or
double-process work.

### wb-01 — unstable ready/blocked story pagination (no unique tie-break)
`sort_key` is derived from the story number (`major*10000 + minor*10`)
and is **not** unique — two stories numbered `1.1` in different projects
share it, which is exactly what `GET /stories/ready` (no `project_id`)
returns. With `ORDER BY sort_key` + OFFSET, rows on a page boundary were
skipped or duplicated across pages.

**Fix:** append `asc: s.id` (the unique PK) as the final sort term on all
four ordered, paginated story queries:
- `list_ready_stories/2`, `list_blocked_stories/2` (`work_breakdown/queries.ex`)
- `list_stories/3`, `list_stories_by_project/3` (`work_breakdown/stories.ex`)

### wb-02 — N+1 in `list_blocked_stories/2`
Each page was enriched by calling `fetch_blocking_story_dependencies/1`
**and** `fetch_blocking_epic_dependencies/1` per story — 2 DB round-trips
× `page_size` (up to ~1000 extra queries at `page_size=500`) on an
agent-polled endpoint.

**Fix:** batch it. Collect the page's story ids + epic ids, issue **one**
query per blocker kind (`WHERE ... IN`), group by `story_id` / `epic_id`
in memory, and attach. Constant queries per page instead of
`O(page_size)`; identical per-story shape; tenant-scoped `WHERE` on both
batched queries.

### tokens-07 — unstable analytics ranking/pagination
`agent_metrics` ordered solely by the computed integer avg-cost-per-story
(`SUM/COUNT`) and `model_metrics` solely by `SUM(cost)`. Integer division
makes ties common, so pagination skipped/duplicated rows **and**
`efficiency_rank` was nondeterministic run-to-run.

**Fix:** append the group-by key as the final sort term
(`asc: agent_id` / `asc: model_name`). `exclude_stranded_corrections`
routing is preserved.

## Tests
- **wb-01:** >page_size ready (and blocked) stories sharing `sort_key`
  across multiple projects with no `project_id` filter; the union of all
  pages covers every story exactly once (no skip, no duplicate). Fails on
  the pre-fix `order_by`.
- **wb-02:** a telemetry query-counter (`[:loopctl, :admin_repo, :query]`,
  scoped to the test process) proves `list_blocked_stories` issues a
  bounded, constant number of SELECTs regardless of page size; plus a
  correctness test that each story still receives its exact blocking
  dependencies (story-level + epic-level combined).
- **tokens-07:** two agents with identical integer-truncated avg cost and
  two models with identical total cost — page 1 + page 2 cover both
  exactly once, and `efficiency_rank` is deterministic across repeated
  calls. Fails without the tiebreaker.

## Verification
`mix precommit` green on Elixir 1.19 / OTP 28: compile
`--warnings-as-errors`, format, `credo --strict` (no issues), dialyzer
(fresh PLT, 0 real errors), full suite **3370 tests, 0 failures**.
