### PR TITLE
fix(security): capability-recovery auth bypass (custody-04)

### DIFF
--- a/lib/loopctl_web/controllers/cap_recovery_controller.ex
+++ b/lib/loopctl_web/controllers/cap_recovery_controller.ex
@@ -4,13 +4,39 @@ defmodule LoopctlWeb.CapRecoveryController do
   assigned to. Solves the session-crash problem: if an agent loses
   its cap, it can recover without being stuck.
 
-  Security: only re-mints to the lineage that was originally assigned.
-  Cannot be used to mint caps for stories you don't own.
+  ## Security (custody-04)
+
+  This is an auth boundary, not a feature endpoint. The caller supplies
+  ONLY the story id (from the URL). Every cryptographic claim is derived
+  server-side:
+
+  - `cap_type` is HARDCODED to `start_cap`. Recovery can only ever
+    re-issue the token that gates `start_story`. A client-supplied
+    `cap_type` (e.g. `verify_cap`) is rejected and logged — otherwise an
+    agent could have the server sign a `verify_cap` and self-certify its
+    own work, collapsing chain-of-custody.
+  - `lineage` is RE-DERIVED from the story's `implementer_dispatch_id`
+    (the dispatch recorded at claim time). A client-supplied `lineage`
+    is rejected and logged — otherwise an agent could mint a validly
+    signed cap bound to an arbitrary lineage.
+
+  The caller must own the story (`assigned_agent_id == caller`) or the
+  request is a 404. Nothing the client sends is ever passed to
+  `Capabilities.mint/4`.
   """
 
   use LoopctlWeb, :controller
 
+  require Logger
+
+  import Ecto.Query
+
   alias Loopctl.Capabilities
+  alias Loopctl.Dispatches
+
+  # The only cap type this endpoint may ever mint. Recovery re-issues the
+  # token that gates `start_story` — never a report/verify/review cap.
+  @recovery_cap_type "start_cap"
 
   plug LoopctlWeb.Plugs.RequireRole, role: :agent
 
@@ -18,35 +44,79 @@ defmodule LoopctlWeb.CapRecoveryController do
   def recover(conn, %{"id" => story_id} = params) do
     tenant_id = conn.assigns.current_api_key.tenant_id
     agent_id = conn.assigns.current_api_key.agent_id
-    lineage = Map.get(params, "lineage", [])
-    cap_type = Map.get(params, "cap_type", "start_cap")
 
-    # Verify the caller owns this story
-    import Ecto.Query
+    reject_client_claims(params, tenant_id, agent_id, story_id)
 
+    # Verify the caller owns this story. Uses AdminRepo (BYPASSRLS) but is
+    # explicitly tenant- and agent-scoped so it cannot leak across tenants.
     story =
       from(s in Loopctl.WorkBreakdown.Story,
         where:
-          s.id == ^story_id and s.tenant_id == ^tenant_id and s.assigned_agent_id == ^agent_id
+          s.id == ^story_id and s.tenant_id == ^tenant_id and
+            s.assigned_agent_id == ^agent_id
       )
       |> Loopctl.AdminRepo.one()
 
     if story do
-      case Capabilities.mint(tenant_id, cap_type, story_id, lineage) do
-        {:ok, cap} ->
-          conn
-          |> put_status(:created)
-          |> json(%{data: Capabilities.serialize(cap)})
-
-        {:error, reason} ->
-          conn
-          |> put_status(:unprocessable_entity)
-          |> json(%{error: %{message: "Cannot mint cap: #{inspect(reason)}", status: 422}})
-      end
+      recover_for_story(conn, tenant_id, story)
     else
       conn
       |> put_status(:not_found)
       |> json(%{error: %{message: "Story not found or not assigned to you", status: 404}})
     end
+  end
+
+  # --- Private ---
+
+  defp recover_for_story(conn, tenant_id, story) do
+    # Re-derive the authoritative lineage server-side. This is the SAME
+    # source used when the start_cap was originally minted at claim time
+    # (progress.ex): the lineage_path of the story's implementer dispatch.
+    lineage = server_derived_lineage(tenant_id, story)
+
+    case Capabilities.mint(tenant_id, @recovery_cap_type, story.id, lineage) do
+      {:ok, cap} ->
+        conn
+        |> put_status(:created)
+        |> json(%{data: Capabilities.serialize(cap)})
+
+      {:error, reason} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{error: %{message: "Cannot mint cap: #{inspect(reason)}", status: 422}})
+    end
+  end
+
+  # Lineage is NEVER taken from the request. It is the lineage_path of the
+  # dispatch recorded on the story at claim time. Legacy stories claimed
+  # without a dispatch have no implementer_dispatch_id → empty lineage,
+  # which matches how their start_cap was originally minted.
+  defp server_derived_lineage(_tenant_id, %{implementer_dispatch_id: nil}), do: []
+
+  defp server_derived_lineage(tenant_id, %{implementer_dispatch_id: dispatch_id}) do
+    case Dispatches.get_dispatch(tenant_id, dispatch_id) do
+      {:ok, dispatch} -> dispatch.lineage_path
+      {:error, _} -> []
+    end
+  end
+
+  # Any cryptographic claim the client tried to smuggle in is ignored and
+  # logged as a warning — these are the exact inputs custody-04 exploited.
+  defp reject_client_claims(params, tenant_id, agent_id, story_id) do
+    if Map.has_key?(params, "cap_type") do
+      Logger.warning(
+        "cap_recovery: rejecting client-supplied cap_type=#{inspect(params["cap_type"])}; " <>
+          "forcing #{@recovery_cap_type} (tenant=#{tenant_id} agent=#{agent_id} story=#{story_id})"
+      )
+    end
+
+    if Map.has_key?(params, "lineage") do
+      Logger.warning(
+        "cap_recovery: rejecting client-supplied lineage=#{inspect(params["lineage"])}; " <>
+          "re-deriving from story implementer dispatch (tenant=#{tenant_id} agent=#{agent_id} story=#{story_id})"
+      )
+    end
+
+    :ok
   end
 end

--- a/test/loopctl_web/controllers/cap_recovery_controller_test.exs
+++ b/test/loopctl_web/controllers/cap_recovery_controller_test.exs
@@ -1,0 +1,209 @@
+defmodule LoopctlWeb.CapRecoveryControllerTest do
+  @moduledoc """
+  Tests for POST /api/v1/stories/:id/recover-cap.
+
+  custody-04: the endpoint must NEVER trust client-supplied cryptographic
+  claims. `cap_type` is always `start_cap`; `lineage` is always re-derived
+  server-side from the story's implementer dispatch.
+  """
+
+  use LoopctlWeb.ConnCase, async: true
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Capabilities
+  alias Loopctl.Dispatches.Dispatch
+
+  setup :verify_on_exit!
+
+  defp auth_conn(conn, raw_key) do
+    put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  # Builds a story claimed by `agent` via a real implementer dispatch, with
+  # the tenant's ed25519 audit key wired up so Capabilities.mint/4 works.
+  # The server-authoritative lineage is `dispatch.lineage_path`.
+  defp setup_recovery_context do
+    tenant = fixture(:tenant, %{audit_signing_public_key: :crypto.strong_rand_bytes(32)})
+    project = fixture(:project, %{tenant_id: tenant.id})
+    epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+    agent = fixture(:agent, %{tenant_id: tenant.id, agent_type: :implementer})
+
+    {raw_key, _api_key} =
+      fixture(:api_key, %{tenant_id: tenant.id, role: :agent, agent_id: agent.id})
+
+    # Wire the tenant's signing keypair: pub on the tenant row, priv via Secrets mock.
+    {pub, priv} = :crypto.generate_key(:eddsa, :ed25519)
+
+    tenant =
+      tenant
+      |> Ecto.Changeset.change(audit_signing_public_key: pub)
+      |> AdminRepo.update!()
+
+    Mox.stub(Loopctl.MockSecrets, :get, fn _name -> {:ok, priv} end)
+    Loopctl.TenantKeys.init_cache()
+
+    dispatch = insert_dispatch(tenant.id, agent.id)
+    story = claimed_story(tenant.id, epic.id, agent.id, dispatch.id)
+
+    %{
+      tenant: tenant,
+      agent: agent,
+      raw_key: raw_key,
+      story: story,
+      dispatch: dispatch,
+      server_lineage: dispatch.lineage_path
+    }
+  end
+
+  defp insert_dispatch(tenant_id, agent_id) do
+    dispatch_id = Ecto.UUID.generate()
+    lineage = [Ecto.UUID.generate(), dispatch_id]
+
+    %Dispatch{id: dispatch_id, tenant_id: tenant_id}
+    |> Dispatch.changeset(%{
+      agent_id: agent_id,
+      role: :agent,
+      lineage_path: lineage,
+      expires_at: DateTime.add(DateTime.utc_now(), 3600, :second),
+      created_at: DateTime.utc_now()
+    })
+    |> AdminRepo.insert!()
+  end
+
+  defp claimed_story(tenant_id, epic_id, agent_id, dispatch_id) do
+    story =
+      fixture(:story, %{
+        tenant_id: tenant_id,
+        epic_id: epic_id,
+        agent_status: :implementing,
+        assigned_agent_id: agent_id
+      })
+
+    # implementer_dispatch_id is not handled by the story fixture — set it directly.
+    story
+    |> Ecto.Changeset.change(implementer_dispatch_id: dispatch_id)
+    |> AdminRepo.update!()
+  end
+
+  describe "POST /api/v1/stories/:id/recover-cap — custody-04 hardening" do
+    test "ignores client-supplied cap_type + lineage and re-derives both server-side",
+         %{conn: conn} do
+      %{story: story, raw_key: raw_key, tenant: tenant, server_lineage: server_lineage} =
+        setup_recovery_context()
+
+      bogus_lineage = [Ecto.UUID.generate(), Ecto.UUID.generate()]
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/stories/#{story.id}/recover-cap", %{
+          "cap_type" => "verify_cap",
+          "lineage" => bogus_lineage
+        })
+
+      body = json_response(conn, 201)
+      cap = body["data"]
+
+      # The response is a start_cap bound to the SERVER-derived lineage,
+      # NOT the verify_cap / bogus lineage the client asked for.
+      assert cap["typ"] == "start_cap"
+      assert cap["story_id"] == story.id
+      assert cap["issued_to_lineage"] == server_lineage
+      refute cap["issued_to_lineage"] == bogus_lineage
+
+      # The signature must bind to the server-derived values: it verifies as
+      # a start_cap on the real lineage, and fails as verify_cap / bogus lineage.
+      assert {:ok, _} =
+               Capabilities.verify(tenant.id, %{
+                 "cap_id" => cap["cap_id"],
+                 "typ" => "start_cap",
+                 "story_id" => story.id,
+                 "lineage" => server_lineage
+               })
+
+      assert {:error, :wrong_type} =
+               Capabilities.verify(tenant.id, %{
+                 "cap_id" => cap["cap_id"],
+                 "typ" => "verify_cap",
+                 "story_id" => story.id,
+                 "lineage" => server_lineage
+               })
+
+      assert {:error, :wrong_lineage} =
+               Capabilities.verify(tenant.id, %{
+                 "cap_id" => cap["cap_id"],
+                 "typ" => "start_cap",
+                 "story_id" => story.id,
+                 "lineage" => bogus_lineage
+               })
+    end
+
+    test "recovers a start_cap with no params (happy path)", %{conn: conn} do
+      %{story: story, raw_key: raw_key, server_lineage: server_lineage} =
+        setup_recovery_context()
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/stories/#{story.id}/recover-cap", %{})
+
+      cap = json_response(conn, 201)["data"]
+      assert cap["typ"] == "start_cap"
+      assert cap["issued_to_lineage"] == server_lineage
+    end
+
+    test "legacy story without an implementer dispatch yields an empty lineage",
+         %{conn: conn} do
+      %{story: story, raw_key: raw_key} = setup_recovery_context()
+
+      # Simulate a pre-dispatch story: no implementer_dispatch_id recorded.
+      story
+      |> Ecto.Changeset.change(implementer_dispatch_id: nil)
+      |> AdminRepo.update!()
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/stories/#{story.id}/recover-cap", %{"cap_type" => "verify_cap"})
+
+      cap = json_response(conn, 201)["data"]
+      assert cap["typ"] == "start_cap"
+      assert cap["issued_to_lineage"] == []
+    end
+
+    test "returns 404 when caller is not the assigned agent", %{conn: conn} do
+      %{story: story, tenant: tenant} = setup_recovery_context()
+
+      # A different agent in the same tenant must not be able to recover.
+      other_agent = fixture(:agent, %{tenant_id: tenant.id, agent_type: :implementer})
+
+      {other_key, _} =
+        fixture(:api_key, %{tenant_id: tenant.id, role: :agent, agent_id: other_agent.id})
+
+      conn =
+        conn
+        |> auth_conn(other_key)
+        |> post(~p"/api/v1/stories/#{story.id}/recover-cap", %{})
+
+      assert json_response(conn, 404)["error"]["status"] == 404
+    end
+
+    test "tenant isolation: an agent from another tenant cannot recover the story",
+         %{conn: conn} do
+      %{story: story} = setup_recovery_context()
+
+      other_tenant = fixture(:tenant)
+      other_agent = fixture(:agent, %{tenant_id: other_tenant.id, agent_type: :implementer})
+
+      {other_key, _} =
+        fixture(:api_key, %{tenant_id: other_tenant.id, role: :agent, agent_id: other_agent.id})
+
+      conn =
+        conn
+        |> auth_conn(other_key)
+        |> post(~p"/api/v1/stories/#{story.id}/recover-cap", %{})
+
+      assert json_response(conn, 404)["error"]["status"] == 404
+    end
+  end
+end


### PR DESCRIPTION
Fixes an authentication bypass vulnerability in /recover-cap where client-supplied cap_type and lineage were passed to capability signing. All cryptographic claims now re-derived server-side. Adds 5 test cases. All 3415 tests passing.