### PR TITLE
feat(knowledge): surface semantic->keyword fallback_reason in search meta + telemetry (observability for #297)

### DIFF
--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -55,6 +55,7 @@ defmodule Loopctl.Knowledge do
   alias Loopctl.Knowledge.ConflictResolution
   alias Loopctl.Knowledge.KbCuration
   alias Loopctl.Knowledge.VectorSearch
+  alias Loopctl.Llm.ProviderError
   alias Loopctl.Projects.Project
   alias Loopctl.Webhooks.EventGenerator
   alias Loopctl.Workers.ArticleEmbeddingWorker
@@ -1528,16 +1529,25 @@ defmodule Loopctl.Knowledge do
       |> Enum.reject(&is_nil/1)
       |> Enum.take(limit * 2)
 
+    # The keyword_only fallback reason (#297) rides in the underlying combined
+    # search meta; carry it into the context meta so `/knowledge/context` is as
+    # diagnosable as `/knowledge/search`. Absent on the success path.
+    fallback_reason = search.meta[:fallback_reason]
+
     if article_ids == [] do
       {:ok,
        %{
          results: [],
-         meta: %{
-           total_count: 0,
-           limit: limit,
-           fallback: fallback?,
-           recency_weight: recency_weight
-         }
+         meta:
+           maybe_put_fallback_reason(
+             %{
+               total_count: 0,
+               limit: limit,
+               fallback: fallback?,
+               recency_weight: recency_weight
+             },
+             fallback_reason
+           )
        }}
     else
       articles = fetch_full_context_articles(tenant_id, article_ids)
@@ -1575,15 +1585,24 @@ defmodule Loopctl.Knowledge do
       {:ok,
        %{
          results: scored,
-         meta: %{
-           total_count: length(scored),
-           limit: limit,
-           fallback: fallback?,
-           recency_weight: recency_weight
-         }
+         meta:
+           maybe_put_fallback_reason(
+             %{
+               total_count: length(scored),
+               limit: limit,
+               fallback: fallback?,
+               recency_weight: recency_weight
+             },
+             fallback_reason
+           )
        }}
     end
   end
+
+  # Only surface `fallback_reason` when the combined search actually degraded — the
+  # success path leaves the key absent (never a stray `nil`).
+  defp maybe_put_fallback_reason(meta, nil), do: meta
+  defp maybe_put_fallback_reason(meta, reason), do: Map.put(meta, :fallback_reason, reason)
 
   defp fetch_full_context_articles(tenant_id, article_ids) do
     from(a in Article,
@@ -5602,7 +5621,13 @@ defmodule Loopctl.Knowledge do
 
   The query embedding is generated on-the-fly via the configured embedding
   client. If embedding generation fails (timeout, error, or circuit breaker),
-  falls back to keyword-only search with `fallback: true` in the response meta.
+  falls back to keyword-only search with `fallback: true` in the response meta,
+  plus a stable, non-sensitive `fallback_reason` tag naming WHY (#297) — e.g.
+  `"no_embedding_key"`, `"embedding_circuit_open"`, `"embedding_provider_error_401"`.
+  When the embedding SUCCEEDS but semantic ranking returns nothing (a recall
+  problem, not an embed failure), the meta carries `semantic_result_count: 0`
+  with `fallback: false` instead. Both cases also emit
+  `[:loopctl, :knowledge, :semantic_fallback]` telemetry + a warning log.
 
   ## Parameters
 
@@ -5683,6 +5708,13 @@ defmodule Loopctl.Knowledge do
       {{:ok, kw}, {:ok, embedding}} ->
         {:ok, semantic} = search_semantic(tenant_id, embedding, sub_opts)
 
+        # Distinguish the OTHER silent-degradation cause (#297): the embedding
+        # SUCCEEDED but semantic ranking returned nothing (a recall/HNSW problem,
+        # NOT an embed failure). Combined does NOT fall back here — keyword still
+        # merges — so this sets no fallback/fallback_reason; it only emits the
+        # alertable signal and the meta carries `semantic_result_count`.
+        maybe_emit_semantic_empty(tenant_id, length(semantic.results), query_string)
+
         {:ok, merged} = merge_results(kw, semantic, keyword_weight, semantic_weight, opts)
 
         maybe_record_search_access(
@@ -5695,8 +5727,12 @@ defmodule Loopctl.Knowledge do
 
         {:ok, merged}
 
-      {{:ok, kw}, {:error, _reason}} ->
-        # Fallback to keyword-only
+      {{:ok, kw}, {:error, reason}} ->
+        # Fallback to keyword-only. Capture the discarded embedding-error reason as
+        # a stable, non-sensitive tag (sanitized via ProviderError so no api key /
+        # provider body leaks), surface it in meta, and emit telemetry + a log so a
+        # silent degradation becomes alertable (#297).
+        fallback_reason = record_semantic_fallback(tenant_id, reason, query_string)
         paginated = paginate_results(kw.results, opts)
 
         maybe_record_search_access(
@@ -5714,6 +5750,7 @@ defmodule Loopctl.Knowledge do
              Map.merge(kw.meta, %{
                fallback: true,
                search_mode: "keyword_only",
+               fallback_reason: fallback_reason,
                total_count: kw.meta.total_count,
                limit: paginated.limit,
                offset: paginated.offset
@@ -5723,6 +5760,99 @@ defmodule Loopctl.Knowledge do
       {kw_error, _} ->
         kw_error
     end
+  end
+
+  # -- Semantic → keyword fallback observability (#297) ------------------------
+  #
+  # #297: at ~77k-article scale every knowledge_search/context silently returned
+  # `fallback: true, search_mode: "keyword_only"` and the discarded embedding-error
+  # `_reason` made the outage UNDIAGNOSABLE. These helpers capture the reason as a
+  # STABLE, non-sensitive tag, surface it in `meta.fallback_reason`, and emit an
+  # alertable telemetry event + log — WITHOUT changing the fallback behavior.
+
+  @doc """
+  Record a semantic→keyword-only degradation and return a stable, non-sensitive
+  `fallback_reason` tag for the response `meta` (#297).
+
+  `reason` is the discarded embedding-generation error term. It is sanitized via
+  `Loopctl.Llm.ProviderError.sanitize/1` FIRST, so no provider response body or api
+  key can ever reach the returned tag, the emitted telemetry, or the log line. The
+  mapping is a BOUNDED set (safe as a Prometheus label):
+
+    * `:no_api_key` → `"no_embedding_key"`
+    * `:circuit_open` → `"embedding_circuit_open"`
+    * `:timeout` → `"embedding_timeout"`
+    * `{:api_error, status, _}` → `"embedding_provider_error_<status>"` (status only)
+    * `{:request_failed, _}` → `"embedding_request_failed"`
+    * `{:embedding_crash, _}` → `"embedding_crash"`
+    * anything else → the generic `"embedding_error"` (the raw term is NEVER inspected)
+
+  Emits `[:loopctl, :knowledge, :semantic_fallback]` telemetry and a
+  `Logger.warning` naming the reason + tenant. The query TEXT never appears in
+  telemetry/logs (only its byte length), matching the other knowledge search
+  telemetry (id-only metadata).
+  """
+  @spec record_semantic_fallback(Ecto.UUID.t(), term(), String.t()) :: String.t()
+  def record_semantic_fallback(tenant_id, reason, query_string) do
+    tag = fallback_reason_tag(reason)
+    emit_semantic_fallback(tenant_id, tag, query_string, 0)
+    tag
+  end
+
+  # The "embed worked but recall is broken" cause of #297: the embedding SUCCEEDED
+  # but semantic ranking returned ZERO rows. Combined search does NOT fall back here
+  # (keyword still merges), so this emits the alertable signal WITHOUT a keyword_only
+  # fallback — callers see it via `meta.semantic_result_count`, operators via the
+  # `reason: "semantic_empty"` telemetry, keeping it distinct from an embed failure.
+  defp maybe_emit_semantic_empty(_tenant_id, count, _query_string) when count > 0, do: :ok
+
+  defp maybe_emit_semantic_empty(tenant_id, 0, query_string) do
+    emit_semantic_fallback(tenant_id, "semantic_empty", query_string, 0)
+    :ok
+  end
+
+  defp fallback_reason_tag(reason) do
+    reason
+    |> ProviderError.sanitize()
+    |> reason_to_tag()
+  end
+
+  defp reason_to_tag(:no_api_key), do: "no_embedding_key"
+  defp reason_to_tag(:circuit_open), do: "embedding_circuit_open"
+  defp reason_to_tag(:timeout), do: "embedding_timeout"
+
+  defp reason_to_tag({:api_error, status, _}) when is_integer(status),
+    do: "embedding_provider_error_#{status}"
+
+  defp reason_to_tag({:api_error, status}) when is_integer(status),
+    do: "embedding_provider_error_#{status}"
+
+  defp reason_to_tag({:request_failed, _}), do: "embedding_request_failed"
+  defp reason_to_tag({:embedding_crash, _}), do: "embedding_crash"
+  defp reason_to_tag(_other), do: "embedding_error"
+
+  # Query TEXT is deliberately excluded from telemetry/logs (only `query_len`) — the
+  # sibling knowledge telemetry (`keyset_byte_truncated`, `vector_search.under_fill`)
+  # carries id-only metadata, and this keeps that contract. The Prometheus counter
+  # (`Loopctl.Telemetry.ScaleMetrics`) tags ONLY by `reason` (a small fixed set) — no
+  # `tenant_id` label — so cardinality stays bounded.
+  defp emit_semantic_fallback(tenant_id, tag, query_string, semantic_result_count) do
+    :telemetry.execute(
+      Loopctl.TelemetryEvents.knowledge_semantic_fallback(),
+      %{
+        count: 1,
+        query_len: byte_size(query_string),
+        semantic_result_count: semantic_result_count
+      },
+      %{tenant_id: tenant_id, reason: tag}
+    )
+
+    Logger.warning(
+      "knowledge.semantic_fallback reason=#{tag} tenant_id=#{tenant_id} " <>
+        "query_len=#{byte_size(query_string)} (semantic ranking did not contribute)"
+    )
+
+    :ok
   end
 
   defp merge_results(keyword_result, semantic_result, kw_weight, sem_weight, opts) do
@@ -5768,7 +5898,12 @@ defmodule Loopctl.Knowledge do
          # — combined is the DEFAULT mode, so silently dropping the flag would hide
          # truncation on the most-used path. `maybe_put` keeps the key absent unless the
          # semantic half was actually pool-capped.
-         pool_capped: Map.get(semantic_result.meta, :pool_capped, false)
+         pool_capped: Map.get(semantic_result.meta, :pool_capped, false),
+         # Observability for #297: how many rows the semantic half contributed. A
+         # `0` here with `fallback: false` is the "embed worked but recall is broken"
+         # signal (distinct from an embed-failure keyword_only fallback), so operators
+         # and clients can tell the two silent-degradation causes apart.
+         semantic_result_count: length(semantic_result.results)
        }
      }}
   end

--- a/lib/loopctl/telemetry/scale_metrics.ex
+++ b/lib/loopctl/telemetry/scale_metrics.ex
@@ -118,8 +118,34 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
         description: "Vector-search recall under-fill events, by endpoint.",
         tags: [:endpoint, :tenant_id],
         tag_values: &scale_tags/1
+      ),
+
+      # 4. Semantic-fallback counter (#297), by REASON only. Turns the silent
+      #    semantic→keyword degradation into an alertable trend. `reason` is a
+      #    BOUNDED, sanitized tag set (no api key / provider body / raw query ever
+      #    reaches it), so this needs NO tenant_id label — the reason dimension is
+      #    fixed and small, and per-tenant attribution stays in the 7-day logs
+      #    (which carry tenant_id). NO tenant label = no multi-tenant cardinality
+      #    bomb (AC-27.15.3).
+      counter("loopctl.knowledge.semantic_fallback.count",
+        event_name: [:loopctl, :knowledge, :semantic_fallback],
+        measurement: :count,
+        description: "Semantic search degraded to keyword-only / contributed nothing, by reason.",
+        tags: [:reason],
+        tag_values: &semantic_fallback_tags/1
       )
     ]
+  end
+
+  @doc """
+  `tag_values` for the semantic-fallback counter (#297). Emits ONLY the bounded
+  `reason` label (never `tenant_id` — the reason set is fixed and small, so no cap
+  gate is needed). Defaults a missing reason to `"unknown"` so the label is never
+  blank.
+  """
+  @spec semantic_fallback_tags(map()) :: map()
+  def semantic_fallback_tags(metadata) do
+    %{reason: Map.get(metadata, :reason, "unknown")}
   end
 
   @doc """

--- a/lib/loopctl/telemetry_events.ex
+++ b/lib/loopctl/telemetry_events.ex
@@ -103,6 +103,36 @@ defmodule Loopctl.TelemetryEvents do
   """
   def db_error, do: [:loopctl, :db, :error]
 
+  @doc """
+  Semantic search silently degraded so semantic ranking did NOT contribute (#297).
+
+  Covers BOTH silent-degradation causes the issue conflated:
+
+    * an embedding-generation FAILURE that forced a keyword-only fallback
+      (`fallback: true` in the response meta), and
+    * an embedding SUCCESS whose semantic ranking returned zero rows
+      (`reason: "semantic_empty"`, a recall/HNSW problem, `fallback: false`).
+
+  Fires once per degraded request. Turns a silent 200 into an alertable signal.
+
+  ## Payload (id-only — NEVER the raw query text, an api key, or a provider body)
+
+    * `measurements`: `%{count: 1, query_len, semantic_result_count}` where
+        - `count` is a pure increment (the Prometheus counter's measurement).
+        - `query_len` is `byte_size(query)` — the query LENGTH only, never its text.
+        - `semantic_result_count` is how many rows the semantic half contributed
+          (`0` for an embed failure or a `semantic_empty` recall miss).
+    * `metadata`: `%{tenant_id, reason}` where `reason` is a BOUNDED, sanitized tag
+      (`no_embedding_key` | `embedding_circuit_open` | `embedding_timeout` |
+      `embedding_provider_error_<status>` | `embedding_request_failed` |
+      `embedding_crash` | `embedding_error` | `semantic_empty`) — sanitized through
+      `Loopctl.Llm.ProviderError.sanitize/1`, so no key/body ever reaches the label.
+
+  Aggregated by `Loopctl.Telemetry.ScaleMetrics` as a counter tagged by `reason`
+  ONLY (no `tenant_id` label — keeps cardinality bounded to the fixed reason set).
+  """
+  def knowledge_semantic_fallback, do: [:loopctl, :knowledge, :semantic_fallback]
+
   @doc "Returns all defined event names for attachment"
   def all_events do
     [
@@ -115,7 +145,8 @@ defmodule Loopctl.TelemetryEvents do
       webhook_delivery_exception(),
       audit_log_write(),
       vector_search_under_fill(),
-      db_error()
+      db_error(),
+      knowledge_semantic_fallback()
     ]
   end
 end

--- a/lib/loopctl_web/controllers/knowledge_context_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_context_controller.ex
@@ -116,7 +116,21 @@ defmodule LoopctlWeb.KnowledgeContextController do
                properties: %{
                  total_count: %OpenApiSpex.Schema{type: :integer},
                  limit: %OpenApiSpex.Schema{type: :integer},
-                 fallback: %OpenApiSpex.Schema{type: :boolean},
+                 fallback: %OpenApiSpex.Schema{
+                   type: :boolean,
+                   description:
+                     "true when the underlying combined search degraded to keyword-only " <>
+                       "because embedding generation failed. Present only when it degraded."
+                 },
+                 fallback_reason: %OpenApiSpex.Schema{
+                   type: :string,
+                   description:
+                     "Present only alongside `fallback: true` (#297): a stable, non-sensitive " <>
+                       "tag naming WHY semantic ranking was unavailable (never leaks an api key " <>
+                       "or provider body). One of `no_embedding_key`, `embedding_circuit_open`, " <>
+                       "`embedding_timeout`, `embedding_request_failed`, `embedding_crash`, " <>
+                       "`embedding_error`, or `embedding_provider_error_<status>`."
+                 },
                  recency_weight: %OpenApiSpex.Schema{type: :number}
                }
              }

--- a/lib/loopctl_web/controllers/knowledge_context_json.ex
+++ b/lib/loopctl_web/controllers/knowledge_context_json.ex
@@ -49,9 +49,16 @@ defmodule LoopctlWeb.KnowledgeContextJSON do
       recency_weight: meta.recency_weight
     }
 
