### PR TITLE
fix(knowledge): stop PDF crash-loop, ingest multi-chunk docs, purge archived by id

### DIFF
--- a/lib/loopctl/knowledge/bulk_ops.ex
+++ b/lib/loopctl/knowledge/bulk_ops.ex
@@ -226,7 +226,7 @@ defmodule Loopctl.Knowledge.BulkOps do
   end
 
   def preview(tenant_id, :delete, selector, _audit_opts) do
-    with {:ok, ids} <- resolve_selector(tenant_id, selector) do
+    with {:ok, ids} <- resolve_delete_selector(tenant_id, selector) do
       sorted = Enum.sort(ids)
       preview_delete_result(tenant_id, sorted)
     end
@@ -346,7 +346,7 @@ defmodule Loopctl.Knowledge.BulkOps do
     do: {:error, :invalid_nonce}
 
   defp delete_with_reconfirm_valid(tenant_id, nonce_id, selector, confirm_hash_value, audit_opts) do
-    with {:ok, ids} <- resolve_selector(tenant_id, selector) do
+    with {:ok, ids} <- resolve_delete_selector(tenant_id, selector) do
       sorted = Enum.sort(ids)
 
       if confirm_hash(tenant_id, sorted) != confirm_hash_value do
@@ -454,6 +454,32 @@ defmodule Loopctl.Knowledge.BulkOps do
 
   def resolve_selector(_tenant_id, _selector) do
     {:error, :bad_request, "Unsupported selector. Use {:ids, [..]}, {:tag, _}, or {:source, _}."}
+  end
+
+  @doc """
+  Resolve a selector for a HARD delete (#266).
+
+  A hard delete PURGES tombstones, so for an EXPLICIT `{:ids, [..]}` selector it
+  must reach `:archived`/`:superseded` rows too — otherwise the natural two-phase
+  "archive → then hard-purge" flow is impossible (archiving first makes the row
+  unreachable by `resolve_selector/2`, whose id-list path is active-only). The
+  id-list is explicit user intent, so widening it to all lifecycle statuses is
+  safe and expected.
+
+  The tag/source selectors deliberately DELEGATE to `resolve_selector/2` (still
+  active-only): a broad tag/query purge that silently swept archived rows would
+  be a surprise-purge. Only the explicit id-list is widened.
+
+  Same bounds/tenant-scoping/return shape as `resolve_selector/2`.
+  """
+  @spec resolve_delete_selector(Ecto.UUID.t(), selector()) ::
+          {:ok, [Ecto.UUID.t()]} | {:error, :too_many} | {:error, :bad_request, String.t()}
+  def resolve_delete_selector(tenant_id, {:ids, ids}) when is_list(ids) do
+    resolve_ids_selector(tenant_id, ids, :all)
+  end
+
+  def resolve_delete_selector(tenant_id, selector) do
+    resolve_selector(tenant_id, selector)
   end
 
   # --- transition (archive / unpublish) ---
@@ -636,24 +662,33 @@ defmodule Loopctl.Knowledge.BulkOps do
   defp maybe_put_source_type(map, st) when is_binary(st), do: Map.put(map, "source_type", st)
   defp maybe_put_source_type(map, _), do: map
 
-  # The :ids selector resolves to active (draft/published), tenant-scoped ids,
-  # capped at 5000 — consistent with archive/unpublish and list_archivable_ids.
-  # Foreign / cross-tenant ids are filtered out by the tenant_id AND id IN guard.
-  defp resolve_ids_selector(tenant_id, ids) do
+  # The :ids selector resolves tenant-scoped ids, capped at 5000. Foreign /
+  # cross-tenant ids are filtered out by the tenant_id AND id IN guard.
+  #
+  # `status_scope`:
+  #   * `:active` (default) — draft/published only, for archive/unpublish and the
+  #     active-only `resolve_selector/2`. Matches list_archivable_ids.
+  #   * `:all` — every lifecycle status, for a HARD delete by explicit id-list
+  #     (#266): a purge targets archived/superseded tombstones too.
+  defp resolve_ids_selector(tenant_id, ids, status_scope \\ :active) do
     queryable = sanitize_ids(ids)
 
     matched =
       from(a in Article,
-        where:
-          a.tenant_id == ^tenant_id and a.id in ^queryable and
-            a.status in ^@archivable_statuses,
+        where: a.tenant_id == ^tenant_id and a.id in ^queryable,
         select: a.id,
         limit: ^(bulk_max() + 1)
       )
+      |> scope_ids_statuses(status_scope)
       |> AdminRepo.all()
 
     if length(matched) > bulk_max(), do: {:error, :too_many}, else: {:ok, matched}
   end
+
+  defp scope_ids_statuses(query, :all), do: query
+
+  defp scope_ids_statuses(query, :active),
+    do: from(a in query, where: a.status in ^@archivable_statuses)
 
   defp mint_token!(tenant_id, ids) do
     expires_at = DateTime.add(DateTime.utc_now(), token_ttl_seconds(), :second)

