### PR TITLE
Entity-definition schema + migration + per-tenant registry (server column allowlist, entity cap)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -369,6 +369,12 @@ config :loopctl, :memory_promotion_sweep_interval_seconds, 600
 config :loopctl, :memory_promotion_sweep_window_seconds, 900
 config :loopctl, :session_memory_ttl_seconds, 3600
 
+# Epic 30 / US-30.1: per-tenant cap on entity definitions
+# (`Loopctl.ContextRetriever.Registry`). Bounds the dynamic ListTools payload/
+# latency of the generated agent query surface so a tenant admin cannot inflate
+# it without limit. Over-cap creation returns `{:error, :entity_limit}`.
+config :loopctl, :max_entity_definitions_per_tenant, 50
+
 # L3 local test runner (Loopctl.Verification.TestRunner). DISABLED by default:
 # it clones a tenant-supplied repo and runs `mix deps.get`/`mix test` on it
 # (untrusted-code execution) and is subject to a clone-time DNS-rebinding SSRF

--- a/config/test.exs
+++ b/config/test.exs
@@ -254,6 +254,10 @@ config :loopctl, :embedding_client, Loopctl.MockEmbeddingClient
 # the cap. Production uses the 10_000 default.
 config :loopctl, :max_long_term_memories_per_subject, 30
 
+# US-30.1: a small per-tenant entity-definition cap so the limit path
+# (`{:error, :entity_limit}`) is testable without inserting 50 rows.
+config :loopctl, :max_entity_definitions_per_tenant, 3
+
 # DI: Use mock knowledge extractor in tests
 config :loopctl, :knowledge_extractor, Loopctl.MockExtractor
 

--- a/lib/loopctl/context_retriever/entity.ex
+++ b/lib/loopctl/context_retriever/entity.ex
@@ -1,0 +1,290 @@
+defmodule Loopctl.ContextRetriever.Entity do
+  @moduledoc """
+  Schema for the `entity_definitions` table (Epic 30, Context Retriever).
+
+  An **entity definition** is a tenant-admin-authored declaration of a queryable
+  "entity" — a name, a set of typed fields, and a backing loopctl-internal source
+  (`projects` / `stories` / `epics`). Later stories (US-30.2 generator, US-30.3
+  executor) turn each definition into an auto-generated, governed agent query
+  surface over loopctl's STRUCTURED records.
+
+  ## Security root — the definition IS the executor's field allowlist
+
+  The entity definition is **attacker-authored**: a tenant admin (role >= user)
+  writes it, and the executor later shapes rows to the "declared fields only". If
+  an admin could declare arbitrary columns (`tenant_id`, audit/custody columns,
+  raw jsonb blobs), the "declared-fields-only" shaping would faithfully
+  exfiltrate them. To prevent that, a **SERVER-defined per-backing-source column
+  allowlist** (`@column_allowlist`, a code constant) bounds which columns any
+  entity may declare. `create_changeset/2` REJECTS any declared field whose name
+  is not in the allowlist for the row's `backing_source`, in addition to
+  validating a safe-identifier regex, the field `type` against a fixed set, and
+  the `filterable`/`searchable` booleans. This is the whole point of the story —
+  do not weaken it.
+
+  ## Fields
+
+  - `tenant_id` — set programmatically, NEVER cast (multi-tenant/RLS rule).
+  - `name` — the admin-chosen entity name, unique per tenant. Independent of
+    `backing_source` (an entity named `"story"` may back onto `:stories`).
+  - `backing_source` — `Ecto.Enum`, phase-1 loopctl-internal sources only
+    (`:projects`, `:stories`, `:epics`).
+  - `fields` — `{:array, :map}`; each element is
+    `%{"name" => ..., "type" => ..., "filterable" => bool, "searchable" => bool}`
+    with per-element validation.
+
+  ## Relationships are OUT of scope for v1 (AC-30.1.6)
+
+  Relationships / joins between entities are explicitly NOT persisted in v1 — no
+  unvalidated relationship JSON is stored anywhere on this schema. Any future
+  relationship or join-traversal feature MUST, before it ships, add:
+
+    1. **per-join tenant scoping** — every joined source is filtered by the same
+       `tenant_id` (RLS + explicit predicate), so a join can never cross tenants;
+       and
+    2. **target-entity-must-be-allowlisted validation** — the join target must
+       itself be an allowlisted entity/source (never a raw table name), so the
+       column allowlist above is not bypassed by traversing into an unsanctioned
+       source.
+
+  Shipping join traversal without BOTH of these re-opens exactly the
+  exfiltration hole `@column_allowlist` closes.
+  """
+
+  use Loopctl.Schema
+
+  @type t :: %__MODULE__{}
+
+  # Phase-1 backing sources: loopctl-internal STRUCTURED records only.
+  @backing_sources [:projects, :stories, :epics]
+
+  # Allowed field types a tenant admin may declare. Kept as a fixed set so a
+  # tenant-supplied `type` string is compared, never `String.to_atom/1`'d.
+  @field_types ~w(string integer boolean float datetime)
+
+  # Safe-identifier regex for a declared field `name`. Bounds names to
+  # lowercase snake_case identifiers, defeating `status; DROP TABLE` style input.
+  @identifier_regex ~r/^[a-z_][a-z0-9_]*$/
+
+  # SERVER-defined per-backing-source exposed-column allowlist (AC-30.1.2).
+  #
+  # This is the SECURITY GATE of Epic 30: it is the exhaustive set of columns a
+  # tenant admin may expose per source. It DELIBERATELY excludes `tenant_id`, the
+  # `metadata` jsonb blob, and every custody/dispatch/audit column
+  # (`implementer_dispatch_id`, `verifier_dispatch_id`, `assigned_agent_id`,
+  # timestamps of custody transitions, etc.). Adding a column here exposes it to
+  # every tenant admin's declared query surface — treat additions as a security
+  # review, not a convenience.
+  @column_allowlist %{
+    projects: [
+      :name,
+      :slug,
+      :repo_url,
+      :description,
+      :tech_stack,
+      :status,
+      :mission
+    ],
+    stories: [
+      :number,
+      :title,
+      :description,
+      :agent_status,
+      :verified_status,
+      :epic_id,
+      :project_id,
+      :sort_key,
+      :estimated_hours
+    ],
+    epics: [
+      :number,
+      :title,
+      :description,
+      :phase,
+      :position,
+      :project_id
+    ]
+  }
+
+  # Precompute the allowlist as a set of STRING column names per source, so a
+  # tenant-supplied field `name` (a string) is membership-tested WITHOUT ever
+  # calling `String.to_atom/1` on user input.
+  @column_allowlist_strings Map.new(@column_allowlist, fn {source, cols} ->
+                              {source, MapSet.new(Enum.map(cols, &Atom.to_string/1))}
+                            end)
+
+  schema "entity_definitions" do
+    tenant_field()
+    field :name, :string
+    field :backing_source, Ecto.Enum, values: @backing_sources
+    field :fields, {:array, :map}, default: []
+
+    timestamps()
+  end
+
+  @doc """
+  Changeset for creating a new entity definition.
+
+  `tenant_id` is set programmatically on the struct and is NEVER cast. Validates:
+
+    * `name`, `backing_source`, `fields` all present;
+    * `backing_source` is one of the phase-1 sources (`Ecto.Enum` rejects
+      unknowns automatically);
+    * each element of `fields` is a well-formed
+      `%{name, type, filterable, searchable}` map whose `name` matches the
+      safe-identifier regex, whose `type` is in the allowed set, whose
+      `filterable`/`searchable` are booleans, AND whose `name` is in the SERVER
+      column allowlist for the row's `backing_source`.
+  """
+  @spec create_changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
+  def create_changeset(entity \\ %__MODULE__{}, attrs) do
+    entity
+    |> cast(attrs, [:name, :backing_source, :fields])
+    |> validate_required([:name, :backing_source, :fields])
+    |> validate_format(:name, @identifier_regex,
+      message: "must be a lowercase snake_case identifier"
+    )
+    |> validate_length(:name, max: 100)
+    |> validate_fields()
+    |> unique_constraint([:tenant_id, :name],
+      message: "has already been taken for this tenant",
+      error_key: :name
+    )
+  end
+
+  @doc "Returns the list of valid backing sources."
+  @spec backing_sources() :: [atom()]
+  def backing_sources, do: @backing_sources
+
+  @doc "Returns the list of allowed field-type strings."
+  @spec field_types() :: [String.t()]
+  def field_types, do: @field_types
+
+  @doc """
+  Returns the SERVER column allowlist (source atom => list of column atoms).
+
+  Later stories (US-30.2 generator, US-30.3 executor) read this to bound the
+  generated/executed query surface to sanctioned columns only.
+  """
+  @spec column_allowlist() :: %{atom() => [atom()]}
+  def column_allowlist, do: @column_allowlist
+
+  # --- Private helpers ---
+
+  # Per-element validation of the `fields` array. Runs against the row's
+  # `backing_source` so the column allowlist is source-specific. A missing/unknown
+  # `backing_source` short-circuits with no field errors — `Ecto.Enum` +
+  # `validate_required` already flag that, and there is no allowlist to check
+  # against.
+  defp validate_fields(changeset) do
+    source = get_field(changeset, :backing_source)
+
+    validate_change(changeset, :fields, fn :fields, fields ->
+      field_list_errors(fields, source)
+    end)
+  end
+
+  defp field_list_errors(fields, _source) when not is_list(fields) do
+    [fields: "must be a list of field definitions"]
+  end
+
+  # No source to validate columns against; the enum/required checks already erred.
+  defp field_list_errors(_fields, nil), do: []
+
+  defp field_list_errors(fields, source) do
+    fields
+    |> Enum.with_index()
+    |> Enum.flat_map(fn {field, index} -> field_errors(field, index, source) end)
+  end
+
+  defp field_errors(field, index, source) when is_map(field) and not is_struct(field) do
+    name = string_value(field, "name")
+    type = type_string(value(field, "type"))
+    filterable = value(field, "filterable")
+    searchable = value(field, "searchable")
+
+    []
+    |> validate_field_name(name, index, source)
+    |> validate_field_type(type, index)
+    |> validate_field_boolean(filterable, "filterable", index)
+    |> validate_field_boolean(searchable, "searchable", index)
+  end
+
+  defp field_errors(_field, index, _source) do
+    [fields: "field ##{index} must be a map with name, type, filterable, searchable"]
+  end
+
+  defp validate_field_name(errors, name, index, source) do
+    allowed = Map.get(@column_allowlist_strings, source, MapSet.new())
+
+    cond do
+      not is_binary(name) ->
+        [{:fields, "field ##{index} name is required"} | errors]
+
+      not Regex.match?(@identifier_regex, name) ->
+        [{:fields, "field ##{index} name #{inspect(name)} is not a safe identifier"} | errors]
+
+      not MapSet.member?(allowed, name) ->
+        [
+          {:fields,
+           "field ##{index} name #{inspect(name)} is not an allowed column for source #{source}"}
+          | errors
+        ]
+
+      true ->
+        errors
+    end
+  end
+
+  defp validate_field_type(errors, type, index) do
+    if is_binary(type) and type in @field_types do
+      errors
+    else
+      [
+        {:fields, "field ##{index} type #{inspect(type)} is not one of #{inspect(@field_types)}"}
+        | errors
+      ]
+    end
+  end
+
+  defp validate_field_boolean(errors, value, key, index) do
+    if is_boolean(value) do
+      errors
+    else
+      [{:fields, "field ##{index} #{key} must be a boolean"} | errors]
+    end
+  end
+
+  # Read a value under the string key OR its atom equivalent. Admin params may
+  # arrive with atom keys (`%{name: ...}`) on the create path, while the DB
+  # round-trips `{:array, :map}` as string-keyed maps. The atom keys checked here
+  # (`name`/`type`/`filterable`/`searchable`) are compile-time literals, so no
+  # atom is ever created from user input.
+  defp value(map, "name"), do: map["name"] || map[:name]
+  defp value(map, "type"), do: map["type"] || map[:type]
+  defp value(map, "filterable"), do: fetch_bool_key(map, "filterable", :filterable)
+  defp value(map, "searchable"), do: fetch_bool_key(map, "searchable", :searchable)
+
+  # For boolean keys, `||` would swallow a legitimate `false`, so fetch explicitly.
+  defp fetch_bool_key(map, string_key, atom_key) do
+    case Map.fetch(map, string_key) do
+      {:ok, v} -> v
+      :error -> Map.get(map, atom_key)
+    end
+  end
+
+  # Normalize a declared `type` to a string for comparison against `@field_types`.
+  # Accepts a string (`"string"`) or an atom (`:string`) — `to_string/1` on an
+  # existing atom is safe (creates no new atom), unlike `String.to_atom/1` on the
+  # user-supplied value. Any other shape becomes `nil` (→ validation error).
+  defp type_string(v) when is_binary(v), do: v
+  defp type_string(v) when is_atom(v) and not is_nil(v), do: Atom.to_string(v)
+  defp type_string(_), do: nil
+
+  defp string_value(map, key) do
+    case value(map, key) do
+      v when is_binary(v) -> v
+      _ -> nil
+    end
+  end
+end

