### PR TITLE
Move Oban queue concurrencies into runtime.exs env vars

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -32,6 +32,17 @@ config :loopctl, LoopctlWeb.Endpoint,
     websocket_options: [max_fragmented_message_size: 64_000]
   ]
 
+# Oban queue widths are env-driven (US-32.2) so an operator can retune a hot/starved
+# queue during an incident via `fly secrets set OBAN_QUEUE_<NAME>` + restart, no deploy.
+# Each defaults to its config.exs value when unset. NB: total worker concurrency (sum of
+# widths, default 33) shares the Repo pool (POOL_SIZE, default 10 — see the Repo config
+# below and `Loopctl.DbCapacity`). Widths far above the connection budget will queue on
+# checkout; operators own this tradeoff — no hard cap is enforced here. This runs in
+# EVERY env (not just prod) so defaults hold under `testing: :inline` (config/test.exs)
+# with zero env vars required; `queues:` REPLACES (not merges) the compile-time list, so
+# `Loopctl.ObanConfig.queues/0` always re-lists all queues to avoid silently dropping one.
+config :loopctl, Oban, queues: Loopctl.ObanConfig.queues()
+
 # Cloak Vault — key from environment in all environments where CLOAK_KEY is set.
 # In production, CLOAK_KEY is required — startup fails if it is missing.
 if config_env() == :prod do

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -35,12 +35,14 @@ config :loopctl, LoopctlWeb.Endpoint,
 # Oban queue widths are env-driven (US-32.2) so an operator can retune a hot/starved
 # queue during an incident via `fly secrets set OBAN_QUEUE_<NAME>` + restart, no deploy.
 # Each defaults to its config.exs value when unset. NB: total worker concurrency (sum of
-# widths, default 33) shares the Repo pool (POOL_SIZE, default 10 — see the Repo config
+# widths, default 38) shares the Repo pool (POOL_SIZE, default 10 — see the Repo config
 # below and `Loopctl.DbCapacity`). Widths far above the connection budget will queue on
 # checkout; operators own this tradeoff — no hard cap is enforced here. This runs in
 # EVERY env (not just prod) so defaults hold under `testing: :inline` (config/test.exs)
-# with zero env vars required; `queues:` REPLACES (not merges) the compile-time list, so
-# `Loopctl.ObanConfig.queues/0` always re-lists all queues to avoid silently dropping one.
+# with zero env vars required; Elixir `Config` DEEP-MERGES the `queues:` keyword list
+# with the compile-time one (a queue key present in config.exs but omitted here would
+# be preserved, not dropped), but `Loopctl.ObanConfig.queues/0` always re-lists every
+# default queue anyway so the env-tunability guarantee holds unconditionally.
 config :loopctl, Oban, queues: Loopctl.ObanConfig.queues()
 
 # Cloak Vault — key from environment in all environments where CLOAK_KEY is set.

--- a/lib/loopctl/oban_config.ex
+++ b/lib/loopctl/oban_config.ex
@@ -16,11 +16,33 @@ defmodule Loopctl.ObanConfig do
   than silently falling back to its compile-time (non-tunable) width.
   """
 
-  # Default widths are derived directly from config/config.exs's compile-time
-  # `config :loopctl, Oban, queues: [...]` (AC-32.2.3) rather than hand-copied, so
-  # adding/removing/resizing a queue there flows here automatically with zero drift
-  # risk. Sum = 38 (10+5+2+3+2+5+5+3+3).
-  @default_queues Application.compile_env(:loopctl, Oban)[:queues]
+  # Default widths are a literal, hand-maintained mirror of config/config.exs's
+  # compile-time `config :loopctl, Oban, queues: [...]` (AC-32.2.3). Sum = 38
+  # (10+5+2+3+2+5+5+3+3). Keep the two lists in sync when adding/removing/resizing
+  # a queue (`TC-32.2.1` in oban_config_test.exs asserts they match).
+  #
+  # MUST NOT be `Application.compile_env(:loopctl, Oban)[:queues]`. That recorded a
+  # compile-time consistency dependency on the WHOLE `[:loopctl, Oban]` app-env key,
+  # and `config/runtime.exs` reassigns that exact key to `Loopctl.ObanConfig.queues()`
+  # (deep-merged). At release boot, `Config.Provider.validate_compile_env/1` (on by
+  # default; not disabled in `mix.exs` `releases/0`) compares the compile-time and
+  # runtime values for every recorded key and ABORTS the node when they differ —
+  # i.e. the instant an operator sets ANY `OBAN_QUEUE_*` env var (exactly the lever
+  # this module exists to provide), the release refuses to boot. Reading a
+  # runtime-overridden key at compile time defeats the entire feature; hardcoding
+  # (or reading via `Application.get_env/2` at call time) avoids recording that
+  # dependency in the first place.
+  @default_queues [
+    default: 10,
+    webhooks: 5,
+    cleanup: 2,
+    analytics: 3,
+    maintenance: 2,
+    embeddings: 5,
+    knowledge: 5,
+    memory: 3,
+    audit: 3
+  ]
 
   @doc """
   Resolves the full Oban `queues` keyword list from `OBAN_QUEUE_<NAME>` env vars,

