### PR TITLE
test(deploy): post-deploy smoke suite + e2e regression journeys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,16 @@ jobs:
         env:
           DATABASE_URL: ecto://postgres:postgres@localhost/loopctl_test
 
+      # The cross-context journeys (test/e2e/*) are @moduletag :e2e and excluded
+      # from the default `mix test` above (keeps it fast). Run them here in the
+      # SAME job so they reuse the provisioned Postgres and GATE deploy (deploy
+      # `needs: [test]`) — otherwise the regression net never fires in CI.
+      # `--only e2e` overrides the default exclude and won't pull :scale/:pgbouncer.
+      - name: Run e2e journey tests
+        run: mix test --only e2e
+        env:
+          DATABASE_URL: ecto://postgres:postgres@localhost/loopctl_test
+
   security:
     name: Security
     runs-on: ubuntu-latest
@@ -548,3 +558,29 @@ jobs:
         run: flyctl deploy --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+  smoke:
+    name: Post-deploy Smoke
+    runs-on: ubuntu-latest
+    # Runs AFTER the Fly deploy so it validates the freshly-deployed release, not
+    # the old one. It does NOT gate anything (deploy already happened) — it is a
+    # DETECTOR: a smoke failure turns the run RED so the operator knows to roll
+    # back (see docs/runbooks/post-deploy-smoke.md). Only on a real master push;
+    # never on PRs (no live release to probe) or the nightly schedule.
+    needs: [deploy]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      # LOOPCTL_SMOKE_KEY MUST be a LOW-PRIVILEGE READ key (agent role is enough):
+      # smoke.sh issues only read-only requests, and CI secrets should carry the
+      # least privilege that satisfies the checks. The secret goes in `env:` (not
+      # inline on `run:`) as the safe pattern against a future `set -x`.
+      - name: Run post-deploy smoke
+        env:
+          BASE_URL: https://loopctl.com
+          LOOPCTL_SMOKE_KEY: ${{ secrets.LOOPCTL_SMOKE_KEY }}
+        run: bash scripts/smoke.sh

