### PR TITLE
feat(auth): opt-in WebAuthn tier upgrade — agent_rooted → human_anchored (US-26.7.2)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -372,6 +372,10 @@ config :loopctl, :webauthn_adapter, Loopctl.WebAuthn.Wax
 # signup LiveView is served from. Overridden in dev and prod as needed.
 config :loopctl, :webauthn,
   rp_id: "loopctl.com",
+  # US-26.7.2: rp_name is served by the stateless enrollment-challenge API
+  # endpoint (POST /tenants/:id/authenticators/challenge) so the relying
+  # party display name comes from server config, not a hard-coded JS client.
+  rp_name: "loopctl",
   origin: "https://loopctl.com",
   user_verification: "preferred"
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -84,6 +84,7 @@ config :loopctl, dev_routes: true
 # WebAuthn relying party — localhost for development
 config :loopctl, :webauthn,
   rp_id: "localhost",
+  rp_name: "loopctl (dev)",
   origin: "http://localhost:4000",
   user_verification: "preferred"
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -308,6 +308,7 @@ config :loopctl, :okf_max_buffered_export_articles, 2
 # WebAuthn relying party — test fixtures expect localhost
 config :loopctl, :webauthn,
   rp_id: "localhost",
+  rp_name: "loopctl (test)",
   origin: "http://localhost:4002",
   user_verification: "preferred"
 

--- a/docs/chain-of-custody-v2.md
+++ b/docs/chain-of-custody-v2.md
@@ -673,10 +673,48 @@ Any endpoint that modifies the root trust requires a fresh WebAuthn assertion:
 - `DELETE /projects/:id` — delete a project. Now additionally tier-gated
   (US-26.7.1): requires a `human_anchored` tenant on top of the existing
   `role: :user` requirement.
-- `POST /tenants/:id/authenticators` — enroll an additional authenticator, and
-  `DELETE /tenants/:id/authenticators/:id` — revoke an authenticator. Both are
-  **deferred to US-26.7.2** (the reciprocal opt-in WebAuthn-enrollment upgrade
-  path for an `agent_rooted` tenant) — these routes do not exist yet.
+- `POST /tenants/:id/authenticators/challenge` then `POST /tenants/:id/authenticators`
+  — enroll a WebAuthn authenticator (US-26.7.2). This is the OPT-IN trust-tier
+  upgrade ceremony: a tenant created via `POST /api/v1/signup` (`agent_rooted`,
+  zero authenticators) enrolls a hardware authenticator here to become
+  `human_anchored` and gain the custody surface. Two authorization shapes,
+  deliberately NOT identical:
+  - **FIRST enrollment** (tenant is `agent_rooted`, zero enrolled
+    authenticators): requires `role: :user` + tenant ownership + a fresh
+    registration attestation. Nothing more to assert against — this is the
+    legitimate bootstrap, mirroring the original signup ceremony's trust
+    model (possession of hardware is the proof).
+  - **SUBSEQUENT enrollment** (tenant is already `human_anchored`):
+    ADDITIONALLY requires a fresh assertion (purpose `add_authenticator`)
+    from an ALREADY-enrolled authenticator, verified via the same
+    challenge-bound `Loopctl.WebAuthn.Reauth` ceremony `rotate-audit-key`
+    uses. This is the critical anti-soft-recovery-backdoor gate: without it,
+    a stolen `role: :user` API key alone could graft an attacker's own
+    hardware onto the tenant's root of trust with no theft of the real
+    device — exactly the backdoor §9.3 rejects. Absent/invalid ->
+    401 `reauth_required`/`reauth_failed`.
+
+  Enrollment runs two-phase (mirroring `Reauth.verify_and_consume/3`): the
+  registration challenge (and, when required, the `add_authenticator`
+  assertion) is consumed in its own committed transaction FIRST, so a later
+  attestation failure never un-burns it; the attestation is then verified
+  OUTSIDE any open transaction; only on success does a DB-only `Ecto.Multi`
+  insert the authenticator and GUARD-flip `trust_tier` via a conditional
+  `UPDATE ... WHERE trust_tier = 'agent_rooted'` — appending exactly one
+  `tenant_trust_upgraded` audit entry when the flip actually happened, or
+  `authenticator_enrolled` for a backup. The append-only genesis entry from
+  original signup (or self-signup) is never rewritten.
+
+- `POST /tenants/:id/authenticators/revoke-challenge` then
+  `DELETE /tenants/:id/authenticators/:auth_id` — revoke an authenticator
+  (US-26.7.2). Gated by a fresh assertion (purpose `revoke_authenticator`)
+  from an EXISTING authenticator, verified the same way. The delete
+  transaction locks the tenant row (`SELECT ... FOR UPDATE`) before counting
+  the tenant's remaining authenticators, so two concurrent revokes against a
+  2-authenticator tenant cannot both succeed. Revoking the tenant's LAST
+  authenticator while `human_anchored` is refused with 409
+  `last_authenticator` — **no auto-downgrade** to `agent_rooted` is ever
+  performed; see §9.3.
 
 Corrections to a stale prior version of this list: `POST /tenants/:id/override`
 and `POST /tenants/:id/budgets` never existed as routes and have been removed
@@ -718,10 +756,25 @@ explicit, reviewed allowlist. The allowlist decisions:
   if provisioning ever became lazy. `rotate-audit-key` (challenge + rotate) is
   gated by a fresh per-op WebAuthn assertion (`WebAuthn.Reauth`), a stronger
   control than the tier.
+- **`.../authenticators` (challenge/create) and `.../authenticators/:auth_id`
+  (revoke-challenge/delete)** are NOT tier-gated (US-26.7.2): `challenge` and
+  `create` ARE the upgrade path itself — an agent-rooted caller is the
+  intended audience for a first enrollment, so a tier gate would make the
+  tier unreachable from the tier it exists to lift a tenant out of. A
+  SUBSEQUENT (backup) enrollment and every revoke are instead gated by a
+  fresh, per-operation WebAuthn assertion (`WebAuthn.Reauth`), a stronger
+  control than the tier — see §9.2 above.
 
 ### 9.3 Recovery
 
 Loss of all enrolled authenticators is a fatal event for the tenant. Recovery requires contacting the loopctl operator (the root of the root of trust — the human running `loopctl.com` itself) and re-enrolling via an out-of-band channel. This is intentional: recovery is rare, loud, and hard. The alternative — soft recovery via email or password — would create a back door that agents could eventually find and exploit.
+
+This is enforced structurally, not just by convention: `DELETE /tenants/:id/authenticators/:auth_id`
+(US-26.7.2) refuses (409 `last_authenticator`) to remove a `human_anchored`
+tenant's last remaining authenticator, and no code path ever downgrades
+`trust_tier` back to `agent_rooted` once it has been raised. A tenant that
+somehow reaches zero authenticators outside this API (e.g. a manual DB
+operation) has no self-service way back in — by design.
 
 ## 10. Phase plan
 

--- a/docs/chain-of-custody-v2.md
+++ b/docs/chain-of-custody-v2.md
@@ -628,7 +628,8 @@ work-custody surface, not for a tenant curating its own wiki notes.
 
 An `agent_rooted` tenant can later enroll a WebAuthn authenticator to
 upgrade to `human_anchored` and unlock the custody surface — that reciprocal
-opt-in ceremony is a dependent fast-follow (US-26.7.2), not yet implemented.
+opt-in ceremony (US-26.7.2) is `POST /tenants/:id/authenticators/challenge`
+then `POST /tenants/:id/authenticators`; see §9.2 below.
 
 `POST /api/v1/signup` — public (no auth), rate-limited per client IP
 (<= 5/hour). Accepts `name`, `slug`, `email`; returns the created tenant

--- a/docs/chain-of-custody-v2.md
+++ b/docs/chain-of-custody-v2.md
@@ -706,6 +706,18 @@ Any endpoint that modifies the root trust requires a fresh WebAuthn assertion:
   `authenticator_enrolled` for a backup. The append-only genesis entry from
   original signup (or self-signup) is never rewritten.
 
+  The backup-enrollment gate is NOT decided from a pre-lock tier read alone.
+  Phase 3 locks the tenant row (`SELECT ... FOR UPDATE`) and RE-EVALUATES the
+  gate against the freshly-locked, authoritative `trust_tier` before inserting
+  the authenticator: if the locked tier is `human_anchored` and no
+  `add_authenticator` assertion was verified for this request, the transaction
+  aborts `401 reauth_required`. This closes the concurrent double-first-enroll
+  race — two simultaneous first enrollments on an `agent_rooted` tenant do NOT
+  both succeed: the lock winner flips + enrolls, and the loser re-reads
+  `human_anchored` under its own lock and is rejected, so it must retry WITH a
+  fresh existing-authenticator assertion. An attacker holding a stolen
+  `role:user` key cannot win this race to graft an unproven device.
+
 - `POST /tenants/:id/authenticators/revoke-challenge` then
   `DELETE /tenants/:id/authenticators/:auth_id` — revoke an authenticator
   (US-26.7.2). Gated by a fresh assertion (purpose `revoke_authenticator`)

--- a/docs/user_stories/epic_26_chain_of_custody_v2/us_26.7.2.json
+++ b/docs/user_stories/epic_26_chain_of_custody_v2/us_26.7.2.json
@@ -1,0 +1,137 @@
+{
+  "id": "US-26.7.2",
+  "title": "Trust-Tier Upgrade: Opt-In WebAuthn Enrollment (agent_rooted -> human_anchored)",
+  "epic": { "id": "epic_26", "name": "Chain of Custody v2" },
+  "priority": "high",
+  "phase": "capability_tiers",
+  "story": {
+    "as_a": "an agent-rooted (KB-tier) tenant created via POST /api/v1/signup whose human operator now wants to run supervised work-breakdown / chain-of-custody operations",
+    "i_want_to": "enroll a WebAuthn hardware authenticator against my existing tenant via an API ceremony, which promotes my tenant from agent_rooted to human_anchored",
+    "so_that": "I gain the custody surface RequireHumanAnchor gates, without creating a new tenant or losing my accumulated knowledge base"
+  },
+  "rationale": "US-26.7.1 opened frictionless agent-rooted self-signup for the KB tier and gated the custody surface behind RequireHumanAnchor (keyed on tenant.trust_tier), but deliberately deferred the RECIPROCAL path: how an agent-rooted tenant becomes human_anchored. Today there is no post-signup authenticator-enrollment route at all (docs/chain-of-custody-v2.md §9.2 references POST /tenants/:id/authenticators and DELETE /tenants/:id/authenticators/:id as deferred here; they do not exist). This story adds the opt-in upgrade ceremony so the two tiers are a round-trip.\n\nThe security model is L0 being established: upgrading requires producing a VALID WebAuthn attestation from a real hardware authenticator. An agent cannot forge that, so (owns the tenant's user key) + (produces a verified attestation) is what promotes the tenant. Holding the self-signup user key alone is NOT sufficient.\n\nHARDENED BY SPEC REVIEW (2 critical + 2 high + mediums found and fixed before implementation):\n- CRITICAL: the FIRST authenticator (agent_rooted bootstrap) and a SUBSEQUENT (backup) authenticator must NOT share the same authorization. If a backup could be enrolled on bearer-key ownership alone, an attacker who exfiltrates the tenant's role:user key could graft THEIR OWN hardware onto the tenant's root of trust with no theft of the real device — the exact 'soft recovery back door' docs/chain-of-custody-v2.md §9.3 deliberately rejects. Therefore: FIRST enrollment (agent_rooted, zero authenticators) needs role:user + ownership + a fresh registration attestation (nothing else to assert against — legitimate bootstrap). SUBSEQUENT enrollment (already human_anchored) ADDITIONALLY requires a fresh ASSERTION from an ALREADY-enrolled authenticator (Reauth purpose add_authenticator), mirroring how rotate-audit-key and revoke are gated.\n- CRITICAL: the last-authenticator revoke guard must be race-safe (SELECT ... FOR UPDATE / advisory lock), not an unlocked count — otherwise two concurrent revokes both pass and strip the tenant to zero authenticators (the doc's 'fatal event').\n- HIGH: the challenge must be consumed in its OWN committed transaction BEFORE attestation verification (mirroring Reauth.verify_and_consume), so a failed attestation does not un-burn the challenge; and no DB transaction may be held open across CPU-bound CBOR/COSE verification. Attestation fields are size-capped before decode.\n\nDESIGN DECISIONS (documented): (1) enrollment APPENDS a tenant_trust_upgraded / authenticator_enrolled audit entry; it never rewrites the append-only genesis. (2) FIRST authenticator flips agent_rooted->human_anchored via a GUARDED conditional update (audit tenant_trust_upgraded only if the flip actually happened). (3) revoking the LAST authenticator while human_anchored is FORBIDDEN (409); no auto-downgrade. (4) attestation policy reuses signup's rp_opts/Wax. (5) NOT headless — an interactive WebAuthn client + hardware touch completes it.",
+  "acceptance_criteria": [
+    {
+      "id": "AC-26.7.2.1",
+      "description": "A persisted, SINGLE-USE, TTL-bound WebAuthn REGISTRATION-challenge store is added for the stateless API. Only the `ReauthChallenge` PERSISTENCE SHAPE may be reused (the schema + the atomic single-use `update_all` consume pattern, web_authn/reauth.ex:191) — NOT `Reauth.issue_challenge/2` itself, which hard-requires an existing enrolled authenticator (list_by_tenant != []) and would make FIRST enrollment impossible. A NEW issuance function calls `Loopctl.WebAuthn.new_registration_challenge/1` directly (no existing-authenticator precondition), persists the challenge tenant+purpose-scoped with TTL ~300s, and consume is a single atomic `update_all` guarded on `used_at IS NULL AND expires_at > now` (0 rows => clean error; no TOCTOU). `tenant_id` is set programmatically, never cast. CLEANUP: whichever storage is chosen (new `webauthn_enrollment_challenges` table or a generalized reauth-challenge store), stale rows MUST be swept — either generalize `Loopctl.Workers.ReauthChallengeCleanupWorker`'s query to cover it or add an equivalent worker — with a regression test. No unbounded-growth table.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-26.7.2.2",
+      "description": "`POST /api/v1/tenants/:id/authenticators/challenge` issues a registration challenge (AC-26.7.2.1) and returns the publicKey creation options a browser WebAuthn client needs: challenge, challenge_id, expires_at, rp {id, name}, user {id, name, displayName}, pubKeyCredParams. rp.name is added to `Loopctl.WebAuthn.rp_opts/0`'s config (config.exs/dev.exs/test.exs currently carry only rp_id/origin) so the server — not a hard-coded JS client — serves it; user.id/name/displayName are derived server-side from the tenant (documented). If the tenant is ALREADY human_anchored, the response ALSO includes a fresh-assertion (reauth) challenge for an existing authenticator (purpose add_authenticator, via Reauth.issue_challenge/2) plus `reauth_required: true`, because a subsequent enrollment must prove possession of an existing device (see AC-26.7.2.3). Auth: the tenant's own role:user key (RequireRole) AND ownership (owns_tenant?/2). Available to an AGENT-ROOTED tenant — NOT tier-gated. Rate-limited (AC-26.7.2.7).",
+      "status": "pending"
+    },
+    {
+      "id": "AC-26.7.2.3",
+      "description": "`POST /api/v1/tenants/:id/authenticators` completes enrollment in a TWO-PHASE shape mirroring Reauth (NOT one Multi spanning the crypto): PHASE 1 — atomically CONSUME the registration challenge in its OWN committed transaction FIRST (so a later failure does not un-burn it); if the tenant is human_anchored, ALSO verify-and-consume the required fresh add_authenticator ASSERTION from an existing authenticator (Reauth.verify_and_consume(:add_authenticator)) — reject 401 if absent/invalid (this is the CRITICAL backup-enrollment gate). PHASE 2 — size-cap each attestation field BEFORE decode (mirror signup's @max_attestation_field_bytes / ensure_attestation_size/1) then verify the attestation via `WebAuthn.verify_registration/3` OUTSIDE any open transaction (CPU-bound CBOR/COSE — no DB connection held). PHASE 3 — only on success, open a DB-only Multi: insert the RootAuthenticator (RootAuthenticators.create/2 shape; store public_key verbatim as the term_to_binary blob verify_registration returns; unique (tenant_id, credential_id)); flip the tier via a GUARDED conditional update `UPDATE tenants SET trust_tier='human_anchored' WHERE id=? AND trust_tier='agent_rooted'` and append `tenant_trust_upgraded` (actor human:webauthn, old->new, authenticator fingerprint) ONLY if 1 row was affected, else append `authenticator_enrolled` (mirrors the guarded-update-then-check-rows idiom in reauth.ex persist_counter/2, closing the concurrent-double-first-enroll race). `friendly_name` is a request param validated 1..120 (default 'Authenticator' if absent). A per-tenant cap (reuse the signup constant 5) is enforced via a guarded/locked count -> 409 when exceeded. Requires role:user + ownership; NOT tier-gated.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-26.7.2.4",
+      "description": "Revoke: `POST /api/v1/tenants/:id/authenticators/revoke-challenge` issues a fresh-assertion challenge (Reauth purpose `revoke_authenticator`), then `DELETE /api/v1/tenants/:id/authenticators/:auth_id` carries the assertion, verified via `Reauth.verify_and_consume(:revoke_authenticator)` (mirrors the rotate-audit-key challenge+verify pair). Auth: role:user + ownership. RACE-SAFE LAST-AUTHENTICATOR GUARD: inside the delete transaction, `SELECT ... FOR UPDATE` the tenant's tenant_root_authenticators rows (mirror audit_chain.ex lock_and_read_previous/1 `lock: \"FOR UPDATE\"`) OR take a per-tenant `pg_try_advisory_xact_lock` (mirror token_usage.ex) BEFORE counting+deleting, so two concurrent revokes cannot both pass — revoking the LAST remaining authenticator while human_anchored returns 409 `last_authenticator` and deletes nothing. No auto-downgrade. Add a tenant-scoped `RootAuthenticators.delete/2` (none exists today) mirroring create/2's shape.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-26.7.2.5",
+      "description": "After a successful FIRST-authenticator enrollment, tenant.trust_tier == :human_anchored and a custody op RequireHumanAnchor previously 403'd now passes (subject to normal role/409/lineage rules). A test proves the round-trip: self-signup (agent_rooted) -> 403 on a custody op -> enroll challenge -> enroll (verify) -> tier human_anchored + a single tenant_trust_upgraded audit entry -> the same custody op now passes.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-26.7.2.6",
+      "description": "The FOUR new routes — `POST .../authenticators/challenge`, `POST .../authenticators`, `POST .../authenticators/revoke-challenge`, `DELETE .../authenticators/:auth_id` — are added to the default-deny guard test's @allowlist (test/loopctl_web/require_human_anchor_default_deny_test.exs) with an explicit written rationale (enroll IS the upgrade path — an agent-rooted caller is intended; revoke + subsequent-enroll are protected by fresh WebAuthn assertions, a stronger control than the tier gate). The route-count floor + representative-route assertions in that test still hold.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-26.7.2.7",
+      "description": "Beyond the blanket RateLimiter plug, the challenge + enroll + revoke-challenge actions consume a tighter per-tenant action budget via the config-resolved `Loopctl.RateLimiter` behaviour (bucket e.g. `enroll:actions:<tenant_id>`), mirroring signup_live.ex ensure_action_budget/1 — WebAuthn verification is abusable and must be bounded. Over-budget returns 429. Tested via the MockRateLimiter DI seam (no Application.put_env).",
+      "status": "pending"
+    },
+    {
+      "id": "AC-26.7.2.8",
+      "description": "Adversarial + isolation + concurrency coverage: (a) a forged/invalid attestation (MockWebAuthn -> {:error,_}) does NOT enroll and does NOT flip the tier, and does NOT un-burn the registration challenge (challenge stays consumed); (b) challenge replay/double-spend blocked; (c) expired challenge rejected; (d) cross-tenant enroll/revoke blocked (ownership + RLS); (e) revoking the last authenticator blocked, INCLUDING a concurrent-revoke race test (two simultaneous DELETEs against a 2-authenticator tenant must not both succeed — the FOR UPDATE/advisory lock holds); (f) SUBSEQUENT enrollment on a human_anchored tenant WITHOUT a valid existing-authenticator assertion is rejected 401 (the critical backup-enrollment gate); (g) a concurrent-double-FIRST-enrollment race writes exactly ONE tenant_trust_upgraded entry (guarded flip); (h) trust_tier never flips on ownership alone (no code path reaches human_anchored without a verified attestation); (i) credential_id unique constraint blocks re-enrolling the same authenticator. Every new test file async:true, config-based DI (no Application.put_env), Mox verify_on_exit!, tenant-isolation case.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-26.7.2.9",
+      "description": "Shared fingerprint helper + MCP + docs. (a) The authenticator-fingerprint algorithm currently private (`fingerprint/1`, tenants.ex:474, used by signup's audit entry) is made a PUBLIC shared function (on Loopctl.Tenants or a small shared helper module) and called by BOTH signup and the new enrollment audit-entry builders, so the two ceremonies can't drift; the enrollment Multi's owning module is named explicitly in the impl. (b) MCP server gains thin tools `request_authenticator_challenge` + `enroll_authenticator` (and revoke) that drive the ceremony from an orchestrator with a browser/human in the loop; tool descriptions state PLAINLY that completing enrollment requires an interactive WebAuthn client + hardware touch (an agent cannot produce the attestation itself) and that first enrollment upgrades the tenant to the custody tier. Package version bumped. (c) docs/chain-of-custody-v2.md §9.2/§9.3: replace the 'deferred to US-26.7.2' annotations with the real enroll/revoke endpoints, the first-vs-subsequent auth distinction, the last-authenticator policy, and the append-not-regenesis upgrade semantics. No doc claim may overstate what the code enforces.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-26.7.2.10",
+      "description": "OpenApiSpex operations registered for all new endpoints (with a regression assertion mirroring the /signup one). `mix precommit` passes clean (compile --warnings-as-errors, format, credo --strict, dialyzer, full suite green). Do NOT weaken L0 for the ops that keep it — this story ADDS the enrollment that establishes L0; the existing audit-key-rotation fresh-assertion gate and the RequireHumanAnchor custody gate are unchanged.",
+      "status": "pending"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "TC-26.7.2.1",
+      "name": "Full upgrade round-trip: agent_rooted -> first enroll -> human_anchored -> custody op passes",
+      "type": "integration",
+      "preconditions": ["An agent_rooted tenant from POST /api/v1/signup + its role:user key; MockWebAuthn accepts the attestation"],
+      "steps": ["Custody op (create project) -> 403 custody_tier_required", "POST .../authenticators/challenge", "POST .../authenticators with the attestation", "Retry the custody op"],
+      "expected_results": ["Initial op 403s", "Enroll 201; trust_tier == human_anchored", "Exactly one tenant_trust_upgraded audit entry", "Retried custody op passes the tier gate"]
+    },
+    {
+      "id": "TC-26.7.2.2",
+      "name": "Subsequent (backup) enrollment REQUIRES a fresh assertion from an existing authenticator",
+      "type": "integration",
+      "preconditions": ["A human_anchored tenant with one authenticator"],
+      "steps": ["Request challenge -> response includes reauth_required + an add_authenticator reauth challenge", "Enroll a 2nd authenticator WITHOUT the existing-authenticator assertion", "Enroll a 2nd authenticator WITH a valid existing-authenticator assertion"],
+      "expected_results": ["Without the assertion -> 401 (backup-enrollment gate)", "With it -> 201; a second RootAuthenticator exists; trust_tier stays human_anchored; an authenticator_enrolled (not tenant_trust_upgraded) audit entry"]
+    },
+    {
+      "id": "TC-26.7.2.3",
+      "name": "Forged attestation: no enroll, no flip, challenge stays consumed",
+      "type": "integration",
+      "preconditions": ["An agent_rooted tenant; MockWebAuthn.verify_registration -> {:error, :invalid_attestation}"],
+      "steps": ["Get a challenge", "POST the bad attestation", "Attempt to reuse the same challenge_id"],
+      "expected_results": ["401 webauthn_failed; no authenticator; trust_tier stays agent_rooted; no audit upgrade", "The challenge was consumed in phase 1 and cannot be replayed"]
+    },
+    {
+      "id": "TC-26.7.2.4",
+      "name": "Registration challenge is single-use and TTL-bound",
+      "type": "integration",
+      "preconditions": ["An agent_rooted tenant"],
+      "steps": ["Issue + successfully consume a challenge", "Replay the same challenge_id", "Attempt an expired challenge"],
+      "expected_results": ["Replay rejected", "Expired rejected", "No second authenticator produced"]
+    },
+    {
+      "id": "TC-26.7.2.5",
+      "name": "Revoke requires a fresh assertion, cannot remove the last authenticator, and is race-safe",
+      "type": "integration",
+      "preconditions": ["A human_anchored tenant with one authenticator; then two"],
+      "steps": ["DELETE the only authenticator with a valid assertion", "With two, run two concurrent DELETEs each with a valid assertion", "DELETE with missing/invalid assertion"],
+      "expected_results": ["Last-authenticator DELETE -> 409 last_authenticator (retained, still human_anchored)", "Concurrent DELETEs on a 2-authenticator tenant do NOT both succeed (lock holds; >=1 remains)", "Missing/invalid assertion -> 401"]
+    },
+    {
+      "id": "TC-26.7.2.6",
+      "name": "Cross-tenant enroll/revoke blocked",
+      "type": "integration",
+      "preconditions": ["Tenant A (agent_rooted) and tenant B each with keys"],
+      "steps": ["A's key targets B's tenant id for challenge/enroll/revoke"],
+      "expected_results": ["403 Forbidden for every cross-tenant attempt; B unchanged"]
+    },
+    {
+      "id": "TC-26.7.2.7",
+      "name": "Concurrent double-FIRST enrollment writes exactly one upgrade entry; enroll ceremony is rate-limited",
+      "type": "integration",
+      "preconditions": ["An agent_rooted tenant; MockRateLimiter denies after a low cap"],
+      "steps": ["Two concurrent first-enrollments each with a distinct valid attestation", "Separately, exceed the enroll action budget"],
+      "expected_results": ["trust_tier ends human_anchored with EXACTLY ONE tenant_trust_upgraded entry (guarded flip)", "Over-budget -> 429"]
+    }
+  ],
+  "technical_notes": [
+    "Reuse (recon-verified): Loopctl.WebAuthn.new_registration_challenge/1 + verify_registration/3 + rp_opts/0 (Wax behind DI; MockWebAuthn in test). RootAuthenticators.create/2 + count_by_tenant/1 + list_by_tenant/2 (add delete/2). Reauth.issue_challenge/2 + verify_and_consume/3 for BOTH the subsequent-enroll add_authenticator assertion AND the revoke_authenticator assertion (new purposes). owns_tenant?/2 (tenant_audit_key_controller.ex:369). Audit.log_in_multi/3. Tenant.activate_after_enrollment_changeset/1 is the template for a Multi-only tier change — but the flip must be a GUARDED conditional update, not a blind change/2 (see AC-26.7.2.3).",
+    "TWO-PHASE, never one Multi across crypto (mirror Reauth.verify_and_consume): consume challenge (+ verify add_authenticator assertion when human_anchored) in committed transactions; size-cap + verify attestation OUTSIDE any transaction; then a DB-only Multi for insert + guarded flip + audit. This closes the un-burn-on-failure hole AND the connection-held-across-CBOR hole.",
+    "Registration challenge persistence: reuse ONLY the ReauthChallenge schema + atomic update_all consume SHAPE; back the challenge endpoint with a NEW issuance fn (no existing-authenticator precondition). Ensure a cleanup sweep covers the new storage.",
+    "Guarded tier flip: `UPDATE tenants SET trust_tier='human_anchored' WHERE id=? AND trust_tier='agent_rooted'` returning affected rows; audit tenant_trust_upgraded iff 1 row, else authenticator_enrolled. Mirrors persist_counter/2's guarded-update idiom (reauth.ex:227).",
+    "Race-safe revoke: SELECT ... FOR UPDATE the tenant's authenticator rows (audit_chain.ex:289 pattern) or pg_try_advisory_xact_lock (token_usage.ex:450) before count+delete; 409 last_authenticator if it would reach zero while human_anchored.",
+    "COSE key: verify_registration returns public_key as :erlang.term_to_binary(cose_key) — store verbatim via create_changeset.",
+    "Make fingerprint/1 public/shared so signup and enrollment audit entries can't drift. Name the module that owns the enrollment Multi (a new context, e.g. Loopctl.Tenants.Enrollment, or Loopctl.Tenants) explicitly.",
+    "Add rp.name to Loopctl.WebAuthn.rp_opts/0 config (config.exs/dev.exs/test.exs) so the challenge endpoint serves rp/user/pubKeyCredParams server-side; friendly_name is a validated (1..120) request param.",
+    "Routes next to the rotate-audit-key trio in the authenticated /api/v1 scope, role:user; NOT behind RequireHumanAnchor; all four added to the default-deny allowlist.",
+    "Full workflow: this spec was reviewed BEFORE implementation (2 critical + 2 high + mediums fixed here). Implement, then diff-stage enhanced review, fix all findings, CI-green squash-merge, verify auto-deploy + npm autopublish."
+  ],
+  "dependencies": ["US-26.7.1"],
+  "estimated_hours": 24
+}

