### PR TITLE
Tool generator: entity definition -> filter + full-text tool specs (US-30.2)

### DIFF
--- a/lib/loopctl/context_retriever/entity.ex
+++ b/lib/loopctl/context_retriever/entity.ex
@@ -216,8 +216,13 @@ defmodule Loopctl.ContextRetriever.Entity do
   contract — `Loopctl.ContextRetriever.ToolGenerator` (US-30.2) consumes it
   rather than re-implementing its own copy, so both interpretations of this
   security-root field-map shape stay in lockstep.
+
+  `key` is intentionally general (`String.t()`), but only the four sanctioned
+  field keys (`#{inspect(@sanctioned_field_key_strings)}`) have dedicated
+  reading logic; any other key safely returns `nil` rather than raising, so
+  callers can pass an arbitrary key without first checking membership.
   """
-  @spec field_value(map(), String.t()) :: term()
+  @spec field_value(map(), String.t()) :: term() | nil
   def field_value(map, key), do: value(map, key)
 
   @doc """
@@ -397,6 +402,13 @@ defmodule Loopctl.ContextRetriever.Entity do
   defp value(map, "type"), do: map["type"] || map[:type]
   defp value(map, "filterable"), do: fetch_bool_key(map, "filterable", :filterable)
   defp value(map, "searchable"), do: fetch_bool_key(map, "searchable", :searchable)
+
+  # Any key outside the four sanctioned field keys has no dedicated reading
+  # logic (there is nothing else stored on a declared field element — see
+  # `take_sanctioned_keys/1`), so it safely reads as absent rather than
+  # raising. This keeps `field_value/2`'s public `String.t()` contract honest
+  # for ANY key, not just the four literals matched above.
+  defp value(_map, _key), do: nil
 
   # For boolean keys, `||` would swallow a legitimate `false`, so fetch explicitly.
   defp fetch_bool_key(map, string_key, atom_key) do

--- a/lib/loopctl/context_retriever/entity.ex
+++ b/lib/loopctl/context_retriever/entity.ex
@@ -33,6 +33,15 @@ defmodule Loopctl.ContextRetriever.Entity do
     `%{"name" => ..., "type" => ..., "filterable" => bool, "searchable" => bool}`
     with per-element validation.
 
+  ## Reading a field element
+
+  Field elements may be atom-keyed (build path) or string-keyed (DB
+  round-trip). `field_value/2`, `field_string_value/2`, `filterable?/1`, and
+  `searchable?/1` are the canonical, public readers for that dual-key-shape
+  contract — other modules that need to inspect a declared field element
+  (e.g. `Loopctl.ContextRetriever.ToolGenerator`) MUST use these instead of
+  re-implementing their own key-shape handling.
+
   ## Relationships are OUT of scope for v1 (AC-30.1.6)
 
   Relationships / joins between entities are explicitly NOT persisted in v1 — no
