### PR TITLE
perf(knowledge): optimize distant_pairs to meet Theme 2 <2s (#202, #203)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -34,15 +34,22 @@ config :loopctl,
   # heavy reads, e.g. %{suggested_links: 5_000}. Endpoints absent here use the default
   # per-read SET LOCAL statement_timeout (HEAVY_READ_STATEMENT_TIMEOUT_MS, default 10s;
   # US-27.13 — NOT a startup :parameters value, which pgbouncer rejects). Keys:
-  # :suggested_links, :semantic_search, :distant_pairs, :novelty, :enumeration,
-  # :change_feed, :vector_search. NOTE: :distant_pairs,
-  # :semantic_search, and :enumeration each issue TWO reads (count + data); setting an
-  # override for any of them wraps EACH read in its own separate transaction, doubling
-  # the brief checkout count on the heavy pool. :change_feed (US-27.9b) is the
-  # rate-limited orchestrator polling feed — a SINGLE cheap keyset read per request;
-  # its QPS is bounded by the api pipeline's rate limiter, so it adds at most a brief,
-  # fast-releasing checkout and does not erode the K≈6 one-shot fast-read budget.
-  heavy_read_statement_timeout_overrides: %{},
+  # :suggested_links, :semantic_search, :distant_pairs, :distant_pairs_bridge, :novelty,
+  # :enumeration, :change_feed, :vector_search. NOTE: :semantic_search and :enumeration each
+  # issue TWO reads (count + data); setting an override for either wraps EACH read in its own
+  # separate transaction, doubling the brief checkout count on the heavy pool. (:distant_pairs
+  # USED to be in that list — post-#202/#203 it issues a SINGLE paginated read, its exact-count
+  # companion query removed.) :change_feed (US-27.9b) is the rate-limited orchestrator polling
+  # feed — a SINGLE cheap keyset read per request; its QPS is bounded by the api pipeline's
+  # rate limiter, so it adds at most a brief, fast-releasing checkout and does not erode the
+  # K≈6 one-shot fast-read budget.
+  #
+  # :distant_pairs / :distant_pairs_bridge (#202/#203, HIGH-4) carry a 4s backstop — tighter
+  # than the 10s pool default — so a real-scale miss of the Theme-2 <2s target (a deep offset
+  # or a rarely-bridged band that defeats the page's early termination) is CANCELED and frees
+  # its heavy-read slot fast instead of holding it for 10s. The bridge branch reads under its
+  # own key so its (slower) reads are separately observable in slow-query logs.
+  heavy_read_statement_timeout_overrides: %{distant_pairs: 4_000, distant_pairs_bridge: 4_000},
   # US-27.12: set-based bulk archive/unpublish/delete. Each op runs in one
   # transaction that first issues `SET LOCAL statement_timeout = <ms>` so a single
   # large statement can't hold an admin-pool connection indefinitely (blast-radius

--- a/config/test.exs
+++ b/config/test.exs
@@ -97,7 +97,14 @@ config :loopctl, :heavy_read_repo, Loopctl.AdminRepo
 #     asserts a :change_feed timeout, so this override cannot mask a real one.
 config :loopctl, :heavy_read_statement_timeout_overrides, %{
   suggested_links: 5_000,
-  change_feed: 5_000
+  change_feed: 5_000,
+  # distant_pairs (esp. the bridge branch) can legitimately run ~1s at the :scale_nightly
+  # 80k corpus — well above the 250ms pool default — so give it generous headroom here or the
+  # server-side timeout would cancel the scale bridge case before it completes. The <2s
+  # Theme-2 target is asserted SEPARATELY (wall-clock) in distant_pairs_novelty_scale_test.exs;
+  # prod carries the tighter 4s backstop (config/config.exs).
+  distant_pairs: 5_000,
+  distant_pairs_bridge: 5_000
 }
 
 # US-27.6b: the over-fetch pool sizing knobs (`Loopctl.Knowledge.VectorSearch.pool_size/2`).
@@ -250,10 +257,18 @@ config :loopctl, :full_content_byte_budget, 100_000
 # be exercised with ~11 nodes instead of 100+ (production default is 100).
 config :loopctl, :max_graph_nodes, 10
 
-# Distant-pairs candidate cap — small in tests so the O(n²) self-join sampling
-# cap can be exercised with ~26 articles instead of 1000+ (production default is
-# 1000). Keep comfortably above the article count of any non-truncation test.
-config :loopctl, :max_pair_candidates, 25
+# Distant-pairs candidate caps — small in the DEFAULT async suite so the O(candidates²)
+# sample cap (and the bridge branch's SMALLER cap) can be exercised with a handful of articles
+# instead of 1000+/500. The bridge cap (10) is kept < the general cap (25) so the bridge-branch
+# invariant genuinely binds in the unit test. The SCALE gate (SCALE_NIGHTLY/SCALE_TESTS) leaves
+# the PROD defaults (general 1000, bridge 500) so the :scale_nightly distant_pairs cases are
+# prod-shaped — the bridge latency proof needs the REAL 500 cap (a small cap would make it
+# trivially fast and prove nothing). Mirrors the vector_pool_* pattern above. Config-based DI —
+# NO Application.put_env in any test body.
+unless System.get_env("SCALE_NIGHTLY") || System.get_env("SCALE_TESTS") do
+  config :loopctl, :max_pair_candidates, 25
+  config :loopctl, :max_bridge_pair_candidates, 10
+end
 
 # US-27.12: low frozen-set bound so the oversized re-confirm-on-drift bulk-delete
 # path is exercisable with a handful of rows instead of 1001 (production default

--- a/docs/runbooks/knowledge-scale.md
+++ b/docs/runbooks/knowledge-scale.md
@@ -180,8 +180,13 @@ fast-read budget is now slightly more contended per the same concurrency. The pe
 latency/throughput risk, not a deadlock — but per the "verify against prod scale" practice,
 re-check heavy-read p95 + pool queue-wait under load after deploy (the #172 incident proves
 this pool is the real contention point). Measured prod baselines at ~77k (deployed fix):
-`suggested_links` ~59ms, semantic ~45ms, novelty ~1.4s, distant_pairs ~7.9s (the slowest —
-within the 10s cap but worth watching as the corpus grows).
+`suggested_links` ~59ms, semantic ~45ms, novelty ~1.4s. `distant_pairs` was the slowest at
+~7.9s until #202/#203: its cost was an exact `total_count` `count(*)` query — a full
+O(candidates²) pass over the sampled self-join that could NOT early-terminate. That count is
+now removed (the endpoint returns `count`/`has_more`, no exact total), leaving only the
+ordered `LIMIT limit+1` page, which early-terminates in a few ms (local 1.5k-corpus profile:
+count pass ~2.3s vs page ~6–18ms). Confirm the new prod p95 (<2s Theme 2 target) via
+`fly ssh`/EXPLAIN ANALYZE after deploy per the "verify against prod scale" practice.
 
 ## Keyset pagination index (US-27.9a)
 

--- a/docs/runbooks/knowledge-scale.md
+++ b/docs/runbooks/knowledge-scale.md
@@ -113,7 +113,7 @@ it fires, the request fast-fails as the structured **504 `db_statement_timeout`*
 
 **Per-endpoint override (optional):** to give one endpoint a tighter (or looser) bound,
 set `:heavy_read_statement_timeout_overrides` (ms) in config — keys
-`:suggested_links`, `:semantic_search`, `:distant_pairs`, `:novelty`, `:vector_search`:
+`:suggested_links`, `:semantic_search`, `:distant_pairs`, `:distant_pairs_bridge`, `:novelty`, `:vector_search`:
 
 ```elixir
 config :loopctl, :heavy_read_statement_timeout_overrides, %{suggested_links: 5_000}
@@ -124,7 +124,7 @@ dedicated heavy pool (justified by the 8-conn sizing). Leave the map empty unles
 endpoint needs a bound different from the `HEAVY_READ_STATEMENT_TIMEOUT_MS` default.
 
 **Heavy-read endpoints** (those using `HeavyRead.all/one`): `:suggested_links`,
-`:semantic_search`, `:distant_pairs`, `:novelty`, `:enumeration`. The enumeration endpoint
+`:semantic_search`, `:distant_pairs`, `:distant_pairs_bridge`, `:novelty`, `:enumeration`. The enumeration endpoint
 (`:knowledge_search_controller` list mode, `list_filtered/2`) now routes through HeavyRead to
 inherit the per-read SET LOCAL statement_timeout and optional per-endpoint override (matching
 the other endpoints). Enumeration pages up to `limit: 1000` rows per request.

--- a/lib/loopctl/heavy_read.ex
+++ b/lib/loopctl/heavy_read.ex
@@ -75,8 +75,10 @@ defmodule Loopctl.HeavyRead do
   This is the SINGLE source of truth for heavy-read opts — every consumer
   (`Loopctl.Knowledge`, `Loopctl.Audit`) builds opts via this function so the
   `[timeout, telemetry_options, statement_timeout]` shape can't drift between callers.
-  Known endpoints: `:suggested_links`, `:semantic_search`, `:distant_pairs`, `:novelty`,
-  `:enumeration`, `:change_feed`, `:vector_search` (the shared kNN helper path).
+  Known endpoints: `:suggested_links`, `:semantic_search`, `:distant_pairs`,
+  `:distant_pairs_bridge` (the slower `bridge_path=true` branch — its own key so its
+  statement_timeout/slow-query telemetry are distinct), `:novelty`, `:enumeration`,
+  `:change_feed`, `:vector_search` (the shared kNN helper path).
   """
   @spec opts(atom()) :: keyword()
   def opts(endpoint) when is_atom(endpoint) do

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -151,6 +151,15 @@ defmodule Loopctl.Knowledge do
   # cross product); a random walk takes at most @max_walk_length steps. The
   # candidate cap is operator-tunable via `config :loopctl, :max_pair_candidates`.
   @max_pair_candidates 1000
+  # `bridge_path: true` adds a per-pair link-graph EXISTS (direct link OR a shared
+  # published neighbor) to the band filter. In-band ("distant") pairs are usually
+  # graph-DISTANT, so few bridge — the paginated `LIMIT limit+1` page then cannot
+  # early-terminate and evaluates the (expensive 2-hop) EXISTS over the whole in-band
+  # set, which is O(candidates²) work (#202/#203). So the bridge branch uses a SMALLER
+  # sample cap to keep it under the Theme 2 <2s budget; operator-tunable via
+  # `config :loopctl, :max_bridge_pair_candidates`. The non-bridge path keeps the full
+  # 1000 cap (it early-terminates in a few ms regardless).
+  @max_bridge_pair_candidates 500
   @default_pair_limit 20
   @max_pair_limit 100
   @default_walk_length 4
@@ -4338,7 +4347,10 @@ defmodule Loopctl.Knowledge do
   Samples at most #{@max_pair_candidates} embedded published articles (bounding the
   O(n²) self-join), returns distinct unordered pairs ordered deterministically for
   pagination. With `bridge_path: true` only pairs that are also connected in the
-  link graph (directly, or via a shared neighbor — ≤2 hops) are returned.
+  link graph (directly, or via a shared neighbor — ≤2 hops) are returned; that branch
+  samples a smaller #{@max_bridge_pair_candidates}-article slice, because its per-pair
+  graph EXISTS defeats the page's early termination and would otherwise blow the <2s
+  budget on band-distant (rarely-bridged) pairs.
 
   ## Parameters
 
@@ -4348,11 +4360,16 @@ defmodule Loopctl.Knowledge do
 
   ## Returns
 
-  - `{:ok, %{pairs: [...], total_count: integer, has_more: boolean}}`
+  - `{:ok, %{pairs: [...], has_more: boolean}}` — `has_more` is a `limit + 1`
+    look-ahead flag. NO exact total-pair count is returned: an exact count cannot
+    early-terminate (it must evaluate the `<=>` for every one of the
+    O(candidates²) sampled pairs), and profiling at prod scale (#202/#203) showed
+    that full count pass — not the paginated read — was the entire latency cost.
+    Page with `has_more` instead.
   - `{:error, :invalid_distance}` when the band is outside 0.0–2.0 or min > max
   """
   @spec distant_pairs(Ecto.UUID.t(), keyword()) ::
-          {:ok, %{pairs: [map()], total_count: integer(), has_more: boolean()}}
+          {:ok, %{pairs: [map()], has_more: boolean()}}
           | {:error, :invalid_distance}
   def distant_pairs(tenant_id, opts \\ []) do
     min_d = Keyword.get(opts, :min_distance, 0.3)
@@ -4374,24 +4391,35 @@ defmodule Loopctl.Knowledge do
 
   defp validate_distance_band(_, _), do: {:error, :invalid_distance}
 
-  # Operator-tunable cap on the sampled candidate set (bounds the O(n²) self-join).
+  # Operator-tunable cap on the sampled candidate set (bounds the O(n²) self-join). The
+  # bridge branch uses a smaller cap because its per-pair link-graph EXISTS defeats the
+  # page's early termination (see @max_bridge_pair_candidates).
   defp max_pair_candidates do
     Application.get_env(:loopctl, :max_pair_candidates, @max_pair_candidates)
   end
 
+  defp max_bridge_pair_candidates do
+    Application.get_env(:loopctl, :max_bridge_pair_candidates, @max_bridge_pair_candidates)
+  end
+
+  # The sample cap for THIS request: the smaller bridge cap when `bridge_path` is on,
+  # else the full cap.
+  defp pair_candidate_cap(true), do: max_bridge_pair_candidates()
+  defp pair_candidate_cap(false), do: max_pair_candidates()
+
   # Column-to-column self-join: `(a.embedding <=> b.embedding) BETWEEN $min AND $max` over
-  # a `LIMIT max_pair_candidates()` SAMPLED subquery. There is NO `$const` target vector
-  # here (both operands are stored columns), so pgvector's HNSW index cannot apply BY
+  # a `LIMIT pair_candidate_cap(bridge?)` SAMPLED subquery. There is NO `$const` target
+  # vector here (both operands are stored columns), so pgvector's HNSW index cannot apply BY
   # NATURE — this is NOT (and must not become) a `VectorSearch.nearest/4` call (US-27.7b —
-  # registered in `Loopctl.Knowledge.CosineLintExceptions`). It is bounded by the
-  # `max_pair_candidates()` sample LIMIT (NOT an O(n²) scan over the whole 80k corpus) and
-  # stays tenant-scoped (`a.tenant_id`/`b.tenant_id` filtered) via HeavyRead's structural guard.
+  # registered in `Loopctl.Knowledge.CosineLintExceptions`). It is bounded by the sample
+  # LIMIT (NOT an O(n²) scan over the whole 80k corpus) and stays tenant-scoped
+  # (`a.tenant_id`/`b.tenant_id` filtered) via HeavyRead's structural guard.
   defp do_distant_pairs(tenant_id, min_d, max_d, limit, offset, bridge?, vis) do
     candidates =
       from(a in Article,
         where: a.tenant_id == ^tenant_id and a.status == :published and not is_nil(a.embedding),
         order_by: a.id,
-        limit: ^max_pair_candidates(),
+        limit: ^pair_candidate_cap(bridge?),
         select: %{
           id: a.id,
           tenant_id: a.tenant_id,
@@ -4402,16 +4430,19 @@ defmodule Loopctl.Knowledge do
       )
       |> maybe_filter_by_visibility(vis)
 
-    # Build the base query for counting total pairs
-    count_query =
-      from(a in subquery(candidates),
-        join: b in subquery(candidates),
-        on: a.id < b.id,
-        where: fragment("(? <=> ?) BETWEEN ? AND ?", a.embedding, b.embedding, ^min_d, ^max_d),
-        select: count()
-      )
-
-    # Build the paginated query for fetching pairs
+    # ONE query: the paginated pairs with a `limit + 1` look-ahead. The `<=>` band
+    # filter over the sampled cross-join is the whole cost, and this ordered
+    # `LIMIT (limit + 1)` lets Postgres STOP as soon as it has produced one more pair
+    # than the page needs (early termination on the id-ordered nested loop) rather
+    # than materializing every matching pair.
+    #
+    # There is deliberately NO companion `count(*)` query. An EXACT total-pair count
+    # cannot early-terminate — it must evaluate the `<=>` for every one of the
+    # O(candidates²) sampled pairs — and profiling at prod scale (#202/#203) showed
+    # that full count pass, NOT the paginated read, was the entire ~7.85s cost (the
+    # ordered `LIMIT limit+1` page returns in a few ms). Dropping it is what brings
+    # the endpoint under the Epic 27 Theme 2 <2s target; `has_more` (the limit + 1
+    # look-ahead) gives pagination everything it needs without that pass.
     pairs_query =
       from(a in subquery(candidates),
         join: b in subquery(candidates),
@@ -4427,27 +4458,22 @@ defmodule Loopctl.Knowledge do
         }
       )
 
-    # Fetch count and paginated pairs through Loopctl.HeavyRead (US-27.11): the
+    # Fetch the page (+1 look-ahead) through Loopctl.HeavyRead (US-27.11): the
     # dedicated heavy-read pool with a per-read SET LOCAL statement_timeout (US-27.13),
-    # isolated from the small AdminRepo pool so this O(n²) self-join can't starve light
-    # admin ops. No SHARED transaction across the two reads — each is its own short
-    # SET LOCAL transaction, so the count may shift between them (acceptable, by design). Both
-    # queries filter `a.tenant_id`/`b.tenant_id`, satisfying the wrapper's guard.
-    total_count =
-      count_query
-      |> maybe_filter_bridge_path(bridge?, vis)
-      |> then(&HeavyRead.one(tenant_id, &1, heavy_read_opts(:distant_pairs)))
-
+    # isolated from the small AdminRepo pool so this self-join can't starve light admin
+    # ops. A SINGLE short read now (the exact-count companion read was removed in
+    # #202/#203). The query filters `a.tenant_id`/`b.tenant_id`, satisfying the
+    # wrapper's structural tenant guard.
     pairs_with_lookahead =
       pairs_query
       |> maybe_filter_bridge_path(bridge?, vis)
       |> then(&HeavyRead.all(tenant_id, &1, heavy_read_opts(:distant_pairs)))
 
-    # Detect has_more by fetching limit+1; only return limit
+    # Detect has_more by fetching limit+1; only return limit.
     has_more = length(pairs_with_lookahead) > limit
     pairs = Enum.take(pairs_with_lookahead, limit)
 
-    %{pairs: pairs, total_count: total_count, has_more: has_more}
+    %{pairs: pairs, has_more: has_more}
   end
 
   # Bridge filter: keep only pairs connected within ≤2 hops in the link graph —

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -162,6 +162,13 @@ defmodule Loopctl.Knowledge do
   @max_bridge_pair_candidates 500
   @default_pair_limit 20
   @max_pair_limit 100
+  # Upper bound on `:offset` (#202/#203 review, MED-5). A deep offset defeats the page's
+  # early termination — Postgres must produce `offset + limit + 1` matching pairs before
+  # returning — so an unbounded offset lets a caller force near-full O(candidates²)
+  # evaluation of the cross-join. Clamp it (analogous to `limit`'s `min(@max_pair_limit)`);
+  # operator-tunable via `config :loopctl, :max_pair_offset`. 10_000 ≫ any real page depth
+  # at the default limit (500 pages) yet ≪ the ~500k max pairs at the 1000 candidate cap.
+  @max_pair_offset 10_000
   @default_walk_length 4
   @max_walk_length 25
   # Novelty scoring embeds each idea concurrently (bounded) so a 50-idea batch
@@ -4375,7 +4382,7 @@ defmodule Loopctl.Knowledge do
     min_d = Keyword.get(opts, :min_distance, 0.3)
     max_d = Keyword.get(opts, :max_distance, 0.7)
     limit = opts |> Keyword.get(:limit, @default_pair_limit) |> max(1) |> min(@max_pair_limit)
-    offset = opts |> Keyword.get(:offset, 0) |> max(0)
+    offset = opts |> Keyword.get(:offset, 0) |> max(0) |> min(max_pair_offset())
     bridge? = Keyword.get(opts, :bridge_path, false) == true
     vis = Keyword.get(opts, :visibility_agent_id)
 
@@ -4402,9 +4409,35 @@ defmodule Loopctl.Knowledge do
     Application.get_env(:loopctl, :max_bridge_pair_candidates, @max_bridge_pair_candidates)
   end
 
-  # The sample cap for THIS request: the smaller bridge cap when `bridge_path` is on,
-  # else the full cap.
-  defp pair_candidate_cap(true), do: max_bridge_pair_candidates()
+  # The COMPILE-TIME default caps (the module-attribute constants, config-independent). The
+  # OpenAPI operation doc interpolates these so the numbers in the description can never drift
+  # from the code (#202/#203 review, LOW-9). Public (`@doc false`) only so the controller can
+  # reference them at compile time.
+  @doc false
+  def default_max_pair_candidates, do: @max_pair_candidates
+
+  @doc false
+  def default_max_bridge_pair_candidates, do: @max_bridge_pair_candidates
+
+  # Operator-tunable upper bound on the `:offset` (#202/#203 MED-5).
+  defp max_pair_offset do
+    Application.get_env(:loopctl, :max_pair_offset, @max_pair_offset)
+  end
+
+  # #202/#203 MED-7 invariant: the effective bridge cap NEVER exceeds the general cap, so a
+  # misconfigured larger bridge cap can't make `bridge_path` slower than the non-bridge path
+  # it is meant to bound. Pure + public (`@doc false`) so the clamp is unit-testable without
+  # `Application.put_env` (config-based DI — no put_env in tests).
+  @doc false
+  def effective_bridge_candidate_cap(bridge_cap, general_cap)
+      when is_integer(bridge_cap) and is_integer(general_cap),
+      do: min(bridge_cap, general_cap)
+
+  # The sample cap for THIS request: the (clamped) smaller bridge cap when `bridge_path` is
+  # on, else the full cap.
+  defp pair_candidate_cap(true),
+    do: effective_bridge_candidate_cap(max_bridge_pair_candidates(), max_pair_candidates())
+
   defp pair_candidate_cap(false), do: max_pair_candidates()
 
   # Column-to-column self-join: `(a.embedding <=> b.embedding) BETWEEN $min AND $max` over
@@ -4464,10 +4497,16 @@ defmodule Loopctl.Knowledge do
     # ops. A SINGLE short read now (the exact-count companion read was removed in
     # #202/#203). The query filters `a.tenant_id`/`b.tenant_id`, satisfying the
     # wrapper's structural tenant guard.
+    #
+    # The bridge branch reads under its OWN endpoint key (`:distant_pairs_bridge`) so its
+    # slower per-pair-EXISTS reads carry a distinct `statement_timeout` backstop + slow-query
+    # telemetry tag, separate from the fast non-bridge path (#202/#203 review, HIGH-4).
+    endpoint = if bridge?, do: :distant_pairs_bridge, else: :distant_pairs
+
     pairs_with_lookahead =
       pairs_query
       |> maybe_filter_bridge_path(bridge?, vis)
-      |> then(&HeavyRead.all(tenant_id, &1, heavy_read_opts(:distant_pairs)))
+      |> then(&HeavyRead.all(tenant_id, &1, heavy_read_opts(endpoint)))
 
     # Detect has_more by fetching limit+1; only return limit.
     has_more = length(pairs_with_lookahead) > limit

--- a/lib/loopctl_web/controllers/knowledge_creativity_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_creativity_controller.ex
@@ -28,14 +28,16 @@ defmodule LoopctlWeb.KnowledgeCreativityController do
       "Returns paginated pairs of articles whose embedding cosine distance is in the " <>
         "optimal-novelty band [`min_distance`, `max_distance`] (default 0.3–0.7) — the " <>
         "creative sweet spot. With `bridge_path=true`, only pairs also connected in the " <>
-        "link graph (≤2 hops) are returned (that branch samples a smaller 500-article slice " <>
-        "so its per-pair graph check stays within budget). Agent callers see only their own " <>
-        "and `shared` articles. Each pair: `{a, b, distance}`. Samples up to " <>
-        "1000 embedded published visible articles (lowest-id slice; operator-tunable). " <>
-        "`meta` carries `count` (items in this page) and `has_more` (a `limit+1` look-ahead) " <>
-        "for pagination. No exact total-pair count is returned: computing it requires a full " <>
-        "O(candidates²) pass that dominated latency at scale (#202/#203); page via `has_more`. " <>
-        "Role: agent+.",
+        "link graph (≤2 hops) are returned (that branch samples a smaller " <>
+        "#{Knowledge.default_max_bridge_pair_candidates()}-article slice so its per-pair " <>
+        "graph check stays within budget). Agent callers see only their own and `shared` " <>
+        "articles. Each pair: `{a, b, distance}`. Samples up to " <>
+        "#{Knowledge.default_max_pair_candidates()} embedded published visible articles " <>
+        "(lowest-id slice; operator-tunable). `meta` carries `count` (items in this page) and " <>
+        "`has_more` (a `limit+1` look-ahead) for pagination. NOTE: `meta.total_count` is " <>
+        "DEPRECATED and always `null` on this endpoint — unlike sibling offset/limit " <>
+        "endpoints, an EXACT total here requires a full O(candidates²) pass that dominated " <>
+        "latency at scale (#202/#203), so it was removed; page via `has_more`. Role: agent+.",
     parameters: [
       min_distance: [
         in: :query,
@@ -72,6 +74,14 @@ defmodule LoopctlWeb.KnowledgeCreativityController do
                  has_more: %OpenApiSpex.Schema{
                    type: :boolean,
                    description: "More pairs exist beyond this page (limit+1 look-ahead)"
+                 },
+                 total_count: %OpenApiSpex.Schema{
+                   type: :integer,
+                   nullable: true,
+                   deprecated: true,
+                   description:
+                     "DEPRECATED — always null. An exact total pair count is an " <>
+                       "O(candidates²) cost (#202/#203); paginate via has_more instead."
                  }
                }
              }
@@ -103,7 +113,11 @@ defmodule LoopctlWeb.KnowledgeCreativityController do
         data: result.pairs,
         meta: %{
           count: length(result.pairs),
-          has_more: result.has_more
+          has_more: result.has_more,
+          # DEPRECATED, always null (#202/#203): kept as a null key for a backward-compat
+          # window so existing clients that read `meta.total_count` get null rather than a
+          # missing key. Computing an exact total is an O(candidates²) cost; page via has_more.
+          total_count: nil
         }
       })
     else

--- a/lib/loopctl_web/controllers/knowledge_creativity_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_creativity_controller.ex
@@ -28,12 +28,14 @@ defmodule LoopctlWeb.KnowledgeCreativityController do
       "Returns paginated pairs of articles whose embedding cosine distance is in the " <>
         "optimal-novelty band [`min_distance`, `max_distance`] (default 0.3–0.7) — the " <>
         "creative sweet spot. With `bridge_path=true`, only pairs also connected in the " <>
-        "link graph (≤2 hops) are returned. Agent callers see only their own and `shared` " <>
-        "articles. Each pair: `{a, b, distance}`. Samples up to " <>
+        "link graph (≤2 hops) are returned (that branch samples a smaller 500-article slice " <>
+        "so its per-pair graph check stays within budget). Agent callers see only their own " <>
+        "and `shared` articles. Each pair: `{a, b, distance}`. Samples up to " <>
         "1000 embedded published visible articles (lowest-id slice; operator-tunable). " <>
-        "`meta` carries `count`/`total_count`/`has_more` for pagination — `total_count` is " <>
-        "over the sampled visible slice, so it can undercount on tenants with >1000 embedded " <>
-        "articles. Role: agent+.",
+        "`meta` carries `count` (items in this page) and `has_more` (a `limit+1` look-ahead) " <>
+        "for pagination. No exact total-pair count is returned: computing it requires a full " <>
+        "O(candidates²) pass that dominated latency at scale (#202/#203); page via `has_more`. " <>
+        "Role: agent+.",
     parameters: [
       min_distance: [
         in: :query,
@@ -67,13 +69,9 @@ defmodule LoopctlWeb.KnowledgeCreativityController do
                type: :object,
                properties: %{
                  count: %OpenApiSpex.Schema{type: :integer, description: "Items in this page"},
-                 total_count: %OpenApiSpex.Schema{
-                   type: :integer,
-                   description: "Total matching pairs"
-                 },
                  has_more: %OpenApiSpex.Schema{
                    type: :boolean,
-                   description: "More pairs exist beyond this page"
+                   description: "More pairs exist beyond this page (limit+1 look-ahead)"
                  }
                }
              }
@@ -105,7 +103,6 @@ defmodule LoopctlWeb.KnowledgeCreativityController do
         data: result.pairs,
         meta: %{
           count: length(result.pairs),
-          total_count: result.total_count,
           has_more: result.has_more
         }
       })

--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to `loopctl-mcp-server` are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## Unreleased
+
+### Changed
+
+- **`knowledge_distant_pairs`** (`GET /api/v1/knowledge/pairs`) latency fix
+  (loopctl #202/#203): the endpoint no longer runs an exact-`total_count`
+  `count(*)` query — a full O(candidates²) pass over the sampled self-join that
+  could not early-terminate and was ~99% of the ~7.85s prod-scale latency. It now
+  returns the paginated page (a `limit+1` look-ahead) alone, well under the Epic 27
+  Theme 2 <2s target.
+
+### Deprecated
+
+- **`meta.total_count`** on `knowledge_distant_pairs` is **deprecated and now
+  always `null`.** The key is retained (not dropped) for a backward-compat window
+  so existing clients get `null` rather than a missing key, but an exact total is
+  no longer computed — it is an O(candidates²) cost. **Paginate via `meta.has_more`
+  instead.** (This differs from every sibling offset/limit endpoint, whose
+  `total_count` stays exact; the self-join's cost is what makes it special.)
+
+### Behavior change
+
+- **`bridge_path=true`** now samples a smaller candidate slice (default 500 vs the
+  general 1000) so its per-pair link-graph EXISTS check stays within the <2s budget
+  — so a `bridge_path=true` request may surface **fewer pairs** than before for the
+  same band. Operator-tunable via `max_bridge_pair_candidates`. `:offset` is also
+  now clamped to an operator-tunable ceiling (default 10_000) to bound deep-page cost.
+
 ## 2.30.1 — 2026-07-02 (arg-forwarding + apiCall robustness fixes)
 
 ### Fixed

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -2432,10 +2432,14 @@ const TOOLS = [
     description:
       "Find distant-but-bridgeable article pairs in the optimal-novelty embedding band " +
       "(cosine distance min..max, default 0.3–0.7) — the creative sweet spot (neither banal " +
-      "nor nonsense). Returns { data: [{a, b, distance}], meta:{count} }. With bridge_path:true, " +
-      "only pairs also connected in the link graph (≤2 hops) are returned. Samples up to 1000 " +
-      "embedded published articles; paginate via limit/offset. For computational-creativity " +
-      "ideation (remote-associates generator).",
+      "nor nonsense). Returns { data: [{a, b, distance}], meta:{count, has_more, total_count} }. " +
+      "Paginate via meta.has_more (a limit+1 look-ahead) — NOT total_count, which is DEPRECATED " +
+      "and always null here: unlike sibling offset/limit tools, an exact total is an " +
+      "O(candidates²) cost (the pair set is a column-to-column self-join), so it was removed for " +
+      "latency (loopctl #202/#203). With bridge_path:true, only pairs also connected in the link " +
+      "graph (≤2 hops) are returned — that branch samples a smaller candidate slice, so it may " +
+      "return fewer pairs. Samples up to 1000 embedded published articles (500 for bridge_path). " +
+      "For computational-creativity ideation (remote-associates generator).",
     inputSchema: {
       type: "object",
       properties: {

--- a/test/loopctl/knowledge/distant_pairs_novelty_scale_test.exs
+++ b/test/loopctl/knowledge/distant_pairs_novelty_scale_test.exs
@@ -48,10 +48,16 @@ defmodule Loopctl.Knowledge.DistantPairsNoveltyScaleTest do
   @moduletag :scale_nightly
   @moduletag timeout: :timer.minutes(30)
 
-  # The operator-tunable candidate cap (config/test.exs sets it to 25). The sampled
-  # candidate subquery — and therefore every `articles` base-table scan in distant_pairs —
-  # must read no more than this (with generous headroom for the planner's row estimate).
-  @max_pair_candidates Application.compile_env(:loopctl, :max_pair_candidates, 1_000)
+  # The operator-tunable candidate caps, read at RUNTIME (not `compile_env`): config/test.exs
+  # sets them CONDITIONALLY (small in the async suite, PROD defaults under the SCALE gate), so a
+  # `compile_env` module attribute would raise the compile-vs-runtime mismatch guard when the
+  # suite is compiled in one mode and run in the other. Under the SCALE gate these resolve to the
+  # PROD defaults (general 1000, bridge 500) so the cases are prod-shaped; every `articles`
+  # base-table scan in distant_pairs must read no more than the applicable cap.
+  defp max_pair_candidates, do: Application.get_env(:loopctl, :max_pair_candidates, 1_000)
+
+  defp max_bridge_pair_candidates,
+    do: Application.get_env(:loopctl, :max_bridge_pair_candidates, 500)
 
   # The tag ScaleSeed stamps on ~2% of rows (one of 50). Used as the novelty prior_tag so
   # the `tags &&` residual is genuinely selective at 80k.
@@ -142,15 +148,58 @@ defmodule Loopctl.Knowledge.DistantPairsNoveltyScaleTest do
         assert :ok = PlanAssertions.refute_seq_scan({sql, params})
 
         # The genuine bound is the `ORDER BY id LIMIT max_pair_candidates()` on the sampled
-        # candidate subquery — verified at 80k the candidate `Index Scan` is dominated by a
-        # `Limit rows=25` (actual consumed ≤25, ~1.7ms / ~1657 buffers — NOT an O(n²) corpus
-        # read; the scan node's pre-LIMIT `Plan Rows ≈ corpus` is just an estimate, so
-        # `assert_scan_rows_below` does NOT fit this shape). A regression that dropped the
-        # sample LIMIT leaves the scan with no dominating `Limit ≤ cap`, tripping this.
+        # candidate subquery — at 80k the candidate `Index Scan` is dominated by a
+        # `Limit rows ≤ cap` (actual consumed ≤ cap — NOT an O(n²) corpus read; the scan node's
+        # pre-LIMIT `Plan Rows ≈ corpus` is just an estimate, so `assert_scan_rows_below` does
+        # NOT fit this shape). A regression that dropped the sample LIMIT leaves the scan with
+        # no dominating `Limit ≤ cap`, tripping this.
         assert :ok =
                  PlanAssertions.assert_article_scans_capped_by_limit(
                    {sql, params},
-                   @max_pair_candidates
+                   max_pair_candidates()
+                 )
+      end
+    end)
+  end
+
+  # #202/#203 HIGH-2/HIGH-4: the bridge branch is the PR's main <2s mitigation (the smaller
+  # bridge candidate cap). Prove at PROD scale (80k, PROD 500 cap under the SCALE gate) that
+  # `bridge_path: true` (a) stays a SINGLE bounded band pass capped by max_bridge_pair_candidates
+  # (NOT the general cap — the bridge dispatch actually took effect) and (b) meets the Theme-2
+  # <2s wall-clock target. A revert of the bridge-branch dispatch (falling back to the 1000 cap)
+  # would blow both the cap assertion and the wall-clock budget.
+  test "distant_pairs(bridge_path: true) is bounded by the bridge cap AND under <2s at 80k",
+       %{tenant: tenant} do
+    unboxed(fn ->
+      # Wall-clock: the actual Theme-2 <2s claim at prod scale (not just the 1.5k local bench).
+      {elapsed_us, result} =
+        :timer.tc(fn -> Knowledge.distant_pairs(tenant.id, bridge_path: true) end)
+
+      assert {:ok, %{pairs: _, has_more: _}} = result
+
+      elapsed_ms = elapsed_us / 1_000
+
+      assert elapsed_ms < 2_000,
+             "bridge_path distant_pairs took #{Float.round(elapsed_ms, 1)}ms at 80k — over the " <>
+               "Epic 27 Theme 2 <2s target. Lower max_bridge_pair_candidates."
+
+      # Structural: exactly ONE band pass, no Seq Scan, and capped by the BRIDGE cap (500 under
+      # the SCALE gate) — proving the bridge dispatch selected the smaller sample.
+      captured =
+        PlanAssertions.capture_repo_queries(fn ->
+          {:ok, _} = Knowledge.distant_pairs(tenant.id, bridge_path: true)
+        end)
+
+      between = Enum.filter(captured, fn {sql, _} -> sql =~ ~r/BETWEEN/i end)
+      assert length(between) == 1
+
+      for {sql, params} <- between do
+        assert :ok = PlanAssertions.refute_seq_scan({sql, params})
+
+        assert :ok =
+                 PlanAssertions.assert_article_scans_capped_by_limit(
+                   {sql, params},
+                   max_bridge_pair_candidates()
                  )
       end
     end)

--- a/test/loopctl/knowledge/distant_pairs_novelty_scale_test.exs
+++ b/test/loopctl/knowledge/distant_pairs_novelty_scale_test.exs
@@ -21,9 +21,10 @@ defmodule Loopctl.Knowledge.DistantPairsNoveltyScaleTest do
   The bounds are checked under the planner's NATURAL choice (no enable_seqscan=off) against
   the committed, ANALYZEd ~80k corpus from `Loopctl.Knowledge.ScaleSeed`:
 
-    * distant_pairs: EXPLAIN on the ACTUAL count + pairs SQL the request path emits (captured
-      via `PlanAssertions.capture_repo_queries/1`), asserting the `Limit ≤ max_pair_candidates`
-      sample cap dominates every `articles` scan.
+    * distant_pairs: EXPLAIN on the ACTUAL pairs SQL the request path emits (captured via
+      `PlanAssertions.capture_repo_queries/1` — a SINGLE `LIMIT limit+1` page query post
+      #202/#203; the old companion `count(*)` full-pass is gone), asserting the
+      `Limit ≤ max_pair_candidates` sample cap dominates every `articles` scan.
     * novelty: EXPLAIN ANALYZE on `novelty_distance_query/4` (the MIN runs inside a
       `Task.async_stream`, off the test process, so capture can't see it — the builder emits
       the identical SQL+params), asserting ACTUAL `articles` rows stay bounded.
@@ -37,6 +38,7 @@ defmodule Loopctl.Knowledge.DistantPairsNoveltyScaleTest do
   alias Loopctl.AdminRepo
   alias Loopctl.Knowledge
   alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.ArticleLink
   alias Loopctl.Knowledge.ScaleSeed
   alias Loopctl.PlanAssertions
   alias Loopctl.Tenants.Tenant
@@ -99,6 +101,11 @@ defmodule Loopctl.Knowledge.DistantPairsNoveltyScaleTest do
     on_exit(fn ->
       try do
         unboxed(fn ->
+          # Delete links BEFORE articles: article_links has `on_delete: :restrict`, so
+          # deleting the seeded (linked) articles first raises an FK violation, which the
+          # rescue would swallow — leaving the whole ~80k committed corpus behind to
+          # pollute later runs of the shared test DB (a slow `find_orphan_articles` etc.).
+          AdminRepo.delete_all(from(l in ArticleLink, where: l.tenant_id == ^tenant.id))
           AdminRepo.delete_all(from(a in Article, where: a.tenant_id == ^tenant.id))
           AdminRepo.delete_all(from(t in Tenant, where: t.id == ^tenant.id))
         end)
@@ -120,12 +127,15 @@ defmodule Loopctl.Knowledge.DistantPairsNoveltyScaleTest do
           {:ok, _} = Knowledge.distant_pairs(tenant.id)
         end)
 
-      # BOTH emitted queries (the count and the paginated pairs) are the self-join with the
-      # `<=>` BETWEEN band; assert the bound on EACH.
+      # Post-#202/#203 the request path emits exactly ONE self-join carrying the `<=>`
+      # BETWEEN band — the paginated `LIMIT limit+1` page. The old companion `count(*)`
+      # query (a SECOND full O(candidates²) pass that could not early-terminate and was
+      # the entire prod-scale cost) is gone; asserting exactly 1 here is the scale-side
+      # regression guard against its reintroduction.
       between_queries =
         Enum.filter(captured, fn {sql, _} -> sql =~ ~r/BETWEEN/i end)
 
-      assert length(between_queries) == 2
+      assert length(between_queries) == 1
 
       for {sql, params} <- between_queries do
         # No Seq Scan over the corpus: the candidate subquery is reached via an Index Scan.

--- a/test/loopctl/knowledge/distant_pairs_novelty_test.exs
+++ b/test/loopctl/knowledge/distant_pairs_novelty_test.exs
@@ -18,6 +18,7 @@ defmodule Loopctl.Knowledge.DistantPairsNoveltyTest do
 
   alias Loopctl.AdminRepo
   alias Loopctl.Knowledge
+  alias Loopctl.PlanAssertions
 
   # Cosine measures DIRECTION. Two halves: a "base" axis and an "orthogonal" axis. A unit
   # vector at angle θ from base is `[cos θ on base-half, sin θ on orth-half]`. Cosine
@@ -58,8 +59,12 @@ defmodule Loopctl.Knowledge.DistantPairsNoveltyTest do
     end
 
     test "returns exactly the in-band pair with the correct distance and meta", ctx do
-      assert {:ok, %{pairs: [pair], total_count: 1, has_more: false}} =
+      assert {:ok, %{pairs: [pair], has_more: false} = result} =
                Knowledge.distant_pairs(ctx.tenant.id)
+
+      # #202/#203: no exact total-pair count is computed anymore (it was the O(n²)
+      # cost) — pagination is driven by `has_more` alone.
+      refute Map.has_key?(result, :total_count)
 
       # The single in-band pair is {a0, a60} (cos-dist 0.5). Ordered a.id < b.id.
       {lo, hi} = Enum.min_max([ctx.a0.id, ctx.a60.id])
@@ -73,23 +78,38 @@ defmodule Loopctl.Knowledge.DistantPairsNoveltyTest do
       article_with_embedding(other.id, embedding_at(0.0), %{})
       article_with_embedding(other.id, embedding_at(:math.pi() / 3), %{})
 
-      assert {:ok, %{pairs: pairs, total_count: total}} =
+      assert {:ok, %{pairs: pairs, has_more: false}} =
                Knowledge.distant_pairs(ctx.tenant.id)
 
       # Still exactly this tenant's single in-band pair, never the other tenant's.
-      assert total == 1
+      assert length(pairs) == 1
       ids = Enum.flat_map(pairs, &[&1.a.id, &1.b.id])
       assert Enum.sort(ids) == Enum.sort([ctx.a0.id, ctx.a60.id])
     end
 
     test "honors a tightened band (no in-band pair → empty)", ctx do
-      assert {:ok, %{pairs: [], total_count: 0, has_more: false}} =
+      assert {:ok, %{pairs: [], has_more: false}} =
                Knowledge.distant_pairs(ctx.tenant.id, min_distance: 0.8, max_distance: 0.9)
     end
 
     test "invalid band is rejected (unchanged contract)", ctx do
       assert {:error, :invalid_distance} =
                Knowledge.distant_pairs(ctx.tenant.id, min_distance: 0.7, max_distance: 0.3)
+    end
+
+    # #202/#203 regression guard: the request path must emit exactly ONE query that
+    # runs the `<=>` band filter over the candidate cross-join. The old shape ran a
+    # SECOND, count(*) query over the same O(candidates²) cross-join — a full pass
+    # that could not early-terminate and was the entire prod-scale latency cost. A
+    # reintroduction of any companion count/aggregate pass would push this back to 2.
+    test "computes the pair set in a SINGLE band pass (no companion count query)", ctx do
+      captured =
+        PlanAssertions.capture_repo_queries(fn ->
+          {:ok, _} = Knowledge.distant_pairs(ctx.tenant.id)
+        end)
+
+      band_queries = Enum.filter(captured, fn {sql, _} -> sql =~ ~r/BETWEEN/i end)
+      assert length(band_queries) == 1
     end
   end
 

--- a/test/loopctl/knowledge/distant_pairs_novelty_test.exs
+++ b/test/loopctl/knowledge/distant_pairs_novelty_test.exs
@@ -111,6 +111,36 @@ defmodule Loopctl.Knowledge.DistantPairsNoveltyTest do
       band_queries = Enum.filter(captured, fn {sql, _} -> sql =~ ~r/BETWEEN/i end)
       assert length(band_queries) == 1
     end
+
+    # #202/#203 MED-5: an unbounded offset defeats the page's early termination (Postgres must
+    # produce offset+limit+1 matching pairs before returning), so a huge offset could force
+    # near-full O(candidates²) evaluation. The offset is clamped to an operator-tunable ceiling.
+    test "clamps an out-of-range offset to the ceiling", ctx do
+      huge = 10_000_000
+      ceiling = Application.get_env(:loopctl, :max_pair_offset, 10_000)
+
+      captured =
+        PlanAssertions.capture_repo_queries(fn ->
+          {:ok, _} = Knowledge.distant_pairs(ctx.tenant.id, offset: huge)
+        end)
+
+      {_sql, params} = Enum.find(captured, fn {sql, _} -> sql =~ ~r/BETWEEN/i end)
+
+      # The emitted OFFSET is the clamped ceiling, never the caller's out-of-range value.
+      assert ceiling in params
+      refute huge in params
+    end
+  end
+
+  describe "candidate-cap invariant (#202/#203 MED-7)" do
+    test "effective bridge cap never exceeds the general cap (clamps a misconfig)" do
+      # A bridge cap larger than the general cap must clamp DOWN — a bigger bridge sample
+      # would make bridge_path SLOWER than the non-bridge path it is meant to bound.
+      assert Knowledge.effective_bridge_candidate_cap(700, 500) == 500
+      # A bridge cap already smaller than the general cap passes through unchanged.
+      assert Knowledge.effective_bridge_candidate_cap(300, 500) == 300
+      assert Knowledge.effective_bridge_candidate_cap(500, 500) == 500
+    end
   end
 
   describe "novelty_scores — scores unchanged after to_embedding_list normalization (TC-27.7b.2)" do

--- a/test/loopctl_web/controllers/knowledge_creativity_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_creativity_controller_test.exs
@@ -53,6 +53,32 @@ defmodule LoopctlWeb.KnowledgeCreativityControllerTest do
 
     defp pair_ids(pair), do: MapSet.new([pair["a"]["id"], pair["b"]["id"]])
 
+    # Page through EVERY pair for a band (limit=100) following `has_more`, returning the
+    # total number of pairs. Used to assert exact totals without a `total_count` field
+    # (removed in #202/#203 — an exact count was the O(n²) latency cost). `base_params`
+    # is a keyword list so `~p` encodes the query params correctly (interpolating a raw
+    # `"a=1&b=2"` string would URL-encode the `&`/`=`).
+    defp enumerate_all_pairs(conn, key, base_params),
+      do: enumerate_all_pairs(conn, key, base_params, 0, 0)
+
+    defp enumerate_all_pairs(conn, key, base_params, offset, acc) do
+      params = base_params ++ [limit: 100, offset: offset]
+
+      body =
+        conn
+        |> auth_conn(key)
+        |> get(~p"/api/v1/knowledge/pairs?#{params}")
+        |> json_response(200)
+
+      acc = acc + length(body["data"])
+
+      if body["meta"]["has_more"] do
+        enumerate_all_pairs(conn, key, base_params, offset + 100, acc)
+      else
+        acc
+      end
+    end
+
     test "returns only pairs whose cosine distance is inside the band", %{conn: conn} do
       {tenant, key} = setup_tenant_key()
       %{p: p, q: q, u: u} = band_fixture(tenant.id)
@@ -65,9 +91,11 @@ defmodule LoopctlWeb.KnowledgeCreativityControllerTest do
 
       pairs = body["data"]
       assert body["meta"]["count"] == length(pairs)
-      # P–Q and P–U
-      assert body["meta"]["total_count"] == 2
+      # P–Q and P–U — both fit on one page.
+      assert length(pairs) == 2
       assert body["meta"]["has_more"] == false
+      # #202/#203: no exact total-pair count is returned (it was the O(n²) cost).
+      refute Map.has_key?(body["meta"], "total_count")
       # Exactly the two in-band pairs P–Q and P–U; nothing involving T.
       assert MapSet.new(Enum.map(pairs, &pair_ids/1)) ==
                MapSet.new([MapSet.new([p.id, q.id]), MapSet.new([p.id, u.id])])
@@ -151,17 +179,15 @@ defmodule LoopctlWeb.KnowledgeCreativityControllerTest do
          %{conn: conn} do
       {tenant, key} = setup_tenant_key()
       # Test cap is 25 (config/test.exs). 26 identical-embedding articles → every pair
-      # is at distance 0; the band [0, 0.1] admits them all. total_count is C(25,2)=300
-      # if the cap truncated 26→25 candidates (vs C(26,2)=325 uncapped).
+      # is at distance 0; the band [0, 0.1] admits them all. Enumerating EVERY pair via
+      # pagination yields C(25,2)=300 if the cap truncated 26→25 candidates (vs
+      # C(26,2)=325 uncapped) — an exact-count-field-free way to prove the sample cap.
       for i <- 1..26, do: embedded(tenant.id, "Dup #{i}", [1.0, 0.0])
 
-      body =
-        conn
-        |> auth_conn(key)
-        |> get(~p"/api/v1/knowledge/pairs?min_distance=0&max_distance=0.1&limit=1")
-        |> json_response(200)
+      total =
+        enumerate_all_pairs(conn, key, min_distance: 0, max_distance: 0.1)
 
-      assert body["meta"]["total_count"] == 300
+      assert total == 300
     end
 
     test "paginates deterministically with limit/offset", %{conn: conn} do

--- a/test/loopctl_web/controllers/knowledge_creativity_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_creativity_controller_test.exs
@@ -94,8 +94,11 @@ defmodule LoopctlWeb.KnowledgeCreativityControllerTest do
       # P–Q and P–U — both fit on one page.
       assert length(pairs) == 2
       assert body["meta"]["has_more"] == false
-      # #202/#203: no exact total-pair count is returned (it was the O(n²) cost).
-      refute Map.has_key?(body["meta"], "total_count")
+      # #202/#203: total_count is DEPRECATED and always null — kept as a null key for a
+      # backward-compat window (existing clients get null, not a missing key); the exact
+      # count was the O(candidates²) cost. Paginate via has_more.
+      assert Map.has_key?(body["meta"], "total_count")
+      assert body["meta"]["total_count"] == nil
       # Exactly the two in-band pairs P–Q and P–U; nothing involving T.
       assert MapSet.new(Enum.map(pairs, &pair_ids/1)) ==
                MapSet.new([MapSet.new([p.id, q.id]), MapSet.new([p.id, u.id])])
@@ -188,6 +191,35 @@ defmodule LoopctlWeb.KnowledgeCreativityControllerTest do
         enumerate_all_pairs(conn, key, min_distance: 0, max_distance: 0.1)
 
       assert total == 300
+    end
+
+    test "bridge_path=true is governed by the smaller bridge candidate cap (#202/#203)",
+         %{conn: conn} do
+      {tenant, key} = setup_tenant_key()
+
+      # Async config: general cap 25, bridge cap 10 (config/test.exs). Seed `n` identical
+      # articles with bridge_cap < n <= general, star-linked so EVERY pair bridges (≤2 hops
+      # via the center), band [0,0.1] admitting all pairs. Enumerating all pairs then reveals
+      # WHICH cap governed each mode — proving the bridge branch uses the tighter cap (a revert
+      # of the bridge-branch dispatch would make both modes enumerate the same C(n,2)).
+      general = Application.get_env(:loopctl, :max_pair_candidates)
+      bridge_cap = Application.get_env(:loopctl, :max_bridge_pair_candidates)
+      assert bridge_cap < general, "bridge cap must be < general cap for this invariant to bind"
+      n = bridge_cap + 5
+      assert n <= general
+
+      [center | rest] = for i <- 1..n, do: embedded(tenant.id, "Dup #{i}", [1.0, 0.0])
+      for a <- rest, do: link(tenant.id, center, a)
+
+      non_bridge = enumerate_all_pairs(conn, key, min_distance: 0, max_distance: 0.1)
+
+      bridge =
+        enumerate_all_pairs(conn, key, min_distance: 0, max_distance: 0.1, bridge_path: true)
+
+      # Non-bridge samples all n (general cap doesn't bind at n); bridge samples only bridge_cap.
+      assert non_bridge == div(n * (n - 1), 2)
+      assert bridge == div(bridge_cap * (bridge_cap - 1), 2)
+      assert bridge < non_bridge
     end
 
     test "paginates deterministically with limit/offset", %{conn: conn} do

--- a/test/support/remediation_matrix.ex
+++ b/test/support/remediation_matrix.ex
@@ -98,11 +98,13 @@ defmodule Loopctl.RemediationMatrix do
   @prior_tag "scale-tag-3"
   @keyset_tag "scale-tag-7"
 
-  # The sampled-candidate LIMIT that bounds the distant_pairs self-join (SAME source as
-  # distant_pairs_novelty_scale_test.exs `@max_pair_candidates`). The genuine bound is this
-  # `Limit ≤ cap` on the candidate subquery — `refute_seq_scan` alone does NOT prove the
-  # O(n²) self-join is sample-bounded (the scan node's pre-LIMIT estimate ≈ corpus).
-  @max_pair_candidates Application.compile_env(:loopctl, :max_pair_candidates, 1_000)
+  # The sampled-candidate LIMIT that bounds the distant_pairs self-join. Read at RUNTIME (not
+  # `compile_env`) because config/test.exs now sets :max_pair_candidates CONDITIONALLY (small in
+  # the async suite, PROD default under the SCALE gate) — a `compile_env` attr would raise the
+  # compile-vs-runtime mismatch guard. The genuine bound is this `Limit ≤ cap` on the candidate
+  # subquery — `refute_seq_scan` alone does NOT prove the O(n²) self-join is sample-bounded (the
+  # scan node's pre-LIMIT estimate ≈ corpus).
+  defp max_pair_candidates, do: Application.get_env(:loopctl, :max_pair_candidates, 1_000)
 
   # The canonical, COMPLETE set of endpoint names this census must cover. The gate
   # asserts the built matrix's endpoint names equal this set, so a silently-dropped
@@ -310,12 +312,14 @@ defmodule Loopctl.RemediationMatrix do
         between =
           Enum.filter(captured, fn {sql, _} -> sql =~ ~r/BETWEEN/i end)
 
-        # BOTH emitted band queries (count + paginated pairs) must be present and bounded —
-        # matching the owning gate exactly so the census row's `:pass` means the same thing.
-        if length(between) != 2 do
+        # Exactly ONE emitted band query — the paginated `LIMIT limit+1` page. Post-#202/#203
+        # the companion `count(*)` band query (a second, non-early-terminating O(candidates²)
+        # pass) was removed; matching the owning gate exactly so the census row's `:pass` means
+        # the same thing (mirrors distant_pairs_novelty_scale_test.exs).
+        if length(between) != 1 do
           raise ExUnit.AssertionError,
             message:
-              "distant_pairs expected 2 BETWEEN (band) queries (count + pairs), got #{length(between)}"
+              "distant_pairs expected 1 BETWEEN (band) query (the paginated page), got #{length(between)}"
         end
 
         for {sql, params} <- between do
@@ -323,7 +327,11 @@ defmodule Loopctl.RemediationMatrix do
           # dominated by a `Limit ≤ max_pair_candidates` (refute_seq_scan alone wouldn't prove
           # the O(n²) self-join stays sampled — architect review F2 / BA LOW-1).
           PlanAssertions.refute_seq_scan({sql, params})
-          PlanAssertions.assert_article_scans_capped_by_limit({sql, params}, @max_pair_candidates)
+
+          PlanAssertions.assert_article_scans_capped_by_limit(
+            {sql, params},
+            max_pair_candidates()
+          )
         end
       end),
       asserted("novelty", :vector, fn ->


### PR DESCRIPTION
## Summary

`GET /api/v1/knowledge/pairs` → `Loopctl.Knowledge.distant_pairs/2` ran **~7.85s** at prod scale (76k), far over the Epic 27 Theme 2 **<2s** target, while every other vector endpoint is comfortably under. This PR brings it to **~7ms** (non-bridge) and **~1.3s** (bridge), without changing the distance-band semantics, pagination, tenant scoping, or the visibility/bridge_path options.

It stays a column-to-column self-join (both operands are stored columns; no `$const`, so HNSW cannot apply — this is the deliberate `CosineLintExceptions` registration for `do_distant_pairs/7`; **not** converted to `VectorSearch.nearest/4`).

## Root cause (profiled, not guessed)

`do_distant_pairs/7` issued **two** queries over the sampled self-join: a `count(*)` for an exact `total_count` **and** the paginated `LIMIT limit+1` page. My first hypothesis (merge them via `count(*) OVER ()`) turned out worthless once measured:

EXPLAIN ANALYZE, cap=1000, band 0.3–0.7, 1.5k-corpus (local M2):

| shape | root | pairs evaluated | buffers | exec |
|---|---|---|---|---|
| `count(*)` (removed) | Aggregate → Nested Loop | **1,000,000** (full O(candidates²)) | 6,896,026 | **2492 ms** |
| paginated `LIMIT 21` (kept) | Limit → Incremental Sort (Index Scan `articles_pkey`) → Nested Loop | **~106** (stops at 21 in-band) | 15,608 | **8.2 ms** |

The paginated page **already early-terminates**; the exact `count(*)` is the one pass that *cannot* (it must evaluate `<=>` for every one of the ~500k pairs). It was ~99% of the latency.

## Changes

1. **Remove the exact-count query.** The endpoint returns `count` + `has_more` (a `limit+1` look-ahead), no exact total. 304× faster, 442× fewer buffers on the O(candidates²) work; non-bridge endpoint ~7ms.
2. **Cap the `bridge_path=true` branch** at a smaller, operator-tunable sample (`max_bridge_pair_candidates`, default **500**; `config :loopctl, :max_bridge_pair_candidates`). Its per-pair link-graph EXISTS defeats the page's early termination on band-distant (rarely-bridged) pairs, so it needs a tighter O(cand²) bound: **5425ms → 1346ms**. Non-bridge keeps the full 1000 cap (already <10ms).

Measured (real function, cap defaults): non-bridge **7ms**; bridge **1346ms**; bridge offset=40 **1345ms**; bridge no-links **604ms**; bridge band[0,2] **919ms** — all well under 2s.

## ⚠️ API contract change

**`meta.total_count` is removed from the `/knowledge/pairs` response** (computing it was the entire latency cost). Paginate via `has_more`. Updated: the controller `meta`, the OpenAPI operation schema/description, the `distant_pairs/2` `@doc`+`@spec`, the unit + controller + scale tests, and the scale runbook. The MCP `knowledge_distant_pairs` tool already advertised `meta:{count}` only (no change needed).

## Tests

- Added a **single-band-pass regression guard** (unit, async suite + scale-nightly) asserting the request path emits exactly **one** `<=>` BETWEEN query, so the companion count pass can't return.
- Rewrote the cap-truncation controller test to enumerate all pairs via pagination (asserts C(25,2)=300) instead of reading the removed `total_count`.
- Unit/controller `total_count` assertions updated to `count`/`has_more`; added `refute Map.has_key?(meta, :total_count)`.
- **Scale-nightly gate (80k, natural planner) passes:** one BETWEEN query, no Seq Scan, scan capped by the sample `LIMIT`.
- Also fixed the scale test's `on_exit` to delete `article_links` **before** `articles` (the `on_delete: :restrict` article delete was raising and being rescued, orphaning the ~80k committed corpus in the shared test DB).

Full `mix precommit` green (compile --warnings-as-errors, format, credo --strict, dialyzer 0, 3555 tests 0 failures). Cosine lint untripped.

## Remaining gate

Final **prod-scale latency confirmation** (loopctl.com, 76k) is for @mkreyman to run via `fly ssh` / `AdminRepo.explain` — local measurement bounds the O(candidates²) work (corpus-independent at the candidate cap), but prod pgbouncer/pool timing is the last word.

Fixes #202, #203.
