### PR TITLE
Drop the redundant tenant re-SELECT in CheckCustodyHalt (reuse loaded tenant)

### DIFF
--- a/lib/loopctl_web/plugs/check_custody_halt.ex
+++ b/lib/loopctl_web/plugs/check_custody_halt.ex
@@ -4,6 +4,17 @@ defmodule LoopctlWeb.Plugs.CheckCustodyHalt do
   operations are halted due to witness divergence.
 
   Mounted after SetTenant in the :authenticated pipeline.
+
+  US-33.2: The halt decision reuses the fully-loaded `current_tenant` struct
+  that `ResolveApiKey` already preloaded (`Auth.verify_api_key/1` uses
+  `preload: [:tenant]`), instead of issuing a redundant AdminRepo SELECT via
+  `Tenants.get_tenant/1`. This drops the authenticated request from 5→4
+  AdminRepo queries with zero behavior change. Freshness: `custody_halted_at`
+  now reflects its value at api-key resolution time (microseconds earlier, same
+  request). This is acceptable — both reads are within the same request, and a
+  halt set mid-request is enforced on the very next request. A defensive DB
+  fallback (`refetch_and_check/2`) preserves the old behavior when no tenant is
+  in assigns (unauthenticated/edge paths).
   """
 
   @behaviour Plug
@@ -11,6 +22,7 @@ defmodule LoopctlWeb.Plugs.CheckCustodyHalt do
   import Plug.Conn
 
   alias Loopctl.Tenants
+  alias Loopctl.Tenants.Tenant
 
   @impl true
   def init(opts), do: opts
@@ -56,7 +68,20 @@ defmodule LoopctlWeb.Plugs.CheckCustodyHalt do
 
   defp memory_oversight_path?(_conn), do: false
 
+  # US-33.2: Prefer the tenant already loaded by ResolveApiKey/Impersonate and
+  # assigned to `current_tenant`. Under impersonation, `current_tenant` is the
+  # impersonated tenant (matching `current_api_key.tenant_id`), while
+  # `current_api_key.tenant` is the superadmin's original preloaded assoc — so
+  # `current_tenant` is the correct source, not `current_api_key.tenant`.
+  # Fall back to a DB fetch only when no tenant struct is in assigns.
   defp check_tenant_halt(conn, tenant_id) do
+    case conn.assigns[:current_tenant] do
+      %Tenant{} = tenant -> maybe_block(conn, tenant)
+      _ -> refetch_and_check(conn, tenant_id)
+    end
+  end
+
+  defp refetch_and_check(conn, tenant_id) do
     case Tenants.get_tenant(tenant_id) do
       {:ok, tenant} -> maybe_block(conn, tenant)
       _ -> conn

--- a/test/loopctl_web/plugs/check_custody_halt_test.exs
+++ b/test/loopctl_web/plugs/check_custody_halt_test.exs
@@ -15,7 +15,35 @@ defmodule LoopctlWeb.Plugs.CheckCustodyHaltTest do
   """
   use LoopctlWeb.ConnCase, async: true
 
+  alias Loopctl.Auth.ApiKey
+  alias LoopctlWeb.Plugs.CheckCustodyHalt
+
   defp auth(conn, raw_key), do: put_req_header(conn, "authorization", "Bearer #{raw_key}")
