### PR TITLE
fix(knowledge): validate project_id param -> 4xx instead of CastError 500 (kbweb-01)

### DIFF
--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -1009,12 +1009,7 @@ defmodule Loopctl.Knowledge do
         where: a.status == :published
       )
 
-    base =
-      if project_id do
-        where(base, [a], is_nil(a.project_id) or a.project_id == ^project_id)
-      else
-        base
-      end
+    base = scope_project_or_global(base, project_id)
 
     base =
       base
@@ -1187,12 +1182,7 @@ defmodule Loopctl.Knowledge do
         where: a.status == :published
       )
 
-    base =
-      if project_id do
-        where(base, [a], is_nil(a.project_id) or a.project_id == ^project_id)
-      else
-        base
-      end
+    base = scope_project_or_global(base, project_id)
 
     base
     |> maybe_filter_by_category(Keyword.get(opts, :category))
@@ -1252,12 +1242,7 @@ defmodule Loopctl.Knowledge do
 
     base = from(a in Article, where: a.tenant_id == ^tenant_id)
 
-    base =
-      if project_id do
-        where(base, [a], is_nil(a.project_id) or a.project_id == ^project_id)
-      else
-        base
-      end
+    base = scope_project_or_global(base, project_id)
 
     # Visibility (#163): an agent's stats never count another agent's private memories.
     base = maybe_filter_by_visibility(base, Keyword.get(opts, :visibility_agent_id))
@@ -2760,6 +2745,21 @@ defmodule Loopctl.Knowledge do
 
   defp valid_uuid?(id) when is_binary(id), do: match?({:ok, _}, Ecto.UUID.cast(id))
   defp valid_uuid?(_), do: false
+
+  # Applies the "tenant-wide (nil project) OR this project" scope on the `[a]`
+  # (Article) binding, guarding the :binary_id cast. A non-UUID project_id would
+  # raise Ecto.Query.CastError on the `== ^project_id` comparison; a malformed
+  # value scopes to tenant-wide articles only rather than crashing (callers 4xx
+  # at the boundary — this is defense in depth).
+  defp scope_project_or_global(query, nil), do: query
+
+  defp scope_project_or_global(query, project_id) do
+    if valid_uuid?(project_id) do
+      where(query, [a], is_nil(a.project_id) or a.project_id == ^project_id)
+    else
+      where(query, [a], is_nil(a.project_id))
+    end
+  end
 
   # Per-id outcome, in request order. Precedence: errored > published > existing-state.
   defp bulk_publish_result(id, existing, published_ids, errored_set) do
@@ -4891,15 +4891,18 @@ defmodule Loopctl.Knowledge do
   defp validate_project_ownership(_tenant_id, nil), do: :ok
 
   defp validate_project_ownership(tenant_id, project_id) do
-    case AdminRepo.get_by(Project, id: project_id, tenant_id: tenant_id) do
-      nil ->
-        {:error,
-         %Article{}
-         |> Ecto.Changeset.change()
-         |> Ecto.Changeset.add_error(:project_id, "does not belong to this tenant")}
-
-      _project ->
-        :ok
+    # `id: project_id` on a :binary_id column raises Ecto.Query.CastError for a
+    # non-UUID value (a malformed string, or a non-string from a JSON body). Guard
+    # the cast so create/update (and OKF import via create_article/update_article)
+    # return the changeset error -> a clean 422, never a 500.
+    if valid_uuid?(project_id) and
+         not is_nil(AdminRepo.get_by(Project, id: project_id, tenant_id: tenant_id)) do
+      :ok
+    else
+      {:error,
+       %Article{}
+       |> Ecto.Changeset.change()
+       |> Ecto.Changeset.add_error(:project_id, "is invalid or does not belong to this tenant")}
     end
   end
 
@@ -6056,21 +6059,30 @@ defmodule Loopctl.Knowledge do
         }
       )
 
-    links_query =
-      if project_id do
-        from([al, src, tgt] in links_query,
-          where:
-            (is_nil(src.project_id) or src.project_id == ^project_id) and
-              (is_nil(tgt.project_id) or tgt.project_id == ^project_id)
-        )
-      else
-        links_query
-      end
-
-    links = AdminRepo.all(links_query)
+    links = links_query |> scope_contradiction_links(project_id) |> AdminRepo.all()
 
     # Build clusters using union-find approach (group connected articles)
     build_contradiction_clusters(links)
+  end
+
+  # Scope contradiction links to a project, guarding the :binary_id cast. A
+  # non-UUID project_id (e.g. `?project_id[]=x` decodes to a truthy list) would
+  # otherwise CastError-500 on the `== ^project_id` comparison; a malformed value
+  # scopes to tenant-wide (nil-project) links only rather than crashing.
+  defp scope_contradiction_links(query, nil), do: query
+
+  defp scope_contradiction_links(query, project_id) do
+    if valid_uuid?(project_id) do
+      from([al, src, tgt] in query,
+        where:
+          (is_nil(src.project_id) or src.project_id == ^project_id) and
+            (is_nil(tgt.project_id) or tgt.project_id == ^project_id)
+      )
+    else
+      from([al, src, tgt] in query,
+        where: is_nil(src.project_id) and is_nil(tgt.project_id)
+      )
+    end
   end
 
   defp build_contradiction_clusters([]), do: []

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -4966,7 +4966,16 @@ defmodule Loopctl.Knowledge do
   defp maybe_filter_by_project_id(query, nil), do: query
 
   defp maybe_filter_by_project_id(query, project_id) do
-    where(query, [a], a.project_id == ^project_id)
+    # Defense in depth: `project_id` is a `:binary_id` column, so a non-UUID
+    # value would make `Ecto.UUID.dump/1` fail and raise `Ecto.Query.CastError`
+    # (an unhandled 500). Callers validate at the API boundary and 422 first, but
+    # a malformed value reaching here must not crash — treat it as "matches
+    # nothing", consistent with a valid-but-nonexistent project.
+    if valid_uuid?(project_id) do
+      where(query, [a], a.project_id == ^project_id)
+    else
+      where(query, [a], false)
+    end
   end
 
   defp maybe_filter_by_category(query, nil), do: query
@@ -5930,11 +5939,21 @@ defmodule Loopctl.Knowledge do
   end
 
   defp published_base_query(tenant_id, project_id) do
-    from(a in Article,
-      where: a.tenant_id == ^tenant_id,
-      where: a.status == :published,
-      where: is_nil(a.project_id) or a.project_id == ^project_id
-    )
+    base =
+      from(a in Article,
+        where: a.tenant_id == ^tenant_id,
+        where: a.status == :published
+      )
+
+    # Defense in depth: a non-UUID project_id would raise Ecto.Query.CastError on
+    # the `== ^project_id` binary_id comparison. Callers 422 before reaching here;
+    # a malformed value that slips through scopes to tenant-wide articles only
+    # (nil project) rather than crashing.
+    if valid_uuid?(project_id) do
+      where(base, [a], is_nil(a.project_id) or a.project_id == ^project_id)
+    else
+      where(base, [a], is_nil(a.project_id))
+    end
   end
 
   defp find_stale_articles(base, stale_days) do

--- a/lib/loopctl/knowledge/okf.ex
+++ b/lib/loopctl/knowledge/okf.ex
@@ -176,10 +176,19 @@ defmodule Loopctl.Knowledge.OKF do
   defp export_query(tenant_id, project_id) do
     query = from(a in Article, where: a.tenant_id == ^tenant_id and a.status == :published)
 
-    if project_id do
-      where(query, [a], is_nil(a.project_id) or a.project_id == ^project_id)
-    else
-      query
+    # Guard the :binary_id cast: a non-UUID project_id (malformed string, or a
+    # non-string that is truthy) would CastError-500 on the `== ^project_id`
+    # comparison — and for the ?format=json export path, AFTER the buffered
+    # bundle build starts. A malformed value scopes to tenant-wide only.
+    cond do
+      is_nil(project_id) ->
+        query
+
+      valid_uuid?(project_id) ->
+        where(query, [a], is_nil(a.project_id) or a.project_id == ^project_id)
+
+      true ->
+        where(query, [a], is_nil(a.project_id))
     end
   end
 
