### PR TITLE
Progressive disclosure: compact index (knowledge_index + link traversal) -> drill into articles

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -307,6 +307,12 @@ config :loopctl, :full_content_byte_budget, 100_000
 # be exercised with ~11 nodes instead of 100+ (production default is 100).
 config :loopctl, :max_graph_nodes, 10
 
+# Progressive-disclosure caps (US-31.3) — small in tests so the top-K/hub caps
+# can be exercised with a handful of fixtures instead of production-scale
+# corpora (production defaults are 10 and 5 respectively).
+config :loopctl, :progressive_top_k, 3
+config :loopctl, :progressive_min_hub_relates_to, 3
+
 # Distant-pairs candidate caps — small in the DEFAULT async suite so the O(candidates²)
 # sample cap (and the bridge branch's SMALLER cap) can be exercised with a handful of articles
 # instead of 1000+/500. The bridge cap (10) is kept < the general cap (25) so the bridge-branch

--- a/docs/user_stories/epic_31_okf_rag_hybrid/us_31.3.json
+++ b/docs/user_stories/epic_31_okf_rag_hybrid/us_31.3.json
@@ -37,7 +37,8 @@
     "Hub is emergent (>= N outgoing :relates_to links via article_link), not a field/category/tag.",
     "Cap traversal fan-out (the code already bounds high-degree hub fan-out elsewhere — mirror it).",
     "Tenant scoping is explicit-predicate on AdminRepo/HeavyRead.",
-    "Tests use Loopctl.Fixtures.fixture/2 with explicit article_link rows (not a nonexistent hub type)."
+    "Tests use Loopctl.Fixtures.fixture/2 with explicit article_link rows (not a nonexistent hub type).",
+    "IMPLEMENTATION NOTE (review, US-31.3): the seed step actually implemented is search_keyword/3 (a websearch_to_tsquery full-text matcher), NOT the knowledge_index controller/context named above -- knowledge_index is a category/tag CATALOG browse with no topic scoping, so it cannot satisfy AC-31.3.1's 'for a topic/query' requirement as-is. search_keyword/3 was substituted deliberately as the topic-scoped seed; article_link :relates_to traversal (this story's other named building block) is implemented as designed. Caveat: a fuzzy tsquery can silently omit a curated article that is topically relevant but shares no lexical tokens with the query and is not linked from a lexically-matching hub -- the hub traversal partially mitigates by recovering linked-but-lexically-disjoint neighbors, but does not fully close the gap. Documented here explicitly per review finding rather than left as a silent building-block swap."
   ],
   "dependencies": ["US-31.1"],
   "estimated_tokens": 280000

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -54,6 +54,7 @@ defmodule Loopctl.Knowledge do
   alias Loopctl.Knowledge.ArticleLink
   alias Loopctl.Knowledge.ConflictResolution
   alias Loopctl.Knowledge.KbCuration
+  alias Loopctl.Knowledge.OKF
   alias Loopctl.Knowledge.VectorSearch
   alias Loopctl.Llm.ProviderError
   alias Loopctl.Projects.Project
@@ -6885,6 +6886,250 @@ defmodule Loopctl.Knowledge do
       @default_hybrid_curated_margin_keyword
     )
   end