@@ -197,6 +206,35 @@ defmodule Loopctl.ContextRetriever.Entity do
   """
   @spec column_allowlist() :: %{atom() => [atom()]}
   def column_allowlist, do: @column_allowlist
+
+  @doc """
+  Reads a declared field element's raw value under `key`.
+
+  `entity.fields` elements may be atom-keyed (build path, e.g. `%Entity{}`
+  literals in tests) or string-keyed (DB round-trip, since `fields` is
+  `{:array, :map}`). This is THE canonical reader for that dual-key-shape
+  contract — `Loopctl.ContextRetriever.ToolGenerator` (US-30.2) consumes it
+  rather than re-implementing its own copy, so both interpretations of this
+  security-root field-map shape stay in lockstep.
+  """
+  @spec field_value(map(), String.t()) :: term()
+  def field_value(map, key), do: value(map, key)
+
+  @doc """
+  Reads a declared field element's value under `key`, coerced to a string.
+
+  Returns `nil` if the value is absent or not string/atom.
+  """
+  @spec field_string_value(map(), String.t()) :: String.t() | nil
+  def field_string_value(map, key), do: string_value(map, key)
+
+  @doc "Whether a declared field element has `filterable: true`."
+  @spec filterable?(map()) :: boolean()
+  def filterable?(field), do: field_value(field, "filterable") == true
+
+  @doc "Whether a declared field element has `searchable: true`."
+  @spec searchable?(map()) :: boolean()
+  def searchable?(field), do: field_value(field, "searchable") == true
 
   # --- Private helpers ---
 
@@ -379,6 +417,7 @@ defmodule Loopctl.ContextRetriever.Entity do
   defp string_value(map, key) do
     case value(map, key) do
       v when is_binary(v) -> v
+      v when is_atom(v) and not is_nil(v) -> Atom.to_string(v)
       _ -> nil
     end
   end

--- a/lib/loopctl/context_retriever/tool_generator.ex
+++ b/lib/loopctl/context_retriever/tool_generator.ex
@@ -66,11 +66,55 @@ defmodule Loopctl.ContextRetriever.ToolGenerator do
 
   @tool_prefix "cr_"
 
-  # Text-like field types eligible to back the search tool (AC-30.2.1: "searchable
-  # TEXT field", not merely "searchable field"). Kept as a fixed set, compared
-  # against the declared `type` string, so a non-text column (e.g. an integer
-  # marked searchable) never triggers a meaningless full-text search tool.
-  @text_types ~w(string)
+  # Field-type vocabulary lives authoritatively on `Entity.field_types/0`. Every
+  # type declared there MUST be explicitly classified here as `:text` (eligible
+  # to back the search tool, AC-30.2.1: "searchable TEXT field", not merely
+  # "searchable field") or `:non_text` — see the compile-time guard below.
+  # Classifying is a deliberate call per type (e.g. an integer marked
+  # searchable never triggers a meaningless full-text search tool), so this map
+  # is hand-maintained, NOT derived from the type's JSON Schema shape.
+  @field_type_classification %{
+    "string" => :text,
+    "integer" => :non_text,
+    "boolean" => :non_text,
+    "float" => :non_text,
+    "datetime" => :non_text
+  }
+
+  @text_types @field_type_classification
+              |> Enum.filter(fn {_type, kind} -> kind == :text end)
+              |> Enum.map(fn {type, _kind} -> type end)
+
+  # Explicit JSON Schema mapping per `Entity.field_types/0` member. See the
+  # compile-time guard below — this map, like `@field_type_classification`,
+  # must cover every Entity-declared field type.
+  @json_schema_types %{
+    "string" => %{"type" => "string"},
+    "integer" => %{"type" => "integer"},
+    "boolean" => %{"type" => "boolean"},
+    "float" => %{"type" => "number"},
+    "datetime" => %{"type" => "string", "format" => "date-time"}
+  }
+
+  # Compile-time guard: if a future `Entity.@field_types` addition (e.g.
+  # `"decimal"` or `"text"`) is left unclassified/unmapped here, compilation
+  # fails loudly instead of the generator silently falling back to
+  # `%{"type" => "string"}` (json_schema_type/1) or silently excluding the new
+  # type from the search tool (@text_types) — the schema-drift bug this guard
+  # closes.
+  unmapped_field_types =
+    Enum.uniq(
+      (Entity.field_types() -- Map.keys(@field_type_classification)) ++
+        (Entity.field_types() -- Map.keys(@json_schema_types))
+    )
+
+  if unmapped_field_types != [] do
+    raise CompileError,
+      description:
+        "Loopctl.ContextRetriever.ToolGenerator is missing a @field_type_classification and/or " <>
+          "@json_schema_types entry for Entity field type(s) #{inspect(unmapped_field_types)}. " <>
+          "Add explicit entries for it before compiling."
+  end
 
   @doc """
   Returns the deterministic list of tool specs authorized by `entity`.
@@ -166,12 +210,12 @@ defmodule Loopctl.ContextRetriever.ToolGenerator do
 
   # --- Field-type -> JSON Schema mapping ---
 