@@ -620,7 +629,20 @@ defmodule Loopctl.Knowledge.OKF do
   end
 
   defp scope_project(query, nil), do: where(query, [a], is_nil(a.project_id))
-  defp scope_project(query, project_id), do: where(query, [a], a.project_id == ^project_id)
+
+  # Guard the :binary_id cast for the import loopctl_id lookup: a non-UUID
+  # top-level project_id would CastError-500 on `== ^project_id`. A malformed
+  # value matches nothing (no article belongs to a bogus project).
+  defp scope_project(query, project_id) do
+    if valid_uuid?(project_id) do
+      where(query, [a], a.project_id == ^project_id)
+    else
+      where(query, [a], false)
+    end
+  end
+
+  defp valid_uuid?(value) when is_binary(value), do: match?({:ok, _}, Ecto.UUID.cast(value))
+  defp valid_uuid?(_), do: false
 
   # Parse one concept file into create_article attrs.
   defp parse_concept(path, content) do

--- a/lib/loopctl/knowledge/streaming_export.ex
+++ b/lib/loopctl/knowledge/streaming_export.ex
@@ -473,12 +473,25 @@ defmodule Loopctl.Knowledge.StreamingExport do
   def base_query(tenant_id, project_id) do
     query = from(a in Article, where: a.tenant_id == ^tenant_id and a.status == :published)
 
-    if project_id do
-      where(query, [a], is_nil(a.project_id) or a.project_id == ^project_id)
-    else
-      query
+    cond do
+      is_nil(project_id) ->
+        query
+
+      # Defense in depth: `project_id` is a `:binary_id` column, so a non-UUID
+      # value would raise Ecto.Query.CastError on the `== ^project_id` comparison
+      # — and here it would do so AFTER `send_chunked` already committed a 200,
+      # truncating the archive. The controller 422s before streaming; a malformed
+      # value that still reaches here scopes to tenant-wide articles only.
+      valid_uuid?(project_id) ->
+        where(query, [a], is_nil(a.project_id) or a.project_id == ^project_id)
+
+      true ->
+        where(query, [a], is_nil(a.project_id))
     end
   end
+
+  defp valid_uuid?(value) when is_binary(value), do: match?({:ok, _}, Ecto.UUID.cast(value))
+  defp valid_uuid?(_), do: false
 
   # The `(inserted_at, id)` keyset seek, shared with the article/index/change-feed
   # keysets via Loopctl.KeysetSeek (the load-bearing type/2 annotations live there).

--- a/lib/loopctl/knowledge/vector_search.ex
+++ b/lib/loopctl/knowledge/vector_search.ex
@@ -493,8 +493,16 @@ defmodule Loopctl.Knowledge.VectorSearch do
   # the index-ordered subquery would defeat HNSW (same class as tags/category).
   defp maybe_filter_by_project(query, nil), do: query
 
-  defp maybe_filter_by_project(query, project_id) when is_binary(project_id),
-    do: where(query, [c], c.project_id == ^project_id)
+  defp maybe_filter_by_project(query, project_id) when is_binary(project_id) do
+    # Guard the :binary_id cast (defense in depth — the search controller 4xxs a
+    # malformed project_id first). A non-UUID value matches nothing, mirroring
+    # Loopctl.Knowledge.maybe_filter_by_project_id/2, rather than CastError-500.
+    if valid_uuid?(project_id) do
+      where(query, [c], c.project_id == ^project_id)
+    else
+      where(query, [c], false)
+    end
+  end
 
   # "Same-project OR tenant-wide" project scope on the OUTER pool — the auto-link
   # worker's `scope_by_project/2` semantics (US-21.2.3): a project-scoped source
@@ -504,8 +512,15 @@ defmodule Loopctl.Knowledge.VectorSearch do
   # `maybe_filter_by_project/2`.
   defp maybe_filter_by_project_or_global(query, nil), do: query
 
-  defp maybe_filter_by_project_or_global(query, project_id) when is_binary(project_id),
-    do: where(query, [c], c.project_id == ^project_id or is_nil(c.project_id))
+  defp maybe_filter_by_project_or_global(query, project_id) when is_binary(project_id) do
+    # Guard the :binary_id cast. A malformed value scopes to tenant-wide
+    # (`project_id IS NULL`) rows only rather than CastError-500.
+    if valid_uuid?(project_id) do
+      where(query, [c], c.project_id == ^project_id or is_nil(c.project_id))
+    else
+      where(query, [c], is_nil(c.project_id))
+    end
+  end
 
   # Same agent-visibility metadata predicate as the other knowledge reads
   # (Loopctl.Knowledge.maybe_filter_by_visibility/2), on the `[a]` binding.
@@ -519,6 +534,10 @@ defmodule Loopctl.Knowledge.VectorSearch do
         fragment("?->>'agent_id' = ?", a.metadata, ^agent_id)
     )
   end
+
+  # Only ever called from the `is_binary(project_id)`-guarded clauses above, so a
+  # single binary clause suffices (a catch-all would be dead code).
+  defp valid_uuid?(value) when is_binary(value), do: match?({:ok, _}, Ecto.UUID.cast(value))
 
   # --- outer (over-the-pool) anti-join: already-linked, both directions ---
 

--- a/lib/loopctl/projects.ex
+++ b/lib/loopctl/projects.ex
@@ -98,14 +98,26 @@ defmodule Loopctl.Projects do
   - `{:ok, %Project{}}` if found
   - `{:error, :not_found}` if not found or belongs to another tenant
   """
-  @spec get_project(Ecto.UUID.t(), Ecto.UUID.t()) ::
+  @spec get_project(Ecto.UUID.t(), term()) ::
           {:ok, Project.t()} | {:error, :not_found}
   def get_project(tenant_id, project_id) do
-    case AdminRepo.get_by(Project, id: project_id, tenant_id: tenant_id) do
-      nil -> {:error, :not_found}
-      project -> {:ok, project}
+    # `id: project_id` on a :binary_id column raises Ecto.Query.CastError for a
+    # non-UUID value (a malformed path segment reaches here from the many
+    # `/projects/:project_id/*` endpoints that scope through this function). Guard
+    # the cast so a malformed project_id is a clean :not_found (-> 404), never a
+    # 500. This is the shared chokepoint for project-scoped work-breakdown reads.
+    if valid_uuid?(project_id) do
+      case AdminRepo.get_by(Project, id: project_id, tenant_id: tenant_id) do
+        nil -> {:error, :not_found}
+        project -> {:ok, project}
+      end
+    else
+      {:error, :not_found}
     end
   end
+
+  defp valid_uuid?(value) when is_binary(value), do: match?({:ok, _}, Ecto.UUID.cast(value))
+  defp valid_uuid?(_), do: false
 
   @doc """
   Gets a project by slug, scoped to a tenant.

--- a/lib/loopctl/workers/content_ingestion_worker.ex
+++ b/lib/loopctl/workers/content_ingestion_worker.ex
@@ -66,7 +66,9 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
       }) do
     url = args["url"]
     raw_content = args["content"]
-    project_id = args["project_id"]
+    # Normalize "" -> nil (a blank project_id is "tenant-wide", not a value to dump
+    # against the :binary_id column).
+    project_id = normalize_project_id(args["project_id"])
     # Default draft; publish only when the ingest request opted in (#133).
     publish = args["publish"] == true
 
@@ -74,12 +76,33 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
     # source_id must be a UUID (:binary_id), so we derive one from the hash.
     source_id = derive_source_id(content_hash)
 
