### PR TITLE
Docs (three-layer model) + terminal scope-isolation / injection / dynamic-listing verification (runs last)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,24 +5,34 @@ This is a web application written using the Phoenix web framework.
 - Use `mix precommit` alias when you are done with all changes and fix any pending issues
 - Use the already included and available `:req` (`Req`) library for HTTP requests, **avoid** `:httpoison`, `:tesla`, and `:httpc`. Req is included by default and is the preferred HTTP client for Phoenix apps
 
-### Agent Memory (`memory_*`) vs Knowledge Wiki (`knowledge_*`)
+### `retrieve_*` (Context Retriever) vs `knowledge_*` (Wiki) vs `memory_*` (Memory)
 
-loopctl has TWO stores an agent can write to — pick by ownership + lifecycle
-(full reference: `docs/agent-memory.md`):
+loopctl has THREE agent information surfaces — pick by WHAT THE DATA IS (full
+references: `docs/context-retriever.md`, `docs/agent-memory.md`):
 
-- **`memory_*` — Agent Memory**: PRIVATE to your `(tenant, subject_id)` scope
-  (`Loopctl.Memory`; tables `memories`/`session_memories`). Use for facts,
-  preferences, and observations THIS agent learned about ITS task/user and needs
-  to recall later. `long_term` = vector-embedded + semantically recalled; `session`
-  = chronological + TTL-pruned. Tools: `memory_remember`, `memory_recall`,
-  `memory_list`, `memory_forget`.
-- **`knowledge_*` — Knowledge Wiki**: SHARED, curated tenant knowledge, deduped and
+- **`retrieve_*` — Context Retriever** (Epic 30; `Loopctl.ContextRetriever`, table
+  `entity_definitions`): GOVERNED, structured access to loopctl's own live ROWS
+  (`projects`/`stories`/`epics`). An admin declares a tenant-scoped **entity**
+  (typed, server-allowlisted fields) over `/api/v1/entities`; per-entity
+  `cr_filter_*`/`cr_search_*` tools are generated dynamically and appended to
+  ListTools from `GET /api/v1/retrieve/tools`; a `cr_*` call dispatches to
+  `POST /api/v1/retrieve/:entity`. Parameterized (never model SQL), dual
+  tenant-scoped, allowlist-shaped, audited (fail-closed), rate-limited. Use to
+  query live operational state by a structured filter or full-text search.
+- **`memory_*` — Agent Memory** (Epic 28; `Loopctl.Memory`; tables
+  `memories`/`session_memories`): PRIVATE to your `(tenant, subject_id)` scope.
+  Use for facts, preferences, and observations THIS agent learned about ITS
+  task/user and needs to recall later. `long_term` = vector-embedded +
+  semantically recalled; `session` = chronological + TTL-pruned. Tools:
+  `memory_remember`, `memory_recall`, `memory_list`, `memory_forget`.
+- **`knowledge_*` — Knowledge Wiki**: SHARED, curated tenant DOCUMENTS, deduped and
   linked. Use when the insight is worth ANOTHER agent reading.
 
-Rule of thumb: *worth another agent reading?* → `knowledge_create`; *a fact only I
-need to recall about my own work?* → `memory_remember`. Scope is key-derived — you
-never pass `tenant_id`/`subject_id`. Do NOT conflate `Loopctl.Memory` (Epic 28)
-with the article-level agent-memory *metadata* (`memory_type`/`visibility`) on the
+Rule of thumb: *live structured business row?* → `retrieve_*`; *worth another
+agent reading?* → `knowledge_create`; *a fact only I need to recall about my own
+work?* → `memory_remember`. Scope is key-derived — you never pass
+`tenant_id`/`subject_id`. Do NOT conflate `Loopctl.Memory` (Epic 28) with the
+article-level agent-memory *metadata* (`memory_type`/`visibility`) on the
 Knowledge `articles` table (#163) — different subsystems.
 
 ### Phoenix v1.8 guidelines

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,55 @@
 
 All notable changes to loopctl are documented here.
 
+## [Unreleased] — 2026-07-10 — Context Retriever (Epic 30)
+
+### Added
+
+- **Context Retriever** — a governed, auto-generated agent query surface over
+  loopctl's own STRUCTURED records (`projects`/`stories`/`epics`), the third of
+  loopctl's three agent information layers (Knowledge Wiki / Agent Memory /
+  Context Retriever). See [`docs/context-retriever.md`](docs/context-retriever.md).
+  - **Entity registry** (`Loopctl.ContextRetriever.Entity`/`Registry`, table
+    `entity_definitions`) — a tenant admin declares a named **entity** (typed
+    `fields` + a backing source) over `POST/PATCH/DELETE /api/v1/entities`. The
+    definition IS the executor's field allowlist, bounded by a SERVER per-source
+    column allowlist that excludes `tenant_id`/`metadata`/custody columns. Defining
+    requires role ≥ `user` + a human-anchored tenant; per-tenant entity count and
+    fields-per-entity are capped. Relationships/joins are out of scope for v1.
+  - **Tool generator** (`ToolGenerator`) — emits per-entity `cr_filter_<entity>_by_<field>`
+    tools (one per filterable field) and a `cr_search_<entity>` tool when a declared
+    searchable TEXT field is covered by the source's `search_vector`; served at
+    `GET /api/v1/retrieve/tools`.
+  - **Executor** (`Executor.run/3`, the security boundary) — `POST /api/v1/retrieve/:entity`
+    runs a filter/search parameterized (Ecto-pinned values / `websearch_to_tsquery`
+    — never model SQL), dual tenant-scoped (RLS `loopctl_app` role + explicit
+    predicate), execute-time allowlist-rechecked, shaped to declared columns only,
+    audited fail-closed (`audit_log` `entity_type: "context_retrieval"`; no rows
+    without a persisted audit trail), and per-tenant rate-limited (429 over-limit,
+    unexecuted). Injection payloads match literally; pagination size + offset are
+    capped.
+- **MCP dynamic tool listing** — `mcp-server/lib/generated-tools.js` fetches the
+  tenant's `cr_*` specs, appends them to ListTools (TTL-cached, negative-cached on
+  outage, non-`cr_`/static-colliding specs dropped), and dispatches a `cr_*` call
+  to `POST /api/v1/retrieve/:entity` under the same agent key as static reads.
+- **Docs** — new [`docs/context-retriever.md`](docs/context-retriever.md) (the
+  three-layer model, architecture, security model, surfaces); README/CLAUDE.md/AGENTS.md
+  extended to a three-way `retrieve_*` vs `knowledge_*` vs `memory_*` decision
+  guide. The #309 "reconcile `docs/cole-medin-self-evolving-wiki.md`" item was
+  already satisfied (removed PR #310; content in KB hub `fb9abd73`); the epic folder
+  is `epic_30`.
+
+### Verification
+
+- **Terminal e2e + security** (US-30.7) — `Loopctl.E2E.ContextRetrieverJourneyTest`
+  (define → ListTools → filter + search via API and the MCP-derived body agree,
+  tenant-scoped) and `Loopctl.E2E.ContextRetrieverSecurityTest` (injection in
+  filter + search match literally; non-allowlist rejected on every surface;
+  cross-tenant define/list/query isolation via context/API/MCP with a positive
+  control; no undeclared-column leak; an audit record per execution; `/retrieve`
+  429 over-limit) — both run under the non-owner app role. All Context Retriever
+  endpoints render at `/swaggerui`.
+
 ## [Unreleased] — 2026-07-10 — Agent Memory auto-promotion (Epic 29, Part 2)
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,6 +257,33 @@ I need to recall about my own work?"* → `memory_remember`. Scope is derived fr
 your key server-side — you never pass `tenant_id`/`subject_id`. loopctl is
 agent-native (no memory UI); operator oversight is the superadmin API path.
 
+## Epic 30: Context Retriever — three surfaces (`retrieve_*` vs `knowledge_*` vs `memory_*`)
+
+Epic 30 adds a THIRD agent information surface (`Loopctl.ContextRetriever`, tables
+`entity_definitions`) alongside the Knowledge Wiki and Agent Memory. Full
+reference: [`docs/context-retriever.md`](docs/context-retriever.md). Pick by what
+the data IS:
+
+- **`retrieve_*` (Context Retriever)** — GOVERNED, structured access to loopctl's
+  own live rows (`projects`/`stories`/`epics`). A tenant admin declares an
+  **entity** (typed, server-allowlisted fields) over `/api/v1/entities`; the
+  generator emits per-entity `cr_filter_*`/`cr_search_*` tools (dynamic,
+  per-tenant, appended to ListTools from `GET /api/v1/retrieve/tools`); a `cr_*`
+  call dispatches to `POST /api/v1/retrieve/:entity`. Every query is
+  parameterized (no model SQL), dual tenant-scoped (RLS `loopctl_app` role +
+  explicit predicate), execute-time allowlist-rechecked, shaped to declared
+  columns only, audited (fail-closed), and rate-limited. Use when you'd query
+  live operational state by a structured filter or full-text search.
+- **`knowledge_*` (Knowledge Wiki)** — SHARED, curated tenant DOCUMENTS. Use when
+  the insight is worth another agent reading.
+- **`memory_*` (Agent Memory)** — PRIVATE `(tenant, subject_id)` working memory.
+  Use for facts only THIS agent needs to recall about its own work.
+
+Rule of thumb: *live structured business row?* → `retrieve_*`. *worth another
+agent reading?* → `knowledge_create`. *a fact only I need?* → `memory_remember`.
+Defining an entity is a security root (role ≥ `user` + human-anchor); querying is
+authenticated-only. You never pass `tenant_id` — scope is key-derived.
+
 ## Elixir / Phoenix guidelines
 
 These are the stock `phx.new` rules, condensed. Each line is a hard rule.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ loopctl does not make decisions, execute code, or run tests. It stores state, en
 | **Agent Memory** | An agent subject's private working memory, isolated per `(tenant, subject_id)`: short-term **session** turns (chronological, TTL-pruned) and long-term, vector-embedded **facts** (semantically recalled, supersede/forget lifecycle). Distinct from the shared Knowledge Wiki. |
 | **Memory Promotion** | Unattended compilation of a session's short-term turns into durable long-term `:promoted` memories (via `POST /api/v1/memory/promote`, the `memory_promote` tool, or an hourly sweep). Watermark-idempotent, per-tenant budget-bounded, confidence-gated, hash-deduped/superseded, and prompt-injection-resistant. See [`docs/agent-memory.md`](docs/agent-memory.md). |
 | **Subject** | The owner of a memory scope, derived server-side from the API key: an agent key's `agent_id` (so rotated keys share one memory), else the key's own id. Never client-supplied. |
+| **Context Retriever** | Governed, auto-generated agent query access to loopctl's own STRUCTURED records (`projects`/`stories`/`epics`). An admin declares a tenant-scoped **entity** (typed, server-allowlisted fields); the generator emits per-entity `cr_filter_*`/`cr_search_*` tools; the executor runs the query parameterized, dual-tenant-scoped, allowlist-shaped, audited (fail-closed), and rate-limited — never model-authored SQL. The third of loopctl's three agent layers (Knowledge Wiki / Agent Memory / Context Retriever). See [`docs/context-retriever.md`](docs/context-retriever.md). |
 
 ## Tech Stack
 
@@ -860,6 +861,7 @@ Full descriptions live in [`mcp-server/README.md`](mcp-server/README.md); summar
 | `memory_list` | List the caller's OWN long-term memories (paginated); superadmin `all_subjects=true` lists a tenant's every subject. | agent |
 | `memory_forget` | Delete one of the caller's OWN memories by id (404 cross-scope, no existence leak). | agent |
 | `memory_promote` | Compile a session's short-term memory into durable long-term memory (async job; caller's own sessions only) | agent |
