### PR TITLE
fix(test): eliminate two test-isolation flakes — fixture unique-number/slug collisions + hnsw reconcile isolation

### DIFF
--- a/lib/loopctl/repo/hnsw_index.ex
+++ b/lib/loopctl/repo/hnsw_index.ex
@@ -1,0 +1,159 @@
+defmodule Loopctl.Repo.HnswIndex do
+  @moduledoc """
+  Single source of truth for the capability-based (`amname = 'hnsw'`) SQL used to
+  detect, create, drop, and reconcile the HNSW index on a pgvector table's
+  `embedding` column.
+
+  ## Why this module exists
+
+  The HNSW index migrations (`AddEmbeddingHnswIndex`, `ReconcileHnswIndexName`)
+  originally inlined this SQL, hard-coded to `public.articles`. That made the
+  migration behaviour untestable in isolation: the only way to exercise it was
+  to drop / rename / recreate the *shared, live* `articles_embedding_hnsw_idx`
+  — a table-level schema object that the Ecto SQL sandbox does **not** isolate
+  the way it isolates row data. Manipulating it from a test is manipulating
+  global state every other embedding test depends on.
+
+  Parameterising the SQL by table name removes that coupling. The production
+  migrations call these functions with the default `"articles"` (emitting the
+  same SQL, targeting the same object, producing the same schema — a pure
+  refactor). The migration-behaviour test calls them with a per-test,
+  uniquely-named THROWAWAY table it creates and drops inside its own sandbox
+  transaction, so it exercises the exact same detection / rename / drop logic
+  against an ISOLATED object and never touches the shared canonical index.
+
+  Detection is by access method (`am.amname = 'hnsw'`), schema-qualified to
+  `public`, NOT by a hard-coded index name — so the logic catches whatever name
+  the index actually lives under (prod's `articles_embedding_hnsw_idx`, the old
+  migration's `articles_embedding_idx`, or any out-of-band name).
+
+  Index names are derived from the table: `\#{table}_embedding_idx` (the old
+  migration's create name) and `\#{table}_embedding_hnsw_idx` (the canonical
+  reconciled name).
+  """
+
+  @doc "The canonical (reconciled) HNSW index name for `table`."
+  @spec canonical_index_name(String.t()) :: String.t()
+  def canonical_index_name(table), do: "#{validate!(table)}_embedding_hnsw_idx"
+
+  @doc "The name the old create-migration uses for `table`'s HNSW index."
+  @spec migration_index_name(String.t()) :: String.t()
+  def migration_index_name(table), do: "#{validate!(table)}_embedding_idx"
+
+  @doc """
+  SQL that creates the HNSW index (named `\#{table}_embedding_idx`) only when the
+  `embedding` column exists AND no HNSW index (by access method) is already
+  present on the table — so from a drifted state where the index lives under a
+  different name, this does NOT create a second, redundant HNSW index.
+  """
+  @spec create_if_absent_sql(String.t()) :: String.t()
+  def create_if_absent_sql(table \\ "articles") do
+    table = validate!(table)
+
+    """
+    DO $$
+    BEGIN
+      IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = '#{table}' AND column_name = 'embedding') THEN
+        IF NOT EXISTS (
+          SELECT 1
+          FROM pg_index x
+          JOIN pg_class i ON i.oid = x.indexrelid
+          JOIN pg_class t ON t.oid = x.indrelid
+          JOIN pg_namespace n ON n.oid = t.relnamespace
+          JOIN pg_am    am ON am.oid = i.relam
+          WHERE t.relname = '#{table}' AND n.nspname = 'public' AND am.amname = 'hnsw'
+        ) THEN
+          CREATE INDEX #{table}_embedding_idx ON #{table} USING hnsw (embedding vector_cosine_ops);
+        END IF;
+      END IF;
+    END $$;
+    """
+  end
+
+  @doc """
+  SQL that drops EVERY HNSW index (by access method, not by name) present on
+  `table`, so a rollback leaves none orphaned regardless of the name the index
+  lives under.
+  """
+  @spec drop_all_sql(String.t()) :: String.t()
+  def drop_all_sql(table \\ "articles") do
+    table = validate!(table)
+
+    """
+    DO $$
+    DECLARE idx text;
+    BEGIN
+      FOR idx IN
+        SELECT i.relname
+        FROM pg_index x
+        JOIN pg_class i ON i.oid = x.indexrelid
+        JOIN pg_class t ON t.oid = x.indrelid
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        JOIN pg_am    am ON am.oid = i.relam
+        WHERE t.relname = '#{table}' AND n.nspname = 'public' AND am.amname = 'hnsw'
+      LOOP
+        EXECUTE format('DROP INDEX IF EXISTS %I', idx);
+      END LOOP;
+    END $$;
+    """
+  end
+
+  @doc """
+  Idempotent reconcile SQL: if the canonical `\#{table}_embedding_hnsw_idx`
+  HNSW index already exists, no-op; otherwise rename whichever HNSW index is
+  present (detected by access method, schema-qualified to `public`) up to the
+  canonical name. If a non-HNSW relation squats the canonical name the RENAME
+  target is occupied and Postgres raises — surfacing the conflict rather than
+  silently reporting success.
+  """
+  @spec reconcile_sql(String.t()) :: String.t()
+  def reconcile_sql(table \\ "articles") do
+    table = validate!(table)
+
+    """
+    DO $$
+    DECLARE idx text;
+    BEGIN
+      IF EXISTS (
+        SELECT 1
+        FROM pg_index x
+        JOIN pg_class i ON i.oid = x.indexrelid
+        JOIN pg_class t ON t.oid = x.indrelid
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        JOIN pg_am    am ON am.oid = i.relam
+        WHERE t.relname = '#{table}'
+          AND n.nspname = 'public'
+          AND am.amname = 'hnsw'
+          AND i.relname = '#{table}_embedding_hnsw_idx'
+      ) THEN
+        RETURN;
+      END IF;
+
+      SELECT i.relname INTO idx
+      FROM pg_index x
+      JOIN pg_class i ON i.oid = x.indexrelid
+      JOIN pg_class t ON t.oid = x.indrelid
+      JOIN pg_namespace n ON n.oid = t.relnamespace
+      JOIN pg_am    am ON am.oid = i.relam
+      WHERE t.relname = '#{table}' AND n.nspname = 'public' AND am.amname = 'hnsw'
+      LIMIT 1;
+
+      IF idx IS NOT NULL THEN
+        EXECUTE format('ALTER INDEX %I RENAME TO #{table}_embedding_hnsw_idx', idx);
+      END IF;
+    END $$;
+    """
+  end
+
+  # Table names are internal constants ("articles") or test-generated with
+  # System.unique_integer — never user input — but validate defensively so the
+  # interpolated identifier can never carry anything but a plain lowercase SQL
+  # identifier.
+  defp validate!(table) when is_binary(table) do
+    if Regex.match?(~r/\A[a-z_][a-z0-9_]*\z/, table) do
+      table
+    else
+      raise ArgumentError, "invalid table identifier: #{inspect(table)}"
+    end
+  end
+end

