### PR TITLE
feat(llm): extend per-tenant BYO to embeddings — mandatory tenant OpenAI key, gated enqueue, usage tracking

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -189,14 +189,18 @@ if config_env() == :prod do
   # The timeout is enforced per-read via SET LOCAL (HeavyRead.opts/1). See the comment
   # above and config_pgbouncer_safe_parameters_test.exs (the regression guard).
 
-  # OpenAI embedding provider for semantic search (Knowledge Wiki)
-  if openai_key = System.get_env("OPENAI_API_KEY") do
-    config :loopctl, :embedding_provider, %{
-      api_key: openai_key,
-      base_url: System.get_env("OPENAI_BASE_URL") || "https://api.openai.com/v1",
-      model: System.get_env("OPENAI_EMBEDDING_MODEL") || "text-embedding-3-small"
-    }
-  end
+  # OpenAI-compatible embedding provider for semantic search (Knowledge Wiki).
+  #
+  # BYO (#294 extended to embeddings): the embedding KEY is PER-TENANT — each tenant
+  # supplies its OWN key via `PATCH /tenants/me/llm-config` (stored encrypted, resolved
+  # by `Loopctl.Llm.resolve(tenant_id, :embedding)`). There is intentionally NO global
+  # operator key here — that was the ungated, operator-funded spend path this change
+  # closes. Only the shared ENDPOINT (base_url) + default model live in global config;
+  # a tenant without a configured key simply gets NO embeddings.
+  config :loopctl, :embedding_provider, %{
+    base_url: System.get_env("OPENAI_BASE_URL") || "https://api.openai.com/v1",
+    model: System.get_env("OPENAI_EMBEDDING_MODEL") || "text-embedding-3-small"
+  }
 
   # NOTE (Epic 28, #179): the global `:anthropic_provider` / `:knowledge_classifier_model`
   # config keys were REMOVED. Tenant knowledge-LLM work (content extraction,

--- a/config/test.exs
+++ b/config/test.exs
@@ -350,6 +350,13 @@ config :loopctl, :ingestion_req_plug, {Req.Test, Loopctl.Workers.ContentIngestio
 # dedicated LLM tests override with crafted content + usage blocks.
 config :loopctl, :anthropic_req_plug, {Req.Test, Loopctl.Llm.Anthropic}
 
+# Epic 28 (#179) embeddings BYO: route the real tenant-scoped EmbeddingClient
+# through a Req.Test plug so its own dedicated test exercises per-tenant key
+# resolution + usage recording without real OpenAI calls. Everywhere ELSE the
+# embedding client is swapped for Loopctl.MockEmbeddingClient (see above), so this
+# plug only matters when a test drives Loopctl.Knowledge.EmbeddingClient directly.
+config :loopctl, :embedding_req_plug, {Req.Test, Loopctl.Knowledge.EmbeddingClient}
+
 # DI: Use Req.Test plug for webhook delivery in tests
 config :loopctl, :webhook_req_plug, {Req.Test, Loopctl.Webhooks.ReqDelivery}
 

--- a/lib/loopctl/api_spec/schemas.ex
+++ b/lib/loopctl/api_spec/schemas.ex
@@ -2616,10 +2616,10 @@ defmodule Loopctl.ApiSpec.Schemas do
       title: "LlmConfigUpdateRequest",
       description:
         "Request body for `PATCH /api/v1/tenants/me/llm-config`. Sets the tenant's " <>
-          "OWN Anthropic API key (encrypted at rest, never returned) and the " <>
-          "granular per-operation model choices. Any subset of fields may be sent; " <>
-          "omitting `api_key` leaves the existing key untouched. Model ids are " <>
-          "free-form (any model the key permits) — not restricted to an allow-list.",
+          "OWN Anthropic API key and OpenAI embedding key (both encrypted at rest, " <>
+          "never returned) and the granular per-operation model choices. Any subset " <>
+          "of fields may be sent; omitting a key leaves the existing key untouched. " <>
+          "Model ids are free-form (any model the key permits) — not an allow-list.",
       type: :object,
       properties: %{
         api_key: %Schema{
@@ -2641,13 +2641,28 @@ defmodule Loopctl.ApiSpec.Schemas do
           type: :string,
           nullable: true,
           description: "Model id for article merge synthesis (null → server default)"
+        },
+        embedding_api_key: %Schema{
+          type: :string,
+          writeOnly: true,
+          description:
+            "OpenAI-compatible embedding API key (write-only; stored encrypted, never " <>
+              "returned). Mandatory BYO — without it the tenant's articles are not " <>
+              "vector-searchable."
+        },
+        embedding_model: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Embedding model id (null → server default `text-embedding-3-small`)"
         }
       },
       example: %{
         api_key: "sk-ant-...",
         extraction_model: "claude-haiku-4-5-20251001",
         classification_model: "claude-sonnet-4-5-20250929",
-        merge_model: "claude-haiku-4-5-20251001"
+        merge_model: "claude-haiku-4-5-20251001",
+        embedding_api_key: "sk-...",
+        embedding_model: "text-embedding-3-small"
       }
     })
   end
@@ -2659,8 +2674,9 @@ defmodule Loopctl.ApiSpec.Schemas do
     OpenApiSpex.schema(%{
       title: "LlmConfigResponse",
       description:
-        "The tenant's LLM configuration. NEVER includes the API key itself — only " <>
-          "whether one is set (`has_api_key`) and a last-4 hint (`api_key_hint`).",
+        "The tenant's LLM configuration. NEVER includes any API key itself — only " <>
+          "whether each key is set (`has_api_key` / `has_embedding_key`) and masked " <>
+          "last-4 hints (`api_key_hint` / `embedding_api_key_hint`).",
       type: :object,
       properties: %{
         has_api_key: %Schema{
@@ -2674,14 +2690,27 @@ defmodule Loopctl.ApiSpec.Schemas do
         },
         extraction_model: %Schema{type: :string, nullable: true},
         classification_model: %Schema{type: :string, nullable: true},
-        merge_model: %Schema{type: :string, nullable: true}
+        merge_model: %Schema{type: :string, nullable: true},
+        has_embedding_key: %Schema{
+          type: :boolean,
+          description: "Whether an OpenAI embedding key is configured"
+        },
+        embedding_api_key_hint: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Masked last-4 hint for the embedding key; never the full key"
+        },
+        embedding_model: %Schema{type: :string, nullable: true}
       },
       example: %{
         has_api_key: true,
         api_key_hint: "...aB3d",
         extraction_model: "claude-haiku-4-5-20251001",
         classification_model: "claude-sonnet-4-5-20250929",
-        merge_model: nil
+        merge_model: nil,
+        has_embedding_key: true,
+        embedding_api_key_hint: "...Xy9z",
+        embedding_model: "text-embedding-3-small"
       }
     })
   end

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -4834,7 +4834,7 @@ defmodule Loopctl.Knowledge do
   end
 
   defp score_embedding(tenant_id, idea, text, prior_tag, vis) do
