### PR TITLE
fix(auth): treat empty impersonation header as absent (auth-01)

### DIFF
--- a/lib/loopctl_web/plugs/impersonate.ex
+++ b/lib/loopctl_web/plugs/impersonate.ex
@@ -97,10 +97,6 @@ defmodule LoopctlWeb.Plugs.Impersonate do
       # non-impersonated pass-through.
       _ ->
         conn
-
-      # Empty header value (X-Impersonate-Tenant: "") — treat as if no header
-      [""] ->
-        conn
     end
   end
 

--- a/lib/loopctl_web/plugs/impersonate.ex
+++ b/lib/loopctl_web/plugs/impersonate.ex
@@ -53,8 +53,12 @@ defmodule LoopctlWeb.Plugs.Impersonate do
   end
 
   defp do_impersonate(conn) do
+    # Normalize the header FIRST so a malformed value can never reach (and blow
+    # up) the `with` chain. An absent, empty, or whitespace-only header — and any
+    # other non-normalizable shape — resolves to `nil`, which is treated exactly
+    # like an absent header: no impersonation, clean pass-through (never a 500).
     with %{current_api_key: %{role: :superadmin} = api_key} <- conn.assigns,
-         [tenant_id] when tenant_id != "" <- get_req_header(conn, "x-impersonate-tenant"),
+         tenant_id when is_binary(tenant_id) <- impersonate_tenant_id(conn),
          {:ok, tenant} <- lookup_tenant(tenant_id) do
       # Set RLS context for the impersonated tenant
       Repo.put_tenant_id(tenant.id)
@@ -81,24 +85,35 @@ defmodule LoopctlWeb.Plugs.Impersonate do
       |> assign(:impersonated_tenant_id, tenant.id)
       |> assign(:effective_role, effective_role)
     else
-      # Not superadmin, or no header — pass through silently
-      %{current_api_key: %{role: _role}} ->
-        conn
-
-      # No current_api_key at all — pass through (RequireAuth will catch)
-      %{} ->
-        conn
-
-      # Header present but tenant not found
+      # Superadmin supplied a header pointing at a tenant that does not exist.
       {:error, :not_found} ->
         conn
         |> put_status(:not_found)
         |> Phoenix.Controller.json(%{error: %{status: 404, message: "Tenant not found"}})
         |> halt()
 
-      # Empty header list (no header present)
-      [] ->
+      # Everything else — non-superadmin key, no/empty/whitespace header
+      # (tenant_id resolved to `nil`), or no current_api_key at all — is a clean
+      # non-impersonated pass-through.
+      _ ->
         conn
+    end
+  end
+
+  # Reads the X-Impersonate-Tenant header and normalizes it to a trimmed,
+  # non-empty tenant identifier, or `nil` when the header is absent, empty,
+  # whitespace-only, or otherwise unusable. An empty header therefore results
+  # in NO impersonation — it never impersonates tenant "" or a default tenant.
+  defp impersonate_tenant_id(conn) do
+    case get_req_header(conn, "x-impersonate-tenant") do
+      [value | _] when is_binary(value) ->
+        case String.trim(value) do
+          "" -> nil
+          trimmed -> trimmed
+        end
+
+      _ ->
+        nil
     end
   end
 

--- a/test/loopctl_web/plugs/impersonate_test.exs
+++ b/test/loopctl_web/plugs/impersonate_test.exs
@@ -104,6 +104,54 @@ defmodule LoopctlWeb.Plugs.ImpersonateTest do
       refute Map.get(result.assigns, :impersonating)
     end
 
+    test "passes through when impersonation header is empty (auth-01)", %{conn: conn} do
+      {raw_key, api_key} = fixture(:api_key, %{role: :superadmin})
+
+      result =
+        conn
+        |> impersonate_conn("")
+        |> resolve_and_auth(raw_key)
+        |> Impersonate.call([])
+
+      # Empty header must behave exactly like an absent header: no 500, no
+      # impersonation, and NOT impersonating tenant "" or a default tenant.
+      refute result.halted
+      refute Map.get(result.assigns, :impersonating)
+      refute Map.has_key?(result.assigns, :impersonated_tenant_id)
+      assert result.assigns.current_api_key.id == api_key.id
+      assert result.assigns.current_api_key.role == :superadmin
+    end
+
+    test "passes through when impersonation header is whitespace-only (auth-01)", %{conn: conn} do
+      {raw_key, _api_key} = fixture(:api_key, %{role: :superadmin})
+
+      result =
+        conn
+        |> impersonate_conn("   ")
+        |> resolve_and_auth(raw_key)
+        |> Impersonate.call([])
+
+      refute result.halted
+      refute Map.get(result.assigns, :impersonating)
+      refute Map.has_key?(result.assigns, :impersonated_tenant_id)
+      assert result.assigns.current_api_key.role == :superadmin
+    end
+
+    test "non-superadmin with empty impersonation header passes through", %{conn: conn} do
+      tenant_a = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant_a.id, role: :user})
+
+      result =
+        conn
+        |> impersonate_conn("")
+        |> resolve_and_auth(raw_key)
+        |> Impersonate.call([])
+
+      refute result.halted
+      refute Map.get(result.assigns, :impersonating)
+      assert result.assigns.current_tenant.id == tenant_a.id
+    end
+
     test "applies X-Effective-Role when present", %{conn: conn} do
       {raw_key, _} = fixture(:api_key, %{role: :superadmin})
       tenant = fixture(:tenant)


### PR DESCRIPTION
## Summary

Fixes **auth-01** (MEDIUM, crash): an `X-Impersonate-Tenant` header that is present but **empty** (or whitespace-only) raised a `WithClauseError` → unhandled **500**.

`get_req_header(conn, "x-impersonate-tenant")` returns `[""]` for an empty header. The `do_impersonate/1` `with`-chain required `[tenant_id] when tenant_id != ""`, so `[""]` matched neither the main clause nor any `else` clause (the else only handled map / `{:error, :not_found}` / `[]` shapes) → `WithClauseError`.

## Fix

Normalize the header **before** the `with` (approach a). A new `impersonate_tenant_id/1` helper reads the header, takes the first value, `String.trim`s it, and resolves **empty / whitespace-only / absent / non-binary** to `nil`. A `nil` tenant id fails the `is_binary/1` guard and falls through a single catch-all `else` clause as a clean, **non-impersonated pass-through** — identical to an absent header.

An empty header can therefore **never** impersonate tenant `""` or a default tenant. No malformed header value (empty, whitespace, multiple values, non-string) can raise.

## Behavior preserved

- Valid tenant slug/id → impersonation still works.
- Non-existent tenant → still `404` (not a 500).
- Superadmin-only role gate untouched; a non-superadmin supplying any header still passes through with no impersonation.

## Tests

Added to `test/loopctl_web/plugs/impersonate_test.exs`:
- superadmin + empty header → pass-through, no 500, no impersonation, no `impersonated_tenant_id` assign, key/role unchanged.
- superadmin + whitespace-only header → same pass-through.
- non-superadmin + empty header → pass-through, keeps own tenant.

Existing valid / 404 / non-superadmin / effective-role / admin-route cases remain green.

Full gate green via pre-commit hook: compile `--warnings-as-errors`, format, `credo --strict` (found no issues), dialyzer (passed successfully), `mix test` → **3427 tests, 0 failures**.

Refs public issue #238 (auth-01).