### PR TITLE
test(mcp): guard real source via shared module + gate mcp-server tests in CI

### DIFF
--- a/.github/workflows/mcp-autopublish.yml
+++ b/.github/workflows/mcp-autopublish.yml
@@ -50,6 +50,15 @@ jobs:
         working-directory: mcp-server
         run: npm install
 
+      # Fail-fast gate: never auto-publish an untested build. The deterministic
+      # node --test unit suite (test/*.test.js) must be green BEFORE npm publish.
+      # NB: this runs `npm test`, which is scoped to the unit suite and does NOT
+      # include the live-network smoke_test.mjs (that would flake in CI).
+      - name: Run MCP server unit tests (gate publish)
+        if: steps.pub.outputs.exists == 'false'
+        working-directory: mcp-server
+        run: npm test
+
       - name: Publish to npm
         if: steps.pub.outputs.exists == 'false'
         working-directory: mcp-server

--- a/.github/workflows/mcp-server-ci.yml
+++ b/.github/workflows/mcp-server-ci.yml
@@ -1,0 +1,42 @@
+name: MCP Server CI
+
+# The main ci.yml is Elixir-only and never touches mcp-server/, so the npm
+# package's own test suite was never run in CI — and the auto-publish workflow
+# ships it to npm on a version bump WITHOUT testing. This job closes that gap:
+# it runs the deterministic node --test unit suite on every push/PR that touches
+# mcp-server/**, so a red suite is caught before merge (and, via the publish
+# gates in mcp-autopublish.yml / npm-publish.yml, before an npm release).
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'mcp-server/**'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'mcp-server/**'
+
+jobs:
+  test:
+    name: Node unit tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mcp-server
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # `npm test` == `node --test test/*.test.js` — the deterministic unit suite.
+      # It mocks fetch / exercises pure helpers, so no network is needed. It does
+      # NOT run smoke_test.mjs, which is a live-network test that depends on server
+      # witness state and would flake CI (run it manually via `npm run test:smoke`).
+      - name: Run unit tests
+        run: npm test

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -44,6 +44,13 @@ jobs:
       - if: steps.pub.outputs.exists == 'false'
         run: npm install
 
+      # Fail-fast gate: a red unit suite must block the npm release. `npm test`
+      # runs the deterministic node --test suite (test/*.test.js) only — not the
+      # live-network smoke_test.mjs.
+      - name: Run MCP server unit tests (gate publish)
+        if: steps.pub.outputs.exists == 'false'
+        run: npm test
+
       - if: steps.pub.outputs.exists == 'false'
         run: npm publish --provenance --access public
         env:

--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -21,6 +21,20 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   exception. The parse is now wrapped so a bad body becomes a structured MCP error
   (`{ error: true, status, body }`) with the HTTP status and a raw-body snippet.
 