+| `cr_filter_*` / `cr_search_*` | **Dynamically generated** Context Retriever tools (one per filterable field + one search tool per entity). Appended to ListTools per-tenant from `GET /api/v1/retrieve/tools`; a `cr_`-prefixed call dispatches generically to `POST /api/v1/retrieve/:entity`. Governed structured-data reads over `projects`/`stories`/`epics` — parameterized, tenant-scoped, allowlist-shaped, audited. Entity definitions are authored over `/api/v1/entities` (user + human-anchor). See [`docs/context-retriever.md`](docs/context-retriever.md). | agent |
 | `get_system_articles` | List/fetch system-scoped wiki articles (public) | none |
 | `dispatch` | Mint an ephemeral key for a sub-agent dispatch (Chain of Custody v2) | orchestrator |
 | `recover_cap` | Re-mint a capability token after a session crash | agent |

--- a/docs/context-retriever.md
+++ b/docs/context-retriever.md
@@ -1,0 +1,208 @@
+# Context Retriever (Epic 30)
+
+Authoritative reference for loopctl's **Context Retriever** — the governed,
+auto-generated agent query surface over loopctl's own STRUCTURED records
+(`projects` / `stories` / `epics`). It is the third of loopctl's three agent
+information layers, alongside the Knowledge Wiki and Agent Memory.
+
+> loopctl is **agent-native**: there is **no web UI, no LiveView, no human login**
+> for the Context Retriever. Entity definitions are authored and queries are run
+> entirely over the **API / MCP** by keys the tenant already holds. Operator
+> oversight is the superadmin-gated API path, not an admin console.
+
+---
+
+## The three-layer mental model (decide fast)
+
+loopctl gives an agent three distinct places to get information. Pick by **what
+the data IS**, not by "where will I find it later":
+
+| Layer | What it holds | Scope / owner | Lifecycle | Reach it via |
+|-------|---------------|---------------|-----------|--------------|
+| **Knowledge Wiki** | Curated, *shared* tenant knowledge — patterns, decisions, findings, references (documents) | Tenant (with per-article agent visibility) | Human/agent-curated, versioned, linked, conflict-resolved | `knowledge_*` tools / `/api/v1/knowledge*` |
+| **Agent Memory** | An agent subject's *private* working memory — session turns + long-term facts about *its* work | `(tenant, subject_id)` — one agent | Append/embed/supersede/forget; session tier expires (auto-accumulated) | `memory_*` tools / `/api/v1/memory*` |
+| **Context Retriever** | *Governed, structured* access to *live business data* — rows in loopctl's own tables, exposed as typed, allowlisted entities | Tenant, schema-scoped | Read-through over the operational store; entity definitions are admin-authored | `retrieve_*` (generated `cr_*`) tools / `/api/v1/entities*` + `/api/v1/retrieve/*` |
+
+Rules of thumb:
+
+- **Is it worth another agent reading?** → Knowledge Wiki (`knowledge_create`).
+  Shared, curated, deduped by the novelty gate.
+- **Is it a fact THIS agent learned about ITS task/user that only it needs to
+  recall later?** → Agent Memory (`memory_remember`). Private to the subject,
+  auto-accumulated.
+- **Is it live operational state (a story, a project, an epic) you'd query by a
+  structured filter or full-text search?** → the Context Retriever
+  (`retrieve_*`). It reads loopctl's real rows through a governed, parameterized,
+  tenant-scoped query — never free-form SQL.
+
+This layering follows the "database as the agent's context layer, split into a
+context-retriever + agent-memory" architecture (Cole Medin, *"I Love the Karpathy
+LLM Wiki but it Doesn't Scale"*). loopctl sits on the **production** side of that
+line: DB-backed, MCP-exposed, allowlist-governed — not a markdown second brain.
+(KB hub: `fb9abd73`.)
+
+> **Doc reconciliation (#309/#310):** the #309 body's "reconcile
+> `docs/cole-medin-self-evolving-wiki.md`" item is **already satisfied** — that
+> note was removed in PR #310 and its durable content now lives in the KB hub
+> (`fb9abd73`) and in this document (single-home). The epic folder for this work
+> is **`epic_30`**; the #309 body's `epic_29_context_retriever` label predates
+> epic_29 being reassigned to Agent Memory Part 2 (#308).
+
+---
+
+## Architecture: entity → generator → executor
+
+Three modules turn an admin-authored declaration into a safe agent query surface.
+
+### 1. Entity registry — `Loopctl.ContextRetriever.Entity` / `Registry`
+
+An **entity definition** is a tenant-admin-authored (role ≥ `user`, human-anchored)
+declaration: a `name`, a `backing_source` (`:projects` / `:stories` / `:epics`),
+and a list of typed `fields` (`%{name, type, filterable, searchable}`). It is
+persisted in `entity_definitions` (tenant-scoped, RLS). **The definition IS the
+executor's field allowlist** — it is attacker-authored, so a **SERVER-defined
+per-source column allowlist** (`Entity.column_allowlist/0`, a code constant)
+bounds which columns any entity may declare. `tenant_id`, `metadata`, and every
+custody/dispatch/audit column are deliberately excluded. Per-tenant entity COUNT
+is capped (`:max_entity_definitions_per_tenant`); fields-per-entity is capped
+(`@max_fields`). Relationships/joins between entities are **out of scope for v1**
+(no unvalidated relationship JSON is stored).
+
+### 2. Tool generator — `Loopctl.ContextRetriever.ToolGenerator`
+
+Reads a tenant's definitions and emits per-entity agent tool specs (`GET
+/api/v1/retrieve/tools`): one `cr_filter_<entity>_by_<field>` tool per filterable
+field, and one `cr_search_<entity>` tool when the entity declares a searchable
+TEXT field that the source's `search_vector` actually covers. The tool schema puts
+the filter value under the field-named key; `metadata` carries the
+`{entity, field, operation}` dispatch tuple the executor consumes.
+
+### 3. Executor — `Loopctl.ContextRetriever.Executor` (the security boundary)
+
+`run/3` is the ONLY entry point. It takes a `Scope` (tenant + audit actor), the
+`{entity, field, operation}` dispatch tuple, and the model-supplied params, and
+returns a page of allowlisted-only result maps. **No model-authored SQL ever
+reaches the database.** See the security model below.
+
+The MCP layer (`mcp-server/lib/generated-tools.js`) calls the HTTP API, not the
+contexts directly: it fetches `/retrieve/tools`, appends the `cr_*` specs to
+ListTools (per-tenant, TTL-cached, negative-cached on outage), and dispatches a
+`cr_*` call to `POST /api/v1/retrieve/:entity` under the SAME agent key as every
+other read.
+
+---
+
+## Security model
+
+The Context Retriever exposes live business data to a model-driven caller, so
+every layer is fail-closed:
+
+- **Server column allowlist** — an entity may only declare columns in
+  `Entity.column_allowlist/0` for its source. This is the security gate:
+  `tenant_id`, `metadata`, and custody columns can never be declared, so the
+  "declared-fields-only" projection can never exfiltrate them. Adding a column is
+  a security review, not a convenience.
+- **Parameterization always** — filter values are Ecto-pinned (`^value`); search
+  uses `websearch_to_tsquery('english', ?)`. An injection payload (`' OR 1=1 --`,
+  `'; DROP TABLE stories; --`) becomes a **literal** that matches nothing — never
+  SQL. An enum/decimal column whose pinned value fails re-cast returns
+  `:no_match` (0 rows), never a DB error leak.
+- **Dual tenant scoping** — every query runs under `Repo.with_tenant/2` (RLS
+  `SET LOCAL app.current_tenant_id` + `SET LOCAL ROLE loopctl_app`, the **non-owner
+  app role**, so RLS — `ENABLE`, not `FORCE` — actually engages) AND an explicit
+  `where q.tenant_id == ^scope.tenant_id` predicate. `tenant_id` is read ONLY from
+  the scope; any `tenant_id` in params is ignored.
+- **Execute-time allowlist re-check** — generate-time checks bound the tool
+  SURFACE, but a raw `POST /retrieve` can name a field the entity does not declare
+  (or declares non-filterable/non-searchable). `run/3` RE-VALIDATES
+  `(field, operation)` against the live definition AND the server allowlist and
+  rejects with `{:error, :field_not_allowlisted}` (HTTP 422) — closing the
+  raw-`/retrieve` bypass.
+- **Result shaping** — results select ONLY the entity's declared, allowlisted
+  columns (`map(q, ^declared_columns)`); never `SELECT *`, never
+  `tenant_id`/`metadata`/custody columns.
+- **Indexed search only** — search runs against the GIN-indexed, trigger-maintained
+  `search_vector`; a declared-searchable column the vector does not cover is
+  rejected with `:search_not_indexed` (422), never silently searched against the
+  wrong columns.
+- **Pagination + offset caps** — page size is clamped to
+  `:context_retriever_max_page_size`; the offset is clamped to
+  `:context_retriever_max_offset` (bounds the O(offset) deep-scan a model could
+  otherwise trigger). No unindexed-scan DoS.
+- **Audit, fail-closed** — every execution appends an `audit_log` entry
+  (`entity_type: "context_retrieval"`) capturing tenant, actor,
+  entity/field/operation, row count, and a SHA-256 digest of the params (raw
+  values are NEVER stored — they may carry injection payloads / PII). If the audit
+  insert fails, `run/3` FAILS CLOSED (`{:error, :audit_failed}`, no rows) — a
+  read over business data is never disclosed without a persisted audit trail.
+- **Rate limit** — `POST /retrieve/:entity` is per-tenant rate-limited
+  (`cr_retrieve:tenant:<id>` bucket) BEFORE dispatch; over-limit is HTTP 429 and
+  does NOT execute.
+- **Role gate** — defining/mutating an entity requires role ≥ `user` AND a
+  human-anchored tenant (the definition is a security root); querying
+  (`/retrieve/*`, list, show) requires only authentication — `:agent` is the floor
+  role, so the negative case for a query is **401** (unauthenticated), never a
+  below-agent 403.
+- **Fail-closed edges** — a `nil`-tenant (superadmin without impersonation) scope
+  is refused (`:no_tenant`, never an `AdminRepo` cross-tenant read); a stale entity
+  def (renamed/dropped backing column) surfaces as `:stale_entity` with no schema
+  internals disclosed; a malformed call returns `:invalid_params` rather than
+  raising.
+
+---
+
+## Surfaces
+
+| Operation | Context (`Loopctl.ContextRetriever`) | HTTP API | MCP tool | Role |
+|-----------|--------------------------------------|----------|----------|------|
+| Define entity | `Registry.create_entity/3` | `POST /api/v1/entities` | *(API/MCP-authored; via the HTTP surface)* | user + human-anchor |
+| List entities | `Registry.for_tenant/1` | `GET /api/v1/entities` | — | agent |
+| Show entity | `Registry.get_entity_by_id/2` | `GET /api/v1/entities/:id` | — | agent |
+| Update entity | `Registry.update_entity/4` | `PATCH /api/v1/entities/:id` | — | user + human-anchor |
+| Delete entity | `Registry.delete_entity/3` | `DELETE /api/v1/entities/:id` | — | user + human-anchor |
+| List generated tools | `Registry.tool_specs/1` | `GET /api/v1/retrieve/tools` | *(drives ListTools)* | agent |
+| Execute filter/search | `Executor.run/3` | `POST /api/v1/retrieve/:entity` | `cr_filter_*` / `cr_search_*` (generated) | agent |
+
+The MCP `retrieve_*` surface is **dynamic**: there are no static `cr_*` tool
+names. The MCP client fetches the tenant's specs from `/retrieve/tools` and
+appends them to ListTools per-tenant; a `cr_`-prefixed call is dispatched
+generically to `POST /retrieve/:entity`. Specs that are not `cr_`-prefixed or that
+collide with a static tool name are dropped (no description-spoofing). All queries
+carry the same agent key as the tenant's other reads — the MCP server never holds
+a stronger key for this path. The MCP tools expose **no** `tenant_id` parameter,
+so a cross-tenant read is not even expressible there.
+
+The `/retrieve` request body is `{"op": "filter"|"search", "field", "value",
+"query", "limit", "offset"}`; `op` is matched to an atom without
+`String.to_atom` on model input. The response is `{"results": [...], "meta":
+{total_count, limit, offset}}`.
+
+Endpoint specs (`OpenApiSpex operation/2`) render at `/swaggerui`.
+
+---
+
+## Verification (US-30.7, terminal)
+
+- **End-to-end** (`Loopctl.E2E.ContextRetrieverJourneyTest`, `@tag :e2e`): an
+  entity with a filterable AND a searchable field is defined via the API (user
+  key); BOTH generated tools appear via `GET /retrieve/tools` (agent key); a
+  FILTER query and a SEARCH query run via `POST /retrieve/:entity` — using the
+  request body the MCP client derives from the tool spec AND a direct-API body —
+  return the SAME tenant-scoped result set.
+- **Terminal security** (`Loopctl.E2E.ContextRetrieverSecurityTest`, `@tag :e2e`,
+  run under the non-owner app role): injection payloads in both a filter value AND
+  a search query match literally (positive control proves the value is genuinely
+  matchable); a non-allowlisted field is rejected on every surface (define-time
+  422, execute-time 422); cross-tenant define/list/query isolation holds via
+  context, API, and MCP-equivalent path (with a positive control); only declared
+  columns are returned (no `tenant_id`/`metadata` leak); an `audit_log` record
+  exists per execution; over-limit `/retrieve` is 429.
+- **MCP dynamic listing + dispatch**
+  (`mcp-server/test/context_retriever_tools.test.js`, `node --test`): ListTools
+  appends the generated specs, `cr_*` calls dispatch to the right
+  `POST /retrieve/:entity` body, tenant scoping / degrade-to-static / auth parity.
+
+Run: `mix test.e2e` (or `E2E_TESTS=1 mix test test/e2e/context_retriever_*_test.exs`)
+plus `cd mcp-server && npm test`. The per-unit suites
+(`test/loopctl/context_retriever/*`, `test/loopctl_web/controllers/context_retriever_controller_test.exs`)
+run in the default `mix test`.

--- a/test/e2e/context_retriever_journey_test.exs
+++ b/test/e2e/context_retriever_journey_test.exs
@@ -33,92 +33,21 @@ defmodule Loopctl.E2E.ContextRetrieverJourneyTest do
 
   setup :verify_on_exit!
 
-  alias Ecto.Adapters.SQL.Sandbox
-  alias Loopctl.AdminRepo
-  alias Loopctl.Projects.Project
-  alias Loopctl.Repo
-  alias Loopctl.Tenants.Tenant
-  alias Loopctl.WorkBreakdown.Epic
-  alias Loopctl.WorkBreakdown.Story
-
-  import Ecto.Query
+  import Loopctl.ContextRetrieverE2EHelpers
 
   @tenant_marker "crjourney-"
 
   setup_all do
-    sweep_marker_tenants()
-    on_exit(&sweep_marker_tenants/0)
+    sweep_marker_tenants(@tenant_marker)
+    on_exit(fn -> sweep_marker_tenants(@tenant_marker) end)
     :ok
   end
 
-  defp sweep_marker_tenants do
-    Sandbox.unboxed_run(AdminRepo, fn ->
-      AdminRepo.delete_all(from(t in Tenant, where: like(t.slug, ^"#{@tenant_marker}%")))
-    end)
-  end
-
-  # A committed, human-anchored tenant visible to BOTH the AdminRepo auth path and
-  # the Repo executor path (see moduledoc).
-  defp commit_tenant do
-    seq = System.unique_integer([:positive])
-    id = Ecto.UUID.generate()
-
-    Sandbox.unboxed_run(AdminRepo, fn ->
-      %Tenant{}
-      |> Tenant.create_changeset(%{
-        name: "T#{seq}",
-        slug: "#{@tenant_marker}#{seq}",
-        email: "#{@tenant_marker}#{seq}@example.com"
-      })
-      |> Ecto.Changeset.put_change(:id, id)
-      |> Ecto.Changeset.put_change(:trust_tier, :human_anchored)
-      |> AdminRepo.insert!()
-    end)
-
-    AdminRepo.get!(Tenant, id)
-  end
-
-  defp user_key(tenant_id) do
-    {raw, _key} = fixture(:api_key, %{tenant_id: tenant_id, role: :user})
-    raw
-  end
-
-  defp agent_key(tenant_id) do
-    agent = fixture(:agent, %{tenant_id: tenant_id})
-    {raw, _key} = fixture(:api_key, %{tenant_id: tenant_id, role: :agent, agent_id: agent.id})
-    raw
-  end
-
-  # Backing rows are seeded on the Repo connection (the executor reads via
-  # Repo.with_tenant). A story needs a project + epic; the committed tenant
-  # satisfies the FK, the Repo inserts roll back at test exit.
-  defp seed_project(tenant_id, attrs \\ %{}) do
-    %Project{tenant_id: tenant_id}
-    |> Project.create_changeset(build(:project, attrs))
-    |> Repo.insert!()
-  end
-
-  defp seed_epic(tenant_id, project_id) do
-    %Epic{tenant_id: tenant_id, project_id: project_id}
-    |> Epic.create_changeset(build(:epic, %{}))
-    |> Repo.insert!()
-  end
-
-  defp seed_story(tenant_id, attrs) do
-    project = seed_project(tenant_id)
-    epic = seed_epic(tenant_id, project.id)
-
-    %Story{tenant_id: tenant_id, project_id: project.id, epic_id: epic.id}
-    |> Story.create_changeset(build(:story, attrs))
-    |> Repo.insert!()
-  end
-
-  defp auth(conn, raw_key), do: put_req_header(conn, "authorization", "Bearer #{raw_key}")
-
-  # A fresh conn carrying the witness STH header (each dispatched request needs its
-  # own conn).
-  defp fresh_conn,
-    do: put_req_header(build_conn(), "x-loopctl-last-known-sth", "0:AAAAAAAAAAAAAAAAAAAAAA")
+  # The committed-tenant scaffolding (sweep, commit_tenant, *_key, seed_*, auth,
+  # fresh_conn) is single-sourced in `Loopctl.ContextRetrieverE2EHelpers` so its
+  # security-critical semantics stay identical to the security suite. Only the
+  # per-suite slug marker differs.
+  defp commit_tenant, do: commit_tenant(@tenant_marker)
 
   # Mirror of the MCP client's `buildRetrieveBody(metadata, args)`
   # (`mcp-server/lib/http-helpers.js`): derive the `POST /retrieve/:entity` body

--- a/test/e2e/context_retriever_journey_test.exs
+++ b/test/e2e/context_retriever_journey_test.exs
@@ -1,0 +1,248 @@
+defmodule Loopctl.E2E.ContextRetrieverJourneyTest do
+  @moduledoc """
+  US-30.7 (TC-30.7.1) — terminal end-to-end journey for the Epic 30 Context
+  Retriever: the FULL path a live agent takes across API + MCP.
+
+  Define an entity with a filterable AND a searchable field via the HTTP API
+  (user key) → assert BOTH generated tools appear via `GET /api/v1/retrieve/tools`
+  (agent key) → run a FILTER query and a SEARCH query via `POST /api/v1/retrieve/:entity`
+  using BOTH a direct-API body AND the request body the MCP client derives from the
+  returned tool spec (mirroring `mcp-server/lib/generated-tools.js` `buildRetrieveBody`)
+  → assert the API and MCP-derived legs return the SAME tenant-scoped result set.
+
+  Excluded from the default suite (`@moduletag :e2e`); run with `mix test.e2e`
+  or `E2E_TESTS=1 mix test --only e2e`.
+
+  ## Why `async: false` + a COMMITTED tenant (see `context_retriever_controller_test.exs`)
+
+  The executor reads backing rows through `Loopctl.Repo.with_tenant/2` (RLS
+  transactions with `SET LOCAL ROLE loopctl_app`) on the `Loopctl.Repo` connection,
+  while the AUTH pipeline resolves the API key through `Loopctl.AdminRepo` — two
+  distinct sandbox connections that cannot see each other's UNCOMMITTED rows. The
+  tenant must be visible to BOTH (FK from api_keys[AdminRepo] AND stories[Repo]),
+  so it is inserted via `Sandbox.unboxed_run/2` (a real, committed connection) and
+  swept at module boundaries by a slug marker. The `async: true` used by the
+  knowledge/memory journeys does not apply here — a committed row would leak across
+  parallel tests. Because the executor's tenant scoping runs under the NON-owner
+  `loopctl_app` role (RLS is ENABLE, not FORCE), the tenant-scoping assertion here
+  actually proves isolation rather than silently passing.
+  """
+  use LoopctlWeb.ConnCase, async: false
+
+  @moduletag :e2e
+
+  setup :verify_on_exit!
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Loopctl.AdminRepo
+  alias Loopctl.Projects.Project
+  alias Loopctl.Repo
+  alias Loopctl.Tenants.Tenant
+  alias Loopctl.WorkBreakdown.Epic
+  alias Loopctl.WorkBreakdown.Story
+
+  import Ecto.Query
+
+  @tenant_marker "crjourney-"
+
+  setup_all do
+    sweep_marker_tenants()
+    on_exit(&sweep_marker_tenants/0)
+    :ok
+  end
+
+  defp sweep_marker_tenants do
+    Sandbox.unboxed_run(AdminRepo, fn ->
+      AdminRepo.delete_all(from(t in Tenant, where: like(t.slug, ^"#{@tenant_marker}%")))
+    end)
+  end
+
+  # A committed, human-anchored tenant visible to BOTH the AdminRepo auth path and
+  # the Repo executor path (see moduledoc).
+  defp commit_tenant do
+    seq = System.unique_integer([:positive])
+    id = Ecto.UUID.generate()
+
+    Sandbox.unboxed_run(AdminRepo, fn ->
+      %Tenant{}
+      |> Tenant.create_changeset(%{
+        name: "T#{seq}",
+        slug: "#{@tenant_marker}#{seq}",
+        email: "#{@tenant_marker}#{seq}@example.com"
+      })
+      |> Ecto.Changeset.put_change(:id, id)
+      |> Ecto.Changeset.put_change(:trust_tier, :human_anchored)
+      |> AdminRepo.insert!()
+    end)
+
+    AdminRepo.get!(Tenant, id)
+  end
+
+  defp user_key(tenant_id) do
+    {raw, _key} = fixture(:api_key, %{tenant_id: tenant_id, role: :user})
+    raw
+  end
+
+  defp agent_key(tenant_id) do
+    agent = fixture(:agent, %{tenant_id: tenant_id})
+    {raw, _key} = fixture(:api_key, %{tenant_id: tenant_id, role: :agent, agent_id: agent.id})
+    raw
+  end
+
+  # Backing rows are seeded on the Repo connection (the executor reads via
+  # Repo.with_tenant). A story needs a project + epic; the committed tenant
+  # satisfies the FK, the Repo inserts roll back at test exit.
+  defp seed_project(tenant_id, attrs \\ %{}) do
+    %Project{tenant_id: tenant_id}
+    |> Project.create_changeset(build(:project, attrs))
+    |> Repo.insert!()
+  end
+
+  defp seed_epic(tenant_id, project_id) do
+    %Epic{tenant_id: tenant_id, project_id: project_id}
+    |> Epic.create_changeset(build(:epic, %{}))
+    |> Repo.insert!()
+  end
+
+  defp seed_story(tenant_id, attrs) do
+    project = seed_project(tenant_id)
+    epic = seed_epic(tenant_id, project.id)
+
+    %Story{tenant_id: tenant_id, project_id: project.id, epic_id: epic.id}
+    |> Story.create_changeset(build(:story, attrs))
+    |> Repo.insert!()
+  end
+
+  defp auth(conn, raw_key), do: put_req_header(conn, "authorization", "Bearer #{raw_key}")
+
+  # A fresh conn carrying the witness STH header (each dispatched request needs its
+  # own conn).
+  defp fresh_conn,
+    do: put_req_header(build_conn(), "x-loopctl-last-known-sth", "0:AAAAAAAAAAAAAAAAAAAAAA")
+
+  # Mirror of the MCP client's `buildRetrieveBody(metadata, args)`
+  # (`mcp-server/lib/http-helpers.js`): derive the `POST /retrieve/:entity` body
+  # from the RETURNED tool spec's metadata + required arg, exactly as the JS
+  # dispatch path does. This proves the spec → body → results wire the MCP leg
+  # rides is the SAME one the direct API uses.
+  defp mcp_body_from_spec(
+         %{"metadata" => %{"operation" => "filter", "field" => field}} = spec,
+         args
+       ) do
+    [required_key] = spec["input_schema"]["required"]
+    %{"op" => "filter", "field" => field, "value" => Map.fetch!(args, required_key)}
+  end
+
+  defp mcp_body_from_spec(%{"metadata" => %{"operation" => "search"}}, args) do
+    %{"op" => "search", "query" => Map.fetch!(args, "query")}
+  end
+
+  describe "TC-30.7.1: define → ListTools → filter + search (API + MCP) agree" do
+    test "both generated tools list; API and MCP-derived filter+search return the same tenant-scoped set",
+         %{conn: _conn} do
+      tenant = commit_tenant()
+      other = commit_tenant()
+      user = user_key(tenant.id)
+      agent = agent_key(tenant.id)
+
+      # A distinctive searchable term so the search match is unambiguous.
+      marker = "zqcontext#{System.unique_integer([:positive])}"
+
+      # Two matching stories for the filter + one for search in the caller tenant.
+      seed_story(tenant.id, %{title: "#{marker} alpha report", number: "101"})
+      seed_story(tenant.id, %{title: "#{marker} alpha report", number: "102"})
+      seed_story(tenant.id, %{title: "unrelated beta", number: "103"})
+
+      # POSITIVE CONTROL is the whole point of tenant-scoping: seed an
+      # IDENTICALLY-titled row in another tenant that must NEVER surface for
+      # `tenant`. If it did, a green result would mean "scoping regressed", not
+      # "scoping works".
+      seed_story(other.id, %{title: "#{marker} alpha report", number: "201"})
+
+      # 1) Define a `story` entity: title is BOTH filterable and searchable, so the
+      #    generator emits a filter tool AND a search tool.
+      created =
+        fresh_conn()
+        |> auth(user)
+        |> post(~p"/api/v1/entities", %{
+          "name" => "story",
+          "backing_source" => "stories",
+          "fields" => [
+            %{"name" => "title", "type" => "string", "filterable" => true, "searchable" => true},
+            %{"name" => "number", "type" => "string", "filterable" => true, "searchable" => false}
+          ]
+        })
+
+      assert %{"data" => %{"name" => "story"}} = json_response(created, 201)
+
+      # 2) BOTH generated tools appear via GET /retrieve/tools (agent key).
+      tools_resp = fresh_conn() |> auth(agent) |> get(~p"/api/v1/retrieve/tools")
+      %{"data" => specs} = json_response(tools_resp, 200)
+      spec_names = Enum.map(specs, & &1["name"])
+
+      assert "cr_filter_story_by_title" in spec_names
+      assert "cr_search_story" in spec_names
+
+      filter_spec = Enum.find(specs, &(&1["name"] == "cr_filter_story_by_title"))
+      search_spec = Enum.find(specs, &(&1["name"] == "cr_search_story"))
+
+      # 3a) FILTER via the DIRECT API body.
+      api_filter =
+        fresh_conn()
+        |> auth(agent)
+        |> post(~p"/api/v1/retrieve/story", %{
+          "op" => "filter",
+          "field" => "title",
+          "value" => "#{marker} alpha report"
+        })
+
+      %{"results" => api_filter_results, "meta" => api_filter_meta} =
+        json_response(api_filter, 200)
+
+      # 3b) FILTER via the MCP-DERIVED body (from the returned spec + the field-named arg).
+      mcp_filter_body = mcp_body_from_spec(filter_spec, %{"title" => "#{marker} alpha report"})
+
+      mcp_filter =
+        fresh_conn() |> auth(agent) |> post(~p"/api/v1/retrieve/story", mcp_filter_body)
+
+      %{"results" => mcp_filter_results} = json_response(mcp_filter, 200)
+
+      # API and MCP agree, and the set is tenant-scoped (2 rows for `tenant`, NOT
+      # the identically-titled `other`-tenant row).
+      assert api_filter_meta["total_count"] == 2
+      assert length(api_filter_results) == 2
+      assert api_filter_results == mcp_filter_results
+      assert Enum.all?(api_filter_results, &(&1["title"] == "#{marker} alpha report"))
+      # Numbers are the caller tenant's, never 201 (the other tenant's row).
+      assert Enum.sort(Enum.map(api_filter_results, & &1["number"])) == ["101", "102"]
+      # Shaped to declared columns only — never tenant_id.
+      refute Enum.any?(api_filter_results, &Map.has_key?(&1, "tenant_id"))
+
+      # 4a) SEARCH via the DIRECT API body.
+      api_search =
+        fresh_conn()
+        |> auth(agent)
+        |> post(~p"/api/v1/retrieve/story", %{"op" => "search", "query" => marker})
+
+      %{"results" => api_search_results, "meta" => api_search_meta} =
+        json_response(api_search, 200)
+
+      # 4b) SEARCH via the MCP-DERIVED body.
+      mcp_search_body = mcp_body_from_spec(search_spec, %{"query" => marker})
+
+      mcp_search =
+        fresh_conn() |> auth(agent) |> post(~p"/api/v1/retrieve/story", mcp_search_body)
+
+      %{"results" => mcp_search_results} = json_response(mcp_search, 200)
+
+      # Search finds the caller tenant's two matching stories (title contains the
+      # marker), agrees across API + MCP, and never returns the other tenant's row.
+      assert api_search_meta["total_count"] == 2
+      assert api_search_results == mcp_search_results
+
+      numbers = api_search_results |> Enum.map(& &1["number"]) |> Enum.sort()
+      assert numbers == ["101", "102"]
+      refute Enum.any?(api_search_results, &(&1["number"] == "201"))
+    end
+  end
+end

--- a/test/e2e/context_retriever_security_test.exs
+++ b/test/e2e/context_retriever_security_test.exs
@@ -11,7 +11,11 @@ defmodule Loopctl.E2E.ContextRetrieverSecurityTest do
     (b) a non-allowlisted field is rejected on EVERY surface (define-time AND
         execute-time);
     (c) cross-tenant define/list/query isolation via context, API, and the
-        MCP-equivalent tool-listing/dispatch surface — with a positive control;
+        MCP-equivalent tool-listing/dispatch surface — covering BOTH entity-
+        DEFINITION isolation (B's key 404s on A's entity name) AND ROW-LEVEL
+        scoping (B defines its own identically-named entity over the same backing
+        source, yet a filter for A's title returns none of A's rows), each with a
+        positive control;
     (d) no undeclared column leaks (only declared fields returned);
     (e) an `audit_log` record exists per `/retrieve` execution;
     (f) `/retrieve` is rate-limited (429, unexecuted).
@@ -247,6 +251,7 @@ defmodule Loopctl.E2E.ContextRetrieverSecurityTest do
       tenant_b = commit_tenant()
       user_a = user_key(tenant_a.id)
       agent_a = agent_key(tenant_a.id)
+      user_b = user_key(tenant_b.id)
       agent_b = agent_key(tenant_b.id)
 
       %{"data" => %{"id" => entity_id}} = define_story_entity(user_a)
@@ -296,6 +301,49 @@ defmodule Loopctl.E2E.ContextRetrieverSecurityTest do
         })
 
       assert json_response(cross, 404)
