### PR TITLE
US-31.2 Hybrid resolver: prefer curated ONLY when it actually answers, else retrieval, with provenance

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -459,12 +459,33 @@ config :loopctl, :knowledge_lint_max_conflict_promotions, 500
 config :loopctl, :article_similarity_search, Loopctl.Knowledge.VectorSearch
 
 # Hybrid resolver (US-31.2): a curated candidate wins `:curated` ONLY when its
-# final_score clears this ABSOLUTE threshold AND beats the best retrieved
-# candidate by at least this margin (see Knowledge.resolve_provenance/4) — a curated
-# doc that is merely semantically near a query it doesn't answer must fall to
+# `Knowledge.absolute_score/1` — the RAW cosine similarity_score (bounded 0..1) for a
+# semantic match, or a bounded raw/(raw+1) transform of the raw ts_rank_cd
+# relevance_score for a keyword match — clears this ABSOLUTE threshold AND beats the
+# best retrieved candidate's absolute score by at least this margin (see
+# Knowledge.resolve_provenance/4). This is NEVER final_score (a pool-relative,
+# min-max-NORMALIZED 0..1 value built by merge_results/5 — a lone/top candidate in a
+# sparse pool always normalizes to 1.0 regardless of its true similarity, which is
+# exactly the false-confident-curated failure this threshold exists to prevent). A
+# curated doc that is merely semantically near a query it doesn't answer must fall to
 # `:retrieved`, never a false-authoritative claim (#305/#306).
+#
+# This pair is the SEMANTIC-scale (cosine similarity) threshold/margin. Cosine
+# similarity and ts_rank_cd are different, incommensurable scales, so the
+# KEYWORD-scale pair below is separate and must never be conflated with this one.
 config :loopctl, :knowledge_hybrid_curated_threshold, 0.75
 config :loopctl, :knowledge_hybrid_curated_margin, 0.1
+
+# Hybrid resolver (US-31.2), KEYWORD scale: applied instead of the semantic-scale pair
+# above when the winning curated candidate's absolute score comes from the bounded
+# raw/(raw+1) transform of ts_rank_cd (a keyword-only match — see
+# Knowledge.normalize_keyword_score/1), never the raw unbounded ts_rank_cd itself.
+# Calibrated against real ts_rank_cd output: a confidently-matching, normal-length
+# curated doc lands around ~0.67 after the transform, while a merely-incidental single
+# mention deep in an unrelated document lands around ~0.29 — 0.5 cleanly separates the
+# two with margin on both sides.
+config :loopctl, :knowledge_hybrid_curated_threshold_keyword, 0.5
+config :loopctl, :knowledge_hybrid_curated_margin_keyword, 0.1
 
 # DI: WebAuthn adapter — defaults to Wax (overridden in test env)
 config :loopctl, :webauthn_adapter, Loopctl.WebAuthn.Wax

--- a/config/config.exs
+++ b/config/config.exs
@@ -458,6 +458,14 @@ config :loopctl, :knowledge_lint_max_conflict_promotions, 500
 # linking logic can be unit-tested deterministically off the timed heavy-read path.
 config :loopctl, :article_similarity_search, Loopctl.Knowledge.VectorSearch
 
+# Hybrid resolver (US-31.2): a curated candidate wins `:curated` ONLY when its
+# final_score clears this ABSOLUTE threshold AND beats the best retrieved
+# candidate by at least this margin (see Knowledge.resolve_provenance/4) — a curated
+# doc that is merely semantically near a query it doesn't answer must fall to
+# `:retrieved`, never a false-authoritative claim (#305/#306).
+config :loopctl, :knowledge_hybrid_curated_threshold, 0.75
+config :loopctl, :knowledge_hybrid_curated_margin, 0.1
+
 # DI: WebAuthn adapter — defaults to Wax (overridden in test env)
 config :loopctl, :webauthn_adapter, Loopctl.WebAuthn.Wax
 

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -2596,6 +2596,12 @@ defmodule Loopctl.Knowledge do
     unbounded). Precedence suppression is applied IN THE QUERY (correlated
     subquery), so `:limit` bounds the FINAL result set, not a pre-suppression pull.
     Use it when the caller (e.g. the US-31.2 resolver) wants a bounded result.
+  - `:select` -- set `:id` for a body-less projection that returns a plain list of
+    article UUIDs (`[Ecto.UUID.t()]`) instead of full `%Article{}` structs. Use this
+    for identity/membership checks (e.g. the US-31.2 hybrid resolver's curated-id
+    lookup) so per-query cost no longer scales with the curated corpus's article
+    BODIES — only ids leave the database. Default (`nil`/anything else) returns full
+    structs, unchanged.
 
   Results are ordered tenant-own-first (tenant rows before system canonicals), then
   most-recently-updated.
@@ -2608,15 +2614,29 @@ defmodule Loopctl.Knowledge do
   `mark_curated` could open between two reads, and (b) removes the previously
   unbounded full curated-title scan — ownership is now evaluated per candidate row
   via the partial index `articles_curated_published_idx`, so `:limit` genuinely