+
+  # --- Progressive disclosure (US-31.3) ---
+  #
+  # Composes ALREADY-SHIPPED subsystems into a bounded, topic-scoped stub index so
+  # an agent reads a compact capped list (id/title/category/one-line summary) and
+  # drills into only the chosen article(s), instead of over-retrieving many fuzzy
+  # chunks. Built from `search_keyword/3` (topic match), `list_curated_sources/2`
+  # (US-31.1 curated preference), a dedicated `:relates_to`-scoped hub-enrichment
+  # query (NOT the general `graph_traversal/3`, which follows every relationship
+  # type), and `Loopctl.Knowledge.OKF.derive_description/1` (the one-line summary).
+  # Deliberately NOT the OKF full-export Markdown (`OKF.export/2`'s `index.md`),
+  # which is a private, full-tenant, project-scoped listing bounded by
+  # `okf_max_buffered_export_articles` — not a topic-scoped stub source (#305/#306).
+
+  # Cap on the FINAL stub count returned by `progressive_index/3` (AC-31.3.2) — a
+  # densely-linked hub cannot flood the caller's context no matter how many
+  # curated neighbors it has. Configurable via `:progressive_top_k`.
+  @default_progressive_top_k 10
+
+  # Operational hub threshold (AC-31.3.4): an article counts as a hub when it has
+  # AT LEAST this many outgoing `:relates_to` article_links. Hubs are emergent
+  # (a link-degree fact), never a modeled type/field/tag. Configurable via
+  # `:progressive_min_hub_relates_to`.
+  @default_min_hub_relates_to 5
+
+  @doc """
+  The top-K cap on stubs returned by `progressive_index/3` (AC-31.3.2).
+  Configurable via `:progressive_top_k` in application config; defaults to
+  `#{@default_progressive_top_k}`.
+  """
+  @spec progressive_top_k() :: pos_integer()
+  def progressive_top_k,
+    do: Application.get_env(:loopctl, :progressive_top_k, @default_progressive_top_k)
+
+  @doc """
+  The outgoing `:relates_to` link-count threshold at which an article is treated
+  as an operational hub for `progressive_index/3` hub enrichment (AC-31.3.4).
+  Configurable via `:progressive_min_hub_relates_to` in application config;
+  defaults to `#{@default_min_hub_relates_to}`.
+  """
+  @spec min_hub_relates_to() :: pos_integer()
+  def min_hub_relates_to,
+    do:
+      Application.get_env(:loopctl, :progressive_min_hub_relates_to, @default_min_hub_relates_to)
+
+  @doc """
+  Progressive-disclosure entrypoint (US-31.3): for a topic/query, returns a
+  COMPACT, CAPPED set of stubs — never full bodies, never the OKF full-export
+  Markdown (AC-31.3.1).
+
+  ## How the index is built
+
+  1. **Seed** — `search_keyword/3` full-text-matches `topic` against published,
+     tenant-scoped articles (title/body), returning candidate ids/titles/categories
+     (no bodies).
+  2. **Hub enrichment** (opt-out via `hub_enrich: false`) — among the seeds, any
+     article with `>= min_hub_relates_to/0` outgoing `:relates_to` links is an
+     operational hub (AC-31.3.4; hubs are not a modeled type). Its `:relates_to`
+     targets are fetched bounded by `max_graph_neighbors_per_node/0` (the SAME
+     fan-out cap `graph_traversal/3` uses elsewhere — mirrored, not
+     re-implemented) and filtered down to the CURATED subset via
+     `list_curated_sources/2`.
+  3. **Curated preference** (AC-31.3.4) — governed curated sources (US-31.1,
+     tenant-own-first, system canonicals participate per AC-31.1.3) are sorted
+     ahead of non-curated matches.
+  4. **Cap** — the combined, deduped candidate list is capped at `top_k`
+     (AC-31.3.2); only the SURVIVING capped ids are read back (title/category/body)
+     to derive each one-line summary — a dense hub's uncapped neighbors are never
+     fetched at all.
+
+  ## Parameters
+
+  - `tenant_id` -- the tenant UUID (from the auth principal)
+  - `topic` -- free-text query/topic string (same constraints as
+    `search_keyword/3`: non-empty, <= 500 chars)
+  - `opts` -- keyword list:
+    - `:limit` -- top-K cap override (default `progressive_top_k/0`)
+    - `:seed_limit` -- how many keyword-search seeds to consider before hub
+      enrichment/capping (default 5x the effective top-K)
+    - `:hub_enrich` -- set `false` to disable `:relates_to` hub enrichment and
+      return only direct topic matches (default `true`)
+    - `:category` -- restrict seed matching to a single category atom
+
+  ## Returns
+
+  - `{:ok, %{stubs: [%{id:, title:, category:, summary:}], meta: %{top_k:,
+    candidate_count:, truncated:}}}` -- `truncated` is `true` when the
+    (deduped) candidate pool exceeded `top_k` before capping
+  - `{:error, :empty_query}` / `{:error, :bad_request, String.t()}` -- same as
+    `search_keyword/3` (an empty/oversized topic is rejected before any query runs)
+  """
+  @spec progressive_index(Ecto.UUID.t(), String.t() | nil, keyword()) ::
+          {:ok, %{stubs: [map()], meta: map()}}
+          | {:error, atom()}
+          | {:error, atom(), String.t()}
+  def progressive_index(tenant_id, topic, opts \\ []) when is_binary(tenant_id) do
+    top_k = Keyword.get(opts, :limit, progressive_top_k())
+    seed_limit = Keyword.get(opts, :seed_limit, top_k * 5)
+    hub_enrich? = Keyword.get(opts, :hub_enrich, true)
+    category = Keyword.get(opts, :category)
+
+    with {:ok, %{results: seed_results}} <-
+           search_keyword(tenant_id, topic,
+             status: :published,
+             limit: seed_limit,
+             category: category,
+             _skip_record_access: true
+           ) do
+      seed_ids = Enum.map(seed_results, & &1.id)
+      curated_ids = tenant_id |> list_curated_sources(select: :id) |> MapSet.new()
+
+      hub_neighbor_ids =
+        if hub_enrich? do
+          progressive_hub_neighbor_ids(tenant_id, seed_ids)
+        else
+          []
+        end
+
+      candidate_ids = Enum.uniq(seed_ids ++ hub_neighbor_ids)
+
+      {curated_first, rest} = Enum.split_with(candidate_ids, &MapSet.member?(curated_ids, &1))
+      capped_ids = Enum.take(curated_first ++ rest, top_k)
+
+      stubs =
+        tenant_id
+        |> fetch_stub_projection(capped_ids)
+        |> order_stubs(capped_ids)
+        |> Enum.map(&build_stub/1)
+
+      {:ok,
+       %{
+         stubs: stubs,
+         meta: %{
+           top_k: top_k,
+           candidate_count: length(candidate_ids),
+           truncated: length(candidate_ids) > top_k
+         }
+       }}
+    end
+  end
+
+  # Hub-enrichment neighbor discovery (AC-31.3.4): finds which of the seed
+  # articles are operational hubs (>= min_hub_relates_to/0 outgoing :relates_to
+  # links), pulls their :relates_to targets bounded by the SAME per-node fan-out
+  # cap `graph_traversal/3` uses, then narrows to the curated subset — never
+  # returning a raw (potentially unbounded-fan-out) neighbor set uncurated.
+  defp progressive_hub_neighbor_ids(_tenant_id, []), do: []
+
+  defp progressive_hub_neighbor_ids(tenant_id, seed_ids) do
+    hub_ids = operational_hub_ids(tenant_id, seed_ids, min_hub_relates_to())
+
+    raw_target_ids =
+      hub_ids
+      |> Enum.flat_map(&hub_relates_to_targets(tenant_id, &1, max_graph_neighbors_per_node()))
+      |> Enum.uniq()
+
+    list_curated_sources(tenant_id, select: :id, ids: raw_target_ids)
+  end
+
+  # Articles among `seed_ids` with >= `min_count` outgoing :relates_to links
+  # (the operational hub definition, AC-31.3.4 — never a modeled type). The only
+  # caller (`progressive_hub_neighbor_ids/2`) already short-circuits an empty
+  # `seed_ids`, so this always receives a non-empty list.
+  defp operational_hub_ids(tenant_id, seed_ids, min_count) do
+    from(l in ArticleLink,
+      where: l.tenant_id == ^tenant_id,
+      where: l.relationship_type == :relates_to,
+      where: l.source_article_id in ^seed_ids,
+      group_by: l.source_article_id,
+      having: count(l.id) >= ^min_count,
+      select: l.source_article_id
+    )
+    |> AdminRepo.all()
+  end
+
+  # Depth-1 :relates_to targets of a single hub, bounded at the SQL level by
+  # `ORDER BY ... LIMIT fanout_limit` — the fan-out cap itself (mirrors the
+  # `JOIN LATERAL ... LIMIT` bound `execute_graph_traversal/4` uses, without
+  # pulling in the general multi-hop/all-relationship-type traversal).
+  defp hub_relates_to_targets(tenant_id, hub_article_id, fanout_limit) do
+    from(l in ArticleLink,
+      where: l.tenant_id == ^tenant_id,
+      where: l.relationship_type == :relates_to,
+      where: l.source_article_id == ^hub_article_id,
+      order_by: [asc: l.inserted_at, asc: l.id],
+      limit: ^fanout_limit,
+      select: l.target_article_id
+    )
+    |> AdminRepo.all()
+  end
+
+  # Body/metadata projection for ONLY the (already-capped) final candidate ids —
+  # a dense hub's uncapped neighbors never reach this query. `tenant_id or scope
+  # == :system` mirrors the explicit tenant-plus-system-canonical predicate used
+  # throughout this module (AC-31.3.4 tenant isolation; system participates per
+  # US-31.1 AC-31.1.3).
+  defp fetch_stub_projection(_tenant_id, []), do: []
+
+  defp fetch_stub_projection(tenant_id, ids) do
+    from(a in Article,
+      where: a.id in ^ids,
+      where: a.tenant_id == ^tenant_id or a.scope == :system,
+      select: %{
+        id: a.id,
+        title: a.title,
+        category: a.category,
+        body: a.body,
+        metadata: a.metadata
+      }
+    )
+    |> AdminRepo.all()
+  end
+
+  # `WHERE id IN (...)` has no defined row order — re-impose the curated-first,
+  # capped candidate order the caller already computed.
+  defp order_stubs(articles, ordered_ids) do
+    by_id = Map.new(articles, &{&1.id, &1})
+
+    ordered_ids
+    |> Enum.map(&Map.get(by_id, &1))
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp build_stub(article) do
+    %{
+      id: article.id,
+      title: article.title,
+      category: article.category,
+      summary: OKF.derive_description(article)
+    }
+  end
+
+  @doc """
+  Drill step (US-31.3, AC-31.3.3): fetches the full body of a single article a
+  `progressive_index/3` stub pointed at, scope-enforced exactly like a direct
+  fetch.
+
+  A thin, explicitly-named delegate to `get_article/3` — the drill step loads
+  ONLY what the index pointed at, never more.
+  """
+  @spec progressive_drill(Ecto.UUID.t(), Ecto.UUID.t(), keyword()) ::
+          {:ok, Article.t()} | {:error, :not_found}
+  def progressive_drill(tenant_id, article_id, opts \\ []),
+    do: get_article(tenant_id, article_id, opts)
 
   # --- Circuit breaker for embedding generation ---
 

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -639,37 +639,43 @@ defmodule Loopctl.Knowledge do
           {:ok, Article.t()} | {:error, :not_found}
   def get_article(tenant_id, article_id, opts \\ []) do
     case AdminRepo.get_by(Article, id: article_id, tenant_id: tenant_id) do
-      nil ->
-        {:error, :not_found}
+      nil -> {:error, :not_found}
+      article -> finalize_article_read(tenant_id, article, opts)
+    end
+  end
 
