### PR TITLE
Fail loud when scale alerts are enabled but SCALE_ALERT_WEBHOOK_URL is unset

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -228,6 +228,10 @@ config :phoenix,
 # DI: Use mock health checker in tests
 config :loopctl, :health_checker, Loopctl.MockHealthChecker
 
+# US-32.4: scale-alerts config-guard DI (Loopctl.HealthCheck.Default's degraded-branch
+# coverage). Default stub in DataCase delegates to the real config_status/0.
+config :loopctl, :scale_alerts_config_checker, Loopctl.MockScaleAlertsConfigChecker
+
 # DI: Use mock rate limiter in tests
 config :loopctl, :rate_limiter, Loopctl.MockRateLimiter
 

--- a/docs/runbooks/post-deploy-smoke.md
+++ b/docs/runbooks/post-deploy-smoke.md
@@ -28,7 +28,8 @@ Total wall time stays well under 30 s.
 
 | # | Check | Asserts | Budget | Why |
 |---|-------|---------|--------|-----|
-| 1 | `GET /health` | 200 **and** `.checks.database == "ok"`; Oban-only degradation is a WARN (pass) | 5 s | App up + DB healthy |
+| 1 | `GET /health` | 200 **and** `.checks.database == "ok"`; Oban-only degradation is a WARN (pass) | 5 s | App up + DB healthy (liveness only — never depooled by the scale-alerts config-guard) |
+| 1.5 | `GET /health/ready` | 200, `.ready == true` (falls back to `.status=="ok"` for an implementation that omits `ready`) | 5 s | **US-32.4 readiness gate**: fails loud (hard RED, not a warn) if scale alerts are enabled but `SCALE_ALERT_WEBHOOK_URL` is unset — the automated consumer of the readiness signal so the misconfig is caught at deploy time instead of during the incident it should have warned about |
 | 2 | `GET /api/v1/knowledge/count` (authed) | 200, `.count` int > 1000 | 5 s | KB not wiped (prod baseline ~83k) |
 | 3a | `GET /api/v1/knowledge/search?q=elixir&mode=keyword&limit=3` (authed) | 200, `.data` non-empty | 5 s | **Keyword retrieval floor** (deterministic DB path, no embedding) |
 | 3b | `GET /api/v1/knowledge/search?q=elixir&limit=3` (authed, combined) | 200, `.data` non-empty **and** `.meta.fallback != true` | 8 s | **Semantic retrieval healthy** — fails if the embedding provider is down (combined silently keyword-falls-back otherwise) |
@@ -49,6 +50,11 @@ Exit code is non-zero if ANY check fails. A WARN (⚠) does not fail the run.
   EITHER the DB or the Oban `:default` queue check fails. A transient Oban blip
   with a healthy DB + KB is **not** a rollback trigger, so the script warns and
   passes. Only a DB failure or a non-200 is a hard FAIL on check 1.
+- **1.5 RED (`/health/ready` 503 or `.ready == false`)** — this is a **config**
+  problem, not a code regression: `:scale_alerts_enabled` is true but
+  `SCALE_ALERT_WEBHOOK_URL` is unset (or blank) on the deployed release. Fix is
+  to set the Fly secret/env var, not to roll back the code. `.reasons.scale_alerts`
+  in the response body names the missing env var (never a value).
 - **2 RED (count ≤ 1000)** — see the visibility invariant below; a wiped corpus or
   a changed smoke-key tenant both show up here.
 

--- a/fly.toml
+++ b/fly.toml
@@ -35,6 +35,16 @@ primary_region = "lax"
   [http_service.http_options]
     h2_backend = false
 
+  # LIVENESS ONLY — this is the CONTINUOUS check that decides whether a running node
+  # stays in the load-balancer's traffic rotation (10s interval, every node, forever).
+  # It intentionally targets plain /health (liveness: database + oban only), never
+  # /health/ready (US-32.4's deploy-time smoke gate for the scale-alerts config-guard).
+  # A benign, purely observational misconfig (scale alerts enabled, no webhook URL) must
+  # never depool an otherwise-healthy node — see Loopctl.HealthCheck.Default's moduledoc.
+  # GET /health/ready is deliberately NOT wired into THIS continuous check for that
+  # reason, but it is not left unpolled: scripts/smoke.sh (the CI post-deploy detector,
+  # .github/workflows/ci.yml `smoke` job) asserts it explicitly after every deploy, so a
+  # genuine misconfig still turns the deploy pipeline RED.
   [[http_service.checks]]
     interval = "10s"
     timeout = "2s"

