### PR TITLE
docs(observability): scale-metrics Grafana dashboard + runbook (#196)

### DIFF
--- a/docs/observability/scale-metrics-dashboard.json
+++ b/docs/observability/scale-metrics-dashboard.json
@@ -1,0 +1,404 @@
+{
+  "__comment": "loopctl Knowledge Scale Metrics dashboard (GitHub #196, visualizes US-27.15 metrics). Import into fly-metrics.net Grafana. Alerting is NOT wired here: the firing path is the in-app Loopctl.Telemetry.ScaleAlerts webhook. See scale-metrics-dashboard.md.",
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "panels": [],
+      "title": "DB statement-timeout / errors",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Per-second rate of mapped DB errors surfaced to clients, broken out by mapped_code. The db_statement_timeout series (Postgres SQLSTATE 57014) is the one that matters for scale — a sustained climb means heavy reads are giving up under load. Siblings (serialization / deadlock / catch-all) are shown for context. NOTE: a timed-out query never records a latency sample, so it shows up HERE, not in the heavy-read histogram.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "errors / sec",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "ops"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "db_statement_timeout" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } },
+              { "id": "custom.lineWidth", "value": 3 }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 1 },
+      "id": 2,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "sum(rate(loopctl_db_error_count[5m])) by (mapped_code)",
+          "legendFormat": "{{mapped_code}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "DB error rate by mapped_code",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Recent (5m) rate of statement-timeout (57014) DB errors, all endpoints. Red threshold 0.083/s = 5 timeouts/min, matching the ScaleAlerts :scale_alert_timeout_rate_per_min default that actually FIRES the in-app webhook. This stat only visualizes the same signal.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 0.05 },
+              { "color": "red", "value": 0.083 }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 1 },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "sum(rate(loopctl_db_error_count{mapped_code=\"db_statement_timeout\"}[5m]))",
+          "legendFormat": "db_statement_timeout",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Statement-timeout rate (57014)",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 },
+      "id": 4,
+      "panels": [],
+      "title": "Heavy-read latency",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "p50 / p95 / p99 latency of SUCCESSFUL heavy-read (vector / enumeration) queries, from the histogram buckets (ms). The 2000 ms line is the sub-2s heavy-read SLO the HEAVY_READ_POOL is sized for (US-27.11) and the ScaleAlerts :scale_alert_p95_latency_ms default. Buckets: 10,50,100,250,500,1000,2500,5000,10000 ms + +Inf. Timed-out queries are absent here (see the DB error panel).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "latency (ms)",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "line" }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 2000 }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "p99" },
+            "properties": [{ "id": "custom.lineStyle", "value": { "dash": [8, 4], "fill": "dash" } }]
+          }
+        ]
+      },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 10 },
+      "id": 5,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(loopctl_heavy_read_repo_query_duration_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(loopctl_heavy_read_repo_query_duration_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(loopctl_heavy_read_repo_query_duration_bucket[5m])) by (le))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Heavy-read latency quantiles (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Heat map of the heavy-read latency histogram (ms buckets). Each cell is the per-second rate of samples landing in that le bucket over [5m] — a fast way to spot the distribution shifting toward the 2500/5000/10000 ms buckets before p95 crosses the 2s line. If cells look empty, set the panel's Format to 'Heatmap' and confirm the query returns the le-labelled _bucket series.",
+      "fieldConfig": {
+        "defaults": { "custom": { "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "scaleDistribution": { "type": "linear" } } },
+        "overrides": []
+      },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 10 },
+      "id": 6,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 64
+        },
+        "exemplars": { "color": "rgba(255,0,255,0.7)" },
+        "filterValues": { "le": 1e-9 },
+        "legend": { "show": true },
+        "rowsFrame": { "layout": "auto", "value": "samples/s" },
+        "tooltip": { "mode": "single", "showColorScale": false, "yHistogram": false },
+        "yAxis": { "axisPlacement": "left", "reverse": false, "unit": "ms" }
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "sum(rate(loopctl_heavy_read_repo_query_duration_bucket[5m])) by (le)",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Heavy-read latency distribution (heatmap)",
+      "type": "heatmap"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 19 },
+      "id": 7,
+      "panels": [],
+      "title": "Recall under-fill",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Per-second rate of vector-search recall under-fill events (returned < requested — a densely-linked hub hiding above-threshold neighbors), broken out by endpoint. Red threshold 0.5/s = 30 events/min, matching the ScaleAlerts :scale_alert_under_fill_rate_per_min default that fires the in-app webhook. Source: US-27.6b.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "events / sec",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "line" }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 0.5 }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 20 },
+      "id": 8,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "sum(rate(loopctl_knowledge_vector_search_under_fill_count[5m])) by (endpoint)",
+          "legendFormat": "{{endpoint}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Under-fill rate by endpoint",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Recent (5m) total under-fill rate across all endpoints. Red threshold 0.5/s = 30 events/min (ScaleAlerts default).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 0.25 },
+              { "color": "red", "value": 0.5 }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 20 },
+      "id": 9,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "sum(rate(loopctl_knowledge_vector_search_under_fill_count[5m]))",
+          "legendFormat": "under_fill",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total under-fill rate",
+      "type": "stat"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["loopctl", "scale", "knowledge", "us-27.15"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "loopctl — Knowledge Scale Metrics (US-27.15)",
+  "uid": "loopctl-scale-metrics",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docs/observability/scale-metrics-dashboard.md
+++ b/docs/observability/scale-metrics-dashboard.md
@@ -1,0 +1,143 @@
+# Runbook: Knowledge Scale Metrics Grafana dashboard (US-27.15 / #196)
+
+> **What this is.** A ready-to-import Grafana dashboard
+> ([`scale-metrics-dashboard.json`](scale-metrics-dashboard.json)) that **visualizes**
+> the three scale-observability metrics US-27.15 already ships. It is the tracked
+> follow-up recorded as **GitHub #196** in the
+> [`knowledge-scale.md`](../runbooks/knowledge-scale.md#metrics--alerting-us-2715)
+> runbook ("Bespoke Grafana dashboard JSON ... a recorded backlog follow-up").
+>
+> **What this is NOT.** It is **not** an alerting mechanism. `fly-metrics.net`'s managed
+> Grafana has **alerting DISABLED** — PromQL here only draws trends. The signal that
+> actually **fires** on a breach is the in-app **`Loopctl.Telemetry.ScaleAlerts`**
+> webhook (see [Alerting](#alerting-is-not-in-this-dashboard) below).
+
+---
+
+## Where the data comes from
+
+The three metrics are `Telemetry.Metrics` defined in
+[`lib/loopctl/telemetry/scale_metrics.ex`](../../lib/loopctl/telemetry/scale_metrics.ex),
+merged into `LoopctlWeb.Telemetry.metrics/0`, and exported by the
+`telemetry_metrics_prometheus` reporter on the **internal `:9568/metrics`** port (started
+through the fault-isolating `Loopctl.Telemetry.MetricsReporter` wrapper). Fly's **managed
+Prometheus** scrapes `:9568` over the private 6PN network (`fly.toml [metrics]`), and the
+series land in **`fly-metrics.net` Grafana**. That is the datasource this dashboard reads.
+
+`:9568` is internal-only (not in `fly.toml`'s public `http_service`); the reporter is off
+in `:test` and off by default in dev — set `config :loopctl, :metrics_reporter_enabled,
+true` in `config/dev.exs` to read `localhost:9568/metrics` locally.
+
+## How to import
+
+1. Open **`fly-metrics.net`** (Fly's managed Grafana for your org) and sign in.
+2. **Dashboards → New → Import**.
+3. Upload `docs/observability/scale-metrics-dashboard.json` (or paste its contents).
+4. When prompted, pick your **Prometheus** datasource for the dashboard's `datasource`
+   variable. The dashboard uses a datasource **template variable** (not a hard-coded uid),
+   so it is portable across orgs / any Prometheus that scrapes the same `/metrics`.
+5. Save. Default range is `now-6h`, auto-refresh `30s`.
+
+The dashboard `uid` is `loopctl-scale-metrics` and it is tagged
+`loopctl`, `scale`, `knowledge`, `us-27.15`.
+
+## Prometheus metric names (how they are derived)
+
+`telemetry_metrics_prometheus_core`'s exporter builds each Prometheus name by joining the
+`Telemetry.Metrics` name segments with `_` (`Enum.join(name, "_")`, then stripping any
+non-`[a-zA-Z0-9_]`). A `counter` exports as a Prometheus **counter** (name **as-is — no
+`_total` suffix** in this library version, `telemetry_metrics_prometheus` 1.1.0 /
+`_core` 1.2.1); a `distribution` exports as a **histogram** with cumulative
+`_bucket{le="..."}` + `_sum` + `_count` series. Tags become labels (sorted). So:
+
+| Telemetry.Metrics name | Prometheus series | Labels |
+| --- | --- | --- |
+| `loopctl.db.error.count` (counter) | `loopctl_db_error_count` | `endpoint`, `mapped_code`, *(cap-gated)* `tenant_id` |
+| `loopctl.heavy_read_repo.query.duration` (distribution) | `loopctl_heavy_read_repo_query_duration_bucket` / `_sum` / `_count` | `endpoint`, plus `le` on `_bucket` |
+| `loopctl.knowledge.vector_search.under_fill.count` (counter) | `loopctl_knowledge_vector_search_under_fill_count` | `endpoint`, *(cap-gated)* `tenant_id` |
+
+Histogram buckets are in **milliseconds** (`unit: {:native, :millisecond}`):
+`10, 50, 100, 250, 500, 1000, 2500, 5000, 10000` plus a `+Inf` overflow bucket. Because the
+unit is ms, `histogram_quantile(...)` returns **ms** directly — the latency panels are in ms.
+
+> **Cap-gated `tenant_id` (AC-27.15.3).** `tenant_id` is a real label on the two counters
+> only while total tenants ≤ `:metrics_tenant_label_cap` (default 1000). Above the cap it
+> collapses to the sentinel value **`_aggregated`** (cardinality 1). It is **never** a
+> histogram label. None of the dashboard PromQL groups by `tenant_id`, so it is correct in
+> both regimes; per-tenant drill-down falls back to the 7-day logs (which still carry
+> `tenant_id`) — see `knowledge-scale.md`.
+
+## The panels
+
+### Row 1 — DB statement-timeout / errors
+
+- **DB error rate by mapped_code** (timeseries, ops = per-sec):
+  `sum(rate(loopctl_db_error_count[5m])) by (mapped_code)`. The
+  **`db_statement_timeout`** series (SQLSTATE **57014**) is forced red/bold — it is the one
+  that signals heavy reads giving up under load. Siblings (serialization / deadlock /
+  catch-all) are context.
+- **Statement-timeout rate (57014)** (stat):
+  `sum(rate(loopctl_db_error_count{mapped_code="db_statement_timeout"}[5m]))`. Red at
+  **0.083/s = 5 timeouts/min**, matching the ScaleAlerts `:scale_alert_timeout_rate_per_min`
+  default that fires the in-app webhook.
+
+> A query that **times out never records a latency sample** — it raises before `total_time`
+> is emitted — so it appears **here**, not in the heavy-read histogram. Expect a healthy p95
+> while timeouts climb; that split is by design (the counter is the "gave up" signal, the
+> histogram the "slow but completed" signal).
+
+### Row 2 — Heavy-read latency
+
+- **Latency quantiles p50 / p95 / p99** (timeseries, ms):
+  `histogram_quantile(0.50|0.95|0.99, sum(rate(loopctl_heavy_read_repo_query_duration_bucket[5m])) by (le))`.
+  A red **threshold line at 2000 ms** marks the sub-2s heavy-read SLO the
+  `HEAVY_READ_POOL` is sized for (US-27.11) and the ScaleAlerts `:scale_alert_p95_latency_ms`
+  default. **The threshold that matters: p95 crossing 2000 ms.**
+- **Latency distribution** (heatmap): `sum(rate(loopctl_heavy_read_repo_query_duration_bucket[5m])) by (le)`
+  with query format **Heatmap** — shows the distribution shifting toward the
+  2500/5000/10000 ms buckets before p95 crosses the line.
+
+### Row 3 — Recall under-fill
+
+- **Under-fill rate by endpoint** (timeseries, ops):
+  `sum(rate(loopctl_knowledge_vector_search_under_fill_count[5m])) by (endpoint)`. Red
+  threshold line at **0.5/s = 30 events/min** (ScaleAlerts
+  `:scale_alert_under_fill_rate_per_min` default). Source: US-27.6b (a densely-linked hub
+  hiding above-threshold neighbors).
+- **Total under-fill rate** (stat): the all-endpoint sum, same 0.5/s red threshold.
+
+## Alerting is NOT in this dashboard
+
+`fly-metrics.net`'s managed Grafana has **alerting disabled** (per Fly: *"Fly.io doesn't
+include built-in alerting on metrics, so you'll need to set up alerting yourself against the
+Prometheus endpoint."*). The PromQL above therefore **visualizes only — nothing fires from
+it**.
+
+The **firing** path (US-27.15 AC-27.15.2) is a self-contained, loopctl-owned threshold
+checker: **[`Loopctl.Telemetry.ScaleAlerts`](../../lib/loopctl/telemetry/scale_alerts.ex)**.
+It windows the same three signals via atomic ETS counters, evaluates them on a timer
+(`:scale_alert_check_interval_ms`, default 60 s), and on an **edge-triggered** breach POSTs
+an id-only JSON payload to `:scale_alert_webhook_url` (Slack / PagerDuty / generic). Its
+thresholds are the SAME numbers the dashboard draws (5 timeouts/min, p95 2000 ms, 30
+under-fills/min). Enable it in prod by setting `SCALE_ALERT_WEBHOOK_URL`; full config table
+in [`knowledge-scale.md`](../runbooks/knowledge-scale.md#the-firing-alert-path-loopctltelemetryscalealerts).
+
+The dashboard is for a human watching the trend; ScaleAlerts is the thing that pages.
+
+## Assumptions a reviewer / importer should check
+
+- **Datasource.** The dashboard binds a Prometheus datasource via the `datasource` template
+  variable at import time — pick the Fly managed-Prometheus datasource. No uid is hard-coded.
+- **Metric presence.** Series only exist once the reporter has been scraped in an env where
+  `:metrics_reporter_enabled` is true (prod) and the underlying events have fired. On a quiet
+  window `rate(...)` and `histogram_quantile(...)` legitimately return empty/NaN.
+- **Histogram unit is ms**, not seconds — the quantile panels and the 2000 ms line are ms.
+- **Heatmap format.** If the heatmap renders empty, confirm the query's **Format = Heatmap**
+  and that the datasource returns the `le`-labelled `_bucket` series (Grafana ≥ 9).
+- **No `_total` suffix.** This library version exports counters without the Prometheus
+  `_total` convention — the names above are literal. If the reporter dep is ever upgraded to
+  one that appends `_total`, update the four counter expressions here and in
+  `knowledge-scale.md`.
+- **Bucket layout.** Buckets are the ms set above; if `reporter_options[:buckets]` in
+  `scale_metrics.ex` changes, the heatmap y-axis and the histogram_quantile accuracy shift
+  accordingly (the PromQL itself stays correct).

--- a/docs/runbooks/knowledge-scale.md
+++ b/docs/runbooks/knowledge-scale.md
@@ -435,10 +435,12 @@ network (`fly.toml [metrics]`). The series appear in **`fly-metrics.net` Grafana
 > **Scope (AC-27.15.4 — USER-signed-off):** metric emission + the Prometheus reporter +
 > the **ScaleAlerts firing webhook** ship in this story. The PromQL expressions below are
 > **query bodies** for an **OPTIONAL self-hosted** Grafana/Alertmanager (they require your
-> own Grafana — fly-metrics.net cannot install or run them). Bespoke Grafana **dashboard
-> JSON** + an external **Alertmanager** wiring are a recorded **backlog follow-up** —
-> tracked in **GitHub issue #196**, not silently dropped. loopctl has no Sentry; the
-> ScaleAlerts webhook is the durable firing signal. To inspect `/metrics` locally, set
+> own Grafana — fly-metrics.net cannot install or run them). The bespoke Grafana
+> **dashboard JSON** (issue #196) now ships as
+> [`docs/observability/scale-metrics-dashboard.json`](../observability/scale-metrics-dashboard.md)
+> (import into fly-metrics.net Grafana — **visualization only**); an external
+> **Alertmanager** wiring remains an optional self-hosted follow-up. loopctl has no Sentry;
+> the ScaleAlerts webhook is the durable firing signal. To inspect `/metrics` locally, set
 > `config :loopctl, :metrics_reporter_enabled, true` in `config/dev.exs`.
 
 ### Surface & security


### PR DESCRIPTION
## What

Adds the remaining deliverable for #196: an importable **Grafana dashboard** that visualizes the three US-27.15 scale metrics, plus a runbook explaining it.

US-27.15 already shipped the durable signal layer (the three `Telemetry.Metrics` in `lib/loopctl/telemetry/scale_metrics.ex`, the `:9568/metrics` Prometheus reporter, and the firing `ScaleAlerts` webhook). This PR is the **visualization + docs** follow-up that `knowledge-scale.md` recorded as issue #196 — no application code changes.

## Files

- `docs/observability/scale-metrics-dashboard.json` — Grafana dashboard model. Portable via a Prometheus **datasource template variable** (no hard-coded uid). Three rows:
  - **DB statement-timeout / errors** — `sum(rate(loopctl_db_error_count[5m])) by (mapped_code)` (57014 `db_statement_timeout` highlighted) + a stat with a 5-timeouts/min threshold.
  - **Heavy-read latency** — p50/p95/p99 from `histogram_quantile(..., sum(rate(loopctl_heavy_read_repo_query_duration_bucket[5m])) by (le))` (ms) with a 2000 ms SLO line, plus a bucket heatmap.
  - **Recall under-fill** — `sum(rate(loopctl_knowledge_vector_search_under_fill_count[5m])) by (endpoint)` + a stat, 30/min threshold.
- `docs/observability/scale-metrics-dashboard.md` — import steps, metric-name derivation (dot→underscore, histogram `_bucket`/`_sum`/`_count`, no `_total` in this lib version), panel/threshold meanings, and the assumptions to check.
- `docs/runbooks/knowledge-scale.md` — cross-linked to the new dashboard.

## Alerting

**Not** wired here. `fly-metrics.net`'s managed Grafana has alerting disabled, so this dashboard only visualizes. The firing path is the already-shipped in-app `Loopctl.Telemetry.ScaleAlerts` webhook, whose thresholds match the lines drawn here.

## Verification

- Dashboard JSON parses (`python3 -m json.tool`); metric names/labels verified against `telemetry_metrics_prometheus_core` 1.2.1's `exporter.ex` and the `scale_metrics.ex` definitions.
- Full `mix precommit` gate green (3554 tests, 0 failures).

Fixes #196.