+
+  # Attaches a `tenants`-SELECT probe SCOPED to one tenant_id so it never catches
+  # parallel async tests' queries (the handler is attached VM-globally). Sends
+  # `{ref, :tenants_query}` to the test process for each matching AdminRepo query.
+  defp attach_tenants_probe(tenant_id) do
+    {:ok, tenant_id_bin} = Ecto.UUID.dump(tenant_id)
+    test_pid = self()
+    ref = make_ref()
+    handler_id = "check-custody-halt-probe-#{inspect(ref)}"
+
+    :telemetry.attach(
+      handler_id,
+      [:loopctl, :admin_repo, :query],
+      fn _event, _measurements, metadata, _config ->
+        if metadata[:source] == "tenants" and
+             tenant_id_bin in List.wrap(metadata[:params]) do
+          send(test_pid, {ref, :tenants_query})
+        end
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+    ref
+  end
 
   # api_keys.agent_id is a FK to agents, so mint a real agent per agent key.
   defp agent_key(tenant_id) do
@@ -117,6 +145,74 @@ defmodule LoopctlWeb.Plugs.CheckCustodyHaltTest do
       # CheckCustodyHalt re-SELECT would make this two.
       assert_receive {^ref, :tenants_query}
       refute_receive {^ref, :tenants_query}
+    end
+  end
+
+  # Direct `call/2` unit tests (SetTenantTest / RequireHumanAnchorTest style) for
+  # the two AC-enumerated branches the integration tests above cannot reach: every
+  # minted-key request preloads a tenant, so those only exercise the `%Tenant{}`
+  # fast path (check_custody_halt.ex:79). These drive the defensive DB fallback and
+  # the tenant-less early return directly.
+  describe "call/2 branch coverage (US-33.2)" do
+    test "TC-33.2.5: refetch fallback enforces the halt via a DB read when no current_tenant is assigned",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      {:ok, _} = Loopctl.Tenants.halt_custody(tenant.id)
+      ref = attach_tenants_probe(tenant.id)
+
+      # AC-33.2.1 defensive path: current_api_key carries the tenant_id, but NO
+      # current_tenant struct is in assigns — the plug must fall back to
+      # Tenants.get_tenant/1 and STILL enforce the halt (guards the "silently
+      # returns conn without enforcing" regression).
+      api_key = %ApiKey{tenant_id: tenant.id, role: :agent}
+
+      result =
+        conn
+        |> assign(:current_api_key, api_key)
+        |> CheckCustodyHalt.call([])
+
+      assert result.halted
+      assert result.status == 503
+      assert Jason.decode!(result.resp_body)["error"]["code"] == "tenant_halted"
+
+      # Proves the fallback actually hit the DB (contrast: TC-33.2.4's fast path
+      # issues the SELECT via the ResolveApiKey preload, not here).
+      assert_receive {^ref, :tenants_query}
+    end
+
+    test "TC-33.2.6: refetch fallback passes a non-halted tenant through (DB read, no halt)",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      ref = attach_tenants_probe(tenant.id)
+      api_key = %ApiKey{tenant_id: tenant.id, role: :agent}
+
+      result =
+        conn
+        |> assign(:current_api_key, api_key)
+        |> CheckCustodyHalt.call([])
+
+      refute result.halted
+      assert is_nil(result.status)
+      assert_receive {^ref, :tenants_query}
+    end
+
+    test "TC-33.2.7: a tenant-less superadmin key passes the halt check untouched (nil tenant_id early return)",
+         %{conn: conn} do
+      # AC-33.2.3: standalone superadmin (nil tenant_id, current_tenant nil) hits the
+      # is_nil(tenant_id) -> conn guard BEFORE check_tenant_halt/2 — so it reaches the
+      # controller and, structurally, issues no tenants SELECT for the halt check.
+      api_key = %ApiKey{tenant_id: nil, role: :superadmin}
+
+      result =
+        conn
+        |> assign(:current_api_key, api_key)
+        |> assign(:current_tenant, nil)
+        |> CheckCustodyHalt.call([])
+
+      # Returned unchanged (not halted, no status/body set) — proceeds to the controller.
+      refute result.halted
+      assert is_nil(result.status)
+      assert is_nil(result.resp_body)
     end
   end
 

--- a/test/loopctl_web/plugs/check_custody_halt_test.exs
+++ b/test/loopctl_web/plugs/check_custody_halt_test.exs
@@ -1,0 +1,127 @@
+defmodule LoopctlWeb.Plugs.CheckCustodyHaltTest do
+  @moduledoc """
+  US-33.2 — CheckCustodyHalt reuses the tenant already preloaded by
+  ResolveApiKey (`current_tenant` assign) instead of issuing a redundant
+  AdminRepo SELECT via `Tenants.get_tenant/1`.
+
+  Covers: a custody-halted tenant is still blocked (503 tenant_halted), a
+  non-halted tenant still passes, per-tenant isolation drives the decision from
+  each request's own loaded tenant, and (telemetry proof) the redundant
+  `tenants` SELECT is gone — a halted request issues exactly ONE query against
+  the `tenants` source (the ResolveApiKey preload), not two.
+
+  Async: every path routes through `Loopctl.AdminRepo`, so all queries share the
+  one sandbox connection the fixtures insert through.
+  """
+  use LoopctlWeb.ConnCase, async: true
+
+  defp auth(conn, raw_key), do: put_req_header(conn, "authorization", "Bearer #{raw_key}")
+
+  # api_keys.agent_id is a FK to agents, so mint a real agent per agent key.
+  defp agent_key(tenant_id) do
+    agent = fixture(:agent, %{tenant_id: tenant_id})
+    {raw, _key} = fixture(:api_key, %{tenant_id: tenant_id, role: :agent, agent_id: agent.id})
+    raw
+  end
+
+  describe "custody halt enforcement (US-33.2)" do
+    test "TC-33.2.1: a custody-halted tenant's request is blocked (503 tenant_halted)", %{
+      conn: conn
+    } do
+      tenant = fixture(:tenant)
+      raw = agent_key(tenant.id)
+      {:ok, _} = Loopctl.Tenants.halt_custody(tenant.id)
+
+      body =
+        conn
+        |> auth(raw)
+        |> get(~p"/api/v1/memory")
+        |> json_response(503)
+
+      assert body["error"]["code"] == "tenant_halted"
+    end
+
+    test "TC-33.2.2: a non-halted tenant's request proceeds normally (non-503)", %{conn: conn} do
+      tenant = fixture(:tenant)
+      raw = agent_key(tenant.id)
+
+      conn
+      |> auth(raw)
+      |> get(~p"/api/v1/memory")
+      |> json_response(200)
+    end
+
+    test "TC-33.2.3: tenant isolation — tenant A halted is blocked, tenant B passes", %{
+      conn: conn
+    } do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      raw_a = agent_key(tenant_a.id)
+      raw_b = agent_key(tenant_b.id)
+      {:ok, _} = Loopctl.Tenants.halt_custody(tenant_a.id)
+
+      blocked =
+        conn
+        |> auth(raw_a)
+        |> get(~p"/api/v1/memory")
+        |> json_response(503)
+
+      assert blocked["error"]["code"] == "tenant_halted"
+
+      base_conn()
+      |> auth(raw_b)
+      |> get(~p"/api/v1/memory")
+      |> json_response(200)
+    end
+
+    test "TC-33.2.4: no redundant tenants SELECT — halted request queries tenants exactly once",
+         %{conn: conn} do
+      tenant = fixture(:tenant)
+      raw = agent_key(tenant.id)
+      {:ok, _} = Loopctl.Tenants.halt_custody(tenant.id)
+
+      # Scope the handler to THIS tenant's queries only — the handler is attached
+      # VM-globally and would otherwise catch parallel async tests' `tenants`
+      # SELECTs (flaky). Ecto dumps the UUID PK to a 16-byte binary in params.
+      {:ok, tenant_id_bin} = Ecto.UUID.dump(tenant.id)
+
+      test_pid = self()
+      ref = make_ref()
+      handler_id = "check-custody-halt-#{inspect(ref)}"
+
+      :telemetry.attach(
+        handler_id,
+        [:loopctl, :admin_repo, :query],
+        fn _event, _measurements, metadata, _config ->
+          if metadata[:source] == "tenants" and
+               tenant_id_bin in List.wrap(metadata[:params]) do
+            send(test_pid, {ref, :tenants_query})
+          end
+        end,
+        nil
+      )
+
+      try do
+        body =
+          conn
+          |> auth(raw)
+          |> get(~p"/api/v1/memory")
+          |> json_response(503)
+
+        assert body["error"]["code"] == "tenant_halted"
+      after
+        :telemetry.detach(handler_id)
+      end
+
+      # Exactly one `tenants` SELECT (the ResolveApiKey preload). The removed
+      # CheckCustodyHalt re-SELECT would make this two.
+      assert_receive {^ref, :tenants_query}
+      refute_receive {^ref, :tenants_query}
+    end
+  end
+
+  # A fresh conn carrying the witness STH header (ConnCase adds it to the shared
+  # `conn`, but a second dispatched request needs its own conn).
+  defp base_conn,
+    do: put_req_header(build_conn(), "x-loopctl-last-known-sth", "0:AAAAAAAAAAAAAAAAAAAAAA")
+end


### PR DESCRIPTION
## US-33.2 — Drop the redundant tenant re-SELECT in CheckCustodyHalt

Closes #348 (Epic 33 — DB Connection Topology & AdminRepo Hot Path).

### What
`CheckCustodyHalt` (last plug in the `:authenticated` pipeline) was issuing a 5th `AdminRepo` SELECT via `Tenants.get_tenant/1` purely to read `custody_halted_at` — despite `ResolveApiKey` already having loaded the fully-preloaded `%Tenant{}` into `conn.assigns.current_tenant` (`Auth.verify_api_key/1` uses `preload: [:tenant]`). This reuses that struct, dropping the authenticated request from 5→4 AdminRepo queries with **zero behavior change**.

### How
- `check_tenant_halt/2` now reads `conn.assigns[:current_tenant]`; on a `%Tenant{}` match it calls the unchanged `maybe_block/2`. When absent (unauthenticated/edge paths) it falls back to the old `Tenants.get_tenant/1` fetch (`refetch_and_check/2`), preserving prior behavior.
- Reads `current_tenant`, **not** `current_api_key.tenant`: under impersonation `Impersonate` reassigns `current_tenant` to the impersonated tenant but leaves `current_api_key.tenant` as the superadmin's original preloaded assoc (often `nil`). `current_tenant` is the correct, impersonation-consistent source.
- `superadmin_memory_oversight?` bypass and `maybe_block/2` (503 `tenant_halted`) are untouched — this is purely a read-source swap on a custody gate.

### Freshness (AC-33.2.4)
The halt decision now reflects `custody_halted_at` as loaded at api-key resolution time (microseconds earlier, same request). Acceptable: both reads are within one request, and a halt set mid-request is enforced on the next request. Documented in the `@moduledoc`.

### Tests
New `test/loopctl_web/plugs/check_custody_halt_test.exs` (async, ConnCase):
- TC-33.2.1 halted tenant blocked (503 `tenant_halted`)
- TC-33.2.2 non-halted tenant passes (200)
- TC-33.2.3 tenant isolation (A halted blocked, B passes)
- TC-33.2.4 telemetry proof: a halted request queries the `tenants` source **exactly once** (the ResolveApiKey preload) — the removed re-SELECT would make it two. Handler scoped to the test's tenant id (dumped UUID in query params) to avoid cross-test flakiness under `async`.

Full gate green: `mix precommit` (format, credo --strict, dialyzer, 4254 tests, 0 failures) plus `memory_controller_test.exs` custody-halt coverage confirms no regression.