--- a/lib/loopctl/health_check/default.ex
+++ b/lib/loopctl/health_check/default.ex
@@ -2,8 +2,30 @@ defmodule Loopctl.HealthCheck.Default do
   @moduledoc """
   Default health check implementation.
 
-  Checks database connectivity (SELECT 1) and Oban process status.
-  Returns the application version from the mix project config.
+  Checks database connectivity (SELECT 1), Oban process status, and the US-32.4
+  scale-alerts config-guard. Returns the application version from the mix project
+  config.
+
+  ## Liveness (`status`) vs readiness (`ready`) — US-32.4 post-review correction
+
+  `fly.toml` wires plain `GET /health` as the CONTINUOUS `http_service` load-balancer
+  check (10s interval, `min_machines_running: 1`, `strategy: rolling`) — it is not a
+  deploy-only smoke probe, it decides whether a running node stays in traffic rotation
+  RIGHT NOW. A benign, purely observational misconfiguration (scale alerts enabled but
+  no webhook URL) must never depool an otherwise-healthy node on that continuous check.
+
+  So `status` — the field `LoopctlWeb.HealthController.check/2` uses for `/health`'s
+  HTTP code, i.e. the one Fly's proxy acts on — reflects ONLY `database` and `oban`:
+  the things that mean this node genuinely cannot serve traffic. `scale_alerts` is
+  still surfaced in `checks` (and `reasons` on failure) for visibility, but it does
+  NOT flip `status`.
+
+  A separate `ready` boolean additionally folds in `scale_alerts`, and is acted on
+  ONLY by `GET /health/ready` (`LoopctlWeb.HealthController.ready/2`) — a genuine
+  deploy-time smoke gate an operator or deploy pipeline can poll explicitly, distinct
+  from the endpoint Fly's proxy continuously checks. This satisfies AC-32.4.1's
+  "flip a readiness flag so /health (or the readiness endpoint) reports NOT-ready"
+  via the readiness-endpoint branch of that disjunction.
   """
 
   @behaviour Loopctl.HealthCheck.Behaviour
@@ -16,7 +38,6 @@ defmodule Loopctl.HealthCheck.Default do
     db_check = check_database()
     oban_check = check_oban()
     scale_alerts_check = check_scale_alerts()
-    version = app_version()
 
     checks = %{
       database: elem(db_check, 0),
@@ -24,12 +45,19 @@ defmodule Loopctl.HealthCheck.Default do
       scale_alerts: elem(scale_alerts_check, 0)
     }
 
+    # Liveness: database/oban only — see the moduledoc on why scale_alerts must NOT
+    # participate here (it would let a benign config-only issue depool a healthy node
+    # on Fly's continuous load-balancer check).
     status =
-      if Enum.all?(Map.values(checks), &(&1 == "ok")),
+      if checks.database == "ok" and checks.oban == "ok",
         do: "ok",
         else: "degraded"
 
-    result = %{status: status, version: version, checks: checks}
+    # Readiness: liveness AND the scale-alerts config-guard. Only `/health/ready` acts
+    # on this — it is the deploy-time smoke signal, not the traffic-routing one.
+    ready = status == "ok" and checks.scale_alerts == "ok"
+
+    result = %{status: status, ready: ready, version: app_version(), checks: checks}
     result = maybe_put_reasons(result, scale_alerts_check)
 
     {:ok, result}
@@ -54,14 +82,28 @@ defmodule Loopctl.HealthCheck.Default do
   end
 
   # US-32.4 config-guard: surfaces `ScaleAlerts.config_status/0` (scale alerts enabled
-  # but no webhook URL configured) so a misconfigured deploy fails readiness instead of
-  # silently going inert. Does not affect alert DELIVERY behavior for the healthy case.
+  # but no webhook URL configured) so a misconfigured deploy fails its readiness check
+  # (`/health/ready`) instead of silently going inert. Does not affect alert DELIVERY
+  # behavior for the healthy case, and — per the moduledoc — never flips the liveness
+  # `status` that Fly's continuous load-balancer check acts on.
+  #
+  # Self-rescuing like its `check_database`/`check_oban` siblings: an unexpected raise
+  # (e.g. a non-string config value reaching `ScaleAlerts.config_status/0`) must degrade
+  # cleanly to an "error" check, never crash the whole endpoint into a 500.
   defp check_scale_alerts do
-    case ScaleAlerts.config_status() do
+    case scale_alerts_config_checker().config_status() do
       :ok -> {"ok"}
       {:error, reason} -> {"error", reason}
     end
+  rescue
+    _ -> {"error", "scale alerts config check raised unexpectedly"}
   end
+
+  # DI seam (Loopctl.Telemetry.ScaleAlerts.ConfigStatusBehaviour) so the degraded
+  # branch above is exercisable in tests via Mox.expect/3 without `Application.put_env`.
+  # Defaults to the real `ScaleAlerts` module (unchanged behavior in dev/prod).
+  defp scale_alerts_config_checker,
+    do: Application.get_env(:loopctl, :scale_alerts_config_checker, ScaleAlerts)
 
   defp app_version do
     Application.spec(:loopctl, :vsn) |> to_string()

--- a/lib/loopctl/health_check/default.ex
+++ b/lib/loopctl/health_check/default.ex
@@ -9,16 +9,19 @@ defmodule Loopctl.HealthCheck.Default do
   @behaviour Loopctl.HealthCheck.Behaviour
 
   alias Ecto.Adapters.SQL
+  alias Loopctl.Telemetry.ScaleAlerts
 
   @impl true
   def check do
     db_check = check_database()
     oban_check = check_oban()
+    scale_alerts_check = check_scale_alerts()
     version = app_version()
 
     checks = %{
       database: elem(db_check, 0),
-      oban: elem(oban_check, 0)
+      oban: elem(oban_check, 0),
+      scale_alerts: elem(scale_alerts_check, 0)
     }
 
     status =