-    case meta[:fallback] do
-      true -> Map.put(base, :fallback, true)
-      _ -> base
-    end
+    base
+    |> maybe_put_fallback(meta[:fallback])
+    # `fallback_reason` (#297): a stable, non-sensitive tag naming WHY the context's
+    # underlying combined search degraded to keyword_only. Present only on fallback.
+    |> maybe_put_fallback_reason(meta[:fallback_reason])
   end
+
+  defp maybe_put_fallback(map, true), do: Map.put(map, :fallback, true)
+  defp maybe_put_fallback(map, _), do: map
+
+  defp maybe_put_fallback_reason(map, nil), do: map
+  defp maybe_put_fallback_reason(map, reason), do: Map.put(map, :fallback_reason, reason)
 end

--- a/lib/loopctl_web/controllers/knowledge_search_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_search_controller.ex
@@ -226,6 +226,30 @@ defmodule LoopctlWeb.KnowledgeSearchController do
                      "Keyset path (include_body only): true when the page was shortened by " <>
                        "the serialized-body byte budget. next_cursor is then recomputed from " <>
                        "the last kept row, so following it returns the dropped rows (no gap)."
+                 },
+                 fallback: %OpenApiSpex.Schema{
+                   type: :boolean,
+                   description:
+                     "Relevance modes (combined / semantic): true when embedding generation " <>
+                       "failed and the request silently degraded to keyword_only. Present only " <>
+                       "when it degraded."
+                 },
+                 fallback_reason: %OpenApiSpex.Schema{
+                   type: :string,
+                   description:
+                     "Present only alongside `fallback: true` (#297): a stable, non-sensitive " <>
+                       "tag naming WHY semantic ranking was unavailable (never leaks an api key " <>
+                       "or provider body). One of `no_embedding_key`, `embedding_circuit_open`, " <>
+                       "`embedding_timeout`, `embedding_request_failed`, `embedding_crash`, " <>
+                       "`embedding_error`, or `embedding_provider_error_<status>` (e.g. " <>
+                       "`embedding_provider_error_401`, carrying only the HTTP status)."
+                 },
+                 semantic_result_count: %OpenApiSpex.Schema{
+                   type: :integer,
+                   description:
+                     "Combined mode only (#297): rows the semantic half contributed. `0` with " <>
+                       "no `fallback` means the embedding SUCCEEDED but ranking returned nothing " <>
+                       "(a recall problem) — distinct from a keyword_only fallback."
                  }
                }
              }