--- a/lib/loopctl/workers/content_ingestion_worker.ex
+++ b/lib/loopctl/workers/content_ingestion_worker.ex
@@ -25,10 +25,21 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   Unique per `content_hash` + `tenant_id` within a 3600-second window.
   """
 
+  # `unique` deliberately EXCLUDES `:completed` (and `:discarded`/`:cancelled`)
+  # from its states (#264, Finding 2): the default set includes `:completed`, so a
+  # legitimate resubmission of UNDER-captured content within the hour would be
+  # absorbed as a duplicate ({:ok, :already_queued}) and silently do no new work.
+  # Excluding `:completed` lets an operator re-ingest; per-article inserts are
+  # idempotent (deterministic idempotency_key + on_conflict), so a resubmission of
+  # already-captured content re-runs safely without creating duplicate rows.
   use Oban.Worker,
     queue: :knowledge,
     max_attempts: 3,
-    unique: [keys: [:content_hash, :tenant_id], period: 3600]
+    unique: [
+      keys: [:content_hash, :tenant_id],
+      period: 3600,
+      states: [:scheduled, :available, :executing, :retryable]
+    ]
 
   require Logger
 
@@ -122,6 +133,10 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
          {:ok, content} <- resolve_content(url, raw_content) do
       ctx = %{
         tenant_id: tenant_id,
+        # content_hash seeds the DETERMINISTIC per-article idempotency_key (#264,
+        # Finding 1) so an Oban retry that re-walks already-persisted chunks
+        # no-ops instead of inserting duplicate rows.
+        content_hash: content_hash,
         source_id: source_id,
         source_type: source_type,
         project_id: project_id,
@@ -200,52 +215,62 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
       )
     end
 
+    acc0 = %{inserted: 0, persisted: 0, attempted: 0, errors: [], seen_titles: MapSet.new()}
+
     processable
-    |> Enum.reduce_while(%{inserted: 0, persisted: 0, errors: []}, fn chunk, acc ->
+    |> Enum.with_index()
+    |> Enum.reduce_while(acc0, fn {chunk, chunk_index}, acc ->
       remaining = @max_articles - acc.inserted
 
       if remaining <= 0 do
         # Article cap reached — stop early; we have the full @max_articles set.
         {:halt, acc}
       else
-        reduce_chunk(ctx, chunk, remaining, acc)
+        reduce_chunk(ctx, chunk, chunk_index, remaining, acc)
       end
     end)
-    |> finalize_ingest(chunk_count, length(processable), dropped)
+    |> finalize_ingest(chunk_count, dropped)
   end
 
-  defp reduce_chunk(ctx, chunk, remaining, acc) do
-    case extract_and_persist_chunk(ctx, chunk, remaining) do
-      {:ok, count} ->
-        {:cont, %{acc | inserted: acc.inserted + count, persisted: acc.persisted + 1}}
+  defp reduce_chunk(ctx, chunk, chunk_index, remaining, acc) do
+    acc = %{acc | attempted: acc.attempted + 1}
+
+    case extract_and_persist_chunk(ctx, chunk, chunk_index, remaining, acc.seen_titles) do
+      {:ok, count, seen_titles} ->
+        {:cont,
+         %{
+           acc
+           | inserted: acc.inserted + count,
+             persisted: acc.persisted + 1,
+             seen_titles: seen_titles
+         }}
 
       {:error, reason} ->
-        # Persist what earlier chunks produced; record the error and keep going.
+        # Persist what earlier chunks produced; record the error and keep going —
+        # finalize_ingest surfaces it as retryable (Finding 2).
         {:cont, %{acc | errors: [reason | acc.errors]}}
     end
   end
 
   # Extract + validate + persist ONE chunk in its own transaction, so its
   # article(s) are durably committed before the next chunk's LLM call runs.
-  defp extract_and_persist_chunk(ctx, chunk, remaining) do
+  #
+  # `seen_titles` carries the normalized titles already persisted by EARLIER
+  # chunks so a title extracted from two different chunks isn't inserted twice
+  # (the pre-#264 flow deduped across the whole accumulated set; per-chunk
+  # persistence reintroduces that need — a cross-chunk title collision would
+  # otherwise abort the whole chunk on the `articles_tenant_title_active_idx`).
+  defp extract_and_persist_chunk(ctx, chunk, chunk_index, remaining, seen_titles) do
     case @content_extractor.extract_from_content(chunk, source_type: ctx.source_type) do
       {:ok, extracted} ->
-        articles =
+        {articles, seen_titles} =
           extracted
           |> dedup_articles()
           |> validate_and_filter()
-          |> Enum.take(remaining)
+          |> dedup_cross_chunk(seen_titles, remaining)
 
-        case insert_articles(
-               ctx.tenant_id,
-               ctx.source_id,
-               ctx.source_type,
-               ctx.project_id,
-               articles,
-               ctx.url,
-               ctx.publish
-             ) do
-          :ok -> {:ok, length(articles)}
+        case insert_articles(ctx, articles, chunk_index) do
+          :ok -> {:ok, length(articles), seen_titles}
           {:error, _} = err -> err
         end
 
@@ -254,38 +279,95 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
     end
   end
 
-  # Decide the job's return value from the incremental run:
-  #   * dropped chunks (document > @max_chunks) → {:discard} (no retry) with a
-  #     clear count; whatever was persisted stays committed.
-  #   * any articles persisted → :ok (partial success is success — never retry
-  #     and risk re-inserting the already-committed chunks).
-  #   * nothing persisted but chunks errored → {:error, first} so Oban retries a
-  #     genuinely-transient failure (safe: nothing was committed yet).
-  #   * nothing persisted, no errors → :ok (legitimately nothing reusable).
+  # Drop articles whose normalized title was already persisted by an earlier
+  # chunk, cap at `remaining`, and return the kept articles plus the updated
+  # seen-title set. Titles are non-blank here (validate_and_filter dropped blanks).
+  defp dedup_cross_chunk(articles, seen_titles, remaining) do
+    {kept_rev, seen} =
+      Enum.reduce(articles, {[], seen_titles}, fn article, {kept, seen} ->
+        title = normalized_title(article)
+
+        cond do
+          length(kept) >= remaining -> {kept, seen}
+          MapSet.member?(seen, title) -> {kept, seen}
+          true -> {[article | kept], MapSet.put(seen, title)}
+        end
+      end)
+
+    {Enum.reverse(kept_rev), seen}
+  end
+
+  defp normalized_title(article) do
+    (Map.get(article, :title) || Map.get(article, "title") || "")
+    |> String.trim()
+    |> String.downcase()
+  end
+
+  # Decide the job's return value from the incremental run. Because per-article
+  # inserts are idempotent (deterministic idempotency_key + on_conflict, Finding
+  # 1), a retry never duplicates already-committed chunks — so we can safely
+  # surface a partial failure as retryable:
+  #
+  #   * ANY transient chunk error → {:error, first} so Oban retries the whole job;
+  #     the retry no-ops the persisted chunks and productively re-attempts only
+  #     the failed one(s). Returning :ok here (the old behavior) would mark the
+  #     job :completed and permanently lose the failed chunk (Finding 2).
+  #   * ONLY permanent errors (4xx that a retry can't fix) → {:discard} so it
+  #     doesn't retry forever; whatever persisted stays committed.
+  #   * dropped chunks (document > @max_chunks) → {:discard} with an ACCURATE
+  #     attempted-chunk count (Finding 3).
+  #   * otherwise → :ok.
   defp finalize_ingest(
-         %{inserted: inserted, persisted: persisted, errors: errors},
+         %{inserted: inserted, persisted: persisted, attempted: attempted, errors: errors},
          chunk_count,
-         processed_count,
          dropped
        ) do
     cond do
+      errors != [] ->
+        finalize_errors(errors, inserted, persisted, attempted)
+
       dropped != [] ->
         {:discard,
-         {:document_too_large,
-          "document too large: #{chunk_count} chunks exceed the #{@max_chunks}-chunk per-job " <>
-            "budget (cap #{div(@max_job_timeout_ms, 1000)}s); persisted #{inserted} article(s) " <>
-            "from #{persisted} of #{processed_count} processed chunk(s), " <>
-            "#{length(dropped)} chunk(s) not processed"}}
-
-      inserted > 0 ->
-        :ok
-
-      errors != [] ->
-        {:error, errors |> Enum.reverse() |> List.first()}
+         {:document_too_large, too_large_message(chunk_count, dropped, inserted, attempted)}}
 
       true ->
         :ok
     end
+  end
+
+  defp finalize_errors(errors, inserted, persisted, attempted) do
+    first = errors |> Enum.reverse() |> List.first()
+
+    if Enum.all?(errors, &permanent_error?/1) do
+      # No transient error a retry could clear — {:discard} (no infinite retry);
+      # whatever persisted stays committed.
+      {:discard,
+       {:extraction_failed,
+        "extraction permanently failed on #{length(errors)} chunk(s) " <>
+          "(first: #{inspect(first)}); persisted #{inserted} article(s) from " <>
+          "#{persisted} of #{attempted} attempted chunk(s) — not retryable"}}
+    else
+      # At least one transient error — retry the whole (idempotent) job so the
+      # failed chunk(s) get re-attempted; persisted chunks no-op on conflict.
+      {:error, first}
+    end
+  end
+
+  # A permanent extractor failure a retry can't fix: a 4xx API error other than
+  # 408 (timeout) / 429 (rate limited), which ARE transient. Everything else
+  # (5xx, request_failed/transport, json_parse_error from a non-deterministic
+  # model response) is treated as transient and retried.
+  defp permanent_error?({:api_error, status, _body})
+       when is_integer(status) and status >= 400 and status < 500 and status != 408 and
+              status != 429,
+       do: true
+
+  defp permanent_error?(_), do: false
+
+  defp too_large_message(chunk_count, dropped, inserted, attempted) do
+    "document too large: #{chunk_count} chunks exceed the #{@max_chunks}-chunk per-job " <>
+      "budget (cap #{div(@max_job_timeout_ms, 1000)}s); persisted #{inserted} article(s) " <>
+      "from #{attempted} attempted chunk(s), #{length(dropped)} chunk(s) not processed"
   end
 
   # When content is split into chunks, the same article may be extracted
@@ -532,11 +614,21 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
     is_binary(tag) and String.length(tag) <= @max_tag_length and Regex.match?(@tag_pattern, tag)
   end
 
-  defp insert_articles(_tenant_id, _job_id, _source_type, _project_id, [], _url, _publish) do
+  defp insert_articles(_ctx, [], _chunk_index) do
     :ok
   end
 
-  defp insert_articles(tenant_id, job_id, source_type, project_id, articles, url, publish) do
+  defp insert_articles(ctx, articles, chunk_index) do
+    %{
+      tenant_id: tenant_id,
+      source_id: job_id,
+      source_type: source_type,
+      project_id: project_id,
+      url: url,
+      publish: publish,
+      content_hash: content_hash
+    } = ctx
+
     status = if publish, do: :published, else: :draft
 
     multi =
@@ -545,8 +637,14 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
       |> Enum.reduce(Multi.new(), fn {attrs, index}, multi ->
         # normalize_attrs already whitelists keys, but drop :status explicitly so
         # the server-set status (above) can never be overridden by extractor
-        # output, independent of future normalize_attrs changes.
-        attrs = normalize_attrs(attrs) |> Map.delete(:status)
+        # output, independent of future normalize_attrs changes. The
+        # idempotency_key is server-derived and set AFTER normalize_attrs so an
+        # extractor-supplied key can never override it (#264, Finding 1).
+        attrs =
+          attrs
+          |> normalize_attrs()
+          |> Map.delete(:status)
+          |> Map.put(:idempotency_key, ingest_idempotency_key(content_hash, chunk_index, index))
 
         article = %Article{
           tenant_id: tenant_id,
@@ -569,7 +667,15 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
 
         changeset = Article.create_changeset(article, attrs)
 
-        Multi.insert(multi, {:article, index}, changeset)
+        # on_conflict: :nothing over the partial `articles_tenant_idempotency_key_idx`
+        # (WHERE idempotency_key IS NOT NULL) makes a retry that re-reaches an
+        # already-persisted (content_hash, chunk_index, article_index) a safe NO-OP
+        # instead of a duplicate row (#264, Finding 1).
+        Multi.insert(multi, {:article, index}, changeset,
+          on_conflict: :nothing,
+          conflict_target:
+            {:unsafe_fragment, "(tenant_id, idempotency_key) WHERE idempotency_key IS NOT NULL"}
+        )
       end)
       |> Audit.log_in_multi(:audit, fn changes ->
         article_ids =
@@ -653,5 +759,20 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
     end)
     |> Enum.reject(&is_nil/1)
     |> Map.new()
+  end
+
+  # DETERMINISTIC per-article idempotency key from (content_hash, chunk_index,
+  # article_index_within_chunk) — NEVER from the LLM output, which varies across
+  # calls (#264, Finding 1). Identical across Oban retries (all three inputs are
+  # deterministic), so a retry re-reaching the same (chunk, article) slot conflicts
+  # on `articles_tenant_idempotency_key_idx` and no-ops instead of duplicating.
+  # SHA-256 hex keeps the key bounded (67 chars) regardless of content_hash length.
+  defp ingest_idempotency_key(content_hash, chunk_index, article_index) do
+    digest =
+      :sha256
+      |> :crypto.hash("#{content_hash}:#{chunk_index}:#{article_index}")
+      |> Base.encode16(case: :lower)
+
+    "ingest:" <> digest
   end
 end

--- a/lib/loopctl/workers/content_ingestion_worker.ex
+++ b/lib/loopctl/workers/content_ingestion_worker.ex
@@ -48,6 +48,44 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
 
   @max_articles 10
   @max_body_length 100_000
+
+  # --- Multi-chunk timeout budget (#264) ---
+  #
+  # A real ~87KB newsletter chunks into ~11 pieces, each 7–13s of LLM
+  # extraction. The old flat 30s timeout killed every such job (Oban.TimeoutError
+  # → discarded after 3 attempts with ZERO articles persisted). We now:
+  #
+  #   * persist each chunk's articles as it completes (partial progress survives
+  #     a later timeout/failure — see ingest_chunks/2), and
+  #   * scale the job timeout by chunk count with a hard cap.
+  #
+  # Concrete values:
+  #   * @per_chunk_timeout_ms = 30s — ~2x+ headroom over the observed 7–13s so a
+  #     healthy chunk is never falsely timed out under tail latency/variance.
+  #   * @max_job_timeout_ms   = 6 min — the ABSOLUTE ceiling a single job may hold
+  #     a :knowledge slot (concurrency 5), independent of chunk count. Bounds abuse
+  #     (GHSA-j7m9-ffmr-pwhm) while comfortably covering a realistic large doc.
+  #   * @max_chunks = cap / per_chunk = 12 — a document chunking to MORE than this
+  #     (>~96KB) can't be guaranteed within the cap, so we ingest the first
+  #     @max_chunks (persisted incrementally) and {:discard} the rest cleanly with
+  #     a count, rather than crash-looping or silently losing everything.
+  @per_chunk_timeout_ms :timer.seconds(30)
+  @max_job_timeout_ms :timer.minutes(6)
+  @max_chunks div(@max_job_timeout_ms, @per_chunk_timeout_ms)
+
+  # Content-Type families that are never ingestible UTF-8 text (#263). A PDF /
+  # image / archive body handed to the JSON-encoded extractor request raises
+  # Jason.EncodeError on the invalid bytes and — because the content hash is
+  # deterministic — every retry fails identically (a permanent crash-loop). We
+  # detect and {:discard} these BEFORE the content reaches the extractor.
+  @binary_application_content_types ~w(
+    application/pdf application/octet-stream application/zip application/gzip
+    application/x-gzip application/x-tar application/x-bzip2 application/x-7z-compressed
+    application/x-rar-compressed application/msword application/vnd.ms-excel
+    application/vnd.ms-powerpoint application/x-protobuf application/wasm
+    application/java-archive application/x-shockwave-flash
+  )
+  @binary_content_type_prefixes ~w(image/ audio/ video/ font/)
   # Single source of truth: the canonical taxonomy (avoids drift).
   @valid_categories Loopctl.Knowledge.Categories.all()
   @tag_pattern ~r/^[a-zA-Z0-9_-]+$/
@@ -81,10 +119,17 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
     # because the uniqueness key excludes project_id, crash-loop as a poison pill.
     # DISCARD such a job (no retry) BEFORE any fetch/LLM work rather than raising.
     with :ok <- validate_project_id(project_id),
-         {:ok, content} <- resolve_content(url, raw_content),
-         {:ok, raw_articles} <- extract_with_chunking(content, source_type) do
-      articles = validate_and_filter(raw_articles)
-      insert_articles(tenant_id, source_id, source_type, project_id, articles, url, publish)
+         {:ok, content} <- resolve_content(url, raw_content) do
+      ctx = %{
+        tenant_id: tenant_id,
+        source_id: source_id,
+        source_type: source_type,
+        project_id: project_id,
+        url: url,
+        publish: publish
+      }
+
+      ingest_chunks(ctx, content)
     end
   end
 
@@ -109,50 +154,137 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
     trunc(:math.pow(attempt, 4) + 15 + :rand.uniform(30) * attempt)
   end
 
-  # Hard per-job wall-clock cap (backstop to the bounded DNS resolve + Req
-  # receive_timeout). A hostile/slow endpoint can't pin a :knowledge queue slot
-  # indefinitely (worker-01 / GHSA-j7m9-ffmr-pwhm).
+  # Per-job wall-clock cap that SCALES with chunk count (#264), floored at one
+  # chunk and hard-capped at @max_job_timeout_ms. A hostile/slow endpoint still
+  # can't pin a :knowledge queue slot beyond the cap (worker-01 /
+  # GHSA-j7m9-ffmr-pwhm), while a legitimate multi-chunk document now gets enough
+  # wall-clock to finish. For a URL job the fetched size is unknown until fetch,
+  # so we grant the full capped budget; perform/1 self-limits to @max_chunks and
+  # persists incrementally, so the cap is a backstop, not the mechanism.
   @impl Oban.Worker
-  def timeout(_job), do: :timer.seconds(30)
+  def timeout(%Oban.Job{args: args}) do
+    args
+    |> chunk_count_for_timeout()
+    |> max(1)
+    |> Kernel.*(@per_chunk_timeout_ms)
+    |> min(@max_job_timeout_ms)
+  end
+
+  defp chunk_count_for_timeout(%{"content" => content})
+       when is_binary(content) and content != "" do
+    content |> ContentChunker.chunk() |> length()
+  end
+
+  defp chunk_count_for_timeout(%{"url" => url}) when is_binary(url) and url != "" do
+    @max_chunks
+  end
+
+  defp chunk_count_for_timeout(_), do: 1
 
   # --- Private ---
 
-  defp extract_with_chunking(content, source_type) do
+  # Ingest a document chunk-by-chunk, PERSISTING each chunk's articles as it
+  # completes (#264). A timeout or mid-run failure therefore keeps the articles
+  # already extracted instead of discarding everything. Documents that chunk
+  # beyond @max_chunks are ingested up to that bound and the remainder is
+  # {:discard}ed cleanly (with a count) rather than silently lost.
+  defp ingest_chunks(ctx, content) do
     chunks = ContentChunker.chunk(content)
+    chunk_count = length(chunks)
+    {processable, dropped} = Enum.split(chunks, @max_chunks)
 
-    if length(chunks) > 1 do
+    if chunk_count > 1 do
       Logger.info(
-        "ContentIngestionWorker: splitting #{byte_size(content)} bytes into #{length(chunks)} chunks"
+        "ContentIngestionWorker: #{byte_size(content)} bytes -> #{chunk_count} chunks " <>
+          "(processing #{length(processable)}, deferring #{length(dropped)})"
       )
     end
 
-    {articles, errors} =
-      Enum.reduce(chunks, {[], []}, fn chunk, {arts, errs} ->
-        case @content_extractor.extract_from_content(chunk, source_type: source_type) do
-          {:ok, extracted} -> {arts ++ extracted, errs}
-          {:error, reason} -> {arts, [reason | errs]}
-        end
-      end)
+    processable
+    |> Enum.reduce_while(%{inserted: 0, persisted: 0, errors: []}, fn chunk, acc ->
+      remaining = @max_articles - acc.inserted
 
+      if remaining <= 0 do
+        # Article cap reached — stop early; we have the full @max_articles set.
+        {:halt, acc}
+      else
+        reduce_chunk(ctx, chunk, remaining, acc)
+      end
+    end)
+    |> finalize_ingest(chunk_count, length(processable), dropped)
+  end
+
+  defp reduce_chunk(ctx, chunk, remaining, acc) do
+    case extract_and_persist_chunk(ctx, chunk, remaining) do
+      {:ok, count} ->
+        {:cont, %{acc | inserted: acc.inserted + count, persisted: acc.persisted + 1}}
+
+      {:error, reason} ->
+        # Persist what earlier chunks produced; record the error and keep going.
+        {:cont, %{acc | errors: [reason | acc.errors]}}
+    end
+  end
+
+  # Extract + validate + persist ONE chunk in its own transaction, so its
+  # article(s) are durably committed before the next chunk's LLM call runs.
+  defp extract_and_persist_chunk(ctx, chunk, remaining) do
+    case @content_extractor.extract_from_content(chunk, source_type: ctx.source_type) do
+      {:ok, extracted} ->
+        articles =
+          extracted
+          |> dedup_articles()
+          |> validate_and_filter()
+          |> Enum.take(remaining)
+
+        case insert_articles(
+               ctx.tenant_id,
+               ctx.source_id,
+               ctx.source_type,
+               ctx.project_id,
+               articles,
+               ctx.url,
+               ctx.publish
+             ) do
+          :ok -> {:ok, length(articles)}
+          {:error, _} = err -> err
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  # Decide the job's return value from the incremental run:
+  #   * dropped chunks (document > @max_chunks) → {:discard} (no retry) with a
+  #     clear count; whatever was persisted stays committed.
+  #   * any articles persisted → :ok (partial success is success — never retry
+  #     and risk re-inserting the already-committed chunks).
+  #   * nothing persisted but chunks errored → {:error, first} so Oban retries a
+  #     genuinely-transient failure (safe: nothing was committed yet).
+  #   * nothing persisted, no errors → :ok (legitimately nothing reusable).
+  defp finalize_ingest(
+         %{inserted: inserted, persisted: persisted, errors: errors},
+         chunk_count,
+         processed_count,
+         dropped
+       ) do
     cond do
-      articles != [] ->
-        # Got some articles — partial success is fine, log errors
-        if errors != [] do
-          Logger.warning(
-            "ContentIngestionWorker: #{length(errors)} of #{length(chunks)} chunks failed"
-          )
-        end
+      dropped != [] ->
+        {:discard,
+         {:document_too_large,
+          "document too large: #{chunk_count} chunks exceed the #{@max_chunks}-chunk per-job " <>
+            "budget (cap #{div(@max_job_timeout_ms, 1000)}s); persisted #{inserted} article(s) " <>
+            "from #{persisted} of #{processed_count} processed chunk(s), " <>
+            "#{length(dropped)} chunk(s) not processed"}}
 
-        {:ok, articles |> dedup_articles() |> Enum.take(@max_articles)}
+      inserted > 0 ->
+        :ok
 
       errors != [] ->
-        # All chunks failed — propagate the first error so Oban retries
-        {:error, List.first(errors)}
+        {:error, errors |> Enum.reverse() |> List.first()}
 
       true ->
-        # All chunks succeeded but extracted no articles — legitimately
-        # nothing reusable in the content.
-        {:ok, []}
+        :ok
     end
   end
 
@@ -196,7 +328,11 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   end
 
   defp resolve_content(nil, content) when is_binary(content) and content != "" do
-    {:ok, content}
+    # Direct-content path: no Content-Type to consult, so the UTF-8 validity
+    # check is the whole guard (#263). Non-UTF-8 inline content (a PDF/binary
+    # posted directly) would raise Jason.EncodeError inside the extractor's JSON
+    # request and crash-loop; {:discard} it cleanly instead.
+    ensure_utf8_text(content)
   end
 
   defp resolve_content(url, _content) when is_binary(url) do
@@ -235,8 +371,8 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
       |> maybe_add_plug()
 
     case Req.get(req_opts) do
-      {:ok, %{status: status, body: body}} when status in 200..299 ->
-        {:ok, strip_html(body)}
+      {:ok, %{status: status} = resp} when status in 200..299 ->
+        handle_fetched_body(resp.body, Req.Response.get_header(resp, "content-type"))
 
       {:ok, %{status: status}} ->
         Logger.warning(
@@ -254,6 +390,58 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
 
         {:error, {:url_fetch_error, reason}}
     end
+  end
+
+  # Guard a fetched body BEFORE it reaches strip_html (which runs regex over the
+  # bytes) or the JSON-encoded extractor request (#263). A binary Content-Type,
+  # or a body that isn't valid UTF-8 (a mislabeled binary), is discarded cleanly
+  # so Oban never retries a deterministically-failing PDF/binary crash-loop.
+  defp handle_fetched_body(body, content_type_values) do
+    content_type = List.first(List.wrap(content_type_values))
+
+    cond do
+      is_binary(content_type) and binary_content_type?(content_type) ->
+        unsupported_content_discard("Content-Type \"#{content_type}\"")
+
+      is_binary(body) and not String.valid?(body) ->
+        unsupported_content_discard("fetched body")
+
+      true ->
+        {:ok, strip_html(body)}
+    end
+  end
+
+  # UTF-8 guard for the direct-content path (#263). There is no Content-Type to
+  # consult here, so validity is the whole check. Returns {:ok, content} for
+  # ingestible text, or {:discard, {:unsupported_content, msg}} — which Oban
+  # DISCARDS (no infinite retry) and never raises — for non-UTF-8 (PDF/binary).
+  defp ensure_utf8_text(content) when is_binary(content) do
+    if String.valid?(content) do
+      {:ok, content}
+    else
+      unsupported_content_discard("content")
+    end
+  end
+
+  defp binary_content_type?(content_type) do
+    normalized =
+      content_type
+      |> String.downcase()
+      |> String.split(";", parts: 2)
+      |> List.first()
+      |> String.trim()
+
+    String.starts_with?(normalized, @binary_content_type_prefixes) or
+      normalized in @binary_application_content_types
+  end
+
+  defp unsupported_content_discard(what) do
+    reason =
+      "#{what} is not UTF-8 text (looks like PDF/binary); " <>
+        "PDF/binary text extraction is not supported on this endpoint"
+
+    Logger.warning("ContentIngestionWorker: discarding job — #{reason}")
+    {:discard, {:unsupported_content, reason}}
   end
 
   defp derive_source_id(content_hash) do

--- a/lib/loopctl/workers/content_ingestion_worker.ex
+++ b/lib/loopctl/workers/content_ingestion_worker.ex
@@ -84,6 +84,11 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   @max_job_timeout_ms :timer.minutes(6)
   @max_chunks div(@max_job_timeout_ms, @per_chunk_timeout_ms)
 
+  # ON CONFLICT arbiter for the partial `articles_tenant_idempotency_key_idx`
+  # (WHERE idempotency_key IS NOT NULL). A partial index can only be inferred as
+  # the arbiter when the predicate is restated, hence the unsafe_fragment (#264).
+  @idempotency_conflict_target "(tenant_id, idempotency_key) WHERE idempotency_key IS NOT NULL"
+
   # Content-Type families that are never ingestible UTF-8 text (#263). A PDF /
   # image / archive body handed to the JSON-encoded extractor request raises
   # Jason.EncodeError on the invalid bytes and — because the content hash is
@@ -270,7 +275,10 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
           |> dedup_cross_chunk(seen_titles, remaining)
 
         case insert_articles(ctx, articles, chunk_index) do
-          :ok -> {:ok, length(articles), seen_titles}
+          # Count GENUINELY-inserted rows (insert_all RETURNING), not the attempted
+          # set — a retry that conflict-skips already-persisted articles reports 0,
+          # so the article budget and audit reflect real work (#264 review F1).
+          {:ok, inserted_count} -> {:ok, inserted_count, seen_titles}
           {:error, _} = err -> err
         end
 
@@ -353,16 +361,34 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
     end
   end
 
-  # A permanent extractor failure a retry can't fix: a 4xx API error other than
-  # 408 (timeout) / 429 (rate limited), which ARE transient. Everything else
-  # (5xx, request_failed/transport, json_parse_error from a non-deterministic
-  # model response) is treated as transient and retried.
+  # A permanent failure a retry can't fix:
+  #   * a 4xx API error other than 408 (timeout) / 429 (rate limited), which ARE
+  #     transient (5xx / request_failed / json_parse_error are all transient); and
+  #   * a DB CONSTRAINT violation (#264 review F2) — e.g. an extracted title equal
+  #     to an EXISTING different article's title trips the active-title unique
+  #     index (the idempotency conflict target doesn't cover it), which is
+  #     deterministic and would otherwise burn every retry before discard.
+  # A non-constraint DB error (serialization/deadlock/connection) stays transient.
   defp permanent_error?({:api_error, status, _body})
        when is_integer(status) and status >= 400 and status < 500 and status != 408 and
               status != 429,
        do: true
 
+  defp permanent_error?({:insert_failed, _step, %Postgrex.Error{} = error}),
+    do: constraint_violation?(error)
+
+  defp permanent_error?({:insert_failed, _step, %Ecto.Changeset{}}), do: true
+
   defp permanent_error?(_), do: false
+
+  @constraint_violation_codes ~w(
+    unique_violation check_violation not_null_violation
+    foreign_key_violation exclusion_violation
+  )a
+  defp constraint_violation?(%Postgrex.Error{postgres: %{code: code}}),
+    do: code in @constraint_violation_codes
+
+  defp constraint_violation?(_), do: false
 
   defp too_large_message(chunk_count, dropped, inserted, attempted) do
     "document too large: #{chunk_count} chunks exceed the #{@max_chunks}-chunk per-job " <>
@@ -614,128 +640,163 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
     is_binary(tag) and String.length(tag) <= @max_tag_length and Regex.match?(@tag_pattern, tag)
   end
 
-  defp insert_articles(_ctx, [], _chunk_index) do
-    :ok
-  end
+  defp insert_articles(_ctx, [], _chunk_index), do: {:ok, 0}
 
   defp insert_articles(ctx, articles, chunk_index) do
-    %{
-      tenant_id: tenant_id,
-      source_id: job_id,
-      source_type: source_type,
-      project_id: project_id,
-      url: url,
-      publish: publish,
-      content_hash: content_hash
-    } = ctx
+    ctx
+    |> build_rows(articles, chunk_index)
+    |> persist_rows(ctx)
+  end
 
-    status = if publish, do: :published, else: :draft
+  # Validate each article via the changeset (insert_all bypasses validation), then
+  # dump the VALID ones to insert_all row maps. Invalid articles are dropped, as
+  # before. id + timestamps are set here because insert_all does not autogenerate.
+  defp build_rows(ctx, articles, chunk_index) do
+    status = if ctx.publish, do: :published, else: :draft
+    # perform/1 already discarded jobs with an invalid project_id; this valid_uuid?
+    # guard is defense in depth so a non-UUID can NEVER dump against the :binary_id
+    # column — it falls back to tenant-wide instead of crashing.
+    project_id = if valid_uuid?(ctx.project_id), do: ctx.project_id, else: nil
+    now = DateTime.utc_now()
 
-    multi =
-      articles
-      |> Enum.with_index()
-      |> Enum.reduce(Multi.new(), fn {attrs, index}, multi ->
-        # normalize_attrs already whitelists keys, but drop :status explicitly so
-        # the server-set status (above) can never be overridden by extractor
-        # output, independent of future normalize_attrs changes. The
-        # idempotency_key is server-derived and set AFTER normalize_attrs so an
-        # extractor-supplied key can never override it (#264, Finding 1).
-        attrs =
-          attrs
-          |> normalize_attrs()
-          |> Map.delete(:status)
-          |> Map.put(:idempotency_key, ingest_idempotency_key(content_hash, chunk_index, index))
+    articles
+    |> Enum.with_index()
+    |> Enum.flat_map(fn {attrs, index} ->
+      # normalize_attrs whitelists keys; :status is dropped and idempotency_key is
+      # server-derived and set AFTER normalize_attrs so extractor output can never
+      # override either (#264 Finding 1). The idempotency_key is deterministic
+      # across retries so on_conflict can no-op a re-inserted (chunk, article).
+      attrs =
+        attrs
+        |> normalize_attrs()
+        |> Map.delete(:status)
+        |> Map.put(:idempotency_key, ingest_idempotency_key(ctx.content_hash, chunk_index, index))
 
-        article = %Article{
-          tenant_id: tenant_id,
-          source_type: source_type,
-          source_id: job_id,
-          status: status
-        }
+      base = %Article{
+        tenant_id: ctx.tenant_id,
+        source_type: ctx.source_type,
+        source_id: ctx.source_id,
+        status: status,
+        project_id: project_id
+      }
 
-        # perform/1 already discarded jobs with an invalid project_id; this
-        # valid_uuid? guard is defense in depth so the raw struct assign can NEVER
-        # dump a non-UUID against the :binary_id column (a pre-existing queued job
-        # replayed through an older path would otherwise raise). A non-UUID here
-        # falls back to tenant-wide rather than crashing.
-        article =
-          if valid_uuid?(project_id) do
-            %{article | project_id: project_id}
-          else
-            article
-          end
+      changeset = Article.create_changeset(base, attrs)
 
-        changeset = Article.create_changeset(article, attrs)
-
-        # on_conflict: :nothing over the partial `articles_tenant_idempotency_key_idx`
-        # (WHERE idempotency_key IS NOT NULL) makes a retry that re-reaches an
-        # already-persisted (content_hash, chunk_index, article_index) a safe NO-OP
-        # instead of a duplicate row (#264, Finding 1).
-        Multi.insert(multi, {:article, index}, changeset,
-          on_conflict: :nothing,
-          conflict_target:
-            {:unsafe_fragment, "(tenant_id, idempotency_key) WHERE idempotency_key IS NOT NULL"}
+      if changeset.valid? do
+        [changeset_to_row(changeset, now)]
+      else
+        Logger.warning(
+          "ContentIngestionWorker: dropping invalid article: #{inspect(changeset.errors)}"
         )
-      end)
-      |> Audit.log_in_multi(:audit, fn changes ->
-        article_ids =
-          changes
-          |> Enum.filter(fn {key, _} -> match?({:article, _}, key) end)
-          |> Enum.map(fn {_, article} -> article.id end)
 
-        %{
-          tenant_id: tenant_id,
-          entity_type: "article",
-          entity_id: job_id,
-          action: "knowledge.content_ingested",
-          actor_type: "system",
-          actor_id: nil,
-          actor_label: "worker:content_ingestion",
-          new_state: %{
-            "source_type" => source_type,
-            "url" => url,
-            "article_count" => length(article_ids),
-            "article_ids" => article_ids,
-            # Record whether ingested articles went live (publish opt-in) or were
-            # staged as drafts, so an operator can tell auto-published content
-            # apart from review-staged content in the audit trail.
-            "status" => to_string(status)
-          }
-        }
-      end)
+        []
+      end
+    end)
+  end
 
+  @insert_all_fields ~w(
+    tenant_id title body category status scope slug tags
+    source_type source_id idempotency_key metadata project_id
+  )a
+  defp changeset_to_row(changeset, now) do
+    changeset
+    |> Ecto.Changeset.apply_changes()
+    |> Map.take(@insert_all_fields)
+    |> Map.merge(%{id: Ecto.UUID.generate(), inserted_at: now, updated_at: now})
+  end
+
+  defp persist_rows([], _ctx), do: {:ok, 0}
+
+  # Persist a chunk's validated rows with insert_all + RETURNING so the returned
+  # set reflects ONLY genuinely-inserted rows (conflict-skipped rows are NOT in
+  # RETURNING). Audit + embeddings are built from THOSE real rows — never from the
+  # client-minted changeset ids, which on_conflict :nothing would otherwise leave
+  # pointing at rows that were never inserted (#264 review F1: phantom audit +
+  # leaked embedding jobs on retry).
+  defp persist_rows(rows, ctx) do
+    multi =
+      Multi.new()
+      |> Multi.insert_all(:articles, Article, rows,
+        on_conflict: :nothing,
+        conflict_target: {:unsafe_fragment, @idempotency_conflict_target},
+        returning: [:id]
+      )
+      |> Multi.merge(fn %{articles: {_count, returned}} -> audit_multi(ctx, returned) end)
+
+    run_persist(multi, ctx)
+  rescue
+    # insert_all does not map constraint violations to changeset errors (there is
+    # no changeset) — it RAISES. A title/slug unique collision surfaces here; we
+    # classify it permanent in permanent_error?/1 so it discards instead of
+    # burning every retry (#264 review F2).
+    error in Postgrex.Error ->
+      Logger.warning("ContentIngestionWorker: insert_all raised: #{inspect(error)}")
+      {:error, {:insert_failed, :constraint, error}}
+  end
+
+  defp run_persist(multi, ctx) do
     case AdminRepo.transaction(multi) do
-      {:ok, changes} ->
-        # Published articles need embeddings to be semantically searchable;
-        # enqueue AFTER commit (Oban runs on a separate repo/pool). Drafts get
-        # none. Best-effort: a transient enqueue failure must not fail the job
-        # (the rows are durably committed).
-        if publish, do: enqueue_embeddings(tenant_id, changes)
+      {:ok, %{articles: {_count, returned}}} ->
+        # Published articles need embeddings; enqueue AFTER commit, best-effort,
+        # and ONLY for the rows that were genuinely inserted this run.
+        if ctx.publish, do: enqueue_embeddings(ctx.tenant_id, returned)
 
         Logger.info(
-          "ContentIngestionWorker: extracted #{length(articles)} articles " <>
-            "(source_type=#{source_type}, url=#{url || "inline"}, publish=#{publish})"
+          "ContentIngestionWorker: persisted #{length(returned)} new article(s) " <>
+            "(source_type=#{ctx.source_type}, url=#{ctx.url || "inline"}, publish=#{ctx.publish})"
         )
 
-        :ok
+        {:ok, length(returned)}
 
-      {:error, step, changeset, _completed} ->
+      {:error, step, reason, _completed} ->
         Logger.warning(
-          "ContentIngestionWorker: insert failed at step #{inspect(step)}: " <>
-            "#{inspect(changeset)}"
+          "ContentIngestionWorker: insert failed at step #{inspect(step)}: #{inspect(reason)}"
         )
 
-        {:error, {:insert_failed, step, changeset}}
+        {:error, {:insert_failed, step, reason}}
     end
+  end
+
+  # Conditional audit: write the `knowledge.content_ingested` event ONLY when rows
+  # were genuinely inserted. On a retry where every article conflict-skips, the
+  # returned set is empty and we write NO audit row — never a phantom "ingested"
+  # entry for rows that already existed (#264 review F1, chain-of-custody).
+  defp audit_multi(_ctx, [] = _returned), do: Multi.new()
+
+  defp audit_multi(ctx, returned) do
+    ids = Enum.map(returned, & &1.id)
+    Audit.log_in_multi(Multi.new(), :audit, fn _changes -> ingested_audit_attrs(ctx, ids) end)
+  end
+
+  defp ingested_audit_attrs(ctx, ids) do
+    status = if ctx.publish, do: :published, else: :draft
+
+    %{
+      tenant_id: ctx.tenant_id,
+      entity_type: "article",
+      entity_id: ctx.source_id,
+      action: "knowledge.content_ingested",
+      actor_type: "system",
+      actor_id: nil,
+      actor_label: "worker:content_ingestion",
+      new_state: %{
+        "source_type" => ctx.source_type,
+        "url" => ctx.url,
+        "article_count" => length(ids),
+        "article_ids" => ids,
+        # Record whether ingested articles went live (publish opt-in) or were
+        # staged as drafts, so an operator can tell auto-published content apart
+        # from review-staged content in the audit trail.
+        "status" => to_string(status)
+      }
+    }
   end
 
   # Enqueue an embedding job for each just-inserted (published) article. Runs
   # post-commit and is best-effort: a transient enqueue failure is logged, never
   # raised, so it can't fail/retry the whole ingestion job.
-  defp enqueue_embeddings(tenant_id, changes) do
-    changes
-    |> Enum.filter(fn {key, _} -> match?({:article, _}, key) end)
-    |> Enum.each(fn {_key, article} ->
+  defp enqueue_embeddings(tenant_id, returned) do
+    Enum.each(returned, fn article ->
       %{article_id: article.id, tenant_id: tenant_id}
       |> ArticleEmbeddingWorker.new()
       |> Oban.insert()

--- a/lib/loopctl_web/controllers/article_workflow_controller.ex
+++ b/lib/loopctl_web/controllers/article_workflow_controller.ex
@@ -564,7 +564,7 @@ defmodule LoopctlWeb.ArticleWorkflowController do
 
     with true <- is_binary(confirm_hash) || :missing_confirm_hash,
          {:ok, selector} <- bulk_delete_selector(params),
-         {:ok, ids} <- BulkOps.resolve_selector(tenant_id, selector),
+         {:ok, ids} <- BulkOps.resolve_delete_selector(tenant_id, selector),
          ^confirm_hash <- BulkOps.confirm_hash(tenant_id, ids),
          {:ok, %{affected: affected}} <- BulkOps.delete(tenant_id, ids, audit_opts) do
       json(conn, %{

--- a/test/loopctl/knowledge/bulk_ops_test.exs
+++ b/test/loopctl/knowledge/bulk_ops_test.exs
@@ -629,4 +629,87 @@ defmodule Loopctl.Knowledge.BulkOpsTest do
              ]
     end
   end
+
+  # --- #266: HARD delete by explicit id-list must purge ARCHIVED tombstones ---
+
+  describe "hard delete by article_ids reaches archived rows (#266)" do
+    test "two-phase flow: create -> archive -> dry-run reports would_affect:1 + mints a token" do
+      tenant = fixture(:tenant)
+      article = fixture(:article, %{tenant_id: tenant.id, status: :archived})
+      article_id = article.id
+
+      # A previously-active row that has been archived (a tombstone) must still be
+      # previewable for a HARD delete via its explicit id — otherwise the natural
+      # archive-then-purge flow is impossible.
+      assert {:ok, %{would_affect: 1, token: token_id, frozen_ids: [^article_id]}} =
+               BulkOps.preview(tenant.id, :delete, {:ids, [article.id]}, audit_opts())
+
+      assert is_binary(token_id)
+
+      # And the tokened delete PURGES the archived row.
+      assert {:ok, %{affected: 1}} =
+               BulkOps.delete_with_token(tenant.id, token_id, audit_opts())
+
+      refute AdminRepo.get(Article, article.id)
+    end
+
+    test "resolve_delete_selector includes archived AND active id-list rows" do
+      tenant = fixture(:tenant)
+      archived = fixture(:article, %{tenant_id: tenant.id, status: :archived})
+      published = fixture(:article, %{tenant_id: tenant.id, status: :published})
+      superseded = fixture(:article, %{tenant_id: tenant.id, status: :superseded})
+
+      {:ok, ids} =
+        BulkOps.resolve_delete_selector(
+          tenant.id,
+          {:ids, [archived.id, published.id, superseded.id]}
+        )
+
+      assert Enum.sort(ids) ==
+               Enum.sort([archived.id, published.id, superseded.id])
+    end
+
+    test "the ACTIVE-only resolve_selector still excludes archived id-list rows (unchanged)" do
+      tenant = fixture(:tenant)
+      archived = fixture(:article, %{tenant_id: tenant.id, status: :archived})
+      published = fixture(:article, %{tenant_id: tenant.id, status: :published})
+
+      # Archive/unpublish semantics are untouched: the active-only resolver still
+      # skips the archived row.
+      assert {:ok, [published_id]} =
+               BulkOps.resolve_selector(tenant.id, {:ids, [archived.id, published.id]})
+
+      assert published_id == published.id
+    end
+
+    test "an active row still purges via the id-list token path" do
+      tenant = fixture(:tenant)
+      active = fixture(:article, %{tenant_id: tenant.id, status: :published})
+
+      assert {:ok, %{would_affect: 1, token: token_id}} =
+               BulkOps.preview(tenant.id, :delete, {:ids, [active.id]}, audit_opts())
+
+      assert {:ok, %{affected: 1}} =
+               BulkOps.delete_with_token(tenant.id, token_id, audit_opts())
+
+      refute AdminRepo.get(Article, active.id)
+    end
+
+    test "tenant isolation: cannot purge another tenant's archived row by id" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+
+      theirs = fixture(:article, %{tenant_id: tenant_b.id, status: :archived})
+
+      # tenant_a previewing tenant_b's archived id resolves to nothing.
+      assert {:ok, %{would_affect: 0, token: nil}} =
+               BulkOps.preview(tenant_a.id, :delete, {:ids, [theirs.id]}, audit_opts())
+
+      # And a direct delete over the foreign id purges nothing.
+      assert {:ok, %{affected: 0}} =
+               BulkOps.delete(tenant_a.id, [theirs.id], audit_opts())
+
+      assert AdminRepo.get(Article, theirs.id)
+    end
+  end
 end

--- a/test/loopctl/workers/content_ingestion_worker_test.exs
+++ b/test/loopctl/workers/content_ingestion_worker_test.exs
@@ -12,6 +12,17 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
     %{tenant: tenant}
   end
 
+  # Build a document that ContentChunker splits into exactly `sections` chunks.
+  # Each section body is ~5.5KB — under the 8KB threshold (so it is never
+  # force-split) but large enough that two adjacent sections (~11KB) can't merge
+  # into one chunk. Net: one chunk per section.
+  defp multi_chunk_content(sections) do
+    1..sections
+    |> Enum.map_join("\n\n", fn i ->
+      "# Section #{i}\n\n" <> String.duplicate("word#{i} ", 900)
+    end)
+  end
+
   # --- Success: extracts articles from inline content ---
 
   describe "perform/1 with inline content" do
@@ -535,6 +546,307 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
       assert log.entity_type == "article"
       assert log.new_state["source_type"] == "newsletter"
       assert log.new_state["article_count"] == 1
+    end
+  end
+
+  # --- #263: PDF / non-UTF-8 binary content is discarded, never crash-looped ---
+
+  describe "perform/1 unsupported (PDF/binary) content (#263)" do
+    test "URL returning application/pdf is discarded cleanly (no Jason.EncodeError, no retry)" do
+      %{tenant: tenant} = setup_tenant()
+
+      # A real PDF magic header + a non-UTF-8 byte (0xE2 as a lone byte). Handing
+      # this to the JSON-encoded extractor request would raise Jason.EncodeError.
+      pdf_bytes = <<0x25, 0x50, 0x44, 0x46, 0x2D, 0x31, 0x2E, 0x34, 0x0A, 0xE2, 0x00, 0xFF>>
+
+      Req.Test.stub(ContentIngestionWorker, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/pdf")
+        |> Plug.Conn.send_resp(200, pdf_bytes)
+      end)
+
+      # The extractor must NEVER be reached — the guard short-circuits first.
+      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _content, _opts ->
+        flunk("extractor must not be called for binary content")
+      end)
+
+      assert {:discard, {:unsupported_content, reason}} =
+               ContentIngestionWorker.perform(%Oban.Job{
+                 id: 300,
+                 args: %{
+                   "tenant_id" => tenant.id,
+                   "url" => "https://example.com/report.pdf",
+                   "content_hash" => "pdf_url",
+                   "source_type" => "web_article"
+                 }
+               })
+
+      assert reason =~ "application/pdf"
+      assert %{data: []} = Knowledge.list_articles(tenant.id, source_type: "web_article")
+    end
+
+    test "a mislabeled body (text/plain header, non-UTF-8 bytes) is discarded via the String.valid? backstop" do
+      %{tenant: tenant} = setup_tenant()
+
+      # Content-Type lies (text/plain) but the bytes are invalid UTF-8.
+      binary_body = <<0xFF, 0xFE, 0x00, 0xE2, 0x82>>
+
+      Req.Test.stub(ContentIngestionWorker, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("text/plain")
+        |> Plug.Conn.send_resp(200, binary_body)
+      end)
+
+      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _content, _opts ->
+        flunk("extractor must not be called for non-UTF-8 content")
+      end)
+
+      assert {:discard, {:unsupported_content, reason}} =
+               ContentIngestionWorker.perform(%Oban.Job{
+                 id: 301,
+                 args: %{
+                   "tenant_id" => tenant.id,
+                   "url" => "https://example.com/mislabeled",
+                   "content_hash" => "mislabeled_url",
+                   "source_type" => "web_article"
+                 }
+               })
+
+      assert reason =~ "UTF-8"
+    end
+
+    test "direct non-UTF-8 inline content is discarded cleanly" do
+      %{tenant: tenant} = setup_tenant()
+
+      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _content, _opts ->
+        flunk("extractor must not be called for non-UTF-8 inline content")
+      end)
+
+      assert {:discard, {:unsupported_content, _reason}} =
+               ContentIngestionWorker.perform(%Oban.Job{
+                 id: 302,
+                 args: %{
+                   "tenant_id" => tenant.id,
+                   "content" => <<0x25, 0x50, 0x44, 0x46, 0xE2, 0x00>>,
+                   "content_hash" => "pdf_inline",
+                   "source_type" => "ingestion"
+                 }
+               })
+    end
+
+    test "a normal UTF-8 URL body still ingests (guard does not over-block)" do
+      %{tenant: tenant} = setup_tenant()
+
+      Req.Test.stub(ContentIngestionWorker, fn conn ->
+        Req.Test.html(conn, "<html><body><p>Perfectly valid text</p></body></html>")
+      end)
+
+      expect(Loopctl.MockContentExtractor, :extract_from_content, fn content, _opts ->
+        assert content =~ "Perfectly valid text"
+
+        {:ok, [%{title: "Valid web", body: "Body.", category: :finding, tags: ["web"]}]}
+      end)
+
+      assert :ok =
+               ContentIngestionWorker.perform(%Oban.Job{
+                 id: 303,
+                 args: %{
+                   "tenant_id" => tenant.id,
+                   "url" => "https://example.com/ok",
+                   "content_hash" => "ok_url",
+                   "source_type" => "web_article"
+                 }
+               })
+
+      %{data: [article]} = Knowledge.list_articles(tenant.id, source_type: "web_article")
+      assert article.title == "Valid web"
+    end
+  end
+
+  # --- #264: multi-chunk documents ingest; partial progress survives failure ---
+
+  describe "perform/1 multi-chunk ingestion (#264)" do
+    test "every chunk's articles are persisted (one article per chunk)" do
+      %{tenant: tenant} = setup_tenant()
+
+      # 4 sections -> 4 chunks. The extractor returns a distinct article per call.
+      counter = :counters.new(1, [])
+
+      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _chunk, _opts ->
+        :counters.add(counter, 1, 1)
+        n = :counters.get(counter, 1)
+
+        {:ok, [%{title: "Chunk article #{n}", body: "Body #{n}.", category: :pattern}]}
+      end)
+
+      assert :ok =
+               ContentIngestionWorker.perform(%Oban.Job{
+                 id: 400,
+                 args: %{
+                   "tenant_id" => tenant.id,
+                   "content" => multi_chunk_content(4),
+                   "content_hash" => "multi_chunk_ok",
+                   "source_type" => "newsletter"
+                 }
+               })
+
+      %{data: articles} = Knowledge.list_articles(tenant.id, source_type: "newsletter")
+      # 4 chunks -> 4 articles, all persisted.
+      assert length(articles) == 4
+    end
+
+    test "partial progress: earlier chunks are PERSISTED even when a later chunk fails" do
+      %{tenant: tenant} = setup_tenant()
+
+      # First chunk succeeds (and is persisted immediately); the next chunk
+      # simulates a failure (timeout/LLM error). With incremental persistence the
+      # first chunk's article must survive.
+      counter = :counters.new(1, [])
+
+      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _chunk, _opts ->
+        :counters.add(counter, 1, 1)
+        n = :counters.get(counter, 1)
+
+        if n == 1 do
+          {:ok, [%{title: "Survivor", body: "Persisted before the failure.", category: :pattern}]}
+        else
+          {:error, {:request_failed, :timeout}}
+        end
+      end)
+
+      assert :ok =
+               ContentIngestionWorker.perform(%Oban.Job{
+                 id: 401,
+                 args: %{
+                   "tenant_id" => tenant.id,
+                   "content" => multi_chunk_content(3),
+                   "content_hash" => "partial_progress",
+                   "source_type" => "newsletter"
+                 }
+               })
+
+      %{data: articles} = Knowledge.list_articles(tenant.id, source_type: "newsletter")
+      assert length(articles) == 1
+      assert hd(articles).title == "Survivor"
+    end
+
+    test "when NO chunk succeeds, the error propagates so Oban retries (nothing persisted)" do
+      %{tenant: tenant} = setup_tenant()
+
+      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _chunk, _opts ->
+        {:error, {:request_failed, :timeout}}
+      end)
+
+      assert {:error, {:request_failed, :timeout}} =
+               ContentIngestionWorker.perform(%Oban.Job{
+                 id: 402,
+                 args: %{
+                   "tenant_id" => tenant.id,
+                   "content" => multi_chunk_content(3),
+                   "content_hash" => "all_fail",
+                   "source_type" => "newsletter"
+                 }
+               })
+
+      assert %{data: []} = Knowledge.list_articles(tenant.id, source_type: "newsletter")
+    end
+
+    test "a tiny single-chunk input still ingests" do
+      %{tenant: tenant} = setup_tenant()
+
+      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _content, _opts ->
+        {:ok, [%{title: "Tiny", body: "Small.", category: :pattern}]}
+      end)
+
+      assert :ok =
+               ContentIngestionWorker.perform(%Oban.Job{
+                 id: 403,
+                 args: %{
+                   "tenant_id" => tenant.id,
+                   "content" => "just a little text",
+                   "content_hash" => "tiny",
+                   "source_type" => "newsletter"
+                 }
+               })
+
+      %{data: articles} = Knowledge.list_articles(tenant.id, source_type: "newsletter")
+      assert length(articles) == 1
+    end
+  end
+
+  # --- #264: the job timeout scales with chunk count (bounded by the cap) ---
+
+  describe "timeout/1 scales with chunk count (#264)" do
+    test "a single-chunk job gets the base 30s budget" do
+      job = %Oban.Job{args: %{"content" => "small", "content_hash" => "t", "source_type" => "x"}}
+      assert ContentIngestionWorker.timeout(job) == :timer.seconds(30)
+    end
+
+    test "a multi-chunk job gets a larger, chunk-scaled budget" do
+      small = %Oban.Job{args: %{"content" => "small", "source_type" => "x"}}
+
+      big = %Oban.Job{
+        args: %{"content" => multi_chunk_content(4), "source_type" => "x"}
+      }
+
+      big_timeout = ContentIngestionWorker.timeout(big)
+
+      assert big_timeout > ContentIngestionWorker.timeout(small)
+      # 4 chunks * 30s = 120s, still under the cap.
+      assert big_timeout == 4 * :timer.seconds(30)
+    end
+
+    test "the timeout is hard-capped for a very large document" do
+      # 40 sections -> ~40 chunks; 40 * 30s = 1200s would blow past the cap, so
+      # the timeout must clamp to the 6-minute ceiling.
+      huge = %Oban.Job{args: %{"content" => multi_chunk_content(40), "source_type" => "x"}}
+      assert ContentIngestionWorker.timeout(huge) == :timer.minutes(6)
+    end
+
+    test "a URL job (unknown size pre-fetch) is granted the full capped budget" do
+      job = %Oban.Job{args: %{"url" => "https://example.com/x", "source_type" => "x"}}
+      assert ContentIngestionWorker.timeout(job) == :timer.minutes(6)
+    end
+  end
+
+  # --- #264: an oversized document is discarded cleanly with partial progress ---
+
+  describe "perform/1 oversized document (#264)" do
+    test "a document exceeding the per-job chunk budget persists what fits, then discards cleanly" do
+      %{tenant: tenant} = setup_tenant()
+
+      # 14 sections -> 14 chunks, above the 12-chunk per-job budget. Each chunk
+      # yields one article; the first 12 persist, the rest are discarded.
+      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _chunk, _opts ->
+        {:ok,
+         [
+           %{
+             title: "Oversized #{System.unique_integer([:positive])}",
+             body: "Body.",
+             category: :pattern
+           }
+         ]}
+      end)
+
+      assert {:discard, {:document_too_large, reason}} =
+               ContentIngestionWorker.perform(%Oban.Job{
+                 id: 404,
+                 args: %{
+                   "tenant_id" => tenant.id,
+                   "content" => multi_chunk_content(14),
+                   "content_hash" => "oversized",
+                   "source_type" => "newsletter"
+                 }
+               })
+
+      assert reason =~ "too large"
+
+      # The @max_articles cap (10) bounds what actually persists, but the point is
+      # that partial work IS committed rather than everything lost.
+      %{meta: %{total_count: total}} =
+        Knowledge.list_articles(tenant.id, source_type: "newsletter")
+
+      assert total > 0
     end
   end
 

--- a/test/loopctl/workers/content_ingestion_worker_test.exs
+++ b/test/loopctl/workers/content_ingestion_worker_test.exs
@@ -695,12 +695,13 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
       assert length(articles) == 4
     end
 
-    test "partial progress: earlier chunks are PERSISTED even when a later chunk fails" do
+    test "partial progress: earlier chunks persist AND a transient later failure is retryable (#264 Finding 2)" do
       %{tenant: tenant} = setup_tenant()
 
-      # First chunk succeeds (and is persisted immediately); the next chunk
-      # simulates a failure (timeout/LLM error). With incremental persistence the
-      # first chunk's article must survive.
+      # First chunk succeeds (persisted immediately); the second simulates a
+      # transient failure. The earlier chunk's article MUST survive AND the job
+      # must return {:error} (retryable) — not :ok — so Oban re-attempts the
+      # failed chunk instead of marking the job :completed and losing it forever.
       counter = :counters.new(1, [])
 
       Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _chunk, _opts ->
@@ -714,7 +715,7 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
         end
       end)
 
-      assert :ok =
+      assert {:error, {:request_failed, :timeout}} =
                ContentIngestionWorker.perform(%Oban.Job{
                  id: 401,
                  args: %{
@@ -725,9 +726,133 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
                  }
                })
 
+      # The earlier chunk's article is durably committed despite the later failure.
       %{data: articles} = Knowledge.list_articles(tenant.id, source_type: "newsletter")
       assert length(articles) == 1
       assert hd(articles).title == "Survivor"
+    end
+
+    test "an Oban retry (SAME args) after partial persistence does NOT duplicate rows (#264 Finding 1)" do
+      %{tenant: tenant} = setup_tenant()
+
+      job_args = %{
+        "tenant_id" => tenant.id,
+        "content" => multi_chunk_content(4),
+        "content_hash" => "retry_idempotent",
+        "source_type" => "newsletter"
+      }
+
+      # A distinct article per chunk; titles/bodies vary per CALL (simulating LLM
+      # non-determinism) so the idempotency guarantee can't depend on the output.
+      call = :counters.new(1, [])
+
+      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _chunk, _opts ->
+        :counters.add(call, 1, 1)
+        n = :counters.get(call, 1)
+
+        {:ok,
+         [
+           %{
+             title: "Article #{n}",
+             body: "Body #{n} at #{System.unique_integer()}.",
+             category: :pattern
+           }
+         ]}
+      end)
+
+      # First run persists all 4 chunks.
+      assert :ok = ContentIngestionWorker.perform(%Oban.Job{id: 410, args: job_args})
+
+      %{meta: %{total_count: after_first}} =
+        Knowledge.list_articles(tenant.id, source_type: "newsletter")
+
+      assert after_first == 4
+
+      # Simulate Oban re-invoking perform/1 with IDENTICAL args (a retry / redeploy
+      # after the chunks were already committed). It must NOT double the rows.
+      assert :ok = ContentIngestionWorker.perform(%Oban.Job{id: 410, args: job_args})
+
+      %{meta: %{total_count: after_retry}} =
+        Knowledge.list_articles(tenant.id, source_type: "newsletter")
+
+      assert after_retry == 4, "retry duplicated rows: #{after_first} -> #{after_retry}"
+    end
+
+    test "retry re-attempts ONLY the previously-failed chunk without duplicating the others (#264)" do
+      %{tenant: tenant} = setup_tenant()
+
+      job_args = %{
+        "tenant_id" => tenant.id,
+        "content" => multi_chunk_content(3),
+        "content_hash" => "retry_failed_chunk",
+        "source_type" => "newsletter"
+      }
+
+      # Run 1: chunks 1 & 3 succeed, chunk 2 fails transiently.
+      # Run 2 (retry): every chunk succeeds. The already-persisted chunks 1 & 3
+      # no-op on conflict; only chunk 2 productively adds a row.
+      chunk_counter = :counters.new(1, [])
+      run = :counters.new(1, [])
+
+      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _chunk, _opts ->
+        idx = rem(:counters.get(chunk_counter, 1), 3) + 1
+        :counters.add(chunk_counter, 1, 1)
+        run_no = :counters.get(run, 1)
+
+        if idx == 2 and run_no == 0 do
+          {:error, {:request_failed, :timeout}}
+        else
+          {:ok, [%{title: "Chunk #{idx}", body: "Body #{idx}.", category: :pattern}]}
+        end
+      end)
+
+      # Run 1 → retryable error, chunks 1 & 3 persisted (2 rows).
+      assert {:error, _} = ContentIngestionWorker.perform(%Oban.Job{id: 411, args: job_args})
+
+      %{meta: %{total_count: after_run1}} =
+        Knowledge.list_articles(tenant.id, source_type: "newsletter")
+
+      assert after_run1 == 2
+
+      # Advance to run 2 (all chunks succeed).
+      :counters.add(run, 1, 1)
+      assert :ok = ContentIngestionWorker.perform(%Oban.Job{id: 411, args: job_args})
+
+      %{meta: %{total_count: after_run2}} =
+        Knowledge.list_articles(tenant.id, source_type: "newsletter")
+
+      # 3 total: chunks 1 & 3 unchanged (idempotent no-op), chunk 2 newly added.
+      assert after_run2 == 3, "expected only the failed chunk to be added, got #{after_run2}"
+    end
+
+    test "a PERMANENT (4xx) extraction failure is discarded, not retried forever (#264 Finding 2)" do
+      %{tenant: tenant} = setup_tenant()
+
+      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _chunk, _opts ->
+        {:error, {:api_error, 400, "bad request"}}
+      end)
+
+      assert {:discard, {:extraction_failed, reason}} =
+               ContentIngestionWorker.perform(%Oban.Job{
+                 id: 412,
+                 args: %{
+                   "tenant_id" => tenant.id,
+                   "content" => multi_chunk_content(3),
+                   "content_hash" => "permanent_fail",
+                   "source_type" => "newsletter"
+                 }
+               })
+
+      assert reason =~ "not retryable"
+    end
+
+    test "unique config excludes :completed so under-captured content can be resubmitted (#264 Finding 2)" do
+      states =
+        ContentIngestionWorker.__opts__() |> Keyword.fetch!(:unique) |> Keyword.fetch!(:states)
+
+      refute :completed in states
+      assert :available in states
+      assert :executing in states
     end
 
     test "when NO chunk succeeds, the error propagates so Oban retries (nothing persisted)" do

--- a/test/loopctl/workers/content_ingestion_worker_test.exs
+++ b/test/loopctl/workers/content_ingestion_worker_test.exs
@@ -855,6 +855,82 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
       assert :executing in states
     end
 
+    test "a retry writes NO phantom content_ingested audit entries for conflict-skipped chunks (#264 review F1)" do
+      %{tenant: tenant} = setup_tenant()
+
+      job_args = %{
+        "tenant_id" => tenant.id,
+        "content" => multi_chunk_content(3),
+        "content_hash" => "audit_no_phantom",
+        "source_type" => "newsletter"
+      }
+
+      call = :counters.new(1, [])
+
+      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _chunk, _opts ->
+        :counters.add(call, 1, 1)
+        n = :counters.get(call, 1)
+        {:ok, [%{title: "Phantom check #{n}", body: "Body #{n}.", category: :pattern}]}
+      end)
+
+      assert :ok = ContentIngestionWorker.perform(%Oban.Job{id: 420, args: job_args})
+
+      {:ok, %{data: after_first}} =
+        Loopctl.Audit.list_entries(tenant.id, action: "knowledge.content_ingested")
+
+      # 3 chunks -> 3 real content_ingested audit entries (one per chunk).
+      assert length(after_first) == 3
+
+      # Every audit entry points at a REAL persisted row (no phantom ids).
+      persisted_ids =
+        Knowledge.list_articles(tenant.id, source_type: "newsletter").data
+        |> MapSet.new(& &1.id)
+
+      audited_ids =
+        after_first
+        |> Enum.flat_map(& &1.new_state["article_ids"])
+        |> MapSet.new()
+
+      assert MapSet.subset?(audited_ids, persisted_ids)
+
+      # Retry (identical args): every chunk conflict-skips -> NO new rows AND NO new
+      # content_ingested audit entries (the phantom-audit defect).
+      assert :ok = ContentIngestionWorker.perform(%Oban.Job{id: 420, args: job_args})
+
+      {:ok, %{data: after_retry}} =
+        Loopctl.Audit.list_entries(tenant.id, action: "knowledge.content_ingested")
+
+      assert length(after_retry) == 3, "retry wrote phantom audit entries"
+    end
+
+    test "a title collision with an existing article is PERMANENT: discarded, not retried (#264 review F2)" do
+      %{tenant: tenant} = setup_tenant()
+
+      # A pre-existing ACTIVE article whose title the extractor will re-emit. The
+      # idempotency conflict target does NOT cover the title index, so insert_all
+      # raises a unique_violation — which must be classified permanent (discard),
+      # not burn all 3 retries.
+      _existing =
+        fixture(:article, %{tenant_id: tenant.id, title: "Clash Title", status: :published})
+
+      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _chunk, _opts ->
+        {:ok, [%{title: "Clash Title", body: "A different body.", category: :pattern}]}
+      end)
+
+      assert {:discard, {:extraction_failed, reason}} =
+               ContentIngestionWorker.perform(%Oban.Job{
+                 id: 421,
+                 args: %{
+                   "tenant_id" => tenant.id,
+                   "content" => "small content",
+                   "content_hash" => "title_clash",
+                   "source_type" => "newsletter"
+                 }
+               })
+
+      assert reason =~ "not retryable"
+    end
+
     test "when NO chunk succeeds, the error propagates so Oban retries (nothing persisted)" do
       %{tenant: tenant} = setup_tenant()
 


### PR DESCRIPTION
Fixes three prod-observed bugs in the knowledge-ingestion path. Opened as a **draft** — do not merge.

## #263 — PDF/binary URL to Jason.EncodeError crash-loop
A PDF (or any non-UTF-8 binary) body was handed straight to the JSON-encoded extractor request, raising `Jason.EncodeError` on the invalid bytes. The content hash is deterministic, so **every retry failed identically** — a permanent crash-loop.

**Fix:** `ContentIngestionWorker` guards content *before* it reaches the extractor:
- URL-fetch path rejects binary `Content-Type`s (`application/pdf`, `application/octet-stream`, `image/*`, `audio/*`, `video/*`, `font/*`, archives, ...).
- Both the URL-fetch **and** direct-`content:` paths run a `String.valid?/1` UTF-8 backstop for mislabeled bodies.
- Unsupported content returns `{:discard, {:unsupported_content, reason}}` — Oban discards (no retry), the reason is clear/actionable, nothing raises.

PDF text extraction stays out of scope (a feature + dependency decision).

## #264 — 30s timeout discarded real multi-chunk docs
Every chunk's LLM call ran sequentially inside one flat 30s job timeout, inserting once at the end, so a real ~87KB newsletter (~11 chunks, 7-13s each) always hit `Oban.TimeoutError` and was discarded with **zero** articles persisted.

**Fix:**
1. **Incremental persistence** — each chunk's articles are committed as that chunk completes, so a timeout/failure keeps what was already extracted.
2. **Scaled timeout** — `timeout/1` = `chunk_count * 30s`, hard-capped at **6 minutes**; inline jobs scale by exact chunk count, URL jobs get the cap (size unknown pre-fetch). The 15s per-fetch `receive_timeout` is preserved.
3. **Oversized docs** — a document beyond the 12-chunk per-job budget ingests what fits and `{:discard}`s the remainder with a count, instead of silently losing everything.

Partial success returns `:ok` (never retries into duplicate inserts); only a run that persisted nothing returns `{:error}` to retry. `project_id` validation/discard guards, server-value-wins `project_id`, and `content_hash` idempotency are all preserved.

## #266 — bulk hard-delete by article_ids could not purge ARCHIVED rows
The id-list delete selector resolved only ACTIVE (draft/published) rows, so a `hard:true, dry_run:true` over an archived id returned `would_affect: 0` and issued no token — archived tombstones were un-purgeable and the archive-then-purge flow was impossible.

**Fix:** new `resolve_delete_selector/2` widens **only** the explicit `{:ids, _}` selector to every lifecycle status (tag/source selectors stay active-only to avoid surprise-purges). Preview, the reconfirm-on-drift path, and the controller all use it, so dry-run accuracy, token issuance, confirm-hash matching, all-or-nothing transactionality, and tenant/RLS scoping are preserved.

## Tests
- **#263:** PDF `Content-Type` and mislabeled non-UTF-8 bodies discard cleanly (no `Jason.EncodeError`, no retry) on both url-fetch and direct paths; valid UTF-8 still ingests.
- **#264:** multi-chunk doc persists every chunk; a later-chunk failure keeps earlier chunks; `timeout/1` scales with chunk count and clamps at the cap; oversized docs discard with partial progress; tiny single-chunk still works.
- **#266:** create then archive then hard-delete by id purges (`would_affect: 1`, token issued); active rows still purge; tenant isolation on archived rows.

Quality gate: compile `--warnings-as-errors` clean, `credo --strict` 0 issues, dialyzer 0, full suite **3548 tests, 0 failures**.

Fixes #263, #264, #266.