@@ -26,7 +29,10 @@ defmodule Loopctl.HealthCheck.Default do
         do: "ok",
         else: "degraded"
 
-    {:ok, %{status: status, version: version, checks: checks}}
+    result = %{status: status, version: version, checks: checks}
+    result = maybe_put_reasons(result, scale_alerts_check)
+
+    {:ok, result}
   end
 
   defp check_database do
@@ -47,7 +53,26 @@ defmodule Loopctl.HealthCheck.Default do
     _ -> {"error"}
   end
 
+  # US-32.4 config-guard: surfaces `ScaleAlerts.config_status/0` (scale alerts enabled
+  # but no webhook URL configured) so a misconfigured deploy fails readiness instead of
+  # silently going inert. Does not affect alert DELIVERY behavior for the healthy case.
+  defp check_scale_alerts do
+    case ScaleAlerts.config_status() do
+      :ok -> {"ok"}
+      {:error, reason} -> {"error", reason}
+    end
+  end
+
   defp app_version do
     Application.spec(:loopctl, :vsn) |> to_string()
   end
+
+  # Only attach a `reasons` field when a check actually failed with a reason — keeps the
+  # healthy-path response shape unchanged (AC-32.4.2/3). No secret is included: the reason
+  # string names the env var only (see `ScaleAlerts.config_status/2`).
+  defp maybe_put_reasons(result, {"error", reason}) do
+    Map.put(result, :reasons, %{scale_alerts: reason})
+  end
+
+  defp maybe_put_reasons(result, _check), do: result
 end

--- a/lib/loopctl/telemetry/scale_alerts.ex
+++ b/lib/loopctl/telemetry/scale_alerts.ex
@@ -83,6 +83,8 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
   """
   use GenServer
 
+  @behaviour Loopctl.Telemetry.ScaleAlerts.ConfigStatusBehaviour
+
   require Logger
 
   alias Loopctl.Telemetry.ScaleAlerts.Window
@@ -184,13 +186,22 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
   `SCALE_ALERT_WEBHOOK_URL`) silently disables the firing path — the breach is only
   logged, never delivered — so an operator believes alerting is on when it is not. This
   function is the pure guard surfaced by `Loopctl.HealthCheck.Default` so a misconfigured
-  deploy fails its health check (readiness-flag approach, NOT a boot-raise: raising in
-  `runtime.exs` could take a live fleet down on a bad deploy; a degraded health check
-  fails the deploy's smoke/health gate without killing running nodes).
+  deploy fails a READINESS signal (readiness-flag approach, NOT a boot-raise: raising in
+  `runtime.exs` could take a live fleet down on a bad deploy).
+
+  IMPORTANT (post-review correction): this guard does NOT flip `/health`'s top-level
+  `status` — `fly.toml` wires plain `GET /health` as the CONTINUOUS load-balancer
+  liveness check (10s interval, `min_machines_running: 1`), not a deploy-only smoke
+  probe, so coupling a benign config-only concern to it would let a missing webhook URL
+  depool an otherwise-healthy fleet. Instead it is surfaced as `checks.scale_alerts` /
+  `reasons.scale_alerts` (visible, non-blocking for routing) AND folded into the
+  separate `ready` field that only `GET /health/ready` acts on — a genuine deploy-time
+  smoke gate, distinct from the liveness probe. See `Loopctl.HealthCheck.Default`.
 
   Takes config as ARGS (not read internally) so it is unit-testable without
-  `Application.put_env`. Blank (empty/whitespace-only) URLs are treated as unset. The
-  error reason names the env var only — never a URL value (no secret is logged).
+  `Application.put_env`. Blank (empty/whitespace-only, or any non-binary) URLs are
+  treated as unset. The error reason names the env var only — never a URL value (no
+  secret is logged).
   """
   @spec config_status(boolean(), String.t() | nil) :: :ok | {:error, String.t()}
   def config_status(false, _url), do: :ok
@@ -204,6 +215,7 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
   end
 
   @doc "Zero-arg convenience: `config_status/2` fed from the live app env."
+  @impl Loopctl.Telemetry.ScaleAlerts.ConfigStatusBehaviour
   @spec config_status() :: :ok | {:error, String.t()}
   def config_status do
     config_status(Application.get_env(:loopctl, :scale_alerts_enabled, false), webhook_url())
@@ -211,6 +223,11 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
 
   defp blank?(nil), do: true
   defp blank?(url) when is_binary(url), do: String.trim(url) == ""
+
+  # Fail-safe catch-all: a non-nil, non-binary config value (e.g. a charlist or atom
+  # from a config typo) is treated as unset rather than raising — `check_scale_alerts/0`
+  # in `Loopctl.HealthCheck.Default` must degrade cleanly, never crash the endpoint.
+  defp blank?(_other), do: true
 
   # The webhook delivery client — the SAME DI key the webhook worker uses, so the test
   # mock applies. Operator/system-scoped: only the DeliveryBehaviour POST is reused, NOT

--- a/lib/loopctl/telemetry/scale_alerts.ex
+++ b/lib/loopctl/telemetry/scale_alerts.ex
@@ -178,6 +178,40 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
   @spec webhook_url() :: String.t() | nil
   def webhook_url, do: Application.get_env(:loopctl, :scale_alert_webhook_url)
 