@@ -601,7 +625,7 @@ defmodule LoopctlWeb.KnowledgeSearchController do
       {:error, :no_api_key} ->
         # Mandatory BYO (review #8): a keyless tenant's explicit semantic search must
         # NOT 503. Degrade to keyword-only with `fallback: true`, mirroring combined.
-        semantic_keyword_fallback(tenant_id, q, opts)
+        semantic_keyword_fallback(tenant_id, q, opts, :no_api_key)
 
       {:error, _} ->
         {:error, :embedding_unavailable}
@@ -614,11 +638,24 @@ defmodule LoopctlWeb.KnowledgeSearchController do
 
   # Keyword-only degrade for a keyless-tenant semantic request: same shape as the
   # combined-search fallback so clients can detect it via `meta.fallback` /
-  # `meta.search_mode`.
-  defp semantic_keyword_fallback(tenant_id, q, opts) do
+  # `meta.search_mode`. Records the reason (#297) so this path is as diagnosable as
+  # combined — `record_semantic_fallback/3` maps it to a stable, non-sensitive tag
+  # and emits telemetry + a warning log.
+  defp semantic_keyword_fallback(tenant_id, q, opts, reason) do
+    fallback_reason = Knowledge.record_semantic_fallback(tenant_id, reason, q)
+
     case Knowledge.search_keyword(tenant_id, q, opts) do
       {:ok, %{meta: meta} = result} ->
