### PR TITLE
feat(epic_33): US-33.1 per-pool checkout queue_time telemetry for Repo and AdminRepo

### DIFF
--- a/lib/loopctl/telemetry/scale_metrics.ex
+++ b/lib/loopctl/telemetry/scale_metrics.ex
@@ -10,6 +10,14 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   The three metrics are MERGED into `LoopctlWeb.Telemetry.metrics/0` and exposed to
   Fly's managed Prometheus by the reporter on the internal `:9568/metrics` port.
 
+  US-33.1 adds TWO more, purely-additive metrics: per-pool connection-checkout
+  `queue_time` distributions for `Loopctl.Repo` (the RLS pool, size 10) and
+  `Loopctl.AdminRepo` (the BYPASSRLS pool, size 3). Ecto already emits `queue_time`
+  (native time spent WAITING for a pooled connection) on every query telemetry event;
+  today only `heavy_read_repo.query.duration` is scraped, so there is no way to see
+  where checkout contention lands between the two pools. See "Per-pool checkout
+  queue_time (US-33.1)" below.
+
   ## The three metrics
 
     1. **Timeout / DB-error counter** — `loopctl.db.error.count`, keyed by
@@ -148,6 +156,42 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
           "Hybrid resolver (US-31.2) provenance decisions, by provenance, hit/miss, and tenant.",
         tags: [:provenance, :hit, :tenant_id],
         tag_values: &hybrid_provenance_tags/1
+      ),
+
+      # 6. Per-pool checkout queue_time (US-33.1): the RLS `Loopctl.Repo` pool (size
+      #    10). Sourced from Ecto's default query event for that repo module
+      #    (`[:loopctl, :repo, :query]`). `repo` is a STATIC single-value tag (not
+      #    read from metadata) — the repo identity is encoded in the event name
+      #    itself, so `tag_values` can never raise and needs no cap gate (AC-33.1.2).
+      #    Distinct name from the existing `loopctl.repo.query.queue_time` SUMMARY in
+      #    `LoopctlWeb.Telemetry.base_metrics/0` — same name + different metric type
+      #    would conflict in the Prometheus reporter.
+      distribution("loopctl.repo.checkout.queue_time",
+        event_name: [:loopctl, :repo, :query],
+        measurement: :queue_time,
+        unit: {:native, :millisecond},
+        description: "Connection-checkout wait for the RLS Repo pool, by repo.",
+        tags: [:repo],
+        tag_values: &queue_time_tags_repo/1,
+        reporter_options: [
+          buckets: [1, 5, 10, 25, 50, 100, 250, 500, 1_000]
+        ]
+      ),
+
+      # 7. Per-pool checkout queue_time (US-33.1): the BYPASSRLS `Loopctl.AdminRepo`
+      #    pool (size 3). Sourced from Ecto's default query event for that repo
+      #    module (`[:loopctl, :admin_repo, :query]`). There was previously NO
+      #    queue_time metric at all for this pool.
+      distribution("loopctl.admin_repo.checkout.queue_time",
+        event_name: [:loopctl, :admin_repo, :query],
+        measurement: :queue_time,
+        unit: {:native, :millisecond},
+        description: "Connection-checkout wait for the AdminRepo pool, by repo.",
+        tags: [:repo],
+        tag_values: &queue_time_tags_admin_repo/1,
+        reporter_options: [
+          buckets: [1, 5, 10, 25, 50, 100, 250, 500, 1_000]
+        ]
       )
     ]
   end
@@ -212,6 +256,23 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
     options = Map.get(metadata, :options) || []
     %{endpoint: Keyword.get(options, :endpoint, :unknown)}
   end
+
+  @doc """
+  `tag_values` for the RLS `Loopctl.Repo` checkout `queue_time` distribution
+  (US-33.1). Returns a FIXED, static `%{repo: "repo"}` map — the repo identity is
+  already encoded in the event name (`[:loopctl, :repo, :query]`), so this ignores
+  `metadata` entirely and cannot raise regardless of what Ecto passes (AC-33.1.4).
+  """
+  @spec queue_time_tags_repo(map()) :: map()
+  def queue_time_tags_repo(_metadata), do: %{repo: "repo"}
+
+  @doc """
+  `tag_values` for the `Loopctl.AdminRepo` checkout `queue_time` distribution
+  (US-33.1). Returns a FIXED, static `%{repo: "admin_repo"}` map for the same
+  reason as `queue_time_tags_repo/1` — the event name already identifies the pool.
+  """
+  @spec queue_time_tags_admin_repo(map()) :: map()
+  def queue_time_tags_admin_repo(_metadata), do: %{repo: "admin_repo"}
 
   # The cap gate read on the hot path: a lock-free O(1) persistent_term lookup,
   # defaulting to `false` (aggregate) if unseeded — an un-warmed boot can never emit