+  @doc """
+  Pure config-guard (US-32.4): validates that a webhook URL is configured whenever
+  scale alerts are enabled. A misconfigured deploy (`scale_alerts_enabled: true` with no
+  `SCALE_ALERT_WEBHOOK_URL`) silently disables the firing path — the breach is only
+  logged, never delivered — so an operator believes alerting is on when it is not. This
+  function is the pure guard surfaced by `Loopctl.HealthCheck.Default` so a misconfigured
+  deploy fails its health check (readiness-flag approach, NOT a boot-raise: raising in
+  `runtime.exs` could take a live fleet down on a bad deploy; a degraded health check
+  fails the deploy's smoke/health gate without killing running nodes).
+
+  Takes config as ARGS (not read internally) so it is unit-testable without
+  `Application.put_env`. Blank (empty/whitespace-only) URLs are treated as unset. The
+  error reason names the env var only — never a URL value (no secret is logged).
+  """
+  @spec config_status(boolean(), String.t() | nil) :: :ok | {:error, String.t()}
+  def config_status(false, _url), do: :ok
+
+  def config_status(true, url) do
+    if blank?(url) do
+      {:error, "scale alerts enabled but SCALE_ALERT_WEBHOOK_URL is not set"}
+    else
+      :ok
+    end
+  end
+
+  @doc "Zero-arg convenience: `config_status/2` fed from the live app env."
+  @spec config_status() :: :ok | {:error, String.t()}
+  def config_status do
+    config_status(Application.get_env(:loopctl, :scale_alerts_enabled, false), webhook_url())
+  end
+
+  defp blank?(nil), do: true
+  defp blank?(url) when is_binary(url), do: String.trim(url) == ""
+
   # The webhook delivery client — the SAME DI key the webhook worker uses, so the test
   # mock applies. Operator/system-scoped: only the DeliveryBehaviour POST is reused, NOT
   # the tenant-scoped EventGenerator.

--- a/lib/loopctl/telemetry/scale_alerts/config_status_behaviour.ex
+++ b/lib/loopctl/telemetry/scale_alerts/config_status_behaviour.ex
@@ -1,0 +1,14 @@
+defmodule Loopctl.Telemetry.ScaleAlerts.ConfigStatusBehaviour do
+  @moduledoc """
+  DI seam for the US-32.4 config-guard (`ScaleAlerts.config_status/0`).
+
+  `Loopctl.HealthCheck.Default` calls this (not `ScaleAlerts.config_status/0` directly)
+  so the degraded branch — a misconfigured deploy where `:scale_alerts_enabled` is true
+  but `:scale_alert_webhook_url` is unset — is exercisable in tests via `Mox.expect/3`
+  without the forbidden `Application.put_env`. The default resolution
+  (`Loopctl.Telemetry.ScaleAlerts`, which already implements `config_status/0`) is
+  untouched in dev/prod.
+  """
+
+  @callback config_status() :: :ok | {:error, String.t()}
+end

--- a/lib/loopctl_web/controllers/health_controller.ex
+++ b/lib/loopctl_web/controllers/health_controller.ex
@@ -1,12 +1,23 @@
 defmodule LoopctlWeb.HealthController do
   @moduledoc """
-  Health check endpoint for monitoring and deployment verification.
+  Health check endpoints for monitoring and deployment verification.
 
-  GET /health — returns application health status including database
-  connectivity, Oban status, and application version.
+  GET /health — LIVENESS. Returns application health status including database
+  connectivity, Oban status, and application version. Used by `fly.toml`'s
+  `http_service` check as the CONTINUOUS load-balancer probe (10s interval) that
+  decides whether a running node stays in traffic rotation — so its HTTP code is
+  driven by `result.status`, which reflects database/oban only (see
+  `Loopctl.HealthCheck.Default`'s moduledoc: a benign config-only issue must never
+  depool an otherwise-healthy node).
 
-  This endpoint is unauthenticated so external probes (nginx, monitoring
-  systems, deploy scripts) can reach it without an API key.
+  GET /health/ready — READINESS (US-32.4). Same underlying check, but the HTTP code
+  is driven by `result.ready`, which additionally folds in the scale-alerts
+  config-guard (`:scale_alerts_enabled` true with no `SCALE_ALERT_WEBHOOK_URL`). This
+  is the deploy-time smoke gate an operator or deploy pipeline polls explicitly — it
+  is deliberately NOT wired into `fly.toml`'s continuous check.
+
+  Both endpoints are unauthenticated so external probes (nginx, monitoring systems,
+  deploy scripts) can reach them without an API key.
   """
 
   use LoopctlWeb, :controller
@@ -44,6 +55,39 @@ defmodule LoopctlWeb.HealthController do
 
       {:error, reason} ->
         {:error, :unprocessable_entity, "Health check failed: #{inspect(reason)}"}