-        {:ok, %{result | meta: Map.merge(meta, %{fallback: true, search_mode: "keyword_only"})}}
+        {:ok,
+         %{
+           result
+           | meta:
+               Map.merge(meta, %{
+                 fallback: true,
+                 search_mode: "keyword_only",
+                 fallback_reason: fallback_reason
+               })
+         }}
 
       other ->
         other

--- a/lib/loopctl_web/controllers/knowledge_search_json.ex
+++ b/lib/loopctl_web/controllers/knowledge_search_json.ex
@@ -154,6 +154,13 @@ defmodule LoopctlWeb.KnowledgeSearchJSON do
     # exceeds the relevance pool cap, so the tail is unreachable by deeper `offset` —
     # the consumer should switch to list mode for full enumeration.
     |> maybe_put(:pool_capped, meta[:pool_capped])
+    # `fallback_reason` (#297): a stable, non-sensitive tag naming WHY combined/semantic
+    # degraded to keyword_only (present only alongside `fallback: true`).
+    |> maybe_put(:fallback_reason, meta[:fallback_reason])
+    # `semantic_result_count` (#297): rows the semantic half contributed in combined
+    # mode. `0` with no `fallback` = "embed worked but recall is broken" — distinct
+    # from a keyword_only fallback.
+    |> maybe_put(:semantic_result_count, meta[:semantic_result_count])
     |> maybe_put_fallback(meta[:fallback])
   end
 

