### PR TITLE
Query executor: generated call -> safe scoped Ecto query (allowlist re-check, indexed full-text, audit, fail-closed)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -381,6 +381,13 @@ config :loopctl, :max_entity_definitions_per_tenant, 50
 # unbounded result set; a caller-supplied `limit` is clamped to `[1, this]`.
 config :loopctl, :context_retriever_max_page_size, 100
 
+# Epic 30 / US-30.3: hard maximum pagination OFFSET for the Context Retriever
+# query executor. A caller-supplied `offset` is clamped to `[0, this]` so a
+# model-driven call cannot force an O(offset) deep-scan (Postgres walking and
+# discarding an arbitrarily large offset) on the governed query surface. Deep
+# paging still works up to this generous bound.
+config :loopctl, :context_retriever_max_offset, 100_000
+
 # L3 local test runner (Loopctl.Verification.TestRunner). DISABLED by default:
 # it clones a tenant-supplied repo and runs `mix deps.get`/`mix test` on it
 # (untrusted-code execution) and is subject to a clone-time DNS-rebinding SSRF

--- a/config/config.exs
+++ b/config/config.exs
@@ -375,6 +375,12 @@ config :loopctl, :session_memory_ttl_seconds, 3600
 # it without limit. Over-cap creation returns `{:error, :entity_limit}`.
 config :loopctl, :max_entity_definitions_per_tenant, 50
 
+# Epic 30 / US-30.3: hard maximum page size for the Context Retriever query
+# executor (`Loopctl.ContextRetriever.Executor`). Every generated filter/search
+# query is capped at this many rows so a model-driven query can never request an
+# unbounded result set; a caller-supplied `limit` is clamped to `[1, this]`.
+config :loopctl, :context_retriever_max_page_size, 100
+
 # L3 local test runner (Loopctl.Verification.TestRunner). DISABLED by default:
 # it clones a tenant-supplied repo and runs `mix deps.get`/`mix test` on it
 # (untrusted-code execution) and is subject to a clone-time DNS-rebinding SSRF

--- a/config/test.exs
+++ b/config/test.exs
@@ -262,6 +262,12 @@ config :loopctl, :max_entity_definitions_per_tenant, 3
 # testable (TC-30.3.5) without seeding 100+ rows.
 config :loopctl, :context_retriever_max_page_size, 5
 
+# US-30.3: Context-Retriever audit writer DI. Resolves to a Mox mock whose
+# DataCase default stub delegates to the real Loopctl.Audit — so existing
+# executor tests write genuine audit rows, while the fail-closed test overrides
+# it to force an {:error, _} and assert run/3 returns {:error, :audit_failed}.
+config :loopctl, :context_retriever_audit, Loopctl.ContextRetriever.MockAudit
+
 # DI: Use mock knowledge extractor in tests
 config :loopctl, :knowledge_extractor, Loopctl.MockExtractor
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -262,6 +262,10 @@ config :loopctl, :max_entity_definitions_per_tenant, 3
 # testable (TC-30.3.5) without seeding 100+ rows.
 config :loopctl, :context_retriever_max_page_size, 5
 
+# US-30.3: a small max pagination offset so the offset-cap path is testable
+# without a deep-offset scan.
+config :loopctl, :context_retriever_max_offset, 50
+
 # US-30.3: Context-Retriever audit writer DI. Resolves to a Mox mock whose
 # DataCase default stub delegates to the real Loopctl.Audit — so existing
 # executor tests write genuine audit rows, while the fail-closed test overrides

--- a/config/test.exs
+++ b/config/test.exs
@@ -258,6 +258,10 @@ config :loopctl, :max_long_term_memories_per_subject, 30
 # (`{:error, :entity_limit}`) is testable without inserting 50 rows.
 config :loopctl, :max_entity_definitions_per_tenant, 3
 
+# US-30.3: a small Context Retriever max page size so the pagination-cap path is
+# testable (TC-30.3.5) without seeding 100+ rows.
+config :loopctl, :context_retriever_max_page_size, 5
+
 # DI: Use mock knowledge extractor in tests
 config :loopctl, :knowledge_extractor, Loopctl.MockExtractor
 

--- a/lib/loopctl/context_retriever/audit_behaviour.ex
+++ b/lib/loopctl/context_retriever/audit_behaviour.ex
@@ -1,0 +1,16 @@
+defmodule Loopctl.ContextRetriever.AuditBehaviour do
+  @moduledoc """
+  Behaviour for the Context-Retriever audit writer (Epic 30, US-30.3).
+
+  `Loopctl.ContextRetriever.Executor` writes one `audit_log` entry per executed
+  query and — per AC-30.3.6 — treats that write as part of the read's
+  correctness (a failed audit insert fails the read closed). This behaviour is
+  the config-based DI seam (CLAUDE.md DI convention): production resolves to
+  `Loopctl.Audit` (whose `create_log_entry/2` matches the callback), while tests
+  map `:context_retriever_audit` to a Mox mock so the fail-closed path can be
+  exercised without forcing a real DB insert failure.
+  """
+
+  @callback create_log_entry(tenant_id :: Ecto.UUID.t() | nil, attrs :: map()) ::
+              {:ok, term()} | {:error, term()}
+end

--- a/lib/loopctl/context_retriever/entity.ex
+++ b/lib/loopctl/context_retriever/entity.ex
@@ -140,6 +140,50 @@ defmodule Loopctl.ContextRetriever.Entity do
                               {source, MapSet.new(Enum.map(cols, &Atom.to_string/1))}
                             end)
 
+  # SERVER-defined per-source set of columns each backing table's generated
+  # `search_vector` tsvector column ACTUALLY covers. This MUST mirror the STORED
+  # generated columns created by
+  # `priv/repo/migrations/20260712000000_add_search_vectors_to_backing_tables.exs`
+  # — the migration is the DB truth, this constant is the code-side mirror the
+  # US-30.2 `ToolGenerator` and US-30.3 `Executor` consult.
+  #
+  # A search is authorized over an entity ONLY when every declared
+  # searchable-text column is present here (AC-30.3.4). Without this gate, an
+  # admin could legitimately declare an allowlisted string-ish column NOT covered
+  # by the vector (e.g. `stories.agent_status`, `projects.slug`) as
+  # `searchable: true` — the changeset validates the declared `type` against a
+  # fixed set, never against the vector coverage — and the executor's fixed
+  # `search_vector @@ ...` query would then silently search `title`/`description`
+  # instead of the declared column (under-match), returning wrong/empty results
+  # with no error.
+  @search_vector_columns %{
+    stories: [:title, :description],
+    projects: [:name, :description, :mission],
+    epics: [:title, :description]
+  }
+
+  # Compile-time guard: every search_vector column must name a known backing
+  # source AND itself be allowlisted for that source (a vector can never index a
+  # column an admin could not even declare). Keeps this mirror honest against
+  # `@column_allowlist`, so the two security constants cannot drift apart.
+  for {vector_source, vector_cols} <- @search_vector_columns do
+    unless vector_source in @backing_sources do
+      raise CompileError,
+        description:
+          "Loopctl.ContextRetriever.Entity @search_vector_columns names unknown source " <>
+            "#{inspect(vector_source)}"
+    end
+
+    unmatched = vector_cols -- Map.fetch!(@column_allowlist, vector_source)
+
+    unless unmatched == [] do
+      raise CompileError,
+        description:
+          "Loopctl.ContextRetriever.Entity @search_vector_columns for " <>
+            "#{inspect(vector_source)} includes non-allowlisted column(s) #{inspect(unmatched)}"
+    end
+  end
+
   schema "entity_definitions" do
     tenant_field()
     field :name, :string
@@ -206,6 +250,20 @@ defmodule Loopctl.ContextRetriever.Entity do
   """
   @spec column_allowlist() :: %{atom() => [atom()]}
   def column_allowlist, do: @column_allowlist
+
+  @doc """
+  Returns the per-source set of columns each backing table's generated
+  `search_vector` actually covers (source atom => list of column atoms).
+
+  Mirrors the STORED generated columns created by
+  `20260712000000_add_search_vectors_to_backing_tables.exs`. US-30.2's
+  `ToolGenerator` and US-30.3's `Executor` consult this to authorize an entity's
+  search tool ONLY when every declared searchable-text column is indexed by the
+  vector (AC-30.3.4) — so a declared-but-unindexed searchable column can never
+  silently search the wrong (vector-covered) columns.
+  """
+  @spec search_vector_columns() :: %{atom() => [atom()]}
+  def search_vector_columns, do: @search_vector_columns
 
   @doc """
   Reads a declared field element's raw value under `key`.

--- a/lib/loopctl/context_retriever/entity.ex
+++ b/lib/loopctl/context_retriever/entity.ex
@@ -141,8 +141,8 @@ defmodule Loopctl.ContextRetriever.Entity do
                             end)
 
   # SERVER-defined per-source set of columns each backing table's generated
-  # `search_vector` tsvector column ACTUALLY covers. This MUST mirror the STORED
-  # generated columns created by
+  # `search_vector` tsvector column ACTUALLY covers. This MUST mirror the
+  # trigger-maintained `search_vector` columns created by
   # `priv/repo/migrations/20260712000000_add_search_vectors_to_backing_tables.exs`
   # — the migration is the DB truth, this constant is the code-side mirror the
   # US-30.2 `ToolGenerator` and US-30.3 `Executor` consult.
@@ -255,7 +255,7 @@ defmodule Loopctl.ContextRetriever.Entity do
   Returns the per-source set of columns each backing table's generated
   `search_vector` actually covers (source atom => list of column atoms).
 
-  Mirrors the STORED generated columns created by
+  Mirrors the trigger-maintained `search_vector` columns created by
   `20260712000000_add_search_vectors_to_backing_tables.exs`. US-30.2's
   `ToolGenerator` and US-30.3's `Executor` consult this to authorize an entity's
   search tool ONLY when every declared searchable-text column is indexed by the