-    with {:ok, content} <- resolve_content(url, raw_content),
+    # Defense in depth (the controller boundary validates before enqueueing): a
+    # malformed / non-string project_id would raise Ecto.ChangeError on insert and,
+    # because the uniqueness key excludes project_id, crash-loop as a poison pill.
+    # DISCARD such a job (no retry) BEFORE any fetch/LLM work rather than raising.
+    with :ok <- validate_project_id(project_id),
+         {:ok, content} <- resolve_content(url, raw_content),
          {:ok, raw_articles} <- extract_with_chunking(content, source_type) do
       articles = validate_and_filter(raw_articles)
       insert_articles(tenant_id, source_id, source_type, project_id, articles, url, publish)
     end
   end
+
+  # nil (tenant-wide) or a valid UUID is fine; anything else is a poison pill —
+  # discard it cleanly (no 3x retry), never raise.
+  defp validate_project_id(nil), do: :ok
+
+  defp validate_project_id(project_id) when is_binary(project_id) do
+    if valid_uuid?(project_id), do: :ok, else: {:discard, {:invalid_project_id, project_id}}
+  end
+
+  defp validate_project_id(other), do: {:discard, {:invalid_project_id, other}}
+
+  defp normalize_project_id(""), do: nil
+  defp normalize_project_id(value), do: value
+
+  defp valid_uuid?(value) when is_binary(value), do: match?({:ok, _}, Ecto.UUID.cast(value))
+  defp valid_uuid?(_), do: false
 
   @impl Oban.Worker
   def backoff(%Oban.Job{attempt: attempt}) do
@@ -344,8 +367,13 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
           status: status
         }
 
+        # perform/1 already discarded jobs with an invalid project_id; this
+        # valid_uuid? guard is defense in depth so the raw struct assign can NEVER
+        # dump a non-UUID against the :binary_id column (a pre-existing queued job
+        # replayed through an older path would otherwise raise). A non-UUID here
+        # falls back to tenant-wide rather than crashing.
         article =
-          if project_id do
+          if valid_uuid?(project_id) do
             %{article | project_id: project_id}
           else
             article

--- a/lib/loopctl_web/controllers/article_controller.ex
+++ b/lib/loopctl_web/controllers/article_controller.ex
@@ -20,6 +20,7 @@ defmodule LoopctlWeb.ArticleController do
   alias LoopctlWeb.ArticleJSON
   alias LoopctlWeb.AuditContext
   alias LoopctlWeb.Helpers.Pagination
+  alias LoopctlWeb.Helpers.ProjectId
   alias LoopctlWeb.Helpers.TagMatch
   alias LoopctlWeb.Helpers.Visibility
 
@@ -451,7 +452,8 @@ defmodule LoopctlWeb.ArticleController do
 
     # Validate enum-typed filters up front: an unknown value is a client error
     # (400 with the allowed values), not a 404/500 from an Ecto.Enum cast failure.
-    with :ok <- validate_enum(params["status"], @valid_statuses, "status"),
+    with :ok <- ProjectId.validate(params["project_id"]),
+         :ok <- validate_enum(params["status"], @valid_statuses, "status"),
          :ok <- validate_enum(params["category"], @valid_categories, "category"),
          {:ok, effective_limit} <- Pagination.validate_limit(params),
          {:ok, match} <- TagMatch.parse(params) do
@@ -475,6 +477,12 @@ defmodule LoopctlWeb.ArticleController do
       result = Knowledge.list_articles(tenant_id, opts)
       json(conn, ArticleJSON.index(%{articles: result.data, meta: result.meta}))
     else
+      # ProjectId.validate/1 returns {:error, :unprocessable_entity, message};
+      # delegate it to the FallbackController (422). Matched before the enum
+      # clause below because that one also has a 3-element error shape.
+      {:error, :unprocessable_entity, _message} = error ->
+        error
+
       {:error, field, allowed} ->
         conn
         |> put_status(:bad_request)

--- a/lib/loopctl_web/controllers/article_controller.ex
+++ b/lib/loopctl_web/controllers/article_controller.ex
@@ -267,38 +267,47 @@ defmodule LoopctlWeb.ArticleController do
         }
       })
     else
-      tenant_id = api_key.tenant_id
-      audit_opts = AuditContext.from_conn(conn)
-
-      # If project_id comes from the path (project-scoped route), merge it into
-      # attrs, then set the initial status server-side (never trusting the
-      # caller's `status`): published by default, draft only when the caller
-      # explicitly opted in via draft:true / status:"draft".
-      attrs =
-        params
-        |> maybe_merge_project_id(params["project_id"])
-        |> put_create_status(draft?)
-
-      # Trust model (#163): an agent may only write a memory under its OWN verified
-      # key identity. For agent-role writers that carry agent-memory metadata, stamp
-      # metadata.agent_id from the key (overriding any spoofed value); an agent with
-      # no key identity can't attribute a memory → 403.
-      case bind_agent_identity(api_key, attrs) do
-        {:ok, bound_attrs} ->
-          create_article(conn, tenant_id, bound_attrs, audit_opts, draft?, gate?)
-
-        {:error, :no_agent_identity} ->
-          conn
-          |> put_status(:forbidden)
-          |> json(%{
-            error: %{
-              status: 403,
-              code: "agent_identity_required",
-              message:
-                "This API key has no agent identity; it cannot write an attributed agent memory"
-            }
-          })
+      # Validate project_id (path segment or JSON body) up front so a non-UUID
+      # value returns a clean 422 instead of reaching validate_project_ownership/2
+      # and raising Ecto.Query.CastError (500).
+      with :ok <- ProjectId.validate(params["project_id"]) do
+        create_validated(conn, api_key, params, draft?, gate?)
       end
+    end
+  end
+
+  defp create_validated(conn, api_key, params, draft?, gate?) do
+    tenant_id = api_key.tenant_id
+    audit_opts = AuditContext.from_conn(conn)
+
+    # If project_id comes from the path (project-scoped route), merge it into
+    # attrs, then set the initial status server-side (never trusting the caller's
+    # `status`): published by default, draft only when the caller explicitly opted
+    # in via draft:true / status:"draft".
+    attrs =
+      params
+      |> maybe_merge_project_id(params["project_id"])
+      |> put_create_status(draft?)
+
+    # Trust model (#163): an agent may only write a memory under its OWN verified
+    # key identity. For agent-role writers that carry agent-memory metadata, stamp
+    # metadata.agent_id from the key (overriding any spoofed value); an agent with
+    # no key identity can't attribute a memory → 403.
+    case bind_agent_identity(api_key, attrs) do
+      {:ok, bound_attrs} ->
+        create_article(conn, tenant_id, bound_attrs, audit_opts, draft?, gate?)
+
+      {:error, :no_agent_identity} ->
+        conn
+        |> put_status(:forbidden)
+        |> json(%{
+          error: %{
+            status: 403,
+            code: "agent_identity_required",
+            message:
+              "This API key has no agent identity; it cannot write an attributed agent memory"
+          }
+        })
     end
   end
 
@@ -525,28 +534,32 @@ defmodule LoopctlWeb.ArticleController do
     tenant_id = conn.assigns.current_api_key.tenant_id
     audit_opts = AuditContext.from_conn(conn)
 
-    attrs =
-      params
-      |> Map.take([
-        "title",
-        "body",
-        "category",
-        "status",
-        "tags",
-        "metadata",
-        "project_id"
-      ])
-      |> Map.reject(fn {_k, v} -> is_nil(v) end)
+    # Validate a caller-supplied project_id (body) before it reaches
+    # validate_project_ownership/2, so a non-UUID returns 422, not a CastError 500.
+    with :ok <- ProjectId.validate(params["project_id"]) do
+      attrs =
+        params
+        |> Map.take([
+          "title",
+          "body",
+          "category",
+          "status",
+          "tags",
+          "metadata",
+          "project_id"
+        ])
+        |> Map.reject(fn {_k, v} -> is_nil(v) end)
 
-    case Knowledge.update_article(tenant_id, article_id, attrs, audit_opts) do
-      {:ok, article} ->
-        json(conn, ArticleJSON.update(%{article: article}))
+      case Knowledge.update_article(tenant_id, article_id, attrs, audit_opts) do
+        {:ok, article} ->
+          json(conn, ArticleJSON.update(%{article: article}))
 
