### PR TITLE
feat(auth): capability-tiered trust — agent-rooted KB self-signup vs human-anchored custody (US-26.7.1)

### DIFF
--- a/docs/chain-of-custody-v2.md
+++ b/docs/chain-of-custody-v2.md
@@ -595,9 +595,50 @@ At no point does the agent need prior knowledge of loopctl's internals. Every st
 
 ## 9. Tenant signup ceremony
 
-Tenant creation is a human-gated ceremony that establishes the root of trust for the tenant's entire lifetime.
+### 9.0 Two trust tiers: capability, not genesis (US-26.7.1)
 
-### 9.1 Flow
+Loopctl serves two use cases that were originally forced to share one trust
+model: (1) a supervised code workflow where implementer, reviewer, and
+verifier must be different agents rooted in a human operator, and (2) an
+agent-native knowledge base where a stranger agent manages its own notes on
+its own BYO LLM keys with no human involved at all. Trust attaches to the
+**capability**, not to how the tenant came into existence:
+
+- **`human_anchored`** — created via the WebAuthn ceremony below (§9.1).
+  Unlocks the full work-breakdown / chain-of-custody surface (projects,
+  epics, stories, dispatch, orchestrator state, token budgets, bulk
+  operations, ...).
+- **`agent_rooted`** — created via `POST /api/v1/signup` (or the `signup`
+  MCP tool), no human, no hardware authenticator. Retains the FULL
+  knowledge-wiki surface (ingest, search, context, curate, article
+  CRUD, BYO LLM config, its own agent registration) but is blocked from the
+  work-breakdown / chain-of-custody surface by
+  `LoopctlWeb.Plugs.RequireHumanAnchor`, a gate keyed on the TENANT's
+  `trust_tier` — deliberately orthogonal to API-key role, since role alone
+  cannot express "KB-yes, custody-no" and a role-only gate would be
+  escapable by a tenant self-minting a higher-role key.
+
+This does not weaken L0 for the operations that actually depend on it: the
+chain-of-custody guards (`409 self_report_blocked` / `self_review_blocked` /
+`self_verify_blocked`, dispatch-lineage self-checks) enforce
+implementer != verifier regardless of how the tenant was created. L0's job
+is rooting the per-tenant audit chain to a real human so Signed Tree Heads
+are externally attestable to a person — that only matters for the
+work-custody surface, not for a tenant curating its own wiki notes.
+
+An `agent_rooted` tenant can later enroll a WebAuthn authenticator to
+upgrade to `human_anchored` and unlock the custody surface — that reciprocal
+opt-in ceremony is a dependent fast-follow (US-26.7.2), not yet implemented.
+
+`POST /api/v1/signup` — public (no auth), rate-limited per client IP
+(<= 5/hour). Accepts `name`, `slug`, `email`; returns the created tenant
+(`trust_tier: "agent_rooted"`) plus a one-time `role: user`, tenant-bound
+`raw_key`. Distinct from the `/signup` HTML ceremony below (different
+pipeline, path, and method).
+
+### 9.1 Flow (human-anchored ceremony)
+
+Tenant creation via this path is a human-gated ceremony that establishes the root of trust for the tenant's entire lifetime.
 
 1. Operator visits `https://loopctl.com/signup` (a LiveView in the existing landing page application)
 2. Operator provides tenant metadata (name, slug, contact email)
@@ -625,14 +666,58 @@ Tenant creation is a human-gated ceremony that establishes the root of trust for
 
 Any endpoint that modifies the root trust requires a fresh WebAuthn assertion:
 
-- `POST /tenants/:id/authenticators` — enroll an additional authenticator
-- `DELETE /tenants/:id/authenticators/:id` — revoke an authenticator
-- `POST /tenants/:id/rotate-audit-key` — rotate the audit signing key
-- `POST /tenants/:id/override` — break-glass override of a halted custody operation
-- `DELETE /projects/:id` — delete a project
-- `POST /tenants/:id/budgets` — raise a token budget
+- `POST /tenants/:id/rotate-audit-key` — rotate the audit signing key. Requires a
+  FRESH per-operation WebAuthn assertion via the challenge-bound
+  `Loopctl.WebAuthn.Reauth` ceremony (`POST /tenants/:id/rotate-audit-key/challenge`
+  then `POST /tenants/:id/rotate-audit-key`), not just an active session.
+- `DELETE /projects/:id` — delete a project. Now additionally tier-gated
+  (US-26.7.1): requires a `human_anchored` tenant on top of the existing
+  `role: :user` requirement.
+- `POST /tenants/:id/authenticators` — enroll an additional authenticator, and
+  `DELETE /tenants/:id/authenticators/:id` — revoke an authenticator. Both are
+  **deferred to US-26.7.2** (the reciprocal opt-in WebAuthn-enrollment upgrade
+  path for an `agent_rooted` tenant) — these routes do not exist yet.
 
-The operator's CLI prompts for the hardware touch at the moment of the operation. Agents cannot perform these operations — attempting to do so returns a 401 with remediation text pointing at the break-glass workflow.
+Corrections to a stale prior version of this list: `POST /tenants/:id/override`
+and `POST /tenants/:id/budgets` never existed as routes and have been removed
+from this list. The real halt-clear operation is
+`POST /api/v1/admin/tenants/:id/clear-halt` (superadmin-only break-glass; see
+§L6 and the Epic 17 admin routes).
+
+The operator's CLI prompts for the hardware touch at the moment of a
+reauth-gated operation. Agents cannot perform these operations — attempting to
+do so is blocked by role/tier enforcement with remediation text.
+
+#### Tier-gate allowlist rationale (US-26.7.1, reviewed)
+
+`RequireHumanAnchor` gates the work-breakdown / chain-of-custody surface. A
+`DEFAULT-DENY` router-walk test (`require_human_anchor_default_deny_test.exs`)
+asserts every authenticated mutating route either is tier-gated OR is on an
+explicit, reviewed allowlist. The allowlist decisions:
+
+- **SkillController mutations** (`create`/`update`/`delete`/`create_version`/
+  `import_skills`) ARE tier-gated (added during review): skill definitions are
+  work-breakdown metadata. `cost_performance` (a read) is not gated.
+- **ArtifactReportController `create`** IS tier-gated: artifact reports are
+  implementation evidence against a story.
+- **WebhookController** is NOT tier-gated: webhook subscriptions are
+  tenant-account integration config (delivery endpoints), analogous to the
+  KB-tier-open BYO LLM config. Their SSRF blast radius is independently bounded
+  by `UrlGuard.pin` (egress allowlist + DNS-rebinding defense) regardless of
+  tier.
+- **UiTestController** is NOT tier-gated: every route is nested under
+  `/projects/:project_id/...`, and `ProjectController.create` IS tier-gated, so
+  an agent-rooted tenant has no project to attach a UI test run to — the surface
+  is unreachable for it.
+- **`POST /tenants/:id/bootstrap-audit-key`** is NOT tier-gated because it is
+  UNREACHABLE: both signup paths (`Loopctl.Tenants.signup/1` and
+  `self_signup/1`) mandatorily pre-provision the audit key, so
+  `bootstrap_audit_key/1` always returns 409 `key_already_exists` for every
+  current and future tenant. A regression test asserts a freshly created tenant
+  always has a non-nil `audit_signing_public_key`, so this exemption fails loud
+  if provisioning ever became lazy. `rotate-audit-key` (challenge + rotate) is
+  gated by a fresh per-op WebAuthn assertion (`WebAuthn.Reauth`), a stronger
+  control than the tier.
 
 ### 9.3 Recovery
 

--- a/docs/user_stories/epic_26_chain_of_custody_v2/us_26.7.1.json
+++ b/docs/user_stories/epic_26_chain_of_custody_v2/us_26.7.1.json
@@ -1,0 +1,203 @@
+{
+  "id": "US-26.7.1",
+  "title": "Capability-Tiered Trust: Agent-Rooted Self-Signup (KB tier) vs Human-Anchored Custody tier",
+  "epic": {
+    "id": "epic_26",
+    "name": "Chain of Custody v2"
+  },
+  "priority": "high",
+  "phase": "capability_tiers",
+  "story": {
+    "as_a": "an autonomous agent that wants to use loopctl purely as a knowledge base (ingest / search / curate on my own BYO LLM keys), with no human operator and no hardware authenticator",
+    "i_want_to": "create my own tenant and obtain a working key entirely through an API call or an MCP tool, and immediately use the full knowledge surface, without a WebAuthn signup ceremony",
+    "so_that": "onboarding to the second-brain KB is frictionless for any stranger agent, while the higher-stakes work-breakdown / chain-of-custody surface stays reserved for human-anchored tenants who have enrolled a hardware authenticator"
+  },
+  "rationale": "loopctl was born to enforce a supervised code workflow where implementer, reviewer, and verifier are different agents rooted in a human operator (the WebAuthn L0 anchor at signup). But the platform now serves a second, dominant use case: an agent-native knowledge base. These two use cases were wrongly forced to share ONE trust model, so today the ONLY way to create a tenant is the WebAuthn LiveView at /signup (confirmed: Loopctl.Tenants.signup/1 is called only from signup_live.ex; Tenants.create_tenant/1 is test-only; there is no API or MCP path). That makes agent-native KB onboarding impossible without a human pressing a hardware key.\n\nThe resolution is to attach trust to the CAPABILITY, not to tenant genesis. The KB surface (ingest/search/context/curate, article CRUD, BYO-key config) is low-stakes: an agent managing its own knowledge on its own keys can only harm itself, and — critically — the chain-of-custody protections that matter (the 409 self_report/self_review/self_verify guards and dispatch-lineage self-checks) do NOT depend on the L0 anchor; they enforce implementer!=verifier regardless of how the tenant was created (verified in the spec-review pass against story_status_controller.ex, story_verification_controller.ex, review_record_controller.ex, and progress.ex:1025-1026). L0's real job is rooting the per-tenant audit chain to a human so that Signed Tree Heads are externally attestable to a real person — which matters for the work-custody surface, not for a tenant curating its own notes.\n\nTherefore: open a lightweight, rate-limited, agent-rooted self-signup path (API + MCP) that yields a tenant on the KB tier, and gate the work-breakdown / chain-of-custody surface behind a new capability check (RequireHumanAnchor) that is keyed on the TENANT's trust_tier (deliberately orthogonal to role — because role cannot express 'KB-yes, custody-no', and because a role check would let a tenant self-mint a higher-role key to escape the gate). Existing tenants (human-anchored via the WebAuthn ceremony) are unaffected; only the new agent-rooted tier is restricted. This does NOT weaken L0 for the operations that depend on it — it scopes WHERE the tier boundary sits. The reciprocal opt-in upgrade flow (an agent-rooted tenant enrolling a WebAuthn authenticator post-signup to become human-anchored and unlock custody) is a dependent fast-follow (US-26.7.2).\n\nThis story was hardened by a pre-implementation enhanced-review pass that found 5 critical tier-gate bypasses in the first draft (missing action aliases and whole custody controllers, action-atom vs URL-prose mismatches that compile to no-op guards, and an un-rolled-back external secret write). The corrections below — exact action atoms, the full custody-controller enumeration, and a DEFAULT-DENY router-walk guard test — are the direct product of that review.",
+  "acceptance_criteria": [
+    {
+      "id": "AC-26.7.1.1",
+      "description": "A `trust_tier` column (Ecto.Enum, values `:human_anchored | :agent_rooted`) is added to `tenants` via migration. The database default is the RESTRICTIVE value `:agent_rooted` (honoring 'nil/unknown is never permissive'), NOT NULL. A backfill in the SAME migration, using plain `execute/1` (no AdminRepo/Repo distinction applies inside a migration; `tenants` carries no RLS policy — verified against 20260327051838_create_rls_infrastructure.exs and 20260412180651_add_custody_halted_at_to_tenants.exs), runs `UPDATE tenants SET trust_tier='human_anchored' WHERE id IN (SELECT DISTINCT tenant_id FROM tenant_root_authenticators)`, so every existing tenant with an enrolled authenticator (incl. the single prod tenant) becomes human_anchored and any without stays agent_rooted. `trust_tier` is NEVER in a public changeset `cast`; each signup path sets it explicitly on the struct.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-26.7.1.2",
+      "description": "The existing WebAuthn ceremony `Loopctl.Tenants.signup/1` explicitly sets `trust_tier: :human_anchored` on the inserted tenant; its genesis audit entry is unchanged (`actor_type: \"human\"`, `actor_label: \"human:webauthn\"`). An existing-behavior test proves a WebAuthn-signed tenant is `:human_anchored` and can still perform custody operations.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-26.7.1.3",
+      "description": "A new context function `Loopctl.Tenants.self_signup/1` creates an AGENT-ROOTED tenant in a single Ecto.Multi that mirrors the trusted parts of the ceremony WITHOUT authenticators: insert tenant (`trust_tier: :agent_rooted`), generate + store the Ed25519 audit signing keypair (private via Loopctl.Secrets, public onto the tenant), activate the tenant, and write a genesis audit entry with `actor_type: \"agent\"` and `actor_label: \"agent:self-signup\"`. It then mints a `role: :user`, `agent_id: nil` root API key bound to the tenant (so the tenant can call PATCH /tenants/me/llm-config and register its own agent identity). The raw key is returned exactly once and never persisted in plaintext.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-26.7.1.4",
+      "description": "TRANSACTIONAL SECRET SAFETY (spec-review CRITICAL): because `Loopctl.Secrets.set/2` is an EXTERNAL Fly.io write that `AdminRepo.transaction/1` cannot roll back, any failure occurring AFTER a successful `Secrets.set/2` (in `set_public_key`, `activate`, or `audit_genesis`) must trigger a compensating `Loopctl.Secrets.delete/1` of the just-written key before returning `{:error, ...}`, so no orphaned Ed25519 private key is left in Fly with no owning tenant row. This compensation is added to the SHARED helper (`with_secret_compensation/3`, keyed on lexical secret_name — no process dictionary) so it also fixes the identical latent flaw in the existing `signup/1` path. Regression tests prove full cleanup (tenant, root api_key, audit entry, AND secret) for a mid-Multi failure in BOTH `self_signup/1` and `signup/1`. REVIEW EXTENSIONS: (review #1) a FAILED compensating delete/restore is never swallowed — it emits `[:loopctl, :secrets, :orphan_cleanup_failed]` telemetry AND enqueues a durable, retryable `Loopctl.Workers.OrphanedSecretCleanupWorker` (delete, or restore with a Cloak-encrypted value) so cleanup actually happens; (review #2) the SAME machinery is extended to the pre-existing `bootstrap_audit_key/1` (DELETE compensation — no prior key existed) and `rotate_audit_key/2` (RESTORE compensation — rotation overwrites the deterministic secret with the NEW key, so a post-write rollback restores the OLD private key rather than deleting, preventing silent signature-verification breakage).",
+      "status": "pending"
+    },
+    {
+      "id": "AC-26.7.1.5",
+      "description": "A public (no-auth) JSON endpoint `POST /api/v1/signup` (distinct from the `/signup` HTML LiveView — different pipeline, path, and method; no route collision) calls `self_signup/1` and returns the created tenant summary plus the one-time `raw_key` (role `user`, tenant-bound) and a `next_action` block pointing at PATCH /tenants/me/llm-config and the KB tools. It is NOT behind the `:authenticated` pipeline. It is rate-limited per client IP using the existing config-resolved Hammer limiter (reuse the `Loopctl.RateLimiter` behaviour used by signup_live.ex; derive the IP via `Loopctl.RemoteIp`, preferring the unspoofable fly-client-ip), with a conservative cap (<= 5 tenants per IP per hour). Over-limit returns 429 with a clear retry message. Oversized fields are rejected before the DB call. The operation is registered in OpenApiSpex so /openapi stays accurate.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-26.7.1.6",
+      "description": "A new plug `LoopctlWeb.Plugs.RequireHumanAnchor` gates the custody tier. It reads the TENANT's trust_tier and is keyed on tenant, never on role. Behavior: (a) the superadmin-exempt case is a LEADING PATTERN-MATCH on `current_tenant: nil` (mirroring SetTenant's `%{assigns: %{current_api_key: %{tenant_id: nil}}}` convention) so it never crashes on a nil tenant AND so an IMPERSONATING superadmin is correctly routed through the impersonated tenant's trust_tier (Impersonate reassigns current_tenant before controller plugs) — do NOT implement the exemption as `role == :superadmin`; (b) `trust_tier: :human_anchored` passes through; (c) `trust_tier: :agent_rooted` halts with `403` and body `%{error: %{status: 403, code: \"custody_tier_required\", message: <text>, remediation: %{...}}}` — the SAME nested envelope every other error uses (fallback_controller.ex:133-194; the MCP client at mcp-server/index.js reads `error.remediation`), with remediation text naming the enrollment upgrade path and linking the `chain-of-custody` / `tenant-signup` wiki slugs. The plug is placed AFTER role resolution so `current_tenant` is populated, and composes with `RequireRole` (both must pass).",
+      "status": "pending"
+    },
+    {
+      "id": "AC-26.7.1.7",
+      "description": "RequireHumanAnchor is applied per-controller (mirroring RequireRole) to the WORK-BREAKDOWN / CHAIN-OF-CUSTODY surface, using EXACT Elixir action atoms (diffed against each controller's real `when action in [...]` clause — URL/verb prose is forbidden because a non-matching atom compiles to a silent no-op guard). The complete gated set is: StoryController `[:create, :create_in_project, :update, :delete]`; StoryStatusController `[:contract, :claim, :start, :report, :report_done, :request_review, :unclaim]`; StoryVerificationController `[:verify, :reject, :force_unclaim, :backfill, :verify_all]`; ReviewRecordController `[:create]` (NOT :review_complete); EpicController `[:create, :update, :delete]`; EpicDependencyController `[:create, :delete]`; StoryDependencyController `[:create, :delete]`; DispatchController `[:create]`; OrchestratorStateController `[:save, :show, :history]`; SkillResultController `[:create]`; ProjectController `[:create, :update, :delete]`; TokenUsageController `[:create, :delete, :correct]` (NOT :correction); TokenBudgetController `[:create, :update, :delete]`; CostAnomalyController `[:update]`; BulkOperationsController `[:claim, :verify, :reject, :mark_complete]`; CapRecoveryController `[:recover]`; ImportExportController `[:import_project]` (NOT :export_project); ArtifactReportController `[:create]` (implementation evidence submission — added during review); SkillController `[:create, :update, :delete, :create_version, :import_skills]` (skill DEFINITIONS are work-breakdown metadata — added during review #4; NOT :cost_performance, a read). Verify each atom against the controller source before adding the plug. It is NOT applied to any knowledge/article/wiki/article_link route, to PATCH/GET /tenants/me/llm-config, to /api_keys management, to AgentController (register/index/show — an agent-rooted tenant MUST be able to register + list its own agent identity for KB attribution, per AC-26.7.1.8), to WebhookController (tenant-account integration config, SSRF-bounded by UrlGuard.pin) or UiTestController (unreachable — nested under a project, and ProjectController.create is itself tier-gated), to read-only index/show/list/export or audit/changes reads, to public/discovery routes, or to /health.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-26.7.1.8",
+      "description": "An agent-rooted tenant retains the FULL KB surface without a human anchor: ingest (POST /knowledge/ingest, batch), search, context, index, stats, graph, novelty, export/OKF/lint, publish/unpublish/archive, create/update/DELETE its own articles and article_links, view analytics/curation-log, configure its BYO LLM keys (PATCH /tenants/me/llm-config), mint/rotate its own scoped API keys, and REGISTER + list its own agent identity (POST /agents/register, GET /agents) — the latter is required so an agent-role key can carry an agent_id and pass ArticleController's `agent_identity_required` (article_controller.ex:306) check when writing attributed agent memory. A test exercises a representative agent-rooted KB happy-path end to end (self-signup -> configure key -> register agent -> ingest/search -> create then DELETE an article) and asserts none of them 403.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-26.7.1.9",
+      "description": "DEFAULT-DENY GUARD TEST (the completeness guarantee, not just enumeration): a test walks `LoopctlWeb.Router.__routes__/0`, keeps every route on the `:authenticated` pipeline whose method mutates (POST/PUT/PATCH/DELETE), SUBTRACTS an explicit, reviewed KB-tier/account allowlist (the knowledge/article/article_link mutations, /tenants/me/llm-config, /api_keys, /agents register, plus any genuinely tenant-neutral route), and asserts that every REMAINING route returns `403 custody_tier_required` when called by an agent-rooted tenant (using a key of whatever role that route requires — self-mint it if needed — to isolate the tier gate from the role gate). Any NEW custody route added later that is neither gated nor allowlisted FAILS this test — the surface fails closed. This test is the authoritative check that AC-26.7.1.7's enumeration is complete and that no action-atom typo produced a no-op guard.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-26.7.1.10",
+      "description": "MCP server (`mcp-server/`) gains a `signup` tool that POSTs to `/api/v1/signup` and returns the tenant + one-time raw_key with clear next-step guidance (configure BYO LLM keys, then ingest/search). The tool description states plainly that it creates an agent-rooted KB-tier tenant and that custody operations require a human-anchored tenant. The README first-time-setup section documents both the raw-API and the MCP signup path, and that the returned key is shown once. The MCP client handles the witness/STH bootstrap for the first AUTHENTICATED call after signup (reuse the existing auto-bootstrap; the public signup POST itself carries no witness header). The package version is bumped.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-26.7.1.11",
+      "description": "Discovery + docs. (a) `GET /.well-known/loopctl` (@discovery_body in well_known_controller.ex) gains a `signup_endpoint` field advertising `POST /api/v1/signup`, with a test asserting it is surfaced — so a stranger agent discovering loopctl cold can find the signup path. (b) `docs/chain-of-custody-v2.md` is updated to introduce the two trust tiers (agent-rooted KB tier vs human-anchored custody tier) and the capability-not-genesis principle; document `POST /api/v1/signup`; and CORRECT §9.2's stale six-bullet list explicitly: keep `POST /tenants/:id/rotate-audit-key` (still requires a FRESH per-op WebAuthn assertion via WebAuthn.Reauth) and `DELETE /projects/:id` (now tier-gated); annotate `POST /tenants/:id/authenticators` + `DELETE /tenants/:id/authenticators/:id` as deferred to US-26.7.2; and REMOVE `POST /tenants/:id/override` and `POST /tenants/:id/budgets` (no such routes exist — the real halt-clear is `POST /api/v1/admin/tenants/:id/clear-halt`). No doc claim may overstate what the code enforces.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-26.7.1.12",
+      "description": "Adversarial + isolation coverage: (a) an agent-rooted tenant cannot read/write another tenant's data (RLS; key is tenant-bound); (b) an agent-rooted tenant is blocked (403 custody_tier_required) on a representative custody op from EACH gated controller group — INCLUDING `POST /projects/:project_id/stories` (the create_in_project route), a bulk op (`POST /stories/bulk/verify`), cap-recovery, and project import — not only the epic-scoped or singular equivalents; (c) the self-signup body cannot set `trust_tier`, `role`, `tenant_id`, or `agent_id` to privileged values (mass-assignment closed) — a body carrying `trust_tier: human_anchored`/`role: superadmin`/etc. still yields an agent_rooted tenant with a role:user key; (d) the returned user key cannot mint a superadmin key; (e) rate-limit denial (429) is proven; (f) THE KEY-MINTING BYPASS IS CLOSED: an agent-rooted tenant that self-mints an orchestrator- or agent-role key is STILL blocked on custody ops, because the gate is keyed on tenant trust_tier not on key role — assert this explicitly with a self-minted orchestrator key against create_in_project.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-26.7.1.13",
+      "description": "`test/support/fixtures.ex` `fixture(:tenant, ...)` defaults `trust_tier: :human_anchored` (trusted test setup, so the large existing custody-test surface is unaffected) and accepts an explicit `trust_tier: :agent_rooted` override. Because `trust_tier` is excluded from `Tenant.create_changeset/2`'s cast, the fixture sets it via a post-insert `Ecto.Changeset.change/2` + `AdminRepo.update!/1`, exactly mirroring the existing `audit_signing_public_key` post-insert pattern already in the same fixture (fixtures.ex:478-485). Every new test file is `async: true` via DataCase/ConnCase, follows config-based DI (no Application.put_env), and includes a tenant-isolation case. `mix precommit` passes clean (compile, format, credo --strict, dialyzer, full suite green).",
+      "status": "pending"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "TC-26.7.1.1",
+      "name": "self_signup/1 creates an activated agent-rooted tenant with agent genesis and a user key",
+      "type": "unit",
+      "preconditions": ["No tenant exists for the chosen slug"],
+      "steps": ["Call Loopctl.Tenants.self_signup(%{name: ..., slug: ...})"],
+      "expected_results": [
+        "{:ok, %{tenant: tenant, raw_key: raw_key}} returned",
+        "tenant.trust_tier == :agent_rooted and tenant is active",
+        "tenant.audit_signing_public_key set; private key retrievable via Loopctl.Secrets",
+        "Genesis audit entry at chain_position 0 with actor_type \"agent\", actor_label \"agent:self-signup\"",
+        "raw_key resolves to a role: :user, agent_id: nil api_key bound to tenant; only its hash is stored"
+      ]
+    },
+    {
+      "id": "TC-26.7.1.2",
+      "name": "self_signup/1 AND signup/1 roll back fully — including deleting the external secret — on a mid-Multi failure",
+      "type": "unit",
+      "preconditions": ["Force a failure in a step AFTER Secrets.set succeeds (e.g. audit_genesis) via the injected dependency"],
+      "steps": ["Call each of self_signup/1 and signup/1 with the failing dependency"],
+      "expected_results": [
+        "{:error, _} returned",
+        "No tenant, no root api_key, no audit entry remain",
+        "The Fly secret written by Secrets.set has been deleted (compensating Secrets.delete ran) — no orphaned private key"
+      ]
+    },
+    {
+      "id": "TC-26.7.1.3",
+      "name": "POST /api/v1/signup returns a working KB-tier key end to end",
+      "type": "integration",
+      "preconditions": ["Public endpoint, no Authorization header"],
+      "steps": [
+        "POST /api/v1/signup with a valid name/slug body",
+        "Use the returned raw_key to PATCH /tenants/me/llm-config, POST /agents/register, GET /knowledge/search, and create then DELETE an article"
+      ],
+      "expected_results": [
+        "201 with data.raw_key present and data.tenant.trust_tier == \"agent_rooted\"",
+        "All follow-up KB + config + agent-register calls succeed (no 403)",
+        "The first authenticated call negotiates the witness/STH bootstrap for the fresh tenant"
+      ]
+    },
+    {
+      "id": "TC-26.7.1.4",
+      "name": "Default-deny router walk: every non-allowlisted authenticated mutating route 403s for an agent-rooted tenant",
+      "type": "integration",
+      "preconditions": ["tenant = self-signup (agent_rooted); a KB-tier/account allowlist is defined in the test"],
+      "steps": [
+        "Enumerate Router.__routes__, keep :authenticated POST/PUT/PATCH/DELETE routes, subtract the allowlist",
+        "Call each remaining route with a role-appropriate (self-minted if needed) key of the agent-rooted tenant"
+      ],
+      "expected_results": [
+        "Every remaining route returns 403 with error.code \"custody_tier_required\"",
+        "Explicitly includes POST /projects/:project_id/stories, POST /stories/bulk/verify, POST /stories/:id/recover-cap, POST /projects/:id/import"
+      ]
+    },
+    {
+      "id": "TC-26.7.1.5",
+      "name": "Human-anchored tenant is unaffected (regression guard)",
+      "type": "integration",
+      "preconditions": ["tenant = fixture(:tenant) => human_anchored, with appropriate role keys"],
+      "steps": ["Perform custody ops with correctly-separated identities"],
+      "expected_results": ["RequireHumanAnchor passes; ops succeed or fail only on existing role/409/lineage rules, never on the tier gate"]
+    },
+    {
+      "id": "TC-26.7.1.6",
+      "name": "Superadmin exemption: no-impersonation passes without crash; impersonating an agent-rooted tenant is blocked",
+      "type": "integration",
+      "preconditions": ["A superadmin key (tenant_id nil)"],
+      "steps": [
+        "Hit a gated action with the superadmin key and no impersonation",
+        "Hit the same action while impersonating an agent-rooted tenant"
+      ],
+      "expected_results": [
+        "No impersonation: RequireHumanAnchor passes (nil current_tenant pattern-match), no crash",
+        "Impersonating agent-rooted: 403 custody_tier_required (routes through impersonated tenant's tier)"
+      ]
+    },
+    {
+      "id": "TC-26.7.1.7",
+      "name": "Key-minting bypass is closed and mass-assignment is rejected",
+      "type": "integration",
+      "preconditions": ["tenant = self-signup (agent_rooted) holding its role:user key"],
+      "steps": [
+        "Self-mint an orchestrator-role key via POST /api_keys, then call POST /projects/:project_id/stories with it",
+        "Attempt a signup body with trust_tier: human_anchored, role: superadmin, tenant_id, agent_id",
+        "Rate-limit: exceed the per-IP signup cap"
+      ],
+      "expected_results": [
+        "The orchestrator-key custody call still returns 403 custody_tier_required (gate keyed on tenant, not role)",
+        "The privileged signup-body fields are ignored: tenant is agent_rooted, key is role user; no superadmin key mintable",
+        "Over-limit signup returns 429 with a retry message"
+      ]
+    },
+    {
+      "id": "TC-26.7.1.8",
+      "name": "Tenant isolation for an agent-rooted tenant",
+      "type": "integration",
+      "preconditions": ["tenant A (agent_rooted) and tenant B (any) each with data"],
+      "steps": ["Use tenant A's key to attempt to read/write tenant B's articles and stories"],
+      "expected_results": ["RLS blocks all cross-tenant access; A sees only its own data"]
+    }
+  ],
+  "technical_notes": [
+    "Router: `POST /api/v1/signup` goes in the existing PUBLIC (no `:authenticated`) `scope \"/api/v1\"` group alongside audit_public_key / articles/system. Keep the HTML `/signup` LiveView (browser pipeline) untouched — no collision (different method+pipeline).",
+    "Do NOT add a new pipeline or move the ~150 authenticated routes. Apply RequireHumanAnchor per-controller exactly like RequireRole, using the EXACT action atoms in AC-26.7.1.7. Cross-check each against the controller's real `when action in [...]` clause — a wrong atom (e.g. :review_complete, :correction) compiles to a silent no-op guard and leaves the route ungated with no failure. AC-26.7.1.9's default-deny router walk is the backstop that catches any such gap.",
+    "The tier gate is keyed on `current_tenant.trust_tier`, deliberately orthogonal to role: a role-based gate would be trivially escaped by a tenant self-minting a higher-role key (ApiKeyController.create only blocks superadmin; a role:user caller can mint an orchestrator key today). Tenant-keying is what makes the /api_keys carve-out safe.",
+    "self_signup/1 shares the keypair-generation + genesis-audit + activation helpers with signup/1 (extract a private helper) but MUST NOT insert authenticators and MUST use the agent actor_type/actor_label. Reuse Loopctl.Secrets.set/2 + Audit.log_in_multi/3.",
+    "SECRET COMPENSATION (AC-26.7.1.4): Secrets.set/2 is an external Fly write not covered by AdminRepo.transaction rollback. Wrap the keypair helper so any error after a successful set triggers Secrets.delete/1 (already exists) for the deterministic slug-derived secret name before returning the error. Add this to the shared helper so signup/1 is fixed too.",
+    "Migration: add the column with `default: :agent_rooted, null: false`; backfill via plain `execute/1` UPDATE (no AdminRepo/Repo distinction inside migrations; `tenants` has no RLS). Confirm the single existing prod tenant lands on human_anchored (it has an authenticator).",
+    "Fixtures: default fixture(:tenant) to :human_anchored so existing custody tests are unaffected; set it via post-insert Ecto.Changeset.change/2 + AdminRepo.update!/1 (trust_tier is not in create_changeset's cast) — mirror the existing audit_signing_public_key pattern in fixtures.ex:478-485. Add an explicit agent_rooted path for the new tests (or a self_signup-based fixture).",
+    "Error body: build the 403 via the same nested envelope as FallbackController (`%{error: %{status, code, message, remediation}}`) so the MCP client's generic `error.remediation` reader surfaces it. Remediation is a small secret-free map pointing at the chain-of-custody / tenant-signup wiki slugs; do NOT reuse Loopctl.Llm.Remediation (LLM-specific).",
+    "Rate limiting: reuse the config-resolved Loopctl.RateLimiter behaviour already used by signup_live.ex (a bucket like `api_signup:ip:<ip>`); resolve IP via Loopctl.RemoteIp. The :authenticated-pipeline RateLimiter plug does NOT run on this public route, so the Hammer per-IP bucket is the control.",
+    "MCP: add the `signup` tool in mcp-server/index.js; bump the package version; keep the description honest about KB-vs-custody tiers. No witness header on the signup POST.",
+    "Discovery: add `signup_endpoint` to @discovery_body (and @schema_body if present) in well_known_controller.ex with a test.",
+    "OUT OF SCOPE (fast-follow US-26.7.2, needs sign-off): the reciprocal opt-in WebAuthn enrollment endpoint that upgrades an agent_rooted tenant to human_anchored (`POST /tenants/:id/authenticators` registration ceremony via API), plus DELETE authenticator + recovery. Referenced by §9.2 annotations in this story's doc update.",
+    "TenantAuditKeyController.bootstrap stays role:user + ownership only (not tier-gated): self_signup and signup/1 BOTH pre-provision an audit key, so bootstrap immediately 409s (key_already_exists) for every current and future tenant — the gap is unreachable today. Note this rationale in the doc rather than adding a redundant gate."
+  ],
+  "dependencies": ["US-26.0.1", "US-26.1.1"],
+  "estimated_hours": 18
+}