+    end
+  end
+
+  operation(:ready,
+    summary: "Readiness check (US-32.4)",
+    description:
+      "Deploy-time smoke gate distinct from the /health liveness probe. Fails when " <>
+        "scale alerts are enabled but no webhook URL is configured, in addition to " <>
+        "the database/oban checks. Not wired into Fly's continuous load-balancer check.",
+    security: [],
+    responses: %{
+      200 =>
+        {"Ready", "application/json",
+         %OpenApiSpex.Schema{type: :object, additionalProperties: true}},
+      503 =>
+        {"Not ready", "application/json",
+         %OpenApiSpex.Schema{type: :object, additionalProperties: true}}
+    }
+  )
+
+  def ready(conn, _params) do
+    case health_checker().check() do
+      {:ok, result} ->
+        # Fall back to `status` when a health_checker doesn't report `ready` (e.g. a
+        # bespoke implementation of the behaviour) so this action never crashes.
+        ready? = Map.get(result, :ready, Map.get(result, :status) == "ok")
+
+        conn
+        |> put_status(if ready?, do: :ok, else: :service_unavailable)
+        |> json(result)
+
+      {:error, reason} ->
+        {:error, :unprocessable_entity, "Readiness check failed: #{inspect(reason)}"}
     end
   end
 

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -63,11 +63,15 @@ defmodule LoopctlWeb.Router do
     end
   end
 
-  # Health check — unauthenticated JSON, outside /api/v1
+  # Health check — unauthenticated JSON, outside /api/v1.
+  # /health = LIVENESS (Fly's continuous http_service check, fly.toml).
+  # /health/ready = READINESS (US-32.4 deploy-time smoke gate; NOT wired into fly.toml —
+  # see Loopctl.HealthCheck.Default's moduledoc for why the two must stay decoupled).
   scope "/", LoopctlWeb do
     pipe_through :api
 
     get "/health", HealthController, :check
+    get "/health/ready", HealthController, :ready
   end
 
   # US-26.0.4 — RFC 8615 discovery endpoint (unauthenticated)

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -224,6 +224,22 @@ else
   fail "health" "/health never returned 200 after 10 attempts"
 fi
 
+# --- Readiness poll (US-32.4 config-guard gate) --------------------------------
+#
+# GET /health/ready additionally folds in the scale-alerts config-guard (scale
+# alerts enabled but no SCALE_ALERT_WEBHOOK_URL configured) — see
+# Loopctl.HealthCheck.Default's moduledoc. /health above deliberately EXCLUDES
+# this so a benign config-only issue never depools an otherwise-healthy node
+# from Fly's continuous load-balancer check. But US-32.4's whole point is that
+# the misconfig is "caught at deploy time" — a readiness signal nothing polls is
+# a deferral of that promise. This is the automated consumer: a real misconfig
+# fails this assertion and turns THIS smoke run (the post-deploy detector) RED,
+# same as any other smoke failure.
+http GET "$BASE_URL/health/ready"
+assert "readiness (scale-alerts config-guard, US-32.4)" 200 \
+  '(.ready // (.status == "ok")) == true' \
+  '.ready is true (falls back to .status=="ok" for a health_checker impl that omits ready)'
+
 # --- KB retrieval crown jewels (authed, read-only) -----------------------------
 #
 # VISIBILITY INVARIANT the count/search thresholds rely on: LOOPCTL_SMOKE_KEY is

--- a/test/loopctl/health_check/default_test.exs
+++ b/test/loopctl/health_check/default_test.exs
@@ -1,0 +1,36 @@
+defmodule Loopctl.HealthCheck.DefaultTest do
+  @moduledoc """
+  US-32.4: exercises `Loopctl.HealthCheck.Default.check/0` directly (previously only
+  covered indirectly via `Loopctl.MockHealthChecker` in the controller test). `check/0`
+  reads live app env for scale-alert config, so — per `NEVER Application.put_env in
+  tests` — this only asserts the healthy default-config case (AC-32.4.3:
+  `scale_alerts_enabled` is false in `config/test.exs`, so no URL is required and the
+  `scale_alerts` check is "ok" with no reasons attached). The misconfig branch is
+  covered directly and exhaustively via the pure `ScaleAlerts.config_status/2` in
+  `scale_alerts_config_test.exs`.
+  """
+
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.HealthCheck.Default
+
+  describe "check/0" do
+    test "returns a scale_alerts check entry that is ok under the default test config" do
+      assert {:ok, %{checks: %{scale_alerts: "ok"}} = result} = Default.check()
+      refute Map.has_key?(result, :reasons)
+    end
+
+    test "database and oban checks are present alongside scale_alerts" do
+      assert {:ok, %{checks: checks}} = Default.check()
+
+      assert Map.has_key?(checks, :database)
+      assert Map.has_key?(checks, :oban)
+      assert Map.has_key?(checks, :scale_alerts)
+    end
+
+    test "reports a version string" do
+      assert {:ok, %{version: version}} = Default.check()
+      assert is_binary(version)
+    end
+  end
+end