--- a/docs/runbooks/post-deploy-smoke.md
+++ b/docs/runbooks/post-deploy-smoke.md
@@ -1,0 +1,206 @@
+# Runbook: Post-Deploy Smoke & Regression Safety Net
+
+## Purpose
+
+loopctl at <https://loopctl.com> is LIVE and serving **knowledge-base (KB)
+retrieval** to agents continuously. This safety net catches regressions right
+after each deploy **without ever mutating live state** — every check is
+read-only. If it goes red, the deploy is suspect and you roll back.
+
+Two layers:
+
+1. **`scripts/smoke.sh`** — fast, read-only curl+jq probes against the live
+   deployment. Runs automatically in CI after each master deploy, and by hand.
+2. **`test/e2e/*` ExUnit journeys** — full cross-context journeys (retrieval,
+   chain-of-custody, agent-memory round-trip) against the test DB. These now run
+   in CI as a step in the `test` job (`mix test --only e2e`), so they **gate
+   deploy** (`deploy` needs `test`) — a broken journey blocks the release. Also
+   runnable locally with `mix test.e2e`.
+
+---
+
+## 1. What the smoke covers (and why)
+
+`scripts/smoke.sh` runs these checks. Pure-DB checks use the default 5000 ms
+budget (`SMOKE_MAX_MS`); the two checks that generate an on-the-fly query
+embedding (an outbound LLM call) get a wider 8000 ms budget (`SMOKE_EMBED_MAX_MS`).
+Total wall time stays well under 30 s.
+
+| # | Check | Asserts | Budget | Why |
+|---|-------|---------|--------|-----|
+| 1 | `GET /health` | 200 **and** `.checks.database == "ok"`; Oban-only degradation is a WARN (pass) | 5 s | App up + DB healthy |
+| 2 | `GET /api/v1/knowledge/count` (authed) | 200, `.count` int > 1000 | 5 s | KB not wiped (prod baseline ~83k) |
+| 3a | `GET /api/v1/knowledge/search?q=elixir&mode=keyword&limit=3` (authed) | 200, `.data` non-empty | 5 s | **Keyword retrieval floor** (deterministic DB path, no embedding) |
+| 3b | `GET /api/v1/knowledge/search?q=elixir&limit=3` (authed, combined) | 200, `.data` non-empty **and** `.meta.fallback != true` | 8 s | **Semantic retrieval healthy** — fails if the embedding provider is down (combined silently keyword-falls-back otherwise) |
+| 4 | `GET /api/v1/knowledge/stats` (authed) | 200, `.total` numeric | 5 s | Stats/aggregation path alive |
+| 5 | `POST /api/v1/memory/recall` (authed, `{"query":"smoke","limit":1}`) | 200, `.data` array + `.meta` | 8 s | Epic-28 agent-memory recall alive (recall is a READ; empty result is a PASS) |
+| 6 | `GET /api/v1/knowledge/search?q=x` (NO key) | 401 | 5 s | Auth boundary intact |
+
+Exit code is non-zero if ANY check fails. A WARN (⚠) does not fail the run.
+
+### Reading a RED result
+
+- **3b RED but 3a green** — keyword retrieval works, semantic doesn't. This is an
+  **embedding-provider / tenant-BYO-key** problem (the embedding API is down, rate
+  limited, or the tenant's LLM key is missing/invalid), NOT necessarily a code
+  regression. Check the embedding provider and the smoke tenant's LLM config
+  before rolling back; a code rollback won't fix a dead provider.
+- **1 WARN (Oban degraded, DB ok)** — `/health` returns `degraded` (HTTP 503) if
+  EITHER the DB or the Oban `:default` queue check fails. A transient Oban blip
+  with a healthy DB + KB is **not** a rollback trigger, so the script warns and
+  passes. Only a DB failure or a non-200 is a hard FAIL on check 1.
+- **2 RED (count ≤ 1000)** — see the visibility invariant below; a wiped corpus or
+  a changed smoke-key tenant both show up here.
+
+### Count-threshold visibility invariant
+
+Checks 2 and 3 rely on this: `LOOPCTL_SMOKE_KEY` is an **agent-role key in the
+tenant that owns the shared knowledge corpus**, and corpus articles are
+`shared`-visibility (metadata `visibility` defaults to `"shared"`, which
+`Visibility.scope_opts` + `Loopctl.Knowledge.maybe_filter_by_visibility` make
+visible to agent callers). So `count > 1000` and non-empty search are provably
+satisfied for that key. **If the smoke key's tenant or the corpus visibility ever
+changes, re-derive these thresholds** — otherwise check 2/3 could false-RED on a
+perfectly healthy deploy.
+
+### Witness header (important)
+
+Every `/api/v1` authenticated request passes through `ValidateWitnessHeader`,
+which is **enforced in prod** (disabled only in test). Without an
+`X-Loopctl-Last-Known-STH` header, authed checks would fail with `412
+witness_header_missing`. `smoke.sh` handles this automatically: it first
+**primes** the current STH via the one-time bootstrap-grace response header
+(`X-Loopctl-STH-Bootstrap: true` → `x-loopctl-current-sth`) and then sends it on
+every authed check. This priming has no side effect (the plug halts before any
+operation runs).
+
+---
+
+## 2. How it runs automatically in CI
+
+Two things run in CI, at two different stages:
+
+**Pre-deploy gate — the e2e journeys.** The `test` job runs `mix test --only e2e`
+right after the normal suite, reusing the provisioned Postgres. Because `deploy`
+needs `test`, a broken journey (retrieval, custody, or memory round-trip) **blocks
+the deploy**. The default `mix test` still excludes `:e2e`, so local dev stays fast.
+
+**Post-deploy detector — the smoke.** `.github/workflows/ci.yml` has a `smoke` job:
+
+- `needs: [deploy]` — runs **after** the Fly deploy, so it validates the
+  freshly-deployed release, not the old one.
+- `if: github.event_name == 'push' && github.ref == 'refs/heads/master'` — only
+  on a real master deploy (never PRs or the nightly schedule).
+- Installs `jq`, then runs `bash scripts/smoke.sh` with `BASE_URL` and
+  `LOOPCTL_SMOKE_KEY` supplied via the step's `env:` block (secret kept off the
+  `run:` line).
+
+It does **not gate** anything (the deploy already happened) — it is a
+**detector**. A smoke failure turns the run RED so the operator knows to roll
+back. `LOOPCTL_SMOKE_KEY` must be a **low-privilege read key** (an `agent`-role
+key is sufficient — the script only reads).
+
+**Cost note:** each master deploy spends ~2 embedding tokens (the semantic-search
+check 3b + the memory-recall check 5 each generate one query embedding). This is
+intended and negligible.
+
+---
+
+## 3. How to run it manually
+
+### CLI
+
+```bash
+LOOPCTL_SMOKE_KEY=<low-priv read key> bash scripts/smoke.sh
+# Optional overrides:
+BASE_URL=https://loopctl.com SMOKE_MAX_MS=5000 SMOKE_EMBED_MAX_MS=8000 \
+  LOOPCTL_SMOKE_KEY=... bash scripts/smoke.sh
+```
+
+Each check prints `✓ name (Nms)`, `⚠ name — detail` (warn, still passes), or
+`✗ name — detail`. Non-zero exit ⇒ investigate.
+
+### Equivalent MCP-tool checklist (operator / agent, read-only)
+
+If you have the loopctl MCP tools wired, you can reproduce the smoke by hand
+without curl — all read-only:
+
+1. `mcp__loopctl__knowledge_search({ q: "elixir", limit: 3 })` → expect a
+   non-empty result set (retrieval works).
+2. `knowledge count` — via `knowledge_search` in list mode or
+   `knowledge_stats` — expect a large populated corpus (thousands of articles).
+3. `mcp__loopctl__list_projects()` → expect your projects to enumerate
+   (auth + tenant scope intact).
+4. `mcp__loopctl__memory_recall({ query: "smoke", limit: 1 })` → expect a 200-shaped
+   result (an empty list is fine; you are proving the endpoint is alive).
+
+An empty result on (4) is a PASS. A hard error, timeout, or auth failure on any
+of these is a FAIL — treat it like a red smoke run.
+
+---
+
+## 4. Latency budgets
+
+- Per-request budget: **5000 ms** (`SMOKE_MAX_MS`) for the pure-DB checks
+  (health, count, keyword floor, stats, auth-negative). A check that exceeds its
+  budget fails even on a 200 — a slow crown-jewel path is a regression signal.
+- Embedding budget: **8000 ms** (`SMOKE_EMBED_MAX_MS`) for the two checks that do
+  an on-the-fly query embedding (semantic search 3b + memory recall 5), since an
+  outbound LLM call is ~1–3 s.
+- Total smoke wall time: **well under 30 s** on the happy path. The `/health`
+  poll retries up to ~10× with capped (≤3 s) backoff so a smoke run kicked the
+  instant a deploy finishes waits for the new release to accept traffic before
+  the real assertions.
+
+---
+
+## 5. ROLLBACK procedure (Fly.io, app `loopctl`)
+
+If smoke is red after a deploy, roll back to the previous known-good release:
+
+```bash
+# List releases (most recent first) — note the previous version/image ref
+fly releases -a loopctl
+
+# Preferred: roll back to the immediately previous release (if your flyctl has it)
+fly releases rollback -a loopctl
+
+# Or roll back to a specific version
+fly releases rollback <version> -a loopctl
+
+# Fallback (older flyctl without `releases rollback`): redeploy the previous image
+#   grab the previous image ref from `fly releases` / `fly image show -a loopctl`
+fly deploy --image <previous-image-ref> -a loopctl
+```
+
+After rollback, re-run the smoke against prod to confirm green:
+
+```bash
+LOOPCTL_SMOKE_KEY=... bash scripts/smoke.sh
+```
+
+Then open an issue capturing the failing check and the bad release, and fix
+forward on a branch through the normal review-gated loop.
+
+---
+
+## 6. Expand–contract migration rule (do NOT skip)
+
+Fly does a **rolling** deploy: for a window, the OLD and NEW releases run
+concurrently and BOTH serve live KB-retrieval traffic. Every migration in these
+epics **must be backward-compatible** so an in-flight request against the old
+release never breaks, and so a rollback is always safe:
+
+- **Expand first.** Add new tables and **nullable** columns; add new indexes
+  `CONCURRENTLY`. The old release must keep working against the new schema.
+- **Never** drop or rename a column/table a still-running release reads, and
+  never add a `NOT NULL` (without a default) or a tightening `CHECK` in the same
+  deploy that starts writing it.
+- **Contract later**, in a SEPARATE deploy, only after every running release no
+  longer references the old shape.
+- Backfills run as their own step (e.g. an Oban job / data migration), decoupled
+  from the schema change, so a long backfill can't hold a lock across the deploy.
+
+Rule of thumb: **a rollback to the previous release must succeed against the
+current database at all times.** If a migration would break the old release,
+it's not expand–contract — split it.