--- a/lib/loopctl/context_retriever/executor.ex
+++ b/lib/loopctl/context_retriever/executor.ex
@@ -1,0 +1,521 @@
+defmodule Loopctl.ContextRetriever.Executor do
+  @moduledoc """
+  The SECURITY BOUNDARY of Epic 30: turns a generated tool call (produced by the
+  US-30.2 `ToolGenerator`) into a safe, parameterized, tenant-scoped Ecto query
+  against a loopctl-internal backing table (`stories` / `projects` / `epics`).
+
+  `run/3` is the ONLY entry point. It takes an explicit
+  `Loopctl.ContextRetriever.Scope`, a `{entity, field, operation}` dispatch tuple
+  (exactly the US-30.2 spec `metadata` shape), and the model-supplied params, and
+  returns a page of allowlisted-only result maps. NO model-authored SQL ever
+  reaches the database.
+
+  ## Why an execute-time re-check (AC-30.3.1)
+
+  Generate-time checks (US-30.2) bound the tool SURFACE, but a caller can craft a
+  raw `/retrieve` dispatch tuple naming a field the entity does not declare, or one
+  the entity declares but marks non-filterable. `run/3` therefore RE-VALIDATES the
+  `(field, operation)` against BOTH the live entity definition (`entity.fields` +
+  `filterable?`/searchable-text) AND the SERVER per-source column allowlist
+  (`Entity.column_allowlist/0`, US-30.1 AC-30.1.2) before building any query. A
+  request naming a field not currently allowlisted/filterable/searchable is
+  REJECTED, never executed — this closes the raw-`/retrieve` bypass of
+  generate-time checks. `run/3`'s job is to REJECT, not sanitize.
+
+  ## Tenant scoping is dual (AC-30.3.2)
+
+  Every query is scoped by BOTH mechanisms:
+
+    * `Loopctl.Repo.with_tenant/2` sets the RLS context
+      (`SET LOCAL app.current_tenant_id` + `SET LOCAL ROLE loopctl_app`), so RLS is
+      actually enforced (the backing tables are RLS ENABLE, not FORCE); AND
+    * an explicit `where: q.tenant_id == ^scope.tenant_id` predicate
+      (defense-in-depth).
+
+  The `tenant_id` is read ONLY from the scope, never from params — a `tenant_id`
+  in the model-supplied params is ignored entirely (never cast, never read), so no
+  param can widen or override the tenant.
+
+  ## No model-authored SQL (AC-30.3.3)
+
+  Field names map from the validated allowlist to KNOWN column atoms (via
+  `Enum.find/2` matching `Atom.to_string/1` against the compile-time allowlist —
+  never `String.to_atom/1` on model input). Filter values are cast to the declared
+  field type and always Ecto-PINNED params (`^value`); the search query string is
+  passed as a `websearch_to_tsquery` parameter. An injection payload in a filter
+  value or search string is therefore a literal, matching nothing — not SQL.
+
+  ## Indexed full-text search (AC-30.3.4)
+
+  `:search` runs `search_vector @@ websearch_to_tsquery('english', ?)` against the
+  GIN-indexed generated `tsvector` column added to each backing table by
+  `20260712000000_add_search_vectors_to_backing_tables.exs` — NOT an on-the-fly
+  `to_tsvector` sequential scan, and NOT `ILIKE`.
+
+  ## Pagination + result shaping (AC-30.3.5)
+
+  Every query is bounded by a hard maximum page size
+  (`:context_retriever_max_page_size` config); a caller `limit` is clamped to
+  `[1, max]`. Results select ONLY the entity's declared (allowlisted) columns into
+  a map (`Ecto.Query.API.map/2` over resolved column atoms) — never `SELECT *`,
+  never `metadata`/`tenant_id`/custody columns. The return carries
+  `%{results, meta: %{total_count, limit, offset}}`.
+
+  ## Audit (AC-30.3.6)
+
+  Every executed query appends an `audit_log` entry
+  (`entity_type: "context_retrieval"`) via `Loopctl.Audit.create_log_entry/2`,
+  capturing tenant, actor, entity/field/operation, row count, and a SHA-256
+  digest of the params (raw param values are NOT stored — they may carry injection
+  payloads / PII).
+
+  ## Fail-closed edges (AC-30.3.7)
+
+    * a `nil`-tenant (superadmin / no-impersonation) scope is refused with
+      `{:error, :no_tenant}` — the executor NEVER touches `AdminRepo` for a
+      cross-tenant read; and
+    * a declared field whose backing column was renamed/dropped (a stale entity
+      def) surfaces as `{:error, :stale_entity}` — the raw `Postgrex.Error` is
+      caught and never propagated, so no schema internals are disclosed.
+  """
+
+  import Ecto.Query
+
+  require Logger
+
+  alias Loopctl.Audit
+  alias Loopctl.ContextRetriever.Entity
+  alias Loopctl.ContextRetriever.Registry
+  alias Loopctl.ContextRetriever.Scope
+  alias Loopctl.Projects.Project
+  alias Loopctl.Repo
+  alias Loopctl.WorkBreakdown.Epic
+  alias Loopctl.WorkBreakdown.Story
+
+  # backing_source atom -> Ecto schema module. The keys are exactly the phase-1
+  # `Entity.backing_sources/0`; a source outside this map is treated as a stale
+  # entity def (never a crash).
+  @schemas %{stories: Story, projects: Project, epics: Epic}
+
+  # Declared field types that are text-like (eligible to authorize the search
+  # tool). Mirrors `ToolGenerator`'s `@text_types` (AC-30.2.1: "searchable TEXT
+  # field", not merely "searchable field").
+  @text_types ~w(string)
+
+  @type dispatch :: {String.t(), String.t() | nil, :filter | :search}
+  @type result :: %{
+          results: [map()],
+          meta: %{total_count: non_neg_integer(), limit: pos_integer(), offset: non_neg_integer()}
+        }
+  @type error ::
+          :no_tenant
+          | :unknown_entity
+          | :field_not_allowlisted
+          | :invalid_operation
+          | :stale_entity
+
+  @doc """
+  Executes a generated Context-Retriever tool call.
+
+  ## Parameters
+
+    * `scope` — a `Loopctl.ContextRetriever.Scope` carrying the `tenant_id`
+      (isolation boundary) and audit actor. A `nil` `tenant_id` is refused.
+    * `dispatch` — the `{entity_name, field, operation}` tuple from the US-30.2
+      spec `metadata`. `entity_name` is a string, `field` a string for `:filter`
+      (the field to match) or `nil` for `:search`, and `operation` is `:filter`
+      or `:search`.
+    * `params` — the model-supplied params map (string- or atom-keyed). For
+      `:filter`, `params[field]` is the value to match; for `:search`,
+      `params["query"]` is the search string. `params["limit"]`/`params["offset"]`
+      drive pagination and are clamped. Any `tenant_id` here is IGNORED.
+
+  ## Returns
+
+    * `{:ok, %{results: [map()], meta: %{total_count, limit, offset}}}`
+    * `{:error, atom()}` where atom is one of `:no_tenant`, `:unknown_entity`,
+      `:field_not_allowlisted`, `:invalid_operation`, `:stale_entity`.
+  """
+  @spec run(Scope.t(), dispatch(), map()) :: {:ok, result()} | {:error, error()}
+  def run(scope, dispatch, params \\ %{})
+
+  # AC-30.3.7a: a superadmin / no-impersonation context is refused BEFORE any DB
+  # access — never a cross-tenant AdminRepo read.
+  def run(%Scope{tenant_id: nil}, _dispatch, _params), do: {:error, :no_tenant}
+
+  def run(%Scope{tenant_id: tenant_id} = scope, {entity_name, field, operation}, params)
+      when is_binary(tenant_id) and is_map(params) do
+    with {:ok, entity} <- resolve_entity(tenant_id, entity_name),
+         {:ok, schema, allowlist} <- resolve_source(entity),
+         select_cols = declared_columns(entity, allowlist),
+         {:ok, plan} <- build_plan(operation, field, entity, allowlist, params) do
+      limit = page_limit(params)
+      offset = page_offset(params)
+
+      case run_query(tenant_id, schema, select_cols, plan, limit, offset) do
+        {:ok, total_count, rows} ->
+          write_audit(scope, entity, operation, field, params, length(rows))
+
+          {:ok, %{results: rows, meta: %{total_count: total_count, limit: limit, offset: offset}}}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  # --- Entity / source resolution ---
+
+  defp resolve_entity(tenant_id, entity_name) when is_binary(entity_name) do
+    case Registry.get_entity(tenant_id, entity_name) do
+      %Entity{} = entity -> {:ok, entity}
+      nil -> {:error, :unknown_entity}
+    end
+  end
+
+  defp resolve_entity(_tenant_id, _entity_name), do: {:error, :unknown_entity}
+
+  defp resolve_source(%Entity{backing_source: source}) do
+    case {Map.get(@schemas, source), Map.get(Entity.column_allowlist(), source)} do
+      {schema, allowlist} when not is_nil(schema) and is_list(allowlist) ->
+        {:ok, schema, allowlist}
+
+      _ ->
+        # A backing_source with no schema/allowlist means the entity def no longer
+        # matches the server's known sources — fail closed as stale.
+        {:error, :stale_entity}
+    end
+  end
+
+  # The declared, allowlisted columns to shape results to (AC-30.3.5). Each
+  # declared field name is matched against the SERVER allowlist to a KNOWN column
+  # atom (never String.to_atom); any declared field that no longer resolves is
+  # dropped from the projection (defense-in-depth — the US-30.1 changeset already
+  # guarantees membership).
+  defp declared_columns(%Entity{fields: fields}, allowlist) do
+    fields
+    |> Enum.map(&Entity.field_string_value(&1, "name"))
+    |> Enum.map(&column_atom(&1, allowlist))
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+  end
+
+  # --- Plan building (allowlist re-check, AC-30.3.1) ---
+
+  # A plan is `{:where, dynamic}` (filter/search where clause) or
+  # `{:no_match, nil}` (a validly-typed request whose value can't match — e.g. a
+  # non-numeric value for an integer column — which must return zero rows, never a
+  # DB type error) plus an optional order clause. To keep the return small we
+  # encode it as a map.
+  defp build_plan(:filter, field, entity, allowlist, params) when is_binary(field) do
+    with {:ok, field_element} <- declared_field(entity, field),
+         true <- Entity.filterable?(field_element) || {:error, :field_not_allowlisted},
+         col when not is_nil(col) <- column_atom(field, allowlist) do
+      declared_type = Entity.field_string_value(field_element, "type")
+
+      case cast_value(fetch_param(params, field), declared_type) do
+        {:ok, value} ->
+          {:ok, %{kind: :filter, column: col, value: value}}
+
+        :no_match ->
+          {:ok, %{kind: :no_match}}
+      end
+    else
+      nil -> {:error, :field_not_allowlisted}
+      {:error, reason} -> {:error, reason}
+      false -> {:error, :field_not_allowlisted}
+    end
+  end
+
+  defp build_plan(:search, _field, entity, allowlist, params) do
+    case searchable_columns(entity, allowlist) do
+      [] ->
+        # No searchable TEXT field authorizes a search over this entity.
+        {:error, :invalid_operation}
+
+      _cols ->
+        query_string = fetch_param(params, "query")
+
+        if is_binary(query_string) and String.trim(query_string) != "" do
+          {:ok, %{kind: :search, query_string: query_string}}
+        else
+          # A blank/absent query matches nothing; short-circuit to zero rows
+          # (websearch_to_tsquery('') would match nothing anyway).
+          {:ok, %{kind: :no_match}}
+        end
+    end
+  end
+
+  # Unknown operation, or a :filter with a nil/non-string field.
+  defp build_plan(_operation, _field, _entity, _allowlist, _params),
+    do: {:error, :invalid_operation}
+
+  # The declared field element for `field_name`, or nil (→ not allowlisted).
+  defp declared_field(%Entity{fields: fields}, field_name) do
+    case Enum.find(fields, fn f -> Entity.field_string_value(f, "name") == field_name end) do
+      nil -> {:error, :field_not_allowlisted}
+      field_element -> {:ok, field_element}
+    end
+  end
+
+  # Declared fields that are both `searchable` and text-typed, mapped to their
+  # server-allowlist column atoms (AC-30.3.1 search branch).
+  defp searchable_columns(%Entity{fields: fields}, allowlist) do
+    fields
+    |> Enum.filter(fn f ->
+      Entity.searchable?(f) and Entity.field_string_value(f, "type") in @text_types
+    end)
+    |> Enum.map(&Entity.field_string_value(&1, "name"))
+    |> Enum.map(&column_atom(&1, allowlist))
+    |> Enum.reject(&is_nil/1)
+  end
+
+  # Resolve a validated string field name to a KNOWN column atom from the SERVER
+  # allowlist. Never String.to_atom/1 — matches Atom.to_string/1 of each
+  # compile-time allowlist atom (US-30.1). Returns nil if not allowlisted.
+  defp column_atom(nil, _allowlist), do: nil
+
+  defp column_atom(name, allowlist) when is_binary(name) do
+    Enum.find(allowlist, fn col -> Atom.to_string(col) == name end)
+  end
+
+  # --- Execution + audit ---
+
+  # `:no_match` never touches the DB — a validly-shaped request that cannot match
+  # any row (bad-typed filter value, blank search) returns an empty page and is
+  # still audited (row_count 0).
+  defp run_query(_tenant_id, _schema, _select_cols, %{kind: :no_match}, _limit, _offset) do
+    {:ok, 0, []}
+  end
+
+  defp run_query(tenant_id, schema, select_cols, plan, limit, offset) do
+    base = base_query(schema, tenant_id, plan)
+    page_query = page_query(base, plan, select_cols, limit, offset)
+
+    Repo.with_tenant(tenant_id, fn ->
+      total = Repo.aggregate(base, :count, :id)
+      rows = Repo.all(page_query)
+      {total, rows}
+    end)
+    |> case do
+      {:ok, {total, rows}} -> {:ok, total, rows}
+      {:error, reason} -> {:error, translate_db_error(reason)}
+    end
+  rescue
+    e in Postgrex.Error ->
+      # AC-30.3.7b: a dropped/renamed backing column (stale entity def) raises
+      # `undefined_column`; any other DB error is likewise failed closed. The raw
+      # error is logged server-side (rule 3) but NEVER returned — no schema
+      # internals are disclosed to the caller.
+      Logger.warning(
+        "ContextRetriever.Executor DB error (fail-closed as :stale_entity): #{inspect(db_error_code(e))}"
+      )
+
+      {:error, :stale_entity}
+  end
+
+  # Where-only base query: RLS (via with_tenant) + explicit tenant predicate
+  # (defense-in-depth) + the operation's dynamic where. Carries NO select so it
+  # can back the count aggregate.
+  defp base_query(schema, tenant_id, %{kind: :filter, column: col, value: value}) do
+    from(q in schema,
+      where: q.tenant_id == ^tenant_id,
+      where: field(q, ^col) == ^value
+    )
+  end
+
+  defp base_query(schema, tenant_id, %{kind: :search, query_string: query_string}) do
+    from(q in schema,
+      where: q.tenant_id == ^tenant_id,
+      where: fragment("search_vector @@ websearch_to_tsquery('english', ?)", ^query_string)
+    )
+  end
+
+  # Whitelisted-map projection over ONLY the declared allowlisted columns
+  # (AC-30.3.5) + deterministic ordering + pagination.
+  defp page_query(base, %{kind: :search, query_string: query_string}, select_cols, limit, offset) do
+    base
+    |> order_by([q],
+      desc:
+        fragment("ts_rank_cd(search_vector, websearch_to_tsquery('english', ?))", ^query_string),
+      asc: q.id
+    )
+    |> select([q], map(q, ^select_cols))
+    |> limit(^limit)
+    |> offset(^offset)
+  end
+
+  defp page_query(base, _plan, select_cols, limit, offset) do
+    base
+    |> order_by([q], asc: q.id)
+    |> select([q], map(q, ^select_cols))
+    |> limit(^limit)
+    |> offset(^offset)
+  end
+
+  defp write_audit(%Scope{} = scope, %Entity{} = entity, operation, field, params, row_count) do
+    attrs = %{
+      entity_type: "context_retrieval",
+      entity_id: entity.id,
+      action: to_string(operation),
+      actor_type: "api_key",
+      actor_id: scope.actor_id,
+      actor_label: scope.actor_label,
+      metadata: %{
+        "entity" => entity.name,
+        "backing_source" => to_string(entity.backing_source),
+        "field" => field,
+        "operation" => to_string(operation),
+        "row_count" => row_count,
+        "param_digest" => param_digest(params)
+      }
+    }
+
+    # Audit is best-effort observability, not part of the read's correctness; a
+    # failed audit insert must not fail the (already-completed) read.
+    case Audit.create_log_entry(scope.tenant_id, attrs) do
+      {:ok, _} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning(
+          "ContextRetriever.Executor failed to write audit entry: #{inspect(reason)}"
+        )
+
+        :ok
+    end
+  end
+
+  # SHA-256 digest of the params — raw values are NEVER stored (they may carry
+  # injection payloads / PII).
+  defp param_digest(params) do
+    :crypto.hash(:sha256, :erlang.term_to_binary(params)) |> Base.encode16()
+  end
+
+  # --- Param reading + value casting ---
+
+  # Read a param under a string key, falling back to its EXISTING atom key (for
+  # test ergonomics — API params arrive string-keyed). Never creates an atom.
+  defp fetch_param(params, key) when is_binary(key) do
+    case Map.fetch(params, key) do
+      {:ok, value} -> value
+      :error -> Map.get(params, existing_atom(key))
+    end
+  end
+
+  defp existing_atom(key) do
+    String.to_existing_atom(key)
+  rescue
+    ArgumentError -> nil
+  end
+
+  defp page_limit(params) do
+    params
+    |> fetch_param("limit")
+    |> to_int(default_limit())
+    |> max(1)
+    |> min(max_page_size())
+  end
+
+  defp page_offset(params) do
+    params
+    |> fetch_param("offset")
+    |> to_int(0)
+    |> max(0)
+  end
+
+  defp to_int(value, _default) when is_integer(value), do: value
+
+  defp to_int(value, default) when is_binary(value) do
+    case Integer.parse(value) do
+      {int, ""} -> int
+      _ -> default
+    end
+  end
+
+  defp to_int(_value, default), do: default
+
+  # Cast a filter param value to the declared field type. A nil value or a value
+  # that cannot represent the declared type yields `:no_match` (the query returns
+  # zero rows rather than a DB type error). The declared type comes from the
+  # entity definition, never from model input.
+  defp cast_value(nil, _type), do: :no_match
+
+  defp cast_value(value, "integer"), do: cast_integer(value)
+  defp cast_value(value, "float"), do: cast_float(value)
+  defp cast_value(value, "boolean"), do: cast_boolean(value)
+  defp cast_value(value, "datetime"), do: cast_datetime(value)
+
+  # string / unknown declared type — compare as text.
+  defp cast_value(value, _type) when is_binary(value), do: {:ok, value}
+  defp cast_value(value, _type) when is_atom(value), do: {:ok, Atom.to_string(value)}
+
+  defp cast_value(value, _type) when is_integer(value) or is_float(value),
+    do: {:ok, to_string(value)}
+
+  defp cast_value(_value, _type), do: :no_match
+
+  defp cast_integer(value) when is_integer(value), do: {:ok, value}
+
+  defp cast_integer(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {int, ""} -> {:ok, int}
+      _ -> :no_match
+    end
+  end
+
+  defp cast_integer(_value), do: :no_match
+
+  defp cast_float(value) when is_float(value), do: {:ok, value}
+  defp cast_float(value) when is_integer(value), do: {:ok, value * 1.0}
+
+  defp cast_float(value) when is_binary(value) do
+    case Float.parse(value) do
+      {float, ""} -> {:ok, float}
+      _ -> :no_match
+    end
+  end
+
+  defp cast_float(_value), do: :no_match
+
+  defp cast_boolean(value) when is_boolean(value), do: {:ok, value}
+  defp cast_boolean("true"), do: {:ok, true}
+  defp cast_boolean("false"), do: {:ok, false}
+  defp cast_boolean(_value), do: :no_match
+
+  defp cast_datetime(%DateTime{} = value), do: {:ok, value}
+
+  defp cast_datetime(value) when is_binary(value) do
+    case DateTime.from_iso8601(value) do
+      {:ok, dt, _offset} -> {:ok, dt}
+      _ -> :no_match
+    end
+  end
+
+  defp cast_datetime(_value), do: :no_match
+
+  # --- Config ---
+
+  defp default_limit, do: min(20, max_page_size())
+
+  defp max_page_size do
+    Application.get_env(:loopctl, :context_retriever_max_page_size, 100)
+  end
+
+  # --- DB error helpers ---
+
+  defp translate_db_error(%Postgrex.Error{} = error) do
+    Logger.warning(
+      "ContextRetriever.Executor DB error (fail-closed as :stale_entity): #{inspect(db_error_code(error))}"
+    )
+
+    :stale_entity
+  end
+
+  # A non-Postgrex transaction failure (e.g. a rolled-back {:error, reason} from
+  # the fun) is also failed closed rather than leaked.
+  defp translate_db_error(_other), do: :stale_entity
+
+  defp db_error_code(%Postgrex.Error{postgres: %{code: code}}), do: code
+  defp db_error_code(_), do: :unknown
+end

--- a/lib/loopctl/context_retriever/executor.ex
+++ b/lib/loopctl/context_retriever/executor.ex
@@ -52,6 +52,22 @@ defmodule Loopctl.ContextRetriever.Executor do
   `20260712000000_add_search_vectors_to_backing_tables.exs` — NOT an on-the-fly
   `to_tsvector` sequential scan, and NOT `ILIKE`.
 
+  Because that vector covers a FIXED per-source column set (stories: title +
+  description; projects: name + description + mission; epics: title +
+  description), a search is authorized ONLY when every declared searchable-text
+  column is covered by the vector (`Entity.search_vector_columns/0`). A declared
+  searchable column the vector does not index (e.g. `stories.agent_status`,
+  `projects.slug` — allowlisted string-ish columns an admin may legitimately mark
+  `searchable`) is REJECTED with `{:error, :search_not_indexed}` rather than
+  silently searched against `title`/`description` (which would return wrong/empty
+  results with no error). This is the execute-time half of the generate-time
+  suppression in `ToolGenerator` (both enforce declared-searchable ⊆
+  vector-covered). Note the vector may cover MORE columns than the entity
+  declared searchable (e.g. an entity declaring only `title` still searches the
+  `description` component of the shared vector); this residual is bounded because
+  every vector column is itself server-allowlisted searchable text and results
+  are shaped to declared columns only.
+
   ## Pagination + result shaping (AC-30.3.5)
 
   Every query is bounded by a hard maximum page size
@@ -64,10 +80,17 @@ defmodule Loopctl.ContextRetriever.Executor do
   ## Audit (AC-30.3.6)
 
   Every executed query appends an `audit_log` entry
-  (`entity_type: "context_retrieval"`) via `Loopctl.Audit.create_log_entry/2`,
-  capturing tenant, actor, entity/field/operation, row count, and a SHA-256
-  digest of the params (raw param values are NOT stored — they may carry injection
-  payloads / PII).
+  (`entity_type: "context_retrieval"`) via the configured audit writer
+  (`Loopctl.Audit.create_log_entry/2` by default), capturing tenant, actor,
+  entity/field/operation, row count, and a SHA-256 digest of the params (raw
+  param values are NOT stored — they may carry injection payloads / PII).
+
+  The audit write is part of the read's correctness, NOT best-effort: AC-30.3.6
+  mandates that EVERY execution appends an audit record, so if the audit insert
+  fails `run/3` FAILS CLOSED with `{:error, :audit_failed}` and returns NO rows
+  to the caller. A model-driven read over business data is therefore never
+  disclosed without a persisted audit trail — the chain-of-custody guarantee
+  outweighs returning an already-fetched page.
 
   ## Fail-closed edges (AC-30.3.7)
 
@@ -112,7 +135,9 @@ defmodule Loopctl.ContextRetriever.Executor do
           | :unknown_entity
           | :field_not_allowlisted
           | :invalid_operation
+          | :search_not_indexed
           | :stale_entity
+          | :audit_failed
 
   @doc """
   Executes a generated Context-Retriever tool call.
@@ -134,7 +159,8 @@ defmodule Loopctl.ContextRetriever.Executor do
 
     * `{:ok, %{results: [map()], meta: %{total_count, limit, offset}}}`
     * `{:error, atom()}` where atom is one of `:no_tenant`, `:unknown_entity`,
-      `:field_not_allowlisted`, `:invalid_operation`, `:stale_entity`.
+      `:field_not_allowlisted`, `:invalid_operation`, `:search_not_indexed`,
+      `:stale_entity`, `:audit_failed`.
   """
   @spec run(Scope.t(), dispatch(), map()) :: {:ok, result()} | {:error, error()}
   def run(scope, dispatch, params \\ %{})
@@ -154,13 +180,22 @@ defmodule Loopctl.ContextRetriever.Executor do
 
       case run_query(tenant_id, schema, select_cols, plan, limit, offset) do
         {:ok, total_count, rows} ->
-          write_audit(scope, entity, operation, field, params, length(rows))
-
-          {:ok, %{results: rows, meta: %{total_count: total_count, limit: limit, offset: offset}}}
+          meta = %{total_count: total_count, limit: limit, offset: offset}
+          finalize_read(scope, entity, operation, field, params, rows, meta)
 
         {:error, reason} ->
           {:error, reason}
       end
+    end
+  end
+
+  # AC-30.3.6: the audit write is part of the read's correctness. If it fails we
+  # FAIL CLOSED — no rows are returned without a persisted audit trail (chain of
+  # custody outweighs the already-fetched page).
+  defp finalize_read(scope, entity, operation, field, params, rows, meta) do
+    case write_audit(scope, entity, operation, field, params, length(rows)) do
+      :ok -> {:ok, %{results: rows, meta: meta}}
+      {:error, _reason} -> {:error, :audit_failed}
     end
   end
 
@@ -233,15 +268,15 @@ defmodule Loopctl.ContextRetriever.Executor do
         # No searchable TEXT field authorizes a search over this entity.
         {:error, :invalid_operation}
 
-      _cols ->
-        query_string = fetch_param(params, "query")
-
-        if is_binary(query_string) and String.trim(query_string) != "" do
-          {:ok, %{kind: :search, query_string: query_string}}
+      cols ->
+        if vector_covered?(entity, cols) do
+          search_plan(fetch_param(params, "query"))
         else
-          # A blank/absent query matches nothing; short-circuit to zero rows
-          # (websearch_to_tsquery('') would match nothing anyway).
-          {:ok, %{kind: :no_match}}
+          # AC-30.3.4: at least one declared searchable column is NOT covered by
+          # the source's fixed `search_vector`, so it cannot be indexed in v1.
+          # Reject rather than silently search the vector's (different) columns —
+          # the execute-time half of ToolGenerator's generate-time suppression.
+          {:error, :search_not_indexed}
         end
     end
   end
@@ -249,6 +284,19 @@ defmodule Loopctl.ContextRetriever.Executor do
   # Unknown operation, or a :filter with a nil/non-string field.
   defp build_plan(_operation, _field, _entity, _allowlist, _params),
     do: {:error, :invalid_operation}
+
+  # A non-blank query is a real search; a blank/absent query matches nothing and
+  # short-circuits to zero rows (websearch_to_tsquery('') would match nothing
+  # anyway), never touching the DB.
+  defp search_plan(query_string) when is_binary(query_string) do
+    if String.trim(query_string) == "" do
+      {:ok, %{kind: :no_match}}
+    else
+      {:ok, %{kind: :search, query_string: query_string}}
+    end
+  end
+
+  defp search_plan(_query_string), do: {:ok, %{kind: :no_match}}
 
   # The declared field element for `field_name`, or nil (→ not allowlisted).
   defp declared_field(%Entity{fields: fields}, field_name) do
@@ -268,6 +316,15 @@ defmodule Loopctl.ContextRetriever.Executor do
     |> Enum.map(&Entity.field_string_value(&1, "name"))
     |> Enum.map(&column_atom(&1, allowlist))
     |> Enum.reject(&is_nil/1)
+  end
+
+  # Every declared searchable column must be covered by the source's generated
+  # `search_vector` (`Entity.search_vector_columns/0`). Otherwise the fixed vector
+  # query would search columns the entity never declared, or miss the declared one
+  # entirely (AC-30.3.4). `cols` and the vector columns are both KNOWN atoms.
+  defp vector_covered?(%Entity{backing_source: source}, cols) do
+    vector_cols = Map.get(Entity.search_vector_columns(), source, [])
+    Enum.all?(cols, &(&1 in vector_cols))
   end
 
   # Resolve a validated string field name to a KNOWN column atom from the SERVER
@@ -371,19 +428,28 @@ defmodule Loopctl.ContextRetriever.Executor do
       }
     }
 