-      {:error, :not_found} ->
-        {:error, :not_found}
+        {:error, :not_found} ->
+          {:error, :not_found}
 
-      {:error, %Ecto.Changeset{} = changeset} ->
-        {:error, changeset}
+        {:error, %Ecto.Changeset{} = changeset} ->
+          {:error, changeset}
+      end
     end
   end
 

--- a/lib/loopctl_web/controllers/knowledge_context_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_context_controller.ex
@@ -22,6 +22,7 @@ defmodule LoopctlWeb.KnowledgeContextController do
   alias Loopctl.ApiSpec.Schemas
   alias Loopctl.Knowledge
   alias Loopctl.Knowledge.Article
+  alias LoopctlWeb.Helpers.ProjectId
   alias LoopctlWeb.Helpers.Visibility
 
   action_fallback LoopctlWeb.FallbackController
@@ -132,7 +133,8 @@ defmodule LoopctlWeb.KnowledgeContextController do
     api_key_id = conn.assigns.current_api_key.id
     role = conn.assigns.current_api_key.role
 
-    with {:ok, query} <- validate_query(params) do
+    with :ok <- ProjectId.validate(params["project_id"]),
+         {:ok, query} <- validate_query(params) do
       opts =
         params
         |> build_opts(role)

--- a/lib/loopctl_web/controllers/knowledge_export_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_export_controller.ex
@@ -25,6 +25,7 @@ defmodule LoopctlWeb.KnowledgeExportController do
 
   alias Loopctl.ApiSpec.Schemas
   alias Loopctl.Knowledge.StreamingExport.ObsidianFormat
+  alias LoopctlWeb.Helpers.ProjectId
 
   action_fallback LoopctlWeb.FallbackController
 
@@ -64,18 +65,24 @@ defmodule LoopctlWeb.KnowledgeExportController do
   def export(conn, params) do
     tenant_id = conn.assigns.current_api_key.tenant_id
 
-    opts =
-      case params["project_id"] do
-        nil -> []
-        project_id -> [project_id: project_id]
-      end
+    # Validate project_id BEFORE streaming: `send_chunked/2` commits a 200 with
+    # no way back to an error status, so a malformed project_id reaching the
+    # query would raise mid-stream and truncate the archive. Reject it here so
+    # the FallbackController can return a clean 422 before any body is sent.
+    with :ok <- ProjectId.validate(params["project_id"]) do
+      opts =
+        case params["project_id"] do
+          value when value in [nil, ""] -> []
+          project_id -> [project_id: project_id]
+        end
 
-    LoopctlWeb.StreamingExport.stream(
-      conn,
-      tenant_id,
-      ObsidianFormat,
-      "knowledge-export",
-      opts
-    )
+      LoopctlWeb.StreamingExport.stream(
+        conn,
+        tenant_id,
+        ObsidianFormat,
+        "knowledge-export",
+        opts
+      )
+    end
   end
 end

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -15,6 +15,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   alias Loopctl.Net.UrlGuard
   alias Loopctl.Workers.ContentIngestionWorker
   alias LoopctlWeb.Helpers.Pagination
+  alias LoopctlWeb.Helpers.ProjectId
 
   action_fallback LoopctlWeb.FallbackController
 
@@ -331,7 +332,9 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     url = params["url"]
     content = params["content"]
     source_type = params["source_type"]
-    project_id = params["project_id"]
+    # Normalize "" -> nil (absent) so a blank project_id never becomes a truthy
+    # job arg that the worker would try to dump against the :binary_id column.
+    project_id = blank_to_nil(params["project_id"])
     metadata = params["metadata"]
     # Ingested (LLM-extracted) articles stay DRAFT by default — they're
     # lower-trust and meant for review. Opt in with publish: true to have the
@@ -339,7 +342,12 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     # default for ingest). Only true/"true" enables it; anything else is draft.
     publish = params["publish"] == true or params["publish"] == "true"
 
-    with :ok <- validate_content_source(url, content),
+    # Validate project_id at the boundary so a malformed / non-string value is a
+    # clean 422 (or per-item batch error) and NEVER becomes a queued job — a job
+    # carrying a non-UUID project_id would crash the worker on Ecto dump and, since
+    # the uniqueness key excludes project_id, crash-loop as a poison pill.
+    with :ok <- validate_ingest_project_id(project_id),
+         :ok <- validate_content_source(url, content),
          :ok <- validate_source_type(source_type),
          :ok <- validate_url_egress(url) do
       content_hash = compute_content_hash(url || content)
@@ -433,6 +441,22 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
 
   defp validate_content_source(_url, nil), do: :ok
   defp validate_content_source(nil, _content), do: :ok
+
+  # Ingestion is a WRITE path: a non-UUID project_id becomes a poison-pill job, so
+  # be strict — nil/"" is absent (:ok), a valid UUID is :ok, and anything else
+  # (malformed string OR a non-string list/map from a JSON array/object body) is a
+  # 422. Unlike the read-path helper, non-strings are rejected here rather than
+  # tolerated, since they would still enqueue a crashing job.
+  defp validate_ingest_project_id(value) when is_nil(value) or is_binary(value) do
+    ProjectId.validate(value)
+  end
+
+  defp validate_ingest_project_id(_non_string) do
+    {:error, :unprocessable_entity, "Invalid project_id: must be a valid UUID"}
+  end
+
+  defp blank_to_nil(""), do: nil
+  defp blank_to_nil(value), do: value
 
   defp validate_source_type(nil) do
     {:error, :unprocessable_entity, "'source_type' is required"}

--- a/lib/loopctl_web/controllers/knowledge_lint_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_lint_controller.ex
@@ -17,6 +17,7 @@ defmodule LoopctlWeb.KnowledgeLintController do
 
   alias Loopctl.ApiSpec.Schemas
   alias Loopctl.Knowledge
+  alias LoopctlWeb.Helpers.ProjectId
 
   action_fallback LoopctlWeb.FallbackController
 
@@ -99,17 +100,17 @@ defmodule LoopctlWeb.KnowledgeLintController do
   end
 
   defp parse_lint_params(params) do
-    opts = []
+    with :ok <- ProjectId.validate(params["project_id"]) do
+      opts =
+        case params["project_id"] do
+          value when value in [nil, ""] -> []
+          project_id -> [project_id: project_id]
+        end
 
-    opts =
-      case params["project_id"] do
-        nil -> opts
-        project_id -> Keyword.put(opts, :project_id, project_id)
+      with {:ok, opts} <- parse_stale_days(params, opts),
+           {:ok, opts} <- parse_min_coverage(params, opts) do
+        parse_max_per_category(params, opts)
       end
-
-    with {:ok, opts} <- parse_stale_days(params, opts),
-         {:ok, opts} <- parse_min_coverage(params, opts) do
-      parse_max_per_category(params, opts)
     end
   end
 

--- a/lib/loopctl_web/controllers/knowledge_search_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_search_controller.ex
@@ -20,6 +20,7 @@ defmodule LoopctlWeb.KnowledgeSearchController do
   alias Loopctl.Knowledge
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.ArticleCursor
+  alias LoopctlWeb.Helpers.ProjectId
   alias LoopctlWeb.Helpers.TagMatch
   alias LoopctlWeb.Helpers.Visibility
 
@@ -400,7 +401,8 @@ defmodule LoopctlWeb.KnowledgeSearchController do
   defp validate_mode(_), do: {:ok, "combined"}
 
   defp build_opts(params) do
-    with {:ok, category} <- validate_category(params["category"]),
+    with :ok <- ProjectId.validate(params["project_id"]),
+         {:ok, category} <- validate_category(params["category"]),
          {:ok, match} <- TagMatch.parse(params) do
       opts =
         []

--- a/lib/loopctl_web/controllers/okf_controller.ex
+++ b/lib/loopctl_web/controllers/okf_controller.ex
@@ -22,6 +22,7 @@ defmodule LoopctlWeb.OKFController do
   alias Loopctl.ApiSpec.Schemas
   alias Loopctl.Knowledge.OKF
   alias Loopctl.Knowledge.StreamingExport.OKFFormat