-  defp json_schema_type("string"), do: %{"type" => "string"}
-  defp json_schema_type("integer"), do: %{"type" => "integer"}
-  defp json_schema_type("boolean"), do: %{"type" => "boolean"}
-  defp json_schema_type("float"), do: %{"type" => "number"}
-  defp json_schema_type("datetime"), do: %{"type" => "string", "format" => "date-time"}
-  defp json_schema_type(_other), do: %{"type" => "string"}
+  # Derived from `@json_schema_types`, guarded at compile time (above) to cover
+  # every `Entity.field_types/0` member. The fallback only fires for a type
+  # string that isn't one of `Entity.field_types/0` at all (e.g. malformed
+  # data) — never for a real, unmapped Entity type, since that case is now a
+  # compile error instead of a silent runtime fallback.
+  defp json_schema_type(type), do: Map.get(@json_schema_types, type, %{"type" => "string"})
 
   # --- Predicates ---
 

--- a/lib/loopctl/context_retriever/tool_generator.ex
+++ b/lib/loopctl/context_retriever/tool_generator.ex
@@ -1,0 +1,188 @@
+defmodule Loopctl.ContextRetriever.ToolGenerator do
+  @moduledoc """
+  Pure generator turning an `%Loopctl.ContextRetriever.Entity{}` definition into
+  the list of agent tool specs it authorizes (Epic 30, Context Retriever).
+
+  This is the bridge between a persisted entity definition (US-30.1) and the
+  agent tool surface later consumed by the executor (US-30.3), the API
+  (US-30.4), and MCP dynamic listing (US-30.5). `specs_for/1` defines the spec
+  SHAPE those all agree on — no DB access, no side effects, no process: same
+  entity in, same list of tool spec maps out, every time.
+
+  ## Generated tools
+
+    * One `cr_filter_<entity>_by_<field>` tool per declared field whose
+      `filterable` is `true`. Its input schema types the field param from the
+      declared field `type`, plus `limit`/`cursor` pagination params.
+    * One `cr_search_<entity>` tool, emitted iff the entity has at least one
+      field that is BOTH `searchable` AND a text-like `type` (currently
+      `string` — see `@text_types`). A `searchable` field of a non-text type
+      (e.g. an integer marked searchable) does not by itself trigger the
+      search tool; the AC-30.2.1 restriction is "searchable TEXT field", not
+      merely "searchable field", since a full-text search over a non-text
+      column is meaningless to the US-30.3 executor. Its input schema takes a
+      `query` string plus `limit`/`cursor` pagination params, and searches
+      across ALL of the entity's searchable TEXT fields collectively (the tool
+      is per-entity, not per-field).
+
+  A field that is neither `filterable` nor (searchable AND text-typed)
+  produces no tool at all — the generated surface is exactly the allowlist,
+  nothing more (AC-30.2.4).
+
+  ## The `cr_` prefix
+
+  Tool names are prefixed `cr_` (context-retriever) so they can never collide
+  with loopctl's static MCP tools, none of which start with `cr_`/`filter_`/
+  `search_` (AC-30.2.3).
+
+  ## Metadata is the executor's dispatch contract
+
+  Every spec carries a `metadata` map (`entity`, `backing_source`, `field`,
+  `operation`, and — for filter tools — `field_type`; for the search tool —
+  `searchable_fields`, the exact list of searchable-text column names it
+  spans) so US-30.3's executor dispatches on STRUCTURED data, never by
+  re-parsing the tool name string or re-deriving the searchable-field set.
+
+  ## Key-shape robustness
+
+  `entity.fields` elements may be atom-keyed (build path, e.g. tests
+  constructing an `%Entity{}` literal) or string-keyed (DB round-trip, since
+  `fields` is `{:array, :map}`). This module reads both forms via
+  `Loopctl.ContextRetriever.Entity`'s public `field_value/2`,
+  `field_string_value/2`, `filterable?/1`, and `searchable?/1` accessors — the
+  canonical, single source of truth for that dual-key-shape contract — rather
+  than re-implementing its own copy. `String.to_atom/1` is never called on
+  field content.
+  """
+
+  alias Loopctl.ContextRetriever.Entity
+
+  @type spec :: %{
+          name: String.t(),
+          description: String.t(),
+          input_schema: map(),
+          metadata: map()
+        }
+
+  @tool_prefix "cr_"
+
+  # Text-like field types eligible to back the search tool (AC-30.2.1: "searchable
+  # TEXT field", not merely "searchable field"). Kept as a fixed set, compared
+  # against the declared `type` string, so a non-text column (e.g. an integer
+  # marked searchable) never triggers a meaningless full-text search tool.
+  @text_types ~w(string)
+
+  @doc """
+  Returns the deterministic list of tool specs authorized by `entity`.
+
+  Filter specs (one per `filterable` field, in field-declaration order) come
+  first, followed by the single `cr_search_<entity>` spec when the entity has
+  at least one field that is both `searchable` and text-typed. Calling this
+  repeatedly on an unchanged entity returns an identical list (AC-30.2.2/
+  AC-30.2.3 determinism).
+  """
+  @spec specs_for(Entity.t()) :: [spec()]
+  def specs_for(%Entity{name: entity_name, backing_source: backing_source, fields: fields}) do
+    filter_specs =
+      fields
+      |> Enum.filter(&Entity.filterable?/1)
+      |> Enum.map(&filter_spec(entity_name, backing_source, &1))
+
+    searchable_field_names =
+      fields
+      |> Enum.filter(&searchable_text?/1)
+      |> Enum.map(&field_name/1)
+
+    search_specs =
+      case searchable_field_names do
+        [] -> []
+        names -> [search_spec(entity_name, backing_source, names)]
+      end
+
+    filter_specs ++ search_specs
+  end
+
+  # --- Filter tool ---
+
+  defp filter_spec(entity_name, backing_source, field) do
+    field_name = field_name(field)
+    field_type = Entity.field_string_value(field, "type")
+    tool_name = "#{@tool_prefix}filter_#{entity_name}_by_#{field_name}"
+
+    %{
+      name: tool_name,
+      description:
+        "Filter #{entity_name} records where #{field_name} matches the given value. " <>
+          "Returns a page of matching records.",
+      input_schema: %{
+        "type" => "object",
+        # Static pagination params are the base; the declared field's own type
+        # is applied LAST via `Map.put/3` so it always wins if `field_name`
+        # ever collided with a reserved key ("limit"/"cursor") — not reachable
+        # today since the US-30.1 column allowlist contains no such names, but
+        # this keeps a future collision a correctly-typed field param rather
+        # than a silently wrong-typed pagination param.
+        "properties" =>
+          %{"limit" => %{"type" => "integer"}, "cursor" => %{"type" => "string"}}
+          |> Map.put(field_name, json_schema_type(field_type)),
+        "required" => [field_name]
+      },
+      metadata: %{
+        entity: entity_name,
+        backing_source: backing_source,
+        field: field_name,
+        operation: :filter,
+        field_type: field_type
+      }
+    }
+  end
+
+  # --- Search tool ---
+
+  defp search_spec(entity_name, backing_source, searchable_field_names) do
+    %{
+      name: "#{@tool_prefix}search_#{entity_name}",
+      description:
+        "Full-text search across #{entity_name}'s searchable fields. " <>
+          "Returns a page of matching records.",
+      input_schema: %{
+        "type" => "object",
+        "properties" => %{
+          "query" => %{"type" => "string"},
+          "limit" => %{"type" => "integer"},
+          "cursor" => %{"type" => "string"}
+        },
+        "required" => ["query"]
+      },
+      metadata: %{
+        entity: entity_name,
+        backing_source: backing_source,
+        field: nil,
+        operation: :search,
+        searchable_fields: searchable_field_names
+      }
+    }
+  end
+
+  # --- Field-type -> JSON Schema mapping ---
+
+  defp json_schema_type("string"), do: %{"type" => "string"}
+  defp json_schema_type("integer"), do: %{"type" => "integer"}
+  defp json_schema_type("boolean"), do: %{"type" => "boolean"}
+  defp json_schema_type("float"), do: %{"type" => "number"}
+  defp json_schema_type("datetime"), do: %{"type" => "string", "format" => "date-time"}
+  defp json_schema_type(_other), do: %{"type" => "string"}
+
+  # --- Predicates ---
+
+  # AC-30.2.1: the search tool spans "searchable TEXT field"s, not merely
+  # "searchable field"s — a `searchable` field of a non-text type (e.g. an
+  # integer) does not qualify.
+  defp searchable_text?(field), do: Entity.searchable?(field) and text_type?(field)
+
+  defp text_type?(field), do: Entity.field_string_value(field, "type") in @text_types
+
+  # --- Field readers (delegate to Entity's public dual-key-shape contract) ---
+
+  defp field_name(field), do: Entity.field_string_value(field, "name")
+end