+### Internal
+
+- The three fixes above now live in a shared, importable module,
+  `lib/http-helpers.js` (`projectsPath` / `ingestionJobsPath` / `parseJsonResponseBody`),
+  imported by both `index.js` and the test suite so the tests exercise the code the
+  server actually ships instead of a hand-copied mirror. `lib/` is now included in the
+  published tarball.
+- CI now runs the MCP server's own `node --test` unit suite: a new `mcp-server-ci.yml`
+  workflow (on every push/PR touching `mcp-server/**`), and both publish workflows
+  (`mcp-autopublish.yml`, `npm-publish.yml`) run `npm test` as a fail-fast gate before
+  `npm publish`, so a red suite blocks the npm release. `npm test` is scoped to the
+  deterministic unit suite (`test/*.test.js`); the live-network `smoke_test.mjs` is now
+  `npm run test:smoke`.
+
 ## 2.30.0 — 2026-07-01 (toggleable KB curation log)
 
 ### Added

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -13,6 +13,11 @@ import {
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
+import {
+  projectsPath,
+  ingestionJobsPath,
+  parseJsonResponseBody,
+} from "./lib/http-helpers.js";
 
 // Single source of truth for the server version: the package.json this file
 // ships with (npm always includes package.json in the published tarball).
@@ -109,26 +114,15 @@ async function apiCall(method, path, body, keyOverride) {
   if (contentType.includes("application/json")) {
     // A JSON content-type is no guarantee of a well-formed body: a transient Fly
     // edge 502/503 or a truncated/empty response can arrive with the JSON header.
-    // Read the raw text and parse defensively so a malformed body becomes a
-    // structured MCP error instead of an unhandled throw from response.json().
+    // Read the raw text and parse defensively (shared with the test suite via
+    // lib/http-helpers.js) so a malformed body becomes a structured MCP error
+    // instead of an unhandled throw from response.json().
     const raw = await response.text();
-    if (raw.trim() === "") {
-      return {
-        error: true,
-        status: response.status,
-        body: `invalid/empty JSON response from server (HTTP ${response.status}): empty body`,
-      };
+    const outcome = parseJsonResponseBody(raw, response.status);
+    if (outcome.error) {
+      return outcome;
     }
-    try {
-      responseBody = JSON.parse(raw);
-    } catch {
-      const snippet = raw.length > 200 ? `${raw.slice(0, 200)}... (truncated)` : raw;
-      return {
-        error: true,
-        status: response.status,
-        body: `invalid/empty JSON response from server (HTTP ${response.status}): ${snippet}`,
-      };
-    }
+    responseBody = outcome.parsed;
   } else {
     const text = await response.text();
     try {
@@ -210,12 +204,10 @@ async function getTenant() {
   return toContent(result);
 }
 
-async function listProjects({ page, page_size } = {}) {
-  const params = new URLSearchParams();
-  if (page != null) params.set("page", String(page));
-  if (page_size != null) params.set("page_size", String(page_size));
-  const query = params.toString() ? `?${params}` : "";
-  const result = await apiCall("GET", `/api/v1/projects${query}`);
+async function listProjects(args = {}) {
+  // Query-string building lives in lib/http-helpers.js so the test suite exercises
+  // the same page/page_size logic the server ships (#247, mcp-01).
+  const result = await apiCall("GET", projectsPath(args));
   return toContent(result);
 }
 
@@ -1152,15 +1144,12 @@ async function knowledgeIngestBatch({ items, project_id, publish }) {
   return toContent(result);
 }
 
-async function knowledgeIngestionJobs({ limit, offset, since_days } = {}) {
-  const params = new URLSearchParams();
-  if (limit != null) params.set("limit", String(limit));
-  if (offset != null) params.set("offset", String(offset));
-  if (since_days != null) params.set("since_days", String(since_days));
-  const query = params.toString() ? `?${params}` : "";
+async function knowledgeIngestionJobs(args = {}) {
+  // Query-string building lives in lib/http-helpers.js so the test suite exercises
+  // the same limit/offset/since_days logic the server ships (#248, mcp-02).
   const result = await apiCall(
     "GET",
-    `/api/v1/knowledge/ingestion-jobs${query}`,
+    ingestionJobsPath(args),
     null,
     process.env.LOOPCTL_ORCH_KEY,
   );

--- a/mcp-server/lib/http-helpers.js
+++ b/mcp-server/lib/http-helpers.js
@@ -1,0 +1,91 @@
+// Pure, importable HTTP helpers shared by index.js and the test suite.
+//
+// index.js is a stdio entry point with top-level await (importing it would boot
+// the MCP server), so it cannot be imported directly by tests. Extracting the
+// logic that actually had bugs — query-string building for the paginated tools
+// and the defensive JSON parse in apiCall — into this side-effect-free module
+// gives BOTH index.js and the tests a single source of truth. The tests exercise
+// the SAME code the server ships, so a regression in this logic fails CI instead
+// of silently passing against a hand-copied mirror.
+
+/**
+ * Build a `?a=b&c=d` query string from an array of [key, value] pairs. Skips
+ * null/undefined values (so unset params are omitted) and stringifies the rest.
+ * Returns "" when nothing is set.
+ *
+ * @param {Array<[string, unknown]>} pairs
+ * @returns {string}
+ */
+export function buildQuery(pairs) {
+  const params = new URLSearchParams();
+  for (const [key, value] of pairs) {
+    if (value != null) params.set(key, String(value));
+  }
+  const qs = params.toString();
+  return qs ? `?${qs}` : "";
+}
+
+/**
+ * Path for `list_projects`, honoring page/page_size (#247, mcp-01).
+ *
+ * @param {{ page?: number, page_size?: number }} [args]
+ * @returns {string}
+ */
+export function projectsPath({ page, page_size } = {}) {
+  return `/api/v1/projects${buildQuery([
+    ["page", page],
+    ["page_size", page_size],
+  ])}`;
+}
+
+/**
+ * Path for `knowledge_ingestion_jobs`, honoring limit/offset/since_days
+ * (#248, mcp-02).
+ *
+ * @param {{ limit?: number, offset?: number, since_days?: number }} [args]
+ * @returns {string}
+ */
+export function ingestionJobsPath({ limit, offset, since_days } = {}) {
+  return `/api/v1/knowledge/ingestion-jobs${buildQuery([
+    ["limit", limit],
+    ["offset", offset],
+    ["since_days", since_days],
+  ])}`;
+}
+
+/**
+ * Defensively parse the raw text body of a JSON-content-type HTTP response
+ * (#249, mcp-03).
+ *
+ * A JSON content-type header is no guarantee of a well-formed body: a transient
+ * Fly edge 502/503 or a truncated response can arrive with the JSON header but an
+ * empty or non-JSON body, which makes a bare `response.json()` throw an unhandled
+ * exception. This turns that into a STRUCTURED error the MCP tool layer already
+ * understands (`{ error: true, status, body }`), including the HTTP status and a
+ * raw-body snippet for debugging.
+ *
+ * @param {string} rawText - the response body as text
+ * @param {number} status - the HTTP status code
+ * @returns {{ parsed: unknown } | { error: true, status: number, body: string }}
+ *   `{ parsed }` on success, or a structured error object on empty/invalid JSON.
+ */
+export function parseJsonResponseBody(rawText, status) {
+  if (rawText.trim() === "") {
+    return {
+      error: true,
+      status,
+      body: `invalid/empty JSON response from server (HTTP ${status}): empty body`,
+    };
+  }
+  try {
+    return { parsed: JSON.parse(rawText) };
+  } catch {
+    const snippet =
+      rawText.length > 200 ? `${rawText.slice(0, 200)}... (truncated)` : rawText;
+    return {
+      error: true,
+      status,
+      body: `invalid/empty JSON response from server (HTTP ${status}): ${snippet}`,
+    };
+  }
+}

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "start": "node index.js",
-    "test": "node --test"
+    "test": "node --test test/*.test.js",
+    "test:smoke": "node smoke_test.mjs"
   },
   "keywords": [
     "mcp",
@@ -33,6 +34,7 @@
   },
   "files": [
     "index.js",
+    "lib",
     "README.md",
     "LICENSE"
   ],

--- a/mcp-server/test/mcp_arg_forwarding.test.js
+++ b/mcp-server/test/mcp_arg_forwarding.test.js
@@ -6,13 +6,15 @@
  *   - #249 (mcp-03): apiCall must not throw on an empty/invalid JSON body when the
  *     response carries a JSON content-type — it returns a STRUCTURED error instead.
  *
- * Uses the Node.js built-in test runner (node:test). Run: node --test test/
+ * Uses the Node.js built-in test runner (node:test). Run: node --test test/*.test.js
  *
- * The handler functions and the dispatch switch in index.js are not exported
- * (server entry point with top-level await). We (a) mirror the exact handler +
- * apiCall bodies here and drive them through a mocked fetch, and (b) assert the
- * source dispatch cases pass `args` through, so the real bug (dropped args) can
- * never silently regress.
+ * SINGLE SOURCE OF TRUTH: the query-building and JSON-parse logic that had bugs
+ * lives in ../lib/http-helpers.js, imported by BOTH the real server (index.js) and
+ * these tests. So the behavioral tests below exercise the exact code the server
+ * ships — a regression in projectsPath / ingestionJobsPath / parseJsonResponseBody
+ * fails here. The remaining tests pin the WIRING in index.js (that the handlers and
+ * apiCall actually call the shared helpers, and the dispatch passes args through),
+ * so drift in either the logic or its use fails CI.
  */
 
 import { test, describe } from "node:test";
@@ -21,164 +23,12 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
-// ---------------------------------------------------------------------------
-// Minimal mirror of index.js helpers under test
-// ---------------------------------------------------------------------------
-
-function getBaseUrl() {
-  return (process.env.LOOPCTL_SERVER || "https://loopctl.com").replace(/\/$/, "");
-}
-
-function resolveKey(keyOverride) {
-  return process.env.LOOPCTL_API_KEY || keyOverride || process.env.LOOPCTL_ORCH_KEY;
-}
-
-// Mirrors index.js apiCall including the #249 defensive JSON parse.
-async function apiCall(method, reqPath, body, keyOverride) {
-  const url = `${getBaseUrl()}${reqPath}`;
-  const key = resolveKey(keyOverride);
-
-  if (!key) {
-    return { error: true, status: 0, body: "No API key configured." };
-  }
-
-  const options = {
-    method,
-    headers: {
-      Authorization: `Bearer ${key}`,
-      "Content-Type": "application/json",
-      Accept: "application/json",
-    },
-  };
-  if (body !== undefined && body !== null) {
-    options.body = JSON.stringify(body);
-  }
-
-  const response = await fetch(url, options);
-
-  if (response.status === 204) {
-    return { ok: true };
-  }
-
-  let responseBody;
-  const contentType = response.headers.get("content-type") || "";
-  if (contentType.includes("application/json")) {
-    const raw = await response.text();
-    if (raw.trim() === "") {
-      return {
-        error: true,
-        status: response.status,
-        body: `invalid/empty JSON response from server (HTTP ${response.status}): empty body`,
-      };
-    }
-    try {
-      responseBody = JSON.parse(raw);
-    } catch {
-      const snippet = raw.length > 200 ? `${raw.slice(0, 200)}... (truncated)` : raw;
-      return {
-        error: true,
-        status: response.status,
-        body: `invalid/empty JSON response from server (HTTP ${response.status}): ${snippet}`,
-      };
-    }
-  } else {
-    const text = await response.text();
-    try {
-      responseBody = JSON.parse(text);
-    } catch {
-      responseBody = text;
-    }
-  }
-
-  if (!response.ok) {
-    return { error: true, status: response.status, body: responseBody };
-  }
-
-  return responseBody;
-}
-
-function toContent(result) {
-  const isErr = result && result.error === true;
-  return {
-    content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-    ...(isErr && { isError: true }),
-  };
-}
-
-// Mirrors index.js listProjects.
-async function listProjects({ page, page_size } = {}) {
-  const params = new URLSearchParams();
-  if (page != null) params.set("page", String(page));
-  if (page_size != null) params.set("page_size", String(page_size));
-  const query = params.toString() ? `?${params}` : "";
-  const result = await apiCall("GET", `/api/v1/projects${query}`);
-  return toContent(result);
-}
-
-// Mirrors index.js knowledgeIngestionJobs.
-async function knowledgeIngestionJobs({ limit, offset, since_days } = {}) {
-  const params = new URLSearchParams();
-  if (limit != null) params.set("limit", String(limit));
-  if (offset != null) params.set("offset", String(offset));
-  if (since_days != null) params.set("since_days", String(since_days));
-  const query = params.toString() ? `?${params}` : "";
-  const result = await apiCall(
-    "GET",
-    `/api/v1/knowledge/ingestion-jobs${query}`,
-    null,
-    process.env.LOOPCTL_ORCH_KEY,
-  );
-  return toContent(result);
-}
-
-// ---------------------------------------------------------------------------
-// Test helpers
-// ---------------------------------------------------------------------------
-
-const ORCH_KEY = "lc_test_orch_key";
-const BASE_URL = "https://loopctl.com";
-
-function setupEnv() {
-  process.env.LOOPCTL_SERVER = BASE_URL;
-  process.env.LOOPCTL_ORCH_KEY = ORCH_KEY;
-  delete process.env.LOOPCTL_API_KEY;
-}
-
-/** Mock fetch that always answers with a JSON content-type + canned JSON body. */
-function mockFetch(responseBody = { data: [], meta: {} }, status = 200) {
-  const calls = [];
-  globalThis.fetch = async (url, options) => {
-    calls.push({ url, options });
-    return {
-      ok: status >= 200 && status < 300,
-      status,
-      headers: { get: (h) => (h.toLowerCase() === "content-type" ? "application/json" : null) },
-      json: async () => responseBody,
-      text: async () => JSON.stringify(responseBody),
-    };
-  };
-  return calls;
-}
-
-/**
- * Mock fetch that returns a JSON content-type but a caller-controlled raw body
- * string, and a json() that reflects real JSON.parse semantics (throws on bad
- * input) — this is what a truncated/empty Fly edge response looks like.
- */
-function mockFetchRaw(rawBody, status = 200, contentType = "application/json") {
-  const calls = [];
-  globalThis.fetch = async (url, options) => {
-    calls.push({ url, options });
-    return {
-      ok: status >= 200 && status < 300,
-      status,
-      headers: { get: (h) => (h.toLowerCase() === "content-type" ? contentType : null) },
-      json: async () => JSON.parse(rawBody), // throws on empty/invalid, like the platform
-      text: async () => rawBody,
-    };
-  };
-  return calls;
-}
+import {
+  buildQuery,
+  projectsPath,
+  ingestionJobsPath,
+  parseJsonResponseBody,
+} from "../lib/http-helpers.js";
 
 const INDEX_SRC = readFileSync(
   path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "index.js"),
@@ -186,36 +36,46 @@ const INDEX_SRC = readFileSync(
 );
 
 // ---------------------------------------------------------------------------
-// #247 (mcp-01): list_projects forwards page/page_size
+// buildQuery — the shared primitive
 // ---------------------------------------------------------------------------
 
-describe("#247 mcp-01: list_projects pagination", () => {
-  test("forwards page and page_size as query params", async () => {
-    setupEnv();
-    const calls = mockFetch({ data: [], meta: { page: 2 } });
+describe("buildQuery (shared query-string primitive)", () => {
+  test("emits set pairs and skips null/undefined", () => {
+    assert.equal(buildQuery([["a", 1], ["b", undefined], ["c", null], ["d", 0]]), "?a=1&d=0");
+  });
 
-    await listProjects({ page: 2, page_size: 50 });
+  test("returns empty string when nothing is set", () => {
+    assert.equal(buildQuery([["a", undefined], ["b", null]]), "");
+  });
+});
 
-    assert.equal(calls.length, 1);
-    const url = new URL(calls[0].url);
+// ---------------------------------------------------------------------------
+// #247 (mcp-01): list_projects forwards page/page_size (REAL projectsPath)
+// ---------------------------------------------------------------------------
+
+describe("#247 mcp-01: list_projects pagination (real projectsPath)", () => {
+  test("forwards page and page_size", () => {
+    const url = new URL(`https://x${projectsPath({ page: 2, page_size: 50 })}`);
     assert.equal(url.pathname, "/api/v1/projects");
     assert.equal(url.searchParams.get("page"), "2");
     assert.equal(url.searchParams.get("page_size"), "50");
   });
 
-  test("omits pagination params when none are supplied", async () => {
-    setupEnv();
-    const calls = mockFetch();
-
-    await listProjects();
-
-    const url = new URL(calls[0].url);
-    assert.equal(url.searchParams.has("page"), false);
-    assert.equal(url.searchParams.has("page_size"), false);
-    assert.equal(url.search, "");
+  test("forwards page alone", () => {
+    assert.equal(projectsPath({ page: 3 }), "/api/v1/projects?page=3");
   });
 
-  test("dispatch passes args through (no dropped page/page_size)", () => {
+  test("omits pagination params when none are supplied", () => {
+    assert.equal(projectsPath(), "/api/v1/projects");
+    assert.equal(projectsPath({}), "/api/v1/projects");
+  });
+
+  test("index.js listProjects uses projectsPath(args) and passes args from dispatch", () => {
+    assert.match(
+      INDEX_SRC,
+      /async function listProjects\(args = \{\}\) \{[\s\S]*?projectsPath\(args\)/,
+      "listProjects must delegate to the shared projectsPath(args)",
+    );
     assert.match(
       INDEX_SRC,
       /case "list_projects":\s*\n\s*return await listProjects\(args\);/,
@@ -228,34 +88,26 @@ describe("#247 mcp-01: list_projects pagination", () => {
 // #248 (mcp-02): knowledge_ingestion_jobs forwards limit/offset/since_days
 // ---------------------------------------------------------------------------
 
-describe("#248 mcp-02: knowledge_ingestion_jobs pagination", () => {
-  test("forwards limit, offset, and since_days as query params", async () => {
-    setupEnv();
-    const calls = mockFetch({ data: [], meta: { limit: 10 } });
-
-    await knowledgeIngestionJobs({ limit: 10, offset: 20, since_days: 7 });
-
-    assert.equal(calls.length, 1);
-    const { url, options } = calls[0];
-    const parsed = new URL(url);
-    assert.equal(parsed.pathname, "/api/v1/knowledge/ingestion-jobs");
-    assert.equal(parsed.searchParams.get("limit"), "10");
-    assert.equal(parsed.searchParams.get("offset"), "20");
-    assert.equal(parsed.searchParams.get("since_days"), "7");
-    assert.equal(options.headers.Authorization, `Bearer ${ORCH_KEY}`);
+describe("#248 mcp-02: knowledge_ingestion_jobs pagination (real ingestionJobsPath)", () => {
+  test("forwards limit, offset, and since_days", () => {
+    const url = new URL(`https://x${ingestionJobsPath({ limit: 10, offset: 20, since_days: 7 })}`);
+    assert.equal(url.pathname, "/api/v1/knowledge/ingestion-jobs");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("offset"), "20");
+    assert.equal(url.searchParams.get("since_days"), "7");
   });
 
-  test("omits params when none are supplied", async () => {
-    setupEnv();
-    const calls = mockFetch();
-
-    await knowledgeIngestionJobs();
-
-    const url = new URL(calls[0].url);
-    assert.equal(url.search, "");
+  test("omits params when none are supplied", () => {
+    assert.equal(ingestionJobsPath(), "/api/v1/knowledge/ingestion-jobs");
+    assert.equal(ingestionJobsPath({}), "/api/v1/knowledge/ingestion-jobs");
   });
 
-  test("dispatch passes args through (no dropped limit/offset/since_days)", () => {
+  test("index.js knowledgeIngestionJobs uses ingestionJobsPath(args) + orch key, dispatch passes args", () => {
+    assert.match(
+      INDEX_SRC,
+      /async function knowledgeIngestionJobs\(args = \{\}\) \{[\s\S]*?ingestionJobsPath\(args\)[\s\S]*?LOOPCTL_ORCH_KEY/,
+      "knowledgeIngestionJobs must delegate to ingestionJobsPath(args) on the orch key",
+    );
     assert.match(
       INDEX_SRC,
       /case "knowledge_ingestion_jobs":\s*\n\s*return await knowledgeIngestionJobs\(args\);/,
@@ -265,66 +117,62 @@ describe("#248 mcp-02: knowledge_ingestion_jobs pagination", () => {
 });
 
 // ---------------------------------------------------------------------------
-// #249 (mcp-03): apiCall guards response.json()
+// #249 (mcp-03): defensive JSON parsing (REAL parseJsonResponseBody)
 // ---------------------------------------------------------------------------
 
-describe("#249 mcp-03: apiCall defensive JSON parsing", () => {
-  test("valid JSON body still parses normally", async () => {
-    setupEnv();
-    mockFetchRaw(JSON.stringify({ data: [1, 2, 3], meta: { total_count: 3 } }));
-
-    const result = await apiCall("GET", "/api/v1/projects", null, ORCH_KEY);
-
-    assert.equal(result.error, undefined, "valid JSON must not be treated as an error");
-    assert.deepEqual(result.data, [1, 2, 3]);
+describe("#249 mcp-03: parseJsonResponseBody (shared with apiCall)", () => {
+  test("valid JSON returns { parsed } (no error)", () => {
+    const out = parseJsonResponseBody(
+      JSON.stringify({ data: [1, 2, 3], meta: { total_count: 3 } }),
+      200,
+    );
+    assert.equal(out.error, undefined);
+    assert.deepEqual(out.parsed, { data: [1, 2, 3], meta: { total_count: 3 } });
   });
 
-  test("empty body with JSON content-type returns a structured error (no throw)", async () => {
-    setupEnv();
-    mockFetchRaw("", 502);
-
-    let result;
-    await assert.doesNotReject(async () => {
-      result = await apiCall("GET", "/api/v1/projects", null, ORCH_KEY);
-    }, "an empty JSON body must not produce an unhandled throw");
-
-    assert.equal(result.error, true);
-    assert.equal(result.status, 502);
-    assert.match(result.body, /empty body/);
-    assert.match(result.body, /HTTP 502/);
+  test("empty body returns a structured error with the status (no throw)", () => {
+    let out;
+    assert.doesNotThrow(() => {
+      out = parseJsonResponseBody("", 502);
+    });
+    assert.equal(out.error, true);
+    assert.equal(out.status, 502);
+    assert.match(out.body, /empty body/);
+    assert.match(out.body, /HTTP 502/);
   });
 
-  test("invalid JSON body with JSON content-type returns a structured error (no throw)", async () => {
-    setupEnv();
-    mockFetchRaw("<html>502 Bad Gateway</html>", 503);
-
-    let result;
-    await assert.doesNotReject(async () => {
-      result = await apiCall("GET", "/api/v1/projects", null, ORCH_KEY);
-    }, "malformed JSON must not produce an unhandled throw");
-
-    assert.equal(result.error, true);
-    assert.equal(result.status, 503);
-    assert.match(result.body, /invalid\/empty JSON response from server/);
-    assert.match(result.body, /HTTP 503/);
-    // A snippet of the raw body is included for debugging.
-    assert.match(result.body, /502 Bad Gateway/);
+  test("whitespace-only body is treated as empty", () => {
+    const out = parseJsonResponseBody("   \n\t ", 503);
+    assert.equal(out.error, true);
+    assert.match(out.body, /empty body/);
   });
 
-  test("long invalid JSON body is truncated in the error snippet", async () => {
-    setupEnv();
+  test("invalid JSON returns a structured error with a raw-body snippet (no throw)", () => {
+    let out;
+    assert.doesNotThrow(() => {
+      out = parseJsonResponseBody("<html>502 Bad Gateway</html>", 503);
+    });
+    assert.equal(out.error, true);
+    assert.equal(out.status, 503);
+    assert.match(out.body, /invalid\/empty JSON response from server/);
+    assert.match(out.body, /HTTP 503/);
+    assert.match(out.body, /502 Bad Gateway/);
+  });
+
+  test("long invalid body is truncated in the snippet", () => {
     const long = "x".repeat(1000);
-    mockFetchRaw(long, 500);
-
-    const result = await apiCall("GET", "/api/v1/projects", null, ORCH_KEY);
-
-    assert.equal(result.error, true);
-    assert.match(result.body, /\.\.\. \(truncated\)/);
-    assert.ok(result.body.length < long.length, "snippet must be shorter than the raw body");
+    const out = parseJsonResponseBody(long, 500);
+    assert.equal(out.error, true);
+    assert.match(out.body, /\.\.\. \(truncated\)/);
+    assert.ok(out.body.length < long.length, "snippet must be shorter than the raw body");
   });
 
-  test("source: apiCall no longer calls response.json() directly", () => {
-    // The unguarded `await response.json()` was the crash vector; it must be gone.
+  test("index.js apiCall delegates to parseJsonResponseBody and no longer calls response.json() unguarded", () => {
+    assert.match(
+      INDEX_SRC,
+      /parseJsonResponseBody\(raw, response\.status\)/,
+      "apiCall must parse the JSON branch via the shared parseJsonResponseBody",
+    );
     assert.ok(
       !/responseBody = await response\.json\(\);/.test(INDEX_SRC),
       "index.js must not call response.json() unguarded",


### PR DESCRIPTION
## Summary

Follow-up to the mcp-01/02/03 fixes (merged in #283). A Sonnet-5/xhigh review verified those three fixes are correct and complete, but flagged two MEDIUM test/CI-efficacy gaps. This PR fixes both.

## FIX 1 — tests exercised a hand-copied mirror, not the shipped `index.js`

The original test file defined LOCAL copies of `listProjects` / `knowledgeIngestionJobs` / `apiCall` and tested those, so gutting the real functions in `index.js` left the suite green — the behavioral tests did not guard the shipped code.

Fix (durable approach): extract the pure logic that had bugs — the query-string building for both paginated tools, and `apiCall`'s defensive JSON parse — into a new importable module **`mcp-server/lib/http-helpers.js`** (`projectsPath` / `ingestionJobsPath` / `parseJsonResponseBody`). `index.js` is a top-level-await stdio entry point (can't be imported), but the pure module can be, so **both `index.js` and the tests import the same source of truth**. The behavioral tests now hit the real shipped functions; source-pin assertions verify the handlers, `apiCall`, and the dispatch actually call the helpers. `lib/` is added to `package.json` `files` so it ships in the tarball.

**Proof a real regression now fails a test** (done locally, then reverted):
- Breaking the real `projectsPath` query-building (`page` → `pageZZ`) → the mcp-01 behavioral tests fail (2 failures).
- Reverting `parseJsonResponseBody` to a bare `JSON.parse(rawText)` → the mcp-03 no-throw tests fail (4 failures: empty, whitespace, invalid, truncation).
- Restored → 67/67 green.

## FIX 2 — the mcp-server suite never ran in CI; a version bump auto-publishes untested

`ci.yml` is Elixir-only (never references `mcp-server/`), and both publish workflows went checkout → read version → `npm install` → `npm publish` with no test step — so a `2.30.x` bump auto-publishes to npm without `node --test` ever running.

- New **`.github/workflows/mcp-server-ci.yml`**: runs the `node --test` unit suite on every push/PR, gated by `paths: ['mcp-server/**']`.
- **`mcp-autopublish.yml`** and **`npm-publish.yml`** now run `npm test` as a **fail-fast gate before `npm publish`** (guarded by the same `exists == 'false'` condition), so a red suite blocks the npm release.
- `package.json` `"test"` is scoped to `test/*.test.js` — deterministic. It was `node --test`, which also picked up the live-network `smoke_test.mjs` via Node's `*_test.*` glob (it fails on server witness state and would flake CI). Smoke is now `npm run test:smoke`.

## Verification

- `cd mcp-server && npm ci && npm test` → **67/67 pass** (was 63; +4 real-source tests).
- `index.js` boots and serves `tools/list` with the new module import (no crash).
- The full Elixir `mix precommit` gate (compile --warnings-as-errors, format, credo --strict, deps.audit, dialyzer, 3475 tests) passes — no `--no-verify`.
- Version stays **2.30.1** (no runtime change beyond the fixes already shipped in #283).

Refs public issues #247 (mcp-01), #248 (mcp-02), #249 (mcp-03).
