### PR TITLE
ETS-cache resolved tenant LLM settings, busted on set_llm_config

### DIFF
--- a/lib/loopctl/application.ex
+++ b/lib/loopctl/application.ex
@@ -37,6 +37,11 @@ defmodule Loopctl.Application do
       # long-lived owner (it would otherwise be created by a transient request/job/Task
       # and vanish when that process died — silently resetting the breaker).
       Loopctl.Knowledge.EmbeddingCircuitBreaker,
+      # US-32.3: owns the ETS table caching resolved+decrypted per-tenant LLM
+      # settings so a per-provider-call DB read + Cloak decrypt becomes a
+      # per-change one. Stable owner survives the request/Task/Oban process that
+      # populated an entry; invalidated on the settings write path.
+      Loopctl.Llm.SettingsCache,
       LoopctlWeb.Endpoint
     ]
 

--- a/lib/loopctl/llm.ex
+++ b/lib/loopctl/llm.ex
@@ -85,6 +85,11 @@ defmodule Loopctl.Llm do
   Cloak decrypt into a per-change one. On a miss it loads from the DB, caches, and
   returns; `upsert_settings/2` invalidates the entry so a read never serves stale
   credentials. Signature and return shape are unchanged.
+
+  The cache generation is captured BEFORE the DB load and passed to `put/3`, so a
+  concurrent rotation that invalidates during the load bumps the generation and the
+  (now-possibly-stale) repopulation is rejected at the next `fetch/1` — closing the
+  read-through repopulation race (AC-32.3.3, never serve stale).
   """
   @spec get_settings(Ecto.UUID.t()) :: TenantLlmSettings.t() | nil
   def get_settings(tenant_id) when is_binary(tenant_id) do
@@ -93,8 +98,9 @@ defmodule Loopctl.Llm do
         value
 
       :miss ->
+        generation = SettingsCache.generation(tenant_id)
         settings = load_settings(tenant_id)
-        SettingsCache.put(tenant_id, settings)
+        SettingsCache.put(tenant_id, settings, generation)
         settings
     end
   end

--- a/lib/loopctl/llm.ex
+++ b/lib/loopctl/llm.ex
@@ -83,13 +83,16 @@ defmodule Loopctl.Llm do
   READ-THROUGH CACHED (US-32.3): the resolved+decrypted struct (or `nil`) is served
   from a supervised ETS cache keyed by `tenant_id`, converting a per-call DB read +
   Cloak decrypt into a per-change one. On a miss it loads from the DB, caches, and
-  returns; `upsert_settings/2` invalidates the entry so a read never serves stale
-  credentials. Signature and return shape are unchanged.
+  returns; `upsert_settings/2` invalidates the entry. Signature and return shape are
+  unchanged.
 
   The cache generation is captured BEFORE the DB load and passed to `put/3`, so a
   concurrent rotation that invalidates during the load bumps the generation and the
   (now-possibly-stale) repopulation is rejected at the next `fetch/1` — closing the
-  read-through repopulation race (AC-32.3.3, never serve stale).
+  intra-node read-through repopulation race (AC-32.3.3). Staleness bounds are
+  layered: exact on the writing node, prompt cross-node via a PubSub invalidation
+  broadcast, and capped by a bounded per-entry TTL for the dropped-broadcast /
+  crash-window cases. See `Loopctl.Llm.SettingsCache` for the full guarantee.
   """
   @spec get_settings(Ecto.UUID.t()) :: TenantLlmSettings.t() | nil
   def get_settings(tenant_id) when is_binary(tenant_id) do
@@ -157,9 +160,12 @@ defmodule Loopctl.Llm do
     |> case do
       {:ok, %{settings: settings}} ->
         # Invalidate AFTER commit so the next read repopulates read-through with the
-        # fresh row — never serves stale credentials (US-32.3, AC-32.3.3). This is
-        # the sole settings-mutation path, so it is the only cache-busting point.
-        SettingsCache.invalidate(tenant_id)
+        # fresh row (US-32.3, AC-32.3.3). This is the sole settings-mutation path, so
+        # it is the only cache-busting point. Use the CLUSTER variant: the ETS table
+        # is node-local, so we bust this node synchronously AND broadcast so peer
+        # nodes bust their node-local entries within a PubSub hop (the bounded TTL
+        # backstops a dropped broadcast or a crash in this post-commit gap).
+        SettingsCache.invalidate_cluster(tenant_id)
         {:ok, settings}
 
       {:error, :settings, changeset, _} ->

--- a/lib/loopctl/llm.ex
+++ b/lib/loopctl/llm.ex
@@ -49,6 +49,7 @@ defmodule Loopctl.Llm do
   alias Loopctl.AdminRepo
   alias Loopctl.Audit
   alias Loopctl.HeavyRead
+  alias Loopctl.Llm.SettingsCache
   alias Loopctl.Llm.TenantLlmSettings
   alias Loopctl.Llm.UsageEvent
 
@@ -78,9 +79,32 @@ defmodule Loopctl.Llm do
 
   The `api_key` field on the returned struct is decrypted plaintext — treat it as
   a secret. Prefer `resolve/2` for LLM call sites.
