### PR TITLE
fix: OKF export rate-limit test flake under async parallelism

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -267,16 +267,11 @@ config :loopctl, :bulk_delete_frozen_max, 3
 #   releases the connection between pages and that max in-flight ≤ chunk_size).
 # - max_links_per_article 5: a "dense hub" of >5 links is bounded with ~6 neighbors
 #   instead of 100+.
-# - export_max_concurrent_global 128: raise from prod default (2) so incidental OKF
-#   export tests in async parallelism don't collide on the global cap. The cap MECHANISM
-#   is proven by ExportConcurrencyTest.global_cap_bounds_total_in_flight_exports, which
-#   dynamically reads max_global() and asserts the behavior against it, so raising this
-#   config knob does NOT silence that test. Prod stays at 2 (config/runtime.exs).
-# - export_max_concurrent_per_tenant: defaults to prod value (1) — per-tenant isolation
-#   is still enforced.
+# (The `:export_max_concurrent_global` cap is raised in the SCALE-gated block above, so
+# it is NOT overridden here — the nightly scale leg keeps the prod default so TC-27.16.5
+# can still prove the cap refuses over-budget exports.)
 config :loopctl, :export_chunk_size, 3
 config :loopctl, :export_max_links_per_article, 5
-config :loopctl, :export_max_concurrent_global, 128
 
 # US-27.16 (#3): small decompression-bomb caps so the bomb-defense test runs cheaply
 # — a ~1KB gzip that inflates past these is rejected without materializing it.

--- a/config/test.exs
+++ b/config/test.exs
@@ -120,6 +120,25 @@ unless System.get_env("SCALE_NIGHTLY") || System.get_env("SCALE_TESTS") do
   # unaffected. The SCALE gate keeps the prod defaults. Config-based DI — no put_env.
   config :loopctl, :semantic_result_pool_floor, 2
   config :loopctl, :semantic_result_pool_cap, 5
+
+  # US-27.16: the streaming-export concurrency cap (`Loopctl.Knowledge.ExportConcurrency`).
+  # The GLOBAL cap (`:export_max_concurrent_global`, prod default 2 — sized to the heavy-read
+  # pool's export reservation) is a SINGLE VM-wide ETS counter shared by EVERY async test that
+  # makes a real export request. In the DEFAULT suite (max_cases ~24) three-plus incidental
+  # OKF/Obsidian export tests — each its OWN tenant, so the PER-TENANT cap of 1 is never the
+  # constraint — run concurrently and contend on that one global counter of 2, so the 3rd+
+  # intermittently got a spurious 429 instead of 200 (a shared-global-state flake, NOT a real
+  # over-cap). Raise the GLOBAL cap well above max_cases so incidental parallel exports never
+  # collide; the PER-TENANT cap stays at the prod default (1) because it is NEVER the incidental
+  # constraint (distinct tenants) and the controller's dedicated 429 test saturates it directly.
+  #
+  # This cannot mask a real limiter regression: the DEDICATED limit tests set their OWN explicit
+  # LOW caps and so are independent of this value — `export_concurrency_test.exs` calls
+  # `ExportConcurrency.acquire/3` with fixed caps, `knowledge_export_controller_test.exs` trips
+  # the per-tenant cap (unchanged at 1), and the nightly `streaming_export_scale_test.exs`
+  # (TC-27.16.5) runs OUTSIDE this SCALE gate so it keeps the prod default (2) and still proves
+  # the cap refuses over-budget exports.
+  config :loopctl, :export_max_concurrent_global, 64
 end
 
 # We don't run a server during test. If one is required,
@@ -248,10 +267,16 @@ config :loopctl, :bulk_delete_frozen_max, 3
 #   releases the connection between pages and that max in-flight ≤ chunk_size).
 # - max_links_per_article 5: a "dense hub" of >5 links is bounded with ~6 neighbors
 #   instead of 100+.
-# - concurrency caps default to prod values (global 2, per-tenant 1) — the cap test
-#   asserts against those.
+# - export_max_concurrent_global 128: raise from prod default (2) so incidental OKF
+#   export tests in async parallelism don't collide on the global cap. The cap MECHANISM
+#   is proven by ExportConcurrencyTest.global_cap_bounds_total_in_flight_exports, which
+#   dynamically reads max_global() and asserts the behavior against it, so raising this
+#   config knob does NOT silence that test. Prod stays at 2 (config/runtime.exs).
+# - export_max_concurrent_per_tenant: defaults to prod value (1) — per-tenant isolation
+#   is still enforced.
 config :loopctl, :export_chunk_size, 3
 config :loopctl, :export_max_links_per_article, 5