-    # Audit is best-effort observability, not part of the read's correctness; a
-    # failed audit insert must not fail the (already-completed) read.
-    case Audit.create_log_entry(scope.tenant_id, attrs) do
+    # AC-30.3.6: the audit write is part of the read's correctness. On failure we
+    # surface the error so `run/3` fails the read closed (returns no rows) rather
+    # than disclosing business data with no persisted audit trail.
+    case audit_writer().create_log_entry(scope.tenant_id, attrs) do
       {:ok, _} ->
         :ok
 
       {:error, reason} ->
-        Logger.warning(
-          "ContextRetriever.Executor failed to write audit entry: #{inspect(reason)}"
+        Logger.error(
+          "ContextRetriever.Executor failed to write audit entry — failing read closed: " <>
+            "#{inspect(reason)}"
         )
 
-        :ok
+        {:error, reason}
     end
+  end
+
+  # Config-based DI for the audit writer (CLAUDE.md DI convention). Defaults to
+  # `Loopctl.Audit`; `config/test.exs` maps it to a Mox mock so the fail-closed
+  # path is exercisable without forcing a real audit-insert failure.
+  defp audit_writer do
+    Application.get_env(:loopctl, :context_retriever_audit, Audit)
   end
 
   # SHA-256 digest of the params — raw values are NEVER stored (they may carry

--- a/lib/loopctl/context_retriever/executor.ex
+++ b/lib/loopctl/context_retriever/executor.ex
@@ -48,7 +48,7 @@ defmodule Loopctl.ContextRetriever.Executor do
   ## Indexed full-text search (AC-30.3.4)
 
   `:search` runs `search_vector @@ websearch_to_tsquery('english', ?)` against the
-  GIN-indexed generated `tsvector` column added to each backing table by
+  GIN-indexed, trigger-maintained `tsvector` column added to each backing table by
   `20260712000000_add_search_vectors_to_backing_tables.exs` — NOT an on-the-fly
   `to_tsvector` sequential scan, and NOT `ILIKE`.
 
@@ -138,6 +138,8 @@ defmodule Loopctl.ContextRetriever.Executor do
           | :search_not_indexed
           | :stale_entity
           | :audit_failed
+          | :invalid_params
+          | :unsupported_filter_type
 
   @doc """
   Executes a generated Context-Retriever tool call.
@@ -160,7 +162,10 @@ defmodule Loopctl.ContextRetriever.Executor do
     * `{:ok, %{results: [map()], meta: %{total_count, limit, offset}}}`
     * `{:error, atom()}` where atom is one of `:no_tenant`, `:unknown_entity`,
       `:field_not_allowlisted`, `:invalid_operation`, `:search_not_indexed`,
-      `:stale_entity`, `:audit_failed`.
+      `:stale_entity`, `:audit_failed`, `:invalid_params` (malformed call —
+      non-`Scope` scope, non-tuple dispatch, or non-map params),
+      `:unsupported_filter_type` (equality filter on a `:decimal` column, which
+      only supports representation-fragile exact equality — rejected in v1).
   """
   @spec run(Scope.t(), dispatch(), map()) :: {:ok, result()} | {:error, error()}
   def run(scope, dispatch, params \\ %{})
@@ -174,7 +179,8 @@ defmodule Loopctl.ContextRetriever.Executor do
     with {:ok, entity} <- resolve_entity(tenant_id, entity_name),
          {:ok, schema, allowlist} <- resolve_source(entity),
          select_cols = declared_columns(entity, allowlist),
-         {:ok, plan} <- build_plan(operation, field, entity, allowlist, params) do
+         {:ok, plan} <- build_plan(operation, field, entity, allowlist, params),
+         :ok <- reject_unsupported_filter(schema, plan) do
       limit = page_limit(params)
       offset = page_offset(params)
 
@@ -188,6 +194,14 @@ defmodule Loopctl.ContextRetriever.Executor do
       end
     end
   end
+
+  # Fail-closed catch-all: a malformed call — a non-`Scope` scope, a dispatch that
+  # is not a `{entity, field, operation}` tuple, or `params` that is not a map
+  # (e.g. a top-level JSON array body forwarded from US-30.4) — matches no clause
+  # above and MUST return an error rather than raise `FunctionClauseError`. The
+  # module is THE fail-closed security boundary; a crash on malformed input is
+  # inconsistent with that contract.
+  def run(_scope, _dispatch, _params), do: {:error, :invalid_params}
 
   # AC-30.3.6: the audit write is part of the read's correctness. If it fails we
   # FAIL CLOSED — no rows are returned without a persisted audit trail (chain of
@@ -285,6 +299,24 @@ defmodule Loopctl.ContextRetriever.Executor do
   defp build_plan(_operation, _field, _entity, _allowlist, _params),
     do: {:error, :invalid_operation}
 
+  # Reject a :filter whose backing column is `:decimal` (stories.estimated_hours).
+  # The executor supports ONLY exact `field == ^value` equality, and an equality
+  # between a stored NUMERIC and a bound param is representation-fragile — a
+  # value that round-trips through the declared "float" cast (0.5 may match, 0.1
+  # silently will not) — so a decimal-column filter would SILENTLY return
+  # wrong/empty rows with no signal that equality-on-decimal is the wrong tool.
+  # Fail explicitly instead. The `:decimal` verdict is read from the LIVE schema
+  # (`__schema__/2`), so it can never drift from the column's real type. Only
+  # :filter plans carry a column; :search / :no_match plans pass through.
+  defp reject_unsupported_filter(schema, %{kind: :filter, column: col}) do
+    case schema.__schema__(:type, col) do
+      :decimal -> {:error, :unsupported_filter_type}
+      _ -> :ok
+    end
+  end
+
+  defp reject_unsupported_filter(_schema, _plan), do: :ok
+
   # A non-blank query is a real search; a blank/absent query matches nothing and
   # short-circuits to zero rows (websearch_to_tsquery('') would match nothing
   # anyway), never touching the DB.
@@ -359,6 +391,27 @@ defmodule Loopctl.ContextRetriever.Executor do
       {:error, reason} -> {:error, translate_db_error(reason)}
     end
   rescue
+    e in [Ecto.Query.CastError, Ecto.ChangeError] ->
+      # AC-30.3.3 / AC-30.3.7b: the pinned filter value cannot be cast to the
+      # column's REAL type. `cast_value/2` only casts to the entity's DECLARED
+      # type, but an allowlisted `Ecto.Enum` column (stories.agent_status /
+      # stories.verified_status / projects.status) or the `:decimal`
+      # stories.estimated_hours has a real column type that DIVERGES from the only
+      # declarable text type ("string"), so Ecto re-casts the pinned value at query
+      # normalization and raises here — e.g. an injection payload `"' OR 1=1 --"`
+      # or a stale/typo status `"ready"` against agent_status. Map it to :no_match
+      # (zero rows, still audited) — EXACTLY the treatment `cast_value/2` gives a
+      # bad-typed value — so injection-as-literal matches nothing (AC-30.3.3) and
+      # `run/3` stays fail-closed (AC-30.3.7). The raw message is NEVER returned: it
+      # echoes the payload AND discloses the column's enum member set / schema
+      # internals, which AC-30.3.7b forbids.
+      Logger.warning(
+        "ContextRetriever.Executor un-castable pinned filter value " <>
+          "(fail-closed as :no_match): #{inspect(e.__struct__)}"
+      )
+
+      {:ok, 0, []}
+
     e in Postgrex.Error ->
       # AC-30.3.7b: a dropped/renamed backing column (stale entity def) raises
       # `undefined_column`; any other DB error is likewise failed closed. The raw
@@ -483,11 +536,18 @@ defmodule Loopctl.ContextRetriever.Executor do
     |> min(max_page_size())
   end
 
+  # Clamp the caller-supplied offset to `[0, max_offset]`. Bounding the UPPER end
+  # matters: an uncapped offset (e.g. `offset: 100_000_000`) makes Postgres walk
+  # and discard that many rows (O(offset)) before returning the capped page — a
+  # residual unbounded-work vector on a surface governed as "no unindexed-scan
+  # DoS", even though AC-30.3.5 only mandates a page-SIZE cap. The cap is
+  # deliberately generous (deep paging still works) but finite.
   defp page_offset(params) do
     params
     |> fetch_param("offset")
     |> to_int(0)
     |> max(0)
+    |> min(max_offset())
   end
 
   defp to_int(value, _default) when is_integer(value), do: value
@@ -566,6 +626,12 @@ defmodule Loopctl.ContextRetriever.Executor do
 
   defp max_page_size do
     Application.get_env(:loopctl, :context_retriever_max_page_size, 100)
+  end
+
+  # Hard upper bound on the pagination offset — bounds the O(offset) deep-scan a
+  # model-driven call could otherwise trigger with an arbitrarily large offset.
+  defp max_offset do
+    Application.get_env(:loopctl, :context_retriever_max_offset, 100_000)
   end
 
   # --- DB error helpers ---

--- a/lib/loopctl/context_retriever/scope.ex
+++ b/lib/loopctl/context_retriever/scope.ex
@@ -1,0 +1,44 @@
+defmodule Loopctl.ContextRetriever.Scope do
+  @moduledoc """
+  The explicit Context-Retriever access scope: `(tenant_id, role, actor)`.
+
+  `Loopctl.ContextRetriever.Executor.run/3` takes a `Scope` as its first argument
+  (Epic 30, US-30.3). Passing the scope EXPLICITLY — rather than reading it from a
+  conn/session — keeps the executor callable in tests without a connection; US-30.4
+  builds it from the authenticated API key (`tenant_id` from the key's tenant,
+  `role` from the key, `actor_id`/`actor_label` from the key identity).
+
+  ## Security
+
+  `tenant_id` is the isolation boundary. It is the ONLY source of tenant scope the
+  executor consults — it is NEVER derived from request params. The executor sets
+  the RLS context from `tenant_id` AND adds an explicit `tenant_id` predicate
+  (defense-in-depth), and a `tenant_id` appearing in the model-supplied params is
+  ignored entirely (never cast, never read).
+
+  A `nil` `tenant_id` denotes a superadmin / no-impersonation context. The
+  executor REFUSES it (`{:error, :no_tenant}`) instead of falling back to a
+  cross-tenant `AdminRepo` read (AC-30.3.7a) — hence `tenant_id` is NOT an
+  `@enforce_keys` field: the struct must be constructible with `tenant_id: nil`
+  so that fail-closed edge is reachable and testable.
+
+  ## Fields
+
+  - `tenant_id` — the owning tenant UUID, or `nil` for a superadmin/no-tenant
+    context (which the executor refuses).
+  - `role` — the caller's role atom (`:agent`, `:orchestrator`, `:user`,
+    `:superadmin`). Carried for completeness / future per-role policy; the v1
+    executor gates on `tenant_id` presence, not role.
+  - `actor_id` — the acting API-key id, recorded on the audit entry (AC-30.3.6).
+  - `actor_label` — human-readable actor label, recorded on the audit entry.
+  """
+
+  defstruct [:tenant_id, :role, :actor_id, :actor_label]
+
+  @type t :: %__MODULE__{
+          tenant_id: String.t() | nil,
+          role: atom() | nil,
+          actor_id: String.t() | nil,
+          actor_label: String.t() | nil
+        }
+end

--- a/lib/loopctl/context_retriever/tool_generator.ex
+++ b/lib/loopctl/context_retriever/tool_generator.ex
@@ -13,17 +13,24 @@ defmodule Loopctl.ContextRetriever.ToolGenerator do
 
     * One `cr_filter_<entity>_by_<field>` tool per declared field whose
       `filterable` is `true`. Its input schema types the field param from the
-      declared field `type`, plus `limit`/`cursor` pagination params.
+      declared field `type`, plus `limit`/`offset` pagination params.
     * One `cr_search_<entity>` tool, emitted iff the entity has at least one
       field that is BOTH `searchable` AND a text-like `type` (currently
-      `string` — see `@text_types`). A `searchable` field of a non-text type
-      (e.g. an integer marked searchable) does not by itself trigger the
-      search tool; the AC-30.2.1 restriction is "searchable TEXT field", not
-      merely "searchable field", since a full-text search over a non-text
-      column is meaningless to the US-30.3 executor. Its input schema takes a
-      `query` string plus `limit`/`cursor` pagination params, and searches
-      across ALL of the entity's searchable TEXT fields collectively (the tool
-      is per-entity, not per-field).
+      `string` — see `@text_types`) AND that field is covered by the source's
+      generated `search_vector` (`Entity.search_vector_columns/0`). A
+      `searchable` field of a non-text type (e.g. an integer marked searchable)
+      does not by itself trigger the search tool; the AC-30.2.1 restriction is
+      "searchable TEXT field", not merely "searchable field", since a full-text
+      search over a non-text column is meaningless to the US-30.3 executor. A
+      searchable text field the vector does NOT index (e.g.
+      `stories.agent_status`, `projects.slug`) ALSO suppresses the search tool
+      (AC-30.3.4: "if a source's searchable columns can't be indexed in v1, that
+      entity's search tool is not generated") — otherwise the executor's fixed
+      `search_vector` query would silently search different columns than the
+      entity declared. Its input schema takes a `query` string plus
+      `limit`/`offset` pagination params, and searches across ALL of the
+      entity's searchable TEXT fields collectively (the tool is per-entity, not
+      per-field).
 
   A field that is neither `filterable` nor (searchable AND text-typed)
   produces no tool at all — the generated surface is exactly the allowlist,