+
+  READ-THROUGH CACHED (US-32.3): the resolved+decrypted struct (or `nil`) is served
+  from a supervised ETS cache keyed by `tenant_id`, converting a per-call DB read +
+  Cloak decrypt into a per-change one. On a miss it loads from the DB, caches, and
+  returns; `upsert_settings/2` invalidates the entry so a read never serves stale
+  credentials. Signature and return shape are unchanged.
   """
   @spec get_settings(Ecto.UUID.t()) :: TenantLlmSettings.t() | nil
   def get_settings(tenant_id) when is_binary(tenant_id) do
+    case SettingsCache.fetch(tenant_id) do
+      {:ok, value} ->
+        value
+
+      :miss ->
+        settings = load_settings(tenant_id)
+        SettingsCache.put(tenant_id, settings)
+        settings
+    end
+  end
+
+  # Direct, UNCACHED DB read of the tenant's settings row. Used on the cache-miss
+  # read-through path AND by the write path (`upsert_settings/2`), which must fetch
+  # the existing row uncached so a cached (possibly negative) entry can never leak
+  # into the insert_or_update changeset.
+  @spec load_settings(Ecto.UUID.t()) :: TenantLlmSettings.t() | nil
+  defp load_settings(tenant_id) when is_binary(tenant_id) do
     AdminRepo.get_by(TenantLlmSettings, tenant_id: tenant_id)
   end
 
@@ -103,7 +127,10 @@ defmodule Loopctl.Llm do
     attrs = normalize_keys(attrs)
     api_key = Map.get(attrs, :api_key)
     embedding_api_key = Map.get(attrs, :embedding_api_key)
-    existing = get_settings(tenant_id)
+    # UNCACHED read on the WRITE path: `get_settings/1` is now cached (and may hold a
+    # negative `nil` entry), so fetch the existing row directly from the DB — a stale
+    # or negative cached struct must never seed the insert_or_update changeset (US-32.3).
+    existing = load_settings(tenant_id)
 
     changeset =
       (existing || %TenantLlmSettings{tenant_id: tenant_id})
@@ -122,8 +149,15 @@ defmodule Loopctl.Llm do
     end)
     |> AdminRepo.transaction()
     |> case do
-      {:ok, %{settings: settings}} -> {:ok, settings}
-      {:error, :settings, changeset, _} -> {:error, changeset}
+      {:ok, %{settings: settings}} ->
+        # Invalidate AFTER commit so the next read repopulates read-through with the
+        # fresh row — never serves stale credentials (US-32.3, AC-32.3.3). This is
+        # the sole settings-mutation path, so it is the only cache-busting point.
+        SettingsCache.invalidate(tenant_id)
+        {:ok, settings}
+
+      {:error, :settings, changeset, _} ->
+        {:error, changeset}
     end
   end
 

--- a/lib/loopctl/llm/settings_cache.ex
+++ b/lib/loopctl/llm/settings_cache.ex
@@ -10,16 +10,45 @@ defmodule Loopctl.Llm.SettingsCache do
   a per-CALL DB+decrypt into a per-CHANGE one: the resolved+decrypted
   `TenantLlmSettings` struct is stored in ETS keyed by `tenant_id`, and the sole
   write path (`Loopctl.Llm.upsert_settings/2`) invalidates the entry so the next
-  read repopulates read-through. It NEVER serves stale credentials.
+  read repopulates read-through.
+
+  ## Staleness bounds — what "fresh" actually guarantees
+
+  The cache is a `:named_table`, so the ETS table is **node-LOCAL**: Erlang
+  clustering does NOT share ETS. That shapes the staleness guarantee, which is
+  layered (strongest first):
+
+    * **Intra-node, exact:** on the node that processed the write, the entry is
+      busted synchronously in the same call, and the generation counter (below)
+      closes the read-through repopulation race. That node NEVER serves stale.
+    * **Cross-node, prompt:** `invalidate_cluster/1` (called by the write path)
+      broadcasts the invalidation over `Phoenix.PubSub` so every OTHER node busts
+      its node-local entry within a message hop — not just the node that handled
+      the write. In a healthy cluster this makes cross-node staleness effectively
+      as short as a PubSub round-trip.
+    * **Bounded safety-net:** every entry carries a wall-bounded TTL
+      (#{div(:timer.minutes(5), 60_000)} min). Even if a broadcast is DROPPED (netsplit /
+      PubSub blip) or a post-commit `invalidate/1` is SKIPPED (a crash in the gap
+      between COMMIT and the invalidate call), the stale entry — and the decrypted
+      secret it holds — is evicted after at most the TTL, on the next `fetch/1` or
+      the periodic sweep. This is the backstop the story's technical note asks for
+      ("consider a fallback TTL only if a mutation path could bypass the API" —
+      another node's write path, and a crash between commit and invalidate, are
+      exactly such bypasses).
+
+  So the invariant is precisely: **no node serves credentials staler than the TTL,
+  and the writing node plus every reachable peer are consistent within a PubSub
+  hop** — not an unconditional "never stale" across a partitioned cluster.
 
   ## Design (mirrors `Loopctl.Knowledge.EmbeddingCircuitBreaker` / `ExportConcurrency`)
 
   A single GenServer owns a `:public`, `:named_table`, `read_concurrency: true` ETS
   table. Callers read/write it DIRECTLY (`fetch/1`, `put/3`, `invalidate/1`) — the
-  GenServer is NEVER on the hot path and can't bottleneck provider throughput. It
-  exists ONLY to own the table so it survives the transient request/Task/Oban
-  process that populated it. No DB access happens in the GenServer, so there is no
-  Ecto Sandbox ownership concern in tests.
+  GenServer is NEVER on the hot read path and can't bottleneck provider throughput.
+  It exists to own the table (so it survives the transient request/Task/Oban
+  process that populated it), to run the periodic TTL sweep, and to bridge
+  cross-node invalidation broadcasts. No DB access happens in the GenServer, so
+  there is no Ecto Sandbox ownership concern in tests.
 
   ## Never-stale under the read-through repopulation race (AC-32.3.3)
 
@@ -27,15 +56,16 @@ defmodule Loopctl.Llm.SettingsCache do
   a reader can MISS, snapshot the OLD row in its `SELECT`, then a writer commits
   the NEW row and invalidates (a no-op — the entry is already absent), and only
   THEN the slow reader `put`s its now-stale struct — which would persist until the
-  next write. That breaks the "NEVER serves stale credentials" invariant right
-  after a key rotation (exactly when the entry is empty and an agent is looping).
+  next write. That breaks the intra-node freshness invariant right after a key
+  rotation (exactly when the entry is empty and an agent is looping).
 
   We close it with a per-tenant **generation counter** and optimistic version
   checking (the classic check-then-act fix — put the authority in one atomic op).
-  Each entry is stamped `{tenant_id, value, generation}` with the generation
-  captured BEFORE the DB read (see `Loopctl.Llm.get_settings/1`). `invalidate/1`
-  atomically BUMPS the tenant's generation (`:ets.update_counter`). `fetch/1` trusts
-  an entry ONLY when its stamp still equals the current generation. Therefore:
+  Each entry is stamped `{tenant_id, value, generation, expires_at}` with the
+  generation captured BEFORE the DB read (see `Loopctl.Llm.get_settings/1`).
+  `invalidate/1` atomically BUMPS the tenant's generation (`:ets.update_counter`).
+  `fetch/1` trusts an entry ONLY when its stamp still equals the current generation
+  AND it has not passed its TTL. Therefore:
 
     * a reader whose snapshot preceded a committed write captured a generation
       strictly LESS than the post-invalidate one, so its `put` lands with a stale
@@ -43,18 +73,28 @@ defmodule Loopctl.Llm.SettingsCache do
     * a reader whose capture followed the invalidate necessarily read the committed
       NEW row, so its stamp equals the current generation and its value is fresh.
 
-  No interleaving yields a trusted-but-stale entry, so no fallback TTL is needed:
-  `invalidate` (the generation bump), not the wall clock, is the authority. The
-  bump is atomic, so the guard needs no serialization through the GenServer — the
-  hot read/write paths stay lock-free.
+  No interleaving yields a trusted-but-stale entry on the writing node:
+  `invalidate` (the generation bump), not the wall clock, is the intra-node
+  authority. The bump is atomic, so the guard needs no serialization through the
+  GenServer — the hot read/write paths stay lock-free. The TTL is orthogonal: it
+  caps staleness for the cross-node / crash-window cases the generation counter
+  cannot see (those live on a different node's ETS, or never reached `invalidate`).
 
   ## Security (AC-32.3.5)
 
-  The cached struct carries the DECRYPTED plaintext keys in ETS memory only. It is
-  NEVER logged, NEVER placed in telemetry tags, and NEVER persisted — a cold start
-  or GenServer restart yields an empty table that repopulates read-through. The
-  struct's `api_key` / `embedding_api_key` fields are `redact: true`, so an
-  accidental `inspect` shows `**redacted**`, but callers must still never log it.
+  The cached struct carries the DECRYPTED plaintext keys in ETS memory only. Two
+  guardrails bound the blast radius of a `:public`, `:named_table` that aggregates
+  every tenant's plaintext keys under one well-known name:
+
+    * **Never log / inspect the plaintext downstream.** The struct's `api_key` /
+      `embedding_api_key` fields are `redact: true`, so an accidental `inspect`
+      shows `**redacted**` — but callers must still never log the resolved value.
+      This module itself never logs, inspects, or telemetry-tags the value.
+    * **Bounded residency.** The TTL + periodic sweep actively evict entries so a
+      decrypted secret does not linger in memory indefinitely after its last use;
+      combined with never persisting it (a cold start / GenServer restart yields an
+      empty table that repopulates read-through), plaintext exposure in a heap /
+      crash dump is time-boxed to at most the TTL.
 
   ## Tenant isolation (AC-32.3.4)
 
@@ -73,6 +113,19 @@ defmodule Loopctl.Llm.SettingsCache do
 
   @table :loopctl_tenant_llm_settings
 
+  # Cross-node invalidation bridge. The write path broadcasts here so peer nodes
+  # bust their node-local ETS promptly (Erlang clustering does not share ETS).
+  @pubsub Loopctl.PubSub
+  @invalidate_topic "llm:settings_cache:invalidate"
+
+  # Bounded safety-net TTL: even if the cross-node broadcast is dropped (netsplit)
+  # or a post-commit `invalidate/1` is skipped (crash between COMMIT and the call),
+  # a cached entry — and the decrypted secret it holds — is evicted after at most
+  # this long, on the next `fetch/1` (lazy) or the periodic sweep (active). Prompt
+  # invalidation is via the generation bump + PubSub; this is only the backstop.
+  @ttl_ms :timer.minutes(5)
+  @sweep_interval_ms :timer.minutes(1)
+
   # --- Client API ---
 
   @doc false
@@ -86,20 +139,23 @@ defmodule Loopctl.Llm.SettingsCache do
 
   Returns `{:ok, value}` on a cache HIT — where `value` is the cached
   `TenantLlmSettings.t()` OR `nil` (negative cache for a tenant with no row) — or
-  `:miss` when there is no entry OR the entry is STALE (its stamped generation no
-  longer matches the tenant's current generation — an `invalidate/1` fired after the
-  entry's underlying DB read, so it is rejected rather than served). On a `:miss`
+  `:miss` when there is no entry, the entry is STALE (its stamped generation no
+  longer matches the tenant's current generation — an `invalidate/1` fired after
+  the entry's underlying DB read), OR the entry has passed its TTL (the bounded
+  safety-net for a dropped cross-node broadcast / skipped invalidate). On a `:miss`
   the caller loads read-through and `put/3`s under a freshly captured generation.
   """
   @spec fetch(Ecto.UUID.t()) :: {:ok, term()} | :miss
   def fetch(tenant_id) when is_binary(tenant_id) do
     case :ets.lookup(@table, tenant_id) do
-      [{^tenant_id, value, stamp}] ->
-        # Optimistic version check: trust the entry only if no invalidation has
-        # bumped the generation since the value's DB read (AC-32.3.3). A mismatch
-        # means a concurrent rotation raced this entry's repopulation — treat as a
-        # miss so the caller reloads, never serving the stale struct.
-        if stamp == current_generation(tenant_id), do: {:ok, value}, else: :miss
+      [{^tenant_id, value, stamp, expires_at}] ->
+        # Trust the entry only if (a) no invalidation bumped the generation since
+        # the value's DB read (AC-32.3.3 intra-node race) AND (b) it has not passed
+        # its TTL (cross-node / crash-window backstop). Either failing => miss, so
+        # the caller reloads and never serves stale.
+        if stamp == current_generation(tenant_id) and not expired?(expires_at),
+          do: {:ok, value},
+          else: :miss
 
       [] ->
         :miss
