### PR TITLE
feat(config): DB-backed live-tunable system configuration for operational knobs

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -286,7 +286,8 @@ config :loopctl, Oban,
        {"*/5 * * * *", Loopctl.Workers.PendingEnrollmentCleanupWorker},
        {"*/5 * * * *", Loopctl.Workers.SessionMemoryPruneWorker},
        {"* * * * *", Loopctl.Workers.ComputeSthWorker, args: %{"mode" => "all_tenants"}},
-       {"* * * * *", Loopctl.Workers.RevokeExpiredDispatchesWorker}
+       {"* * * * *", Loopctl.Workers.RevokeExpiredDispatchesWorker},
+       {"* * * * *", Loopctl.Workers.SystemConfigRefreshWorker}
      ]},
     # Rescue jobs orphaned in :executing when a node dies mid-run (e.g. a deploy).
     # Without Lifeline these rows stay `executing` forever — 110 such orphans (from

--- a/lib/loopctl/application.ex
+++ b/lib/loopctl/application.ex
@@ -40,6 +40,13 @@ defmodule Loopctl.Application do
     opts = [strategy: :one_for_one, name: Loopctl.Supervisor]
     result = Supervisor.start_link(children, opts)
 
+    # Prime the SystemConfig :persistent_term cache from the DB now that the repos
+    # are started, so the ingestion/extraction hot path reads live values from the
+    # first request. refresh/0 is rescue-wrapped (a DB blip logs and no-ops), so a
+    # failed prime NEVER blocks boot — the in-code defaults simply apply until the
+    # per-minute refresh cron succeeds.
+    Loopctl.SystemConfig.refresh()
+
     # US-27.11 (AC-27.11.5): warn if the actual configured pools would exceed the live
     # DB max_connections at the expected node count. Prod only (dev/test pools differ),
     # log-only, never blocks boot.

--- a/lib/loopctl/knowledge/claude_content_extractor.ex
+++ b/lib/loopctl/knowledge/claude_content_extractor.ex
@@ -21,6 +21,7 @@ defmodule Loopctl.Knowledge.ClaudeContentExtractor do
 
   alias Loopctl.Knowledge.Categories
   alias Loopctl.Llm.Anthropic
