### PR TITLE
Epic 28 — Agent Memory (Part 1) user-story scaffold [#307]

### DIFF
--- a/docs/user_stories/epic_28_agent_memory/README.md
+++ b/docs/user_stories/epic_28_agent_memory/README.md
@@ -1,0 +1,60 @@
+# Epic 28 — Agent Memory (Part 1: store + semantic retrieval)
+
+Decomposition of GitHub issue **#307** (Agent Memory — Part 1: per-scope memory store +
+semantic retrieval). This is the **substrate**: a first-class, tenant/project/agent-scoped
+memory subsystem — short-term *session memory* + long-term, vector-retrieved *promoted
+memory* — distinct from the Knowledge Wiki.
+
+> **Status: FIRST-DRAFT SCAFFOLD — not yet review-hardened.**
+> These stories were authored quickly to give #307 an implementable shape. Before running
+> `/implement-plan`, refine them with the `user-story-writer` skill and put them through the
+> enhanced-review pass (the way epic_27 was), then verify every AC against the live code.
+
+## Scope boundary (read first)
+
+- **In scope (Part 1):** the memory *store* (schemas, migrations), the `Loopctl.Memory`
+  context (`remember`/`recall`/`forget`/`list`/`supersede`), the embedding pipeline for
+  memories, the HTTP API, the MCP `memory_*` tools, the human Memory-Inspector LiveView,
+  and docs. Memory is written **explicitly** by an agent/user in Part 1.
+- **Out of scope (Part 2 = #308):** the *auto-promotion / session-memory compiler* (the
+  Oban job that extracts golden nuggets from session memory into long-term memory without
+  the agent being explicit). Part 2 depends on this epic.
+- **Sibling pillar (#309):** the Context Retriever (structured business-data access) is a
+  separate epic, not here.
+- **Adjacent, NOT this:** #305 / #306 (curated + RAG *knowledge* interface) operate on the
+  Knowledge Wiki. Do **not** overload `knowledge_*` / the `articles` table for memory.
+
+## How to implement (later, once reviewed)
+
+```
+/implement-plan --epic docs/user_stories/epic_28_agent_memory
+```
+
+Epic mode topologically sorts by each story's `dependencies` and drives each through
+implement → enhanced review → zero-deferral fix → `mix precommit` → CI-gated squash-merge.
+WIP=1, dependency-blocked.
+
+## Story map
+
+| Story | Title | Surface | Depends on |
+|-------|-------|---------|-----------|
+| US-28.1 | Schemas + migrations: `session_memories` + `memories` (embedded, HNSW), scoped | domain/db | — |
+| US-28.2 | `Loopctl.Memory` context + embedding worker (remember/recall/forget/list/supersede) | domain | 28.1 |
+| US-28.3 | HTTP JSON API `/api/v1/memory*` (+ OpenAPI, auth pipeline) | api | 28.2 |
+| US-28.4 | MCP `memory_*` tools (+ docstrings disambiguating memory vs knowledge) | mcp | 28.3 |
+| US-28.5 | Memory-Inspector LiveView (browse / search / delete per scope) | app | 28.2, 28.3 |
+| US-28.6 | Docs + terminal cross-surface scope-isolation verification (runs last) | docs/verify | all |
+
+## Reuse (don't reinvent)
+
+pgvector is already a dependency and enabled (`20260410022854_enable_pgvector_and_add_embedding.exs`).
+Memory reuses the existing embedding infra: `Loopctl.Knowledge.EmbeddingClient` (per-tenant BYO
+key), `VectorSearch` (HNSW kNN), `EmbeddingCircuitBreaker`, and the HNSW index helper
+`lib/loopctl/repo/hnsw_index.ex`. The embedding worker mirrors
+`lib/loopctl/workers/article_embedding_worker.ex`. Auth reuses the `:authenticated` pipeline and
+`Loopctl.Auth.Role` (`superadmin > user > orchestrator > agent`). Scoping reuses `SetTenant` + RLS.
+
+## Provenance
+
+Second Brain hub `3ee5f890` (Cole Medin — *"…the Karpathy LLM Wiki … Doesn't Scale…"*, agent-memory
+pillar) + revived idea `787761cd` (loopctl × mcp-memory-keeper). GitHub #307.

--- a/docs/user_stories/epic_28_agent_memory/README.md
+++ b/docs/user_stories/epic_28_agent_memory/README.md
@@ -5,10 +5,12 @@ semantic retrieval). This is the **substrate**: a first-class, tenant/project/ag
 memory subsystem — short-term *session memory* + long-term, vector-retrieved *promoted
 memory* — distinct from the Knowledge Wiki.
 
-> **Status: FIRST-DRAFT SCAFFOLD — not yet review-hardened.**
-> These stories were authored quickly to give #307 an implementable shape. Before running
-> `/implement-plan`, refine them with the `user-story-writer` skill and put them through the
-> enhanced-review pass (the way epic_27 was), then verify every AC against the live code.
+> **Status: authored with the `user-story-writer` skill; not yet enhanced-review-hardened.**
+> These stories follow the skill's schema and the epic_27 JSON convention (`fixture/2`
+> preconditions, `unit`/`integration` test types, AC/TC id patterns). Before running
+> `/implement-plan`, put them through the multi-agent enhanced-review pass the way epic_27
+> was (two rounds: analyst / architect / adversarial), verifying every AC against the live
+> code — that review, not another authoring pass, is the remaining gate.
 
 ## Scope boundary (read first)
 

