### PR TITLE
feat: smooth agent BYO-LLM onboarding — self-healing remediation + self-documenting MCP tools + first-time-setup docs

### DIFF
--- a/docs/onboarding-agent-tenant.md
+++ b/docs/onboarding-agent-tenant.md
@@ -1,0 +1,118 @@
+# Onboarding an agent-tenant
+
+loopctl is **agent-native** and **strictly BYO** (bring-your-own-keys). A tenant
+*is* an agent: there is no human settings UI. The only human touch is the
+hardware-anchored signup ceremony (WebAuthn L0, see
+[`chain-of-custody-v2.md`](./chain-of-custody-v2.md) §2.1). Everything after that —
+including provisioning the LLM keys the knowledge wiki runs on — an agent does for
+itself through the API and the MCP tools.
+
+This doc is the **authoritative sequence** a stranger agent follows to go from a
+fresh signup to a working knowledge wiki.
+
+## The lifecycle
+
+```
+  1. Human-anchored signup (WebAuthn)  ──▶  mints your user-role API key
+                    │
+                    ▼
+  2. Provision your BYO LLM keys       ──▶  set_llm_config({ api_key, embedding_api_key })
+     (the step RIGHT AFTER signup)          (once; stored encrypted, never returned)
+                    │
+                    ▼
+  3. Use the wiki                      ──▶  knowledge_ingest / knowledge_search / knowledge_context
+```
+
+### 1. Signup — the one human touch
+
+Tenant signup is anchored to a hardware authenticator (WebAuthn). This is the L0
+root of the chain of custody and is the **only** step that requires a human. Signup
+mints your **user-role** API key (`LOOPCTL_USER_KEY`) and gives you your agent and
+orchestrator keys for day-to-day work. The post-signup onboarding checklist lists
+"Provision your BYO LLM keys" as an explicit step.
+
+Do **not** weaken or automate the WebAuthn anchor — it is a security boundary, not
+an onboarding inconvenience.
+
+### 2. Provision your BYO LLM keys — the step right after signup
+
+loopctl fronts **no** LLM cost. The wiki's ingest and semantic-search features run
+entirely on *your* provider keys, which bill you directly. Two SEPARATE keys power
+two capabilities:
+
+| Key | Provider | Powers | Missing ⇒ |
+|---|---|---|---|
+| `api_key` | Anthropic | ingest — extraction / classification / merge | `knowledge_ingest` returns 422 (`code: no_api_key`) |
+| `embedding_api_key` | OpenAI-compatible | article embeddings + semantic search | `knowledge_search` degrades to keyword-only (`meta.fallback_reason: no_embedding_key`) |
+
+Provision both in a single MCP call (uses your user-role key):
+
+```
+set_llm_config({ api_key: "sk-ant-...", embedding_api_key: "sk-..." })
+```
+
+Or via REST:
+
+```
+PATCH /api/v1/tenants/me/llm-config
+{ "api_key": "sk-ant-...", "embedding_api_key": "sk-..." }
+```
+
+Notes:
+
+- **Partial-merge.** Send any subset; omitting a key leaves the existing one
+  untouched. Rotate a single key the same way.
+- **Model overrides** (`extraction_model`, `classification_model`, `merge_model`,
+  `embedding_model`) are optional and free-form; each defaults server-side.
+- **Never returned.** Both keys are stored encrypted. `llm_config` (or `GET
+  /api/v1/tenants/me/llm-config`) reports only `has_api_key` / `has_embedding_key`
+  and masked last-4 hints — use it to confirm setup took.
+- **User role only.** Managing tenant secrets requires the user-role key; an agent
+  or orchestrator key is rejected. This does not weaken chain-of-custody — it is a
+  secret-management gate, orthogonal to the report/verify separation.
+
+### 3. Use the wiki
+
+Once both keys are set:
+
+- `knowledge_ingest` / `knowledge_ingest_batch` extract articles from URLs or raw
+  content (drafts by default).
+- `knowledge_search` (combined/semantic) ranks by meaning; `knowledge_context`
+  returns full ranked articles for a task.
+
+## Self-healing: you can't get stuck
+
+Every no-key wall returns a **machine-readable, secret-free `remediation`** an agent
+can act on without a human:
+
+```json
+{
+  "action": "configure_llm",
+  "missing": ["embedding_api_key"],
+  "mcp_tool": "set_llm_config",
+  "example": "set_llm_config({\"embedding_api_key\": \"<your OpenAI API key>\"})",
+  "api": "PATCH /api/v1/tenants/me/llm-config",
+  "docs": "https://loopctl.com/wiki/agent-onboarding"
+}
+```
+
+Where it appears:
+
+- **Ingest 422** (`code: no_api_key`) — `error.remediation`, credential
+  `api_key` (Anthropic).
+- **Search / context degrade** (`meta.fallback_reason: "no_embedding_key"`) —
+  `meta.remediation`, credential `embedding_api_key` (OpenAI). The request still
+  returns 200 keyword-only results, so the degrade is graceful.
+
+The MCP tools (`knowledge_ingest`, `knowledge_ingest_batch`, `knowledge_search`,
+`knowledge_context`) **lead their result with an `ACTION REQUIRED` notice** built
+from that remediation, so an agent that skips setup reads the exact next step
+instead of a bare error. The remediation is emitted by a single shared builder,
+`Loopctl.Llm.Remediation`, so ingest / classify / merge / search stay consistent and
+it never leaks a key or a provider body.
+
+## Reference
+
+- MCP first-time setup: [`mcp-server/README.md`](../mcp-server/README.md#first-time-setup--provision-your-byo-llm-keys)
+- BYO LLM config internals: `lib/loopctl/llm.ex`, `lib/loopctl/llm/remediation.ex`
+- Trust model: [`chain-of-custody-v2.md`](./chain-of-custody-v2.md)

--- a/lib/loopctl/llm/remediation.ex
+++ b/lib/loopctl/llm/remediation.ex
@@ -1,0 +1,106 @@
+defmodule Loopctl.Llm.Remediation do
+  @moduledoc """
+  Shared, machine-readable BYO-LLM remediation objects for self-service onboarding.
+
+  loopctl is agent-native and strictly BYO: every tenant provisions its OWN
+  provider keys and pays the provider directly (see `Loopctl.Llm`). When a
+  knowledge-LLM operation is blocked because a key is missing, the API returns a
+  STRUCTURED, ACTIONABLE remediation an agent can act on WITHOUT a human — it
+  names the exact MCP tool (`set_llm_config`), the REST endpoint, a copy-paste
+  example, and the onboarding docs. This is the linchpin that turns a dead-end
+  "no key" wall into a next step a stranger agent can follow from the tool result
+  alone.
+
+  Two SEPARATE credentials back two different capabilities, so the remediation
+  distinguishes WHICH one is missing:
+
+    * `:anthropic` — the Anthropic `api_key` powers ingest synthesis / classify /
+      merge. Missing ⇒ `POST /knowledge/ingest` 422s.
+    * `:embedding` — the OpenAI-compatible `embedding_api_key` powers article
+      embeddings + semantic search. Missing ⇒ search silently degrades to
+      keyword-only (`meta.fallback_reason: "no_embedding_key"`).
+
+  The objects are VALUE-FREE: they never carry a key, a provider body, or any
+  tenant secret — only the field NAME the agent must set. Safe to render into any
+  API response or MCP tool result.
+  """
+
+  # Agent-facing canonical onboarding reference (mirrors the FallbackController
+  # `learn_more` wiki-URL convention). The in-repo companion is
+  # `docs/onboarding-agent-tenant.md`.
+  @docs_url "https://loopctl.com/wiki/agent-onboarding"
+
+  @mcp_tool "set_llm_config"
+  @api "PATCH /api/v1/tenants/me/llm-config"
+
+  @typedoc "The credential a blocked operation needs the tenant to provision."
+  @type credential :: :anthropic | :embedding
+
+  @typedoc "A machine-readable, secret-free remediation object."
+  @type t :: %{
+          action: String.t(),
+          missing: [String.t()],
+          credential: String.t(),
+          mcp_tool: String.t(),
+          example: String.t(),
+          api: String.t(),
+          docs: String.t(),
+          message: String.t()
+        }
+
+  @doc """
+  Build the remediation object for a missing `credential`.
+
+    * `:anthropic` → the `api_key` (ingest / classify / merge)
+    * `:embedding` → the `embedding_api_key` (embeddings / semantic search)
+
+  The returned map is secret-free and safe to embed in any response or tool result.
+  """
+  @spec for_credential(credential()) :: t()
+  def for_credential(:anthropic) do
+    %{
+      action: "configure_llm",
+      missing: ["api_key"],
+      credential: "anthropic_api_key",
+      mcp_tool: @mcp_tool,
+      example: ~s|set_llm_config({"api_key": "<your Anthropic API key>"})|,
+      api: @api,
+      docs: @docs_url,
+      message:
+        "This tenant has no Anthropic API key configured. loopctl is BYO — provision " <>
+          "your own key ONCE via the set_llm_config MCP tool (user role), then ingest works. " <>
+          "Your key is stored encrypted and never returned."
+    }
+  end
+
+  def for_credential(:embedding) do
+    %{
+      action: "configure_llm",
+      missing: ["embedding_api_key"],
+      credential: "openai_embedding_api_key",
+      mcp_tool: @mcp_tool,
+      example: ~s|set_llm_config({"embedding_api_key": "<your OpenAI API key>"})|,
+      api: @api,
+      docs: @docs_url,
+      message:
+        "Semantic ranking is unavailable because this tenant has no embedding API key " <>
+          "configured — search degraded to keyword-only. loopctl is BYO — provision your own " <>
+          "OpenAI-compatible key ONCE via the set_llm_config MCP tool (user role) to enable " <>
+          "embeddings + semantic search. Your key is stored encrypted and never returned."
+    }
+  end
+
+  @doc """
+  Map a search `fallback_reason` tag (see `Loopctl.Knowledge`) to a remediation,
+  or `nil` when the reason is NOT a missing-key condition.
+
+  Only `"no_embedding_key"` is actionable by the agent (provision a key). Every
+  other tag (`"embedding_circuit_open"`, `"embedding_timeout"`,
+  `"embedding_provider_error_<status>"`, ...) means a key IS configured but the
+  provider/circuit failed transiently — telling the agent to "configure a key"
+  would be wrong, so those return `nil`.
+  """
+  @spec for_fallback_reason(String.t() | nil) :: t() | nil
+  def for_fallback_reason("no_embedding_key"), do: for_credential(:embedding)
+  def for_fallback_reason(_other), do: nil
+end

--- a/lib/loopctl_web/controllers/knowledge_context_json.ex
+++ b/lib/loopctl_web/controllers/knowledge_context_json.ex
@@ -6,6 +6,8 @@ defmodule LoopctlWeb.KnowledgeContextJSON do
   plus one-hop linked article references (lightweight: id, title, category).
   """
 
+  alias Loopctl.Llm.Remediation
+
   @doc "Renders context results with full bodies and scores."
   def context(%{results: results, meta: meta}) do
     %{
@@ -54,6 +56,10 @@ defmodule LoopctlWeb.KnowledgeContextJSON do
     # `fallback_reason` (#297): a stable, non-sensitive tag naming WHY the context's
     # underlying combined search degraded to keyword_only. Present only on fallback.
     |> maybe_put_fallback_reason(meta[:fallback_reason])
+    # `remediation`: a machine-readable, secret-free next-step when the degradation
+    # is a MISSING embedding key, so an agent can enable semantic ranking without a
+    # human. Mirrors the /knowledge/search response. Absent otherwise.
+    |> maybe_put_remediation(Remediation.for_fallback_reason(meta[:fallback_reason]))
   end
 
   defp maybe_put_fallback(map, true), do: Map.put(map, :fallback, true)
@@ -61,4 +67,7 @@ defmodule LoopctlWeb.KnowledgeContextJSON do
 
   defp maybe_put_fallback_reason(map, nil), do: map
   defp maybe_put_fallback_reason(map, reason), do: Map.put(map, :fallback_reason, reason)
+
+  defp maybe_put_remediation(map, nil), do: map
+  defp maybe_put_remediation(map, remediation), do: Map.put(map, :remediation, remediation)
 end

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -19,7 +19,10 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   # Mandatory BYO (Epic 28, #179): extraction runs on the tenant's OWN Anthropic
   # key. Reject up front with a clear 422 so we never enqueue a job that can only
   # {:discard} for a missing key.
-  @no_api_key_message "Configure your Anthropic API key (PATCH /api/v1/tenants/me/llm-config) before ingesting content."
+  @no_api_key_message "Configure your Anthropic API key before ingesting content. " <>
+                        "loopctl is BYO — provision it ONCE via the set_llm_config MCP tool " <>
+                        "(user role), or PATCH /api/v1/tenants/me/llm-config. See the response " <>
+                        "`remediation` for the exact call."
   alias LoopctlWeb.Helpers.Pagination
   alias LoopctlWeb.Helpers.ProjectId
 

--- a/lib/loopctl_web/controllers/knowledge_search_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_search_controller.ex
@@ -250,6 +250,17 @@ defmodule LoopctlWeb.KnowledgeSearchController do
                      "Combined mode only (#297): rows the semantic half contributed. `0` with " <>
                        "no `fallback` means the embedding SUCCEEDED but ranking returned nothing " <>
                        "(a recall problem) — distinct from a keyword_only fallback."
+                 },
+                 remediation: %OpenApiSpex.Schema{
+                   type: :object,
+                   description:
+                     "Present ONLY when `fallback_reason == \"no_embedding_key\"`: a " <>
+                       "machine-readable, secret-free next-step so an agent can enable semantic " <>
+                       "ranking WITHOUT a human. Names the `set_llm_config` MCP tool " <>
+                       "(`mcp_tool`), the REST endpoint (`api`), the missing credential " <>
+                       "(`missing: [\"embedding_api_key\"]`), a copy-paste `example`, and the " <>
+                       "onboarding `docs`. Absent for transient/provider fallbacks (a key IS " <>
+                       "configured there)."
                  }
                }
              }

--- a/lib/loopctl_web/controllers/knowledge_search_json.ex
+++ b/lib/loopctl_web/controllers/knowledge_search_json.ex
@@ -13,6 +13,8 @@ defmodule LoopctlWeb.KnowledgeSearchJSON do
   Full article body is never included.
   """
 
+  alias Loopctl.Llm.Remediation
+
   @max_snippet_length 300
 
   @doc "Renders search results with unified score field and truncated snippets."
@@ -157,6 +159,13 @@ defmodule LoopctlWeb.KnowledgeSearchJSON do
     # `fallback_reason` (#297): a stable, non-sensitive tag naming WHY combined/semantic
     # degraded to keyword_only (present only alongside `fallback: true`).
     |> maybe_put(:fallback_reason, meta[:fallback_reason])
+    # `remediation`: when the degradation is a MISSING embedding key
+    # (`fallback_reason == "no_embedding_key"`), attach a machine-readable,
+    # secret-free next-step so the agent can enable semantic ranking WITHOUT a
+    # human — naming the `set_llm_config` MCP tool + the REST endpoint. Absent for
+    # transient/provider fallbacks (a key IS configured there, so "configure a key"
+    # would be wrong).
+    |> maybe_put(:remediation, Remediation.for_fallback_reason(meta[:fallback_reason]))
     # `semantic_result_count` (#297): rows the semantic half contributed in combined
     # mode. `0` with no `fallback` = "embed worked but recall is broken" — distinct
     # from a keyword_only fallback.

--- a/lib/loopctl_web/fallback_controller.ex
+++ b/lib/loopctl_web/fallback_controller.ex
@@ -29,6 +29,7 @@ defmodule LoopctlWeb.FallbackController do
   use LoopctlWeb, :controller
 
   alias Ecto.Changeset
+  alias Loopctl.Llm.Remediation
   alias LoopctlWeb.DBError
   alias LoopctlWeb.DBErrorLogger
 
@@ -316,8 +317,11 @@ defmodule LoopctlWeb.FallbackController do
 
   # Epic 28 (#179): mandatory BYO — a tenant knowledge-LLM operation was blocked
   # because the tenant has no Anthropic key configured. Carries a machine-readable
-  # `code` so clients can distinguish this from other 422s and prompt the user to
-  # configure a key.
+  # `code` PLUS a structured, self-service `remediation` (naming the `set_llm_config`
+  # MCP tool, the REST endpoint, a copy-paste example, and the onboarding docs) so a
+  # stranger agent can provision its own key from the response ALONE — no human
+  # needed. Ingest is always the Anthropic path, so the missing credential is the
+  # `api_key`.
   def call(conn, {:error, :no_api_key_configured, message}) when is_binary(message) do
     conn
     |> put_status(:unprocessable_entity)
@@ -326,7 +330,7 @@ defmodule LoopctlWeb.FallbackController do
         status: 422,
         code: "no_api_key",
         message: message,
-        remediation: %{configure: "PATCH /api/v1/tenants/me/llm-config"}
+        remediation: Remediation.for_credential(:anthropic)
       }
     })
   end

