### PR TITLE
fix(embeddings): close 15 BYO review regressions — tenant-scoped/error-classed circuit breaker, provider-error sanitizer, permanent-error/idempotent embed, keyless degrade

### DIFF
--- a/lib/loopctl/api_spec/schemas.ex
+++ b/lib/loopctl/api_spec/schemas.ex
@@ -2773,7 +2773,7 @@ defmodule Loopctl.ApiSpec.Schemas do
               day: %Schema{type: :string, format: :"date-time"},
               operation: %Schema{
                 type: :string,
-                enum: ["extraction", "classification", "merge"]
+                enum: ["extraction", "classification", "merge", "embedding"]
               },
               model: %Schema{type: :string},
               source_type: %Schema{type: :string, nullable: true},

--- a/lib/loopctl/application.ex
+++ b/lib/loopctl/application.ex
@@ -28,6 +28,10 @@ defmodule Loopctl.Application do
       # US-27.16: owns the ETS table tracking in-flight streaming-export slots so a
       # crashed exporter's slot is reclaimed (concurrency cap, AC-27.16.6).
       Loopctl.Knowledge.ExportConcurrency,
+      # Owns the per-tenant embedding circuit-breaker ETS table so it has a STABLE,
+      # long-lived owner (it would otherwise be created by a transient request/job/Task
+      # and vanish when that process died — silently resetting the breaker).
+      Loopctl.Knowledge.EmbeddingCircuitBreaker,
       LoopctlWeb.Endpoint
     ]
 

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -5842,9 +5842,7 @@ defmodule Loopctl.Knowledge do
   @doc false
   def reset_circuit_breaker(tenant_id) when is_binary(tenant_id) do
     if :ets.whereis(@circuit_breaker_table) != :undefined do
-      :ets.delete(@circuit_breaker_table, {tenant_id, :failures})
-      :ets.delete(@circuit_breaker_table, {tenant_id, :window_start})
-      :ets.delete(@circuit_breaker_table, {tenant_id, :open_until})
+      clear_tenant_breaker(tenant_id, System.monotonic_time(:second))
     end
 
     :ok
@@ -5956,37 +5954,43 @@ defmodule Loopctl.Knowledge do
     key = {tenant_id, :open_until}
 
     case :ets.lookup(@circuit_breaker_table, key) do
-      [{^key, open_until}] ->
-        now = System.monotonic_time(:second)
-
-        if now < open_until do
-          true
-        else
-          # Cooldown expired — clear this tenant's breaker state.
-          :ets.delete(@circuit_breaker_table, key)
-          :ets.delete(@circuit_breaker_table, {tenant_id, :failures})
-          :ets.delete(@circuit_breaker_table, {tenant_id, :window_start})
-          false
-        end
-
-      [] ->
-        false
+      [{^key, open_until}] -> check_open_until(tenant_id, open_until)
+      [] -> false
     end
   end
 
+  defp check_open_until(tenant_id, open_until) do
+    now = System.monotonic_time(:second)
+
+    if now < open_until do
+      true
+    else
+      # Cooldown expired — clear this tenant's breaker state.
+      clear_tenant_breaker(tenant_id, now)
+      false
+    end
+  end
+
+  # The failure counter is keyed by the WINDOW PERIOD (review #2): each rolling
+  # window is a DISTINCT ETS key, so an expired window is simply a different key —
+  # there is no non-atomic "check the timestamp, then reset the counter in place"
+  # step to race. `update_counter/4` is the sole, atomic mutation, so a burst of
+  # concurrent failures for one tenant counts reliably to the threshold.
   defp record_failure(tenant_id) do
     ensure_circuit_breaker_table()
     now = System.monotonic_time(:second)
-    maybe_reset_window(tenant_id, now)
+    period = period_for(now)
 
-    # Atomic increment (review #13): concurrent failures for the same tenant can no
-    # longer read-modify-write over each other and undercount.
+    # Bound ETS growth: the previous window's counter can never grow again, so drop
+    # it. (At most one stale key per tenant survives between failures.)
+    :ets.delete(@circuit_breaker_table, failures_key(tenant_id, period - 1))
+
     count =
       :ets.update_counter(
         @circuit_breaker_table,
-        {tenant_id, :failures},
+        failures_key(tenant_id, period),
         {2, 1},
-        {{tenant_id, :failures}, 0}
+        {failures_key(tenant_id, period), 0}
       )
 
     if count >= @failure_threshold do
@@ -5996,29 +6000,25 @@ defmodule Loopctl.Knowledge do
     :ok
   end
 
-  # Reset the tenant's rolling window (and its counter) once the window has elapsed,
-  # so sparse failures over a long span never accumulate to the threshold.
-  defp maybe_reset_window(tenant_id, now) do
-    key = {tenant_id, :window_start}
-
-    case :ets.lookup(@circuit_breaker_table, key) do
-      [{^key, ws}] when now - ws < @failure_window_seconds ->
-        :ok
-
-      _ ->
-        :ets.insert(@circuit_breaker_table, {key, now})
-        :ets.insert(@circuit_breaker_table, {{tenant_id, :failures}, 0})
-        :ok
-    end
-  end
-
   defp record_success(tenant_id) do
     ensure_circuit_breaker_table()
-    :ets.delete(@circuit_breaker_table, {tenant_id, :failures})
-    :ets.delete(@circuit_breaker_table, {tenant_id, :window_start})
-    :ets.delete(@circuit_breaker_table, {tenant_id, :open_until})
+    clear_tenant_breaker(tenant_id, System.monotonic_time(:second))
     :ok
   end
+
+  # Delete ALL of a tenant's breaker state: the open flag + the current and previous
+  # window counters (a failure is always in one of those two periods).
+  defp clear_tenant_breaker(tenant_id, now) do
+    period = period_for(now)
+    :ets.delete(@circuit_breaker_table, {tenant_id, :open_until})
+    :ets.delete(@circuit_breaker_table, failures_key(tenant_id, period))
+    :ets.delete(@circuit_breaker_table, failures_key(tenant_id, period - 1))
+    :ok
+  end
+
+  defp failures_key(tenant_id, period), do: {tenant_id, :failures, period}
+
+  defp period_for(now), do: div(now, @failure_window_seconds)
 
   defp ensure_circuit_breaker_table do
     if :ets.whereis(@circuit_breaker_table) == :undefined do

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -4931,6 +4931,8 @@ defmodule Loopctl.Knowledge do
   - `tenant_id` -- the tenant UUID
   - `article_id` -- the article UUID
   - `embedding_vector` -- a list of floats matching the configured dimension
