### PR TITLE
Curated-source identification: a GOVERNED (non-self-assignable) canonical marker + scope rules

### DIFF
--- a/docs/user_stories/epic_31_okf_rag_hybrid/README.md
+++ b/docs/user_stories/epic_31_okf_rag_hybrid/README.md
@@ -68,6 +68,39 @@ Unlike epics 28–30, this is a **resolution layer on top of existing code**: `k
 - **Deferred (v2, tracked):** #306's freshness/novelty index ranking is out of scope for v1 (noted
   here rather than silently dropped).
 
+## US-31.1 implementation notes (shipped)
+
+The "curated" marker was implemented as a **dedicated non-castable column**, not config.
+Round-1 review concluded a governed marker is required and that `metadata` is unsafe (it is
+cast freely by `Article.create_changeset/2`/`update_changeset/2`), so:
+
+- **Marker:** `articles.curated_at :utc_datetime_usec` (+ advisory `curated_by :string`),
+  added by `20260712010000_add_curated_marker_to_articles.exs`. Both are EXCLUDED from
+  `Article`'s `@cast_fields` and writable ONLY via `Article.curation_changeset/3` — the same
+  isolation technique as `:embedding`. An agent create/update that sets `curated_at`,
+  `curated_by`, or `metadata["curated"]` cannot self-promote (proven by tests).
+- **Governed writer:** `Loopctl.Knowledge.mark_curated/3` / `unmark_curated/3` — the ONLY
+  writers, each audited (`article.curated`/`article.uncurated`) and logged to the
+  `KbCuration` feed. Marking is a trust gate: any HTTP surface reaching it must be role-gated
+  at `:user`+ (the domain fn is the non-castable half; the role check is the transport half).
+  HTTP exposure is deferred to US-31.4.
+- **Pure predicate:** `Knowledge.curated?/1` — `status == :published AND curated_at != nil`,
+  no DB call (unit-testable on an in-memory struct). Category may be a filter, never
+  sufficient alone.
+- **Scoped listing:** `Knowledge.list_curated_sources/2` — tenant's own curated-published
+  UNION system-scoped curated-published, via the explicit
+  `where a.tenant_id == ^tenant_id or a.scope == :system` predicate on AdminRepo (never RLS).
+- **System vs tenant precedence (AC-31.1.3):** a system canonical (`scope: :system`,
+  `tenant_id` nil) MAY participate as curated, but a tenant's OWN curated article on the same
+  topic (case-insensitive title) WINS — the system one is suppressed from that tenant's
+  result and never overrides the tenant's fresher/own answer. System canonicals on topics the
+  tenant has not curated still participate. System articles never leak as another tenant's
+  private content (surfaced only via the explicit `or a.scope == :system` opt-in).
+- **Conflict exclusion (AC-31.1.4):** `Knowledge.authoritative_curated?/1` and
+  `list_curated_sources/2` exclude an article in an OPEN `:potential_conflict` (an
+  auto-generated conflict link with no `conflict_resolutions` row) — the pure `curated?/1`
+  stays marker+status only.
+
 ## Provenance
 
 Second Brain hub `820602df` (Cloud Codes — "Google OKF + RAG: The Ultimate AI Agent Architecture",

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -2333,6 +2333,325 @@ defmodule Loopctl.Knowledge do
     end
   end
 
+  # --- Curated sources (US-31.1) ---
+
+  @doc """
+  Pure predicate: is this article a GOVERNED "curated" (authoritative) source?
+
+  An article is curated **iff** it is `:published` AND carries the governed
+  curated marker (`curated_at` is set). The marker is writable ONLY via the
+  admin/curation-gated `mark_curated/3` path (it is absent from
+  `Article`'s cast fields) — so an agent CANNOT self-promote its own article to
+  authoritative merely by choosing a `:reference`/`:playbook` `category` or by
+  setting a `metadata` flag. Category may be used as an additional *filter* by
+  callers, but is never sufficient on its own.
+
+  This function is deliberately **pure** — it inspects only the struct, does no
+  DB call, and is unit-testable with an in-memory `%Article{}`. It knows only
+  `status` + marker. The heavier authoritativeness rules (excluding an article in
+  an OPEN `:potential_conflict`, and tenant-over-system precedence) live in
+  `list_curated_sources/2` / `authoritative_curated?/1`, which do the DB work.
+
+  ## System vs tenant scope (see also `list_curated_sources/2`)
+
+  A system-scoped canonical article (`scope: :system`, `tenant_id` nil) MAY be
+  curated and participate in the hybrid path. But a tenant's OWN curated article
+  on the same topic takes precedence — a system canonical never overrides a
+  tenant's fresher/own answer. System articles never leak as another tenant's
+  private content: they are only ever surfaced via the explicit
+  `or a.scope == :system` predicate in `list_curated_sources/2`.
+
+  ## Examples
+
+      iex> Knowledge.curated?(%Article{status: :published, curated_at: ~U[2026-07-10 00:00:00.000000Z]})
+      true
+
+      iex> Knowledge.curated?(%Article{status: :published, curated_at: nil})
+      false
+
+      iex> Knowledge.curated?(%Article{status: :draft, curated_at: ~U[2026-07-10 00:00:00.000000Z]})
+      false
+  """
+  @spec curated?(Article.t()) :: boolean()
+  def curated?(%Article{status: :published, curated_at: %DateTime{}}), do: true
+  def curated?(%Article{}), do: false
+
+  @doc """
+  Governed setter: marks an article as curated (authoritative).
+
+  This is the ONLY writer of the curated marker. It writes through the dedicated
+  `Article.curation_changeset/3` (the marker is NOT in the ordinary cast fields),
+  records an `article.curated` audit event, and appends a `KbCuration` feed entry.
+
+  Marking authoritative is a **trust gate** (the hybrid resolver, US-31.2, prefers
+  curated answers), so the HTTP surface that reaches this MUST be role-gated at
+  `:user` or above — do not expose it at `:agent`. The non-castable marker is the
+  domain-layer half of the gate; the role check is the transport half.
+
+  Marking is allowed regardless of the article's current status, but `curated?/1`
+  only reports `true` once the article is `:published`.
+
+  ## Parameters
+
+  - `tenant_id` -- the owning tenant UUID (pass `nil` for a `scope: :system` article)
+  - `article_id` -- the article UUID
+  - `opts` -- `:actor_id`, `:actor_label`, `:actor_type`, and `:at` (mark time)
+
+  ## Returns
+
+  - `{:ok, %Article{}}` on success
+  - `{:error, :not_found}` if not found / wrong tenant
+  - `{:error, %Ecto.Changeset{}}` on a write failure
+  """
+  @spec mark_curated(Ecto.UUID.t() | nil, Ecto.UUID.t(), keyword()) ::
+          {:ok, Article.t()} | {:error, :not_found} | {:error, Ecto.Changeset.t()}
+  def mark_curated(tenant_id, article_id, opts \\ []) do
+    at = Keyword.get(opts, :at) || DateTime.utc_now()
+    actor_label = Keyword.get(opts, :actor_label)
+    changeset_fun = fn article -> Article.curation_changeset(article, at, actor_label) end
+
+    write_curation(tenant_id, article_id, changeset_fun, "article.curated", opts)
+  end
+
+  @doc """
+  Governed setter: clears an article's curated marker (the inverse of `mark_curated/3`).
+
+  Reversible + audited, same governance as `mark_curated/3`. Returns the same shapes.
+  """
+  @spec unmark_curated(Ecto.UUID.t() | nil, Ecto.UUID.t(), keyword()) ::
+          {:ok, Article.t()} | {:error, :not_found} | {:error, Ecto.Changeset.t()}
+  def unmark_curated(tenant_id, article_id, opts \\ []) do
+    changeset_fun = fn article -> Article.curation_changeset(article, nil, nil) end
+    write_curation(tenant_id, article_id, changeset_fun, "article.uncurated", opts)
+  end
+
+  defp write_curation(tenant_id, article_id, changeset_fun, action, opts) do
+    actor_id = Keyword.get(opts, :actor_id)
+    actor_label = Keyword.get(opts, :actor_label)
+    actor_type = Keyword.get(opts, :actor_type, "api_key")
+
+    with {:ok, article} <- fetch_curatable_article(tenant_id, article_id) do
+      changeset = changeset_fun.(article)
+
+      multi =
+        Multi.new()
+        |> Multi.update(:article, changeset)
+        |> Audit.log_in_multi(:audit, fn %{article: updated} ->
+          %{
+            tenant_id: updated.tenant_id,
+            entity_type: "article",
+            entity_id: updated.id,
+            action: action,
+            actor_type: actor_type,
+            actor_id: actor_id,
+            actor_label: actor_label,
+            old_state: %{"curated_at" => marker_iso(article.curated_at)},
+            new_state: %{"curated_at" => marker_iso(updated.curated_at)}
+          }
+        end)
+
+      case AdminRepo.transaction(multi) do
+        {:ok, %{article: updated}} ->
+          KbCuration.record(
+            updated.tenant_id,
+            curation_kind(action),
+            curation_summary(action, updated),
+            refs: [updated.id],
+            actor: actor_label
+          )
+
+          {:ok, updated}
+
+        {:error, :article, changeset, _} ->
+          {:error, changeset}
+      end
+    end
+  end
+
+  defp marker_iso(nil), do: nil
+  defp marker_iso(%DateTime{} = dt), do: DateTime.to_iso8601(dt)
+
+  defp curation_kind("article.curated"), do: "curated"
+  defp curation_kind("article.uncurated"), do: "uncurated"
+
+  defp curation_summary("article.curated", article),
+    do: "Marked article #{article.id} (#{article.title}) as curated"
+
+  defp curation_summary("article.uncurated", article),
+    do: "Cleared curated marker on article #{article.id} (#{article.title})"
+
+  # Fetches an article for curation. A tenant article is scoped by tenant_id; a
+  # system article (tenant_id nil) is fetched by its system scope. Never crosses
+  # tenants — a wrong tenant_id resolves to :not_found.
+  defp fetch_curatable_article(nil, article_id) do
+    case AdminRepo.one(from(a in Article, where: a.id == ^article_id and a.scope == :system)) do
+      nil -> {:error, :not_found}
+      article -> {:ok, article}
+    end
+  end
+
+  defp fetch_curatable_article(tenant_id, article_id) when is_binary(tenant_id) do
+    case AdminRepo.one(
+           from(a in Article, where: a.id == ^article_id and a.tenant_id == ^tenant_id)
+         ) do
+      nil -> {:error, :not_found}
+      article -> {:ok, article}
+    end
+  end
+
+  @doc """
+  Lists the AUTHORITATIVE curated sources visible to a tenant.
+
+  Returns the tenant's OWN curated, published articles UNIONed with system-scoped
+  (`scope: :system`, `tenant_id` nil) curated, published articles — the set the
+  hybrid resolver (US-31.2) may prefer.
+
+  Governance / correctness rules baked in:
+
+    * **Explicit tenant predicate, never RLS.** Like every Knowledge read, this
+      runs on `AdminRepo` (BYPASSRLS) scoped by an explicit
+      `where a.tenant_id == ^tenant_id or a.scope == :system` — system articles
+      are opted in *only* by that `or`, and one tenant never sees another tenant's
+      private curated articles.
+    * **Only published + governed marker.** Drafts, archived, and superseded
+      articles are excluded (`curated?/1` semantics, enforced in SQL).
+    * **Open conflicts excluded (AC-31.1.4).** An article in an OPEN
+      `:potential_conflict` (an auto-generated conflict link with no
+      `conflict_resolutions` row) is NOT returned as authoritative — the conflict
+      must be surfaced/resolved first (ties to US-31.2 AC-31.2.6).
+    * **Tenant precedence (AC-31.1.3).** When a tenant's own curated article and a
+      system canonical share a topic (case-insensitive title), the tenant's own
+      wins and the system one is suppressed from the result — a system canonical
+      never overrides a tenant's own answer. System canonicals on topics the
+      tenant has NOT curated are still returned (they participate).
+
+  ## Options
+
+  - `:category` -- restrict to a single category atom
+  - `:include_system` -- set `false` to exclude system canonicals (default `true`)
+
+  Results are ordered tenant-own-first, then most-recently-updated.
+  """
+  @spec list_curated_sources(Ecto.UUID.t(), keyword()) :: [Article.t()]
+  def list_curated_sources(tenant_id, opts \\ []) when is_binary(tenant_id) do
+    include_system = Keyword.get(opts, :include_system, true)
+    category = Keyword.get(opts, :category)
+
+    scope_filter =
+      if include_system do
+        dynamic([a], a.tenant_id == ^tenant_id or a.scope == :system)
+      else
+        dynamic([a], a.tenant_id == ^tenant_id)
+      end
+
+    base =
+      from(a in Article,
+        as: :article,
+        where: a.status == :published,
+        where: not is_nil(a.curated_at),
+        where: ^scope_filter,
+        # AC-31.1.4: never surface an article that is in an OPEN potential_conflict.
+        where: not exists(open_conflict_subquery()),
+        order_by: [desc: a.updated_at, asc: a.id]
+      )
+
+    base =
+      case category do
+        nil -> base
+        cat -> from(a in base, where: a.category == ^cat)
+      end
+
+    base
+    |> AdminRepo.all()
+    |> apply_tenant_precedence(tenant_id)
+  end
+
+  # Subquery correlated on the outer :article binding: TRUE when the article is a
+  # member of an auto-generated :potential_conflict pair that has NOT yet been
+  # resolved (no conflict_resolutions row either direction). Mirrors the open-conflict
+  # definition in list_potential_conflicts/2.
+  defp open_conflict_subquery do
+    from(l in ArticleLink,
+      as: :link,
+      where: l.relationship_type == :potential_conflict,
+      where: fragment("(?->>'auto_generated') = 'true'", l.metadata),
+      where:
+        l.source_article_id == parent_as(:article).id or
+          l.target_article_id == parent_as(:article).id,
+      where:
+        not exists(
+          from(r in ConflictResolution,
+            where:
+              r.tenant_id == parent_as(:link).tenant_id and
+                ((r.source_article_id == parent_as(:link).source_article_id and
+                    r.target_article_id == parent_as(:link).target_article_id) or
+                   (r.source_article_id == parent_as(:link).target_article_id and
+                      r.target_article_id == parent_as(:link).source_article_id))
+          )
+        ),
+      select: 1
+    )
+  end
+
+  # AC-31.1.3 tenant precedence: when a tenant's own curated article and a system
+  # canonical share a topic (case-insensitive title), the tenant's own wins and the
+  # system one is dropped. Tenant-own rows are kept unconditionally.
+  defp apply_tenant_precedence(articles, tenant_id) do
+    owned_topics =
+      articles
+      |> Enum.filter(&(&1.tenant_id == tenant_id))
+      |> Enum.map(&topic_key/1)
+      |> MapSet.new()
+
+    Enum.reject(articles, fn a ->
+      a.scope == :system and MapSet.member?(owned_topics, topic_key(a))
+    end)
+  end
+
+  defp topic_key(%Article{title: title}) when is_binary(title),
+    do: title |> String.trim() |> String.downcase()
+
+  defp topic_key(%Article{}), do: nil
+
+  @doc """
+  Authoritative-curated check for a single article (AC-31.1.4).
+
+  Unlike the pure `curated?/1` (status + marker only), this additionally excludes
+  an article that is in an OPEN `:potential_conflict` — such an article is NOT
+  treated as authoritative until the conflict is surfaced/resolved. Does a DB
+  lookup for the open conflict; the conflict is scoped to the article's own tenant.
+  """
+  @spec authoritative_curated?(Article.t()) :: boolean()
+  def authoritative_curated?(%Article{} = article) do
+    curated?(article) and not article_in_open_conflict?(article)
+  end
+
+  # TRUE when the article is a member of an unresolved auto-generated
+  # :potential_conflict pair within its own tenant.
+  defp article_in_open_conflict?(%Article{id: article_id, tenant_id: tenant_id}) do
+    query =
+      from(l in ArticleLink,
+        as: :link,
+        where: l.tenant_id == ^tenant_id,
+        where: l.relationship_type == :potential_conflict,
+        where: fragment("(?->>'auto_generated') = 'true'", l.metadata),
+        where: l.source_article_id == ^article_id or l.target_article_id == ^article_id,
+        where:
+          not exists(
+            from(r in ConflictResolution,
+              where:
+                r.tenant_id == parent_as(:link).tenant_id and
+                  ((r.source_article_id == parent_as(:link).source_article_id and
+                      r.target_article_id == parent_as(:link).target_article_id) or
+                     (r.source_article_id == parent_as(:link).target_article_id and
+                        r.target_article_id == parent_as(:link).source_article_id))
+            )
+          )
+      )
+
+    AdminRepo.exists?(query)
+  end
+
   # --- Publish Workflow ---
 
   @doc """

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -2401,21 +2401,31 @@ defmodule Loopctl.Knowledge do
     operation. The audit event is written with `tenant_id: nil` (global scope; the
     superadmin API is the oversight path) and NO per-tenant `KbCuration` feed line is
     written — that feed is per-tenant and a system canonical belongs to no tenant.
+    Because the global path is destructive of the "trust curated" guarantee for
+    EVERY tenant, the caller MUST pass `scope: :system` to use it; a bare `nil`
+    `tenant_id` (e.g. from a missing tenant context) is rejected with
+    `{:error, :system_scope_required}` rather than silently curating a global
+    canonical. That domain guard is defense in depth — the transport layer
+    (US-31.4) still MUST role-gate the system path at superadmin/WebAuthn.
 
   ## Parameters
 
-  - `tenant_id` -- the owning tenant UUID (pass `nil` for a `scope: :system` article)
+  - `tenant_id` -- the owning tenant UUID (pass `nil` WITH `scope: :system` for a
+    system canonical)
   - `article_id` -- the article UUID
-  - `opts` -- `:actor_id`, `:actor_label`, `:actor_type`, and `:at` (mark time)
+  - `opts` -- `:actor_id`, `:actor_label`, `:actor_type`, `:at` (mark time), and
+    `:scope` (`:system` REQUIRED when `tenant_id` is `nil`)
 
   ## Returns
 
   - `{:ok, %Article{}}` on success
   - `{:error, :not_found}` if not found / wrong tenant
+  - `{:error, :system_scope_required}` if `tenant_id` is `nil` without `scope: :system`
   - `{:error, %Ecto.Changeset{}}` on a write failure
   """
   @spec mark_curated(Ecto.UUID.t() | nil, Ecto.UUID.t(), keyword()) ::
-          {:ok, Article.t()} | {:error, :not_found} | {:error, Ecto.Changeset.t()}
+          {:ok, Article.t()}
+          | {:error, :not_found | :system_scope_required | Ecto.Changeset.t()}
   def mark_curated(tenant_id, article_id, opts \\ []) do
     at = Keyword.get(opts, :at) || DateTime.utc_now()
     actor_label = Keyword.get(opts, :actor_label)
@@ -2432,7 +2442,8 @@ defmodule Loopctl.Knowledge do
   `article.uncurated` audit event. Returns the same shapes.
   """
   @spec unmark_curated(Ecto.UUID.t() | nil, Ecto.UUID.t(), keyword()) ::
-          {:ok, Article.t()} | {:error, :not_found} | {:error, Ecto.Changeset.t()}
+          {:ok, Article.t()}
+          | {:error, :not_found | :system_scope_required | Ecto.Changeset.t()}
   def unmark_curated(tenant_id, article_id, opts \\ []) do
     changeset_fun = fn article -> Article.curation_changeset(article, nil, nil) end
     write_curation(tenant_id, article_id, changeset_fun, "article.uncurated", opts)
@@ -2443,7 +2454,8 @@ defmodule Loopctl.Knowledge do
     actor_label = Keyword.get(opts, :actor_label)
     actor_type = Keyword.get(opts, :actor_type, "api_key")
 
-    with {:ok, article} <- fetch_curatable_article(tenant_id, article_id) do
+    with :ok <- authorize_curation_scope(tenant_id, opts),
+         {:ok, article} <- fetch_curatable_article(tenant_id, article_id) do
       changeset = changeset_fun.(article)
 
       multi =
@@ -2493,6 +2505,24 @@ defmodule Loopctl.Knowledge do
   defp curation_summary("article.uncurated", article),
     do: "Cleared curated marker on article #{article.id} (#{article.title})"
 
+  # US-31.1 defense in depth: curating a system-scoped canonical (tenant_id nil) is
+  # a GLOBAL, all-tenant-visible authoritative operation. Reaching that path with a
+  # nil tenant_id must be DELIBERATE, never accidental — an unset/missing tenant
+  # context (a common bug shape) would otherwise silently curate a global article.
+  # The caller must therefore explicitly declare `scope: :system` to use the
+  # nil-tenant path; a nil tenant_id without it is rejected. This is orthogonal to
+  # (and does not replace) the transport-layer role gate that US-31.4 must add:
+  # tenant curation at role `:user`+, system curation at superadmin/WebAuthn.
+  defp authorize_curation_scope(nil, opts) do
+    if Keyword.get(opts, :scope) == :system do
+      :ok
+    else
+      {:error, :system_scope_required}
+    end
+  end
+
+  defp authorize_curation_scope(tenant_id, _opts) when is_binary(tenant_id), do: :ok
+
   # Fetches an article for curation. A tenant article is scoped by tenant_id; a
   # system article (tenant_id nil) is fetched by its system scope. Never crosses
   # tenants — a wrong tenant_id resolves to :not_found.
@@ -2531,38 +2561,56 @@ defmodule Loopctl.Knowledge do
     * **Open conflicts excluded (AC-31.1.4).** An article in an OPEN
       `:potential_conflict` (an auto-generated conflict link with no
       `conflict_resolutions` row) is NOT returned as authoritative — the conflict
-      must be surfaced/resolved first (ties to US-31.2 AC-31.2.6).
+      must be surfaced/resolved first (ties to US-31.2 AC-31.2.6). The conflict
+      link is correlated to the CALLER's `tenant_id` (see `open_conflict_subquery/1`)
+      so one tenant's dispute over a shared system canonical cannot retract that
+      global canonical from OTHER tenants' lists.
     * **Tenant precedence (AC-31.1.3).** When a tenant's own curated article and a
-      system canonical share a topic (case-insensitive title), the tenant's own
-      wins and the system one is suppressed from the result — a system canonical
-      never overrides a tenant's own answer. System canonicals on topics the
-      tenant has NOT curated are still returned (they participate). Ownership is
-      computed INDEPENDENTLY of open-conflict status (see `tenant_owned_topics/2`):
-      if the tenant's own curated article on a topic is itself in an open conflict,
-      it is excluded from the RESULT (AC-31.1.4) but STILL suppresses the system
-      canonical — so on a topic the tenant owns-but-is-disputing, neither surfaces
-      and the conflict must be resolved first, rather than papering over the
-      tenant's disputed answer with the system one.
+      system canonical share a topic (case-insensitive EXACT title — a v1
+      interpretation; see below), the tenant's own wins and the system one is
+      suppressed from the result — a system canonical never overrides a tenant's
+      own answer. System canonicals on topics the tenant has NOT curated are still
+      returned (they participate). Ownership is folded into the main query as a
+      correlated `NOT EXISTS` (see `tenant_owns_topic_subquery/2`) evaluated
+      INDEPENDENTLY of open-conflict status: if the tenant's own curated article on
+      a topic is itself in an open conflict, it is excluded from the RESULT
+      (AC-31.1.4) but STILL suppresses the system canonical — so on a topic the
+      tenant owns-but-is-disputing, neither surfaces and the conflict must be
+      resolved first, rather than papering over the tenant's disputed answer with
+      the system one.
+
+  ## Topic identity (v1 scope)
+
+  "Same topic" for precedence is keyed on the article's **case-insensitive,
+  trimmed title** (exact equality). Two curated articles about the same conceptual
+  topic under DIFFERENT titles are treated as distinct topics and both surface.
+  Broader (semantic) topic identity is deliberately OUT OF SCOPE for US-31.1 and
+  belongs to the US-31.2 hybrid resolver's blending layer, which has embeddings;
+  callers here must not assume title-equality captures semantic sameness.
 
   ## Options
 
   - `:category` -- restrict to a single category atom
   - `:include_system` -- set `false` to exclude system canonicals (default `true`)
-  - `:limit` -- cap the number of rows PULLED from the DB (a positive integer;
-    default unbounded). Precedence suppression runs after the pull, so the returned
-    list may be shorter than `:limit`. Use it when the caller (e.g. the US-31.2
-    resolver) wants a bounded pull rather than the whole curated set.
+  - `:limit` -- cap the number of rows returned (a positive integer; default
+    unbounded). Precedence suppression is applied IN THE QUERY (correlated
+    subquery), so `:limit` bounds the FINAL result set, not a pre-suppression pull.
+    Use it when the caller (e.g. the US-31.2 resolver) wants a bounded result.
 
   Results are ordered tenant-own-first (tenant rows before system canonicals), then
   most-recently-updated.
 
-  ## Scaling note
+  ## Consistency & scaling notes
 
-  This returns full `%Article{}` structs (including bodies) and applies tenant
-  precedence in memory. It is bounded in practice by the partial index
-  `articles_curated_published_idx` and the small-curated-set assumption; the
-  `:limit` opt is the pressure valve. If the curated corpus grows into a hot path,
-  add cursor pagination or a body-less projection before this becomes a bottleneck.
+  Precedence is computed in a SINGLE query (one snapshot): the tenant-ownership
+  suppression is a correlated `NOT EXISTS` on the same `%Article{}` scan rather than
+  a second, independent read. This (a) removes the torn-view window a concurrent
+  `mark_curated` could open between two reads, and (b) removes the previously
+  unbounded full curated-title scan — ownership is now evaluated per candidate row
+  via the partial index `articles_curated_published_idx`, so `:limit` genuinely
+  bounds the work. This still returns full `%Article{}` structs (including bodies);
+  if the curated corpus grows into a hot path, add cursor pagination or a body-less
+  projection before this becomes a bottleneck.
   """
   @spec list_curated_sources(Ecto.UUID.t(), keyword()) :: [Article.t()]
   def list_curated_sources(tenant_id, opts \\ []) when is_binary(tenant_id) do
@@ -2572,7 +2620,16 @@ defmodule Loopctl.Knowledge do
 
     scope_filter =
       if include_system do
-        dynamic([a], a.tenant_id == ^tenant_id or a.scope == :system)
+        # A system canonical participates ONLY when the tenant does not OWN the same
+        # topic (AC-31.1.3). Folding the ownership check here (rather than a second
+        # in-memory pass over a separately-read owned-topic set) keeps the whole
+        # precedence decision in one atomic snapshot and bounded by :limit.
+        dynamic(
+          [a],
+          a.tenant_id == ^tenant_id or
+            (a.scope == :system and
+               not exists(tenant_owns_topic_subquery(tenant_id, category)))
+        )
       else
         dynamic([a], a.tenant_id == ^tenant_id)
       end
@@ -2584,7 +2641,7 @@ defmodule Loopctl.Knowledge do
         where: not is_nil(a.curated_at),
         where: ^scope_filter,
         # AC-31.1.4: never surface an article that is in an OPEN potential_conflict.
-        where: not exists(open_conflict_subquery()),
+        where: not exists(open_conflict_subquery(tenant_id)),
         # Tenant-own-first: tenant rows (tenant_id NOT NULL, so `IS NULL` = false)
         # sort before system canonicals (tenant_id NULL, `IS NULL` = true), then freshest.
         order_by: [asc: fragment("? IS NULL", a.tenant_id), desc: a.updated_at, asc: a.id]
@@ -2598,23 +2655,21 @@ defmodule Loopctl.Knowledge do
 
     base = if is_integer(limit) and limit > 0, do: from(a in base, limit: ^limit), else: base
 
-    # Owned topics are computed independently of the open-conflict exclusion above,
-    # so a tenant's disputed-but-owned topic still suppresses the system canonical.
-    owned_topics =
-      if include_system, do: tenant_owned_topics(tenant_id, category), else: MapSet.new()
-
-    base
-    |> AdminRepo.all()
-    |> apply_tenant_precedence(owned_topics)
+    AdminRepo.all(base)
   end
 
   # Subquery correlated on the outer :article binding: TRUE when the article is a
   # member of an auto-generated :potential_conflict pair that has NOT yet been
-  # resolved (no conflict_resolutions row either direction). Mirrors the open-conflict
-  # definition in list_potential_conflicts/2.
-  defp open_conflict_subquery do
+  # resolved (no conflict_resolutions row either direction). The link is scoped to
+  # `tenant_id` (the CALLER's tenant) so one tenant's unresolved dispute over a
+  # shared system canonical (article ids are global) cannot retract that canonical
+  # from ANOTHER tenant's list. For a tenant's own article the link necessarily
+  # lives under that same tenant, so this predicate is a no-op restriction there.
+  # Mirrors the open-conflict definition in list_potential_conflicts/2.
+  defp open_conflict_subquery(tenant_id) do
     from(l in ArticleLink,
       as: :link,
+      where: l.tenant_id == ^tenant_id,
       where: l.relationship_type == :potential_conflict,
       where: fragment("(?->>'auto_generated') = 'true'", l.metadata),
       where:
@@ -2641,48 +2696,32 @@ defmodule Loopctl.Knowledge do
     )
   end
 
-  # AC-31.1.3 tenant precedence: drop a system canonical whose topic (case-insensitive
-  # title) the tenant OWNS. `owned_topics` is precomputed from the tenant's own curated
-  # articles independently of conflict status (tenant_owned_topics/2), so a disputed but
-  # tenant-owned topic still suppresses the system answer. Tenant-own rows are kept as-is.
-  defp apply_tenant_precedence(articles, owned_topics) do
-    Enum.reject(articles, fn a ->
-      a.scope == :system and MapSet.member?(owned_topics, topic_key(a))
-    end)
-  end
-
-  # Topics (case-insensitive titles) the tenant OWNS via its own curated + published
-  # articles. Computed INDEPENDENTLY of open-conflict status (AC-31.1.3): if the tenant's
-  # own answer on a topic is currently in an unresolved conflict it is excluded from the
-  # RESULT (AC-31.1.4) yet must STILL suppress a same-topic system canonical, so ownership
-  # cannot be derived from the (conflict-filtered) surviving rows — it is queried here.
-  defp tenant_owned_topics(tenant_id, category) do
+  # AC-31.1.3 tenant precedence, folded into list_curated_sources/2's main scan.
+  # Correlated on the outer :article binding: TRUE when the CALLER's tenant OWNS the
+  # outer article's topic — i.e. has its OWN curated + published article whose topic
+  # (case-insensitive, trimmed title) matches. Evaluated INDEPENDENTLY of open-conflict
+  # status: a tenant's disputed-but-owned topic (excluded from the RESULT by the
+  # open-conflict filter) STILL suppresses a same-topic system canonical, so ownership
+  # is queried directly here rather than derived from the conflict-filtered rows.
+  # Applied only to `a.scope == :system` candidates, so tenant-own rows are unaffected.
+  # Topic equality uses `lower(btrim(title))` on both sides — the SQL analogue of the
+  # documented v1 case-insensitive exact-title key; the partial index
+  # `articles_curated_published_idx` bounds the correlated lookup.
+  defp tenant_owns_topic_subquery(tenant_id, category) do
     query =
-      from(a in Article,
-        where: a.tenant_id == ^tenant_id,
-        where: a.status == :published,
-        where: not is_nil(a.curated_at),
-        select: a.title
+      from(o in Article,
+        where: o.tenant_id == ^tenant_id,
+        where: o.status == :published,
+        where: not is_nil(o.curated_at),
+        where: fragment("lower(btrim(?)) = lower(btrim(?))", o.title, parent_as(:article).title),
+        select: 1
       )
 
-    query =
-      case category do
-        nil -> query
-        cat -> from(a in query, where: a.category == ^cat)
-      end
-
-    query
-    |> AdminRepo.all()
-    |> Enum.map(&normalize_topic/1)
-    |> MapSet.new()
+    case category do
+      nil -> query
+      cat -> from(o in query, where: o.category == ^cat)
+    end
   end
-
-  defp topic_key(%Article{title: title}), do: normalize_topic(title)
-
-  defp normalize_topic(title) when is_binary(title),
-    do: title |> String.trim() |> String.downcase()
-
-  defp normalize_topic(_), do: nil
 
   @doc """
   Authoritative-curated check for a single article (AC-31.1.4).

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -2380,8 +2380,8 @@ defmodule Loopctl.Knowledge do
   Governed setter: marks an article as curated (authoritative).
 
   This is the ONLY writer of the curated marker. It writes through the dedicated
-  `Article.curation_changeset/3` (the marker is NOT in the ordinary cast fields),
-  records an `article.curated` audit event, and appends a `KbCuration` feed entry.
+  `Article.curation_changeset/3` (the marker is NOT in the ordinary cast fields) and
+  records an `article.curated` audit event in the same transaction.
 
   Marking authoritative is a **trust gate** (the hybrid resolver, US-31.2, prefers
   curated answers), so the HTTP surface that reaches this MUST be role-gated at
@@ -2390,6 +2390,17 @@ defmodule Loopctl.Knowledge do
 
   Marking is allowed regardless of the article's current status, but `curated?/1`
   only reports `true` once the article is `:published`.
+
+  ## Audit & curation-feed scope
+
+  - **Tenant-scoped article** (`tenant_id` a UUID): the `article.curated` audit event
+    is recorded under that tenant, and a per-tenant `KbCuration` feed line is appended
+    *when the tenant's `kb_curation_log` toggle is on* (off by default — see
+    `Loopctl.Knowledge.KbCuration`).
+  - **System-scope article** (`tenant_id == nil`): curation is a GLOBAL superadmin
+    operation. The audit event is written with `tenant_id: nil` (global scope; the
+    superadmin API is the oversight path) and NO per-tenant `KbCuration` feed line is
+    written — that feed is per-tenant and a system canonical belongs to no tenant.
 
   ## Parameters
 
@@ -2416,7 +2427,9 @@ defmodule Loopctl.Knowledge do
   @doc """
   Governed setter: clears an article's curated marker (the inverse of `mark_curated/3`).
 
-  Reversible + audited, same governance as `mark_curated/3`. Returns the same shapes.
+  Reversible + audited, same governance as `mark_curated/3` — including the same
+  audit & curation-feed scope rules (tenant-scoped vs global system-scope). Records an
+  `article.uncurated` audit event. Returns the same shapes.
   """
   @spec unmark_curated(Ecto.UUID.t() | nil, Ecto.UUID.t(), keyword()) ::
           {:ok, Article.t()} | {:error, :not_found} | {:error, Ecto.Changeset.t()}
@@ -2523,19 +2536,39 @@ defmodule Loopctl.Knowledge do
       system canonical share a topic (case-insensitive title), the tenant's own
       wins and the system one is suppressed from the result — a system canonical
       never overrides a tenant's own answer. System canonicals on topics the
-      tenant has NOT curated are still returned (they participate).
+      tenant has NOT curated are still returned (they participate). Ownership is
+      computed INDEPENDENTLY of open-conflict status (see `tenant_owned_topics/2`):
+      if the tenant's own curated article on a topic is itself in an open conflict,
+      it is excluded from the RESULT (AC-31.1.4) but STILL suppresses the system
+      canonical — so on a topic the tenant owns-but-is-disputing, neither surfaces
+      and the conflict must be resolved first, rather than papering over the
+      tenant's disputed answer with the system one.
 
   ## Options
 
   - `:category` -- restrict to a single category atom
   - `:include_system` -- set `false` to exclude system canonicals (default `true`)
+  - `:limit` -- cap the number of rows PULLED from the DB (a positive integer;
+    default unbounded). Precedence suppression runs after the pull, so the returned
+    list may be shorter than `:limit`. Use it when the caller (e.g. the US-31.2
+    resolver) wants a bounded pull rather than the whole curated set.
 
-  Results are ordered tenant-own-first, then most-recently-updated.
+  Results are ordered tenant-own-first (tenant rows before system canonicals), then
+  most-recently-updated.
+
+  ## Scaling note
+
+  This returns full `%Article{}` structs (including bodies) and applies tenant
+  precedence in memory. It is bounded in practice by the partial index
+  `articles_curated_published_idx` and the small-curated-set assumption; the
+  `:limit` opt is the pressure valve. If the curated corpus grows into a hot path,
+  add cursor pagination or a body-less projection before this becomes a bottleneck.
   """
   @spec list_curated_sources(Ecto.UUID.t(), keyword()) :: [Article.t()]
   def list_curated_sources(tenant_id, opts \\ []) when is_binary(tenant_id) do
     include_system = Keyword.get(opts, :include_system, true)
     category = Keyword.get(opts, :category)
+    limit = Keyword.get(opts, :limit)
 
     scope_filter =
       if include_system do
@@ -2552,7 +2585,9 @@ defmodule Loopctl.Knowledge do
         where: ^scope_filter,
         # AC-31.1.4: never surface an article that is in an OPEN potential_conflict.
         where: not exists(open_conflict_subquery()),
-        order_by: [desc: a.updated_at, asc: a.id]
+        # Tenant-own-first: tenant rows (tenant_id NOT NULL, so `IS NULL` = false)
+        # sort before system canonicals (tenant_id NULL, `IS NULL` = true), then freshest.
+        order_by: [asc: fragment("? IS NULL", a.tenant_id), desc: a.updated_at, asc: a.id]
       )
 
     base =
@@ -2561,9 +2596,16 @@ defmodule Loopctl.Knowledge do
         cat -> from(a in base, where: a.category == ^cat)
       end
 
+    base = if is_integer(limit) and limit > 0, do: from(a in base, limit: ^limit), else: base
+
+    # Owned topics are computed independently of the open-conflict exclusion above,
+    # so a tenant's disputed-but-owned topic still suppresses the system canonical.
+    owned_topics =
+      if include_system, do: tenant_owned_topics(tenant_id, category), else: MapSet.new()
+
     base
     |> AdminRepo.all()
-    |> apply_tenant_precedence(tenant_id)
+    |> apply_tenant_precedence(owned_topics)
   end
 
   # Subquery correlated on the outer :article binding: TRUE when the article is a
@@ -2578,48 +2620,79 @@ defmodule Loopctl.Knowledge do
       where:
         l.source_article_id == parent_as(:article).id or
           l.target_article_id == parent_as(:article).id,
-      where:
-        not exists(
-          from(r in ConflictResolution,
-            where:
-              r.tenant_id == parent_as(:link).tenant_id and
-                ((r.source_article_id == parent_as(:link).source_article_id and
-                    r.target_article_id == parent_as(:link).target_article_id) or
-                   (r.source_article_id == parent_as(:link).target_article_id and
-                      r.target_article_id == parent_as(:link).source_article_id))
-          )
-        ),
+      where: not exists(conflict_unresolved_subquery()),
       select: 1
     )
   end
 
-  # AC-31.1.3 tenant precedence: when a tenant's own curated article and a system
-  # canonical share a topic (case-insensitive title), the tenant's own wins and the
-  # system one is dropped. Tenant-own rows are kept unconditionally.
-  defp apply_tenant_precedence(articles, tenant_id) do
-    owned_topics =
-      articles
-      |> Enum.filter(&(&1.tenant_id == tenant_id))
-      |> Enum.map(&topic_key/1)
-      |> MapSet.new()
+  # THE single authority for "this potential_conflict link is still unresolved":
+  # correlated on the enclosing `as: :link` binding, TRUE when NO conflict_resolutions
+  # row exists for the pair in either direction. Every open-conflict query
+  # (open_conflict_subquery/0, article_in_open_conflict?/1, list_potential_conflicts/2)
+  # composes THIS so the definition can never drift between paths.
+  defp conflict_unresolved_subquery do
+    from(r in ConflictResolution,
+      where:
+        r.tenant_id == parent_as(:link).tenant_id and
+          ((r.source_article_id == parent_as(:link).source_article_id and
+              r.target_article_id == parent_as(:link).target_article_id) or
+             (r.source_article_id == parent_as(:link).target_article_id and
+                r.target_article_id == parent_as(:link).source_article_id))
+    )
+  end
 
+  # AC-31.1.3 tenant precedence: drop a system canonical whose topic (case-insensitive
+  # title) the tenant OWNS. `owned_topics` is precomputed from the tenant's own curated
+  # articles independently of conflict status (tenant_owned_topics/2), so a disputed but
+  # tenant-owned topic still suppresses the system answer. Tenant-own rows are kept as-is.
+  defp apply_tenant_precedence(articles, owned_topics) do
     Enum.reject(articles, fn a ->
       a.scope == :system and MapSet.member?(owned_topics, topic_key(a))
     end)
   end
 
-  defp topic_key(%Article{title: title}) when is_binary(title),
+  # Topics (case-insensitive titles) the tenant OWNS via its own curated + published
+  # articles. Computed INDEPENDENTLY of open-conflict status (AC-31.1.3): if the tenant's
+  # own answer on a topic is currently in an unresolved conflict it is excluded from the
+  # RESULT (AC-31.1.4) yet must STILL suppress a same-topic system canonical, so ownership
+  # cannot be derived from the (conflict-filtered) surviving rows — it is queried here.
+  defp tenant_owned_topics(tenant_id, category) do
+    query =
+      from(a in Article,
+        where: a.tenant_id == ^tenant_id,
+        where: a.status == :published,
+        where: not is_nil(a.curated_at),
+        select: a.title
+      )
+
+    query =
+      case category do
+        nil -> query
+        cat -> from(a in query, where: a.category == ^cat)
+      end
+
+    query
+    |> AdminRepo.all()
+    |> Enum.map(&normalize_topic/1)
+    |> MapSet.new()
+  end
+
+  defp topic_key(%Article{title: title}), do: normalize_topic(title)
+
+  defp normalize_topic(title) when is_binary(title),
     do: title |> String.trim() |> String.downcase()
 
-  defp topic_key(%Article{}), do: nil
+  defp normalize_topic(_), do: nil
 
   @doc """
   Authoritative-curated check for a single article (AC-31.1.4).
 
   Unlike the pure `curated?/1` (status + marker only), this additionally excludes
   an article that is in an OPEN `:potential_conflict` — such an article is NOT
-  treated as authoritative until the conflict is surfaced/resolved. Does a DB
-  lookup for the open conflict; the conflict is scoped to the article's own tenant.
+  treated as authoritative until the conflict is surfaced/resolved. Does a DB lookup
+  for the open conflict, correlated on the article's globally-unique id. Works for
+  BOTH tenant articles and system canonicals (`tenant_id == nil`) — the latter is the
+  exact input AC-31.1.3 requires to participate as curated.
   """
   @spec authoritative_curated?(Article.t()) :: boolean()
   def authoritative_curated?(%Article{} = article) do
@@ -2627,26 +2700,21 @@ defmodule Loopctl.Knowledge do
   end
 
   # TRUE when the article is a member of an unresolved auto-generated
-  # :potential_conflict pair within its own tenant.
-  defp article_in_open_conflict?(%Article{id: article_id, tenant_id: tenant_id}) do
+  # :potential_conflict pair. Correlates on the article's globally-unique id ONLY
+  # (never `l.tenant_id == ^tenant_id`): a system canonical has `tenant_id == nil`,
+  # and Ecto's `==` escaper wraps a pinned nil in a RUNTIME `not_nil!/2` guard that
+  # RAISES `ArgumentError: comparing ... with nil is forbidden`. Article ids are UUIDs
+  # unique across tenants, so id-only correlation is exactly as scoped as an id+tenant
+  # filter would be while also participating for system articles (AC-31.1.3). Mirrors
+  # open_conflict_subquery/0 and shares conflict_unresolved_subquery/0.
+  defp article_in_open_conflict?(%Article{id: article_id}) do
     query =
       from(l in ArticleLink,
         as: :link,
-        where: l.tenant_id == ^tenant_id,
         where: l.relationship_type == :potential_conflict,
         where: fragment("(?->>'auto_generated') = 'true'", l.metadata),
         where: l.source_article_id == ^article_id or l.target_article_id == ^article_id,
-        where:
-          not exists(
-            from(r in ConflictResolution,
-              where:
-                r.tenant_id == parent_as(:link).tenant_id and
-                  ((r.source_article_id == parent_as(:link).source_article_id and
-                      r.target_article_id == parent_as(:link).target_article_id) or
-                     (r.source_article_id == parent_as(:link).target_article_id and
-                        r.target_article_id == parent_as(:link).source_article_id))
-            )
-          )
+        where: not exists(conflict_unresolved_subquery())
       )
 
     AdminRepo.exists?(query)
@@ -3641,17 +3709,7 @@ defmodule Loopctl.Knowledge do
         # kb-02: only surface SYSTEM-flagged conflicts as resolvable evidence, so a stray
         # or legacy non-system potential_conflict row is never presented to a :user.
         where: fragment("(?->>'auto_generated') = 'true'", l.metadata),
-        where:
-          not exists(
-            from(r in ConflictResolution,
-              where:
-                r.tenant_id == parent_as(:link).tenant_id and
-                  ((r.source_article_id == parent_as(:link).source_article_id and
-                      r.target_article_id == parent_as(:link).target_article_id) or
-                     (r.source_article_id == parent_as(:link).target_article_id and
-                        r.target_article_id == parent_as(:link).source_article_id))
-            )
-          )
+        where: not exists(conflict_unresolved_subquery())
       )
       |> filter_conflict_pairs_by_visibility(vis)
 

--- a/lib/loopctl/knowledge/article.ex
+++ b/lib/loopctl/knowledge/article.ex
@@ -178,6 +178,23 @@ defmodule Loopctl.Knowledge.Article do
 
   Allows partial updates to title, body, category, status, tags,
   metadata, and project_id. Same constraints as create_changeset.
+
+  ## Curated-marker invalidation (US-31.1, poisoning defense)
+
+  The governed curated marker (`curated_at`/`curated_by`) attests that a curator
+  approved a SPECIFIC published-content snapshot as authoritative. Any ordinary,
+  agent-reachable edit through this changeset that changes the article's `:title`,
+  `:body`, or `:status` therefore **clears the marker** — see
+  `clear_curated_marker_on_content_change/1`. This closes the edit-after-curate
+  poisoning class: an agent cannot overwrite a curated article's body (or flip a
+  curated draft to `:published`) and keep the authoritative marker; re-curation
+  must go back through the governed `Loopctl.Knowledge.mark_curated/3` path against
+  the final published content. Pure metadata/tags/category/project edits preserve
+  the marker (they do not change what the curator approved).
+
+  This is defense in depth alongside the fact that the marker is NOT castable here:
+  `mark_curated/3`'s `curation_changeset/3` is the only writer, and this changeset
+  is the only in-place clearer.
   """
   @spec update_changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
   def update_changeset(article, attrs) do
@@ -189,6 +206,7 @@ defmodule Loopctl.Knowledge.Article do
     |> validate_tags()
     |> validate_metadata()
     |> validate_agent_metadata()
+    |> clear_curated_marker_on_content_change()
     |> foreign_key_constraint(:project_id)
     |> unique_constraint(:title,
       name: :articles_tenant_title_active_idx,
@@ -296,6 +314,28 @@ defmodule Loopctl.Knowledge.Article do
 
   def curation_changeset(article, %DateTime{} = curated_at, curated_by) do
     change(article, %{curated_at: curated_at, curated_by: curated_by})
+  end
+
+  # US-31.1 poisoning defense: any in-place edit that changes the article's
+  # title, body, or status invalidates a previously-set governed curated marker,
+  # forcing re-curation through mark_curated/3 against the final content. Only acts
+  # when the article currently carries a marker AND a content/lifecycle field is
+  # actually changing (a no-op edit or a pure metadata/tags edit keeps the marker).
+  # `:curated_at`/`:curated_by` are NOT in this changeset's cast list, so these
+  # put_change calls — not caller input — are the only way they change here.
+  defp clear_curated_marker_on_content_change(changeset) do
+    content_or_status_changed? =
+      Enum.any?([:title, :body, :status], &Map.has_key?(changeset.changes, &1))
+
+    already_curated? = not is_nil(get_field(changeset, :curated_at))
+
+    if content_or_status_changed? and already_curated? do
+      changeset
+      |> put_change(:curated_at, nil)
+      |> put_change(:curated_by, nil)
+    else
+      changeset
+    end
   end
 
   # --- Private validations ---

--- a/lib/loopctl/knowledge/article.ex
+++ b/lib/loopctl/knowledge/article.ex
@@ -65,6 +65,15 @@ defmodule Loopctl.Knowledge.Article do
     # that lets ArticleEmbeddingWorker skip re-calling the paid provider on retry.
     field :embedding_content_hash, :string
 
+    # GOVERNED curated (authoritative) marker (US-31.1). Deliberately EXCLUDED from
+    # `@cast_fields` and `update_changeset/2` — writable ONLY via `curation_changeset/3`
+    # (invoked from `Loopctl.Knowledge.mark_curated/3`), mirroring the `embedding`
+    # isolation precedent. This is what stops an agent from self-promoting its own
+    # article to "authoritative" (agents CAN set `category`/`metadata`, so those are
+    # never sufficient — see `Loopctl.Knowledge.curated?/1`).
+    field :curated_at, :utc_datetime_usec
+    field :curated_by, :string
+
     has_many :outgoing_links, Loopctl.Knowledge.ArticleLink, foreign_key: :source_article_id
     has_many :incoming_links, Loopctl.Knowledge.ArticleLink, foreign_key: :target_article_id
 
@@ -254,6 +263,39 @@ defmodule Loopctl.Knowledge.Article do
     article
     |> change(%{embedding: embedding, embedding_content_hash: content_hash})
     |> validate_embedding_dimensions()
+  end
+
+  @doc """
+  Changeset for setting or clearing the GOVERNED curated marker (US-31.1).
+
+  This is the ONLY changeset that may modify `:curated_at`/`:curated_by`. Neither
+  `create_changeset/2` nor `update_changeset/2` includes them in their cast fields,
+  so an agent writing an ordinary create/update — even one that freely sets
+  `category`/`metadata` — cannot make its own article "curated" (authoritative).
+  The marker is written exclusively through the admin/curation-gated
+  `Loopctl.Knowledge.mark_curated/3` context path.
+
+  ## Parameters
+
+  - `article` -- an existing `%Article{}` struct
+  - `curated_at` -- a `DateTime` (mark) or `nil` (unmark)
+  - `curated_by` -- optional advisory actor label (e.g. `"user:admin"`); ignored
+    (forced `nil`) when unmarking
+
+  ## Returns
+
+  An `Ecto.Changeset` carrying only the marker changes.
+  """
+  @spec curation_changeset(%__MODULE__{}, DateTime.t() | nil, String.t() | nil) ::
+          Ecto.Changeset.t()
+  def curation_changeset(article, curated_at, curated_by \\ nil)
+
+  def curation_changeset(article, nil, _curated_by) do
+    change(article, %{curated_at: nil, curated_by: nil})
+  end
+
+  def curation_changeset(article, %DateTime{} = curated_at, curated_by) do
+    change(article, %{curated_at: curated_at, curated_by: curated_by})
   end
 
   # --- Private validations ---

--- a/priv/repo/migrations/20260712010000_add_curated_marker_to_articles.exs
+++ b/priv/repo/migrations/20260712010000_add_curated_marker_to_articles.exs
@@ -1,0 +1,34 @@
+defmodule Loopctl.Repo.Migrations.AddCuratedMarkerToArticles do
+  use Ecto.Migration
+
+  @moduledoc """
+  US-31.1: a GOVERNED "curated" marker for Knowledge Wiki articles.
+
+  `curated_at`/`curated_by` are a dedicated, NON-castable marker: they are absent
+  from `Article`'s `@cast_fields` (create/update changesets) and are writable ONLY
+  via `Article.curation_changeset/3`, invoked from the governed
+  `Loopctl.Knowledge.mark_curated/3` path. This mirrors the `embedding` isolation
+  precedent so an agent cannot self-promote its own article to "authoritative" by
+  setting `category`/`metadata` — which are agent-castable.
+
+  A published article is "curated" iff `curated_at` is set (see
+  `Loopctl.Knowledge.curated?/1`). The `articles` table already has
+  `ENABLE ROW LEVEL SECURITY`; these are plain nullable columns, no new RLS surface.
+  """
+
+  def change do
+    alter table(:articles) do
+      # When set, the article carries the governed curated (authoritative) marker.
+      add :curated_at, :utc_datetime_usec
+      # Advisory label of the actor that marked it curated (e.g. "user:admin").
+      add :curated_by, :string
+    end
+
+    # Partial index for the curated-source listing / hybrid resolver: only the
+    # (small) set of published, marked-curated articles is indexed.
+    create index(:articles, [:tenant_id, :scope],
+             where: "curated_at IS NOT NULL AND status = 'published'",
+             name: :articles_curated_published_idx
+           )
+  end
+end

--- a/test/loopctl/knowledge_curated_test.exs
+++ b/test/loopctl/knowledge_curated_test.exs
@@ -1,0 +1,240 @@
+defmodule Loopctl.KnowledgeCuratedTest do
+  @moduledoc """
+  US-31.1: GOVERNED "curated" (authoritative) marker + scope rules.
+
+  Covers the pure `curated?/1` predicate, the governed `mark_curated/3` setter
+  (the ONLY writer of the marker — an agent create/update cannot self-promote),
+  the tenant-isolated `list_curated_sources/2` with system-scope precedence, and
+  the authoritative check that excludes open `:potential_conflict` articles.
+  """
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge
+  alias Loopctl.Knowledge.Article
+
+  # Creates a published tenant article and marks it curated via the governed path.
+  defp curated_article(tenant_id, attrs \\ %{}) do
+    article =
+      fixture(:article, Map.merge(%{tenant_id: tenant_id, status: :published}, attrs))
+
+    {:ok, marked} = Knowledge.mark_curated(tenant_id, article.id, actor_label: "user:admin")
+    marked
+  end
+
+  # Creates a published SYSTEM article (tenant_id nil) and marks it curated.
+  defp curated_system_article(attrs, tenant_id_for_create) do
+    {:ok, article} =
+      Knowledge.create_article(
+        tenant_id_for_create,
+        Map.merge(
+          %{scope: :system, status: :published, category: :reference, body: "system body"},
+          attrs
+        )
+      )
+
+    assert is_nil(article.tenant_id)
+    {:ok, marked} = Knowledge.mark_curated(nil, article.id, actor_label: "superadmin")
+    marked
+  end
+
+  describe "curated?/1 (TC-31.1.1 — pure predicate, unit)" do
+    test "requires the governed marker, not just category" do
+      # An agent-authored, published :reference WITHOUT the governed marker is NOT
+      # curated (self-promotion via category is blocked).
+      agent_authored = %Article{status: :published, category: :reference, curated_at: nil}
+      refute Knowledge.curated?(agent_authored)
+
+      # The same article WITH the governed marker IS curated.
+      marked = %Article{
+        status: :published,
+        category: :reference,
+        curated_at: ~U[2026-07-10 00:00:00.000000Z]
+      }
+
+      assert Knowledge.curated?(marked)
+    end
+
+    test "is pure — no DB required, marker + published only" do
+      assert Knowledge.curated?(%Article{
+               status: :published,
+               curated_at: ~U[2026-07-10 00:00:00.000000Z]
+             })
+
+      refute Knowledge.curated?(%Article{status: :published, curated_at: nil})
+      refute Knowledge.curated?(%Article{status: :draft, curated_at: nil})
+    end
+  end
+
+  describe "mark_curated/3 governance (security constraint)" do
+    test "an agent create cannot self-set the curated marker via attrs/metadata" do
+      tenant = fixture(:tenant)
+
+      {:ok, article} =
+        Knowledge.create_article(tenant.id, %{
+          title: "Self-promoted?",
+          body: "body",
+          category: :reference,
+          status: :published,
+          curated_at: ~U[2020-01-01 00:00:00.000000Z],
+          curated_by: "agent:sneaky",
+          metadata: %{"curated" => true}
+        })
+
+      # The non-castable marker was NOT set from attrs.
+      assert is_nil(article.curated_at)
+      refute Knowledge.curated?(article)
+    end
+
+    test "an agent update cannot self-set the curated marker via attrs" do
+      tenant = fixture(:tenant)
+      article = fixture(:article, %{tenant_id: tenant.id, status: :published})
+
+      {:ok, updated} =
+        Knowledge.update_article(tenant.id, article.id, %{
+          body: "new body",
+          curated_at: ~U[2020-01-01 00:00:00.000000Z]
+        })
+
+      assert is_nil(updated.curated_at)
+      refute Knowledge.curated?(updated)
+    end
+
+    test "the governed setter marks and unmarks; only it writes the marker" do
+      tenant = fixture(:tenant)
+      article = fixture(:article, %{tenant_id: tenant.id, status: :published})
+
+      refute Knowledge.curated?(article)
+
+      {:ok, marked} = Knowledge.mark_curated(tenant.id, article.id, actor_label: "user:admin")
+      assert Knowledge.curated?(marked)
+      assert marked.curated_by == "user:admin"
+
+      {:ok, unmarked} = Knowledge.unmark_curated(tenant.id, article.id)
+      refute Knowledge.curated?(unmarked)
+      assert is_nil(unmarked.curated_at)
+    end
+
+    test "returns :not_found for a wrong-tenant article (no cross-tenant marking)" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      article = fixture(:article, %{tenant_id: tenant_a.id, status: :published})
+
+      assert {:error, :not_found} = Knowledge.mark_curated(tenant_b.id, article.id, [])
+    end
+  end
+
+  describe "authoritative curated excludes draft/superseded/conflicted (TC-31.1.2)" do
+    test "a draft governed article is not curated" do
+      tenant = fixture(:tenant)
+      draft = fixture(:article, %{tenant_id: tenant.id, status: :draft})
+      {:ok, marked} = Knowledge.mark_curated(tenant.id, draft.id, [])
+
+      refute Knowledge.curated?(marked)
+      refute marked.id in ids(Knowledge.list_curated_sources(tenant.id))
+    end
+
+    test "a superseded governed article is not curated" do
+      tenant = fixture(:tenant)
+      marked = curated_article(tenant.id)
+
+      superseded =
+        marked
+        |> Article.curation_changeset(marked.curated_at, marked.curated_by)
+        |> Ecto.Changeset.change(status: :superseded)
+        |> AdminRepo.update!()
+
+      refute Knowledge.curated?(superseded)
+      refute marked.id in ids(Knowledge.list_curated_sources(tenant.id))
+    end
+
+    test "a curated article in an OPEN potential_conflict is not authoritative" do
+      tenant = fixture(:tenant)
+      curated = curated_article(tenant.id, %{title: "Conflicted Curated"})
+      other = fixture(:article, %{tenant_id: tenant.id, status: :published, title: "Rival"})
+
+      fixture(:article_link, %{
+        tenant_id: tenant.id,
+        source_article_id: curated.id,
+        target_article_id: other.id,
+        relationship_type: :potential_conflict,
+        metadata: %{"auto_generated" => true, "similarity_score" => 0.95}
+      })
+
+      # Pure predicate still true (status + marker), but authoritative check excludes it.
+      assert Knowledge.curated?(curated)
+      refute Knowledge.authoritative_curated?(curated)
+      refute curated.id in ids(Knowledge.list_curated_sources(tenant.id))
+    end
+  end
+
+  describe "system-scope precedence (TC-31.1.3 / AC-31.1.3)" do
+    test "system canonical participates but a tenant's own curated wins on the same topic" do
+      tenant_a = fixture(:tenant)
+
+      system = curated_system_article(%{title: "Topic X", body: "system answer"}, tenant_a.id)
+
+      tenant_own =
+        curated_article(tenant_a.id, %{
+          title: "Topic X",
+          body: "tenant answer",
+          category: :reference
+        })
+
+      # A system-only topic still participates.
+      system_only =
+        curated_system_article(%{title: "Topic Y", body: "system only"}, tenant_a.id)
+
+      result = Knowledge.list_curated_sources(tenant_a.id)
+      result_ids = ids(result)
+
+      # Tenant's own wins for Topic X; the system Topic X is suppressed (does not override).
+      assert tenant_own.id in result_ids
+      refute system.id in result_ids
+      # System canonical on a topic the tenant hasn't curated still participates.
+      assert system_only.id in result_ids
+    end
+
+    test "a system canonical participates when the tenant has no own answer on that topic" do
+      tenant_a = fixture(:tenant)
+      system = curated_system_article(%{title: "Only System Topic"}, tenant_a.id)
+
+      assert system.id in ids(Knowledge.list_curated_sources(tenant_a.id))
+    end
+  end
+
+  describe "list_curated_sources/2 tenant isolation (TC-31.1.4 / AC-31.1.5)" do
+    test "a fresh tenant sees none of another tenant's curated articles" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+
+      a_curated = curated_article(tenant_a.id, %{title: "Tenant A Secret"})
+
+      # tenant_b is fresh — its curated listing is empty and never leaks tenant_a's.
+      b_result = Knowledge.list_curated_sources(tenant_b.id)
+      assert b_result == []
+      refute a_curated.id in ids(b_result)
+    end
+
+    test "two-tenant isolation: each tenant's listing contains only its own (plus system)" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+
+      a_curated = curated_article(tenant_a.id, %{title: "A doc"})
+      b_curated = curated_article(tenant_b.id, %{title: "B doc"})
+
+      a_ids = ids(Knowledge.list_curated_sources(tenant_a.id))
+      b_ids = ids(Knowledge.list_curated_sources(tenant_b.id))
+
+      assert a_curated.id in a_ids
+      refute b_curated.id in a_ids
+
+      assert b_curated.id in b_ids
+      refute a_curated.id in b_ids
+    end
+  end
+
+  defp ids(articles), do: Enum.map(articles, & &1.id)
+end

--- a/test/loopctl/knowledge_curated_test.exs
+++ b/test/loopctl/knowledge_curated_test.exs
@@ -37,7 +37,10 @@ defmodule Loopctl.KnowledgeCuratedTest do
       )
 
     assert is_nil(article.tenant_id)
-    {:ok, marked} = Knowledge.mark_curated(nil, article.id, actor_label: "superadmin")
+
+    {:ok, marked} =
+      Knowledge.mark_curated(nil, article.id, actor_label: "superadmin", scope: :system)
+
     marked
   end
 
@@ -157,6 +160,94 @@ defmodule Loopctl.KnowledgeCuratedTest do
       audit = audit_event(system.id, "article.curated")
       assert is_nil(audit.tenant_id)
     end
+
+    test "nil-tenant curation is REJECTED without an explicit scope: :system opt-in" do
+      tenant = fixture(:tenant)
+
+      {:ok, system} =
+        Knowledge.create_article(tenant.id, %{
+          title: "Accidental Global",
+          body: "b",
+          category: :reference,
+          scope: :system,
+          status: :published
+        })
+
+      # An accidental/missing tenant context (nil) must NOT silently curate a GLOBAL
+      # canonical — the system path requires a deliberate scope: :system.
+      assert {:error, :system_scope_required} = Knowledge.mark_curated(nil, system.id, [])
+      assert {:error, :system_scope_required} = Knowledge.unmark_curated(nil, system.id, [])
+
+      # Reload: the marker was never written.
+      reloaded = AdminRepo.get!(Article, system.id)
+      assert is_nil(reloaded.curated_at)
+      refute Knowledge.curated?(reloaded)
+
+      # The deliberate path works.
+      assert {:ok, marked} =
+               Knowledge.mark_curated(nil, system.id, scope: :system, actor_label: "superadmin")
+
+      assert Knowledge.curated?(marked)
+    end
+  end
+
+  describe "curated marker invalidation on content edit (US-31.1 poisoning defense)" do
+    test "editing the BODY of a curated article clears the marker, forcing re-curation" do
+      tenant = fixture(:tenant)
+      curated = curated_article(tenant.id, %{body: "approved body"})
+      assert Knowledge.curated?(curated)
+
+      {:ok, edited} = Knowledge.update_article(tenant.id, curated.id, %{body: "poisoned body"})
+
+      # The governed marker was invalidated by the content change: the poisoned
+      # body is NOT authoritative until re-curated through the governed path.
+      assert is_nil(edited.curated_at)
+      refute Knowledge.curated?(edited)
+      refute edited.id in ids(Knowledge.list_curated_sources(tenant.id))
+    end
+
+    test "editing the TITLE of a curated article clears the marker" do
+      tenant = fixture(:tenant)
+      curated = curated_article(tenant.id, %{title: "Approved Title"})
+
+      {:ok, edited} = Knowledge.update_article(tenant.id, curated.id, %{title: "Changed Title"})
+
+      assert is_nil(edited.curated_at)
+      refute Knowledge.curated?(edited)
+    end
+
+    test "publishing a curated DRAFT via the ordinary edit path clears the marker" do
+      tenant = fixture(:tenant)
+      draft = fixture(:article, %{tenant_id: tenant.id, status: :draft})
+      {:ok, marked} = Knowledge.mark_curated(tenant.id, draft.id, [])
+
+      # Marker set but not yet effective (draft).
+      refute is_nil(marked.curated_at)
+      refute Knowledge.curated?(marked)
+
+      # Agent self-publishing via update must NOT flip it live under the admin marker.
+      {:ok, published} = Knowledge.update_article(tenant.id, draft.id, %{status: :published})
+
+      assert is_nil(published.curated_at)
+      refute Knowledge.curated?(published)
+    end
+
+    test "a pure metadata/tags edit PRESERVES the curated marker" do
+      tenant = fixture(:tenant)
+      curated = curated_article(tenant.id)
+      assert Knowledge.curated?(curated)
+
+      {:ok, edited} =
+        Knowledge.update_article(tenant.id, curated.id, %{
+          tags: ["a", "b"],
+          metadata: %{"note" => "unrelated"}
+        })
+
+      # No title/body/status change → the curator's approval still stands.
+      assert edited.curated_at == curated.curated_at
+      assert Knowledge.curated?(edited)
+      assert edited.id in ids(Knowledge.list_curated_sources(tenant.id))
+    end
   end
 
   describe "authoritative curated excludes draft/superseded/conflicted (TC-31.1.2)" do
@@ -234,6 +325,34 @@ defmodule Loopctl.KnowledgeCuratedTest do
       assert Knowledge.curated?(system)
       refute Knowledge.authoritative_curated?(system)
       refute system.id in ids(Knowledge.list_curated_sources(tenant.id))
+    end
+
+    test "one tenant's conflict over a system canonical does NOT retract it for OTHER tenants" do
+      # A system canonical is shared by every tenant. Tenant A opens a conflict link
+      # referencing it. The open-conflict exclusion is correlated on the CALLER's
+      # tenant, so the canonical is suppressed only in TENANT A's list — tenant B
+      # (uninvolved) still sees the global canonical. (Guards against a cross-tenant
+      # global retraction via a single tenant's dispute.)
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+
+      system = curated_system_article(%{title: "Shared Canonical"}, tenant_a.id)
+      other = curated_system_article(%{title: "Rival Shared", body: "rival"}, tenant_a.id)
+
+      # Conflict link lives under tenant_a only.
+      fixture(:article_link, %{
+        tenant_id: tenant_a.id,
+        source_article_id: system.id,
+        target_article_id: other.id,
+        relationship_type: :potential_conflict,
+        metadata: %{"auto_generated" => true, "similarity_score" => 0.95}
+      })
+
+      # Tenant A (the disputing tenant): canonical is withheld.
+      refute system.id in ids(Knowledge.list_curated_sources(tenant_a.id))
+
+      # Tenant B (uninvolved): the global canonical STILL participates.
+      assert system.id in ids(Knowledge.list_curated_sources(tenant_b.id))
     end
   end
 

--- a/test/loopctl/knowledge_curated_test.exs
+++ b/test/loopctl/knowledge_curated_test.exs
@@ -12,6 +12,7 @@ defmodule Loopctl.KnowledgeCuratedTest do
   setup :verify_on_exit!
 
   alias Loopctl.AdminRepo
+  alias Loopctl.Audit.AuditLog
   alias Loopctl.Knowledge
   alias Loopctl.Knowledge.Article
 
@@ -124,6 +125,38 @@ defmodule Loopctl.KnowledgeCuratedTest do
 
       assert {:error, :not_found} = Knowledge.mark_curated(tenant_b.id, article.id, [])
     end
+
+    test "mark_curated writes an article.curated audit event under the tenant" do
+      tenant = fixture(:tenant)
+      article = fixture(:article, %{tenant_id: tenant.id, status: :published})
+
+      {:ok, marked} =
+        Knowledge.mark_curated(tenant.id, article.id, actor_label: "user:admin")
+
+      audit = audit_event(article.id, "article.curated")
+      assert audit.tenant_id == tenant.id
+      assert audit.actor_label == "user:admin"
+      assert audit.new_state["curated_at"] == DateTime.to_iso8601(marked.curated_at)
+    end
+
+    test "unmark_curated writes an article.uncurated audit event" do
+      tenant = fixture(:tenant)
+      curated = curated_article(tenant.id)
+
+      {:ok, _unmarked} = Knowledge.unmark_curated(tenant.id, curated.id)
+
+      audit = audit_event(curated.id, "article.uncurated")
+      assert audit.tenant_id == tenant.id
+      assert is_nil(audit.new_state["curated_at"])
+    end
+
+    test "system-scope curation writes a GLOBAL (tenant_id nil) audit event" do
+      tenant = fixture(:tenant)
+      system = curated_system_article(%{title: "Global Canonical"}, tenant.id)
+
+      audit = audit_event(system.id, "article.curated")
+      assert is_nil(audit.tenant_id)
+    end
   end
 
   describe "authoritative curated excludes draft/superseded/conflicted (TC-31.1.2)" do
@@ -168,6 +201,40 @@ defmodule Loopctl.KnowledgeCuratedTest do
       refute Knowledge.authoritative_curated?(curated)
       refute curated.id in ids(Knowledge.list_curated_sources(tenant.id))
     end
+
+    test "authoritative_curated?/1 does not crash on a system canonical (tenant_id nil)" do
+      tenant = fixture(:tenant)
+      system = curated_system_article(%{title: "System Canonical"}, tenant.id)
+
+      # Regression: article_in_open_conflict?/1 used to compare `l.tenant_id == ^nil`,
+      # which Ecto rejects at runtime. A curated, non-conflicted system canonical MUST
+      # be authoritative (AC-31.1.3) rather than raising.
+      assert is_nil(system.tenant_id)
+      assert Knowledge.curated?(system)
+      assert Knowledge.authoritative_curated?(system)
+    end
+
+    test "a system canonical in an OPEN potential_conflict is not authoritative" do
+      tenant = fixture(:tenant)
+      system = curated_system_article(%{title: "Disputed System"}, tenant.id)
+
+      other =
+        curated_system_article(%{title: "Rival System", body: "rival"}, tenant.id)
+
+      # A system-scoped auto-generated conflict pair (links live under the tenant that
+      # surfaced them; correlation is by article id, so the system member still matches).
+      fixture(:article_link, %{
+        tenant_id: tenant.id,
+        source_article_id: system.id,
+        target_article_id: other.id,
+        relationship_type: :potential_conflict,
+        metadata: %{"auto_generated" => true, "similarity_score" => 0.95}
+      })
+
+      assert Knowledge.curated?(system)
+      refute Knowledge.authoritative_curated?(system)
+      refute system.id in ids(Knowledge.list_curated_sources(tenant.id))
+    end
   end
 
   describe "system-scope precedence (TC-31.1.3 / AC-31.1.3)" do
@@ -203,6 +270,43 @@ defmodule Loopctl.KnowledgeCuratedTest do
 
       assert system.id in ids(Knowledge.list_curated_sources(tenant_a.id))
     end
+
+    test "a tenant's own curated-but-conflicted topic still suppresses the system canonical" do
+      # AC-31.1.3 x AC-31.1.4 interaction: the tenant OWNS "Topic Z" (curated+published)
+      # but that own article is itself in an open conflict. It is excluded from the RESULT
+      # (AC-31.1.4), yet ownership is computed independently of conflict status, so the
+      # system canonical on the same topic is STILL suppressed — a system answer never
+      # overrides the tenant's own (disputed) answer. Net: neither surfaces; the conflict
+      # must be resolved first.
+      tenant_a = fixture(:tenant)
+
+      system = curated_system_article(%{title: "Topic Z", body: "system answer"}, tenant_a.id)
+
+      tenant_own =
+        curated_article(tenant_a.id, %{
+          title: "Topic Z",
+          body: "tenant answer",
+          category: :reference
+        })
+
+      rival =
+        fixture(:article, %{tenant_id: tenant_a.id, status: :published, title: "Topic Z Rival"})
+
+      fixture(:article_link, %{
+        tenant_id: tenant_a.id,
+        source_article_id: tenant_own.id,
+        target_article_id: rival.id,
+        relationship_type: :potential_conflict,
+        metadata: %{"auto_generated" => true, "similarity_score" => 0.95}
+      })
+
+      result_ids = ids(Knowledge.list_curated_sources(tenant_a.id))
+
+      # The conflicted tenant-own article is excluded (AC-31.1.4)...
+      refute tenant_own.id in result_ids
+      # ...and the system canonical on the same owned topic is STILL suppressed (AC-31.1.3).
+      refute system.id in result_ids
+    end
   end
 
   describe "list_curated_sources/2 tenant isolation (TC-31.1.4 / AC-31.1.5)" do
@@ -237,4 +341,12 @@ defmodule Loopctl.KnowledgeCuratedTest do
   end
 
   defp ids(articles), do: Enum.map(articles, & &1.id)
+
+  defp audit_event(article_id, action) do
+    from(a in AuditLog,
+      where: a.entity_type == "article" and a.entity_id == ^article_id,
+      where: a.action == ^action
+    )
+    |> AdminRepo.one!()
+  end
 end


### PR DESCRIPTION
## US-31.1 — Governed curated-source marker + scope rules

Domain-only foundation for the Epic 31 hybrid resolver (US-31.2). Adds a **governed** "curated" (authoritative) marker so an agent cannot self-promote its own article to authoritative and poison the hybrid path.

### The security constraint
Article.create_changeset/2 and update_changeset/2 cast :status and :metadata freely, and :category is agent-self-assignable. So the marker cannot live in category or metadata. It is a dedicated non-castable column written only through a governed path — the same isolation technique already used for :embedding.

### What is implemented
- Migration 20260712010000: articles.curated_at :utc_datetime_usec + advisory curated_by :string (nullable), plus a partial index for the curated-published listing.
- Article schema: curated_at/curated_by EXCLUDED from @cast_fields and update_changeset; writable ONLY via new curation_changeset/3.
- Knowledge context:
  - curated?/1 — PURE predicate (status == :published AND curated_at != nil), no DB, unit-testable. Category may filter, never suffices alone.
  - mark_curated/3 / unmark_curated/3 — the ONLY marker writers; audited (article.curated / article.uncurated) + logged to the KbCuration feed. Trust gate: HTTP surface (deferred to US-31.4) must be role-gated :user+.
  - list_curated_sources/2 — tenant own + system curated-published via explicit `where a.tenant_id == ^tenant_id or a.scope == :system` on AdminRepo (never RLS); tenant precedence over system on same topic; open-conflict exclusion.
  - authoritative_curated?/1 — curated?/1 AND not in an open :potential_conflict.
- Docs: curated definition + system-vs-tenant precedence in the Knowledge moduledoc / curated?/1 @doc and the epic README implementation notes.

### Acceptance criteria
- AC-31.1.1 governed marker, not agent-settable category — met (non-castable column; self-promotion test)
- AC-31.1.2 curated?/1 + scoped listing keyed on marker + published — met
- AC-31.1.3 system-scope precedence documented + enforced — met
- AC-31.1.4 only published; open-conflict excluded from authoritative — met
- AC-31.1.5 tenant-scoped, explicit-predicate two-tenant isolation test — met

### Tests
New test/loopctl/knowledge_curated_test.exs (13 tests): pure predicate, self-promotion-blocked (create + update), draft/superseded/conflicted exclusion, system precedence, two-tenant isolation. mix precommit green (format, credo --strict, dialyzer, 4109 tests / 0 failures).

Closes #305
