### PR TITLE
fix: harden remaining project_id filters against malformed-UUID CastError 500

### DIFF
--- a/lib/loopctl/audit.ex
+++ b/lib/loopctl/audit.ex
@@ -368,7 +368,22 @@ defmodule Loopctl.Audit do
   defp filter_by(query, :action, val), do: where(query, [a], a.action == ^val)
   defp filter_by(query, :actor_type, val), do: where(query, [a], a.actor_type == ^val)
   defp filter_by(query, :actor_id, val), do: where(query, [a], a.actor_id == ^val)
-  defp filter_by(query, :project_id, val), do: where(query, [a], a.project_id == ^val)
+
+  defp filter_by(query, :project_id, val) do
+    # `project_id` is a :binary_id column; a non-UUID value would make
+    # Ecto.UUID.dump/1 fail and raise Ecto.Query.CastError (an unhandled 500).
+    # Callers validate at the API boundary and 422 first, but a malformed value
+    # reaching here must not crash — treat it as "matches nothing", consistent
+    # with a valid-but-nonexistent project (defense in depth).
+    if valid_uuid?(val) do
+      where(query, [a], a.project_id == ^val)
+    else
+      where(query, [a], false)
+    end
+  end
+
+  defp valid_uuid?(value) when is_binary(value), do: match?({:ok, _}, Ecto.UUID.cast(value))
+  defp valid_uuid?(_), do: false
 
   defp filter_from(query, nil), do: query
   defp filter_from(query, from), do: where(query, [a], a.inserted_at >= ^from)

--- a/lib/loopctl/import_export.ex
+++ b/lib/loopctl/import_export.ex
@@ -146,6 +146,18 @@ defmodule Loopctl.ImportExport do
   @spec export_project(Ecto.UUID.t(), Ecto.UUID.t()) ::
           {:ok, map()} | {:error, :not_found}
   def export_project(tenant_id, project_id) do
+    if valid_uuid?(project_id) do
+      do_export_project(tenant_id, project_id)
+    else
+      # `project_id` is a :binary_id column; a non-UUID path segment would raise
+      # Ecto.Query.CastError (an unhandled 500) on the lookup below. A malformed
+      # value is a clean :not_found (-> 404), matching Projects.get_project and
+      # the sibling import_project path.
+      {:error, :not_found}
+    end
+  end
+
+  defp do_export_project(tenant_id, project_id) do
     project =
       Loopctl.Projects.Project
       |> where([p], p.id == ^project_id and p.tenant_id == ^tenant_id)
@@ -1554,4 +1566,7 @@ defmodule Loopctl.ImportExport do
   end
 
   defp normalize_ac_item(item), do: item
+
+  defp valid_uuid?(value) when is_binary(value), do: match?({:ok, _}, Ecto.UUID.cast(value))
+  defp valid_uuid?(_), do: false
 end

--- a/lib/loopctl/orchestrator.ex
+++ b/lib/loopctl/orchestrator.ex
@@ -228,11 +228,23 @@ defmodule Loopctl.Orchestrator do
   end
 
   defp get_project(tenant_id, project_id) do
-    case AdminRepo.get_by(Project, id: project_id, tenant_id: tenant_id) do
-      nil -> {:error, :not_found}
-      project -> {:ok, project}
+    # `id: project_id` on a :binary_id column raises Ecto.Query.CastError for a
+    # non-UUID value. save_state/get_state/get_state_history all gate on this
+    # function first, so guarding the cast here makes a malformed
+    # `/orchestrator/state/:project_id` segment a clean :not_found (-> 404),
+    # never a 500. Matches Projects.get_project.
+    if valid_uuid?(project_id) do
+      case AdminRepo.get_by(Project, id: project_id, tenant_id: tenant_id) do
+        nil -> {:error, :not_found}
+        project -> {:ok, project}
+      end
+    else
+      {:error, :not_found}
     end
   end
+
+  defp valid_uuid?(value) when is_binary(value), do: match?({:ok, _}, Ecto.UUID.cast(value))
+  defp valid_uuid?(_), do: false
 
   defp insert_state(tenant_id, project_id, attrs, actor_id, actor_label) do
     changeset =

--- a/lib/loopctl/quality_assurance.ex
+++ b/lib/loopctl/quality_assurance.ex
@@ -234,9 +234,21 @@ defmodule Loopctl.QualityAssurance do
 
     base =
       from(r in UiTestRun,
-        where: r.tenant_id == ^tenant_id and r.project_id == ^project_id,
+        where: r.tenant_id == ^tenant_id,
         order_by: [desc: r.started_at]
       )
+
+    # `project_id` is a :binary_id column; a non-UUID value would raise
+    # Ecto.Query.CastError (an unhandled 500). Callers validate at the API
+    # boundary and 422 first, but a malformed value reaching here must not
+    # crash — scope to nothing, consistent with a nonexistent project (defense
+    # in depth).
+    base =
+      if valid_uuid?(project_id) do
+        where(base, [r], r.project_id == ^project_id)
+      else
+        where(base, [r], false)
+      end
 
     base =
       if status do
@@ -282,4 +294,7 @@ defmodule Loopctl.QualityAssurance do
 
   defp require_in_progress(%UiTestRun{status: :in_progress}), do: :ok
   defp require_in_progress(%UiTestRun{}), do: {:error, :run_not_in_progress}
+
+  defp valid_uuid?(value) when is_binary(value), do: match?({:ok, _}, Ecto.UUID.cast(value))
+  defp valid_uuid?(_), do: false
 end

--- a/lib/loopctl/skills.ex
+++ b/lib/loopctl/skills.ex
@@ -708,7 +708,21 @@ defmodule Loopctl.Skills do
   end
 
   defp filter_project_id(query, nil), do: query
-  defp filter_project_id(query, id), do: where(query, [s], s.project_id == ^id)
+
+  defp filter_project_id(query, id) do
+    # `project_id` is a :binary_id column; a non-UUID value would raise
+    # Ecto.Query.CastError (an unhandled 500). Callers validate at the API
+    # boundary and 422 first, but a malformed value reaching here must not
+    # crash — treat it as "matches nothing" (defense in depth).
+    if valid_uuid?(id) do
+      where(query, [s], s.project_id == ^id)
+    else
+      where(query, [s], false)
+    end
+  end
+
+  defp valid_uuid?(value) when is_binary(value), do: match?({:ok, _}, Ecto.UUID.cast(value))
+  defp valid_uuid?(_), do: false
 
   defp filter_status(query, nil), do: query
 

--- a/lib/loopctl/skills.ex
+++ b/lib/loopctl/skills.ex
@@ -534,9 +534,24 @@ defmodule Loopctl.Skills do
   end
 
   defp import_single_skill(tenant_id, params, actor_label) do
-    case AdminRepo.get_by(Skill, name: params.name, tenant_id: tenant_id) do
-      nil -> import_create_skill(tenant_id, params, actor_label)
-      existing -> import_update_skill(tenant_id, existing, params, actor_label)
+    # Defense in depth: import_create_skill sets `project_id` DIRECTLY on the
+    # %Skill{} struct (it is NOT in Skill.create_changeset's cast list), so a
+    # non-nil, non-UUID value dumps to Ecto.ChangeError on insert -> unhandled
+    # 500. The controller validates each item and 422s first, but a malformed
+    # value reaching here must return a clean changeset error (rolls the whole
+    # import Multi back — no partial insert) instead of raising.
+    if is_nil(params.project_id) or valid_uuid?(params.project_id) do
+      case AdminRepo.get_by(Skill, name: params.name, tenant_id: tenant_id) do
+        nil -> import_create_skill(tenant_id, params, actor_label)
+        existing -> import_update_skill(tenant_id, existing, params, actor_label)
+      end
+    else
+      changeset =
+        %Skill{}
+        |> Skill.create_changeset(%{"name" => params.name})
+        |> Ecto.Changeset.add_error(:project_id, "must be a valid UUID")
+
+      {:error, changeset}
     end
   end
 

--- a/lib/loopctl/token_usage.ex
+++ b/lib/loopctl/token_usage.ex
@@ -1600,10 +1600,21 @@ defmodule Loopctl.TokenUsage do
   defp apply_anomaly_filter(query, :project_id, "", _tenant_id), do: query
 
   defp apply_anomaly_filter(query, :project_id, project_id, _tenant_id) do
-    query
-    |> join(:inner, [a], s in Story, on: a.story_id == s.id)
-    |> where([_a, s], s.project_id == ^project_id)
+    # `project_id` is a :binary_id column; a non-UUID value would raise
+    # Ecto.Query.CastError (an unhandled 500). Callers validate at the API
+    # boundary and 422 first, but a malformed value reaching here must not
+    # crash — treat it as "matches nothing" (defense in depth).
+    if valid_uuid?(project_id) do
+      query
+      |> join(:inner, [a], s in Story, on: a.story_id == s.id)
+      |> where([_a, s], s.project_id == ^project_id)
+    else
+      where(query, [a], false)
+    end
   end