--- a/docs/user_stories/epic_28_agent_memory/us_28.1.json
+++ b/docs/user_stories/epic_28_agent_memory/us_28.1.json
@@ -1,82 +1,119 @@
 {
   "id": "US-28.1",
-  "title": "Memory store schemas + migrations: session_memories + memories (embedded, HNSW), tenant/project/agent scoped",
+  "title": "Memory store schemas + migrations: session_memories + memories (embedded, HNSW), tenant/project/subject scoped",
   "epic": {
     "id": "epic_28",
     "name": "Agent Memory (Part 1: store + semantic retrieval)"
   },
   "priority": "high",
   "phase": "foundation",
+  "priority_note": "Foundation story — every other epic_28 story depends on these tables. No dependencies of its own.",
   "background": {
     "reference": "GitHub issue #307; Second Brain hub 3ee5f890 (Cole Medin agent-memory pillar); revived idea 787761cd",
-    "includes": "loopctl's Knowledge Wiki stores curated articles (articles table, pgvector embeddings, HNSW index). There is NO per-agent/per-user working-memory concept; mcp-memory-keeper (separate repo, flat JSON) is the current stand-in. This story adds the persistence substrate for a native memory subsystem, kept strictly separate from the knowledge tables."
+    "includes": "loopctl's Knowledge Wiki stores curated articles (articles table, pgvector embeddings, HNSW index). There is NO per-agent/per-user working-memory concept; mcp-memory-keeper (separate repo, flat JSON) is the current stand-in. This story adds the persistence substrate for a native memory subsystem, kept strictly separate from the knowledge tables. pgvector is already enabled by migration 20260410022854."
   },
-  "priority_note": "Foundation story — every other epic_28 story depends on these tables. No dependencies of its own.",
   "story": {
     "as_a": "loopctl platform engineer",
-    "i_want_to": "add two Ecto schemas and migrations — session_memories (short-term, append log, not embedded) and memories (long-term, embedded vector(1536) + HNSW cosine index) — each scoped by tenant_id + project_id + agent/user identity",
-    "so_that": "agents have a durable, scoped place to write and later semantically recall memory, without overloading the curated-knowledge articles table"
+    "i_want_to": "add two Ecto schemas and migrations — session_memories (short-term append log, not embedded) and memories (long-term, embedded vector(1536) + HNSW cosine index) — each scoped by tenant_id + project_id + subject_id",
+    "so_that": "agents have a durable, scoped place to write and later semantically recall memory without overloading the curated-knowledge articles table"
   },
-  "rationale": "Cole Medin's production architecture names agent memory as a non-optional pillar: short-term session memory plus a per-user long-term memory retrieved by vector search that scales to millions of entries. The Knowledge Wiki is the wrong home for this (different lifecycle, different scope, agent-private not curated). A dedicated, scoped schema is the precondition for the context module, API, MCP tools, and UI in the rest of the epic.",
+  "rationale": "Cole Medin's production architecture names agent memory as a non-optional pillar: short-term session memory plus a per-user long-term memory retrieved by vector search that scales to millions of entries. The Knowledge Wiki is the wrong home for this (different lifecycle, agent-private not curated), so a dedicated scoped schema is the precondition for the context module, API, MCP tools, and UI in the rest of the epic.",
   "acceptance_criteria": [
     {
       "id": "AC-28.1.1",
-      "description": "New Ecto schema Loopctl.Memory.SessionMemory (table session_memories): fields session_id (string, required), tenant_id, project_id (nullable), agent_id/subject (the scope owner), role (enum: user|assistant|system|fact), content (text), metadata (map), inserted_at. Append-only; no embedding column. Indexed on (tenant_id, session_id, inserted_at).",
+      "description": "Schema Loopctl.Memory.SessionMemory (table session_memories): fields session_id :string (required), tenant_id, project_id (nullable), subject_id (scope owner), role Ecto.Enum [:user,:assistant,:system,:fact], content :text, metadata :map, inserted_at. Append-only, no embedding column. Composite index on (tenant_id, session_id, inserted_at).",
       "status": "pending"
     },
     {
       "id": "AC-28.1.2",
-      "description": "New Ecto schema Loopctl.Memory.Memory (table memories): fields tenant_id, project_id (nullable), subject_id (per-user/per-agent scope owner), text (required), embedding (Pgvector.Ecto.Vector, load_in_query: false), embedding_content_hash, confidence (float, default 1.0), source_session_id (nullable), source ('explicit' now; 'promoted' reserved for Part 2/#308), tags ({:array,:string}), superseded_by (nullable self-ref), inserted_at/updated_at.",
+      "description": "Schema Loopctl.Memory.Memory (table memories): fields tenant_id, project_id (nullable), subject_id (scope owner), text :text (required), embedding Pgvector.Ecto.Vector with load_in_query: false, embedding_content_hash :string, confidence :float default 1.0, source Ecto.Enum [:explicit,:promoted] default :explicit, source_session_id (nullable), tags {:array,:string} default [], superseded_by (nullable self-reference), inserted_at, updated_at.",
       "status": "pending"
     },
     {
       "id": "AC-28.1.3",
-      "description": "Migration enables/reuses pgvector (already enabled by 20260410022854) and creates an HNSW cosine index on memories.embedding via the existing hnsw_index helper pattern (mirror 20260410022906_add_embedding_hnsw_index.exs). Index detected by capability (amname='hnsw'), not a hard-coded name.",
+      "description": "Migration creates an HNSW cosine index on memories.embedding using the existing lib/loopctl/repo/hnsw_index.ex helper (mirroring 20260410022906_add_embedding_hnsw_index.exs). The index is asserted present by capability (pg_am amname = 'hnsw'), never by a hard-coded name (tolerating prod name drift, same foot-gun as US-27.1 AC-27.1.7).",
       "status": "pending"
     },
     {
       "id": "AC-28.1.4",
-      "description": "Both schemas set tenant_id programmatically (never via cast). Changesets validate required fields, cap text/content length, and reject a memory whose subject_id/tenant_id is not derivable from the caller's resolved scope.",
+      "description": "Changesets set tenant_id and subject_id programmatically from the caller scope (never via cast), validate required fields, cap text/content byte length, and return a changeset error when tenant_id/subject_id are absent — no row can be persisted without a resolved scope.",
       "status": "pending"
     },
     {
       "id": "AC-28.1.5",
-      "description": "Tenant isolation: rows are only visible within their tenant_id (reuse the existing RLS/SetTenant mechanism used by articles). A memory or session_memory written under tenant A is invisible to tenant B, verified by test.",
+      "description": "Tenant isolation is enforced by the same RLS/SetTenant mechanism used for articles: a memory or session_memory written under tenant A is invisible to tenant B at the Repo level.",
       "status": "pending"
     },
     {
       "id": "AC-28.1.6",
-      "description": "Down migrations cleanly drop both tables and the HNSW index; no orphaned index or type. Migrations run green on a fresh DB and are idempotent-safe under the project's migration test.",
+      "description": "Down migrations drop both tables and the HNSW index with no orphaned index or enum type; migrations run green on a fresh DB and pass the project's migration/rollback test.",
       "status": "pending"
     }
   ],
   "test_cases": [
     {
       "id": "TC-28.1.1",
-      "name": "Both tables exist with the expected columns and the HNSW index is present",
+      "name": "Both tables exist with expected columns and an HNSW index on memories.embedding",
       "type": "integration",
-      "preconditions": ["Migrations run on a fresh test DB"],
-      "steps": ["Introspect information_schema for session_memories + memories columns", "Query pg_indexes joined to pg_am for an hnsw index on memories.embedding"],
-      "expected_results": ["All AC-28.1.1 / AC-28.1.2 columns present", "An HNSW index on memories.embedding is detected by capability (amname='hnsw')"],
+      "preconditions": [
+        "migrations run on a fresh test database"
+      ],
+      "steps": [
+        "Query information_schema.columns for session_memories and memories",
+        "Query pg_indexes joined to pg_am for an hnsw index on memories.embedding"
+      ],
+      "expected_results": [
+        "All columns from AC-28.1.1 and AC-28.1.2 are present with the specified types",
+        "An HNSW index on memories.embedding is detected via pg_am amname = 'hnsw'"
+      ],
       "status": "pending"
     },
     {
       "id": "TC-28.1.2",
-      "name": "Memory rows are tenant-isolated",
+      "name": "Memory changeset rejects a row with no resolved scope",
+      "type": "unit",
+      "preconditions": [
+        "tenant = fixture(:tenant)"
+      ],
+      "steps": [
+        "Build Loopctl.Memory.Memory changeset with text set but subject_id/tenant_id omitted from the scope"
+      ],
+      "expected_results": [
+        "changeset.valid? == false",
+        "errors include tenant_id and subject_id"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-28.1.3",
+      "name": "Memory rows are tenant-isolated at the Repo level",
       "type": "integration",
-      "preconditions": ["tenant_a, tenant_b", "Insert one memory under tenant_a"],
-      "steps": ["Query memories in tenant_b scope"],
-      "expected_results": ["tenant_b sees 0 memories; tenant_a sees 1; tenant_id was set programmatically, not cast"],
+      "preconditions": [
+        "tenant_a = fixture(:tenant)",
+        "tenant_b = fixture(:tenant)",
+        "insert one memory under tenant_a via the scoped changeset"
+      ],
+      "steps": [
+        "List memories in tenant_b scope",
+        "List memories in tenant_a scope"
+      ],
+      "expected_results": [
+        "tenant_b sees 0 memories",
+        "tenant_a sees 1 memory",
+        "tenant_id was set programmatically, not from cast params"
+      ],
       "status": "pending"
     }
   ],
   "technical_notes": [
     "Namespace: Loopctl.Memory.* (domain) — a sibling to Loopctl.Knowledge.*, NOT nested under it.",
-    "Reuse Pgvector.Ecto.Vector and load_in_query:false exactly as lib/loopctl/knowledge/article.ex does.",
-    "HNSW: reuse lib/loopctl/repo/hnsw_index.ex; detect by amname='hnsw' to tolerate name drift (same foot-gun as US-27.1 AC-27.1.7).",
-    "embedding is NULL on insert here; it is populated by the embedding worker in US-28.2 (do not block writes on embedding).",
-    "source field: only 'explicit' is produced in Part 1; 'promoted' is written by #308's compiler — include the enum value now so Part 2 needs no migration.",
-    "Keep session_memories cheap: no embedding, bounded by a documented TTL/retention (retention policy itself can be a Part-2 concern; note it)."
+    "Schema modules: Loopctl.Memory.SessionMemory, Loopctl.Memory.Memory. Tables: session_memories, memories.",
+    "Reuse Pgvector.Ecto.Vector with load_in_query: false exactly as lib/loopctl/knowledge/article.ex does.",
+    "HNSW: reuse lib/loopctl/repo/hnsw_index.ex; detect by pg_am amname = 'hnsw' to tolerate name drift.",
+    "embedding is NULL on insert; it is populated asynchronously by the worker in US-28.2 — do not block writes on embedding.",
+    "source enum includes :promoted now (written by #308's compiler in Part 2) so Part 2 needs no migration.",
+    "Tests use Loopctl.Fixtures.fixture/1,2; add fixture(:memory, attrs) and fixture(:session_memory, attrs) helpers in this story.",
+    "tenant_id/subject_id set programmatically on every row, never cast (same rule as US-27.1 AC-27.1.9)."
   ],
   "dependencies": [],
   "estimated_hours": 10

--- a/docs/user_stories/epic_28_agent_memory/us_28.1.json
+++ b/docs/user_stories/epic_28_agent_memory/us_28.1.json
@@ -1,0 +1,83 @@
+{
+  "id": "US-28.1",
+  "title": "Memory store schemas + migrations: session_memories + memories (embedded, HNSW), tenant/project/agent scoped",
+  "epic": {
+    "id": "epic_28",
+    "name": "Agent Memory (Part 1: store + semantic retrieval)"
+  },
+  "priority": "high",
+  "phase": "foundation",
+  "background": {
+    "reference": "GitHub issue #307; Second Brain hub 3ee5f890 (Cole Medin agent-memory pillar); revived idea 787761cd",
+    "includes": "loopctl's Knowledge Wiki stores curated articles (articles table, pgvector embeddings, HNSW index). There is NO per-agent/per-user working-memory concept; mcp-memory-keeper (separate repo, flat JSON) is the current stand-in. This story adds the persistence substrate for a native memory subsystem, kept strictly separate from the knowledge tables."
+  },
+  "priority_note": "Foundation story — every other epic_28 story depends on these tables. No dependencies of its own.",
+  "story": {
+    "as_a": "loopctl platform engineer",
+    "i_want_to": "add two Ecto schemas and migrations — session_memories (short-term, append log, not embedded) and memories (long-term, embedded vector(1536) + HNSW cosine index) — each scoped by tenant_id + project_id + agent/user identity",
+    "so_that": "agents have a durable, scoped place to write and later semantically recall memory, without overloading the curated-knowledge articles table"
+  },
+  "rationale": "Cole Medin's production architecture names agent memory as a non-optional pillar: short-term session memory plus a per-user long-term memory retrieved by vector search that scales to millions of entries. The Knowledge Wiki is the wrong home for this (different lifecycle, different scope, agent-private not curated). A dedicated, scoped schema is the precondition for the context module, API, MCP tools, and UI in the rest of the epic.",
+  "acceptance_criteria": [
+    {
+      "id": "AC-28.1.1",
+      "description": "New Ecto schema Loopctl.Memory.SessionMemory (table session_memories): fields session_id (string, required), tenant_id, project_id (nullable), agent_id/subject (the scope owner), role (enum: user|assistant|system|fact), content (text), metadata (map), inserted_at. Append-only; no embedding column. Indexed on (tenant_id, session_id, inserted_at).",
+      "status": "pending"
+    },
+    {
+      "id": "AC-28.1.2",
+      "description": "New Ecto schema Loopctl.Memory.Memory (table memories): fields tenant_id, project_id (nullable), subject_id (per-user/per-agent scope owner), text (required), embedding (Pgvector.Ecto.Vector, load_in_query: false), embedding_content_hash, confidence (float, default 1.0), source_session_id (nullable), source ('explicit' now; 'promoted' reserved for Part 2/#308), tags ({:array,:string}), superseded_by (nullable self-ref), inserted_at/updated_at.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-28.1.3",
+      "description": "Migration enables/reuses pgvector (already enabled by 20260410022854) and creates an HNSW cosine index on memories.embedding via the existing hnsw_index helper pattern (mirror 20260410022906_add_embedding_hnsw_index.exs). Index detected by capability (amname='hnsw'), not a hard-coded name.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-28.1.4",
+      "description": "Both schemas set tenant_id programmatically (never via cast). Changesets validate required fields, cap text/content length, and reject a memory whose subject_id/tenant_id is not derivable from the caller's resolved scope.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-28.1.5",
+      "description": "Tenant isolation: rows are only visible within their tenant_id (reuse the existing RLS/SetTenant mechanism used by articles). A memory or session_memory written under tenant A is invisible to tenant B, verified by test.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-28.1.6",
+      "description": "Down migrations cleanly drop both tables and the HNSW index; no orphaned index or type. Migrations run green on a fresh DB and are idempotent-safe under the project's migration test.",
+      "status": "pending"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "TC-28.1.1",
+      "name": "Both tables exist with the expected columns and the HNSW index is present",
+      "type": "integration",
+      "preconditions": ["Migrations run on a fresh test DB"],
+      "steps": ["Introspect information_schema for session_memories + memories columns", "Query pg_indexes joined to pg_am for an hnsw index on memories.embedding"],
+      "expected_results": ["All AC-28.1.1 / AC-28.1.2 columns present", "An HNSW index on memories.embedding is detected by capability (amname='hnsw')"],
+      "status": "pending"
+    },
+    {
+      "id": "TC-28.1.2",
+      "name": "Memory rows are tenant-isolated",
+      "type": "integration",
+      "preconditions": ["tenant_a, tenant_b", "Insert one memory under tenant_a"],
+      "steps": ["Query memories in tenant_b scope"],
+      "expected_results": ["tenant_b sees 0 memories; tenant_a sees 1; tenant_id was set programmatically, not cast"],
+      "status": "pending"
+    }
+  ],
+  "technical_notes": [
+    "Namespace: Loopctl.Memory.* (domain) — a sibling to Loopctl.Knowledge.*, NOT nested under it.",
+    "Reuse Pgvector.Ecto.Vector and load_in_query:false exactly as lib/loopctl/knowledge/article.ex does.",
+    "HNSW: reuse lib/loopctl/repo/hnsw_index.ex; detect by amname='hnsw' to tolerate name drift (same foot-gun as US-27.1 AC-27.1.7).",
+    "embedding is NULL on insert here; it is populated by the embedding worker in US-28.2 (do not block writes on embedding).",
+    "source field: only 'explicit' is produced in Part 1; 'promoted' is written by #308's compiler — include the enum value now so Part 2 needs no migration.",
+    "Keep session_memories cheap: no embedding, bounded by a documented TTL/retention (retention policy itself can be a Part-2 concern; note it)."
+  ],
+  "dependencies": [],
+  "estimated_hours": 10
+}

--- a/docs/user_stories/epic_28_agent_memory/us_28.2.json
+++ b/docs/user_stories/epic_28_agent_memory/us_28.2.json
@@ -7,83 +7,143 @@
   },
   "priority": "high",
   "phase": "domain",
-  "background": {
-    "reference": "GitHub issue #307; mirrors the Loopctl.Knowledge context + article_embedding_worker patterns",
-    "includes": "US-28.1 provides the tables. This story provides the public domain API the API/MCP/UI layers call, plus the async embedding of long-term memories so recall is semantic."
-  },
   "priority_note": "The domain heart of the epic; the API (28.3), MCP (28.4), and UI (28.5) are thin layers over this context.",
+  "background": {
+    "reference": "GitHub issue #307; mirrors the Loopctl.Knowledge context + lib/loopctl/workers/article_embedding_worker.ex patterns",
+    "includes": "US-28.1 provides the tables. This story provides the public domain API the API/MCP/UI layers call, plus async embedding of long-term memories so recall is semantic. Reuses Loopctl.Knowledge.EmbeddingClient (per-tenant BYO key), VectorSearch (HNSW kNN), and EmbeddingCircuitBreaker."
+  },
   "story": {
     "as_a": "loopctl platform engineer",
-    "i_want_to": "implement a Loopctl.Memory context exposing remember/2, recall/2 (semantic top-k within scope), forget/2, list/2, and supersede/2, backed by an Oban embedding worker that embeds long-term memories using the existing knowledge embedding pipeline",
-    "so_that": "callers can write and semantically retrieve scoped memory through one governed API that enforces scope on every read"
+    "i_want_to": "implement Loopctl.Memory.remember/2, recall/2, forget/2, list/2, and supersede/2, backed by an Oban worker that embeds long-term memories via the existing knowledge embedding pipeline",
+    "so_that": "callers write and semantically retrieve scoped memory through one governed API that enforces scope on every read"
   },
-  "rationale": "A store with no accessor is unusable and a store with an unenforced scope is a data-leak. Centralizing remember/recall/forget/list/supersede in one context guarantees every read is scope-filtered and every write is embedded exactly once — the same discipline Loopctl.Knowledge applies to articles.",
+  "rationale": "A store with no accessor is unusable and a store with an unenforced scope is a data leak. Centralizing remember/recall/forget/list/supersede in one context guarantees every read is scope-filtered and every long-term write is embedded exactly once — the discipline Loopctl.Knowledge already applies to articles.",
   "acceptance_criteria": [
     {
       "id": "AC-28.2.1",
-      "description": "Loopctl.Memory.remember/2 writes either a session memory (short-term) or a long-term memory depending on opts; long-term writes enqueue the embedding worker (embedding starts NULL, populated async). Scope (tenant/project/subject) is taken from the caller context, never from free-form params.",
+      "description": "Loopctl.Memory.remember/2 accepts a scope struct + attrs and writes either a session memory or a long-term memory depending on opts[:tier]; long-term writes enqueue the embedding worker (embedding starts NULL). Scope (tenant_id/project_id/subject_id) comes from the scope struct, never from free-form attrs.",
       "status": "pending"
     },
     {
       "id": "AC-28.2.2",
-      "description": "Loopctl.Memory.recall/2 performs HNSW cosine top-k over long-term memories WITHIN the caller's (tenant, project?, subject) scope, using Loopctl.Knowledge.VectorSearch (or a shared helper), excluding superseded rows. Returns ranked {memory, score}. A recall never returns a memory outside scope.",
+      "description": "Loopctl.Memory.recall/2 runs HNSW cosine top-k over long-term memories WITHIN the scope's (tenant_id, optional project_id, subject_id), excludes rows where superseded_by is not null, and returns [{memory, score}] ranked. A recall never returns a memory outside scope.",
       "status": "pending"
     },
     {
       "id": "AC-28.2.3",
-      "description": "recall degrades gracefully when embeddings are unavailable (EmbeddingCircuitBreaker open / no key): it falls back to recent-first keyword/text match within scope and sets a meta flag (fallback: true, reason) mirroring knowledge_search's contract — never a silent empty result.",
+      "description": "recall/2 degrades gracefully when embeddings are unavailable (EmbeddingCircuitBreaker open or no key): it falls back to recent-first ILIKE text match within scope and returns meta %{fallback: true, reason: <tag>} mirroring knowledge_search — never a silent empty result (SOUL rule 7).",
       "status": "pending"
     },
     {
       "id": "AC-28.2.4",
-      "description": "forget/2 deletes (or soft-deletes) a memory by id only within the caller's scope; a caller cannot forget another scope's memory (returns not_found, not an error leaking existence). list/2 enumerates scoped memories with limit/offset + total_count meta (no silent cap).",
+      "description": "forget/2 deletes a memory by id only within scope; a foreign-scope id returns {:error, :not_found} (no existence leak). list/2 enumerates scoped memories with limit/offset and returns total_count in meta with no silent cap.",
       "status": "pending"
     },
     {
       "id": "AC-28.2.5",
-      "description": "supersede/2 marks an existing in-scope memory superseded_by a new one (used later by #308 dedup); superseded memories are excluded from recall/list by default but retrievable with an explicit include_superseded flag.",
+      "description": "supersede/2 sets superseded_by on an in-scope memory to a new memory id; superseded memories are excluded from recall/2 and list/2 by default and included only when opts[:include_superseded] is true.",
       "status": "pending"
     },
     {
       "id": "AC-28.2.6",
-      "description": "Loopctl.Memory.Workers.MemoryEmbeddingWorker (Oban) embeds a long-term memory via EmbeddingClient (per-tenant BYO key), writes embedding + embedding_content_hash, is idempotent (re-run with unchanged text is a no-op via the content hash), and honors EmbeddingCircuitBreaker. Mirrors lib/loopctl/workers/article_embedding_worker.ex.",
+      "description": "Loopctl.Memory.Workers.MemoryEmbeddingWorker (Oban) embeds a long-term memory via EmbeddingClient, writes embedding + embedding_content_hash, is idempotent (unchanged text re-run is a no-op via the content hash), and honors EmbeddingCircuitBreaker. Mirrors lib/loopctl/workers/article_embedding_worker.ex.",
       "status": "pending"
     }
   ],
   "test_cases": [
     {
       "id": "TC-28.2.1",
-      "name": "remember → embed → recall round-trips within scope",
+      "name": "remember then recall round-trips a long-term memory within scope",
       "type": "integration",
-      "preconditions": ["tenant + subject scope", "Stub/di the embedding client to deterministic vectors"],
-      "steps": ["remember a long-term memory", "drain the embedding worker", "recall with a semantically-near query"],
-      "expected_results": ["The memory is returned top-1 with a score; embedding + content_hash populated"],
+      "preconditions": [
+        "tenant = fixture(:tenant)",
+        "scope = fixture(:memory_scope, tenant: tenant, subject_id: \"agent-1\")",
+        "embedding client stubbed via Mox to deterministic vectors"
+      ],
+      "steps": [
+        "Loopctl.Memory.remember(scope, %{tier: :long_term, text: \"prefers reshipments over refunds\"})",
+        "drain the MemoryEmbeddingWorker Oban queue",
+        "Loopctl.Memory.recall(scope, %{query: \"how does this user want delayed orders handled?\"})"
+      ],
+      "expected_results": [
+        "recall returns the memory as top-1 with a numeric score",
+        "the stored row has non-null embedding and embedding_content_hash"
+      ],
       "status": "pending"
     },
     {
       "id": "TC-28.2.2",
-      "name": "recall and forget are scope-isolated",
+      "name": "recall and forget are isolated across subject and tenant",
       "type": "integration",
-      "preconditions": ["Memory M written under subject A of tenant T"],
-      "steps": ["recall as subject B / tenant T", "recall as a subject of tenant U", "forget M as subject B"],
-      "expected_results": ["B and tenant-U recalls never return M; forget as B returns not_found and M still exists for A"],
+      "preconditions": [
+        "tenant = fixture(:tenant)",
+        "scope_a = fixture(:memory_scope, tenant: tenant, subject_id: \"A\")",
+        "scope_b = fixture(:memory_scope, tenant: tenant, subject_id: \"B\")",
+        "tenant2 = fixture(:tenant)",
+        "scope_u = fixture(:memory_scope, tenant: tenant2, subject_id: \"A\")",
+        "m = remember(scope_a, %{tier: :long_term, text: \"secret A fact\"}); drain embedding"
+      ],
+      "steps": [
+        "Loopctl.Memory.recall(scope_b, %{query: \"secret\"})",
+        "Loopctl.Memory.recall(scope_u, %{query: \"secret\"})",
+        "Loopctl.Memory.forget(scope_b, m.id)"
+      ],
+      "expected_results": [
+        "scope_b recall does not include m",
+        "scope_u recall does not include m",
+        "forget returns {:error, :not_found} and m still exists for scope_a"
+      ],
       "status": "pending"
     },
     {
       "id": "TC-28.2.3",
-      "name": "recall falls back (not empty) when embeddings are down",
+      "name": "recall falls back to text match (not empty) when embeddings are down",
       "type": "integration",
-      "preconditions": ["EmbeddingCircuitBreaker forced open"],
-      "steps": ["recall a query that matches a memory's text"],
-      "expected_results": ["Returns the memory via text fallback with meta.fallback=true and a reason; not a silent []"],
+      "preconditions": [
+        "tenant = fixture(:tenant)",
+        "scope = fixture(:memory_scope, tenant: tenant, subject_id: \"A\")",
+        "remember(scope, %{tier: :long_term, text: \"always expedite reships\"}); drain embedding",
+        "EmbeddingCircuitBreaker forced open"
+      ],
+      "steps": [
+        "Loopctl.Memory.recall(scope, %{query: \"expedite\"})"
+      ],
+      "expected_results": [
+        "the memory is returned via ILIKE text fallback",
+        "meta == %{fallback: true, reason: _} (not a silent [])"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-28.2.4",
+      "name": "supersede hides the old memory from recall by default",
+      "type": "unit",
+      "preconditions": [
+        "tenant = fixture(:tenant)",
+        "scope = fixture(:memory_scope, tenant: tenant, subject_id: \"A\")",
+        "old = fixture(:memory, scope: scope, text: \"prefers refunds\")",
+        "new = fixture(:memory, scope: scope, text: \"prefers reshipments\")"
+      ],
+      "steps": [
+        "Loopctl.Memory.supersede(scope, old.id, new.id)",
+        "Loopctl.Memory.list(scope, %{})",
+        "Loopctl.Memory.list(scope, %{include_superseded: true})"
+      ],
+      "expected_results": [
+        "default list excludes old, includes new",
+        "include_superseded list includes both"
+      ],
       "status": "pending"
     }
   ],
   "technical_notes": [
+    "Context module: Loopctl.Memory (lib/loopctl/memory.ex). Worker: Loopctl.Memory.Workers.MemoryEmbeddingWorker.",
     "Reuse Loopctl.Knowledge.VectorSearch for the kNN; if it is article-specific, extract a shared kNN helper rather than duplicating the HNSW query.",
-    "EmbeddingClient is per-tenant BYO key and mandatory — same constraint as knowledge; recall fallback (AC-28.2.3) is the SOUL rule-7 'no silent degradation' analogue of knowledge_search's keyword_only fallback.",
-    "Scope resolution: session/subject/tenant come from the authenticated caller (US-28.3 plug chain), passed into the context as an explicit scope struct — the context must be callable in tests without a conn.",
-    "supersede + the source='promoted' field are the seams #308 will use; implement them now so Part 2 adds no schema/context surface."
+    "Scope struct (tenant_id, project_id, subject_id) is passed explicitly so the context is callable in tests without a conn; the plug chain in US-28.3 builds it from the authenticated caller.",
+    "EmbeddingClient is per-tenant BYO key and mandatory; the AC-28.2.3 fallback is the memory analogue of knowledge_search's keyword_only fallback (finding 877a415d).",
+    "supersede + source=:promoted are the seams #308 uses — implement them now so Part 2 adds no schema/context surface.",
+    "Tests use Loopctl.Fixtures.fixture/2; add fixture(:memory_scope, attrs) and fixture(:memory, attrs).",
+    "Stub the embedding provider with Mox against the existing embedding behaviour so tests are deterministic (no network)."
   ],
   "dependencies": ["US-28.1"],
   "estimated_hours": 16

--- a/docs/user_stories/epic_28_agent_memory/us_28.2.json
+++ b/docs/user_stories/epic_28_agent_memory/us_28.2.json
@@ -1,0 +1,90 @@
+{
+  "id": "US-28.2",
+  "title": "Loopctl.Memory context + embedding worker: remember / recall / forget / list / supersede with scope enforcement",
+  "epic": {
+    "id": "epic_28",
+    "name": "Agent Memory (Part 1: store + semantic retrieval)"
+  },
+  "priority": "high",
+  "phase": "domain",
+  "background": {
+    "reference": "GitHub issue #307; mirrors the Loopctl.Knowledge context + article_embedding_worker patterns",
+    "includes": "US-28.1 provides the tables. This story provides the public domain API the API/MCP/UI layers call, plus the async embedding of long-term memories so recall is semantic."
+  },
+  "priority_note": "The domain heart of the epic; the API (28.3), MCP (28.4), and UI (28.5) are thin layers over this context.",
+  "story": {
+    "as_a": "loopctl platform engineer",
+    "i_want_to": "implement a Loopctl.Memory context exposing remember/2, recall/2 (semantic top-k within scope), forget/2, list/2, and supersede/2, backed by an Oban embedding worker that embeds long-term memories using the existing knowledge embedding pipeline",
+    "so_that": "callers can write and semantically retrieve scoped memory through one governed API that enforces scope on every read"
+  },
+  "rationale": "A store with no accessor is unusable and a store with an unenforced scope is a data-leak. Centralizing remember/recall/forget/list/supersede in one context guarantees every read is scope-filtered and every write is embedded exactly once — the same discipline Loopctl.Knowledge applies to articles.",
+  "acceptance_criteria": [
+    {
+      "id": "AC-28.2.1",
+      "description": "Loopctl.Memory.remember/2 writes either a session memory (short-term) or a long-term memory depending on opts; long-term writes enqueue the embedding worker (embedding starts NULL, populated async). Scope (tenant/project/subject) is taken from the caller context, never from free-form params.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-28.2.2",
+      "description": "Loopctl.Memory.recall/2 performs HNSW cosine top-k over long-term memories WITHIN the caller's (tenant, project?, subject) scope, using Loopctl.Knowledge.VectorSearch (or a shared helper), excluding superseded rows. Returns ranked {memory, score}. A recall never returns a memory outside scope.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-28.2.3",
+      "description": "recall degrades gracefully when embeddings are unavailable (EmbeddingCircuitBreaker open / no key): it falls back to recent-first keyword/text match within scope and sets a meta flag (fallback: true, reason) mirroring knowledge_search's contract — never a silent empty result.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-28.2.4",
+      "description": "forget/2 deletes (or soft-deletes) a memory by id only within the caller's scope; a caller cannot forget another scope's memory (returns not_found, not an error leaking existence). list/2 enumerates scoped memories with limit/offset + total_count meta (no silent cap).",
+      "status": "pending"
+    },
+    {
+      "id": "AC-28.2.5",
+      "description": "supersede/2 marks an existing in-scope memory superseded_by a new one (used later by #308 dedup); superseded memories are excluded from recall/list by default but retrievable with an explicit include_superseded flag.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-28.2.6",
+      "description": "Loopctl.Memory.Workers.MemoryEmbeddingWorker (Oban) embeds a long-term memory via EmbeddingClient (per-tenant BYO key), writes embedding + embedding_content_hash, is idempotent (re-run with unchanged text is a no-op via the content hash), and honors EmbeddingCircuitBreaker. Mirrors lib/loopctl/workers/article_embedding_worker.ex.",
+      "status": "pending"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "TC-28.2.1",
+      "name": "remember → embed → recall round-trips within scope",
+      "type": "integration",
+      "preconditions": ["tenant + subject scope", "Stub/di the embedding client to deterministic vectors"],
+      "steps": ["remember a long-term memory", "drain the embedding worker", "recall with a semantically-near query"],
+      "expected_results": ["The memory is returned top-1 with a score; embedding + content_hash populated"],
+      "status": "pending"
+    },
+    {
+      "id": "TC-28.2.2",
+      "name": "recall and forget are scope-isolated",
+      "type": "integration",
+      "preconditions": ["Memory M written under subject A of tenant T"],
+      "steps": ["recall as subject B / tenant T", "recall as a subject of tenant U", "forget M as subject B"],
+      "expected_results": ["B and tenant-U recalls never return M; forget as B returns not_found and M still exists for A"],
+      "status": "pending"
+    },
+    {
+      "id": "TC-28.2.3",
+      "name": "recall falls back (not empty) when embeddings are down",
+      "type": "integration",
+      "preconditions": ["EmbeddingCircuitBreaker forced open"],
+      "steps": ["recall a query that matches a memory's text"],
+      "expected_results": ["Returns the memory via text fallback with meta.fallback=true and a reason; not a silent []"],
+      "status": "pending"
+    }
+  ],
+  "technical_notes": [
+    "Reuse Loopctl.Knowledge.VectorSearch for the kNN; if it is article-specific, extract a shared kNN helper rather than duplicating the HNSW query.",
+    "EmbeddingClient is per-tenant BYO key and mandatory — same constraint as knowledge; recall fallback (AC-28.2.3) is the SOUL rule-7 'no silent degradation' analogue of knowledge_search's keyword_only fallback.",
+    "Scope resolution: session/subject/tenant come from the authenticated caller (US-28.3 plug chain), passed into the context as an explicit scope struct — the context must be callable in tests without a conn.",
+    "supersede + the source='promoted' field are the seams #308 will use; implement them now so Part 2 adds no schema/context surface."
+  ],
+  "dependencies": ["US-28.1"],
+  "estimated_hours": 16
+}

--- a/docs/user_stories/epic_28_agent_memory/us_28.3.json
+++ b/docs/user_stories/epic_28_agent_memory/us_28.3.json
@@ -7,41 +7,41 @@
   },
   "priority": "high",
   "phase": "api",
+  "priority_note": "Bridges the domain (28.2) to the MCP layer (28.4); must reuse the existing auth/witness pipeline exactly.",
   "background": {
-    "reference": "GitHub issue #307; mirrors the knowledge_* controllers and the :authenticated router pipeline",
-    "includes": "The MCP tools (US-28.4) call the Phoenix /api/v1 API, not the context directly. This story exposes Loopctl.Memory over HTTP with the existing auth/witness stack."
+    "reference": "GitHub issue #307; mirrors the knowledge_* controllers and the :authenticated router pipeline (ExtractApiKey/ResolveApiKey/SetTenant/RequireAuth/ValidateWitnessHeader/CheckCustodyHalt)",
+    "includes": "The MCP tools (US-28.4) call the Phoenix /api/v1 API, not the context directly. This story exposes Loopctl.Memory over HTTP so it inherits tenant resolution, role gating, and the witness/chain-of-custody layer."
   },
-  "priority_note": "Bridges the domain (28.2) to the MCP layer (28.4). Must reuse the existing auth pipeline exactly.",
   "story": {
-    "as_a": "loopctl API consumer (an agent via MCP, or a direct API client)",
+    "as_a": "a loopctl API consumer (an agent via MCP, or a direct client)",
     "i_want_to": "call REST endpoints to write, recall, list, and delete memory, authenticated with my API key and scoped to my tenant/role",
-    "so_that": "agents can use memory over the same governed transport as the knowledge and story APIs"
+    "so_that": "agents use memory over the same governed transport as the knowledge and story APIs"
   },
-  "rationale": "loopctl's MCP server is a thin HTTP client over /api/v1; memory must live there to inherit tenant resolution, role gating, and the witness/chain-of-custody layer instead of re-implementing them.",
+  "rationale": "loopctl's MCP server is a thin HTTP client over /api/v1, so memory must live there to inherit tenant resolution, role gating, and the witness/custody layer instead of re-implementing them. Putting the boundary anywhere else would fork the auth story.",
   "acceptance_criteria": [
     {
       "id": "AC-28.3.1",
-      "description": "New LoopctlWeb.MemoryController + MemoryJSON view. Routes under scope \"/api/v1\": POST /api/v1/memory (remember), POST /api/v1/memory/recall (semantic recall), GET /api/v1/memory (list, limit/offset + total_count meta), DELETE /api/v1/memory/:id (forget). All on the :authenticated pipeline.",
+      "description": "LoopctlWeb.MemoryController + MemoryJSON view expose, under scope \"/api/v1\" on the :authenticated pipeline: POST /api/v1/memory (remember), POST /api/v1/memory/recall (semantic recall), GET /api/v1/memory (list, limit/offset + total_count meta), DELETE /api/v1/memory/:id (forget).",
       "status": "pending"
     },
     {
       "id": "AC-28.3.2",
-      "description": "Role gating via Loopctl.Auth.Role: writing/reading memory requires >= agent; the scope (tenant + subject) is derived from the resolved API key (ResolveApiKey/SetTenant/Impersonate), never accepted from the request body. Requests that try to set another tenant/subject are ignored or 403, not honored.",
+      "description": "Role gating via Loopctl.Auth.Role: memory read/write requires role >= agent. Scope (tenant_id + subject_id) is derived from the resolved key (ResolveApiKey/SetTenant/Impersonate) and any tenant_id/subject_id in the request body is ignored, not honored.",
       "status": "pending"
     },
     {
       "id": "AC-28.3.3",
-      "description": "The full authenticated plug chain applies (ExtractApiKey → ResolveApiKey → SetTenant → RequireAuth → ValidateWitnessHeader → CheckCustodyHalt). A custody-halted key cannot write memory; a missing/invalid witness header is rejected consistently with other write endpoints.",
+      "description": "The full authenticated plug chain applies; a custody-halted key cannot write memory (CheckCustodyHalt), and a missing/invalid witness header is rejected consistently with other write endpoints (ValidateWitnessHeader).",
       "status": "pending"
     },
     {
       "id": "AC-28.3.4",
-      "description": "recall response carries the same meta contract as knowledge_search where relevant (fallback flag + reason when embeddings degrade); list carries offset/limit/total_count. Errors use the API's standard error envelope.",
+      "description": "recall responses carry meta (fallback flag + reason when embeddings degrade); list carries offset/limit/total_count; errors use the API's standard error envelope. No endpoint imposes a silent hard cap.",
       "status": "pending"
     },
     {
       "id": "AC-28.3.5",
-      "description": "OpenAPI: operations for all four endpoints are added under lib/loopctl/api_spec/ (request/response schemas), appear at /swaggerui, and the existing openapi_test passes (no 'No operation spec defined' warning for the new actions).",
+      "description": "OpenAPI operations for all four endpoints are added under lib/loopctl/api_spec/, render at /swaggerui, and the existing openapi_test passes with no 'No operation spec defined' warning for the new actions.",
       "status": "pending"
     }
   ],
@@ -49,35 +49,69 @@
     {
       "id": "TC-28.3.1",
       "name": "remember + recall round-trip over HTTP within tenant scope",
-      "type": "controller",
-      "preconditions": ["Authenticated agent-role key for tenant T"],
-      "steps": ["POST /api/v1/memory with a fact", "drain embedding worker", "POST /api/v1/memory/recall with a near query"],
-      "expected_results": ["201 on write; recall returns the memory ranked, scoped to T; response meta present"],
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant)",
+        "key = fixture(:api_key, tenant: tenant, role: :agent)",
+        "conn authenticated with key + valid witness header",
+        "embedding client stubbed via Mox"
+      ],
+      "steps": [
+        "POST /api/v1/memory with %{tier: \"long_term\", text: \"prefers reshipments\"}",
+        "drain the MemoryEmbeddingWorker queue",
+        "POST /api/v1/memory/recall with %{query: \"handling delayed orders\"}"
+      ],
+      "expected_results": [
+        "write returns 201",
+        "recall returns 200 with the memory ranked and meta present, scoped to tenant"
+      ],
       "status": "pending"
     },
     {
       "id": "TC-28.3.2",
-      "name": "Body-supplied tenant/subject is ignored; cross-tenant read impossible",
-      "type": "controller",
-      "preconditions": ["Key for tenant T; a memory exists under tenant U"],
-      "steps": ["POST recall with body claiming tenant_id=U", "GET /api/v1/memory"],
-      "expected_results": ["Scope stays T; tenant-U memory never returned; no 500, no leak"],
+      "name": "Body-supplied tenant/subject is ignored; cross-tenant read is impossible",
+      "type": "integration",
+      "preconditions": [
+        "tenant_t = fixture(:tenant)",
+        "tenant_u = fixture(:tenant)",
+        "key = fixture(:api_key, tenant: tenant_t, role: :agent)",
+        "a memory exists under tenant_u"
+      ],
+      "steps": [
+        "POST /api/v1/memory/recall as key with body %{query: \"x\", tenant_id: tenant_u.id}",
+        "GET /api/v1/memory as key"
+      ],
+      "expected_results": [
+        "scope stays tenant_t; the tenant_u memory is never returned",
+        "no 500 and no existence leak"
+      ],
       "status": "pending"
     },
     {
       "id": "TC-28.3.3",
-      "name": "Custody-halted / witness-invalid write is rejected",
-      "type": "controller",
-      "preconditions": ["A key placed in custody-halt"],
-      "steps": ["POST /api/v1/memory"],
-      "expected_results": ["Rejected consistently with other write endpoints (same status/shape)"],
+      "name": "Custody-halted key cannot write memory",
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant)",
+        "key = fixture(:api_key, tenant: tenant, role: :agent)",
+        "key placed in custody-halt"
+      ],
+      "steps": [
+        "POST /api/v1/memory with a valid body"
+      ],
+      "expected_results": [
+        "rejected consistently with other write endpoints (same status and error shape as a halted knowledge write)"
+      ],
       "status": "pending"
     }
   ],
   "technical_notes": [
+    "Controller: LoopctlWeb.MemoryController; view: LoopctlWeb.MemoryJSON; routes added in lib/loopctl_web/router.ex under the existing :authenticated scope \"/api/v1\".",
     "Model the controller on an existing write-capable knowledge controller for the plug pipeline + error envelope; do not invent a new auth path.",
-    "Scope struct passed to Loopctl.Memory comes from conn.assigns set by SetTenant/Impersonate — mirror how knowledge controllers read the current tenant/subject.",
-    "Keep recall a POST (query + params in body) to match knowledge_search ergonomics and avoid long query strings for embeddings."
+    "The scope struct passed to Loopctl.Memory is built from conn.assigns set by SetTenant/Impersonate — mirror how knowledge controllers read the current tenant/subject.",
+    "Keep recall a POST (query/params in body) to match knowledge_search ergonomics and avoid long query strings.",
+    "OpenAPI schemas live in lib/loopctl/api_spec/; add request/response schema modules and wire operations so openapi_test stays green.",
+    "Tests use Loopctl.Fixtures.fixture/2; fixture(:api_key, tenant:, role:) already exists for other controller tests."
   ],
   "dependencies": ["US-28.2"],
   "estimated_hours": 12

