### PR TITLE
feat(llm): per-tenant BYO Anthropic config + usage tracking (Epic 28, #179)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to loopctl are documented here.
 
+## [Unreleased] — 2026-07-03 — per-tenant BYO Anthropic LLM config + usage (Epic 28, #179)
+
+### Added
+
+- **Per-tenant BYO Anthropic config** — `GET` / `PATCH /api/v1/tenants/me/llm-config`
+  (role `:user`): each tenant supplies its OWN Anthropic API key (encrypted at rest,
+  never returned — only `has_api_key` + a last-4 hint) and picks a model per operation
+  (`extraction_model` / `classification_model` / `merge_model`). loopctl fronts no LLM
+  cost. Setting/rotating a key writes an audit event (without the value).
+- **Per-tenant LLM usage tracking** — `GET /api/v1/knowledge/llm-usage`
+  (role `:orchestrator`): token usage grouped by operation + model + source_type + day
+  over an optional date range, with offset/limit pagination (default 90-day lookback).
+  Record-only — no budget enforcement.
+
+### Changed — BREAKING (mandatory BYO)
+
+- **Tenant knowledge-LLM work now REQUIRES a per-tenant Anthropic key.** Content
+  ingestion, category classification, article merge, and review-finding extraction all
+  resolve the tenant's OWN key via `Loopctl.Llm.resolve/2` — there is **no**
+  global-system-key fallback. The global `ANTHROPIC_API_KEY` / `:anthropic_provider`
+  config path was removed.
+- With no key configured, `POST /knowledge/ingest[/batch]` returns **422** with
+  `code: "no_api_key"` and a remediation hint; the Oban workers `{:discard}` cleanly
+  (no crash, no retry loop). A `[:loopctl, :llm, :blocked]` telemetry event and an
+  `llm.blocked_no_api_key` audit entry are emitted when a tenant is blocked.
+  (Single-tenant today; no grace period — the operator sets a key.)
+
 ## [Unreleased] — 2026-06-30 — docs sync + agents'-KB endpoints backfill
 
 ### Added

--- a/config/config.exs
+++ b/config/config.exs
@@ -330,7 +330,8 @@ config :loopctl, :knowledge_proposal_overlap_threshold, 0.88
 config :loopctl, :knowledge_conflict_threshold, 0.93
 
 # Merge synthesizer (#4 step 2): the LLM that combines two articles a grounded agent
-# marked `:merge` into ONE draft. Reuses the shared :anthropic_provider key; drafts only.
+# marked `:merge` into ONE draft. Resolves the tenant's BYO Anthropic key per-tenant
+# via Loopctl.Llm.resolve/2 (Epic 28, #179); drafts only.
 config :loopctl, :merge_synthesizer, Loopctl.Knowledge.ClaudeMergeSynthesizer
 # Max `:relates_to`→`:potential_conflict` promotions the nightly lint sweep does per
 # tenant per run (bounds the existing-corpus backfill; it cycles over nights).

--- a/config/config.exs
+++ b/config/config.exs
@@ -219,6 +219,15 @@ config :tailwind,
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 
+# Redact secrets from Phoenix's request-parameter debug log (Epic 28, #179 review):
+# PATCH /api/v1/tenants/me/llm-config carries a raw `api_key` in its body. This
+# applies in ALL envs so the plaintext key can never surface in a param log even if
+# debug logging is enabled. (Cloak dumps the key before it reaches Ecto, so the SQL
+# log already shows ciphertext — this closes the Phoenix param-log path.)
+config :phoenix,
+       :filter_parameters,
+       {:discard, ["password", "api_key", "secret", "token", "authorization"]}
+
 # Override phoenix_ecto's Plug.Exception impls:
 # - CastError (default: 400 -> our: 404): an invalid UUID in a URL path means
 #   the resource cannot exist, hence 404 (see LoopctlWeb.Plugs.CastErrorHandler).

--- a/config/config.exs
+++ b/config/config.exs
@@ -221,9 +221,15 @@ config :phoenix, :json_library, Jason
 
 # Redact secrets from Phoenix's request-parameter debug log (Epic 28, #179 review):
 # PATCH /api/v1/tenants/me/llm-config carries a raw `api_key` in its body. This
-# applies in ALL envs so the plaintext key can never surface in a param log even if
-# debug logging is enabled. (Cloak dumps the key before it reaches Ecto, so the SQL
-# log already shows ciphertext — this closes the Phoenix param-log path.)
+# applies in ALL envs so the plaintext key can never surface in the Phoenix
+# "Parameters:" log line even if debug logging is enabled.
+#
+# NOTE (scope): this closes the PHOENIX PARAM-LOG path. Ecto's own :debug SQL-query
+# log still prints the plaintext value of ANY Cloak `Loopctl.Vault.Binary` field
+# (the existing webhook signing secret leaks identically — a pre-existing,
+# codebase-wide Ecto+Cloak logging behaviour, NOT specific to this feature). Prod
+# runs at :info, so :debug SQL logs never emit there; redacting encrypted-field
+# params from Ecto's logger is a separate cross-cutting change.
 config :phoenix,
        :filter_parameters,
        {:discard, ["password", "api_key", "secret", "token", "authorization"]}

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -198,22 +198,12 @@ if config_env() == :prod do
     }
   end
 
-  # Anthropic provider for knowledge extraction (content ingestion + review extraction)
-  if anthropic_key = System.get_env("ANTHROPIC_API_KEY") do
-    config :loopctl, :anthropic_provider, %{
-      api_key: anthropic_key,
-      base_url: System.get_env("ANTHROPIC_BASE_URL") || "https://api.anthropic.com/v1",
-      model: System.get_env("ANTHROPIC_EXTRACTION_MODEL") || "claude-haiku-4-5-20251001"
-    }
-  end
-
-  # Optional override for the reclassification classifier model, independent of
-  # the extraction model above. Set ANTHROPIC_CLASSIFIER_MODEL to e.g. a Sonnet id
-  # for a higher-accuracy one-time 77k reclassification; unset = the shared
-  # provider model (Haiku).
-  if classifier_model = System.get_env("ANTHROPIC_CLASSIFIER_MODEL") do
-    config :loopctl, :knowledge_classifier_model, classifier_model
-  end
+  # NOTE (Epic 28, #179): the global `:anthropic_provider` / `:knowledge_classifier_model`
+  # config keys were REMOVED. Tenant knowledge-LLM work (content extraction,
+  # classification, merge synthesis, review extraction) now resolves each tenant's
+  # OWN Anthropic key + per-operation model via `Loopctl.Llm.resolve/2` (mandatory
+  # BYO — no global-system-key fallback). There is intentionally no global
+  # ANTHROPIC_API_KEY path for tenant LLM work.
 
   # The secret key base is used to sign/encrypt cookies and other secrets.
   # A default value is used in config/dev.exs and config/test.exs but you

--- a/config/test.exs
+++ b/config/test.exs
@@ -322,6 +322,13 @@ config :loopctl, :enforce_witness_header, false
 # DI: Use Req.Test plug for content ingestion URL fetching in tests
 config :loopctl, :ingestion_req_plug, {Req.Test, Loopctl.Workers.ContentIngestionWorker}
 
+# Epic 28 (#179): route the tenant-scoped Anthropic client (Loopctl.Llm.Anthropic)
+# through a Req.Test plug so the real Claude extractor/classifier/merge modules —
+# including per-tenant key resolution and usage recording — are exercised without
+# real API calls. DataCase default-stubs it to an empty-articles response; the
+# dedicated LLM tests override with crafted content + usage blocks.
+config :loopctl, :anthropic_req_plug, {Req.Test, Loopctl.Llm.Anthropic}
+
 # DI: Use Req.Test plug for webhook delivery in tests
 config :loopctl, :webhook_req_plug, {Req.Test, Loopctl.Webhooks.ReqDelivery}
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -97,7 +97,13 @@ config :loopctl, :heavy_read_repo, Loopctl.AdminRepo
 #     asserts a :change_feed timeout, so this override cannot mask a real one.
 config :loopctl, :heavy_read_statement_timeout_overrides, %{
   suggested_links: 5_000,
-  change_feed: 5_000
+  change_feed: 5_000,
+  # Epic 28 (#179): the per-tenant LLM usage summary (GET /knowledge/llm-usage)
+  # routes through HeavyRead. On the small sandbox dataset it's sub-ms, but a
+  # generous 5s override keeps it from tripping the aggressive 250ms pool default
+  # under parallel contention (same rationale as :change_feed). No test asserts an
+  # :llm_usage timeout, so this cannot mask a real one.
+  llm_usage: 5_000
 }
 
 # US-27.6b: the over-fetch pool sizing knobs (`Loopctl.Knowledge.VectorSearch.pool_size/2`).

--- a/lib/loopctl/api_spec/schemas.ex
+++ b/lib/loopctl/api_spec/schemas.ex
@@ -2605,4 +2605,119 @@ defmodule Loopctl.ApiSpec.Schemas do
       }
     })
   end
+
+  # ---------- Per-tenant BYO LLM config + usage (Epic 28 residual, #179) ----------
+
+  defmodule LlmConfigUpdateRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "LlmConfigUpdateRequest",
+      description:
+        "Request body for `PUT /api/v1/tenants/me/llm-config`. Sets the tenant's " <>
+          "OWN Anthropic API key (encrypted at rest, never returned) and the " <>
+          "granular per-operation model choices. Any subset of fields may be sent; " <>
+          "omitting `api_key` leaves the existing key untouched. Model ids are " <>
+          "free-form (any model the key permits) — not restricted to an allow-list.",
+      type: :object,
+      properties: %{
+        api_key: %Schema{
+          type: :string,
+          writeOnly: true,
+          description: "Anthropic API key (write-only; stored encrypted, never returned)"
+        },
+        extraction_model: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Model id for knowledge extraction (null → server default)"
+        },
+        classification_model: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Model id for category classification (null → server default)"
+        },
+        merge_model: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Model id for article merge synthesis (null → server default)"
+        }
+      },
+      example: %{
+        api_key: "sk-ant-...",
+        extraction_model: "claude-haiku-4-5-20251001",
+        classification_model: "claude-sonnet-4-5-20250929",
+        merge_model: "claude-haiku-4-5-20251001"
+      }
+    })
+  end
+
+  defmodule LlmConfigResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "LlmConfigResponse",
+      description:
+        "The tenant's LLM configuration. NEVER includes the API key itself — only " <>
+          "whether one is set (`has_api_key`) and a last-4 hint (`api_key_hint`).",
+      type: :object,
+      properties: %{
+        has_api_key: %Schema{
+          type: :boolean,
+          description: "Whether an Anthropic key is configured"
+        },
+        api_key_hint: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Masked last-4 hint (e.g. \"...aB3d\"); never the full key"
+        },
+        extraction_model: %Schema{type: :string, nullable: true},
+        classification_model: %Schema{type: :string, nullable: true},
+        merge_model: %Schema{type: :string, nullable: true}
+      },
+      example: %{
+        has_api_key: true,
+        api_key_hint: "...aB3d",
+        extraction_model: "claude-haiku-4-5-20251001",
+        classification_model: "claude-sonnet-4-5-20250929",
+        merge_model: nil
+      }
+    })
+  end
+
+  defmodule LlmUsageResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "LlmUsageResponse",
+      description:
+        "Per-tenant LLM token-usage summary, grouped by operation + model + " <>
+          "source_type + day over an optional date range. Record-only — there is " <>
+          "no budget enforcement.",
+      type: :object,
+      properties: %{
+        data: %Schema{
+          type: :array,
+          items: %Schema{
+            type: :object,
+            properties: %{
+              day: %Schema{type: :string, format: :"date-time"},
+              operation: %Schema{
+                type: :string,
+                enum: ["extraction", "classification", "merge"]
+              },
+              model: %Schema{type: :string},
+              source_type: %Schema{type: :string, nullable: true},
+              input_tokens: %Schema{type: :integer},
+              output_tokens: %Schema{type: :integer},
+              event_count: %Schema{type: :integer}
+            }
+          }
+        },
+        meta: PaginationMeta
+      }
+    })
+  end
 end

--- a/lib/loopctl/api_spec/schemas.ex
+++ b/lib/loopctl/api_spec/schemas.ex
@@ -2686,6 +2686,25 @@ defmodule Loopctl.ApiSpec.Schemas do
     })
   end
 
+  defmodule LlmUsageMeta do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "LlmUsageMeta",
+      description:
+        "Offset/limit pagination metadata for the LLM usage summary. Advance " <>
+          "`offset` by `limit` to enumerate `total_count` grouped rows.",
+      type: :object,
+      properties: %{
+        limit: %Schema{type: :integer, description: "Effective page size (rows returned)"},
+        offset: %Schema{type: :integer, description: "Rows skipped"},
+        total_count: %Schema{type: :integer, description: "Total grouped rows across all pages"}
+      },
+      example: %{limit: 50, offset: 0, total_count: 3}
+    })
+  end
+
   defmodule LlmUsageResponse do
     @moduledoc false
     require OpenApiSpex
@@ -2716,7 +2735,7 @@ defmodule Loopctl.ApiSpec.Schemas do
             }
           }
         },
-        meta: PaginationMeta
+        meta: LlmUsageMeta
       }
     })
   end

--- a/lib/loopctl/api_spec/schemas.ex
+++ b/lib/loopctl/api_spec/schemas.ex
@@ -2615,7 +2615,7 @@ defmodule Loopctl.ApiSpec.Schemas do
     OpenApiSpex.schema(%{
       title: "LlmConfigUpdateRequest",
       description:
-        "Request body for `PUT /api/v1/tenants/me/llm-config`. Sets the tenant's " <>
+        "Request body for `PATCH /api/v1/tenants/me/llm-config`. Sets the tenant's " <>
           "OWN Anthropic API key (encrypted at rest, never returned) and the " <>
           "granular per-operation model choices. Any subset of fields may be sent; " <>
           "omitting `api_key` leaves the existing key untouched. Model ids are " <>
@@ -2693,15 +2693,34 @@ defmodule Loopctl.ApiSpec.Schemas do
     OpenApiSpex.schema(%{
       title: "LlmUsageMeta",
       description:
-        "Offset/limit pagination metadata for the LLM usage summary. Advance " <>
-          "`offset` by `limit` to enumerate `total_count` grouped rows.",
+        "Offset/limit pagination metadata for the LLM usage summary, plus the " <>
+          "EFFECTIVE date window actually applied. Advance `offset` by `limit` to " <>
+          "enumerate `total_count` grouped rows. When `from` is omitted it defaults " <>
+          "to a 90-day lookback (echoed here so callers can detect the truncation).",
       type: :object,
       properties: %{
         limit: %Schema{type: :integer, description: "Effective page size (rows returned)"},
         offset: %Schema{type: :integer, description: "Rows skipped"},
-        total_count: %Schema{type: :integer, description: "Total grouped rows across all pages"}
+        total_count: %Schema{type: :integer, description: "Total grouped rows across all pages"},
+        from: %Schema{
+          type: :string,
+          format: :"date-time",
+          description: "Effective lower bound applied (defaults to now − 90 days when omitted)"
+        },
+        to: %Schema{
+          type: :string,
+          format: :"date-time",
+          nullable: true,
+          description: "Effective upper bound applied (null = open-ended / now)"
+        }
       },
-      example: %{limit: 50, offset: 0, total_count: 3}
+      example: %{
+        limit: 50,
+        offset: 0,
+        total_count: 3,
+        from: "2026-04-04T00:00:00Z",
+        to: nil
+      }
     })
   end
 

--- a/lib/loopctl/artifacts/review_record.ex
+++ b/lib/loopctl/artifacts/review_record.ex
@@ -92,6 +92,11 @@ defmodule Loopctl.Artifacts.ReviewRecord do
     ])
     |> validate_required([:review_type, :completed_at])
     |> validate_length(:review_type, min: 1)
