### PR TITLE
fix(witness): STH persistence + transparent bootstrap-412 retry (#298)

### DIFF
--- a/lib/loopctl_web/plugs/validate_witness_header.ex
+++ b/lib/loopctl_web/plugs/validate_witness_header.ex
@@ -24,6 +24,19 @@ defmodule LoopctlWeb.Plugs.ValidateWitnessHeader do
     one-time grace (custody-03): the request is still rejected — we only make the
     already-present resync path reliable and self-documenting.
 
+  ## Pipeline ordering (deliberate)
+
+  This plug runs AFTER `RateLimiter` and `UpdateLastSeen` in the `:authenticated`
+  pipeline. A client's transparent bootstrap-412 retry is therefore a second HTTP
+  request that costs one extra rate-limit tick and one extra `last_seen` write.
+  This is accepted, not a bug: (a) the retry fires AT MOST ONCE per fresh process
+  cold-start (once the STH is cached, no more bootstraps), and with client-side STH
+  persistence the common fresh-process path sends a real header and never retries;
+  (b) reordering this plug ahead of `RateLimiter` would remove rate-limiting from
+  its own DB work (the bootstrap-consume UPDATE + STH lookup), widening a DoS
+  surface — a worse trade than a rare +1 tick. Any HTTP client retry costs a tick;
+  keeping the limiter first protects the DB.
+
   ## Custody safety (private advisories)
 
   This plug operates on **raw, unauthenticated client input** and therefore
@@ -156,11 +169,23 @@ defmodule LoopctlWeb.Plugs.ValidateWitnessHeader do
   defp compare_against_server_sth(conn, tenant_id, position, sig_prefix) do
     case AuditChain.get_sth_at_position(tenant_id, position) do
       nil ->
-        # custody-02: NO pass-through. The server is the SOLE source of STHs, so
-        # a position beyond the tenant's latest sealed STH is not something an
-        # honest agent can know (its cached position is always <= latest sealed).
-        # Treat it as resync-required, never a silent bypass.
-        resync_required(conn, tenant_id, position, sig_prefix, "future_position")
+        # #298 fresh-tenant zero-STH pass-through: when the tenant has sealed NO
+        # STH yet (the ~60s window between a new tenant's first audit entry and the
+        # ComputeSthWorker cron sealing its first STH), the bootstrap grace hands
+        # out the all-zero placeholder `0:<zero_prefix>` — which the server ITSELF
+        # issued. A client echoing exactly that placeholder while nothing is sealed
+        # is NOT a future-position divergence (there is nothing to diverge from), so
+        # let it through. This closes the zero-STH 409 loop the 412-only client
+        # retry could never recover from. The moment a real STH is sealed,
+        # get_latest_sth/1 is non-nil and this branch no longer applies.
+        if zero_sth_placeholder?(position, sig_prefix) and no_sealed_sth?(tenant_id) do
+          conn
+        else
+          # custody-02: otherwise NO pass-through. A position beyond the tenant's
+          # latest sealed STH is not something an honest agent can know (its cached
+          # position is always <= latest sealed). Resync-required, never a bypass.
+          resync_required(conn, tenant_id, position, sig_prefix, "future_position")
+        end
 
       sth ->
         server_prefix = server_sig_prefix(sth.signature)
@@ -230,40 +255,67 @@ defmodule LoopctlWeb.Plugs.ValidateWitnessHeader do
   end
 
   defp atomic_consume_bootstrap(conn, id, tenant_id) do
-    # Read the STH the client will cache BEFORE consuming the one-time grace.
-    # This lookup is read-only and idempotent, so doing it first means a
-    # transient read failure raises here — with the grace NOT yet consumed
-    # (rescued to a retryable missing_header) — instead of AFTER the UPDATE has
-    # already burned the grace, which would permanently strand the key.
+    # LOW-9: the rescue is NARROWED to consume_grace/2 — ONLY the STH read + the
+    # conditional UPDATE. So a raise means the grace was NOT committed (the read
+    # failed, or the UPDATE rolled back), and the pure response builders
+    # (grant_bootstrap_grace / bootstrap_already_consumed) are outside the guard.
+    case consume_grace(id, tenant_id) do
+      # Winner: grant the grace with the STH we already read.
+      {:ok, 1, sth_value} ->
+        grant_bootstrap_grace(conn, sth_value)
+
+      # Already consumed: hand the client the STH we ALREADY read (no second DB
+      # round-trip) — so the already-consumed 412 can never be a 500 and ALWAYS
+      # carries a valid `x-loopctl-current-sth` for the client's one-shot retry.
+      {:ok, 0, sth_value} ->
+        bootstrap_already_consumed(conn, sth_value)
+
+      {:error, exception} ->
+        Logger.warning(
+          "ValidateWitnessHeader: atomic bootstrap consume failed for " <>
+            "api_key=#{id}: #{sanitized_db_error(exception)}"
+        )
+
+        recover_consume_error(conn, id, tenant_id)
+    end
+  end
+
+  # The ONLY rescue-guarded step: read the STH the client will cache, then flip the
+  # one-time grace column iff still NULL. The STH read runs FIRST so a transient
+  # read failure never burns the grace. Returns {:ok, count, sth} or {:error, ex}.
+  defp consume_grace(id, tenant_id) do
     sth_value = current_sth_value(tenant_id)
 
     {count, _} =
       from(a in ApiKey, where: a.id == ^id and is_nil(a.sth_bootstrap_consumed_at))
       |> AdminRepo.update_all(set: [sth_bootstrap_consumed_at: DateTime.utc_now()])
 
-    case count do
-      # Winner: grant the grace. Only pure response-header setting remains after
-      # the committed UPDATE, so nothing here can fail and strand the client.
-      1 -> grant_bootstrap_grace(conn, sth_value)
-      # Already consumed: hand the client the STH we ALREADY read above (never a
-      # second DB round-trip). Because that read is inside this rescue-guarded
-      # block, a transient failure would have already fallen through to a clean
-      # retryable `missing_header` 412 — so the already-consumed 412 can never be
-      # a 500 and ALWAYS carries a valid `x-loopctl-current-sth` for the client's
-      # one-shot retry (#298).
-      0 -> bootstrap_already_consumed(conn, sth_value)
+    {:ok, count, sth_value}
+  rescue
+    exception -> {:error, exception}
+  end
+
+  # A raise inside consume_grace means the grace was NOT committed, so
+  # `missing_header` (retryable) is the safe default. Defensively re-check with a
+  # FRESH read: if a prior request already burned the grace, return the
+  # already-consumed 412 (with a never-raising STH lookup) instead of inviting yet
+  # another bootstrap attempt. Any failure of that safety read falls back to
+  # missing_header.
+  defp recover_consume_error(conn, id, tenant_id) do
+    if bootstrap_already_consumed_row?(id) do
+      bootstrap_already_consumed(conn, safe_current_sth_value(tenant_id))
+    else
+      missing_header(conn)
+    end
+  end
+
+  defp bootstrap_already_consumed_row?(id) do
+    case AdminRepo.get(ApiKey, id) do
+      %ApiKey{sth_bootstrap_consumed_at: %DateTime{}} -> true
+      _ -> false
     end
   rescue
-    exception ->
-      # Fail closed on a DB error BEFORE the grace is consumed (the STH read or
-      # the UPDATE itself): never grant an unbounded/repeatable grace, and never
-      # burn the one-time grace on a transient failure — this path is retryable.
-      Logger.warning(
-        "ValidateWitnessHeader: atomic bootstrap consume failed for " <>
-          "api_key=#{id}: #{sanitized_db_error(exception)}"
-      )
-
-      missing_header(conn)
+    _ -> false
   end
 
   defp grant_bootstrap_grace(conn, sth_value) do
@@ -392,6 +444,27 @@ defmodule LoopctlWeb.Plugs.ValidateWitnessHeader do
       sth -> "#{sth.chain_position}:#{server_sig_prefix(sth.signature)}"
     end
   end
+
+  # current_sth_value/1 that can never raise — used only in the DB-error RECOVERY
+  # path (recover_consume_error) where the STH read may itself be flaky. Falls back
+  # to the all-zero placeholder so the already-consumed 412 still carries a
+  # shape-valid resync header instead of turning into a 500.
+  defp safe_current_sth_value(tenant_id) do
+    current_sth_value(tenant_id)
+  rescue
+    _ -> @zero_sth
+  end
+
+  # True only for the exact all-zero STH placeholder the bootstrap grace issues
+  # while the tenant has no sealed STH: chain position 0 and the fixed zero prefix.
+  # Constant-time compare against the fixed-length server constant (sig_prefix is
+  # already length/charset validated upstream).
+  defp zero_sth_placeholder?(0, sig_prefix),
+    do: Plug.Crypto.secure_compare(sig_prefix, @zero_sth_prefix)
+
+  defp zero_sth_placeholder?(_position, _sig_prefix), do: false
+
+  defp no_sealed_sth?(tenant_id), do: is_nil(AuditChain.get_latest_sth(tenant_id))
 
   defp valid_sig_prefix?(prefix) do
     String.length(prefix) == @sig_prefix_length and

--- a/lib/loopctl_web/plugs/validate_witness_header.ex
+++ b/lib/loopctl_web/plugs/validate_witness_header.ex
@@ -14,6 +14,15 @@ defmodule LoopctlWeb.Plugs.ValidateWitnessHeader do
   - Signature-prefix mismatch against the server's STH → 409
     (`witness_divergence`) with the server's current STH in the
     `x-loopctl-current-sth` response header so a stale client can resync.
+  - A key whose one-time bootstrap grace is already spent → 412
+    (`witness_bootstrap_already_consumed`). This 412 ALWAYS carries the current
+    STH in the `x-loopctl-current-sth` response header (and echoes it, plus a
+    machine-readable retry contract, in `error.remediation`) so a fresh client
+    can cache it and retry the SAME request ONCE with `X-Loopctl-Last-Known-STH`.
+    That retry-once is safe because this plug halts BEFORE the operation runs, so
+    the rejected request had no side effect (#298). This does NOT weaken the
+    one-time grace (custody-03): the request is still rejected — we only make the
+    already-present resync path reliable and self-documenting.
 
   ## Custody safety (private advisories)
 
@@ -236,7 +245,13 @@ defmodule LoopctlWeb.Plugs.ValidateWitnessHeader do
       # Winner: grant the grace. Only pure response-header setting remains after
       # the committed UPDATE, so nothing here can fail and strand the client.
       1 -> grant_bootstrap_grace(conn, sth_value)
-      0 -> bootstrap_already_consumed(conn)
+      # Already consumed: hand the client the STH we ALREADY read above (never a
+      # second DB round-trip). Because that read is inside this rescue-guarded
+      # block, a transient failure would have already fallen through to a clean
+      # retryable `missing_header` 412 — so the already-consumed 412 can never be
+      # a 500 and ALWAYS carries a valid `x-loopctl-current-sth` for the client's
+      # one-shot retry (#298).
+      0 -> bootstrap_already_consumed(conn, sth_value)
     end
   rescue
     exception ->
@@ -267,10 +282,33 @@ defmodule LoopctlWeb.Plugs.ValidateWitnessHeader do
 
   defp sanitized_db_error(exception), do: inspect(exception.__struct__)
 
-  defp bootstrap_already_consumed(conn) do
+  # `sth_value` is the STH already read (successfully) in `atomic_consume_bootstrap`
+  # BEFORE the conditional UPDATE, so this response never re-queries the DB and can
+  # never turn into a 500 — it is a clean, stable 412 that ALWAYS carries the
+  # current STH for a client one-shot retry. The one-time grace is NOT weakened:
+  # the request is still halted (no operation runs); we only make the already-
+  # present retry path reliable and self-documenting.
+  defp bootstrap_already_consumed(conn, sth_value) do
+    # Observability: a DISTINCT, low-severity signal for consumed-grace 412s so an
+    # operator can watch how often fresh clients arrive without a cached STH. This
+    # is the custody-03 gate working as DESIGNED (a retryable precondition), not a
+    # divergence — hence info level and its own telemetry event, separate from the
+    # `[:loopctl, :witness, :divergence]` alerting path.
+    tenant_id = get_tenant_id(conn)
+
+    Logger.info(
+      "WITNESS bootstrap grace already consumed (412, retryable): tenant=#{inspect(tenant_id)}"
+    )
+
+    :telemetry.execute(
+      [:loopctl, :witness, :bootstrap_already_consumed],
+      %{count: 1},
+      %{tenant_id: tenant_id}
+    )
+
     conn
     |> put_status(:precondition_failed)
-    |> put_resp_header("x-loopctl-current-sth", current_sth_value(get_tenant_id(conn)))
+    |> put_resp_header("x-loopctl-current-sth", sth_value)
     |> Phoenix.Controller.json(%{
       error: %{
         code: "witness_bootstrap_already_consumed",
@@ -281,6 +319,16 @@ defmodule LoopctlWeb.Plugs.ValidateWitnessHeader do
             "every subsequent request. The current STH is in the " <>
             "x-loopctl-current-sth response header.",
         remediation: %{
+          # Machine-readable retry contract so clients don't each rediscover it:
+          # read the STH from `cache_header`, resend it as `resend_as`, and retry
+          # AT MOST `max_retries` time(s). The witness plug halts before the
+          # operation runs, so this retry is side-effect-safe.
+          retry: %{
+            cache_header: "x-loopctl-current-sth",
+            resend_as: "X-Loopctl-Last-Known-STH",
+            max_retries: 1
+          },
+          current_sth: sth_value,
           learn_more: "https://loopctl.com/wiki/witness-protocol"
         }
       }

--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to `loopctl-mcp-server` are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 2.33.1 — 2026-07-03 (witness STH cache hardening — #298 enhanced review)
+
+### Security
+
+- **Symlink / file-clobber (CWE-59) closed.** The STH state file is now written
+  atomically and symlink-safely: to a private `0600` temp file opened with
+  `O_EXCL` (`wx`), then `rename`d over the target — so a pre-planted symlink at the
+  cache path is *replaced*, never followed, and can no longer be used to clobber an
+  arbitrary victim-owned file on a shared `/tmp`. Loads `lstat` the path and refuse
+  a symlinked or foreign-owned file. This also fixes the torn-file race on a killed
+  mid-write.
+- **Per-(server + key) cache scoping.** The state file AND the in-memory client are
+  now keyed by `sha256(serverUrl + ":" + apiKey)`, so two keys/tenants on one host
+  no longer share (and clobber) a cache — which previously caused spurious `409
+  witness_divergence` responses and false divergence telemetry. Only a non-secret
+  hash of the key appears in the filename; the key itself never hits disk.
+
+### Fixed
+
+- **Fresh-tenant zero-STH 409 loop (server-side).** A brand-new tenant has a ~60s
+  window before its first STH is sealed; the bootstrap handed out the all-zero STH
+  placeholder, which the client echoed and the server then rejected `409
+  witness_divergence` (unrecoverable, since the client retry is 412-only). The
+  server now treats the zero placeholder as a pass-through while no STH is sealed
+  (nothing to diverge from) — gated strictly on there being no sealed STH.
+- **Cold-start bootstrap coalescing.** Concurrent tool calls at process start now
+  share ONE bootstrap (singleflight) instead of each firing their own.
+
+### Changed
+
+- The transparent retry now anchors to the response `error.code`
+  (`witness_bootstrap_already_consumed`), not just the status + header shape.
+- `409 witness_divergence` is explicitly NOT auto-retried (the genuine-fork/resync
+  signal); the client caches the server's STH so the next request self-heals.
+- `LOOPCTL_STH_STATE_PATH` documentation clarified; cache is per-(server + key).
+
 ## 2.33.0 — 2026-07-03 (witness STH persistence + transparent bootstrap-412 retry — #298)
 
 ### Fixed

--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to `loopctl-mcp-server` are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 2.33.0 — 2026-07-03 (witness STH persistence + transparent bootstrap-412 retry — #298)
+
+### Fixed
+
+- **Fresh MCP processes no longer fail their first tool call with `412
+  witness_bootstrap_already_consumed` (#298).** The witness protocol's one-time
+  bootstrap grace is consumed once per API key; every subsequent fresh process
+  (a new Claude session, a standalone script, a CI run) reusing a long-lived
+  env-var key (`LOOPCTL_AGENT_KEY`, `LOOPCTL_ORCH_KEY`, …) previously started with
+  no Signed Tree Head (STH) and tripped that 412. Two client-side fixes:
+  - **Transparent retry:** any `412` carrying an `x-loopctl-current-sth` header is
+    now caught, the STH is cached, and the SAME request is retried exactly ONCE
+    with `X-Loopctl-Last-Known-STH` — so the tool call succeeds instead of
+    surfacing the 412. Bounded to a single retry (never a loop). Safe because the
+    server's witness plug halts BEFORE the operation runs, so the rejected request
+    had no side effect.
+  - **Cross-process persistence:** the learned STH is cached to a small state file
+    so a FRESH process loads it and sends a real header on its first request,
+    avoiding the 412 entirely. Location defaults to a per-server file under the OS
+    temp dir (`loopctl-mcp-sth-<hash>.json`) and can be overridden with
+    `LOOPCTL_STH_STATE_PATH`. All file I/O degrades gracefully: a missing,
+    corrupt, or unwritable state file falls back to in-memory caching + the
+    transparent retry above.
+
+### Added
+
+- **`LOOPCTL_STH_STATE_PATH`** env var to override the STH state-file location
+  (absolute path). Dispatch-based (v2) clients that mint a fresh ephemeral key per
+  dispatch are unaffected by the 412 (each fresh key gets its own clean bootstrap)
+  and do not need this.
+
 ## 2.32.0 — 2026-07-03 (per-tenant BYO for embeddings — Epic 28 #179)
 
 ### Added

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -63,6 +63,7 @@ Or if installed locally:
 | `LOOPCTL_ORCH_KEY` | Orchestrator role API key (verify, reject, review, import) | -- |
 | `LOOPCTL_AGENT_KEY` | Agent role API key (contract, claim, start, request-review) | -- |
 | `LOOPCTL_USER_KEY` | User role API key. Required ONLY for destructive admin tools like `knowledge_bulk_publish`. Leave unset if you don't use those tools. | -- |
+| `LOOPCTL_STH_STATE_PATH` | Absolute path for the witness-protocol STH cache file (see [Witness protocol](#witness-protocol-sth)). Optional. | per-server file under the OS temp dir |
 
 Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_KEY`.
 
@@ -321,6 +322,35 @@ loopctl enforces that nobody marks their own work as done. The API returns `409`
 - `verify_story` -- 409 `self_verify_blocked`
 
 The implementer's final action is `request_review`. All subsequent steps (report, review, verify) must come from different agents.
+
+## Witness protocol (STH)
+
+Every authenticated request echoes the caller's last-known Signed Tree Head (STH)
+via the `X-Loopctl-Last-Known-STH` header — loopctl's tamper-evident audit chain
+(chain-of-custody v2, §4.4). A brand-new caller has no STH, so its first request
+opts in with `X-Loopctl-STH-Bootstrap: true` to receive the current STH in the
+`x-loopctl-current-sth` response header. **That bootstrap grace is one-time per
+API key** (a deliberate security gate): once consumed, a later request that still
+lacks the header gets `412 witness_bootstrap_already_consumed`.
+
+This MCP server handles that transparently, so you never see the 412:
+
+- **Retry-once contract.** Any `412` carrying an `x-loopctl-current-sth` header is
+  caught, the STH is cached, and the SAME request is retried exactly **once** with
+  `X-Loopctl-Last-Known-STH`. Bounded to a single retry (never a loop). It is safe
+  because the server's witness plug halts *before* the operation runs, so the
+  rejected request had no side effect. The 412 body also carries a machine-readable
+  `error.remediation.retry` contract describing exactly this.
+- **Cross-process persistence.** The learned STH is cached to a small state file so
+  a **fresh** MCP process (a new Claude session, a script, a CI run) loads it and
+  sends a real header on its first request — avoiding the 412 entirely. The file
+  defaults to a per-server path under the OS temp dir
+  (`loopctl-mcp-sth-<hash>.json`) and can be overridden with `LOOPCTL_STH_STATE_PATH`.
+  All file I/O degrades gracefully: a missing, corrupt, or unwritable state file
+  falls back to in-memory caching plus the retry-once contract above.
+
+Dispatch-based (v2) clients that mint a fresh ephemeral key per dispatch are
+unaffected — each fresh key gets its own clean one-time bootstrap.
 
 ## Troubleshooting
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -63,7 +63,7 @@ Or if installed locally:
 | `LOOPCTL_ORCH_KEY` | Orchestrator role API key (verify, reject, review, import) | -- |
 | `LOOPCTL_AGENT_KEY` | Agent role API key (contract, claim, start, request-review) | -- |
 | `LOOPCTL_USER_KEY` | User role API key. Required ONLY for destructive admin tools like `knowledge_bulk_publish`. Leave unset if you don't use those tools. | -- |
-| `LOOPCTL_STH_STATE_PATH` | Absolute path for the witness-protocol STH cache file (see [Witness protocol](#witness-protocol-sth)). Optional. | per-server file under the OS temp dir |
+| `LOOPCTL_STH_STATE_PATH` | Absolute path for the witness-protocol STH cache file (see [Witness protocol](#witness-protocol-sth)). Optional. | per-(server + key) file under the OS temp dir |
 
 Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_KEY`.
 
@@ -335,22 +335,33 @@ lacks the header gets `412 witness_bootstrap_already_consumed`.
 
 This MCP server handles that transparently, so you never see the 412:
 
-- **Retry-once contract.** Any `412` carrying an `x-loopctl-current-sth` header is
-  caught, the STH is cached, and the SAME request is retried exactly **once** with
-  `X-Loopctl-Last-Known-STH`. Bounded to a single retry (never a loop). It is safe
-  because the server's witness plug halts *before* the operation runs, so the
-  rejected request had no side effect. The 412 body also carries a machine-readable
-  `error.remediation.retry` contract describing exactly this.
+- **Retry-once contract (412 only).** Any `412 witness_bootstrap_already_consumed`
+  carrying an `x-loopctl-current-sth` header is caught, the STH is cached, and the
+  SAME request is retried exactly **once** with `X-Loopctl-Last-Known-STH`. Bounded
+  to a single retry (never a loop) and anchored to the response's `error.code`. It
+  is safe because the server's witness plug halts *before* the operation runs, so
+  the rejected request had no side effect. The 412 body also carries a
+  machine-readable `error.remediation.retry` contract describing exactly this.
+- **A `409 witness_divergence` is NOT auto-retried** — deliberately. It means the
+  cached STH prefix does not match the server's (the genuine-fork / resync signal,
+  custody-01). The client caches the server's STH from the 409 so the *next*
+  request self-heals, but the current 409 is surfaced rather than papered over.
 - **Cross-process persistence.** The learned STH is cached to a small state file so
   a **fresh** MCP process (a new Claude session, a script, a CI run) loads it and
-  sends a real header on its first request — avoiding the 412 entirely. The file
-  defaults to a per-server path under the OS temp dir
-  (`loopctl-mcp-sth-<hash>.json`) and can be overridden with `LOOPCTL_STH_STATE_PATH`.
-  All file I/O degrades gracefully: a missing, corrupt, or unwritable state file
-  falls back to in-memory caching plus the retry-once contract above.
+  sends a real header on its first request — avoiding the 412 entirely. The file is
+  keyed by **(server URL + API key)** so distinct keys/tenants on one host never
+  share (or clobber) each other's cache; only a non-secret hash of the key appears
+  in the filename (`loopctl-mcp-sth-<hash>.json` under the OS temp dir), never the
+  key itself. Override the location with `LOOPCTL_STH_STATE_PATH`. Writes are
+  **atomic and symlink-safe** (write to a private `0600` temp file with `O_EXCL`,
+  then rename over the target — never write through a symlink), and loads refuse a
+  symlinked or foreign-owned file. All file I/O degrades gracefully: a missing,
+  corrupt, unwritable, or refused state file falls back to in-memory caching plus
+  the retry-once contract above.
 
 Dispatch-based (v2) clients that mint a fresh ephemeral key per dispatch are
-unaffected — each fresh key gets its own clean one-time bootstrap.
+unaffected: because the cache is keyed per API key, each fresh key gets its own
+clean one-time bootstrap (no cross-key collision).
 
 ## Troubleshooting
 

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -10,15 +10,20 @@ import {
   ListToolsRequestSchema,
   CallToolRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
-import { readFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
 import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
+import path, { dirname, join } from "node:path";
 import {
   projectsPath,
   ingestionJobsPath,
   llmUsagePath,
   parseJsonResponseBody,
 } from "./lib/http-helpers.js";
+import {
+  createWitnessClient,
+  resolveSthStatePath,
+} from "./lib/witness-sth.js";
 
 // Single source of truth for the server version: the package.json this file
 // ships with (npm always includes package.json in the published tarball).
@@ -32,11 +37,34 @@ const SERVER_VERSION = JSON.parse(
 // HTTP helper — witness protocol state
 // ---------------------------------------------------------------------------
 
-// The witness protocol requires clients to echo back the last-known Signed
-// Tree Head (STH) on every authenticated request. On the very first request
-// we send X-Loopctl-STH-Bootstrap: true to receive the current STH without
-// needing one already. After that we cache and send X-Loopctl-Last-Known-STH.
-let lastKnownSTH = null;
+// The witness protocol requires clients to echo back the last-known Signed Tree
+// Head (STH) on every authenticated request. The mechanics live in
+// ./lib/witness-sth.js (shared with the test suite):
+//
+//   * On the very first request from a caller that has never seen an STH we send
+//     `X-Loopctl-STH-Bootstrap: true` to receive the current STH in the
+//     `x-loopctl-current-sth` response header.
+//   * That STH is cached AND persisted to a small per-server state file, so a
+//     FRESH MCP process (new Claude session) loads it and sends a real
+//     `X-Loopctl-Last-Known-STH` on its first request — never tripping the
+//     one-time bootstrap-grace 412 (`witness_bootstrap_already_consumed`, #298).
+//   * If a request still hits that bootstrap-grace 412 (state file missing or
+//     corrupt), the client caches the STH from the 412's `x-loopctl-current-sth`
+//     header and RETRIES the SAME request exactly ONCE — transparently — so the
+//     tool call succeeds. The witness plug halts before the operation runs, so
+//     retrying a witness 412 is side-effect-safe even for POSTs.
+//
+// The state file location defaults to a per-server file under the OS temp dir and
+// can be overridden with LOOPCTL_STH_STATE_PATH. All file I/O degrades gracefully
+// (missing/corrupt/unwritable → in-memory cache + the transparent retry above).
+const STH_STATE_PATH = resolveSthStatePath({ env: process.env, os, path });
+
+const witnessClient = createWitnessClient({
+  statePath: STH_STATE_PATH,
+  readFileSync,
+  writeFileSync,
+  timeoutMs: 30_000,
+});
 
 function getBaseUrl() {
   return (process.env.LOOPCTL_SERVER || "https://loopctl.com").replace(/\/$/, "");
@@ -82,38 +110,22 @@ async function apiCall(method, path, body, keyOverride, { exactKey = false } = {
     Accept: "application/json",
   };
 
-  // Witness protocol: send cached STH or request bootstrap
-  if (lastKnownSTH) {
-    headers["X-Loopctl-Last-Known-STH"] = lastKnownSTH;
-  } else {
-    headers["X-Loopctl-STH-Bootstrap"] = "true";
-  }
+  const serializedBody =
+    body !== undefined && body !== null ? JSON.stringify(body) : undefined;
 
-  const options = {
-    method,
-    headers,
-    signal: AbortSignal.timeout(30_000),
-  };
-
-  if (body !== undefined && body !== null) {
-    options.body = JSON.stringify(body);
-  }
-
+  // The witness client injects the STH header, caches + persists any STH the
+  // server returns, and transparently retries a bootstrap-grace 412 ONCE (see
+  // ./lib/witness-sth.js and the module comment above). It returns the final
+  // attempt's Response; we keep body parsing / error shaping here.
   let response;
   try {
-    response = await fetch(url, options);
+    response = await witnessClient.send({ url, method, headers, serializedBody });
   } catch (err) {
     if (err.name === "TimeoutError") {
       return { error: true, status: 0, body: "Request timed out after 30s" };
     }
     const cause = err.cause?.message ? ` (${err.cause.message})` : "";
     return { error: true, status: 0, body: `Network error: ${err.message}${cause}` };
-  }
-
-  // Witness protocol: cache the STH from response for subsequent requests
-  const sthHeader = response.headers.get("x-loopctl-current-sth");
-  if (sthHeader) {
-    lastKnownSTH = sthHeader;
   }
 
   if (response.status === 204) {

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -10,7 +10,7 @@ import {
   ListToolsRequestSchema,
   CallToolRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync, renameSync, lstatSync, unlinkSync } from "node:fs";
 import os from "node:os";
 import { fileURLToPath } from "node:url";
 import path, { dirname, join } from "node:path";
@@ -54,17 +54,34 @@ const SERVER_VERSION = JSON.parse(
 //     tool call succeeds. The witness plug halts before the operation runs, so
 //     retrying a witness 412 is side-effect-safe even for POSTs.
 //
-// The state file location defaults to a per-server file under the OS temp dir and
-// can be overridden with LOOPCTL_STH_STATE_PATH. All file I/O degrades gracefully
-// (missing/corrupt/unwritable → in-memory cache + the transparent retry above).
-const STH_STATE_PATH = resolveSthStatePath({ env: process.env, os, path });
+// The state file location defaults to a per-(server + key) file under the OS temp
+// dir and can be overridden with LOOPCTL_STH_STATE_PATH. All file I/O degrades
+// gracefully (missing/corrupt/unwritable/symlinked → in-memory cache + the
+// transparent retry above). The write is atomic + symlink-safe (temp + rename).
+const WITNESS_FS = { readFileSync, writeFileSync, renameSync, lstatSync, unlinkSync };
 
-const witnessClient = createWitnessClient({
-  statePath: STH_STATE_PATH,
-  readFileSync,
-  writeFileSync,
-  timeoutMs: 30_000,
-});
+// One witness client PER API KEY (#298 review HIGH-2): the STH is per-tenant and
+// each key resolves to a tenant server-side, so distinct keys must NOT share an
+// in-memory cache or a state file (a collision causes spurious 409s + false
+// divergence telemetry). The state file is keyed by sha256(serverUrl + ":" + key)
+// — a non-secret hash; the key never hits disk in plaintext.
+const witnessClients = new Map();
+
+function witnessClientFor(apiKey) {
+  let client = witnessClients.get(apiKey);
+  if (!client) {
+    const statePath = resolveSthStatePath({ env: process.env, os, path, apiKey });
+    client = createWitnessClient({
+      statePath,
+      fs: WITNESS_FS,
+      getuid: typeof process.getuid === "function" ? () => process.getuid() : undefined,
+      pid: process.pid,
+      timeoutMs: 30_000,
+    });
+    witnessClients.set(apiKey, client);
+  }
+  return client;
+}
 
 function getBaseUrl() {
   return (process.env.LOOPCTL_SERVER || "https://loopctl.com").replace(/\/$/, "");
@@ -119,7 +136,7 @@ async function apiCall(method, path, body, keyOverride, { exactKey = false } = {
   // attempt's Response; we keep body parsing / error shaping here.
   let response;
   try {
-    response = await witnessClient.send({ url, method, headers, serializedBody });
+    response = await witnessClientFor(key).send({ url, method, headers, serializedBody });
   } catch (err) {
     if (err.name === "TimeoutError") {
       return { error: true, status: 0, body: "Request timed out after 30s" };

--- a/mcp-server/lib/witness-sth.js
+++ b/mcp-server/lib/witness-sth.js
@@ -15,8 +15,8 @@
 // 412 (#298). This module fixes that on the CLIENT side, two ways:
 //
 //   1. PERSISTENCE — the learned STH is cached to a small state file keyed by
-//      server URL, so a fresh process loads it and sends a real header on its
-//      first request, never tripping the bootstrap 412 at all.
+//      (server URL + API key), so a fresh process loads it and sends a real
+//      header on its first request, never tripping the bootstrap 412 at all.
 //   2. TRANSPARENT RETRY — if a request still hits a witness-plug 412 that
 //      carries the current STH (e.g. the state file was missing/corrupt), the
 //      client caches that STH and retries the SAME request ONCE, so the tool
@@ -28,11 +28,18 @@
 // a single attempt (never a loop). None of this weakens the server-side one-time
 // grace: it only teaches legit clients to carry/relearn the STH they are entitled
 // to. See mcp-server/README.md → "Witness protocol (STH)".
+//
+// 409 IS NOT AUTO-RETRIED (deliberate): a `409 witness_divergence` means the
+// client's cached STH prefix does not match the server's at that position — the
+// genuine-fork / resync signal (custody-01). The client caches the server's STH
+// from the 409's `x-loopctl-current-sth` header so the NEXT request self-heals,
+// but the current request's 409 is surfaced (not silently retried) so a real
+// divergence is never papered over. Only the bootstrap-grace 412 is retried.
 
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 
 // Explicit override for the STH state-file location (absolute path). When unset,
-// the file is derived under the OS temp dir, keyed by the server URL.
+// the file is derived under the OS temp dir, keyed by (server URL + API key).
 export const STH_STATE_PATH_ENV = "LOOPCTL_STH_STATE_PATH";
 
 // The `x-loopctl-current-sth` header the client caches / retries with. Shape:
@@ -40,6 +47,9 @@ export const STH_STATE_PATH_ENV = "LOOPCTL_STH_STATE_PATH";
 // against a corrupt state file feeding a malformed header (which the server would
 // itself reject 412 witness_header_malformed).
 const STH_SHAPE = /^\d+:[A-Za-z0-9_-]{22}$/;
+
+// The error code of the ONE 412 that is safe to transparently retry.
+const BOOTSTRAP_CONSUMED_CODE = "witness_bootstrap_already_consumed";
 
 /**
  * True when `sth` is a well-formed `<position>:<22-char base64url prefix>` value.
@@ -52,19 +62,22 @@ export function isValidSth(sth) {
 
 /**
  * Resolve the STH state-file path. Honors an explicit `LOOPCTL_STH_STATE_PATH`
- * override; otherwise derives a per-server file under the OS temp dir so distinct
- * loopctl servers don't share (and needlessly invalidate) each other's STH. The
- * server URL — not the API key — is hashed, so no secret is written to a path.
+ * override; otherwise derives a file under the OS temp dir keyed by BOTH the
+ * server URL AND the API key, so two keys/tenants on the same host never share
+ * (and clobber / spuriously invalidate) each other's cached STH. Only a NON-SECRET
+ * sha256 hash of the key goes in the filename — the key itself never hits disk.
  *
- * @param {{ env: Record<string,string|undefined>, os: { tmpdir(): string }, path: { join(...p: string[]): string } }} deps
+ * @param {{ env: Record<string,string|undefined>, os: { tmpdir(): string }, path: { join(...p: string[]): string }, apiKey?: string }} deps
  * @returns {string}
  */
-export function resolveSthStatePath({ env, os, path }) {
+export function resolveSthStatePath({ env, os, path, apiKey = "" }) {
   const override = env[STH_STATE_PATH_ENV];
   if (typeof override === "string" && override.trim() !== "") return override;
 
   const baseUrl = (env.LOOPCTL_SERVER || "https://loopctl.com").replace(/\/$/, "");
-  const digest = createHash("sha256").update(baseUrl).digest("hex").slice(0, 16);
+  // Scope by server URL AND api key (#298 review HIGH-2): distinct keys must not
+  // collide on one cache file. The key is hashed (never stored in plaintext).
+  const digest = createHash("sha256").update(`${baseUrl}:${apiKey}`).digest("hex").slice(0, 16);
   return path.join(os.tmpdir(), `loopctl-mcp-sth-${digest}.json`);
 }
 
@@ -73,13 +86,23 @@ export function resolveSthStatePath({ env, os, path }) {
  * missing, unreadable, non-JSON, or shape-invalid file degrades to `null` so the
  * caller falls back to the bootstrap+retry path.
  *
+ * SYMLINK / OWNERSHIP GUARD (CWE-59, #298 review HIGH-1): on a shared `/tmp` the
+ * cache path is predictable, so a co-located user could pre-plant a file/symlink
+ * there. Before reading we `lstat` the path and refuse (→ null, in-memory only) if
+ * it is a symlink or is not owned by the current uid.
+ *
  * @param {string} filePath
- * @param {{ readFileSync(p: string, enc: string): string }} deps
+ * @param {{ fs: { readFileSync: Function, lstatSync?: Function }, getuid?: () => number }} deps
  * @returns {string|null}
  */
-export function loadPersistedSth(filePath, { readFileSync }) {
+export function loadPersistedSth(filePath, { fs, getuid }) {
   try {
-    const parsed = JSON.parse(readFileSync(filePath, "utf8"));
+    if (typeof fs.lstatSync === "function") {
+      const st = fs.lstatSync(filePath);
+      if (st.isSymbolicLink()) return null;
+      if (typeof getuid === "function" && st.uid !== getuid()) return null;
+    }
+    const parsed = JSON.parse(fs.readFileSync(filePath, "utf8"));
     const sth = parsed && typeof parsed.sth === "string" ? parsed.sth : null;
     return isValidSth(sth) ? sth : null;
   } catch {
@@ -89,24 +112,40 @@ export function loadPersistedSth(filePath, { readFileSync }) {
 
 /**
  * Persist an STH string to `filePath`. NEVER throws — a write failure (read-only
- * temp dir, full disk) degrades to in-memory-only caching. Returns whether the
- * write succeeded.
+ * temp dir, full disk, symlink refusal) degrades to in-memory-only caching.
+ * Returns whether the write succeeded.
+ *
+ * ATOMIC + SYMLINK-SAFE (CWE-59, #298 review HIGH-1): writes to a fresh
+ * per-process temp file opened with `wx` (O_CREAT|O_EXCL — refuses a pre-planted
+ * symlink at the temp path) and mode 0o600, then `rename`s it over `filePath`.
+ * `rename` replaces the destination path ENTRY atomically and never writes THROUGH
+ * a symlink at `filePath`, so an attacker's symlink there is replaced, not
+ * followed — no arbitrary-file clobber. The rename-over also fixes the torn-file
+ * race from a killed mid-write.
  *
  * @param {string} filePath
  * @param {string} sth
- * @param {{ writeFileSync(p: string, data: string, enc: string): void }} deps
+ * @param {{ fs: { writeFileSync: Function, renameSync: Function, unlinkSync?: Function }, pid?: number }} deps
  * @returns {boolean}
  */
-export function persistSth(filePath, sth, { writeFileSync }) {
+export function persistSth(filePath, sth, { fs, pid = process.pid }) {
   if (!isValidSth(sth)) return false;
+  const tmp = `${filePath}.${pid}.${randomBytes(6).toString("hex")}.tmp`;
   try {
-    writeFileSync(
-      filePath,
+    fs.writeFileSync(
+      tmp,
       JSON.stringify({ sth, updated_at: new Date().toISOString() }),
-      "utf8",
+      { encoding: "utf8", flag: "wx", mode: 0o600 },
     );
+    fs.renameSync(tmp, filePath);
     return true;
   } catch {
+    // Best-effort cleanup of the temp file; ignore any failure.
+    try {
+      if (typeof fs.unlinkSync === "function") fs.unlinkSync(tmp);
+    } catch {
+      /* ignore */
+    }
     return false;
   }
 }
@@ -118,7 +157,8 @@ export function persistSth(filePath, sth, { writeFileSync }) {
  * Gated on `412` AND a shape-valid `x-loopctl-current-sth` header — which the
  * witness plug sets ONLY on the `witness_bootstrap_already_consumed` branch (not
  * on the malformed/missing 412s, where a retry couldn't help). This precisely
- * targets the fresh-process bootstrap-grace 412 (#298).
+ * targets the fresh-process bootstrap-grace 412 (#298). The caller additionally
+ * confirms the body's `error.code` (see `createWitnessClient`).
  *
  * @param {number} status
  * @param {string|null|undefined} currentSthHeader
@@ -131,8 +171,8 @@ export function bootstrapRetrySth(status, currentSthHeader) {
 /**
  * Create a witness-aware request client that owns the shared STH state (loaded
  * from `statePath` at construction), injects the witness header on every attempt,
- * caches + persists any STH the server returns, and transparently retries a
- * bootstrap-grace 412 ONCE.
+ * caches + persists any STH the server returns, coalesces concurrent cold-start
+ * bootstraps, and transparently retries a bootstrap-grace 412 ONCE.
  *
  * `send` returns the raw `Response` of the FINAL attempt so the caller keeps full
  * control of body parsing / error shaping. Network errors from `fetchImpl`
@@ -142,27 +182,35 @@ export function bootstrapRetrySth(status, currentSthHeader) {
  * @param {{
  *   fetchImpl?: typeof fetch,
  *   statePath?: string|null,
- *   readFileSync?: (p: string, enc: string) => string,
- *   writeFileSync?: (p: string, data: string, enc: string) => void,
+ *   fs?: object,
+ *   getuid?: () => number,
+ *   pid?: number,
  *   timeoutMs?: number,
  * }} [deps]
  */
 export function createWitnessClient({
   fetchImpl = fetch,
   statePath = null,
-  readFileSync,
-  writeFileSync,
+  fs,
+  getuid,
+  pid,
   timeoutMs = 30_000,
 } = {}) {
   // Load any persisted STH so a FRESH process sends a real header on request #1
   // and skips the bootstrap-grace 412 entirely.
   let lastKnownSTH =
-    statePath && readFileSync ? loadPersistedSth(statePath, { readFileSync }) : null;
+    statePath && fs ? loadPersistedSth(statePath, { fs, getuid }) : null;
+
+  // Cold-start singleflight (#298 review MEDIUM-6): when several tool calls fire
+  // at process start they all observe lastKnownSTH === null; without coalescing
+  // each would send its own bootstrap. The FIRST becomes the leader; the rest
+  // await its result and then send with the learned header.
+  let bootstrapInFlight = null;
 
   function remember(sth) {
     if (!isValidSth(sth) || sth === lastKnownSTH) return;
     lastKnownSTH = sth;
-    if (statePath && writeFileSync) persistSth(statePath, sth, { writeFileSync });
+    if (statePath && fs) persistSth(statePath, sth, { fs, pid });
   }
 
   async function attempt({ url, method, headers, serializedBody }) {
@@ -183,20 +231,62 @@ export function createWitnessClient({
     return fetchImpl(url, options);
   }
 
-  async function send(req) {
+  // Confirm a bootstrap-grace 412 against the DOCUMENTED contract before retrying
+  // (#298 review LOW-8): status 412 + a valid STH header, AND — when the body is
+  // readable — error.code === "witness_bootstrap_already_consumed". A body-read
+  // failure falls back to the status+header decision so a transient parse issue
+  // never defeats the retry. Reads a CLONE so the caller can still consume the
+  // body of a response we end up NOT retrying.
+  async function retrySthFor(response) {
+    const sth = response.headers.get("x-loopctl-current-sth");
+    if (!bootstrapRetrySth(response.status, sth)) return null;
+    try {
+      const body = await response.clone().json();
+      const code = body && body.error && body.error.code;
+      if (code && code !== BOOTSTRAP_CONSUMED_CODE) return null;
+    } catch {
+      /* unreadable body → fall back to status+header */
+    }
+    return sth;
+  }
+
+  async function performSend(req) {
     let response = await attempt(req);
-    let sth = response.headers.get("x-loopctl-current-sth");
-    if (sth) remember(sth);
+    remember(response.headers.get("x-loopctl-current-sth"));
 
     // Bounded, single transparent retry for the bootstrap-grace 412. `remember`
     // above already cached the STH, so this second attempt sends a real header.
-    if (bootstrapRetrySth(response.status, sth)) {
+    if (await retrySthFor(response)) {
       response = await attempt(req);
-      const retrySth = response.headers.get("x-loopctl-current-sth");
-      if (retrySth) remember(retrySth);
+      remember(response.headers.get("x-loopctl-current-sth"));
     }
 
     return response;
+  }
+
+  async function send(req) {
+    // Cold-start coalescing: only the leader bootstraps; followers await it and
+    // then send with the learned STH. On the (rare) leader failure, followers
+    // fall through and each bootstrap — acceptable degradation.
+    if (lastKnownSTH === null && bootstrapInFlight) {
+      await bootstrapInFlight;
+      return performSend(req);
+    }
+
+    if (lastKnownSTH === null) {
+      let done;
+      bootstrapInFlight = new Promise((resolve) => {
+        done = resolve;
+      });
+      try {
+        return await performSend(req);
+      } finally {
+        done();
+        bootstrapInFlight = null;
+      }
+    }
+
+    return performSend(req);
   }
 
   return {

--- a/mcp-server/lib/witness-sth.js
+++ b/mcp-server/lib/witness-sth.js
@@ -1,0 +1,206 @@
+// Witness-protocol (Signed Tree Head) client state — shared by index.js and the
+// test suite so both exercise the SAME retry + persistence logic.
+//
+// Background (loopctl chain-of-custody v2, §4.4): every authenticated request
+// must echo the caller's last-known STH via `X-Loopctl-Last-Known-STH`. A brand
+// new caller has no STH, so its FIRST request opts in with
+// `X-Loopctl-STH-Bootstrap: true` to receive the current STH in the response's
+// `x-loopctl-current-sth` header. That bootstrap grace is ONE-TIME PER API KEY
+// (custody-03 / GHSA-36g5-mcrh-rcrm): once consumed, a later request that still
+// lacks the header gets `412 witness_bootstrap_already_consumed`.
+//
+// The MCP server is a short-lived process: a fresh Claude session spawns a fresh
+// process that historically started with no STH, so — once the key's one-time
+// grace was consumed by an earlier process — its very first tool call hit that
+// 412 (#298). This module fixes that on the CLIENT side, two ways:
+//
+//   1. PERSISTENCE — the learned STH is cached to a small state file keyed by
+//      server URL, so a fresh process loads it and sends a real header on its
+//      first request, never tripping the bootstrap 412 at all.
+//   2. TRANSPARENT RETRY — if a request still hits a witness-plug 412 that
+//      carries the current STH (e.g. the state file was missing/corrupt), the
+//      client caches that STH and retries the SAME request ONCE, so the tool
+//      call succeeds instead of surfacing the 412.
+//
+// SAFETY: the witness plug runs early and HALTS the request before the operation
+// executes, so a witness 412/409 means the original request had no side effect —
+// retrying it once is safe even for non-idempotent POSTs. The retry is bounded to
+// a single attempt (never a loop). None of this weakens the server-side one-time
+// grace: it only teaches legit clients to carry/relearn the STH they are entitled
+// to. See mcp-server/README.md → "Witness protocol (STH)".
+
+import { createHash } from "node:crypto";
+
+// Explicit override for the STH state-file location (absolute path). When unset,
+// the file is derived under the OS temp dir, keyed by the server URL.
+export const STH_STATE_PATH_ENV = "LOOPCTL_STH_STATE_PATH";
+
+// The `x-loopctl-current-sth` header the client caches / retries with. Shape:
+// `<position>:<22-char base64url signature prefix>`. Validating the shape guards
+// against a corrupt state file feeding a malformed header (which the server would
+// itself reject 412 witness_header_malformed).
+const STH_SHAPE = /^\d+:[A-Za-z0-9_-]{22}$/;
+
+/**
+ * True when `sth` is a well-formed `<position>:<22-char base64url prefix>` value.
+ * @param {unknown} sth
+ * @returns {boolean}
+ */
+export function isValidSth(sth) {
+  return typeof sth === "string" && STH_SHAPE.test(sth);
+}
+
+/**
+ * Resolve the STH state-file path. Honors an explicit `LOOPCTL_STH_STATE_PATH`
+ * override; otherwise derives a per-server file under the OS temp dir so distinct
+ * loopctl servers don't share (and needlessly invalidate) each other's STH. The
+ * server URL — not the API key — is hashed, so no secret is written to a path.
+ *
+ * @param {{ env: Record<string,string|undefined>, os: { tmpdir(): string }, path: { join(...p: string[]): string } }} deps
+ * @returns {string}
+ */
+export function resolveSthStatePath({ env, os, path }) {
+  const override = env[STH_STATE_PATH_ENV];
+  if (typeof override === "string" && override.trim() !== "") return override;
+
+  const baseUrl = (env.LOOPCTL_SERVER || "https://loopctl.com").replace(/\/$/, "");
+  const digest = createHash("sha256").update(baseUrl).digest("hex").slice(0, 16);
+  return path.join(os.tmpdir(), `loopctl-mcp-sth-${digest}.json`);
+}
+
+/**
+ * Load a persisted STH string from `filePath`, or `null`. NEVER throws — a
+ * missing, unreadable, non-JSON, or shape-invalid file degrades to `null` so the
+ * caller falls back to the bootstrap+retry path.
+ *
+ * @param {string} filePath
+ * @param {{ readFileSync(p: string, enc: string): string }} deps
+ * @returns {string|null}
+ */
+export function loadPersistedSth(filePath, { readFileSync }) {
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, "utf8"));
+    const sth = parsed && typeof parsed.sth === "string" ? parsed.sth : null;
+    return isValidSth(sth) ? sth : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist an STH string to `filePath`. NEVER throws — a write failure (read-only
+ * temp dir, full disk) degrades to in-memory-only caching. Returns whether the
+ * write succeeded.
+ *
+ * @param {string} filePath
+ * @param {string} sth
+ * @param {{ writeFileSync(p: string, data: string, enc: string): void }} deps
+ * @returns {boolean}
+ */
+export function persistSth(filePath, sth, { writeFileSync }) {
+  if (!isValidSth(sth)) return false;
+  try {
+    writeFileSync(
+      filePath,
+      JSON.stringify({ sth, updated_at: new Date().toISOString() }),
+      "utf8",
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Decide whether a response should trigger a one-shot transparent retry, and with
+ * which STH. Returns the STH to retry with, or `null`.
+ *
+ * Gated on `412` AND a shape-valid `x-loopctl-current-sth` header — which the
+ * witness plug sets ONLY on the `witness_bootstrap_already_consumed` branch (not
+ * on the malformed/missing 412s, where a retry couldn't help). This precisely
+ * targets the fresh-process bootstrap-grace 412 (#298).
+ *
+ * @param {number} status
+ * @param {string|null|undefined} currentSthHeader
+ * @returns {string|null}
+ */
+export function bootstrapRetrySth(status, currentSthHeader) {
+  return status === 412 && isValidSth(currentSthHeader) ? currentSthHeader : null;
+}
+
+/**
+ * Create a witness-aware request client that owns the shared STH state (loaded
+ * from `statePath` at construction), injects the witness header on every attempt,
+ * caches + persists any STH the server returns, and transparently retries a
+ * bootstrap-grace 412 ONCE.
+ *
+ * `send` returns the raw `Response` of the FINAL attempt so the caller keeps full
+ * control of body parsing / error shaping. Network errors from `fetchImpl`
+ * propagate (the caller's try/catch handles them); a network failure is not
+ * retried.
+ *
+ * @param {{
+ *   fetchImpl?: typeof fetch,
+ *   statePath?: string|null,
+ *   readFileSync?: (p: string, enc: string) => string,
+ *   writeFileSync?: (p: string, data: string, enc: string) => void,
+ *   timeoutMs?: number,
+ * }} [deps]
+ */
+export function createWitnessClient({
+  fetchImpl = fetch,
+  statePath = null,
+  readFileSync,
+  writeFileSync,
+  timeoutMs = 30_000,
+} = {}) {
+  // Load any persisted STH so a FRESH process sends a real header on request #1
+  // and skips the bootstrap-grace 412 entirely.
+  let lastKnownSTH =
+    statePath && readFileSync ? loadPersistedSth(statePath, { readFileSync }) : null;
+
+  function remember(sth) {
+    if (!isValidSth(sth) || sth === lastKnownSTH) return;
+    lastKnownSTH = sth;
+    if (statePath && writeFileSync) persistSth(statePath, sth, { writeFileSync });
+  }
+
+  async function attempt({ url, method, headers, serializedBody }) {
+    // Witness protocol: echo the cached STH, or (never seen one) request a
+    // one-time bootstrap. A fresh AbortSignal per attempt so the retry gets its
+    // own timeout budget.
+    const withWitness = { ...headers };
+    if (lastKnownSTH) withWitness["X-Loopctl-Last-Known-STH"] = lastKnownSTH;
+    else withWitness["X-Loopctl-STH-Bootstrap"] = "true";
+
+    const options = {
+      method,
+      headers: withWitness,
+      signal: AbortSignal.timeout(timeoutMs),
+    };
+    if (serializedBody !== undefined) options.body = serializedBody;
+
+    return fetchImpl(url, options);
+  }
+
+  async function send(req) {
+    let response = await attempt(req);
+    let sth = response.headers.get("x-loopctl-current-sth");
+    if (sth) remember(sth);
+
+    // Bounded, single transparent retry for the bootstrap-grace 412. `remember`
+    // above already cached the STH, so this second attempt sends a real header.
+    if (bootstrapRetrySth(response.status, sth)) {
+      response = await attempt(req);
+      const retrySth = response.headers.get("x-loopctl-current-sth");
+      if (retrySth) remember(retrySth);
+    }
+
+    return response;
+  }
+
+  return {
+    send,
+    getSTH: () => lastKnownSTH,
+  };
+}

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.33.0",
+  "version": "2.33.1",
   "description": "MCP server for loopctl — structural trust for AI development loops",
   "type": "module",
   "main": "index.js",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.32.0",
+  "version": "2.33.0",
   "description": "MCP server for loopctl — structural trust for AI development loops",
   "type": "module",
   "main": "index.js",

--- a/mcp-server/test/witness_sth.test.js
+++ b/mcp-server/test/witness_sth.test.js
@@ -1,0 +1,407 @@
+/**
+ * Regression tests for the witness-protocol STH client (#298):
+ *
+ *   - A bootstrap-grace 412 that carries `x-loopctl-current-sth` triggers a
+ *     SINGLE transparent retry with that STH and returns the success response.
+ *   - A persisted STH is loaded on construction and sent as
+ *     `X-Loopctl-Last-Known-STH` on the FIRST request (no bootstrap 412).
+ *   - A corrupt / missing state file degrades gracefully to bootstrap + retry.
+ *   - The retry is bounded to a single attempt (never a loop).
+ *   - Pure helpers: isValidSth / bootstrapRetrySth / resolveSthStatePath /
+ *     loadPersistedSth / persistSth.
+ *
+ * SINGLE SOURCE OF TRUTH: the retry + persistence logic lives in
+ * ../lib/witness-sth.js, imported by BOTH the real server (index.js) and these
+ * tests, so a regression in that logic fails CI. A wiring assertion at the end
+ * pins that index.js actually delegates apiCall to the shared witness client.
+ *
+ * Run: node --test test/*.test.js
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+import {
+  isValidSth,
+  bootstrapRetrySth,
+  resolveSthStatePath,
+  loadPersistedSth,
+  persistSth,
+  createWitnessClient,
+  STH_STATE_PATH_ENV,
+} from "../lib/witness-sth.js";
+
+const INDEX_SRC = readFileSync(
+  path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "index.js"),
+  "utf8",
+);
+
+// A well-formed `<position>:<22-char base64url prefix>` STH value.
+const STH_A = "5:AAAAAAAAAAAAAAAAAAAAAA";
+const STH_B = "9:ZZZZZZZZZZZZZZZZZZZZZZ";
+
+// Build a fake Response with a header bag and a status.
+function fakeResponse(status, headers = {}) {
+  const lower = {};
+  for (const [k, v] of Object.entries(headers)) lower[k.toLowerCase()] = v;
+  return {
+    status,
+    headers: { get: (name) => lower[name.toLowerCase()] ?? null },
+  };
+}
+
+// A fetch spy that returns queued responses in order and records each call.
+function spyFetch(responses) {
+  const calls = [];
+  const queue = [...responses];
+  const fetchImpl = async (url, options) => {
+    calls.push({ url, options });
+    return queue.length > 1 ? queue.shift() : queue[0];
+  };
+  return { fetchImpl, calls };
+}
+
+// ---------------------------------------------------------------------------
+// isValidSth
+// ---------------------------------------------------------------------------
+
+describe("isValidSth", () => {
+  test("accepts a position + 22-char base64url prefix", () => {
+    assert.equal(isValidSth(STH_A), true);
+    assert.equal(isValidSth("0:AAAAAAAAAAAAAAAAAAAAAA"), true);
+    assert.equal(isValidSth("123456:_-AAAAAAAAAAAAAAAAAAAA"), true);
+  });
+
+  test("rejects malformed / short / non-base64url / non-string values", () => {
+    assert.equal(isValidSth("5:"), false);
+    assert.equal(isValidSth("5:abc"), false);
+    assert.equal(isValidSth("5:" + "A".repeat(23)), false);
+    assert.equal(isValidSth("5:AAAAAAAAAA++//AAAAAAAA"), false); // standard, not url
+    assert.equal(isValidSth("x:AAAAAAAAAAAAAAAAAAAAAA"), false);
+    assert.equal(isValidSth(null), false);
+    assert.equal(isValidSth(undefined), false);
+    assert.equal(isValidSth(5), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bootstrapRetrySth
+// ---------------------------------------------------------------------------
+
+describe("bootstrapRetrySth", () => {
+  test("returns the STH on a 412 carrying a valid current-sth header", () => {
+    assert.equal(bootstrapRetrySth(412, STH_A), STH_A);
+  });
+
+  test("returns null for non-412 statuses even with a valid STH", () => {
+    assert.equal(bootstrapRetrySth(200, STH_A), null);
+    assert.equal(bootstrapRetrySth(409, STH_A), null);
+    assert.equal(bootstrapRetrySth(500, STH_A), null);
+  });
+
+  test("returns null for a 412 without / with a malformed STH header", () => {
+    assert.equal(bootstrapRetrySth(412, null), null);
+    assert.equal(bootstrapRetrySth(412, undefined), null);
+    assert.equal(bootstrapRetrySth(412, "not-an-sth"), null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveSthStatePath
+// ---------------------------------------------------------------------------
+
+describe("resolveSthStatePath", () => {
+  const os = { tmpdir: () => "/tmp" };
+  const path = { join: (...p) => p.join("/") };
+
+  test("honors an explicit LOOPCTL_STH_STATE_PATH override", () => {
+    const env = { [STH_STATE_PATH_ENV]: "/custom/sth.json" };
+    assert.equal(resolveSthStatePath({ env, os, path }), "/custom/sth.json");
+  });
+
+  test("ignores a blank override and derives a per-server temp path", () => {
+    const env = { [STH_STATE_PATH_ENV]: "   ", LOOPCTL_SERVER: "https://loopctl.com" };
+    const result = resolveSthStatePath({ env, os, path });
+    assert.match(result, /^\/tmp\/loopctl-mcp-sth-[0-9a-f]{16}\.json$/);
+  });
+
+  test("derives distinct files for distinct servers", () => {
+    const a = resolveSthStatePath({ env: { LOOPCTL_SERVER: "https://a.example" }, os, path });
+    const b = resolveSthStatePath({ env: { LOOPCTL_SERVER: "https://b.example" }, os, path });
+    assert.notEqual(a, b);
+  });
+
+  test("is stable for the same server (ignoring a trailing slash)", () => {
+    const a = resolveSthStatePath({ env: { LOOPCTL_SERVER: "https://a.example" }, os, path });
+    const b = resolveSthStatePath({ env: { LOOPCTL_SERVER: "https://a.example/" }, os, path });
+    assert.equal(a, b);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadPersistedSth / persistSth (injected fs, never touches real disk)
+// ---------------------------------------------------------------------------
+
+describe("loadPersistedSth", () => {
+  test("returns the STH from a well-formed state file", () => {
+    const readFileSync = () => JSON.stringify({ sth: STH_A, updated_at: "x" });
+    assert.equal(loadPersistedSth("/x", { readFileSync }), STH_A);
+  });
+
+  test("returns null when the file is missing (readFileSync throws)", () => {
+    const readFileSync = () => {
+      throw new Error("ENOENT");
+    };
+    assert.equal(loadPersistedSth("/x", { readFileSync }), null);
+  });
+
+  test("returns null for non-JSON / corrupt content", () => {
+    const readFileSync = () => "}{ not json";
+    assert.equal(loadPersistedSth("/x", { readFileSync }), null);
+  });
+
+  test("returns null when the stored STH is shape-invalid", () => {
+    const readFileSync = () => JSON.stringify({ sth: "garbage" });
+    assert.equal(loadPersistedSth("/x", { readFileSync }), null);
+  });
+});
+
+describe("persistSth", () => {
+  test("writes a valid STH and reports success", () => {
+    let written;
+    const writeFileSync = (p, data) => {
+      written = { p, data };
+    };
+    assert.equal(persistSth("/x", STH_A, { writeFileSync }), true);
+    assert.equal(written.p, "/x");
+    assert.deepEqual(JSON.parse(written.data).sth, STH_A);
+  });
+
+  test("refuses to persist a shape-invalid STH", () => {
+    let called = false;
+    const writeFileSync = () => {
+      called = true;
+    };
+    assert.equal(persistSth("/x", "garbage", { writeFileSync }), false);
+    assert.equal(called, false);
+  });
+
+  test("degrades to false when the write throws (read-only dir, full disk)", () => {
+    const writeFileSync = () => {
+      throw new Error("EROFS");
+    };
+    assert.equal(persistSth("/x", STH_A, { writeFileSync }), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createWitnessClient.send — the transparent bootstrap-412 retry
+// ---------------------------------------------------------------------------
+
+describe("createWitnessClient.send — bootstrap-grace 412 retry", () => {
+  const req = { url: "https://x/api/v1/tenants/me", method: "GET", headers: {} };
+
+  test("a 412 carrying current-sth triggers exactly ONE retry that succeeds", async () => {
+    const { fetchImpl, calls } = spyFetch([
+      fakeResponse(412, { "x-loopctl-current-sth": STH_A }),
+      fakeResponse(200, { "x-loopctl-current-sth": STH_A }),
+    ]);
+    const client = createWitnessClient({ fetchImpl });
+
+    const response = await client.send(req);
+
+    // Returns the SUCCESS response, not the 412.
+    assert.equal(response.status, 200);
+    // Exactly two attempts — a single bounded retry, never a loop.
+    assert.equal(calls.length, 2);
+    // First attempt bootstrapped (no cached STH); retry sent the learned STH.
+    assert.equal(calls[0].options.headers["X-Loopctl-STH-Bootstrap"], "true");
+    assert.equal(calls[0].options.headers["X-Loopctl-Last-Known-STH"], undefined);
+    assert.equal(calls[1].options.headers["X-Loopctl-Last-Known-STH"], STH_A);
+    assert.equal(calls[1].options.headers["X-Loopctl-STH-Bootstrap"], undefined);
+    // The learned STH is cached for subsequent requests.
+    assert.equal(client.getSTH(), STH_A);
+  });
+
+  test("does NOT retry a 412 that lacks a valid current-sth header", async () => {
+    const { fetchImpl, calls } = spyFetch([fakeResponse(412, {})]);
+    const client = createWitnessClient({ fetchImpl });
+
+    const response = await client.send(req);
+
+    assert.equal(response.status, 412);
+    assert.equal(calls.length, 1);
+  });
+
+  test("is bounded to a single retry even if the retry also 412s", async () => {
+    // Server keeps 412-ing (pathological): the client must retry exactly once
+    // and then surface the 412 rather than looping forever.
+    const { fetchImpl, calls } = spyFetch([
+      fakeResponse(412, { "x-loopctl-current-sth": STH_A }),
+      fakeResponse(412, { "x-loopctl-current-sth": STH_A }),
+      fakeResponse(200),
+    ]);
+    const client = createWitnessClient({ fetchImpl });
+
+    const response = await client.send(req);
+
+    assert.equal(response.status, 412);
+    assert.equal(calls.length, 2);
+  });
+
+  test("does not retry a plain 200 and caches its STH", async () => {
+    const { fetchImpl, calls } = spyFetch([
+      fakeResponse(200, { "x-loopctl-current-sth": STH_B }),
+    ]);
+    const client = createWitnessClient({ fetchImpl });
+
+    const response = await client.send(req);
+
+    assert.equal(response.status, 200);
+    assert.equal(calls.length, 1);
+    assert.equal(client.getSTH(), STH_B);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createWitnessClient — startup persistence load
+// ---------------------------------------------------------------------------
+
+describe("createWitnessClient — persisted STH loaded on construction", () => {
+  const req = { url: "https://x/api/v1/tenants/me", method: "GET", headers: {} };
+
+  test("a persisted STH is loaded and sent on the FIRST request (no bootstrap)", async () => {
+    const { fetchImpl, calls } = spyFetch([fakeResponse(200)]);
+    const readFileSync = () => JSON.stringify({ sth: STH_A });
+
+    const client = createWitnessClient({
+      fetchImpl,
+      statePath: "/state.json",
+      readFileSync,
+    });
+
+    assert.equal(client.getSTH(), STH_A);
+
+    await client.send(req);
+
+    // First request carried the real header — never tripped the bootstrap path.
+    assert.equal(calls[0].options.headers["X-Loopctl-Last-Known-STH"], STH_A);
+    assert.equal(calls[0].options.headers["X-Loopctl-STH-Bootstrap"], undefined);
+  });
+
+  test("a corrupt state file degrades to bootstrap + transparent retry", async () => {
+    const { fetchImpl, calls } = spyFetch([
+      fakeResponse(412, { "x-loopctl-current-sth": STH_A }),
+      fakeResponse(200),
+    ]);
+    const readFileSync = () => "corrupt-not-json";
+    let persisted = null;
+    const writeFileSync = (p, data) => {
+      persisted = JSON.parse(data).sth;
+    };
+
+    const client = createWitnessClient({
+      fetchImpl,
+      statePath: "/state.json",
+      readFileSync,
+      writeFileSync,
+    });
+
+    // Corrupt file → no STH loaded → first request bootstraps.
+    assert.equal(client.getSTH(), null);
+
+    const response = await client.send(req);
+
+    assert.equal(response.status, 200);
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].options.headers["X-Loopctl-STH-Bootstrap"], "true");
+    assert.equal(calls[1].options.headers["X-Loopctl-Last-Known-STH"], STH_A);
+    // The relearned STH was persisted for the next fresh process.
+    assert.equal(persisted, STH_A);
+  });
+
+  test("persists a newly-learned STH from a successful response", async () => {
+    const { fetchImpl } = spyFetch([
+      fakeResponse(200, { "x-loopctl-current-sth": STH_B }),
+    ]);
+    let persisted = null;
+    const writeFileSync = (p, data) => {
+      persisted = JSON.parse(data).sth;
+    };
+    const readFileSync = () => {
+      throw new Error("ENOENT");
+    };
+
+    const client = createWitnessClient({
+      fetchImpl,
+      statePath: "/state.json",
+      readFileSync,
+      writeFileSync,
+    });
+
+    await client.send(req);
+
+    assert.equal(persisted, STH_B);
+    assert.equal(client.getSTH(), STH_B);
+  });
+
+  test("an unwritable state file does not break request handling", async () => {
+    const { fetchImpl } = spyFetch([
+      fakeResponse(200, { "x-loopctl-current-sth": STH_B }),
+    ]);
+    const readFileSync = () => {
+      throw new Error("ENOENT");
+    };
+    const writeFileSync = () => {
+      throw new Error("EROFS");
+    };
+
+    const client = createWitnessClient({
+      fetchImpl,
+      statePath: "/state.json",
+      readFileSync,
+      writeFileSync,
+    });
+
+    const response = await client.send(req);
+
+    // Request still succeeds; STH cached in-memory despite the failed write.
+    assert.equal(response.status, 200);
+    assert.equal(client.getSTH(), STH_B);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wiring: index.js delegates apiCall to the shared witness client
+// ---------------------------------------------------------------------------
+
+describe("#298 wiring: index.js apiCall uses the shared witness client", () => {
+  test("constructs a witness client from resolveSthStatePath + fs", () => {
+    assert.match(
+      INDEX_SRC,
+      /const STH_STATE_PATH = resolveSthStatePath\(\{ env: process\.env, os, path \}\);/,
+      "index.js must resolve the STH state path via the shared helper",
+    );
+    assert.match(
+      INDEX_SRC,
+      /createWitnessClient\(\{[\s\S]*?statePath: STH_STATE_PATH,[\s\S]*?readFileSync,[\s\S]*?writeFileSync,[\s\S]*?\}\)/,
+      "index.js must build the witness client with the persistence fs handles",
+    );
+  });
+
+  test("apiCall delegates the request to witnessClient.send", () => {
+    assert.match(
+      INDEX_SRC,
+      /await witnessClient\.send\(\{ url, method, headers, serializedBody \}\)/,
+      "apiCall must send through the witness client (which owns STH + retry)",
+    );
+    // The old in-line STH caching / manual fetch must be gone from apiCall.
+    assert.ok(
+      !/let lastKnownSTH = null;/.test(INDEX_SRC),
+      "index.js must not keep a module-level in-memory-only lastKnownSTH",
+    );
+  });
+});

--- a/mcp-server/test/witness_sth.test.js
+++ b/mcp-server/test/witness_sth.test.js
@@ -1,19 +1,20 @@
 /**
- * Regression tests for the witness-protocol STH client (#298):
+ * Regression tests for the witness-protocol STH client (#298 + enhanced review):
  *
- *   - A bootstrap-grace 412 that carries `x-loopctl-current-sth` triggers a
- *     SINGLE transparent retry with that STH and returns the success response.
- *   - A persisted STH is loaded on construction and sent as
- *     `X-Loopctl-Last-Known-STH` on the FIRST request (no bootstrap 412).
+ *   - A bootstrap-grace 412 with `x-loopctl-current-sth` triggers a SINGLE
+ *     transparent retry, anchored to error.code, that returns the success
+ *     response (LOW-8).
+ *   - A persisted STH is loaded on construction and sent on the FIRST request.
  *   - A corrupt / missing state file degrades gracefully to bootstrap + retry.
- *   - The retry is bounded to a single attempt (never a loop).
- *   - Pure helpers: isValidSth / bootstrapRetrySth / resolveSthStatePath /
- *     loadPersistedSth / persistSth.
+ *   - Persistence is per-(server + key): distinct keys never collide (HIGH-2).
+ *   - The state write is atomic + symlink-safe (temp + `wx` + rename) (HIGH-1),
+ *     and load refuses a symlink / foreign-owned file (HIGH-1).
+ *   - Concurrent cold-start sends coalesce into ONE bootstrap (MEDIUM-6).
+ *   - 409 is NOT auto-retried (MEDIUM-4).
  *
- * SINGLE SOURCE OF TRUTH: the retry + persistence logic lives in
- * ../lib/witness-sth.js, imported by BOTH the real server (index.js) and these
- * tests, so a regression in that logic fails CI. A wiring assertion at the end
- * pins that index.js actually delegates apiCall to the shared witness client.
+ * SINGLE SOURCE OF TRUTH: the logic lives in ../lib/witness-sth.js, imported by
+ * BOTH the real server (index.js) and these tests. Wiring assertions at the end
+ * pin that index.js delegates apiCall to a PER-KEY witness client.
  *
  * Run: node --test test/*.test.js
  */
@@ -39,21 +40,27 @@ const INDEX_SRC = readFileSync(
   "utf8",
 );
 
-// A well-formed `<position>:<22-char base64url prefix>` STH value.
+// Well-formed `<position>:<22-char base64url prefix>` STH values.
 const STH_A = "5:AAAAAAAAAAAAAAAAAAAAAA";
 const STH_B = "9:ZZZZZZZZZZZZZZZZZZZZZZ";
 
-// Build a fake Response with a header bag and a status.
-function fakeResponse(status, headers = {}) {
+// Build a fake Response with a header bag, a status, and an optional JSON body.
+function fakeResponse(status, headers = {}, body) {
   const lower = {};
   for (const [k, v] of Object.entries(headers)) lower[k.toLowerCase()] = v;
   return {
     status,
     headers: { get: (name) => lower[name.toLowerCase()] ?? null },
+    clone: () => ({
+      async json() {
+        if (body === undefined) throw new Error("no body");
+        return body;
+      },
+    }),
   };
 }
 
-// A fetch spy that returns queued responses in order and records each call.
+// A fetch spy returning queued responses in order (last repeats), recording calls.
 function spyFetch(responses) {
   const calls = [];
   const queue = [...responses];
@@ -64,184 +71,239 @@ function spyFetch(responses) {
   return { fetchImpl, calls };
 }
 
+// Minimal in-memory fs honoring `wx` (O_EXCL) and rename semantics.
+function memFs(initial = {}, { uid = 1000, symlinks = new Set() } = {}) {
+  const files = new Map(Object.entries(initial));
+  const enoent = () => {
+    const e = new Error("ENOENT");
+    e.code = "ENOENT";
+    return e;
+  };
+  return {
+    files,
+    readFileSync(p) {
+      if (!files.has(p)) throw enoent();
+      return files.get(p);
+    },
+    lstatSync(p) {
+      if (!files.has(p) && !symlinks.has(p)) throw enoent();
+      return { isSymbolicLink: () => symlinks.has(p), uid };
+    },
+    writeFileSync(p, data, opts) {
+      if (opts && opts.flag === "wx" && files.has(p)) {
+        const e = new Error("EEXIST");
+        e.code = "EEXIST";
+        throw e;
+      }
+      files.set(p, data);
+    },
+    renameSync(from, to) {
+      if (!files.has(from)) throw enoent();
+      files.set(to, files.get(from));
+      files.delete(from);
+    },
+    unlinkSync(p) {
+      files.delete(p);
+    },
+  };
+}
+
+const getuid1000 = () => 1000;
+
 // ---------------------------------------------------------------------------
-// isValidSth
+// isValidSth / bootstrapRetrySth
 // ---------------------------------------------------------------------------
 
 describe("isValidSth", () => {
   test("accepts a position + 22-char base64url prefix", () => {
     assert.equal(isValidSth(STH_A), true);
     assert.equal(isValidSth("0:AAAAAAAAAAAAAAAAAAAAAA"), true);
-    assert.equal(isValidSth("123456:_-AAAAAAAAAAAAAAAAAAAA"), true);
   });
-
-  test("rejects malformed / short / non-base64url / non-string values", () => {
+  test("rejects malformed / non-base64url / non-string values", () => {
     assert.equal(isValidSth("5:"), false);
-    assert.equal(isValidSth("5:abc"), false);
-    assert.equal(isValidSth("5:" + "A".repeat(23)), false);
-    assert.equal(isValidSth("5:AAAAAAAAAA++//AAAAAAAA"), false); // standard, not url
+    assert.equal(isValidSth("5:AAAAAAAAAA++//AAAAAAAA"), false);
     assert.equal(isValidSth("x:AAAAAAAAAAAAAAAAAAAAAA"), false);
     assert.equal(isValidSth(null), false);
-    assert.equal(isValidSth(undefined), false);
-    assert.equal(isValidSth(5), false);
   });
 });
-
-// ---------------------------------------------------------------------------
-// bootstrapRetrySth
-// ---------------------------------------------------------------------------
 
 describe("bootstrapRetrySth", () => {
-  test("returns the STH on a 412 carrying a valid current-sth header", () => {
+  test("returns the STH only on a 412 with a valid current-sth header", () => {
     assert.equal(bootstrapRetrySth(412, STH_A), STH_A);
-  });
-
-  test("returns null for non-412 statuses even with a valid STH", () => {
     assert.equal(bootstrapRetrySth(200, STH_A), null);
     assert.equal(bootstrapRetrySth(409, STH_A), null);
-    assert.equal(bootstrapRetrySth(500, STH_A), null);
-  });
-
-  test("returns null for a 412 without / with a malformed STH header", () => {
-    assert.equal(bootstrapRetrySth(412, null), null);
-    assert.equal(bootstrapRetrySth(412, undefined), null);
     assert.equal(bootstrapRetrySth(412, "not-an-sth"), null);
+    assert.equal(bootstrapRetrySth(412, null), null);
   });
 });
 
 // ---------------------------------------------------------------------------
-// resolveSthStatePath
+// resolveSthStatePath — per-(server + key) scoping (HIGH-2)
 // ---------------------------------------------------------------------------
 
-describe("resolveSthStatePath", () => {
+describe("resolveSthStatePath — per-key scoping (HIGH-2)", () => {
   const os = { tmpdir: () => "/tmp" };
-  const path = { join: (...p) => p.join("/") };
+  const p = { join: (...parts) => parts.join("/") };
 
-  test("honors an explicit LOOPCTL_STH_STATE_PATH override", () => {
+  test("honors an explicit override", () => {
     const env = { [STH_STATE_PATH_ENV]: "/custom/sth.json" };
-    assert.equal(resolveSthStatePath({ env, os, path }), "/custom/sth.json");
+    assert.equal(resolveSthStatePath({ env, os, path: p, apiKey: "k" }), "/custom/sth.json");
   });
 
-  test("ignores a blank override and derives a per-server temp path", () => {
-    const env = { [STH_STATE_PATH_ENV]: "   ", LOOPCTL_SERVER: "https://loopctl.com" };
-    const result = resolveSthStatePath({ env, os, path });
+  test("derives a per-server temp path", () => {
+    const env = { LOOPCTL_SERVER: "https://loopctl.com" };
+    const result = resolveSthStatePath({ env, os, path: p, apiKey: "k1" });
     assert.match(result, /^\/tmp\/loopctl-mcp-sth-[0-9a-f]{16}\.json$/);
   });
 
-  test("derives distinct files for distinct servers", () => {
-    const a = resolveSthStatePath({ env: { LOOPCTL_SERVER: "https://a.example" }, os, path });
-    const b = resolveSthStatePath({ env: { LOOPCTL_SERVER: "https://b.example" }, os, path });
+  test("DIFFERENT keys against the SAME server never share a cache file", () => {
+    const env = { LOOPCTL_SERVER: "https://loopctl.com" };
+    const a = resolveSthStatePath({ env, os, path: p, apiKey: "key-A" });
+    const b = resolveSthStatePath({ env, os, path: p, apiKey: "key-B" });
     assert.notEqual(a, b);
   });
 
-  test("is stable for the same server (ignoring a trailing slash)", () => {
-    const a = resolveSthStatePath({ env: { LOOPCTL_SERVER: "https://a.example" }, os, path });
-    const b = resolveSthStatePath({ env: { LOOPCTL_SERVER: "https://a.example/" }, os, path });
-    assert.equal(a, b);
+  test("same (server, key) is stable; different servers differ", () => {
+    const a = resolveSthStatePath({ env: { LOOPCTL_SERVER: "https://a" }, os, path: p, apiKey: "k" });
+    const a2 = resolveSthStatePath({ env: { LOOPCTL_SERVER: "https://a/" }, os, path: p, apiKey: "k" });
+    const b = resolveSthStatePath({ env: { LOOPCTL_SERVER: "https://b" }, os, path: p, apiKey: "k" });
+    assert.equal(a, a2);
+    assert.notEqual(a, b);
+  });
+
+  test("the api key never appears in plaintext in the derived path", () => {
+    const env = { LOOPCTL_SERVER: "https://loopctl.com" };
+    const secret = "lc_supersecretkey";
+    const result = resolveSthStatePath({ env, os, path: p, apiKey: secret });
+    assert.ok(!result.includes(secret));
   });
 });
 
 // ---------------------------------------------------------------------------
-// loadPersistedSth / persistSth (injected fs, never touches real disk)
+// loadPersistedSth — symlink / ownership guard (HIGH-1)
 // ---------------------------------------------------------------------------
 
 describe("loadPersistedSth", () => {
-  test("returns the STH from a well-formed state file", () => {
-    const readFileSync = () => JSON.stringify({ sth: STH_A, updated_at: "x" });
-    assert.equal(loadPersistedSth("/x", { readFileSync }), STH_A);
+  test("returns the STH from a well-formed, regular, owned file", () => {
+    const fs = memFs({ "/x": JSON.stringify({ sth: STH_A }) });
+    assert.equal(loadPersistedSth("/x", { fs, getuid: getuid1000 }), STH_A);
   });
 
-  test("returns null when the file is missing (readFileSync throws)", () => {
-    const readFileSync = () => {
-      throw new Error("ENOENT");
-    };
-    assert.equal(loadPersistedSth("/x", { readFileSync }), null);
+  test("returns null when the file is missing", () => {
+    const fs = memFs({});
+    assert.equal(loadPersistedSth("/x", { fs, getuid: getuid1000 }), null);
   });
 
-  test("returns null for non-JSON / corrupt content", () => {
-    const readFileSync = () => "}{ not json";
-    assert.equal(loadPersistedSth("/x", { readFileSync }), null);
+  test("REFUSES a symlink at the path (CWE-59) → null", () => {
+    const fs = memFs({ "/x": JSON.stringify({ sth: STH_A }) }, { symlinks: new Set(["/x"]) });
+    assert.equal(loadPersistedSth("/x", { fs, getuid: getuid1000 }), null);
   });
 
-  test("returns null when the stored STH is shape-invalid", () => {
-    const readFileSync = () => JSON.stringify({ sth: "garbage" });
-    assert.equal(loadPersistedSth("/x", { readFileSync }), null);
-  });
-});
-
-describe("persistSth", () => {
-  test("writes a valid STH and reports success", () => {
-    let written;
-    const writeFileSync = (p, data) => {
-      written = { p, data };
-    };
-    assert.equal(persistSth("/x", STH_A, { writeFileSync }), true);
-    assert.equal(written.p, "/x");
-    assert.deepEqual(JSON.parse(written.data).sth, STH_A);
+  test("REFUSES a foreign-owned file → null", () => {
+    const fs = memFs({ "/x": JSON.stringify({ sth: STH_A }) }, { uid: 4242 });
+    assert.equal(loadPersistedSth("/x", { fs, getuid: getuid1000 }), null);
   });
 
-  test("refuses to persist a shape-invalid STH", () => {
-    let called = false;
-    const writeFileSync = () => {
-      called = true;
-    };
-    assert.equal(persistSth("/x", "garbage", { writeFileSync }), false);
-    assert.equal(called, false);
-  });
-
-  test("degrades to false when the write throws (read-only dir, full disk)", () => {
-    const writeFileSync = () => {
-      throw new Error("EROFS");
-    };
-    assert.equal(persistSth("/x", STH_A, { writeFileSync }), false);
+  test("returns null for corrupt / shape-invalid content", () => {
+    assert.equal(loadPersistedSth("/x", { fs: memFs({ "/x": "}{" }), getuid: getuid1000 }), null);
+    assert.equal(
+      loadPersistedSth("/x", { fs: memFs({ "/x": JSON.stringify({ sth: "garbage" }) }), getuid: getuid1000 }),
+      null,
+    );
   });
 });
 
 // ---------------------------------------------------------------------------
-// createWitnessClient.send — the transparent bootstrap-412 retry
+// persistSth — atomic + symlink-safe write (HIGH-1)
+// ---------------------------------------------------------------------------
+
+describe("persistSth — atomic + symlink-safe (HIGH-1)", () => {
+  test("writes to a temp file with wx+0600 then renames over the target", () => {
+    const events = [];
+    const fs = {
+      writeFileSync: (p, data, opts) => events.push({ op: "write", p, opts }),
+      renameSync: (from, to) => events.push({ op: "rename", from, to }),
+      unlinkSync: (p) => events.push({ op: "unlink", p }),
+    };
+    assert.equal(persistSth("/state.json", STH_A, { fs, pid: 4321 }), true);
+
+    const write = events.find((e) => e.op === "write");
+    const rename = events.find((e) => e.op === "rename");
+    // Never writes directly to the target — a temp path derived from the pid.
+    assert.notEqual(write.p, "/state.json");
+    assert.match(write.p, /^\/state\.json\.4321\.[0-9a-f]+\.tmp$/);
+    // Exclusive create (refuses a pre-planted symlink) + private mode.
+    assert.equal(write.opts.flag, "wx");
+    assert.equal(write.opts.mode, 0o600);
+    // Atomic replace of the target ENTRY (never writes THROUGH a symlink there).
+    assert.equal(rename.from, write.p);
+    assert.equal(rename.to, "/state.json");
+  });
+
+  test("refuses to persist a shape-invalid STH (no write attempted)", () => {
+    let wrote = false;
+    const fs = { writeFileSync: () => (wrote = true), renameSync: () => {}, unlinkSync: () => {} };
+    assert.equal(persistSth("/x", "garbage", { fs, pid: 1 }), false);
+    assert.equal(wrote, false);
+  });
+
+  test("cleans up the temp file and returns false when rename fails", () => {
+    let unlinked = null;
+    const fs = {
+      writeFileSync: () => {},
+      renameSync: () => {
+        throw new Error("EXDEV");
+      },
+      unlinkSync: (p) => (unlinked = p),
+    };
+    assert.equal(persistSth("/state.json", STH_A, { fs, pid: 7 }), false);
+    assert.match(unlinked, /^\/state\.json\.7\.[0-9a-f]+\.tmp$/);
+  });
+
+  test("degrades to false when the exclusive create is refused (pre-planted temp)", () => {
+    const fs = {
+      writeFileSync: () => {
+        const e = new Error("EEXIST");
+        e.code = "EEXIST";
+        throw e;
+      },
+      renameSync: () => {},
+      unlinkSync: () => {},
+    };
+    assert.equal(persistSth("/state.json", STH_A, { fs, pid: 9 }), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createWitnessClient.send — transparent bootstrap-412 retry
 // ---------------------------------------------------------------------------
 
 describe("createWitnessClient.send — bootstrap-grace 412 retry", () => {
   const req = { url: "https://x/api/v1/tenants/me", method: "GET", headers: {} };
 
-  test("a 412 carrying current-sth triggers exactly ONE retry that succeeds", async () => {
+  test("a 412 (correct error.code) triggers exactly ONE retry that succeeds", async () => {
     const { fetchImpl, calls } = spyFetch([
-      fakeResponse(412, { "x-loopctl-current-sth": STH_A }),
+      fakeResponse(412, { "x-loopctl-current-sth": STH_A }, {
+        error: { code: "witness_bootstrap_already_consumed" },
+      }),
       fakeResponse(200, { "x-loopctl-current-sth": STH_A }),
     ]);
     const client = createWitnessClient({ fetchImpl });
 
     const response = await client.send(req);
 
-    // Returns the SUCCESS response, not the 412.
     assert.equal(response.status, 200);
-    // Exactly two attempts — a single bounded retry, never a loop.
     assert.equal(calls.length, 2);
-    // First attempt bootstrapped (no cached STH); retry sent the learned STH.
     assert.equal(calls[0].options.headers["X-Loopctl-STH-Bootstrap"], "true");
-    assert.equal(calls[0].options.headers["X-Loopctl-Last-Known-STH"], undefined);
     assert.equal(calls[1].options.headers["X-Loopctl-Last-Known-STH"], STH_A);
-    assert.equal(calls[1].options.headers["X-Loopctl-STH-Bootstrap"], undefined);
-    // The learned STH is cached for subsequent requests.
     assert.equal(client.getSTH(), STH_A);
   });
 
-  test("does NOT retry a 412 that lacks a valid current-sth header", async () => {
-    const { fetchImpl, calls } = spyFetch([fakeResponse(412, {})]);
-    const client = createWitnessClient({ fetchImpl });
-
-    const response = await client.send(req);
-
-    assert.equal(response.status, 412);
-    assert.equal(calls.length, 1);
-  });
-
-  test("is bounded to a single retry even if the retry also 412s", async () => {
-    // Server keeps 412-ing (pathological): the client must retry exactly once
-    // and then surface the 412 rather than looping forever.
+  test("anchors to error.code: a 412 with a DIFFERENT code is NOT retried (LOW-8)", async () => {
     const { fetchImpl, calls } = spyFetch([
-      fakeResponse(412, { "x-loopctl-current-sth": STH_A }),
-      fakeResponse(412, { "x-loopctl-current-sth": STH_A }),
+      fakeResponse(412, { "x-loopctl-current-sth": STH_A }, {
+        error: { code: "witness_header_malformed" },
+      }),
       fakeResponse(200),
     ]);
     const client = createWitnessClient({ fetchImpl });
@@ -249,159 +311,199 @@ describe("createWitnessClient.send — bootstrap-grace 412 retry", () => {
     const response = await client.send(req);
 
     assert.equal(response.status, 412);
-    assert.equal(calls.length, 2);
+    assert.equal(calls.length, 1);
   });
 
-  test("does not retry a plain 200 and caches its STH", async () => {
+  test("falls back to status+header when the 412 body is unreadable", async () => {
     const { fetchImpl, calls } = spyFetch([
-      fakeResponse(200, { "x-loopctl-current-sth": STH_B }),
+      fakeResponse(412, { "x-loopctl-current-sth": STH_A }), // no body → json() throws
+      fakeResponse(200),
     ]);
     const client = createWitnessClient({ fetchImpl });
 
     const response = await client.send(req);
-
     assert.equal(response.status, 200);
+    assert.equal(calls.length, 2);
+  });
+
+  test("does NOT retry a 412 lacking a valid current-sth header", async () => {
+    const { fetchImpl, calls } = spyFetch([fakeResponse(412, {})]);
+    const client = createWitnessClient({ fetchImpl });
+    const response = await client.send(req);
+    assert.equal(response.status, 412);
+    assert.equal(calls.length, 1);
+  });
+
+  test("does NOT auto-retry a 409 witness_divergence (MEDIUM-4)", async () => {
+    const { fetchImpl, calls } = spyFetch([
+      fakeResponse(409, { "x-loopctl-current-sth": STH_B }, {
+        error: { code: "witness_divergence" },
+      }),
+    ]);
+    const client = createWitnessClient({ fetchImpl });
+
+    const response = await client.send(req);
+    // Surfaced, not retried — but the STH is cached so the NEXT request self-heals.
+    assert.equal(response.status, 409);
     assert.equal(calls.length, 1);
     assert.equal(client.getSTH(), STH_B);
+  });
+
+  test("is bounded to a single retry even if the retry also 412s", async () => {
+    const { fetchImpl, calls } = spyFetch([
+      fakeResponse(412, { "x-loopctl-current-sth": STH_A }, {
+        error: { code: "witness_bootstrap_already_consumed" },
+      }),
+      fakeResponse(412, { "x-loopctl-current-sth": STH_A }, {
+        error: { code: "witness_bootstrap_already_consumed" },
+      }),
+      fakeResponse(200),
+    ]);
+    const client = createWitnessClient({ fetchImpl });
+
+    const response = await client.send(req);
+    assert.equal(response.status, 412);
+    assert.equal(calls.length, 2);
   });
 });
 
 // ---------------------------------------------------------------------------
-// createWitnessClient — startup persistence load
+// Cold-start coalescing (MEDIUM-6)
 // ---------------------------------------------------------------------------
 
-describe("createWitnessClient — persisted STH loaded on construction", () => {
+describe("createWitnessClient — cold-start singleflight (MEDIUM-6)", () => {
+  const req = { url: "https://x/api/v1/tenants/me", method: "GET", headers: {} };
+
+  test("concurrent cold-start sends coalesce into ONE bootstrap", async () => {
+    let served = 0;
+    const bootstrapCalls = [];
+    const fetchImpl = async (url, options) => {
+      if (options.headers["X-Loopctl-STH-Bootstrap"] === "true") bootstrapCalls.push(1);
+      served += 1;
+      // First bootstrap attempt returns the consumed-412; everything else 200.
+      if (served === 1) {
+        return fakeResponse(412, { "x-loopctl-current-sth": STH_A }, {
+          error: { code: "witness_bootstrap_already_consumed" },
+        });
+      }
+      return fakeResponse(200, { "x-loopctl-current-sth": STH_A });
+    };
+
+    const client = createWitnessClient({ fetchImpl });
+
+    // Fire three concurrent sends before any resolves.
+    const results = await Promise.all([client.send(req), client.send(req), client.send(req)]);
+
+    assert.deepEqual(results.map((r) => r.status), [200, 200, 200]);
+    // Only the leader bootstrapped; followers waited and sent the learned header.
+    assert.equal(bootstrapCalls.length, 1);
+    assert.equal(client.getSTH(), STH_A);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Persistence lifecycle (with the in-memory fs)
+// ---------------------------------------------------------------------------
+
+describe("createWitnessClient — persistence", () => {
   const req = { url: "https://x/api/v1/tenants/me", method: "GET", headers: {} };
 
   test("a persisted STH is loaded and sent on the FIRST request (no bootstrap)", async () => {
     const { fetchImpl, calls } = spyFetch([fakeResponse(200)]);
-    const readFileSync = () => JSON.stringify({ sth: STH_A });
+    const fs = memFs({ "/state.json": JSON.stringify({ sth: STH_A }) });
 
-    const client = createWitnessClient({
-      fetchImpl,
-      statePath: "/state.json",
-      readFileSync,
-    });
-
+    const client = createWitnessClient({ fetchImpl, statePath: "/state.json", fs, getuid: getuid1000 });
     assert.equal(client.getSTH(), STH_A);
 
     await client.send(req);
-
-    // First request carried the real header — never tripped the bootstrap path.
     assert.equal(calls[0].options.headers["X-Loopctl-Last-Known-STH"], STH_A);
     assert.equal(calls[0].options.headers["X-Loopctl-STH-Bootstrap"], undefined);
   });
 
-  test("a corrupt state file degrades to bootstrap + transparent retry", async () => {
+  test("a corrupt state file degrades to bootstrap + retry, then re-persists", async () => {
     const { fetchImpl, calls } = spyFetch([
-      fakeResponse(412, { "x-loopctl-current-sth": STH_A }),
+      fakeResponse(412, { "x-loopctl-current-sth": STH_A }, {
+        error: { code: "witness_bootstrap_already_consumed" },
+      }),
       fakeResponse(200),
     ]);
-    const readFileSync = () => "corrupt-not-json";
-    let persisted = null;
-    const writeFileSync = (p, data) => {
-      persisted = JSON.parse(data).sth;
-    };
+    const fs = memFs({ "/state.json": "corrupt-not-json" });
 
-    const client = createWitnessClient({
-      fetchImpl,
-      statePath: "/state.json",
-      readFileSync,
-      writeFileSync,
-    });
-
-    // Corrupt file → no STH loaded → first request bootstraps.
+    const client = createWitnessClient({ fetchImpl, statePath: "/state.json", fs, getuid: getuid1000 });
     assert.equal(client.getSTH(), null);
 
     const response = await client.send(req);
-
     assert.equal(response.status, 200);
     assert.equal(calls.length, 2);
-    assert.equal(calls[0].options.headers["X-Loopctl-STH-Bootstrap"], "true");
-    assert.equal(calls[1].options.headers["X-Loopctl-Last-Known-STH"], STH_A);
-    // The relearned STH was persisted for the next fresh process.
-    assert.equal(persisted, STH_A);
+    // The relearned STH was persisted (atomically) for the next fresh process.
+    assert.equal(JSON.parse(fs.files.get("/state.json")).sth, STH_A);
   });
 
   test("persists a newly-learned STH from a successful response", async () => {
-    const { fetchImpl } = spyFetch([
-      fakeResponse(200, { "x-loopctl-current-sth": STH_B }),
-    ]);
-    let persisted = null;
-    const writeFileSync = (p, data) => {
-      persisted = JSON.parse(data).sth;
-    };
-    const readFileSync = () => {
-      throw new Error("ENOENT");
-    };
-
-    const client = createWitnessClient({
-      fetchImpl,
-      statePath: "/state.json",
-      readFileSync,
-      writeFileSync,
-    });
+    const { fetchImpl } = spyFetch([fakeResponse(200, { "x-loopctl-current-sth": STH_B })]);
+    const fs = memFs({});
+    const client = createWitnessClient({ fetchImpl, statePath: "/state.json", fs, getuid: getuid1000 });
 
     await client.send(req);
-
-    assert.equal(persisted, STH_B);
     assert.equal(client.getSTH(), STH_B);
+    assert.equal(JSON.parse(fs.files.get("/state.json")).sth, STH_B);
   });
 
   test("an unwritable state file does not break request handling", async () => {
-    const { fetchImpl } = spyFetch([
-      fakeResponse(200, { "x-loopctl-current-sth": STH_B }),
-    ]);
-    const readFileSync = () => {
-      throw new Error("ENOENT");
+    const { fetchImpl } = spyFetch([fakeResponse(200, { "x-loopctl-current-sth": STH_B })]);
+    const fs = {
+      readFileSync: () => {
+        throw new Error("ENOENT");
+      },
+      lstatSync: () => {
+        throw new Error("ENOENT");
+      },
+      writeFileSync: () => {
+        throw new Error("EROFS");
+      },
+      renameSync: () => {},
+      unlinkSync: () => {},
     };
-    const writeFileSync = () => {
-      throw new Error("EROFS");
-    };
-
-    const client = createWitnessClient({
-      fetchImpl,
-      statePath: "/state.json",
-      readFileSync,
-      writeFileSync,
-    });
+    const client = createWitnessClient({ fetchImpl, statePath: "/state.json", fs, getuid: getuid1000 });
 
     const response = await client.send(req);
-
-    // Request still succeeds; STH cached in-memory despite the failed write.
     assert.equal(response.status, 200);
-    assert.equal(client.getSTH(), STH_B);
+    assert.equal(client.getSTH(), STH_B); // cached in-memory despite failed write
   });
 });
 
 // ---------------------------------------------------------------------------
-// Wiring: index.js delegates apiCall to the shared witness client
+// Wiring: index.js delegates apiCall to a PER-KEY witness client
 // ---------------------------------------------------------------------------
 
-describe("#298 wiring: index.js apiCall uses the shared witness client", () => {
-  test("constructs a witness client from resolveSthStatePath + fs", () => {
+describe("#298 wiring: per-key witness client", () => {
+  test("resolves a per-(server + key) state path", () => {
     assert.match(
       INDEX_SRC,
-      /const STH_STATE_PATH = resolveSthStatePath\(\{ env: process\.env, os, path \}\);/,
-      "index.js must resolve the STH state path via the shared helper",
-    );
-    assert.match(
-      INDEX_SRC,
-      /createWitnessClient\(\{[\s\S]*?statePath: STH_STATE_PATH,[\s\S]*?readFileSync,[\s\S]*?writeFileSync,[\s\S]*?\}\)/,
-      "index.js must build the witness client with the persistence fs handles",
+      /resolveSthStatePath\(\{ env: process\.env, os, path, apiKey \}\)/,
+      "state path must be scoped by apiKey",
     );
   });
 
-  test("apiCall delegates the request to witnessClient.send", () => {
+  test("keeps ONE witness client per api key (Map keyed by key)", () => {
+    assert.match(INDEX_SRC, /const witnessClients = new Map\(\);/);
     assert.match(
       INDEX_SRC,
-      /await witnessClient\.send\(\{ url, method, headers, serializedBody \}\)/,
-      "apiCall must send through the witness client (which owns STH + retry)",
+      /function witnessClientFor\(apiKey\) \{[\s\S]*?witnessClients\.get\(apiKey\)/,
+      "witnessClientFor must look the client up by api key",
     );
-    // The old in-line STH caching / manual fetch must be gone from apiCall.
-    assert.ok(
-      !/let lastKnownSTH = null;/.test(INDEX_SRC),
-      "index.js must not keep a module-level in-memory-only lastKnownSTH",
+  });
+
+  test("apiCall sends through the per-key client and passes the symlink-safe fs", () => {
+    assert.match(
+      INDEX_SRC,
+      /await witnessClientFor\(key\)\.send\(\{ url, method, headers, serializedBody \}\)/,
     );
+    assert.match(
+      INDEX_SRC,
+      /WITNESS_FS = \{ readFileSync, writeFileSync, renameSync, lstatSync, unlinkSync \}/,
+      "the witness fs must include renameSync + lstatSync for atomic + guarded I/O",
+    );
+    assert.ok(!/let lastKnownSTH = null;/.test(INDEX_SRC));
   });
 });

--- a/test/loopctl_web/plugs/validate_witness_header_test.exs
+++ b/test/loopctl_web/plugs/validate_witness_header_test.exs
@@ -265,20 +265,29 @@ defmodule LoopctlWeb.Plugs.ValidateWitnessHeaderTest do
       assert remediation["retry"]["max_retries"] == 1
     end
 
-    test "the already-consumed 412 carries the zero STH header even when the tenant has no STH" do
-      # Guarantee holds on the no-STH branch too: current_sth_value/1 falls back to
-      # the all-zero STH, so the header is ALWAYS present and shape-valid — the
-      # retry path can never be stranded by a header-less 412.
+    test "the already-consumed 412 reuses the read STH — no second audit_signed_tree_heads query (#298 review MEDIUM-7)" do
+      # The PR's central efficiency + no-500 claim: the already-consumed 412 hands
+      # back the STH read ONCE in consume_grace, never re-querying it. Count the
+      # audit_signed_tree_heads reads during the 412 request: exactly one.
       {_raw, api_key} = fixture(:api_key, %{role: :agent})
+      _server_prefix = insert_sth(api_key.tenant_id, 3)
 
       _ = api_key |> bootstrap_conn() |> ValidateWitnessHeader.call(@enforce)
       reloaded = AdminRepo.get!(ApiKey, api_key.id)
 
-      conn = reloaded |> bootstrap_conn() |> ValidateWitnessHeader.call(@enforce)
+      sth_queries =
+        capture_admin_sth_queries(fn ->
+          conn = reloaded |> bootstrap_conn() |> ValidateWitnessHeader.call(@enforce)
 
-      assert conn.status == 412
-      assert [sth] = get_resp_header(conn, "x-loopctl-current-sth")
-      assert sth =~ ~r/\A\d+:[A-Za-z0-9_-]{22}\z/
+          assert conn.status == 412
+
+          assert Jason.decode!(conn.resp_body)["error"]["code"] ==
+                   "witness_bootstrap_already_consumed"
+        end)
+
+      assert length(sth_queries) == 1,
+             "already-consumed 412 must read the STH exactly once (reuse, not re-query), " <>
+               "got #{length(sth_queries)}"
     end
 
     test "consumed-grace 412 emits a distinct telemetry event for the operator" do
@@ -396,6 +405,98 @@ defmodule LoopctlWeb.Plugs.ValidateWitnessHeaderTest do
       assert conn.halted
       assert conn.status == 412
       assert Jason.decode!(conn.resp_body)["error"]["code"] == "witness_header_malformed"
+    end
+  end
+
+  describe "FIX #298 review HIGH-3 — fresh-tenant zero-STH placeholder does not 409-loop" do
+    # base64url(no padding) of 16 zero bytes — the all-zero placeholder the
+    # bootstrap grace issues while a tenant has no sealed STH yet.
+    @zero_prefix Base.url_encode64(:binary.copy(<<0>>, 16), padding: false)
+
+    test "echoing the zero-STH placeholder PASSES when the tenant has no sealed STH" do
+      # A new tenant has a ~60s window (before ComputeSthWorker seals its first
+      # STH) where the bootstrap hands out `0:<zero_prefix>`. A subsequent request
+      # echoing exactly that must NOT 409 — there is nothing to diverge from, and
+      # the 412-only client retry could never recover from a 409 here.
+      {_raw, api_key} = fixture(:api_key, %{role: :agent})
+
+      conn =
+        base_conn()
+        |> put_req_header("x-loopctl-last-known-sth", "0:#{@zero_prefix}")
+        |> with_api_key(api_key)
+        |> ValidateWitnessHeader.call(@enforce)
+
+      refute conn.halted
+      assert is_nil(conn.status)
+    end
+
+    test "the zero-STH placeholder is NOT a free pass once a real STH is sealed" do
+      # Discriminating: once the tenant has a sealed STH, the zero placeholder no
+      # longer matches (get_sth_at_position finds the real STH) → genuine 409. The
+      # pass-through is gated strictly on there being NO sealed STH.
+      {_raw, api_key} = fixture(:api_key, %{role: :agent})
+      insert_sth(api_key.tenant_id, 5)
+
+      conn =
+        base_conn()
+        |> put_req_header("x-loopctl-last-known-sth", "0:#{@zero_prefix}")
+        |> with_api_key(api_key)
+        |> ValidateWitnessHeader.call(@enforce)
+
+      assert conn.halted
+      assert conn.status == 409
+      assert Jason.decode!(conn.resp_body)["error"]["code"] == "witness_divergence"
+    end
+
+    test "a non-zero position with no sealed STH still resyncs (only the zero placeholder passes)" do
+      # The pass-through is scoped to position 0 + the zero prefix. A client that
+      # claims some other position while nothing is sealed cannot have gotten it
+      # from us → resync, never a bypass.
+      {_raw, api_key} = fixture(:api_key, %{role: :agent})
+
+      conn =
+        base_conn()
+        |> put_req_header("x-loopctl-last-known-sth", "7:#{@other_prefix}")
+        |> with_api_key(api_key)
+        |> ValidateWitnessHeader.call(@enforce)
+
+      assert conn.halted
+      assert conn.status == 409
+      assert Jason.decode!(conn.resp_body)["error"]["code"] == "witness_divergence"
+    end
+  end
+
+  # Captures the SQL of every audit_signed_tree_heads query the AdminRepo runs
+  # inside `fun`, scoped to self() so concurrent async tests don't leak in.
+  defp capture_admin_sth_queries(fun) do
+    test_pid = self()
+    handler_id = "sth-query-capture-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach(
+      handler_id,
+      [:loopctl, :admin_repo, :query],
+      fn _event, _measurements, %{query: query}, _config ->
+        if self() == test_pid and String.contains?(query, "audit_signed_tree_heads") do
+          send(test_pid, {:sth_query, query})
+        end
+      end,
+      nil
+    )
+
+    try do
+      fun.()
+    after
+      :telemetry.detach(handler_id)
+    end
+
+    drain_sth_queries([])
+  end
+
+  defp drain_sth_queries(acc) do
+    receive do
+      {:sth_query, q} -> drain_sth_queries([q | acc])
+    after
+      0 -> Enum.reverse(acc)
     end
   end
 end

--- a/test/loopctl_web/plugs/validate_witness_header_test.exs
+++ b/test/loopctl_web/plugs/validate_witness_header_test.exs
@@ -235,6 +235,83 @@ defmodule LoopctlWeb.Plugs.ValidateWitnessHeaderTest do
                "witness_bootstrap_already_consumed"
     end
 
+    test "the already-consumed 412 ALWAYS carries a valid current-sth header + retry contract (#298)" do
+      # The linchpin that makes a fresh client's retry-once reliable: the
+      # bootstrap-already-consumed 412 must ALWAYS hand back the current STH (in
+      # the header AND the body) plus a machine-readable retry contract, so the
+      # client can cache it and retry the same request without rediscovering the
+      # protocol.
+      {_raw, api_key} = fixture(:api_key, %{role: :agent})
+      _server_prefix = insert_sth(api_key.tenant_id, 3)
+
+      _ = api_key |> bootstrap_conn() |> ValidateWitnessHeader.call(@enforce)
+      reloaded = AdminRepo.get!(ApiKey, api_key.id)
+
+      conn = reloaded |> bootstrap_conn() |> ValidateWitnessHeader.call(@enforce)
+
+      assert conn.status == 412
+      body = Jason.decode!(conn.resp_body)
+      assert body["error"]["code"] == "witness_bootstrap_already_consumed"
+
+      # Header is present and well-formed (position:22-char-base64url-prefix).
+      assert [sth] = get_resp_header(conn, "x-loopctl-current-sth")
+      assert sth =~ ~r/\A\d+:[A-Za-z0-9_-]{22}\z/
+
+      # The body echoes the same STH and the machine-readable retry contract.
+      remediation = body["error"]["remediation"]
+      assert remediation["current_sth"] == sth
+      assert remediation["retry"]["cache_header"] == "x-loopctl-current-sth"
+      assert remediation["retry"]["resend_as"] == "X-Loopctl-Last-Known-STH"
+      assert remediation["retry"]["max_retries"] == 1
+    end
+
+    test "the already-consumed 412 carries the zero STH header even when the tenant has no STH" do
+      # Guarantee holds on the no-STH branch too: current_sth_value/1 falls back to
+      # the all-zero STH, so the header is ALWAYS present and shape-valid — the
+      # retry path can never be stranded by a header-less 412.
+      {_raw, api_key} = fixture(:api_key, %{role: :agent})
+
+      _ = api_key |> bootstrap_conn() |> ValidateWitnessHeader.call(@enforce)
+      reloaded = AdminRepo.get!(ApiKey, api_key.id)
+
+      conn = reloaded |> bootstrap_conn() |> ValidateWitnessHeader.call(@enforce)
+
+      assert conn.status == 412
+      assert [sth] = get_resp_header(conn, "x-loopctl-current-sth")
+      assert sth =~ ~r/\A\d+:[A-Za-z0-9_-]{22}\z/
+    end
+
+    test "consumed-grace 412 emits a distinct telemetry event for the operator" do
+      # Observability: the consumed-grace 412 is expected/benign (retryable), so it
+      # emits its OWN event — separate from the divergence-alerting path — that an
+      # operator can meter without alarm.
+      {_raw, api_key} = fixture(:api_key, %{role: :agent})
+      _ = api_key |> bootstrap_conn() |> ValidateWitnessHeader.call(@enforce)
+      reloaded = AdminRepo.get!(ApiKey, api_key.id)
+
+      ref = make_ref()
+      test_pid = self()
+      handler_id = "witness-bootstrap-consumed-#{inspect(ref)}"
+
+      :telemetry.attach(
+        handler_id,
+        [:loopctl, :witness, :bootstrap_already_consumed],
+        fn event, measurements, metadata, _config ->
+          send(test_pid, {ref, event, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      _conn = reloaded |> bootstrap_conn() |> ValidateWitnessHeader.call(@enforce)
+
+      assert_receive {^ref, [:loopctl, :witness, :bootstrap_already_consumed], %{count: 1},
+                      %{tenant_id: tenant_id}}
+
+      assert tenant_id == api_key.tenant_id
+    end
+
     test "atomic consume is single-winner even when the in-memory struct still shows nil (TOCTOU)" do
       {_raw, api_key} = fixture(:api_key, %{role: :agent})
       assert is_nil(api_key.sth_bootstrap_consumed_at)


### PR DESCRIPTION
## Summary

Fixes #298 (and the #299 root cause): a fresh MCP-server process reusing a
long-lived env-var key (`LOOPCTL_AGENT_KEY`, `LOOPCTL_ORCH_KEY`, …) failed its
**first tool call** with `412 witness_bootstrap_already_consumed`, because the
witness protocol's one-time bootstrap grace is consumed once per API key and the
MCP server kept the learned Signed Tree Head (STH) in memory only.

Two parts: a client-robustness fix in the MCP server, and a careful,
security-neutral server-side hardening of the witness plug.

## Part A — MCP server client robustness

- **Cross-process persistence.** The learned STH is cached to a small per-server
  state file (default `<os-tmp>/loopctl-mcp-sth-<hash>.json`, override via
  `LOOPCTL_STH_STATE_PATH`) so a fresh process loads it and sends
  `X-Loopctl-Last-Known-STH` on its first request — avoiding the 412 entirely.
  STHs are append-only (one row per `(tenant_id, chain_position)`), so a persisted
  historical STH still validates; it is never a stale-STH 409 trap.
- **Transparent retry-once.** Any `412` carrying an `x-loopctl-current-sth` header
  is caught, the STH is cached, and the SAME request is retried exactly **once**
  with the real header — so the tool call succeeds instead of surfacing the 412.
  Bounded to a single attempt (never a loop). Safe because the witness plug halts
  *before* the operation runs, so the rejected request had no side effect (even
  for POSTs).
- Logic extracted to `mcp-server/lib/witness-sth.js` (shared with the test suite,
  single source of truth); `apiCall` delegates to it. All file I/O degrades
  gracefully (missing/corrupt/unwritable → in-memory + retry).
- Docs: README "Witness protocol (STH)" section + `LOOPCTL_STH_STATE_PATH`;
  version bump **2.32.0 → 2.33.0** + CHANGELOG entry.
- Tests: `mcp-server/test/witness_sth.test.js` — 412-with-STH triggers a single
  transparent retry that succeeds; persisted STH loaded on startup + sent on the
  first request; corrupt/missing/unwritable state file degrades to bootstrap +
  retry; retry bounded to one attempt. **99/99 node tests pass.**

## Part B — server-side protocol hardening (security-neutral)

In `lib/loopctl_web/plugs/validate_witness_header.ex`:

- The `witness_bootstrap_already_consumed` 412 now **reuses the STH already read**
  (successfully, inside the rescue-guarded block) before the atomic consume — no
  second DB round-trip — so it can **never become a 500** and **ALWAYS carries a
  valid `x-loopctl-current-sth` header** for the client's one-shot retry. This is
  the linchpin that makes retry-once reliable.
- Adds a **machine-readable retry contract** (`error.remediation.retry` +
  `current_sth`) so future clients don't rediscover the protocol.
- Adds a **distinct info log + `[:loopctl, :witness, :bootstrap_already_consumed]`
  telemetry event** so operators can meter consumed-grace 412s separately from the
  divergence-alerting path.

### Why this does NOT weaken chain-of-custody

The one-time bootstrap grace (`api_keys.sth_bootstrap_consumed_at`, custody-03 /
GHSA-36g5-mcrh-rcrm) is **unchanged**: the atomic conditional UPDATE guarded by
`is_nil(sth_bootstrap_consumed_at)` still lets exactly one first-request win, and
a consumed key's request is still **rejected and halted** (no operation runs). We
only make the *already-present* resync path (the STH was always returned in the
412 header) reliable, self-documenting, and observable. The STH handed back is
already public via `GET /api/v1/audit/sth/:tenant_id`. No role, RLS, or trust
boundary changed.

**Deliberately NOT done (would re-open custody-03):** making the grace repeatable,
per-request, unbounded, or letting a client skip witness enforcement. If reducing
412s further required weakening the gate, this PR stops at the safe changes above.

**Dispatch-based (v2) clients are already unaffected** — each dispatch mints a
fresh ephemeral key that gets its own clean one-time bootstrap. The affected
population is exactly the long-lived-env-key clients (the MCP server), which
Part A fixes.

## Verification

- `mix precommit` green (compile `--warnings-as-errors`, format, credo `--strict`,
  deps.audit, dialyzer 0, **3655 tests, 0 failures**) — incl. the witness/custody
  suite (`validate_witness_header_test.exs`, +4 new tests).
- mcp-server node suite: **99/99 pass**.

Draft — do not merge.
