### PR TITLE
test: scope capture_log assertions to per-test unique ids (fix async global-Logger cross-test flakes)

### DIFF
--- a/test/loopctl/knowledge/attribution_test.exs
+++ b/test/loopctl/knowledge/attribution_test.exs
@@ -180,7 +180,9 @@ defmodule Loopctl.Knowledge.AttributionTest do
             )
         end)
 
-      assert log =~ "invalid project_id dropped"
+      # Scope to THIS tenant's id — capture_log sees the global Logger, so a bare
+      # "invalid project_id dropped" could match a concurrent async test's warning.
+      assert log =~ "invalid project_id dropped tenant_id=#{tenant.id}"
 
       [event] = AdminRepo.all(ArticleAccessEvent)
       assert event.tenant_id == tenant.id
@@ -206,7 +208,8 @@ defmodule Loopctl.Knowledge.AttributionTest do
             )
         end)
 
-      assert log =~ "invalid story_id dropped"
+      # Scope to THIS tenant's id (global Logger is shared across async tests).
+      assert log =~ "invalid story_id dropped tenant_id=#{tenant.id}"
 
       [event] = AdminRepo.all(ArticleAccessEvent)
       assert is_nil(event.project_id)
@@ -273,7 +276,8 @@ defmodule Loopctl.Knowledge.AttributionTest do
                    )
         end)
 
-      assert log =~ "cross-tenant project_id dropped"
+      # Scope to tenant_a's id (global Logger is shared across async tests).
+      assert log =~ "cross-tenant project_id dropped tenant_id=#{tenant_a.id}"
 
       # Event was still inserted, but with NULL attribution columns.
       events = AdminRepo.all(ArticleAccessEvent)
@@ -308,7 +312,8 @@ defmodule Loopctl.Knowledge.AttributionTest do
                    )
         end)
 
-      assert log =~ "cross-tenant story_id dropped"
+      # Scope to tenant_a's id (global Logger is shared across async tests).
+      assert log =~ "cross-tenant story_id dropped tenant_id=#{tenant_a.id}"
 
       [event] = AdminRepo.all(ArticleAccessEvent)
       assert event.tenant_id == tenant_a.id
@@ -336,8 +341,10 @@ defmodule Loopctl.Knowledge.AttributionTest do
                    )
         end)
 
-      assert log =~ "cross-tenant project_id dropped"
-      assert log =~ "api_key_id="
+      # Scope to tenant_a's id + the caller's api_key id (both unique to this
+      # test) so the global-Logger capture can't be satisfied by a sibling.
+      assert log =~ "cross-tenant project_id dropped tenant_id=#{tenant_a.id}"
+      assert log =~ "api_key_id=#{inspect(api_key_a.id)}"
       assert log =~ api_key_a.id
     end
   end

--- a/test/loopctl/progress/custody_invariants_test.exs
+++ b/test/loopctl/progress/custody_invariants_test.exs
@@ -24,6 +24,17 @@ defmodule Loopctl.Progress.CustodyInvariantsTest do
   alias Loopctl.Progress
   alias Loopctl.WorkBreakdown.Story
 
+  # capture_log/1 captures the GLOBAL, process-wide Logger — including log lines
+  # emitted by OTHER tests running concurrently in the async suite. Keep only the
+  # captured line(s) carrying this test's unique story.id so marker assertions
+  # can never be satisfied (or tripped) by a sibling's log line.
+  defp custody_line(log, story_id) do
+    log
+    |> String.split("\n")
+    |> Enum.filter(&String.contains?(&1, story_id))
+    |> Enum.join("\n")
+  end
+
   # A story that has been genuinely reported_done: assigned agent + reported_done_at.
   defp reported_story(reported_done_at \\ nil) do
     tenant = fixture(:tenant)
@@ -214,10 +225,14 @@ defmodule Loopctl.Progress.CustodyInvariantsTest do
                    )
         end)
 
-      assert verify_log =~ "custody_orphaned_blocked"
-      assert verify_log =~ "verify"
-      assert verify_log =~ story.id
-      assert verify_log =~ tenant.id
+      # Scope every marker assertion to THIS story's log line: capture_log sees
+      # the global process-wide Logger, so a bare "custody_orphaned_blocked" /
+      # "verify" substring could match a SIBLING async test's warning captured
+      # concurrently. `custody_line/2` keeps only the line carrying this story.id.
+      verify_line = custody_line(verify_log, story.id)
+      assert verify_line =~ "custody_orphaned_blocked"
+      assert verify_line =~ "verify"
+      assert verify_line =~ tenant.id
 
       # …and on the review path too.
       review_log =
@@ -228,9 +243,9 @@ defmodule Loopctl.Progress.CustodyInvariantsTest do
                    )
         end)
 
-      assert review_log =~ "custody_orphaned_blocked"
-      assert review_log =~ "review"
-      assert review_log =~ story.id
+      review_line = custody_line(review_log, story.id)
+      assert review_line =~ "custody_orphaned_blocked"
+      assert review_line =~ "review"
     end
 
     test "record_review fails closed on a custody-orphaned story" do

