### PR TITLE
Dynamic MCP tool listing: append per-tenant generated tools, dispatch generically

### DIFF
--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to `loopctl-mcp-server` are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 2.40.0 — 2026-07-10 (US-30.5 — dynamic per-tenant Context Retriever tools)
+
+### Added
+
+- **Dynamic MCP tool listing.** `ListTools` now returns the static hand-maintained
+  tools PLUS the calling tenant's **generated** Context Retriever tools (Epic 30),
+  fetched at listing time from `GET /api/v1/retrieve/tools` through the shared
+  authenticated `apiCall` (agent key, same witness/STH path as every read tool).
+  When a tenant declares an entity, loopctl auto-generates
+  `cr_filter_<entity>_by_<field>` and `cr_search_<entity>` tools over its
+  allowlisted columns; those now appear in the agent's tool list automatically. If
+  the `/retrieve/tools` fetch fails, the listing **degrades to the static tools**
+  (logged, never errors the whole listing). A short (30s) in-process cache bounds
+  the extra latency the dynamic fetch adds to `ListTools`.
+- **Generic dispatch of `cr_`-prefixed calls.** `CallTool` now routes any unknown
+  tool name starting with `cr_` to a single generic handler that POSTs to `POST
+  /api/v1/retrieve/:entity`. The `(entity, field, operation)` are read from the
+  STRUCTURED metadata carried on each generated spec (US-30.2), never by splitting
+  the tool name (entity/field names contain underscores). Static tools dispatch
+  exactly as before — no regression.
+
+### Security / trust model
+
+- Generated tools are **tenant-scoped by construction**: the stdio MCP process is
+  one-tenant-per-process, so `/retrieve/tools` returns only the process key's
+  tenant's specs and a generic call executes under that key's scope. The client
+  never selects a tenant. Both the listing fetch and the generic call ride the
+  SAME `apiCall`/witness path as static reads, so they carry identical
+  auth + witness/STH headers — no second, weaker HTTP path was introduced.
+
 ## 2.38.0 — 2026-07-10 (US-29.4 — memory_promote tool)
 
 ### Added

--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -17,14 +17,40 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   `cr_filter_<entity>_by_<field>` and `cr_search_<entity>` tools over its
   allowlisted columns; those now appear in the agent's tool list automatically. If
   the `/retrieve/tools` fetch fails, the listing **degrades to the static tools**
-  (logged, never errors the whole listing). A short (30s) in-process cache bounds
-  the extra latency the dynamic fetch adds to `ListTools`.
+  (logged, never errors the whole listing). The dynamic fetch uses a **short (5s)
+  timeout** and a **positive (30s) + negative (5s) in-process cache** so a
+  Context-Retriever backend blip degrades to the static surface fast and does NOT
+  re-issue a blocking fetch on every subsequent `ListTools`.
 - **Generic dispatch of `cr_`-prefixed calls.** `CallTool` now routes any unknown
   tool name starting with `cr_` to a single generic handler that POSTs to `POST
   /api/v1/retrieve/:entity`. The `(entity, field, operation)` are read from the
   STRUCTURED metadata carried on each generated spec (US-30.2), never by splitting
   the tool name (entity/field names contain underscores). Static tools dispatch
-  exactly as before — no regression.
+  exactly as before — no regression. Resolving a generated-tool call whose name
+  isn't yet cached **forces one fresh `/retrieve/tools` fetch** (bypassing the warm
+  TTL) so a tool created server-side since the last listing resolves instead of
+  being reported as unknown; a call that stays unresolved returns **503
+  temporarily-unavailable** when the tools fetch itself failed (retryable) versus a
+  definitive **404** only when the listing was healthy and the name is genuinely not
+  this tenant's.
+
+### Review hardening
+
+- **Short timeout + negative caching for the init-time listing fetch.** `ListTools`
+  is agent-blocking at connection setup; the generated-tools fetch now carries its
+  own short `AbortSignal` budget and negative-caches failures, so a backend outage
+  can't stall the whole tool surface (all static tools included) with repeated
+  full-timeout blocking fetches. Per-request timeout override threaded through the
+  shared `apiCall` → witness client.
+- **Defense-in-depth on the `cr_` invariant.** The prefix is re-checked at
+  listing/metadata population, not only at dispatch: any server spec whose name
+  isn't `cr_`-prefixed, or that collides with a static tool name, is dropped and
+  logged — closing a tool-confusion / description-spoofing vector where
+  tenant-controlled text could be shown under a trusted built-in tool's identity.
+- **Extracted `lib/generated-tools.js`.** The fetch/cache/TTL/negative-cache/
+  dispatch runtime moved out of the non-importable `index.js` entry point into a
+  side-effect-free module (like `lib/http-helpers.js`), so its edge cases are
+  exercised DIRECTLY by the test suite instead of a hand-copied mirror.
 
 ### Security / trust model
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -123,6 +123,10 @@ autonomous agent) can self-remediate without a human. Full agent-tenant lifecycl
 
 ## Tools (84)
 
+> Plus **per-tenant generated Context Retriever tools** (`cr_*`) appended
+> dynamically at runtime — see [Dynamic per-tenant Context Retriever
+> tools](#dynamic-per-tenant-context-retriever-tools-epic-30) below.
+
 ### Project Tools
 
 | Tool | Description |
@@ -279,6 +283,26 @@ it is enforced server-side and a no-op for a non-superadmin key — see below.)
 |---|---|
 | `list_routes` | List all available API routes on the loopctl server. |
 | `get_system_articles` | List or fetch system-scoped (global, cross-tenant) wiki articles. Public — no auth required. Optional: `slug` (fetch one), `category`. |
+
+### Dynamic per-tenant Context Retriever tools (Epic 30)
+
+Beyond the static tools above, the server appends **per-tenant generated tools** to
+`ListTools` at runtime. When your tenant declares an **entity** (`POST
+/api/v1/entities`), loopctl auto-generates governed query tools over that entity's
+allowlisted columns, and this MCP server fetches them from `GET
+/api/v1/retrieve/tools` and lists them alongside the static tools:
+
+| Generated tool | What it does |
+|---|---|
+| `cr_filter_<entity>_by_<field>` | Filter that entity's records where `<field>` equals a value. Params: the field value + `limit`/`offset`. |
+| `cr_search_<entity>` | Full-text search across that entity's searchable text fields. Params: `query` + `limit`/`offset`. |
+
+These are **tenant-scoped**: the listing reflects only the tenant of the process
+key (`LOOPCTL_AGENT_KEY`), resolved server-side — you never pass a tenant. A
+`cr_`-prefixed call is dispatched generically to `POST /api/v1/retrieve/:entity`
+through the same authenticated + witness/STH path as every static read tool. If the
+`/retrieve/tools` fetch fails, listing degrades to the static tools (never errors).
+The generated-tool count per tenant is bounded by the per-tenant entity cap.
 
 ### Dispatch & Chain of Custody (v2) Tools
 

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -20,6 +20,10 @@ import {
   llmUsagePath,
   memoryPath,
   parseJsonResponseBody,
+  retrieveToolsPath,
+  retrieveEntityPath,
+  specToMcpTool,
+  buildRetrieveBody,
 } from "./lib/http-helpers.js";
 import {
   createWitnessClient,
@@ -4468,6 +4472,136 @@ const TOOLS = [
 ];
 
 // ---------------------------------------------------------------------------
+// Context Retriever — dynamic per-tenant generated tools (US-30.5)
+// ---------------------------------------------------------------------------
+//
+// Epic 30 lets a tenant declare ENTITIES whose schema auto-generates agent tools
+// (`cr_filter_<entity>_by_<field>`, `cr_search_<entity>`) over governed loopctl
+// data. Those specs are generated SERVER-SIDE per tenant, so the MCP server can't
+// hard-code them in the static TOOLS array — it must fetch them at ListTools time
+// and append them, then dispatch any unknown `cr_`-prefixed CallTool to one
+// generic executor endpoint.
+//
+// Trust model: the stdio MCP process is ONE-TENANT-PER-PROCESS — the process key
+// (LOOPCTL_AGENT_KEY) resolves to a tenant server-side, and GET /retrieve/tools
+// returns ONLY that tenant's generated specs. The client never picks a tenant, so
+// cross-tenant listing/calling is impossible by construction (AC-30.5.3). Both the
+// listing fetch and the generic call ride the SAME `apiCall` path as static read
+// tools, so they carry identical auth + witness/STH headers (AC-30.5.4).
+
+const GENERATED_TOOL_PREFIX = "cr_";
+
+// Short in-process cache: ListTools now makes an HTTP call, so cache the fetched
+// specs briefly to bound repeated-listing latency. Degrade-to-static is still the
+// hard requirement — a fetch failure never poisons the cache (we keep whatever we
+// had, empty at first) and never errors the whole listing.
+const GENERATED_TOOLS_CACHE_TTL_MS = 30_000;
+let generatedToolsCache = { tools: [], fetchedAt: 0 };
+
+// name -> STRUCTURED dispatch metadata (`{ entity, field, operation, ... }`, from
+// US-30.2). The generic dispatcher resolves (entity, field, operation) from THIS
+// map, never by splitting the tool name (entity/field names contain underscores,
+// so name-splitting is ambiguous — AC-30.5.2). Repopulated on every successful
+// /retrieve/tools fetch.
+let generatedToolMetadata = new Map();
+
+/**
+ * Fetch the calling tenant's generated tool specs from GET /api/v1/retrieve/tools
+ * (via the shared authenticated `apiCall`, agent+ key) and map them to the MCP
+ * `{ name, description, inputSchema }` shape. On ANY failure (thrown, or an
+ * `{ error: true }` result) this logs and returns the last-known (possibly empty)
+ * cache so ListTools degrades to the static tools rather than erroring the whole
+ * listing (AC-30.5.1 / TC-30.5.4). Also (re)populates `generatedToolMetadata`.
+ *
+ * @returns {Promise<Array<{ name: string, description: string, inputSchema: object }>>}
+ */
+async function fetchGeneratedTools() {
+  const now = Date.now();
+  if (generatedToolsCache.fetchedAt !== 0 && now - generatedToolsCache.fetchedAt < GENERATED_TOOLS_CACHE_TTL_MS) {
+    return generatedToolsCache.tools;
+  }
+
+  let result;
+  try {
+    result = await apiCall("GET", retrieveToolsPath(), null, process.env.LOOPCTL_AGENT_KEY);
+  } catch (err) {
+    console.error(`loopctl: failed to fetch generated tools, degrading to static tools: ${err.message}`);
+    return generatedToolsCache.tools;
+  }
+
+  if (result && result.error === true) {
+    const detail = typeof result.body === "string" ? result.body : JSON.stringify(result.body);
+    console.error(
+      `loopctl: failed to fetch generated tools (HTTP ${result.status}), degrading to static tools: ${detail}`,
+    );
+    return generatedToolsCache.tools;
+  }
+
+  const specs = result && Array.isArray(result.data) ? result.data : [];
+  const tools = [];
+  const metadata = new Map();
+  for (const spec of specs) {
+    const tool = specToMcpTool(spec);
+    if (!tool) continue;
+    tools.push(tool);
+    if (spec.metadata && typeof spec.metadata === "object") {
+      metadata.set(spec.name, spec.metadata);
+    }
+  }
+
+  generatedToolMetadata = metadata;
+  generatedToolsCache = { tools, fetchedAt: now };
+  return tools;
+}
+
+/**
+ * Resolve a `cr_`-prefixed tool name to its STRUCTURED dispatch metadata,
+ * lazily (re)fetching the specs if the name isn't already known (e.g. CallTool
+ * arriving before any ListTools). A name that stays unresolved after a fresh
+ * fetch is genuinely unknown to THIS tenant — the generic handler treats it as an
+ * unknown tool (which is exactly how a cross-tenant `cr_` name presents, since the
+ * fetch only ever returns the process key's tenant — AC-30.5.3 / TC-30.5.3).
+ *
+ * @param {string} name
+ * @returns {Promise<object|null>}
+ */
+async function resolveGeneratedToolMetadata(name) {
+  if (generatedToolMetadata.has(name)) return generatedToolMetadata.get(name);
+  await fetchGeneratedTools();
+  return generatedToolMetadata.get(name) || null;
+}
+
+/**
+ * Generic dispatcher for a per-tenant generated tool. Resolves the tool's
+ * (entity, field, operation) from STRUCTURED metadata (never by name-splitting —
+ * AC-30.5.2), builds the US-30.4 request body, and POSTs to
+ * /api/v1/retrieve/:entity via the SAME `apiCall` path (hence the SAME auth +
+ * witness/STH headers) as every static read tool (AC-30.5.4 / TC-30.5.5). An
+ * unresolvable name returns a structured "unknown tool" error result.
+ *
+ * @param {string} name
+ * @param {object} [args]
+ */
+async function callGeneratedTool(name, args = {}) {
+  const metadata = await resolveGeneratedToolMetadata(name);
+  if (!metadata || typeof metadata.entity !== "string" || typeof metadata.operation !== "string") {
+    return toContent({
+      error: true,
+      status: 404,
+      body: `Unknown tool: ${name}. No generated tool by that name is available to this tenant.`,
+    });
+  }
+
+  const result = await apiCall(
+    "POST",
+    retrieveEntityPath(metadata.entity),
+    buildRetrieveBody(metadata, args),
+    process.env.LOOPCTL_AGENT_KEY,
+  );
+  return toContent(result);
+}
+
+// ---------------------------------------------------------------------------
 // MCP Server
 // ---------------------------------------------------------------------------
 
@@ -4481,9 +4615,13 @@ const server = new Server(
   }
 );
 
-server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: TOOLS,
-}));
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  // Static hand-maintained tools PLUS the calling tenant's per-tenant generated
+  // Context Retriever tools (US-30.5). fetchGeneratedTools degrades to the static
+  // tools (returns []/cache) on any fetch failure, so listing never errors.
+  const generated = await fetchGeneratedTools();
+  return { tools: [...TOOLS, ...generated] };
+});
 
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
@@ -4753,6 +4891,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return await getAcceptanceCriteria(args);
 
     default:
+      // Per-tenant generated Context Retriever tools (US-30.5) are not in the
+      // static switch — dispatch any unknown `cr_`-prefixed name generically to
+      // the /retrieve/:entity executor. Static tools are handled above, so this
+      // never regresses them (AC-30.5.2).
+      if (typeof name === "string" && name.startsWith(GENERATED_TOOL_PREFIX)) {
+        return await callGeneratedTool(name, args);
+      }
       throw new Error(`Unknown tool: ${name}`);
   }
 });

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -20,15 +20,15 @@ import {
   llmUsagePath,
   memoryPath,
   parseJsonResponseBody,
-  retrieveToolsPath,
-  retrieveEntityPath,
-  specToMcpTool,
-  buildRetrieveBody,
 } from "./lib/http-helpers.js";
 import {
   createWitnessClient,
   resolveSthStatePath,
 } from "./lib/witness-sth.js";
+import {
+  createGeneratedToolsRuntime,
+  GENERATED_TOOL_PREFIX,
+} from "./lib/generated-tools.js";
 
 // Single source of truth for the server version: the package.json this file
 // ships with (npm always includes package.json in the published tarball).
@@ -65,6 +65,11 @@ const SERVER_VERSION = JSON.parse(
 // transparent retry above). The write is atomic + symlink-safe (temp + rename).
 const WITNESS_FS = { readFileSync, writeFileSync, renameSync, lstatSync, unlinkSync };
 
+// Default per-request HTTP timeout. Individual calls may pass a SHORTER budget via
+// `apiCall(..., { timeoutMs })` — e.g. the init-time generated-tools listing fetch,
+// which must degrade to static tools quickly rather than block connection setup.
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+
 // One witness client PER API KEY (#298 review HIGH-2): the STH is per-tenant and
 // each key resolves to a tenant server-side, so distinct keys must NOT share an
 // in-memory cache or a state file (a collision causes spurious 409s + false
@@ -81,7 +86,7 @@ function witnessClientFor(apiKey) {
       fs: WITNESS_FS,
       getuid: typeof process.getuid === "function" ? () => process.getuid() : undefined,
       pid: process.pid,
-      timeoutMs: 30_000,
+      timeoutMs: DEFAULT_REQUEST_TIMEOUT_MS,
     });
     witnessClients.set(apiKey, client);
   }
@@ -108,7 +113,7 @@ function resolveKey(keyOverride) {
   );
 }
 