+
+      # ISOLATION — ROW-LEVEL scoping (the 404 above only proves entity-DEFINITION
+      # isolation; it short-circuits on `unknown_entity` BEFORE the executor's RLS
+      # + `where tenant_id == scope.tenant_id` row filter runs). So B now defines
+      # its OWN identically-named `story` entity over the SAME `stories` backing
+      # source and seeds its own row. With the entity resolvable for B, a filter
+      # for A's title must exercise — and be stopped by — the row predicate, not
+      # entity resolution.
+      %{"data" => %{"id" => entity_id_b}} = define_story_entity(user_b)
+      # B's entity is genuinely B's, not a view onto A's definition.
+      refute entity_id_b == entity_id
+      seed_story(tenant_b.id, %{title: "TenantB own story", number: "301"})
+
+      # POSITIVE CONTROL — B's own row is retrievable through B's entity, so the
+      # empty A-title result below means "A's rows are RLS-scoped out", not
+      # "B's executor path is broken / matches nothing".
+      b_own =
+        fresh_conn()
+        |> auth(agent_b)
+        |> post(~p"/api/v1/retrieve/story", %{
+          "op" => "filter",
+          "field" => "title",
+          "value" => "TenantB own story"
+        })
+
+      assert %{"results" => [%{"number" => "301"}], "meta" => %{"total_count" => 1}} =
+               json_response(b_own, 200)
+
+      # ROW SCOPING — B filters for A's exact title against an identically-named
+      # entity over the same table: A's row (number 101) is NOT returned. This
+      # directly proves RLS + the explicit tenant_id predicate deny B a peer
+      # tenant's ROWS, independent of entity-definition isolation.
+      b_cross_rows =
+        fresh_conn()
+        |> auth(agent_b)
+        |> post(~p"/api/v1/retrieve/story", %{
+          "op" => "filter",
+          "field" => "title",
+          "value" => "TenantA secret story"
+        })
+
+      assert %{"results" => [], "meta" => %{"total_count" => 0}} =
+               json_response(b_cross_rows, 200)
     end
   end
 