--- a/lib/loopctl/context_retriever/entity.ex
+++ b/lib/loopctl/context_retriever/entity.ex
@@ -128,13 +128,17 @@ defmodule Loopctl.ContextRetriever.Entity do
   `tenant_id` is set programmatically on the struct and is NEVER cast. Validates:
 
     * `name`, `backing_source`, `fields` all present;
+    * `fields` declares at least one field — an empty list is rejected (a
+      zero-field entity would generate a useless, empty tool surface);
     * `backing_source` is one of the phase-1 sources (`Ecto.Enum` rejects
       unknowns automatically);
     * each element of `fields` is a well-formed
       `%{name, type, filterable, searchable}` map whose `name` matches the
       safe-identifier regex, whose `type` is in the allowed set, whose
       `filterable`/`searchable` are booleans, AND whose `name` is in the SERVER
-      column allowlist for the row's `backing_source`.
+      column allowlist for the row's `backing_source`;
+    * no field `name` is declared more than once (a duplicate would emit
+      duplicate tool-parameter/select entries downstream).
   """
   @spec create_changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
   def create_changeset(entity \\ %__MODULE__{}, attrs) do
@@ -145,6 +149,7 @@ defmodule Loopctl.ContextRetriever.Entity do
       message: "must be a lowercase snake_case identifier"
     )
     |> validate_length(:name, max: 100)
+    |> validate_non_empty_fields()
     |> validate_fields()
     |> unique_constraint([:tenant_id, :name],
       message: "has already been taken for this tenant",
@@ -176,6 +181,18 @@ defmodule Loopctl.ContextRetriever.Entity do
   # `backing_source` short-circuits with no field errors — `Ecto.Enum` +
   # `validate_required` already flag that, and there is no allowlist to check
   # against.
+  # Reject a definition that declares zero fields. `validate_length(:fields, min: 1)`
+  # canNOT be used here: the schema default for `fields` is `[]`, so casting an
+  # empty list (or omitting `fields`) produces NO change and `validate_length`
+  # skips it. Read the resolved value via `get_field/2` instead. A zero-field
+  # entity would generate a useless, empty tool surface downstream (US-30.2).
+  defp validate_non_empty_fields(changeset) do
+    case get_field(changeset, :fields) do
+      [] -> add_error(changeset, :fields, "must declare at least one field")
+      _ -> changeset
+    end
+  end
+
   defp validate_fields(changeset) do
     source = get_field(changeset, :backing_source)
 
@@ -192,9 +209,41 @@ defmodule Loopctl.ContextRetriever.Entity do
   defp field_list_errors(_fields, nil), do: []
 
   defp field_list_errors(fields, source) do
+    per_element =
+      fields
+      |> Enum.with_index()
+      |> Enum.flat_map(fn {field, index} -> field_errors(field, index, source) end)
+
+    per_element ++ duplicate_name_errors(fields)
+  end
+
+  # Reject an entity that declares the same field `name` twice. Duplicates would
+  # otherwise round-trip into the stored `fields` array and let the US-30.2
+  # generator emit duplicate tool-parameter/select entries. Names are compared as
+  # strings so `"title"` and `:title` collide; unnamed/malformed elements are
+  # skipped here (their own per-element error already fired).
+  defp duplicate_name_errors(fields) do
     fields
-    |> Enum.with_index()
-    |> Enum.flat_map(fn {field, index} -> field_errors(field, index, source) end)
+    |> Enum.map(&declared_name/1)
+    |> Enum.reject(&is_nil/1)
+    |> duplicated_values()
+    |> Enum.map(fn name ->
+      {:fields, "field name #{inspect(name)} is declared more than once"}
+    end)
+  end
+
+  defp declared_name(field) when is_map(field) and not is_struct(field) do
+    string_value(field, "name")
+  end
+
+  defp declared_name(_field), do: nil
+
+  # Distinct values that appear more than once, each reported once.
+  defp duplicated_values(values) do
+    values
+    |> Enum.frequencies()
+    |> Enum.filter(fn {_value, count} -> count > 1 end)
+    |> Enum.map(fn {value, _count} -> value end)
   end
 
   defp field_errors(field, index, source) when is_map(field) and not is_struct(field) do

--- a/lib/loopctl/context_retriever/entity.ex
+++ b/lib/loopctl/context_retriever/entity.ex
@@ -62,6 +62,24 @@ defmodule Loopctl.ContextRetriever.Entity do
   # tenant-supplied `type` string is compared, never `String.to_atom/1`'d.
   @field_types ~w(string integer boolean float datetime)
 
+  # Hard cap on how many fields one entity may declare. The per-tenant Registry
+  # cap bounds entity COUNT, not fields-per-entity, so without this a single
+  # definition could declare an unbounded number of fields and inflate the
+  # generated ListTools payload/latency (US-30.2). Every valid field must also be
+  # an allowlisted, non-duplicate column, so the largest real source (stories, 9
+  # columns) sits well under this; the cap is a payload/DoS guard, not a
+  # functional limit.
+  @max_fields 50
+
+  # The ONLY keys a declared field map may carry. `field :fields, {:array, :map}`
+  # casts each element verbatim, so extra keys (e.g. a multi-megabyte `blob`)
+  # would otherwise round-trip into the stored jsonb of this security-root record.
+  # Each field map is normalized with `Map.take/2` to these keys (in both string
+  # and atom form, since params arrive atom-keyed and the DB round-trips
+  # string-keyed) before validation and storage.
+  @sanctioned_field_keys ~w(name type filterable searchable)a
+  @sanctioned_field_key_strings ~w(name type filterable searchable)
+
   # Safe-identifier regex for a declared field `name`. Bounds names to
   # lowercase snake_case identifiers, defeating `status; DROP TABLE` style input.
   @identifier_regex ~r/^[a-z_][a-z0-9_]*$/
@@ -129,7 +147,11 @@ defmodule Loopctl.ContextRetriever.Entity do
 
     * `name`, `backing_source`, `fields` all present;
     * `fields` declares at least one field — an empty list is rejected (a
-      zero-field entity would generate a useless, empty tool surface);
+      zero-field entity would generate a useless, empty tool surface) — and at
+      most `#{@max_fields}` (payload/DoS guard on the generated tool surface);
+    * each declared field map is normalized to the four sanctioned keys
+      (`name`/`type`/`filterable`/`searchable`) so no extra key (e.g. an
+      arbitrary `blob`) round-trips into this security-root record's jsonb;
     * `backing_source` is one of the phase-1 sources (`Ecto.Enum` rejects
       unknowns automatically);
     * each element of `fields` is a well-formed
@@ -149,6 +171,8 @@ defmodule Loopctl.ContextRetriever.Entity do
       message: "must be a lowercase snake_case identifier"
     )
     |> validate_length(:name, max: 100)
+    |> normalize_field_keys()
+    |> validate_length(:fields, max: @max_fields)
     |> validate_non_empty_fields()
     |> validate_fields()
     |> unique_constraint([:tenant_id, :name],
@@ -175,6 +199,28 @@ defmodule Loopctl.ContextRetriever.Entity do
   def column_allowlist, do: @column_allowlist
 
   # --- Private helpers ---
+
+  # Strip every declared field map down to the sanctioned keys BEFORE validation
+  # and storage, so an unknown key (e.g. `%{name: ..., blob: <megabytes>}`) cannot
+  # round-trip into the `{:array, :map}` jsonb of this security-root record. Runs
+  # only when `:fields` was cast to a list; non-list values are left for
+  # `validate_fields/1` to reject. `Map.take/2` keeps whichever key form (string
+  # or atom) each element actually carries.
+  defp normalize_field_keys(changeset) do
+    case get_change(changeset, :fields) do
+      fields when is_list(fields) ->
+        put_change(changeset, :fields, Enum.map(fields, &take_sanctioned_keys/1))
+
+      _ ->
+        changeset
+    end
+  end
+
+  defp take_sanctioned_keys(field) when is_map(field) and not is_struct(field) do
+    Map.take(field, @sanctioned_field_keys ++ @sanctioned_field_key_strings)
+  end
+
+  defp take_sanctioned_keys(field), do: field
 
   # Per-element validation of the `fields` array. Runs against the row's
   # `backing_source` so the column allowlist is source-specific. A missing/unknown

--- a/lib/loopctl/context_retriever/registry.ex
+++ b/lib/loopctl/context_retriever/registry.ex
@@ -1,0 +1,110 @@
+defmodule Loopctl.ContextRetriever.Registry do
+  @moduledoc """
+  Per-tenant registry of entity definitions (Epic 30, Context Retriever).
+
+  Reads and writes go through `Loopctl.Repo.with_tenant/2`, which sets the RLS
+  context (`SET LOCAL app.current_tenant_id` + `SET LOCAL ROLE`) for the
+  transaction. Tenant isolation therefore rides RLS on `entity_definitions`
+  (ENABLE, not FORCE — see `Loopctl.Repo.RlsHelpers`): a definition authored by
+  tenant A is invisible to tenant B. The `tenant_id` is still passed explicitly
+  as the first argument to every function (multi-tenant rule).
+
+  ## Per-tenant cap
+
+  `create_entity/2` enforces a configurable per-tenant cap
+  (`:max_entity_definitions_per_tenant`) BEFORE inserting, so a tenant cannot
+  inflate the dynamic ListTools payload/latency of the generated agent query
+  surface without bound. The count and the insert share ONE `with_tenant`
+  transaction, so the check is consistent with the write. An over-cap create
+  returns `{:error, :entity_limit}` and inserts nothing.
+  """
+
+  import Ecto.Query
+
+  alias Ecto.Multi
+  alias Loopctl.ContextRetriever.Entity
+  alias Loopctl.Repo
+
+  @default_max_entities 50
+
+  @doc """
+  Returns all of `tenant_id`'s entity definitions, ordered by `name`.
+
+  Scope-enforced: only the caller tenant's rows are visible (RLS). A tenant with
+  no definitions gets `[]`.
+  """
+  @spec for_tenant(Ecto.UUID.t()) :: [Entity.t()]
+  def for_tenant(tenant_id) when is_binary(tenant_id) do
+    {:ok, entities} =
+      Repo.with_tenant(tenant_id, fn ->
+        Repo.all(from(e in Entity, order_by: [asc: e.name]))
+      end)
+
+    entities
+  end
+
+  @doc """
+  Returns `tenant_id`'s entity definition named `name`, or `nil` if none.
+
+  Scope-enforced via RLS: a name that exists only under a different tenant
+  returns `nil` (no cross-tenant existence leak).
+  """
+  @spec get_entity(Ecto.UUID.t(), String.t()) :: Entity.t() | nil
+  def get_entity(tenant_id, name) when is_binary(tenant_id) and is_binary(name) do
+    {:ok, entity} =
+      Repo.with_tenant(tenant_id, fn ->
+        Repo.get_by(Entity, name: name)
+      end)
+
+    entity
+  end
+
+  @doc """
+  Creates an entity definition for `tenant_id` from `attrs`.
+
+  `tenant_id` is set programmatically on the struct (never cast). Enforces the
+  per-tenant cap: if the tenant is already at `max_entities/0`, returns
+  `{:error, :entity_limit}` WITHOUT inserting. Otherwise validates via
+  `Entity.create_changeset/2` and inserts.
+
+  Runs as an `Ecto.Multi` so the RLS context, the cap check, and the insert all
+  execute in ONE transaction and the write's `unique_constraint` is caught as an
+  `{:error, changeset}` (a bare `Repo.insert` inside `Repo.with_tenant` would
+  poison the transaction on a constraint violation — Ecto only savepoints per-op
+  under `Multi`). The `:rls` step sets `SET LOCAL app.current_tenant_id` +
+  `SET LOCAL ROLE`, so the cap count and insert are RLS-scoped to this tenant.
+
+  Returns `{:ok, entity}`, `{:error, :entity_limit}`, or `{:error, changeset}`.
+  """
+  @spec create_entity(Ecto.UUID.t(), map()) ::
+          {:ok, Entity.t()} | {:error, :entity_limit | Ecto.Changeset.t()}
+  def create_entity(tenant_id, attrs) when is_binary(tenant_id) and is_map(attrs) do
+    Multi.new()
+    |> Multi.run(:rls, fn _repo, _changes ->
+      Repo.set_rls_context(tenant_id)
+      {:ok, :ok}
+    end)
+    |> Multi.run(:cap, fn repo, _changes ->
+      # The cap check shares this transaction with the insert. RLS scopes the
+      # count to this tenant.
+      if repo.aggregate(Entity, :count, :id) >= max_entities() do
+        {:error, :entity_limit}
+      else
+        {:ok, :ok}
+      end
+    end)
+    |> Multi.insert(:entity, Entity.create_changeset(%Entity{tenant_id: tenant_id}, attrs))
+    |> Repo.transaction()
+    |> case do
+      {:ok, %{entity: entity}} -> {:ok, entity}
+      {:error, :cap, :entity_limit, _changes} -> {:error, :entity_limit}
+      {:error, :entity, %Ecto.Changeset{} = changeset, _changes} -> {:error, changeset}
+    end
+  end
+
+  @doc "Configurable per-tenant cap on entity definitions."
+  @spec max_entities() :: pos_integer()
+  def max_entities do
+    Application.get_env(:loopctl, :max_entity_definitions_per_tenant, @default_max_entities)
+  end
+end

--- a/lib/loopctl/context_retriever/registry.ex
+++ b/lib/loopctl/context_retriever/registry.ex
@@ -11,21 +11,36 @@ defmodule Loopctl.ContextRetriever.Registry do
 
   ## Per-tenant cap
 
-  `create_entity/2` enforces a configurable per-tenant cap
+  `create_entity/3` enforces a configurable per-tenant cap
   (`:max_entity_definitions_per_tenant`) BEFORE inserting, so a tenant cannot
   inflate the dynamic ListTools payload/latency of the generated agent query
-  surface without bound. The count and the insert share ONE `with_tenant`
-  transaction, so the check is consistent with the write. An over-cap create
-  returns `{:error, :entity_limit}` and inserts nothing.
+  surface without bound. A transaction-scoped `pg_advisory_xact_lock` keyed on
+  `tenant_id` serializes concurrent same-tenant creates, so the count-then-insert
+  cap is race-free (mirrors `Loopctl.Memory.remember/2`). The count and the
+  insert share ONE transaction, so the check is consistent with the write. An
+  over-cap create returns `{:error, :entity_limit}` and inserts nothing.
+
+  ## Audit
+
+  Because an entity definition is the executor's field allowlist (a security
+  root), `create_entity/3` writes an `audit_log` entry (`entity_definition` /
+  `created`) inside the same transaction via `Loopctl.Audit.log_in_multi/3`.
   """
 
   import Ecto.Query
 
   alias Ecto.Multi