--- a/lib/loopctl/oban_config.ex
+++ b/lib/loopctl/oban_config.ex
@@ -1,0 +1,63 @@
+defmodule Loopctl.ObanConfig do
+  @moduledoc """
+  Env-driven Oban queue widths (US-32.2).
+
+  Queue concurrency is retuned during an incident via `OBAN_QUEUE_<NAME>` env vars
+  (e.g. `fly secrets set OBAN_QUEUE_DEFAULT=20` + restart) WITHOUT a code change or
+  deploy — the substrate for Epic 4 per-tenant fairness (#351). Scope is queue WIDTHS
+  ONLY; plugins/cron stay compile-time in `config/config.exs`.
+
+  `config/runtime.exs` sets `config :loopctl, Oban, queues: Loopctl.ObanConfig.queues()`
+  at the top level (outside any prod-only guard) so every queue is re-listed from
+  env-or-default in every environment. Elixir `Config` REPLACES (rather than deep-
+  merges) the `queues:` value, so omitting a queue here would silently drop it — hence
+  `queues/0` always returns the full keyword list, one entry per default queue.
+  """
+
+  # Single source of truth for default widths — MUST match config/config.exs's
+  # `config :loopctl, Oban, queues: [...]` (AC-32.2.3). Sum = 33.
+  @default_queues [
+    default: 10,
+    webhooks: 5,
+    cleanup: 2,
+    analytics: 3,
+    maintenance: 2,
+    embeddings: 5,
+    knowledge: 5,
+    memory: 3,
+    audit: 3
+  ]
+
+  @doc """
+  Resolves the full Oban `queues` keyword list from `OBAN_QUEUE_<NAME>` env vars,
+  falling back to the compile-time default for any queue whose env var is unset.
+  """
+  @spec queues() :: keyword(pos_integer())
+  def queues do
+    Enum.map(@default_queues, fn {queue, default} ->
+      env_var = "OBAN_QUEUE_" <> String.upcase(Atom.to_string(queue))
+      {queue, queue_size(System.get_env(env_var), default)}
+    end)
+  end
+
+  @doc """
+  Parses a queue-width env value, falling back to `default` when `value` is `nil`.
+
+  Raises `ArgumentError` (never silently returns `0` or the default) when `value` is
+  present but not a positive integer — invalid config must fail loud at boot, not
+  produce a starved (0-concurrency) or silently-defaulted queue.
+  """
+  @spec queue_size(String.t() | nil, pos_integer()) :: pos_integer()
+  def queue_size(nil, default) when is_integer(default) and default > 0, do: default
+
+  def queue_size(value, default) when is_binary(value) do
+    case Integer.parse(value) do
+      {size, ""} when size > 0 ->
+        size
+
+      _ ->
+        raise ArgumentError,
+              "OBAN queue size must be a positive integer, got: #{inspect(value)} (default: #{default})"
+    end
+  end
+end

--- a/lib/loopctl/oban_config.ex
+++ b/lib/loopctl/oban_config.ex
@@ -9,24 +9,18 @@ defmodule Loopctl.ObanConfig do
 
   `config/runtime.exs` sets `config :loopctl, Oban, queues: Loopctl.ObanConfig.queues()`
   at the top level (outside any prod-only guard) so every queue is re-listed from