--- a/test/loopctl/context_retriever/entity_test.exs
+++ b/test/loopctl/context_retriever/entity_test.exs
@@ -241,6 +241,33 @@ defmodule Loopctl.ContextRetriever.EntityTest do
     end
   end
 
+  describe "field_value/2 and field_string_value/2 — general-key contract" do
+    # Regression: field_value/2 and field_string_value/2 advertise a general
+    # `String.t()` key in their @spec, but previously delegated to a private
+    # `value/2` with only four literal-string clauses and no catch-all —
+    # any other key raised FunctionClauseError instead of returning nil.
+    test "field_value/2 returns nil for a key with no dedicated reading logic" do
+      field = %{name: "title", type: "string", filterable: true, searchable: false}
+
+      assert Entity.field_value(field, "description") == nil
+      assert Entity.field_value(field, "blob") == nil
+    end
+
+    test "field_string_value/2 returns nil for a key with no dedicated reading logic" do
+      field = %{"name" => "title", "type" => "string"}
+
+      assert Entity.field_string_value(field, "description") == nil
+    end
+
+    test "field_value/2 and field_string_value/2 still work for the four sanctioned keys" do
+      field = %{name: "title", type: "string", filterable: true, searchable: false}
+
+      assert Entity.field_value(field, "name") == "title"
+      assert Entity.field_value(field, "filterable") == true
+      assert Entity.field_string_value(field, "type") == "string"
+    end
+  end
+
   describe "introspection helpers" do
     test "column_allowlist/0 excludes isolation and custody columns" do
       allow = Entity.column_allowlist()