--- a/priv/repo/migrations/20260410022906_add_embedding_hnsw_index.exs
+++ b/priv/repo/migrations/20260410022906_add_embedding_hnsw_index.exs
@@ -4,35 +4,23 @@ defmodule Loopctl.Repo.Migrations.AddEmbeddingHnswIndex do
   @disable_ddl_transaction true
   @disable_migration_lock true
 
+  # The capability-based (amname='hnsw') detection/create/drop SQL lives in
+  # `Loopctl.Repo.HnswIndex`, parameterized by table name, so the migration
+  # behaviour can be exercised in isolation against a per-test throwaway table
+  # (see test/loopctl/repo/reconcile_hnsw_index_migration_test.exs) instead of
+  # the shared, sandbox-uninsolated `articles_embedding_hnsw_idx`. For the
+  # default `"articles"` these emit the same SQL this migration always ran.
+
   def up do
-    # Only create the HNSW index if the embedding column exists (pgvector was
-    # enabled). AC-27.14.2: the existence guard is capability-based (ANY hnsw
-    # index on articles already present), symmetric with down/0's amname-based
+    # AC-27.14.2: the existence guard is capability-based (ANY hnsw index on
+    # articles already present), symmetric with down/0's amname-based
     # detection — NOT a hard-coded `indexname = 'articles_embedding_idx'`
     # check. The old name-based guard only saw the migration's own name, so
     # from prod's drift state {articles_embedding_hnsw_idx} this up-step would
-    # create a SECOND, redundant hnsw index. By skipping when any hnsw index on
-    # articles(embedding) exists (detected by am.amname='hnsw', the same
-    # pg_index/pg_am join down/0 and the reconcile migration use), the two-index
-    # state can never arise.
-    execute("""
-    DO $$
-    BEGIN
-      IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'articles' AND column_name = 'embedding') THEN
-        IF NOT EXISTS (
-          SELECT 1
-          FROM pg_index x
-          JOIN pg_class i ON i.oid = x.indexrelid
-          JOIN pg_class t ON t.oid = x.indrelid
-          JOIN pg_namespace n ON n.oid = t.relnamespace
-          JOIN pg_am    am ON am.oid = i.relam
-          WHERE t.relname = 'articles' AND n.nspname = 'public' AND am.amname = 'hnsw'
-        ) THEN
-          CREATE INDEX articles_embedding_idx ON articles USING hnsw (embedding vector_cosine_ops);
-        END IF;
-      END IF;
-    END $$;
-    """)
+    # create a SECOND, redundant hnsw index. Skipping when any hnsw index on
+    # articles(embedding) exists (detected by am.amname='hnsw') means the
+    # two-index state can never arise.
+    execute(Loopctl.Repo.HnswIndex.create_if_absent_sql("articles"))
   end
 
   def down do
@@ -44,22 +32,6 @@ defmodule Loopctl.Repo.Migrations.AddEmbeddingHnswIndex do
     # orphaned. Iterating over EVERY hnsw index (rather than `LIMIT 1`) means
     # that even if multiple hnsw indexes somehow coexist, the down-step leaves
     # none orphaned.
-    execute("""
-    DO $$
-    DECLARE idx text;
-    BEGIN
-      FOR idx IN
-        SELECT i.relname
-        FROM pg_index x
-        JOIN pg_class i ON i.oid = x.indexrelid
-        JOIN pg_class t ON t.oid = x.indrelid
-        JOIN pg_namespace n ON n.oid = t.relnamespace
-        JOIN pg_am    am ON am.oid = i.relam
-        WHERE t.relname = 'articles' AND n.nspname = 'public' AND am.amname = 'hnsw'
-      LOOP
-        EXECUTE format('DROP INDEX IF EXISTS %I', idx);
-      END LOOP;
-    END $$;
-    """)
+    execute(Loopctl.Repo.HnswIndex.drop_all_sql("articles"))
   end
 end