-  bounds the work. This still returns full `%Article{}` structs (including bodies);
-  if the curated corpus grows into a hot path, add cursor pagination or a body-less
-  projection before this becomes a bottleneck.
+  bounds the work. Pass `select: :id` (above) for a body-less projection when only
+  membership/identity is needed — the default remains full `%Article{}` structs
+  (including bodies) for callers that need the whole record.
   """
-  @spec list_curated_sources(Ecto.UUID.t(), keyword()) :: [Article.t()]
+  @spec list_curated_sources(Ecto.UUID.t(), keyword()) :: [Article.t()] | [Ecto.UUID.t()]
   def list_curated_sources(tenant_id, opts \\ []) when is_binary(tenant_id) do
-    include_system = Keyword.get(opts, :include_system, true)
     category = Keyword.get(opts, :category)
     limit = Keyword.get(opts, :limit)
+
+    base =
+      tenant_id
+      |> curated_sources_base_query(category, opts)
+      |> maybe_filter_curated_by_category(category)
+      |> maybe_limit_curated(limit)
+
+    case Keyword.get(opts, :select) do
+      :id -> base |> select([a], a.id) |> AdminRepo.all()
+      _ -> AdminRepo.all(base)
+    end
+  end
+
+  defp curated_sources_base_query(tenant_id, category, opts) do
+    include_system = Keyword.get(opts, :include_system, true)
 
     scope_filter =
       if include_system do
@@ -2634,29 +2654,28 @@ defmodule Loopctl.Knowledge do
         dynamic([a], a.tenant_id == ^tenant_id)
       end
 
-    base =
-      from(a in Article,
-        as: :article,
-        where: a.status == :published,
-        where: not is_nil(a.curated_at),
-        where: ^scope_filter,
-        # AC-31.1.4: never surface an article that is in an OPEN potential_conflict.
-        where: not exists(open_conflict_subquery(tenant_id)),
-        # Tenant-own-first: tenant rows (tenant_id NOT NULL, so `IS NULL` = false)
-        # sort before system canonicals (tenant_id NULL, `IS NULL` = true), then freshest.
-        order_by: [asc: fragment("? IS NULL", a.tenant_id), desc: a.updated_at, asc: a.id]
-      )
-
-    base =
-      case category do
-        nil -> base
-        cat -> from(a in base, where: a.category == ^cat)
-      end
-
-    base = if is_integer(limit) and limit > 0, do: from(a in base, limit: ^limit), else: base
-
-    AdminRepo.all(base)
+    from(a in Article,
+      as: :article,
+      where: a.status == :published,
+      where: not is_nil(a.curated_at),
+      where: ^scope_filter,
+      # AC-31.1.4: never surface an article that is in an OPEN potential_conflict.
+      where: not exists(open_conflict_subquery(tenant_id)),
+      # Tenant-own-first: tenant rows (tenant_id NOT NULL, so `IS NULL` = false)
+      # sort before system canonicals (tenant_id NULL, `IS NULL` = true), then freshest.
+      order_by: [asc: fragment("? IS NULL", a.tenant_id), desc: a.updated_at, asc: a.id]
+    )
   end
+
+  defp maybe_filter_curated_by_category(query, nil), do: query
+
+  defp maybe_filter_curated_by_category(query, category),
+    do: from(a in query, where: a.category == ^category)
+
+  defp maybe_limit_curated(query, limit) when is_integer(limit) and limit > 0,
+    do: from(a in query, limit: ^limit)
+
+  defp maybe_limit_curated(query, _limit), do: query
 
   # Subquery correlated on the outer :article binding: TRUE when the article is a
   # member of an auto-generated :potential_conflict pair that has NOT yet been
@@ -6352,9 +6371,19 @@ defmodule Loopctl.Knowledge do
         {r.id, Map.put(r, :final_score, sem_weight * r.normalized_score)}
       end)
 
+    # For a candidate found in BOTH pools, `Map.merge(kw, sem)` keeps EACH side's
+    # exclusive raw fields (kw's raw `:relevance_score`/`:snippet`, sem's raw
+    # `:similarity_score`) instead of silently dropping one — the hybrid resolver
+    # (US-31.2) needs both raw, ABSOLUTE (non-pool-relative) scores to survive on the
+    # merged result map so it never has to fall back to the pool-normalized
+    # `:final_score` for its curated-confidence decision (see `absolute_score/1`).
+    # `:final_score` itself is explicitly overridden to the correct weighted SUM
+    # (Map.merge alone would have just taken sem's half).
     merged =
       Map.merge(kw_map, sem_map, fn _id, kw, sem ->
-        Map.put(kw, :final_score, kw.final_score + sem.final_score)
+        kw
+        |> Map.merge(sem)
+        |> Map.put(:final_score, kw.final_score + sem.final_score)
       end)
 
     sorted =
@@ -6415,6 +6444,299 @@ defmodule Loopctl.Knowledge do
       |> Enum.take(limit)
 
     %{results: paginated, limit: limit, offset: offset}
+  end
+
+  # --- Hybrid resolver (US-31.2) ---
+  #
+  # Composes the ALREADY-SHIPPED retrieval (`search_combined/3`) and curated
+  # (`list_curated_sources/2` / US-31.1) subsystems into a single resolution layer.
+  # Does NOT re-architect embeddings or add a migration (#305/#306).
+
+  @default_hybrid_curated_threshold 0.75
+  @default_hybrid_curated_margin 0.1
+
+  @doc """
+  Hybrid resolver (US-31.2): returns a **curated** answer ONLY when a governed curated
+  source (US-31.1) actually answers the query — else falls back to **retrieval**
+  (`search_combined/3`). Every response carries `meta.provenance` (`:curated` |
+  `:retrieved`) so a caller branches on that FIELD alone, never on which subsystem
+  answered (the literal fix for #305's "no caller-side RAG-or-curated branching").
+
+  The harvested failure this guards against is WORSE than a plain RAG miss: a curated
+  doc that is semantically near a query it does NOT answer, mislabeled authoritative,
+  is a confidently-wrong answer that is now trusted. So `:curated` requires ALL of:
+
+    * the curated candidate's ABSOLUTE confidence score (see `absolute_score/1` below
+      — never a pool-relative, min-max-normalized score) clears the absolute
+      confidence threshold (config `:knowledge_hybrid_curated_threshold`, default
+      `#{@default_hybrid_curated_threshold}`), AND
+    * it beats the best NON-curated candidate's absolute score by a margin (config
+      `:knowledge_hybrid_curated_margin`, default `#{@default_hybrid_curated_margin}`),
+      AND
+    * it is authoritative (published, not superseded, not in an open
+      `:potential_conflict` — enforced by `list_curated_sources/2`, US-31.1).
+
+  Otherwise the response is `:retrieved` — a near-but-wrong curated doc that is
+  semantically close but below threshold, or not competitive against retrieval, NEVER
+  wins `:curated`. See `resolve_provenance/4` for the pure decision rule.
+
+  ## Absolute, not pool-relative, scoring (AC-31.2.1/.2 — critical fix)
+
+  `final_score` (built by `merge_results/5`) is a min-max-NORMALIZED, pool-RELATIVE
+  score: a lone or top candidate in an otherwise-sparse pool always normalizes to
+  `1.0` regardless of its TRUE similarity/relevance — that would let a curated doc
+  win `:curated` at "confidence 1.0" even when it barely relates to the query. The
+  provenance decision therefore scores every candidate via `absolute_score/1`, which
+  reads the RAW, un-normalized field straight off the result map: `:similarity_score`
+  (`1 - cosine_distance`, already on an absolute 0..1 scale) when present, else the
+  raw `:relevance_score` (`ts_rank_cd`, absolute/non-pool-relative though unbounded).
+  `merge_results/5` preserves BOTH raw fields on every merged candidate (not just the
+  winning half) specifically so this is always possible in "combined" mode.
+
+  ## Resolved over the ranked pool, independent of the caller's page (AC-31.2.1/.2)
+
+  The provenance decision is made over the FULL ranked candidate pool (up to
+  `#{@max_relevance_page_size}` per side, the same cap `search_combined/3` already
+  uses for its sub-searches) — NOT the caller's paginated page. A genuinely-answering
+  curated source ranked outside the caller's requested `:limit`/`:offset` window is
+  still found and scored; a caller-supplied `:offset` shifts only which page of
+  `results` comes BACK, never which candidates the resolver reasons over.
+
+  ## Tenant isolation (AC-31.2.6)
+
+  `tenant_id` is threaded into BOTH `search_combined/3` (retrieval) AND
+  `list_curated_sources/2` (curated identification) — both run on `AdminRepo`/
+  `HeavyRead` (BYPASSRLS). RLS does NOT backstop these reads; the explicit predicate
+  in each function is the sole isolation boundary.
+
+  ## Degradation honesty (AC-31.2.4, SOUL rule 7)
+
+  This function does NOT re-implement `search_combined/3`'s embedding degradation — it
+  reuses it. When embeddings are unavailable, `search_combined/3` already falls back to
+  keyword-only (`meta.fallback: true`, `meta.search_mode: "keyword_only"`) and the
+  curated candidate's absolute (raw `ts_rank_cd`) score in that pool is compared
+  against the SAME absolute threshold: a curated source still confidently identifiable
+  by keyword can win `:curated`; a merely-incidental keyword hit (low raw rank) falls
+  to `:retrieved`, same as a weak semantic match would. Never a silent empty, never a
+  false `:curated` under degraded matching.
+
+  ## Shape parity (AC-31.2.3)
+
+  Both provenance branches return the IDENTICAL map shape: `results` is the caller's
+  requested page of the SAME ranked pool used for scoring (so per-result keys are
+  identical by construction — nothing is added/removed based on provenance), and
+  `meta` is always `search_combined/3`'s own meta (with `:limit`/`:offset` overridden
+  to the caller's actual requested page) merged with exactly `%{provenance: ...,
+  confidence: ...}` — no key ever appears on only one branch.
+
+  ## Provenance metrics (AC-31.2.5)
+
+  The retrieval pool's OWN search-access recording is suppressed
+  (`_skip_record_access: true` on the inner `search_combined/3` call, mirroring how
+  `do_combined_search/5` already dedupes its own sub-search recordings) and replaced
+  with a SINGLE recording (scoped to the caller's returned page) tagged
+  `mode: "hybrid_curated"` or `mode: "hybrid_retrieved"` in the `ArticleAccessEvent`
+  metadata — an additive extension of the existing mode tags (`"keyword"`,
+  `"semantic"`, `"combined"`). This rides the existing
+  `Loopctl.Knowledge.RetrievalMetrics` / `article_access_events` pipeline (see its
+  `curated_searched`/`retrieved_searched` breakdown), so "prefer-curated silently
+  hiding better retrieval" is observable per tenant without a new table. That DB-backed
+  recording still requires a non-empty page + `:api_key_id` (an inherited constraint of
+  `article_access_events`, whose `article_id`/`api_key_id` are NOT NULL); a MISS
+  (empty page) or a keyless call additionally emits a bare
+  `[:loopctl, :knowledge, :hybrid_provenance]` telemetry count (tenant/provenance/hit
+  only — no article/query content) so that dimension stays observable too (closes the
+  gap the DB recording structurally cannot).
+
+  ## Parameters
+
+  - `tenant_id` -- the tenant UUID
+  - `query_string` -- the search query text
+  - `opts` -- forwarded to `search_combined/3` (`:keyword_weight`, `:semantic_weight`,
+    `:project_id`, `:category`, `:status`, `:tags`, `:limit`, `:offset`,
+    `:api_key_id`, `:project_id`/`:story_id` attribution)
+
+  ## Returns
+
+  - `{:ok, %{results: [map()], meta: map()}}` -- `meta.provenance` is `:curated` or
+    `:retrieved`, `meta.confidence` is the winning candidate's ABSOLUTE score (0.0 when
+    there are no results at all)
+  - `{:error, :invalid_weights}` / `{:error, :empty_query}` / `{:error, atom(),
+    String.t()}` -- propagated unchanged from `search_combined/3`
+  """
+  @spec hybrid_search(Ecto.UUID.t(), String.t(), keyword()) ::
+          {:ok, %{results: [map()], meta: map()}}
+          | {:error, :invalid_weights}
+          | {:error, :empty_query}
+          | {:error, atom(), String.t()}
+  def hybrid_search(tenant_id, query_string, opts \\ []) when is_binary(tenant_id) do
+    requested_limit = Keyword.get(opts, :limit, 10)
+    requested_offset = Keyword.get(opts, :offset, 0)
+
+    # Force the INNER search over the full ranked pool (offset 0, the same cap
+    # `search_combined/3`'s own sub-searches already use) so the provenance decision
+    # below reasons over the top of the ranked pool, never just the caller's
+    # requested page — a curated source ranked outside `:limit`/beyond `:offset` is
+    # still found and scored (AC-31.2.1/.2, fixes the pagination-scoped defect).
+    pool_opts =
+      opts
+      |> Keyword.put(:_skip_record_access, true)
+      |> Keyword.put(:limit, @max_relevance_page_size)
+      |> Keyword.put(:offset, 0)
+
+    with {:ok, %{results: pool_results, meta: pool_meta}} <-
+           search_combined(tenant_id, query_string, pool_opts) do
+      curated_ids = curated_source_ids(tenant_id)
+      scores = candidate_scores(pool_results)
+
+      {curated_candidates, retrieved_candidates} =
+        Enum.split_with(pool_results, &MapSet.member?(curated_ids, &1.id))
+
+      best_curated = Enum.max_by(curated_candidates, &Map.fetch!(scores, &1.id), fn -> nil end)
+      curated_score = best_curated && Map.fetch!(scores, best_curated.id)
+      best_retrieved_score = best_score(retrieved_candidates, scores)
+
+      provenance =
+        resolve_provenance(
+          curated_score,
+          best_retrieved_score,
+          hybrid_curated_threshold(),
+          hybrid_curated_margin()
+        )
+
+      confidence =
+        case provenance do
+          :curated -> curated_score
+          :retrieved -> best_score(pool_results, scores)
+        end
+
+      page = paginate_results(pool_results, limit: requested_limit, offset: requested_offset)
+
+      maybe_record_search_access(
+        tenant_id,
+        page.results,
+        query_string,
+        opts,
+        hybrid_search_mode(provenance)
+      )
+
+      emit_hybrid_provenance(tenant_id, provenance, page.results != [])
+
+      {:ok,
+       %{
+         results: page.results,
+         meta:
+           Map.merge(pool_meta, %{
+             provenance: provenance,
+             confidence: confidence,
+             limit: page.limit,
+             offset: page.offset
+           })
+       }}
+    end
+  end
+
+  # Body-less/id-only curated lookup (finding 5): `list_curated_sources/2` defaults to
+  # returning full `%Article{}` structs (including bodies), which the resolver would
+  # otherwise discard entirely except for `.id`. `select: :id` keeps this a per-query
+  # hot path cheap regardless of how large the curated corpus grows.
+  defp curated_source_ids(tenant_id) do
+    tenant_id |> list_curated_sources(select: :id) |> MapSet.new()
+  end
+
+  # Builds an id -> ABSOLUTE (non-pool-relative) score index used ONLY for the
+  # provenance decision — `results` themselves are unaffected (AC-31.2.3 shape
+  # parity). See `absolute_score/1` for why this reads raw fields instead of the
+  # pool-normalized `:final_score`/`:normalized_score`.
+  defp candidate_scores(results) do
+    Map.new(results, fn r -> {r.id, absolute_score(r)} end)
+  end
+
+  # The ABSOLUTE, per-candidate confidence signal (critical fix, AC-31.2.1/.2): NEVER
+  # the pool-relative, min-max-normalized `:final_score`/`:normalized_score` — those
+  # force a lone/top candidate in a sparse pool to normalize to `1.0` regardless of its
+  # TRUE similarity, which is exactly the false-confident-curated failure this resolver
+  # exists to prevent.
+  #
+  # Prefers the raw `:similarity_score` (`1 - cosine_distance`, already on an absolute
+  # 0..1 scale — see `search_semantic/3`) when the candidate was found in the semantic
+  # pool; falls back to the raw `:relevance_score` (`ts_rank_cd` — see `search_keyword/3`)
+  # for a keyword-only candidate. Both are ABSOLUTE (computed independently of what
+  # else is in the pool), unlike `normalize_scores/2`'s output. `merge_results/5`
+  # preserves BOTH raw fields on a candidate found in both pools, so this always has
+  # the more-precisely-bounded semantic signal available when there is one.
+  defp absolute_score(%{similarity_score: score}) when is_number(score), do: score
+  defp absolute_score(%{relevance_score: score}) when is_number(score), do: score
+  defp absolute_score(_result), do: 0.0
+
+  defp best_score([], _scores), do: 0.0
+
+  defp best_score(results, scores),
+    do: results |> Enum.map(&Map.fetch!(scores, &1.id)) |> Enum.max()
+
+  defp hybrid_search_mode(:curated), do: "hybrid_curated"
+  defp hybrid_search_mode(:retrieved), do: "hybrid_retrieved"
+
+  # Bare telemetry signal for AC-31.2.5's hit/miss + keyless observability gap
+  # (finding 6): `maybe_record_search_access/5` structurally CANNOT record a MISS
+  # (empty page — `article_id` is NOT NULL on `article_access_events`) or a keyless
+  # call (no `api_key_id` to attribute to), so those two dimensions would otherwise be
+  # invisible. This fires UNCONDITIONALLY (regardless of page emptiness or api key
+  # presence) so an operator can attach a handler (or the `ScaleMetrics` counter) and
+  # see EVERY provenance decision, not just the ones that happened to produce a
+  # recordable DB row. Payload is id/atom/bool only — never article content or the
+  # query text.
+  defp emit_hybrid_provenance(tenant_id, provenance, hit?) do
+    :telemetry.execute(
+      Loopctl.TelemetryEvents.knowledge_hybrid_provenance(),
+      %{count: 1},
+      %{tenant_id: tenant_id, provenance: Atom.to_string(provenance), hit: hit?}
+    )
+
+    :ok
+  end
+
+  @doc """
+  Pure resolution rule (TC-31.2.4) behind `hybrid_search/3` — no DB, unit-testable in
+  isolation.
+
+  `:curated` iff `curated_score` is present AND clears `threshold` AND beats
+  `best_retrieved_score` by at least `margin`; `:retrieved` otherwise (including when
+  `curated_score` is `nil` — no authoritative curated candidate was in the pool at
+  all). This is the SINGLE, non-contradictory decision: AC-31.2.1 ("above threshold")
+  and AC-31.2.2 ("beats retrieval by a margin, not superseded/conflicted") are both
+  folded in here — the caller is responsible for only ever passing an ALREADY
+  authoritative (`list_curated_sources/2`-filtered) `curated_score`, so the
+  superseded/conflicted leg never reaches this pure function as a false positive.
+  """
+  @spec resolve_provenance(number() | nil, number(), number(), number()) ::
+          :curated | :retrieved
+  def resolve_provenance(nil, _best_retrieved_score, _threshold, _margin), do: :retrieved
+
+  def resolve_provenance(curated_score, best_retrieved_score, threshold, margin)
+      when is_number(curated_score) and is_number(best_retrieved_score) and
+             is_number(threshold) and is_number(margin) do
+    if curated_score >= threshold and curated_score - best_retrieved_score >= margin do
+      :curated
+    else
+      :retrieved
+    end
+  end
+
+  defp hybrid_curated_threshold do
+    Application.get_env(
+      :loopctl,
+      :knowledge_hybrid_curated_threshold,
+      @default_hybrid_curated_threshold
+    )
+  end
+
+  defp hybrid_curated_margin do
+    Application.get_env(
+      :loopctl,
+      :knowledge_hybrid_curated_margin,
+      @default_hybrid_curated_margin
+    )
   end
 
   # --- Circuit breaker for embedding generation ---

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -2601,10 +2601,16 @@ defmodule Loopctl.Knowledge do
     for identity/membership checks (e.g. the US-31.2 hybrid resolver's curated-id
     lookup) so per-query cost no longer scales with the curated corpus's article
     BODIES — only ids leave the database. Default (`nil`/anything else) returns full
-    structs, unchanged.
+    structs, unchanged. Combined with `:select, :id`, the `order_by` is also dropped
+    (a MapSet has no order) — pure wasted sort work otherwise.
+  - `:ids` -- restrict the scan to this list of article UUIDs (e.g. a caller's
+    already-fetched candidate pool). Use this WITH `select: :id` so per-query cost
+    scales with the caller's candidate set, not the tenant's entire curated/system-
+    canonical corpus (US-31.2's `curated_source_ids/2` is the reference caller).
+    Default (`nil`) scans the full curated corpus, unchanged.
 
   Results are ordered tenant-own-first (tenant rows before system canonicals), then
-  most-recently-updated.
+  most-recently-updated (unless `select: :id` drops the order, see above).
 
   ## Consistency & scaling notes
 
@@ -2622,15 +2628,21 @@ defmodule Loopctl.Knowledge do
   def list_curated_sources(tenant_id, opts \\ []) when is_binary(tenant_id) do
     category = Keyword.get(opts, :category)
     limit = Keyword.get(opts, :limit)
+    ids = Keyword.get(opts, :ids)
 
     base =
       tenant_id
       |> curated_sources_base_query(category, opts)
       |> maybe_filter_curated_by_category(category)
+      |> maybe_filter_curated_by_ids(ids)
       |> maybe_limit_curated(limit)
 
     case Keyword.get(opts, :select) do
-      :id -> base |> select([a], a.id) |> AdminRepo.all()
+      # `order_by` is pure wasted sort work once the result is collapsed into a
+      # MapSet (order is irrelevant to membership) — dropped here so an `:ids`-scoped
+      # membership check (e.g. `curated_source_ids/2`) never pays for a corpus-wide
+      # sort it never uses (review finding, US-31.2).
+      :id -> base |> exclude(:order_by) |> select([a], a.id) |> AdminRepo.all()
       _ -> AdminRepo.all(base)
     end
   end
@@ -2671,6 +2683,16 @@ defmodule Loopctl.Knowledge do
 
   defp maybe_filter_curated_by_category(query, category),
     do: from(a in query, where: a.category == ^category)
+
+  # Membership scope (US-31.2 fix): restricts the curated-corpus scan to only the
+  # given article ids (e.g. the hybrid resolver's <=200-candidate pool) instead of
+  # materializing the tenant's ENTIRE curated/system-canonical universe just to test
+  # membership of a small candidate set. `nil` (the default) is a no-op — every other
+  # caller keeps scanning the full curated corpus unaffected.
+  defp maybe_filter_curated_by_ids(query, nil), do: query
+
+  defp maybe_filter_curated_by_ids(query, ids) when is_list(ids),
+    do: from(a in query, where: a.id in ^ids)
 
   defp maybe_limit_curated(query, limit) when is_integer(limit) and limit > 0,
     do: from(a in query, limit: ^limit)
@@ -6454,6 +6476,15 @@ defmodule Loopctl.Knowledge do
 
   @default_hybrid_curated_threshold 0.75
   @default_hybrid_curated_margin 0.1
+  # Keyword-scale (bounded `raw / (raw + 1)` transform of `ts_rank_cd`, see
+  # `normalize_keyword_score/1`) threshold/margin — deliberately a DIFFERENT default
+  # than the semantic-scale pair above. Calibrated against real `ts_rank_cd` output
+  # (verified empirically): a confidently-matching, normal-length curated doc lands
+  # around `~0.67`, while a merely-incidental single mention deep in an unrelated
+  # document lands around `~0.29` — `0.5` cleanly separates the two with margin on
+  # both sides.
+  @default_hybrid_curated_threshold_keyword 0.5
+  @default_hybrid_curated_margin_keyword 0.1
 
   @doc """
   Hybrid resolver (US-31.2): returns a **curated** answer ONLY when a governed curated
@@ -6468,10 +6499,15 @@ defmodule Loopctl.Knowledge do
 
     * the curated candidate's ABSOLUTE confidence score (see `absolute_score/1` below
       — never a pool-relative, min-max-normalized score) clears the absolute
-      confidence threshold (config `:knowledge_hybrid_curated_threshold`, default
-      `#{@default_hybrid_curated_threshold}`), AND
-    * it beats the best NON-curated candidate's absolute score by a margin (config
-      `:knowledge_hybrid_curated_margin`, default `#{@default_hybrid_curated_margin}`),
+      confidence threshold FOR ITS OWN SCALE (config
+      `:knowledge_hybrid_curated_threshold`, default `#{@default_hybrid_curated_threshold}`,
+      for a semantic/cosine match; `:knowledge_hybrid_curated_threshold_keyword`,
+      default `#{@default_hybrid_curated_threshold_keyword}`, for a keyword-only
+      match), AND
+    * it beats the best NON-curated candidate's absolute score by the matching margin
+      (config `:knowledge_hybrid_curated_margin` /
+      `:knowledge_hybrid_curated_margin_keyword`, defaults
+      `#{@default_hybrid_curated_margin}` / `#{@default_hybrid_curated_margin_keyword}`),
       AND
     * it is authoritative (published, not superseded, not in an open
       `:potential_conflict` — enforced by `list_curated_sources/2`, US-31.1).