--- a/test/e2e/context_retriever_security_test.exs
+++ b/test/e2e/context_retriever_security_test.exs
@@ -1,0 +1,441 @@
+defmodule Loopctl.E2E.ContextRetrieverSecurityTest do
+  @moduledoc """
+  US-30.7 (TC-30.7.2) — TERMINAL, epic-wide security suite for the Epic 30 Context
+  Retriever. Proves the six AC-30.7.4 properties end-to-end across API + MCP +
+  context, run under the NON-owner `loopctl_app` app role (RLS is ENABLE, not
+  FORCE, so isolation assertions genuinely prove isolation):
+
+    (a) injection payloads in BOTH a filter value AND a search query match
+        literally (no SQL execution) — with a positive control proving the value
+        is genuinely matchable;
+    (b) a non-allowlisted field is rejected on EVERY surface (define-time AND
+        execute-time);
+    (c) cross-tenant define/list/query isolation via context, API, and the
+        MCP-equivalent tool-listing/dispatch surface — with a positive control;
+    (d) no undeclared column leaks (only declared fields returned);
+    (e) an `audit_log` record exists per `/retrieve` execution;
+    (f) `/retrieve` is rate-limited (429, unexecuted).
+
+  Excluded from the default suite (`@moduletag :e2e`); run with `mix test.e2e`.
+
+  ## Why `async: false` + a COMMITTED tenant
+
+  Same as `context_retriever_journey_test.exs` / `context_retriever_controller_test.exs`:
+  the executor reads backing rows via `Loopctl.Repo.with_tenant/2` (RLS + `SET
+  LOCAL ROLE loopctl_app`) on the Repo connection while auth resolves via
+  AdminRepo — two sandbox connections. The tenant must be committed (visible to
+  both) so it is inserted via `Sandbox.unboxed_run/2` and swept by a slug marker at
+  module boundaries.
+  """
+  use LoopctlWeb.ConnCase, async: false
+
+  @moduletag :e2e
+
+  setup :verify_on_exit!
+
+  import Ecto.Query
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Loopctl.AdminRepo
+  alias Loopctl.Audit.AuditLog
+  alias Loopctl.ContextRetriever.Registry
+  alias Loopctl.Projects.Project
+  alias Loopctl.Repo
+  alias Loopctl.Tenants.Tenant
+  alias Loopctl.WorkBreakdown.Epic
+  alias Loopctl.WorkBreakdown.Story
+
+  @tenant_marker "crsec-"
+
+  setup_all do
+    sweep_marker_tenants()
+    on_exit(&sweep_marker_tenants/0)
+    :ok
+  end
+
+  defp sweep_marker_tenants do
+    Sandbox.unboxed_run(AdminRepo, fn ->
+      AdminRepo.delete_all(from(t in Tenant, where: like(t.slug, ^"#{@tenant_marker}%")))
+    end)
+  end
+
+  defp commit_tenant do
+    seq = System.unique_integer([:positive])
+    id = Ecto.UUID.generate()
+
+    Sandbox.unboxed_run(AdminRepo, fn ->
+      %Tenant{}
+      |> Tenant.create_changeset(%{
+        name: "T#{seq}",
+        slug: "#{@tenant_marker}#{seq}",
+        email: "#{@tenant_marker}#{seq}@example.com"
+      })
+      |> Ecto.Changeset.put_change(:id, id)
+      |> Ecto.Changeset.put_change(:trust_tier, :human_anchored)
+      |> AdminRepo.insert!()
+    end)
+
+    AdminRepo.get!(Tenant, id)
+  end
+
+  defp user_key(tenant_id) do
+    {raw, _key} = fixture(:api_key, %{tenant_id: tenant_id, role: :user})
+    raw
+  end
+
+  defp agent_key(tenant_id) do
+    agent = fixture(:agent, %{tenant_id: tenant_id})
+    {raw, _key} = fixture(:api_key, %{tenant_id: tenant_id, role: :agent, agent_id: agent.id})
+    raw
+  end
+
+  defp seed_project(tenant_id, attrs \\ %{}) do
+    %Project{tenant_id: tenant_id}
+    |> Project.create_changeset(build(:project, attrs))
+    |> Repo.insert!()
+  end
+
+  defp seed_epic(tenant_id, project_id) do
+    %Epic{tenant_id: tenant_id, project_id: project_id}
+    |> Epic.create_changeset(build(:epic, %{}))
+    |> Repo.insert!()
+  end
+
+  defp seed_story(tenant_id, attrs) do
+    project = seed_project(tenant_id)
+    epic = seed_epic(tenant_id, project.id)
+
+    %Story{tenant_id: tenant_id, project_id: project.id, epic_id: epic.id}
+    |> Story.create_changeset(build(:story, attrs))
+    |> Repo.insert!()
+  end
+
+  defp auth(conn, raw_key), do: put_req_header(conn, "authorization", "Bearer #{raw_key}")
+
+  defp fresh_conn,
+    do: put_req_header(build_conn(), "x-loopctl-last-known-sth", "0:AAAAAAAAAAAAAAAAAAAAAA")
+
+  # A `story` entity: title (filterable + searchable), number (filterable).
+  defp define_story_entity(user_key) do
+    resp =
+      fresh_conn()
+      |> auth(user_key)
+      |> post(~p"/api/v1/entities", %{
+        "name" => "story",
+        "backing_source" => "stories",
+        "fields" => [
+          %{"name" => "title", "type" => "string", "filterable" => true, "searchable" => true},
+          %{"name" => "number", "type" => "string", "filterable" => true, "searchable" => false}
+        ]
+      })
+
+    json_response(resp, 201)
+  end
+
+  defp context_audits(tenant_id) do
+    AdminRepo.all(
+      from a in AuditLog,
+        where: a.tenant_id == ^tenant_id and a.entity_type == "context_retrieval"
+    )
+  end
+
+  # --- (a) injection in filter + search matches literally ---
+
+  describe "AC-30.7.4a: injection payloads (filter + search) match literally, no SQL" do
+    test "a filter injection value and a search injection query both match nothing; legit values match",
+         %{conn: _conn} do
+      tenant = commit_tenant()
+      user = user_key(tenant.id)
+      agent = agent_key(tenant.id)
+
+      marker = "zqinj#{System.unique_integer([:positive])}"
+      seed_story(tenant.id, %{title: "#{marker} legitimate story", number: "101"})
+      define_story_entity(user)
+
+      # POSITIVE CONTROL: the legit value genuinely matches — so a 0-row injection
+      # result below means "injection was neutralized", not "filter matches nothing".
+      legit =
+        fresh_conn()
+        |> auth(agent)
+        |> post(~p"/api/v1/retrieve/story", %{
+          "op" => "filter",
+          "field" => "title",
+          "value" => "#{marker} legitimate story"
+        })
+
+      assert %{"results" => [_one], "meta" => %{"total_count" => 1}} = json_response(legit, 200)
+
+      # Injection in a FILTER value → literal, matches nothing, no SQL error.
+      filter_inj =
+        fresh_conn()
+        |> auth(agent)
+        |> post(~p"/api/v1/retrieve/story", %{
+          "op" => "filter",
+          "field" => "title",
+          "value" => "' OR 1=1 --"
+        })
+
+      assert %{"results" => [], "meta" => %{"total_count" => 0}} = json_response(filter_inj, 200)
+
+      # Injection in a SEARCH query → literal tsquery term, matches nothing, and
+      # the table is NOT dropped.
+      search_inj =
+        fresh_conn()
+        |> auth(agent)
+        |> post(~p"/api/v1/retrieve/story", %{
+          "op" => "search",
+          "query" => "'; DROP TABLE stories; --"
+        })
+
+      assert %{"results" => [], "meta" => %{"total_count" => 0}} = json_response(search_inj, 200)
+
+      # The stories table still exists and is queryable — the payload was a literal.
+      assert Repo.aggregate(from(s in Story), :count, :id) >= 0
+    end
+  end
+
+  # --- (b) non-allowlisted field rejected on every surface ---
+
+  describe "AC-30.7.4b: non-allowlisted field rejected on every surface" do
+    test "define-time: declaring a non-allowlisted column is 422", %{conn: _conn} do
+      tenant = commit_tenant()
+      user = user_key(tenant.id)
+
+      # `tenant_id` is a real column but DELIBERATELY excluded from the server
+      # allowlist — declaring it must be rejected at create time (422), never
+      # persisted into a security-root entity definition.
+      resp =
+        fresh_conn()
+        |> auth(user)
+        |> post(~p"/api/v1/entities", %{
+          "name" => "leaky",
+          "backing_source" => "stories",
+          "fields" => [
+            %{
+              "name" => "tenant_id",
+              "type" => "string",
+              "filterable" => true,
+              "searchable" => false
+            }
+          ]
+        })
+
+      assert json_response(resp, 422)
+    end
+
+    test "execute-time: a declared-but-non-filterable field, and an undeclared field, are 422",
+         %{conn: _conn} do
+      tenant = commit_tenant()
+      user = user_key(tenant.id)
+      agent = agent_key(tenant.id)
+
+      seed_story(tenant.id, %{title: "Anything", number: "101"})
+
+      # description declared searchable-only (filterable: false).
+      fresh_conn()
+      |> auth(user)
+      |> post(~p"/api/v1/entities", %{
+        "name" => "story",
+        "backing_source" => "stories",
+        "fields" => [
+          %{"name" => "title", "type" => "string", "filterable" => true, "searchable" => true},
+          %{
+            "name" => "description",
+            "type" => "string",
+            "filterable" => false,
+            "searchable" => true
+          }
+        ]
+      })
+      |> json_response(201)
+
+      # A raw op:filter naming `description` (declared, not filterable) → 422,
+      # never executed (the execute-time allowlist re-check closes the raw-/retrieve
+      # bypass).
+      non_filterable =
+        fresh_conn()
+        |> auth(agent)
+        |> post(~p"/api/v1/retrieve/story", %{
+          "op" => "filter",
+          "field" => "description",
+          "value" => "x"
+        })
+
+      assert %{"error" => %{"code" => "field_not_allowlisted"}} =
+               json_response(non_filterable, 422)
+
+      # A field the entity never declares (`agent_status`, a real allowlisted
+      # column) is rejected the same way.
+      undeclared =
+        fresh_conn()
+        |> auth(agent)
+        |> post(~p"/api/v1/retrieve/story", %{
+          "op" => "filter",
+          "field" => "agent_status",
+          "value" => "pending"
+        })
+
+      assert %{"error" => %{"code" => "field_not_allowlisted"}} = json_response(undeclared, 422)
+    end
+  end
+
+  # --- (c) cross-tenant isolation via context, API, MCP ---
+
+  describe "AC-30.7.4c: cross-tenant define/list/query isolation (context + API + MCP)" do
+    test "tenant B sees none of tenant A's entity or rows on any surface; A sees its own",
+         %{conn: _conn} do
+      tenant_a = commit_tenant()
+      tenant_b = commit_tenant()
+      user_a = user_key(tenant_a.id)
+      agent_a = agent_key(tenant_a.id)
+      agent_b = agent_key(tenant_b.id)
+
+      %{"data" => %{"id" => entity_id}} = define_story_entity(user_a)
+      seed_story(tenant_a.id, %{title: "TenantA secret story", number: "101"})
+
+      # POSITIVE CONTROL — tenant A's own key sees its entity + rows, so a green
+      # isolation result below means "isolation works", not "everything is empty".
+      tools_a = fresh_conn() |> auth(agent_a) |> get(~p"/api/v1/retrieve/tools")
+      names_a = json_response(tools_a, 200)["data"] |> Enum.map(& &1["name"])
+      assert "cr_filter_story_by_title" in names_a
+
+      own =
+        fresh_conn()
+        |> auth(agent_a)
+        |> post(~p"/api/v1/retrieve/story", %{
+          "op" => "filter",
+          "field" => "title",
+          "value" => "TenantA secret story"
+        })
+
+      assert %{"meta" => %{"total_count" => 1}} = json_response(own, 200)
+
+      # ISOLATION — CONTEXT path: tenant B cannot read A's entity by id, and A's
+      # entity is absent from B's listing.
+      assert Registry.get_entity_by_id(tenant_b.id, entity_id) == nil
+      refute Enum.any?(Registry.for_tenant(tenant_b.id), &(&1.id == entity_id))
+
+      # ISOLATION — API path: B's GET /entities does not include A's entity.
+      b_entities = fresh_conn() |> auth(agent_b) |> get(~p"/api/v1/entities")
+      b_ids = json_response(b_entities, 200)["data"] |> Enum.map(& &1["id"])
+      refute entity_id in b_ids
+
+      # ISOLATION — MCP-equivalent path: B's tool listing (what its MCP client
+      # fetches) sees none of A's generated tools...
+      tools_b = fresh_conn() |> auth(agent_b) |> get(~p"/api/v1/retrieve/tools")
+      assert %{"data" => []} = json_response(tools_b, 200)
+
+      # ...and dispatching A's entity name as B's key is an unknown entity (404),
+      # never A's rows.
+      cross =
+        fresh_conn()
+        |> auth(agent_b)
+        |> post(~p"/api/v1/retrieve/story", %{
+          "op" => "filter",
+          "field" => "title",
+          "value" => "TenantA secret story"
+        })
+
+      assert json_response(cross, 404)
+    end
+  end
+
+  # --- (d) no undeclared column leaks ---
+
+  describe "AC-30.7.4d: only declared columns are returned" do
+    test "results carry only declared fields — never tenant_id/metadata/custody columns",
+         %{conn: _conn} do
+      tenant = commit_tenant()
+      user = user_key(tenant.id)
+      agent = agent_key(tenant.id)
+
+      seed_story(tenant.id, %{title: "Shaped story", number: "101"})
+      define_story_entity(user)
+
+      resp =
+        fresh_conn()
+        |> auth(agent)
+        |> post(~p"/api/v1/retrieve/story", %{
+          "op" => "filter",
+          "field" => "title",
+          "value" => "Shaped story"
+        })
+
+      %{"results" => [row]} = json_response(resp, 200)
+
+      # Exactly the two declared columns, nothing more.
+      assert Map.keys(row) |> Enum.sort() == ["number", "title"]
+      refute Map.has_key?(row, "tenant_id")
+      refute Map.has_key?(row, "metadata")
+      refute Map.has_key?(row, "id")
+    end
+  end
+
+  # --- (e) an audit record per execution ---
+
+  describe "AC-30.7.4e: every /retrieve execution writes an audit record" do
+    test "a successful filter execution appends a context_retrieval audit row",
+         %{conn: _conn} do
+      tenant = commit_tenant()
+      user = user_key(tenant.id)
+      agent = agent_key(tenant.id)
+
+      seed_story(tenant.id, %{title: "Audited story", number: "101"})
+      define_story_entity(user)
+
+      assert context_audits(tenant.id) == []
+
+      resp =
+        fresh_conn()
+        |> auth(agent)
+        |> post(~p"/api/v1/retrieve/story", %{
+          "op" => "filter",
+          "field" => "title",
+          "value" => "Audited story"
+        })
+
+      assert json_response(resp, 200)
+
+      assert [audit] = context_audits(tenant.id)
+      assert audit.entity_type == "context_retrieval"
+      assert audit.action == "filter"
+      assert audit.metadata["entity"] == "story"
+      assert audit.metadata["field"] == "title"
+      assert audit.metadata["row_count"] == 1
+      # Raw filter value is never stored (only a digest).
+      refute audit.metadata["param_digest"] =~ "Audited story"
+    end
+  end
+
+  # --- (f) rate limited ---
+
+  describe "AC-30.7.4f: /retrieve is rate-limited" do
+    test "over the per-tenant limit returns 429 and does not execute", %{conn: _conn} do
+      tenant = commit_tenant()
+      user = user_key(tenant.id)
+      agent = agent_key(tenant.id)
+
+      seed_story(tenant.id, %{title: "RateLimited", number: "101"})
+      define_story_entity(user)
+
+      # Force the per-tenant bucket over-limit (config-based DI mock; no put_env).
+      Mox.stub(Loopctl.MockRateLimiter, :check_rate, fn _bucket, _window, _limit ->
+        {:deny, 999}
+      end)
+
+      resp =
+        fresh_conn()
+        |> auth(agent)
+        |> post(~p"/api/v1/retrieve/story", %{
+          "op" => "filter",
+          "field" => "title",
+          "value" => "RateLimited"
+        })
+
+      assert json_response(resp, 429)
+
+      # Over-limit did NOT execute → no audit row was written.
+      assert context_audits(tenant.id) == []
+    end
+  end
+end

