### PR TITLE
STH all-tenants fanout uses Oban.insert_all with scheduled jitter

### DIFF
--- a/docs/user_stories/epic_32_scale_quick_wins/us_32.5.json
+++ b/docs/user_stories/epic_32_scale_quick_wins/us_32.5.json
@@ -18,7 +18,7 @@
   "acceptance_criteria": [
     { "id": "AC-32.5.1", "description": "The all_tenants branch builds one list of `ComputeSthWorker.new(%{\"tenant_id\" => id}, schedule_in: jitter)` changesets and enqueues them via a single `Oban.insert_all/1` (or `Oban.insert_all/2`), replacing the per-tenant `Oban.insert/1` loop.", "status": "pending" },
     { "id": "AC-32.5.2", "description": "Each per-tenant job gets a bounded, deterministic-per-run jitter `schedule_in` in [0, 55] seconds (stay within the 1-minute cadence) derived per index/tenant so the jobs spread across the minute rather than all at :00. No use of :rand at module level that would break Oban unique/dedup.", "status": "pending" },
-    { "id": "AC-32.5.3", "description": "Behavior parity: still enqueues exactly one job per ACTIVE tenant (status == :active), and the per-tenant branch (sth_needed? / sign_and_store_tree_head) is UNCHANGED. If Oban unique options are present, insert_all respects them (no duplicate storms).", "status": "pending" },
+    { "id": "AC-32.5.3", "description": "Behavior parity: still enqueues exactly one job per ACTIVE tenant (status == :active), and the per-tenant branch (sth_needed? / sign_and_store_tree_head) is UNCHANGED. CORRECTION (post-implementation review): on the Basic Oban engine (what this app runs), `Oban.insert_all/1` does NOT honor `unique` options -- only the Smart Engine (Oban Pro) does. This worker's `unique: [fields: [:worker, :args], period: 30]` is therefore inert on the fanout path; duplicate-per-tenant enqueues are prevented from causing duplicate STHs by `AuditChain.sth_needed?/1`'s idempotency, not by Oban uniqueness. Do not treat the original 'no duplicate storms via unique' clause as satisfied.", "status": "pending" },
     { "id": "AC-32.5.4", "description": "Empty tenant list is handled (insert_all of [] is a no-op, returns :ok, no crash).", "status": "pending" }
   ],
   "test_cases": [
@@ -38,7 +38,7 @@
   "technical_notes": [
     "Oban.insert_all takes a list of Oban.Job changesets (Worker.new/2); build them with schedule_in: seconds.",
     "Jitter without Math.random at compile time: derive from rem(:erlang.phash2(tenant_id), 56) or the enumeration index — stable within a run, spreads across the minute, and won't interfere with Oban :unique keys.",
-    "Preserve any existing unique/replace options on ComputeSthWorker.new; if the worker is @unique, insert_all still honors it.",
+    "Preserve any existing unique/replace options on ComputeSthWorker.new for single-job inserts. CORRECTION (post-implementation review): this claim ('if the worker is @unique, insert_all still honors it') is FALSE on the Basic engine -- Oban.insert_all/1 only honors `unique` on the Smart Engine (Oban Pro); verified against Oban 2.21.1 / Oban.Engines.Basic in this app. Duplicate-per-tenant jobs from the fanout are made harmless by AuditChain.sth_needed?/1's idempotency, not by `unique`.",
     "This is a fanout-only change; do NOT touch AuditChain.sth_needed?/sign_and_store_tree_head (incremental Merkle is Epic 3).",
     "Oban testing: config/test.exs uses testing: :inline — assert enqueued jobs with Oban.Testing helpers (all_enqueued/assert_enqueued) rather than relying on execution timing."
   ],

--- a/lib/loopctl/workers/compute_sth_worker.ex
+++ b/lib/loopctl/workers/compute_sth_worker.ex
@@ -8,7 +8,10 @@ defmodule Loopctl.Workers.ComputeSthWorker do
   ## Scheduling
 
   Configured via Oban Cron to run every minute in `all_tenants` mode,
-  which enqueues individual per-tenant jobs.
+  which fans out individual per-tenant jobs via a single `Oban.insert_all/1`
+  batch. Each per-tenant job is scheduled with a small deterministic jitter
+  (see `jitter/1`) so the fanout doesn't thundering-herd the `:audit` queue
+  and the primary DB at the exact `:00` instant of the cron tick.
   """
 
   use Oban.Worker,
@@ -22,6 +25,10 @@ defmodule Loopctl.Workers.ComputeSthWorker do
   alias Loopctl.AuditChain
   alias Loopctl.Tenants.Tenant
 
+  # US-32.5: bounded jitter window (seconds) spread across the per-minute cron
+  # tick, so per-tenant fanout jobs don't all land at the same `:00` instant.
+  @jitter_window_seconds 56
+
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"mode" => "all_tenants"}}) do
     import Ecto.Query
@@ -30,11 +37,11 @@ defmodule Loopctl.Workers.ComputeSthWorker do
       from(t in Tenant, where: t.status == :active, select: t.id)
       |> AdminRepo.all()
 
-    for tenant_id <- tenants do
-      %{"tenant_id" => tenant_id}
-      |> __MODULE__.new()
-      |> Oban.insert()
-    end
+    tenants
+    |> Enum.map(fn tenant_id ->
+      __MODULE__.new(%{"tenant_id" => tenant_id}, schedule_in: jitter(tenant_id))
+    end)
+    |> Oban.insert_all()
 
     :ok
   end
@@ -60,4 +67,15 @@ defmodule Loopctl.Workers.ComputeSthWorker do
       :ok
     end
   end
+
+  # US-32.5 (AC-32.5.2): bounded, deterministic-per-tenant jitter in
+  # [0, @jitter_window_seconds - 1] seconds. Deliberately NOT `:rand` at the
+  # module level -- a random value here would make the enqueued job's
+  # `schedule_in` (and therefore `scheduled_at`) non-reproducible across
+  # retries/tests, and would fight `Oban.insert_all/1`'s ability to spread
+  # fanout evenly. `:erlang.phash2/1` is stable for a given tenant_id and
+  # independent of the `unique: [fields: [:worker, :args]]` dedup key (which
+  # only looks at worker + args, never `scheduled_at`), so jitter never
+  # collides with uniqueness.
+  defp jitter(tenant_id), do: rem(:erlang.phash2(tenant_id), @jitter_window_seconds)
 end

--- a/lib/loopctl/workers/compute_sth_worker.ex
+++ b/lib/loopctl/workers/compute_sth_worker.ex
@@ -12,6 +12,21 @@ defmodule Loopctl.Workers.ComputeSthWorker do
   batch. Each per-tenant job is scheduled with a small deterministic jitter
   (see `jitter/1`) so the fanout doesn't thundering-herd the `:audit` queue
   and the primary DB at the exact `:00` instant of the cron tick.
+
+  ## `unique` does NOT apply to this fanout
+
+  This worker declares `unique: [fields: [:worker, :args], period: 30]`, but
+  Oban's bulk insert (`Oban.insert_all/1`, used above for fanout) only honors
+  `unique` on the Smart Engine (Oban Pro). On the Basic Engine (what this app
+  runs), `unique` is checked by `Oban.insert/2` (single-job inserts) and is
+  inert for `insert_all/1` -- see `Oban.insert_all/1`'s own docs. So the
+  fanout can, in principle, enqueue duplicate per-tenant jobs; this is safe
+  because `perform/1`'s `tenant_id` clause is idempotent via
+  `AuditChain.sth_needed?/1` below -- a duplicate job is a cheap no-op, not a
+  duplicate STH. Do not rely on `unique` as the dedup mechanism here; if
+  stronger duplicate-prevention is ever required, that means adopting the
+  Smart Engine or adding an explicit application-level guard, not assuming
+  this attribute already provides it.
   """
 
   use Oban.Worker,
@@ -73,9 +88,11 @@ defmodule Loopctl.Workers.ComputeSthWorker do
   # module level -- a random value here would make the enqueued job's
   # `schedule_in` (and therefore `scheduled_at`) non-reproducible across
   # retries/tests, and would fight `Oban.insert_all/1`'s ability to spread
-  # fanout evenly. `:erlang.phash2/1` is stable for a given tenant_id and
-  # independent of the `unique: [fields: [:worker, :args]]` dedup key (which
-  # only looks at worker + args, never `scheduled_at`), so jitter never
-  # collides with uniqueness.
+  # fanout evenly. `:erlang.phash2/1` is stable for a given tenant_id.
+  #
+  # Note this has nothing to do with the `unique: [fields: [:worker, :args]]`
+  # declaration above: that option is inert on this `insert_all/1` fanout
+  # path regardless of `scheduled_at` (see the moduledoc). Jitter's actual
+  # job is spreading fanout load, not participating in dedup.
   defp jitter(tenant_id), do: rem(:erlang.phash2(tenant_id), @jitter_window_seconds)
 end

--- a/lib/loopctl/workers/compute_sth_worker.ex
+++ b/lib/loopctl/workers/compute_sth_worker.ex
@@ -56,7 +56,16 @@ defmodule Loopctl.Workers.ComputeSthWorker do
     |> Enum.map(fn tenant_id ->
       __MODULE__.new(%{"tenant_id" => tenant_id}, schedule_in: jitter(tenant_id))
     end)
-    |> Oban.insert_all()
+    # US-32.5 review fix: `Oban.insert_all/1` -> `Repo.insert_all/3` with NO
+    # internal chunking (Oban.Engines.Basic.insert_all_jobs/3). Job.to_map/1
+    # emits ~10 non-nil columns per job, so one un-chunked INSERT hits
+    # Postgres's 65535 bind-parameter limit around ~6.5k active tenants,
+    # failing the ENTIRE fanout (zero STHs computed for any tenant that
+    # minute) instead of degrading gracefully. Chunking collapses N tenants
+    # to ceil(N/5000) round-trips -- still far fewer than the old one-insert-
+    # per-tenant loop -- while removing the crash ceiling entirely.
+    |> Enum.chunk_every(5_000)
+    |> Enum.each(&Oban.insert_all/1)
 
     :ok
   end
@@ -82,6 +91,13 @@ defmodule Loopctl.Workers.ComputeSthWorker do
       :ok
     end
   end
+
+  @doc """
+  The jitter window (seconds) used by `jitter/1`, exposed so callers (and
+  tests) have a single source of truth instead of mirroring the private
+  `@jitter_window_seconds` module attribute.
+  """
+  def jitter_window_seconds, do: @jitter_window_seconds
 
   # US-32.5 (AC-32.5.2): bounded, deterministic-per-tenant jitter in
   # [0, @jitter_window_seconds - 1] seconds. Deliberately NOT `:rand` at the

--- a/test/loopctl/workers/compute_sth_worker_test.exs
+++ b/test/loopctl/workers/compute_sth_worker_test.exs
@@ -1,0 +1,120 @@
+defmodule Loopctl.Workers.ComputeSthWorkerTest do
+  @moduledoc """
+  Tests for US-32.5 -- STH all-tenants fanout uses Oban.insert_all with
+  scheduled jitter.
+  """
+
+  use Loopctl.DataCase, async: true
+  use Oban.Testing, repo: Loopctl.Repo
+
+  setup :verify_on_exit!
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.AuditChain
+  alias Loopctl.Tenants.Tenant
+  alias Loopctl.Workers.ComputeSthWorker
+
+  import Ecto.Query
+
+  # The test DB may carry pre-existing active tenants committed outside this
+  # test's sandbox transaction (e.g. from a scale-test run). Since the
+  # `all_tenants` fanout genuinely queries ALL active tenants system-wide (no
+  # tenant scoping applies to that query), neutralize any such rows within
+  # this test's own transaction so assertions about exact fanout counts are
+  # deterministic. This update is rolled back at the end of the test like
+  # everything else in the sandbox -- it never touches real data permanently.
+  setup do
+    AdminRepo.update_all(from(t in Tenant, where: t.status == :active), set: [status: :suspended])
+    :ok
+  end
+
+  # Mirrors the jitter derivation in ComputeSthWorker (AC-32.5.2): bounded,
+  # deterministic-per-tenant, independent of the unique dedup key.
+  defp expected_jitter(tenant_id), do: rem(:erlang.phash2(tenant_id), 56)
+
+  describe "perform/1 with mode: all_tenants" do
+    test "TC-32.5.1: one job per active tenant via batch, each within the jitter window" do
+      active_1 = fixture(:tenant)
+      active_2 = fixture(:tenant)
+      active_3 = fixture(:tenant)
+      inactive = fixture(:tenant, %{status: :suspended})
+
+      now = DateTime.utc_now()
+
+      result =
+        Oban.Testing.with_testing_mode(:manual, fn ->
+          ComputeSthWorker.perform(%Oban.Job{args: %{"mode" => "all_tenants"}})
+        end)
+
+      assert result == :ok
+
+      tenant_jobs =
+        all_enqueued(worker: ComputeSthWorker)
+        |> Enum.filter(&Map.has_key?(&1.args, "tenant_id"))
+
+      assert length(tenant_jobs) == 3
+
+      enqueued_tenant_ids = Enum.map(tenant_jobs, & &1.args["tenant_id"])
+      assert Enum.sort(enqueued_tenant_ids) == Enum.sort([active_1.id, active_2.id, active_3.id])
+      refute inactive.id in enqueued_tenant_ids
+
+      for job <- tenant_jobs do
+        tenant_id = job.args["tenant_id"]
+        diff = DateTime.diff(job.scheduled_at, now)
+
+        assert diff in 0..55
+        assert diff == expected_jitter(tenant_id)
+      end
+    end
+
+    test "TC-32.5.2: no active tenants is a no-op" do
+      fixture(:tenant, %{status: :suspended})
+
+      result =
+        Oban.Testing.with_testing_mode(:manual, fn ->
+          ComputeSthWorker.perform(%Oban.Job{args: %{"mode" => "all_tenants"}})
+        end)
+
+      assert result == :ok
+
+      tenant_jobs =
+        all_enqueued(worker: ComputeSthWorker)
+        |> Enum.filter(&Map.has_key?(&1.args, "tenant_id"))
+
+      assert tenant_jobs == []
+    end
+  end
+
+  describe "perform/1 with tenant_id (per-tenant STH computation, unchanged)" do
+    test "TC-32.5.3: still signs and stores the tree head as before" do
+      tenant = fixture(:tenant, %{slug: "sth-fanout-#{System.unique_integer([:positive])}"})
+      pub_key = :crypto.strong_rand_bytes(32)
+
+      tenant =
+        tenant
+        |> Ecto.Changeset.change(audit_signing_public_key: pub_key)
+        |> Loopctl.AdminRepo.update!()
+
+      {_pub, priv} = :crypto.generate_key(:eddsa, :ed25519)
+
+      Mox.expect(Loopctl.MockSecrets, :get, fn _name -> {:ok, priv} end)
+      Loopctl.TenantKeys.init_cache()
+
+      {:ok, _} =
+        AuditChain.append(tenant.id, %{
+          action: "test_event",
+          actor_lineage: ["test"],
+          entity_type: "test",
+          payload: %{"k" => "v"}
+        })
+
+      {matching_pub, _} = :crypto.generate_key(:eddsa, :ed25519, priv)
+
+      tenant
+      |> Ecto.Changeset.change(audit_signing_public_key: matching_pub)
+      |> Loopctl.AdminRepo.update!()
+
+      assert :ok = ComputeSthWorker.perform(%Oban.Job{args: %{"tenant_id" => tenant.id}})
+    end
+  end
+end

--- a/test/loopctl/workers/compute_sth_worker_test.exs
+++ b/test/loopctl/workers/compute_sth_worker_test.exs
@@ -61,9 +61,16 @@ defmodule Loopctl.Workers.ComputeSthWorkerTest do
       for job <- tenant_jobs do
         tenant_id = job.args["tenant_id"]
         diff = DateTime.diff(job.scheduled_at, now)
+        expected = expected_jitter(tenant_id)
 
         assert diff in 0..55
-        assert diff == expected_jitter(tenant_id)
+        # `scheduled_at` is computed from `utc_now()` at build time (after
+        # `now` was captured above), and DateTime.diff truncates to whole
+        # seconds -- so diff normally equals `expected` but can be
+        # `expected + 1` if wall-clock time crosses a second boundary
+        # between capturing `now` and building the job. Tolerate that one
+        # second of build-time elapsed rather than asserting exact equality.
+        assert diff in expected..(expected + 1)
       end
     end
 
@@ -115,6 +122,13 @@ defmodule Loopctl.Workers.ComputeSthWorkerTest do
       |> Loopctl.AdminRepo.update!()
 
       assert :ok = ComputeSthWorker.perform(%Oban.Job{args: %{"tenant_id" => tenant.id}})
+
+      # Guard against a storage-path regression: `:ok` alone is also
+      # returned on the sth_needed?==false and :empty_chain branches, so
+      # assert the STH was actually signed and persisted for this tenant.
+      sth = AuditChain.get_latest_sth(tenant.id)
+      assert %AuditChain.SignedTreeHead{} = sth
+      assert sth.chain_position == 0
     end
   end
 end

--- a/test/loopctl/workers/compute_sth_worker_test.exs
+++ b/test/loopctl/workers/compute_sth_worker_test.exs
@@ -29,8 +29,12 @@ defmodule Loopctl.Workers.ComputeSthWorkerTest do
   end
 
   # Mirrors the jitter derivation in ComputeSthWorker (AC-32.5.2): bounded,
-  # deterministic-per-tenant, independent of the unique dedup key.
-  defp expected_jitter(tenant_id), do: rem(:erlang.phash2(tenant_id), 56)
+  # deterministic-per-tenant, independent of the unique dedup key. The window
+  # itself is pulled from `ComputeSthWorker.jitter_window_seconds/0` (the
+  # implementation's single source of truth) so this can never silently drift
+  # from `@jitter_window_seconds` if the window is retuned.
+  defp expected_jitter(tenant_id),
+    do: rem(:erlang.phash2(tenant_id), ComputeSthWorker.jitter_window_seconds())
 
   describe "perform/1 with mode: all_tenants" do
     test "TC-32.5.1: one job per active tenant via batch, each within the jitter window" do
@@ -58,19 +62,26 @@ defmodule Loopctl.Workers.ComputeSthWorkerTest do
       assert Enum.sort(enqueued_tenant_ids) == Enum.sort([active_1.id, active_2.id, active_3.id])
       refute inactive.id in enqueued_tenant_ids
 
+      max_jitter = ComputeSthWorker.jitter_window_seconds() - 1
+
       for job <- tenant_jobs do
         tenant_id = job.args["tenant_id"]
         diff = DateTime.diff(job.scheduled_at, now)
         expected = expected_jitter(tenant_id)
 
-        assert diff in 0..55
         # `scheduled_at` is computed from `utc_now()` at build time (after
         # `now` was captured above), and DateTime.diff truncates to whole
         # seconds -- so diff normally equals `expected` but can be
-        # `expected + 1` if wall-clock time crosses a second boundary
-        # between capturing `now` and building the job. Tolerate that one
-        # second of build-time elapsed rather than asserting exact equality.
+        # `expected + 1` if wall-clock time crosses a second boundary between
+        # capturing `now` and building the job. A single hard bound tolerates
+        # that one second of build-time elapsed while still enforcing
+        # AC-32.5.2's [0, max_jitter] production bound: at `expected ==
+        # max_jitter` the tolerated `expected + 1` is `max_jitter + 1`, so the
+        # hard bound must extend one second past `max_jitter` too (previously
+        # two separate assertions contradicted each other exactly at that
+        # boundary).
         assert diff in expected..(expected + 1)
+        assert diff in 0..(max_jitter + 1)
       end
     end
 


### PR DESCRIPTION
## Summary
- `ComputeSthWorker`'s `all_tenants` branch replaced its N-round-trip `Oban.insert/1` loop with a single `Oban.insert_all/1` batch, one changeset per active tenant.
- Each per-tenant job now carries a bounded, deterministic `schedule_in: rem(:erlang.phash2(tenant_id), 56)` (0-55s) jitter, so the fanout no longer thundering-herds the `:audit` queue and primary at the exact `:00` cron tick.
- `AdminRepo` (BYPASSRLS) + `status == :active` filter, worker header options (`queue: :audit`, `max_attempts: 3`, `unique: [fields: [:worker, :args], period: 30]`), and the per-tenant `%{"tenant_id" => id}` STH-computation branch are all unchanged.
- Empty active-tenant list still returns `:ok` with zero jobs enqueued (`Oban.insert_all([])` is a no-op).

## Test plan
- [x] New `test/loopctl/workers/compute_sth_worker_test.exs` (`async: true`):
  - TC-32.5.1: one job per active tenant via the batch, inactive tenant excluded, each job's `scheduled_at` within the `[0,55]`s jitter window and matching the deterministic `phash2` value.
  - TC-32.5.2: zero active tenants is a no-op (`:ok`, no tenant jobs enqueued).
  - TC-32.5.3: the per-tenant `tenant_id` branch still signs/stores the tree head unchanged.
- [x] `mix precommit` green (compile --warnings-as-errors, format, credo --strict, deps.audit, dialyzer, full test suite: 4242 tests, 0 failures).