### PR TITLE
chore(mcp): publish knowledge_update — bump loopctl-mcp-server to 2.39.0 (#331)

### DIFF
--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.38.0",
+  "version": "2.39.0",
   "description": "MCP server for loopctl — structural trust for AI development loops",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
#333 added the `knowledge_update` MCP tool (agent-role in-place article edit) + the archive/delete/supersede/merge role loosening, but did not bump `mcp-server/package.json`, so the auto-publish workflow never fired and npm still serves 2.38.0 without the new tool. This bumps the version 2.38.0 → 2.39.0 to trigger `mcp-autopublish.yml` and ship `knowledge_update` (and the archive/delete agent-role changes) to `npx loopctl-mcp-server` users. Code-only version bump; no behavior change beyond publishing.