--- a/docs/user_stories/epic_28_agent_memory/us_28.3.json
+++ b/docs/user_stories/epic_28_agent_memory/us_28.3.json
@@ -1,0 +1,84 @@
+{
+  "id": "US-28.3",
+  "title": "HTTP JSON API for memory: /api/v1/memory* on the authenticated pipeline (+ OpenAPI)",
+  "epic": {
+    "id": "epic_28",
+    "name": "Agent Memory (Part 1: store + semantic retrieval)"
+  },
+  "priority": "high",
+  "phase": "api",
+  "background": {
+    "reference": "GitHub issue #307; mirrors the knowledge_* controllers and the :authenticated router pipeline",
+    "includes": "The MCP tools (US-28.4) call the Phoenix /api/v1 API, not the context directly. This story exposes Loopctl.Memory over HTTP with the existing auth/witness stack."
+  },
+  "priority_note": "Bridges the domain (28.2) to the MCP layer (28.4). Must reuse the existing auth pipeline exactly.",
+  "story": {
+    "as_a": "loopctl API consumer (an agent via MCP, or a direct API client)",
+    "i_want_to": "call REST endpoints to write, recall, list, and delete memory, authenticated with my API key and scoped to my tenant/role",
+    "so_that": "agents can use memory over the same governed transport as the knowledge and story APIs"
+  },
+  "rationale": "loopctl's MCP server is a thin HTTP client over /api/v1; memory must live there to inherit tenant resolution, role gating, and the witness/chain-of-custody layer instead of re-implementing them.",
+  "acceptance_criteria": [
+    {
+      "id": "AC-28.3.1",
+      "description": "New LoopctlWeb.MemoryController + MemoryJSON view. Routes under scope \"/api/v1\": POST /api/v1/memory (remember), POST /api/v1/memory/recall (semantic recall), GET /api/v1/memory (list, limit/offset + total_count meta), DELETE /api/v1/memory/:id (forget). All on the :authenticated pipeline.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-28.3.2",
+      "description": "Role gating via Loopctl.Auth.Role: writing/reading memory requires >= agent; the scope (tenant + subject) is derived from the resolved API key (ResolveApiKey/SetTenant/Impersonate), never accepted from the request body. Requests that try to set another tenant/subject are ignored or 403, not honored.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-28.3.3",
+      "description": "The full authenticated plug chain applies (ExtractApiKey → ResolveApiKey → SetTenant → RequireAuth → ValidateWitnessHeader → CheckCustodyHalt). A custody-halted key cannot write memory; a missing/invalid witness header is rejected consistently with other write endpoints.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-28.3.4",
+      "description": "recall response carries the same meta contract as knowledge_search where relevant (fallback flag + reason when embeddings degrade); list carries offset/limit/total_count. Errors use the API's standard error envelope.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-28.3.5",
+      "description": "OpenAPI: operations for all four endpoints are added under lib/loopctl/api_spec/ (request/response schemas), appear at /swaggerui, and the existing openapi_test passes (no 'No operation spec defined' warning for the new actions).",
+      "status": "pending"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "TC-28.3.1",
+      "name": "remember + recall round-trip over HTTP within tenant scope",
+      "type": "controller",
+      "preconditions": ["Authenticated agent-role key for tenant T"],
+      "steps": ["POST /api/v1/memory with a fact", "drain embedding worker", "POST /api/v1/memory/recall with a near query"],
+      "expected_results": ["201 on write; recall returns the memory ranked, scoped to T; response meta present"],
+      "status": "pending"
+    },
+    {
+      "id": "TC-28.3.2",
+      "name": "Body-supplied tenant/subject is ignored; cross-tenant read impossible",
+      "type": "controller",
+      "preconditions": ["Key for tenant T; a memory exists under tenant U"],
+      "steps": ["POST recall with body claiming tenant_id=U", "GET /api/v1/memory"],
+      "expected_results": ["Scope stays T; tenant-U memory never returned; no 500, no leak"],
+      "status": "pending"
+    },
+    {
+      "id": "TC-28.3.3",
+      "name": "Custody-halted / witness-invalid write is rejected",
+      "type": "controller",
+      "preconditions": ["A key placed in custody-halt"],
+      "steps": ["POST /api/v1/memory"],
+      "expected_results": ["Rejected consistently with other write endpoints (same status/shape)"],
+      "status": "pending"
+    }
+  ],
+  "technical_notes": [
+    "Model the controller on an existing write-capable knowledge controller for the plug pipeline + error envelope; do not invent a new auth path.",
+    "Scope struct passed to Loopctl.Memory comes from conn.assigns set by SetTenant/Impersonate — mirror how knowledge controllers read the current tenant/subject.",
+    "Keep recall a POST (query + params in body) to match knowledge_search ergonomics and avoid long query strings for embeddings."
+  ],
+  "dependencies": ["US-28.2"],
+  "estimated_hours": 12
+}