--- a/lib/loopctl/api_spec/schemas.ex
+++ b/lib/loopctl/api_spec/schemas.ex
@@ -481,6 +481,183 @@ defmodule Loopctl.ApiSpec.Schemas do
     })
   end
 
+  defmodule AuthenticatorChallengeResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "AuthenticatorChallengeResponse",
+      description:
+        "Step 1 of the opt-in WebAuthn enrollment ceremony (US-26.7.2). Returns the " <>
+          "publicKey creation options a browser WebAuthn client needs to call " <>
+          "navigator.credentials.create(). If the tenant is already human_anchored, " <>
+          "also includes a fresh-assertion (reauth) challenge for an EXISTING " <>
+          "authenticator (`reauth_required: true`) — a subsequent enrollment must " <>
+          "prove possession of an already-enrolled device before adding a backup.",
+      type: :object,
+      required: [:data],
+      properties: %{
+        data: %Schema{
+          type: :object,
+          required: [:challenge_id, :challenge, :expires_at, :rp, :user, :pub_key_cred_params],
+          properties: %{
+            challenge_id: %Schema{
+              type: :string,
+              format: :uuid,
+              description: "Opaque single-use handle for the stored registration challenge"
+            },
+            challenge: %Schema{
+              type: :string,
+              description:
+                "Base64url-encoded challenge bytes to feed into navigator.credentials.create()"
+            },
+            expires_at: %Schema{type: :string, format: :"date-time"},
+            rp: %Schema{
+              type: :object,
+              properties: %{
+                id: %Schema{type: :string, description: "Relying party id"},
+                name: %Schema{type: :string, description: "Relying party display name"}
+              }
+            },
+            user: %Schema{
+              type: :object,
+              properties: %{
+                id: %Schema{
+                  type: :string,
+                  description: "Base64url opaque per-tenant WebAuthn user handle"
+                },
+                name: %Schema{type: :string},
+                display_name: %Schema{type: :string}
+              }
+            },
+            pub_key_cred_params: %Schema{
+              type: :array,
+              items: %Schema{type: :object},
+              description: "Accepted public key algorithms (ES256, RS256)"
+            },
+            reauth_required: %Schema{
+              type: :boolean,
+              description: "true when this is a subsequent (backup) enrollment"
+            },
+            reauth_challenge: %Schema{
+              type: :object,
+              nullable: true,
+              description: "Present only when reauth_required is true",
+              properties: %{
+                challenge_id: %Schema{type: :string, format: :uuid},
+                challenge: %Schema{type: :string},
+                allowed_credentials: %Schema{type: :array, items: %Schema{type: :string}},
+                rp_id: %Schema{type: :string},
+                expires_at: %Schema{type: :string, format: :"date-time"}
+              }
+            }
+          }
+        }
+      }
+    })
+  end
+
+  defmodule EnrollAuthenticatorRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "EnrollAuthenticatorRequest",
+      description:
+        "Step 2 of the opt-in WebAuthn enrollment ceremony. Carries the WebAuthn " <>
+          "attestation produced by navigator.credentials.create(), keyed to the " <>
+          "challenge_id from step 1. All binary fields are base64url encoded. " <>
+          "`reauth_assertion` is REQUIRED (and verified) when the tenant is already " <>
+          "human_anchored — a fresh assertion from an existing authenticator.",
+      type: :object,
+      required: [:challenge_id, :attestation_object, :client_data_json, :credential_id],
+      properties: %{
+        challenge_id: %Schema{type: :string, format: :uuid},
+        attestation_object: %Schema{type: :string, description: "Base64url attestation object"},
+        client_data_json: %Schema{type: :string, description: "Base64url raw client data JSON"},
+        credential_id: %Schema{type: :string, description: "Base64url credential id"},
+        friendly_name: %Schema{
+          type: :string,
+          description: "Operator-supplied label (1..120 chars, default \"Authenticator\")"
+        },
+        reauth_assertion: WebAuthnAssertion
+      }
+    })
+  end
+
+  defmodule AuthenticatorEnrollResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "AuthenticatorEnrollResponse",
+      description: "Result of a successful authenticator enrollment.",
+      type: :object,
+      required: [:data],
+      properties: %{
+        data: %Schema{
+          type: :object,
+          properties: %{
+            tenant_id: %Schema{type: :string, format: :uuid},
+            trust_tier: %Schema{type: :string, enum: ["agent_rooted", "human_anchored"]},
+            upgraded: %Schema{
+              type: :boolean,
+              description: "true iff THIS call flipped the tenant to human_anchored"
+            },
+            authenticator: %Schema{
+              type: :object,
+              properties: %{
+                id: %Schema{type: :string, format: :uuid},
+                friendly_name: %Schema{type: :string},
+                attestation_format: %Schema{type: :string},
+                inserted_at: %Schema{type: :string, format: :"date-time"}
+              }
+            }
+          }
+        }
+      }
+    })
+  end
+
+  defmodule RevokeAuthenticatorRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "RevokeAuthenticatorRequest",
+      description:
+        "Carries the WebAuthn assertion verified against the STORED " <>
+          "revoke_authenticator challenge before the target authenticator is deleted.",
+      type: :object,
+      required: [:webauthn_assertion],
+      properties: %{
+        webauthn_assertion: WebAuthnAssertion
+      }
+    })
+  end
+
+  defmodule RevokeAuthenticatorResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "RevokeAuthenticatorResponse",
+      description: "Result of a successful authenticator revocation.",
+      type: :object,
+      required: [:data],
+      properties: %{
+        data: %Schema{
+          type: :object,
+          properties: %{
+            tenant_id: %Schema{type: :string, format: :uuid},
+            authenticator_id: %Schema{type: :string, format: :uuid},
+            revoked: %Schema{type: :boolean}
+          }
+        }
+      }
+    })
+  end
+
   # ---------- API Keys ----------
 
   defmodule ApiKeyCreateRequest do

--- a/lib/loopctl/tenants.ex
+++ b/lib/loopctl/tenants.ex
@@ -469,9 +469,18 @@ defmodule Loopctl.Tenants do
     end)
   end
 
-  # Short, non-reversible label for the audit entry so we can tell
-  # authenticators apart in human-readable logs.
-  defp fingerprint(credential_id) when is_binary(credential_id) do
+  @doc """
+  Short, non-reversible label for an authenticator's `credential_id`, used in
+  audit-entry `new_state`/`old_state` payloads so authenticators can be told
+  apart in human-readable logs without ever persisting the raw credential id.
+
+  Public (US-26.7.2) so BOTH the signup ceremony (`signup/1`, above) and the
+  opt-in trust-tier upgrade ceremony (`Loopctl.Tenants.Enrollment`) compute
+  the identical fingerprint — a single source of truth so the two ceremonies
+  can't drift.
+  """
+  @spec fingerprint(binary()) :: String.t()
+  def fingerprint(credential_id) when is_binary(credential_id) do
     :crypto.hash(:sha256, credential_id)
     |> Base.encode16(case: :lower)
     |> String.slice(0, 16)

--- a/lib/loopctl/tenants/enrollment.ex
+++ b/lib/loopctl/tenants/enrollment.ex
@@ -4,7 +4,7 @@ defmodule Loopctl.Tenants.Enrollment do
   trust-tier upgrade ceremony (agent_rooted -> human_anchored) and for
   authenticator revocation.
 
-  `enroll/2` is PHASE 3 of the enrollment ceremony (AC-26.7.2.3). By the
+  `enroll/3` is PHASE 3 of the enrollment ceremony (AC-26.7.2.3). By the
   time it is called, the caller (`LoopctlWeb.TenantAuthenticatorController`)
   has already, in strictly this order:
 
@@ -21,12 +21,12 @@ defmodule Loopctl.Tenants.Enrollment do
        (`Loopctl.WebAuthn.verify_registration/3`) OUTSIDE any open
        transaction (CPU-bound CBOR/COSE work never holds a DB connection).
 
-  So `enroll/2` performs NO crypto — it is a pure, atomic DB transaction:
+  So `enroll/3` performs NO crypto — it is a pure, atomic DB transaction:
   lock the tenant row, enforce the per-tenant authenticator cap, insert the
   `RootAuthenticator`, GUARD-flip `trust_tier` from `:agent_rooted` to
   `:human_anchored`, and append exactly one audit entry.
 
-  Both `enroll/2` and `revoke/2` open with a `SELECT ... FOR UPDATE` on the
+  Both `enroll/3` and `revoke/2` open with a `SELECT ... FOR UPDATE` on the
   TENANT row itself (mirroring `Loopctl.AuditChain`'s "lock the latest row to
   serialize concurrent appends" idiom, audit_chain.ex:289) — NOT the
   authenticator rows. A tenant's FIRST enrollment has ZERO authenticator
@@ -61,24 +61,44 @@ defmodule Loopctl.Tenants.Enrollment do
           upgraded: boolean()
         }
 
-  @doc "The per-tenant authenticator cap enforced by `enroll/2`."
+  @doc "The per-tenant authenticator cap enforced by `enroll/3`."
   @spec max_authenticators() :: pos_integer()
   def max_authenticators, do: @max_authenticators
 
   @doc """
   PHASE 3 of the enrollment ceremony (AC-26.7.2.3): a DB-only `Ecto.Multi`
-  that locks the tenant row, enforces the per-tenant authenticator cap,
-  inserts the `RootAuthenticator`, GUARD-flips `trust_tier` from
+  that locks the tenant row, RE-CHECKS the backup-enrollment gate against the
+  freshly-locked authoritative tier, enforces the per-tenant authenticator
+  cap, inserts the `RootAuthenticator`, GUARD-flips `trust_tier` from
   `:agent_rooted` to `:human_anchored` via a conditional `UPDATE ... WHERE
   trust_tier = 'agent_rooted'` (a no-op, zero-row update if the tenant is
   already `human_anchored` or a racing transaction already flipped it), and
   appends exactly one audit entry — `tenant_trust_upgraded` when THIS call
-  performed the flip, `authenticator_enrolled` otherwise. This closes the
-  concurrent-double-first-enroll race (AC-26.7.2.8g): whichever transaction's
-  `SELECT ... FOR UPDATE` on the tenant row wins the lock flips the tier and
-  logs the upgrade; the other re-reads the (now `human_anchored`) tenant
-  under its own lock acquisition, so its flip affects zero rows and it logs
-  a plain enrollment instead.
+  performed the flip, `authenticator_enrolled` otherwise.
+
+  `assertion_verified?` records whether PHASE 1 actually verified AND consumed
+  a fresh `add_authenticator` assertion from an EXISTING authenticator for
+  THIS request. The critical invariant — a backup authenticator can only be
+  added to an already-`human_anchored` tenant with proof of possession of an
+  existing device — is enforced HERE, under the lock, NOT only in the
+  controller's pre-lock read:
+
+    * `assert_gate/2` runs AFTER `lock_tenant/2`, against the freshly-locked
+      authoritative `trust_tier`. If the locked tier is `:human_anchored` and
+      `assertion_verified?` is not `true`, the Multi is ABORTED with
+      `{:error, :reauth_required}` BEFORE `Multi.insert(:authenticator, ...)`.
+
+  This closes the concurrent-double-FIRST-enroll race (AC-26.7.2.8g) as a
+  SECURITY property, not just an audit-count one: two concurrent enrollments
+  on an `agent_rooted` tenant each read `agent_rooted` pre-lock and skip the
+  assertion. The one that wins the tenant-row lock flips to `human_anchored`
+  and enrolls (logging `tenant_trust_upgraded`); the loser then acquires the
+  lock, sees `human_anchored` + `assertion_verified? == false`, and is
+  REJECTED `:reauth_required` — it MUST retry with an `add_authenticator`
+  assertion. So an attacker holding a stolen `role:user` key + their own
+  hardware can never graft a second device onto a tenant that a legitimate
+  first-enroll just anchored: exactly one enrollment wins, and every
+  subsequent device must prove possession of an existing one.
 
   `attrs` is the already-verified attestation result, e.g.
   `%{credential_id:, public_key:, attestation_format:, sign_count:,
@@ -86,15 +106,20 @@ defmodule Loopctl.Tenants.Enrollment do
   `:erlang.term_to_binary(cose_key)` blob `WebAuthn.verify_registration/3`
   returns (`RootAuthenticator.create_changeset/2` stores it as-is).
   """
-  @spec enroll(Ecto.UUID.t(), map()) ::
+  @spec enroll(Ecto.UUID.t(), map(), boolean()) ::
           {:ok, enroll_result()}
           | {:error, :not_found}
+          | {:error, :reauth_required}
           | {:error, :too_many_authenticators}
           | {:error, Ecto.Changeset.t()}
-  def enroll(tenant_id, attrs) when is_binary(tenant_id) and is_map(attrs) do
+  def enroll(tenant_id, attrs, assertion_verified?)
+      when is_binary(tenant_id) and is_map(attrs) and is_boolean(assertion_verified?) do
     multi =
       Multi.new()
       |> Multi.run(:tenant, fn repo, _changes -> lock_tenant(repo, tenant_id) end)