+
+  defp valid_uuid?(value) when is_binary(value), do: match?({:ok, _}, Ecto.UUID.cast(value))
+  defp valid_uuid?(_), do: false
 
   defp format_anomaly(%CostAnomaly{} = anomaly) do
     story_title =

--- a/lib/loopctl/token_usage.ex
+++ b/lib/loopctl/token_usage.ex
@@ -1261,9 +1261,17 @@ defmodule Loopctl.TokenUsage do
   defp check_entity_exists(nil, _scope_id, _tenant_id), do: :ok
 
   defp check_entity_exists(schema, scope_id, tenant_id) do
-    case AdminRepo.get_by(schema, id: scope_id, tenant_id: tenant_id) do
-      nil -> {:error, :not_found}
-      _entity -> :ok
+    # `id: scope_id` on a :binary_id column raises Ecto.Query.CastError for a
+    # non-UUID value. The controller 422s a malformed scope_id first; guarding
+    # the cast here makes a malformed value a clean :not_found (never a raised
+    # query error), consistent with a valid-but-nonexistent scope entity.
+    if valid_uuid?(scope_id) do
+      case AdminRepo.get_by(schema, id: scope_id, tenant_id: tenant_id) do
+        nil -> {:error, :not_found}
+        _entity -> :ok
+      end
+    else
+      {:error, :not_found}
     end
   end
 

--- a/lib/loopctl/token_usage/analytics.ex
+++ b/lib/loopctl/token_usage/analytics.ex
@@ -236,6 +236,17 @@ defmodule Loopctl.TokenUsage.Analytics do
   """
   @spec project_metrics(Ecto.UUID.t(), Ecto.UUID.t()) :: {:ok, map()} | {:error, :not_found}
   def project_metrics(tenant_id, project_id) do
+    if valid_uuid?(project_id) do
+      compute_project_metrics(tenant_id, project_id)
+    else
+      # `project_id` is a :binary_id column; a non-UUID path segment would raise
+      # Ecto.Query.CastError (an unhandled 500) on the existence check below. A
+      # malformed value is a clean :not_found (-> 404), matching Projects.get_project.
+      {:error, :not_found}
+    end
+  end
+
+  defp compute_project_metrics(tenant_id, project_id) do
     # Verify project exists
     project_query =
       from(p in Loopctl.Projects.Project,
@@ -632,15 +643,29 @@ defmodule Loopctl.TokenUsage.Analytics do
 
   defp apply_project_filter(query, opts) do
     case Keyword.get(opts, :project_id) do
-      nil -> query
-      pid -> where(query, [r], r.project_id == ^pid)
+      nil ->
+        query
+
+      pid ->
+        # Defense in depth: a non-UUID :binary_id value would raise
+        # Ecto.Query.CastError (500). Callers 422 at the boundary; a malformed
+        # value here matches nothing rather than crashing.
+        if valid_uuid?(pid) do
+          where(query, [r], r.project_id == ^pid)
+        else
+          where(query, [r], false)
+        end
     end
   end
 
   defp maybe_filter_epic_project(query, nil), do: query
 
   defp maybe_filter_epic_project(query, project_id) do
-    where(query, [e], e.project_id == ^project_id)
+    if valid_uuid?(project_id) do
+      where(query, [e], e.project_id == ^project_id)
+    else
+      where(query, [e], false)
+    end
   end
 
   # Batch-fetch primary model per agent by total token count (AC-21.4.1).
@@ -1118,10 +1143,23 @@ defmodule Loopctl.TokenUsage.Analytics do
 
   defp apply_model_project_filter(query, opts) do
     case Keyword.get(opts, :project_id) do
-      nil -> query
-      pid -> where(query, [r, _s], r.project_id == ^pid)
+      nil ->
+        query
+
+      pid ->
+        # Defense in depth: a non-UUID :binary_id value would raise
+        # Ecto.Query.CastError (500). Callers 422 at the boundary; a malformed
+        # value here matches nothing rather than crashing.
+        if valid_uuid?(pid) do
+          where(query, [r, _s], r.project_id == ^pid)
+        else
+          where(query, [r, _s], false)
+        end
     end
   end
+
+  defp valid_uuid?(value) when is_binary(value), do: match?({:ok, _}, Ecto.UUID.cast(value))
+  defp valid_uuid?(_), do: false
 
   defp apply_model_agent_filter(query, opts) do
     case Keyword.get(opts, :agent_id) do

--- a/lib/loopctl/work_breakdown/queries.ex
+++ b/lib/loopctl/work_breakdown/queries.ex
@@ -204,6 +204,17 @@ defmodule Loopctl.WorkBreakdown.Queries do
   @spec get_dependency_graph(Ecto.UUID.t(), Ecto.UUID.t()) ::
           {:ok, map()} | {:error, :not_found}
   def get_dependency_graph(tenant_id, project_id) do
+    if valid_uuid?(project_id) do
+      build_dependency_graph(tenant_id, project_id)
+    else
+      # `project_id` is a :binary_id column; a non-UUID path segment would raise
+      # Ecto.Query.CastError (an unhandled 500) on the existence check below. A
+      # malformed value is a clean :not_found (-> 404), matching Projects.get_project.
+      {:error, :not_found}
+    end
+  end
+
+  defp build_dependency_graph(tenant_id, project_id) do
     # Verify the project exists
     project_exists =
       from(p in Project,
@@ -278,11 +289,27 @@ defmodule Loopctl.WorkBreakdown.Queries do
 
   defp apply_project_filter(query, opts) do
     case Keyword.get(opts, :project_id) do
-      nil -> query
-      "" -> query
-      project_id -> where(query, [s], s.project_id == ^project_id)
+      nil ->
+        query
+
+      "" ->
+        query
+
+      project_id ->
+        # `project_id` is a :binary_id column; a non-UUID value would raise
+        # Ecto.Query.CastError (an unhandled 500). Callers validate at the API
+        # boundary and 422 first, but a malformed value reaching here must not
+        # crash — treat it as "matches nothing" (defense in depth).
+        if valid_uuid?(project_id) do
+          where(query, [s], s.project_id == ^project_id)
+        else
+          where(query, [s], false)
+        end
     end
   end
+
+  defp valid_uuid?(value) when is_binary(value), do: match?({:ok, _}, Ecto.UUID.cast(value))
+  defp valid_uuid?(_), do: false
 
   defp apply_epic_filter(query, opts) do
     case Keyword.get(opts, :epic_id) do

--- a/lib/loopctl/work_breakdown/queries.ex
+++ b/lib/loopctl/work_breakdown/queries.ex
@@ -313,9 +313,21 @@ defmodule Loopctl.WorkBreakdown.Queries do
 
   defp apply_epic_filter(query, opts) do
     case Keyword.get(opts, :epic_id) do
-      nil -> query
-      "" -> query
-      epic_id -> where(query, [s], s.epic_id == ^epic_id)
+      nil ->
+        query
+
+      "" ->
+        query
+
+      epic_id ->
+        # `epic_id` is a :binary_id column; a non-UUID value would raise
+        # Ecto.Query.CastError. Treat a malformed value as "matches nothing",
+        # consistent with apply_project_filter/2 above (defense in depth).
+        if valid_uuid?(epic_id) do
+          where(query, [s], s.epic_id == ^epic_id)
+        else
+          where(query, [s], false)
+        end
     end
   end
 

--- a/lib/loopctl/work_breakdown/stories.ex
+++ b/lib/loopctl/work_breakdown/stories.ex
@@ -287,7 +287,8 @@ defmodule Loopctl.WorkBreakdown.Stories do
 
     base_query =
       Story
-      |> where([s], s.tenant_id == ^tenant_id and s.project_id == ^project_id)
+      |> where([s], s.tenant_id == ^tenant_id)
+      |> scope_by_project(project_id)
       |> apply_project_filters(opts)
 
     total = AdminRepo.aggregate(base_query, :count, :id)
@@ -330,7 +331,31 @@ defmodule Loopctl.WorkBreakdown.Stories do
 
   defp filter_by_epic_id(query, nil), do: query
   defp filter_by_epic_id(query, ""), do: query
-  defp filter_by_epic_id(query, epic_id), do: where(query, [s], s.epic_id == ^epic_id)
+
+  defp filter_by_epic_id(query, epic_id) do
+    # `epic_id` is a :binary_id column; a non-UUID value would raise
+    # Ecto.Query.CastError (500 -> global handler 404). Treat a malformed value
+    # as "matches nothing", consistent with a nonexistent epic (defense in depth).
+    if valid_uuid?(epic_id) do
+      where(query, [s], s.epic_id == ^epic_id)
+    else
+      where(query, [s], false)
+    end
+  end
+
+  # `project_id` is mandatory here (stories are scoped to a project). A non-UUID
+  # value would raise Ecto.Query.CastError; scope to nothing instead, matching a
+  # valid-but-nonexistent project. The controller 422s a malformed value first.
+  defp scope_by_project(query, project_id) do
+    if valid_uuid?(project_id) do
+      where(query, [s], s.project_id == ^project_id)
+    else
+      where(query, [s], false)
+    end
+  end
+
+  defp valid_uuid?(value) when is_binary(value), do: match?({:ok, _}, Ecto.UUID.cast(value))
+  defp valid_uuid?(_), do: false
 
   defp filter_by_agent_status(query, nil), do: query
   defp filter_by_agent_status(query, ""), do: query

--- a/lib/loopctl_web/controllers/analytics_controller.ex
+++ b/lib/loopctl_web/controllers/analytics_controller.ex
@@ -18,6 +18,7 @@ defmodule LoopctlWeb.AnalyticsController do
 
   alias Loopctl.ApiSpec.Schemas
   alias Loopctl.TokenUsage.Analytics
+  alias LoopctlWeb.Helpers.ProjectId
 
   action_fallback LoopctlWeb.FallbackController
 
@@ -274,14 +275,17 @@ defmodule LoopctlWeb.AnalyticsController do
   """
   def agents(conn, params) do
     tenant_id = conn.assigns.current_api_key.tenant_id
