### PR TITLE
API: entity-definition CRUD + GET /retrieve/tools + POST /retrieve/:entity

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -388,6 +388,14 @@ config :loopctl, :context_retriever_max_page_size, 100
 # paging still works up to this generous bound.
 config :loopctl, :context_retriever_max_offset, 100_000
 
+# Epic 30 / US-30.4: per-tenant rate limit on the model-invoked
+# `POST /api/v1/retrieve/:entity` endpoint (in ADDITION to the global per-key/
+# per-tenant request limiter). Bounds how often a single tenant may fire the
+# Context Retriever executor within a rolling window so a looping/hostile agent
+# cannot flood it; over-limit returns 429 without executing.
+config :loopctl, :context_retriever_retrieve_rate_window_ms, 60_000
+config :loopctl, :context_retriever_retrieve_rate_limit, 120
+
 # L3 local test runner (Loopctl.Verification.TestRunner). DISABLED by default:
 # it clones a tenant-supplied repo and runs `mix deps.get`/`mix test` on it
 # (untrusted-code execution) and is subject to a clone-time DNS-rebinding SSRF

--- a/lib/loopctl/api_spec/schemas.ex
+++ b/lib/loopctl/api_spec/schemas.ex
@@ -3326,4 +3326,187 @@ defmodule Loopctl.ApiSpec.Schemas do
       }
     })
   end
+
+  # ---------- Context Retriever (Epic 30, US-30.4) ----------
+
+  defmodule EntityDefinitionField do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "EntityDefinitionField",
+      description:
+        "A single declared field on an entity definition. `name` must be a column " <>
+          "in the SERVER per-source allowlist; `type` is one of the allowed field " <>
+          "types. `filterable`/`searchable` gate which tools the field generates.",
+      type: :object,
+      required: [:name, :type],
+      properties: %{
+        name: %Schema{type: :string, description: "Allowlisted column name (snake_case)."},
+        type: %Schema{
+          type: :string,
+          enum: ["string", "integer", "boolean", "float", "datetime"]
+        },
+        filterable: %Schema{type: :boolean, description: "Generate a filter tool. Default false."},
+        searchable: %Schema{
+          type: :boolean,
+          description: "Contribute to the entity's full-text search tool. Default false."
+        }
+      }
+    })
+  end
+
+  defmodule EntityDefinition do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "EntityDefinition",
+      description:
+        "A tenant-authored entity definition: a named, typed view over a " <>
+          "loopctl-internal backing source (projects/stories/epics). Its declared " <>
+          "fields ARE the executor's field allowlist.",
+      type: :object,
+      properties: %{
+        id: %Schema{type: :string, format: :uuid},
+        tenant_id: %Schema{type: :string, format: :uuid},
+        name: %Schema{type: :string},
+        backing_source: %Schema{type: :string, enum: ["projects", "stories", "epics"]},
+        fields: %Schema{type: :array, items: EntityDefinitionField},
+        inserted_at: %Schema{type: :string, format: :"date-time"},
+        updated_at: %Schema{type: :string, format: :"date-time"}
+      }
+    })
+  end
+
+  defmodule EntityDefinitionRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "EntityDefinitionRequest",
+      description:
+        "Params for POST/PATCH /entities. `tenant_id` is derived from the API key " <>
+          "and any tenant_id in the body is ignored. On PATCH, omitted top-level " <>
+          "fields keep their current value.",
+      type: :object,
+      properties: %{
+        name: %Schema{type: :string, description: "Entity name, unique per tenant."},
+        backing_source: %Schema{type: :string, enum: ["projects", "stories", "epics"]},
+        fields: %Schema{type: :array, items: EntityDefinitionField}
+      }
+    })
+  end
+
+  defmodule EntityDefinitionResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "EntityDefinitionResponse",
+      description: "A single entity definition wrapped in `data`.",
+      type: :object,
+      properties: %{data: EntityDefinition}
+    })
+  end
+
+  defmodule EntityDefinitionListResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "EntityDefinitionListResponse",
+      description: "The calling tenant's entity definitions.",
+      type: :object,
+      properties: %{data: %Schema{type: :array, items: EntityDefinition}}
+    })
+  end
+
+  defmodule RetrieveToolSpec do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "RetrieveToolSpec",
+      description:
+        "A generated agent tool spec (from the tenant's entity definitions). " <>
+          "`input_schema` is a JSON Schema for the tool's params; `metadata` is the " <>
+          "executor dispatch contract (entity/backing_source/field/operation).",
+      type: :object,
+      properties: %{
+        name: %Schema{type: :string, description: "Tool name, prefixed `cr_`."},
+        description: %Schema{type: :string},
+        input_schema: %Schema{type: :object, additionalProperties: true},
+        metadata: %Schema{type: :object, additionalProperties: true}
+      }
+    })
+  end
+
+  defmodule RetrieveToolsResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "RetrieveToolsResponse",
+      description:
+        "The generated tool specs for the CALLING tenant only — another tenant's " <>
+          "entities never appear.",
+      type: :object,
+      properties: %{data: %Schema{type: :array, items: RetrieveToolSpec}}
+    })
+  end
+
+  defmodule RetrieveRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "RetrieveRequest",
+      description:
+        "Params for POST /retrieve/:entity. `field` + `op` select the operation " <>
+          "(`filter` needs the matched field's value in `value`; `search` needs " <>
+          "`query`). Any `tenant_id` in the body is ignored (scope is from the key).",
+      type: :object,
+      properties: %{
+        field: %Schema{type: :string, description: "Field to filter on (op=filter)."},
+        op: %Schema{type: :string, enum: ["filter", "search"], description: "Operation."},
+        operation: %Schema{
+          type: :string,
+          enum: ["filter", "search"],
+          description: "Alias for `op`."
+        },
+        value: %Schema{description: "Filter value (op=filter)."},
+        query: %Schema{type: :string, description: "Search string (op=search)."},
+        limit: %Schema{type: :integer, description: "Page size (clamped to the server max)."},
+        offset: %Schema{type: :integer, description: "Records to skip (clamped)."}
+      }
+    })
+  end
+
+  defmodule RetrieveResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "RetrieveResponse",
+      description:
+        "A page of allowlisted-column result maps plus pagination meta. Only the " <>
+          "entity's declared columns appear in each result.",
+      type: :object,
+      properties: %{
+        results: %Schema{
+          type: :array,
+          items: %Schema{type: :object, additionalProperties: true}
+        },
+        meta: %Schema{
+          type: :object,
+          properties: %{
+            total_count: %Schema{type: :integer},
+            limit: %Schema{type: :integer},
+            offset: %Schema{type: :integer}
+          }
+        }
+      }
+    })
+  end
 end

--- a/lib/loopctl/context_retriever/entity.ex
+++ b/lib/loopctl/context_retriever/entity.ex
@@ -234,6 +234,21 @@ defmodule Loopctl.ContextRetriever.Entity do
     )
   end
 
+  @doc """
+  Changeset for updating an existing entity definition (US-30.4 PATCH).
+
+  Applies the EXACT same security validations as `create_changeset/2` — the
+  SERVER column allowlist, the safe-identifier regex, the field-type/boolean
+  checks, the field-key normalization, the non-empty/max-fields caps, and the
+  per-tenant unique name — so a PATCH can never relax the allowlist that a
+  create was held to. `tenant_id` is NEVER cast (it stays on the struct). A
+  partial update (e.g. only `fields`) keeps the row's existing `name`/
+  `backing_source` via `validate_required` reading the struct data, so callers
+  need not resend unchanged columns.
+  """
+  @spec update_changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
+  def update_changeset(%__MODULE__{} = entity, attrs), do: create_changeset(entity, attrs)
+
   @doc "Returns the list of valid backing sources."
   @spec backing_sources() :: [atom()]
   def backing_sources, do: @backing_sources

--- a/lib/loopctl/context_retriever/entity.ex
+++ b/lib/loopctl/context_retriever/entity.ex
@@ -355,12 +355,22 @@ defmodule Loopctl.ContextRetriever.Entity do
     end
   end
 
+  # Validate the RESOLVED fields against the RESOLVED backing_source
+  # UNCONDITIONALLY (via `get_field`, not `validate_change`). `validate_change`
+  # only fires when `:fields` is in the changeset's *changes*, so a partial PATCH
+  # that flips ONLY `backing_source` (leaving the retained fields unchanged) would
+  # otherwise skip the per-source column-allowlist check and persist a definition
+  # whose stored fields are NOT allowlisted for its new source — breaking the
+  # security-root invariant `declared_fields ⊆ column_allowlist[backing_source]`.
+  # Reading both via `get_field` re-checks the fields-vs-source pair on every
+  # write regardless of which of the two actually changed.
   defp validate_fields(changeset) do
     source = get_field(changeset, :backing_source)
+    fields = get_field(changeset, :fields)
 
-    validate_change(changeset, :fields, fn :fields, fields ->
-      field_list_errors(fields, source)
-    end)
+    fields
+    |> field_list_errors(source)
+    |> Enum.reduce(changeset, fn {key, message}, cs -> add_error(cs, key, message) end)
   end
 
   defp field_list_errors(fields, _source) when not is_list(fields) do

--- a/lib/loopctl/context_retriever/registry.ex
+++ b/lib/loopctl/context_retriever/registry.ex
@@ -32,6 +32,7 @@ defmodule Loopctl.ContextRetriever.Registry do
   alias Ecto.Multi
   alias Loopctl.Audit
   alias Loopctl.ContextRetriever.Entity
+  alias Loopctl.ContextRetriever.ToolGenerator
   alias Loopctl.Repo
 
   @default_max_entities 50
@@ -60,6 +61,26 @@ defmodule Loopctl.ContextRetriever.Registry do
       end)
 
     entities