--- a/lib/loopctl/telemetry/scale_metrics.ex
+++ b/lib/loopctl/telemetry/scale_metrics.ex
@@ -4,21 +4,24 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
 
   Turns the structured signals epic 27 already emits — `db_statement_timeout`
   (US-27.3), heavy-read latency (US-27.4), and recall under-fill (US-27.6b) — into
-  three aggregated metrics a reporter can scrape, so a degradation TREND is visible
+  aggregated metrics a reporter can scrape, so a degradation TREND is visible
   before it becomes an incident (instead of grepping 7-day logs after users hit it).
 
-  The three metrics are MERGED into `LoopctlWeb.Telemetry.metrics/0` and exposed to
+  These metrics are MERGED into `LoopctlWeb.Telemetry.metrics/0` and exposed to
   Fly's managed Prometheus by the reporter on the internal `:9568/metrics` port.
+  `scale_metrics/0` has grown past its original US-27.15 scope as later stories
+  added observability signals to the same list: #297 added the semantic-fallback
+  counter and US-31.2 added the hybrid-provenance counter (both already present
+  before this branch); US-33.1 adds TWO more, purely-additive metrics: per-pool
+  connection-checkout `queue_time` distributions for `Loopctl.Repo` (the RLS pool,
+  size 10) and `Loopctl.AdminRepo` (the BYPASSRLS pool, size 3). Ecto already emits
+  `queue_time` (native time spent WAITING for a pooled connection) on every query
+  telemetry event; before this branch only `heavy_read_repo.query.duration` was
+  scraped, so there was no way to see where checkout contention lands between the
+  two pools. See "Per-pool checkout queue_time (US-33.1)" below. `scale_metrics/0`
+  now returns 7 metrics total.
 
-  US-33.1 adds TWO more, purely-additive metrics: per-pool connection-checkout
-  `queue_time` distributions for `Loopctl.Repo` (the RLS pool, size 10) and
-  `Loopctl.AdminRepo` (the BYPASSRLS pool, size 3). Ecto already emits `queue_time`
-  (native time spent WAITING for a pooled connection) on every query telemetry event;
-  today only `heavy_read_repo.query.duration` is scraped, so there is no way to see
-  where checkout contention lands between the two pools. See "Per-pool checkout
-  queue_time (US-33.1)" below.
-
-  ## The three metrics
+  ## The metrics (7 total)
 
     1. **Timeout / DB-error counter** — `loopctl.db.error.count`, keyed by
        `[:endpoint, :mapped_code]` (+ a cap-gated `:tenant_id`). `mapped_code`
@@ -33,6 +36,18 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
     3. **Under-fill counter** — `loopctl.knowledge.vector_search.under_fill.count`,
        keyed by `[:endpoint]` (+ a cap-gated `:tenant_id`). Sourced from
        `[:loopctl, :knowledge, :vector_search, :under_fill]` (US-27.6b).