--- a/priv/repo/migrations/20260624120000_reconcile_hnsw_index_name.exs
+++ b/priv/repo/migrations/20260624120000_reconcile_hnsw_index_name.exs
@@ -76,60 +76,16 @@ defmodule Loopctl.Repo.Migrations.ReconcileHnswIndexName do
       WHERE t.relname = 'articles' AND n.nspname = 'public' AND am.amname = 'hnsw';
   """
 
+  # The capability-based (amname='hnsw'), `public`-schema-qualified reconcile SQL
+  # — including the tightened idempotency guard (matches only an hnsw index of
+  # the canonical NAME, so an unrelated relation squatting the name cannot
+  # short-circuit reconciliation) and the name-agnostic RENAME — lives in
+  # `Loopctl.Repo.HnswIndex.reconcile_sql/1`, parameterized by table name. For
+  # `"articles"` it emits exactly the SQL this migration always ran; the shared
+  # module lets the migration-behaviour test exercise the same logic against a
+  # per-test throwaway table instead of the live `articles_embedding_hnsw_idx`.
   def up do
-    execute("""
-    DO $$
-    DECLARE idx text;
-    BEGIN
-      -- Already canonical (prod, or this migration already ran): no-op.
-      -- Use the SAME predicate as the detection query below — the canonical
-      -- hnsw index on `articles` already present — rather than a bare
-      -- relname match. A bare `pg_class.relname` check is unqualified by
-      -- relkind/access-method/namespace, so an unrelated object squatting
-      -- the name (table, view, sequence, or an index of another AM, in any
-      -- schema) would RETURN early and silently skip reconciliation, leaving
-      -- the very drift this migration exists to fix. The `n.nspname = 'public'`
-      -- join below makes that namespace-safety claim TRUE: in a hypothetical
-      -- multi-schema (schema-per-tenant) deployment with more than one
-      -- `articles` relation, this predicate matches only the one in `public`,
-      -- so neither the guard nor the RENAME below can touch a same-named
-      -- relation in another schema. (loopctl is single-schema RLS today, so in
-      -- practice exactly one `articles` exists — but the predicate is correct
-      -- ahead of any future schema-per-tenant move.)
-      IF EXISTS (
-        SELECT 1
-        FROM pg_index x
-        JOIN pg_class i ON i.oid = x.indexrelid
-        JOIN pg_class t ON t.oid = x.indrelid
-        JOIN pg_namespace n ON n.oid = t.relnamespace
-        JOIN pg_am    am ON am.oid = i.relam
-        WHERE t.relname = 'articles'
-          AND n.nspname = 'public'
-          AND am.amname = 'hnsw'
-          AND i.relname = 'articles_embedding_hnsw_idx'
-      ) THEN
-        RETURN;
-      END IF;
-
-      -- Find whichever hnsw index on articles is present, by access method
-      -- (not by name) so we catch the test-DB `articles_embedding_idx` and
-      -- any other out-of-band name. Same `public`-schema qualification as the
-      -- guard above, so the RENAME target is always the public `articles`.
-      SELECT i.relname INTO idx
-      FROM pg_index x
-      JOIN pg_class i ON i.oid = x.indexrelid
-      JOIN pg_class t ON t.oid = x.indrelid
-      JOIN pg_namespace n ON n.oid = t.relnamespace
-      JOIN pg_am    am ON am.oid = i.relam
-      WHERE t.relname = 'articles' AND n.nspname = 'public' AND am.amname = 'hnsw'
-      LIMIT 1;
-
-      IF idx IS NOT NULL THEN
-        EXECUTE format('ALTER INDEX %I RENAME TO articles_embedding_hnsw_idx', idx);
-      END IF;
-      -- No hnsw index present (e.g. pgvector disabled): nothing to reconcile.
-    END $$;
-    """)
+    execute(Loopctl.Repo.HnswIndex.reconcile_sql("articles"))
   end
 
   # The reconcile is a forward-only normalization; there is no destructive

--- a/test/loopctl/fixtures_uniqueness_test.exs
+++ b/test/loopctl/fixtures_uniqueness_test.exs
@@ -1,0 +1,88 @@
+defmodule Loopctl.FixturesUniquenessTest do
+  @moduledoc """
+  Regression guard for the fixture-generated uniqueness sources.
+
+  These fixtures previously derived story numbers from a modulo truncation
+  (`"1.\#{rem(System.unique_integer([:positive]), 9999) + 1}"`), which is
+  non-injective: two distinct seqs congruent mod 9999 — or a project with more
+  than 9999 stories — produced the same `number`, intermittently tripping the
+  `stories_tenant_id_project_id_number_index` unique constraint under parallel
+  load. Tenant `slug`/`email` were already unique-per-VM via
+  `System.unique_integer/1`; these tests pin BOTH invariants so a regression to
+  a collidable generator (modulo / timestamp / plain counter) fails loudly.
+  """
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.WorkBreakdown.Story
+
+  describe "next_story_number/0" do
+    test "returns only distinct, format-valid numbers across a large batch" do
+      numbers = for _ <- 1..5_000, do: Loopctl.Fixtures.next_story_number()
+
+      assert length(Enum.uniq(numbers)) == 5_000,
+             "next_story_number/0 must never repeat within a VM run"
+
+      for number <- numbers do
+        parts = String.split(number, ".")
+        assert length(parts) == 2
+
+        for part <- parts do
+          {n, ""} = Integer.parse(part)
+          assert n >= 0 and n < 10_000, "each part must satisfy Story's <10000 format rule"
+        end
+      end
+    end
+
+    test "generated numbers never collide with small hard-coded numbers" do
+      # Tests routinely insert explicit "1.1", "2.3", "72.3", … — generated
+      # numbers use a high major (>= 1000) so they can never collide with those.
+      numbers = for _ <- 1..2_000, do: Loopctl.Fixtures.next_story_number()
+
+      majors =
+        Enum.map(numbers, fn n -> n |> String.split(".") |> hd() |> String.to_integer() end)
+
+      assert Enum.min(majors) >= 1_000
+    end
+  end
+
+  describe "story number uniqueness within a (tenant, project)" do
+    test "inserting many fixture stories in one project never collides" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+
+      stories =
+        for _ <- 1..300 do
+          fixture(:story, %{
+            tenant_id: tenant.id,
+            project_id: project.id,
+            epic_id: epic.id
+          })
+        end
+
+      numbers = Enum.map(stories, & &1.number)
+
+      assert length(Enum.uniq(numbers)) == 300
+
+      # And the constraint really is satisfied at the DB level.
+      persisted =
+        Story
+        |> where([s], s.project_id == ^project.id)
+        |> Loopctl.AdminRepo.all()
+
+      assert length(persisted) == 300
+    end
+  end
+
+  describe "tenant slug/email uniqueness" do
+    test "building many tenants yields distinct slugs and emails" do
+      tenants = for _ <- 1..500, do: fixture(:tenant)
+
+      slugs = Enum.map(tenants, & &1.slug)
+      emails = Enum.map(tenants, & &1.email)
+
+      assert length(Enum.uniq(slugs)) == 500
+      assert length(Enum.uniq(emails)) == 500
+    end
+  end
+end

--- a/test/loopctl/repo/reconcile_hnsw_index_migration_test.exs
+++ b/test/loopctl/repo/reconcile_hnsw_index_migration_test.exs
@@ -1,191 +1,185 @@
 defmodule Loopctl.Repo.ReconcileHnswIndexMigrationTest do
   @moduledoc """