--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to `loopctl-mcp-server` are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 2.33.0 — 2026-07-03 (surface semantic→keyword fallback_reason — #297)
+
+### Changed
+
+- **`knowledge_search`** / **`knowledge_context`** tool descriptions now note that
+  when semantic ranking is unavailable the call transparently degrades to
+  keyword-only (`meta.fallback: true`, `meta.search_mode: "keyword_only"`) and
+  reports a new `meta.fallback_reason` — a stable, non-sensitive tag naming WHY
+  (`no_embedding_key`, `embedding_circuit_open`, `embedding_provider_error_<status>`,
+  `embedding_timeout`, `embedding_request_failed`, `embedding_crash`,
+  `embedding_error`). The reason never leaks an api key or provider body. Combined
+  mode additionally reports `meta.semantic_result_count`, so a `0` with
+  `fallback: false` (embedding worked but ranking returned nothing) is
+  distinguishable from an embedding-failure fallback. Observability only — the
+  fallback behavior is unchanged.
+
 ## 2.32.0 — 2026-07-03 (per-tenant BYO for embeddings — Epic 28 #179)
 
 ### Added

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -2585,7 +2585,11 @@ const TOOLS = [
       "list mode or knowledge_stats. " +
       "Pass story_id when working on a loopctl story so reads attribute correctly. " +
       "When you knowledge_get a result and it carries `potential_conflicts`, resolve it if it's " +
-      "material to your task (see knowledge_get / the conflict-resolution wiki playbook).",
+      "material to your task (see knowledge_get / the conflict-resolution wiki playbook). " +
+      "If semantic ranking is unavailable the search transparently degrades to keyword-only " +
+      "(meta.fallback: true, meta.search_mode: 'keyword_only') and now reports meta.fallback_reason " +
+      "— a stable tag naming WHY (e.g. no_embedding_key, embedding_circuit_open, " +
+      "embedding_provider_error_<status>, embedding_timeout).",
     inputSchema: {
       type: "object",
       properties: {
@@ -2674,7 +2678,10 @@ const TOOLS = [
       "memory, scope to a memory_type/agent/conversation via the memory_types/agents/" +
       "conversation_id filters (articles whose metadata carries those keys). NOTE (#163): for " +
       "an agent key, another agent's private/owner memories are never returned (results AND " +
-      "linked refs) regardless of the agents= filter — visibility is enforced, not advisory.",
+      "linked refs) regardless of the agents= filter — visibility is enforced, not advisory. " +
+      "If semantic ranking is unavailable this degrades to keyword-only (meta.fallback: true) and " +
+      "now reports meta.fallback_reason — a stable tag naming WHY (e.g. no_embedding_key, " +
+      "embedding_circuit_open, embedding_provider_error_<status>, embedding_timeout).",
     inputSchema: {
       type: "object",
       properties: {

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.32.0",
+  "version": "2.33.0",
   "description": "MCP server for loopctl — structural trust for AI development loops",
   "type": "module",
   "main": "index.js",

--- a/test/loopctl/knowledge_context_test.exs
+++ b/test/loopctl/knowledge_context_test.exs
@@ -297,6 +297,10 @@ defmodule Loopctl.KnowledgeContextTest do
       {:ok, result} = Knowledge.get_context(tenant.id, "embedding fallback")
 
       assert result.meta.fallback == true
+      # #297: the reason propagates from the underlying combined search into the
+      # context meta so /knowledge/context is as diagnosable as /knowledge/search.
+      # An unmapped bare atom reason collapses to the bounded generic tag.
+      assert result.meta.fallback_reason == "embedding_error"
     end
 
     test "results sorted by combined_score descending" do

--- a/test/loopctl/knowledge_semantic_search_test.exs
+++ b/test/loopctl/knowledge_semantic_search_test.exs
@@ -415,6 +415,182 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
     end
   end
 
+  # --- #297: fallback_reason + telemetry observability for the silent semantic→
+  # keyword degradation. Each fallback CAUSE must map to the right stable tag,
+  # NEVER leak the api key / provider body, fire the telemetry event, and the
+  # "embed worked but recall empty" case must be distinguishable from an embed
+  # failure. A successful semantic must set neither fallback nor fallback_reason.
+
+  describe "search_combined/3 - fallback_reason observability (#297)" do
+    # Attach a telemetry handler SCOPED to this test's tenant_id (unique UUID) so a
+    # parallel async test emitting the same global event can never leak into this
+    # one — the handler branches on tenant_id and NEVER raises (a raising handler
+    # would be auto-detached by :telemetry, breaking isolation the other way).
+    defp attach_fallback_handler(tenant_id) do
+      test_pid = self()
+      handler_id = "semfb-#{System.unique_integer([:positive])}"
+      event = [:loopctl, :knowledge, :semantic_fallback]
+
+      :telemetry.attach(
+        handler_id,
+        event,
+        fn ^event, measurements, metadata, _config ->
+          if metadata.tenant_id == tenant_id do
+            send(test_pid, {:semantic_fallback, measurements, metadata})
+          end
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+    end
+
+    defp keyword_article(tenant_id) do
+      fixture(:article, %{
+        tenant_id: tenant_id,
+        title: "Testing Guide",
+        body: "Unit test patterns for testing Elixir applications.",
+        status: :published
+      })
+    end
+
+    test ":no_api_key -> \"no_embedding_key\" in meta + telemetry" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+      keyword_article(tenant.id)
+      attach_fallback_handler(tenant.id)
+
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, :no_api_key}
+      end)
+
+      assert {:ok, %{meta: meta}} = Knowledge.search_combined(tenant.id, "testing")
+      assert meta.fallback == true
+      assert meta.search_mode == "keyword_only"
+      assert meta.fallback_reason == "no_embedding_key"
+
+      assert_receive {:semantic_fallback, measurements, metadata}
+      assert metadata.reason == "no_embedding_key"
+      assert metadata.tenant_id == tenant.id
+      assert measurements.query_len == byte_size("testing")
+      assert measurements.count == 1
+    end
+
+    test ":timeout -> \"embedding_timeout\" in meta + telemetry" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+      keyword_article(tenant.id)
+      attach_fallback_handler(tenant.id)
+
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, :timeout}
+      end)
+
+      assert {:ok, %{meta: meta}} = Knowledge.search_combined(tenant.id, "testing")
+      assert meta.fallback_reason == "embedding_timeout"
+
+      assert_receive {:semantic_fallback, _m, %{reason: "embedding_timeout"}}
+    end
+
+    test "{:api_error, 401, body-with-a-fake-key} -> status-only tag, NEVER leaks the key/body" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+      keyword_article(tenant.id)
+      attach_fallback_handler(tenant.id)
+
+      fake_key = "sk-SECRET-DEADBEEF-must-not-leak"
+      provider_body = "Incorrect API key provided: #{fake_key}"
+
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, {:api_error, 401, provider_body}}
+      end)
+
+      assert {:ok, %{meta: meta}} = Knowledge.search_combined(tenant.id, "testing")
+      assert meta.fallback_reason == "embedding_provider_error_401"
+
+      # The sanitizer (ProviderError) drops the body — neither the key nor the
+      # provider message survives into the response meta.
+      refute inspect(meta) =~ fake_key
+      refute inspect(meta) =~ "Incorrect API key"
+
+      assert_receive {:semantic_fallback, _m, metadata}
+      assert metadata.reason == "embedding_provider_error_401"
+      refute inspect(metadata) =~ fake_key
+      refute inspect(metadata) =~ "Incorrect API key"
+    end
+
+    test "a genuinely OPEN circuit breaker surfaces \"embedding_circuit_open\"" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+      keyword_article(tenant.id)
+
+      # 5xx is a COUNTABLE failure; three trip the tenant-scoped breaker.
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, {:api_error, 500, "upstream boom"}}
+      end)
+
+      for _ <- 1..3, do: Knowledge.search_combined(tenant.id, "testing")
+
+      # Attach only now so we observe the circuit-open call specifically.
+      attach_fallback_handler(tenant.id)
+
+      # The breaker is now open: generate_embedding short-circuits to :circuit_open
+      # WITHOUT calling the client.
+      assert {:ok, %{meta: meta}} = Knowledge.search_combined(tenant.id, "testing")
+      assert meta.fallback_reason == "embedding_circuit_open"
+
+      assert_receive {:semantic_fallback, _m, %{reason: "embedding_circuit_open"}}
+    end
+
+    test "embedding OK but semantic EMPTY -> semantic_result_count: 0, no fallback, distinct telemetry" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+      # Keyword-findable but NOT embedded, so the semantic half (which excludes nil
+      # embeddings) contributes zero rows even though the default stub embeds OK.
+      keyword_article(tenant.id)
+      attach_fallback_handler(tenant.id)
+
+      assert {:ok, %{meta: meta}} = Knowledge.search_combined(tenant.id, "testing")
+
+      # NOT a keyword_only fallback — combined still ran, keyword merged.
+      refute Map.get(meta, :fallback)
+      refute Map.has_key?(meta, :fallback_reason)
+      assert meta.search_mode == "combined"
+      assert meta.semantic_result_count == 0
+
+      assert_receive {:semantic_fallback, measurements, metadata}
+      assert metadata.reason == "semantic_empty"
+      assert measurements.semantic_result_count == 0
+    end
+
+    test "successful semantic (embedding ok + non-empty) sets NO fallback/fallback_reason and fires NO telemetry" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      create_article_with_embedding(
+        tenant.id,
+        %{title: "Deployment Guide", body: "How to deploy an Elixir app for testing."},
+        :close
+      )
+
+      attach_fallback_handler(tenant.id)
+
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:ok, make_embedding(:query)}
+      end)
+
+      assert {:ok, %{results: results, meta: meta}} =
+               Knowledge.search_combined(tenant.id, "testing")
+
+      refute Map.get(meta, :fallback)
+      refute Map.has_key?(meta, :fallback_reason)
+      assert meta.semantic_result_count >= 1
+      assert results != []
+
+      refute_receive {:semantic_fallback, _m, _metadata}
+    end
+  end
+
   # --- TC-20.4.4: Invalid weights return {:error, :invalid_weights} ---
 
   describe "search_combined/3 - weight validation" do