--- a/test/loopctl/tenants/tenants_test.exs
+++ b/test/loopctl/tenants/tenants_test.exs
@@ -173,9 +173,12 @@ defmodule Loopctl.TenantsTest do
     test "does not log when slug is unchanged or absent (rls-02 observability)" do
       tenant = fixture(:tenant, %{slug: "steady-slug"})
 
-      # slug absent
+      # slug absent. Scope the refute to THIS tenant's id: the log message is
+      # global-Logger process-wide, so an unscoped "attempted slug mutation"
+      # substring would spuriously match a SIBLING async test's slug-mutation
+      # warning (e.g. the rls-02 test above) captured concurrently.
       log_absent = capture_log(fn -> Tenants.update_tenant(tenant, %{name: "Renamed"}) end)
-      refute log_absent =~ "attempted slug mutation"
+      refute log_absent =~ "attempted slug mutation ignored for tenant #{tenant.id}"
 
       # slug present but identical
       log_same =
@@ -183,7 +186,7 @@ defmodule Loopctl.TenantsTest do
           Tenants.update_tenant(tenant, %{slug: "steady-slug", name: "Renamed Again"})
         end)
 
-      refute log_same =~ "attempted slug mutation"
+      refute log_same =~ "attempted slug mutation ignored for tenant #{tenant.id}"
     end
 
     # rls-03: a colliding email must produce a clean changeset error, not a

--- a/test/loopctl/workers/cost_anomaly_worker_test.exs
+++ b/test/loopctl/workers/cost_anomaly_worker_test.exs
@@ -515,8 +515,14 @@ defmodule Loopctl.Workers.CostAnomalyWorkerTest do
                    })
         end)
 
-      # The clamp ran...
-      assert log =~ "exceeds 90 days; clamping end"
+      # The clamp ran. Scope to the worker-prefixed period range (unique to this
+      # test's inputs) — capture_log sees the global Logger, and a bare
+      # "exceeds 90 days; clamping end" is also emitted by CostRollupWorker and
+      # by sibling async tests, so an unscoped match could come from either.
+      assert log =~
+               "CostAnomalyWorker: period range #{Date.to_iso8601(start_date)}.." <>
+                 "#{Date.to_iso8601(Date.add(start_date, 364))} exceeds 90 days; clamping end"
+
       # ...and the far epic (day 200, outside [start, start+90]) was NOT scanned.
       assert AdminRepo.all(CostAnomaly) == []
     end

--- a/test/loopctl_web/controllers/cap_recovery_controller_test.exs
+++ b/test/loopctl_web/controllers/cap_recovery_controller_test.exs
@@ -27,6 +27,16 @@ defmodule LoopctlWeb.CapRecoveryControllerTest do
     AdminRepo.all(from(c in CapabilityToken, where: c.story_id == ^story_id))
   end
 
+  # capture_log/1 captures the GLOBAL, process-wide Logger — including lines from
+  # OTHER async tests running concurrently. Keep only the captured line(s) carrying
+  # this test's unique story.id so marker assertions can't be satisfied by a sibling.
+  defp forgery_line(log, story_id) do
+    log
+    |> String.split("\n")
+    |> Enum.filter(&String.contains?(&1, story_id))
+    |> Enum.join("\n")
+  end
+
   defp audit_entries(story_id, action) do
     AdminRepo.all(
       from(a in AuditLog,
@@ -262,8 +272,14 @@ defmodule LoopctlWeb.CapRecoveryControllerTest do
           assert %{"error" => %{"status" => 422}} = json_response(conn, 422)
         end)
 
-      assert log =~ "cap_recovery_forgery_attempt"
-      assert log =~ "rejected_cap_type=\"verify_cap\""
+      # Scope marker assertions to THIS story's log line: capture_log sees the
+      # global process-wide Logger, so bare "cap_recovery_forgery_attempt" /
+      # "rejected_cap_type=..." substrings could match a SIBLING async test's
+      # warning captured concurrently. `forgery_line/2` keeps only the line
+      # carrying this story.id (the message emits both on one line).
+      forgery_line = forgery_line(log, story.id)
+      assert forgery_line =~ "cap_recovery_forgery_attempt"
+      assert forgery_line =~ "rejected_cap_type=\"verify_cap\""
       assert log =~ story.id
 
       # Surfaces in GET /stories/:id/history (Audit.entity_history reads this table)

--- a/test/loopctl_web/controllers/fallback_controller_test.exs
+++ b/test/loopctl_web/controllers/fallback_controller_test.exs
@@ -11,6 +11,25 @@ defmodule LoopctlWeb.FallbackControllerTest do
     |> FallbackController.call(error)
   end
 
+  # DBErrorLogger emits a single structured line per error, embedding the conn's
+  # request_id (both as Logger metadata and inline). capture_log/1 captures the
+  # GLOBAL, process-wide Logger — including DB-error/vector/slow-query lines from
+  # OTHER async tests running concurrently — so a bare `refute log =~ "embedding
+  # <=>"` (or "0.123", "::vector", "already exists") could be tripped by a
+  # sibling's log. Stamp a per-call unique x-request-id and return ONLY this
+  # call's own line, so every assert/refute inspects our line and no other.
+  defp capture_db_error_log(conn, error) do
+    req_id = "flbk-req-#{System.unique_integer([:positive])}"
+    conn = Plug.Conn.put_resp_header(conn, "x-request-id", req_id)
+
+    log = ExUnit.CaptureLog.capture_log(fn -> call_fallback(conn, error) end)
+
+    log
+    |> String.split("\n")
+    |> Enum.filter(&String.contains?(&1, req_id))
+    |> Enum.join("\n")
+  end
+
   describe "error atom handling" do
     test "renders 404 for :not_found", %{conn: conn} do
       conn = call_fallback(conn, {:error, :not_found})
@@ -323,13 +342,8 @@ defmodule LoopctlWeb.FallbackControllerTest do
   end
 
   describe "structured DB-error log (AC-27.3.3 / .8)" do
-    import ExUnit.CaptureLog
-
     test "logs sqlstate + mapped_code at error level, no SQL/vector leak", %{conn: conn} do
-      log =
-        capture_log(fn ->
-          call_fallback(conn, {:error, pg_error(:query_canceled, "57014")})
-        end)
+      log = capture_db_error_log(conn, {:error, pg_error(:query_canceled, "57014")})
 
       assert log =~ "sqlstate=57014"
       assert log =~ "mapped_code=db_statement_timeout"
@@ -345,7 +359,7 @@ defmodule LoopctlWeb.FallbackControllerTest do
     test "pg_message IS logged for the allowlisted serialization class", %{conn: conn} do
       error = constraint_error(:serialization_failure, "40001", "could not serialize access")
 
-      log = capture_log(fn -> call_fallback(conn, {:error, error}) end)
+      log = capture_db_error_log(conn, {:error, error})
 
       assert log =~ "sqlstate=40001"
       assert log =~ "could not serialize access"
@@ -365,7 +379,7 @@ defmodule LoopctlWeb.FallbackControllerTest do
           "Key (slug)=(secret-tenant-slug) already exists"
         )
 