-      article ->
-        # Visibility enforcement (#163): a private/owner memory the caller doesn't
-        # own resolves to :not_found — no existence leak, no access recorded.
-        vis = Keyword.get(opts, :visibility_agent_id)
+  # Shared visibility/preload/access-tracking tail of an article fetch, once the
+  # row itself has been located (tenant-owned or, via `progressive_drill/3`'s
+  # system fallback, a system canonical). Factored out so BOTH scopes get
+  # identical visibility enforcement, link preloading, conflict-link filtering,
+  # and access recording — never duplicated ad hoc per caller.
+  defp finalize_article_read(tenant_id, article, opts) do
+    # Visibility enforcement (#163): a private/owner memory the caller doesn't
+    # own resolves to :not_found — no existence leak, no access recorded.
+    vis = Keyword.get(opts, :visibility_agent_id)
 
-        if visible_to_caller?(article, vis) do
-          article =
-            article
-            |> AdminRepo.preload(
-              outgoing_links: :target_article,
-              incoming_links: :source_article
-            )
-            |> filter_visible_links(vis)
-            |> drop_resolved_conflict_links(tenant_id)
+    if visible_to_caller?(article, vis) do
+      article =
+        article
+        |> AdminRepo.preload(
+          outgoing_links: :target_article,
+          incoming_links: :source_article
+        )
+        |> filter_visible_links(vis)
+        |> drop_resolved_conflict_links(tenant_id)
 
-          Analytics.record_access(
-            tenant_id,
-            article.id,
-            Keyword.get(opts, :api_key_id),
-            "get",
-            Keyword.get(opts, :access_metadata, %{}),
-            attribution_context(opts)
-          )
+      Analytics.record_access(
+        tenant_id,
+        article.id,
+        Keyword.get(opts, :api_key_id),
+        "get",
+        Keyword.get(opts, :access_metadata, %{}),
+        attribution_context(opts)
+      )
 
-          {:ok, article}
-        else
-          {:error, :not_found}
-        end
+      {:ok, article}
+    else
+      {:error, :not_found}
     end
   end
 
@@ -6940,7 +6946,15 @@ defmodule Loopctl.Knowledge do
 
   1. **Seed** — `search_keyword/3` full-text-matches `topic` against published,
      tenant-scoped articles (title/body), returning candidate ids/titles/categories
-     (no bodies).
+     (no bodies). NOTE: this is a deliberate substitution for the
+     `knowledge_index` catalog browse named in the story/AC — `knowledge_index`
+     is a category/tag catalog with no topic scoping, so it cannot answer "for a
+     topic/query" on its own; `search_keyword/3` is the topic-scoped mechanism
+     that does. Caveat: a fuzzy `websearch_to_tsquery` match can silently omit a
+     curated article that is topically relevant but shares no lexical tokens
+     with `topic` and isn't linked from a lexically-matching hub — step 2's
+     `:relates_to` traversal partially (not fully) mitigates this by recovering
+     linked-but-lexically-disjoint neighbors.
   2. **Hub enrichment** (opt-out via `hub_enrich: false`) — among the seeds, any
      article with `>= min_hub_relates_to/0` outgoing `:relates_to` links is an
      operational hub (AC-31.3.4; hubs are not a modeled type). Its `:relates_to`
@@ -6995,7 +7009,6 @@ defmodule Loopctl.Knowledge do
              _skip_record_access: true
            ) do
       seed_ids = Enum.map(seed_results, & &1.id)
-      curated_ids = tenant_id |> list_curated_sources(select: :id) |> MapSet.new()
 
       hub_neighbor_ids =
         if hub_enrich? do
@@ -7005,6 +7018,15 @@ defmodule Loopctl.Knowledge do
         end
 
       candidate_ids = Enum.uniq(seed_ids ++ hub_neighbor_ids)
+
+      # Membership-only scan restricted to the (already small, capped) candidate
+      # pool -- never the tenant's entire curated/system-canonical corpus. Mirrors
+      # the `ids: raw_target_ids` scoping `progressive_hub_neighbor_ids/2` already
+      # uses below.
+      curated_ids =
+        tenant_id
+        |> list_curated_sources(select: :id, ids: candidate_ids)
+        |> MapSet.new()
 
       {curated_first, rest} = Enum.split_with(candidate_ids, &MapSet.member?(curated_ids, &1))
       capped_ids = Enum.take(curated_first ++ rest, top_k)
@@ -7038,8 +7060,8 @@ defmodule Loopctl.Knowledge do
     hub_ids = operational_hub_ids(tenant_id, seed_ids, min_hub_relates_to())
 
     raw_target_ids =
-      hub_ids
-      |> Enum.flat_map(&hub_relates_to_targets(tenant_id, &1, max_graph_neighbors_per_node()))
+      tenant_id
+      |> hub_relates_to_targets(hub_ids, max_graph_neighbors_per_node())
       |> Enum.uniq()
 
     list_curated_sources(tenant_id, select: :id, ids: raw_target_ids)
@@ -7061,18 +7083,33 @@ defmodule Loopctl.Knowledge do
     |> AdminRepo.all()
   end
 