@@ -6488,10 +6524,20 @@ defmodule Loopctl.Knowledge do
   win `:curated` at "confidence 1.0" even when it barely relates to the query. The
   provenance decision therefore scores every candidate via `absolute_score/1`, which
   reads the RAW, un-normalized field straight off the result map: `:similarity_score`
-  (`1 - cosine_distance`, already on an absolute 0..1 scale) when present, else the
-  raw `:relevance_score` (`ts_rank_cd`, absolute/non-pool-relative though unbounded).
-  `merge_results/5` preserves BOTH raw fields on every merged candidate (not just the
-  winning half) specifically so this is always possible in "combined" mode.
+  (`1 - cosine_distance`, already on an absolute, bounded `0..1` scale) when present,
+  else a BOUNDED transform of the raw `:relevance_score` (`ts_rank_cd`, itself
+  unbounded — confirmed empirically up to ~2.0 for a short, title-exact match) — see
+  `normalize_keyword_score/1`. `merge_results/5` preserves BOTH raw fields on every
+  merged candidate (not just the winning half) specifically so this is always possible
+  in "combined" mode.
+
+  Cosine similarity and (normalized) `ts_rank_cd` are DIFFERENT, incommensurable
+  scales — comparing them with ONE raw threshold/margin pair would either make the
+  keyword branch practically unreachable (a realistic keyword-confident match sits
+  well below a cosine-tuned `0.75`) or let an unnaturally high/low score on one scale
+  distort a cross-scale margin subtraction. `hybrid_curated_threshold_and_margin/1`
+  therefore selects the config pair matching the WINNING curated candidate's OWN
+  scale (finding, US-31.2) — the threshold/margin is never compared across scales.
 
   ## Resolved over the ranked pool, independent of the caller's page (AC-31.2.1/.2)
 
@@ -6500,7 +6546,12 @@ defmodule Loopctl.Knowledge do
   uses for its sub-searches) — NOT the caller's paginated page. A genuinely-answering
   curated source ranked outside the caller's requested `:limit`/`:offset` window is
   still found and scored; a caller-supplied `:offset` shifts only which page of