--- a/test/loopctl/context_retriever/tool_generator_test.exs
+++ b/test/loopctl/context_retriever/tool_generator_test.exs
@@ -293,4 +293,44 @@ defmodule Loopctl.ContextRetriever.ToolGeneratorTest do
       assert spec.input_schema["properties"]["phase"] == %{"type" => "string"}
     end
   end
+
+  describe "specs_for/1 — Entity.field_types/0 coverage (schema-drift guard)" do
+    # Regression: json_schema_type/1's silent `%{"type" => "string"}` fallback
+    # made it possible for a future Entity.@field_types addition to be mapped
+    # to a wrong JSON Schema type with no compile warning and no test failure.
+    # ToolGenerator now raises a CompileError if any Entity.field_types/0
+    # member lacks an explicit @json_schema_types / @field_type_classification
+    # entry (enforced at compile time — this module already compiled clean, so
+    # that guard passed). This test is a second, runtime-visible line of
+    # defense: it proves every declared type maps to its OWN distinct,
+    # non-fallback JSON Schema type shape, not merely "some non-string shape".
+    test "every Entity.field_types/0 member produces a distinct, non-fallback JSON Schema type" do
+      schema_types_by_field_type =
+        Map.new(Entity.field_types(), fn type ->
+          entity = %Entity{
+            name: "probe",
+            backing_source: :epics,
+            fields: [%{name: "position", type: type, filterable: true, searchable: false}]
+          }
+
+          [spec] = ToolGenerator.specs_for(entity)
+          {type, spec.input_schema["properties"]["position"]}
+        end)
+
+      # No two distinct Entity field types collapse onto the same JSON Schema
+      # shape as the fallback (%{"type" => "string"}) would silently cause for
+      # any type not explicitly handled.
+      fallback = %{"type" => "string"}
+
+      non_string_types = Entity.field_types() -- ["string"]
+
+      Enum.each(non_string_types, fn type ->
+        refute schema_types_by_field_type[type] == fallback,
+               "Entity field type #{inspect(type)} silently fell back to #{inspect(fallback)} " <>
+                 "in ToolGenerator.json_schema_type/1 — add an explicit mapping"
+      end)
+
+      assert schema_types_by_field_type["string"] == fallback
+    end
+  end
 end

