### PR TITLE
chore(epic_28): estimated_hours -> estimated_tokens

### DIFF
--- a/docs/user_stories/epic_28_agent_memory/us_28.1.json
+++ b/docs/user_stories/epic_28_agent_memory/us_28.1.json
@@ -159,5 +159,5 @@
     "Tests use Loopctl.Fixtures.fixture/1,2; add fixture(:memory, attrs) and fixture(:session_memory, attrs) helpers in this story. fixture(:tenant) and fixture(:api_key, role:) already exist; there is NO fixture(:user)/fixture(:tenant_user) (no human-auth in loopctl)."
   ],
   "dependencies": [],
-  "estimated_hours": 12
+  "estimated_tokens": 300000
 }

--- a/docs/user_stories/epic_28_agent_memory/us_28.2.json
+++ b/docs/user_stories/epic_28_agent_memory/us_28.2.json
@@ -240,6 +240,8 @@
     "supersede + source=:promoted are the seams #308 uses. superseded_by on_delete: :nilify_all is set in US-28.1.",
     "Tests use Loopctl.Fixtures.fixture/2; add fixture(:memory_scope, attrs), fixture(:memory, attrs), fixture(:session_memory, attrs). Stub the embedding provider with Mox against the existing embedding behaviour (no network)."
   ],
-  "dependencies": ["US-28.1"],
-  "estimated_hours": 20
+  "dependencies": [
+    "US-28.1"
+  ],
+  "estimated_tokens": 480000
 }

--- a/docs/user_stories/epic_28_agent_memory/us_28.3.json
+++ b/docs/user_stories/epic_28_agent_memory/us_28.3.json
@@ -158,6 +158,8 @@
     "fixture(:api_key, tenant:, role:) returns {raw_key, %ApiKey{}} and already exists; there is no human-user fixture.",
     "agent role is the floor (level 1) in lib/loopctl/auth/role.ex — 'role >= agent' is a no-op gate; the boundary is (tenant_id, subject_id)."
   ],
-  "dependencies": ["US-28.2"],
-  "estimated_hours": 14
+  "dependencies": [
+    "US-28.2"
+  ],
+  "estimated_tokens": 280000
 }

--- a/docs/user_stories/epic_28_agent_memory/us_28.4.json
+++ b/docs/user_stories/epic_28_agent_memory/us_28.4.json
@@ -121,6 +121,8 @@
     "Mirror the STH persistence pattern proven in youtube-knowledge-extract's publish.py (persists an .sth file, self-heals on 412) — referenced in KB finding 877a415d.",
     "Node tests use the existing mcp-server/test harness (see knowledge_tools.test.js / story_tools.test.js); add memory_tools.test.js."
   ],
-  "dependencies": ["US-28.3"],
-  "estimated_hours": 10
+  "dependencies": [
+    "US-28.3"
+  ],
+  "estimated_tokens": 160000
 }

--- a/docs/user_stories/epic_28_agent_memory/us_28.5.json
+++ b/docs/user_stories/epic_28_agent_memory/us_28.5.json
@@ -122,6 +122,11 @@
     "Do NOT implement #308 or claude-config#85 here; only assert and document the seams they rely on.",
     "Tests use Loopctl.Fixtures.fixture/2; reuse the deterministic Mox embedding stub from US-28.2 and the ScaleSeed helper from US-27.1."
   ],
-  "dependencies": ["US-28.1", "US-28.2", "US-28.3", "US-28.4"],
-  "estimated_hours": 12
+  "dependencies": [
+    "US-28.1",
+    "US-28.2",
+    "US-28.3",
+    "US-28.4"
+  ],
+  "estimated_tokens": 240000
 }


### PR DESCRIPTION
The `user-story-writer` skill schema now uses `estimated_tokens` (the loopctl orchestrator reads it to pick the implementation model); epic_28 was authored just before that skill change. Converts its 5 stories to `estimated_tokens` for consistency with epic_29/30/31. Field-only change.