-  US-27.14 / TC-27.14.1 — integration test for the HNSW index-name reconcile.
+  US-27.14 / TC-27.14.1 — behaviour test for the HNSW index-name reconcile.
 
-  Exercises the REAL migration modules (`AddEmbeddingHnswIndex` and
-  `ReconcileHnswIndexName`) against the live AdminRepo connection, proving:
+  Exercises the capability-based (`amname = 'hnsw'`) detection / create / drop /
+  reconcile SQL that the two HNSW migrations run — `AddEmbeddingHnswIndex`
+  (`up`/`down`) and `ReconcileHnswIndexName` (`up`) — proving:
 
-    * the OLD migration's fixed `down/0` drops WHICHEVER hnsw index is present
-      (by `amname='hnsw'`, not a hard-coded name) — so a rollback against a DB
-      where the index lives under a non-migration name (prod's
-      `articles_embedding_hnsw_idx`, or any out-of-band name) actually drops it
-      instead of silently no-opping; and
-    * the reconcile migration is idempotent and renames any non-canonical hnsw
-      index up to the canonical `articles_embedding_hnsw_idx`.
+    * the drop-step drops WHICHEVER hnsw index is present (by `amname='hnsw'`,
+      not a hard-coded name), and drops ALL of them (never `LIMIT 1`), so a
+      rollback against a DB where the index lives under a non-migration name
+      leaves none orphaned;
+    * the create-step is capability-guarded — with any hnsw index already
+      present it does NOT create a second, redundant one;
+    * the reconcile step is idempotent and renames any non-canonical hnsw index
+      up to the canonical `<table>_embedding_hnsw_idx`; and
+    * the tightened idempotency guard matches only an hnsw index of the
+      canonical NAME, so an unrelated relation squatting that name cannot
+      short-circuit reconciliation — the RENAME instead surfaces the conflict.
 
-  Runs inside the SQL sandbox transaction so the index DDL it performs is
-  fully rolled back at the end of each test, leaving the shared test DB's
-  canonical index intact for every other test (the index DDL here is
-  non-concurrent, so it runs happily inside a transaction). It does NOT touch
-  `schema_migrations`; it invokes the migration modules' `up/0` / `down/0`
-  directly via `Ecto.Migration.Runner.run/8`.
+  ## Isolation — no shared global state
 
-  Scope of what this exercises: `Runner.run/8` starts the runner Agent and
-  calls `perform_operation/3` — it executes the migrations' SQL and detection
-  logic, which is what this test validates. It does NOT manage transactions or
-  consult `@disable_ddl_transaction` / `@disable_migration_lock`; that logic
-  lives one layer up in `Ecto.Migrator.run_maybe_in_transaction/4`, which this
-  test deliberately bypasses. Consequently the old `AddEmbeddingHnswIndex`
-  migration's `@disable_ddl_transaction true` is NOT honored here: its DDL runs
-  on the sandbox connection INSIDE the test transaction (which is exactly what
-  makes the test safe and self-cleaning), rather than outside a transaction as
-  it would under the real migrator. This test therefore proves the SQL /
-  detection behavior, not the disable-ddl-transaction behavior.
+  This SQL is the single source of truth in `Loopctl.Repo.HnswIndex`,
+  parameterized by table name. The production migrations call it with
+  `"articles"` (targeting the live, shared `articles_embedding_hnsw_idx`); this
+  test calls it against a PER-TEST, UNIQUELY-NAMED THROWAWAY table it creates in
+  its own sandbox transaction. Index DDL — unlike row data — is NOT isolated by
+  the Ecto SQL sandbox at the object level, so a test that dropped / renamed the
+  shared `articles_embedding_hnsw_idx` would be mutating global state that every
+  other embedding test depends on. Operating on a throwaway table removes that
+  coupling entirely: the CREATE/DROP/RENAME here only ever touch this test's own
+  object, so the test is `async: true` and can never race the async embedding
+  tests over the canonical index. (An empty throwaway table also builds its
+  hnsw index instantly, so there is no multi-second index-build timing race.)
 