--- a/test/e2e/context_retriever_security_test.exs
+++ b/test/e2e/context_retriever_security_test.exs
@@ -34,86 +34,27 @@ defmodule Loopctl.E2E.ContextRetrieverSecurityTest do
   setup :verify_on_exit!
 
   import Ecto.Query
+  import Loopctl.ContextRetrieverE2EHelpers
 
-  alias Ecto.Adapters.SQL.Sandbox
   alias Loopctl.AdminRepo
   alias Loopctl.Audit.AuditLog
   alias Loopctl.ContextRetriever.Registry
-  alias Loopctl.Projects.Project
   alias Loopctl.Repo
-  alias Loopctl.Tenants.Tenant
-  alias Loopctl.WorkBreakdown.Epic
   alias Loopctl.WorkBreakdown.Story
 
   @tenant_marker "crsec-"
 
   setup_all do
-    sweep_marker_tenants()
-    on_exit(&sweep_marker_tenants/0)
+    sweep_marker_tenants(@tenant_marker)
+    on_exit(fn -> sweep_marker_tenants(@tenant_marker) end)
     :ok
   end
 
-  defp sweep_marker_tenants do
-    Sandbox.unboxed_run(AdminRepo, fn ->
-      AdminRepo.delete_all(from(t in Tenant, where: like(t.slug, ^"#{@tenant_marker}%")))
-    end)
-  end
-
-  defp commit_tenant do
-    seq = System.unique_integer([:positive])
-    id = Ecto.UUID.generate()
-
-    Sandbox.unboxed_run(AdminRepo, fn ->
-      %Tenant{}
-      |> Tenant.create_changeset(%{
-        name: "T#{seq}",
-        slug: "#{@tenant_marker}#{seq}",
-        email: "#{@tenant_marker}#{seq}@example.com"
-      })
-      |> Ecto.Changeset.put_change(:id, id)
-      |> Ecto.Changeset.put_change(:trust_tier, :human_anchored)
-      |> AdminRepo.insert!()
-    end)
-
-    AdminRepo.get!(Tenant, id)
-  end
-
-  defp user_key(tenant_id) do
-    {raw, _key} = fixture(:api_key, %{tenant_id: tenant_id, role: :user})
-    raw
-  end
-
-  defp agent_key(tenant_id) do
-    agent = fixture(:agent, %{tenant_id: tenant_id})
-    {raw, _key} = fixture(:api_key, %{tenant_id: tenant_id, role: :agent, agent_id: agent.id})
-    raw
-  end
-
-  defp seed_project(tenant_id, attrs \\ %{}) do
-    %Project{tenant_id: tenant_id}
-    |> Project.create_changeset(build(:project, attrs))
-    |> Repo.insert!()
-  end
-
-  defp seed_epic(tenant_id, project_id) do
-    %Epic{tenant_id: tenant_id, project_id: project_id}
-    |> Epic.create_changeset(build(:epic, %{}))
-    |> Repo.insert!()
-  end
-
-  defp seed_story(tenant_id, attrs) do
-    project = seed_project(tenant_id)
-    epic = seed_epic(tenant_id, project.id)
-
-    %Story{tenant_id: tenant_id, project_id: project.id, epic_id: epic.id}
-    |> Story.create_changeset(build(:story, attrs))
-    |> Repo.insert!()
-  end
-
-  defp auth(conn, raw_key), do: put_req_header(conn, "authorization", "Bearer #{raw_key}")
-
-  defp fresh_conn,
-    do: put_req_header(build_conn(), "x-loopctl-last-known-sth", "0:AAAAAAAAAAAAAAAAAAAAAA")
+  # The committed-tenant scaffolding (sweep, commit_tenant, *_key, seed_*, auth,
+  # fresh_conn) is single-sourced in `Loopctl.ContextRetrieverE2EHelpers` so its
+  # security-critical semantics stay identical to the journey suite. Only the
+  # per-suite slug marker differs.
+  defp commit_tenant, do: commit_tenant(@tenant_marker)
 
   # A `story` entity: title (filterable + searchable), number (filterable).
   defp define_story_entity(user_key) do
