### PR TITLE
API: POST /memory/promote + superadmin promoted-vs-explicit oversight

### DIFF
--- a/lib/loopctl/api_spec/schemas.ex
+++ b/lib/loopctl/api_spec/schemas.ex
@@ -3139,6 +3139,47 @@ defmodule Loopctl.ApiSpec.Schemas do
     })
   end
 
+  defmodule MemoryPromoteRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "MemoryPromoteRequest",
+      description:
+        "Params for POST /memory/promote. Scope (tenant_id/subject_id) is derived " <>
+          "from the API key — only `session_id` is read from the body.",
+      type: :object,
+      required: [:session_id],
+      properties: %{
+        session_id: %Schema{
+          type: :string,
+          description: "The session to promote into long-term memory."
+        }
+      }
+    })
+  end
+
+  defmodule MemoryPromoteResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "MemoryPromoteResponse",
+      description: "Confirmation that a session→long-term promotion was enqueued.",
+      type: :object,
+      properties: %{
+        data: %Schema{
+          type: :object,
+          properties: %{
+            job_id: %Schema{type: :integer, description: "The enqueued Oban job id."},
+            session_id: %Schema{type: :string},
+            status: %Schema{type: :string, enum: ["enqueued"]}
+          }
+        }
+      }
+    })
+  end
+
   defmodule MemoryResponse do
     @moduledoc false
     require OpenApiSpex