-  # Depth-1 :relates_to targets of a single hub, bounded at the SQL level by
-  # `ORDER BY ... LIMIT fanout_limit` — the fan-out cap itself (mirrors the
-  # `JOIN LATERAL ... LIMIT` bound `execute_graph_traversal/4` uses, without
-  # pulling in the general multi-hop/all-relationship-type traversal).
-  defp hub_relates_to_targets(tenant_id, hub_article_id, fanout_limit) do
-    from(l in ArticleLink,
-      where: l.tenant_id == ^tenant_id,
-      where: l.relationship_type == :relates_to,
-      where: l.source_article_id == ^hub_article_id,
-      order_by: [asc: l.inserted_at, asc: l.id],
-      limit: ^fanout_limit,
-      select: l.target_article_id
+  # Depth-1 :relates_to targets of EVERY hub in `hub_ids`, bounded PER HUB at
+  # the SQL level by `ROW_NUMBER() OVER (PARTITION BY source_article_id ...) <=
+  # fanout_limit` -- the same fan-out cap (mirrors the `JOIN LATERAL ... LIMIT`
+  # bound `execute_graph_traversal/4` uses, without pulling in the general
+  # multi-hop/all-relationship-type traversal), but in ONE round-trip regardless
+  # of hub count instead of one query per hub (review finding: bounded N+1).
+  defp hub_relates_to_targets(_tenant_id, [], _fanout_limit), do: []
+
+  defp hub_relates_to_targets(tenant_id, hub_ids, fanout_limit) do
+    ranked =
+      from(l in ArticleLink,
+        where: l.tenant_id == ^tenant_id,
+        where: l.relationship_type == :relates_to,
+        where: l.source_article_id in ^hub_ids,
+        select: %{
+          target_article_id: l.target_article_id,
+          rank:
+            over(row_number(),
+              partition_by: l.source_article_id,
+              order_by: [asc: l.inserted_at, asc: l.id]
+            )
+        }
+      )
+
+    from(r in subquery(ranked),
+      where: r.rank <= ^fanout_limit,
+      select: r.target_article_id
     )
     |> AdminRepo.all()
   end
@@ -7123,13 +7160,35 @@ defmodule Loopctl.Knowledge do
   `progressive_index/3` stub pointed at, scope-enforced exactly like a direct
   fetch.
 
-  A thin, explicitly-named delegate to `get_article/3` — the drill step loads
-  ONLY what the index pointed at, never more.
+  Mirrors `progressive_index/3`'s OWN scope (AC-31.3.3 vs AC-31.3.4
+  consistency): `progressive_index/3` surfaces both tenant-owned articles AND
+  system-scope (`tenant_id: nil`) curated canonicals (`fetch_stub_projection/2`
+  reads `where a.tenant_id == ^tenant_id or a.scope == :system`), so the drill
+  step must be able to open EITHER. It tries the tenant-scoped fetch first
+  (`get_article/3`); only when that misses does it fall back to the
+  system-scope-by-id lookup (the same predicate `fetch_curatable_article/2`
+  uses for curation) so a system canonical's `tenant_id: nil` never falls
+  through to a false `:not_found`. A tenant-owned article never matches the
+  system-scope fallback (system articles require `scope: :system`), so tenant
+  isolation is unaffected — the fallback only ever *widens* what a tenant-scoped
+  `:not_found` was allowed to catch, onto the same system-canonical set the
+  index already surfaces.
   """
   @spec progressive_drill(Ecto.UUID.t(), Ecto.UUID.t(), keyword()) ::
           {:ok, Article.t()} | {:error, :not_found}
-  def progressive_drill(tenant_id, article_id, opts \\ []),
-    do: get_article(tenant_id, article_id, opts)
+  def progressive_drill(tenant_id, article_id, opts \\ []) do
+    case get_article(tenant_id, article_id, opts) do
+      {:error, :not_found} -> drill_system_canonical(tenant_id, article_id, opts)
+      result -> result
+    end
+  end
+
+  defp drill_system_canonical(tenant_id, article_id, opts) do
+    case AdminRepo.one(from(a in Article, where: a.id == ^article_id and a.scope == :system)) do
+      nil -> {:error, :not_found}
+      article -> finalize_article_read(tenant_id, article, opts)
+    end
+  end
 
   # --- Circuit breaker for embedding generation ---
 

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -6982,6 +6982,12 @@ defmodule Loopctl.Knowledge do
     - `:hub_enrich` -- set `false` to disable `:relates_to` hub enrichment and
       return only direct topic matches (default `true`)
     - `:category` -- restrict seed matching to a single category atom
+    - `:visibility_agent_id` -- the calling agent's id (#163). Forwarded to the
+      seed `search_keyword/3` call and re-applied to hub-neighbor discovery and
+      the final stub projection, so another agent's `private`/`owner` memory
+      never surfaces as an index stub within the same tenant. `nil` (the
+      default, used by non-agent/higher-role callers) is a no-op — everything
+      is visible.
 
   ## Returns
 
@@ -6996,23 +7002,30 @@ defmodule Loopctl.Knowledge do
           | {:error, atom()}
           | {:error, atom(), String.t()}
   def progressive_index(tenant_id, topic, opts \\ []) when is_binary(tenant_id) do
-    top_k = Keyword.get(opts, :limit, progressive_top_k())
+    # Clamped exactly like `search_keyword/3`'s own `:limit` (AC-31.3.2's
+    # "bounded" top-K must hold even for an explicit caller override, not just
+    # the default -- otherwise a densely-linked hub could still flood context).
+    top_k =
+      opts |> Keyword.get(:limit, progressive_top_k()) |> max(1) |> min(@max_relevance_page_size)
+
     seed_limit = Keyword.get(opts, :seed_limit, top_k * 5)
     hub_enrich? = Keyword.get(opts, :hub_enrich, true)
     category = Keyword.get(opts, :category)
+    vis = Keyword.get(opts, :visibility_agent_id)
 
     with {:ok, %{results: seed_results}} <-
            search_keyword(tenant_id, topic,
              status: :published,
              limit: seed_limit,
              category: category,
+             visibility_agent_id: vis,
              _skip_record_access: true
            ) do
       seed_ids = Enum.map(seed_results, & &1.id)
 
       hub_neighbor_ids =
         if hub_enrich? do
-          progressive_hub_neighbor_ids(tenant_id, seed_ids)
+          progressive_hub_neighbor_ids(tenant_id, seed_ids, vis)
         else
           []
         end
@@ -7021,7 +7034,7 @@ defmodule Loopctl.Knowledge do
 
       # Membership-only scan restricted to the (already small, capped) candidate
       # pool -- never the tenant's entire curated/system-canonical corpus. Mirrors
-      # the `ids: raw_target_ids` scoping `progressive_hub_neighbor_ids/2` already
+      # the `ids: raw_target_ids` scoping `progressive_hub_neighbor_ids/3` already
       # uses below.
       curated_ids =
         tenant_id
@@ -7033,7 +7046,7 @@ defmodule Loopctl.Knowledge do
 
       stubs =
         tenant_id
-        |> fetch_stub_projection(capped_ids)
+        |> fetch_stub_projection(capped_ids, vis)
         |> order_stubs(capped_ids)
         |> Enum.map(&build_stub/1)
 
@@ -7054,9 +7067,14 @@ defmodule Loopctl.Knowledge do
   # links), pulls their :relates_to targets bounded by the SAME per-node fan-out
   # cap `graph_traversal/3` uses, then narrows to the curated subset — never
   # returning a raw (potentially unbounded-fan-out) neighbor set uncurated.
-  defp progressive_hub_neighbor_ids(_tenant_id, []), do: []
+  #
+  # `vis` (#163): the hub targets are discovered via `ArticleLink`/
+  # `list_curated_sources/2`, NEITHER of which is visibility-scoped, so a
+  # private/owner memory reachable via a `:relates_to` edge is re-filtered here
+  # before it can ever reach the candidate pool.
+  defp progressive_hub_neighbor_ids(_tenant_id, [], _vis), do: []
 
-  defp progressive_hub_neighbor_ids(tenant_id, seed_ids) do
+  defp progressive_hub_neighbor_ids(tenant_id, seed_ids, vis) do
     hub_ids = operational_hub_ids(tenant_id, seed_ids, min_hub_relates_to())
 
     raw_target_ids =
@@ -7064,12 +7082,23 @@ defmodule Loopctl.Knowledge do
       |> hub_relates_to_targets(hub_ids, max_graph_neighbors_per_node())
       |> Enum.uniq()
 
-    list_curated_sources(tenant_id, select: :id, ids: raw_target_ids)
+    tenant_id
+    |> list_curated_sources(select: :id, ids: raw_target_ids)
+    |> filter_visible_candidate_ids(vis)
+  end
+
+  defp filter_visible_candidate_ids([], _vis), do: []
+  defp filter_visible_candidate_ids(ids, nil), do: ids
+
+  defp filter_visible_candidate_ids(ids, vis) do
+    from(a in Article, where: a.id in ^ids, select: a.id)
+    |> maybe_filter_by_visibility(vis)
+    |> AdminRepo.all()
   end
 
   # Articles among `seed_ids` with >= `min_count` outgoing :relates_to links
   # (the operational hub definition, AC-31.3.4 — never a modeled type). The only
-  # caller (`progressive_hub_neighbor_ids/2`) already short-circuits an empty
+  # caller (`progressive_hub_neighbor_ids/3`) already short-circuits an empty
   # `seed_ids`, so this always receives a non-empty list.
   defp operational_hub_ids(tenant_id, seed_ids, min_count) do
     from(l in ArticleLink,
@@ -7118,10 +7147,14 @@ defmodule Loopctl.Knowledge do
   # a dense hub's uncapped neighbors never reach this query. `tenant_id or scope
   # == :system` mirrors the explicit tenant-plus-system-canonical predicate used
   # throughout this module (AC-31.3.4 tenant isolation; system participates per
-  # US-31.1 AC-31.1.3).
-  defp fetch_stub_projection(_tenant_id, []), do: []
+  # US-31.1 AC-31.1.3). `maybe_filter_by_visibility/2` is the LAST line of
+  # defense-in-depth for #163: the seed and hub-neighbor pools are already
+  # visibility-filtered upstream (`search_keyword/3`, `filter_visible_candidate_ids/2`),
+  # but this is the query that actually reads title/body — it must never trust
+  # the caller wired only one of those two upstream gates correctly.
+  defp fetch_stub_projection(_tenant_id, [], _vis), do: []
 
-  defp fetch_stub_projection(tenant_id, ids) do
+  defp fetch_stub_projection(tenant_id, ids, vis) do
     from(a in Article,
       where: a.id in ^ids,
       where: a.tenant_id == ^tenant_id or a.scope == :system,
@@ -7133,6 +7166,7 @@ defmodule Loopctl.Knowledge do
         metadata: a.metadata
       }
     )
+    |> maybe_filter_by_visibility(vis)
     |> AdminRepo.all()
   end
 
@@ -7162,7 +7196,7 @@ defmodule Loopctl.Knowledge do
 
   Mirrors `progressive_index/3`'s OWN scope (AC-31.3.3 vs AC-31.3.4
   consistency): `progressive_index/3` surfaces both tenant-owned articles AND
-  system-scope (`tenant_id: nil`) curated canonicals (`fetch_stub_projection/2`
+  system-scope (`tenant_id: nil`) curated canonicals (`fetch_stub_projection/3`
   reads `where a.tenant_id == ^tenant_id or a.scope == :system`), so the drill
   step must be able to open EITHER. It tries the tenant-scoped fetch first
   (`get_article/3`); only when that misses does it fall back to the
@@ -7184,7 +7218,18 @@ defmodule Loopctl.Knowledge do
   end
 
   defp drill_system_canonical(tenant_id, article_id, opts) do
-    case AdminRepo.one(from(a in Article, where: a.id == ^article_id and a.scope == :system)) do
+    # `status == :published` (mirrors `get_system_article_by_slug/1` and
+    # `list_system_articles/1`) -- this is the ONLY tenant-facing read path for
+    # a system canonical's body (get_article/2 requires a tenant_id match,
+    # which nil-tenant system rows never satisfy), so unlike
+    # `fetch_curatable_article/2` (the privileged, role-gated curation path
+    # that legitimately needs drafts), this must never expose a draft or
+    # archived system canonical by id.
+    case AdminRepo.one(
+           from(a in Article,
+             where: a.id == ^article_id and a.scope == :system and a.status == :published
+           )
+         ) do
       nil -> {:error, :not_found}
       article -> finalize_article_read(tenant_id, article, opts)
     end

--- a/lib/loopctl/knowledge/okf.ex
+++ b/lib/loopctl/knowledge/okf.ex
@@ -342,7 +342,21 @@ defmodule Loopctl.Knowledge.OKF do
     "# Knowledge Update Log\n\n" <> body <> "\n"
   end
 
-  defp derive_description(article) do
+  @doc """
+  Derives a one-line, 160-char-capped summary for an article.
+
+  Public (extracted from the OKF index-file renderer, US-31.3 AC-31.3.1) so
+  other progressive-disclosure surfaces (`Loopctl.Knowledge.progressive_index/3`)
+  can build a compact stub without duplicating this logic. Prefers the
+  round-tripped `metadata["okf"]["description"]` (set on OKF import) and falls
+  back to the first non-heading line of the body, truncated to 160 bytes.
+
+  Takes anything with `:body`/`:metadata` fields (a full `%Article{}` or a bare
+  projection map carrying just those two) — callers that only need the summary
+  need not fetch/preload the rest of the article.
+  """
+  @spec derive_description(%{body: String.t() | nil, metadata: map() | nil}) :: String.t()
+  def derive_description(article) do
     okf = Map.get(article.metadata || %{}, "okf", %{})
 
     case Map.get(okf, "description") do

--- a/lib/loopctl/knowledge/okf.ex
+++ b/lib/loopctl/knowledge/okf.ex
@@ -343,13 +343,16 @@ defmodule Loopctl.Knowledge.OKF do
   end
 
   @doc """