--- a/lib/loopctl_web/live/tenant_onboarding_live.ex
+++ b/lib/loopctl_web/live/tenant_onboarding_live.ex
@@ -3,12 +3,14 @@ defmodule LoopctlWeb.TenantOnboardingLive do
   US-26.0.1 — post-signup onboarding checklist.
 
   Rendered after a tenant completes the WebAuthn signup ceremony. Walks
-  the operator through the first four setup steps:
+  the operator through the first setup steps:
 
   1. Audit key generation (US-26.0.2)
-  2. System article tour
-  3. First project creation
-  4. First agent registration
+  2. Provision BYO LLM keys (the step right after the human-anchored signup;
+     see `docs/onboarding-agent-tenant.md`)
+  3. System article tour
+  4. First project creation
+  5. First agent registration
 
   This LiveView is intentionally a skeleton: the individual step
   completion is tracked on the tenant's `settings.onboarding` jsonb
@@ -25,6 +27,15 @@ defmodule LoopctlWeb.TenantOnboardingLive do
       title: "Generate audit signing key",
       body:
         "Creates the ed25519 keypair that signs every audit chain entry for this tenant (US-26.0.2)."
+    },
+    %{
+      key: "provision_llm_keys",
+      title: "Provision your BYO LLM keys",
+      body:
+        "loopctl is strictly BYO — it fronts no LLM cost. Provision your own Anthropic + " <>
+          "OpenAI embedding keys once via the set_llm_config MCP tool " <>
+          "(PATCH /api/v1/tenants/me/llm-config). Until then, knowledge ingest 422s and " <>
+          "semantic search degrades to keyword-only. See docs/onboarding-agent-tenant.md."
     },
     %{
       key: "system_article_tour",

--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to `loopctl-mcp-server` are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 2.34.0 — 2026-07-03 (smooth agent BYO-LLM onboarding — self-healing remediation + self-documenting tools)
+
+### Added
+
+- **First-time-setup walkthrough in the README.** A prominent "First-time setup —
+  provision your BYO LLM keys" section BEFORE the tool reference walks a stranger
+  agent the whole smooth path: sign up → set env (`LOOPCTL_SERVER`,
+  `LOOPCTL_USER_KEY`, agent/orch keys) → call `set_llm_config({api_key, embedding_api_key})`
+  ONCE → ingest + semantic search work. Explains the strictly-BYO model, which key
+  powers what, the per-op model overrides, and that without keys ingest 422s and
+  search silently degrades to keyword-only.
+- **Self-healing remediation surfaced in tool results.** `knowledge_ingest`,
+  `knowledge_ingest_batch`, `knowledge_search`, and `knowledge_context` now lead
+  their result with an `ACTION REQUIRED` notice when the server reports a missing
+  BYO key — the ingest no-key 422 (`code: no_api_key`) and the search/context
+  keyword-only degrade (`meta.fallback_reason: no_embedding_key`) both carry a
+  machine-readable `remediation` naming the `set_llm_config` MCP tool, a copy-paste
+  example, the REST endpoint, and the onboarding docs. An agent that skips setup
+  reads the exact next step instead of a bare error.
+
+### Changed
+
+- **`set_llm_config` / `llm_config` descriptions rewritten to fully onboard a
+  stranger agent** — WHAT (provision your OWN Anthropic + OpenAI embedding keys, BYO,
+  stored encrypted, never returned), WHY (required before ingest/search; loopctl
+  fronts no LLM cost), WHEN (once, at signup), the required `LOOPCTL_USER_KEY`, which
+  key powers what, the partial-merge semantics, and that `llm_config` reports
+  `has_api_key` / `has_embedding_key` so an agent can CHECK its setup.
+- README tool-table rows for `llm_config` / `set_llm_config` now mention BOTH the
+  Anthropic AND embedding keys; the `LOOPCTL_USER_KEY` env row notes it is also
+  required for first-time LLM-key provisioning.
+
 ## 2.33.1 — 2026-07-03 (witness STH persistence + transparent bootstrap-412 retry + cache hardening — #298)
 
 ### Security

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -62,10 +62,55 @@ Or if installed locally:
 | `LOOPCTL_API_KEY` | Global API key override (if set, always used) | -- |
 | `LOOPCTL_ORCH_KEY` | Orchestrator role API key (verify, reject, review, import) | -- |
 | `LOOPCTL_AGENT_KEY` | Agent role API key (contract, claim, start, request-review) | -- |
-| `LOOPCTL_USER_KEY` | User role API key. Required ONLY for destructive admin tools like `knowledge_bulk_publish`. Leave unset if you don't use those tools. | -- |
+| `LOOPCTL_USER_KEY` | User role API key (minted at signup). Required for **first-time BYO LLM key provisioning** (`set_llm_config` / `llm_config` — see [First-time setup](#first-time-setup--provision-your-byo-llm-keys)) and for destructive admin tools like `knowledge_bulk_publish`. | -- |
 | `LOOPCTL_STH_STATE_PATH` | Absolute path for the witness-protocol STH cache file (see [Witness protocol](#witness-protocol-sth)). Optional. | per-(server + key) file under the OS temp dir |
 
 Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_KEY`.
+
+## First-time setup — provision your BYO LLM keys
+
+**loopctl is agent-native and strictly BYO (bring-your-own-keys).** loopctl fronts
+**no** LLM cost — the knowledge wiki runs entirely on *your* provider keys, which you
+provision once and which bill you directly. Two SEPARATE keys power two capabilities:
+
+| Key | Provider | Powers | Missing ⇒ |
+|---|---|---|---|
+| `api_key` | Anthropic | knowledge **ingest** — extraction, classification, merge synthesis | `knowledge_ingest` returns **422** (`code: no_api_key`) |
+| `embedding_api_key` | OpenAI-compatible | article **embeddings + semantic search** | `knowledge_search` silently degrades to **keyword-only** (`meta.fallback_reason: no_embedding_key`) |
+
+Both keys are stored **encrypted** and are **never returned** by any tool. You can set
+per-operation model overrides (`extraction_model`, `classification_model`,
+`merge_model`, `embedding_model`); each defaults server-side when omitted.
+
+### The smooth path (once, at onboarding)
+
+1. **Sign up** and obtain your keys. Tenant signup is anchored to a hardware
+   authenticator (WebAuthn) — the one human touch. Signup mints your **user-role**
+   API key. Also grab your **agent** and **orchestrator** keys for day-to-day work.
+2. **Set the env** in your `.mcp.json` (see [Configuration](#configuration)):
+   `LOOPCTL_SERVER`, `LOOPCTL_USER_KEY` (needed for this step), plus `LOOPCTL_AGENT_KEY`
+   / `LOOPCTL_ORCH_KEY`.
+3. **Provision both keys in one call** (uses `LOOPCTL_USER_KEY`):
+
+   ```
+   set_llm_config({ api_key: "sk-ant-...", embedding_api_key: "sk-..." })
+   ```
+
+   Partial-merge: you can set or rotate one key at a time; omitting a key leaves the
+   existing one untouched. Optionally pass model overrides in the same call.
+4. **You're live.** `knowledge_ingest` extracts articles and `knowledge_search`
+   (combined/semantic) ranks by meaning. Check status anytime with
+   `llm_config` (reports `has_api_key` / `has_embedding_key` + masked last-4 hints,
+   never the key).
+
+### Self-healing: you can't get stuck
+
+If you call `knowledge_ingest` or `knowledge_search` **before** provisioning, the
+tool result **leads with an `ACTION REQUIRED` notice** and a machine-readable
+`remediation` object — naming the `set_llm_config` tool, a copy-paste example, the
+REST endpoint (`PATCH /api/v1/tenants/me/llm-config`), and the docs — so you (or an
+autonomous agent) can self-remediate without a human. Full agent-tenant lifecycle:
+[`docs/onboarding-agent-tenant.md`](../docs/onboarding-agent-tenant.md).
 
 ## Tools (72)
 
@@ -177,7 +222,7 @@ Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_K
 | `knowledge_drafts` | List draft (unpublished) knowledge articles with pagination. Optional: `limit` (default 20, max 1000 — over-max → 400, no silent clamp), `offset` (default 0), `project_id`. Returns `meta.total_count`. |
 | `knowledge_lint` | Run a lint check on the knowledge wiki to identify stale or low-coverage articles. Optional: `project_id`, `stale_days`, `min_coverage`, `max_per_category` (default 50, max 500). True totals returned in `summary.total_per_category`. |
 | `knowledge_export` | Export all knowledge articles as an OKF v0.1 bundle (gzipped tar archive, unbounded, bounded-memory streaming, fail-closed). Returns a curl command for direct download — **the download requires `LOOPCTL_USER_KEY`** (an orchestrator key would 403). Pass `format=json` for buffered in-memory JSON (convenience tool for file writers; capped at `export_max_buffered_export_articles` — returns 413 if over-cap). Optional: `project_id`, `format` (`tar.gz` default or `json`). |
-| `knowledge_ingest` | Submit a URL or raw content for knowledge extraction. Enqueues an Oban job. Extracted articles are **drafts by default** (lower-trust LLM output); pass `publish: true` to publish on extraction. Required: `source_type`. One of: `url` or `content`. Optional: `project_id`, `publish`. |
+| `knowledge_ingest` | Submit a URL or raw content for knowledge extraction. Enqueues an Oban job. Extracted articles are **drafts by default** (lower-trust LLM output); pass `publish: true` to publish on extraction. **BYO:** runs on the tenant's own Anthropic key — a keyless tenant gets a 422 whose result leads with an `ACTION REQUIRED` notice pointing at `set_llm_config` (see [First-time setup](#first-time-setup--provision-your-byo-llm-keys)). Required: `source_type`. One of: `url` or `content`. Optional: `project_id`, `publish`. |
 | `knowledge_ingest_batch` | Submit up to 50 ingestion items in a single request. Each item has the same shape as `knowledge_ingest` (incl. `publish`). Returns per-item results. Required: `items`. Optional: batch-level `project_id` / `publish` defaults. |
 | `knowledge_ingestion_jobs` | List recent content ingestion jobs (last 7 days, max 50). |
 
@@ -185,8 +230,8 @@ Key resolution priority: `LOOPCTL_API_KEY` > tool-specific key > `LOOPCTL_ORCH_K
 
 | Tool | Description |
 |---|---|
-| `llm_config` | Get the tenant's BYO Anthropic LLM config: per-operation models, `has_api_key`, and a masked last-4 hint. Never returns the key. Requires **user** key. |
-| `set_llm_config` | Set/rotate the tenant's OWN Anthropic API key (stored encrypted, never returned) + the three per-operation models (`extraction_model`/`classification_model`/`merge_model`). Any subset; omitting `api_key` leaves it untouched. Requires **user** key. |
+| `llm_config` | **Check your onboarding status.** Get the tenant's BYO LLM config: per-operation models and whether each key is set — `has_api_key` (Anthropic) / `has_embedding_key` (OpenAI embedding) — plus masked last-4 hints. Never returns a key. Requires **user** key. |
+| `set_llm_config` | **First-time setup (do once).** Set/rotate the tenant's OWN **Anthropic `api_key`** (powers ingest) AND **OpenAI `embedding_api_key`** (powers semantic search) — both stored encrypted, never returned — plus the per-operation models (`extraction_model`/`classification_model`/`merge_model`/`embedding_model`). Any subset; partial-merge (omitting a key leaves it untouched). See [First-time setup](#first-time-setup--provision-your-byo-llm-keys). Requires **user** key. |
 | `knowledge_llm_usage` | Per-tenant LLM token-usage summary, grouped by operation + model + source_type + day over an optional `from`/`to` range (defaults to a 90-day lookback; effective window echoed in `meta.from`/`meta.to`), with `limit`/`offset` pagination. Record-only (no budget enforcement). Requires orchestrator key. |
 
 ### Knowledge Analytics Tools (orchestrator key)

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -233,6 +233,51 @@ function toContentCompact(result) {
   return toContent(result);
 }
 
+/**
+ * Surface a server-emitted BYO-LLM `remediation` PROMINENTLY as a leading text
+ * block. A stranger agent that calls knowledge_ingest / knowledge_search /
+ * knowledge_context BEFORE provisioning its keys then reads the exact next step
+ * in the tool result — call set_llm_config — instead of hunting through raw JSON.
+ *
+ * The remediation lives in one of two places depending on the failure shape:
+ *   - ingest no-key 422  → result.body.error.remediation (code "no_api_key")
+ *   - search/context degrade → result.meta.remediation (fallback_reason
+ *     "no_embedding_key"); the request still returns 200 keyword-only results.
+ *
+ * Returns a notice string, or null when there is no LLM remediation to surface.
+ */
+function llmRemediationNotice(result) {
+  const rem =
+    (result &&
+      result.error === true &&
+      result.body &&
+      result.body.error &&
+      result.body.error.remediation) ||
+    (result && result.meta && result.meta.remediation) ||
+    null;
+
+  if (!rem || rem.action !== "configure_llm") return null;
+
+  const missing = Array.isArray(rem.missing) ? rem.missing.join(", ") : rem.missing;
+  return (
+    `ACTION REQUIRED — BYO LLM key not configured (missing: ${missing}). ` +
+    `${rem.message || ""} Provision it ONCE with the ${rem.mcp_tool} MCP tool, e.g. ` +
+    `${rem.example} (REST: ${rem.api}). Requires your user-role key (LOOPCTL_USER_KEY). ` +
+    `Docs: ${rem.docs}`
+  ).replace(/\s+/g, " ").trim();
+}
+
+/**
+ * toContent, but with any BYO-LLM remediation notice prepended so it is the first
+ * thing the agent reads. Preserves isError from the underlying result.
+ */
+function withRemediationNotice(result) {
+  const base = toContent(result);
+  const notice = llmRemediationNotice(result);
+  if (!notice) return base;
+  return { ...base, content: [{ type: "text", text: notice }, ...base.content] };
+}
+
 // ---------------------------------------------------------------------------
 // Tool implementations
 // ---------------------------------------------------------------------------
@@ -831,7 +876,10 @@ async function knowledgeSearch({ q, project_id, story_id, category, tags, match,
   if (offset != null) params.set("offset", String(offset));
 
   const result = await apiCall("GET", `/api/v1/knowledge/search?${params}`, null, process.env.LOOPCTL_AGENT_KEY);
-  return toContent(result);
+  // If search silently degraded to keyword-only for a missing embedding key, the
+  // server attaches meta.remediation — surface it PROMINENTLY so the agent knows to
+  // call set_llm_config to enable semantic ranking.
+  return withRemediationNotice(result);
 }
 
 async function knowledgeList({
@@ -902,7 +950,8 @@ async function knowledgeContext({
   if (conversation_id) params.set("conversation_id", conversation_id);
 
   const result = await apiCall("GET", `/api/v1/knowledge/context?${params}`, null, process.env.LOOPCTL_AGENT_KEY);
-  return toContent(result);
+  // Same as knowledge_search: surface a missing-embedding-key remediation prominently.
+  return withRemediationNotice(result);
 }
 
 async function knowledgeCreate({
@@ -1158,7 +1207,9 @@ async function knowledgeIngest({ url, content, source_type, project_id, publish 
   if (project_id) body.project_id = project_id;
   if (publish) body.publish = true;
   const result = await apiCall("POST", "/api/v1/knowledge/ingest", body, process.env.LOOPCTL_ORCH_KEY);
-  return toContent(result);
+  // A keyless tenant gets a 422 (code no_api_key) carrying a remediation — surface it
+  // prominently so a first-time agent knows to call set_llm_config before ingesting.
+  return withRemediationNotice(result);
 }
 
 async function knowledgeIngestBatch({ items, project_id, publish }) {
@@ -1181,7 +1232,9 @@ async function knowledgeIngestBatch({ items, project_id, publish }) {
     { items: resolvedItems },
     process.env.LOOPCTL_ORCH_KEY
   );
-  return toContent(result);
+  // Batch ingest gates on the Anthropic key up front too — a keyless tenant gets a
+  // 422 with the same remediation; surface it prominently.
+  return withRemediationNotice(result);
 }
 
 async function knowledgeIngestionJobs(args = {}) {
@@ -2618,7 +2671,9 @@ const TOOLS = [
       "If semantic ranking is unavailable the search transparently degrades to keyword-only " +
       "(meta.fallback: true, meta.search_mode: 'keyword_only') and now reports meta.fallback_reason " +
       "— a stable tag naming WHY (e.g. no_embedding_key, embedding_circuit_open, " +
-      "embedding_provider_error_<status>, embedding_timeout).",
+      "embedding_provider_error_<status>, embedding_timeout). When the reason is a MISSING " +
+      "embedding key (no_embedding_key), the result leads with an ACTION REQUIRED notice + " +
+      "meta.remediation telling you to provision it with set_llm_config (BYO — do it once).",
     inputSchema: {
       type: "object",
       properties: {
@@ -3296,7 +3351,10 @@ const TOOLS = [
       "Enqueues an Oban job that fetches the content (if URL), extracts knowledge articles via LLM, " +
       "and inserts them. Extracted articles are DRAFTS by default (lower-trust LLM output, staged " +
       "for review) — unlike knowledge_create which publishes by default. Pass publish:true to " +
-      "publish them on extraction. Requires orchestrator role.",
+      "publish them on extraction. Requires orchestrator role. BYO: extraction runs on the " +
+      "tenant's OWN Anthropic key — a keyless tenant gets a 422 (code no_api_key) and the " +
+      "result leads with an ACTION REQUIRED notice telling you to provision it once via " +
+      "set_llm_config.",
     inputSchema: {
       type: "object",
       properties: {
@@ -3409,29 +3467,44 @@ const TOOLS = [
   {
     name: "llm_config",
     description:
-      "Get the tenant's BYO Anthropic + embedding configuration: the per-operation " +
-      "model choices, whether each key is configured (has_api_key / has_embedding_key), " +
-      "and masked last-4 hints. NEVER returns a key itself. Requires user role " +
-      "(LOOPCTL_USER_KEY).",
+      "CHECK your BYO LLM onboarding status. Returns this tenant's per-operation model " +
+      "choices and whether each key is configured — `has_api_key` (Anthropic, powers " +
+      "ingest) and `has_embedding_key` (OpenAI embedding, powers semantic search) — plus " +
+      "masked last-4 hints. NEVER returns a key itself. Call this BEFORE ingest/search to " +
+      "confirm setup, or after set_llm_config to verify it took. Uses your user-role key " +
+      "(LOOPCTL_USER_KEY, obtained at signup); managing tenant secrets is user-only, so an " +
+      "agent/orchestrator key is rejected.",
     inputSchema: { type: "object", properties: {}, required: [] },
   },
   {
     name: "set_llm_config",
     description:
-      "Set/rotate the tenant's OWN Anthropic API key AND OpenAI embedding key (both " +
-      "stored encrypted, never returned) and the per-operation models " +
-      "(extraction/classification/merge/embedding). loopctl fronts no cost — the " +
-      "tenant's keys bill the tenant. Mandatory BYO for embeddings: without an " +
-      "embedding_api_key the tenant's articles are not vector-searchable. Any subset " +
-      "of fields may be sent; omitting a key leaves the existing key untouched. Model " +
-      "ids are free-form (any model the key permits). Requires user role " +
-      "(LOOPCTL_USER_KEY).",
+      "FIRST-TIME SETUP — do this ONCE, right after signup, to bring the wiki online. " +
+      "Provision your OWN Anthropic + OpenAI embedding keys so knowledge ingest AND " +
+      "semantic search work. loopctl is strictly BYO: it fronts NO LLM cost — your keys " +
+      "bill you directly and are stored ENCRYPTED, never returned. WHY it's required: with " +
+      "no `api_key`, knowledge_ingest returns 422 (code no_api_key); with no " +
+      "`embedding_api_key`, knowledge_search silently degrades to keyword-only " +
+      "(meta.fallback_reason: no_embedding_key) — both responses carry a `remediation` " +
+      "pointing back to THIS tool. WHICH key powers WHAT: `api_key` (Anthropic) → ingest " +
+      "extraction / classification / merge synthesis; `embedding_api_key` " +
+      "(OpenAI-compatible) → article embeddings + semantic ranking. All params are optional " +
+      "and partial-merge — omitting a key leaves the existing one untouched, so you can set " +
+      "or rotate one at a time. The per-operation model overrides " +
+      "(extraction_model / classification_model / merge_model / embedding_model) are " +
+      "free-form (any model the key permits) and default server-side when omitted. Typical " +
+      'onboarding call: set_llm_config({api_key: "sk-ant-...", embedding_api_key: "sk-..."}). ' +
+      "Verify anytime with llm_config (has_api_key / has_embedding_key). REQUIRES your " +
+      "user-role key LOOPCTL_USER_KEY (minted by the human-anchored signup ceremony); if it " +
+      "is unset the tool fails fast telling you to set it.",
     inputSchema: {
       type: "object",
       properties: {
         api_key: {
           type: "string",
-          description: "Anthropic API key (write-only; stored encrypted, never returned).",
+          description:
+            "Anthropic API key — powers knowledge ingest (extraction/classification/merge). " +
+            "Write-only; stored encrypted, never returned.",
         },
         extraction_model: {
           type: "string",
@@ -3448,7 +3521,9 @@ const TOOLS = [
         embedding_api_key: {
           type: "string",
           description:
-            "OpenAI-compatible embedding API key (write-only; stored encrypted, never returned).",
+            "OpenAI-compatible embedding API key — powers article embeddings + semantic " +
+            "search. Write-only; stored encrypted, never returned. Without it, articles are " +
+            "not vector-searchable and search degrades to keyword-only.",
         },
         embedding_model: {
           type: "string",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.33.1",
+  "version": "2.34.0",
   "description": "MCP server for loopctl — structural trust for AI development loops",
   "type": "module",
   "main": "index.js",

--- a/mcp-server/test/llm_onboarding.test.js
+++ b/mcp-server/test/llm_onboarding.test.js
@@ -1,0 +1,191 @@
+/**
+ * Tests for the smooth agent BYO-LLM onboarding experience:
+ *  - set_llm_config / llm_config tool descriptions fully onboard a stranger agent
+ *  - ingest/search tool RESULTS surface the server's remediation prominently
+ *  - README carries the first-time-setup walkthrough
+ *
+ * Uses Node.js built-in test runner (node:test). Run: node --test test/
+ *
+ * The handler helpers in index.js are not exported (server entry point with
+ * top-level await), so — per the existing test convention (knowledge_tools.test.js)
+ * — we re-implement the minimal helpers under test here, mirroring index.js exactly,
+ * and read index.js / README.md as text for the description assertions.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const indexPath = path.join(__dirname, "..", "index.js");
+const readmePath = path.join(__dirname, "..", "README.md");
+
+// ---------------------------------------------------------------------------
+// Minimal re-implementation of the helpers under test (mirror index.js exactly)
+// ---------------------------------------------------------------------------
+
+function toContent(result) {
+  const isErr = result && result.error === true;
+  return {
+    content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+    ...(isErr && { isError: true }),
+  };
+}
+
+function llmRemediationNotice(result) {
+  const rem =
+    (result &&
+      result.error === true &&
+      result.body &&
+      result.body.error &&
+      result.body.error.remediation) ||
+    (result && result.meta && result.meta.remediation) ||
+    null;
+
+  if (!rem || rem.action !== "configure_llm") return null;
+
+  const missing = Array.isArray(rem.missing) ? rem.missing.join(", ") : rem.missing;
+  return (
+    `ACTION REQUIRED — BYO LLM key not configured (missing: ${missing}). ` +
+    `${rem.message || ""} Provision it ONCE with the ${rem.mcp_tool} MCP tool, e.g. ` +
+    `${rem.example} (REST: ${rem.api}). Requires your user-role key (LOOPCTL_USER_KEY). ` +
+    `Docs: ${rem.docs}`
+  ).replace(/\s+/g, " ").trim();
+}
+
+function withRemediationNotice(result) {
+  const base = toContent(result);
+  const notice = llmRemediationNotice(result);
+  if (!notice) return base;
+  return { ...base, content: [{ type: "text", text: notice }, ...base.content] };
+}
+
+// Server-shaped fixtures (match lib/loopctl/llm/remediation.ex).
+const ANTHROPIC_REMEDIATION = {
+  action: "configure_llm",
+  missing: ["api_key"],
+  credential: "anthropic_api_key",
+  mcp_tool: "set_llm_config",
+  example: 'set_llm_config({"api_key": "<your Anthropic API key>"})',
+  api: "PATCH /api/v1/tenants/me/llm-config",
+  docs: "https://loopctl.com/wiki/agent-onboarding",
+  message: "This tenant has no Anthropic API key configured.",
+};
+
+const EMBEDDING_REMEDIATION = {
+  ...ANTHROPIC_REMEDIATION,
+  missing: ["embedding_api_key"],
+  credential: "openai_embedding_api_key",
+  example: 'set_llm_config({"embedding_api_key": "<your OpenAI API key>"})',
+  message: "Semantic ranking is unavailable because this tenant has no embedding API key.",
+};
+
+// ---------------------------------------------------------------------------
+
+describe("set_llm_config / llm_config tool descriptions onboard a stranger agent", () => {
+  const source = readFileSync(indexPath, "utf8");
+
+  // Isolate each tool block so assertions target the right description.
+  function toolBlock(name) {
+    const marker = `name: "${name}"`;
+    const start = source.indexOf(marker);
+    assert.ok(start !== -1, `tool ${name} should be defined`);
+    return source.slice(start, start + 2000);
+  }
+
+  test("set_llm_config explains WHAT / WHY / WHEN / the required user key", () => {
+    const block = toolBlock("set_llm_config");
+    assert.match(block, /FIRST-TIME SETUP/);
+    assert.match(block, /BYO/);
+    assert.match(block, /Anthropic/);
+    assert.match(block, /embedding/i);
+    assert.match(block, /encrypted/);
+    assert.match(block, /LOOPCTL_USER_KEY/);
+    assert.match(block, /partial-merge/);
+    // Both credential params are documented with what they power.
+    assert.match(block, /api_key/);
+    assert.match(block, /embedding_api_key/);
+  });
+
+  test("llm_config advertises has_api_key / has_embedding_key as a setup check", () => {
+    const block = toolBlock("llm_config");
+    assert.match(block, /has_api_key/);
+    assert.match(block, /has_embedding_key/);
+    assert.match(block, /LOOPCTL_USER_KEY/);
+  });
+});
+
+describe("ingest/search results surface the BYO remediation prominently", () => {
+  test("ingest no-key 422 leads with an ACTION REQUIRED notice naming set_llm_config", () => {
+    const result = {
+      error: true,
+      status: 422,
+      body: { error: { status: 422, code: "no_api_key", message: "x", remediation: ANTHROPIC_REMEDIATION } },
+    };
+    const out = withRemediationNotice(result);
+
+    const lead = out.content[0].text;
+    assert.match(lead, /ACTION REQUIRED/);
+    assert.match(lead, /set_llm_config/);
+    assert.match(lead, /api_key/);
+    assert.match(lead, /LOOPCTL_USER_KEY/);
+    // isError is preserved so the caller still sees it failed.
+    assert.equal(out.isError, true);
+    // The raw JSON body is still present after the notice.
+    assert.ok(out.content.length >= 2);
+  });
+
+  test("search keyword-only degrade leads with the embedding-key remediation", () => {
+    const result = {
+      data: [],
+      meta: {
+        fallback: true,
+        search_mode: "keyword_only",
+        fallback_reason: "no_embedding_key",
+        remediation: EMBEDDING_REMEDIATION,
+      },
+    };
+    const out = withRemediationNotice(result);
+
+    const lead = out.content[0].text;
+    assert.match(lead, /ACTION REQUIRED/);
+    assert.match(lead, /set_llm_config/);
+    assert.match(lead, /embedding_api_key/);
+    // A 200 degrade is not an error.
+    assert.equal(out.isError, undefined);
+  });
+
+  test("a normal result surfaces NO notice (no false positives)", () => {
+    const result = { data: [{ id: "a" }], meta: { total_count: 1, search_mode: "combined" } };
+    const out = withRemediationNotice(result);
+    assert.equal(out.content.length, 1);
+    assert.doesNotMatch(out.content[0].text, /ACTION REQUIRED/);
+  });
+
+  test("a non-LLM error (learn_more shape) surfaces NO llm notice", () => {
+    const result = {
+      error: true,
+      status: 409,
+      body: { error: { code: "self_verify_blocked", remediation: { learn_more: "https://x" } } },
+    };
+    assert.equal(llmRemediationNotice(result), null);
+  });
+});
+
+describe("README carries the first-time-setup walkthrough", () => {
+  const readme = readFileSync(readmePath, "utf8");
+
+  test("has a First-time setup section with the smooth path", () => {
+    assert.match(readme, /First-time setup — provision your BYO LLM keys/);
+    assert.match(readme, /set_llm_config\(\{ api_key/);
+    assert.match(readme, /embedding_api_key/);
+    assert.match(readme, /LOOPCTL_USER_KEY/);
+  });
+
+  test("tool table mentions BOTH the Anthropic and embedding keys for set_llm_config", () => {
+    assert.match(readme, /Anthropic `api_key`/);
+    assert.match(readme, /OpenAI `embedding_api_key`/);
+  });
+});

--- a/test/loopctl/llm/remediation_test.exs
+++ b/test/loopctl/llm/remediation_test.exs
@@ -1,0 +1,62 @@
+defmodule Loopctl.Llm.RemediationTest do
+  use ExUnit.Case, async: true
+
+  alias Loopctl.Llm.Remediation
+
+  describe "for_credential/1" do
+    test ":anthropic names the api_key + the set_llm_config MCP tool" do
+      r = Remediation.for_credential(:anthropic)
+
+      assert r.action == "configure_llm"
+      assert r.missing == ["api_key"]
+      assert r.mcp_tool == "set_llm_config"
+      assert r.api == "PATCH /api/v1/tenants/me/llm-config"
+      assert r.example =~ "set_llm_config"
+      assert r.example =~ "api_key"
+      assert is_binary(r.docs) and r.docs =~ "onboarding"
+      assert r.message =~ "Anthropic"
+    end
+
+    test ":embedding names the embedding_api_key + the set_llm_config MCP tool" do
+      r = Remediation.for_credential(:embedding)
+
+      assert r.action == "configure_llm"
+      assert r.missing == ["embedding_api_key"]
+      assert r.mcp_tool == "set_llm_config"
+      assert r.api == "PATCH /api/v1/tenants/me/llm-config"
+      assert r.example =~ "embedding_api_key"
+      assert r.message =~ "semantic" or r.message =~ "embedding"
+    end
+
+    test "carries no secret-looking value (it only names fields)" do
+      for cred <- [:anthropic, :embedding] do
+        r = Remediation.for_credential(cred)
+        blob = inspect(r)
+        # The placeholder is angle-bracketed, never a real sk-... token.
+        refute blob =~ ~r/sk-[A-Za-z0-9]{8}/
+        assert r.example =~ "<your"
+      end
+    end
+  end
+
+  describe "for_fallback_reason/1" do
+    test "maps the missing-embedding-key tag to the embedding remediation" do
+      assert Remediation.for_fallback_reason("no_embedding_key") ==
+               Remediation.for_credential(:embedding)
+    end
+
+    test "returns nil for transient/provider fallbacks (a key IS configured there)" do
+      for tag <- [
+            "embedding_circuit_open",
+            "embedding_timeout",
+            "embedding_provider_error_401",
+            "embedding_request_failed",
+            "embedding_crash",
+            "embedding_error",
+            nil
+          ] do
+        assert Remediation.for_fallback_reason(tag) == nil
+      end
+    end
+  end
+end

--- a/test/loopctl_web/controllers/knowledge_context_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_context_controller_test.exs
@@ -231,6 +231,46 @@ defmodule LoopctlWeb.KnowledgeContextControllerTest do
       assert body["meta"]["fallback"] == true
     end
 
+    test "keyless-embedding fallback surfaces meta.remediation naming set_llm_config (no secret)",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Keyword Findable Article",
+        body: "Content about pagination that keyword search can find.",
+        category: :pattern,
+        status: :published,
+        tags: ["pagination"]
+      })
+
+      # A missing embedding key (mandatory BYO) — sanitizes to the actionable
+      # "no_embedding_key" tag, unlike the generic ":service_unavailable" above.
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, :no_api_key}
+      end)
+
+      body =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/context", %{query: "pagination"})
+        |> json_response(200)
+
+      assert body["meta"]["fallback"] == true
+      assert body["meta"]["fallback_reason"] == "no_embedding_key"
+
+      # Self-service remediation mirrors /knowledge/search: name the set_llm_config
+      # MCP tool + the missing embedding credential, and NEVER a secret.
+      remediation = body["meta"]["remediation"]
+      assert remediation["action"] == "configure_llm"
+      assert remediation["missing"] == ["embedding_api_key"]
+      assert remediation["mcp_tool"] == "set_llm_config"
+      assert remediation["api"] == "PATCH /api/v1/tenants/me/llm-config"
+      assert remediation["example"] =~ "embedding_api_key"
+      refute inspect(body) =~ ~r/sk-[A-Za-z0-9]{8}/
+    end
+
     test "missing query returns 400", %{conn: conn} do
       tenant = fixture(:tenant)
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -58,12 +58,25 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       assert body["error"]["code"] == "no_api_key"
       assert body["error"]["message"] =~ "Anthropic API key"
 
-      # The remediation string must name a verb+path ACTUALLY registered in the
+      # Self-service remediation: the agent must be able to onboard from the response
+      # ALONE — it names the set_llm_config MCP tool, the missing credential, a
+      # copy-paste example, and the REST endpoint.
+      remediation = body["error"]["remediation"]
+      assert remediation["action"] == "configure_llm"
+      assert remediation["missing"] == ["api_key"]
+      assert remediation["mcp_tool"] == "set_llm_config"
+      assert remediation["example"] =~ "set_llm_config"
+      assert is_binary(remediation["docs"])
+
+      # The remediation's `api` must name a verb+path ACTUALLY registered in the
       # router (review #7 — catches PUT/PATCH drift between the copy and the route).
-      [verb, path] = String.split(body["error"]["remediation"]["configure"], " ", parts: 2)
+      [verb, path] = String.split(remediation["api"], " ", parts: 2)
 
       assert route_registered?(verb, path),
              "422 remediation names #{verb} #{path}, which is not a registered route"
+
+      # Never leaks a key/secret.
+      refute inspect(body) =~ ~r/sk-[A-Za-z0-9]{8}/
     end
 
     test "POST /knowledge/ingest/batch with a keyless tenant -> 422 code no_api_key", %{

--- a/test/loopctl_web/controllers/knowledge_search_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_search_controller_test.exs
@@ -295,6 +295,50 @@ defmodule LoopctlWeb.KnowledgeSearchControllerTest do
       assert body["meta"]["fallback"] == true
       assert body["meta"]["search_mode"] == "keyword_only"
       assert body["meta"]["fallback_reason"] == "no_embedding_key"
+
+      # Self-service remediation: the degraded response tells the agent how to enable
+      # semantic ranking without a human — name the set_llm_config MCP tool + the
+      # missing embedding credential, and NEVER a secret.
+      remediation = body["meta"]["remediation"]
+      assert remediation["action"] == "configure_llm"
+      assert remediation["missing"] == ["embedding_api_key"]
+      assert remediation["mcp_tool"] == "set_llm_config"
+      assert remediation["api"] == "PATCH /api/v1/tenants/me/llm-config"
+      assert remediation["example"] =~ "embedding_api_key"
+      refute inspect(body) =~ ~r/sk-[A-Za-z0-9]{8}/
+    end
+
+    test "combined provider-error fallback carries NO remediation (a key IS configured)", %{
+      conn: conn
+    } do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      Loopctl.Knowledge.reset_circuit_breaker(tenant.id)
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Keyword Findable Article",
+        body: "Content about pagination that keyword search can find.",
+        category: :pattern,
+        status: :published,
+        tags: ["pagination"]
+      })
+
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, {:api_error, 401, "Incorrect API key provided: sk-SECRETDEADBEEF"}}
+      end)
+
+      body =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{q: "pagination"})
+        |> json_response(200)
+
+      assert body["meta"]["fallback_reason"] == "embedding_provider_error_401"
+      # The key is configured but the provider rejected it — "configure a key" would
+      # be the wrong advice, so no remediation is attached.
+      refute Map.has_key?(body["meta"], "remediation")
     end
 
     test "filters by project_id, category, and tags", %{conn: conn} do

--- a/test/loopctl_web/live/signup_live_test.exs
+++ b/test/loopctl_web/live/signup_live_test.exs
@@ -816,6 +816,8 @@ defmodule LoopctlWeb.SignupLiveTest do
 
       assert html =~ "Onboarding Target"
       assert html =~ "Generate audit signing key"
+      assert html =~ "Provision your BYO LLM keys"
+      assert html =~ "set_llm_config"
       assert html =~ "Create your first project"
       assert html =~ "Register your first agent"
     end


### PR DESCRIPTION
## Summary

Makes provisioning BYO LLM keys a **smooth, discoverable, self-service** experience a stranger agent can complete from docs + tool descriptions + self-healing errors alone. The mechanism already existed (`PATCH /api/v1/tenants/me/llm-config` + the `set_llm_config` MCP tool, role `:user`); this closes the onboarding gap around it. No security/role/chain-of-custody changes.

## Self-healing remediation (server-side)

- **`Loopctl.Llm.Remediation`** — one shared builder emitting a consistent, machine-readable, **secret-free** object: `action`, `missing`, `credential`, `mcp_tool`, `example`, `api`, `docs`, `message`. Distinguishes the missing credential — Anthropic `api_key` (ingest/classify/merge) vs OpenAI `embedding_api_key` (embeddings/semantic search).
- **Ingest no-key 422** (`code: no_api_key`) now carries `error.remediation` (Anthropic). The bare string is gone.
- **Search/context keyword-only degrade** now carries `meta.remediation` **only** when `fallback_reason == "no_embedding_key"` — transient/provider fallbacks carry none (a key IS configured there, so "configure a key" would be wrong). Derives from the existing `ProviderError`-sanitized `fallback_reason`, so no key/body can leak.

## Self-documenting MCP tools (mcp-server 2.33.1 → 2.34.0)

- Rewrote **`set_llm_config`** / **`llm_config`** descriptions to fully onboard a stranger agent: WHAT (BYO, encrypted, never returned), WHY (required before ingest/search; loopctl fronts no cost), WHEN (once, at signup), the required `LOOPCTL_USER_KEY`, which key powers what, partial-merge, and the `has_api_key`/`has_embedding_key` status check.
- **`knowledge_ingest` / `_batch` / `_search` / `_context`** results now **lead with an `ACTION REQUIRED` notice** built from the server remediation, so an agent that skips setup reads the exact next step (call `set_llm_config`) instead of a bare error.
- README: new **First-time setup** section before the tool reference; updated tool-table + `LOOPCTL_USER_KEY` env rows; CHANGELOG entry.

## Docs + signup hook

- New **`docs/onboarding-agent-tenant.md`** — the authoritative agent-tenant sequence (WebAuthn L0 signup → provision keys → use ingest/search).
- Added a **"Provision your BYO LLM keys"** step to the post-signup onboarding checklist (`TenantOnboardingLive`). Security-neutral display step — WebAuthn / chain-of-custody untouched. (The only concrete signup surface is this checklist; there is no getting-started API payload, so the doc is the authoritative sequence.)

## Tests

- `Loopctl.Llm.Remediation` unit test (shapes, missing-key names, no secret, `for_fallback_reason` mapping).
- Ingest 422 remediation shape (names `set_llm_config` + `api_key`, `api` is a registered route, no secret).
- Search `no_embedding_key` fallback carries the embedding remediation; a provider-error fallback carries **none**.
- Node tests: tool descriptions carry the onboarding language; ingest/search results surface the remediation notice; no false positives.

## Verification

- `mix compile --warnings-as-errors`, `format`, `credo --strict` (0), `dialyzer` (0), full `mix test` — **3673 tests, 0 failures** (via the pre-commit hook, 1.19/OTP28).
- mcp-server: `node --test test/*.test.js` — **112 tests, 0 failures**.