--- a/test/loopctl/context_retriever/tool_generator_test.exs
+++ b/test/loopctl/context_retriever/tool_generator_test.exs
@@ -1,0 +1,296 @@
+defmodule Loopctl.ContextRetriever.ToolGeneratorTest do
+  # ToolGenerator is a pure function of the entity — no DB, no side effects
+  # (technical_notes, us_30.2.json:39,42) — so this is a pure ExUnit.Case unit
+  # test, not Loopctl.DataCase (which checks out a SQL-sandbox connection this
+  # module never uses).
+  use ExUnit.Case, async: true
+
+  alias Loopctl.ContextRetriever.Entity
+  alias Loopctl.ContextRetriever.ToolGenerator
+
+  # A representative sample of loopctl's static MCP tool names, to prove the
+  # `cr_` prefix cannot collide with the existing tool surface (AC-30.2.3).
+  @static_mcp_tool_names ~w(
+    list_projects list_stories verify_story claim_story start_story
+    contract_story get_story knowledge_search knowledge_get knowledge_context
+    knowledge_index knowledge_create
+  )
+
+  describe "specs_for/1 — TC-30.2.1 (mixed filterable/searchable/neither fields)" do
+    setup do
+      entity = %Entity{
+        name: "story",
+        backing_source: :stories,
+        fields: [
+          %{name: "status", type: "string", filterable: true, searchable: false},
+          %{name: "priority", type: "integer", filterable: true, searchable: false},
+          %{name: "active", type: "boolean", filterable: true, searchable: false},
+          %{name: "due", type: "datetime", filterable: true, searchable: false},
+          %{name: "description", type: "string", filterable: false, searchable: true},
+          %{name: "secret", type: "string", filterable: false, searchable: false}
+        ]
+      }
+
+      %{entity: entity, specs: ToolGenerator.specs_for(entity)}
+    end
+
+    test "emits a filter tool for each filterable field, typed correctly", %{specs: specs} do
+      by_name = Map.new(specs, &{&1.name, &1})
+
+      assert %{input_schema: %{"properties" => %{"status" => %{"type" => "string"}}}} =
+               by_name["cr_filter_story_by_status"]
+
+      assert %{input_schema: %{"properties" => %{"priority" => %{"type" => "integer"}}}} =
+               by_name["cr_filter_story_by_priority"]
+
+      assert %{input_schema: %{"properties" => %{"active" => %{"type" => "boolean"}}}} =
+               by_name["cr_filter_story_by_active"]
+
+      assert %{
+               input_schema: %{
+                 "properties" => %{"due" => %{"type" => "string", "format" => "date-time"}}
+               }
+             } = by_name["cr_filter_story_by_due"]
+    end
+
+    test "emits a single cr_search_story tool", %{specs: specs} do
+      names = Enum.map(specs, & &1.name)
+      assert "cr_search_story" in names
+      assert Enum.count(names, &(&1 == "cr_search_story")) == 1
+    end
+
+    test "no tool references the non-filterable, non-searchable field", %{specs: specs} do
+      refute Enum.any?(specs, fn spec ->
+               spec.name =~ "secret" or spec.metadata[:field] == "secret"
+             end)
+    end
+
+    test "every spec carries (entity, field, operation) dispatch metadata", %{specs: specs} do
+      Enum.each(specs, fn spec ->
+        assert spec.metadata.entity == "story"
+        assert spec.metadata.backing_source == :stories
+        assert spec.metadata.operation in [:filter, :search]
+        assert Map.has_key?(spec.metadata, :field)
+      end)
+
+      filter_specs = Enum.filter(specs, &(&1.metadata.operation == :filter))
+      assert Enum.all?(filter_specs, &is_binary(&1.metadata.field))
+      assert Enum.all?(filter_specs, &is_binary(&1.metadata.field_type))
+
+      search_spec = Enum.find(specs, &(&1.metadata.operation == :search))
+      assert search_spec.metadata.field == nil
+      assert search_spec.metadata.searchable_fields == ["description"]
+    end
+
+    test "filter tool input schemas require the field and expose pagination", %{specs: specs} do
+      status_spec = Enum.find(specs, &(&1.name == "cr_filter_story_by_status"))
+
+      assert status_spec.input_schema["required"] == ["status"]
+      assert status_spec.input_schema["properties"]["limit"] == %{"type" => "integer"}
+      assert status_spec.input_schema["properties"]["cursor"] == %{"type" => "string"}
+    end
+
+    test "search tool input schema requires query and exposes pagination", %{specs: specs} do
+      search_spec = Enum.find(specs, &(&1.name == "cr_search_story"))
+
+      assert search_spec.input_schema["required"] == ["query"]
+      assert search_spec.input_schema["properties"]["query"] == %{"type" => "string"}
+      assert search_spec.input_schema["properties"]["limit"] == %{"type" => "integer"}
+      assert search_spec.input_schema["properties"]["cursor"] == %{"type" => "string"}
+    end
+  end
+
+  describe "specs_for/1 — TC-30.2.3 (no searchable field)" do
+    test "emits only filter tools, no search tool" do
+      entity = %Entity{
+        name: "project_view",
+        backing_source: :projects,
+        fields: [
+          %{name: "name", type: "string", filterable: true, searchable: false},
+          %{name: "status", type: "string", filterable: true, searchable: false}
+        ]
+      }
+
+      specs = ToolGenerator.specs_for(entity)
+      names = Enum.map(specs, & &1.name)
+
+      assert "cr_filter_project_view_by_name" in names
+      assert "cr_filter_project_view_by_status" in names
+      refute Enum.any?(names, &(&1 =~ "search"))
+      refute "cr_search_project_view" in names
+    end
+  end
+
+  describe "specs_for/1 — AC-30.2.4 (allowlist is exact)" do
+    test "a filterable == false field produces no filter tool" do
+      entity = %Entity{
+        name: "epic",
+        backing_source: :epics,
+        fields: [
+          %{name: "title", type: "string", filterable: false, searchable: true}
+        ]
+      }
+
+      specs = ToolGenerator.specs_for(entity)
+      names = Enum.map(specs, & &1.name)
+
+      refute "cr_filter_epic_by_title" in names
+      assert "cr_search_epic" in names
+    end
+
+    test "an entity with no fields at all produces no specs" do
+      entity = %Entity{name: "empty", backing_source: :epics, fields: []}
+
+      assert ToolGenerator.specs_for(entity) == []
+    end
+  end
+
+  describe "specs_for/1 — TC-30.2.2 (determinism + collision-safe prefix)" do
+    test "calling twice on the same entity returns identical specs" do
+      entity = %Entity{
+        name: "story",
+        backing_source: :stories,
+        fields: [
+          %{name: "status", type: "string", filterable: true, searchable: false},
+          %{name: "title", type: "string", filterable: false, searchable: true}
+        ]
+      }
+
+      assert ToolGenerator.specs_for(entity) == ToolGenerator.specs_for(entity)
+    end
+
+    test "every generated tool name starts with the cr_ prefix" do
+      entity = %Entity{
+        name: "story",
+        backing_source: :stories,
+        fields: [
+          %{name: "status", type: "string", filterable: true, searchable: false},
+          %{name: "title", type: "string", filterable: false, searchable: true}
+        ]
+      }
+
+      specs = ToolGenerator.specs_for(entity)
+      assert specs != []
+      assert Enum.all?(specs, &String.starts_with?(&1.name, "cr_"))
+    end
+
+    test "generated tool names never collide with a sample of loopctl static tool names" do
+      entity = %Entity{
+        name: "story",
+        backing_source: :stories,
+        fields: [
+          %{name: "status", type: "string", filterable: true, searchable: false},
+          %{name: "title", type: "string", filterable: false, searchable: true}
+        ]
+      }
+
+      generated_names = entity |> ToolGenerator.specs_for() |> Enum.map(& &1.name)
+
+      assert MapSet.disjoint?(
+               MapSet.new(generated_names),
+               MapSet.new(@static_mcp_tool_names)
+             )
+    end
+  end
+
+  describe "specs_for/1 — key-shape robustness" do
+    test "string-keyed and atom-keyed field maps produce identical specs" do
+      string_keyed = %Entity{
+        name: "story",
+        backing_source: :stories,
+        fields: [
+          %{
+            "name" => "status",
+            "type" => "string",
+            "filterable" => true,
+            "searchable" => false
+          },
+          %{
+            "name" => "title",
+            "type" => "string",
+            "filterable" => false,
+            "searchable" => true
+          }
+        ]
+      }
+
+      atom_keyed = %Entity{
+        name: "story",
+        backing_source: :stories,
+        fields: [
+          %{name: "status", type: "string", filterable: true, searchable: false},
+          %{name: "title", type: "string", filterable: false, searchable: true}
+        ]
+      }
+
+      assert ToolGenerator.specs_for(string_keyed) == ToolGenerator.specs_for(atom_keyed)
+    end
+  end
+
+  describe "specs_for/1 — AC-30.2.1 (search tool requires a searchable TEXT field)" do
+    test "a searchable non-text field alone does not trigger the search tool" do
+      entity = %Entity{
+        name: "story",
+        backing_source: :stories,
+        fields: [
+          %{name: "estimated_hours", type: "integer", filterable: false, searchable: true}
+        ]
+      }
+
+      specs = ToolGenerator.specs_for(entity)
+
+      assert specs == []
+      refute Enum.any?(specs, &(&1.name == "cr_search_story"))
+    end
+
+    test "a searchable non-text field does not expand the search tool's field set" do
+      entity = %Entity{
+        name: "story",
+        backing_source: :stories,
+        fields: [
+          %{name: "estimated_hours", type: "integer", filterable: false, searchable: true},
+          %{name: "description", type: "string", filterable: false, searchable: true}
+        ]
+      }
+
+      specs = ToolGenerator.specs_for(entity)
+      search_spec = Enum.find(specs, &(&1.name == "cr_search_story"))
+
+      assert search_spec
+      assert search_spec.metadata.searchable_fields == ["description"]
+    end
+  end
+
+  describe "specs_for/1 — json schema type mapping (float + fallback)" do
+    test "types a float field as JSON Schema number" do
+      entity = %Entity{
+        name: "epic",
+        backing_source: :epics,
+        fields: [
+          %{name: "position", type: "float", filterable: true, searchable: false}
+        ]
+      }
+
+      specs = ToolGenerator.specs_for(entity)
+      spec = Enum.find(specs, &(&1.name == "cr_filter_epic_by_position"))
+
+      assert spec.input_schema["properties"]["position"] == %{"type" => "number"}
+      assert spec.metadata.field_type == "float"
+    end
+
+    test "falls back to string for an unrecognized field type" do
+      entity = %Entity{
+        name: "epic",
+        backing_source: :epics,
+        fields: [
+          %{name: "phase", type: "unrecognized_type", filterable: true, searchable: false}
+        ]
+      }
+
+      specs = ToolGenerator.specs_for(entity)
+      spec = Enum.find(specs, &(&1.name == "cr_filter_epic_by_phase"))
+
+      assert spec.input_schema["properties"]["phase"] == %{"type" => "string"}
+    end
+  end
+end