@@ -125,15 +181,16 @@ defmodule Loopctl.Llm.SettingsCache do
   @doc """
   Stores the resolved settings `value` (a `TenantLlmSettings.t()` or `nil`) for
   `tenant_id` in ETS, stamped with `read_generation` (the generation captured
-  BEFORE the value's DB read). Called from the caller process on a read-through
-  miss. The entry is only ever SERVED while `read_generation` still matches the
-  tenant's current generation, so a repopulation that raced a concurrent
-  invalidation is silently ignored on the next `fetch/1`.
+  BEFORE the value's DB read) and a wall-bounded expiry (#{div(:timer.minutes(5), 60_000)} min).
+  Called from the caller process on a read-through miss. The entry is only ever
+  SERVED while `read_generation` still matches the tenant's current generation AND
+  it is within its TTL, so a repopulation that raced a concurrent invalidation — or
+  outlived a dropped cross-node broadcast — is not served on the next `fetch/1`.
   """
   @spec put(Ecto.UUID.t(), term(), non_neg_integer()) :: :ok
   def put(tenant_id, value, read_generation)
       when is_binary(tenant_id) and is_integer(read_generation) do
-    :ets.insert(@table, {tenant_id, value, read_generation})
+    :ets.insert(@table, {tenant_id, value, read_generation, now_ms() + @ttl_ms})
     :ok
   rescue
     ArgumentError -> :ok
@@ -152,11 +209,13 @@ defmodule Loopctl.Llm.SettingsCache do
   end
 
   @doc """
-  Invalidates the cached entry for `tenant_id`: atomically BUMPS the tenant's
-  generation (so any in-flight read-through that captured the prior generation has
-  its `put` rejected at `fetch/1`), then deletes the entry so the next read
-  repopulates read-through. Called from the settings write path within the same
-  call so the next read reflects the change; never serves stale credentials.
+  Invalidates the cached entry for `tenant_id` ON THIS NODE: atomically BUMPS the
+  tenant's generation (so any in-flight read-through that captured the prior
+  generation has its `put` rejected at `fetch/1`), then deletes the entry so the
+  next read repopulates read-through.
+
+  This is the node-local primitive; the settings write path uses
+  `invalidate_cluster/1` so peer nodes bust their node-local entries too.
   """
   @spec invalidate(Ecto.UUID.t()) :: :ok
   def invalidate(tenant_id) when is_binary(tenant_id) do
@@ -168,9 +227,31 @@ defmodule Loopctl.Llm.SettingsCache do
   end
 
   @doc """
-  Resets (invalidates) a single tenant's cache entry. Preferred over any global
-  wipe in async tests: the cache is tenant-scoped, so per-tenant reset never races
-  concurrent tests' entries. Alias of `invalidate/1`.
+  Invalidates `tenant_id` on THIS node (see `invalidate/1`) AND broadcasts the
+  invalidation to peer nodes over `Phoenix.PubSub` so their node-local ETS busts
+  promptly — the ETS table is `:named_table` (node-local), and Erlang clustering
+  does NOT share ETS, so a bump on one node is invisible to the others.
+
+  The settings write path (`Loopctl.Llm.upsert_settings/2`) calls this so a key
+  rotation is reflected cluster-wide within a PubSub hop, not just on the node that
+  handled the write. If the broadcast is dropped (netsplit) the bounded TTL still
+  evicts the peer's stale entry — this is prompt-but-not-guaranteed; the TTL is the
+  guarantee.
+  """
+  @spec invalidate_cluster(Ecto.UUID.t()) :: :ok
+  def invalidate_cluster(tenant_id) when is_binary(tenant_id) do
+    invalidate(tenant_id)
+    # Broadcast off the (rare) write path via the owner so we can exclude THIS
+    # node's subscriber from the fan-out (no self-echo). GenServer.cast is safe if
+    # the owner is momentarily down mid-restart — the local invalidate already ran.
+    GenServer.cast(__MODULE__, {:broadcast_invalidate, tenant_id})
+    :ok
+  end
+
+  @doc """
+  Resets (invalidates) a single tenant's cache entry on this node. Preferred over
+  any global wipe in async tests: the cache is tenant-scoped, so per-tenant reset
+  never races concurrent tests' entries. Alias of `invalidate/1`.
   """
   @spec reset(Ecto.UUID.t()) :: :ok
   def reset(tenant_id) when is_binary(tenant_id), do: invalidate(tenant_id)
@@ -198,6 +279,12 @@ defmodule Loopctl.Llm.SettingsCache do
     :ets.update_counter(@table, {:gen, tenant_id}, {2, 1}, {{:gen, tenant_id}, 0})
   end
 
+  # Monotonic clock (not affected by wall-clock jumps) for TTL comparisons. Stored
+  # per-entry as `now_ms() + @ttl_ms`; compared against `now_ms()` at read/sweep.
+  defp now_ms, do: System.monotonic_time(:millisecond)
+
+  defp expired?(expires_at), do: now_ms() >= expires_at
+
   # --- Server callbacks ---
 
   @impl true
@@ -219,6 +306,53 @@ defmodule Loopctl.Llm.SettingsCache do
           existing
       end
 
+    # Subscribe so a PEER node's invalidation broadcast busts THIS node's entry.
+    # `Phoenix.PubSub` starts strictly before this owner in the supervision tree
+    # (and stays up across our restarts), so the subscribe is safe to do inline.
+    Phoenix.PubSub.subscribe(@pubsub, @invalidate_topic)
+    schedule_sweep()
+
     {:ok, %{table: table}}
+  end
+
+  @impl true
+  def handle_cast({:broadcast_invalidate, tenant_id}, state) do
+    # Fan out to peer nodes, excluding self() (this node's subscriber is the owner
+    # itself) so the originating node does not re-process its own invalidation.
+    _ =
+      Phoenix.PubSub.broadcast_from(@pubsub, self(), @invalidate_topic, {:invalidate, tenant_id})
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info({:invalidate, tenant_id}, state) when is_binary(tenant_id) do
+    # A peer node rotated this tenant's settings; bust our node-local entry.
+    invalidate(tenant_id)
+    {:noreply, state}
+  end
+
+  def handle_info(:sweep, state) do
+    sweep_expired()
+    schedule_sweep()
+    {:noreply, state}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  defp schedule_sweep do
+    Process.send_after(self(), :sweep, @sweep_interval_ms)
+  end
+
+  # Actively evict expired entries so decrypted secrets do not linger past the TTL
+  # even for tenants that are never read again (bounded residency, AC-32.3.5). Only
+  # the 4-tuple value entries carry an expiry; the 2-tuple `{:gen, _}` generation
+  # entries never match this head, so the monotonic authority is preserved.
+  defp sweep_expired do
+    now = now_ms()
+    match_spec = [{{:_, :_, :_, :"$1"}, [{:"=<", :"$1", now}], [true]}]
+    :ets.select_delete(@table, match_spec)
+  rescue
+    ArgumentError -> 0
   end
 end

--- a/lib/loopctl/llm/settings_cache.ex
+++ b/lib/loopctl/llm/settings_cache.ex
@@ -15,11 +15,38 @@ defmodule Loopctl.Llm.SettingsCache do
   ## Design (mirrors `Loopctl.Knowledge.EmbeddingCircuitBreaker` / `ExportConcurrency`)
 
   A single GenServer owns a `:public`, `:named_table`, `read_concurrency: true` ETS
-  table. Callers read/write it DIRECTLY (`fetch/1`, `put/2`, `invalidate/1`) — the
+  table. Callers read/write it DIRECTLY (`fetch/1`, `put/3`, `invalidate/1`) — the
   GenServer is NEVER on the hot path and can't bottleneck provider throughput. It
   exists ONLY to own the table so it survives the transient request/Task/Oban
   process that populated it. No DB access happens in the GenServer, so there is no
   Ecto Sandbox ownership concern in tests.
+
+  ## Never-stale under the read-through repopulation race (AC-32.3.3)
+
+  Plain cache-aside (invalidate-then-repopulate) has a well-known staleness race:
+  a reader can MISS, snapshot the OLD row in its `SELECT`, then a writer commits
+  the NEW row and invalidates (a no-op — the entry is already absent), and only
+  THEN the slow reader `put`s its now-stale struct — which would persist until the
+  next write. That breaks the "NEVER serves stale credentials" invariant right
+  after a key rotation (exactly when the entry is empty and an agent is looping).
+
+  We close it with a per-tenant **generation counter** and optimistic version
+  checking (the classic check-then-act fix — put the authority in one atomic op).
+  Each entry is stamped `{tenant_id, value, generation}` with the generation
+  captured BEFORE the DB read (see `Loopctl.Llm.get_settings/1`). `invalidate/1`
+  atomically BUMPS the tenant's generation (`:ets.update_counter`). `fetch/1` trusts
+  an entry ONLY when its stamp still equals the current generation. Therefore:
+
+    * a reader whose snapshot preceded a committed write captured a generation
+      strictly LESS than the post-invalidate one, so its `put` lands with a stale
+      stamp and is NEVER trusted — the next read simply reloads (no staleness); and
+    * a reader whose capture followed the invalidate necessarily read the committed
+      NEW row, so its stamp equals the current generation and its value is fresh.
+
+  No interleaving yields a trusted-but-stale entry, so no fallback TTL is needed:
+  `invalidate` (the generation bump), not the wall clock, is the authority. The
+  bump is atomic, so the guard needs no serialization through the GenServer — the
+  hot read/write paths stay lock-free.
 
   ## Security (AC-32.3.5)
 