+    4. **Semantic-fallback counter** (#297) — `loopctl.knowledge.semantic_fallback.count`,
+       keyed by `[:reason]` ONLY (no `:tenant_id` — the reason set is fixed and
+       small). Sourced from `[:loopctl, :knowledge, :semantic_fallback]`.
+    5. **Hybrid-provenance counter** (US-31.2) — `loopctl.knowledge.hybrid_provenance.count`,
+       keyed by `[:provenance, :hit]` (+ a cap-gated `:tenant_id`). Sourced from
+       `[:loopctl, :knowledge, :hybrid_provenance]`.
+    6. **RLS-pool checkout `queue_time` distribution** (US-33.1) —
+       `loopctl.repo.checkout.queue_time`, with a static `[:repo]` tag (no cap gate
+       needed). Sourced from the Ecto query event `[:loopctl, :repo, :query]`.
+    7. **AdminRepo-pool checkout `queue_time` distribution** (US-33.1) —
+       `loopctl.admin_repo.checkout.queue_time`, with a static `[:repo]` tag (no cap
+       gate needed). Sourced from `[:loopctl, :admin_repo, :query]`.
 
   ## Bounded cardinality (AC-27.15.3) — the no-leak contract
 
@@ -88,7 +103,9 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   @default_tenant_label_cap 1_000
 
   @doc """
-  The three scale metrics (US-27.15). Appended to `LoopctlWeb.Telemetry.metrics/0`.
+  All 7 scale metrics: the original US-27.15 trio, #297's semantic-fallback
+  counter, US-31.2's hybrid-provenance counter, and US-33.1's two per-pool
+  checkout `queue_time` distributions. Appended to `LoopctlWeb.Telemetry.metrics/0`.
   """
   @spec scale_metrics() :: [Telemetry.Metrics.t()]
   def scale_metrics do

--- a/test/loopctl/telemetry/scale_metrics_test.exs
+++ b/test/loopctl/telemetry/scale_metrics_test.exs
@@ -13,10 +13,18 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
       `scale_tags/1` collapses `tenant_id` to the fixed `:_aggregated` sentinel
       (cardinality 1); with it ON (≤ cap), the real `tenant_id` is included.
 
-  It also pins the test-env contract that the Prometheus reporter is NOT a started
-  child in `:test` (no `:9568` bind) while `metrics/0` still returns the scale defs.
+  It also pins the test-env contract that the APP's Prometheus reporter
+  (`Loopctl.Telemetry.MetricsReporter` / the `:prometheus_metrics` singleton) is NOT a
+  started child in `:test` (no `:9568` bind) while `metrics/0` still returns the scale
+  defs.
 
-  Pure metric-definition / `tag_values` inspection — no DB, no running server.
+  Mostly pure metric-definition / `tag_values` inspection — no DB. The US-33.1
+  queue_time "reporter round-trip" describe is the one exception: it boots a REAL,
+  privately-named `TelemetryMetricsPrometheus.Core` instance (never the app's
+  `:9568`-bound singleton) to prove the definitions/`tag_values`/measurement wiring
+  actually record and scrape correctly, rather than asserting `:telemetry.execute/3 ==
+  :ok` against zero attached handlers (which the framework guarantees regardless of
+  whether the code under test is correct).
 
   `async: false` (R2 review): the cap-gate tests MUTATE the process-global
   `:persistent_term` gate (`{ScaleMetrics, :tenant_label?}`), which is shared across the
@@ -33,7 +41,9 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
     "loopctl.heavy_read_repo.query.duration",
     "loopctl.knowledge.vector_search.under_fill.count",
     "loopctl.knowledge.semantic_fallback.count",
-    "loopctl.knowledge.hybrid_provenance.count"
+    "loopctl.knowledge.hybrid_provenance.count",
+    "loopctl.repo.checkout.queue_time",
+    "loopctl.admin_repo.checkout.queue_time"
   ]
 
   # The ONLY labels any scale metric may ever carry (AC-27.15.3). Anything outside this
@@ -41,8 +51,18 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
   # `:reason` (#297 semantic-fallback counter) is a BOUNDED, sanitized tag set (never a
   # key/body/query), so it is a safe dimension. `:provenance` (`"curated"`/`"retrieved"`)
   # and `:hit` (`true`/`false`) — US-31.2's hybrid-provenance counter — are likewise
-  # small, fixed-cardinality dimensions.
-  @allowed_tags MapSet.new([:endpoint, :mapped_code, :tenant_id, :reason, :provenance, :hit])
+  # small, fixed-cardinality dimensions. `:repo` (US-33.1) is a static, fixed 2-value
+  # tag ("repo"/"admin_repo") — the repo identity is encoded in the event name, not
+  # read from metadata.
+  @allowed_tags MapSet.new([
+                  :endpoint,
+                  :mapped_code,
+                  :tenant_id,
+                  :reason,
+                  :provenance,
+                  :hit,
+                  :repo
+                ])
 
   defp scale_metrics, do: ScaleMetrics.scale_metrics()
 
@@ -238,6 +258,160 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
                :_aggregated
 
       assert ScaleMetrics.tenant_label_cap() == 1_000