--- a/docs/user_stories/epic_28_agent_memory/us_28.4.json
+++ b/docs/user_stories/epic_28_agent_memory/us_28.4.json
@@ -7,68 +7,101 @@
   },
   "priority": "high",
   "phase": "mcp",
+  "priority_note": "This is what agents actually call; docstrings must steer agents to memory vs knowledge or the feature gets misused.",
   "background": {
-    "reference": "GitHub issue #307; mcp-server/index.js two-list convention (tools array + switch dispatch)",
-    "includes": "The agent-facing surface. Adding a tool = a {name,description,inputSchema} entry in the tools array + a case in the CallToolRequestSchema switch + a handler that HTTP-calls /api/v1/memory* (helpers in mcp-server/lib/http-helpers.js, witness signing in witness-sth.js)."
+    "reference": "GitHub issue #307; mcp-server/index.js two-list convention (tools array + CallToolRequestSchema switch); helpers in mcp-server/lib/http-helpers.js and witness-sth.js",
+    "includes": "Adding a tool = a {name, description, inputSchema} entry in the tools array + a case in the switch + a handler that HTTP-calls /api/v1/memory*. Node tests live in mcp-server/test/."
   },
-  "priority_note": "This is what agents actually call. Docstrings must steer agents to memory vs knowledge or the feature gets misused.",
   "story": {
     "as_a": "an AI agent connected to the loopctl MCP server",
-    "i_want_to": "call memory_remember / memory_recall / memory_forget / memory_list to persist and retrieve my scoped working memory",
+    "i_want_to": "call memory_remember, memory_recall, memory_forget, and memory_list to persist and retrieve my scoped working memory",
     "so_that": "I accumulate and reuse per-project/per-user context across sessions without hand-rolling storage"
   },
