### PR TITLE
docs(epic_33): DB Connection Topology stories (US-33.1..33.7)

### DIFF
--- a/docs/user_stories/epic_33_db_topology/README.md
+++ b/docs/user_stories/epic_33_db_topology/README.md
@@ -1,0 +1,36 @@
+# Epic 33 — DB Connection Topology & AdminRepo Hot Path
+
+Remediation of GitHub issue **#348** (roadmap Epic 1, tracked **#355**) — the do-first root cause of the "degraded under one heavy agent" incident.
+
+## The problem (verified against live code)
+
+Every authenticated request runs **5 AdminRepo queries incl. 2 writes** on a **3-connection** BYPASSRLS pool, while the 10-connection RLS `Repo` pool sits nearly idle:
+
+1. `SELECT api_keys` by key_hash + `preload: [:tenant]` (`auth.ex:83`)
+2. `UPDATE api_keys.last_used_at` (`auth.ex:197`) — **write**
+3. `SELECT agents` (`agents.ex:154`)
+4. `UPDATE agents.last_seen_at` (`agents.ex:161`) — **write**
+5. `SELECT tenants` for custody halt (`tenants.ex:680`) — **redundant**, tenant already loaded by #1
+
+Plus a token-report N+1 (`get_scope_spend` per budget) on the same pool.
+
+## Decomposition — safe wins first, blanket reroute avoided
+
+Grounding (see the DB-topology map) showed the roadmap's headline "route all OLTP through the RLS Repo" is **high-risk on a live system and likely unnecessary**: the hot-path pressure is relieved far more safely by targeted fixes. So the blanket reroute is replaced by a flag-guarded, measured **pilot** (US-33.7).
+
+| Story | Title | Risk | #348 aspect | Depends |
+|-------|-------|------|-------------|---------|
+| US-33.1 | Per-pool `queue_time` telemetry (Repo + AdminRepo) | Low (additive) | measure first | — |
+| US-33.2 | Drop redundant tenant re-SELECT (#5) | Low (pure win) | fewer hot-path queries | — |
+| US-33.3 | ETS cache for api-key resolution (#1) | **Med — security** | remove hot-path SELECT | — |
+| US-33.4 | Debounce last_seen/last_used writes (#2,#4) | Med | remove hot-path writes | — |
+| US-33.5 | Batch token-spend N+1 | Med | reduce AdminRepo fan-out | — |
+| US-33.6 | Rebalance pool sizes + DbCapacity | Low-Med (config) | re-size to where load lands | US-33.1 |
+| US-33.7 | Flag-guarded RLS-reroute **pilot** (1 read path) | **High** | validate reroute safely | US-33.1 |
+
+## Non-negotiable constraints (system is LIVE with agents doing KB retrieval)
+
+- **US-33.3 is a security boundary:** a revoked/rotated key must NEVER authenticate from stale cache — invalidation on every revoke/rotate path + bounded TTL are release gates.
+- **US-33.7 is a security boundary:** RLS-parity + tenant-isolation + fail-closed tests are release gates; the flag stays OFF in prod unless the prod Repo role is verified to lack BYPASSRLS.
+- Every merge auto-deploys behind the **smoke gate** (DB+Oban liveness, KB/retrieval/memory/auth hard-checked) with a KB-health check either side. Config/flag changes default to current behavior.
+- No migration here is expected; any added index is online (`CONCURRENTLY`).

--- a/docs/user_stories/epic_33_db_topology/us_33.1.json
+++ b/docs/user_stories/epic_33_db_topology/us_33.1.json
@@ -1,0 +1,48 @@
+{
+  "id": "US-33.1",
+  "title": "Per-pool checkout queue_time telemetry for Repo and AdminRepo",
+  "epic": { "id": "epic_33", "name": "DB Connection Topology & AdminRepo Hot Path" },
+  "priority": "high",
+  "phase": "scalability",
+  "priority_note": "MEASURE FIRST. Prerequisite for US-33.6 (pool rebalance) and US-33.7 (reroute decision) — do not resize pools blind.",
+  "background": {
+    "reference": "GH #348. Ecto emits [:loopctl, :repo, :query] / [:loopctl, :admin_repo, :query] with queue_time/query_time/total_time; only heavy_read_repo is currently wired into a metric (lib/loopctl/telemetry/scale_metrics.ex, LoopctlWeb.Telemetry.metrics/0). No per-pool checkout-wait metric exists for Repo or AdminRepo.",
+    "includes": "The auth hot path runs 5 AdminRepo queries (2 writes) per request on a 3-connection pool while the RLS Repo pool of 10 is nearly idle. There is no metric proving where checkout contention actually lands, so any pool resize would be guesswork."
+  },
+  "story": {
+    "as_a": "loopctl operator",
+    "i_want_to": "export per-pool connection-checkout queue_time (p95/p99) for Repo and AdminRepo to Prometheus",
+    "so_that": "I can empirically confirm the AdminRepo pool is the checkout bottleneck and re-derive pool sizing from data instead of guessing"
+  },
+  "rationale": "Ecto already measures queue_time (time spent waiting for a pooled connection) on every query, but it's only surfaced for HeavyReadRepo. Without a Repo/AdminRepo checkout-wait metric, the roadmap's central claim — that the 3-connection AdminRepo pool saturates while the 10-connection Repo idles — is unverified, and US-33.6's pool resize would be blind. This is a pure-add observability story that de-risks every later story in the epic.",
+  "acceptance_criteria": [
+    { "id": "AC-33.1.1", "description": "ScaleMetrics attaches to the Ecto query telemetry events for `Loopctl.Repo` and `Loopctl.AdminRepo` and exports a `queue_time` distribution (or summary) metric per repo, tagged by repo name, into LoopctlWeb.Telemetry.metrics/0 (Prometheus at :9568/metrics). Reuse the existing heavy_read_repo pattern.", "status": "pending" },
+    { "id": "AC-33.1.2", "description": "Tag cardinality is bounded — the metric is keyed by repo (and optionally a small fixed source label), NEVER by tenant_id or query text, to avoid Prometheus cardinality blowup. Follow the existing tenant-label cap gate discipline in scale_metrics.ex.", "status": "pending" },
+    { "id": "AC-33.1.3", "description": "`queue_time` is converted to the metric's unit consistently (Ecto emits native time units; convert to milliseconds) matching the existing heavy_read_repo.query.duration convention.", "status": "pending" },
+    { "id": "AC-33.1.4", "description": "Purely additive: no query, transaction, or request behavior changes; the telemetry handler is a lightweight :telemetry.attach that does no DB work and cannot raise into the query path (handler is defensive).", "status": "pending" },
+    { "id": "AC-33.1.5", "description": "No new hot-path cost: attaching a telemetry handler must not add per-query DB round-trips; it only reads measurements already emitted by Ecto.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-33.1.1", "name": "queue_time metric is defined for both pools", "type": "unit",
+      "preconditions": [],
+      "steps": ["read LoopctlWeb.Telemetry.metrics/0 (or ScaleMetrics.scale_metrics/0)"],
+      "expected_results": ["a queue_time distribution/summary metric exists for Repo and for AdminRepo, tagged by repo, in milliseconds"], "status": "pending" },
+    { "id": "TC-33.1.2", "name": "handler records a queue_time measurement without error", "type": "unit",
+      "preconditions": ["the telemetry handler attached"],
+      "steps": ["execute :telemetry.execute([:loopctl, :admin_repo, :query], %{queue_time: 1_000_000, query_time: 500_000, total_time: 1_500_000}, %{})"],
+      "expected_results": ["handler runs without raising; no DB call is made by the handler"], "status": "pending" },
+    { "id": "TC-33.1.3", "name": "tag cardinality is bounded (no tenant/query tags)", "type": "unit",
+      "preconditions": [],
+      "steps": ["inspect the metric's :tags"],
+      "expected_results": ["tags contain only bounded labels (repo, maybe a small fixed set); no tenant_id, no query string"], "status": "pending" }
+  ],
+  "technical_notes": [
+    "Module: lib/loopctl/telemetry/scale_metrics.ex; metric list merged in LoopctlWeb.Telemetry.metrics/0.",
+    "Ecto telemetry: config the repos' telemetry_prefix is [:loopctl, :repo] / [:loopctl, :admin_repo]; the :query event measurement `queue_time` is the connection-checkout wait. Convert native → :millisecond.",
+    "Prefer Telemetry.Metrics.distribution or summary with reporter_options for Prometheus buckets consistent with heavy_read_repo.query.duration.",
+    "DI/config conventions: no Application.put_env in tests; async:true; the handler must be idempotent and defensive (rescue) so a telemetry error never propagates into a query.",
+    "No tenant data is read; this is global infra telemetry. Still add a test asserting bounded tags (cardinality is the multi-tenant risk here)."
+  ],
+  "dependencies": [],
+  "estimated_tokens": 180000
+}

--- a/docs/user_stories/epic_33_db_topology/us_33.2.json
+++ b/docs/user_stories/epic_33_db_topology/us_33.2.json
@@ -1,0 +1,47 @@
+{
+  "id": "US-33.2",
+  "title": "Drop the redundant tenant re-SELECT in CheckCustodyHalt (reuse loaded tenant)",
+  "epic": { "id": "epic_33", "name": "DB Connection Topology & AdminRepo Hot Path" },
+  "priority": "high",
+  "phase": "scalability",
+  "priority_note": "Pure win, lowest risk: removes 1 of 5 per-request AdminRepo queries with no behavior change.",
+  "background": {
+    "reference": "GH #348. Pipeline lib/loopctl_web/router.ex:20-31. ResolveApiKey/Auth.verify_api_key already loads api_key with preload: [:tenant] (lib/loopctl/auth.ex:83), populating current_api_key/current_tenant assigns. CheckCustodyHalt then calls Tenants.get_tenant/1 (lib/loopctl/tenants.ex:680, AdminRepo.get) purely to read custody_halted_at.",
+    "includes": "Every authenticated request performs a 5th AdminRepo SELECT to re-fetch the tenant that was ALREADY loaded (with custody_halted_at) by the api-key preload earlier in the same pipeline."
+  },
+  "story": {
+    "as_a": "loopctl platform",
+    "i_want_to": "have CheckCustodyHalt read custody_halted_at from the tenant already loaded into conn assigns instead of re-SELECTing it",
+    "so_that": "each authenticated request drops from 5 to 4 AdminRepo queries with zero change to custody-halt enforcement"
+  },
+  "rationale": "The custody-halt plug re-selects the tenant row that the api-key resolution already loaded microseconds earlier in the same request, spending a scarce AdminRepo connection to read a field that is already in memory. Reusing the assign is a behavior-preserving removal of a per-request round-trip on the 3-connection pool — the cheapest, safest reduction in the epic.",
+  "acceptance_criteria": [
+    { "id": "AC-33.2.1", "description": "CheckCustodyHalt reads custody_halted_at from the already-populated `current_tenant` (or `current_api_key.tenant`) assign when present, and only falls back to a DB fetch if the tenant is not in assigns (defensive — e.g. an unauthenticated/edge path). The custody-halt decision (halt when custody_halted_at is set) is byte-for-byte identical.", "status": "pending" },
+    { "id": "AC-33.2.2", "description": "The api-key preload continues to include :tenant with custody_halted_at populated; confirm the assign carries the field the plug needs (add to preload/select if it was being dropped).", "status": "pending" },
+    { "id": "AC-33.2.3", "description": "No weakening of enforcement: a request from a custody-halted tenant is still blocked with the same status/error; a non-halted tenant still passes. Superadmin/tenant-less (tenant_id nil) paths behave as before.", "status": "pending" },
+    { "id": "AC-33.2.4", "description": "Freshness note: reusing the preloaded tenant means custody_halted_at reflects its value at api-key resolution time (same request, microseconds earlier) — document that this is acceptable because both reads are within the same request and a halt set mid-request is caught on the next request.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-33.2.1", "name": "custody-halted tenant is blocked without a re-SELECT", "type": "integration",
+      "preconditions": ["tenant = fixture(:tenant, custody_halted_at: now)", "{key,_} = fixture(:api_key, tenant_id: tenant.id, role: :agent)"],
+      "steps": ["make an authenticated request with key"],
+      "expected_results": ["request is blocked by custody halt (same status/error as before)", "no additional Tenants.get_tenant SELECT is issued for the halt check (assert via query count/telemetry or by asserting the plug uses the assign)"], "status": "pending" },
+    { "id": "TC-33.2.2", "name": "non-halted tenant passes", "type": "integration",
+      "preconditions": ["tenant = fixture(:tenant, custody_halted_at: nil)", "{key,_} = fixture(:api_key, tenant_id: tenant.id, role: :agent)"],
+      "steps": ["make an authenticated request"],
+      "expected_results": ["request proceeds to the controller normally"], "status": "pending" },
+    { "id": "TC-33.2.3", "name": "tenant isolation preserved", "type": "integration",
+      "preconditions": ["tenant_a halted, tenant_b not; keys for each"],
+      "steps": ["request as tenant_a (blocked), request as tenant_b (passes)"],
+      "expected_results": ["halt is per-tenant, driven by each request's own loaded tenant"], "status": "pending" }
+  ],
+  "technical_notes": [
+    "Plug: lib/loopctl_web/plugs/check_custody_halt.ex; assigns set by ResolveApiKey/SetTenant. current_api_key preload: lib/loopctl/auth.ex:83.",
+    "Read custody_halted_at from conn.assigns.current_tenant (or current_api_key.tenant); guard with a nil-fallback to the existing Tenants.get_tenant/1 so no path regresses.",
+    "Ensure the :tenant preload/select includes custody_halted_at (Ecto: struct field access, not map access).",
+    "Behavior-preserving: keep the exact halt response. Add a query-count assertion if the test support exposes one; otherwise assert the plug path uses the assign.",
+    "No migration, no new config."
+  ],
+  "dependencies": [],
+  "estimated_tokens": 150000
+}

--- a/docs/user_stories/epic_33_db_topology/us_33.3.json
+++ b/docs/user_stories/epic_33_db_topology/us_33.3.json
@@ -1,0 +1,60 @@
+{
+  "id": "US-33.3",
+  "title": "ETS read-through cache for API-key resolution (revoke/rotate-invalidated, bounded TTL)",
+  "epic": { "id": "epic_33", "name": "DB Connection Topology & AdminRepo Hot Path" },
+  "priority": "high",
+  "phase": "scalability",
+  "priority_note": "Highest single hot-path win (removes SELECT+preload from every request) AND the most security-sensitive — a stale cache must NEVER authenticate a revoked/rotated key.",
+  "background": {
+    "reference": "GH #348. Auth.verify_api_key/1 (lib/loopctl/auth.ex:83) does AdminRepo.one(SELECT api_keys by key_hash + preload: [:tenant]) then update_last_used (auth.ex:197, UPDATE) on EVERY authenticated request. Mirror the supervised ETS-owner pattern from US-32.3 (SettingsCache) / EmbeddingCircuitBreaker.",
+    "includes": "The api-key SELECT+preload is the single most-repeated query in the system (every authenticated request). It is on the 3-connection AdminRepo pool. Caching it by key_hash removes that read from the hot path — but auth caching is a security boundary: revocation and rotation MUST invalidate immediately."
+  },
+  "story": {
+    "as_a": "loopctl platform",
+    "i_want_to": "resolve API keys through a short-TTL ETS read-through cache keyed by key_hash, invalidated the instant a key is revoked or rotated",
+    "so_that": "the per-request api-key SELECT+preload leaves the AdminRepo hot path without ever letting a revoked or rotated key authenticate from stale cache"
+  },
+  "rationale": "Because every authenticated request re-reads the same api_keys row, a read-through cache keyed by key_hash converts a per-request DB SELECT into a per-change one — the largest hot-path reduction available. The entire risk is correctness of invalidation: a cached entry for a key that is later revoked or rotated must not authenticate. The design therefore pairs a short bounded TTL (defense-in-depth) with explicit invalidation on every revoke/rotate path, so a compromised or retired key is rejected immediately, not after a TTL.",
+  "acceptance_criteria": [
+    { "id": "AC-33.3.1", "description": "A supervised ETS-owner (GenServer in the app tree, mirroring US-32.3 SettingsCache) owns a `:public`, `:named_table`, read-concurrency table keyed by key_hash, storing the resolved api_key struct WITH its :tenant preloaded and a stored expiry timestamp. verify_api_key becomes read-through: on hit-and-fresh, return the cached struct with NO AdminRepo SELECT; on miss/expired, load from AdminRepo, preload :tenant, store, return.", "status": "pending" },
+    { "id": "AC-33.3.2", "description": "SECURITY — invalidate on revoke: every path that sets api_keys.revoked_at (single revoke, RevokeExpiredDispatchesWorker cascade auth.ex/dispatches, tenant audit-key rotation, break-glass) deletes the cache entry for that key_hash within the same operation. A revoked key returns unauthorized on the very next request (test-proven), not after the TTL.", "status": "pending" },
+    { "id": "AC-33.3.3", "description": "SECURITY — invalidate on rotate/mutate: creating, rotating, or otherwise mutating a key (any change to hash/role/scopes/expiry) invalidates the affected key_hash entries so a rotated secret or a role/scope change takes effect immediately.", "status": "pending" },
+    { "id": "AC-33.3.4", "description": "Defense-in-depth bounded TTL: cached entries carry a short max lifetime (config, e.g. default 30-60s) after which they are re-validated against the DB even absent an explicit invalidation — so any missed invalidation path self-heals within the TTL rather than persisting. TTL is checked on read (lazy expiry); no unbounded staleness.", "status": "pending" },
+    { "id": "AC-33.3.5", "description": "The cache stores the AUTHORIZATION-relevant fields (revoked_at, expires_at, role, scopes, tenant with custody_halted_at). verify_api_key still enforces revoked_at/expires_at from the cached struct (a cached-but-now-expired-by-wallclock key is rejected the same as an uncached one). Never cache across tenants incorrectly — key_hash is globally unique so entries are self-scoped.", "status": "pending" },
+    { "id": "AC-33.3.6", "description": "The per-request last_used_at UPDATE (auth.ex:197) is NOT part of this story's cache read path decision (it is addressed by US-33.4's write debounce); this story only removes the SELECT. If US-33.4 has not merged, the UPDATE still fires — the SELECT removal is independently correct.", "status": "pending" },
+    { "id": "AC-33.3.7", "description": "Cold start / GenServer restart yields an empty table that repopulates read-through; secrets/hashes are never logged or put in telemetry tags.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-33.3.1", "name": "second request for the same key skips the DB SELECT", "type": "integration",
+      "preconditions": ["tenant = fixture(:tenant)", "{key,_} = fixture(:api_key, tenant_id: tenant.id, role: :agent)"],
+      "steps": ["verify_api_key(key) twice within the TTL"],
+      "expected_results": ["both resolve the same api_key+tenant", "the second resolves from ETS (assert by mutating the DB row directly and confirming the cached value is returned until invalidation/TTL)"], "status": "pending" },
+    { "id": "TC-33.3.2", "name": "SECURITY: revoked key is rejected on the very next request (no TTL wait)", "type": "integration",
+      "preconditions": ["{key, ak} = fixture(:api_key, ...)", "verify_api_key(key) once to populate cache"],
+      "steps": ["revoke the key (set revoked_at via the revoke path)", "verify_api_key(key) again immediately"],
+      "expected_results": ["returns unauthorized/{:error,...} immediately (cache entry was invalidated by the revoke path), NOT the stale valid struct"], "status": "pending" },
+    { "id": "TC-33.3.3", "name": "SECURITY: rotated key hash change takes effect immediately", "type": "integration",
+      "preconditions": ["a key cached via a prior verify"],
+      "steps": ["rotate/mutate the key (role or hash change) via its mutation path", "verify_api_key with old vs new as applicable"],
+      "expected_results": ["the change is reflected immediately (old secret rejected / new role enforced), not after TTL"], "status": "pending" },
+    { "id": "TC-33.3.4", "name": "TTL self-heals a missed invalidation", "type": "integration",
+      "preconditions": ["a key cached; simulate a DB revoke WITHOUT calling the invalidation (to model a missed path) by expiring the entry"],
+      "steps": ["advance past TTL (inject clock or set a tiny TTL in test config)", "verify_api_key"],
+      "expected_results": ["entry is re-validated against the DB and the revoke is honored"], "status": "pending" },
+    { "id": "TC-33.3.5", "name": "tenant isolation of resolved keys", "type": "integration",
+      "preconditions": ["keys for tenant_a and tenant_b, both cached"],
+      "steps": ["revoke tenant_a's key", "verify tenant_b's key"],
+      "expected_results": ["tenant_b unaffected; tenant_a rejected"], "status": "pending" }
+  ],
+  "technical_notes": [
+    "Mirror US-32.3 SettingsCache / EmbeddingCircuitBreaker: supervised GenServer owns :public :named_table with read_concurrency in the app tree (lib/loopctl/application.ex), readers hit ETS directly.",
+    "Invalidation is the crux: audit EVERY revoked_at/rotation writer (Auth single-revoke, dispatches revoke cascade auth.ex:54, RevokeExpiredDispatchesWorker, tenant audit-key rotation, break-glass) and delete the key_hash entry in-band. A grep for `revoked_at` / `:revoke` writers is mandatory in implementation.",
+    "TTL is a hard backstop, NOT the primary invalidation — set a short default (30-60s) via config-based DI; make it test-overridable to a tiny value for TC-33.3.4 (config, not Application.put_env in test — use config/test.exs).",
+    "Store the tenant preload with custody_halted_at so it composes with US-33.2.",
+    "Never log key_hash or the raw key; keep them out of telemetry tags and error messages.",
+    "Chain-of-custody: this MUST NOT let a revoked implementer/reviewer key act — TC-33.3.2 is a release gate.",
+    "Consider cache size bound / eviction if key_hash space is large (LRU or periodic sweep) to cap memory; document the bound."
+  ],
+  "dependencies": [],
+  "estimated_tokens": 420000
+}

--- a/docs/user_stories/epic_33_db_topology/us_33.4.json
+++ b/docs/user_stories/epic_33_db_topology/us_33.4.json
@@ -1,0 +1,53 @@
+{
+  "id": "US-33.4",
+  "title": "Debounce last_seen_at / last_used_at touch-writes off the request path",
+  "epic": { "id": "epic_33", "name": "DB Connection Topology & AdminRepo Hot Path" },
+  "priority": "high",
+  "phase": "scalability",
+  "priority_note": "Removes the 2 per-request WRITES from the AdminRepo hot path — the write-amplification the roadmap calls out as row-lock contention + dead-tuple bloat.",
+  "background": {
+    "reference": "GH #348. Every authenticated request issues UPDATE api_keys.last_used_at (Auth.update_last_used, lib/loopctl/auth.ex:197) and UPDATE agents.last_seen_at (Agents.touch_last_seen, lib/loopctl/agents.ex:161) — both on AdminRepo (pool 3). A fast-looping agent hammers the SAME rows, causing row-lock contention and dead-tuple bloat.",
+    "includes": "These two timestamps are observational (‘when did this key/agent last act’) — they do not need per-request precision. Writing them on every request turns every READ request into 2 hot-row WRITES on the tiny AdminRepo pool."
+  },
+  "story": {
+    "as_a": "loopctl platform",
+    "i_want_to": "coalesce last_seen_at / last_used_at updates into an in-memory buffer flushed periodically (batched) instead of writing on every request",
+    "so_that": "the per-request write amplification and hot-row lock contention on the AdminRepo pool is removed while last-seen/last-used stay accurate to within the flush interval"
+  },
+  "rationale": "last_seen_at/last_used_at are liveness heuristics, not custody-critical facts, so a few seconds of staleness is harmless — but writing them synchronously on every request doubles the AdminRepo write load and concentrates it on a handful of hot rows (one api_key, one agent per busy agent), producing lock contention and table bloat. Buffering the latest timestamp per id and flushing in one batched UPDATE per interval collapses N per-request writes into one periodic write per active id.",
+  "acceptance_criteria": [
+    { "id": "AC-33.4.1", "description": "A supervised buffer (ETS + a periodic flusher GenServer, or an existing debounce mechanism) records the latest last_seen_at per agent id and last_used_at per api_key id in memory on each request (no DB write on the request path). A flusher periodically writes the buffered maxima in a batched UPDATE (e.g. update_all over the buffered ids, or upsert), then clears the flushed entries.", "status": "pending" },
+    { "id": "AC-33.4.2", "description": "The request path no longer performs the two touch UPDATEs synchronously; the plug/context records into the buffer instead. Net per-request AdminRepo writes for touch = 0.", "status": "pending" },
+    { "id": "AC-33.4.3", "description": "Flush is batched and tenant-safe: writes are grouped so one flush issues O(1) statements (or O(scopes)), not O(ids); each UPDATE is correctly scoped (by id, which is globally unique) so no cross-tenant write. monotonic: a flush only advances a timestamp forward (never regresses last_seen/last_used to an older value than what's in the DB).", "status": "pending" },
+    { "id": "AC-33.4.4", "description": "Bounded staleness: flush interval is config (default a few seconds). last_seen_at/last_used_at are at most one interval stale — documented and acceptable for a liveness heuristic. On graceful shutdown the buffer is flushed; on crash, at most one interval of buffered touches is lost (acceptable — best-effort).", "status": "pending" },
+    { "id": "AC-33.4.5", "description": "No semantic consumer of last_seen_at/last_used_at requires per-request freshness — verify (grep) that nothing gates auth/custody on an exact last_used_at; if something does, it is out of scope or must read through the buffer. Document the audit.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-33.4.1", "name": "request records touch in buffer, no synchronous UPDATE", "type": "integration",
+      "preconditions": ["tenant + agent + api_key fixtures", "buffer/flusher started"],
+      "steps": ["make an authenticated request", "before a flush, inspect the DB row"],
+      "expected_results": ["no synchronous last_used/last_seen UPDATE occurred on the request path (assert via query count or buffer contents); the buffer holds the pending timestamp"], "status": "pending" },
+    { "id": "TC-33.4.2", "name": "flush writes the latest buffered timestamp (batched, monotonic)", "type": "integration",
+      "preconditions": ["several requests for the same agent+key buffered"],
+      "steps": ["trigger a flush"],
+      "expected_results": ["one batched UPDATE advances last_seen_at/last_used_at to the newest buffered value; the value only moves forward"], "status": "pending" },
+    { "id": "TC-33.4.3", "name": "multiple ids flushed in one batch", "type": "integration",
+      "preconditions": ["requests for 3 different agents buffered"],
+      "steps": ["trigger a flush"],
+      "expected_results": ["all 3 agents updated in O(1)/O(scopes) statements, each to its own newest timestamp"], "status": "pending" },
+    { "id": "TC-33.4.4", "name": "tenant isolation preserved", "type": "integration",
+      "preconditions": ["agents in tenant_a and tenant_b buffered"],
+      "steps": ["flush"],
+      "expected_results": ["each agent's own row updated; no cross-tenant write (ids are unique)"], "status": "pending" }
+  ],
+  "technical_notes": [
+    "Buffer: ETS keyed by {:agent, id} / {:api_key, id} holding max timestamp; flusher GenServer on a config interval (Process.send_after) does update_all grouped by table. Supervise in application.ex.",
+    "Plug UpdateLastSeen (lib/loopctl_web/plugs/update_last_seen.ex) + Agents.touch_last_seen (agents.ex:161) + Auth.update_last_used (auth.ex:197) are the write sites to redirect into the buffer.",
+    "Monotonic UPDATE: `set last_seen_at = GREATEST(last_seen_at, $buffered)` or a WHERE guard so a delayed flush can't move it backward.",
+    "Config-based DI for the interval; flush on terminate/ shutdown. No Application.put_env in tests.",
+    "This composes with US-33.3 (which removes the SELECT); together the touch path becomes read-cache + buffered-write.",
+    "Best-effort semantics: acceptable to lose <1 interval of touches on crash; DO NOT use this pattern for any custody/audit write."
+  ],
+  "dependencies": [],
+  "estimated_tokens": 340000
+}

--- a/docs/user_stories/epic_33_db_topology/us_33.5.json
+++ b/docs/user_stories/epic_33_db_topology/us_33.5.json
@@ -1,0 +1,51 @@
+{
+  "id": "US-33.5",
+  "title": "Reuse batch_attach_spend on the token-usage budget-threshold path (kill the N+1)",
+  "epic": { "id": "epic_33", "name": "DB Connection Topology & AdminRepo Hot Path" },
+  "priority": "medium",
+  "phase": "scalability",
+  "priority_note": "Collapses the per-report N (1-3) get_scope_spend queries into the existing batched aggregate — reduces AdminRepo fan-out on every token report.",
+  "background": {
+    "reference": "GH #348. TokenUsage.check_budget_thresholds/2 (lib/loopctl/token_usage.ex:938-942) calls get_scope_spend/3 (:896, AdminRepo.one) ONCE PER applicable budget (story/epic/project → up to 3 queries). batch_attach_spend/2 (:1339) already batches spend into ≤3 queries (one AdminRepo.all per scope_type via batch_spend_query/3 :1361) — but it is only used by list_budgets/2 (:744), NOT on the report/threshold hot path.",
+    "includes": "Every token-usage report (POST /api/v1/token-usage and Progress.report_story) triggers check_budget_thresholds, which fans out 1 get_scope_spend query per applicable budget on the 3-connection AdminRepo pool — an N+1 that the already-tested batch_attach_spend eliminates."
+  },
+  "story": {
+    "as_a": "loopctl platform",
+    "i_want_to": "compute per-budget spend on the threshold-check path via the existing batched batch_attach_spend/batch_spend_query instead of one get_scope_spend query per budget",
+    "so_that": "each token report issues O(scopes) spend queries instead of O(applicable budgets), cutting AdminRepo fan-out with no change to threshold decisions"
+  },
+  "rationale": "The batched spend aggregate already exists and is proven by list_budgets, but the hotter threshold path re-implements it as a per-budget loop, multiplying AdminRepo queries on every report. Routing the threshold check through the same batched query is a behavior-preserving consolidation: the same spend numbers, the same threshold crossings, fewer round-trips on the scarce pool.",
+  "acceptance_criteria": [
+    { "id": "AC-33.5.1", "description": "check_budget_thresholds/2 obtains each applicable budget's spend via batch_attach_spend/2 (or batch_spend_query/3) in ≤ O(distinct scope_types) AdminRepo queries, replacing the per-budget get_scope_spend/3 calls. The spend value used for each threshold comparison is identical to the current per-budget computation (same countable_reports/exclude_stranded_corrections rules).", "status": "pending" },
+    { "id": "AC-33.5.2", "description": "Threshold-crossing behavior is byte-for-byte unchanged: the same budgets cross the same thresholds, the same claim_budget_threshold CAS + emit_threshold_crossed + fire_budget_event + WebhookEvent + Oban side effects fire, in the same conditions.", "status": "pending" },
+    { "id": "AC-33.5.3", "description": "Tenant isolation: batched spend is scoped to the report's tenant exactly as get_scope_spend was (AdminRepo with explicit tenant predicate); no cross-tenant spend leakage.", "status": "pending" },
+    { "id": "AC-33.5.4", "description": "find_applicable_budgets' own 2 queries (get_by(Story) for epic_id + all(Budget)) are out of scope OR opportunistically reduced if trivial; the story's core is replacing the per-budget spend loop.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-33.5.1", "name": "threshold crossing fires identically via batched spend", "type": "integration",
+      "preconditions": ["tenant + project/epic/story budgets set", "prior reports pushing spend near a threshold"],
+      "steps": ["create a report that crosses a threshold"],
+      "expected_results": ["the same threshold-crossed event/webhook/Oban side effects fire as before; spend value matches the per-budget computation"], "status": "pending" },
+    { "id": "TC-33.5.2", "name": "fewer spend queries per report", "type": "integration",
+      "preconditions": ["a report applying to 3 budgets (story+epic+project)"],
+      "steps": ["create the report"],
+      "expected_results": ["spend is computed in ≤ O(scope_types) AdminRepo queries (assert via query count/telemetry), not 3 separate get_scope_spend calls"], "status": "pending" },
+    { "id": "TC-33.5.3", "name": "no threshold crossing when under budget", "type": "integration",
+      "preconditions": ["budgets with spend well under thresholds"],
+      "steps": ["create a report"],
+      "expected_results": ["no threshold event fires; batched spend matches per-budget spend"], "status": "pending" },
+    { "id": "TC-33.5.4", "name": "tenant isolation of spend", "type": "integration",
+      "preconditions": ["tenant_a and tenant_b each with budgets + reports"],
+      "steps": ["report for tenant_a"],
+      "expected_results": ["only tenant_a spend is aggregated; tenant_b spend never included"], "status": "pending" }
+  ],
+  "technical_notes": [
+    "Module: lib/loopctl/token_usage.ex. Reuse batch_attach_spend/2 (:1339) / batch_spend_query/3 (:1361); the per-budget path is get_scope_spend/3 (:896) inside check_budget_thresholds (:938-942).",
+    "Preserve countable_reports/1 + Report.exclude_stranded_corrections (report.ex:174) so the numbers match exactly.",
+    "This is a hot path reached by both POST /token-usage and Progress.report_story/4 — keep all side effects (CAS claim, audit, webhook, Oban) identical.",
+    "AdminRepo stays (token_usage is AdminRepo-based); this reduces the NUMBER of AdminRepo queries, not the repo.",
+    "Add a query-count assertion (TC-33.5.2) to lock in the reduction."
+  ],
+  "dependencies": [],
+  "estimated_tokens": 300000
+}

--- a/docs/user_stories/epic_33_db_topology/us_33.6.json
+++ b/docs/user_stories/epic_33_db_topology/us_33.6.json
@@ -1,0 +1,48 @@
+{
+  "id": "US-33.6",
+  "title": "Rebalance Repo/AdminRepo pool sizes against measured checkout-wait; keep DbCapacity in lockstep",
+  "epic": { "id": "epic_33", "name": "DB Connection Topology & AdminRepo Hot Path" },
+  "priority": "medium",
+  "phase": "scalability",
+  "priority_note": "Do AFTER US-33.1 (metrics) and ideally after 33.2-33.4 relieve the AdminRepo hot path — resize from data, not guesswork; must stay within the verified 100-connection budget.",
+  "background": {
+    "reference": "GH #348. runtime.exs prod pools: Repo=POOL_SIZE/10, AdminRepo=ADMIN_POOL_SIZE/3, HeavyReadRepo=HEAVY_READ_POOL_SIZE/8 (per-node total 21). DbCapacity (lib/loopctl/db_capacity.ex) hardcodes @prod_pool_sizes %{repo: 10, admin_repo: 3, heavy_read_repo: 8} and is pinned by db_capacity_test.exs; @verified_live_max_connections 100.",
+    "includes": "The AdminRepo pool (3) carries the auth hot path while the RLS Repo pool (10) is nearly idle — capacity is sized backwards vs where load lands. US-33.1 adds the per-pool queue_time metric needed to right-size."
+  },
+  "story": {
+    "as_a": "loopctl operator",
+    "i_want_to": "rebalance the Repo and AdminRepo pool sizes based on the measured per-pool checkout-wait, keeping DbCapacity's budget model and the 100-connection ceiling consistent",
+    "so_that": "connection capacity is allocated where load actually lands (AdminRepo hot path) without exceeding the verified max_connections or breaking the per-node budget math"
+  },
+  "rationale": "With the hot path relieved (33.2-33.4) and per-pool checkout-wait now measured (33.1), pool sizes should reflect real contention: AdminRepo likely needs more than 3 (it carries auth + OLTP), while the idle RLS Repo can cede headroom — all within the verified 100-connection ceiling and the per-node budget the DbCapacity model enforces. Sizing must stay coupled to DbCapacity or the boot-time budget check and the max-nodes math silently drift.",
+  "acceptance_criteria": [
+    { "id": "AC-33.6.1", "description": "Pool sizes (Repo/AdminRepo, and HeavyRead if touched) are re-derived from the US-33.1 checkout-wait data and updated in runtime.exs via the existing env-var/default mechanism. The new per-node total × peak-deploy-overlap + notifier + fixed_ops stays STRICTLY under @verified_live_max_connections (100) at EXPECTED_APP_NODES — computed, not asserted by hand.", "status": "pending" },
+    { "id": "AC-33.6.2", "description": "DbCapacity @prod_pool_sizes is updated to match the new runtime.exs defaults (db_capacity_test.exs enforces lockstep); max_supported_nodes/peak_total recomputed and the test updated to the new expected values.", "status": "pending" },
+    { "id": "AC-33.6.3", "description": "The boot-time warn_if_over_budget/0 (SHOW max_connections) still runs and logs; the new totals do not trip it. queue_target/queue_interval are left as-is unless the data shows they need adjustment (documented if changed).", "status": "pending" },
+    { "id": "AC-33.6.4", "description": "Change is config-only and reversible via env vars (POOL_SIZE / ADMIN_POOL_SIZE / HEAVY_READ_POOL_SIZE) — an operator can revert a bad size without a deploy. pgbouncer-safe parameter guard (config_pgbouncer_safe_parameters_test) still passes.", "status": "pending" },
+    { "id": "AC-33.6.5", "description": "The PR documents the BEFORE/AFTER checkout-wait rationale (from 33.1 metrics or, if metrics not yet populated in prod, a conservative rebalance that only moves idle Repo headroom to AdminRepo while staying budget-neutral).", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-33.6.1", "name": "DbCapacity peak stays under the 100-connection ceiling", "type": "unit",
+      "preconditions": ["new pool sizes configured"],
+      "steps": ["compute DbCapacity.peak_total at EXPECTED_APP_NODES"],
+      "expected_results": ["peak_total < 100 (verified max_connections) with margin"], "status": "pending" },
+    { "id": "TC-33.6.2", "name": "DbCapacity and runtime.exs stay in lockstep", "type": "unit",
+      "preconditions": [],
+      "steps": ["compare @prod_pool_sizes to the runtime.exs defaults"],
+      "expected_results": ["they match (db_capacity_test passes with the new numbers)"], "status": "pending" },
+    { "id": "TC-33.6.3", "name": "max_supported_nodes recomputed correctly", "type": "unit",
+      "preconditions": ["new sizes"],
+      "steps": ["call DbCapacity.max_supported_nodes"],
+      "expected_results": ["returns the correctly-derived node count for the new per-node total"], "status": "pending" }
+  ],
+  "technical_notes": [
+    "Files: config/runtime.exs (pool defaults), lib/loopctl/db_capacity.ex (@prod_pool_sizes + recompute), test/loopctl/db_capacity_test.exs (update expected numbers).",
+    "Budget math: peak = per_node_total*nodes + per_node_total (deploy overlap) + notifier*nodes + fixed_ops; keep < 100. Prefer moving Repo headroom to AdminRepo to stay budget-neutral if prod metrics aren't yet conclusive.",
+    "Do NOT add startup :parameters (pgbouncer FATAL) — statement_timeout stays per-query SET LOCAL.",
+    "Reversible via env vars; no migration.",
+    "If 33.1 metrics aren't populated in prod at implementation time, make a conservative budget-neutral shift and note that a data-driven follow-up can tune further."
+  ],
+  "dependencies": ["US-33.1"],
+  "estimated_tokens": 220000
+}

--- a/docs/user_stories/epic_33_db_topology/us_33.7.json
+++ b/docs/user_stories/epic_33_db_topology/us_33.7.json
@@ -1,0 +1,54 @@
+{
+  "id": "US-33.7",
+  "title": "Flag-guarded RLS-Repo reroute pilot for one audited tenant-scoped read path",
+  "epic": { "id": "epic_33", "name": "DB Connection Topology & AdminRepo Hot Path" },
+  "priority": "medium",
+  "phase": "scalability",
+  "priority_note": "HIGHEST RISK, runs LAST. A flag-guarded PILOT of the RLS reroute (not the blanket ~75-module rewrite), gated on US-33.1 metrics still showing AdminRepo pressure after 33.2-33.6.",
+  "background": {
+    "reference": "GH #348 (‘Route tenant OLTP through the RLS Repo’). Repo.with_tenant/2 (lib/loopctl/repo.ex:81) sets transaction-local app.current_tenant_id via set_config; RLS policy `tenant_id = current_tenant_id()`. Prod Repo connects as a non-BYPASSRLS role (repo.ex:112) — RLS relies on that role, there is NO SET LOCAL ROLE in prod. Almost all OLTP currently uses AdminRepo with explicit tenant predicates.",
+    "includes": "The blanket AdminRepo→RLS reroute across ~75 modules is a separate epic-sized, high-risk rewrite (per-op transaction+set_config overhead; correctness depends on the prod role genuinely lacking BYPASSRLS; each query's implicit-vs-explicit predicate must be audited). This story instead PILOTS the mechanism on ONE high-volume, well-audited tenant-scoped READ path behind a flag, to validate RLS parity + measure the effect before any broader move."
+  },
+  "story": {
+    "as_a": "loopctl platform",
+    "i_want_to": "route one high-volume tenant-scoped read path through Repo.with_tenant behind a default-off config flag, proving RLS parity with the AdminRepo version",
+    "so_that": "we validate the RLS-reroute mechanism safely and measure whether shifting load off AdminRepo helps, without a blanket rewrite or a risky live flip"
+  },
+  "rationale": "The roadmap's headline reroute is high-value but high-risk on a live system, and the earlier stories (33.2-33.5) may relieve AdminRepo enough to make a blanket reroute unnecessary. A flag-guarded pilot on a single audited read path de-risks the whole idea: it proves RLS isolation matches the explicit-predicate version, measures the AdminRepo relief via US-33.1's metric, and gives a reversible on/off — turning an all-or-nothing architectural gamble into a measured, incremental decision.",
+  "acceptance_criteria": [
+    { "id": "AC-33.7.1", "description": "PREREQUISITE GATE: implementation first checks US-33.1's per-pool queue_time metric (prod or load-test). If AdminRepo checkout-wait is already healthy after 33.2-33.6, the story documents that finding, ships the flag+pilot wiring with the flag OFF, and does not push a reroute live — the mechanism + parity proof is still delivered. If AdminRepo still saturates, the pilot is the justified next step.", "status": "pending" },
+    { "id": "AC-33.7.2", "description": "ONE selected tenant-scoped READ path (e.g. a list/read in token_usage or work_breakdown that has a clean explicit tenant predicate and no cross-tenant semantics) gains an alternate implementation using Repo.with_tenant/2, selected by a config flag (default: AdminRepo path). No write paths, no custody/audit paths, no cross-tenant/admin paths are rerouted.", "status": "pending" },
+    { "id": "AC-33.7.3", "description": "RLS-PARITY PROOF: a test proves the RLS path returns EXACTLY the same rows as the AdminRepo path for the same tenant, AND that tenant A running the RLS path can never see tenant B's rows (RLS actually enforces, not just the explicit predicate). A negative test confirms that with the flag on, a missing/incorrect tenant context yields zero rows (fail-closed), never cross-tenant rows.", "status": "pending" },
+    { "id": "AC-33.7.4", "description": "PROD-ROLE SAFETY: the story documents/verifies that the prod Repo DB role lacks BYPASSRLS (so RLS is actually enforced) — since dev/test use SET LOCAL ROLE loopctl_app but prod relies on the connection role. If this cannot be verified, the flag stays OFF in prod and that is stated explicitly.", "status": "pending" },
+    { "id": "AC-33.7.5", "description": "Reversible + observable: the flag flips the path with no deploy dependency beyond config; the US-33.1 metric shows AdminRepo vs Repo checkout-wait so the effect is measurable; a rollback is a config flip. The extra per-op transaction+set_config cost of with_tenant is measured and reported (it may offset the pool relief for a cheap single-statement read).", "status": "pending" },
+    { "id": "AC-33.7.6", "description": "The PR explicitly states that the BLANKET reroute of all OLTP remains out of scope (a separate future epic), with this pilot's parity + cost findings as the evidence base for that decision.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-33.7.1", "name": "RLS path returns identical rows to AdminRepo path (same tenant)", "type": "integration",
+      "preconditions": ["tenant = fixture(:tenant) with seeded rows for the chosen read path"],
+      "steps": ["run the read via the AdminRepo path (flag off) and via the RLS path (flag on)"],
+      "expected_results": ["identical row sets / ids"], "status": "pending" },
+    { "id": "TC-33.7.2", "name": "RLS path enforces tenant isolation (cannot see other tenant)", "type": "integration",
+      "preconditions": ["tenant_a and tenant_b each with rows"],
+      "steps": ["run the RLS-path read as tenant_a (with tenant_a context)"],
+      "expected_results": ["only tenant_a rows; tenant_b rows never returned — enforced by RLS via with_tenant, matching the AdminRepo explicit-predicate result"], "status": "pending" },
+    { "id": "TC-33.7.3", "name": "fail-closed on missing tenant context", "type": "integration",
+      "preconditions": ["RLS path selected"],
+      "steps": ["invoke the read with no/blank tenant context"],
+      "expected_results": ["zero rows (fail-closed), never cross-tenant rows or an error that leaks other tenants"], "status": "pending" },
+    { "id": "TC-33.7.4", "name": "flag default routes to the AdminRepo path unchanged", "type": "integration",
+      "preconditions": ["default config (flag off)"],
+      "steps": ["run the read"],
+      "expected_results": ["uses the existing AdminRepo path; behavior identical to today"], "status": "pending" }
+  ],
+  "technical_notes": [
+    "Repo.with_tenant/2 (repo.ex:81) wraps a transaction + set_config('app.current_tenant_id', …, true). Note the EXTRA round-trip + transaction per call — measure whether it's worth it for a single-statement read.",
+    "Config-based DI flag (config/*.exs), default AdminRepo; NEVER Application.put_env in tests — exercise both paths via config or a passed selector in the test.",
+    "Pick a READ-ONLY, single-table, clean-tenant-predicate path. Explicitly exclude: writes, custody/audit, cross-tenant admin, Tenants/Auth (no tenant_id column / pre-tenant lookups — must stay AdminRepo).",
+    "The RLS-parity + isolation + fail-closed tests are release gates — this is a security boundary change.",
+    "Verify the prod role lacks BYPASSRLS before enabling in prod; otherwise RLS silently no-ops and you'd lose isolation while removing the explicit predicate. If unverified → flag stays OFF, documented.",
+    "This story deliberately does NOT reroute broadly; it establishes the pattern + evidence."
+  ],
+  "dependencies": ["US-33.1"],
+  "estimated_tokens": 400000
+}


### PR DESCRIPTION
Remediation of #348 (roadmap Epic 1, tracked #355), grounded against the live DB-topology hot path. Safe high-leverage wins first (telemetry, drop redundant SELECT, ETS api-key cache, debounce writes, batch spend, pool rebalance); the roadmap's high-risk blanket AdminRepo→RLS reroute is replaced with a flag-guarded, measured pilot (US-33.7). Security gates on US-33.3 (revoke/rotate cache invalidation) and US-33.7 (RLS parity/isolation/fail-closed). Docs-only; implemented next through the standard implement→review→CI-merge loop. No story may break live KB retrieval.