+  alias Loopctl.Audit
   alias Loopctl.ContextRetriever.Entity
   alias Loopctl.Repo
 
   @default_max_entities 50
+
+  # Namespace for the per-tenant entity-cap advisory lock. `pg_advisory_xact_lock`
+  # takes two int4s (namespace, key); the namespace isolates this lock CLASS from
+  # every other advisory lock in the app (e.g. the memory-quota lock), so hashing
+  # a tenant_id here can never collide with an unrelated lock keyed on the same int.
+  @entity_cap_lock_ns :erlang.phash2(:loopctl_context_retriever_entity_cap)
 
   @doc """
   Returns all of `tenant_id`'s entity definitions, ordered by `name`.
@@ -67,33 +82,88 @@ defmodule Loopctl.ContextRetriever.Registry do
   `{:error, :entity_limit}` WITHOUT inserting. Otherwise validates via
   `Entity.create_changeset/2` and inserts.
 
-  Runs as an `Ecto.Multi` so the RLS context, the cap check, and the insert all
-  execute in ONE transaction and the write's `unique_constraint` is caught as an
-  `{:error, changeset}` (a bare `Repo.insert` inside `Repo.with_tenant` would
-  poison the transaction on a constraint violation — Ecto only savepoints per-op
-  under `Multi`). The `:rls` step sets `SET LOCAL app.current_tenant_id` +
-  `SET LOCAL ROLE`, so the cap count and insert are RLS-scoped to this tenant.
+  Runs as an `Ecto.Multi` so the RLS context, the advisory lock, the cap check,
+  the insert, and the audit entry all execute in ONE transaction and the write's
+  `unique_constraint` is caught as an `{:error, changeset}` (a bare `Repo.insert`
+  inside `Repo.with_tenant` would poison the transaction on a constraint
+  violation — Ecto only savepoints per-op under `Multi`). The `:rls` step sets
+  `SET LOCAL app.current_tenant_id` + `SET LOCAL ROLE`, so the cap count, insert,
+  and audit write are RLS-scoped to this tenant.
+
+  ## Race-free cap (advisory lock)
+
+  The `:lock` step takes a transaction-scoped `pg_advisory_xact_lock` keyed on
+  `tenant_id` BEFORE the count, serializing concurrent same-tenant creates.
+  Without it, two creates under READ COMMITTED could each observe
+  `count = cap - 1` (neither sees the other's uncommitted insert) and both
+  commit, landing at `cap + N`. This mirrors `Loopctl.Memory.remember/2`'s
+  quota lock. The lock auto-releases at COMMIT/ROLLBACK.
+
+  ## Audit trail
+
+  The entity definition is a SECURITY ROOT (the executor's field allowlist), so
+  its creation is recorded via `Audit.log_in_multi/3` inside the same
+  transaction. `opts` supplies the actor for that entry:
+
+    * `:actor_id` — the acting API key id (optional).
+    * `:actor_label` — human-readable actor label (optional).
+    * `:actor_type` — defaults to `"api_key"`.
+    * `:metadata` — extra JSONB context (defaults to `%{}`).
 
   Returns `{:ok, entity}`, `{:error, :entity_limit}`, or `{:error, changeset}`.
   """