+  alias LoopctlWeb.Helpers.ProjectId
 
   action_fallback LoopctlWeb.FallbackController
 
@@ -75,6 +76,28 @@ defmodule LoopctlWeb.OKFController do
     # path, which has NO count cap).
     tenant_id = conn.assigns.current_api_key.tenant_id
 
+    with :ok <- ProjectId.validate(params["project_id"]) do
+      export_json(conn, tenant_id, params)
+    end
+  end
+
+  def export(conn, params) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+
+    # Validate BEFORE streaming: send_chunked commits a 200 with no way back to an
+    # error status, so a malformed project_id must be rejected up front.
+    with :ok <- ProjectId.validate(params["project_id"]) do
+      LoopctlWeb.StreamingExport.stream(
+        conn,
+        tenant_id,
+        OKFFormat,
+        "okf-bundle",
+        export_opts(params)
+      )
+    end
+  end
+
+  defp export_json(conn, tenant_id, params) do
     case OKF.build_bundle(tenant_id, export_opts(params)) do
       {:ok, %{files: files, meta: meta}} ->
         json(conn, %{data: %{files: files, meta: meta}})
@@ -93,18 +116,6 @@ defmodule LoopctlWeb.OKFController do
           }
         })
     end
-  end
-
-  def export(conn, params) do
-    tenant_id = conn.assigns.current_api_key.tenant_id
-
-    LoopctlWeb.StreamingExport.stream(
-      conn,
-      tenant_id,
-      OKFFormat,
-      "okf-bundle",
-      export_opts(params)
-    )
   end
 
   operation(:import,
@@ -153,7 +164,8 @@ defmodule LoopctlWeb.OKFController do
   def import(conn, params) do
     api_key = conn.assigns.current_api_key
 
-    with {:ok, files} <- fetch_files(params),
+    with :ok <- ProjectId.validate(params["project_id"]),
+         {:ok, files} <- fetch_files(params),
          {:ok, report} <- OKF.import_files(api_key.tenant_id, files, import_opts(params, api_key)) do
       json(conn, %{data: report})
     else
@@ -169,7 +181,7 @@ defmodule LoopctlWeb.OKFController do
 
   defp export_opts(params) do
     case params["project_id"] do
-      nil -> []
+      value when value in [nil, ""] -> []
       project_id -> [project_id: project_id]
     end
   end

--- a/lib/loopctl_web/helpers/project_id.ex
+++ b/lib/loopctl_web/helpers/project_id.ex
@@ -1,0 +1,57 @@
+defmodule LoopctlWeb.Helpers.ProjectId do
+  @moduledoc """
+  Validates a client-supplied `project_id` param at the API boundary.
+
+  `project_id` is a `:binary_id` (UUID) column. Threading a raw non-UUID value
+  straight into `where a.project_id == ^project_id` makes `Ecto.UUID.dump/1`
+  fail, which raises `Ecto.Query.CastError` — an unhandled 500. Every knowledge
+  read endpoint that filters by `project_id` (path or query param) calls
+  `validate/1` FIRST so a malformed value returns a clean 422 (via
+  `LoopctlWeb.FallbackController`) instead of crashing.
+
+  Contract:
+
+    - `nil` / `""` (absent) -> `:ok` (tenant-wide listing stays available)
+    - a canonical 36-char dashed UUID -> `:ok`
+    - a malformed STRING (non-UUID, wrong length) ->
+      `{:error, :unprocessable_entity, message}` (the real 500 vector)
+    - a non-string value (e.g. `?project_id[]=x` decodes to a list) -> `:ok`;
+      controllers already neutralize these to "no filter" via `string_param/1`,
+      and the context filters guard the cast, so they never reach a query as a
+      value that could raise. Rejecting them here would needlessly break clients
+      that send array-style params.
+
+  The canonical 36-char form is required on purpose: `Ecto.UUID.cast/1` also
+  accepts a raw 16-byte binary, so a 16-char junk segment would otherwise coerce
+  into a bogus-but-valid UUID and silently narrow (or leak nothing from) a query
+  instead of being rejected.
+  """
+
+  @error_message "Invalid project_id: must be a valid UUID"
+
+  @doc """
+  Validates a `project_id` param value.
+
+  Returns `:ok` for an absent (`nil`/`""`) or valid UUID value, or
+  `{:error, :unprocessable_entity, message}` — the shape
+  `LoopctlWeb.FallbackController` renders as a 422 — for a malformed value.
+  """
+  @spec validate(term()) :: :ok | {:error, :unprocessable_entity, String.t()}
+  def validate(value) when value in [nil, ""], do: :ok
+
+  def validate(value) when is_binary(value) and byte_size(value) == 36 do
+    case Ecto.UUID.cast(value) do
+      {:ok, _uuid} -> :ok
+      :error -> {:error, :unprocessable_entity, @error_message}
+    end
+  end
+
+  # Any other STRING is a malformed UUID (wrong length / non-hex) — the actual
+  # Ecto.Query.CastError vector. Reject it with a 422.
+  def validate(value) when is_binary(value),
+    do: {:error, :unprocessable_entity, @error_message}
+
+  # Non-string values (list/map from `?project_id[]=x`) are tolerated as "absent":
+  # controllers nil them via string_param/1 and the context filters guard the cast.
+  def validate(_value), do: :ok
+end

--- a/test/loopctl/workers/content_ingestion_worker_test.exs
+++ b/test/loopctl/workers/content_ingestion_worker_test.exs
@@ -393,6 +393,72 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
     end
   end
 
+  describe "perform/1 with an invalid project_id (kbweb-01 poison pill)" do
+    test "a malformed project_id is discarded cleanly (no raise, no crash-loop, nothing inserted)" do
+      %{tenant: tenant} = setup_tenant()
+
+      # Discarded BEFORE any extraction, so the extractor is never invoked.
+      result =
+        ContentIngestionWorker.perform(%Oban.Job{
+          id: 201,
+          args: %{
+            "tenant_id" => tenant.id,
+            "content" => "Poison pill content",
+            "content_hash" => "poison_malformed",
+            "source_type" => "ingestion",
+            "project_id" => "not-a-uuid"
+          }
+        })
+
+      assert {:discard, {:invalid_project_id, "not-a-uuid"}} = result
+
+      assert %{meta: %{total_count: 0}} =
+               Knowledge.list_articles(tenant.id, source_type: "ingestion")
+    end
+
+    test "a non-string (array/map) project_id is discarded cleanly, not raised" do
+      %{tenant: tenant} = setup_tenant()
+
+      result =
+        ContentIngestionWorker.perform(%Oban.Job{
+          id: 202,
+          args: %{
+            "tenant_id" => tenant.id,
+            "content" => "Array poison content",
+            "content_hash" => "poison_array",
+            "source_type" => "ingestion",
+            "project_id" => ["x"]
+          }
+        })
+
+      assert {:discard, {:invalid_project_id, ["x"]}} = result
+    end
+
+    test "an empty-string project_id is treated as tenant-wide (normalized to nil), still ingests" do
+      %{tenant: tenant} = setup_tenant()
+
+      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _content, _opts ->
+        {:ok, [%{title: "Blank pid article", body: "Body.", category: :pattern, tags: []}]}
+      end)
+
+      assert :ok =
+               ContentIngestionWorker.perform(%Oban.Job{
+                 id: 203,
+                 args: %{
+                   "tenant_id" => tenant.id,
+                   "content" => "Blank project content",
+                   "content_hash" => "blank_pid",
+                   "source_type" => "ingestion",
+                   "project_id" => ""
+                 }
+               })
+
+      %{data: articles} = Knowledge.list_articles(tenant.id, source_type: "ingestion")
+      assert length(articles) == 1
+      assert is_nil(hd(articles).project_id)
+    end
+  end
+
   # --- Tenant isolation ---
 
   describe "tenant isolation" do