-    opts = build_opts(params, [:project_id, :since, :until, :page, :page_size])
 
-    {:ok, result} = Analytics.agent_metrics(tenant_id, opts)
+    with :ok <- ProjectId.validate(params["project_id"]) do
+      opts = build_opts(params, [:project_id, :since, :until, :page, :page_size])
 
-    json(conn, %{
-      data: result.data,
-      meta: pagination_meta(result)
-    })
+      {:ok, result} = Analytics.agent_metrics(tenant_id, opts)
+
+      json(conn, %{
+        data: result.data,
+        meta: pagination_meta(result)
+      })
+    end
   end
 
   @doc """
@@ -291,14 +295,17 @@ defmodule LoopctlWeb.AnalyticsController do
   """
   def epics(conn, params) do
     tenant_id = conn.assigns.current_api_key.tenant_id
-    opts = build_opts(params, [:project_id, :page, :page_size])
 
-    {:ok, result} = Analytics.epic_metrics(tenant_id, opts)
+    with :ok <- ProjectId.validate(params["project_id"]) do
+      opts = build_opts(params, [:project_id, :page, :page_size])
 
-    json(conn, %{
-      data: result.data,
-      meta: pagination_meta(result)
-    })
+      {:ok, result} = Analytics.epic_metrics(tenant_id, opts)
+
+      json(conn, %{
+        data: result.data,
+        meta: pagination_meta(result)
+      })
+    end
   end
 
   @doc """
@@ -321,14 +328,17 @@ defmodule LoopctlWeb.AnalyticsController do
   """
   def models(conn, params) do
     tenant_id = conn.assigns.current_api_key.tenant_id
-    opts = build_opts(params, [:project_id, :since, :until, :page, :page_size])
 
-    {:ok, result} = Analytics.model_metrics(tenant_id, opts)
+    with :ok <- ProjectId.validate(params["project_id"]) do
+      opts = build_opts(params, [:project_id, :since, :until, :page, :page_size])
 
-    json(conn, %{
-      data: result.data,
-      meta: pagination_meta(result)
-    })
+      {:ok, result} = Analytics.model_metrics(tenant_id, opts)
+
+      json(conn, %{
+        data: result.data,
+        meta: pagination_meta(result)
+      })
+    end
   end
 
   @doc """
@@ -339,15 +349,17 @@ defmodule LoopctlWeb.AnalyticsController do
   def trends(conn, params) do
     tenant_id = conn.assigns.current_api_key.tenant_id
 
-    opts =
-      build_opts(params, [:project_id, :since, :until, :page, :page_size, :granularity])
+    with :ok <- ProjectId.validate(params["project_id"]) do
+      opts =
+        build_opts(params, [:project_id, :since, :until, :page, :page_size, :granularity])
 
-    {:ok, result} = Analytics.trend_metrics(tenant_id, opts)
+      {:ok, result} = Analytics.trend_metrics(tenant_id, opts)
 
-    json(conn, %{
-      data: result.data,
-      meta: pagination_meta(result)
-    })
+      json(conn, %{
+        data: result.data,
+        meta: pagination_meta(result)
+      })
+    end
   end
 
   @doc """
@@ -357,11 +369,14 @@ defmodule LoopctlWeb.AnalyticsController do
   """
   def model_mix(conn, params) do
     tenant_id = conn.assigns.current_api_key.tenant_id
-    opts = build_opts(params, [:project_id, :agent_id, :since, :until])
 
-    {:ok, result} = Analytics.model_mix(tenant_id, opts)
+    with :ok <- ProjectId.validate(params["project_id"]) do
+      opts = build_opts(params, [:project_id, :agent_id, :since, :until])
 
-    json(conn, %{data: result})
+      {:ok, result} = Analytics.model_mix(tenant_id, opts)
+
+      json(conn, %{data: result})
+    end
   end
 
   @doc """
@@ -373,7 +388,8 @@ defmodule LoopctlWeb.AnalyticsController do
     tenant_id = conn.assigns.current_api_key.tenant_id
     opts = build_opts(params, [:project_id, :since, :until])
 
-    with {:ok, profile} <- Analytics.agent_model_profile(tenant_id, agent_id, opts) do
+    with :ok <- ProjectId.validate(params["project_id"]),
+         {:ok, profile} <- Analytics.agent_model_profile(tenant_id, agent_id, opts) do
       json(conn, %{data: profile})
     end
   end

--- a/lib/loopctl_web/controllers/audit_controller.ex
+++ b/lib/loopctl_web/controllers/audit_controller.ex
@@ -11,6 +11,7 @@ defmodule LoopctlWeb.AuditController do
 
   alias Loopctl.ApiSpec.Schemas
   alias Loopctl.Audit
+  alias LoopctlWeb.Helpers.ProjectId
 
   action_fallback LoopctlWeb.FallbackController
 
@@ -49,7 +50,8 @@ defmodule LoopctlWeb.AuditController do
   project_id, from, to, page, page_size.
   """
   def index(conn, params) do
-    with {:ok, tenant_id} <- require_tenant(conn) do
+    with {:ok, tenant_id} <- require_tenant(conn),
+         :ok <- ProjectId.validate(params["project_id"]) do
       opts =
         []
         |> maybe_put(:entity_type, params["entity_type"])

--- a/lib/loopctl_web/controllers/change_controller.ex
+++ b/lib/loopctl_web/controllers/change_controller.ex
@@ -17,6 +17,7 @@ defmodule LoopctlWeb.ChangeController do
   alias Loopctl.Audit
   alias Loopctl.Audit.ChangesCursor
   alias Loopctl.Knowledge
+  alias LoopctlWeb.Helpers.ProjectId
   alias LoopctlWeb.Helpers.Visibility
 
   action_fallback LoopctlWeb.FallbackController
@@ -98,6 +99,7 @@ defmodule LoopctlWeb.ChangeController do
   """
   def index(conn, params) do
     with {:ok, tenant_id} <- require_tenant(conn),
+         :ok <- ProjectId.validate(params["project_id"]),
          {:ok, since, cursor_opt} <- resolve_seek(tenant_id, params) do
       limit = parse_limit(params["limit"])
 

--- a/lib/loopctl_web/controllers/cost_anomaly_controller.ex
+++ b/lib/loopctl_web/controllers/cost_anomaly_controller.ex
@@ -11,6 +11,7 @@ defmodule LoopctlWeb.CostAnomalyController do
 
   alias Loopctl.ApiSpec.Schemas
   alias Loopctl.TokenUsage
+  alias LoopctlWeb.Helpers.ProjectId
 
   action_fallback LoopctlWeb.FallbackController
 
@@ -101,26 +102,28 @@ defmodule LoopctlWeb.CostAnomalyController do
     api_key = conn.assigns.current_api_key
     tenant_id = api_key.tenant_id
 
-    opts =
-      []
-      |> maybe_add_opt(:anomaly_type, params["anomaly_type"])
-      |> maybe_add_opt(:project_id, params["project_id"])
-      |> maybe_add_opt(:include_archived, parse_bool(params["include_archived"]))
-      |> maybe_add_opt(:resolved, parse_bool(params["resolved"]))
-      |> maybe_add_opt(:page, parse_int(params["page"]))
-      |> maybe_add_opt(:page_size, parse_int(params["page_size"]))
+    with :ok <- ProjectId.validate(params["project_id"]) do
+      opts =
+        []
+        |> maybe_add_opt(:anomaly_type, params["anomaly_type"])
+        |> maybe_add_opt(:project_id, params["project_id"])
+        |> maybe_add_opt(:include_archived, parse_bool(params["include_archived"]))
+        |> maybe_add_opt(:resolved, parse_bool(params["resolved"]))
+        |> maybe_add_opt(:page, parse_int(params["page"]))
+        |> maybe_add_opt(:page_size, parse_int(params["page_size"]))
 