-  `results` comes BACK, never which candidates the resolver reasons over.
+  `results` comes BACK, never which candidates the resolver reasons over. When
+  `:curated` wins, the winning article is additionally hoisted to the FRONT of the
+  (still full, still ranked) pool BEFORE pagination — so `meta.provenance == :curated`
+  always means `results |> List.first()` (at `offset: 0`) IS that curated answer,
+  never a decoy that merely out-ranked it on the pool-relative `:final_score` (the
+  "label != payload" defect this resolver exists to prevent, #305).
 
   ## Tenant isolation (AC-31.2.6)
 
@@ -6514,20 +6565,22 @@ defmodule Loopctl.Knowledge do
   This function does NOT re-implement `search_combined/3`'s embedding degradation — it
   reuses it. When embeddings are unavailable, `search_combined/3` already falls back to
   keyword-only (`meta.fallback: true`, `meta.search_mode: "keyword_only"`) and the
-  curated candidate's absolute (raw `ts_rank_cd`) score in that pool is compared
-  against the SAME absolute threshold: a curated source still confidently identifiable
-  by keyword can win `:curated`; a merely-incidental keyword hit (low raw rank) falls
-  to `:retrieved`, same as a weak semantic match would. Never a silent empty, never a
-  false `:curated` under degraded matching.
+  curated candidate's absolute (normalized `ts_rank_cd`) score in that pool is compared
+  against the matching KEYWORD-scale threshold: a curated source still confidently
+  identifiable by keyword can win `:curated`; a merely-incidental keyword hit (low raw
+  rank) falls to `:retrieved`, same as a weak semantic match would. Never a silent
+  empty, never a false `:curated` under degraded matching.
 
   ## Shape parity (AC-31.2.3)
 
   Both provenance branches return the IDENTICAL map shape: `results` is the caller's
-  requested page of the SAME ranked pool used for scoring (so per-result keys are
-  identical by construction — nothing is added/removed based on provenance), and
-  `meta` is always `search_combined/3`'s own meta (with `:limit`/`:offset` overridden
-  to the caller's actual requested page) merged with exactly `%{provenance: ...,
-  confidence: ...}` — no key ever appears on only one branch.
+  requested page of the SAME ranked pool used for scoring — reordered (curated winner
+  hoisted to the front) rather than re-filtered when `:curated` wins, so per-result
+  keys are identical by construction regardless of provenance — and `meta` is always
+  `search_combined/3`'s own meta (with `:limit`/`:offset` overridden to the caller's
+  actual requested page) merged with exactly `%{provenance: ..., confidence: ...,
+  curated_article_id: ...}` — no key ever appears on only one branch (`curated_article_id`
+  is `nil` on the `:retrieved` branch).
 
   ## Provenance metrics (AC-31.2.5)
 
@@ -6559,8 +6612,12 @@ defmodule Loopctl.Knowledge do
   ## Returns
 
   - `{:ok, %{results: [map()], meta: map()}}` -- `meta.provenance` is `:curated` or
-    `:retrieved`, `meta.confidence` is the winning candidate's ABSOLUTE score (0.0 when
-    there are no results at all)
+    `:retrieved`. `meta.confidence` is the winning candidate's ABSOLUTE score for that
+    SAME provenance class (0.0 when there are no results at all, or when `:retrieved`
+    won with no genuine non-curated competitor in the pool) — never a rejected
+    candidate from the OTHER provenance class. `meta.curated_article_id` is the
+    winning curated article's id when `meta.provenance == :curated` (and it is
+    guaranteed to be present, first, in `results`), else `nil`.
   - `{:error, :invalid_weights}` / `{:error, :empty_query}` / `{:error, atom(),
     String.t()}` -- propagated unchanged from `search_combined/3`
   """
@@ -6586,7 +6643,7 @@ defmodule Loopctl.Knowledge do
 
     with {:ok, %{results: pool_results, meta: pool_meta}} <-
            search_combined(tenant_id, query_string, pool_opts) do
-      curated_ids = curated_source_ids(tenant_id)
+      curated_ids = curated_source_ids(tenant_id, pool_results)
       scores = candidate_scores(pool_results)
 
       {curated_candidates, retrieved_candidates} =
@@ -6596,21 +6653,30 @@ defmodule Loopctl.Knowledge do
       curated_score = best_curated && Map.fetch!(scores, best_curated.id)
       best_retrieved_score = best_score(retrieved_candidates, scores)
 
-      provenance =
-        resolve_provenance(
-          curated_score,
-          best_retrieved_score,
-          hybrid_curated_threshold(),
-          hybrid_curated_margin()
-        )
+      {threshold, margin} = hybrid_curated_threshold_and_margin(best_curated)
 
-      confidence =
+      provenance = resolve_provenance(curated_score, best_retrieved_score, threshold, margin)
+
+      # (finding: mislabeled-authoritative decoy) When `:curated` wins, the winning
+      # curated article MUST actually be present — and first — in the returned page,
+      # never just a label attached to whatever the pool-relative ranking happened to
+      # place in the requested window. Reordering the FULL pool (not just the page)
+      # keeps `results` sourced from the same ranked pool for every offset (AC-31.2.3
+      # shape parity is unaffected — same map shape, just reordered).
+      {ordered_pool, confidence, curated_article_id} =
         case provenance do
-          :curated -> curated_score
-          :retrieved -> best_score(pool_results, scores)
+          :curated ->
+            {hoist_to_front(pool_results, best_curated.id), curated_score, best_curated.id}
+
+          :retrieved ->
+            # (finding: mislabeled confidence) `best_retrieved_score` — NEVER
+            # `best_score(pool_results, scores)`, which would report a REJECTED
+            # curated candidate's score (a different provenance class) as if it were
+            # the winning retrieved candidate's confidence.
+            {pool_results, best_retrieved_score, nil}
         end
 
-      page = paginate_results(pool_results, limit: requested_limit, offset: requested_offset)
+      page = paginate_results(ordered_pool, limit: requested_limit, offset: requested_offset)
 
       maybe_record_search_access(
         tenant_id,
@@ -6629,6 +6695,11 @@ defmodule Loopctl.Knowledge do
            Map.merge(pool_meta, %{
              provenance: provenance,
              confidence: confidence,
+             # Always present on BOTH branches (nil for `:retrieved`) so a caller can
+             # locate the curated answer via `meta.curated_article_id` even when the
+             # ranked pool's own ordering places it outside `results` — the actionable
+             # pointer this finding required alongside the hoist above.
+             curated_article_id: curated_article_id,
              limit: page.limit,
              offset: page.offset
            })
@@ -6636,12 +6707,28 @@ defmodule Loopctl.Knowledge do
     end
   end
 
+  # Moves the winning curated candidate to the FRONT of the pool (stable order for
+  # everything else) — called ONLY when provenance is `:curated`, so a caller
+  # branching on `meta.provenance` can always trust `results |> List.first()` is the
+  # curated, authoritative answer, never a decoy that happened to out-rank it on the
+  # pool-relative `:final_score` (finding, US-31.2).
+  defp hoist_to_front(pool_results, curated_id) do
+    {winner, rest} = Enum.split_with(pool_results, &(&1.id == curated_id))
+    winner ++ rest
+  end
+
   # Body-less/id-only curated lookup (finding 5): `list_curated_sources/2` defaults to
   # returning full `%Article{}` structs (including bodies), which the resolver would
   # otherwise discard entirely except for `.id`. `select: :id` keeps this a per-query
-  # hot path cheap regardless of how large the curated corpus grows.
-  defp curated_source_ids(tenant_id) do
-    tenant_id |> list_curated_sources(select: :id) |> MapSet.new()
+  # hot path cheap regardless of how large the curated corpus grows. Scoped to the
+  # POOL's own ids (`:ids`) — NEVER the tenant's full curated/system-canonical corpus
+  # — so per-query cost scales with the <=200-candidate pool, not the curated corpus
+  # (review finding, US-31.2).
+  defp curated_source_ids(_tenant_id, []), do: MapSet.new()
+
+  defp curated_source_ids(tenant_id, pool_results) do
+    pool_ids = Enum.map(pool_results, & &1.id)
+    tenant_id |> list_curated_sources(select: :id, ids: pool_ids) |> MapSet.new()
   end
 
   # Builds an id -> ABSOLUTE (non-pool-relative) score index used ONLY for the
@@ -6660,19 +6747,57 @@ defmodule Loopctl.Knowledge do
   #
   # Prefers the raw `:similarity_score` (`1 - cosine_distance`, already on an absolute
   # 0..1 scale — see `search_semantic/3`) when the candidate was found in the semantic
-  # pool; falls back to the raw `:relevance_score` (`ts_rank_cd` — see `search_keyword/3`)
-  # for a keyword-only candidate. Both are ABSOLUTE (computed independently of what
-  # else is in the pool), unlike `normalize_scores/2`'s output. `merge_results/5`
-  # preserves BOTH raw fields on a candidate found in both pools, so this always has
-  # the more-precisely-bounded semantic signal available when there is one.
+  # pool; falls back to a BOUNDED transform of the raw `:relevance_score` (`ts_rank_cd`
+  # — see `search_keyword/3`) for a keyword-only candidate. Both are ABSOLUTE (computed
+  # independently of what else is in the pool), unlike `normalize_scores/2`'s output.
+  # `merge_results/5` preserves BOTH raw fields on a candidate found in both pools, so
+  # this always has the more-precisely-bounded semantic signal available when there is
+  # one.
   defp absolute_score(%{similarity_score: score}) when is_number(score), do: score
-  defp absolute_score(%{relevance_score: score}) when is_number(score), do: score
+
+  defp absolute_score(%{relevance_score: score}) when is_number(score),
+    do: normalize_keyword_score(score)
+
   defp absolute_score(_result), do: 0.0
+
+  # `ts_rank_cd` is RAW/UNBOUNDED (a short, heavily-title-weighted match can exceed
+  # `1.0` — confirmed empirically up to ~2.0 for a title-exact match) — unlike cosine
+  # similarity's bounded `0..1` scale. Applying the same saturating transform
+  # Postgres's own `ts_rank_cd(..., normalization => 8)` uses (`rank / (rank + 1)`)
+  # keeps the keyword-scale absolute score an ABSOLUTE (non-pool-relative — still a
+  # pure function of the one raw score, never of what else is in the pool) but BOUNDED
+  # `0..1` value: `meta.confidence` can no longer silently exceed `1.0` in keyword-only
+  # mode, and the value is at least magnitude-comparable to cosine similarity (review
+  # finding, US-31.2). This does NOT change `search_keyword/3`'s own public
+  # `:relevance_score` field (still raw ts_rank_cd) — the transform is applied ONLY at
+  # this resolver's own confidence/threshold boundary.
+  defp normalize_keyword_score(raw) when is_number(raw) and raw > 0, do: raw / (raw + 1)
+  defp normalize_keyword_score(_raw), do: 0.0
 
   defp best_score([], _scores), do: 0.0
 
   defp best_score(results, scores),
     do: results |> Enum.map(&Map.fetch!(scores, &1.id)) |> Enum.max()
+
+  # Two INCOMPARABLE score scales feed `absolute_score/1` (bounded cosine similarity
+  # vs. the bounded-but-differently-distributed keyword transform above) — a single
+  # raw threshold/margin pair compared against BOTH scales interchangeably was the
+  # defect (review finding, US-31.2). Selects the config pair matching the WINNING
+  # curated candidate's OWN scale (mirroring `absolute_score/1`'s semantic-first
+  # priority for a candidate present in both sub-pools); `nil` (no curated candidate at
+  # all) is scale-irrelevant since `resolve_provenance/4` short-circuits to
+  # `:retrieved` on a `nil` curated score regardless of which pair is passed.
+  defp hybrid_curated_threshold_and_margin(%{similarity_score: score}) when is_number(score) do
+    {hybrid_curated_threshold(), hybrid_curated_margin()}
+  end
+
+  defp hybrid_curated_threshold_and_margin(%{relevance_score: score}) when is_number(score) do
+    {hybrid_curated_threshold_keyword(), hybrid_curated_margin_keyword()}
+  end
+
+  defp hybrid_curated_threshold_and_margin(_candidate) do
+    {hybrid_curated_threshold(), hybrid_curated_margin()}
+  end
 
   defp hybrid_search_mode(:curated), do: "hybrid_curated"
   defp hybrid_search_mode(:retrieved), do: "hybrid_retrieved"
@@ -6708,6 +6833,12 @@ defmodule Loopctl.Knowledge do
   folded in here — the caller is responsible for only ever passing an ALREADY
   authoritative (`list_curated_sources/2`-filtered) `curated_score`, so the
   superseded/conflicted leg never reaches this pure function as a false positive.
+
+  `threshold`/`margin` MUST already be scale-matched to `curated_score`/
+  `best_retrieved_score` by the caller (`hybrid_search/3` does this via
+  `hybrid_curated_threshold_and_margin/1`) — cosine similarity and (normalized)
+  `ts_rank_cd` are different scales, and this function does no scale reasoning of its
+  own; it only compares whatever numbers it is given.
   """
   @spec resolve_provenance(number() | nil, number(), number(), number()) ::
           :curated | :retrieved
@@ -6736,6 +6867,22 @@ defmodule Loopctl.Knowledge do
       :loopctl,
       :knowledge_hybrid_curated_margin,
       @default_hybrid_curated_margin
+    )
+  end
+
+  defp hybrid_curated_threshold_keyword do
+    Application.get_env(
+      :loopctl,
+      :knowledge_hybrid_curated_threshold_keyword,
+      @default_hybrid_curated_threshold_keyword
+    )
+  end
+
+  defp hybrid_curated_margin_keyword do
+    Application.get_env(
+      :loopctl,
+      :knowledge_hybrid_curated_margin_keyword,
+      @default_hybrid_curated_margin_keyword
     )
   end
 

--- a/lib/loopctl/knowledge/retrieval_metric_snapshot.ex
+++ b/lib/loopctl/knowledge/retrieval_metric_snapshot.ex
@@ -4,6 +4,16 @@ defmodule Loopctl.Knowledge.RetrievalMetricSnapshot do
   day's search results the agent then opened (search → get/context within
   `window_seconds`) — a mechanical proxy for retrieval quality, tracked over time.
 
+  The `curated_*`/`retrieved_*` columns (US-31.2, AC-31.2.5) are the SAME searched /
+  followed_through / precision breakdown, restricted to `article_access_events` whose
+  `metadata->>'mode'` is `"hybrid_curated"` / `"hybrid_retrieved"` respectively — so an
+  operator can tell whether the hybrid resolver's `:curated` answers are actually
+  followed through on as often as `:retrieved` ones (a "prefer-curated silently hides
+  better retrieval" regression would show up as `curated_precision` trending well below
+  `retrieved_precision`). Rows written before US-31.2 (or by non-hybrid searches) simply
+  carry `0`/`0.0` in these columns — same "additive, never breaking" convention as the
+  rest of this schema.
+
   `tenant_id` is set programmatically, never cast.
   """
 
@@ -19,12 +29,31 @@ defmodule Loopctl.Knowledge.RetrievalMetricSnapshot do
     field :searched, :integer, default: 0
     field :followed_through, :integer, default: 0
     field :precision, :float, default: 0.0
+    field :curated_searched, :integer, default: 0
+    field :curated_followed_through, :integer, default: 0
+    field :curated_precision, :float, default: 0.0
+    field :retrieved_searched, :integer, default: 0
+    field :retrieved_followed_through, :integer, default: 0
+    field :retrieved_precision, :float, default: 0.0
     field :computed_at, :utc_datetime_usec
 
     timestamps(type: :utc_datetime_usec)
   end
 
-  @cast_fields [:day, :window_seconds, :searched, :followed_through, :precision, :computed_at]
+  @cast_fields [
+    :day,
+    :window_seconds,
+    :searched,
+    :followed_through,
+    :precision,
+    :curated_searched,
+    :curated_followed_through,
+    :curated_precision,
+    :retrieved_searched,
+    :retrieved_followed_through,
+    :retrieved_precision,
+    :computed_at
+  ]
 
   @doc "Changeset for a snapshot. `tenant_id` is set on the struct, not cast."
   @spec changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
@@ -37,6 +66,12 @@ defmodule Loopctl.Knowledge.RetrievalMetricSnapshot do
       :searched,
       :followed_through,
       :precision,
+      :curated_searched,
+      :curated_followed_through,
+      :curated_precision,
+      :retrieved_searched,
+      :retrieved_followed_through,
+      :retrieved_precision,
       :computed_at
     ])
     |> unique_constraint([:tenant_id, :day, :window_seconds],

--- a/lib/loopctl/knowledge/retrieval_metrics.ex
+++ b/lib/loopctl/knowledge/retrieval_metrics.ex
@@ -25,7 +25,19 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
 
   @doc """
   Compute precision for a single `day` (a `Date`) and follow-through `window_seconds`.
-  Returns `%{searched, followed_through, precision, day, window_seconds}`.
+
+  Returns `%{searched, followed_through, precision, day, window_seconds,
+  curated_searched, curated_followed_through, curated_precision, retrieved_searched,
+  retrieved_followed_through, retrieved_precision}`.
+
+  The `curated_*`/`retrieved_*` fields (US-31.2, AC-31.2.5) are the SAME
+  searched/followed_through/precision computation, restricted to `"search"` events
+  whose `metadata->>'mode'` is `"hybrid_curated"` / `"hybrid_retrieved"` (set by
+  `Loopctl.Knowledge.hybrid_search/3`) — so the hybrid resolver's provenance decision
+  is observable through this NAMED surface, not just via ad-hoc raw
+  `article_access_events` queries on the mode tag. Non-hybrid search events (`"keyword"`,
+  `"semantic"`, `"combined"`, etc.) contribute to the top-level `searched`/
+  `followed_through`/`precision` only, never to either provenance bucket.
   """
   @spec compute(Ecto.UUID.t(), Date.t(), pos_integer()) :: map()
   def compute(tenant_id, %Date{} = day, window_seconds \\ @default_window_seconds) do
@@ -41,40 +53,65 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
       )
 
     searched = AdminRepo.aggregate(searched_q, :count, :id)
+    followed = compute_followed_through(searched_q, window_seconds)
+    precision = safe_precision(followed, searched)
 
-    followed =
-      searched_q
-      |> where(
-        [s],
-        exists(
-          from(o in ArticleAccessEvent,
-            where:
-              o.tenant_id == parent_as(:s).tenant_id and
-                o.api_key_id == parent_as(:s).api_key_id and
-                o.article_id == parent_as(:s).article_id and
-                o.access_type in ["get", "context"] and
-                o.accessed_at > parent_as(:s).accessed_at and
-                fragment(
-                  "? <= ? + (? * interval '1 second')",
-                  o.accessed_at,
-                  parent_as(:s).accessed_at,
-                  ^window_seconds
-                )
-          )
-        )
-      )
-      |> AdminRepo.aggregate(:count, :id)
+    curated_q = where(searched_q, [s], fragment("?->>'mode' = ?", s.metadata, "hybrid_curated"))
+    curated_searched = AdminRepo.aggregate(curated_q, :count, :id)
+    curated_followed = compute_followed_through(curated_q, window_seconds)
+    curated_precision = safe_precision(curated_followed, curated_searched)
 
-    precision = if searched > 0, do: followed / searched, else: 0.0
+    retrieved_q =
+      where(searched_q, [s], fragment("?->>'mode' = ?", s.metadata, "hybrid_retrieved"))
+
+    retrieved_searched = AdminRepo.aggregate(retrieved_q, :count, :id)
+    retrieved_followed = compute_followed_through(retrieved_q, window_seconds)
+    retrieved_precision = safe_precision(retrieved_followed, retrieved_searched)
 
     %{
       day: day,
       window_seconds: window_seconds,
       searched: searched,
       followed_through: followed,
-      precision: precision
+      precision: precision,
+      curated_searched: curated_searched,
+      curated_followed_through: curated_followed,
+      curated_precision: curated_precision,
+      retrieved_searched: retrieved_searched,
+      retrieved_followed_through: retrieved_followed,
+      retrieved_precision: retrieved_precision
     }
   end
+
+  # Shared "searched -> followed-through within window" correlated-exists count, reused
+  # for the aggregate AND each provenance bucket so the follow-through definition can
+  # never drift between the three.
+  defp compute_followed_through(searched_q, window_seconds) do
+    searched_q
+    |> where(
+      [s],
+      exists(
+        from(o in ArticleAccessEvent,
+          where:
+            o.tenant_id == parent_as(:s).tenant_id and
+              o.api_key_id == parent_as(:s).api_key_id and
+              o.article_id == parent_as(:s).article_id and
+              o.access_type in ["get", "context"] and
+              o.accessed_at > parent_as(:s).accessed_at and
+              fragment(
+                "? <= ? + (? * interval '1 second')",
+                o.accessed_at,
+                parent_as(:s).accessed_at,
+                ^window_seconds
+              )
+        )
+      )
+    )
+    |> AdminRepo.aggregate(:count, :id)
+  end
+
+  defp safe_precision(_followed, 0), do: 0.0
+  defp safe_precision(followed, searched), do: followed / searched
 
   @doc """
   Compute a day's precision and upsert the snapshot (idempotent per tenant/day/window).
@@ -91,6 +128,12 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
       searched: m.searched,
       followed_through: m.followed_through,
       precision: m.precision,
+      curated_searched: m.curated_searched,
+      curated_followed_through: m.curated_followed_through,
+      curated_precision: m.curated_precision,
+      retrieved_searched: m.retrieved_searched,
+      retrieved_followed_through: m.retrieved_followed_through,
+      retrieved_precision: m.retrieved_precision,
       computed_at: DateTime.utc_now()
     }
 
@@ -98,7 +141,20 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
     |> RetrievalMetricSnapshot.changeset(attrs)
     |> AdminRepo.insert(
       on_conflict:
-        {:replace, [:searched, :followed_through, :precision, :computed_at, :updated_at]},
+        {:replace,
+         [
+           :searched,
+           :followed_through,
+           :precision,
+           :curated_searched,
+           :curated_followed_through,
+           :curated_precision,
+           :retrieved_searched,
+           :retrieved_followed_through,
+           :retrieved_precision,
+           :computed_at,
+           :updated_at
+         ]},
       conflict_target: [:tenant_id, :day, :window_seconds]
     )
   end
@@ -125,7 +181,13 @@ defmodule Loopctl.Knowledge.RetrievalMetrics do
           window_seconds: s.window_seconds,
           searched: s.searched,
           followed_through: s.followed_through,
-          precision: s.precision
+          precision: s.precision,
+          curated_searched: s.curated_searched,
+          curated_followed_through: s.curated_followed_through,
+          curated_precision: s.curated_precision,
+          retrieved_searched: s.retrieved_searched,
+          retrieved_followed_through: s.retrieved_followed_through,
+          retrieved_precision: s.retrieved_precision
         }
       )
       |> AdminRepo.all()

--- a/lib/loopctl/telemetry/scale_metrics.ex
+++ b/lib/loopctl/telemetry/scale_metrics.ex
@@ -133,6 +133,21 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
         description: "Semantic search degraded to keyword-only / contributed nothing, by reason.",
         tags: [:reason],
         tag_values: &semantic_fallback_tags/1
+      ),
+
+      # 5. Hybrid-resolver provenance counter (US-31.2, finding 6): every
+      #    `hybrid_search/3` decision, by `provenance` (curated/retrieved) and `hit`
+      #    (non-empty/empty page). Fires unconditionally (unlike the
+      #    `article_access_events` recording, which cannot represent a MISS or a
+      #    keyless call), so the hit/miss + keyless dimension stays observable. MAY
+      #    carry a cap-gated `tenant_id` (sentinel when over cap).
+      counter("loopctl.knowledge.hybrid_provenance.count",
+        event_name: [:loopctl, :knowledge, :hybrid_provenance],
+        measurement: :count,
+        description:
+          "Hybrid resolver (US-31.2) provenance decisions, by provenance, hit/miss, and tenant.",
+        tags: [:provenance, :hit, :tenant_id],
+        tag_values: &hybrid_provenance_tags/1
       )
     ]
   end
@@ -146,6 +161,21 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   @spec semantic_fallback_tags(map()) :: map()
   def semantic_fallback_tags(metadata) do
     %{reason: Map.get(metadata, :reason, "unknown")}
+  end
+
+  @doc """
+  `tag_values` for the hybrid-provenance counter (US-31.2). `provenance` and `hit` are
+  small, fixed-cardinality dimensions (2 values each) so they need no cap gate;
+  `tenant_id` reuses the SAME cap-gated sentinel collapse as the other two counters
+  (`gated_tenant_id/1`) to keep its cardinality bounded identically.
+  """
+  @spec hybrid_provenance_tags(map()) :: map()
+  def hybrid_provenance_tags(metadata) do
+    %{
+      provenance: Map.get(metadata, :provenance, "unknown"),
+      hit: Map.get(metadata, :hit, false),
+      tenant_id: gated_tenant_id(metadata)
+    }
   end
 
   @doc """

--- a/lib/loopctl/telemetry_events.ex
+++ b/lib/loopctl/telemetry_events.ex
@@ -133,6 +133,30 @@ defmodule Loopctl.TelemetryEvents do
   """
   def knowledge_semantic_fallback, do: [:loopctl, :knowledge, :semantic_fallback]
 
+  @doc """
+  A hybrid-resolver (US-31.2, `Loopctl.Knowledge.hybrid_search/3`) provenance
+  decision fired. Turns the two dimensions `maybe_record_search_access/5` structurally
+  CANNOT observe — a MISS (empty result page — `article_access_events.article_id` is
+  NOT NULL) and a keyless call (no `api_key_id` to attribute a DB row to) — into an
+  always-emitted signal, so "curated vs retrieved" and "hit vs miss" stay observable
+  per tenant even off the `article_access_events`/`RetrievalMetrics` path.
+
+  Fires on EVERY `hybrid_search/3` call, regardless of result-page emptiness or
+  `:api_key_id` presence.
+
+  ## Payload (id/atom/bool only — NEVER article content or the query text)
+
+    * `measurements`: `%{count: 1}` — a pure increment.
+    * `metadata`: `%{tenant_id, provenance, hit}` where `provenance` is `"curated"` |
+      `"retrieved"` (a BOUNDED 2-value tag) and `hit` is `true`/`false` (the page was
+      non-empty / empty).
+
+  Aggregated by `Loopctl.Telemetry.ScaleMetrics` as a counter tagged by
+  `[:provenance, :hit, :tenant_id]` (tenant cap-gated, same convention as the other
+  scale counters).
+  """
+  def knowledge_hybrid_provenance, do: [:loopctl, :knowledge, :hybrid_provenance]
+
   @doc "Returns all defined event names for attachment"
   def all_events do
     [
@@ -146,7 +170,8 @@ defmodule Loopctl.TelemetryEvents do
       audit_log_write(),
       vector_search_under_fill(),
       db_error(),
-      knowledge_semantic_fallback()
+      knowledge_semantic_fallback(),
+      knowledge_hybrid_provenance()
     ]
   end
 end

--- a/priv/repo/migrations/20260712020000_add_provenance_breakdown_to_retrieval_metric_snapshots.exs
+++ b/priv/repo/migrations/20260712020000_add_provenance_breakdown_to_retrieval_metric_snapshots.exs
@@ -1,0 +1,19 @@
+defmodule Loopctl.Repo.Migrations.AddProvenanceBreakdownToRetrievalMetricSnapshots do
+  use Ecto.Migration
+
+  # US-31.2 review finding 3 (AC-31.2.5): the hybrid resolver's provenance decision
+  # (curated vs retrieved) needs to be observable through the NAMED RetrievalMetrics /
+  # retrieval_metric_snapshot surface, not just via ad-hoc raw `article_access_events`
+  # queries on the `mode` metadata tag. Adds a curated/retrieved breakdown alongside
+  # the existing aggregate searched/followed_through/precision columns.
+  def change do
+    alter table(:retrieval_metric_snapshots) do
+      add :curated_searched, :integer, null: false, default: 0
+      add :curated_followed_through, :integer, null: false, default: 0
+      add :curated_precision, :float, null: false, default: 0.0
+      add :retrieved_searched, :integer, null: false, default: 0
+      add :retrieved_followed_through, :integer, null: false, default: 0
+      add :retrieved_precision, :float, null: false, default: 0.0
+    end
+  end
+end

--- a/test/loopctl/knowledge/retrieval_metrics_test.exs
+++ b/test/loopctl/knowledge/retrieval_metrics_test.exs
@@ -78,8 +78,67 @@ defmodule Loopctl.Knowledge.RetrievalMetricsTest do
                window_seconds: 1800,
                searched: 0,
                followed_through: 0,
-               precision: 0.0
+               precision: 0.0,
+               curated_searched: 0,
+               curated_followed_through: 0,
+               curated_precision: 0.0,
+               retrieved_searched: 0,
+               retrieved_followed_through: 0,
+               retrieved_precision: 0.0
              }
+    end
+  end
+
+  describe "compute/3 - provenance breakdown (US-31.2, AC-31.2.5)" do
+    test "curated and retrieved hybrid-search events are broken out from each other and from non-hybrid events",
+         ctx do
+      %{tenant: t, key: k, x: x, y: y} = ctx
+      z = fixture(:article, %{tenant_id: t.id, status: :published})
+
+      # A hybrid :curated search, opened within the window -> curated follow-through.
+      fixture(:article_access_event, %{
+        tenant_id: t.id,
+        api_key_id: k.id,
+        article_id: x.id,
+        access_type: "search",
+        metadata: %{"mode" => "hybrid_curated"},
+        accessed_at: at(~T[12:00:00])
+      })
+
+      event(t.id, k.id, x.id, "get", ~T[12:05:00])
+
+      # A hybrid :retrieved search, never opened -> retrieved miss.
+      fixture(:article_access_event, %{
+        tenant_id: t.id,
+        api_key_id: k.id,
+        article_id: y.id,
+        access_type: "search",
+        metadata: %{"mode" => "hybrid_retrieved"},
+        accessed_at: at(~T[12:00:00])
+      })
+
+      # A plain (non-hybrid) combined search -> counts toward the aggregate only.
+      fixture(:article_access_event, %{
+        tenant_id: t.id,
+        api_key_id: k.id,
+        article_id: z.id,
+        access_type: "search",
+        metadata: %{"mode" => "combined"},
+        accessed_at: at(~T[12:00:00])
+      })
+
+      m = RetrievalMetrics.compute(t.id, @day, 1800)
+
+      assert m.searched == 3
+      assert m.followed_through == 1
+
+      assert m.curated_searched == 1
+      assert m.curated_followed_through == 1
+      assert m.curated_precision == 1.0
+
+      assert m.retrieved_searched == 1
+      assert m.retrieved_followed_through == 0
+      assert m.retrieved_precision == 0.0
     end
   end
 
@@ -108,6 +167,47 @@ defmodule Loopctl.Knowledge.RetrievalMetricsTest do
       {:ok, _} = RetrievalMetrics.snapshot(t.id, @day, 1800)
 
       assert %{meta: %{total_count: 0}} = RetrievalMetrics.list_snapshots(other.id)
+    end
+
+    test "persists and lists the curated/retrieved provenance breakdown (US-31.2, AC-31.2.5)",
+         ctx do
+      %{tenant: t, key: k, x: x, y: y} = ctx
+
+      fixture(:article_access_event, %{
+        tenant_id: t.id,
+        api_key_id: k.id,
+        article_id: x.id,
+        access_type: "search",
+        metadata: %{"mode" => "hybrid_curated"},
+        accessed_at: at(~T[12:00:00])
+      })
+
+      event(t.id, k.id, x.id, "get", ~T[12:05:00])
+
+      fixture(:article_access_event, %{
+        tenant_id: t.id,
+        api_key_id: k.id,
+        article_id: y.id,
+        access_type: "search",
+        metadata: %{"mode" => "hybrid_retrieved"},
+        accessed_at: at(~T[12:00:00])
+      })
+
+      assert {:ok, snap} = RetrievalMetrics.snapshot(t.id, @day, 1800)
+      assert snap.curated_searched == 1
+      assert snap.curated_followed_through == 1
+      assert snap.curated_precision == 1.0
+      assert snap.retrieved_searched == 1
+      assert snap.retrieved_followed_through == 0
+      assert snap.retrieved_precision == 0.0
+
+      %{data: [row]} = RetrievalMetrics.list_snapshots(t.id)
+      assert row.curated_searched == 1
+      assert row.curated_followed_through == 1
+      assert row.curated_precision == 1.0
+      assert row.retrieved_searched == 1
+      assert row.retrieved_followed_through == 0
+      assert row.retrieved_precision == 0.0
     end
   end
 end

--- a/test/loopctl/knowledge_curated_test.exs
+++ b/test/loopctl/knowledge_curated_test.exs
@@ -459,6 +459,31 @@ defmodule Loopctl.KnowledgeCuratedTest do
     end
   end
 
+  describe "list_curated_sources/2 - select: :id body-less projection (US-31.2 finding 5)" do
+    test "select: :id returns a plain list of UUIDs, not full %Article{} structs" do
+      tenant = fixture(:tenant)
+      curated = curated_article(tenant.id, %{title: "Body-less Projection Target"})
+      _other = fixture(:article, %{tenant_id: tenant.id, status: :published})
+
+      full_result = Knowledge.list_curated_sources(tenant.id)
+      id_result = Knowledge.list_curated_sources(tenant.id, select: :id)
+
+      assert Enum.all?(full_result, &match?(%Loopctl.Knowledge.Article{}, &1))
+      assert id_result == [curated.id]
+      refute match?([%Loopctl.Knowledge.Article{} | _], id_result)
+    end
+
+    test "select: :id still honors every filter (category, include_system, limit, tenant scope)" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+
+      a_curated = curated_article(tenant_a.id, %{title: "A doc for id projection"})
+      _b_curated = curated_article(tenant_b.id, %{title: "B doc for id projection"})
+
+      assert Knowledge.list_curated_sources(tenant_a.id, select: :id) == [a_curated.id]
+    end
+  end
+
   defp ids(articles), do: Enum.map(articles, & &1.id)
 
   defp audit_event(article_id, action) do

--- a/test/loopctl/knowledge_hybrid_test.exs
+++ b/test/loopctl/knowledge_hybrid_test.exs
@@ -1,0 +1,630 @@
+defmodule Loopctl.KnowledgeHybridTest do
+  @moduledoc """
+  US-31.2: Hybrid resolver — prefer curated ONLY when it actually answers, else
+  retrieval, with provenance.
+
+  Covers `Knowledge.hybrid_search/3` (composing the already-shipped
+  `search_combined/3` retrieval and `list_curated_sources/2` curated-identification
+  subsystems, US-31.1) and the pure `Knowledge.resolve_provenance/4` decision rule.
+  """
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge
+  alias Loopctl.Knowledge.ArticleAccessEvent
+
+  # Two orthogonal "directions" + a midpoint, mirroring the pattern in
+  # knowledge_semantic_search_test.exs: cosine similarity of identical directions is
+  # 1.0, orthogonal directions is 0.0, and the midpoint sits at ~0.7033 to either —
+  # deterministic enough to sit safely below the 0.75 default threshold without
+  # floating-point flakiness.
+  @direction_a List.duplicate(1.0, 768) ++ List.duplicate(0.0, 768)
+  @direction_b List.duplicate(0.0, 768) ++ List.duplicate(1.0, 768)
+  @direction_medium List.duplicate(0.5, 768) ++ List.duplicate(0.5, 768)
+
+  # Creates a published tenant article and marks it curated via the governed path
+  # (mirrors test/loopctl/knowledge_curated_test.exs).
+  defp curated_article(tenant_id, attrs) do
+    article =
+      fixture(:article, Map.merge(%{tenant_id: tenant_id, status: :published}, attrs))
+
+    {:ok, marked} = Knowledge.mark_curated(tenant_id, article.id, actor_label: "user:admin")
+    marked
+  end
+
+  defp set_embedding(tenant_id, article, vector) do
+    {:ok, updated} = Knowledge.update_embedding(tenant_id, article.id, vector)
+    updated
+  end
+
+  # Stubs the embedding client to return a specific vector per exact query text,
+  # falling back to the DataCase default (uniform 0.1 vector) for any other text.
+  defp stub_embeddings_by_query(mapping) do
+    Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, text ->
+      case Map.fetch(mapping, text) do
+        {:ok, vector} -> {:ok, vector}
+        :error -> {:ok, List.duplicate(0.1, 1536)}
+      end
+    end)
+  end
+
+  # --- TC-31.2.1: curated that answers wins; near-but-wrong curated does NOT ---
+
+  describe "hybrid_search/3 - curated that answers wins; near-but-wrong curated does NOT (TC-31.2.1)" do
+    test "the answering curated article wins :curated; a different curated doc only loosely related to another query falls to :retrieved" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      answering =
+        tenant.id
+        |> curated_article(%{title: "Refund Policy Answer"})
+        |> then(&set_embedding(tenant.id, &1, @direction_a))
+
+      _near_but_wrong =
+        tenant.id
+        |> curated_article(%{title: "Shipping Refund Process"})
+        |> then(&set_embedding(tenant.id, &1, @direction_medium))
+
+      # A non-curated distractor exactly aligned with `other_query`'s embedding —
+      # the genuine best-retrieved competitor `other_query` must fall back to,
+      # proving the near-but-wrong curated doc is beaten on merit, not by default.
+      _distractor =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Unrelated Distractor",
+          status: :published
+        })
+        |> then(&set_embedding(tenant.id, &1, @direction_b))
+
+      answering_query = "what is the refund policy?"
+      other_query = "a query only loosely related to shipping refunds"
+
+      stub_embeddings_by_query(%{answering_query => @direction_a, other_query => @direction_b})
+
+      assert {:ok, %{results: results1, meta: meta1}} =
+               Knowledge.hybrid_search(tenant.id, answering_query,
+                 keyword_weight: 0,
+                 semantic_weight: 1
+               )
+
+      assert meta1.provenance == :curated
+      assert Enum.any?(results1, &(&1.id == answering.id))
+
+      assert {:ok, %{meta: meta2}} =
+               Knowledge.hybrid_search(tenant.id, other_query,
+                 keyword_weight: 0,
+                 semantic_weight: 1
+               )
+
+      assert meta2.provenance == :retrieved
+    end
+  end
+
+  # --- Regression (review finding 1/2): a LONE/top curated candidate must NOT win
+  # :curated just because it is the only thing in the pool. Removing TC-31.2.1's
+  # non-curated distractor is the exact scenario the original review flagged: without
+  # a competitor, min-max normalization used to force this doc's score to 1.0
+  # regardless of its true (sub-threshold) cosine similarity.
+
+  describe "hybrid_search/3 - lone curated candidate, weak similarity (finding 1/2 regression)" do
+    test "the ONLY pool candidate, with cosine below threshold, does not win :curated by normalizing to 1.0" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      weak_curated =
+        tenant.id
+        |> curated_article(%{title: "Shipping Refund Process"})
+        |> then(&set_embedding(tenant.id, &1, @direction_medium))
+
+      query = "what is the refund policy?"
+      stub_embeddings_by_query(%{query => @direction_a})
+
+      assert {:ok, %{results: results, meta: meta}} =
+               Knowledge.hybrid_search(tenant.id, query, keyword_weight: 0, semantic_weight: 1)
+
+      assert Enum.any?(results, &(&1.id == weak_curated.id))
+      assert meta.provenance == :retrieved
+      assert meta.confidence < 0.75
+      assert meta.confidence > 0.0
+    end
+  end
+
+  # --- Regression (review finding 4): the curated/retrieved decision must be resolved
+  # over the top of the RANKED POOL, independent of the caller's `:limit`/`:offset`
+  # page window — a curated source that answers but ranks outside the default page
+  # must still be identified, and a caller-supplied `:offset` must shift only which
+  # page of `results` comes back, never the provenance decision itself.
+
+  describe "hybrid_search/3 - resolved over the ranked pool, independent of pagination (finding 4)" do
+    test "a curated source ranked outside the default page is still identified; :offset shifts only the page, never the decision" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      query = "invoice generation troubleshooting steps"
+
+      # 12 non-curated decoys: STRONG keyword match (identical relevant terms, so ts_rank
+      # is identical across all of them) but a FAR/orthogonal embedding (cosine 0 to the
+      # query embedding) — with keyword weighted heavily, every decoy outranks the
+      # curated doc in the merged/combined pool ordering.
+      for i <- 1..12 do
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :published,
+          title: "Invoice Generation Troubleshooting Guide #{i}",
+          body:
+            "Invoice generation troubleshooting steps for common invoice generation issues. " <>
+              "Invoice generation troubleshooting requires careful invoice generation review."
+        })
+        |> then(&set_embedding(tenant.id, &1, @direction_b))
+      end
+
+      # The curated doc shares NO keyword terms with the query at all (so it never
+      # enters the keyword sub-pool), but its embedding is an EXACT match (cosine 1.0)
+      # — the strongest possible absolute semantic signal, and no decoy comes close
+      # (their absolute similarity is 0.0).
+      curated =
+        tenant.id
+        |> curated_article(%{
+          title: "Refund Policy Definitive Answer",
+          body: "Our refund policy is fully documented here with complete refund guidance."
+        })
+        |> then(&set_embedding(tenant.id, &1, @direction_a))
+
+      stub_embeddings_by_query(%{query => @direction_a})
+
+      # Default page (limit 10, offset 0): the curated doc — ranked 13th by the
+      # keyword-heavy combined score — is NOT in the returned page, yet the resolver
+      # still finds and scores it correctly.
+      assert {:ok, %{results: page1, meta: meta1}} =
+               Knowledge.hybrid_search(tenant.id, query,
+                 keyword_weight: 0.9,
+                 semantic_weight: 0.1
+               )
+
+      refute Enum.any?(page1, &(&1.id == curated.id))
+      assert meta1.provenance == :curated
+      assert meta1.confidence == 1.0
+
+      # A deeper page (offset 10) now reaches the curated doc — but the DECISION
+      # (provenance/confidence) is identical: the offset shifted only which page came
+      # back, never which candidates the resolver reasoned over.
+      assert {:ok, %{results: page2, meta: meta2}} =
+               Knowledge.hybrid_search(tenant.id, query,
+                 keyword_weight: 0.9,
+                 semantic_weight: 0.1,
+                 offset: 10
+               )
+
+      assert Enum.any?(page2, &(&1.id == curated.id))
+      assert meta2.provenance == :curated
+      assert meta2.confidence == 1.0
+    end
+  end
+
+  # --- TC-31.2.2: curated and retrieved responses share the same shape ---
+
+  describe "hybrid_search/3 - shape parity between :curated and :retrieved (TC-31.2.2)" do
+    test "curated and retrieved responses have identical result/meta key sets" do
+      curated_tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(curated_tenant.id)
+
+      curated = curated_article(curated_tenant.id, %{title: "Deploy Guide Curated"})
+      set_embedding(curated_tenant.id, curated, @direction_a)
+
+      stub_embeddings_by_query(%{"deploy guide" => @direction_a})
+
+      assert {:ok, %{results: [curated_result | _], meta: curated_meta}} =
+               Knowledge.hybrid_search(curated_tenant.id, "deploy guide",
+                 keyword_weight: 0,
+                 semantic_weight: 1
+               )
+
+      assert curated_meta.provenance == :curated
+
+      retrieved_tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(retrieved_tenant.id)
+
+      fixture(:article, %{
+        tenant_id: retrieved_tenant.id,
+        title: "Niche Article",
+        body: "A niche topic nobody has curated an answer for.",
+        status: :published
+      })
+
+      assert {:ok, %{results: [retrieved_result | _], meta: retrieved_meta}} =
+               Knowledge.hybrid_search(retrieved_tenant.id, "niche topic")
+
+      assert retrieved_meta.provenance == :retrieved
+
+      assert Enum.sort(Map.keys(curated_meta)) == Enum.sort(Map.keys(retrieved_meta))
+
+      # The CORE identity/ranking fields are present on every result regardless of
+      # provenance. The OPTIONAL raw score fields (`:relevance_score`/`:snippet` from
+      # the keyword sub-pool, `:similarity_score` from the semantic sub-pool) legitimately
+      # vary per CANDIDATE based on which sub-pool(s) it individually matched — that is
+      # inherent to `search_combined/3`'s per-candidate merge (a keyword-only match never
+      # carries `:similarity_score`; a semantic-only match never carries
+      # `:relevance_score`/`:snippet`) and orthogonal to provenance, so it is not part of
+      # the shape-parity contract this test guards.
+      core_fields = [
+        :id,
+        :tenant_id,
+        :project_id,
+        :title,
+        :category,
+        :status,
+        :tags,
+        :inserted_at,
+        :updated_at,
+        :final_score
+      ]
+
+      for field <- core_fields do
+        assert Map.has_key?(curated_result, field)
+        assert Map.has_key?(retrieved_result, field)
+      end
+
+      for key <- [:provenance, :confidence, :search_mode] do
+        assert Map.has_key?(curated_meta, key)
+        assert Map.has_key?(retrieved_meta, key)
+      end
+    end
+  end
+
+  # --- TC-31.2.3: long-tail query falls back to retrieval, flagged ---
+
+  describe "hybrid_search/3 - long-tail query falls back to retrieval (TC-31.2.3)" do
+    test "no curated content for the tenant -> :retrieved with search_mode in meta" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Niche Topic Deep Dive",
+        body: "A very niche topic with no curated coverage whatsoever.",
+        status: :published
+      })
+
+      assert {:ok, %{results: results, meta: meta}} =
+               Knowledge.hybrid_search(tenant.id, "niche topic")
+
+      assert results != []
+      assert meta.provenance == :retrieved
+      assert is_binary(meta.search_mode)
+    end
+  end
+
+  # --- TC-31.2.4: threshold/margin resolution is a testable pure decision ---
+
+  describe "resolve_provenance/4 - pure resolution rule (TC-31.2.4)" do
+    test "above threshold and beats margin -> :curated" do
+      assert Knowledge.resolve_provenance(0.9, 0.5, 0.75, 0.1) == :curated
+    end
+
+    test "above threshold but within margin -> :retrieved" do
+      assert Knowledge.resolve_provenance(0.8, 0.75, 0.75, 0.1) == :retrieved
+    end
+
+    test "below threshold -> :retrieved (even with a huge margin over retrieval)" do
+      assert Knowledge.resolve_provenance(0.6, 0.0, 0.75, 0.1) == :retrieved
+    end
+
+    test "no authoritative curated candidate (nil score) -> :retrieved" do
+      assert Knowledge.resolve_provenance(nil, 0.9, 0.75, 0.1) == :retrieved
+    end
+
+    test "exact boundary: threshold and margin both met exactly -> :curated" do
+      # 0.5, 0.75, 0.25 are exactly representable in binary floating point, so the
+      # `>=` boundary checks are exact (no float-precision flake at the edge).
+      assert Knowledge.resolve_provenance(0.75, 0.5, 0.5, 0.25) == :curated
+    end
+  end
+
+  # --- TC-31.2.5: degraded embeddings: honest meta, no false curated ---
+
+  describe "hybrid_search/3 - degraded embeddings: honest meta, no false curated (TC-31.2.5)" do
+    test "a curated source that is still confidently keyword-matched wins :curated under keyword_only fallback" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      curated =
+        curated_article(tenant.id, %{
+          title: "Refund Policy Guide",
+          body: "Our refund policy allows returns within 30 days. Refund policy details follow."
+        })
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, :service_unavailable}
+      end)
+
+      assert {:ok, %{results: results, meta: meta}} =
+               Knowledge.hybrid_search(tenant.id, "refund policy")
+
+      assert meta.fallback == true
+      assert meta.search_mode == "keyword_only"
+      assert meta.provenance == :curated
+      assert Enum.any?(results, &(&1.id == curated.id))
+    end
+
+    # Regression (finding 2): the positive case above previously passed for ANY sole
+    # keyword hit regardless of ts_rank strength (min-max normalization forced a lone
+    # candidate to 1.0). This negative case proves the resolver actually discriminates
+    # on keyword-match STRENGTH: a curated doc that only incidentally mentions the
+    # query terms once, deep in an otherwise-unrelated document (a genuinely weak,
+    # non-"confidently identifiable" raw ts_rank_cd), must fall to :retrieved even as
+    # the sole curated (and sole matching) candidate.
+    test "a weakly/incidentally keyword-matched curated source (low raw ts_rank) falls to :retrieved as the sole matching candidate" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      weakly_matched =
+        curated_article(tenant.id, %{
+          title: "Unrelated Document Title",
+          body:
+            "This is a long document about many different topics. Somewhere deep in " <>
+              "this text we mention the refund policy just once in passing, without " <>
+              "further discussion. The rest of this document covers unrelated material " <>
+              "about logistics, warehousing, inventory management, and other operational " <>
+              "topics that have nothing to do with the query at hand."
+        })
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, :service_unavailable}
+      end)
+
+      assert {:ok, %{results: results, meta: meta}} =
+               Knowledge.hybrid_search(tenant.id, "refund policy")
+
+      assert meta.fallback == true
+      assert meta.search_mode == "keyword_only"
+      assert meta.provenance == :retrieved
+      assert Enum.any?(results, &(&1.id == weakly_matched.id))
+    end
+
+    test "a curated source NOT keyword-matched falls to :retrieved under keyword_only fallback (never a false curated)" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      _curated =
+        curated_article(tenant.id, %{
+          title: "Refund Policy Guide",
+          body: "Our refund policy allows returns within 30 days."
+        })
+
+      distractor =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Database Migration Strategy",
+          body: "How to plan a database migration strategy safely. Migration, migration.",
+          status: :published
+        })
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, :service_unavailable}
+      end)
+
+      assert {:ok, %{results: results, meta: meta}} =
+               Knowledge.hybrid_search(tenant.id, "database migration strategy")
+
+      assert meta.fallback == true
+      assert meta.search_mode == "keyword_only"
+      assert meta.provenance == :retrieved
+      assert Enum.any?(results, &(&1.id == distractor.id))
+    end
+
+    test "no matching articles at all under keyword_only fallback -> honest empty, never a crash or false curated" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, :service_unavailable}
+      end)
+
+      assert {:ok, %{results: [], meta: meta}} =
+               Knowledge.hybrid_search(tenant.id, "completely absent phrase xyz")
+
+      assert meta.fallback == true
+      assert meta.search_mode == "keyword_only"
+      assert meta.provenance == :retrieved
+      assert meta.confidence == 0.0
+    end
+  end
+
+  # --- TC-31.2.6: hybrid_search is tenant-isolated ---
+
+  describe "hybrid_search/3 - tenant isolation (TC-31.2.6)" do
+    test "threads tenant_id into both retrieval and curated lookup; no cross-tenant leakage" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant_a.id)
+      Knowledge.reset_circuit_breaker(tenant_b.id)
+
+      curated_a =
+        curated_article(tenant_a.id, %{
+          title: "Tenant A Secret Policy",
+          body: "Tenant A's secret refund handling policy. Refund, refund policy."
+        })
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:ok, List.duplicate(0.1, 1536)}
+      end)
+
+      assert {:ok, %{results: results_b, meta: meta_b}} =
+               Knowledge.hybrid_search(tenant_b.id, "tenant a secret refund handling policy")
+
+      assert results_b == []
+      refute Enum.any?(results_b, &(&1.id == curated_a.id))
+      assert meta_b.provenance == :retrieved
+    end
+  end
+
+  # --- AC-31.2.5: provenance outcome emitted into retrieval metrics ---
+
+  describe "hybrid_search/3 - provenance metrics emission (AC-31.2.5)" do
+    test "the provenance outcome is recorded on the ArticleAccessEvent metadata mode tag, without double-recording" do
+      tenant = fixture(:tenant)
+      {_raw, api_key} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      curated = curated_article(tenant.id, %{title: "Deploy Guide Curated"})
+      set_embedding(tenant.id, curated, @direction_a)
+
+      stub_embeddings_by_query(%{"deploy guide" => @direction_a})
+
+      assert {:ok, %{meta: %{provenance: :curated}}} =
+               Knowledge.hybrid_search(tenant.id, "deploy guide",
+                 keyword_weight: 0,
+                 semantic_weight: 1,
+                 api_key_id: api_key.id
+               )
+
+      events =
+        AdminRepo.all(
+          from(e in ArticleAccessEvent,
+            where: e.tenant_id == ^tenant.id and e.access_type == "search"
+          )
+        )
+
+      assert events != []
+      assert Enum.all?(events, &(&1.metadata["mode"] == "hybrid_curated"))
+
+      # The inner search_combined/3 recording was suppressed (`_skip_record_access`),
+      # so there is no separate "combined"-tagged event double-counting
+      # RetrievalMetrics' `searched` aggregate.
+      refute Enum.any?(events, &(&1.metadata["mode"] == "combined"))
+    end
+
+    test "a :retrieved outcome is tagged hybrid_retrieved" do
+      tenant = fixture(:tenant)
+      {_raw, api_key} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Uncurated Guide",
+        body: "An uncurated article about some general topic.",
+        status: :published
+      })
+
+      assert {:ok, %{meta: %{provenance: :retrieved}}} =
+               Knowledge.hybrid_search(tenant.id, "general topic", api_key_id: api_key.id)
+
+      events =
+        AdminRepo.all(
+          from(e in ArticleAccessEvent,
+            where: e.tenant_id == ^tenant.id and e.access_type == "search"
+          )
+        )
+
+      assert events != []
+      assert Enum.all?(events, &(&1.metadata["mode"] == "hybrid_retrieved"))
+    end
+  end
+
+  # --- Regression (finding 6): the ArticleAccessEvent/RetrievalMetrics recording
+  # structurally CANNOT represent a MISS (empty page — `article_id` is NOT NULL) or a
+  # keyless call (no `api_key_id` to attribute a row to). The hybrid-provenance
+  # telemetry event closes that observability gap by firing unconditionally.
+
+  describe "hybrid_search/3 - provenance telemetry fires even for a MISS or a keyless call (finding 6 regression)" do
+    defp attach_hybrid_provenance_handler(tenant_id) do
+      test_pid = self()
+      handler_id = "hybrid-prov-#{System.unique_integer([:positive])}"
+      event = [:loopctl, :knowledge, :hybrid_provenance]
+
+      :telemetry.attach(
+        handler_id,
+        event,
+        fn ^event, measurements, metadata, _config ->
+          if metadata.tenant_id == tenant_id do
+            send(test_pid, {:hybrid_provenance, measurements, metadata})
+          end
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+    end
+
+    test "a :retrieved MISS (empty results, no api_key_id) still emits the telemetry event" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+      attach_hybrid_provenance_handler(tenant.id)
+
+      assert {:ok, %{results: [], meta: %{provenance: :retrieved}}} =
+               Knowledge.hybrid_search(tenant.id, "completely absent phrase xyz")
+
+      assert_receive {:hybrid_provenance, %{count: 1}, metadata}
+      assert metadata.provenance == "retrieved"
+      assert metadata.hit == false
+
+      # No ArticleAccessEvent could possibly have been recorded for this MISS
+      # (article_id is NOT NULL) — the telemetry event is the ONLY observable trace.
+      assert AdminRepo.aggregate(
+               from(e in ArticleAccessEvent, where: e.tenant_id == ^tenant.id),
+               :count,
+               :id
+             ) == 0
+    end
+
+    test "a hit with no :api_key_id (keyless call) still emits the telemetry event" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+      attach_hybrid_provenance_handler(tenant.id)
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Keyless Caller Guide",
+        body: "An article findable by a caller with no api_key_id attribution.",
+        status: :published
+      })
+
+      assert {:ok, %{results: results, meta: %{provenance: :retrieved}}} =
+               Knowledge.hybrid_search(tenant.id, "keyless caller guide")
+
+      assert results != []
+
+      assert_receive {:hybrid_provenance, %{count: 1}, metadata}
+      assert metadata.provenance == "retrieved"
+      assert metadata.hit == true
+
+      # No ArticleAccessEvent could possibly have been recorded (no api_key_id to
+      # attribute to) — the telemetry event is the ONLY observable trace.
+      assert AdminRepo.aggregate(
+               from(e in ArticleAccessEvent, where: e.tenant_id == ^tenant.id),
+               :count,
+               :id
+             ) == 0
+    end
+
+    test "a :curated hit DOES double-record: the DB event (api_key_id present) AND the telemetry event" do
+      tenant = fixture(:tenant)
+      {_raw, api_key} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      Knowledge.reset_circuit_breaker(tenant.id)
+      attach_hybrid_provenance_handler(tenant.id)
+
+      curated = curated_article(tenant.id, %{title: "Telemetry Deploy Guide"})
+      set_embedding(tenant.id, curated, @direction_a)
+      stub_embeddings_by_query(%{"telemetry deploy guide" => @direction_a})
+
+      assert {:ok, %{meta: %{provenance: :curated}}} =
+               Knowledge.hybrid_search(tenant.id, "telemetry deploy guide",
+                 keyword_weight: 0,
+                 semantic_weight: 1,
+                 api_key_id: api_key.id
+               )
+
+      assert_receive {:hybrid_provenance, %{count: 1}, metadata}
+      assert metadata.provenance == "curated"
+      assert metadata.hit == true
+
+      assert AdminRepo.aggregate(
+               from(e in ArticleAccessEvent, where: e.tenant_id == ^tenant.id),
+               :count,
+               :id
+             ) == 1
+    end
+  end
+end

--- a/test/loopctl/knowledge_hybrid_test.exs
+++ b/test/loopctl/knowledge_hybrid_test.exs
@@ -126,19 +126,31 @@ defmodule Loopctl.KnowledgeHybridTest do
 
       assert Enum.any?(results, &(&1.id == weak_curated.id))
       assert meta.provenance == :retrieved
-      assert meta.confidence < 0.75
-      assert meta.confidence > 0.0
+
+      # meta.confidence is scoped to the :retrieved provenance CLASS (finding: a
+      # :retrieved response must never report a rejected CURATED candidate's score as
+      # if it belonged to a genuine retrieval winner — a different provenance class).
+      # Here the sole pool candidate is the rejected curated article itself, so there
+      # is no genuine non-curated competitor at all: confidence is honestly 0.0, even
+      # though `results` still (correctly) surfaces that below-threshold article as
+      # the best answer we have.
+      assert meta.confidence == 0.0
     end
   end
 
-  # --- Regression (review finding 4): the curated/retrieved decision must be resolved
-  # over the top of the RANKED POOL, independent of the caller's `:limit`/`:offset`
-  # page window — a curated source that answers but ranks outside the default page
-  # must still be identified, and a caller-supplied `:offset` must shift only which
-  # page of `results` comes back, never the provenance decision itself.
+  # --- Regression (review finding 4, later hardened by the "label != payload"
+  # hoist-to-front fix): the curated/retrieved decision must be resolved over the top
+  # of the RANKED POOL, independent of the caller's `:limit`/`:offset` page window — a
+  # curated source that answers but ranks outside the default page must still be
+  # identified. Once identified, the winning curated article is additionally hoisted
+  # to the FRONT of the (still full) pool BEFORE pagination — never left as a mere
+  # label with no corresponding payload in `results` — so `meta.provenance ==
+  # :curated` always means `results |> List.first()` (at the default `offset: 0`) IS
+  # that curated answer, never one of the keyword-heavy decoys that merely out-ranked
+  # it on the pool-relative `:final_score`.
 