@@ -177,6 +118,17 @@ defmodule Loopctl.E2E.ContextRetrieverSecurityTest do
 
       assert %{"results" => [], "meta" => %{"total_count" => 0}} = json_response(filter_inj, 200)
 
+      # POSITIVE CONTROL for SEARCH: the seeded marker is genuinely searchable
+      # (title is a searchable field), so the 0-row injection search below means
+      # "injection was neutralized", not "search matches nothing / is broken".
+      legit_search =
+        fresh_conn()
+        |> auth(agent)
+        |> post(~p"/api/v1/retrieve/story", %{"op" => "search", "query" => marker})
+
+      assert %{"results" => [_one], "meta" => %{"total_count" => 1}} =
+               json_response(legit_search, 200)
+
       # Injection in a SEARCH query → literal tsquery term, matches nothing, and
       # the table is NOT dropped.
       search_inj =
@@ -189,8 +141,15 @@ defmodule Loopctl.E2E.ContextRetrieverSecurityTest do
 
       assert %{"results" => [], "meta" => %{"total_count" => 0}} = json_response(search_inj, 200)
 
-      # The stories table still exists and is queryable — the payload was a literal.
-      assert Repo.aggregate(from(s in Story), :count, :id) >= 0
+      # The stories table still exists (a DROP would make this raise). Count is
+      # tenant-scoped via Repo.with_tenant/2 so RLS (ENABLE, loopctl_app role)
+      # cannot legitimately hide the row: our seeded story survives the payload.
+      assert {:ok, story_count} =
+               Repo.with_tenant(tenant.id, fn ->
+                 Repo.aggregate(from(s in Story), :count, :id)
+               end)
+
+      assert story_count >= 1
     end
   end
 