@@ -139,8 +146,19 @@ defmodule Loopctl.ContextRetriever.ToolGenerator do
 
     search_specs =
       case searchable_field_names do
-        [] -> []
-        names -> [search_spec(entity_name, backing_source, names)]
+        [] ->
+          []
+
+        names ->
+          if vector_indexed?(backing_source, names) do
+            [search_spec(entity_name, backing_source, names)]
+          else
+            # AC-30.3.4: at least one declared searchable text field is not
+            # covered by the source's generated `search_vector`, so it cannot be
+            # indexed in v1 — suppress the search tool rather than emit one the
+            # executor would answer over the WRONG (vector-covered) columns.
+            []
+          end
       end
 
     filter_specs ++ search_specs
@@ -162,12 +180,18 @@ defmodule Loopctl.ContextRetriever.ToolGenerator do
         "type" => "object",
         # Static pagination params are the base; the declared field's own type
         # is applied LAST via `Map.put/3` so it always wins if `field_name`
-        # ever collided with a reserved key ("limit"/"cursor") — not reachable
+        # ever collided with a reserved key ("limit"/"offset") — not reachable
         # today since the US-30.1 column allowlist contains no such names, but
         # this keeps a future collision a correctly-typed field param rather
         # than a silently wrong-typed pagination param.