+  end
+
+  @doc """
+  Returns the generated agent tool specs for ALL of `tenant_id`'s entity
+  definitions — the US-30.2 `ToolGenerator` fanned out over `for_tenant/1`.
+
+  This is THE canonical context entry point for a tenant's tool surface. Both
+  the US-30.4 HTTP layer (`GET /api/v1/retrieve/tools`) and the US-30.5 MCP
+  dynamic tool listing call this instead of re-deriving the
+  `for_tenant/1 |> Enum.flat_map(&ToolGenerator.specs_for/1)` fan-out themselves,
+  so the Context-Retriever domain fan-out stays inside the context rather than
+  leaking into the thin JSON controller. Scope-enforced via `for_tenant/1` (RLS):
+  another tenant's entities never contribute. A tenant with no definitions (or
+  only fieldless-after-filter definitions) gets `[]`.
+  """
+  @spec tool_specs(Ecto.UUID.t()) :: [ToolGenerator.spec()]
+  def tool_specs(tenant_id) when is_binary(tenant_id) do
+    tenant_id
+    |> for_tenant()
+    |> Enum.flat_map(&ToolGenerator.specs_for/1)
   end
 
   @doc """

--- a/lib/loopctl/context_retriever/registry.ex
+++ b/lib/loopctl/context_retriever/registry.ex
@@ -338,9 +338,24 @@ defmodule Loopctl.ContextRetriever.Registry do
   # Fetch the row inside the transaction, scoped by RLS + an explicit tenant
   # predicate (defense-in-depth on this security-root read). A missing/foreign id
   # short-circuits the Multi with `{:error, :not_found}`.
+  #
+  # `lock: "FOR UPDATE"` serializes this fetch against a concurrent update/delete
+  # of the same row. Without it, a concurrent transaction committing a delete
+  # between this fetch and the subsequent `Multi.update`/`Multi.delete` makes the
+  # write match 0 rows and Ecto RAISES `Ecto.StaleEntryError` (→ 500). The row
+  # lock forces a concurrent delete to serialize: it either commits first (our
+  # re-read under READ COMMITTED then finds no row → clean `{:error, :not_found}`
+  # → 404) or blocks behind our lock until we commit. Either way the write always
+  # matches the locked row and never goes stale.
   defp fetch_entity(multi, tenant_id, uuid) do
     Multi.run(multi, :fetch, fn repo, _changes ->
-      case repo.get_by(Entity, id: uuid, tenant_id: tenant_id) do
+      query =
+        from(e in Entity,
+          where: e.id == ^uuid and e.tenant_id == ^tenant_id,
+          lock: "FOR UPDATE"
+        )
+
+      case repo.one(query) do
         %Entity{} = entity -> {:ok, entity}
         nil -> {:error, :not_found}
       end

--- a/lib/loopctl/context_retriever/registry.ex
+++ b/lib/loopctl/context_retriever/registry.ex
@@ -186,9 +186,171 @@ defmodule Loopctl.ContextRetriever.Registry do
     end
   end
 
+  @doc """
+  Returns `tenant_id`'s entity definition with id `id`, or `nil`.
+
+  Scope-enforced via RLS + an explicit `tenant_id` predicate: an id belonging to
+  a different tenant returns `nil` (no cross-tenant existence leak). A
+  syntactically invalid UUID returns `nil` rather than raising, so a controller
+  can map a bad path id to a clean 404.
+  """
+  @spec get_entity_by_id(Ecto.UUID.t(), String.t()) :: Entity.t() | nil
+  def get_entity_by_id(tenant_id, id) when is_binary(tenant_id) and is_binary(id) do
+    case Ecto.UUID.cast(id) do
+      {:ok, uuid} ->
+        {:ok, entity} =
+          Repo.with_tenant(tenant_id, fn ->
+            Repo.get_by(Entity, id: uuid, tenant_id: tenant_id)
+          end)
+
+        entity
+
+      :error ->
+        nil
+    end
+  end
+
+  @doc """
+  Updates `tenant_id`'s entity definition `id` from `attrs` (US-30.4 PATCH).
+
+  Re-validates via `Entity.update_changeset/2` — the SAME security validations
+  as create (SERVER column allowlist, safe-identifier regex, type/boolean
+  checks) — so a PATCH can never relax the allowlist. The per-tenant COUNT cap
+  is NOT re-run (an update does not add a row), so this path is advisory-lock
+  free. `tenant_id` is set programmatically on the fetched struct, never cast.
+
+  Runs as an `Ecto.Multi` so the RLS context set, the scoped fetch, the update,
+  and the `"updated"` audit entry share ONE transaction (and a
+  `unique_constraint` on a renamed entity is caught as `{:error, changeset}`).
+  `opts` supplies the audit actor (see `create_entity/3`).
+
+  Returns `{:ok, entity}`, `{:error, :not_found}` (unknown/foreign id), or
+  `{:error, changeset}`.
+  """
+  @spec update_entity(Ecto.UUID.t(), String.t(), map(), keyword()) ::
+          {:ok, Entity.t()} | {:error, :not_found | Ecto.Changeset.t() | term()}
+  def update_entity(tenant_id, id, attrs, opts \\ [])
+      when is_binary(tenant_id) and is_binary(id) and is_map(attrs) and is_list(opts) do
+    case Ecto.UUID.cast(id) do
+      :error ->
+        {:error, :not_found}
+
+      {:ok, uuid} ->
+        Multi.new()
+        |> put_rls(tenant_id)
+        |> fetch_entity(tenant_id, uuid)
+        |> Multi.update(:entity, fn %{fetch: entity} ->
+          Entity.update_changeset(entity, attrs)
+        end)
+        |> Audit.log_in_multi(:audit, fn %{fetch: before, entity: entity} ->
+          audit_attrs(tenant_id, entity, "updated", opts, %{
+            old_state: state_snapshot(before),
+            new_state: state_snapshot(entity)
+          })
+        end)
+        |> finish_entity_write()
+    end
+  end
+
+  @doc """
+  Deletes `tenant_id`'s entity definition `id` (US-30.4 DELETE).
+
+  Runs as an `Ecto.Multi` so the RLS context set, the scoped fetch, the delete,
+  and the `"deleted"` audit entry share ONE transaction. `opts` supplies the
+  audit actor (see `create_entity/3`).
+
+  Returns `{:ok, entity}` (the deleted row) or `{:error, :not_found}` (unknown/
+  foreign id).
+  """
+  @spec delete_entity(Ecto.UUID.t(), String.t(), keyword()) ::
+          {:ok, Entity.t()} | {:error, :not_found | term()}
+  def delete_entity(tenant_id, id, opts \\ [])
+      when is_binary(tenant_id) and is_binary(id) and is_list(opts) do
+    case Ecto.UUID.cast(id) do
+      :error ->
+        {:error, :not_found}
+
+      {:ok, uuid} ->
+        Multi.new()
+        |> put_rls(tenant_id)
+        |> fetch_entity(tenant_id, uuid)
+        |> Multi.delete(:entity, fn %{fetch: entity} -> entity end)
+        |> Audit.log_in_multi(:audit, fn %{entity: entity} ->
+          audit_attrs(tenant_id, entity, "deleted", opts, %{old_state: state_snapshot(entity)})
+        end)
+        |> finish_entity_write()
+    end
+  end
+
   @doc "Configurable per-tenant cap on entity definitions."
   @spec max_entities() :: pos_integer()
   def max_entities do
     Application.get_env(:loopctl, :max_entity_definitions_per_tenant, @default_max_entities)
+  end
+
+  # Run the update/delete Multi and normalize its result. The `:entity` changeset
+  # branch is only reachable from `update_entity/4` (a delete never re-validates);
+  # `delete_entity/3` simply never produces it.
+  defp finish_entity_write(multi) do
+    multi
+    |> Repo.transaction()
+    |> case do
+      {:ok, %{entity: entity}} -> {:ok, entity}
+      {:error, :fetch, :not_found, _changes} -> {:error, :not_found}
+      {:error, :entity, %Ecto.Changeset{} = changeset, _changes} -> {:error, changeset}
+      {:error, _step, reason, _changes} -> {:error, reason}
+    end
+  end
+
+  # --- Shared Multi steps (update/delete) ---
+
+  # Set the RLS context (`SET LOCAL app.current_tenant_id` + `SET LOCAL ROLE`) so
+  # the scoped fetch, the write, and the audit insert all run RLS-scoped to this
+  # tenant — mirroring `create_entity/3`'s `:rls` step.
+  defp put_rls(multi, tenant_id) do
+    Multi.run(multi, :rls, fn _repo, _changes ->
+      Repo.set_rls_context(tenant_id)
+      {:ok, :ok}
+    end)
+  end
+
+  # Fetch the row inside the transaction, scoped by RLS + an explicit tenant
+  # predicate (defense-in-depth on this security-root read). A missing/foreign id
+  # short-circuits the Multi with `{:error, :not_found}`.
+  defp fetch_entity(multi, tenant_id, uuid) do
+    Multi.run(multi, :fetch, fn repo, _changes ->
+      case repo.get_by(Entity, id: uuid, tenant_id: tenant_id) do
+        %Entity{} = entity -> {:ok, entity}
+        nil -> {:error, :not_found}
+      end
+    end)
+  end
+
+  # Build the audit attrs for an update/delete, merging the actor from `opts`
+  # (mirrors `create_entity/3`'s audit block) with the caller-supplied state.
+  defp audit_attrs(tenant_id, entity, action, opts, extra) do
+    Map.merge(
+      %{
+        tenant_id: tenant_id,
+        entity_type: "entity_definition",
+        entity_id: entity.id,
+        action: action,
+        actor_type: Keyword.get(opts, :actor_type, "api_key"),
+        actor_id: Keyword.get(opts, :actor_id),
+        actor_label: Keyword.get(opts, :actor_label),
+        metadata: Keyword.get(opts, :metadata, %{})
+      },
+      extra
+    )
+  end
+
+  # A compact, JSON-safe snapshot of an entity for the audit trail (no raw
+  # tenant_id/custody columns — just the declared surface).
+  defp state_snapshot(%Entity{} = entity) do
+    %{
+      "name" => entity.name,
+      "backing_source" => to_string(entity.backing_source),
+      "field_count" => length(entity.fields)
+    }
   end
 end

--- a/lib/loopctl_web/controllers/context_retriever_controller.ex
+++ b/lib/loopctl_web/controllers/context_retriever_controller.ex
@@ -44,10 +44,10 @@ defmodule LoopctlWeb.ContextRetrieverController do
   use OpenApiSpex.ControllerSpecs
 
   alias Loopctl.ApiSpec.Schemas
+  alias Loopctl.ContextRetriever.Entity
   alias Loopctl.ContextRetriever.Executor
   alias Loopctl.ContextRetriever.Registry
   alias Loopctl.ContextRetriever.Scope
-  alias Loopctl.ContextRetriever.ToolGenerator
   alias LoopctlWeb.AuditContext
   alias Plug.Conn.Status
 
@@ -76,6 +76,32 @@ defmodule LoopctlWeb.ContextRetrieverController do
   # Overridable via config; kept generous (a real agent bursts) but finite.
   @retrieve_rate_window_ms 60_000
   @retrieve_rate_limit 120
+
+  # Reserved param keys the US-30.3 Executor reads for search/pagination
+  # (`params["query"]` / `params["limit"]` / `params["offset"]`). `exec_params/2`
+  # writes a `:filter` field's value into that SAME string-keyed param namespace,
+  # so a filterable column literally named one of these would clobber (or be
+  # clobbered by) the caller's search/pagination value — silently mis-paginating.
+  # No phase-1 backing source allowlists such a column, so the coupling is latent
+  # today; the compile-time guard below ASSERTS that, so a future
+  # `Entity.@column_allowlist` addition of a `query`/`limit`/`offset` column fails
+  # loudly here (mirroring the compile-time guards in `Entity`/`ToolGenerator`)
+  # instead of regressing into a silent mis-pagination.
+  @reserved_exec_keys ~w(query limit offset)
+
+  for {source, cols} <- Entity.column_allowlist() do
+    collisions = Enum.filter(cols, &(Atom.to_string(&1) in @reserved_exec_keys))
+
+    unless collisions == [] do
+      raise CompileError,
+        description:
+          "LoopctlWeb.ContextRetrieverController: backing source #{inspect(source)} allowlists " <>
+            "column(s) #{inspect(collisions)} that collide with the reserved Executor param " <>
+            "keys #{inspect(@reserved_exec_keys)}. `exec_params/2` shares one param namespace " <>
+            "with the executor's search/pagination reads, so such a column would silently " <>
+            "mis-paginate. Namespace the filter value into a dedicated slot before adding it."
+    end
+  end
 
   operation(:create,
     summary: "Create an entity definition",
@@ -239,12 +265,10 @@ defmodule LoopctlWeb.ContextRetrieverController do
   @doc "GET /api/v1/retrieve/tools"
   def tools(conn, _params) do
     with_tenant(conn, fn tenant_id ->
-      specs =
-        tenant_id
-        |> Registry.for_tenant()
-        |> Enum.flat_map(&ToolGenerator.specs_for/1)
-
-      json(conn, %{data: specs})
+      # Per-tenant tool-spec fan-out lives in the context (Registry.tool_specs/1),
+      # not inline here — keeps this a thin JSON layer and gives US-30.5's MCP
+      # client one canonical entry point (see the moduledoc).
+      json(conn, %{data: Registry.tool_specs(tenant_id)})
     end)
   end
 

--- a/lib/loopctl_web/controllers/context_retriever_controller.ex
+++ b/lib/loopctl_web/controllers/context_retriever_controller.ex
@@ -1,0 +1,487 @@
+defmodule LoopctlWeb.ContextRetrieverController do
+  @moduledoc """
+  Controller for the Context Retriever HTTP API (Epic 30, US-30.4) — a thin JSON
+  layer wiring the already-built domain (US-30.1 Registry/Entity, US-30.2
+  ToolGenerator, US-30.3 Executor) to `/api/v1` on the `:authenticated` pipeline.
+  The MCP layer (US-30.5) calls THIS API, not the contexts directly.
+
+  ## Endpoints
+
+    * `POST   /api/v1/entities`         — create an entity definition (user+)
+    * `GET    /api/v1/entities`         — list the tenant's definitions
+    * `GET    /api/v1/entities/:id`     — fetch one definition
+    * `PATCH  /api/v1/entities/:id`     — update a definition (user+)
+    * `DELETE /api/v1/entities/:id`     — delete a definition (user+)
+    * `GET    /api/v1/retrieve/tools`   — the tenant's generated tool specs
+    * `POST   /api/v1/retrieve/:entity` — execute a filter/search via the Executor
+
+  ## Scope is derived from the KEY, never the body (AC-30.4.1)
+
+  The `tenant_id` is resolved SERVER-SIDE from the resolved API key
+  (`conn.assigns.current_api_key`). Any `tenant_id` in the request body is
+  ignored. A tenant-less key (a superadmin without an impersonation target — the
+  api_key schema forbids a superadmin `tenant_id`) is refused deterministically
+  with a 422 rather than a null-scoped operation, mirroring
+  `LoopctlWeb.MemoryController`.
+
+  ## Role gating (AC-30.4.2)
+
+  Defining/mutating a definition requires `>= :user` (403 for agent/orchestrator).
+  Querying (`/retrieve/*`, list, show) requires only authentication — `:agent` is
+  the FLOOR role, so the `role: :agent` plug is a documentation no-op; the real
+  negative case for a query is 401 (unauthenticated, handled by `RequireAuth` in
+  the pipeline), never a below-agent 403.
+
+  ## Rate limiting the model-invoked path (AC-30.4.6)
+
+  `POST /retrieve/:entity` is additionally rate-limited PER TENANT via the
+  configured `Loopctl.RateLimiter.Hammer` (DI key `:rate_limiter`) so a looping or
+  hostile agent cannot flood the executor. Over-limit returns 429 and does NOT
+  execute.
+  """
+
+  use LoopctlWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Loopctl.ApiSpec.Schemas
+  alias Loopctl.ContextRetriever.Executor
+  alias Loopctl.ContextRetriever.Registry
+  alias Loopctl.ContextRetriever.Scope
+  alias Loopctl.ContextRetriever.ToolGenerator
+  alias LoopctlWeb.AuditContext
+  alias Plug.Conn.Status
+
+  action_fallback LoopctlWeb.FallbackController
+
+  # AC-30.4.2: define/mutate requires >= user; querying is floored at agent (a
+  # documentation no-op — every authenticated key clears it; the negative case is
+  # a pipeline 401, not a below-agent 403).
+  plug LoopctlWeb.Plugs.RequireRole, [role: :user] when action in [:create, :update, :delete]
+
+  plug LoopctlWeb.Plugs.RequireRole,
+       [role: :agent] when action in [:index, :show, :tools, :retrieve]
+
+  # An entity definition IS a security root (the executor's field allowlist), so
+  # DEFINING/MUTATING one is gated behind the human-anchored tenant tier — exactly
+  # like the rest of the work-breakdown surface (project_controller /
+  # story_dependency_controller). Querying (`/retrieve/*`, list, show) is NOT
+  # tier-gated: an agent-rooted KB-tier tenant may still query its own definitions.
+  plug LoopctlWeb.Plugs.RequireHumanAnchor when action in [:create, :update, :delete]
+
+  tags(["Context Retriever"])
+
+  @entity_attr_keys ~w(name backing_source fields)
+
+  # The default per-tenant window/limit for the model-invoked /retrieve path.
+  # Overridable via config; kept generous (a real agent bursts) but finite.
+  @retrieve_rate_window_ms 60_000
+  @retrieve_rate_limit 120
+
+  operation(:create,
+    summary: "Create an entity definition",
+    description:
+      "Creates a tenant-scoped entity definition (name + typed, allowlisted fields " <>
+        "+ a backing source). Requires >= user role. `tenant_id` is derived from the " <>
+        "key. Returns 201 with the created definition.",
+    request_body: {"Entity params", "application/json", Schemas.EntityDefinitionRequest},
+    responses: %{
+      201 => {"Created", "application/json", Schemas.EntityDefinitionResponse},
+      422 =>
+        {"Validation error or entity limit reached", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  operation(:index,
+    summary: "List entity definitions",
+    description: "Lists the calling tenant's entity definitions, ordered by name.",
+    responses: %{
+      200 => {"Definitions", "application/json", Schemas.EntityDefinitionListResponse}
+    }
+  )
+
+  operation(:show,
+    summary: "Fetch an entity definition",
+    description: "Fetches one of the calling tenant's entity definitions by id.",
+    parameters: [id: [in: :path, type: :string, description: "Entity definition UUID"]],
+    responses: %{
+      200 => {"Definition", "application/json", Schemas.EntityDefinitionResponse},
+      404 => {"Not found", "application/json", Schemas.ErrorResponse}
+    }
+  )
+
+  operation(:update,
+    summary: "Update an entity definition",
+    description:
+      "Updates a definition by id, re-validating against the SERVER column " <>
+        "allowlist (a PATCH can never relax it). Requires >= user role. Omitted " <>
+        "top-level fields keep their current value.",
+    parameters: [id: [in: :path, type: :string, description: "Entity definition UUID"]],
+    request_body: {"Entity params", "application/json", Schemas.EntityDefinitionRequest},
+    responses: %{
+      200 => {"Updated", "application/json", Schemas.EntityDefinitionResponse},
+      404 => {"Not found", "application/json", Schemas.ErrorResponse},
+      422 => {"Validation error", "application/json", Schemas.ErrorResponse}
+    }
+  )
+
+  operation(:delete,
+    summary: "Delete an entity definition",
+    description: "Deletes a definition by id. Requires >= user role.",
+    parameters: [id: [in: :path, type: :string, description: "Entity definition UUID"]],
+    responses: %{
+      200 => {"Deleted", "application/json", Schemas.EntityDefinitionResponse},
+      404 => {"Not found", "application/json", Schemas.ErrorResponse}
+    }
+  )
+
+  operation(:tools,
+    summary: "List generated tool specs",
+    description:
+      "Returns the generated agent tool specs (ToolGenerator over the tenant's " <>
+        "entity definitions) for the CALLING tenant only. Another tenant's entities " <>
+        "never appear.",
+    responses: %{
+      200 => {"Tool specs", "application/json", Schemas.RetrieveToolsResponse}
+    }
+  )
+
+  operation(:retrieve,
+    summary: "Execute a filter/search over an entity",
+    description:
+      "Executes a `filter` or `search` over the named entity via the US-30.3 " <>
+        "Executor, which re-validates the field/operation against the tenant's " <>
+        "definition + the SERVER allowlist and dual tenant-scopes the query. " <>
+        "Rate-limited per tenant (429 over-limit, not executed). An unknown entity " <>
+        "or non-allowlisted field is 4xx and never executed.",
+    parameters: [entity: [in: :path, type: :string, description: "Entity name"]],
+    request_body: {"Retrieve params", "application/json", Schemas.RetrieveRequest},
+    responses: %{
+      200 => {"Results + meta", "application/json", Schemas.RetrieveResponse},
+      400 => {"Malformed request", "application/json", Schemas.ErrorResponse},
+      404 => {"Unknown entity", "application/json", Schemas.ErrorResponse},
+      422 =>
+        {"Field not allowlisted / invalid operation", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  # --- Entity definition CRUD ---
+
+  @doc "POST /api/v1/entities"
+  def create(conn, params) do
+    with_tenant(conn, fn tenant_id ->
+      audit_opts = AuditContext.from_conn(conn)
+
+      case Registry.create_entity(tenant_id, entity_attrs(params), audit_opts) do
+        {:ok, entity} ->
+          conn |> put_status(:created) |> json(%{data: entity_json(entity)})
+
+        {:error, :entity_limit} ->
+          entity_limit_error(conn)
+
+        {:error, %Ecto.Changeset{} = changeset} ->
+          {:error, changeset}
+
+        {:error, reason} ->
+          registry_error(conn, reason)
+      end
+    end)
+  end
+
+  @doc "GET /api/v1/entities"
+  def index(conn, _params) do
+    with_tenant(conn, fn tenant_id ->
+      entities = Registry.for_tenant(tenant_id)
+      json(conn, %{data: Enum.map(entities, &entity_json/1)})
+    end)
+  end
+
+  @doc "GET /api/v1/entities/:id"
+  def show(conn, %{"id" => id}) do
+    with_tenant(conn, fn tenant_id ->
+      case Registry.get_entity_by_id(tenant_id, id) do
+        nil -> {:error, :not_found}
+        entity -> json(conn, %{data: entity_json(entity)})
+      end
+    end)
+  end
+
+  @doc "PATCH /api/v1/entities/:id"
+  def update(conn, %{"id" => id} = params) do
+    with_tenant(conn, fn tenant_id ->
+      audit_opts = AuditContext.from_conn(conn)
+
+      case Registry.update_entity(tenant_id, id, entity_attrs(params), audit_opts) do
+        {:ok, entity} -> json(conn, %{data: entity_json(entity)})
+        {:error, :not_found} -> {:error, :not_found}
+        {:error, %Ecto.Changeset{} = changeset} -> {:error, changeset}
+        {:error, reason} -> registry_error(conn, reason)
+      end
+    end)
+  end
+
+  @doc "DELETE /api/v1/entities/:id"
+  def delete(conn, %{"id" => id}) do
+    with_tenant(conn, fn tenant_id ->
+      audit_opts = AuditContext.from_conn(conn)
+
+      case Registry.delete_entity(tenant_id, id, audit_opts) do
+        {:ok, entity} -> json(conn, %{data: entity_json(entity)})
+        {:error, :not_found} -> {:error, :not_found}
+        {:error, reason} -> registry_error(conn, reason)
+      end
+    end)
+  end
+
+  # --- Generated tools ---
+
+  @doc "GET /api/v1/retrieve/tools"
+  def tools(conn, _params) do
+    with_tenant(conn, fn tenant_id ->
+      specs =
+        tenant_id
+        |> Registry.for_tenant()
+        |> Enum.flat_map(&ToolGenerator.specs_for/1)
+
+      json(conn, %{data: specs})
+    end)
+  end
+
+  # --- Execute ---
+
+  @doc "POST /api/v1/retrieve/:entity"
+  def retrieve(conn, %{"entity" => entity_name} = params) do
+    with_tenant(conn, fn tenant_id ->
+      # AC-30.4.6: per-tenant rate limit BEFORE dispatching to the executor, so a
+      # looping/hostile agent cannot flood it. Over-limit returns 429, unexecuted.
+      case check_retrieve_rate(tenant_id) do
+        :ok -> run_retrieve(conn, entity_name, params)
+        {:error, :rate_limited} -> {:error, :rate_limited}
+      end
+    end)
+  end
+
+  defp run_retrieve(conn, entity_name, params) do
+    # Map the request into the executor's dispatch tuple + params. `op`/`operation`
+    # is pattern-matched to an atom (never String.to_atom on model input).
+    case operation_atom(params["op"] || params["operation"]) do
+      {:ok, operation} ->
+        field = string_or_nil(params["field"])
+        scope = build_scope(conn)
+        exec_params = exec_params(params, field)
+
+        case Executor.run(scope, {entity_name, field, operation}, exec_params) do
+          {:ok, %{results: results, meta: meta}} ->
+            json(conn, %{results: results, meta: meta})
+
+          {:error, reason} ->
+            executor_error(conn, reason)
+        end
+
+      :error ->
+        invalid_operation(conn)
+    end
+  end
+
+  # --- Private helpers ---
+
+  # Resolve the tenant_id from the KEY (never the body) and run `fun` with it. A
+  # tenant-less key (a superadmin without an impersonation target) is refused with
+  # a deterministic 422 rather than a null-scoped op — the Registry functions are
+  # guarded `when is_binary(tenant_id)` and the Executor returns `{:error,
+  # :no_tenant}`, so refuse here consistently (mirrors MemoryController).
+  defp with_tenant(conn, fun) do
+    case conn.assigns.current_api_key.tenant_id do
+      tenant_id when is_binary(tenant_id) -> fun.(tenant_id)
+      _ -> impersonation_tenant_required(conn)
+    end
+  end
+
+  # Build the Executor scope from the authenticated key: tenant_id + role from the
+  # key, actor_id = key id, actor_label = "<role>:<name>" (the audit actor).
+  defp build_scope(conn) do
+    api_key = conn.assigns.current_api_key
+
+    %Scope{
+      tenant_id: api_key.tenant_id,
+      role: api_key.role,
+      actor_id: api_key.id,
+      actor_label: "#{api_key.role}:#{api_key.name}"
+    }
+  end
+
+  # Build the executor param map: for :filter the executor reads `params[field]`,
+  # so map the body's `value` (fallback: a value already under the field key) to
+  # that key. `query`/`limit`/`offset` pass through. Any body `tenant_id` is
+  # dropped (the executor ignores it regardless).
+  defp exec_params(params, field) do
+    base = %{
+      "query" => params["query"],
+      "limit" => params["limit"],
+      "offset" => params["offset"]
+    }
+
+    if is_binary(field) do
+      filter_value =
+        if Map.has_key?(params, "value"), do: params["value"], else: params[field]
+
+      Map.put(base, field, filter_value)
+    else
+      base
+    end
+  end
+
+  # Map the operation string to its atom WITHOUT String.to_atom on model input.
+  defp operation_atom("filter"), do: {:ok, :filter}
+  defp operation_atom("search"), do: {:ok, :search}
+  defp operation_atom(_), do: :error
+
+  defp string_or_nil(value) when is_binary(value), do: value
+  defp string_or_nil(_), do: nil
+
+  defp entity_attrs(params), do: Map.take(params, @entity_attr_keys)
+
+  # Serialize an entity definition for the JSON envelope (declared surface only).
+  defp entity_json(entity) do
+    %{
+      id: entity.id,
+      tenant_id: entity.tenant_id,
+      name: entity.name,
+      backing_source: entity.backing_source,
+      fields: entity.fields,
+      inserted_at: entity.inserted_at,
+      updated_at: entity.updated_at
+    }
+  end
+
+  defp check_retrieve_rate(tenant_id) do
+    bucket = "cr_retrieve:tenant:#{tenant_id}"
+
+    case rate_limiter().check_rate(bucket, retrieve_rate_window_ms(), retrieve_rate_limit()) do
+      {:allow, _count} -> :ok
+      {:deny, _limit} -> {:error, :rate_limited}
+    end
+  end
+
+  defp rate_limiter do
+    Application.get_env(:loopctl, :rate_limiter, Loopctl.RateLimiter.Hammer)
+  end
+
+  defp retrieve_rate_window_ms do
+    Application.get_env(
+      :loopctl,
+      :context_retriever_retrieve_rate_window_ms,
+      @retrieve_rate_window_ms
+    )
+  end
+
+  defp retrieve_rate_limit do
+    Application.get_env(:loopctl, :context_retriever_retrieve_rate_limit, @retrieve_rate_limit)
+  end
+
+  # --- Error envelopes (executor / registry errors aren't handled by the
+  # FallbackController, so render them here with named codes) ---
+
+  # Map Executor `{:error, reason}` to the right status + stable code.
+  defp executor_error(conn, :unknown_entity),
+    do: error(conn, :not_found, "unknown_entity", "No such entity is defined for this tenant.")
+
+  defp executor_error(conn, :field_not_allowlisted),
+    do:
+      error(
+        conn,
+        :unprocessable_entity,
+        "field_not_allowlisted",
+        "The requested field is not a filterable/searchable field of this entity."
+      )
+
+  defp executor_error(conn, :invalid_operation), do: invalid_operation(conn)
+
+  defp executor_error(conn, :search_not_indexed),
+    do:
+      error(
+        conn,
+        :unprocessable_entity,
+        "search_not_indexed",
+        "This entity's searchable fields are not full-text indexed, so search is unavailable."
+      )
+
+  defp executor_error(conn, :unsupported_filter_type),
+    do:
+      error(
+        conn,
+        :unprocessable_entity,
+        "unsupported_filter_type",
+        "The requested field's column type does not support equality filtering."
+      )
+
+  defp executor_error(conn, :invalid_params),
+    do: error(conn, :bad_request, "invalid_params", "The request body is malformed.")
+
+  defp executor_error(conn, :no_tenant), do: impersonation_tenant_required(conn)
+
+  defp executor_error(conn, :stale_entity),
+    do:
+      error(
+        conn,
+        :unprocessable_entity,
+        "stale_entity",
+        "The entity definition no longer matches its backing source; update or recreate it."
+      )
+
+  defp executor_error(conn, :audit_failed),
+    do:
+      error(
+        conn,
+        :internal_server_error,
+        "audit_failed",
+        "The query could not be audited, so no results were returned. Please retry."
+      )
+
+  # A registry write failing for a non-changeset reason (e.g. an audit-step
+  # failure surfaced via the trailing catch-all) is a server-side error.
+  defp registry_error(conn, _reason),
+    do:
+      error(
+        conn,
+        :internal_server_error,
+        "internal_error",
+        "The operation could not be completed due to an unexpected server error."
+      )
+
+  defp entity_limit_error(conn) do
+    error(
+      conn,
+      :unprocessable_entity,
+      "entity_limit",
+      "The per-tenant entity-definition limit has been reached. " <>
+        "Delete an existing definition before creating a new one."
+    )
+  end
+
+  defp invalid_operation(conn) do
+    error(
+      conn,
+      :unprocessable_entity,
+      "invalid_operation",
+      "`op` must be one of \"filter\" or \"search\"."
+    )
+  end
+
+  defp impersonation_tenant_required(conn) do
+    error(
+      conn,
+      :unprocessable_entity,
+      "impersonation_tenant_required",
+      "A superadmin Context-Retriever request needs an impersonation target " <>
+        "(superadmin keys are tenant-less). Set the X-Impersonate-Tenant header."
+    )
+  end
+
+  defp error(conn, status, code, message) do
+    conn
+    |> put_status(status)
+    |> json(%{error: %{status: Status.code(status), code: code, message: message}})
+  end
+end

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -318,6 +318,17 @@ defmodule LoopctlWeb.Router do
     get "/memory", MemoryController, :index
     delete "/memory/:id", MemoryController, :delete
 
+    # Context Retriever (Epic 30, US-30.4) — entity-definition CRUD + the
+    # model-invoked query surface. Literal /retrieve/tools MUST precede the
+    # parameterized /retrieve/:entity so it is not captured as an :entity.
+    get "/entities", ContextRetrieverController, :index
+    post "/entities", ContextRetrieverController, :create
+    get "/entities/:id", ContextRetrieverController, :show
+    patch "/entities/:id", ContextRetrieverController, :update
+    delete "/entities/:id", ContextRetrieverController, :delete
+    get "/retrieve/tools", ContextRetrieverController, :tools
+    post "/retrieve/:entity", ContextRetrieverController, :retrieve
+
     # Knowledge Wiki (Epic 19)
     # Publish workflow routes (must precede resources to avoid route conflicts)
     post "/articles/:id/publish", ArticleWorkflowController, :publish

--- a/test/loopctl/context_retriever/entity_test.exs
+++ b/test/loopctl/context_retriever/entity_test.exs
@@ -379,4 +379,78 @@ defmodule Loopctl.ContextRetriever.EntityTest do
       refute Map.has_key?(field, "blob")
     end
   end
+
+  describe "update_changeset/2 — security: allowlist re-validated against the RESOLVED source" do
+    # Regression: a partial PATCH that flips ONLY `backing_source` (leaving the
+    # retained fields unchanged) must still re-check those fields against the NEW
+    # source's column allowlist. Otherwise a projects-only column (`mission`)
+    # survives a switch to `:stories`, persisting a definition that violates the
+    # security-root invariant `declared_fields ⊆ column_allowlist[backing_source]`.
+    test "rejects a backing_source-only change that strands a now-unallowlisted field" do
+      stored = %Entity{
+        tenant_id: Ecto.UUID.generate(),
+        name: "proj",
+        backing_source: :projects,
+        fields: [
+          %{"name" => "mission", "type" => "string", "filterable" => true, "searchable" => false}
+        ]
+      }
+
+      cs = Entity.update_changeset(stored, %{"backing_source" => "stories"})
+
+      refute cs.valid?
+      assert Enum.any?(errors_on(cs).fields, &(&1 =~ "not an allowed column"))
+      # And the invalid source flip is NOT quietly retained as a valid change.
+      assert Ecto.Changeset.get_change(cs, :backing_source) == :stories
+    end
+
+    test "accepts a backing_source-only change when the retained fields are allowlisted for the new source" do
+      # `title`/`description` are allowlisted for BOTH projects and stories, so a
+      # source flip that keeps only cross-allowlisted fields is legitimate.
+      stored = %Entity{
+        tenant_id: Ecto.UUID.generate(),
+        name: "thing",
+        backing_source: :projects,
+        fields: [
+          %{
+            "name" => "description",
+            "type" => "string",
+            "filterable" => true,
+            "searchable" => true
+          }
+        ]
+      }
+
+      cs = Entity.update_changeset(stored, %{"backing_source" => "stories"})
+
+      assert cs.valid?
+      assert Ecto.Changeset.get_field(cs, :backing_source) == :stories
+    end
+
+    test "still rejects a fields-only PATCH that declares an unallowlisted column" do
+      stored = %Entity{
+        tenant_id: Ecto.UUID.generate(),
+        name: "story",
+        backing_source: :stories,
+        fields: [
+          %{"name" => "title", "type" => "string", "filterable" => true, "searchable" => false}
+        ]
+      }
+
+      cs =
+        Entity.update_changeset(stored, %{
+          "fields" => [
+            %{
+              "name" => "tenant_id",
+              "type" => "string",
+              "filterable" => true,
+              "searchable" => false
+            }
+          ]
+        })
+
+      refute cs.valid?
+      assert Enum.any?(errors_on(cs).fields, &(&1 =~ "not an allowed column"))
+    end
+  end
 end

--- a/test/loopctl/context_retriever/registry_test.exs
+++ b/test/loopctl/context_retriever/registry_test.exs
@@ -202,6 +202,44 @@ defmodule Loopctl.ContextRetriever.RegistryTest do
     end
   end
 
+  describe "tool_specs/1 — per-tenant tool-spec fan-out (US-30.4/US-30.5 entry point)" do
+    test "fans ToolGenerator over all of the tenant's definitions" do
+      tenant = repo_tenant()
+
+      {:ok, _} =
+        Registry.create_entity(tenant.id, %{
+          name: "story",
+          backing_source: :stories,
+          fields: [%{name: "title", type: :string, filterable: true, searchable: false}]
+        })
+
+      {:ok, _} =
+        Registry.create_entity(tenant.id, %{
+          name: "project",
+          backing_source: :projects,
+          fields: [%{name: "status", type: :string, filterable: true, searchable: false}]
+        })
+
+      names = tenant.id |> Registry.tool_specs() |> Enum.map(& &1.name)
+      assert "cr_filter_story_by_title" in names
+      assert "cr_filter_project_by_status" in names
+    end
+
+    test "is []-scoped to the caller tenant (no cross-tenant specs)" do
+      tenant_a = repo_tenant()
+      tenant_b = repo_tenant()
+
+      {:ok, _} =
+        Registry.create_entity(tenant_a.id, %{
+          name: "story",
+          backing_source: :stories,
+          fields: @valid_fields
+        })
+
+      assert Registry.tool_specs(tenant_b.id) == []
+    end
+  end
+
   describe "create_entity/2 — per-tenant cap (AC-30.1.5)" do
     test "over-cap creation returns {:error, :entity_limit} and inserts no row" do
       # config/test.exs sets :max_entity_definitions_per_tenant to 3.

--- a/test/loopctl/context_retriever/registry_test.exs
+++ b/test/loopctl/context_retriever/registry_test.exs
@@ -291,4 +291,60 @@ defmodule Loopctl.ContextRetriever.RegistryTest do
                })
     end
   end
+
+  describe "update_entity/4 — allowlist re-validation + clean not-found" do
+    test "a backing_source-only PATCH re-validates retained fields and does NOT persist an allowlist violation" do
+      tenant = repo_tenant()
+
+      {:ok, entity} =
+        Registry.create_entity(tenant.id, %{
+          name: "proj",
+          backing_source: :projects,
+          fields: [%{name: "mission", type: :string, filterable: true, searchable: false}]
+        })
+
+      # `mission` is a projects-only column; flipping to :stories must be rejected
+      # (it is NOT in the stories allowlist), and nothing may be persisted.
+      assert {:error, %Ecto.Changeset{} = cs} =
+               Registry.update_entity(tenant.id, entity.id, %{"backing_source" => "stories"})
+
+      assert Enum.any?(errors_on(cs).fields, &(&1 =~ "not an allowed column"))
+
+      # The stored row is unchanged: still :projects with `mission`.
+      reloaded = Registry.get_entity(tenant.id, "proj")
+      assert reloaded.backing_source == :projects
+      assert [%{"name" => "mission"}] = reloaded.fields
+    end
+
+    test "returns :not_found for an unknown id (clean 404, not a raise)" do
+      tenant = repo_tenant()
+
+      assert {:error, :not_found} =
+               Registry.update_entity(tenant.id, Ecto.UUID.generate(), %{"name" => "renamed"})
+    end
+  end
+
+  describe "delete_entity/3 — clean not-found" do
+    test "deletes an existing entity" do
+      tenant = repo_tenant()
+
+      {:ok, entity} =
+        Registry.create_entity(tenant.id, %{
+          name: "story",
+          backing_source: :stories,
+          fields: @valid_fields
+        })
+
+      assert {:ok, deleted} = Registry.delete_entity(tenant.id, entity.id)
+      assert deleted.id == entity.id
+      assert Registry.get_entity(tenant.id, "story") == nil
+    end
+
+    test "returns :not_found for an unknown id (clean 404, not a raise)" do
+      tenant = repo_tenant()
+
+      assert {:error, :not_found} =
+               Registry.delete_entity(tenant.id, Ecto.UUID.generate())
+    end
+  end
 end

--- a/test/loopctl_web/controllers/context_retriever_controller_test.exs
+++ b/test/loopctl_web/controllers/context_retriever_controller_test.exs
@@ -1,0 +1,310 @@
+defmodule LoopctlWeb.ContextRetrieverControllerTest do
+  @moduledoc """
+  US-30.4 — HTTP JSON API for the Context Retriever (`/api/v1/entities*`,
+  `/api/v1/retrieve/*`).
+
+  ## Why `async: false` + a COMMITTED tenant
+
+  The executor and registry read/write through `Loopctl.Repo.with_tenant/2` (RLS
+  transactions with `SET LOCAL ROLE loopctl_app`) on the `Loopctl.Repo`
+  connection, while the AUTH pipeline resolves the API key through
+  `Loopctl.AdminRepo` — two distinct sandbox connections that cannot see each
+  other's UNCOMMITTED rows. A single tenant row must therefore be visible to
+  BOTH: we insert it via `Sandbox.unboxed_run/2` (a real, committed connection)
+  and delete it on exit. The api_key/agent (AdminRepo) and the entity
+  definitions + backing rows (Repo) then reference that committed tenant from
+  their own rolled-back sandbox transactions.
+
+  Because the executor's isolation runs under the NON-owner `loopctl_app` role
+  (RLS is ENABLE, not FORCE), the cross-tenant assertions actually prove
+  isolation rather than silently passing — mirroring `executor_test.exs` /
+  `registry_test.exs`.
+  """
+  use LoopctlWeb.ConnCase, async: false
+
+  setup :verify_on_exit!
+
+  import Ecto.Query
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Loopctl.AdminRepo
+  alias Loopctl.ContextRetriever.Registry
+  alias Loopctl.Projects.Project
+  alias Loopctl.Repo
+  alias Loopctl.Tenants.Tenant
+
+  # Slug marker so the committed test tenants can be swept without touching real
+  # data. See `commit_tenant/0` + the module teardown below.
+  @tenant_marker "ctrtest-"
+
+  # Sweep every committed marker tenant at module setup AND teardown. This runs
+  # OUTSIDE any per-test sandbox transaction, so no open transaction holds an FK
+  # lock on the tenant rows (a per-test on_exit delete deadlocks: it fires BEFORE
+  # the sandbox transaction that inserted the FK-referencing api_keys/entities is
+  # rolled back). Cleaning at module boundaries sidesteps that entirely.
+  setup_all do
+    sweep_marker_tenants()
+    on_exit(&sweep_marker_tenants/0)
+    :ok
+  end
+
+  defp sweep_marker_tenants do
+    Sandbox.unboxed_run(AdminRepo, fn ->
+      AdminRepo.delete_all(from(t in Tenant, where: like(t.slug, ^"#{@tenant_marker}%")))
+    end)
+  end
+
+  # --- Committed-tenant + seeding helpers (see moduledoc) ---
+
+  # Insert a tenant on a real (committed) connection so BOTH the AdminRepo auth
+  # path and the Repo executor path can see it. Cleanup is handled by the
+  # module-level sweep (see above), not a per-test on_exit.
+  defp commit_tenant do
+    seq = System.unique_integer([:positive])
+    id = Ecto.UUID.generate()
+
+    Sandbox.unboxed_run(AdminRepo, fn ->
+      %Tenant{}
+      |> Tenant.create_changeset(%{
+        name: "T#{seq}",
+        slug: "#{@tenant_marker}#{seq}",
+        email: "#{@tenant_marker}#{seq}@example.com"
+      })
+      |> Ecto.Changeset.put_change(:id, id)
+      # Defining/mutating entity definitions is gated behind RequireHumanAnchor
+      # (a security root), so the test tenant must be human-anchored. trust_tier is
+      # excluded from create_changeset's cast, so set it programmatically (mirrors
+      # the tenant fixture's post-insert convention).
+      |> Ecto.Changeset.put_change(:trust_tier, :human_anchored)
+      |> AdminRepo.insert!()
+    end)
+
+    AdminRepo.get!(Tenant, id)
+  end
+
+  # A user-role key (may define/mutate entity definitions).
+  defp user_key(tenant_id) do
+    {raw, _key} = fixture(:api_key, %{tenant_id: tenant_id, role: :user})
+    raw
+  end
+
+  # An agent-role key (query only). api_keys.agent_id FKs agents, so mint a real
+  # agent per agent key.
+  defp agent_key(tenant_id) do
+    agent = fixture(:agent, %{tenant_id: tenant_id})
+    {raw, _key} = fixture(:api_key, %{tenant_id: tenant_id, role: :agent, agent_id: agent.id})
+    raw
+  end
+
+  # Seed a backing project on the Repo connection (the executor reads via
+  # Repo.with_tenant). Status defaults to :active.
+  defp seed_project(tenant_id, attrs \\ %{}) do
+    %Project{tenant_id: tenant_id}
+    |> Project.create_changeset(build(:project, attrs))
+    |> Repo.insert!()
+  end
+
+  # A "project" entity exposing a filterable `status` field.
+  defp project_status_fields do
+    [%{name: "status", type: "string", filterable: true, searchable: false}]
+  end
+
+  defp auth(conn, raw_key), do: put_req_header(conn, "authorization", "Bearer #{raw_key}")
+
+  # A fresh conn carrying the witness STH header (each dispatched request needs
+  # its own conn).
+  defp base_conn,
+    do: put_req_header(build_conn(), "x-loopctl-last-known-sth", "0:AAAAAAAAAAAAAAAAAAAAAA")
+
+  defp create_project_entity(conn, raw_user_key, fields) do
+    conn
+    |> auth(raw_user_key)
+    |> post(~p"/api/v1/entities", %{
+      "name" => "project",
+      "backing_source" => "projects",
+      "fields" => fields
+    })
+  end
+
+  # --- TC-30.4.1: create + tools + retrieve happy path ---
+
+  describe "TC-30.4.1: CRUD create, tools, retrieve" do
+    test "user creates an entity, agent lists tools and retrieves rows", %{conn: conn} do
+      tenant = commit_tenant()
+      user = user_key(tenant.id)
+      agent = agent_key(tenant.id)
+
+      seed_project(tenant.id)
+      seed_project(tenant.id)
+
+      created = create_project_entity(conn, user, project_status_fields())
+      assert %{"data" => data} = json_response(created, 201)
+      assert data["name"] == "project"
+      assert data["backing_source"] == "projects"
+
+      tools = base_conn() |> auth(agent) |> get(~p"/api/v1/retrieve/tools")
+      %{"data" => specs} = json_response(tools, 200)
+      tool_names = Enum.map(specs, & &1["name"])
+      assert "cr_filter_project_by_status" in tool_names
+
+      retrieved =
+        base_conn()
+        |> auth(agent)
+        |> post(~p"/api/v1/retrieve/project", %{
+          "field" => "status",
+          "op" => "filter",
+          "value" => "active"
+        })
+
+      body = json_response(retrieved, 200)
+      assert %{"results" => results, "meta" => meta} = body
+      assert length(results) == 2
+      assert meta["total_count"] == 2
+      # Results are shaped to declared columns only.
+      assert Enum.all?(results, &Map.has_key?(&1, "status"))
+      refute Enum.any?(results, &Map.has_key?(&1, "tenant_id"))
+    end
+  end
+
+  # --- TC-30.4.2: role gating ---
+
+  describe "TC-30.4.2: role gating" do
+    test "agent key cannot create an entity (403, below user)", %{conn: conn} do
+      tenant = commit_tenant()
+      agent = agent_key(tenant.id)
+
+      resp = create_project_entity(conn, agent, project_status_fields())
+      assert json_response(resp, 403)
+    end
+
+    test "retrieve with no key is 401 (never a below-agent 403)", %{conn: conn} do
+      resp = post(conn, ~p"/api/v1/retrieve/project", %{"field" => "status", "op" => "filter"})
+      assert json_response(resp, 401)
+    end
+
+    test "retrieve with an invalid key is 401", %{conn: _conn} do
+      resp =
+        base_conn()
+        |> auth("loopctl_bogus_invalid_key")
+        |> post(~p"/api/v1/retrieve/project", %{"field" => "status", "op" => "filter"})
+
+      assert json_response(resp, 401)
+    end
+  end
+
+  # --- TC-30.4.4: update + delete reflected in tools ---
+
+  describe "TC-30.4.4: PATCH + DELETE reflected in generated tools" do
+    test "patch adds a filterable field; delete removes the entity's tools", %{conn: conn} do
+      tenant = commit_tenant()
+      user = user_key(tenant.id)
+
+      created = create_project_entity(conn, user, project_status_fields())
+      %{"data" => %{"id" => id}} = json_response(created, 201)
+
+      # PATCH: mark `name` filterable in addition to `status`.
+      patched =
+        base_conn()
+        |> auth(user)
+        |> patch(~p"/api/v1/entities/#{id}", %{
+          "fields" => [
+            %{
+              "name" => "status",
+              "type" => "string",
+              "filterable" => true,
+              "searchable" => false
+            },
+            %{"name" => "name", "type" => "string", "filterable" => true, "searchable" => false}
+          ]
+        })
+
+      assert json_response(patched, 200)
+
+      tools = base_conn() |> auth(user) |> get(~p"/api/v1/retrieve/tools")
+      names = json_response(tools, 200)["data"] |> Enum.map(& &1["name"])
+      assert "cr_filter_project_by_status" in names
+      assert "cr_filter_project_by_name" in names
+
+      deleted = base_conn() |> auth(user) |> delete(~p"/api/v1/entities/#{id}")
+      assert json_response(deleted, 200)
+
+      tools_after = base_conn() |> auth(user) |> get(~p"/api/v1/retrieve/tools")
+      names_after = json_response(tools_after, 200)["data"] |> Enum.map(& &1["name"])
+      refute "cr_filter_project_by_status" in names_after
+      refute "cr_filter_project_by_name" in names_after
+    end
+  end
+
+  # --- TC-30.4.5: rate limit ---
+
+  describe "TC-30.4.5: retrieve is rate-limited per tenant" do
+    test "over-limit returns 429 and does not execute", %{conn: conn} do
+      tenant = commit_tenant()
+      user = user_key(tenant.id)
+      agent = agent_key(tenant.id)
+
+      create_project_entity(conn, user, project_status_fields())
+      seed_project(tenant.id)
+
+      Mox.stub(Loopctl.MockRateLimiter, :check_rate, fn _bucket, _window, _limit ->
+        {:deny, 999}
+      end)
+
+      resp =
+        base_conn()
+        |> auth(agent)
+        |> post(~p"/api/v1/retrieve/project", %{
+          "field" => "status",
+          "op" => "filter",
+          "value" => "active"
+        })
+
+      assert json_response(resp, 429)
+    end
+  end
+
+  # --- TC-30.4.3: tenant isolation (mandatory) ---
+
+  describe "TC-30.4.3: tenant isolation" do
+    test "another tenant's key sees none of tenant_t's tools or rows", %{conn: conn} do
+      tenant_t = commit_tenant()
+      tenant_u = commit_tenant()
+
+      user_t = user_key(tenant_t.id)
+      agent_u = agent_key(tenant_u.id)
+
+      # tenant_t has an entity + backing rows.
+      create_project_entity(conn, user_t, project_status_fields())
+      seed_project(tenant_t.id)
+
+      # tenant_u's agent sees NONE of tenant_t's tools.
+      tools_u = base_conn() |> auth(agent_u) |> get(~p"/api/v1/retrieve/tools")
+      assert %{"data" => []} = json_response(tools_u, 200)
+
+      # POST /retrieve/project (tenant_t's entity name) as tenant_u's key ⇒
+      # unknown entity (404), never tenant_t's rows.
+      resp =
+        base_conn()
+        |> auth(agent_u)
+        |> post(~p"/api/v1/retrieve/project", %{
+          "field" => "status",
+          "op" => "filter",
+          "value" => "active"
+        })
+
+      assert json_response(resp, 404)
+    end
+
+    test "the registry cannot read another tenant's entity by id", %{conn: conn} do
+      tenant_t = commit_tenant()
+      tenant_u = commit_tenant()
+      user_t = user_key(tenant_t.id)
+
+      created = create_project_entity(conn, user_t, project_status_fields())
+      %{"data" => %{"id" => id}} = json_response(created, 201)
+
+      # Cross-tenant id fetch returns nil (no existence leak).
+      assert Registry.get_entity_by_id(tenant_u.id, id) == nil
+    end
+  end
+end

--- a/test/loopctl_web/controllers/context_retriever_controller_test.exs
+++ b/test/loopctl_web/controllers/context_retriever_controller_test.exs
@@ -96,6 +96,14 @@ defmodule LoopctlWeb.ContextRetrieverControllerTest do
     raw
   end
 
+  # An orchestrator-role key (role 2 < user 3). Deliberately elevated to write
+  # work-breakdown data, but NOT to define entity definitions (a security root) —
+  # so define/mutate must 403 it, exactly like an agent key (AC-30.4.2).
+  defp orchestrator_key(tenant_id) do
+    {raw, _key} = fixture(:api_key, %{tenant_id: tenant_id, role: :orchestrator})
+    raw
+  end
+
   # Seed a backing project on the Repo connection (the executor reads via
   # Repo.with_tenant). Status defaults to :active.
   defp seed_project(tenant_id, attrs \\ %{}) do
@@ -107,6 +115,29 @@ defmodule LoopctlWeb.ContextRetrieverControllerTest do
   # A "project" entity exposing a filterable `status` field.
   defp project_status_fields do
     [%{name: "status", type: "string", filterable: true, searchable: false}]
+  end
+
+  # `status` filterable + `slug` declared but NOT filterable. Exercises the
+  # execute-time allowlist re-check: a raw `/retrieve` naming `slug` op:"filter"
+  # must be rejected (422 field_not_allowlisted), never executed.
+  defp project_status_and_unfilterable_slug_fields do
+    [
+      %{name: "status", type: "string", filterable: true, searchable: false},
+      %{name: "slug", type: "string", filterable: false, searchable: false}
+    ]
+  end
+
+  # A "project" entity exposing a vector-covered searchable text field (`name` is
+  # in the projects search_vector) — authorizes the op:"search" path.
+  defp project_searchable_name_fields do
+    [%{name: "name", type: "string", filterable: false, searchable: true}]
+  end
+
+  # A "project" entity declaring `slug` searchable — allowlisted, but NOT covered
+  # by the projects search_vector (name/description/mission). A raw op:"search"
+  # must be rejected (422 search_not_indexed), never silently searched.
+  defp project_unindexed_searchable_slug_fields do
+    [%{name: "slug", type: "string", filterable: false, searchable: true}]
   end
 
   defp auth(conn, raw_key), do: put_req_header(conn, "authorization", "Bearer #{raw_key}")
@@ -166,6 +197,78 @@ defmodule LoopctlWeb.ContextRetrieverControllerTest do
     end
   end
 
+  # --- TC-30.4.1b: GET index + show over HTTP ---
+
+  describe "TC-30.4.1: GET /entities (index) and GET /entities/:id (show)" do
+    test "index lists the tenant's definitions ordered by name", %{conn: _conn} do
+      tenant = commit_tenant()
+      user = user_key(tenant.id)
+      agent = agent_key(tenant.id)
+
+      # Two definitions with names that sort z-before-a to prove ordering.
+      base_conn()
+      |> auth(user)
+      |> post(~p"/api/v1/entities", %{
+        "name" => "zeta",
+        "backing_source" => "projects",
+        "fields" => project_status_fields()
+      })
+      |> json_response(201)
+
+      base_conn()
+      |> auth(user)
+      |> post(~p"/api/v1/entities", %{
+        "name" => "alpha",
+        "backing_source" => "projects",
+        "fields" => project_status_fields()
+      })
+      |> json_response(201)
+
+      # Query-role (agent) may list — index requires only authentication.
+      resp = base_conn() |> auth(agent) |> get(~p"/api/v1/entities")
+      %{"data" => data} = json_response(resp, 200)
+
+      names = Enum.map(data, & &1["name"])
+      assert names == ["alpha", "zeta"]
+      assert Enum.all?(data, &(&1["backing_source"] == "projects"))
+    end
+
+    test "show returns one definition by id (query role allowed)", %{conn: conn} do
+      tenant = commit_tenant()
+      user = user_key(tenant.id)
+      agent = agent_key(tenant.id)
+
+      created = create_project_entity(conn, user, project_status_fields())
+      %{"data" => %{"id" => id}} = json_response(created, 201)
+
+      resp = base_conn() |> auth(agent) |> get(~p"/api/v1/entities/#{id}")
+      assert %{"data" => data} = json_response(resp, 200)
+      assert data["id"] == id
+      assert data["name"] == "project"
+    end
+
+    test "show is 404 for an unknown id", %{conn: _conn} do
+      tenant = commit_tenant()
+      agent = agent_key(tenant.id)
+
+      resp = base_conn() |> auth(agent) |> get(~p"/api/v1/entities/#{Ecto.UUID.generate()}")
+      assert json_response(resp, 404)
+    end
+
+    test "show is 404 for another tenant's id (no cross-tenant read over HTTP)", %{conn: conn} do
+      tenant_t = commit_tenant()
+      tenant_u = commit_tenant()
+      user_t = user_key(tenant_t.id)
+      agent_u = agent_key(tenant_u.id)
+
+      created = create_project_entity(conn, user_t, project_status_fields())
+      %{"data" => %{"id" => id}} = json_response(created, 201)
+
+      resp = base_conn() |> auth(agent_u) |> get(~p"/api/v1/entities/#{id}")
+      assert json_response(resp, 404)
+    end
+  end
+
   # --- TC-30.4.2: role gating ---
 
   describe "TC-30.4.2: role gating" do
@@ -175,6 +278,40 @@ defmodule LoopctlWeb.ContextRetrieverControllerTest do
 
       resp = create_project_entity(conn, agent, project_status_fields())
       assert json_response(resp, 403)
+    end
+
+    test "orchestrator key cannot create an entity (403, role 2 < user 3)", %{conn: conn} do
+      # AC-30.4.2: define/mutate is 403 for orchestrator too. An orchestrator is
+      # deliberately elevated to write work-breakdown data (CLAUDE.md), but an
+      # entity definition is the executor's field allowlist (a security root), so
+      # RequireRole role: :user must still block it — the more meaningful negative
+      # case than the below-floor agent.
+      tenant = commit_tenant()
+      orchestrator = orchestrator_key(tenant.id)
+
+      resp = create_project_entity(conn, orchestrator, project_status_fields())
+      assert json_response(resp, 403)
+    end
+
+    test "orchestrator key cannot PATCH or DELETE an entity (403)", %{conn: conn} do
+      # The same role gate covers the other define/mutate verbs. Create as a user,
+      # then prove an orchestrator key is refused on both PATCH and DELETE.
+      tenant = commit_tenant()
+      user = user_key(tenant.id)
+      orchestrator = orchestrator_key(tenant.id)
+
+      created = create_project_entity(conn, user, project_status_fields())
+      %{"data" => %{"id" => id}} = json_response(created, 201)
+
+      patched =
+        base_conn()
+        |> auth(orchestrator)
+        |> patch(~p"/api/v1/entities/#{id}", %{"fields" => project_status_fields()})
+
+      assert json_response(patched, 403)
+
+      deleted = base_conn() |> auth(orchestrator) |> delete(~p"/api/v1/entities/#{id}")
+      assert json_response(deleted, 403)
     end
 
     test "retrieve with no key is 401 (never a below-agent 403)", %{conn: conn} do
@@ -260,6 +397,127 @@ defmodule LoopctlWeb.ContextRetrieverControllerTest do
         })
 
       assert json_response(resp, 429)
+    end
+  end
+
+  # --- TC-30.4.6: execute-time allowlist re-check (the raw-/retrieve bypass close) ---
+
+  describe "TC-30.4.6: execute-time field-allowlist rejection" do
+    test "op:filter naming a declared-but-non-filterable field is 422, not executed",
+         %{conn: conn} do
+      # `slug` is declared on the entity but `filterable: false`. The generate-time
+      # tool surface never exposes a filter tool for it, but a raw POST can still
+      # name it — the executor's execute-time re-check must REJECT it (422
+      # field_not_allowlisted), never run the query. This is the most
+      # security-relevant branch of the story (the raw-/retrieve bypass close).
+      tenant = commit_tenant()
+      user = user_key(tenant.id)
+      agent = agent_key(tenant.id)
+
+      create_project_entity(conn, user, project_status_and_unfilterable_slug_fields())
+      seed_project(tenant.id)
+
+      resp =
+        base_conn()
+        |> auth(agent)
+        |> post(~p"/api/v1/retrieve/project", %{
+          "field" => "slug",
+          "op" => "filter",
+          "value" => "anything"
+        })
+
+      assert %{"error" => %{"code" => "field_not_allowlisted"}} = json_response(resp, 422)
+    end
+
+    test "op:filter naming a field the entity never declares is 422", %{conn: conn} do
+      # `mission` is a server-allowlisted projects column, but this entity does not
+      # declare it — the executor rejects it the same way (never executed).
+      tenant = commit_tenant()
+      user = user_key(tenant.id)
+      agent = agent_key(tenant.id)
+
+      create_project_entity(conn, user, project_status_fields())
+      seed_project(tenant.id)
+
+      resp =
+        base_conn()
+        |> auth(agent)
+        |> post(~p"/api/v1/retrieve/project", %{
+          "field" => "mission",
+          "op" => "filter",
+          "value" => "anything"
+        })
+
+      assert %{"error" => %{"code" => "field_not_allowlisted"}} = json_response(resp, 422)
+    end
+  end
+
+  # --- TC-30.4.7: op:"search" over HTTP ---
+
+  describe "TC-30.4.7: retrieve op:search" do
+    test "search over a vector-covered text field returns 200 with results + meta",
+         %{conn: conn} do
+      tenant = commit_tenant()
+      user = user_key(tenant.id)
+      agent = agent_key(tenant.id)
+
+      create_project_entity(conn, user, project_searchable_name_fields())
+      seed_project(tenant.id, %{name: "Photosynthesis research initiative"})
+      seed_project(tenant.id, %{name: "Unrelated ledger tooling"})
+
+      resp =
+        base_conn()
+        |> auth(agent)
+        |> post(~p"/api/v1/retrieve/project", %{
+          "op" => "search",
+          "query" => "photosynthesis"
+        })
+
+      assert %{"results" => results, "meta" => meta} = json_response(resp, 200)
+      assert results == [%{"name" => "Photosynthesis research initiative"}]
+      assert meta["total_count"] == 1
+      # Shaped to declared columns only.
+      refute Enum.any?(results, &Map.has_key?(&1, "tenant_id"))
+    end
+
+    test "search over a declared-but-unindexed searchable field is 422 search_not_indexed",
+         %{conn: conn} do
+      # `slug` is allowlisted + declared searchable, but NOT covered by the
+      # projects search_vector (name/description/mission). The generate-time tool
+      # surface suppresses the search tool, but a raw POST op:"search" must be
+      # rejected (422 search_not_indexed), never silently searched against the
+      # vector's different columns.
+      tenant = commit_tenant()
+      user = user_key(tenant.id)
+      agent = agent_key(tenant.id)
+
+      create_project_entity(conn, user, project_unindexed_searchable_slug_fields())
+      seed_project(tenant.id)
+
+      resp =
+        base_conn()
+        |> auth(agent)
+        |> post(~p"/api/v1/retrieve/project", %{
+          "op" => "search",
+          "query" => "anything"
+        })
+
+      assert %{"error" => %{"code" => "search_not_indexed"}} = json_response(resp, 422)
+    end
+
+    test "an unknown op is 422 invalid_operation", %{conn: conn} do
+      tenant = commit_tenant()
+      user = user_key(tenant.id)
+      agent = agent_key(tenant.id)
+
+      create_project_entity(conn, user, project_status_fields())
+
+      resp =
+        base_conn()
+        |> auth(agent)
+        |> post(~p"/api/v1/retrieve/project", %{"op" => "sort", "field" => "status"})
+
+      assert %{"error" => %{"code" => "invalid_operation"}} = json_response(resp, 422)
     end
   end
 

--- a/test/loopctl_web/controllers/openapi_test.exs
+++ b/test/loopctl_web/controllers/openapi_test.exs
@@ -79,6 +79,36 @@ defmodule LoopctlWeb.OpenApiTest do
       assert Map.has_key?(schemas, "MemoryRecallResponse")
       assert Map.has_key?(schemas, "MemoryPromoteRequest")
     end
+
+    # US-30.4 (AC-30.4.5) — the Context Retriever endpoints (Epic 30) must render
+    # in the OpenAPI spec (declared via `operation(...)` in
+    # ContextRetrieverController) so they show up at /swaggerui.
+    test "includes the Context Retriever (Epic 30) endpoints", %{conn: conn} do
+      body = conn |> get("/api/v1/openapi") |> json_response(200)
+      paths = body["paths"]
+
+      assert Map.has_key?(paths, "/api/v1/entities")
+      assert Map.has_key?(paths, "/api/v1/entities/{id}")
+      assert Map.has_key?(paths, "/api/v1/retrieve/tools")
+      assert Map.has_key?(paths, "/api/v1/retrieve/{entity}")
+
+      # The verbs each route declares.
+      assert Map.has_key?(paths["/api/v1/entities"], "get")
+      assert Map.has_key?(paths["/api/v1/entities"], "post")
+      assert Map.has_key?(paths["/api/v1/entities/{id}"], "get")
+      assert Map.has_key?(paths["/api/v1/entities/{id}"], "patch")
+      assert Map.has_key?(paths["/api/v1/entities/{id}"], "delete")
+      assert Map.has_key?(paths["/api/v1/retrieve/tools"], "get")
+      assert Map.has_key?(paths["/api/v1/retrieve/{entity}"], "post")
+
+      # And the Context Retriever schemas are registered under components.
+      schemas = body["components"]["schemas"]
+      assert Map.has_key?(schemas, "EntityDefinition")
+      assert Map.has_key?(schemas, "EntityDefinitionRequest")
+      assert Map.has_key?(schemas, "EntityDefinitionListResponse")
+      assert Map.has_key?(schemas, "RetrieveToolsResponse")
+      assert Map.has_key?(schemas, "RetrieveResponse")
+    end
   end
 
   describe "GET /swaggerui" do

--- a/test/loopctl_web/require_human_anchor_default_deny_test.exs
+++ b/test/loopctl_web/require_human_anchor_default_deny_test.exs
@@ -111,6 +111,19 @@ defmodule LoopctlWeb.RequireHumanAnchorDefaultDenyTest do
                {:post, "/api/v1/memory/promote"},
                {:delete, "/api/v1/memory/:id"},
 
+               # Context Retriever (Epic 30, US-30.4) — `POST /retrieve/:entity` is a
+               # POST-shaped READ (a governed filter/search over the tenant's OWN
+               # structured records), NOT a mutation. Querying is the floor-agent /
+               # KB-tier surface (AC-30.4.2), so gating it behind human-anchor would
+               # make an agent-rooted tenant unable to query its own data — the
+               # opposite of intent. The executor dual tenant-scopes every read (RLS +
+               # explicit predicate) and re-validates the field against the SERVER
+               # allowlist, so no data crosses tenants. DEFINING/mutating an entity
+               # definition (POST/PATCH/DELETE /entities) IS tier-gated — see
+               # ContextRetrieverController's RequireHumanAnchor plug — so those routes
+               # are (correctly) absent from this allowlist and asserted to 403.
+               {:post, "/api/v1/retrieve/:entity"},
+
                # UI test runs (#4/#5 reviewed rationale): a QA/tooling surface,
                # NOT work-breakdown state. Every route is nested under
                # `/projects/:project_id/...` and creating a project


### PR DESCRIPTION
## US-30.4 — Context Retriever API

Wires the already-built Context Retriever domain (US-30.1 Registry/Entity,
US-30.2 ToolGenerator, US-30.3 Executor) to `/api/v1` on the `:authenticated`
pipeline via a thin JSON controller. No new domain logic, no LiveView.

### Endpoints
- `POST/GET /api/v1/entities`, `GET/PATCH/DELETE /api/v1/entities/:id` — entity-definition CRUD
- `GET /api/v1/retrieve/tools` — the tenant's generated tool specs
- `POST /api/v1/retrieve/:entity` — execute a filter/search via the Executor

### Acceptance criteria
- **AC-30.4.1** CRUD + tools + retrieve; scope derived from the key, body `tenant_id` ignored.
- **AC-30.4.2** Define/mutate requires `>= :user` (403 for agent/orchestrator); querying is floor `:agent` (negative case is 401 unauthenticated).
- **AC-30.4.3** `GET /retrieve/tools` returns only the calling tenant's specs (RLS-scoped `Registry.for_tenant`); isolation test proves it under the non-owner `loopctl_app` role.
- **AC-30.4.4** `/retrieve/:entity` re-validates entity+field+operation via the Executor; unknown entity / non-allowlisted field is 4xx, never executed.
- **AC-30.4.5** OpenAPI operation macros + schemas (`EntityDefinition*`, `Retrieve*`); renders at `/swaggerui`, `openapi_test` extended.
- **AC-30.4.6** `POST /retrieve/:entity` is rate-limited per tenant (Hammer DI seam); over-limit returns 429 without executing.

### Notable decisions
- Entity-definition mutations are additionally gated behind `RequireHumanAnchor` (an entity definition IS the executor's field allowlist — a security root), consistent with the rest of the work-breakdown surface; the query-shaped `POST /retrieve/:entity` is allowlisted in the default-deny guard as a POST-shaped read.
- `Registry` gained `update_entity/4`, `delete_entity/3`, `get_entity_by_id/2` following the existing `Ecto.Multi` + `Repo.with_tenant` + `Audit.log_in_multi` pattern (cap-free, advisory-lock-free); `Entity` gained `update_changeset/2` (identical security validations to create).
- Controller tests bridge the AdminRepo auth path and the Repo executor path via a committed test tenant (both connections can only see committed rows), async: false, and assert isolation under the real RLS role.

### Testing
- New `context_retriever_controller_test.exs` (all TCs: create/tools/retrieve, role gating, PATCH/DELETE reflected in tools, rate limit, tenant isolation) + extended `openapi_test.exs` — green.
- `mix precommit` (compile --warnings-as-errors, format, credo --strict, dialyzer, full test suite) passes.
- Note: the full suite has a PRE-EXISTING intermittent flake in `MemoryPromotionWorkerTest` (Epic 29, embedding/supersede) reproducible on `master` with these changes stashed — unrelated to this PR.

Part of #309 (Epic 30 — Context Retriever). Story US-30.4; no per-story issue exists, so no auto-close.