+  - `content_hash` -- optional SHA-256 hex of the embedded text; stored as the
+    idempotency key so a retry can skip re-calling the paid provider (review #12)
 
   ## Returns
 
@@ -4938,15 +4940,15 @@ defmodule Loopctl.Knowledge do
   - `{:error, changeset}` on dimension mismatch
   - `{:error, :not_found}` if the article does not exist in this tenant
   """
-  @spec update_embedding(Ecto.UUID.t(), Ecto.UUID.t(), list(number())) ::
+  @spec update_embedding(Ecto.UUID.t(), Ecto.UUID.t(), list(number()), String.t() | nil) ::
           {:ok, Article.t()} | {:error, Ecto.Changeset.t() | :not_found}
-  def update_embedding(tenant_id, article_id, embedding_vector) do
+  def update_embedding(tenant_id, article_id, embedding_vector, content_hash \\ nil) do
     case AdminRepo.get_by(Article, id: article_id, tenant_id: tenant_id) do
       nil ->
         {:error, :not_found}
 
       article ->
-        changeset = Article.embedding_changeset(article, embedding_vector)
+        changeset = Article.embedding_changeset(article, embedding_vector, content_hash)
 
         multi =
           Multi.new()
@@ -5675,7 +5677,7 @@ defmodule Loopctl.Knowledge do
       |> Keyword.put(:_skip_record_access, true)
 
     keyword_result = search_keyword(tenant_id, query_string, sub_opts)
-    embedding_result = try_generate_embedding(tenant_id, query_string)
+    embedding_result = try_generate_embedding(tenant_id, query_string, [])
 
     case {keyword_result, embedding_result} do
       {{:ok, kw}, {:ok, embedding}} ->
@@ -5833,71 +5835,137 @@ defmodule Loopctl.Knowledge do
     :ok
   end
 
+  # Reset ONLY the given tenant's breaker state. Preferred over
+  # `reset_circuit_breaker/0` in async tests: the breaker is tenant-scoped, so a
+  # global `delete_all_objects` would race concurrent tests and wipe each other's
+  # per-tenant counts.
+  @doc false
+  def reset_circuit_breaker(tenant_id) when is_binary(tenant_id) do
+    if :ets.whereis(@circuit_breaker_table) != :undefined do
+      :ets.delete(@circuit_breaker_table, {tenant_id, :failures})
+      :ets.delete(@circuit_breaker_table, {tenant_id, :window_start})
+      :ets.delete(@circuit_breaker_table, {tenant_id, :open_until})
+    end
+
+    :ok
+  end
+
+  # Task.yield budget for a query embedding. Kept STRICTLY ABOVE the embedding
+  # client's own worst-case (single-attempt receive_timeout, no client retries —
+  # see EmbeddingClient) so a slow-but-valid embed completes inside the yield and is
+  # never killed-then-miscounted as a breaker failure (review #10).
+  @embedding_yield_ms 5_000
+
   @doc """
-  Generate an embedding for the given text with circuit breaker and timeout protection.
+  Generate an embedding for the given text with a PER-TENANT circuit breaker and
+  timeout protection.
 
   Resolves the TENANT's OWN embedding key (mandatory BYO) via the configured
   embedding client, wrapped with:
-  - Circuit breaker (opens after #{@failure_threshold} failures within #{@failure_window_seconds}s)
-  - 5-second Task.async timeout
-  - Crash rescue handler
+  - A tenant-scoped circuit breaker (opens for a tenant after #{@failure_threshold}
+    COUNTABLE failures within #{@failure_window_seconds}s — so a failing tenant only
+    degrades ITSELF, never other tenants; review #1).
+  - A `#{@embedding_yield_ms}`ms `Task.async` timeout (review #10).
+  - A crash rescue handler.
 
-  Returns `{:ok, embedding}` or `{:error, reason}`. A keyless tenant yields
-  `{:error, :no_api_key}` WITHOUT tripping the (global) circuit breaker — it is a
-  per-tenant config gap, not a provider outage, so it must not degrade embeddings
-  for tenants that DO have a key.
+  Returns `{:ok, embedding}` or `{:error, reason}`. Two error classes are EXEMPT
+  from the breaker: `{:error, :no_api_key}` (a per-tenant config gap) and 4xx
+  provider responses (per-tenant credential/quota problems — 401/403/429). Only
+  5xx / transport / timeout / crash failures count toward opening the breaker
+  (review #1). This is the single guarded entry point — the embedding worker and
+  the proposal gate route through it too (review #4) so circuit-open is both
+  respected AND contributed to.
+
+  `opts`:
+    * `:timeout` — Task.yield budget in ms (default `#{@embedding_yield_ms}`).
   """
-  def generate_embedding(tenant_id, query_string) when is_binary(tenant_id) do
-    try_generate_embedding(tenant_id, query_string)
+  @spec generate_embedding(Ecto.UUID.t(), String.t(), keyword()) ::
+          {:ok, [float()]} | {:error, term()}
+  def generate_embedding(tenant_id, query_string, opts \\ []) when is_binary(tenant_id) do
+    try_generate_embedding(tenant_id, query_string, opts)
   end
 
-  defp try_generate_embedding(tenant_id, query_string) do
+  defp try_generate_embedding(tenant_id, query_string, opts) do
     ensure_circuit_breaker_table()
 
-    if circuit_open?() do
+    if circuit_open?(tenant_id) do
       {:error, :circuit_open}
     else
-      task =
-        Task.async(fn ->
-          try do
-            embedding_client().generate_embedding(tenant_id, query_string)
-          rescue
-            e -> {:error, {:embedding_crash, Exception.message(e)}}
-          end
-        end)
-
-      case Task.yield(task, 5_000) || Task.shutdown(task) do
-        {:ok, {:ok, embedding}} ->
-          record_success()
-          {:ok, embedding}
-
-        # A missing tenant key is a config gap, not a provider failure — do NOT
-        # record it against the shared circuit breaker.
-        {:ok, {:error, :no_api_key}} ->
-          {:error, :no_api_key}
-
-        {:ok, {:error, reason}} ->
-          record_failure()
-          {:error, reason}
-
-        nil ->
-          record_failure()
-          {:error, :timeout}
-      end
+      timeout = Keyword.get(opts, :timeout, @embedding_yield_ms)
+      run_embedding_task(tenant_id, query_string, timeout)
     end
   end
 
-  defp circuit_open? do
-    case :ets.lookup(@circuit_breaker_table, :circuit_open_until) do
-      [{:circuit_open_until, open_until}] ->
+  defp run_embedding_task(tenant_id, query_string, timeout) do
+    task =
+      Task.async(fn ->
+        try do
+          embedding_client().generate_embedding(tenant_id, query_string)
+        rescue
+          e -> {:error, {:embedding_crash, Exception.message(e)}}
+        end
+      end)
+
+    case Task.yield(task, timeout) || Task.shutdown(task) do
+      {:ok, {:ok, embedding}} ->
+        record_success(tenant_id)
+        {:ok, embedding}
+
+      # A missing tenant key is a config gap, not a provider failure — do NOT
+      # record it against the (now tenant-scoped) circuit breaker.
+      {:ok, {:error, :no_api_key}} ->
+        {:error, :no_api_key}
+
+      {:ok, {:error, reason} = err} ->
+        maybe_record_failure(tenant_id, reason)
+        err
+
+      _ ->
+        # nil (yield timeout) or an abnormal task exit — a provider/infra failure.
+        record_failure(tenant_id)
+        {:error, :timeout}
+    end
+  end
+
+  defp maybe_record_failure(tenant_id, reason) do
+    if breaker_countable?(reason), do: record_failure(tenant_id)
+    :ok
+  end
+
+  # Only systemic provider/infra failures count toward the breaker. A 4xx is a
+  # per-tenant credential/quota problem (401/403/429) and must NEVER contribute —
+  # otherwise one tenant's bad key would open the breaker and degrade every tenant
+  # sharing it (review #1). Mirrors the `:no_api_key` exemption.
+  defp breaker_countable?({:api_error, status, _}) when is_integer(status) and status >= 500,
+    do: true
+
+  defp breaker_countable?({:api_error, status, _}) when is_integer(status), do: false
+
+  defp breaker_countable?({:api_error, status}) when is_integer(status) and status >= 500,
+    do: true
+
+  defp breaker_countable?({:api_error, _status}), do: false
+  defp breaker_countable?({:request_failed, _}), do: true
+  defp breaker_countable?({:embedding_crash, _}), do: true
+  defp breaker_countable?(:timeout), do: true
+  defp breaker_countable?(:circuit_open), do: false
+  # Unknown/other transport-ish failures: count (conservative — a real outage).
+  defp breaker_countable?(_), do: true
+
+  defp circuit_open?(tenant_id) do
+    key = {tenant_id, :open_until}
+
+    case :ets.lookup(@circuit_breaker_table, key) do
+      [{^key, open_until}] ->
         now = System.monotonic_time(:second)
 
         if now < open_until do
           true
         else
-          # Cooldown expired, reset
-          :ets.delete(@circuit_breaker_table, :circuit_open_until)
-          :ets.delete(@circuit_breaker_table, :failures)
+          # Cooldown expired — clear this tenant's breaker state.
+          :ets.delete(@circuit_breaker_table, key)
+          :ets.delete(@circuit_breaker_table, {tenant_id, :failures})
+          :ets.delete(@circuit_breaker_table, {tenant_id, :window_start})
           false
         end
 
@@ -5906,33 +5974,50 @@ defmodule Loopctl.Knowledge do
     end
   end
 
-  defp record_failure do
+  defp record_failure(tenant_id) do
     ensure_circuit_breaker_table()
     now = System.monotonic_time(:second)
+    maybe_reset_window(tenant_id, now)
 
-    failures =
-      case :ets.lookup(@circuit_breaker_table, :failures) do
-        [{:failures, existing}] -> existing
-        [] -> []
-      end
-
-    # Keep only failures within the window
-    recent = Enum.filter(failures, fn t -> now - t < @failure_window_seconds end)
-    updated = [now | recent]
-    :ets.insert(@circuit_breaker_table, {:failures, updated})
-
-    if length(updated) >= @failure_threshold do
-      :ets.insert(
+    # Atomic increment (review #13): concurrent failures for the same tenant can no
+    # longer read-modify-write over each other and undercount.
+    count =
+      :ets.update_counter(
         @circuit_breaker_table,
-        {:circuit_open_until, now + @cooldown_seconds}
+        {tenant_id, :failures},
+        {2, 1},
+        {{tenant_id, :failures}, 0}
       )
+
+    if count >= @failure_threshold do
+      :ets.insert(@circuit_breaker_table, {{tenant_id, :open_until}, now + @cooldown_seconds})
+    end
+
+    :ok
+  end
+
+  # Reset the tenant's rolling window (and its counter) once the window has elapsed,
+  # so sparse failures over a long span never accumulate to the threshold.
+  defp maybe_reset_window(tenant_id, now) do
+    key = {tenant_id, :window_start}
+
+    case :ets.lookup(@circuit_breaker_table, key) do
+      [{^key, ws}] when now - ws < @failure_window_seconds ->
+        :ok
+
+      _ ->
+        :ets.insert(@circuit_breaker_table, {key, now})
+        :ets.insert(@circuit_breaker_table, {{tenant_id, :failures}, 0})
+        :ok
     end
   end
 
-  defp record_success do
+  defp record_success(tenant_id) do
     ensure_circuit_breaker_table()
-    :ets.insert(@circuit_breaker_table, {:failures, []})
-    :ets.delete(@circuit_breaker_table, :circuit_open_until)
+    :ets.delete(@circuit_breaker_table, {tenant_id, :failures})
+    :ets.delete(@circuit_breaker_table, {tenant_id, :window_start})
+    :ets.delete(@circuit_breaker_table, {tenant_id, :open_until})
+    :ok
   end
 
   defp ensure_circuit_breaker_table do

--- a/lib/loopctl/knowledge/article.ex
+++ b/lib/loopctl/knowledge/article.ex
@@ -61,6 +61,9 @@ defmodule Loopctl.Knowledge.Article do
     field :metadata, :map, default: %{}
 
     field :embedding, Pgvector.Ecto.Vector, load_in_query: false
+    # SHA-256 hex of the exact text that produced `embedding` — the idempotency key
+    # that lets ArticleEmbeddingWorker skip re-calling the paid provider on retry.
+    field :embedding_content_hash, :string
 
     has_many :outgoing_links, Loopctl.Knowledge.ArticleLink, foreign_key: :source_article_id
     has_many :incoming_links, Loopctl.Knowledge.ArticleLink, foreign_key: :target_article_id
@@ -245,10 +248,11 @@ defmodule Loopctl.Knowledge.Article do
 
   An `Ecto.Changeset` with dimension validation applied when `embedding` is not nil.
   """
-  @spec embedding_changeset(%__MODULE__{}, list(number()) | nil) :: Ecto.Changeset.t()
-  def embedding_changeset(article, embedding) do
+  @spec embedding_changeset(%__MODULE__{}, list(number()) | nil, String.t() | nil) ::
+          Ecto.Changeset.t()
+  def embedding_changeset(article, embedding, content_hash \\ nil) do
     article
-    |> change(%{embedding: embedding})
+    |> change(%{embedding: embedding, embedding_content_hash: content_hash})
     |> validate_embedding_dimensions()
   end
 

--- a/lib/loopctl/knowledge/embedding_circuit_breaker.ex
+++ b/lib/loopctl/knowledge/embedding_circuit_breaker.ex
@@ -1,0 +1,40 @@
+defmodule Loopctl.Knowledge.EmbeddingCircuitBreaker do
+  @moduledoc """
+  Stable, supervised OWNER of the ETS table backing the per-tenant embedding
+  circuit breaker (review #2 follow-through).
+
+  The breaker state lives in a `:public`, `:named_table` ETS table that
+  `Loopctl.Knowledge` reads/writes directly with `:ets.update_counter` (atomic,
+  lock-free) — so this process is NEVER on the hot path and can't bottleneck
+  embedding throughput. It exists ONLY to own the table.
+
+  ## Why a dedicated owner (the bug this fixes)
+
+  An ETS table dies with the process that created it. If the table were created
+  lazily by whatever transient process first touched the breaker — a web request, an
+  Oban embedding job, or a `Task` spawned by `generate_embedding/3` — it would VANISH
+  when that process finished: silently resetting every tenant's breaker, and, under
+  concurrency, crashing a peer mid-`update_counter` with "table does not exist". A
+  supervised owner keeps the table alive for the whole node lifetime; if this process
+  ever crashes, the supervisor restarts it and `init/1` recreates the table (losing
+  only the transient breaker counts, which is the correct fail-safe).
+
+  Mirrors `Loopctl.Knowledge.ExportConcurrency` (the sibling ETS-owner in the tree).
+  """
+
+  use GenServer
+
+  @doc false
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_opts) do
+    # Create + own the table here (in the GenServer process) so it persists for the
+    # node's lifetime. Idempotent if it somehow already exists.
+    :ok = Loopctl.Knowledge.init_circuit_breaker()
+    {:ok, %{}}
+  end
+end

--- a/lib/loopctl/knowledge/embedding_client.ex
+++ b/lib/loopctl/knowledge/embedding_client.ex
@@ -33,8 +33,16 @@ defmodule Loopctl.Knowledge.EmbeddingClient do
   require Logger
 
   alias Loopctl.Llm
+  alias Loopctl.Llm.ProviderError
 
   @default_base_url "https://api.openai.com/v1"
+
+  # Kept STRICTLY BELOW `Knowledge`'s Task.yield budget (review #10): a single
+  # attempt, no client-side retries. The embedding endpoint is fast; job-level retry
+  # is Oban's responsibility for the worker, and the query path fast-fails to
+  # keyword search. This guarantees a valid embed returns before the guard kills it.
+  @receive_timeout 4_000
+  @max_retries 0
 
   @impl true
   def generate_embedding(tenant_id, text) when is_binary(tenant_id) do
@@ -57,8 +65,8 @@ defmodule Loopctl.Knowledge.EmbeddingClient do
         # NOTE: never log `opts` / `api_key` — the key is a tenant secret.
         headers: [{"authorization", "Bearer #{api_key}"}],
         retry: :transient,
-        max_retries: 2,
-        receive_timeout: 30_000
+        max_retries: @max_retries,
+        receive_timeout: @receive_timeout
       ]
       |> maybe_put_plug()
 
@@ -69,14 +77,17 @@ defmodule Loopctl.Knowledge.EmbeddingClient do
 
       {:ok, %{status: status, body: body}} ->
         Logger.warning("Loopctl.Knowledge.EmbeddingClient: API error (status=#{status})")
-        {:error, {:api_error, status, body}}
+        # SANITIZE: the provider error body can echo a masked key fragment (review
+        # #3). Drop it — keep only the status — so it never reaches the caller / an
+        # Oban `{:error, reason}` persisted into oban_jobs.errors.
+        {:error, ProviderError.sanitize({:api_error, status, body})}
 
       {:error, reason} ->
         Logger.warning(
-          "Loopctl.Knowledge.EmbeddingClient: request failed (error=#{inspect(reason)})"
+          "Loopctl.Knowledge.EmbeddingClient: request failed (#{ProviderError.log_tag({:request_failed, reason})})"
         )
 
-        {:error, reason}
+        {:error, {:request_failed, reason}}
     end
   end
 

--- a/lib/loopctl/knowledge/proposal_gate.ex
+++ b/lib/loopctl/knowledge/proposal_gate.ex
@@ -26,13 +26,10 @@ defmodule Loopctl.Knowledge.ProposalGate do
 
   require Logger
 
+  alias Loopctl.Knowledge
   alias Loopctl.Knowledge.VectorSearch
-
-  @embedding_client Application.compile_env(
-                      :loopctl,
-                      :embedding_client,
-                      Loopctl.Knowledge.EmbeddingClient
-                    )
+  alias Loopctl.Llm
+  alias Loopctl.Llm.ProviderError
 
   @default_duplicate_threshold 0.97
   @default_overlap_threshold 0.88
@@ -49,7 +46,11 @@ defmodule Loopctl.Knowledge.ProposalGate do
     dup = config(:knowledge_proposal_duplicate_threshold, @default_duplicate_threshold)
     overlap = config(:knowledge_proposal_overlap_threshold, @default_overlap_threshold)
 
-    case @embedding_client.generate_embedding(tenant_id, build_text(attrs)) do
+    # Route through the GUARDED embedding path (review #4): tenant-scoped circuit
+    # breaker + timeout, so a provider outage fast-fails here (this runs SYNCHRONOUSLY
+    # in the HTTP write path) instead of hammering a dead provider and risking an LB
+    # timeout.
+    case Knowledge.generate_embedding(tenant_id, build_text(attrs)) do
       {:ok, vector} when is_list(vector) and vector != [] ->
         neighbors =
           VectorSearch.nearest(tenant_id, vector, @neighbors_k,
@@ -60,8 +61,19 @@ defmodule Loopctl.Knowledge.ProposalGate do
         score = neighbors |> List.first() |> neighbor_score()
         %{verdict: classify(score, dup, overlap), score: score, neighbors: neighbors}
 
+      {:error, :no_api_key} ->
+        # Mandatory BYO: keyless tenant — fall open (never block write-back) and audit
+        # the block for a consistent trail with the worker/Anthropic paths (review #9).
+        Llm.record_blocked(tenant_id, :embedding)
+        open_verdict()
+
       other ->
-        Logger.warning("ProposalGate: embedding failed, falling open: #{inspect(other)}")
+        # NEVER inspect the raw tuple (review #2): a provider error body can echo a
+        # masked key fragment. Log only a value-free tag.
+        Logger.warning(
+          "ProposalGate: embedding failed, falling open (#{ProviderError.log_tag(other)})"
+        )
+
         open_verdict()
     end
   end

--- a/lib/loopctl/llm.ex
+++ b/lib/loopctl/llm.ex
@@ -180,6 +180,28 @@ defmodule Loopctl.Llm do
   end
 
   @doc """
+  Whether a (sanitized) provider error is PERMANENT — it will never succeed on
+  retry, so a worker should `{:discard}` rather than burn its Oban attempts on it
+  (review #5). A 4xx response is a bad/revoked key or malformed request (permanent)
+  EXCEPT 408 (request timeout) and 429 (rate limit), which are transient. Everything
+  else (5xx, transport, timeout, crash) is transient.
+  """
+  @spec permanent_provider_error?(term()) :: boolean()
+  def permanent_provider_error?({:api_error, status, _}) when status in [408, 429], do: false
+
+  def permanent_provider_error?({:api_error, status, _})
+      when is_integer(status) and status >= 400 and status < 500,
+      do: true
+
+  def permanent_provider_error?({:api_error, status}) when status in [408, 429], do: false
+
+  def permanent_provider_error?({:api_error, status})
+      when is_integer(status) and status >= 400 and status < 500,
+      do: true
+
+  def permanent_provider_error?(_other), do: false
+
+  @doc """
   Records that a tenant LLM `operation` was BLOCKED for a missing BYO key
   (review #2 — the mandatory-BYO cutover needs observability). Emits a
   `Logger.warning`, a `[:loopctl, :llm, :blocked]` telemetry event, and an

--- a/lib/loopctl/llm.ex
+++ b/lib/loopctl/llm.ex
@@ -211,8 +211,8 @@ defmodule Loopctl.Llm do
   @spec record_blocked(Ecto.UUID.t(), operation()) :: :ok
   def record_blocked(tenant_id, operation) when is_binary(tenant_id) do
     Logger.warning(
-      "Loopctl.Llm: tenant=#{tenant_id} blocked op=#{operation} — no Anthropic API key " <>
-        "configured (mandatory BYO)."
+      "Loopctl.Llm: tenant=#{tenant_id} blocked op=#{operation} — no " <>
+        "#{blocked_credential(operation)} configured (mandatory BYO)."
     )
 
     :telemetry.execute([:loopctl, :llm, :blocked], %{count: 1}, %{
@@ -236,6 +236,12 @@ defmodule Loopctl.Llm do
       Logger.error("Loopctl.Llm.record_blocked failed: #{Exception.message(e)}")
       :ok
   end
+
+  # The two BYO credentials are SEPARATE — name the right one in the block log so an
+  # operator isn't misled into checking the Anthropic key for an embedding block
+  # (review MED #3). The structured audit already carries the exact operation.
+  defp blocked_credential(:embedding), do: "embedding API key"
+  defp blocked_credential(_anthropic_op), do: "Anthropic API key"
 
   @doc """
   A safe view of the tenant's settings for API responses: the model choices,

--- a/lib/loopctl/llm/anthropic.ex
+++ b/lib/loopctl/llm/anthropic.ex
@@ -117,18 +117,24 @@ defmodule Loopctl.Llm.Anthropic do
 
       {:ok, %{status: 200, body: body}} ->
         Logger.warning("Loopctl.Llm.Anthropic: 200 with unexpected shape (op=#{operation})")
-        {:error, {:api_error, 200, redact_body(body)}}
+        # A 200 with the wrong shape can STILL be a misconfigured/compromised
+        # endpoint echoing a masked key fragment in an error-shaped body (review
+        # CRIT #1). Sanitize it exactly like a non-200 — never return the raw body.
+        {:error, ProviderError.sanitize({:api_error, 200, body})}
 
-      {:ok, %{status: status, body: _body}} ->
+      {:ok, %{status: status, body: body}} ->
         Logger.warning("Loopctl.Llm.Anthropic: API error (op=#{operation}, status=#{status})")
         # SANITIZE the provider error body (review #11): it can echo a masked key
         # fragment, and callers surface it as an Oban `{:error, reason}` persisted
         # into oban_jobs.errors. Drop the body; keep only the status.
-        {:error, ProviderError.sanitize({:api_error, status, nil})}
+        {:error, ProviderError.sanitize({:api_error, status, body})}
 
       {:error, reason} ->
+        # Never inspect the raw transport reason (review MED #4) — log a value-free
+        # tag, mirroring EmbeddingClient.post.
         Logger.warning(
-          "Loopctl.Llm.Anthropic: request failed (op=#{operation}, error=#{inspect(reason)})"
+          "Loopctl.Llm.Anthropic: request failed (op=#{operation}, " <>
+            "#{ProviderError.log_tag({:request_failed, reason})})"
         )
 
         {:error, {:request_failed, reason}}
@@ -194,7 +200,4 @@ defmodule Loopctl.Llm.Anthropic do
       plug -> Keyword.put(opts, :plug, plug)
     end
   end
-
-  defp redact_body(body) when is_binary(body), do: String.slice(body, 0, 200)
-  defp redact_body(body), do: body
 end

--- a/lib/loopctl/llm/anthropic.ex
+++ b/lib/loopctl/llm/anthropic.ex
@@ -30,6 +30,7 @@ defmodule Loopctl.Llm.Anthropic do
   require Logger
 
   alias Loopctl.Llm
+  alias Loopctl.Llm.ProviderError
 
   @base_url "https://api.anthropic.com/v1"
   @anthropic_version "2023-06-01"
@@ -118,9 +119,12 @@ defmodule Loopctl.Llm.Anthropic do
         Logger.warning("Loopctl.Llm.Anthropic: 200 with unexpected shape (op=#{operation})")
         {:error, {:api_error, 200, redact_body(body)}}
 
-      {:ok, %{status: status, body: body}} ->
+      {:ok, %{status: status, body: _body}} ->
         Logger.warning("Loopctl.Llm.Anthropic: API error (op=#{operation}, status=#{status})")
-        {:error, {:api_error, status, body}}
+        # SANITIZE the provider error body (review #11): it can echo a masked key
+        # fragment, and callers surface it as an Oban `{:error, reason}` persisted
+        # into oban_jobs.errors. Drop the body; keep only the status.
+        {:error, ProviderError.sanitize({:api_error, status, nil})}
 
       {:error, reason} ->
         Logger.warning(

--- a/lib/loopctl/llm/provider_error.ex
+++ b/lib/loopctl/llm/provider_error.ex
@@ -13,15 +13,32 @@ defmodule Loopctl.Llm.ProviderError do
   keeping only the status (for retry/breaker classification). It is arity-preserving
   for the `{:api_error, status, body}` shape so existing 3-tuple matches keep working.
   Apply it at the boundary in BOTH `Loopctl.Llm.Anthropic` and
-  `Loopctl.Knowledge.EmbeddingClient` so nothing downstream ever sees a raw body.
+  `Loopctl.Knowledge.EmbeddingClient`, AND at every worker boundary that turns an
+  error term into an Oban `{:error, _}` / `{:discard, _}` reason, so nothing
+  downstream ever sees a raw provider body.
+
+  The ONLY way a tenant's API key reaches this function is inside a provider
+  RESPONSE BODY — which always arrives either wrapped as `{:api_error, status,
+  body}` (collapsed here) or, defensively, as a bare decoded body (a string or a
+  map — also collapsed, review #6). A structured DOMAIN error tuple (e.g.
+  `{:insert_failed, step, changeset}`, `{:url_blocked, reason}`) never contains the
+  key and IS preserved — collapsing it would replace a precise operator-facing
+  reason with a misleading `:provider_error`. Bare atoms (`:timeout`, `:no_api_key`)
+  are inherently value-free and preserved.
   """
 
-  @typedoc "A sanitized, value-free provider error term."
-  @type t :: {:api_error, integer(), :provider_error} | term()
+  @typedoc "A sanitized provider error term (never carries a response body)."
+  @type t ::
+          {:api_error, integer(), :provider_error}
+          | {:request_failed, atom()}
+          | {:embedding_crash, :exception}
+          | atom()
+          | tuple()
 
   @doc """
-  Strip any provider response body, preserving only the status. Non-`api_error`
-  terms pass through unchanged (transport reasons / atoms carry no secret).
+  Strip any provider response body/secret. Collapses the key-bearing provider
+  shapes (and bare body strings/maps) to a value-free term; preserves bare atoms and
+  structured domain-error tuples (which are provably key-free).
   """
   @spec sanitize(term()) :: t()
   def sanitize({:api_error, status, _body}) when is_integer(status),
@@ -30,6 +47,22 @@ defmodule Loopctl.Llm.ProviderError do
   def sanitize({:api_error, status}) when is_integer(status),
     do: {:api_error, status, :provider_error}
 
+  # A transport reason that is a bare atom (`:timeout`, `:closed`, `:econnrefused`)
+  # is safe and useful — keep it. A struct/string/other reason could carry arbitrary
+  # data, so collapse it to a value-free tag.
+  def sanitize({:request_failed, reason}) when is_atom(reason), do: {:request_failed, reason}
+  def sanitize({:request_failed, _reason}), do: {:request_failed, :transport_error}
+
+  # A crash detail is an Exception.message string — collapse it.
+  def sanitize({:embedding_crash, _detail}), do: {:embedding_crash, :exception}
+
+  # A RAW provider body (the ONLY key-bearing shape besides {:api_error, ...}) can
+  # only arrive as a bare string or a decoded JSON map — collapse both (review #6).
+  # Structs are maps, but a struct only reaches here bare (never a domain error,
+  # which is always a TUPLE); collapsing a stray bare struct body is correct.
+  def sanitize(body) when is_binary(body) or is_map(body), do: :provider_error
+
+  # Bare atoms and structured domain-error tuples are key-free — preserve them.
   def sanitize(other), do: other
 
   @doc """

--- a/lib/loopctl/llm/provider_error.ex
+++ b/lib/loopctl/llm/provider_error.ex
@@ -1,0 +1,47 @@
+defmodule Loopctl.Llm.ProviderError do
+  @moduledoc """
+  Shared, vendor-agnostic sanitizer for external LLM/embedding provider errors.
+
+  Provider error RESPONSE BODIES routinely echo a masked fragment of the caller's
+  API key (e.g. OpenAI's `"Incorrect API key provided: sk-...ZXY"`). If that raw
+  body is returned as an Oban `{:error, reason}` it is persisted verbatim into
+  `oban_jobs.errors` (a table without `tenant_llm_settings`' access controls, and
+  already surfaced to tenants via `Knowledge.list_extraction_errors/2`), and if it
+  is `inspect/1`-ed into a log line it leaks there too.
+
+  `sanitize/1` returns a bounded, VALUE-FREE representation — it drops the body,
+  keeping only the status (for retry/breaker classification). It is arity-preserving
+  for the `{:api_error, status, body}` shape so existing 3-tuple matches keep working.
+  Apply it at the boundary in BOTH `Loopctl.Llm.Anthropic` and
+  `Loopctl.Knowledge.EmbeddingClient` so nothing downstream ever sees a raw body.
+  """
+
+  @typedoc "A sanitized, value-free provider error term."
+  @type t :: {:api_error, integer(), :provider_error} | term()
+
+  @doc """
+  Strip any provider response body, preserving only the status. Non-`api_error`
+  terms pass through unchanged (transport reasons / atoms carry no secret).
+  """
+  @spec sanitize(term()) :: t()
+  def sanitize({:api_error, status, _body}) when is_integer(status),
+    do: {:api_error, status, :provider_error}
+
+  def sanitize({:api_error, status}) when is_integer(status),
+    do: {:api_error, status, :provider_error}
+
+  def sanitize(other), do: other
+
+  @doc """
+  A short, log-safe tag for a provider error (never includes a body). Accepts a
+  bare error term or an `{:error, term}` tuple.
+  """
+  @spec log_tag(term()) :: String.t()
+  def log_tag({:error, inner}), do: log_tag(inner)
+  def log_tag({:api_error, status, _}), do: "api_error status=#{status}"
+  def log_tag({:api_error, status}), do: "api_error status=#{status}"
+  def log_tag({:request_failed, _}), do: "request_failed"
+  def log_tag({:embedding_crash, _}), do: "embedding_crash"
+  def log_tag(atom) when is_atom(atom), do: to_string(atom)
+  def log_tag(_other), do: "provider_error"
+end

--- a/lib/loopctl/workers/article_embedding_worker.ex
+++ b/lib/loopctl/workers/article_embedding_worker.ex
@@ -99,6 +99,10 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
         skip_no_embedding_key(tenant_id, article_id)
 
       {:error, reason} ->
+        # Classify on the raw reason, but the term that becomes an Oban discard/error
+        # reason (-> oban_jobs.errors) is SANITIZED (review #5/#6) — never a raw body.
+        sanitized = ProviderError.sanitize(reason)
+
         if Llm.permanent_provider_error?(reason) do
           # A revoked/invalid tenant key (4xx) will never succeed on retry (review #5).
           Logger.debug(
@@ -106,9 +110,9 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
               "embedding error (#{ProviderError.log_tag(reason)}); discarding."
           )
 
-          {:discard, {:embedding_permanent_error, reason}}
+          {:discard, {:embedding_permanent_error, sanitized}}
         else
-          {:error, reason}
+          {:error, sanitized}
         end
     end
   end

--- a/lib/loopctl/workers/article_embedding_worker.ex
+++ b/lib/loopctl/workers/article_embedding_worker.ex
@@ -9,16 +9,23 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
 
   ## Flow
 
-  1. Fetch the article by `article_id` + `tenant_id`
+  1. Fetch the article (with its embedding + content-hash) by `article_id` + `tenant_id`
   2. If article was deleted, return `:ok` (no-op)
   3. Build embedding text: `"{title}\\n\\n{body}"` truncated to 32K chars
-  4. Call `@embedding_client.generate_embedding/2` (threads `tenant_id`)
-  5. On success, store via `Knowledge.update_embedding/3`
+  4. IDEMPOTENCY (review #12): if the article already carries an embedding whose
+     stored content-hash matches the current content, skip the paid provider call
+     entirely (re-ensure linking, return `:ok`). This stops an Oban retry after a
+     post-embed failure from re-billing the tenant for identical content.
+  5. Otherwise generate via the GUARDED `Knowledge.generate_embedding/3` (review #4:
+     tenant-scoped circuit breaker + timeout) and store via `Knowledge.update_embedding/4`
   6. On `{:error, :no_api_key}` (mandatory BYO — the tenant has no embedding key),
      `{:discard, {:no_embedding_key, article_id}}` — a CLEAN skip: no crash, no
      retry, no operator-key fallback. The article stays created; it is simply not
      vector-searchable until the tenant configures a key.
-  7. On any other failure, return `{:error, reason}` for Oban retry
+  7. On a PERMANENT provider error (a 4xx other than 408/429 — bad/revoked key),
+     `{:discard, {:embedding_permanent_error, _}}` (review #5): retrying a revoked
+     key 3× is pointless. Transient errors (5xx / network / timeout / circuit-open)
+     return `{:error, reason}` for Oban retry.
 
   ## Retry Strategy
 
@@ -30,12 +37,6 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
   Unique per `article_id` within a 300-second window. If a new job is
   inserted for the same article while one is pending, it replaces the
   existing job.
-
-  ## Linking (AC-20.3.13)
-
-  Once `Loopctl.Workers.ArticleLinkingWorker` (US-21.2) is implemented,
-  this worker should enqueue it on successful embedding. Add the enqueue
-  call inside `generate_and_store/3` after `update_embedding` succeeds.
   """
 
   use Oban.Worker,
@@ -47,19 +48,20 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
   require Logger
 
   alias Loopctl.Knowledge
+  alias Loopctl.Llm
+  alias Loopctl.Llm.ProviderError
   alias Loopctl.Workers.ArticleLinkingWorker
 
-  @embedding_client Application.compile_env(
-                      :loopctl,
-                      :embedding_client,
-                      Loopctl.Knowledge.EmbeddingClient
-                    )
-
+  # Longer Task.yield budget than the interactive query path: a background embed can
+  # afford a little more headroom, but still bounded so a wedged provider can't pin a
+  # worker. The client itself caps a single attempt at ~4s (no client retries), so
+  # this only adds slack for scheduling/DB.
+  @worker_yield_ms 8_000
   @max_text_length 32_000
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"article_id" => article_id, "tenant_id" => tenant_id}}) do
-    case Knowledge.get_article(tenant_id, article_id) do
+    case Knowledge.get_article_with_embedding(tenant_id, article_id) do
       {:error, :not_found} ->
         # Article deleted -- no-op
         :ok
@@ -76,31 +78,71 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
 
   defp generate_and_store(article, tenant_id, article_id) do
     text = build_embedding_text(article)
+    content_hash = content_hash(text)
 
-    case @embedding_client.generate_embedding(tenant_id, text) do
+    if already_embedded?(article, content_hash) do
+      # Idempotent no-op: this exact content is already embedded (review #12). Ensure
+      # linking is (re-)enqueued and finish — never re-call the paid provider.
+      enqueue_linking(article_id, tenant_id)
+      :ok
+    else
+      generate(tenant_id, article_id, text, content_hash)
+    end
+  end
+
+  defp generate(tenant_id, article_id, text, content_hash) do
+    case Knowledge.generate_embedding(tenant_id, text, timeout: @worker_yield_ms) do
       {:ok, embedding} ->
-        with {:ok, _article} <- Knowledge.update_embedding(tenant_id, article_id, embedding) do
-          enqueue_linking(article_id, tenant_id)
-          :ok
-        end
+        store(tenant_id, article_id, embedding, content_hash)
 
       {:error, :no_api_key} ->
         skip_no_embedding_key(tenant_id, article_id)
 
       {:error, reason} ->
-        {:error, reason}
+        if Llm.permanent_provider_error?(reason) do
+          # A revoked/invalid tenant key (4xx) will never succeed on retry (review #5).
+          Logger.debug(
+            "ArticleEmbeddingWorker: tenant=#{tenant_id} article=#{article_id} permanent " <>
+              "embedding error (#{ProviderError.log_tag(reason)}); discarding."
+          )
+
+          {:discard, {:embedding_permanent_error, reason}}
+        else
+          {:error, reason}
+        end
     end
   end
 
+  defp store(tenant_id, article_id, embedding, content_hash) do
+    with {:ok, _article} <-
+           Knowledge.update_embedding(tenant_id, article_id, embedding, content_hash) do
+      enqueue_linking(article_id, tenant_id)
+      :ok
+    end
+  end
+
+  defp already_embedded?(%{embedding: embedding, embedding_content_hash: hash}, content_hash)
+       when not is_nil(embedding) and is_binary(hash),
+       do: hash == content_hash
+
+  defp already_embedded?(_article, _content_hash), do: false
+
+  defp content_hash(text) do
+    :sha256 |> :crypto.hash(text) |> Base.encode16(case: :lower)
+  end
+
   # Mandatory BYO: the tenant has no embedding key. Cleanly DISCARD (no retry, no
-  # crash, no operator-key fallback) with a distinct, queryable reason + a
-  # telemetry signal so the keyless-tenant volume is observable.
+  # crash, no operator-key fallback) with a distinct, queryable reason + a telemetry
+  # signal AND an audit entry (review #9) so the keyless-tenant volume is observable
+  # and consistent with the Anthropic mandatory-BYO path.
   defp skip_no_embedding_key(tenant_id, article_id) do
     :telemetry.execute(
       [:loopctl, :embedding, :skipped_no_key],
       %{count: 1},
       %{tenant_id: tenant_id, article_id: article_id}
     )
+
+    Llm.record_blocked(tenant_id, :embedding)
 
     Logger.debug(
       "ArticleEmbeddingWorker: tenant=#{tenant_id} article=#{article_id} skipped — no " <>

--- a/lib/loopctl/workers/content_ingestion_worker.ex
+++ b/lib/loopctl/workers/content_ingestion_worker.ex
@@ -51,6 +51,7 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.ContentChunker
   alias Loopctl.Llm
+  alias Loopctl.Llm.ProviderError
   alias Loopctl.Net.UrlGuard
   alias Loopctl.Workers.ArticleEmbeddingWorker
 
@@ -407,7 +408,11 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   end
 
   defp finalize_errors(errors, inserted, persisted, attempted) do
-    first = errors |> Enum.reverse() |> List.first()
+    # Sanitize the representative error BEFORE it becomes an Oban reason / log line
+    # (review #5): a provider `{:api_error, _, body}` can echo a masked key fragment,
+    # and these reasons land in oban_jobs.errors (surfaced by list_extraction_errors).
+    # Classification below runs on the RAW errors (it needs the status/Postgrex code).
+    first = errors |> Enum.reverse() |> List.first() |> ProviderError.sanitize()
 
     if Enum.all?(errors, &permanent_error?/1) do
       # No transient error a retry could clear — {:discard} (no infinite retry);

--- a/lib/loopctl/workers/review_knowledge_worker.ex
+++ b/lib/loopctl/workers/review_knowledge_worker.ex
@@ -41,6 +41,7 @@ defmodule Loopctl.Workers.ReviewKnowledgeWorker do
   alias Loopctl.Audit
   alias Loopctl.Knowledge.Article
   alias Loopctl.Llm
+  alias Loopctl.Llm.ProviderError
 
   @extractor Application.compile_env(
                :loopctl,
@@ -118,8 +119,12 @@ defmodule Loopctl.Workers.ReviewKnowledgeWorker do
     classify_result(result)
   end
 
-  defp classify_result({:error, reason} = err) do
-    if permanent_error?(reason), do: {:discard, reason}, else: err
+  defp classify_result({:error, reason}) do
+    # Classify on the RAW reason (needs status), but SANITIZE what becomes the Oban
+    # reason (review #5): a provider api_error body can echo a masked key fragment,
+    # and both {:discard,_}/{:error,_} reasons are persisted into oban_jobs.errors.
+    sanitized = ProviderError.sanitize(reason)
+    if permanent_error?(reason), do: {:discard, sanitized}, else: {:error, sanitized}
   end
 
   defp classify_result(other), do: other

--- a/lib/loopctl_web/controllers/knowledge_search_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_search_controller.ex
@@ -595,12 +595,33 @@ defmodule LoopctlWeb.KnowledgeSearchController do
 
   defp execute_search(tenant_id, {:search, q}, "semantic", opts) do
     case Knowledge.generate_embedding(tenant_id, q) do
-      {:ok, embedding} -> Knowledge.search_semantic(tenant_id, embedding, opts)
-      {:error, _} -> {:error, :embedding_unavailable}
+      {:ok, embedding} ->
+        Knowledge.search_semantic(tenant_id, embedding, opts)
+
+      {:error, :no_api_key} ->
+        # Mandatory BYO (review #8): a keyless tenant's explicit semantic search must
+        # NOT 503. Degrade to keyword-only with `fallback: true`, mirroring combined.
+        semantic_keyword_fallback(tenant_id, q, opts)
+
+      {:error, _} ->
+        {:error, :embedding_unavailable}
     end
   end
 
   defp execute_search(tenant_id, {:search, q}, "combined", opts) do
     Knowledge.search_combined(tenant_id, q, opts)
+  end
+
+  # Keyword-only degrade for a keyless-tenant semantic request: same shape as the
+  # combined-search fallback so clients can detect it via `meta.fallback` /
+  # `meta.search_mode`.
+  defp semantic_keyword_fallback(tenant_id, q, opts) do
+    case Knowledge.search_keyword(tenant_id, q, opts) do
+      {:ok, %{meta: meta} = result} ->
+        {:ok, %{result | meta: Map.merge(meta, %{fallback: true, search_mode: "keyword_only"})}}
+
+      other ->
+        other
+    end
   end
 end

--- a/priv/repo/migrations/20260703093000_add_embedding_content_hash_to_articles.exs
+++ b/priv/repo/migrations/20260703093000_add_embedding_content_hash_to_articles.exs
@@ -1,0 +1,21 @@
+defmodule Loopctl.Repo.Migrations.AddEmbeddingContentHashToArticles do
+  @moduledoc """
+  Idempotency key for article embedding generation (BYO embeddings review #12).
+
+  Stores the SHA-256 hex digest of the exact text that was embedded (title + body,
+  truncated) alongside the vector. `ArticleEmbeddingWorker` skips re-calling the
+  (paid) provider on an Oban retry when the article already carries an embedding
+  whose stored content-hash matches the current content — so a retry after a
+  post-embed failure never re-bills the tenant for identical content.
+
+  Nullable, no backfill: existing articles simply have `NULL` until their next
+  embedding refresh.
+  """
+  use Ecto.Migration
+
+  def change do
+    alter table(:articles) do
+      add :embedding_content_hash, :string, null: true
+    end
+  end
+end

--- a/test/loopctl/knowledge/embedding_client_test.exs
+++ b/test/loopctl/knowledge/embedding_client_test.exs
@@ -89,20 +89,49 @@ defmodule Loopctl.Knowledge.EmbeddingClientTest do
     refute_received {:auth, ["Bearer test-openai-key-BBBB"]}
   end
 
-  test "never logs the embedding api_key (success + error branches)" do
+  test "never logs the embedding api_key on the SUCCESS branch (review #14)" do
     tenant = fixture(:tenant)
-    secret = "test-openai-key-NEVERLOG-#{System.unique_integer([:positive])}"
+    secret = "test-openai-key-SUCCESS-NEVERLOG-#{System.unique_integer([:positive])}"
     set_embedding_key(tenant, secret)
 
     Req.Test.stub(EmbeddingClient, fn conn ->
-      conn |> Plug.Conn.put_status(500) |> Req.Test.json(%{"error" => "boom"})
+      Req.Test.json(conn, %{
+        "data" => [%{"embedding" => [0.5, 0.5]}],
+        "usage" => %{"prompt_tokens" => 3, "total_tokens" => 3}
+      })
     end)
 
     log =
       capture_log(fn ->
-        assert {:error, {:api_error, 500, _}} = EmbeddingClient.generate_embedding(tenant.id, "x")
+        assert {:ok, [0.5, 0.5]} = EmbeddingClient.generate_embedding(tenant.id, "x")
       end)
 
     refute log =~ secret
+  end
+
+  test "never logs the embedding api_key on the error branch, and DROPS the body (review #3)" do
+    tenant = fixture(:tenant)
+    secret = "test-openai-key-NEVERLOG-#{System.unique_integer([:positive])}"
+    set_embedding_key(tenant, secret)
+
+    # A realistic OpenAI 401 body that echoes a masked key fragment — it must never
+    # reach the returned error term (which becomes an Oban error) nor the logs.
+    masked = "test-openai-...ZXY9"
+
+    Req.Test.stub(EmbeddingClient, fn conn ->
+      conn
+      |> Plug.Conn.put_status(401)
+      |> Req.Test.json(%{"error" => %{"message" => "Incorrect API key provided: #{masked}"}})
+    end)
+
+    log =
+      capture_log(fn ->
+        # Sanitized: value-free {:api_error, 401, :provider_error} — no body.
+        assert {:error, {:api_error, 401, :provider_error}} =
+                 EmbeddingClient.generate_embedding(tenant.id, "x")
+      end)
+
+    refute log =~ secret
+    refute log =~ masked
   end
 end

--- a/test/loopctl/knowledge_semantic_search_test.exs
+++ b/test/loopctl/knowledge_semantic_search_test.exs
@@ -727,6 +727,33 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
       # ...but B is completely unaffected — its breaker is independent.
       assert {:ok, _vec} = Knowledge.generate_embedding(b.id, "q")
     end
+
+    test "concurrent failures for one tenant reliably open the breaker (atomic window #2)" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, {:api_error, 500, :provider_error}}
+      end)
+
+      # Fire many failures for the SAME tenant CONCURRENTLY. With a non-atomic
+      # window reset (the pre-fix TOCTOU) a parallel reset-to-0 could wipe an
+      # increment and delay the breaker; the period-keyed atomic counter must count
+      # them all and open reliably.
+      1..12
+      |> Task.async_stream(fn _ -> Knowledge.generate_embedding(tenant.id, "q") end,
+        max_concurrency: 8,
+        timeout: 10_000
+      )
+      |> Stream.run()
+
+      # Even a single successful call now must be short-circuited — the breaker is open.
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:ok, make_embedding(:query)}
+      end)
+
+      assert {:error, :circuit_open} = Knowledge.generate_embedding(tenant.id, "q")
+    end
   end
 
   # --- Score normalization edge case ---

--- a/test/loopctl/knowledge_semantic_search_test.exs
+++ b/test/loopctl/knowledge_semantic_search_test.exs
@@ -388,7 +388,7 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
     test "falls back to keyword-only when embedding generation fails" do
       %{tenant: tenant} = setup_tenant()
 
-      Knowledge.reset_circuit_breaker()
+      Knowledge.reset_circuit_breaker(tenant.id)
 
       fixture(:article, %{
         tenant_id: tenant.id,
@@ -451,7 +451,7 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
     test "accepts weights that sum to 1.0 within tolerance" do
       %{tenant: tenant} = setup_tenant()
 
-      Knowledge.reset_circuit_breaker()
+      Knowledge.reset_circuit_breaker(tenant.id)
 
       fixture(:article, %{
         tenant_id: tenant.id,
@@ -493,7 +493,7 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
     test "semantic-heavy weight favors semantically close results" do
       %{tenant: tenant} = setup_tenant()
 
-      Knowledge.reset_circuit_breaker()
+      Knowledge.reset_circuit_breaker(tenant.id)
 
       # "Exact Match" has keyword match on "deployment" + far embedding
       _exact_match =
@@ -570,7 +570,7 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
     test "falls back after 3 consecutive failures within 60 seconds" do
       %{tenant: tenant} = setup_tenant()
 
-      Knowledge.reset_circuit_breaker()
+      Knowledge.reset_circuit_breaker(tenant.id)
 
       fixture(:article, %{
         tenant_id: tenant.id,
@@ -599,7 +599,7 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
     test "circuit breaker resets after success" do
       %{tenant: tenant} = setup_tenant()
 
-      Knowledge.reset_circuit_breaker()
+      Knowledge.reset_circuit_breaker(tenant.id)
 
       fixture(:article, %{
         tenant_id: tenant.id,
@@ -636,13 +636,106 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
     end
   end
 
+  # --- Per-tenant circuit breaker + error classification (BYO review #1/#6) ---
+
+  describe "generate_embedding/3 - per-tenant circuit breaker" do
+    test "a keyless tenant's :no_api_key NEVER trips the breaker" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, :no_api_key}
+      end)
+
+      for _i <- 1..5 do
+        assert {:error, :no_api_key} = Knowledge.generate_embedding(tenant.id, "q")
+      end
+
+      # A subsequent successful call still reaches the client — proving the breaker
+      # was never opened by the config-gap errors (an open breaker would short-circuit
+      # to {:error, :circuit_open} WITHOUT calling the client).
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:ok, make_embedding(:query)}
+      end)
+
+      assert {:ok, _vec} = Knowledge.generate_embedding(tenant.id, "q")
+    end
+
+    test "a 4xx (per-tenant credential/quota) NEVER trips the breaker" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, {:api_error, 401, :provider_error}}
+      end)
+
+      for _i <- 1..5 do
+        assert {:error, {:api_error, 401, _}} = Knowledge.generate_embedding(tenant.id, "q")
+      end
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:ok, make_embedding(:query)}
+      end)
+
+      assert {:ok, _vec} = Knowledge.generate_embedding(tenant.id, "q")
+    end
+
+    test "5xx failures DO open the breaker (and short-circuit further calls)" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, {:api_error, 500, :provider_error}}
+      end)
+
+      for _i <- 1..3 do
+        assert {:error, {:api_error, 500, _}} = Knowledge.generate_embedding(tenant.id, "q")
+      end
+
+      # Breaker is now open for THIS tenant: the next call short-circuits without
+      # touching the client (which would otherwise return {:ok, _}).
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:ok, make_embedding(:query)}
+      end)
+
+      assert {:error, :circuit_open} = Knowledge.generate_embedding(tenant.id, "q")
+    end
+
+    test "tenant A's 5xx failures do NOT degrade tenant B's search (the #1 repro)" do
+      %{tenant: a} = setup_tenant()
+      %{tenant: b} = setup_tenant()
+      Knowledge.reset_circuit_breaker(a.id)
+      Knowledge.reset_circuit_breaker(b.id)
+
+      # A always 5xx-fails; B always succeeds.
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn tenant_id, _text ->
+        if tenant_id == a.id do
+          {:error, {:api_error, 500, :provider_error}}
+        else
+          {:ok, make_embedding(:query)}
+        end
+      end)
+
+      # Trip A's breaker.
+      for _i <- 1..3 do
+        assert {:error, {:api_error, 500, _}} = Knowledge.generate_embedding(a.id, "q")
+      end
+
+      # A is now circuit-open...
+      assert {:error, :circuit_open} = Knowledge.generate_embedding(a.id, "q")
+
+      # ...but B is completely unaffected — its breaker is independent.
+      assert {:ok, _vec} = Knowledge.generate_embedding(b.id, "q")
+    end
+  end
+
   # --- Score normalization edge case ---
 
   describe "score normalization" do
     test "all equal scores normalize to 1.0" do
       %{tenant: tenant} = setup_tenant()
 
-      Knowledge.reset_circuit_breaker()
+      Knowledge.reset_circuit_breaker(tenant.id)
 
       # Create multiple articles with identical embeddings
       for i <- 1..3 do
@@ -689,7 +782,7 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
     test "combined search includes search_mode: combined on success" do
       %{tenant: tenant} = setup_tenant()
 
-      Knowledge.reset_circuit_breaker()
+      Knowledge.reset_circuit_breaker(tenant.id)
 
       fixture(:article, %{
         tenant_id: tenant.id,
@@ -709,7 +802,7 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
     test "combined search includes search_mode: keyword_only on fallback" do
       %{tenant: tenant} = setup_tenant()
 
-      Knowledge.reset_circuit_breaker()
+      Knowledge.reset_circuit_breaker(tenant.id)
 
       fixture(:article, %{
         tenant_id: tenant.id,
@@ -847,7 +940,7 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
         {:ok, make_embedding(:query)}
       end)
 
-      Knowledge.reset_circuit_breaker()
+      Knowledge.reset_circuit_breaker(tenant.id)
 
       {:ok, %{meta: meta}} = Knowledge.search_combined(tenant.id, "hub")
 

--- a/test/loopctl/llm/anthropic_test.exs
+++ b/test/loopctl/llm/anthropic_test.exs
@@ -38,15 +38,45 @@ defmodule Loopctl.Llm.AnthropicTest do
     refute log =~ @secret
   end
 
-  test "never logs the api_key on the 200-unexpected-shape branch" do
+  test "sanitizes the 200-unexpected-shape body (never leaks a key fragment) (review CRIT #1)" do
     tenant = tenant_with_key()
 
+    # A misconfigured/compromised endpoint can return HTTP 200 with an error-shaped
+    # body echoing a masked key fragment. The 200-shape branch must sanitize it just
+    # like a non-200 — the returned term is value-free and the fragment never leaks
+    # (into the error term that becomes an Oban reason, nor the log).
+    masked = "sk-ant-...LEAK200"
+
     Req.Test.stub(Loopctl.Llm.Anthropic, fn conn ->
-      Req.Test.json(conn, %{"unexpected" => true})
+      Req.Test.json(conn, %{"error" => %{"message" => "Invalid x-api-key header: #{masked}"}})
     end)
 
-    log = capture_log(fn -> assert {:error, {:api_error, 200, _}} = run(tenant) end)
+    log =
+      capture_log(fn ->
+        assert {:error, {:api_error, 200, :provider_error}} = run(tenant)
+      end)
+
     refute log =~ @secret
+    refute log =~ masked
+  end
+
+  test "sanitizes the non-200 body to the exact value-free term (review #11)" do
+    tenant = tenant_with_key()
+    masked = "sk-ant-...LEAK401"
+
+    Req.Test.stub(Loopctl.Llm.Anthropic, fn conn ->
+      conn
+      |> Plug.Conn.put_status(401)
+      |> Req.Test.json(%{"error" => %{"message" => "Invalid x-api-key header: #{masked}"}})
+    end)
+
+    log =
+      capture_log(fn ->
+        assert {:error, {:api_error, 401, :provider_error}} = run(tenant)
+      end)
+
+    refute log =~ @secret
+    refute log =~ masked
   end
 
   test "never logs the api_key on the non-200 branch" do

--- a/test/loopctl/llm/provider_error_test.exs
+++ b/test/loopctl/llm/provider_error_test.exs
@@ -1,0 +1,71 @@
+defmodule Loopctl.Llm.ProviderErrorTest do
+  @moduledoc """
+  The shared provider-error sanitizer is the single chokepoint that keeps a masked
+  API-key fragment (echoed in a provider error body) out of logs and
+  `oban_jobs.errors`. It MUST be value-free for EVERY input shape (review #6).
+  """
+  use ExUnit.Case, async: true
+
+  alias Loopctl.Llm.ProviderError
+
+  describe "sanitize/1" do
+    test "drops the api_error body but keeps the status" do
+      body = %{"error" => %{"message" => "Incorrect API key provided: test-openai-...ZXY9"}}
+      assert ProviderError.sanitize({:api_error, 401, body}) == {:api_error, 401, :provider_error}
+
+      assert ProviderError.sanitize({:api_error, 500, "raw"}) ==
+               {:api_error, 500, :provider_error}
+
+      assert ProviderError.sanitize({:api_error, 200, body}) == {:api_error, 200, :provider_error}
+      refute inspect(ProviderError.sanitize({:api_error, 401, body})) =~ "ZXY9"
+    end
+
+    test "collapses the 2-tuple api_error form" do
+      assert ProviderError.sanitize({:api_error, 429}) == {:api_error, 429, :provider_error}
+    end
+
+    test "collapses transport + crash payloads to a value-free tag" do
+      assert ProviderError.sanitize({:request_failed, %{secret: "x"}}) ==
+               {:request_failed, :transport_error}
+
+      assert ProviderError.sanitize({:embedding_crash, "boom sk-leak"}) ==
+               {:embedding_crash, :exception}
+    end
+
+    test "preserves bare atoms (they cannot carry a secret)" do
+      assert ProviderError.sanitize(:timeout) == :timeout
+      assert ProviderError.sanitize(:circuit_open) == :circuit_open
+      assert ProviderError.sanitize(:no_api_key) == :no_api_key
+    end
+
+    test "collapses a BARE provider body (string or map) — the #6 key-bearing shapes" do
+      # The only key-bearing shapes besides {:api_error,...}: a raw string body or a
+      # decoded JSON map body. Both must collapse — never pass through.
+      assert ProviderError.sanitize("Invalid x-api-key: sk-ant-...WXYZ") == :provider_error
+      assert ProviderError.sanitize(%{"error" => "sk-ant-...WXYZ"}) == :provider_error
+
+      for term <- ["Invalid x-api-key: sk-ant-...WXYZ", %{"error" => "sk-ant-...WXYZ"}] do
+        refute term |> ProviderError.sanitize() |> inspect() =~ "WXYZ"
+      end
+    end
+
+    test "PRESERVES structured domain-error tuples (they carry no key)" do
+      # Must NOT collapse — replacing e.g. an insert-failed reason with a misleading
+      # :provider_error would hurt operators, and these carry no secret.
+      assert ProviderError.sanitize({:url_blocked, :blocked_ip}) == {:url_blocked, :blocked_ip}
+
+      assert ProviderError.sanitize({:insert_failed, :article, :some_changeset}) ==
+               {:insert_failed, :article, :some_changeset}
+    end
+  end
+
+  describe "log_tag/1" do
+    test "never includes a body and unwraps {:error, _}" do
+      body = %{"error" => "Incorrect API key: test-openai-...ZXY9"}
+      assert ProviderError.log_tag({:api_error, 401, body}) == "api_error status=401"
+      assert ProviderError.log_tag({:error, {:api_error, 500, body}}) == "api_error status=500"
+      assert ProviderError.log_tag({:request_failed, %{secret: "x"}}) == "request_failed"
+      refute ProviderError.log_tag({:api_error, 401, body}) =~ "ZXY9"
+    end
+  end
+end

--- a/test/loopctl/llm_test.exs
+++ b/test/loopctl/llm_test.exs
@@ -7,6 +7,7 @@ defmodule Loopctl.LlmTest do
   alias Loopctl.Llm.TenantLlmSettings
 
   import Ecto.Query
+  import ExUnit.CaptureLog
 
   describe "upsert_settings/2 + resolve/2" do
     test "stores models + key and resolves the per-operation model + decrypted key" do
@@ -467,6 +468,26 @@ defmodule Loopctl.LlmTest do
       assert %{data: []} = Llm.usage_summary(a.id, [])
       %{data: rows_b} = Llm.usage_summary(b.id, [])
       assert Enum.any?(rows_b, &(&1.operation == :embedding))
+    end
+  end
+
+  describe "record_blocked/2 log text names the right credential (review #3)" do
+    test ":embedding names the embedding key, not the Anthropic key" do
+      tenant = fixture(:tenant)
+
+      log = capture_log(fn -> assert :ok = Llm.record_blocked(tenant.id, :embedding) end)
+
+      assert log =~ "no embedding API key configured"
+      refute log =~ "no Anthropic API key configured"
+    end
+
+    test "an Anthropic operation names the Anthropic key" do
+      tenant = fixture(:tenant)
+
+      log = capture_log(fn -> assert :ok = Llm.record_blocked(tenant.id, :extraction) end)
+
+      assert log =~ "no Anthropic API key configured"
+      refute log =~ "no embedding API key configured"
     end
   end
 end

--- a/test/loopctl/workers/article_embedding_worker_test.exs
+++ b/test/loopctl/workers/article_embedding_worker_test.exs
@@ -335,22 +335,43 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorkerTest do
 
   # --- Mandatory BYO: a keyless tenant gets a clean discard, never a crash ---
 
+  defp create_draft_then_publish(tenant_id, attrs) do
+    {:ok, article} =
+      Knowledge.create_article(
+        tenant_id,
+        Map.merge(%{category: :pattern, status: :draft}, attrs)
+      )
+
+    article
+    |> Ecto.Changeset.change(%{status: :published})
+    |> Loopctl.AdminRepo.update!()
+  end
+
   describe "mandatory BYO embeddings" do
-    test "discards {:no_embedding_key, id} when the tenant has no embedding key" do
+    test "discards {:no_embedding_key, id} + emits telemetry when the tenant has no key" do
       %{tenant: tenant} = setup_tenant()
 
-      {:ok, article} =
-        Knowledge.create_article(tenant.id, %{
+      article =
+        create_draft_then_publish(tenant.id, %{
           title: "Keyless Tenant Article",
-          body: "This tenant configured no embedding key.",
-          category: :pattern,
-          status: :draft
+          body: "This tenant configured no embedding key."
         })
 
-      article =
-        article
-        |> Ecto.Changeset.change(%{status: :published})
-        |> Loopctl.AdminRepo.update!()
+      # Attach a telemetry handler and assert the skip signal fires with tenant_id (#15).
+      ref = make_ref()
+      handler_id = "test-skip-#{inspect(ref)}"
+      parent = self()
+
+      :telemetry.attach(
+        handler_id,
+        [:loopctl, :embedding, :skipped_no_key],
+        fn _event, measurements, metadata, _cfg ->
+          send(parent, {:telemetry, ref, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
 
       # The embedding client refuses to call the provider for a keyless tenant.
       expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
@@ -364,9 +385,92 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorkerTest do
 
       assert article_id == article.id
 
+      assert_received {:telemetry, ^ref, %{count: 1}, %{tenant_id: tenant_id}}
+      assert tenant_id == tenant.id
+
       # No embedding was stored (the article stays created, just not vector-searchable).
       {:ok, loaded} = Knowledge.get_article_with_embedding(tenant.id, article.id)
       assert loaded.embedding == nil
+    end
+  end
+
+  # --- Permanent-error discard: a revoked/invalid key (4xx) isn't retried (#5) ---
+
+  describe "permanent provider errors" do
+    test "discards on a 4xx (bad/revoked key) instead of retrying" do
+      %{tenant: tenant} = setup_tenant()
+
+      article =
+        create_draft_then_publish(tenant.id, %{
+          title: "Revoked Key Article",
+          body: "The tenant's embedding key was revoked."
+        })
+
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, {:api_error, 401, :provider_error}}
+      end)
+
+      assert {:discard, {:embedding_permanent_error, {:api_error, 401, _}}} =
+               ArticleEmbeddingWorker.perform(%Oban.Job{
+                 args: %{"article_id" => article.id, "tenant_id" => tenant.id}
+               })
+    end
+
+    test "retries (returns {:error, _}) on a transient 5xx" do
+      %{tenant: tenant} = setup_tenant()
+
+      article =
+        create_draft_then_publish(tenant.id, %{
+          title: "Transient Error Article",
+          body: "The provider had a hiccup."
+        })
+
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, {:api_error, 500, :provider_error}}
+      end)
+
+      assert {:error, {:api_error, 500, _}} =
+               ArticleEmbeddingWorker.perform(%Oban.Job{
+                 args: %{"article_id" => article.id, "tenant_id" => tenant.id}
+               })
+    end
+  end
+
+  # --- Idempotency: a retry with unchanged content never re-calls the provider (#12) ---
+
+  describe "idempotent re-runs" do
+    test "skips the paid provider when the article is already embedded for this content" do
+      %{tenant: tenant} = setup_tenant()
+
+      article =
+        create_draft_then_publish(tenant.id, %{
+          title: "Already Embedded Article",
+          body: "Content that will be embedded exactly once."
+        })
+
+      # First run: the provider IS called (exactly once) and the embedding is stored.
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, 1, fn _tenant_id, _text ->
+        {:ok, List.duplicate(0.25, 1536)}
+      end)
+
+      assert :ok =
+               ArticleEmbeddingWorker.perform(%Oban.Job{
+                 args: %{"article_id" => article.id, "tenant_id" => tenant.id}
+               })
+
+      # Second run (a retry for the SAME content): the provider must NOT be called
+      # again — the stored content-hash matches, so it's an idempotent no-op.
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, 0, fn _tenant_id, _text ->
+        flunk("provider must not be re-called for already-embedded content")
+      end)
+
+      assert :ok =
+               ArticleEmbeddingWorker.perform(%Oban.Job{
+                 args: %{"article_id" => article.id, "tenant_id" => tenant.id}
+               })
+
+      {:ok, loaded} = Knowledge.get_article_with_embedding(tenant.id, article.id)
+      assert loaded.embedding != nil
     end
   end
 end

--- a/test/loopctl/workers/article_embedding_worker_test.exs
+++ b/test/loopctl/workers/article_embedding_worker_test.exs
@@ -86,14 +86,20 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorkerTest do
         |> Ecto.Changeset.change(%{status: :published})
         |> Loopctl.AdminRepo.update!()
 
+      # A transient 5xx whose body echoes a key fragment: the worker retries
+      # ({:error, _}) but the reason that lands in oban_jobs.errors is SANITIZED
+      # (review #5) — the body is dropped, only the status remains.
       expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
-        {:error, {:api_error, 500, "Internal Server Error"}}
+        {:error, {:api_error, 500, "Internal Server Error: key sk-...LEAK"}}
       end)
 
-      assert {:error, {:api_error, 500, "Internal Server Error"}} =
-               ArticleEmbeddingWorker.perform(%Oban.Job{
-                 args: %{"article_id" => article.id, "tenant_id" => tenant.id}
-               })
+      result =
+        ArticleEmbeddingWorker.perform(%Oban.Job{
+          args: %{"article_id" => article.id, "tenant_id" => tenant.id}
+        })
+
+      assert {:error, {:api_error, 500, :provider_error}} = result
+      refute inspect(result) =~ "LEAK"
     end
   end
 

--- a/test/loopctl/workers/content_ingestion_worker_test.exs
+++ b/test/loopctl/workers/content_ingestion_worker_test.exs
@@ -390,25 +390,60 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
   # --- Extractor failure ---
 
   describe "perform/1 extractor failure" do
-    test "propagates error when extractor fails" do
+    test "propagates a transient error, sanitized (no provider body reaches the Oban reason)" do
       %{tenant: tenant} = setup_tenant()
+      masked = "sk-ant-...5XX-LEAK"
 
       expect(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id,
                                                                      _content,
                                                                      _opts ->
-        {:error, {:api_error, 500, "Internal Server Error"}}
+        {:error, {:api_error, 500, "upstream error echoing key #{masked}"}}
       end)
 
-      assert {:error, {:api_error, 500, "Internal Server Error"}} =
-               ContentIngestionWorker.perform(%Oban.Job{
-                 id: 105,
-                 args: %{
-                   "tenant_id" => tenant.id,
-                   "content" => "Failing content",
-                   "content_hash" => "fail_test",
-                   "source_type" => "ingestion"
-                 }
-               })
+      # The 500 is transient -> {:error, _} (Oban retry), but the reason that lands
+      # in oban_jobs.errors is SANITIZED (review #5): status only, never the body.
+      result =
+        ContentIngestionWorker.perform(%Oban.Job{
+          id: 105,
+          args: %{
+            "tenant_id" => tenant.id,
+            "content" => "Failing content",
+            "content_hash" => "fail_test",
+            "source_type" => "ingestion"
+          }
+        })
+
+      assert {:error, {:api_error, 500, :provider_error}} = result
+      refute inspect(result) =~ masked
+    end
+
+    test "a permanent 4xx DISCARDS with a sanitized reason (no key fragment)" do
+      %{tenant: tenant} = setup_tenant()
+      masked = "sk-ant-...4XX-LEAK"
+
+      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id,
+                                                                     _content,
+                                                                     _opts ->
+        {:error, {:api_error, 401, "Invalid x-api-key header: #{masked}"}}
+      end)
+
+      result =
+        ContentIngestionWorker.perform(%Oban.Job{
+          id: 106,
+          args: %{
+            "tenant_id" => tenant.id,
+            "content" => "Failing content",
+            "content_hash" => "fail_test_4xx",
+            "source_type" => "ingestion"
+          }
+        })
+
+      # Permanent -> discard; the extraction_failed message embeds the SANITIZED
+      # `first` error, so no masked key fragment can reach oban_jobs.errors.
+      assert {:discard, {:extraction_failed, message}} = result
+      assert message =~ "api_error"
+      refute message =~ masked
+      refute inspect(result) =~ masked
     end
   end
 

--- a/test/loopctl/workers/review_knowledge_worker_test.exs
+++ b/test/loopctl/workers/review_knowledge_worker_test.exs
@@ -606,4 +606,46 @@ defmodule Loopctl.Workers.ReviewKnowledgeWorkerTest do
       assert log.new_state["article_count"] == 1
     end
   end
+
+  # --- Provider-error sanitization at the worker boundary (review #5) ---
+
+  describe "provider-error sanitization" do
+    test "a key-bearing api_error becomes a value-free Oban discard reason" do
+      %{tenant: tenant} = setup_tenant()
+      review_record = create_review_record(tenant.id)
+      masked = "sk-ant-...WXYZ-LEAK"
+
+      # A 4xx (permanent) provider error whose body echoes a masked key fragment.
+      expect(Loopctl.MockExtractor, :extract_articles, fn _tenant_id, _ctx ->
+        {:error, {:api_error, 401, "Invalid x-api-key header: #{masked}"}}
+      end)
+
+      result =
+        ReviewKnowledgeWorker.perform(%Oban.Job{
+          args: %{"review_record_id" => review_record.id, "tenant_id" => tenant.id}
+        })
+
+      # Permanent -> discard, but the reason is sanitized (no body, no key fragment).
+      assert {:discard, {:api_error, 401, :provider_error}} = result
+      refute inspect(result) =~ masked
+    end
+
+    test "a transient 5xx api_error becomes a value-free Oban error reason" do
+      %{tenant: tenant} = setup_tenant()
+      review_record = create_review_record(tenant.id)
+      masked = "sk-ant-...5XX-LEAK"
+
+      expect(Loopctl.MockExtractor, :extract_articles, fn _tenant_id, _ctx ->
+        {:error, {:api_error, 503, "upstream error for key #{masked}"}}
+      end)
+
+      result =
+        ReviewKnowledgeWorker.perform(%Oban.Job{
+          args: %{"review_record_id" => review_record.id, "tenant_id" => tenant.id}
+        })
+
+      assert {:error, {:api_error, 503, :provider_error}} = result
+      refute inspect(result) =~ masked
+    end
+  end
 end

--- a/test/loopctl_web/controllers/knowledge_search_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_search_controller_test.exs
@@ -141,6 +141,38 @@ defmodule LoopctlWeb.KnowledgeSearchControllerTest do
       assert body["error"]["message"] =~ "Embedding service unavailable"
     end
 
+    test "semantic mode degrades to keyword-only for a KEYLESS tenant (no 503) (review #8)", %{
+      conn: conn
+    } do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      Loopctl.Knowledge.reset_circuit_breaker(tenant.id)
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Keyword Findable Article",
+        body: "Content about pagination that keyword search can find.",
+        category: :pattern,
+        status: :published,
+        tags: ["pagination"]
+      })
+
+      # Mandatory BYO: the embedding client reports the tenant has no key.
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, :no_api_key}
+      end)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{q: "pagination", mode: "semantic"})
+
+      body = json_response(conn, 200)
+      assert body["meta"]["fallback"] == true
+      assert body["meta"]["search_mode"] == "keyword_only"
+    end
+
     test "semantic mode labels total_count as ranked_corpus", %{conn: conn} do
       tenant = fixture(:tenant)
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
@@ -165,7 +197,7 @@ defmodule LoopctlWeb.KnowledgeSearchControllerTest do
       tenant = fixture(:tenant)
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
 
-      Loopctl.Knowledge.reset_circuit_breaker()
+      Loopctl.Knowledge.reset_circuit_breaker(tenant.id)
 
       fixture(:article, %{
         tenant_id: tenant.id,


### PR DESCRIPTION
## Why this is a separate PR

The enhanced review ran against PR #295 (BYO embeddings). **#295 was squash-merged into `master` (commit `10b871e`) before this review pass landed**, so `master` currently ships the round-1 code **including all 15 review regressions** (2 Critical, 4 High, 7 Medium, 2 Low). This PR carries the fixes forward as a follow-up. It branches cleanly off `master`, so the diff is only the regression fixes.

The operator-spend gap the review confirmed CLOSED is untouched — no global embedding key is reintroduced.

## Circuit-breaker cluster

- **CRIT #1** — the embedding circuit breaker was process-**GLOBAL** (keyed only by `:failures` / `:circuit_open_until`), so tenant A's own 401/429/timeout tripped the shared breaker and opened it for **all** tenants (weaponizable: 3 reqs/30s = platform-wide semantic-search degradation). Now keyed **per-tenant** (`{tenant_id, :failures}` / `:window_start` / `:open_until`) so a failing tenant only degrades itself. Failures are **classified**: only 5xx / transport / timeout / crash count; 4xx (401/403/429) and `:no_api_key` are per-tenant credential/quota problems and are exempt.
- **HIGH #4** — `ArticleEmbeddingWorker` and `ProposalGate` no longer call the client directly; both route through the guarded `Knowledge.generate_embedding/3` (circuit-open respected AND contributed to). ProposalGate ran **synchronously in the HTTP write path** — it now fast-fails on outage instead of hammering a dead provider (LB-timeout risk).
- **MED #13** — the failure counter is now atomic via `:ets.update_counter/4` (concurrent failures no longer undercount).

## Provider-error-body key-leak cluster (one shared helper, both vendors)

- New `Loopctl.Llm.ProviderError.sanitize/1` + `log_tag/1` drop any provider response **body** — which echoes a masked key fragment (`"Incorrect API key provided: sk-...ZXY"`) — keeping only the status.
- **HIGH #3** — applied in `EmbeddingClient.post` (the error term becomes an Oban `{:error, reason}` persisted into `oban_jobs.errors`, already surfaced to tenants via `list_extraction_errors`).
- **MED #11** — applied in `Anthropic.post` (same anti-pattern).
- **CRIT #2** — `ProposalGate` now logs a value-free tag instead of `inspect`-ing the raw error tuple.

## Retry / idempotency / classification

- **HIGH #5** — `Loopctl.Llm.permanent_provider_error?/1`: a 4xx (except 408/429) is permanent; the worker `{:discard, {:embedding_permanent_error, _}}`s a bad/revoked-key embed instead of burning its Oban attempts.
- **MED #12** — new `articles.embedding_content_hash` column (migration) records the SHA-256 of the embedded text; the worker skips re-calling the paid provider on retry when the stored hash matches the current content.

## Keyless UX + audit + timeout + schema

- **MED #8** — `mode=semantic` degrades to keyword-only (`fallback: true`) for a keyless tenant instead of a hard 503.
- **MED #9** — `Llm.record_blocked(tenant_id, :embedding)` from the worker skip and ProposalGate's fall-open, matching the Anthropic audit trail.
- **MED #10** — the embedding client's single-attempt budget (4s, no client retries) is kept strictly below `Knowledge`'s 5s `Task.yield`, so a slow-but-valid embed isn't killed-then-miscounted as a breaker failure.
- **MED #7** — `"embedding"` added to the `LlmUsageResponse` operation enum.

## Tests

Per-tenant breaker (`:no_api_key` + 4xx exempt; 5xx opens; **the two-tenant no-cross-degrade repro** proving A's 401s don't degrade B); permanent-error discard vs transient retry; idempotent skip on re-run; keyless semantic degrade; success-path no-key-leak; a realistic OpenAI 401 body dropped from the error term + logs; skip telemetry asserted. Also adds tenant-scoped `reset_circuit_breaker/1` so the breaker tests stay async-isolated.

Full precommit green (compile `--warnings-as-errors`, format, `credo --strict`, dialyzer 0, **3638 tests / 0 failures**) + **73 mcp node tests**.