-  `async: false` because it mutates a shared, table-level index whose name
-  other (async) tests assert on — the sandbox isolates the data, but the
-  index rename must not race those assertions.
+  The two migration modules are thin `execute(Loopctl.Repo.HnswIndex.<...>)`
+  wrappers over the exact SQL exercised here; their production path against
+  `public.articles` is smoke-covered every run by `mix ecto.reset` (which runs
+  the real migrations) and by `Loopctl.KnowledgeEmbeddingTest`, which asserts the
+  canonical index exists on `articles`.
   """
-  use ExUnit.Case, async: false
-
-  # Building a real HNSW index (CREATE INDEX ... USING hnsw) over the test corpus
-  # legitimately takes ~60-70s on a loaded machine — over ExUnit's 60s default — which
-  # intermittently RED-flaked `mix precommit` and the CI Test job. Give the index DDL
-  # ample headroom so this is a deterministic pass, not a timing race. (Test-infra only.)
-  @moduletag timeout: :timer.minutes(5)
+  use ExUnit.Case, async: true
 
   alias Ecto.Adapters.SQL.Sandbox
-  alias Ecto.Migration.Runner
   alias Loopctl.AdminRepo
-
-  # Migration files in priv/repo/migrations are not compiled into the app, so
-  # load the two we exercise by path (idempotent — guarded against re-loading
-  # when the test module is recompiled).
-  @migrations_path "priv/repo/migrations"
-  unless Code.ensure_loaded?(Loopctl.Repo.Migrations.AddEmbeddingHnswIndex) do
-    Code.require_file("#{@migrations_path}/20260410022906_add_embedding_hnsw_index.exs")
-  end
-
-  unless Code.ensure_loaded?(Loopctl.Repo.Migrations.ReconcileHnswIndexName) do
-    Code.require_file("#{@migrations_path}/20260624120000_reconcile_hnsw_index_name.exs")
-  end
-
-  alias Loopctl.Repo.Migrations.AddEmbeddingHnswIndex
-  alias Loopctl.Repo.Migrations.ReconcileHnswIndexName
-
-  @canonical "articles_embedding_hnsw_idx"
-  @noncanonical "articles_embedding_idx"
+  alias Loopctl.Repo.HnswIndex
 
   setup do
-    pid = Sandbox.start_owner!(AdminRepo, shared: true)
+    pid = Sandbox.start_owner!(AdminRepo, shared: false)
     on_exit(fn -> Sandbox.stop_owner(pid) end)
-    :ok
+
+    # A per-test, uniquely-named throwaway table with a pgvector embedding
+    # column. Created inside this test's sandbox transaction, so it is invisible
+    # to every other test and rolled back on exit — nothing to drop explicitly.
+    table = "hnsw_reconcile_test_#{System.unique_integer([:positive])}"
+
+    AdminRepo.query!("CREATE TABLE #{table} (id bigserial PRIMARY KEY, embedding vector(1536))")
+
+    %{
+      table: table,
+      migration: HnswIndex.migration_index_name(table),
+      canonical: HnswIndex.canonical_index_name(table)
+    }
   end
 
-  defp hnsw_index_names do
+  # Names of all hnsw-access-method indexes on `table`, schema-qualified to public.
+  defp hnsw_index_names(table) do
     AdminRepo.query!("""
     SELECT i.relname
     FROM pg_index x
     JOIN pg_class i ON i.oid = x.indexrelid
     JOIN pg_class t ON t.oid = x.indrelid
+    JOIN pg_namespace n ON n.oid = t.relnamespace
     JOIN pg_am    am ON am.oid = i.relam