--- a/test/support/context_retriever_e2e_helpers.ex
+++ b/test/support/context_retriever_e2e_helpers.ex
@@ -15,10 +15,25 @@ defmodule Loopctl.ContextRetrieverE2EHelpers do
     * seeding backing rows on the `Loopctl.Repo` connection the RLS-scoped
       executor (`Repo.with_tenant/2`, `SET LOCAL ROLE loopctl_app`) reads.
 
-  The `marker` argument to `sweep_marker_tenants/1` and `commit_tenant/1` is the
+  The `base` argument to `sweep_marker_tenants/1` and `commit_tenant/1` is the
   per-suite slug prefix (e.g. `"crjourney-"`, `"crsec-"`) so each suite's
-  committed tenants are swept independently. See either suite's moduledoc for
-  WHY a committed tenant + `async: false` are required.
+  committed tenants are swept independently. Internally each base is narrowed to
+  a PER-RUN marker (`base <> run_nonce <> "-"`, see `run_marker/1`) so the
+  BYPASSRLS sweep only ever deletes tenants THIS run created. See either suite's
+  moduledoc for WHY a committed tenant + `async: false` are required.
+
+  ## Why the sweep is run-scoped (not just prefix-scoped)
+
+  `sweep_marker_tenants/1` runs `AdminRepo.delete_all` (BYPASSRLS) over COMMITTED
+  tenants at each suite's `setup_all`/`on_exit`. A static prefix (`"crsec-%"`)
+  is safe within ONE run — the e2e suites are `async: false` and per-tenant slugs
+  carry a `System.unique_integer` suffix — but NOT across two runs sharing one
+  physical Postgres (parallel CI jobs, or a dev running e2e while CI does): one
+  run's `setup_all` sweep would delete the other run's live tenants mid-flight,
+  orphaning committed api_keys/agents/stories into FK-failure flakiness. Narrowing
+  the marker to `run_marker/1` (the BEAM's OS pid — stable within a `mix test`
+  run, distinct across concurrent runs) confines every sweep to the tenants the
+  current run committed.
   """
 
   import Ecto.Query
@@ -34,8 +49,20 @@ defmodule Loopctl.ContextRetrieverE2EHelpers do
   alias Loopctl.WorkBreakdown.Epic
   alias Loopctl.WorkBreakdown.Story
 
-  @doc "Deletes every committed tenant whose slug starts with `marker` (module-boundary cleanup)."
-  def sweep_marker_tenants(marker) do
+  @doc """
+  Narrows a per-suite slug `base` (e.g. `"crsec-"`) to a PER-RUN marker
+  (`base <> os_pid <> "-"`). `System.pid/0` is the BEAM's OS process id: one per
+  `mix test` invocation (shared by every suite in that run) and distinct across
+  concurrent runs sharing a physical Postgres — so the BYPASSRLS sweep never
+  clobbers another run's live committed tenants. The pid is digits-only, keeping
+  the slug within `Tenant`'s `^[a-z0-9][a-z0-9-]*[a-z0-9]$` / 63-char rules.
+  """
+  def run_marker(base), do: "#{base}#{System.pid()}-"
+
+  @doc "Deletes every committed tenant this RUN created under `base` (module-boundary cleanup)."
+  def sweep_marker_tenants(base) do
+    marker = run_marker(base)
+
     Sandbox.unboxed_run(AdminRepo, fn ->
       AdminRepo.delete_all(from(t in Tenant, where: like(t.slug, ^"#{marker}%")))
     end)
@@ -43,11 +70,12 @@ defmodule Loopctl.ContextRetrieverE2EHelpers do
 
   @doc """
   Inserts a committed, human-anchored tenant visible to BOTH the AdminRepo auth