-  describe "hybrid_search/3 - resolved over the ranked pool, independent of pagination (finding 4)" do
-    test "a curated source ranked outside the default page is still identified; :offset shifts only the page, never the decision" do
+  describe "hybrid_search/3 - resolved over pool, curated winner hoisted to front (finding 4 + decoy fix)" do
+    test "a curated source ranked outside the default page is identified AND hoisted to front; a deeper offset never re-surfaces it" do
       tenant = fixture(:tenant)
       Knowledge.reset_circuit_breaker(tenant.id)
 
@@ -174,22 +186,28 @@ defmodule Loopctl.KnowledgeHybridTest do
 
       stub_embeddings_by_query(%{query => @direction_a})
 
-      # Default page (limit 10, offset 0): the curated doc — ranked 13th by the
-      # keyword-heavy combined score — is NOT in the returned page, yet the resolver
-      # still finds and scores it correctly.
+      # Default page (limit 10, offset 0): the curated doc ranks 13th by the
+      # keyword-heavy combined `:final_score` — but the resolver still finds and
+      # scores it correctly, AND hoists it to the front of the returned page (it is
+      # `List.first/1`, not merely present somewhere in the pool) so a caller trusting
+      # `results[0]` as "the curated answer" is never handed a decoy instead.
       assert {:ok, %{results: page1, meta: meta1}} =
                Knowledge.hybrid_search(tenant.id, query,
                  keyword_weight: 0.9,
                  semantic_weight: 0.1
                )
 