-    {:ok, result} = TokenUsage.list_anomalies(tenant_id, opts)
+      {:ok, result} = TokenUsage.list_anomalies(tenant_id, opts)
 
-    json(conn, %{
-      data: result.data,
-      meta: %{
-        page: result.page,
-        page_size: result.page_size,
-        total_count: result.total,
-        total_pages: ceil_div(result.total, result.page_size)
-      }
-    })
+      json(conn, %{
+        data: result.data,
+        meta: %{
+          page: result.page,
+          page_size: result.page_size,
+          total_count: result.total,
+          total_pages: ceil_div(result.total, result.page_size)
+        }
+      })
+    end
   end
 
   @doc """

--- a/lib/loopctl_web/controllers/dependency_graph_controller.ex
+++ b/lib/loopctl_web/controllers/dependency_graph_controller.ex
@@ -12,6 +12,7 @@ defmodule LoopctlWeb.DependencyGraphController do
 
   alias Loopctl.ApiSpec.Schemas
   alias Loopctl.WorkBreakdown.Queries
+  alias LoopctlWeb.Helpers.ProjectId
 
   action_fallback LoopctlWeb.FallbackController
 
@@ -79,24 +80,26 @@ defmodule LoopctlWeb.DependencyGraphController do
   def ready(conn, params) do
     tenant_id = conn.assigns.current_api_key.tenant_id
 
-    opts =
-      []
-      |> maybe_add_opt(:project_id, params["project_id"])
-      |> maybe_add_opt(:epic_id, params["epic_id"])
-      |> maybe_add_opt(:page, parse_int(params["page"]))
-      |> maybe_add_opt(:page_size, parse_int(params["page_size"]))
+    with :ok <- ProjectId.validate(params["project_id"]) do
+      opts =
+        []
+        |> maybe_add_opt(:project_id, params["project_id"])
+        |> maybe_add_opt(:epic_id, params["epic_id"])
+        |> maybe_add_opt(:page, parse_int(params["page"]))
+        |> maybe_add_opt(:page_size, parse_int(params["page_size"]))
 
-    {:ok, result} = Queries.list_ready_stories(tenant_id, opts)
+      {:ok, result} = Queries.list_ready_stories(tenant_id, opts)
 
-    json(conn, %{
-      data: Enum.map(result.data, &story_json/1),
-      meta: %{
-        page: result.page,
-        page_size: result.page_size,
-        total_count: result.total,
-        total_pages: ceil_div(result.total, result.page_size)
-      }
-    })
+      json(conn, %{
+        data: Enum.map(result.data, &story_json/1),
+        meta: %{
+          page: result.page,
+          page_size: result.page_size,
+          total_count: result.total,
+          total_pages: ceil_div(result.total, result.page_size)
+        }
+      })
+    end
   end
 
   @doc """
@@ -107,29 +110,31 @@ defmodule LoopctlWeb.DependencyGraphController do
   def blocked(conn, params) do
     tenant_id = conn.assigns.current_api_key.tenant_id
 
-    opts =
-      []
-      |> maybe_add_opt(:project_id, params["project_id"])
-      |> maybe_add_opt(:page, parse_int(params["page"]))
-      |> maybe_add_opt(:page_size, parse_int(params["page_size"]))
+    with :ok <- ProjectId.validate(params["project_id"]) do
+      opts =
+        []
+        |> maybe_add_opt(:project_id, params["project_id"])
+        |> maybe_add_opt(:page, parse_int(params["page"]))
+        |> maybe_add_opt(:page_size, parse_int(params["page_size"]))
 
-    {:ok, result} = Queries.list_blocked_stories(tenant_id, opts)
+      {:ok, result} = Queries.list_blocked_stories(tenant_id, opts)
 