--- a/test/loopctl_web/controllers/article_controller_test.exs
+++ b/test/loopctl_web/controllers/article_controller_test.exs
@@ -1269,4 +1269,91 @@ defmodule LoopctlWeb.ArticleControllerTest do
       refute Enum.any?(body["data"], &(&1["title"] == "Tenant B Secret"))
     end
   end
+
+  describe "POST/PATCH /api/v1/articles project_id validation (kbweb-01)" do
+    test "create with a malformed body project_id returns 422, not a 500", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_key}")
+        |> post(~p"/api/v1/articles", %{
+          "title" => "Bad Project",
+          "body" => "body",
+          "category" => "pattern",
+          "project_id" => "not-a-uuid"
+        })
+
+      body = json_response(conn, 422)
+      assert body["error"]["message"] =~ "project_id"
+    end
+
+    test "create via the project-scoped path with a malformed project_id returns 422", %{
+      conn: conn
+    } do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_key}")
+        |> post("/api/v1/projects/not-a-uuid/articles", %{
+          "title" => "Bad Project Path",
+          "body" => "body",
+          "category" => "pattern"
+        })
+
+      body = json_response(conn, 422)
+      assert body["error"]["message"] =~ "project_id"
+    end
+
+    test "create with a valid project_id still works (201, scoped)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      project = fixture(:project, %{tenant_id: tenant.id})
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_key}")
+        |> post(~p"/api/v1/articles", %{
+          "title" => "Good Project",
+          "body" => "body",
+          "category" => "pattern",
+          "project_id" => project.id
+        })
+
+      body = json_response(conn, 201)
+      assert body["data"]["project_id"] == project.id
+    end
+
+    test "update with a malformed body project_id returns 422, not a 500", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      article = fixture(:article, %{tenant_id: tenant.id, status: :published})
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_key}")
+        |> patch(~p"/api/v1/articles/#{article.id}", %{"project_id" => "not-a-uuid"})
+
+      body = json_response(conn, 422)
+      assert body["error"]["message"] =~ "project_id"
+    end
+
+    test "update with a valid project_id still works (200)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      project = fixture(:project, %{tenant_id: tenant.id})
+      article = fixture(:article, %{tenant_id: tenant.id, status: :published})
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_key}")
+        |> patch(~p"/api/v1/articles/#{article.id}", %{"project_id" => project.id})
+
+      body = json_response(conn, 200)
+      assert body["data"]["project_id"] == project.id
+    end
+  end
 end

--- a/test/loopctl_web/controllers/article_controller_test.exs
+++ b/test/loopctl_web/controllers/article_controller_test.exs
@@ -1187,4 +1187,86 @@ defmodule LoopctlWeb.ArticleControllerTest do
       assert json_response(conn_delete, 404)
     end
   end
+
+  describe "GET /api/v1/articles project_id validation (kbweb-01)" do
+    test "a malformed project_id returns 422, not a 500", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_key}")
+        |> get(~p"/api/v1/articles", %{project_id: "not-a-uuid"})
+
+      body = json_response(conn, 422)
+      assert body["error"]["status"] == 422
+      assert body["error"]["message"] =~ "project_id"
+    end
+
+    test "a valid project_id returns 200 filtered to that project", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      project = fixture(:project, %{tenant_id: tenant.id})
+
+      in_project =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          project_id: project.id,
+          title: "In Project",
+          status: :published
+        })
+
+      _tenant_wide =
+        fixture(:article, %{tenant_id: tenant.id, title: "Tenant Wide", status: :published})
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_key}")
+        |> get(~p"/api/v1/articles", %{project_id: project.id})
+
+      body = json_response(conn, 200)
+      ids = Enum.map(body["data"], & &1["id"])
+      assert in_project.id in ids
+      refute Enum.any?(body["data"], &(&1["title"] == "Tenant Wide"))
+    end
+
+    test "an absent project_id returns 200 tenant-wide", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      fixture(:article, %{tenant_id: tenant.id, title: "Tenant Wide", status: :published})
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_key}")
+        |> get(~p"/api/v1/articles")
+
+      body = json_response(conn, 200)
+      assert Enum.any?(body["data"], &(&1["title"] == "Tenant Wide"))
+    end
+
+    test "a valid project_id belonging to another tenant does not leak (empty, not 500)", %{
+      conn: conn
+    } do
+      tenant_a = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant_a.id, role: :agent})
+
+      tenant_b = fixture(:tenant)
+      project_b = fixture(:project, %{tenant_id: tenant_b.id})
+
+      fixture(:article, %{
+        tenant_id: tenant_b.id,
+        project_id: project_b.id,
+        title: "Tenant B Secret",
+        status: :published
+      })
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_key}")
+        |> get(~p"/api/v1/articles", %{project_id: project_b.id})
+
+      body = json_response(conn, 200)
+      refute Enum.any?(body["data"], &(&1["title"] == "Tenant B Secret"))
+    end
+  end
 end

--- a/test/loopctl_web/controllers/epic_controller_test.exs
+++ b/test/loopctl_web/controllers/epic_controller_test.exs
@@ -114,6 +114,20 @@ defmodule LoopctlWeb.EpicControllerTest do
       assert json_response(conn, 404)
     end
 
+    test "returns 404 (not a 500) for a malformed project_id path segment (kbweb-01)", %{
+      conn: conn
+    } do
+      tenant = fixture(:tenant)
+      {raw_key, _api_key} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post("/api/v1/projects/not-a-uuid/epics", %{"number" => 1, "title" => "Bad"})
+
+      assert json_response(conn, 404)
+    end
+
     test "creates audit log entry", %{conn: conn} do
       tenant = fixture(:tenant)
       {raw_key, _api_key} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})

--- a/test/loopctl_web/controllers/knowledge_context_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_context_controller_test.exs
@@ -569,4 +569,96 @@ defmodule LoopctlWeb.KnowledgeContextControllerTest do
       assert decision.id in ids
     end
   end
+
+  describe "GET /api/v1/knowledge/context project_id validation (kbweb-01)" do
+    test "a malformed project_id returns 422, not a 500", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/context", %{query: "anything", project_id: "not-a-uuid"})
+
+      body = json_response(conn, 422)
+      assert body["error"]["status"] == 422
+      assert body["error"]["message"] =~ "project_id"
+    end
+
+    test "a valid project_id returns 200 scoped to that project", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      project = fixture(:project, %{tenant_id: tenant.id})
+
+      scoped =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          project_id: project.id,
+          title: "Scoped Ctx",
+          body: "scopedctxword zeta content for context scoping",
+          category: :pattern,
+          status: :published
+        })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/context", %{query: "scopedctxword", project_id: project.id})
+
+      body = json_response(conn, 200)
+      ids = Enum.map(body["data"] || [], & &1["id"])
+      assert scoped.id in ids
+    end
+
+    test "an absent project_id returns 200 tenant-wide", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      tenant_wide =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Tenant Wide Ctx",
+          body: "tenantwidectxword zeta content for context",
+          category: :pattern,
+          status: :published
+        })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/context", %{query: "tenantwidectxword"})
+
+      body = json_response(conn, 200)
+      ids = Enum.map(body["data"] || [], & &1["id"])
+      assert tenant_wide.id in ids
+    end
+
+    test "a valid project_id from another tenant does not leak (empty, not 500)", %{conn: conn} do
+      tenant_a = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant_a.id, role: :agent})
+
+      tenant_b = fixture(:tenant)
+      project_b = fixture(:project, %{tenant_id: tenant_b.id})
+
+      fixture(:article, %{
+        tenant_id: tenant_b.id,
+        project_id: project_b.id,
+        title: "Tenant B Ctx Secret",
+        body: "crosstenantctxword zeta secret content",
+        category: :pattern,
+        status: :published
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/context", %{
+          query: "crosstenantctxword",
+          project_id: project_b.id
+        })
+
+      body = json_response(conn, 200)
+      refute Enum.any?(body["data"] || [], &(&1["title"] == "Tenant B Ctx Secret"))
+    end
+  end
 end