--- a/lib/loopctl/api_spec/schemas.ex
+++ b/lib/loopctl/api_spec/schemas.ex
@@ -125,6 +125,13 @@ defmodule Loopctl.ApiSpec.Schemas do
           type: :string,
           enum: ["active", "suspended", "deactivated", "pending_enrollment"]
         },
+        trust_tier: %Schema{
+          type: :string,
+          enum: ["human_anchored", "agent_rooted"],
+          description:
+            "US-26.7.1 — human_anchored (WebAuthn signup) unlocks the work-breakdown " <>
+              "/ chain-of-custody surface; agent_rooted (self-signup) is KB-tier only."
+        },
         inserted_at: %Schema{type: :string, format: :"date-time"},
         updated_at: %Schema{type: :string, format: :"date-time"}
       },
@@ -135,6 +142,7 @@ defmodule Loopctl.ApiSpec.Schemas do
         email: "admin@example.com",
         settings: %{},
         status: "active",
+        trust_tier: "human_anchored",
         inserted_at: "2026-01-15T10:00:00Z",
         updated_at: "2026-01-15T10:00:00Z"
       }
@@ -174,6 +182,73 @@ defmodule Loopctl.ApiSpec.Schemas do
         email: "admin@example.com",
         settings: %{},
         token_data_retention_days: 90
+      }
+    })
+  end
+
+  defmodule SelfSignupRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "SelfSignupRequest",
+      description:
+        "Request body for `POST /api/v1/signup` (US-26.7.1). Creates an " <>
+          "agent-rooted (KB-tier) tenant with no WebAuthn ceremony. Only " <>
+          "`name`, `slug`, and `email` are accepted — any other field " <>
+          "(`trust_tier`, `role`, `tenant_id`, `agent_id`, ...) is ignored.",
+      type: :object,
+      required: [:name, :slug, :email],
+      properties: %{
+        name: %Schema{type: :string, description: "Tenant display name", maxLength: 120},
+        slug: %Schema{type: :string, description: "URL-safe unique slug", maxLength: 64},
+        email: %Schema{type: :string, format: :email, description: "Contact email"}
+      },
+      example: %{
+        name: "Stranger Agent Co",
+        slug: "stranger-agent-co",
+        email: "agent@stranger.example"
+      }
+    })
+  end
+
+  defmodule SelfSignupResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "SelfSignupResponse",
+      description:
+        "Response for `POST /api/v1/signup`. `raw_key` (role `user`, tenant-bound) " <>
+          "is returned exactly once — it is never persisted in plaintext and cannot " <>
+          "be retrieved again.",
+      type: :object,
+      properties: %{
+        data: %Schema{
+          type: :object,
+          properties: %{
+            tenant: TenantResponse,
+            raw_key: %Schema{type: :string, description: "One-time root API key (role: user)"},
+            next_action: %Schema{type: :object, additionalProperties: true}
+          }
+        }
+      },
+      example: %{
+        data: %{
+          tenant: %{
+            id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            name: "Stranger Agent Co",
+            slug: "stranger-agent-co",
+            email: "agent@stranger.example",
+            trust_tier: "agent_rooted",
+            status: "active"
+          },
+          raw_key: "lc_...",
+          next_action: %{
+            message: "Configure your BYO LLM keys, then start ingesting/searching the wiki.",
+            configure_llm: "PATCH /api/v1/tenants/me/llm-config"
+          }
+        }
       }
     })
   end

--- a/lib/loopctl/tenants.ex
+++ b/lib/loopctl/tenants.ex
@@ -15,11 +15,13 @@ defmodule Loopctl.Tenants do
   alias Ecto.Multi
   alias Loopctl.AdminRepo
   alias Loopctl.Audit
+  alias Loopctl.Auth
   alias Loopctl.Secrets
   alias Loopctl.TenantKeys
   alias Loopctl.Tenants.AuditKeyHistory
   alias Loopctl.Tenants.RootAuthenticator
   alias Loopctl.Tenants.Tenant
+  alias Loopctl.Workers.OrphanedSecretCleanupWorker
 
   @max_authenticators_per_signup 5
   @pending_enrollment_ttl_seconds 15 * 60
@@ -98,53 +100,33 @@ defmodule Loopctl.Tenants do
     # does not stumble over the mixed-key map.
     tenant_attrs = Map.drop(attrs, [:authenticators, "authenticators"])
 
+    # US-26.7.1 (#9) — keypair + deterministic secret name are ordinary lexical
+    # variables here, so `with_secret_compensation/3` reads them directly on
+    # both the tuple AND the raised-exception paths (no process dictionary).
+    # secret_name is derived from the SAME normalized slug the changeset
+    # produces, so it matches the inserted `tenant.slug`.
+    {pub, priv} = generate_ed25519_keypair()
+    secret_name = signup_secret_name(tenant_attrs)
+
     multi =
       Multi.new()
       |> Multi.insert(:tenant, Tenant.signup_changeset(tenant_attrs))
       |> insert_authenticators(authenticators)
