### PR TITLE
chore: untrack .claude/settings.local.json (public repo), allowlist project skills

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(bash ~/.claude/hooks/knowledge-capture.sh)"
-    ]
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,13 @@ mcp-server/node_modules/
 
 # Design reference templates (not application code)
 /docs/tailwind/
-.claude/implement-plan.run.json
+
+# Claude Code harness state — ignore run artifacts + personal local settings,
+# but keep project-scoped skills/commands/agents tracked.
+.claude/*
+!.claude/skills/
+!.claude/skills/**
+!.claude/commands/
+!.claude/commands/**
+!.claude/agents/
+!.claude/agents/**


### PR DESCRIPTION
loopctl is public; `.claude/settings.local.json` is personal local Claude Code config (tool-permission allowlists only — no secrets) that shouldn't be shared. Untracks it (local file kept) and adopts the allowlist gitignore convention used in home_care_billing / cron_books: ignore `.claude/*` run artifacts + local settings, keep project-scoped `skills/`, `commands/`, `agents/` tracked.

Note: the file was benign (permissions only), so its prior presence in public history is not a secret exposure — no history rewrite needed.