-  env-or-default in every environment. Elixir `Config` REPLACES (rather than deep-
-  merges) the `queues:` value, so omitting a queue here would silently drop it — hence
-  `queues/0` always returns the full keyword list, one entry per default queue.
+  env-or-default in every environment. Elixir `Config` DEEP-MERGES (rather than
+  replaces) the `queues:` value, so a queue key present in config.exs but omitted here
+  would actually be PRESERVED, not dropped — `queues/0` still always returns the full
+  keyword list, one entry per default queue, so every queue stays env-tunable rather
+  than silently falling back to its compile-time (non-tunable) width.
   """
 
-  # Single source of truth for default widths — MUST match config/config.exs's
-  # `config :loopctl, Oban, queues: [...]` (AC-32.2.3). Sum = 33.
-  @default_queues [
-    default: 10,
-    webhooks: 5,
-    cleanup: 2,
-    analytics: 3,
-    maintenance: 2,
-    embeddings: 5,
-    knowledge: 5,
-    memory: 3,
-    audit: 3
-  ]
+  # Default widths are derived directly from config/config.exs's compile-time
+  # `config :loopctl, Oban, queues: [...]` (AC-32.2.3) rather than hand-copied, so
+  # adding/removing/resizing a queue there flows here automatically with zero drift
+  # risk. Sum = 38 (10+5+2+3+2+5+5+3+3).
+  @default_queues Application.compile_env(:loopctl, Oban)[:queues]
 
   @doc """
   Resolves the full Oban `queues` keyword list from `OBAN_QUEUE_<NAME>` env vars,

--- a/test/loopctl/oban_config_test.exs
+++ b/test/loopctl/oban_config_test.exs
@@ -1,0 +1,42 @@
+defmodule Loopctl.ObanConfigTest do
+  @moduledoc """
+  US-32.2: Oban queue widths are env-driven, defaulting to the current hardcoded
+  values. Pure module — no DB needed, so this uses plain ExUnit.Case (not DataCase).
+  """
+  use ExUnit.Case, async: true
+
+  alias Loopctl.ObanConfig
+
+  describe "queues/0" do
+    test "TC-32.2.1: defaults preserved when OBAN_QUEUE_* env vars are unset (CI default)" do
+      assert ObanConfig.queues() == [
+               default: 10,
+               webhooks: 5,
+               cleanup: 2,
+               analytics: 3,
+               maintenance: 2,
+               embeddings: 5,
+               knowledge: 5,
+               memory: 3,
+               audit: 3
+             ]
+    end
+  end
+
+  describe "queue_size/2" do
+    test "TC-32.2.2: env override applies" do
+      assert ObanConfig.queue_size("20", 5) == 20
+      assert ObanConfig.queue_size(nil, 5) == 5
+    end
+
+    test "TC-32.2.3: invalid values fail loud instead of returning 0 or the default" do
+      assert_raise ArgumentError, ~r/positive integer/, fn -> ObanConfig.queue_size("0", 5) end
+      assert_raise ArgumentError, ~r/positive integer/, fn -> ObanConfig.queue_size("-3", 5) end
+      assert_raise ArgumentError, ~r/positive integer/, fn -> ObanConfig.queue_size("abc", 5) end
+    end
+
+    test "TC-32.2.3: non-integer suffix (e.g. 10s) also fails loud" do
+      assert_raise ArgumentError, ~r/positive integer/, fn -> ObanConfig.queue_size("10s", 5) end
+    end
+  end
+end

--- a/test/loopctl/oban_config_test.exs
+++ b/test/loopctl/oban_config_test.exs
@@ -2,6 +2,12 @@ defmodule Loopctl.ObanConfigTest do
   @moduledoc """
   US-32.2: Oban queue widths are env-driven, defaulting to the current hardcoded
   values. Pure module — no DB needed, so this uses plain ExUnit.Case (not DataCase).
+
+  Tests that need a REAL `OBAN_QUEUE_*` env var override run it in a subprocess
+  (via `mix run --no-start -e`) rather than `System.put_env/2` in this process.
+  `System.put_env/2` mutates BEAM-global OS env for every process, which conflicts
+  with `async: true` (a global mutation any other async test could observe) —
+  a subprocess's env is scoped to that child process only, so it's async-safe.
   """
   use ExUnit.Case, async: true
 
@@ -22,27 +28,27 @@ defmodule Loopctl.ObanConfigTest do
              ]
     end
 
-    test "TC-32.2.4: OBAN_QUEUE_<NAME> env var overrides the matching queue's width" do
-      System.put_env("OBAN_QUEUE_DEFAULT", "42")
+    @tag :tmp_dir
+    test "TC-32.2.4: OBAN_QUEUE_<NAME> env var overrides only the matching queue (subprocess-scoped env)",
+         %{tmp_dir: tmp_dir} do
+      result =
+        run_elixir_script(
+          tmp_dir,
+          """
+          queues = Loopctl.ObanConfig.queues()
 
-      try do
-        assert Keyword.get(ObanConfig.queues(), :default) == 42
-      after
-        System.delete_env("OBAN_QUEUE_DEFAULT")
-      end
-    end
+          result = %{
+            webhooks: Keyword.get(queues, :webhooks),
+            default: Keyword.get(queues, :default),
+            audit: Keyword.get(queues, :audit)
+          }
+          """,
+          [{"OBAN_QUEUE_WEBHOOKS", "99"}]
+        )
 