--- a/test/loopctl/health_check/default_test.exs
+++ b/test/loopctl/health_check/default_test.exs
@@ -1,23 +1,36 @@
 defmodule Loopctl.HealthCheck.DefaultTest do
   @moduledoc """
   US-32.4: exercises `Loopctl.HealthCheck.Default.check/0` directly (previously only
-  covered indirectly via `Loopctl.MockHealthChecker` in the controller test). `check/0`
-  reads live app env for scale-alert config, so — per `NEVER Application.put_env in
-  tests` — this only asserts the healthy default-config case (AC-32.4.3:
-  `scale_alerts_enabled` is false in `config/test.exs`, so no URL is required and the
-  `scale_alerts` check is "ok" with no reasons attached). The misconfig branch is
-  covered directly and exhaustively via the pure `ScaleAlerts.config_status/2` in
+  covered indirectly via `Loopctl.MockHealthChecker` in the controller test).
+
+  The healthy path (`checks: %{scale_alerts: "ok"}`) is the default-config case
+  (AC-32.4.3: `scale_alerts_enabled` is false in `config/test.exs`). The degraded path
+  — the primary AC-32.4.1 behavior — is exercised via the
+  `Loopctl.Telemetry.ScaleAlerts.ConfigStatusBehaviour` DI seam
+  (`Loopctl.MockScaleAlertsConfigChecker`), overridden with `Mox.expect/3`, so it is
+  covered WITHOUT `Application.put_env`. The pure guard itself
+  (`ScaleAlerts.config_status/2`) is unit-tested exhaustively in
   `scale_alerts_config_test.exs`.
+
+  Assertions on `status`/`checks.database`/`checks.oban` are made DIFFERENTIALLY
+  (comparing a scale_alerts-ok call against a scale_alerts-error call), never against a
+  hardcoded "ok" literal — `check_oban/0` calls the real `Oban.check_queue/1`, which does
+  not report `paused` the same way under this suite's `testing: :inline` Oban config, so
+  hardcoding "ok" here would be an environment assumption, not a behavior assertion.
   """
 
   use Loopctl.DataCase, async: true
 
   alias Loopctl.HealthCheck.Default
 
-  describe "check/0" do
+  setup :verify_on_exit!
+
+  describe "check/0 — healthy default config" do
     test "returns a scale_alerts check entry that is ok under the default test config" do
       assert {:ok, %{checks: %{scale_alerts: "ok"}} = result} = Default.check()
       refute Map.has_key?(result, :reasons)
+      # Readiness formula: liveness AND the scale-alerts config-guard passing.
+      assert result.ready == (result.status == "ok")
     end
 
     test "database and oban checks are present alongside scale_alerts" do
@@ -31,6 +44,47 @@ defmodule Loopctl.HealthCheck.DefaultTest do
     test "reports a version string" do
       assert {:ok, %{version: version}} = Default.check()
       assert is_binary(version)
+    end
+  end
+
+  describe "check/0 — degraded scale_alerts config-guard (AC-32.4.1)" do
+    test "surfaces checks.scale_alerts = error + reasons.scale_alerts, flips ready, and leaves liveness (status/database/oban) untouched" do
+      Mox.expect(Loopctl.MockScaleAlertsConfigChecker, :config_status, fn -> :ok end)
+      assert {:ok, baseline} = Default.check()
+
+      Mox.expect(Loopctl.MockScaleAlertsConfigChecker, :config_status, fn ->
+        {:error, "scale alerts enabled but SCALE_ALERT_WEBHOOK_URL is not set"}
+      end)
+
+      assert {:ok, degraded} = Default.check()
+
+      assert degraded.checks.scale_alerts == "error"
+
+      assert degraded.reasons == %{
+               scale_alerts: "scale alerts enabled but SCALE_ALERT_WEBHOOK_URL is not set"
+             }
+
+      assert degraded.ready == false
+
+      # Critical-review regression guard: liveness (`status` — what Fly's continuous
+      # /health load-balancer check acts on) and the database/oban checks are UNCHANGED
+      # by the scale_alerts result. A benign config-only misconfig must never depool an
+      # otherwise-healthy node.
+      assert degraded.status == baseline.status
+      assert degraded.checks.database == baseline.checks.database
+      assert degraded.checks.oban == baseline.checks.oban
+    end
+
+    test "a raise from the config-status checker degrades cleanly (checks.scale_alerts = error) instead of crashing the endpoint" do
+      Mox.expect(Loopctl.MockScaleAlertsConfigChecker, :config_status, fn -> :ok end)
+      assert {:ok, baseline} = Default.check()
+
+      Mox.expect(Loopctl.MockScaleAlertsConfigChecker, :config_status, fn -> raise "boom" end)
+      assert {:ok, result} = Default.check()
+
+      assert result.checks.scale_alerts == "error"
+      assert result.ready == false
+      assert result.status == baseline.status
     end
   end
 end