-  "rationale": "The MCP tools are the product surface for #307. Their docstrings are load-bearing: agents must know that memory_* is agent-private, scoped, auto-accumulated working state, while knowledge_* is curated, shared knowledge — otherwise they will write memories into the wiki or search the wiki for memories.",
+  "rationale": "The MCP tools are the product surface for #307, and their docstrings are load-bearing: agents must know memory_* is agent-private scoped working state while knowledge_* is curated shared knowledge, or they will write memories into the wiki and search the wiki for memories. Clear disambiguation is the difference between the feature helping and polluting the KB.",
   "acceptance_criteria": [
     {
       "id": "AC-28.4.1",
-      "description": "Four tools registered by the existing convention: memory_remember, memory_recall, memory_forget, memory_list — each with an inputSchema entry in the tools array AND a case in the switch AND a handler calling the corresponding /api/v1/memory* endpoint via the shared HTTP + witness/STH helpers.",
+      "description": "Four tools registered by the existing convention: memory_remember, memory_recall, memory_forget, memory_list — each with an inputSchema entry in the tools array, a case in the CallToolRequestSchema switch, and a handler calling the matching /api/v1/memory* endpoint via the shared HTTP + witness/STH helpers.",
       "status": "pending"
     },
     {
       "id": "AC-28.4.2",
-      "description": "Each tool description explicitly disambiguates memory vs knowledge (e.g. 'Use memory_* for YOUR scoped, private, accumulated working state across sessions; use knowledge_* for curated, shared knowledge articles'). Naming and description style match the existing knowledge_* / story tools.",
+      "description": "Each tool description explicitly disambiguates memory vs knowledge (e.g. 'Use memory_* for YOUR scoped, private, accumulated working state across sessions; use knowledge_* for curated, shared knowledge articles'), matching the style of the existing knowledge_*/story tool descriptions.",
       "status": "pending"
     },
     {
       "id": "AC-28.4.3",
-      "description": "The witness/STH protocol is applied exactly as other write tools (persist + echo STH, self-heal on the 412 witness_bootstrap_already_consumed the way publish.py does); a fresh MCP process does not fail permanently on first memory write.",
+      "description": "The witness/STH protocol is applied exactly as other write tools (persist + echo the STH, self-heal on the 412 witness_bootstrap_already_consumed), so a fresh MCP process does not fail permanently on its first memory write.",
       "status": "pending"
     },
     {
       "id": "AC-28.4.4",
-      "description": "recall/list surface the API meta (fallback flag/reason, total_count) back to the caller so an agent can tell degraded recall from an empty scope.",
+      "description": "recall and list surface the API meta (fallback flag/reason, total_count) back to the caller so an agent can distinguish degraded recall from an empty scope.",
       "status": "pending"
     },
     {
       "id": "AC-28.4.5",
-      "description": "mcp-server/test/memory_tools.test.js covers each tool's happy path + an auth/witness failure + a scope-isolation assertion (a tool call cannot read another scope). ListTools includes the four new tools; existing tools unchanged.",
+      "description": "ListTools includes the four new tools and all existing tools remain unchanged; mcp-server/test/memory_tools.test.js covers each tool's happy path, an auth/witness failure, and a scope-isolation assertion (a tool call cannot read another scope).",
       "status": "pending"
     }
   ],
   "test_cases": [
     {
       "id": "TC-28.4.1",
-      "name": "memory_remember then memory_recall via MCP",
+      "name": "memory_remember then memory_recall via MCP round-trips",
       "type": "integration",
-      "preconditions": ["MCP server pointed at a test API with an agent key"],
-      "steps": ["Call memory_remember", "Call memory_recall with a near query"],
-      "expected_results": ["recall returns the stored memory; response includes meta; witness/STH handled"],
+      "preconditions": [
+        "MCP server pointed at a test API base URL",
+        "an agent-role API key + STH configured in the test env"
+      ],
+      "steps": [
+        "Call the memory_remember tool with a fact",
+        "Call the memory_recall tool with a semantically near query"
+      ],
+      "expected_results": [
+        "memory_recall returns the stored memory",
+        "the response includes meta and the witness/STH exchange succeeded"
+      ],
       "status": "pending"
     },
     {
       "id": "TC-28.4.2",
-      "name": "ListTools exposes the memory tools without regressing existing ones",
+      "name": "ListTools exposes memory tools without regressing existing ones",
       "type": "integration",
-      "preconditions": ["MCP server booted"],
-      "steps": ["Issue ListToolsRequest"],
-      "expected_results": ["memory_remember/recall/forget/list present with disambiguating descriptions; knowledge_*/story tools still present"],
+      "preconditions": [
+        "MCP server booted against the test API"
+      ],
+      "steps": [
+        "Issue a ListToolsRequest"
+      ],
+      "expected_results": [
+        "memory_remember/recall/forget/list are present with disambiguating descriptions",
+        "knowledge_* and story tools are still present and unchanged"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-28.4.3",
+      "name": "A memory tool call cannot read another scope",
+      "type": "integration",
+      "preconditions": [
+        "two agent keys for different subjects in the test API",
+        "a memory written by subject A"
+      ],
+      "steps": [
+        "Call memory_recall using subject B's key for A's fact"
+      ],
+      "expected_results": [
+        "A's memory is not returned to B; no error leaks its existence"
+      ],
       "status": "pending"
     }
   ],
   "technical_notes": [
-    "index.js is ~4,395 lines with two hand-maintained lists; keep the additions localized and consistent — this hand-maintenance pain is itself the motivation for the Context Retriever epic (#309), out of scope here.",
+    "index.js is ~4,395 lines with two hand-maintained lists; keep additions localized and consistent. The hand-maintenance pain is itself the motivation for the Context Retriever epic (#309) and is out of scope here.",
     "Reuse mcp-server/lib/http-helpers.js and witness-sth.js; do not open a second HTTP path.",
-    "Mirror the STH persistence pattern already proven in youtube-knowledge-extract's publish.py (persists ~/.config/...sth, self-heals on 412) — referenced in KB finding 877a415d."
+    "Mirror the STH persistence pattern proven in youtube-knowledge-extract's publish.py (persists an .sth file, self-heals on 412) — referenced in KB finding 877a415d.",
+    "Node tests use the existing mcp-server/test harness (see knowledge_tools.test.js / story_tools.test.js); add memory_tools.test.js."
   ],
   "dependencies": ["US-28.3"],
   "estimated_hours": 10

--- a/docs/user_stories/epic_28_agent_memory/us_28.4.json
+++ b/docs/user_stories/epic_28_agent_memory/us_28.4.json
@@ -1,0 +1,75 @@
+{
+  "id": "US-28.4",
+  "title": "MCP memory_* tools (remember/recall/forget/list) with memory-vs-knowledge docstrings",
+  "epic": {
+    "id": "epic_28",
+    "name": "Agent Memory (Part 1: store + semantic retrieval)"
+  },
+  "priority": "high",
+  "phase": "mcp",
+  "background": {
+    "reference": "GitHub issue #307; mcp-server/index.js two-list convention (tools array + switch dispatch)",
+    "includes": "The agent-facing surface. Adding a tool = a {name,description,inputSchema} entry in the tools array + a case in the CallToolRequestSchema switch + a handler that HTTP-calls /api/v1/memory* (helpers in mcp-server/lib/http-helpers.js, witness signing in witness-sth.js)."
+  },
+  "priority_note": "This is what agents actually call. Docstrings must steer agents to memory vs knowledge or the feature gets misused.",
+  "story": {
+    "as_a": "an AI agent connected to the loopctl MCP server",
+    "i_want_to": "call memory_remember / memory_recall / memory_forget / memory_list to persist and retrieve my scoped working memory",
+    "so_that": "I accumulate and reuse per-project/per-user context across sessions without hand-rolling storage"
+  },
+  "rationale": "The MCP tools are the product surface for #307. Their docstrings are load-bearing: agents must know that memory_* is agent-private, scoped, auto-accumulated working state, while knowledge_* is curated, shared knowledge — otherwise they will write memories into the wiki or search the wiki for memories.",
+  "acceptance_criteria": [
+    {
+      "id": "AC-28.4.1",
+      "description": "Four tools registered by the existing convention: memory_remember, memory_recall, memory_forget, memory_list — each with an inputSchema entry in the tools array AND a case in the switch AND a handler calling the corresponding /api/v1/memory* endpoint via the shared HTTP + witness/STH helpers.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-28.4.2",
+      "description": "Each tool description explicitly disambiguates memory vs knowledge (e.g. 'Use memory_* for YOUR scoped, private, accumulated working state across sessions; use knowledge_* for curated, shared knowledge articles'). Naming and description style match the existing knowledge_* / story tools.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-28.4.3",
+      "description": "The witness/STH protocol is applied exactly as other write tools (persist + echo STH, self-heal on the 412 witness_bootstrap_already_consumed the way publish.py does); a fresh MCP process does not fail permanently on first memory write.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-28.4.4",
+      "description": "recall/list surface the API meta (fallback flag/reason, total_count) back to the caller so an agent can tell degraded recall from an empty scope.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-28.4.5",
+      "description": "mcp-server/test/memory_tools.test.js covers each tool's happy path + an auth/witness failure + a scope-isolation assertion (a tool call cannot read another scope). ListTools includes the four new tools; existing tools unchanged.",
+      "status": "pending"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "TC-28.4.1",
+      "name": "memory_remember then memory_recall via MCP",
+      "type": "integration",
+      "preconditions": ["MCP server pointed at a test API with an agent key"],
+      "steps": ["Call memory_remember", "Call memory_recall with a near query"],
+      "expected_results": ["recall returns the stored memory; response includes meta; witness/STH handled"],
+      "status": "pending"
+    },
+    {
+      "id": "TC-28.4.2",
+      "name": "ListTools exposes the memory tools without regressing existing ones",
+      "type": "integration",
+      "preconditions": ["MCP server booted"],
+      "steps": ["Issue ListToolsRequest"],
+      "expected_results": ["memory_remember/recall/forget/list present with disambiguating descriptions; knowledge_*/story tools still present"],
+      "status": "pending"
+    }
+  ],
+  "technical_notes": [
+    "index.js is ~4,395 lines with two hand-maintained lists; keep the additions localized and consistent — this hand-maintenance pain is itself the motivation for the Context Retriever epic (#309), out of scope here.",
+    "Reuse mcp-server/lib/http-helpers.js and witness-sth.js; do not open a second HTTP path.",
+    "Mirror the STH persistence pattern already proven in youtube-knowledge-extract's publish.py (persists ~/.config/...sth, self-heals on 412) — referenced in KB finding 877a415d."
+  ],
+  "dependencies": ["US-28.3"],
+  "estimated_hours": 10
+}

--- a/docs/user_stories/epic_28_agent_memory/us_28.5.json
+++ b/docs/user_stories/epic_28_agent_memory/us_28.5.json
@@ -7,41 +7,41 @@
   },
   "priority": "medium",
   "phase": "app",