+        #
+        # Pagination is `offset`-based to match the US-30.3 `Executor`, which
+        # reads `params["offset"]` and returns `meta: %{limit, offset}`
+        # (AC-30.3.5). An earlier `cursor` param here was a dead contract — the
+        # executor never read it and emits no cursor, so only page 1 was
+        # reachable; `offset` reconciles the generated surface with the executor.
         "properties" =>
-          %{"limit" => %{"type" => "integer"}, "cursor" => %{"type" => "string"}}
+          %{"limit" => %{"type" => "integer"}, "offset" => %{"type" => "integer"}}
           |> Map.put(field_name, json_schema_type(field_type)),
         "required" => [field_name]
       },
@@ -194,7 +218,9 @@ defmodule Loopctl.ContextRetriever.ToolGenerator do
         "properties" => %{
           "query" => %{"type" => "string"},
           "limit" => %{"type" => "integer"},
-          "cursor" => %{"type" => "string"}
+          # `offset`-based to match the US-30.3 executor (AC-30.3.5); see the
+          # filter spec's pagination note.
+          "offset" => %{"type" => "integer"}
         },
         "required" => ["query"]
       },
@@ -225,6 +251,19 @@ defmodule Loopctl.ContextRetriever.ToolGenerator do
   defp searchable_text?(field), do: Entity.searchable?(field) and text_type?(field)
 
   defp text_type?(field), do: Entity.field_string_value(field, "type") in @text_types
+
+  # AC-30.3.4: every declared searchable text field must be covered by the
+  # source's generated `search_vector` (Entity.search_vector_columns/0) for the
+  # search tool to be authorized. `field_names` are strings; vector columns are
+  # atoms, so compare their string forms (no `String.to_atom/1` on field data).
+  defp vector_indexed?(backing_source, field_names) do
+    vector_col_strings =
+      Entity.search_vector_columns()
+      |> Map.get(backing_source, [])
+      |> Enum.map(&Atom.to_string/1)
+
+    Enum.all?(field_names, &(&1 in vector_col_strings))
+  end
 
   # --- Field readers (delegate to Entity's public dual-key-shape contract) ---
 

--- a/priv/repo/migrations/20260712000000_add_search_vectors_to_backing_tables.exs
+++ b/priv/repo/migrations/20260712000000_add_search_vectors_to_backing_tables.exs
@@ -1,0 +1,69 @@
+defmodule Loopctl.Repo.Migrations.AddSearchVectorsToBackingTables do
+  @moduledoc """
+  US-30.3 / AC-30.3.4 — adds INDEXED full-text search columns to the phase-1
+  Context-Retriever backing tables (`stories`, `projects`, `epics`).
+
+  Each table gets a `search_vector` generated `tsvector` column covering ONLY
+  that source's allowlisted TEXT columns (US-30.1 `@column_allowlist`), plus a
+  GIN index over it. `Loopctl.ContextRetriever.Executor` runs
+  `search_vector @@ websearch_to_tsquery('english', ?)` against this column so
+  full-text search hits the GIN index instead of an on-the-fly `to_tsvector`
+  sequential scan (and never `ILIKE`).
+
+  Column weights mirror the `articles.search_vector` precedent
+  (`20260410021836_add_search_vector_to_articles.exs`): the primary title/name
+  field is weight `A`, secondary description/mission text `B`/`C`.
+
+  These tables already have RLS enabled — this migration only adds a column and
+  an index, so it does NOT touch RLS.
+  """
+
+  use Ecto.Migration
+
+  def up do
+    # stories: title (A) + description (B)
+    execute """
+    ALTER TABLE stories ADD COLUMN search_vector tsvector
+    GENERATED ALWAYS AS (
+      setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
+      setweight(to_tsvector('english', coalesce(description, '')), 'B')
+    ) STORED
+    """
+
+    execute "CREATE INDEX stories_search_vector_idx ON stories USING GIN (search_vector)"
+
+    # projects: name (A) + description (B) + mission (C)
+    execute """
+    ALTER TABLE projects ADD COLUMN search_vector tsvector
+    GENERATED ALWAYS AS (
+      setweight(to_tsvector('english', coalesce(name, '')), 'A') ||
+      setweight(to_tsvector('english', coalesce(description, '')), 'B') ||
+      setweight(to_tsvector('english', coalesce(mission, '')), 'C')
+    ) STORED
+    """
+
+    execute "CREATE INDEX projects_search_vector_idx ON projects USING GIN (search_vector)"
+
+    # epics: title (A) + description (B)
+    execute """
+    ALTER TABLE epics ADD COLUMN search_vector tsvector
+    GENERATED ALWAYS AS (
+      setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
+      setweight(to_tsvector('english', coalesce(description, '')), 'B')
+    ) STORED
+    """
+
+    execute "CREATE INDEX epics_search_vector_idx ON epics USING GIN (search_vector)"
+  end
+
+  def down do
+    execute "DROP INDEX IF EXISTS epics_search_vector_idx"
+    execute "ALTER TABLE epics DROP COLUMN IF EXISTS search_vector"
+
+    execute "DROP INDEX IF EXISTS projects_search_vector_idx"
+    execute "ALTER TABLE projects DROP COLUMN IF EXISTS search_vector"
+
+    execute "DROP INDEX IF EXISTS stories_search_vector_idx"
+    execute "ALTER TABLE stories DROP COLUMN IF EXISTS search_vector"
+  end
+end

--- a/priv/repo/migrations/20260712000000_add_search_vectors_to_backing_tables.exs
+++ b/priv/repo/migrations/20260712000000_add_search_vectors_to_backing_tables.exs
@@ -3,9 +3,9 @@ defmodule Loopctl.Repo.Migrations.AddSearchVectorsToBackingTables do
   US-30.3 / AC-30.3.4 — adds INDEXED full-text search columns to the phase-1
   Context-Retriever backing tables (`stories`, `projects`, `epics`).
 
-  Each table gets a `search_vector` generated `tsvector` column covering ONLY
-  that source's allowlisted TEXT columns (US-30.1 `@column_allowlist`), plus a
-  GIN index over it. `Loopctl.ContextRetriever.Executor` runs
+  Each table gets a `search_vector` `tsvector` column covering ONLY that source's
+  allowlisted TEXT columns (US-30.1 `@column_allowlist`), plus a GIN index over
+  it. `Loopctl.ContextRetriever.Executor` runs
   `search_vector @@ websearch_to_tsquery('english', ?)` against this column so
   full-text search hits the GIN index instead of an on-the-fly `to_tsvector`
   sequential scan (and never `ILIKE`).
@@ -14,56 +14,133 @@ defmodule Loopctl.Repo.Migrations.AddSearchVectorsToBackingTables do
   (`20260410021836_add_search_vector_to_articles.exs`): the primary title/name
   field is weight `A`, secondary description/mission text `B`/`C`.
 