+      |> Multi.run(:assert_gate, fn _repo, %{tenant: tenant} ->
+        assert_gate(tenant, assertion_verified?)
+      end)
       |> Multi.run(:check_cap, fn repo, _changes -> check_cap(repo, tenant_id) end)
       |> Multi.insert(:authenticator, fn _changes ->
         RootAuthenticator.create_changeset(%RootAuthenticator{tenant_id: tenant_id}, attrs)
@@ -110,6 +135,9 @@ defmodule Loopctl.Tenants.Enrollment do
       {:error, :tenant, :not_found, _changes} ->
         {:error, :not_found}
 
+      {:error, :assert_gate, :reauth_required, _changes} ->
+        {:error, :reauth_required}
+
       {:error, :check_cap, :too_many_authenticators, _changes} ->
         {:error, :too_many_authenticators}
 
@@ -121,6 +149,13 @@ defmodule Loopctl.Tenants.Enrollment do
     end
   end
 
+  # Under-lock backup-enrollment gate. A first enrollment (locked tier still
+  # `agent_rooted`) needs no assertion — the flip happens later in THIS same
+  # transaction. An already-`human_anchored` tenant needs a verified
+  # `add_authenticator` assertion; without one, abort before the insert.
+  defp assert_gate(%Tenant{trust_tier: :human_anchored}, false), do: {:error, :reauth_required}
+  defp assert_gate(%Tenant{}, _assertion_verified?), do: {:ok, :ok}
+
   @doc """
   Revokes a single authenticator (AC-26.7.2.4). Callers must have already
   verified a fresh `revoke_authenticator` reauth assertion
@@ -128,7 +163,7 @@ defmodule Loopctl.Tenants.Enrollment do
   no crypto, only the race-safe DB delete.
 
   RACE-SAFE LAST-AUTHENTICATOR GUARD: locks the tenant row `FOR UPDATE`
-  (same mechanism as `enroll/2`) before counting the tenant's authenticators,
+  (same mechanism as `enroll/3`) before counting the tenant's authenticators,
   so two concurrent revokes against a 2-authenticator tenant cannot both
   pass — the second waits for the first's transaction to commit, then
   re-counts and sees only 1 remaining. Revoking the LAST authenticator while

--- a/lib/loopctl/tenants/enrollment.ex
+++ b/lib/loopctl/tenants/enrollment.ex
@@ -1,0 +1,281 @@
+defmodule Loopctl.Tenants.Enrollment do
+  @moduledoc """
+  US-26.7.2 — owns the DB-only `Ecto.Multi` for the opt-in WebAuthn
+  trust-tier upgrade ceremony (agent_rooted -> human_anchored) and for
+  authenticator revocation.
+
+  `enroll/2` is PHASE 3 of the enrollment ceremony (AC-26.7.2.3). By the
+  time it is called, the caller (`LoopctlWeb.TenantAuthenticatorController`)
+  has already, in strictly this order:
+
+    1. Consumed the registration challenge in its OWN committed transaction
+       (`Loopctl.WebAuthn.Enrollment.consume/2`) — and, if the tenant is
+       already `human_anchored`, ALSO verified + consumed a fresh
+       `add_authenticator` reauth assertion
+       (`Loopctl.WebAuthn.Reauth.verify_and_consume/3`) from an
+       ALREADY-enrolled authenticator. This is the critical
+       anti-soft-recovery-backdoor gate: a stolen `role: :user` API key
+       alone can never add a backup authenticator to an already-anchored
+       tenant.
+    2. Size-capped and verified the WebAuthn attestation
+       (`Loopctl.WebAuthn.verify_registration/3`) OUTSIDE any open
+       transaction (CPU-bound CBOR/COSE work never holds a DB connection).
+
+  So `enroll/2` performs NO crypto — it is a pure, atomic DB transaction:
+  lock the tenant row, enforce the per-tenant authenticator cap, insert the
+  `RootAuthenticator`, GUARD-flip `trust_tier` from `:agent_rooted` to
+  `:human_anchored`, and append exactly one audit entry.
+
+  Both `enroll/2` and `revoke/2` open with a `SELECT ... FOR UPDATE` on the
+  TENANT row itself (mirroring `Loopctl.AuditChain`'s "lock the latest row to
+  serialize concurrent appends" idiom, audit_chain.ex:289) — NOT the
+  authenticator rows. A tenant's FIRST enrollment has ZERO authenticator
+  rows to lock, so a `FOR UPDATE` on `tenant_root_authenticators` would lock
+  nothing and fail to serialize the concurrent-double-first-enroll race
+  (AC-26.7.2.8g) or the cap-check race. Locking the tenant row is the
+  transaction-scoped, per-tenant mutual-exclusion mechanism the spec
+  explicitly allows as an alternative to a `pg_try_advisory_xact_lock`
+  (`token_usage.ex:450`) — and, unlike a derived advisory-lock key, it also
+  gives us the CURRENT `trust_tier` in the same read, which the guarded flip
+  and the revoke last-authenticator guard both need.
+  """
+
+  import Ecto.Query
+
+  alias Ecto.Multi
+  alias Loopctl.AdminRepo
+  alias Loopctl.Audit
+  alias Loopctl.Tenants
+  alias Loopctl.Tenants.RootAuthenticator
+  alias Loopctl.Tenants.RootAuthenticators
+  alias Loopctl.Tenants.Tenant
+
+  # Reuses the signup ceremony's per-tenant cap (Loopctl.Tenants,
+  # @max_authenticators_per_signup) so a tenant can never end up with more
+  # enrolled authenticators via the upgrade path than via original signup.
+  @max_authenticators 5
+
+  @type enroll_result :: %{
+          tenant: Tenant.t(),
+          authenticator: RootAuthenticator.t(),
+          upgraded: boolean()
+        }
+
+  @doc "The per-tenant authenticator cap enforced by `enroll/2`."
+  @spec max_authenticators() :: pos_integer()
+  def max_authenticators, do: @max_authenticators
+
+  @doc """
+  PHASE 3 of the enrollment ceremony (AC-26.7.2.3): a DB-only `Ecto.Multi`
+  that locks the tenant row, enforces the per-tenant authenticator cap,
+  inserts the `RootAuthenticator`, GUARD-flips `trust_tier` from
+  `:agent_rooted` to `:human_anchored` via a conditional `UPDATE ... WHERE
+  trust_tier = 'agent_rooted'` (a no-op, zero-row update if the tenant is
+  already `human_anchored` or a racing transaction already flipped it), and
+  appends exactly one audit entry — `tenant_trust_upgraded` when THIS call
+  performed the flip, `authenticator_enrolled` otherwise. This closes the
+  concurrent-double-first-enroll race (AC-26.7.2.8g): whichever transaction's
+  `SELECT ... FOR UPDATE` on the tenant row wins the lock flips the tier and
+  logs the upgrade; the other re-reads the (now `human_anchored`) tenant
+  under its own lock acquisition, so its flip affects zero rows and it logs
+  a plain enrollment instead.
+
+  `attrs` is the already-verified attestation result, e.g.
+  `%{credential_id:, public_key:, attestation_format:, sign_count:,
+  friendly_name:}` — `public_key` must be the verbatim
+  `:erlang.term_to_binary(cose_key)` blob `WebAuthn.verify_registration/3`
+  returns (`RootAuthenticator.create_changeset/2` stores it as-is).
+  """
+  @spec enroll(Ecto.UUID.t(), map()) ::
+          {:ok, enroll_result()}
+          | {:error, :not_found}
+          | {:error, :too_many_authenticators}
+          | {:error, Ecto.Changeset.t()}
+  def enroll(tenant_id, attrs) when is_binary(tenant_id) and is_map(attrs) do
+    multi =
+      Multi.new()
+      |> Multi.run(:tenant, fn repo, _changes -> lock_tenant(repo, tenant_id) end)
+      |> Multi.run(:check_cap, fn repo, _changes -> check_cap(repo, tenant_id) end)
+      |> Multi.insert(:authenticator, fn _changes ->
+        RootAuthenticator.create_changeset(%RootAuthenticator{tenant_id: tenant_id}, attrs)
+      end)
+      |> Multi.update_all(:flip_tier, flip_query(tenant_id), set: [trust_tier: :human_anchored])
+      |> Multi.run(:reloaded_tenant, fn repo, _changes -> {:ok, repo.get!(Tenant, tenant_id)} end)
+      |> Audit.log_in_multi(:audit, &build_enroll_audit_attrs(tenant_id, &1))
+
+    case AdminRepo.transaction(multi) do
+      {:ok, %{authenticator: auth, reloaded_tenant: tenant, flip_tier: {flipped, _}}} ->
+        {:ok, %{tenant: tenant, authenticator: auth, upgraded: flipped == 1}}
+
+      {:error, :tenant, :not_found, _changes} ->
+        {:error, :not_found}
+
+      {:error, :check_cap, :too_many_authenticators, _changes} ->
+        {:error, :too_many_authenticators}
+
+      {:error, :authenticator, %Ecto.Changeset{} = changeset, _changes} ->
+        {:error, changeset}
+
+      {:error, _step, reason, _changes} ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Revokes a single authenticator (AC-26.7.2.4). Callers must have already
+  verified a fresh `revoke_authenticator` reauth assertion
+  (`Loopctl.WebAuthn.Reauth.verify_and_consume/3`) — this function performs
+  no crypto, only the race-safe DB delete.
+
+  RACE-SAFE LAST-AUTHENTICATOR GUARD: locks the tenant row `FOR UPDATE`
+  (same mechanism as `enroll/2`) before counting the tenant's authenticators,
+  so two concurrent revokes against a 2-authenticator tenant cannot both
+  pass — the second waits for the first's transaction to commit, then
+  re-counts and sees only 1 remaining. Revoking the LAST authenticator while
+  `human_anchored` is refused with `{:error, :last_authenticator}` — no
+  auto-downgrade to `agent_rooted`.
+  """
+  @spec revoke(Ecto.UUID.t(), Ecto.UUID.t()) ::
+          {:ok, RootAuthenticator.t()}
+          | {:error, :not_found}
+          | {:error, :last_authenticator}
+  def revoke(tenant_id, authenticator_id)
+      when is_binary(tenant_id) and is_binary(authenticator_id) do
+    multi =
+      Multi.new()
+      |> Multi.run(:tenant, fn repo, _changes -> lock_tenant(repo, tenant_id) end)
+      |> Multi.run(:target, fn repo, _changes ->
+        find_authenticator(repo, tenant_id, authenticator_id)
+      end)
+      |> Multi.run(:guard_last, fn repo, %{tenant: tenant} ->
+        guard_last_authenticator(repo, tenant_id, tenant)
+      end)
+      |> Multi.run(:deleted, fn _repo, %{target: auth} ->
+        RootAuthenticators.delete(tenant_id, auth.id)
+      end)
+      |> Audit.log_in_multi(:audit, fn %{deleted: auth} ->
+        %{
+          tenant_id: tenant_id,
+          entity_type: "tenant",
+          entity_id: tenant_id,
+          action: "authenticator_revoked",
+          actor_type: "human",
+          actor_id: nil,
+          actor_label: "human:webauthn",
+          old_state: %{
+            "authenticator_fingerprint" => Tenants.fingerprint(auth.credential_id),
+            "friendly_name" => auth.friendly_name
+          }
+        }
+      end)
+
+    case AdminRepo.transaction(multi) do
+      {:ok, %{deleted: auth}} ->
+        {:ok, auth}
+
+      {:error, :tenant, :not_found, _changes} ->
+        {:error, :not_found}
+
+      {:error, :target, :not_found, _changes} ->
+        {:error, :not_found}
+
+      {:error, :guard_last, :last_authenticator, _changes} ->
+        {:error, :last_authenticator}
+
+      {:error, _step, reason, _changes} ->
+        {:error, reason}
+    end
+  end
+
+  # Locks the tenant row for the duration of the enclosing transaction —
+  # the single mechanism serializing every authenticator mutation
+  # (enroll AND revoke) for this tenant, including the zero-row first-enroll
+  # case a `FOR UPDATE` on `tenant_root_authenticators` could not cover.
+  defp lock_tenant(repo, tenant_id) do
+    case from(t in Tenant, where: t.id == ^tenant_id, lock: "FOR UPDATE") |> repo.one() do
+      nil -> {:error, :not_found}
+      tenant -> {:ok, tenant}
+    end
+  end
+
+  defp check_cap(repo, tenant_id) do
+    count =
+      from(a in RootAuthenticator, where: a.tenant_id == ^tenant_id, select: count(a.id))
+      |> repo.one()
+
+    if count >= @max_authenticators do
+      {:error, :too_many_authenticators}
+    else
+      {:ok, count}
+    end
+  end
+
+  defp flip_query(tenant_id) do
+    from(t in Tenant, where: t.id == ^tenant_id and t.trust_tier == :agent_rooted)
+  end
+
+  defp find_authenticator(repo, tenant_id, authenticator_id) do
+    query =
+      from a in RootAuthenticator,
+        where: a.tenant_id == ^tenant_id and a.id == ^authenticator_id
+
+    case repo.one(query) do
+      nil -> {:error, :not_found}
+      authenticator -> {:ok, authenticator}
+    end
+  end
+
+  # Revoking the tenant's LAST authenticator while human_anchored is a
+  # deliberate 409 — the docs' "fatal event" (chain-of-custody-v2.md §9.3).
+  # No auto-downgrade to agent_rooted is ever performed.
+  defp guard_last_authenticator(repo, tenant_id, %Tenant{trust_tier: :human_anchored}) do
+    count =
+      from(a in RootAuthenticator, where: a.tenant_id == ^tenant_id, select: count(a.id))
+      |> repo.one()
+
+    if count <= 1 do
+      {:error, :last_authenticator}
+    else
+      {:ok, count}
+    end
+  end
+
+  defp guard_last_authenticator(_repo, _tenant_id, %Tenant{}), do: {:ok, :not_gated}
+
+  defp build_enroll_audit_attrs(tenant_id, %{flip_tier: {flipped, _}} = changes) do
+    auth = changes.authenticator
+    old_tenant = changes.tenant
+    new_tenant = changes.reloaded_tenant
+
+    if flipped == 1 do
+      %{
+        tenant_id: tenant_id,
+        entity_type: "tenant",
+        entity_id: tenant_id,
+        action: "tenant_trust_upgraded",
+        actor_type: "human",
+        actor_id: nil,
+        actor_label: "human:webauthn",
+        old_state: %{"trust_tier" => Atom.to_string(old_tenant.trust_tier)},
+        new_state: %{
+          "trust_tier" => Atom.to_string(new_tenant.trust_tier),
+          "authenticator_fingerprint" => Tenants.fingerprint(auth.credential_id)
+        }
+      }
+    else
+      %{
+        tenant_id: tenant_id,
+        entity_type: "tenant",
+        entity_id: tenant_id,
+        action: "authenticator_enrolled",
+        actor_type: "human",
+        actor_id: nil,
+        actor_label: "human:webauthn",
+        new_state: %{
+          "authenticator_fingerprint" => Tenants.fingerprint(auth.credential_id),
+          "friendly_name" => auth.friendly_name
+        }
+      }
+    end
+  end
+end

--- a/lib/loopctl/tenants/root_authenticators.ex
+++ b/lib/loopctl/tenants/root_authenticators.ex
@@ -63,4 +63,34 @@ defmodule Loopctl.Tenants.RootAuthenticators do
     |> RootAuthenticator.create_changeset(attrs)
     |> AdminRepo.insert()
   end
+
+  @doc """
+  US-26.7.2 — deletes a single authenticator, scoped to the tenant (mirrors
+  `create/2`'s tenant-scoped shape). Returns `{:error, :not_found}` if the
+  row doesn't exist or belongs to a different tenant, so a cross-tenant
+  delete attempt fails closed instead of raising.
+
+  Callers that need the RACE-SAFE "don't strip the tenant to zero
+  authenticators" guarantee (AC-26.7.2.4) must call this from inside a
+  transaction that has already locked the tenant row — see
+  `Loopctl.Tenants.Enrollment.revoke/2`, which is the only intended caller
+  for a `human_anchored` tenant.
+  """
+  @spec delete(Ecto.UUID.t(), Ecto.UUID.t()) ::
+          {:ok, RootAuthenticator.t()} | {:error, :not_found} | {:error, Ecto.Changeset.t()}
+  def delete(tenant_id, id) when is_binary(tenant_id) and is_binary(id) do
+    case get_by_id(tenant_id, id) do
+      {:error, :not_found} = error -> error
+      {:ok, authenticator} -> AdminRepo.delete(authenticator)
+    end
+  end
+
+  defp get_by_id(tenant_id, id) do
+    query = from a in RootAuthenticator, where: a.tenant_id == ^tenant_id and a.id == ^id
+
+    case AdminRepo.one(query) do
+      nil -> {:error, :not_found}
+      authenticator -> {:ok, authenticator}
+    end
+  end
 end

--- a/lib/loopctl/web_authn/enrollment.ex
+++ b/lib/loopctl/web_authn/enrollment.ex
@@ -1,0 +1,164 @@
+defmodule Loopctl.WebAuthn.Enrollment do
+  @moduledoc """
+  US-26.7.2 — persisted, single-use, TTL-bound WebAuthn REGISTRATION-challenge
+  issuance/consumption for the opt-in trust-tier upgrade ceremony
+  (agent_rooted -> human_anchored).
+
+  Reuses ONLY the `ReauthChallenge` PERSISTENCE SHAPE (the schema fields plus
+  the atomic single-use `update_all` consume pattern from
+  `Loopctl.WebAuthn.Reauth.consume_challenge/3`, reauth.ex:191) via a SEPARATE
+  table (`webauthn_enrollment_challenges`,
+  `Loopctl.WebAuthn.EnrollmentChallenge`) — NOT `Reauth.issue_challenge/2`
+  itself, which hard-requires an existing enrolled authenticator
+  (`RootAuthenticators.list_by_tenant/1 != []`) and would make a tenant's
+  FIRST enrollment impossible (AC-26.7.2.1).
+
+  `issue/1` calls `Loopctl.WebAuthn.new_registration_challenge/1` directly —
+  no existing-authenticator precondition — and persists the challenge
+  tenant-scoped with a 300s TTL. `consume/2` atomically single-use-consumes
+  it: a guarded `update_all` stamps `used_at` ONLY when the row is unused,
+  unexpired, and in-tenant, so a double-spend/replay/cross-tenant attempt
+  sees zero rows and a clean `{:error, :challenge_not_found}` — no TOCTOU.
+
+  This module performs NO WebAuthn crypto — it only manages the opaque
+  challenge handle. The caller (`LoopctlWeb.TenantAuthenticatorController`)
+  consumes the challenge in its OWN committed transaction BEFORE running
+  `WebAuthn.verify_registration/3` outside any transaction, per the
+  two-phase shape mandated by AC-26.7.2.3.
+  """
+
+  import Ecto.Query
+
+  alias Ecto.Multi
+  alias Loopctl.AdminRepo
+  alias Loopctl.WebAuthn
+  alias Loopctl.WebAuthn.EnrollmentChallenge
+
+  # Mirrors Reauth's ceremony TTL — the operator is expected to touch their
+  # authenticator immediately after requesting the challenge.
+  @challenge_ttl_seconds 300
+  @purpose "enroll_authenticator"
+
+  @type issue_result :: %{
+          challenge_id: Ecto.UUID.t(),
+          challenge: term(),
+          challenge_bytes: String.t(),
+          expires_at: DateTime.t()
+        }
+
+  @doc "TTL (seconds) applied to freshly issued enrollment registration challenges."
+  @spec challenge_ttl_seconds() :: pos_integer()
+  def challenge_ttl_seconds, do: @challenge_ttl_seconds
+
+  @doc """
+  Issues and persists a new registration challenge for `tenant_id`. No
+  existing-authenticator precondition (unlike `Reauth.issue_challenge/2`) —
+  this is exactly what makes FIRST enrollment possible.
+  """
+  @spec issue(Ecto.UUID.t()) :: {:ok, issue_result()} | {:error, Ecto.Changeset.t()}
+  def issue(tenant_id) when is_binary(tenant_id) do
+    rp_opts = WebAuthn.rp_opts()
+    challenge = WebAuthn.new_registration_challenge(rp_opts)
+    expires_at = DateTime.utc_now() |> DateTime.add(@challenge_ttl_seconds, :second)
+
+    attrs = %{
+      purpose: @purpose,
+      challenge: :erlang.term_to_binary(challenge),
+      expires_at: expires_at
+    }
+
+    case %EnrollmentChallenge{tenant_id: tenant_id}
+         |> EnrollmentChallenge.create_changeset(attrs)
+         |> AdminRepo.insert() do
+      {:ok, stored} ->
+        {:ok,
+         %{
+           challenge_id: stored.id,
+           challenge: challenge,
+           challenge_bytes: encode_challenge_bytes(challenge),
+           expires_at: expires_at
+         }}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
+  end
+
+  @doc """
+  Atomically consumes a previously issued registration challenge
+  (single-use, TTL-bound, tenant-scoped). PHASE 1 of the enrollment
+  ceremony (AC-26.7.2.3): this MUST run and commit in its own transaction
+  BEFORE any WebAuthn attestation verification, so a later verification
+  failure never un-burns the challenge (replay stays blocked either way).
+
+  Returns `{:ok, challenge}` — the deserialized adapter registration
+  challenge struct, ready for `WebAuthn.verify_registration/3` — or
+  `{:error, :challenge_not_found}` on any miss (unknown id, wrong tenant,
+  already used, or expired — all collapsed to one response so a caller
+  cannot distinguish "never existed" from "already consumed" from "expired").
+  """
+  @spec consume(Ecto.UUID.t(), Ecto.UUID.t() | String.t()) ::
+          {:ok, term()}
+          | {:error, :challenge_not_found}
+          | {:error, :invalid_challenge_id}
+          | {:error, :challenge_corrupt}
+  def consume(tenant_id, challenge_id) when is_binary(tenant_id) do
+    case cast_uuid(challenge_id) do
+      {:ok, uuid} -> do_consume(tenant_id, uuid)
+      {:error, _} = error -> error
+    end
+  end
+
+  defp cast_uuid(value) when is_binary(value) do
+    case Ecto.UUID.cast(value) do
+      {:ok, uuid} -> {:ok, uuid}
+      :error -> {:error, :invalid_challenge_id}
+    end
+  end
+
+  defp cast_uuid(_value), do: {:error, :invalid_challenge_id}
+
+  defp do_consume(tenant_id, challenge_id) do
+    now = DateTime.utc_now()
+
+    consume_query =
+      from(c in EnrollmentChallenge,
+        where:
+          c.id == ^challenge_id and c.tenant_id == ^tenant_id and c.purpose == ^@purpose and
+            is_nil(c.used_at) and c.expires_at > ^now,
+        select: c.challenge
+      )
+
+    Multi.new()
+    |> Multi.update_all(:consume, consume_query, set: [used_at: now])
+    |> Multi.run(:assert_consumed, &assert_consumed/2)
+    |> AdminRepo.transaction()
+    |> case do
+      {:ok, %{assert_consumed: challenge}} -> {:ok, challenge}
+      {:error, _step, reason, _changes} -> {:error, reason}
+    end
+  end
+
+  defp assert_consumed(_repo, %{consume: {1, [serialized]}}),
+    do: deserialize_challenge(serialized)
+
+  defp assert_consumed(_repo, _changes), do: {:error, :challenge_not_found}
+
+  # The stored blob is our own `term_to_binary` output, not user input.
+  # `[:safe]` still guards against decoding funs/new atoms if the row were
+  # ever tampered with. A corrupt/undecodable blob fails CLOSED rather than
+  # letting a nil challenge reach the adapter.
+  defp deserialize_challenge(serialized) when is_binary(serialized) do
+    {:ok, :erlang.binary_to_term(serialized, [:safe])}
+  rescue
+    _ -> {:error, :challenge_corrupt}
+  end
+
+  defp encode_challenge_bytes(%{bytes: bytes}) when is_binary(bytes),
+    do: Base.url_encode64(bytes, padding: false)
+
+  defp encode_challenge_bytes(bytes) when is_binary(bytes),
+    do: Base.url_encode64(bytes, padding: false)
+
+  defp encode_challenge_bytes(_), do: ""
+end

--- a/lib/loopctl/web_authn/enrollment_challenge.ex
+++ b/lib/loopctl/web_authn/enrollment_challenge.ex
@@ -1,0 +1,60 @@
+defmodule Loopctl.WebAuthn.EnrollmentChallenge do
+  @moduledoc """
+  Schema for the `webauthn_enrollment_challenges` table (US-26.7.2).
+
+  Mirrors `Loopctl.WebAuthn.ReauthChallenge`'s persistence SHAPE exactly (a
+  persisted, single-use, TTL-bound challenge handle: mint, hand the `id` to
+  the client, refuse if missing/expired/used, atomically stamp `used_at`)
+  but is a SEPARATE table and schema. `Reauth.issue_challenge/2` requires
+  >=1 enrolled authenticator (it embeds `allow_credentials`), which makes it
+  unusable for a tenant's FIRST enrollment (zero authenticators). This table
+  stores plain REGISTRATION challenges (`Wax.new_registration_challenge`),
+  not authentication/reauth challenges, so it carries no
+  `allow_credentials` semantics at all.
+
+  ## Tenant isolation (NOT via RLS here)
+
+  Every query runs on `Loopctl.AdminRepo` (BYPASSRLS), so the table's RLS
+  policy is never evaluated on this path. Isolation rests solely on the
+  explicit `tenant_id` predicates in `Loopctl.WebAuthn.Enrollment`.
+
+  ## Fields
+
+  - `id`         -- binary UUID primary key; the opaque challenge handle
+  - `tenant_id`  -- FK to tenants (set programmatically, never cast)
+  - `purpose`    -- ceremony label, always `"enroll_authenticator"` today
+  - `challenge`  -- Erlang-term-binary encoded adapter registration challenge
+  - `expires_at` -- TTL boundary; a challenge past this is refused
+  - `used_at`    -- single-use stamp; non-nil ⇒ already consumed, refused
+  - `inserted_at`-- creation timestamp (no `updated_at`)
+  """
+
+  use Loopctl.Schema
+
+  @type t :: %__MODULE__{}
+
+  schema "webauthn_enrollment_challenges" do
+    tenant_field()
+
+    field :purpose, :string
+    field :challenge, :binary
+    field :expires_at, :utc_datetime_usec
+    field :used_at, :utc_datetime_usec
+
+    timestamps(updated_at: false)
+  end
+
+  @cast_fields [:purpose, :challenge, :expires_at]
+
+  @doc """
+  Changeset for minting a new enrollment registration challenge.
+
+  `tenant_id` is set programmatically and must not appear in attrs.
+  """
+  @spec create_changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
+  def create_changeset(challenge \\ %__MODULE__{}, attrs) do
+    challenge
+    |> cast(attrs, @cast_fields)
+    |> validate_required([:purpose, :challenge, :expires_at])
+  end
+end

--- a/lib/loopctl/web_authn/reauth.ex
+++ b/lib/loopctl/web_authn/reauth.ex
@@ -45,6 +45,15 @@ defmodule Loopctl.WebAuthn.Reauth do
   # "rotate" and is expected to touch their authenticator immediately.
   @challenge_ttl_seconds 300
 
+  # crypto-01 / US-26.7.2 review #2: reject an assertion field larger than this
+  # BEFORE base64-decoding it, bounding the per-call decode + CPU-bound verify
+  # cost. Applied uniformly to EVERY base64 field of EVERY assertion this
+  # module verifies — the audit-key `rotate_audit_key` path AND the US-26.7.2
+  # `add_authenticator` / `revoke_authenticator` paths — since all route
+  # through `fetch_b64/2`. A real FIDO2 assertion field is well under 8 KB
+  # (mirrors signup_live.ex's @max_attestation_field_bytes).
+  @max_assertion_field_bytes 8 * 1024
+
   @type issue_result :: %{
           challenge_id: Ecto.UUID.t(),
           challenge: String.t(),
@@ -259,7 +268,16 @@ defmodule Loopctl.WebAuthn.Reauth do
   defp fetch_b64(params, key) do
     case Map.get(params, key) do
       value when is_binary(value) and value != "" ->
-        decode_b64url(value, key)
+        # Size-cap BEFORE decode (review #2): an oversized field is rejected
+        # here, before any base64 decode or CPU-bound signature verification,
+        # and — because this runs BEFORE `consume_challenge/3` in
+        # `verify_and_consume/3`'s `with` chain — WITHOUT even burning the
+        # single-use challenge.
+        if byte_size(value) > @max_assertion_field_bytes do
+          {:error, {:field_too_large, key}}
+        else
+          decode_b64url(value, key)
+        end
 
       _ ->
         {:error, {:missing_field, key}}

--- a/lib/loopctl/workers/reauth_challenge_cleanup_worker.ex
+++ b/lib/loopctl/workers/reauth_challenge_cleanup_worker.ex
@@ -1,11 +1,21 @@
 defmodule Loopctl.Workers.ReauthChallengeCleanupWorker do
   @moduledoc """
-  crypto-01 — Oban worker that periodically deletes stale WebAuthn reauth
-  challenges.
+  crypto-01 (GHSA-c3cw-5f7p-g76r) / US-26.7.2 — Oban worker that periodically
+  deletes stale WebAuthn challenges from BOTH:
+
+    * `webauthn_reauth_challenges` (`Loopctl.WebAuthn.ReauthChallenge`) — the
+      audit-key-rotation and authenticator-revoke reauth ceremonies.
+    * `webauthn_enrollment_challenges` (`Loopctl.WebAuthn.EnrollmentChallenge`,
+      US-26.7.2) — the registration-challenge store backing the opt-in
+      agent_rooted -> human_anchored trust-tier upgrade ceremony.
+
+  Both tables share the exact same single-use/TTL persistence shape and
+  cleanup cadence, so one worker sweeps both rather than duplicating an
+  almost-identical cron job and Oban queue entry.
 
   Runs hourly via the Oban Cron plugin. Deletes every challenge past its
   `expires_at` (which includes consumed ones, since a consumed challenge is
-  still TTL-bounded) to prevent unbounded table growth.
+  still TTL-bounded) from each table to prevent unbounded growth.
   """
 
   use Oban.Worker, queue: :cleanup, max_attempts: 3
@@ -13,21 +23,34 @@ defmodule Loopctl.Workers.ReauthChallengeCleanupWorker do
   import Ecto.Query
 
   alias Loopctl.AdminRepo
+  alias Loopctl.WebAuthn.EnrollmentChallenge
   alias Loopctl.WebAuthn.ReauthChallenge
 
   @impl Oban.Worker
   def perform(_job) do
-    now = DateTime.utc_now()
+    reauth_deleted = purge_stale(ReauthChallenge)
+    enrollment_deleted = purge_stale(EnrollmentChallenge)
+    total = reauth_deleted + enrollment_deleted
 
-    {deleted_count, _} =
-      from(c in ReauthChallenge, where: c.expires_at < ^now or not is_nil(c.used_at))
-      |> AdminRepo.delete_all()
-
-    if deleted_count > 0 do
+    if total > 0 do
       require Logger
-      Logger.info("ReauthChallengeCleanupWorker deleted #{deleted_count} stale challenges")
+
+      Logger.info(
+        "ReauthChallengeCleanupWorker deleted #{reauth_deleted} stale reauth challenge(s) " <>
+          "and #{enrollment_deleted} stale enrollment challenge(s)"
+      )
     end
 
     :ok
+  end
+
+  defp purge_stale(schema) do
+    now = DateTime.utc_now()
+
+    {deleted_count, _} =
+      from(c in schema, where: c.expires_at < ^now or not is_nil(c.used_at))
+      |> AdminRepo.delete_all()
+
+    deleted_count
   end
 end

--- a/lib/loopctl_web/controllers/tenant_authenticator_controller.ex
+++ b/lib/loopctl_web/controllers/tenant_authenticator_controller.ex
@@ -1,0 +1,644 @@
+defmodule LoopctlWeb.TenantAuthenticatorController do
+  @moduledoc """
+  US-26.7.2 — opt-in WebAuthn trust-tier upgrade ceremony
+  (agent_rooted -> human_anchored) and authenticator revocation.
+
+  Four endpoints, mirroring `LoopctlWeb.TenantAuditKeyController`'s
+  challenge/act shape:
+
+    1. `POST /tenants/:id/authenticators/challenge` — issues a registration
+       challenge (AC-26.7.2.1/.2). If the tenant is already `human_anchored`,
+       ALSO issues a fresh-assertion (reauth) challenge for an existing
+       authenticator (`reauth_required: true`) — a subsequent enrollment
+       must prove possession of an already-enrolled device.
+    2. `POST /tenants/:id/authenticators` — completes enrollment in a
+       TWO-PHASE shape (AC-26.7.2.3), mirroring `Reauth.verify_and_consume/3`:
+       PHASE 1 atomically consumes the registration challenge in its own
+       committed transaction (and, when human_anchored, ALSO verifies +
+       consumes the required `add_authenticator` assertion — the CRITICAL
+       anti-soft-recovery-backdoor gate); PHASE 2 size-caps and verifies the
+       attestation OUTSIDE any transaction; PHASE 3 is the DB-only
+       `Loopctl.Tenants.Enrollment.enroll/2` Multi (insert + guarded tier
+       flip + audit).
+    3. `POST /tenants/:id/authenticators/revoke-challenge` — issues a
+       `revoke_authenticator` reauth challenge.
+    4. `DELETE /tenants/:id/authenticators/:auth_id` — verifies the
+       assertion against that challenge, then race-safe revokes
+       (`Loopctl.Tenants.Enrollment.revoke/2`) — refuses to strip the last
+       authenticator off a human_anchored tenant.
+
+  ## Not tier-gated (US-26.7.1 pattern)
+
+  None of these actions carry `RequireHumanAnchor`, deliberately: `challenge`
+  and `create` ARE the upgrade path — an agent-rooted caller is the intended
+  audience for the FIRST enrollment. `revoke-challenge`/`delete` and any
+  SUBSEQUENT enrollment are protected by fresh, per-operation WebAuthn
+  assertions (`Loopctl.WebAuthn.Reauth`), a STRONGER control than the tier
+  gate. All four require `role: :user` + tenant ownership
+  (`owns_tenant?/2`, mirroring `TenantAuditKeyController`).
+  """
+
+  use LoopctlWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Loopctl.ApiSpec.Schemas
+  alias Loopctl.Tenants
+  alias Loopctl.Tenants.Enrollment
+  alias Loopctl.WebAuthn
+  alias Loopctl.WebAuthn.Enrollment, as: RegistrationChallenges
+  alias Loopctl.WebAuthn.Reauth
+
+  @add_authenticator_purpose "add_authenticator"
+  @revoke_purpose "revoke_authenticator"
+
+  # Reject attestation fields larger than this BEFORE base64-decoding them,
+  # bounding per-call CBOR-decode cost. Mirrors signup_live.ex's
+  # @max_attestation_field_bytes — a real FIDO2 attestation object is well
+  # under 8 KB.
+  @max_attestation_field_bytes 8 * 1024
+
+  # Matches RootAuthenticator's `validate_length(:friendly_name, max: 120)`.
+  @max_friendly_name_bytes 120
+
+  # WebAuthn verification (and, for revoke, the assertion verify) is
+  # CPU-bound and abusable. A tighter, per-tenant budget on top of the
+  # blanket RateLimiter plug, mirroring signup_live.ex's ensure_action_budget/1.
+  @enroll_rate_window_ms 60_000 * 60
+  @max_enroll_actions_per_window 30
+
+  @pub_key_cred_params [
+    %{type: "public-key", alg: -7},
+    %{type: "public-key", alg: -257}
+  ]
+
+  # Authenticator enrollment/revocation requires user role — agents must not
+  # perform trust-tier operations.
+  plug LoopctlWeb.Plugs.RequireRole,
+       [role: :user] when action in [:challenge, :create, :revoke_challenge, :delete]
+
+  tags(["Tenants"])
+
+  operation(:challenge,
+    summary: "Issue a WebAuthn enrollment registration challenge",
+    description:
+      "Step 1 of the opt-in trust-tier upgrade ceremony (US-26.7.2). Requires user " <>
+        "role and tenant ownership. Not tier-gated.",
+    parameters: [id: [in: :path, type: :string, description: "Tenant UUID"]],
+    responses: %{
+      200 => {"Enrollment challenge", "application/json", Schemas.AuthenticatorChallengeResponse},
+      403 => {"Forbidden", "application/json", Schemas.ErrorResponse},
+      404 => {"Not found", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limited", "application/json", Schemas.ErrorResponse}
+    }
+  )
+
+  @doc """
+  POST /api/v1/tenants/:id/authenticators/challenge
+
+  Step 1 of the enrollment ceremony. Mints a server-side, single-use,
+  TTL-bounded registration challenge. When the tenant is already
+  `human_anchored`, also mints a fresh `add_authenticator` reauth challenge
+  for an existing authenticator.
+  """
+  def challenge(conn, %{"id" => tenant_id}) do
+    if owns_tenant?(conn, tenant_id) do
+      do_challenge(conn, tenant_id)
+    else
+      forbidden(conn)
+    end
+  end
+
+  defp do_challenge(conn, tenant_id) do
+    with :ok <- check_rate_limit(tenant_id),
+         {:ok, tenant} <- Tenants.get_tenant(tenant_id),
+         {:ok, issued} <- RegistrationChallenges.issue(tenant_id) do
+      render_challenge(conn, tenant, issued)
+    else
+      {:error, :rate_limited} -> rate_limited(conn)
+      {:error, :not_found} -> not_found(conn)
+      {:error, _reason} -> internal_error(conn, "Failed to issue enrollment challenge")
+    end
+  end
+
+  defp render_challenge(conn, tenant, issued) do
+    rp_opts = WebAuthn.rp_opts()
+
+    base = %{
+      challenge_id: issued.challenge_id,
+      challenge: issued.challenge_bytes,
+      expires_at: issued.expires_at,
+      rp: %{id: Keyword.get(rp_opts, :rp_id), name: Keyword.get(rp_opts, :rp_name)},
+      user: webauthn_user(tenant),
+      pub_key_cred_params: @pub_key_cred_params
+    }
+
+    case tenant.trust_tier do
+      :human_anchored ->
+        render_subsequent_challenge(conn, tenant, base)
+
+      :agent_rooted ->
+        conn |> put_status(:ok) |> json(%{data: Map.put(base, :reauth_required, false)})
+    end
+  end
+
+  defp render_subsequent_challenge(conn, tenant, base) do
+    case Reauth.issue_challenge(tenant.id, @add_authenticator_purpose) do
+      {:ok, reauth} ->
+        data =
+          Map.merge(base, %{
+            reauth_required: true,
+            reauth_challenge: %{
+              challenge_id: reauth.challenge_id,
+              challenge: reauth.challenge,
+              allowed_credentials: reauth.allowed_credentials,
+              rp_id: reauth.rp_id,
+              expires_at: reauth.expires_at
+            }
+          })
+
+        conn |> put_status(:ok) |> json(%{data: data})
+
+      {:error, _reason} ->
+        internal_error(conn, "Failed to issue reauth challenge")
+    end
+  end
+
+  # Opaque, per-tenant, non-PII WebAuthn user handle. Not a login identity —
+  # only used to populate navigator.credentials.create()'s required
+  # `user.id`. Documented per AC-26.7.2.2: derived server-side from the
+  # tenant, never client-supplied.
+  defp webauthn_user(tenant) do
+    %{
+      id: Base.url_encode64(Ecto.UUID.dump!(tenant.id), padding: false),
+      name: tenant.slug,
+      display_name: tenant.name
+    }
+  end
+
+  operation(:create,
+    summary: "Complete WebAuthn authenticator enrollment",
+    description:
+      "Step 2 of the opt-in trust-tier upgrade ceremony. Two-phase: consumes the " <>
+        "registration challenge (and, if already human_anchored, verifies a fresh " <>
+        "add_authenticator assertion) FIRST, then verifies the attestation, then " <>
+        "atomically inserts the authenticator and guard-flips trust_tier. Requires " <>
+        "user role and tenant ownership. Not tier-gated.",
+    parameters: [id: [in: :path, type: :string, description: "Tenant UUID"]],
+    request_body:
+      {"Enrollment attestation", "application/json", Schemas.EnrollAuthenticatorRequest},
+    responses: %{
+      201 => {"Authenticator enrolled", "application/json", Schemas.AuthenticatorEnrollResponse},
+      401 =>
+        {"Challenge/assertion/attestation invalid", "application/json", Schemas.ErrorResponse},
+      403 => {"Forbidden", "application/json", Schemas.ErrorResponse},
+      404 => {"Not found", "application/json", Schemas.ErrorResponse},
+      409 => {"Too many authenticators", "application/json", Schemas.ErrorResponse},
+      422 => {"Validation failed", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limited", "application/json", Schemas.ErrorResponse}
+    }
+  )
+
+  @doc """
+  POST /api/v1/tenants/:id/authenticators
+
+  Step 2 of the enrollment ceremony.
+  """
+  def create(conn, %{"id" => tenant_id} = params) do
+    if owns_tenant?(conn, tenant_id) do
+      do_create(conn, tenant_id, params)
+    else
+      forbidden(conn)
+    end
+  end
+
+  defp do_create(conn, tenant_id, params) do
+    with :ok <- check_rate_limit(tenant_id),
+         {:ok, tenant} <- Tenants.get_tenant(tenant_id),
+         {:ok, challenge} <- consume_registration_challenge(tenant_id, params),
+         :ok <- maybe_require_add_authenticator_assertion(tenant, params),
+         :ok <- ensure_attestation_size(params),
+         {:ok, decoded} <- decode_attestation(params),
+         {:ok, verified} <- WebAuthn.verify_registration(decoded, challenge, WebAuthn.rp_opts()) do
+      complete_enroll(conn, tenant_id, verified, friendly_name(params))
+    else
+      {:error, :rate_limited} ->
+        rate_limited(conn)
+
+      {:error, :not_found} ->
+        not_found(conn)
+
+      {:error, :challenge_invalid} ->
+        challenge_invalid(conn)
+
+      {:error, :reauth_required} ->
+        reauth_required(conn)
+
+      {:error, :reauth_failed} ->
+        reauth_failed(conn)
+
+      {:error, :attestation_too_large} ->
+        attestation_too_large(conn)
+
+      {:error, :invalid_encoding} ->
+        bad_request(conn, "Attestation fields must be base64url-encoded")
+
+      {:error, _reason} ->
+        webauthn_failed(conn)
+    end
+  end
+
+  # PHASE 1 (part 1): consume the registration challenge in its OWN
+  # committed transaction FIRST (AC-26.7.2.3), so a later attestation
+  # failure never un-burns it.
+  defp consume_registration_challenge(tenant_id, params) do
+    challenge_id = Map.get(params, "challenge_id")
+
+    case RegistrationChallenges.consume(tenant_id, challenge_id) do
+      {:ok, challenge} -> {:ok, challenge}
+      {:error, _reason} -> {:error, :challenge_invalid}
+    end
+  end
+
+  # PHASE 1 (part 2): the CRITICAL backup-enrollment gate. An agent_rooted
+  # tenant (zero authenticators — legitimate bootstrap) needs nothing more
+  # than ownership + a fresh registration attestation. An already
+  # human_anchored tenant additionally requires a fresh assertion from an
+  # ALREADY-enrolled authenticator, verified + consumed here — this is what
+  # closes the "stolen role:user key grafts an attacker's own hardware onto
+  # the tenant's root of trust" backdoor (docs/chain-of-custody-v2.md §9.3).
+  defp maybe_require_add_authenticator_assertion(%{trust_tier: :agent_rooted}, _params), do: :ok
+
+  defp maybe_require_add_authenticator_assertion(
+         %{trust_tier: :human_anchored, id: tenant_id},
+         params
+       ) do
+    case Map.get(params, "reauth_assertion") do
+      assertion when is_map(assertion) ->
+        case Reauth.verify_and_consume(tenant_id, @add_authenticator_purpose, assertion) do
+          {:ok, _verified} -> :ok
+          {:error, _reason} -> {:error, :reauth_failed}
+        end
+
+      _ ->
+        {:error, :reauth_required}
+    end
+  end
+
+  defp ensure_attestation_size(params) do
+    within? =
+      ["attestation_object", "client_data_json", "credential_id"]
+      |> Enum.all?(fn key -> field_within_size?(Map.get(params, key, "")) end)
+
+    if within?, do: :ok, else: {:error, :attestation_too_large}
+  end
+
+  defp field_within_size?(value) when is_binary(value),
+    do: byte_size(value) <= @max_attestation_field_bytes
+
+  defp field_within_size?(_value), do: true
+
+  # PHASE 2: decode + verify OUTSIDE any open transaction — CPU-bound
+  # CBOR/COSE work never holds a DB connection (AC-26.7.2.3).
+  defp decode_attestation(params) do
+    with {:ok, attestation_object} <- decode_b64url(Map.get(params, "attestation_object", "")),
+         {:ok, client_data_json} <- decode_b64url(Map.get(params, "client_data_json", "")),
+         {:ok, credential_id} <- decode_b64url(Map.get(params, "credential_id", "")) do
+      {:ok,
+       %{
+         attestation_object: attestation_object,
+         client_data_json: client_data_json,
+         credential_id: credential_id
+       }}
+    end
+  end
+
+  defp decode_b64url(value) when is_binary(value) do
+    case Base.url_decode64(value, padding: false) do
+      {:ok, decoded} -> {:ok, decoded}
+      :error -> {:error, :invalid_encoding}
+    end
+  end
+
+  defp decode_b64url(_value), do: {:error, :invalid_encoding}
+
+  defp friendly_name(params) do
+    case Map.get(params, "friendly_name") do
+      value when is_binary(value) ->
+        case value |> String.trim() |> truncate_to(@max_friendly_name_bytes) do
+          "" -> "Authenticator"
+          trimmed -> trimmed
+        end
+
+      _ ->
+        "Authenticator"
+    end
+  end
+
+  defp truncate_to(string, max_bytes) when byte_size(string) <= max_bytes, do: string
+
+  defp truncate_to(string, max_bytes) do
+    string |> :binary.part(0, max_bytes) |> snap_utf8()
+  end
+
+  defp snap_utf8(bin) do
+    Enum.find_value(0..3, "", fn n ->
+      candidate = :binary.part(bin, 0, byte_size(bin) - n)
+      if String.valid?(candidate), do: candidate
+    end)
+  end
+
+  # PHASE 3: the DB-only Multi (insert + guarded tier flip + audit).
+  defp complete_enroll(conn, tenant_id, verified, friendly_name) do
+    attrs =
+      verified
+      |> Map.take([:credential_id, :public_key, :attestation_format, :sign_count])
+      |> Map.put(:friendly_name, friendly_name)
+      |> Map.put_new(:sign_count, 0)
+
+    case Enrollment.enroll(tenant_id, attrs) do
+      {:ok, %{tenant: tenant, authenticator: auth, upgraded: upgraded}} ->
+        conn
+        |> put_status(:created)
+        |> json(%{
+          data: %{
+            tenant_id: tenant.id,
+            trust_tier: Atom.to_string(tenant.trust_tier),
+            upgraded: upgraded,
+            authenticator: %{
+              id: auth.id,
+              friendly_name: auth.friendly_name,
+              attestation_format: auth.attestation_format,
+              inserted_at: auth.inserted_at
+            }
+          }
+        })
+
+      {:error, :not_found} ->
+        not_found(conn)
+
+      {:error, :too_many_authenticators} ->
+        too_many_authenticators(conn)
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        changeset_error(conn, changeset)
+    end
+  end
+
+  operation(:revoke_challenge,
+    summary: "Issue an authenticator-revocation reauth challenge",
+    description:
+      "Issues a fresh-assertion challenge (purpose revoke_authenticator) for an " <>
+        "existing authenticator. Requires user role and tenant ownership.",
+    parameters: [id: [in: :path, type: :string, description: "Tenant UUID"]],
+    responses: %{
+      200 => {"Reauth challenge", "application/json", Schemas.ReauthChallengeResponse},
+      403 => {"Forbidden", "application/json", Schemas.ErrorResponse},
+      422 => {"No enrolled authenticators", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limited", "application/json", Schemas.ErrorResponse}
+    }
+  )
+
+  @doc """
+  POST /api/v1/tenants/:id/authenticators/revoke-challenge
+  """
+  def revoke_challenge(conn, %{"id" => tenant_id}) do
+    if owns_tenant?(conn, tenant_id) do
+      do_revoke_challenge(conn, tenant_id)
+    else
+      forbidden(conn)
+    end
+  end
+
+  defp do_revoke_challenge(conn, tenant_id) do
+    with :ok <- check_rate_limit(tenant_id),
+         {:ok, issued} <- Reauth.issue_challenge(tenant_id, @revoke_purpose) do
+      conn
+      |> put_status(:ok)
+      |> json(%{
+        data: %{
+          challenge_id: issued.challenge_id,
+          challenge: issued.challenge,
+          allowed_credentials: issued.allowed_credentials,
+          rp_id: issued.rp_id,
+          expires_at: issued.expires_at
+        }
+      })
+    else
+      {:error, :rate_limited} ->
+        rate_limited(conn)
+
+      {:error, :no_authenticators} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{
+          error: %{
+            status: 422,
+            code: "no_authenticators",
+            message: "Tenant has no enrolled root authenticator to authorize revocation"
+          }
+        })
+
+      {:error, _reason} ->
+        internal_error(conn, "Failed to issue reauth challenge")
+    end
+  end
+
+  operation(:delete,
+    summary: "Revoke an enrolled authenticator",
+    description:
+      "Verifies the WebAuthn assertion against the STORED revoke_authenticator " <>
+        "challenge, then race-safe deletes the target authenticator. Refuses (409) " <>
+        "to remove the LAST authenticator on a human_anchored tenant — no " <>
+        "auto-downgrade. Requires user role and tenant ownership.",
+    parameters: [
+      id: [in: :path, type: :string, description: "Tenant UUID"],
+      auth_id: [in: :path, type: :string, description: "Authenticator UUID"]
+    ],
+    request_body: {"WebAuthn assertion", "application/json", Schemas.RevokeAuthenticatorRequest},
+    responses: %{
+      200 => {"Authenticator revoked", "application/json", Schemas.RevokeAuthenticatorResponse},
+      401 => {"WebAuthn required or failed", "application/json", Schemas.ErrorResponse},
+      403 => {"Forbidden", "application/json", Schemas.ErrorResponse},
+      404 => {"Not found", "application/json", Schemas.ErrorResponse},
+      409 => {"Last authenticator", "application/json", Schemas.ErrorResponse}
+    }
+  )
+
+  @doc """
+  DELETE /api/v1/tenants/:id/authenticators/:auth_id
+  """
+  def delete(conn, %{"id" => tenant_id, "auth_id" => auth_id} = params) do
+    assertion = Map.get(params, "webauthn_assertion")
+
+    cond do
+      not owns_tenant?(conn, tenant_id) ->
+        forbidden(conn)
+
+      not is_map(assertion) ->
+        unauthorized(
+          conn,
+          "webauthn_required",
+          "WebAuthn assertion required to revoke an authenticator"
+        )
+
+      true ->
+        do_revoke(conn, tenant_id, auth_id, assertion)
+    end
+  end
+
+  defp do_revoke(conn, tenant_id, auth_id, assertion) do
+    case Reauth.verify_and_consume(tenant_id, @revoke_purpose, assertion) do
+      {:ok, _verified} ->
+        case Enrollment.revoke(tenant_id, auth_id) do
+          {:ok, auth} ->
+            conn
+            |> put_status(:ok)
+            |> json(%{data: %{tenant_id: tenant_id, authenticator_id: auth.id, revoked: true}})
+
+          {:error, :not_found} ->
+            not_found(conn)
+
+          {:error, :last_authenticator} ->
+            last_authenticator(conn)
+        end
+
+      {:error, _reason} ->
+        unauthorized(conn, "webauthn_failed", "WebAuthn assertion verification failed")
+    end
+  end
+
+  # --- Shared helpers ---
+
+  defp check_rate_limit(tenant_id) do
+    bucket = "enroll:actions:#{tenant_id}"
+
+    case rate_limiter().check_rate(bucket, @enroll_rate_window_ms, @max_enroll_actions_per_window) do
+      {:allow, _count} -> :ok
+      {:deny, _limit} -> {:error, :rate_limited}
+    end
+  end
+
+  defp rate_limiter do
+    Application.get_env(:loopctl, :rate_limiter, Loopctl.RateLimiter.Hammer)
+  end
+
+  # Ownership check: the caller's user-role key must belong to the target
+  # tenant. Mirrors TenantAuditKeyController.owns_tenant?/2.
+  defp owns_tenant?(conn, tenant_id) do
+    case conn.assigns do
+      %{current_api_key: %{tenant_id: tid}} -> tid == tenant_id
+      _ -> false
+    end
+  end
+
+  defp forbidden(conn) do
+    conn |> put_status(:forbidden) |> json(%{error: %{status: 403, message: "Forbidden"}})
+  end
+
+  defp not_found(conn) do
+    conn |> put_status(:not_found) |> json(%{error: %{status: 404, message: "Not found"}})
+  end
+
+  defp rate_limited(conn) do
+    conn
+    |> put_status(:too_many_requests)
+    |> json(%{
+      error: %{
+        status: 429,
+        code: "rate_limited",
+        message: "Too many authenticator enrollment actions. Please try again later."
+      }
+    })
+  end
+
+  defp challenge_invalid(conn) do
+    unauthorized(
+      conn,
+      "challenge_invalid",
+      "Registration challenge missing, expired, already used, or does not belong to this tenant"
+    )
+  end
+
+  defp reauth_required(conn) do
+    unauthorized(
+      conn,
+      "reauth_required",
+      "A fresh WebAuthn assertion from an existing authenticator is required to " <>
+        "enroll an additional authenticator on a human-anchored tenant"
+    )
+  end
+
+  defp reauth_failed(conn) do
+    unauthorized(conn, "reauth_failed", "WebAuthn assertion verification failed")
+  end
+
+  defp webauthn_failed(conn) do
+    unauthorized(conn, "webauthn_failed", "WebAuthn attestation verification failed")
+  end
+
+  defp attestation_too_large(conn) do
+    conn
+    |> put_status(:bad_request)
+    |> json(%{error: %{status: 400, message: "Attestation payload too large"}})
+  end
+
+  defp bad_request(conn, message) do
+    conn |> put_status(:bad_request) |> json(%{error: %{status: 400, message: message}})
+  end
+
+  defp too_many_authenticators(conn) do
+    conn
+    |> put_status(:conflict)
+    |> json(%{
+      error: %{
+        status: 409,
+        code: "too_many_authenticators",
+        message:
+          "Tenant already has the maximum number of enrolled authenticators " <>
+            "(#{Enrollment.max_authenticators()})"
+      }
+    })
+  end
+
+  defp last_authenticator(conn) do
+    conn
+    |> put_status(:conflict)
+    |> json(%{
+      error: %{
+        status: 409,
+        code: "last_authenticator",
+        message: "Cannot revoke the last enrolled authenticator on a human-anchored tenant"
+      }
+    })
+  end
+
+  defp unauthorized(conn, code, message) do
+    conn
+    |> put_status(:unauthorized)
+    |> json(%{error: %{status: 401, code: code, message: message}})
+  end
+
+  defp internal_error(conn, message) do
+    conn |> put_status(:internal_server_error) |> json(%{error: %{status: 500, message: message}})
+  end
+
+  defp changeset_error(conn, changeset) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{
+      error: %{
+        status: 422,
+        message: "Validation failed",
+        details: format_changeset_errors(changeset)
+      }
+    })
+  end
+
+  defp format_changeset_errors(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
+      Regex.replace(~r"%{(\w+)}", msg, fn _, key ->
+        opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
+      end)
+    end)
+  end
+end

--- a/lib/loopctl_web/controllers/tenant_authenticator_controller.ex
+++ b/lib/loopctl_web/controllers/tenant_authenticator_controller.ex
@@ -213,16 +213,21 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
 
   defp do_create(conn, tenant_id, params) do
     with :ok <- check_rate_limit(tenant_id),
+         {:ok, friendly_name} <- friendly_name(params),
          {:ok, tenant} <- Tenants.get_tenant(tenant_id),
          {:ok, challenge} <- consume_registration_challenge(tenant_id, params),
-         :ok <- maybe_require_add_authenticator_assertion(tenant, params),
+         {:ok, assertion_verified?} <-
+           maybe_require_add_authenticator_assertion(tenant, params),
          :ok <- ensure_attestation_size(params),
          {:ok, decoded} <- decode_attestation(params),
          {:ok, verified} <- WebAuthn.verify_registration(decoded, challenge, WebAuthn.rp_opts()) do
-      complete_enroll(conn, tenant_id, verified, friendly_name(params))
+      complete_enroll(conn, tenant_id, verified, friendly_name, assertion_verified?)
     else
       {:error, :rate_limited} ->
         rate_limited(conn)
+
+      {:error, :friendly_name_too_long} ->
+        friendly_name_too_long(conn)
 
       {:error, :not_found} ->
         not_found(conn)
@@ -261,12 +266,20 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
 
   # PHASE 1 (part 2): the CRITICAL backup-enrollment gate. An agent_rooted
   # tenant (zero authenticators — legitimate bootstrap) needs nothing more
-  # than ownership + a fresh registration attestation. An already
-  # human_anchored tenant additionally requires a fresh assertion from an
-  # ALREADY-enrolled authenticator, verified + consumed here — this is what
+  # than ownership + a fresh registration attestation, so no assertion is
+  # verified here (`{:ok, false}`). An already human_anchored tenant
+  # additionally requires a fresh assertion from an ALREADY-enrolled
+  # authenticator, verified + consumed here (`{:ok, true}`) — this is what
   # closes the "stolen role:user key grafts an attacker's own hardware onto
   # the tenant's root of trust" backdoor (docs/chain-of-custody-v2.md §9.3).
-  defp maybe_require_add_authenticator_assertion(%{trust_tier: :agent_rooted}, _params), do: :ok
+  #
+  # The returned boolean is threaded into `Enrollment.enroll/3`, which
+  # RE-ENFORCES this gate under the tenant-row lock against the authoritative
+  # (post-lock) tier — so a tenant that races from agent_rooted to
+  # human_anchored between this pre-lock read and Phase 3 still cannot enroll
+  # a backup without an assertion.
+  defp maybe_require_add_authenticator_assertion(%{trust_tier: :agent_rooted}, _params),
+    do: {:ok, false}
 
   defp maybe_require_add_authenticator_assertion(
          %{trust_tier: :human_anchored, id: tenant_id},
@@ -275,7 +288,7 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
     case Map.get(params, "reauth_assertion") do
       assertion when is_map(assertion) ->
         case Reauth.verify_and_consume(tenant_id, @add_authenticator_purpose, assertion) do
-          {:ok, _verified} -> :ok
+          {:ok, _verified} -> {:ok, true}
           {:error, _reason} -> {:error, :reauth_failed}
         end
 
@@ -321,41 +334,36 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
 
   defp decode_b64url(_value), do: {:error, :invalid_encoding}
 
+  # AC-26.7.2.3: friendly_name is "validated 1..120" — an over-120-byte name
+  # is REJECTED (422), never silently truncated and persisted. An absent /
+  # blank name defaults to "Authenticator". The byte cap mirrors signup's
+  # @max_friendly_name_bytes; RootAuthenticator.create_changeset/2 re-validates
+  # length 1..120 as defense in depth.
   defp friendly_name(params) do
     case Map.get(params, "friendly_name") do
       value when is_binary(value) ->
-        case value |> String.trim() |> truncate_to(@max_friendly_name_bytes) do
-          "" -> "Authenticator"
-          trimmed -> trimmed
+        trimmed = String.trim(value)
+
+        cond do
+          trimmed == "" -> {:ok, "Authenticator"}
+          byte_size(trimmed) > @max_friendly_name_bytes -> {:error, :friendly_name_too_long}
+          true -> {:ok, trimmed}
         end
 
       _ ->
-        "Authenticator"
+        {:ok, "Authenticator"}
     end
   end
 
-  defp truncate_to(string, max_bytes) when byte_size(string) <= max_bytes, do: string
-
-  defp truncate_to(string, max_bytes) do
-    string |> :binary.part(0, max_bytes) |> snap_utf8()
-  end
-
-  defp snap_utf8(bin) do
-    Enum.find_value(0..3, "", fn n ->
-      candidate = :binary.part(bin, 0, byte_size(bin) - n)
-      if String.valid?(candidate), do: candidate
-    end)
-  end
-
   # PHASE 3: the DB-only Multi (insert + guarded tier flip + audit).
-  defp complete_enroll(conn, tenant_id, verified, friendly_name) do
+  defp complete_enroll(conn, tenant_id, verified, friendly_name, assertion_verified?) do
     attrs =
       verified
       |> Map.take([:credential_id, :public_key, :attestation_format, :sign_count])
       |> Map.put(:friendly_name, friendly_name)
       |> Map.put_new(:sign_count, 0)
 
-    case Enrollment.enroll(tenant_id, attrs) do
+    case Enrollment.enroll(tenant_id, attrs, assertion_verified?) do
       {:ok, %{tenant: tenant, authenticator: auth, upgraded: upgraded}} ->
         conn
         |> put_status(:created)
@@ -375,6 +383,15 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
 
       {:error, :not_found} ->
         not_found(conn)
+
+      # The under-lock backup-enrollment gate rejected this: a concurrent
+      # first-enroll flipped the tenant to human_anchored between the
+      # controller's pre-lock read and Phase 3, so this request now needs an
+      # add_authenticator assertion it didn't supply. Same 401 as the pre-lock
+      # gate — the caller must retry WITH a fresh existing-authenticator
+      # assertion.
+      {:error, :reauth_required} ->
+        reauth_required(conn)
 
       {:error, :too_many_authenticators} ->
         too_many_authenticators(conn)
@@ -580,6 +597,18 @@ defmodule LoopctlWeb.TenantAuthenticatorController do
     conn
     |> put_status(:bad_request)
     |> json(%{error: %{status: 400, message: "Attestation payload too large"}})
+  end
+
+  defp friendly_name_too_long(conn) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{
+      error: %{
+        status: 422,
+        code: "friendly_name_too_long",
+        message: "friendly_name must be at most #{@max_friendly_name_bytes} bytes"
+      }
+    })
   end
 
   defp bad_request(conn, message) do

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -131,6 +131,19 @@ defmodule LoopctlWeb.Router do
     post "/tenants/:id/rotate-audit-key", TenantAuditKeyController, :rotate
     post "/tenants/:id/bootstrap-audit-key", TenantAuditKeyController, :bootstrap
 
+    # US-26.7.2 — opt-in WebAuthn trust-tier upgrade (agent_rooted -> human_anchored)
+    # + authenticator revocation. Not tier-gated (enroll IS the upgrade path;
+    # revoke + subsequent-enroll are protected by fresh WebAuthn assertions instead —
+    # see require_human_anchor_default_deny_test.exs).
+    post "/tenants/:id/authenticators/challenge", TenantAuthenticatorController, :challenge
+    post "/tenants/:id/authenticators", TenantAuthenticatorController, :create
+
+    post "/tenants/:id/authenticators/revoke-challenge",
+         TenantAuthenticatorController,
+         :revoke_challenge
+
+    delete "/tenants/:id/authenticators/:auth_id", TenantAuthenticatorController, :delete
+
     # US-26.2.1 — Dispatch lineage
     resources "/dispatches", DispatchController, only: [:create, :show, :index]
 

--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to `loopctl-mcp-server` are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 2.36.0 — 2026-07-04 (US-26.7.2 — opt-in WebAuthn trust-tier upgrade ceremony)
+
+### Added
+
+- **`request_authenticator_challenge` / `enroll_authenticator` / `request_authenticator_revoke_challenge` / `revoke_authenticator`.**
+  Four thin tools driving the new opt-in WebAuthn trust-tier upgrade ceremony
+  (`agent_rooted` -> `human_anchored`) added server-side in US-26.7.2. An
+  agent-rooted (KB-tier) tenant created via `signup` can now enroll a
+  hardware authenticator to unlock the work-breakdown / chain-of-custody
+  surface WITHOUT creating a new tenant or losing its knowledge base. All
+  four require the exact `LOOPCTL_USER_KEY` (user role) bound to the target
+  `tenant_id` and are explicit that they are **not headless**: completing
+  enrollment/revocation requires an interactive WebAuthn client (a browser
+  or native FIDO2 library) with a human physically touching the hardware
+  authenticator — an agent alone cannot produce a valid attestation or
+  assertion. Enrolling a SECOND (backup) authenticator on an
+  already-`human_anchored` tenant additionally requires a fresh assertion
+  from an existing authenticator (`reauth_assertion`), and revoking a
+  tenant's last remaining authenticator is refused server-side (no
+  auto-downgrade).
+
 ## 2.34.0 — 2026-07-03 (smooth agent BYO-LLM onboarding — self-healing remediation + self-documenting tools)
 
 ### Added

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -1690,6 +1690,71 @@ async function signup({ name, slug, email }) {
   return toContent(result);
 }
 
+// US-26.7.2: opt-in WebAuthn trust-tier upgrade ceremony (agent_rooted ->
+// human_anchored) + authenticator revocation. All four require the EXACT
+// user-role key (LOOPCTL_USER_KEY) + ownership of `tenant_id` — mirroring
+// set_llm_config's exactKey:true pattern, since these mutate the tenant's
+// root of trust. NOT headless: completing enrollment/revocation requires an
+// INTERACTIVE WebAuthn client (a browser or a native FIDO2 library) with a
+// human present to touch the hardware authenticator — an agent alone cannot
+// produce a valid attestation or assertion, by design (see
+// docs/chain-of-custody-v2.md §9).
+async function requestAuthenticatorChallenge({ tenant_id }) {
+  const result = await apiCall(
+    "POST",
+    `/api/v1/tenants/${tenant_id}/authenticators/challenge`,
+    {},
+    process.env.LOOPCTL_USER_KEY,
+    { exactKey: true },
+  );
+  return toContent(result);
+}
+
+async function enrollAuthenticator({
+  tenant_id,
+  challenge_id,
+  attestation_object,
+  client_data_json,
+  credential_id,
+  friendly_name,
+  reauth_assertion,
+}) {
+  const body = { challenge_id, attestation_object, client_data_json, credential_id };
+  if (friendly_name != null) body.friendly_name = friendly_name;
+  if (reauth_assertion != null) body.reauth_assertion = reauth_assertion;
+
+  const result = await apiCall(
+    "POST",
+    `/api/v1/tenants/${tenant_id}/authenticators`,
+    body,
+    process.env.LOOPCTL_USER_KEY,
+    { exactKey: true },
+  );
+  return toContent(result);
+}
+
+async function requestAuthenticatorRevokeChallenge({ tenant_id }) {
+  const result = await apiCall(
+    "POST",
+    `/api/v1/tenants/${tenant_id}/authenticators/revoke-challenge`,
+    {},
+    process.env.LOOPCTL_USER_KEY,
+    { exactKey: true },
+  );
+  return toContent(result);
+}
+
+async function revokeAuthenticator({ tenant_id, authenticator_id, webauthn_assertion }) {
+  const result = await apiCall(
+    "DELETE",
+    `/api/v1/tenants/${tenant_id}/authenticators/${authenticator_id}`,
+    { webauthn_assertion },
+    process.env.LOOPCTL_USER_KEY,
+    { exactKey: true },
+  );
+  return toContent(result);
+}
+
 // US-26: Signed Tree Head retrieval
 async function getSth({ tenant_id }) {
   const result = await apiCall("GET", `/api/v1/audit/sth/${tenant_id}`);
@@ -3893,6 +3958,114 @@ const TOOLS = [
     },
   },
   {
+    name: "request_authenticator_challenge",
+    description:
+      "Step 1 of the opt-in WebAuthn trust-tier upgrade ceremony (US-26.7.2): issues a " +
+      "registration challenge for enrolling a hardware authenticator against an EXISTING " +
+      "agent_rooted (KB-tier) tenant, promoting it to human_anchored on success. " +
+      "IMPORTANT: completing this ceremony requires an INTERACTIVE WebAuthn client " +
+      "(a browser calling navigator.credentials.create(), or a native FIDO2 library) " +
+      "with a HUMAN present to physically touch the authenticator — an agent alone " +
+      "cannot produce a valid attestation, by design. Use this tool to fetch the " +
+      "challenge/rp/user/pubKeyCredParams payload, drive the WebAuthn ceremony in your " +
+      "interactive client, then call enroll_authenticator with the result. If the " +
+      "tenant is already human_anchored, the response includes reauth_required: true " +
+      "plus a reauth_challenge — enroll_authenticator will need a fresh assertion from " +
+      "an EXISTING authenticator too (see enroll_authenticator's description). Requires " +
+      "LOOPCTL_USER_KEY (user role) bound to tenant_id.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        tenant_id: { type: "string", description: "Tenant UUID to enroll an authenticator for." },
+      },
+      required: ["tenant_id"],
+    },
+  },
+  {
+    name: "enroll_authenticator",
+    description:
+      "Step 2 of the opt-in WebAuthn trust-tier upgrade ceremony: completes enrollment " +
+      "with the attestation produced by navigator.credentials.create() against the " +
+      "challenge from request_authenticator_challenge. On a tenant's FIRST enrollment " +
+      "(zero prior authenticators) this call FLIPS the tenant from agent_rooted to " +
+      "human_anchored, unlocking the work-breakdown / chain-of-custody surface " +
+      "(projects, stories, dispatch, ...). On a SUBSEQUENT (backup) enrollment for an " +
+      "already human_anchored tenant, `reauth_assertion` (a fresh WebAuthn assertion " +
+      "from an EXISTING enrolled authenticator, from the challenge's reauth_challenge) " +
+      "is REQUIRED — omitting it when required returns 401 reauth_required. All " +
+      "binary fields are base64url encoded. Requires LOOPCTL_USER_KEY (user role) " +
+      "bound to tenant_id. Cannot be completed by an agent alone — see " +
+      "request_authenticator_challenge.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        tenant_id: { type: "string", description: "Tenant UUID." },
+        challenge_id: {
+          type: "string",
+          description: "challenge_id from request_authenticator_challenge.",
+        },
+        attestation_object: { type: "string", description: "Base64url attestation object." },
+        client_data_json: { type: "string", description: "Base64url raw client data JSON." },
+        credential_id: { type: "string", description: "Base64url credential id." },
+        friendly_name: {
+          type: "string",
+          description: "Operator-supplied label (1..120 chars, default \"Authenticator\").",
+        },
+        reauth_assertion: {
+          type: "object",
+          description:
+            "Required ONLY when enrolling a backup authenticator on an already " +
+            "human_anchored tenant: a fresh assertion (challenge_id, credential_id, " +
+            "authenticator_data, signature, client_data_json — all base64url) from an " +
+            "EXISTING enrolled authenticator, bound to the reauth_challenge returned by " +
+            "request_authenticator_challenge.",
+        },
+      },
+      required: ["tenant_id", "challenge_id", "attestation_object", "client_data_json", "credential_id"],
+    },
+  },
+  {
+    name: "request_authenticator_revoke_challenge",
+    description:
+      "Issues a fresh-assertion challenge to authorize revoking one of a tenant's " +
+      "enrolled WebAuthn authenticators. Requires an INTERACTIVE WebAuthn client + " +
+      "human touch to produce the assertion revoke_authenticator needs — an agent " +
+      "alone cannot authorize a revocation. Requires LOOPCTL_USER_KEY (user role) " +
+      "bound to tenant_id.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        tenant_id: { type: "string", description: "Tenant UUID." },
+      },
+      required: ["tenant_id"],
+    },
+  },
+  {
+    name: "revoke_authenticator",
+    description:
+      "Revokes an enrolled authenticator using the assertion from " +
+      "request_authenticator_revoke_challenge (navigator.credentials.get() against an " +
+      "EXISTING authenticator — human touch required). Refuses (409 last_authenticator) " +
+      "to remove a human_anchored tenant's LAST authenticator — there is no " +
+      "auto-downgrade; losing every authenticator is a fatal, human-recovery-only event " +
+      "(docs/chain-of-custody-v2.md §9.3). Requires LOOPCTL_USER_KEY (user role) bound " +
+      "to tenant_id.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        tenant_id: { type: "string", description: "Tenant UUID." },
+        authenticator_id: { type: "string", description: "UUID of the authenticator to revoke." },
+        webauthn_assertion: {
+          type: "object",
+          description:
+            "The assertion (challenge_id, credential_id, authenticator_data, signature, " +
+            "client_data_json — all base64url) bound to the revoke-challenge.",
+        },
+      },
+      required: ["tenant_id", "authenticator_id", "webauthn_assertion"],
+    },
+  },
+  {
     name: "get_sth",
     description: "Get the latest Signed Tree Head for a tenant's audit chain. Public — no auth required.",
     inputSchema: {
@@ -4181,6 +4354,18 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     case "signup":
       return await signup(args);
+
+    case "request_authenticator_challenge":
+      return await requestAuthenticatorChallenge(args);
+
+    case "enroll_authenticator":
+      return await enrollAuthenticator(args);
+
+    case "request_authenticator_revoke_challenge":
+      return await requestAuthenticatorRevokeChallenge(args);
+
+    case "revoke_authenticator":
+      return await revokeAuthenticator(args);
 
     case "get_sth":
       return await getSth(args);

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.35.0",
+  "version": "2.36.0",
   "description": "MCP server for loopctl — structural trust for AI development loops",
   "type": "module",
   "main": "index.js",

--- a/priv/repo/migrations/20260704000000_create_webauthn_enrollment_challenges.exs
+++ b/priv/repo/migrations/20260704000000_create_webauthn_enrollment_challenges.exs
@@ -1,0 +1,56 @@
+defmodule Loopctl.Repo.Migrations.CreateWebauthnEnrollmentChallenges do
+  @moduledoc """
+  US-26.7.2 — creates `webauthn_enrollment_challenges`.
+
+  Backs the persisted, single-use, TTL-bound WebAuthn REGISTRATION-challenge
+  store for the opt-in trust-tier upgrade ceremony
+  (`Loopctl.WebAuthn.Enrollment`). Mirrors the `webauthn_reauth_challenges`
+  PERSISTENCE SHAPE (see `20260702120000_create_webauthn_reauth_challenges.exs`)
+  exactly — same columns, same single-use/TTL semantics — but is a SEPARATE
+  table: `Loopctl.WebAuthn.Reauth.issue_challenge/2` hard-requires an existing
+  enrolled authenticator (it embeds `allow_credentials`), which would make a
+  tenant's FIRST enrollment impossible. This table stores plain registration
+  challenges with no such precondition.
+
+  ## Tenant isolation (NOT via RLS here)
+
+  Every query against this table runs on `Loopctl.AdminRepo` (BYPASSRLS), so
+  the RLS policy enabled below is NEVER evaluated on the live path — tenant
+  isolation rests solely on the explicit `tenant_id` predicates in
+  `Loopctl.WebAuthn.Enrollment`. The policy is kept for defense-in-depth /
+  future RLS-repo use, mirroring the reauth-challenges table.
+  """
+
+  use Ecto.Migration
+  import Loopctl.Repo.RlsHelpers
+
+  def change do
+    create table(:webauthn_enrollment_challenges, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      add :tenant_id,
+          references(:tenants, type: :binary_id, on_delete: :delete_all),
+          null: false
+
+      # Ceremony this challenge authorizes — always "enroll_authenticator" today.
+      add :purpose, :string, null: false
+
+      # Opaque, adapter-produced REGISTRATION challenge, stored as
+      # Erlang-term-binary so it round-trips back to the WebAuthn adapter
+      # for verification (bytes + rp_id + origin + timeout).
+      add :challenge, :bytea, null: false
+
+      add :expires_at, :utc_datetime_usec, null: false
+      add :used_at, :utc_datetime_usec
+
+      # Only `inserted_at` — challenges are immutable except for the
+      # single-use `used_at` stamp, so no `updated_at`.
+      timestamps(type: :utc_datetime_usec, updated_at: false)
+    end
+
+    create index(:webauthn_enrollment_challenges, [:tenant_id])
+    create index(:webauthn_enrollment_challenges, [:expires_at])
+
+    enable_rls(:webauthn_enrollment_challenges)
+  end
+end

--- a/test/loopctl/tenants/enrollment_lock_test.exs
+++ b/test/loopctl/tenants/enrollment_lock_test.exs
@@ -1,0 +1,178 @@
+defmodule Loopctl.Tenants.EnrollmentLockTest do
+  @moduledoc """
+  US-26.7.2 (AC-26.7.2.8e/g, TC-26.7.2.5/.7) — deterministic proof that
+  `Loopctl.Tenants.Enrollment`'s `SELECT ... FOR UPDATE` tenant-row lock
+  genuinely serializes concurrent enrollment/revocation across SEPARATE DB
+  sessions.
+
+  A two-`Task.async` race under `Ecto.Adapters.SQL.Sandbox`'s default shared
+  mode cannot distinguish "lock present" from "lock absent" — the sandbox
+  multiplexes every allowed process onto ONE checked-out connection, which
+  already serializes access regardless of any application-level lock (the
+  same reasoning `token_usage/correction_lock_test.exs` documents for the
+  advisory-lock case). So this uses two genuinely independent
+  `sandbox: false` sessions, `async: false`, and cleans up its own real
+  (committed) rows via `on_exit` — deleting the tenant cascades (ON DELETE
+  CASCADE) to its authenticators and audit entries.
+  """
+
+  use ExUnit.Case, async: false
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Loopctl.AdminRepo
+  alias Loopctl.Audit
+  alias Loopctl.Tenants
+  alias Loopctl.Tenants.Enrollment
+  alias Loopctl.Tenants.RootAuthenticator
+  alias Loopctl.Tenants.Tenant
+
+  setup do
+    :ok = Sandbox.checkout(AdminRepo, sandbox: false)
+    :ok
+  end
+
+  defp real_tenant(attrs) do
+    %Tenant{}
+    |> Tenant.create_changeset(%{
+      name: "Lock Test Tenant #{System.unique_integer([:positive])}",
+      slug: "lock-test-#{System.unique_integer([:positive])}",
+      email: "lock-test-#{System.unique_integer([:positive])}@example.com"
+    })
+    |> AdminRepo.insert!()
+    |> Ecto.Changeset.change(Map.take(attrs, [:trust_tier]))
+    |> AdminRepo.update!()
+  end
+
+  defp attestation_attrs(overrides \\ %{}) do
+    Map.merge(
+      %{
+        credential_id: :crypto.strong_rand_bytes(32),
+        public_key: :erlang.term_to_binary(%{1 => 2, 3 => -7}),
+        attestation_format: "none",
+        sign_count: 0,
+        friendly_name: "Authenticator"
+      },
+      overrides
+    )
+  end
+
+  defp cleanup(tenant) do
+    on_exit(fn ->
+      :ok = Sandbox.checkout(AdminRepo, sandbox: false)
+      AdminRepo.delete_all(from(t in Tenant, where: t.id == ^tenant.id))
+    end)
+  end
+
+  test "the tenant-row FOR UPDATE lock blocks a second real session while held" do
+    tenant = real_tenant(%{trust_tier: :agent_rooted})
+    cleanup(tenant)
+
+    parent = self()
+
+    holder =
+      Task.async(fn ->
+        :ok = Sandbox.checkout(AdminRepo, sandbox: false)
+
+        AdminRepo.transaction(fn ->
+          from(t in Tenant, where: t.id == ^tenant.id, lock: "FOR UPDATE") |> AdminRepo.one()
+          send(parent, :locked)
+
+          receive do
+            :release -> :ok
+          end
+        end)
+      end)
+
+    assert_receive :locked, 2_000
+
+    # A different real session attempting the SAME row lock must NOT
+    # complete instantly — it blocks until the holder's transaction ends.
+    waiter =
+      Task.async(fn ->
+        :ok = Sandbox.checkout(AdminRepo, sandbox: false)
+        start = System.monotonic_time(:millisecond)
+
+        AdminRepo.transaction(fn ->
+          from(t in Tenant, where: t.id == ^tenant.id, lock: "FOR UPDATE") |> AdminRepo.one()
+        end)
+
+        System.monotonic_time(:millisecond) - start
+      end)
+
+    Process.sleep(200)
+    send(holder.pid, :release)
+    Task.await(holder, 2_000)
+
+    elapsed_ms = Task.await(waiter, 2_000)
+    assert elapsed_ms >= 150
+  end
+
+  test "a concurrent double-first-enroll writes exactly one tenant_trust_upgraded entry" do
+    tenant = real_tenant(%{trust_tier: :agent_rooted})
+    cleanup(tenant)
+
+    task_a =
+      Task.async(fn ->
+        :ok = Sandbox.checkout(AdminRepo, sandbox: false)
+        Enrollment.enroll(tenant.id, attestation_attrs())
+      end)
+
+    task_b =
+      Task.async(fn ->
+        :ok = Sandbox.checkout(AdminRepo, sandbox: false)
+        Enrollment.enroll(tenant.id, attestation_attrs())
+      end)
+
+    result_a = Task.await(task_a, 5_000)
+    result_b = Task.await(task_b, 5_000)
+
+    assert {:ok, %{authenticator: %RootAuthenticator{}}} = result_a
+    assert {:ok, %{authenticator: %RootAuthenticator{}}} = result_b
+
+    {:ok, final_tenant} = Tenants.get_tenant(tenant.id)
+    assert final_tenant.trust_tier == :human_anchored
+
+    {:ok, upgraded} =
+      Audit.list_entries(tenant.id, entity_type: "tenant", action: "tenant_trust_upgraded")
+
+    assert upgraded.total == 1
+
+    {:ok, enrolled} =
+      Audit.list_entries(tenant.id, entity_type: "tenant", action: "authenticator_enrolled")
+
+    assert enrolled.total == 1
+  end
+
+  test "concurrent revokes on a 2-authenticator tenant do not both succeed" do
+    tenant = real_tenant(%{trust_tier: :human_anchored})
+    cleanup(tenant)
+
+    {:ok, %{authenticator: auth_a}} = Enrollment.enroll(tenant.id, attestation_attrs())
+    {:ok, %{authenticator: auth_b}} = Enrollment.enroll(tenant.id, attestation_attrs())
+
+    task_a =
+      Task.async(fn ->
+        :ok = Sandbox.checkout(AdminRepo, sandbox: false)
+        Enrollment.revoke(tenant.id, auth_a.id)
+      end)
+
+    task_b =
+      Task.async(fn ->
+        :ok = Sandbox.checkout(AdminRepo, sandbox: false)
+        Enrollment.revoke(tenant.id, auth_b.id)
+      end)
+
+    results = [Task.await(task_a, 5_000), Task.await(task_b, 5_000)]
+
+    successes = Enum.count(results, &match?({:ok, _}, &1))
+    blocked = Enum.count(results, &match?({:error, :last_authenticator}, &1))
+
+    # The lock guarantees the SECOND revoke to acquire it re-counts under the
+    # first's already-committed delete — so it can never also succeed once
+    # only one authenticator remains. Exactly one succeeds, one is refused.
+    assert successes == 1
+    assert blocked == 1
+  end
+end

--- a/test/loopctl/tenants/enrollment_lock_test.exs
+++ b/test/loopctl/tenants/enrollment_lock_test.exs
@@ -26,6 +26,7 @@ defmodule Loopctl.Tenants.EnrollmentLockTest do
   alias Loopctl.Tenants
   alias Loopctl.Tenants.Enrollment
   alias Loopctl.Tenants.RootAuthenticator
+  alias Loopctl.Tenants.RootAuthenticators
   alias Loopctl.Tenants.Tenant
 
   setup do
@@ -109,30 +110,44 @@ defmodule Loopctl.Tenants.EnrollmentLockTest do
     assert elapsed_ms >= 150
   end
 
-  test "a concurrent double-first-enroll writes exactly one tenant_trust_upgraded entry" do
+  test "concurrent double-FIRST-enroll: exactly one succeeds, the loser is rejected :reauth_required" do
+    # SECURITY (review #1): both callers are FIRST enrollments (no
+    # add_authenticator assertion, assertion_verified? = false). They both read
+    # agent_rooted pre-lock. The one that wins the tenant-row lock flips to
+    # human_anchored + enrolls; the loser re-locks, sees human_anchored + no
+    # verified assertion, and is REJECTED :reauth_required. This models the
+    # attacker (stolen role:user key + own hardware) racing a legitimate first
+    # enroll: the attacker's device must NOT be grafted on.
     tenant = real_tenant(%{trust_tier: :agent_rooted})
     cleanup(tenant)
 
     task_a =
       Task.async(fn ->
         :ok = Sandbox.checkout(AdminRepo, sandbox: false)
-        Enrollment.enroll(tenant.id, attestation_attrs())
+        Enrollment.enroll(tenant.id, attestation_attrs(), false)
       end)
 
     task_b =
       Task.async(fn ->
         :ok = Sandbox.checkout(AdminRepo, sandbox: false)
-        Enrollment.enroll(tenant.id, attestation_attrs())
+        Enrollment.enroll(tenant.id, attestation_attrs(), false)
       end)
 
-    result_a = Task.await(task_a, 5_000)
-    result_b = Task.await(task_b, 5_000)
+    results = [Task.await(task_a, 5_000), Task.await(task_b, 5_000)]
 
-    assert {:ok, %{authenticator: %RootAuthenticator{}}} = result_a
-    assert {:ok, %{authenticator: %RootAuthenticator{}}} = result_b
+    successes = Enum.count(results, &match?({:ok, %{authenticator: %RootAuthenticator{}}}, &1))
+    rejected = Enum.count(results, &match?({:error, :reauth_required}, &1))
+
+    # Exactly one enrollment wins; the loser is turned away (must retry WITH an
+    # existing-authenticator assertion). NOT both-succeed.
+    assert successes == 1
+    assert rejected == 1
 
     {:ok, final_tenant} = Tenants.get_tenant(tenant.id)
     assert final_tenant.trust_tier == :human_anchored
+
+    # Exactly ONE authenticator was grafted on, and exactly ONE upgrade logged.
+    assert RootAuthenticators.count_by_tenant(tenant.id) == 1
 
     {:ok, upgraded} =
       Audit.list_entries(tenant.id, entity_type: "tenant", action: "tenant_trust_upgraded")
@@ -142,15 +157,16 @@ defmodule Loopctl.Tenants.EnrollmentLockTest do
     {:ok, enrolled} =
       Audit.list_entries(tenant.id, entity_type: "tenant", action: "authenticator_enrolled")
 
-    assert enrolled.total == 1
+    assert enrolled.total == 0
   end
 
   test "concurrent revokes on a 2-authenticator tenant do not both succeed" do
     tenant = real_tenant(%{trust_tier: :human_anchored})
     cleanup(tenant)
 
-    {:ok, %{authenticator: auth_a}} = Enrollment.enroll(tenant.id, attestation_attrs())
-    {:ok, %{authenticator: auth_b}} = Enrollment.enroll(tenant.id, attestation_attrs())
+    # Backup enrollment requires a verified assertion (assertion_verified? = true).
+    {:ok, %{authenticator: auth_a}} = Enrollment.enroll(tenant.id, attestation_attrs(), true)
+    {:ok, %{authenticator: auth_b}} = Enrollment.enroll(tenant.id, attestation_attrs(), true)
 
     task_a =
       Task.async(fn ->

--- a/test/loopctl/tenants/enrollment_test.exs
+++ b/test/loopctl/tenants/enrollment_test.exs
@@ -1,0 +1,149 @@
+defmodule Loopctl.Tenants.EnrollmentTest do
+  @moduledoc """
+  US-26.7.2 — the DB-only `Ecto.Multi` for enrollment (AC-26.7.2.3) and
+  revocation (AC-26.7.2.4): guarded tier flip, per-tenant authenticator cap,
+  race-safe last-authenticator revoke guard, and exactly-one audit entry per
+  outcome.
+  """
+
+  use Loopctl.DataCase, async: true
+
+  import Loopctl.Fixtures
+
+  alias Loopctl.Audit
+  alias Loopctl.Tenants
+  alias Loopctl.Tenants.Enrollment
+  alias Loopctl.Tenants.RootAuthenticators
+
+  defp attestation_attrs(overrides \\ %{}) do
+    Map.merge(
+      %{
+        credential_id: :crypto.strong_rand_bytes(32),
+        public_key: :erlang.term_to_binary(%{1 => 2, 3 => -7}),
+        attestation_format: "none",
+        sign_count: 0,
+        friendly_name: "Authenticator"
+      },
+      overrides
+    )
+  end
+
+  describe "enroll/2 — first enrollment" do
+    test "inserts the authenticator and flips agent_rooted -> human_anchored" do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+
+      assert {:ok, %{tenant: updated, authenticator: auth, upgraded: true}} =
+               Enrollment.enroll(tenant.id, attestation_attrs())
+
+      assert updated.trust_tier == :human_anchored
+      assert auth.tenant_id == tenant.id
+
+      {:ok, entries} =
+        Audit.list_entries(tenant.id, entity_type: "tenant", action: "tenant_trust_upgraded")
+
+      assert entries.total == 1
+      [entry] = entries.data
+      assert entry.old_state["trust_tier"] == "agent_rooted"
+      assert entry.new_state["trust_tier"] == "human_anchored"
+
+      assert entry.new_state["authenticator_fingerprint"] ==
+               Tenants.fingerprint(auth.credential_id)
+    end
+
+    test "an already human_anchored tenant's first-call enroll does NOT re-flip or re-log an upgrade" do
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+
+      assert {:ok, %{tenant: updated, upgraded: false}} =
+               Enrollment.enroll(tenant.id, attestation_attrs())
+
+      assert updated.trust_tier == :human_anchored
+
+      {:ok, upgraded} =
+        Audit.list_entries(tenant.id, entity_type: "tenant", action: "tenant_trust_upgraded")
+
+      assert upgraded.total == 0
+
+      {:ok, enrolled} =
+        Audit.list_entries(tenant.id, entity_type: "tenant", action: "authenticator_enrolled")
+
+      assert enrolled.total == 1
+    end
+
+    test "returns {:error, :not_found} for an unknown tenant" do
+      assert {:error, :not_found} = Enrollment.enroll(Ecto.UUID.generate(), attestation_attrs())
+    end
+
+    test "rejects re-enrolling the same credential_id for the same tenant" do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      credential_id = :crypto.strong_rand_bytes(32)
+
+      assert {:ok, _} =
+               Enrollment.enroll(tenant.id, attestation_attrs(%{credential_id: credential_id}))
+
+      assert {:error, %Ecto.Changeset{} = changeset} =
+               Enrollment.enroll(tenant.id, attestation_attrs(%{credential_id: credential_id}))
+
+      assert %{credential_id: [_ | _]} = errors_on(changeset)
+    end
+
+    test "enforces the per-tenant authenticator cap" do
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+
+      for _ <- 1..Enrollment.max_authenticators() do
+        fixture(:root_authenticator, tenant_id: tenant.id)
+      end
+
+      assert {:error, :too_many_authenticators} =
+               Enrollment.enroll(tenant.id, attestation_attrs())
+    end
+  end
+
+  describe "revoke/2" do
+    test "deletes a non-last authenticator and logs authenticator_revoked" do
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+      auth_a = fixture(:root_authenticator, tenant_id: tenant.id)
+      auth_b = fixture(:root_authenticator, tenant_id: tenant.id)
+
+      assert {:ok, deleted} = Enrollment.revoke(tenant.id, auth_b.id)
+      assert deleted.id == auth_b.id
+
+      assert {:ok, remaining} =
+               RootAuthenticators.get_by_credential_id(tenant.id, auth_a.credential_id)
+
+      assert remaining.id == auth_a.id
+
+      assert {:error, :not_found} =
+               RootAuthenticators.get_by_credential_id(tenant.id, auth_b.credential_id)
+
+      {:ok, entries} =
+        Audit.list_entries(tenant.id, entity_type: "tenant", action: "authenticator_revoked")
+
+      assert entries.total == 1
+    end
+
+    test "refuses to revoke the LAST authenticator on a human_anchored tenant" do
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+      auth = fixture(:root_authenticator, tenant_id: tenant.id)
+
+      assert {:error, :last_authenticator} = Enrollment.revoke(tenant.id, auth.id)
+      assert {:ok, _} = RootAuthenticators.get_by_credential_id(tenant.id, auth.credential_id)
+    end
+
+    test "returns {:error, :not_found} for an unknown authenticator id" do
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+      fixture(:root_authenticator, tenant_id: tenant.id)
+
+      assert {:error, :not_found} = Enrollment.revoke(tenant.id, Ecto.UUID.generate())
+    end
+
+    test "returns {:error, :not_found} for a cross-tenant authenticator id" do
+      tenant_a = fixture(:tenant, %{trust_tier: :human_anchored})
+      tenant_b = fixture(:tenant, %{trust_tier: :human_anchored})
+      auth_b = fixture(:root_authenticator, tenant_id: tenant_b.id)
+      fixture(:root_authenticator, tenant_id: tenant_a.id)
+
+      assert {:error, :not_found} = Enrollment.revoke(tenant_a.id, auth_b.id)
+      assert {:ok, _} = RootAuthenticators.get_by_credential_id(tenant_b.id, auth_b.credential_id)
+    end
+  end
+end

--- a/test/loopctl/tenants/enrollment_test.exs
+++ b/test/loopctl/tenants/enrollment_test.exs
@@ -29,11 +29,13 @@ defmodule Loopctl.Tenants.EnrollmentTest do
   end
 
   describe "enroll/2 — first enrollment" do
-    test "inserts the authenticator and flips agent_rooted -> human_anchored" do
+    test "inserts the authenticator and flips agent_rooted -> human_anchored (no assertion)" do
       tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
 
+      # First enrollment: locked tier is agent_rooted, so no add_authenticator
+      # assertion is required -> assertion_verified? = false is legitimate.
       assert {:ok, %{tenant: updated, authenticator: auth, upgraded: true}} =
-               Enrollment.enroll(tenant.id, attestation_attrs())
+               Enrollment.enroll(tenant.id, attestation_attrs(), false)
 
       assert updated.trust_tier == :human_anchored
       assert auth.tenant_id == tenant.id
@@ -50,11 +52,29 @@ defmodule Loopctl.Tenants.EnrollmentTest do
                Tenants.fingerprint(auth.credential_id)
     end
 
-    test "an already human_anchored tenant's first-call enroll does NOT re-flip or re-log an upgrade" do
+    test "a human_anchored tenant enroll WITHOUT a verified assertion is rejected at the enroll/3 layer" do
+      # The backup-enrollment invariant now lives UNDER THE LOCK, not only in
+      # the controller: even calling enroll/3 directly, a human_anchored tenant
+      # with assertion_verified? = false must be rejected :reauth_required and
+      # insert NO authenticator.
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+
+      assert {:error, :reauth_required} =
+               Enrollment.enroll(tenant.id, attestation_attrs(), false)
+
+      assert RootAuthenticators.count_by_tenant(tenant.id) == 0
+
+      {:ok, enrolled} =
+        Audit.list_entries(tenant.id, entity_type: "tenant", action: "authenticator_enrolled")
+
+      assert enrolled.total == 0
+    end
+
+    test "a human_anchored tenant enroll WITH a verified assertion enrolls a backup, no re-flip" do
       tenant = fixture(:tenant, %{trust_tier: :human_anchored})
 
       assert {:ok, %{tenant: updated, upgraded: false}} =
-               Enrollment.enroll(tenant.id, attestation_attrs())
+               Enrollment.enroll(tenant.id, attestation_attrs(), true)
 
       assert updated.trust_tier == :human_anchored
 
@@ -70,18 +90,31 @@ defmodule Loopctl.Tenants.EnrollmentTest do
     end
 
     test "returns {:error, :not_found} for an unknown tenant" do
-      assert {:error, :not_found} = Enrollment.enroll(Ecto.UUID.generate(), attestation_attrs())
+      assert {:error, :not_found} =
+               Enrollment.enroll(Ecto.UUID.generate(), attestation_attrs(), false)
     end
 
     test "rejects re-enrolling the same credential_id for the same tenant" do
       tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
       credential_id = :crypto.strong_rand_bytes(32)
 
+      # First enroll flips agent_rooted -> human_anchored (no assertion needed).
       assert {:ok, _} =
-               Enrollment.enroll(tenant.id, attestation_attrs(%{credential_id: credential_id}))
+               Enrollment.enroll(
+                 tenant.id,
+                 attestation_attrs(%{credential_id: credential_id}),
+                 false
+               )
 
+      # Re-enroll the SAME credential on the now-human_anchored tenant, with a
+      # verified assertion (assertion_verified? = true) so the request passes
+      # the backup gate and reaches the unique-constraint violation.
       assert {:error, %Ecto.Changeset{} = changeset} =
-               Enrollment.enroll(tenant.id, attestation_attrs(%{credential_id: credential_id}))
+               Enrollment.enroll(
+                 tenant.id,
+                 attestation_attrs(%{credential_id: credential_id}),
+                 true
+               )
 
       assert %{credential_id: [_ | _]} = errors_on(changeset)
     end
@@ -93,8 +126,9 @@ defmodule Loopctl.Tenants.EnrollmentTest do
         fixture(:root_authenticator, tenant_id: tenant.id)
       end
 
+      # assertion_verified? = true so we pass the backup gate and hit the cap.
       assert {:error, :too_many_authenticators} =
-               Enrollment.enroll(tenant.id, attestation_attrs())
+               Enrollment.enroll(tenant.id, attestation_attrs(), true)
     end
   end
 

--- a/test/loopctl/web_authn/enrollment_test.exs
+++ b/test/loopctl/web_authn/enrollment_test.exs
@@ -1,0 +1,90 @@
+defmodule Loopctl.WebAuthn.EnrollmentTest do
+  @moduledoc """
+  US-26.7.2 (AC-26.7.2.1) — the persisted, single-use, TTL-bound WebAuthn
+  REGISTRATION-challenge store backing the opt-in trust-tier upgrade
+  ceremony. Verifies the atomic single-use `update_all` consume pattern has
+  no TOCTOU (replay/double-spend/wrong-tenant/expired all fail closed) and
+  that issuance carries NO existing-authenticator precondition (unlike
+  `Reauth.issue_challenge/2`), since that's exactly what makes a tenant's
+  FIRST enrollment possible.
+  """
+
+  use Loopctl.DataCase, async: true
+
+  import Loopctl.Fixtures
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.WebAuthn.Enrollment
+  alias Loopctl.WebAuthn.EnrollmentChallenge
+
+  setup :verify_on_exit!
+
+  describe "issue/1" do
+    test "persists a single-use registration challenge with no existing-authenticator precondition" do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+
+      # Zero authenticators — Reauth.issue_challenge/2 would refuse this
+      # tenant with {:error, :no_authenticators}. issue/1 must not.
+      assert {:ok, issued} = Enrollment.issue(tenant.id)
+      assert is_binary(issued.challenge_id)
+      assert issued.challenge_bytes != ""
+      assert DateTime.compare(issued.expires_at, DateTime.utc_now()) == :gt
+
+      stored = AdminRepo.get!(EnrollmentChallenge, issued.challenge_id)
+      assert stored.tenant_id == tenant.id
+      assert stored.purpose == "enroll_authenticator"
+      assert is_nil(stored.used_at)
+    end
+  end
+
+  describe "consume/2" do
+    test "consumes a fresh challenge exactly once" do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      {:ok, issued} = Enrollment.issue(tenant.id)
+
+      assert {:ok, _challenge} = Enrollment.consume(tenant.id, issued.challenge_id)
+
+      stored = AdminRepo.get!(EnrollmentChallenge, issued.challenge_id)
+      refute is_nil(stored.used_at)
+    end
+
+    test "replay of an already-consumed challenge is rejected" do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      {:ok, issued} = Enrollment.issue(tenant.id)
+
+      assert {:ok, _challenge} = Enrollment.consume(tenant.id, issued.challenge_id)
+      assert {:error, :challenge_not_found} = Enrollment.consume(tenant.id, issued.challenge_id)
+    end
+
+    test "an expired challenge is rejected" do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      {:ok, issued} = Enrollment.issue(tenant.id)
+
+      AdminRepo.get!(EnrollmentChallenge, issued.challenge_id)
+      |> Ecto.Changeset.change(expires_at: DateTime.add(DateTime.utc_now(), -1, :second))
+      |> AdminRepo.update!()
+
+      assert {:error, :challenge_not_found} = Enrollment.consume(tenant.id, issued.challenge_id)
+    end
+
+    test "a challenge cannot be consumed by a different tenant" do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      other_tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      {:ok, issued} = Enrollment.issue(tenant.id)
+
+      assert {:error, :challenge_not_found} =
+               Enrollment.consume(other_tenant.id, issued.challenge_id)
+    end
+
+    test "an unknown challenge id is rejected" do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      assert {:error, :challenge_not_found} = Enrollment.consume(tenant.id, Ecto.UUID.generate())
+    end
+
+    test "a non-UUID challenge id is rejected without raising" do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      assert {:error, :invalid_challenge_id} = Enrollment.consume(tenant.id, "not-a-uuid")
+      assert {:error, :invalid_challenge_id} = Enrollment.consume(tenant.id, nil)
+    end
+  end
+end

--- a/test/loopctl/web_authn/reauth_test.exs
+++ b/test/loopctl/web_authn/reauth_test.exs
@@ -228,6 +228,32 @@ defmodule Loopctl.WebAuthn.ReauthTest do
       {:ok, reloaded} = RootAuthenticators.get_by_credential_id(tenant.id, auth.credential_id)
       assert reloaded.sign_count == 4
     end
+
+    # US-26.7.2 review #2: an oversized assertion field is rejected BEFORE any
+    # base64 decode or CPU-bound verification — and, because the size check in
+    # `fetch_b64/2` precedes `consume_challenge/3` in the `with` chain, WITHOUT
+    # even burning the single-use challenge. Applies to every Reauth caller
+    # (rotate_audit_key, add_authenticator, revoke_authenticator).
+    test "rejects an oversized assertion field before consuming the challenge or verifying" do
+      tenant = fixture(:tenant)
+      auth = fixture(:root_authenticator, tenant_id: tenant.id, sign_count: 0)
+      {:ok, issued} = Reauth.issue_challenge(tenant.id, @purpose)
+
+      # A field an order of magnitude over the 8 KB cap.
+      oversized = Base.url_encode64(:crypto.strong_rand_bytes(64 * 1024), padding: false)
+
+      params =
+        assertion_params(issued.challenge_id, auth.credential_id, %{"signature" => oversized})
+
+      assert {:error, {:field_too_large, "signature"}} =
+               Reauth.verify_and_consume(tenant.id, @purpose, params)
+
+      # Structural proof it was rejected BEFORE verify: `consume_challenge/3`
+      # runs strictly after `fetch_b64/2` and strictly before
+      # `verify_authentication`, so an un-burned challenge means neither ran.
+      stored = AdminRepo.get!(ReauthChallenge, issued.challenge_id)
+      assert is_nil(stored.used_at)
+    end
   end
 
   describe "verify_and_consume/3 — real Wax adapter (end-to-end crypto)" do

--- a/test/loopctl/workers/reauth_challenge_cleanup_worker_test.exs
+++ b/test/loopctl/workers/reauth_challenge_cleanup_worker_test.exs
@@ -1,0 +1,88 @@
+defmodule Loopctl.Workers.ReauthChallengeCleanupWorkerTest do
+  @moduledoc """
+  crypto-01 / US-26.7.2 (AC-26.7.2.1) — regression test proving the hourly
+  cleanup worker sweeps BOTH `webauthn_reauth_challenges` and
+  `webauthn_enrollment_challenges`, so neither table grows unbounded.
+  """
+
+  use Loopctl.DataCase, async: true
+
+  import Loopctl.Fixtures
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.WebAuthn.EnrollmentChallenge
+  alias Loopctl.WebAuthn.ReauthChallenge
+  alias Loopctl.Workers.ReauthChallengeCleanupWorker
+
+  defp insert_reauth_challenge(tenant_id, expires_at, used_at \\ nil) do
+    %ReauthChallenge{tenant_id: tenant_id}
+    |> ReauthChallenge.create_changeset(%{
+      purpose: "rotate_audit_key",
+      challenge: :erlang.term_to_binary(%{bytes: :crypto.strong_rand_bytes(16)}),
+      expires_at: expires_at
+    })
+    |> AdminRepo.insert!()
+    |> then(fn row ->
+      if used_at do
+        row |> Ecto.Changeset.change(used_at: used_at) |> AdminRepo.update!()
+      else
+        row
+      end
+    end)
+  end
+
+  defp insert_enrollment_challenge(tenant_id, expires_at, used_at \\ nil) do
+    %EnrollmentChallenge{tenant_id: tenant_id}
+    |> EnrollmentChallenge.create_changeset(%{
+      purpose: "enroll_authenticator",
+      challenge: :erlang.term_to_binary(%{bytes: :crypto.strong_rand_bytes(16)}),
+      expires_at: expires_at
+    })
+    |> AdminRepo.insert!()
+    |> then(fn row ->
+      if used_at do
+        row |> Ecto.Changeset.change(used_at: used_at) |> AdminRepo.update!()
+      else
+        row
+      end
+    end)
+  end
+
+  test "deletes expired and used rows from both challenge tables, keeps live unused rows" do
+    tenant = fixture(:tenant)
+    now = DateTime.utc_now()
+    future = DateTime.add(now, 300, :second)
+    past = DateTime.add(now, -60, :second)
+
+    expired_reauth = insert_reauth_challenge(tenant.id, past)
+    used_reauth = insert_reauth_challenge(tenant.id, future, now)
+    live_reauth = insert_reauth_challenge(tenant.id, future)
+
+    expired_enrollment = insert_enrollment_challenge(tenant.id, past)
+    used_enrollment = insert_enrollment_challenge(tenant.id, future, now)
+    live_enrollment = insert_enrollment_challenge(tenant.id, future)
+
+    assert :ok = ReauthChallengeCleanupWorker.perform(%Oban.Job{args: %{}})
+
+    refute AdminRepo.get(ReauthChallenge, expired_reauth.id)
+    refute AdminRepo.get(ReauthChallenge, used_reauth.id)
+    assert AdminRepo.get(ReauthChallenge, live_reauth.id)
+
+    refute AdminRepo.get(EnrollmentChallenge, expired_enrollment.id)
+    refute AdminRepo.get(EnrollmentChallenge, used_enrollment.id)
+    assert AdminRepo.get(EnrollmentChallenge, live_enrollment.id)
+  end
+
+  test "is a no-op when both tables are empty of stale rows" do
+    tenant = fixture(:tenant)
+    future = DateTime.add(DateTime.utc_now(), 300, :second)
+
+    live_reauth = insert_reauth_challenge(tenant.id, future)
+    live_enrollment = insert_enrollment_challenge(tenant.id, future)
+
+    assert :ok = ReauthChallengeCleanupWorker.perform(%Oban.Job{args: %{}})
+
+    assert AdminRepo.get(ReauthChallenge, live_reauth.id)
+    assert AdminRepo.get(EnrollmentChallenge, live_enrollment.id)
+  end
+end

--- a/test/loopctl_web/controllers/openapi_test.exs
+++ b/test/loopctl_web/controllers/openapi_test.exs
@@ -45,6 +45,12 @@ defmodule LoopctlWeb.OpenApiTest do
       # US-26.7.1 (#10) — the public agent-rooted self-signup endpoint must stay
       # registered in the OpenAPI spec (it's the API tenant-creation path).
       assert "/api/v1/signup" in paths
+      # US-26.7.2 — the opt-in WebAuthn trust-tier upgrade ceremony endpoints
+      # must be registered.
+      assert "/api/v1/tenants/{id}/authenticators/challenge" in paths
+      assert "/api/v1/tenants/{id}/authenticators" in paths
+      assert "/api/v1/tenants/{id}/authenticators/revoke-challenge" in paths
+      assert "/api/v1/tenants/{id}/authenticators/{auth_id}" in paths
     end
   end
 

--- a/test/loopctl_web/controllers/tenant_authenticator_controller_test.exs
+++ b/test/loopctl_web/controllers/tenant_authenticator_controller_test.exs
@@ -1,0 +1,548 @@
+defmodule LoopctlWeb.TenantAuthenticatorControllerTest do
+  @moduledoc """
+  US-26.7.2 — the opt-in WebAuthn trust-tier upgrade ceremony
+  (agent_rooted -> human_anchored) and authenticator revocation. Covers the
+  story's test cases TC-26.7.2.1 through TC-26.7.2.7.
+  """
+
+  use LoopctlWeb.ConnCase, async: true
+
+  import Loopctl.Fixtures
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Audit
+  alias Loopctl.Tenants
+  alias Loopctl.Tenants.RootAuthenticators
+  alias Loopctl.WebAuthn.EnrollmentChallenge
+
+  setup :verify_on_exit!
+
+  # A reauth assertion body (add_authenticator / revoke_authenticator
+  # purposes) — mirrors tenant_audit_key_controller_test.exs's shape.
+  defp assertion_body(challenge_id, credential_id) do
+    %{
+      "challenge_id" => challenge_id,
+      "credential_id" => Base.url_encode64(credential_id, padding: false),
+      "authenticator_data" => Base.url_encode64(:crypto.strong_rand_bytes(37), padding: false),
+      "signature" => Base.url_encode64(:crypto.strong_rand_bytes(64), padding: false),
+      "client_data_json" => Base.url_encode64(~s({"type":"webauthn.get"}), padding: false)
+    }
+  end
+
+  # A registration attestation body for POST .../authenticators.
+  defp attestation_body(challenge_id, opts \\ []) do
+    credential_id = Keyword.get(opts, :credential_id, :crypto.strong_rand_bytes(32))
+
+    base = %{
+      "challenge_id" => challenge_id,
+      "attestation_object" => Base.url_encode64(:crypto.strong_rand_bytes(64), padding: false),
+      "client_data_json" => Base.url_encode64(~s({"type":"webauthn.create"}), padding: false),
+      "credential_id" => Base.url_encode64(credential_id, padding: false)
+    }
+
+    case Keyword.get(opts, :friendly_name) do
+      nil -> base
+      name -> Map.put(base, "friendly_name", name)
+    end
+    |> maybe_put_reauth(Keyword.get(opts, :reauth_assertion))
+  end
+
+  defp maybe_put_reauth(body, nil), do: body
+  defp maybe_put_reauth(body, assertion), do: Map.put(body, "reauth_assertion", assertion)
+
+  defp authed(conn, raw_key) do
+    put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  describe "POST /api/v1/tenants/:id/authenticators/challenge" do
+    test "issues a registration challenge for an agent_rooted tenant (no reauth required)", %{
+      conn: conn
+    } do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+
+      resp =
+        conn
+        |> authed(raw_key)
+        |> post(~p"/api/v1/tenants/#{tenant.id}/authenticators/challenge", %{})
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      assert resp["challenge_id"]
+      assert resp["challenge"] != ""
+      assert resp["rp"]["id"]
+      assert resp["user"]["id"]
+      assert resp["pub_key_cred_params"] != []
+      assert resp["reauth_required"] == false
+      refute Map.has_key?(resp, "reauth_challenge")
+    end
+
+    test "includes a reauth challenge when the tenant is already human_anchored", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+      auth = fixture(:root_authenticator, tenant_id: tenant.id)
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+
+      resp =
+        conn
+        |> authed(raw_key)
+        |> post(~p"/api/v1/tenants/#{tenant.id}/authenticators/challenge", %{})
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      assert resp["reauth_required"] == true
+      assert resp["reauth_challenge"]["challenge_id"]
+
+      assert Base.url_encode64(auth.credential_id, padding: false) in resp["reauth_challenge"][
+               "allowed_credentials"
+             ]
+    end
+
+    test "rejects when the caller doesn't own the target tenant", %{conn: conn} do
+      tenant_a = fixture(:tenant, %{trust_tier: :agent_rooted})
+      tenant_b = fixture(:tenant, %{trust_tier: :agent_rooted})
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant_a.id, role: :user)
+
+      conn =
+        conn
+        |> authed(raw_key)
+        |> post(~p"/api/v1/tenants/#{tenant_b.id}/authenticators/challenge", %{})
+
+      assert json_response(conn, 403)["error"]["message"] == "Forbidden"
+    end
+
+    test "is rate limited", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+
+      Mox.expect(Loopctl.MockRateLimiter, :check_rate, fn _bucket, _window, _limit ->
+        {:deny, 0}
+      end)
+
+      conn =
+        conn
+        |> authed(raw_key)
+        |> post(~p"/api/v1/tenants/#{tenant.id}/authenticators/challenge", %{})
+
+      assert json_response(conn, 429)["error"]["code"] == "rate_limited"
+    end
+  end
+
+  describe "POST /api/v1/tenants/:id/authenticators — full round trip (TC-26.7.2.1)" do
+    test "self-signup -> 403 on custody op -> enroll -> human_anchored -> custody op passes", %{
+      conn: conn
+    } do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+      client = authed(conn, raw_key)
+
+      project_params = %{"name" => "First project", "slug" => "first-project"}
+
+      denied = post(client, ~p"/api/v1/projects", project_params)
+      assert json_response(denied, 403)["error"]["code"] == "custody_tier_required"
+
+      challenge_data =
+        client
+        |> post(~p"/api/v1/tenants/#{tenant.id}/authenticators/challenge", %{})
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      enroll_resp =
+        client
+        |> post(
+          ~p"/api/v1/tenants/#{tenant.id}/authenticators",
+          attestation_body(challenge_data["challenge_id"])
+        )
+        |> json_response(201)
+        |> Map.fetch!("data")
+
+      assert enroll_resp["trust_tier"] == "human_anchored"
+      assert enroll_resp["upgraded"] == true
+      assert enroll_resp["authenticator"]["friendly_name"] == "Authenticator"
+
+      {:ok, tenant_reloaded} = Tenants.get_tenant(tenant.id)
+      assert tenant_reloaded.trust_tier == :human_anchored
+
+      {:ok, entries} =
+        Audit.list_entries(tenant.id, entity_type: "tenant", action: "tenant_trust_upgraded")
+
+      assert entries.total == 1
+
+      allowed = post(client, ~p"/api/v1/projects", project_params)
+      assert json_response(allowed, 201)
+    end
+  end
+
+  describe "POST /api/v1/tenants/:id/authenticators — subsequent enrollment gate (TC-26.7.2.2)" do
+    setup do
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+      auth = fixture(:root_authenticator, tenant_id: tenant.id)
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+      %{tenant: tenant, auth: auth, raw_key: raw_key}
+    end
+
+    test "without the existing-authenticator assertion is rejected 401", %{
+      conn: conn,
+      tenant: tenant,
+      raw_key: raw_key
+    } do
+      client = authed(conn, raw_key)
+
+      challenge_data =
+        client
+        |> post(~p"/api/v1/tenants/#{tenant.id}/authenticators/challenge", %{})
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      assert challenge_data["reauth_required"] == true
+
+      resp =
+        client
+        |> post(
+          ~p"/api/v1/tenants/#{tenant.id}/authenticators",
+          attestation_body(challenge_data["challenge_id"])
+        )
+
+      assert json_response(resp, 401)["error"]["code"] == "reauth_required"
+      assert RootAuthenticators.count_by_tenant(tenant.id) == 1
+    end
+
+    test "with a valid existing-authenticator assertion succeeds and stays human_anchored", %{
+      conn: conn,
+      tenant: tenant,
+      auth: auth,
+      raw_key: raw_key
+    } do
+      client = authed(conn, raw_key)
+
+      challenge_data =
+        client
+        |> post(~p"/api/v1/tenants/#{tenant.id}/authenticators/challenge", %{})
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      reauth_assertion =
+        assertion_body(challenge_data["reauth_challenge"]["challenge_id"], auth.credential_id)
+
+      resp =
+        client
+        |> post(
+          ~p"/api/v1/tenants/#{tenant.id}/authenticators",
+          attestation_body(challenge_data["challenge_id"], reauth_assertion: reauth_assertion)
+        )
+        |> json_response(201)
+        |> Map.fetch!("data")
+
+      assert resp["trust_tier"] == "human_anchored"
+      assert resp["upgraded"] == false
+      assert RootAuthenticators.count_by_tenant(tenant.id) == 2
+
+      {:ok, upgraded} =
+        Audit.list_entries(tenant.id, entity_type: "tenant", action: "tenant_trust_upgraded")
+
+      assert upgraded.total == 0
+
+      {:ok, enrolled} =
+        Audit.list_entries(tenant.id, entity_type: "tenant", action: "authenticator_enrolled")
+
+      assert enrolled.total == 1
+    end
+  end
+
+  describe "POST /api/v1/tenants/:id/authenticators — forged attestation (TC-26.7.2.3)" do
+    test "does not enroll, does not flip the tier, and does not un-burn the challenge", %{
+      conn: conn
+    } do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+      client = authed(conn, raw_key)
+
+      Mox.expect(Loopctl.MockWebAuthn, :verify_registration, fn _payload, _challenge, _opts ->
+        {:error, :invalid_attestation}
+      end)
+
+      challenge_data =
+        client
+        |> post(~p"/api/v1/tenants/#{tenant.id}/authenticators/challenge", %{})
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      resp =
+        client
+        |> post(
+          ~p"/api/v1/tenants/#{tenant.id}/authenticators",
+          attestation_body(challenge_data["challenge_id"])
+        )
+
+      assert json_response(resp, 401)["error"]["code"] == "webauthn_failed"
+      assert RootAuthenticators.count_by_tenant(tenant.id) == 0
+
+      {:ok, tenant_reloaded} = Tenants.get_tenant(tenant.id)
+      assert tenant_reloaded.trust_tier == :agent_rooted
+
+      {:ok, upgraded} =
+        Audit.list_entries(tenant.id, entity_type: "tenant", action: "tenant_trust_upgraded")
+
+      assert upgraded.total == 0
+
+      # Replaying the SAME (already-consumed-in-phase-1) challenge is refused.
+      replay =
+        client
+        |> post(
+          ~p"/api/v1/tenants/#{tenant.id}/authenticators",
+          attestation_body(challenge_data["challenge_id"])
+        )
+
+      assert json_response(replay, 401)["error"]["code"] == "challenge_invalid"
+    end
+  end
+
+  describe "registration challenge is single-use and TTL-bound (TC-26.7.2.4)" do
+    test "replay of an already-consumed challenge_id is rejected", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+      client = authed(conn, raw_key)
+
+      challenge_data =
+        client
+        |> post(~p"/api/v1/tenants/#{tenant.id}/authenticators/challenge", %{})
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      assert client
+             |> post(
+               ~p"/api/v1/tenants/#{tenant.id}/authenticators",
+               attestation_body(challenge_data["challenge_id"])
+             )
+             |> json_response(201)
+
+      replay =
+        client
+        |> post(
+          ~p"/api/v1/tenants/#{tenant.id}/authenticators",
+          attestation_body(challenge_data["challenge_id"])
+        )
+
+      assert json_response(replay, 401)["error"]["code"] == "challenge_invalid"
+      assert RootAuthenticators.count_by_tenant(tenant.id) == 1
+    end
+
+    test "an expired challenge is rejected", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+      client = authed(conn, raw_key)
+
+      challenge_data =
+        client
+        |> post(~p"/api/v1/tenants/#{tenant.id}/authenticators/challenge", %{})
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      AdminRepo.get!(EnrollmentChallenge, challenge_data["challenge_id"])
+      |> Ecto.Changeset.change(expires_at: DateTime.add(DateTime.utc_now(), -1, :second))
+      |> AdminRepo.update!()
+
+      resp =
+        client
+        |> post(
+          ~p"/api/v1/tenants/#{tenant.id}/authenticators",
+          attestation_body(challenge_data["challenge_id"])
+        )
+
+      assert json_response(resp, 401)["error"]["code"] == "challenge_invalid"
+      assert RootAuthenticators.count_by_tenant(tenant.id) == 0
+    end
+  end
+
+  describe "revoke ceremony (TC-26.7.2.5)" do
+    test "revoking the last authenticator is refused with 409, no auto-downgrade", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+      auth = fixture(:root_authenticator, tenant_id: tenant.id)
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+      client = authed(conn, raw_key)
+
+      challenge_data =
+        client
+        |> post(~p"/api/v1/tenants/#{tenant.id}/authenticators/revoke-challenge", %{})
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      resp =
+        client
+        |> delete(~p"/api/v1/tenants/#{tenant.id}/authenticators/#{auth.id}", %{
+          "webauthn_assertion" =>
+            assertion_body(challenge_data["challenge_id"], auth.credential_id)
+        })
+
+      assert json_response(resp, 409)["error"]["code"] == "last_authenticator"
+      assert RootAuthenticators.count_by_tenant(tenant.id) == 1
+
+      {:ok, tenant_reloaded} = Tenants.get_tenant(tenant.id)
+      assert tenant_reloaded.trust_tier == :human_anchored
+    end
+
+    test "revoking a non-last authenticator succeeds", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+      auth_a = fixture(:root_authenticator, tenant_id: tenant.id)
+      auth_b = fixture(:root_authenticator, tenant_id: tenant.id)
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+      client = authed(conn, raw_key)
+
+      challenge_data =
+        client
+        |> post(~p"/api/v1/tenants/#{tenant.id}/authenticators/revoke-challenge", %{})
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      resp =
+        client
+        |> delete(~p"/api/v1/tenants/#{tenant.id}/authenticators/#{auth_b.id}", %{
+          "webauthn_assertion" =>
+            assertion_body(challenge_data["challenge_id"], auth_a.credential_id)
+        })
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      assert resp["revoked"] == true
+      assert RootAuthenticators.count_by_tenant(tenant.id) == 1
+    end
+
+    test "missing assertion is rejected 401", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+      auth_a = fixture(:root_authenticator, tenant_id: tenant.id)
+      fixture(:root_authenticator, tenant_id: tenant.id)
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+
+      resp =
+        conn
+        |> authed(raw_key)
+        |> delete(~p"/api/v1/tenants/#{tenant.id}/authenticators/#{auth_a.id}", %{})
+
+      assert json_response(resp, 401)["error"]["code"] == "webauthn_required"
+    end
+  end
+
+  describe "cross-tenant isolation (TC-26.7.2.6)" do
+    test "every action 403s when the caller doesn't own the target tenant", %{conn: conn} do
+      tenant_a = fixture(:tenant, %{trust_tier: :agent_rooted})
+      tenant_b = fixture(:tenant, %{trust_tier: :human_anchored})
+      auth_b = fixture(:root_authenticator, tenant_id: tenant_b.id)
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant_a.id, role: :user)
+      client = authed(conn, raw_key)
+
+      assert client
+             |> post(~p"/api/v1/tenants/#{tenant_b.id}/authenticators/challenge", %{})
+             |> json_response(403)
+
+      assert client
+             |> post(~p"/api/v1/tenants/#{tenant_b.id}/authenticators", %{
+               "challenge_id" => Ecto.UUID.generate()
+             })
+             |> json_response(403)
+
+      assert client
+             |> post(~p"/api/v1/tenants/#{tenant_b.id}/authenticators/revoke-challenge", %{})
+             |> json_response(403)
+
+      assert client
+             |> delete(~p"/api/v1/tenants/#{tenant_b.id}/authenticators/#{auth_b.id}", %{
+               "webauthn_assertion" => assertion_body(Ecto.UUID.generate(), auth_b.credential_id)
+             })
+             |> json_response(403)
+
+      assert RootAuthenticators.count_by_tenant(tenant_b.id) == 1
+    end
+  end
+
+  describe "credential_id uniqueness (AC-26.7.2.8i)" do
+    test "re-enrolling the same credential_id for a tenant is rejected 422", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+      client = authed(conn, raw_key)
+      credential_id = :crypto.strong_rand_bytes(32)
+
+      challenge_1 =
+        client
+        |> post(~p"/api/v1/tenants/#{tenant.id}/authenticators/challenge", %{})
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      assert client
+             |> post(
+               ~p"/api/v1/tenants/#{tenant.id}/authenticators",
+               attestation_body(challenge_1["challenge_id"], credential_id: credential_id)
+             )
+             |> json_response(201)
+
+      challenge_2 =
+        client
+        |> post(~p"/api/v1/tenants/#{tenant.id}/authenticators/challenge", %{})
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      resp =
+        client
+        |> post(
+          ~p"/api/v1/tenants/#{tenant.id}/authenticators",
+          attestation_body(challenge_2["challenge_id"],
+            credential_id: credential_id,
+            reauth_assertion:
+              assertion_body(challenge_2["reauth_challenge"]["challenge_id"], credential_id)
+          )
+        )
+
+      assert json_response(resp, 422)["error"]["message"]
+      assert RootAuthenticators.count_by_tenant(tenant.id) == 1
+    end
+  end
+
+  describe "revoke-challenge action" do
+    test "422s when the tenant has no enrolled authenticator", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+
+      resp =
+        conn
+        |> authed(raw_key)
+        |> post(~p"/api/v1/tenants/#{tenant.id}/authenticators/revoke-challenge", %{})
+
+      assert json_response(resp, 422)["error"]["code"] == "no_authenticators"
+    end
+
+    test "is rate limited", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+      fixture(:root_authenticator, tenant_id: tenant.id)
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+
+      Mox.expect(Loopctl.MockRateLimiter, :check_rate, fn _bucket, _window, _limit ->
+        {:deny, 0}
+      end)
+
+      resp =
+        conn
+        |> authed(raw_key)
+        |> post(~p"/api/v1/tenants/#{tenant.id}/authenticators/revoke-challenge", %{})
+
+      assert json_response(resp, 429)["error"]["code"] == "rate_limited"
+    end
+  end
+
+  describe "enroll action rate limiting (AC-26.7.2.7)" do
+    test "over-budget create is rejected 429", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+
+      Mox.expect(Loopctl.MockRateLimiter, :check_rate, fn _bucket, _window, _limit ->
+        {:deny, 0}
+      end)
+
+      resp =
+        conn
+        |> authed(raw_key)
+        |> post(~p"/api/v1/tenants/#{tenant.id}/authenticators", %{
+          "challenge_id" => Ecto.UUID.generate()
+        })
+
+      assert json_response(resp, 429)["error"]["code"] == "rate_limited"
+    end
+  end
+end

--- a/test/loopctl_web/controllers/tenant_authenticator_controller_test.exs
+++ b/test/loopctl_web/controllers/tenant_authenticator_controller_test.exs
@@ -9,6 +9,7 @@ defmodule LoopctlWeb.TenantAuthenticatorControllerTest do
 
   import Loopctl.Fixtures
 
+  alias Ecto.Adapters.SQL.Sandbox
   alias Loopctl.AdminRepo
   alias Loopctl.Audit
   alias Loopctl.Tenants
@@ -543,6 +544,125 @@ defmodule LoopctlWeb.TenantAuthenticatorControllerTest do
         })
 
       assert json_response(resp, 429)["error"]["code"] == "rate_limited"
