### PR TITLE
fix(ingest): retry transient extraction errors + rescue orphaned Oban jobs

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -287,7 +287,16 @@ config :loopctl, Oban,
        {"*/5 * * * *", Loopctl.Workers.SessionMemoryPruneWorker},
        {"* * * * *", Loopctl.Workers.ComputeSthWorker, args: %{"mode" => "all_tenants"}},
        {"* * * * *", Loopctl.Workers.RevokeExpiredDispatchesWorker}
-     ]}
+     ]},
+    # Rescue jobs orphaned in :executing when a node dies mid-run (e.g. a deploy).
+    # Without Lifeline these rows stay `executing` forever — 110 such orphans (from
+    # 2026-06-22) were found still clogging the queues on 2026-07-10. Reset a stuck
+    # job back to `available` (or discard if attempts are exhausted) after 30 min so
+    # the slot frees and it re-runs instead of leaking.
+    {Oban.Plugins.Lifeline, rescue_after: :timer.minutes(30)},
+    # Prune terminal (completed/discarded/cancelled) jobs older than 7 days so the
+    # oban_jobs table doesn't grow unbounded.
+    {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 7}
   ]
 
 # Cloak Vault — key configured per environment

--- a/lib/loopctl/knowledge/claude_content_extractor.ex
+++ b/lib/loopctl/knowledge/claude_content_extractor.ex
@@ -53,11 +53,19 @@ defmodule Loopctl.Knowledge.ClaudeContentExtractor do
 
     # Explicit client budget UNDER the worker's @per_chunk_timeout_ms (30s) Oban
     # budget (review #9) — the highest-max_tokens (64k) site, so don't rely on the
-    # shared default. 25s + no internal retry keeps the whole request inside the
-    # per-chunk budget; the worker retries the whole (idempotent) job on transients.
+    # shared default. 25s keeps a single attempt inside the per-chunk budget.
+    #
+    # ONE bounded transient retry (2026-07-10): under a harvest burst the provider
+    # throttles and a single fast `:transport_error` / 429 was discarding the whole
+    # multi-chunk ingestion job (then Oban re-ran the entire idempotent job — costly
+    # and often failing all 3 attempts). `retry: :transient` is always set by
+    # Anthropic.message; max_retries: 1 lets Req re-attempt once (~1s backoff) so the
+    # COMMON fast-transient failure self-heals within the existing 30s per-chunk
+    # budget. A slow (~25s) first failure still can't fit a retry — unchanged, no
+    # regression — but those are the minority.
     case Anthropic.message(tenant_id, :extraction, body_fun, %{source_type: source_type},
            receive_timeout: 25_000,
-           max_retries: 0
+           max_retries: 1
          ) do
       {:ok, text} -> parse_articles(text)
       {:error, :no_api_key} -> {:error, :no_api_key}

--- a/test/loopctl/knowledge/claude_content_extractor_test.exs
+++ b/test/loopctl/knowledge/claude_content_extractor_test.exs
@@ -65,6 +65,34 @@ defmodule Loopctl.Knowledge.ClaudeContentExtractorTest do
     assert %{data: []} = Llm.usage_summary(tenant.id, [])
   end
 
+  test "retries once on a transient transport error, then succeeds (harvest hardening 2026-07-10)" do
+    tenant = fixture(:tenant)
+    {:ok, _} = Llm.upsert_settings(tenant.id, %{"api_key" => "test-anthropic-retry"})
+
+    articles_json =
+      JSON.encode!([%{title: "R1", body: "B1", category: "pattern", tags: ["x"]}])
+
+    # A single fast transient blip on the first attempt must NOT discard the whole
+    # ingestion job: `retry: :transient` (set by Anthropic.message) + max_retries: 1
+    # (the extractor) re-attempts once, and the second attempt succeeds. Req.Test
+    # expectations are consumed in order — first HTTP call, then the retry.
+    Req.Test.expect(Loopctl.Llm.Anthropic, fn conn ->
+      Req.Test.transport_error(conn, :econnrefused)
+    end)
+
+    Req.Test.expect(Loopctl.Llm.Anthropic, fn conn ->
+      Req.Test.json(conn, %{
+        "content" => [%{"type" => "text", "text" => articles_json}],
+        "usage" => %{"input_tokens" => 10, "output_tokens" => 5}
+      })
+    end)
+
+    assert {:ok, [%{title: "R1", category: :pattern}]} =
+             ClaudeContentExtractor.extract_from_content(tenant.id, "raw content",
+               source_type: "newsletter"
+             )
+  end
+
   test "surfaces an API error and records no usage" do
     tenant = fixture(:tenant)
     {:ok, _} = Llm.upsert_settings(tenant.id, %{"api_key" => "test-anthropic-1"})


### PR DESCRIPTION
## Production hotfix — ingestion worker degradation during a harvest

### Diagnosis (from prod `oban_jobs` + `knowledge_llm_usage`)
Under a concurrent harvest burst, the extraction provider (Anthropic) throttles. `ClaudeContentExtractor` was configured `max_retries: 0`, so a single fast `:transport_error` / 429 discarded the **whole multi-chunk ingestion job**; Oban then re-ran the entire (idempotent) job, often failing all three attempts. Result: harvest content never ingested.

Separately, **110 jobs orphaned since 2026-06-22** were found stuck in `:executing` forever — because **no `Oban.Plugins.Lifeline`** was configured to rescue jobs abandoned when a node dies mid-run (deploys).

### Changes
1. **Extraction resilience** — flip `max_retries: 0 → 1` in `ClaudeContentExtractor`. `retry: :transient` is already set by `Anthropic.message`, so the common fast-transient failure now self-heals within the existing 30s per-chunk budget (no timeout / `@max_chunks` / GHSA-bound changes). + regression test.
2. **Oban hygiene** — add `Oban.Plugins.Lifeline` (rescue `:executing` orphans after 30 min) and `Oban.Plugins.Pruner` (prune terminal jobs after 7 days).

### Not in scope (tracked fast-follow)
The deeper embedding-path brittleness (`EmbeddingClient` 4s / 0-retry, worker budget never reaching the HTTP call — the 74 `ArticleEmbeddingWorker` discards) needs a behaviour `/3` threading change and is a separate PR.

### Validation
- `mix precommit` green locally: **3860 tests, 0 failures**, format + credo --strict + dialyzer clean.
- New test: transient transport error on first attempt → retried → succeeds.

### Post-deploy
Retry tonight's failed harvest jobs via the Oban API (11 transient `ContentIngestionWorker` discards; then the 74 `ArticleEmbeddingWorker` discards).