-      refute Enum.any?(page1, &(&1.id == curated.id))
       assert meta1.provenance == :curated
       assert meta1.confidence == 1.0
+      assert meta1.curated_article_id == curated.id
+      assert %{id: curated_id} = List.first(page1)
+      assert curated_id == curated.id
 
-      # A deeper page (offset 10) now reaches the curated doc — but the DECISION
-      # (provenance/confidence) is identical: the offset shifted only which page came
-      # back, never which candidates the resolver reasoned over.
+      # A deeper page (offset 10) shifts to the tail of the reordered pool — the
+      # curated winner (now pinned at position 0) does NOT reappear on a later page,
+      # but the DECISION (provenance/confidence/curated_article_id) is identical: the
+      # offset shifted only which page came back, never which candidates the resolver
+      # reasoned over nor which one won.
       assert {:ok, %{results: page2, meta: meta2}} =
                Knowledge.hybrid_search(tenant.id, query,
                  keyword_weight: 0.9,
@@ -197,9 +215,10 @@ defmodule Loopctl.KnowledgeHybridTest do
                  offset: 10
                )
 
-      assert Enum.any?(page2, &(&1.id == curated.id))
+      refute Enum.any?(page2, &(&1.id == curated.id))
       assert meta2.provenance == :curated
       assert meta2.confidence == 1.0