+    end
+  end
+
+  describe "friendly_name validation (AC-26.7.2.3, review #3)" do
+    test "an over-120-byte friendly_name is REJECTED 422, not silently truncated", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+      client = authed(conn, raw_key)
+
+      challenge =
+        client
+        |> post(~p"/api/v1/tenants/#{tenant.id}/authenticators/challenge", %{})
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      resp =
+        client
+        |> post(
+          ~p"/api/v1/tenants/#{tenant.id}/authenticators",
+          attestation_body(challenge["challenge_id"], friendly_name: String.duplicate("a", 121))
+        )
+
+      assert json_response(resp, 422)["error"]["code"] == "friendly_name_too_long"
+      # Nothing was enrolled and the tier did NOT flip.
+      assert RootAuthenticators.count_by_tenant(tenant.id) == 0
+      {:ok, reloaded} = Tenants.get_tenant(tenant.id)
+      assert reloaded.trust_tier == :agent_rooted
+    end
+
+    test "a 120-byte friendly_name is accepted VERBATIM (proves no truncation)", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+      client = authed(conn, raw_key)
+
+      challenge =
+        client
+        |> post(~p"/api/v1/tenants/#{tenant.id}/authenticators/challenge", %{})
+        |> json_response(200)
+        |> Map.fetch!("data")
+
+      name = String.duplicate("b", 120)
+
+      resp =
+        client
+        |> post(
+          ~p"/api/v1/tenants/#{tenant.id}/authenticators",
+          attestation_body(challenge["challenge_id"], friendly_name: name)
+        )
+        |> json_response(201)
+        |> Map.fetch!("data")
+
+      assert resp["authenticator"]["friendly_name"] == name
+    end
+  end
+
+  # review #1 regression: the residual double-first-enroll race, at the HTTP
+  # layer. Two concurrent POST .../authenticators against an agent_rooted
+  # tenant, BOTH with NO reauth_assertion (both are first-enroll attempts).
+  # Exactly one must 201 (flip to human_anchored + enroll); the loser must be
+  # rejected 401 reauth_required by the under-lock gate — it must NOT get a
+  # 201 grafting a second, possession-unproven device.
+  describe "concurrent double-first-enroll at the HTTP layer (review #1)" do
+    @tag :capture_log
+    test "exactly one 201; the loser gets 401 reauth_required, never 201", %{conn: _conn} do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
+
+      # Two independent single-use challenges, issued sequentially before the race.
+      issue_challenge = fn ->
+        build_conn()
+        |> authed(raw_key)
+        |> post(~p"/api/v1/tenants/#{tenant.id}/authenticators/challenge", %{})
+        |> json_response(200)
+        |> Map.fetch!("data")
+        |> Map.fetch!("challenge_id")
+      end
+
+      challenge_a = issue_challenge.()
+      challenge_b = issue_challenge.()
+
+      parent = self()
+
+      fire = fn challenge_id ->
+        Task.async(fn ->
+          Sandbox.allow(Loopctl.Repo, parent, self())
+          Sandbox.allow(Loopctl.AdminRepo, parent, self())
+          Mox.allow(Loopctl.MockWebAuthn, parent, self())
+          Mox.allow(Loopctl.MockRateLimiter, parent, self())
+
+          build_conn()
+          |> authed(raw_key)
+          |> post(
+            ~p"/api/v1/tenants/#{tenant.id}/authenticators",
+            attestation_body(challenge_id)
+          )
+        end)
+      end
+
+      task_a = fire.(challenge_a)
+      task_b = fire.(challenge_b)
+
+      result_a = Task.await(task_a, 10_000)
+      result_b = Task.await(task_b, 10_000)
+
+      assert Enum.sort([result_a.status, result_b.status]) == [201, 401]
+
+      loser = Enum.find([result_a, result_b], &(&1.status == 401))
+      assert Jason.decode!(loser.resp_body)["error"]["code"] == "reauth_required"
+
+      # Exactly ONE device was grafted on; the tenant is human_anchored with a
+      # single upgrade entry.
+      assert RootAuthenticators.count_by_tenant(tenant.id) == 1
+      {:ok, reloaded} = Tenants.get_tenant(tenant.id)
+      assert reloaded.trust_tier == :human_anchored
+
+      {:ok, upgraded} =
+        Audit.list_entries(tenant.id, entity_type: "tenant", action: "tenant_trust_upgraded")
+
+      assert upgraded.total == 1
     end
   end
 end