-    WHERE t.relname = 'articles' AND am.amname = 'hnsw'
+    WHERE t.relname = '#{table}' AND n.nspname = 'public' AND am.amname = 'hnsw'
     """).rows
     |> List.flatten()
   end
 
-  defp run_migration(module, op) do
-    Runner.run(AdminRepo, [], 0, module, :forward, op, op, log: false)
+  defp create_hnsw_index(table, name) do
+    AdminRepo.query!("CREATE INDEX #{name} ON #{table} USING hnsw (embedding vector_cosine_ops)")
   end
 
-  test "down-migration drops the actually-present HNSW index (non-migration name)" do
-    # Precondition: a DB where the hnsw index exists under a NON-migration
-    # name — i.e. exactly prod's situation. Rename the canonical test index
-    # to a foreign name so the only hnsw index is not what the old migration
-    # hard-coded.
-    AdminRepo.query!("ALTER INDEX #{@canonical} RENAME TO articles_embedding_out_of_band_idx")
+  test "drop-step drops the actually-present HNSW index (non-migration name)", ctx do
+    %{table: table, migration: migration, canonical: canonical} = ctx
 
-    assert hnsw_index_names() == ["articles_embedding_out_of_band_idx"]
+    # An hnsw index present under an out-of-band name — exactly prod's situation
+    # (the live index was created outside the migration's name).
+    out_of_band = "#{table}_out_of_band_idx"
+    create_hnsw_index(table, out_of_band)
+    assert hnsw_index_names(table) == [out_of_band]
 
-    # The FIXED down-step must drop it by amname, not silently no-op on a
-    # hard-coded `articles_embedding_idx`.
-    run_migration(AddEmbeddingHnswIndex, :down)
+    # The amname-based drop must drop it, not no-op against a hard-coded name.
+    AdminRepo.query!(HnswIndex.drop_all_sql(table))
 
-    assert hnsw_index_names() == [],
-           "down-migration must drop the present hnsw index, not no-op against a foreign name"
+    assert hnsw_index_names(table) == [],
+           "drop-step must drop the present hnsw index, not no-op against a foreign name"
 
-    # And the up-step recreates it (under the old migration's name), which the
-    # reconcile migration then renames to the canonical name.
-    run_migration(AddEmbeddingHnswIndex, :up)
-    assert hnsw_index_names() == [@noncanonical]
+    # The create-step recreates it (under the old migration's name), which the
+    # reconcile step then renames to the canonical name.
+    AdminRepo.query!(HnswIndex.create_if_absent_sql(table))
+    assert hnsw_index_names(table) == [migration]
 
-    run_migration(ReconcileHnswIndexName, :up)
-    assert hnsw_index_names() == [@canonical]
+    AdminRepo.query!(HnswIndex.reconcile_sql(table))
+    assert hnsw_index_names(table) == [canonical]
   end
 
-  test "old up-step does not create a duplicate hnsw index from the prod drift state (AC-27.14.2)" do
-    # Reproduce prod's drift: the single hnsw index lives under the out-of-band
-    # name `articles_embedding_hnsw_idx`, NOT the migration's `articles_embedding_idx`.
-    assert hnsw_index_names() == [@canonical]
+  test "create-step does not create a duplicate hnsw index from the drift state (AC-27.14.2)",
+       ctx do
+    %{table: table, canonical: canonical} = ctx
 
-    # The amname-aware up-guard must see the existing hnsw index and SKIP, so
-    # no second redundant hnsw index is created. (The old name-based guard
-    # `indexname = 'articles_embedding_idx'` would have created a duplicate.)
-    run_migration(AddEmbeddingHnswIndex, :up)
+    # Drift state: the single hnsw index lives under the out-of-band canonical
+    # name, NOT the migration's `<table>_embedding_idx`.
+    create_hnsw_index(table, canonical)
+    assert hnsw_index_names(table) == [canonical]
 
-    assert hnsw_index_names() == [@canonical],
-           "up-step must not create a duplicate hnsw index when one already exists under a different name"
+    # The amname-aware create-guard must see the existing hnsw index and SKIP,
+    # so no second redundant hnsw index is created.
+    AdminRepo.query!(HnswIndex.create_if_absent_sql(table))
+
+    assert hnsw_index_names(table) == [canonical],
+           "create-step must not create a duplicate hnsw index when one already exists under a different name"
   end
 
-  test "down-step drops ALL hnsw indexes, leaving none orphaned (AC-27.14.2)" do
-    # Force the (normally unreachable) two-index state to prove the down-step
+  test "drop-step drops ALL hnsw indexes, leaving none orphaned (AC-27.14.2)", ctx do
+    %{table: table, migration: migration, canonical: canonical} = ctx
+
+    # Force the (normally unreachable) two-index state to prove the drop-step
     # iterates over every hnsw index rather than dropping only one (LIMIT 1).
-    AdminRepo.query!(
-      "CREATE INDEX articles_embedding_idx ON articles USING hnsw (embedding vector_cosine_ops)"
-    )
+    create_hnsw_index(table, canonical)
+    create_hnsw_index(table, migration)
+    assert Enum.sort(hnsw_index_names(table)) == Enum.sort([canonical, migration])
 
-    assert Enum.sort(hnsw_index_names()) == Enum.sort([@canonical, @noncanonical])
+    AdminRepo.query!(HnswIndex.drop_all_sql(table))
 
-    run_migration(AddEmbeddingHnswIndex, :down)
-
-    assert hnsw_index_names() == [],
-           "down-step must drop every hnsw index, leaving none orphaned"
+    assert hnsw_index_names(table) == [],
+           "drop-step must drop every hnsw index, leaving none orphaned"
   end
 
-  test "reconcile migration renames a non-canonical hnsw index to the canonical name" do
-    # Simulate a fresh test DB: only the old migration's name is present.
-    AdminRepo.query!("ALTER INDEX #{@canonical} RENAME TO #{@noncanonical}")
-    assert hnsw_index_names() == [@noncanonical]
+  test "reconcile renames a non-canonical hnsw index to the canonical name", ctx do
+    %{table: table, migration: migration, canonical: canonical} = ctx
 
-    run_migration(ReconcileHnswIndexName, :up)
-    assert hnsw_index_names() == [@canonical]
+    # Fresh-DB shape: only the old migration's name is present.
+    create_hnsw_index(table, migration)
+    assert hnsw_index_names(table) == [migration]
+
+    AdminRepo.query!(HnswIndex.reconcile_sql(table))
+    assert hnsw_index_names(table) == [canonical]
   end
 
-  test "reconcile migration is idempotent — re-running it is a no-op" do
-    assert hnsw_index_names() == [@canonical]
+  test "reconcile is idempotent — re-running it is a no-op", ctx do
+    %{table: table, canonical: canonical} = ctx
+
+    create_hnsw_index(table, canonical)
+    assert hnsw_index_names(table) == [canonical]
 
     # Already canonical: first run is a no-op...
-    run_migration(ReconcileHnswIndexName, :up)
-    assert hnsw_index_names() == [@canonical]
+    AdminRepo.query!(HnswIndex.reconcile_sql(table))
+    assert hnsw_index_names(table) == [canonical]
 
     # ...and a second run is also a no-op (the guard short-circuits).
-    run_migration(ReconcileHnswIndexName, :up)
-    assert hnsw_index_names() == [@canonical]
+    AdminRepo.query!(HnswIndex.reconcile_sql(table))
+    assert hnsw_index_names(table) == [canonical]
   end
 
-  test "guard does not treat a non-hnsw object squatting the canonical name as 'already reconciled'" do
-    # Failure mode the tightened idempotency guard fixes: a bare
-    # `pg_class.relname = 'articles_embedding_hnsw_idx'` check matches ANY
-    # relation of that name (table, view, sequence, or an index of another AM)
-    # and RETURNs early, silently reporting success while the real hnsw index
-    # still sits under a non-canonical name — leaving the very drift this
-    # migration exists to remove.
-    #
-    # Set up exactly that: the real hnsw index lives under the non-canonical
-    # name, and an UNRELATED table squats the canonical name. Postgres puts
-    # tables and indexes in the same relation namespace, so reconciliation
-    # legitimately cannot complete (the RENAME target is occupied). The CORRECT
-    # behavior is to surface that conflict by raising — NOT to short-circuit at
-    # the guard and report a false success. The old bare-relname guard would
-    # have hidden the drift by returning early; the amname='hnsw' guard does
-    # not, so the migration proceeds to the RENAME and raises on the collision.
-    AdminRepo.query!("ALTER INDEX #{@canonical} RENAME TO #{@noncanonical}")
-    AdminRepo.query!("CREATE TABLE #{@canonical} (id int)")
+  test "guard does not treat a non-hnsw object squatting the canonical name as reconciled",
+       ctx do
+    %{table: table, migration: migration, canonical: canonical} = ctx
 
-    assert hnsw_index_names() == [@noncanonical]
+    # The real hnsw index lives under the non-canonical name, and an UNRELATED
+    # table squats the canonical name. Postgres puts tables and indexes in the
+    # same relation namespace, so the RENAME target is occupied and
+    # reconciliation legitimately cannot complete. The CORRECT behaviour is to
+    # surface that conflict by RAISING — not to short-circuit at the guard and
+    # report a false success (which a bare `relname` guard would have done).
+    create_hnsw_index(table, migration)
+    AdminRepo.query!("CREATE TABLE #{canonical} (id int)")
+
+    assert hnsw_index_names(table) == [migration]
 
     assert_raise Postgrex.Error, fn ->
-      run_migration(ReconcileHnswIndexName, :up)
+      AdminRepo.query!(HnswIndex.reconcile_sql(table))
     end
   end
 end

--- a/test/loopctl/token_usage/default_archival_test.exs
+++ b/test/loopctl/token_usage/default_archival_test.exs
@@ -73,11 +73,10 @@ defmodule Loopctl.TokenUsage.DefaultArchivalTest do
 
   defp repo_story(tenant_id, project_id, epic_id) do
     seq = System.unique_integer([:positive])
-    minor = rem(seq, 9999) + 1
 
     %Story{tenant_id: tenant_id, project_id: project_id, epic_id: epic_id}
     |> Story.create_changeset(%{
-      number: "1.#{minor}",
+      number: Loopctl.Fixtures.next_story_number(),
       title: "Story #{seq}",
       description: "test",
       acceptance_criteria: [],

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -38,6 +38,41 @@ defmodule Loopctl.Fixtures do
   alias Loopctl.WorkBreakdown.Story
   alias Loopctl.WorkBreakdown.StoryDependency
 
+  # Persistent-term key holding the VM-global :atomics counter that backs
+  # `next_story_number/0`. The counter is initialized once, single-threaded, in
+  # `test/test_helper.exs` before any (async) test runs — see that file.
+  @story_number_counter {__MODULE__, :story_number_counter}
+
+  @doc """
+  Returns a VM-globally-unique story `number` of the form `"MAJOR.MINOR"` where
+  both parts are non-negative integers `< 10000` (satisfying `Story`'s
+  number-format validation).
+
+  Every call returns a distinct `(MAJOR, MINOR)` pair, so fixture-generated
+  story numbers can never collide with one another *within any
+  `(tenant_id, project_id)`* — structurally eliminating the intermittent
+  `stories_tenant_id_project_id_number_index` fixture flake.
+
+  The old scheme (`number: "1.\#{rem(seq, 9999) + 1}"`) was non-injective: it
+  truncated an unbounded `System.unique_integer/1` into only 9999 minor buckets
+  under a fixed major of `1`. Two stories in the same project collided whenever
+  their seqs were congruent mod 9999 (or once a project exceeded 9999 stories),
+  and a default minor of `1` collided with any test that inserted an explicit
+  `"1.1"` in the same project.
+
+  `MAJOR` starts at `1000` and only advances every 9000 numbers, so generated
+  numbers never collide with the small, explicitly hard-coded numbers (`"1.1"`,
+  `"2.3"`, `"72.3"`, …) that individual tests insert directly. The pair space
+  covers 9000 × 9000 ≈ 81M distinct numbers — far beyond any suite.
+  """
+  @spec next_story_number() :: String.t()
+  def next_story_number do
+    n = :atomics.add_get(:persistent_term.get(@story_number_counter), 1, 1)
+    major = 1000 + div(n - 1, 9000)
+    minor = rem(n - 1, 9000) + 1
+    "#{major}.#{minor}"
+  end
+
   @doc """
   Builds a data map for the given type without database insertion.
   Useful for changeset tests and unit tests that don't need persistence.