-async function apiCall(method, path, body, keyOverride, { exactKey = false } = {}) {
+async function apiCall(method, path, body, keyOverride, { exactKey = false, timeoutMs } = {}) {
   const url = `${getBaseUrl()}${path}`;
   // Secret-managing tools pass exactKey:true so the request uses the EXACT
   // role-pinned key (LOOPCTL_USER_KEY) and does NOT fall back to the global
@@ -141,10 +146,11 @@ async function apiCall(method, path, body, keyOverride, { exactKey = false } = {
   // attempt's Response; we keep body parsing / error shaping here.
   let response;
   try {
-    response = await witnessClientFor(key).send({ url, method, headers, serializedBody });
+    response = await witnessClientFor(key).send({ url, method, headers, serializedBody, timeoutMs });
   } catch (err) {
     if (err.name === "TimeoutError") {
-      return { error: true, status: 0, body: "Request timed out after 30s" };
+      const secs = Math.max(1, Math.round((timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS) / 1000));
+      return { error: true, status: 0, body: `Request timed out after ${secs}s` };
     }
     const cause = err.cause?.message ? ` (${err.cause.message})` : "";
     return { error: true, status: 0, body: `Network error: ${err.message}${cause}` };
@@ -4489,117 +4495,22 @@ const TOOLS = [
 // listing fetch and the generic call ride the SAME `apiCall` path as static read
 // tools, so they carry identical auth + witness/STH headers (AC-30.5.4).
 
-const GENERATED_TOOL_PREFIX = "cr_";
+// The generated-tools runtime (fetch + short-timeout/negative-TTL cache + generic
+// dispatch) lives in lib/generated-tools.js so its caching/TTL/negative-cache and
+// error-classification edge cases are exercised DIRECTLY by the test suite rather
+// than a hand-copied mirror. We wire the SHIPPED `apiCall` + static tool names +
+// `toContent` into it here. The process key (LOOPCTL_AGENT_KEY) is read per-call via
+// a getter so it rides the SAME auth + witness/STH path as every static read tool
+// (AC-30.5.4), and the static-name set powers the defense-in-depth drop of any spec
+// that isn't `cr_`-prefixed or that collides with a built-in tool name.
+const generatedToolsRuntime = createGeneratedToolsRuntime({
+  apiCall,
+  agentKey: () => process.env.LOOPCTL_AGENT_KEY,
+  staticToolNames: new Set(TOOLS.map((t) => t.name)),
+  toContent,
+});
 
-// Short in-process cache: ListTools now makes an HTTP call, so cache the fetched
-// specs briefly to bound repeated-listing latency. Degrade-to-static is still the
-// hard requirement — a fetch failure never poisons the cache (we keep whatever we
-// had, empty at first) and never errors the whole listing.
-const GENERATED_TOOLS_CACHE_TTL_MS = 30_000;
-let generatedToolsCache = { tools: [], fetchedAt: 0 };
-
-// name -> STRUCTURED dispatch metadata (`{ entity, field, operation, ... }`, from
-// US-30.2). The generic dispatcher resolves (entity, field, operation) from THIS
-// map, never by splitting the tool name (entity/field names contain underscores,
-// so name-splitting is ambiguous — AC-30.5.2). Repopulated on every successful
-// /retrieve/tools fetch.
-let generatedToolMetadata = new Map();
-
-/**
- * Fetch the calling tenant's generated tool specs from GET /api/v1/retrieve/tools
- * (via the shared authenticated `apiCall`, agent+ key) and map them to the MCP
- * `{ name, description, inputSchema }` shape. On ANY failure (thrown, or an
- * `{ error: true }` result) this logs and returns the last-known (possibly empty)
- * cache so ListTools degrades to the static tools rather than erroring the whole
- * listing (AC-30.5.1 / TC-30.5.4). Also (re)populates `generatedToolMetadata`.
- *
- * @returns {Promise<Array<{ name: string, description: string, inputSchema: object }>>}
- */
-async function fetchGeneratedTools() {
-  const now = Date.now();
-  if (generatedToolsCache.fetchedAt !== 0 && now - generatedToolsCache.fetchedAt < GENERATED_TOOLS_CACHE_TTL_MS) {
-    return generatedToolsCache.tools;
-  }
-
-  let result;
-  try {
-    result = await apiCall("GET", retrieveToolsPath(), null, process.env.LOOPCTL_AGENT_KEY);
-  } catch (err) {
-    console.error(`loopctl: failed to fetch generated tools, degrading to static tools: ${err.message}`);
-    return generatedToolsCache.tools;
-  }
-
-  if (result && result.error === true) {
-    const detail = typeof result.body === "string" ? result.body : JSON.stringify(result.body);
-    console.error(
-      `loopctl: failed to fetch generated tools (HTTP ${result.status}), degrading to static tools: ${detail}`,
-    );
-    return generatedToolsCache.tools;
-  }
-
-  const specs = result && Array.isArray(result.data) ? result.data : [];
-  const tools = [];
-  const metadata = new Map();
-  for (const spec of specs) {
-    const tool = specToMcpTool(spec);
-    if (!tool) continue;
-    tools.push(tool);
-    if (spec.metadata && typeof spec.metadata === "object") {
-      metadata.set(spec.name, spec.metadata);
-    }
-  }
-
-  generatedToolMetadata = metadata;
-  generatedToolsCache = { tools, fetchedAt: now };
-  return tools;
-}
-
-/**
- * Resolve a `cr_`-prefixed tool name to its STRUCTURED dispatch metadata,
- * lazily (re)fetching the specs if the name isn't already known (e.g. CallTool
- * arriving before any ListTools). A name that stays unresolved after a fresh
- * fetch is genuinely unknown to THIS tenant — the generic handler treats it as an
- * unknown tool (which is exactly how a cross-tenant `cr_` name presents, since the
- * fetch only ever returns the process key's tenant — AC-30.5.3 / TC-30.5.3).
- *
- * @param {string} name
- * @returns {Promise<object|null>}
- */
-async function resolveGeneratedToolMetadata(name) {
-  if (generatedToolMetadata.has(name)) return generatedToolMetadata.get(name);
-  await fetchGeneratedTools();
-  return generatedToolMetadata.get(name) || null;
-}
-
-/**
- * Generic dispatcher for a per-tenant generated tool. Resolves the tool's
- * (entity, field, operation) from STRUCTURED metadata (never by name-splitting —
- * AC-30.5.2), builds the US-30.4 request body, and POSTs to
- * /api/v1/retrieve/:entity via the SAME `apiCall` path (hence the SAME auth +
- * witness/STH headers) as every static read tool (AC-30.5.4 / TC-30.5.5). An
- * unresolvable name returns a structured "unknown tool" error result.
- *
- * @param {string} name
- * @param {object} [args]
- */
-async function callGeneratedTool(name, args = {}) {
-  const metadata = await resolveGeneratedToolMetadata(name);
-  if (!metadata || typeof metadata.entity !== "string" || typeof metadata.operation !== "string") {
-    return toContent({
-      error: true,
-      status: 404,
-      body: `Unknown tool: ${name}. No generated tool by that name is available to this tenant.`,
-    });
-  }
-
-  const result = await apiCall(
-    "POST",
-    retrieveEntityPath(metadata.entity),
-    buildRetrieveBody(metadata, args),
-    process.env.LOOPCTL_AGENT_KEY,
-  );
-  return toContent(result);
-}
+const { fetchGeneratedTools, callGeneratedTool } = generatedToolsRuntime;
 
 // ---------------------------------------------------------------------------
 // MCP Server

--- a/mcp-server/lib/generated-tools.js
+++ b/mcp-server/lib/generated-tools.js
@@ -1,0 +1,209 @@
+// Per-tenant generated Context Retriever tool runtime (US-30.5).
+//
+// index.js is a stdio entry point with top-level await (importing it boots the MCP
+// server), so its handlers can't be imported by tests. This module extracts the
+// generated-tools fetch / cache / dispatch runtime — the logic with real caching,
+// TTL, negative-cache and error-classification edge cases — into a side-effect-free
+// factory (like lib/http-helpers.js). index.js wires the SHIPPED `apiCall`, static
+// tool names, and `toContent` into `createGeneratedToolsRuntime`, and the test suite
+// exercises the SAME code, so a regression fails CI instead of silently passing
+// against a hand-copied mirror.
+
+import {
+  retrieveToolsPath,
+  retrieveEntityPath,
+  specToMcpTool,
+  buildRetrieveBody,
+} from "./http-helpers.js";
+
+export const GENERATED_TOOL_PREFIX = "cr_";
+
+// ListTools is an init-time, agent-blocking call (Claude Code blocks on it during
+// connection setup). So the generated-tools fetch uses BOTH a SHORT timeout and a
+// NEGATIVE TTL: during any Context-Retriever backend slowness/outage the listing
+// degrades to the static tool surface quickly, and a failed fetch is cached for a
+// short window so subsequent ListTools calls do NOT each re-issue a blocking fetch
+// before degrading (us_30.5.json technical_notes: "keep it cached/short-timeout and
+// degrade to static on failure").
+export const GENERATED_TOOLS_CACHE_TTL_MS = 30_000; // positive: last fetch succeeded
+export const GENERATED_TOOLS_NEGATIVE_TTL_MS = 5_000; // negative: last fetch failed
+export const GENERATED_TOOLS_FETCH_TIMEOUT_MS = 5_000; // short per-fetch AbortSignal budget
+
+/**
+ * Build a generated-tools runtime bound to injected dependencies. State (cache +
+ * name->metadata map) is private to the returned closure.
+ *
+ * @param {{
+ *   apiCall: (method: string, path: string, body: unknown, key: (string|undefined), opts?: object) => Promise<any>,
+ *   agentKey: () => (string|undefined),
+ *   staticToolNames?: Set<string>,
+ *   toContent: (result: any) => object,
+ *   now?: () => number,
+ *   log?: (msg: string) => void,
+ *   cacheTtlMs?: number,
+ *   negativeTtlMs?: number,
+ *   fetchTimeoutMs?: number,
+ *   prefix?: string,
+ * }} deps
+ */
+export function createGeneratedToolsRuntime({
+  apiCall,
+  agentKey,
+  staticToolNames = new Set(),
+  toContent,
+  now = () => Date.now(),
+  log = (msg) => console.error(msg),
+  cacheTtlMs = GENERATED_TOOLS_CACHE_TTL_MS,
+  negativeTtlMs = GENERATED_TOOLS_NEGATIVE_TTL_MS,
+  fetchTimeoutMs = GENERATED_TOOLS_FETCH_TIMEOUT_MS,
+  prefix = GENERATED_TOOL_PREFIX,
+}) {
+  // `ok` records the LAST fetch outcome so (a) the TTL guard applies the negative
+  // TTL after a failure and (b) an unresolved CallTool can tell "temporarily
+  // unavailable" from "genuinely unknown to this tenant". `tools`/`metadata` retain
+  // the last KNOWN-GOOD listing so a failure degrades to it, never poisons it.
+  let cache = { tools: [], fetchedAt: 0, ok: true };
+  let metadataByName = new Map();
+
+  function cacheFailure(at, message) {
+    log(message);
+    // Negative caching: stamp fetchedAt on failure (ok:false) WITHOUT touching the
+    // retained tools/metadata, so subsequent calls within the negative-TTL window
+    // return the degraded static surface instead of re-issuing a blocking fetch.
+    cache = { tools: cache.tools, fetchedAt: at, ok: false };
+    return cache.tools;
+  }
+
+  /**
+   * Fetch the calling tenant's generated tool specs from GET /retrieve/tools and
+   * map them to the MCP `{ name, description, inputSchema }` shape, (re)populating
+   * the name->metadata map. On ANY failure this logs, negative-caches, and returns
+   * the last-known (possibly empty) tools so ListTools degrades to static rather
+   * than erroring (AC-30.5.1). Honors the positive/negative TTL unless `force`.
+   *
+   * @param {{ force?: boolean }} [opts]
+   * @returns {Promise<Array<{ name: string, description: string, inputSchema: object }>>}
+   */
+  async function fetchGeneratedTools({ force = false } = {}) {
+    const at = now();
+    if (!force && cache.fetchedAt !== 0) {
+      const ttl = cache.ok ? cacheTtlMs : negativeTtlMs;
+      if (at - cache.fetchedAt < ttl) return cache.tools;
+    }
+
+    let result;
+    try {
+      result = await apiCall("GET", retrieveToolsPath(), null, agentKey(), {
+        timeoutMs: fetchTimeoutMs,
+      });
+    } catch (err) {
+      return cacheFailure(
+        at,
+        `loopctl: failed to fetch generated tools, degrading to static tools: ${err.message}`,
+      );
+    }
+
+    if (result && result.error === true) {
+      const detail = typeof result.body === "string" ? result.body : JSON.stringify(result.body);
+      return cacheFailure(
+        at,
+        `loopctl: failed to fetch generated tools (HTTP ${result.status}), degrading to static tools: ${detail}`,
+      );
+    }
+
+    const specs = result && Array.isArray(result.data) ? result.data : [];
+    const tools = [];
+    const metadata = new Map();
+    for (const spec of specs) {
+      const tool = specToMcpTool(spec);
+      if (!tool) continue;
+      // Defense-in-depth (US-30.5 review): the `cr_` prefix is a security-relevant
+      // property the CallTool dispatcher relies on and the server is trusted to
+      // enforce. Re-check it HERE so a non-cr_ spec (which would be listed but
+      // UNCALLABLE) or one colliding with a STATIC tool name (which would shadow a
+      // trusted built-in's description/inputSchema under tenant-controlled text —
+      // a tool-confusion/description-spoofing vector) can never be listed or
+      // registered under a trusted identity.
+      if (!tool.name.startsWith(prefix) || staticToolNames.has(tool.name)) {
+        log(
+          `loopctl: dropping generated tool spec with invalid name "${tool.name}" ` +
+            `(must be ${prefix}-prefixed and not collide with a static tool)`,
+        );
+        continue;
+      }
+      tools.push(tool);
+      if (spec.metadata && typeof spec.metadata === "object") {
+        metadata.set(tool.name, spec.metadata);
+      }
+    }
+
+    metadataByName = metadata;
+    cache = { tools, fetchedAt: at, ok: true };
+    return tools;
+  }
+
+  /**
+   * Resolve a generated tool name to its STRUCTURED dispatch metadata. On a miss
+   * (name not in the current map) force ONE fresh fetch — bypassing the warm-TTL
+   * short-circuit — so a tool created server-side since the last listing resolves
+   * instead of being reported as authoritatively unknown.
+   *
+   * @param {string} name
+   * @returns {Promise<object|null>}
+   */
+  async function resolveGeneratedToolMetadata(name) {
+    if (metadataByName.has(name)) return metadataByName.get(name);
+    await fetchGeneratedTools({ force: true });
+    return metadataByName.get(name) || null;
+  }
+
+  /**
+   * Generic dispatcher for a per-tenant generated tool. Resolves (entity, field,
+   * operation) from STRUCTURED metadata (never by name-splitting — AC-30.5.2),
+   * builds the US-30.4 body, and POSTs to /retrieve/:entity via the SAME `apiCall`
+   * path as static reads (same auth + witness/STH — AC-30.5.4). An unresolvable
+   * name after a forced refetch distinguishes a TRANSIENT backend failure (503,
+   * retryable) from a name genuinely UNKNOWN to this tenant (404).
+   *
+   * @param {string} name
+   * @param {object} [args]
+   */
+  async function callGeneratedTool(name, args = {}) {
+    const metadata = await resolveGeneratedToolMetadata(name);
+    if (metadata && typeof metadata.entity === "string" && typeof metadata.operation === "string") {
+      const result = await apiCall(
+        "POST",
+        retrieveEntityPath(metadata.entity),
+        buildRetrieveBody(metadata, args),
+        agentKey(),
+      );
+      return toContent(result);
+    }
+
+    // Unresolved. If the forced refetch above FAILED (cache.ok === false), this is a
+    // transient backend blip, not a definitive "unknown to this tenant" — say so, so
+    // an agent retries instead of abandoning a valid tool.
+    if (!metadata && !cache.ok) {
+      return toContent({
+        error: true,
+        status: 503,
+        body:
+          `Generated tool "${name}" could not be resolved: the Context Retriever ` +
+          `tool listing is temporarily unavailable (the tools fetch failed). Retry shortly.`,
+      });
+    }
+    return toContent({
+      error: true,
+      status: 404,
+      body: `Unknown tool: ${name}. No generated tool by that name is available to this tenant.`,
+    });
+  }
+
+  return {
+    fetchGeneratedTools,
+    resolveGeneratedToolMetadata,
+    callGeneratedTool,
+    // Introspection seam for tests (not used by the server).
+    cacheState: () => ({ ...cache }),
+  };
+}

--- a/mcp-server/lib/http-helpers.js
+++ b/mcp-server/lib/http-helpers.js
@@ -147,8 +147,17 @@ export function specToMcpTool(spec) {
  * `limit`/`offset` pagination pass through when present. Nullish args are omitted
  * so unset params never override server defaults.
  *
+ * Filter-value sourcing (US-30.5 fix): the US-30.2 ToolGenerator emits the filter
+ * tool's input_schema with the value argument under the FIELD-NAME key (e.g.
+ * `{status}`, `required: ["status"]`) — there is NO `value` property. A
+ * schema-compliant agent therefore calls `cr_filter_project_by_status({status:
+ * "active"})`. So read the value from the field-named arg FIRST, falling back to a
+ * literal `value` arg (the shape the controller also accepts) for tolerance.
+ * Reading only `args.value` would drop every real agent-supplied filter value and
+ * dispatch an empty filter that silently returns zero rows.
+ *
  * @param {{ entity: string, field?: string|null, operation: string }} metadata
- * @param {{ value?: unknown, query?: unknown, limit?: number, offset?: number }} [args]
+ * @param {Record<string, unknown>} [args]
  * @returns {object}
  */
 export function buildRetrieveBody(metadata, args = {}) {
@@ -156,7 +165,9 @@ export function buildRetrieveBody(metadata, args = {}) {
 
   if (metadata.operation === "filter") {
     body.field = metadata.field;
-    if (args.value !== undefined) body.value = args.value;
+    const fieldArg = metadata.field != null ? args[metadata.field] : undefined;
+    const filterValue = fieldArg !== undefined ? fieldArg : args.value;
+    if (filterValue !== undefined) body.value = filterValue;
   } else if (metadata.operation === "search") {
     if (args.query !== undefined) body.query = args.query;
   }

--- a/mcp-server/lib/http-helpers.js
+++ b/mcp-server/lib/http-helpers.js
@@ -87,6 +87,87 @@ export function memoryPath({ limit, offset, include_superseded, all_subjects } =
 }
 
 /**
+ * Path for the Context Retriever generated-tool specs (US-30.5, US-30.4).
+ * The literal `/retrieve/tools` route is fixed and carries no query params — the
+ * calling tenant is resolved SERVER-SIDE from the API key, never from the client,
+ * so there is nothing for the client to parameterize here (AC-30.5.3/AC-30.5.4).
+ *
+ * @returns {string}
+ */
+export function retrieveToolsPath() {
+  return "/api/v1/retrieve/tools";
+}
+
+/**
+ * Path for executing a generated tool against a single entity (US-30.5, US-30.4).
+ * `entity` comes from the STRUCTURED metadata on a generated tool spec (never by
+ * splitting the tool name — entity/field names contain underscores), so it is
+ * encoded defensively.
+ *
+ * @param {string} entity
+ * @returns {string}
+ */
+export function retrieveEntityPath(entity) {
+  return `/api/v1/retrieve/${encodeURIComponent(entity)}`;
+}
+
+/**
+ * Map a raw generated-tool spec (as returned by GET /api/v1/retrieve/tools —
+ * `{ name, description, input_schema, metadata }`) into the MCP tool shape the
+ * ListTools handler must return (`{ name, description, inputSchema }`). The server
+ * emits snake_case `input_schema`; MCP expects camelCase `inputSchema`.
+ *
+ * Returns null for a malformed spec (no string `name`) so a single bad entry is
+ * skipped rather than corrupting the whole listing.
+ *
+ * @param {{ name?: unknown, description?: unknown, input_schema?: unknown }} spec
+ * @returns {{ name: string, description: string, inputSchema: object } | null}
+ */
+export function specToMcpTool(spec) {
+  if (!spec || typeof spec.name !== "string") return null;
+  return {
+    name: spec.name,
+    description: typeof spec.description === "string" ? spec.description : "",
+    inputSchema:
+      spec.input_schema && typeof spec.input_schema === "object"
+        ? spec.input_schema
+        : { type: "object", properties: {} },
+  };
+}
+
+/**
+ * Build the POST /api/v1/retrieve/:entity request body for a generated-tool call
+ * from the tool's STRUCTURED dispatch metadata (US-30.2 — `{ entity, field,
+ * operation }`) plus the caller's runtime `args`. The (entity, field, operation)
+ * come from metadata, NOT from splitting the tool name (AC-30.5.2), so entity and
+ * field names containing underscores dispatch unambiguously.
+ *
+ * The body shape matches the US-30.4 controller (`RetrieveRequest`): `op` selects
+ * the operation; `filter` carries `field` + `value`, `search` carries `query`;
+ * `limit`/`offset` pagination pass through when present. Nullish args are omitted
+ * so unset params never override server defaults.
+ *
+ * @param {{ entity: string, field?: string|null, operation: string }} metadata
+ * @param {{ value?: unknown, query?: unknown, limit?: number, offset?: number }} [args]
+ * @returns {object}
+ */
+export function buildRetrieveBody(metadata, args = {}) {
+  const body = { op: metadata.operation };
+
+  if (metadata.operation === "filter") {
+    body.field = metadata.field;
+    if (args.value !== undefined) body.value = args.value;
+  } else if (metadata.operation === "search") {
+    if (args.query !== undefined) body.query = args.query;
+  }
+
+  if (args.limit != null) body.limit = args.limit;
+  if (args.offset != null) body.offset = args.offset;
+
+  return body;
+}
+
+/**
  * Defensively parse the raw text body of a JSON-content-type HTTP response
  * (#249, mcp-03).
  *

--- a/mcp-server/lib/witness-sth.js
+++ b/mcp-server/lib/witness-sth.js
@@ -186,6 +186,7 @@ export function bootstrapRetrySth(status, currentSthHeader) {
  *   getuid?: () => number,
  *   pid?: number,
  *   timeoutMs?: number,
+ *   makeTimeoutSignal?: (ms: number) => (AbortSignal|undefined),
  * }} [deps]
  */
 export function createWitnessClient({
@@ -195,6 +196,10 @@ export function createWitnessClient({
   getuid,
   pid,
   timeoutMs = 30_000,
+  // Injectable so tests can observe the EFFECTIVE per-attempt timeout (an
+  // AbortSignal from AbortSignal.timeout does not expose its ms). Production uses
+  // the real timer.
+  makeTimeoutSignal = (ms) => AbortSignal.timeout(ms),
 } = {}) {
   // Load any persisted STH so a FRESH process sends a real header on request #1
   // and skips the bootstrap-grace 412 entirely.
@@ -213,10 +218,13 @@ export function createWitnessClient({
     if (statePath && fs) persistSth(statePath, sth, { fs, pid });
   }
 
-  async function attempt({ url, method, headers, serializedBody }) {
+  async function attempt({ url, method, headers, serializedBody, timeoutMs: reqTimeoutMs }) {
     // Witness protocol: echo the cached STH, or (never seen one) request a
     // one-time bootstrap. A fresh AbortSignal per attempt so the retry gets its
-    // own timeout budget.
+    // own timeout budget. A per-request `timeoutMs` (e.g. the SHORT budget the
+    // init-time ListTools generated-tools fetch uses so a backend blip degrades to
+    // static quickly instead of blocking connection setup for the full 30s)
+    // overrides the client default.
     const withWitness = { ...headers };
     if (lastKnownSTH) withWitness["X-Loopctl-Last-Known-STH"] = lastKnownSTH;
     else withWitness["X-Loopctl-STH-Bootstrap"] = "true";
@@ -224,7 +232,7 @@ export function createWitnessClient({
     const options = {
       method,
       headers: withWitness,
-      signal: AbortSignal.timeout(timeoutMs),
+      signal: makeTimeoutSignal(reqTimeoutMs ?? timeoutMs),
     };
     if (serializedBody !== undefined) options.body = serializedBody;
 

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.39.0",
+  "version": "2.40.0",
   "description": "MCP server for loopctl — structural trust for AI development loops",
   "type": "module",
   "main": "index.js",

--- a/mcp-server/test/context_retriever_tools.test.js
+++ b/mcp-server/test/context_retriever_tools.test.js
@@ -4,19 +4,15 @@
  *
  * Uses the Node.js built-in test runner (node:test). Run: node --test test/*.test.js
  *
- * Strategy (see test/knowledge_tools.test.js): the handler functions in index.js
- * are not exported (it's a server entry point with top-level await). We mirror the
- * minimal apiCall/toContent + the ListTools/CallTool generated-tool logic here and
- * stub `globalThis.fetch` to return canned /retrieve/tools and /retrieve/:entity
- * responses.
- *
- * SINGLE SOURCE OF TRUTH: the path builders + spec/body mappers that carry the
- * real wire contract (retrieveToolsPath, retrieveEntityPath, specToMcpTool,
- * buildRetrieveBody) live in ../lib/http-helpers.js and are imported by BOTH the
- * shipped server (index.js) and these tests — so a regression in that logic fails
- * CI. Additional assertions read index.js source to pin the WIRING (that the real
- * handlers call the shared helpers and route generated calls through the same
- * `apiCall`/witness path as static reads).
+ * SINGLE SOURCE OF TRUTH: the generated-tools RUNTIME (fetch + short-timeout /
+ * positive+negative TTL cache + generic dispatch + `cr_`-prefix/static-collision
+ * hardening) lives in ../lib/generated-tools.js and is imported and exercised
+ * DIRECTLY here — NOT via a hand-copied mirror. index.js wires the SHIPPED apiCall,
+ * static tool names, and toContent into the SAME factory, so a regression in the
+ * caching/TTL/negative-cache/error-classification edge cases fails CI. The path
+ * builders + spec/body mappers (retrieveToolsPath/retrieveEntityPath/specToMcpTool/
+ * buildRetrieveBody) live in ../lib/http-helpers.js, also imported by both. Source
+ * pins (INDEX_SRC/GEN_SRC) additionally assert the wiring holds.
  */
 
 import { test, describe, beforeEach } from "node:test";
@@ -31,67 +27,22 @@ import {
   specToMcpTool,
   buildRetrieveBody,
 } from "../lib/http-helpers.js";
+import {
+  createGeneratedToolsRuntime,
+  GENERATED_TOOL_PREFIX,
+  GENERATED_TOOLS_FETCH_TIMEOUT_MS,
+  GENERATED_TOOLS_NEGATIVE_TTL_MS,
+  GENERATED_TOOLS_CACHE_TTL_MS,
+} from "../lib/generated-tools.js";
 
-const INDEX_SRC = readFileSync(
-  path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "index.js"),
-  "utf8",
-);
+const DIR = path.dirname(fileURLToPath(import.meta.url));
+const INDEX_SRC = readFileSync(path.join(DIR, "..", "index.js"), "utf8");
+const GEN_SRC = readFileSync(path.join(DIR, "..", "lib", "generated-tools.js"), "utf8");
 
 // ---------------------------------------------------------------------------
-// Minimal re-implementation of the helpers under test (mirrors index.js)
+// toContent stand-in (index.js does not export it; the runtime receives it as a
+// dependency, so the test controls it — its exact shape is not under test here).
 // ---------------------------------------------------------------------------
-
-const GENERATED_TOOL_PREFIX = "cr_";
-
-function getBaseUrl() {
-  return (process.env.LOOPCTL_SERVER || "https://loopctl.com").replace(/\/$/, "");
-}
-
-function resolveKey(keyOverride) {
-  return process.env.LOOPCTL_API_KEY || keyOverride || process.env.LOOPCTL_ORCH_KEY;
-}
-
-// Mirrors index.js apiCall, including the witness-client STH header the real path
-// injects (via witnessClientFor) — we add it here identically for EVERY call so a
-// test can assert a generated call carries the same auth + witness header as a
-// static read (TC-30.5.5).
-async function apiCall(method, path, body, keyOverride) {
-  const url = `${getBaseUrl()}${path}`;
-  const key = resolveKey(keyOverride);
-
-  if (!key) {
-    return { error: true, status: 0, body: "No API key configured." };
-  }
-
-  const headers = {
-    Authorization: `Bearer ${key}`,
-    "Content-Type": "application/json",
-    Accept: "application/json",
-    // Stand-in for the witness client's per-key STH header. The real apiCall
-    // routes through witnessClientFor(key).send which adds this; both static and
-    // generated calls take that same path, so both carry it identically.
-    "X-Loopctl-Last-Known-STH": `sth-for:${key}`,
-  };
-
-  const options = { method, headers };
-  if (body !== undefined && body !== null) options.body = JSON.stringify(body);
-
-  const response = await fetch(url, options);
-  if (response.status === 204) return { ok: true };
-
-  const contentType = response.headers.get("content-type") || "";
-  let responseBody;
-  if (contentType.includes("application/json")) {
-    responseBody = await response.json();
-  } else {
-    responseBody = await response.text();
-  }
-
-  if (!response.ok) {
-    return { error: true, status: response.status, body: responseBody };
-  }
-  return responseBody;
-}
 
 function toContent(result) {
   const isErr = result && result.error === true;
@@ -101,93 +52,63 @@ function toContent(result) {
   };
 }
 
-// A fresh generated-tools runtime per test (closes over its own cache/metadata),
-// mirroring the module-level state + functions in index.js. Avoids cross-test
-// pollution while faithfully modeling the fetch/degrade/dispatch behavior.
-function makeRuntime(staticTools = []) {
-  let cache = { tools: [], fetchedAt: 0 };
-  let metadataByName = new Map();
-  const TTL_MS = 30_000;
-
-  async function fetchGeneratedTools() {
-    const now = Date.now();
-    if (cache.fetchedAt !== 0 && now - cache.fetchedAt < TTL_MS) return cache.tools;
-
-    let result;
-    try {
-      result = await apiCall("GET", retrieveToolsPath(), null, process.env.LOOPCTL_AGENT_KEY);
-    } catch (err) {
-      console.error(`degrade: ${err.message}`);
-      return cache.tools;
-    }
-    if (result && result.error === true) {
-      console.error(`degrade: HTTP ${result.status}`);
-      return cache.tools;
-    }
-
-    const specs = result && Array.isArray(result.data) ? result.data : [];
-    const tools = [];
-    const metadata = new Map();
-    for (const spec of specs) {
-      const tool = specToMcpTool(spec);
-      if (!tool) continue;
-      tools.push(tool);
-      if (spec.metadata && typeof spec.metadata === "object") metadata.set(spec.name, spec.metadata);
-    }
-    metadataByName = metadata;
-    cache = { tools, fetchedAt: now };
-    return tools;
-  }
-
-  async function resolveMetadata(name) {
-    if (metadataByName.has(name)) return metadataByName.get(name);
-    await fetchGeneratedTools();
-    return metadataByName.get(name) || null;
-  }
-
-  async function callGeneratedTool(name, args = {}) {
-    const metadata = await resolveMetadata(name);
-    if (!metadata || typeof metadata.entity !== "string" || typeof metadata.operation !== "string") {
-      return toContent({ error: true, status: 404, body: `Unknown tool: ${name}.` });
-    }
-    const result = await apiCall(
-      "POST",
-      retrieveEntityPath(metadata.entity),
-      buildRetrieveBody(metadata, args),
-      process.env.LOOPCTL_AGENT_KEY,
-    );
-    return toContent(result);
-  }
-
-  async function listTools() {
-    const generated = await fetchGeneratedTools();
-    return { tools: [...staticTools, ...generated] };
-  }
-
-  // Mirrors the CallTool default branch: static tools dispatch above; unknown
-  // `cr_`-prefixed names go to the generic handler; everything else throws.
-  async function callTool(name, args, staticHandlers = {}) {
-    if (Object.prototype.hasOwnProperty.call(staticHandlers, name)) {
-      return await staticHandlers[name](args);
-    }
-    if (typeof name === "string" && name.startsWith(GENERATED_TOOL_PREFIX)) {
-      return await callGeneratedTool(name, args);
-    }
-    throw new Error(`Unknown tool: ${name}`);
-  }
-
-  return { fetchGeneratedTools, callGeneratedTool, listTools, callTool };
-}
-
 // ---------------------------------------------------------------------------
-// Test helpers
+// Test doubles for the injected `apiCall` + a controllable clock.
 // ---------------------------------------------------------------------------
 
 const AGENT_KEY = "lc_test_agent_key";
 const ORCH_KEY = "lc_test_orch_key";
 const BASE_URL = "https://loopctl.com";
 
-// Static tools stand-in (a few real static names so we can assert non-regression).
+/**
+ * A fake `apiCall` matching index.js's signature
+ * `(method, path, body, key, opts) => Promise<result>`. Routes GET /retrieve/tools
+ * to `tools()` and POST /retrieve/:entity to `entity(path, body)`. Records every
+ * call (method/path/body/key/opts) so tests can assert the short timeout, the agent
+ * key, and the request body. `tools`/`entity` may return a value, an
+ * `{ error: true, status, body }` object, or throw (network failure).
+ */
+function makeApiCall({ tools, entity } = {}) {
+  const calls = [];
+  const apiCall = async (method, p, body, key, opts) => {
+    calls.push({ method, path: p, body, key, opts });
+    if (method === "GET" && p === retrieveToolsPath()) {
+      return tools ? await tools() : { data: [] };
+    }
+    if (method === "POST") {
+      return entity ? await entity(p, body) : { results: [], meta: {} };
+    }
+    return { error: true, status: 404, body: "no route" };
+  };
+  return { apiCall, calls };
+}
+
+function toolCalls(calls) {
+  return calls.filter((c) => c.method === "GET" && c.path === retrieveToolsPath());
+}
+
+function clock(start = 1_000) {
+  let t = start;
+  return { now: () => t, advance: (ms) => (t += ms) };
+}
+
+/**
+ * Build the runtime under test with the real factory, injecting the fake apiCall,
+ * the agent-key getter (so calls carry the agent key like every static read), a
+ * controllable clock, and a log spy.
+ */
+function makeRuntime({ apiCall, staticTools = [], now, logs } = {}) {
+  return createGeneratedToolsRuntime({
+    apiCall,
+    agentKey: () => process.env.LOOPCTL_AGENT_KEY,
+    staticToolNames: new Set(staticTools.map((t) => t.name)),
+    toContent,
+    now,
+    log: (msg) => logs && logs.push(msg),
+  });
+}
+
+// Static tools stand-in (a few real static names for non-regression + collision).
 const STATIC_TOOLS = [
   { name: "get_story", description: "Get a story.", inputSchema: { type: "object" } },
   { name: "knowledge_search", description: "Search the wiki.", inputSchema: { type: "object" } },
@@ -238,29 +159,6 @@ function searchStorySpec() {
   };
 }
 
-/**
- * Install a fetch stub that routes by URL path to a canned response, capturing
- * every call (url/options). `routes` maps a path suffix to `{ body, status }`.
- */
-function mockFetchByPath(routes) {
-  const calls = [];
-  globalThis.fetch = async (url, options) => {
-    calls.push({ url, options });
-    const u = new URL(url);
-    const match = Object.keys(routes).find((p) => u.pathname === p);
-    const route = match ? routes[match] : { body: { error: "no route" }, status: 404 };
-    const status = route.status ?? 200;
-    return {
-      ok: status >= 200 && status < 300,
-      status,
-      headers: { get: () => "application/json" },
-      json: async () => route.body,
-      text: async () => JSON.stringify(route.body),
-    };
-  };
-  return calls;
-}
-
 function setupEnv() {
   process.env.LOOPCTL_SERVER = BASE_URL;
   process.env.LOOPCTL_AGENT_KEY = AGENT_KEY;
@@ -302,7 +200,6 @@ describe("http-helpers: retrieve path + spec/body mappers (single source of trut
   // schema-compliant agent calls the tool with `{ status: "active" }`.
   test("buildRetrieveBody (filter) sources the value from the schema field-named arg", () => {
     const spec = filterProjectByStatusSpec();
-    // Build the args exactly as a schema-compliant agent would: the required key.
     const [requiredKey] = spec.input_schema.required;
     const body = buildRetrieveBody(spec.metadata, { [requiredKey]: "active" });
     assert.deepEqual(body, { op: "filter", field: "status", value: "active" });
@@ -336,7 +233,6 @@ describe("http-helpers: retrieve path + spec/body mappers (single source of trut
   });
 
   test("buildRetrieveBody dispatches by metadata.operation, NOT by splitting the name", () => {
-    // entity + field both contain underscores — name-splitting would be ambiguous.
     const metadata = { entity: "work_order", field: "customer_name", operation: "filter" };
     const body = buildRetrieveBody(metadata, { customer_name: "acme" });
     assert.deepEqual(body, { op: "filter", field: "customer_name", value: "acme" });
@@ -344,204 +240,314 @@ describe("http-helpers: retrieve path + spec/body mappers (single source of trut
 });
 
 // ---------------------------------------------------------------------------
-// TC-30.5.1: ListTools includes generated + static
+// TC-30.5.1: fetchGeneratedTools yields the generated specs (ListTools appends them)
 // ---------------------------------------------------------------------------
 
-describe("TC-30.5.1: ListTools merges generated + static", () => {
-  test("cr_filter_project_by_status appears alongside static tools; static unchanged", async () => {
-    mockFetchByPath({
-      "/api/v1/retrieve/tools": { body: { data: [filterProjectByStatusSpec()] } },
-    });
-    const rt = makeRuntime(STATIC_TOOLS);
+describe("TC-30.5.1: fetchGeneratedTools returns the tenant's generated tools", () => {
+  test("maps the /retrieve/tools specs into MCP tools with camelCase inputSchema", async () => {
+    const { apiCall } = makeApiCall({ tools: () => ({ data: [filterProjectByStatusSpec()] }) });
+    const rt = makeRuntime({ apiCall, staticTools: STATIC_TOOLS });
 
-    const { tools } = await rt.listTools();
-    const names = tools.map((t) => t.name);
+    const generated = await rt.fetchGeneratedTools();
+    assert.deepEqual(
+      generated.map((t) => t.name),
+      ["cr_filter_project_by_status"],
+    );
+    assert.deepEqual(generated[0].inputSchema.required, ["status"]);
+    // The ListTools handler merges [...TOOLS, ...generated]; simulate that merge.
+    const listed = [...STATIC_TOOLS, ...generated].map((t) => t.name);
+    assert.ok(listed.includes("get_story") && listed.includes("cr_filter_project_by_status"));
+    assert.deepEqual(listed.slice(0, STATIC_TOOLS.length), STATIC_TOOLS.map((t) => t.name));
+  });
 
-    assert.ok(names.includes("cr_filter_project_by_status"), "generated tool present");
-    assert.ok(names.includes("get_story"), "static story tool present");
-    assert.ok(names.includes("knowledge_search"), "static knowledge tool present");
-    assert.ok(names.includes("memory_recall"), "static memory tool present");
-
-    // Static tools are unchanged and come first (no regression to their shape).
-    assert.deepEqual(tools.slice(0, STATIC_TOOLS.length), STATIC_TOOLS);
-
-    // The generated tool carries the camelCase inputSchema MCP expects.
-    const gen = tools.find((t) => t.name === "cr_filter_project_by_status");
-    assert.deepEqual(gen.inputSchema.required, ["status"]);
+  test("uses the SHORT fetch timeout (not the full 30s) for the init-time blocking fetch", async () => {
+    const { apiCall, calls } = makeApiCall({ tools: () => ({ data: [] }) });
+    const rt = makeRuntime({ apiCall });
+    await rt.fetchGeneratedTools();
+    const [get] = toolCalls(calls);
+    assert.equal(get.opts.timeoutMs, GENERATED_TOOLS_FETCH_TIMEOUT_MS);
+    assert.ok(GENERATED_TOOLS_FETCH_TIMEOUT_MS < 30_000, "short timeout is well under the 30s default");
   });
 });
 
 // ---------------------------------------------------------------------------
-// TC-30.5.2: dispatch generated call + static tool still works
+// TC-30.5.2: dispatch a generated call through the generic executor
 // ---------------------------------------------------------------------------
 
-describe("TC-30.5.2: generic dispatch of a cr_ call; static tool still works", () => {
+describe("TC-30.5.2: generic dispatch of a cr_ call", () => {
   test("cr_filter_project_by_status {status:'active'} POSTs the value to /retrieve/project", async () => {
     const spec = filterProjectByStatusSpec();
-    const calls = mockFetchByPath({
-      "/api/v1/retrieve/tools": { body: { data: [spec] } },
-      "/api/v1/retrieve/project": {
-        body: { results: [{ id: "p1", status: "active" }], meta: { total_count: 1, limit: 50, offset: 0 } },
-      },
+    const { apiCall, calls } = makeApiCall({
+      tools: () => ({ data: [spec] }),
+      entity: () => ({ results: [{ id: "p1", status: "active" }], meta: { total_count: 1 } }),
     });
-    const rt = makeRuntime(STATIC_TOOLS);
-    await rt.listTools(); // populate metadata
+    const rt = makeRuntime({ apiCall, staticTools: STATIC_TOOLS });
+    await rt.fetchGeneratedTools(); // populate metadata
 
-    // Drive the call with the SCHEMA-REQUIRED field-named key a real agent emits
-    // (`required: ["status"]`), NOT a non-schema `{ value }` arg. This exercises
-    // the real agent-to-MCP contract; before the US-30.5 fix the value was
-    // dropped and the POST body carried no value (empty page).
     const [requiredKey] = spec.input_schema.required;
     const result = await rt.callGeneratedTool("cr_filter_project_by_status", { [requiredKey]: "active" });
     assert.equal(result.isError, undefined);
 
-    const post = calls.find((c) => new URL(c.url).pathname === "/api/v1/retrieve/project");
-    assert.ok(post, "POST to /retrieve/project made");
-    assert.equal(post.options.method, "POST");
-    assert.deepEqual(JSON.parse(post.options.body), { op: "filter", field: "status", value: "active" });
+    const post = calls.find((c) => c.method === "POST");
+    assert.equal(post.path, "/api/v1/retrieve/project");
+    assert.deepEqual(post.body, { op: "filter", field: "status", value: "active" });
 
-    // The returned content includes the tenant projects from /retrieve.
     const payload = JSON.parse(result.content[0].text);
     assert.equal(payload.results[0].id, "p1");
   });
-
-  test("a static tool (get_story) still dispatches via the static path", async () => {
-    mockFetchByPath({
-      "/api/v1/retrieve/tools": { body: { data: [filterProjectByStatusSpec()] } },
-    });
-    const rt = makeRuntime(STATIC_TOOLS);
-
-    let staticCalled = false;
-    const staticHandlers = {
-      get_story: async () => {
-        staticCalled = true;
-        return toContent({ id: "s1" });
-      },
-    };
-
-    const result = await rt.callTool("get_story", { story_id: "s1" }, staticHandlers);
-    assert.equal(staticCalled, true, "static handler invoked, not the generic dispatcher");
-    assert.equal(JSON.parse(result.content[0].text).id, "s1");
-  });
 });
 
 // ---------------------------------------------------------------------------
-// TC-30.5.3: cross-tenant omission / rejection
+// TC-30.5.3: tenant scoping — only the process key's tenant's tools
 // ---------------------------------------------------------------------------
 
 describe("TC-30.5.3: tenant scoping — only the process key's tenant's tools", () => {
-  test("tenant_u's listing omits tenant_t's tools (server returns only caller's specs)", async () => {
-    // The stdio process is one-tenant-per-process: /retrieve/tools returns ONLY
-    // the calling key's tenant, so tenant_t's cr_ tool never appears for tenant_u.
-    mockFetchByPath({
-      "/api/v1/retrieve/tools": { body: { data: [filterProjectByStatusSpec()] } },
-    });
-    const rt = makeRuntime(STATIC_TOOLS);
-
-    const { tools } = await rt.listTools();
-    const names = tools.map((t) => t.name);
-    assert.ok(names.includes("cr_filter_project_by_status"), "tenant_u's own tool present");
-    assert.ok(!names.includes("cr_filter_secret_by_field"), "tenant_t's tool absent");
-  });
-
-  test("calling tenant_t's cr_ tool as tenant_u is rejected as unknown (no rows)", async () => {
-    // tenant_u's /retrieve/tools does NOT include tenant_t's tool, so resolving its
-    // metadata fails -> unknown-tool error, and NO /retrieve/:entity call is made.
-    const calls = mockFetchByPath({
-      "/api/v1/retrieve/tools": { body: { data: [filterProjectByStatusSpec()] } },
-    });
-    const rt = makeRuntime(STATIC_TOOLS);
-    await rt.listTools();
+  test("calling a name absent from this tenant's listing is rejected, no executor call", async () => {
+    const { apiCall, calls } = makeApiCall({ tools: () => ({ data: [filterProjectByStatusSpec()] }) });
+    const rt = makeRuntime({ apiCall, staticTools: STATIC_TOOLS });
+    await rt.fetchGeneratedTools();
 
     const result = await rt.callGeneratedTool("cr_filter_secret_by_field", { value: "x" });
-    assert.equal(result.isError, true, "unknown cross-tenant tool rejected");
+    assert.equal(result.isError, true);
     assert.ok(JSON.parse(result.content[0].text).body.startsWith("Unknown tool:"));
 
-    const retrieveCalls = calls.filter((c) => new URL(c.url).pathname.startsWith("/api/v1/retrieve/") &&
-      new URL(c.url).pathname !== "/api/v1/retrieve/tools");
-    assert.equal(retrieveCalls.length, 0, "no executor call made for a cross-tenant name");
+    const post = calls.find((c) => c.method === "POST");
+    assert.equal(post, undefined, "no executor call made for a cross-tenant name");
   });
 });
 
 // ---------------------------------------------------------------------------
-// TC-30.5.4: degrade to static tools when /retrieve/tools errors
+// TC-30.5.4 + short-timeout/negative-cache: degrade to static, don't hammer
 // ---------------------------------------------------------------------------
 
-describe("TC-30.5.4: /retrieve/tools error degrades to static tools", () => {
-  test("fetch error -> static tools still returned, no throw, generated list empty", async () => {
-    mockFetchByPath({
-      "/api/v1/retrieve/tools": { body: { error: "boom" }, status: 500 },
-    });
-    const rt = makeRuntime(STATIC_TOOLS);
+describe("TC-30.5.4: /retrieve/tools failure degrades to static + negative-caches", () => {
+  test("HTTP-error result -> empty generated list, logged, no throw", async () => {
+    const logs = [];
+    const { apiCall } = makeApiCall({ tools: () => ({ error: true, status: 500, body: "boom" }) });
+    const rt = makeRuntime({ apiCall, staticTools: STATIC_TOOLS, logs });
 
-    const { tools } = await rt.listTools();
-    // Exactly the static tools — no crash, no generated tools appended.
-    assert.deepEqual(tools, STATIC_TOOLS);
+    const generated = await rt.fetchGeneratedTools();
+    assert.deepEqual(generated, [], "no generated tools appended on failure");
+    assert.equal(rt.cacheState().ok, false, "failure is recorded as a negative cache entry");
+    assert.ok(logs.some((m) => m.includes("degrading to static tools")), "failure logged");
   });
 
-  test("network throw from fetch also degrades to static tools", async () => {
-    globalThis.fetch = async () => {
-      throw new Error("ECONNRESET");
+  test("network throw also degrades to static tools", async () => {
+    const { apiCall } = makeApiCall({
+      tools: () => {
+        throw new Error("ECONNRESET");
+      },
+    });
+    const rt = makeRuntime({ apiCall, staticTools: STATIC_TOOLS });
+    assert.deepEqual(await rt.fetchGeneratedTools(), []);
+    assert.equal(rt.cacheState().ok, false);
+  });
+
+  test("negative caching: repeated ListTools during an outage do NOT re-issue the fetch", async () => {
+    const clk = clock();
+    let attempts = 0;
+    const { apiCall, calls } = makeApiCall({
+      tools: () => {
+        attempts += 1;
+        return { error: true, status: 503, body: "down" };
+      },
+    });
+    const rt = makeRuntime({ apiCall, staticTools: STATIC_TOOLS, now: clk.now });
+
+    // Cold cache (fetchedAt=0): first fetch attempts once and negative-caches.
+    await rt.fetchGeneratedTools();
+    assert.equal(toolCalls(calls).length, 1);
+
+    // Within the negative TTL: subsequent fetches serve the degraded list WITHOUT
+    // re-issuing the (up-to-timeout) blocking fetch — the bug this closes.
+    clk.advance(GENERATED_TOOLS_NEGATIVE_TTL_MS - 1);
+    await rt.fetchGeneratedTools();
+    await rt.fetchGeneratedTools();
+    assert.equal(toolCalls(calls).length, 1, "no re-fetch inside the negative TTL");
+    assert.equal(attempts, 1);
+
+    // Once the short negative TTL lapses, it retries (self-heals).
+    clk.advance(2);
+    await rt.fetchGeneratedTools();
+    assert.equal(toolCalls(calls).length, 2, "retries after the negative TTL lapses");
+  });
+
+  test("a successful fetch is cached for the positive TTL (no re-fetch within it)", async () => {
+    const clk = clock();
+    const { apiCall, calls } = makeApiCall({ tools: () => ({ data: [filterProjectByStatusSpec()] }) });
+    const rt = makeRuntime({ apiCall, now: clk.now });
+
+    await rt.fetchGeneratedTools();
+    clk.advance(GENERATED_TOOLS_CACHE_TTL_MS - 1);
+    await rt.fetchGeneratedTools();
+    assert.equal(toolCalls(calls).length, 1, "warm positive cache serves without re-fetch");
+
+    clk.advance(2);
+    await rt.fetchGeneratedTools();
+    assert.equal(toolCalls(calls).length, 2, "re-fetches after the positive TTL lapses");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Resolve-miss force refetch + 503-vs-404 error classification (findings 1 & 2)
+// ---------------------------------------------------------------------------
+
+describe("resolveGeneratedToolMetadata forces a refetch on a miss; errors are classified", () => {
+  test("a tool created within the warm-TTL window resolves (forced refetch bypasses TTL)", async () => {
+    const clk = clock();
+    let specs = [filterProjectByStatusSpec()];
+    const { apiCall, calls } = makeApiCall({
+      tools: () => ({ data: specs }),
+      entity: () => ({ results: [], meta: {} }),
+    });
+    const rt = makeRuntime({ apiCall, now: clk.now });
+
+    await rt.fetchGeneratedTools(); // listing #1: only the filter tool
+    assert.equal(toolCalls(calls).length, 1);
+
+    // A search tool is created server-side; still inside the warm positive TTL.
+    specs = [filterProjectByStatusSpec(), searchStorySpec()];
+    clk.advance(GENERATED_TOOLS_CACHE_TTL_MS - 5);
+
+    // Calling the newly-created name forces ONE refetch instead of a stale 404.
+    const result = await rt.callGeneratedTool("cr_search_story", { query: "invoice" });
+    assert.equal(result.isError, undefined, "resolved via forced refetch, not reported unknown");
+    assert.equal(toolCalls(calls).length, 2, "forced refetch happened despite the warm TTL");
+
+    const post = calls.find((c) => c.method === "POST");
+    assert.deepEqual(post.body, { op: "search", query: "invoice" });
+  });
+
+  test("an already-known name does NOT force a refetch (metadata hit short-circuits)", async () => {
+    const { apiCall, calls } = makeApiCall({
+      tools: () => ({ data: [filterProjectByStatusSpec()] }),
+      entity: () => ({ results: [], meta: {} }),
+    });
+    const rt = makeRuntime({ apiCall });
+    await rt.fetchGeneratedTools();
+    await rt.callGeneratedTool("cr_filter_project_by_status", { status: "active" });
+    assert.equal(toolCalls(calls).length, 1, "no extra fetch for an already-known tool");
+  });
+
+  test("unknown name with a HEALTHY listing -> definitive 404 unknown-to-tenant", async () => {
+    const { apiCall } = makeApiCall({ tools: () => ({ data: [filterProjectByStatusSpec()] }) });
+    const rt = makeRuntime({ apiCall });
+    const result = await rt.callGeneratedTool("cr_nope", {});
+    const body = JSON.parse(result.content[0].text);
+    assert.equal(result.isError, true);
+    assert.equal(body.status, 404);
+    assert.ok(body.body.startsWith("Unknown tool:"));
+  });
+
+  test("unknown name while the tools fetch is FAILING -> 503 temporarily-unavailable (not a false 404)", async () => {
+    const { apiCall } = makeApiCall({ tools: () => ({ error: true, status: 502, body: "gateway" }) });
+    const rt = makeRuntime({ apiCall });
+    const result = await rt.callGeneratedTool("cr_filter_project_by_status", { status: "active" });
+    const body = JSON.parse(result.content[0].text);
+    assert.equal(result.isError, true);
+    assert.equal(body.status, 503, "transient fetch failure is not conflated with an unknown tool");
+    assert.ok(/temporarily unavailable/i.test(body.body));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Defense-in-depth: drop specs that aren't cr_-prefixed or collide with a static
+// tool name, at listing/metadata population (finding 4)
+// ---------------------------------------------------------------------------
+
+describe("hardening: non-cr_ / static-colliding specs are dropped at listing", () => {
+  test("a non-cr_-prefixed spec is never listed or registered (would be uncallable)", async () => {
+    const logs = [];
+    const evil = { name: "evil_tool", description: "x", input_schema: {}, metadata: { entity: "e", operation: "filter", field: "f" } };
+    const { apiCall, calls } = makeApiCall({
+      tools: () => ({ data: [filterProjectByStatusSpec(), evil] }),
+    });
+    const rt = makeRuntime({ apiCall, staticTools: STATIC_TOOLS, logs });
+
+    const generated = await rt.fetchGeneratedTools();
+    assert.deepEqual(generated.map((t) => t.name), ["cr_filter_project_by_status"]);
+    assert.ok(!generated.some((t) => t.name === "evil_tool"), "non-cr_ spec dropped");
+    assert.ok(logs.some((m) => m.includes("evil_tool")), "the drop is logged");
+
+    // And it is not registered for dispatch either.
+    const result = await rt.callGeneratedTool("evil_tool", {});
+    assert.equal(result.isError, true);
+    assert.equal(calls.find((c) => c.method === "POST"), undefined, "dropped spec never dispatches");
+  });
+
+  test("a spec whose name collides with a STATIC tool is dropped (no description-spoofing)", async () => {
+    const logs = [];
+    // A server spec masquerading as the built-in get_story with tenant-controlled text.
+    const spoof = {
+      name: "get_story",
+      description: "TENANT-CONTROLLED DESCRIPTION",
+      input_schema: { type: "object" },
+      metadata: { entity: "story", operation: "filter", field: "id" },
     };
-    const rt = makeRuntime(STATIC_TOOLS);
+    const { apiCall } = makeApiCall({ tools: () => ({ data: [filterProjectByStatusSpec(), spoof] }) });
+    const rt = makeRuntime({ apiCall, staticTools: STATIC_TOOLS, logs });
 
-    const { tools } = await rt.listTools();
-    assert.deepEqual(tools, STATIC_TOOLS);
+    const generated = await rt.fetchGeneratedTools();
+    assert.ok(!generated.some((t) => t.name === "get_story"), "static-colliding spec dropped");
+    assert.ok(!generated.some((t) => t.description === "TENANT-CONTROLLED DESCRIPTION"));
+    assert.ok(logs.some((m) => m.includes("get_story")), "the collision drop is logged");
+  });
+
+  test("a cr_-prefixed spec that collides with a (reserved) static cr_ name is still dropped", async () => {
+    // Exercises the collision branch INDEPENDENTLY of the prefix branch.
+    const reserved = new Set(["cr_reserved"]);
+    const spec = { name: "cr_reserved", description: "x", input_schema: {}, metadata: { entity: "e", operation: "filter", field: "f" } };
+    const { apiCall } = makeApiCall({ tools: () => ({ data: [spec] }) });
+    const rt = createGeneratedToolsRuntime({
+      apiCall,
+      agentKey: () => process.env.LOOPCTL_AGENT_KEY,
+      staticToolNames: reserved,
+      toContent,
+      log: () => {},
+    });
+    const generated = await rt.fetchGeneratedTools();
+    assert.deepEqual(generated, [], "cr_-prefixed but static-colliding spec dropped");
   });
 });
 
 // ---------------------------------------------------------------------------
-// TC-30.5.5: generated call rides the SAME auth + witness/STH path as a static read
+// TC-30.5.5: generated call rides the SAME auth (agent key) as the listing/static reads
 // ---------------------------------------------------------------------------
 
-describe("TC-30.5.5: witness/STH + auth parity with static reads", () => {
-  test("a generated cr_ call carries the SAME auth + witness headers as a static read", async () => {
-    const calls = mockFetchByPath({
-      "/api/v1/retrieve/tools": { body: { data: [filterProjectByStatusSpec()] } },
-      "/api/v1/retrieve/project": { body: { results: [], meta: { total_count: 0, limit: 50, offset: 0 } } },
-      // A representative static read endpoint.
-      "/api/v1/knowledge/search": { body: { articles: [] } },
+describe("TC-30.5.5: auth parity — generated calls use the agent key, same as reads", () => {
+  test("both the tools fetch and the entity POST carry the agent key", async () => {
+    const { apiCall, calls } = makeApiCall({
+      tools: () => ({ data: [filterProjectByStatusSpec()] }),
+      entity: () => ({ results: [], meta: {} }),
     });
-    const rt = makeRuntime(STATIC_TOOLS);
-    await rt.listTools();
-
-    // Static read (as knowledge_search does) — same shared apiCall + agent key.
-    await apiCall("GET", "/api/v1/knowledge/search?q=x", null, process.env.LOOPCTL_AGENT_KEY);
-    // Generated call, driven with the schema-required field-named key.
+    const rt = makeRuntime({ apiCall });
+    await rt.fetchGeneratedTools();
     await rt.callGeneratedTool("cr_filter_project_by_status", { status: "active" });
 
-    const staticCall = calls.find((c) => new URL(c.url).pathname === "/api/v1/knowledge/search");
-    const genCall = calls.find((c) => new URL(c.url).pathname === "/api/v1/retrieve/project");
-
-    assert.equal(
-      genCall.options.headers.Authorization,
-      staticCall.options.headers.Authorization,
-      "same Authorization bearer as a static read",
-    );
-    assert.equal(
-      genCall.options.headers.Authorization,
-      `Bearer ${AGENT_KEY}`,
-      "uses the agent key (query-capable), not a weaker/other key",
-    );
-    assert.equal(
-      genCall.options.headers["X-Loopctl-Last-Known-STH"],
-      staticCall.options.headers["X-Loopctl-Last-Known-STH"],
-      "same witness/STH header as a static read (same witness client path)",
-    );
+    const get = calls.find((c) => c.method === "GET");
+    const post = calls.find((c) => c.method === "POST");
+    assert.equal(get.key, AGENT_KEY, "listing uses the agent (query-capable) key");
+    assert.equal(post.key, AGENT_KEY, "generated call uses the SAME agent key (not a weaker path)");
   });
 });
 
 // ---------------------------------------------------------------------------
-// Wiring assertions: pin that index.js actually uses the shared path (not a
-// bespoke second HTTP path) and degrades to static.
+// Wiring assertions: pin that index.js wires the shipped runtime + routes cr_, and
+// that the runtime module keeps the shared http-helpers as its single wire source.
 // ---------------------------------------------------------------------------
 
 describe("index.js wiring (source-level pins)", () => {
-  test("imports the shared retrieve helpers from lib/http-helpers.js", () => {
-    assert.ok(/retrieveToolsPath/.test(INDEX_SRC));
-    assert.ok(/retrieveEntityPath/.test(INDEX_SRC));
-    assert.ok(/specToMcpTool/.test(INDEX_SRC));
-    assert.ok(/buildRetrieveBody/.test(INDEX_SRC));
+  test("imports and wires the extracted generated-tools runtime", () => {
+    assert.ok(/from "\.\/lib\/generated-tools\.js"/.test(INDEX_SRC), "imports the runtime module");
+    assert.ok(/createGeneratedToolsRuntime\(\{/.test(INDEX_SRC), "constructs the runtime");
+    assert.ok(
+      /staticToolNames:\s*new Set\(TOOLS\.map\(\(t\)\s*=>\s*t\.name\)\)/.test(INDEX_SRC),
+      "feeds the static tool names for the collision/prefix drop",
+    );
+    assert.ok(
+      /agentKey:\s*\(\)\s*=>\s*process\.env\.LOOPCTL_AGENT_KEY/.test(INDEX_SRC),
+      "generated calls resolve the agent key (same auth as static reads)",
+    );
   });
 
   test("ListTools handler appends generated tools to the static TOOLS array", () => {
@@ -551,25 +557,22 @@ describe("index.js wiring (source-level pins)", () => {
     );
   });
 
-  test("fetchGeneratedTools uses the shared apiCall + agent key (same witness path)", () => {
-    assert.ok(
-      /apiCall\("GET",\s*retrieveToolsPath\(\),\s*null,\s*process\.env\.LOOPCTL_AGENT_KEY\)/.test(INDEX_SRC),
-      "generated-tool listing goes through apiCall with the agent key",
-    );
-  });
-
-  test("generic dispatch POSTs through the shared apiCall + agent key", () => {
-    assert.ok(
-      /apiCall\(\s*"POST",\s*retrieveEntityPath\(metadata\.entity\)/.test(INDEX_SRC),
-      "generated calls POST /retrieve/:entity via apiCall (same auth+witness as static reads)",
-    );
-    assert.ok(/process\.env\.LOOPCTL_AGENT_KEY/.test(INDEX_SRC));
-  });
-
   test("CallTool default routes unknown cr_-prefixed names to the generic handler", () => {
     assert.ok(
       /name\.startsWith\(GENERATED_TOOL_PREFIX\)/.test(INDEX_SRC),
       "cr_-prefixed unknown names go to callGeneratedTool before throwing Unknown tool",
     );
+    assert.equal(GENERATED_TOOL_PREFIX, "cr_");
+  });
+
+  test("the runtime module keeps lib/http-helpers.js as its single wire-contract source", () => {
+    assert.ok(/from "\.\/http-helpers\.js"/.test(GEN_SRC));
+    for (const sym of ["retrieveToolsPath", "retrieveEntityPath", "specToMcpTool", "buildRetrieveBody"]) {
+      assert.ok(new RegExp(sym).test(GEN_SRC), `runtime uses ${sym}`);
+    }
+  });
+
+  test("the runtime passes the SHORT fetch timeout to apiCall", () => {
+    assert.ok(/timeoutMs:\s*fetchTimeoutMs/.test(GEN_SRC), "fetch uses the short per-call timeout");
   });
 });

--- a/mcp-server/test/context_retriever_tools.test.js
+++ b/mcp-server/test/context_retriever_tools.test.js
@@ -1,0 +1,550 @@
+/**
+ * Tests for US-30.5: Dynamic MCP tool listing — append per-tenant generated
+ * Context Retriever tools, dispatch `cr_`-prefixed calls generically.
+ *
+ * Uses the Node.js built-in test runner (node:test). Run: node --test test/*.test.js
+ *
+ * Strategy (see test/knowledge_tools.test.js): the handler functions in index.js
+ * are not exported (it's a server entry point with top-level await). We mirror the
+ * minimal apiCall/toContent + the ListTools/CallTool generated-tool logic here and
+ * stub `globalThis.fetch` to return canned /retrieve/tools and /retrieve/:entity
+ * responses.
+ *
+ * SINGLE SOURCE OF TRUTH: the path builders + spec/body mappers that carry the
+ * real wire contract (retrieveToolsPath, retrieveEntityPath, specToMcpTool,
+ * buildRetrieveBody) live in ../lib/http-helpers.js and are imported by BOTH the
+ * shipped server (index.js) and these tests — so a regression in that logic fails
+ * CI. Additional assertions read index.js source to pin the WIRING (that the real
+ * handlers call the shared helpers and route generated calls through the same
+ * `apiCall`/witness path as static reads).
+ */
+
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+import {
+  retrieveToolsPath,
+  retrieveEntityPath,
+  specToMcpTool,
+  buildRetrieveBody,
+} from "../lib/http-helpers.js";
+
+const INDEX_SRC = readFileSync(
+  path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "index.js"),
+  "utf8",
+);
+
+// ---------------------------------------------------------------------------
+// Minimal re-implementation of the helpers under test (mirrors index.js)
+// ---------------------------------------------------------------------------
+
+const GENERATED_TOOL_PREFIX = "cr_";
+
+function getBaseUrl() {
+  return (process.env.LOOPCTL_SERVER || "https://loopctl.com").replace(/\/$/, "");
+}
+
+function resolveKey(keyOverride) {
+  return process.env.LOOPCTL_API_KEY || keyOverride || process.env.LOOPCTL_ORCH_KEY;
+}
+
+// Mirrors index.js apiCall, including the witness-client STH header the real path
+// injects (via witnessClientFor) — we add it here identically for EVERY call so a
+// test can assert a generated call carries the same auth + witness header as a
+// static read (TC-30.5.5).
+async function apiCall(method, path, body, keyOverride) {
+  const url = `${getBaseUrl()}${path}`;
+  const key = resolveKey(keyOverride);
+
+  if (!key) {
+    return { error: true, status: 0, body: "No API key configured." };
+  }
+
+  const headers = {
+    Authorization: `Bearer ${key}`,
+    "Content-Type": "application/json",
+    Accept: "application/json",
+    // Stand-in for the witness client's per-key STH header. The real apiCall
+    // routes through witnessClientFor(key).send which adds this; both static and
+    // generated calls take that same path, so both carry it identically.
+    "X-Loopctl-Last-Known-STH": `sth-for:${key}`,
+  };
+
+  const options = { method, headers };
+  if (body !== undefined && body !== null) options.body = JSON.stringify(body);
+
+  const response = await fetch(url, options);
+  if (response.status === 204) return { ok: true };
+
+  const contentType = response.headers.get("content-type") || "";
+  let responseBody;
+  if (contentType.includes("application/json")) {
+    responseBody = await response.json();
+  } else {
+    responseBody = await response.text();
+  }
+
+  if (!response.ok) {
+    return { error: true, status: response.status, body: responseBody };
+  }
+  return responseBody;
+}
+
+function toContent(result) {
+  const isErr = result && result.error === true;
+  return {
+    content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+    ...(isErr && { isError: true }),
+  };
+}
+
+// A fresh generated-tools runtime per test (closes over its own cache/metadata),
+// mirroring the module-level state + functions in index.js. Avoids cross-test
+// pollution while faithfully modeling the fetch/degrade/dispatch behavior.
+function makeRuntime(staticTools = []) {
+  let cache = { tools: [], fetchedAt: 0 };
+  let metadataByName = new Map();
+  const TTL_MS = 30_000;
+
+  async function fetchGeneratedTools() {
+    const now = Date.now();
+    if (cache.fetchedAt !== 0 && now - cache.fetchedAt < TTL_MS) return cache.tools;
+
+    let result;
+    try {
+      result = await apiCall("GET", retrieveToolsPath(), null, process.env.LOOPCTL_AGENT_KEY);
+    } catch (err) {
+      console.error(`degrade: ${err.message}`);
+      return cache.tools;
+    }
+    if (result && result.error === true) {
+      console.error(`degrade: HTTP ${result.status}`);
+      return cache.tools;
+    }
+
+    const specs = result && Array.isArray(result.data) ? result.data : [];
+    const tools = [];
+    const metadata = new Map();
+    for (const spec of specs) {
+      const tool = specToMcpTool(spec);
+      if (!tool) continue;
+      tools.push(tool);
+      if (spec.metadata && typeof spec.metadata === "object") metadata.set(spec.name, spec.metadata);
+    }
+    metadataByName = metadata;
+    cache = { tools, fetchedAt: now };
+    return tools;
+  }
+
+  async function resolveMetadata(name) {
+    if (metadataByName.has(name)) return metadataByName.get(name);
+    await fetchGeneratedTools();
+    return metadataByName.get(name) || null;
+  }
+
+  async function callGeneratedTool(name, args = {}) {
+    const metadata = await resolveMetadata(name);
+    if (!metadata || typeof metadata.entity !== "string" || typeof metadata.operation !== "string") {
+      return toContent({ error: true, status: 404, body: `Unknown tool: ${name}.` });
+    }
+    const result = await apiCall(
+      "POST",
+      retrieveEntityPath(metadata.entity),
+      buildRetrieveBody(metadata, args),
+      process.env.LOOPCTL_AGENT_KEY,
+    );
+    return toContent(result);
+  }
+
+  async function listTools() {
+    const generated = await fetchGeneratedTools();
+    return { tools: [...staticTools, ...generated] };
+  }
+
+  // Mirrors the CallTool default branch: static tools dispatch above; unknown
+  // `cr_`-prefixed names go to the generic handler; everything else throws.
+  async function callTool(name, args, staticHandlers = {}) {
+    if (Object.prototype.hasOwnProperty.call(staticHandlers, name)) {
+      return await staticHandlers[name](args);
+    }
+    if (typeof name === "string" && name.startsWith(GENERATED_TOOL_PREFIX)) {
+      return await callGeneratedTool(name, args);
+    }
+    throw new Error(`Unknown tool: ${name}`);
+  }
+
+  return { fetchGeneratedTools, callGeneratedTool, listTools, callTool };
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const AGENT_KEY = "lc_test_agent_key";
+const ORCH_KEY = "lc_test_orch_key";
+const BASE_URL = "https://loopctl.com";
+
+// Static tools stand-in (a few real static names so we can assert non-regression).
+const STATIC_TOOLS = [
+  { name: "get_story", description: "Get a story.", inputSchema: { type: "object" } },
+  { name: "knowledge_search", description: "Search the wiki.", inputSchema: { type: "object" } },
+  { name: "memory_recall", description: "Recall memory.", inputSchema: { type: "object" } },
+];
+
+// A generated filter spec for `project.status`, as GET /retrieve/tools returns it
+// (snake_case input_schema; metadata.operation is the JSON string "filter").
+function filterProjectByStatusSpec() {
+  return {
+    name: "cr_filter_project_by_status",
+    description: "Filter project records where status matches the given value.",
+    input_schema: {
+      type: "object",
+      properties: {
+        status: { type: "string" },
+        limit: { type: "integer" },
+        offset: { type: "integer" },
+      },
+      required: ["status"],
+    },
+    metadata: {
+      entity: "project",
+      backing_source: "projects",
+      field: "status",
+      operation: "filter",
+      field_type: "string",
+    },
+  };
+}
+
+function searchStorySpec() {
+  return {
+    name: "cr_search_story",
+    description: "Full-text search across story's searchable fields.",
+    input_schema: {
+      type: "object",
+      properties: { query: { type: "string" }, limit: { type: "integer" }, offset: { type: "integer" } },
+      required: ["query"],
+    },
+    metadata: {
+      entity: "story",
+      backing_source: "stories",
+      field: null,
+      operation: "search",
+      searchable_fields: ["title"],
+    },
+  };
+}
+
+/**
+ * Install a fetch stub that routes by URL path to a canned response, capturing
+ * every call (url/options). `routes` maps a path suffix to `{ body, status }`.
+ */
+function mockFetchByPath(routes) {
+  const calls = [];
+  globalThis.fetch = async (url, options) => {
+    calls.push({ url, options });
+    const u = new URL(url);
+    const match = Object.keys(routes).find((p) => u.pathname === p);
+    const route = match ? routes[match] : { body: { error: "no route" }, status: 404 };
+    const status = route.status ?? 200;
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      headers: { get: () => "application/json" },
+      json: async () => route.body,
+      text: async () => JSON.stringify(route.body),
+    };
+  };
+  return calls;
+}
+
+function setupEnv() {
+  process.env.LOOPCTL_SERVER = BASE_URL;
+  process.env.LOOPCTL_AGENT_KEY = AGENT_KEY;
+  process.env.LOOPCTL_ORCH_KEY = ORCH_KEY;
+  delete process.env.LOOPCTL_API_KEY;
+}
+
+beforeEach(() => setupEnv());
+
+// ---------------------------------------------------------------------------
+// Shared helper unit coverage (the real wire contract)
+// ---------------------------------------------------------------------------
+
+describe("http-helpers: retrieve path + spec/body mappers (single source of truth)", () => {
+  test("retrieveToolsPath is the fixed literal route (no client tenant param)", () => {
+    assert.equal(retrieveToolsPath(), "/api/v1/retrieve/tools");
+  });
+
+  test("retrieveEntityPath encodes the entity name", () => {
+    assert.equal(retrieveEntityPath("project"), "/api/v1/retrieve/project");
+    assert.equal(retrieveEntityPath("a/b"), "/api/v1/retrieve/a%2Fb");
+  });
+
+  test("specToMcpTool maps input_schema -> inputSchema and keeps name/description", () => {
+    const tool = specToMcpTool(filterProjectByStatusSpec());
+    assert.equal(tool.name, "cr_filter_project_by_status");
+    assert.equal(tool.description.startsWith("Filter project"), true);
+    assert.deepEqual(tool.inputSchema.required, ["status"]);
+    assert.equal("input_schema" in tool, false, "no snake_case key leaks into the MCP tool");
+  });
+
+  test("specToMcpTool returns null for a malformed spec (no string name)", () => {
+    assert.equal(specToMcpTool({ description: "x" }), null);
+    assert.equal(specToMcpTool(null), null);
+  });
+
+  test("buildRetrieveBody (filter) uses metadata field + args.value, omits nullish", () => {
+    const body = buildRetrieveBody(filterProjectByStatusSpec().metadata, { value: "active" });
+    assert.deepEqual(body, { op: "filter", field: "status", value: "active" });
+  });
+
+  test("buildRetrieveBody (filter) passes limit/offset when present", () => {
+    const body = buildRetrieveBody(filterProjectByStatusSpec().metadata, {
+      value: "active",
+      limit: 10,
+      offset: 20,
+    });
+    assert.deepEqual(body, { op: "filter", field: "status", value: "active", limit: 10, offset: 20 });
+  });
+
+  test("buildRetrieveBody (search) uses args.query, no field", () => {
+    const body = buildRetrieveBody(searchStorySpec().metadata, { query: "invoice" });
+    assert.deepEqual(body, { op: "search", query: "invoice" });
+  });
+
+  test("buildRetrieveBody dispatches by metadata.operation, NOT by splitting the name", () => {
+    // entity + field both contain underscores — name-splitting would be ambiguous.
+    const metadata = { entity: "work_order", field: "customer_name", operation: "filter" };
+    const body = buildRetrieveBody(metadata, { value: "acme" });
+    assert.deepEqual(body, { op: "filter", field: "customer_name", value: "acme" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TC-30.5.1: ListTools includes generated + static
+// ---------------------------------------------------------------------------
+
+describe("TC-30.5.1: ListTools merges generated + static", () => {
+  test("cr_filter_project_by_status appears alongside static tools; static unchanged", async () => {
+    mockFetchByPath({
+      "/api/v1/retrieve/tools": { body: { data: [filterProjectByStatusSpec()] } },
+    });
+    const rt = makeRuntime(STATIC_TOOLS);
+
+    const { tools } = await rt.listTools();
+    const names = tools.map((t) => t.name);
+
+    assert.ok(names.includes("cr_filter_project_by_status"), "generated tool present");
+    assert.ok(names.includes("get_story"), "static story tool present");
+    assert.ok(names.includes("knowledge_search"), "static knowledge tool present");
+    assert.ok(names.includes("memory_recall"), "static memory tool present");
+
+    // Static tools are unchanged and come first (no regression to their shape).
+    assert.deepEqual(tools.slice(0, STATIC_TOOLS.length), STATIC_TOOLS);
+
+    // The generated tool carries the camelCase inputSchema MCP expects.
+    const gen = tools.find((t) => t.name === "cr_filter_project_by_status");
+    assert.deepEqual(gen.inputSchema.required, ["status"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TC-30.5.2: dispatch generated call + static tool still works
+// ---------------------------------------------------------------------------
+
+describe("TC-30.5.2: generic dispatch of a cr_ call; static tool still works", () => {
+  test("cr_filter_project_by_status {value:'active'} POSTs to /retrieve/project", async () => {
+    const calls = mockFetchByPath({
+      "/api/v1/retrieve/tools": { body: { data: [filterProjectByStatusSpec()] } },
+      "/api/v1/retrieve/project": {
+        body: { results: [{ id: "p1", status: "active" }], meta: { total_count: 1, limit: 50, offset: 0 } },
+      },
+    });
+    const rt = makeRuntime(STATIC_TOOLS);
+    await rt.listTools(); // populate metadata
+
+    const result = await rt.callGeneratedTool("cr_filter_project_by_status", { value: "active" });
+    assert.equal(result.isError, undefined);
+
+    const post = calls.find((c) => new URL(c.url).pathname === "/api/v1/retrieve/project");
+    assert.ok(post, "POST to /retrieve/project made");
+    assert.equal(post.options.method, "POST");
+    assert.deepEqual(JSON.parse(post.options.body), { op: "filter", field: "status", value: "active" });
+
+    // The returned content includes the tenant projects from /retrieve.
+    const payload = JSON.parse(result.content[0].text);
+    assert.equal(payload.results[0].id, "p1");
+  });
+
+  test("a static tool (get_story) still dispatches via the static path", async () => {
+    mockFetchByPath({
+      "/api/v1/retrieve/tools": { body: { data: [filterProjectByStatusSpec()] } },
+    });
+    const rt = makeRuntime(STATIC_TOOLS);
+
+    let staticCalled = false;
+    const staticHandlers = {
+      get_story: async () => {
+        staticCalled = true;
+        return toContent({ id: "s1" });
+      },
+    };
+
+    const result = await rt.callTool("get_story", { story_id: "s1" }, staticHandlers);
+    assert.equal(staticCalled, true, "static handler invoked, not the generic dispatcher");
+    assert.equal(JSON.parse(result.content[0].text).id, "s1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TC-30.5.3: cross-tenant omission / rejection
+// ---------------------------------------------------------------------------
+
+describe("TC-30.5.3: tenant scoping — only the process key's tenant's tools", () => {
+  test("tenant_u's listing omits tenant_t's tools (server returns only caller's specs)", async () => {
+    // The stdio process is one-tenant-per-process: /retrieve/tools returns ONLY
+    // the calling key's tenant, so tenant_t's cr_ tool never appears for tenant_u.
+    mockFetchByPath({
+      "/api/v1/retrieve/tools": { body: { data: [filterProjectByStatusSpec()] } },
+    });
+    const rt = makeRuntime(STATIC_TOOLS);
+
+    const { tools } = await rt.listTools();
+    const names = tools.map((t) => t.name);
+    assert.ok(names.includes("cr_filter_project_by_status"), "tenant_u's own tool present");
+    assert.ok(!names.includes("cr_filter_secret_by_field"), "tenant_t's tool absent");
+  });
+
+  test("calling tenant_t's cr_ tool as tenant_u is rejected as unknown (no rows)", async () => {
+    // tenant_u's /retrieve/tools does NOT include tenant_t's tool, so resolving its
+    // metadata fails -> unknown-tool error, and NO /retrieve/:entity call is made.
+    const calls = mockFetchByPath({
+      "/api/v1/retrieve/tools": { body: { data: [filterProjectByStatusSpec()] } },
+    });
+    const rt = makeRuntime(STATIC_TOOLS);
+    await rt.listTools();
+
+    const result = await rt.callGeneratedTool("cr_filter_secret_by_field", { value: "x" });
+    assert.equal(result.isError, true, "unknown cross-tenant tool rejected");
+    assert.ok(JSON.parse(result.content[0].text).body.startsWith("Unknown tool:"));
+
+    const retrieveCalls = calls.filter((c) => new URL(c.url).pathname.startsWith("/api/v1/retrieve/") &&
+      new URL(c.url).pathname !== "/api/v1/retrieve/tools");
+    assert.equal(retrieveCalls.length, 0, "no executor call made for a cross-tenant name");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TC-30.5.4: degrade to static tools when /retrieve/tools errors
+// ---------------------------------------------------------------------------
+
+describe("TC-30.5.4: /retrieve/tools error degrades to static tools", () => {
+  test("fetch error -> static tools still returned, no throw, generated list empty", async () => {
+    mockFetchByPath({
+      "/api/v1/retrieve/tools": { body: { error: "boom" }, status: 500 },
+    });
+    const rt = makeRuntime(STATIC_TOOLS);
+
+    const { tools } = await rt.listTools();
+    // Exactly the static tools — no crash, no generated tools appended.
+    assert.deepEqual(tools, STATIC_TOOLS);
+  });
+
+  test("network throw from fetch also degrades to static tools", async () => {
+    globalThis.fetch = async () => {
+      throw new Error("ECONNRESET");
+    };
+    const rt = makeRuntime(STATIC_TOOLS);
+
+    const { tools } = await rt.listTools();
+    assert.deepEqual(tools, STATIC_TOOLS);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TC-30.5.5: generated call rides the SAME auth + witness/STH path as a static read
+// ---------------------------------------------------------------------------
+
+describe("TC-30.5.5: witness/STH + auth parity with static reads", () => {
+  test("a generated cr_ call carries the SAME auth + witness headers as a static read", async () => {
+    const calls = mockFetchByPath({
+      "/api/v1/retrieve/tools": { body: { data: [filterProjectByStatusSpec()] } },
+      "/api/v1/retrieve/project": { body: { results: [], meta: { total_count: 0, limit: 50, offset: 0 } } },
+      // A representative static read endpoint.
+      "/api/v1/knowledge/search": { body: { articles: [] } },
+    });
+    const rt = makeRuntime(STATIC_TOOLS);
+    await rt.listTools();
+
+    // Static read (as knowledge_search does) — same shared apiCall + agent key.
+    await apiCall("GET", "/api/v1/knowledge/search?q=x", null, process.env.LOOPCTL_AGENT_KEY);
+    // Generated call.
+    await rt.callGeneratedTool("cr_filter_project_by_status", { value: "active" });
+
+    const staticCall = calls.find((c) => new URL(c.url).pathname === "/api/v1/knowledge/search");
+    const genCall = calls.find((c) => new URL(c.url).pathname === "/api/v1/retrieve/project");
+
+    assert.equal(
+      genCall.options.headers.Authorization,
+      staticCall.options.headers.Authorization,
+      "same Authorization bearer as a static read",
+    );
+    assert.equal(
+      genCall.options.headers.Authorization,
+      `Bearer ${AGENT_KEY}`,
+      "uses the agent key (query-capable), not a weaker/other key",
+    );
+    assert.equal(
+      genCall.options.headers["X-Loopctl-Last-Known-STH"],
+      staticCall.options.headers["X-Loopctl-Last-Known-STH"],
+      "same witness/STH header as a static read (same witness client path)",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wiring assertions: pin that index.js actually uses the shared path (not a
+// bespoke second HTTP path) and degrades to static.
+// ---------------------------------------------------------------------------
+
+describe("index.js wiring (source-level pins)", () => {
+  test("imports the shared retrieve helpers from lib/http-helpers.js", () => {
+    assert.ok(/retrieveToolsPath/.test(INDEX_SRC));
+    assert.ok(/retrieveEntityPath/.test(INDEX_SRC));
+    assert.ok(/specToMcpTool/.test(INDEX_SRC));
+    assert.ok(/buildRetrieveBody/.test(INDEX_SRC));
+  });
+
+  test("ListTools handler appends generated tools to the static TOOLS array", () => {
+    assert.ok(
+      /tools:\s*\[\.\.\.TOOLS,\s*\.\.\.generated\]/.test(INDEX_SRC),
+      "ListTools returns [...TOOLS, ...generated]",
+    );
+  });
+
+  test("fetchGeneratedTools uses the shared apiCall + agent key (same witness path)", () => {
+    assert.ok(
+      /apiCall\("GET",\s*retrieveToolsPath\(\),\s*null,\s*process\.env\.LOOPCTL_AGENT_KEY\)/.test(INDEX_SRC),
+      "generated-tool listing goes through apiCall with the agent key",
+    );
+  });
+
+  test("generic dispatch POSTs through the shared apiCall + agent key", () => {
+    assert.ok(
+      /apiCall\(\s*"POST",\s*retrieveEntityPath\(metadata\.entity\)/.test(INDEX_SRC),
+      "generated calls POST /retrieve/:entity via apiCall (same auth+witness as static reads)",
+    );
+    assert.ok(/process\.env\.LOOPCTL_AGENT_KEY/.test(INDEX_SRC));
+  });
+
+  test("CallTool default routes unknown cr_-prefixed names to the generic handler", () => {
+    assert.ok(
+      /name\.startsWith\(GENERATED_TOOL_PREFIX\)/.test(INDEX_SRC),
+      "cr_-prefixed unknown names go to callGeneratedTool before throwing Unknown tool",
+    );
+  });
+});

--- a/mcp-server/test/context_retriever_tools.test.js
+++ b/mcp-server/test/context_retriever_tools.test.js
@@ -297,14 +297,33 @@ describe("http-helpers: retrieve path + spec/body mappers (single source of trut
     assert.equal(specToMcpTool(null), null);
   });
 
-  test("buildRetrieveBody (filter) uses metadata field + args.value, omits nullish", () => {
+  // The REAL agent contract: the US-30.2 schema puts the value under the
+  // field-named key (`required: ["status"]`, no `value` property), so a
+  // schema-compliant agent calls the tool with `{ status: "active" }`.
+  test("buildRetrieveBody (filter) sources the value from the schema field-named arg", () => {
+    const spec = filterProjectByStatusSpec();
+    // Build the args exactly as a schema-compliant agent would: the required key.
+    const [requiredKey] = spec.input_schema.required;
+    const body = buildRetrieveBody(spec.metadata, { [requiredKey]: "active" });
+    assert.deepEqual(body, { op: "filter", field: "status", value: "active" });
+  });
+
+  test("buildRetrieveBody (filter) still tolerates a literal {value:...} arg", () => {
     const body = buildRetrieveBody(filterProjectByStatusSpec().metadata, { value: "active" });
+    assert.deepEqual(body, { op: "filter", field: "status", value: "active" });
+  });
+
+  test("buildRetrieveBody (filter) prefers the field-named arg over a stray value arg", () => {
+    const body = buildRetrieveBody(filterProjectByStatusSpec().metadata, {
+      status: "active",
+      value: "ignored",
+    });
     assert.deepEqual(body, { op: "filter", field: "status", value: "active" });
   });
 
   test("buildRetrieveBody (filter) passes limit/offset when present", () => {
     const body = buildRetrieveBody(filterProjectByStatusSpec().metadata, {
-      value: "active",
+      status: "active",
       limit: 10,
       offset: 20,
     });
@@ -319,7 +338,7 @@ describe("http-helpers: retrieve path + spec/body mappers (single source of trut
   test("buildRetrieveBody dispatches by metadata.operation, NOT by splitting the name", () => {
     // entity + field both contain underscores — name-splitting would be ambiguous.
     const metadata = { entity: "work_order", field: "customer_name", operation: "filter" };
-    const body = buildRetrieveBody(metadata, { value: "acme" });
+    const body = buildRetrieveBody(metadata, { customer_name: "acme" });
     assert.deepEqual(body, { op: "filter", field: "customer_name", value: "acme" });
   });
 });
@@ -357,9 +376,10 @@ describe("TC-30.5.1: ListTools merges generated + static", () => {
 // ---------------------------------------------------------------------------
 
 describe("TC-30.5.2: generic dispatch of a cr_ call; static tool still works", () => {
-  test("cr_filter_project_by_status {value:'active'} POSTs to /retrieve/project", async () => {
+  test("cr_filter_project_by_status {status:'active'} POSTs the value to /retrieve/project", async () => {
+    const spec = filterProjectByStatusSpec();
     const calls = mockFetchByPath({
-      "/api/v1/retrieve/tools": { body: { data: [filterProjectByStatusSpec()] } },
+      "/api/v1/retrieve/tools": { body: { data: [spec] } },
       "/api/v1/retrieve/project": {
         body: { results: [{ id: "p1", status: "active" }], meta: { total_count: 1, limit: 50, offset: 0 } },
       },
@@ -367,7 +387,12 @@ describe("TC-30.5.2: generic dispatch of a cr_ call; static tool still works", (
     const rt = makeRuntime(STATIC_TOOLS);
     await rt.listTools(); // populate metadata
 
-    const result = await rt.callGeneratedTool("cr_filter_project_by_status", { value: "active" });
+    // Drive the call with the SCHEMA-REQUIRED field-named key a real agent emits
+    // (`required: ["status"]`), NOT a non-schema `{ value }` arg. This exercises
+    // the real agent-to-MCP contract; before the US-30.5 fix the value was
+    // dropped and the POST body carried no value (empty page).
+    const [requiredKey] = spec.input_schema.required;
+    const result = await rt.callGeneratedTool("cr_filter_project_by_status", { [requiredKey]: "active" });
     assert.equal(result.isError, undefined);
 
     const post = calls.find((c) => new URL(c.url).pathname === "/api/v1/retrieve/project");
@@ -482,8 +507,8 @@ describe("TC-30.5.5: witness/STH + auth parity with static reads", () => {
 
     // Static read (as knowledge_search does) — same shared apiCall + agent key.
     await apiCall("GET", "/api/v1/knowledge/search?q=x", null, process.env.LOOPCTL_AGENT_KEY);
-    // Generated call.
-    await rt.callGeneratedTool("cr_filter_project_by_status", { value: "active" });
+    // Generated call, driven with the schema-required field-named key.
+    await rt.callGeneratedTool("cr_filter_project_by_status", { status: "active" });
 
     const staticCall = calls.find((c) => new URL(c.url).pathname === "/api/v1/knowledge/search");
     const genCall = calls.find((c) => new URL(c.url).pathname === "/api/v1/retrieve/project");

--- a/mcp-server/test/memory_tools.test.js
+++ b/mcp-server/test/memory_tools.test.js
@@ -1176,8 +1176,11 @@ describe("AC-28.4.5: existing knowledge_*/story tools remain unchanged", () => {
     }
   });
 
-  test("ListToolsRequestSchema returns the TOOLS array as-is (append-only exposure)", () => {
-    assert.match(INDEX_SRC, /server\.setRequestHandler\(ListToolsRequestSchema, async \(\) => \(\{\s*\n\s*tools: TOOLS,/);
+  test("ListToolsRequestSchema exposes the full static TOOLS array (append-only)", () => {
+    // US-30.5 made ListTools dynamic: it now returns the static TOOLS array PLUS
+    // the tenant's generated Context Retriever tools (`[...TOOLS, ...generated]`).
+    // The static tools are still exposed in full and come first — append-only.
+    assert.match(INDEX_SRC, /tools:\s*\[\.\.\.TOOLS,\s*\.\.\.generated\]/);
   });
 });
 

--- a/mcp-server/test/witness_sth.test.js
+++ b/mcp-server/test/witness_sth.test.js
@@ -402,6 +402,42 @@ describe("createWitnessClient — cold-start singleflight (MEDIUM-6)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// createWitnessClient.send — per-request timeout override (US-30.5)
+// ---------------------------------------------------------------------------
+
+describe("createWitnessClient.send — per-request timeout override", () => {
+  const req = { url: "https://x/api/v1/tenants/me", method: "GET", headers: {} };
+
+  // Inject makeTimeoutSignal so we can observe the EFFECTIVE per-attempt timeout an
+  // AbortSignal.timeout would use but does not expose.
+  function captureTimeouts(clientOpts = {}) {
+    const timeouts = [];
+    const { fetchImpl } = spyFetch([fakeResponse(200, { "x-loopctl-current-sth": STH_A })]);
+    const client = createWitnessClient({
+      fetchImpl,
+      makeTimeoutSignal: (ms) => {
+        timeouts.push(ms);
+        return undefined;
+      },
+      ...clientOpts,
+    });
+    return { client, timeouts };
+  }
+
+  test("a per-request timeoutMs overrides the client default", async () => {
+    const { client, timeouts } = captureTimeouts({ timeoutMs: 30_000 });
+    await client.send({ ...req, timeoutMs: 5_000 });
+    assert.deepEqual(timeouts, [5_000], "short per-request budget used, not the 30s default");
+  });
+
+  test("without a per-request timeoutMs the client default applies", async () => {
+    const { client, timeouts } = captureTimeouts({ timeoutMs: 12_345 });
+    await client.send(req);
+    assert.deepEqual(timeouts, [12_345]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Persistence lifecycle (with the in-memory fs)
 // ---------------------------------------------------------------------------
 
@@ -497,7 +533,7 @@ describe("#298 wiring: per-key witness client", () => {
   test("apiCall sends through the per-key client and passes the symlink-safe fs", () => {
     assert.match(
       INDEX_SRC,
-      /await witnessClientFor\(key\)\.send\(\{ url, method, headers, serializedBody \}\)/,
+      /await witnessClientFor\(key\)\.send\(\{ url, method, headers, serializedBody, timeoutMs \}\)/,
     );
     assert.match(
       INDEX_SRC,


### PR DESCRIPTION
## US-30.5 — Dynamic MCP tool listing (Epic 30, Context Retriever)

Wires the Node.js MCP server (`mcp-server/`) to Epic 30's per-tenant generated tools, on top of the already-built API (US-30.4) and spec metadata (US-30.2).

### What changed
- **ListTools is now dynamic** — returns the static `TOOLS` array PLUS the calling tenant's generated Context Retriever tools, fetched from `GET /api/v1/retrieve/tools` via the shared authenticated `apiCall` (agent key, same witness/STH path as static reads). On any fetch failure it **degrades to the static tools** (logged, never errors the listing). A short 30s in-process cache bounds the added latency.
- **CallTool dispatches `cr_`-prefixed unknown names generically** to `POST /api/v1/retrieve/:entity`, resolving `(entity, field, operation)` from **STRUCTURED spec metadata** (US-30.2) — never by splitting the tool name (entity/field names contain underscores). Static tools dispatch unchanged (no regression).
- Path builders + spec→MCP-tool and metadata→body mappers extracted into `lib/http-helpers.js` (single source of truth, imported by both `index.js` and the test).

### Trust model
Tenant scoping is structural: the stdio MCP process is one-tenant-per-process, so `/retrieve/tools` returns only the process key's tenant's specs, and a generic call runs under that key. No second/weaker HTTP path — both fetch and call ride the same `apiCall`/witness path as static reads (AC-30.5.3 / AC-30.5.4).

### Acceptance criteria
- AC-30.5.1 static + generated listing, degrade-to-static on fetch error — met
- AC-30.5.2 generic dispatch of `cr_` via structured metadata, static unchanged — met
- AC-30.5.3 tenant-scoped listing + call (structural) — met
- AC-30.5.4 witness/STH + error parity with static reads, bounded count — met

### Tests
New `mcp-server/test/context_retriever_tools.test.js` covers TC-30.5.1–5 (merged listing, dispatch + static-still-works, cross-tenant omission/rejection, degrade-on-error, witness/STH+auth parity). Full suite: 194 passing, 0 failing. `mix precommit` gate ran green on commit (4084 Elixir tests, 0 failures).

Part of #309 (epic — do not auto-close on this single story)