+  "priority_note": "Medium — the API/MCP make memory usable; this makes it trustworthy. Cole explicitly calls out visibility + delete as part of the pillar.",
   "background": {
     "reference": "GitHub issue #307; Cole Medin's 'full control and visibility' — the delete-a-memory UX",
-    "includes": "loopctl has only 4 LiveViews (wiki index/show, signup, onboarding). This adds an authenticated inspector so a human can see and prune what agents have stored — not the public wiki live_session."
+    "includes": "loopctl has only 4 LiveViews (wiki index/show, signup, onboarding). This adds an AUTHENTICATED inspector (not the live_session :public_wiki), reusing wiki_show_live.ex's Earmark rendering and wiki_index_live.ex's pagination."
   },
-  "priority_note": "Medium — the API/MCP make memory usable; this makes it trustworthy (humans can audit and delete). Cole explicitly calls out visibility + delete as part of the pillar.",
   "story": {
     "as_a": "a loopctl operator (human) for my tenant",
     "i_want_to": "browse, semantically search, and delete the memories agents have stored, scoped to a project/subject",
     "so_that": "I keep control and visibility over agent memory and can remove wrong or stale entries"
   },
-  "rationale": "Auto-accumulated memory that a human cannot see or correct is a liability. A minimal read+search+delete inspector closes the trust loop and is the seam Part 2 (#308) extends to flag promoted-vs-explicit and reject bad promotions.",
+  "rationale": "Auto-accumulated memory that a human cannot see or correct is a liability. A minimal read + search + delete inspector closes the trust loop and is the seam Part 2 (#308) extends to flag promoted-vs-explicit and reject bad promotions.",
   "acceptance_criteria": [
     {
       "id": "AC-28.5.1",
-      "description": "New LoopctlWeb.MemoryInspectorLive routed in an AUTHENTICATED live_session in router.ex (not live_session :public_wiki). Access requires an authenticated human tenant session; a memory is only shown within the viewer's tenant scope.",
+      "description": "LoopctlWeb.MemoryInspectorLive is routed in an AUTHENTICATED live_session in lib/loopctl_web/router.ex (NOT live_session :public_wiki). Access requires an authenticated human tenant session, and memories are shown only within the viewer's tenant scope via on_mount scope assignment.",
       "status": "pending"
     },
     {
       "id": "AC-28.5.2",
-      "description": "Lists long-term memories for a selected scope (project/subject filter) with pagination (limit/offset + total_count), newest-first default, showing text, tags, confidence, source ('explicit' now), and timestamps. Renders text via the existing Earmark pattern from wiki_show_live.ex.",
+      "description": "The view lists long-term memories for a selected scope (project/subject filter) with pagination (limit/offset + total_count), newest-first by default, showing text, tags, confidence, source, and timestamps, rendering text via the Earmark pattern from wiki_show_live.ex.",
       "status": "pending"
     },
     {
       "id": "AC-28.5.3",
-      "description": "A search box runs Loopctl.Memory.recall within scope and shows ranked results with scores; degraded-embedding fallback is surfaced visibly (a banner), never a silent empty list.",
+      "description": "A search box calls Loopctl.Memory.recall/2 within scope and shows ranked results with scores; when recall returns meta.fallback == true a visible 'degraded recall' banner is shown — never a silent empty list.",
       "status": "pending"
     },
     {
       "id": "AC-28.5.4",
-      "description": "Delete: an operator can delete a memory from the UI (with a confirm); the delete is scope-checked server-side (cannot delete outside tenant), and the list updates without a full reload.",
+      "description": "An operator can delete a memory from the UI behind a confirm; the delete calls Loopctl.Memory.forget/2 (scope-checked server-side, cannot delete outside tenant) and the list updates without a full page reload.",
       "status": "pending"
     },
     {
       "id": "AC-28.5.5",
-      "description": "The view leaves a clean seam for Part 2: columns/filters for source (explicit|promoted), source_session_id, and confidence exist or are trivially extensible so #308 can add promoted-vs-explicit flagging and a reject action without a rewrite.",
+      "description": "The view leaves a clean seam for Part 2: columns/filters for source (:explicit|:promoted), source_session_id, and confidence exist or are trivially extensible so #308 can add promoted-vs-explicit flagging and a reject action without a rewrite.",
       "status": "pending"
     }
   ],