+    # Bound the summary length (Epic 28, #179 review). The summary is fed verbatim
+    # into the BYO review-knowledge LLM extraction, so an unbounded summary is an
+    # unbounded per-call token (cost) surface. 16k chars is generous for a real
+    # review summary while capping the extraction input.
+    |> validate_length(:summary, max: 16_000)
     |> validate_number(:findings_count, greater_than_or_equal_to: 0)
     |> validate_number(:fixes_count, greater_than_or_equal_to: 0)
     |> validate_number(:disproved_count, greater_than_or_equal_to: 0)

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -3450,9 +3450,19 @@ defmodule Loopctl.Knowledge do
   `:dismiss` needs no execution (recorded complete on annotate). Bounded per run via
   `opts[:limit]`. Returns the count applied.
   """
+  # Default wall-clock budget for ONE executor run. `:merge` rows each make an LLM
+  # synthesis call (up to ~110s worst case with the merge client's 55s x 1-retry
+  # budget), so an unbounded 200-row loop could pin a shared `:knowledge` queue slot
+  # for hours and starve other tenants' ingestion/review/reclassify jobs (review #4).
+  # A run applies rows until this budget elapses; the remainder (still
+  # `executed_at IS NULL`) is picked up by the next nightly run. Config-overridable.
+  @default_execute_budget_ms 120_000
+
   @spec execute_conflict_resolutions(Ecto.UUID.t(), keyword()) :: non_neg_integer()
   def execute_conflict_resolutions(tenant_id, opts \\ []) do
     limit = Keyword.get(opts, :limit, 200)
+    budget_ms = Keyword.get(opts, :budget_ms, execute_budget_ms())
+    deadline = System.monotonic_time(:millisecond) + budget_ms
 
     rows =
       from(r in ConflictResolution,
@@ -3464,9 +3474,26 @@ defmodule Loopctl.Knowledge do
       )
       |> AdminRepo.all()
 
-    Enum.reduce(rows, 0, fn r, count ->
-      if apply_resolution(tenant_id, r), do: count + 1, else: count
+    Enum.reduce_while(rows, 0, fn r, count ->
+      if System.monotonic_time(:millisecond) >= deadline do
+        Logger.info(
+          "ConflictExecutor: tenant=#{tenant_id} hit the #{budget_ms}ms execute budget " <>
+            "after #{count} resolution(s); remainder left for the next run."
+        )
+
+        {:halt, count}
+      else
+        {:cont, if(apply_resolution(tenant_id, r), do: count + 1, else: count)}
+      end
     end)
+  end
+
+  defp execute_budget_ms do
+    Application.get_env(
+      :loopctl,
+      :knowledge_conflict_execute_budget_ms,
+      @default_execute_budget_ms
+    )
   end
 
   # kb-02 FIX B (TOCTOU): the flag is checked at annotate time, but a :user may DELETE
@@ -3579,13 +3606,42 @@ defmodule Loopctl.Knowledge do
       {:ok, %{title: title, body: body}} ->
         create_merged_draft(tenant_id, r, a, title, body)
 
-      # No backend / unparseable → leave unexecuted so a later run (or config) retries;
-      # NEVER draft a placeholder.
       {:error, reason} ->
-        Logger.warning("ConflictExecutor: merge synthesis failed for #{r.id}: #{inspect(reason)}")
-        false
+        handle_merge_error(r, reason)
     end
   end
+
+  # PERMANENT synthesis errors (non-408/429 4xx, unparseable output) must NOT be
+  # left to retry every nightly run — that re-bills the tenant's paid Anthropic
+  # call each time (review #6). Mark them executed with a distinct queryable
+  # `failed` result. TRANSIENT errors (5xx/408/429/request_failed) are left
+  # unexecuted so a later run legitimately retries. NEVER draft a placeholder.
+  defp handle_merge_error(%ConflictResolution{} = r, reason) do
+    if permanent_merge_error?(reason) do
+      Logger.warning(
+        "ConflictExecutor: merge synthesis PERMANENTLY failed for #{r.id} " <>
+          "(#{inspect(reason)}); marking failed (not retrying)."
+      )
+
+      mark_resolution_executed(r, %{"action" => "failed", "reason" => inspect(reason)})
+    else
+      Logger.warning(
+        "ConflictExecutor: merge synthesis transiently failed for #{r.id} " <>
+          "(#{inspect(reason)}); leaving for retry."
+      )
+    end
+
+    false
+  end
+
+  defp permanent_merge_error?(:unparseable_merge), do: true
+
+  defp permanent_merge_error?({:api_error, status, _body})
+       when is_integer(status) and status >= 400 and status < 500 and status != 408 and
+              status != 429,
+       do: true
+
+  defp permanent_merge_error?(_), do: false
 
   defp create_merged_draft(tenant_id, r, source_a, title, body) do
     attrs = %{

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -3545,6 +3545,20 @@ defmodule Loopctl.Knowledge do
   end
 
   defp apply_merge(tenant_id, %ConflictResolution{} = r) do
+    # Mandatory BYO (Epic 28, #179): merge synthesis runs on the tenant's OWN
+    # Anthropic key. Without one, DON'T silently retry every run — mark the
+    # resolution executed with a DISTINCT, queryable "skipped/no_api_key" marker
+    # (not a false "merged" state) and record the block (review #10).
+    if Loopctl.Llm.has_api_key?(tenant_id) do
+      merge_source_articles(tenant_id, r)
+    else
+      Loopctl.Llm.record_blocked(tenant_id, :merge)
+      mark_resolution_executed(r, %{"action" => "skipped", "reason" => "no_api_key"})
+      false
+    end
+  end
+
+  defp merge_source_articles(tenant_id, %ConflictResolution{} = r) do
     a = AdminRepo.get_by(Article, id: r.source_article_id, tenant_id: tenant_id)
     b = AdminRepo.get_by(Article, id: r.target_article_id, tenant_id: tenant_id)
 

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -3558,6 +3558,7 @@ defmodule Loopctl.Knowledge do
 
   defp do_merge(tenant_id, r, a, b) do
     case merge_synthesizer().synthesize(
+           tenant_id,
            %{title: a.title, body: a.body},
            %{title: b.title, body: b.body}
          ) do

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -3470,6 +3470,14 @@ defmodule Loopctl.Knowledge do
         where: is_nil(r.executed_at),
         where: r.disposition in [:supersede, :merge],
         where: r.confidence == :high,
+        # Deterministic OLDEST-first order (review round 4): without it Postgres can
+        # return the same subset in the same arbitrary order every run, so a backlog
+        # that exceeds the wall-clock budget would forever apply the same head rows and
+        # NEVER reach the tail (permanently stuck at executed_at IS NULL, contradicting
+        # the "remainder picked up next run" invariant). Oldest-first guarantees each
+        # budgeted run makes forward progress toward the tail; the `id` tiebreaker keeps
+        # the order TOTAL across equal `inserted_at` so no row is ever indefinitely skipped.
+        order_by: [asc: r.inserted_at, asc: r.id],
         limit: ^limit
       )
       |> AdminRepo.all()

--- a/lib/loopctl/knowledge/classifier_behaviour.ex
+++ b/lib/loopctl/knowledge/classifier_behaviour.ex
@@ -15,6 +15,6 @@ defmodule Loopctl.Knowledge.ClassifierBehaviour do
 
   @type result :: %{required(:category) => atom(), required(:confidence) => float()}
 
-  @callback classify(title :: String.t(), body :: String.t()) ::
-              {:ok, result()} | {:error, term()}
+  @callback classify(tenant_id :: Ecto.UUID.t(), title :: String.t(), body :: String.t()) ::
+              {:ok, result()} | {:error, :no_api_key} | {:error, term()}
 end

--- a/lib/loopctl/knowledge/classifier_behaviour.ex
+++ b/lib/loopctl/knowledge/classifier_behaviour.ex
@@ -15,6 +15,19 @@ defmodule Loopctl.Knowledge.ClassifierBehaviour do
 
   @type result :: %{required(:category) => atom(), required(:confidence) => float()}
 
-  @callback classify(tenant_id :: Ecto.UUID.t(), title :: String.t(), body :: String.t()) ::
+  @doc """
+  Classify one article into a single active category.
+
+  `opts` may carry pre-resolved credentials `:api_key` + `:model` so a batched
+  caller can resolve the tenant's key ONCE and thread it through many calls
+  (review #19), avoiding a per-article `Loopctl.Llm.resolve/2` DB read. When
+  absent, the implementation resolves per call.
+  """
+  @callback classify(
+              tenant_id :: Ecto.UUID.t(),
+              title :: String.t(),
+              body :: String.t(),
+              opts :: keyword()
+            ) ::
               {:ok, result()} | {:error, :no_api_key} | {:error, term()}
 end

--- a/lib/loopctl/knowledge/claude_category_classifier.ex
+++ b/lib/loopctl/knowledge/claude_category_classifier.ex
@@ -37,7 +37,7 @@ defmodule Loopctl.Knowledge.ClaudeCategoryClassifier do
   @max_body_chars 16_000
 
   @impl true
-  def classify(tenant_id, title, body) do
+  def classify(tenant_id, title, body, opts \\ []) do
     user_content = "Title: #{title}\n\nBody:\n#{String.slice(body || "", 0, @max_body_chars)}"
 
     body_fun = fn _model ->
@@ -48,10 +48,22 @@ defmodule Loopctl.Knowledge.ClaudeCategoryClassifier do
       }
     end
 
-    case Anthropic.message(tenant_id, :classification, body_fun) do
+    case classify_via(tenant_id, opts, body_fun) do
       {:ok, text} -> parse_text(text)
       {:error, :no_api_key} -> {:error, :no_api_key}
       {:error, _} = err -> err
+    end
+  end
+
+  # Use pre-resolved credentials when the caller supplied them (batched callers
+  # resolve once — review #19); otherwise resolve per call.
+  defp classify_via(tenant_id, opts, body_fun) do
+    case {opts[:api_key], opts[:model]} do
+      {api_key, model} when is_binary(api_key) and is_binary(model) ->
+        Anthropic.call(tenant_id, :classification, api_key, model, body_fun)
+
+      _ ->
+        Anthropic.message(tenant_id, :classification, body_fun)
     end
   end
 

--- a/lib/loopctl/knowledge/claude_category_classifier.ex
+++ b/lib/loopctl/knowledge/claude_category_classifier.ex
@@ -2,10 +2,12 @@ defmodule Loopctl.Knowledge.ClaudeCategoryClassifier do
   @moduledoc """
   Anthropic Claude-backed implementation of `Loopctl.Knowledge.ClassifierBehaviour`.
 
-  Reuses the shared `:anthropic_provider` config (same key as the extractors).
-  When no API key is configured it returns `{:error, :not_configured}` so the
-  reclassification backfill degrades gracefully (it never mutates data with a
-  placeholder verdict) in environments without Anthropic access.
+  Per-tenant BYO (Epic 28 residual, #179): the Anthropic key + classification
+  model are resolved via `Loopctl.Llm.resolve(tenant_id, :classification)`. When
+  the tenant has no key it returns `{:error, :no_api_key}` so the reclassification
+  backfill degrades gracefully (it never mutates data with a placeholder verdict).
+  Token usage is recorded after a successful call via the shared
+  `Loopctl.Llm.Anthropic` client.
 
   Only ACTIVE categories are ever returned — the model is never offered the
   retired `convention`, so a reclassification can only move an article ONTO the
@@ -17,6 +19,7 @@ defmodule Loopctl.Knowledge.ClaudeCategoryClassifier do
   require Logger
 
   alias Loopctl.Knowledge.Categories
+  alias Loopctl.Llm.Anthropic
 
   @system_prompt """
   You classify one knowledge-base article into exactly one category. Allowed \
@@ -34,52 +37,21 @@ defmodule Loopctl.Knowledge.ClaudeCategoryClassifier do
   @max_body_chars 16_000
 
   @impl true
-  def classify(title, body) do
-    config = Application.get_env(:loopctl, :anthropic_provider, %{})
-    api_key = config[:api_key] || ""
-
-    if api_key == "" do
-      {:error, :not_configured}
-    else
-      call_anthropic(title, body, config)
-    end
-  end
-
-  defp call_anthropic(title, body, config) do
-    base_url = config[:base_url] || "https://api.anthropic.com/v1"
-
-    # Classification can use a STRONGER model than content extraction without
-    # changing extraction: :knowledge_classifier_model wins, else the shared
-    # provider model, else Haiku. Set ANTHROPIC_CLASSIFIER_MODEL in prod to
-    # override (e.g. a Sonnet id) for the one-time 77k reclassification.
-    model =
-      Application.get_env(:loopctl, :knowledge_classifier_model) ||
-        config[:model] || "claude-haiku-4-5-20251001"
-
+  def classify(tenant_id, title, body) do
     user_content = "Title: #{title}\n\nBody:\n#{String.slice(body || "", 0, @max_body_chars)}"
 
-    req_body = %{
-      model: model,
-      max_tokens: 100,
-      system: @system_prompt,
-      messages: [%{role: "user", content: user_content}]
-    }
+    body_fun = fn _model ->
+      %{
+        max_tokens: 100,
+        system: @system_prompt,
+        messages: [%{role: "user", content: user_content}]
+      }
+    end
 
-    case Req.post("#{base_url}/messages",
-           json: req_body,
-           headers: [
-             {"x-api-key", config[:api_key]},
-             {"anthropic-version", "2023-06-01"}
-           ]
-         ) do
-      {:ok, %{status: 200, body: resp}} ->
-        parse_text(get_in(resp, ["content", Access.at(0), "text"]))
-
-      {:ok, %{status: status}} ->
-        {:error, {:http_status, status}}
-
-      {:error, reason} ->
-        {:error, reason}
+    case Anthropic.message(tenant_id, :classification, body_fun) do
+      {:ok, text} -> parse_text(text)
+      {:error, :no_api_key} -> {:error, :no_api_key}
+      {:error, _} = err -> err
     end
   end
 

--- a/lib/loopctl/knowledge/claude_content_extractor.ex
+++ b/lib/loopctl/knowledge/claude_content_extractor.ex
@@ -51,7 +51,14 @@ defmodule Loopctl.Knowledge.ClaudeContentExtractor do
       }
     end
 
-    case Anthropic.message(tenant_id, :extraction, body_fun, %{source_type: source_type}) do
+    # Explicit client budget UNDER the worker's @per_chunk_timeout_ms (30s) Oban
+    # budget (review #9) — the highest-max_tokens (64k) site, so don't rely on the
+    # shared default. 25s + no internal retry keeps the whole request inside the
+    # per-chunk budget; the worker retries the whole (idempotent) job on transients.
+    case Anthropic.message(tenant_id, :extraction, body_fun, %{source_type: source_type},
+           receive_timeout: 25_000,
+           max_retries: 0
+         ) do
       {:ok, text} -> parse_articles(text)
       {:error, :no_api_key} -> {:error, :no_api_key}
       {:error, _} = err -> err

--- a/lib/loopctl/knowledge/claude_content_extractor.ex
+++ b/lib/loopctl/knowledge/claude_content_extractor.ex
@@ -5,15 +5,14 @@ defmodule Loopctl.Knowledge.ClaudeContentExtractor do
   Calls the Anthropic Messages API to extract structured knowledge articles
   from raw content (web articles, newsletters, skill templates, etc.).
 
-  ## Configuration
+  ## Per-tenant BYO (Epic 28 residual, #179)
 
-  Set the following in runtime config (via `ANTHROPIC_API_KEY` env var):
-
-      config :loopctl, :anthropic_provider, %{
-        api_key: "sk-ant-...",
-        base_url: "https://api.anthropic.com/v1",
-        model: "claude-haiku-4-5-20251001"
-      }
+  The Anthropic key + extraction model are resolved PER TENANT via
+  `Loopctl.Llm.resolve(tenant_id, :extraction)` — each tenant supplies its own
+  key and pays Anthropic directly. A tenant with no key gets `{:error,
+  :no_api_key}` (mandatory BYO — no global fallback). Token usage is recorded
+  after a successful call. The shared `Loopctl.Llm.Anthropic` client owns the
+  resolve → POST → record_usage flow.
   """
 
   @behaviour Loopctl.Knowledge.ContentExtractorBehaviour
@@ -21,6 +20,7 @@ defmodule Loopctl.Knowledge.ClaudeContentExtractor do
   require Logger
 
   alias Loopctl.Knowledge.Categories
+  alias Loopctl.Llm.Anthropic
 
   @system_prompt """
   You are a knowledge extraction assistant. Given raw content (web article, \
@@ -35,51 +35,26 @@ defmodule Loopctl.Knowledge.ClaudeContentExtractor do
   """
 
   @impl true
-  def extract_from_content(content, opts \\ []) do
-    config = Application.get_env(:loopctl, :anthropic_provider, %{})
-    api_key = config[:api_key] || ""
-    base_url = config[:base_url] || "https://api.anthropic.com/v1"
-    model = config[:model] || "claude-haiku-4-5-20251001"
-
+  def extract_from_content(tenant_id, content, opts \\ []) do
     source_type = Keyword.get(opts, :source_type, "unknown")
 
-    body = %{
-      model: model,
-      max_tokens: 64_000,
-      system: @system_prompt,
-      messages: [
-        %{
-          role: "user",
-          content: "Source type: #{source_type}\n\nContent:\n#{content}"
-        }
-      ]
-    }
+    body_fun = fn _model ->
+      %{
+        max_tokens: 64_000,
+        system: @system_prompt,
+        messages: [
+          %{
+            role: "user",
+            content: "Source type: #{source_type}\n\nContent:\n#{content}"
+          }
+        ]
+      }
+    end
 
-    case Req.post("#{base_url}/messages",
-           json: body,
-           headers: [
-             {"x-api-key", api_key},
-             {"anthropic-version", "2023-06-01"}
-           ],
-           retry: :transient,
-           max_retries: 2,
-           receive_timeout: 60_000
-         ) do
-      {:ok, %{status: 200, body: %{"content" => [%{"text" => text} | _]}}} ->
-        parse_articles(text)
-
-      {:ok, %{status: status, body: resp_body}} ->
-        Logger.warning(
-          "ClaudeContentExtractor: API error " <>
-            "(status=#{status}, body=#{inspect(resp_body)})"
-        )
-
-        {:error, {:api_error, status, resp_body}}
-
-      {:error, reason} ->
-        Logger.warning("ClaudeContentExtractor: request failed (error=#{inspect(reason)})")
-
-        {:error, {:request_failed, reason}}
+    case Anthropic.message(tenant_id, :extraction, body_fun, %{source_type: source_type}) do
+      {:ok, text} -> parse_articles(text)
+      {:error, :no_api_key} -> {:error, :no_api_key}
+      {:error, _} = err -> err
     end
   end
 

--- a/lib/loopctl/knowledge/claude_merge_synthesizer.ex
+++ b/lib/loopctl/knowledge/claude_merge_synthesizer.ex
@@ -42,7 +42,12 @@ defmodule Loopctl.Knowledge.ClaudeMergeSynthesizer do
       }
     end
 
-    case Anthropic.message(tenant_id, :merge, body_fun) do
+    # Merge is a larger synthesis with no tight outer timeout; give it a slightly
+    # longer bounded client budget (review #5).
+    case Anthropic.message(tenant_id, :merge, body_fun, %{},
+           receive_timeout: 55_000,
+           max_retries: 1
+         ) do
       {:ok, text} -> parse_text(text)
       {:error, :no_api_key} -> {:error, :no_api_key}
       {:error, _} = err -> err

--- a/lib/loopctl/knowledge/claude_merge_synthesizer.ex
+++ b/lib/loopctl/knowledge/claude_merge_synthesizer.ex
@@ -3,14 +3,19 @@ defmodule Loopctl.Knowledge.ClaudeMergeSynthesizer do
   Anthropic Claude-backed `MergeSynthesizerBehaviour`. Combines two overlapping
   knowledge articles into one, preserving every distinct fact and reconciling wording.
 
-  Reuses the shared `:anthropic_provider` config (same key as the classifier/extractors).
-  With no API key it returns `{:error, :not_configured}`, so the merge executor degrades
-  gracefully (leaves the `:merge` resolution unexecuted) rather than drafting a placeholder.
+  Per-tenant BYO (Epic 28 residual, #179): the Anthropic key + merge model are
+  resolved via `Loopctl.Llm.resolve(tenant_id, :merge)`. With no key it returns
+  `{:error, :no_api_key}`, so the merge executor degrades gracefully (leaves the
+  `:merge` resolution unexecuted) rather than drafting a placeholder. Token usage
+  is recorded after a successful call via the shared `Loopctl.Llm.Anthropic`
+  client.
   """
 
   @behaviour Loopctl.Knowledge.MergeSynthesizerBehaviour
 
   require Logger
+
+  alias Loopctl.Llm.Anthropic
 
   @system_prompt """
   You merge TWO overlapping knowledge-base articles into ONE. Preserve every distinct \
@@ -24,50 +29,23 @@ defmodule Loopctl.Knowledge.ClaudeMergeSynthesizer do
   @max_body_chars 12_000
 
   @impl true
-  def synthesize(a, b) do
-    config = Application.get_env(:loopctl, :anthropic_provider, %{})
-    api_key = config[:api_key] || ""
-
-    if api_key == "" do
-      {:error, :not_configured}
-    else
-      call_anthropic(a, b, config)
-    end
-  end
-
-  defp call_anthropic(a, b, config) do
-    base_url = config[:base_url] || "https://api.anthropic.com/v1"
-
-    model =
-      Application.get_env(:loopctl, :knowledge_merge_model) ||
-        config[:model] || "claude-haiku-4-5-20251001"
-
+  def synthesize(tenant_id, a, b) do
     user_content =
       "ARTICLE A\nTitle: #{a.title}\n\nBody:\n#{clip(a.body)}\n\n" <>
         "ARTICLE B\nTitle: #{b.title}\n\nBody:\n#{clip(b.body)}"
 
-    req_body = %{
-      model: model,
-      max_tokens: 2000,
-      system: @system_prompt,
-      messages: [%{role: "user", content: user_content}]
-    }
+    body_fun = fn _model ->
+      %{
+        max_tokens: 2000,
+        system: @system_prompt,
+        messages: [%{role: "user", content: user_content}]
+      }
+    end
 
-    case Req.post("#{base_url}/messages",
-           json: req_body,
-           headers: [
-             {"x-api-key", config[:api_key]},
-             {"anthropic-version", "2023-06-01"}
-           ]
-         ) do
-      {:ok, %{status: 200, body: resp}} ->
-        parse_text(get_in(resp, ["content", Access.at(0), "text"]))
-
-      {:ok, %{status: status}} ->
-        {:error, {:http_status, status}}
-
-      {:error, reason} ->
-        {:error, reason}
+    case Anthropic.message(tenant_id, :merge, body_fun) do
+      {:ok, text} -> parse_text(text)
+      {:error, :no_api_key} -> {:error, :no_api_key}
+      {:error, _} = err -> err
     end
   end
 

--- a/lib/loopctl/knowledge/content_extractor_behaviour.ex
+++ b/lib/loopctl/knowledge/content_extractor_behaviour.ex
@@ -23,14 +23,23 @@ defmodule Loopctl.Knowledge.ContentExtractorBehaviour do
 
   ## Parameters
 
+  - `tenant_id` -- the tenant whose BYO Anthropic key + extraction model to use.
+    The implementation resolves the tenant's key via `Loopctl.Llm.resolve/2` and
+    records token usage after a successful call.
   - `content` -- raw text content to extract knowledge from
   - `opts` -- keyword list of options (e.g., `source_type: "newsletter"`)
 
   ## Returns
 
   - `{:ok, articles}` -- list of article attribute maps
+  - `{:error, :no_api_key}` -- the tenant has no Anthropic key configured
+    (mandatory BYO); the caller must fail cleanly (422 / `{:discard}`)
   - `{:error, reason}` -- extraction failure (triggers Oban retry)
   """
-  @callback extract_from_content(content :: String.t(), opts :: keyword()) ::
-              {:ok, [article_attrs()]} | {:error, term()}
+  @callback extract_from_content(
+              tenant_id :: Ecto.UUID.t(),
+              content :: String.t(),
+              opts :: keyword()
+            ) ::
+              {:ok, [article_attrs()]} | {:error, :no_api_key} | {:error, term()}
 end

--- a/lib/loopctl/knowledge/extractor_behaviour.ex
+++ b/lib/loopctl/knowledge/extractor_behaviour.ex
@@ -6,8 +6,9 @@ defmodule Loopctl.Knowledge.ExtractorBehaviour do
   (story, review type, findings, summary) and return a list of
   article attribute maps suitable for `Article.create_changeset/2`.
 
-  The default production implementation (`LlmExtractor`) is a stub
-  that returns an empty list until LLM integration is built.
+  The default production implementation (`LlmExtractor`) calls the Anthropic
+  Messages API using the TENANT's own BYO key (Epic 28, #179) and records token
+  usage — there is no global-system-key fallback.
   """
 
   @type context :: %{
@@ -30,10 +31,13 @@ defmodule Loopctl.Knowledge.ExtractorBehaviour do
         }
 
   @doc """
-  Extracts knowledge article attribute maps from review context.
+  Extracts knowledge article attribute maps from review context, using the
+  tenant's BYO Anthropic key + extraction model.
 
   Returns `{:ok, articles}` with a list of article attribute maps,
-  or `{:error, reason}` on failure (triggers Oban retry).
+  `{:error, :no_api_key}` when the tenant has no key configured (mandatory BYO),
+  or `{:error, reason}` on other failures (triggers Oban retry).
   """
-  @callback extract_articles(context()) :: {:ok, [article_attrs()]} | {:error, term()}
+  @callback extract_articles(tenant_id :: Ecto.UUID.t(), context()) ::
+              {:ok, [article_attrs()]} | {:error, :no_api_key} | {:error, term()}
 end

--- a/lib/loopctl/knowledge/llm_extractor.ex
+++ b/lib/loopctl/knowledge/llm_extractor.ex
@@ -7,18 +7,14 @@ defmodule Loopctl.Knowledge.LlmExtractor do
   extracts reusable knowledge articles about patterns, conventions, or
   decisions that would help future code reviews.
 
-  ## Configuration
+  ## Per-tenant BYO (Epic 28, #179)
 
-  Uses the `:anthropic_provider` config key (shared with `ClaudeContentExtractor`):
-
-      config :loopctl, :anthropic_provider, %{
-        api_key: "sk-ant-...",
-        base_url: "https://api.anthropic.com/v1",
-        model: "claude-haiku-4-5-20251001"
-      }
-
-  When no API key is configured, falls back to returning an empty list
-  (graceful degradation for dev/test environments without Anthropic access).
+  The Anthropic key + extraction model are resolved PER TENANT via
+  `Loopctl.Llm.resolve(tenant_id, :extraction)` — each tenant supplies its own
+  key and pays Anthropic directly. A tenant with no key gets `{:error,
+  :no_api_key}` (mandatory BYO — no global-system-key fallback). Token usage is
+  recorded after a successful call. The shared `Loopctl.Llm.Anthropic` client
+  owns the resolve → POST → record_usage flow.
   """
 
   @behaviour Loopctl.Knowledge.ExtractorBehaviour
@@ -26,6 +22,12 @@ defmodule Loopctl.Knowledge.LlmExtractor do
   require Logger
 
   alias Loopctl.Knowledge.Categories
+  alias Loopctl.Llm.Anthropic
+
+  # This review-extraction call has no tight outer Oban timeout, but keep the
+  # client budget bounded (review #5).
+  @receive_timeout 55_000
+  @max_retries 1
 
   @system_prompt """
   You are a code review knowledge extractor. Given a code review context \
@@ -40,52 +42,24 @@ defmodule Loopctl.Knowledge.LlmExtractor do
   """
 
   @impl true
-  def extract_articles(context) do
-    config = Application.get_env(:loopctl, :anthropic_provider, %{})
-    api_key = config[:api_key] || ""
-
-    if api_key == "" do
-      Logger.debug("LlmExtractor: no Anthropic API key configured, returning empty list")
-      {:ok, []}
-    else
-      call_anthropic(context, config)
-    end
-  end
-
-  defp call_anthropic(context, config) do
-    base_url = config[:base_url] || "https://api.anthropic.com/v1"
-    model = config[:model] || "claude-haiku-4-5-20251001"
-
+  def extract_articles(tenant_id, context) do
     user_message = build_user_message(context)
 
-    body = %{
-      model: model,
-      max_tokens: 16_384,
-      system: @system_prompt,
-      messages: [%{role: "user", content: user_message}]
-    }
+    body_fun = fn _model ->
+      %{
+        max_tokens: 16_384,
+        system: @system_prompt,
+        messages: [%{role: "user", content: user_message}]
+      }
+    end
 
-    case Req.post("#{base_url}/messages",
-           json: body,
-           headers: [
-             {"x-api-key", config[:api_key]},
-             {"anthropic-version", "2023-06-01"}
-           ],
-           retry: :transient,
-           max_retries: 2,
-           receive_timeout: 60_000
+    case Anthropic.message(tenant_id, :extraction, body_fun, %{source_type: "review_finding"},
+           receive_timeout: @receive_timeout,
+           max_retries: @max_retries
          ) do
-      {:ok, %{status: 200, body: %{"content" => [%{"text" => text} | _]}}} ->
-        parse_articles(text)
-
-      {:ok, %{status: status, body: resp_body}} ->
-        Logger.warning("LlmExtractor: API error (status=#{status}, body=#{inspect(resp_body)})")
-
-        {:error, {:api_error, status, resp_body}}
-
-      {:error, reason} ->
-        Logger.warning("LlmExtractor: request failed (error=#{inspect(reason)})")
-        {:error, {:request_failed, reason}}
+      {:ok, text} -> parse_articles(text)
+      {:error, :no_api_key} -> {:error, :no_api_key}
+      {:error, _} = err -> err
     end
   end
 

--- a/lib/loopctl/knowledge/merge_synthesizer_behaviour.ex
+++ b/lib/loopctl/knowledge/merge_synthesizer_behaviour.ex
@@ -24,6 +24,6 @@ defmodule Loopctl.Knowledge.MergeSynthesizerBehaviour do
   backend is unavailable, so the executor leaves the resolution for retry rather than
   drafting garbage.
   """
-  @callback synthesize(a :: article(), b :: article()) ::
-              {:ok, article()} | {:error, term()}
+  @callback synthesize(tenant_id :: Ecto.UUID.t(), a :: article(), b :: article()) ::
+              {:ok, article()} | {:error, :no_api_key} | {:error, term()}
 end

--- a/lib/loopctl/llm.ex
+++ b/lib/loopctl/llm.ex
@@ -240,7 +240,13 @@ defmodule Loopctl.Llm do
     limit = opts |> Keyword.get(:limit, @default_summary_limit) |> clamp_limit()
     offset = opts |> Keyword.get(:offset, 0) |> max_zero()
 
-    base = usage_base_query(tenant_id, opts)
+    # The EFFECTIVE window actually applied (review #8): `from` defaults to a
+    # 90-day lookback when omitted, so echo it in meta — otherwise a caller can't
+    # tell that older usage was silently excluded. `to` is nil = open-ended (now).
+    effective_from = Keyword.get(opts, :from) || default_from()
+    effective_to = Keyword.get(opts, :to)
+
+    base = usage_base_query(tenant_id, effective_from, effective_to)
 
     grouped =
       from(e in base,
@@ -285,7 +291,16 @@ defmodule Loopctl.Llm do
       |> HeavyRead.all(rows_query, HeavyRead.opts(:llm_usage))
       |> Enum.map(&normalize_summary_row/1)
 
-    %{data: rows, meta: %{limit: limit, offset: offset, total_count: total}}
+    %{
+      data: rows,
+      meta: %{
+        limit: limit,
+        offset: offset,
+        total_count: total,
+        from: effective_from,
+        to: effective_to
+      }
+    }
   end
 
   # --- Private ---
@@ -296,10 +311,10 @@ defmodule Loopctl.Llm do
   # bounded range efficient).
   @default_lookback_days 90
 
-  defp usage_base_query(tenant_id, opts) do
+  defp usage_base_query(tenant_id, effective_from, effective_to) do
     from(e in UsageEvent, where: e.tenant_id == ^tenant_id)
-    |> maybe_from(Keyword.get(opts, :from) || default_from())
-    |> maybe_to(Keyword.get(opts, :to))
+    |> maybe_from(effective_from)
+    |> maybe_to(effective_to)
   end
 
   defp default_from,

--- a/lib/loopctl/llm.ex
+++ b/lib/loopctl/llm.ex
@@ -1,0 +1,359 @@
+defmodule Loopctl.Llm do
+  @moduledoc """
+  Per-tenant BYO Anthropic LLM configuration + usage tracking (Epic 28 residual, #179).
+
+  loopctl is multi-tenant and **BYO-key**: every tenant supplies its OWN Anthropic
+  API key and pays Anthropic directly. loopctl fronts no LLM cost — there is no
+  markup, price table, or billing. A tenant with no configured key CANNOT run
+  tenant knowledge-LLM work (ingest/classify/merge): `resolve/2` returns
+  `{:error, :no_api_key}` and callers fail cleanly (a 422 at the API boundary; the
+  Oban worker `{:discard}`s). There is intentionally NO global-system-key fallback
+  for tenant LLM work.
+
+  ## Repo strategy
+
+  Like `Loopctl.Webhooks` (the other encrypted-secret tenant context), these
+  functions run from BOTH web requests and Oban workers, so they use
+  `Loopctl.AdminRepo` with an EXPLICIT `tenant_id` filter on every query. RLS is
+  additionally enabled on both tables (defense in depth + the repo-wide
+  `rls_coverage_test` invariant). A caller only ever passes its own `tenant_id`
+  (web: `current_api_key.tenant_id`; worker: the job's `tenant_id` arg), so there
+  is no cross-tenant resolve.
+
+  ## Security
+
+  - The API key is encrypted at rest (`Loopctl.Vault.Binary`) and `redact: true`,
+    so it never appears in logs/inspect.
+  - It is NEVER returned by any function that feeds a serializer — only
+    `resolve/2` (which hands it straight to the Anthropic client) exposes the
+    plaintext. `settings_view/1` returns `has_api_key?` + a last-4 hint only.
+  - Setting/rotating a key writes an audit event (WITHOUT the value).
+  """
+
+  import Ecto.Query
+
+  alias Ecto.Multi
+  alias Loopctl.AdminRepo
+  alias Loopctl.Audit
+  alias Loopctl.Llm.TenantLlmSettings
+  alias Loopctl.Llm.UsageEvent
+
+  # Server default model per operation when the tenant left that field nil. A key
+  # is still MANDATORY — the default only fills the model, never the key. Haiku is
+  # the cheap sensible default; a tenant overrides per-operation as they wish.
+  @default_model "claude-haiku-4-5-20251001"
+  @default_models %{
+    extraction: @default_model,
+    classification: @default_model,
+    merge: @default_model
+  }
+
+  @type operation :: :extraction | :classification | :merge
+  @type resolved :: %{api_key: String.t(), model: String.t()}
+
+  # --- Settings ---
+
+  @doc """
+  Returns the tenant's LLM settings row, or `nil` if none exists.
+
+  The `api_key` field on the returned struct is decrypted plaintext — treat it as
+  a secret. Prefer `resolve/2` for LLM call sites.
+  """
+  @spec get_settings(Ecto.UUID.t()) :: TenantLlmSettings.t() | nil
+  def get_settings(tenant_id) when is_binary(tenant_id) do
+    AdminRepo.get_by(TenantLlmSettings, tenant_id: tenant_id)
+  end
+
+  @doc """
+  Upserts the tenant's LLM settings (one row per tenant).
+
+  `attrs` may carry any of `api_key`, `extraction_model`, `classification_model`,
+  `merge_model` (string or atom keys). `tenant_id` is set programmatically. The
+  api_key (when present) is stored encrypted and NEVER cast from params. When an
+  api_key is set/rotated, an `llm_config.key_set` audit event is written WITHOUT
+  the value; every upsert writes an `llm_config.updated` event listing which
+  model fields changed.
+
+  Returns `{:ok, settings}` or `{:error, changeset}`.
+  """
+  @spec upsert_settings(Ecto.UUID.t(), map()) ::
+          {:ok, TenantLlmSettings.t()} | {:error, Ecto.Changeset.t()}
+  def upsert_settings(tenant_id, attrs) when is_binary(tenant_id) and is_map(attrs) do
+    attrs = normalize_keys(attrs)
+    api_key = Map.get(attrs, :api_key)
+    existing = get_settings(tenant_id)
+
+    changeset =
+      (existing || %TenantLlmSettings{tenant_id: tenant_id})
+      |> TenantLlmSettings.models_changeset(attrs)
+      |> TenantLlmSettings.put_api_key(api_key)
+      |> Ecto.Changeset.put_change(:tenant_id, tenant_id)
+
+    key_set? = not is_nil(api_key)
+
+    Multi.new()
+    |> Multi.insert_or_update(:settings, changeset)
+    |> Multi.merge(fn %{settings: settings} ->
+      audit_multi(tenant_id, settings, changeset, key_set?)
+    end)
+    |> AdminRepo.transaction()
+    |> case do
+      {:ok, %{settings: settings}} -> {:ok, settings}
+      {:error, :settings, changeset, _} -> {:error, changeset}
+    end
+  end
+
+  @doc """
+  Resolves the tenant's API key + per-operation model for an LLM call.
+
+  Returns `{:ok, %{api_key: decrypted, model: model}}` or `{:error, :no_api_key}`
+  when the tenant has no key configured (mandatory BYO — no fallback). When the
+  tenant left the per-operation model nil, the server default for that operation
+  is used.
+  """
+  @spec resolve(Ecto.UUID.t(), operation()) :: {:ok, resolved()} | {:error, :no_api_key}
+  def resolve(tenant_id, operation)
+      when is_binary(tenant_id) and operation in [:extraction, :classification, :merge] do
+    case get_settings(tenant_id) do
+      %TenantLlmSettings{api_key: key} = settings when is_binary(key) and key != "" ->
+        {:ok, %{api_key: key, model: model_for(settings, operation)}}
+
+      _ ->
+        {:error, :no_api_key}
+    end
+  end
+
+  @doc """
+  Whether the tenant has a usable Anthropic API key configured. Used by the
+  ingest boundary (422 up front) and workers (discard) to enforce mandatory BYO
+  WITHOUT holding the plaintext key.
+  """
+  @spec has_api_key?(Ecto.UUID.t()) :: boolean()
+  def has_api_key?(tenant_id) when is_binary(tenant_id) do
+    match?({:ok, _}, resolve(tenant_id, :extraction))
+  end
+
+  @doc """
+  A safe view of the tenant's settings for API responses: the model choices,
+  `has_api_key`, and a `api_key_hint` (last 4 chars) — NEVER the key itself.
+  """
+  @spec settings_view(TenantLlmSettings.t() | nil) :: map()
+  def settings_view(nil) do
+    %{
+      has_api_key: false,
+      api_key_hint: nil,
+      extraction_model: nil,
+      classification_model: nil,
+      merge_model: nil
+    }
+  end
+
+  def settings_view(%TenantLlmSettings{} = s) do
+    %{
+      has_api_key: has_key?(s.api_key),
+      api_key_hint: api_key_hint(s.api_key),
+      extraction_model: s.extraction_model,
+      classification_model: s.classification_model,
+      merge_model: s.merge_model
+    }
+  end
+
+  # --- Usage tracking ---
+
+  @doc """
+  Records a token-usage event AFTER a successful LLM response.
+
+  `attrs` must carry `:operation`, `:model`, `:input_tokens`, `:output_tokens`
+  and may carry `:source_type` and `:article_id`. `tenant_id` and `occurred_at`
+  are set programmatically. Returns `{:ok, event}` or `{:error, changeset}`.
+  """
+  @spec record_usage(Ecto.UUID.t(), map()) ::
+          {:ok, UsageEvent.t()} | {:error, Ecto.Changeset.t()}
+  def record_usage(tenant_id, attrs) when is_binary(tenant_id) and is_map(attrs) do
+    attrs =
+      attrs
+      |> normalize_keys()
+      |> Map.put_new(:occurred_at, DateTime.utc_now())
+
+    %UsageEvent{tenant_id: tenant_id}
+    |> UsageEvent.create_changeset(attrs)
+    |> Ecto.Changeset.put_change(:tenant_id, tenant_id)
+    |> AdminRepo.insert()
+  end
+
+  @default_summary_limit 50
+  @max_summary_limit 200
+
+  @doc """
+  Aggregates a tenant's usage, grouped by operation + model + source_type + day,
+  summing input/output tokens and counting events, over an optional date range.
+
+  Opts: `:from`, `:to` (DateTime), `:limit` (default #{@default_summary_limit},
+  clamped to #{@max_summary_limit}), `:offset` (default 0). Rows are ordered
+  `day desc` with an `(operation, model, source_type)` tiebreaker for a stable
+  page across equal days.
+
+  Returns `%{data: [row], meta: %{limit, offset, total_count}}` where each row is
+  `%{day, operation, model, source_type, input_tokens, output_tokens, event_count}`.
+  """
+  @spec usage_summary(Ecto.UUID.t(), keyword()) :: %{data: [map()], meta: map()}
+  def usage_summary(tenant_id, opts \\ []) when is_binary(tenant_id) do
+    limit = opts |> Keyword.get(:limit, @default_summary_limit) |> clamp_limit()
+    offset = opts |> Keyword.get(:offset, 0) |> max_zero()
+
+    base = usage_base_query(tenant_id, opts)
+
+    grouped =
+      from(e in base,
+        group_by: [
+          fragment("date_trunc('day', ?)", e.occurred_at),
+          e.operation,
+          e.model,
+          e.source_type
+        ],
+        select: %{
+          day: fragment("date_trunc('day', ?)", e.occurred_at),
+          operation: e.operation,
+          model: e.model,
+          source_type: e.source_type,
+          input_tokens: sum(e.input_tokens),
+          output_tokens: sum(e.output_tokens),
+          event_count: count(e.id)
+        }
+      )
+
+    total = grouped |> subquery() |> AdminRepo.aggregate(:count, :day)
+
+    rows =
+      from(g in subquery(grouped),
+        order_by: [
+          desc: g.day,
+          asc: g.operation,
+          asc: g.model,
+          asc: g.source_type
+        ],
+        limit: ^limit,
+        offset: ^offset
+      )
+      |> AdminRepo.all()
+      |> Enum.map(&normalize_summary_row/1)
+
+    %{data: rows, meta: %{limit: limit, offset: offset, total_count: total}}
+  end
+
+  # --- Private ---
+
+  defp usage_base_query(tenant_id, opts) do
+    from(e in UsageEvent, where: e.tenant_id == ^tenant_id)
+    |> maybe_from(Keyword.get(opts, :from))
+    |> maybe_to(Keyword.get(opts, :to))
+  end
+
+  defp maybe_from(query, %DateTime{} = from), do: where(query, [e], e.occurred_at >= ^from)
+  defp maybe_from(query, _), do: query
+
+  defp maybe_to(query, %DateTime{} = to), do: where(query, [e], e.occurred_at <= ^to)
+  defp maybe_to(query, _), do: query
+
+  # sum() over integers returns a Decimal; normalize to integers for the JSON view.
+  defp normalize_summary_row(row) do
+    %{
+      row
+      | input_tokens: to_int(row.input_tokens),
+        output_tokens: to_int(row.output_tokens),
+        event_count: to_int(row.event_count)
+    }
+  end
+
+  defp to_int(%Decimal{} = d), do: Decimal.to_integer(d)
+  defp to_int(n) when is_integer(n), do: n
+  defp to_int(nil), do: 0
+
+  defp model_for(%TenantLlmSettings{} = s, :extraction),
+    do: s.extraction_model || default_model(:extraction)
+
+  defp model_for(%TenantLlmSettings{} = s, :classification),
+    do: s.classification_model || default_model(:classification)
+
+  defp model_for(%TenantLlmSettings{} = s, :merge),
+    do: s.merge_model || default_model(:merge)
+
+  defp default_model(operation), do: Map.fetch!(@default_models, operation)
+
+  defp has_key?(key), do: is_binary(key) and key != ""
+
+  defp api_key_hint(key) when is_binary(key) do
+    if String.length(key) >= 4, do: "..." <> String.slice(key, -4, 4), else: "..."
+  end
+
+  defp api_key_hint(_), do: nil
+
+  # Accept both atom- and string-keyed attrs; whitelist to the known keys so an
+  # attacker can't smuggle e.g. tenant_id in.
+  @known_attr_keys ~w(api_key extraction_model classification_model merge_model
+                      operation model input_tokens output_tokens source_type
+                      article_id occurred_at)a
+  defp normalize_keys(attrs) do
+    Enum.reduce(@known_attr_keys, %{}, fn key, acc ->
+      case fetch_attr(attrs, key) do
+        {:ok, value} -> Map.put(acc, key, value)
+        :error -> acc
+      end
+    end)
+  end
+
+  defp fetch_attr(attrs, key) do
+    case Map.fetch(attrs, key) do
+      {:ok, value} -> {:ok, value}
+      :error -> Map.fetch(attrs, Atom.to_string(key))
+    end
+  end
+
+  defp clamp_limit(n) when is_integer(n) and n > 0, do: min(n, @max_summary_limit)
+  defp clamp_limit(_), do: @default_summary_limit
+
+  defp max_zero(n) when is_integer(n) and n > 0, do: n
+  defp max_zero(_), do: 0
+
+  # Audit the config change WITHOUT the key value. Always record `llm_config.updated`
+  # with the changed model fields; additionally record `llm_config.key_set` when the
+  # api_key was set/rotated (value never included).
+  defp audit_multi(tenant_id, settings, changeset, key_set?) do
+    changed_models =
+      changeset.changes
+      |> Map.take([:extraction_model, :classification_model, :merge_model])
+      |> Map.new(fn {k, v} -> {Atom.to_string(k), v} end)
+
+    multi =
+      Audit.log_in_multi(Multi.new(), :audit_updated, fn _ ->
+        %{
+          tenant_id: tenant_id,
+          entity_type: "llm_config",
+          entity_id: settings.id,
+          action: "llm_config.updated",
+          actor_type: "system",
+          actor_id: nil,
+          actor_label: "llm_config",
+          new_state: %{"changed_models" => changed_models, "api_key_set" => key_set?}
+        }
+      end)
+
+    if key_set? do
+      Audit.log_in_multi(multi, :audit_key_set, fn _ ->
+        %{
+          tenant_id: tenant_id,
+          entity_type: "llm_config",
+          entity_id: settings.id,
+          action: "llm_config.key_set",
+          actor_type: "system",
+          actor_id: nil,
+          actor_label: "llm_config",
+          # NEVER the key value — only that a key was set + its last-4 hint.
+          new_state: %{"api_key_hint" => api_key_hint(settings.api_key)}
+        }
+      end)
+    else
+      multi
+    end
+  end
+end

--- a/lib/loopctl/llm.ex
+++ b/lib/loopctl/llm.ex
@@ -32,9 +32,12 @@ defmodule Loopctl.Llm do
 
   import Ecto.Query
 
+  require Logger
+
   alias Ecto.Multi
   alias Loopctl.AdminRepo
   alias Loopctl.Audit
+  alias Loopctl.HeavyRead
   alias Loopctl.Llm.TenantLlmSettings
   alias Loopctl.Llm.UsageEvent
 
@@ -134,6 +137,42 @@ defmodule Loopctl.Llm do
   end
 
   @doc """
+  Records that a tenant LLM `operation` was BLOCKED for a missing BYO key
+  (review #2 — the mandatory-BYO cutover needs observability). Emits a
+  `Logger.warning`, a `[:loopctl, :llm, :blocked]` telemetry event, and an
+  `llm.blocked_no_api_key` audit entry (with tenant_id + operation, never a key).
+  Best-effort: a telemetry/audit failure never propagates to the caller.
+  """
+  @spec record_blocked(Ecto.UUID.t(), operation()) :: :ok
+  def record_blocked(tenant_id, operation) when is_binary(tenant_id) do
+    Logger.warning(
+      "Loopctl.Llm: tenant=#{tenant_id} blocked op=#{operation} — no Anthropic API key " <>
+        "configured (mandatory BYO)."
+    )
+
+    :telemetry.execute([:loopctl, :llm, :blocked], %{count: 1}, %{
+      tenant_id: tenant_id,
+      operation: operation
+    })
+
+    Audit.create_log_entry(tenant_id, %{
+      entity_type: "llm_config",
+      entity_id: tenant_id,
+      action: "llm.blocked_no_api_key",
+      actor_type: "system",
+      actor_id: nil,
+      actor_label: "llm",
+      new_state: %{"operation" => to_string(operation)}
+    })
+
+    :ok
+  rescue
+    e ->
+      Logger.error("Loopctl.Llm.record_blocked failed: #{Exception.message(e)}")
+      :ok
+  end
+
+  @doc """
   A safe view of the tenant's settings for API responses: the model choices,
   `has_api_key`, and a `api_key_hint` (last 4 chars) — NEVER the key itself.
   """
@@ -222,9 +261,14 @@ defmodule Loopctl.Llm do
         }
       )
 
-    total = grouped |> subquery() |> AdminRepo.aggregate(:count, :day)
+    # This customer-facing aggregate reads the (potentially large) llm_usage_events
+    # table, so route it through HeavyRead (per-read SET LOCAL statement_timeout +
+    # tenant-scope guard) like the other heavy reads (review #9). The grouped
+    # subquery's base carries `e.tenant_id == ^tenant_id`, so the guard passes.
+    total_query = from(g in subquery(grouped), select: count(g.day))
+    total = HeavyRead.one(tenant_id, total_query, HeavyRead.opts(:llm_usage)) || 0
 
-    rows =
+    rows_query =
       from(g in subquery(grouped),
         order_by: [
           desc: g.day,
@@ -235,7 +279,10 @@ defmodule Loopctl.Llm do
         limit: ^limit,
         offset: ^offset
       )
-      |> AdminRepo.all()
+
+    rows =
+      tenant_id
+      |> HeavyRead.all(rows_query, HeavyRead.opts(:llm_usage))
       |> Enum.map(&normalize_summary_row/1)
 
     %{data: rows, meta: %{limit: limit, offset: offset, total_count: total}}
@@ -243,11 +290,20 @@ defmodule Loopctl.Llm do
 
   # --- Private ---
 
+  # Default the lower bound to a 90-day lookback when the caller omits `:from`, so
+  # the aggregate can never unboundedly scan the whole table (review #9). An
+  # explicit `:from`/`:to` is honored (the (tenant_id, occurred_at) index keeps a
+  # bounded range efficient).
+  @default_lookback_days 90
+
   defp usage_base_query(tenant_id, opts) do
     from(e in UsageEvent, where: e.tenant_id == ^tenant_id)
-    |> maybe_from(Keyword.get(opts, :from))
+    |> maybe_from(Keyword.get(opts, :from) || default_from())
     |> maybe_to(Keyword.get(opts, :to))
   end
+
+  defp default_from,
+    do: DateTime.add(DateTime.utc_now(), -@default_lookback_days * 86_400, :second)
 
   defp maybe_from(query, %DateTime{} = from), do: where(query, [e], e.occurred_at >= ^from)
   defp maybe_from(query, _), do: query

--- a/lib/loopctl/llm/anthropic.ex
+++ b/lib/loopctl/llm/anthropic.ex
@@ -3,15 +3,24 @@ defmodule Loopctl.Llm.Anthropic do
   Shared Anthropic Messages API call for tenant-scoped LLM operations
   (Epic 28 residual, #179).
 
-  Centralizes the mandatory-BYO + usage-tracking flow for the three LLM call
-  sites (extraction/classification/merge):
+  Centralizes the mandatory-BYO + usage-tracking flow for the four LLM call
+  sites (content extraction / classification / merge / review extraction):
 
     1. `Loopctl.Llm.resolve(tenant_id, operation)` — get the tenant's key + the
        per-operation model, or `{:error, :no_api_key}` (no global fallback).
     2. POST the Messages request with THAT key (`x-api-key`) + THAT model.
     3. On a 200, capture the response `usage` (`input_tokens`/`output_tokens`) and
-       `Loopctl.Llm.record_usage/2`.
+       `Loopctl.Llm.record_usage/2` — BEST-EFFORT (a usage-recording failure never
+       fails an already-billed Anthropic call; see `record_usage_safe/5`).
     4. Return the assistant text for the caller to parse.
+
+  ## Timeout budget (review #5)
+
+  Callers pass `receive_timeout` / `max_retries` in `req_opts` so the client's
+  worst-case wall-clock stays strictly BELOW the caller's outer budget (the Oban
+  job/`Task.async_stream` timeout). This prevents the outer supervisor from
+  killing an in-flight request mid-way (which the client can neither observe nor
+  retry). The defaults here are conservative; every real caller overrides them.
 
   The API key is NEVER logged. HTTP is injectable for tests via the
   `:anthropic_req_plug` config (a `Req.Test` plug), so the whole flow — including
@@ -25,19 +34,21 @@ defmodule Loopctl.Llm.Anthropic do
   @base_url "https://api.anthropic.com/v1"
   @anthropic_version "2023-06-01"
 
+  # Conservative defaults; callers override with budgets that fit their outer
+  # timeout (review #5). retry :transient + max_retries drives Req's retry.
+  @default_receive_timeout 25_000
+  @default_max_retries 0
+
   @type usage_meta :: %{
           optional(:source_type) => String.t() | nil,
           optional(:article_id) => Ecto.UUID.t() | nil
         }
 
   @doc """
-  Resolve the tenant key+model for `operation`, POST a Messages request whose body
-  is built by `body_fun.(model)` (the caller supplies `system`/`messages`/
-  `max_tokens`; this fn injects `model`), record usage on success, and return the
-  assistant text.
+  Resolve the tenant key+model for `operation`, then POST via `call/7`.
 
   Returns:
-    * `{:ok, text}` on a 200 (usage recorded)
+    * `{:ok, text}` on a 200 (usage recorded best-effort)
     * `{:error, :no_api_key}` when the tenant has no key (mandatory BYO)
     * `{:error, {:api_error, status, body}}` on a non-200
     * `{:error, {:request_failed, reason}}` on a transport error
@@ -54,9 +65,32 @@ defmodule Loopctl.Llm.Anthropic do
         {:error, :no_api_key}
 
       {:ok, %{api_key: api_key, model: model}} ->
-        body = model |> body_fun.() |> Map.put(:model, model)
-        post(tenant_id, operation, model, body, usage_meta, api_key, req_opts)
+        call(tenant_id, operation, api_key, model, body_fun, usage_meta, req_opts)
     end
+  end
+
+  @doc """
+  Like `message/5` but with EXPLICIT pre-resolved `api_key` + `model` — skips the
+  per-call `Loopctl.Llm.resolve/2` DB read. Used to resolve ONCE per batch and
+  thread the resolved credentials through many calls (review #19). The caller is
+  responsible for having resolved the tenant's credentials.
+  """
+  @spec call(
+          Ecto.UUID.t(),
+          Llm.operation(),
+          String.t(),
+          String.t(),
+          (String.t() -> map()),
+          usage_meta(),
+          keyword()
+        ) ::
+          {:ok, String.t()}
+          | {:error, {:api_error, integer(), term()}}
+          | {:error, {:request_failed, term()}}
+  def call(tenant_id, operation, api_key, model, body_fun, usage_meta \\ %{}, req_opts \\ [])
+      when is_binary(api_key) and is_binary(model) and is_function(body_fun, 1) do
+    body = model |> body_fun.() |> Map.put(:model, model)
+    post(tenant_id, operation, model, body, usage_meta, api_key, req_opts)
   end
 
   defp post(tenant_id, operation, model, body, usage_meta, api_key, req_opts) do
@@ -68,8 +102,8 @@ defmodule Loopctl.Llm.Anthropic do
           {"anthropic-version", @anthropic_version}
         ],
         retry: :transient,
-        max_retries: 2,
-        receive_timeout: 60_000
+        max_retries: @default_max_retries,
+        receive_timeout: @default_receive_timeout
       ]
       |> Keyword.merge(req_opts)
       |> maybe_put_plug()
@@ -77,7 +111,7 @@ defmodule Loopctl.Llm.Anthropic do
     # NOTE: never log `opts` / `api_key` — the key is a tenant secret.
     case Req.post("#{@base_url}/messages", opts) do
       {:ok, %{status: 200, body: %{"content" => [%{"text" => text} | _]} = resp}} ->
-        record_usage(tenant_id, operation, model, resp["usage"], usage_meta)
+        record_usage_safe(tenant_id, operation, model, resp["usage"], usage_meta)
         {:ok, text}
 
       {:ok, %{status: 200, body: body}} ->
@@ -97,20 +131,49 @@ defmodule Loopctl.Llm.Anthropic do
     end
   end
 
+  # BEST-EFFORT usage recording (review #3). The Anthropic call has already
+  # SUCCEEDED (and been billed to the tenant) by the time we get here, so a DB
+  # blip / FK race while inserting the usage row must NEVER raise — that would
+  # crash the job, trigger an Oban retry, and RE-BILL the tenant. Mirror
+  # `ContentIngestionWorker.enqueue_embeddings/2`: log-and-continue, always :ok.
+  defp record_usage_safe(tenant_id, operation, model, usage, meta) do
+    record_usage(tenant_id, operation, model, usage, meta)
+  rescue
+    e ->
+      Logger.error(
+        "Loopctl.Llm.Anthropic: usage recording raised (op=#{operation}); " <>
+          "the Anthropic call already succeeded, continuing: #{Exception.message(e)}"
+      )
+
+      :ok
+  end
+
   # Record token usage from the Anthropic `usage` object. A missing/malformed usage
-  # block is logged and skipped — never crashes a successful extraction.
+  # block, or an `{:error, changeset}` from the insert (e.g. a mapped FK violation),
+  # is logged and skipped — never crashes a successful extraction.
   defp record_usage(tenant_id, operation, model, %{} = usage, meta) do
     input = Map.get(usage, "input_tokens", 0)
     output = Map.get(usage, "output_tokens", 0)
 
-    Llm.record_usage(tenant_id, %{
-      operation: operation,
-      model: model,
-      input_tokens: normalize_token(input),
-      output_tokens: normalize_token(output),
-      source_type: Map.get(meta, :source_type),
-      article_id: Map.get(meta, :article_id)
-    })
+    case Llm.record_usage(tenant_id, %{
+           operation: operation,
+           model: model,
+           input_tokens: normalize_token(input),
+           output_tokens: normalize_token(output),
+           source_type: Map.get(meta, :source_type),
+           article_id: Map.get(meta, :article_id)
+         }) do
+      {:ok, _event} ->
+        :ok
+
+      {:error, changeset} ->
+        Logger.error(
+          "Loopctl.Llm.Anthropic: usage record rejected (op=#{operation}): " <>
+            "#{inspect(changeset.errors)}"
+        )
+
+        :ok
+    end
   end
 
   defp record_usage(_tenant_id, operation, _model, _usage, _meta) do

--- a/lib/loopctl/llm/anthropic.ex
+++ b/lib/loopctl/llm/anthropic.ex
@@ -1,0 +1,133 @@
+defmodule Loopctl.Llm.Anthropic do
+  @moduledoc """
+  Shared Anthropic Messages API call for tenant-scoped LLM operations
+  (Epic 28 residual, #179).
+
+  Centralizes the mandatory-BYO + usage-tracking flow for the three LLM call
+  sites (extraction/classification/merge):
+
+    1. `Loopctl.Llm.resolve(tenant_id, operation)` — get the tenant's key + the
+       per-operation model, or `{:error, :no_api_key}` (no global fallback).
+    2. POST the Messages request with THAT key (`x-api-key`) + THAT model.
+    3. On a 200, capture the response `usage` (`input_tokens`/`output_tokens`) and
+       `Loopctl.Llm.record_usage/2`.
+    4. Return the assistant text for the caller to parse.
+
+  The API key is NEVER logged. HTTP is injectable for tests via the
+  `:anthropic_req_plug` config (a `Req.Test` plug), so the whole flow — including
+  usage recording — is exercised without real API calls.
+  """
+
+  require Logger
+
+  alias Loopctl.Llm
+
+  @base_url "https://api.anthropic.com/v1"
+  @anthropic_version "2023-06-01"
+
+  @type usage_meta :: %{
+          optional(:source_type) => String.t() | nil,
+          optional(:article_id) => Ecto.UUID.t() | nil
+        }
+
+  @doc """
+  Resolve the tenant key+model for `operation`, POST a Messages request whose body
+  is built by `body_fun.(model)` (the caller supplies `system`/`messages`/
+  `max_tokens`; this fn injects `model`), record usage on success, and return the
+  assistant text.
+
+  Returns:
+    * `{:ok, text}` on a 200 (usage recorded)
+    * `{:error, :no_api_key}` when the tenant has no key (mandatory BYO)
+    * `{:error, {:api_error, status, body}}` on a non-200
+    * `{:error, {:request_failed, reason}}` on a transport error
+  """
+  @spec message(Ecto.UUID.t(), Llm.operation(), (String.t() -> map()), usage_meta(), keyword()) ::
+          {:ok, String.t()}
+          | {:error, :no_api_key}
+          | {:error, {:api_error, integer(), term()}}
+          | {:error, {:request_failed, term()}}
+  def message(tenant_id, operation, body_fun, usage_meta \\ %{}, req_opts \\ [])
+      when is_function(body_fun, 1) do
+    case Llm.resolve(tenant_id, operation) do
+      {:error, :no_api_key} ->
+        {:error, :no_api_key}
+
+      {:ok, %{api_key: api_key, model: model}} ->
+        body = model |> body_fun.() |> Map.put(:model, model)
+        post(tenant_id, operation, model, body, usage_meta, api_key, req_opts)
+    end
+  end
+
+  defp post(tenant_id, operation, model, body, usage_meta, api_key, req_opts) do
+    opts =
+      [
+        json: body,
+        headers: [
+          {"x-api-key", api_key},
+          {"anthropic-version", @anthropic_version}
+        ],
+        retry: :transient,
+        max_retries: 2,
+        receive_timeout: 60_000
+      ]
+      |> Keyword.merge(req_opts)
+      |> maybe_put_plug()
+
+    # NOTE: never log `opts` / `api_key` — the key is a tenant secret.
+    case Req.post("#{@base_url}/messages", opts) do
+      {:ok, %{status: 200, body: %{"content" => [%{"text" => text} | _]} = resp}} ->
+        record_usage(tenant_id, operation, model, resp["usage"], usage_meta)
+        {:ok, text}
+
+      {:ok, %{status: 200, body: body}} ->
+        Logger.warning("Loopctl.Llm.Anthropic: 200 with unexpected shape (op=#{operation})")
+        {:error, {:api_error, 200, redact_body(body)}}
+
+      {:ok, %{status: status, body: body}} ->
+        Logger.warning("Loopctl.Llm.Anthropic: API error (op=#{operation}, status=#{status})")
+        {:error, {:api_error, status, body}}
+
+      {:error, reason} ->
+        Logger.warning(
+          "Loopctl.Llm.Anthropic: request failed (op=#{operation}, error=#{inspect(reason)})"
+        )
+
+        {:error, {:request_failed, reason}}
+    end
+  end
+
+  # Record token usage from the Anthropic `usage` object. A missing/malformed usage
+  # block is logged and skipped — never crashes a successful extraction.
+  defp record_usage(tenant_id, operation, model, %{} = usage, meta) do
+    input = Map.get(usage, "input_tokens", 0)
+    output = Map.get(usage, "output_tokens", 0)
+
+    Llm.record_usage(tenant_id, %{
+      operation: operation,
+      model: model,
+      input_tokens: normalize_token(input),
+      output_tokens: normalize_token(output),
+      source_type: Map.get(meta, :source_type),
+      article_id: Map.get(meta, :article_id)
+    })
+  end
+
+  defp record_usage(_tenant_id, operation, _model, _usage, _meta) do
+    Logger.warning("Loopctl.Llm.Anthropic: response had no usage block (op=#{operation})")
+    :ok
+  end
+
+  defp normalize_token(n) when is_integer(n) and n >= 0, do: n
+  defp normalize_token(_), do: 0
+
+  defp maybe_put_plug(opts) do
+    case Application.get_env(:loopctl, :anthropic_req_plug) do
+      nil -> opts
+      plug -> Keyword.put(opts, :plug, plug)
+    end
+  end
+
+  defp redact_body(body) when is_binary(body), do: String.slice(body, 0, 200)
+  defp redact_body(body), do: body
+end

--- a/lib/loopctl/llm/tenant_llm_settings.ex
+++ b/lib/loopctl/llm/tenant_llm_settings.ex
@@ -52,7 +52,10 @@ defmodule Loopctl.Llm.TenantLlmSettings do
   @spec models_changeset(t(), map()) :: Ecto.Changeset.t()
   def models_changeset(settings, attrs) do
     settings
-    |> cast(attrs, @model_fields)
+    # Cast ONLY the model fields — never let the raw api_key transit through
+    # `cast/3` into `changeset.params` (review #15), where it could surface in a
+    # logged/rendered changeset. The key is set separately via put_api_key/2.
+    |> cast(model_attrs(attrs), @model_fields)
     |> validate_models()
     # A concurrent first-insert race yields a clean {:error, changeset} (422)
     # instead of an Ecto.ConstraintError (500) on the unique tenant_id index.
@@ -84,6 +87,15 @@ defmodule Loopctl.Llm.TenantLlmSettings do
 
   def put_api_key(changeset, _other),
     do: add_error(changeset, :api_key, "must be a string")
+
+  # Keep ONLY the model fields (string- or atom-keyed) so the api_key can never
+  # reach `cast/3`/`changeset.params` (review #15).
+  @model_string_keys Enum.map(@model_fields, &Atom.to_string/1)
+  defp model_attrs(attrs) when is_map(attrs) do
+    Map.take(attrs, @model_fields ++ @model_string_keys)
+  end
+
+  defp model_attrs(_), do: %{}
 
   defp validate_models(changeset) do
     Enum.reduce(@model_fields, changeset, fn field, acc ->

--- a/lib/loopctl/llm/tenant_llm_settings.ex
+++ b/lib/loopctl/llm/tenant_llm_settings.ex
@@ -1,0 +1,97 @@
+defmodule Loopctl.Llm.TenantLlmSettings do
+  @moduledoc """
+  Schema for the `tenant_llm_settings` table — a tenant's BYO Anthropic
+  configuration (Epic 28 residual, #179).
+
+  Each tenant has at most ONE row (unique `tenant_id`). It holds the tenant's own
+  Anthropic API key, encrypted at rest via Cloak (`Loopctl.Vault.Binary`,
+  AES-256-GCM) and `redact: true` so it never appears in `inspect/1` or log output.
+  The three per-operation model fields let a tenant pick a different model for
+  extraction, classification, and merge; each is a free-form, plausible model id
+  (NOT restricted to an allow-list) or NULL to fall back to the server default.
+
+  ## Security invariants
+
+  - `api_key` is NEVER placed in a `cast/3` list — it is set programmatically via
+    `put_change/3` so a stray param can't overwrite it and it never lands in the
+    changeset's `params` echoed by error rendering.
+  - `api_key` is `redact: true` — `inspect(%TenantLlmSettings{})` shows
+    `**redacted**`.
+  - No serializer ever returns the key (only `has_api_key?` + a last-4 hint).
+  """
+
+  use Loopctl.Schema
+
+  @type t :: %__MODULE__{}
+
+  # A plausible Anthropic model id — non-empty, bounded, no whitespace. We do NOT
+  # restrict to a known-model allow-list: the tenant may use any model their key
+  # permits (Sonnet, Opus, Haiku, dated snapshots, future ids).
+  @model_format ~r/^[A-Za-z0-9._:-]+$/
+  @max_model_length 200
+  @max_api_key_length 500
+
+  schema "tenant_llm_settings" do
+    tenant_field()
+
+    field :api_key, Loopctl.Vault.Binary, redact: true
+    field :extraction_model, :string
+    field :classification_model, :string
+    field :merge_model, :string
+
+    timestamps()
+  end
+
+  @model_fields [:extraction_model, :classification_model, :merge_model]
+
+  @doc """
+  Changeset for the per-operation model fields ONLY.
+
+  `api_key` is deliberately excluded from the cast — set it via `put_api_key/2`.
+  """
+  @spec models_changeset(t(), map()) :: Ecto.Changeset.t()
+  def models_changeset(settings, attrs) do
+    settings
+    |> cast(attrs, @model_fields)
+    |> validate_models()
+    # A concurrent first-insert race yields a clean {:error, changeset} (422)
+    # instead of an Ecto.ConstraintError (500) on the unique tenant_id index.
+    |> unique_constraint(:tenant_id)
+  end
+
+  @doc """
+  Sets the encrypted `api_key` on a changeset via `put_change/3` (never `cast`),
+  validating it's a non-empty, bounded string. A `nil`/absent value leaves the
+  existing key untouched; a blank string is rejected.
+  """
+  @spec put_api_key(Ecto.Changeset.t(), String.t() | nil) :: Ecto.Changeset.t()
+  def put_api_key(changeset, nil), do: changeset
+
+  def put_api_key(changeset, api_key) when is_binary(api_key) do
+    trimmed = String.trim(api_key)
+
+    cond do
+      trimmed == "" ->
+        add_error(changeset, :api_key, "must not be blank")
+
+      String.length(trimmed) > @max_api_key_length ->
+        add_error(changeset, :api_key, "is too long (max #{@max_api_key_length} characters)")
+
+      true ->
+        put_change(changeset, :api_key, trimmed)
+    end
+  end
+
+  def put_api_key(changeset, _other),
+    do: add_error(changeset, :api_key, "must be a string")
+
+  defp validate_models(changeset) do
+    Enum.reduce(@model_fields, changeset, fn field, acc ->
+      acc
+      |> validate_format(field, @model_format,
+        message: "must be a plausible model id (letters, digits, . _ : -)"
+      )
+      |> validate_length(field, min: 1, max: @max_model_length)
+    end)
+  end
+end

--- a/lib/loopctl/llm/usage_event.ex
+++ b/lib/loopctl/llm/usage_event.ex
@@ -49,5 +49,9 @@ defmodule Loopctl.Llm.UsageEvent do
     |> validate_required([:operation, :model, :occurred_at])
     |> validate_number(:input_tokens, greater_than_or_equal_to: 0)
     |> validate_number(:output_tokens, greater_than_or_equal_to: 0)
+    # A tenant deleted mid-flight (FK race) maps to a clean {:error, changeset}
+    # instead of raising — so best-effort usage recording never crashes an
+    # already-successful (already-billed) Anthropic call (review #3).
+    |> foreign_key_constraint(:tenant_id)
   end
 end

--- a/lib/loopctl/llm/usage_event.ex
+++ b/lib/loopctl/llm/usage_event.ex
@@ -1,0 +1,53 @@
+defmodule Loopctl.Llm.UsageEvent do
+  @moduledoc """
+  Schema for the `llm_usage_events` table — one immutable row per successful
+  tenant LLM operation (Epic 28 residual, #179).
+
+  Records the operation, the model used, and the Anthropic-reported token counts.
+  This is a RECORD-ONLY ledger backing the per-tenant usage-summary API; there is
+  NO budget enforcement anywhere in the system.
+  """
+
+  use Loopctl.Schema
+
+  @type t :: %__MODULE__{}
+
+  @operations [:extraction, :classification, :merge]
+
+  schema "llm_usage_events" do
+    tenant_field()
+
+    field :operation, Ecto.Enum, values: @operations
+    field :model, :string
+    field :input_tokens, :integer, default: 0
+    field :output_tokens, :integer, default: 0
+    field :source_type, :string
+    field :article_id, :binary_id
+    field :occurred_at, :utc_datetime_usec
+  end
+
+  @doc "The valid operation atoms (extraction | classification | merge)."
+  @spec operations() :: [atom()]
+  def operations, do: @operations
+
+  @doc """
+  Changeset for inserting a usage event. `tenant_id` and `occurred_at` are set
+  programmatically by the context.
+  """
+  @spec create_changeset(t(), map()) :: Ecto.Changeset.t()
+  def create_changeset(event \\ %__MODULE__{}, attrs) do
+    event
+    |> cast(attrs, [
+      :operation,
+      :model,
+      :input_tokens,
+      :output_tokens,
+      :source_type,
+      :article_id,
+      :occurred_at
+    ])
+    |> validate_required([:operation, :model, :occurred_at])
+    |> validate_number(:input_tokens, greater_than_or_equal_to: 0)
+    |> validate_number(:output_tokens, greater_than_or_equal_to: 0)
+  end
+end

--- a/lib/loopctl/workers/content_ingestion_worker.ex
+++ b/lib/loopctl/workers/content_ingestion_worker.ex
@@ -165,6 +165,7 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
     if Llm.has_api_key?(tenant_id) do
       :ok
     else
+      Llm.record_blocked(tenant_id, :extraction)
       {:discard, {:no_api_key, "tenant has no Anthropic API key configured (BYO required)"}}
     end
   end

--- a/lib/loopctl/workers/content_ingestion_worker.ex
+++ b/lib/loopctl/workers/content_ingestion_worker.ex
@@ -48,6 +48,7 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   alias Loopctl.Audit
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.ContentChunker
+  alias Loopctl.Llm
   alias Loopctl.Net.UrlGuard
   alias Loopctl.Workers.ArticleEmbeddingWorker
 
@@ -134,7 +135,11 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
     # malformed / non-string project_id would raise Ecto.ChangeError on insert and,
     # because the uniqueness key excludes project_id, crash-loop as a poison pill.
     # DISCARD such a job (no retry) BEFORE any fetch/LLM work rather than raising.
+    # Mandatory BYO (Epic 28, #179): the tenant must have its own Anthropic key.
+    # {:discard} up front (no fetch, no LLM work, no retry-loop) when it doesn't —
+    # the controller boundary 422s before enqueue, this is defense in depth.
     with :ok <- validate_project_id(project_id),
+         :ok <- require_tenant_llm_key(tenant_id),
          {:ok, content} <- resolve_content(url, raw_content) do
       ctx = %{
         tenant_id: tenant_id,
@@ -150,6 +155,17 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
       }
 
       ingest_chunks(ctx, content)
+    end
+  end
+
+  # Mandatory BYO: without a tenant Anthropic key, extraction can never succeed —
+  # {:discard} cleanly (no infinite retry) rather than burning 3 attempts on a
+  # deterministic no-key failure.
+  defp require_tenant_llm_key(tenant_id) do
+    if Llm.has_api_key?(tenant_id) do
+      :ok
+    else
+      {:discard, {:no_api_key, "tenant has no Anthropic API key configured (BYO required)"}}
     end
   end
 
@@ -266,7 +282,9 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   # persistence reintroduces that need — a cross-chunk title collision would
   # otherwise abort the whole chunk on the `articles_tenant_title_active_idx`).
   defp extract_and_persist_chunk(ctx, chunk, chunk_index, remaining, seen_titles) do
-    case @content_extractor.extract_from_content(chunk, source_type: ctx.source_type) do
+    case @content_extractor.extract_from_content(ctx.tenant_id, chunk,
+           source_type: ctx.source_type
+         ) do
       {:ok, extracted} ->
         {articles, seen_titles} =
           extracted
@@ -378,6 +396,11 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
     do: constraint_violation?(error)
 
   defp permanent_error?({:insert_failed, _step, %Ecto.Changeset{}}), do: true
+
+  # Mandatory BYO: a missing tenant key is deterministic (a retry can't fix it).
+  # The top-level gate normally discards before any chunk runs; this backstops the
+  # case where the key is removed mid-job between chunks.
+  defp permanent_error?(:no_api_key), do: true
 
   defp permanent_error?(_), do: false
 

--- a/lib/loopctl/workers/content_ingestion_worker.ex
+++ b/lib/loopctl/workers/content_ingestion_worker.ex
@@ -43,6 +43,8 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
 
   require Logger
 
+  import Ecto.Query, only: [from: 2]
+
   alias Ecto.Multi
   alias Loopctl.AdminRepo
   alias Loopctl.Audit
@@ -255,6 +257,37 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   end
 
   defp reduce_chunk(ctx, chunk, chunk_index, remaining, acc) do
+    case persisted_chunk_titles(ctx, chunk_index) do
+      [] ->
+        extract_reduce_chunk(ctx, chunk, chunk_index, remaining, acc)
+
+      titles ->
+        # This chunk's articles were durably committed by a PRIOR attempt (#179
+        # review #1). SKIP re-extraction entirely — a whole-job Oban retry must
+        # NEVER re-call (and re-BILL) the tenant's Anthropic key for a chunk that
+        # already succeeded. Seed cross-chunk dedup with the persisted titles and
+        # count them toward the article budget so the run stays consistent.
+        seen =
+          Enum.reduce(titles, acc.seen_titles, fn t, s ->
+            MapSet.put(s, normalize_persisted_title(t))
+          end)
+
+        Logger.info(
+          "ContentIngestionWorker: chunk #{chunk_index} already persisted " <>
+            "(#{length(titles)} article(s)); skipping re-extraction (no re-bill)"
+        )
+
+        {:cont,
+         %{
+           acc
+           | inserted: acc.inserted + length(titles),
+             persisted: acc.persisted + 1,
+             seen_titles: seen
+         }}
+    end
+  end
+
+  defp extract_reduce_chunk(ctx, chunk, chunk_index, remaining, acc) do
     acc = %{acc | attempted: acc.attempted + 1}
 
     case extract_and_persist_chunk(ctx, chunk, chunk_index, remaining, acc.seen_titles) do
@@ -846,18 +879,45 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
     |> Map.new()
   end
 
-  # DETERMINISTIC per-article idempotency key from (content_hash, chunk_index,
-  # article_index_within_chunk) — NEVER from the LLM output, which varies across
-  # calls (#264, Finding 1). Identical across Oban retries (all three inputs are
-  # deterministic), so a retry re-reaching the same (chunk, article) slot conflicts
-  # on `articles_tenant_idempotency_key_idx` and no-ops instead of duplicating.
-  # SHA-256 hex keeps the key bounded (67 chars) regardless of content_hash length.
-  defp ingest_idempotency_key(content_hash, chunk_index, article_index) do
+  # DETERMINISTIC per-CHUNK idempotency prefix from (content_hash, chunk_index).
+  # The per-article key appends ":<article_index>" (below), so ALL of a chunk's
+  # articles share this prefix — which lets `chunk_already_persisted?/2` detect a
+  # committed chunk via a `LIKE prefix || ':%'` query and SKIP re-extraction on a
+  # retry (#179 review #1: re-extracting an already-persisted chunk re-BILLS the
+  # tenant's Anthropic key). SHA-256 hex keeps it bounded regardless of hash length.
+  defp ingest_chunk_prefix(content_hash, chunk_index) do
     digest =
       :sha256
-      |> :crypto.hash("#{content_hash}:#{chunk_index}:#{article_index}")
+      |> :crypto.hash("#{content_hash}:#{chunk_index}")
       |> Base.encode16(case: :lower)
 
     "ingest:" <> digest
+  end
+
+  # DETERMINISTIC per-article idempotency key = chunk prefix + ":" + article index.
+  # NEVER from the LLM output (which varies across calls, #264 Finding 1). Identical
+  # across Oban retries, so a retry re-reaching the same (chunk, article) slot
+  # conflicts on `articles_tenant_idempotency_key_idx` and no-ops (backstop to the
+  # chunk-skip above).
+  defp ingest_idempotency_key(content_hash, chunk_index, article_index) do
+    ingest_chunk_prefix(content_hash, chunk_index) <> ":" <> Integer.to_string(article_index)
+  end
+
+  # Titles of the articles a PRIOR attempt already persisted for this chunk (empty
+  # list = not yet persisted). Keyed on the deterministic per-chunk idempotency
+  # prefix; the digest + integer index contain no LIKE wildcards, so the pattern is
+  # injection-safe. Used both to SKIP re-extraction and to seed cross-chunk dedup.
+  defp persisted_chunk_titles(ctx, chunk_index) do
+    pattern = ingest_chunk_prefix(ctx.content_hash, chunk_index) <> ":%"
+
+    from(a in Article,
+      where: a.tenant_id == ^ctx.tenant_id and like(a.idempotency_key, ^pattern),
+      select: a.title
+    )
+    |> AdminRepo.all()
+  end
+
+  defp normalize_persisted_title(title) do
+    (title || "") |> String.trim() |> String.downcase()
   end
 end

--- a/lib/loopctl/workers/content_ingestion_worker.ex
+++ b/lib/loopctl/workers/content_ingestion_worker.ex
@@ -228,6 +228,17 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   # beyond @max_chunks are ingested up to that bound and the remainder is
   # {:discard}ed cleanly (with a count) rather than silently lost.
   defp ingest_chunks(ctx, content) do
+    # Key the per-chunk idempotency/skip on a hash of the ACTUALLY-RESOLVED bytes
+    # for THIS attempt — NOT the enqueue-time `content_hash` (#179 review round 4).
+    # For a URL job `content_hash` is sha256(url), but the bytes are re-fetched fresh
+    # on every Oban attempt; if the URL's content changed between attempts, keying the
+    # skip on the URL would false-SKIP the new bytes' chunks and silently keep stale
+    # content. Keying on sha256(fetched bytes) SKIPS correctly only when the content
+    # is byte-identical across attempts and RE-EXTRACTS when it genuinely changed.
+    # (For content-only jobs this equals `content_hash`, so their behavior is unchanged.)
+    fetched_hash = :sha256 |> :crypto.hash(content) |> Base.encode16(case: :lower)
+    ctx = Map.put(ctx, :fetched_hash, fetched_hash)
+
     chunks = ContentChunker.chunk(content)
     chunk_count = length(chunks)
     {processable, dropped} = Enum.split(chunks, @max_chunks)
@@ -727,7 +738,7 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
         attrs
         |> normalize_attrs()
         |> Map.delete(:status)
-        |> Map.put(:idempotency_key, ingest_idempotency_key(ctx.content_hash, chunk_index, index))
+        |> Map.put(:idempotency_key, ingest_idempotency_key(ctx.fetched_hash, chunk_index, index))
 
       base = %Article{
         tenant_id: ctx.tenant_id,
@@ -879,16 +890,18 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
     |> Map.new()
   end
 
-  # DETERMINISTIC per-CHUNK idempotency prefix from (content_hash, chunk_index).
-  # The per-article key appends ":<article_index>" (below), so ALL of a chunk's
-  # articles share this prefix — which lets `chunk_already_persisted?/2` detect a
-  # committed chunk via a `LIKE prefix || ':%'` query and SKIP re-extraction on a
-  # retry (#179 review #1: re-extracting an already-persisted chunk re-BILLS the
-  # tenant's Anthropic key). SHA-256 hex keeps it bounded regardless of hash length.
-  defp ingest_chunk_prefix(content_hash, chunk_index) do
+  # DETERMINISTIC per-CHUNK idempotency prefix from (fetched_hash, chunk_index),
+  # where `fetched_hash = sha256(actually-resolved bytes for this attempt)` — NOT the
+  # enqueue-time content_hash (#179 review round 4). The per-article key appends
+  # ":<article_index>" (below), so ALL of a chunk's articles share this prefix — which
+  # lets `persisted_chunk_titles/2` detect a committed chunk via a `LIKE prefix || ':%'`
+  # query and SKIP re-extraction on a retry (round-3 #1: re-extracting an
+  # already-persisted chunk re-BILLS the tenant's Anthropic key) ONLY when the resolved
+  # bytes are byte-identical across attempts. SHA-256 hex keeps it bounded.
+  defp ingest_chunk_prefix(fetched_hash, chunk_index) do
     digest =
       :sha256
-      |> :crypto.hash("#{content_hash}:#{chunk_index}")
+      |> :crypto.hash("#{fetched_hash}:#{chunk_index}")
       |> Base.encode16(case: :lower)
 
     "ingest:" <> digest
@@ -896,11 +909,11 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
 
   # DETERMINISTIC per-article idempotency key = chunk prefix + ":" + article index.
   # NEVER from the LLM output (which varies across calls, #264 Finding 1). Identical
-  # across Oban retries, so a retry re-reaching the same (chunk, article) slot
-  # conflicts on `articles_tenant_idempotency_key_idx` and no-ops (backstop to the
-  # chunk-skip above).
-  defp ingest_idempotency_key(content_hash, chunk_index, article_index) do
-    ingest_chunk_prefix(content_hash, chunk_index) <> ":" <> Integer.to_string(article_index)
+  # across Oban retries FOR IDENTICAL fetched bytes, so a retry re-reaching the same
+  # (chunk, article) slot conflicts on `articles_tenant_idempotency_key_idx` and no-ops
+  # (backstop to the chunk-skip above).
+  defp ingest_idempotency_key(fetched_hash, chunk_index, article_index) do
+    ingest_chunk_prefix(fetched_hash, chunk_index) <> ":" <> Integer.to_string(article_index)
   end
 
   # Titles of the articles a PRIOR attempt already persisted for this chunk (empty
@@ -908,7 +921,7 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   # prefix; the digest + integer index contain no LIKE wildcards, so the pattern is
   # injection-safe. Used both to SKIP re-extraction and to seed cross-chunk dedup.
   defp persisted_chunk_titles(ctx, chunk_index) do
-    pattern = ingest_chunk_prefix(ctx.content_hash, chunk_index) <> ":%"
+    pattern = ingest_chunk_prefix(ctx.fetched_hash, chunk_index) <> ":%"
 
     from(a in Article,
       where: a.tenant_id == ^ctx.tenant_id and like(a.idempotency_key, ^pattern),

--- a/lib/loopctl/workers/knowledge_lint_worker.ex
+++ b/lib/loopctl/workers/knowledge_lint_worker.ex
@@ -106,6 +106,15 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
     :ok
   end
 
+  # Hard wall-clock backstop for a shared `:knowledge` queue slot (review #4).
+  # `Knowledge.execute_conflict_resolutions/2` is itself budget-bounded (~2 min),
+  # and orphan re-link only ENQUEUES cheap jobs, so a healthy per-tenant run is
+  # well under this; without it, an Oban default of `:infinity` would let a
+  # pathological run pin a slot indefinitely (concurrency 5) and starve other
+  # tenants' ingestion/review jobs.
+  @impl Oban.Worker
+  def timeout(_job), do: :timer.minutes(10)
+
   # --- Private ---
 
   # Orphans split two ways:

--- a/lib/loopctl/workers/knowledge_reclassify_worker.ex
+++ b/lib/loopctl/workers/knowledge_reclassify_worker.ex
@@ -104,21 +104,23 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorker do
   end
 
   def perform(%Oban.Job{args: %{"tenant_id" => tenant_id} = args}) do
-    if Loopctl.Llm.has_api_key?(tenant_id) do
-      run_tenant(tenant_id, args)
-    else
-      # Mandatory BYO (Epic 28, #179): no tenant Anthropic key → nothing to do.
-      # Skip cleanly (no snooze/retry loop) rather than failing every classify call.
-      Logger.info(
-        "KnowledgeReclassifyWorker: tenant=#{tenant_id} has no Anthropic key configured; " <>
-          "skipping reclassification (BYO required)."
-      )
+    # Resolve the tenant's key + classification model ONCE per kick (review #19):
+    # this both enforces mandatory BYO (Epic 28, #179) AND avoids a per-article
+    # Loopctl.Llm.resolve/2 DB read across the batch — the resolved credentials are
+    # threaded into every classify call.
+    case Loopctl.Llm.resolve(tenant_id, :classification) do
+      {:ok, resolved} ->
+        run_tenant(tenant_id, resolved, args)
 
-      :ok
+      {:error, :no_api_key} ->
+        # No tenant Anthropic key → nothing to do. Skip cleanly (no snooze/retry
+        # loop) rather than failing every classify call.
+        Loopctl.Llm.record_blocked(tenant_id, :classification)
+        :ok
     end
   end
 
-  defp run_tenant(tenant_id, args) do
+  defp run_tenant(tenant_id, resolved, args) do
     run_mode = Map.get(args, "run_mode", "dry_run")
 
     batch_size =
@@ -139,16 +141,15 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorker do
     processed_so_far = Map.get(args, "processed", 0)
 
     batch = fetch_batch(tenant_id, cursor, batch_size)
-    tally = process_batch(tenant_id, batch, run_mode, min_confidence)
+    tally = process_batch(tenant_id, resolved, batch, run_mode, min_confidence)
 
-    if upstream_unavailable?(batch, tally) do
-      # A mostly/entirely failed batch means the classifier upstream (Anthropic,
-      # or this host's egress) is unreachable -- NOT that the articles are bad.
-      # Snooze: Oban re-runs THIS SAME job (same cursor) later WITHOUT consuming
-      # an attempt and WITHOUT advancing, so an outage pauses the migration and it
-      # resumes cleanly when connectivity returns -- no articles skipped, no audit
-      # spam. (The migration also runs on the Fly host, so a local outage at the
-      # operator's site never touches it.)
+    if transient_outage?(batch, tally) do
+      # A batch dominated by TRANSIENT errors (connection refused, timeout, 5xx,
+      # 408/429) means the classifier upstream is unreachable -- NOT that the
+      # articles or the tenant's key are bad. Snooze: Oban re-runs THIS SAME job
+      # (same cursor) later WITHOUT consuming an attempt and WITHOUT advancing, so
+      # an outage pauses the migration and resumes cleanly when connectivity
+      # returns -- no articles skipped, no audit spam.
       snooze =
         Application.get_env(
           :loopctl,
@@ -158,12 +159,18 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorker do
 
       Logger.warning(
         "KnowledgeReclassifyWorker: tenant=#{tenant_id} batch failed to classify " <>
-          "(#{tally.errors}/#{tally.processed}); classifier upstream likely unreachable. " <>
-          "Snoozing #{snooze}s and retrying the same cursor (nothing skipped)."
+          "(#{tally.transient_errors}/#{tally.processed} transient); upstream likely " <>
+          "unreachable. Snoozing #{snooze}s and retrying the same cursor (nothing skipped)."
       )
 
       {:snooze, snooze}
     else
+      # PERMANENT errors (4xx auth/bad-request, unparseable) do NOT snooze — a
+      # permanently-misconfigured tenant (bad key / bogus model) would otherwise
+      # snooze every 60s forever (review #4). Log if permanent errors dominate,
+      # then advance normally: those articles stay unchanged and the migration
+      # progresses to completion rather than looping.
+      maybe_warn_permanent(tenant_id, tally)
       log_audit(tenant_id, run_mode, tally, processed_so_far)
       new_processed = processed_so_far + tally.processed
       maybe_chain(batch, tenant_id, args, batch_size, max_per_run, new_processed)
@@ -171,23 +178,37 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorker do
     end
   end
 
-  # True when a non-empty batch came back with an error RATE at or above the
-  # configured threshold -- the signal of an upstream/connectivity outage rather
-  # than a few unparseable articles. (With the JSON-parse fix, genuine per-article
-  # errors are rare, so a high rate almost always means the API is unreachable.)
-  defp upstream_unavailable?([], _tally), do: false
+  # Snooze ONLY when TRANSIENT errors dominate the batch (a real outage). Permanent
+  # errors never trigger a snooze, so a misconfigured tenant can't loop forever.
+  defp transient_outage?([], _tally), do: false
+  defp transient_outage?(_batch, %{processed: 0}), do: false
 
-  defp upstream_unavailable?(_batch, %{processed: 0}), do: false
+  defp transient_outage?(_batch, %{processed: processed, transient_errors: transient}) do
+    transient / processed >= snooze_rate()
+  end
 
-  defp upstream_unavailable?(_batch, %{processed: processed, errors: errors}) do
-    rate =
-      Application.get_env(
-        :loopctl,
-        :knowledge_reclassify_snooze_error_rate,
-        @default_snooze_error_rate
+  # When permanent errors dominate a batch, log it once (chain-of-custody breadcrumb
+  # in the standard log stream) so a persistently bad key/model is visible instead of
+  # silently no-oping the whole corpus.
+  defp maybe_warn_permanent(tenant_id, %{processed: processed, permanent_errors: permanent})
+       when processed > 0 do
+    if permanent / processed >= snooze_rate() do
+      Logger.warning(
+        "KnowledgeReclassifyWorker: tenant=#{tenant_id} batch dominated by PERMANENT " <>
+          "classify errors (#{permanent}/#{processed}) — likely a bad key/model. Advancing " <>
+          "without retrying those articles (not an outage; not snoozing)."
       )
+    end
+  end
 
-    errors / processed >= rate
+  defp maybe_warn_permanent(_tenant_id, _tally), do: :ok
+
+  defp snooze_rate do
+    Application.get_env(
+      :loopctl,
+      :knowledge_reclassify_snooze_error_rate,
+      @default_snooze_error_rate
+    )
   end
 
   # --- batch fetch (keyset by id) ---
@@ -220,7 +241,7 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorker do
   # batch isn't 100 serial round-trips. Writes stay SERIAL (in the reduce, on the
   # worker process) so the small BYPASSRLS admin pool is never hit by N
   # concurrent updates.
-  defp process_batch(tenant_id, batch, run_mode, min_confidence) do
+  defp process_batch(tenant_id, resolved, batch, run_mode, min_confidence) do
     max_concurrency =
       Application.get_env(
         :loopctl,
@@ -228,9 +249,14 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorker do
         @default_max_concurrency
       )
 
+    # Thread the ONCE-resolved credentials into every classify call (review #19).
+    classify_opts = [api_key: resolved.api_key, model: resolved.model]
+
     batch
     |> Task.async_stream(
-      fn article -> {article, @classifier.classify(tenant_id, article.title, article.body)} end,
+      fn article ->
+        {article, @classifier.classify(tenant_id, article.title, article.body, classify_opts)}
+      end,
       max_concurrency: max_concurrency,
       timeout: @classify_timeout_ms,
       on_timeout: :kill_task,
@@ -240,7 +266,16 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorker do
   end
 
   defp empty_tally do
-    %{processed: 0, changed: 0, unchanged: 0, low_confidence: 0, errors: 0, by_transition: %{}}
+    %{
+      processed: 0,
+      changed: 0,
+      unchanged: 0,
+      low_confidence: 0,
+      errors: 0,
+      transient_errors: 0,
+      permanent_errors: 0,
+      by_transition: %{}
+    }
   end
 
   defp reduce_outcome({:ok, {article, {:ok, verdict}}}, acc, min_confidence, run_mode) do
@@ -249,15 +284,42 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorker do
     classify_outcome(acc, article, proposed, confidence, min_confidence, run_mode)
   end
 
-  defp reduce_outcome({:ok, {_article, {:error, _reason}}}, acc, _min_confidence, _run_mode) do
-    %{acc | processed: acc.processed + 1, errors: acc.errors + 1}
+  defp reduce_outcome({:ok, {_article, {:error, reason}}}, acc, _min_confidence, _run_mode) do
+    # Classify error rate/transient split (review #4): a PERMANENT error (4xx
+    # auth/bad-request, unparseable verdict, no_api_key) must not cause an infinite
+    # snooze; only TRANSIENT errors (timeout/5xx/429/connection) signal an outage.
+    count_error(acc, permanent_classify_error?(reason))
   end
 
-  # A classification task that timed out or crashed -- count it processed+errored;
-  # its article is simply left for a later run (commit writes are idempotent).
+  # A classification task that timed out or crashed -- TRANSIENT (a hung/slow
+  # upstream, retryable). Count it processed+errored; its article is left for a
+  # later run (commit writes are idempotent).
   defp reduce_outcome({:exit, _reason}, acc, _min_confidence, _run_mode) do
-    %{acc | processed: acc.processed + 1, errors: acc.errors + 1}
+    count_error(acc, false)
   end
+
+  defp count_error(acc, permanent?) do
+    acc = %{acc | processed: acc.processed + 1, errors: acc.errors + 1}
+
+    if permanent? do
+      %{acc | permanent_errors: acc.permanent_errors + 1}
+    else
+      %{acc | transient_errors: acc.transient_errors + 1}
+    end
+  end
+
+  # Permanent = a retry can't fix it: a 4xx (other than 408 timeout / 429 rate
+  # limited, which ARE transient), an unparseable verdict, or a missing key.
+  # Everything else (connection/timeout/5xx/request_failed) is transient.
+  defp permanent_classify_error?(:no_api_key), do: true
+  defp permanent_classify_error?(:unparseable_classification), do: true
+
+  defp permanent_classify_error?({:api_error, status, _body})
+       when is_integer(status) and status >= 400 and status < 500 and status != 408 and
+              status != 429,
+       do: true
+
+  defp permanent_classify_error?(_), do: false
 
   defp classify_outcome(acc, article, proposed, confidence, min_confidence, run_mode) do
     current = article.category
@@ -337,6 +399,8 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorker do
           "unchanged" => tally.unchanged,
           "low_confidence" => tally.low_confidence,
           "errors" => tally.errors,
+          "transient_errors" => tally.transient_errors,
+          "permanent_errors" => tally.permanent_errors,
           "by_transition" => tally.by_transition
         }
       }

--- a/lib/loopctl/workers/knowledge_reclassify_worker.ex
+++ b/lib/loopctl/workers/knowledge_reclassify_worker.ex
@@ -104,6 +104,21 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorker do
   end
 
   def perform(%Oban.Job{args: %{"tenant_id" => tenant_id} = args}) do
+    if Loopctl.Llm.has_api_key?(tenant_id) do
+      run_tenant(tenant_id, args)
+    else
+      # Mandatory BYO (Epic 28, #179): no tenant Anthropic key → nothing to do.
+      # Skip cleanly (no snooze/retry loop) rather than failing every classify call.
+      Logger.info(
+        "KnowledgeReclassifyWorker: tenant=#{tenant_id} has no Anthropic key configured; " <>
+          "skipping reclassification (BYO required)."
+      )
+
+      :ok
+    end
+  end
+
+  defp run_tenant(tenant_id, args) do
     run_mode = Map.get(args, "run_mode", "dry_run")
 
     batch_size =
@@ -124,7 +139,7 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorker do
     processed_so_far = Map.get(args, "processed", 0)
 
     batch = fetch_batch(tenant_id, cursor, batch_size)
-    tally = process_batch(batch, run_mode, min_confidence)
+    tally = process_batch(tenant_id, batch, run_mode, min_confidence)
 
     if upstream_unavailable?(batch, tally) do
       # A mostly/entirely failed batch means the classifier upstream (Anthropic,
@@ -205,7 +220,7 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorker do
   # batch isn't 100 serial round-trips. Writes stay SERIAL (in the reduce, on the
   # worker process) so the small BYPASSRLS admin pool is never hit by N
   # concurrent updates.
-  defp process_batch(batch, run_mode, min_confidence) do
+  defp process_batch(tenant_id, batch, run_mode, min_confidence) do
     max_concurrency =
       Application.get_env(
         :loopctl,
@@ -215,7 +230,7 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorker do
 
     batch
     |> Task.async_stream(
-      fn article -> {article, @classifier.classify(article.title, article.body)} end,
+      fn article -> {article, @classifier.classify(tenant_id, article.title, article.body)} end,
       max_concurrency: max_concurrency,
       timeout: @classify_timeout_ms,
       on_timeout: :kill_task,

--- a/lib/loopctl/workers/review_knowledge_worker.ex
+++ b/lib/loopctl/workers/review_knowledge_worker.ex
@@ -12,7 +12,8 @@ defmodule Loopctl.Workers.ReviewKnowledgeWorker do
   1. Check for duplicate extraction (source_type + source_id)
   2. Load the review record by `review_record_id` + `tenant_id`
   3. Build context map from the review record
-  4. Call `@extractor.extract_articles/1` via compile-time DI
+  4. Call `@extractor.extract_articles/2` (tenant_id + context) via compile-time DI,
+     using the tenant's BYO Anthropic key (Epic 28, #179)
   5. Validate extractor output (max 5 articles, body max 100KB, etc.)
   6. Insert valid articles in one Ecto.Multi with source_type: "review_finding"
   7. Log audit event "knowledge.articles_extracted"
@@ -39,6 +40,7 @@ defmodule Loopctl.Workers.ReviewKnowledgeWorker do
   alias Loopctl.Artifacts.ReviewRecord
   alias Loopctl.Audit
   alias Loopctl.Knowledge.Article
+  alias Loopctl.Llm
 
   @extractor Application.compile_env(
                :loopctl,
@@ -59,15 +61,25 @@ defmodule Loopctl.Workers.ReviewKnowledgeWorker do
   def perform(%Oban.Job{
         args: %{"review_record_id" => review_record_id, "tenant_id" => tenant_id}
       }) do
-    if already_extracted?(tenant_id, review_record_id) do
-      Logger.info(
-        "ReviewKnowledgeWorker: skipping duplicate extraction " <>
-          "(review_record_id=#{review_record_id})"
-      )
+    cond do
+      already_extracted?(tenant_id, review_record_id) ->
+        Logger.info(
+          "ReviewKnowledgeWorker: skipping duplicate extraction " <>
+            "(review_record_id=#{review_record_id})"
+        )
 
-      :ok
-    else
-      extract_from_review(tenant_id, review_record_id)
+        :ok
+
+      # Mandatory BYO (Epic 28, #179): review-knowledge extraction runs on the
+      # tenant's OWN Anthropic key. Without one, {:discard} cleanly (no crash, no
+      # retry loop, no operator-billed spend) rather than falling back to a global
+      # key. Defense in depth — the extractor also returns {:error, :no_api_key}.
+      not Llm.has_api_key?(tenant_id) ->
+        Llm.record_blocked(tenant_id, :extraction)
+        {:discard, {:no_api_key, "tenant has no Anthropic API key configured (BYO required)"}}
+
+      true ->
+        extract_from_review(tenant_id, review_record_id)
     end
   end
 
@@ -94,9 +106,21 @@ defmodule Loopctl.Workers.ReviewKnowledgeWorker do
   defp extract_from_review(tenant_id, review_record_id) do
     with {:ok, review_record} <- load_review_record(tenant_id, review_record_id),
          context <- build_context(review_record, tenant_id),
-         {:ok, raw_articles} <- @extractor.extract_articles(context) do
+         {:ok, raw_articles} <- extract(tenant_id, context) do
       articles = validate_and_filter(raw_articles)
       insert_articles(tenant_id, review_record_id, articles)
+    end
+  end
+
+  # Backstop for a key removed between the perform/1 gate and here: map
+  # {:error, :no_api_key} to a clean {:discard} rather than an infinite retry.
+  defp extract(tenant_id, context) do
+    case @extractor.extract_articles(tenant_id, context) do
+      {:error, :no_api_key} ->
+        {:discard, {:no_api_key, "tenant has no Anthropic API key configured (BYO required)"}}
+
+      other ->
+        other
     end
   end
 

--- a/lib/loopctl/workers/review_knowledge_worker.ex
+++ b/lib/loopctl/workers/review_knowledge_worker.ex
@@ -104,13 +104,25 @@ defmodule Loopctl.Workers.ReviewKnowledgeWorker do
   end
 
   defp extract_from_review(tenant_id, review_record_id) do
-    with {:ok, review_record} <- load_review_record(tenant_id, review_record_id),
-         context <- build_context(review_record, tenant_id),
-         {:ok, raw_articles} <- extract(tenant_id, context) do
-      articles = validate_and_filter(raw_articles)
-      insert_articles(tenant_id, review_record_id, articles)
-    end
+    result =
+      with {:ok, review_record} <- load_review_record(tenant_id, review_record_id),
+           context <- build_context(review_record, tenant_id),
+           {:ok, raw_articles} <- extract(tenant_id, context) do
+        articles = validate_and_filter(raw_articles)
+        insert_articles(tenant_id, review_record_id, articles)
+      end
+
+    # PERMANENT failures (non-408/429 4xx from a bad extraction_model, a
+    # title-collision insert) must NOT retry 3x — each retry burns the TENANT's
+    # paid Anthropic call (review #3). Mirror ContentIngestionWorker.permanent_error?/1.
+    classify_result(result)
   end
+
+  defp classify_result({:error, reason} = err) do
+    if permanent_error?(reason), do: {:discard, reason}, else: err
+  end
+
+  defp classify_result(other), do: other
 
   # Backstop for a key removed between the perform/1 gate and here: map
   # {:error, :no_api_key} to a clean {:discard} rather than an infinite retry.
@@ -123,6 +135,34 @@ defmodule Loopctl.Workers.ReviewKnowledgeWorker do
         other
     end
   end
+
+  # A permanent failure a retry can't fix (mirrors ContentIngestionWorker):
+  #   * a 4xx api_error other than 408 (timeout) / 429 (rate limited);
+  #   * an insert that failed on a changeset (e.g. the active-title unique index
+  #     `articles_tenant_title_active_idx` — review findings recur, so title
+  #     collisions with an existing article are plausible and deterministic); or
+  #   * an insert that raised a constraint Postgrex.Error.
+  # Everything else (5xx / request_failed / json_parse_error / serialization) is transient.
+  defp permanent_error?({:api_error, status, _body})
+       when is_integer(status) and status >= 400 and status < 500 and status != 408 and
+              status != 429,
+       do: true
+
+  defp permanent_error?({:insert_failed, _step, %Ecto.Changeset{}}), do: true
+
+  defp permanent_error?({:insert_failed, _step, %Postgrex.Error{} = error}),
+    do: constraint_violation?(error)
+
+  defp permanent_error?(_), do: false
+
+  @constraint_violation_codes ~w(
+    unique_violation check_violation not_null_violation
+    foreign_key_violation exclusion_violation
+  )a
+  defp constraint_violation?(%Postgrex.Error{postgres: %{code: code}}),
+    do: code in @constraint_violation_codes
+
+  defp constraint_violation?(_), do: false
 
   defp load_review_record(tenant_id, review_record_id) do
     case AdminRepo.get_by(ReviewRecord, id: review_record_id, tenant_id: tenant_id) do

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -206,12 +206,14 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     end
   end
 
-  # Mandatory BYO gate shared by single + batch ingest.
+  # Mandatory BYO gate shared by single + batch ingest. On a miss, record the block
+  # (log + telemetry + audit, review #2) and return a coded 422.
   defp require_llm_key(tenant_id) do
     if Llm.has_api_key?(tenant_id) do
       :ok
     else
-      {:error, :unprocessable_entity, @no_api_key_message}
+      Llm.record_blocked(tenant_id, :extraction)
+      {:error, :no_api_key_configured, @no_api_key_message}
     end
   end
 

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -12,8 +12,14 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   require Logger
 
   alias Loopctl.ApiSpec.Schemas
+  alias Loopctl.Llm
   alias Loopctl.Net.UrlGuard
   alias Loopctl.Workers.ContentIngestionWorker
+
+  # Mandatory BYO (Epic 28, #179): extraction runs on the tenant's OWN Anthropic
+  # key. Reject up front with a clear 422 so we never enqueue a job that can only
+  # {:discard} for a missing key.
+  @no_api_key_message "Configure your Anthropic API key (PUT /api/v1/tenants/me/llm-config) before ingesting content."
   alias LoopctlWeb.Helpers.Pagination
   alias LoopctlWeb.Helpers.ProjectId
 
@@ -109,6 +115,12 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   def create(conn, params) do
     tenant_id = conn.assigns.current_api_key.tenant_id
 
+    with :ok <- require_llm_key(tenant_id) do
+      handle_create(conn, tenant_id, params)
+    end
+  end
+
+  defp handle_create(conn, tenant_id, params) do
     case enqueue_item(tenant_id, params) do
       {:ok, :queued, %{job: job, content_hash: content_hash, source_type: source_type}} ->
         conn
@@ -187,9 +199,19 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     tenant_id = conn.assigns.current_api_key.tenant_id
     items = params["items"]
 
-    with :ok <- validate_batch_items(items) do
+    with :ok <- require_llm_key(tenant_id),
+         :ok <- validate_batch_items(items) do
       results = process_batch_items(tenant_id, items)
       json(conn, LoopctlWeb.KnowledgeIngestionJSON.batch(results))
+    end
+  end
+
+  # Mandatory BYO gate shared by single + batch ingest.
+  defp require_llm_key(tenant_id) do
+    if Llm.has_api_key?(tenant_id) do
+      :ok
+    else
+      {:error, :unprocessable_entity, @no_api_key_message}
     end
   end
 

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -19,7 +19,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # Mandatory BYO (Epic 28, #179): extraction runs on the tenant's OWN Anthropic
   # key. Reject up front with a clear 422 so we never enqueue a job that can only
   # {:discard} for a missing key.
-  @no_api_key_message "Configure your Anthropic API key (PUT /api/v1/tenants/me/llm-config) before ingesting content."
+  @no_api_key_message "Configure your Anthropic API key (PATCH /api/v1/tenants/me/llm-config) before ingesting content."
   alias LoopctlWeb.Helpers.Pagination
   alias LoopctlWeb.Helpers.ProjectId
 

--- a/lib/loopctl_web/controllers/llm_config_controller.ex
+++ b/lib/loopctl_web/controllers/llm_config_controller.ex
@@ -1,0 +1,78 @@
+defmodule LoopctlWeb.LlmConfigController do
+  @moduledoc """
+  Per-tenant BYO Anthropic LLM configuration (Epic 28 residual, #179).
+
+  - `GET  /api/v1/tenants/me/llm-config` — the tenant's model choices +
+    `has_api_key` + a masked last-4 hint. NEVER returns the key itself.
+  - `PUT  /api/v1/tenants/me/llm-config` — set/rotate the api_key and the three
+    per-operation models.
+
+  Both endpoints require the `:user` role — this endpoint stores a tenant secret,
+  so per the security checklist (managing secrets ⇒ `:user`) neither agents nor
+  orchestrators may read or write it.
+  """
+
+  use LoopctlWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Loopctl.ApiSpec.Schemas
+  alias Loopctl.Llm
+
+  action_fallback LoopctlWeb.FallbackController
+
+  # Managing a stored secret is a user-level operation (security checklist §2).
+  plug LoopctlWeb.Plugs.RequireRole, role: :user
+
+  tags(["LLM Configuration"])
+
+  operation(:show,
+    summary: "Get the tenant's LLM configuration",
+    description:
+      "Returns the per-operation model choices, whether an Anthropic API key is " <>
+        "configured (`has_api_key`), and a masked last-4 hint. The key itself is " <>
+        "never returned. Role: user+.",
+    responses: %{
+      200 => {"LLM config", "application/json", Schemas.LlmConfigResponse},
+      401 => {"Unauthorized", "application/json", Schemas.ErrorResponse},
+      403 => {"Forbidden", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  operation(:update,
+    summary: "Set the tenant's LLM configuration",
+    description:
+      "Sets/rotates the tenant's OWN Anthropic API key (stored encrypted, never " <>
+        "returned) and the three per-operation models. loopctl fronts no LLM cost " <>
+        "— the tenant's key bills the tenant. Role: user+.",
+    request_body: {"LLM config", "application/json", Schemas.LlmConfigUpdateRequest},
+    responses: %{
+      200 => {"Updated LLM config", "application/json", Schemas.LlmConfigResponse},
+      401 => {"Unauthorized", "application/json", Schemas.ErrorResponse},
+      403 => {"Forbidden", "application/json", Schemas.ErrorResponse},
+      422 => {"Validation error", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  @doc "GET /api/v1/tenants/me/llm-config"
+  def show(conn, _params) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+    view = tenant_id |> Llm.get_settings() |> Llm.settings_view()
+    json(conn, view)
+  end
+
+  @doc "PUT /api/v1/tenants/me/llm-config"
+  def update(conn, params) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+
+    with {:ok, settings} <- Llm.upsert_settings(tenant_id, config_params(params)) do
+      json(conn, Llm.settings_view(settings))
+    end
+  end
+
+  # Whitelist the accepted keys so nothing else (e.g. tenant_id) can slip in.
+  defp config_params(params) do
+    Map.take(params, ["api_key", "extraction_model", "classification_model", "merge_model"])
+  end
+end

--- a/lib/loopctl_web/controllers/llm_config_controller.ex
+++ b/lib/loopctl_web/controllers/llm_config_controller.ex
@@ -2,10 +2,10 @@ defmodule LoopctlWeb.LlmConfigController do
   @moduledoc """
   Per-tenant BYO Anthropic LLM configuration (Epic 28 residual, #179).
 
-  - `GET  /api/v1/tenants/me/llm-config` — the tenant's model choices +
+  - `GET   /api/v1/tenants/me/llm-config` — the tenant's model choices +
     `has_api_key` + a masked last-4 hint. NEVER returns the key itself.
-  - `PUT  /api/v1/tenants/me/llm-config` — set/rotate the api_key and the three
-    per-operation models.
+  - `PATCH /api/v1/tenants/me/llm-config` — set/rotate the api_key and the three
+    per-operation models (partial-merge; omitted fields are left untouched).
 
   Both endpoints require the `:user` role — this endpoint stores a tenant secret,
   so per the security checklist (managing secrets ⇒ `:user`) neither agents nor
@@ -62,7 +62,7 @@ defmodule LoopctlWeb.LlmConfigController do
     json(conn, view)
   end
 
-  @doc "PUT /api/v1/tenants/me/llm-config"
+  @doc "PATCH /api/v1/tenants/me/llm-config"
   def update(conn, params) do
     tenant_id = conn.assigns.current_api_key.tenant_id
 

--- a/lib/loopctl_web/controllers/llm_usage_controller.ex
+++ b/lib/loopctl_web/controllers/llm_usage_controller.ex
@@ -33,7 +33,9 @@ defmodule LoopctlWeb.LlmUsageController do
       from: [
         in: :query,
         type: :string,
-        description: "Optional ISO 8601 lower bound (inclusive) on occurred_at",
+        description:
+          "Optional ISO 8601 lower bound (inclusive) on occurred_at. Defaults to a " <>
+            "90-day lookback when omitted; the effective window is echoed in `meta.from`/`meta.to`.",
         required: false
       ],
       to: [

--- a/lib/loopctl_web/controllers/llm_usage_controller.ex
+++ b/lib/loopctl_web/controllers/llm_usage_controller.ex
@@ -1,0 +1,102 @@
+defmodule LoopctlWeb.LlmUsageController do
+  @moduledoc """
+  Per-tenant LLM token-usage summary (Epic 28 residual, #179).
+
+  - `GET /api/v1/knowledge/llm-usage` — usage grouped by operation + model +
+    source_type + day, over an optional date range, with offset/limit pagination.
+
+  Record-only reporting (there is NO budget enforcement). Role: orchestrator+ so
+  an autonomous orchestrator can monitor consumption; the data is the tenant's own
+  aggregate token counts (no secret).
+  """
+
+  use LoopctlWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Loopctl.ApiSpec.Schemas
+  alias Loopctl.Llm
+
+  action_fallback LoopctlWeb.FallbackController
+
+  plug LoopctlWeb.Plugs.RequireRole, role: :orchestrator
+
+  tags(["Knowledge Wiki"])
+
+  operation(:index,
+    summary: "Per-tenant LLM usage summary",
+    description:
+      "Returns token usage for the current tenant grouped by operation + model + " <>
+        "source_type + day, newest day first, with offset/limit pagination over " <>
+        "`meta.total_count`. Optional `from`/`to` (ISO 8601) narrow the window. " <>
+        "Record-only — no budget enforcement. Role: orchestrator+.",
+    parameters: [
+      from: [
+        in: :query,
+        type: :string,
+        description: "Optional ISO 8601 lower bound (inclusive) on occurred_at",
+        required: false
+      ],
+      to: [
+        in: :query,
+        type: :string,
+        description: "Optional ISO 8601 upper bound (inclusive) on occurred_at",
+        required: false
+      ],
+      limit: [
+        in: :query,
+        type: :integer,
+        description: "Max rows per page (default 50, clamped to 200)",
+        required: false
+      ],
+      offset: [
+        in: :query,
+        type: :integer,
+        description: "Rows to skip (default 0)",
+        required: false
+      ]
+    ],
+    responses: %{
+      200 => {"Usage summary", "application/json", Schemas.LlmUsageResponse},
+      401 => {"Unauthorized", "application/json", Schemas.ErrorResponse},
+      403 => {"Forbidden", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  @doc "GET /api/v1/knowledge/llm-usage"
+  def index(conn, params) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+
+    opts = [
+      from: parse_datetime(params["from"]),
+      to: parse_datetime(params["to"]),
+      limit: parse_int(params["limit"]),
+      offset: parse_int(params["offset"])
+    ]
+
+    summary = Llm.usage_summary(tenant_id, Enum.reject(opts, fn {_k, v} -> is_nil(v) end))
+    json(conn, summary)
+  end
+
+  defp parse_datetime(nil), do: nil
+
+  defp parse_datetime(value) when is_binary(value) do
+    case DateTime.from_iso8601(value) do
+      {:ok, dt, _offset} -> dt
+      _ -> nil
+    end
+  end
+
+  defp parse_datetime(_), do: nil
+
+  defp parse_int(value) when is_integer(value), do: value
+
+  defp parse_int(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {n, ""} -> n
+      _ -> nil
+    end
+  end
+
+  defp parse_int(_), do: nil
+end

--- a/lib/loopctl_web/fallback_controller.ex
+++ b/lib/loopctl_web/fallback_controller.ex
@@ -314,6 +314,23 @@ defmodule LoopctlWeb.FallbackController do
     |> json(%{error: %{status: 422, message: message}})
   end
 
+  # Epic 28 (#179): mandatory BYO — a tenant knowledge-LLM operation was blocked
+  # because the tenant has no Anthropic key configured. Carries a machine-readable
+  # `code` so clients can distinguish this from other 422s and prompt the user to
+  # configure a key.
+  def call(conn, {:error, :no_api_key_configured, message}) when is_binary(message) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{
+      error: %{
+        status: 422,
+        code: "no_api_key",
+        message: message,
+        remediation: %{configure: "PUT /api/v1/tenants/me/llm-config"}
+      }
+    })
+  end
+
   # US-27.3: shared DB-error rendering for both Postgrex.Error and
   # DBConnection.ConnectionError. `DBError.map/1` returns the pinned status,
   # safe client message, and the real SQLSTATE for the log. A non-DB error

--- a/lib/loopctl_web/fallback_controller.ex
+++ b/lib/loopctl_web/fallback_controller.ex
@@ -326,7 +326,7 @@ defmodule LoopctlWeb.FallbackController do
         status: 422,
         code: "no_api_key",
         message: message,
-        remediation: %{configure: "PUT /api/v1/tenants/me/llm-config"}
+        remediation: %{configure: "PATCH /api/v1/tenants/me/llm-config"}
       }
     })
   end

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -119,9 +119,10 @@ defmodule LoopctlWeb.Router do
     patch "/tenants/me", TenantController, :update
 
     # Per-tenant BYO Anthropic LLM config (Epic 28 residual, #179). Role :user —
-    # the PUT stores a tenant secret (enforced by the controller's RequireRole).
+    # the PATCH stores a tenant secret (enforced by the controller's RequireRole).
+    # PATCH (partial-merge) mirrors the sibling PATCH /tenants/me.
     get "/tenants/me/llm-config", LlmConfigController, :show
-    put "/tenants/me/llm-config", LlmConfigController, :update
+    patch "/tenants/me/llm-config", LlmConfigController, :update
     post "/tenants/:id/rotate-audit-key/challenge", TenantAuditKeyController, :challenge
     post "/tenants/:id/rotate-audit-key", TenantAuditKeyController, :rotate
     post "/tenants/:id/bootstrap-audit-key", TenantAuditKeyController, :bootstrap

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -117,6 +117,11 @@ defmodule LoopctlWeb.Router do
 
     get "/tenants/me", TenantController, :show
     patch "/tenants/me", TenantController, :update
+
+    # Per-tenant BYO Anthropic LLM config (Epic 28 residual, #179). Role :user —
+    # the PUT stores a tenant secret (enforced by the controller's RequireRole).
+    get "/tenants/me/llm-config", LlmConfigController, :show
+    put "/tenants/me/llm-config", LlmConfigController, :update
     post "/tenants/:id/rotate-audit-key/challenge", TenantAuditKeyController, :challenge
     post "/tenants/:id/rotate-audit-key", TenantAuditKeyController, :rotate
     post "/tenants/:id/bootstrap-audit-key", TenantAuditKeyController, :bootstrap
@@ -340,6 +345,9 @@ defmodule LoopctlWeb.Router do
     post "/knowledge/ingest", KnowledgeIngestionController, :create
     post "/knowledge/ingest/batch", KnowledgeIngestionController, :create_batch
     get "/knowledge/ingestion-jobs", KnowledgeIngestionController, :index
+
+    # Per-tenant LLM token-usage summary (Epic 28 residual, #179). Role: orchestrator+.
+    get "/knowledge/llm-usage", LlmUsageController, :index
 
     # Knowledge Analytics (article usage tracking — orchestrator+)
     get "/knowledge/analytics/top-articles",

--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to `loopctl-mcp-server` are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 2.31.1 — 2026-07-03 (usage-window doc clarity — Epic 28, #179 review)
+
+### Changed
+
+- **`knowledge_llm_usage`** docs now state the 90-day default lookback when `from` is
+  omitted and that the EFFECTIVE window is echoed in `meta.from`/`meta.to`, so callers
+  can detect that older usage was excluded and widen the window explicitly.
+
 ## 2.31.0 — 2026-07-03 (per-tenant BYO Anthropic LLM config + usage — Epic 28, #179)
 
 ### Added

--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to `loopctl-mcp-server` are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 2.31.0 — 2026-07-03 (per-tenant BYO Anthropic LLM config + usage — Epic 28, #179)
+
+### Added
+
+- **`llm_config`** / **`set_llm_config`** — get / set-rotate the tenant's OWN Anthropic
+  API key (stored encrypted, never returned — only `has_api_key` + a last-4 hint) and the
+  three per-operation models. Both require a **user-role** key: they use `LOOPCTL_USER_KEY`
+  EXACTLY, bypassing the global `LOOPCTL_API_KEY` override and failing fast if it's unset,
+  so a secret-management call never runs under a non-user global key.
+- **`knowledge_llm_usage`** — per-tenant LLM token-usage summary (grouped by operation +
+  model + source_type + day, optional `from`/`to`, offset/limit pagination). Orchestrator key.
+
+### Note
+
+- Ingesting content now requires the tenant to have configured an Anthropic key
+  (`set_llm_config`); `knowledge_ingest`/`knowledge_ingest_batch` return a `422` with
+  `code: "no_api_key"` otherwise (mandatory BYO, server #179).
+
 ## 2.30.1 — 2026-07-02 (arg-forwarding + apiCall robustness fixes)
 
 ### Fixed

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -2,7 +2,7 @@
 
 MCP (Model Context Protocol) server for [loopctl](https://loopctl.com) -- structural trust for AI development loops.
 
-Wraps the loopctl REST API into 69 typed MCP tools so AI coding agents (Claude Code, etc.) can interact with loopctl without writing curl commands.
+Wraps the loopctl REST API into 72 typed MCP tools so AI coding agents (Claude Code, etc.) can interact with loopctl without writing curl commands.
 
 ## Installation
 
@@ -66,7 +66,7 @@ Or if installed locally:
 
 Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_KEY`.
 
-## Tools (69)
+## Tools (72)
 
 ### Project Tools
 
@@ -179,6 +179,14 @@ Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_K
 | `knowledge_ingest` | Submit a URL or raw content for knowledge extraction. Enqueues an Oban job. Extracted articles are **drafts by default** (lower-trust LLM output); pass `publish: true` to publish on extraction. Required: `source_type`. One of: `url` or `content`. Optional: `project_id`, `publish`. |
 | `knowledge_ingest_batch` | Submit up to 50 ingestion items in a single request. Each item has the same shape as `knowledge_ingest` (incl. `publish`). Returns per-item results. Required: `items`. Optional: batch-level `project_id` / `publish` defaults. |
 | `knowledge_ingestion_jobs` | List recent content ingestion jobs (last 7 days, max 50). |
+
+### Per-tenant BYO LLM config + usage (Epic 28, #179)
+
+| Tool | Description |
+|---|---|
+| `llm_config` | Get the tenant's BYO Anthropic LLM config: per-operation models, `has_api_key`, and a masked last-4 hint. Never returns the key. Requires **user** key. |
+| `set_llm_config` | Set/rotate the tenant's OWN Anthropic API key (stored encrypted, never returned) + the three per-operation models (`extraction_model`/`classification_model`/`merge_model`). Any subset; omitting `api_key` leaves it untouched. Requires **user** key. |
+| `knowledge_llm_usage` | Per-tenant LLM token-usage summary, grouped by operation + model + source_type + day over an optional `from`/`to` range, with `limit`/`offset` pagination. Record-only (no budget enforcement). Requires orchestrator key. |
 
 ### Knowledge Analytics Tools (orchestrator key)
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -186,7 +186,7 @@ Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_K
 |---|---|
 | `llm_config` | Get the tenant's BYO Anthropic LLM config: per-operation models, `has_api_key`, and a masked last-4 hint. Never returns the key. Requires **user** key. |
 | `set_llm_config` | Set/rotate the tenant's OWN Anthropic API key (stored encrypted, never returned) + the three per-operation models (`extraction_model`/`classification_model`/`merge_model`). Any subset; omitting `api_key` leaves it untouched. Requires **user** key. |
-| `knowledge_llm_usage` | Per-tenant LLM token-usage summary, grouped by operation + model + source_type + day over an optional `from`/`to` range, with `limit`/`offset` pagination. Record-only (no budget enforcement). Requires orchestrator key. |
+| `knowledge_llm_usage` | Per-tenant LLM token-usage summary, grouped by operation + model + source_type + day over an optional `from`/`to` range (defaults to a 90-day lookback; effective window echoed in `meta.from`/`meta.to`), with `limit`/`offset` pagination. Record-only (no budget enforcement). Requires orchestrator key. |
 
 ### Knowledge Analytics Tools (orchestrator key)
 

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -58,12 +58,22 @@ function resolveKey(keyOverride) {
   );
 }
 
-async function apiCall(method, path, body, keyOverride) {
+async function apiCall(method, path, body, keyOverride, { exactKey = false } = {}) {
   const url = `${getBaseUrl()}${path}`;
-  const key = resolveKey(keyOverride);
+  // Secret-managing tools pass exactKey:true so the request uses the EXACT
+  // role-pinned key (LOOPCTL_USER_KEY) and does NOT fall back to the global
+  // LOOPCTL_API_KEY override — a secret op must never silently run under a
+  // non-user global key (review #12).
+  const key = exactKey ? keyOverride : resolveKey(keyOverride);
 
   if (!key) {
-    return { error: true, status: 0, body: "No API key configured. Set LOOPCTL_API_KEY, LOOPCTL_ORCH_KEY, or LOOPCTL_AGENT_KEY." };
+    return {
+      error: true,
+      status: 0,
+      body: exactKey
+        ? "No user-role API key configured. Set LOOPCTL_USER_KEY to a user-role key to manage LLM configuration."
+        : "No API key configured. Set LOOPCTL_API_KEY, LOOPCTL_ORCH_KEY, or LOOPCTL_AGENT_KEY.",
+    };
   }
 
   const headers = {
@@ -1160,12 +1170,14 @@ async function knowledgeIngestionJobs(args = {}) {
 // --- Per-tenant BYO LLM config + usage (Epic 28 residual, #179) ---
 
 async function llmConfig() {
-  // Reading/writing the tenant LLM config touches a stored secret → user key.
+  // Reading/writing the tenant LLM config touches a stored secret → EXACT user
+  // key only (bypass the global LOOPCTL_API_KEY override; fail fast if unset).
   const result = await apiCall(
     "GET",
     "/api/v1/tenants/me/llm-config",
     null,
     process.env.LOOPCTL_USER_KEY,
+    { exactKey: true },
   );
   return toContent(result);
 }
@@ -1176,11 +1188,13 @@ async function setLlmConfig({ api_key, extraction_model, classification_model, m
   if (extraction_model !== undefined) body.extraction_model = extraction_model;
   if (classification_model !== undefined) body.classification_model = classification_model;
   if (merge_model !== undefined) body.merge_model = merge_model;
+  // PATCH (partial-merge) + EXACT user key (review #12, #13).
   const result = await apiCall(
-    "PUT",
+    "PATCH",
     "/api/v1/tenants/me/llm-config",
     body,
     process.env.LOOPCTL_USER_KEY,
+    { exactKey: true },
   );
   return toContent(result);
 }

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -16,6 +16,7 @@ import { dirname, join } from "node:path";
 import {
   projectsPath,
   ingestionJobsPath,
+  llmUsagePath,
   parseJsonResponseBody,
 } from "./lib/http-helpers.js";
 
@@ -1150,6 +1151,46 @@ async function knowledgeIngestionJobs(args = {}) {
   const result = await apiCall(
     "GET",
     ingestionJobsPath(args),
+    null,
+    process.env.LOOPCTL_ORCH_KEY,
+  );
+  return toContent(result);
+}
+
+// --- Per-tenant BYO LLM config + usage (Epic 28 residual, #179) ---
+
+async function llmConfig() {
+  // Reading/writing the tenant LLM config touches a stored secret → user key.
+  const result = await apiCall(
+    "GET",
+    "/api/v1/tenants/me/llm-config",
+    null,
+    process.env.LOOPCTL_USER_KEY,
+  );
+  return toContent(result);
+}
+
+async function setLlmConfig({ api_key, extraction_model, classification_model, merge_model }) {
+  const body = {};
+  if (api_key != null) body.api_key = api_key;
+  if (extraction_model !== undefined) body.extraction_model = extraction_model;
+  if (classification_model !== undefined) body.classification_model = classification_model;
+  if (merge_model !== undefined) body.merge_model = merge_model;
+  const result = await apiCall(
+    "PUT",
+    "/api/v1/tenants/me/llm-config",
+    body,
+    process.env.LOOPCTL_USER_KEY,
+  );
+  return toContent(result);
+}
+
+async function knowledgeLlmUsage(args = {}) {
+  // Query-string building lives in lib/http-helpers.js so the test suite exercises
+  // the same from/to/limit/offset logic the server ships.
+  const result = await apiCall(
+    "GET",
+    llmUsagePath(args),
     null,
     process.env.LOOPCTL_ORCH_KEY,
   );
@@ -3301,6 +3342,74 @@ const TOOLS = [
     },
   },
 
+  // Per-tenant BYO LLM config + usage (Epic 28 residual, #179)
+  {
+    name: "llm_config",
+    description:
+      "Get the tenant's BYO Anthropic LLM configuration: the per-operation model " +
+      "choices, whether a key is configured (has_api_key), and a masked last-4 hint. " +
+      "NEVER returns the key itself. Requires user role (LOOPCTL_USER_KEY).",
+    inputSchema: { type: "object", properties: {}, required: [] },
+  },
+  {
+    name: "set_llm_config",
+    description:
+      "Set/rotate the tenant's OWN Anthropic API key (stored encrypted, never returned) " +
+      "and the three per-operation models (extraction/classification/merge). loopctl " +
+      "fronts no LLM cost — the tenant's key bills the tenant. Any subset of fields may " +
+      "be sent; omitting api_key leaves the existing key untouched. Model ids are " +
+      "free-form (any model the key permits). Requires user role (LOOPCTL_USER_KEY).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        api_key: {
+          type: "string",
+          description: "Anthropic API key (write-only; stored encrypted, never returned).",
+        },
+        extraction_model: {
+          type: "string",
+          description: "Model id for knowledge extraction (null → server default).",
+        },
+        classification_model: {
+          type: "string",
+          description: "Model id for category classification (null → server default).",
+        },
+        merge_model: {
+          type: "string",
+          description: "Model id for article merge synthesis (null → server default).",
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: "knowledge_llm_usage",
+    description:
+      "Per-tenant LLM token-usage summary, grouped by operation + model + source_type + " +
+      "day over an optional date range, newest day first, with offset/limit pagination " +
+      "over meta.total_count. Record-only — there is no budget enforcement. Requires " +
+      "orchestrator role.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        from: {
+          type: "string",
+          description: "Optional ISO 8601 lower bound (inclusive) on occurred_at.",
+        },
+        to: {
+          type: "string",
+          description: "Optional ISO 8601 upper bound (inclusive) on occurred_at.",
+        },
+        limit: {
+          type: "integer",
+          description: "Rows per page (default 50, clamped to 200).",
+        },
+        offset: { type: "integer", description: "Rows to skip (default 0)." },
+      },
+      required: [],
+    },
+  },
+
   // Knowledge Analytics Tools (orchestrator key)
   {
     name: "knowledge_curation_log",
@@ -3775,6 +3884,16 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     case "knowledge_ingestion_jobs":
       return await knowledgeIngestionJobs(args);
+
+    // Per-tenant BYO LLM config + usage (Epic 28, #179)
+    case "llm_config":
+      return await llmConfig();
+
+    case "set_llm_config":
+      return await setLlmConfig(args);
+
+    case "knowledge_llm_usage":
+      return await knowledgeLlmUsage(args);
 
     // Knowledge Analytics Tools
     case "knowledge_curation_log":

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -3401,8 +3401,10 @@ const TOOLS = [
     description:
       "Per-tenant LLM token-usage summary, grouped by operation + model + source_type + " +
       "day over an optional date range, newest day first, with offset/limit pagination " +
-      "over meta.total_count. Record-only — there is no budget enforcement. Requires " +
-      "orchestrator role.",
+      "over meta.total_count. When `from` is omitted it defaults to a 90-day lookback; the " +
+      "EFFECTIVE window is echoed in meta.from/meta.to so you can detect that older usage " +
+      "was excluded (pass an explicit `from` to widen it). Record-only — there is no budget " +
+      "enforcement. Requires orchestrator role.",
     inputSchema: {
       type: "object",
       properties: {

--- a/mcp-server/lib/http-helpers.js
+++ b/mcp-server/lib/http-helpers.js
@@ -54,6 +54,21 @@ export function ingestionJobsPath({ limit, offset, since_days } = {}) {
 }
 
 /**
+ * Path for `knowledge_llm_usage`, honoring from/to/limit/offset (Epic 28, #179).
+ *
+ * @param {{ from?: string, to?: string, limit?: number, offset?: number }} [args]
+ * @returns {string}
+ */
+export function llmUsagePath({ from, to, limit, offset } = {}) {
+  return `/api/v1/knowledge/llm-usage${buildQuery([
+    ["from", from],
+    ["to", to],
+    ["limit", limit],
+    ["offset", offset],
+  ])}`;
+}
+
+/**
  * Defensively parse the raw text body of a JSON-content-type HTTP response
  * (#249, mcp-03).
  *

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.31.0",
+  "version": "2.31.1",
   "description": "MCP server for loopctl — structural trust for AI development loops",
   "type": "module",
   "main": "index.js",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.30.1",
+  "version": "2.31.0",
   "description": "MCP server for loopctl — structural trust for AI development loops",
   "type": "module",
   "main": "index.js",

--- a/mcp-server/test/mcp_arg_forwarding.test.js
+++ b/mcp-server/test/mcp_arg_forwarding.test.js
@@ -153,11 +153,11 @@ describe("#179 BYO LLM: knowledge_llm_usage pagination (real llmUsagePath)", () 
 });
 
 describe("#179 BYO LLM: llm_config / set_llm_config use the USER key", () => {
-  test("llm_config GETs the config on the user key", () => {
+  test("llm_config GETs the config with the EXACT user key (review #12)", () => {
     assert.match(
       INDEX_SRC,
-      /async function llmConfig\(\) \{[\s\S]*?"\/api\/v1\/tenants\/me\/llm-config"[\s\S]*?LOOPCTL_USER_KEY/,
-      "llmConfig must GET /tenants/me/llm-config on the user key (it touches a secret)",
+      /async function llmConfig\(\) \{[\s\S]*?"\/api\/v1\/tenants\/me\/llm-config"[\s\S]*?LOOPCTL_USER_KEY[\s\S]*?exactKey: true/,
+      "llmConfig must GET /tenants/me/llm-config with the EXACT user key (exactKey:true)",
     );
     assert.match(
       INDEX_SRC,
@@ -166,16 +166,26 @@ describe("#179 BYO LLM: llm_config / set_llm_config use the USER key", () => {
     );
   });
 
-  test("set_llm_config PUTs on the user key and forwards api_key + models", () => {
+  test("set_llm_config PATCHes with the EXACT user key (review #12, #13)", () => {
     assert.match(
       INDEX_SRC,
-      /async function setLlmConfig\(\{[\s\S]*?"PUT",\s*\n\s*"\/api\/v1\/tenants\/me\/llm-config",[\s\S]*?LOOPCTL_USER_KEY/,
-      "setLlmConfig must PUT /tenants/me/llm-config on the user key",
+      /async function setLlmConfig\(\{[\s\S]*?"PATCH",\s*\n\s*"\/api\/v1\/tenants\/me\/llm-config",[\s\S]*?LOOPCTL_USER_KEY[\s\S]*?exactKey: true/,
+      "setLlmConfig must PATCH /tenants/me/llm-config with the EXACT user key (exactKey:true)",
     );
     assert.match(
       INDEX_SRC,
       /case "set_llm_config":\s*\n\s*return await setLlmConfig\(args\);/,
       "the set_llm_config dispatch case must call setLlmConfig(args)",
+    );
+  });
+
+  test("apiCall exactKey mode bypasses the global LOOPCTL_API_KEY override", () => {
+    // exactKey:true must use the passed key verbatim (not resolveKey), so a secret
+    // op never runs under a non-user global override (review #12).
+    assert.match(
+      INDEX_SRC,
+      /const key = exactKey \? keyOverride : resolveKey\(keyOverride\);/,
+      "apiCall must use the exact key (not resolveKey) when exactKey is true",
     );
   });
 });

--- a/mcp-server/test/mcp_arg_forwarding.test.js
+++ b/mcp-server/test/mcp_arg_forwarding.test.js
@@ -27,6 +27,7 @@ import {
   buildQuery,
   projectsPath,
   ingestionJobsPath,
+  llmUsagePath,
   parseJsonResponseBody,
 } from "../lib/http-helpers.js";
 
@@ -112,6 +113,69 @@ describe("#248 mcp-02: knowledge_ingestion_jobs pagination (real ingestionJobsPa
       INDEX_SRC,
       /case "knowledge_ingestion_jobs":\s*\n\s*return await knowledgeIngestionJobs\(args\);/,
       "the knowledge_ingestion_jobs dispatch case must call knowledgeIngestionJobs(args)",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Epic 28 (#179): per-tenant BYO LLM config + usage tools
+// ---------------------------------------------------------------------------
+
+describe("#179 BYO LLM: knowledge_llm_usage pagination (real llmUsagePath)", () => {
+  test("forwards from, to, limit, and offset", () => {
+    const url = new URL(
+      `https://x${llmUsagePath({ from: "2026-01-01T00:00:00Z", to: "2026-02-01T00:00:00Z", limit: 10, offset: 20 })}`,
+    );
+    assert.equal(url.pathname, "/api/v1/knowledge/llm-usage");
+    assert.equal(url.searchParams.get("from"), "2026-01-01T00:00:00Z");
+    assert.equal(url.searchParams.get("to"), "2026-02-01T00:00:00Z");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("offset"), "20");
+  });
+
+  test("omits params when none are supplied", () => {
+    assert.equal(llmUsagePath(), "/api/v1/knowledge/llm-usage");
+    assert.equal(llmUsagePath({}), "/api/v1/knowledge/llm-usage");
+  });
+
+  test("index.js knowledgeLlmUsage uses llmUsagePath(args) + orch key, dispatch passes args", () => {
+    assert.match(
+      INDEX_SRC,
+      /async function knowledgeLlmUsage\(args = \{\}\) \{[\s\S]*?llmUsagePath\(args\)[\s\S]*?LOOPCTL_ORCH_KEY/,
+      "knowledgeLlmUsage must delegate to llmUsagePath(args) on the orch key",
+    );
+    assert.match(
+      INDEX_SRC,
+      /case "knowledge_llm_usage":\s*\n\s*return await knowledgeLlmUsage\(args\);/,
+      "the knowledge_llm_usage dispatch case must call knowledgeLlmUsage(args)",
+    );
+  });
+});
+
+describe("#179 BYO LLM: llm_config / set_llm_config use the USER key", () => {
+  test("llm_config GETs the config on the user key", () => {
+    assert.match(
+      INDEX_SRC,
+      /async function llmConfig\(\) \{[\s\S]*?"\/api\/v1\/tenants\/me\/llm-config"[\s\S]*?LOOPCTL_USER_KEY/,
+      "llmConfig must GET /tenants/me/llm-config on the user key (it touches a secret)",
+    );
+    assert.match(
+      INDEX_SRC,
+      /case "llm_config":\s*\n\s*return await llmConfig\(\);/,
+      "the llm_config dispatch case must call llmConfig()",
+    );
+  });
+
+  test("set_llm_config PUTs on the user key and forwards api_key + models", () => {
+    assert.match(
+      INDEX_SRC,
+      /async function setLlmConfig\(\{[\s\S]*?"PUT",\s*\n\s*"\/api\/v1\/tenants\/me\/llm-config",[\s\S]*?LOOPCTL_USER_KEY/,
+      "setLlmConfig must PUT /tenants/me/llm-config on the user key",
+    );
+    assert.match(
+      INDEX_SRC,
+      /case "set_llm_config":\s*\n\s*return await setLlmConfig\(args\);/,
+      "the set_llm_config dispatch case must call setLlmConfig(args)",
     );
   });
 });

--- a/priv/repo/migrations/20260703090000_create_tenant_llm_settings.exs
+++ b/priv/repo/migrations/20260703090000_create_tenant_llm_settings.exs
@@ -1,0 +1,45 @@
+defmodule Loopctl.Repo.Migrations.CreateTenantLlmSettings do
+  @moduledoc """
+  Epic 28 residual (#179): per-tenant BYO Anthropic LLM configuration.
+
+  One row per tenant holding the tenant's OWN Anthropic API key (encrypted at
+  rest via Cloak `Loopctl.Vault.Binary` — the column is opaque `:binary`
+  ciphertext) plus the granular per-operation model choices
+  (extraction/classification/merge). loopctl fronts no LLM cost: the tenant's key
+  bills the tenant directly.
+
+  RLS-enforced like every other tenant table (`ENABLE ROW LEVEL SECURITY`, not
+  FORCE — the production owner role has no BYPASSRLS) with a `tenant_isolation`
+  policy `USING (tenant_id = current_tenant_id())`. The context layer additionally
+  filters by tenant_id explicitly (it runs from Oban workers on AdminRepo too),
+  matching the `Loopctl.Webhooks` encrypted-secret precedent.
+  """
+  use Ecto.Migration
+
+  import Loopctl.Repo.RlsHelpers
+
+  def change do
+    create table(:tenant_llm_settings, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      add :tenant_id, references(:tenants, type: :binary_id, on_delete: :delete_all), null: false
+
+      # Cloak-encrypted Anthropic API key (AES-256-GCM). Opaque ciphertext at rest.
+      add :api_key, :binary, null: true
+
+      # Granular per-operation model ids. NULL means "use the server default for
+      # that operation" (see Loopctl.Llm.resolve/2). Free-form — validated as a
+      # plausible non-empty id, NOT restricted to an allow-list.
+      add :extraction_model, :string, null: true
+      add :classification_model, :string, null: true
+      add :merge_model, :string, null: true
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    # Exactly one settings row per tenant.
+    create unique_index(:tenant_llm_settings, [:tenant_id])
+
+    enable_rls(:tenant_llm_settings)
+  end
+end

--- a/priv/repo/migrations/20260703090100_create_llm_usage_events.exs
+++ b/priv/repo/migrations/20260703090100_create_llm_usage_events.exs
@@ -1,0 +1,42 @@
+defmodule Loopctl.Repo.Migrations.CreateLlmUsageEvents do
+  @moduledoc """
+  Epic 28 residual (#179): per-tenant LLM token-usage tracking.
+
+  One row per successful tenant LLM operation (extraction/classification/merge),
+  capturing the model used and the Anthropic-reported input/output token counts.
+  This is a RECORD-ONLY ledger — there is NO budget enforcement; it backs the
+  per-tenant usage-summary API (`GET /api/v1/knowledge/llm-usage`).
+
+  RLS-enforced like every other tenant table. Composite indexes on
+  (tenant_id, occurred_at) and (tenant_id, operation) back the summary
+  aggregation + date-range window.
+  """
+  use Ecto.Migration
+
+  import Loopctl.Repo.RlsHelpers
+
+  def change do
+    create table(:llm_usage_events, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      add :tenant_id, references(:tenants, type: :binary_id, on_delete: :delete_all), null: false
+
+      # extraction | classification | merge (Ecto.Enum in the schema).
+      add :operation, :string, null: false
+      add :model, :string, null: false
+      add :input_tokens, :integer, null: false, default: 0
+      add :output_tokens, :integer, null: false, default: 0
+
+      # Optional provenance for the summary breakdown.
+      add :source_type, :string, null: true
+      add :article_id, :binary_id, null: true
+
+      add :occurred_at, :utc_datetime_usec, null: false, default: fragment("now()")
+    end
+
+    create index(:llm_usage_events, [:tenant_id, :occurred_at])
+    create index(:llm_usage_events, [:tenant_id, :operation])
+
+    enable_rls(:llm_usage_events)
+  end
+end

--- a/test/loopctl/knowledge/claude_category_classifier_test.exs
+++ b/test/loopctl/knowledge/claude_category_classifier_test.exs
@@ -2,6 +2,7 @@ defmodule Loopctl.Knowledge.ClaudeCategoryClassifierTest do
   use Loopctl.DataCase, async: true
 
   alias Loopctl.Knowledge.ClaudeCategoryClassifier
+  alias Loopctl.Llm
 
   describe "classify/3 graceful degradation" do
     test "returns {:error, :no_api_key} when the tenant has no Anthropic key (mandatory BYO)" do
@@ -12,6 +13,69 @@ defmodule Loopctl.Knowledge.ClaudeCategoryClassifierTest do
 
       assert {:error, :no_api_key} =
                ClaudeCategoryClassifier.classify(tenant.id, "Some title", "Some body")
+    end
+  end
+
+  describe "classify/4 end-to-end (Req.Test seam, review #11)" do
+    test "uses the tenant's key + classification model and records usage" do
+      tenant = fixture(:tenant)
+
+      {:ok, _} =
+        Llm.upsert_settings(tenant.id, %{
+          "api_key" => "sk-ant-classify-777",
+          "classification_model" => "claude-sonnet-4-5"
+        })
+
+      Req.Test.stub(Loopctl.Llm.Anthropic, fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        send(self(), {:req, conn.req_headers, JSON.decode!(body)})
+
+        Req.Test.json(conn, %{
+          "content" => [
+            %{"type" => "text", "text" => ~s({"category":"playbook","confidence":0.9})}
+          ],
+          "usage" => %{"input_tokens" => 12, "output_tokens" => 4}
+        })
+      end)
+
+      assert {:ok, %{category: :playbook, confidence: 0.9}} =
+               ClaudeCategoryClassifier.classify(tenant.id, "Title", "Body")
+
+      assert_received {:req, headers, req_body}
+      assert {"x-api-key", "sk-ant-classify-777"} in headers
+      assert req_body["model"] == "claude-sonnet-4-5"
+
+      %{data: [row]} = Llm.usage_summary(tenant.id, [])
+      assert row.operation == :classification
+      assert row.model == "claude-sonnet-4-5"
+      assert row.input_tokens == 12
+      assert row.output_tokens == 4
+    end
+
+    test "accepts pre-resolved credentials (review #19 batch path) without re-resolving" do
+      tenant = fixture(:tenant)
+      # NO settings row — proves classify uses the passed creds, not resolve/2.
+      Req.Test.stub(Loopctl.Llm.Anthropic, fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        send(self(), {:req, conn.req_headers, JSON.decode!(body)})
+
+        Req.Test.json(conn, %{
+          "content" => [
+            %{"type" => "text", "text" => ~s({"category":"pattern","confidence":0.8})}
+          ],
+          "usage" => %{"input_tokens" => 1, "output_tokens" => 1}
+        })
+      end)
+
+      assert {:ok, %{category: :pattern}} =
+               ClaudeCategoryClassifier.classify(tenant.id, "T", "B",
+                 api_key: "sk-ant-preresolved",
+                 model: "claude-haiku-4-5-20251001"
+               )
+
+      assert_received {:req, headers, req_body}
+      assert {"x-api-key", "sk-ant-preresolved"} in headers
+      assert req_body["model"] == "claude-haiku-4-5-20251001"
     end
   end
 

--- a/test/loopctl/knowledge/claude_category_classifier_test.exs
+++ b/test/loopctl/knowledge/claude_category_classifier_test.exs
@@ -22,7 +22,7 @@ defmodule Loopctl.Knowledge.ClaudeCategoryClassifierTest do
 
       {:ok, _} =
         Llm.upsert_settings(tenant.id, %{
-          "api_key" => "sk-ant-classify-777",
+          "api_key" => "test-anthropic-classify-777",
           "classification_model" => "claude-sonnet-4-5"
         })
 
@@ -42,7 +42,7 @@ defmodule Loopctl.Knowledge.ClaudeCategoryClassifierTest do
                ClaudeCategoryClassifier.classify(tenant.id, "Title", "Body")
 
       assert_received {:req, headers, req_body}
-      assert {"x-api-key", "sk-ant-classify-777"} in headers
+      assert {"x-api-key", "test-anthropic-classify-777"} in headers
       assert req_body["model"] == "claude-sonnet-4-5"
 
       %{data: [row]} = Llm.usage_summary(tenant.id, [])
@@ -69,12 +69,12 @@ defmodule Loopctl.Knowledge.ClaudeCategoryClassifierTest do
 
       assert {:ok, %{category: :pattern}} =
                ClaudeCategoryClassifier.classify(tenant.id, "T", "B",
-                 api_key: "sk-ant-preresolved",
+                 api_key: "test-anthropic-preresolved",
                  model: "claude-haiku-4-5-20251001"
                )
 
       assert_received {:req, headers, req_body}
-      assert {"x-api-key", "sk-ant-preresolved"} in headers
+      assert {"x-api-key", "test-anthropic-preresolved"} in headers
       assert req_body["model"] == "claude-haiku-4-5-20251001"
     end
   end

--- a/test/loopctl/knowledge/claude_category_classifier_test.exs
+++ b/test/loopctl/knowledge/claude_category_classifier_test.exs
@@ -1,16 +1,17 @@
 defmodule Loopctl.Knowledge.ClaudeCategoryClassifierTest do
-  use ExUnit.Case, async: true
+  use Loopctl.DataCase, async: true
 
   alias Loopctl.Knowledge.ClaudeCategoryClassifier
 
-  describe "classify/2 graceful degradation" do
-    test "returns {:error, :not_configured} when no Anthropic API key is set" do
-      # No :anthropic_provider key is configured in the test env, so the real
-      # classifier must degrade rather than attempt a live HTTP call. This is
-      # what keeps the reclassification backfill from mutating data with a
-      # placeholder verdict in environments without Anthropic access.
-      assert {:error, :not_configured} =
-               ClaudeCategoryClassifier.classify("Some title", "Some body")
+  describe "classify/3 graceful degradation" do
+    test "returns {:error, :no_api_key} when the tenant has no Anthropic key (mandatory BYO)" do
+      # The tenant has no configured key, so the real classifier must degrade
+      # rather than attempt a live HTTP call. This is what keeps the
+      # reclassification backfill from mutating data with a placeholder verdict.
+      tenant = fixture(:tenant)
+
+      assert {:error, :no_api_key} =
+               ClaudeCategoryClassifier.classify(tenant.id, "Some title", "Some body")
     end
   end
 

--- a/test/loopctl/knowledge/claude_content_extractor_test.exs
+++ b/test/loopctl/knowledge/claude_content_extractor_test.exs
@@ -1,0 +1,83 @@
+defmodule Loopctl.Knowledge.ClaudeContentExtractorTest do
+  @moduledoc """
+  Exercises the REAL extractor end-to-end via the `:anthropic_req_plug` Req.Test
+  seam (no real API call): per-tenant key + model resolution, article parsing, and
+  the token-usage recording that the worker relies on.
+  """
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.Knowledge.ClaudeContentExtractor
+  alias Loopctl.Llm
+
+  # Canned Anthropic Messages response: one article + a usage block.
+  defp stub_anthropic(articles_json, usage) do
+    Req.Test.stub(Loopctl.Llm.Anthropic, fn conn ->
+      # Capture the request for header/model assertions.
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      send(self(), {:anthropic_request, conn.req_headers, JSON.decode!(body)})
+
+      Req.Test.json(conn, %{
+        "content" => [%{"type" => "text", "text" => articles_json}],
+        "usage" => usage
+      })
+    end)
+  end
+
+  test "resolves the tenant key + extraction model, extracts articles, and records usage" do
+    tenant = fixture(:tenant)
+
+    {:ok, _} =
+      Llm.upsert_settings(tenant.id, %{
+        "api_key" => "sk-ant-tenant-key-777",
+        "extraction_model" => "claude-opus-4-1"
+      })
+
+    articles_json =
+      JSON.encode!([%{title: "T1", body: "B1", category: "pattern", tags: ["x"]}])
+
+    stub_anthropic(articles_json, %{"input_tokens" => 321, "output_tokens" => 123})
+
+    assert {:ok, [%{title: "T1", category: :pattern}]} =
+             ClaudeContentExtractor.extract_from_content(tenant.id, "raw content",
+               source_type: "newsletter"
+             )
+
+    # The request used THIS tenant's key + resolved model.
+    assert_received {:anthropic_request, headers, req_body}
+    assert {"x-api-key", "sk-ant-tenant-key-777"} in headers
+    assert req_body["model"] == "claude-opus-4-1"
+
+    # A usage event was recorded with the right tokens/operation/model/source.
+    %{data: [row]} = Llm.usage_summary(tenant.id, [])
+    assert row.operation == :extraction
+    assert row.model == "claude-opus-4-1"
+    assert row.input_tokens == 321
+    assert row.output_tokens == 123
+    assert row.source_type == "newsletter"
+  end
+
+  test "returns {:error, :no_api_key} and records nothing when the tenant has no key" do
+    tenant = fixture(:tenant)
+
+    assert {:error, :no_api_key} =
+             ClaudeContentExtractor.extract_from_content(tenant.id, "raw", source_type: "x")
+
+    assert %{data: []} = Llm.usage_summary(tenant.id, [])
+  end
+
+  test "surfaces an API error and records no usage" do
+    tenant = fixture(:tenant)
+    {:ok, _} = Llm.upsert_settings(tenant.id, %{"api_key" => "sk-ant-1"})
+
+    Req.Test.stub(Loopctl.Llm.Anthropic, fn conn ->
+      conn
+      |> Plug.Conn.put_status(429)
+      |> Req.Test.json(%{"error" => "rate_limited"})
+    end)
+
+    assert {:error, {:api_error, 429, _}} =
+             ClaudeContentExtractor.extract_from_content(tenant.id, "raw", source_type: "x")
+
+    assert %{data: []} = Llm.usage_summary(tenant.id, [])
+  end
+end

--- a/test/loopctl/knowledge/claude_content_extractor_test.exs
+++ b/test/loopctl/knowledge/claude_content_extractor_test.exs
@@ -28,7 +28,7 @@ defmodule Loopctl.Knowledge.ClaudeContentExtractorTest do
 
     {:ok, _} =
       Llm.upsert_settings(tenant.id, %{
-        "api_key" => "sk-ant-tenant-key-777",
+        "api_key" => "test-anthropic-tenant-key-777",
         "extraction_model" => "claude-opus-4-1"
       })
 
@@ -44,7 +44,7 @@ defmodule Loopctl.Knowledge.ClaudeContentExtractorTest do
 
     # The request used THIS tenant's key + resolved model.
     assert_received {:anthropic_request, headers, req_body}
-    assert {"x-api-key", "sk-ant-tenant-key-777"} in headers
+    assert {"x-api-key", "test-anthropic-tenant-key-777"} in headers
     assert req_body["model"] == "claude-opus-4-1"
 
     # A usage event was recorded with the right tokens/operation/model/source.
@@ -67,7 +67,7 @@ defmodule Loopctl.Knowledge.ClaudeContentExtractorTest do
 
   test "surfaces an API error and records no usage" do
     tenant = fixture(:tenant)
-    {:ok, _} = Llm.upsert_settings(tenant.id, %{"api_key" => "sk-ant-1"})
+    {:ok, _} = Llm.upsert_settings(tenant.id, %{"api_key" => "test-anthropic-1"})
 
     Req.Test.stub(Loopctl.Llm.Anthropic, fn conn ->
       conn

--- a/test/loopctl/knowledge/claude_merge_synthesizer_test.exs
+++ b/test/loopctl/knowledge/claude_merge_synthesizer_test.exs
@@ -10,7 +10,7 @@ defmodule Loopctl.Knowledge.ClaudeMergeSynthesizerTest do
 
       {:ok, _} =
         Llm.upsert_settings(tenant.id, %{
-          "api_key" => "sk-ant-merge-999",
+          "api_key" => "test-anthropic-merge-999",
           "merge_model" => "claude-opus-4-1"
         })
 
@@ -28,7 +28,7 @@ defmodule Loopctl.Knowledge.ClaudeMergeSynthesizerTest do
                Synth.synthesize(tenant.id, %{title: "A", body: "a"}, %{title: "B", body: "b"})
 
       assert_received {:req, headers, req_body}
-      assert {"x-api-key", "sk-ant-merge-999"} in headers
+      assert {"x-api-key", "test-anthropic-merge-999"} in headers
       assert req_body["model"] == "claude-opus-4-1"
 
       %{data: [row]} = Llm.usage_summary(tenant.id, [])

--- a/test/loopctl/knowledge/claude_merge_synthesizer_test.exs
+++ b/test/loopctl/knowledge/claude_merge_synthesizer_test.exs
@@ -2,6 +2,42 @@ defmodule Loopctl.Knowledge.ClaudeMergeSynthesizerTest do
   use Loopctl.DataCase, async: true
 
   alias Loopctl.Knowledge.ClaudeMergeSynthesizer, as: Synth
+  alias Loopctl.Llm
+
+  describe "synthesize/3 end-to-end (Req.Test seam, review #11)" do
+    test "uses the tenant's key + merge model and records usage" do
+      tenant = fixture(:tenant)
+
+      {:ok, _} =
+        Llm.upsert_settings(tenant.id, %{
+          "api_key" => "sk-ant-merge-999",
+          "merge_model" => "claude-opus-4-1"
+        })
+
+      Req.Test.stub(Loopctl.Llm.Anthropic, fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        send(self(), {:req, conn.req_headers, JSON.decode!(body)})
+
+        Req.Test.json(conn, %{
+          "content" => [%{"type" => "text", "text" => ~s({"title":"Merged","body":"Both."})}],
+          "usage" => %{"input_tokens" => 30, "output_tokens" => 15}
+        })
+      end)
+
+      assert {:ok, %{title: "Merged", body: "Both."}} =
+               Synth.synthesize(tenant.id, %{title: "A", body: "a"}, %{title: "B", body: "b"})
+
+      assert_received {:req, headers, req_body}
+      assert {"x-api-key", "sk-ant-merge-999"} in headers
+      assert req_body["model"] == "claude-opus-4-1"
+
+      %{data: [row]} = Llm.usage_summary(tenant.id, [])
+      assert row.operation == :merge
+      assert row.model == "claude-opus-4-1"
+      assert row.input_tokens == 30
+      assert row.output_tokens == 15
+    end
+  end
 
   describe "parse_text/1" do
     test "parses a clean JSON object" do

--- a/test/loopctl/knowledge/claude_merge_synthesizer_test.exs
+++ b/test/loopctl/knowledge/claude_merge_synthesizer_test.exs
@@ -1,5 +1,5 @@
 defmodule Loopctl.Knowledge.ClaudeMergeSynthesizerTest do
-  use ExUnit.Case, async: true
+  use Loopctl.DataCase, async: true
 
   alias Loopctl.Knowledge.ClaudeMergeSynthesizer, as: Synth
 
@@ -26,11 +26,13 @@ defmodule Loopctl.Knowledge.ClaudeMergeSynthesizerTest do
     end
   end
 
-  describe "synthesize/2 without a configured backend" do
-    test "returns :not_configured rather than a placeholder" do
-      # No :anthropic_provider api_key in :test → graceful degrade.
-      assert {:error, :not_configured} =
-               Synth.synthesize(%{title: "A", body: "a"}, %{title: "B", body: "b"})
+  describe "synthesize/3 without a configured backend" do
+    test "returns :no_api_key rather than a placeholder (mandatory BYO)" do
+      # The tenant has no configured key → graceful degrade, no live HTTP call.
+      tenant = fixture(:tenant)
+
+      assert {:error, :no_api_key} =
+               Synth.synthesize(tenant.id, %{title: "A", body: "a"}, %{title: "B", body: "b"})
     end
   end
 end

--- a/test/loopctl/knowledge/llm_extractor_test.exs
+++ b/test/loopctl/knowledge/llm_extractor_test.exs
@@ -37,7 +37,7 @@ defmodule Loopctl.Knowledge.LlmExtractorTest do
 
     {:ok, _} =
       Llm.upsert_settings(tenant.id, %{
-        "api_key" => "sk-ant-review-key-555",
+        "api_key" => "test-anthropic-review-key-555",
         "extraction_model" => "claude-sonnet-4-5"
       })
 

--- a/test/loopctl/knowledge/llm_extractor_test.exs
+++ b/test/loopctl/knowledge/llm_extractor_test.exs
@@ -1,0 +1,66 @@
+defmodule Loopctl.Knowledge.LlmExtractorTest do
+  @moduledoc """
+  Exercises the REAL review-finding extractor end-to-end via the
+  `:anthropic_req_plug` Req.Test seam (no real API call): per-tenant key + model
+  resolution, article parsing, mandatory BYO, and token-usage recording.
+  """
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.Knowledge.LlmExtractor
+  alias Loopctl.Llm
+
+  defp context(tenant_id) do
+    %{
+      review_record_id: Ecto.UUID.generate(),
+      tenant_id: tenant_id,
+      story_id: Ecto.UUID.generate(),
+      review_type: "enhanced",
+      findings_count: 2,
+      fixes_count: 2,
+      summary: "Two findings, both fixed."
+    }
+  end
+
+  defp stub_anthropic(articles_json, usage) do
+    Req.Test.stub(Loopctl.Llm.Anthropic, fn conn ->
+      {:ok, _body, conn} = Plug.Conn.read_body(conn)
+
+      Req.Test.json(conn, %{
+        "content" => [%{"type" => "text", "text" => articles_json}],
+        "usage" => usage
+      })
+    end)
+  end
+
+  test "resolves the tenant key + extraction model, extracts articles, and records usage" do
+    tenant = fixture(:tenant)
+
+    {:ok, _} =
+      Llm.upsert_settings(tenant.id, %{
+        "api_key" => "sk-ant-review-key-555",
+        "extraction_model" => "claude-sonnet-4-5"
+      })
+
+    articles_json =
+      JSON.encode!([%{title: "Review pattern", body: "Body.", category: "pattern", tags: ["x"]}])
+
+    stub_anthropic(articles_json, %{"input_tokens" => 210, "output_tokens" => 90})
+
+    assert {:ok, [%{title: "Review pattern", category: :pattern}]} =
+             LlmExtractor.extract_articles(tenant.id, context(tenant.id))
+
+    %{data: [row]} = Llm.usage_summary(tenant.id, [])
+    assert row.operation == :extraction
+    assert row.model == "claude-sonnet-4-5"
+    assert row.input_tokens == 210
+    assert row.output_tokens == 90
+    assert row.source_type == "review_finding"
+  end
+
+  test "returns {:error, :no_api_key} and records nothing when the tenant has no key" do
+    tenant = fixture(:tenant)
+
+    assert {:error, :no_api_key} = LlmExtractor.extract_articles(tenant.id, context(tenant.id))
+    assert %{data: []} = Llm.usage_summary(tenant.id, [])
+  end
+end

--- a/test/loopctl/knowledge/potential_conflicts_test.exs
+++ b/test/loopctl/knowledge/potential_conflicts_test.exs
@@ -360,7 +360,7 @@ defmodule Loopctl.Knowledge.PotentialConflictsTest do
          ctx do
       %{tenant: t, a: a, b: b} = ctx
 
-      stub(Loopctl.MockMergeSynthesizer, :synthesize, fn _a, _b ->
+      stub(Loopctl.MockMergeSynthesizer, :synthesize, fn _tenant_id, _a, _b ->
         {:ok, %{title: "Parsing XML in Elixir (xmerl)", body: "Merged body covering both."}}
       end)
 

--- a/test/loopctl/knowledge/potential_conflicts_test.exs
+++ b/test/loopctl/knowledge/potential_conflicts_test.exs
@@ -350,6 +350,10 @@ defmodule Loopctl.Knowledge.PotentialConflictsTest do
 
     setup do
       tenant = fixture(:tenant)
+      # Mandatory BYO (Epic 28, #179): the merge executor now gates on has_api_key?
+      # before synthesizing. Configure a key so these merge-path tests reach the
+      # synthesizer (the keyless-skip path has its own dedicated test below).
+      fixture(:tenant_llm_settings, %{tenant_id: tenant.id})
       a = published(tenant.id, "XML in Elixir with xmerl")
       b = published(tenant.id, "How to parse XML documents in Elixir")
       conflict_link(tenant.id, a, b, 0.98)
@@ -418,6 +422,37 @@ defmodule Loopctl.Knowledge.PotentialConflictsTest do
 
       row = AdminRepo.get_by(Loopctl.Knowledge.ConflictResolution, tenant_id: t.id)
       assert is_nil(row.executed_at)
+    end
+
+    test "mandatory BYO: a keyless tenant's merge is marked skipped, not retried forever (review #10)" do
+      # A DISTINCT tenant with NO llm settings row (no key configured).
+      tenant = fixture(:tenant)
+      a = published(tenant.id, "Alpha article about widgets")
+      b = published(tenant.id, "Beta article about widgets")
+      conflict_link(tenant.id, a, b, 0.98)
+
+      # The synthesizer must NEVER be called without a tenant key.
+      stub(Loopctl.MockMergeSynthesizer, :synthesize, fn _t, _a, _b ->
+        flunk("merge synthesizer must not run without a tenant key")
+      end)
+
+      {:ok, _} =
+        Knowledge.annotate_conflict(tenant.id, %{
+          "source_article_id" => a.id,
+          "target_article_id" => b.id,
+          "disposition" => "merge",
+          "authoritative_article_id" => a.id,
+          "confidence" => "high"
+        })
+
+      assert 0 == Knowledge.execute_conflict_resolutions(tenant.id)
+
+      # Marked executed with a DISTINCT, queryable "skipped/no_api_key" result —
+      # NOT left unexecuted (which would retry every run forever).
+      row = AdminRepo.get_by(Loopctl.Knowledge.ConflictResolution, tenant_id: tenant.id)
+      refute is_nil(row.executed_at)
+      assert row.execution_result["action"] == "skipped"
+      assert row.execution_result["reason"] == "no_api_key"
     end
   end
 end

--- a/test/loopctl/knowledge/potential_conflicts_test.exs
+++ b/test/loopctl/knowledge/potential_conflicts_test.exs
@@ -424,6 +424,28 @@ defmodule Loopctl.Knowledge.PotentialConflictsTest do
       assert is_nil(row.executed_at)
     end
 
+    test "respects the wall-clock budget: budget_ms 0 applies nothing, leaves rows for next run (review #4)",
+         ctx do
+      %{tenant: t, a: a, b: b} = ctx
+
+      {:ok, _} =
+        Knowledge.annotate_conflict(t.id, %{
+          "source_article_id" => a.id,
+          "target_article_id" => b.id,
+          "disposition" => "merge",
+          "authoritative_article_id" => a.id,
+          "confidence" => "high"
+        })
+
+      # With a zero budget, the executor halts BEFORE applying the first row, so
+      # nothing is executed and the (high-confidence) resolution stays for the next
+      # run — the bound that prevents a 200-row loop pinning a shared slot for hours.
+      assert 0 == Knowledge.execute_conflict_resolutions(t.id, budget_ms: 0)
+
+      row = AdminRepo.get_by(Loopctl.Knowledge.ConflictResolution, tenant_id: t.id)
+      assert is_nil(row.executed_at)
+    end
+
     test "mandatory BYO: a keyless tenant's merge is marked skipped, not retried forever (review #10)" do
       # A DISTINCT tenant with NO llm settings row (no key configured).
       tenant = fixture(:tenant)

--- a/test/loopctl/knowledge/potential_conflicts_test.exs
+++ b/test/loopctl/knowledge/potential_conflicts_test.exs
@@ -446,6 +446,51 @@ defmodule Loopctl.Knowledge.PotentialConflictsTest do
       assert is_nil(row.executed_at)
     end
 
+    test "applies resolutions OLDEST-first and drains the tail across runs (order_by, review round 4)" do
+      tenant = fixture(:tenant)
+
+      # Three high-confidence SUPERSEDE resolutions (no LLM synthesizer needed, so this
+      # is deterministic + fast) created oldest→newest with distinct inserted_at.
+      [ra, rb, rc] =
+        for label <- ["A", "B", "C"] do
+          a = published(tenant.id, "#{label}1")
+          b = published(tenant.id, "#{label}2")
+          conflict_link(tenant.id, a, b, 0.95)
+
+          {:ok, r} =
+            Knowledge.annotate_conflict(tenant.id, %{
+              "source_article_id" => a.id,
+              "target_article_id" => b.id,
+              "disposition" => "supersede",
+              "authoritative_article_id" => a.id,
+              "confidence" => "high"
+            })
+
+          # Distinct inserted_at (the `asc: r.id` tiebreaker also makes the order total).
+          Process.sleep(5)
+          r
+        end
+
+      executed? = fn r ->
+        not is_nil(AdminRepo.get!(Loopctl.Knowledge.ConflictResolution, r.id).executed_at)
+      end
+
+      # Each bounded run makes forward progress OLDEST-first — never re-picking the
+      # same head while the tail starves.
+      assert 1 == Knowledge.execute_conflict_resolutions(tenant.id, limit: 1)
+      assert executed?.(ra)
+      refute executed?.(rb)
+      refute executed?.(rc)
+
+      assert 1 == Knowledge.execute_conflict_resolutions(tenant.id, limit: 1)
+      assert executed?.(rb)
+      refute executed?.(rc)
+
+      # The TAIL (newest) eventually executes — no permanent starvation.
+      assert 1 == Knowledge.execute_conflict_resolutions(tenant.id, limit: 1)
+      assert executed?.(rc)
+    end
+
     test "mandatory BYO: a keyless tenant's merge is marked skipped, not retried forever (review #10)" do
       # A DISTINCT tenant with NO llm settings row (no key configured).
       tenant = fixture(:tenant)

--- a/test/loopctl/llm/anthropic_test.exs
+++ b/test/loopctl/llm/anthropic_test.exs
@@ -1,0 +1,73 @@
+defmodule Loopctl.Llm.AnthropicTest do
+  @moduledoc """
+  The tenant's API key is a secret — it must NEVER appear in any log line, across
+  ALL response branches of the client (review #16).
+  """
+  use Loopctl.DataCase, async: true
+
+  import ExUnit.CaptureLog
+
+  alias Loopctl.Llm
+  alias Loopctl.Llm.Anthropic
+
+  # A distinctive, per-test key so a hit in captured output is unambiguous and can
+  # never be another test's key (avoids cross-test capture_log leakage concerns).
+  @secret "sk-ant-DISTINCTIVE-NEVER-LOG-#{System.unique_integer([:positive])}"
+
+  defp tenant_with_key do
+    tenant = fixture(:tenant)
+    {:ok, _} = Llm.upsert_settings(tenant.id, %{"api_key" => @secret})
+    tenant
+  end
+
+  defp body_fun, do: fn _model -> %{max_tokens: 10, system: "s", messages: []} end
+
+  defp run(tenant), do: Anthropic.message(tenant.id, :extraction, body_fun())
+
+  test "never logs the api_key on the 200-success branch" do
+    tenant = tenant_with_key()
+
+    Req.Test.stub(Loopctl.Llm.Anthropic, fn conn ->
+      Req.Test.json(conn, %{
+        "content" => [%{"type" => "text", "text" => "ok"}],
+        "usage" => %{"input_tokens" => 1, "output_tokens" => 1}
+      })
+    end)
+
+    log = capture_log(fn -> assert {:ok, "ok"} = run(tenant) end)
+    refute log =~ @secret
+  end
+
+  test "never logs the api_key on the 200-unexpected-shape branch" do
+    tenant = tenant_with_key()
+
+    Req.Test.stub(Loopctl.Llm.Anthropic, fn conn ->
+      Req.Test.json(conn, %{"unexpected" => true})
+    end)
+
+    log = capture_log(fn -> assert {:error, {:api_error, 200, _}} = run(tenant) end)
+    refute log =~ @secret
+  end
+
+  test "never logs the api_key on the non-200 branch" do
+    tenant = tenant_with_key()
+
+    Req.Test.stub(Loopctl.Llm.Anthropic, fn conn ->
+      conn |> Plug.Conn.put_status(500) |> Req.Test.json(%{"error" => "boom"})
+    end)
+
+    log = capture_log(fn -> assert {:error, {:api_error, 500, _}} = run(tenant) end)
+    refute log =~ @secret
+  end
+
+  test "never logs the api_key on the transport-error branch" do
+    tenant = tenant_with_key()
+
+    Req.Test.stub(Loopctl.Llm.Anthropic, fn conn ->
+      Req.Test.transport_error(conn, :econnrefused)
+    end)
+
+    log = capture_log(fn -> assert {:error, {:request_failed, _}} = run(tenant) end)
+    refute log =~ @secret
+  end
+end

--- a/test/loopctl/llm/anthropic_test.exs
+++ b/test/loopctl/llm/anthropic_test.exs
@@ -12,7 +12,7 @@ defmodule Loopctl.Llm.AnthropicTest do
 
   # A distinctive, per-test key so a hit in captured output is unambiguous and can
   # never be another test's key (avoids cross-test capture_log leakage concerns).
-  @secret "sk-ant-DISTINCTIVE-NEVER-LOG-#{System.unique_integer([:positive])}"
+  @secret "test-anthropic-DISTINCTIVE-NEVER-LOG-#{System.unique_integer([:positive])}"
 
   defp tenant_with_key do
     tenant = fixture(:tenant)

--- a/test/loopctl/llm_test.exs
+++ b/test/loopctl/llm_test.exs
@@ -1,0 +1,266 @@
+defmodule Loopctl.LlmTest do
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Audit.AuditLog
+  alias Loopctl.Llm
+  alias Loopctl.Llm.TenantLlmSettings
+
+  import Ecto.Query
+
+  describe "upsert_settings/2 + resolve/2" do
+    test "stores models + key and resolves the per-operation model + decrypted key" do
+      tenant = fixture(:tenant)
+
+      {:ok, _settings} =
+        Llm.upsert_settings(tenant.id, %{
+          "api_key" => "sk-ant-secret-key-1234",
+          "extraction_model" => "claude-opus-4-1",
+          "classification_model" => "claude-sonnet-4-5"
+        })
+
+      assert {:ok, %{api_key: "sk-ant-secret-key-1234", model: "claude-opus-4-1"}} =
+               Llm.resolve(tenant.id, :extraction)
+
+      assert {:ok, %{model: "claude-sonnet-4-5"}} = Llm.resolve(tenant.id, :classification)
+
+      # merge_model was left nil -> falls back to the server default (Haiku).
+      assert {:ok, %{model: "claude-haiku-4-5-20251001"}} = Llm.resolve(tenant.id, :merge)
+    end
+
+    test "upsert is idempotent per tenant (one row, updates in place)" do
+      tenant = fixture(:tenant)
+      {:ok, _} = Llm.upsert_settings(tenant.id, %{"api_key" => "sk-ant-a"})
+      {:ok, _} = Llm.upsert_settings(tenant.id, %{"extraction_model" => "m-x"})
+
+      # Both persisted on the single row.
+      assert {:ok, %{api_key: "sk-ant-a", model: "m-x"}} = Llm.resolve(tenant.id, :extraction)
+
+      count =
+        from(s in TenantLlmSettings, where: s.tenant_id == ^tenant.id, select: count(s.id))
+        |> AdminRepo.one()
+
+      assert count == 1
+    end
+
+    test "resolve/2 returns {:error, :no_api_key} when no key is configured" do
+      tenant = fixture(:tenant)
+      assert {:error, :no_api_key} = Llm.resolve(tenant.id, :extraction)
+
+      # A settings row with only models but no key is still "no key".
+      {:ok, _} = Llm.upsert_settings(tenant.id, %{"extraction_model" => "m-x"})
+      assert {:error, :no_api_key} = Llm.resolve(tenant.id, :extraction)
+      refute Llm.has_api_key?(tenant.id)
+    end
+
+    test "rejects an invalid (blank) api_key and an implausible model id" do
+      tenant = fixture(:tenant)
+      assert {:error, changeset} = Llm.upsert_settings(tenant.id, %{"api_key" => "   "})
+      assert %{api_key: _} = errors_on(changeset)
+
+      assert {:error, cs2} =
+               Llm.upsert_settings(tenant.id, %{"extraction_model" => "has spaces!"})
+
+      assert %{extraction_model: _} = errors_on(cs2)
+    end
+  end
+
+  describe "encryption at rest + redaction" do
+    test "the api_key column is ciphertext, not the plaintext key" do
+      tenant = fixture(:tenant)
+      {:ok, _} = Llm.upsert_settings(tenant.id, %{"api_key" => "sk-ant-plaintext-xyz"})
+
+      %{rows: [[raw]]} =
+        AdminRepo.query!(
+          "SELECT api_key FROM tenant_llm_settings WHERE tenant_id = $1",
+          [Ecto.UUID.dump!(tenant.id)]
+        )
+
+      assert is_binary(raw)
+      refute raw == "sk-ant-plaintext-xyz"
+      refute String.contains?(raw, "sk-ant-plaintext-xyz")
+
+      # ... but it decrypts back on load.
+      assert {:ok, %{api_key: "sk-ant-plaintext-xyz"}} = Llm.resolve(tenant.id, :extraction)
+    end
+
+    test "inspect/settings_view never expose the raw key" do
+      tenant = fixture(:tenant)
+      {:ok, settings} = Llm.upsert_settings(tenant.id, %{"api_key" => "sk-ant-hidden-9999"})
+
+      # redact: true omits the value from inspect entirely.
+      refute inspect(settings) =~ "sk-ant-hidden-9999"
+
+      view = Llm.settings_view(settings)
+      assert view.has_api_key == true
+      assert view.api_key_hint == "...9999"
+      refute Map.has_key?(view, :api_key)
+      refute view |> inspect() =~ "sk-ant-hidden-9999"
+    end
+  end
+
+  describe "audit" do
+    test "setting a key writes an llm_config.key_set audit event WITHOUT the value" do
+      tenant = fixture(:tenant)
+      {:ok, _} = Llm.upsert_settings(tenant.id, %{"api_key" => "sk-ant-audit-4242"})
+
+      events =
+        from(a in AuditLog,
+          where: a.tenant_id == ^tenant.id and a.entity_type == "llm_config",
+          select: a
+        )
+        |> AdminRepo.all()
+
+      actions = Enum.map(events, & &1.action)
+      assert "llm_config.updated" in actions
+      assert "llm_config.key_set" in actions
+
+      # No event's serialized state contains the raw key.
+      refute events |> inspect() =~ "sk-ant-audit-4242"
+    end
+
+    test "a models-only update does not write a key_set event" do
+      tenant = fixture(:tenant)
+      {:ok, _} = Llm.upsert_settings(tenant.id, %{"api_key" => "sk-ant-1"})
+      {:ok, _} = Llm.upsert_settings(tenant.id, %{"extraction_model" => "m-y"})
+
+      key_set_count =
+        from(a in AuditLog,
+          where: a.tenant_id == ^tenant.id and a.action == "llm_config.key_set",
+          select: count(a.id)
+        )
+        |> AdminRepo.one()
+
+      # Only the first upsert (which set the key) emitted key_set.
+      assert key_set_count == 1
+    end
+  end
+
+  describe "record_usage/2 + usage_summary/2" do
+    test "records events and aggregates by operation/model/source over a range" do
+      tenant = fixture(:tenant)
+
+      {:ok, _} =
+        Llm.record_usage(tenant.id, %{
+          operation: :extraction,
+          model: "haiku",
+          input_tokens: 100,
+          output_tokens: 40,
+          source_type: "newsletter"
+        })
+
+      {:ok, _} =
+        Llm.record_usage(tenant.id, %{
+          operation: :extraction,
+          model: "haiku",
+          input_tokens: 50,
+          output_tokens: 10,
+          source_type: "newsletter"
+        })
+
+      {:ok, _} =
+        Llm.record_usage(tenant.id, %{
+          operation: :classification,
+          model: "sonnet",
+          input_tokens: 5,
+          output_tokens: 2,
+          source_type: nil
+        })
+
+      %{data: rows, meta: meta} = Llm.usage_summary(tenant.id, [])
+
+      extraction =
+        Enum.find(rows, &(&1.operation == :extraction and &1.model == "haiku"))
+
+      assert extraction.input_tokens == 150
+      assert extraction.output_tokens == 50
+      assert extraction.event_count == 2
+
+      classification = Enum.find(rows, &(&1.operation == :classification))
+      assert classification.input_tokens == 5
+      assert classification.event_count == 1
+
+      assert meta.total_count == length(rows)
+    end
+
+    test "usage_summary is tenant-isolated (A cannot see B's usage)" do
+      a = fixture(:tenant)
+      b = fixture(:tenant)
+
+      {:ok, _} =
+        Llm.record_usage(b.id, %{
+          operation: :extraction,
+          model: "haiku",
+          input_tokens: 999,
+          output_tokens: 999,
+          source_type: "leak"
+        })
+
+      %{data: rows_a} = Llm.usage_summary(a.id, [])
+      assert rows_a == []
+
+      %{data: rows_b} = Llm.usage_summary(b.id, [])
+      assert length(rows_b) == 1
+    end
+
+    test "paginates with a stable order across pages" do
+      tenant = fixture(:tenant)
+
+      # Three distinct groups on the same day (different models) → 3 summary rows.
+      for model <- ["m-a", "m-b", "m-c"] do
+        {:ok, _} =
+          Llm.record_usage(tenant.id, %{
+            operation: :extraction,
+            model: model,
+            input_tokens: 1,
+            output_tokens: 1,
+            source_type: "s"
+          })
+      end
+
+      %{data: page1, meta: m1} = Llm.usage_summary(tenant.id, limit: 2, offset: 0)
+      %{data: page2} = Llm.usage_summary(tenant.id, limit: 2, offset: 2)
+
+      assert m1.total_count == 3
+      assert length(page1) == 2
+      assert length(page2) == 1
+
+      # No overlap between pages (stable tiebreaker).
+      keys1 = Enum.map(page1, & &1.model)
+      keys2 = Enum.map(page2, & &1.model)
+      assert keys1 -- keys2 == keys1
+      assert Enum.sort(keys1 ++ keys2) == ["m-a", "m-b", "m-c"]
+    end
+
+    test "date-range filters narrow the window" do
+      tenant = fixture(:tenant)
+      now = DateTime.utc_now()
+      old = DateTime.add(now, -10 * 86_400, :second)
+
+      {:ok, _} =
+        Llm.record_usage(tenant.id, %{
+          operation: :extraction,
+          model: "recent",
+          input_tokens: 1,
+          output_tokens: 1,
+          occurred_at: now
+        })
+
+      {:ok, _} =
+        Llm.record_usage(tenant.id, %{
+          operation: :extraction,
+          model: "ancient",
+          input_tokens: 1,
+          output_tokens: 1,
+          occurred_at: old
+        })
+
+      from = DateTime.add(now, -2 * 86_400, :second)
+      %{data: rows} = Llm.usage_summary(tenant.id, from: from)
+
+      models = Enum.map(rows, & &1.model)
+      assert "recent" in models
+      refute "ancient" in models
+    end
+  end
+end

--- a/test/loopctl/llm_test.exs
+++ b/test/loopctl/llm_test.exs
@@ -43,6 +43,24 @@ defmodule Loopctl.LlmTest do
       assert count == 1
     end
 
+    test "resolve/2 is tenant-scoped — A and B each get their own key + model (review #17)" do
+      a = fixture(:tenant)
+      b = fixture(:tenant)
+
+      {:ok, _} =
+        Llm.upsert_settings(a.id, %{"api_key" => "sk-ant-AAAA", "extraction_model" => "model-a"})
+
+      {:ok, _} =
+        Llm.upsert_settings(b.id, %{"api_key" => "sk-ant-BBBB", "extraction_model" => "model-b"})
+
+      assert {:ok, %{api_key: "sk-ant-AAAA", model: "model-a"}} = Llm.resolve(a.id, :extraction)
+      assert {:ok, %{api_key: "sk-ant-BBBB", model: "model-b"}} = Llm.resolve(b.id, :extraction)
+
+      # No cross-tenant leakage in either direction.
+      refute match?({:ok, %{api_key: "sk-ant-BBBB"}}, Llm.resolve(a.id, :extraction))
+      refute match?({:ok, %{api_key: "sk-ant-AAAA"}}, Llm.resolve(b.id, :extraction))
+    end
+
     test "resolve/2 returns {:error, :no_api_key} when no key is configured" do
       tenant = fixture(:tenant)
       assert {:error, :no_api_key} = Llm.resolve(tenant.id, :extraction)

--- a/test/loopctl/llm_test.exs
+++ b/test/loopctl/llm_test.exs
@@ -14,12 +14,12 @@ defmodule Loopctl.LlmTest do
 
       {:ok, _settings} =
         Llm.upsert_settings(tenant.id, %{
-          "api_key" => "sk-ant-secret-key-1234",
+          "api_key" => "test-anthropic-secret-key-1234",
           "extraction_model" => "claude-opus-4-1",
           "classification_model" => "claude-sonnet-4-5"
         })
 
-      assert {:ok, %{api_key: "sk-ant-secret-key-1234", model: "claude-opus-4-1"}} =
+      assert {:ok, %{api_key: "test-anthropic-secret-key-1234", model: "claude-opus-4-1"}} =
                Llm.resolve(tenant.id, :extraction)
 
       assert {:ok, %{model: "claude-sonnet-4-5"}} = Llm.resolve(tenant.id, :classification)
@@ -30,11 +30,12 @@ defmodule Loopctl.LlmTest do
 
     test "upsert is idempotent per tenant (one row, updates in place)" do
       tenant = fixture(:tenant)
-      {:ok, _} = Llm.upsert_settings(tenant.id, %{"api_key" => "sk-ant-a"})
+      {:ok, _} = Llm.upsert_settings(tenant.id, %{"api_key" => "test-anthropic-a"})
       {:ok, _} = Llm.upsert_settings(tenant.id, %{"extraction_model" => "m-x"})
 
       # Both persisted on the single row.
-      assert {:ok, %{api_key: "sk-ant-a", model: "m-x"}} = Llm.resolve(tenant.id, :extraction)
+      assert {:ok, %{api_key: "test-anthropic-a", model: "m-x"}} =
+               Llm.resolve(tenant.id, :extraction)
 
       count =
         from(s in TenantLlmSettings, where: s.tenant_id == ^tenant.id, select: count(s.id))
@@ -48,17 +49,26 @@ defmodule Loopctl.LlmTest do
       b = fixture(:tenant)
 
       {:ok, _} =
-        Llm.upsert_settings(a.id, %{"api_key" => "sk-ant-AAAA", "extraction_model" => "model-a"})
+        Llm.upsert_settings(a.id, %{
+          "api_key" => "test-anthropic-AAAA",
+          "extraction_model" => "model-a"
+        })
 
       {:ok, _} =
-        Llm.upsert_settings(b.id, %{"api_key" => "sk-ant-BBBB", "extraction_model" => "model-b"})
+        Llm.upsert_settings(b.id, %{
+          "api_key" => "test-anthropic-BBBB",
+          "extraction_model" => "model-b"
+        })
 
-      assert {:ok, %{api_key: "sk-ant-AAAA", model: "model-a"}} = Llm.resolve(a.id, :extraction)
-      assert {:ok, %{api_key: "sk-ant-BBBB", model: "model-b"}} = Llm.resolve(b.id, :extraction)
+      assert {:ok, %{api_key: "test-anthropic-AAAA", model: "model-a"}} =
+               Llm.resolve(a.id, :extraction)
+
+      assert {:ok, %{api_key: "test-anthropic-BBBB", model: "model-b"}} =
+               Llm.resolve(b.id, :extraction)
 
       # No cross-tenant leakage in either direction.
-      refute match?({:ok, %{api_key: "sk-ant-BBBB"}}, Llm.resolve(a.id, :extraction))
-      refute match?({:ok, %{api_key: "sk-ant-AAAA"}}, Llm.resolve(b.id, :extraction))
+      refute match?({:ok, %{api_key: "test-anthropic-BBBB"}}, Llm.resolve(a.id, :extraction))
+      refute match?({:ok, %{api_key: "test-anthropic-AAAA"}}, Llm.resolve(b.id, :extraction))
     end
 
     test "resolve/2 returns {:error, :no_api_key} when no key is configured" do
@@ -86,7 +96,7 @@ defmodule Loopctl.LlmTest do
   describe "encryption at rest + redaction" do
     test "the api_key column is ciphertext, not the plaintext key" do
       tenant = fixture(:tenant)
-      {:ok, _} = Llm.upsert_settings(tenant.id, %{"api_key" => "sk-ant-plaintext-xyz"})
+      {:ok, _} = Llm.upsert_settings(tenant.id, %{"api_key" => "test-anthropic-plaintext-xyz"})
 
       %{rows: [[raw]]} =
         AdminRepo.query!(
@@ -95,32 +105,35 @@ defmodule Loopctl.LlmTest do
         )
 
       assert is_binary(raw)
-      refute raw == "sk-ant-plaintext-xyz"
-      refute String.contains?(raw, "sk-ant-plaintext-xyz")
+      refute raw == "test-anthropic-plaintext-xyz"
+      refute String.contains?(raw, "test-anthropic-plaintext-xyz")
 
       # ... but it decrypts back on load.
-      assert {:ok, %{api_key: "sk-ant-plaintext-xyz"}} = Llm.resolve(tenant.id, :extraction)
+      assert {:ok, %{api_key: "test-anthropic-plaintext-xyz"}} =
+               Llm.resolve(tenant.id, :extraction)
     end
 
     test "inspect/settings_view never expose the raw key" do
       tenant = fixture(:tenant)
-      {:ok, settings} = Llm.upsert_settings(tenant.id, %{"api_key" => "sk-ant-hidden-9999"})
+
+      {:ok, settings} =
+        Llm.upsert_settings(tenant.id, %{"api_key" => "test-anthropic-hidden-9999"})
 
       # redact: true omits the value from inspect entirely.
-      refute inspect(settings) =~ "sk-ant-hidden-9999"
+      refute inspect(settings) =~ "test-anthropic-hidden-9999"
 
       view = Llm.settings_view(settings)
       assert view.has_api_key == true
       assert view.api_key_hint == "...9999"
       refute Map.has_key?(view, :api_key)
-      refute view |> inspect() =~ "sk-ant-hidden-9999"
+      refute view |> inspect() =~ "test-anthropic-hidden-9999"
     end
   end
 
   describe "audit" do
     test "setting a key writes an llm_config.key_set audit event WITHOUT the value" do
       tenant = fixture(:tenant)
-      {:ok, _} = Llm.upsert_settings(tenant.id, %{"api_key" => "sk-ant-audit-4242"})
+      {:ok, _} = Llm.upsert_settings(tenant.id, %{"api_key" => "test-anthropic-audit-4242"})
 
       events =
         from(a in AuditLog,
@@ -134,12 +147,12 @@ defmodule Loopctl.LlmTest do
       assert "llm_config.key_set" in actions
 
       # No event's serialized state contains the raw key.
-      refute events |> inspect() =~ "sk-ant-audit-4242"
+      refute events |> inspect() =~ "test-anthropic-audit-4242"
     end
 
     test "a models-only update does not write a key_set event" do
       tenant = fixture(:tenant)
-      {:ok, _} = Llm.upsert_settings(tenant.id, %{"api_key" => "sk-ant-1"})
+      {:ok, _} = Llm.upsert_settings(tenant.id, %{"api_key" => "test-anthropic-1"})
       {:ok, _} = Llm.upsert_settings(tenant.id, %{"extraction_model" => "m-y"})
 
       key_set_count =

--- a/test/loopctl/progress/knowledge_auto_extract_test.exs
+++ b/test/loopctl/progress/knowledge_auto_extract_test.exs
@@ -7,6 +7,9 @@ defmodule Loopctl.Progress.KnowledgeAutoExtractTest do
 
   defp setup_story(tenant_attrs \\ %{}) do
     tenant = fixture(:tenant, tenant_attrs)
+    # Mandatory BYO (Epic 28, #179): the ReviewKnowledgeWorker gates on
+    # has_api_key? — configure a tenant key so the auto-extract worker proceeds.
+    fixture(:tenant_llm_settings, %{tenant_id: tenant.id})
     project = fixture(:project, %{tenant_id: tenant.id})
     epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
 
@@ -32,7 +35,7 @@ defmodule Loopctl.Progress.KnowledgeAutoExtractTest do
       # The mock extractor is stubbed by default to return {:ok, []}.
       # If the worker is enqueued (inline mode), it will call extract_articles.
       # We verify it's called (meaning the worker was enqueued).
-      expect(Loopctl.MockExtractor, :extract_articles, fn _ctx ->
+      expect(Loopctl.MockExtractor, :extract_articles, fn _tenant_id, _ctx ->
         {:ok, []}
       end)
 
@@ -55,7 +58,7 @@ defmodule Loopctl.Progress.KnowledgeAutoExtractTest do
       %{tenant: tenant, story: story, reviewer: reviewer} =
         setup_story(%{settings: %{"knowledge_auto_extract" => true}})
 
-      expect(Loopctl.MockExtractor, :extract_articles, fn _ctx ->
+      expect(Loopctl.MockExtractor, :extract_articles, fn _tenant_id, _ctx ->
         {:ok, []}
       end)
 
@@ -82,7 +85,7 @@ defmodule Loopctl.Progress.KnowledgeAutoExtractTest do
 
       # The extractor should NOT be called because auto_extract is disabled.
       # Using expect with count 0 will fail if the mock is called.
-      expect(Loopctl.MockExtractor, :extract_articles, 0, fn _ctx ->
+      expect(Loopctl.MockExtractor, :extract_articles, 0, fn _tenant_id, _ctx ->
         {:ok, []}
       end)
 

--- a/test/loopctl/repo/rls_coverage_test.exs
+++ b/test/loopctl/repo/rls_coverage_test.exs
@@ -48,6 +48,9 @@ defmodule Loopctl.Repo.RlsCoverageTest do
     table_names = Enum.map(rows, fn [name, _rls, _count] -> name end)
     assert "stories" in table_names
     assert "audit_pending_violations" in table_names
+    # Epic 28 (#179): both BYO-LLM tables carry tenant_id and must be RLS-enforced.
+    assert "tenant_llm_settings" in table_names
+    assert "llm_usage_events" in table_names
 
     offenders =
       for [name, rls, policy_count] <- rows,

--- a/test/loopctl/workers/content_ingestion_worker_test.exs
+++ b/test/loopctl/workers/content_ingestion_worker_test.exs
@@ -934,6 +934,58 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
       assert after_retry == 2
     end
 
+    test "a URL whose content CHANGED between attempts RE-EXTRACTS the new bytes (no false skip, round-4 review)" do
+      %{tenant: tenant} = setup_tenant()
+
+      # Two DIFFERENT fetch bodies across the two perform/1 calls with the SAME job
+      # args. The chunk-skip must key on the FETCHED BYTES, not the enqueue-time
+      # content_hash (= sha256(url) for a URL job): keying on the URL would find V1's
+      # chunk-0 titles under the same prefix and SILENTLY skip extracting V2 (stale
+      # content, zero signal). Keying on sha256(bytes) re-extracts the changed bytes.
+      extract_count = :counters.new(1, [])
+      fetch_count = :counters.new(1, [])
+
+      Req.Test.stub(ContentIngestionWorker, fn conn ->
+        :counters.add(fetch_count, 1, 1)
+
+        body =
+          if :counters.get(fetch_count, 1) == 1,
+            do: "First version of the page about alpha widgets",
+            else: "Second version of the page about beta gadgets"
+
+        Req.Test.text(conn, body)
+      end)
+
+      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id,
+                                                                       content,
+                                                                       _opts ->
+        :counters.add(extract_count, 1, 1)
+        title = if content =~ "alpha", do: "V1 article", else: "V2 article"
+        {:ok, [%{title: title, body: "Body.", category: :pattern}]}
+      end)
+
+      args = %{
+        "tenant_id" => tenant.id,
+        "url" => "https://example.com/dynamic-page",
+        "content_hash" => "url_change_test",
+        "source_type" => "web_article"
+      }
+
+      # Run 1: fetch V1 → extract "V1 article".
+      assert :ok = ContentIngestionWorker.perform(%Oban.Job{id: 430, args: args})
+
+      # Run 2 (retry, IDENTICAL args): fetch V2 (different bytes) → MUST re-extract.
+      assert :ok = ContentIngestionWorker.perform(%Oban.Job{id: 430, args: args})
+
+      # The extractor was invoked on BOTH attempts (no false skip on the changed URL).
+      assert :counters.get(extract_count, 1) == 2
+
+      # V2's genuinely-new content was captured (not silently kept as stale V1).
+      %{data: articles} = Knowledge.list_articles(tenant.id, source_type: "web_article")
+      titles = Enum.map(articles, & &1.title)
+      assert "V2 article" in titles
+    end
+
     test "a PERMANENT (4xx) extraction failure is discarded, not retried forever (#264 Finding 2)" do
       %{tenant: tenant} = setup_tenant()
 

--- a/test/loopctl/workers/content_ingestion_worker_test.exs
+++ b/test/loopctl/workers/content_ingestion_worker_test.exs
@@ -9,6 +9,9 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
 
   defp setup_tenant do
     tenant = fixture(:tenant)
+    # Mandatory BYO (Epic 28, #179): configure a tenant Anthropic key so the
+    # worker's has_api_key? gate passes and extraction proceeds.
+    fixture(:tenant_llm_settings, %{tenant_id: tenant.id})
     %{tenant: tenant}
   end
 
@@ -23,13 +26,41 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
     end)
   end
 
+  # --- Mandatory BYO (Epic 28, #179) ---
+
+  describe "perform/1 mandatory BYO enforcement" do
+    test "discards cleanly (no crash, no retry) when the tenant has no Anthropic key" do
+      # A tenant WITHOUT an llm settings row (no key configured).
+      tenant = fixture(:tenant)
+
+      # The extractor must never be called — we discard before any LLM work.
+      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _t, _c, _o ->
+        flunk("extractor should not run without a tenant key")
+      end)
+
+      assert {:discard, {:no_api_key, _reason}} =
+               ContentIngestionWorker.perform(%Oban.Job{
+                 id: 1,
+                 args: %{
+                   "tenant_id" => tenant.id,
+                   "content" => "some content",
+                   "content_hash" => "nokey123",
+                   "source_type" => "newsletter"
+                 }
+               })
+
+      %{data: articles} = Knowledge.list_articles(tenant.id, source_type: "newsletter")
+      assert articles == []
+    end
+  end
+
   # --- Success: extracts articles from inline content ---
 
   describe "perform/1 with inline content" do
     test "extracts articles and inserts them as drafts" do
       %{tenant: tenant} = setup_tenant()
 
-      expect(Loopctl.MockContentExtractor, :extract_from_content, fn content, opts ->
+      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id, content, opts ->
         assert content == "Some raw content about Elixir patterns"
         assert opts[:source_type] == "newsletter"
 
@@ -77,7 +108,9 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
     test "publishes extracted articles when publish: true is set" do
       %{tenant: tenant} = setup_tenant()
 
-      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _content, _opts ->
+      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id,
+                                                                     _content,
+                                                                     _opts ->
         {:ok,
          [
            %{
@@ -122,7 +155,7 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
         Req.Test.html(conn, "<html><body><h1>Title</h1><p>Content here</p></body></html>")
       end)
 
-      expect(Loopctl.MockContentExtractor, :extract_from_content, fn content, _opts ->
+      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id, content, _opts ->
         # HTML should be stripped
         assert content =~ "Title"
         assert content =~ "Content here"
@@ -208,7 +241,9 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
     test "filters out articles with invalid categories" do
       %{tenant: tenant} = setup_tenant()
 
-      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _content, _opts ->
+      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id,
+                                                                     _content,
+                                                                     _opts ->
         {:ok,
          [
            %{title: "Valid", body: "Valid body.", category: :pattern},
@@ -235,7 +270,9 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
     test "filters out articles with empty title" do
       %{tenant: tenant} = setup_tenant()
 
-      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _content, _opts ->
+      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id,
+                                                                     _content,
+                                                                     _opts ->
         {:ok,
          [
            %{title: "Valid", body: "Body.", category: :convention},
@@ -262,7 +299,9 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
     test "filters out articles with body exceeding 100KB" do
       %{tenant: tenant} = setup_tenant()
 
-      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _content, _opts ->
+      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id,
+                                                                     _content,
+                                                                     _opts ->
         {:ok,
          [
            %{title: "Valid", body: "Short body.", category: :pattern},
@@ -289,7 +328,9 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
     test "enforces max 10 articles limit" do
       %{tenant: tenant} = setup_tenant()
 
-      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _content, _opts ->
+      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id,
+                                                                     _content,
+                                                                     _opts ->
         articles =
           for i <- 1..12 do
             %{
@@ -324,7 +365,9 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
     test "returns :ok when extractor returns empty list" do
       %{tenant: tenant} = setup_tenant()
 
-      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _content, _opts ->
+      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id,
+                                                                     _content,
+                                                                     _opts ->
         {:ok, []}
       end)
 
@@ -350,7 +393,9 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
     test "propagates error when extractor fails" do
       %{tenant: tenant} = setup_tenant()
 
-      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _content, _opts ->
+      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id,
+                                                                     _content,
+                                                                     _opts ->
         {:error, {:api_error, 500, "Internal Server Error"}}
       end)
 
@@ -374,7 +419,9 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
       %{tenant: tenant} = setup_tenant()
       project = fixture(:project, %{tenant_id: tenant.id})
 
-      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _content, _opts ->
+      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id,
+                                                                     _content,
+                                                                     _opts ->
         {:ok,
          [
            %{
@@ -448,7 +495,9 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
     test "an empty-string project_id is treated as tenant-wide (normalized to nil), still ingests" do
       %{tenant: tenant} = setup_tenant()
 
-      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _content, _opts ->
+      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id,
+                                                                     _content,
+                                                                     _opts ->
         {:ok, [%{title: "Blank pid article", body: "Body.", category: :pattern, tags: []}]}
       end)
 
@@ -477,7 +526,9 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
       %{tenant: tenant_a} = setup_tenant()
       %{tenant: tenant_b} = setup_tenant()
 
-      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _content, _opts ->
+      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id,
+                                                                     _content,
+                                                                     _opts ->
         {:ok,
          [
            %{
@@ -515,7 +566,9 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
     test "logs knowledge.content_ingested audit event" do
       %{tenant: tenant} = setup_tenant()
 
-      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _content, _opts ->
+      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id,
+                                                                     _content,
+                                                                     _opts ->
         {:ok,
          [
            %{
@@ -566,7 +619,9 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
       end)
 
       # The extractor must NEVER be reached — the guard short-circuits first.
-      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _content, _opts ->
+      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id,
+                                                                       _content,
+                                                                       _opts ->
         flunk("extractor must not be called for binary content")
       end)
 
@@ -597,7 +652,9 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
         |> Plug.Conn.send_resp(200, binary_body)
       end)
 
-      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _content, _opts ->
+      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id,
+                                                                       _content,
+                                                                       _opts ->
         flunk("extractor must not be called for non-UTF-8 content")
       end)
 
@@ -618,7 +675,9 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
     test "direct non-UTF-8 inline content is discarded cleanly" do
       %{tenant: tenant} = setup_tenant()
 
-      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _content, _opts ->
+      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id,
+                                                                       _content,
+                                                                       _opts ->
         flunk("extractor must not be called for non-UTF-8 inline content")
       end)
 
@@ -641,7 +700,7 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
         Req.Test.html(conn, "<html><body><p>Perfectly valid text</p></body></html>")
       end)
 
-      expect(Loopctl.MockContentExtractor, :extract_from_content, fn content, _opts ->
+      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id, content, _opts ->
         assert content =~ "Perfectly valid text"
 
         {:ok, [%{title: "Valid web", body: "Body.", category: :finding, tags: ["web"]}]}
@@ -672,7 +731,9 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
       # 4 sections -> 4 chunks. The extractor returns a distinct article per call.
       counter = :counters.new(1, [])
 
-      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _chunk, _opts ->
+      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id,
+                                                                       _chunk,
+                                                                       _opts ->
         :counters.add(counter, 1, 1)
         n = :counters.get(counter, 1)
 
@@ -704,7 +765,9 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
       # failed chunk instead of marking the job :completed and losing it forever.
       counter = :counters.new(1, [])
 
-      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _chunk, _opts ->
+      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id,
+                                                                       _chunk,
+                                                                       _opts ->
         :counters.add(counter, 1, 1)
         n = :counters.get(counter, 1)
 
@@ -746,7 +809,9 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
       # non-determinism) so the idempotency guarantee can't depend on the output.
       call = :counters.new(1, [])
 
-      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _chunk, _opts ->
+      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id,
+                                                                       _chunk,
+                                                                       _opts ->
         :counters.add(call, 1, 1)
         n = :counters.get(call, 1)
 
@@ -794,7 +859,9 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
       chunk_counter = :counters.new(1, [])
       run = :counters.new(1, [])
 
-      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _chunk, _opts ->
+      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id,
+                                                                       _chunk,
+                                                                       _opts ->
         idx = rem(:counters.get(chunk_counter, 1), 3) + 1
         :counters.add(chunk_counter, 1, 1)
         run_no = :counters.get(run, 1)
@@ -828,7 +895,9 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
     test "a PERMANENT (4xx) extraction failure is discarded, not retried forever (#264 Finding 2)" do
       %{tenant: tenant} = setup_tenant()
 
-      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _chunk, _opts ->
+      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id,
+                                                                       _chunk,
+                                                                       _opts ->
         {:error, {:api_error, 400, "bad request"}}
       end)
 
@@ -867,7 +936,9 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
 
       call = :counters.new(1, [])
 
-      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _chunk, _opts ->
+      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id,
+                                                                       _chunk,
+                                                                       _opts ->
         :counters.add(call, 1, 1)
         n = :counters.get(call, 1)
         {:ok, [%{title: "Phantom check #{n}", body: "Body #{n}.", category: :pattern}]}
@@ -913,7 +984,9 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
       _existing =
         fixture(:article, %{tenant_id: tenant.id, title: "Clash Title", status: :published})
 
-      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _chunk, _opts ->
+      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id,
+                                                                       _chunk,
+                                                                       _opts ->
         {:ok, [%{title: "Clash Title", body: "A different body.", category: :pattern}]}
       end)
 
@@ -934,7 +1007,9 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
     test "when NO chunk succeeds, the error propagates so Oban retries (nothing persisted)" do
       %{tenant: tenant} = setup_tenant()
 
-      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _chunk, _opts ->
+      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id,
+                                                                       _chunk,
+                                                                       _opts ->
         {:error, {:request_failed, :timeout}}
       end)
 
@@ -955,7 +1030,9 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
     test "a tiny single-chunk input still ingests" do
       %{tenant: tenant} = setup_tenant()
 
-      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _content, _opts ->
+      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id,
+                                                                     _content,
+                                                                     _opts ->
         {:ok, [%{title: "Tiny", body: "Small.", category: :pattern}]}
       end)
 
@@ -1018,7 +1095,9 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
 
       # 14 sections -> 14 chunks, above the 12-chunk per-job budget. Each chunk
       # yields one article; the first 12 persist, the rest are discarded.
-      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _chunk, _opts ->
+      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id,
+                                                                       _chunk,
+                                                                       _opts ->
         {:ok,
          [
            %{

--- a/test/loopctl/workers/content_ingestion_worker_test.exs
+++ b/test/loopctl/workers/content_ingestion_worker_test.exs
@@ -854,16 +854,21 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
       }
 
       # Run 1: chunks 1 & 3 succeed, chunk 2 fails transiently.
-      # Run 2 (retry): every chunk succeeds. The already-persisted chunks 1 & 3
-      # no-op on conflict; only chunk 2 productively adds a row.
-      chunk_counter = :counters.new(1, [])
+      # Run 2 (retry): chunk 2 is re-extracted; chunks 1 & 3 are SKIPPED (already
+      # persisted — no re-BILL, #179 review #1). The per-chunk verdict keys off the
+      # chunk's CONTENT (its "Section N"), NOT a global call counter, precisely so it
+      # stays correct when the retry re-invokes the extractor for ONLY the failed chunk.
       run = :counters.new(1, [])
 
-      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id,
-                                                                       _chunk,
-                                                                       _opts ->
-        idx = rem(:counters.get(chunk_counter, 1), 3) + 1
-        :counters.add(chunk_counter, 1, 1)
+      section_no = fn chunk ->
+        case Regex.run(~r/Section (\d+)/, chunk) do
+          [_, n] -> String.to_integer(n)
+          _ -> 0
+        end
+      end
+
+      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id, chunk, _opts ->
+        idx = section_no.(chunk)
         run_no = :counters.get(run, 1)
 
         if idx == 2 and run_no == 0 do
@@ -890,6 +895,43 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
 
       # 3 total: chunks 1 & 3 unchanged (idempotent no-op), chunk 2 newly added.
       assert after_run2 == 3, "expected only the failed chunk to be added, got #{after_run2}"
+    end
+
+    test "a retry does NOT re-invoke the extractor for chunks already persisted (no re-bill, review #1)" do
+      %{tenant: tenant} = setup_tenant()
+
+      job_args = %{
+        "tenant_id" => tenant.id,
+        "content" => multi_chunk_content(2),
+        "content_hash" => "no_rebill",
+        "source_type" => "newsletter"
+      }
+
+      # First attempt: both chunks succeed (a distinct title per chunk content).
+      Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id, chunk, _opts ->
+        n = :erlang.phash2(chunk)
+        {:ok, [%{title: "Article #{n}", body: "Body #{n}.", category: :pattern}]}
+      end)
+
+      assert :ok = ContentIngestionWorker.perform(%Oban.Job{id: 420, args: job_args})
+
+      %{meta: %{total_count: after_first}} =
+        Knowledge.list_articles(tenant.id, source_type: "newsletter")
+
+      assert after_first == 2
+
+      # Retry (SAME args): every chunk is already durably persisted, so the extractor
+      # (the TENANT-BILLED Anthropic call) must NOT be invoked even once.
+      Mox.expect(Loopctl.MockContentExtractor, :extract_from_content, 0, fn _t, _c, _o ->
+        flunk("extractor must not be re-invoked for already-persisted chunks (re-bill)")
+      end)
+
+      assert :ok = ContentIngestionWorker.perform(%Oban.Job{id: 420, args: job_args})
+
+      %{meta: %{total_count: after_retry}} =
+        Knowledge.list_articles(tenant.id, source_type: "newsletter")
+
+      assert after_retry == 2
     end
 
     test "a PERMANENT (4xx) extraction failure is discarded, not retried forever (#264 Finding 2)" do

--- a/test/loopctl/workers/knowledge_reclassify_worker_test.exs
+++ b/test/loopctl/workers/knowledge_reclassify_worker_test.exs
@@ -35,7 +35,7 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorkerTest do
   end
 
   defp verdict(category, confidence) do
-    Mox.stub(Loopctl.MockCategoryClassifier, :classify, fn _tenant_id, _title, _body ->
+    Mox.stub(Loopctl.MockCategoryClassifier, :classify, fn _tenant_id, _title, _body, _opts ->
       {:ok, %{category: category, confidence: confidence}}
     end)
   end
@@ -132,7 +132,7 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorkerTest do
       good_a = published(tenant.id, :convention)
       good_b = published(tenant.id, :convention)
 
-      Mox.stub(Loopctl.MockCategoryClassifier, :classify, fn _tenant_id, title, _body ->
+      Mox.stub(Loopctl.MockCategoryClassifier, :classify, fn _tenant_id, title, _body, _opts ->
         if title == bad.title,
           do: {:error, :unparseable_classification},
           else: {:ok, %{category: :playbook, confidence: 0.9}}
@@ -155,7 +155,7 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorkerTest do
       a = published(tenant.id, :convention)
 
       # Every classify errors -> 100% error rate -> upstream is unreachable.
-      Mox.stub(Loopctl.MockCategoryClassifier, :classify, fn _tenant_id, _t, _b ->
+      Mox.stub(Loopctl.MockCategoryClassifier, :classify, fn _tenant_id, _t, _b, _opts ->
         {:error, :econnrefused}
       end)
 
@@ -225,6 +225,42 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorkerTest do
       assert reload(a.id).category == :playbook
       assert reload(b.id).category == :convention
       assert [] == reclassify_audits(tenant_b.id)
+    end
+  end
+
+  describe "mandatory BYO (Epic 28, #179)" do
+    test "skips a tenant with no Anthropic key; the classifier is never called (review #8)" do
+      # A tenant WITHOUT an llm settings row (no key configured).
+      tenant = fixture(:tenant)
+      a = published(tenant.id, :convention)
+
+      expect(Loopctl.MockCategoryClassifier, :classify, 0, fn _t, _ti, _b, _o ->
+        flunk("classifier must not run without a tenant key")
+      end)
+
+      assert :ok = run(tenant.id, %{"run_mode" => "commit"})
+      # Nothing changed, no audit (no work done).
+      assert reload(a.id).category == :convention
+      assert [] == reclassify_audits(tenant.id)
+    end
+
+    test "a batch of PERMANENT classify errors advances without snoozing forever (review #4)" do
+      tenant = tenant_with_key()
+      a = published(tenant.id, :convention)
+
+      # A 401 (bad key) is a PERMANENT error — a retry can't fix it, so the worker
+      # must NOT snooze (which would loop every 60s forever); it advances instead.
+      Mox.stub(Loopctl.MockCategoryClassifier, :classify, fn _t, _ti, _b, _o ->
+        {:error, {:api_error, 401, %{}}}
+      end)
+
+      assert :ok = run(tenant.id, %{"run_mode" => "commit"})
+
+      # Article left unchanged, but the batch is audited (advanced, not paused).
+      assert reload(a.id).category == :convention
+      assert [entry] = reclassify_audits(tenant.id)
+      assert entry.new_state["batch"]["permanent_errors"] == 1
+      assert entry.new_state["batch"]["transient_errors"] == 0
     end
   end
 end

--- a/test/loopctl/workers/knowledge_reclassify_worker_test.exs
+++ b/test/loopctl/workers/knowledge_reclassify_worker_test.exs
@@ -26,8 +26,16 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorkerTest do
 
   defp reload(id), do: AdminRepo.get!(Article, id)
 
+  # Mandatory BYO (Epic 28, #179): the reclassify worker skips a tenant with no
+  # Anthropic key. Every reclassify test needs a keyed tenant.
+  defp tenant_with_key do
+    t = fixture(:tenant, %{})
+    fixture(:tenant_llm_settings, %{tenant_id: t.id})
+    t
+  end
+
   defp verdict(category, confidence) do
-    Mox.stub(Loopctl.MockCategoryClassifier, :classify, fn _title, _body ->
+    Mox.stub(Loopctl.MockCategoryClassifier, :classify, fn _tenant_id, _title, _body ->
       {:ok, %{category: category, confidence: confidence}}
     end)
   end
@@ -48,7 +56,7 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorkerTest do
 
   describe "dry_run mode" do
     test "classifies but writes nothing; audit tallies what would change" do
-      tenant = fixture(:tenant)
+      tenant = tenant_with_key()
       a = published(tenant.id, :convention)
       b = published(tenant.id, :pattern)
       verdict(:playbook, 0.9)
@@ -69,7 +77,7 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorkerTest do
 
   describe "commit mode write-on-confident-change" do
     test "rewrites category and records provenance when confident and different" do
-      tenant = fixture(:tenant)
+      tenant = tenant_with_key()
       a = published(tenant.id, :convention)
       verdict(:playbook, 0.9)
 
@@ -82,7 +90,7 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorkerTest do
     end
 
     test "leaves the article alone when confidence is below threshold" do
-      tenant = fixture(:tenant)
+      tenant = tenant_with_key()
       a = published(tenant.id, :convention)
       verdict(:playbook, 0.5)
 
@@ -95,7 +103,7 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorkerTest do
     end
 
     test "no-op when the proposed category equals the current one" do
-      tenant = fixture(:tenant)
+      tenant = tenant_with_key()
       a = published(tenant.id, :pattern)
       verdict(:pattern, 0.99)
 
@@ -108,7 +116,7 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorkerTest do
     end
 
     test "always moves a retired convention row off convention when confident" do
-      tenant = fixture(:tenant)
+      tenant = tenant_with_key()
       a = published(tenant.id, :convention)
       verdict(:insight, 0.8)
 
@@ -118,13 +126,13 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorkerTest do
     end
 
     test "a few errored classifications (below the snooze rate) leave those articles alone but proceed" do
-      tenant = fixture(:tenant)
+      tenant = tenant_with_key()
       # 3 articles: one errors (33% < 50% snooze rate), two classify fine.
       bad = published(tenant.id, :convention)
       good_a = published(tenant.id, :convention)
       good_b = published(tenant.id, :convention)
 
-      Mox.stub(Loopctl.MockCategoryClassifier, :classify, fn title, _body ->
+      Mox.stub(Loopctl.MockCategoryClassifier, :classify, fn _tenant_id, title, _body ->
         if title == bad.title,
           do: {:error, :unparseable_classification},
           else: {:ok, %{category: :playbook, confidence: 0.9}}
@@ -143,11 +151,11 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorkerTest do
 
   describe "outage resilience" do
     test "snoozes and retries the same cursor when the whole batch fails (upstream down)" do
-      tenant = fixture(:tenant)
+      tenant = tenant_with_key()
       a = published(tenant.id, :convention)
 
       # Every classify errors -> 100% error rate -> upstream is unreachable.
-      Mox.stub(Loopctl.MockCategoryClassifier, :classify, fn _t, _b ->
+      Mox.stub(Loopctl.MockCategoryClassifier, :classify, fn _tenant_id, _t, _b ->
         {:error, :econnrefused}
       end)
 
@@ -162,7 +170,7 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorkerTest do
 
   describe "cost ceiling + batch chaining" do
     test "stops after max_per_run, leaving the remainder for the next kick" do
-      tenant = fixture(:tenant)
+      tenant = tenant_with_key()
       a = published(tenant.id, :convention)
       b = published(tenant.id, :convention)
       c = published(tenant.id, :convention)
@@ -184,8 +192,8 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorkerTest do
 
   describe "all_tenants fan-out" do
     test "reclassifies each active tenant, skipping suspended ones" do
-      active_a = fixture(:tenant)
-      active_b = fixture(:tenant)
+      active_a = tenant_with_key()
+      active_b = tenant_with_key()
       suspended = fixture(:tenant, %{status: :suspended})
 
       a = published(active_a.id, :convention)
@@ -206,8 +214,8 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorkerTest do
 
   describe "tenant isolation" do
     test "only the caller tenant's articles are touched" do
-      tenant_a = fixture(:tenant)
-      tenant_b = fixture(:tenant)
+      tenant_a = tenant_with_key()
+      tenant_b = tenant_with_key()
       a = published(tenant_a.id, :convention)
       b = published(tenant_b.id, :convention)
       verdict(:playbook, 0.9)

--- a/test/loopctl/workers/review_knowledge_worker_test.exs
+++ b/test/loopctl/workers/review_knowledge_worker_test.exs
@@ -9,11 +9,31 @@ defmodule Loopctl.Workers.ReviewKnowledgeWorkerTest do
 
   defp setup_tenant do
     tenant = fixture(:tenant)
+    # Mandatory BYO (Epic 28, #179): the worker gates on has_api_key? — configure
+    # a tenant Anthropic key so review-knowledge extraction proceeds.
+    fixture(:tenant_llm_settings, %{tenant_id: tenant.id})
     %{tenant: tenant}
   end
 
   defp create_review_record(tenant_id, attrs \\ %{}) do
     fixture(:review_record, Map.merge(%{tenant_id: tenant_id}, attrs))
+  end
+
+  describe "mandatory BYO (Epic 28, #179)" do
+    test "discards cleanly when the tenant has no Anthropic key; extractor never called" do
+      # A tenant WITHOUT an llm settings row (no key configured).
+      tenant = fixture(:tenant)
+      review = create_review_record(tenant.id)
+
+      expect(Loopctl.MockExtractor, :extract_articles, 0, fn _tenant_id, _ctx ->
+        flunk("extractor must not run without a tenant key")
+      end)
+
+      assert {:discard, {:no_api_key, _reason}} =
+               ReviewKnowledgeWorker.perform(%Oban.Job{
+                 args: %{"review_record_id" => review.id, "tenant_id" => tenant.id}
+               })
+    end
   end
 
   # --- TC-21.1.1: Worker extracts articles from review successfully ---
@@ -23,7 +43,7 @@ defmodule Loopctl.Workers.ReviewKnowledgeWorkerTest do
       %{tenant: tenant} = setup_tenant()
       review_record = create_review_record(tenant.id)
 
-      expect(Loopctl.MockExtractor, :extract_articles, fn context ->
+      expect(Loopctl.MockExtractor, :extract_articles, fn _tenant_id, context ->
         assert context.review_record_id == review_record.id
         assert context.tenant_id == tenant.id
         assert context.story_id == review_record.story_id
@@ -80,7 +100,7 @@ defmodule Loopctl.Workers.ReviewKnowledgeWorkerTest do
       })
 
       # Extractor should NOT be called (verify_on_exit! will catch unexpected calls)
-      expect(Loopctl.MockExtractor, :extract_articles, 0, fn _ctx ->
+      expect(Loopctl.MockExtractor, :extract_articles, 0, fn _tenant_id, _ctx ->
         {:ok, []}
       end)
 
@@ -101,7 +121,7 @@ defmodule Loopctl.Workers.ReviewKnowledgeWorkerTest do
       %{tenant: tenant} = setup_tenant()
       review_record = create_review_record(tenant.id)
 
-      expect(Loopctl.MockExtractor, :extract_articles, fn _ctx ->
+      expect(Loopctl.MockExtractor, :extract_articles, fn _tenant_id, _ctx ->
         {:error, {:llm_error, "API timeout"}}
       end)
 
@@ -122,7 +142,7 @@ defmodule Loopctl.Workers.ReviewKnowledgeWorkerTest do
       %{tenant: tenant} = setup_tenant()
       review_record = create_review_record(tenant.id)
 
-      expect(Loopctl.MockExtractor, :extract_articles, fn _ctx ->
+      expect(Loopctl.MockExtractor, :extract_articles, fn _tenant_id, _ctx ->
         {:ok,
          [
            %{
@@ -182,7 +202,7 @@ defmodule Loopctl.Workers.ReviewKnowledgeWorkerTest do
           }
         end
 
-      expect(Loopctl.MockExtractor, :extract_articles, fn _ctx ->
+      expect(Loopctl.MockExtractor, :extract_articles, fn _tenant_id, _ctx ->
         {:ok, six_articles}
       end)
 
@@ -204,7 +224,7 @@ defmodule Loopctl.Workers.ReviewKnowledgeWorkerTest do
       %{tenant: tenant} = setup_tenant()
       review_record = create_review_record(tenant.id)
 
-      expect(Loopctl.MockExtractor, :extract_articles, fn _ctx ->
+      expect(Loopctl.MockExtractor, :extract_articles, fn _tenant_id, _ctx ->
         {:ok,
          [
            %{title: "Valid", body: "Valid body.", category: :pattern},
@@ -231,7 +251,7 @@ defmodule Loopctl.Workers.ReviewKnowledgeWorkerTest do
       %{tenant: tenant} = setup_tenant()
       review_record = create_review_record(tenant.id)
 
-      expect(Loopctl.MockExtractor, :extract_articles, fn _ctx ->
+      expect(Loopctl.MockExtractor, :extract_articles, fn _tenant_id, _ctx ->
         {:ok,
          [
            %{"title" => "Valid string keys", "body" => "Valid body.", "category" => "pattern"},
@@ -262,7 +282,7 @@ defmodule Loopctl.Workers.ReviewKnowledgeWorkerTest do
       %{tenant: tenant} = setup_tenant()
       review_record = create_review_record(tenant.id)
 
-      expect(Loopctl.MockExtractor, :extract_articles, fn _ctx ->
+      expect(Loopctl.MockExtractor, :extract_articles, fn _tenant_id, _ctx ->
         {:ok,
          [
            %{title: "Valid", body: "Short body.", category: :pattern},
@@ -293,7 +313,7 @@ defmodule Loopctl.Workers.ReviewKnowledgeWorkerTest do
       %{tenant: tenant} = setup_tenant()
       review_record = create_review_record(tenant.id)
 
-      expect(Loopctl.MockExtractor, :extract_articles, fn _ctx ->
+      expect(Loopctl.MockExtractor, :extract_articles, fn _tenant_id, _ctx ->
         {:ok,
          [
            %{title: "Valid", body: "Short body.", category: :pattern},
@@ -324,7 +344,7 @@ defmodule Loopctl.Workers.ReviewKnowledgeWorkerTest do
       %{tenant: tenant} = setup_tenant()
       review_record = create_review_record(tenant.id)
 
-      expect(Loopctl.MockExtractor, :extract_articles, fn _ctx ->
+      expect(Loopctl.MockExtractor, :extract_articles, fn _tenant_id, _ctx ->
         {:ok,
          [
            %{title: "Valid tags", body: "Body.", category: :pattern, tags: ["valid-tag"]},
@@ -365,7 +385,7 @@ defmodule Loopctl.Workers.ReviewKnowledgeWorkerTest do
       # Worker runs with tenant_b but tenant_a's review_record_id.
       # The review record lookup is scoped by tenant_id, so it returns not_found.
       # Extractor should NOT be called
-      expect(Loopctl.MockExtractor, :extract_articles, 0, fn _ctx ->
+      expect(Loopctl.MockExtractor, :extract_articles, 0, fn _tenant_id, _ctx ->
         {:ok, []}
       end)
 
@@ -398,7 +418,7 @@ defmodule Loopctl.Workers.ReviewKnowledgeWorkerTest do
       %{tenant: tenant} = setup_tenant()
       review_record = create_review_record(tenant.id)
 
-      expect(Loopctl.MockExtractor, :extract_articles, fn _ctx ->
+      expect(Loopctl.MockExtractor, :extract_articles, fn _tenant_id, _ctx ->
         {:ok, []}
       end)
 
@@ -421,7 +441,7 @@ defmodule Loopctl.Workers.ReviewKnowledgeWorkerTest do
       fake_id = Ecto.UUID.generate()
 
       # Extractor should NOT be called
-      expect(Loopctl.MockExtractor, :extract_articles, 0, fn _ctx ->
+      expect(Loopctl.MockExtractor, :extract_articles, 0, fn _tenant_id, _ctx ->
         {:ok, []}
       end)
 
@@ -507,7 +527,7 @@ defmodule Loopctl.Workers.ReviewKnowledgeWorkerTest do
       %{tenant: tenant} = setup_tenant()
       review_record = create_review_record(tenant.id)
 
-      expect(Loopctl.MockExtractor, :extract_articles, fn _ctx ->
+      expect(Loopctl.MockExtractor, :extract_articles, fn _tenant_id, _ctx ->
         {:ok,
          [
            %{

--- a/test/loopctl/workers/review_knowledge_worker_test.exs
+++ b/test/loopctl/workers/review_knowledge_worker_test.exs
@@ -36,6 +36,53 @@ defmodule Loopctl.Workers.ReviewKnowledgeWorkerTest do
     end
   end
 
+  describe "permanent-error handling (review #3)" do
+    test "a title-collision insert DISCARDS (permanent), not a blind 3x retry" do
+      %{tenant: tenant} = setup_tenant()
+      # Pre-existing active article whose title the extraction will collide with
+      # (the partial unique index articles_tenant_title_active_idx covers drafts).
+      _existing = fixture(:article, %{tenant_id: tenant.id, title: "Colliding Title"})
+      review = create_review_record(tenant.id)
+
+      expect(Loopctl.MockExtractor, :extract_articles, fn _tenant_id, _ctx ->
+        {:ok, [%{title: "Colliding Title", body: "Body.", category: :pattern, tags: []}]}
+      end)
+
+      assert {:discard, {:insert_failed, _step, _changeset}} =
+               ReviewKnowledgeWorker.perform(%Oban.Job{
+                 args: %{"review_record_id" => review.id, "tenant_id" => tenant.id}
+               })
+    end
+
+    test "a permanent 4xx extractor error DISCARDS, not retries" do
+      %{tenant: tenant} = setup_tenant()
+      review = create_review_record(tenant.id)
+
+      expect(Loopctl.MockExtractor, :extract_articles, fn _tenant_id, _ctx ->
+        {:error, {:api_error, 400, "bad extraction_model"}}
+      end)
+
+      assert {:discard, {:api_error, 400, _}} =
+               ReviewKnowledgeWorker.perform(%Oban.Job{
+                 args: %{"review_record_id" => review.id, "tenant_id" => tenant.id}
+               })
+    end
+
+    test "a transient error still RETRIES (returns {:error, _})" do
+      %{tenant: tenant} = setup_tenant()
+      review = create_review_record(tenant.id)
+
+      expect(Loopctl.MockExtractor, :extract_articles, fn _tenant_id, _ctx ->
+        {:error, {:request_failed, :timeout}}
+      end)
+
+      assert {:error, {:request_failed, :timeout}} =
+               ReviewKnowledgeWorker.perform(%Oban.Job{
+                 args: %{"review_record_id" => review.id, "tenant_id" => tenant.id}
+               })
+    end
+  end
+
   # --- TC-21.1.1: Worker extracts articles from review successfully ---
 
   describe "perform/1 success" do

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -9,11 +9,20 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
     put_req_header(conn, "authorization", "Bearer #{raw_key}")
   end
 
+  # Mandatory BYO (Epic 28, #179): ingest requires the tenant to have configured an
+  # Anthropic key. Every existing ingest test needs a keyed tenant; the dedicated
+  # "no key -> 422" test creates a keyless tenant directly.
+  defp keyed_tenant do
+    t = fixture(:tenant, %{})
+    fixture(:tenant_llm_settings, %{tenant_id: t.id})
+    t
+  end
+
   # Oban runs :inline in tests, so the ingestion worker executes within the
   # request; stub the extractor to yield exactly one article so we can assert the
   # resulting article's status (draft by default, published with publish: true).
   defp expect_one_extracted_article(title) do
-    expect(Loopctl.MockContentExtractor, :extract_from_content, fn _content, _opts ->
+    expect(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id, _content, _opts ->
       {:ok, [%{title: title, body: "Body for #{title}.", category: :pattern, tags: ["t"]}]}
     end)
   end
@@ -22,7 +31,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
 
   describe "POST /api/v1/knowledge/ingest" do
     test "queues ingestion job with URL", %{conn: conn} do
-      tenant = fixture(:tenant)
+      tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
 
       conn =
@@ -41,7 +50,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
     end
 
     test "queues ingestion job with inline content", %{conn: conn} do
-      tenant = fixture(:tenant)
+      tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
 
       conn =
@@ -58,7 +67,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
     end
 
     test "extracted articles default to draft", %{conn: conn} do
-      tenant = fixture(:tenant)
+      tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
       expect_one_extracted_article("Drafted by ingest")
 
@@ -72,7 +81,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
     end
 
     test "publish: true publishes the extracted articles", %{conn: conn} do
-      tenant = fixture(:tenant)
+      tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
       expect_one_extracted_article("Published by ingest")
 
@@ -90,7 +99,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
     end
 
     test "returns 422 when both url and content provided", %{conn: conn} do
-      tenant = fixture(:tenant)
+      tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
 
       conn =
@@ -107,7 +116,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
     end
 
     test "returns 422 when neither url nor content provided", %{conn: conn} do
-      tenant = fixture(:tenant)
+      tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
 
       conn =
@@ -122,7 +131,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
     end
 
     test "returns 422 when source_type missing", %{conn: conn} do
-      tenant = fixture(:tenant)
+      tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
 
       conn =
@@ -140,7 +149,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
     # private / loopback / cloud-metadata address is rejected 4xx up front, before
     # any job is enqueued or fetched.
     test "returns 422 for a URL targeting the cloud metadata endpoint", %{conn: conn} do
-      tenant = fixture(:tenant)
+      tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
 
       conn =
@@ -156,7 +165,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
     end
 
     test "returns 422 for a decimal-encoded loopback URL", %{conn: conn} do
-      tenant = fixture(:tenant)
+      tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
 
       conn =
@@ -171,7 +180,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
     end
 
     test "returns 422 for a v4-in-v6 NAT64-embedded metadata URL", %{conn: conn} do
-      tenant = fixture(:tenant)
+      tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
 
       conn =
@@ -186,7 +195,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
     end
 
     test "returns 422 with a distinct message when the host cannot be resolved", %{conn: conn} do
-      tenant = fixture(:tenant)
+      tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
 
       expect(Loopctl.MockDnsResolver, :resolve, fn _host -> {:error, :nxdomain} end)
@@ -205,7 +214,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
     end
 
     test "agent role is rejected (requires orchestrator)", %{conn: conn} do
-      tenant = fixture(:tenant)
+      tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
 
       conn =
@@ -220,7 +229,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
     end
 
     test "user role is allowed (higher than orchestrator)", %{conn: conn} do
-      tenant = fixture(:tenant)
+      tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
 
       conn =
@@ -246,7 +255,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
     end
 
     test "includes project_id in job args when provided", %{conn: conn} do
-      tenant = fixture(:tenant)
+      tenant = keyed_tenant()
       project = fixture(:project, %{tenant_id: tenant.id})
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
 
@@ -263,7 +272,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
     end
 
     test "returns 422 for a malformed project_id (not enqueued, kbweb-01)", %{conn: conn} do
-      tenant = fixture(:tenant)
+      tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
 
       conn =
@@ -280,7 +289,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
     end
 
     test "returns 422 for a non-string (array) project_id (not enqueued)", %{conn: conn} do
-      tenant = fixture(:tenant)
+      tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
 
       conn =
@@ -297,7 +306,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
     end
 
     test "an empty-string project_id is accepted as tenant-wide (202)", %{conn: conn} do
-      tenant = fixture(:tenant)
+      tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
       expect_one_extracted_article("Blank pid ingest")
 
@@ -318,7 +327,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
 
   describe "POST /api/v1/knowledge/ingest/batch" do
     test "queues all three items successfully", %{conn: conn} do
-      tenant = fixture(:tenant)
+      tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
 
       items = [
@@ -340,7 +349,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
     end
 
     test "returns per-item results for duplicate items within the same batch", %{conn: conn} do
-      tenant = fixture(:tenant)
+      tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
 
       items = [
@@ -375,7 +384,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
     end
 
     test "returns 422 when batch exceeds 50 items", %{conn: conn} do
-      tenant = fixture(:tenant)
+      tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
 
       items =
@@ -393,7 +402,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
     end
 
     test "returns 422 when items is empty", %{conn: conn} do
-      tenant = fixture(:tenant)
+      tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
 
       conn =
@@ -405,7 +414,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
     end
 
     test "mixed valid and invalid items produce per-item results", %{conn: conn} do
-      tenant = fixture(:tenant)
+      tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
 
       items = [
@@ -430,7 +439,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
     end
 
     test "agent role is rejected (requires orchestrator)", %{conn: conn} do
-      tenant = fixture(:tenant)
+      tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
 
       conn =
@@ -449,7 +458,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
     # item to a validation_timeout error instead of hanging the whole batch.
     test "bounds the batch when the resolver hangs (validation_timeout, no hang)",
          %{conn: conn} do
-      tenant = fixture(:tenant)
+      tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
 
       # Resolver never returns → each item's pin exceeds the per-item deadline and
@@ -480,7 +489,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
     @tag :capture_log
     test "a raising item yields validation_failed; other items still return 200",
          %{conn: conn} do
-      tenant = fixture(:tenant)
+      tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
 
       # One host makes the resolver raise; everything else resolves public.
@@ -510,8 +519,8 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
     end
 
     test "tenant isolation: tenant A cannot see tenant B's batch jobs", %{conn: conn} do
-      tenant_a = fixture(:tenant)
-      tenant_b = fixture(:tenant)
+      tenant_a = keyed_tenant()
+      tenant_b = keyed_tenant()
       {raw_key_a, _} = fixture(:api_key, %{tenant_id: tenant_a.id, role: :orchestrator})
       {raw_key_b, _} = fixture(:api_key, %{tenant_id: tenant_b.id, role: :orchestrator})
 
@@ -543,7 +552,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
 
     test "a malformed project_id yields a per-item error while valid items still queue (kbweb-01)",
          %{conn: conn} do
-      tenant = fixture(:tenant)
+      tenant = keyed_tenant()
       project = fixture(:project, %{tenant_id: tenant.id})
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
 
@@ -569,7 +578,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
 
   describe "GET /api/v1/knowledge/ingestion-jobs" do
     test "returns empty list for new tenant", %{conn: conn} do
-      tenant = fixture(:tenant)
+      tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
 
       conn =
@@ -582,7 +591,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
     end
 
     test "lists recent ingestion jobs", %{conn: conn} do
-      tenant = fixture(:tenant)
+      tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
 
       # Create an ingestion job (inline mode will execute immediately)
@@ -605,7 +614,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
 
     test "paginates with limit/offset + meta, and never caps or rejects (no hard 50)",
          %{conn: conn} do
-      tenant = fixture(:tenant)
+      tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
 
       # Insert ingestion-job rows directly (deterministic — no inline-cascade or
@@ -655,7 +664,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
     end
 
     test "agent role is rejected", %{conn: conn} do
-      tenant = fixture(:tenant)
+      tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
 
       conn =
@@ -676,8 +685,8 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
 
   describe "tenant isolation" do
     test "tenant A cannot see tenant B's ingestion jobs", %{conn: conn} do
-      tenant_a = fixture(:tenant)
-      tenant_b = fixture(:tenant)
+      tenant_a = keyed_tenant()
+      tenant_b = keyed_tenant()
       {raw_key_a, _} = fixture(:api_key, %{tenant_id: tenant_a.id, role: :orchestrator})
       {raw_key_b, _} = fixture(:api_key, %{tenant_id: tenant_b.id, role: :orchestrator})
 

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -27,6 +27,47 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
     end)
   end
 
+  # --- Mandatory BYO gate at the HTTP boundary (Epic 28, #179 — review #7) ---
+
+  describe "mandatory BYO 422 gate" do
+    test "POST /knowledge/ingest with a keyless tenant -> 422 code no_api_key", %{conn: conn} do
+      # A tenant WITHOUT an llm settings row (no key configured).
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      # The extractor must never run — we reject before enqueuing.
+      expect(Loopctl.MockContentExtractor, :extract_from_content, 0, fn _t, _c, _o ->
+        flunk("extractor must not run without a tenant key")
+      end)
+
+      body =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest", %{content: "x", source_type: "newsletter"})
+        |> json_response(422)
+
+      assert body["error"]["code"] == "no_api_key"
+      assert body["error"]["message"] =~ "Anthropic API key"
+    end
+
+    test "POST /knowledge/ingest/batch with a keyless tenant -> 422 code no_api_key", %{
+      conn: conn
+    } do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      body =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{
+          items: [%{content: "x", source_type: "newsletter"}]
+        })
+        |> json_response(422)
+
+      assert body["error"]["code"] == "no_api_key"
+    end
+  end
+
   # --- POST /api/v1/knowledge/ingest ---
 
   describe "POST /api/v1/knowledge/ingest" do

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -18,6 +18,15 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
     t
   end
 
+  # A verb+path pair (as printed in a remediation string) is a real router route.
+  defp route_registered?(verb, path) do
+    wanted = verb |> String.downcase() |> String.to_existing_atom()
+
+    Enum.any?(LoopctlWeb.Router.__routes__(), fn route ->
+      route.verb == wanted and route.path == path
+    end)
+  end
+
   # Oban runs :inline in tests, so the ingestion worker executes within the
   # request; stub the extractor to yield exactly one article so we can assert the
   # resulting article's status (draft by default, published with publish: true).
@@ -48,6 +57,13 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
 
       assert body["error"]["code"] == "no_api_key"
       assert body["error"]["message"] =~ "Anthropic API key"
+
+      # The remediation string must name a verb+path ACTUALLY registered in the
+      # router (review #7 — catches PUT/PATCH drift between the copy and the route).
+      [verb, path] = String.split(body["error"]["remediation"]["configure"], " ", parts: 2)
+
+      assert route_registered?(verb, path),
+             "422 remediation names #{verb} #{path}, which is not a registered route"
     end
 
     test "POST /knowledge/ingest/batch with a keyless tenant -> 422 code no_api_key", %{

--- a/test/loopctl_web/controllers/llm_config_controller_test.exs
+++ b/test/loopctl_web/controllers/llm_config_controller_test.exs
@@ -17,7 +17,7 @@ defmodule LoopctlWeb.LlmConfigControllerTest do
     # NON-VACUOUS: removing the `config :phoenix, :filter_parameters` entry reverts
     # the api_key to the default (unfiltered) behaviour and fails the first assert.
     test "filter_parameters redacts api_key (the exact param-log redaction)" do
-      secret = "sk-ant-LEAKCHECK-#{System.unique_integer([:positive])}"
+      secret = "test-anthropic-LEAKCHECK-#{System.unique_integer([:positive])}"
 
       filtered = Phoenix.Logger.filter_values(%{"api_key" => secret, "keep_me" => "visible"})
 
@@ -37,7 +37,7 @@ defmodule LoopctlWeb.LlmConfigControllerTest do
         conn
         |> auth_conn(raw_key)
         |> patch(~p"/api/v1/tenants/me/llm-config", %{
-          api_key: "sk-ant-controller-key",
+          api_key: "test-anthropic-controller-key",
           extraction_model: "claude-opus-4-1",
           classification_model: "claude-sonnet-4-5"
         })
@@ -48,10 +48,10 @@ defmodule LoopctlWeb.LlmConfigControllerTest do
       assert body["extraction_model"] == "claude-opus-4-1"
       assert body["classification_model"] == "claude-sonnet-4-5"
       refute Map.has_key?(body, "api_key")
-      refute inspect(body) =~ "sk-ant-controller-key"
+      refute inspect(body) =~ "test-anthropic-controller-key"
 
       # Persisted + resolvable.
-      assert {:ok, %{api_key: "sk-ant-controller-key", model: "claude-opus-4-1"}} =
+      assert {:ok, %{api_key: "test-anthropic-controller-key", model: "claude-opus-4-1"}} =
                Llm.resolve(tenant.id, :extraction)
     end
 
@@ -62,7 +62,7 @@ defmodule LoopctlWeb.LlmConfigControllerTest do
       conn =
         conn
         |> auth_conn(raw_key)
-        |> patch(~p"/api/v1/tenants/me/llm-config", %{api_key: "sk-ant-x"})
+        |> patch(~p"/api/v1/tenants/me/llm-config", %{api_key: "test-anthropic-x"})
 
       assert json_response(conn, 403)
       # Nothing was stored.
@@ -85,7 +85,7 @@ defmodule LoopctlWeb.LlmConfigControllerTest do
   describe "GET /api/v1/tenants/me/llm-config" do
     test "returns models + has_api_key + masked hint, never the key", %{conn: conn} do
       tenant = fixture(:tenant)
-      {:ok, _} = Llm.upsert_settings(tenant.id, %{"api_key" => "sk-ant-abcd1234"})
+      {:ok, _} = Llm.upsert_settings(tenant.id, %{"api_key" => "test-anthropic-abcd1234"})
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
 
       body =
@@ -96,7 +96,7 @@ defmodule LoopctlWeb.LlmConfigControllerTest do
 
       assert body["has_api_key"] == true
       assert body["api_key_hint"] == "...1234"
-      refute inspect(body) =~ "sk-ant-abcd1234"
+      refute inspect(body) =~ "test-anthropic-abcd1234"
     end
 
     test "reports has_api_key false when unconfigured", %{conn: conn} do
@@ -118,8 +118,8 @@ defmodule LoopctlWeb.LlmConfigControllerTest do
     test "tenant A only sees its own config, never tenant B's key", %{conn: conn} do
       a = fixture(:tenant)
       b = fixture(:tenant)
-      {:ok, _} = Llm.upsert_settings(a.id, %{"api_key" => "sk-ant-aaaa1111"})
-      {:ok, _} = Llm.upsert_settings(b.id, %{"api_key" => "sk-ant-bbbb2222"})
+      {:ok, _} = Llm.upsert_settings(a.id, %{"api_key" => "test-anthropic-aaaa1111"})
+      {:ok, _} = Llm.upsert_settings(b.id, %{"api_key" => "test-anthropic-bbbb2222"})
 
       {raw_key_a, _} = fixture(:api_key, %{tenant_id: a.id, role: :user})
 

--- a/test/loopctl_web/controllers/llm_config_controller_test.exs
+++ b/test/loopctl_web/controllers/llm_config_controller_test.exs
@@ -1,9 +1,31 @@
 defmodule LoopctlWeb.LlmConfigControllerTest do
   use LoopctlWeb.ConnCase, async: true
 
+  import ExUnit.CaptureLog
+
   alias Loopctl.Llm
 
   defp auth_conn(conn, raw_key), do: put_req_header(conn, "authorization", "Bearer #{raw_key}")
+
+  describe "secret redaction on the PATCH path (review #5, #10)" do
+    test "the raw api_key never appears in request logs", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      secret = "sk-ant-LEAKCHECK-#{System.unique_integer([:positive])}"
+
+      log =
+        capture_log(fn ->
+          conn
+          |> auth_conn(raw_key)
+          |> patch(~p"/api/v1/tenants/me/llm-config", %{api_key: secret})
+          |> json_response(200)
+        end)
+
+      # Phoenix's :filter_parameters config discards api_key from the param log;
+      # Cloak dumps ciphertext before Ecto, so the SQL log can't leak it either.
+      refute log =~ secret
+    end
+  end
 
   describe "PATCH /api/v1/tenants/me/llm-config" do
     test "sets the api_key + models (role user); response never leaks the key", %{conn: conn} do

--- a/test/loopctl_web/controllers/llm_config_controller_test.exs
+++ b/test/loopctl_web/controllers/llm_config_controller_test.exs
@@ -1,0 +1,113 @@
+defmodule LoopctlWeb.LlmConfigControllerTest do
+  use LoopctlWeb.ConnCase, async: true
+
+  alias Loopctl.Llm
+
+  defp auth_conn(conn, raw_key), do: put_req_header(conn, "authorization", "Bearer #{raw_key}")
+
+  describe "PUT /api/v1/tenants/me/llm-config" do
+    test "sets the api_key + models (role user); response never leaks the key", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      body =
+        conn
+        |> auth_conn(raw_key)
+        |> put(~p"/api/v1/tenants/me/llm-config", %{
+          api_key: "sk-ant-controller-key",
+          extraction_model: "claude-opus-4-1",
+          classification_model: "claude-sonnet-4-5"
+        })
+        |> json_response(200)
+
+      assert body["has_api_key"] == true
+      assert body["api_key_hint"] == "...-key"
+      assert body["extraction_model"] == "claude-opus-4-1"
+      assert body["classification_model"] == "claude-sonnet-4-5"
+      refute Map.has_key?(body, "api_key")
+      refute inspect(body) =~ "sk-ant-controller-key"
+
+      # Persisted + resolvable.
+      assert {:ok, %{api_key: "sk-ant-controller-key", model: "claude-opus-4-1"}} =
+               Llm.resolve(tenant.id, :extraction)
+    end
+
+    test "a lower role (orchestrator) is rejected with 403", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> put(~p"/api/v1/tenants/me/llm-config", %{api_key: "sk-ant-x"})
+
+      assert json_response(conn, 403)
+      # Nothing was stored.
+      refute Llm.has_api_key?(tenant.id)
+    end
+
+    test "422 on an invalid model id", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> put(~p"/api/v1/tenants/me/llm-config", %{extraction_model: "bad model!"})
+
+      assert json_response(conn, 422)
+    end
+  end
+
+  describe "GET /api/v1/tenants/me/llm-config" do
+    test "returns models + has_api_key + masked hint, never the key", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {:ok, _} = Llm.upsert_settings(tenant.id, %{"api_key" => "sk-ant-abcd1234"})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      body =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/tenants/me/llm-config")
+        |> json_response(200)
+
+      assert body["has_api_key"] == true
+      assert body["api_key_hint"] == "...1234"
+      refute inspect(body) =~ "sk-ant-abcd1234"
+    end
+
+    test "reports has_api_key false when unconfigured", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      body =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/tenants/me/llm-config")
+        |> json_response(200)
+
+      assert body["has_api_key"] == false
+      assert is_nil(body["api_key_hint"])
+    end
+  end
+
+  describe "tenant isolation" do
+    test "tenant A only sees its own config, never tenant B's key", %{conn: conn} do
+      a = fixture(:tenant)
+      b = fixture(:tenant)
+      {:ok, _} = Llm.upsert_settings(a.id, %{"api_key" => "sk-ant-aaaa1111"})
+      {:ok, _} = Llm.upsert_settings(b.id, %{"api_key" => "sk-ant-bbbb2222"})
+
+      {raw_key_a, _} = fixture(:api_key, %{tenant_id: a.id, role: :user})
+
+      body =
+        conn
+        |> auth_conn(raw_key_a)
+        |> get(~p"/api/v1/tenants/me/llm-config")
+        |> json_response(200)
+
+      assert body["api_key_hint"] == "...1111"
+      refute inspect(body) =~ "bbbb2222"
+    end
+  end
+end

--- a/test/loopctl_web/controllers/llm_config_controller_test.exs
+++ b/test/loopctl_web/controllers/llm_config_controller_test.exs
@@ -1,29 +1,30 @@
 defmodule LoopctlWeb.LlmConfigControllerTest do
   use LoopctlWeb.ConnCase, async: true
 
-  import ExUnit.CaptureLog
-
   alias Loopctl.Llm
 
   defp auth_conn(conn, raw_key), do: put_req_header(conn, "authorization", "Bearer #{raw_key}")
 
-  describe "secret redaction on the PATCH path (review #5, #10)" do
-    test "the raw api_key never appears in request logs", %{conn: conn} do
-      tenant = fixture(:tenant)
-      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+  describe "secret redaction from Phoenix request-param logs (review #5, #10)" do
+    # The Phoenix "Parameters:" request-log line redacts values via
+    # `Phoenix.Logger.filter_values/1`, which applies the `:filter_parameters` config
+    # (#5). We test that exact function — it IS the param-log redaction path — rather
+    # than a capture_log integration test, because the param line is emitted at :debug
+    # while config/test.exs pins the primary Logger level to :warning, and neither
+    # capture_log's `:level` opt nor `Logger.put_process_level/2` lowers the primary
+    # level (verified empirically), so a capture-based test can't emit that line in an
+    # async test without the forbidden global `Logger.configure/1`. This assertion is
+    # NON-VACUOUS: removing the `config :phoenix, :filter_parameters` entry reverts
+    # the api_key to the default (unfiltered) behaviour and fails the first assert.
+    test "filter_parameters redacts api_key (the exact param-log redaction)" do
       secret = "sk-ant-LEAKCHECK-#{System.unique_integer([:positive])}"
 
-      log =
-        capture_log(fn ->
-          conn
-          |> auth_conn(raw_key)
-          |> patch(~p"/api/v1/tenants/me/llm-config", %{api_key: secret})
-          |> json_response(200)
-        end)
+      filtered = Phoenix.Logger.filter_values(%{"api_key" => secret, "keep_me" => "visible"})
 
-      # Phoenix's :filter_parameters config discards api_key from the param log;
-      # Cloak dumps ciphertext before Ecto, so the SQL log can't leak it either.
-      refute log =~ secret
+      assert filtered["api_key"] == "[FILTERED]"
+      # A non-secret param is untouched (proves we didn't over-filter / vacuously pass).
+      assert filtered["keep_me"] == "visible"
+      refute inspect(filtered) =~ secret
     end
   end
 

--- a/test/loopctl_web/controllers/llm_config_controller_test.exs
+++ b/test/loopctl_web/controllers/llm_config_controller_test.exs
@@ -5,7 +5,7 @@ defmodule LoopctlWeb.LlmConfigControllerTest do
 
   defp auth_conn(conn, raw_key), do: put_req_header(conn, "authorization", "Bearer #{raw_key}")
 
-  describe "PUT /api/v1/tenants/me/llm-config" do
+  describe "PATCH /api/v1/tenants/me/llm-config" do
     test "sets the api_key + models (role user); response never leaks the key", %{conn: conn} do
       tenant = fixture(:tenant)
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
@@ -13,7 +13,7 @@ defmodule LoopctlWeb.LlmConfigControllerTest do
       body =
         conn
         |> auth_conn(raw_key)
-        |> put(~p"/api/v1/tenants/me/llm-config", %{
+        |> patch(~p"/api/v1/tenants/me/llm-config", %{
           api_key: "sk-ant-controller-key",
           extraction_model: "claude-opus-4-1",
           classification_model: "claude-sonnet-4-5"
@@ -39,7 +39,7 @@ defmodule LoopctlWeb.LlmConfigControllerTest do
       conn =
         conn
         |> auth_conn(raw_key)
-        |> put(~p"/api/v1/tenants/me/llm-config", %{api_key: "sk-ant-x"})
+        |> patch(~p"/api/v1/tenants/me/llm-config", %{api_key: "sk-ant-x"})
 
       assert json_response(conn, 403)
       # Nothing was stored.
@@ -53,7 +53,7 @@ defmodule LoopctlWeb.LlmConfigControllerTest do
       conn =
         conn
         |> auth_conn(raw_key)
-        |> put(~p"/api/v1/tenants/me/llm-config", %{extraction_model: "bad model!"})
+        |> patch(~p"/api/v1/tenants/me/llm-config", %{extraction_model: "bad model!"})
 
       assert json_response(conn, 422)
     end

--- a/test/loopctl_web/controllers/llm_usage_controller_test.exs
+++ b/test/loopctl_web/controllers/llm_usage_controller_test.exs
@@ -1,0 +1,85 @@
+defmodule LoopctlWeb.LlmUsageControllerTest do
+  use LoopctlWeb.ConnCase, async: true
+
+  alias Loopctl.Llm
+
+  defp auth_conn(conn, raw_key), do: put_req_header(conn, "authorization", "Bearer #{raw_key}")
+
+  defp record(tenant_id, attrs) do
+    {:ok, _} =
+      Llm.record_usage(
+        tenant_id,
+        Map.merge(
+          %{operation: :extraction, model: "haiku", input_tokens: 10, output_tokens: 5},
+          attrs
+        )
+      )
+  end
+
+  describe "GET /api/v1/knowledge/llm-usage" do
+    test "returns the tenant's usage summary (role orchestrator)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      record(tenant.id, %{model: "haiku", input_tokens: 100, output_tokens: 40})
+      record(tenant.id, %{model: "haiku", input_tokens: 50, output_tokens: 10})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      body =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/llm-usage")
+        |> json_response(200)
+
+      assert [row] = body["data"]
+      assert row["operation"] == "extraction"
+      assert row["model"] == "haiku"
+      assert row["input_tokens"] == 150
+      assert row["output_tokens"] == 50
+      assert row["event_count"] == 2
+      assert body["meta"]["total_count"] == 1
+    end
+
+    test "an agent role is rejected with 403", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/llm-usage")
+
+      assert json_response(conn, 403)
+    end
+
+    test "paginates via limit/offset with meta", %{conn: conn} do
+      tenant = fixture(:tenant)
+      for model <- ["m-a", "m-b", "m-c"], do: record(tenant.id, %{model: model})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      page1 =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/llm-usage?limit=2&offset=0")
+        |> json_response(200)
+
+      assert length(page1["data"]) == 2
+      assert page1["meta"]["total_count"] == 3
+      assert page1["meta"]["limit"] == 2
+    end
+
+    test "is tenant-isolated (A never sees B's usage)", %{conn: conn} do
+      a = fixture(:tenant)
+      b = fixture(:tenant)
+      record(b.id, %{model: "b-only", input_tokens: 999, output_tokens: 999})
+      {raw_key_a, _} = fixture(:api_key, %{tenant_id: a.id, role: :orchestrator})
+
+      body =
+        conn
+        |> auth_conn(raw_key_a)
+        |> get(~p"/api/v1/knowledge/llm-usage")
+        |> json_response(200)
+
+      assert body["data"] == []
+      refute inspect(body) =~ "b-only"
+    end
+  end
+end

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -103,8 +103,9 @@ defmodule Loopctl.DataCase do
       {:ok, List.duplicate(0.1, 1536)}
     end)
 
-    # Default stub for knowledge extractor -- returns empty list (no articles)
-    Mox.stub(Loopctl.MockExtractor, :extract_articles, fn _ctx ->
+    # Default stub for knowledge extractor -- returns empty list (no articles).
+    # tenant_id is threaded first (Epic 28 BYO, review #1).
+    Mox.stub(Loopctl.MockExtractor, :extract_articles, fn _tenant_id, _ctx ->
       {:ok, []}
     end)
 
@@ -118,7 +119,7 @@ defmodule Loopctl.DataCase do
 
     # Default stub for category classifier -- zero confidence, so the
     # reclassification backfill is a no-op unless a test sets its own verdict.
-    Mox.stub(Loopctl.MockCategoryClassifier, :classify, fn _tenant_id, _title, _body ->
+    Mox.stub(Loopctl.MockCategoryClassifier, :classify, fn _tenant_id, _title, _body, _opts ->
       {:ok, %{category: :pattern, confidence: 0.0}}
     end)
 

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -108,14 +108,17 @@ defmodule Loopctl.DataCase do
       {:ok, []}
     end)
 
-    # Default stub for content extractor -- returns empty list (no articles)
-    Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _content, _opts ->
+    # Default stub for content extractor -- returns empty list (no articles).
+    # tenant_id is threaded first (Epic 28 BYO); tests that assert threading match on it.
+    Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id,
+                                                                     _content,
+                                                                     _opts ->
       {:ok, []}
     end)
 
     # Default stub for category classifier -- zero confidence, so the
     # reclassification backfill is a no-op unless a test sets its own verdict.
-    Mox.stub(Loopctl.MockCategoryClassifier, :classify, fn _title, _body ->
+    Mox.stub(Loopctl.MockCategoryClassifier, :classify, fn _tenant_id, _title, _body ->
       {:ok, %{category: :pattern, confidence: 0.0}}
     end)
 
@@ -200,7 +203,21 @@ defmodule Loopctl.DataCase do
 
     # Merge synthesizer defaults to "no backend" so the conflict executor no-ops on
     # :merge rows unless a test opts in with a real merged result.
-    Mox.stub(Loopctl.MockMergeSynthesizer, :synthesize, fn _a, _b -> {:error, :not_configured} end)
+    Mox.stub(Loopctl.MockMergeSynthesizer, :synthesize, fn _tenant_id, _a, _b ->
+      {:error, :not_configured}
+    end)
+
+    # Epic 28 (#179): default Req.Test stub for the shared tenant-scoped Anthropic
+    # client. Returns an empty-articles Messages response with a zero-usage block so
+    # any incidental call to a REAL Claude module (only when a tenant key is
+    # configured) is intercepted without a real API call. Dedicated LLM tests
+    # override this to return crafted content + usage.
+    Req.Test.stub(Loopctl.Llm.Anthropic, fn conn ->
+      Req.Test.json(conn, %{
+        "content" => [%{"type" => "text", "text" => "[]"}],
+        "usage" => %{"input_tokens" => 0, "output_tokens" => 0}
+      })
+    end)
 
     # ArticleLinkingWorker similarity lookup: default to NO candidates so unrelated tests
     # (and the inline-Oban embedding→linking cascade an article create/publish triggers)

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -285,7 +285,7 @@ defmodule Loopctl.Fixtures do
   # Per-tenant BYO LLM config + usage (Epic 28 residual, #179).
   def build(:tenant_llm_settings, attrs) do
     Enum.into(attrs, %{
-      api_key: "sk-ant-test-#{System.unique_integer([:positive])}",
+      api_key: "test-anthropic-test-#{System.unique_integer([:positive])}",
       extraction_model: nil,
       classification_model: nil,
       merge_model: nil

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -19,6 +19,8 @@ defmodule Loopctl.Fixtures do
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.ArticleAccessEvent
   alias Loopctl.Knowledge.ArticleLink
+  alias Loopctl.Llm.TenantLlmSettings
+  alias Loopctl.Llm.UsageEvent, as: LlmUsageEvent
   alias Loopctl.Orchestrator.OrchestratorState
   alias Loopctl.Projects.Project
   alias Loopctl.QualityAssurance.UiTestRun
@@ -278,6 +280,28 @@ defmodule Loopctl.Fixtures do
       },
       Enum.into(attrs, %{})
     )
+  end
+
+  # Per-tenant BYO LLM config + usage (Epic 28 residual, #179).
+  def build(:tenant_llm_settings, attrs) do
+    Enum.into(attrs, %{
+      api_key: "sk-ant-test-#{System.unique_integer([:positive])}",
+      extraction_model: nil,
+      classification_model: nil,
+      merge_model: nil
+    })
+  end
+
+  def build(:llm_usage_event, attrs) do
+    Enum.into(attrs, %{
+      operation: :extraction,
+      model: "claude-haiku-4-5-20251001",
+      input_tokens: 100,
+      output_tokens: 50,
+      source_type: "newsletter",
+      article_id: nil,
+      occurred_at: DateTime.utc_now()
+    })
   end
 
   def build(:webhook_event, attrs) do
@@ -1046,6 +1070,56 @@ defmodule Loopctl.Fixtures do
       |> ReviewRecord.create_changeset(data)
 
     AdminRepo.insert!(changeset)
+  end
+
+  # --- Per-tenant BYO LLM config + usage (Epic 28 residual, #179) ---
+
+  # Inserts a tenant_llm_settings row (auto-creating a tenant if needed). The
+  # `api_key` defaults to a plausible test key so `Loopctl.Llm.has_api_key?/1`
+  # returns true and the mandatory-BYO gate passes.
+  def fixture(:tenant_llm_settings, attrs) do
+    attrs = Enum.into(attrs, %{})
+
+    {tenant_id, attrs} =
+      case Map.get(attrs, :tenant_id) do
+        nil ->
+          tenant = fixture(:tenant)
+          {tenant.id, attrs}
+
+        tid ->
+          {tid, attrs}
+      end
+
+    data = build(:tenant_llm_settings, Map.delete(attrs, :tenant_id))
+    api_key = Map.get(data, :api_key)
+
+    %TenantLlmSettings{tenant_id: tenant_id}
+    |> TenantLlmSettings.models_changeset(data)
+    |> TenantLlmSettings.put_api_key(api_key)
+    |> Ecto.Changeset.put_change(:tenant_id, tenant_id)
+    |> AdminRepo.insert!()
+  end
+
+  # Inserts an llm_usage_events row (auto-creating a tenant if needed).
+  def fixture(:llm_usage_event, attrs) do
+    attrs = Enum.into(attrs, %{})
+
+    {tenant_id, attrs} =
+      case Map.get(attrs, :tenant_id) do
+        nil ->
+          tenant = fixture(:tenant)
+          {tenant.id, attrs}
+
+        tid ->
+          {tid, attrs}
+      end
+
+    data = build(:llm_usage_event, Map.delete(attrs, :tenant_id))
+
+    %LlmUsageEvent{tenant_id: tenant_id}
+    |> LlmUsageEvent.create_changeset(data)
+    |> Ecto.Changeset.put_change(:tenant_id, tenant_id)
+    |> AdminRepo.insert!()
   end
 
   def fixture(:webhook, attrs) do


### PR DESCRIPTION
## Per-tenant BYO Anthropic LLM config + usage tracking (Epic 28 residual, #179)

Closes the two Epic-28 residual product decisions:

1. **Mandatory BYO-key LLM config** — every tenant supplies its OWN Anthropic API key and pays Anthropic directly. loopctl fronts no cost (no markup, no price table, no billing). Tenant knowledge-LLM work (ingest/classify/merge) **fails cleanly** when no key is configured — there is **no global-system-key fallback**.
2. **Per-operation usage tracking** — record token usage per operation and expose a per-tenant usage summary. No budget enforcement.

### Data model + RLS

- `tenant_llm_settings` — one row per tenant (unique `tenant_id`). `api_key` encrypted at rest via Cloak `Loopctl.Vault.Binary` (`redact: true`); `extraction_model` / `classification_model` / `merge_model` free-form (validated as plausible ids, **not** an allow-list).
- `llm_usage_events` — record-only ledger (`operation`, `model`, `input_tokens`, `output_tokens`, `source_type`, `article_id`, `occurred_at`). Indexes on `(tenant_id, occurred_at)` and `(tenant_id, operation)`.
- Both tables `ENABLE ROW LEVEL SECURITY` (not FORCE) with a `tenant_isolation` policy; both asserted in `rls_coverage_test`.

### Context — `Loopctl.Llm`

`get_settings/1`, `upsert_settings/2`, **`resolve/2`** → `{:ok, %{api_key, model}}` | `{:error, :no_api_key}`, `record_usage/2`, `usage_summary/2` (grouped by operation+model+source+day, date range + stable-tiebreaker offset pagination). Uses `AdminRepo` + explicit `tenant_id` filter (the `Loopctl.Webhooks` encrypted-secret precedent — runs from web + Oban workers).

### LLM call sites

`tenant_id` threaded through all 3 behaviours (`extract_from_content` / `classify` / `synthesize`) + every caller + the Mox mocks. The Claude implementations resolve the tenant key + per-op model and record usage via the shared `Loopctl.Llm.Anthropic` client (resolve → POST → `record_usage` from the response `usage` block). **The API key is never logged.**

### Mandatory-BYO enforcement (end to end)

- `KnowledgeIngestionController` 422s up front (`configure your Anthropic API key`) before enqueuing.
- `ContentIngestionWorker` `{:discard, {:no_api_key, _}}`s — no crash, no retry loop (+ `:no_api_key` classified permanent as a backstop).
- The reclassify backfill skips a keyless tenant cleanly.

### APIs + MCP

- `GET`/`PUT /api/v1/tenants/me/llm-config` (**role :user** — stores a secret; never returns the key, only `has_api_key` + a last-4 hint; setting a key writes an audit event **without** the value).
- `GET /api/v1/knowledge/llm-usage` (role :orchestrator).
- OpenApiSpex schemas added.
- MCP tools `llm_config` / `set_llm_config` (user key) + `knowledge_llm_usage` (orch key); `loopctl-mcp-server` bumped to `2.31.0`.

### Security

Encryption at rest (Vault.Binary) + `redact: true`; key never logged, never serialized (asserted); RLS on both tables; config endpoint at `:user`; resolve is tenant_id-scoped (no cross-tenant); key set/rotate is auditable (no value).

### Tests

Full suite green: **3580 tests, 0 failures**. New coverage: context (upsert/resolve/encryption-at-rest/redaction/audit/usage aggregation/tenant isolation/pagination), real extractor via Req.Test (records usage + threads the tenant key/model + `:no_api_key`), config + usage controllers (role, isolation, no-leak), worker mandatory-BYO discard, and MCP arg-forwarding. Pre-commit gate (compile --warnings-as-errors, format, credo --strict, deps.audit, dialyzer, test) passed.

### Scope note / needs a Mark decision

`Loopctl.Knowledge.LlmExtractor` (the `ReviewKnowledgeWorker` path, `ExtractorBehaviour`) still uses the global `:anthropic_provider` key — a **4th** tenant-LLM path outside the 3 call sites this change scoped. If review-knowledge extraction should also be mandatory-BYO, that's a small follow-up (thread `tenant_id` through `ExtractorBehaviour` + `MockExtractor` + the worker).

Draft — not for merge.
