### PR TITLE
fix(security): restrict cap recovery to server-derived start_cap (custody-04)

### DIFF
--- a/lib/loopctl_web/controllers/cap_recovery_controller.ex
+++ b/lib/loopctl_web/controllers/cap_recovery_controller.ex
@@ -10,26 +10,37 @@ defmodule LoopctlWeb.CapRecoveryController do
       other `cap_type` (e.g. `verify_cap`, `report_cap`,
       `review_complete_cap`) is rejected with 422 — an agent must never
       be able to mint a capability to verify/report/review its own work.
+      A forged-cap-type attempt is an L1 forgery attempt: it is logged
+      (Logger.warning) and recorded in the story's audit history
+      (`cap_recovery_forgery_attempt`) so operators and L5/L6 detection
+      can see it.
     * The lineage the cap is bound to is DERIVED SERVER-SIDE from the
       story's recorded implementer dispatch (`implementer_dispatch_id` ->
       `Dispatch.lineage_path`). A client-supplied `lineage` param is
       ignored entirely — the cap is always scoped to the lineage that was
       actually dispatched to work the story.
-    * The caller must own the story (`assigned_agent_id`), and the story
-      must have a recorded dispatch lineage. Otherwise recovery is
-      refused: you cannot recover a cap for a story you weren't
-      dispatched to.
+    * The recorded dispatch must still be ACTIVE (not revoked, not
+      expired). A revoked dispatch is an L6 custody-halt stop signal;
+      recovery must not mint a fresh cap off a halted/expired lineage.
+    * The caller must own the story (`assigned_agent_id`). The role gate
+      is `exact_role: :agent` (no hierarchy) to match the sibling
+      agent-exclusive custody endpoints (claim/start/request_review/
+      unclaim) — an orchestrator identity linked to the same agent_id
+      must not be able to walk this gate where it couldn't walk claim.
   """
 
   use LoopctlWeb, :controller
 
+  require Logger
+
   import Ecto.Query
 
+  alias Loopctl.Audit
   alias Loopctl.Capabilities
   alias Loopctl.Dispatches
   alias Loopctl.WorkBreakdown.Story
 
-  plug LoopctlWeb.Plugs.RequireRole, role: :agent
+  plug LoopctlWeb.Plugs.RequireRole, exact_role: :agent
 
   @doc "POST /api/v1/stories/:id/recover-cap"
   def recover(conn, %{"id" => story_id} = params) do
@@ -45,6 +56,7 @@ defmodule LoopctlWeb.CapRecoveryController do
       |> json(%{data: Capabilities.serialize(cap)})
     else
       {:error, :invalid_cap_type} ->
+        log_forgery_attempt(conn, tenant_id, agent_id, story_id, Map.get(params, "cap_type"))
         error(conn, 422, "cap recovery only re-mints start_cap")
 
       {:error, :not_found} ->
@@ -56,6 +68,14 @@ defmodule LoopctlWeb.CapRecoveryController do
           422,
           "No recorded dispatch lineage for this story — cannot recover a cap " <>
             "for a story you weren't dispatched to"
+        )
+
+      {:error, :dispatch_inactive} ->
+        error(
+          conn,
+          422,
+          "The story's implementer dispatch has been revoked or has expired — " <>
+            "cannot recover a cap off a halted lineage"
         )
 
       {:error, reason} ->
@@ -89,15 +109,61 @@ defmodule LoopctlWeb.CapRecoveryController do
 
   # The canonical lineage is the implementer dispatch's lineage_path,
   # recorded on the story at claim time. Never trust a client-supplied
-  # lineage — resolve it from the dispatch record server-side.
+  # lineage — resolve it from the dispatch record server-side, and only
+  # if that dispatch is still active.
   defp recorded_lineage(_tenant_id, %Story{implementer_dispatch_id: nil}),
     do: {:error, :no_dispatch_lineage}
 
   defp recorded_lineage(tenant_id, %Story{implementer_dispatch_id: dispatch_id}) do
     case Dispatches.get_dispatch(tenant_id, dispatch_id) do
-      {:ok, %{lineage_path: [_ | _] = lineage}} -> {:ok, lineage}
+      {:ok, dispatch} -> active_lineage(dispatch)
       _ -> {:error, :no_dispatch_lineage}
     end
+  end
+
+  # Mirror DispatchController.validate_parent_and_create/4: a dispatch is
+  # only usable if it is neither revoked nor expired. A revoked dispatch is
+  # a custody-halt stop signal — recovery must not mint off it.
+  defp active_lineage(dispatch) do
+    now = DateTime.utc_now()
+
+    cond do
+      not is_nil(dispatch.revoked_at) -> {:error, :dispatch_inactive}
+      DateTime.compare(dispatch.expires_at, now) != :gt -> {:error, :dispatch_inactive}
+      dispatch.lineage_path == [] -> {:error, :no_dispatch_lineage}
+      true -> {:ok, dispatch.lineage_path}
+    end
+  end
+
+  # An agent asking recovery to mint it a verify_cap/report_cap/
+  # review_complete_cap is forging the L1 capability layer. Surface it: a
+  # Logger.warning (structured data in the message string, following
+  # log_custody_orphaned) plus an audit entry so it appears in
+  # GET /stories/:id/history and can feed anomaly detection. The audit
+  # write is best-effort — it must never mask the 422.
+  defp log_forgery_attempt(conn, tenant_id, agent_id, story_id, rejected_cap_type) do
+    Logger.warning(
+      "cap_recovery_forgery_attempt: agent attempted to mint a non-start_cap via cap " <>
+        "recovery — rejected_cap_type=#{inspect(rejected_cap_type)} story_id=#{story_id} " <>
+        "tenant_id=#{tenant_id} caller_agent_id=#{inspect(agent_id)}"
+    )
+
+    attrs =
+      conn
+      |> LoopctlWeb.AuditContext.from_conn()
+      |> Map.new()
+      |> Map.merge(%{
+        entity_type: "story",
+        entity_id: story_id,
+        action: "cap_recovery_forgery_attempt",
+        metadata: %{
+          "rejected_cap_type" => to_string(rejected_cap_type),
+          "caller_agent_id" => agent_id
+        }
+      })
+
+    _ = Audit.create_log_entry(tenant_id, attrs)
+    :ok
   end
 
   defp error(conn, status, message) do

--- a/lib/loopctl_web/controllers/cap_recovery_controller.ex
+++ b/lib/loopctl_web/controllers/cap_recovery_controller.ex
@@ -4,13 +4,30 @@ defmodule LoopctlWeb.CapRecoveryController do
   assigned to. Solves the session-crash problem: if an agent loses
   its cap, it can recover without being stuck.
 
-  Security: only re-mints to the lineage that was originally assigned.
-  Cannot be used to mint caps for stories you don't own.
+  Security (L1 capability layer, chain-of-custody v2):
+
+    * Recovery re-mints ONLY a `start_cap`. A client that supplies any
+      other `cap_type` (e.g. `verify_cap`, `report_cap`,
+      `review_complete_cap`) is rejected with 422 — an agent must never
+      be able to mint a capability to verify/report/review its own work.
+    * The lineage the cap is bound to is DERIVED SERVER-SIDE from the
+      story's recorded implementer dispatch (`implementer_dispatch_id` ->
+      `Dispatch.lineage_path`). A client-supplied `lineage` param is
+      ignored entirely — the cap is always scoped to the lineage that was
+      actually dispatched to work the story.
+    * The caller must own the story (`assigned_agent_id`), and the story
+      must have a recorded dispatch lineage. Otherwise recovery is
+      refused: you cannot recover a cap for a story you weren't
+      dispatched to.
   """
 
   use LoopctlWeb, :controller
 
