### PR TITLE
fix(auth): handle empty X-Impersonate-Tenant header gracefully (auth-01)

### DIFF
--- a/lib/loopctl_web/plugs/impersonate.ex
+++ b/lib/loopctl_web/plugs/impersonate.ex
@@ -99,6 +99,10 @@ defmodule LoopctlWeb.Plugs.Impersonate do
       # Empty header list (no header present)
       [] ->
         conn
+
+      # Empty header value (X-Impersonate-Tenant: "") — treat as if no header
+      [""] ->
+        conn
     end
   end
 

--- a/test/loopctl_web/plugs/impersonate_test.exs
+++ b/test/loopctl_web/plugs/impersonate_test.exs
@@ -150,5 +150,20 @@ defmodule LoopctlWeb.Plugs.ImpersonateTest do
       assert result.assigns.current_api_key.id == api_key.id
       assert result.assigns.current_api_key.role == :superadmin
     end
+
+    test "passes through on empty impersonation header without crashing", %{conn: conn} do
+      {raw_key, _} = fixture(:api_key, %{role: :superadmin})
+
+      # Empty header should not cause WithClauseError
+      result =
+        conn
+        |> impersonate_conn("")
+        |> resolve_and_auth(raw_key)
+        |> Impersonate.call([])
+
+      # Should pass through without halting or crashing
+      refute result.halted
+      refute Map.get(result.assigns, :impersonating)
+    end
   end
 end


### PR DESCRIPTION
## Summary
Fixed auth-01 crash: the impersonate plug's with-clause guard `[tenant_id] when tenant_id != ""` failed on empty `X-Impersonate-Tenant` header (becomes `[""]`), causing a WithClauseError → 500.

## Changes
- Added explicit `[""]` clause in the impersonate plug's else block to treat empty headers the same as missing headers
- Added regression test to verify empty headers pass through without crashing

## Testing
- All impersonate plug tests pass (9 tests)
- Full precommit suite passes (3425 tests)
- New test case: "passes through on empty impersonation header without crashing"

Fixes #auth-01