+      assert meta2.curated_article_id == curated.id
     end
   end
 
@@ -266,10 +285,15 @@ defmodule Loopctl.KnowledgeHybridTest do
         assert Map.has_key?(retrieved_result, field)
       end
 
-      for key <- [:provenance, :confidence, :search_mode] do
+      for key <- [:provenance, :confidence, :search_mode, :curated_article_id] do
         assert Map.has_key?(curated_meta, key)
         assert Map.has_key?(retrieved_meta, key)
       end
+
+      # curated_article_id is the actionable pointer (finding: mislabeled-authoritative
+      # decoy) — present with a real id when :curated won, nil on the :retrieved branch.
+      assert curated_meta.curated_article_id == curated.id
+      assert retrieved_meta.curated_article_id == nil
     end
   end
 

--- a/test/loopctl/telemetry/scale_metrics_test.exs
+++ b/test/loopctl/telemetry/scale_metrics_test.exs
@@ -32,14 +32,17 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
     "loopctl.db.error.count",
     "loopctl.heavy_read_repo.query.duration",
     "loopctl.knowledge.vector_search.under_fill.count",
-    "loopctl.knowledge.semantic_fallback.count"
+    "loopctl.knowledge.semantic_fallback.count",
+    "loopctl.knowledge.hybrid_provenance.count"
   ]
 
   # The ONLY labels any scale metric may ever carry (AC-27.15.3). Anything outside this
   # set — especially an unbounded `:article_id` or a raw vector/body — is a hard fail.
   # `:reason` (#297 semantic-fallback counter) is a BOUNDED, sanitized tag set (never a