-  Derives a one-line, 160-char-capped summary for an article.
+  Derives a one-line, 160-byte-capped summary for an article.
 
   Public (extracted from the OKF index-file renderer, US-31.3 AC-31.3.1) so
   other progressive-disclosure surfaces (`Loopctl.Knowledge.progressive_index/3`)
   can build a compact stub without duplicating this logic. Prefers the
-  round-tripped `metadata["okf"]["description"]` (set on OKF import) and falls
-  back to the first non-heading line of the body, truncated to 160 bytes.
+  round-tripped `metadata["okf"]["description"]` (set on OKF import) --
+  returned AS-IS, untruncated, since it's an author-supplied one-liner, not
+  body text that needs clipping -- and otherwise falls back to the first
+  non-heading line of the body, truncated to 160 bytes (plus a 3-byte "…"
+  suffix when truncation occurs).
 
   Takes anything with `:body`/`:metadata` fields (a full `%Article{}` or a bare
   projection map carrying just those two) — callers that only need the summary
@@ -373,8 +376,32 @@ defmodule Loopctl.Knowledge.OKF do
     end
   end
 
+  # Byte-bounded (not grapheme-bounded) truncation: `String.slice/3` counts
+  # GRAPHEMES, so for multibyte text (accents, emoji) slicing to `max`
+  # graphemes can produce a result several times larger than `max` BYTES --
+  # exactly the opposite of what a byte cap promises. Walk graphemes and stop
+  # accumulating the instant the NEXT one would push byte_size over `max`, so
+  # the returned (pre-ellipsis) string never exceeds `max` bytes regardless of
+  # encoding width.
   defp truncate(str, max) when byte_size(str) <= max, do: str
-  defp truncate(str, max), do: String.slice(str, 0, max) <> "…"
+
+  defp truncate(str, max) do
+    str
+    |> String.graphemes()
+    |> Enum.reduce_while({[], 0}, fn grapheme, {acc, size} ->
+      new_size = size + byte_size(grapheme)
+
+      if new_size > max do
+        {:halt, {acc, size}}
+      else
+        {:cont, {[grapheme | acc], new_size}}
+      end
+    end)
+    |> elem(0)
+    |> Enum.reverse()
+    |> Enum.join()
+    |> Kernel.<>("…")
+  end
 
   # ---------------------------------------------------------------------------
   # Import

--- a/test/loopctl/knowledge/okf_test.exs
+++ b/test/loopctl/knowledge/okf_test.exs
@@ -59,6 +59,56 @@ defmodule Loopctl.Knowledge.OKFTest do
     end
   end
 