-      log = capture_log(fn -> call_fallback(conn, {:error, error}) end)
+      log = capture_db_error_log(conn, {:error, error})
 
       # Diagnostics still present.
       assert log =~ "sqlstate=23505"
@@ -383,7 +397,7 @@ defmodule LoopctlWeb.FallbackControllerTest do
           "invalid byte sequence 0xDEADBEEF"
         )
 
-      log = capture_log(fn -> call_fallback(conn, {:error, error}) end)
+      log = capture_db_error_log(conn, {:error, error})
 
       assert log =~ "sqlstate=22021"
       assert log =~ "mapped_code=db_invalid_input"


### PR DESCRIPTION
## Problem

The Elixir `Logger` is global, process-wide state. `ExUnit.CaptureLog.capture_log/1` captures **all** log output emitted during its block — including log lines from **other** tests running concurrently in the async suite (`max_cases: 24`). Any `refute captured =~ "<generic substring>"` (or an `assert` on a non-unique substring) can therefore be tripped — or spuriously satisfied — by a sibling test's log line, producing intermittent CI flakes.

**Confirmed trigger:** `tenants_test.exs` *"does not log when slug is unchanged or absent"* refuted the bare substring `"attempted slug mutation"`. The sibling rls-02 test legitimately logs `"attempted slug mutation ignored for tenant <id>"`. Under async load the `refute` captured the sibling's line and flaked CI.

## Fix (test-only)

Scope every `capture_log` assertion to a value **unique to that test**. No `lib/` log message needed changing — each already carried a unique id (`tenant_id`, `story_id`, `api_key_id`).

| File | Assertions | Fix |
|------|-----------|-----|
| `tenants_test.exs` | 2 dangerous refutes | scope to `...for tenant #{tenant.id}` |
| `custody_invariants_test.exs` | 4 marker asserts | filter captured log to this `story.id`'s line first |
| `cap_recovery_controller_test.exs` | 2 marker asserts | filter to this `story.id`'s line first |
| `fallback_controller_test.exs` | 4 log tests (incl. 5 leak refutes) | stamp a per-call unique `x-request-id`, inspect only this call's own `DBErrorLogger` line |
| `attribution_test.exs` | 5 `*_dropped` asserts | scope to `tenant_id=#{tenant.id}` (+ caller api_key id) |
| `cost_anomaly_worker_test.exs` | 1 clamp assert | scope to the `CostAnomalyWorker:`-prefixed period range |

**Verified safe, left as-is:** `slow_query_logger_test.exs` is `async: false` (runs in isolation, no concurrent log pollution); the `@tag :capture_log` files (`export_concurrency`, `token_data_archival`, `story_status`, `article_workflow`, `story_verification`, `knowledge_ingestion`) only silence expected error logs and make no assertion on captured content.

## Verification

- `mix precommit` green: compile `--warnings-as-errors`, format, `credo --strict`, deps.audit, dialyzer (0), full suite (3530 tests, 0 failures).
- **43 full-suite runs** across varied seeds + **15 focused high-repetition runs** of the affected files — no `capture_log` cross-test flake observed.