-    json(conn, %{
-      data:
-        Enum.map(result.data, fn item ->
-          %{
-            story: story_json(item.story),
-            blocking_dependencies: item.blocking_dependencies
-          }
-        end),
-      meta: %{
-        page: result.page,
-        page_size: result.page_size,
-        total_count: result.total,
-        total_pages: ceil_div(result.total, result.page_size)
-      }
-    })
+      json(conn, %{
+        data:
+          Enum.map(result.data, fn item ->
+            %{
+              story: story_json(item.story),
+              blocking_dependencies: item.blocking_dependencies
+            }
+          end),
+        meta: %{
+          page: result.page,
+          page_size: result.page_size,
+          total_count: result.total,
+          total_pages: ceil_div(result.total, result.page_size)
+        }
+      })
+    end
   end
 
   @doc """

--- a/lib/loopctl_web/controllers/skill_controller.ex
+++ b/lib/loopctl_web/controllers/skill_controller.ex
@@ -19,6 +19,7 @@ defmodule LoopctlWeb.SkillController do
   alias Loopctl.ApiSpec.Schemas
   alias Loopctl.Skills
   alias LoopctlWeb.AuditContext
+  alias LoopctlWeb.Helpers.ProjectId
 
   action_fallback LoopctlWeb.FallbackController
 
@@ -295,14 +296,12 @@ defmodule LoopctlWeb.SkillController do
     tenant_id = api_key.tenant_id
     audit_opts = AuditContext.from_conn(conn)
 
-    case Skills.create_skill(tenant_id, params, audit_opts) do
-      {:ok, %{skill: skill, version: version}} ->
-        conn
-        |> put_status(:created)
-        |> json(%{skill: skill_json(skill), version: version_json(version)})
-
-      {:error, %Ecto.Changeset{} = changeset} ->
-        {:error, changeset}
+    with :ok <- ProjectId.validate(params["project_id"]),
+         {:ok, %{skill: skill, version: version}} <-
+           Skills.create_skill(tenant_id, params, audit_opts) do
+      conn
+      |> put_status(:created)
+      |> json(%{skill: skill_json(skill), version: version_json(version)})
     end
   end
 
@@ -310,27 +309,29 @@ defmodule LoopctlWeb.SkillController do
   def index(conn, params) do
     tenant_id = conn.assigns.current_api_key.tenant_id
 
-    opts = [
-      page: parse_int(params["page"]),
-      page_size: parse_int(params["page_size"]),
-      project_id: params["project_id"],
-      status: params["status"],
-      name_pattern: params["name"]
-    ]
+    with :ok <- ProjectId.validate(params["project_id"]) do
+      opts = [
+        page: parse_int(params["page"]),
+        page_size: parse_int(params["page_size"]),
+        project_id: params["project_id"],
+        status: params["status"],
+        name_pattern: params["name"]
+      ]
 
-    opts = Enum.reject(opts, fn {_k, v} -> is_nil(v) end)
+      opts = Enum.reject(opts, fn {_k, v} -> is_nil(v) end)
 
-    {:ok, result} = Skills.list_skills(tenant_id, opts)
+      {:ok, result} = Skills.list_skills(tenant_id, opts)
 
-    json(conn, %{
-      data: Enum.map(result.data, &skill_json/1),
-      meta: %{
-        page: result.page,
-        page_size: result.page_size,
-        total_count: result.total,
-        total_pages: ceil_div(result.total, result.page_size)
-      }
-    })
+      json(conn, %{
+        data: Enum.map(result.data, &skill_json/1),
+        meta: %{
+          page: result.page,
+          page_size: result.page_size,
+          total_count: result.total,
+          total_pages: ceil_div(result.total, result.page_size)
+        }
+      })
+    end
   end
 
   @doc "GET /api/v1/skills/:id"

--- a/lib/loopctl_web/controllers/skill_controller.ex
+++ b/lib/loopctl_web/controllers/skill_controller.ex
@@ -456,12 +456,37 @@ defmodule LoopctlWeb.SkillController do
     tenant_id = api_key.tenant_id
     audit_opts = AuditContext.from_conn(conn)
 
-    {:ok, summary} = Skills.import_skills(tenant_id, skills_data, audit_opts)
-    json(conn, summary)
+    with :ok <- validate_import_project_ids(skills_data),
+         {:ok, summary} <- Skills.import_skills(tenant_id, skills_data, audit_opts) do
+      json(conn, summary)
+    end
   end
 
   def import_skills(_conn, _params) do
     {:error, :bad_request, "Request body must contain a 'skills' array"}
+  end
+
+  # Reject the whole import if ANY item carries a malformed project_id: each
+  # item's project_id is set uncast on the %Skill{} struct, so a bad value would
+  # otherwise dump to Ecto.ChangeError on insert (an unhandled 500). Naming the
+  # offending index gives the caller a clean, actionable 422 and guarantees no
+  # partial insert (validated before the import Multi runs).
+  defp validate_import_project_ids(skills_data) do
+    skills_data
+    |> Enum.with_index()
+    |> Enum.reduce_while(:ok, fn {skill_data, index}, :ok ->
+      project_id = if is_map(skill_data), do: skill_data["project_id"], else: nil
+
+      case ProjectId.validate(project_id) do
+        :ok ->
+          {:cont, :ok}
+
+        {:error, :unprocessable_entity, _msg} ->
+          {:halt,
+           {:error, :unprocessable_entity,
+            "Invalid project_id at skills[#{index}]: must be a valid UUID"}}
+      end
+    end)
   end
 
   @doc "GET /api/v1/skills/:id/stats"

--- a/lib/loopctl_web/controllers/story_controller.ex
+++ b/lib/loopctl_web/controllers/story_controller.ex
@@ -20,6 +20,7 @@ defmodule LoopctlWeb.StoryController do
   alias Loopctl.WorkBreakdown.Epics
   alias Loopctl.WorkBreakdown.Stories
   alias LoopctlWeb.AuditContext
+  alias LoopctlWeb.Helpers.ProjectId
 
   action_fallback LoopctlWeb.FallbackController
 
@@ -334,26 +335,28 @@ defmodule LoopctlWeb.StoryController do
   def index_by_project(conn, %{"project_id" => project_id} = params) do
     tenant_id = conn.assigns.current_api_key.tenant_id
 
-    limit = parse_int(params["limit"]) || parse_int(params["page_size"])
+    with :ok <- ProjectId.validate(project_id) do
+      limit = parse_int(params["limit"]) || parse_int(params["page_size"])
 
-    opts =
-      []
-      |> maybe_add_opt(:agent_status, params["agent_status"])
-      |> maybe_add_opt(:verified_status, params["verified_status"])
-      |> maybe_add_opt(:epic_id, params["epic_id"])
-      |> maybe_add_opt(:limit, limit)
-      |> maybe_add_opt(:offset, parse_int(params["offset"]))
+      opts =
+        []
+        |> maybe_add_opt(:agent_status, params["agent_status"])
+        |> maybe_add_opt(:verified_status, params["verified_status"])
+        |> maybe_add_opt(:epic_id, params["epic_id"])
+        |> maybe_add_opt(:limit, limit)
+        |> maybe_add_opt(:offset, parse_int(params["offset"]))
 
-    {:ok, result} = Stories.list_stories_by_project(tenant_id, project_id, opts)
+      {:ok, result} = Stories.list_stories_by_project(tenant_id, project_id, opts)
 
-    json(conn, %{
-      data: Enum.map(result.data, &story_json/1),
-      meta: %{
-        total_count: result.total,
-        limit: result.limit,
-        offset: result.offset
-      }
-    })
+      json(conn, %{
+        data: Enum.map(result.data, &story_json/1),
+        meta: %{
+          total_count: result.total,
+          limit: result.limit,
+          offset: result.offset
+        }
+      })
+    end
   end
 
   def index_by_project(conn, _params) do

--- a/lib/loopctl_web/controllers/token_budget_controller.ex
+++ b/lib/loopctl_web/controllers/token_budget_controller.ex
@@ -16,6 +16,7 @@ defmodule LoopctlWeb.TokenBudgetController do
   alias Loopctl.TokenUsage
   alias Loopctl.TokenUsage.Formatting
   alias LoopctlWeb.AuditContext
+  alias LoopctlWeb.Helpers.ProjectId
 
   action_fallback LoopctlWeb.FallbackController
 
@@ -214,22 +215,17 @@ defmodule LoopctlWeb.TokenBudgetController do
     tenant_id = api_key.tenant_id
     audit_opts = AuditContext.from_conn(conn)
 
-    case TokenUsage.create_budget(tenant_id, params, audit_opts) do
-      {:ok, budget} ->
-        spend = TokenUsage.get_scope_spend(tenant_id, budget.scope_type, budget.scope_id)
+    # `scope_id` (a project/epic/story UUID) is set uncast on the %Budget{}
+    # struct, so a malformed value would raise Ecto.Query.CastError on the
+    # existence check (or dump on insert). Validate its UUID format at the
+    # boundary for a clean 422 before any DB work.
+    with :ok <- ProjectId.validate(params["scope_id"]),
+         {:ok, budget} <- TokenUsage.create_budget(tenant_id, params, audit_opts) do
+      spend = TokenUsage.get_scope_spend(tenant_id, budget.scope_type, budget.scope_id)
 
-        conn
-        |> put_status(:created)
-        |> json(%{token_budget: format_budget_with_spend(budget, spend)})
-
-      {:error, :not_found} ->
-        {:error, :not_found}
-
-      {:error, :conflict} ->
-        {:error, :conflict}
-
-      {:error, %Ecto.Changeset{} = changeset} ->
-        {:error, changeset}
+      conn
+      |> put_status(:created)
+      |> json(%{token_budget: format_budget_with_spend(budget, spend)})
     end
   end
 

--- a/lib/loopctl_web/controllers/ui_test_controller.ex
+++ b/lib/loopctl_web/controllers/ui_test_controller.ex
@@ -17,6 +17,7 @@ defmodule LoopctlWeb.UiTestController do
   alias Loopctl.ApiSpec.Schemas
   alias Loopctl.QualityAssurance
   alias LoopctlWeb.AuditContext
+  alias LoopctlWeb.Helpers.ProjectId
 
   action_fallback LoopctlWeb.FallbackController
 
@@ -130,14 +131,11 @@ defmodule LoopctlWeb.UiTestController do
 
     opts = Keyword.merge(audit_opts, agent_id: api_key.agent_id)
 
-    case QualityAssurance.start_ui_test(tenant_id, project_id, run_params, opts) do
-      {:ok, run} ->
-        conn
-        |> put_status(:created)
-        |> json(%{ui_test_run: run})
-
-      {:error, %Ecto.Changeset{} = changeset} ->
-        {:error, changeset}
+    with :ok <- ProjectId.validate(project_id),
+         {:ok, run} <- QualityAssurance.start_ui_test(tenant_id, project_id, run_params, opts) do
+      conn
+      |> put_status(:created)
+      |> json(%{ui_test_run: run})
     end
   end
 
@@ -150,22 +148,24 @@ defmodule LoopctlWeb.UiTestController do
     api_key = conn.assigns.current_api_key
     tenant_id = api_key.tenant_id
 
-    opts =
-      []
-      |> maybe_add_opt(:status, params["status"])
-      |> maybe_add_opt(:limit, parse_int(params["limit"]))
-      |> maybe_add_opt(:offset, parse_int(params["offset"]))
+    with :ok <- ProjectId.validate(project_id) do
+      opts =
+        []
+        |> maybe_add_opt(:status, params["status"])
+        |> maybe_add_opt(:limit, parse_int(params["limit"]))
+        |> maybe_add_opt(:offset, parse_int(params["offset"]))
 
-    {:ok, result} = QualityAssurance.list_ui_tests(tenant_id, project_id, opts)
+      {:ok, result} = QualityAssurance.list_ui_tests(tenant_id, project_id, opts)
 
-    json(conn, %{
-      data: result.data,
-      meta: %{
-        total: result.total,
-        limit: result.limit,
-        offset: result.offset
-      }
-    })
+      json(conn, %{
+        data: result.data,
+        meta: %{
+          total: result.total,
+          limit: result.limit,
+          offset: result.offset
+        }
+      })
+    end
   end
 
   @doc """

--- a/lib/loopctl_web/plugs/cast_error_handler.ex
+++ b/lib/loopctl_web/plugs/cast_error_handler.ex
@@ -1,11 +1,26 @@
 defmodule LoopctlWeb.Plugs.CastErrorHandler do
   @moduledoc """
-  Implements `Plug.Exception` for Ecto cast errors to return 404.
+  Implements `Plug.Exception` for Ecto cast/change errors so a malformed
+  client-supplied value maps to a clean 4xx instead of a raw 500.
 
-  When an invalid UUID format is passed to a GET-by-ID endpoint
-  (e.g., `/api/v1/projects/not-a-uuid`), Ecto raises a `CastError`.
-  Without this, Phoenix returns a 500 Internal Server Error.
-  With these protocol implementations, it correctly returns 404 Not Found.
+  Two distinct failure modes exist, at different points in the request:
+
+    * **Query-time** — an invalid UUID threaded into a `where … == ^value`
+      (or a `get_by(id: value)`) against a `:binary_id` column raises
+      `Ecto.CastError` / `Ecto.Query.CastError` while *building* the query.
+      These map to 404 (the resource that id could name cannot exist).
+
+    * **Insert/update-time** — a value set DIRECTLY on a struct field
+      (outside `cast/3`, e.g. `%Skill{project_id: params.project_id}`) is only
+      validated when Ecto *dumps* it on `insert`/`update`; a malformed value
+      raises `Ecto.ChangeError` at that point. `CastError` handling does NOT
+      cover this, so without the impl below it is an unhandled 500. It maps to
+      400 (the client sent an unusable parameter).
+
+  These are a defense-in-depth backstop. Endpoints still validate the specific
+  `project_id` / `scope_id` params at the boundary (clean 422 + a
+  no-partial-write guarantee); this net only exists so a future
+  struct-set-uncast value can never surface as a 500.
   """
 end
 