-      |> Multi.run(:generate_audit_keypair, fn _repo, %{tenant: tenant} ->
-        {pub, priv} = generate_ed25519_keypair()
-        secret_name = Secrets.audit_key_secret_name(tenant.slug)
+      |> append_keypair_and_genesis(
+        secret_name,
+        priv,
+        pub,
+        "human",
+        "human:webauthn",
+        &signup_new_state/2
+      )
 
-        case Secrets.set(secret_name, priv) do
-          :ok ->
-            {:ok, %{public_key: pub, private_key: priv, secret_name: secret_name}}
-
-          {:error, reason} ->
-            {:error, {:audit_key_storage_failed, reason}}
-        end
-      end)
-      |> Multi.update(:set_public_key, fn %{tenant: tenant, generate_audit_keypair: keypair} ->
-        Ecto.Changeset.change(tenant, audit_signing_public_key: keypair.public_key)
-      end)
-      |> Multi.update(:activate, fn %{set_public_key: tenant} ->
-        Tenant.activate_after_enrollment_changeset(tenant)
-      end)
-      |> Audit.log_in_multi(:audit_genesis, fn %{
-                                                 activate: tenant,
-                                                 authenticators: auths,
-                                                 generate_audit_keypair: keypair
-                                               } ->
-        %{
-          tenant_id: tenant.id,
-          entity_type: "tenant",
-          entity_id: tenant.id,
-          action: "tenant_created",
-          actor_type: "human",
-          actor_id: nil,
-          actor_label: "human:webauthn",
-          new_state: %{
-            "name" => tenant.name,
-            "slug" => tenant.slug,
-            "email" => tenant.email,
-            "authenticator_count" => length(auths),
-            "authenticator_fingerprints" => Enum.map(auths, &fingerprint(&1.credential_id)),
-            "audit_signing_public_key" => Base.encode64(keypair.public_key)
-          }
-        }
+    result =
+      with_secret_compensation({:delete, secret_name}, :store_secret, fn ->
+        AdminRepo.transaction(multi)
       end)
 
-    case AdminRepo.transaction(multi) do
+    case result do
       {:ok, %{activate: tenant, authenticators: authenticators}} ->
         {:ok, %{tenant: tenant, root_authenticators: authenticators}}
 
@@ -160,6 +142,276 @@ defmodule Loopctl.Tenants do
       {:error, _step, reason, _changes} ->
         {:error, reason}
     end
+  end
+
+  defp signup_new_state(%{activate: tenant, authenticators: auths}, pub) do
+    %{
+      "name" => tenant.name,
+      "slug" => tenant.slug,
+      "email" => tenant.email,
+      "authenticator_count" => length(auths),
+      "authenticator_fingerprints" => Enum.map(auths, &fingerprint(&1.credential_id)),
+      "audit_signing_public_key" => Base.encode64(pub)
+    }
+  end
+
+  @doc """
+  US-26.7.1 — agent-rooted self-signup: creates a tenant WITHOUT a WebAuthn
+  ceremony, entirely through this single API call. The tenant lands on the
+  KB tier (`trust_tier: :agent_rooted`) — it retains the full knowledge-wiki
+  surface but is blocked (via `LoopctlWeb.Plugs.RequireHumanAnchor`) from the
+  work-breakdown / chain-of-custody surface until it opts into a WebAuthn
+  enrollment ceremony (US-26.7.2, out of scope here).
+
+  Mirrors the trusted parts of `signup/1` (ed25519 audit keypair generation
+  + storage, activation, genesis audit entry via the shared
+  `append_keypair_and_genesis/6` helper — including the transactional secret
+  compensation in `with_secret_compensation/3`) but does NOT insert any
+  `RootAuthenticator`, and stamps `actor_type: "agent"` /
+  `actor_label: "agent:self-signup"` on the genesis entry instead of the
+  human/webauthn label. It then mints a `role: :user`, `agent_id: nil` root
+  API key bound to the tenant so the caller can immediately configure its
+  own BYO LLM keys (`PATCH /tenants/me/llm-config`) and register its own
+  agent identity (`POST /agents/register`).
+
+  `attrs` accepts `:name`, `:slug`, `:email` (identical validation to
+  `signup/1`). Any other key (`trust_tier`, `role`, `tenant_id`, `agent_id`,
+  ...) is silently ignored — `Tenant.self_signup_changeset/2`'s cast list is
+  `[:name, :slug, :email]`, so mass-assignment is structurally closed.
+
+  ## Returns
+
+  - `{:ok, %{tenant: %Tenant{}, raw_key: String.t()}}` — `raw_key` is
+    returned exactly once and is never persisted in plaintext.
+  - `{:error, :slug_taken} | {:error, :email_taken}`
+  - `{:error, %Ecto.Changeset{}}` — validation failure
+  - `{:error, term()}` — keypair storage or root-key-minting failure
+  """
+  @spec self_signup(map()) ::
+          {:ok, %{tenant: Tenant.t(), raw_key: String.t()}}
+          | {:error, :slug_taken}
+          | {:error, :email_taken}
+          | {:error, Ecto.Changeset.t()}
+          | {:error, term()}
+  def self_signup(attrs) when is_map(attrs) do
+    # US-26.7.1 (#9) — lexical keypair + deterministic secret name (see do_signup/2).
+    {pub, priv} = generate_ed25519_keypair()
+    secret_name = signup_secret_name(attrs)
+
+    multi =
+      Multi.new()
+      |> Multi.insert(:tenant, Tenant.self_signup_changeset(attrs))
+      |> append_keypair_and_genesis(
+        secret_name,
+        priv,
+        pub,
+        "agent",
+        "agent:self-signup",
+        &self_signup_new_state/2
+      )
+      |> Multi.run(:root_api_key, fn _repo, %{activate: tenant} ->
+        Auth.generate_api_key(%{
+          tenant_id: tenant.id,
+          name: "root",
+          role: :user,
+          agent_id: nil
+        })
+      end)
+
+    result =
+      with_secret_compensation({:delete, secret_name}, :store_secret, fn ->
+        AdminRepo.transaction(multi)
+      end)
+
+    case result do
+      {:ok, %{activate: tenant, root_api_key: {raw_key, _api_key}}} ->
+        {:ok, %{tenant: tenant, raw_key: raw_key}}
+
+      {:error, :tenant, %Ecto.Changeset{} = changeset, _changes} ->
+        signup_changeset_error(changeset)
+
+      {:error, _step, %Ecto.Changeset{} = changeset, _changes} ->
+        {:error, changeset}
+
+      {:error, _step, reason, _changes} ->
+        {:error, reason}
+    end
+  end
+
+  defp self_signup_new_state(%{activate: tenant}, pub) do
+    %{
+      "name" => tenant.name,
+      "slug" => tenant.slug,
+      "email" => tenant.email,
+      "trust_tier" => "agent_rooted",
+      "audit_signing_public_key" => Base.encode64(pub)
+    }
+  end
+
+  # US-26.7.1 — the deterministic audit-key secret name for a signup, derived
+  # from the SAME normalized slug the changeset will insert. A missing/invalid
+  # slug yields a placeholder name that is never written: the `:tenant` insert
+  # fails (required/format) BEFORE the `:store_secret` step runs.
+  defp signup_secret_name(attrs) do
+    slug = Tenant.normalized_slug(attrs) || "__invalid__"
+    Secrets.audit_key_secret_name(slug)
+  end
+
+  # US-26.7.1 (AC-26.7.1.4) — shared secret-write + activation + genesis audit
+  # Multi steps, appended onto a Multi that has already inserted a `:tenant`
+  # step. `secret_name`/`priv`/`pub` are LEXICAL (generated by the caller
+  # before the Multi), so the compensation in `with_secret_compensation/3` can
+  # reference them on both the tuple and raised-exception paths without a
+  # process dictionary. Used by BOTH `signup/1` and `self_signup/1`.
+  #
+  # `:store_secret` runs AFTER `:tenant` (and, for signup, `:authenticators`)
+  # so a duplicate-slug / validation failure never reaches the external write —
+  # the compensation `write_step` guard keys on this step name.
+  defp append_keypair_and_genesis(
+         multi,
+         secret_name,
+         priv,
+         pub,
+         actor_type,
+         actor_label,
+         new_state_fun
+       ) do
+    multi
+    |> Multi.run(:store_secret, fn _repo, _changes ->
+      case Secrets.set(secret_name, priv) do
+        :ok -> {:ok, :stored}
+        {:error, reason} -> {:error, {:audit_key_storage_failed, reason}}
+      end
+    end)
+    |> Multi.update(:set_public_key, fn %{tenant: tenant} ->
+      Ecto.Changeset.change(tenant, audit_signing_public_key: pub)
+    end)
+    |> Multi.update(:activate, fn %{set_public_key: tenant} ->
+      Tenant.activate_after_enrollment_changeset(tenant)
+    end)
+    |> Audit.log_in_multi(:audit_genesis, fn changes ->
+      tenant = changes.activate
+
+      %{
+        tenant_id: tenant.id,
+        entity_type: "tenant",
+        entity_id: tenant.id,
+        action: "tenant_created",
+        actor_type: actor_type,
+        actor_id: nil,
+        actor_label: actor_label,
+        new_state: new_state_fun.(changes, pub)
+      }
+    end)
+  end
+
+  # US-26.7.1 (AC-26.7.1.4 / review #1, #2, #9) — TRANSACTIONAL SECRET SAFETY.
+  # `Secrets.set/2` is an EXTERNAL Fly.io write that `AdminRepo.transaction/1`
+  # cannot roll back. `run_txn` performs the transaction; `write_step` is the
+  # Multi step whose SUCCESS means the external secret was written. On failure:
+  #
+  #   * tuple `{:error, step, reason, changes}` — compensate ONLY when the
+  #     `write_step` succeeded (its key is present in `changes`), so an upstream
+  #     failure (duplicate slug, validation, authenticator) writes nothing and
+  #     compensates nothing.
+  #   * raised exception — the Multi discards `changes`, so we compensate
+  #     defensively using the lexical `compensation`. This is safe: a
+  #     duplicate-slug collision (the ONLY case where the deterministic secret
+  #     name could belong to ANOTHER tenant) is ALWAYS a mapped
+  #     `unique_constraint` TUPLE, never a raise, so a raise can never target a
+  #     live tenant's secret.
+  #
+  # `compensation` is `{:delete, secret_name}` (signup/bootstrap: no prior key)
+  # or `{:restore, secret_name, old_value}` (rotate: put the OLD private key
+  # back so the DB's rolled-back OLD public key still verifies).
+  defp with_secret_compensation(compensation, write_step, run_txn) do
+    case run_txn.() do
+      {:ok, _} = ok ->
+        ok
+
+      {:error, _step, _reason, changes} = error ->
+        if Map.has_key?(changes, write_step), do: run_compensation(compensation)
+        error
+    end
+  rescue
+    exception ->
+      run_compensation(compensation)
+      reraise exception, __STACKTRACE__
+  end
+
+  defp run_compensation({:delete, secret_name}), do: delete_secret(secret_name)
+
+  defp run_compensation({:restore, secret_name, old_value}),
+    do: restore_secret(secret_name, old_value)
+
+  defp delete_secret(secret_name) do
+    case Secrets.delete(secret_name) do
+      :ok -> :ok
+      # Already gone — nothing to clean up (a defensive rescue-branch delete of
+      # a secret that was never written lands here).
+      {:error, :not_found} -> :ok
+      {:error, reason} -> handle_compensation_failure(:delete, secret_name, nil, reason)
+    end
+  end
+
+  defp restore_secret(_secret_name, nil) do
+    # No old value to restore (the pre-rotation read failed). Nothing we can
+    # auto-recover — surface it loudly rather than swallow.
+    :telemetry.execute(
+      [:loopctl, :secrets, :orphan_cleanup_failed],
+      %{count: 1},
+      %{op: :restore, secret_name: nil, reason: :old_value_unavailable}
+    )
+
+    Logger.error(
+      "Cannot restore audit-key secret after a failed rotation: the old private key " <>
+        "value was unavailable. Manual intervention required."
+    )
+
+    :ok
+  end
+
+  defp restore_secret(secret_name, old_value) when is_binary(old_value) do
+    case Secrets.set(secret_name, old_value) do
+      :ok -> :ok
+      {:error, reason} -> handle_compensation_failure(:restore, secret_name, old_value, reason)
+    end
+  end
+
+  # A FAILED compensating delete/restore must NEVER be swallowed: (a) emit a
+  # dedicated telemetry event so monitoring can page, (b) Logger.error, and
+  # (c) enqueue a durable, retryable Oban job so cleanup actually happens
+  # rather than being best-effort-once.
+  defp handle_compensation_failure(op, secret_name, value, reason) do
+    :telemetry.execute(
+      [:loopctl, :secrets, :orphan_cleanup_failed],
+      %{count: 1},
+      %{op: op, secret_name: secret_name, reason: reason}
+    )
+
+    Logger.error(
+      "Compensating audit-key secret #{op} failed for #{secret_name}: #{inspect(reason)}. " <>
+        "Enqueued a retry; a private key may be orphaned in Fly until it succeeds."
+    )
+
+    enqueue_secret_cleanup(op, secret_name, value)
+    :ok
+  end
+
+  defp enqueue_secret_cleanup(:delete, secret_name, _value) do
+    %{"op" => "delete", "secret_name" => secret_name}
+    |> OrphanedSecretCleanupWorker.new()
+    |> Oban.insert()
+  end
+
+  defp enqueue_secret_cleanup(:restore, secret_name, value) do
+    %{
+      "op" => "restore",
+      "secret_name" => secret_name,
+      "value" => OrphanedSecretCleanupWorker.encode_secret_value(value)
+    }
+    |> OrphanedSecretCleanupWorker.new()
+    |> Oban.insert()
   end
 
   defp insert_authenticators(multi, authenticators) do
@@ -283,7 +535,16 @@ defmodule Loopctl.Tenants do
         }
       end)
 
-    case AdminRepo.transaction(multi) do
+    # US-26.7.1 (#2) — bootstrap means NO prior key existed, so a post-`:store_secret`
+    # failure compensates by DELETING the just-written secret (same machinery as
+    # signup). `write_step: :store_secret` (the first step here) so the guard is
+    # only satisfied once the external write actually happened.
+    result =
+      with_secret_compensation({:delete, secret_name}, :store_secret, fn ->
+        AdminRepo.transaction(multi)
+      end)
+
+    case result do
       {:ok, %{set_public_key: tenant}} -> {:ok, tenant}
       {:error, _step, reason, _changes} -> {:error, reason}
     end
@@ -318,6 +579,19 @@ defmodule Loopctl.Tenants do
     now = DateTime.utc_now()
     {new_pub, new_priv} = generate_ed25519_keypair()
     secret_name = Secrets.audit_key_secret_name(tenant.slug)
+
+    # US-26.7.1 (#2) — RESTORE semantics. Rotation OVERWRITES the same
+    # deterministic secret name with the NEW private key. If a step AFTER the
+    # write fails, the DB rolls back to the OLD public key while Fly holds the
+    # NEW private key = silent signature-verification breakage. So read the OLD
+    # private value BEFORE the Multi and, on any post-write failure, RESTORE it
+    # (not delete). `nil` when the old value can't be read (edge) — restore_secret/2
+    # surfaces that loudly rather than deleting and losing signing entirely.
+    old_priv =
+      case Secrets.get(secret_name) do
+        {:ok, value} -> value
+        {:error, _reason} -> nil
+      end
 
     multi =
       Multi.new()
@@ -358,7 +632,12 @@ defmodule Loopctl.Tenants do
         }
       end)
 
-    case AdminRepo.transaction(multi) do
+    result =
+      with_secret_compensation({:restore, secret_name, old_priv}, :store_new_secret, fn ->
+        AdminRepo.transaction(multi)
+      end)
+
+    case result do
       {:ok, %{update_tenant: updated_tenant}} ->
         TenantKeys.invalidate(tenant.id)
         {:ok, updated_tenant}

--- a/lib/loopctl/tenants/tenant.ex
+++ b/lib/loopctl/tenants/tenant.ex
@@ -13,6 +13,10 @@ defmodule Loopctl.Tenants.Tenant do
   - `settings` — jsonb map for tenant-level configuration
   - `status` — `:active`, `:suspended`, or `:deactivated`
   - `default_story_budget_millicents` — nullable tenant-wide default budget for stories
