### PR TITLE
Docs + terminal verification: refund-policy failure avoided, provenance correct, no caller branching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,10 +5,11 @@ This is a web application written using the Phoenix web framework.
 - Use `mix precommit` alias when you are done with all changes and fix any pending issues
 - Use the already included and available `:req` (`Req`) library for HTTP requests, **avoid** `:httpoison`, `:tesla`, and `:httpc`. Req is included by default and is the preferred HTTP client for Phoenix apps
 
-### `retrieve_*` (Context Retriever) vs `knowledge_*` (Wiki) vs `memory_*` (Memory)
+### `retrieve_*` (Context Retriever) vs `knowledge_*` (Wiki, incl. hybrid retrieval) vs `memory_*` (Memory)
 
 loopctl has THREE agent information surfaces — pick by WHAT THE DATA IS (full
-references: `docs/context-retriever.md`, `docs/agent-memory.md`):
+references: `docs/context-retriever.md`, `docs/agent-memory.md`,
+`docs/knowledge-hybrid-retrieval.md`):
 
 - **`retrieve_*` — Context Retriever** (Epic 30; `Loopctl.ContextRetriever`, table
   `entity_definitions`): GOVERNED, structured access to loopctl's own live ROWS
@@ -27,13 +28,25 @@ references: `docs/context-retriever.md`, `docs/agent-memory.md`):
   `memory_remember`, `memory_recall`, `memory_list`, `memory_forget`.
 - **`knowledge_*` — Knowledge Wiki**: SHARED, curated tenant DOCUMENTS, deduped and
   linked. Use when the insight is worth ANOTHER agent reading.
+  - **`knowledge_hybrid_search`** (Epic 31): resolves a query to a governed
+    **curated** answer (ONLY when its absolute confidence clears a scale-matched
+    threshold + margin over retrieval, and it is authoritative — not
+    superseded/conflicted) else falls back to semantic/keyword **retrieval** — one
+    shape carrying `meta.provenance` (`curated`/`retrieved`); never branch on
+    which subsystem answered, branch on `meta.provenance`.
+  - **`knowledge_progressive_index`/`knowledge_progressive_drill`** (Epic 31): a
+    cheap, top-K-capped, curated-preferred topic browse (compact stubs, then a
+    full-body drill) — NOT a substitute for `hybrid_search`'s semantic/governed
+    resolution (a fuzzy topic can miss a lexically-dissimilar curated article).
 
 Rule of thumb: *live structured business row?* → `retrieve_*`; *worth another
 agent reading?* → `knowledge_create`; *a fact only I need to recall about my own