@@ -16,5 +31,12 @@ end
 
 defimpl Plug.Exception, for: Ecto.Query.CastError do
   def status(_exception), do: 404
+  def actions(_exception), do: []
+end
+
+defimpl Plug.Exception, for: Ecto.ChangeError do
+  # An insert/update-time dump failure on a malformed value is a client-input
+  # problem (a bad parameter), so 400 rather than a raw 500.
+  def status(_exception), do: 400
   def actions(_exception), do: []
 end

--- a/test/loopctl_web/controllers/analytics_controller_test.exs
+++ b/test/loopctl_web/controllers/analytics_controller_test.exs
@@ -445,4 +445,95 @@ defmodule LoopctlWeb.AnalyticsControllerTest do
       assert body["data"] == []
     end
   end
+
+  describe "analytics project_id hardening" do
+    test "GET /analytics/agents malformed project_id returns 422, not 500", %{conn: conn} do
+      ctx = setup_analytics_context()
+
+      conn =
+        conn
+        |> auth_conn(ctx.orch_key)
+        |> get(~p"/api/v1/analytics/agents?project_id=not-a-uuid")
+
+      body = json_response(conn, 422)
+      assert body["error"]["status"] == 422
+    end
+
+    test "GET /analytics/agents valid project_id filters normally (200)", %{conn: conn} do
+      ctx = setup_analytics_context()
+
+      conn =
+        conn
+        |> auth_conn(ctx.orch_key)
+        |> get(~p"/api/v1/analytics/agents?project_id=#{ctx.project.id}")
+
+      assert json_response(conn, 200)
+    end
+
+    test "GET /analytics/agents absent project_id lists normally (200)", %{conn: conn} do
+      ctx = setup_analytics_context()
+
+      conn =
+        conn
+        |> auth_conn(ctx.orch_key)
+        |> get(~p"/api/v1/analytics/agents")
+
+      assert json_response(conn, 200)
+    end
+
+    test "GET /analytics/epics malformed project_id returns 422, not 500", %{conn: conn} do
+      ctx = setup_analytics_context()
+
+      conn =
+        conn
+        |> auth_conn(ctx.agent_key)
+        |> get(~p"/api/v1/analytics/epics?project_id=not-a-uuid")
+
+      assert json_response(conn, 422)["error"]["status"] == 422
+    end
+
+    test "GET /analytics/models malformed project_id returns 422, not 500", %{conn: conn} do
+      ctx = setup_analytics_context()
+
+      conn =
+        conn
+        |> auth_conn(ctx.agent_key)
+        |> get(~p"/api/v1/analytics/models?project_id=not-a-uuid")
+
+      assert json_response(conn, 422)["error"]["status"] == 422
+    end
+
+    test "GET /analytics/model-mix non-string project_id[] is tolerated (no 500)", %{conn: conn} do
+      ctx = setup_analytics_context()
+
+      conn =
+        conn
+        |> auth_conn(ctx.orch_key)
+        |> get("/api/v1/analytics/model-mix?project_id[]=x")
+
+      assert json_response(conn, 200)
+    end
+
+    test "GET /analytics/projects/:id malformed path segment returns 404, not 500", %{conn: conn} do
+      ctx = setup_analytics_context()
+
+      conn =
+        conn
+        |> auth_conn(ctx.agent_key)
+        |> get(~p"/api/v1/analytics/projects/not-a-uuid")
+
+      assert json_response(conn, 404)
+    end
+
+    test "GET /analytics/projects/:id valid project returns 200", %{conn: conn} do
+      ctx = setup_analytics_context()
+
+      conn =
+        conn
+        |> auth_conn(ctx.agent_key)
+        |> get(~p"/api/v1/analytics/projects/#{ctx.project.id}")
+
+      assert json_response(conn, 200)
+    end
+  end
 end

--- a/test/loopctl_web/controllers/audit_controller_test.exs
+++ b/test/loopctl_web/controllers/audit_controller_test.exs
@@ -211,4 +211,61 @@ defmodule LoopctlWeb.AuditControllerTest do
       assert Map.has_key?(entry, "inserted_at")
     end
   end
+
+  describe "GET /api/v1/audit project_id hardening" do
+    test "malformed project_id returns 422, not 500", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      create_audit_entry(tenant.id)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/audit?project_id=not-a-uuid")
+
+      body = json_response(conn, 422)
+      assert body["error"]["status"] == 422
+    end
+
+    test "valid project_id filters normally (200)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      create_audit_entry(tenant.id, %{project_id: project.id})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/audit?project_id=#{project.id}")
+
+      body = json_response(conn, 200)
+      assert length(body["data"]) == 1
+    end
+
+    test "absent project_id lists normally (200)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      create_audit_entry(tenant.id)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/audit")
+
+      assert json_response(conn, 200)
+    end
+
+    test "non-string project_id[] list param is tolerated (no 500)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      create_audit_entry(tenant.id)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get("/api/v1/audit?project_id[]=x")
+
+      assert json_response(conn, 200)
+    end
+  end
 end

--- a/test/loopctl_web/controllers/change_controller_test.exs
+++ b/test/loopctl_web/controllers/change_controller_test.exs
@@ -234,4 +234,64 @@ defmodule LoopctlWeb.ChangeControllerTest do
       assert Map.has_key?(entry, "inserted_at")
     end
   end
+
+  describe "GET /api/v1/changes project_id hardening" do
+    test "malformed project_id returns 422, not 500", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+      past = DateTime.utc_now() |> DateTime.add(-60) |> DateTime.to_iso8601()
+      create_audit_entry(tenant.id)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/changes?since=#{past}&project_id=not-a-uuid")
+
+      body = json_response(conn, 422)
+      assert body["error"]["status"] == 422
+    end
+
+    test "valid project_id filters normally (200)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+      past = DateTime.utc_now() |> DateTime.add(-60) |> DateTime.to_iso8601()
+      create_audit_entry(tenant.id, %{project_id: project.id})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/changes?since=#{past}&project_id=#{project.id}")
+
+      assert json_response(conn, 200)
+    end
+
+    test "absent project_id lists normally (200)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+      past = DateTime.utc_now() |> DateTime.add(-60) |> DateTime.to_iso8601()
+      create_audit_entry(tenant.id)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/changes?since=#{past}")
+
+      assert json_response(conn, 200)
+    end
+
+    test "non-string project_id[] list param is tolerated (no 500)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+      past = DateTime.utc_now() |> DateTime.add(-60) |> DateTime.to_iso8601()
+      create_audit_entry(tenant.id)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get("/api/v1/changes?since=#{past}&project_id[]=x")
+
+      assert json_response(conn, 200)
+    end
+  end
 end

--- a/test/loopctl_web/controllers/cost_anomaly_controller_test.exs
+++ b/test/loopctl_web/controllers/cost_anomaly_controller_test.exs
@@ -224,4 +224,51 @@ defmodule LoopctlWeb.CostAnomalyControllerTest do
       assert json_response(conn, 403)
     end
   end
+
+  describe "GET /api/v1/cost-anomalies project_id hardening" do
+    test "malformed project_id returns 422, not 500", %{conn: conn} do
+      ctx = setup_tenant_with_anomalies()
+
+      conn =
+        conn
+        |> auth_conn(ctx.user_key)
+        |> get(~p"/api/v1/cost-anomalies?project_id=not-a-uuid")
+
+      body = json_response(conn, 422)
+      assert body["error"]["status"] == 422
+    end
+
+    test "valid project_id filters normally (200)", %{conn: conn} do
+      ctx = setup_tenant_with_anomalies()
+
+      conn =
+        conn
+        |> auth_conn(ctx.user_key)
+        |> get(~p"/api/v1/cost-anomalies?project_id=#{ctx.project.id}")
+
+      assert json_response(conn, 200)
+    end
+
+    test "absent project_id lists normally (200)", %{conn: conn} do
+      ctx = setup_tenant_with_anomalies()
+
+      conn =
+        conn
+        |> auth_conn(ctx.user_key)
+        |> get(~p"/api/v1/cost-anomalies")
+
+      assert json_response(conn, 200)
+    end
+
+    test "non-string project_id[] list param is tolerated (no 500)", %{conn: conn} do
+      ctx = setup_tenant_with_anomalies()
+
+      conn =
+        conn
+        |> auth_conn(ctx.user_key)
+        |> get("/api/v1/cost-anomalies?project_id[]=x")
+
+      assert json_response(conn, 200)
+    end
+  end
 end