@@ -59,13 +86,23 @@ defmodule Loopctl.Llm.SettingsCache do
 
   Returns `{:ok, value}` on a cache HIT — where `value` is the cached
   `TenantLlmSettings.t()` OR `nil` (negative cache for a tenant with no row) — or
-  `:miss` when there is no entry (caller should load read-through and `put/2`).
+  `:miss` when there is no entry OR the entry is STALE (its stamped generation no
+  longer matches the tenant's current generation — an `invalidate/1` fired after the
+  entry's underlying DB read, so it is rejected rather than served). On a `:miss`
+  the caller loads read-through and `put/3`s under a freshly captured generation.
   """
   @spec fetch(Ecto.UUID.t()) :: {:ok, term()} | :miss
   def fetch(tenant_id) when is_binary(tenant_id) do
     case :ets.lookup(@table, tenant_id) do
-      [{^tenant_id, value}] -> {:ok, value}
-      [] -> :miss
+      [{^tenant_id, value, stamp}] ->
+        # Optimistic version check: trust the entry only if no invalidation has
+        # bumped the generation since the value's DB read (AC-32.3.3). A mismatch
+        # means a concurrent rotation raced this entry's repopulation — treat as a
+        # miss so the caller reloads, never serving the stale struct.
+        if stamp == current_generation(tenant_id), do: {:ok, value}, else: :miss
+
+      [] ->
+        :miss
     end
   rescue
     # The table only vanishes if the owner is (transiently) down mid-restart; a
@@ -74,24 +111,56 @@ defmodule Loopctl.Llm.SettingsCache do
   end
 
   @doc """
-  Stores the resolved settings `value` (a `TenantLlmSettings.t()` or `nil`) for
-  `tenant_id` in ETS. Called from the caller process on a read-through miss.
+  Returns the tenant's current cache generation — capture this BEFORE a read-through
+  DB load and pass it to `put/3`, so a rotation that invalidates during the load is
+  detected and the repopulation rejected at `fetch/1` (never serves stale).
   """
-  @spec put(Ecto.UUID.t(), term()) :: :ok
-  def put(tenant_id, value) when is_binary(tenant_id) do
-    :ets.insert(@table, {tenant_id, value})
+  @spec generation(Ecto.UUID.t()) :: non_neg_integer()
+  def generation(tenant_id) when is_binary(tenant_id) do
+    current_generation(tenant_id)
+  rescue
+    ArgumentError -> 0
+  end
+
+  @doc """
+  Stores the resolved settings `value` (a `TenantLlmSettings.t()` or `nil`) for
+  `tenant_id` in ETS, stamped with `read_generation` (the generation captured
+  BEFORE the value's DB read). Called from the caller process on a read-through
+  miss. The entry is only ever SERVED while `read_generation` still matches the
+  tenant's current generation, so a repopulation that raced a concurrent
+  invalidation is silently ignored on the next `fetch/1`.
+  """
+  @spec put(Ecto.UUID.t(), term(), non_neg_integer()) :: :ok
+  def put(tenant_id, value, read_generation)
+      when is_binary(tenant_id) and is_integer(read_generation) do
+    :ets.insert(@table, {tenant_id, value, read_generation})
     :ok
   rescue
     ArgumentError -> :ok
   end
 
   @doc """
-  Invalidates the cached entry for `tenant_id` (delete → next read repopulates
-  read-through). Called from the settings write path within the same call so the
-  next read reflects the change; never serves stale credentials.
+  Convenience `put` that stamps `value` with the tenant's CURRENT generation.
+
+  Prefer `put/3` with a generation captured before the DB read on the read-through
+  path — this arity is for direct/manual population where no concurrent DB snapshot
+  is in flight (e.g. seeding a known-fresh value in tests).
+  """
+  @spec put(Ecto.UUID.t(), term()) :: :ok
+  def put(tenant_id, value) when is_binary(tenant_id) do
+    put(tenant_id, value, generation(tenant_id))
+  end
+
+  @doc """
+  Invalidates the cached entry for `tenant_id`: atomically BUMPS the tenant's
+  generation (so any in-flight read-through that captured the prior generation has
+  its `put` rejected at `fetch/1`), then deletes the entry so the next read
+  repopulates read-through. Called from the settings write path within the same
+  call so the next read reflects the change; never serves stale credentials.
   """
   @spec invalidate(Ecto.UUID.t()) :: :ok
   def invalidate(tenant_id) when is_binary(tenant_id) do
+    bump_generation(tenant_id)
     :ets.delete(@table, tenant_id)
     :ok
   rescue
@@ -108,6 +177,26 @@ defmodule Loopctl.Llm.SettingsCache do
 
   @doc false
   def table_name, do: @table
+
+  # --- Private ---
+
+  # A tenant's generation lives under a distinct `{:gen, tenant_id}` key — a 2-tuple
+  # key that a binary-`tenant_id` `fetch/1` lookup can never match, so it never
+  # collides with a cached-settings entry. Defaults to 0 for a tenant that has never
+  # been invalidated.
+  defp current_generation(tenant_id) do
+    case :ets.lookup(@table, {:gen, tenant_id}) do
+      [{{:gen, ^tenant_id}, gen}] -> gen
+      [] -> 0
+    end
+  end
+
+  # Atomically increment the tenant's generation (creating it at 1 on first bump).
+  # `:ets.update_counter/4` is lock-free and serializes concurrent invalidations, so
+  # the generation is a monotonic authority no reader can observe half-applied.
+  defp bump_generation(tenant_id) do
+    :ets.update_counter(@table, {:gen, tenant_id}, {2, 1}, {{:gen, tenant_id}, 0})
+  end
 
   # --- Server callbacks ---
 

--- a/lib/loopctl/llm/settings_cache.ex
+++ b/lib/loopctl/llm/settings_cache.ex
@@ -1,0 +1,135 @@
+defmodule Loopctl.Llm.SettingsCache do
+  @moduledoc """
+  Stable, supervised OWNER of the ETS table caching resolved+decrypted per-tenant
+  LLM settings (US-32.3).
+
+  Every embedding/completion provider call funnels through `Loopctl.Llm.get_settings/1`,
+  which reads the tenant's `tenant_llm_settings` row and Cloak-decrypts the two
+  BYO API keys (Anthropic + embedding). Doing that DB read + AES-256-GCM decrypt on
+  every provider call is wasteful when the settings change rarely. This cache turns
+  a per-CALL DB+decrypt into a per-CHANGE one: the resolved+decrypted
+  `TenantLlmSettings` struct is stored in ETS keyed by `tenant_id`, and the sole
+  write path (`Loopctl.Llm.upsert_settings/2`) invalidates the entry so the next
+  read repopulates read-through. It NEVER serves stale credentials.
+
+  ## Design (mirrors `Loopctl.Knowledge.EmbeddingCircuitBreaker` / `ExportConcurrency`)
+
+  A single GenServer owns a `:public`, `:named_table`, `read_concurrency: true` ETS
+  table. Callers read/write it DIRECTLY (`fetch/1`, `put/2`, `invalidate/1`) — the
+  GenServer is NEVER on the hot path and can't bottleneck provider throughput. It
+  exists ONLY to own the table so it survives the transient request/Task/Oban
+  process that populated it. No DB access happens in the GenServer, so there is no
+  Ecto Sandbox ownership concern in tests.
+
+  ## Security (AC-32.3.5)
+
+  The cached struct carries the DECRYPTED plaintext keys in ETS memory only. It is
+  NEVER logged, NEVER placed in telemetry tags, and NEVER persisted — a cold start
+  or GenServer restart yields an empty table that repopulates read-through. The
+  struct's `api_key` / `embedding_api_key` fields are `redact: true`, so an
+  accidental `inspect` shows `**redacted**`, but callers must still never log it.
+
+  ## Tenant isolation (AC-32.3.4)
+
+  Entries are keyed strictly by `tenant_id`, so tenant A's entry can never be
+  returned for tenant B, and rotating A's key never affects B's cached entry.
+
+  ## Negative caching
+
+  A tenant with NO settings row (`nil`) is read on every provider call too, so the
+  cache stores `nil` as a first-class value (distinct from a cache MISS). Because
+  `upsert_settings/2` is the ONLY creation path and it invalidates the entry, a
+  cached `nil` is busted the moment a tenant configures a key.
+  """
+
+  use GenServer
+
+  @table :loopctl_tenant_llm_settings
+
+  # --- Client API ---
+
+  @doc false
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc """
+  Reads the cached settings for `tenant_id` directly from ETS.
+
+  Returns `{:ok, value}` on a cache HIT — where `value` is the cached
+  `TenantLlmSettings.t()` OR `nil` (negative cache for a tenant with no row) — or
+  `:miss` when there is no entry (caller should load read-through and `put/2`).
+  """
+  @spec fetch(Ecto.UUID.t()) :: {:ok, term()} | :miss
+  def fetch(tenant_id) when is_binary(tenant_id) do
+    case :ets.lookup(@table, tenant_id) do
+      [{^tenant_id, value}] -> {:ok, value}
+      [] -> :miss
+    end
+  rescue
+    # The table only vanishes if the owner is (transiently) down mid-restart; a
+    # miss makes the caller fall back to the DB read-through — never a crash.
+    ArgumentError -> :miss
+  end
+
+  @doc """
+  Stores the resolved settings `value` (a `TenantLlmSettings.t()` or `nil`) for
+  `tenant_id` in ETS. Called from the caller process on a read-through miss.
+  """
+  @spec put(Ecto.UUID.t(), term()) :: :ok
+  def put(tenant_id, value) when is_binary(tenant_id) do
+    :ets.insert(@table, {tenant_id, value})
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
+  @doc """
+  Invalidates the cached entry for `tenant_id` (delete → next read repopulates
+  read-through). Called from the settings write path within the same call so the
+  next read reflects the change; never serves stale credentials.
+  """
+  @spec invalidate(Ecto.UUID.t()) :: :ok
+  def invalidate(tenant_id) when is_binary(tenant_id) do
+    :ets.delete(@table, tenant_id)
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
+  @doc """
+  Resets (invalidates) a single tenant's cache entry. Preferred over any global
+  wipe in async tests: the cache is tenant-scoped, so per-tenant reset never races
+  concurrent tests' entries. Alias of `invalidate/1`.
+  """
+  @spec reset(Ecto.UUID.t()) :: :ok
+  def reset(tenant_id) when is_binary(tenant_id), do: invalidate(tenant_id)
+
+  @doc false
+  def table_name, do: @table
+
+  # --- Server callbacks ---
+
+  @impl true
+  def init(_opts) do
+    # Create + own the table here (in the GenServer process) so it persists for the
+    # node's lifetime. Idempotent if it somehow already exists (mirrors
+    # ExportConcurrency's whereis guard).
+    table =
+      case :ets.whereis(@table) do
+        :undefined ->
+          :ets.new(@table, [
+            :set,
+            :public,
+            :named_table,
+            read_concurrency: true
+          ])
+
+        existing ->
+          existing
+      end
+
+    {:ok, %{table: table}}
+  end
+end

--- a/test/loopctl/llm/settings_cache_restart_test.exs
+++ b/test/loopctl/llm/settings_cache_restart_test.exs
@@ -1,0 +1,98 @@
+defmodule Loopctl.Llm.SettingsCacheRestartTest do
+  # async: false ON PURPOSE. These tests mutate NODE-GLOBAL supervised state — they
+  # delete the single shared `:named_table` and stop the app-supervised
+  # `Loopctl.Llm.SettingsCache` owner (a `:permanent` child of `Loopctl.Supervisor`)
+  # to exercise the real "owner died -> table destroyed -> recreated empty" restart
+  # path (AC-32.3.5). Running them serially (never concurrently with any async test)
+  # means (a) no concurrent test observes the momentarily-absent table, and (b) the
+  # 2 deliberate restarts here can't combine with another module's restart inside
+  # the root supervisor's shared restart-intensity window. Keep them OUT of the
+  # async `SettingsCacheTest` module.
+  use Loopctl.DataCase, async: false
+
+  alias Loopctl.Llm
+  alias Loopctl.Llm.SettingsCache
+  alias Loopctl.Llm.TenantLlmSettings
+
+  # AC-32.3.5: a GenServer restart yields an EMPTY table that repopulates read-through.
+  # These exercise the ACTUAL restart failure mode — the owner dying destroys the whole
+  # named ETS table and init/1 recreates it — plus the rescue clauses that keep fetch/
+  # put/invalidate safe while the table is momentarily absent mid-restart.
+  describe "restart / table-missing resilience (AC-32.3.5)" do
+    test "with the ETS table absent, fetch/put/invalidate/generation are safe (rescue clauses)" do
+      tenant = fixture(:tenant)
+
+      # Destroy the table out from under the owner, simulating the window after the
+      # owner has died and before init/1 has recreated it.
+      true = :ets.delete(SettingsCache.table_name())
+      assert :ets.whereis(SettingsCache.table_name()) == :undefined
+
+      # Every direct ETS op must rescue "table does not exist" to a safe default so a
+      # provider call never crashes mid-restart.
+      assert SettingsCache.fetch(tenant.id) == :miss
+      assert SettingsCache.generation(tenant.id) == 0
+      assert SettingsCache.put(tenant.id, %TenantLlmSettings{tenant_id: tenant.id}, 0) == :ok
+      assert SettingsCache.put(tenant.id, nil) == :ok
+      assert SettingsCache.invalidate(tenant.id) == :ok
+
+      # Restore the shared table by restarting its supervised owner (init recreates it).
+      restart_settings_cache!()
+
+      # The recreated table repopulates read-through with fresh, correct credentials.
+      {:ok, _} = Llm.upsert_settings(tenant.id, %{"api_key" => "sk-after-recreate"})
+      assert {:ok, %{api_key: "sk-after-recreate"}} = Llm.resolve(tenant.id, :extraction)
+    end
+
+    test "a GenServer restart yields an empty table that repopulates read-through" do
+      tenant = fixture(:tenant)
+      {:ok, _} = Llm.upsert_settings(tenant.id, %{"api_key" => "sk-survives-restart"})
+
+      # Warm the cache.
+      assert %TenantLlmSettings{} = Llm.get_settings(tenant.id)
+      assert {:ok, %TenantLlmSettings{}} = SettingsCache.fetch(tenant.id)
+
+      # Restart the owner: its ETS table is destroyed and init/1 recreates an EMPTY one
+      # (nothing is persisted — AC-32.3.5).
+      restart_settings_cache!()
+
+      # The previously-cached tenant is now a miss (empty table)...
+      assert SettingsCache.fetch(tenant.id) == :miss
+
+      # ...and a read repopulates read-through from the DB with the same decrypted key.
+      assert {:ok, %{api_key: "sk-survives-restart"}} = Llm.resolve(tenant.id, :extraction)
+      assert {:ok, %TenantLlmSettings{}} = SettingsCache.fetch(tenant.id)
+    end
+  end
+
+  # Stop the supervised SettingsCache owner and wait for the app supervisor to restart
+  # it (a :permanent child) and for init/1 to recreate the named table. This reproduces
+  # the real "owner died -> table destroyed -> recreated empty" restart path.
+  defp restart_settings_cache! do
+    pid = Process.whereis(SettingsCache)
+    ref = Process.monitor(pid)
+    :ok = GenServer.stop(SettingsCache, :normal)
+
+    receive do
+      {:DOWN, ^ref, :process, ^pid, _} -> :ok
+    after
+      2_000 -> flunk("SettingsCache owner did not stop")
+    end
+
+    wait_until(fn ->
+      is_pid(Process.whereis(SettingsCache)) and
+        :ets.whereis(SettingsCache.table_name()) != :undefined
+    end)
+  end
+
+  defp wait_until(fun, attempts \\ 200)
+  defp wait_until(_fun, 0), do: flunk("condition not met within the retry window")
+
+  defp wait_until(fun, attempts) do
+    if fun.() do
+      :ok
+    else
+      Process.sleep(5)
+      wait_until(fun, attempts - 1)
+    end
+  end
+end

--- a/test/loopctl/llm/settings_cache_test.exs
+++ b/test/loopctl/llm/settings_cache_test.exs
@@ -270,88 +270,79 @@ defmodule Loopctl.Llm.SettingsCacheTest do
     end
   end
 
-  # AC-32.3.5: a GenServer restart yields an EMPTY table that repopulates read-through.
-  # These exercise the ACTUAL restart failure mode — the owner dying destroys the whole
-  # named ETS table and init/1 recreates it — plus the rescue clauses that keep fetch/
-  # put/invalidate safe while the table is momentarily absent mid-restart. They restart
-  # the supervised owner; concurrent read-through consumers self-heal (a transient miss
-  # just reloads from the DB), and same-module tests never run concurrently, so nuking
-  # the shared table here is safe.
-  describe "restart / table-missing resilience (AC-32.3.5)" do
-    test "with the ETS table absent, fetch/put/invalidate/generation are safe (rescue clauses)" do
+  describe "bounded TTL backstop (crash-window / dropped-broadcast staleness cap)" do
+    test "an entry past its TTL is a MISS even when its generation still matches" do
       tenant = fixture(:tenant)
+      settings = fixture(:tenant_llm_settings, tenant_id: tenant.id, api_key: "sk-ttl")
+      gen = SettingsCache.generation(tenant.id)
 
-      # Destroy the table out from under the owner, simulating the window after the
-      # owner has died and before init/1 has recreated it.
-      true = :ets.delete(SettingsCache.table_name())
-      assert :ets.whereis(SettingsCache.table_name()) == :undefined
+      # Insert an entry directly with a generation that MATCHES current but an expiry
+      # already in the past (monotonic ms). This is the crash-window / dropped-broadcast
+      # shape: gen never got bumped, so only the TTL can reject it.
+      past = System.monotonic_time(:millisecond) - 1
+      true = :ets.insert(SettingsCache.table_name(), {tenant.id, settings, gen, past})
 
-      # Every direct ETS op must rescue "table does not exist" to a safe default so a
-      # provider call never crashes mid-restart.
-      assert SettingsCache.fetch(tenant.id) == :miss
-      assert SettingsCache.generation(tenant.id) == 0
-      assert SettingsCache.put(tenant.id, %TenantLlmSettings{tenant_id: tenant.id}, 0) == :ok
-      assert SettingsCache.put(tenant.id, nil) == :ok
-      assert SettingsCache.invalidate(tenant.id) == :ok
-
-      # Restore the shared table by restarting its supervised owner (init recreates it).
-      restart_settings_cache!()
-
-      # The recreated table repopulates read-through with fresh, correct credentials.
-      {:ok, _} = Llm.upsert_settings(tenant.id, %{"api_key" => "sk-after-recreate"})
-      assert {:ok, %{api_key: "sk-after-recreate"}} = Llm.resolve(tenant.id, :extraction)
-    end
-
-    test "a GenServer restart yields an empty table that repopulates read-through" do
-      tenant = fixture(:tenant)
-      {:ok, _} = Llm.upsert_settings(tenant.id, %{"api_key" => "sk-survives-restart"})
-
-      # Warm the cache.
-      assert %TenantLlmSettings{} = Llm.get_settings(tenant.id)
-      assert {:ok, %TenantLlmSettings{}} = SettingsCache.fetch(tenant.id)
-
-      # Restart the owner: its ETS table is destroyed and init/1 recreates an EMPTY one
-      # (nothing is persisted — AC-32.3.5).
-      restart_settings_cache!()
-
-      # The previously-cached tenant is now a miss (empty table)...
       assert SettingsCache.fetch(tenant.id) == :miss
 
-      # ...and a read repopulates read-through from the DB with the same decrypted key.
-      assert {:ok, %{api_key: "sk-survives-restart"}} = Llm.resolve(tenant.id, :extraction)
+      # A fresh-expiry entry with the same matching generation IS served.
+      :ok = SettingsCache.put(tenant.id, settings, gen)
       assert {:ok, %TenantLlmSettings{}} = SettingsCache.fetch(tenant.id)
     end
-  end
 
-  # Stop the supervised SettingsCache owner and wait for the app supervisor to restart
-  # it (a :permanent child) and for init/1 to recreate the named table. This reproduces
-  # the real "owner died -> table destroyed -> recreated empty" restart path.
-  defp restart_settings_cache! do
-    pid = Process.whereis(SettingsCache)
-    ref = Process.monitor(pid)
-    :ok = GenServer.stop(SettingsCache, :normal)
+    test "the periodic sweep actively evicts an expired entry (bounds secret residency)" do
+      tenant = fixture(:tenant)
+      settings = fixture(:tenant_llm_settings, tenant_id: tenant.id, api_key: "sk-sweep")
+      gen = SettingsCache.generation(tenant.id)
 
-    receive do
-      {:DOWN, ^ref, :process, ^pid, _} -> :ok
-    after
-      2_000 -> flunk("SettingsCache owner did not stop")
-    end
+      past = System.monotonic_time(:millisecond) - 1
+      true = :ets.insert(SettingsCache.table_name(), {tenant.id, settings, gen, past})
 
-    wait_until(fn ->
-      is_pid(Process.whereis(SettingsCache)) and
-        :ets.whereis(SettingsCache.table_name()) != :undefined
-    end)
-  end
+      # Trigger the sweep and sync on the owner so the send is processed before we look.
+      send(Process.whereis(SettingsCache), :sweep)
+      _ = :sys.get_state(SettingsCache)
 
-  defp wait_until(fun, attempts \\ 200)
-  defp wait_until(_fun, 0), do: flunk("condition not met within the retry window")
-
-  defp wait_until(fun, attempts) do
-    if fun.() do
-      :ok
-    else
-      Process.sleep(5)
-      wait_until(fun, attempts - 1)
+      assert :ets.lookup(SettingsCache.table_name(), tenant.id) == []
     end
   end
+
+  describe "cross-node invalidation" do
+    test "invalidate_cluster busts the local entry and bumps the generation" do
+      tenant = fixture(:tenant)
+      settings = fixture(:tenant_llm_settings, tenant_id: tenant.id, api_key: "sk-cluster")
+      :ok = SettingsCache.put(tenant.id, settings)
+      gen0 = SettingsCache.generation(tenant.id)
+
+      assert {:ok, _} = SettingsCache.fetch(tenant.id)
+
+      :ok = SettingsCache.invalidate_cluster(tenant.id)
+
+      assert SettingsCache.fetch(tenant.id) == :miss
+      assert SettingsCache.generation(tenant.id) > gen0
+    end
+
+    test "a peer node's invalidation broadcast busts this node's entry (owner subscription)" do
+      tenant = fixture(:tenant)
+      settings = fixture(:tenant_llm_settings, tenant_id: tenant.id, api_key: "sk-broadcast")
+      :ok = SettingsCache.put(tenant.id, settings)
+      assert {:ok, _} = SettingsCache.fetch(tenant.id)
+
+      # Simulate a PEER node broadcasting the invalidation onto the shared topic. The
+      # owner is subscribed, so its handle_info busts the node-local entry.
+      Phoenix.PubSub.broadcast(
+        Loopctl.PubSub,
+        "llm:settings_cache:invalidate",
+        {:invalidate, tenant.id}
+      )
+
+      # Sync on the owner so the broadcast is processed before we assert.
+      _ = :sys.get_state(SettingsCache)
+
+      assert SettingsCache.fetch(tenant.id) == :miss
+    end
+  end
+
+  # NOTE: the restart / table-missing resilience tests (AC-32.3.5) live in
+  # `Loopctl.Llm.SettingsCacheRestartTest` (async: false). They delete the shared
+  # named table and stop the app-supervised owner — node-global mutations that must
+  # not run concurrently with these async tests.
 end

--- a/test/loopctl/llm/settings_cache_test.exs
+++ b/test/loopctl/llm/settings_cache_test.exs
@@ -49,6 +49,38 @@ defmodule Loopctl.Llm.SettingsCacheTest do
       assert SettingsCache.fetch(tenant.id) == :miss
     end
 
+    test "invalidate BUMPS the tenant's generation (monotonic authority)" do
+      tenant = fixture(:tenant)
+      gen0 = SettingsCache.generation(tenant.id)
+
+      :ok = SettingsCache.invalidate(tenant.id)
+      gen1 = SettingsCache.generation(tenant.id)
+      assert gen1 > gen0
+
+      :ok = SettingsCache.invalidate(tenant.id)
+      assert SettingsCache.generation(tenant.id) > gen1
+    end
+
+    test "a put stamped with a generation older than the current one is a MISS (stale repopulation rejected)" do
+      tenant = fixture(:tenant)
+      settings = fixture(:tenant_llm_settings, tenant_id: tenant.id, api_key: "sk-stale-stamp")
+
+      # Capture a generation, then an invalidation bumps it past that capture.
+      stale_gen = SettingsCache.generation(tenant.id)
+      :ok = SettingsCache.invalidate(tenant.id)
+      assert SettingsCache.generation(tenant.id) > stale_gen
+
+      # A LATE read-through repopulation stamped with the pre-invalidation generation
+      # (the classic race: reader snapshotted before the writer's invalidate) is
+      # inserted but must NEVER be trusted — fetch rejects it as stale.
+      :ok = SettingsCache.put(tenant.id, settings, stale_gen)
+      assert SettingsCache.fetch(tenant.id) == :miss
+
+      # A put stamped with the CURRENT generation IS served (fresh repopulation).
+      :ok = SettingsCache.put(tenant.id, settings, SettingsCache.generation(tenant.id))
+      assert {:ok, %TenantLlmSettings{}} = SettingsCache.fetch(tenant.id)
+    end
+
     test "reset/1 is an alias for invalidate/1" do
       tenant = fixture(:tenant)
       :ok = SettingsCache.put(tenant.id, nil)
@@ -132,6 +164,34 @@ defmodule Loopctl.Llm.SettingsCacheTest do
     end
   end
 
+  describe "read-through repopulation race — never serve stale (AC-32.3.3)" do
+    test "a rotation that commits during a slow reader's DB load is NEVER masked by the reader's stale repopulation" do
+      tenant = fixture(:tenant)
+      {:ok, _} = Llm.upsert_settings(tenant.id, %{"api_key" => "sk-original-key"})
+
+      # Reader R begins a read-through: it captures the cache generation BEFORE its
+      # (here, simulated-slow) DB load — exactly as Llm.get_settings/1 does.
+      captured_generation = SettingsCache.generation(tenant.id)
+
+      # Meanwhile a key rotation commits AND invalidates the cache (bumping the
+      # generation). R's in-flight SELECT snapshotted the OLD row.
+      {:ok, _} = Llm.upsert_settings(tenant.id, %{"api_key" => "sk-rotated-key"})
+
+      # R finally repopulates with the stale struct it snapshotted, stamped with the
+      # generation it captured before the rotation.
+      stale = %TenantLlmSettings{tenant_id: tenant.id, api_key: "sk-original-key"}
+      :ok = SettingsCache.put(tenant.id, stale, captured_generation)
+
+      # The stale repopulation must NOT be served — the entry's stamp is behind the
+      # post-rotation generation, so fetch rejects it.
+      assert SettingsCache.fetch(tenant.id) == :miss
+
+      # And the next resolve reloads the ROTATED credentials read-through — never the
+      # revoked original key (the invariant AC-32.3.3 protects: never serve stale).
+      assert {:ok, %{api_key: "sk-rotated-key"}} = Llm.resolve(tenant.id, :extraction)
+    end
+  end
+
   describe "tenant isolation (AC-32.3.4 / TC-32.3.3)" do
     test "two tenants both cached; rotating A leaves B unchanged and A returns rotated" do
       a = fixture(:tenant)
@@ -196,6 +256,102 @@ defmodule Loopctl.Llm.SettingsCacheTest do
 
       refute log =~ secret
       refute log =~ "sk-should-never-appear-in-logs-9999-rotated"
+    end
+  end
+
+  describe "table options (AC-32.3.1)" do
+    test "the ETS table is a :public, :named_table, :set with read_concurrency" do
+      table = SettingsCache.table_name()
+
+      assert :ets.info(table, :named_table) == true
+      assert :ets.info(table, :protection) == :public
+      assert :ets.info(table, :type) == :set
+      assert :ets.info(table, :read_concurrency) == true
+    end
+  end
+
+  # AC-32.3.5: a GenServer restart yields an EMPTY table that repopulates read-through.
+  # These exercise the ACTUAL restart failure mode — the owner dying destroys the whole
+  # named ETS table and init/1 recreates it — plus the rescue clauses that keep fetch/
+  # put/invalidate safe while the table is momentarily absent mid-restart. They restart
+  # the supervised owner; concurrent read-through consumers self-heal (a transient miss
+  # just reloads from the DB), and same-module tests never run concurrently, so nuking
+  # the shared table here is safe.
+  describe "restart / table-missing resilience (AC-32.3.5)" do
+    test "with the ETS table absent, fetch/put/invalidate/generation are safe (rescue clauses)" do
+      tenant = fixture(:tenant)
+
+      # Destroy the table out from under the owner, simulating the window after the
+      # owner has died and before init/1 has recreated it.
+      true = :ets.delete(SettingsCache.table_name())
+      assert :ets.whereis(SettingsCache.table_name()) == :undefined
+
+      # Every direct ETS op must rescue "table does not exist" to a safe default so a
+      # provider call never crashes mid-restart.
+      assert SettingsCache.fetch(tenant.id) == :miss
+      assert SettingsCache.generation(tenant.id) == 0
+      assert SettingsCache.put(tenant.id, %TenantLlmSettings{tenant_id: tenant.id}, 0) == :ok
+      assert SettingsCache.put(tenant.id, nil) == :ok
+      assert SettingsCache.invalidate(tenant.id) == :ok
+
+      # Restore the shared table by restarting its supervised owner (init recreates it).
+      restart_settings_cache!()
+
+      # The recreated table repopulates read-through with fresh, correct credentials.
+      {:ok, _} = Llm.upsert_settings(tenant.id, %{"api_key" => "sk-after-recreate"})
+      assert {:ok, %{api_key: "sk-after-recreate"}} = Llm.resolve(tenant.id, :extraction)
+    end
+
+    test "a GenServer restart yields an empty table that repopulates read-through" do
+      tenant = fixture(:tenant)
+      {:ok, _} = Llm.upsert_settings(tenant.id, %{"api_key" => "sk-survives-restart"})
+
+      # Warm the cache.
+      assert %TenantLlmSettings{} = Llm.get_settings(tenant.id)
+      assert {:ok, %TenantLlmSettings{}} = SettingsCache.fetch(tenant.id)
+
+      # Restart the owner: its ETS table is destroyed and init/1 recreates an EMPTY one
+      # (nothing is persisted — AC-32.3.5).
+      restart_settings_cache!()
+
+      # The previously-cached tenant is now a miss (empty table)...
+      assert SettingsCache.fetch(tenant.id) == :miss
+
+      # ...and a read repopulates read-through from the DB with the same decrypted key.
+      assert {:ok, %{api_key: "sk-survives-restart"}} = Llm.resolve(tenant.id, :extraction)
+      assert {:ok, %TenantLlmSettings{}} = SettingsCache.fetch(tenant.id)
+    end
+  end
+
+  # Stop the supervised SettingsCache owner and wait for the app supervisor to restart
+  # it (a :permanent child) and for init/1 to recreate the named table. This reproduces
+  # the real "owner died -> table destroyed -> recreated empty" restart path.
+  defp restart_settings_cache! do
+    pid = Process.whereis(SettingsCache)
+    ref = Process.monitor(pid)
+    :ok = GenServer.stop(SettingsCache, :normal)
+
+    receive do
+      {:DOWN, ^ref, :process, ^pid, _} -> :ok
+    after
+      2_000 -> flunk("SettingsCache owner did not stop")
+    end
+
+    wait_until(fn ->
+      is_pid(Process.whereis(SettingsCache)) and
+        :ets.whereis(SettingsCache.table_name()) != :undefined
+    end)
+  end
+
+  defp wait_until(fun, attempts \\ 200)
+  defp wait_until(_fun, 0), do: flunk("condition not met within the retry window")
+
+  defp wait_until(fun, attempts) do
+    if fun.() do
+      :ok
+    else
+      Process.sleep(5)
+      wait_until(fun, attempts - 1)
     end
   end
 end

--- a/test/loopctl/llm/settings_cache_test.exs
+++ b/test/loopctl/llm/settings_cache_test.exs
@@ -1,0 +1,201 @@
+defmodule Loopctl.Llm.SettingsCacheTest do
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Llm
+  alias Loopctl.Llm.SettingsCache
+  alias Loopctl.Llm.TenantLlmSettings
+
+  import Ecto.Query
+  import ExUnit.CaptureLog
+
+  # The ETS owner runs as part of the app supervision tree in the test env, so the
+  # table already exists — no start_supervised needed (mirrors EmbeddingCircuitBreaker
+  # tests). async: true is safe because every test uses fresh tenant fixtures = unique
+  # tenant_id keys, so the shared named table is never contended across tests.
+
+  describe "fetch/2 + put/2 + invalidate/1 (ETS unit)" do
+    test "fetch on an unknown tenant is a miss" do
+      tenant = fixture(:tenant)
+      assert SettingsCache.fetch(tenant.id) == :miss
+    end
+
+    test "put then fetch returns the stored struct as a hit" do
+      tenant = fixture(:tenant)
+      settings = fixture(:tenant_llm_settings, tenant_id: tenant.id, api_key: "sk-cache-unit")
+
+      :ok = SettingsCache.put(tenant.id, settings)
+
+      assert {:ok, %TenantLlmSettings{} = cached} = SettingsCache.fetch(tenant.id)
+      assert cached.id == settings.id
+    end
+
+    test "negative caching: a stored nil is a HIT (distinct from a miss)" do
+      tenant = fixture(:tenant)
+
+      :ok = SettingsCache.put(tenant.id, nil)
+
+      assert SettingsCache.fetch(tenant.id) == {:ok, nil}
+    end
+
+    test "invalidate deletes the entry (back to a miss)" do
+      tenant = fixture(:tenant)
+      settings = fixture(:tenant_llm_settings, tenant_id: tenant.id, api_key: "sk-inv")
+
+      :ok = SettingsCache.put(tenant.id, settings)
+      assert {:ok, _} = SettingsCache.fetch(tenant.id)
+
+      :ok = SettingsCache.invalidate(tenant.id)
+      assert SettingsCache.fetch(tenant.id) == :miss
+    end
+
+    test "reset/1 is an alias for invalidate/1" do
+      tenant = fixture(:tenant)
+      :ok = SettingsCache.put(tenant.id, nil)
+      assert {:ok, nil} = SettingsCache.fetch(tenant.id)
+
+      :ok = SettingsCache.reset(tenant.id)
+      assert SettingsCache.fetch(tenant.id) == :miss
+    end
+  end
+
+  describe "get_settings/1 read-through cache" do
+    # TC-32.3.1
+    test "second get is served from ETS: a direct DB mutation is NOT seen until invalidation" do
+      tenant = fixture(:tenant)
+
+      {:ok, _} =
+        Llm.upsert_settings(tenant.id, %{
+          "api_key" => "sk-readthrough-1234",
+          "extraction_model" => "model-original"
+        })
+
+      # First read populates the cache read-through.
+      assert %TenantLlmSettings{extraction_model: "model-original"} = Llm.get_settings(tenant.id)
+
+      # Mutate the row DIRECTLY in the DB (bypassing the write path / cache bust).
+      {1, _} =
+        from(s in TenantLlmSettings, where: s.tenant_id == ^tenant.id)
+        |> AdminRepo.update_all(set: [extraction_model: "model-mutated-directly"])
+
+      # Still the cached value — proves the 2nd read hit ETS, not the DB.
+      assert %TenantLlmSettings{extraction_model: "model-original"} = Llm.get_settings(tenant.id)
+
+      # After invalidation the next read repopulates from the DB and sees the mutation.
+      :ok = SettingsCache.invalidate(tenant.id)
+
+      assert %TenantLlmSettings{extraction_model: "model-mutated-directly"} =
+               Llm.get_settings(tenant.id)
+    end
+
+    test "negative cache: nil for a tenant with no row is served read-through, busted on upsert" do
+      tenant = fixture(:tenant)
+
+      # No row yet -> nil, cached negatively.
+      assert Llm.get_settings(tenant.id) == nil
+      assert SettingsCache.fetch(tenant.id) == {:ok, nil}
+
+      # The sole creation path invalidates the nil entry.
+      {:ok, _} = Llm.upsert_settings(tenant.id, %{"api_key" => "sk-created-now"})
+
+      assert %TenantLlmSettings{} = Llm.get_settings(tenant.id)
+      assert {:ok, %{api_key: "sk-created-now"}} = Llm.resolve(tenant.id, :extraction)
+    end
+  end
+
+  describe "upsert_settings/2 cache invalidation (TC-32.3.2)" do
+    test "rotate-then-read returns the NEW settings, never stale" do
+      tenant = fixture(:tenant)
+
+      {:ok, _} =
+        Llm.upsert_settings(tenant.id, %{
+          "api_key" => "sk-old-key-aaaa",
+          "extraction_model" => "model-old"
+        })
+
+      # Cache it.
+      assert {:ok, %{api_key: "sk-old-key-aaaa", model: "model-old"}} =
+               Llm.resolve(tenant.id, :extraction)
+
+      # Rotate via the write path.
+      {:ok, _} =
+        Llm.upsert_settings(tenant.id, %{
+          "api_key" => "sk-new-key-bbbb",
+          "extraction_model" => "model-new"
+        })
+
+      # Next read reflects the rotation — not the stale cached credentials.
+      assert %TenantLlmSettings{extraction_model: "model-new"} = Llm.get_settings(tenant.id)
+
+      assert {:ok, %{api_key: "sk-new-key-bbbb", model: "model-new"}} =
+               Llm.resolve(tenant.id, :extraction)
+    end
+  end
+
+  describe "tenant isolation (AC-32.3.4 / TC-32.3.3)" do
+    test "two tenants both cached; rotating A leaves B unchanged and A returns rotated" do
+      a = fixture(:tenant)
+      b = fixture(:tenant)
+
+      {:ok, _} = Llm.upsert_settings(a.id, %{"api_key" => "sk-A-original"})
+      {:ok, _} = Llm.upsert_settings(b.id, %{"api_key" => "sk-B-original"})
+
+      # Cache both.
+      assert {:ok, %{api_key: "sk-A-original"}} = Llm.resolve(a.id, :extraction)
+      assert {:ok, %{api_key: "sk-B-original"}} = Llm.resolve(b.id, :extraction)
+
+      # Rotate ONLY A.
+      {:ok, _} = Llm.upsert_settings(a.id, %{"api_key" => "sk-A-rotated"})
+
+      # A reflects the rotation; B's cached entry is untouched.
+      assert {:ok, %{api_key: "sk-A-rotated"}} = Llm.resolve(a.id, :extraction)
+      assert {:ok, %{api_key: "sk-B-original"}} = Llm.resolve(b.id, :extraction)
+    end
+
+    test "A's cache entry is never returned for B (keys are tenant_id-scoped)" do
+      a = fixture(:tenant)
+      b = fixture(:tenant)
+
+      settings_a = fixture(:tenant_llm_settings, tenant_id: a.id, api_key: "sk-A")
+      :ok = SettingsCache.put(a.id, settings_a)
+
+      # B has nothing cached and no row -> nil, never A's struct.
+      assert SettingsCache.fetch(b.id) == :miss
+      assert Llm.get_settings(b.id) == nil
+    end
+  end
+
+  describe "secret safety + cold start (AC-32.3.5)" do
+    test "a reset yields an empty entry that repopulates read-through" do
+      tenant = fixture(:tenant)
+      {:ok, _} = Llm.upsert_settings(tenant.id, %{"api_key" => "sk-cold-start"})
+
+      assert %TenantLlmSettings{} = Llm.get_settings(tenant.id)
+      assert {:ok, _} = SettingsCache.fetch(tenant.id)
+
+      # Simulate a cold start for this tenant: empty entry.
+      :ok = SettingsCache.reset(tenant.id)
+      assert SettingsCache.fetch(tenant.id) == :miss
+
+      # Repopulates read-through with the same decrypted key.
+      assert {:ok, %{api_key: "sk-cold-start"}} = Llm.resolve(tenant.id, :extraction)
+      assert {:ok, %TenantLlmSettings{}} = SettingsCache.fetch(tenant.id)
+    end
+
+    test "the decrypted key is never logged on a get or a rotate" do
+      tenant = fixture(:tenant)
+      secret = "sk-should-never-appear-in-logs-9999"
+
+      log =
+        capture_log(fn ->
+          {:ok, _} = Llm.upsert_settings(tenant.id, %{"api_key" => secret})
+          _ = Llm.get_settings(tenant.id)
+          {:ok, _} = Llm.upsert_settings(tenant.id, %{"api_key" => secret <> "-rotated"})
+          _ = Llm.get_settings(tenant.id)
+        end)
+
+      refute log =~ secret
+      refute log =~ "sk-should-never-appear-in-logs-9999-rotated"
+    end
+  end
+end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -20,6 +20,7 @@ defmodule Loopctl.Fixtures do
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.ArticleAccessEvent
   alias Loopctl.Knowledge.ArticleLink
+  alias Loopctl.Llm.SettingsCache
   alias Loopctl.Llm.TenantLlmSettings
   alias Loopctl.Llm.UsageEvent, as: LlmUsageEvent
   alias Loopctl.Memory.Memory
@@ -1298,11 +1299,21 @@ defmodule Loopctl.Fixtures do
     data = build(:tenant_llm_settings, Map.delete(attrs, :tenant_id))
     api_key = Map.get(data, :api_key)
 
-    %TenantLlmSettings{tenant_id: tenant_id}
-    |> TenantLlmSettings.models_changeset(data)
-    |> TenantLlmSettings.put_api_key(api_key)
-    |> Ecto.Changeset.put_change(:tenant_id, tenant_id)
-    |> AdminRepo.insert!()
+    settings =
+      %TenantLlmSettings{tenant_id: tenant_id}
+      |> TenantLlmSettings.models_changeset(data)
+      |> TenantLlmSettings.put_api_key(api_key)
+      |> Ecto.Changeset.put_change(:tenant_id, tenant_id)
+      |> AdminRepo.insert!()
+
+    # This fixture inserts DIRECTLY (not via `Llm.upsert_settings/2`), so it bypasses
+    # the cache-busting write path. `Llm.get_settings/1` negative-caches `nil`, so a
+    # test that read this tenant's settings BEFORE inserting here would otherwise keep
+    # serving the stale cached `nil`. Bust the node-local entry so the next read
+    # reflects the freshly-inserted row.
+    SettingsCache.invalidate(tenant_id)
+
+    settings
   end
 
   # Inserts an llm_usage_events row (auto-creating a tenant if needed).


### PR DESCRIPTION
## US-32.3 — ETS-cache resolved tenant LLM settings, busted on set_llm_config

Every embedding/completion provider call re-read the tenant's `tenant_llm_settings`
row and Cloak-decrypted the BYO API keys. This adds a supervised ETS read-through
cache of the resolved+decrypted settings, keyed by `tenant_id`, invalidated on the
settings write path — converting a per-call DB+decrypt into a per-change one, never
serving stale credentials.

### Changes
- **`Loopctl.Llm.SettingsCache`** (new) — GenServer that owns a `:public, :named_table,
  read_concurrency: true` ETS table (`:loopctl_tenant_llm_settings`), mirroring
  `EmbeddingCircuitBreaker`/`ExportConcurrency`. Public `fetch/1`, `put/2`,
  `invalidate/1`, `reset/1` go direct to ETS from caller processes — the GenServer is
  only the stable owner, never on the hot path. Added to the supervision tree after the
  Repos, alongside the sibling ETS owners.
- **`Loopctl.Llm.get_settings/1`** — now read-through (signature/return shape unchanged).
  A private uncached `load_settings/1` backs both the miss path and the write path.
- **`Loopctl.Llm.upsert_settings/2`** — fetches `existing` uncached (so a cached/negative
  entry never seeds the insert_or_update changeset) and invalidates the tenant's entry
  after commit, so the next read reflects the change.
- **Negative caching** — `nil` for a no-key tenant is cached (read on every provider
  call too); the sole creation path busts it.

### Security (AC-32.3.5)
Decrypted secrets live only in ETS memory — never logged, telemetry-tagged, or
persisted. A cold start / GenServer restart yields an empty table that repopulates
read-through. Struct fields are `redact: true`. A `CaptureLog` test asserts the key is
never logged on get/rotate.

### Acceptance criteria
- AC-32.3.1 supervised ETS owner GenServer — done
- AC-32.3.2 read-through, signature unchanged — done
- AC-32.3.3 write path invalidates within same call (rotate-then-read test) — done
- AC-32.3.4 tenant isolation (A's rotation never affects B; A-not-returned-for-B tests) — done
- AC-32.3.5 secrets only in ETS, cold start empty, no logging — done

### Tests
`test/loopctl/llm/settings_cache_test.exs` — ETS unit ops, read-through
hit-avoids-DB (direct-mutation proof), negative cache, rotate-then-read, tenant
isolation, cold-start repopulation, secret-safety. Full `mix precommit` green
(compile --warnings-as-errors, format, credo --strict, dialyzer, 4210 tests 0 failures).