--- a/mix.exs
+++ b/mix.exs
@@ -130,6 +130,9 @@ defmodule Loopctl.MixProject do
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.create", "ecto.migrate"],
       test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"],
+      # Run ONLY the cross-context journey tests (test/e2e/*, tagged :e2e). `--only`
+      # overrides the default :e2e exclude in test_helper.exs.
+      "test.e2e": ["ecto.create --quiet", "ecto.migrate --quiet", "test --only e2e"],
       "assets.setup": ["tailwind.install --if-missing", "esbuild.install --if-missing"],
       "assets.deploy": ["tailwind loopctl --minify", "esbuild loopctl --minify", "phx.digest"],
       precommit: [

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,302 @@
+#!/usr/bin/env bash
+#
+# scripts/smoke.sh — post-deploy smoke test for loopctl (READ-ONLY).
+#
+# Runs a handful of fast, read-only checks against a LIVE loopctl deployment to
+# prove the crown-jewel paths (KB retrieval + agent memory) still work after a
+# deploy. It issues NO state-mutating writes. Intended to run in CI immediately
+# after the Fly deploy job (see .github/workflows/ci.yml `smoke` job) and to be
+# runnable by hand:
+#
+#   LOOPCTL_SMOKE_KEY=<low-priv read key> bash scripts/smoke.sh
+#
+# Env:
+#   BASE_URL           Base URL to probe                    (default https://loopctl.com)
+#   LOOPCTL_SMOKE_KEY  API key for authed checks            (REQUIRED — a low-privilege read key)
+#   SMOKE_MAX_MS       Per-request latency budget           (default 5000)
+#   SMOKE_EMBED_MAX_MS Latency budget for checks that do an on-the-fly LLM query
+#                      embedding (semantic search + memory recall)  (default 8000)
+#
+# Exit code is non-zero if ANY check fails, so a smoke failure turns the CI run
+# RED and the operator knows to roll back (see docs/runbooks/post-deploy-smoke.md).
+#
+# Dependencies: bash, curl, jq only.
+#
+# Witness header note: loopctl's /api/v1 authenticated pipeline enforces the
+# chain-of-custody witness header (X-Loopctl-Last-Known-STH) in every non-test
+# environment. This script first PRIMES the current STH via the one-time
+# bootstrap-grace response header, then sends it on every authed check — without
+# it, all authed requests would fail with 412 witness_header_missing.
+
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-https://loopctl.com}"
+SMOKE_MAX_MS="${SMOKE_MAX_MS:-5000}"
+# Semantic search and memory recall each generate a query embedding on the fly
+# (an outbound LLM call, ~1-3s), so they get a wider budget than the pure DB paths.
+SMOKE_EMBED_MAX_MS="${SMOKE_EMBED_MAX_MS:-8000}"
+KEY="${LOOPCTL_SMOKE_KEY:-}"
+
+# ✓ / ⚠ / ✗ markers.
+OK="✓"
+WARN="⚠"
+NO="✗"
+
+FAILURES=0
+
+# Hard ceiling for curl itself — a few seconds above the WIDEST per-check budget so
+# a hung endpoint can't stall the run, while a legitimately slow embed check still
+# completes and is judged against its own budget.
+if [ "$SMOKE_EMBED_MAX_MS" -gt "$SMOKE_MAX_MS" ]; then
+  CURL_MAX_SECS=$(( (SMOKE_EMBED_MAX_MS / 1000) + 5 ))
+else
+  CURL_MAX_SECS=$(( (SMOKE_MAX_MS / 1000) + 5 ))
+fi
+
+# --- Dependency + arg checks (fail fast) ---------------------------------------
+
+for dep in curl jq awk; do
+  if ! command -v "$dep" >/dev/null 2>&1; then
+    echo "$NO smoke aborted — required dependency '$dep' is not installed" >&2
+    exit 2
+  fi
+done
+
+if [ -z "$KEY" ]; then
+  echo "$NO smoke aborted — LOOPCTL_SMOKE_KEY is unset." >&2
+  echo "  Set it to a low-privilege read API key, e.g.:" >&2
+  echo "  LOOPCTL_SMOKE_KEY=... bash scripts/smoke.sh" >&2
+  exit 2
+fi
+
+# Scratch space for response bodies/headers; cleaned up on exit.
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+BODY="$TMP/body"
+HDRS="$TMP/hdrs"
+
+# HTTP_CODE / TIME_MS are set by http() and read by the assert helpers.
+HTTP_CODE=""
+TIME_MS=""
+
+# http METHOD URL [extra curl args...]
+# Writes the response body to $BODY and response headers to $HDRS, and sets
+# HTTP_CODE + TIME_MS (milliseconds). A hard curl failure (DNS/connect/timeout)
+# is normalized to code 000 so the caller reports a clean ✗ rather than aborting
+# under `set -e`.
+http() {
+  local method="$1"
+  local url="$2"
+  shift 2
+  local out
+  # --max-time gives curl a hard ceiling a few seconds above the widest per-check
+  # latency budget so a hung endpoint can't stall the whole run.
+  if out=$(curl -sS -X "$method" \
+      -o "$BODY" -D "$HDRS" \
+      -w '%{http_code} %{time_total}' \
+      --max-time "$CURL_MAX_SECS" \
+      "$@" \
+      "$url" 2>/dev/null); then
+    :
+  else
+    out="000 0"
+  fi
+  HTTP_CODE="${out%% *}"
+  local secs="${out##* }"
+  TIME_MS="$(awk -v t="$secs" 'BEGIN { printf "%d", t * 1000 }')"
+}
+
+pass() { printf '%s %s (%sms)\n' "$OK" "$1" "$TIME_MS"; }
+
+warn() { printf '%s %s — %s\n' "$WARN" "$1" "$2"; }
+
+fail() {
+  printf '%s %s — %s\n' "$NO" "$1" "$2" >&2
+  FAILURES=$((FAILURES + 1))
+}
+
+# assert NAME EXPECTED_CODE [JQ_FILTER] [JQ_DESC] [BUDGET_MS]
+# Enforces (in order): HTTP status, latency budget, then an optional jq predicate
+# on the body. BUDGET_MS defaults to SMOKE_MAX_MS; pass SMOKE_EMBED_MAX_MS for
+# checks that trigger an on-the-fly LLM embedding. Reports one ✓/✗ line.
+assert() {
+  local name="$1"
+  local expected="$2"
+  local jqfilter="${3:-}"
+  local jqdesc="${4:-}"
+  local budget="${5:-$SMOKE_MAX_MS}"
+
+  if [ "$HTTP_CODE" != "$expected" ]; then
+    fail "$name" "expected HTTP $expected, got $HTTP_CODE ($(head -c 200 "$BODY" 2>/dev/null | tr '\n' ' '))"
+    return
+  fi
+
+  if [ "$TIME_MS" -gt "$budget" ]; then
+    fail "$name" "latency ${TIME_MS}ms exceeds budget ${budget}ms"
+    return
+  fi
+
+  if [ -n "$jqfilter" ]; then
+    if ! jq -e "$jqfilter" "$BODY" >/dev/null 2>&1; then
+      fail "$name" "body assertion failed (${jqdesc:-$jqfilter})"
+      return
+    fi
+  fi
+
+  pass "$name"
+}
+
+# --- STH priming ---------------------------------------------------------------
+
+# Fetch the tenant's current STH so authed checks satisfy ValidateWitnessHeader.
+# We send X-Loopctl-STH-Bootstrap: true with NO last-known header. On a reused
+# key the one-time grace is already spent and we get a 412 that STILL carries
+# x-loopctl-current-sth; on a first-ever use we get 200 with the same header.
+# Either way we capture the value. If the header is absent (e.g. witness
+# enforcement is off, or a superadmin/public context), we proceed header-less.
+STH=""
+prime_sth() {
+  curl -sS -o /dev/null -D "$HDRS" \
+    -H "Authorization: Bearer $KEY" \
+    -H "X-Loopctl-STH-Bootstrap: true" \
+    --max-time "$CURL_MAX_SECS" \
+    "$BASE_URL/api/v1/knowledge/stats" >/dev/null 2>&1 || true
+  # `|| true` on the whole substitution: under `set -euo pipefail` a header-absent
+  # pipeline exits non-zero and would abort the script before any check runs. This
+  # keeps the "proceed header-less" contract when witness enforcement is off.
+  STH="$(grep -i '^x-loopctl-current-sth:' "$HDRS" 2>/dev/null | tail -1 \
+    | sed 's/^[^:]*:[[:space:]]*//; s/[[:space:]]*$//' | tr -d '\r' || true)"
+}
+
+prime_sth
+
+# Authed header set (Bearer + the primed witness header when available).
+AUTH_HDRS=(-H "Authorization: Bearer $KEY")
+if [ -n "$STH" ]; then
+  AUTH_HDRS+=(-H "X-Loopctl-Last-Known-STH: $STH")
+fi
+
+echo "loopctl post-deploy smoke — ${BASE_URL} (budget ${SMOKE_MAX_MS}ms; embed ${SMOKE_EMBED_MAX_MS}ms)"
+
+# --- Health poll (resilient to a just-deployed release) ------------------------
+
+# Retry /health with capped exponential backoff so a smoke run kicked the instant
+# a deploy finishes waits for the new release to accept traffic before the real
+# assertions. Backoff is capped at 3s (worst case < 30s) — the happy path returns
+# on the first attempt.
+wait_for_health() {
+  local attempt=1 max=10 delay=1
+  while [ "$attempt" -le "$max" ]; do
+    http GET "$BASE_URL/health"
+    if [ "$HTTP_CODE" = "200" ]; then
+      return 0
+    fi
+    sleep "$delay"
+    attempt=$((attempt + 1))
+    if [ "$delay" -lt 3 ]; then
+      delay=$((delay * 2))
+    fi
+  done
+  return 1
+}
+
+# /health JSON shape (Loopctl.HealthCheck.Default):
+#   { "status": "ok"|"degraded", "version": "...", "checks": { "database": "ok", "oban": "ok" } }
+# It returns 503 "degraded" if EITHER db OR the Oban :default queue check fails. A
+# transient Oban blip with a healthy DB+KB is NOT a rollback signal, so we HARD
+# require HTTP 200 + database=="ok" and treat Oban-only degradation as a WARN (pass).
+if wait_for_health; then
+  db_ok="$(jq -r '.checks.database // "missing"' "$BODY" 2>/dev/null || echo missing)"
+  status="$(jq -r '.status // "missing"' "$BODY" 2>/dev/null || echo missing)"
+
+  if [ "$TIME_MS" -gt "$SMOKE_MAX_MS" ]; then
+    fail "health" "latency ${TIME_MS}ms exceeds budget ${SMOKE_MAX_MS}ms"
+  elif [ "$db_ok" != "ok" ]; then
+    fail "health" "database check is '${db_ok}' (expected ok)"
+  elif [ "$status" = "ok" ]; then
+    pass "health"
+  else
+    # DB healthy but overall status degraded (e.g. Oban queue check) — warn, not fail.
+    oban="$(jq -r '.checks.oban // "missing"' "$BODY" 2>/dev/null || echo missing)"
+    warn "health" "status='${status}' with database=ok (oban='${oban}') — not a rollback trigger"
+  fi
+else
+  fail "health" "/health never returned 200 after 10 attempts"
+fi
+
+# --- KB retrieval crown jewels (authed, read-only) -----------------------------
+#
+# VISIBILITY INVARIANT the count/search thresholds rely on: LOOPCTL_SMOKE_KEY is
+# an AGENT-role key in the tenant that OWNS the shared knowledge corpus. Corpus
+# articles are `shared`-visibility (metadata.visibility defaults to "shared", which
+# Visibility.scope_opts + Loopctl.Knowledge.maybe_filter_by_visibility make visible
+# to agent callers), so a large `count` and non-empty search results are provably
+# satisfied for THIS key. If the smoke key's tenant or the corpus visibility ever
+# changes, `count > 1000` and the search floors below must be re-derived.
+
+# Knowledge count — { "count": <int> }. Prod baseline is ~83k; assert > 1000 so a
+# wiped/empty KB (a catastrophic regression) fails loudly.
+http GET "$BASE_URL/api/v1/knowledge/count" "${AUTH_HDRS[@]}"
+assert "knowledge count populated" 200 \
+  '(.count | type) == "number" and .count > 1000' \
+  'count is an integer > 1000'
+
+# Knowledge search — { "data": [ ... ], "meta": {...} }. TWO checks, because
+# combined mode silently falls back to keyword-only on an embedding-provider
+# failure and STILL returns 200 + non-empty .data (flagging it only via
+# meta.fallback) — a single combined check would stay green while semantic recall
+# is 100% broken.
+#
+# (a) keyword floor: the deterministic DB/keyword path (no embedding call).
+http GET "$BASE_URL/api/v1/knowledge/search?q=elixir&mode=keyword&limit=3" "${AUTH_HDRS[@]}"
+assert "keyword retrieval floor" 200 \
+  '(.data | type) == "array" and (.data | length) > 0' \
+  '.data is a non-empty array'
+
+# (b) semantic health: combined (default) mode, but REQUIRE meta.fallback != true.
+# On success `fallback` is absent → null != true → passes; on embedding-provider
+# failure it is true → FAILS (the point). Wider embed budget (does an LLM call).
+http GET "$BASE_URL/api/v1/knowledge/search?q=elixir&limit=3" "${AUTH_HDRS[@]}"
+assert "semantic retrieval healthy" 200 \
+  '(.data | type) == "array" and (.data | length) > 0 and (.meta.fallback != true)' \
+  '.data non-empty and meta.fallback != true' \
+  "$SMOKE_EMBED_MAX_MS"
+
+# Knowledge stats — { "total": <int>, "by_category": {...}, "by_status": {...} }.
+http GET "$BASE_URL/api/v1/knowledge/stats" "${AUTH_HDRS[@]}"
+assert "knowledge stats" 200 \
+  '(.total | type) == "number"' \
+  '.total is a number'
+
+# --- Agent memory recall (authed, read-only) -----------------------------------
+
+# POST /memory/recall is a READ (semantic search; no persistence — see
+# memory_controller.ex). An empty result is a PASS: we assert the epic-28 endpoint
+# is alive and shaped { "data": [...], "meta": {...} }, not that data exists. It
+# generates a query embedding, so it gets the wider embed budget.
+http POST "$BASE_URL/api/v1/memory/recall" \
+  "${AUTH_HDRS[@]}" \
+  -H "Content-Type: application/json" \
+  --data '{"query":"smoke","limit":1}'
+assert "memory recall alive" 200 \
+  '(.data | type) == "array" and (.meta != null)' \
+  '.data is an array with .meta' \
+  "$SMOKE_EMBED_MAX_MS"
+
+# --- Auth boundary negative check ----------------------------------------------
+
+# No key at all → RequireAuth must 401 (it runs before the witness plug), proving
+# the authentication boundary is intact on the freshly-deployed release.
+http GET "$BASE_URL/api/v1/knowledge/search?q=x"
+assert "auth boundary enforced (401 without key)" 401
+
+# --- Summary -------------------------------------------------------------------
+
+echo
+if [ "$FAILURES" -eq 0 ]; then
+  echo "$OK all smoke checks passed"
+  exit 0
+else
+  echo "$NO $FAILURES smoke check(s) failed"
+  exit 1
+fi

--- a/test/e2e/custody_lifecycle_journey_test.exs
+++ b/test/e2e/custody_lifecycle_journey_test.exs
@@ -1,0 +1,245 @@
+defmodule Loopctl.E2E.CustodyLifecycleJourneyTest do
+  @moduledoc """
+  End-to-end journey for the full story chain-of-custody lifecycle.
+
+  Excluded from the default suite (`@moduletag :e2e`); run with `mix test.e2e`
+  or `mix test --only e2e`. Drives a story through the ENTIRE lifecycle over the
+  real HTTP controllers — contract → claim → start → request-review → report →
+  review-complete → verify — and asserts the chain-of-custody 409s fire when the
+  same agent tries to report / review / verify its own work
+  (self_report_blocked / self_review_blocked / self_verify_blocked).
+
+  Each self-block runs on its OWN tenant: two of those guards halt the tenant on
+  violation (custody enforcement working as designed), so isolating them keeps
+  the assertions independent.
+  """
+  use LoopctlWeb.ConnCase, async: true
+
+  @moduletag :e2e
+
+  alias Loopctl.AdminRepo
+
+  setup :verify_on_exit!
+
+  defp auth_conn(conn, raw_key) do
+    put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  # A pending story with two ACs, an implementer agent+key, and a distinct
+  # orchestrator agent+key (used for the cross-agent report/review/verify steps).
+  defp lifecycle_ctx do
+    tenant = fixture(:tenant)
+    project = fixture(:project, %{tenant_id: tenant.id})
+    epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+
+    impl_agent = fixture(:agent, %{tenant_id: tenant.id, agent_type: :implementer})
+
+    {impl_key, _} =
+      fixture(:api_key, %{tenant_id: tenant.id, role: :agent, agent_id: impl_agent.id})
+
+    orch_agent = fixture(:agent, %{tenant_id: tenant.id, agent_type: :orchestrator})
+
+    {orch_key, _} =
+      fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator, agent_id: orch_agent.id})
+
+    story =
+      fixture(:story, %{
+        tenant_id: tenant.id,
+        epic_id: epic.id,
+        title: "Custody journey story",
+        acceptance_criteria: [
+          %{"id" => "AC-1", "description" => "It works"},
+          %{"id" => "AC-2", "description" => "Tests pass"}
+        ]
+      })
+
+    %{
+      tenant: tenant,
+      impl_agent: impl_agent,
+      impl_key: impl_key,
+      orch_agent: orch_agent,
+      orch_key: orch_key,
+      story: story
+    }
+  end
+
+  describe "full custody lifecycle" do
+    test "contract -> claim -> start -> request-review -> report -> review-complete -> verify",
+         %{conn: _conn} do
+      ctx = lifecycle_ctx()
+      %{story: story, impl_key: impl_key, orch_key: orch_key, impl_agent: impl_agent} = ctx
+
+      # Contract (implementer)
+      contract =
+        build_conn()
+        |> auth_conn(impl_key)
+        |> post(~p"/api/v1/stories/#{story.id}/contract", %{
+          "story_title" => "Custody journey story",
+          "ac_count" => 2
+        })
+
+      assert json_response(contract, 200)["story"]["agent_status"] == "contracted"
+
+      # Claim (implementer)
+      claim =
+        build_conn()
+        |> auth_conn(impl_key)
+        |> post(~p"/api/v1/stories/#{story.id}/claim")
+
+      claim_body = json_response(claim, 200)
+      assert claim_body["story"]["agent_status"] == "assigned"
+      assert claim_body["story"]["assigned_agent_id"] == impl_agent.id
+
+      # Start (implementer)
+      start =
+        build_conn()
+        |> auth_conn(impl_key)
+        |> post(~p"/api/v1/stories/#{story.id}/start")
+
+      assert json_response(start, 200)["story"]["agent_status"] == "implementing"
+
+      # Request review (implementer signals readiness; status unchanged)
+      request_review =
+        build_conn()
+        |> auth_conn(impl_key)
+        |> post(~p"/api/v1/stories/#{story.id}/request-review")
+
+      assert json_response(request_review, 200)["story"]["agent_status"] == "implementing"
+
+      # Report (orchestrator — a DIFFERENT identity than the implementer)
+      report =
+        build_conn()
+        |> auth_conn(orch_key)
+        |> post(~p"/api/v1/stories/#{story.id}/report")
+
+      report_body = json_response(report, 200)
+      assert report_body["story"]["agent_status"] == "reported_done"
+      assert report_body["story"]["reported_done_at"] != nil
+
+      # Review complete (orchestrator — independent review record)
+      review =
+        build_conn()
+        |> auth_conn(orch_key)
+        |> post(~p"/api/v1/stories/#{story.id}/review-complete", %{
+          "review_type" => "enhanced",
+          "summary" => "Reviewed end to end.",
+          "findings_count" => 0,
+          "fixes_count" => 0
+        })
+
+      assert json_response(review, 201)["review_record"]["story_id"] == story.id
+
+      # Verify (orchestrator) — 202 accepted, story flips to verified
+      verify =
+        build_conn()
+        |> auth_conn(orch_key)
+        |> post(~p"/api/v1/stories/#{story.id}/verify", %{
+          "summary" => "All acceptance criteria met.",
+          "review_type" => "enhanced_review"
+        })
+
+      verify_body = json_response(verify, 202)
+      assert verify_body["story"]["verified_status"] == "verified"
+      assert verify_body["story"]["verified_at"] != nil
+    end
+  end
+
+  describe "chain-of-custody self-action blocks" do
+    test "self_report_blocked (409): the assigned agent cannot report its own work",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      agent = fixture(:agent, %{tenant_id: tenant.id, agent_type: :implementer})
+      {key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent, agent_id: agent.id})
+      project = fixture(:project, %{tenant_id: tenant.id})
+      epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+
+      story = fixture(:story, %{tenant_id: tenant.id, epic_id: epic.id})
+
+      story
+      |> Ecto.Changeset.change(%{
+        agent_status: :implementing,
+        assigned_agent_id: agent.id,
+        assigned_at: DateTime.utc_now()
+      })
+      |> AdminRepo.update!()
+
+      resp =
+        conn
+        |> auth_conn(key)
+        |> post(~p"/api/v1/stories/#{story.id}/report")
+
+      body = json_response(resp, 409)
+      assert body["error"]["code"] == "self_report_blocked"
+    end
+
+    test "self_review_blocked (409): the assigned agent cannot review its own work",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      agent = fixture(:agent, %{tenant_id: tenant.id, agent_type: :implementer})
+
+      # An orchestrator-role key whose agent_id IS the assigned agent — the review
+      # endpoint requires orchestrator/user role, and self-review is caught by
+      # reviewer_agent_id == assigned_agent_id.
+      {key, _} =
+        fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator, agent_id: agent.id})
+
+      project = fixture(:project, %{tenant_id: tenant.id})
+      epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+
+      # reported_done + assigned_agent_id are enough — self-review keys on
+      # reviewer_agent_id == assigned_agent_id, checked before any timestamp logic.
+      story =
+        fixture(:story, %{
+          tenant_id: tenant.id,
+          epic_id: epic.id,
+          agent_status: :reported_done,
+          assigned_agent_id: agent.id
+        })
+
+      resp =
+        conn
+        |> auth_conn(key)
+        |> post(~p"/api/v1/stories/#{story.id}/review-complete", %{
+          "review_type" => "enhanced",
+          "summary" => "Trying to review my own work."
+        })
+
+      body = json_response(resp, 409)
+      assert body["error"]["status"] == 409
+      assert body["error"]["message"] =~ "Cannot review your own implementation"
+    end
+
+    test "self_verify_blocked (409): the assigned agent cannot verify its own work",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      agent = fixture(:agent, %{tenant_id: tenant.id, agent_type: :orchestrator})
+
+      {key, _} =
+        fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator, agent_id: agent.id})
+
+      project = fixture(:project, %{tenant_id: tenant.id})
+      epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+
+      # self_verify_check is the FIRST step in verify_story's Multi (before the
+      # review-record check), so reported_done + assigned_agent_id suffice.
+      story =
+        fixture(:story, %{
+          tenant_id: tenant.id,
+          epic_id: epic.id,
+          agent_status: :reported_done,
+          assigned_agent_id: agent.id
+        })
+
+      resp =
+        conn
+        |> auth_conn(key)
+        |> post(~p"/api/v1/stories/#{story.id}/verify", %{
+          "summary" => "Trying to verify my own work.",
+          "review_type" => "enhanced_review"
+        })
+
+      body = json_response(resp, 409)
+      assert body["error"]["code"] == "self_verify_blocked"
+    end
+  end
+end