-work?* → `memory_remember`. Scope is key-derived — you never pass
-`tenant_id`/`subject_id`. Do NOT conflate `Loopctl.Memory` (Epic 28) with the
-article-level agent-memory *metadata* (`memory_type`/`visibility`) on the
-Knowledge `articles` table (#163) — different subsystems.
+work?* → `memory_remember`; *might have a governed answer, need to know if it's
+authoritative or "best guess"?* → `knowledge_hybrid_search`. Scope is key-derived
+— you never pass `tenant_id`/`subject_id`. Do NOT conflate `Loopctl.Memory`
+(Epic 28) with the article-level agent-memory *metadata*
+(`memory_type`/`visibility`) on the Knowledge `articles` table (#163) —
+different subsystems.
 
 ### Phoenix v1.8 guidelines
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,60 @@
 
 All notable changes to loopctl are documented here.
 
+## [Unreleased] — 2026-07-11 — OKF-curated + RAG Hybrid Knowledge Retrieval (Epic 31)
+
+### Added
+
+- **Hybrid knowledge retrieval** — `Loopctl.Knowledge.hybrid_search/3`
+  (`POST /api/v1/knowledge/hybrid_search`, MCP tool `knowledge_hybrid_search`)
+  composes the already-shipped retrieval (`search_combined/3`) and curated-source
+  identification (`list_curated_sources/2`, US-31.1) subsystems into a single
+  resolution layer: `:curated` wins ONLY when a governed curated source's
+  ABSOLUTE (never pool-relative, min-max-normalized) confidence score clears a
+  scale-matched threshold AND beats the best retrieved candidate by a margin AND
+  is authoritative (published, not superseded, not in an open
+  `:potential_conflict`); otherwise `:retrieved`. Both branches return an
+  identical `results`/`meta` key shape carrying `meta.provenance`
+  (`:curated`/`:retrieved`), `meta.confidence`, and `meta.curated_article_id` — a
+  caller branches on `meta.provenance` alone, never on which subsystem answered.
+  See [`docs/knowledge-hybrid-retrieval.md`](docs/knowledge-hybrid-retrieval.md).
+  - **Curated-source identification** (US-31.1) — a GOVERNED, non-self-assignable
+    `articles.curated_at`/`curated_by` marker (excluded from `@cast_fields`),
+    written only by `Knowledge.mark_curated/3` / `unmark_curated/3` (audited).
+    Content edits (title/body/publish) invalidate the marker, forcing
+    re-curation. `list_curated_sources/2` applies system-scope precedence (a
+    tenant's own curated answer always wins over a `scope: :system` canonical on
+    the same topic) and excludes superseded/conflicted articles.
+  - **Progressive disclosure** (US-31.3) — `Knowledge.progressive_index/3` /
+    `progressive_drill/3` (`GET /api/v1/knowledge/progressive_index` /
+    `GET /api/v1/knowledge/progressive/:id`, MCP tools
+    `knowledge_progressive_index` / `knowledge_progressive_drill`): a bounded,
+    top-K-capped topic index of compact stubs (curated-preferred, one hop of
+    `:relates_to` hub enrichment), then a full-body drill.
+- **Docs** — new
+  [`docs/knowledge-hybrid-retrieval.md`](docs/knowledge-hybrid-retrieval.md) (the
+  resolution rule, provenance contract, progressive disclosure, and the
+  three-layer model positioning hybrid retrieval within the Knowledge Wiki
+  alongside Agent Memory and the Context Retriever); README/CLAUDE.md/AGENTS.md
+  extended. **#305 and #306 describe the same feature** — recommend closing one
+  as a duplicate rather than tracking separately; the "#305 reconcile
+  `docs/cole-medin-self-evolving-wiki.md`" item is already satisfied by the
+  epics 28–30 reconciliation (KB hub `fb9abd73`/`3ee5f890`).
+
+### Verification
+
+- **Terminal e2e + negative control** (US-31.5,
+  `test/loopctl/knowledge/hybrid_e2e_test.exs`) — a governed curated
+  refund-policy article suppresses an unrelated fuzzy chunk (`:curated`, hoisted
+  first); removing ONLY the curated marker from the SAME corpus flips the result
+  to `:retrieved` and surfaces the previously-suppressed chunk, proving causation;
+  a niche non-curated topic falls to `:retrieved`; a near-but-wrong curated doc is
+  never mislabeled `:curated`; `:curated`/`:retrieved` meta share an identical key
+  shape. Tenant isolation is proven across the resolver, progressive index/drill,
+  and the HTTP API; a system-scoped curated article participates without
+  overriding a tenant's own; a superseded/conflicted curated article is never
+  authoritative without the conflict surfaced.
+
 ## [Unreleased] — 2026-07-10 — Context Retriever (Epic 30)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,11 +47,11 @@ All notable changes to loopctl are documented here.
 - **Terminal e2e + negative control** (US-31.5,
   `test/loopctl/knowledge/hybrid_e2e_test.exs`) — a governed curated
   refund-policy article suppresses an unrelated fuzzy chunk (`:curated`, hoisted
-  first); removing ONLY the curated marker from the SAME corpus flips the result
-  to `:retrieved` and surfaces the previously-suppressed chunk, proving causation;
-  a niche non-curated topic falls to `:retrieved`; a near-but-wrong curated doc is
-  never mislabeled `:curated`; `:curated`/`:retrieved` meta share an identical key
-  shape. Tenant isolation is proven across the resolver, progressive index/drill,
+  first); archiving that curated article (removed from the published search
+  pool, unrelated chunk unchanged) flips the result to `:retrieved` and surfaces
+  the previously-suppressed chunk, proving causation; a niche non-curated topic
+  falls to `:retrieved`; a near-but-wrong curated doc is never mislabeled
+  `:curated`; `:curated`/`:retrieved` meta share an identical key shape. Tenant isolation is proven across the resolver, progressive index/drill,
   and the HTTP API; a system-scoped curated article participates without
   overriding a tenant's own; a superseded/conflicted curated article is never
   authoritative without the conflict surfaced.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,6 +284,32 @@ agent reading?* → `knowledge_create`. *a fact only I need?* → `memory_rememb
 Defining an entity is a security root (role ≥ `user` + human-anchor); querying is
 authenticated-only. You never pass `tenant_id` — scope is key-derived.
 
+## Epic 31: Hybrid (curated + RAG) Knowledge Retrieval
+
+Epic 31 adds a **capability of the Knowledge Wiki layer** — not a fourth agent
+surface — that resolves a query to EITHER a governed **curated** answer OR a
+semantic/keyword **retrieval** result, on one uniform shape carrying
+`meta.provenance` (`:curated`/`:retrieved`). Full reference:
+[`docs/knowledge-hybrid-retrieval.md`](docs/knowledge-hybrid-retrieval.md).
+
+- **`Loopctl.Knowledge.hybrid_search/3`** (`knowledge_hybrid_search` tool /
+  `POST /api/v1/knowledge/hybrid_search`) — `:curated` wins ONLY when a governed
+  curated source's ABSOLUTE (never pool-relative) confidence score clears a
+  scale-matched threshold AND beats the best retrieved candidate by a margin AND
+  is authoritative (not superseded/conflicted). Otherwise `:retrieved` — a
+  near-but-wrong curated doc NEVER wins by default just because a pool is
+  sparse. Both branches share identical `results`/`meta` key sets — callers
+  branch on `meta.provenance` alone, never on which subsystem answered.
+- **Progressive disclosure** (`knowledge_progressive_index` /
+  `knowledge_progressive_drill`, `GET /api/v1/knowledge/progressive_index` /
+  `GET /api/v1/knowledge/progressive/:id`) — a cheap, top-K-capped, curated-
+  preferred topic browse (compact stubs, no bodies) with one hop of `:relates_to`
+  hub enrichment, then a full-body drill into a chosen stub. A fuzzy/paraphrased
+  topic can miss a lexically-dissimilar curated article — use `hybrid_search/3`
+  when you need the governed provenance decision instead.
+- **#305/#306 are the same feature** (this epic implements both) — recommend
+  closing one as a duplicate of the other rather than tracking them separately.
+
 ## Elixir / Phoenix guidelines
 
 These are the stock `phx.new` rules, condensed. Each line is a hard rule.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ loopctl does not make decisions, execute code, or run tests. It stores state, en
 - **CLI** -- escript binary for all operations (`loopctl status`, `loopctl claim`, `loopctl verify`)
 - **Token cost intelligence** -- agents report token usage per story; per-agent efficiency rankings, configurable budgets, and anomaly detection prevent runaway costs across long sprints
 - **Agent memory** -- per-agent private working memory (Epic 28): short-term session turns (TTL-pruned) plus long-term, vector-embedded facts recalled by semantic similarity, isolated per `(tenant, subject_id)` and distinct from the shared Knowledge Wiki. See [`docs/agent-memory.md`](docs/agent-memory.md).
+- **Hybrid (curated + RAG) knowledge retrieval** -- a single Knowledge Wiki entrypoint (Epic 31) that prefers a governed curated answer when one genuinely answers a query, else falls back to semantic/keyword retrieval, returning `provenance` (`curated`/`retrieved`) on one uniform shape so callers never branch on which subsystem answered. See [`docs/knowledge-hybrid-retrieval.md`](docs/knowledge-hybrid-retrieval.md).
 - **OpenAPI 3.0** -- self-documenting API with Swagger UI for agent discovery
 
 ## Concepts
@@ -68,6 +69,7 @@ loopctl does not make decisions, execute code, or run tests. It stores state, en
 | **Memory Promotion** | Unattended compilation of a session's short-term turns into durable long-term `:promoted` memories (via `POST /api/v1/memory/promote`, the `memory_promote` tool, or an hourly sweep). Watermark-idempotent, per-tenant budget-bounded, confidence-gated, hash-deduped/superseded, and prompt-injection-resistant. See [`docs/agent-memory.md`](docs/agent-memory.md). |
 | **Subject** | The owner of a memory scope, derived server-side from the API key: an agent key's `agent_id` (so rotated keys share one memory), else the key's own id. Never client-supplied. |
 | **Context Retriever** | Governed, auto-generated agent query access to loopctl's own STRUCTURED records (`projects`/`stories`/`epics`). An admin declares a tenant-scoped **entity** (typed, server-allowlisted fields); the generator emits per-entity `cr_filter_*`/`cr_search_*` tools; the executor runs the query parameterized, dual-tenant-scoped, allowlist-shaped, audited (fail-closed), and rate-limited — never model-authored SQL. The third of loopctl's three agent layers (Knowledge Wiki / Agent Memory / Context Retriever). See [`docs/context-retriever.md`](docs/context-retriever.md). |
+| **Hybrid Retrieval** | A Knowledge Wiki entrypoint (`knowledge_hybrid_search`) that resolves a query to EITHER a governed curated answer OR a semantic/keyword retrieval result, on one shape carrying `provenance` (`curated`/`retrieved`), `confidence`, and `curated_article_id`. Prevents a curated doc that doesn't actually answer the query from winning by default in a sparse pool (absolute, not pool-relative, scoring). Paired with progressive disclosure (`knowledge_progressive_index`/`knowledge_progressive_drill`) for cheap topic browsing. See [`docs/knowledge-hybrid-retrieval.md`](docs/knowledge-hybrid-retrieval.md). |
 
 ## Tech Stack
 
@@ -856,6 +858,9 @@ Full descriptions live in [`mcp-server/README.md`](mcp-server/README.md); summar
 | `knowledge_unused_articles` | Published articles with zero accesses | orchestrator |
 | `knowledge_curation_log` | Human-readable feed of KB curation adjustments (gate/supersede/merge/dismiss); recorded only while tenant `settings.kb_curation_log` is on | orchestrator |
 | `knowledge_retrieval_metrics` | Daily retrieval-precision time series (search → open follow-through) | orchestrator |
+| `knowledge_hybrid_search` | Resolve a query to a governed **curated** answer when one genuinely answers it, else falls back to semantic/keyword **retrieval** — one shape with `meta.provenance` (`curated`/`retrieved`), `confidence`, `curated_article_id`. See [`docs/knowledge-hybrid-retrieval.md`](docs/knowledge-hybrid-retrieval.md). | agent |
+| `knowledge_progressive_index` | Compact, top-K-capped topic stubs (id/title/category/summary, no bodies), curated-preferred, hub-linked one hop via `:relates_to`. Follow up with `knowledge_progressive_drill`. | agent |
+| `knowledge_progressive_drill` | Fetch the full body of one stub returned by `knowledge_progressive_index`. | agent |
 | `memory_remember` | Write agent MEMORY (private to the caller's `(tenant, subject)` scope) — a `long_term` fact (embedded, semantically recalled) or a `session` turn. NOT the shared Knowledge Wiki — use `knowledge_create` for curated tenant knowledge. | agent |
 | `memory_recall` | Semantically recall the caller's OWN long-term memories by `query` (degrades to a scoped text match, never a silent empty). Private memory, not `knowledge_search`. | agent |
 | `memory_list` | List the caller's OWN long-term memories (paginated); superadmin `all_subjects=true` lists a tenant's every subject. | agent |

--- a/docs/knowledge-hybrid-retrieval.md
+++ b/docs/knowledge-hybrid-retrieval.md
@@ -1,0 +1,287 @@
+# Knowledge Wiki — Hybrid (Curated + RAG) Retrieval (Epic 31)
+
+Authoritative reference for loopctl's **hybrid knowledge retrieval interface**: a
+single entrypoint that prefers a **governed curated** answer when one genuinely
+answers a query, else falls back to semantic/keyword **retrieval** — returning
+**provenance** (`:curated` | `:retrieved`) on one uniform shape so a caller never
+branches on "RAG-or-curated." This sits INSIDE the Knowledge Wiki layer (it does
+not add a fourth agent-information surface) — see
+[the three-layer model](#the-three-layer-model-knowledge-wiki-vs-agent-memory-vs-context-retriever)
+below for how it relates to Agent Memory (Epic 28) and the Context Retriever
+(Epic 30).
+
+> loopctl is **agent-native**: there is no web UI for hybrid search. Every call is
+> an API/MCP call made by an agent under its own key.
+
+---
+
+## Why this exists (the harvested failure)
+
+A confidently-wrong RAG answer is worse than an honest miss: a semantically-near
+chunk that does NOT actually answer the query, returned with no signal that it's
+"just retrieval," gets trusted as if it were authoritative. The canonical example
+(the "refund policy" case this epic's terminal test proves): a tenant has a
+governed, curated refund-policy article, but an unrelated "shipping timelines"
+chunk sits nearby in embedding space. A naive RAG search can surface that
+unrelated chunk with high confidence. `hybrid_search/3` prevents this two ways:
+
+1. It checks for a genuinely-answering **curated** source FIRST, using an
+   **absolute** (never pool-relative) confidence score, so a curated doc doesn't
+   win just because it's the only thing in a sparse pool.
+2. When curated does NOT clear the bar, it falls through to ordinary retrieval and
+   is HONEST about it — `meta.provenance == :retrieved` tells the caller this is
+   RAG, not a governed answer.
+
+Both branches return through the same function, same map shape, same field names
+— a caller reads `meta.provenance` and nothing else changes.
+
+---
+
+## The resolution rule
+
+`Loopctl.Knowledge.hybrid_search(tenant_id, query_string, opts \\ [])` composes
+the ALREADY-SHIPPED `search_combined/3` (retrieval: semantic + keyword, US-shipped
+pre-epic-31) and `list_curated_sources/2` (curated identification, US-31.1) into
+one resolution layer. It does not re-architect either.
+
+`:curated` wins iff **ALL** of:
+
+1. The curated candidate's **absolute** confidence score clears an absolute
+   threshold for its own scale:
+   - Semantic (cosine similarity, `1 - cosine_distance`, already `0..1`):
+     `:knowledge_hybrid_curated_threshold`, default **0.75**.
+   - Keyword-only (a bounded `raw / (raw + 1)` transform of `ts_rank_cd`, which is
+     otherwise unbounded — a short, title-exact match empirically exceeds 2.0):
+     `:knowledge_hybrid_curated_threshold_keyword`, default **0.5**.
+2. It beats the best NON-curated candidate's absolute score by a margin:
+   `:knowledge_hybrid_curated_margin` / `_keyword`, both default **0.1**.
+3. It is **authoritative** — published, not superseded, not part of an open
+   `:potential_conflict` link (enforced by `list_curated_sources/2`, US-31.1;
+   `Knowledge.authoritative_curated?/1` is the pure per-article check).
+
+Otherwise the response is `:retrieved`, even if a curated doc is technically in
+the pool — a near-but-wrong curated doc that is semantically close but below
+threshold, or that loses the margin check against a stronger retrieval result,
+NEVER wins `:curated`.
+
+### Why absolute, not pool-relative, scoring
+
+`search_combined/3`'s own `:final_score` is **min-max normalized** across the
+current pool — a lone or top candidate in a sparse pool always normalizes to
+`1.0` regardless of its TRUE similarity. Using that score for the curated
+decision would let a curated doc that barely relates to the query win at
+"confidence 1.0" simply because nothing else was in the pool. `hybrid_search/3`
+instead scores every candidate via `absolute_score/1`, reading the RAW
+`:similarity_score` (semantic) or a bounded transform of the raw
+`:relevance_score` (keyword) — a value computed independently of pool
+composition. Cosine similarity and normalized `ts_rank_cd` are **different,
+incommensurable scales**; the threshold/margin PAIR used is selected to match the
+winning curated candidate's own scale (never compared cross-scale).
+
+### Resolved over the full ranked pool, not the caller's page
+
+The decision is made over the FULL ranked candidate pool (same cap
+`search_combined/3`'s own sub-searches already use), independent of the caller's
+`:limit`/`:offset`. A curated source ranked outside the requested page is still
+found and scored. When `:curated` wins, the winning article is hoisted to the
+FRONT of the pool BEFORE pagination, so `meta.provenance == :curated` always
+means `results |> List.first()` (at `offset: 0`) IS that curated answer — never a
+decoy that merely out-ranked it on the pool-relative `:final_score`.
+
+### The pure decision function
+
+`Knowledge.resolve_provenance(curated_score, best_retrieved_score, threshold,
+margin)` is the single, unit-testable rule behind the above:
+
+```elixir
+def resolve_provenance(nil, _best_retrieved_score, _threshold, _margin), do: :retrieved
+
+def resolve_provenance(curated_score, best_retrieved_score, threshold, margin) do
+  if curated_score >= threshold and curated_score - best_retrieved_score >= margin do
+    :curated
+  else
+    :retrieved
+  end
+end
+```
+
+`threshold`/`margin` must already be scale-matched by the caller
+(`hybrid_curated_threshold_and_margin/1` does this internally) — the pure
+function does no scale reasoning of its own.
+
+---
+
+## The uniform shape / no-caller-branching contract
+
+```elixir
+{:ok, %{results: [map()], meta: map()}} = Knowledge.hybrid_search(tenant_id, query, opts)
+```
+
+`meta` is `search_combined/3`'s own meta (search_mode, fallback, keyword_only,
+limit, offset) merged with exactly:
+
+| Field | Meaning |
+|-------|---------|
+| `provenance` | `:curated` \| `:retrieved` |
+| `confidence` | The WINNING candidate's absolute score for its OWN provenance class. `0.0` when there are no results, or `:retrieved` won with no genuine non-curated competitor. **Never** a rejected candidate's score from the OTHER class (`:retrieved`'s confidence is never a below-threshold curated score). |
+| `curated_article_id` | The winning curated article's id when `provenance == :curated` (guaranteed present AND first in `results`); `nil` on `:retrieved`. |
+
+**Both branches return the identical map-key set** — on `results` (per-item keys
+are identical by construction; `:curated` reorders the same ranked pool rather
+than re-filtering it) and on `meta`. A caller reads `meta.provenance` and
+`meta.curated_article_id`; it never needs to know which subsystem (curated lookup
+vs `search_combined/3`) actually produced the answer. This is the literal fix for
+#305's "no caller-side RAG-or-curated branching."
+
+### Degradation honesty
+
+`hybrid_search/3` does not re-implement embedding degradation — it reuses
+`search_combined/3`'s. When embeddings are unavailable, the pool falls back to
+keyword-only (`meta.fallback: true`, `meta.search_mode: "keyword_only"`), and the
+curated candidate's absolute keyword-scale score is compared against the
+KEYWORD threshold/margin: a curated source still confidently identifiable by
+keyword can win `:curated` under degradation; a merely-incidental keyword hit
+falls to `:retrieved`, same as a weak semantic match would. Never a silent empty,
+never a false `:curated` under degraded matching.
+
+### Tenant isolation
+
+`tenant_id` is threaded into BOTH `search_combined/3` (retrieval) and
+`list_curated_sources/2` (curated identification) — both run on `AdminRepo`/
+`HeavyRead` (BYPASSRLS). **RLS does not backstop these reads.** The explicit
+`tenant_id` predicate in each function is the sole isolation boundary — assert it
+by test, never assume it.
+
+### System-scoped curated sources
+
+A `scope: :system` curated article (tenant_id `nil`, curated via
+`mark_curated(nil, article_id, scope: :system, ...)`) participates in EVERY
+tenant's curated pool as a fallback — but a tenant's OWN curated answer on the
+same topic always wins over the system canonical (system never overrides a
+tenant's own). If the tenant's own curated answer on that topic is itself in an
+open conflict, it is excluded (per the authoritative check) — and the system
+canonical on that SAME topic is still suppressed too (a disputed topic never
+silently falls back to the generic system answer; the conflict must be resolved
+first). See `test/loopctl/knowledge_curated_test.exs` "system-scope precedence"
+for the full matrix.
+
+### Conflicted / superseded curated articles
+
+`list_curated_sources/2` excludes a curated article that is `:superseded` or
+part of an OPEN `:potential_conflict` link from the authoritative pool entirely
+— such an article can never win `:curated` through `hybrid_search/3`, and the
+conflict is never silently resolved in the caller's favor; it must be resolved
+through the normal conflict-resolution path (`knowledge_resolve_conflict`)
+before the article can be authoritative again.
+
+---
+
+## Progressive disclosure (US-31.3)
+
+Two-step retrieval to bound the tokens returned per query:
+
+1. **Index** — `Knowledge.progressive_index(tenant_id, topic, opts)` /
+   `GET /api/v1/knowledge/progressive_index?topic=...` — returns `<=` a
+   configurable top-K (`Knowledge.progressive_top_k/0`) of COMPACT stubs
+   (`id`/`title`/`category`/`summary` — never a `body`). The seed is
+   `search_keyword/3` over `topic`, enriched by one hop of `:relates_to`
+   article-link traversal from any "hub" article (an article whose outgoing
+   `:relates_to` degree clears `Knowledge.min_hub_relates_to/0`), capped per-hub at
+   `Knowledge.max_graph_neighbors_per_node/0`. Curated matches are ordered ahead
+   of non-curated matches for the same topic (AC-31.3.4).
+2. **Drill** — `Knowledge.progressive_drill(tenant_id, article_id)` /
+   `GET /api/v1/knowledge/progressive/:id` — fetches the FULL body of one stub the
+   caller chose from the index. Tenant-scoped (a foreign tenant's article id is a
+   clean `{:error, :not_found}` / 404, including for a system-scope article's
+   draft/archived guard).
+
+**Known lexical-omission caveat** (documented honestly, not swept under the rug):
+the index's seed step is a `tsquery` match against `topic` — a fuzzy or
+paraphrased query can miss a topically-relevant curated article that shares no
+lexical tokens with the seed text, even though `hybrid_search/3`'s semantic pool
+would have found it. Progressive disclosure is a keyword-first navigation aid
+over the corpus, not a substitute for `hybrid_search/3`'s semantic resolution —
+use `hybrid_search/3` when you need the governed provenance decision, and
+progressive disclosure when you want to browse/enumerate a topic cheaply.
+
+Do NOT use the OKF full-tenant export (`index.md`) for this purpose — it is a
+private, full-corpus artifact, not the progressive-disclosure seed.
+
+---
+
+## Surfaces
+
+| Operation | Context (`Loopctl.Knowledge`) | HTTP API | MCP tool |
+|-----------|-------------------------------|----------|----------|
+| Hybrid search | `hybrid_search/3` | `POST /api/v1/knowledge/hybrid_search` | `knowledge_hybrid_search` |
+| Progressive index | `progressive_index/3` | `GET /api/v1/knowledge/progressive_index` | `knowledge_progressive_index` |
+| Progressive drill | `progressive_drill/3` | `GET /api/v1/knowledge/progressive/:id` | `knowledge_progressive_drill` |
+
+All three endpoints render at `GET /swaggerui` (loopctl's self-documenting
+OpenAPI 3.0 surface) alongside every other API route.
+
+`hybrid_search/3`'s `opts` forward directly to `search_combined/3`:
+`:keyword_weight`, `:semantic_weight`, `:project_id`, `:category`, `:status`,
+`:tags`, `:limit`, `:offset`, `:api_key_id` (attribution). Errors
+(`{:error, :invalid_weights}`, `{:error, :empty_query}`,
+`{:error, atom(), String.t()}`) propagate unchanged from `search_combined/3`.
+
+---
+
+## The three-layer model: Knowledge Wiki vs Agent Memory vs Context Retriever
+
+Hybrid retrieval is a **capability of the Knowledge Wiki layer** — it does not
+add a fourth surface. The three layers (full references:
+[`docs/agent-memory.md`](agent-memory.md),
+[`docs/context-retriever.md`](context-retriever.md)):
+
+| Layer | What it holds | Scope / owner | Lifecycle | Reach it via |
+|-------|---------------|---------------|-----------|--------------|
+| **Knowledge Wiki** (incl. hybrid retrieval) | Curated, *shared* tenant knowledge — patterns, decisions, findings, references (documents). Hybrid search prefers a governed **curated** answer, else falls back to semantic/keyword **retrieval**, on one uniform shape with `provenance`. | Tenant (with per-article agent visibility) | Human/agent-curated, versioned, linked, conflict-resolved | `knowledge_*` tools / `/api/v1/knowledge*` |
+| **Agent Memory** | An agent subject's *private* working memory — session turns + long-term facts about *its* work | `(tenant, subject_id)` — one agent | Append/embed/supersede/forget; session tier expires | `memory_*` tools / `/api/v1/memory*` |
+| **Context Retriever** | *Governed, structured* access to *live business data* (rows, not documents) | Tenant, schema-scoped | Read-through over the operational store; entity definitions are admin-authored | `retrieve_*` tools / `/api/v1/entities*` + `/api/v1/retrieve/*` |
+
+Rule of thumb, extended for hybrid search: *asking a question that MIGHT have a
+governed answer, and you want to know whether the answer is authoritative or "our
+best guess"?* → `knowledge_hybrid_search` (reads `meta.provenance`). *Just
+browsing/enumerating a topic cheaply?* → `knowledge_progressive_index` +
+`knowledge_progressive_drill`. *A fact only you need to recall about your own
+work?* → `memory_remember`. *A live structured row (a story, a project)?* →
+`retrieve_*`.
+
+---
+
+## #305 / #306 — same feature, and the "reconcile cole-medin doc" item
+
+GitHub issues **#305 and #306 describe the SAME feature** (the OKF-curated + RAG
+hybrid knowledge interface this epic implements). **Recommendation: close one as
+a duplicate of the other** — do not auto-close either; a human/orchestrator with
+issue-write access should pick which stays open and link the other as
+`Closes #<n>` on this epic's merge.
+
+The "#305 reconcile `docs/cole-medin-self-evolving-wiki.md`"-style follow-up item
+is the SAME reconciliation epics 28/29/30 already completed: the retired note was
+removed in PR #310 and its durable content lives in the KB hub (`fb9abd73`/
+`3ee5f890`) and in `docs/agent-memory.md` / `docs/context-retriever.md` (and now
+here). No parallel/duplicate doc exists for hybrid retrieval — this file is its
+single home.
+
+---
+
+## Verification (US-31.5, terminal)
+
+- **End-to-end + negative control** (`test/loopctl/knowledge/hybrid_e2e_test.exs`):
+  a governed curated refund-policy article suppresses an unrelated fuzzy chunk
+  (`:curated`, the curated article first in `results`); removing ONLY the
+  curated marker from the SAME corpus (same unrelated chunk, unchanged) flips the
+  result to `:retrieved` and surfaces the previously-suppressed chunk — proving
+  the curated article, not corpus composition, was what suppressed it. A niche,
+  non-curated topic falls to `:retrieved`. A near-but-wrong curated doc (below
+  threshold) is never mislabeled `:curated`.
+- **Shape parity**: the `:curated` and `:retrieved` meta key sets are identical;
+  a caller branches on `meta.provenance` alone.
+- **Tenant isolation across every surface** (context, progressive index/drill,
+  HTTP API): no tenant A content is reachable via a tenant B key on any surface.
+  A system-scoped curated article participates without overriding a tenant's own
+  curated answer. A superseded / open-conflict curated article is never returned
+  as authoritative without the conflict being surfaced.

--- a/docs/knowledge-hybrid-retrieval.md
+++ b/docs/knowledge-hybrid-retrieval.md
@@ -272,12 +272,13 @@ single home.
 
 - **End-to-end + negative control** (`test/loopctl/knowledge/hybrid_e2e_test.exs`):
   a governed curated refund-policy article suppresses an unrelated fuzzy chunk
-  (`:curated`, the curated article first in `results`); removing ONLY the
-  curated marker from the SAME corpus (same unrelated chunk, unchanged) flips the
-  result to `:retrieved` and surfaces the previously-suppressed chunk — proving
-  the curated article, not corpus composition, was what suppressed it. A niche,
-  non-curated topic falls to `:retrieved`. A near-but-wrong curated doc (below
-  threshold) is never mislabeled `:curated`.
+  (`:curated`, the curated article first in `results`); archiving that curated
+  article — removing it from the published search pool while leaving the
+  unrelated chunk unchanged — flips the result to `:retrieved` and surfaces the
+  previously-suppressed chunk — proving the governed answer's presence, not an
+  unrelated corpus change, was what suppressed it. A niche, non-curated topic
+  falls to `:retrieved`. A near-but-wrong curated doc (below threshold) is never
+  mislabeled `:curated`.
 - **Shape parity**: the `:curated` and `:retrieved` meta key sets are identical;
   a caller branches on `meta.provenance` alone.
 - **Tenant isolation across every surface** (context, progressive index/drill,

--- a/test/loopctl/knowledge/hybrid_e2e_test.exs
+++ b/test/loopctl/knowledge/hybrid_e2e_test.exs
@@ -42,13 +42,13 @@ defmodule Loopctl.Knowledge.HybridE2ETest do
   alias Loopctl.Knowledge
   alias Loopctl.Knowledge.Article
 
-  # Two orthogonal "directions" + a midpoint, mirroring the pattern in
-  # knowledge_hybrid_test.exs / knowledge_semantic_search_test.exs: cosine
-  # similarity of identical directions is 1.0, orthogonal directions is 0.0, and
-  # the midpoint sits at ~0.7033 to either — deterministic enough to sit safely
-  # below the 0.75 default threshold without floating-point flakiness.
+  # A "direction" + a midpoint, mirroring the pattern in knowledge_hybrid_test.exs
+  # / knowledge_semantic_search_test.exs: cosine similarity of identical
+  # directions is 1.0, and the midpoint sits at ~0.7033 to it — deterministic
+  # enough to sit safely below the 0.75 default threshold without
+  # floating-point flakiness, while still representing a genuinely near
+  # (not orthogonal) chunk.
   @direction_a List.duplicate(1.0, 768) ++ List.duplicate(0.0, 768)
-  @direction_b List.duplicate(0.0, 768) ++ List.duplicate(1.0, 768)
   @direction_medium List.duplicate(0.5, 768) ++ List.duplicate(0.5, 768)
 
   defp auth_conn(conn, raw_key) do
@@ -104,9 +104,16 @@ defmodule Loopctl.Knowledge.HybridE2ETest do
         })
         |> then(&set_embedding(tenant.id, &1, @direction_a))
 
-      # A fuzzy, non-curated chunk on a DIFFERENT axis — never touched by the
-      # negative control below, so any change in outcome is attributable ONLY to
-      # the curated article's presence/absence.
+      # A fuzzy, non-curated chunk that sits NEAR the query in embedding space
+      # (@direction_medium, ~0.7033 cosine to the query — the same near-miss
+      # vector used by the below-threshold test further down) rather than
+      # orthogonal to it. This is what docs/knowledge-hybrid-retrieval.md:20-26
+      # actually describes as the harvested failure: a chunk close enough that
+      # naive RAG search surfaces it with substantial confidence, not a
+      # zero-similarity chunk that would honestly show up as low-confidence on
+      # its own. It is never touched by the negative control below, so any
+      # change in outcome is attributable ONLY to the curated article's
+      # presence/absence.
       unrelated =
         fixture(:article, %{
           tenant_id: tenant.id,
@@ -114,7 +121,7 @@ defmodule Loopctl.Knowledge.HybridE2ETest do
           body: "How long orders take to ship across different carriers.",
           status: :published
         })
-        |> then(&set_embedding(tenant.id, &1, @direction_b))
+        |> then(&set_embedding(tenant.id, &1, @direction_medium))
 
       query = "refund policy"
       stub_embeddings_by_query(%{query => @direction_a})
@@ -133,9 +140,11 @@ defmodule Loopctl.Knowledge.HybridE2ETest do
       # (d) NEGATIVE CONTROL — the SAME corpus, with ONLY the curated article now
       # ABSENT (archived: excluded from the published search pool, same as if the
       # governed answer had never been written). This is the literal harvested
-      # failure this epic exists to prevent: with no governed answer, the merely
-      # nearby (orthogonal-embedding) chunk becomes the best available answer —
-      # honestly labeled :retrieved, never silently trusted as :curated.
+      # failure this epic exists to prevent: with no governed answer, the
+      # semantically-near (~0.7033 cosine, below the 0.75 curated threshold but
+      # far from zero) chunk becomes the best available answer, surfaced at
+      # substantial confidence — honestly labeled :retrieved, never silently
+      # trusted as :curated.
       assert {:ok, _archived} = Knowledge.archive_article(tenant.id, curated.id)
 
       assert {:ok, %{results: without_curated, meta: meta_without_curated}} =

--- a/test/loopctl/knowledge/hybrid_e2e_test.exs
+++ b/test/loopctl/knowledge/hybrid_e2e_test.exs
@@ -1,0 +1,466 @@
+defmodule Loopctl.Knowledge.HybridE2ETest do
+  @moduledoc """
+  US-31.5: terminal end-to-end verification for Epic 31 (the OKF-curated + RAG
+  hybrid knowledge retrieval interface, GitHub issues #305/#306 — the SAME
+  feature). Writes NO new production feature code; proves the epic's acceptance
+  across every surface in one place.
+
+  - **TC-31.5.1** (end-to-end + negative control): a governed curated
+    refund-policy article suppresses an unrelated fuzzy chunk (`:curated`,
+    hoisted first, flagged); removing ONLY the curated article from the SAME
+    corpus (the unrelated chunk untouched) flips the result to `:retrieved` and
+    surfaces the previously-suppressed chunk — proving the curated article, not
+    some other corpus property, is what suppressed it. A niche non-curated
+    topic falls to `:retrieved`. A near-but-wrong curated doc below threshold is
+    never mislabeled `:curated`.
+  - **TC-31.5.1(c)** shape parity: `:curated`/`:retrieved` meta share an
+    identical key set — a caller branches on `meta.provenance` alone, never on
+    which subsystem answered.
+  - **AC-31.5.3 / TC-31.5.2**: tenant isolation across every surface (resolver,
+    progressive index/drill, HTTP API — MCP scope-blindness for these same tools
+    is proven in `mcp-server/test/knowledge_tools.test.js`, US-31.4, which
+    asserts no `tenant_id` parameter is ever accepted and every call dispatches
+    to the tenant-scoped HTTP endpoint under the caller's own key). A
+    system-scoped curated article participates in the resolver's curated
+    identification without overriding a tenant's own. A conflicted curated
+    article is never returned as authoritative without the conflict being
+    surfaced.
+
+  This does NOT duplicate `test/loopctl/knowledge_hybrid_test.exs` (US-31.2
+  resolver unit/integration coverage), `test/loopctl/knowledge_curated_test.exs`
+  (US-31.1 governance/precedence unit coverage), or
+  `test/loopctl/knowledge/progressive_index_test.exs` (US-31.3 index/drill unit
+  coverage) — those remain the detailed per-unit proofs; this file is the
+  epic-wide E2E proof, with the negative control those files do not carry.
+
+  Setup helpers are copied verbatim from `test/loopctl/knowledge_hybrid_test.exs`.
+  """
+  use LoopctlWeb.ConnCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.Knowledge
+  alias Loopctl.Knowledge.Article
+
+  # Two orthogonal "directions" + a midpoint, mirroring the pattern in
+  # knowledge_hybrid_test.exs / knowledge_semantic_search_test.exs: cosine
+  # similarity of identical directions is 1.0, orthogonal directions is 0.0, and
+  # the midpoint sits at ~0.7033 to either — deterministic enough to sit safely
+  # below the 0.75 default threshold without floating-point flakiness.
+  @direction_a List.duplicate(1.0, 768) ++ List.duplicate(0.0, 768)
+  @direction_b List.duplicate(0.0, 768) ++ List.duplicate(1.0, 768)
+  @direction_medium List.duplicate(0.5, 768) ++ List.duplicate(0.5, 768)
+
+  defp auth_conn(conn, raw_key) do
+    put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  # Creates a published tenant article and marks it curated via the governed path.
+  defp curated_article(tenant_id, attrs) do
+    article =
+      fixture(:article, Map.merge(%{tenant_id: tenant_id, status: :published}, attrs))
+
+    {:ok, marked} = Knowledge.mark_curated(tenant_id, article.id, actor_label: "user:admin")
+    marked
+  end
+
+  defp set_embedding(tenant_id, article, vector) do
+    {:ok, updated} = Knowledge.update_embedding(tenant_id, article.id, vector)
+    updated
+  end
+
+  # Stubs the embedding client to return a specific vector per exact query text,
+  # falling back to the DataCase default (uniform 0.1 vector) for any other text.
+  defp stub_embeddings_by_query(mapping) do
+    Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, text ->
+      case Map.fetch(mapping, text) do
+        {:ok, vector} -> {:ok, vector}
+        :error -> {:ok, List.duplicate(0.1, 1536)}
+      end
+    end)
+  end
+
+  defp relates_to(tenant_id, source, target) do
+    fixture(:article_link, %{
+      tenant_id: tenant_id,
+      source_article_id: source.id,
+      target_article_id: target.id,
+      relationship_type: :relates_to
+    })
+  end
+
+  # --- TC-31.5.1: end-to-end with negative control ---
+
+  describe "hybrid_search/3 - refund-policy negative control (TC-31.5.1)" do
+    test "curated wins when present; removing it from the SAME corpus surfaces the suppressed chunk" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      curated =
+        tenant.id
+        |> curated_article(%{
+          title: "Refund Policy Guide",
+          body: "Our refund policy allows returns within 30 days for a full refund."
+        })
+        |> then(&set_embedding(tenant.id, &1, @direction_a))
+
+      # A fuzzy, non-curated chunk on a DIFFERENT axis — never touched by the
+      # negative control below, so any change in outcome is attributable ONLY to
+      # the curated article's presence/absence.
+      unrelated =
+        fixture(:article, %{
+          tenant_id: tenant.id,
+          title: "Shipping Timelines",
+          body: "How long orders take to ship across different carriers.",
+          status: :published
+        })
+        |> then(&set_embedding(tenant.id, &1, @direction_b))
+
+      query = "refund policy"
+      stub_embeddings_by_query(%{query => @direction_a})
+
+      # (a) WITH the curated article present: it wins :curated, is hoisted to
+      # the front, and the unrelated chunk is NOT what the caller is handed as
+      # the answer.
+      assert {:ok, %{results: with_curated, meta: meta_with_curated}} =
+               Knowledge.hybrid_search(tenant.id, query, keyword_weight: 0, semantic_weight: 1)
+
+      assert meta_with_curated.provenance == :curated
+      assert meta_with_curated.curated_article_id == curated.id
+      assert List.first(with_curated).id == curated.id
+      refute meta_with_curated.curated_article_id == unrelated.id
+
+      # (d) NEGATIVE CONTROL — the SAME corpus, with ONLY the curated article now
+      # ABSENT (archived: excluded from the published search pool, same as if the
+      # governed answer had never been written). This is the literal harvested
+      # failure this epic exists to prevent: with no governed answer, the merely
+      # nearby (orthogonal-embedding) chunk becomes the best available answer —
+      # honestly labeled :retrieved, never silently trusted as :curated.
+      assert {:ok, _archived} = Knowledge.archive_article(tenant.id, curated.id)
+
+      assert {:ok, %{results: without_curated, meta: meta_without_curated}} =
+               Knowledge.hybrid_search(tenant.id, query, keyword_weight: 0, semantic_weight: 1)
+
+      assert meta_without_curated.provenance == :retrieved
+      assert meta_without_curated.curated_article_id == nil
+      assert List.first(without_curated).id == unrelated.id
+    end
+
+    test "a long-tail/niche query with no curated coverage at all falls to :retrieved" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Niche Topic Deep Dive",
+        body: "A very niche topic with no curated coverage whatsoever.",
+        status: :published
+      })
+
+      assert {:ok, %{results: results, meta: meta}} =
+               Knowledge.hybrid_search(tenant.id, "niche topic")
+
+      assert results != []
+      assert meta.provenance == :retrieved
+      assert meta.curated_article_id == nil
+    end
+
+    test "a near-but-wrong curated doc below threshold is never mislabeled :curated" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      near_but_wrong =
+        tenant.id
+        |> curated_article(%{title: "Shipping Refund Process"})
+        |> then(&set_embedding(tenant.id, &1, @direction_medium))
+
+      query = "what is the refund policy?"
+      stub_embeddings_by_query(%{query => @direction_a})
+
+      assert {:ok, %{results: results, meta: meta}} =
+               Knowledge.hybrid_search(tenant.id, query, keyword_weight: 0, semantic_weight: 1)
+
+      # Still findable (retrieval is honest that it exists)...
+      assert Enum.any?(results, &(&1.id == near_but_wrong.id))
+      # ...but never trusted as the authoritative curated answer -- its absolute
+      # cosine similarity to the query (~0.7033) sits below the 0.75 threshold.
+      assert meta.provenance == :retrieved
+      refute meta.curated_article_id == near_but_wrong.id
+    end
+  end
+
+  # --- TC-31.5.1(c): shape parity / no caller-side branching ---
+
+  describe "hybrid_search/3 - shape parity (TC-31.5.1c)" do
+    test "curated and retrieved meta share an identical key set" do
+      curated_tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(curated_tenant.id)
+
+      curated = curated_article(curated_tenant.id, %{title: "Deploy Guide Curated"})
+      set_embedding(curated_tenant.id, curated, @direction_a)
+      stub_embeddings_by_query(%{"deploy guide" => @direction_a})
+
+      assert {:ok, %{meta: curated_meta}} =
+               Knowledge.hybrid_search(curated_tenant.id, "deploy guide",
+                 keyword_weight: 0,
+                 semantic_weight: 1
+               )
+
+      assert curated_meta.provenance == :curated
+
+      retrieved_tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(retrieved_tenant.id)
+
+      fixture(:article, %{
+        tenant_id: retrieved_tenant.id,
+        title: "Niche Article",
+        body: "A niche topic nobody has curated an answer for.",
+        status: :published
+      })
+
+      assert {:ok, %{meta: retrieved_meta}} =
+               Knowledge.hybrid_search(retrieved_tenant.id, "niche topic")
+
+      assert retrieved_meta.provenance == :retrieved
+      assert Enum.sort(Map.keys(curated_meta)) == Enum.sort(Map.keys(retrieved_meta))
+
+      for key <- [:provenance, :confidence, :search_mode, :curated_article_id] do
+        assert Map.has_key?(curated_meta, key)
+        assert Map.has_key?(retrieved_meta, key)
+      end
+    end
+  end
+
+  # --- AC-31.5.3 / TC-31.5.2: tenant isolation across every surface ---
+
+  describe "hybrid_search/3 - tenant isolation (context surface, TC-31.5.2)" do
+    test "tenant B never sees tenant A's curated content, even against a populated pool" do
+      tenant_a = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant_a.id)
+
+      secret =
+        tenant_a.id
+        |> curated_article(%{
+          title: "Tenant A Refund Policy",
+          body: "Tenant A's confidential refund policy details."
+        })
+        |> then(&set_embedding(tenant_a.id, &1, @direction_a))
+
+      # tenant_b is seeded with its OWN decoy on the SAME axis, so this proves
+      # tenant A's curated article does not intermingle into a populated tenant
+      # B result set (stronger than an empty pool, which would pass even if
+      # tenant-scoping logic were broken).
+      tenant_b = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant_b.id)
+
+      decoy =
+        tenant_b.id
+        |> curated_article(%{
+          title: "Tenant B Refund Policy",
+          body: "Tenant B's own refund policy on the same axis as tenant A's."
+        })
+        |> then(&set_embedding(tenant_b.id, &1, @direction_a))
+
+      query = "refund policy"
+      stub_embeddings_by_query(%{query => @direction_a})
+
+      assert {:ok, %{results: results_b, meta: meta_b}} =
+               Knowledge.hybrid_search(tenant_b.id, query, keyword_weight: 0, semantic_weight: 1)
+
+      refute Enum.any?(results_b, &(&1.id == secret.id))
+      assert meta_b.curated_article_id != secret.id
+      assert meta_b.provenance == :curated
+      assert meta_b.curated_article_id == decoy.id
+    end
+  end
+
+  describe "progressive_index/drill - tenant isolation (progressive surface, TC-31.5.2)" do
+    test "a tenant B index for tenant A's topic returns none of tenant A's stubs" do
+      tenant_a = fixture(:tenant)
+      topic = "HybridE2ETenantIsolatedTopicABCD"
+
+      hub =
+        fixture(:article, %{
+          tenant_id: tenant_a.id,
+          status: :published,
+          title: "#{topic} Hub"
+        })
+
+      target_a = curated_article(tenant_a.id, %{title: "#{topic} Curated Target"})
+      relates_to(tenant_a.id, hub, target_a)
+
+      tenant_b = fixture(:tenant)
+
+      assert {:ok, %{stubs: stubs_b}} = Knowledge.progressive_index(tenant_b.id, topic)
+      assert stubs_b == []
+
+      # Sanity: tenant_a genuinely sees its own stubs for the same topic.
+      assert {:ok, %{stubs: stubs_a}} = Knowledge.progressive_index(tenant_a.id, topic)
+      refute stubs_a == []
+    end
+
+    test "a tenant B drill on tenant A's article id is a clean not_found (no leak)" do
+      tenant_a = fixture(:tenant)
+      secret = curated_article(tenant_a.id, %{title: "Tenant A Progressive Secret"})
+
+      tenant_b = fixture(:tenant)
+
+      assert {:error, :not_found} = Knowledge.progressive_drill(tenant_b.id, secret.id)
+      assert {:ok, _} = Knowledge.progressive_drill(tenant_a.id, secret.id)
+    end
+  end
+
+  describe "POST hybrid_search - tenant isolation (HTTP API surface, TC-31.5.2)" do
+    test "tenant B key never sees tenant A's curated content over the HTTP API", %{conn: conn} do
+      tenant_a = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant_a.id)
+
+      secret =
+        tenant_a.id
+        |> curated_article(%{
+          title: "Tenant A HTTP Refund Policy",
+          body: "Tenant A's confidential refund policy details over HTTP."
+        })
+        |> then(&set_embedding(tenant_a.id, &1, @direction_a))
+
+      tenant_b = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant_b.id)
+      {raw_key_b, _} = fixture(:api_key, %{tenant_id: tenant_b.id, role: :agent})
+
+      decoy =
+        tenant_b.id
+        |> curated_article(%{
+          title: "Tenant B HTTP Refund Policy",
+          body: "Tenant B's own refund policy over HTTP."
+        })
+        |> then(&set_embedding(tenant_b.id, &1, @direction_a))
+
+      query = "refund policy"
+      stub_embeddings_by_query(%{query => @direction_a})
+
+      conn =
+        conn
+        |> auth_conn(raw_key_b)
+        |> post(~p"/api/v1/knowledge/hybrid_search", %{query: query})
+
+      body = json_response(conn, 200)
+
+      refute Enum.any?(body["data"], &(&1["id"] == secret.id))
+      assert body["meta"]["curated_article_id"] != secret.id
+      assert Enum.any?(body["data"], &(&1["id"] == decoy.id))
+      assert body["meta"]["provenance"] == "curated"
+      assert body["meta"]["curated_article_id"] == decoy.id
+    end
+  end
+
+  # --- AC-31.5.3: system-scope precedence feeds the resolver's curated identification ---
+
+  describe "hybrid_search/3 - system-scope precedence (AC-31.5.3)" do
+    test "the resolver's :ids-restricted list_curated_sources/2 suppresses a same-topic system canonical" do
+      tenant = fixture(:tenant)
+
+      {:ok, system_article} =
+        Knowledge.create_article(tenant.id, %{
+          scope: :system,
+          status: :published,
+          category: :reference,
+          title: "Shared Topic Answer",
+          body: "system body"
+        })
+
+      {:ok, system} =
+        Knowledge.mark_curated(nil, system_article.id, actor_label: "superadmin", scope: :system)
+
+      tenant_own =
+        curated_article(tenant.id, %{title: "Shared Topic Answer", body: "tenant body"})
+
+      # This is the EXACT call hybrid_search/3's internal curated_source_ids/2
+      # makes (select: :id, ids: the caller's own search pool) — proving the
+      # dependency the resolver relies on for system-scope precedence.
+      assert Knowledge.list_curated_sources(tenant.id,
+               select: :id,
+               ids: [tenant_own.id, system.id]
+             ) == [tenant_own.id]
+
+      # A system canonical on a DIFFERENT topic the tenant has not curated still
+      # participates when it is in the pool (it does not vanish outright).
+      {:ok, system_only_article} =
+        Knowledge.create_article(tenant.id, %{
+          scope: :system,
+          status: :published,
+          category: :reference,
+          title: "System-Only Topic",
+          body: "system only body"
+        })
+
+      {:ok, system_only} =
+        Knowledge.mark_curated(nil, system_only_article.id,
+          actor_label: "superadmin",
+          scope: :system
+        )
+
+      assert Knowledge.list_curated_sources(tenant.id, select: :id, ids: [system_only.id]) == [
+               system_only.id
+             ]
+    end
+  end
+
+  # --- AC-31.5.3: a conflicted curated article is never returned as authoritative ---
+
+  describe "hybrid_search/3 - a conflicted curated article is never authoritative (AC-31.5.3)" do
+    test "an open-conflict curated article, even with a high embedding match, falls to :retrieved" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      conflicted =
+        tenant.id
+        |> curated_article(%{title: "Conflicted Curated Answer"})
+        |> then(&set_embedding(tenant.id, &1, @direction_a))
+
+      rival =
+        fixture(:article, %{tenant_id: tenant.id, status: :published, title: "Rival Answer"})
+
+      fixture(:article_link, %{
+        tenant_id: tenant.id,
+        source_article_id: conflicted.id,
+        target_article_id: rival.id,
+        relationship_type: :potential_conflict,
+        metadata: %{"auto_generated" => true, "similarity_score" => 0.95}
+      })
+
+      query = "conflicted curated answer topic"
+      stub_embeddings_by_query(%{query => @direction_a})
+
+      assert {:ok, %{results: results, meta: meta}} =
+               Knowledge.hybrid_search(tenant.id, query, keyword_weight: 0, semantic_weight: 1)
+
+      # Still genuinely findable via retrieval (a real, high-similarity match)...
+      assert Enum.any?(results, &(&1.id == conflicted.id))
+      # ...but NEVER labeled the authoritative curated answer while the conflict
+      # is open. The conflict must be resolved through
+      # `knowledge_resolve_conflict` first -- it is not silently papered over.
+      assert meta.provenance == :retrieved
+      assert meta.curated_article_id == nil
+    end
+
+    test "a superseded curated article is structurally excluded from the search pool and never authoritative" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      marked =
+        curated_article(tenant.id, %{title: "Superseded Curated Answer", body: "old answer"})
+
+      _superseded =
+        marked
+        |> Article.curation_changeset(marked.curated_at, marked.curated_by)
+        |> Ecto.Changeset.change(status: :superseded)
+        |> Loopctl.AdminRepo.update!()
+
+      assert {:ok, %{meta: meta}} =
+               Knowledge.hybrid_search(tenant.id, "superseded curated answer")
+
+      assert meta.provenance == :retrieved
+      assert meta.curated_article_id == nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

US-31.5 — the terminal, docs-and-tests-only story for Epic 31 (OKF-curated +
RAG hybrid knowledge retrieval interface, GitHub issues #305/#306 — the SAME
feature). US-31.1 through US-31.4 (resolver, curated marker, progressive index,
API + MCP) are already merged; this story adds no new production feature code.

- `docs/knowledge-hybrid-retrieval.md` (new): the curated-vs-retrieved
  resolution rule (absolute, scale-matched threshold + margin, authoritative
  check), the provenance/confidence/curated_article_id contract, progressive
  disclosure (index -> drill, top-K cap, the lexical-omission caveat), the
  three-layer model positioning hybrid retrieval within the Knowledge Wiki
  alongside Agent Memory (Epic 28) and the Context Retriever (Epic 30), the
  `/api/v1/knowledge/hybrid_search` + progressive endpoints (rendered at
  `/swaggerui`), and a note that #305/#306 describe the same feature
  (recommend closing one as a duplicate — not auto-closed here).
- README.md / CLAUDE.md / AGENTS.md updated with the hybrid retrieval surface
  and its `retrieve_*`/`knowledge_*`/`memory_*` decision guide entry.
- CHANGELOG.md: new `[Unreleased]` Epic 31 entry at the top, modeled on the
  Epic 30 block.
- `test/loopctl/knowledge/hybrid_e2e_test.exs` (new, terminal E2E test):
  - **TC-31.5.1 + negative control**: a governed curated refund-policy article
    wins `:curated` (hoisted first) over an unrelated fuzzy chunk; archiving
    ONLY the curated article from the SAME corpus (the unrelated chunk
    untouched) flips the result to `:retrieved` and surfaces the
    previously-suppressed chunk — proving the curated article, not some other
    corpus property, is what suppressed it. A niche non-curated query falls to
    `:retrieved`. A near-but-wrong curated doc below threshold is never
    mislabeled `:curated`.
  - **Shape parity**: `:curated`/`:retrieved` meta share an identical key set.
  - **AC-31.5.3 / TC-31.5.2**: tenant isolation proven across the resolver,
    progressive index/drill, and the HTTP API (MCP scope-blindness for these
    same tools is already proven in `mcp-server/test/knowledge_tools.test.js`,
    US-31.4). System-scope precedence never overrides a tenant's own curated
    answer. A curated article in an open `:potential_conflict` (or superseded)
    is never returned as authoritative.

**Recommendation** (not acted on, per story scope): close GitHub issue #306 as
a duplicate of #305 (or vice versa) — both describe this exact feature.

## Test plan

- [x] `mix precommit` green (compile --warnings-as-errors, format, credo
      --strict, deps.audit, dialyzer, full test suite): 4188 tests, 0
      failures.
- [x] New terminal test file passes in isolation and alongside the full
      `test/loopctl/knowledge/` suite + the existing US-31.1-31.4 test files
      (507 tests, 0 failures for that combined run).