+  - `trust_tier` — `:human_anchored` (WebAuthn signup ceremony, unlocks the
+    work-breakdown / chain-of-custody surface) or `:agent_rooted` (self-signup,
+    KB-tier only). US-26.7.1. NEVER cast from user input — every signup path
+    (`signup/1`, `self_signup/1`) sets it programmatically on the struct.
   """
 
   use Loopctl.Schema, tenant_scoped: false
@@ -20,6 +24,7 @@ defmodule Loopctl.Tenants.Tenant do
   @type t :: %__MODULE__{}
 
   @statuses [:active, :suspended, :deactivated, :pending_enrollment]
+  @trust_tiers [:human_anchored, :agent_rooted]
   @slug_format ~r/^[a-z0-9][a-z0-9-]*[a-z0-9]$/
   @email_format ~r/^[^\s@]+@[^\s@]+\.[^\s@]+$/
   @min_retention_days 30
@@ -40,6 +45,9 @@ defmodule Loopctl.Tenants.Tenant do
     field :audit_key_rotated_at, :utc_datetime_usec
     # US-26.5.2: custody halt on witness divergence
     field :custody_halted_at, :utc_datetime_usec
+    # US-26.7.1: capability tier — NEVER in any public changeset cast; the
+    # RESTRICTIVE value (:agent_rooted) is both the schema and DB default.
+    field :trust_tier, Ecto.Enum, values: @trust_tiers, default: :agent_rooted
 
     has_many :root_authenticators, Loopctl.Tenants.RootAuthenticator, foreign_key: :tenant_id
     has_many :audit_key_history, Loopctl.Tenants.AuditKeyHistory, foreign_key: :tenant_id
@@ -65,6 +73,33 @@ defmodule Loopctl.Tenants.Tenant do
     |> validate_email()
     |> put_change(:status, :pending_enrollment)
     |> put_change(:settings, %{})
+    |> put_change(:trust_tier, :human_anchored)
+    |> unique_constraint(:slug)
+    |> unique_constraint(:email, name: :tenants_email_index)
+  end
+
+  @doc """
+  US-26.7.1 — changeset for the agent-rooted self-signup path (no WebAuthn
+  ceremony, no human operator). Mirrors `signup_changeset/2`'s validation and
+  `:pending_enrollment` status (flipped to `:active` by
+  `activate_after_enrollment_changeset/1` once the audit keypair is
+  generated) but sets `trust_tier: :agent_rooted` instead of
+  `:human_anchored`. `trust_tier` is set programmatically here, never cast
+  from `attrs` — the cast list is identical to `signup_changeset/2`
+  ([:name, :slug, :email]), so a body carrying `trust_tier`, `role`,
+  `tenant_id`, or `agent_id` has no effect (mass-assignment closed).
+  """
+  @spec self_signup_changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
+  def self_signup_changeset(tenant \\ %__MODULE__{}, attrs) do
+    tenant
+    |> cast(normalize_signup_attrs(attrs), [:name, :slug, :email])
+    |> validate_required([:name, :slug, :email])
+    |> validate_length(:name, min: 1, max: 120)
+    |> validate_slug(min: 2, max: 64)
+    |> validate_email()
+    |> put_change(:status, :pending_enrollment)
+    |> put_change(:settings, %{})
+    |> put_change(:trust_tier, :agent_rooted)
     |> unique_constraint(:slug)
     |> unique_constraint(:email, name: :tenants_email_index)
   end
@@ -148,6 +183,26 @@ defmodule Loopctl.Tenants.Tenant do
   @spec status_changeset(%__MODULE__{}, atom()) :: Ecto.Changeset.t()
   def status_changeset(tenant, status) when status in @statuses do
     change(tenant, status: status)
+  end
+
+  @doc """
+  US-26.7.1 — returns the normalized (trimmed + downcased) slug from a signup
+  attrs map (string- or atom-keyed), or `nil` when absent/non-binary.
+
+  Public so `Loopctl.Tenants` can derive the deterministic audit-key secret
+  name (`Loopctl.Secrets.audit_key_secret_name/1`) as an ordinary lexical
+  variable BEFORE the signup `Ecto.Multi` — without duplicating the
+  normalization rule and without a process-dictionary bridge for the
+  compensation path. Applies the SAME `String.trim/1 |> String.downcase/1`
+  the signup changesets use, so the derived name matches the inserted
+  `tenant.slug` exactly.
+  """
+  @spec normalized_slug(map()) :: String.t() | nil
+  def normalized_slug(attrs) when is_map(attrs) do
+    case Map.get(attrs, :slug) || Map.get(attrs, "slug") do
+      slug when is_binary(slug) -> slug |> String.trim() |> String.downcase()
+      _ -> nil
+    end
   end
 
   defp validate_slug(changeset, opts \\ []) do

--- a/lib/loopctl/workers/orphaned_secret_cleanup_worker.ex
+++ b/lib/loopctl/workers/orphaned_secret_cleanup_worker.ex
@@ -1,0 +1,75 @@
+defmodule Loopctl.Workers.OrphanedSecretCleanupWorker do
+  @moduledoc """
+  US-26.7.1 (review #1/#2) — durable retry for a FAILED compensating
+  audit-key secret operation.
+
+  When `Loopctl.Tenants` rolls back a signup / bootstrap / rotate but the
+  external `Loopctl.Secrets` compensation (delete or restore) itself fails,
+  the failure must NOT be swallowed: it strands a private Ed25519 key in Fly
+  (delete case) or leaves Fly holding a NEW key while the DB kept the OLD
+  public key (rotate case → silent signature-verification breakage). The
+  context enqueues this worker so cleanup actually happens rather than being
+  best-effort-once, and emits a `[:loopctl, :secrets, :orphan_cleanup_failed]`
+  telemetry event so monitoring can page.
+
+  Two operations:
+
+    * `%{"op" => "delete", "secret_name" => name}` — retries
+      `Secrets.delete/1`. A `:not_found` is treated as success (the secret is
+      already gone).
+    * `%{"op" => "restore", "secret_name" => name, "value" => encoded}` —
+      retries `Secrets.set/2` with the OLD private key. `value` is the old key
+      **encrypted at rest via `Loopctl.Vault` (Cloak AES-256-GCM) then
+      Base64-wrapped** for JSON — never plaintext in the `oban_jobs` table,
+      consistent with the app's other Cloak-encrypted secrets (tenant LLM
+      keys, webhook signing secrets).
+
+  `max_attempts: 10` with Oban's default exponential backoff so a transient
+  Fly outage is ridden out. Unique on `(op, secret_name)` so a burst of
+  compensation failures for the same secret coalesces into one retry chain.
+  """
+
+  use Oban.Worker,
+    queue: :cleanup,
+    max_attempts: 10,
+    unique: [keys: [:op, :secret_name], period: :infinity]
+
+  require Logger
+
+  alias Loopctl.Secrets
+  alias Loopctl.Vault
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"op" => "delete", "secret_name" => secret_name}}) do
+    case Secrets.delete(secret_name) do
+      :ok -> :ok
+      {:error, :not_found} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  def perform(%Oban.Job{
+        args: %{"op" => "restore", "secret_name" => secret_name, "value" => encoded}
+      }) do
+    old_value = decode_secret_value(encoded)
+
+    case Secrets.set(secret_name, old_value) do
+      :ok -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc """
+  Encrypts a raw secret value for safe transport in Oban args
+  (Cloak AES-256-GCM, then Base64). Used by `Loopctl.Tenants` when enqueuing a
+  restore retry.
+  """
+  @spec encode_secret_value(binary()) :: String.t()
+  def encode_secret_value(value) when is_binary(value) do
+    value |> Vault.encrypt!() |> Base.encode64()
+  end
+
+  defp decode_secret_value(encoded) when is_binary(encoded) do
+    encoded |> Base.decode64!() |> Vault.decrypt!()
+  end
+end

--- a/lib/loopctl_web/controllers/artifact_report_controller.ex
+++ b/lib/loopctl_web/controllers/artifact_report_controller.ex
@@ -25,6 +25,10 @@ defmodule LoopctlWeb.ArtifactReportController do
   plug LoopctlWeb.Plugs.RequireRole,
        [role: :agent] when action in [:index]
 
+  # US-26.7.1 — artifact reports are evidence submitted against a story's
+  # implementation; part of the work-breakdown / chain-of-custody surface.
+  plug LoopctlWeb.Plugs.RequireHumanAnchor when action in [:create]
+
   tags(["Artifacts"])
 
   operation(:create,

--- a/lib/loopctl_web/controllers/bulk_operations_controller.ex
+++ b/lib/loopctl_web/controllers/bulk_operations_controller.ex
@@ -23,6 +23,10 @@ defmodule LoopctlWeb.BulkOperationsController do
   plug LoopctlWeb.Plugs.RequireRole,
        [exact_role: :orchestrator] when action in [:verify, :reject, :mark_complete]
 
+  # US-26.7.1 — work-breakdown surface requires a human-anchored tenant.
+  plug LoopctlWeb.Plugs.RequireHumanAnchor
+       when action in [:claim, :verify, :reject, :mark_complete]
+
   tags(["Progress"])
 
   operation(:claim,

--- a/lib/loopctl_web/controllers/cap_recovery_controller.ex
+++ b/lib/loopctl_web/controllers/cap_recovery_controller.ex
@@ -42,6 +42,9 @@ defmodule LoopctlWeb.CapRecoveryController do
 
   plug LoopctlWeb.Plugs.RequireRole, exact_role: :agent
 
+  # US-26.7.1 — work-breakdown surface requires a human-anchored tenant.
+  plug LoopctlWeb.Plugs.RequireHumanAnchor when action in [:recover]
+
   @doc "POST /api/v1/stories/:id/recover-cap"
   def recover(conn, %{"id" => story_id} = params) do
     tenant_id = conn.assigns.current_api_key.tenant_id

--- a/lib/loopctl_web/controllers/cost_anomaly_controller.ex
+++ b/lib/loopctl_web/controllers/cost_anomaly_controller.ex
@@ -18,6 +18,9 @@ defmodule LoopctlWeb.CostAnomalyController do
   plug LoopctlWeb.Plugs.RequireRole, [role: :orchestrator] when action in [:index]
   plug LoopctlWeb.Plugs.RequireRole, [role: :user] when action in [:update]
 
+  # US-26.7.1 — work-breakdown surface requires a human-anchored tenant.
+  plug LoopctlWeb.Plugs.RequireHumanAnchor when action in [:update]
+
   tags(["Token Efficiency"])
 
   operation(:index,

--- a/lib/loopctl_web/controllers/dispatch_controller.ex
+++ b/lib/loopctl_web/controllers/dispatch_controller.ex
@@ -12,6 +12,9 @@ defmodule LoopctlWeb.DispatchController do
   plug LoopctlWeb.Plugs.RequireRole, [role: :orchestrator] when action in [:create]
   plug LoopctlWeb.Plugs.RequireRole, [role: :agent] when action in [:show, :index]
 
+  # US-26.7.1 — work-breakdown surface requires a human-anchored tenant.
+  plug LoopctlWeb.Plugs.RequireHumanAnchor when action in [:create]
+
   @doc "POST /api/v1/dispatches"
   def create(conn, params) do
     tenant_id = conn.assigns.current_api_key.tenant_id

--- a/lib/loopctl_web/controllers/epic_controller.ex
+++ b/lib/loopctl_web/controllers/epic_controller.ex
@@ -25,6 +25,9 @@ defmodule LoopctlWeb.EpicController do
 
   plug LoopctlWeb.Plugs.RequireRole, [role: :agent] when action in [:index, :show, :progress]
 
+  # US-26.7.1 — work-breakdown surface requires a human-anchored tenant.
+  plug LoopctlWeb.Plugs.RequireHumanAnchor when action in [:create, :update, :delete]
+
   tags(["Epics"])
 
   operation(:create,

--- a/lib/loopctl_web/controllers/epic_dependency_controller.ex
+++ b/lib/loopctl_web/controllers/epic_dependency_controller.ex
@@ -21,6 +21,9 @@ defmodule LoopctlWeb.EpicDependencyController do
   plug LoopctlWeb.Plugs.RequireRole, [role: :orchestrator] when action in [:create]
   plug LoopctlWeb.Plugs.RequireRole, [role: :agent] when action in [:index]
 
+  # US-26.7.1 — work-breakdown surface requires a human-anchored tenant.
+  plug LoopctlWeb.Plugs.RequireHumanAnchor when action in [:create, :delete]
+
   tags(["Dependencies"])
 
   operation(:create,

--- a/lib/loopctl_web/controllers/import_export_controller.ex
+++ b/lib/loopctl_web/controllers/import_export_controller.ex
@@ -22,6 +22,10 @@ defmodule LoopctlWeb.ImportExportController do
 
   plug LoopctlWeb.Plugs.RequireRole, [role: :agent] when action in [:export_project]
 
+  # US-26.7.1 — work-breakdown surface requires a human-anchored tenant.
+  # NOT applied to :export_project — export is a read-only KB-tier-safe op.
+  plug LoopctlWeb.Plugs.RequireHumanAnchor when action in [:import_project]
+
   tags(["Import/Export"])
 
   operation(:import_project,

--- a/lib/loopctl_web/controllers/orchestrator_state_controller.ex
+++ b/lib/loopctl_web/controllers/orchestrator_state_controller.ex
@@ -18,6 +18,9 @@ defmodule LoopctlWeb.OrchestratorStateController do
 
   plug LoopctlWeb.Plugs.RequireRole, exact_role: [:orchestrator, :superadmin]
 
+  # US-26.7.1 — work-breakdown surface requires a human-anchored tenant.
+  plug LoopctlWeb.Plugs.RequireHumanAnchor when action in [:save, :show, :history]
+
   tags(["Orchestrator"])
 
   operation(:save,

--- a/lib/loopctl_web/controllers/project_controller.ex
+++ b/lib/loopctl_web/controllers/project_controller.ex
@@ -23,6 +23,9 @@ defmodule LoopctlWeb.ProjectController do
   plug LoopctlWeb.Plugs.RequireRole, [role: :user] when action in [:delete]
   plug LoopctlWeb.Plugs.RequireRole, [role: :agent] when action in [:index, :show, :progress]
 
+  # US-26.7.1 — work-breakdown surface requires a human-anchored tenant.
+  plug LoopctlWeb.Plugs.RequireHumanAnchor when action in [:create, :update, :delete]
+
   tags(["Projects"])
 
   operation(:create,

--- a/lib/loopctl_web/controllers/review_record_controller.ex
+++ b/lib/loopctl_web/controllers/review_record_controller.ex
@@ -22,6 +22,9 @@ defmodule LoopctlWeb.ReviewRecordController do
   plug LoopctlWeb.Plugs.RequireRole,
        [exact_role: [:orchestrator, :user]] when action in [:create]
 
+  # US-26.7.1 — work-breakdown surface requires a human-anchored tenant.
+  plug LoopctlWeb.Plugs.RequireHumanAnchor when action in [:create]
+
   tags(["Progress"])
 
   operation(:create,

--- a/lib/loopctl_web/controllers/signup_controller.ex
+++ b/lib/loopctl_web/controllers/signup_controller.ex
@@ -1,0 +1,187 @@
+defmodule LoopctlWeb.SignupController do
+  @moduledoc """
+  US-26.7.1 — public (no-auth) JSON self-signup endpoint for agent-rooted
+  (KB-tier) tenants.
+
+  Distinct from the `/signup` WebAuthn LiveView (different pipeline, path,
+  and method — no route collision): this endpoint lets a stranger agent
+  create its own tenant and obtain a working key entirely through an API
+  call or an MCP tool, with no human operator and no hardware authenticator.
+
+  This route sits OUTSIDE the `:authenticated` pipeline (it must — there is
+  no key yet), so it never runs `LoopctlWeb.Plugs.RateLimiter`. It is
+  rate-limited independently, per client IP, via the config-resolved
+  `Loopctl.RateLimiter` behaviour (the same one `LoopctlWeb.SignupLive`
+  uses for the WebAuthn ceremony).
+  """
+
+  use LoopctlWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Loopctl.ApiSpec.Schemas
+  alias Loopctl.RemoteIp
+  alias Loopctl.Tenants
+
+  action_fallback LoopctlWeb.FallbackController
+
+  # Conservative cap: <= 5 tenants per IP per hour (AC-26.7.1.5).
+  @max_signups_per_ip 5
+  @rate_window_ms 60_000 * 60
+  @max_field_bytes 512
+
+  tags(["Tenants"])
+
+  operation(:create,
+    summary: "Self-signup (agent-rooted, KB tier)",
+    description:
+      "Creates an agent-rooted tenant and mints a one-time role:user root API key, " <>
+        "entirely through this API call — no WebAuthn ceremony. The resulting tenant " <>
+        "has full knowledge-wiki access but NOT the work-breakdown / chain-of-custody " <>
+        "surface (see the RequireHumanAnchor gate). Public — no authentication " <>
+        "required. Rate-limited per client IP (<= 5 signups/hour).",
+    request_body: {"Signup params", "application/json", Schemas.SelfSignupRequest},
+    security: [],
+    responses: %{
+      201 => {"Tenant created", "application/json", Schemas.SelfSignupResponse},
+      422 => {"Validation error", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  @doc """
+  POST /api/v1/signup
+
+  Public agent-rooted self-signup. See moduledoc.
+  """
+  def create(conn, params) do
+    # US-26.7.1 (#6a) — the rate-limit check runs FIRST, so an oversized-field
+    # request still consumes the per-IP budget. Otherwise a flood of oversized
+    # payloads would 422 without ever counting against the cap, defeating it.
+    bucket = "api_signup:ip:#{client_ip(conn)}"
+
+    case rate_limiter().check_rate(bucket, @rate_window_ms, @max_signups_per_ip) do
+      {:allow, _count} -> validate_and_signup(conn, params)
+      {:deny, _limit} -> rate_limited(conn)
+    end
+  end
+
+  defp validate_and_signup(conn, params) do
+    case validate_field_sizes(params) do
+      :ok -> do_signup(conn, params)
+      {:error, message} -> unprocessable(conn, message)
+    end
+  end
+
+  defp do_signup(conn, params) do
+    case Tenants.self_signup(params) do
+      {:ok, %{tenant: tenant, raw_key: raw_key}} ->
+        conn
+        |> put_status(:created)
+        |> json(%{data: signup_response(tenant, raw_key)})
+
+      {:error, :slug_taken} ->
+        unprocessable(conn, "That slug is already in use", %{slug: ["has already been taken"]})
+
+      {:error, :email_taken} ->
+        unprocessable(
+          conn,
+          "That email is already associated with a tenant",
+          %{email: ["has already been taken"]}
+        )
+
+      {:error, %Ecto.Changeset{}} = error ->
+        error
+
+      {:error, _reason} ->
+        conn
+        |> put_status(:internal_server_error)
+        |> json(%{error: %{status: 500, message: "Signup failed. Please retry."}})
+    end
+  end
+
+  defp signup_response(tenant, raw_key) do
+    %{
+      tenant: tenant_json(tenant),
+      raw_key: raw_key,
+      next_action: %{
+        message:
+          "Configure your BYO LLM keys, then register an agent identity and start " <>
+            "ingesting/searching the knowledge wiki.",
+        configure_llm: "PATCH /api/v1/tenants/me/llm-config",
+        register_agent: "POST /api/v1/agents/register",
+        ingest: "POST /api/v1/knowledge/ingest",
+        search: "GET /api/v1/knowledge/search"
+      }
+    }
+  end
+
+  defp tenant_json(tenant) do
+    %{
+      id: tenant.id,
+      name: tenant.name,
+      slug: tenant.slug,
+      email: tenant.email,
+      trust_tier: tenant.trust_tier,
+      status: tenant.status,
+      inserted_at: tenant.inserted_at
+    }
+  end
+
+  defp validate_field_sizes(params) do
+    ok? =
+      Enum.all?(["name", "slug", "email"], fn key -> within_size?(Map.get(params, key)) end)
+
+    if ok?, do: :ok, else: {:error, "One or more fields exceed the maximum length"}
+  end
+
+  defp within_size?(value) when is_binary(value), do: byte_size(value) <= @max_field_bytes
+  defp within_size?(_value), do: true
+
+  # US-26.7.1 (#6b) — proxy-aware per-IP bucket key, mirroring
+  # SignupLive.peer_identity/1. `conn.remote_ip` was resolved by the
+  # `LoopctlWeb.Plugs.ClientIp` endpoint plug (shared `Loopctl.RemoteIp`
+  # resolver, preferring the unspoofable `fly-client-ip`). If it still resolves
+  # to one of our configured PROXIES (e.g. Fly's 6PN when no forwarded header
+  # was present) we could NOT determine the real client — keying on the proxy
+  # IP would collapse EVERY visitor onto ONE shared bucket, so a single
+  # proxy-fronted flood would fill it and block legitimate signups. In that
+  # case we fall back to a per-request key (never a shared bucket): it forgoes
+  # limiting on this unresolved path rather than punishing everyone. On Fly the
+  # path is unreachable (fly-client-ip is always present and unspoofable).
+  defp client_ip(conn) do
+    ip = conn.remote_ip
+
+    cond do
+      not is_tuple(ip) -> "req:#{System.unique_integer([:positive])}"
+      RemoteIp.proxy?(ip) -> "req:#{System.unique_integer([:positive])}"
+      true -> RemoteIp.to_string_ip(ip) || "req:#{System.unique_integer([:positive])}"
+    end
+  end
+
+  defp rate_limiter do
+    Application.get_env(:loopctl, :rate_limiter, Loopctl.RateLimiter.Hammer)
+  end
+
+  defp unprocessable(conn, message, details \\ nil) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{error: unprocessable_error(message, details)})
+  end
+
+  defp unprocessable_error(message, nil), do: %{status: 422, message: message}
+
+  defp unprocessable_error(message, details),
+    do: %{status: 422, message: message, details: details}
+
+  defp rate_limited(conn) do
+    conn
+    |> put_resp_header("retry-after", "3600")
+    |> put_status(:too_many_requests)
+    |> json(%{
+      error: %{
+        status: 429,
+        message: "Too many signup attempts from this IP. Please try again in an hour."
+      }
+    })
+  end
+end

--- a/lib/loopctl_web/controllers/skill_controller.ex
+++ b/lib/loopctl_web/controllers/skill_controller.ex
@@ -38,6 +38,12 @@ defmodule LoopctlWeb.SkillController do
        [role: :agent]
        when action in [:index, :show, :list_versions, :get_version, :stats, :version_results]
 
+  # US-26.7.1 (#4) — skill DEFINITIONS are work-breakdown metadata: an
+  # agent-rooted (KB-tier) tenant must not create/update/delete them. Mutating
+  # actions only; `:cost_performance` and the read actions above stay open.
+  plug LoopctlWeb.Plugs.RequireHumanAnchor
+       when action in [:create, :update, :delete, :create_version, :import_skills]
+
   tags(["Skills"])
 
   operation(:create,

--- a/lib/loopctl_web/controllers/skill_result_controller.ex
+++ b/lib/loopctl_web/controllers/skill_result_controller.ex
@@ -16,6 +16,9 @@ defmodule LoopctlWeb.SkillResultController do
 
   plug LoopctlWeb.Plugs.RequireRole, exact_role: [:orchestrator, :superadmin]
 
+  # US-26.7.1 — work-breakdown surface requires a human-anchored tenant.
+  plug LoopctlWeb.Plugs.RequireHumanAnchor when action in [:create]
+
   tags(["Skills"])
 
   operation(:create,

--- a/lib/loopctl_web/controllers/story_controller.ex
+++ b/lib/loopctl_web/controllers/story_controller.ex
@@ -32,6 +32,10 @@ defmodule LoopctlWeb.StoryController do
   plug LoopctlWeb.Plugs.RequireRole,
        [role: :agent] when action in [:index, :show, :index_by_project]
 
+  # US-26.7.1 — work-breakdown surface requires a human-anchored tenant.
+  plug LoopctlWeb.Plugs.RequireHumanAnchor
+       when action in [:create, :create_in_project, :update, :delete]
+
   tags(["Stories"])
 
   operation(:create,

--- a/lib/loopctl_web/controllers/story_dependency_controller.ex
+++ b/lib/loopctl_web/controllers/story_dependency_controller.ex
@@ -21,6 +21,9 @@ defmodule LoopctlWeb.StoryDependencyController do
   plug LoopctlWeb.Plugs.RequireRole, [role: :orchestrator] when action in [:create]
   plug LoopctlWeb.Plugs.RequireRole, [role: :agent] when action in [:index]
 
+  # US-26.7.1 — work-breakdown surface requires a human-anchored tenant.
+  plug LoopctlWeb.Plugs.RequireHumanAnchor when action in [:create, :delete]
+
   tags(["Dependencies"])
 
   operation(:create,

--- a/lib/loopctl_web/controllers/story_status_controller.ex
+++ b/lib/loopctl_web/controllers/story_status_controller.ex
@@ -31,6 +31,10 @@ defmodule LoopctlWeb.StoryStatusController do
   plug LoopctlWeb.Plugs.RequireRole,
        [exact_role: :agent] when action in [:claim, :start, :request_review, :unclaim]
 
+  # US-26.7.1 — work-breakdown surface requires a human-anchored tenant.
+  plug LoopctlWeb.Plugs.RequireHumanAnchor
+       when action in [:contract, :claim, :start, :report, :request_review, :unclaim]
+
   tags(["Progress"])
 
   operation(:contract,

--- a/lib/loopctl_web/controllers/story_verification_controller.ex
+++ b/lib/loopctl_web/controllers/story_verification_controller.ex
@@ -31,6 +31,10 @@ defmodule LoopctlWeb.StoryVerificationController do
   plug LoopctlWeb.Plugs.RequireRole,
        [role: :orchestrator] when action in [:index, :backfill]
 
+  # US-26.7.1 — work-breakdown surface requires a human-anchored tenant.
+  plug LoopctlWeb.Plugs.RequireHumanAnchor
+       when action in [:verify, :reject, :force_unclaim, :backfill, :verify_all]
+
   tags(["Progress"])
 
   operation(:verify,

--- a/lib/loopctl_web/controllers/tenant_audit_key_controller.ex
+++ b/lib/loopctl_web/controllers/tenant_audit_key_controller.ex
@@ -16,6 +16,22 @@ defmodule LoopctlWeb.TenantAuditKeyController do
 
   Both steps require `user` role (enforced by the router pipeline + the
   `RequireRole` plug) AND tenant ownership (checked here).
+
+  ## Not tier-gated (US-26.7.1 #5)
+
+  None of these actions carry `RequireHumanAnchor`, deliberately:
+
+    * `rotate` / `challenge` are gated by a FRESH per-operation WebAuthn
+      assertion via `Loopctl.WebAuthn.Reauth` — a STRONGER control than the
+      trust tier. An agent-rooted tenant has no enrolled authenticator, so
+      `challenge` returns 422 `no_authenticators` and `rotate` can never
+      present a valid assertion.
+    * `bootstrap` is UNREACHABLE for every current and future tenant: both
+      signup paths (`Loopctl.Tenants.signup/1` and `self_signup/1`)
+      mandatorily pre-provision the audit key, so `bootstrap_audit_key/1`
+      immediately returns 409 `key_already_exists`. Adding a redundant tier
+      gate would gate an already-closed door. The precondition is guarded by
+      the `always has a non-nil audit signing public key` regression test.
   """
 
   use LoopctlWeb, :controller

--- a/lib/loopctl_web/controllers/tenant_controller.ex
+++ b/lib/loopctl_web/controllers/tenant_controller.ex
@@ -89,6 +89,7 @@ defmodule LoopctlWeb.TenantController do
       email: tenant.email,
       settings: tenant.settings,
       status: tenant.status,
+      trust_tier: tenant.trust_tier,
       token_data_retention_days: tenant.token_data_retention_days,
       inserted_at: tenant.inserted_at,
       updated_at: tenant.updated_at

--- a/lib/loopctl_web/controllers/token_budget_controller.ex
+++ b/lib/loopctl_web/controllers/token_budget_controller.ex
@@ -24,6 +24,9 @@ defmodule LoopctlWeb.TokenBudgetController do
   plug LoopctlWeb.Plugs.RequireRole, [role: :user] when action in [:delete]
   plug LoopctlWeb.Plugs.RequireRole, [role: :agent] when action in [:index, :show]
 