-    case generate_embedding(text) do
+    case generate_embedding(tenant_id, text) do
       {:ok, embedding} ->
         Map.put(
           idea,
@@ -5675,7 +5675,7 @@ defmodule Loopctl.Knowledge do
       |> Keyword.put(:_skip_record_access, true)
 
     keyword_result = search_keyword(tenant_id, query_string, sub_opts)
-    embedding_result = try_generate_embedding(query_string)
+    embedding_result = try_generate_embedding(tenant_id, query_string)
 
     case {keyword_result, embedding_result} do
       {{:ok, kw}, {:ok, embedding}} ->
@@ -5836,18 +5836,22 @@ defmodule Loopctl.Knowledge do
   @doc """
   Generate an embedding for the given text with circuit breaker and timeout protection.
 
-  Wraps the configured embedding client with:
+  Resolves the TENANT's OWN embedding key (mandatory BYO) via the configured
+  embedding client, wrapped with:
   - Circuit breaker (opens after #{@failure_threshold} failures within #{@failure_window_seconds}s)
   - 5-second Task.async timeout
   - Crash rescue handler
 
-  Returns `{:ok, embedding}` or `{:error, reason}`.
+  Returns `{:ok, embedding}` or `{:error, reason}`. A keyless tenant yields
+  `{:error, :no_api_key}` WITHOUT tripping the (global) circuit breaker — it is a
+  per-tenant config gap, not a provider outage, so it must not degrade embeddings
+  for tenants that DO have a key.
   """
-  def generate_embedding(query_string) do
-    try_generate_embedding(query_string)
+  def generate_embedding(tenant_id, query_string) when is_binary(tenant_id) do
+    try_generate_embedding(tenant_id, query_string)
   end
 
-  defp try_generate_embedding(query_string) do
+  defp try_generate_embedding(tenant_id, query_string) do
     ensure_circuit_breaker_table()
 
     if circuit_open?() do
@@ -5856,7 +5860,7 @@ defmodule Loopctl.Knowledge do
       task =
         Task.async(fn ->
           try do
-            embedding_client().generate_embedding(query_string)
+            embedding_client().generate_embedding(tenant_id, query_string)
           rescue
             e -> {:error, {:embedding_crash, Exception.message(e)}}
           end
@@ -5866,6 +5870,11 @@ defmodule Loopctl.Knowledge do
         {:ok, {:ok, embedding}} ->
           record_success()
           {:ok, embedding}
+
+        # A missing tenant key is a config gap, not a provider failure — do NOT
+        # record it against the shared circuit breaker.
+        {:ok, {:error, :no_api_key}} ->
+          {:error, :no_api_key}
 
         {:ok, {:error, reason}} ->
           record_failure()

--- a/lib/loopctl/knowledge/embedding_behaviour.ex
+++ b/lib/loopctl/knowledge/embedding_behaviour.ex
@@ -3,8 +3,10 @@ defmodule Loopctl.Knowledge.EmbeddingBehaviour do
   Behaviour for embedding generation clients.
 
   Implementations convert text into vector embeddings for semantic search.
-  The default implementation (`Loopctl.Knowledge.EmbeddingClient`) calls
-  the OpenAI embeddings API via Req.
+  The default implementation (`Loopctl.Knowledge.EmbeddingClient`) resolves the
+  TENANT's OWN OpenAI embedding key + model (mandatory BYO — no operator-funded
+  fallback) and calls the OpenAI-compatible embeddings API via Req, recording an
+  `:embedding` usage event on success.
 
   ## Config-based DI
 
@@ -21,5 +23,6 @@ defmodule Loopctl.Knowledge.EmbeddingBehaviour do
       config :loopctl, :embedding_client, Loopctl.MockEmbeddingClient
   """
 
-  @callback generate_embedding(text :: String.t()) :: {:ok, [float()]} | {:error, term()}
+  @callback generate_embedding(tenant_id :: Ecto.UUID.t(), text :: String.t()) ::
+              {:ok, [float()]} | {:error, :no_api_key} | {:error, term()}
 end

--- a/lib/loopctl/knowledge/embedding_client.ex
+++ b/lib/loopctl/knowledge/embedding_client.ex
@@ -1,44 +1,138 @@
 defmodule Loopctl.Knowledge.EmbeddingClient do
   @moduledoc """
-  Default embedding client that calls the OpenAI-compatible embeddings API via Req.
+  Default embedding client that calls the OpenAI-compatible embeddings API via Req,
+  using the TENANT's OWN embedding key (mandatory BYO — #294 extended to embeddings).
+
+  ## Mandatory BYO
+
+  `generate_embedding/2` resolves the tenant's embedding key + model via
+  `Loopctl.Llm.resolve(tenant_id, :embedding)`. There is NO global/operator key
+  fallback: a tenant with no configured embedding key gets `{:error, :no_api_key}`
+  and NO provider call is made (so a low-privilege agent key can never run up the
+  operator's OpenAI bill). On a successful 200 an `:embedding` usage event is
+  recorded (best-effort — a usage-recording blip never fails an already-billed
+  call).
 
   ## Configuration
 
-  Set the following in your runtime config:
+  The provider endpoint (base_url) + default model come from runtime config; the
+  KEY is per-tenant and NEVER read from global config:
 
       config :loopctl, :embedding_provider, %{
         base_url: "https://api.openai.com/v1",
-        api_key: "sk-...",
         model: "text-embedding-3-small"
       }
 
-  All keys are optional and fall back to sensible defaults.
+  HTTP is injectable for tests via the `:embedding_req_plug` config (a `Req.Test`
+  plug), so the whole flow — including usage recording — is exercised without real
+  API calls. The api_key is NEVER logged.
   """
 
   @behaviour Loopctl.Knowledge.EmbeddingBehaviour
 
-  @impl true
-  def generate_embedding(text) do
-    config = Application.get_env(:loopctl, :embedding_provider, %{})
-    base_url = config[:base_url] || "https://api.openai.com/v1"
-    api_key = config[:api_key] || ""
-    model = config[:model] || "text-embedding-3-small"
+  require Logger
 
-    case Req.post("#{base_url}/embeddings",
-           json: %{input: text, model: model},
-           headers: [{"authorization", "Bearer #{api_key}"}],
-           retry: :transient,
-           max_retries: 2,
-           receive_timeout: 30_000
-         ) do
-      {:ok, %{status: 200, body: %{"data" => [%{"embedding" => embedding} | _]}}} ->
+  alias Loopctl.Llm
+
+  @default_base_url "https://api.openai.com/v1"
+
+  @impl true
+  def generate_embedding(tenant_id, text) when is_binary(tenant_id) do
+    case Llm.resolve(tenant_id, :embedding) do
+      {:error, :no_api_key} ->
+        # Mandatory BYO: no tenant key => no provider call, no operator spend.
+        {:error, :no_api_key}
+
+      {:ok, %{api_key: api_key, model: model}} ->
+        post(tenant_id, api_key, model, text)
+    end
+  end
+
+  defp post(tenant_id, api_key, model, text) do
+    base_url = provider_config()[:base_url] || @default_base_url
+
+    opts =
+      [
+        json: %{input: text, model: model},
+        # NOTE: never log `opts` / `api_key` — the key is a tenant secret.
+        headers: [{"authorization", "Bearer #{api_key}"}],
+        retry: :transient,
+        max_retries: 2,
+        receive_timeout: 30_000
+      ]
+      |> maybe_put_plug()
+
+    case Req.post("#{base_url}/embeddings", opts) do
+      {:ok, %{status: 200, body: %{"data" => [%{"embedding" => embedding} | _]} = resp}} ->
+        record_usage_safe(tenant_id, model, resp["usage"])
         {:ok, embedding}
 
       {:ok, %{status: status, body: body}} ->
+        Logger.warning("Loopctl.Knowledge.EmbeddingClient: API error (status=#{status})")
         {:error, {:api_error, status, body}}
 
       {:error, reason} ->
+        Logger.warning(
+          "Loopctl.Knowledge.EmbeddingClient: request failed (error=#{inspect(reason)})"
+        )
+
         {:error, reason}
+    end
+  end
+
+  # BEST-EFFORT usage recording: the embedding call has already SUCCEEDED (and been
+  # billed to the tenant) by the time we get here, so a DB blip / FK race while
+  # inserting the usage row must NEVER raise — that would crash the worker, trigger
+  # an Oban retry, and RE-BILL the tenant. Log-and-continue, always {:ok, embedding}.
+  defp record_usage_safe(tenant_id, model, usage) do
+    record_usage(tenant_id, model, usage)
+  rescue
+    e ->
+      Logger.error(
+        "Loopctl.Knowledge.EmbeddingClient: usage recording raised; the embedding call " <>
+          "already succeeded, continuing: #{Exception.message(e)}"
+      )
+
+      :ok
+  end
+
+  # OpenAI embeddings report `usage.prompt_tokens` (== total_tokens for embeddings).
+  # There is no completion, so output_tokens is 0.
+  defp record_usage(tenant_id, model, %{} = usage) do
+    input = Map.get(usage, "prompt_tokens") || Map.get(usage, "total_tokens") || 0
+
+    case Llm.record_usage(tenant_id, %{
+           operation: :embedding,
+           model: model,
+           input_tokens: normalize_token(input),
+           output_tokens: 0
+         }) do
+      {:ok, _event} ->
+        :ok
+
+      {:error, changeset} ->
+        Logger.error(
+          "Loopctl.Knowledge.EmbeddingClient: usage record rejected: #{inspect(changeset.errors)}"
+        )
+
+        :ok
+    end
+  end
+
+  defp record_usage(_tenant_id, _model, _usage) do
+    Logger.warning("Loopctl.Knowledge.EmbeddingClient: response had no usage block")
+    :ok
+  end
+
+  defp normalize_token(n) when is_integer(n) and n >= 0, do: n
+  defp normalize_token(_), do: 0
+
+  defp provider_config, do: Application.get_env(:loopctl, :embedding_provider, %{})
+
+  defp maybe_put_plug(opts) do
+    case Application.get_env(:loopctl, :embedding_req_plug) do
+      nil -> opts
+      plug -> Keyword.put(opts, :plug, plug)
     end
   end
 end

--- a/lib/loopctl/knowledge/proposal_gate.ex
+++ b/lib/loopctl/knowledge/proposal_gate.ex
@@ -49,7 +49,7 @@ defmodule Loopctl.Knowledge.ProposalGate do
     dup = config(:knowledge_proposal_duplicate_threshold, @default_duplicate_threshold)
     overlap = config(:knowledge_proposal_overlap_threshold, @default_overlap_threshold)
 
-    case @embedding_client.generate_embedding(build_text(attrs)) do
+    case @embedding_client.generate_embedding(tenant_id, build_text(attrs)) do
       {:ok, vector} when is_list(vector) and vector != [] ->
         neighbors =
           VectorSearch.nearest(tenant_id, vector, @neighbors_k,

--- a/lib/loopctl/llm.ex
+++ b/lib/loopctl/llm.ex
@@ -1,14 +1,25 @@
 defmodule Loopctl.Llm do
   @moduledoc """
-  Per-tenant BYO Anthropic LLM configuration + usage tracking (Epic 28 residual, #179).
+  Per-tenant BYO LLM + embedding configuration + usage tracking (Epic 28 residual,
+  #179; embeddings closes the operator-funded embedding-spend gap).
 
-  loopctl is multi-tenant and **BYO-key**: every tenant supplies its OWN Anthropic
-  API key and pays Anthropic directly. loopctl fronts no LLM cost — there is no
-  markup, price table, or billing. A tenant with no configured key CANNOT run
-  tenant knowledge-LLM work (ingest/classify/merge): `resolve/2` returns
+  loopctl is multi-tenant and **BYO-key**: every tenant supplies its OWN keys and
+  pays the provider directly. loopctl fronts no cost — there is no markup, price
+  table, or billing. Two SEPARATE keys are configured per tenant:
+
+    * an **Anthropic** key for knowledge LLM work (ingest/classify/merge), and
+    * an **OpenAI-compatible embedding** key for article vector embeddings +
+      semantic search.
+
+  A tenant with no Anthropic key CANNOT run tenant knowledge-LLM work:
+  `resolve(tenant_id, :extraction | :classification | :merge)` returns
   `{:error, :no_api_key}` and callers fail cleanly (a 422 at the API boundary; the
-  Oban worker `{:discard}`s). There is intentionally NO global-system-key fallback
-  for tenant LLM work.
+  Oban worker `{:discard}`s). A tenant with no embedding key gets NO embeddings:
+  `resolve(tenant_id, :embedding)` returns `{:error, :no_api_key}`, the embedding
+  client refuses to call the provider, and `ArticleEmbeddingWorker` cleanly
+  `{:discard}`s `{:no_embedding_key, _}` (the article is still created — it is just
+  not vector-searchable until a key is set). There is intentionally NO
+  global-system-key fallback for either path.
 
   ## Repo strategy
 
@@ -43,15 +54,21 @@ defmodule Loopctl.Llm do
 
   # Server default model per operation when the tenant left that field nil. A key
   # is still MANDATORY — the default only fills the model, never the key. Haiku is
-  # the cheap sensible default; a tenant overrides per-operation as they wish.
+  # the cheap sensible default; a tenant overrides per-operation as they wish. The
+  # embedding default is OpenAI's cheap small embedding model.
   @default_model "claude-haiku-4-5-20251001"
+  @default_embedding_model "text-embedding-3-small"
   @default_models %{
     extraction: @default_model,
     classification: @default_model,
-    merge: @default_model
+    merge: @default_model,
+    embedding: @default_embedding_model
   }
 
-  @type operation :: :extraction | :classification | :merge
+  # Operations backed by the Anthropic `api_key`.
+  @llm_operations [:extraction, :classification, :merge]
+
+  @type operation :: :extraction | :classification | :merge | :embedding
   @type resolved :: %{api_key: String.t(), model: String.t()}
 
   # --- Settings ---
@@ -70,12 +87,13 @@ defmodule Loopctl.Llm do
   @doc """
   Upserts the tenant's LLM settings (one row per tenant).
 
-  `attrs` may carry any of `api_key`, `extraction_model`, `classification_model`,
-  `merge_model` (string or atom keys). `tenant_id` is set programmatically. The
-  api_key (when present) is stored encrypted and NEVER cast from params. When an
-  api_key is set/rotated, an `llm_config.key_set` audit event is written WITHOUT
-  the value; every upsert writes an `llm_config.updated` event listing which
-  model fields changed.
+  `attrs` may carry any of `api_key`, `embedding_api_key`, `extraction_model`,
+  `classification_model`, `merge_model`, `embedding_model` (string or atom keys).
+  `tenant_id` is set programmatically. Both secret keys (when present) are stored
+  encrypted and NEVER cast from params. When a key is set/rotated, an
+  `llm_config.key_set` / `llm_config.embedding_key_set` audit event is written
+  WITHOUT the value; every upsert writes an `llm_config.updated` event listing
+  which model fields changed.
 
   Returns `{:ok, settings}` or `{:error, changeset}`.
   """
@@ -84,20 +102,23 @@ defmodule Loopctl.Llm do
   def upsert_settings(tenant_id, attrs) when is_binary(tenant_id) and is_map(attrs) do
     attrs = normalize_keys(attrs)
     api_key = Map.get(attrs, :api_key)
+    embedding_api_key = Map.get(attrs, :embedding_api_key)
     existing = get_settings(tenant_id)
 
     changeset =
       (existing || %TenantLlmSettings{tenant_id: tenant_id})
       |> TenantLlmSettings.models_changeset(attrs)
       |> TenantLlmSettings.put_api_key(api_key)
+      |> TenantLlmSettings.put_embedding_api_key(embedding_api_key)
       |> Ecto.Changeset.put_change(:tenant_id, tenant_id)
 
     key_set? = not is_nil(api_key)
+    embedding_key_set? = not is_nil(embedding_api_key)
 
     Multi.new()
     |> Multi.insert_or_update(:settings, changeset)
     |> Multi.merge(fn %{settings: settings} ->
-      audit_multi(tenant_id, settings, changeset, key_set?)
+      audit_multi(tenant_id, settings, changeset, key_set?, embedding_key_set?)
     end)
     |> AdminRepo.transaction()
     |> case do
@@ -107,16 +128,28 @@ defmodule Loopctl.Llm do
   end
 
   @doc """
-  Resolves the tenant's API key + per-operation model for an LLM call.
+  Resolves the tenant's API key + per-operation model for a provider call.
 
-  Returns `{:ok, %{api_key: decrypted, model: model}}` or `{:error, :no_api_key}`
-  when the tenant has no key configured (mandatory BYO — no fallback). When the
-  tenant left the per-operation model nil, the server default for that operation
-  is used.
+  For the Anthropic operations (`:extraction`, `:classification`, `:merge`) this
+  resolves the `api_key`; for `:embedding` it resolves the SEPARATE
+  `embedding_api_key`. Returns `{:ok, %{api_key: decrypted, model: model}}` or
+  `{:error, :no_api_key}` when the tenant has no key configured for that path
+  (mandatory BYO — no fallback). When the tenant left the per-operation model nil,
+  the server default for that operation is used.
   """
   @spec resolve(Ecto.UUID.t(), operation()) :: {:ok, resolved()} | {:error, :no_api_key}
+  def resolve(tenant_id, :embedding) when is_binary(tenant_id) do
+    case get_settings(tenant_id) do
+      %TenantLlmSettings{embedding_api_key: key} = settings when is_binary(key) and key != "" ->
+        {:ok, %{api_key: key, model: model_for(settings, :embedding)}}
+
+      _ ->
+        {:error, :no_api_key}
+    end
+  end
+
   def resolve(tenant_id, operation)
-      when is_binary(tenant_id) and operation in [:extraction, :classification, :merge] do
+      when is_binary(tenant_id) and operation in @llm_operations do
     case get_settings(tenant_id) do
       %TenantLlmSettings{api_key: key} = settings when is_binary(key) and key != "" ->
         {:ok, %{api_key: key, model: model_for(settings, operation)}}
@@ -134,6 +167,16 @@ defmodule Loopctl.Llm do
   @spec has_api_key?(Ecto.UUID.t()) :: boolean()
   def has_api_key?(tenant_id) when is_binary(tenant_id) do
     match?({:ok, _}, resolve(tenant_id, :extraction))
+  end
+
+  @doc """
+  Whether the tenant has a usable embedding API key configured. Used by
+  `ArticleEmbeddingWorker` (discard) to enforce mandatory BYO for embeddings
+  WITHOUT holding the plaintext key.
+  """
+  @spec has_embedding_key?(Ecto.UUID.t()) :: boolean()
+  def has_embedding_key?(tenant_id) when is_binary(tenant_id) do
+    match?({:ok, _}, resolve(tenant_id, :embedding))
   end
 
   @doc """
@@ -174,7 +217,7 @@ defmodule Loopctl.Llm do
 
   @doc """
   A safe view of the tenant's settings for API responses: the model choices,
-  `has_api_key`, and a `api_key_hint` (last 4 chars) — NEVER the key itself.
+  `has_api_key` / `has_embedding_key`, and last-4 hints — NEVER a key itself.
   """
   @spec settings_view(TenantLlmSettings.t() | nil) :: map()
   def settings_view(nil) do
@@ -183,7 +226,10 @@ defmodule Loopctl.Llm do
       api_key_hint: nil,
       extraction_model: nil,
       classification_model: nil,
-      merge_model: nil
+      merge_model: nil,
+      has_embedding_key: false,
+      embedding_api_key_hint: nil,
+      embedding_model: nil
     }
   end
 
@@ -193,7 +239,10 @@ defmodule Loopctl.Llm do
       api_key_hint: api_key_hint(s.api_key),
       extraction_model: s.extraction_model,
       classification_model: s.classification_model,
-      merge_model: s.merge_model
+      merge_model: s.merge_model,
+      has_embedding_key: has_key?(s.embedding_api_key),
+      embedding_api_key_hint: api_key_hint(s.embedding_api_key),
+      embedding_model: s.embedding_model
     }
   end
 
@@ -349,6 +398,9 @@ defmodule Loopctl.Llm do
   defp model_for(%TenantLlmSettings{} = s, :merge),
     do: s.merge_model || default_model(:merge)
 
+  defp model_for(%TenantLlmSettings{} = s, :embedding),
+    do: s.embedding_model || default_model(:embedding)
+
   defp default_model(operation), do: Map.fetch!(@default_models, operation)
 
   defp has_key?(key), do: is_binary(key) and key != ""
@@ -361,9 +413,9 @@ defmodule Loopctl.Llm do
 
   # Accept both atom- and string-keyed attrs; whitelist to the known keys so an
   # attacker can't smuggle e.g. tenant_id in.
-  @known_attr_keys ~w(api_key extraction_model classification_model merge_model
-                      operation model input_tokens output_tokens source_type
-                      article_id occurred_at)a
+  @known_attr_keys ~w(api_key embedding_api_key extraction_model classification_model
+                      merge_model embedding_model operation model input_tokens
+                      output_tokens source_type article_id occurred_at)a
   defp normalize_keys(attrs) do
     Enum.reduce(@known_attr_keys, %{}, fn key, acc ->
       case fetch_attr(attrs, key) do
@@ -386,45 +438,62 @@ defmodule Loopctl.Llm do
   defp max_zero(n) when is_integer(n) and n > 0, do: n
   defp max_zero(_), do: 0
 
-  # Audit the config change WITHOUT the key value. Always record `llm_config.updated`
-  # with the changed model fields; additionally record `llm_config.key_set` when the
-  # api_key was set/rotated (value never included).
-  defp audit_multi(tenant_id, settings, changeset, key_set?) do
+  # Audit the config change WITHOUT any key value. Always record `llm_config.updated`
+  # with the changed model fields; additionally record `llm_config.key_set` /
+  # `llm_config.embedding_key_set` when the respective key was set/rotated (value
+  # never included — only its last-4 hint).
+  defp audit_multi(tenant_id, settings, changeset, key_set?, embedding_key_set?) do
     changed_models =
       changeset.changes
-      |> Map.take([:extraction_model, :classification_model, :merge_model])
+      |> Map.take([:extraction_model, :classification_model, :merge_model, :embedding_model])
       |> Map.new(fn {k, v} -> {Atom.to_string(k), v} end)
 
-    multi =
-      Audit.log_in_multi(Multi.new(), :audit_updated, fn _ ->
-        %{
-          tenant_id: tenant_id,
-          entity_type: "llm_config",
-          entity_id: settings.id,
-          action: "llm_config.updated",
-          actor_type: "system",
-          actor_id: nil,
-          actor_label: "llm_config",
-          new_state: %{"changed_models" => changed_models, "api_key_set" => key_set?}
+    Multi.new()
+    |> Audit.log_in_multi(:audit_updated, fn _ ->
+      %{
+        tenant_id: tenant_id,
+        entity_type: "llm_config",
+        entity_id: settings.id,
+        action: "llm_config.updated",
+        actor_type: "system",
+        actor_id: nil,
+        actor_label: "llm_config",
+        new_state: %{
+          "changed_models" => changed_models,
+          "api_key_set" => key_set?,
+          "embedding_api_key_set" => embedding_key_set?
         }
-      end)
+      }
+    end)
+    |> maybe_audit_key_set(tenant_id, settings, key_set?, :api_key)
+    |> maybe_audit_key_set(tenant_id, settings, embedding_key_set?, :embedding_api_key)
+  end
 
-    if key_set? do
-      Audit.log_in_multi(multi, :audit_key_set, fn _ ->
-        %{
-          tenant_id: tenant_id,
-          entity_type: "llm_config",
-          entity_id: settings.id,
-          action: "llm_config.key_set",
-          actor_type: "system",
-          actor_id: nil,
-          actor_label: "llm_config",
-          # NEVER the key value — only that a key was set + its last-4 hint.
-          new_state: %{"api_key_hint" => api_key_hint(settings.api_key)}
-        }
-      end)
-    else
-      multi
-    end
+  defp maybe_audit_key_set(multi, _tenant_id, _settings, false, _field), do: multi
+
+  defp maybe_audit_key_set(multi, tenant_id, settings, true, field) do
+    {step, action, hint_key, value} =
+      case field do
+        :api_key ->
+          {:audit_key_set, "llm_config.key_set", "api_key_hint", settings.api_key}
+
+        :embedding_api_key ->
+          {:audit_embedding_key_set, "llm_config.embedding_key_set", "embedding_api_key_hint",
+           settings.embedding_api_key}
+      end
+
+    Audit.log_in_multi(multi, step, fn _ ->
+      %{
+        tenant_id: tenant_id,
+        entity_type: "llm_config",
+        entity_id: settings.id,
+        action: action,
+        actor_type: "system",
+        actor_id: nil,
+        actor_label: "llm_config",
+        # NEVER the key value — only that a key was set + its last-4 hint.
+        new_state: %{hint_key => api_key_hint(value)}
+      }
+    end)
   end
 end

--- a/lib/loopctl/llm/tenant_llm_settings.ex
+++ b/lib/loopctl/llm/tenant_llm_settings.ex
@@ -1,23 +1,30 @@
 defmodule Loopctl.Llm.TenantLlmSettings do
   @moduledoc """
-  Schema for the `tenant_llm_settings` table — a tenant's BYO Anthropic
-  configuration (Epic 28 residual, #179).
+  Schema for the `tenant_llm_settings` table — a tenant's BYO Anthropic + embedding
+  configuration (Epic 28 residual, #179; embeddings closes the operator-funded
+  embedding-spend gap).
 
-  Each tenant has at most ONE row (unique `tenant_id`). It holds the tenant's own
-  Anthropic API key, encrypted at rest via Cloak (`Loopctl.Vault.Binary`,
-  AES-256-GCM) and `redact: true` so it never appears in `inspect/1` or log output.
-  The three per-operation model fields let a tenant pick a different model for
-  extraction, classification, and merge; each is a free-form, plausible model id
-  (NOT restricted to an allow-list) or NULL to fall back to the server default.
+  Each tenant has at most ONE row (unique `tenant_id`). It holds two SEPARATE,
+  encrypted secrets:
+
+    * `api_key`           — the tenant's own **Anthropic** key (knowledge LLM work).
+    * `embedding_api_key` — the tenant's own **OpenAI-compatible embedding** key
+      (article vector embeddings + semantic search).
+
+  Both are encrypted at rest via Cloak (`Loopctl.Vault.Binary`, AES-256-GCM) and
+  `redact: true` so neither ever appears in `inspect/1` or log output. The
+  per-operation model fields (`extraction_model` / `classification_model` /
+  `merge_model` for Anthropic; `embedding_model` for embeddings) let a tenant pick
+  a different model per operation; each is a free-form, plausible model id (NOT
+  restricted to an allow-list) or NULL to fall back to the server default.
 
   ## Security invariants
 
-  - `api_key` is NEVER placed in a `cast/3` list — it is set programmatically via
-    `put_change/3` so a stray param can't overwrite it and it never lands in the
-    changeset's `params` echoed by error rendering.
-  - `api_key` is `redact: true` — `inspect(%TenantLlmSettings{})` shows
-    `**redacted**`.
-  - No serializer ever returns the key (only `has_api_key?` + a last-4 hint).
+  - `api_key` / `embedding_api_key` are NEVER placed in a `cast/3` list — they are
+    set programmatically via `put_change/3` so a stray param can't overwrite them
+    and they never land in the changeset's `params` echoed by error rendering.
+  - Both are `redact: true` — `inspect(%TenantLlmSettings{})` shows `**redacted**`.
+  - No serializer ever returns a key (only `has_*_key` + a last-4 hint).
   """
 
   use Loopctl.Schema
@@ -39,10 +46,15 @@ defmodule Loopctl.Llm.TenantLlmSettings do
     field :classification_model, :string
     field :merge_model, :string
 
+    # BYO embeddings: the tenant's OWN OpenAI-compatible key + model, SEPARATE from
+    # the Anthropic key above.
+    field :embedding_api_key, Loopctl.Vault.Binary, redact: true
+    field :embedding_model, :string
+
     timestamps()
   end
 
-  @model_fields [:extraction_model, :classification_model, :merge_model]
+  @model_fields [:extraction_model, :classification_model, :merge_model, :embedding_model]
 
   @doc """
   Changeset for the per-operation model fields ONLY.
@@ -63,30 +75,43 @@ defmodule Loopctl.Llm.TenantLlmSettings do
   end
 
   @doc """
-  Sets the encrypted `api_key` on a changeset via `put_change/3` (never `cast`),
-  validating it's a non-empty, bounded string. A `nil`/absent value leaves the
-  existing key untouched; a blank string is rejected.
+  Sets the encrypted Anthropic `api_key` on a changeset via `put_change/3` (never
+  `cast`), validating it's a non-empty, bounded string. A `nil`/absent value leaves
+  the existing key untouched; a blank string is rejected.
   """
   @spec put_api_key(Ecto.Changeset.t(), String.t() | nil) :: Ecto.Changeset.t()
-  def put_api_key(changeset, nil), do: changeset
+  def put_api_key(changeset, value), do: put_secret_key(changeset, :api_key, value)
 
-  def put_api_key(changeset, api_key) when is_binary(api_key) do
-    trimmed = String.trim(api_key)
+  @doc """
+  Sets the encrypted `embedding_api_key` (the tenant's OpenAI embedding key) on a
+  changeset via `put_change/3` (never `cast`) — same non-empty/bounded validation
+  and never-cast handling as `put_api_key/2`.
+  """
+  @spec put_embedding_api_key(Ecto.Changeset.t(), String.t() | nil) :: Ecto.Changeset.t()
+  def put_embedding_api_key(changeset, value),
+    do: put_secret_key(changeset, :embedding_api_key, value)
+
+  # Shared validator for the two encrypted secret fields: never cast, set via
+  # put_change/3, reject blank/oversized, leave untouched on nil.
+  defp put_secret_key(changeset, _field, nil), do: changeset
+
+  defp put_secret_key(changeset, field, value) when is_binary(value) do
+    trimmed = String.trim(value)
 
     cond do
       trimmed == "" ->
-        add_error(changeset, :api_key, "must not be blank")
+        add_error(changeset, field, "must not be blank")
 
       String.length(trimmed) > @max_api_key_length ->
-        add_error(changeset, :api_key, "is too long (max #{@max_api_key_length} characters)")
+        add_error(changeset, field, "is too long (max #{@max_api_key_length} characters)")
 
       true ->
-        put_change(changeset, :api_key, trimmed)
+        put_change(changeset, field, trimmed)
     end
   end
 
-  def put_api_key(changeset, _other),
-    do: add_error(changeset, :api_key, "must be a string")
+  defp put_secret_key(changeset, field, _other),
+    do: add_error(changeset, field, "must be a string")
 
   # Keep ONLY the model fields (string- or atom-keyed) so the api_key can never
   # reach `cast/3`/`changeset.params` (review #15).

--- a/lib/loopctl/llm/usage_event.ex
+++ b/lib/loopctl/llm/usage_event.ex
@@ -3,16 +3,18 @@ defmodule Loopctl.Llm.UsageEvent do
   Schema for the `llm_usage_events` table — one immutable row per successful
   tenant LLM operation (Epic 28 residual, #179).
 
-  Records the operation, the model used, and the Anthropic-reported token counts.
-  This is a RECORD-ONLY ledger backing the per-tenant usage-summary API; there is
-  NO budget enforcement anywhere in the system.
+  Records the operation, the model used, and the provider-reported token counts
+  (Anthropic `input_tokens`/`output_tokens` for LLM ops; OpenAI
+  `prompt_tokens`/`total_tokens` as `input_tokens` with `output_tokens: 0` for
+  `:embedding`). This is a RECORD-ONLY ledger backing the per-tenant usage-summary
+  API; there is NO budget enforcement anywhere in the system.
   """
 
   use Loopctl.Schema
 
   @type t :: %__MODULE__{}
 
-  @operations [:extraction, :classification, :merge]
+  @operations [:extraction, :classification, :merge, :embedding]
 
   schema "llm_usage_events" do
     tenant_field()
@@ -26,7 +28,7 @@ defmodule Loopctl.Llm.UsageEvent do
     field :occurred_at, :utc_datetime_usec
   end
 
-  @doc "The valid operation atoms (extraction | classification | merge)."
+  @doc "The valid operation atoms (extraction | classification | merge | embedding)."
   @spec operations() :: [atom()]
   def operations, do: @operations
 

--- a/lib/loopctl/workers/article_embedding_worker.ex
+++ b/lib/loopctl/workers/article_embedding_worker.ex
@@ -12,9 +12,13 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
   1. Fetch the article by `article_id` + `tenant_id`
   2. If article was deleted, return `:ok` (no-op)
   3. Build embedding text: `"{title}\\n\\n{body}"` truncated to 32K chars
-  4. Call `@embedding_client.generate_embedding/1`
+  4. Call `@embedding_client.generate_embedding/2` (threads `tenant_id`)
   5. On success, store via `Knowledge.update_embedding/3`
-  6. On failure, return `{:error, reason}` for Oban retry
+  6. On `{:error, :no_api_key}` (mandatory BYO — the tenant has no embedding key),
+     `{:discard, {:no_embedding_key, article_id}}` — a CLEAN skip: no crash, no
+     retry, no operator-key fallback. The article stays created; it is simply not
+     vector-searchable until the tenant configures a key.
+  7. On any other failure, return `{:error, reason}` for Oban retry
 
   ## Retry Strategy
 
@@ -73,11 +77,37 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
   defp generate_and_store(article, tenant_id, article_id) do
     text = build_embedding_text(article)
 
-    with {:ok, embedding} <- @embedding_client.generate_embedding(text),
-         {:ok, _article} <- Knowledge.update_embedding(tenant_id, article_id, embedding) do
-      enqueue_linking(article_id, tenant_id)
-      :ok
+    case @embedding_client.generate_embedding(tenant_id, text) do
+      {:ok, embedding} ->
+        with {:ok, _article} <- Knowledge.update_embedding(tenant_id, article_id, embedding) do
+          enqueue_linking(article_id, tenant_id)
+          :ok
+        end
+
+      {:error, :no_api_key} ->
+        skip_no_embedding_key(tenant_id, article_id)
+
+      {:error, reason} ->
+        {:error, reason}
     end
+  end
+
+  # Mandatory BYO: the tenant has no embedding key. Cleanly DISCARD (no retry, no
+  # crash, no operator-key fallback) with a distinct, queryable reason + a
+  # telemetry signal so the keyless-tenant volume is observable.
+  defp skip_no_embedding_key(tenant_id, article_id) do
+    :telemetry.execute(
+      [:loopctl, :embedding, :skipped_no_key],
+      %{count: 1},
+      %{tenant_id: tenant_id, article_id: article_id}
+    )
+
+    Logger.debug(
+      "ArticleEmbeddingWorker: tenant=#{tenant_id} article=#{article_id} skipped — no " <>
+        "embedding API key configured (mandatory BYO)."
+    )
+
+    {:discard, {:no_embedding_key, article_id}}
   end
 
   defp enqueue_linking(article_id, tenant_id) do

--- a/lib/loopctl_web/controllers/knowledge_search_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_search_controller.ex
@@ -594,7 +594,7 @@ defmodule LoopctlWeb.KnowledgeSearchController do
   end
 
   defp execute_search(tenant_id, {:search, q}, "semantic", opts) do
-    case Knowledge.generate_embedding(q) do
+    case Knowledge.generate_embedding(tenant_id, q) do
       {:ok, embedding} -> Knowledge.search_semantic(tenant_id, embedding, opts)
       {:error, _} -> {:error, :embedding_unavailable}
     end

--- a/lib/loopctl_web/controllers/llm_config_controller.ex
+++ b/lib/loopctl_web/controllers/llm_config_controller.ex
@@ -1,13 +1,14 @@
 defmodule LoopctlWeb.LlmConfigController do
   @moduledoc """
-  Per-tenant BYO Anthropic LLM configuration (Epic 28 residual, #179).
+  Per-tenant BYO Anthropic LLM + embedding configuration (Epic 28 residual, #179).
 
   - `GET   /api/v1/tenants/me/llm-config` — the tenant's model choices +
-    `has_api_key` + a masked last-4 hint. NEVER returns the key itself.
-  - `PATCH /api/v1/tenants/me/llm-config` — set/rotate the api_key and the three
-    per-operation models (partial-merge; omitted fields are left untouched).
+    `has_api_key` / `has_embedding_key` + masked last-4 hints. NEVER returns a key.
+  - `PATCH /api/v1/tenants/me/llm-config` — set/rotate the Anthropic `api_key`, the
+    OpenAI `embedding_api_key`, and the per-operation models (partial-merge;
+    omitted fields are left untouched).
 
-  Both endpoints require the `:user` role — this endpoint stores a tenant secret,
+  Both endpoints require the `:user` role — this endpoint stores tenant secrets,
   so per the security checklist (managing secrets ⇒ `:user`) neither agents nor
   orchestrators may read or write it.
   """
@@ -28,9 +29,10 @@ defmodule LoopctlWeb.LlmConfigController do
   operation(:show,
     summary: "Get the tenant's LLM configuration",
     description:
-      "Returns the per-operation model choices, whether an Anthropic API key is " <>
-        "configured (`has_api_key`), and a masked last-4 hint. The key itself is " <>
-        "never returned. Role: user+.",
+      "Returns the per-operation model choices, whether an Anthropic API key " <>
+        "(`has_api_key`) and an embedding API key (`has_embedding_key`) are " <>
+        "configured, plus masked last-4 hints. No key itself is ever returned. " <>
+        "Role: user+.",
     responses: %{
       200 => {"LLM config", "application/json", Schemas.LlmConfigResponse},
       401 => {"Unauthorized", "application/json", Schemas.ErrorResponse},
@@ -42,9 +44,9 @@ defmodule LoopctlWeb.LlmConfigController do
   operation(:update,
     summary: "Set the tenant's LLM configuration",
     description:
-      "Sets/rotates the tenant's OWN Anthropic API key (stored encrypted, never " <>
-        "returned) and the three per-operation models. loopctl fronts no LLM cost " <>
-        "— the tenant's key bills the tenant. Role: user+.",
+      "Sets/rotates the tenant's OWN Anthropic API key + OpenAI embedding key " <>
+        "(both stored encrypted, never returned) and the per-operation models. " <>
+        "loopctl fronts no cost — the tenant's keys bill the tenant. Role: user+.",
     request_body: {"LLM config", "application/json", Schemas.LlmConfigUpdateRequest},
     responses: %{
       200 => {"Updated LLM config", "application/json", Schemas.LlmConfigResponse},
@@ -73,6 +75,13 @@ defmodule LoopctlWeb.LlmConfigController do
 
   # Whitelist the accepted keys so nothing else (e.g. tenant_id) can slip in.
   defp config_params(params) do
-    Map.take(params, ["api_key", "extraction_model", "classification_model", "merge_model"])
+    Map.take(params, [
+      "api_key",
+      "extraction_model",
+      "classification_model",
+      "merge_model",
+      "embedding_api_key",
+      "embedding_model"
+    ])
   end
 end

--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to `loopctl-mcp-server` are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 2.32.0 — 2026-07-03 (per-tenant BYO for embeddings — Epic 28 #179)
+
+### Added
+
+- **`set_llm_config`** now accepts `embedding_api_key` (the tenant's OWN
+  OpenAI-compatible embedding key, stored encrypted, never returned) and
+  `embedding_model` (free-form; null → server default `text-embedding-3-small`).
+  Mandatory BYO: without an `embedding_api_key` the tenant's articles are created
+  but are NOT vector-searchable until a key is configured — this closes the
+  previously ungated, operator-funded embedding-spend path.
+- **`llm_config`** response now also reports `has_embedding_key` +
+  `embedding_api_key_hint` (masked last-4) + `embedding_model`. No key is ever
+  returned.
+
 ## 2.31.1 — 2026-07-03 (usage-window doc clarity + distant_pairs latency — Epic 28 #179 review, loopctl #202/#203)
 
 ### Changed

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -1182,12 +1182,21 @@ async function llmConfig() {
   return toContent(result);
 }
 
-async function setLlmConfig({ api_key, extraction_model, classification_model, merge_model }) {
+async function setLlmConfig({
+  api_key,
+  extraction_model,
+  classification_model,
+  merge_model,
+  embedding_api_key,
+  embedding_model,
+}) {
   const body = {};
   if (api_key != null) body.api_key = api_key;
   if (extraction_model !== undefined) body.extraction_model = extraction_model;
   if (classification_model !== undefined) body.classification_model = classification_model;
   if (merge_model !== undefined) body.merge_model = merge_model;
+  if (embedding_api_key != null) body.embedding_api_key = embedding_api_key;
+  if (embedding_model !== undefined) body.embedding_model = embedding_model;
   // PATCH (partial-merge) + EXACT user key (review #12, #13).
   const result = await apiCall(
     "PATCH",
@@ -3364,19 +3373,23 @@ const TOOLS = [
   {
     name: "llm_config",
     description:
-      "Get the tenant's BYO Anthropic LLM configuration: the per-operation model " +
-      "choices, whether a key is configured (has_api_key), and a masked last-4 hint. " +
-      "NEVER returns the key itself. Requires user role (LOOPCTL_USER_KEY).",
+      "Get the tenant's BYO Anthropic + embedding configuration: the per-operation " +
+      "model choices, whether each key is configured (has_api_key / has_embedding_key), " +
+      "and masked last-4 hints. NEVER returns a key itself. Requires user role " +
+      "(LOOPCTL_USER_KEY).",
     inputSchema: { type: "object", properties: {}, required: [] },
   },
   {
     name: "set_llm_config",
     description:
-      "Set/rotate the tenant's OWN Anthropic API key (stored encrypted, never returned) " +
-      "and the three per-operation models (extraction/classification/merge). loopctl " +
-      "fronts no LLM cost — the tenant's key bills the tenant. Any subset of fields may " +
-      "be sent; omitting api_key leaves the existing key untouched. Model ids are " +
-      "free-form (any model the key permits). Requires user role (LOOPCTL_USER_KEY).",
+      "Set/rotate the tenant's OWN Anthropic API key AND OpenAI embedding key (both " +
+      "stored encrypted, never returned) and the per-operation models " +
+      "(extraction/classification/merge/embedding). loopctl fronts no cost — the " +
+      "tenant's keys bill the tenant. Mandatory BYO for embeddings: without an " +
+      "embedding_api_key the tenant's articles are not vector-searchable. Any subset " +
+      "of fields may be sent; omitting a key leaves the existing key untouched. Model " +
+      "ids are free-form (any model the key permits). Requires user role " +
+      "(LOOPCTL_USER_KEY).",
     inputSchema: {
       type: "object",
       properties: {
@@ -3395,6 +3408,16 @@ const TOOLS = [
         merge_model: {
           type: "string",
           description: "Model id for article merge synthesis (null → server default).",
+        },
+        embedding_api_key: {
+          type: "string",
+          description:
+            "OpenAI-compatible embedding API key (write-only; stored encrypted, never returned).",
+        },
+        embedding_model: {
+          type: "string",
+          description:
+            "Embedding model id (null → server default text-embedding-3-small).",
         },
       },
       required: [],

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.31.1",
+  "version": "2.32.0",
   "description": "MCP server for loopctl — structural trust for AI development loops",
   "type": "module",
   "main": "index.js",

--- a/priv/repo/migrations/20260703091000_add_embedding_to_tenant_llm_settings.exs
+++ b/priv/repo/migrations/20260703091000_add_embedding_to_tenant_llm_settings.exs
@@ -1,0 +1,32 @@
+defmodule Loopctl.Repo.Migrations.AddEmbeddingToTenantLlmSettings do
+  @moduledoc """
+  Extend per-tenant BYO LLM config (#294) to EMBEDDINGS.
+
+  Adds two columns to the existing `tenant_llm_settings` table (no new table — the
+  RLS policy already on `tenant_llm_settings` covers them):
+
+    * `embedding_api_key` — the tenant's OWN OpenAI-compatible embedding key,
+      encrypted at rest via Cloak `Loopctl.Vault.Binary` (opaque `:binary`
+      ciphertext), SEPARATE from the Anthropic `api_key`.
+    * `embedding_model`   — free-form embedding model id (NULL → server default
+      `text-embedding-3-small`; see `Loopctl.Llm.resolve/2`).
+
+  Mandatory BYO: a tenant with no `embedding_api_key` gets NO embeddings — their
+  articles are created successfully but are not vector-searchable until they
+  configure a key. loopctl fronts no embedding cost: the tenant's key bills the
+  tenant directly.
+  """
+  use Ecto.Migration
+
+  def change do
+    alter table(:tenant_llm_settings) do
+      # Cloak-encrypted OpenAI embedding key (AES-256-GCM). Opaque ciphertext at rest.
+      add :embedding_api_key, :binary, null: true
+
+      # Free-form embedding model id. NULL means "use the server default"
+      # (see Loopctl.Llm.resolve/2). Validated as a plausible non-empty id,
+      # NOT restricted to an allow-list.
+      add :embedding_model, :string, null: true
+    end
+  end
+end

--- a/test/loopctl/knowledge/distant_pairs_novelty_scale_test.exs
+++ b/test/loopctl/knowledge/distant_pairs_novelty_scale_test.exs
@@ -73,7 +73,7 @@ defmodule Loopctl.Knowledge.DistantPairsNoveltyScaleTest do
     # The deterministic idea embedding the novelty test scores against (a real seeded
     # vector). Stubbed in THIS (the global-owner) process — global mode only lets the
     # owner set stubs, and the off-process Task.async_stream workers read it globally.
-    Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _text ->
+    Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
       {:ok, ScaleSeed.embedding_for(0)}
     end)
 

--- a/test/loopctl/knowledge/distant_pairs_novelty_test.exs
+++ b/test/loopctl/knowledge/distant_pairs_novelty_test.exs
@@ -162,7 +162,9 @@ defmodule Loopctl.Knowledge.DistantPairsNoveltyTest do
       # MIN ⇒ ≈ 0.1340 (this is the aggregate that must NOT degrade to top-k-then-min).
       idea_vec = embedding_at(:math.pi() / 6)
 
-      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _text -> {:ok, idea_vec} end)
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:ok, idea_vec}
+      end)
 
       assert {:ok, [scored], prior_count} =
                Knowledge.novelty_scores(tenant.id, [%{text: "an idea"}])
@@ -185,7 +187,10 @@ defmodule Loopctl.Knowledge.DistantPairsNoveltyTest do
 
       # This tenant still has exactly its own 2 priors, not the other tenant's.
       idea_vec = embedding_at(0.0)
-      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _text -> {:ok, idea_vec} end)
+
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:ok, idea_vec}
+      end)
 
       assert {:ok, [scored], prior_count} =
                Knowledge.novelty_scores(tenant.id, [%{text: "y"}])

--- a/test/loopctl/knowledge/embedding_client_test.exs
+++ b/test/loopctl/knowledge/embedding_client_test.exs
@@ -1,0 +1,108 @@
+defmodule Loopctl.Knowledge.EmbeddingClientTest do
+  @moduledoc """
+  The real tenant-scoped embedding client (mandatory BYO — #294 extended).
+
+  Everywhere else the embedding client is swapped for `Loopctl.MockEmbeddingClient`;
+  here we drive `Loopctl.Knowledge.EmbeddingClient` DIRECTLY through the
+  `:embedding_req_plug` Req.Test plug so per-tenant key resolution + usage recording
+  are exercised without any real OpenAI call.
+  """
+  use Loopctl.DataCase, async: true
+
+  import ExUnit.CaptureLog
+
+  alias Loopctl.Knowledge.EmbeddingClient
+  alias Loopctl.Llm
+
+  # Obviously-fake OpenAI-style key that does NOT use the real sk-/sk-proj- prefix
+  # (so a secret scanner never flags it).
+  defp set_embedding_key(tenant, key, model \\ "text-embedding-3-small") do
+    {:ok, _} =
+      Llm.upsert_settings(tenant.id, %{
+        "embedding_api_key" => key,
+        "embedding_model" => model
+      })
+
+    :ok
+  end
+
+  test "mandatory BYO: a keyless tenant gets {:error, :no_api_key} with NO provider call" do
+    tenant = fixture(:tenant)
+    test_pid = self()
+
+    # If the client wrongly issued an HTTP request, this stub would fire.
+    Req.Test.stub(EmbeddingClient, fn conn ->
+      send(test_pid, :unexpected_http_call)
+      Req.Test.json(conn, %{"data" => [%{"embedding" => [0.0]}]})
+    end)
+
+    assert {:error, :no_api_key} = EmbeddingClient.generate_embedding(tenant.id, "hello")
+    refute_received :unexpected_http_call
+  end
+
+  test "with a key: uses the TENANT's Bearer key, returns the vector, records :embedding usage" do
+    tenant = fixture(:tenant)
+    test_pid = self()
+    set_embedding_key(tenant, "test-openai-key-SUCCESS-777")
+
+    Req.Test.stub(EmbeddingClient, fn conn ->
+      send(test_pid, {:auth, Plug.Conn.get_req_header(conn, "authorization")})
+
+      Req.Test.json(conn, %{
+        "data" => [%{"embedding" => [0.1, 0.2, 0.3]}],
+        "usage" => %{"prompt_tokens" => 11, "total_tokens" => 11}
+      })
+    end)
+
+    assert {:ok, [0.1, 0.2, 0.3]} = EmbeddingClient.generate_embedding(tenant.id, "some text")
+
+    # The tenant's OWN key rode the Authorization header.
+    assert_received {:auth, ["Bearer test-openai-key-SUCCESS-777"]}
+
+    # An :embedding usage event was recorded in the shared ledger.
+    %{data: rows} = Llm.usage_summary(tenant.id, [])
+    embedding = Enum.find(rows, &(&1.operation == :embedding))
+    assert embedding.model == "text-embedding-3-small"
+    assert embedding.input_tokens == 11
+    assert embedding.output_tokens == 0
+  end
+
+  test "cross-tenant: tenant A's call uses A's key, never B's" do
+    a = fixture(:tenant)
+    b = fixture(:tenant)
+    test_pid = self()
+
+    set_embedding_key(a, "test-openai-key-AAAA")
+    set_embedding_key(b, "test-openai-key-BBBB")
+
+    Req.Test.stub(EmbeddingClient, fn conn ->
+      send(test_pid, {:auth, Plug.Conn.get_req_header(conn, "authorization")})
+
+      Req.Test.json(conn, %{
+        "data" => [%{"embedding" => [1.0]}],
+        "usage" => %{"prompt_tokens" => 1}
+      })
+    end)
+
+    assert {:ok, [1.0]} = EmbeddingClient.generate_embedding(a.id, "x")
+    assert_received {:auth, ["Bearer test-openai-key-AAAA"]}
+    refute_received {:auth, ["Bearer test-openai-key-BBBB"]}
+  end
+
+  test "never logs the embedding api_key (success + error branches)" do
+    tenant = fixture(:tenant)
+    secret = "test-openai-key-NEVERLOG-#{System.unique_integer([:positive])}"
+    set_embedding_key(tenant, secret)
+
+    Req.Test.stub(EmbeddingClient, fn conn ->
+      conn |> Plug.Conn.put_status(500) |> Req.Test.json(%{"error" => "boom"})
+    end)
+
+    log =
+      capture_log(fn ->
+        assert {:error, {:api_error, 500, _}} = EmbeddingClient.generate_embedding(tenant.id, "x")
+      end)
+
+    refute log =~ secret
+  end
+end

--- a/test/loopctl/knowledge/proposal_gate_test.exs
+++ b/test/loopctl/knowledge/proposal_gate_test.exs
@@ -50,7 +50,9 @@ defmodule Loopctl.Knowledge.ProposalGateTest do
     end
 
     test "an identical-direction proposal is a duplicate", %{tenant: tenant, existing: existing} do
-      stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _text -> {:ok, e([1.0])} end)
+      stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:ok, e([1.0])}
+      end)
 
       assessment = ProposalGate.assess(tenant.id, %{"title" => "Supervisors", "body" => "OTP"})
 
@@ -62,7 +64,7 @@ defmodule Loopctl.Knowledge.ProposalGateTest do
 
     test "a high-overlap proposal is low-novelty", %{tenant: tenant} do
       # cos(e([1.0]), e([1.0, 0.426])) ≈ 0.92 — inside [0.88, 0.97).
-      stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _text ->
+      stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
         {:ok, e([1.0, 0.426])}
       end)
 
@@ -73,7 +75,9 @@ defmodule Loopctl.Knowledge.ProposalGateTest do
     end
 
     test "an orthogonal proposal is novel (no neighbor clears the floor)", %{tenant: tenant} do
-      stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _text -> {:ok, e([0.0, 1.0])} end)
+      stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:ok, e([0.0, 1.0])}
+      end)
 
       assessment = ProposalGate.assess(tenant.id, %{"title" => "Billing", "body" => "invoices"})
 
@@ -82,7 +86,9 @@ defmodule Loopctl.Knowledge.ProposalGateTest do
     end
 
     test "falls OPEN (:unknown) when embedding fails — never blocks a write", %{tenant: tenant} do
-      stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _text -> {:error, :timeout} end)
+      stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, :timeout}
+      end)
 
       assessment = ProposalGate.assess(tenant.id, %{"title" => "X", "body" => "Y"})
 

--- a/test/loopctl/knowledge/vector_endpoint_e2e_latency_scale_test.exs
+++ b/test/loopctl/knowledge/vector_endpoint_e2e_latency_scale_test.exs
@@ -134,7 +134,7 @@ defmodule Loopctl.Knowledge.VectorEndpointE2eLatencyScaleTest do
     Mox.set_mox_global()
     Loopctl.DataCase.stub_all_defaults()
 
-    Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _text ->
+    Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
       {:ok, ScaleSeed.embedding_for(0)}
     end)
 

--- a/test/loopctl/knowledge_context_test.exs
+++ b/test/loopctl/knowledge_context_test.exs
@@ -290,7 +290,7 @@ defmodule Loopctl.KnowledgeContextTest do
         tags: ["embfallback"]
       })
 
-      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _text ->
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
         {:error, :service_unavailable}
       end)
 

--- a/test/loopctl/knowledge_semantic_search_test.exs
+++ b/test/loopctl/knowledge_semantic_search_test.exs
@@ -355,7 +355,7 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
 
       query_embedding = make_embedding(:query)
 
-      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _text ->
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
         {:ok, query_embedding}
       end)
 
@@ -397,7 +397,7 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
         status: :published
       })
 
-      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _text ->
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
         {:error, :service_unavailable}
       end)
 
@@ -460,7 +460,7 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
         status: :published
       })
 
-      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _text ->
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
         {:ok, make_embedding(:query)}
       end)
 
@@ -520,7 +520,7 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
       query_embedding = make_embedding(:query)
 
       # With semantic_weight=0.8, conceptual match should rank higher
-      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _text ->
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
         {:ok, query_embedding}
       end)
 
@@ -531,7 +531,7 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
                )
 
       # With keyword_weight=0.8, exact match should rank higher
-      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _text ->
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
         {:ok, query_embedding}
       end)
 
@@ -581,7 +581,7 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
 
       # Fail 3 times to trip the circuit breaker
       for _i <- 1..3 do
-        expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _text ->
+        expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
           {:error, :service_unavailable}
         end)
 
@@ -609,7 +609,7 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
       })
 
       # One failure
-      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _text ->
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
         {:error, :temporary_failure}
       end)
 
@@ -619,7 +619,7 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
       # Then a success (resets failure count)
       query_embedding = make_embedding(:query)
 
-      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _text ->
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
         {:ok, query_embedding}
       end)
 
@@ -627,7 +627,7 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
                Knowledge.search_combined(tenant.id, "recovery")
 
       # Another failure should not trip the breaker (counter was reset)
-      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _text ->
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
         {:error, :temporary_failure}
       end)
 
@@ -658,7 +658,7 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
 
       query_embedding = make_embedding(:uniform)
 
-      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _text ->
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
         {:ok, query_embedding}
       end)
 
@@ -698,7 +698,7 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
         status: :published
       })
 
-      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _text ->
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
         {:ok, make_embedding(:query)}
       end)
 
@@ -718,7 +718,7 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
         status: :published
       })
 
-      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _text ->
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
         {:error, :unavailable}
       end)
 
@@ -843,7 +843,7 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
       # surface that, not drop it (combined is the DEFAULT search mode).
       for i <- 1..7, do: create_article_with_embedding(tenant.id, %{title: "Hub #{i}"}, :query)
 
-      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _text ->
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
         {:ok, make_embedding(:query)}
       end)
 

--- a/test/loopctl/llm_test.exs
+++ b/test/loopctl/llm_test.exs
@@ -294,4 +294,179 @@ defmodule Loopctl.LlmTest do
       refute "ancient" in models
     end
   end
+
+  # --- BYO embeddings (#294 extended): a SEPARATE OpenAI embedding key + model ---
+
+  describe "embedding config: resolve(:embedding) + has_embedding_key?/1" do
+    test "resolves the tenant's embedding key + model, defaulting the model when nil" do
+      tenant = fixture(:tenant)
+
+      {:ok, _} =
+        Llm.upsert_settings(tenant.id, %{
+          "embedding_api_key" => "test-openai-embed-key-1234",
+          "embedding_model" => "text-embedding-3-large"
+        })
+
+      assert {:ok, %{api_key: "test-openai-embed-key-1234", model: "text-embedding-3-large"}} =
+               Llm.resolve(tenant.id, :embedding)
+
+      assert Llm.has_embedding_key?(tenant.id)
+
+      # embedding_model left nil -> server default.
+      {:ok, _} = Llm.upsert_settings(tenant.id, %{"embedding_model" => nil})
+
+      assert {:ok, %{model: "text-embedding-3-small"}} = Llm.resolve(tenant.id, :embedding)
+    end
+
+    test "the Anthropic key and the embedding key are INDEPENDENT" do
+      tenant = fixture(:tenant)
+
+      # Only an Anthropic key -> LLM ops resolve, embedding does NOT.
+      {:ok, _} = Llm.upsert_settings(tenant.id, %{"api_key" => "test-anthropic-only"})
+      assert {:ok, %{api_key: "test-anthropic-only"}} = Llm.resolve(tenant.id, :extraction)
+      assert {:error, :no_api_key} = Llm.resolve(tenant.id, :embedding)
+      refute Llm.has_embedding_key?(tenant.id)
+
+      # Add an embedding key -> both resolve, each to its OWN key.
+      {:ok, _} = Llm.upsert_settings(tenant.id, %{"embedding_api_key" => "test-openai-embed"})
+      assert {:ok, %{api_key: "test-anthropic-only"}} = Llm.resolve(tenant.id, :extraction)
+      assert {:ok, %{api_key: "test-openai-embed"}} = Llm.resolve(tenant.id, :embedding)
+    end
+
+    test "resolve(:embedding) returns {:error, :no_api_key} with no key configured" do
+      tenant = fixture(:tenant)
+      assert {:error, :no_api_key} = Llm.resolve(tenant.id, :embedding)
+
+      # A models-only row is still "no key".
+      {:ok, _} = Llm.upsert_settings(tenant.id, %{"embedding_model" => "text-embedding-3-small"})
+      assert {:error, :no_api_key} = Llm.resolve(tenant.id, :embedding)
+      refute Llm.has_embedding_key?(tenant.id)
+    end
+
+    test "resolve(:embedding) is tenant-scoped — A and B each get their own key" do
+      a = fixture(:tenant)
+      b = fixture(:tenant)
+
+      {:ok, _} = Llm.upsert_settings(a.id, %{"embedding_api_key" => "test-openai-AAAA"})
+      {:ok, _} = Llm.upsert_settings(b.id, %{"embedding_api_key" => "test-openai-BBBB"})
+
+      assert {:ok, %{api_key: "test-openai-AAAA"}} = Llm.resolve(a.id, :embedding)
+      assert {:ok, %{api_key: "test-openai-BBBB"}} = Llm.resolve(b.id, :embedding)
+
+      refute match?({:ok, %{api_key: "test-openai-BBBB"}}, Llm.resolve(a.id, :embedding))
+      refute match?({:ok, %{api_key: "test-openai-AAAA"}}, Llm.resolve(b.id, :embedding))
+    end
+
+    test "rejects a blank embedding_api_key and an implausible embedding_model" do
+      tenant = fixture(:tenant)
+
+      assert {:error, cs1} = Llm.upsert_settings(tenant.id, %{"embedding_api_key" => "  "})
+      assert %{embedding_api_key: _} = errors_on(cs1)
+
+      assert {:error, cs2} =
+               Llm.upsert_settings(tenant.id, %{"embedding_model" => "bad model!"})
+
+      assert %{embedding_model: _} = errors_on(cs2)
+    end
+  end
+
+  describe "embedding config: encryption at rest + redaction + audit" do
+    test "the embedding_api_key column is ciphertext, not the plaintext key" do
+      tenant = fixture(:tenant)
+
+      {:ok, settings} =
+        Llm.upsert_settings(tenant.id, %{"embedding_api_key" => "test-openai-plaintext-zzz"})
+
+      %{rows: [[raw]]} =
+        AdminRepo.query!(
+          "SELECT embedding_api_key FROM tenant_llm_settings WHERE tenant_id = $1",
+          [Ecto.UUID.dump!(tenant.id)]
+        )
+
+      assert is_binary(raw)
+      refute String.contains?(raw, "test-openai-plaintext-zzz")
+
+      # redact: true keeps it out of inspect; it decrypts back on load.
+      refute inspect(settings) =~ "test-openai-plaintext-zzz"
+      assert {:ok, %{api_key: "test-openai-plaintext-zzz"}} = Llm.resolve(tenant.id, :embedding)
+    end
+
+    test "settings_view exposes has_embedding_key + last-4 hint, NEVER the key" do
+      tenant = fixture(:tenant)
+
+      {:ok, settings} =
+        Llm.upsert_settings(tenant.id, %{
+          "embedding_api_key" => "test-openai-hidden-9977",
+          "embedding_model" => "text-embedding-3-small"
+        })
+
+      view = Llm.settings_view(settings)
+      assert view.has_embedding_key == true
+      assert view.embedding_api_key_hint == "...9977"
+      assert view.embedding_model == "text-embedding-3-small"
+      refute Map.has_key?(view, :embedding_api_key)
+      refute view |> inspect() =~ "test-openai-hidden-9977"
+    end
+
+    test "settings_view/1 for a keyless tenant reports has_embedding_key: false" do
+      assert %{has_embedding_key: false, embedding_api_key_hint: nil} = Llm.settings_view(nil)
+    end
+
+    test "setting an embedding key writes llm_config.embedding_key_set WITHOUT the value" do
+      tenant = fixture(:tenant)
+
+      {:ok, _} =
+        Llm.upsert_settings(tenant.id, %{"embedding_api_key" => "test-openai-audit-5150"})
+
+      events =
+        from(a in AuditLog,
+          where: a.tenant_id == ^tenant.id and a.entity_type == "llm_config",
+          select: a
+        )
+        |> AdminRepo.all()
+
+      actions = Enum.map(events, & &1.action)
+      assert "llm_config.embedding_key_set" in actions
+      refute events |> inspect() =~ "test-openai-audit-5150"
+    end
+  end
+
+  describe "embedding usage in the shared ledger" do
+    test "record_usage/2 accepts operation :embedding and usage_summary groups it" do
+      tenant = fixture(:tenant)
+
+      {:ok, _} =
+        Llm.record_usage(tenant.id, %{
+          operation: :embedding,
+          model: "text-embedding-3-small",
+          input_tokens: 42,
+          output_tokens: 0
+        })
+
+      %{data: rows} = Llm.usage_summary(tenant.id, [])
+      embedding = Enum.find(rows, &(&1.operation == :embedding))
+
+      assert embedding.model == "text-embedding-3-small"
+      assert embedding.input_tokens == 42
+      assert embedding.output_tokens == 0
+      assert embedding.event_count == 1
+    end
+
+    test "embedding usage is tenant-isolated (A cannot see B's embedding usage)" do
+      a = fixture(:tenant)
+      b = fixture(:tenant)
+
+      {:ok, _} =
+        Llm.record_usage(b.id, %{
+          operation: :embedding,
+          model: "text-embedding-3-small",
+          input_tokens: 7,
+          output_tokens: 0
+        })
+
+      assert %{data: []} = Llm.usage_summary(a.id, [])
+      %{data: rows_b} = Llm.usage_summary(b.id, [])
+      assert Enum.any?(rows_b, &(&1.operation == :embedding))
+    end
+  end
 end

--- a/test/loopctl/workers/article_embedding_worker_test.exs
+++ b/test/loopctl/workers/article_embedding_worker_test.exs
@@ -48,7 +48,7 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorkerTest do
         |> Ecto.Changeset.change(%{status: :published})
         |> Loopctl.AdminRepo.update!()
 
-      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn text ->
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, text ->
         assert is_binary(text)
         assert text =~ "Published Article For Perform Test"
         {:ok, embedding}
@@ -86,7 +86,7 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorkerTest do
         |> Ecto.Changeset.change(%{status: :published})
         |> Loopctl.AdminRepo.update!()
 
-      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _text ->
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
         {:error, {:api_error, 500, "Internal Server Error"}}
       end)
 
@@ -157,7 +157,7 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorkerTest do
       %{tenant: tenant} = setup_tenant()
       article = create_published_article(tenant.id)
 
-      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn text ->
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, text ->
         assert text =~ "Updated Title"
         {:ok, List.duplicate(0.2, 1536)}
       end)
@@ -172,7 +172,7 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorkerTest do
       %{tenant: tenant} = setup_tenant()
       article = create_published_article(tenant.id)
 
-      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn text ->
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, text ->
         assert text =~ "Updated body content"
         {:ok, List.duplicate(0.3, 1536)}
       end)
@@ -195,7 +195,7 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorkerTest do
 
       assert draft.embedding == nil
 
-      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn text ->
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, text ->
         assert text =~ "Draft to Publish"
         {:ok, List.duplicate(0.4, 1536)}
       end)
@@ -213,7 +213,7 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorkerTest do
       # After create (which uses the default stub), set expect with 0 calls.
       # If update_article incorrectly enqueues an embedding job for a
       # tags-only change, Mox will fail because the mock was called.
-      expect(Loopctl.MockEmbeddingClient, :generate_embedding, 0, fn _text ->
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, 0, fn _tenant_id, _text ->
         {:ok, List.duplicate(0.1, 1536)}
       end)
 
@@ -229,7 +229,7 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorkerTest do
 
       # After create (which uses the default stub), set expect with 0 calls.
       # Ensures no embedding job is enqueued for metadata-only changes.
-      expect(Loopctl.MockEmbeddingClient, :generate_embedding, 0, fn _text ->
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, 0, fn _tenant_id, _text ->
         {:ok, List.duplicate(0.1, 1536)}
       end)
 
@@ -262,7 +262,7 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorkerTest do
         |> Ecto.Changeset.change(%{status: :published})
         |> Loopctl.AdminRepo.update!()
 
-      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn text ->
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, text ->
         # title + "\n\n" + body should be truncated to 32K total
         assert String.length(text) <= 32_000
         {:ok, List.duplicate(0.1, 1536)}
@@ -330,6 +330,43 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorkerTest do
 
       # Verify the deterministic component increases monotonically
       assert backoffs == Enum.sort(backoffs)
+    end
+  end
+
+  # --- Mandatory BYO: a keyless tenant gets a clean discard, never a crash ---
+
+  describe "mandatory BYO embeddings" do
+    test "discards {:no_embedding_key, id} when the tenant has no embedding key" do
+      %{tenant: tenant} = setup_tenant()
+
+      {:ok, article} =
+        Knowledge.create_article(tenant.id, %{
+          title: "Keyless Tenant Article",
+          body: "This tenant configured no embedding key.",
+          category: :pattern,
+          status: :draft
+        })
+
+      article =
+        article
+        |> Ecto.Changeset.change(%{status: :published})
+        |> Loopctl.AdminRepo.update!()
+
+      # The embedding client refuses to call the provider for a keyless tenant.
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, :no_api_key}
+      end)
+
+      assert {:discard, {:no_embedding_key, article_id}} =
+               ArticleEmbeddingWorker.perform(%Oban.Job{
+                 args: %{"article_id" => article.id, "tenant_id" => tenant.id}
+               })
+
+      assert article_id == article.id
+
+      # No embedding was stored (the article stays created, just not vector-searchable).
+      {:ok, loaded} = Knowledge.get_article_with_embedding(tenant.id, article.id)
+      assert loaded.embedding == nil
     end
   end
 end

--- a/test/loopctl_web/controllers/agent_memory_trust_test.exs
+++ b/test/loopctl_web/controllers/agent_memory_trust_test.exs
@@ -604,7 +604,9 @@ defmodule LoopctlWeb.AgentMemoryTrustTest do
       # Agent A's private proposal; agent B scoring an idea sees no comparable prior.
       private_embedded(ctx.conn, ctx.raw_a, ctx.tenant.id, "Proposal", [1.0, 0.0], ["proposal"])
 
-      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _ -> {:ok, e([1.0, 0.0])} end)
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _ ->
+        {:ok, e([1.0, 0.0])}
+      end)
 
       b_meta =
         ctx.conn

--- a/test/loopctl_web/controllers/knowledge_context_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_context_controller_test.exs
@@ -214,7 +214,7 @@ defmodule LoopctlWeb.KnowledgeContextControllerTest do
       })
 
       # Make embedding generation fail
-      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _text ->
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
         {:error, :service_unavailable}
       end)
 

--- a/test/loopctl_web/controllers/knowledge_creativity_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_creativity_controller_test.exs
@@ -284,7 +284,7 @@ defmodule LoopctlWeb.KnowledgeCreativityControllerTest do
   describe "POST /api/v1/knowledge/novelty (#152 A2)" do
     # Map idea text → a controllable embedding so novelty is deterministic.
     defp stub_idea_embeddings(mapping) do
-      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn text ->
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, text ->
         {:ok, e(Map.get(mapping, text, [0.0, 0.0]))}
       end)
     end
@@ -379,7 +379,7 @@ defmodule LoopctlWeb.KnowledgeCreativityControllerTest do
       embedded(tenant.id, "Prior", [1.0, 0.0], %{tags: ["proposal"]})
 
       # Expect NO embedding calls for blank ideas (would be called for non-blank)
-      Mox.expect(Loopctl.MockEmbeddingClient, :generate_embedding, 0, fn _ ->
+      Mox.expect(Loopctl.MockEmbeddingClient, :generate_embedding, 0, fn _tenant_id, _ ->
         {:ok, e([1.0, 0.0])}
       end)
 
@@ -403,7 +403,9 @@ defmodule LoopctlWeb.KnowledgeCreativityControllerTest do
       embedded(tenant.id, "Prior", [1.0, 0.0], %{tags: ["proposal"]})
       # Embedding service errors → that idea scores nil, but prior_count > 0 lets a
       # client tell "embed failed" apart from "no priors to compare against".
-      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _ -> {:error, :boom} end)
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _ ->
+        {:error, :boom}
+      end)
 
       body =
         conn

--- a/test/loopctl_web/controllers/knowledge_search_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_search_controller_test.exs
@@ -127,7 +127,7 @@ defmodule LoopctlWeb.KnowledgeSearchControllerTest do
       tenant = fixture(:tenant)
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
 
-      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _text ->
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
         {:error, :service_unavailable}
       end)
 
@@ -145,7 +145,7 @@ defmodule LoopctlWeb.KnowledgeSearchControllerTest do
       tenant = fixture(:tenant)
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
 
-      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _text ->
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
         {:ok, [1.0 | List.duplicate(0.0, 1535)]}
       end)
 
@@ -176,7 +176,7 @@ defmodule LoopctlWeb.KnowledgeSearchControllerTest do
         tags: ["ecto"]
       })
 
-      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _text ->
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
         {:error, :service_unavailable}
       end)
 

--- a/test/loopctl_web/controllers/llm_config_controller_test.exs
+++ b/test/loopctl_web/controllers/llm_config_controller_test.exs
@@ -133,4 +133,91 @@ defmodule LoopctlWeb.LlmConfigControllerTest do
       refute inspect(body) =~ "bbbb2222"
     end
   end
+
+  # --- BYO embeddings (#294 extended): the SEPARATE OpenAI embedding key/model ---
+
+  describe "embedding config via PATCH/GET" do
+    test "filter_parameters redacts embedding_api_key (the exact param-log redaction)" do
+      secret = "test-openai-LEAKCHECK-#{System.unique_integer([:positive])}"
+
+      filtered =
+        Phoenix.Logger.filter_values(%{"embedding_api_key" => secret, "keep_me" => "visible"})
+
+      # "embedding_api_key" contains the "api_key" discard-substring, so it is filtered.
+      assert filtered["embedding_api_key"] == "[FILTERED]"
+      assert filtered["keep_me"] == "visible"
+      refute inspect(filtered) =~ secret
+    end
+
+    test "PATCH sets the embedding key + model (role user); response never leaks the key",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      body =
+        conn
+        |> auth_conn(raw_key)
+        |> patch(~p"/api/v1/tenants/me/llm-config", %{
+          embedding_api_key: "test-openai-controller-key",
+          embedding_model: "text-embedding-3-large"
+        })
+        |> json_response(200)
+
+      assert body["has_embedding_key"] == true
+      assert body["embedding_api_key_hint"] == "...-key"
+      assert body["embedding_model"] == "text-embedding-3-large"
+      refute Map.has_key?(body, "embedding_api_key")
+      refute inspect(body) =~ "test-openai-controller-key"
+
+      assert {:ok, %{api_key: "test-openai-controller-key", model: "text-embedding-3-large"}} =
+               Llm.resolve(tenant.id, :embedding)
+    end
+
+    test "a lower role (agent) is rejected with 403 and stores nothing", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> patch(~p"/api/v1/tenants/me/llm-config", %{embedding_api_key: "test-openai-x"})
+
+      assert json_response(conn, 403)
+      refute Llm.has_embedding_key?(tenant.id)
+    end
+
+    test "GET reports has_embedding_key + hint, never the embedding key", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {:ok, _} = Llm.upsert_settings(tenant.id, %{"embedding_api_key" => "test-openai-wxyz5678"})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      body =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/tenants/me/llm-config")
+        |> json_response(200)
+
+      assert body["has_embedding_key"] == true
+      assert body["embedding_api_key_hint"] == "...5678"
+      refute inspect(body) =~ "test-openai-wxyz5678"
+    end
+
+    test "tenant A never sees tenant B's embedding key", %{conn: conn} do
+      a = fixture(:tenant)
+      b = fixture(:tenant)
+      {:ok, _} = Llm.upsert_settings(a.id, %{"embedding_api_key" => "test-openai-aaaa1111"})
+      {:ok, _} = Llm.upsert_settings(b.id, %{"embedding_api_key" => "test-openai-bbbb2222"})
+
+      {raw_key_a, _} = fixture(:api_key, %{tenant_id: a.id, role: :user})
+
+      body =
+        conn
+        |> auth_conn(raw_key_a)
+        |> get(~p"/api/v1/tenants/me/llm-config")
+        |> json_response(200)
+
+      assert body["embedding_api_key_hint"] == "...1111"
+      refute inspect(body) =~ "bbbb2222"
+    end
+  end
 end

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -98,8 +98,9 @@ defmodule Loopctl.DataCase do
       {:ok, 0}
     end)
 
-    # Default stub for embedding client -- returns a 1536-dim vector of 0.1
-    Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _text ->
+    # Default stub for embedding client -- returns a 1536-dim vector of 0.1.
+    # tenant_id is threaded first (BYO embeddings, #294 extended).
+    Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
       {:ok, List.duplicate(0.1, 1536)}
     end)
 


### PR DESCRIPTION
## Why

Closes a Critical from the enhanced review: the embeddings pipeline was an **ungated, operator-funded, untracked external-API spend path**. `POST /api/v1/articles` (role `:agent`, the lowest role) fired `EmbeddingClient.generate_embedding/1` on every create/update/publish using the **global** operator OpenAI key — no tenant scoping, no cap, no usage record. A single agent key could loop it to run up the operator's OpenAI bill.

Mark's decision: **mandatory BYO for embeddings too** — each tenant supplies its OWN embedding key; a tenant without one gets NO embeddings (their articles simply aren't vector-searchable until they configure it). This mirrors the just-merged #294 (per-tenant BYO Anthropic) exactly.

## What

- **Schema/migration** — add encrypted `embedding_api_key` (Cloak `Vault.Binary`, `redact: true`, never cast — set via `put_change`) + free-form `embedding_model` to `tenant_llm_settings`. No new table; the existing RLS policy covers the new columns.
- **Context (`Loopctl.Llm`)** — `resolve(tenant_id, :embedding)` resolves the SEPARATE embedding key + model (default `text-embedding-3-small`); `has_embedding_key?/1`; `:embedding` recorded in the SAME `llm_usage_events` ledger (`input_tokens` = OpenAI `prompt_tokens`/`total_tokens`, `output_tokens` = 0); `usage_summary` groups it automatically.
- **Client** — `EmbeddingClient.generate_embedding/2` now takes `tenant_id`, resolves the TENANT's key (`Authorization: Bearer`), records an `:embedding` usage event on success, and returns `{:error, :no_api_key}` for a keyless tenant (no provider call, no operator key). `tenant_id` threaded through the behaviour + every caller (worker, proposal gate, knowledge search paths, search controller) + the Mox mock.
- **Enforcement** — `ArticleEmbeddingWorker` gates on the client's `{:error, :no_api_key}` and cleanly `{:discard, {:no_embedding_key, id}}` + telemetry — no crash, no retry, no operator-key fallback. Article creation is never blocked. The keyless case does NOT trip the global embedding circuit breaker (a per-tenant config gap must not degrade embeddings for tenants that DO have a key).
- **Config removal** — the global operator embedding key is removed from `runtime.exs` `:embedding_provider` (only `base_url`/`model` defaults remain).
- **Config API + MCP** — `PATCH`/`GET /tenants/me/llm-config` and `set_llm_config`/`llm_config` handle `embedding_api_key` + `embedding_model` (role `:user`, key never returned — `has_embedding_key` + last-4 hint only). OpenApiSpex schemas updated; `mcp-server` bumped `2.31.1` → `2.32.0` + CHANGELOG.

## Security

- Key encrypted at rest, **never logged** (verified across every branch of the client + worker + resolve path), never serialized or audited with its value (`llm_config.embedding_key_set` audit carries only a last-4 hint), RLS-covered, strictly tenant-scoped resolve (no cross-tenant key use), config at role `:user`, and `filter_parameters` already redacts `embedding_api_key` (the `api_key` discard-substring).

## Tests

`resolve(:embedding)` + defaults + tenant isolation, encryption-at-rest, audit, usage ledger; worker mandatory-BYO discard; the real `EmbeddingClient` (via `Req.Test`) — tenant-key resolution + usage recording + cross-tenant (A uses A's key, never B's) + no-key-leak; config API set/leak/role/isolation.

Full precommit green (compile `--warnings-as-errors`, format, `credo --strict`, dialyzer 0, **3629 tests / 0 failures**) + **73 mcp node tests**.

## Follow-up (not in this PR)

Backfilling embeddings for a tenant's EXISTING articles once they first configure an embedding key is out of scope here — noted for a separate story. Until then, a tenant that sets a key gets embeddings for NEW/updated articles going forward; pre-existing articles stay keyword-searchable only until re-published or a backfill ships.