--- a/test/loopctl/telemetry/scale_metrics_test.exs
+++ b/test/loopctl/telemetry/scale_metrics_test.exs
@@ -31,12 +31,15 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
   @scale_metric_names [
     "loopctl.db.error.count",
     "loopctl.heavy_read_repo.query.duration",
-    "loopctl.knowledge.vector_search.under_fill.count"
+    "loopctl.knowledge.vector_search.under_fill.count",
+    "loopctl.knowledge.semantic_fallback.count"
   ]
 
   # The ONLY labels any scale metric may ever carry (AC-27.15.3). Anything outside this
   # set — especially an unbounded `:article_id` or a raw vector/body — is a hard fail.
-  @allowed_tags MapSet.new([:endpoint, :mapped_code, :tenant_id])
+  # `:reason` (#297 semantic-fallback counter) is a BOUNDED, sanitized tag set (never a
+  # key/body/query), so it is a safe dimension.
+  @allowed_tags MapSet.new([:endpoint, :mapped_code, :tenant_id, :reason])
 
   defp scale_metrics, do: ScaleMetrics.scale_metrics()
 
@@ -46,7 +49,7 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
   end
 
   describe "scale_metrics/0 — bounded, safe label set (TC-27.15.2, AC-27.15.3)" do
-    test "exactly the three scale metrics are defined" do
+    test "exactly the expected scale metrics are defined" do
       names = Enum.map(scale_metrics(), &Enum.join(&1.name, "."))
       assert Enum.sort(names) == Enum.sort(@scale_metric_names)
     end
