### PR TITLE
fix(security): RLS on audit_pending_violations + two chain-of-custody invariants

### DIFF
--- a/lib/loopctl/artifacts/review_record.ex
+++ b/lib/loopctl/artifacts/review_record.ex
@@ -16,6 +16,13 @@ defmodule Loopctl.Artifacts.ReviewRecord do
   - `fixes_count` -- number of issues that were fixed
   - `summary` -- human-readable summary of review findings
   - `completed_at` -- when the review pipeline completed (must be AFTER reported_done_at)
+  - `reviewed_report_at` -- snapshot of the story's `reported_done_at` at the time
+    this review was created. Binds the review to the specific report generation it
+    reviewed (chain-of-custody INVARIANT 2). `verify_story/4` / `bulk_verify`
+    require this to equal the story's CURRENT `reported_done_at`, so a review of a
+    superseded report no longer qualifies. Set programmatically, never cast.
+    Nullable: legacy pre-migration records are `NULL` and grandfathered as
+    "matches".
   """
 
   use Loopctl.Schema
@@ -34,6 +41,7 @@ defmodule Loopctl.Artifacts.ReviewRecord do
              :disproved_count,
              :summary,
              :completed_at,
+             :reviewed_report_at,
              :inserted_at,
              :updated_at
            ]}
@@ -50,6 +58,10 @@ defmodule Loopctl.Artifacts.ReviewRecord do
     field :summary, :string
     field :completed_at, :utc_datetime_usec
 
+    # Snapshot of story.reported_done_at at review creation (INVARIANT 2).
+    # Set programmatically in Loopctl.Progress.record_review/4 — NOT in cast.
+    field :reviewed_report_at, :utc_datetime_usec
+
     timestamps()
   end
 
@@ -62,10 +74,10 @@ defmodule Loopctl.Artifacts.ReviewRecord do
   Validates that `completed_at` is not more than 60 seconds in the future (a
   clock-skew allowance), so a client cannot forward-date a review to satisfy the
   verify-time review-record check (`Loopctl.Progress.ensure_review_conducted/3`)
-  for a report that had not yet happened. NOTE: this bounds, but does not fully
-  eliminate, the stale-review-vs-re-report window — the structural closure
-  (binding a review record to the specific report generation it covers) is
-  tracked with the chain-of-custody invariant work.
+  for a report that had not yet happened. This `completed_at` skew check remains
+  as a SECONDARY guard; the primary structural closure of the
+  stale-review-vs-re-report window is `reviewed_report_at` (INVARIANT 2), which
+  binds each review to the exact report generation it covers.
   """
   @spec create_changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
   def create_changeset(record \\ %__MODULE__{}, attrs) do

--- a/lib/loopctl/bulk_operations.ex
+++ b/lib/loopctl/bulk_operations.ex
@@ -811,6 +811,11 @@ defmodule Loopctl.BulkOperations do
   defp format_reason(:self_verify_blocked),
     do: "cannot verify your own implemented work (chain-of-custody)"
 
+  defp format_reason(:missing_assigned_agent),
+    do:
+      "story is reported_done with no assigned agent or dispatch lineage; " <>
+        "its custody chain is broken and it cannot be verified"
+
   defp format_reason(:review_not_conducted),
     do: "no independent review record exists for this story since it was reported done"
 

