### PR TITLE
docs(epic_32): Scalability Quick Wins stories (US-32.1..32.5)

### DIFF
--- a/docs/user_stories/epic_32_scale_quick_wins/README.md
+++ b/docs/user_stories/epic_32_scale_quick_wins/README.md
@@ -1,0 +1,34 @@
+# Epic 32 — Scalability Quick Wins
+
+The low-effort, high-impact first batch of the [Scalability Remediation Roadmap](../../../) — GitHub issue **#354**, tracked under **#355**. Each is a config / index / small-code change that de-risks the "one heavy agent" incident and/or is a prerequisite for a later epic.
+
+## Scope reconciliation (verified against live code before authoring)
+
+Issue #354 listed 8 quick wins; grounding against the current `master` found 3 already handled:
+
+| #354 item | Status | Evidence |
+|-----------|--------|----------|
+| 1. Oban Lifeline | ✅ done (#323) | `config/config.exs` `{Oban.Plugins.Lifeline, rescue_after: :timer.minutes(30)}` |
+| 2. Oban Pruner | ✅ done (#323) | `config/config.exs` `{Oban.Plugins.Pruner, max_age: 7d}` |
+| 8. DNS_CLUSTER_QUERY | ⚙️ code wired; Fly secret only | `application.ex` + `runtime.exs` read it — folded into Epic 6 (scale-out gate) |
+
+The remaining 5 are the stories below.
+
+## Stories
+
+| Story | Title | #354 item | Depends |
+|-------|-------|-----------|---------|
+| US-32.1 | Partial index `dispatches(expires_at) WHERE revoked_at IS NULL` | 3 | — |
+| US-32.2 | Oban queue widths → `runtime.exs` env vars | 4 | — |
+| US-32.3 | ETS-cache tenant LLM settings (bust on `set_llm_config`) | 5 | — |
+| US-32.4 | Fail loud when scale alerts enabled but URL unset | 6 | — |
+| US-32.5 | STH fanout `Oban.insert_all` + jitter | 7 | — |
+
+All five are independent (distinct files), so WIP=1 order is not constrained.
+
+## Non-negotiable constraint
+
+loopctl is **live**, with agents actively doing KB retrieval. No story may cause an outage:
+- Every merge auto-deploys; the post-deploy **smoke suite gates each deploy** and KB retrieval health is checked before/after.
+- The one migration (US-32.1) is **online** (`CONCURRENTLY`, `@disable_ddl_transaction`).
+- Config changes (US-32.2/32.4) default to current behavior when env is unset.

--- a/docs/user_stories/epic_32_scale_quick_wins/us_32.1.json
+++ b/docs/user_stories/epic_32_scale_quick_wins/us_32.1.json
@@ -1,0 +1,43 @@
+{
+  "id": "US-32.1",
+  "title": "Partial index on dispatches(expires_at) WHERE revoked_at IS NULL for the revoke sweep",
+  "epic": { "id": "epic_32", "name": "Scalability Quick Wins" },
+  "priority": "high",
+  "phase": "scalability",
+  "priority_note": "S-effort, high-impact: turns a per-minute seq scan on a growing table into an index range scan. Down-payment on Epic 3 (#350).",
+  "background": {
+    "reference": "GH #354 quick win 3; #350 Epic 3. Worker: lib/loopctl/workers/revoke_expired_dispatches_worker.ex; schema: lib/loopctl/dispatches/dispatch.ex; existing indexes in priv/repo/migrations/20260411234856_create_dispatches.exs.",
+    "includes": "RevokeExpiredDispatchesWorker runs every 60s with a tenant-AGNOSTIC query `from(d in Dispatch, where: is_nil(d.revoked_at) and d.expires_at < ^now)`. The only expiry index is composite `[:tenant_id, :expires_at]`, whose leading column (tenant_id) is absent from the predicate, so Postgres cannot use it — the sweep seq-scans the whole dispatches table each minute as it grows."
+  },
+  "story": {
+    "as_a": "loopctl operator",
+    "i_want_to": "add a partial index on dispatches(expires_at) filtered to non-revoked rows",
+    "so_that": "the every-minute expired-dispatch revoke sweep uses an index range scan instead of a full sequential scan on a continuously growing table"
+  },
+  "rationale": "The revoke sweep is unavoidably tenant-agnostic (it must find expired dispatches across all tenants), so it can never use the tenant-leading composite index. As the dispatches table grows with every agent dispatch, the per-minute seq scan becomes a steadily worsening fixed cost on the shared primary. A partial index matching the exact predicate makes the sweep O(expired rows), not O(table).",
+  "acceptance_criteria": [
+    { "id": "AC-32.1.1", "description": "A new migration adds `create index(:dispatches, [:expires_at], where: \"revoked_at IS NULL\")`. Because dispatches is a hot, actively-written table, the index is built online: `@disable_ddl_transaction true`, `@disable_migration_lock true`, and `create index(..., concurrently: true)`, preceded by `drop index(..., if_exists: true, concurrently: true)` so a prior failed/invalid index is rebuilt rather than skipped-by-name.", "status": "pending" },
+    { "id": "AC-32.1.2", "description": "After migration, `EXPLAIN` of the worker's query (`WHERE revoked_at IS NULL AND expires_at < now()`) shows an Index Scan / Index-Only Scan using the new partial index, not a Seq Scan.", "status": "pending" },
+    { "id": "AC-32.1.3", "description": "RevokeExpiredDispatchesWorker behavior is UNCHANGED — the story adds only an index; the query, revoke semantics, and audit/cascade to api_keys are untouched.", "status": "pending" },
+    { "id": "AC-32.1.4", "description": "The migration follows loopctl RLS conventions: dispatches already has RLS enabled; adding an index does not alter RLS. No BYPASSRLS/ownership change.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-32.1.1", "name": "revoke sweep still revokes expired non-revoked dispatches", "type": "integration",
+      "preconditions": ["tenant = fixture(:tenant)", "expired = fixture(:dispatch, tenant: tenant, expires_at: past, revoked_at: nil)", "active = fixture(:dispatch, tenant: tenant, expires_at: future, revoked_at: nil)"],
+      "steps": ["perform RevokeExpiredDispatchesWorker (all-tenants sweep)"],
+      "expected_results": ["expired.revoked_at is set", "active.revoked_at stays nil", "linked api_keys of expired are revoked (behavior parity)"], "status": "pending" },
+    { "id": "TC-32.1.2", "name": "already-revoked dispatches are not touched again (partial-index exclusion holds)", "type": "integration",
+      "preconditions": ["tenant = fixture(:tenant)", "old = fixture(:dispatch, tenant: tenant, expires_at: past, revoked_at: earlier_timestamp)"],
+      "steps": ["capture old.revoked_at", "perform the sweep"],
+      "expected_results": ["old.revoked_at unchanged (row excluded by revoked_at IS NULL)"], "status": "pending" }
+  ],
+  "technical_notes": [
+    "Migration only — no app-code change. Place in priv/repo/migrations with a timestamp after existing dispatch migrations.",
+    "Online index pattern (loopctl convention for hot tables): @disable_ddl_transaction true + @disable_migration_lock true + concurrently: true; DROP INDEX CONCURRENTLY IF EXISTS before CREATE to self-heal a prior INVALID index.",
+    "Verify with EXPLAIN (ANALYZE off in test) against the worker predicate; a data-shape test asserting behavior parity is the ExUnit guard since index usage is a planner concern.",
+    "Do NOT drop or alter the existing [:tenant_id, :expires_at] index — other per-tenant lookups may use it.",
+    "Tests use Loopctl.Fixtures.fixture/2; include a tenant-isolation-safe setup (sweep is cross-tenant by design — assert it only revokes expired rows, regardless of tenant)."
+  ],
+  "dependencies": [],
+  "estimated_tokens": 130000
+}

--- a/docs/user_stories/epic_32_scale_quick_wins/us_32.2.json
+++ b/docs/user_stories/epic_32_scale_quick_wins/us_32.2.json
@@ -1,0 +1,48 @@
+{
+  "id": "US-32.2",
+  "title": "Move Oban queue concurrencies into runtime.exs env vars",
+  "epic": { "id": "epic_32", "name": "Scalability Quick Wins" },
+  "priority": "high",
+  "phase": "scalability",
+  "priority_note": "S-effort; prerequisite for Epic 4 (#351) per-tenant fairness (operators must be able to retune queue widths without a deploy).",
+  "background": {
+    "reference": "GH #354 quick win 4; #351 Epic 4. Oban config: config/config.exs (config :loopctl, Oban, queues: [...]); runtime resolution: config/runtime.exs; test override: config/test.exs (Oban testing: :inline).",
+    "includes": "Queue concurrencies are hardcoded at compile time in config/config.exs: default:10, webhooks:5, cleanup:2, analytics:3, maintenance:2, embeddings:5, knowledge:5, memory:3, audit:3. Relieving a backlog (or throttling a noisy queue) today requires a code change + full deploy."
+  },
+  "story": {
+    "as_a": "loopctl operator",
+    "i_want_to": "drive each Oban queue's concurrency from an environment variable, defaulting to the current value",
+    "so_that": "I can retune queue widths against the real DB pool budget during an incident without a code change and deploy"
+  },
+  "rationale": "During a saturation incident the fastest safe lever is reducing a hot queue's concurrency (or raising a starved one). Hardcoded compile-time widths force a full deploy for that, which is exactly the wrong latency during an incident. Env-driven widths make it a `fly secrets set` + restart, and are the necessary substrate for Epic 4's per-tenant fairness work.",
+  "acceptance_criteria": [
+    { "id": "AC-32.2.1", "description": "In config/runtime.exs, the Oban `queues` list is set from env vars — one per queue, e.g. `OBAN_QUEUE_DEFAULT`, `OBAN_QUEUE_EMBEDDINGS`, `OBAN_QUEUE_KNOWLEDGE`, etc. — each parsed as a positive integer, defaulting to the CURRENT hardcoded value when unset. A small helper (e.g. `queue_size(env, default)`) parses/validates (String.to_integer with a positive-int guard; invalid → raise at boot with a clear message, never silently 0).", "status": "pending" },
+    { "id": "AC-32.2.2", "description": "The runtime.exs Oban config merges with (overrides) the compile-time config/config.exs queues so the full plugin/cron config is preserved and only queue widths become env-driven. No queue is dropped and no plugin config is lost.", "status": "pending" },
+    { "id": "AC-32.2.3", "description": "With no env vars set, effective queue widths are byte-for-byte the current defaults (default:10, webhooks:5, cleanup:2, analytics:3, maintenance:2, embeddings:5, knowledge:5, memory:3, audit:3).", "status": "pending" },
+    { "id": "AC-32.2.4", "description": "config/test.exs continues to force `testing: :inline` (jobs run synchronously) — the env-var wiring must not disturb the inline test mode or require env vars in CI.", "status": "pending" },
+    { "id": "AC-32.2.5", "description": "The sum of default queue widths still fits the documented DB pool budget; a comment in runtime.exs cross-references POOL_SIZE / DbCapacity so operators don't set widths that exceed connections.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-32.2.1", "name": "defaults preserved when env unset", "type": "unit",
+      "preconditions": ["no OBAN_QUEUE_* env vars set"],
+      "steps": ["read the resolved Oban queues config"],
+      "expected_results": ["each queue equals its documented default width"], "status": "pending" },
+    { "id": "TC-32.2.2", "name": "env override applies", "type": "unit",
+      "preconditions": ["a test-visible resolver function queue_size/2 (pure, testable without mutating global env)"],
+      "steps": ["call queue_size(\"20\", 5)", "call queue_size(nil, 5)"],
+      "expected_results": ["returns 20", "returns 5"], "status": "pending" },
+    { "id": "TC-32.2.3", "name": "invalid value fails loud", "type": "unit",
+      "preconditions": [],
+      "steps": ["call queue_size(\"0\", 5) / queue_size(\"-3\", 5) / queue_size(\"abc\", 5)"],
+      "expected_results": ["raises ArgumentError with a clear message (never returns 0 or the default silently)"], "status": "pending" }
+  ],
+  "technical_notes": [
+    "runtime.exs runs at boot in prod; keep the parsing helper pure and unit-testable (extract to a tiny module fn rather than inline anonymous logic so TC-32.2.2/3 can call it).",
+    "Ecto/Oban: setting `config :loopctl, Oban, queues: [...]` in runtime.exs replaces the queues key; re-list ALL queues from env-or-default so none is dropped.",
+    "Do NOT move plugins/cron into runtime.exs in this story — scope is queue widths only (Lifeline/Pruner already landed in config.exs).",
+    "No DB/migration. No tenant data touched — but note in the PR that queue widths are global (per-node), not per-tenant; per-tenant fairness is Epic 4.",
+    "Guard against total width > pool: document the relationship; do not enforce a hard cap here (operators own the tradeoff)."
+  ],
+  "dependencies": [],
+  "estimated_tokens": 160000
+}

--- a/docs/user_stories/epic_32_scale_quick_wins/us_32.3.json
+++ b/docs/user_stories/epic_32_scale_quick_wins/us_32.3.json
@@ -1,0 +1,49 @@
+{
+  "id": "US-32.3",
+  "title": "ETS-cache resolved tenant LLM settings, busted on set_llm_config",
+  "epic": { "id": "epic_32", "name": "Scalability Quick Wins" },
+  "priority": "high",
+  "phase": "scalability",
+  "priority_note": "S/M-effort; removes a DB read + Cloak decrypt from every provider call. Down-payment on Epic 5 (#352).",
+  "background": {
+    "reference": "GH #354 quick win 5; #352 Epic 5. Settings: lib/loopctl/llm/tenant_llm_settings.ex, lib/loopctl/llm.ex, set via set_llm_config. Sibling ETS-owner pattern to mirror: lib/loopctl/knowledge/embedding_circuit_breaker.ex and Loopctl.Knowledge.ExportConcurrency (public named_table owned by a supervised GenServer in the app tree).",
+    "includes": "Every embedding/completion provider call re-reads the tenant's LLM settings from the DB and Cloak-decrypts the API key. Under a fast-looping agent this is a per-call DB hit + decrypt on the hot path."
+  },
+  "story": {
+    "as_a": "loopctl platform",
+    "i_want_to": "cache each tenant's resolved, decrypted LLM settings in a supervised ETS table and invalidate the entry when the tenant's config changes",
+    "so_that": "provider calls stop paying a DB read plus a Cloak decrypt on every request while never serving stale credentials"
+  },
+  "rationale": "LLM settings change rarely but are read on every provider call, so an ETS read-through cache converts a per-call DB+decrypt into a per-change one. Correctness hinges on invalidation: set_llm_config must bust the entry so a rotated key or changed provider is honored immediately. loopctl already owns two ETS tables via supervised owners, so this follows an established, crash-safe pattern rather than inventing one.",
+  "acceptance_criteria": [
+    { "id": "AC-32.3.1", "description": "A supervised ETS owner (GenServer in the app supervision tree, mirroring EmbeddingCircuitBreaker/ExportConcurrency) owns a `:public`, `:named_table`, read-concurrency ETS table keyed by tenant_id holding the resolved+decrypted settings struct. The table survives caller processes (owned by the stable GenServer, not the request process).", "status": "pending" },
+    { "id": "AC-32.3.2", "description": "Settings resolution is read-through: on cache miss, load from DB, decrypt via Cloak, store in ETS, return; on hit, return the cached struct with no DB/decrypt. The public API (e.g. Loopctl.LLM.get_settings(tenant_id) or equivalent) keeps its existing signature and return shape.", "status": "pending" },
+    { "id": "AC-32.3.3", "description": "set_llm_config (and any other settings mutation path) invalidates the tenant's cache entry (delete or overwrite) within the same call, so the next read reflects the change — verified by a rotate-then-read test.", "status": "pending" },
+    { "id": "AC-32.3.4", "description": "Tenant isolation: a cache entry for tenant A is never returned for tenant B; keys are tenant_id-scoped and there is a test proving A's rotation does not affect B's cached entry and vice-versa.", "status": "pending" },
+    { "id": "AC-32.3.5", "description": "Decrypted secrets live only in ETS memory (never logged, never in telemetry tags); the cache is not persisted. A cold start / GenServer restart yields an empty table that repopulates read-through.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-32.3.1", "name": "cache hit avoids second DB read", "type": "integration",
+      "preconditions": ["tenant = fixture(:tenant)", "fixture(:tenant_llm_settings, tenant: tenant, ...)"],
+      "steps": ["call get_settings(tenant.id) twice"],
+      "expected_results": ["both return the same decrypted struct", "second call served from ETS (assert via a DB-call counter/telemetry or by mutating the row directly in the DB and confirming the cached value is still returned until invalidation)"], "status": "pending" },
+    { "id": "TC-32.3.2", "name": "set_llm_config busts the cache", "type": "integration",
+      "preconditions": ["tenant = fixture(:tenant)", "settings cached via a prior get_settings"],
+      "steps": ["call set_llm_config(tenant.id, new_api_key/provider)", "call get_settings(tenant.id)"],
+      "expected_results": ["returns the NEW settings (not the stale cached ones)"], "status": "pending" },
+    { "id": "TC-32.3.3", "name": "tenant isolation of cache entries", "type": "integration",
+      "preconditions": ["tenant_a = fixture(:tenant); tenant_b = fixture(:tenant)", "both have distinct llm settings, both cached"],
+      "steps": ["set_llm_config(tenant_a) to rotate A", "get_settings(tenant_b)"],
+      "expected_results": ["tenant_b still returns its own unchanged settings", "tenant_a returns rotated settings"], "status": "pending" }
+  ],
+  "technical_notes": [
+    "Mirror lib/loopctl/knowledge/embedding_circuit_breaker.ex: a supervised GenServer creates the :public :named_table in init/1 so the table outlives request processes; readers hit ETS directly.",
+    "Config-based DI conventions: no Application.put_env in tests; async:true; verify_on_exit!.",
+    "Cloak decrypt happens once per (tenant, config-version); store the decrypted struct, not the ciphertext.",
+    "Invalidation must be in the SAME transaction/call as the settings write path (set_llm_config) — a delete after commit; consider a fallback TTL only if a mutation path could bypass the API (document if so).",
+    "Never log the decrypted key; keep it out of telemetry tags and error messages.",
+    "Add the GenServer to lib/loopctl/application.ex children after the Repo(s) and alongside the sibling ETS owners."
+  ],
+  "dependencies": [],
+  "estimated_tokens": 320000
+}

--- a/docs/user_stories/epic_32_scale_quick_wins/us_32.4.json
+++ b/docs/user_stories/epic_32_scale_quick_wins/us_32.4.json
@@ -1,0 +1,48 @@
+{
+  "id": "US-32.4",
+  "title": "Fail loud when scale alerts are enabled but SCALE_ALERT_WEBHOOK_URL is unset",
+  "epic": { "id": "epic_32", "name": "Scalability Quick Wins" },
+  "priority": "high",
+  "phase": "scalability",
+  "priority_note": "S-effort; prerequisite for trusting Epic 2 (#349) observability — a silently-dead alert path is worse than none.",
+  "background": {
+    "reference": "GH #354 quick win 6; #349 Epic 2. config/runtime.exs: :scale_alerts_enabled (true in prod) + :scale_alert_webhook_url (System.get_env('SCALE_ALERT_WEBHOOK_URL'), nil when unset). Alert sender lives in the scale-alerts module (lib/loopctl/scale*/).",
+    "includes": "Today scale_alerts_enabled is true in prod but the webhook URL is only read from env; when unset, breaches are logged and nothing is POSTed — the alerting path is silently inert with no signal that it's dead. An operator believes alerts are on when they are not."
+  },
+  "story": {
+    "as_a": "loopctl operator",
+    "i_want_to": "have the app refuse to come up healthy when scale alerts are enabled but no webhook URL is configured",
+    "so_that": "a misconfigured alert pipeline is caught at deploy time instead of discovered during the incident it was supposed to warn me about"
+  },
+  "rationale": "An alerting system that fails silently gives false confidence — the worst failure mode, because you only learn it's broken when a real breach goes unannounced. Making the misconfiguration loud at startup (or via readiness) converts a latent silent gap into an immediate, visible deploy-time failure, which is the whole point of the observability epic that follows.",
+  "acceptance_criteria": [
+    { "id": "AC-32.4.1", "description": "When `:scale_alerts_enabled` is true and `:scale_alert_webhook_url` is nil/blank, the app fails loud: either raise at boot in runtime.exs with a clear message naming SCALE_ALERT_WEBHOOK_URL, OR flip a readiness flag so /health (or the readiness endpoint) reports NOT-ready/degraded with that reason. Choose the readiness-flag approach if a hard boot-raise would risk an outage on the live system; document the choice.", "status": "pending" },
+    { "id": "AC-32.4.2", "description": "When alerts are enabled AND the URL is set, startup/readiness is unaffected (no false positive).", "status": "pending" },
+    { "id": "AC-32.4.3", "description": "When `:scale_alerts_enabled` is false, the URL is not required and no failure/degradation is signaled (opt-out stays clean).", "status": "pending" },
+    { "id": "AC-32.4.4", "description": "The check does not change alert DELIVERY behavior for the healthy case; it only adds the missing-config guard. Existing scale-alert tests still pass.", "status": "pending" },
+    { "id": "AC-32.4.5", "description": "No secret is logged; the message names the env var, not any value.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-32.4.1", "name": "enabled + missing url is caught", "type": "unit",
+      "preconditions": ["config: scale_alerts_enabled true, scale_alert_webhook_url nil"],
+      "steps": ["run the validation function (extracted, pure/testable)"],
+      "expected_results": ["returns {:error, reason} / raises with a message naming SCALE_ALERT_WEBHOOK_URL (per chosen mechanism)"], "status": "pending" },
+    { "id": "TC-32.4.2", "name": "enabled + url present is ok", "type": "unit",
+      "preconditions": ["scale_alerts_enabled true, scale_alert_webhook_url set"],
+      "steps": ["run the validation function"],
+      "expected_results": [":ok / readiness true"], "status": "pending" },
+    { "id": "TC-32.4.3", "name": "disabled needs no url", "type": "unit",
+      "preconditions": ["scale_alerts_enabled false, scale_alert_webhook_url nil"],
+      "steps": ["run the validation function"],
+      "expected_results": [":ok / readiness true"], "status": "pending" }
+  ],
+  "technical_notes": [
+    "Extract the enabled+url check into a pure function so it is unit-testable without booting the app or mutating global env (no Application.put_env in tests — pass config in).",
+    "Prefer the readiness-flag path over a hard boot-raise for a LIVE system: a boot-raise on a bad deploy could take the fleet down; a readiness=degraded signal fails the deploy's smoke/health gate without killing running nodes. Document the decision in the PR.",
+    "If using readiness: wire it into the existing /health degraded path (same place Oban/DB degradation is surfaced).",
+    "blank check: treat empty string as unset (String.trim == '').",
+    "Scope: config-guard only — do NOT build the new alert signals here (that is Epic 2)."
+  ],
+  "dependencies": [],
+  "estimated_tokens": 150000
+}

--- a/docs/user_stories/epic_32_scale_quick_wins/us_32.5.json
+++ b/docs/user_stories/epic_32_scale_quick_wins/us_32.5.json
@@ -1,0 +1,47 @@
+{
+  "id": "US-32.5",
+  "title": "STH all-tenants fanout uses Oban.insert_all with scheduled jitter",
+  "epic": { "id": "epic_32", "name": "Scalability Quick Wins" },
+  "priority": "high",
+  "phase": "scalability",
+  "priority_note": "S-effort; cuts N per-minute round-trips to one and de-spikes the fanout. Down-payment on Epic 3 (#350).",
+  "background": {
+    "reference": "GH #354 quick win 7; #350 Epic 3. Worker: lib/loopctl/workers/compute_sth_worker.ex; cron: config/config.exs `{\"* * * * *\", Loopctl.Workers.ComputeSthWorker, args: %{\"mode\" => \"all_tenants\"}}`.",
+    "includes": "The all_tenants mode does `for tenant_id <- tenants do %{\"tenant_id\" => tenant_id} |> __MODULE__.new() |> Oban.insert() end` — N separate single-row inserts every minute, all scheduled at the same :00 instant (a zero-jitter thundering herd against the :audit queue and the primary)."
+  },
+  "story": {
+    "as_a": "loopctl platform",
+    "i_want_to": "enqueue the per-tenant STH jobs in a single batched insert spread across the minute with jitter",
+    "so_that": "the per-minute fanout is one DB round-trip instead of N and the per-tenant STH jobs don't all fire simultaneously and spike the audit queue and primary"
+  },
+  "rationale": "The fanout currently pays a DB insert per active tenant every minute and releases them all at the same instant, which both wastes round-trips and creates a synchronized load spike that worsens with tenant count. Batching to a single insert_all and staggering execution with schedule_in jitter flattens the spike and cuts the cost to O(1) inserts — a safe, self-contained down-payment on the larger STH redesign (Epic 3) without changing the per-tenant STH computation itself.",
+  "acceptance_criteria": [
+    { "id": "AC-32.5.1", "description": "The all_tenants branch builds one list of `ComputeSthWorker.new(%{\"tenant_id\" => id}, schedule_in: jitter)` changesets and enqueues them via a single `Oban.insert_all/1` (or `Oban.insert_all/2`), replacing the per-tenant `Oban.insert/1` loop.", "status": "pending" },
+    { "id": "AC-32.5.2", "description": "Each per-tenant job gets a bounded, deterministic-per-run jitter `schedule_in` in [0, 55] seconds (stay within the 1-minute cadence) derived per index/tenant so the jobs spread across the minute rather than all at :00. No use of :rand at module level that would break Oban unique/dedup.", "status": "pending" },
+    { "id": "AC-32.5.3", "description": "Behavior parity: still enqueues exactly one job per ACTIVE tenant (status == :active), and the per-tenant branch (sth_needed? / sign_and_store_tree_head) is UNCHANGED. If Oban unique options are present, insert_all respects them (no duplicate storms).", "status": "pending" },
+    { "id": "AC-32.5.4", "description": "Empty tenant list is handled (insert_all of [] is a no-op, returns :ok, no crash).", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-32.5.1", "name": "one job enqueued per active tenant via batch", "type": "integration",
+      "preconditions": ["3 active tenants + 1 inactive tenant (fixtures)", "Oban testing mode captures enqueued jobs"],
+      "steps": ["perform ComputeSthWorker with args mode=all_tenants"],
+      "expected_results": ["exactly 3 ComputeSthWorker jobs enqueued (one per active tenant)", "inactive tenant gets none", "each job has a schedule_in within [0,55]s"], "status": "pending" },
+    { "id": "TC-32.5.2", "name": "no active tenants is a no-op", "type": "integration",
+      "preconditions": ["no active tenants"],
+      "steps": ["perform the all-tenants fanout"],
+      "expected_results": [":ok, zero jobs enqueued, no error"], "status": "pending" },
+    { "id": "TC-32.5.3", "name": "per-tenant STH computation unchanged", "type": "integration",
+      "preconditions": ["tenant = fixture(:tenant) with audit chain growth"],
+      "steps": ["perform ComputeSthWorker with args tenant_id"],
+      "expected_results": ["signs + stores STH exactly as before (parity with pre-change behavior)"], "status": "pending" }
+  ],
+  "technical_notes": [
+    "Oban.insert_all takes a list of Oban.Job changesets (Worker.new/2); build them with schedule_in: seconds.",
+    "Jitter without Math.random at compile time: derive from rem(:erlang.phash2(tenant_id), 56) or the enumeration index — stable within a run, spreads across the minute, and won't interfere with Oban :unique keys.",
+    "Preserve any existing unique/replace options on ComputeSthWorker.new; if the worker is @unique, insert_all still honors it.",
+    "This is a fanout-only change; do NOT touch AuditChain.sth_needed?/sign_and_store_tree_head (incremental Merkle is Epic 3).",
+    "Oban testing: config/test.exs uses testing: :inline — assert enqueued jobs with Oban.Testing helpers (all_enqueued/assert_enqueued) rather than relying on execution timing."
+  ],
+  "dependencies": [],
+  "estimated_tokens": 180000
+}


### PR DESCRIPTION
Authors the 5 remaining quick-win stories (issue #354, tracked #355) after reconciling scope against master (Lifeline/Pruner already landed via #323; DNS_CLUSTER_QUERY code-wired → Epic 6). Docs-only; each story implemented next through the standard implement→review→CI-merge loop. No story may break live KB retrieval.