--- a/test/loopctl_web/controllers/dependency_graph_controller_test.exs
+++ b/test/loopctl_web/controllers/dependency_graph_controller_test.exs
@@ -83,6 +83,21 @@ defmodule LoopctlWeb.DependencyGraphControllerTest do
 
       assert json_response(conn, 200)
     end
+
+    test "GET /stories/ready malformed epic_id matches nothing without crashing (200)", %{
+      conn: conn
+    } do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/stories/ready?epic_id=not-a-uuid")
+
+      body = json_response(conn, 200)
+      assert body["data"] == []
+    end
   end
 
   describe "GET /api/v1/stories/ready" do

--- a/test/loopctl_web/controllers/dependency_graph_controller_test.exs
+++ b/test/loopctl_web/controllers/dependency_graph_controller_test.exs
@@ -7,6 +7,84 @@ defmodule LoopctlWeb.DependencyGraphControllerTest do
     put_req_header(conn, "authorization", "Bearer #{raw_key}")
   end
 
+  describe "dependency-graph project_id hardening" do
+    test "GET /stories/ready malformed project_id returns 422, not 500", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/stories/ready?project_id=not-a-uuid")
+
+      assert json_response(conn, 422)["error"]["status"] == 422
+    end
+
+    test "GET /stories/ready valid project_id filters normally (200)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/stories/ready?project_id=#{project.id}")
+
+      assert json_response(conn, 200)
+    end
+
+    test "GET /stories/blocked malformed project_id returns 422, not 500", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/stories/blocked?project_id=not-a-uuid")
+
+      assert json_response(conn, 422)["error"]["status"] == 422
+    end
+
+    test "GET /stories/ready non-string project_id[] is tolerated (no 500)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get("/api/v1/stories/ready?project_id[]=x")
+
+      assert json_response(conn, 200)
+    end
+
+    test "GET /projects/:id/dependency_graph malformed segment returns 404, not 500", %{
+      conn: conn
+    } do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/projects/not-a-uuid/dependency_graph")
+
+      assert json_response(conn, 404)
+    end
+
+    test "GET /projects/:id/dependency_graph valid project returns 200", %{conn: conn} do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/projects/#{project.id}/dependency_graph")
+
+      assert json_response(conn, 200)
+    end
+  end
+
   describe "GET /api/v1/stories/ready" do
     test "returns ready stories with no dependencies", %{conn: conn} do
       tenant = fixture(:tenant)

--- a/test/loopctl_web/controllers/import_controller_test.exs
+++ b/test/loopctl_web/controllers/import_controller_test.exs
@@ -452,4 +452,31 @@ defmodule LoopctlWeb.ImportControllerTest do
       assert story.reported_done_at != nil
     end
   end
+
+  describe "GET /api/v1/projects/:id/export project_id hardening" do
+    test "malformed project_id path segment returns 404, not 500", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/projects/not-a-uuid/export")
+
+      assert json_response(conn, 404)
+    end
+
+    test "valid project_id exports normally (200)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/projects/#{project.id}/export")
+
+      assert json_response(conn, 200)
+    end
+  end
 end

--- a/test/loopctl_web/controllers/orchestrator_state_controller_test.exs
+++ b/test/loopctl_web/controllers/orchestrator_state_controller_test.exs
@@ -582,4 +582,55 @@ defmodule LoopctlWeb.OrchestratorStateControllerTest do
       assert Enum.at(body["data"], 0)["state_data"] == %{"main_data" => true}
     end
   end
+
+  describe "orchestrator state project_id hardening" do
+    test "PUT malformed project_id segment returns 404, not 500", %{conn: conn} do
+      tenant = fixture(:tenant)
+      agent = fixture(:agent, %{tenant_id: tenant.id, agent_type: :orchestrator})
+
+      {raw_key, _} =
+        fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator, agent_id: agent.id})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> put("/api/v1/orchestrator/state/not-a-uuid", %{
+          "state_key" => "main",
+          "state_data" => %{"a" => 1},
+          "version" => 0
+        })
+
+      assert json_response(conn, 404)
+    end
+
+    test "GET malformed project_id segment returns 404, not 500", %{conn: conn} do
+      tenant = fixture(:tenant)
+      agent = fixture(:agent, %{tenant_id: tenant.id, agent_type: :orchestrator})
+
+      {raw_key, _} =
+        fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator, agent_id: agent.id})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get("/api/v1/orchestrator/state/not-a-uuid")
+
+      assert json_response(conn, 404)
+    end
+
+    test "GET history malformed project_id segment returns 404, not 500", %{conn: conn} do
+      tenant = fixture(:tenant)
+      agent = fixture(:agent, %{tenant_id: tenant.id, agent_type: :orchestrator})
+
+      {raw_key, _} =
+        fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator, agent_id: agent.id})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get("/api/v1/orchestrator/state/not-a-uuid/history")
+
+      assert json_response(conn, 404)
+    end
+  end
 end

--- a/test/loopctl_web/controllers/skill_controller_test.exs
+++ b/test/loopctl_web/controllers/skill_controller_test.exs
@@ -180,4 +180,82 @@ defmodule LoopctlWeb.SkillControllerTest do
       assert body["version"]["prompt_text"] == "V1 prompt"
     end
   end
+
+  describe "skills project_id hardening" do
+    test "POST /skills with malformed project_id returns 422, not 500", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/skills", %{
+          "name" => "loopctl:x",
+          "prompt_text" => "p",
+          "project_id" => "not-a-uuid"
+        })
+
+      body = json_response(conn, 422)
+      assert body["error"]["status"] == 422
+    end
+
+    test "POST /skills with valid project_id creates (201)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/skills", %{
+          "name" => "loopctl:y",
+          "prompt_text" => "p",
+          "project_id" => project.id
+        })
+
+      body = json_response(conn, 201)
+      assert body["skill"]["project_id"] == project.id
+    end
+
+    test "GET /skills with malformed project_id returns 422, not 500", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/skills?project_id=not-a-uuid")
+
+      body = json_response(conn, 422)
+      assert body["error"]["status"] == 422
+    end
+
+    test "GET /skills with valid project_id filters normally (200)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      fixture(:skill, %{tenant_id: tenant.id, project_id: project.id})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/skills?project_id=#{project.id}")
+
+      body = json_response(conn, 200)
+      assert length(body["data"]) == 1
+    end
+
+    test "GET /skills absent project_id lists normally (200)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      fixture(:skill, %{tenant_id: tenant.id})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/skills")
+
+      assert json_response(conn, 200)
+    end
+  end
 end

--- a/test/loopctl_web/controllers/skill_controller_test.exs
+++ b/test/loopctl_web/controllers/skill_controller_test.exs
@@ -1,6 +1,8 @@
 defmodule LoopctlWeb.SkillControllerTest do
   use LoopctlWeb.ConnCase, async: true
 
+  alias Loopctl.Skills
+
   setup :verify_on_exit!
 
   defp auth_conn(conn, raw_key) do
@@ -256,6 +258,52 @@ defmodule LoopctlWeb.SkillControllerTest do
         |> get(~p"/api/v1/skills")
 
       assert json_response(conn, 200)
+    end
+  end
+
+  describe "POST /api/v1/skills/import project_id hardening" do
+    test "a malformed project_id in the import array returns 422, no partial insert", %{
+      conn: conn
+    } do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/skills/import", %{
+          "skills" => [
+            %{"name" => "loopctl:ok", "prompt_text" => "p", "project_id" => project.id},
+            %{"name" => "loopctl:bad", "prompt_text" => "p", "project_id" => "not-a-uuid"}
+          ]
+        })
+
+      body = json_response(conn, 422)
+      assert body["error"]["status"] == 422
+
+      # No partial insert: neither skill was created (whole import rejected).
+      {:ok, result} = Skills.list_skills(tenant.id, [])
+      assert result.data == []
+    end
+
+    test "valid project_ids import successfully", %{conn: conn} do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/skills/import", %{
+          "skills" => [
+            %{"name" => "loopctl:imp", "prompt_text" => "p", "project_id" => project.id}
+          ]
+        })
+
+      assert json_response(conn, 200)
+      {:ok, result} = Skills.list_skills(tenant.id, [])
+      assert length(result.data) == 1
     end
   end
 end

--- a/test/loopctl_web/controllers/story_controller_test.exs
+++ b/test/loopctl_web/controllers/story_controller_test.exs
@@ -565,4 +565,48 @@ defmodule LoopctlWeb.StoryControllerTest do
       assert body["meta"]["limit"] == 3
     end
   end
+
+  describe "GET /api/v1/stories project_id/epic_id hardening" do
+    test "malformed project_id returns 422, not 404/500", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/stories?project_id=not-a-uuid")
+
+      body = json_response(conn, 422)
+      assert body["error"]["status"] == 422
+    end
+
+    test "valid project_id lists normally (200)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/stories?project_id=#{project.id}")
+
+      assert json_response(conn, 200)
+    end
+
+    test "malformed epic_id filter matches nothing without crashing (200)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+      fixture(:story, %{tenant_id: tenant.id, epic_id: epic.id, project_id: project.id})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/stories?project_id=#{project.id}&epic_id=not-a-uuid")
+
+      body = json_response(conn, 200)
+      assert body["data"] == []
+    end
+  end
 end