+  alias Loopctl.SystemConfig
 
   @system_prompt """
   You are a knowledge extraction assistant. Given raw content (web article, \
@@ -51,21 +52,24 @@ defmodule Loopctl.Knowledge.ClaudeContentExtractor do
       }
     end
 
-    # Explicit client budget UNDER the worker's @per_chunk_timeout_ms (30s) Oban
-    # budget (review #9) — the highest-max_tokens (64k) site, so don't rely on the
-    # shared default. 25s keeps a single attempt inside the per-chunk budget.
+    # Explicit client budget UNDER the worker's per_chunk_timeout_ms/0 (60s
+    # default) Oban budget (review #9) — the highest-max_tokens (64k) site, so
+    # don't rely on the shared default. Both knobs are DB-backed and live-tunable
+    # via Loopctl.SystemConfig; the in-code defaults below match the seeded rows
+    # and apply on a cache miss (safe degrade). 25s keeps a single attempt inside
+    # the per-chunk budget.
     #
     # ONE bounded transient retry (2026-07-10): under a harvest burst the provider
     # throttles and a single fast `:transport_error` / 429 was discarding the whole
     # multi-chunk ingestion job (then Oban re-ran the entire idempotent job — costly
     # and often failing all 3 attempts). `retry: :transient` is always set by
     # Anthropic.message; max_retries: 1 lets Req re-attempt once (~1s backoff) so the
-    # COMMON fast-transient failure self-heals within the existing 30s per-chunk
-    # budget. A slow (~25s) first failure still can't fit a retry — unchanged, no
-    # regression — but those are the minority.
+    # COMMON fast-transient failure self-heals within the per-chunk budget. A slow
+    # (~25s) first failure still can't fit a retry — unchanged, no regression — but
+    # those are the minority.
     case Anthropic.message(tenant_id, :extraction, body_fun, %{source_type: source_type},
-           receive_timeout: 25_000,
-           max_retries: 1
+           receive_timeout: SystemConfig.get_int("extraction_receive_timeout_ms", 25_000),
+           max_retries: SystemConfig.get_int("extraction_max_retries", 1)
          ) do
       {:ok, text} -> parse_articles(text)
       {:error, :no_api_key} -> {:error, :no_api_key}

--- a/lib/loopctl/knowledge/embedding_client.ex
+++ b/lib/loopctl/knowledge/embedding_client.ex
@@ -34,15 +34,9 @@ defmodule Loopctl.Knowledge.EmbeddingClient do
 
   alias Loopctl.Llm
   alias Loopctl.Llm.ProviderError
+  alias Loopctl.SystemConfig
 
   @default_base_url "https://api.openai.com/v1"
-
-  # Kept STRICTLY BELOW `Knowledge`'s Task.yield budget (review #10): a single
-  # attempt, no client-side retries. The embedding endpoint is fast; job-level retry
-  # is Oban's responsibility for the worker, and the query path fast-fails to
-  # keyword search. This guarantees a valid embed returns before the guard kills it.
-  @receive_timeout 4_000
-  @max_retries 0
 
   @impl true
   def generate_embedding(tenant_id, text) when is_binary(tenant_id) do
@@ -59,14 +53,21 @@ defmodule Loopctl.Knowledge.EmbeddingClient do
   defp post(tenant_id, api_key, model, text) do
     base_url = provider_config()[:base_url] || @default_base_url
 
+    # Kept STRICTLY BELOW `Knowledge`'s Task.yield budget (review #10): a single
+    # attempt, no client-side retries by default. The embedding endpoint is fast;
+    # job-level retry is Oban's responsibility for the worker, and the query path
+    # fast-fails to keyword search. This guarantees a valid embed returns before
+    # the guard kills it. Both knobs are DB-backed and live-tunable via
+    # Loopctl.SystemConfig; the in-code defaults match the seeded rows and apply on
+    # a cache miss (safe degrade) — keep any raised timeout under the yield budget.
     opts =
       [
         json: %{input: text, model: model},
         # NOTE: never log `opts` / `api_key` — the key is a tenant secret.
         headers: [{"authorization", "Bearer #{api_key}"}],
         retry: :transient,
-        max_retries: @max_retries,
-        receive_timeout: @receive_timeout
+        max_retries: SystemConfig.get_int("embedding_max_retries", 0),
+        receive_timeout: SystemConfig.get_int("embedding_receive_timeout_ms", 4_000)
       ]
       |> maybe_put_plug()
 

--- a/lib/loopctl/system_config.ex
+++ b/lib/loopctl/system_config.ex
@@ -1,0 +1,116 @@
+defmodule Loopctl.SystemConfig do
+  @moduledoc """
+  DB-backed, live-tunable system configuration for operational knobs
+  (timeout/retry budgets) that were previously hardcoded module attributes.
+
+  Changing a value is now an `UPDATE` of a `system_configs` row — no code change,
+  no redeploy. The change is picked up immediately on write (`put/2`), and by any
+  other node within a minute via the `SystemConfigRefreshWorker` Oban cron.
+
+  ## Hot-path read
+
+  `get_int/2` reads from `:persistent_term` (a near-zero-cost VM-global read) and
+  MUST NEVER raise — it is called on the ingestion/extraction hot path. A cache
+  miss OR any error returns the caller-supplied default, so a missing DB row (or a
+  DB the cache was never primed from) behaves exactly like the pre-existing
+  in-code default.
+
+  ## Refresh lifecycle
+
+  The cache is (re)loaded from the DB via `Loopctl.AdminRepo`:
+
+    * once at boot (`Loopctl.Application.start/2`, guarded), and
+    * every minute by `Loopctl.Workers.SystemConfigRefreshWorker`, and
+    * immediately for a single key on `put/2`.
+
+  `refresh/0` is `try/rescue`-wrapped so a DB blip logs and no-ops — it never
+  crashes boot or the cron worker; the previously-cached values simply persist.
+
+  The `:persistent_term` key is `{__MODULE__, key_string}` — string keys are used
+  verbatim (never `String.to_atom/1` on them).
+  """
+
+  import Ecto.Query, only: [from: 2]
+
+  require Logger
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.SystemConfig.Setting
+
+  @doc """
+  Reads an integer config value from the `:persistent_term` cache.
+
+  Returns `default` on a cache miss, a non-integer cached value, or any error.
+  Never raises — safe to call on the hot path.
+  """
+  @spec get_int(String.t(), integer()) :: integer()
+  def get_int(key, default) when is_binary(key) and is_integer(default) do
+    case :persistent_term.get(pt_key(key), :__miss__) do
+      value when is_integer(value) -> value
+      _ -> default
+    end
+  rescue
+    _ -> default
+  end
+
+  @doc """
+  Loads ALL settings from the DB (via `AdminRepo`) into `:persistent_term`.
+
+  Wrapped in `try/rescue`: a DB error logs and no-ops (returns `:ok`) so it can
+  never crash boot or the refresh cron. The existing cache is left untouched.
+  """
+  @spec refresh() :: :ok
+  def refresh do
+    Setting
+    |> AdminRepo.all()
+    |> Enum.each(fn %Setting{key: key, value: value} ->
+      :persistent_term.put(pt_key(key), value)
+    end)
+
+    :ok
+  rescue
+    e ->
+      Logger.warning(
+        "Loopctl.SystemConfig.refresh/0 failed; keeping existing cache: " <>
+          Exception.message(e)
+      )
+
+      :ok
+  end
+
+  @doc """
+  Upserts a setting row (via `AdminRepo`) AND updates the `:persistent_term`
+  cache immediately, so the new value is live on this node without waiting for the
+  refresh cron. For a future admin API.
+  """
+  @spec put(String.t(), integer()) :: {:ok, Setting.t()} | {:error, Ecto.Changeset.t()}
+  def put(key, value) when is_binary(key) and is_integer(value) do
+    now = DateTime.utc_now()
+
+    %Setting{}
+    |> Setting.changeset(%{key: key, value: value})
+    |> AdminRepo.insert(
+      on_conflict: [set: [value: value, updated_at: now]],
+      conflict_target: :key,
+      returning: true
+    )
+    |> case do
+      {:ok, setting} ->
+        :persistent_term.put(pt_key(key), value)
+        {:ok, setting}
+
+      {:error, _changeset} = error ->
+        error
+    end
+  end
+
+  @doc """
+  Lists all settings (via `AdminRepo`), ordered by key. For observability.
+  """
+  @spec all() :: [Setting.t()]
+  def all do
+    AdminRepo.all(from s in Setting, order_by: [asc: s.key])
+  end
+
+  defp pt_key(key), do: {__MODULE__, key}
+end

--- a/lib/loopctl/system_config/setting.ex
+++ b/lib/loopctl/system_config/setting.ex
@@ -1,0 +1,34 @@
+defmodule Loopctl.SystemConfig.Setting do
+  @moduledoc """
+  Schema for the `system_configs` table — a GLOBAL (non-tenant) key/value store
+  of live-tunable operational knobs (timeout/retry budgets).
+
+  Global, like `Loopctl.Tenants.Tenant`: there is no `tenant_id`. All access goes
+  through `Loopctl.AdminRepo` (BYPASSRLS). Values are `:integer` (`bigint` in the
+  DB) so millisecond timeouts and small counts share one column type.
+  """
+
+  use Loopctl.Schema, tenant_scoped: false
+
+  @type t :: %__MODULE__{}
+
+  schema "system_configs" do
+    field :key, :string
+    field :value, :integer
+    field :description, :string
+
+    timestamps()
+  end
+
+  @doc """
+  Changeset for a single setting. `key` and `value` are required; `key` is
+  unique. `description` is optional operator documentation.
+  """
+  @spec changeset(t() | Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
+  def changeset(setting, attrs) do
+    setting
+    |> cast(attrs, [:key, :value, :description])
+    |> validate_required([:key, :value])
+    |> unique_constraint(:key)
+  end
+end

--- a/lib/loopctl/workers/content_ingestion_worker.ex
+++ b/lib/loopctl/workers/content_ingestion_worker.ex
@@ -53,6 +53,7 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   alias Loopctl.Llm
   alias Loopctl.Llm.ProviderError
   alias Loopctl.Net.UrlGuard
+  alias Loopctl.SystemConfig
   alias Loopctl.Workers.ArticleEmbeddingWorker
 
   @content_extractor Application.compile_env(
@@ -74,19 +75,32 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   #     a later timeout/failure — see ingest_chunks/2), and
   #   * scale the job timeout by chunk count with a hard cap.
   #
-  # Concrete values:
-  #   * @per_chunk_timeout_ms = 30s — ~2x+ headroom over the observed 7–13s so a
-  #     healthy chunk is never falsely timed out under tail latency/variance.
-  #   * @max_job_timeout_ms   = 6 min — the ABSOLUTE ceiling a single job may hold
-  #     a :knowledge slot (concurrency 5), independent of chunk count. Bounds abuse
-  #     (GHSA-j7m9-ffmr-pwhm) while comfortably covering a realistic large doc.
-  #   * @max_chunks = cap / per_chunk = 12 — a document chunking to MORE than this
-  #     (>~96KB) can't be guaranteed within the cap, so we ingest the first
-  #     @max_chunks (persisted incrementally) and {:discard} the rest cleanly with
-  #     a count, rather than crash-looping or silently losing everything.
-  @per_chunk_timeout_ms :timer.seconds(30)
-  @max_job_timeout_ms :timer.minutes(6)
-  @max_chunks div(@max_job_timeout_ms, @per_chunk_timeout_ms)
+  # These budgets are now DB-backed and live-tunable via `Loopctl.SystemConfig`
+  # (no redeploy to adjust). The in-code defaults below match the seeded rows and
+  # apply on a cache miss (safe degrade):
+  #   * per_chunk_timeout_ms/0 = 60s (default) — ample headroom over the observed
+  #     7–13s so a healthy chunk is never falsely timed out under tail latency,
+  #     with room for one internal extractor retry (see ClaudeContentExtractor).
+  #   * max_job_timeout_ms/0   = 6 min (default) — the ABSOLUTE ceiling a single
+  #     job may hold a :knowledge slot (concurrency 5), independent of chunk count.
+  #     Bounds abuse (GHSA-j7m9-ffmr-pwhm) while covering a realistic large doc.
+  #   * max_chunks/0 = cap / per_chunk = 6 (at the defaults) — a document chunking
+  #     to MORE than this can't be guaranteed within the cap, so we ingest the
+  #     first max_chunks (persisted incrementally) and {:discard} the rest cleanly
+  #     with a count, rather than crash-looping or silently losing everything.
+  defp per_chunk_timeout_ms,
+    do: SystemConfig.get_int("ingestion_per_chunk_timeout_ms", 60_000)
+
+  defp max_job_timeout_ms,
+    do: SystemConfig.get_int("ingestion_max_job_timeout_ms", 360_000)
+
+  # Derived at runtime from the two live budgets. Guarded against a
+  # (mis)configured per-chunk value of 0 so the worker can never divide by zero,
+  # and floored at 1 chunk.
+  defp max_chunks do
+    per_chunk = per_chunk_timeout_ms()
+    if per_chunk > 0, do: max(div(max_job_timeout_ms(), per_chunk), 1), else: 1
+  end
 
   # ON CONFLICT arbiter for the partial `articles_tenant_idempotency_key_idx`
   # (WHERE idempotency_key IS NOT NULL). A partial index can only be inferred as
@@ -195,19 +209,19 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   end
 
   # Per-job wall-clock cap that SCALES with chunk count (#264), floored at one
-  # chunk and hard-capped at @max_job_timeout_ms. A hostile/slow endpoint still
+  # chunk and hard-capped at max_job_timeout_ms/0. A hostile/slow endpoint still
   # can't pin a :knowledge queue slot beyond the cap (worker-01 /
   # GHSA-j7m9-ffmr-pwhm), while a legitimate multi-chunk document now gets enough
   # wall-clock to finish. For a URL job the fetched size is unknown until fetch,
-  # so we grant the full capped budget; perform/1 self-limits to @max_chunks and
+  # so we grant the full capped budget; perform/1 self-limits to max_chunks/0 and
   # persists incrementally, so the cap is a backstop, not the mechanism.
   @impl Oban.Worker
   def timeout(%Oban.Job{args: args}) do
     args
     |> chunk_count_for_timeout()
     |> max(1)
-    |> Kernel.*(@per_chunk_timeout_ms)
-    |> min(@max_job_timeout_ms)
+    |> Kernel.*(per_chunk_timeout_ms())
+    |> min(max_job_timeout_ms())
   end
 
   defp chunk_count_for_timeout(%{"content" => content})
@@ -216,7 +230,7 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   end
 
   defp chunk_count_for_timeout(%{"url" => url}) when is_binary(url) and url != "" do
-    @max_chunks
+    max_chunks()
   end
 
   defp chunk_count_for_timeout(_), do: 1
@@ -226,7 +240,7 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   # Ingest a document chunk-by-chunk, PERSISTING each chunk's articles as it
   # completes (#264). A timeout or mid-run failure therefore keeps the articles
   # already extracted instead of discarding everything. Documents that chunk
-  # beyond @max_chunks are ingested up to that bound and the remainder is
+  # beyond max_chunks/0 are ingested up to that bound and the remainder is
   # {:discard}ed cleanly (with a count) rather than silently lost.
   defp ingest_chunks(ctx, content) do
     # Key the per-chunk idempotency/skip on a hash of the ACTUALLY-RESOLVED bytes
@@ -242,7 +256,7 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
 
     chunks = ContentChunker.chunk(content)
     chunk_count = length(chunks)
-    {processable, dropped} = Enum.split(chunks, @max_chunks)
+    {processable, dropped} = Enum.split(chunks, max_chunks())
 
     if chunk_count > 1 do
       Logger.info(
@@ -386,7 +400,7 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   #     job :completed and permanently lose the failed chunk (Finding 2).
   #   * ONLY permanent errors (4xx that a retry can't fix) → {:discard} so it
   #     doesn't retry forever; whatever persisted stays committed.
-  #   * dropped chunks (document > @max_chunks) → {:discard} with an ACCURATE
+  #   * dropped chunks (document > max_chunks/0) → {:discard} with an ACCURATE
   #     attempted-chunk count (Finding 3).
   #   * otherwise → :ok.
   defp finalize_ingest(
@@ -464,8 +478,8 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   defp constraint_violation?(_), do: false
 
   defp too_large_message(chunk_count, dropped, inserted, attempted) do
-    "document too large: #{chunk_count} chunks exceed the #{@max_chunks}-chunk per-job " <>
-      "budget (cap #{div(@max_job_timeout_ms, 1000)}s); persisted #{inserted} article(s) " <>
+    "document too large: #{chunk_count} chunks exceed the #{max_chunks()}-chunk per-job " <>
+      "budget (cap #{div(max_job_timeout_ms(), 1000)}s); persisted #{inserted} article(s) " <>
       "from #{attempted} attempted chunk(s), #{length(dropped)} chunk(s) not processed"
   end
 

--- a/lib/loopctl/workers/system_config_refresh_worker.ex
+++ b/lib/loopctl/workers/system_config_refresh_worker.ex
@@ -1,0 +1,20 @@
+defmodule Loopctl.Workers.SystemConfigRefreshWorker do
+  @moduledoc """
+  Oban cron worker that re-primes the `Loopctl.SystemConfig` `:persistent_term`
+  cache from the DB every minute, so a `system_configs` UPDATE propagates to every
+  node within ~60s without a redeploy.
+
+  `SystemConfig.refresh/0` is itself `try/rescue`-wrapped (a DB blip logs and
+  no-ops), so this worker's `perform/1` always returns `:ok`.
+  """
+
+  use Oban.Worker, queue: :maintenance, max_attempts: 3
+
+  alias Loopctl.SystemConfig
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{}) do
+    SystemConfig.refresh()
+    :ok
+  end
+end

--- a/priv/repo/migrations/20260709100000_create_system_configs.exs
+++ b/priv/repo/migrations/20260709100000_create_system_configs.exs
@@ -1,0 +1,72 @@
+defmodule Loopctl.Repo.Migrations.CreateSystemConfigs do
+  use Ecto.Migration
+
+  # GLOBAL (non-tenant) key/value store for live-tunable operational knobs
+  # (timeout/retry budgets). Read on the hot path via :persistent_term; a missing
+  # row makes SystemConfig.get_int/2 fall back to the in-code default (safe
+  # degrade), so seeding here only makes the values operator-visible/tunable from
+  # day one.
+  #
+  # No tenant_id — this is a global table like `tenants`. Per CLAUDE.md rule 4 we
+  # ENABLE (never FORCE) Row Level Security. There is deliberately NO
+  # tenant_isolation policy: the table has no tenant_id, and ALL access goes
+  # through Loopctl.AdminRepo (BYPASSRLS in prod, table owner in dev/test). RLS
+  # therefore simply denies the low-privilege Loopctl.Repo role, which never
+  # touches this table.
+
+  def change do
+    create table(:system_configs, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :key, :string, null: false
+      add :value, :bigint, null: false
+      add :description, :text
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create unique_index(:system_configs, [:key])
+
+    execute(
+      "ALTER TABLE system_configs ENABLE ROW LEVEL SECURITY",
+      "ALTER TABLE system_configs DISABLE ROW LEVEL SECURITY"
+    )
+
+    # Seed the known knobs with their defaults. NOTE:
+    # ingestion_per_chunk_timeout_ms is intentionally 60000 (up from the old
+    # hardcoded 30000). `now() AT TIME ZONE 'UTC'` yields a naive UTC timestamp
+    # matching the :utc_datetime_usec columns. ON CONFLICT keeps re-runs safe.
+    execute(
+      """
+      INSERT INTO system_configs (id, key, value, description, inserted_at, updated_at)
+      VALUES
+        (gen_random_uuid(), 'ingestion_per_chunk_timeout_ms', 60000,
+          'Per-chunk LLM extraction timeout budget (ms) for ContentIngestionWorker',
+          now() AT TIME ZONE 'UTC', now() AT TIME ZONE 'UTC'),
+        (gen_random_uuid(), 'ingestion_max_job_timeout_ms', 360000,
+          'Absolute per-job wall-clock ceiling (ms) for ContentIngestionWorker',
+          now() AT TIME ZONE 'UTC', now() AT TIME ZONE 'UTC'),
+        (gen_random_uuid(), 'extraction_receive_timeout_ms', 25000,
+          'Anthropic receive_timeout (ms) for ClaudeContentExtractor',
+          now() AT TIME ZONE 'UTC', now() AT TIME ZONE 'UTC'),
+        (gen_random_uuid(), 'extraction_max_retries', 1,
+          'Anthropic max_retries for ClaudeContentExtractor',
+          now() AT TIME ZONE 'UTC', now() AT TIME ZONE 'UTC'),
+        (gen_random_uuid(), 'embedding_receive_timeout_ms', 4000,
+          'Req receive_timeout (ms) for EmbeddingClient',
+          now() AT TIME ZONE 'UTC', now() AT TIME ZONE 'UTC'),
+        (gen_random_uuid(), 'embedding_max_retries', 0,
+          'Req max_retries for EmbeddingClient',
+          now() AT TIME ZONE 'UTC', now() AT TIME ZONE 'UTC')
+      ON CONFLICT (key) DO NOTHING
+      """,
+      """
+      DELETE FROM system_configs
+      WHERE key IN (
+        'ingestion_per_chunk_timeout_ms', 'ingestion_max_job_timeout_ms',
+        'extraction_receive_timeout_ms', 'extraction_max_retries',
+        'embedding_receive_timeout_ms', 'embedding_max_retries'
+      )
+      """
+    )
+  end
+end

--- a/test/loopctl/system_config_test.exs
+++ b/test/loopctl/system_config_test.exs
@@ -1,0 +1,93 @@
+defmodule Loopctl.SystemConfigTest do
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.SystemConfig
+  alias Loopctl.SystemConfig.Setting
+  alias Loopctl.Workers.ContentIngestionWorker
+
+  setup :verify_on_exit!
+
+  # NOTE ON ASYNC ISOLATION: `:persistent_term` is VM-global (no per-process
+  # isolation), so every test here operates on a UNIQUE key — via the
+  # `:system_config` fixture (unique key per call) or `unique_key/0`. A test's
+  # cache writes therefore can never clobber another async test's entry, and no
+  # test mutates a REAL config key that a concurrent worker test reads.
+  #
+  # There is no tenant-isolation test: `system_configs` is a GLOBAL, non-tenant
+  # table (like `tenants`) with no `tenant_id`, accessed only via AdminRepo.
+
+  describe "get_int/2" do
+    test "returns the default on a cache miss" do
+      assert SystemConfig.get_int(unique_key(), 4242) == 4242
+    end
+
+    test "never raises for an unknown key (returns the default)" do
+      assert SystemConfig.get_int(unique_key(), 7) == 7
+    end
+  end
+
+  describe "put/2" do
+    test "upserts the row AND updates the persistent_term cache immediately" do
+      key = unique_key()
+
+      assert {:ok, %Setting{} = setting} = SystemConfig.put(key, 123)
+      assert setting.key == key
+      assert setting.value == 123
+
+      # Cache is updated immediately — no refresh needed.
+      assert SystemConfig.get_int(key, 0) == 123
+      # ...and it lives under the module-scoped persistent_term key.
+      assert :persistent_term.get({SystemConfig, key}) == 123
+    end
+
+    test "a second put upserts the existing row (unique on key) and updates the cache" do
+      key = unique_key()
+
+      assert {:ok, _} = SystemConfig.put(key, 1)
+      assert {:ok, updated} = SystemConfig.put(key, 2)
+      assert updated.value == 2
+      assert SystemConfig.get_int(key, 0) == 2
+
+      # Exactly one row for the key (upsert, not a second insert).
+      assert Enum.count(SystemConfig.all(), &(&1.key == key)) == 1
+    end
+  end
+
+  describe "refresh/0" do
+    test "loads seeded DB values into the cache" do
+      # Insert a uniquely-keyed row DIRECTLY (the fixture bypasses put/2's cache
+      # write), so we prove refresh/0 — not put/2 — is what primes the cache.
+      setting = fixture(:system_config, value: 9001)
+
+      # Not in the cache yet.
+      assert SystemConfig.get_int(setting.key, -1) == -1
+
+      assert :ok = SystemConfig.refresh()
+      assert SystemConfig.get_int(setting.key, -1) == 9001
+    end
+  end
+
+  describe "all/0" do
+    test "lists settings including a freshly inserted one" do
+      setting = fixture(:system_config, value: 55)
+      assert setting.key in Enum.map(SystemConfig.all(), & &1.key)
+    end
+  end
+
+  describe "call-site wiring" do
+    test "ContentIngestionWorker.timeout/1 reads the per-chunk budget from SystemConfig" do
+      # A single-chunk job's timeout is exactly one per-chunk budget, so the
+      # worker's value must equal what SystemConfig returns for the knob it reads —
+      # proving the call site is driven by SystemConfig, not a compile-time
+      # constant. We deliberately do NOT mutate the real key here: that would
+      # clobber VM-global persistent_term for concurrent async worker tests. The
+      # put -> cache -> get override mechanism is proven above with unique keys.
+      per_chunk = SystemConfig.get_int("ingestion_per_chunk_timeout_ms", 60_000)
+      job = %Oban.Job{args: %{"content" => "tiny", "source_type" => "x"}}
+
+      assert ContentIngestionWorker.timeout(job) == per_chunk
+    end
+  end
+
+  defp unique_key, do: "test_config_#{System.unique_integer([:positive])}"
+end

--- a/test/loopctl/workers/content_ingestion_worker_test.exs
+++ b/test/loopctl/workers/content_ingestion_worker_test.exs
@@ -1184,9 +1184,10 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
   # --- #264: the job timeout scales with chunk count (bounded by the cap) ---
 
   describe "timeout/1 scales with chunk count (#264)" do
-    test "a single-chunk job gets the base 30s budget" do
+    test "a single-chunk job gets the base 60s budget" do
       job = %Oban.Job{args: %{"content" => "small", "content_hash" => "t", "source_type" => "x"}}
-      assert ContentIngestionWorker.timeout(job) == :timer.seconds(30)
+      # per-chunk budget is now DB-backed (SystemConfig), default 60s.
+      assert ContentIngestionWorker.timeout(job) == :timer.seconds(60)
     end
 
     test "a multi-chunk job gets a larger, chunk-scaled budget" do
@@ -1199,12 +1200,12 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
       big_timeout = ContentIngestionWorker.timeout(big)
 
       assert big_timeout > ContentIngestionWorker.timeout(small)
-      # 4 chunks * 30s = 120s, still under the cap.
-      assert big_timeout == 4 * :timer.seconds(30)
+      # 4 chunks * 60s = 240s, still under the 6-min cap.
+      assert big_timeout == 4 * :timer.seconds(60)
     end
 
     test "the timeout is hard-capped for a very large document" do
-      # 40 sections -> ~40 chunks; 40 * 30s = 1200s would blow past the cap, so
+      # 40 sections -> ~40 chunks; 40 * 60s = 2400s would blow past the cap, so
       # the timeout must clamp to the 6-minute ceiling.
       huge = %Oban.Job{args: %{"content" => multi_chunk_content(40), "source_type" => "x"}}
       assert ContentIngestionWorker.timeout(huge) == :timer.minutes(6)
@@ -1222,8 +1223,9 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
     test "a document exceeding the per-job chunk budget persists what fits, then discards cleanly" do
       %{tenant: tenant} = setup_tenant()
 
-      # 14 sections -> 14 chunks, above the 12-chunk per-job budget. Each chunk
-      # yields one article; the first 12 persist, the rest are discarded.
+      # 14 sections -> 14 chunks, above the 6-chunk per-job budget (max_job 6min /
+      # per_chunk 60s). Each chunk yields one article; the first 6 persist, the
+      # rest are discarded.
       Mox.stub(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id,
                                                                        _chunk,
                                                                        _opts ->

--- a/test/loopctl/workers/system_config_refresh_worker_test.exs
+++ b/test/loopctl/workers/system_config_refresh_worker_test.exs
@@ -1,0 +1,18 @@
+defmodule Loopctl.Workers.SystemConfigRefreshWorkerTest do
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.SystemConfig
+  alias Loopctl.Workers.SystemConfigRefreshWorker
+
+  setup :verify_on_exit!
+
+  test "perform/1 primes the SystemConfig cache from the DB and returns :ok" do
+    # Uniquely-keyed row (async-safe): absent from the VM-global cache until a
+    # refresh runs, so a hit proves the worker performed the reload.
+    setting = fixture(:system_config, value: 8080)
+    assert SystemConfig.get_int(setting.key, -1) == -1
+
+    assert :ok = SystemConfigRefreshWorker.perform(%Oban.Job{args: %{}})
+    assert SystemConfig.get_int(setting.key, -1) == 8080
+  end
+end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -29,6 +29,7 @@ defmodule Loopctl.Fixtures do
   alias Loopctl.Skills.Skill
   alias Loopctl.Skills.SkillResult
   alias Loopctl.Skills.SkillVersion
+  alias Loopctl.SystemConfig.Setting
   alias Loopctl.Tenants.RootAuthenticator
   alias Loopctl.Tenants.Tenant
   alias Loopctl.TokenUsage.Budget, as: TokenBudget
@@ -95,6 +96,20 @@ defmodule Loopctl.Fixtures do
         # large existing custody-test surface is unaffected. Pass
         # `trust_tier: :agent_rooted` explicitly to get a KB-tier tenant.
         trust_tier: :human_anchored
+      },
+      Enum.into(attrs, %{})
+    )
+  end
+
+  def build(:system_config, attrs) do
+    Map.merge(
+      %{
+        # Unique key per call so DB-backed system-config tests never collide on the
+        # `system_configs_key_index` unique index, and so their :persistent_term
+        # writes (VM-global) can't clobber another async test's cache entry.
+        key: "test_config_#{System.unique_integer([:positive])}",
+        value: System.unique_integer([:positive]),
+        description: nil
       },
       Enum.into(attrs, %{})
     )
@@ -1192,6 +1207,14 @@ defmodule Loopctl.Fixtures do
   # Inserts a tenant_llm_settings row (auto-creating a tenant if needed). The
   # `api_key` defaults to a plausible test key so `Loopctl.Llm.has_api_key?/1`
   # returns true and the mandatory-BYO gate passes.
+  def fixture(:system_config, attrs) do
+    data = build(:system_config, attrs)
+
+    %Setting{}
+    |> Setting.changeset(data)
+    |> AdminRepo.insert!()
+  end
+
   def fixture(:tenant_llm_settings, attrs) do
     attrs = Enum.into(attrs, %{})
 


### PR DESCRIPTION
## Why
During tonight's harvest incident, every timeout/retry tweak was a **hardcoded module attribute** → each adjustment required a full CI + redeploy (we paid that twice). Operational knobs belong in **DB-backed config** so an operator retunes them live.

## What
`Loopctl.SystemConfig` — a GLOBAL (non-tenant) `system_configs` key/value table:
- **Hot-path read** via `:persistent_term` (`get_int/2`, never raises; a cache miss returns the in-code default = safe degrade, identical to today's behavior).
- **Refresh** primed at boot + every minute via `SystemConfigRefreshWorker` (Oban cron) + immediately on `put/2`. All DB access via `AdminRepo`; table is RLS-enabled per convention (owner-exempt, no tenant policy).
- **Wired knobs** (seeded): `ingestion_per_chunk_timeout_ms` (**default 60000, up from 30000** — large multi-chunk extractions were timing out), `ingestion_max_job_timeout_ms` (360000, GHSA bound preserved), `extraction_receive_timeout_ms` (25000), `extraction_max_retries` (1), `embedding_receive_timeout_ms` (4000), `embedding_max_retries` (0).
- `ContentIngestionWorker`'s compile-time `@max_chunks` is now derived at runtime (=6 at defaults; live-tunable via `ingestion_max_job_timeout_ms`).

Tuning is now: `UPDATE system_configs SET value=… WHERE key=…` — no redeploy (picked up within 60s, or immediately via the future admin API).

## Follow-up
This is the mechanism; the broader **architecture scalability audit** (queues/fairness, provider backpressure, DB scale, observability) is running separately and will land as its own epics.

## Validation
Local `mix precommit` green; format + credo --strict clean; 53 targeted tests 0 failures (SystemConfig, refresh worker, ContentIngestionWorker, extractor). Getter is async-safe (tests use unique keys, never mutate real keys).