+  describe "derive_description/1 (US-31.3 AC-31.3.1; review finding, low: byte cap vs multibyte text)" do
+    test "an ASCII body line under 160 bytes is returned as-is" do
+      article = %{body: "A short summary line.", metadata: %{}}
+
+      assert OKF.derive_description(article) == "A short summary line."
+    end
+
+    test "a body line is truncated to <= 160 bytes plus the ellipsis, never 160 GRAPHEMES" do
+      # 200 multibyte graphemes (é is 2 bytes in UTF-8) -- slicing by grapheme
+      # count (the old, buggy behavior) would return 160 of these (320 bytes),
+      # blowing well past the documented 160-byte cap.
+      long_multibyte_line = String.duplicate("é", 200)
+      article = %{body: long_multibyte_line, metadata: %{}}
+
+      summary = OKF.derive_description(article)
+
+      # Byte size of the truncated portion (excluding the 3-byte "…" ellipsis)
+      # must not exceed the 160-byte cap.
+      ellipsis = "…"
+      without_ellipsis = String.trim_trailing(summary, ellipsis)
+      assert byte_size(without_ellipsis) <= 160
+      assert String.ends_with?(summary, ellipsis)
+      # Sanity: genuinely truncated, not the full 200-grapheme/400-byte input.
+      assert String.length(without_ellipsis) < 200
+    end
+
+    test "an untruncated multibyte line at or under the byte cap is returned without an ellipsis" do
+      # 79 "é" graphemes = 158 bytes, under the 160-byte cap -- must round-trip
+      # unchanged (no ellipsis appended).
+      short_multibyte_line = String.duplicate("é", 79)
+      article = %{body: short_multibyte_line, metadata: %{}}
+
+      assert OKF.derive_description(article) == short_multibyte_line
+    end
+
+    test "the metadata['okf']['description'] path returns the description verbatim, untruncated" do
+      # Documented (not just implied): an author-supplied OKF description is
+      # returned as-is even when it exceeds the 160-byte cap that applies to
+      # the body-derived fallback -- it isn't body text needing clipping.
+      long_description = String.duplicate("word ", 60)
+
+      article = %{
+        body: "irrelevant body",
+        metadata: %{"okf" => %{"description" => long_description}}
+      }
+
+      assert OKF.derive_description(article) == long_description
+    end
+  end
+
   describe "build_bundle/2 cap (#2 TOCTOU: enforced on the MATERIALIZED set)" do
     test "exactly at the cap succeeds; one over rejects (peek-and-reject, no silent truncation)" do
       tenant = fixture(:tenant)

--- a/test/loopctl/knowledge/progressive_index_test.exs
+++ b/test/loopctl/knowledge/progressive_index_test.exs
@@ -210,6 +210,40 @@ defmodule Loopctl.Knowledge.ProgressiveIndexTest do
       assert drilled.id == marked.id
       assert drilled.body == "system body"
     end
+
+    test "drill rejects a draft or archived system canonical by id (review finding, medium)" do
+      tenant = fixture(:tenant)
+
+      {:ok, draft_system} =
+        Knowledge.create_article(
+          tenant.id,
+          %{
+            scope: :system,
+            status: :draft,
+            category: :reference,
+            title: "Draft System Canonical",
+            body: "draft system body"
+          }
+        )
+
+      {:ok, archived_system} =
+        Knowledge.create_article(
+          tenant.id,
+          %{
+            scope: :system,
+            status: :archived,
+            category: :reference,
+            title: "Archived System Canonical",
+            body: "archived system body"
+          }
+        )
+
+      # Neither is reachable via the tenant-scoped get_article/3 path (nil
+      # tenant_id), so the ONLY way to probe this is the system-canonical
+      # fallback drill_system_canonical/3 exercises directly.
+      assert {:error, :not_found} = Knowledge.progressive_drill(tenant.id, draft_system.id)
+      assert {:error, :not_found} = Knowledge.progressive_drill(tenant.id, archived_system.id)
+    end
   end
 
   # --- AC-31.3.2: the cap is configurable and documented ---
@@ -218,6 +252,21 @@ defmodule Loopctl.Knowledge.ProgressiveIndexTest do
     test "read from application config, overridable in config/test.exs" do
       assert Knowledge.progressive_top_k() == 3
       assert Knowledge.min_hub_relates_to() == 3
+    end
+
+    test "an oversized :limit override is clamped to max_relevance_page_size/0 (review finding, low)" do
+      tenant = fixture(:tenant)
+      topic = "ClampedLimitTopicEFGHI"
+
+      fixture(:article, %{tenant_id: tenant.id, status: :published, title: topic})
+
+      assert {:ok, %{meta: meta}} =
+               Knowledge.progressive_index(tenant.id, topic,
+                 limit: 1_000_000,
+                 hub_enrich: false
+               )
+
+      assert meta.top_k == Knowledge.max_relevance_page_size()
     end
 
     test "a :limit opt overrides the default top-K cap" do
@@ -301,6 +350,105 @@ defmodule Loopctl.Knowledge.ProgressiveIndexTest do
                Knowledge.progressive_index(tenant.id, topic, hub_enrich: false)
 
       assert Enum.map(stubs, & &1.id) == [hub.id]
+    end
+  end
+
+  # --- #163 agent-visibility enforcement (review finding, high) ---
+
+  describe "progressive_index/3 - agent visibility scope (#163)" do
+    test "another agent's private/owner memory never surfaces as an index stub" do
+      tenant = fixture(:tenant)
+      owner_agent = fixture(:agent, %{tenant_id: tenant.id})
+      other_agent = fixture(:agent, %{tenant_id: tenant.id})
+      topic = "PrivateMemoryTopicLMNOP"
+
+      private =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :published,
+          title: "#{topic} Private Memory",
+          body: "PRIVATE BODY — must not leak",
+          metadata: %{"visibility" => "private", "agent_id" => to_string(owner_agent.id)}
+        })
+
+      shared =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :published,
+          title: "#{topic} Shared"
+        })
+
+      # A caller with no visibility_agent_id (higher role) sees everything.
+      assert {:ok, %{stubs: unscoped_stubs}} = Knowledge.progressive_index(tenant.id, topic)
+      unscoped_ids = Enum.map(unscoped_stubs, & &1.id)
+      assert private.id in unscoped_ids
+      assert shared.id in unscoped_ids
+
+      # The NON-owning agent must never see the private memory's stub -- no
+      # title, no body-derived summary.
+      assert {:ok, %{stubs: other_stubs}} =
+               Knowledge.progressive_index(tenant.id, topic,
+                 visibility_agent_id: to_string(other_agent.id)
+               )
+
+      other_ids = Enum.map(other_stubs, & &1.id)
+      refute private.id in other_ids
+      assert shared.id in other_ids
+      refute Enum.any?(other_stubs, fn stub -> stub.title == "#{topic} Private Memory" end)
+
+      # The OWNER, by contrast, does see its own private memory's stub.
+      assert {:ok, %{stubs: owner_stubs}} =
+               Knowledge.progressive_index(tenant.id, topic,
+                 visibility_agent_id: to_string(owner_agent.id)
+               )
+
+      assert private.id in Enum.map(owner_stubs, & &1.id)
+    end
+
+    test "a private memory reachable only via hub :relates_to traversal is filtered for a non-owning agent" do
+      tenant = fixture(:tenant)
+      owner_agent = fixture(:agent, %{tenant_id: tenant.id})
+      other_agent = fixture(:agent, %{tenant_id: tenant.id})
+      topic = "HubPrivateNeighborTopicRSTU"
+
+      hub =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :published,
+          title: "#{topic} Hub"
+        })
+
+      private_neighbor =
+        curated_article(tenant.id, %{
+          title: "Private Neighbor #{topic}",
+          metadata: %{"visibility" => "private", "agent_id" => to_string(owner_agent.id)}
+        })
+
+      relates_to(tenant.id, hub, private_neighbor)
+
+      # min_hub_relates_to is configured to 3 in test.exs -- pad two more
+      # outgoing :relates_to links so `hub` clears the operational-hub
+      # threshold and enrichment actually runs.
+      for n <- 1..2 do
+        padding = curated_article(tenant.id, %{title: "Padding Target #{n} #{topic}"})
+        relates_to(tenant.id, hub, padding)
+      end
+
+      assert {:ok, %{stubs: other_stubs}} =
+               Knowledge.progressive_index(tenant.id, topic,
+                 limit: 10,
+                 visibility_agent_id: to_string(other_agent.id)
+               )
+
+      refute private_neighbor.id in Enum.map(other_stubs, & &1.id)
+
+      assert {:ok, %{stubs: owner_stubs}} =
+               Knowledge.progressive_index(tenant.id, topic,
+                 limit: 10,
+                 visibility_agent_id: to_string(owner_agent.id)
+               )
+
+      assert private_neighbor.id in Enum.map(owner_stubs, & &1.id)
     end
   end
 