+  import Ecto.Query
+
   alias Loopctl.Capabilities
+  alias Loopctl.Dispatches
+  alias Loopctl.WorkBreakdown.Story
 
   plug LoopctlWeb.Plugs.RequireRole, role: :agent
 
@@ -18,35 +35,74 @@ defmodule LoopctlWeb.CapRecoveryController do
   def recover(conn, %{"id" => story_id} = params) do
     tenant_id = conn.assigns.current_api_key.tenant_id
     agent_id = conn.assigns.current_api_key.agent_id
-    lineage = Map.get(params, "lineage", [])
-    cap_type = Map.get(params, "cap_type", "start_cap")
 
-    # Verify the caller owns this story
-    import Ecto.Query
+    with :ok <- validate_start_cap(params),
+         {:ok, story} <- fetch_owned_story(tenant_id, agent_id, story_id),
+         {:ok, lineage} <- recorded_lineage(tenant_id, story),
+         {:ok, cap} <- Capabilities.mint(tenant_id, "start_cap", story.id, lineage) do
+      conn
+      |> put_status(:created)
+      |> json(%{data: Capabilities.serialize(cap)})
+    else
+      {:error, :invalid_cap_type} ->
+        error(conn, 422, "cap recovery only re-mints start_cap")
 
+      {:error, :not_found} ->
+        error(conn, 404, "Story not found or not assigned to you")
+
+      {:error, :no_dispatch_lineage} ->
+        error(
+          conn,
+          422,
+          "No recorded dispatch lineage for this story — cannot recover a cap " <>
+            "for a story you weren't dispatched to"
+        )
+
+      {:error, reason} ->
+        error(conn, 422, "Cannot mint cap: #{inspect(reason)}")
+    end
+  end
+
+  # --- Private ---
+
+  # Recovery only ever re-mints a start_cap. An absent cap_type defaults
+  # to start_cap; anything else is a client trying to forge a higher-trust
+  # capability and is rejected.
+  defp validate_start_cap(params) do
+    case Map.get(params, "cap_type") do
+      nil -> :ok
+      "start_cap" -> :ok
+      _other -> {:error, :invalid_cap_type}
+    end
+  end
+
+  defp fetch_owned_story(tenant_id, agent_id, story_id) do
     story =