--- a/lib/loopctl/bulk_operations.ex
+++ b/lib/loopctl/bulk_operations.ex
@@ -515,7 +515,10 @@ defmodule Loopctl.BulkOperations do
     story
     |> Ecto.Changeset.change(%{
       agent_status: :reported_done,
-      reported_done_at: now,
+      # Preserve an existing reported_done_at (e.g. a story imported with
+      # initial_agent_status="reported_done" carries pre-loopctl-done provenance);
+      # only stamp `now` when there is none. Matches backfill_story's behavior.
+      reported_done_at: story.reported_done_at || now,
       verified_status: :verified,
       verified_at: now,
       rejected_at: nil,
@@ -813,14 +816,23 @@ defmodule Loopctl.BulkOperations do
 
   defp format_reason(:missing_assigned_agent),
     do:
-      "story is reported_done with no assigned agent or dispatch lineage; " <>
-        "its custody chain is broken and it cannot be verified"
+      "story is reported_done with no assigned agent or dispatch lineage; its " <>
+        "custody chain is broken, so it cannot be verified. If this is " <>
+        "never-dispatched / pre-existing work, use mark-complete (bulk) or backfill " <>
+        "instead, which record it as done without an agent"
 
   defp format_reason(:review_not_conducted),
     do: "no independent review record exists for this story since it was reported done"
 
   defp format_reason(:story_has_dispatch_lineage),
-    do: "story has dispatch lineage; use the normal verify flow, not mark-complete"
+    do:
+      "story has dispatch lineage (an assigned agent or dispatch id); use the normal " <>
+        "report → review → verify flow, not mark-complete"
+
+  defp format_reason(:story_in_progress),
+    do:
+      "story is mid-lifecycle (being worked) with no dispatch lineage yet; it is not " <>
+        "pre-existing done work, so mark-complete does not apply"
 
   defp format_reason(:already_verified), do: "story is already verified"
 

--- a/lib/loopctl/progress.ex
+++ b/lib/loopctl/progress.ex
@@ -1051,13 +1051,20 @@ defmodule Loopctl.Progress do
   @doc """
   Structural custody guard for the bulk mark-complete (backfill) path.
 
-  Returns `:ok` only when `story` never entered the dispatch lifecycle, matching
-  `backfill_story/4`. Prevents mark-complete from being used to self-verify
-  dispatched work.
+  Returns `:ok` only when `story` never entered the dispatch lifecycle (no
+  dispatch markers) — including a never-dispatched story already at
+  `agent_status: :reported_done` (e.g. imported with
+  `initial_agent_status: "reported_done"`), for which mark-complete is the
+  correct remediation. Matches `backfill_story/4`. Prevents mark-complete from
+  being used to self-verify dispatched work.
   """
   @spec ensure_mark_complete_allowed(Story.t()) ::
           :ok
-          | {:error, :already_verified | :story_rejected | :story_has_dispatch_lineage}
+          | {:error,
+             :already_verified
+             | :story_rejected
+             | :story_has_dispatch_lineage
+             | :story_in_progress}
   def ensure_mark_complete_allowed(story) do
     case guard_backfillable(story) do
       {:ok, _} -> :ok
@@ -1095,7 +1102,11 @@ defmodule Loopctl.Progress do
     * `{:error, :reason_required}` — `reason` missing or blank
     * `{:error, :already_verified}` — story already `:verified` (idempotent no-op)
     * `{:error, :story_rejected}` — story is `:rejected`; investigate instead of papering over
-    * `{:error, :story_has_dispatch_lineage}` — story has an `assigned_agent_id`; use the normal verify flow
+    * `{:error, :story_has_dispatch_lineage}` — story has a dispatch marker
+      (`assigned_agent_id`, `implementer_dispatch_id`, or `verifier_dispatch_id`);
+      use the normal report/review/verify flow
+    * `{:error, :story_in_progress}` — story is mid-lifecycle (e.g. `:contracted`)
+      with no dispatch lineage yet; it is being worked, not pre-existing done work
     * `{:error, %Ecto.Changeset{}}` — persistence error surfaced from Multi step
   """
   @spec backfill_story(Ecto.UUID.t(), Ecto.UUID.t(), map(), keyword()) ::
@@ -1110,6 +1121,7 @@ defmodule Loopctl.Progress do
              | :already_verified
              | :story_rejected
              | :story_has_dispatch_lineage
+             | :story_in_progress
              | Ecto.Changeset.t()}
   def backfill_story(tenant_id, story_id, params, opts \\ []) do
     actor_id = Keyword.get(opts, :actor_id)
@@ -1265,22 +1277,29 @@ defmodule Loopctl.Progress do
 
   defp handle_backfill_success(story), do: {:ok, story}
 
-  # Backfill is ONLY for stories that never entered loopctl's dispatch lifecycle.
-  # The refusal conditions are:
+  # Backfill / bulk mark-complete is ONLY for stories that never entered loopctl's
+  # dispatch lifecycle. "Never dispatched" is defined by the ABSENCE of dispatch
+  # markers (assigned_agent_id, implementer_dispatch_id, verifier_dispatch_id) —
+  # NOT by agent_status == :pending. This matters because a story imported with
+  # `initial_agent_status: "reported_done"` (or a prior mark-complete) is
+  # never-dispatched work sitting at agent_status == :reported_done with NULL
+  # dispatch markers; backfill/mark-complete must remain its correct remediation
+  # (it sets verified_status without needing an agent, preserving reported_done_at
+  # provenance). Without this, INVARIANT 1's custody-orphaned guard would strand
+  # such a story — verify/review fail closed AND backfill wrongly refused.
   #
-  #   - verified (nothing to do)
-  #   - rejected (investigate, don't paper over)
-  #   - agent_status is past :pending (contract/claim/start/report all indicate
-  #     an agent engaged with this story)
-  #   - any dispatch lineage field is set (implementer_dispatch_id,
-  #     verifier_dispatch_id). These are the "ever-dispatched" markers that
-  #     force_unclaim_story does NOT clear — relying on assigned_agent_id alone
-  #     is bypassable via force_unclaim → backfill.
+  # Refusal conditions, in order:
+  #   - verified (nothing to do) / rejected (investigate, don't paper over)
+  #   - ANY dispatch marker set — genuine dispatch lineage; use the normal
+  #     report → review → verify flow. These are the "ever-dispatched" markers
+  #     force_unclaim_story does NOT clear, so relying on assigned_agent_id alone
+  #     is bypassable; all three are checked.
+  #   - otherwise, only :pending or :reported_done (never-dispatched) are
+  #     backfillable; a story mid-lifecycle (:contracted with no dispatch yet) is
+  #     being worked, not pre-existing done work — an ACCURATE reason, not a false
+  #     "dispatch lineage" claim.
   defp guard_backfillable(%{verified_status: :verified}), do: {:error, :already_verified}
   defp guard_backfillable(%{verified_status: :rejected}), do: {:error, :story_rejected}
-
-  defp guard_backfillable(%{agent_status: status}) when status != :pending,
-    do: {:error, :story_has_dispatch_lineage}
 
   defp guard_backfillable(%{assigned_agent_id: agent_id}) when not is_nil(agent_id),
     do: {:error, :story_has_dispatch_lineage}
@@ -1291,7 +1310,10 @@ defmodule Loopctl.Progress do
   defp guard_backfillable(%{verifier_dispatch_id: id}) when not is_nil(id),
     do: {:error, :story_has_dispatch_lineage}
 
-  defp guard_backfillable(_story), do: {:ok, :ok}
+  # No dispatch markers from here down.
+  defp guard_backfillable(%{agent_status: :pending}), do: {:ok, :ok}
+  defp guard_backfillable(%{agent_status: :reported_done}), do: {:ok, :ok}
+  defp guard_backfillable(_story), do: {:error, :story_in_progress}
 
   defp apply_backfill_status(story, reason, evidence_url, pr_number) do
     now = DateTime.utc_now()
@@ -1602,6 +1624,7 @@ defmodule Loopctl.Progress do
       # this is the defense-in-depth backstop. Backfilled stories are already
       # verified and never reach here.)
       custody_orphaned?(story) ->
+        log_custody_orphaned(story, orchestrator_agent_id, "verify")
         {:error, :missing_assigned_agent}
 
       # Lineage-based check (preferred): compare dispatch lineage paths
@@ -1646,6 +1669,20 @@ defmodule Loopctl.Progress do
        do: true
 
   defp custody_orphaned?(_story), do: false
+
+  # Observability for INVARIANT 1: emit a warning (no tenant halt, unlike the
+  # byzantine self_verify path) whenever the custody-orphaned guard fires, so
+  # operators can distinguish a broken import batch (recoverable via
+  # backfill/mark-complete) from a probing attempt. Includes story + tenant +
+  # calling identity.
+  defp log_custody_orphaned(%Story{} = story, caller_agent_id, operation) do
+    Logger.warning(
+      "custody_orphaned_blocked: #{operation} blocked — reported_done story has no " <>
+        "assigned agent or dispatch lineage (custody chain broken) " <>
+        "story_id=#{story.id} tenant_id=#{story.tenant_id} " <>
+        "caller_agent_id=#{inspect(caller_agent_id)}"
+    )
+  end
 
   defp validate_verifiable(story) do
     cond do
@@ -2098,6 +2135,7 @@ defmodule Loopctl.Progress do
       # of reviewer identity (including nil human reviewers). Backstops the DB
       # CHECK stories_reported_done_requires_agent.
       custody_orphaned?(story) ->
+        log_custody_orphaned(story, reviewer_agent_id, "review")
         {:error, :missing_assigned_agent}
 
       # nil reviewer_agent_id: this is a human operator (user-role key with no

--- a/lib/loopctl/progress.ex
+++ b/lib/loopctl/progress.ex
@@ -833,7 +833,12 @@ defmodule Loopctl.Progress do
         %ReviewRecord{
           tenant_id: tenant_id,
           story_id: story_id,
-          reviewer_agent_id: reviewer_agent_id
+          reviewer_agent_id: reviewer_agent_id,
+          # INVARIANT 2: bind this review to the report generation it reviewed by
+          # snapshotting the story's CURRENT reported_done_at. Programmatic (never
+          # cast from client input). verify_story/4 + bulk_verify later require
+          # this to match the story's reported_done_at at verify time.
+          reviewed_report_at: story.reported_done_at
         }
         |> ReviewRecord.create_changeset(attrs)
 
@@ -1021,7 +1026,7 @@ defmodule Loopctl.Progress do
   the single-story `verify_story/4` path — otherwise bulk verify is a chain-of-custody bypass.
   """
   @spec ensure_verify_allowed(Story.t(), Ecto.UUID.t() | nil) ::
-          :ok | {:error, :self_verify_blocked}
+          :ok | {:error, :self_verify_blocked | :missing_assigned_agent}
   def ensure_verify_allowed(story, orchestrator_agent_id) do
     case validate_not_self_verify(story, orchestrator_agent_id) do
       {:ok, _} -> :ok
@@ -1588,6 +1593,17 @@ defmodule Loopctl.Progress do
   defp validate_not_self_verify(story, orchestrator_agent_id) do
     # US-26.2.2 AC-2: use lineage comparison when dispatch IDs are available
     cond do
+      # INVARIANT 1 (fail closed / §2.2 "nil is never permissive"): a story that
+      # is reported_done but not yet verified, with NO assigned agent and NO
+      # dispatch lineage, has no implementer to compare the verifier against — the
+      # checks below would pass VACUOUSLY (a non-nil verifier is never == a nil
+      # implementer). Reject rather than allow a custody-orphaned verify. (The DB
+      # CHECK stories_reported_done_requires_agent makes this state unreachable;
+      # this is the defense-in-depth backstop. Backfilled stories are already
+      # verified and never reach here.)
+      custody_orphaned?(story) ->
+        {:error, :missing_assigned_agent}
+
       # Lineage-based check (preferred): compare dispatch lineage paths
       not is_nil(story.implementer_dispatch_id) and not is_nil(story.verifier_dispatch_id) ->
         impl = get_dispatch_lineage(story.tenant_id, story.implementer_dispatch_id)
@@ -1614,6 +1630,22 @@ defmodule Loopctl.Progress do
       {:error, _} -> []
     end
   end
+
+  # INVARIANT 1: a story is "custody orphaned" when it is reported_done and still
+  # unverified but carries no provenance for who did the work — no assigned agent
+  # and no implementer dispatch lineage. Such a story cannot be legitimately
+  # verified or reviewed (there is no implementer to separate the verifier/reviewer
+  # from), so the self-* guards fail closed on it. The DB CHECK constraint makes
+  # this state unreachable in practice; this predicate is the code-level backstop.
+  defp custody_orphaned?(%Story{
+         agent_status: :reported_done,
+         verified_status: :unverified,
+         assigned_agent_id: nil,
+         implementer_dispatch_id: nil
+       }),
+       do: true
+
+  defp custody_orphaned?(_story), do: false
 
   defp validate_verifiable(story) do
     cond do
@@ -1651,7 +1683,20 @@ defmodule Loopctl.Progress do
 
     query =
       if reported_done_at do
-        where(query, [r], r.completed_at > ^reported_done_at)
+        # Primary structural guard (INVARIANT 2): the review must have reviewed
+        # THIS report generation — reviewed_report_at is snapshotted from
+        # reported_done_at at review-creation time. If the story was re-reported
+        # since, the snapshot no longer matches and the review no longer qualifies
+        # (a fresh review of the new generation is required). Legacy pre-migration
+        # reviews have reviewed_report_at IS NULL and are grandfathered as matching
+        # (see migration 20260702130200). Secondary guard (kept): the review must
+        # have completed after the report (completed_at > reported_done_at).
+        query
+        |> where(
+          [r],
+          is_nil(r.reviewed_report_at) or r.reviewed_report_at == ^reported_done_at
+        )
+        |> where([r], r.completed_at > ^reported_done_at)
       else
         query
       end
@@ -2045,15 +2090,25 @@ defmodule Loopctl.Progress do
     end
   end
 
-  # nil reviewer_agent_id: this is a human operator (user-role key with no agent).
-  # Humans are structurally different from the assigned implementing agent, so
-  # nil cannot equal any agent_id — pass through. The controller enforces that
-  # agent/orchestrator-role keys must provide a real reviewer_agent_id.
-  defp validate_not_self_review(_story, nil), do: :ok
-
   defp validate_not_self_review(story, reviewer_agent_id) do
-    # US-26.2.2 AC-2: use lineage when available, fallback to agent_id
     cond do
+      # INVARIANT 1 (fail closed): reviewing a custody-orphaned reported_done story
+      # is illegitimate — there is no known implementer, so the reviewer cannot be
+      # proven distinct and the check below would pass vacuously. Fires regardless
+      # of reviewer identity (including nil human reviewers). Backstops the DB
+      # CHECK stories_reported_done_requires_agent.
+      custody_orphaned?(story) ->
+        {:error, :missing_assigned_agent}
+
+      # nil reviewer_agent_id: this is a human operator (user-role key with no
+      # agent). Humans are structurally different from the assigned implementing
+      # agent, so nil cannot equal any agent_id — pass through. The controller
+      # enforces that agent/orchestrator-role keys must provide a real
+      # reviewer_agent_id.
+      is_nil(reviewer_agent_id) ->
+        :ok
+
+      # US-26.2.2 AC-2: use lineage when available, fallback to agent_id
       not is_nil(story.implementer_dispatch_id) ->
         # Same fallback pattern as self_report — full lineage comparison
         # will be wired when reviewer dispatch tracking is added

--- a/lib/loopctl_web/controllers/review_record_controller.ex
+++ b/lib/loopctl_web/controllers/review_record_controller.ex
@@ -129,6 +129,9 @@ defmodule LoopctlWeb.ReviewRecordController do
       {:error, :self_review_blocked} ->
         {:error, :self_review_blocked}
 
+      {:error, :missing_assigned_agent} ->
+        {:error, :missing_assigned_agent}
+
       {:error, %Ecto.Changeset{} = changeset} ->
         {:error, changeset}
     end

--- a/lib/loopctl_web/controllers/story_verification_controller.ex
+++ b/lib/loopctl_web/controllers/story_verification_controller.ex
@@ -305,6 +305,9 @@ defmodule LoopctlWeb.StoryVerificationController do
         {:error, :self_verify_blocked} ->
           {:error, :self_verify_blocked}
 
+        {:error, :missing_assigned_agent} ->
+          {:error, :missing_assigned_agent}
+
         {:error, :reason_required} ->
           {:error, :unprocessable_entity, "reason is required and cannot be blank"}
 

--- a/lib/loopctl_web/controllers/story_verification_controller.ex
+++ b/lib/loopctl_web/controllers/story_verification_controller.ex
@@ -279,10 +279,16 @@ defmodule LoopctlWeb.StoryVerificationController do
   end
 
   defp backfill_error_message(:story_has_dispatch_lineage) do
-    "Story has loopctl dispatch lineage (non-pending agent_status, assigned_agent_id, " <>
-      "implementer_dispatch_id, or verifier_dispatch_id is set). " <>
+    "Story has loopctl dispatch lineage (assigned_agent_id, implementer_dispatch_id, " <>
+      "or verifier_dispatch_id is set). " <>
       "Backfill is only for work completed OUTSIDE the loopctl dispatch lifecycle. " <>
       "Use the normal report_story → review_complete → verify_story flow instead."
+  end
+
+  defp backfill_error_message(:story_in_progress) do
+    "Story is mid-lifecycle (e.g. contracted) with no dispatch lineage yet — it is " <>
+      "being worked, not pre-existing done work. Let the report → review → verify " <>
+      "flow run, or force_unclaim it back to pending first if it was abandoned."
   end
 
   @doc """

--- a/lib/loopctl_web/fallback_controller.ex
+++ b/lib/loopctl_web/fallback_controller.ex
@@ -17,6 +17,7 @@ defmodule LoopctlWeb.FallbackController do
   - `{:error, :self_verify_blocked}` -> 409 (same agent implemented and tries to verify)
   - `{:error, :self_report_blocked}` -> 409 (implementer tries to report their own work)
   - `{:error, :self_review_blocked}` -> 409 (implementer tries to review their own work)
+  - `{:error, :missing_assigned_agent}` -> 409 (reported_done story has no assigned agent/dispatch lineage; custody chain broken)
   - `{:error, :rate_limited}` -> 429 with retry_after_seconds from header
   - `{:error, %Ecto.Changeset{}}` -> 422 with field-level details
   - `{:error, :bad_request, message}` -> 400 with custom message

--- a/lib/loopctl_web/fallback_controller.ex
+++ b/lib/loopctl_web/fallback_controller.ex
@@ -144,6 +144,28 @@ defmodule LoopctlWeb.FallbackController do
     })
   end
 
+  def call(conn, {:error, :missing_assigned_agent}) do
+    # INVARIANT 1: verify/review attempted on a custody-orphaned reported_done
+    # story (no assigned agent, no dispatch lineage). This is a data-integrity /
+    # custody-chain violation, NOT a byzantine self-verify attempt, so we do NOT
+    # halt the tenant — we return a clear 409 so the caller re-establishes
+    # provenance (the DB CHECK stories_reported_done_requires_agent makes this
+    # unreachable for well-formed data).
+    conn
+    |> put_status(:conflict)
+    |> json(%{
+      error: %{
+        status: 409,
+        code: "missing_assigned_agent",
+        message:
+          "Story is reported_done but has no assigned agent or dispatch lineage. " <>
+            "Its custody chain is broken, so it cannot be verified or reviewed. " <>
+            "Re-establish provenance (claim/report or backfill) before proceeding.",
+        remediation: %{learn_more: "https://loopctl.com/wiki/chain-of-custody"}
+      }
+    })
+  end
+
   def call(conn, {:error, :self_report_blocked}) do
     halt_tenant_on_violation(conn, "self_report_blocked")
 

--- a/priv/repo/migrations/20260702130000_enable_rls_on_audit_pending_violations.exs
+++ b/priv/repo/migrations/20260702130000_enable_rls_on_audit_pending_violations.exs
@@ -1,0 +1,25 @@
+defmodule Loopctl.Repo.Migrations.EnableRlsOnAuditPendingViolations do
+  @moduledoc """
+  rls-01 (GHSA-q46q-6f5q-f7xj): the `audit_pending_violations` table was created
+  with a `tenant_id` column but WITHOUT Row Level Security — it had
+  `relrowsecurity = false` and zero policies, while every sibling tenant table is
+  RLS-enforced. Under the RLS-enforced `loopctl_app` role (which is GRANTed ALL by
+  fly-db-setup), the app could read/write ALL tenants' rows unfiltered. Today only
+  superadmin/AdminRepo touches this table so there is no live leak, but the
+  mandatory tenant-isolation invariant was broken. This closes it (defense in
+  depth, L2 database invariant per docs/chain-of-custody-v2.md §2.1/§2.4).
+
+  Uses the shared `RlsHelpers.enable_rls/1` so this table matches every other
+  tenant table: `ENABLE ROW LEVEL SECURITY` (not FORCE — the production owner
+  role has no BYPASSRLS) + a `tenant_isolation` policy
+  `USING (tenant_id = current_tenant_id())`. Reversible: `down` disables RLS and
+  drops the policy.
+  """
+  use Ecto.Migration
+
+  import Loopctl.Repo.RlsHelpers
+
+  def change do
+    enable_rls(:audit_pending_violations)
+  end
+end

--- a/priv/repo/migrations/20260702130100_add_reported_done_requires_agent_check_to_stories.exs
+++ b/priv/repo/migrations/20260702130100_add_reported_done_requires_agent_check_to_stories.exs
@@ -1,0 +1,48 @@
+defmodule Loopctl.Repo.Migrations.AddReportedDoneRequiresAgentCheckToStories do
+  @moduledoc """
+  Chain-of-custody INVARIANT 1 (L2 structural, docs/chain-of-custody-v2.md
+  §2.1/§2.2). The threat: the self-verify guard (`validate_not_self_verify/2`)
+  passes VACUOUSLY when a `reported_done` story has a NULL `assigned_agent_id` —
+  a non-nil verifier is never `== NULL`, so "nobody verifies their own work" is
+  satisfied for a report with no implementer. An agent could implement work, erase
+  its own `assigned_agent_id`, and then self-verify.
+
+  SCOPED CONSTRAINT — dispatch-identity erasure. This forbids the precise
+  illegitimate shape: a story that carries an implementer DISPATCH lineage
+  (`implementer_dispatch_id IS NOT NULL` — the "was dispatched to an implementer"
+  marker that `force_unclaim_story` deliberately does NOT clear) but has lost its
+  `assigned_agent_id` while still `reported_done`. No legitimate code path produces
+  this: `claim_story` sets `assigned_agent_id` (and `implementer_dispatch_id` for
+  dispatched work) together, and nothing clears the agent while the story stays
+  `reported_done`.
+
+  Why NOT the broader "reported_done ⇒ assigned_agent_id NOT NULL": there are
+  legitimate never-dispatched producers of `reported_done` + NULL agent that carry
+  NO dispatch lineage —
+    * `backfill_story/4` (reported_done + verified, stamps `metadata.backfill`)
+    * bulk mark-complete (`BulkOperations.apply_mark_complete/1` — reported_done +
+      verified)
+    * import with `initial_agent_status = reported_done` / `initial_verified_status
+      = verified`
+  A broad CHECK would break all of these. The AGENTLESS-but-never-dispatched case
+  is instead closed at the OPERATION level: `Loopctl.Progress.custody_orphaned?/1`
+  makes `validate_not_self_verify/2` and `validate_not_self_review/2` FAIL CLOSED
+  (`:missing_assigned_agent`) on any `reported_done` + unverified + NULL-agent +
+  NULL-dispatch story, so it can never be vacuously verified or reviewed. The two
+  layers together close the fail-open (structural DB backstop for the dispatch
+  case; fail-closed guard for the import/backfill-shaped case).
+
+  Pre-flight: dev (`loopctl_dev`) and test (`loopctl_test`) both have 0 stories, so
+  the constraint applies cleanly; no legacy backfill needed.
+
+  Reversible: Ecto auto-derives the `DROP CONSTRAINT` for `create constraint`.
+  """
+  use Ecto.Migration
+
+  def change do
+    create constraint(:stories, :stories_reported_done_requires_agent,
+             check:
+               "agent_status <> 'reported_done' OR implementer_dispatch_id IS NULL OR assigned_agent_id IS NOT NULL"
+           )
+  end
+end

--- a/priv/repo/migrations/20260702130100_add_reported_done_requires_agent_check_to_stories.exs
+++ b/priv/repo/migrations/20260702130100_add_reported_done_requires_agent_check_to_stories.exs
@@ -35,14 +35,31 @@ defmodule Loopctl.Repo.Migrations.AddReportedDoneRequiresAgentCheckToStories do
   Pre-flight: dev (`loopctl_dev`) and test (`loopctl_test`) both have 0 stories, so
   the constraint applies cleanly; no legacy backfill needed.
 
-  Reversible: Ecto auto-derives the `DROP CONSTRAINT` for `create constraint`.
+  Production-safe locking: added `NOT VALID` first (a fast catalog-only change that
+  does NOT scan the table), then `VALIDATE CONSTRAINT` in a separate statement —
+  which takes only a `SHARE UPDATE EXCLUSIVE` lock (concurrent reads AND writes
+  allowed) instead of the `ACCESS EXCLUSIVE` full-table lock a plain
+  `ADD CONSTRAINT ... CHECK` would hold for the whole scan. Behavior is identical
+  on the empty dev/test tables; this is purely the safe form for a populated
+  production `stories` table.
+
+  Reversible: the `execute/2` up/down pairs drop the constraint on rollback
+  (the VALIDATE step's down is a no-op — dropping the constraint removes it whole).
   """
   use Ecto.Migration
 
+  @check "agent_status <> 'reported_done' OR implementer_dispatch_id IS NULL OR assigned_agent_id IS NOT NULL"
+
   def change do
-    create constraint(:stories, :stories_reported_done_requires_agent,
-             check:
-               "agent_status <> 'reported_done' OR implementer_dispatch_id IS NULL OR assigned_agent_id IS NOT NULL"
-           )
+    execute(
+      "ALTER TABLE stories ADD CONSTRAINT stories_reported_done_requires_agent CHECK (#{@check}) NOT VALID",
+      "ALTER TABLE stories DROP CONSTRAINT stories_reported_done_requires_agent"
+    )
+
+    execute(
+      "ALTER TABLE stories VALIDATE CONSTRAINT stories_reported_done_requires_agent",
+      # Down no-op: the ADD's down (above) drops the constraint entirely on rollback.
+      "SELECT 1"
+    )
   end
 end

--- a/priv/repo/migrations/20260702130100_add_reported_done_requires_agent_check_to_stories.exs
+++ b/priv/repo/migrations/20260702130100_add_reported_done_requires_agent_check_to_stories.exs
@@ -1,4 +1,18 @@
 defmodule Loopctl.Repo.Migrations.AddReportedDoneRequiresAgentCheckToStories do
+  use Ecto.Migration
+
+  # Run each ALTER in its OWN auto-committed transaction. This is REQUIRED for the
+  # NOT VALID / VALIDATE split to actually help: inside a single Ecto-wrapped
+  # transaction Postgres would hold the ADD-CONSTRAINT lock until COMMIT, i.e.
+  # through the whole VALIDATE scan — an ACCESS-EXCLUSIVE-equivalent write block on
+  # `stories` (the hottest table). With the DDL transaction disabled, ADD
+  # CONSTRAINT ... NOT VALID commits first (fast, catalog-only, no scan), THEN
+  # VALIDATE CONSTRAINT runs on its own taking only SHARE UPDATE EXCLUSIVE
+  # (concurrent reads AND writes allowed). Same repo pattern as the CONCURRENTLY
+  # index migrations (e.g. 20260625120000_add_articles_source_keyset_index).
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
   @moduledoc """
   Chain-of-custody INVARIANT 1 (L2 structural, docs/chain-of-custody-v2.md
   §2.1/§2.2). The threat: the self-verify guard (`validate_not_self_verify/2`)
@@ -35,31 +49,27 @@ defmodule Loopctl.Repo.Migrations.AddReportedDoneRequiresAgentCheckToStories do
   Pre-flight: dev (`loopctl_dev`) and test (`loopctl_test`) both have 0 stories, so
   the constraint applies cleanly; no legacy backfill needed.
 
-  Production-safe locking: added `NOT VALID` first (a fast catalog-only change that
-  does NOT scan the table), then `VALIDATE CONSTRAINT` in a separate statement —
-  which takes only a `SHARE UPDATE EXCLUSIVE` lock (concurrent reads AND writes
-  allowed) instead of the `ACCESS EXCLUSIVE` full-table lock a plain
-  `ADD CONSTRAINT ... CHECK` would hold for the whole scan. Behavior is identical
-  on the empty dev/test tables; this is purely the safe form for a populated
-  production `stories` table.
+  Online-safe locking: `@disable_ddl_transaction true` (see the module attribute
+  note) makes `ADD CONSTRAINT ... NOT VALID` and `VALIDATE CONSTRAINT` each run in
+  their own auto-committed transaction, so VALIDATE holds only a SHARE UPDATE
+  EXCLUSIVE lock — concurrent reads and writes to `stories` continue during the
+  scan. Behavior is identical on the empty dev/test tables; this is the
+  production-safe form.
 
-  Reversible: the `execute/2` up/down pairs drop the constraint on rollback
-  (the VALIDATE step's down is a no-op — dropping the constraint removes it whole).
+  Reversible: `down` drops the constraint (idempotent `IF EXISTS`).
   """
-  use Ecto.Migration
 
   @check "agent_status <> 'reported_done' OR implementer_dispatch_id IS NULL OR assigned_agent_id IS NOT NULL"
 
-  def change do
+  def up do
     execute(
-      "ALTER TABLE stories ADD CONSTRAINT stories_reported_done_requires_agent CHECK (#{@check}) NOT VALID",
-      "ALTER TABLE stories DROP CONSTRAINT stories_reported_done_requires_agent"
+      "ALTER TABLE stories ADD CONSTRAINT stories_reported_done_requires_agent CHECK (#{@check}) NOT VALID"
     )
 
-    execute(
-      "ALTER TABLE stories VALIDATE CONSTRAINT stories_reported_done_requires_agent",
-      # Down no-op: the ADD's down (above) drops the constraint entirely on rollback.
-      "SELECT 1"
-    )
+    execute("ALTER TABLE stories VALIDATE CONSTRAINT stories_reported_done_requires_agent")
+  end
+
+  def down do
+    execute("ALTER TABLE stories DROP CONSTRAINT IF EXISTS stories_reported_done_requires_agent")
   end
 end

--- a/priv/repo/migrations/20260702130200_add_reviewed_report_at_to_review_records.exs
+++ b/priv/repo/migrations/20260702130200_add_reviewed_report_at_to_review_records.exs
@@ -1,0 +1,37 @@
+defmodule Loopctl.Repo.Migrations.AddReviewedReportAtToReviewRecords do
+  @moduledoc """
+  Chain-of-custody INVARIANT 2: bind a review record to the specific REPORT
+  GENERATION it reviewed. Previously `ensure_review_conducted` only checked
+  `review.completed_at > story.reported_done_at` (a pure timestamp check bounded
+  by a 60s skew allowance). That leaves a residual stale-review window: a review
+  of an OLD report generation, if it completes after the story is re-reported,
+  can still satisfy verify even though it never looked at the current report.
+
+  `reviewed_report_at` snapshots the story's `reported_done_at` at review-record
+  CREATION time (set programmatically, never cast from client input). At verify
+  time the review must have `reviewed_report_at = story.reported_done_at` (i.e. it
+  reviewed THIS generation); if the story was re-reported since, the snapshot no
+  longer matches and a fresh review is required.
+
+  Nullable for backwards compatibility.
+
+  LEGACY DECISION — GRANDFATHER NULLS (not backfill): pre-migration review_records
+  have `reviewed_report_at IS NULL`. The verify-time check treats `NULL` as
+  "matches" (see `Loopctl.Progress.validate_review_record_exists/3`), and the
+  existing `completed_at > reported_done_at` secondary guard still applies to them.
+  Backfilling `reviewed_report_at = reported_done_at` was considered and REJECTED
+  as ambiguous: a legacy review that reviewed an older generation but completed
+  after a re-report would be fabricated as "matching the current generation",
+  silently validating exactly the stale review this invariant is meant to catch.
+  A NULL is an honest "unknown pre-migration generation". dev/test both have 0
+  review_records, so this only affects hypothetical production legacy rows, for
+  which the secondary timestamp guard remains in force.
+  """
+  use Ecto.Migration
+
+  def change do
+    alter table(:review_records) do
+      add :reviewed_report_at, :utc_datetime_usec
+    end
+  end
+end

--- a/test/loopctl/progress/custody_invariants_test.exs
+++ b/test/loopctl/progress/custody_invariants_test.exs
@@ -13,6 +13,8 @@ defmodule Loopctl.Progress.CustodyInvariantsTest do
   """
   use Loopctl.DataCase, async: true
 
+  import ExUnit.CaptureLog
+
   setup :verify_on_exit!
 
   alias Loopctl.AdminRepo
@@ -195,6 +197,40 @@ defmodule Loopctl.Progress.CustodyInvariantsTest do
                Progress.verify_story(tenant.id, story.id, %{"summary" => "x"},
                  orchestrator_agent_id: orchestrator.id
                )
+    end
+
+    test "the guard emits an operator warning (story_id + tenant_id) so a broken import is visible" do
+      tenant = fixture(:tenant)
+      epic = fixture(:epic, %{tenant_id: tenant.id})
+      story = imported_orphan(tenant, epic, now_usec())
+      orchestrator = fixture(:agent, %{tenant_id: tenant.id, agent_type: :orchestrator})
+      reviewer = fixture(:agent, %{tenant_id: tenant.id, agent_type: :orchestrator})
+
+      verify_log =
+        capture_log(fn ->
+          assert {:error, :missing_assigned_agent} =
+                   Progress.verify_story(tenant.id, story.id, %{"summary" => "x"},
+                     orchestrator_agent_id: orchestrator.id
+                   )
+        end)
+
+      assert verify_log =~ "custody_orphaned_blocked"
+      assert verify_log =~ "verify"
+      assert verify_log =~ story.id
+      assert verify_log =~ tenant.id
+
+      # …and on the review path too.
+      review_log =
+        capture_log(fn ->
+          assert {:error, :missing_assigned_agent} =
+                   Progress.record_review(tenant.id, story.id, review_params("x"),
+                     reviewer_agent_id: reviewer.id
+                   )
+        end)
+
+      assert review_log =~ "custody_orphaned_blocked"
+      assert review_log =~ "review"
+      assert review_log =~ story.id
     end
 
     test "record_review fails closed on a custody-orphaned story" do

--- a/test/loopctl/progress/custody_invariants_test.exs
+++ b/test/loopctl/progress/custody_invariants_test.exs
@@ -49,6 +49,44 @@ defmodule Loopctl.Progress.CustodyInvariantsTest do
   defp review_params(summary),
     do: %{"review_type" => "enhanced", "summary" => summary}
 
+  # An import-shaped orphan: reported_done + unverified + NULL-agent + NULL-dispatch
+  # with a pre-existing reported_done_at (as `initial_agent_status: "reported_done"`
+  # import produces). Permitted by the scoped CHECK; blocked at verify/review by the
+  # custody-orphaned guard; recoverable via backfill / bulk mark-complete.
+  defp imported_orphan(tenant, epic, reported_done_at) do
+    fixture(:story, %{tenant_id: tenant.id, epic_id: epic.id})
+    |> Ecto.Changeset.change(%{
+      agent_status: :reported_done,
+      verified_status: :unverified,
+      reported_done_at: reported_done_at
+    })
+    |> AdminRepo.update!()
+  end
+
+  # A genuinely reported+reviewed story (assigned agent + qualifying review) in the
+  # given tenant/epic, ready to verify. Returns {story, reviewer}.
+  defp healthy_reviewed_story(tenant, epic, reported_done_at) do
+    agent = fixture(:agent, %{tenant_id: tenant.id, agent_type: :implementer})
+    reviewer = fixture(:agent, %{tenant_id: tenant.id, agent_type: :orchestrator})
+
+    story =
+      fixture(:story, %{tenant_id: tenant.id, epic_id: epic.id})
+      |> Ecto.Changeset.change(%{
+        agent_status: :reported_done,
+        assigned_agent_id: agent.id,
+        assigned_at: now_usec(),
+        reported_done_at: reported_done_at
+      })
+      |> AdminRepo.update!()
+
+    {:ok, _} =
+      Progress.record_review(tenant.id, story.id, review_params("ok"),
+        reviewer_agent_id: reviewer.id
+      )
+
+    {story, reviewer}
+  end
+
   # ------------------------------------------------------------------
   # INVARIANT 1 — reported_done requires an assigned agent
   # ------------------------------------------------------------------
@@ -335,6 +373,100 @@ defmodule Loopctl.Progress.CustodyInvariantsTest do
                Progress.verify_story(tenant_b.id, story_b.id, %{"summary" => "x"},
                  orchestrator_agent_id: orch_b.id
                )
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # INVARIANT 1 — recovery path for imported agentless reported_done work
+  # ------------------------------------------------------------------
+
+  describe "INVARIANT 1: imported agentless reported_done has a working recovery" do
+    test "backfill_story recovers it (preserving reported_done_at) while verify/review stay blocked" do
+      t1 = seconds_ago(200)
+      tenant = fixture(:tenant)
+      epic = fixture(:epic, %{tenant_id: tenant.id})
+      story = imported_orphan(tenant, epic, t1)
+      orch = fixture(:agent, %{tenant_id: tenant.id, agent_type: :orchestrator})
+
+      # Fail-closed on the WRONG paths…
+      assert {:error, :missing_assigned_agent} =
+               Progress.verify_story(tenant.id, story.id, %{"summary" => "x"},
+                 orchestrator_agent_id: orch.id
+               )
+
+      assert {:error, :missing_assigned_agent} =
+               Progress.record_review(tenant.id, story.id, review_params("x"),
+                 reviewer_agent_id: orch.id
+               )
+
+      # …recover on the RIGHT path, WITHOUT destroying the pre-loopctl-done
+      # provenance (reported_done_at preserved, not overwritten/cleared).
+      assert {:ok, updated} =
+               Progress.backfill_story(tenant.id, story.id, %{"reason" => "pre-existing import"})
+
+      assert updated.agent_status == :reported_done
+      assert updated.verified_status == :verified
+      assert is_nil(updated.assigned_agent_id)
+      assert DateTime.compare(updated.reported_done_at, t1) == :eq
+    end
+
+    test "bulk mark-complete recovers it, preserving reported_done_at" do
+      t1 = seconds_ago(200)
+      tenant = fixture(:tenant)
+      epic = fixture(:epic, %{tenant_id: tenant.id})
+      story = imported_orphan(tenant, epic, t1)
+      orch = fixture(:agent, %{tenant_id: tenant.id, agent_type: :orchestrator})
+
+      entry = %{
+        "story_id" => story.id,
+        "summary" => "pre-existing",
+        "review_type" => "pre_existing"
+      }
+
+      assert {:ok, [result]} = BulkOperations.bulk_mark_complete(tenant.id, [entry], orch.id)
+      assert result.status == "success"
+
+      reloaded = AdminRepo.get!(Story, story.id)
+      assert reloaded.verified_status == :verified
+      assert is_nil(reloaded.assigned_agent_id)
+      assert DateTime.compare(reloaded.reported_done_at, t1) == :eq
+    end
+  end
+
+  describe "INVARIANT 1: bulk paths emit per-story :missing_assigned_agent" do
+    test "bulk_verify errors the orphan per-story without failing the healthy story in the batch" do
+      t1 = seconds_ago(100)
+      tenant = fixture(:tenant)
+      epic = fixture(:epic, %{tenant_id: tenant.id})
+
+      orphan = imported_orphan(tenant, epic, t1)
+      {healthy, reviewer} = healthy_reviewed_story(tenant, epic, t1)
+
+      entries =
+        for id <- [orphan.id, healthy.id],
+            do: %{"story_id" => id, "summary" => "b", "review_type" => "enhanced"}
+
+      assert {:ok, results} = BulkOperations.bulk_verify(tenant.id, entries, reviewer.id)
+
+      by_id = Map.new(results, &{&1.story_id, &1})
+      assert by_id[orphan.id].status == "error"
+      assert by_id[orphan.id].reason =~ "custody chain is broken"
+      assert by_id[healthy.id].status == "success"
+    end
+
+    test "bulk_reject errors the orphan per-story without failing the whole batch" do
+      t1 = seconds_ago(100)
+      tenant = fixture(:tenant)
+      epic = fixture(:epic, %{tenant_id: tenant.id})
+
+      orphan = imported_orphan(tenant, epic, t1)
+      orch = fixture(:agent, %{tenant_id: tenant.id, agent_type: :orchestrator})
+
+      entry = %{"story_id" => orphan.id, "reason" => "regression"}
+
+      assert {:ok, [result]} = BulkOperations.bulk_reject(tenant.id, [entry], orch.id)
+      assert result.status == "error"
+      assert result.reason =~ "custody chain is broken"
     end
   end
 end

--- a/test/loopctl/progress/custody_invariants_test.exs
+++ b/test/loopctl/progress/custody_invariants_test.exs
@@ -1,0 +1,340 @@
+defmodule Loopctl.Progress.CustodyInvariantsTest do
+  @moduledoc """
+  Chain-of-custody invariants (docs/chain-of-custody-v2.md §2.1/§2.2, L2):
+
+  * INVARIANT 1 — `reported_done` ⇒ `assigned_agent_id NOT NULL` (or backfilled).
+    Enforced structurally by the DB CHECK `stories_reported_done_requires_agent`
+    and backstopped by the fail-closed `validate_not_self_verify/2` guard
+    (surfaced via `ensure_verify_allowed/2`).
+
+  * INVARIANT 2 — a review record is bound to the report generation it reviewed
+    via `reviewed_report_at`. A review of a superseded report no longer qualifies
+    at verify time, in BOTH `verify_story/4` and `BulkOperations.bulk_verify/4`.
+  """
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Artifacts.ReviewRecord
+  alias Loopctl.BulkOperations
+  alias Loopctl.Dispatches
+  alias Loopctl.Progress
+  alias Loopctl.WorkBreakdown.Story
+
+  # A story that has been genuinely reported_done: assigned agent + reported_done_at.
+  defp reported_story(reported_done_at \\ nil) do
+    tenant = fixture(:tenant)
+    epic = fixture(:epic, %{tenant_id: tenant.id})
+    agent = fixture(:agent, %{tenant_id: tenant.id, agent_type: :implementer})
+    reviewer = fixture(:agent, %{tenant_id: tenant.id, agent_type: :orchestrator})
+    rdt = reported_done_at || now_usec()
+
+    story =
+      fixture(:story, %{tenant_id: tenant.id, epic_id: epic.id})
+      |> Ecto.Changeset.change(%{
+        agent_status: :reported_done,
+        assigned_agent_id: agent.id,
+        assigned_at: now_usec(),
+        reported_done_at: rdt
+      })
+      |> AdminRepo.update!()
+
+    %{tenant: tenant, agent: agent, reviewer: reviewer, story: story}
+  end
+
+  defp now_usec, do: DateTime.utc_now() |> DateTime.truncate(:microsecond)
+  defp seconds_ago(n), do: now_usec() |> DateTime.add(-n, :second)
+
+  defp review_params(summary),
+    do: %{"review_type" => "enhanced", "summary" => summary}
+
+  # ------------------------------------------------------------------
+  # INVARIANT 1 — reported_done requires an assigned agent
+  # ------------------------------------------------------------------
+
+  describe "INVARIANT 1: reported_done requires provenance (DB CHECK)" do
+    test "rejects erasing the assigned agent from a DISPATCHED reported_done story" do
+      tenant = fixture(:tenant)
+      epic = fixture(:epic, %{tenant_id: tenant.id})
+      agent = fixture(:agent, %{tenant_id: tenant.id, agent_type: :implementer})
+
+      {:ok, %{dispatch: dispatch}} =
+        Dispatches.create_dispatch(tenant.id, %{role: :agent, agent_id: agent.id})
+
+      # A dispatched, reported story: carries an implementer dispatch lineage AND
+      # its assigned agent (as claim_story would set them together).
+      story =
+        fixture(:story, %{tenant_id: tenant.id, epic_id: epic.id})
+        |> Ecto.Changeset.change(%{
+          agent_status: :reported_done,
+          assigned_agent_id: agent.id,
+          implementer_dispatch_id: dispatch.id,
+          reported_done_at: now_usec()
+        })
+        |> AdminRepo.update!()
+
+      # Erasing the implementer identity while the dispatch lineage remains is the
+      # forbidden state (it would let the implementer self-verify vacuously).
+      assert_raise Ecto.ConstraintError, ~r/stories_reported_done_requires_agent/, fn ->
+        story
+        |> Ecto.Changeset.change(%{assigned_agent_id: nil})
+        |> AdminRepo.update!()
+      end
+    end
+
+    test "allows a never-dispatched reported_done story with a NULL assigned_agent_id" do
+      # backfill / bulk mark-complete / import all legitimately produce a
+      # reported_done story with no assigned agent and NO dispatch lineage. The
+      # CHECK permits it (the operation-level guard, tested below, prevents it from
+      # being vacuously verified). backfill_story is the representative path.
+      tenant = fixture(:tenant)
+      epic = fixture(:epic, %{tenant_id: tenant.id})
+      story = fixture(:story, %{tenant_id: tenant.id, epic_id: epic.id})
+
+      assert {:ok, updated} =
+               Progress.backfill_story(tenant.id, story.id, %{
+                 "reason" => "completed before loopctl onboarding"
+               })
+
+      assert updated.agent_status == :reported_done
+      assert is_nil(updated.assigned_agent_id)
+      assert is_nil(updated.implementer_dispatch_id)
+    end
+  end
+
+  describe "INVARIANT 1: self-verify guard fails closed (backstop)" do
+    test "ensure_verify_allowed/2 rejects a custody-orphaned story with :missing_assigned_agent" do
+      orphan = %Story{
+        tenant_id: Ecto.UUID.generate(),
+        agent_status: :reported_done,
+        verified_status: :unverified,
+        assigned_agent_id: nil,
+        implementer_dispatch_id: nil,
+        verifier_dispatch_id: nil
+      }
+
+      # A non-nil verifier would otherwise "!= nil implementer" and pass VACUOUSLY.
+      assert {:error, :missing_assigned_agent} =
+               Progress.ensure_verify_allowed(orphan, Ecto.UUID.generate())
+    end
+
+    test "ensure_verify_allowed/2 still separates verifier from a real assigned agent" do
+      implementer = Ecto.UUID.generate()
+
+      story = %Story{
+        tenant_id: Ecto.UUID.generate(),
+        agent_status: :reported_done,
+        verified_status: :unverified,
+        assigned_agent_id: implementer,
+        implementer_dispatch_id: nil,
+        verifier_dispatch_id: nil
+      }
+
+      assert :ok = Progress.ensure_verify_allowed(story, Ecto.UUID.generate())
+      assert {:error, :self_verify_blocked} = Progress.ensure_verify_allowed(story, implementer)
+    end
+
+    test "verify_story/4 fails closed on a persisted custody-orphaned story" do
+      # An import-shaped orphan (reported_done + unverified + NULL-agent +
+      # NULL-dispatch) is permitted by the scoped CHECK but must not be verifiable:
+      # the self-verify check would otherwise pass vacuously.
+      tenant = fixture(:tenant)
+      epic = fixture(:epic, %{tenant_id: tenant.id})
+
+      story =
+        fixture(:story, %{tenant_id: tenant.id, epic_id: epic.id})
+        |> Ecto.Changeset.change(%{
+          agent_status: :reported_done,
+          verified_status: :unverified,
+          reported_done_at: now_usec()
+        })
+        |> AdminRepo.update!()
+
+      orchestrator = fixture(:agent, %{tenant_id: tenant.id, agent_type: :orchestrator})
+
+      assert {:error, :missing_assigned_agent} =
+               Progress.verify_story(tenant.id, story.id, %{"summary" => "x"},
+                 orchestrator_agent_id: orchestrator.id
+               )
+    end
+
+    test "record_review fails closed on a custody-orphaned story" do
+      # A reported_done + unverified + NULL-agent + NULL-dispatch story (import-
+      # shaped): permitted by the scoped CHECK, but must NOT be reviewable — there
+      # is no known implementer to separate the reviewer from.
+      tenant = fixture(:tenant)
+      epic = fixture(:epic, %{tenant_id: tenant.id})
+
+      story =
+        fixture(:story, %{tenant_id: tenant.id, epic_id: epic.id})
+        |> Ecto.Changeset.change(%{
+          agent_status: :reported_done,
+          verified_status: :unverified,
+          reported_done_at: now_usec()
+        })
+        |> AdminRepo.update!()
+
+      reviewer = fixture(:agent, %{tenant_id: tenant.id, agent_type: :orchestrator})
+
+      assert {:error, :missing_assigned_agent} =
+               Progress.record_review(tenant.id, story.id, review_params("x"),
+                 reviewer_agent_id: reviewer.id
+               )
+    end
+  end
+
+  describe "INVARIANT 1: legitimate flow still verifies" do
+    test "a reported_done story with an assigned agent + independent review verifies" do
+      %{tenant: tenant, story: story, reviewer: reviewer} = reported_story()
+
+      assert {:ok, _} =
+               Progress.record_review(tenant.id, story.id, review_params("ok"),
+                 reviewer_agent_id: reviewer.id
+               )
+
+      assert {:ok, updated} =
+               Progress.verify_story(tenant.id, story.id, %{"summary" => "good"},
+                 orchestrator_agent_id: reviewer.id
+               )
+
+      assert updated.verified_status == :verified
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # INVARIANT 2 — review bound to the report generation it reviewed
+  # ------------------------------------------------------------------
+
+  describe "INVARIANT 2: reviewed_report_at snapshot" do
+    test "record_review snapshots the story's current reported_done_at" do
+      t1 = seconds_ago(100)
+      %{tenant: tenant, story: story, reviewer: reviewer} = reported_story(t1)
+
+      assert {:ok, rr} =
+               Progress.record_review(tenant.id, story.id, review_params("gen1"),
+                 reviewer_agent_id: reviewer.id
+               )
+
+      assert DateTime.compare(rr.reviewed_report_at, t1) == :eq
+    end
+  end
+
+  describe "INVARIANT 2: verify_story requires the review to match the current report" do
+    test "verifies when the review matches the current generation" do
+      t1 = seconds_ago(100)
+      %{tenant: tenant, story: story, reviewer: reviewer} = reported_story(t1)
+
+      {:ok, _} =
+        Progress.record_review(tenant.id, story.id, review_params("gen1"),
+          reviewer_agent_id: reviewer.id
+        )
+
+      assert {:ok, updated} =
+               Progress.verify_story(tenant.id, story.id, %{"summary" => "ok"},
+                 orchestrator_agent_id: reviewer.id
+               )
+
+      assert updated.verified_status == :verified
+    end
+
+    test "blocks verify when the story was re-reported after the review (stale generation)" do
+      t1 = seconds_ago(100)
+      %{tenant: tenant, story: story, reviewer: reviewer} = reported_story(t1)
+
+      # Review of generation T1. completed_at defaults to ~now, which is LATER
+      # than the T2 we re-report to below — so the secondary completed_at >
+      # reported_done_at guard still PASSES and only the reviewed_report_at
+      # binding can block. This isolates INVARIANT 2.
+      {:ok, _} =
+        Progress.record_review(tenant.id, story.id, review_params("gen1"),
+          reviewer_agent_id: reviewer.id
+        )
+
+      # Re-report: reported_done_at advances to T2 (T1 < T2 < review.completed_at).
+      t2 = seconds_ago(50)
+
+      story
+      |> Ecto.Changeset.change(%{reported_done_at: t2})
+      |> AdminRepo.update!()
+
+      assert {:error, :review_not_conducted} =
+               Progress.verify_story(tenant.id, story.id, %{"summary" => "try"},
+                 orchestrator_agent_id: reviewer.id
+               )
+
+      # A fresh review of generation T2 re-qualifies.
+      {:ok, _} =
+        Progress.record_review(tenant.id, story.id, review_params("gen2"),
+          reviewer_agent_id: reviewer.id
+        )
+
+      assert {:ok, updated} =
+               Progress.verify_story(tenant.id, story.id, %{"summary" => "ok"},
+                 orchestrator_agent_id: reviewer.id
+               )
+
+      assert updated.verified_status == :verified
+    end
+  end
+
+  describe "INVARIANT 2: bulk_verify enforces the same binding" do
+    test "bulk_verify blocks a stale-generation review and passes after re-review" do
+      t1 = seconds_ago(100)
+      %{tenant: tenant, story: story, reviewer: reviewer} = reported_story(t1)
+
+      {:ok, _} =
+        Progress.record_review(tenant.id, story.id, review_params("gen1"),
+          reviewer_agent_id: reviewer.id
+        )
+
+      t2 = seconds_ago(50)
+
+      story
+      |> Ecto.Changeset.change(%{reported_done_at: t2})
+      |> AdminRepo.update!()
+
+      entry = %{"story_id" => story.id, "summary" => "bulk", "review_type" => "enhanced"}
+
+      assert {:ok, [stale]} = BulkOperations.bulk_verify(tenant.id, [entry], reviewer.id)
+      assert stale.status == "error"
+      assert stale.reason =~ "review"
+
+      {:ok, _} =
+        Progress.record_review(tenant.id, story.id, review_params("gen2"),
+          reviewer_agent_id: reviewer.id
+        )
+
+      assert {:ok, [ok_result]} = BulkOperations.bulk_verify(tenant.id, [entry], reviewer.id)
+      assert ok_result.status == "success"
+    end
+  end
+
+  describe "INVARIANT 2: tenant isolation of the review-record check" do
+    test "a review record in another tenant does not satisfy verify" do
+      t1 = seconds_ago(100)
+      %{tenant: tenant_b, story: story_b} = reported_story(t1)
+
+      other_tenant = fixture(:tenant)
+
+      # A review row in ANOTHER tenant that, if tenant scoping were broken, would
+      # match story_b's current generation exactly.
+      %ReviewRecord{
+        tenant_id: other_tenant.id,
+        story_id: story_b.id,
+        review_type: "enhanced",
+        summary: "cross-tenant",
+        completed_at: now_usec(),
+        reviewed_report_at: story_b.reported_done_at
+      }
+      |> AdminRepo.insert!()
+
+      orch_b = fixture(:agent, %{tenant_id: tenant_b.id, agent_type: :orchestrator})
+
+      assert {:error, :review_not_conducted} =
+               Progress.verify_story(tenant_b.id, story_b.id, %{"summary" => "x"},
+                 orchestrator_agent_id: orch_b.id
+               )
+    end
+  end
+end

--- a/test/loopctl/progress/epic_completion_test.exs
+++ b/test/loopctl/progress/epic_completion_test.exs
@@ -148,13 +148,18 @@ defmodule Loopctl.Progress.EpicCompletionTest do
                  orchestrator_agent_id: orch_agent.id
                )
 
-      # Re-set to reported_done for re-verification
+      # Re-set to reported_done for re-verification. Rejection auto-resets the
+      # story (clears assigned_agent_id), so re-establish an implementing agent
+      # distinct from the orchestrator to satisfy the reported_done⇒assigned-agent
+      # invariant (DB CHECK) without becoming a self-verify.
       story = Loopctl.AdminRepo.get!(Loopctl.WorkBreakdown.Story, story.id)
+      impl_agent = fixture(:agent, %{tenant_id: tenant.id, agent_type: :implementer})
 
       story
       |> Ecto.Changeset.change(%{
         agent_status: :reported_done,
         verified_status: :unverified,
+        assigned_agent_id: impl_agent.id,
         reported_done_at: DateTime.utc_now()
       })
       |> Loopctl.AdminRepo.update!()

--- a/test/loopctl/repo/rls_coverage_test.exs
+++ b/test/loopctl/repo/rls_coverage_test.exs
@@ -1,0 +1,78 @@
+defmodule Loopctl.Repo.RlsCoverageTest do
+  @moduledoc """
+  rls-01 regression (GHSA-q46q-6f5q-f7xj): a repo-wide invariant that EVERY
+  tenant-scoped table has Row Level Security enabled AND at least one policy.
+
+  This keys purely on the presence of a `tenant_id` column, so it catches both
+  the `audit_pending_violations` gap this PR fixes AND any future tenant table
+  that forgets `RlsHelpers.enable_rls/1`. Legitimately-global tables (no
+  `tenant_id`, e.g. `tenants`, `schema_migrations`) are excluded automatically.
+
+  Child partitions (`relispartition = true`) are excluded: RLS is enforced on the
+  partitioned PARENT (`relkind = 'p'`, which IS checked here), and loopctl only
+  ever queries through the parent — the partitions inherit that enforcement.
+  """
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.AdminRepo
+
+  @tenant_tables_sql """
+  SELECT c.relname,
+         c.relrowsecurity,
+         (
+           SELECT count(*)
+           FROM pg_policies p
+           WHERE p.schemaname = 'public' AND p.tablename = c.relname
+         ) AS policy_count
+  FROM pg_class c
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public'
+    AND c.relkind IN ('r', 'p')
+    AND c.relispartition = false
+    AND EXISTS (
+      SELECT 1
+      FROM information_schema.columns col
+      WHERE col.table_schema = 'public'
+        AND col.table_name = c.relname
+        AND col.column_name = 'tenant_id'
+    )
+  ORDER BY c.relname
+  """
+
+  test "every table with a tenant_id column has RLS enabled and >= 1 policy" do
+    %{rows: rows} = AdminRepo.query!(@tenant_tables_sql, [])
+
+    # Sanity: we actually discovered tenant-scoped tables (the query isn't a no-op)
+    # and one of them is a table we know is tenant-scoped.
+    refute rows == [], "expected to discover tenant-scoped tables via the catalog"
+    table_names = Enum.map(rows, fn [name, _rls, _count] -> name end)
+    assert "stories" in table_names
+    assert "audit_pending_violations" in table_names
+
+    offenders =
+      for [name, rls, policy_count] <- rows,
+          rls == false or policy_count == 0,
+          do: %{table: name, rowsecurity: rls, policies: policy_count}
+
+    assert offenders == [],
+           "tenant-scoped tables missing RLS and/or a policy: #{inspect(offenders, pretty: true)}"
+  end
+
+  test "audit_pending_violations is RLS-enforced with a tenant_isolation policy (rls-01)" do
+    %{rows: [[rowsecurity]]} =
+      AdminRepo.query!(
+        "SELECT relrowsecurity FROM pg_class WHERE relname = 'audit_pending_violations'",
+        []
+      )
+
+    assert rowsecurity == true
+
+    %{rows: [[qual]]} =
+      AdminRepo.query!(
+        "SELECT qual FROM pg_policies WHERE tablename = 'audit_pending_violations' AND policyname = 'tenant_isolation'",
+        []
+      )
+
+    assert qual =~ "current_tenant_id()"
+  end
+end

--- a/test/loopctl_web/controllers/story_verification_controller_test.exs
+++ b/test/loopctl_web/controllers/story_verification_controller_test.exs
@@ -363,14 +363,12 @@ defmodule LoopctlWeb.StoryVerificationControllerTest do
       assert reloaded.assigned_agent_id == agent.id
     end
 
-    test "refuses backfill after force_unclaim clears assigned_agent_id", %{conn: conn} do
-      # SECURITY: force_unclaim_story clears assigned_agent_id but leaves
-      # agent_status in a non-:pending state (typically :pending is set back
-      # but only after unclaim actually happens through the real path). A
-      # simpler attack model: a story with agent_status=:implementing but
-      # assigned_agent_id=nil (impossible in practice — the guard catches
-      # this too via the agent_status check). The broader defense is that
-      # guard_backfillable refuses any non-:pending agent_status.
+    test "refuses backfill of an in-progress story with an accurate reason (not a false dispatch-lineage claim)",
+         %{conn: conn} do
+      # An :implementing story with a NULL assigned_agent_id (impossible in
+      # practice — claim sets the agent) carries NO dispatch lineage. The guard
+      # must still REFUSE it, but with an ACCURATE reason (:story_in_progress —
+      # "being worked"), NOT a misleading "dispatch lineage" claim.
       tenant = fixture(:tenant)
 
       {raw_key, _api_key} =
@@ -379,15 +377,6 @@ defmodule LoopctlWeb.StoryVerificationControllerTest do
       project = fixture(:project, %{tenant_id: tenant.id})
       epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
 
-      # force_unclaim sets agent_status=:pending and clears assigned_agent_id.
-      # BUT it does NOT clear implementer_dispatch_id. Test that the guard
-      # catches a story with only implementer_dispatch_id set by asserting
-      # agent_status check works — the pragmatic attack scenario is blocked
-      # by agent_status != :pending (tested in the next test) and the
-      # strict guard is a defense in depth.
-
-      # For now: test the obvious case — agent_status=:implementing should
-      # refuse regardless of assigned_agent_id.
       story =
         fixture(:story, %{
           tenant_id: tenant.id,
@@ -402,7 +391,11 @@ defmodule LoopctlWeb.StoryVerificationControllerTest do
         |> post(~p"/api/v1/stories/#{story.id}/backfill", %{"reason" => "bypass attempt"})
 
       body = json_response(conn, 422)
-      assert body["error"]["message"] =~ "dispatch lineage"
+      # Accurate :story_in_progress reason ("being worked"), NOT the misleading
+      # dispatch-lineage refusal — the message must not falsely claim the story
+      # HAS dispatch lineage when it does not.
+      assert body["error"]["message"] =~ "being worked"
+      refute body["error"]["message"] =~ "has loopctl dispatch lineage"
 
       # Story state unchanged
       reloaded = Loopctl.AdminRepo.get!(Loopctl.WorkBreakdown.Story, story.id)

--- a/test/loopctl_web/controllers/verification_listing_test.exs
+++ b/test/loopctl_web/controllers/verification_listing_test.exs
@@ -196,13 +196,18 @@ defmodule LoopctlWeb.VerificationListingTest do
         "reason" => "Regression found"
       })
 
-      # Advance story back to reported_done for second verify; set fresh reported_done_at
+      # Advance story back to reported_done for second verify; set fresh
+      # reported_done_at. Rejection auto-resets the story (clears assigned_agent_id),
+      # so re-establish an implementing agent (distinct from the orchestrator) to
+      # keep the story from being custody-orphaned (INVARIANT 1 fail-closed guard).
       story_now = Loopctl.AdminRepo.get!(Loopctl.WorkBreakdown.Story, story.id)
+      impl_agent = fixture(:agent, %{tenant_id: tenant.id, agent_type: :implementer})
 
       story_now
       |> Ecto.Changeset.change(%{
         agent_status: :reported_done,
         verified_status: :unverified,
+        assigned_agent_id: impl_agent.id,
         reported_done_at: DateTime.utc_now()
       })
       |> Loopctl.AdminRepo.update!()

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -1332,6 +1332,20 @@ defmodule Loopctl.Fixtures do
   defp apply_story_overrides(story, :pending, :unverified, nil), do: story
 
   defp apply_story_overrides(story, agent_status, verified_status, assigned_agent_id) do
+    # DB CHECK stories_reported_done_requires_agent (chain-of-custody INVARIANT 1):
+    # a reported_done story must carry provenance for who did the work — an
+    # assigned agent (unless backfilled). Keep fixtures realistic AND valid by
+    # auto-assigning a fresh agent when a test asks for reported_done without
+    # specifying one. Tests that need the illegitimate reported_done + NULL-agent
+    # state (e.g. asserting the CHECK/guard rejects it) build it directly, not via
+    # this fixture.
+    assigned_agent_id =
+      if agent_status == :reported_done and is_nil(assigned_agent_id) do
+        fixture(:agent, %{tenant_id: story.tenant_id}).id
+      else
+        assigned_agent_id
+      end
+
     overrides =
       %{agent_status: agent_status, verified_status: verified_status}
       |> maybe_put(:assigned_agent_id, assigned_agent_id)


### PR DESCRIPTION
## Summary

Three independent-but-related security fixes (custody-critical, Chain of Custody v2). Draft — do not merge / do not mark ready.

### rls-01 — `audit_pending_violations` had no RLS (GHSA-q46q-6f5q-f7xj)
The table was hand-rolled with a `tenant_id` column but no `enable_rls` — `rowsecurity=false`, zero policies — while every sibling tenant table is RLS-enforced. Under the RLS-enforced `loopctl_app` role (GRANTed ALL by fly-db-setup) the app could read/write all tenants' rows unfiltered. No live leak today (only superadmin/AdminRepo reads it) but the mandatory invariant was broken.

- New migration `enable_rls(:audit_pending_violations)` via `RlsHelpers` → `ENABLE ROW LEVEL SECURITY` + `tenant_isolation` policy, matching every other tenant table. Reversible.
- **Repo-wide regression test** (`test/loopctl/repo/rls_coverage_test.exs`): queries the catalog for EVERY table with a `tenant_id` column and asserts each has `rowsecurity=true` AND ≥1 policy. Child partitions inherit enforcement from the partitioned parent (which is itself checked), so they're excluded. Catches this gap and any future tenant table that forgets RLS.

### INVARIANT 1 — `reported_done` ⇒ implementer provenance
`validate_not_self_verify/2` passes vacuously for a `reported_done` story with a NULL `assigned_agent_id` (a non-nil verifier is never `== NULL`), so an implementer could erase its identity and self-verify.

- **Scoped DB CHECK** `stories_reported_done_requires_agent`: `agent_status <> 'reported_done' OR implementer_dispatch_id IS NULL OR assigned_agent_id IS NOT NULL` — forbids the dispatch-identity-erasure shape, which has no legitimate producer (`claim_story` sets both together). The broad `reported_done ⇒ assigned_agent_id NOT NULL` was **rejected** because `backfill_story`, bulk `mark-complete`, and import legitimately create never-dispatched agentless `reported_done` rows (verified against the actual code paths + failing tests). This is the "scope the constraint" path.
- **Fail-closed guard** `custody_orphaned?/1`: `validate_not_self_verify/2` and `validate_not_self_review/2` return `:missing_assigned_agent` (409, **no** tenant halt) on any `reported_done` + unverified + NULL-agent + NULL-dispatch story — closes the agentless case at the operation level (verify + reject + bulk + review). Wired through fallback / verification / review-record controllers and `BulkOperations.format_reason`.
- Fixtures auto-assign an agent to `reported_done` stories so they stay realistic and non-orphaned.
- Pre-flight: dev + test DBs have **0 stories / 0 violating rows** — migration applies cleanly, no legacy backfill needed.

### INVARIANT 2 — bind a review record to the report generation it reviewed
`ensure_review_conducted` only checked `review.completed_at > reported_done_at`, leaving a stale-review window (a review of an old generation could satisfy verify after a re-report).

- New column `review_records.reviewed_report_at`, snapshotted from the story's current `reported_done_at` at review creation (programmatic, never cast).
- At verify time — in BOTH `verify_story/4` and `BulkOperations.bulk_verify` (both route through `validate_review_record_exists/3`) — the review must have `reviewed_report_at = the story's current reported_done_at`; the `completed_at` skew check is kept as a secondary guard.
- **Legacy decision: GRANDFATHER NULLs.** Pre-migration reviews (`reviewed_report_at IS NULL`) are treated as matching. Backfilling was rejected as ambiguous — it would fabricate "matched current generation" for a legacy review that may have reviewed an older one, silently validating the exact stale review this closes. dev/test both have 0 review_records.

## Testing
- `mix precommit` green via the commit hook: compile `--warnings-as-errors`, format, `credo --strict`, `deps.audit`, `dialyzer` (0 real errors), **3405 tests, 0 failures**.
- All 3 migrations verified reversible (rollback → clean → re-migrate) on dev + test.
- New tests: repo-wide RLS coverage + `audit_pending_violations` regression; INVARIANT 1 (CHECK rejects dispatch-erasure; never-dispatched agentless allowed; `verify_story`/`ensure_verify_allowed`/`record_review` fail closed; legit flow still verifies); INVARIANT 2 (snapshot; match verifies; re-report invalidates in `verify_story` AND `bulk_verify`; tenant isolation).

Refs advisory GHSA-q46q-6f5q-f7xj (rls-01) + the tracked reported_done-assigned-agent and review-record-binding invariants.