-  These tables already have RLS enabled — this migration only adds a column and
-  an index, so it does NOT touch RLS.
+  ## Online strategy (repo `CONCURRENTLY` convention)
+
+  `stories` / `projects` / `epics` are the core, most-trafficked work-breakdown
+  tables, so this migration MUST NOT take a deploy-time write outage on them.
+  A STORED generated column (`ADD COLUMN ... GENERATED ALWAYS AS (...) STORED`)
+  would force a full `ACCESS EXCLUSIVE` table REWRITE of every row, and a plain
+  (non-`CONCURRENTLY`) `CREATE INDEX` would block writes for the build — a write
+  outage on the three hottest tables. Instead, following the repo's established
+  `@disable_ddl_transaction` + `CREATE INDEX CONCURRENTLY` convention
+  (`20260625120000_add_articles_source_keyset_index.exs`,
+  `20260709000100_add_memories_embedding_hnsw_index.exs`), we:
+
+    1. ADD a PLAIN nullable `tsvector` column — a metadata-only catalog change
+       (momentary lock, NO table rewrite);
+    2. install a `BEFORE INSERT OR UPDATE` trigger that maintains the column,
+       giving the same self-maintaining behavior a generated column would have,
+       WITHOUT the up-front rewrite;
+    3. backfill existing rows in bounded batches, committing between batches (the
+       migration runs OUTSIDE a transaction) so no single long-held lock;
+    4. build each GIN index `CONCURRENTLY` (no write block).
+
+  `Loopctl.ContextRetriever.Entity.search_vector_columns/0` mirrors the COLUMN
+  SET each vector covers; the weighted expressions in `@configs` below MUST stay
+  in lockstep with it (stories/epics: title + description; projects: name +
+  description + mission).
+
+  These tables already have RLS enabled — this migration only adds a column, a
+  trigger, and an index, so it does NOT touch RLS.
   """
 
   use Ecto.Migration
 
+  # Backfill + CONCURRENTLY index builds cannot run inside a transaction, and the
+  # batched backfill needs each batch to commit independently.
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  # Rows updated per backfill batch. Bounded so each UPDATE holds row locks only
+  # briefly before committing.
+  @backfill_batch_size 5_000
+
+  # table => weighted `{column, weight}` set the search_vector covers. MUST mirror
+  # `Entity.search_vector_columns/0`. The weighted tsvector expression is built
+  # from this both for the trigger (columns qualified `NEW.`) and the backfill /
+  # would-be-generated form (bare column names).
+  @configs [
+    %{table: "stories", columns: [{"title", "A"}, {"description", "B"}]},
+    %{table: "projects", columns: [{"name", "A"}, {"description", "B"}, {"mission", "C"}]},
+    %{table: "epics", columns: [{"title", "A"}, {"description", "B"}]}
+  ]
+
   def up do
-    # stories: title (A) + description (B)
-    execute """
-    ALTER TABLE stories ADD COLUMN search_vector tsvector
-    GENERATED ALWAYS AS (
-      setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
-      setweight(to_tsvector('english', coalesce(description, '')), 'B')
-    ) STORED
-    """
+    for %{table: table, columns: columns} <- @configs do
+      # 1. Plain nullable column — metadata-only, no table rewrite.
+      execute "ALTER TABLE #{table} ADD COLUMN search_vector tsvector"
 
-    execute "CREATE INDEX stories_search_vector_idx ON stories USING GIN (search_vector)"
+      # 2. Self-maintaining trigger (same effect as a generated column, no
+      #    rewrite). In a plpgsql assignment the tsvector expression is evaluated
+      #    with NO table in scope, so each column MUST be qualified `NEW.<col>`.
+      execute """
+      CREATE OR REPLACE FUNCTION #{table}_search_vector_update() RETURNS trigger AS $$
+      BEGIN
+        NEW.search_vector := #{tsvector_expr(columns, "NEW.")};
+        RETURN NEW;
+      END
+      $$ LANGUAGE plpgsql
+      """
 
-    # projects: name (A) + description (B) + mission (C)
-    execute """
-    ALTER TABLE projects ADD COLUMN search_vector tsvector
-    GENERATED ALWAYS AS (
-      setweight(to_tsvector('english', coalesce(name, '')), 'A') ||
-      setweight(to_tsvector('english', coalesce(description, '')), 'B') ||
-      setweight(to_tsvector('english', coalesce(mission, '')), 'C')
-    ) STORED
-    """
+      execute """
+      CREATE TRIGGER #{table}_search_vector_trg
+      BEFORE INSERT OR UPDATE ON #{table}
+      FOR EACH ROW EXECUTE FUNCTION #{table}_search_vector_update()
+      """
 
-    execute "CREATE INDEX projects_search_vector_idx ON projects USING GIN (search_vector)"
+      # Ensure column + trigger exist before the raw backfill queries run.
+      flush()
 
-    # epics: title (A) + description (B)
-    execute """
-    ALTER TABLE epics ADD COLUMN search_vector tsvector
-    GENERATED ALWAYS AS (
-      setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
-      setweight(to_tsvector('english', coalesce(description, '')), 'B')
-    ) STORED
-    """
+      # 3. Batched backfill — bounded UPDATEs, each auto-committing. The UPDATE
+      #    evaluates the expression against the row being updated, so columns are
+      #    referenced bare (no `NEW.` prefix).
+      backfill(table, tsvector_expr(columns, ""))
 
-    execute "CREATE INDEX epics_search_vector_idx ON epics USING GIN (search_vector)"
+      # 4. GIN index built CONCURRENTLY so the build does not block writes.
+      execute """
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS #{table}_search_vector_idx
+      ON #{table} USING GIN (search_vector)
+      """
+    end
   end
 
   def down do
-    execute "DROP INDEX IF EXISTS epics_search_vector_idx"
-    execute "ALTER TABLE epics DROP COLUMN IF EXISTS search_vector"
+    for %{table: table} <- Enum.reverse(@configs) do
+      execute "DROP INDEX CONCURRENTLY IF EXISTS #{table}_search_vector_idx"
+      execute "DROP TRIGGER IF EXISTS #{table}_search_vector_trg ON #{table}"
+      execute "DROP FUNCTION IF EXISTS #{table}_search_vector_update()"
+      execute "ALTER TABLE #{table} DROP COLUMN IF EXISTS search_vector"
+    end
+  end
 
-    execute "DROP INDEX IF EXISTS projects_search_vector_idx"
-    execute "ALTER TABLE projects DROP COLUMN IF EXISTS search_vector"
+  # Populate `search_vector` for pre-existing rows in bounded batches. Each batch
+  # is a self-contained UPDATE that commits before the next (the migration runs
+  # outside a transaction), so no long-held lock. New rows inserted during the
+  # backfill already have `search_vector` set by the trigger, so the
+  # `search_vector IS NULL` predicate converges to zero.
+  defp backfill(table, expr) do
+    Stream.repeatedly(fn ->
+      %{num_rows: num_rows} =
+        repo().query!("""
+        UPDATE #{table} SET search_vector = #{expr}
+        WHERE id IN (
+          SELECT id FROM #{table} WHERE search_vector IS NULL LIMIT #{@backfill_batch_size}
+        )
+        """)
 
-    execute "DROP INDEX IF EXISTS stories_search_vector_idx"
-    execute "ALTER TABLE stories DROP COLUMN IF EXISTS search_vector"
+      num_rows
+    end)
+    |> Enum.take_while(fn num_rows -> num_rows > 0 end)
+  end
+
+  # Weighted tsvector expression over `{column, weight}` pairs. `prefix` is
+  # `"NEW."` for the trigger body (no table in scope) and `""` for the backfill
+  # UPDATE (columns resolve against the updated row).
+  defp tsvector_expr(columns, prefix) do
+    columns
+    |> Enum.map(fn {col, weight} ->
+      "setweight(to_tsvector('english', coalesce(#{prefix}#{col}, '')), '#{weight}')"
+    end)
+    |> Enum.join(" || ")
   end
 end

--- a/test/loopctl/context_retriever/executor_test.exs
+++ b/test/loopctl/context_retriever/executor_test.exs
@@ -27,6 +27,7 @@ defmodule Loopctl.ContextRetriever.ExecutorTest do
   alias Loopctl.AdminRepo
   alias Loopctl.Audit.AuditLog
   alias Loopctl.ContextRetriever.Executor
+  alias Loopctl.ContextRetriever.MockAudit
   alias Loopctl.ContextRetriever.Registry
   alias Loopctl.ContextRetriever.Scope
   alias Loopctl.Projects.Project
@@ -296,6 +297,113 @@ defmodule Loopctl.ContextRetriever.ExecutorTest do
                Executor.run(scope_for(tenant), {"story", "estimated_hours", :filter}, %{
                  "estimated_hours" => "1.5"
                })
+    end
+  end
+
+  describe "TC-30.3.7 — mistyped filter value returns an empty page (no DB type error)" do
+    test "a non-numeric value for an integer-declared field yields zero rows via :no_match" do
+      tenant = repo_tenant()
+      seed_story(tenant.id, %{title: "Has a sort key", number: "101"})
+
+      # sort_key is an allowlisted stories column declared here as an integer.
+      create_story_entity(tenant.id, [
+        %{name: "sort_key", type: :integer, filterable: true, searchable: false}
+      ])
+
+      # "not-a-number" cannot represent the declared integer type -> cast_value/2
+      # returns :no_match, so the executor returns an empty page WITHOUT issuing a
+      # query (never a DB type error).
+      assert {:ok, %{results: [], meta: meta}} =
+               Executor.run(scope_for(tenant), {"story", "sort_key", :filter}, %{
+                 "sort_key" => "not-a-number"
+               })
+
+      assert meta.total_count == 0
+
+      # Still audited (row_count 0) — the value never reached the DB.
+      assert [audit] = context_audits(tenant.id)
+      assert audit.metadata["row_count"] == 0
+    end
+
+    test "a nil filter value yields zero rows via :no_match" do
+      tenant = repo_tenant()
+      seed_story(tenant.id, %{title: "Present", number: "101"})
+      create_story_entity(tenant.id, @story_fields)
+
+      # No value supplied for the declared field -> fetch_param returns nil ->
+      # cast_value(nil, _) is :no_match -> empty page, no query.
+      assert {:ok, %{results: [], meta: %{total_count: 0}}} =
+               Executor.run(scope_for(tenant), {"story", "title", :filter}, %{})
+    end
+  end
+
+  describe "AC-30.3.4 — search rejected when a declared searchable column is not vector-indexed" do
+    test "a searchable column outside the source search_vector returns :search_not_indexed" do
+      tenant = repo_tenant()
+      seed_story(tenant.id, %{title: "Anything", number: "101"})
+
+      # agent_status is allowlisted + declarable as a string, but is NOT covered by
+      # the stories search_vector (title + description). The executor must REJECT
+      # the search rather than silently match against title/description.
+      create_story_entity(tenant.id, [
+        %{name: "agent_status", type: :string, filterable: false, searchable: true}
+      ])
+
+      assert {:error, :search_not_indexed} =
+               Executor.run(scope_for(tenant), {"story", nil, :search}, %{"query" => "anything"})
+
+      # Rejected before any query/audit.
+      assert context_audits(tenant.id) == []
+    end
+  end
+
+  describe "invalid-operation branches" do
+    test "search over an entity with no searchable text field returns :invalid_operation" do
+      tenant = repo_tenant()
+      seed_story(tenant.id, %{title: "x", number: "101"})
+
+      # Only a non-searchable filterable field declared -> no searchable columns.
+      create_story_entity(tenant.id, [
+        %{name: "number", type: :string, filterable: true, searchable: false}
+      ])
+
+      assert {:error, :invalid_operation} =
+               Executor.run(scope_for(tenant), {"story", nil, :search}, %{"query" => "x"})
+
+      assert context_audits(tenant.id) == []
+    end
+
+    test "an unknown operation is rejected with :invalid_operation" do
+      tenant = repo_tenant()
+      create_story_entity(tenant.id, @story_fields)
+
+      assert {:error, :invalid_operation} =
+               Executor.run(scope_for(tenant), {"story", "title", :bogus_op}, %{"title" => "x"})
+
+      assert context_audits(tenant.id) == []
+    end
+  end
+
+  describe "AC-30.3.6 — audit failure fails the read closed" do
+    test "when the audit write fails, run/3 returns {:error, :audit_failed} and no rows leak" do
+      tenant = repo_tenant()
+      seed_story(tenant.id, %{title: "Audited", number: "101"})
+      create_story_entity(tenant.id, @story_fields)
+
+      # Force the audit insert to fail for this call (overrides the DataCase default
+      # stub that delegates to the real Loopctl.Audit).
+      expect(MockAudit, :create_log_entry, fn _tenant_id, _attrs ->
+        {:error, :db_unavailable}
+      end)
+
+      assert {:error, :audit_failed} =
+               Executor.run(scope_for(tenant), {"story", "title", :filter}, %{
+                 "title" => "Audited"
+               })
+
+      # No rows disclosed to the caller AND no audit row persisted — chain of
+      # custody is preserved by failing closed.
+      assert context_audits(tenant.id) == []
     end
   end
 

--- a/test/loopctl/context_retriever/executor_test.exs
+++ b/test/loopctl/context_retriever/executor_test.exs
@@ -1,0 +1,321 @@
+defmodule Loopctl.ContextRetriever.ExecutorTest do
+  @moduledoc """
+  US-30.3 — integration tests for `Loopctl.ContextRetriever.Executor.run/3`, the
+  security boundary that turns a generated tool call into a safe, parameterized,
+  tenant-scoped Ecto query.
+
+  ## Why `async: false` + `Repo`-connection seeding
+
+  The executor reads through `Loopctl.Repo.with_tenant/2` (RLS transactions with
+  `SET LOCAL ROLE loopctl_app`), which needs shared sandbox mode and
+  same-connection seeding. The backing rows (projects/epics/stories) and the
+  tenant are therefore seeded via `Repo` (NOT the AdminRepo-backed `fixture/2`),
+  so they live on the SAME DB connection the executor reads on — mirroring
+  `registry_test.exs`'s `repo_tenant/0` pattern.
+
+  Because the isolation assertions run under the NON-owner app role (RLS is ENABLE
+  not FORCE), they actually prove tenant isolation rather than silently passing
+  (AC-30.3.2). Audit rows are written by the executor via `AdminRepo`
+  (`Audit.create_log_entry/2`) and read back via `AdminRepo` here.
+  """
+  use Loopctl.DataCase, async: false
+
+  setup :verify_on_exit!
+
+  import Ecto.Query
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Audit.AuditLog
+  alias Loopctl.ContextRetriever.Executor
+  alias Loopctl.ContextRetriever.Registry
+  alias Loopctl.ContextRetriever.Scope
+  alias Loopctl.Projects.Project
+  alias Loopctl.Tenants.Tenant
+  alias Loopctl.WorkBreakdown.Epic
+  alias Loopctl.WorkBreakdown.Story
+
+  # --- Repo-connection seeding helpers (see moduledoc) ---
+
+  defp repo_tenant do
+    seq = System.unique_integer([:positive])
+
+    %Tenant{}
+    |> Tenant.create_changeset(%{
+      name: "Test Tenant #{seq}",
+      slug: "test-tenant-#{seq}",
+      email: "test-#{seq}@example.com",
+      status: :active
+    })
+    |> Repo.insert!()
+  end
+
+  defp seed_project(tenant_id, attrs \\ %{}) do
+    %Project{tenant_id: tenant_id}
+    |> Project.create_changeset(build(:project, attrs))
+    |> Repo.insert!()
+  end
+
+  defp seed_epic(tenant_id, project_id, attrs \\ %{}) do
+    %Epic{tenant_id: tenant_id, project_id: project_id}
+    |> Epic.create_changeset(build(:epic, attrs))
+    |> Repo.insert!()
+  end
+
+  defp seed_story(tenant_id, attrs) do
+    project = seed_project(tenant_id)
+    epic = seed_epic(tenant_id, project.id)
+
+    %Story{tenant_id: tenant_id, project_id: project.id, epic_id: epic.id}
+    |> Story.create_changeset(build(:story, attrs))
+    |> Repo.insert!()
+  end
+
+  defp create_story_entity(tenant_id, fields) do
+    {:ok, entity} =
+      Registry.create_entity(tenant_id, %{name: "story", backing_source: :stories, fields: fields})
+
+    entity
+  end
+
+  defp scope_for(tenant) do
+    %Scope{
+      tenant_id: tenant.id,
+      role: :agent,
+      actor_id: Ecto.UUID.generate(),
+      actor_label: "agent:test"
+    }
+  end
+
+  defp context_audits(tenant_id) do
+    AdminRepo.all(
+      from a in AuditLog,
+        where: a.tenant_id == ^tenant_id and a.entity_type == "context_retrieval"
+    )
+  end
+
+  # title (filterable + searchable) + number (filterable) — enough to distinguish
+  # rows across tenants in the result projection (id is not allowlisted).
+  @story_fields [
+    %{name: "title", type: :string, filterable: true, searchable: true},
+    %{name: "number", type: :string, filterable: true, searchable: false}
+  ]
+
+  describe "TC-30.3.1 — filter: parameterized, tenant-scoped, shaped, audited" do
+    test "returns only caller-tenant matching rows with meta and writes an audit row" do
+      tenant_a = repo_tenant()
+      tenant_b = repo_tenant()
+
+      seed_story(tenant_a.id, %{title: "Shared Title", number: "101"})
+      seed_story(tenant_a.id, %{title: "Other", number: "102"})
+      # Tenant B has an IDENTICALLY-titled row that must never surface for A.
+      seed_story(tenant_b.id, %{title: "Shared Title", number: "201"})
+
+      create_story_entity(tenant_a.id, @story_fields)
+      scope = scope_for(tenant_a)
+
+      assert {:ok, %{results: results, meta: meta}} =
+               Executor.run(scope, {"story", "title", :filter}, %{"title" => "Shared Title"})
+
+      # Only tenant A's matching row, shaped to declared fields only.
+      assert results == [%{title: "Shared Title", number: "101"}]
+      assert meta.total_count == 1
+      assert meta.limit == 5
+      assert meta.offset == 0
+
+      # Audit row captures the execution.
+      assert [audit] = context_audits(tenant_a.id)
+      assert audit.action == "filter"
+      assert audit.actor_label == "agent:test"
+      assert audit.metadata["entity"] == "story"
+      assert audit.metadata["field"] == "title"
+      assert audit.metadata["operation"] == "filter"
+      assert audit.metadata["row_count"] == 1
+      assert is_binary(audit.metadata["param_digest"])
+      # Raw filter value is never stored.
+      refute audit.metadata["param_digest"] =~ "Shared Title"
+    end
+  end
+
+  describe "TC-30.3.2 — non-allowlisted field rejected at execute time" do
+    test "a field the entity does not declare is rejected, no query run, no audit" do
+      tenant = repo_tenant()
+      seed_story(tenant.id, %{title: "Anything", number: "101"})
+      create_story_entity(tenant.id, @story_fields)
+
+      assert {:error, :field_not_allowlisted} =
+               Executor.run(scope_for(tenant), {"story", "tenant_id", :filter}, %{
+                 "tenant_id" => "x"
+               })
+
+      # Rejected before any query/audit.
+      assert context_audits(tenant.id) == []
+    end
+
+    test "a declared-but-non-filterable field is rejected" do
+      tenant = repo_tenant()
+      seed_story(tenant.id, %{title: "Anything", number: "101"})
+
+      # description declared searchable only (filterable: false).
+      create_story_entity(tenant.id, [
+        %{name: "title", type: :string, filterable: true, searchable: true},
+        %{name: "description", type: :string, filterable: false, searchable: true}
+      ])
+
+      assert {:error, :field_not_allowlisted} =
+               Executor.run(scope_for(tenant), {"story", "description", :filter}, %{
+                 "description" => "x"
+               })
+    end
+
+    test "an unknown entity is rejected" do
+      tenant = repo_tenant()
+
+      assert {:error, :unknown_entity} =
+               Executor.run(scope_for(tenant), {"nope", "title", :filter}, %{"title" => "x"})
+    end
+  end
+
+  describe "TC-30.3.3 — injection payloads are literals, not SQL" do
+    test "a filter injection value matches nothing and raises no SQL error" do
+      tenant = repo_tenant()
+      seed_story(tenant.id, %{title: "Legit", number: "101"})
+      create_story_entity(tenant.id, @story_fields)
+
+      assert {:ok, %{results: [], meta: %{total_count: 0}}} =
+               Executor.run(scope_for(tenant), {"story", "title", :filter}, %{
+                 "title" => "' OR 1=1 --"
+               })
+    end
+
+    test "a search injection query matches nothing and does not drop the table" do
+      tenant = repo_tenant()
+      seed_story(tenant.id, %{title: "Legit story", number: "101"})
+      create_story_entity(tenant.id, @story_fields)
+
+      assert {:ok, %{results: [], meta: %{total_count: 0}}} =
+               Executor.run(scope_for(tenant), {"story", nil, :search}, %{
+                 "query" => "'; DROP TABLE stories; --"
+               })
+
+      # The table still exists and is queryable — the payload was a literal.
+      assert Repo.aggregate(from(s in Story), :count, :id) >= 0
+    end
+  end
+
+  describe "TC-30.3.4 — full-text search via GIN-indexed tsvector" do
+    test "search matches on the indexed search_vector and returns a shaped page" do
+      tenant = repo_tenant()
+      seed_story(tenant.id, %{title: "Photosynthesis research notes", number: "101"})
+      seed_story(tenant.id, %{title: "Unrelated topic", number: "102"})
+      create_story_entity(tenant.id, @story_fields)
+
+      assert {:ok, %{results: results, meta: meta}} =
+               Executor.run(scope_for(tenant), {"story", nil, :search}, %{
+                 "query" => "photosynthesis"
+               })
+
+      assert results == [%{title: "Photosynthesis research notes", number: "101"}]
+      assert meta.total_count == 1
+
+      # Search is audited too.
+      assert [audit] = context_audits(tenant.id)
+      assert audit.action == "search"
+      assert audit.metadata["operation"] == "search"
+    end
+  end
+
+  describe "TC-30.3.5 — pagination cap + tenant override defense" do
+    test "results are capped at the max page size; params[:tenant_id] cannot widen scope" do
+      tenant_a = repo_tenant()
+      tenant_b = repo_tenant()
+
+      for i <- 1..7 do
+        seed_story(tenant_a.id, %{title: "PageTest", number: "#{100 + i}"})
+      end
+
+      seed_story(tenant_b.id, %{title: "PageTest", number: "201"})
+
+      create_story_entity(tenant_a.id, @story_fields)
+
+      assert {:ok, %{results: results, meta: meta}} =
+               Executor.run(scope_for(tenant_a), {"story", "title", :filter}, %{
+                 "title" => "PageTest",
+                 "limit" => 100,
+                 # A malicious tenant override that must be ignored entirely.
+                 "tenant_id" => tenant_b.id
+               })
+
+      # Capped at config max (5 in test.exs), not the requested 100.
+      assert length(results) == 5
+      assert meta.limit == 5
+      # total_count counts ALL of tenant A's 7 matches — NOT tenant B's row,
+      # proving the param tenant_id did not widen the scope.
+      assert meta.total_count == 7
+
+      # offset paging returns the rest, still capped and tenant-scoped.
+      assert {:ok, %{results: page2, meta: meta2}} =
+               Executor.run(scope_for(tenant_a), {"story", "title", :filter}, %{
+                 "title" => "PageTest",
+                 "limit" => 100,
+                 "offset" => 5
+               })
+
+      assert length(page2) == 2
+      assert meta2.offset == 5
+      assert meta2.total_count == 7
+    end
+  end
+
+  describe "TC-30.3.6 — fail-closed edges" do
+    test "a nil-tenant (superadmin) scope is refused with no cross-tenant read" do
+      superadmin_scope = %Scope{tenant_id: nil, role: :superadmin, actor_label: "superadmin"}
+
+      assert {:error, :no_tenant} =
+               Executor.run(superadmin_scope, {"story", "title", :filter}, %{"title" => "x"})
+    end
+
+    test "a declared field whose backing column was dropped returns :stale_entity" do
+      tenant = repo_tenant()
+      seed_story(tenant.id, %{title: "Some story", number: "101"})
+
+      # estimated_hours is server-allowlisted and text-safe to drop (not part of
+      # search_vector). Declaring it filterable, then dropping the underlying
+      # column, simulates a stale entity def.
+      create_story_entity(tenant.id, [
+        %{name: "estimated_hours", type: :float, filterable: true, searchable: false}
+      ])
+
+      # Drop the backing column on the Repo connection (rolls back at test exit).
+      # `create_story_entity/2` ran through `Repo.with_tenant`, whose
+      # `SET LOCAL ROLE loopctl_app` persists for the rest of the sandbox
+      # transaction; reset to the owner role so the DDL is permitted.
+      Repo.query!("RESET ROLE")
+      Repo.query!("ALTER TABLE stories DROP COLUMN estimated_hours")
+
+      assert {:error, :stale_entity} =
+               Executor.run(scope_for(tenant), {"story", "estimated_hours", :filter}, %{
+                 "estimated_hours" => "1.5"
+               })
+    end
+  end
+
+  describe "tenant isolation (CLAUDE.md mandatory)" do
+    test "tenant A's search never returns tenant B's rows" do
+      tenant_a = repo_tenant()
+      tenant_b = repo_tenant()
+
+      seed_story(tenant_a.id, %{title: "Isolation keyword alpha", number: "101"})
+      seed_story(tenant_b.id, %{title: "Isolation keyword beta", number: "201"})
+
+      create_story_entity(tenant_a.id, @story_fields)
+
+      assert {:ok, %{results: results}} =
+               Executor.run(scope_for(tenant_a), {"story", nil, :search}, %{
+                 "query" => "isolation"
+               })
+
+      # Only tenant A's row, under the non-owner app role.
+      assert results == [%{title: "Isolation keyword alpha", number: "101"}]
+    end
+  end
+end

--- a/test/loopctl/context_retriever/executor_test.exs
+++ b/test/loopctl/context_retriever/executor_test.exs
@@ -101,6 +101,12 @@ defmodule Loopctl.ContextRetriever.ExecutorTest do
     %{name: "number", type: :string, filterable: true, searchable: false}
   ]
 
+  # agent_status is an Ecto.Enum column, declared here as a filterable string —
+  # the canonical enum-filter path exercised by the HIGH-finding regression tests.
+  @agent_status_fields [
+    %{name: "agent_status", type: :string, filterable: true, searchable: false}
+  ]
+
   describe "TC-30.3.1 — filter: parameterized, tenant-scoped, shaped, audited" do
     test "returns only caller-tenant matching rows with meta and writes an audit row" do
       tenant_a = repo_tenant()
@@ -279,11 +285,12 @@ defmodule Loopctl.ContextRetriever.ExecutorTest do
       tenant = repo_tenant()
       seed_story(tenant.id, %{title: "Some story", number: "101"})
 
-      # estimated_hours is server-allowlisted and text-safe to drop (not part of
-      # search_vector). Declaring it filterable, then dropping the underlying
-      # column, simulates a stale entity def.
+      # sort_key is a server-allowlisted :integer column, not part of the
+      # search_vector and not :decimal (so it is filter-supported). Declaring it
+      # filterable, then dropping the underlying column, simulates a stale entity
+      # def whose backing column no longer exists.
       create_story_entity(tenant.id, [
-        %{name: "estimated_hours", type: :float, filterable: true, searchable: false}
+        %{name: "sort_key", type: :integer, filterable: true, searchable: false}
       ])
 
       # Drop the backing column on the Repo connection (rolls back at test exit).
@@ -291,11 +298,11 @@ defmodule Loopctl.ContextRetriever.ExecutorTest do
       # `SET LOCAL ROLE loopctl_app` persists for the rest of the sandbox
       # transaction; reset to the owner role so the DDL is permitted.
       Repo.query!("RESET ROLE")
-      Repo.query!("ALTER TABLE stories DROP COLUMN estimated_hours")
+      Repo.query!("ALTER TABLE stories DROP COLUMN sort_key")
 
       assert {:error, :stale_entity} =
-               Executor.run(scope_for(tenant), {"story", "estimated_hours", :filter}, %{
-                 "estimated_hours" => "1.5"
+               Executor.run(scope_for(tenant), {"story", "sort_key", :filter}, %{
+                 "sort_key" => "3"
                })
     end
   end
@@ -404,6 +411,111 @@ defmodule Loopctl.ContextRetriever.ExecutorTest do
       # No rows disclosed to the caller AND no audit row persisted — chain of
       # custody is preserved by failing closed.
       assert context_audits(tenant.id) == []
+    end
+  end
+
+  describe "enum-status filter — the canonical filter use case (HIGH-finding regression)" do
+    # agent_status is an Ecto.Enum column. cast_value/2 can only cast to the
+    # declared "string" type, but Ecto re-casts the pinned value against the
+    # column's REAL enum type at query normalization — a non-member value raises
+    # Ecto.Query.CastError. run_query/6 must map that to :no_match (zero rows,
+    # still audited), NOT crash and NOT disclose the enum member set.
+    test "filtering by a VALID enum member returns matching rows" do
+      tenant = repo_tenant()
+      # seed_story defaults agent_status to :pending.
+      seed_story(tenant.id, %{title: "Pending story", number: "101"})
+      create_story_entity(tenant.id, @agent_status_fields)
+
+      assert {:ok, %{results: results, meta: meta}} =
+               Executor.run(scope_for(tenant), {"story", "agent_status", :filter}, %{
+                 "agent_status" => "pending"
+               })
+
+      assert results == [%{agent_status: :pending}]
+      assert meta.total_count == 1
+    end
+
+    test "an injection payload on the enum column matches nothing (no crash, no disclosure)" do
+      tenant = repo_tenant()
+      seed_story(tenant.id, %{title: "Pending story", number: "101"})
+      create_story_entity(tenant.id, @agent_status_fields)
+
+      assert {:ok, %{results: [], meta: %{total_count: 0}}} =
+               Executor.run(scope_for(tenant), {"story", "agent_status", :filter}, %{
+                 "agent_status" => "' OR 1=1 --"
+               })
+
+      # Still audited (row_count 0) even though the value never matched a member.
+      assert [audit] = context_audits(tenant.id)
+      assert audit.metadata["row_count"] == 0
+    end
+
+    test "a non-member / stale status value returns an empty page rather than crashing" do
+      tenant = repo_tenant()
+      seed_story(tenant.id, %{title: "Pending story", number: "101"})
+      create_story_entity(tenant.id, @agent_status_fields)
+
+      # "ready" is a plausible typo / stale status that is NOT a current enum
+      # member — it must return zero rows, not raise Ecto.Query.CastError.
+      assert {:ok, %{results: [], meta: %{total_count: 0}}} =
+               Executor.run(scope_for(tenant), {"story", "agent_status", :filter}, %{
+                 "agent_status" => "ready"
+               })
+    end
+  end
+
+  describe "decimal-column filter is rejected as unsupported" do
+    test "a filter on the :decimal estimated_hours column returns :unsupported_filter_type" do
+      tenant = repo_tenant()
+      seed_story(tenant.id, %{title: "Has hours", number: "101"})
+
+      # estimated_hours is a :decimal column; exact float8 equality against NUMERIC
+      # is representation-fragile, so an equality filter on it is rejected rather
+      # than silently returning wrong/empty rows.
+      create_story_entity(tenant.id, [
+        %{name: "estimated_hours", type: :float, filterable: true, searchable: false}
+      ])
+
+      assert {:error, :unsupported_filter_type} =
+               Executor.run(scope_for(tenant), {"story", "estimated_hours", :filter}, %{
+                 "estimated_hours" => "0.5"
+               })
+
+      # Rejected before any query/audit.
+      assert context_audits(tenant.id) == []
+    end
+  end
+
+  describe "malformed calls fail closed (no FunctionClauseError)" do
+    test "a non-map params returns :invalid_params" do
+      tenant = repo_tenant()
+
+      assert {:error, :invalid_params} =
+               Executor.run(scope_for(tenant), {"story", "title", :filter}, [1, 2, 3])
+    end
+
+    test "a non-tuple dispatch returns :invalid_params" do
+      tenant = repo_tenant()
+
+      assert {:error, :invalid_params} =
+               Executor.run(scope_for(tenant), "not-a-tuple", %{"x" => 1})
+    end
+  end
+
+  describe "pagination offset is capped" do
+    test "an absurd offset is clamped to the configured max (no unbounded scan)" do
+      tenant = repo_tenant()
+      seed_story(tenant.id, %{title: "OffsetCap", number: "101"})
+      create_story_entity(tenant.id, @story_fields)
+
+      assert {:ok, %{results: [], meta: meta}} =
+               Executor.run(scope_for(tenant), {"story", "title", :filter}, %{
+                 "title" => "OffsetCap",
+                 "offset" => 100_000_000
+               })
+
+      # Clamped to the test-config max (50), not the requested 100_000_000.
+      assert meta.offset == 50
     end
   end
 

--- a/test/loopctl/context_retriever/tool_generator_test.exs
+++ b/test/loopctl/context_retriever/tool_generator_test.exs
@@ -87,7 +87,9 @@ defmodule Loopctl.ContextRetriever.ToolGeneratorTest do
 
       assert status_spec.input_schema["required"] == ["status"]
       assert status_spec.input_schema["properties"]["limit"] == %{"type" => "integer"}
-      assert status_spec.input_schema["properties"]["cursor"] == %{"type" => "string"}
+      # Pagination is offset-based to match the US-30.3 executor (AC-30.3.5).
+      assert status_spec.input_schema["properties"]["offset"] == %{"type" => "integer"}
+      refute Map.has_key?(status_spec.input_schema["properties"], "cursor")
     end
 
     test "search tool input schema requires query and exposes pagination", %{specs: specs} do
@@ -96,7 +98,9 @@ defmodule Loopctl.ContextRetriever.ToolGeneratorTest do
       assert search_spec.input_schema["required"] == ["query"]
       assert search_spec.input_schema["properties"]["query"] == %{"type" => "string"}
       assert search_spec.input_schema["properties"]["limit"] == %{"type" => "integer"}
-      assert search_spec.input_schema["properties"]["cursor"] == %{"type" => "string"}
+      # Pagination is offset-based to match the US-30.3 executor (AC-30.3.5).
+      assert search_spec.input_schema["properties"]["offset"] == %{"type" => "integer"}
+      refute Map.has_key?(search_spec.input_schema["properties"], "cursor")
     end
   end
 
@@ -258,6 +262,42 @@ defmodule Loopctl.ContextRetriever.ToolGeneratorTest do
 
       assert search_spec
       assert search_spec.metadata.searchable_fields == ["description"]
+    end
+  end
+
+  describe "specs_for/1 — AC-30.3.4 (search tool suppressed when a searchable field is not vector-indexed)" do
+    test "a searchable text field not covered by the source search_vector suppresses the search tool" do
+      # agent_status is an allowlisted stories column (so it may be declared) that
+      # the generated search_vector (title + description) does NOT cover. Declaring
+      # it searchable must NOT produce a search tool the executor would answer over
+      # title/description instead.
+      entity = %Entity{
+        name: "story",
+        backing_source: :stories,
+        fields: [
+          %{name: "agent_status", type: "string", filterable: false, searchable: true}
+        ]
+      }
+
+      assert ToolGenerator.specs_for(entity) == []
+    end
+
+    test "a mix of vector-covered and non-covered searchable fields still suppresses the tool" do
+      # title IS covered but agent_status is not; because the fixed vector cannot
+      # index agent_status, the whole search tool is suppressed rather than emit
+      # one that silently omits the declared-but-unindexed column.
+      entity = %Entity{
+        name: "story",
+        backing_source: :stories,
+        fields: [
+          %{name: "title", type: "string", filterable: false, searchable: true},
+          %{name: "agent_status", type: "string", filterable: false, searchable: true}
+        ]
+      }
+
+      specs = ToolGenerator.specs_for(entity)
+
+      refute Enum.any?(specs, &(&1.name == "cr_search_story"))
     end
   end
 

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -216,6 +216,14 @@ defmodule Loopctl.DataCase do
       {:error, :not_configured}
     end)
 
+    # US-30.3: Context-Retriever audit writer. The DEFAULT delegates to the real
+    # Loopctl.Audit so every existing executor test writes and reads back a genuine
+    # audit row unchanged. The fail-closed test overrides this with Mox.expect/3 to
+    # return {:error, _} and assert run/3 returns {:error, :audit_failed}.
+    Mox.stub(Loopctl.ContextRetriever.MockAudit, :create_log_entry, fn tenant_id, attrs ->
+      Loopctl.Audit.create_log_entry(tenant_id, attrs)
+    end)
+
     # Epic 28 (#179): default Req.Test stub for the shared tenant-scoped Anthropic
     # client. Returns an empty-articles Messages response with a zero-usage block so
     # any incidental call to a REAL Claude module (only when a tenant key is

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -13,6 +13,16 @@ Mox.defmock(Loopctl.MockSecrets, for: Loopctl.Secrets.Behaviour)
 Mox.defmock(Loopctl.MockSuggestLinks, for: Loopctl.Knowledge.SuggestLinksBehaviour)
 Mox.defmock(Loopctl.MockProposalAssessor, for: Loopctl.Knowledge.ProposalAssessorBehaviour)
 Mox.defmock(Loopctl.MockMergeSynthesizer, for: Loopctl.Knowledge.MergeSynthesizerBehaviour)
+
+# US-30.3: Context-Retriever audit writer DI. The executor treats the audit write
+# as part of the read's correctness (AC-30.3.6 fail-closed). The DataCase default
+# stub delegates to the real Loopctl.Audit so existing executor tests still write
+# and read back real audit rows; the fail-closed test overrides create_log_entry/2
+# with Mox.expect/3 to return {:error, _}.
+Mox.defmock(Loopctl.ContextRetriever.MockAudit,
+  for: Loopctl.ContextRetriever.AuditBehaviour
+)
+
 # ArticleLinkingWorker's injectable similarity lookup. Lets the worker's linking-logic
 # unit tests feed deterministic candidate lists instead of exercising the real 250ms-timed
 # pgvector heavy read (the flake source). DataCase default-stubs `nearest/4` to return [].


### PR DESCRIPTION
## US-30.3 — Context Retriever query executor

`Loopctl.ContextRetriever.Executor.run/3` is the security boundary of Epic 30: it turns a US-30.2-generated tool call into a safe, parameterized, tenant-scoped Ecto query against a loopctl-internal backing table (stories/projects/epics). No model-authored SQL ever reaches the DB.

### Acceptance criteria
- **AC-30.3.1** — Execute-time re-validation of `(field, operation)` against the live entity definition (`entity.fields` + `filterable?`/searchable-text) AND the server per-source column allowlist (US-30.1). A non-allowlisted / non-filterable field is rejected (`:field_not_allowlisted`), never executed — closes the raw-`/retrieve` bypass of generate-time checks.
- **AC-30.3.2** — Dual tenant scoping: `Repo.with_tenant/2` (RLS `SET LOCAL` role + tenant) plus an explicit `tenant_id` predicate. `tenant_id` is read only from the scope, never from params; a param `tenant_id` cannot widen scope.
- **AC-30.3.3** — No model-authored SQL: field names resolve from the allowlist to known column atoms (never `String.to_atom` on model input); values are cast to the declared type and Ecto-pinned; search strings are `websearch_to_tsquery` params. Injection payloads are literals.
- **AC-30.3.4** — Indexed full-text search via a new migration adding GIN-indexed generated `tsvector` columns to `stories`/`projects`/`epics` over their allowlisted text fields; `websearch_to_tsquery`, not `ILIKE` / on-the-fly `to_tsvector`.
- **AC-30.3.5** — Hard max page size (`:context_retriever_max_page_size` config) with `limit` clamping; results shaped to ONLY the entity's declared allowlisted columns via Ecto `map/2`; returns `%{results, meta: %{total_count, limit, offset}}`.
- **AC-30.3.6** — Every execution appends an `audit_log` entry (`context_retrieval`) capturing tenant/actor/entity/field/operation/row_count and a SHA-256 param digest (raw values never stored).
- **AC-30.3.7** — Fail-closed: a nil-tenant (superadmin) scope is refused (`:no_tenant`, no `AdminRepo` read); a dropped/renamed backing column returns `:stale_entity`, never a raw `Postgrex.Error`.

### Files
- `lib/loopctl/context_retriever/executor.ex` — the module.
- `lib/loopctl/context_retriever/scope.ex` — CR access scope struct.
- `priv/repo/migrations/20260712000000_add_search_vectors_to_backing_tables.exs` — GIN tsvector columns (clean up/down).
- `config/config.exs` + `config/test.exs` — CR max page size (5 in test).
- `test/loopctl/context_retriever/executor_test.exs` — TC-30.3.1..6 + tenant isolation, run under the non-owner app role.

### Verification
`mix precommit` green: compile (warnings-as-errors), format, credo --strict, mix_audit, dialyzer, 4040 tests 0 failures. Migration up/down verified reversible.
