### PR TITLE
Promotion workers: watermarked idempotent promotion + cross-tenant sweep, budget + telemetry

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -268,6 +268,7 @@ config :loopctl, Oban,
     maintenance: 2,
     embeddings: 5,
     knowledge: 5,
+    memory: 3,
     audit: 3
   ],
   plugins: [
@@ -285,6 +286,11 @@ config :loopctl, Oban,
        {"30 4 * * *", Loopctl.Workers.RetrievalMetricsWorker, args: %{"mode" => "all_tenants"}},
        {"*/5 * * * *", Loopctl.Workers.PendingEnrollmentCleanupWorker},
        {"*/5 * * * *", Loopctl.Workers.SessionMemoryPruneWorker},
+       # Cross-tenant memory-promotion sweep (Epic 29 / US-29.2). Runs every 10 min —
+       # its window MUST stay shorter than :session_memory_ttl_seconds (asserted at
+       # boot below) so session turns are promoted before SessionMemoryPruneWorker can
+       # delete them (no silent golden-nugget loss).
+       {"*/10 * * * *", Loopctl.Workers.MemoryPromotionSweepWorker},
        {"* * * * *", Loopctl.Workers.ComputeSthWorker, args: %{"mode" => "all_tenants"}},
        {"* * * * *", Loopctl.Workers.RevokeExpiredDispatchesWorker},
        {"* * * * *", Loopctl.Workers.SystemConfigRefreshWorker}
@@ -324,6 +330,25 @@ config :loopctl, :promoter_llm, Loopctl.Memory.Promoter.DefaultLLM
 # confidence. Query-shaped defaults; documented in the module.
 config :loopctl, :memory_promotion_confidence_threshold, 0.5
 config :loopctl, :memory_promotion_max_candidates, 5
+
+# Auto-promotion loop tunables (Epic 29 / US-29.2).
+#
+# - compiles_per_hour: per-tenant cap on promotion COMPILES (each compile = one LLM
+#   call), enforced BEFORE any LLM call in `Loopctl.Memory.promote_session/1` and the
+#   sweep, so a spamming agent or a tenant with thousands of stale sessions cannot
+#   exhaust its BYO LLM key.
+# - near_dup_threshold: cosine score at/above which a candidate supersedes the nearest
+#   existing memory instead of inserting a fresh row.
+# - sweep_max_per_tick / sweep_scan_limit: bound the cross-tenant sweep's fan-out.
+# - session_memory_ttl_seconds: the session-turn TTL used to set `expires_at`. The
+#   promotion sweep window MUST be shorter than this so turns are promoted before they
+#   are pruned (invariant asserted at boot in runtime.exs).
+config :loopctl, :memory_promotion_compiles_per_hour, 200
+config :loopctl, :memory_promotion_near_dup_threshold, 0.92
+config :loopctl, :memory_promotion_sweep_max_per_tick, 100
+config :loopctl, :memory_promotion_sweep_scan_limit, 2000
+config :loopctl, :memory_promotion_sweep_window_seconds, 600
+config :loopctl, :session_memory_ttl_seconds, 3600
 
 # L3 local test runner (Loopctl.Verification.TestRunner). DISABLED by default:
 # it clones a tenant-supplied repo and runs `mix deps.get`/`mix test` on it

--- a/config/test.exs
+++ b/config/test.exs
@@ -267,6 +267,13 @@ config :loopctl, :promoter_llm, Loopctl.MockPromoterLLM
 config :loopctl, :memory_promotion_confidence_threshold, 0.5
 config :loopctl, :memory_promotion_max_candidates, 3
 
+# US-29.2 auto-promotion tunables. Small caps so the per-tenant compiles/hour budget
+# and the sweep per-tick cap are exercised without seeding hundreds of rows. The TTL
+# invariant (sweep window < session TTL) holds: 600 < 3600 (defaults from config.exs).
+config :loopctl, :memory_promotion_compiles_per_hour, 5
+config :loopctl, :memory_promotion_sweep_max_per_tick, 5
+config :loopctl, :memory_promotion_near_dup_threshold, 0.9
+
 # DI: Use mock category classifier in tests
 config :loopctl, :category_classifier, Loopctl.MockCategoryClassifier
 

--- a/lib/loopctl/application.ex
+++ b/lib/loopctl/application.ex
@@ -9,6 +9,11 @@ defmodule Loopctl.Application do
 
   @impl true
   def start(_type, _args) do
+    # US-29.2 (AC-29.2.10): fail fast if the promotion sweep window is not strictly
+    # shorter than the session-turn TTL — otherwise SessionMemoryPruneWorker could
+    # delete turns before they are promoted (silent golden-nugget loss).
+    Loopctl.Memory.assert_promotion_ttl_invariant!()
+
     Loopctl.TenantKeys.init_cache()
 
     # US-27.4: uniform slow-query logging across all repos via one telemetry handler.

--- a/lib/loopctl/memory.ex
+++ b/lib/loopctl/memory.ex
@@ -52,9 +52,15 @@ defmodule Loopctl.Memory do
   alias Loopctl.Knowledge.VectorSearch
   alias Loopctl.Llm.ProviderError
   alias Loopctl.Memory.Memory, as: MemorySchema
+  alias Loopctl.Memory.PromotionTelemetry
   alias Loopctl.Memory.Scope
   alias Loopctl.Memory.SessionMemory
+  alias Loopctl.Memory.SessionPromotion
   alias Loopctl.Workers.MemoryEmbeddingWorker
+  alias Loopctl.Workers.MemoryPromotionWorker
+
+  @default_near_dup_threshold 0.92
+  @default_compiles_per_hour 200
 
   @default_recall_k 10
   @default_list_limit 50
@@ -689,6 +695,346 @@ defmodule Loopctl.Memory do
     |> case do
       {:ok, memory} -> memory
       {:error, changeset} -> AdminRepo.rollback(changeset)
+    end
+  end
+
+  # ===========================================================================
+  # Promotion (Epic 29, Agent Memory Part 2 / auto-promotion — US-29.2)
+  # ===========================================================================
+
+  @doc """
+  Explicit promotion trigger: enqueues a per-session promotion job for
+  `scope.session_id`, enforcing the per-tenant promotion budget FIRST.
+
+  Takes a `%Loopctl.Memory.Scope{}` carrying a `session_id` (the `%{scope | session_id:
+  ...}` shape). Refuses `{:error, :budget_exceeded}` — WITHOUT enqueuing and therefore
+  WITHOUT any LLM call — when the tenant has already hit its compiles/hour cap
+  (`:memory_promotion_compiles_per_hour`), so a spamming agent cycling distinct
+  `session_id`s cannot exhaust the tenant's BYO LLM key. On success returns
+  `{:ok, %Oban.Job{}}`; a missing `session_id` returns `{:error, :missing_session_id}`.
+
+  The compile + persistence happen in `Loopctl.Workers.MemoryPromotionWorker`; the
+  watermark makes an unchanged session a cheap no-op there.
+  """
+  @spec promote_session(Scope.t()) ::
+          {:ok, Oban.Job.t()} | {:error, :budget_exceeded | :missing_session_id | term()}
+  def promote_session(%Scope{session_id: session_id} = scope)
+      when is_binary(session_id) and session_id != "" do
+    if promotion_budget_available?(scope.tenant_id) do
+      %{
+        "tenant_id" => scope.tenant_id,
+        "subject_id" => scope.subject_id,
+        "project_id" => scope.project_id,
+        "session_id" => session_id
+      }
+      |> MemoryPromotionWorker.new()
+      |> Oban.insert()
+    else
+      PromotionTelemetry.emit(:budget_exceeded, %{count: 1}, %{
+        tenant_id: scope.tenant_id,
+        subject_id: scope.subject_id,
+        session_id: session_id
+      })
+
+      {:error, :budget_exceeded}
+    end
+  end
+
+  def promote_session(%Scope{}), do: {:error, :missing_session_id}
+
+  @doc """
+  Whether `tenant_id` is under its per-hour promotion (compile) budget.
+
+  `extra` accounts for compiles already ENQUEUED in the current sweep tick that have
+  not yet advanced the DB watermark count (async execution) — so the sweep can bound
+  itself within a single pass. Counts `session_promotions` rows whose `promoted_at`
+  falls in the last hour; each promotion run (including a zero-survivor run) upserts
+  exactly one such row, so the count is a faithful compiles/hour meter.
+  """
+  @spec promotion_budget_available?(String.t(), non_neg_integer()) :: boolean()
+  def promotion_budget_available?(tenant_id, extra \\ 0) when is_binary(tenant_id) do
+    promotion_compiles_this_hour(tenant_id) + extra < promotion_budget()
+  end
+
+  @doc "Count of promotion compiles for `tenant_id` in the last hour (watermark rows)."
+  @spec promotion_compiles_this_hour(String.t()) :: non_neg_integer()
+  def promotion_compiles_this_hour(tenant_id) when is_binary(tenant_id) do
+    since = DateTime.add(DateTime.utc_now(), -3600, :second)
+
+    SessionPromotion
+    |> where([w], w.tenant_id == ^tenant_id and w.promoted_at >= ^since)
+    |> AdminRepo.aggregate(:count, :id)
+  end
+
+  @doc "Per-tenant compiles/hour cap (`:memory_promotion_compiles_per_hour`)."
+  @spec promotion_budget() :: pos_integer()
+  def promotion_budget do
+    Application.get_env(:loopctl, :memory_promotion_compiles_per_hour, @default_compiles_per_hour)
+  end
+
+  @doc """
+  Reads the promotion watermark for `(scope, session_id)`, or `nil` if never promoted.
+  """
+  @spec get_session_promotion(Scope.t(), String.t()) :: SessionPromotion.t() | nil
+  def get_session_promotion(%Scope{} = scope, session_id) when is_binary(session_id) do
+    AdminRepo.one(
+      from(w in SessionPromotion,
+        where:
+          w.tenant_id == ^scope.tenant_id and w.subject_id == ^scope.subject_id and
+            w.session_id == ^session_id
+      )
+    )
+  end
+
+  @doc """
+  Upserts the promotion watermark for `scope.session_id` to `fingerprint`.
+
+  Called on EVERY completed promotion run — including a zero-survivor run — so that
+  an unchanged session (same `content_hash`) is skipped on the next trigger. Keyed on
+  `(tenant_id, subject_id, session_id)`; a re-run REPLACES the hash / newest-turn /
+  `promoted_at`.
+  """
+  @spec upsert_session_promotion(Scope.t(), %{
+          :content_hash => String.t(),
+          :last_turn_inserted_at => DateTime.t() | nil,
+          optional(atom()) => any()
+        }) :: {:ok, SessionPromotion.t()} | {:error, Ecto.Changeset.t()}
+  def upsert_session_promotion(%Scope{session_id: session_id} = scope, fingerprint)
+      when is_binary(session_id) do
+    attrs = %{
+      session_id: session_id,
+      session_content_hash: fingerprint.content_hash,
+      last_turn_inserted_at: fingerprint.last_turn_inserted_at,
+      promoted_at: DateTime.utc_now()
+    }
+
+    %SessionPromotion{tenant_id: scope.tenant_id, subject_id: scope.subject_id}
+    |> SessionPromotion.upsert_changeset(attrs)
+    |> AdminRepo.insert(
+      on_conflict:
+        {:replace, [:session_content_hash, :last_turn_inserted_at, :promoted_at, :updated_at]},
+      conflict_target: [:tenant_id, :subject_id, :session_id]
+    )
+  end
+
+  @doc """
+  Persists a session's surviving promotion `candidates` (from
+  `Loopctl.Memory.Promoter.compile/2`) as long-term `:promoted` memories in `scope`.
+
+  For each candidate, in order:
+
+    1. **Exact dedupe** — compute `embedding_content_hash` from the candidate text AT
+       WRITE TIME (decoupled from the async embedding). If a `:promoted` memory with
+       that hash already exists in scope, the candidate is a no-op (`deduped`). The
+       write itself runs `ON CONFLICT DO NOTHING` against the partial unique index, so
+       two concurrent workers (explicit + sweep on the same session) cannot
+       double-insert.
+    2. **Near-dup supersede** — recall the nearest LIVE memory in `(tenant_id,
+       subject_id)` (epic_28 cosine path). If `recall/2` reports `meta.fallback`
+       (embeddings degraded), NO near-dup answer is authoritative, so the whole run
+       aborts with `{:error, :embeddings_degraded}` (the worker snoozes/retries rather
+       than risk inserting a duplicate). On a genuine near-match (score ≥
+       `:memory_promotion_near_dup_threshold`) the new row is inserted and the prior
+       memory is `supersede/3`d.
+    3. Otherwise the candidate is inserted fresh (`promoted`).
+
+  Each inserted `:promoted` row enqueues `Loopctl.Workers.MemoryEmbeddingWorker` to
+  fill its vector asynchronously (reusing the epic_28 path). Subject-cap enforcement
+  is shared with `remember/2` (advisory-locked count) — a candidate that would exceed
+  the cap halts with `{:error, :quota_exceeded, summary}` (a TERMINAL condition for the
+  worker; the rows written so far stand, matching the resumable-not-all-or-nothing
+  contract).
+
+  Returns `{:ok, summary}` on full success, `{:error, :embeddings_degraded}`,
+  `{:error, :quota_exceeded, summary}`, or `{:error, other}` (a bad write —
+  retryable). `summary` is `%{promoted, superseded, deduped}` (promoted = fresh
+  inserts; superseded = insert-and-supersede pairs; deduped = exact-dup skips).
+  """
+  @spec persist_promotion(Scope.t(), [map()]) ::
+          {:ok, map()}
+          | {:error, :embeddings_degraded}
+          | {:error, :quota_exceeded, map()}
+          | {:error, term()}
+  def persist_promotion(%Scope{} = scope, candidates) when is_list(candidates) do
+    Enum.reduce_while(candidates, {:ok, %{promoted: 0, superseded: 0, deduped: 0}}, fn candidate,
+                                                                                       {:ok, acc} ->
+      case promote_one(scope, candidate) do
+        {:ok, :deduped} -> {:cont, {:ok, %{acc | deduped: acc.deduped + 1}}}
+        {:ok, :promoted} -> {:cont, {:ok, %{acc | promoted: acc.promoted + 1}}}
+        {:ok, :superseded} -> {:cont, {:ok, %{acc | superseded: acc.superseded + 1}}}
+        {:error, :embeddings_degraded} -> {:halt, {:error, :embeddings_degraded}}
+        {:error, :quota_exceeded} -> {:halt, {:error, :quota_exceeded, acc}}
+        {:error, other} -> {:halt, {:error, other}}
+      end
+    end)
+  end
+
+  defp promote_one(scope, candidate) do
+    hash = MemorySchema.embedding_content_hash(candidate.text)
+
+    if promoted_hash_exists?(AdminRepo, scope, hash) do
+      {:ok, :deduped}
+    else
+      case nearest_live(scope, candidate.text) do
+        {:error, :embeddings_degraded} -> {:error, :embeddings_degraded}
+        {:ok, near_dup_id} -> insert_and_maybe_supersede(scope, candidate, hash, near_dup_id)
+      end
+    end
+  end
+
+  # Recall the nearest LIVE memory to `text` in scope. Returns the near-dup's id (or
+  # nil when none clears the threshold), or `{:error, :embeddings_degraded}` when
+  # recall fell back (AC-29.2.4 — a degraded 'no near-dup found' is NOT authoritative).
+  defp nearest_live(scope, text) do
+    %{results: results, meta: meta} = recall(scope, query: text, limit: 1)
+
+    cond do
+      meta.fallback ->
+        {:error, :embeddings_degraded}
+
+      match?([{_memory, score} | _] when is_number(score) and score >= 0, results) ->
+        [{memory, score} | _] = results
+        if score >= near_dup_threshold(), do: {:ok, memory.id}, else: {:ok, nil}
+
+      true ->
+        {:ok, nil}
+    end
+  end
+
+  defp insert_and_maybe_supersede(scope, candidate, hash, near_dup_id) do
+    case insert_promoted(scope, candidate, hash) do
+      {:ok, :deduped} ->
+        {:ok, :deduped}
+
+      {:ok, %MemorySchema{} = memory} ->
+        maybe_supersede(scope, near_dup_id, memory)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp maybe_supersede(_scope, nil, _memory), do: {:ok, :promoted}
+
+  defp maybe_supersede(scope, near_dup_id, memory) do
+    if near_dup_id == memory.id do
+      {:ok, :promoted}
+    else
+      case supersede(scope, near_dup_id, memory.id) do
+        {:ok, _} -> {:ok, :superseded}
+        # A concurrent supersede won the race (already superseded / not found). The new
+        # row still stands as a fresh promotion — never crash the run over it.
+        {:error, _} -> {:ok, :promoted}
+      end
+    end
+  end
+
+  # Insert one promoted candidate under the subject-cap advisory lock, re-checking the
+  # exact-dup hash INSIDE the lock (authoritative — the lock serializes same-subject
+  # writers) and writing ON CONFLICT DO NOTHING against the partial unique index as a
+  # belt-and-suspenders backstop. The embedding job is enqueued on the SAME AdminRepo
+  # connection via `Oban.insert/3` (see `remember_long_term/2`).
+  defp insert_promoted(scope, candidate, hash) do
+    attrs = %{
+      text: candidate.text,
+      confidence: candidate.confidence,
+      source: :promoted,
+      source_session_id: scope.session_id,
+      embedding_content_hash: hash,
+      tags: candidate.tags,
+      metadata: promoted_metadata(candidate)
+    }
+
+    Multi.new()
+    |> Multi.run(:lock, fn repo, _changes ->
+      lock_long_term_quota!(repo, scope)
+      {:ok, :ok}
+    end)
+    |> Multi.run(:precheck, fn repo, _changes ->
+      if promoted_hash_exists?(repo, scope, hash),
+        do: {:error, :already_promoted},
+        else: {:ok, :absent}
+    end)
+    |> Multi.run(:quota, fn repo, _changes ->
+      if long_term_count(repo, scope) >= max_long_term_memories(),
+        do: {:error, :quota_exceeded},
+        else: {:ok, :ok}
+    end)
+    |> Multi.insert(:memory, long_term_changeset(scope, attrs),
+      on_conflict: :nothing,
+      conflict_target:
+        {:unsafe_fragment,
+         "(tenant_id, subject_id, embedding_content_hash) WHERE source = 'promoted'"}
+    )
+    |> Oban.insert(:embedding_job, fn %{memory: memory} ->
+      MemoryEmbeddingWorker.new(%{memory_id: memory.id, tenant_id: memory.tenant_id})
+    end)
+    |> AdminRepo.transaction()
+    |> case do
+      {:ok, %{memory: memory}} -> {:ok, memory}
+      {:error, :precheck, :already_promoted, _changes} -> {:ok, :deduped}
+      {:error, :quota, :quota_exceeded, _changes} -> {:error, :quota_exceeded}
+      {:error, :memory, %Ecto.Changeset{} = changeset, _changes} -> {:error, changeset}
+      {:error, :embedding_job, reason, _changes} -> {:error, reason}
+    end
+  end
+
+  defp promoted_hash_exists?(repo, scope, hash) do
+    MemorySchema
+    |> where(
+      [m],
+      m.tenant_id == ^scope.tenant_id and m.subject_id == ^scope.subject_id and
+        m.source == :promoted and m.embedding_content_hash == ^hash
+    )
+    |> repo.exists?()
+  end
+
+  # Carry the compiler's `when_to_apply` + `cross_links` into the promoted memory's
+  # metadata so the durable fact keeps its applicability note and article links.
+  defp promoted_metadata(candidate) do
+    %{
+      "when_to_apply" => Map.get(candidate, :when_to_apply, ""),
+      "cross_links" => Map.get(candidate, :cross_links, [])
+    }
+  end
+
+  defp near_dup_threshold do
+    Application.get_env(
+      :loopctl,
+      :memory_promotion_near_dup_threshold,
+      @default_near_dup_threshold
+    )
+  end
+
+  @doc "The session-turn TTL in seconds (`expires_at` = now + this)."
+  @spec session_memory_ttl_seconds() :: pos_integer()
+  def session_memory_ttl_seconds do
+    Application.get_env(:loopctl, :session_memory_ttl_seconds, 3600)
+  end
+
+  @doc "The promotion sweep window in seconds (must be < the session-turn TTL)."
+  @spec promotion_sweep_window_seconds() :: pos_integer()
+  def promotion_sweep_window_seconds do
+    Application.get_env(:loopctl, :memory_promotion_sweep_window_seconds, 600)
+  end
+
+  @doc """
+  Asserts the TTL-vs-promotion safety invariant (AC-29.2.10): the promotion sweep
+  window MUST be strictly shorter than the session-turn TTL, so session turns are
+  promoted before `SessionMemoryPruneWorker` can delete them. Raises otherwise.
+  """
+  @spec assert_promotion_ttl_invariant!() :: :ok
+  def assert_promotion_ttl_invariant! do
+    window = promotion_sweep_window_seconds()
+    ttl = session_memory_ttl_seconds()
+
+    if window < ttl do
+      :ok
+    else
+      raise ArgumentError,
+            "memory promotion sweep window (#{window}s) must be strictly shorter than " <>
+              "the session-memory TTL (#{ttl}s) so turns are promoted before they are " <>
+              "pruned (US-29.2 AC-29.2.10)"
     end
   end
 

--- a/lib/loopctl/memory/memory.ex
+++ b/lib/loopctl/memory/memory.ex
@@ -66,6 +66,16 @@ defmodule Loopctl.Memory.Memory do
   # A blank subject_id must never be a usable owner (see SessionMemory / #163).
   @max_subject_id_length 200
 
+  # The embedder's input is the memory text SLICED to this many chars (the embedding
+  # model's ~8191-token window is far below the 100KB text cap). `embedding_input/1`
+  # and `embedding_content_hash/1` are the SINGLE source of truth for that slice + its
+  # SHA-256 content hash, shared by BOTH the async `MemoryEmbeddingWorker` (which
+  # embeds + hashes async) and the synchronous US-29.2 promotion write path (which
+  # sets `embedding_content_hash` AT WRITE TIME for the exact-dedupe partial unique
+  # index). Keeping one implementation guarantees the two hashes match, so the async
+  # worker's `already_embedded?` idempotency check is not defeated by a drifted slice.
+  @embedding_max_chars 32_000
+
   schema "memories" do
     tenant_field()
     belongs_to :project, Loopctl.Projects.Project
@@ -158,6 +168,30 @@ defmodule Loopctl.Memory.Memory do
   @doc "Maximum `text` byte size."
   @spec max_text_bytes() :: pos_integer()
   def max_text_bytes, do: @max_text_bytes
+
+  @doc """
+  The exact text handed to the embedder: `text` sliced to the model's char window.
+
+  The single source of truth for the slice shared by the async embedding worker and
+  the synchronous US-29.2 promotion write path.
+  """
+  @spec embedding_input(String.t()) :: String.t()
+  def embedding_input(text) when is_binary(text), do: String.slice(text, 0, @embedding_max_chars)
+
+  @doc """
+  SHA-256 hex of `embedding_input(text)` — the `embedding_content_hash` value.
+
+  Computed synchronously at promotion write time (for the exact-dedupe partial unique
+  index) AND by the async `MemoryEmbeddingWorker` after embedding; both call this so
+  the hashes match and the worker's idempotency check holds.
+  """
+  @spec embedding_content_hash(String.t()) :: String.t()
+  def embedding_content_hash(text) when is_binary(text) do
+    text
+    |> embedding_input()
+    |> then(&:crypto.hash(:sha256, &1))
+    |> Base.encode16(case: :lower)
+  end
 
   # A caller may pass an explicit `tags: nil`; `cast/3` records that as a nil
   # CHANGE (the schema default `[]` differs from nil), but the DB column is

--- a/lib/loopctl/memory/promoter.ex
+++ b/lib/loopctl/memory/promoter.ex
@@ -96,6 +96,39 @@ defmodule Loopctl.Memory.Promoter do
     end
   end
 
+  @doc """
+  Returns the idempotency FINGERPRINT of a session WITHOUT calling the LLM.
+
+  Used by US-29.2's promotion watermark: the `content_hash` is a deterministic
+  SHA-256 hex over the SAME assembled turns `compile/2` would send to the LLM (same
+  ordering, same read window), so an unchanged session hashes identically across runs
+  and is skipped. `last_turn_inserted_at` is the newest loaded turn's insert time (a
+  cheap monotonic pre-filter for the sweep), and `turn_count` is how many turns were
+  assembled.
+
+  A session with no turns yields the hash of the empty string and a nil
+  `last_turn_inserted_at`. This never calls the LLM and never crosses scope (its
+  `session_history/2` read is scope-enforced).
+  """
+  @spec session_fingerprint(Scope.t(), String.t()) :: %{
+          content_hash: String.t(),
+          last_turn_inserted_at: DateTime.t() | nil,
+          turn_count: non_neg_integer()
+        }
+  def session_fingerprint(%Scope{} = scope, session_id) when is_binary(session_id) do
+    turns = load_turns(scope, session_id)
+    content = assemble_content(turns)
+
+    %{
+      content_hash: :sha256 |> :crypto.hash(content) |> Base.encode16(case: :lower),
+      last_turn_inserted_at: turns |> List.last() |> turn_inserted_at(),
+      turn_count: length(turns)
+    }
+  end
+
+  defp turn_inserted_at(nil), do: nil
+  defp turn_inserted_at(%{inserted_at: inserted_at}), do: inserted_at
+
   @read_window 200
 
   defp load_turns(scope, session_id) do

--- a/lib/loopctl/memory/promotion_telemetry.ex
+++ b/lib/loopctl/memory/promotion_telemetry.ex
@@ -1,0 +1,45 @@
+defmodule Loopctl.Memory.PromotionTelemetry do
+  @moduledoc """
+  `:telemetry` emission for the Epic 29 memory-promotion pipeline (US-29.2,
+  AC-29.2.11 / SOUL rule 7).
+
+  Every event is `[:loopctl, :memory_promotion, <event>]` with per-tenant metadata,
+  so a sweep failing every tick (bad BYO key, open circuit, budget wall) is VISIBLE
+  in metrics rather than silent. Emitted by both `Loopctl.Memory` (budget refusals)
+  and the two workers (`MemoryPromotionWorker`, `MemoryPromotionSweepWorker`).
+
+  ## Events
+
+    * `:swept` — a sweep tick enumerated sessions (`%{sessions, enqueued}`).
+    * `:skipped` — a session was watermark-unchanged and not re-compiled.
+    * `:compiled` — a session was compiled (`%{candidates}` surviving the gate).
+    * `:gated_out` — candidates dropped at promotion as exact duplicates.
+    * `:promoted` — fresh `:promoted` memories written.
+    * `:superseded` — near-dup supersedes (new row + prior superseded).
+    * `:degraded` — recall fell back (embeddings degraded); run snoozed.
+    * `:quota_exceeded` — subject hit its memory cap; run terminally discarded.
+    * `:budget_exceeded` — tenant hit its compiles/hour cap; refused pre-LLM.
+    * `:failed` — a compile/LLM/write failure (retryable).
+  """
+
+  @prefix [:loopctl, :memory_promotion]
+
+  @type event ::
+          :swept
+          | :skipped
+          | :compiled
+          | :gated_out
+          | :promoted
+          | :superseded
+          | :degraded
+          | :quota_exceeded
+          | :budget_exceeded
+          | :failed
+
+  @doc "Emit a promotion telemetry event with `measurements` and `metadata`."
+  @spec emit(event(), map(), map()) :: :ok
+  def emit(event, measurements, metadata)
+      when is_atom(event) and is_map(measurements) and is_map(metadata) do
+    :telemetry.execute(@prefix ++ [event], measurements, metadata)
+  end
+end

--- a/lib/loopctl/memory/scope.ex
+++ b/lib/loopctl/memory/scope.ex
@@ -22,14 +22,19 @@ defmodule Loopctl.Memory.Scope do
   - `tenant_id` — the owning tenant UUID (required)
   - `subject_id` — the memory scope owner = the API-key identity (required)
   - `project_id` — optional project UUID (`nil` = tenant-wide)
+  - `session_id` — optional session identifier. Not an isolation key; carried on the
+    scope only so the explicit promotion trigger `Loopctl.Memory.promote_session/1`
+    (US-29.2) can accept a `%{scope | session_id: ...}` struct without a second
+    positional argument. `nil` for every non-promotion path.
   """
 
   @enforce_keys [:tenant_id, :subject_id]
-  defstruct [:tenant_id, :subject_id, :project_id]
+  defstruct [:tenant_id, :subject_id, :project_id, :session_id]
 
   @type t :: %__MODULE__{
           tenant_id: String.t(),
           subject_id: String.t(),
-          project_id: String.t() | nil
+          project_id: String.t() | nil,
+          session_id: String.t() | nil
         }
 end

--- a/lib/loopctl/memory/session_promotion.ex
+++ b/lib/loopctl/memory/session_promotion.ex
@@ -1,0 +1,63 @@
+defmodule Loopctl.Memory.SessionPromotion do
+  @moduledoc """
+  Schema for the `session_promotions` table — the promotion WATERMARK (Epic 29,
+  Agent Memory Part 2 / auto-promotion, US-29.2).
+
+  One row per `(tenant_id, subject_id, session_id)` recording the
+  `session_content_hash` a session was last compiled at (plus the
+  `last_turn_inserted_at` of the newest turn seen and the `promoted_at` timestamp of
+  the run). Both promotion triggers — the explicit per-session job and the
+  cross-tenant cron sweep — skip a session whose CURRENT content hash equals the
+  stored watermark's, so an unchanged session is never re-compiled. It is upserted on
+  EVERY compile run, including zero-survivor runs (that is what stops the
+  re-LLM-every-tick loop).
+
+  ## Scope / security boundary
+
+  Like the rest of `Loopctl.Memory`, isolation is the explicit
+  `(tenant_id, subject_id)` predicate — `tenant_id`/`subject_id` are set
+  programmatically on the struct, never cast from params, and the context reaches
+  this table only through the BYPASSRLS `Loopctl.AdminRepo`.
+  """
+
+  use Loopctl.Schema
+
+  @type t :: %__MODULE__{}
+
+  schema "session_promotions" do
+    tenant_field()
+
+    field :subject_id, :string
+    field :session_id, :string
+    field :session_content_hash, :string
+    field :last_turn_inserted_at, :utc_datetime_usec
+    field :promoted_at, :utc_datetime_usec
+
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  @cast_fields [:session_id, :session_content_hash, :last_turn_inserted_at, :promoted_at]
+
+  @doc """
+  Changeset for inserting/upserting a promotion watermark.
+
+  `tenant_id` and `subject_id` are set programmatically on the struct and must NOT
+  appear in `attrs`.
+  """
+  @spec upsert_changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
+  def upsert_changeset(watermark \\ %__MODULE__{}, attrs) do
+    watermark
+    |> cast(attrs, @cast_fields)
+    |> validate_required([
+      :tenant_id,
+      :subject_id,
+      :session_id,
+      :session_content_hash,
+      :promoted_at
+    ])
+    |> foreign_key_constraint(:tenant_id)
+    |> unique_constraint([:tenant_id, :subject_id, :session_id],
+      name: :session_promotions_scope_session_uniq_idx
+    )
+  end
+end

--- a/lib/loopctl/workers/knowledge_moc_worker.ex
+++ b/lib/loopctl/workers/knowledge_moc_worker.ex
@@ -6,9 +6,15 @@ defmodule Loopctl.Workers.KnowledgeMocWorker do
 
   Design principle: the KB does only MECHANICAL work; intelligence lives at
   consumption. So a MOC body is a deterministic, grouped, cross-linked index —
-  **no LLM narrative** (which the killed "session memory compiler" idea showed is
-  brittle without an eval loop). An agent reads the hub and `knowledge_get`s the
-  entries it needs; the smart synthesis happens in the consuming session.
+  **no LLM narrative**. An agent reads the hub and `knowledge_get`s the entries it
+  needs; the smart synthesis happens in the consuming session.
+
+  (History: this comment once cited a "killed session memory compiler" as evidence
+  that LLM narrative is brittle *without an eval loop*. That compiler now ships — as
+  the Agent Memory Part 2 auto-promotion pipeline (#308) — precisely BECAUSE it now
+  carries that eval loop (US-29.5). The point stands unchanged for MOCs: this worker's
+  no-LLM-narrative design is intentional — a MOC is a navigational index, not a
+  synthesis, so it needs no eval loop and takes no LLM dependency.)
 
   ## What it does (per tenant)
 

--- a/lib/loopctl/workers/memory_embedding_worker.ex
+++ b/lib/loopctl/workers/memory_embedding_worker.ex
@@ -50,7 +50,6 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorker do
   alias Loopctl.Memory
 
   @worker_yield_ms 8_000
-  @max_text_length 32_000
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"memory_id" => memory_id, "tenant_id" => tenant_id}}) do
@@ -121,7 +120,11 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorker do
   defp already_embedded?(_memory, _content_hash), do: false
 
   defp content_hash(text) do
-    :sha256 |> :crypto.hash(text) |> Base.encode16(case: :lower)
+    # Delegates to the schema's single source of truth so the async worker hash and
+    # the synchronous US-29.2 promotion write-time hash never drift. `text` here is
+    # already `build_embedding_text/1` (the sliced input); `embedding_content_hash/1`
+    # re-slices idempotently, so the hash is identical either way.
+    Memory.Memory.embedding_content_hash(text)
   end
 
   defp skip_no_embedding_key(tenant_id, memory_id) do
@@ -142,6 +145,6 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorker do
   end
 
   defp build_embedding_text(memory) do
-    String.slice(memory.text, 0, @max_text_length)
+    Memory.Memory.embedding_input(memory.text)
   end
 end

--- a/lib/loopctl/workers/memory_promotion_sweep_worker.ex
+++ b/lib/loopctl/workers/memory_promotion_sweep_worker.ex
@@ -1,0 +1,133 @@
+defmodule Loopctl.Workers.MemoryPromotionSweepWorker do
+  @moduledoc """
+  Scheduled cross-tenant promotion sweep (Epic 29, Agent Memory Part 2 — US-29.2).
+
+  The crontab target for auto-promotion (the per-session
+  `Loopctl.Workers.MemoryPromotionWorker` cannot be a cron entry — it needs a
+  `session_id`). Each tick it enumerates candidate sessions ACROSS ALL TENANTS on the
+  BYPASSRLS `Loopctl.AdminRepo` (mirroring `KnowledgeMocWorker`'s all-tenants
+  fan-out), pairs each session with ITS OWN `(tenant_id, subject_id)` from the row so a
+  session is NEVER mis-attributed to another tenant/subject, and enqueues a
+  per-session promotion job.
+
+  ## Bounding (AC-29.2.7 / AC-29.2.8)
+
+    * **Watermark pre-filter** — a session whose newest turn (`max(inserted_at)`)
+      equals its watermark's `last_turn_inserted_at` is unchanged since the last
+      compile and is skipped WITHOUT enqueuing (the worker re-checks the authoritative
+      content hash).
+    * **Per-tenant budget** — a tenant already at its compiles/hour cap is skipped
+      (`Loopctl.Memory.promotion_budget_available?/2`, offset by this tick's own
+      enqueues), so a tenant with thousands of stale sessions cannot exhaust its BYO
+      LLM key.
+    * **Per-tick cap** — at most `:memory_promotion_sweep_max_per_tick` sessions are
+      enqueued per tick.
+
+  Sessions with a single turn are excluded (nothing durable to compile) so they do not
+  consume budget. Sweep-promoted memories are tenant-wide (`project_id: nil`); the
+  explicit trigger carries `project_id`.
+  """
+
+  use Oban.Worker,
+    queue: :memory,
+    max_attempts: 3,
+    unique: [fields: [:worker], period: 60]
+
+  require Logger
+
+  import Ecto.Query
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Memory
+  alias Loopctl.Memory.PromotionTelemetry
+  alias Loopctl.Memory.Scope
+  alias Loopctl.Memory.SessionMemory
+  alias Loopctl.Workers.MemoryPromotionWorker
+
+  @default_max_per_tick 100
+  @default_scan_limit 2000
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{}) do
+    cap = max_per_tick()
+    sessions = candidate_sessions(scan_limit())
+
+    {_count, allocated, seen} =
+      Enum.reduce_while(sessions, {0, %{}, %{}}, fn session, {count, allocated, seen} ->
+        {tenant_id, _subject_id, _session_id, _last_at} = session
+        seen = Map.update(seen, tenant_id, 1, &(&1 + 1))
+
+        cond do
+          count >= cap ->
+            {:halt, {count, allocated, seen}}
+
+          watermark_current?(session) ->
+            {:cont, {count, allocated, seen}}
+
+          true ->
+            maybe_enqueue(session, count, allocated, seen)
+        end
+      end)
+
+    emit_swept(seen, allocated)
+    :ok
+  end
+
+  defp maybe_enqueue({tenant_id, subject_id, session_id, _last_at}, count, allocated, seen) do
+    used = Map.get(allocated, tenant_id, 0)
+
+    if Memory.promotion_budget_available?(tenant_id, used) do
+      enqueue(tenant_id, subject_id, session_id)
+      {:cont, {count + 1, Map.update(allocated, tenant_id, 1, &(&1 + 1)), seen}}
+    else
+      {:cont, {count, allocated, seen}}
+    end
+  end
+
+  defp enqueue(tenant_id, subject_id, session_id) do
+    %{"tenant_id" => tenant_id, "subject_id" => subject_id, "session_id" => session_id}
+    |> MemoryPromotionWorker.new()
+    |> Oban.insert()
+  end
+
+  # Distinct (tenant_id, subject_id, session_id) with the session's newest-turn time,
+  # across ALL tenants (BYPASSRLS). Single-turn sessions are excluded. Newest-active
+  # sessions first so an active session is promoted before a stale one when capped.
+  defp candidate_sessions(limit) do
+    from(s in SessionMemory,
+      group_by: [s.tenant_id, s.subject_id, s.session_id],
+      having: count(s.id) > 1,
+      order_by: [desc: max(s.inserted_at)],
+      limit: ^limit,
+      select: {s.tenant_id, s.subject_id, s.session_id, max(s.inserted_at)}
+    )
+    |> AdminRepo.all()
+  end
+
+  defp watermark_current?({tenant_id, subject_id, session_id, last_at}) do
+    scope = %Scope{tenant_id: tenant_id, subject_id: subject_id}
+
+    case Memory.get_session_promotion(scope, session_id) do
+      %{last_turn_inserted_at: %DateTime{} = wm_at} -> DateTime.compare(wm_at, last_at) == :eq
+      _ -> false
+    end
+  end
+
+  defp emit_swept(seen, allocated) do
+    Enum.each(seen, fn {tenant_id, sessions} ->
+      PromotionTelemetry.emit(
+        :swept,
+        %{sessions: sessions, enqueued: Map.get(allocated, tenant_id, 0)},
+        %{tenant_id: tenant_id}
+      )
+    end)
+  end
+
+  defp max_per_tick do
+    Application.get_env(:loopctl, :memory_promotion_sweep_max_per_tick, @default_max_per_tick)
+  end
+
+  defp scan_limit do
+    Application.get_env(:loopctl, :memory_promotion_sweep_scan_limit, @default_scan_limit)
+  end
+end

--- a/lib/loopctl/workers/memory_promotion_worker.ex
+++ b/lib/loopctl/workers/memory_promotion_worker.ex
@@ -1,0 +1,162 @@
+defmodule Loopctl.Workers.MemoryPromotionWorker do
+  @moduledoc """
+  Oban worker that promotes ONE session's short-term turns into durable long-term
+  memories (Epic 29, Agent Memory Part 2 / auto-promotion — US-29.2).
+
+  Enqueued by the explicit trigger `Loopctl.Memory.promote_session/1` and by the
+  cross-tenant `Loopctl.Workers.MemoryPromotionSweepWorker`. It is the SESSION-scoped
+  half of the pipeline; the cron target is the sweep worker (this one needs a
+  `session_id` and so cannot be a crontab entry).
+
+  ## Flow (idempotency spine)
+
+  1. **Watermark skip** — compute the session's current content hash
+     (`Loopctl.Memory.Promoter.session_fingerprint/2`) and compare it to the stored
+     `session_promotions` watermark. Equal hash → the session is unchanged since the
+     last compile → skip WITHOUT calling the LLM (kills re-LLM-every-tick /
+     paraphrase-drift). Emits `:skipped`.
+  2. **Compile** — `Loopctl.Memory.Promoter.compile/2` (deterministic, temperature 0)
+     → gated candidates. A `{:error, _}` compile/LLM failure returns `{:error, _}` for
+     Oban RETRY with NO watermark advance (AC-29.2.9).
+  3. **Persist** — `Loopctl.Memory.persist_promotion/2` writes survivors as
+     `:promoted` memories (exact-dedupe + near-dup supersede, each row's embedding
+     enqueued async). Then the watermark is upserted — INCLUDING a zero-survivor run —
+     so the next trigger skips.
+
+  ## Terminal vs retryable
+
+    * `{:error, :embeddings_degraded}` (recall fell back) → `{:snooze, n}`; NO
+      watermark advance, so a later healthy run re-attempts (AC-29.2.4).
+    * `{:error, :quota_exceeded, _}` (subject at its memory cap) → `{:discard, _}`;
+      TERMINAL — do NOT retry-loop the LLM. Watermark IS advanced so an unchanged
+      session is not re-compiled just to hit the cap again.
+    * any other `{:error, _}` (compile/LLM/write) → retryable; no watermark advance.
+
+  ## Uniqueness (AC-29.2.5)
+
+  Unique per `(tenant_id, subject_id, session_id)` across the live states, so a
+  concurrent explicit + sweep enqueue for the same session cannot double-promote.
+  """
+
+  use Oban.Worker,
+    queue: :memory,
+    max_attempts: 5,
+    unique: [
+      keys: [:tenant_id, :subject_id, :session_id],
+      states: [:available, :scheduled, :executing, :retryable],
+      period: 900
+    ]
+
+  require Logger
+
+  alias Loopctl.Memory
+  alias Loopctl.Memory.Promoter
+  alias Loopctl.Memory.PromotionTelemetry
+  alias Loopctl.Memory.Scope
+
+  @snooze_seconds 300
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{
+        args:
+          %{"tenant_id" => tenant_id, "subject_id" => subject_id, "session_id" => session_id} =
+            args
+      }) do
+    scope = %Scope{
+      tenant_id: tenant_id,
+      subject_id: subject_id,
+      project_id: Map.get(args, "project_id"),
+      session_id: session_id
+    }
+
+    fingerprint = Promoter.session_fingerprint(scope, session_id)
+
+    if watermark_unchanged?(scope, session_id, fingerprint) do
+      PromotionTelemetry.emit(:skipped, %{count: 1}, meta(scope, session_id))
+      :ok
+    else
+      run_promotion(scope, session_id, fingerprint)
+    end
+  end
+
+  @impl Oban.Worker
+  def backoff(%Oban.Job{attempt: attempt}) do
+    trunc(:math.pow(attempt, 4) + 15 + :rand.uniform(30) * attempt)
+  end
+
+  defp watermark_unchanged?(scope, session_id, fingerprint) do
+    case Memory.get_session_promotion(scope, session_id) do
+      %{session_content_hash: hash} -> hash == fingerprint.content_hash
+      nil -> false
+    end
+  end
+
+  defp run_promotion(scope, session_id, fingerprint) do
+    case Promoter.compile(scope, session_id) do
+      {:ok, candidates} ->
+        PromotionTelemetry.emit(
+          :compiled,
+          %{candidates: length(candidates)},
+          meta(scope, session_id)
+        )
+
+        persist(scope, session_id, fingerprint, candidates)
+
+      {:error, reason} ->
+        PromotionTelemetry.emit(
+          :failed,
+          %{count: 1},
+          Map.put(meta(scope, session_id), :stage, :compile)
+        )
+
+        Logger.warning(
+          "MemoryPromotionWorker: compile failed tenant=#{scope.tenant_id} " <>
+            "session=#{session_id} reason=#{inspect(reason)}"
+        )
+
+        {:error, reason}
+    end
+  end
+
+  defp persist(scope, session_id, fingerprint, candidates) do
+    case Memory.persist_promotion(scope, candidates) do
+      {:ok, summary} ->
+        emit_summary(scope, session_id, summary)
+        {:ok, _} = Memory.upsert_session_promotion(scope, fingerprint)
+        :ok
+
+      {:error, :embeddings_degraded} ->
+        PromotionTelemetry.emit(:degraded, %{count: 1}, meta(scope, session_id))
+        # No watermark advance — retry when embeddings recover.
+        {:snooze, @snooze_seconds}
+
+      {:error, :quota_exceeded, summary} ->
+        emit_summary(scope, session_id, summary)
+        PromotionTelemetry.emit(:quota_exceeded, %{count: 1}, meta(scope, session_id))
+        # Advance the watermark so an unchanged session is not re-compiled just to hit
+        # the cap again, then TERMINALLY discard (no LLM retry loop).
+        {:ok, _} = Memory.upsert_session_promotion(scope, fingerprint)
+        {:discard, :quota_exceeded}
+
+      {:error, reason} ->
+        PromotionTelemetry.emit(
+          :failed,
+          %{count: 1},
+          Map.put(meta(scope, session_id), :stage, :persist)
+        )
+
+        {:error, reason}
+    end
+  end
+
+  defp emit_summary(scope, session_id, summary) do
+    base = meta(scope, session_id)
+    PromotionTelemetry.emit(:promoted, %{count: summary.promoted}, base)
+    PromotionTelemetry.emit(:superseded, %{count: summary.superseded}, base)
+    PromotionTelemetry.emit(:gated_out, %{count: summary.deduped}, base)
+  end
+
+  defp meta(scope, session_id) do
+    %{tenant_id: scope.tenant_id, subject_id: scope.subject_id, session_id: session_id}
+  end
+end

--- a/priv/repo/migrations/20260710000000_create_session_promotions.exs
+++ b/priv/repo/migrations/20260710000000_create_session_promotions.exs
@@ -1,0 +1,58 @@
+defmodule Loopctl.Repo.Migrations.CreateSessionPromotions do
+  use Ecto.Migration
+  import Loopctl.Repo.RlsHelpers
+
+  # Epic 29 (Agent Memory, Part 2 / auto-promotion), US-29.2.
+  #
+  # `session_promotions` is the promotion WATERMARK: one row per
+  # (tenant_id, subject_id, session_id) recording the content hash the session was
+  # last compiled at. Both promotion triggers (the explicit per-session job and the
+  # cross-tenant cron sweep) skip a session whose CURRENT content hash equals the
+  # stored watermark's — so an unchanged session is never re-compiled (kills the
+  # re-LLM-every-tick + paraphrase-drift problems). It is upserted on EVERY compile
+  # run, including zero-survivor runs.
+  #
+  # The PARTIAL UNIQUE INDEX on `memories` gives the exact-dedupe backstop: two
+  # concurrent promotion workers writing the same candidate text (same
+  # `embedding_content_hash`) for the same (tenant, subject) cannot double-insert a
+  # `:promoted` row. `embedding_content_hash` already exists on `memories`
+  # (20260709000000) — only the index is new here. `source` is stored as text
+  # (Ecto.Enum → `:string`), so the partial predicate is `source = 'promoted'`.
+
+  def change do
+    create table(:session_promotions, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      add :tenant_id, references(:tenants, type: :binary_id, on_delete: :delete_all), null: false
+
+      add :subject_id, :string, null: false
+      add :session_id, :string, null: false
+      add :session_content_hash, :string, null: false
+      add :last_turn_inserted_at, :utc_datetime_usec, null: true
+      add :promoted_at, :utc_datetime_usec, null: false
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    # The watermark identity: one row per session in a subject's scope. Upserts
+    # (ON CONFLICT ... DO UPDATE) target this index.
+    create unique_index(:session_promotions, [:tenant_id, :subject_id, :session_id],
+             name: :session_promotions_scope_session_uniq_idx
+           )
+
+    # Backs the per-tenant compiles/hour budget count (rows with recent promoted_at).
+    create index(:session_promotions, [:tenant_id, :promoted_at])
+
+    enable_rls(:session_promotions)
+
+    # Exact-dedupe backstop for promoted memories (AC-29.2.3): a partial UNIQUE index
+    # over (tenant_id, subject_id, embedding_content_hash) restricted to promoted rows,
+    # so `ON CONFLICT DO NOTHING` on the promotion write path is race-safe against a
+    # concurrent explicit+sweep double-insert. Explicit (`:explicit`) memories are NOT
+    # constrained (a user may legitimately store the same text twice).
+    create unique_index(:memories, [:tenant_id, :subject_id, :embedding_content_hash],
+             where: "source = 'promoted'",
+             name: :memories_promoted_content_hash_uniq_idx
+           )
+  end
+end

--- a/test/loopctl/memory/promotion_test.exs
+++ b/test/loopctl/memory/promotion_test.exs
@@ -1,0 +1,123 @@
+defmodule Loopctl.Memory.PromotionTest do
+  use Loopctl.DataCase, async: true
+
+  import Ecto.Query
+  import Mox
+
+  setup :verify_on_exit!
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Memory
+  alias Loopctl.Memory.Memory, as: MemorySchema
+
+  defp all_promoted(tenant_id, subject_id) do
+    from(m in MemorySchema,
+      where: m.tenant_id == ^tenant_id and m.subject_id == ^subject_id and m.source == :promoted
+    )
+    |> AdminRepo.all()
+  end
+
+  # ---------------------------------------------------------------------------
+  # TC-29.2.10 — explicit trigger
+  # ---------------------------------------------------------------------------
+
+  describe "promote_session/1 (TC-29.2.10)" do
+    test "enqueues a per-session job carrying the scope's tenant/subject/session" do
+      scope = fixture(:memory_scope, subject_id: "A")
+      trigger = %{scope | session_id: "s1"}
+
+      assert {:ok, %Oban.Job{args: args}} = Memory.promote_session(trigger)
+      assert args["tenant_id"] == scope.tenant_id
+      assert args["subject_id"] == "A"
+      assert args["session_id"] == "s1"
+    end
+
+    test "a scope without a session_id is rejected" do
+      scope = fixture(:memory_scope, subject_id: "A")
+      assert {:error, :missing_session_id} = Memory.promote_session(scope)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # TC-29.2.8 — per-tenant budget
+  # ---------------------------------------------------------------------------
+
+  describe "promote_session/1 — per-tenant budget (TC-29.2.8)" do
+    test "refuses an over-budget request without enqueuing or calling the LLM" do
+      tenant = fixture(:tenant)
+      scope = fixture(:memory_scope, tenant_id: tenant.id, subject_id: "A")
+      cap = Memory.promotion_budget()
+
+      # Fill the tenant's compiles/hour budget with recent watermarks.
+      for _ <- 1..cap do
+        fixture(:session_promotion, tenant_id: tenant.id, subject_id: "A")
+      end
+
+      stub(Loopctl.MockPromoterLLM, :extract, fn _t, _c, _o ->
+        send(self(), :llm_called)
+        {:ok, "[]"}
+      end)
+
+      assert {:error, :budget_exceeded} = Memory.promote_session(%{scope | session_id: "s-new"})
+      refute_received :llm_called
+      # No promoted rows written for the refused session.
+      assert all_promoted(tenant.id, "A") == []
+    end
+
+    test "budget frees as watermarks age out of the last hour" do
+      tenant = fixture(:tenant)
+      scope = fixture(:memory_scope, tenant_id: tenant.id, subject_id: "A")
+      cap = Memory.promotion_budget()
+
+      # Old watermarks (> 1h ago) do NOT count against the budget.
+      old = DateTime.add(DateTime.utc_now(), -7200, :second)
+
+      for _ <- 1..cap do
+        fixture(:session_promotion, tenant_id: tenant.id, subject_id: "A", promoted_at: old)
+      end
+
+      assert Memory.promotion_compiles_this_hour(tenant.id) == 0
+      assert {:ok, %Oban.Job{}} = Memory.promote_session(%{scope | session_id: "s-fresh"})
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Scope isolation (mandatory context test)
+  # ---------------------------------------------------------------------------
+
+  describe "persist_promotion/2 — scope isolation" do
+    test "promoted rows are written only under the caller's (tenant, subject)" do
+      tenant = fixture(:tenant)
+      other = fixture(:tenant)
+      scope = %{fixture(:memory_scope, tenant_id: tenant.id, subject_id: "A") | session_id: "s1"}
+
+      candidate = %{
+        text: "isolated fact",
+        when_to_apply: "",
+        tags: [],
+        confidence: 0.9,
+        cross_links: []
+      }
+
+      assert {:ok, %{promoted: 1}} = Memory.persist_promotion(scope, [candidate])
+
+      assert [row] = all_promoted(tenant.id, "A")
+      assert row.tenant_id == tenant.id and row.subject_id == "A"
+
+      # Neither another subject in the same tenant nor another tenant sees it.
+      assert all_promoted(tenant.id, "B") == []
+      assert all_promoted(other.id, "A") == []
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # TC-29.2.10 — TTL-vs-promotion safety invariant
+  # ---------------------------------------------------------------------------
+
+  describe "TTL invariant (AC-29.2.10)" do
+    test "the sweep window is strictly shorter than the session-memory TTL" do
+      assert Memory.promotion_sweep_window_seconds() < Memory.session_memory_ttl_seconds()
+      assert :ok = Memory.assert_promotion_ttl_invariant!()
+    end
+  end
+end

--- a/test/loopctl/workers/memory_promotion_sweep_worker_test.exs
+++ b/test/loopctl/workers/memory_promotion_sweep_worker_test.exs
@@ -1,0 +1,136 @@
+defmodule Loopctl.Workers.MemoryPromotionSweepWorkerTest do
+  use Loopctl.DataCase, async: true
+
+  import Ecto.Query
+  import Mox
+
+  setup :verify_on_exit!
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Memory.Memory, as: MemorySchema
+  alias Loopctl.Memory.SessionPromotion
+  alias Loopctl.Workers.MemoryPromotionSweepWorker
+
+  defp seed_turns(tenant_id, subject_id, session_id, contents) do
+    Enum.each(contents, fn content ->
+      fixture(:session_memory,
+        tenant_id: tenant_id,
+        subject_id: subject_id,
+        session_id: session_id,
+        role: :user,
+        content: content
+      )
+    end)
+  end
+
+  defp stub_llm(text) do
+    json =
+      JSON.encode!([
+        %{
+          "text" => text,
+          "when_to_apply" => "when relevant",
+          "tags" => ["t"],
+          "confidence" => 0.9,
+          "cross_links" => []
+        }
+      ])
+
+    stub(Loopctl.MockPromoterLLM, :extract, fn _t, _c, _o -> {:ok, json} end)
+  end
+
+  defp promoted_for(tenant_id, subject_id) do
+    from(m in MemorySchema,
+      where: m.tenant_id == ^tenant_id and m.subject_id == ^subject_id and m.source == :promoted
+    )
+    |> AdminRepo.all()
+  end
+
+  defp watermark_count do
+    AdminRepo.aggregate(SessionPromotion, :count, :id)
+  end
+
+  defp attach_swept do
+    handler = "test-#{inspect(make_ref())}"
+    test_pid = self()
+
+    :telemetry.attach(
+      handler,
+      [:loopctl, :memory_promotion, :swept],
+      fn _name, meas, meta, _ -> send(test_pid, {:swept, meas, meta}) end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler) end)
+  end
+
+  describe "perform/1 — cross-tenant attribution (TC-29.2.7)" do
+    test "attributes each session to its OWN (tenant, subject) and never mis-pairs" do
+      stub_llm("swept durable fact")
+      attach_swept()
+
+      tenant_t = fixture(:tenant)
+      tenant_u = fixture(:tenant)
+
+      seed_turns(tenant_t.id, "A", "sA", ["ta1", "ta2"])
+      seed_turns(tenant_t.id, "B", "sB", ["tb1", "tb2"])
+      seed_turns(tenant_u.id, "C", "sC", ["tc1", "tc2"])
+
+      assert :ok = MemoryPromotionSweepWorker.perform(%Oban.Job{args: %{}})
+
+      # Each subject got its own promoted row; none crossed scope.
+      assert [a] = promoted_for(tenant_t.id, "A")
+      assert a.subject_id == "A" and a.tenant_id == tenant_t.id
+      assert a.source_session_id == "sA"
+
+      assert [b] = promoted_for(tenant_t.id, "B")
+      assert b.source_session_id == "sB"
+
+      assert [c] = promoted_for(tenant_u.id, "C")
+      assert c.tenant_id == tenant_u.id
+      assert c.source_session_id == "sC"
+
+      # No cross-tenant leakage.
+      assert promoted_for(tenant_t.id, "C") == []
+      assert promoted_for(tenant_u.id, "A") == []
+
+      assert_received {:swept, %{sessions: _, enqueued: _}, %{tenant_id: _}}
+    end
+  end
+
+  describe "perform/1 — per-tick cap (TC-29.2.7)" do
+    test "enqueues at most the configured sessions-per-tick" do
+      stub_llm("capped fact")
+      cap = Application.get_env(:loopctl, :memory_promotion_sweep_max_per_tick)
+
+      # cap + 1 distinct sessions across distinct tenants (so per-tenant budget never
+      # binds first) — only `cap` may be enqueued this tick.
+      for i <- 1..(cap + 1) do
+        tenant = fixture(:tenant)
+        seed_turns(tenant.id, "S#{i}", "sess#{i}", ["one", "two"])
+      end
+
+      assert :ok = MemoryPromotionSweepWorker.perform(%Oban.Job{args: %{}})
+
+      # Each enqueued (inline) job upserts exactly one watermark → count == cap.
+      assert watermark_count() == cap
+    end
+  end
+
+  describe "perform/1 — watermark pre-filter (TC-29.2.7)" do
+    test "an unchanged session (watermark last_turn matches) is not re-enqueued" do
+      stub_llm("wm fact")
+      tenant = fixture(:tenant)
+      seed_turns(tenant.id, "A", "s1", ["one", "two"])
+
+      # First sweep promotes + watermarks the session.
+      assert :ok = MemoryPromotionSweepWorker.perform(%Oban.Job{args: %{}})
+      assert length(promoted_for(tenant.id, "A")) == 1
+      count_after_first = watermark_count()
+
+      # Second sweep with no new turns: pre-filter skips, nothing re-enqueued.
+      assert :ok = MemoryPromotionSweepWorker.perform(%Oban.Job{args: %{}})
+      assert watermark_count() == count_after_first
+      assert length(promoted_for(tenant.id, "A")) == 1
+    end
+  end
+end

--- a/test/loopctl/workers/memory_promotion_worker_test.exs
+++ b/test/loopctl/workers/memory_promotion_worker_test.exs
@@ -1,0 +1,315 @@
+defmodule Loopctl.Workers.MemoryPromotionWorkerTest do
+  use Loopctl.DataCase, async: true
+
+  import Ecto.Query
+  import Mox
+
+  setup :verify_on_exit!
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Memory
+  alias Loopctl.Memory.Memory, as: MemorySchema
+  alias Loopctl.Workers.MemoryPromotionWorker
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp seed_turns(scope, session_id, contents) do
+    Enum.each(contents, fn content ->
+      fixture(:session_memory,
+        tenant_id: scope.tenant_id,
+        subject_id: scope.subject_id,
+        session_id: session_id,
+        role: :user,
+        content: content
+      )
+    end)
+  end
+
+  defp candidate_json(candidates) do
+    candidates
+    |> Enum.map(fn c ->
+      %{
+        "text" => c.text,
+        "when_to_apply" => Map.get(c, :when_to_apply, "when relevant"),
+        "tags" => Map.get(c, :tags, ["t"]),
+        "confidence" => c.confidence,
+        "cross_links" => Map.get(c, :cross_links, [])
+      }
+    end)
+    |> JSON.encode!()
+  end
+
+  # Stub the LLM to send a message on every call (so a re-run's skip is observable)
+  # and return the crafted candidates.
+  defp stub_llm(candidates) do
+    json = candidate_json(candidates)
+
+    stub(Loopctl.MockPromoterLLM, :extract, fn _tenant_id, _content, _opts ->
+      send(self(), :llm_called)
+      {:ok, json}
+    end)
+  end
+
+  # A 1536-dim unit vector keyed on `seed` — distinct seeds are orthogonal (cosine
+  # score 0, not near-dup), identical seeds are identical (score 1.0, near-dup).
+  defp unit_vec(seed) do
+    idx = rem(:erlang.phash2(seed), 1536)
+    Enum.map(0..1535, fn i -> if i == idx, do: 1.0, else: 0.0 end)
+  end
+
+  defp stub_embeddings(text_to_seed) do
+    stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, text ->
+      {:ok, unit_vec(text_to_seed.(text))}
+    end)
+  end
+
+  defp run(scope, session_id) do
+    MemoryPromotionWorker.perform(%Oban.Job{
+      args: %{
+        "tenant_id" => scope.tenant_id,
+        "subject_id" => scope.subject_id,
+        "project_id" => scope.project_id,
+        "session_id" => session_id
+      }
+    })
+  end
+
+  defp all_promoted(scope) do
+    from(m in MemorySchema,
+      where:
+        m.tenant_id == ^scope.tenant_id and m.subject_id == ^scope.subject_id and
+          m.source == :promoted
+    )
+    |> AdminRepo.all()
+  end
+
+  defp watermark(scope, session_id), do: Memory.get_session_promotion(scope, session_id)
+
+  defp attach_telemetry(events) do
+    handler = "test-#{inspect(make_ref())}"
+    test_pid = self()
+
+    :telemetry.attach_many(
+      handler,
+      Enum.map(events, &[:loopctl, :memory_promotion, &1]),
+      fn name, meas, meta, _ -> send(test_pid, {:telemetry, List.last(name), meas, meta}) end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler) end)
+  end
+
+  # ---------------------------------------------------------------------------
+  # TC-29.2.1 — writes promoted memories + watermark
+  # ---------------------------------------------------------------------------
+
+  describe "perform/1 — promotes candidates (TC-29.2.1)" do
+    test "writes gated candidates as :promoted with source_session_id/confidence/hash + watermark" do
+      scope = fixture(:memory_scope, subject_id: "A")
+      stub_embeddings(& &1)
+      seed_turns(scope, "s1", ["decision one made", "decision two made"])
+
+      stub_llm([
+        %{text: "prefer expedited reship", confidence: 0.9, tags: ["ship"]},
+        %{text: "email beats phone for this customer", confidence: 0.8, tags: ["comm"]}
+      ])
+
+      assert :ok = run(scope, "s1")
+
+      rows = all_promoted(scope)
+      assert length(rows) == 2
+
+      Enum.each(rows, fn m ->
+        assert m.source == :promoted
+        assert m.source_session_id == "s1"
+        assert is_float(m.confidence)
+        assert is_binary(m.embedding_content_hash)
+        # The synchronous write-time hash matches the schema's canonical hash.
+        assert m.embedding_content_hash == MemorySchema.embedding_content_hash(m.text)
+      end)
+
+      wm = watermark(scope, "s1")
+      assert wm.session_content_hash != nil
+      assert wm.promoted_at != nil
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # TC-29.2.2 — watermark skip (unchanged + zero-survivor)
+  # ---------------------------------------------------------------------------
+
+  describe "perform/1 — watermark idempotency (TC-29.2.2)" do
+    test "an unchanged session is not re-compiled on re-run (no LLM call)" do
+      scope = fixture(:memory_scope, subject_id: "A")
+      stub_embeddings(& &1)
+      seed_turns(scope, "s1", ["fact a stated", "fact b stated"])
+      stub_llm([%{text: "durable fact a", confidence: 0.9}])
+
+      assert :ok = run(scope, "s1")
+      assert_received :llm_called
+      assert length(all_promoted(scope)) == 1
+
+      # Re-run with identical content: watermark match → skipped, LLM NOT called.
+      assert :ok = run(scope, "s1")
+      refute_received :llm_called
+      assert length(all_promoted(scope)) == 1
+    end
+
+    test "a zero-survivor session is still watermarked and then skipped" do
+      scope = fixture(:memory_scope, subject_id: "A")
+      stub_embeddings(& &1)
+      seed_turns(scope, "s1", ["chatter one", "chatter two"])
+      # All candidates below the 0.5 threshold → compile returns [].
+      stub_llm([%{text: "low signal", confidence: 0.1}])
+
+      assert :ok = run(scope, "s1")
+      assert_received :llm_called
+      assert all_promoted(scope) == []
+      assert watermark(scope, "s1") != nil
+
+      assert :ok = run(scope, "s1")
+      refute_received :llm_called
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # TC-29.2.3 — paraphrase supersede
+  # ---------------------------------------------------------------------------
+
+  describe "perform/1 — near-dup supersede (TC-29.2.3)" do
+    test "a changed session paraphrase supersedes rather than duplicating" do
+      scope = fixture(:memory_scope, subject_id: "A")
+      orig = "customer prefers async email updates"
+      para = "this customer likes email updates asynchronously"
+      # Map the original and its paraphrase to the SAME embedding (near-dup); every
+      # other text is orthogonal.
+      stub_embeddings(fn text -> if text in [orig, para], do: "shared", else: text end)
+
+      seed_turns(scope, "s1", ["turn one", "turn two"])
+      stub_llm([%{text: orig, confidence: 0.9}])
+      assert :ok = run(scope, "s1")
+      assert length(all_promoted(scope)) == 1
+
+      # Change the session content (new hash) and emit the paraphrase.
+      seed_turns(scope, "s1", ["turn three added"])
+      stub_llm([%{text: para, confidence: 0.9}])
+      assert :ok = run(scope, "s1")
+
+      # Two rows total (incl. superseded); default list shows only the live one.
+      all = all_promoted(scope)
+      assert length(all) == 2
+      live = Enum.filter(all, &is_nil(&1.superseded_by))
+      superseded = Enum.reject(all, &is_nil(&1.superseded_by))
+      assert length(live) == 1
+      assert length(superseded) == 1
+      assert hd(live).text == para
+      assert hd(superseded).text == orig
+
+      assert Memory.list(scope).meta.total_count == 1
+      assert Memory.list(scope, include_superseded: true).meta.total_count == 2
+    end
+
+    test "re-running the same (changed) content is a watermark no-op — superseded count stable" do
+      scope = fixture(:memory_scope, subject_id: "A")
+      stub_embeddings(& &1)
+      seed_turns(scope, "s1", ["one", "two"])
+      stub_llm([%{text: "fact", confidence: 0.9}])
+      assert :ok = run(scope, "s1")
+
+      before = length(all_promoted(scope))
+      assert :ok = run(scope, "s1")
+      assert length(all_promoted(scope)) == before
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # TC-29.2.4 — exact dedupe / on-conflict (no double insert)
+  # ---------------------------------------------------------------------------
+
+  describe "persist_promotion/2 — exact dedupe (TC-29.2.4)" do
+    test "persisting the same candidate twice yields exactly one promoted row" do
+      scope = %{fixture(:memory_scope, subject_id: "A") | session_id: "s1"}
+      stub_embeddings(& &1)
+
+      candidates = [
+        %{text: "exactly one row", when_to_apply: "", tags: [], confidence: 0.9, cross_links: []}
+      ]
+
+      assert {:ok, %{promoted: 1}} = Memory.persist_promotion(scope, candidates)
+      assert {:ok, %{deduped: 1, promoted: 0}} = Memory.persist_promotion(scope, candidates)
+
+      assert length(all_promoted(scope)) == 1
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # TC-29.2.5 — degraded embeddings → snooze, no duplicate
+  # ---------------------------------------------------------------------------
+
+  describe "perform/1 — degraded embeddings (TC-29.2.5)" do
+    test "recall fallback snoozes the job without inserting a possible duplicate" do
+      scope = fixture(:memory_scope, subject_id: "A")
+
+      stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
+        {:error, :timeout}
+      end)
+
+      seed_turns(scope, "s1", ["one", "two"])
+      stub_llm([%{text: "would-be fact", confidence: 0.9}])
+
+      assert {:snooze, _} = run(scope, "s1")
+      assert all_promoted(scope) == []
+      # No watermark advance — a healthy retry can re-attempt.
+      assert watermark(scope, "s1") == nil
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # TC-29.2.6 — scope isolation
+  # ---------------------------------------------------------------------------
+
+  describe "perform/1 — scope isolation (TC-29.2.6)" do
+    test "promotion never crosses subject scope" do
+      tenant = fixture(:tenant)
+      scope_a = fixture(:memory_scope, tenant_id: tenant.id, subject_id: "A")
+      scope_b = fixture(:memory_scope, tenant_id: tenant.id, subject_id: "B")
+      stub_embeddings(& &1)
+
+      seed_turns(scope_a, "s1", ["a-one", "a-two"])
+      stub_llm([%{text: "subject A fact", confidence: 0.9}])
+      assert :ok = run(scope_a, "s1")
+
+      assert Enum.all?(all_promoted(scope_a), &(&1.subject_id == "A"))
+      assert all_promoted(scope_b) == []
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # TC-29.2.9 — subject at memory cap → terminal discard + telemetry
+  # ---------------------------------------------------------------------------
+
+  describe "perform/1 — quota terminal discard (TC-29.2.9)" do
+    test "a subject at its memory cap discards terminally and records telemetry" do
+      scope = fixture(:memory_scope, subject_id: "A")
+      stub_embeddings(& &1)
+      attach_telemetry([:quota_exceeded])
+
+      cap = Application.get_env(:loopctl, :max_long_term_memories_per_subject)
+
+      for _ <- 1..cap do
+        fixture(:memory, tenant_id: scope.tenant_id, subject_id: "A")
+      end
+
+      seed_turns(scope, "s1", ["one", "two"])
+      stub_llm([%{text: "cannot fit", confidence: 0.9}])
+
+      assert {:discard, :quota_exceeded} = run(scope, "s1")
+      assert_received {:telemetry, :quota_exceeded, _, %{tenant_id: _}}
+      # Watermark advanced so the unchanged session is not re-compiled just to re-hit
+      # the cap.
+      assert watermark(scope, "s1") != nil
+    end
+  end
+end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -23,6 +23,7 @@ defmodule Loopctl.Fixtures do
   alias Loopctl.Llm.UsageEvent, as: LlmUsageEvent
   alias Loopctl.Memory.Memory
   alias Loopctl.Memory.SessionMemory
+  alias Loopctl.Memory.SessionPromotion
   alias Loopctl.Orchestrator.OrchestratorState
   alias Loopctl.Projects.Project
   alias Loopctl.QualityAssurance.UiTestRun
@@ -677,6 +678,27 @@ defmodule Loopctl.Fixtures do
       subject_id: subject_id,
       project_id: project_id
     }
+  end
+
+  # A US-29.2 promotion WATERMARK row. Auto-creates a tenant when one isn't supplied;
+  # `promoted_at` defaults to now (so it counts against the compiles/hour budget).
+  def fixture(:session_promotion, attrs) do
+    attrs = Enum.into(attrs, %{})
+
+    tenant_id = Map.get(attrs, :tenant_id) || fixture(:tenant).id
+    subject_id = Map.get(attrs, :subject_id) || "subject-#{System.unique_integer([:positive])}"
+    seq = System.unique_integer([:positive])
+
+    data = %{
+      session_id: Map.get(attrs, :session_id) || "session-#{seq}",
+      session_content_hash: Map.get(attrs, :session_content_hash) || "hash-#{seq}",
+      last_turn_inserted_at: Map.get(attrs, :last_turn_inserted_at),
+      promoted_at: Map.get(attrs, :promoted_at) || DateTime.utc_now()
+    }
+
+    %SessionPromotion{tenant_id: tenant_id, subject_id: subject_id}
+    |> SessionPromotion.upsert_changeset(data)
+    |> AdminRepo.insert!()
   end
 
   def fixture(:article_link, attrs) do


### PR DESCRIPTION
## US-29.2 — Promotion workers

Turns the US-29.1 pure compiler (`Loopctl.Memory.Promoter.compile/2`) into an unattended, self-evolving loop: persist surviving candidates as long-term `:promoted` memories, dedupe/supersede idempotently, and provide both an explicit per-session trigger and a scheduled cross-tenant sweep. Because it runs on a cron + Stop-hook, idempotency and scope-safety are load-bearing.

### Idempotency spine
- **Watermark** (`session_promotions` table, unique on `(tenant_id, subject_id, session_id)`): upserted on EVERY run incl. zero-survivor; both triggers skip a session whose current content hash equals the stored one — kills re-LLM-every-tick / paraphrase-drift.
- **Exact dedupe**: synchronous `embedding_content_hash` (shared `Loopctl.Memory.Memory.embedding_content_hash/1` so sync + async worker hashes never drift) + partial unique index on `memories (tenant_id, subject_id, embedding_content_hash) WHERE source='promoted'`, written `ON CONFLICT DO NOTHING` under the advisory-locked subject-cap.
- **Near-dup supersede**: epic_28 cosine recall within `(tenant_id, subject_id)`; a near-match supersedes the prior memory. If recall reports `meta.fallback` (embeddings degraded), the job snoozes rather than risk a duplicate.
- **Oban `unique`** on `(tenant_id, subject_id, session_id)` prevents concurrent double-promotion.

### Triggers
- `Loopctl.Memory.promote_session/1` — enforces the per-tenant compiles/hour budget BEFORE any LLM call, then enqueues.
- `Loopctl.Workers.MemoryPromotionWorker` — per-session: watermark skip, compile, persist, watermark; terminal quota discard, retryable compile failure (no watermark advance), snooze on degraded embeddings.
- `Loopctl.Workers.MemoryPromotionSweepWorker` — all-tenants cron (every 10 min): own-scope attribution, watermark pre-filter, per-tenant budget, per-tick cap.

### Safety / observability
- Per-tenant budget refuses over-cap requests (`{:error, :budget_exceeded}`) without an LLM call.
- TTL invariant (sweep window < session-turn TTL) asserted at boot (AC-29.2.10).
- `Loopctl.Memory.PromotionTelemetry` per-tenant events: swept / compiled / gated_out / promoted / superseded / skipped / degraded / quota_exceeded / budget_exceeded / failed.
- Reconciled `knowledge_moc_worker` moduledoc (#308 — the compiler now ships with its eval loop; the MOC no-LLM design stays intentional).

### Tests
New: `memory_promotion_worker_test`, `memory_promotion_sweep_worker_test`, `memory/promotion_test` (all 12 ACs incl. tenant/scope isolation). Full `mix precommit` green (3902 tests, 0 failures; credo --strict + dialyzer clean).

Closes #308