--- a/test/loopctl/knowledge/progressive_index_test.exs
+++ b/test/loopctl/knowledge/progressive_index_test.exs
@@ -202,6 +202,13 @@ defmodule Loopctl.Knowledge.ProgressiveIndexTest do
       assert {:ok, %{stubs: stubs}} = Knowledge.progressive_index(tenant.id, topic)
       ids = Enum.map(stubs, & &1.id)
       assert marked.id in ids
+
+      # AC-31.3.3 vs AC-31.3.4 consistency (review finding): a system-scope stub
+      # the index surfaces must actually be openable by drill — a `tenant_id: nil`
+      # system canonical must not fall through to a false {:error, :not_found}.
+      assert {:ok, drilled} = Knowledge.progressive_drill(tenant.id, marked.id)
+      assert drilled.id == marked.id
+      assert drilled.body == "system body"
     end
   end
 
@@ -231,6 +238,47 @@ defmodule Loopctl.Knowledge.ProgressiveIndexTest do
       assert length(stubs) == 2
       assert meta.top_k == 2
       assert meta.truncated == true
+    end
+
+    test "per-hub :relates_to fan-out is capped at max_graph_neighbors_per_node/0, not the hub's full degree" do
+      tenant = fixture(:tenant)
+      topic = "FanoutCapTopicUVWXY"
+
+      hub =
+        fixture(:article, %{tenant_id: tenant.id, status: :published, title: "#{topic} Hub"})
+
+      fanout_cap = Knowledge.max_graph_neighbors_per_node()
+      # Degree well past the cap (and past min_hub_relates_to == 3) so the LIMIT
+      # is actually exercised -- if it were removed, all of these would surface.
+      extra = 5
+      total_targets = fanout_cap + extra
+
+      # Titles deliberately DO NOT contain `topic` -- only `hub` is a direct
+      # search_keyword seed; every target is reachable ONLY via hub traversal,
+      # isolating the fan-out cap from the unrelated top-K stub cap.
+      targets =
+        for n <- 1..total_targets do
+          target = curated_article(tenant.id, %{title: "Fanout Target #{n}"})
+          relates_to(tenant.id, hub, target)
+          target
+        end
+
+      # Override :limit well above total_targets so the top-K cap cannot mask
+      # the fan-out cap's effect.
+      assert {:ok, %{stubs: stubs, meta: meta}} =
+               Knowledge.progressive_index(tenant.id, topic, limit: total_targets + 5)
+
+      # Candidate pool = 1 seed (hub) + fanout_cap neighbors -- never the full
+      # degree of `total_targets` links.
+      assert meta.candidate_count == 1 + fanout_cap
+      assert length(stubs) == 1 + fanout_cap
+      assert meta.truncated == false
+
+      surfaced_target_ids = stubs |> Enum.map(& &1.id) |> MapSet.new() |> MapSet.delete(hub.id)
+      all_target_ids = MapSet.new(targets, & &1.id)
+
+      assert MapSet.size(surfaced_target_ids) == fanout_cap
+      assert MapSet.subset?(surfaced_target_ids, all_target_ids)
     end
   end
 