--- a/test/loopctl_web/controllers/knowledge_export_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_export_controller_test.exs
@@ -435,4 +435,81 @@ defmodule LoopctlWeb.KnowledgeExportControllerTest do
              )
     end
   end
+
+  describe "GET /api/v1/knowledge/export project_id validation (kbweb-01)" do
+    test "a malformed project_id returns 422 BEFORE any chunked body commits a 200", %{
+      conn: conn
+    } do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/export", %{project_id: "not-a-uuid"})
+
+      body = json_response(conn, 422)
+      assert body["error"]["status"] == 422
+      assert body["error"]["message"] =~ "project_id"
+    end
+
+    test "a valid project_id streams a 200 archive scoped to that project", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      project = fixture(:project, %{tenant_id: tenant.id})
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        project_id: project.id,
+        title: "Scoped Export Pattern",
+        body: "Use Ecto.Multi for atomic operations.",
+        category: :pattern,
+        status: :published
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/export", %{project_id: project.id})
+
+      assert conn.status == 200
+      files = export_files(conn)
+      assert has_slug?(files, "pattern/scoped-export-pattern")
+    end
+
+    test "an absent project_id streams a 200 tenant-wide archive", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Tenant Wide Export",
+        body: "Use Ecto.Multi for atomic operations.",
+        category: :pattern,
+        status: :published
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/export")
+
+      assert conn.status == 200
+      files = export_files(conn)
+      assert has_slug?(files, "pattern/tenant-wide-export")
+    end
+
+    test "the project-scoped path with a malformed project_id returns 422", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get("/api/v1/projects/not-a-uuid/knowledge/export")
+
+      body = json_response(conn, 422)
+      assert body["error"]["message"] =~ "project_id"
+    end
+  end
 end

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -261,6 +261,57 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
 
       assert json_response(conn, 202)
     end
+
+    test "returns 422 for a malformed project_id (not enqueued, kbweb-01)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest", %{
+          content: "Some content",
+          source_type: "newsletter",
+          project_id: "not-a-uuid"
+        })
+
+      body = json_response(conn, 422)
+      assert body["error"]["message"] =~ "project_id"
+    end
+
+    test "returns 422 for a non-string (array) project_id (not enqueued)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest", %{
+          content: "Some content",
+          source_type: "newsletter",
+          project_id: ["x"]
+        })
+
+      body = json_response(conn, 422)
+      assert body["error"]["message"] =~ "project_id"
+    end
+
+    test "an empty-string project_id is accepted as tenant-wide (202)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+      expect_one_extracted_article("Blank pid ingest")
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest", %{
+          content: "Blank pid content",
+          source_type: "newsletter",
+          project_id: ""
+        })
+
+      assert json_response(conn, 202)
+    end
   end
 
   # --- POST /api/v1/knowledge/ingest/batch ---
@@ -488,6 +539,29 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
         end)
 
       assert tenant_b_jobs == []
+    end
+
+    test "a malformed project_id yields a per-item error while valid items still queue (kbweb-01)",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      items = [
+        %{content: "Good item", source_type: "newsletter", project_id: project.id},
+        %{content: "Poison item", source_type: "newsletter", project_id: "not-a-uuid"}
+      ]
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{items: items})
+
+      body = json_response(conn, 200)
+      assert [good, bad] = body["data"]
+      assert good["status"] == "queued"
+      assert bad["status"] == "error"
+      assert bad["error"] =~ "project_id"
     end
   end
 

--- a/test/loopctl_web/controllers/knowledge_lint_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_lint_controller_test.exs
@@ -843,5 +843,22 @@ defmodule LoopctlWeb.KnowledgeLintControllerTest do
       body = json_response(conn, 422)
       assert body["error"]["message"] =~ "project_id"
     end
+
+    test "an array-style project_id[]=x does not 500 (find_contradiction_clusters guarded)", %{
+      conn: conn
+    } do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      # `?project_id[]=x` decodes to a list, which ProjectId.validate tolerates as
+      # absent; the context guards then keep find_contradiction_clusters/2 (and
+      # published_base_query/2) from CastError-500 on the raw list value.
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get("/api/v1/knowledge/lint?project_id[]=x")
+
+      assert json_response(conn, 200)["data"]
+    end
   end
 end

--- a/test/loopctl_web/controllers/knowledge_lint_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_lint_controller_test.exs
@@ -781,4 +781,67 @@ defmodule LoopctlWeb.KnowledgeLintControllerTest do
       assert refetched.status == :published
     end
   end
+
+  describe "GET /api/v1/knowledge/lint project_id validation (kbweb-01)" do
+    test "a malformed project_id returns 422, not a 500", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/lint", %{project_id: "not-a-uuid"})
+
+      body = json_response(conn, 422)
+      assert body["error"]["status"] == 422
+      assert body["error"]["message"] =~ "project_id"
+    end
+
+    test "a valid project_id returns a 200 report", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+      project = fixture(:project, %{tenant_id: tenant.id})
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        project_id: project.id,
+        title: "Scoped Lint Pattern",
+        category: :pattern,
+        status: :published
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/lint", %{project_id: project.id})
+
+      body = json_response(conn, 200)
+      assert is_map(body["data"])
+    end
+
+    test "an absent project_id returns a 200 tenant-wide report", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/lint")
+
+      assert json_response(conn, 200)["data"]
+    end
+
+    test "the project-scoped path with a malformed project_id returns 422", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get("/api/v1/projects/not-a-uuid/knowledge/lint")
+
+      body = json_response(conn, 422)
+      assert body["error"]["message"] =~ "project_id"
+    end
+  end
 end

--- a/test/loopctl_web/controllers/knowledge_search_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_search_controller_test.exs
@@ -636,4 +636,96 @@ defmodule LoopctlWeb.KnowledgeSearchControllerTest do
       assert List.first(body["data"])["title"] == "Published Hub"
     end
   end
+
+  describe "GET /api/v1/knowledge/search project_id validation (kbweb-01)" do
+    test "a malformed project_id returns 422, not a 500", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{q: "anything", project_id: "not-a-uuid"})
+
+      body = json_response(conn, 422)
+      assert body["error"]["status"] == 422
+      assert body["error"]["message"] =~ "project_id"
+    end
+
+    test "a valid project_id returns 200 filtered to that project", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      project = fixture(:project, %{tenant_id: tenant.id})
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        project_id: project.id,
+        title: "Scoped Ecto Pattern",
+        body: "Use Ecto.Multi for atomic operations.",
+        category: :pattern,
+        status: :published
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{
+          q: "Ecto",
+          mode: "keyword",
+          project_id: project.id
+        })
+
+      body = json_response(conn, 200)
+      assert Enum.any?(body["data"], &(&1["title"] == "Scoped Ecto Pattern"))
+    end
+
+    test "an absent project_id returns 200 tenant-wide", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Tenant Wide Ecto",
+        body: "Use Ecto.Multi for atomic operations.",
+        category: :pattern,
+        status: :published
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{q: "Ecto", mode: "keyword"})
+
+      assert json_response(conn, 200)["data"] != nil
+    end
+
+    test "a valid project_id from another tenant does not leak (empty, not 500)", %{conn: conn} do
+      tenant_a = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant_a.id, role: :agent})
+
+      tenant_b = fixture(:tenant)
+      project_b = fixture(:project, %{tenant_id: tenant_b.id})
+
+      fixture(:article, %{
+        tenant_id: tenant_b.id,
+        project_id: project_b.id,
+        title: "Tenant B Ecto Secret",
+        body: "Use Ecto.Multi for atomic operations.",
+        category: :pattern,
+        status: :published
+      })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{
+          q: "Ecto",
+          mode: "keyword",
+          project_id: project_b.id
+        })
+
+      body = json_response(conn, 200)
+      refute Enum.any?(body["data"], &(&1["title"] == "Tenant B Ecto Secret"))
+    end
+  end
 end