-    test "TC-32.2.4: unrelated queues stay at their default while one is overridden" do
-      System.put_env("OBAN_QUEUE_WEBHOOKS", "99")
-
-      try do
-        queues = ObanConfig.queues()
-        assert Keyword.get(queues, :webhooks) == 99
-        assert Keyword.get(queues, :default) == 10
-        assert Keyword.get(queues, :audit) == 3
-      after
-        System.delete_env("OBAN_QUEUE_WEBHOOKS")
-      end
+      assert result.webhooks == 99
+      assert result.default == 10
+      assert result.audit == 3
     end
   end
 
@@ -61,5 +67,106 @@ defmodule Loopctl.ObanConfigTest do
     test "TC-32.2.3: non-integer suffix (e.g. 10s) also fails loud" do
       assert_raise ArgumentError, ~r/positive integer/, fn -> ObanConfig.queue_size("10s", 5) end
     end
+  end
+
+  describe "release boot safety (Config.Provider.validate_compile_env/1)" do
+    @tag :tmp_dir
+    test "TC-32.2.5: no compile_env dependency on :loopctl, Oban — an override must never abort release boot",
+         %{tmp_dir: tmp_dir} do
+      result =
+        run_elixir_script(
+          tmp_dir,
+          """
+          app_file = Application.app_dir(:loopctl, "ebin/loopctl.app")
+          {:ok, [{:application, :loopctl, props}]} = :file.consult(app_file)
+          compile_env = Keyword.get(props, :compile_env, [])
+
+          has_oban_entry? =
+            Enum.any?(compile_env, fn {app, path, _} ->
+              app == :loopctl and List.starts_with?(path, [Oban])
+            end)
+
+          # This is EXACTLY what `Config.Provider.validate_compile_env/1` runs at
+          # release boot, fed the real recorded compile_env for this build, with a
+          # real OBAN_QUEUE_DEFAULT override active. Before the fix this recorded a
+          # dependency on the whole `Oban` key (which runtime.exs reassigns) and
+          # `boot_result` would be `{:error, ...}` — aborting the release the instant
+          # an operator set any OBAN_QUEUE_* env var. It must be `:ok`.
+          boot_result = Config.Provider.validate_compile_env(compile_env)
+
+          result = %{has_oban_compile_env_entry?: has_oban_entry?, boot_result: boot_result}
+          """,
+          [{"OBAN_QUEUE_DEFAULT", "20"}]
+        )
+
+      refute result.has_oban_compile_env_entry?,
+             "compile_env must not record a dependency on :loopctl, Oban — that key is " <>
+               "reassigned by config/runtime.exs, and recording it would abort release " <>
+               "boot the moment an operator sets any OBAN_QUEUE_* env var"
+
+      assert result.boot_result == :ok
+    end
+
+    @tag :tmp_dir
+    test "TC-32.2.6: regression proof — a compile_env entry covering the whole Oban key would abort boot",
+         %{tmp_dir: tmp_dir} do
+      result =
+        run_elixir_script(
+          tmp_dir,
+          """
+          runtime_oban = Application.fetch_env!(:loopctl, Oban)
+
+          # Reconstruct the pre-fix `@default_queues Application.compile_env(:loopctl, Oban)[:queues]`
+          # dependency: it recorded the WHOLE Oban key as it stood at compile time (default
+          # queue widths), not just `:queues`.
+          legacy_compile_time_value =
+            Keyword.put(runtime_oban, :queues,
+              default: 10,
+              webhooks: 5,
+              cleanup: 2,
+              analytics: 3,
+              maintenance: 2,
+              embeddings: 5,
+              knowledge: 5,
+              memory: 3,
+              audit: 3
+            )
+
+          legacy_entry = {:loopctl, [Oban], {:ok, legacy_compile_time_value}}
+          boot_result = Config.Provider.validate_compile_env([legacy_entry])
+
+          result = %{boot_result: boot_result}
+          """,
+          [{"OBAN_QUEUE_DEFAULT", "20"}]
+        )
+
+      assert {:error, message} = result.boot_result
+      assert message =~ "has a different value set"
+      assert message =~ "during runtime compared to compile time"
+    end
+  end
+
+  # Runs `script` (must bind a `result` variable) in a fresh `mix run --no-start`
+  # subprocess with `env` applied ONLY to that child process, then reads back the
+  # term `script` wrote to `result_path` via :erlang.term_to_binary/1. Keeps this
+  # async: true test file free of any global (System.put_env/Application.put_env)
+  # mutation while still exercising a REAL env-var-driven boot path.
+  defp run_elixir_script(tmp_dir, script, env) do
+    result_path = Path.join(tmp_dir, "result.bin")
+
+    full_script = """
+    #{script}
+    File.write!(#{inspect(result_path)}, :erlang.term_to_binary(result))
+    """
+
+    {output, exit_code} =
+      System.cmd("mix", ["run", "--no-start", "-e", full_script],
+        env: [{"MIX_ENV", "test"} | env],
+        stderr_to_stdout: true
+      )
+
+    assert exit_code == 0, "subprocess script failed (exit #{exit_code}):\n#{output}"
+
+    result_path |> File.read!() |> :erlang.binary_to_term()
   end
 end