--- a/test/e2e/knowledge_retrieval_journey_test.exs
+++ b/test/e2e/knowledge_retrieval_journey_test.exs
@@ -1,0 +1,118 @@
+defmodule Loopctl.E2E.KnowledgeRetrievalJourneyTest do
+  @moduledoc """
+  End-to-end journey for the crown-jewel KB retrieval path.
+
+  Excluded from the default suite (`@moduletag :e2e`); run with `mix test.e2e`
+  or `mix test --only e2e`. Unlike the focused controller/context unit tests,
+  this exercises the FULL cross-context journey a live agent takes — seed an
+  article, then retrieve it both through the `Loopctl.Knowledge` context path
+  AND through the HTTP `/api/v1/knowledge/search` endpoint — and asserts tenant
+  isolation (tenant A's article is invisible to tenant B).
+
+  This is the regression net for the exact capability the production system is
+  serving right now: agents retrieving knowledge.
+  """
+  use LoopctlWeb.ConnCase, async: true
+
+  @moduletag :e2e
+
+  alias Loopctl.Knowledge
+
+  setup :verify_on_exit!
+
+  defp auth_conn(conn, raw_key) do
+    put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  describe "knowledge retrieval journey" do
+    test "a seeded published article is retrievable via the context and the HTTP endpoint",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _api_key} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      # A distinctive term so the match is unambiguous within the test tenant.
+      marker = "zorptango#{System.unique_integer([:positive])}"
+
+      article =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "#{marker} retrieval pattern",
+          body: "The #{marker} pattern documents how agents retrieve knowledge.",
+          category: :pattern,
+          status: :published,
+          tags: ["retrieval", marker]
+        })
+
+      # 1) Context path — the actual retrieval function the controller calls.
+      assert {:ok, %{results: results}} = Knowledge.search_keyword(tenant.id, marker, limit: 5)
+      assert Enum.any?(results, fn r -> r.id == article.id end)
+
+      # 2) HTTP path — the full stack an agent hits (auth + visibility + RLS).
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/knowledge/search", %{q: marker, mode: "keyword", limit: 3})
+
+      body = json_response(conn, 200)
+      assert is_list(body["data"])
+      ids = Enum.map(body["data"], & &1["id"])
+      assert article.id in ids
+
+      hit = Enum.find(body["data"], &(&1["id"] == article.id))
+      assert hit["title"] == "#{marker} retrieval pattern"
+      assert hit["category"] == "pattern"
+      # Search returns snippets/metadata, never the full body.
+      refute Map.has_key?(hit, "body")
+    end
+
+    test "tenant isolation: tenant B cannot retrieve tenant A's article", %{conn: conn} do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      {raw_key_a, _} = fixture(:api_key, %{tenant_id: tenant_a.id, role: :agent})
+      {raw_key_b, _} = fixture(:api_key, %{tenant_id: tenant_b.id, role: :agent})
+
+      marker = "isolationkw#{System.unique_integer([:positive])}"
+
+      article_a =
+        fixture(:article, %{
+          tenant_id: tenant_a.id,
+          title: "#{marker} tenant-A secret",
+          body: "Tenant A's private #{marker} knowledge.",
+          category: :pattern,
+          status: :published,
+          tags: [marker]
+        })
+
+      # POSITIVE CONTROL: tenant A's OWN key finds the article — proves the marker
+      # is genuinely retrievable, so a green isolation result below means "isolation
+      # works", not "search regressed to returning nothing for everyone".
+      assert {:ok, %{results: results_a}} =
+               Knowledge.search_keyword(tenant_a.id, marker, limit: 5)
+
+      assert Enum.any?(results_a, fn r -> r.id == article_a.id end)
+
+      conn_a =
+        build_conn()
+        |> auth_conn(raw_key_a)
+        |> get(~p"/api/v1/knowledge/search", %{q: marker, mode: "keyword", limit: 3})
+
+      assert article_a.id in Enum.map(json_response(conn_a, 200)["data"], & &1["id"])
+
+      # ISOLATION — context path: a tenant-B-scoped search never sees tenant A's row.
+      assert {:ok, %{results: results_b}} =
+               Knowledge.search_keyword(tenant_b.id, marker, limit: 5)
+
+      refute Enum.any?(results_b, fn r -> r.id == article_a.id end)
+
+      # ISOLATION — HTTP path: tenant B's agent key gets no such row for the query.
+      conn =
+        conn
+        |> auth_conn(raw_key_b)
+        |> get(~p"/api/v1/knowledge/search", %{q: marker, mode: "keyword", limit: 3})
+
+      body = json_response(conn, 200)
+      ids = Enum.map(body["data"], & &1["id"])
+      refute article_a.id in ids
+    end
+  end
+end