+    end
+  end
+
+  describe "per-pool checkout queue_time distributions (US-33.1, TC-33.1.1)" do
+    test "the Repo pool queue_time distribution is defined, in milliseconds, tagged by repo" do
+      dist = metric("loopctl.repo.checkout.queue_time")
+
+      assert %Telemetry.Metrics.Distribution{} = dist
+      assert dist.event_name == [:loopctl, :repo, :query]
+      assert is_function(dist.measurement, 1)
+      assert dist.unit == :millisecond
+      assert dist.tags == [:repo]
+    end
+
+    test "the AdminRepo pool queue_time distribution is defined, in milliseconds, tagged by repo" do
+      dist = metric("loopctl.admin_repo.checkout.queue_time")
+
+      assert %Telemetry.Metrics.Distribution{} = dist
+      assert dist.event_name == [:loopctl, :admin_repo, :query]
+      assert is_function(dist.measurement, 1)
+      assert dist.unit == :millisecond
+      assert dist.tags == [:repo]
+    end
+
+    test "both distributions use the documented sub-second checkout-wait buckets" do
+      for name <- ["loopctl.repo.checkout.queue_time", "loopctl.admin_repo.checkout.queue_time"] do
+        dist = metric(name)
+
+        assert dist.reporter_options[:buckets] == [1, 5, 10, 25, 50, 100, 250, 500, 1_000]
+      end
+    end
+  end
+
+  describe "queue_time tag_values — static, defensive, bounded (TC-33.1.2/.3)" do
+    test "queue_time_tags_repo/1 always returns the static %{repo: \"repo\"} map" do
+      assert ScaleMetrics.queue_time_tags_repo(%{}) == %{repo: "repo"}
+
+      assert ScaleMetrics.queue_time_tags_repo(%{
+               tenant_id: "t-123",
+               query: "SELECT 1",
+               source: "stories"
+             }) == %{repo: "repo"}
+    end
+
+    test "queue_time_tags_admin_repo/1 always returns the static %{repo: \"admin_repo\"} map" do
+      assert ScaleMetrics.queue_time_tags_admin_repo(%{}) == %{repo: "admin_repo"}
+
+      assert ScaleMetrics.queue_time_tags_admin_repo(%{
+               tenant_id: "t-456",
+               query: "SELECT 1"
+             }) == %{repo: "admin_repo"}
+    end
+
+    test "tag cardinality is bounded to :repo only — no tenant/query tags (TC-33.1.3)" do
+      for name <- ["loopctl.repo.checkout.queue_time", "loopctl.admin_repo.checkout.queue_time"] do
+        dist = metric(name)
+
+        assert dist.tags == [:repo]
+        refute :tenant_id in dist.tags
+        refute :query in dist.tags
+      end
+    end
+  end
+
+  describe "queue_time reporter round-trip — a REAL Prometheus reporter, not a no-handler no-op (TC-33.1.2, raw finding #3)" do
+    # R2 review: the prior version of this describe only asserted `:telemetry.execute/3
+    # == :ok` with ZERO handlers attached in :test — that assertion holds even if the
+    # two distributions were deleted or `tag_values` raised, so it proved nothing about
+    # the reporter path it was named for. These tests boot a REAL
+    # `TelemetryMetricsPrometheus.Core` reporter (a private, uniquely-named instance —
+    # NOT the app's `:prometheus_metrics` singleton, so this never binds `:9568` or
+    # collides with `Loopctl.Telemetry.MetricsReporter`), attach the two queue_time
+    # distributions to it, emit REAL Ecto-shaped measurement maps, and assert the
+    # SCRAPE reflects the recorded value — proof the definitions, `tag_values` fns, and
+    # measurement wiring are all correct end to end, and that the reporter process
+    # survives both the present-value and the absent-value (dropped) path.
+    #
+    # `start_async: false` forces metric registration to happen synchronously inside
+    # `init/1` (the default `start_async: true` defers it to a `handle_info` message),
+    # so the handlers are guaranteed attached before `start_supervised!/2` returns —
+    # otherwise the very first `:telemetry.execute/3` below would race the async attach.
+    setup do
+      reporter_name = :"scale_metrics_queue_time_test_#{System.unique_integer([:positive])}"
+
+      metrics = [
+        metric("loopctl.repo.checkout.queue_time"),
+        metric("loopctl.admin_repo.checkout.queue_time")
+      ]
+
+      pid =
+        start_supervised!(
+          {TelemetryMetricsPrometheus.Core,
+           [metrics: metrics, name: reporter_name, start_async: false]}
+        )
+
+      %{reporter: reporter_name, reporter_pid: pid}
+    end
+
+    test "a Repo query WITH queue_time present is recorded and scraped, reporter survives",
+         %{reporter: reporter, reporter_pid: pid} do
+      :telemetry.execute(
+        [:loopctl, :repo, :query],
+        %{queue_time: 5_000_000, query_time: 1_000_000, total_time: 6_000_000},
+        %{}
+      )
+
+      scrape = TelemetryMetricsPrometheus.Core.scrape(reporter)
+
+      # 5_000_000 native ticks -> 5.0ms, landing (cumulatively) in the le="5" bucket and
+      # every bucket above it, +Inf included — this is the ACTUAL aggregation output,
+      # not a framework no-op.
+      assert scrape =~ ~s(loopctl_repo_checkout_queue_time_bucket{repo="repo",le="1"} 0)
+      assert scrape =~ ~s(loopctl_repo_checkout_queue_time_bucket{repo="repo",le="5"} 1)
+      assert scrape =~ ~s(loopctl_repo_checkout_queue_time_bucket{repo="repo",le="+Inf"} 1)
+      assert scrape =~ ~s(loopctl_repo_checkout_queue_time_sum{repo="repo"} 5.0)
+      assert scrape =~ ~s(loopctl_repo_checkout_queue_time_count{repo="repo"} 1)
+
+      assert Process.alive?(pid)
+    end
+
+    test "an AdminRepo query WITHOUT queue_time (in-transaction hot path) is dropped, not raised — reporter survives (raw finding #5)",
+         %{reporter: reporter, reporter_pid: pid} do
+      # This is the shape Ecto emits for every query AFTER the first inside
+      # `AdminRepo.transaction/1` (the connection is already checked out, so `queue_time`
+      # is OMITTED entirely from measurements) — precisely the 5-AdminRepo-query auth hot
+      # path US-33.1 targets. `get_measurement/3` returns `{:measurement_not_found,
+      # :queue_time}`, which `handle_event/4` routes to `Logger.debug` and drops (no
+      # crash, no sample recorded).
+      :telemetry.execute(
+        [:loopctl, :admin_repo, :query],
+        %{query_time: 500_000, total_time: 500_000},
+        %{}
+      )
+
+      scrape = TelemetryMetricsPrometheus.Core.scrape(reporter)
+
+      # No sample was ever recorded for this metric, so the Exporter emits NOTHING for
+      # it (not even the HELP/TYPE header) — distinct, explicit proof of the drop, not
+      # merely "no crash".
+      refute scrape =~ "loopctl_admin_repo_checkout_queue_time"
+
+      assert Process.alive?(pid)
+
+      # The Repo distribution (a different metric on the SAME reporter) is unaffected by
+      # the AdminRepo drop — proves the drop is isolated to the one series, not a
+      # reporter-wide failure.
+      :telemetry.execute(
+        [:loopctl, :repo, :query],
+        %{queue_time: 1_000_000, query_time: 100_000, total_time: 1_100_000},
+        %{}
+      )
+
+      assert TelemetryMetricsPrometheus.Core.scrape(reporter) =~
+               ~s(loopctl_repo_checkout_queue_time_count{repo="repo"} 1)
     end
   end
 