--- a/test/loopctl/knowledge/progressive_index_test.exs
+++ b/test/loopctl/knowledge/progressive_index_test.exs
@@ -1,0 +1,273 @@
+defmodule Loopctl.Knowledge.ProgressiveIndexTest do
+  @moduledoc """
+  US-31.3: Progressive disclosure — compact index (knowledge_index + article_link
+  traversal) -> drill into articles.
+
+  Covers `Knowledge.progressive_index/3` (a bounded, topic-scoped stub query
+  composing `search_keyword/3`, `list_curated_sources/2` (US-31.1), a dedicated
+  `:relates_to`-scoped hub-enrichment query, and `OKF.derive_description/1`) and
+  the `Knowledge.progressive_drill/3` full-body fetch.
+  """
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.Knowledge
+
+  # Creates a published tenant article and marks it curated via the governed path
+  # (mirrors test/loopctl/knowledge_curated_test.exs / knowledge_hybrid_test.exs).
+  defp curated_article(tenant_id, attrs) do
+    article =
+      fixture(:article, Map.merge(%{tenant_id: tenant_id, status: :published}, attrs))
+
+    {:ok, marked} = Knowledge.mark_curated(tenant_id, article.id, actor_label: "user:admin")
+    marked
+  end
+
+  defp relates_to(tenant_id, source, target) do
+    fixture(:article_link, %{
+      tenant_id: tenant_id,
+      source_article_id: source.id,
+      target_article_id: target.id,
+      relationship_type: :relates_to
+    })
+  end
+
+  # --- TC-31.3.1: index returns capped compact stubs then drill returns the body ---
+
+  describe "progressive_index/3 - capped compact stubs then drill (TC-31.3.1)" do
+    test "returns <= top-K stubs (id/title/category/summary, no bodies); drill returns the full body" do
+      tenant = fixture(:tenant)
+      topic = "ProgressiveHubTopicQZX"
+
+      hub =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :published,
+          title: "#{topic} Overview",
+          body: "An overview article that links to many curated sources."
+        })
+
+      # top_k is configured to 3 in config/test.exs; 5 curated targets is > top-K,
+      # and min_hub_relates_to is configured to 3, so 5 outgoing :relates_to links
+      # makes `hub` an operational hub (AC-31.3.4).
+      targets =
+        for n <- 1..5 do
+          target =
+            curated_article(tenant.id, %{
+              title: "Curated Target #{n} #{topic}",
+              body: "# Curated Target #{n}\nThe curated body content for target #{n}."
+            })
+
+          relates_to(tenant.id, hub, target)
+          target
+        end
+
+      assert Knowledge.progressive_top_k() == 3
+
+      assert {:ok, %{stubs: stubs, meta: meta}} = Knowledge.progressive_index(tenant.id, topic)
+
+      assert length(stubs) <= Knowledge.progressive_top_k()
+      assert length(stubs) == 3
+      assert meta.top_k == 3
+      assert meta.truncated == true
+      # Candidate pool (hub + 5 curated targets, deduped) is 6 — bigger than top_k.
+      assert meta.candidate_count == 6
+
+      # Stubs are compact: id/title/category/summary only, never a body.
+      Enum.each(stubs, fn stub ->
+        assert Map.has_key?(stub, :id)
+        assert Map.has_key?(stub, :title)
+        assert Map.has_key?(stub, :category)
+        assert is_binary(stub.summary)
+        refute Map.has_key?(stub, :body)
+      end)
+
+      # Curated targets are preferred over the (non-curated) hub itself (AC-31.3.4).
+      target_ids = MapSet.new(targets, & &1.id)
+      assert Enum.all?(stubs, fn stub -> MapSet.member?(target_ids, stub.id) end)
+
+      # Drill into one returned stub: full body, scope-enforced.
+      chosen = List.first(stubs)
+      assert {:ok, drilled} = Knowledge.progressive_drill(tenant.id, chosen.id)
+      assert drilled.id == chosen.id
+      assert is_binary(drilled.body)
+      assert String.contains?(drilled.body, "curated body content")
+    end
+  end
+
+  # --- TC-31.3.2: index is tenant-isolated ---
+
+  describe "progressive_index/3 - tenant isolation (TC-31.3.2)" do
+    test "no tenant_a stubs appear when fetched as tenant_b" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      topic = "TenantIsolatedTopicABCD"
+
+      hub_a =
+        fixture(:article, %{
+          tenant_id: tenant_a.id,
+          status: :published,
+          title: "#{topic} Hub"
+        })
+
+      target_a = curated_article(tenant_a.id, %{title: "#{topic} Curated Target"})
+      relates_to(tenant_a.id, hub_a, target_a)
+
+      assert {:ok, %{stubs: stubs_b}} = Knowledge.progressive_index(tenant_b.id, topic)
+      assert stubs_b == []
+
+      # Sanity: tenant_a genuinely sees its own stubs for the same topic.
+      assert {:ok, %{stubs: stubs_a}} = Knowledge.progressive_index(tenant_a.id, topic)
+      refute stubs_a == []
+    end
+
+    test "drill does not leak another tenant's article" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+
+      article = fixture(:article, %{tenant_id: tenant_a.id, status: :published})
+
+      assert {:error, :not_found} = Knowledge.progressive_drill(tenant_b.id, article.id)
+      assert {:ok, _} = Knowledge.progressive_drill(tenant_a.id, article.id)
+    end
+  end
+
+  # --- AC-31.3.4: prefers governed curated sources ---
+
+  describe "progressive_index/3 - curated preference (AC-31.3.4)" do
+    test "curated matches are ordered ahead of non-curated matches for the same topic" do
+      tenant = fixture(:tenant)
+      topic = "CuratedPreferenceTopicWXYZ"
+
+      non_curated =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :published,
+          title: "#{topic} Non-Curated"
+        })
+
+      curated = curated_article(tenant.id, %{title: "#{topic} Curated"})
+
+      assert {:ok, %{stubs: stubs}} =
+               Knowledge.progressive_index(tenant.id, topic, hub_enrich: false)
+
+      ids = Enum.map(stubs, & &1.id)
+      assert curated.id in ids
+      assert non_curated.id in ids
+
+      assert Enum.find_index(ids, &(&1 == curated.id)) <
+               Enum.find_index(ids, &(&1 == non_curated.id))
+    end
+
+    test "system-scope curated sources may participate (US-31.1 AC-31.1.3)" do
+      tenant = fixture(:tenant)
+      topic = "SystemScopeTopicQRST"
+
+      {:ok, system_article} =
+        Knowledge.create_article(
+          tenant.id,
+          %{
+            scope: :system,
+            status: :published,
+            category: :reference,
+            title: "#{topic} System Canonical",
+            body: "system body"
+          }
+        )
+
+      {:ok, marked} =
+        Knowledge.mark_curated(nil, system_article.id, actor_label: "superadmin", scope: :system)
+
+      # System-scope articles have a nil tenant_id, so they aren't reachable via the
+      # tenant-scoped search_keyword seed step directly — but they DO participate via
+      # the curated-preference set when a tenant-owned seed hub links to them.
+      hub =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :published,
+          title: "#{topic} Hub"
+        })
+
+      relates_to(tenant.id, hub, marked)
+
+      # min_hub_relates_to is configured to 3 in test.exs — pad two more outgoing
+      # :relates_to links so `hub` clears the operational-hub threshold and
+      # enrichment actually runs.
+      for n <- 1..2 do
+        padding = curated_article(tenant.id, %{title: "Padding Target #{n} #{topic}"})
+        relates_to(tenant.id, hub, padding)
+      end
+
+      assert {:ok, %{stubs: stubs}} = Knowledge.progressive_index(tenant.id, topic)
+      ids = Enum.map(stubs, & &1.id)
+      assert marked.id in ids
+    end
+  end
+
+  # --- AC-31.3.2: the cap is configurable and documented ---
+
+  describe "progressive_top_k/0 and min_hub_relates_to/0 (AC-31.3.2 / AC-31.3.4)" do
+    test "read from application config, overridable in config/test.exs" do
+      assert Knowledge.progressive_top_k() == 3
+      assert Knowledge.min_hub_relates_to() == 3
+    end
+
+    test "a :limit opt overrides the default top-K cap" do
+      tenant = fixture(:tenant)
+      topic = "CustomLimitTopicHJKL"
+
+      for n <- 1..4 do
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          status: :published,
+          title: "#{topic} Match #{n}"
+        })
+      end
+
+      assert {:ok, %{stubs: stubs, meta: meta}} =
+               Knowledge.progressive_index(tenant.id, topic, limit: 2, hub_enrich: false)
+
+      assert length(stubs) == 2
+      assert meta.top_k == 2
+      assert meta.truncated == true
+    end
+  end
+
+  # --- hub_enrich: false disables :relates_to enrichment ---
+
+  describe "progressive_index/3 - hub_enrich opt-out" do
+    test "hub_enrich: false returns only direct topic matches, no traversal" do
+      tenant = fixture(:tenant)
+      topic = "NoEnrichTopicMNOP"
+
+      hub =
+        fixture(:article, %{tenant_id: tenant.id, status: :published, title: "#{topic} Hub"})
+
+      for n <- 1..4 do
+        target = curated_article(tenant.id, %{title: "Unrelated Curated #{n}"})
+        relates_to(tenant.id, hub, target)
+      end
+
+      assert {:ok, %{stubs: stubs}} =
+               Knowledge.progressive_index(tenant.id, topic, hub_enrich: false)
+
+      assert Enum.map(stubs, & &1.id) == [hub.id]
+    end
+  end
+
+  # --- Error propagation mirrors search_keyword/3 ---
+
+  describe "progressive_index/3 - error propagation" do
+    test "returns {:error, :empty_query} for an empty topic" do
+      tenant = fixture(:tenant)
+      assert {:error, :empty_query} = Knowledge.progressive_index(tenant.id, "")
+    end
+
+    test "returns {:error, :bad_request, _} for an over-long topic" do
+      tenant = fixture(:tenant)
+      too_long = String.duplicate("a", 501)
+      assert {:error, :bad_request, _} = Knowledge.progressive_index(tenant.id, too_long)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

US-31.3 (epic 31, OKF-curated + RAG Hybrid Knowledge Interface). Adds a domain-only progressive-disclosure entrypoint composing already-shipped subsystems (no migration, no new index store, no reuse of the OKF full-export Markdown):

- `Knowledge.progressive_index/3` — for a topic/query, returns a compact, capped set of stubs (`id`, `title`, `category`, one-line `summary`), tenant-scoped. Seeds from `search_keyword/3`, prefers governed curated sources (`list_curated_sources/2`, US-31.1), and optionally hub-enriches via a dedicated `:relates_to`-scoped query (an "operational hub" is an article with `>= min_hub_relates_to/0` outgoing `:relates_to` links — never a modeled type), fan-out bounded by the same `max_graph_neighbors_per_node/0` `graph_traversal/3` already uses. The final candidate list is capped at `progressive_top_k/0` before any body is fetched.
- `Knowledge.progressive_drill/3` — a thin, explicitly-named delegate to `get_article/3` fetching the full body of a chosen stub's id, scope-enforced.
- `Loopctl.Knowledge.OKF.derive_description/1` extracted from `defp` to a public, documented helper, reused for the stub summary (no duplicated logic).
- New configurable caps `progressive_top_k` (default 10) and `progressive_min_hub_relates_to` (default 5), mirroring the `max_graph_*` accessor pattern; both overridden small in `config/test.exs` (3/3) so the bound is exercised without production-scale fixtures.

## Test plan

- [x] `test/loopctl/knowledge/progressive_index_test.exs` — TC-31.3.1 (capped stubs + drill), TC-31.3.2 (tenant isolation, index + drill), curated preference (AC-31.3.4), system-scope participation, configurable top-K/hub-threshold, `:limit` override, `hub_enrich: false` opt-out, and `search_keyword`-style error propagation (`:empty_query` / `:bad_request`).
- [x] `mix precommit` green: compile clean, `mix format` clean, `credo --strict` no issues, dialyzer no issues, full suite 4157 tests / 0 failures.