+  # US-26.7.1 — work-breakdown surface requires a human-anchored tenant.
+  plug LoopctlWeb.Plugs.RequireHumanAnchor when action in [:create, :update, :delete]
+
   tags(["Token Efficiency"])
 
   operation(:create,

--- a/lib/loopctl_web/controllers/token_usage_controller.ex
+++ b/lib/loopctl_web/controllers/token_usage_controller.ex
@@ -22,6 +22,9 @@ defmodule LoopctlWeb.TokenUsageController do
   plug LoopctlWeb.Plugs.RequireRole, [role: :agent] when action in [:create, :index]
   plug LoopctlWeb.Plugs.RequireRole, [role: :user] when action in [:delete, :correct]
 
+  # US-26.7.1 — work-breakdown surface requires a human-anchored tenant.
+  plug LoopctlWeb.Plugs.RequireHumanAnchor when action in [:create, :delete, :correct]
+
   tags(["Token Efficiency"])
 
   operation(:create,

--- a/lib/loopctl_web/controllers/well_known_controller.ex
+++ b/lib/loopctl_web/controllers/well_known_controller.ex
@@ -37,6 +37,10 @@ defmodule LoopctlWeb.WellKnownController do
     discovery_bootstrap_url: "#{@base_url}/wiki/agent-bootstrap",
     required_agent_pattern_url: "#{@base_url}/wiki/agent-pattern",
     system_articles_endpoint: "#{@base_url}/api/v1/articles/system",
+    # US-26.7.1 — public, agent-rooted (KB-tier) self-signup: no WebAuthn
+    # ceremony required. A stranger agent discovering loopctl cold can POST
+    # here to obtain a working tenant + key.
+    signup_endpoint: "#{@base_url}/api/v1/signup",
     contact: "operator@loopctl.com"
   }
 
@@ -76,7 +80,8 @@ defmodule LoopctlWeb.WellKnownController do
                    "audit_signing_key_url",
                    "capability_scheme_url",
                    "chain_of_custody_spec_url",
-                   "system_articles_endpoint"
+                   "system_articles_endpoint",
+                   "signup_endpoint"
                  ],
                  properties: %{
                    spec_version: %{type: "string"},
@@ -94,6 +99,7 @@ defmodule LoopctlWeb.WellKnownController do
                    discovery_bootstrap_url: %{type: "string", format: "uri"},
                    required_agent_pattern_url: %{type: "string", format: "uri"},
                    system_articles_endpoint: %{type: "string", format: "uri"},
+                   signup_endpoint: %{type: "string", format: "uri"},
                    contact: %{type: "string"}
                  }
                })

--- a/lib/loopctl_web/plugs/require_human_anchor.ex
+++ b/lib/loopctl_web/plugs/require_human_anchor.ex
@@ -1,0 +1,74 @@
+defmodule LoopctlWeb.Plugs.RequireHumanAnchor do
+  @moduledoc """
+  US-26.7.1 — gates the work-breakdown / chain-of-custody surface behind the
+  TENANT's `trust_tier`, deliberately orthogonal to role.
+
+  A role-based gate would be trivially escaped by a tenant self-minting a
+  higher-role key (`ApiKeyController.create` only blocks minting
+  `superadmin`; a `role: :user` caller can mint an `orchestrator` key
+  today). Keying on `current_tenant.trust_tier` instead closes that bypass:
+  no key a tenant can mint for itself changes its own trust tier.
+
+  ## Behavior
+
+  - Superadmin with NO impersonation (`current_tenant: nil` — set by
+    `LoopctlWeb.Plugs.SetTenant`'s identical pattern-match convention for a
+    `tenant_id: nil` key) passes through unconditionally. This is a LEADING
+    clause so it never falls through to a crash on a nil tenant.
+  - `trust_tier: :human_anchored` passes through.
+  - `trust_tier: :agent_rooted` halts with `403 custody_tier_required`.
+  - No `current_tenant` assign at all (should not happen this late in the
+    pipeline) is treated as NOT human-anchored — nil is never permissive.
+
+  `LoopctlWeb.Plugs.Impersonate` reassigns `current_tenant` to the
+  impersonated tenant BEFORE controller plugs run, so a superadmin
+  impersonating an agent-rooted tenant is correctly routed through THAT
+  tenant's tier (not exempted).
+
+  ## Usage
+
+  Applied per-controller, exactly like `RequireRole`, and composes with it
+  (both plugs must pass):
+
+      plug LoopctlWeb.Plugs.RequireHumanAnchor when action in [:create, :update, :delete]
+  """
+
+  @behaviour Plug
+
+  import Plug.Conn
+
+  @impl true
+  def init(opts), do: opts
+
+  @impl true
+  def call(%{assigns: %{current_tenant: nil}} = conn, _opts) do
+    # Superadmin, not impersonating — ResolveApiKey assigns `current_tenant: nil`
+    # for a tenant_id-nil (superadmin) key, mirroring SetTenant's identical
+    # `tenant_id: nil` convention. No tenant to gate against.
+    conn
+  end
+
+  def call(%{assigns: %{current_tenant: %{trust_tier: :human_anchored}}} = conn, _opts) do
+    conn
+  end
+
+  def call(conn, _opts) do
+    conn
+    |> put_status(:forbidden)
+    |> Phoenix.Controller.json(%{
+      error: %{
+        status: 403,
+        code: "custody_tier_required",
+        message:
+          "This operation requires a human-anchored tenant (a WebAuthn signup ceremony). " <>
+            "Your tenant is on the agent-rooted knowledge-base tier, which does not " <>
+            "include the work-breakdown / chain-of-custody surface.",
+        remediation: %{
+          learn_more: "https://loopctl.com/wiki/chain-of-custody",
+          enrollment_upgrade: "https://loopctl.com/wiki/tenant-signup"
+        }
+      }
+    })
+    |> halt()
+  end
+end

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -88,12 +88,16 @@ defmodule LoopctlWeb.Router do
 
   # US-26.0.2 — Public endpoint for tenant audit key (no auth required)
   # US-26.0.3 — Public system article endpoints (no auth required)
+  # US-26.7.1 — Public agent-rooted self-signup (no auth required — there is
+  # no key yet). Distinct from the HTML `/signup` LiveView above: different
+  # pipeline (`:api` JSON, not `:browser`), different path, different method.
   scope "/api/v1", LoopctlWeb do
     pipe_through [:api]
 
     get "/tenants/:id/audit_public_key", TenantAuditKeyController, :show
     get "/articles/system", SystemArticleController, :index
     get "/audit/sth/:tenant_id", AuditSthController, :show
