### PR TITLE
fix(test): inject a realistic :change_feed heavy-read statement_timeout override to stop incidental GET /changes flakes

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -75,10 +75,30 @@ config :loopctl, :enable_local_test_runner, false
 # query in the SAME test. Keep timeout assertions on the dedicated pool to avoid that.
 config :loopctl, :heavy_read_repo, Loopctl.AdminRepo
 
-# US-27.4: TC-27.4.1 integration test — set a low statement_timeout override
-# for suggested_links to make timeout tests fast and deterministic. Harmless
-# for normal tests (the timeout is much longer than any real query).
-config :loopctl, :heavy_read_statement_timeout_overrides, %{suggested_links: 5_000}
+# Per-endpoint statement_timeout overrides (HeavyRead.opts/1). An endpoint listed here
+# uses its own SET LOCAL statement_timeout instead of the aggressive 250ms pool-wide
+# default (`:heavy_read_statement_timeout_ms` above). Two distinct reasons an endpoint
+# appears here:
+#
+#   * :suggested_links (US-27.4, TC-27.4.1) — a generous 5s so the integration test's
+#     real query never times out; the timeout MECHANISM is proven elsewhere by tests
+#     that pass an EXPLICIT low per-call `statement_timeout` (heavy_read_statement_timeout_test.exs,
+#     suggest_links_controller "override -> real 57014 -> 504") and by :semantic_search
+#     inheriting the 250ms default (slow_query_logger_test.exs).
+#
+#   * :change_feed — the keyset change-feed read behind `GET /api/v1/changes`
+#     (Audit.list_changes/3 -> HeavyRead.opts(:change_feed)). On the small sandbox
+#     dataset this read is sub-millisecond, but under 24-way parallel DB contention it
+#     intermittently exceeded the 250ms default and 57014'd (HTTP 504), flaking
+#     INCIDENTAL callers of GET /changes (update_last_seen_test.exs and friends) that
+#     don't intend to test the timeout at all. 5s is generous enough to never trip under
+#     contention yet still finite (prod-scale plan/index is guarded separately by
+#     by_source_change_feed_plan_scale_test.exs / keyset_plan_scale_test.exs). No test
+#     asserts a :change_feed timeout, so this override cannot mask a real one.
+config :loopctl, :heavy_read_statement_timeout_overrides, %{
+  suggested_links: 5_000,
+  change_feed: 5_000
+}
 
 # US-27.6b: the over-fetch pool sizing knobs (`Loopctl.Knowledge.VectorSearch.pool_size/2`).
 # In the DEFAULT async suite we shrink floor/cap to 6 so the under-fill detection can be


### PR DESCRIPTION
## The flake (third test-isolation flake, ~1/6 full runs)

`test/loopctl_web/plugs/update_last_seen_test.exs` (and other incidental callers of `GET /api/v1/changes`) intermittently failed under 24-way parallel test contention with `db_statement_timeout` / SQLSTATE **57014** → **HTTP 504**.

**Exact reproduced stacktrace (pre-fix, seed 32):**

```
1) test UpdateLastSeen plug updates last_seen_at ... (LoopctlWeb.Plugs.UpdateLastSeenTest)
   test/loopctl_web/plugs/update_last_seen_test.exs:13
   ** (LoopctlWeb.SanitizedDBError) mapped to HTTP 504 mapped_code=db_statement_timeout sqlstate=57014
   code: |> get(~p"/api/v1/changes?since=#{past}")
     lib/loopctl/heavy_read.ex:147: Loopctl.HeavyRead.with_statement_timeout/2
     lib/loopctl/audit.ex:230: Loopctl.Audit.list_changes/3
     lib/loopctl_web/controllers/change_controller.ex:114: LoopctlWeb.ChangeController.index/2
```

## Root cause

`Audit.list_changes/3` runs the change-feed keyset read via `HeavyRead.all(tenant_id, query, HeavyRead.opts(:change_feed))`. `:change_feed` had **no entry** in `:heavy_read_statement_timeout_overrides`, so it fell back to the pool-wide default `:heavy_read_statement_timeout_ms` = **250ms** (deliberately aggressive in test so timeout *behavior* is testable). On the small sandbox dataset the read is sub-millisecond, but under 24-way DB contention it occasionally exceeded 250ms and 57014'd — flaking **incidental** tests that merely use `GET /changes` and never intended to test the timeout.

This is pure test-contention, **not** a missing index / full scan: prod-scale plan/index is guarded separately by `by_source_change_feed_plan_scale_test.exs` and `keyset_plan_scale_test.exs`.

## Fix (config-based DI, test-config only — NO production code change)

Add a `:change_feed` entry to the existing per-operation override map in `config/test.exs`, mirroring the `suggested_links: 5_000` precedent:

```elixir
config :loopctl, :heavy_read_statement_timeout_overrides, %{
  suggested_links: 5_000,
  change_feed: 5_000
}
```

The incidental change-feed read now gets an appropriate injected timeout (5s — generous enough to never trip under contention, still finite) instead of the artificial 250ms global default.

## The dedicated timeout mechanism stays explicitly tested

No test relies on the 250ms default for `:change_feed`, so this override masks nothing:
- `heavy_read_statement_timeout_test.exs` and the suggest_links controller pass an **explicit low per-call** `statement_timeout` (50ms) to fire a real 57014 → 504.
- `:semantic_search` still inherits the 250ms default (`slow_query_logger_test.exs`).
- Dedicated-pool cancellations run in `heavy_read_repo_test.exs` / `heavy_read_pool_isolation_test.exs`.

## Verification

- **Pre-fix:** 4/23 full-suite runs 57014'd on `:change_feed` (seeds 6, 9, 11, 32) ≈ 1/5.75, matching "~1/6".
- **Post-fix:** 0/22 full-suite runs had any `:change_feed` 504, including the 4 previously-failing seeds now green.
- Dedicated timeout tests: 67 tests, 0 failures.
- `mix precommit` green (compile --warnings-as-errors, format, credo --strict, dialyzer 0, full test 3530/0).

## Out of scope (separate pre-existing flake, surfaced honestly)

One post-fix run (seed 43) failed on an **unrelated** flake: `OKFControllerTest` streamed export got **HTTP 429 (rate-limited)** instead of 200 under contention. Different subsystem (rate limiter), different root cause, not a `GET /changes`/heavy-read-timeout issue, and unaffected by this config change. Flagging for a separate fix.