-  # key/body/query), so it is a safe dimension.
-  @allowed_tags MapSet.new([:endpoint, :mapped_code, :tenant_id, :reason])
+  # key/body/query), so it is a safe dimension. `:provenance` (`"curated"`/`"retrieved"`)
+  # and `:hit` (`true`/`false`) — US-31.2's hybrid-provenance counter — are likewise
+  # small, fixed-cardinality dimensions.
+  @allowed_tags MapSet.new([:endpoint, :mapped_code, :tenant_id, :reason, :provenance, :hit])
 
   defp scale_metrics, do: ScaleMetrics.scale_metrics()
 
@@ -113,6 +116,19 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
       assert ScaleMetrics.semantic_fallback_tags(%{}) == %{reason: "unknown"}
     end
 
+    test "the hybrid-provenance counter (US-31.2) is tagged by provenance, hit, and tenant_id" do
+      counter = metric("loopctl.knowledge.hybrid_provenance.count")
+
+      assert %Telemetry.Metrics.Counter{} = counter
+      assert MapSet.new(counter.tags) == MapSet.new([:provenance, :hit, :tenant_id])
+
+      # Defaults are bounded/never blank when metadata is missing keys (tenant_id's
+      # gated value is exercised separately in the "tenant-label cap gate" describe,
+      # which explicitly controls the gate so this assertion isn't order-dependent).
+      assert ScaleMetrics.hybrid_provenance_tags(%{}).provenance == "unknown"
+      refute ScaleMetrics.hybrid_provenance_tags(%{}).hit
+    end
+
     test "histogram buckets are the documented bounded set" do
       hist = metric("loopctl.heavy_read_repo.query.duration")
 
@@ -180,6 +196,24 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
 
       assert ScaleMetrics.scale_tags(%{endpoint: :x, mapped_code: "y", tenant_id: nil}).tenant_id ==
                :_aggregated
+    end
+
+    test "hybrid_provenance_tags/1 reuses the SAME cap-gated tenant_id collapse" do
+      gate_off()
+
+      assert ScaleMetrics.hybrid_provenance_tags(%{
+               provenance: "curated",
+               hit: true,
+               tenant_id: "t-123"
+             }) == %{provenance: "curated", hit: true, tenant_id: :_aggregated}
+
+      gate_on()
+
+      assert ScaleMetrics.hybrid_provenance_tags(%{
+               provenance: "retrieved",
+               hit: false,
+               tenant_id: "t-123"
+             }) == %{provenance: "retrieved", hit: false, tenant_id: "t-123"}
     end
 
     test "tenant_id over the cap is bounded to cardinality 1 across many distinct tenants" do


### PR DESCRIPTION
Implements US-31.2: the hybrid knowledge resolver prefers a curated source only when it actually answers the query (absolute-score gated), otherwise falls back to retrieval, and always reports provenance.

## What changed
- hybrid_search scores every candidate via an ABSOLUTE (non-pool-relative) signal — separate semantic (cosine 0..1) and keyword (raw/(raw+1) transform of ts_rank_cd) scales — so a lone/top curated candidate no longer normalizes to ~1.0 and the curated branch is gated on true relevance.
- Provenance is resolved over the top of the ranked pool (not the caller's paginated page); the winning curated article is hoisted to the front when meta.provenance == :curated, with meta.curated_article_id as an actionable pointer.
- curated_source_ids/2 membership is scoped to the caller's own candidate pool (list_curated_sources/2 gains an :ids filter + body-less select: :id), avoiding a full-corpus scan and full-body loads.
- RetrievalMetrics/RetrievalMetricSnapshot break out curated_*/retrieved_* searched/followed_through/precision (migration adds the columns); a hybrid_provenance telemetry event + ScaleMetrics counter fires unconditionally, closing the observability gap for retrieved MISS / keyless calls.

## Tests
mix precommit green: compile --warnings-as-errors, format, credo --strict, deps.audit, dialyzer, full suite (4147 tests, 0 failures). Adds knowledge_hybrid_test.exs plus regression coverage for the lone/top-candidate case on both semantic and keyword_only paths.

All enhanced-review findings addressed in-branch (no deferrals).