-      from(s in Loopctl.WorkBreakdown.Story,
+      from(s in Story,
         where:
           s.id == ^story_id and s.tenant_id == ^tenant_id and s.assigned_agent_id == ^agent_id
       )
       |> Loopctl.AdminRepo.one()
 
-    if story do
-      case Capabilities.mint(tenant_id, cap_type, story_id, lineage) do
-        {:ok, cap} ->
-          conn
-          |> put_status(:created)
-          |> json(%{data: Capabilities.serialize(cap)})
+    if story, do: {:ok, story}, else: {:error, :not_found}
+  end
 
-        {:error, reason} ->
-          conn
-          |> put_status(:unprocessable_entity)
-          |> json(%{error: %{message: "Cannot mint cap: #{inspect(reason)}", status: 422}})
-      end
-    else
-      conn
-      |> put_status(:not_found)
-      |> json(%{error: %{message: "Story not found or not assigned to you", status: 404}})
+  # The canonical lineage is the implementer dispatch's lineage_path,
+  # recorded on the story at claim time. Never trust a client-supplied
+  # lineage — resolve it from the dispatch record server-side.
+  defp recorded_lineage(_tenant_id, %Story{implementer_dispatch_id: nil}),
+    do: {:error, :no_dispatch_lineage}
+
+  defp recorded_lineage(tenant_id, %Story{implementer_dispatch_id: dispatch_id}) do
+    case Dispatches.get_dispatch(tenant_id, dispatch_id) do
+      {:ok, %{lineage_path: [_ | _] = lineage}} -> {:ok, lineage}
+      _ -> {:error, :no_dispatch_lineage}
     end
+  end
+
+  defp error(conn, status, message) do
+    conn
+    |> put_status(status)
+    |> json(%{error: %{message: message, status: status}})
   end
 end

--- a/test/loopctl_web/controllers/cap_recovery_controller_test.exs
+++ b/test/loopctl_web/controllers/cap_recovery_controller_test.exs
@@ -1,0 +1,208 @@
+defmodule LoopctlWeb.CapRecoveryControllerTest do
+  @moduledoc """
+  Chain-of-custody v2 (L1): capability recovery must only ever re-mint a
+  `start_cap`, bound to the lineage recorded on the story's implementer
+  dispatch — never a client-chosen cap type or lineage.
+
+  Refs advisory GHSA-w3j2-2w3r-hjcf.
+  """
+
+  use LoopctlWeb.ConnCase, async: true
+
+  import Ecto.Query
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Capabilities.CapabilityToken
+  alias Loopctl.Dispatches.Dispatch
+
+  setup :verify_on_exit!
+
+  defp auth_conn(conn, raw_key) do
+    put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  defp caps_for(story_id) do
+    AdminRepo.all(from(c in CapabilityToken, where: c.story_id == ^story_id))
+  end
+
+  defp insert_dispatch(tenant_id, agent_id, story_id, lineage) do
+    %Dispatch{tenant_id: tenant_id}
+    |> Dispatch.changeset(%{
+      role: :agent,
+      agent_id: agent_id,
+      story_id: story_id,
+      lineage_path: lineage,
+      expires_at: DateTime.add(DateTime.utc_now(), 3600, :second)
+    })
+    |> AdminRepo.insert!()
+  end
+
+  # Builds a tenant whose audit signing key is available, an agent + agent-role
+  # API key, and a story assigned to that agent. When `with_dispatch: true`
+  # (default) the story also carries a recorded implementer dispatch whose
+  # lineage_path is the canonical, server-side lineage.
+  defp setup_ctx(opts \\ %{}) do
+    tenant = fixture(:tenant)
+
+    # Make the tenant's audit signing key available so mint/4 can succeed.
+    {pub, priv} = :crypto.generate_key(:eddsa, :ed25519)
+
+    tenant =
+      tenant
+      |> Ecto.Changeset.change(audit_signing_public_key: pub)
+      |> AdminRepo.update!()
+
+    Mox.stub(Loopctl.MockSecrets, :get, fn _name -> {:ok, priv} end)
+    Loopctl.TenantKeys.init_cache()
+
+    project = fixture(:project, %{tenant_id: tenant.id})
+    epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+    agent = fixture(:agent, %{tenant_id: tenant.id})
+
+    {raw_key, _api_key} =
+      fixture(:api_key, %{tenant_id: tenant.id, role: :agent, agent_id: agent.id})
+
+    story = fixture(:story, %{tenant_id: tenant.id, epic_id: epic.id})
+    lineage = [Ecto.UUID.generate(), Ecto.UUID.generate()]
+
+    {story, recorded_lineage} =
+      if Map.get(opts, :with_dispatch, true) do
+        dispatch = insert_dispatch(tenant.id, agent.id, story.id, lineage)
+
+        story =
+          story
+          |> Ecto.Changeset.change(
+            assigned_agent_id: agent.id,
+            implementer_dispatch_id: dispatch.id
+          )
+          |> AdminRepo.update!()
+
+        {story, lineage}
+      else
+        story =
+          story
+          |> Ecto.Changeset.change(assigned_agent_id: agent.id)
+          |> AdminRepo.update!()
+
+        {story, nil}
+      end
+
+    %{
+      tenant: tenant,
+      agent: agent,
+      raw_key: raw_key,
+      story: story,
+      lineage: recorded_lineage
+    }
+  end
+
+  describe "POST /api/v1/stories/:id/recover-cap — cap_type restriction" do
+    for forged <- ["verify_cap", "report_cap", "review_complete_cap"] do
+      test "rejects client-supplied cap_type #{forged} with 422 and mints nothing", %{conn: conn} do
+        %{raw_key: raw_key, story: story} = setup_ctx()
+
+        conn =
+          conn
+          |> auth_conn(raw_key)
+          |> post("/api/v1/stories/#{story.id}/recover-cap", %{"cap_type" => unquote(forged)})
+
+        assert %{"error" => %{"status" => 422, "message" => message}} = json_response(conn, 422)
+        assert message =~ "start_cap"
+        assert caps_for(story.id) == []
+      end
+    end
+  end
+
+  describe "POST /api/v1/stories/:id/recover-cap — start_cap recovery" do
+    test "with no cap_type mints a start_cap bound to the server-derived lineage", %{conn: conn} do
+      %{raw_key: raw_key, story: story, lineage: lineage} = setup_ctx()
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post("/api/v1/stories/#{story.id}/recover-cap", %{})
+
+      assert %{"data" => data} = json_response(conn, 201)
+      assert data["typ"] == "start_cap"
+      assert data["story_id"] == story.id
+      assert data["issued_to_lineage"] == lineage
+    end
+
+    test "with explicit cap_type start_cap mints a start_cap", %{conn: conn} do
+      %{raw_key: raw_key, story: story, lineage: lineage} = setup_ctx()
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post("/api/v1/stories/#{story.id}/recover-cap", %{"cap_type" => "start_cap"})
+
+      assert %{"data" => data} = json_response(conn, 201)
+      assert data["typ"] == "start_cap"
+      assert data["issued_to_lineage"] == lineage
+    end
+
+    test "ignores a client-supplied lineage and uses the recorded dispatch lineage", %{conn: conn} do
+      %{raw_key: raw_key, story: story, lineage: lineage} = setup_ctx()
+      attacker_lineage = [Ecto.UUID.generate(), Ecto.UUID.generate()]
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post("/api/v1/stories/#{story.id}/recover-cap", %{"lineage" => attacker_lineage})
+
+      assert %{"data" => data} = json_response(conn, 201)
+      assert data["typ"] == "start_cap"
+      assert data["issued_to_lineage"] == lineage
+      refute data["issued_to_lineage"] == attacker_lineage
+    end
+  end
+
+  describe "POST /api/v1/stories/:id/recover-cap — guards" do
+    test "rejects a caller with no recorded dispatch lineage for the story", %{conn: conn} do
+      %{raw_key: raw_key, story: story} = setup_ctx(%{with_dispatch: false})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post("/api/v1/stories/#{story.id}/recover-cap", %{})
+
+      assert %{"error" => %{"status" => 422}} = json_response(conn, 422)
+      assert caps_for(story.id) == []
+    end
+
+    test "returns 404 for a same-tenant story assigned to another agent", %{conn: conn} do
+      %{raw_key: raw_key, tenant: tenant} = setup_ctx()
+
+      other_agent = fixture(:agent, %{tenant_id: tenant.id})
+      project = fixture(:project, %{tenant_id: tenant.id})
+      epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+
+      other_story =
+        fixture(:story, %{tenant_id: tenant.id, epic_id: epic.id})
+        |> Ecto.Changeset.change(assigned_agent_id: other_agent.id)
+        |> AdminRepo.update!()
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post("/api/v1/stories/#{other_story.id}/recover-cap", %{})
+
+      assert %{"error" => %{"status" => 404}} = json_response(conn, 404)
+      assert caps_for(other_story.id) == []
+    end
+
+    test "tenant isolation: cannot recover a cap for another tenant's story", %{conn: conn} do
+      %{raw_key: raw_key} = setup_ctx()
+      # A completely separate tenant with its own agent-owned story.
+      %{story: foreign_story} = setup_ctx()
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post("/api/v1/stories/#{foreign_story.id}/recover-cap", %{})
+
+      assert %{"error" => %{"status" => 404}} = json_response(conn, 404)
+      assert caps_for(foreign_story.id) == []
+    end
+  end
+end

--- a/test/loopctl_web/controllers/cap_recovery_controller_test.exs
+++ b/test/loopctl_web/controllers/cap_recovery_controller_test.exs
@@ -10,8 +10,10 @@ defmodule LoopctlWeb.CapRecoveryControllerTest do
   use LoopctlWeb.ConnCase, async: true
 
   import Ecto.Query
+  import ExUnit.CaptureLog
 
   alias Loopctl.AdminRepo
+  alias Loopctl.Audit.AuditLog
   alias Loopctl.Capabilities.CapabilityToken
   alias Loopctl.Dispatches.Dispatch
 
@@ -25,15 +27,29 @@ defmodule LoopctlWeb.CapRecoveryControllerTest do
     AdminRepo.all(from(c in CapabilityToken, where: c.story_id == ^story_id))
   end
 
-  defp insert_dispatch(tenant_id, agent_id, story_id, lineage) do
+  defp audit_entries(story_id, action) do
+    AdminRepo.all(
+      from(a in AuditLog,
+        where: a.entity_id == ^story_id and a.action == ^action
+      )
+    )
+  end
+
+  defp insert_dispatch(tenant_id, agent_id, story_id, lineage, extra) do
+    attrs =
+      Map.merge(
+        %{
+          role: :agent,
+          agent_id: agent_id,
+          story_id: story_id,
+          lineage_path: lineage,
+          expires_at: DateTime.add(DateTime.utc_now(), 3600, :second)
+        },
+        extra
+      )
+
     %Dispatch{tenant_id: tenant_id}
-    |> Dispatch.changeset(%{
-      role: :agent,
-      agent_id: agent_id,
-      story_id: story_id,
-      lineage_path: lineage,
-      expires_at: DateTime.add(DateTime.utc_now(), 3600, :second)
-    })
+    |> Dispatch.changeset(attrs)
     |> AdminRepo.insert!()
   end
 
@@ -59,15 +75,24 @@ defmodule LoopctlWeb.CapRecoveryControllerTest do
     epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
     agent = fixture(:agent, %{tenant_id: tenant.id})
 
+    role = Map.get(opts, :role, :agent)
+
     {raw_key, _api_key} =
-      fixture(:api_key, %{tenant_id: tenant.id, role: :agent, agent_id: agent.id})
+      fixture(:api_key, %{tenant_id: tenant.id, role: role, agent_id: agent.id})
 
     story = fixture(:story, %{tenant_id: tenant.id, epic_id: epic.id})
     lineage = [Ecto.UUID.generate(), Ecto.UUID.generate()]
 
     {story, recorded_lineage} =
       if Map.get(opts, :with_dispatch, true) do
-        dispatch = insert_dispatch(tenant.id, agent.id, story.id, lineage)
+        dispatch =
+          insert_dispatch(
+            tenant.id,
+            agent.id,
+            story.id,
+            lineage,
+            Map.get(opts, :dispatch_attrs, %{})
+          )
 
         story =
           story
@@ -203,6 +228,94 @@ defmodule LoopctlWeb.CapRecoveryControllerTest do
 
       assert %{"error" => %{"status" => 404}} = json_response(conn, 404)
       assert caps_for(foreign_story.id) == []
+    end
+  end
+
+  describe "POST /api/v1/stories/:id/recover-cap — exact_role gate" do
+    test "rejects an orchestrator key linked to the same agent_id with 403", %{conn: conn} do
+      # An orchestrator identity can be linked to the same agent_id as an
+      # implementer. The exact_role: :agent gate (matching claim/start) must
+      # not let it walk this custody endpoint via role hierarchy.
+      %{raw_key: orch_key, story: story} = setup_ctx(%{role: :orchestrator})
+
+      conn =
+        conn
+        |> auth_conn(orch_key)
+        |> post("/api/v1/stories/#{story.id}/recover-cap", %{})
+
+      assert %{"error" => %{"status" => 403}} = json_response(conn, 403)
+      assert caps_for(story.id) == []
+    end
+  end
+
+  describe "POST /api/v1/stories/:id/recover-cap — forgery-attempt observability" do
+    test "logs a warning and writes an audit entry on a forged cap_type", %{conn: conn} do
+      %{raw_key: raw_key, story: story, agent: agent} = setup_ctx()
+
+      log =
+        capture_log(fn ->
+          conn =
+            conn
+            |> auth_conn(raw_key)
+            |> post("/api/v1/stories/#{story.id}/recover-cap", %{"cap_type" => "verify_cap"})
+
+          assert %{"error" => %{"status" => 422}} = json_response(conn, 422)
+        end)
+
+      assert log =~ "cap_recovery_forgery_attempt"
+      assert log =~ "rejected_cap_type=\"verify_cap\""
+      assert log =~ story.id
+
+      # Surfaces in GET /stories/:id/history (Audit.entity_history reads this table)
+      assert [entry] = audit_entries(story.id, "cap_recovery_forgery_attempt")
+      assert entry.entity_type == "story"
+      assert entry.metadata["rejected_cap_type"] == "verify_cap"
+      assert entry.metadata["caller_agent_id"] == agent.id
+      assert caps_for(story.id) == []
+    end
+  end
+
+  describe "POST /api/v1/stories/:id/recover-cap — dispatch activeness" do
+    test "rejects recovery when the implementer dispatch is revoked", %{conn: conn} do
+      %{raw_key: raw_key, story: story} =
+        setup_ctx(%{dispatch_attrs: %{revoked_at: DateTime.utc_now()}})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post("/api/v1/stories/#{story.id}/recover-cap", %{})
+
+      assert %{"error" => %{"status" => 422, "message" => message}} = json_response(conn, 422)
+      assert message =~ "revoked"
+      assert caps_for(story.id) == []
+    end
+
+    test "rejects recovery when the implementer dispatch is expired", %{conn: conn} do
+      %{raw_key: raw_key, story: story} =
+        setup_ctx(%{
+          dispatch_attrs: %{expires_at: DateTime.add(DateTime.utc_now(), -60, :second)}
+        })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post("/api/v1/stories/#{story.id}/recover-cap", %{})
+
+      assert %{"error" => %{"status" => 422}} = json_response(conn, 422)
+      assert caps_for(story.id) == []
+    end
+
+    test "mints as usual when the implementer dispatch is active", %{conn: conn} do
+      %{raw_key: raw_key, story: story, lineage: lineage} = setup_ctx()
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post("/api/v1/stories/#{story.id}/recover-cap", %{})
+
+      assert %{"data" => data} = json_response(conn, 201)
+      assert data["typ"] == "start_cap"
+      assert data["issued_to_lineage"] == lineage
     end
   end
 end


### PR DESCRIPTION
## Summary

`POST /api/v1/stories/:id/recover-cap` (`CapRecoveryController`, agent role) took **both** `cap_type` and `lineage` straight from request params and passed them into `Capabilities.mint/4`, which signs whatever `typ`/`lineage` it is handed. The only gate was story ownership.

So an agent assigned to a story could POST `recover-cap` with `cap_type: "verify_cap"` (or `report_cap` / `review_complete_cap`) and an **attacker-chosen lineage**, and receive a `201` with a validly-signed capability bound to arbitrary lineage — forging the **L1 capability layer** that chain-of-custody v2 relies on (a cap to *verify/report/review* work it implemented). Latent today (no controller currently consumes a client-supplied `verify_cap`), but it breaks the L1 invariant.

## Fix (`lib/loopctl_web/controllers/cap_recovery_controller.ex`)

Recovery now:
- **re-mints ONLY a `start_cap`** — any other client-supplied `cap_type` is rejected `422` with no capability minted; an absent `cap_type` defaults to `start_cap`.
- **derives the lineage server-side** from the story's recorded implementer dispatch: `story.implementer_dispatch_id` -> `Dispatches.get_dispatch/2` -> `Dispatch.lineage_path`. The client-supplied `lineage` param is ignored entirely.
- **refuses** when the story has no recorded dispatch lineage (nil `implementer_dispatch_id` or empty `lineage_path`) — you cannot recover a cap for a story you weren't dispatched to.
- keeps the existing story-ownership / tenant scoping (`assigned_agent_id` + `tenant_id`).

`Capabilities.mint/4` stays general for legitimate internal server-side callers (`progress.ex` claim/report/verify flow, which hardcodes `typ` and derives lineage from the selected verifier's dispatch or `opts` defaulting to `[]`). The controller is the trust boundary. Grepped all `Capabilities.mint` callers: **no other user-facing endpoint** pipes a client `cap_type`/`lineage` into mint — no controller passes a `:lineage` opt into `Progress` (only hardcoded `actor_lineage: []`).

## Tests (`test/loopctl_web/controllers/cap_recovery_controller_test.exs`)

- `cap_type` `verify_cap` / `report_cap` / `review_complete_cap` -> `422`, nothing minted.
- No `cap_type` / explicit `start_cap` -> `201` with a `start_cap` bound to the **server-derived** dispatch lineage.
- Client-supplied `lineage` differing from the recorded one -> minted cap uses the **server** lineage; client value ignored.
- Caller with no recorded dispatch for the story -> `422`, nothing minted.
- Same-tenant story assigned to another agent -> `404`.
- Tenant isolation: cannot recover a cap for another tenant's story -> `404`.

`mix precommit` green via the commit hook: **3419 tests, 0 failures** (compile --warnings-as-errors, format, credo --strict, deps.audit, dialyzer all clean).

Refs advisory GHSA-w3j2-2w3r-hjcf.