@@ -176,12 +211,10 @@ defmodule Loopctl.Fixtures do
 
   def build(:story, attrs) do
     seq = System.unique_integer([:positive])
-    # Keep minor part under 10000 to satisfy sort_key validation
-    minor = rem(seq, 9999) + 1
 
     Map.merge(
       %{
-        number: "1.#{minor}",
+        number: next_story_number(),
         title: "Story #{seq}",
         description: "Test story description",
         acceptance_criteria: [],

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,6 +2,15 @@ ExUnit.start()
 Ecto.Adapters.SQL.Sandbox.mode(Loopctl.Repo, :manual)
 Ecto.Adapters.SQL.Sandbox.mode(Loopctl.AdminRepo, :manual)
 
+# VM-global :atomics counter backing `Loopctl.Fixtures.next_story_number/0`.
+# Initialized once here, single-threaded, before any (async) test runs, so the
+# counter is a single shared source of guaranteed-unique story numbers — no
+# lazy-init race. `:atomics.add_get/3` is atomic across all test processes.
+:persistent_term.put(
+  {Loopctl.Fixtures, :story_number_counter},
+  :atomics.new(1, signed: false)
+)
+
 # audit_log is time-partitioned. The create_audit_log migration seeds partitions for a
 # window anchored to WHEN IT RAN (its month + 3). A fresh CI DB migrated today therefore
 # has no partition for the FIXED past-dated rows many tests insert (e.g. ~U[2026-06-24]),


### PR DESCRIPTION
## Summary

Two intermittent CI flakes, both the same root disease: a test depending on **shared/mutable global state the Ecto SQL sandbox does not isolate**. Root-caused each and fixed the design structurally so they cannot recur.

## FLAKE 1 — fixture story-number collisions

`build(:story)` (and a duplicated inline helper in `default_archival_test`) generated:

```elixir
number: "1.#{rem(System.unique_integer([:positive]), 9999) + 1}"
```

`rem/2` is **non-injective** — it collapsed an unbounded unique integer into only 9999 minor buckets under a fixed major of `1`. Two stories in the same `(tenant_id, project_id)` collided whenever their seqs were congruent mod 9999 (or once a project passed 9999 stories), and a default minor of `1` collided with any test inserting an explicit `"1.1"` in the same project — intermittently tripping `stories_tenant_id_project_id_number_index`. Reproduced: 20000 generated defaults → only **9999 distinct** minors; `minor == 1` recurs (~1/9999, matching the observed intermittency). Tenant `slug`/`email` were already unique-per-VM via `System.unique_integer/1`.

**Fix:** one shared source of truth — `Loopctl.Fixtures.next_story_number/0`, backed by a VM-global `:atomics` counter (initialized once, single-threaded, in `test_helper.exs`, so no lazy-init race). It emits injective `"MAJOR.MINOR"` pairs (both `< 10000`, satisfying `Story`'s format rule) with `MAJOR` starting at `1000` — above every hard-coded test number (max is `72`) — so generated numbers can never collide with one another within a project nor with explicit small numbers. Removed both `rem` generators. Added `fixtures_uniqueness_test.exs` (5000 distinct numbers; 300 stories in one project; 500 distinct tenant slugs/emails).

## FLAKE 2 — hnsw reconcile test isolation

`reconcile_hnsw_index_migration_test` dropped / renamed / recreated the shared, table-level `articles_embedding_hnsw_idx` on `public.articles` to exercise the migration behaviour. The sandbox isolates **row data, not DDL on a shared schema object**, so the test manipulated global state every embedding test depends on (and built a real hnsw index over the live corpus — the ~60s build behind the older timeout flake).

**Fix (dependency injection / isolate-the-global-state):** extracted the capability-based (`amname='hnsw'`) detect/create/drop/reconcile SQL — previously inlined and hard-coded to `public.articles` — into `Loopctl.Repo.HnswIndex`, parameterized by table name. The two migrations now delegate with `"articles"` (semantically identical SQL — a pure refactor, verified by `ecto.reset` running the real migrations). The test exercises the same logic against a **per-test, uniquely-named throwaway table** it creates in its own sandbox transaction, so it never touches the canonical index — which lets it become `async: true` (no shared object to race; an empty table builds its index instantly). The production path stays smoke-covered by `ecto.reset` and `KnowledgeEmbeddingTest`'s canonical-index assertion.

## Verification

- `mix precommit` green via the commit hook: compile `--warnings-as-errors`, format, `credo --strict`, dialyzer (0 real errors), full `mix test` = **3530 tests, 0 failures**.
- Both flake areas stress-tested across **15 seeds, 0 failures**; full suite green on 5+ additional seeds.
- No production behaviour change — migrations emit the same SQL against the same object.

## Out of scope — a separate pre-existing flake found

While sweeping the full suite I hit a **third, unrelated** intermittent failure (~1 in 6 full runs): `update_last_seen_test` → `GET /api/v1/changes` raises `db_statement_timeout` (SQLSTATE 57014) via `Loopctl.HeavyRead.with_statement_timeout` — the 10s per-read statement timeout exceeded under 24-way parallel load. It lives entirely in untouched audit/heavy-read code (different root cause: timeout-under-contention, not isolation/uniqueness) and needs its own decision (test-env timeout vs prod-parity, which `config/test.exs` deliberately mirrors). Flagged here rather than silently expanding this PR's scope; happy to take it as a follow-up with sign-off.