-  @spec create_entity(Ecto.UUID.t(), map()) ::
+  @spec create_entity(Ecto.UUID.t(), map(), keyword()) ::
           {:ok, Entity.t()} | {:error, :entity_limit | Ecto.Changeset.t()}
-  def create_entity(tenant_id, attrs) when is_binary(tenant_id) and is_map(attrs) do
+  def create_entity(tenant_id, attrs, opts \\ [])
+      when is_binary(tenant_id) and is_map(attrs) and is_list(opts) do
+    actor_id = Keyword.get(opts, :actor_id)
+    actor_label = Keyword.get(opts, :actor_label)
+    actor_type = Keyword.get(opts, :actor_type, "api_key")
+    metadata = Keyword.get(opts, :metadata, %{})
+
     Multi.new()
     |> Multi.run(:rls, fn _repo, _changes ->
       Repo.set_rls_context(tenant_id)
       {:ok, :ok}
     end)
+    |> Multi.run(:lock, fn repo, _changes ->
+      # Serialize concurrent same-tenant creates so the count-then-insert cap is
+      # race-free. Two-int form isolates this lock class by namespace.
+      key = :erlang.phash2(tenant_id)
+      repo.query!("SELECT pg_advisory_xact_lock($1, $2)", [@entity_cap_lock_ns, key])
+      {:ok, :ok}
+    end)
     |> Multi.run(:cap, fn repo, _changes ->
-      # The cap check shares this transaction with the insert. RLS scopes the
-      # count to this tenant.
-      if repo.aggregate(Entity, :count, :id) >= max_entities() do
+      # The cap check shares this transaction with the insert (under the advisory
+      # lock). RLS already scopes the count to this tenant; the explicit
+      # `tenant_id` predicate is defense-in-depth on the security-root count so a
+      # future reorder/removal of `:rls` can't silently make it cross-tenant.
+      count = repo.aggregate(from(e in Entity, where: e.tenant_id == ^tenant_id), :count, :id)
+
+      if count >= max_entities() do
         {:error, :entity_limit}
       else
         {:ok, :ok}
       end
     end)
     |> Multi.insert(:entity, Entity.create_changeset(%Entity{tenant_id: tenant_id}, attrs))
+    |> Audit.log_in_multi(:audit, fn %{entity: entity} ->
+      %{
+        tenant_id: tenant_id,
+        entity_type: "entity_definition",
+        entity_id: entity.id,
+        action: "created",
+        actor_type: actor_type,
+        actor_id: actor_id,
+        actor_label: actor_label,
+        metadata: metadata,
+        new_state: %{
+          "name" => entity.name,
+          "backing_source" => to_string(entity.backing_source),
+          "field_count" => length(entity.fields)
+        }
+      }
+    end)
     |> Repo.transaction()
     |> case do
       {:ok, %{entity: entity}} -> {:ok, entity}

--- a/lib/loopctl/context_retriever/registry.ex
+++ b/lib/loopctl/context_retriever/registry.ex
@@ -52,7 +52,11 @@ defmodule Loopctl.ContextRetriever.Registry do
   def for_tenant(tenant_id) when is_binary(tenant_id) do
     {:ok, entities} =
       Repo.with_tenant(tenant_id, fn ->
-        Repo.all(from(e in Entity, order_by: [asc: e.name]))
+        # RLS already scopes this read to the caller tenant; the explicit
+        # `tenant_id` predicate is defense-in-depth on this security-root read
+        # (mirrors the `:cap` step below) so a future reorder/removal of the RLS
+        # context can't silently make these definitions cross-tenant.
+        Repo.all(from(e in Entity, where: e.tenant_id == ^tenant_id, order_by: [asc: e.name]))
       end)
 
     entities
@@ -68,7 +72,10 @@ defmodule Loopctl.ContextRetriever.Registry do
   def get_entity(tenant_id, name) when is_binary(tenant_id) and is_binary(name) do
     {:ok, entity} =
       Repo.with_tenant(tenant_id, fn ->
-        Repo.get_by(Entity, name: name)
+        # Explicit `tenant_id` predicate as defense-in-depth alongside RLS (see
+        # `for_tenant/1`), so this security-root read stays single-tenant even if
+        # the RLS context were ever broken by a future refactor.
+        Repo.get_by(Entity, tenant_id: tenant_id, name: name)
       end)
 
     entity