--- a/test/loopctl_web/require_human_anchor_default_deny_test.exs
+++ b/test/loopctl_web/require_human_anchor_default_deny_test.exs
@@ -47,6 +47,24 @@ defmodule LoopctlWeb.RequireHumanAnchorDefaultDenyTest do
                # provisioning ever became lazy.
                {:post, "/api/v1/tenants/:id/bootstrap-audit-key"},
 
+               # US-26.7.2 — opt-in WebAuthn trust-tier upgrade ceremony. `challenge`
+               # and `create` ARE the upgrade path itself: an agent-rooted caller
+               # (zero authenticators) is the INTENDED audience for a first
+               # enrollment, so gating them behind RequireHumanAnchor would make the
+               # tier unreachable from the tier it's meant to lift a tenant out of.
+               # A SUBSEQUENT (backup) enrollment on an already-human_anchored tenant
+               # is instead gated by a FRESH `add_authenticator` WebAuthn assertion
+               # from an existing authenticator (Loopctl.WebAuthn.Reauth) — a
+               # STRONGER control than the tier gate, since a stolen role:user key
+               # alone can never satisfy it (AC-26.7.2.3's critical
+               # anti-soft-recovery-backdoor gate). `revoke-challenge` + the DELETE
+               # are likewise gated by a fresh `revoke_authenticator` assertion, not
+               # the tier — mirroring rotate-audit-key's exemption above.
+               {:post, "/api/v1/tenants/:id/authenticators/challenge"},
+               {:post, "/api/v1/tenants/:id/authenticators"},
+               {:post, "/api/v1/tenants/:id/authenticators/revoke-challenge"},
+               {:delete, "/api/v1/tenants/:id/authenticators/:auth_id"},
+
                # /api_keys management — explicitly excluded (AC-26.7.1.7).
                {:post, "/api/v1/api_keys"},
                {:delete, "/api/v1/api_keys/:id"},