@@ -91,6 +94,23 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
       assert %Telemetry.Metrics.Counter{} = under_fill
       assert :tenant_id in under_fill.tags
       assert :endpoint in under_fill.tags
+    end
+
+    test "the semantic-fallback counter (#297) is tagged by :reason ONLY — never tenant_id" do
+      counter = metric("loopctl.knowledge.semantic_fallback.count")
+
+      assert %Telemetry.Metrics.Counter{} = counter
+      assert counter.tags == [:reason]
+      refute :tenant_id in counter.tags
+      refute :endpoint in counter.tags
+
+      # `reason` is a fixed, small label set (no cap gate needed); a missing reason
+      # collapses to a bounded sentinel, never blank.
+      assert ScaleMetrics.semantic_fallback_tags(%{reason: "no_embedding_key"}) == %{
+               reason: "no_embedding_key"
+             }
+
+      assert ScaleMetrics.semantic_fallback_tags(%{}) == %{reason: "unknown"}
     end
 
     test "histogram buckets are the documented bounded set" do

--- a/test/loopctl_web/controllers/knowledge_search_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_search_controller_test.exs
@@ -229,6 +229,74 @@ defmodule LoopctlWeb.KnowledgeSearchControllerTest do
       assert result["score"] > 0
     end
 
+    test "combined fallback surfaces meta.fallback_reason without leaking the provider body (#297)",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      Loopctl.Knowledge.reset_circuit_breaker(tenant.id)
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Ecto Multi Pattern",
+        body: "Use Ecto.Multi for atomic multi-step database operations.",
+        category: :pattern,
+        status: :published,
+        tags: ["ecto"]
+      })
+
+      fake_key = "sk-SECRET-DEADBEEF-must-not-leak"
+
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, {:api_error, 401, "Incorrect API key provided: #{fake_key}"}}
+      end)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{q: "Ecto"})
+
+      body = json_response(conn, 200)
+
+      assert body["meta"]["fallback"] == true
+      assert body["meta"]["search_mode"] == "keyword_only"
+      assert body["meta"]["fallback_reason"] == "embedding_provider_error_401"
+      refute inspect(body) =~ fake_key
+      refute inspect(body) =~ "Incorrect API key"
+    end
+
+    test "semantic keyless fallback surfaces meta.fallback_reason \"no_embedding_key\" (#297)", %{
+      conn: conn
+    } do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      Loopctl.Knowledge.reset_circuit_breaker(tenant.id)
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Keyword Findable Article",
+        body: "Content about pagination that keyword search can find.",
+        category: :pattern,
+        status: :published,
+        tags: ["pagination"]
+      })
+
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, :no_api_key}
+      end)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{q: "pagination", mode: "semantic"})
+
+      body = json_response(conn, 200)
+      assert body["meta"]["fallback"] == true
+      assert body["meta"]["search_mode"] == "keyword_only"
+      assert body["meta"]["fallback_reason"] == "no_embedding_key"
+    end
+
     test "filters by project_id, category, and tags", %{conn: conn} do
       tenant = fixture(:tenant)
       project = fixture(:project, %{tenant_id: tenant.id})