@@ -113,7 +120,7 @@ defmodule Loopctl.ContextRetriever.Registry do
   Returns `{:ok, entity}`, `{:error, :entity_limit}`, or `{:error, changeset}`.
   """
   @spec create_entity(Ecto.UUID.t(), map(), keyword()) ::
-          {:ok, Entity.t()} | {:error, :entity_limit | Ecto.Changeset.t()}
+          {:ok, Entity.t()} | {:error, :entity_limit | Ecto.Changeset.t() | term()}
   def create_entity(tenant_id, attrs, opts \\ [])
       when is_binary(tenant_id) and is_map(attrs) and is_list(opts) do
     actor_id = Keyword.get(opts, :actor_id)
@@ -169,6 +176,13 @@ defmodule Loopctl.ContextRetriever.Registry do
       {:ok, %{entity: entity}} -> {:ok, entity}
       {:error, :cap, :entity_limit, _changes} -> {:error, :entity_limit}
       {:error, :entity, %Ecto.Changeset{} = changeset, _changes} -> {:error, changeset}
+      # Catch-all so any other failing step (notably `:audit` — e.g. a
+      # caller-supplied non-map `:metadata` invalidating the audit changeset, or a
+      # future required/validated audit field or added step) returns `{:error, _}`
+      # per the documented contract instead of raising `CaseClauseError`. The
+      # transaction still rolls back, so nothing is persisted. Mirrors
+      # `Loopctl.Memory.remember/2`'s trailing per-step error handling.
+      {:error, _step, reason, _changes} -> {:error, reason}
     end
   end
 

--- a/priv/repo/migrations/20260711120000_create_entity_definitions.exs
+++ b/priv/repo/migrations/20260711120000_create_entity_definitions.exs
@@ -1,0 +1,29 @@
+defmodule Loopctl.Repo.Migrations.CreateEntityDefinitions do
+  use Ecto.Migration
+  import Loopctl.Repo.RlsHelpers
+
+  # Epic 30 / US-30.1: the per-tenant table backing `Loopctl.ContextRetriever`.
+  # A tenant admin declares "entities" (name + typed fields + a loopctl-internal
+  # backing source) that later stories turn into a governed agent query surface.
+  # The SERVER column allowlist lives in code (`Loopctl.ContextRetriever.Entity`),
+  # not this table — `fields` stores only the tenant's declared, allowlist-validated
+  # field set. `enable_rls/1` applies ENABLE (not FORCE) row-level security so
+  # tenant A's definitions are invisible to tenant B.
+  def change do
+    create table(:entity_definitions, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :tenant_id, references(:tenants, type: :binary_id, on_delete: :delete_all), null: false
+
+      add :name, :string, null: false
+      add :backing_source, :string, null: false
+      add :fields, {:array, :map}, null: false, default: []
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    # Entity name is unique per tenant.
+    create unique_index(:entity_definitions, [:tenant_id, :name])
+
+    enable_rls(:entity_definitions)
+  end
+end

--- a/test/loopctl/context_retriever/entity_definitions_rollback_test.exs
+++ b/test/loopctl/context_retriever/entity_definitions_rollback_test.exs
@@ -1,0 +1,140 @@
+defmodule Loopctl.ContextRetriever.EntityDefinitionsRollbackTest do
+  @moduledoc """
+  US-30.1 / AC-30.1.7 / TC-30.1.5 — exercises the DOWN path of the
+  `entity_definitions` migration, asserting the reversibility invariant the AC
+  pins:
+
+    > The migration creates entity_definitions AND calls
+    > enable_rls(:entity_definitions); the down migration cleanly drops it.
+    > Migrations run green on a fresh DB and pass the rollback test.
+
+  The forward-migrated state is exercised by the schema/registry tests; this test
+  complements them by proving the reverse: after rolling the migration down the
+  `entity_definitions` table is gone, its `tenant_isolation` RLS policy is not
+  left orphaned, and re-applying `up` restores the forward state (table present,
+  RLS policy present again).
+
+  ## How the migration is driven
+
+  The migration files under `priv/repo/migrations` are not compiled into the app,
+  so the file is loaded here at runtime and driven with
+  `Ecto.Migration.Runner.run/9` DIRECTLY (the same entry point
+  `Ecto.Migrator.attempt/7` uses) rather than via `Ecto.Migrator.up/down`. The
+  latter runs each migration in a spawned `Task` under its own transaction/lock,
+  which cannot check out the single sandbox-owned connection; `Runner.run/9`
+  performs the operation in THIS process, so the DDL executes inside the sandbox
+  transaction and is rolled back on exit — leaving the real `entity_definitions`
+  table (and the suite DB) untouched.
+
+  The migration is a `change/0` migration: up runs `:forward`/`:change` and down
+  runs `:backward`/`:change` (reversed commands). `create table` auto-reverses to
+  a `DROP TABLE`, and `enable_rls/1` uses the two-arg `Ecto.Migration.execute/2`
+  with explicit DISABLE RLS / DROP POLICY / REVOKE down SQL, so the whole
+  migration is cleanly reversible.
+
+  ## Isolation
+
+  Runs `async: false` inside a manual sandbox owner so the whole down → assert →
+  up sequence lives in one transaction that is rolled back on exit; the
+  DROP/CREATE TABLE ACCESS EXCLUSIVE locks are released on rollback and never
+  escape this test.
+
+  `no orphaned enum type` is structurally guaranteed — `backing_source` is stored
+  as a `:string` column (`Ecto.Enum` values live in app code, not a Postgres enum
+  type), so the migration creates no enum type to drop or assert-absent.
+  """
+  use ExUnit.Case, async: false
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Ecto.Migration.Runner
+  alias Loopctl.AdminRepo
+
+  @version 20_260_711_120_000
+
+  @migrations_dir Path.join([File.cwd!(), "priv", "repo", "migrations"])
+  migration_file = Path.wildcard(Path.join(@migrations_dir, "#{@version}_*.exs")) |> hd()
+  Code.require_file(migration_file)
+
+  alias Loopctl.Repo.Migrations.CreateEntityDefinitions
+
+  setup do
+    pid = Sandbox.start_owner!(AdminRepo)
+    on_exit(fn -> Sandbox.stop_owner(pid) end)
+    :ok
+  end
+
+  # Drive the change/0 migration up/down in THIS process, mirroring
+  # Ecto.Migrator.attempt/7: :forward for up, :backward (reversed commands) for
+  # down.
+  defp migrate(:up) do
+    Runner.run(
+      AdminRepo,
+      AdminRepo.config(),
+      @version,
+      CreateEntityDefinitions,
+      :forward,
+      :change,
+      :up,
+      log: false
+    )
+  end
+
+  defp migrate(:down) do
+    Runner.run(
+      AdminRepo,
+      AdminRepo.config(),
+      @version,
+      CreateEntityDefinitions,
+      :backward,
+      :change,
+      :down,
+      log: false
+    )
+  end
+
+  defp relation_exists?(name) do
+    %{rows: [[exists]]} =
+      AdminRepo.query!(
+        """
+        SELECT EXISTS (
+          SELECT 1 FROM pg_class c
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+          WHERE c.relname = $1 AND n.nspname = 'public'
+        )
+        """,
+        [name]
+      )
+
+    exists
+  end
+
+  defp policy_present?(table) do
+    %{rows: [[count]]} =
+      AdminRepo.query!(
+        "SELECT count(*) FROM pg_policies WHERE tablename = $1 AND policyname = 'tenant_isolation'",
+        [table]
+      )
+
+    count > 0
+  end
+
+  test "down drops entity_definitions and its RLS policy with no orphans; up restores them" do
+    # Baseline: the forward-migrated table exists with its tenant_isolation policy.
+    assert relation_exists?("entity_definitions")
+    assert policy_present?("entity_definitions")
+
+    # Roll the migration back.
+    migrate(:down)
+
+    # The table (and its indexes, which drop with the table) is gone, and no
+    # orphaned tenant_isolation policy remains.
+    refute relation_exists?("entity_definitions")
+    refute policy_present?("entity_definitions")
+
+    # Re-applying up restores the full forward-migrated state.
+    migrate(:up)
+
+    assert relation_exists?("entity_definitions")
+    assert policy_present?("entity_definitions")
+  end
+end

--- a/test/loopctl/context_retriever/entity_test.exs
+++ b/test/loopctl/context_retriever/entity_test.exs
@@ -4,6 +4,13 @@ defmodule Loopctl.ContextRetriever.EntityTest do
   setup :verify_on_exit!
 
   alias Loopctl.ContextRetriever.Entity
+  alias Loopctl.Projects.Project
+  alias Loopctl.WorkBreakdown.Epic
+  alias Loopctl.WorkBreakdown.Story
+
+  # Maps each backing_source to the real Ecto schema whose columns it exposes, so
+  # the drift-guard test can prove every allowlisted atom is a live field.
+  @backing_schemas %{projects: Project, stories: Story, epics: Epic}
 
   # tenant_id is set programmatically on the struct, never cast — mirror the real
   # create path so unique_constraint and the changeset shape match production.
@@ -250,6 +257,99 @@ defmodule Loopctl.ContextRetriever.EntityTest do
 
     test "backing_sources/0 is loopctl-internal only" do
       assert Entity.backing_sources() == [:projects, :stories, :epics]
+    end
+  end
+
+  describe "column allowlist drift guard" do
+    # Positive guard binding @column_allowlist to the backing schemas' REAL
+    # fields. The existing introspection test is a NEGATIVE guard only (asserts
+    # sensitive columns are absent); this asserts every allowlisted atom is an
+    # actual field on its backing schema. If a backing column is later
+    # renamed/dropped, the allowlist would silently name a stale column and the
+    # US-30.3 executor would raise Ecto.QueryError at runtime — this fails at test
+    # time instead.
+    test "every allowlisted column is a real field on its backing schema" do
+      for {source, columns} <- Entity.column_allowlist() do
+        schema = Map.fetch!(@backing_schemas, source)
+        schema_fields = schema.__schema__(:fields)
+
+        stale = Enum.reject(columns, &(&1 in schema_fields))
+
+        assert stale == [],
+               "#{inspect(source)} allowlist names column(s) #{inspect(stale)} " <>
+                 "absent from #{inspect(schema)}.__schema__(:fields)"
+      end
+    end
+
+    test "the drift guard covers every backing source" do
+      assert Map.keys(@backing_schemas) |> Enum.sort() ==
+               Entity.backing_sources() |> Enum.sort()
+    end
+  end
+
+  describe "create_changeset/2 — fields payload bounds" do
+    test "rejects an entity that declares more than the max number of fields" do
+      # 60 well-shaped field maps (> the 50 cap). These names are not all
+      # allowlisted, but the length cap fires regardless and its message is
+      # distinct from the per-element column errors, so we assert on it directly.
+      too_many =
+        Enum.map(1..60, fn i ->
+          %{name: "f_#{i}", type: :string, filterable: true, searchable: true}
+        end)
+
+      cs =
+        changeset(%{
+          name: "story",
+          backing_source: :stories,
+          fields: too_many
+        })
+
+      refute cs.valid?
+      assert Enum.any?(errors_on(cs).fields, &(&1 =~ "should have at most"))
+    end
+
+    test "strips unsanctioned keys from each field map before storage" do
+      cs =
+        changeset(%{
+          name: "story",
+          backing_source: :stories,
+          fields: [
+            %{
+              name: "title",
+              type: :string,
+              filterable: true,
+              searchable: true,
+              blob: %{"deeply" => %{"nested" => "junk"}}
+            }
+          ]
+        })
+
+      assert cs.valid?
+      [field] = Ecto.Changeset.get_field(cs, :fields)
+      refute Map.has_key?(field, :blob)
+      refute Map.has_key?(field, "blob")
+      assert field[:name] == "title" || field["name"] == "title"
+    end
+
+    test "strips unsanctioned keys from string-keyed field maps" do
+      cs =
+        changeset(%{
+          "name" => "story",
+          "backing_source" => "stories",
+          "fields" => [
+            %{
+              "name" => "title",
+              "type" => "string",
+              "filterable" => true,
+              "searchable" => true,
+              "blob" => "megabytes"
+            }
+          ]
+        })
+
+      assert cs.valid?
+      [field] = Ecto.Changeset.get_field(cs, :fields)
+      refute Map.has_key?(field, "blob")
     end
   end
 end

--- a/test/loopctl/context_retriever/entity_test.exs
+++ b/test/loopctl/context_retriever/entity_test.exs
@@ -1,0 +1,202 @@
+defmodule Loopctl.ContextRetriever.EntityTest do
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.ContextRetriever.Entity
+
+  # tenant_id is set programmatically on the struct, never cast — mirror the real
+  # create path so unique_constraint and the changeset shape match production.
+  defp changeset(attrs) do
+    %Entity{tenant_id: Ecto.UUID.generate()}
+    |> Entity.create_changeset(attrs)
+  end
+
+  describe "create_changeset/2 — valid" do
+    test "accepts an allowlisted field for the backing source" do
+      cs =
+        changeset(%{
+          name: "story",
+          backing_source: :stories,
+          fields: [%{name: "title", type: :string, filterable: true, searchable: true}]
+        })
+
+      assert cs.valid?
+    end
+
+    test "accepts multiple allowlisted fields across sources" do
+      cs =
+        changeset(%{
+          name: "project_view",
+          backing_source: :projects,
+          fields: [
+            %{name: "name", type: :string, filterable: true, searchable: true},
+            %{name: "status", type: :string, filterable: true, searchable: false}
+          ]
+        })
+
+      assert cs.valid?
+    end
+
+    test "accepts string-keyed field maps (DB round-trip shape)" do
+      cs =
+        changeset(%{
+          "name" => "story",
+          "backing_source" => "stories",
+          "fields" => [
+            %{"name" => "title", "type" => "string", "filterable" => true, "searchable" => false}
+          ]
+        })
+
+      assert cs.valid?
+    end
+  end
+
+  describe "create_changeset/2 — security: column allowlist + identifier + enum" do
+    test "rejects a field whose name is not in the source column allowlist" do
+      # `tenant_id` is deliberately NOT in the stories allowlist — declaring it
+      # would let the executor exfiltrate the isolation column.
+      cs =
+        changeset(%{
+          name: "story",
+          backing_source: :stories,
+          fields: [%{name: "tenant_id", type: :string, filterable: true, searchable: false}]
+        })
+
+      refute cs.valid?
+      assert Enum.any?(errors_on(cs).fields, &(&1 =~ "not an allowed column"))
+    end
+
+    test "rejects an unsanctioned column (metadata jsonb blob)" do
+      cs =
+        changeset(%{
+          name: "story",
+          backing_source: :stories,
+          fields: [%{name: "metadata", type: :string, filterable: false, searchable: false}]
+        })
+
+      refute cs.valid?
+      assert Enum.any?(errors_on(cs).fields, &(&1 =~ "not an allowed column"))
+    end
+
+    test "rejects a custody/dispatch column" do
+      cs =
+        changeset(%{
+          name: "story",
+          backing_source: :stories,
+          fields: [
+            %{
+              name: "implementer_dispatch_id",
+              type: :string,
+              filterable: false,
+              searchable: false
+            }
+          ]
+        })
+
+      refute cs.valid?
+      assert Enum.any?(errors_on(cs).fields, &(&1 =~ "not an allowed column"))
+    end
+
+    test "rejects a field name that is not a safe identifier (SQL injection shape)" do
+      cs =
+        changeset(%{
+          name: "story",
+          backing_source: :stories,
+          fields: [%{name: "status; DROP", type: :string, filterable: true, searchable: false}]
+        })
+
+      refute cs.valid?
+      assert Enum.any?(errors_on(cs).fields, &(&1 =~ "not a safe identifier"))
+    end
+
+    test "rejects an unknown backing_source (Ecto.Enum)" do
+      cs =
+        changeset(%{
+          name: "story",
+          backing_source: :tenant_supplied,
+          fields: [%{name: "status", type: :string, filterable: true, searchable: false}]
+        })
+
+      refute cs.valid?
+      assert Map.has_key?(errors_on(cs), :backing_source)
+    end
+
+    test "rejects an unknown field type" do
+      cs =
+        changeset(%{
+          name: "story",
+          backing_source: :stories,
+          fields: [%{name: "title", type: :jsonb, filterable: true, searchable: false}]
+        })
+
+      refute cs.valid?
+      assert Enum.any?(errors_on(cs).fields, &(&1 =~ "is not one of"))
+    end
+
+    test "rejects non-boolean filterable/searchable" do
+      cs =
+        changeset(%{
+          name: "story",
+          backing_source: :stories,
+          fields: [%{name: "title", type: :string, filterable: "yes", searchable: nil}]
+        })
+
+      refute cs.valid?
+      assert Enum.any?(errors_on(cs).fields, &(&1 =~ "filterable must be a boolean"))
+      assert Enum.any?(errors_on(cs).fields, &(&1 =~ "searchable must be a boolean"))
+    end
+
+    test "rejects a field element that is not a map" do
+      cs =
+        changeset(%{
+          name: "story",
+          backing_source: :stories,
+          fields: ["status"]
+        })
+
+      refute cs.valid?
+      assert Map.has_key?(errors_on(cs), :fields)
+    end
+
+    test "rejects a non-identifier entity name" do
+      cs =
+        changeset(%{
+          name: "Bad Name!",
+          backing_source: :stories,
+          fields: [%{name: "title", type: :string, filterable: true, searchable: false}]
+        })
+
+      refute cs.valid?
+      assert Map.has_key?(errors_on(cs), :name)
+    end
+
+    test "requires name and backing_source" do
+      cs = changeset(%{})
+
+      refute cs.valid?
+      errors = errors_on(cs)
+      assert Map.has_key?(errors, :name)
+      assert Map.has_key?(errors, :backing_source)
+    end
+  end
+
+  describe "introspection helpers" do
+    test "column_allowlist/0 excludes isolation and custody columns" do
+      allow = Entity.column_allowlist()
+
+      refute :tenant_id in allow.stories
+      refute :metadata in allow.stories
+      refute :implementer_dispatch_id in allow.stories
+      assert :agent_status in allow.stories
+      # `projects` exposes its own `status`, `stories` deliberately does not
+      # (only `agent_status`/`verified_status`).
+      assert :status in allow.projects
+      refute :status in allow.stories
+    end
+
+    test "backing_sources/0 is loopctl-internal only" do
+      assert Entity.backing_sources() == [:projects, :stories, :epics]
+    end
+  end
+end

--- a/test/loopctl/context_retriever/entity_test.exs
+++ b/test/loopctl/context_retriever/entity_test.exs
@@ -159,6 +159,59 @@ defmodule Loopctl.ContextRetriever.EntityTest do
       assert Map.has_key?(errors_on(cs), :fields)
     end
 
+    test "rejects an entity that declares zero fields (empty list)" do
+      cs =
+        changeset(%{
+          name: "story",
+          backing_source: :stories,
+          fields: []
+        })
+
+      refute cs.valid?
+      assert Map.has_key?(errors_on(cs), :fields)
+    end
+
+    test "rejects an entity with fields omitted" do
+      cs =
+        changeset(%{
+          name: "story",
+          backing_source: :stories
+        })
+
+      refute cs.valid?
+      assert Map.has_key?(errors_on(cs), :fields)
+    end
+
+    test "rejects duplicate field names" do
+      cs =
+        changeset(%{
+          name: "story",
+          backing_source: :stories,
+          fields: [
+            %{name: "title", type: :string, filterable: true, searchable: true},
+            %{name: "title", type: :string, filterable: false, searchable: false}
+          ]
+        })
+
+      refute cs.valid?
+      assert Map.has_key?(errors_on(cs), :fields)
+    end
+
+    test "rejects duplicate field names across string/atom key shapes" do
+      cs =
+        changeset(%{
+          name: "story",
+          backing_source: :stories,
+          fields: [
+            %{name: "title", type: :string, filterable: true, searchable: true},
+            %{"name" => "title", "type" => "string", "filterable" => false, "searchable" => false}
+          ]
+        })
+
+      refute cs.valid?
+      assert Map.has_key?(errors_on(cs), :fields)
+    end
+
     test "rejects a non-identifier entity name" do
       cs =
         changeset(%{

--- a/test/loopctl/context_retriever/registry_test.exs
+++ b/test/loopctl/context_retriever/registry_test.exs
@@ -10,6 +10,9 @@ defmodule Loopctl.ContextRetriever.RegistryTest do
 
   setup :verify_on_exit!
 
+  import Ecto.Query
+
+  alias Loopctl.Audit.AuditLog
   alias Loopctl.ContextRetriever.Entity
   alias Loopctl.ContextRetriever.Registry
   alias Loopctl.Tenants.Tenant
@@ -112,6 +115,34 @@ defmodule Loopctl.ContextRetriever.RegistryTest do
     test "get_entity/2 returns nil for an unknown name" do
       tenant = repo_tenant()
       assert Registry.get_entity(tenant.id, "nope") == nil
+    end
+
+    test "writes an audit_log entry recording the security-root creation" do
+      tenant = repo_tenant()
+      actor_id = Ecto.UUID.generate()
+
+      assert {:ok, entity} =
+               Registry.create_entity(
+                 tenant.id,
+                 %{name: "story", backing_source: :stories, fields: @valid_fields},
+                 actor_id: actor_id,
+                 actor_label: "user:admin"
+               )
+
+      # Read the audit row back through the SAME RLS Repo the Registry writes on
+      # (the AdminRepo runs on a separate sandbox connection and cannot see the
+      # row). RLS scopes the read to this tenant.
+      {:ok, [audit]} =
+        Repo.with_tenant(tenant.id, fn ->
+          Repo.all(from a in AuditLog, where: a.entity_type == "entity_definition")
+        end)
+
+      assert audit.entity_id == entity.id
+      assert audit.action == "created"
+      assert audit.actor_id == actor_id
+      assert audit.actor_label == "user:admin"
+      assert audit.new_state["name"] == "story"
+      assert audit.new_state["backing_source"] == "stories"
     end
   end
 

--- a/test/loopctl/context_retriever/registry_test.exs
+++ b/test/loopctl/context_retriever/registry_test.exs
@@ -1,0 +1,206 @@
+defmodule Loopctl.ContextRetriever.RegistryTest do
+  # async: false — the Registry reads/writes through `Loopctl.Repo.with_tenant`
+  # (RLS-enforced Repo transactions with `SET LOCAL ROLE loopctl_app`), which
+  # needs shared sandbox mode and same-connection seeding (see `repo_tenant/0`).
+  # This mirrors the documented RLS exception in `default_archival_test.exs` and
+  # `rls_test.exs`. Because the isolation assertion runs under the NON-owner app
+  # role (not a superuser/owner connection that would bypass ENABLE-only RLS), it
+  # actually proves tenant isolation rather than silently passing (AC-30.1.4).
+  use Loopctl.DataCase, async: false
+
+  setup :verify_on_exit!
+
+  alias Loopctl.ContextRetriever.Entity
+  alias Loopctl.ContextRetriever.Registry
+  alias Loopctl.Tenants.Tenant
+
+  @valid_fields [%{name: "title", type: :string, filterable: true, searchable: true}]
+
+  # Seed the tenant via `Repo` (not the AdminRepo-backed `fixture(:tenant)`) so it
+  # lives on the SAME DB connection as the `Repo.with_tenant` transactions the
+  # Registry runs — otherwise the `entity_definitions.tenant_id` FK cannot see it.
+  # This mirrors `default_archival_test.exs`'s RLS-test seeding pattern.
+  defp repo_tenant do
+    seq = System.unique_integer([:positive])
+
+    %Tenant{}
+    |> Tenant.create_changeset(%{
+      name: "Test Tenant #{seq}",
+      slug: "test-tenant-#{seq}",
+      email: "test-#{seq}@example.com",
+      status: :active
+    })
+    |> Repo.insert!()
+  end
+
+  describe "create_entity/2 + get_entity/2" do
+    test "creates a definition and reads it back within the tenant" do
+      tenant = repo_tenant()
+
+      assert {:ok, %Entity{} = entity} =
+               Registry.create_entity(tenant.id, %{
+                 name: "story",
+                 backing_source: :stories,
+                 fields: @valid_fields
+               })
+
+      assert entity.tenant_id == tenant.id
+      assert entity.name == "story"
+      assert entity.backing_source == :stories
+
+      fetched = Registry.get_entity(tenant.id, "story")
+      assert fetched.id == entity.id
+      # Round-trips through jsonb as string-keyed maps with string values.
+      assert [field] = fetched.fields
+      assert field["name"] == "title"
+      assert field["type"] == "string"
+      assert field["filterable"] == true
+      assert field["searchable"] == true
+    end
+
+    test "the entity name is admin-chosen and independent of backing_source" do
+      tenant = repo_tenant()
+
+      assert {:ok, entity} =
+               Registry.create_entity(tenant.id, %{
+                 name: "story",
+                 backing_source: :projects,
+                 fields: [%{name: "name", type: :string, filterable: true, searchable: true}]
+               })
+
+      assert entity.name == "story"
+      assert entity.backing_source == :projects
+    end
+
+    test "enforces unique name per tenant" do
+      tenant = repo_tenant()
+
+      assert {:ok, _} =
+               Registry.create_entity(tenant.id, %{
+                 name: "story",
+                 backing_source: :stories,
+                 fields: @valid_fields
+               })
+
+      assert {:error, changeset} =
+               Registry.create_entity(tenant.id, %{
+                 name: "story",
+                 backing_source: :epics,
+                 fields: [%{name: "title", type: :string, filterable: true, searchable: true}]
+               })
+
+      refute changeset.valid?
+      assert Map.has_key?(errors_on(changeset), :name)
+    end
+
+    test "rejects an invalid definition via the changeset" do
+      tenant = repo_tenant()
+
+      assert {:error, changeset} =
+               Registry.create_entity(tenant.id, %{
+                 name: "story",
+                 backing_source: :stories,
+                 fields: [
+                   %{name: "tenant_id", type: :string, filterable: true, searchable: false}
+                 ]
+               })
+
+      refute changeset.valid?
+      assert Map.has_key?(errors_on(changeset), :fields)
+    end
+
+    test "get_entity/2 returns nil for an unknown name" do
+      tenant = repo_tenant()
+      assert Registry.get_entity(tenant.id, "nope") == nil
+    end
+  end
+
+  describe "for_tenant/1 — tenant isolation (AC-30.1.3)" do
+    test "a definition from tenant A is invisible to tenant B" do
+      tenant_a = repo_tenant()
+      tenant_b = repo_tenant()
+
+      assert {:ok, entity_a} =
+               Registry.create_entity(tenant_a.id, %{
+                 name: "story",
+                 backing_source: :stories,
+                 fields: @valid_fields
+               })
+
+      # Tenant A sees exactly its one definition.
+      assert [seen] = Registry.for_tenant(tenant_a.id)
+      assert seen.id == entity_a.id
+
+      # Tenant B sees none of tenant A's definitions (RLS under the app role).
+      assert Registry.for_tenant(tenant_b.id) == []
+      assert Registry.get_entity(tenant_b.id, "story") == nil
+    end
+
+    test "returns definitions ordered by name" do
+      tenant = repo_tenant()
+
+      for name <- ["zeta", "alpha", "mid"] do
+        {:ok, _} =
+          Registry.create_entity(tenant.id, %{
+            name: name,
+            backing_source: :stories,
+            fields: @valid_fields
+          })
+      end
+
+      assert Registry.for_tenant(tenant.id) |> Enum.map(& &1.name) == ["alpha", "mid", "zeta"]
+    end
+  end
+
+  describe "create_entity/2 — per-tenant cap (AC-30.1.5)" do
+    test "over-cap creation returns {:error, :entity_limit} and inserts no row" do
+      # config/test.exs sets :max_entity_definitions_per_tenant to 3.
+      cap = Registry.max_entities()
+      tenant = repo_tenant()
+
+      for i <- 1..cap do
+        assert {:ok, _} =
+                 Registry.create_entity(tenant.id, %{
+                   name: "entity_#{i}",
+                   backing_source: :stories,
+                   fields: @valid_fields
+                 })
+      end
+
+      assert {:error, :entity_limit} =
+               Registry.create_entity(tenant.id, %{
+                 name: "one_too_many",
+                 backing_source: :stories,
+                 fields: @valid_fields
+               })
+
+      # No row was inserted for the over-cap create.
+      names = Registry.for_tenant(tenant.id) |> Enum.map(& &1.name)
+      assert length(names) == cap
+      refute "one_too_many" in names
+    end
+
+    test "the cap is per-tenant, not global" do
+      cap = Registry.max_entities()
+      tenant_a = repo_tenant()
+      tenant_b = repo_tenant()
+
+      for i <- 1..cap do
+        {:ok, _} =
+          Registry.create_entity(tenant_a.id, %{
+            name: "a_#{i}",
+            backing_source: :stories,
+            fields: @valid_fields
+          })
+      end
+
+      # Tenant B still has full headroom despite tenant A being at cap.
+      assert {:ok, _} =
+               Registry.create_entity(tenant_b.id, %{
+                 name: "b_1",
+                 backing_source: :stories,
+                 fields: @valid_fields
+               })
+    end
+  end
+end

--- a/test/loopctl/context_retriever/registry_test.exs
+++ b/test/loopctl/context_retriever/registry_test.exs
@@ -144,6 +144,25 @@ defmodule Loopctl.ContextRetriever.RegistryTest do
       assert audit.new_state["name"] == "story"
       assert audit.new_state["backing_source"] == "stories"
     end
+
+    test "an invalid audit step returns {:error, _} rather than raising" do
+      # A non-map `:metadata` opt fails the audit changeset's `:map` cast, so the
+      # `:audit` Multi step returns `{:error, :audit, changeset, _}`. That must map
+      # to the documented `{:error, _}` contract (via the catch-all clause), NOT a
+      # CaseClauseError, and the transaction must roll back the entity insert.
+      tenant = repo_tenant()
+
+      assert {:error, %Ecto.Changeset{} = changeset} =
+               Registry.create_entity(
+                 tenant.id,
+                 %{name: "story", backing_source: :stories, fields: @valid_fields},
+                 metadata: "not-a-map"
+               )
+
+      refute changeset.valid?
+      # Nothing persisted — the whole transaction rolled back.
+      assert Registry.for_tenant(tenant.id) == []
+    end
   end
 
   describe "for_tenant/1 — tenant isolation (AC-30.1.3)" do

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -16,6 +16,7 @@ defmodule Loopctl.Fixtures do
   alias Loopctl.Artifacts.VerificationResult
   alias Loopctl.Audit.AuditLog
   alias Loopctl.Auth
+  alias Loopctl.ContextRetriever.Entity
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.ArticleAccessEvent
   alias Loopctl.Knowledge.ArticleLink
@@ -197,6 +198,19 @@ defmodule Loopctl.Fixtures do
         access_type: "get",
         metadata: %{},
         accessed_at: DateTime.utc_now()
+      },
+      Enum.into(attrs, %{})
+    )
+  end
+
+  def build(:entity, attrs) do
+    seq = System.unique_integer([:positive])
+
+    Map.merge(
+      %{
+        name: "entity_#{seq}",
+        backing_source: :stories,
+        fields: [%{name: "title", type: :string, filterable: true, searchable: true}]
       },
       Enum.into(attrs, %{})
     )
@@ -606,6 +620,28 @@ defmodule Loopctl.Fixtures do
     changeset =
       %Article{tenant_id: tenant_id, project_id: project_id}
       |> Article.create_changeset(data)
+
+    AdminRepo.insert!(changeset)
+  end
+
+  def fixture(:entity, attrs) do
+    attrs = Enum.into(attrs, %{})
+
+    {tenant_id, attrs} =
+      case Map.get(attrs, :tenant_id) do
+        nil ->
+          tenant = fixture(:tenant)
+          {tenant.id, Map.put(attrs, :tenant_id, tenant.id)}
+
+        tid ->
+          {tid, attrs}
+      end
+
+    data = build(:entity, attrs)
+
+    changeset =
+      %Entity{tenant_id: tenant_id}
+      |> Entity.create_changeset(data)
 
     AdminRepo.insert!(changeset)
   end


### PR DESCRIPTION
## US-30.1 — Entity-definition schema + migration + per-tenant registry

Foundation of Epic 30 (Context Retriever). Adds a per-tenant `entity_definitions`
table + registry so a tenant admin (role >= user) can declare queryable
"entities" (name + typed fields + a loopctl-internal backing source) that later
stories (US-30.2 generator, US-30.3 executor) turn into a governed agent query
surface over structured records (projects/stories/epics).

### Security root
The entity definition IS the executor's field allowlist and is attacker-authored.
A **SERVER-defined per-backing-source column allowlist** (a code constant in
`Loopctl.ContextRetriever.Entity`) bounds which columns any entity may declare, so
an admin cannot declare `tenant_id`, `metadata` jsonb, or custody/dispatch/audit
columns and exfiltrate them through "declared-fields-only" shaping. Field
validation also enforces a safe-identifier regex, a fixed type set, and boolean
`filterable`/`searchable`. Field `type`/`name` are never `String.to_atom`'d.

### What's here
- `Loopctl.ContextRetriever.Entity` — schema, `create_changeset/2`,
  `@column_allowlist` (+ introspection helpers).
- `Loopctl.ContextRetriever.Registry` — `for_tenant/1`, `get_entity/2`,
  `create_entity/2`. Reads via `Repo.with_tenant`; create runs as an `Ecto.Multi`
  (RLS step + per-tenant cap + insert) so the `unique_constraint` surfaces as a
  changeset error instead of poisoning the transaction. Over-cap create returns
  `{:error, :entity_limit}` with no insert.
- Migration `20260711120000_create_entity_definitions` — creates the table,
  unique index `(tenant_id, name)`, and `enable_rls/1` (ENABLE, reversible up/down).
- Config `:max_entity_definitions_per_tenant` (50 default; 3 in test).
- Relationships are explicitly OUT of scope for v1 — nothing is persisted; a
  module-doc note records the future per-join tenant-scoping + target-entity
  allowlist requirement.

### Acceptance criteria
All of AC-30.1.1 … AC-30.1.7 met.

### Tests
- `entity_test.exs` (async) — changeset unit tests: allowlist rejection
  (tenant_id / metadata / custody column), identifier-regex rejection, unknown
  enum/type, non-boolean flags, valid cases (atom- and string-keyed).
- `registry_test.exs` (async: false, documented RLS exception) — create/read,
  unique-per-tenant, tenant isolation **under the non-owner `loopctl_app` role**,
  ordering, and the per-tenant cap (incl. per-tenant-not-global).
- Full gate green locally: `mix precommit` (compile, format, credo --strict,
  sobelow, dialyzer, 3996 tests 0 failures).

Part of #309 (Epic 30 — first story; US-30.2/US-30.3 follow)