### PR DESCRIPTION
## US-26.7.2 — Opt-In WebAuthn Tier Upgrade (agent_rooted → human_anchored)

Completes the capability-tiered-trust round-trip from US-26.7.1: an agent-rooted KB-tier tenant can enroll a WebAuthn hardware authenticator to become human-anchored and unlock the custody surface. Upgrading requires a **verified attestation from real hardware** (an agent can't forge it) — that's L0 being established.

### Endpoints
- `POST /tenants/:id/authenticators/challenge` — registration challenge (+ a fresh-assertion challenge when already human-anchored)
- `POST /tenants/:id/authenticators` — verify attestation, insert authenticator, flip tier on first enrollment
- `POST /tenants/:id/authenticators/revoke-challenge` + `DELETE /tenants/:id/authenticators/:auth_id` — revoke with a fresh assertion
- All four are ownership + attestation gated (not tier-gated — an agent-rooted tenant is the intended caller); added to the default-deny guard allowlist.

### Design (documented calls)
- Enrollment **appends** a `tenant_trust_upgraded` / `authenticator_enrolled` audit entry — never rewrites the append-only genesis.
- **First** enrollment (agent-rooted) needs the tenant's key + a fresh attestation; **subsequent** enrollment (human-anchored) *additionally* requires a fresh assertion from an **existing** authenticator — closing the soft-recovery backdoor.
- Revoking the **last** authenticator is forbidden (409); no auto-downgrade.
- Not headless — an interactive WebAuthn client + hardware touch completes it.

### Two-stage review (both ran before merge)
- **Spec review (pre-code):** found **2 critical** design flaws — a soft-recovery backdoor (backup enrollment on bearer-key alone) and a last-authenticator TOCTOU — plus 2 high (challenge un-burn, txn-across-crypto) and mediums. Fixed in the spec.
- **Diff review (post-code):** found **1 critical** — a residual TOCTOU where the assertion gate was decided from a stale pre-lock `trust_tier` read (and the concurrency test *encoded the vulnerable outcome as passing*) — plus 2 minors. All fixed: the gate is now re-checked **under the Phase-3 tenant-row lock**, aborting before insert; the test now proves the racing loser is rejected `401 reauth_required` (verified non-tautological by neutralizing the guard and confirming failure).

### Security shape
- Two-phase: challenge consumed in its own committed txn before attestation verify; no DB txn held across CBOR/COSE crypto; attestation + assertion fields size-capped before decode.
- Guarded conditional tier-flip (`WHERE trust_tier='agent_rooted'`) → exactly one `tenant_trust_upgraded` under concurrency; genuine two-DB-session concurrency tests.

`mix precommit` green: 3762 tests, 0 failures; credo --strict clean; dialyzer passed.