--- a/lib/loopctl/memory.ex
+++ b/lib/loopctl/memory.ex
@@ -483,6 +483,9 @@ defmodule Loopctl.Memory do
     * `:limit` — page size (clamped to `[1, #{@max_list_limit}]`, default #{@default_list_limit}).
     * `:offset` — pagination offset (default 0).
     * `:include_superseded` — include superseded rows (default `false`).
+    * `:source` — filter by provenance (`:promoted` | `:explicit`, or the string
+      forms; anything else is ignored → no filter). US-29.3 oversight of
+      promoted-vs-explicit memories.
 
   Returns `%{results: [memory], meta: %{total_count, limit, offset}}`. `total_count`
   is the TRUE scoped total (never silently capped by `limit`).
@@ -497,6 +500,7 @@ defmodule Loopctl.Memory do
       MemorySchema
       |> where([m], m.tenant_id == ^scope.tenant_id and m.subject_id == ^scope.subject_id)
       |> maybe_exclude_superseded_base(include_superseded?)
+      |> maybe_filter_source(opt(opts, :source, nil))
 
     total = AdminRepo.aggregate(base, :count, :id)
 
@@ -520,9 +524,10 @@ defmodule Loopctl.Memory do
   tenant can never see another's rows); the CALLER is responsible for gating this
   to superadmin keys — a non-superadmin must never reach this function.
 
-  Same options and `%{results, meta: %{total_count, limit, offset}}` envelope as
-  `list/2`. Runs on `AdminRepo` (BYPASSRLS) with an explicit `tenant_id` predicate,
-  mirroring the rest of this context.
+  Same options (including the `:source` promoted/explicit filter — so a superadmin
+  can filter oversight by provenance, US-29.3) and `%{results, meta: %{total_count,
+  limit, offset}}` envelope as `list/2`. Runs on `AdminRepo` (BYPASSRLS) with an
+  explicit `tenant_id` predicate, mirroring the rest of this context.
   """
   @spec list_all_subjects(String.t(), keyword() | map()) :: result_envelope()
   def list_all_subjects(tenant_id, opts \\ []) when is_binary(tenant_id) do
@@ -534,6 +539,7 @@ defmodule Loopctl.Memory do
       MemorySchema
       |> where([m], m.tenant_id == ^tenant_id)
       |> maybe_exclude_superseded_base(include_superseded?)
+      |> maybe_filter_source(opt(opts, :source, nil))
 
     total = AdminRepo.aggregate(base, :count, :id)
 
@@ -1090,6 +1096,17 @@ defmodule Loopctl.Memory do
 
   defp maybe_exclude_superseded_base(query, false),
     do: where(query, [m], is_nil(m.superseded_by))
+
+  # Optional provenance filter for the list readers (US-29.3 promoted-vs-explicit
+  # oversight). Accepts the `:promoted`/`:explicit` atoms or their string forms;
+  # `nil` or any unrecognized value leaves the query unfiltered (no source filter).
+  defp maybe_filter_source(query, source) when source in [:promoted, "promoted"],
+    do: where(query, [m], m.source == :promoted)
+
+  defp maybe_filter_source(query, source) when source in [:explicit, "explicit"],
+    do: where(query, [m], m.source == :explicit)
+
+  defp maybe_filter_source(query, _), do: query
 
   defp normalize_tier(tier) when tier in [:session, :long_term], do: tier
   defp normalize_tier("session"), do: :session

--- a/lib/loopctl_web/controllers/memory_controller.ex
+++ b/lib/loopctl_web/controllers/memory_controller.ex
@@ -5,6 +5,7 @@ defmodule LoopctlWeb.MemoryController do
 
   - `POST   /api/v1/memory`         — remember (write a long-term or session memory)
   - `POST   /api/v1/memory/recall`  — semantic recall (query in the request BODY)
+  - `POST   /api/v1/memory/promote` — trigger session→long-term promotion (US-29.3)
   - `GET    /api/v1/memory`         — list (limit/offset + total_count meta)
   - `DELETE /api/v1/memory/:id`     — forget
 
@@ -96,15 +97,39 @@ defmodule LoopctlWeb.MemoryController do
     }
   )
 
+  operation(:promote,
+    summary: "Promote (trigger session→long-term promotion)",
+    description:
+      "Triggers promotion of the caller's own session `session_id` into durable " <>
+        "long-term `:promoted` memories via `Loopctl.Memory.promote_session/1`. " <>
+        "Scope (`tenant_id`, `subject_id`) is derived from the API key — a caller " <>
+        "may only promote its OWN (tenant, subject) sessions; any tenant/subject in " <>
+        "the body is ignored, only `session_id` is read. Returns 202 with the " <>
+        "enqueued job reference on success; returns 429 (standard error envelope) " <>
+        "when the tenant is over its per-hour promotion budget, WITHOUT enqueuing or " <>
+        "calling the LLM. Subject to the full :authenticated write chain (custody " <>
+        "halt, witness header, rate limiting).",
+    request_body: {"Promote params", "application/json", Schemas.MemoryPromoteRequest},
+    responses: %{
+      202 => {"Promotion enqueued", "application/json", Schemas.MemoryPromoteResponse},
+      422 =>
+        {"Missing session_id or subject/tenant unresolvable", "application/json",
+         Schemas.ErrorResponse},
+      429 => {"Promotion budget exceeded", "application/json", Schemas.RateLimitError},
+      503 => {"Tenant custody halted", "application/json", Schemas.ErrorResponse}
+    }
+  )
+
   operation(:index,
     summary: "List memories",
     description:
       "Lists the caller's own long-term memories, newest first, paginated with " <>
         "`meta.total_count/limit/offset` (total is the true scoped count, never " <>
-        "silently capped by `limit`). Superadmin oversight: a superadmin key may " <>
-        "pass `all_subjects=true` to list EVERY subject's memories within its " <>
-        "tenant; the same parameter from a non-superadmin key is ignored (results " <>
-        "stay confined to its own subject).",
+        "silently capped by `limit`). Optionally filter by provenance with " <>
+        "`source=promoted|explicit` (US-29.3). Superadmin oversight: a superadmin " <>
+        "key may pass `all_subjects=true` to list EVERY subject's memories within " <>
+        "its tenant; the same parameter from a non-superadmin key is ignored " <>
+        "(results stay confined to its own subject).",
     parameters: [
       limit: [in: :query, type: :integer, description: "Page size (default 50, max 200)"],
       offset: [in: :query, type: :integer, description: "Records to skip (default 0)"],
@@ -112,6 +137,13 @@ defmodule LoopctlWeb.MemoryController do
         in: :query,
         type: :boolean,
         description: "Include superseded memories (default false)"
+      ],
+      source: [
+        in: :query,
+        type: :string,
+        description:
+          "Filter by provenance — one of `promoted` (session→long-term promotions) " <>
+            "or `explicit` (directly written). Any other/omitted value → no filter."
       ],
       all_subjects: [
         in: :query,
@@ -204,6 +236,44 @@ defmodule LoopctlWeb.MemoryController do
     end)
   end
 
+  @doc "POST /api/v1/memory/promote"
+  def promote(conn, params) do
+    with_scope(conn, fn %Scope{} = scope ->
+      case Memory.promote_session(%{scope | session_id: params["session_id"]}) do
+        {:ok, %Oban.Job{} = job} ->
+          conn
+          |> put_status(:accepted)
+          |> json(%{
+            data: %{job_id: job.id, session_id: params["session_id"], status: "enqueued"}
+          })
+
+        {:error, :budget_exceeded} ->
+          conn
+          |> put_status(:too_many_requests)
+          |> json(%{
+            error: %{
+              status: 429,
+              code: "promotion_budget_exceeded",
+              message:
+                "The tenant's per-hour memory-promotion budget has been reached. " <>
+                  "The session was not enqueued and no LLM call was made; retry later."
+            }
+          })
+
+        {:error, :missing_session_id} ->
+          conn
+          |> put_status(:unprocessable_entity)
+          |> json(%{
+            error: %{
+              status: 422,
+              code: "missing_session_id",
+              message: "A non-blank `session_id` is required to promote a session."
+            }
+          })
+      end
+    end)
+  end
+
   @doc "GET /api/v1/memory"
   def index(conn, params) do
     api_key = conn.assigns.current_api_key
@@ -259,7 +329,8 @@ defmodule LoopctlWeb.MemoryController do
     [
       limit: params["limit"],
       offset: params["offset"],
-      include_superseded: params["include_superseded"]
+      include_superseded: params["include_superseded"],
+      source: params["source"]
     ]
   end
 

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -311,6 +311,9 @@ defmodule LoopctlWeb.Router do
     # Scope (tenant_id, subject_id) is derived from the key, never the body.
     # Literal /memory/recall must precede parameterized paths.
     post "/memory/recall", MemoryController, :recall
+    # Literal /memory/promote must precede the parameterized delete so it is not
+    # captured as an :id (US-29.3).
+    post "/memory/promote", MemoryController, :promote
     post "/memory", MemoryController, :create
     get "/memory", MemoryController, :index
     delete "/memory/:id", MemoryController, :delete

--- a/test/loopctl/memory_context_test.exs
+++ b/test/loopctl/memory_context_test.exs
@@ -414,6 +414,72 @@ defmodule Loopctl.MemoryContextTest do
     end
   end
 
+  # --- US-29.3: :source filter on list/2 and list_all_subjects/2 ---
+
+  describe "list/2 :source filter (US-29.3)" do
+    test "filters the caller's own memories by promoted / explicit provenance" do
+      scope = fixture(:memory_scope)
+
+      fixture(:memory, %{
+        tenant_id: scope.tenant_id,
+        subject_id: scope.subject_id,
+        source: :explicit,
+        text: "explicit fact"
+      })
+
+      fixture(:memory, %{
+        tenant_id: scope.tenant_id,
+        subject_id: scope.subject_id,
+        source: :promoted,
+        source_session_id: "s1",
+        text: "promoted fact"
+      })
+
+      %{results: promoted} = Memory.list(scope, %{source: "promoted"})
+      assert Enum.map(promoted, & &1.text) == ["promoted fact"]
+      assert Enum.all?(promoted, &(&1.source == :promoted))
+
+      %{results: explicit} = Memory.list(scope, %{source: "explicit"})
+      assert Enum.map(explicit, & &1.text) == ["explicit fact"]
+      assert Enum.all?(explicit, &(&1.source == :explicit))
+
+      # No/unknown source → both rows.
+      assert %{meta: %{total_count: 2}} = Memory.list(scope, %{})
+      assert %{meta: %{total_count: 2}} = Memory.list(scope, %{source: "bogus"})
+    end
+  end
+
+  describe "list_all_subjects/2 :source filter (US-29.3)" do
+    test "a superadmin oversight list can filter provenance across subjects" do
+      tenant = fixture(:tenant)
+
+      fixture(:memory, %{tenant_id: tenant.id, subject_id: "s1", source: :explicit, text: "e1"})
+
+      fixture(:memory, %{
+        tenant_id: tenant.id,
+        subject_id: "s2",
+        source: :promoted,
+        source_session_id: "sess-2",
+        text: "p2"
+      })
+
+      %{results: promoted, meta: pmeta} =
+        Memory.list_all_subjects(tenant.id, %{source: :promoted})
+
+      assert pmeta.total_count == 1
+      assert Enum.map(promoted, & &1.text) == ["p2"]
+
+      %{results: explicit, meta: emeta} =
+        Memory.list_all_subjects(tenant.id, %{source: :explicit})
+
+      assert emeta.total_count == 1
+      assert Enum.map(explicit, & &1.text) == ["e1"]
+
+      # Unfiltered → both subjects.
+      assert %{meta: %{total_count: 2}} = Memory.list_all_subjects(tenant.id)
+    end
+  end
+
   defp default_recall_ids(scope, query) do
     scope
     |> Memory.recall(query: query, limit: 10)

--- a/test/loopctl_web/controllers/memory_controller_test.exs
+++ b/test/loopctl_web/controllers/memory_controller_test.exs
@@ -17,6 +17,8 @@ defmodule LoopctlWeb.MemoryControllerTest do
 
   alias Loopctl.Auth.ApiKey
   alias Loopctl.Knowledge
+  alias Loopctl.Memory
+  alias Loopctl.Memory.Scope
   alias LoopctlWeb.MemoryController
 
   defp auth(conn, raw_key), do: put_req_header(conn, "authorization", "Bearer #{raw_key}")
@@ -32,6 +34,32 @@ defmodule LoopctlWeb.MemoryControllerTest do
     agent = fixture(:agent, %{tenant_id: tenant_id})
     {raw, key} = fixture(:api_key, %{tenant_id: tenant_id, role: :agent, agent_id: agent.id})
     {raw, key, agent}
+  end
+
+  # The %Scope{} a given agent key resolves to (subject_id = agent.id).
+  defp scope_for(tenant_id, agent),
+    do: %Scope{tenant_id: tenant_id, subject_id: to_string(agent.id)}
+
+  # Override the default promoter-LLM stub to emit a crafted candidate array, and
+  # signal every call so a NON-call can be asserted (refute_received :llm_called).
+  defp stub_promoter(candidates) do
+    json =
+      candidates
+      |> Enum.map(fn c ->
+        %{
+          "text" => c.text,
+          "when_to_apply" => Map.get(c, :when_to_apply, "when relevant"),
+          "tags" => Map.get(c, :tags, ["t"]),
+          "confidence" => c.confidence,
+          "cross_links" => []
+        }
+      end)
+      |> JSON.encode!()
+
+    Mox.stub(Loopctl.MockPromoterLLM, :extract, fn _tenant_id, _content, _opts ->
+      send(self(), :llm_called)
+      {:ok, json}
+    end)
   end
 
   # --- TC-28.3.1: remember + recall round-trip over HTTP ---
@@ -556,6 +584,281 @@ defmodule LoopctlWeb.MemoryControllerTest do
         |> json_response(200)
 
       assert del_body["data"]["deleted"] == true
+    end
+  end
+
+  # =========================================================================
+  # US-29.3 — POST /api/v1/memory/promote + promoted-vs-explicit oversight
+  # =========================================================================
+
+  # --- TC-29.3.1: promote endpoint enqueues promotion scoped to the key ---
+
+  describe "POST /api/v1/memory/promote (TC-29.3.1)" do
+    test "enqueues promotion under the key's scope; promoted memory surfaces via source=promoted",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw, _key, agent} = agent_key(tenant.id)
+      Knowledge.reset_circuit_breaker(tenant.id)
+      scope = scope_for(tenant.id, agent)
+
+      # Seed >1 session turn under the KEY's subject so the promotion has content
+      # (compile/2 short-circuits a 0/1-turn session without an LLM call).
+      for content <- [
+            "decided to always expedite reships for this customer",
+            "confirmed the customer prefers email follow-ups"
+          ] do
+        {:ok, _} =
+          Memory.remember(scope, %{
+            tier: :session,
+            session_id: "s1",
+            role: :user,
+            content: content,
+            expires_at: DateTime.add(DateTime.utc_now(), 3600, :second)
+          })
+      end
+
+      stub_promoter([
+        %{text: "expedite reships for this customer", confidence: 0.9, tags: ["ship"]}
+      ])
+
+      promote_body =
+        conn
+        |> auth(raw)
+        |> post(~p"/api/v1/memory/promote", %{"session_id" => "s1"})
+        |> json_response(202)
+
+      assert promote_body["data"]["session_id"] == "s1"
+      assert promote_body["data"]["status"] == "enqueued"
+      # job_id is the job reference (a real integer in prod; nil under Oban's
+      # `testing: :inline`, where the job runs synchronously and is not persisted).
+      assert Map.has_key?(promote_body["data"], "job_id")
+
+      # Inline Oban runs the worker during the request; drain is a harmless no-op.
+      Oban.drain_queue(queue: :memory)
+
+      list_body =
+        base_conn()
+        |> auth(raw)
+        |> get(~p"/api/v1/memory?source=promoted")
+        |> json_response(200)
+
+      assert [entry | _] = list_body["data"]
+      assert entry["source"] == "promoted"
+      assert entry["source_session_id"] == "s1"
+      assert entry["confidence"] == 0.9
+      assert entry["subject_id"] == to_string(agent.id)
+    end
+  end
+
+  # --- TC-29.3.2: a caller cannot promote another subject's session ---
+
+  describe "POST /api/v1/memory/promote scope isolation (TC-29.3.2)" do
+    test "B promoting A's session_id is a scoped no-op; A's memory is never written", %{
+      conn: conn
+    } do
+      tenant = fixture(:tenant)
+      {_raw_a, _key_a, agent_a} = agent_key(tenant.id)
+      {raw_b, _key_b, _agent_b} = agent_key(tenant.id)
+      Knowledge.reset_circuit_breaker(tenant.id)
+      scope_a = scope_for(tenant.id, agent_a)
+
+      # Session s1 belongs to A.
+      {:ok, _} =
+        Memory.remember(scope_a, %{
+          tier: :session,
+          session_id: "s1",
+          role: :user,
+          content: "A's private decision that must not leak to B",
+          expires_at: DateTime.add(DateTime.utc_now(), 3600, :second)
+        })
+
+      stub_promoter([%{text: "should never be promoted for A via B", confidence: 0.9}])
+
+      # B promotes "s1" — resolves to B's subject, whose session s1 is empty → no-op.
+      conn
+      |> auth(raw_b)
+      |> post(~p"/api/v1/memory/promote", %{"session_id" => "s1"})
+      |> json_response(202)
+
+      Oban.drain_queue(queue: :memory)
+
+      # A has NO promoted memory — B's run could not touch A's (tenant, subject).
+      assert %{results: [], meta: %{total_count: 0}} = Memory.list(scope_a, %{source: :promoted})
+    end
+  end
+
+  # --- TC-29.3.3: superadmin lists promoted across subjects and rejects one ---
+
+  describe "superadmin promoted oversight (TC-29.3.3)" do
+    test "lists promoted memories across subjects and can reject one", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_super, _super_key} = fixture(:api_key, %{role: :superadmin})
+
+      p1 =
+        fixture(:memory, %{
+          tenant_id: tenant.id,
+          subject_id: "subj-1",
+          source: :promoted,
+          source_session_id: "sess-1",
+          confidence: 0.8,
+          text: "promoted for subject one"
+        })
+
+      _p2 =
+        fixture(:memory, %{
+          tenant_id: tenant.id,
+          subject_id: "subj-2",
+          source: :promoted,
+          source_session_id: "sess-2",
+          confidence: 0.7,
+          text: "promoted for subject two"
+        })
+
+      # An explicit memory must NOT appear under source=promoted.
+      fixture(:memory, %{tenant_id: tenant.id, subject_id: "subj-1", text: "explicit note"})
+
+      list_body =
+        conn
+        |> put_req_header("x-impersonate-tenant", tenant.id)
+        |> auth(raw_super)
+        |> get(~p"/api/v1/memory?source=promoted&all_subjects=true")
+        |> json_response(200)
+
+      subjects = list_body["data"] |> Enum.map(& &1["subject_id"]) |> Enum.uniq() |> Enum.sort()
+      assert subjects == ["subj-1", "subj-2"]
+      assert Enum.all?(list_body["data"], &(&1["source"] == "promoted"))
+      assert Enum.all?(list_body["data"], &(&1["source_session_id"] != nil))
+      assert Enum.all?(list_body["data"], &(&1["confidence"] != nil))
+      refute Enum.any?(list_body["data"], &(&1["text"] == "explicit note"))
+
+      # Reject a bad promotion via DELETE — nothing left orphaned-invisible.
+      del_body =
+        base_conn()
+        |> put_req_header("x-impersonate-tenant", tenant.id)
+        |> auth(raw_super)
+        |> delete(~p"/api/v1/memory/#{p1.id}")
+        |> json_response(200)
+
+      assert del_body["data"]["deleted"] == true
+
+      after_body =
+        base_conn()
+        |> put_req_header("x-impersonate-tenant", tenant.id)
+        |> auth(raw_super)
+        |> get(~p"/api/v1/memory?source=promoted&all_subjects=true")
+        |> json_response(200)
+
+      refute Enum.any?(after_body["data"], &(&1["id"] == p1.id))
+    end
+  end
+
+  # --- TC-29.3.4: custody-halted key cannot promote (503) ---
+
+  describe "POST /api/v1/memory/promote custody halt (TC-29.3.4)" do
+    test "a custody-halted tenant's key cannot promote (503)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw, _key, _agent} = agent_key(tenant.id)
+      {:ok, _} = Loopctl.Tenants.halt_custody(tenant.id)
+
+      body =
+        conn
+        |> auth(raw)
+        |> post(~p"/api/v1/memory/promote", %{"session_id" => "s1"})
+        |> json_response(503)
+
+      assert body["error"]["code"] == "tenant_halted"
+    end
+  end
+
+  # --- Over-budget: 429 without enqueuing or calling the LLM ---
+
+  describe "POST /api/v1/memory/promote over budget" do
+    test "returns 429 (standard envelope), enqueues nothing, and never calls the LLM", %{
+      conn: conn
+    } do
+      tenant = fixture(:tenant)
+      {raw, _key, agent} = agent_key(tenant.id)
+      scope = scope_for(tenant.id, agent)
+
+      # Exhaust the per-hour promotion budget by seeding watermark rows in-hour
+      # (config: :memory_promotion_compiles_per_hour = 5).
+      for i <- 1..Memory.promotion_budget() do
+        {:ok, _} =
+          Memory.upsert_session_promotion(
+            %Scope{scope | session_id: "budget-#{i}"},
+            %{content_hash: "h#{i}", last_turn_inserted_at: DateTime.utc_now()}
+          )
+      end
+
+      # A LLM call would signal :llm_called — assert it never happens.
+      stub_promoter([%{text: "should not compile", confidence: 0.9}])
+
+      body =
+        conn
+        |> auth(raw)
+        |> post(~p"/api/v1/memory/promote", %{"session_id" => "over-budget"})
+        |> json_response(429)
+
+      assert body["error"]["code"] == "promotion_budget_exceeded"
+      assert body["error"]["status"] == 429
+
+      Oban.drain_queue(queue: :memory)
+
+      # No LLM call, and nothing promoted for this subject.
+      refute_received :llm_called
+      assert %{results: [], meta: %{total_count: 0}} = Memory.list(scope, %{source: :promoted})
+    end
+  end
+
+  # --- Missing session_id: 422 ---
+
+  describe "POST /api/v1/memory/promote validation" do
+    test "a blank/missing session_id is rejected with a deterministic 422", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw, _key, _agent} = agent_key(tenant.id)
+
+      body =
+        conn
+        |> auth(raw)
+        |> post(~p"/api/v1/memory/promote", %{})
+        |> json_response(422)
+
+      assert body["error"]["code"] == "missing_session_id"
+      assert body["error"]["status"] == 422
+    end
+  end
+
+  # --- GET source=explicit filter isolation ---
+
+  describe "GET /api/v1/memory?source=explicit" do
+    test "returns only explicit memories, never promoted ones", %{conn: _conn} do
+      tenant = fixture(:tenant)
+      {raw, _key, agent} = agent_key(tenant.id)
+
+      fixture(:memory, %{
+        tenant_id: tenant.id,
+        subject_id: to_string(agent.id),
+        text: "explicit one"
+      })
+
+      fixture(:memory, %{
+        tenant_id: tenant.id,
+        subject_id: to_string(agent.id),
+        source: :promoted,
+        source_session_id: "sX",
+        text: "promoted one"
+      })
+
+      body =
+        base_conn()
+        |> auth(raw)
+        |> get(~p"/api/v1/memory?source=explicit")
+        |> json_response(200)
+
+      texts = Enum.map(body["data"], & &1["text"])
+      assert "explicit one" in texts
+      refute "promoted one" in texts
+      assert Enum.all?(body["data"], &(&1["source"] == "explicit"))
     end
   end
 end

--- a/test/loopctl_web/controllers/openapi_test.exs
+++ b/test/loopctl_web/controllers/openapi_test.exs
@@ -62,19 +62,22 @@ defmodule LoopctlWeb.OpenApiTest do
 
       assert Map.has_key?(paths, "/api/v1/memory")
       assert Map.has_key?(paths, "/api/v1/memory/recall")
+      assert Map.has_key?(paths, "/api/v1/memory/promote")
       assert Map.has_key?(paths, "/api/v1/memory/{id}")
 
       # The verbs the controller declares: remember (POST), list (GET), recall
-      # (POST), forget (DELETE).
+      # (POST), promote (POST), forget (DELETE).
       assert Map.has_key?(paths["/api/v1/memory"], "post")
       assert Map.has_key?(paths["/api/v1/memory"], "get")
       assert Map.has_key?(paths["/api/v1/memory/recall"], "post")
+      assert Map.has_key?(paths["/api/v1/memory/promote"], "post")
       assert Map.has_key?(paths["/api/v1/memory/{id}"], "delete")
 
       # And the Memory* response schemas are registered under components.
       schemas = body["components"]["schemas"]
       assert Map.has_key?(schemas, "Memory")
       assert Map.has_key?(schemas, "MemoryRecallResponse")
+      assert Map.has_key?(schemas, "MemoryPromoteRequest")
     end
   end
 

--- a/test/loopctl_web/require_human_anchor_default_deny_test.exs
+++ b/test/loopctl_web/require_human_anchor_default_deny_test.exs
@@ -103,8 +103,12 @@ defmodule LoopctlWeb.RequireHumanAnchorDefaultDenyTest do
                # (derived from the key, never the body); own-memory delete is
                # subject-scoped and the tenant-wide (any-subject) list/delete
                # oversight path is superadmin-only. recall is a POST-shaped READ.
+               # promote (US-29.3) triggers the agent's own session→long-term
+               # promotion — same KB-tier agent surface, same (tenant, subject)
+               # key-derived scope, so it is allowlisted alongside its siblings.
                {:post, "/api/v1/memory"},
                {:post, "/api/v1/memory/recall"},
+               {:post, "/api/v1/memory/promote"},
                {:delete, "/api/v1/memory/:id"},
 
                # UI test runs (#4/#5 reviewed rationale): a QA/tooling surface,


### PR DESCRIPTION
## US-29.3 — POST /api/v1/memory/promote + promoted-vs-explicit oversight

Adds the agent-memory promotion write endpoint and provenance oversight to the existing Epic 28 memory API. No LiveView (loopctl is agent-native; #308's oversight is delivered as this API affordance).

### Changes
- **POST /api/v1/memory/promote** (on the `:authenticated` write pipeline): derives `(tenant_id, subject_id)` from the API key, reads only `session_id` from the body, and enqueues `Loopctl.Memory.promote_session/1`. Renders **202** with the job reference; an inline **429** `promotion_budget_exceeded` envelope over budget (no enqueue, no LLM call); **422** `missing_session_id` for a blank session. Custody halt, witness validation, and rate limiting come from the pipeline. A caller can only promote its OWN `(tenant, subject)` sessions — structurally guaranteed by key-derived scope (a foreign `session_id` runs under the caller's subject, yielding an empty no-op).
- **GET /api/v1/memory?source=promoted|explicit**: new provenance filter applied to both `list/2` and `list_all_subjects/2` (superadmin oversight stays tenant-clamped). `source`/`source_session_id`/`confidence` already render.
- **OpenAPI**: `operation(:promote)` + `MemoryPromoteRequest`/`MemoryPromoteResponse` schemas; source query param documented on `:index`.
- Allowlisted the promote route in the human-anchor default-deny test (KB-tier agent surface, same as its memory siblings).

### Acceptance criteria
- AC-29.3.1 promote enqueues scoped to key, 202 / 429-over-budget / 422 — done
- AC-29.3.2 full write pipeline (custody halt 503), own-scope only — done
- AC-29.3.3 `source` filter + per-memory fields, superadmin tenant-clamped — done
- AC-29.3.4 reject-a-promotion via DELETE (owner + superadmin) — done
- AC-29.3.5 OpenAPI promote operation + schema registered, openapi_test green — done

### Tests
Controller: promote enqueue+scope (TC-29.3.1), cross-subject no-op (TC-29.3.2), superadmin promoted oversight + reject (TC-29.3.3), custody-halt 503 (TC-29.3.4), over-budget 429 (no LLM), missing session_id 422, `source=explicit` isolation. Context: `:source` filter on both `list/2` and `list_all_subjects/2`.

`mix precommit` green (compile --warnings-as-errors, format, credo --strict, deps.audit, dialyzer, 3911 tests / 0 failures).