--- a/test/loopctl_web/controllers/okf_controller_test.exs
+++ b/test/loopctl_web/controllers/okf_controller_test.exs
@@ -218,4 +218,91 @@ defmodule LoopctlWeb.OKFControllerTest do
       assert %{meta: %{total_count: 0}} = Knowledge.list_articles(other.id, category: :reference)
     end
   end
+
+  describe "OKF project_id validation (kbweb-01)" do
+    test "export ?format=json with a malformed project_id returns 422, not a 500", %{conn: conn} do
+      tenant = fixture(:tenant)
+      raw = user_key(tenant)
+
+      conn =
+        conn
+        |> auth_conn(raw)
+        |> get(~p"/api/v1/knowledge/okf/export?format=json&project_id=not-a-uuid")
+
+      body = json_response(conn, 422)
+      assert body["error"]["message"] =~ "project_id"
+    end
+
+    test "streamed export with a malformed project_id returns 422 before committing a 200", %{
+      conn: conn
+    } do
+      tenant = fixture(:tenant)
+      raw = user_key(tenant)
+
+      conn =
+        conn
+        |> auth_conn(raw)
+        |> get(~p"/api/v1/knowledge/okf/export?project_id=not-a-uuid")
+
+      body = json_response(conn, 422)
+      assert body["error"]["message"] =~ "project_id"
+    end
+
+    test "the project-scoped export path with a malformed project_id returns 422", %{conn: conn} do
+      tenant = fixture(:tenant)
+      raw = user_key(tenant)
+
+      conn =
+        conn
+        |> auth_conn(raw)
+        |> get("/api/v1/projects/not-a-uuid/knowledge/okf/export")
+
+      body = json_response(conn, 422)
+      assert body["error"]["message"] =~ "project_id"
+    end
+
+    test "export ?format=json with a valid project_id still works (200)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      raw = user_key(tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      published(tenant.id, %{title: "Scoped OKF", category: :pattern, project_id: project.id})
+
+      conn =
+        conn
+        |> auth_conn(raw)
+        |> get(~p"/api/v1/knowledge/okf/export?format=json&project_id=#{project.id}")
+
+      body = json_response(conn, 200)
+      assert is_map(body["data"]["files"])
+    end
+
+    test "import with a malformed project_id returns 422, not a 500", %{conn: conn} do
+      tenant = fixture(:tenant)
+      raw = user_key(tenant)
+
+      conn =
+        conn
+        |> auth_conn(raw)
+        |> post(~p"/api/v1/knowledge/okf/import", %{
+          files: sample_files(),
+          project_id: "not-a-uuid"
+        })
+
+      body = json_response(conn, 422)
+      assert body["error"]["message"] =~ "project_id"
+    end
+
+    test "import with a valid project_id still works (200)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      raw = user_key(tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+
+      conn =
+        conn
+        |> auth_conn(raw)
+        |> post(~p"/api/v1/knowledge/okf/import", %{files: sample_files(), project_id: project.id})
+
+      assert json_response(conn, 200)["data"]["created"] == 1
+    end
+  end
 end

--- a/test/loopctl_web/helpers/project_id_test.exs
+++ b/test/loopctl_web/helpers/project_id_test.exs
@@ -1,0 +1,43 @@
+defmodule LoopctlWeb.Helpers.ProjectIdTest do
+  use ExUnit.Case, async: true
+
+  alias LoopctlWeb.Helpers.ProjectId
+
+  describe "validate/1" do
+    test "absent (nil) project_id is :ok (tenant-wide listing stays available)" do
+      assert ProjectId.validate(nil) == :ok
+    end
+
+    test "empty string project_id is :ok (treated as absent)" do
+      assert ProjectId.validate("") == :ok
+    end
+
+    test "a valid canonical UUID is :ok" do
+      assert ProjectId.validate(Ecto.UUID.generate()) == :ok
+    end
+
+    test "a malformed (non-UUID) string is a 422 error tuple" do
+      assert {:error, :unprocessable_entity, message} = ProjectId.validate("not-a-uuid")
+      assert message =~ "project_id"
+    end
+
+    test "a 16-char junk string is rejected (does not coerce into a raw-binary UUID)" do
+      # Ecto.UUID.cast/1 accepts a raw 16-byte binary; requiring the 36-char
+      # dashed form prevents a 16-char junk value coercing into a bogus UUID.
+      assert {:error, :unprocessable_entity, _} = ProjectId.validate("0123456789abcdef")
+    end
+
+    test "a 36-char non-UUID string is rejected" do
+      assert {:error, :unprocessable_entity, _} =
+               ProjectId.validate(String.duplicate("z", 36))
+    end
+
+    test "a non-string value is tolerated as absent (:ok)" do
+      # `?project_id[]=x` decodes to a list; controllers neutralize it to
+      # "no filter" and the context filters guard the cast, so it never 500s.
+      # Rejecting it here would break array-style query params, so it is :ok.
+      assert ProjectId.validate(["not", "a", "string"]) == :ok
+      assert ProjectId.validate(123) == :ok
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Multiple knowledge read endpoints threaded a raw client-supplied `project_id` (path or query param) straight into `where a.project_id == ^project_id` against the `:binary_id` column. A non-UUID value (e.g. `not-a-uuid`) made `Ecto.UUID.dump/1` fail, raising `Ecto.Query.CastError` — an unhandled **500**. This validates `project_id` at the boundary of every affected endpoint so a malformed value returns a clean **422** instead.

## The shared helper + 4xx shape

New `LoopctlWeb.Helpers.ProjectId.validate/1`:
- `nil` / `""` (absent) -> `:ok` (tenant-wide listing unchanged)
- canonical 36-char UUID -> `:ok`
- malformed string -> `{:error, :unprocessable_entity, "Invalid project_id: must be a valid UUID"}` — rendered by `FallbackController` as a **422** (`{"error": {"status": 422, "message": ...}}`)
- non-string (`?project_id[]=x` decodes to a list) -> `:ok`, preserving existing tolerance (already neutralized downstream + guarded in the context)

Uses `Ecto.UUID.cast/1` and requires the 36-char dashed form (matching the existing convention in `KnowledgeStats`/`KnowledgeIndex`/`KnowledgeAnalytics` controllers), so a 16-char junk value can't coerce into a raw-binary UUID.

## Endpoints validated (before the query runs)

| Endpoint | Role | Notes |
|---|---|---|
| `GET /articles` (+ `/projects/:project_id/articles`) | agent+ | added to the index `with`; distinct `else` clause so the 3-tuple isn't misread as the enum-error shape |
| `GET /knowledge/search` | agent+ | added to `build_opts` `with` |
| `GET /knowledge/context` | agent+ | added to the action `with` |
| `GET /knowledge/lint` (+ `/projects/:project_id/...`) | orchestrator+ | validate first in `parse_lint_params` |
| `GET /knowledge/export` (+ `/projects/:project_id/...`) | user+ | validate **before** `send_chunked` commits a 200 (otherwise a mid-stream raise truncates the archive) |

## Defense in depth (context)

Guarded the filters so a non-UUID `project_id` passed programmatically matches nothing / scopes to tenant-wide instead of raising:
- `Loopctl.Knowledge.maybe_filter_by_project_id/2` (articles, search, context)
- `Loopctl.Knowledge.published_base_query/2` (lint)
- `Loopctl.Knowledge.StreamingExport.base_query/2` (export)

Tenant scoping/RLS is unchanged — a valid **other-tenant** `project_id` yields empty results, never a leak.

## Tests

- `ProjectIdTest` — unit tests for the helper (nil/""/valid/malformed-string/16-char-junk/36-char-junk/non-string).
- Each of the 5 endpoints, end-to-end: malformed `project_id` -> **422** (not 500), valid -> **200** filtered, absent -> **200** tenant-wide, and a valid other-tenant `project_id` -> **200** empty (no cross-tenant leak). Lint + export also cover the `/projects/:project_id/*` path with a malformed segment.

`mix test`: **3455 tests, 0 failures**. compile `--warnings-as-errors` clean, `format` clean, `credo --strict` clean, `dialyzer` 0 real (73 pre-existing skips).

Refs public issue #251 (kbweb-01).