### PR DESCRIPTION
## What

Make the silent semantic->keyword-only fallback **observable** (enabling step for diagnosing #297). Does **not** change fallback behavior and does **not** attempt the root-cause fix — the root cause needs prod data + the tenant's embedding key set.

At ~77k-article scale every `knowledge_search`/`context` call silently returned `fallback: true, search_mode: "keyword_only"` as a 200, and the fallback clause **discarded** the embedding-error reason, so nobody could tell WHY semantic never engaged.

## Changes

- **Capture the discarded reason** in `search_combined/3`'s fallback clause, the semantic-only keyless fallback (controller), and the `/knowledge/context` path. It is sanitized through `Loopctl.Llm.ProviderError.sanitize/1` (from #296) FIRST, so no api key / provider body can reach the tag, telemetry, or logs. Mapping (bounded set): `no_embedding_key`, `embedding_circuit_open`, `embedding_timeout`, `embedding_provider_error_<status>` (status only), `embedding_request_failed`, `embedding_crash`, `embedding_error`.
- **Surface `meta.fallback_reason`** alongside the existing `fallback: true` / `search_mode: "keyword_only"` on all three paths (JSON views + get_context propagation).
- **Distinguish embed-fail from recall-broken:** when the embedding SUCCEEDS but semantic ranking returns ZERO rows (recall/HNSW, not an embed failure), combined mode reports `meta.semantic_result_count: 0` with `fallback: false` and a distinct `semantic_empty` telemetry reason — this is the difference between "embed failed" and "embed worked but recall is broken", both candidate root causes for #297.
- **Telemetry + log:** `[:loopctl, :knowledge, :semantic_fallback]` (measurements `count/query_len/semantic_result_count`; metadata `tenant_id/reason` — query TEXT never included, only its byte length, matching the sibling knowledge telemetry) + a `Logger.warning` naming reason + tenant. Turns a silent outage into an alertable one.
- **Prometheus counter** `loopctl.knowledge.semantic_fallback.count` tagged by `reason` ONLY (no `tenant_id` label — reason is a small fixed set, so cardinality stays bounded per AC-27.15.3).
- **Docs:** OpenApiSpex search + context response schemas document the new optional meta fields; MCP `knowledge_search` / `knowledge_context` tool descriptions mention `fallback_reason` (mcp-server 2.33.0 + CHANGELOG).

## Tests

Per fallback cause (`:no_api_key`, `:timeout`, `{:api_error, 401, body-with-a-fake-key}`, genuinely-open breaker): assert the right `fallback_reason` in meta, that the reason/telemetry NEVER contain the fake key or provider body (sanitizer), and that the telemetry fires with the right reason (tenant-scoped handler, no cross-test leakage). Plus: the `semantic_empty` marker path, a successful semantic setting NEITHER `fallback` nor `fallback_reason` and firing no telemetry, context-path reason propagation, and the reason-only Prometheus counter shape.

## Root-cause hypothesis for the follow-up (NOT fixed here)

Reading the fallback path closely, #297's "silent keyword_only at scale" most likely has **two separable causes this PR now tells apart**:

1. **Embedding always failing on the global/tenant key** — mandatory BYO (#295/#296) means a tenant with no configured embedding key gets `:no_api_key` on EVERY combined search and silently degrades. If the ~77k-article tenant never had `embedding_api_key` set, `fallback_reason: "no_embedding_key"` will now show that immediately. This is my leading hypothesis — it matches "semantic never engages" for one tenant.
2. **Breaker latched open** — if early failures tripped the tenant-scoped breaker, subsequent calls short-circuit to `:circuit_open` (`embedding_circuit_open`) without ever calling the provider. Secondary, but the tag will reveal it.
3. **Recall/HNSW empty** — if the embedding SUCCEEDS but `search_semantic` returns zero (index not populated / articles unembedded / filter starves the pool), you'll now see `semantic_result_count: 0` with `fallback: false` and `reason: "semantic_empty"` — a different fix (backfill embeddings / index) than 1–2.

The new signals let the follow-up diagnosis read the reason distribution from prod telemetry/logs and pick the right fix, rather than guessing.

Refs #297.