--- a/test/e2e/memory_roundtrip_journey_test.exs
+++ b/test/e2e/memory_roundtrip_journey_test.exs
@@ -1,0 +1,113 @@
+defmodule Loopctl.E2E.MemoryRoundtripJourneyTest do
+  @moduledoc """
+  End-to-end journey for the epic-28 agent-memory remember → recall/list path.
+
+  Excluded from the default suite (`@moduletag :e2e`); run with `mix test.e2e`
+  or `mix test --only e2e`. The smoke script only checks memory recall read-only
+  (an empty result passes), so this journey proves the FULL round-trip over the
+  real HTTP `/api/v1/memory` endpoints and the real DB: remember a fact carrying
+  a unique marker, then get it back via BOTH `list` (deterministic, chronological)
+  and `recall` (semantic), and prove tenant isolation.
+
+  Ranking is NOT asserted: under test all embeddings are a constant (the mock
+  embedding client), so every memory sits at cosine distance 0 — recall proves
+  the endpoint retrieves the persisted row, not that it ranks. `list` is the
+  order-independent backbone; `recall` mirrors the proven controller round-trip.
+  """
+  use LoopctlWeb.ConnCase, async: true
+
+  @moduletag :e2e
+
+  alias Loopctl.Knowledge
+
+  setup :verify_on_exit!
+
+  defp auth_conn(conn, raw_key) do
+    put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  # A fresh conn carrying the witness STH header. ConnCase adds it to the shared
+  # `conn`, but each independently-built request needs its own.
+  defp fresh_conn do
+    build_conn()
+    |> put_req_header("x-loopctl-last-known-sth", "0:AAAAAAAAAAAAAAAAAAAAAA")
+  end
+
+  # api_keys.agent_id is an FK to agents, and the agent id becomes the memory
+  # subject_id (Memory.subject_id_for/1), so mint a real agent per key.
+  defp agent_key(tenant_id) do
+    agent = fixture(:agent, %{tenant_id: tenant_id})
+    {raw, _key} = fixture(:api_key, %{tenant_id: tenant_id, role: :agent, agent_id: agent.id})
+    raw
+  end
+
+  describe "agent memory round-trip journey" do
+    test "remember then recall/list returns the fact; another tenant cannot see it",
+         %{conn: conn} do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      raw_a = agent_key(tenant_a.id)
+      raw_b = agent_key(tenant_b.id)
+
+      # Reset the embedding circuit breaker so the semantic recall leg uses the
+      # (mock) embedding path rather than degrading to the text fallback.
+      Knowledge.reset_circuit_breaker(tenant_a.id)
+
+      marker = "zqmemory#{System.unique_integer([:positive])}"
+      fact = "The agent #{marker} prefers Req over Tesla for HTTP."
+
+      # Remember (write a long_term memory) via the real HTTP endpoint.
+      created =
+        conn
+        |> auth_conn(raw_a)
+        |> post(~p"/api/v1/memory", %{"tier" => "long_term", "text" => fact})
+        |> json_response(201)
+
+      assert created["data"]["tier"] == "long_term"
+      assert created["data"]["text"] == fact
+      memory_id = created["data"]["id"]
+
+      # List (chronological, order-independent) — the deterministic proof of
+      # persistence + retrieval within the caller's own scope.
+      list_body =
+        fresh_conn()
+        |> auth_conn(raw_a)
+        |> get(~p"/api/v1/memory")
+        |> json_response(200)
+
+      list_ids = Enum.map(list_body["data"], & &1["id"])
+      assert memory_id in list_ids
+      assert Enum.any?(list_body["data"], &(&1["text"] == fact))
+
+      # Recall (semantic) — mirrors the proven controller round-trip; returns the
+      # persisted fact with meta.fallback == false under the mock embedder.
+      recall_body =
+        fresh_conn()
+        |> auth_conn(raw_a)
+        |> post(~p"/api/v1/memory/recall", %{"query" => marker})
+        |> json_response(200)
+
+      assert recall_body["meta"]["fallback"] == false
+      assert Enum.any?(recall_body["data"], &(&1["memory"]["text"] == fact))
+
+      # Tenant isolation — a DIFFERENT tenant's agent key sees none of it.
+      Knowledge.reset_circuit_breaker(tenant_b.id)
+
+      b_list =
+        fresh_conn()
+        |> auth_conn(raw_b)
+        |> get(~p"/api/v1/memory")
+        |> json_response(200)
+
+      refute memory_id in Enum.map(b_list["data"], & &1["id"])
+
+      b_recall =
+        fresh_conn()
+        |> auth_conn(raw_b)
+        |> post(~p"/api/v1/memory/recall", %{"query" => marker})
+        |> json_response(200)
+
+      refute Enum.any?(b_recall["data"], &(&1["memory"]["text"] == fact))
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -50,6 +50,13 @@ nightly_excluded = if System.get_env("SCALE_NIGHTLY"), do: [], else: [:scale_nig
 #     mix test --include pgbouncer test/loopctl/pgbouncer_startup_params_test.exs
 pgbouncer_excluded = if System.get_env("PGBOUNCER_URL"), do: [], else: [:pgbouncer]
 
+# :e2e — full cross-context journey tests (test/e2e/*) that exercise the
+# retrieval and chain-of-custody paths end-to-end via DataCase/ConnCase. They are
+# regular sandboxed async tests, but excluded from the default suite so the normal
+# `mix test` stays fast and focused; run them explicitly with `mix test --only e2e`
+# (or the `mix test.e2e` alias). `--only e2e` overrides this exclude.
+e2e_excluded = if System.get_env("E2E_TESTS"), do: [], else: [:e2e]
+
 # :requires_ipv6 — the SSRF IP-pinning Host-header regression test stands up a
 # loopback HTTP server bound to ::1 (the ONLY way to exercise Req.Finch.run/1's
 # IPv6 host-injection path). Probe ::1 bindability once; skip (not error) the
@@ -66,5 +73,6 @@ ipv6_excluded =
   end
 
 ExUnit.configure(
-  exclude: scale_excluded ++ nightly_excluded ++ pgbouncer_excluded ++ ipv6_excluded
+  exclude:
+    scale_excluded ++ nightly_excluded ++ pgbouncer_excluded ++ ipv6_excluded ++ e2e_excluded
 )


### PR DESCRIPTION
Adds a deploy-time regression safety net so master deploys can't silently break the crown-jewel KB-retrieval path the live system serves to agents right now.

## What
- **scripts/smoke.sh** — read-only prod smoke. Health with a DB hard-gate (Oban-only degradation is a WARN, not a rollback signal); KB count; a **keyword-retrieval floor** plus a **semantic-health check that asserts `meta.fallback != true`** so a silent semantic→keyword fallback (embedding provider down) can't pass green; stats; memory-recall liveness; and a 401 auth-boundary check. Primes the chain-of-custody witness STH and applies per-check latency budgets (embedding-bearing checks get a wider one).
- **ci.yml** — a post-deploy `smoke` job (`needs: deploy`) runs the script against prod on master push as a rollback **detector** (red ⇒ operator rolls back), and an **e2e step in the `test` job** so the journeys actually gate deploy.
- **test/e2e/** — three `:e2e`-tagged cross-context journeys (excluded from default `mix test`, run via `mix test.e2e`): KB retrieval + RLS isolation, chain-of-custody story lifecycle with self_report/review/verify 409s, and agent-memory remember→recall round-trip + tenant isolation.
- **docs/runbooks/post-deploy-smoke.md** — what each check means, an MCP-tool manual checklist, the Fly rollback procedure, and the expand-contract migration rule.

## Review
Two independent adversarial reviews (security + architecture) ran on the branch. All confirmed findings were fixed in-branch (zero deferrals), including a **CRITICAL false-green** (headline search stayed green while semantic recall was fully broken) and a **CRITICAL gap** (the e2e journeys were never actually run in CI). Re-verified against the real code + full `mix precommit` (3871 tests, 0 failures) and `mix test --only e2e` (7 tests, 0 failures).

No runtime code changes — script/CI/tests/docs only — so the deploy is a no-op rolling release and this PR is the first real prod exercise of the smoke job.