@@ -49,26 +49,68 @@
     {
       "id": "TC-28.5.1",
       "name": "Inspector lists and deletes only in-scope memories",
-      "type": "liveview",
-      "preconditions": ["Authenticated operator for tenant T; memories under T and under tenant U"],
-      "steps": ["Mount the inspector", "Assert listed set", "Delete one memory"],
-      "expected_results": ["Only tenant-T memories listed (never U); delete removes it and updates the list; a delete attempt on a foreign id is rejected server-side"],
+      "type": "integration",
+      "preconditions": [
+        "tenant_t = fixture(:tenant)",
+        "operator = fixture(:user); fixture(:tenant_user, tenant: tenant_t, user: operator)",
+        "tenant_u = fixture(:tenant)",
+        "fixture(:memory, tenant: tenant_t, subject_id: \"A\", text: \"T fact\")",
+        "fixture(:memory, tenant: tenant_u, subject_id: \"A\", text: \"U fact\")"
+      ],
+      "steps": [
+        "live(conn authenticated as operator, ~p\"/memory\")",
+        "assert the rendered memory list",
+        "click delete on the tenant_t memory and confirm"
+      ],
+      "expected_results": [
+        "only the tenant_t memory is listed (never the tenant_u one)",
+        "after delete the row is gone and the list re-renders without a full reload",
+        "a delete attempt on a foreign id is rejected server-side"
+      ],
       "status": "pending"
     },
     {
       "id": "TC-28.5.2",
       "name": "Search shows ranked results and a degraded banner on fallback",
-      "type": "liveview",
-      "preconditions": ["EmbeddingCircuitBreaker open"],
-      "steps": ["Enter a query that matches a memory's text"],
-      "expected_results": ["Result shown via text fallback with a visible 'degraded recall' banner"],
+      "type": "integration",
+      "preconditions": [
+        "tenant = fixture(:tenant)",
+        "operator = fixture(:user); fixture(:tenant_user, tenant: tenant, user: operator)",
+        "fixture(:memory, tenant: tenant, subject_id: \"A\", text: \"always expedite reships\")",
+        "EmbeddingCircuitBreaker forced open"
+      ],
+      "steps": [
+        "live(conn as operator, ~p\"/memory\")",
+        "submit the search form with query \"expedite\""
+      ],
+      "expected_results": [
+        "the matching memory is shown via text fallback",
+        "a visible 'degraded recall' banner is rendered"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "TC-28.5.3",
+      "name": "Unauthenticated access is refused",
+      "type": "integration",
+      "preconditions": [
+        "no authenticated session"
+      ],
+      "steps": [
+        "attempt live(conn, ~p\"/memory\")"
+      ],
+      "expected_results": [
+        "redirected/denied (not served); the route is not in the public_wiki live_session"
+      ],
       "status": "pending"
     }
   ],
   "technical_notes": [
-    "Put the route behind the same authenticated on_mount used by other tenant-scoped surfaces; do NOT reuse the public_wiki live_session (that renders system-scoped, unauthenticated).",
-    "Reuse wiki_show_live.ex's Earmark rendering and wiki_index_live.ex's pagination approach for consistency.",
-    "Keep it deliberately minimal (read/search/delete). Promoted-vs-explicit UX and reject-a-promotion belong to #308 — just leave the columns/filters extensible."
+    "LiveView: LoopctlWeb.MemoryInspectorLive; route under an authenticated live_session with the same on_mount used by other tenant-scoped surfaces — do NOT reuse live_session :public_wiki (system-scoped, unauthenticated).",
+    "Reuse wiki_show_live.ex Earmark rendering and wiki_index_live.ex pagination for consistency.",
+    "Phoenix 1.8 conventions: Layouts.app, to_form/2, .input; keep the UI deliberately minimal (read/search/delete).",
+    "Promoted-vs-explicit UX and reject-a-promotion belong to #308 — only leave the columns/filters extensible.",
+    "Tests use Loopctl.Fixtures.fixture/2 and Phoenix.LiveViewTest live/2; fixture(:tenant_user) already exists."
   ],
   "dependencies": ["US-28.2", "US-28.3"],
   "estimated_hours": 12

--- a/docs/user_stories/epic_28_agent_memory/us_28.5.json
+++ b/docs/user_stories/epic_28_agent_memory/us_28.5.json
@@ -1,0 +1,75 @@
+{
+  "id": "US-28.5",
+  "title": "Memory-Inspector LiveView: human browse / search / delete of memories per scope",
+  "epic": {
+    "id": "epic_28",
+    "name": "Agent Memory (Part 1: store + semantic retrieval)"
+  },
+  "priority": "medium",
+  "phase": "app",
+  "background": {
+    "reference": "GitHub issue #307; Cole Medin's 'full control and visibility' — the delete-a-memory UX",
+    "includes": "loopctl has only 4 LiveViews (wiki index/show, signup, onboarding). This adds an authenticated inspector so a human can see and prune what agents have stored — not the public wiki live_session."
+  },
+  "priority_note": "Medium — the API/MCP make memory usable; this makes it trustworthy (humans can audit and delete). Cole explicitly calls out visibility + delete as part of the pillar.",
+  "story": {
+    "as_a": "a loopctl operator (human) for my tenant",
+    "i_want_to": "browse, semantically search, and delete the memories agents have stored, scoped to a project/subject",
+    "so_that": "I keep control and visibility over agent memory and can remove wrong or stale entries"
+  },
+  "rationale": "Auto-accumulated memory that a human cannot see or correct is a liability. A minimal read+search+delete inspector closes the trust loop and is the seam Part 2 (#308) extends to flag promoted-vs-explicit and reject bad promotions.",
+  "acceptance_criteria": [
+    {
+      "id": "AC-28.5.1",
+      "description": "New LoopctlWeb.MemoryInspectorLive routed in an AUTHENTICATED live_session in router.ex (not live_session :public_wiki). Access requires an authenticated human tenant session; a memory is only shown within the viewer's tenant scope.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-28.5.2",
+      "description": "Lists long-term memories for a selected scope (project/subject filter) with pagination (limit/offset + total_count), newest-first default, showing text, tags, confidence, source ('explicit' now), and timestamps. Renders text via the existing Earmark pattern from wiki_show_live.ex.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-28.5.3",
+      "description": "A search box runs Loopctl.Memory.recall within scope and shows ranked results with scores; degraded-embedding fallback is surfaced visibly (a banner), never a silent empty list.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-28.5.4",
+      "description": "Delete: an operator can delete a memory from the UI (with a confirm); the delete is scope-checked server-side (cannot delete outside tenant), and the list updates without a full reload.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-28.5.5",
+      "description": "The view leaves a clean seam for Part 2: columns/filters for source (explicit|promoted), source_session_id, and confidence exist or are trivially extensible so #308 can add promoted-vs-explicit flagging and a reject action without a rewrite.",
+      "status": "pending"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "TC-28.5.1",
+      "name": "Inspector lists and deletes only in-scope memories",
+      "type": "liveview",
+      "preconditions": ["Authenticated operator for tenant T; memories under T and under tenant U"],
+      "steps": ["Mount the inspector", "Assert listed set", "Delete one memory"],
+      "expected_results": ["Only tenant-T memories listed (never U); delete removes it and updates the list; a delete attempt on a foreign id is rejected server-side"],
+      "status": "pending"
+    },
+    {
+      "id": "TC-28.5.2",
+      "name": "Search shows ranked results and a degraded banner on fallback",
+      "type": "liveview",
+      "preconditions": ["EmbeddingCircuitBreaker open"],
+      "steps": ["Enter a query that matches a memory's text"],
+      "expected_results": ["Result shown via text fallback with a visible 'degraded recall' banner"],
+      "status": "pending"
+    }
+  ],
+  "technical_notes": [
+    "Put the route behind the same authenticated on_mount used by other tenant-scoped surfaces; do NOT reuse the public_wiki live_session (that renders system-scoped, unauthenticated).",
+    "Reuse wiki_show_live.ex's Earmark rendering and wiki_index_live.ex's pagination approach for consistency.",
+    "Keep it deliberately minimal (read/search/delete). Promoted-vs-explicit UX and reject-a-promotion belong to #308 — just leave the columns/filters extensible."
+  ],
+  "dependencies": ["US-28.2", "US-28.3"],
+  "estimated_hours": 12
+}

--- a/docs/user_stories/epic_28_agent_memory/us_28.6.json
+++ b/docs/user_stories/epic_28_agent_memory/us_28.6.json
@@ -7,68 +7,91 @@
   },
   "priority": "high",
   "phase": "verification_docs",
+  "priority_note": "Terminal story: owns the epic-wide scope-isolation proof and the docs so no earlier story is blocked mid-loop on cross-surface concerns.",
   "background": {
     "reference": "GitHub issue #307; mirrors epic_27's terminal verification story (US-27.17) pattern",
-    "includes": "Every prior story asserts its own slice; this story proves the pillar end-to-end across app/api/mcp and writes the memory-vs-knowledge documentation. It depends on every leaf story and runs DEAD LAST."
+    "includes": "Every prior story asserts its own slice; this story proves the pillar end-to-end across context/API/MCP, proves cross-scope isolation everywhere, and writes the memory-vs-knowledge documentation. It depends on every leaf story and runs DEAD LAST."
   },
-  "priority_note": "Terminal story: owns the epic-wide scope-isolation proof and the docs so no earlier story is blocked mid-loop on cross-surface concerns.",
   "story": {
-    "as_a": "loopctl maintainer",
-    "i_want_to": "run one end-to-end pass that writes and recalls memory through every surface (context, API, MCP) and proves cross-tenant/cross-subject isolation holds everywhere, plus document the memory-vs-knowledge boundary",
+    "as_a": "a loopctl maintainer",
+    "i_want_to": "run one end-to-end pass that writes and recalls memory through every surface and proves cross-tenant/cross-subject isolation holds everywhere, plus document the memory-vs-knowledge boundary",
     "so_that": "the agent-memory pillar ships proven and understandable, not just unit-green"
   },