### PR DESCRIPTION
## US-33.1 — Per-pool checkout queue_time telemetry for Repo and AdminRepo

Adds two per-pool checkout queue_time distribution metrics to Loopctl.Telemetry.ScaleMetrics — one for Loopctl.Repo and one for Loopctl.AdminRepo — so DB pool checkout wait time (the leading indicator of pool saturation on the AdminRepo hot path) is observable per pool. scale_metrics/0 now returns 7 metrics (the original US-27.15 trio, the #297 semantic-fallback counter, the US-31.2 hybrid-provenance counter, and these two US-33.1 queue_time distributions).

### Changes
- lib/loopctl/telemetry/scale_metrics.ex — two new per-pool queue_time distribution definitions with Ecto-shaped tag_values; moduledoc/@doc corrected to describe all 7 metrics.
- test/loopctl/telemetry/scale_metrics_test.exs — real TelemetryMetricsPrometheus.Core reporter round-trip: boots a uniquely-named private reporter, emits real Ecto-shaped measurement maps, and asserts the scrape reflects the recorded bucket/sum/count. Also pins the in-transaction regression: an AdminRepo query event with queue_time OMITTED from measurements is dropped without raising, the reporter survives, and a subsequent Repo event still records.

### Review fixes applied (in-branch, no deferrals)
- Replaced the tautological :telemetry.execute/3 == :ok test (zero handlers attached in :test) with the reporter round-trip described above.
- Corrected stale "three metrics" moduledoc/@doc to match the code.