-  path and the Repo executor path. Slug is prefixed with `marker` so it is swept
-  at module boundaries.
+  path and the Repo executor path. Slug carries the per-run marker (`base` scoped
+  by `run_marker/1`) so it is swept only by THIS run's `sweep_marker_tenants/1`.
   """
-  def commit_tenant(marker) do
+  def commit_tenant(base) do
     seq = System.unique_integer([:positive])
+    marker = run_marker(base)
     id = Ecto.UUID.generate()
 
     Sandbox.unboxed_run(AdminRepo, fn ->

--- a/test/support/context_retriever_e2e_helpers.ex
+++ b/test/support/context_retriever_e2e_helpers.ex
@@ -1,0 +1,114 @@
+defmodule Loopctl.ContextRetrieverE2EHelpers do
+  @moduledoc """
+  Shared committed-tenant scaffolding for the Epic 30 Context Retriever
+  end-to-end suites (`test/e2e/context_retriever_journey_test.exs` and
+  `test/e2e/context_retriever_security_test.exs`).
+
+  These helpers single-source the SECURITY-CRITICAL setup those suites depend on
+  so its semantics cannot silently drift between them:
+
+    * the two-connection, cross-repo tenant visibility (the AdminRepo auth path
+      AND the `Loopctl.Repo` executor path must both see the tenant), which is
+      why the tenant is inserted via `Sandbox.unboxed_run/2` (a committed
+      connection) rather than the boxed sandbox;
+    * the slug-marker tenant sweep at module boundaries;
+    * seeding backing rows on the `Loopctl.Repo` connection the RLS-scoped
+      executor (`Repo.with_tenant/2`, `SET LOCAL ROLE loopctl_app`) reads.
+
+  The `marker` argument to `sweep_marker_tenants/1` and `commit_tenant/1` is the
+  per-suite slug prefix (e.g. `"crjourney-"`, `"crsec-"`) so each suite's
+  committed tenants are swept independently. See either suite's moduledoc for
+  WHY a committed tenant + `async: false` are required.
+  """
+
+  import Ecto.Query
+  import Loopctl.Fixtures
+  import Phoenix.ConnTest, only: [build_conn: 0]
+  import Plug.Conn, only: [put_req_header: 3]
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Loopctl.AdminRepo
+  alias Loopctl.Projects.Project
+  alias Loopctl.Repo
+  alias Loopctl.Tenants.Tenant
+  alias Loopctl.WorkBreakdown.Epic
+  alias Loopctl.WorkBreakdown.Story
+
+  @doc "Deletes every committed tenant whose slug starts with `marker` (module-boundary cleanup)."
+  def sweep_marker_tenants(marker) do
+    Sandbox.unboxed_run(AdminRepo, fn ->
+      AdminRepo.delete_all(from(t in Tenant, where: like(t.slug, ^"#{marker}%")))
+    end)
+  end
+
+  @doc """
+  Inserts a committed, human-anchored tenant visible to BOTH the AdminRepo auth
+  path and the Repo executor path. Slug is prefixed with `marker` so it is swept
+  at module boundaries.
+  """
+  def commit_tenant(marker) do
+    seq = System.unique_integer([:positive])
+    id = Ecto.UUID.generate()
+
+    Sandbox.unboxed_run(AdminRepo, fn ->
+      %Tenant{}
+      |> Tenant.create_changeset(%{
+        name: "T#{seq}",
+        slug: "#{marker}#{seq}",
+        email: "#{marker}#{seq}@example.com"
+      })
+      |> Ecto.Changeset.put_change(:id, id)
+      |> Ecto.Changeset.put_change(:trust_tier, :human_anchored)
+      |> AdminRepo.insert!()
+    end)
+
+    AdminRepo.get!(Tenant, id)
+  end
+
+  @doc "Returns a raw `:user`-role API key for `tenant_id`."
+  def user_key(tenant_id) do
+    {raw, _key} = fixture(:api_key, %{tenant_id: tenant_id, role: :user})
+    raw
+  end
+
+  @doc "Returns a raw `:agent`-role API key (with a backing agent) for `tenant_id`."
+  def agent_key(tenant_id) do
+    agent = fixture(:agent, %{tenant_id: tenant_id})
+    {raw, _key} = fixture(:api_key, %{tenant_id: tenant_id, role: :agent, agent_id: agent.id})
+    raw
+  end
+
+  @doc "Seeds a project on the Repo connection the executor reads."
+  def seed_project(tenant_id, attrs \\ %{}) do
+    %Project{tenant_id: tenant_id}
+    |> Project.create_changeset(build(:project, attrs))
+    |> Repo.insert!()
+  end
+
+  @doc "Seeds an epic under `project_id`."
+  def seed_epic(tenant_id, project_id) do
+    %Epic{tenant_id: tenant_id, project_id: project_id}
+    |> Epic.create_changeset(build(:epic, %{}))
+    |> Repo.insert!()
+  end
+
+  @doc "Seeds a story (auto-creating its parent project + epic) with `attrs`."
+  def seed_story(tenant_id, attrs) do
+    project = seed_project(tenant_id)
+    epic = seed_epic(tenant_id, project.id)
+
+    %Story{tenant_id: tenant_id, project_id: project.id, epic_id: epic.id}
+    |> Story.create_changeset(build(:story, attrs))
+    |> Repo.insert!()
+  end
+
+  @doc "Adds the `Authorization: Bearer <raw_key>` header to `conn`."
+  def auth(conn, raw_key), do: put_req_header(conn, "authorization", "Bearer #{raw_key}")
+
+  @doc """
+  A fresh conn carrying the witness STH header (each dispatched request needs its
+  own conn).
+  """
+  def fresh_conn,
+    do: put_req_header(build_conn(), "x-loopctl-last-known-sth", "0:AAAAAAAAAAAAAAAAAAAAAA")
+end


### PR DESCRIPTION
## US-30.7 — Context Retriever docs + terminal security verification (runs last)

Terminal story of Epic 30 (Context Retriever). US-30.1..30.6 already implement the entity registry, tool generator, executor, HTTP API, dynamic MCP listing, and dogfood. This story is verification + docs only — it does NOT change executor/controller/generator behavior; it PROVES and DOCUMENTS the security properties end-to-end.

### Docs (AC-30.7.1 / AC-30.7.2)
- New docs/context-retriever.md — entity to generator to executor architecture; the security model (server column allowlist, parameterization, dual tenant scoping + non-owner loopctl_app role, execute-time allowlist re-check, pagination/offset caps, audit fail-closed, rate limit, no model SQL); and the three-layer model (Knowledge Wiki vs Agent Memory vs Context Retriever). States loopctl is agent-native (no web UI); entity management is via API/MCP.
- README.md / CLAUDE.md / AGENTS.md — extended to a three-way retrieve_* vs knowledge_* vs memory_* decision guide (README capability + tool rows; CLAUDE.md "Epic 30" section; AGENTS.md three-way block). CHANGELOG.md — new [Unreleased] Epic 30 entry.
- Notes the #309 "reconcile docs/cole-medin-self-evolving-wiki.md" item is already satisfied (removed PR #310; content in KB hub fb9abd73) and the epic folder is epic_30.
- swaggerui: the CR endpoints already render — confirmed by the existing openapi_test.exs (asserts /api/v1/entities, /entities/{id}, /retrieve/tools, /retrieve/{entity}). No new operation specs needed.

### Tests
- test/e2e/context_retriever_journey_test.exs (TC-30.7.1) — define an entity (filterable + searchable field) via API (user key), both generated tools appear via GET /retrieve/tools (agent key), a FILTER and a SEARCH query via POST /retrieve/:entity using a direct-API body AND the MCP-client-derived body (mirroring buildRetrieveBody) return the SAME tenant-scoped set (with a cross-tenant positive control).
- test/e2e/context_retriever_security_test.exs (TC-30.7.2) — terminal suite for all six AC-30.7.4 properties under the non-owner app role: (a) injection in a filter value AND a search query match literally (positive control); (b) non-allowlisted field rejected define-time AND execute-time; (c) cross-tenant define/list/query isolation via context + API + MCP-equivalent (positive control); (d) only declared columns returned; (e) an audit record per execution; (f) /retrieve 429 over-limit.
- Both mirror the controller test's committed-tenant + async: false pattern (required: the executor reads backing rows via Repo.with_tenant on a different sandbox connection than the AdminRepo auth path). Tagged @moduletag :e2e.
- MCP JS ListTools+dispatch agreement already covered by mcp-server/test/context_retriever_tools.test.js (206 tests green).

### Verification
- mix test.e2e: 15 e2e tests, 0 failures (8 new + 7 existing journeys).
- cd mcp-server && npm test: 206 tests, 0 failures.
- mix precommit: compile clean, format clean, credo --strict clean, dialyzer passed, 4096 tests 0 failures.

Closes #309
