### PR TITLE
fix(workers): Decimal LazyScore boundary + atomic pending-enrollment cleanup

### DIFF
--- a/lib/loopctl/token_usage/lazy_score.ex
+++ b/lib/loopctl/token_usage/lazy_score.ex
@@ -32,6 +32,13 @@ defmodule Loopctl.TokenUsage.LazyScore do
   """
   @spec compute(map()) :: {float(), [String.t()]}
   def compute(metrics) do
+    # `estimated_hours` is `:decimal` in the Story schema, so a caller reading
+    # it schemaless (or straight off the struct) can hand us a %Decimal{}. The
+    # factor checks + small-story exemption below guard on `is_number/1`, which
+    # a %Decimal{} fails — silently disabling those signals. Normalize to a
+    # plain float once, up front, so every downstream check sees a number.
+    metrics = normalize_estimated_hours(metrics)
+
     factors = [
       check_token_ratio(metrics),
       check_tool_calls(metrics),
@@ -65,6 +72,19 @@ defmodule Loopctl.TokenUsage.LazyScore do
   @doc "Returns true if the score exceeds the re-review threshold."
   @spec flagged?(float()) :: boolean()
   def flagged?(score), do: score > @threshold
+
+  # Coerce a %Decimal{} `estimated_hours` to a float so the numeric guards in
+  # the factor checks and the small-story exemption engage. nil and existing
+  # numbers pass through untouched.
+  defp normalize_estimated_hours(metrics) do
+    case Map.get(metrics, :estimated_hours) do
+      %Decimal{} = decimal ->
+        Map.put(metrics, :estimated_hours, Decimal.to_float(decimal))
+
+      _ ->
+        metrics
+    end
+  end
 
   # --- Factor checks ---
 

--- a/lib/loopctl/workers/cot_sanity_monitor_worker.ex
+++ b/lib/loopctl/workers/cot_sanity_monitor_worker.ex
@@ -26,29 +26,9 @@ defmodule Loopctl.Workers.CotSanityMonitorWorker do
     # Scan stories completed in the last 24 hours
     cutoff = DateTime.add(DateTime.utc_now(), -86_400, :second)
 
-    recent_reports =
-      from(r in "token_usage_reports",
-        join: s in "stories",
-        on: r.story_id == s.id,
-        where: r.inserted_at > ^cutoff,
-        select: %{
-          story_id: r.story_id,
-          tenant_id: r.tenant_id,
-          total_tokens: fragment("? + ?", r.input_tokens, r.output_tokens),
-          tool_call_count: r.tool_call_count,
-          cot_length_tokens: r.cot_length_tokens,
-          tests_run_count: r.tests_run_count,
-          estimated_hours: s.estimated_hours
-        }
-      )
-      |> AdminRepo.all()
-
     flagged =
-      recent_reports
-      |> Enum.map(fn report ->
-        {score, reasons} = LazyScore.compute(report)
-        %{report: report, score: score, reasons: reasons, flagged: LazyScore.flagged?(score)}
-      end)
+      cutoff
+      |> score_recent_completions()
       |> Enum.filter(& &1.flagged)
 
     if flagged != [] do
@@ -56,5 +36,43 @@ defmodule Loopctl.Workers.CotSanityMonitorWorker do
     end
 
     :ok
+  end
+
+  @doc """
+  Loads token-usage reports since `cutoff`, joins the owning story, and scores
+  each with `LazyScore.compute/1`.
+
+  Returns a list of `%{report:, score:, reasons:, flagged:}` maps. Exposed for
+  testing so the score (which reflects the token-ratio factor + small-story
+  exemption) can be asserted directly, rather than only observed via logs.
+  """
+  @spec score_recent_completions(DateTime.t()) :: [
+          %{report: map(), score: float(), reasons: [String.t()], flagged: boolean()}
+        ]
+  def score_recent_completions(cutoff) do
+    from(r in "token_usage_reports",
+      join: s in "stories",
+      on: r.story_id == s.id,
+      where: r.inserted_at > ^cutoff,
+      select: %{
+        story_id: r.story_id,
+        tenant_id: r.tenant_id,
+        total_tokens: fragment("? + ?", r.input_tokens, r.output_tokens),
+        tool_call_count: r.tool_call_count,
+        cot_length_tokens: r.cot_length_tokens,
+        tests_run_count: r.tests_run_count,
+        # `stories` is queried schemaless (a string source), so Postgrex
+        # would otherwise decode the NUMERIC `estimated_hours` column as a
+        # %Decimal{} — which LazyScore's `is_number/1` guards silently
+        # reject, disabling the token-ratio factor + small-story exemption.
+        # Cast to float8 at the DB so a plain float reaches LazyScore.
+        estimated_hours: fragment("?::float8", s.estimated_hours)
+      }
+    )
+    |> AdminRepo.all()
+    |> Enum.map(fn report ->
+      {score, reasons} = LazyScore.compute(report)
+      %{report: report, score: score, reasons: reasons, flagged: LazyScore.flagged?(score)}
+    end)
   end
 end

--- a/lib/loopctl/workers/pending_enrollment_cleanup_worker.ex
+++ b/lib/loopctl/workers/pending_enrollment_cleanup_worker.ex
@@ -28,10 +28,14 @@ defmodule Loopctl.Workers.PendingEnrollmentCleanupWorker do
       DateTime.utc_now()
       |> DateTime.add(-Tenants.pending_enrollment_ttl_seconds(), :second)
 
-    # Fetch the abandoned tenants first so we can log their IDs,
-    # then delete. SELECT + DELETE is safe here because no other
-    # process transitions tenants OUT of :pending_enrollment except
-    # the signup Multi (which sets :active atomically).
+    # Fetch the abandoned tenants first purely so we can log their IDs.
+    # The SELECT is observability only — it is NOT a source of truth for
+    # the DELETE. A tenant whose WebAuthn activation Multi commits in the
+    # (sub-millisecond) window between this SELECT and the DELETE below
+    # would flip to `:active`; re-selecting by id alone would then destroy
+    # a legitimately-activated tenant. So `delete_abandoned/2` re-checks
+    # the FULL predicate (`:pending_enrollment` AND older than the cutoff)
+    # atomically at delete time — an activated tenant is excluded.
     abandoned =
       from(t in Tenant,
         where: t.status == :pending_enrollment,
@@ -43,15 +47,38 @@ defmodule Loopctl.Workers.PendingEnrollmentCleanupWorker do
     if abandoned != [] do
       ids = Enum.map(abandoned, & &1.id)
 
-      {deleted_count, _} =
-        from(t in Tenant, where: t.id in ^ids)
-        |> AdminRepo.delete_all()
+      {deleted_count, _} = delete_abandoned(ids, cutoff)
 
       Logger.warning(
-        "PendingEnrollmentCleanupWorker deleted #{deleted_count} abandoned signup tenants: #{inspect(ids)}"
+        "PendingEnrollmentCleanupWorker deleted #{deleted_count} abandoned " <>
+          "signup tenants (of #{length(ids)} candidates): #{inspect(ids)}"
       )
     end
 
     :ok
+  end
+
+  @doc """
+  Atomically deletes the candidate tenants that are STILL abandoned.
+
+  The DELETE re-checks the full abandonment predicate — `:pending_enrollment`
+  status AND `inserted_at` older than `cutoff` — bounded to the observed
+  `ids`. This closes the SELECT-then-DELETE race: a candidate that activated
+  (or was otherwise transitioned out of `:pending_enrollment`) after the
+  observing SELECT no longer matches and is left untouched. Deleting a still
+  pending tenant cascades to its `root_authenticators` / reauth challenges via
+  `on_delete: :delete_all`, which is the intended cleanup of an abandoned
+  ceremony.
+
+  Returns the `{count, nil}` tuple from `delete_all/1`.
+  """
+  @spec delete_abandoned([binary()], DateTime.t()) :: {non_neg_integer(), nil}
+  def delete_abandoned(ids, cutoff) do
+    from(t in Tenant,
+      where: t.id in ^ids,
+      where: t.status == :pending_enrollment,
+      where: t.inserted_at < ^cutoff
+    )
+    |> AdminRepo.delete_all()
   end
 end

--- a/test/loopctl/token_usage/lazy_score_test.exs
+++ b/test/loopctl/token_usage/lazy_score_test.exs
@@ -36,4 +36,61 @@ defmodule Loopctl.TokenUsage.LazyScoreTest do
     {score, _} = LazyScore.compute(%{})
     assert score == 0.0
   end
+
+  describe "compute/1 with a Decimal estimated_hours (worker-02)" do
+    # `estimated_hours` is `:decimal` in the Story schema. A caller that reads
+    # it schemaless (or straight off the struct) hands LazyScore a %Decimal{}.
+    # Pre-fix, the `is_number/1` guards silently rejected it, disabling the
+    # token-ratio factor and the small-story exemption. These tests assert the
+    # factors ENGAGE for a Decimal input, not the buggy pass-through.
+
+    test "token-ratio factor engages for a Decimal estimated_hours" do
+      # Only the token-ratio factor is active (the other three are nil), so the
+      # score equals that factor's weight exactly. Pre-fix this returned
+      # {0.0, []} because the Decimal disabled the sole active factor.
+      {score, reasons} =
+        LazyScore.compute(%{
+          total_tokens: 1_000,
+          estimated_hours: Decimal.new("8"),
+          tool_call_count: 100,
+          cot_length_tokens: 5_000,
+          tests_run_count: 25
+        })
+
+      assert score == 0.8
+      assert Enum.any?(reasons, &String.contains?(&1, "Token usage is"))
+    end
+
+    test "small-story exemption engages for a Decimal estimated_hours <= 1" do
+      # A sub-1-hour story is exempt — floor 0.0, no reasons — even though every
+      # raw factor screams "lazy". Pre-fix, the Decimal failed the exemption
+      # guard so this scored ~0.87 instead.
+      {score, reasons} =
+        LazyScore.compute(%{
+          total_tokens: 1_000,
+          estimated_hours: Decimal.new("0.5"),
+          tool_call_count: 0,
+          cot_length_tokens: 10,
+          tests_run_count: 0
+        })
+
+      assert score == 0.0
+      assert reasons == []
+    end
+
+    test "Decimal and float estimated_hours produce identical scores" do
+      metrics = fn hours ->
+        %{
+          total_tokens: 1_000,
+          estimated_hours: hours,
+          tool_call_count: 100,
+          cot_length_tokens: 5_000,
+          tests_run_count: 25
+        }
+      end
+
+      assert LazyScore.compute(metrics.(Decimal.new("8"))) ==
+               LazyScore.compute(metrics.(8.0))
+    end
+  end
 end

--- a/test/loopctl/workers/cot_sanity_monitor_worker_test.exs
+++ b/test/loopctl/workers/cot_sanity_monitor_worker_test.exs
@@ -1,0 +1,95 @@
+defmodule Loopctl.Workers.CotSanityMonitorWorkerTest do
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  import Loopctl.Fixtures
+
+  alias Loopctl.Workers.CotSanityMonitorWorker
+
+  # 24h scan window — reports are inserted "now" so they land inside it.
+  defp cutoff, do: DateTime.add(DateTime.utc_now(), -86_400, :second)
+
+  describe "perform/1" do
+    test "runs and returns :ok" do
+      assert :ok = CotSanityMonitorWorker.perform(%Oban.Job{})
+    end
+  end
+
+  describe "score_recent_completions/1 (worker-02: Decimal estimated_hours)" do
+    test "estimated_hours reaches LazyScore as a float, not a Decimal" do
+      tenant = fixture(:tenant)
+      story = fixture(:story, %{tenant_id: tenant.id, estimated_hours: Decimal.new("8")})
+
+      _report =
+        fixture(:token_usage_report, %{
+          tenant_id: tenant.id,
+          story_id: story.id,
+          input_tokens: 1_000,
+          output_tokens: 500,
+          tool_call_count: 100,
+          cot_length_tokens: 5_000,
+          tests_run_count: 25
+        })
+
+      # The sandbox transaction only sees this test's single report.
+      [entry] = CotSanityMonitorWorker.score_recent_completions(cutoff())
+
+      # The schemaless select casts NUMERIC -> float8, so Postgrex hands back a
+      # plain float rather than a %Decimal{}.
+      assert is_float(entry.report.estimated_hours)
+      assert entry.report.estimated_hours == 8.0
+    end
+
+    test "token-ratio factor engages for a story with a non-null estimated_hours" do
+      tenant = fixture(:tenant)
+      story = fixture(:story, %{tenant_id: tenant.id, estimated_hours: Decimal.new("8")})
+
+      # total_tokens = 1500, expected = 8h * 10k = 80k, ratio ~1.9% < 20%.
+      # The other three factors are deliberately non-suspicious (nil), so the
+      # score equals the token-ratio weight exactly. Pre-fix, the Decimal
+      # estimated_hours disabled this factor and the score collapsed to 0.0.
+      _report =
+        fixture(:token_usage_report, %{
+          tenant_id: tenant.id,
+          story_id: story.id,
+          input_tokens: 1_000,
+          output_tokens: 500,
+          tool_call_count: 100,
+          cot_length_tokens: 5_000,
+          tests_run_count: 25
+        })
+
+      [entry] = CotSanityMonitorWorker.score_recent_completions(cutoff())
+
+      assert entry.score == 0.8
+      assert entry.flagged
+      assert Enum.any?(entry.reasons, &String.contains?(&1, "Token usage is"))
+    end
+
+    test "small-story exemption engages for a story estimated at <= 1 hour" do
+      tenant = fixture(:tenant)
+      story = fixture(:story, %{tenant_id: tenant.id, estimated_hours: Decimal.new("0.5")})
+
+      # Every raw factor is suspicious (0 tool calls, tiny CoT, 0 tests), but a
+      # sub-1-hour story is exempt: floor 0.0, no reasons, not flagged. Pre-fix
+      # the Decimal skipped the exemption and this scored ~0.87 (flagged).
+      _report =
+        fixture(:token_usage_report, %{
+          tenant_id: tenant.id,
+          story_id: story.id,
+          input_tokens: 500,
+          output_tokens: 500,
+          tool_call_count: 0,
+          cot_length_tokens: 10,
+          tests_run_count: 0
+        })
+
+      [entry] = CotSanityMonitorWorker.score_recent_completions(cutoff())
+
+      assert entry.score == 0.0
+      assert entry.reasons == []
+      refute entry.flagged
+    end
+  end
+end

--- a/test/loopctl/workers/pending_enrollment_cleanup_worker_test.exs
+++ b/test/loopctl/workers/pending_enrollment_cleanup_worker_test.exs
@@ -1,0 +1,103 @@
+defmodule Loopctl.Workers.PendingEnrollmentCleanupWorkerTest do
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  import Ecto.Query
+  import Loopctl.Fixtures
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Tenants
+  alias Loopctl.Tenants.Tenant
+  alias Loopctl.Workers.PendingEnrollmentCleanupWorker
+
+  # A cutoff older than the TTL — any tenant we age past this is "abandoned".
+  defp cutoff,
+    do: DateTime.add(DateTime.utc_now(), -Tenants.pending_enrollment_ttl_seconds(), :second)
+
+  # Force a tenant's inserted_at into the past so it predates the TTL cutoff.
+  defp age_tenant(tenant, seconds_ago) do
+    old = DateTime.add(DateTime.utc_now(), -seconds_ago, :second)
+
+    {1, _} =
+      from(t in Tenant, where: t.id == ^tenant.id)
+      |> AdminRepo.update_all(set: [inserted_at: old])
+
+    tenant
+  end
+
+  # An abandoned ceremony: pending_enrollment and older than the TTL.
+  defp abandoned_tenant do
+    fixture(:tenant, %{status: :pending_enrollment})
+    |> age_tenant(Tenants.pending_enrollment_ttl_seconds() + 300)
+  end
+
+  describe "perform/1" do
+    test "deletes abandoned pending-enrollment tenants past the TTL" do
+      tenant = abandoned_tenant()
+
+      assert :ok = PendingEnrollmentCleanupWorker.perform(%Oban.Job{})
+
+      assert AdminRepo.get(Tenant, tenant.id) == nil
+    end
+
+    test "keeps pending-enrollment tenants still inside the TTL" do
+      # inserted_at defaults to "now", so it is newer than the cutoff.
+      recent = fixture(:tenant, %{status: :pending_enrollment})
+
+      assert :ok = PendingEnrollmentCleanupWorker.perform(%Oban.Job{})
+
+      assert AdminRepo.get(Tenant, recent.id) != nil
+    end
+
+    test "keeps active tenants regardless of age" do
+      active_old =
+        fixture(:tenant, %{status: :active})
+        |> age_tenant(Tenants.pending_enrollment_ttl_seconds() + 300)
+
+      assert :ok = PendingEnrollmentCleanupWorker.perform(%Oban.Job{})
+
+      assert AdminRepo.get(Tenant, active_old.id) != nil
+    end
+  end
+
+  describe "delete_abandoned/2 (worker-03: SELECT-then-DELETE race)" do
+    test "deletes a candidate that is still pending and old" do
+      tenant = abandoned_tenant()
+
+      assert {1, _} = PendingEnrollmentCleanupWorker.delete_abandoned([tenant.id], cutoff())
+      assert AdminRepo.get(Tenant, tenant.id) == nil
+    end
+
+    test "does NOT delete a candidate that activated after being observed" do
+      # The tenant was :pending_enrollment + old when the observing SELECT
+      # captured its id. Simulate the race: its WebAuthn activation Multi
+      # commits in the window BEFORE the DELETE fires.
+      tenant = abandoned_tenant()
+
+      activated =
+        tenant
+        |> Tenant.activate_after_enrollment_changeset()
+        |> AdminRepo.update!()
+
+      assert activated.status == :active
+
+      # The guarded DELETE re-checks status + cutoff atomically, so the now
+      # active tenant is excluded. The pre-fix id-only DELETE would destroy it.
+      assert {0, _} = PendingEnrollmentCleanupWorker.delete_abandoned([tenant.id], cutoff())
+
+      survivor = AdminRepo.get(Tenant, tenant.id)
+      assert survivor != nil
+      assert survivor.status == :active
+    end
+
+    test "does NOT delete a candidate that is pending but no longer old" do
+      # e.g. clock skew / a candidate that only just crossed into the window;
+      # the DELETE re-checks the cutoff so a fresh tenant is left alone.
+      fresh = fixture(:tenant, %{status: :pending_enrollment})
+
+      assert {0, _} = PendingEnrollmentCleanupWorker.delete_abandoned([fresh.id], cutoff())
+      assert AdminRepo.get(Tenant, fresh.id) != nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Two independent worker-correctness bugs, each a weakened chain-of-custody / data-loss risk.

### worker-02 (wrong-calc) — Decimal `estimated_hours` silently disabled LazyScore factors

`CotSanityMonitorWorker` reads `stories` via a **schemaless** query (`from(s in "stories")`). With no Ecto schema to type the source, Postgrex decodes the NUMERIC `estimated_hours` column as a `%Decimal{}`. `LazyScore.compute/1` guards its **token-ratio factor** and **small-story exemption** on `is_number/1`, which a `%Decimal{}` fails — so both signals were **silently disabled** on every report whose story had a non-null estimate, yielding a weaker lazy-bastard custody score (L5).

**Fix (defense in depth):**
- Cast `estimated_hours` to `float8` in the schemaless `select` (`fragment("?::float8", s.estimated_hours)`) so Postgrex returns a plain float.
- Normalize at the `LazyScore` boundary too: `compute/1` coerces a `%Decimal{}` estimate to a float up front. `estimated_hours` is `:decimal` on the `Story` schema, so any caller (not just this worker) is now safe passing a Decimal.
- Extracted `score_recent_completions/1` so the scored output is directly assertable.

### worker-03 (race) — non-atomic SELECT-then-DELETE could delete an activated tenant

`PendingEnrollmentCleanupWorker` SELECTed abandoned tenant ids (`:pending_enrollment` AND older than the TTL) then DELETEd by **id only**, dropping the status/cutoff predicate. A tenant whose WebAuthn activation `Multi` commits in the sub-millisecond window between the SELECT and the DELETE would be **deleted anyway** — destroying a legitimately-activated tenant (and cascading to its `root_authenticators` / reauth challenges).

**Fix:**
- The DELETE (`delete_abandoned/2`) now re-checks the **full predicate** atomically — `:pending_enrollment` AND `inserted_at < cutoff`, bounded to the observed ids — so a candidate that activated after being observed is excluded.
- The SELECT is kept purely for id logging (observability). Deleting a still-abandoned ceremony still cascades to its authenticator rows, unchanged.

## Tests

- `LazyScore.compute/1` Decimal-input unit tests: token-ratio factor engages, small-story exemption engages, and Decimal vs float produce identical scores.
- `CotSanityMonitorWorker.score_recent_completions/1`: `estimated_hours` arrives as a float (not `%Decimal{}`); token-ratio factor engages for a non-null estimate; small-story exemption engages — all via the real DB query.
- `PendingEnrollmentCleanupWorker`: perform deletes abandoned/old, keeps recent-pending and active; `delete_abandoned/2` deletes a still-pending old candidate, **leaves a candidate that activated after being observed** (the race), and leaves a too-fresh candidate.

## Verification

- `mix compile --warnings-as-errors` clean
- `mix format --check-formatted` clean
- `mix credo --strict` — no issues
- `mix dialyzer` (fresh PLT) — passed, 0 real errors
- `mix test` — **3391 tests, 0 failures** (40 excluded). One earlier single failure was a known env flake, confirmed by repeated clean re-runs.