-  "rationale": "Scope isolation is the security property of the whole subsystem; asserting it once per layer is not the same as asserting it holds across the full write→embed→recall→UI path. A single terminal verification (the epic_27 model) plus authoritative docs turns a set of merged stories into a trustworthy, teachable feature.",
+  "rationale": "Scope isolation is the security property of the whole subsystem, and asserting it once per layer is not the same as asserting it holds across the full write→embed→recall→UI path. A single terminal verification (the epic_27 model) plus authoritative docs turns a set of merged stories into a trustworthy, teachable feature.",
   "acceptance_criteria": [
     {
       "id": "AC-28.6.1",
-      "description": "docs/agent-memory.md written: the subsystem architecture, the two tiers (session vs long-term), the scope model, and an explicit 'when to use memory vs knowledge (vs the future context retriever)' section. It reconciles/absorbs any content the removed docs/cole-medin-self-evolving-wiki.md carried (that transcript is now KB hub fb9abd73).",
+      "description": "docs/agent-memory.md is written: subsystem architecture, the two tiers (session vs long-term), the scope model, and an explicit 'when to use memory vs knowledge (vs the future context retriever)' section. It absorbs any durable content the removed docs/cole-medin-self-evolving-wiki.md carried (now KB hub fb9abd73).",
       "status": "pending"
     },
     {
       "id": "AC-28.6.2",
-      "description": "README.md (feature + memory_* tool list), CLAUDE.md and AGENTS.md (agent guidance: pick memory_* vs knowledge_*), and CHANGELOG.md are updated. OpenAPI docs render the memory endpoints at /swaggerui.",
+      "description": "README.md (feature + memory_* tool list), CLAUDE.md and AGENTS.md (agent guidance: pick memory_* vs knowledge_*), and CHANGELOG.md are updated; the memory endpoints render at /swaggerui.",
       "status": "pending"
     },
     {
       "id": "AC-28.6.3",
-      "description": "An end-to-end test writes a memory via the API, drains embedding, recalls it via the context AND the API, and asserts the same memory is reachable through each — one coherent path, not three isolated stubs.",
+      "description": "An end-to-end integration test writes a memory via the API, drains embedding, then recalls it via BOTH Loopctl.Memory and the API, asserting the same memory is reachable through each — one coherent path, not three isolated stubs.",
       "status": "pending"
     },
     {
       "id": "AC-28.6.4",
-      "description": "A cross-surface scope-isolation suite proves a memory written under (tenant T, subject A) is NOT retrievable as tenant U, nor as subject B of T, through the context, the API, and the MCP tool — closing the leak surface epic-wide.",
+      "description": "A cross-surface scope-isolation suite proves a memory written under (tenant T, subject A) is NOT retrievable as tenant U nor as subject B of T through the context and the API (and, where testable, the MCP tool) — closing the leak surface epic-wide.",
       "status": "pending"
     },
     {
       "id": "AC-28.6.5",
-      "description": "A documented seam note for #308 (auto-promotion) and mkreyman/claude-config#85 (skills consumer): where the compiler hooks in (source='promoted', supersede) and which memory_* tools the skills call. No implementation of those here — just the verified extension points.",
+      "description": "A documented seam note records where #308 (auto-promotion) and mkreyman/claude-config#85 (skills consumer) hook in (source=:promoted, supersede/2, which memory_* tools the skills call). No implementation of those here — only the verified extension points.",
       "status": "pending"
     }
   ],
   "test_cases": [
     {
       "id": "TC-28.6.1",
-      "name": "End-to-end write(API) → recall(context+API) for one memory",
+      "name": "End-to-end write(API) then recall(context + API) for one memory",
       "type": "integration",
-      "preconditions": ["Authenticated agent key; deterministic embedding stub"],
-      "steps": ["POST /api/v1/memory", "drain worker", "recall via Loopctl.Memory and via POST /api/v1/memory/recall"],
-      "expected_results": ["Both recalls return the same memory; scores present"],
+      "preconditions": [
+        "tenant = fixture(:tenant)",
+        "key = fixture(:api_key, tenant: tenant, role: :agent)",
+        "embedding client stubbed via Mox to deterministic vectors"
+      ],
+      "steps": [
+        "POST /api/v1/memory with a fact",
+        "drain the MemoryEmbeddingWorker queue",
+        "Loopctl.Memory.recall(scope, %{query: ...}) and POST /api/v1/memory/recall with the same query"
+      ],
+      "expected_results": [
+        "both recalls return the same memory id with a score",
+        "the API and context results agree"
+      ],
       "status": "pending"
     },
     {
       "id": "TC-28.6.2",
       "name": "Cross-tenant and cross-subject isolation holds on every surface",
       "type": "integration",
-      "preconditions": ["Memory under (T, A)"],
-      "steps": ["Attempt recall/list/forget as tenant U and as (T, B) via context, API, and MCP"],
-      "expected_results": ["Never returned or mutated on any surface; no existence leak"],
+      "preconditions": [
+        "tenant_t = fixture(:tenant)",
+        "tenant_u = fixture(:tenant)",
+        "key_u = fixture(:api_key, tenant: tenant_u, role: :agent)",
+        "m = fixture(:memory, tenant: tenant_t, subject_id: \"A\", text: \"T/A secret\"); drain embedding"
+      ],
+      "steps": [
+        "recall/list/forget m as tenant_u via the API",
+        "recall/list/forget m as (tenant_t, subject B) via Loopctl.Memory"
+      ],
+      "expected_results": [
+        "m is never returned or mutated on any surface",
+        "no response leaks m's existence"
+      ],
       "status": "pending"
     }
   ],
   "technical_notes": [
     "Model on epic_27's US-27.17 terminal-verification pattern: this story depends on all leaves and runs last so no implementation story blocks on cross-surface concerns.",
-    "Docs are authoritative for the three-layer mental model (knowledge / memory / context-retriever) that the Cole Medin comparison surfaced — keep it short and decision-oriented.",
-    "Do not implement #308 or #85 here; only assert and document the seams they rely on."
+    "Docs file: docs/agent-memory.md is authoritative for the three-layer mental model (knowledge / memory / context-retriever) the Cole Medin comparison surfaced — keep it short and decision-oriented.",
+    "Do NOT implement #308 or claude-config#85 here; only assert and document the seams they rely on.",
+    "Tests use Loopctl.Fixtures.fixture/2; reuse the deterministic Mox embedding stub from US-28.2."
   ],
   "dependencies": ["US-28.1", "US-28.2", "US-28.3", "US-28.4", "US-28.5"],
   "estimated_hours": 10

--- a/docs/user_stories/epic_28_agent_memory/us_28.6.json
+++ b/docs/user_stories/epic_28_agent_memory/us_28.6.json
@@ -1,0 +1,75 @@
+{
+  "id": "US-28.6",
+  "title": "Docs + terminal cross-surface scope-isolation & end-to-end verification (runs last)",
+  "epic": {
+    "id": "epic_28",
+    "name": "Agent Memory (Part 1: store + semantic retrieval)"
+  },
+  "priority": "high",
+  "phase": "verification_docs",
+  "background": {
+    "reference": "GitHub issue #307; mirrors epic_27's terminal verification story (US-27.17) pattern",
+    "includes": "Every prior story asserts its own slice; this story proves the pillar end-to-end across app/api/mcp and writes the memory-vs-knowledge documentation. It depends on every leaf story and runs DEAD LAST."
+  },
+  "priority_note": "Terminal story: owns the epic-wide scope-isolation proof and the docs so no earlier story is blocked mid-loop on cross-surface concerns.",
+  "story": {
+    "as_a": "loopctl maintainer",
+    "i_want_to": "run one end-to-end pass that writes and recalls memory through every surface (context, API, MCP) and proves cross-tenant/cross-subject isolation holds everywhere, plus document the memory-vs-knowledge boundary",
+    "so_that": "the agent-memory pillar ships proven and understandable, not just unit-green"
+  },
+  "rationale": "Scope isolation is the security property of the whole subsystem; asserting it once per layer is not the same as asserting it holds across the full write→embed→recall→UI path. A single terminal verification (the epic_27 model) plus authoritative docs turns a set of merged stories into a trustworthy, teachable feature.",
+  "acceptance_criteria": [
+    {
+      "id": "AC-28.6.1",
+      "description": "docs/agent-memory.md written: the subsystem architecture, the two tiers (session vs long-term), the scope model, and an explicit 'when to use memory vs knowledge (vs the future context retriever)' section. It reconciles/absorbs any content the removed docs/cole-medin-self-evolving-wiki.md carried (that transcript is now KB hub fb9abd73).",
+      "status": "pending"
+    },
+    {
+      "id": "AC-28.6.2",
+      "description": "README.md (feature + memory_* tool list), CLAUDE.md and AGENTS.md (agent guidance: pick memory_* vs knowledge_*), and CHANGELOG.md are updated. OpenAPI docs render the memory endpoints at /swaggerui.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-28.6.3",
+      "description": "An end-to-end test writes a memory via the API, drains embedding, recalls it via the context AND the API, and asserts the same memory is reachable through each — one coherent path, not three isolated stubs.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-28.6.4",
+      "description": "A cross-surface scope-isolation suite proves a memory written under (tenant T, subject A) is NOT retrievable as tenant U, nor as subject B of T, through the context, the API, and the MCP tool — closing the leak surface epic-wide.",
+      "status": "pending"
+    },
+    {
+      "id": "AC-28.6.5",
+      "description": "A documented seam note for #308 (auto-promotion) and mkreyman/claude-config#85 (skills consumer): where the compiler hooks in (source='promoted', supersede) and which memory_* tools the skills call. No implementation of those here — just the verified extension points.",
+      "status": "pending"
+    }
+  ],
+  "test_cases": [
+    {
+      "id": "TC-28.6.1",
+      "name": "End-to-end write(API) → recall(context+API) for one memory",
+      "type": "integration",
+      "preconditions": ["Authenticated agent key; deterministic embedding stub"],
+      "steps": ["POST /api/v1/memory", "drain worker", "recall via Loopctl.Memory and via POST /api/v1/memory/recall"],
+      "expected_results": ["Both recalls return the same memory; scores present"],
+      "status": "pending"
+    },
+    {
+      "id": "TC-28.6.2",
+      "name": "Cross-tenant and cross-subject isolation holds on every surface",
+      "type": "integration",
+      "preconditions": ["Memory under (T, A)"],
+      "steps": ["Attempt recall/list/forget as tenant U and as (T, B) via context, API, and MCP"],
+      "expected_results": ["Never returned or mutated on any surface; no existence leak"],
+      "status": "pending"
+    }
+  ],
+  "technical_notes": [
+    "Model on epic_27's US-27.17 terminal-verification pattern: this story depends on all leaves and runs last so no implementation story blocks on cross-surface concerns.",
+    "Docs are authoritative for the three-layer mental model (knowledge / memory / context-retriever) that the Cole Medin comparison surfaced — keep it short and decision-oriented.",
+    "Do not implement #308 or #85 here; only assert and document the seams they rely on."
+  ],
+  "dependencies": ["US-28.1", "US-28.2", "US-28.3", "US-28.4", "US-28.5"],
+  "estimated_hours": 10
+}


### PR DESCRIPTION
First-draft user-story scaffold decomposing **#307** (Agent Memory — Part 1: per-scope store + semantic retrieval) into 6 stories + README, matching the epic_27 JSON convention.

**Docs-only — no code.** Adds `docs/user_stories/epic_28_agent_memory/`.

| Story | Surface |
|-------|---------|
| US-28.1 | schemas + migrations (session_memories + memories, HNSW, scoped) |
| US-28.2 | Loopctl.Memory context + embedding worker |
| US-28.3 | HTTP JSON API /api/v1/memory* |
| US-28.4 | MCP memory_* tools |
| US-28.5 | Memory-Inspector LiveView |
| US-28.6 | docs + terminal cross-surface scope-isolation verification |

⚠️ **FIRST-DRAFT — review before implementing.** The README flags that these should be refined with `user-story-writer` and run through enhanced review (as epic_27 was) before `/implement-plan`. Opened for review, not for immediate merge.

Provenance: Second Brain hub `3ee5f890` (Cole Medin) + revived idea `787761cd`. Refs #307.