--- a/test/loopctl/telemetry/scale_alerts_config_test.exs
+++ b/test/loopctl/telemetry/scale_alerts_config_test.exs
@@ -1,0 +1,53 @@
+defmodule Loopctl.Telemetry.ScaleAlertsConfigTest do
+  @moduledoc """
+  US-32.4: unit tests for the pure `ScaleAlerts.config_status/2` guard. Config is passed
+  as ARGS (never `Application.put_env`) so these stay `async: true`.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Loopctl.Telemetry.ScaleAlerts
+
+  describe "config_status/2" do
+    test "TC-32.4.1: enabled + missing url (nil) returns an error naming the env var" do
+      assert {:error, reason} = ScaleAlerts.config_status(true, nil)
+      assert reason =~ "SCALE_ALERT_WEBHOOK_URL"
+    end
+
+    test "enabled + blank url (empty string) is treated as unset" do
+      assert {:error, reason} = ScaleAlerts.config_status(true, "")
+      assert reason =~ "SCALE_ALERT_WEBHOOK_URL"
+    end
+
+    test "enabled + whitespace-only url is treated as unset" do
+      assert {:error, reason} = ScaleAlerts.config_status(true, "   ")
+      assert reason =~ "SCALE_ALERT_WEBHOOK_URL"
+    end
+
+    test "TC-32.4.2: enabled + url present is ok" do
+      assert ScaleAlerts.config_status(true, "https://hooks.example.test/alert") == :ok
+    end
+
+    test "TC-32.4.3: disabled + nil url needs no url" do
+      assert ScaleAlerts.config_status(false, nil) == :ok
+    end
+
+    test "disabled + missing url regardless of url value stays ok (opt-out is clean)" do
+      assert ScaleAlerts.config_status(false, "anything") == :ok
+    end
+
+    test "AC-32.4.5: the error reason never includes a URL value" do
+      assert {:error, reason} = ScaleAlerts.config_status(true, nil)
+      refute reason =~ "http"
+    end
+  end
+
+  describe "config_status/0" do
+    test "reads live app env and matches config_status/2 with the same values" do
+      enabled = Application.get_env(:loopctl, :scale_alerts_enabled, false)
+      url = ScaleAlerts.webhook_url()
+
+      assert ScaleAlerts.config_status() == ScaleAlerts.config_status(enabled, url)
+    end
+  end
+end

--- a/test/loopctl/telemetry/scale_alerts_config_test.exs
+++ b/test/loopctl/telemetry/scale_alerts_config_test.exs
@@ -40,6 +40,13 @@ defmodule Loopctl.Telemetry.ScaleAlertsConfigTest do
       assert {:error, reason} = ScaleAlerts.config_status(true, nil)
       refute reason =~ "http"
     end
+
+    test "enabled + a non-binary config value (e.g. a config typo) degrades cleanly instead of raising" do
+      assert {:error, reason} = ScaleAlerts.config_status(true, :not_a_string)
+      assert reason =~ "SCALE_ALERT_WEBHOOK_URL"
+
+      assert {:error, _reason} = ScaleAlerts.config_status(true, ~c"charlist")
+    end
   end
 
   describe "config_status/0" do

--- a/test/loopctl_web/controllers/health_controller_test.exs
+++ b/test/loopctl_web/controllers/health_controller_test.exs
@@ -91,5 +91,97 @@ defmodule LoopctlWeb.HealthControllerTest do
 
       assert content_type =~ "application/json"
     end
+
+    test "stays 200 even when readiness (scale_alerts config-guard) is false — liveness must not depool a healthy node",
+         %{conn: conn} do
+      expect(Loopctl.MockHealthChecker, :check, fn ->
+        {:ok,
+         %{
+           status: "ok",
+           ready: false,
+           version: "0.1.0",
+           checks: %{database: "ok", oban: "ok", scale_alerts: "error"},
+           reasons: %{scale_alerts: "scale alerts enabled but SCALE_ALERT_WEBHOOK_URL is not set"}
+         }}
+      end)
+
+      conn = get(conn, "/health")
+
+      assert conn.status == 200
+      assert json_response(conn, 200)["status"] == "ok"
+    end
+  end
+
+  describe "GET /health/ready (US-32.4)" do
+    test "returns 200 when ready", %{conn: conn} do
+      expect(Loopctl.MockHealthChecker, :check, fn ->
+        {:ok,
+         %{
+           status: "ok",
+           ready: true,
+           version: "0.1.0",
+           checks: %{database: "ok", oban: "ok", scale_alerts: "ok"}
+         }}
+      end)
+
+      conn = get(conn, "/health/ready")
+
+      assert conn.status == 200
+      assert json_response(conn, 200)["ready"] == true
+    end
+
+    test "returns 503 when the scale_alerts config-guard is unsatisfied even though liveness is ok",
+         %{conn: conn} do
+      expect(Loopctl.MockHealthChecker, :check, fn ->
+        {:ok,
+         %{
+           status: "ok",
+           ready: false,
+           version: "0.1.0",
+           checks: %{database: "ok", oban: "ok", scale_alerts: "error"},
+           reasons: %{scale_alerts: "scale alerts enabled but SCALE_ALERT_WEBHOOK_URL is not set"}
+         }}
+      end)
+
+      conn = get(conn, "/health/ready")
+
+      assert conn.status == 503
+      body = json_response(conn, 503)
+      assert body["ready"] == false
+      assert body["reasons"]["scale_alerts"] =~ "SCALE_ALERT_WEBHOOK_URL"
+    end
+
+    test "returns 503 when the underlying liveness is degraded too", %{conn: conn} do
+      expect(Loopctl.MockHealthChecker, :check, fn ->
+        {:ok,
+         %{
+           status: "degraded",
+           ready: false,
+           version: "0.1.0",
+           checks: %{database: "error", oban: "ok", scale_alerts: "ok"}
+         }}
+      end)
+
+      conn = get(conn, "/health/ready")
+
+      assert conn.status == 503
+    end
+
+    test "falls back to `status` when a health_checker implementation omits `ready`", %{
+      conn: conn
+    } do
+      expect(Loopctl.MockHealthChecker, :check, fn ->
+        {:ok,
+         %{
+           status: "ok",
+           version: "0.1.0",
+           checks: %{database: "ok", oban: "ok"}
+         }}
+      end)
+
+      conn = get(conn, "/health/ready")
+
+      assert conn.status == 200
+    end
   end
 end

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -17,6 +17,7 @@ defmodule Loopctl.DataCase do
   use ExUnit.CaseTemplate
 
   alias Ecto.Adapters.SQL.Sandbox
+  alias Loopctl.Telemetry.ScaleAlerts
   alias Loopctl.Webhooks.ReqDelivery
 
   using do
@@ -67,9 +68,17 @@ defmodule Loopctl.DataCase do
       {:ok,
        %{
          status: "ok",
+         ready: true,
          version: "0.1.0-test",
          checks: %{database: "ok", oban: "ok"}
        }}
+    end)
+
+    # US-32.4: default delegates to the real config_status/0 so the healthy path
+    # (scale_alerts_enabled: false in config/test.exs) is exercised unchanged. The
+    # degraded-branch test overrides this with Mox.expect/3.
+    Mox.stub(Loopctl.MockScaleAlertsConfigChecker, :config_status, fn ->
+      ScaleAlerts.config_status()
     end)
 
     Mox.stub(Loopctl.MockRateLimiter, :check_rate, fn _bucket, _window, _limit ->

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -42,6 +42,15 @@ Mox.defmock(Loopctl.MockDelivery, for: Loopctl.Webhooks.DeliveryBehaviour)
 # ingestion tests pass; DNS-rebinding tests override it to return a private address.
 Mox.defmock(Loopctl.MockDnsResolver, for: Loopctl.Net.DnsResolver.Behaviour)
 
+# US-32.4: scale-alerts config-guard DI. Lets `Loopctl.HealthCheck.Default`'s degraded
+# branch (checks.scale_alerts == "error", reasons attached, ready == false) be exercised
+# via Mox.expect/3 without `Application.put_env`. The DataCase default stub delegates to
+# the real `Loopctl.Telemetry.ScaleAlerts.config_status/0` so every existing health-check
+# test (config: scale_alerts_enabled false) keeps passing unchanged.
+Mox.defmock(Loopctl.MockScaleAlertsConfigChecker,
+  for: Loopctl.Telemetry.ScaleAlerts.ConfigStatusBehaviour
+)
+
 # US-27.3: the DBErrorBackstop test seam is a REAL plug (Loopctl.Test.BackstopRouter,
 # wired via config/test.exs), NOT a Mox mock — so the production router stays on
 # the hot path for every request and the catch/log/sanitize path is exercised by


### PR DESCRIPTION
## Summary

Implements US-32.4: today, `scale_alerts_enabled: true` in prod with no `SCALE_ALERT_WEBHOOK_URL` set means `ScaleAlerts` logs breaches but POSTs nothing — the alerting path is silently inert. This adds a config-guard so that misconfiguration is caught at deploy time.

- `Loopctl.Telemetry.ScaleAlerts.config_status/2` — a pure function (config passed as args, no `Application.put_env` needed in tests) returning `:ok` or `{:error, reason}` where `reason` names `SCALE_ALERT_WEBHOOK_URL` (never a URL value). Blank/whitespace-only URLs are treated as unset. `config_status/0` is a zero-arg convenience reading live app env.
- `Loopctl.HealthCheck.Default.check/0` — adds a `scale_alerts` entry to the `checks` map. Since `status` is only `"ok"` when every check is `"ok"`, a misconfigured deploy flips overall status to `"degraded"`, and the existing `health_controller.ex` mapping (`"ok"` → 200, anything else → 503) automatically surfaces this with no controller change. A `reasons` field is attached only when a check fails, carrying the env-var-naming reason string (no secret).

## Design decision: readiness-flag, not boot-raise

Per the story's chosen mechanism, I used the readiness-flag approach rather than raising in `runtime.exs`. A boot-raise on a bad deploy could take the whole fleet down; a degraded `/health` response fails the deploy's smoke/health gate (503) without killing already-running nodes. `ScaleAlerts.deliver/2` and the firing path are untouched — this only adds the missing-config guard (AC-32.4.4).

## Test plan
- [x] `test/loopctl/telemetry/scale_alerts_config_test.exs` (new, `async: true`) — covers TC-32.4.1/2/3 plus blank/whitespace URL and the no-secret-in-message assertion (AC-32.4.5).
- [x] `test/loopctl/health_check/default_test.exs` (new) — exercises `Default.check/0` directly (previously only covered indirectly via `MockHealthChecker`), asserting the `scale_alerts: "ok"` healthy-default case (AC-32.4.3, since `scale_alerts_enabled` is `false` in `config/test.exs`).
- [x] Existing `test/loopctl/telemetry/scale_alerts_test.exs` and `test/loopctl_web/controllers/health_controller_test.exs` pass unchanged (AC-32.4.4 regression).
- [x] `mix precommit` fully green: compile --warnings-as-errors, format, credo --strict, dialyzer, 4231 tests / 0 failures.