### PR DESCRIPTION
Implements US-30.2: the tool generator that turns a per-tenant Entity definition into `cr_filter_<entity>` and `cr_search_<entity>` MCP tool specs.

## What changed

- **Entity accessors** — `Entity` now exposes canonical `field_value/2`, `field_string_value/2`, `filterable?/1`, `searchable?/1`, and `field_types/0`, giving one authoritative interpretation of the security-root fields shape. `value/2` gains a catch-all clause so the string accessors honor their `String.t()` `@spec` for any key instead of raising `FunctionClauseError`.
- **ToolGenerator** — derives `json_schema_type/1` and the text-type set from an explicit per-`Entity.field_types()` classification, guarded by a compile-time check that fails the build if a future field type is left unmapped (closes the silent schema-drift fallback to `%{"type" => "string"}`).
- **Full-text tool gating** — `cr_search_<entity>` is now gated on searchable TEXT fields (AC-30.2.1); a searchable integer/boolean column can no longer emit a meaningless full-text tool. The search spec metadata carries `searchable_fields` for the US-30.3 executor.
- **Filter spec** — applies the declared field's type after the static pagination defaults, so a field named `limit`/`cursor` gets its own correct type rather than inheriting the pagination param's type.
- **Tests** — switched to plain `ExUnit.Case` per the story's pure-unit-test note; added coverage for float mapping, the type fallback branch, the `field_type`/`searchable_fields` metadata keys, and the searchable non-text-field restriction.