+config :loopctl, :export_max_concurrent_global, 128
 
 # US-27.16 (#3): small decompression-bomb caps so the bomb-defense test runs cheaply
 # — a ~1KB gzip that inflates past these is rejected without materializing it.

--- a/lib/loopctl/knowledge/export_concurrency.ex
+++ b/lib/loopctl/knowledge/export_concurrency.ex
@@ -66,9 +66,25 @@ defmodule Loopctl.Knowledge.ExportConcurrency do
   """
   @spec acquire(binary()) :: :ok | {:error, :too_many_exports}
   def acquire(tenant_id) when is_binary(tenant_id) do
-    global_max = max_global()
-    tenant_max = max_per_tenant()
+    acquire(tenant_id, max_global(), max_per_tenant())
+  end
 
+  @doc """
+  Like `acquire/1`, but reserves against EXPLICIT `global_max` / `tenant_max` caps
+  instead of the configured ones.
+
+  Production always uses `acquire/1` (which reads `max_global/0` / `max_per_tenant/0`
+  from config). This variant exists for the tracker's OWN unit tests: the async test
+  suite deliberately raises `:export_max_concurrent_global` (see `config/test.exs`) so
+  incidental parallel export tests never collide on the shared, VM-wide global counter
+  — so a test that must PROVE the limiter refuses over-cap acquires passes its own fixed
+  LOW caps here, independent of that (high) suite default. Mirrors the `pool_size/2`
+  unit tests passing explicit knob args (US-27.6b).
+  """
+  @spec acquire(binary(), pos_integer(), pos_integer()) :: :ok | {:error, :too_many_exports}
+  def acquire(tenant_id, global_max, tenant_max)
+      when is_binary(tenant_id) and is_integer(global_max) and global_max > 0 and
+             is_integer(tenant_max) and tenant_max > 0 do
     # Reserve the slots ONLY IF the monitor registration succeeds atomically.
     # Use a GenServer call to atomically (on the server) check the caps, increment
     # the counters IF both pass, and register the monitor — all in one operation.

--- a/test/loopctl/knowledge/export_concurrency_test.exs
+++ b/test/loopctl/knowledge/export_concurrency_test.exs
@@ -16,10 +16,21 @@ defmodule Loopctl.Knowledge.ExportConcurrencyTest do
 
   alias Loopctl.Knowledge.ExportConcurrency, as: EC
 
+  # This unit test proves the limiter with its OWN fixed LOW caps via `EC.acquire/3`,
+  # INDEPENDENT of the (deliberately high) `:export_max_concurrent_global` the async
+  # suite sets in `config/test.exs` to stop incidental parallel export tests colliding
+  # on the shared global counter. So we saturate a LOGICAL cap of #{2} — never the
+  # configured one — and hold at most #{2} shared-global slots, which can't starve those
+  # cap-64 incidental exports. Mirrors the `pool_size/2` unit tests passing explicit knob
+  # args (US-27.6b).
+  @global 2
+  @per_tenant 1
+
   defp tid, do: Ecto.UUID.generate()
 
-  # Acquire (retrying on transient global-cap contention from concurrent async tests)
-  # and hold the slot in a kept-alive process until released. Returns the pid.
+  # Acquire against the test's explicit low caps (retrying on transient global-counter
+  # contention from concurrent async tests) and hold the slot in a kept-alive process
+  # until released. Returns the pid.
   defp hold(tenant_id) do
     parent = self()
 
@@ -43,7 +54,7 @@ defmodule Loopctl.Knowledge.ExportConcurrencyTest do
   defp retry_acquire(_t, 0), do: flunk("could not acquire export slot")
 
   defp retry_acquire(t, attempts) do
-    case EC.acquire(t) do
+    case EC.acquire(t, @global, @per_tenant) do
       :ok ->
         :ok
 
@@ -62,12 +73,13 @@ defmodule Loopctl.Knowledge.ExportConcurrencyTest do
       # Default per-tenant cap is 1 (config). The first acquire on a tenant
       # succeeds; a second concurrent one (from another process) is refused.
       t = tid()
-      assert :ok = EC.acquire(t)
+      assert :ok = EC.acquire(t, @global, @per_tenant)
       assert EC.tenant_count(t) == 1
 
       # A second acquirer for the SAME tenant, from another process, is over the
       # per-tenant cap of 1.
-      assert {:error, :too_many_exports} = from_other_process(fn -> EC.acquire(t) end)
+      assert {:error, :too_many_exports} =
+               from_other_process(fn -> EC.acquire(t, @global, @per_tenant) end)
 
       assert :ok = EC.release(t)
       assert EC.tenant_count(t) == 0
@@ -75,30 +87,30 @@ defmodule Loopctl.Knowledge.ExportConcurrencyTest do
 
     test "release/1 frees the slot so a later acquire succeeds" do
       t = tid()
-      assert :ok = EC.acquire(t)
+      assert :ok = EC.acquire(t, @global, @per_tenant)
       assert :ok = EC.release(t)
       # After release, another process can acquire again.
-      assert :ok = from_other_process(fn -> EC.acquire(t) end)
+      assert :ok = from_other_process(fn -> EC.acquire(t, @global, @per_tenant) end)
       from_other_process(fn -> EC.release(t) end)
     end
 
     test "global cap bounds total in-flight exports across tenants" do
-      # Global cap default is 2. Hold the global cap with `max_global` DIFFERENT
-      # tenants (each within its per-tenant cap of 1). Once saturated, a fresh tenant
-      # is refused on the GLOBAL cap (its per-tenant count is 0). Because the GLOBAL
-      # counter is shared with concurrent async tests, we retry the saturation+refusal
-      # invariant until it holds (a transient concurrent holder just delays it).
-      holders = for _ <- 1..EC.max_global(), do: hold(tid())
+      # Explicit logical global cap of `@global` (2). Hold it with `@global` DIFFERENT
+      # tenants (each within its per-tenant cap of 1). Once saturated, a fresh tenant is
+      # refused on the GLOBAL cap (its per-tenant count is 0). Because the GLOBAL counter
+      # is shared with concurrent async tests, we retry the saturation+refusal invariant
+      # until it holds (a transient concurrent holder just delays it).
+      holders = for _ <- 1..@global, do: hold(tid())
 
       t_extra = tid()
 
       assert eventually(fn ->
                # Saturated by our holders (+ possibly others) AND a 0-count tenant is
                # refused purely on the global cap.
-               EC.global_count() >= EC.max_global() and
+               EC.global_count() >= @global and
                  match?(
                    {:error, :too_many_exports},
-                   from_other_process(fn -> EC.acquire(t_extra) end)
+                   from_other_process(fn -> EC.acquire(t_extra, @global, @per_tenant) end)
                  ) and
                  EC.tenant_count(t_extra) == 0
              end),
@@ -113,9 +125,10 @@ defmodule Loopctl.Knowledge.ExportConcurrencyTest do
       # exactly 1 — the refused acquire undid BOTH its global and tenant increments
       # (a partial reservation would leave tenant_count at 2 or the global leaked).
       t = tid()
-      assert :ok = EC.acquire(t)
+      assert :ok = EC.acquire(t, @global, @per_tenant)
 
-      assert {:error, :too_many_exports} = from_other_process(fn -> EC.acquire(t) end)
+      assert {:error, :too_many_exports} =
+               from_other_process(fn -> EC.acquire(t, @global, @per_tenant) end)
 
       # The refused per-tenant acquire must have left the tenant counter at 1 (not 2),
       # proving it undid its increment. (We assert the isolated per-tenant counter,
@@ -133,7 +146,7 @@ defmodule Loopctl.Knowledge.ExportConcurrencyTest do
       # Acquire in a process that then dies WITHOUT releasing.
       {:ok, pid} =
         Task.start(fn ->
-          :ok = EC.acquire(t)
+          :ok = EC.acquire(t, @global, @per_tenant)
           # Signal acquired, then block until killed.
           receive do
             :stop -> :ok
@@ -162,11 +175,11 @@ defmodule Loopctl.Knowledge.ExportConcurrencyTest do
       # admitting MORE than max_global.
       #
       # We detect it via the CAP BEHAVIOR (robust to concurrent global activity):
-      # SATURATE the global cap with `max_global` held tenants, then have one EXTRA
+      # SATURATE the explicit global cap with `@global` held tenants, then have one EXTRA
       # tenant acquire → release → exit-immediately (release racing its :DOWN). If the
       # decrement were doubled, the global would drop below the held count and a fresh
       # tenant would be wrongly ADMITTED. It must STAY refused.
-      holders = for _ <- 1..EC.max_global(), do: hold(tid())
+      holders = for _ <- 1..@global, do: hold(tid())
 
       b = tid()
       parent = self()
@@ -177,7 +190,7 @@ defmodule Loopctl.Knowledge.ExportConcurrencyTest do
           # a holder's slot is momentarily free, OR just attempt once; either way the
           # decrement (if it happened) must not over-free. To make the race exist we
           # need b to have ACQUIRED, so retry until it does (a holder briefly yields).
-          case EC.acquire(b) do
+          case EC.acquire(b, @global, @per_tenant) do
             :ok ->
               :ok = EC.release(b)
               send(parent, :b_done)
@@ -198,13 +211,13 @@ defmodule Loopctl.Knowledge.ExportConcurrencyTest do
       t_fresh = tid()
 
       assert eventually(fn ->
-               EC.global_count() >= EC.max_global() and
+               EC.global_count() >= @global and
                  match?(
                    {:error, :too_many_exports},
-                   from_other_process(fn -> EC.acquire(t_fresh) end)
+                   from_other_process(fn -> EC.acquire(t_fresh, @global, @per_tenant) end)
                  )
              end),
-             "global was under-counted: a fresh tenant was admitted though #{EC.max_global()} " <>
+             "global was under-counted: a fresh tenant was admitted though #{@global} " <>
                "holders are live — the cap-bypass double-decrement regressed"
 
       Enum.each(holders, &release/1)


### PR DESCRIPTION
## Summary

Under 24-way async test parallelism, incidental streaming-export tests (OKF `GET /api/v1/knowledge/okf/export` and the Obsidian export) intermittently returned **HTTP 429 "too many concurrent exports"** instead of 200. Root cause is **shared VM-wide global state**: `Loopctl.Knowledge.ExportConcurrency` enforces a GLOBAL cap (`:export_max_concurrent_global`, prod default **2**) on total in-flight streaming exports across ALL tenants, via a single named ETS counter. Each export test uses its own tenant (so the per-tenant cap of 1 is never the constraint), but 3+ of them running concurrently contend on that one global counter of 2, so the 3rd+ got a spurious 429.

It is **pure contention, not a slot leak**: `LoopctlWeb.StreamingExport.stream/2` acquires a slot then runs the body in `try/after` that always calls `release/1`, backed by a GenServer `:DOWN` monitor and an exit-safe `release/1`. The acquire/release path is balanced in production — no prod release-path bug, so no `lib/` change was needed.

## Fix (config-based DI + explicit-cap test seam)

1. **Raise the GLOBAL cap for the default async suite only** — `config :loopctl, :export_max_concurrent_global, 64`, placed inside the existing `SCALE_NIGHTLY`/`SCALE_TESTS`-gated block (mirroring the vector-pool knobs). 64 is comfortably above `max_cases` (~24), so incidental parallel exports never collide. The **per-tenant cap stays at 1** (never the incidental constraint — distinct tenants).
2. **Add `ExportConcurrency.acquire/3`** (explicit `global_max`/`tenant_max`); `acquire/1` delegates, reading config. Production always uses `acquire/1`.
3. **Keep every dedicated limit test explicit:**
   - `export_concurrency_test.exs` uses `acquire/3` with fixed LOW caps (`@global 2`, `@per_tenant 1`), so it proves the limiter independent of the raised config default and holds at most 2 shared-global slots (can't starve incidental exports). Mirrors the `pool_size/2` unit-test pattern (US-27.6b).
   - `knowledge_export_controller_test.exs` still trips the **per-tenant** cap (unchanged at 1) for its dedicated 429 test.
   - The nightly `streaming_export_scale_test.exs` TC-27.16.5 runs **outside** the SCALE gate, so it keeps the prod default (2): its 8 concurrent exporters still trip the cap and it still asserts a 429. (This is why the override is SCALE-gated rather than global — an earlier ungated raise would have silenced that assertion.)

## Changes

- `config/test.exs`: single SCALE-gated `export_max_concurrent_global: 64` override (removed a duplicate ungated `128` that would have broken the nightly scale test's 429 assertion).
- `lib/loopctl/knowledge/export_concurrency.ex`: `acquire/1` delegates to new `acquire/3(tenant_id, global_max, tenant_max)`.
- `test/loopctl/knowledge/export_concurrency_test.exs`: all acquires use explicit low caps via `acquire/3`.

## Verification

- `mix precommit` green: compile `--warnings-as-errors`, format, `credo --strict`, dialyzer (0), full suite **3530 tests, 0 failures**.
- Confirmed effective caps: default async suite → **global 64 / per-tenant 1**; `SCALE_NIGHTLY` leg → **global 2 / per-tenant 1** (nightly limiter test preserved).
- **Contention stress: 34 full-suite runs across random seeds + 15 focused export-file runs — zero export-related failures.** (Pre-fix this 429 appeared ~1 in several full runs.)

## Out of scope — separately observed flake (not this PR)

During stress runs, `test/loopctl/capabilities_test.exs:102` ("consume/1 marks token as consumed", `assert consumed.consumed_at != nil`) failed once in 34 full runs and was **not** reproducible at the same seed — a distinct, rare intermittent flake in token consumption, unrelated to export concurrency. Flagged here for separate triage (kept out to keep this PR one logical change). Note there is also a benign constant Elixir 1.19 type-checker warning on that same line (`%DateTime{} != nil` is "always true").