--- a/test/loopctl_web/controllers/token_budget_controller_test.exs
+++ b/test/loopctl_web/controllers/token_budget_controller_test.exs
@@ -586,4 +586,37 @@ defmodule LoopctlWeb.TokenBudgetControllerTest do
       assert json_response(conn, 404)
     end
   end
+
+  describe "POST /api/v1/token-budgets scope_id hardening" do
+    test "malformed project scope_id returns 422, not 500", %{conn: conn} do
+      %{user_key: user_key} = setup_project_with_keys()
+
+      conn =
+        conn
+        |> auth_conn(user_key)
+        |> post(~p"/api/v1/token-budgets", %{
+          "scope_type" => "project",
+          "scope_id" => "not-a-uuid",
+          "budget_millicents" => 1000
+        })
+
+      body = json_response(conn, 422)
+      assert body["error"]["status"] == 422
+    end
+
+    test "valid project scope_id creates a budget (201)", %{conn: conn} do
+      %{project: project, user_key: user_key} = setup_project_with_keys()
+
+      conn =
+        conn
+        |> auth_conn(user_key)
+        |> post(~p"/api/v1/token-budgets", %{
+          "scope_type" => "project",
+          "scope_id" => project.id,
+          "budget_millicents" => 1000
+        })
+
+      assert json_response(conn, 201)
+    end
+  end
 end

--- a/test/loopctl_web/controllers/ui_test_controller_test.exs
+++ b/test/loopctl_web/controllers/ui_test_controller_test.exs
@@ -397,4 +397,50 @@ defmodule LoopctlWeb.UiTestControllerTest do
       assert json_response(conn, 200)
     end
   end
+
+  describe "ui-tests project_id hardening" do
+    test "GET malformed project_id path segment returns 422, not 500", %{conn: conn} do
+      ctx = setup_project_with_keys()
+
+      conn =
+        conn
+        |> auth_conn(ctx.agent_key)
+        |> get(~p"/api/v1/projects/not-a-uuid/ui-tests")
+
+      assert json_response(conn, 422)["error"]["status"] == 422
+    end
+
+    test "GET valid project_id lists normally (200)", %{conn: conn} do
+      ctx = setup_project_with_keys()
+
+      conn =
+        conn
+        |> auth_conn(ctx.agent_key)
+        |> get(~p"/api/v1/projects/#{ctx.project.id}/ui-tests")
+
+      assert json_response(conn, 200)
+    end
+
+    test "POST malformed project_id path segment returns 422, not 500", %{conn: conn} do
+      ctx = setup_project_with_keys()
+
+      conn =
+        conn
+        |> auth_conn(ctx.agent_key)
+        |> post(~p"/api/v1/projects/not-a-uuid/ui-tests", %{"guide_reference" => "g"})
+
+      assert json_response(conn, 422)["error"]["status"] == 422
+    end
+
+    test "POST valid project_id creates a run (201)", %{conn: conn} do
+      ctx = setup_project_with_keys()
+
+      conn =
+        conn
+        |> auth_conn(ctx.agent_key)
+        |> post(~p"/api/v1/projects/#{ctx.project.id}/ui-tests", %{"guide_reference" => "g"})
+
+      assert json_response(conn, 201)
+    end
+  end
 end

--- a/test/loopctl_web/plugs/cast_error_handler_test.exs
+++ b/test/loopctl_web/plugs/cast_error_handler_test.exs
@@ -1,0 +1,26 @@
+defmodule LoopctlWeb.Plugs.CastErrorHandlerTest do
+  @moduledoc """
+  The `Plug.Exception` impls map Ecto cast/change errors to clean 4xx statuses
+  instead of a raw 500. Query-time cast errors -> 404; insert/update-time
+  `Ecto.ChangeError` (a struct field set uncast, dumped on write) -> 400.
+  """
+  use ExUnit.Case, async: true
+
+  test "Ecto.Query.CastError maps to 404" do
+    exception = %Ecto.Query.CastError{type: :binary_id, value: "not-a-uuid", message: "bad"}
+    assert Plug.Exception.status(exception) == 404
+  end
+
+  test "Ecto.CastError maps to 404" do
+    exception = %Ecto.CastError{type: :binary_id, value: "not-a-uuid", message: "bad"}
+    assert Plug.Exception.status(exception) == 404
+  end
+
+  test "Ecto.ChangeError (insert/update-time dump failure) maps to 400, not 500" do
+    exception = %Ecto.ChangeError{
+      message: "value `\"not-a-uuid\"` cannot be dumped to :binary_id"
+    }
+
+    assert Plug.Exception.status(exception) == 400
+  end
+end


### PR DESCRIPTION
## Summary

Follow-up to **kbweb-01 (#282, public #251)**. That fix closed the "malformed `project_id` → `Ecto.Query.CastError` → 500" class in the **knowledge** subsystem. The same class remained reachable in every other subsystem whose endpoints take a client-controlled `project_id` (path or query param) and thread it raw into a `where … project_id == ^value` (or a bare `get_by` / project-existence check) against the `:binary_id` column.

This PR closes the class app-wide.

## Audit — every candidate site classified

**REACHABLE-b (hardened):**
| Site | Endpoint(s) | Source | Fix |
|------|-------------|--------|-----|
| `audit.ex` `filter_by(:project_id)` | `GET /audit`, `GET /changes` | query | controller 422 + context guard |
| `skills.ex` `filter_project_id` | `GET /skills`, `POST /skills` | query/body | controller 422 + context guard |
| `quality_assurance.ex` `list_ui_tests` / `start_ui_test` | `/projects/:project_id/ui-tests` (GET+POST) | path | controller 422 + context guard |
| `work_breakdown/queries.ex` `get_dependency_graph` | `/projects/:id/dependency_graph` | path | context → 404 |
| `work_breakdown/queries.ex` `apply_project_filter` | `/stories/ready`, `/stories/blocked` | query | controller 422 + context guard |
| `token_usage/analytics.ex` `project_metrics` | `/analytics/projects/:id` | path | context → 404 |
| `token_usage/analytics.ex` `apply_project_filter` / `maybe_filter_epic_project` / `apply_model_project_filter` | `/analytics/{agents,epics,models,trends,model-mix,agents/:id/model-profile}` | query | controller 422 + context guard |
| `token_usage.ex` `apply_anomaly_filter(:project_id)` | `/cost-anomalies` | query | controller 422 + context guard |
| `import_export.ex` `export_project` | `/projects/:id/export` | path | context → 404 (matches sibling import) |
| `orchestrator.ex` private `get_project` | `/orchestrator/state/:project_id` (save/get/history) | path | context → 404 (single chokepoint) |

**SAFE-c (no change — value is loaded/pre-validated):** `token_usage.ex` `spend_query(:project)` (scope_id from a loaded `Budget`); `token_usage/analytics.ex` `get_cost_by_phase` / `get_project_model_breakdown` (reached only after the `project_metrics` guard); `knowledge/analytics.ex` (uses `project.id` or `cast_uuid` + `get_project`).

**SAFE-a (path routes through `Projects.get_project/2`, already 404 since kbweb-01):** epic/story/dependency CRUD, `import_project`, `projects.ex` internals.

**ALREADY-GUARDED (kbweb-01 / pre-existing):** `knowledge.ex`, `knowledge/okf.ex`, `knowledge/streaming_export.ex`, `knowledge/vector_search.ex`, `knowledge_analytics_controller` `put_project_id`.

**INTERNAL (job args / non-client):** `workers/article_linking_worker.ex`, `webhooks/event_generator.ex`.

## Two-layer defense (mirrors kbweb-01)

1. **Controller boundary** — query-param filters call `LoopctlWeb.Helpers.ProjectId.validate/1` → clean **422** for a malformed value; absent/valid unchanged. Non-string `?project_id[]=x` stays tolerated.
2. **Context guard** — each filter is wrapped with `valid_uuid?/1`; a non-UUID matches nothing (`where …, false`) instead of raising. Path-`:id` project resources return `:not_found` → **404**, matching `Projects.get_project`.

Behavior for valid/absent `project_id` is unchanged; tenant scoping/RLS intact (a valid other-tenant id yields empty, never a leak).

## Tests

Per reachable endpoint: malformed `project_id` → **4xx (not 500)**, valid → normal **200**/201, absent → normal, plus non-string `project_id[]=x` where the endpoint takes a query param. Path-`:id` resources assert **404** on a malformed segment.

## Verification

`mix compile --warnings-as-errors`, `format --check-formatted`, `credo --strict` (no issues), `dialyzer` (0, passed), full `mix test` — **3515 tests, 0 failures**.