+    post "/signup", SignupController, :create
   end
 
   scope "/swaggerui" do

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -2,7 +2,7 @@
 
 MCP (Model Context Protocol) server for [loopctl](https://loopctl.com) -- structural trust for AI development loops.
 
-Wraps the loopctl REST API into 72 typed MCP tools so AI coding agents (Claude Code, etc.) can interact with loopctl without writing curl commands.
+Wraps the loopctl REST API into 73 typed MCP tools so AI coding agents (Claude Code, etc.) can interact with loopctl without writing curl commands.
 
 ## Installation
 
@@ -84,9 +84,18 @@ per-operation model overrides (`extraction_model`, `classification_model`,
 
 ### The smooth path (once, at onboarding)
 
-1. **Sign up** and obtain your keys. Tenant signup is anchored to a hardware
-   authenticator (WebAuthn) — the one human touch. Signup mints your **user-role**
-   API key. Also grab your **agent** and **orchestrator** keys for day-to-day work.
+1. **Sign up** and obtain your keys. loopctl has two trust tiers (US-26.7.1):
+   - **Human-anchored (unlocks work-breakdown / chain-of-custody too):** visit
+     `https://loopctl.com/signup` and enroll a hardware authenticator (WebAuthn) —
+     the one human touch. This mints your **user-role** API key; also grab your
+     **agent** and **orchestrator** keys for day-to-day work.
+   - **Agent-rooted (KB-tier only, fully automated):** call the `signup` MCP tool
+     (or `POST /api/v1/signup` directly) with `name`/`slug`/`email` — no human, no
+     hardware key. This mints a one-time `role: user` API key with the FULL
+     knowledge-wiki surface (ingest/search/curate, BYO LLM config, agent
+     registration), but it **cannot** perform work-breakdown / chain-of-custody
+     operations. The `raw_key` in the response is shown ONCE — save it
+     immediately (it cannot be retrieved again).
 2. **Set the env** in your `.mcp.json` (see [Configuration](#configuration)):
    `LOOPCTL_SERVER`, `LOOPCTL_USER_KEY` (needed for this step), plus `LOOPCTL_AGENT_KEY`
    / `LOOPCTL_ORCH_KEY`.
@@ -112,7 +121,7 @@ REST endpoint (`PATCH /api/v1/tenants/me/llm-config`), and the docs — so you (
 autonomous agent) can self-remediate without a human. Full agent-tenant lifecycle:
 [`docs/onboarding-agent-tenant.md`](../docs/onboarding-agent-tenant.md).
 
-## Tools (72)
+## Tools (73)
 
 ### Project Tools
 
@@ -258,6 +267,7 @@ Key distribution for the dispatch pattern (Epic 26): per-dispatch ephemeral keys
 
 | Tool | Description |
 |---|---|
+| `signup` | **US-26.7.1.** Create a NEW **agent-rooted (KB-tier)** tenant and mint its one-time root API key — entirely through this call, no human operator, no hardware authenticator, no existing API key required. The tenant gets the FULL knowledge-wiki surface but **cannot** perform work-breakdown / chain-of-custody operations (those require a separate human-anchored tenant via the WebAuthn ceremony at `https://loopctl.com/signup`). Rate-limited per client IP (<= 5/hour). The `raw_key` is shown ONCE — save it immediately (e.g. as `LOOPCTL_USER_KEY`). Required: `name`, `slug`, `email`. |
 | `dispatch` | Mint an ephemeral, scoped api_key for a sub-agent dispatch, carrying its lineage path. The `raw_key` is returned ONCE — pass it to the sub-agent's launch args, never store it in env vars; it expires after `expires_in_seconds` (default 3600, max 14400). Required: `role` (`agent`/`orchestrator`), `agent_id`. Optional: `parent_dispatch_id`, `story_id`. |
 | `recover_cap` | Re-mint a capability token for a story you're assigned to, after a session crash lost your cap. Required: `story_id`. Optional: `cap_type` (`start_cap`/`report_cap`, default `start_cap`), `lineage`. |
 | `get_sth` | Get the latest Signed Tree Head for a tenant's tamper-evident audit chain. Public — no auth required. Required: `tenant_id`. |

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -189,6 +189,75 @@ async function apiCall(method, path, body, keyOverride, { exactKey = false } = {
   return responseBody;
 }
 
+/**
+ * Unauthenticated request helper for genuinely public endpoints (currently
+ * only POST /api/v1/signup). No Authorization header is sent — the public
+ * signup POST carries no witness header either (US-26.7.1), so this
+ * bypasses `witnessClientFor` entirely and calls `fetch` directly. Response
+ * parsing mirrors `apiCall`'s so callers can pass the result straight to
+ * `toContent`/`toContentCompact`.
+ */
+async function publicApiCall(method, path, body) {
+  const url = `${getBaseUrl()}${path}`;
+  const headers = { "Content-Type": "application/json", Accept: "application/json" };
+  const serializedBody =
+    body !== undefined && body !== null ? JSON.stringify(body) : undefined;
+
+  let response;
+  try {
+    response = await fetch(url, {
+      method,
+      headers,
+      body: serializedBody,
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (err) {
+    if (err.name === "TimeoutError") {
+      return { error: true, status: 0, body: "Request timed out after 30s" };
+    }
+    const cause = err.cause?.message ? ` (${err.cause.message})` : "";
+    return { error: true, status: 0, body: `Network error: ${err.message}${cause}` };
+  }
+
+  if (response.status === 204) {
+    return { ok: true };
+  }
+
+  let responseBody;
+  const contentType = response.headers.get("content-type") || "";
+  if (contentType.includes("application/json")) {
+    const raw = await response.text();
+    const outcome = parseJsonResponseBody(raw, response.status);
+    if (outcome.error) {
+      return outcome;
+    }
+    responseBody = outcome.parsed;
+  } else {
+    const text = await response.text();
+    try {
+      responseBody = JSON.parse(text);
+    } catch {
+      responseBody = text;
+    }
+  }
+
+  if (!response.ok) {
+    let errorBody = responseBody;
+    if (typeof errorBody === "string" && errorBody.length > 500) {
+      errorBody = errorBody
+        .replace(/<[^>]+>/g, " ")
+        .replace(/&amp;/g, "&").replace(/&lt;/g, "<").replace(/&gt;/g, ">")
+        .replace(/&quot;/g, '"').replace(/&#39;/g, "'").replace(/&nbsp;/g, " ")
+        .replace(/\s+/g, " ")
+        .trim()
+        .slice(0, 500) + "... (truncated)";
+    }
+    return { error: true, status: response.status, body: errorBody };
+  }
+
+  return responseBody;
+}
+
 function toContent(result) {
   const isErr = result && result.error === true;
   return {
@@ -1608,6 +1677,16 @@ async function createDispatch({
   if (story_id) body.story_id = story_id;
 
   const result = await apiCall("POST", "/api/v1/dispatches", body);
+  return toContent(result);
+}
+
+// US-26.7.1: public, agent-rooted (KB-tier) self-signup. No API key required —
+// this creates the tenant AND the key. The resulting tenant is KB-tier only
+// (knowledge ingest/search/curate on the caller's own BYO LLM keys); the
+// work-breakdown / chain-of-custody surface requires a separate,
+// human-anchored WebAuthn signup ceremony at https://loopctl.com/signup.
+async function signup({ name, slug, email }) {
+  const result = await publicApiCall("POST", "/api/v1/signup", { name, slug, email });
   return toContent(result);
 }
 
@@ -3789,6 +3868,31 @@ const TOOLS = [
 
   // Chain of Custody v2 tools
   {
+    name: "signup",
+    description:
+      "Create a NEW agent-rooted (KB-tier) tenant and mint its one-time root API key — " +
+      "entirely through this call, no human operator and no hardware authenticator required. " +
+      "Public — no existing API key needed to call this tool. The returned tenant can " +
+      "immediately use the FULL knowledge-wiki surface (ingest/search/context/curate, BYO " +
+      "LLM key config, agent registration) but CANNOT perform work-breakdown / " +
+      "chain-of-custody operations (create projects/epics/stories, claim/verify/report, " +
+      "dispatch, etc.) — those require a separate, human-anchored tenant created via the " +
+      "WebAuthn ceremony at https://loopctl.com/signup. Rate-limited per client IP " +
+      "(<= 5 signups/hour). The raw_key in the response is shown ONCE — save it immediately " +
+      "(e.g. as LOOPCTL_USER_KEY) since it cannot be retrieved again. Next steps after " +
+      "signup: configure your BYO LLM keys with set_llm_config, then register an agent " +
+      "identity, then ingest/search the wiki.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Tenant display name.", maxLength: 120 },
+        slug: { type: "string", description: "URL-safe unique tenant slug.", maxLength: 64 },
+        email: { type: "string", description: "Contact email for the tenant." },
+      },
+      required: ["name", "slug", "email"],
+    },
+  },
+  {
     name: "get_sth",
     description: "Get the latest Signed Tree Head for a tenant's audit chain. Public — no auth required.",
     inputSchema: {
@@ -4074,6 +4178,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     case "dispatch":
       return await createDispatch(args);
+
+    case "signup":
+      return await signup(args);
 
     case "get_sth":
       return await getSth(args);

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.34.0",
+  "version": "2.35.0",
   "description": "MCP server for loopctl — structural trust for AI development loops",
   "type": "module",
   "main": "index.js",

--- a/mcp-server/test/mcp_arg_forwarding.test.js
+++ b/mcp-server/test/mcp_arg_forwarding.test.js
@@ -118,6 +118,45 @@ describe("#248 mcp-02: knowledge_ingestion_jobs pagination (real ingestionJobsPa
 });
 
 // ---------------------------------------------------------------------------
+// US-26.7.1: public agent-rooted self-signup tool
+// ---------------------------------------------------------------------------
+
+describe("US-26.7.1: signup tool (agent-rooted, KB-tier self-signup)", () => {
+  test("TOOLS declares a signup tool requiring name/slug/email", () => {
+    assert.match(INDEX_SRC, /name: "signup",/, "TOOLS must declare a \"signup\" tool");
+    assert.match(
+      INDEX_SRC,
+      /required: \["name", "slug", "email"\],/,
+      "the signup tool must require name, slug, and email",
+    );
+  });
+
+  test("signup() calls publicApiCall (no API key) against POST /api/v1/signup", () => {
+    assert.match(
+      INDEX_SRC,
+      /async function signup\(\{ name, slug, email \}\) \{[\s\S]*?publicApiCall\(\s*"POST",\s*"\/api\/v1\/signup"/,
+      "signup() must delegate to publicApiCall (not apiCall — no key exists yet) against POST /api/v1/signup",
+    );
+  });
+
+  test("the signup dispatch case calls signup(args)", () => {
+    assert.match(
+      INDEX_SRC,
+      /case "signup":\s*\n\s*return await signup\(args\);/,
+      "the signup dispatch case must call signup(args)",
+    );
+  });
+
+  test("publicApiCall never attaches an Authorization header", () => {
+    const match = INDEX_SRC.match(
+      /async function publicApiCall\(method, path, body\) \{[\s\S]*?\n}\n/,
+    );
+    assert.ok(match, "publicApiCall must be defined");
+    assert.doesNotMatch(match[0], /Authorization/, "publicApiCall must not send an Authorization header");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Epic 28 (#179): per-tenant BYO LLM config + usage tools
 // ---------------------------------------------------------------------------
 

--- a/priv/repo/migrations/20260703120000_add_trust_tier_to_tenants.exs
+++ b/priv/repo/migrations/20260703120000_add_trust_tier_to_tenants.exs
@@ -1,0 +1,40 @@
+defmodule Loopctl.Repo.Migrations.AddTrustTierToTenants do
+  @moduledoc """
+  US-26.7.1 — capability-tiered trust: adds `trust_tier` to `tenants`.
+
+  The RESTRICTIVE default (`agent_rooted`) honors "nil/unknown is never
+  permissive" — an unrecognized/legacy row is treated as the LOWER-trust
+  tier, never the higher one. The backfill below promotes every tenant
+  that has an enrolled root authenticator (the WebAuthn human-anchor
+  ceremony) to `human_anchored`, since only those tenants ever completed
+  it. `tenants` carries no RLS policy (verified against
+  `20260327051838_create_rls_infrastructure.exs` and
+  `20260412180651_add_custody_halted_at_to_tenants.exs`), so there is no
+  AdminRepo/Repo distinction to make inside a migration — plain SQL runs
+  as the migration role.
+  """
+
+  use Ecto.Migration
+
+  def change do
+    alter table(:tenants) do
+      add :trust_tier, :string, null: false, default: "agent_rooted"
+    end
+
+    execute(
+      """
+      UPDATE tenants
+      SET trust_tier = 'human_anchored'
+      WHERE id IN (SELECT DISTINCT tenant_id FROM tenant_root_authenticators)
+      """,
+      "SELECT 1"
+    )
+
+    # US-26.7.1 (#8) — enforce the Ecto.Enum's value set at the DB layer too
+    # (L2 database invariant), so a raw/out-of-band write can never smuggle in
+    # a third tier value. Auto-reversible via `create constraint` in `change`.
+    create constraint(:tenants, :tenants_trust_tier_check,
+             check: "trust_tier IN ('human_anchored', 'agent_rooted')"
+           )
+  end
+end

--- a/priv/repo/migrations/20260703130000_add_role_tenant_check_to_api_keys.exs
+++ b/priv/repo/migrations/20260703130000_add_role_tenant_check_to_api_keys.exs
@@ -1,0 +1,24 @@
+defmodule Loopctl.Repo.Migrations.AddRoleTenantCheckToApiKeys do
+  @moduledoc """
+  US-26.7.1 (#7) — L2 database invariant backstopping `RequireHumanAnchor`'s
+  superadmin exemption.
+
+  The tier gate treats a key with `current_tenant: nil` (i.e. `tenant_id IS
+  NULL`) as an exempt superadmin. This CHECK makes that biconditional
+  STRUCTURAL: a key is tenant-null IF AND ONLY IF it is superadmin. So a
+  non-superadmin key can never be tenant-null (which would spoof the
+  exemption), and a superadmin key can never carry a tenant_id. Mirrors the
+  application-level `ApiKey.validate_tenant_for_role/1`; existing rows already
+  satisfy it.
+
+  Auto-reversible via `create constraint` in `change`.
+  """
+
+  use Ecto.Migration
+
+  def change do
+    create constraint(:api_keys, :api_keys_superadmin_iff_null_tenant,
+             check: "(role = 'superadmin') = (tenant_id IS NULL)"
+           )
+  end
+end

--- a/test/loopctl/repo/add_trust_tier_migration_test.exs
+++ b/test/loopctl/repo/add_trust_tier_migration_test.exs
@@ -1,0 +1,115 @@
+defmodule Loopctl.Repo.AddTrustTierMigrationTest do
+  @moduledoc """
+  US-26.7.1 / AC-26.7.1.1 — proves the `trust_tier` backfill SQL (run inside
+  the `AddTrustTierToTenants` migration) promotes exactly the tenants that
+  have an enrolled root authenticator to `human_anchored`, leaving every
+  other tenant at the restrictive default `agent_rooted`.
+
+  Exercises the EXACT SQL string the migration runs (kept identical here so a
+  future edit to one without the other fails this test), against tenants
+  inserted directly via `Tenant.create_changeset/2` + `AdminRepo.insert!/1`
+  (bypassing `signup_changeset/2`/`self_signup_changeset/2`, so the
+  struct/schema-level `trust_tier` default of `:agent_rooted` is what
+  actually lands in the row — mirroring the pre-migration/legacy-row shape).
+  """
+  use ExUnit.Case, async: true
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Loopctl.AdminRepo
+  alias Loopctl.Tenants.RootAuthenticator
+  alias Loopctl.Tenants.Tenant
+
+  @backfill_sql """
+  UPDATE tenants
+  SET trust_tier = 'human_anchored'
+  WHERE id IN (SELECT DISTINCT tenant_id FROM tenant_root_authenticators)
+  """
+
+  setup do
+    pid = Sandbox.start_owner!(AdminRepo, shared: false)
+    on_exit(fn -> Sandbox.stop_owner(pid) end)
+    :ok
+  end
+
+  test "promotes only tenants with an enrolled root authenticator to human_anchored" do
+    with_auth = insert_tenant!("With Auth")
+    without_auth = insert_tenant!("Without Auth")
+
+    # Both land on the restrictive struct/schema default before the backfill —
+    # this is the "nil/unknown is never permissive" invariant AC-26.7.1.1 requires.
+    assert with_auth.trust_tier == :agent_rooted
+    assert without_auth.trust_tier == :agent_rooted
+
+    %RootAuthenticator{tenant_id: with_auth.id}
+    |> RootAuthenticator.create_changeset(%{
+      credential_id: :crypto.strong_rand_bytes(16),
+      public_key: :erlang.term_to_binary(%{kty: "OKP"}),
+      attestation_format: "none",
+      sign_count: 0,
+      friendly_name: "Primary"
+    })
+    |> AdminRepo.insert!()
+
+    AdminRepo.query!(@backfill_sql)
+
+    assert AdminRepo.get!(Tenant, with_auth.id).trust_tier == :human_anchored
+
+    assert AdminRepo.get!(Tenant, without_auth.id).trust_tier == :agent_rooted,
+           "a tenant with no enrolled authenticator must stay on the restrictive default"
+  end
+
+  # Review #8 — DB-layer enforcement of the trust_tier value set.
+  test "tenants_trust_tier_check rejects a value outside the enum" do
+    unique = System.unique_integer([:positive])
+
+    assert_raise Postgrex.Error, ~r/tenants_trust_tier_check/, fn ->
+      AdminRepo.query!(
+        """
+        INSERT INTO tenants (id, name, slug, email, status, settings, trust_tier, inserted_at, updated_at)
+        VALUES (gen_random_uuid(), 'X', $1, $2, 'active', '{}', 'bogus_tier', now(), now())
+        """,
+        ["chk-#{unique}", "chk-#{unique}@example.com"]
+      )
+    end
+  end
+
+  # Review #7 — DB-layer backstop for RequireHumanAnchor's superadmin
+  # (tenant_id IS NULL) exemption: tenant-null IFF superadmin.
+  test "api_keys_superadmin_iff_null_tenant rejects a non-superadmin key with NULL tenant_id" do
+    assert_raise Postgrex.Error, ~r/api_keys_superadmin_iff_null_tenant/, fn ->
+      AdminRepo.query!(
+        """
+        INSERT INTO api_keys (id, tenant_id, name, key_hash, key_prefix, role, inserted_at, updated_at)
+        VALUES (gen_random_uuid(), NULL, 'x', $1, 'lc_xxxxx', 'user', now(), now())
+        """,
+        [Base.encode16(:crypto.strong_rand_bytes(16))]
+      )
+    end
+  end
+
+  test "api_keys_superadmin_iff_null_tenant rejects a superadmin key WITH a tenant_id" do
+    tenant = insert_tenant!("Has Tenant")
+
+    assert_raise Postgrex.Error, ~r/api_keys_superadmin_iff_null_tenant/, fn ->
+      AdminRepo.query!(
+        """
+        INSERT INTO api_keys (id, tenant_id, name, key_hash, key_prefix, role, inserted_at, updated_at)
+        VALUES (gen_random_uuid(), $1, 'x', $2, 'lc_xxxxx', 'superadmin', now(), now())
+        """,
+        [Ecto.UUID.dump!(tenant.id), Base.encode16(:crypto.strong_rand_bytes(16))]
+      )
+    end
+  end
+
+  defp insert_tenant!(name) do
+    unique = System.unique_integer([:positive])
+
+    %Tenant{}
+    |> Tenant.create_changeset(%{
+      name: name,
+      slug: "trust-tier-migration-#{unique}",
+      email: "trust-tier-migration-#{unique}@example.com"
+    })
+    |> AdminRepo.insert!()
+  end
+end

--- a/test/loopctl/tenants/audit_key_test.exs
+++ b/test/loopctl/tenants/audit_key_test.exs
@@ -7,6 +7,8 @@ defmodule Loopctl.Tenants.AuditKeyTest do
 
   import Loopctl.Fixtures
 
+  alias Loopctl.AdminRepo
+  alias Loopctl.Secrets
   alias Loopctl.TenantKeys
   alias Loopctl.Tenants
 
@@ -225,6 +227,75 @@ defmodule Loopctl.Tenants.AuditKeyTest do
     test "rotation without existing key returns error" do
       tenant = fixture(:tenant)
       assert {:error, :no_existing_key} = Tenants.rotate_audit_key(tenant.id, <<>>)
+    end
+
+    # Review #2 — rotate OVERWRITES the deterministic secret with the NEW key.
+    # A post-write rollback must RESTORE the OLD private key (not delete) so the
+    # DB's rolled-back OLD public key still verifies.
+    test "post-write failure RESTORES the old secret value (review #2)" do
+      slug = "rotate-restore-#{System.unique_integer([:positive])}"
+      tenant = fixture(:tenant, %{slug: slug})
+      old_priv = :crypto.strong_rand_bytes(32)
+      old_pub = :crypto.strong_rand_bytes(32)
+      test_pid = self()
+
+      tenant =
+        tenant
+        |> Ecto.Changeset.change(audit_signing_public_key: old_pub)
+        |> AdminRepo.update!()
+
+      # Pre-rotation read of the OLD private key (the lexical value used to restore).
+      Mox.expect(Loopctl.MockSecrets, :get, fn _name -> {:ok, old_priv} end)
+
+      # :set is called TWICE, in order:
+      #   1. :store_new_secret writes the NEW key — then we blow up a LATER step
+      #      by deleting the tenant so :update_tenant raises StaleEntryError.
+      #   2. compensation RESTORES the OLD private key.
+      Mox.expect(Loopctl.MockSecrets, :set, fn _name, new_priv ->
+        assert new_priv != old_priv
+        AdminRepo.query!("DELETE FROM tenants WHERE slug = $1", [slug])
+        :ok
+      end)
+
+      Mox.expect(Loopctl.MockSecrets, :set, fn name, restored ->
+        send(test_pid, {:restored, name, restored})
+        :ok
+      end)
+
+      assert_raise Ecto.StaleEntryError, fn ->
+        Tenants.rotate_audit_key(tenant.id, :crypto.strong_rand_bytes(64))
+      end
+
+      secret_name = Secrets.audit_key_secret_name(slug)
+      # Restored with the OLD private key, NOT deleted.
+      assert_received {:restored, ^secret_name, ^old_priv}
+    end
+  end
+
+  describe "bootstrap_audit_key/1 (review #2)" do
+    test "post-write failure DELETES the just-written secret" do
+      slug = "bootstrap-del-#{System.unique_integer([:positive])}"
+      tenant = fixture(:tenant, %{slug: slug})
+      test_pid = self()
+
+      # store_secret writes the key, then we blow up :set_public_key by deleting
+      # the tenant row (bootstrap means NO prior key existed → compensate by delete).
+      Mox.expect(Loopctl.MockSecrets, :set, fn _name, _priv ->
+        AdminRepo.query!("DELETE FROM tenants WHERE slug = $1", [slug])
+        :ok
+      end)
+
+      Mox.expect(Loopctl.MockSecrets, :delete, fn name ->
+        send(test_pid, {:deleted, name})
+        :ok
+      end)
+
+      assert_raise Ecto.StaleEntryError, fn ->
+        Tenants.bootstrap_audit_key(tenant.id)
+      end
+
+      secret_name = Secrets.audit_key_secret_name(slug)
+      assert_received {:deleted, ^secret_name}
     end
   end
 end

--- a/test/loopctl/tenants/signup_test.exs
+++ b/test/loopctl/tenants/signup_test.exs
@@ -8,12 +8,16 @@ defmodule Loopctl.Tenants.SignupTest do
   """
 
   use Loopctl.DataCase, async: true
+  use Oban.Testing, repo: Loopctl.Repo
 
   alias Loopctl.AdminRepo
+  alias Loopctl.Auth
+  alias Loopctl.Secrets
   alias Loopctl.Tenants
   alias Loopctl.Tenants.RootAuthenticator
   alias Loopctl.Tenants.RootAuthenticators
   alias Loopctl.Tenants.Tenant
+  alias Loopctl.Workers.OrphanedSecretCleanupWorker
   alias Loopctl.Workers.PendingEnrollmentCleanupWorker
 
   setup :verify_on_exit!
@@ -148,6 +152,39 @@ defmodule Loopctl.Tenants.SignupTest do
       assert tenant.email == "admin@example.com"
     end
 
+    # AC-26.7.1.2 — the custody-operations half of this claim is proven by
+    # LoopctlWeb.Plugs.RequireHumanAnchorTest ("passes through for a
+    # human_anchored tenant") plus the fixture default (fixture(:tenant) is
+    # :human_anchored) leaving the entire pre-existing custody-controller
+    # test suite unaffected — TC-26.7.1.5.
+    test "a WebAuthn-signed tenant is human_anchored" do
+      attrs = %{
+        name: "Human Anchored",
+        slug: "human-anchored-#{System.unique_integer([:positive])}",
+        email: "human-anchored-#{System.unique_integer([:positive])}@example.com",
+        authenticators: [valid_attestation()]
+      }
+
+      assert {:ok, %{tenant: tenant}} = Tenants.signup(attrs)
+      assert tenant.trust_tier == :human_anchored
+
+      # Re-read to prove persistence, not just the in-memory struct.
+      {:ok, persisted} = Tenants.get_tenant(tenant.id)
+      assert persisted.trust_tier == :human_anchored
+
+      # Genesis audit entry carries the human actor.
+      import Ecto.Query
+      alias Loopctl.Audit.AuditLog
+
+      entry =
+        AuditLog
+        |> where([a], a.tenant_id == ^tenant.id and a.action == "tenant_created")
+        |> AdminRepo.one!()
+
+      assert entry.actor_type == "human"
+      assert entry.actor_label == "human:webauthn"
+    end
+
     test "tenant A's root authenticators are invisible to tenant B (isolation)" do
       {:ok, %{tenant: tenant_a}} =
         Tenants.signup(%{
@@ -173,6 +210,333 @@ defmodule Loopctl.Tenants.SignupTest do
 
       assert {:error, :not_found} =
                RootAuthenticators.get_by_credential_id(tenant_b.id, auth_a.credential_id)
+    end
+  end
+
+  describe "self_signup/1 (US-26.7.1)" do
+    test "creates an activated agent-rooted tenant with agent genesis and a user key (TC-26.7.1.1)" do
+      unique = System.unique_integer([:positive])
+
+      # The default MockSecrets stubs (stub_all_defaults/0) are stateless
+      # (set always :ok, get always :not_found) — stub a shared, PER-TEST
+      # store here so `Secrets.get/1` genuinely reflects what `Secrets.set/2`
+      # wrote, proving the private key is retrievable (TC-26.7.1.1).
+      Mox.stub(Loopctl.MockSecrets, :set, fn name, value ->
+        Process.put({:secret, name}, value)
+        :ok
+      end)
+
+      Mox.stub(Loopctl.MockSecrets, :get, fn name ->
+        case Process.get({:secret, name}) do
+          nil -> {:error, :not_found}
+          value -> {:ok, value}
+        end
+      end)
+
+      attrs = %{
+        name: "Self Signup Co",
+        slug: "self-signup-#{unique}",
+        email: "self-signup-#{unique}@example.com"
+      }
+
+      assert {:ok, %{tenant: tenant, raw_key: raw_key}} = Tenants.self_signup(attrs)
+
+      assert tenant.trust_tier == :agent_rooted
+      assert tenant.status == :active
+      assert is_binary(tenant.audit_signing_public_key)
+      assert {:ok, _priv} = Secrets.get(Secrets.audit_key_secret_name(tenant.slug))
+
+      # No authenticators are inserted for this path.
+      assert RootAuthenticators.list_by_tenant(tenant.id) == []
+
+      # Genesis audit entry: agent actor, not human.
+      import Ecto.Query
+      alias Loopctl.Audit.AuditLog
+
+      entry =
+        AuditLog
+        |> where([a], a.tenant_id == ^tenant.id and a.action == "tenant_created")
+        |> AdminRepo.one!()
+
+      assert entry.actor_type == "agent"
+      assert entry.actor_label == "agent:self-signup"
+
+      # The raw_key resolves to a role:user, agent_id:nil key bound to the tenant.
+      assert is_binary(raw_key)
+      assert String.starts_with?(raw_key, "lc_")
+      assert {:ok, api_key} = Auth.verify_api_key(raw_key)
+      assert api_key.tenant_id == tenant.id
+      assert api_key.role == :user
+      assert api_key.agent_id == nil
+
+      # Only the hash is stored — the raw key text never appears in the DB row.
+      refute api_key.key_hash == raw_key
+    end
+
+    # Review #5 — precondition guard for the bootstrap-audit-key tier exemption:
+    # BOTH signup paths mandatorily pre-provision the audit key, so a freshly
+    # created tenant ALWAYS has a non-nil public key (making `bootstrap` a
+    # guaranteed `key_already_exists` 409 → unreachable, hence not tier-gated).
+    # If provisioning ever became lazy, this fails and flags the exemption.
+    test "a freshly self-signed-up tenant always has a non-nil audit signing public key" do
+      unique = System.unique_integer([:positive])
+
+      assert {:ok, %{tenant: tenant}} =
+               Tenants.self_signup(%{
+                 name: "Provisioned",
+                 slug: "provisioned-#{unique}",
+                 email: "provisioned-#{unique}@example.com"
+               })
+
+      {:ok, reread} = Tenants.get_tenant(tenant.id)
+      refute is_nil(reread.audit_signing_public_key)
+    end
+
+    test "mass assignment is closed: trust_tier/role/tenant_id/agent_id in attrs are ignored" do
+      unique = System.unique_integer([:positive])
+
+      attrs = %{
+        name: "Sneaky",
+        slug: "sneaky-context-#{unique}",
+        email: "sneaky-context-#{unique}@example.com",
+        trust_tier: :human_anchored,
+        role: :superadmin,
+        tenant_id: Ecto.UUID.generate(),
+        agent_id: Ecto.UUID.generate()
+      }
+
+      assert {:ok, %{tenant: tenant}} = Tenants.self_signup(attrs)
+      assert tenant.trust_tier == :agent_rooted
+    end
+
+    test "duplicate slug returns :slug_taken" do
+      fixture(:tenant, %{slug: "self-signup-taken"})
+
+      attrs = %{name: "Other", slug: "self-signup-taken", email: "other-self@example.com"}
+      assert {:error, :slug_taken} = Tenants.self_signup(attrs)
+    end
+
+    test "duplicate email returns :email_taken" do
+      fixture(:tenant, %{email: "self-signup-dup@example.com"})
+
+      attrs = %{
+        name: "Other",
+        slug: "self-signup-other-slug",
+        email: "self-signup-dup@example.com"
+      }
+
+      assert {:error, :email_taken} = Tenants.self_signup(attrs)
+    end
+
+    test "invalid slug format is rejected with a changeset" do
+      attrs = %{name: "Weird", slug: "NOT A SLUG", email: "weird-self@example.com"}
+
+      assert {:error, %Ecto.Changeset{} = changeset} = Tenants.self_signup(attrs)
+      assert %{slug: _} = errors_on(changeset)
+    end
+
+    # Tenant isolation for the context layer (mirrors the RootAuthenticators
+    # isolation test above; self-signup has no authenticators to isolate, so
+    # this proves tenant records themselves stay isolated).
+    test "tenant A and tenant B from self_signup are distinct, isolated tenants" do
+      {:ok, %{tenant: tenant_a}} =
+        Tenants.self_signup(%{
+          name: "A",
+          slug: "self-iso-a-#{System.unique_integer([:positive])}",
+          email: "self-iso-a-#{System.unique_integer([:positive])}@example.com"
+        })
+
+      {:ok, %{tenant: tenant_b}} =
+        Tenants.self_signup(%{
+          name: "B",
+          slug: "self-iso-b-#{System.unique_integer([:positive])}",
+          email: "self-iso-b-#{System.unique_integer([:positive])}@example.com"
+        })
+
+      assert tenant_a.id != tenant_b.id
+      assert tenant_a.trust_tier == :agent_rooted
+      assert tenant_b.trust_tier == :agent_rooted
+    end
+  end
+
+  describe "transactional secret compensation (AC-26.7.1.4 / TC-26.7.1.2)" do
+    test "self_signup/1 deletes the external secret when a later Multi step fails" do
+      slug = "compensate-self-#{System.unique_integer([:positive])}"
+      test_pid = self()
+
+      # Force a REAL failure in a step AFTER Secrets.set succeeds: delete the
+      # tenant row (bypassing Ecto) from within the Secrets.set stub, so the
+      # VERY NEXT step (`:set_public_key`, an `Ecto.Repo.update` against the
+      # now-vanished row) raises `Ecto.StaleEntryError` — exercising the
+      # rescue arm of `with_secret_compensation/3`.
+      Mox.expect(Loopctl.MockSecrets, :set, fn secret_name, _priv ->
+        AdminRepo.query!("DELETE FROM tenants WHERE slug = $1", [slug])
+        send(test_pid, {:secret_set, secret_name})
+        :ok
+      end)
+
+      Mox.expect(Loopctl.MockSecrets, :delete, fn secret_name ->
+        send(test_pid, {:secret_deleted, secret_name})
+        :ok
+      end)
+
+      assert_raise Ecto.StaleEntryError, fn ->
+        Tenants.self_signup(%{
+          name: "Compensate Me",
+          slug: slug,
+          email: "compensate-self@example.com"
+        })
+      end
+
+      assert_receive {:secret_set, secret_name}
+      assert_receive {:secret_deleted, ^secret_name}
+      assert secret_name == Secrets.audit_key_secret_name(slug)
+
+      # Nothing left behind: no tenant, no root api_key, no audit entry.
+      assert {:error, :not_found} = Tenants.get_tenant_by_slug(slug)
+    end
+
+    test "signup/1 (WebAuthn ceremony) deletes the external secret when a later Multi step fails" do
+      slug = "compensate-webauthn-#{System.unique_integer([:positive])}"
+      test_pid = self()
+
+      Mox.expect(Loopctl.MockSecrets, :set, fn secret_name, _priv ->
+        AdminRepo.query!("DELETE FROM tenants WHERE slug = $1", [slug])
+        send(test_pid, {:secret_set, secret_name})
+        :ok
+      end)
+
+      Mox.expect(Loopctl.MockSecrets, :delete, fn secret_name ->
+        send(test_pid, {:secret_deleted, secret_name})
+        :ok
+      end)
+
+      assert_raise Ecto.StaleEntryError, fn ->
+        Tenants.signup(%{
+          name: "Compensate Me Too",
+          slug: slug,
+          email: "compensate-webauthn@example.com",
+          authenticators: [valid_attestation()]
+        })
+      end
+
+      assert_receive {:secret_set, secret_name}
+      assert_receive {:secret_deleted, ^secret_name}
+      assert secret_name == Secrets.audit_key_secret_name(slug)
+
+      assert {:error, :not_found} = Tenants.get_tenant_by_slug(slug)
+    end
+
+    # Tuple branch, guard = FALSE (Map.has_key?(changes, :store_secret) is false).
+    test "no compensation runs when the failure happens BEFORE Secrets.set (no secret was ever written)" do
+      fixture(:tenant, %{slug: "no-compensation-needed"})
+
+      # :delete must never be called — the changeset failure on the `:tenant`
+      # insert happens BEFORE the `:store_secret` step, so with_secret_compensation/3's
+      # write-step guard correctly skips compensation (nothing was written).
+      Mox.expect(Loopctl.MockSecrets, :delete, 0, fn _name -> :ok end)
+
+      assert {:error, :slug_taken} =
+               Tenants.self_signup(%{
+                 name: "No Secret Written",
+                 slug: "no-compensation-needed",
+                 email: "no-compensation@example.com"
+               })
+    end
+
+    # Review #1 (HIGH) — a FAILED compensating delete must NOT be swallowed.
+    test "a failed compensating delete fires telemetry AND enqueues a durable Oban retry" do
+      slug = "compensate-delete-fails-#{System.unique_integer([:positive])}"
+      handler = "orphan-cleanup-#{System.unique_integer([:positive])}"
+      test_pid = self()
+
+      # Same mid-Multi failure trigger as above (delete the tenant so a later
+      # update raises StaleEntryError), but now the compensating delete FAILS.
+      Mox.expect(Loopctl.MockSecrets, :set, fn _name, _priv ->
+        AdminRepo.query!("DELETE FROM tenants WHERE slug = $1", [slug])
+        :ok
+      end)
+
+      Mox.expect(Loopctl.MockSecrets, :delete, fn _name -> {:error, :fly_unavailable} end)
+
+      :telemetry.attach(
+        handler,
+        [:loopctl, :secrets, :orphan_cleanup_failed],
+        fn event, measurements, metadata, _cfg ->
+          send(test_pid, {:telemetry, event, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler) end)
+
+      # :manual so the enqueued retry is observable via assert_enqueued rather
+      # than executing inline (the suite's default Oban testing mode).
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert_raise Ecto.StaleEntryError, fn ->
+          Tenants.self_signup(%{
+            name: "Delete Fails",
+            slug: slug,
+            email: "compensate-delete-fails@example.com"
+          })
+        end
+      end)
+
+      secret_name = Secrets.audit_key_secret_name(slug)
+
+      assert_received {:telemetry, [:loopctl, :secrets, :orphan_cleanup_failed], %{count: 1},
+                       %{op: :delete, secret_name: ^secret_name, reason: :fly_unavailable}}
+
+      assert_enqueued(
+        worker: OrphanedSecretCleanupWorker,
+        args: %{"op" => "delete", "secret_name" => secret_name}
+      )
+    end
+
+    # Review #3 — TUPLE-branch (clean {:error, ...}) compensation.
+    #
+    # NOTE (honest coverage limitation): the clean-tuple post-`:store_secret`
+    # path is NOT deterministically reachable through any public flow. The only
+    # tuple-returning post-write step is self_signup/1's `:root_api_key`, and
+    # `Auth.generate_api_key/1` only returns `{:error, changeset}` on a
+    # validation error or a MAPPED api_keys constraint — neither is trippable by
+    # the valid `role: :user` root key (the mapped `[:tenant_id, :agent_id]`
+    # unique index is PARTIAL, excluding user/superadmin roles). Every other
+    # post-write step (`:set_public_key`, `:activate`, `:audit_genesis`) RAISES
+    # on failure (covered by the rescue-branch tests above). Deleting the tenant
+    # mid-Multi always trips `:set_public_key`'s StaleEntryError first.
+    #
+    # So this test asserts what IS observable and load-bearing: the write-step
+    # GUARD. It confirms the guard=TRUE arm (store_secret present in `changes`)
+    # runs `run_compensation/1` — the SAME function the (tested) rescue arm
+    # calls — by driving a rollback where the secret WAS written and asserting
+    # the delete fired exactly once. (guard=FALSE is the test directly above.)
+    test "tuple/rescue compensation runs run_compensation exactly once when the secret was written" do
+      slug = "compensate-once-#{System.unique_integer([:positive])}"
+      test_pid = self()
+
+      Mox.expect(Loopctl.MockSecrets, :set, fn _name, _priv ->
+        AdminRepo.query!("DELETE FROM tenants WHERE slug = $1", [slug])
+        :ok
+      end)
+
+      # Exactly ONE compensating delete — proves the two branches don't
+      # double-compensate and that the write-step guard fired.
+      Mox.expect(Loopctl.MockSecrets, :delete, 1, fn name ->
+        send(test_pid, {:deleted, name})
+        :ok
+      end)
+
+      assert_raise Ecto.StaleEntryError, fn ->
+        Tenants.self_signup(%{
+          name: "Compensate Once",
+          slug: slug,
+          email: "compensate-once@example.com"
+        })
+      end
+
+      assert_received {:deleted, secret_name}
+      assert secret_name == Secrets.audit_key_secret_name(slug)
     end
   end
 

--- a/test/loopctl/workers/orphaned_secret_cleanup_worker_test.exs
+++ b/test/loopctl/workers/orphaned_secret_cleanup_worker_test.exs
@@ -1,0 +1,89 @@
+defmodule Loopctl.Workers.OrphanedSecretCleanupWorkerTest do
+  @moduledoc """
+  US-26.7.1 (#1/#2) — durable retry of a failed compensating secret op.
+  """
+
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.Workers.OrphanedSecretCleanupWorker, as: Worker
+
+  setup :verify_on_exit!
+
+  describe "delete op" do
+    test "retries Secrets.delete and succeeds" do
+      test_pid = self()
+
+      Mox.expect(Loopctl.MockSecrets, :delete, fn name ->
+        send(test_pid, {:deleted, name})
+        :ok
+      end)
+
+      assert :ok =
+               Worker.perform(%Oban.Job{
+                 args: %{"op" => "delete", "secret_name" => "TENANT_AUDIT_KEY_X"}
+               })
+
+      assert_received {:deleted, "TENANT_AUDIT_KEY_X"}
+    end
+
+    test "treats :not_found as success (already gone)" do
+      Mox.expect(Loopctl.MockSecrets, :delete, fn _name -> {:error, :not_found} end)
+
+      assert :ok =
+               Worker.perform(%Oban.Job{
+                 args: %{"op" => "delete", "secret_name" => "TENANT_AUDIT_KEY_X"}
+               })
+    end
+
+    test "returns {:error, reason} so Oban retries on a real failure" do
+      Mox.expect(Loopctl.MockSecrets, :delete, fn _name -> {:error, :fly_down} end)
+
+      assert {:error, :fly_down} =
+               Worker.perform(%Oban.Job{
+                 args: %{"op" => "delete", "secret_name" => "TENANT_AUDIT_KEY_X"}
+               })
+    end
+  end
+
+  describe "restore op" do
+    test "decrypts the Cloak-wrapped value and restores it via Secrets.set" do
+      old_value = :crypto.strong_rand_bytes(32)
+      encoded = Worker.encode_secret_value(old_value)
+      test_pid = self()
+
+      # The encoded value must NOT be the plaintext key (encrypted at rest).
+      refute encoded == Base.encode64(old_value)
+
+      Mox.expect(Loopctl.MockSecrets, :set, fn name, value ->
+        send(test_pid, {:restored, name, value})
+        :ok
+      end)
+
+      assert :ok =
+               Worker.perform(%Oban.Job{
+                 args: %{
+                   "op" => "restore",
+                   "secret_name" => "TENANT_AUDIT_KEY_X",
+                   "value" => encoded
+                 }
+               })
+
+      # The worker restored the ORIGINAL plaintext key.
+      assert_received {:restored, "TENANT_AUDIT_KEY_X", ^old_value}
+    end
+
+    test "returns {:error, reason} so Oban retries when the restore set fails" do
+      encoded = Worker.encode_secret_value(:crypto.strong_rand_bytes(32))
+      Mox.expect(Loopctl.MockSecrets, :set, fn _name, _value -> {:error, :fly_down} end)
+
+      assert {:error, :fly_down} =
+               Worker.perform(%Oban.Job{
+                 args: %{
+                   "op" => "restore",
+                   "secret_name" => "TENANT_AUDIT_KEY_X",
+                   "value" => encoded
+                 }
+               })
+    end
+  end
+end

--- a/test/loopctl_web/controllers/openapi_test.exs
+++ b/test/loopctl_web/controllers/openapi_test.exs
@@ -42,6 +42,9 @@ defmodule LoopctlWeb.OpenApiTest do
       assert "/health" in paths
       assert "/api/v1/projects" in paths
       assert "/api/v1/stories/{id}" in paths
+      # US-26.7.1 (#10) — the public agent-rooted self-signup endpoint must stay
+      # registered in the OpenAPI spec (it's the API tenant-creation path).
+      assert "/api/v1/signup" in paths
     end
   end
 

--- a/test/loopctl_web/controllers/signup_controller_test.exs
+++ b/test/loopctl_web/controllers/signup_controller_test.exs
@@ -1,0 +1,344 @@
+defmodule LoopctlWeb.SignupControllerTest do
+  @moduledoc """
+  US-26.7.1 — `POST /api/v1/signup`, the public agent-rooted self-signup path.
+  """
+
+  use LoopctlWeb.ConnCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.Tenants
+
+  defp auth_conn(conn, raw_key) do
+    put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  describe "POST /api/v1/signup" do
+    test "creates an agent-rooted tenant and returns a one-time raw_key (TC-26.7.1.3)", %{
+      conn: conn
+    } do
+      unique = System.unique_integer([:positive])
+
+      conn =
+        post(conn, ~p"/api/v1/signup", %{
+          "name" => "Stranger Agent Co",
+          "slug" => "stranger-agent-#{unique}",
+          "email" => "agent-#{unique}@stranger.example"
+        })
+
+      body = json_response(conn, 201)
+      data = body["data"]
+
+      assert data["tenant"]["trust_tier"] == "agent_rooted"
+      assert data["tenant"]["status"] == "active"
+      assert data["tenant"]["slug"] == "stranger-agent-#{unique}"
+      assert is_binary(data["raw_key"])
+      assert String.starts_with?(data["raw_key"], "lc_")
+      assert is_map(data["next_action"])
+    end
+
+    test "does not require any Authorization header (public)", %{conn: conn} do
+      unique = System.unique_integer([:positive])
+
+      conn = conn |> delete_req_header("authorization")
+
+      conn =
+        post(conn, ~p"/api/v1/signup", %{
+          "name" => "No Auth Needed",
+          "slug" => "no-auth-#{unique}",
+          "email" => "noauth-#{unique}@example.com"
+        })
+
+      assert json_response(conn, 201)
+    end
+
+    test "duplicate slug returns 422", %{conn: conn} do
+      fixture(:tenant, %{slug: "signup-taken"})
+
+      conn =
+        post(conn, ~p"/api/v1/signup", %{
+          "name" => "Dup",
+          "slug" => "signup-taken",
+          "email" => "dup-signup@example.com"
+        })
+
+      body = json_response(conn, 422)
+      assert body["error"]["status"] == 422
+    end
+
+    test "duplicate email returns 422", %{conn: conn} do
+      fixture(:tenant, %{email: "signup-dup@example.com"})
+
+      conn =
+        post(conn, ~p"/api/v1/signup", %{
+          "name" => "Dup",
+          "slug" => "signup-email-dup",
+          "email" => "signup-dup@example.com"
+        })
+
+      body = json_response(conn, 422)
+      assert body["error"]["status"] == 422
+    end
+
+    test "invalid slug format returns 422 via changeset", %{conn: conn} do
+      conn =
+        post(conn, ~p"/api/v1/signup", %{
+          "name" => "Weird",
+          "slug" => "NOT A SLUG",
+          "email" => "weird-signup@example.com"
+        })
+
+      body = json_response(conn, 422)
+      assert body["error"]["details"]["slug"]
+    end
+
+    test "oversized field is rejected before the DB call", %{conn: conn} do
+      conn =
+        post(conn, ~p"/api/v1/signup", %{
+          "name" => String.duplicate("a", 10_000),
+          "slug" => "oversized-signup",
+          "email" => "oversized@example.com"
+        })
+
+      body = json_response(conn, 422)
+      assert body["error"]["status"] == 422
+
+      assert {:error, :not_found} = Tenants.get_tenant_by_slug("oversized-signup"),
+             "an oversized field must be rejected before any DB write"
+    end
+
+    # Review #6a — an oversized-field request must still consume the per-IP
+    # budget, so the rate-limit check runs BEFORE the size validation.
+    test "an oversized-field request still consumes the rate-limit budget", %{conn: conn} do
+      test_pid = self()
+
+      Mox.expect(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, _limit ->
+        send(test_pid, {:rate_checked, bucket})
+        {:allow, 1}
+      end)
+
+      conn =
+        post(conn, ~p"/api/v1/signup", %{
+          "name" => String.duplicate("a", 10_000),
+          "slug" => "oversized-budget",
+          "email" => "oversized-budget@example.com"
+        })
+
+      assert json_response(conn, 422)
+      # The rate limiter was consulted even though the request 422s on size.
+      assert_received {:rate_checked, _bucket}
+    end
+
+    # Review #6b — a proxy-resolved client must NOT collapse onto one shared
+    # bucket (which a flood could fill to block legitimate signups).
+    test "a proxy-resolved client falls back to a non-shared, per-request bucket", %{conn: conn} do
+      test_pid = self()
+
+      Mox.expect(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, _limit ->
+        send(test_pid, {:bucket, bucket})
+        {:allow, 1}
+      end)
+
+      unique = System.unique_integer([:positive])
+
+      # 198.51.100.0/24 is the configured proxy range (config/test.exs). No
+      # forwarding header resolves, so ClientIp leaves this proxy IP in place.
+      conn =
+        %{conn | remote_ip: {198, 51, 100, 5}}
+        |> post(~p"/api/v1/signup", %{
+          "name" => "Proxy Client",
+          "slug" => "proxy-client-#{unique}",
+          "email" => "proxy-#{unique}@example.com"
+        })
+
+      assert json_response(conn, 201)
+
+      assert_received {:bucket, bucket}
+      refute bucket =~ "198.51.100.5"
+      assert String.starts_with?(bucket, "api_signup:ip:req:")
+    end
+
+    # AC-26.7.1.12(c) — mass assignment closed
+    test "privileged fields in the body are ignored (mass assignment closed)", %{conn: conn} do
+      unique = System.unique_integer([:positive])
+
+      conn =
+        post(conn, ~p"/api/v1/signup", %{
+          "name" => "Sneaky",
+          "slug" => "sneaky-#{unique}",
+          "email" => "sneaky-#{unique}@example.com",
+          "trust_tier" => "human_anchored",
+          "role" => "superadmin",
+          "tenant_id" => Ecto.UUID.generate(),
+          "agent_id" => Ecto.UUID.generate()
+        })
+
+      body = json_response(conn, 201)
+      data = body["data"]
+
+      assert data["tenant"]["trust_tier"] == "agent_rooted"
+
+      {:ok, tenant} = Tenants.get_tenant_by_slug("sneaky-#{unique}")
+      assert tenant.trust_tier == :agent_rooted
+
+      # The returned key is role:user, tenant-bound — cannot mint a superadmin key.
+      conn2 =
+        build_conn()
+        |> auth_conn(data["raw_key"])
+        |> post(~p"/api/v1/api_keys", %{"name" => "escalate", "role" => "superadmin"})
+
+      assert json_response(conn2, 403)
+    end
+
+    # AC-26.7.1.5 — rate limiting
+    test "rate-limit denial returns 429 (TC-26.7.1.7)", %{conn: conn} do
+      Mox.expect(Loopctl.MockRateLimiter, :check_rate, fn _bucket, _window, _limit ->
+        {:deny, 5}
+      end)
+
+      conn =
+        post(conn, ~p"/api/v1/signup", %{
+          "name" => "Rate Limited",
+          "slug" => "rate-limited-#{System.unique_integer([:positive])}",
+          "email" => "rate-limited@example.com"
+        })
+
+      body = json_response(conn, 429)
+      assert body["error"]["status"] == 429
+      assert get_resp_header(conn, "retry-after") != []
+    end
+
+    # TC-26.7.1.3 + AC-26.7.1.8 — full agent-rooted KB-tier happy path
+    test "end-to-end: configure key -> register agent -> ingest/search -> create then delete an article",
+         %{conn: conn} do
+      unique = System.unique_integer([:positive])
+
+      signup_conn =
+        post(conn, ~p"/api/v1/signup", %{
+          "name" => "KB Tier Co",
+          "slug" => "kb-tier-#{unique}",
+          "email" => "kb-tier-#{unique}@example.com"
+        })
+
+      %{"data" => %{"raw_key" => user_key}} = json_response(signup_conn, 201)
+
+      # Configure BYO LLM keys (role: user).
+      llm_conn =
+        build_conn()
+        |> auth_conn(user_key)
+        |> patch(~p"/api/v1/tenants/me/llm-config", %{
+          "api_key" => "sk-ant-test-key",
+          "embedding_api_key" => "sk-embed-test-key"
+        })
+
+      refute llm_conn.status == 403
+
+      # Mint its own agent-role key (role:user is allowed to do this).
+      key_conn =
+        build_conn()
+        |> auth_conn(user_key)
+        |> post(~p"/api/v1/api_keys", %{"name" => "worker", "role" => "agent"})
+
+      %{"api_key" => %{"raw_key" => agent_key}} = json_response(key_conn, 201)
+
+      # Register an agent identity (AgentController requires exact_role: :agent).
+      register_conn =
+        build_conn()
+        |> auth_conn(agent_key)
+        |> post(~p"/api/v1/agents/register", %{
+          "name" => "worker-1",
+          "agent_type" => "implementer"
+        })
+
+      assert json_response(register_conn, 201)
+
+      # Search the wiki.
+      search_conn =
+        build_conn()
+        |> auth_conn(user_key)
+        |> get(~p"/api/v1/knowledge/search?q=test")
+
+      refute search_conn.status == 403
+
+      # Create then delete an article.
+      create_conn =
+        build_conn()
+        |> auth_conn(user_key)
+        |> post(~p"/api/v1/articles", %{
+          "title" => "KB tier article",
+          "body" => "Some content",
+          "category" => "pattern"
+        })
+
+      %{"data" => %{"id" => article_id}} = json_response(create_conn, 201)
+
+      delete_conn =
+        build_conn()
+        |> auth_conn(user_key)
+        |> delete(~p"/api/v1/articles/#{article_id}")
+
+      refute delete_conn.status == 403
+    end
+
+    # AC-26.7.1.12(f) — key-minting bypass is closed
+    test "a self-minted orchestrator key is still blocked on custody ops (tier gate keyed on tenant, not role)",
+         %{conn: conn} do
+      unique = System.unique_integer([:positive])
+
+      signup_conn =
+        post(conn, ~p"/api/v1/signup", %{
+          "name" => "Bypass Attempt",
+          "slug" => "bypass-#{unique}",
+          "email" => "bypass-#{unique}@example.com"
+        })
+
+      %{"data" => %{"raw_key" => user_key}} = json_response(signup_conn, 201)
+
+      key_conn =
+        build_conn()
+        |> auth_conn(user_key)
+        |> post(~p"/api/v1/api_keys", %{"name" => "escalated-orch", "role" => "orchestrator"})
+
+      %{"api_key" => %{"raw_key" => orch_key}} = json_response(key_conn, 201)
+
+      # The RequireHumanAnchor gate runs before any project lookup, so a
+      # bogus project_id is sufficient to prove the tier gate fires first.
+      create_conn =
+        build_conn()
+        |> auth_conn(orch_key)
+        |> post(~p"/api/v1/projects/#{Ecto.UUID.generate()}/stories", %{
+          "epic_number" => 1,
+          "number" => "1.1",
+          "title" => "Should be blocked"
+        })
+
+      body = json_response(create_conn, 403)
+      assert body["error"]["code"] == "custody_tier_required"
+    end
+
+    # AC-26.7.1.12(a) / TC-26.7.1.8 — tenant isolation for an agent-rooted tenant
+    test "an agent-rooted tenant cannot read another tenant's articles (RLS isolation)",
+         %{conn: conn} do
+      unique = System.unique_integer([:positive])
+
+      signup_conn =
+        post(conn, ~p"/api/v1/signup", %{
+          "name" => "Isolation A",
+          "slug" => "isolation-a-#{unique}",
+          "email" => "isolation-a-#{unique}@example.com"
+        })
+
+      %{"data" => %{"raw_key" => key_a}} = json_response(signup_conn, 201)
+
+      tenant_b = fixture(:tenant)
+      article_b = fixture(:article, %{tenant_id: tenant_b.id})
+
+      show_conn =
+        build_conn()
+        |> auth_conn(key_a)
+        |> get(~p"/api/v1/articles/#{article_b.id}")
+
+      assert show_conn.status == 404
+    end
+  end
+end

--- a/test/loopctl_web/controllers/well_known_controller_test.exs
+++ b/test/loopctl_web/controllers/well_known_controller_test.exs
@@ -25,6 +25,9 @@ defmodule LoopctlWeb.WellKnownControllerTest do
       assert body["discovery_bootstrap_url"] =~ "loopctl.com/wiki/agent-bootstrap"
       assert body["required_agent_pattern_url"] =~ "loopctl.com/wiki/agent-pattern"
       assert body["system_articles_endpoint"] =~ "loopctl.com/api/v1/articles/system"
+      # US-26.7.1: a stranger agent discovering loopctl cold can find the
+      # public, agent-rooted self-signup path.
+      assert body["signup_endpoint"] =~ "loopctl.com/api/v1/signup"
       assert is_binary(body["contact"])
     end
 

--- a/test/loopctl_web/plugs/require_human_anchor_test.exs
+++ b/test/loopctl_web/plugs/require_human_anchor_test.exs
@@ -1,0 +1,110 @@
+defmodule LoopctlWeb.Plugs.RequireHumanAnchorTest do
+  @moduledoc """
+  US-26.7.1 — unit tests for the `RequireHumanAnchor` plug, mirroring the
+  direct `assign/3` + `Plug.call/2` style used by `SetTenantTest`.
+  """
+
+  use LoopctlWeb.ConnCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.Auth.ApiKey
+  alias LoopctlWeb.Plugs.RequireHumanAnchor
+
+  describe "call/2" do
+    test "passes through for a human_anchored tenant", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+      api_key = %ApiKey{tenant_id: tenant.id, role: :user}
+
+      conn =
+        conn
+        |> assign(:current_api_key, api_key)
+        |> assign(:current_tenant, tenant)
+        |> RequireHumanAnchor.call([])
+
+      refute conn.halted
+    end
+
+    test "halts with 403 custody_tier_required for an agent_rooted tenant", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      api_key = %ApiKey{tenant_id: tenant.id, role: :user}
+
+      conn =
+        conn
+        |> assign(:current_api_key, api_key)
+        |> assign(:current_tenant, tenant)
+        |> RequireHumanAnchor.call([])
+
+      assert conn.halted
+      assert conn.status == 403
+
+      body = Jason.decode!(conn.resp_body)
+      assert body["error"]["status"] == 403
+      assert body["error"]["code"] == "custody_tier_required"
+      assert is_binary(body["error"]["message"])
+      assert is_map(body["error"]["remediation"])
+      assert body["error"]["remediation"]["learn_more"] =~ "chain-of-custody"
+    end
+
+    test "superadmin key with no impersonation (current_tenant: nil) passes without crashing",
+         %{conn: conn} do
+      api_key = %ApiKey{tenant_id: nil, role: :superadmin}
+
+      conn =
+        conn
+        |> assign(:current_api_key, api_key)
+        |> assign(:current_tenant, nil)
+        |> RequireHumanAnchor.call([])
+
+      refute conn.halted
+    end
+
+    test "superadmin impersonating an agent_rooted tenant is blocked (routes through the impersonated tenant's tier)",
+         %{conn: conn} do
+      agent_rooted_tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      superadmin_key = %ApiKey{tenant_id: nil, role: :superadmin}
+      # Mirrors what LoopctlWeb.Plugs.Impersonate actually does: reassigns
+      # current_tenant + current_api_key.tenant_id to the impersonated
+      # tenant BEFORE controller plugs run.
+      impersonated_key = %{superadmin_key | tenant_id: agent_rooted_tenant.id}
+
+      conn =
+        conn
+        |> assign(:current_api_key, impersonated_key)
+        |> assign(:current_tenant, agent_rooted_tenant)
+        |> assign(:impersonating, true)
+        |> RequireHumanAnchor.call([])
+
+      assert conn.halted
+      assert conn.status == 403
+      assert Jason.decode!(conn.resp_body)["error"]["code"] == "custody_tier_required"
+    end
+
+    test "superadmin impersonating a human_anchored tenant passes", %{conn: conn} do
+      human_tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+      superadmin_key = %ApiKey{tenant_id: nil, role: :superadmin}
+      impersonated_key = %{superadmin_key | tenant_id: human_tenant.id}
+
+      conn =
+        conn
+        |> assign(:current_api_key, impersonated_key)
+        |> assign(:current_tenant, human_tenant)
+        |> assign(:impersonating, true)
+        |> RequireHumanAnchor.call([])
+
+      refute conn.halted
+    end
+
+    test "no current_tenant assign at all fails closed (never permissive)", %{conn: conn} do
+      api_key = %ApiKey{tenant_id: Ecto.UUID.generate(), role: :user}
+
+      conn =
+        conn
+        |> assign(:current_api_key, api_key)
+        |> RequireHumanAnchor.call([])
+
+      assert conn.halted
+      assert conn.status == 403
+    end
+  end
+end

--- a/test/loopctl_web/require_human_anchor_default_deny_test.exs
+++ b/test/loopctl_web/require_human_anchor_default_deny_test.exs
@@ -1,0 +1,222 @@
+defmodule LoopctlWeb.RequireHumanAnchorDefaultDenyTest do
+  @moduledoc """
+  US-26.7.1 / AC-26.7.1.9 (TC-26.7.1.4) — DEFAULT-DENY GUARD TEST.
+
+  Walks `LoopctlWeb.Router.__routes__/0`, keeps every route on the
+  `:authenticated` pipeline whose method mutates (POST/PUT/PATCH/DELETE),
+  SUBTRACTS an explicit, reviewed KB-tier/account/superadmin allowlist, and
+  asserts that EVERY remaining route returns `403 custody_tier_required`
+  when called by an agent-rooted tenant — using a role-appropriate key for
+  that specific route (some routes gate on `exact_role`, which a plain
+  `:user` key does not satisfy; those are looked up in `@role_overrides` and
+  called with the matching role instead, so the assertion isolates the tier
+  gate from the role gate per TC-26.7.1.4).
+
+  This is the authoritative check that AC-26.7.1.7's per-controller
+  enumeration is complete: a wrong/missing action atom compiles to a silent
+  no-op guard with NO other symptom, so this test is the only thing that
+  would catch it. Any NEW custody route added later that is neither gated
+  nor allowlisted here FAILS this test — the surface fails closed.
+  """
+
+  use LoopctlWeb.ConnCase, async: true
+
+  setup :verify_on_exit!
+
+  # {verb, path} pairs deliberately NOT tier-gated. Every group has a
+  # one-line reason. Anything NOT in this set (still on the `:authenticated`
+  # pipeline, with a mutating verb) is asserted to 403 below.
+  @allowlist MapSet.new([
+               # Tenant self-management + BYO LLM config — account-neutral, not custody.
+               {:patch, "/api/v1/tenants/me"},
+               {:patch, "/api/v1/tenants/me/llm-config"},
+               # rotate-audit-key (challenge + rotate) is gated by a FRESH
+               # per-op WebAuthn assertion (WebAuthn.Reauth) + tenant ownership,
+               # a STRONGER control than the tier gate — an agent-rooted tenant
+               # has no enrolled authenticator, so `challenge` 422s
+               # (no_authenticators) and `rotate` can never produce a valid
+               # assertion. No tier gate needed.
+               {:post, "/api/v1/tenants/:id/rotate-audit-key/challenge"},
+               {:post, "/api/v1/tenants/:id/rotate-audit-key"},
+               # bootstrap-audit-key (#5 reviewed rationale): UNREACHABLE, not
+               # tier-relevant. BOTH signup paths (signup/1 and self_signup/1)
+               # mandatorily pre-provision the audit key, so `bootstrap` 409s
+               # `key_already_exists` for every current and future tenant. The
+               # `always_has_audit_key` regression test (signup_test.exs) guards
+               # that precondition so this exemption can't silently rot if
+               # provisioning ever became lazy.
+               {:post, "/api/v1/tenants/:id/bootstrap-audit-key"},
+
+               # /api_keys management — explicitly excluded (AC-26.7.1.7).
+               {:post, "/api/v1/api_keys"},
+               {:delete, "/api/v1/api_keys/:id"},
+               {:post, "/api/v1/api_keys/:id/rotate"},
+
+               # Agent's own identity — explicitly excluded (AC-26.7.1.7/.8).
+               {:post, "/api/v1/agents/register"},
+
+               # Knowledge/article/wiki/article_link — full KB-tier surface,
+               # explicitly excluded (AC-26.7.1.7).
+               {:post, "/api/v1/articles"},
+               {:put, "/api/v1/articles/:id"},
+               {:patch, "/api/v1/articles/:id"},
+               {:delete, "/api/v1/articles/:id"},
+               {:post, "/api/v1/articles/:id/publish"},
+               {:post, "/api/v1/articles/:id/unpublish"},
+               {:post, "/api/v1/articles/:id/archive"},
+               {:post, "/api/v1/knowledge/bulk-publish"},
+               {:post, "/api/v1/knowledge/bulk-unpublish"},
+               {:post, "/api/v1/knowledge/bulk-delete"},
+               {:post, "/api/v1/knowledge/conflicts/resolve"},
+               {:post, "/api/v1/knowledge/novelty"},
+               {:post, "/api/v1/knowledge/okf/import"},
+               {:post, "/api/v1/knowledge/ingest"},
+               {:post, "/api/v1/knowledge/ingest/batch"},
+               {:post, "/api/v1/projects/:project_id/articles"},
+               {:post, "/api/v1/article_links"},
+               {:delete, "/api/v1/article_links/:id"},
+
+               # UI test runs (#4/#5 reviewed rationale): a QA/tooling surface,
+               # NOT work-breakdown state. Every route is nested under
+               # `/projects/:project_id/...` and creating a project
+               # (`ProjectController.create`) is ALREADY tier-gated, so an
+               # agent-rooted tenant has no project to attach a UI test to —
+               # the surface is unreachable for it even without a per-route gate.
+               {:post, "/api/v1/projects/:project_id/ui-tests"},
+               {:post, "/api/v1/projects/:project_id/ui-tests/:id/findings"},
+               {:post, "/api/v1/projects/:project_id/ui-tests/:id/complete"},
+
+               # Webhooks (#4/#5 reviewed rationale): tenant-account integration
+               # config (delivery endpoints), NOT custody state — analogous to
+               # BYO LLM config, which is deliberately KB-tier-open. The SSRF
+               # blast radius is independently bounded by `UrlGuard.pin` (egress
+               # allowlist + DNS-rebinding defense) regardless of tier, so a
+               # KB-tier tenant configuring a webhook cannot reach internal hosts.
+               {:post, "/api/v1/webhooks"},
+               {:put, "/api/v1/webhooks/:id"},
+               {:patch, "/api/v1/webhooks/:id"},
+               {:delete, "/api/v1/webhooks/:id"},
+               {:post, "/api/v1/webhooks/:id/test"},
+
+               # Superadmin-only admin scope — RequireRole already pins these
+               # to superadmin; Impersonate explicitly skips
+               # /api/v1/admin/*, so current_tenant is always nil
+               # (superadmin) there — the tier gate doesn't apply and isn't
+               # attached to these controllers.
+               {:patch, "/api/v1/admin/tenants/:id"},
+               {:post, "/api/v1/admin/tenants/:id/suspend"},
+               {:post, "/api/v1/admin/tenants/:id/activate"},
+               {:post, "/api/v1/admin/violators/:id/resolve"},
+               {:post, "/api/v1/admin/violators/:id/ignore"},
+               {:post, "/api/v1/admin/tenants/:id/clear-halt"}
+             ])
+
+  # Routes gated by `exact_role:` (not hierarchy) that a plain `:user` key
+  # does not satisfy — mapped to the role that DOES, so the request reaches
+  # (and is blocked by) the tier gate rather than the role gate first.
+  @role_overrides %{
+    {:post, "/api/v1/stories/:id/contract"} => :agent,
+    {:post, "/api/v1/stories/:id/claim"} => :agent,
+    {:post, "/api/v1/stories/:id/start"} => :agent,
+    {:post, "/api/v1/stories/:id/request-review"} => :agent,
+    {:post, "/api/v1/stories/:id/report"} => :agent,
+    {:post, "/api/v1/stories/:id/unclaim"} => :agent,
+    {:post, "/api/v1/stories/:id/report-done"} => :agent,
+    {:post, "/api/v1/stories/:id/start-work"} => :agent,
+    {:post, "/api/v1/stories/:id/recover-cap"} => :agent,
+    {:post, "/api/v1/stories/bulk/claim"} => :agent,
+    {:post, "/api/v1/stories/:id/artifacts"} => :agent,
+    {:post, "/api/v1/stories/:id/verify"} => :orchestrator,
+    {:post, "/api/v1/stories/:id/reject"} => :orchestrator,
+    {:post, "/api/v1/stories/:id/force-unclaim"} => :orchestrator,
+    {:post, "/api/v1/epics/:id/verify-all"} => :orchestrator,
+    {:post, "/api/v1/stories/bulk/verify"} => :orchestrator,
+    {:post, "/api/v1/stories/bulk/reject"} => :orchestrator,
+    {:post, "/api/v1/stories/bulk/mark-complete"} => :orchestrator,
+    {:put, "/api/v1/orchestrator/state/:project_id"} => :orchestrator,
+    {:post, "/api/v1/skill_results"} => :orchestrator
+  }
+
+  test "every non-allowlisted authenticated mutating route 403s for an agent-rooted tenant" do
+    tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+    {user_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+    {orch_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+    {agent_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+    keys = %{user: user_key, orchestrator: orch_key, agent: agent_key}
+
+    # `LoopctlWeb.Router.__routes__/0` deliberately does NOT expose
+    # `:pipe_through` (Phoenix.Router only keeps [:verb, :path, :plug,
+    # :plug_opts, :helper, :metadata] there) — so pipeline membership is
+    # resolved per-route via `Phoenix.Router.route_info/4`, which DOES
+    # surface `:pipe_through` in its metadata map (confirmed against a live
+    # match — it calls the router's own generated `__match_route__/3`).
+    routes =
+      LoopctlWeb.Router.__routes__()
+      |> Enum.filter(fn route ->
+        route.verb in [:post, :put, :patch, :delete] and authenticated_route?(route)
+      end)
+
+    assert length(routes) > 40,
+           "sanity check: expected dozens of authenticated mutating routes, found #{length(routes)}"
+
+    checked =
+      Enum.reject(routes, fn route -> MapSet.member?(@allowlist, {route.verb, route.path}) end)
+
+    # Includes representative routes from EVERY gated controller group
+    # (AC-26.7.1.12b), explicitly named per TC-26.7.1.4.
+    checked_pairs = Enum.map(checked, &{&1.verb, &1.path})
+    assert {:post, "/api/v1/projects/:project_id/stories"} in checked_pairs
+    assert {:post, "/api/v1/stories/bulk/verify"} in checked_pairs
+    assert {:post, "/api/v1/stories/:id/recover-cap"} in checked_pairs
+    assert {:post, "/api/v1/projects/:id/import"} in checked_pairs
+
+    assert checked != [], "sanity check: there should be routes left to assert against"
+
+    for route <- checked do
+      role = Map.get(@role_overrides, {route.verb, route.path}, :user)
+      raw_key = Map.fetch!(keys, role)
+      path = substitute_params(route.path)
+
+      conn =
+        build_conn()
+        |> put_req_header("x-loopctl-last-known-sth", "0:AAAAAAAAAAAAAAAAAAAAAA")
+        |> put_req_header("authorization", "Bearer #{raw_key}")
+        |> dispatch_verb(route.verb, path)
+
+      assert conn.status == 403,
+             "expected 403 for #{route.verb} #{route.path} (role=#{role}), " <>
+               "got #{conn.status}: #{conn.resp_body}"
+
+      body = Jason.decode!(conn.resp_body)
+
+      assert body["error"]["code"] == "custody_tier_required",
+             "expected custody_tier_required for #{route.verb} #{route.path}, " <>
+               "got: #{inspect(body)}"
+    end
+  end
+
+  defp substitute_params(path) do
+    path
+    |> String.split("/")
+    |> Enum.map_join("/", fn
+      ":" <> _param -> Ecto.UUID.generate()
+      segment -> segment
+    end)
+  end
+
+  defp authenticated_route?(route) do
+    method = route.verb |> Atom.to_string() |> String.upcase()
+    path = substitute_params(route.path)
+
+    case Phoenix.Router.route_info(LoopctlWeb.Router, method, path, "localhost") do
+      %{pipe_through: pipe_through} -> :authenticated in pipe_through
+      _ -> false
+    end
+  end
+
+  defp dispatch_verb(conn, :post, path), do: Phoenix.ConnTest.post(conn, path, %{})
+  defp dispatch_verb(conn, :put, path), do: Phoenix.ConnTest.put(conn, path, %{})
+  defp dispatch_verb(conn, :patch, path), do: Phoenix.ConnTest.patch(conn, path, %{})
+  defp dispatch_verb(conn, :delete, path), do: Phoenix.ConnTest.delete(conn, path)
+end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -88,7 +88,11 @@ defmodule Loopctl.Fixtures do
         slug: "test-tenant-#{System.unique_integer([:positive])}",
         email: "test-#{System.unique_integer([:positive])}@example.com",
         settings: %{},
-        status: :active
+        status: :active,
+        # US-26.7.1: default fixtures to the trusted, human-anchored tier so the
+        # large existing custody-test surface is unaffected. Pass
+        # `trust_tier: :agent_rooted` explicitly to get a KB-tier tenant.
+        trust_tier: :human_anchored
       },
       Enum.into(attrs, %{})
     )
@@ -459,6 +463,7 @@ defmodule Loopctl.Fixtures do
     data = build(:tenant, attrs)
     status = Map.get(data, :status, :active)
     audit_pub_key = Map.get(data, :audit_signing_public_key)
+    trust_tier = Map.get(data, :trust_tier, :human_anchored)
 
     tenant =
       %Tenant{}
@@ -476,13 +481,21 @@ defmodule Loopctl.Fixtures do
       end
 
     # Set audit_signing_public_key if provided (not in create_changeset cast)
-    if audit_pub_key do
-      tenant
-      |> Ecto.Changeset.change(audit_signing_public_key: audit_pub_key)
-      |> AdminRepo.update!()
-    else
-      tenant
-    end
+    tenant =
+      if audit_pub_key do
+        tenant
+        |> Ecto.Changeset.change(audit_signing_public_key: audit_pub_key)
+        |> AdminRepo.update!()
+      else
+        tenant
+      end
+
+    # US-26.7.1: trust_tier is excluded from create_changeset's cast (never
+    # settable from a public changeset) — set it programmatically here,
+    # mirroring the audit_signing_public_key post-insert pattern above.
+    tenant
+    |> Ecto.Changeset.change(trust_tier: trust_tier)
+    |> AdminRepo.update!()
   end
 
   def fixture(:root_authenticator, attrs) do


### PR DESCRIPTION
## US-26.7.1 — Capability-Tiered Trust

Attaches trust to the **capability**, not to tenant genesis, resolving the two-use-case conflict (supervised code workflow vs. agent-native KB):

- **KB tier (agent-rooted):** a lightweight, rate-limited `POST /api/v1/signup` (+ MCP `signup` tool) mints a tenant with no human/WebAuthn ceremony. It gets the full knowledge surface immediately (ingest/search/curate, article CRUD, BYO-LLM config, own agent identity).
- **Custody tier (human-anchored):** the work-breakdown / chain-of-custody surface stays behind a new `RequireHumanAnchor` plug, keyed on `tenant.trust_tier` (orthogonal to role, so a self-minted higher-role key can't escape it). Existing WebAuthn-signed tenants are unaffected.

This does **not** weaken L0 for the ops that depend on it — it scopes *where* the boundary sits. The 409 self-custody guards and dispatch-lineage checks are independent of L0 and remain intact. The opt-in WebAuthn *upgrade* flow (agent-rooted → human-anchored) is a signed-off fast-follow (US-26.7.2).

### Two-stage review (both ran before merge)
- **Spec review (pre-implementation):** found **5 critical tier-gate bypasses in the story itself** — a missing `:create_in_project` alias, whole un-enumerated custody controllers (Bulk/CapRecovery/ImportExport), and action-atom-vs-prose mismatches that compile to silent no-op guards. Fixed in the spec, plus added a **default-deny router-walk guard test** so any future custody route fails closed.
- **Full enhanced review (post-implementation):** team (security/architecture/correctness/completeness) + adversarial + VCA. **No custody bypass survived.** 10 confirmed findings (1 high / 4 med / 5 low), all fixed in-branch — no deferrals — including a pre-existing audit-key-rotation orphan bug (keypair-mismatch) the review surfaced.

### Notable hardening
- Transactional secret safety: external Fly secret writes now compensate on mid-`Multi` failure (delete for signup/bootstrap, **restore-old-key** for rotate), with a durable retry `OrphanedSecretCleanupWorker` + telemetry when compensation itself fails. Process-dictionary bridge removed.
- DB-level CHECK constraints backstop `trust_tier` and the superadmin↔`tenant_id IS NULL` invariant.

`mix precommit` green: 3718 tests, 0 failures; credo --strict clean; dialyzer passed.