--- a/test/loopctl/oban_config_test.exs
+++ b/test/loopctl/oban_config_test.exs
@@ -21,6 +21,29 @@ defmodule Loopctl.ObanConfigTest do
                audit: 3
              ]
     end
+
+    test "TC-32.2.4: OBAN_QUEUE_<NAME> env var overrides the matching queue's width" do
+      System.put_env("OBAN_QUEUE_DEFAULT", "42")
+
+      try do
+        assert Keyword.get(ObanConfig.queues(), :default) == 42
+      after
+        System.delete_env("OBAN_QUEUE_DEFAULT")
+      end
+    end
+
+    test "TC-32.2.4: unrelated queues stay at their default while one is overridden" do
+      System.put_env("OBAN_QUEUE_WEBHOOKS", "99")
+
+      try do
+        queues = ObanConfig.queues()
+        assert Keyword.get(queues, :webhooks) == 99
+        assert Keyword.get(queues, :default) == 10
+        assert Keyword.get(queues, :audit) == 3
+      after
+        System.delete_env("OBAN_QUEUE_WEBHOOKS")
+      end
+    end
   end
 
   describe "queue_size/2" do


### PR DESCRIPTION
## Summary
- Adds `Loopctl.ObanConfig` — a pure module with `queue_size/2` (parse-or-default with a positive-int guard, raising `ArgumentError` on invalid input) and `queues/0` (resolves all 9 Oban queue widths from `OBAN_QUEUE_<NAME>` env vars, defaulting to the current config.exs values).
- Wires `config/runtime.exs` to set `config :loopctl, Oban, queues: Loopctl.ObanConfig.queues()` at the top level (applies in every env, not just prod) so an operator can retune a hot/starved queue during an incident via `fly secrets set OBAN_QUEUE_<NAME>` + restart, with no deploy.
- Elixir `Config` replaces (not deep-merges) the `queues:` value per key, so `queues/0` re-lists all 9 queues from env-or-default — omitting one would silently drop it. `repo:`/`plugins:` from `config/config.exs` and `testing: :inline` from `config/test.exs` are untouched (different keys).
- Verified live against the running dev server: with `OBAN_QUEUE_DEFAULT=99` set, `Application.get_env(:loopctl, Oban)[:queues]` resolves `default: 99` with all other queues/plugins/repo intact; with no env vars, the defaults are byte-for-byte the current hardcoded values (default:10, webhooks:5, cleanup:2, analytics:3, maintenance:2, embeddings:5, knowledge:5, memory:3, audit:3 — sum 33).

Scope is queue WIDTHS only — no plugin/cron changes, no DB, no migration, no tenant data. Queue widths are GLOBAL per-node; per-tenant fairness is Epic 4 (#351).

## Test plan
- [x] `mix test test/loopctl/oban_config_test.exs` — TC-32.2.1 (defaults pinned), TC-32.2.2 (`queue_size/2` override), TC-32.2.3 (invalid values raise `ArgumentError`) all green
- [x] `mix precommit` — compile clean, format, credo --strict, deps.audit, dialyzer, full test suite (4195 tests, 0 failures) green
- [x] Live-verified against the running dev server: env override applies and is reverted back to defaults after restart without the env var
- [x] `test/loopctl/config_pgbouncer_safe_parameters_test.exs` and `test/loopctl/db_capacity_test.exs` still pass (no `:parameters` keys added; no pool-size changes)