### PR TITLE
ETS read-through cache for API-key resolution (revoke/rotate-invalidated, bounded TTL)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -125,6 +125,14 @@ config :loopctl,
   scale_alert_p95_latency_ms: 2_000,
   scale_alert_under_fill_rate_per_min: 30
 
+# US-33.3: bounded TTL (ms) for the ETS read-through api-key cache. This is the
+# defense-in-depth backstop, NOT the primary invalidation — every revoke/rotate/
+# mutate writer busts the key_hash entry in-band. A cached entry is re-validated
+# against the DB after at most this long even absent an explicit invalidation, so
+# any missed path self-heals within the TTL (AC-33.3.4). Default 60s (within the
+# 30-60s range the AC specifies); overridable per-env.
+config :loopctl, Loopctl.Auth.ApiKeyCache, ttl_ms: :timer.seconds(60)
+
 # AdminRepo shares the same database but uses a role with BYPASSRLS in production.
 # In dev/test, it uses the same credentials as Repo.
 config :loopctl, Loopctl.AdminRepo,

--- a/lib/loopctl/agents.ex
+++ b/lib/loopctl/agents.ex
@@ -20,6 +20,7 @@ defmodule Loopctl.Agents do
   alias Loopctl.AdminRepo
   alias Loopctl.Agents.Agent
   alias Loopctl.Audit
+  alias Loopctl.Auth
   alias Loopctl.Webhooks.EventGenerator
 
   @doc """
@@ -90,6 +91,11 @@ defmodule Loopctl.Agents do
 
     case AdminRepo.transaction(multi) do
       {:ok, %{agent: agent}} ->
+        # US-33.3: binding an agent MUTATES the api_key (sets agent_id — a
+        # scope-relevant change, AC-33.3.3). Bust the cached entry so the next
+        # request sees the bound key (e.g. the "already has an agent" 409 guard),
+        # not the stale pre-bind snapshot.
+        Auth.invalidate_key_cache_by_ids(List.wrap(api_key_id))
         {:ok, agent}
 
       {:error, :agent, changeset, _changes} ->

--- a/lib/loopctl/agents.ex
+++ b/lib/loopctl/agents.ex
@@ -90,13 +90,16 @@ defmodule Loopctl.Agents do
       end)
 
     case AdminRepo.transaction(multi) do
-      {:ok, %{agent: agent}} ->
+      {:ok, changes} ->
         # US-33.3: binding an agent MUTATES the api_key (sets agent_id — a
         # scope-relevant change, AC-33.3.3). Bust the cached entry so the next
         # request sees the bound key (e.g. the "already has an agent" 409 guard),
-        # not the stale pre-bind snapshot.
-        Auth.invalidate_key_cache_by_ids(List.wrap(api_key_id))
-        {:ok, agent}
+        # not the stale pre-bind snapshot. The `:link_api_key` Multi step already
+        # loaded+updated the api_key struct, so invalidate by its key_hash in hand
+        # — no second AdminRepo round-trip on the cache's own pool (US-33.3,
+        # finding-4 remediation). When no key was linked the step is absent.
+        changes |> linked_key_hashes() |> Auth.invalidate_key_cache_by_hashes()
+        {:ok, changes.agent}
 
       {:error, :agent, changeset, _changes} ->
         {:error, changeset}
@@ -244,4 +247,9 @@ defmodule Loopctl.Agents do
       Ecto.Changeset.change(api_key, %{agent_id: agent.id})
     end)
   end
+
+  # The `:link_api_key` step is only present when an api_key_id was passed; its
+  # value is the updated ApiKey struct, so its key_hash is already in memory.
+  defp linked_key_hashes(%{link_api_key: %{key_hash: key_hash}}), do: [key_hash]
+  defp linked_key_hashes(_changes), do: []
 end

--- a/lib/loopctl/application.ex
+++ b/lib/loopctl/application.ex
@@ -42,6 +42,14 @@ defmodule Loopctl.Application do
       # per-change one. Stable owner survives the request/Task/Oban process that
       # populated an entry; invalidated on the settings write path.
       Loopctl.Llm.SettingsCache,
+      # US-33.3: owns the ETS table caching resolved api_keys by key_hash so the
+      # authenticated hot path becomes read-through — a per-request AdminRepo
+      # SELECT becomes a per-change one. Stable owner survives the request/Task/
+      # Oban process that populated an entry; every revoke/rotate/mutate writer
+      # invalidates the key_hash entry (a bounded TTL backstops any missed path).
+      # After PubSub + AdminRepo: it subscribes in init and its values preload
+      # :tenant (custody_halted_at) for the CheckCustodyHalt plug (US-33.2).
+      Loopctl.Auth.ApiKeyCache,
       LoopctlWeb.Endpoint
     ]
 

--- a/lib/loopctl/auth.ex
+++ b/lib/loopctl/auth.ex
@@ -25,6 +25,7 @@ defmodule Loopctl.Auth do
 
   alias Loopctl.AdminRepo
   alias Loopctl.Auth.ApiKey
+  alias Loopctl.Auth.ApiKeyCache
 
   @key_prefix "lc_"
   @random_bytes 30
@@ -58,8 +59,15 @@ defmodule Loopctl.Auth do
       |> Ecto.Changeset.put_change(:key_prefix, key_prefix)
 
     case AdminRepo.insert(changeset) do
-      {:ok, api_key} -> {:ok, {raw_key, api_key}}
-      {:error, changeset} -> {:error, changeset}
+      {:ok, api_key} ->
+        # A brand-new key_hash has nothing cached, but invalidate defensively to
+        # cover the (astronomically unlikely) re-created-hash path and to keep the
+        # rule "every key writer busts its key_hash" uniform (AC-33.3.3).
+        ApiKeyCache.invalidate_cluster(api_key.key_hash)
+        {:ok, {raw_key, api_key}}
+
+      {:error, changeset} ->
+        {:error, changeset}
     end
   end
 
@@ -68,11 +76,56 @@ defmodule Loopctl.Auth do
 
   Returns `{:ok, %ApiKey{}}` with preloaded tenant on success.
   Returns `{:error, :unauthorized}` if the key is not found, revoked, or expired.
+
+  READ-THROUGH CACHED (US-33.3): the resolved `%ApiKey{}` (with `:tenant`
+  preloaded) is served from a supervised ETS cache keyed by `key_hash`,
+  converting a per-request AdminRepo SELECT into a per-change one. On a HIT the
+  SQL `revoked_at`/`expires_at` guards are no longer applied, so they are
+  re-enforced against wall-clock now on the cached struct (`valid_now?/1`,
+  AC-33.3.5) — a cached-but-now-expired/revoked key is rejected exactly like an
+  uncached one. On a MISS the generation is captured BEFORE the DB load and
+  passed to `put/3`, so a revoke/rotation that invalidates during the load is
+  detected and the repopulation rejected (never serve a revoked key). Every
+  revoke/rotate/mutate writer invalidates the `key_hash` entry in-band, with a
+  bounded TTL as the defense-in-depth backstop. See `Loopctl.Auth.ApiKeyCache`.
+
+  The per-request `last_used_at` UPDATE still fires on every request — this
+  story removes ONLY the SELECT (AC-33.3.6; US-33.4 owns debouncing the write).
   """
   @spec verify_api_key(String.t()) :: {:ok, ApiKey.t()} | {:error, :unauthorized}
   def verify_api_key(raw_key) when is_binary(raw_key) do
     key_hash = hash_key(raw_key)
 
+    case ApiKeyCache.fetch(key_hash) do
+      {:ok, %ApiKey{} = api_key} ->
+        # HIT: the SQL guards were not applied, so re-enforce revoked_at/
+        # expires_at against wall-clock now before trusting the cached struct.
+        if valid_now?(api_key),
+          do: verify_and_touch(api_key, key_hash),
+          else: {:error, :unauthorized}
+
+      :miss ->
+        # Capture the generation BEFORE the DB read so a concurrent invalidation
+        # rejects this (possibly stale) repopulation at the next fetch/1.
+        generation = ApiKeyCache.generation(key_hash)
+
+        case load_active_api_key(key_hash) do
+          nil ->
+            {:error, :unauthorized}
+
+          api_key ->
+            # Cache only POSITIVE resolutions (the SQL guards already excluded
+            # revoked/expired rows), so a revoked/expired key is never cached.
+            ApiKeyCache.put(key_hash, api_key, generation)
+            verify_and_touch(api_key, key_hash)
+        end
+    end
+  end
+
+  # Uncached DB read of the ACTIVE (non-revoked, non-expired) api_key for a hash,
+  # with :tenant preloaded (custody_halted_at). Mirrors the guards that make a
+  # cache HIT safe to re-enforce in `valid_now?/1`.
+  defp load_active_api_key(key_hash) do
     query =
       from ak in ApiKey,
         where: ak.key_hash == ^key_hash,
@@ -80,11 +133,16 @@ defmodule Loopctl.Auth do
         where: is_nil(ak.expires_at) or ak.expires_at > ^DateTime.utc_now(),
         preload: [:tenant]
 
-    case AdminRepo.one(query) do
-      nil -> {:error, :unauthorized}
-      api_key -> verify_and_touch(api_key, key_hash)
-    end
+    AdminRepo.one(query)
   end
+
+  # Re-enforces the SQL WHERE guards on a cache HIT: active iff not revoked AND
+  # (no expiry OR expiry still in the future).
+  defp valid_now?(%ApiKey{revoked_at: revoked_at}) when not is_nil(revoked_at), do: false
+  defp valid_now?(%ApiKey{expires_at: nil}), do: true
+
+  defp valid_now?(%ApiKey{expires_at: expires_at}),
+    do: DateTime.compare(expires_at, DateTime.utc_now()) == :gt
 
   defp verify_and_touch(api_key, key_hash) do
     # Constant-time comparison to prevent timing-based side channels.
@@ -107,6 +165,54 @@ defmodule Loopctl.Auth do
     api_key
     |> ApiKey.revoke_changeset()
     |> AdminRepo.update()
+    |> tap_invalidate(api_key.key_hash)
+  end
+
+  # SECURITY (AC-33.3.2/.3): bust the cached entry for this key_hash the moment a
+  # revoke/rotate write commits, cluster-wide, so the very next request re-loads
+  # read-through (and the wall-clock guards reject a revoked/expired key) instead
+  # of serving the stale cached struct until the TTL.
+  defp tap_invalidate({:ok, _} = result, key_hash) do
+    ApiKeyCache.invalidate_cluster(key_hash)
+    result
+  end
+
+  defp tap_invalidate(other, _key_hash), do: other
+
+  @doc """
+  Busts the api-key cache entry for each api_key id in `ids`, cluster-wide.
+
+  For the cascade writers (`Loopctl.Dispatches.revoke/2`, the expired-dispatch
+  worker, agent binding) that mutate/revoke keys via `update_all` or by id and do
+  NOT have the `key_hash` in hand — the caches are keyed by `key_hash`, so this
+  resolves the hashes for the given ids and invalidates each (US-33.3).
+  """
+  @spec invalidate_key_cache_by_ids([Ecto.UUID.t()]) :: :ok
+  def invalidate_key_cache_by_ids([]), do: :ok
+
+  def invalidate_key_cache_by_ids(ids) when is_list(ids) do
+    from(ak in ApiKey, where: ak.id in ^ids, select: ak.key_hash)
+    |> AdminRepo.all()
+    |> Enum.each(&ApiKeyCache.invalidate_cluster/1)
+  end
+
+  @doc """
+  Busts the api-key cache for ALL of a tenant's keys, cluster-wide.
+
+  The cache stores each api_key WITH its `:tenant` preloaded (carrying
+  authorization-relevant tenant fields: `status`, `custody_halted_at`,
+  `trust_tier` — read by `ResolveApiKey`, `CheckCustodyHalt`, and
+  `RequireHumanAnchor`). A tenant-row mutation therefore leaves those cached
+  snapshots stale, so every tenant-auth mutation (suspend/activate, custody
+  halt/clear, WebAuthn trust-tier upgrade, audit-key rotation) calls this so the
+  change takes effect on the very next request rather than after the TTL
+  (US-33.3, composes with US-33.2).
+  """
+  @spec invalidate_tenant_key_cache(Ecto.UUID.t()) :: :ok
+  def invalidate_tenant_key_cache(tenant_id) when is_binary(tenant_id) do
+    from(ak in ApiKey, where: ak.tenant_id == ^tenant_id, select: ak.key_hash)
+    |> AdminRepo.all()
+    |> Enum.each(&ApiKeyCache.invalidate_cluster/1)
   end
 
   @doc """
@@ -170,6 +276,7 @@ defmodule Loopctl.Auth do
     api_key
     |> ApiKey.expire_changeset(expires_at)
     |> AdminRepo.update()
+    |> tap_invalidate(api_key.key_hash)
   end
 
   @doc """

--- a/lib/loopctl/auth.ex
+++ b/lib/loopctl/auth.ex
@@ -193,7 +193,22 @@ defmodule Loopctl.Auth do
   def invalidate_key_cache_by_ids(ids) when is_list(ids) do
     from(ak in ApiKey, where: ak.id in ^ids, select: ak.key_hash)
     |> AdminRepo.all()
-    |> Enum.each(&ApiKeyCache.invalidate_cluster/1)
+    |> invalidate_key_cache_by_hashes()
+  end
+
+  @doc """
+  Busts the api-key cache entry for each `key_hash` in `hashes`, cluster-wide.
+
+  The zero-round-trip counterpart to `invalidate_key_cache_by_ids/1`: cascade
+  writers that revoke keys via `update_all` can select the `key_hash`es back in
+  the SAME statement (`select: k.key_hash` / `returning`), so invalidation needs
+  NO second `AdminRepo` lookup on the very pool the cache exists to relieve.
+  Prefer this over `invalidate_key_cache_by_ids/1` whenever the hashes are
+  already in hand (US-33.3, finding-4 remediation).
+  """
+  @spec invalidate_key_cache_by_hashes([binary()]) :: :ok
+  def invalidate_key_cache_by_hashes(hashes) when is_list(hashes) do
+    Enum.each(hashes, &ApiKeyCache.invalidate_cluster/1)
   end
 
   @doc """
@@ -210,9 +225,21 @@ defmodule Loopctl.Auth do
   """
   @spec invalidate_tenant_key_cache(Ecto.UUID.t()) :: :ok
   def invalidate_tenant_key_cache(tenant_id) when is_binary(tenant_id) do
-    from(ak in ApiKey, where: ak.tenant_id == ^tenant_id, select: ak.key_hash)
+    # Only ACTIVE keys are ever cached: `verify_api_key/1` caches solely positive
+    # resolutions, and `load_active_api_key/1` excludes revoked/expired rows. So
+    # scope the fan-out to `is_nil(revoked_at)` — invalidating a revoked key_hash
+    # is pure waste (a generation bump no live entry references), and in Epic 33's
+    # dispatch pattern revoked ephemeral keys accumulate per tenant without bound,
+    # which would otherwise fan one `invalidate_cluster` cast + PubSub broadcast
+    # out over tens of thousands of dead hashes on every tenant mutation
+    # (US-33.3, finding-2 remediation). Strictly correct: a revoked key is never
+    # cached, so it never needs busting.
+    from(ak in ApiKey,
+      where: ak.tenant_id == ^tenant_id and is_nil(ak.revoked_at),
+      select: ak.key_hash
+    )
     |> AdminRepo.all()
-    |> Enum.each(&ApiKeyCache.invalidate_cluster/1)
+    |> invalidate_key_cache_by_hashes()
   end
 
   @doc """

--- a/lib/loopctl/auth/api_key_cache.ex
+++ b/lib/loopctl/auth/api_key_cache.ex
@@ -1,0 +1,339 @@
+defmodule Loopctl.Auth.ApiKeyCache do
+  @moduledoc """
+  Stable, supervised OWNER of the ETS table caching resolved API keys by
+  `key_hash` for the authentication hot path (US-33.3).
+
+  Every authenticated request funnels through `Loopctl.Auth.verify_api_key/1`,
+  which SHA-256-hashes the raw key and looks the hash up in `api_keys` (via the
+  BYPASSRLS `AdminRepo`) with `revoked_at`/`expires_at` guards and `preload:
+  [:tenant]`. Doing that DB SELECT on EVERY request is the dominant AdminRepo
+  cost on the hot path. This cache turns a per-REQUEST SELECT into a per-CHANGE
+  one: the resolved `%ApiKey{}` (with its `:tenant` preloaded, carrying
+  `custody_halted_at`) is stored in ETS keyed by `key_hash`, and every writer
+  that revokes/rotates/mutates a key invalidates the entry so the next request
+  re-loads read-through.
+
+  This module removes ONLY the SELECT. The per-request `last_used_at` UPDATE
+  (`Loopctl.Auth` `update_last_used/1`) is untouched and still fires on every
+  request — US-33.4 owns debouncing that write (AC-33.3.6).
+
+  ## Security — a stale cache must NEVER authenticate a revoked/rotated key
+
+  This is an auth boundary, so correctness of invalidation is a hard release
+  gate. Three layers guarantee no revoked/rotated key is ever served stale:
+
+    * **Prompt, in-band invalidation (primary).** EVERY code path that sets
+      `api_keys.revoked_at` or mutates a key (single revoke, rotation grace via
+      `expires_at`, the dispatch-cascade `update_all` in `Loopctl.Dispatches`
+      and `Loopctl.Workers.RevokeExpiredDispatchesWorker`) calls
+      `invalidate_cluster/1` for the affected `key_hash` within the same
+      operation. A revoked key is rejected on the VERY NEXT request, not after
+      the TTL.
+    * **Read-time re-enforcement.** On a cache HIT the SQL `revoked_at`/
+      `expires_at` guards are no longer applied, so `verify_api_key/1`
+      re-enforces them against wall-clock now on the cached struct
+      (AC-33.3.5): a cached-but-now-expired key is rejected exactly like an
+      uncached one.
+    * **Bounded TTL backstop (defense-in-depth).** Each entry carries a short
+      wall-bounded TTL (config, default 60s, checked lazily on read + swept
+      periodically). Even if some future invalidation path is missed, the stale
+      entry self-heals — is re-validated against the DB — within the TTL rather
+      than persisting.
+
+  ## No secrets logged (AC-33.3.7)
+
+  The module NEVER logs, `inspect`s, or telemetry-tags a `key_hash` or a raw
+  key. A cold start / GenServer restart yields an empty table that repopulates
+  read-through — nothing secret is persisted.
+
+  ## Design (mirrors `Loopctl.Llm.SettingsCache`, US-32.3)
+
+  A single GenServer owns a `:public`, `:named_table`, `read_concurrency: true`
+  ETS table. Callers read/write it DIRECTLY (`fetch/1`, `put/3`,
+  `invalidate/1`) — the GenServer is NEVER on the hot read path and can't
+  bottleneck request throughput. It exists to own the table (so it survives the
+  transient request/Task/Oban process that populated it), to run the periodic
+  TTL sweep, and to bridge cross-node invalidation broadcasts. No DB access
+  happens in the GenServer, so there is no Ecto Sandbox ownership concern in
+  tests.
+
+  ## Never-stale under the read-through repopulation race
+
+  Plain cache-aside has a well-known staleness race: a reader can MISS, snapshot
+  the OLD row in its SELECT, then a writer revokes the key and invalidates (a
+  no-op — the entry is already absent), and only THEN the slow reader `put`s its
+  now-stale struct, which would persist until the next write. Right after a
+  revocation, that would authenticate a revoked key.
+
+  We close it with a per-`key_hash` **generation counter** and optimistic
+  version checking. Each entry is stamped `{key_hash, value, generation,
+  expires_at}` with the generation captured BEFORE the DB read (see
+  `Loopctl.Auth.verify_api_key/1`). `invalidate/1` atomically BUMPS the
+  generation (`:ets.update_counter`). `fetch/1` trusts an entry ONLY when its
+  stamp still equals the current generation AND it has not passed its TTL. A
+  reader whose snapshot preceded a committed revoke captured a strictly LESS
+  generation, so its `put` lands with a stale stamp and is never trusted — the
+  next read reloads and rejects the revoked key.
+
+  ## Cross-node invalidation
+
+  The table is `:named_table` (node-LOCAL); Erlang clustering does NOT share
+  ETS. `invalidate_cluster/1` busts this node synchronously AND broadcasts over
+  `Phoenix.PubSub` so peer nodes bust their node-local entries within a message
+  hop — a revocation must not authenticate on a peer node either. The `key_hash`
+  travels only over internal cluster PubSub (never logged/telemetry-tagged), and
+  the hash alone cannot authenticate (the raw-key preimage is required); a
+  dropped broadcast is backstopped by the bounded TTL.
+
+  ## Tenant isolation (AC-33.3.5)
+
+  Entries are keyed strictly by `key_hash`, which is globally unique across all
+  tenants, so an entry is self-scoped: tenant A's key can never be returned for
+  tenant B, and revoking A's key never affects B's cached entry.
+  """
+
+  use GenServer
+
+  alias Loopctl.Auth.ApiKey
+
+  @table :loopctl_api_key_cache
+
+  # Cross-node invalidation bridge. Revocation/rotation writers broadcast here so
+  # peer nodes bust their node-local ETS promptly (Erlang clustering does not
+  # share ETS). The topic carries only a key_hash on an internal cluster channel.
+  @pubsub Loopctl.PubSub
+  @invalidate_topic "auth:api_key_cache:invalidate"
+
+  # Bounded safety-net TTL (config-driven, default 60s — within the 30-60s range
+  # AC-33.3.4 specifies). Even if a future invalidation path is missed or a
+  # cross-node broadcast is dropped, a cached entry is evicted after at most this
+  # long, on the next `fetch/1` (lazy) or the periodic sweep (active). Prompt
+  # invalidation is via the generation bump + PubSub; this is only the backstop.
+  @ttl_ms Application.compile_env(:loopctl, [__MODULE__, :ttl_ms], :timer.seconds(60))
+  @sweep_interval_ms :timer.seconds(30)
+
+  # --- Client API ---
+
+  @doc false
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc """
+  Reads the cached `%ApiKey{}` for `key_hash` directly from ETS.
+
+  Returns `{:ok, %ApiKey{}}` (with `:tenant` preloaded) on a fresh cache HIT, or
+  `:miss` when there is no entry, the entry is STALE (its stamped generation no
+  longer matches — an `invalidate/1` fired after the entry's DB read), OR the
+  entry has passed its TTL (the bounded backstop). On a `:miss` the caller loads
+  read-through and `put/3`s under a freshly captured generation.
+
+  A cache HIT does NOT re-check `revoked_at`/`expires_at` — the caller
+  (`verify_api_key/1`) re-enforces those against wall-clock now (AC-33.3.5).
+  """
+  @spec fetch(String.t()) :: {:ok, ApiKey.t()} | :miss
+  def fetch(key_hash) when is_binary(key_hash) do
+    case :ets.lookup(@table, key_hash) do
+      [{^key_hash, value, stamp, expires_at}] ->
+        if stamp == current_generation(key_hash) and not expired?(expires_at),
+          do: {:ok, value},
+          else: :miss
+
+      [] ->
+        :miss
+    end
+  rescue
+    # The table only vanishes if the owner is (transiently) down mid-restart; a
+    # miss makes the caller fall back to the DB read-through — never a crash.
+    ArgumentError -> :miss
+  end
+
+  @doc """
+  Returns the current cache generation for `key_hash` — capture this BEFORE a
+  read-through DB load and pass it to `put/3`, so a revoke/rotation that
+  invalidates during the load is detected and the repopulation rejected at
+  `fetch/1` (never serves a stale/revoked key).
+  """
+  @spec generation(String.t()) :: non_neg_integer()
+  def generation(key_hash) when is_binary(key_hash) do
+    current_generation(key_hash)
+  rescue
+    ArgumentError -> 0
+  end
+
+  @doc """
+  Stores the resolved `%ApiKey{}` for `key_hash` in ETS, stamped with
+  `read_generation` (captured BEFORE the value's DB read) and a wall-bounded
+  expiry. Called from the caller process on a read-through miss. The entry is
+  only ever SERVED while `read_generation` still matches the current generation
+  AND it is within its TTL.
+  """
+  @spec put(String.t(), ApiKey.t(), non_neg_integer()) :: :ok
+  def put(key_hash, %ApiKey{} = value, read_generation)
+      when is_binary(key_hash) and is_integer(read_generation) do
+    :ets.insert(@table, {key_hash, value, read_generation, now_ms() + @ttl_ms})
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
+  @doc """
+  Convenience `put` that stamps `value` with the CURRENT generation.
+
+  Prefer `put/3` with a generation captured before the DB read on the
+  read-through path — this arity is for direct/manual population where no
+  concurrent DB snapshot is in flight (e.g. seeding a known-fresh value in
+  tests).
+  """
+  @spec put(String.t(), ApiKey.t()) :: :ok
+  def put(key_hash, %ApiKey{} = value) when is_binary(key_hash) do
+    put(key_hash, value, generation(key_hash))
+  end
+
+  @doc """
+  Invalidates the cached entry for `key_hash` ON THIS NODE: atomically BUMPS the
+  generation (so any in-flight read-through that captured the prior generation
+  has its `put` rejected at `fetch/1`), then deletes the entry so the next read
+  repopulates read-through.
+
+  This is the node-local primitive; key writers use `invalidate_cluster/1` so
+  peer nodes bust their node-local entries too.
+  """
+  @spec invalidate(String.t()) :: :ok
+  def invalidate(key_hash) when is_binary(key_hash) do
+    bump_generation(key_hash)
+    :ets.delete(@table, key_hash)
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
+  @doc """
+  Invalidates `key_hash` on THIS node (see `invalidate/1`) AND broadcasts the
+  invalidation to peer nodes over `Phoenix.PubSub` so their node-local ETS busts
+  promptly — the table is `:named_table` (node-local) and Erlang clustering does
+  NOT share ETS.
+
+  EVERY api-key revoke/rotate/mutate writer calls this so a revocation is
+  reflected cluster-wide within a PubSub hop, not just on the node that handled
+  the write. If the broadcast is dropped (netsplit) the bounded TTL still evicts
+  the peer's stale entry.
+  """
+  @spec invalidate_cluster(String.t()) :: :ok
+  def invalidate_cluster(key_hash) when is_binary(key_hash) do
+    invalidate(key_hash)
+    # Broadcast via the owner so we can exclude THIS node's subscriber from the
+    # fan-out (no self-echo). GenServer.cast is safe if the owner is momentarily
+    # down mid-restart — the local invalidate already ran.
+    GenServer.cast(__MODULE__, {:broadcast_invalidate, key_hash})
+    :ok
+  end
+
+  @doc """
+  Resets (invalidates) a single `key_hash` entry on this node. Alias of
+  `invalidate/1`; preferred over any global wipe in async tests since the cache
+  is key_hash-scoped and fixtures produce unique hashes.
+  """
+  @spec reset(String.t()) :: :ok
+  def reset(key_hash) when is_binary(key_hash), do: invalidate(key_hash)
+
+  @doc false
+  def table_name, do: @table
+
+  @doc false
+  def ttl_ms, do: @ttl_ms
+
+  # --- Private ---
+
+  # A key_hash's generation lives under a distinct `{:gen, key_hash}` 2-tuple key
+  # that a binary-`key_hash` `fetch/1` lookup can never match, so it never
+  # collides with a cached-value entry. Defaults to 0 for a hash never
+  # invalidated.
+  defp current_generation(key_hash) do
+    case :ets.lookup(@table, {:gen, key_hash}) do
+      [{{:gen, ^key_hash}, gen}] -> gen
+      [] -> 0
+    end
+  end
+
+  # Atomically increment the generation (creating it at 1 on first bump).
+  # `:ets.update_counter/4` is lock-free and serializes concurrent invalidations.
+  defp bump_generation(key_hash) do
+    :ets.update_counter(@table, {:gen, key_hash}, {2, 1}, {{:gen, key_hash}, 0})
+  end
+
+  # Monotonic clock (not affected by wall-clock jumps) for TTL comparisons.
+  defp now_ms, do: System.monotonic_time(:millisecond)
+
+  defp expired?(expires_at), do: now_ms() >= expires_at
+
+  # --- Server callbacks ---
+
+  @impl true
+  def init(_opts) do
+    # Create + own the table here (in the GenServer process) so it persists for
+    # the node's lifetime. Idempotent if it somehow already exists.
+    table =
+      case :ets.whereis(@table) do
+        :undefined ->
+          :ets.new(@table, [
+            :set,
+            :public,
+            :named_table,
+            read_concurrency: true
+          ])
+
+        existing ->
+          existing
+      end
+
+    # Subscribe so a PEER node's invalidation broadcast busts THIS node's entry.
+    # `Phoenix.PubSub` starts strictly before this owner in the supervision tree.
+    Phoenix.PubSub.subscribe(@pubsub, @invalidate_topic)
+    schedule_sweep()
+
+    {:ok, %{table: table}}
+  end
+
+  @impl true
+  def handle_cast({:broadcast_invalidate, key_hash}, state) do
+    # Fan out to peer nodes, excluding self() (this node's subscriber is the
+    # owner itself) so the originating node does not re-process its own
+    # invalidation.
+    _ =
+      Phoenix.PubSub.broadcast_from(@pubsub, self(), @invalidate_topic, {:invalidate, key_hash})
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info({:invalidate, key_hash}, state) when is_binary(key_hash) do
+    # A peer node revoked/rotated this key; bust our node-local entry.
+    invalidate(key_hash)
+    {:noreply, state}
+  end
+
+  def handle_info(:sweep, state) do
+    sweep_expired()
+    schedule_sweep()
+    {:noreply, state}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  defp schedule_sweep do
+    Process.send_after(self(), :sweep, @sweep_interval_ms)
+  end
+
+  # Actively evict expired entries so cached auth material does not linger past
+  # the TTL. Only the 4-tuple value entries carry an expiry; the 2-tuple
+  # `{:gen, _}` generation entries never match this head.
+  defp sweep_expired do
+    now = now_ms()
+    match_spec = [{{:_, :_, :_, :"$1"}, [{:"=<", :"$1", now}], [true]}]
+    :ets.select_delete(@table, match_spec)
+  rescue
+    ArgumentError -> 0
+  end
+end

--- a/lib/loopctl/auth/api_key_cache.ex
+++ b/lib/loopctl/auth/api_key_cache.ex
@@ -75,6 +75,31 @@ defmodule Loopctl.Auth.ApiKeyCache do
   generation, so its `put` lands with a stale stamp and is never trusted — the
   next read reloads and rejects the revoked key.
 
+  ## Bounded memory — BOTH entry kinds self-evict
+
+  Two kinds of rows live in the table, and neither grows without bound:
+
+    * **Value entries** `{key_hash, value, generation, expires_at}` are
+      TTL-bounded — lazily missed on read past their expiry and actively swept.
+    * **Generation entries** `{{:gen, key_hash}, gen, reap_after}` are created
+      on the first `invalidate/1` of a `key_hash` and are the crux above, so
+      they cannot be deleted eagerly with the value: a bump must OUTLIVE any
+      in-flight read-through that snapshotted a pre-bump generation, or the
+      staleness race reopens. Instead each generation entry carries a
+      `reap_after` deadline set to `now + @gen_reap_grace_ms` on every bump. A
+      read-through is a single indexed AdminRepo SELECT (sub-second); the grace
+      is the value TTL plus a generous read-through margin, so by the time a
+      generation entry is reaped every value entry stamped before its last bump
+      has already TTL-expired — reaping resets the generation to the `0` default
+      only once no live entry could match it (proof: a matching stale value
+      would need stamp `0`, but a stamp-`0` value is only produced while the
+      generation entry is ABSENT, and it is present-and-un-reaped for the whole
+      grace window). A hot, repeatedly-revoked `key_hash` keeps its counter
+      (each bump refreshes `reap_after`); an idle one is swept. This caps the
+      generation-entry set to roughly the distinct `key_hash`es invalidated
+      within one grace window rather than every `key_hash` ever invalidated for
+      the node lifetime (US-33.3 technical-notes memory-bound requirement).
+
   ## Cross-node invalidation
 
   The table is `:named_table` (node-LOCAL); Erlang clustering does NOT share
@@ -111,6 +136,16 @@ defmodule Loopctl.Auth.ApiKeyCache do
   # invalidation is via the generation bump + PubSub; this is only the backstop.
   @ttl_ms Application.compile_env(:loopctl, [__MODULE__, :ttl_ms], :timer.seconds(60))
   @sweep_interval_ms :timer.seconds(30)
+
+  # Generation entries must OUTLIVE any in-flight read-through that captured a
+  # pre-bump generation, or the never-stale invariant reopens (see moduledoc
+  # "Bounded memory"). A read-through is one indexed AdminRepo SELECT (sub-second);
+  # we reap a generation entry only once it has been idle (un-bumped) for the value
+  # TTL PLUS this read-through margin, guaranteeing every value entry stamped before
+  # its last bump has already TTL-expired. Bumping refreshes the deadline so a
+  # repeatedly-invalidated key_hash keeps its counter; an idle counter is swept.
+  @gen_reap_margin_ms :timer.seconds(30)
+  @gen_reap_grace_ms @ttl_ms + @gen_reap_margin_ms
 
   # --- Client API ---
 
@@ -246,21 +281,28 @@ defmodule Loopctl.Auth.ApiKeyCache do
 
   # --- Private ---
 
-  # A key_hash's generation lives under a distinct `{:gen, key_hash}` 2-tuple key
-  # that a binary-`key_hash` `fetch/1` lookup can never match, so it never
-  # collides with a cached-value entry. Defaults to 0 for a hash never
-  # invalidated.
+  # A key_hash's generation lives under a distinct `{:gen, key_hash}` tuple key
+  # (a 3-tuple `{{:gen, key_hash}, gen, reap_after}`) that a binary-`key_hash`
+  # `fetch/1` lookup can never match, so it never collides with a cached-value
+  # entry. Defaults to 0 for a hash never invalidated.
   defp current_generation(key_hash) do
     case :ets.lookup(@table, {:gen, key_hash}) do
-      [{{:gen, ^key_hash}, gen}] -> gen
+      [{{:gen, ^key_hash}, gen, _reap_after}] -> gen
       [] -> 0
     end
   end
 
-  # Atomically increment the generation (creating it at 1 on first bump).
-  # `:ets.update_counter/4` is lock-free and serializes concurrent invalidations.
+  # Atomically increment the generation (creating it at 1 on first bump) and
+  # refresh its reap deadline so an actively-invalidated key_hash keeps its
+  # counter while an idle one is later swept (see moduledoc "Bounded memory").
+  # `:ets.update_counter/4` is lock-free and serializes concurrent invalidations;
+  # the default seeds a future `reap_after` so a freshly-created entry is never
+  # eligible for the sweep before its bump is observable.
   defp bump_generation(key_hash) do
-    :ets.update_counter(@table, {:gen, key_hash}, {2, 1}, {{:gen, key_hash}, 0})
+    reap_after = now_ms() + @gen_reap_grace_ms
+    gen = :ets.update_counter(@table, {:gen, key_hash}, {2, 1}, {{:gen, key_hash}, 0, reap_after})
+    :ets.update_element(@table, {:gen, key_hash}, {3, reap_after})
+    gen
   end
 
   # Monotonic clock (not affected by wall-clock jumps) for TTL comparisons.
@@ -327,12 +369,22 @@ defmodule Loopctl.Auth.ApiKeyCache do
   end
 
   # Actively evict expired entries so cached auth material does not linger past
-  # the TTL. Only the 4-tuple value entries carry an expiry; the 2-tuple
-  # `{:gen, _}` generation entries never match this head.
+  # the TTL, AND reap generation entries idle beyond their bump grace so they do
+  # not accumulate for the node lifetime (see moduledoc "Bounded memory").
+  #
+  #   * Value entries `{key_hash, value, gen, expires_at}` (4-tuple) evict once
+  #     `expires_at <= now`.
+  #   * Generation entries `{{:gen, key_hash}, gen, reap_after}` (3-tuple, tuple
+  #     key) reap once `reap_after <= now` — only after the value TTL + margin
+  #     since the last bump, so the never-stale invariant is preserved.
+  #
+  # The heads are disjoint (4-tuple binary key vs 3-tuple `{:gen, _}` key), so
+  # neither spec ever matches the other kind.
   defp sweep_expired do
     now = now_ms()
-    match_spec = [{{:_, :_, :_, :"$1"}, [{:"=<", :"$1", now}], [true]}]
-    :ets.select_delete(@table, match_spec)
+    value_spec = [{{:_, :_, :_, :"$1"}, [{:"=<", :"$1", now}], [true]}]
+    gen_spec = [{{{:gen, :_}, :_, :"$1"}, [{:"=<", :"$1", now}], [true]}]
+    :ets.select_delete(@table, value_spec) + :ets.select_delete(@table, gen_spec)
   rescue
     ArgumentError -> 0
   end

--- a/lib/loopctl/dispatches.ex
+++ b/lib/loopctl/dispatches.ex
@@ -235,23 +235,28 @@ defmodule Loopctl.Dispatches do
       end)
       |> Multi.run(:revoke_keys, fn _repo, _ ->
         if key_ids != [] do
-          {count, _} =
-            from(k in ApiKey, where: k.id in ^key_ids and is_nil(k.revoked_at))
+          # Select the revoked key_hashes back in the SAME update statement so the
+          # post-commit cache invalidation needs no second AdminRepo lookup on the
+          # very 3-connection pool this cache exists to relieve (US-33.3, finding-4).
+          {_count, key_hashes} =
+            from(k in ApiKey,
+              where: k.id in ^key_ids and is_nil(k.revoked_at),
+              select: k.key_hash
+            )
             |> AdminRepo.update_all(set: [revoked_at: now])
 
-          {:ok, count}
+          {:ok, key_hashes}
         else
-          {:ok, 0}
+          {:ok, []}
         end
       end)
 
     case AdminRepo.transaction(multi) do
-      {:ok, %{revoke_dispatches: count}} ->
+      {:ok, %{revoke_dispatches: count, revoke_keys: key_hashes}} ->
         # SECURITY (AC-33.3.2): the update_all cascade bypasses changesets, so bust
-        # the api-key cache explicitly for every revoked key_hash. The dispatch
-        # query above selects only {id, api_key_id} (no key_hash), so resolve the
-        # hashes for the revoked key_ids and invalidate each cluster-wide.
-        Loopctl.Auth.invalidate_key_cache_by_ids(key_ids)
+        # the api-key cache explicitly for every revoked key_hash AFTER commit. The
+        # hashes came back from the revoke statement itself (no extra round-trip).
+        Loopctl.Auth.invalidate_key_cache_by_hashes(key_hashes)
         {:ok, count}
 
       {:error, _step, reason, _} ->

--- a/lib/loopctl/dispatches.ex
+++ b/lib/loopctl/dispatches.ex
@@ -246,8 +246,16 @@ defmodule Loopctl.Dispatches do
       end)
 
     case AdminRepo.transaction(multi) do
-      {:ok, %{revoke_dispatches: count}} -> {:ok, count}
-      {:error, _step, reason, _} -> {:error, reason}
+      {:ok, %{revoke_dispatches: count}} ->
+        # SECURITY (AC-33.3.2): the update_all cascade bypasses changesets, so bust
+        # the api-key cache explicitly for every revoked key_hash. The dispatch
+        # query above selects only {id, api_key_id} (no key_hash), so resolve the
+        # hashes for the revoked key_ids and invalidate each cluster-wide.
+        Loopctl.Auth.invalidate_key_cache_by_ids(key_ids)
+        {:ok, count}
+
+      {:error, _step, reason, _} ->
+        {:error, reason}
     end
   end
 

--- a/lib/loopctl/tenants.ex
+++ b/lib/loopctl/tenants.ex
@@ -649,6 +649,9 @@ defmodule Loopctl.Tenants do
     case result do
       {:ok, %{update_tenant: updated_tenant}} ->
         TenantKeys.invalidate(tenant.id)
+        # US-33.3: the cached api_key snapshots carry the tenant's
+        # audit_signing_public_key — bust them so a rotation is reflected at once.
+        Auth.invalidate_tenant_key_cache(tenant.id)
         {:ok, updated_tenant}
 
       {:error, _step, reason, _changes} ->
@@ -717,6 +720,7 @@ defmodule Loopctl.Tenants do
         tenant
         |> Ecto.Changeset.change(custody_halted_at: DateTime.utc_now())
         |> AdminRepo.update()
+        |> bust_key_cache_on_update()
 
       error ->
         error
@@ -731,6 +735,7 @@ defmodule Loopctl.Tenants do
         tenant
         |> Ecto.Changeset.change(custody_halted_at: nil)
         |> AdminRepo.update()
+        |> bust_key_cache_on_update()
 
       error ->
         error
@@ -756,6 +761,7 @@ defmodule Loopctl.Tenants do
     tenant
     |> Tenant.update_changeset(attrs)
     |> AdminRepo.update()
+    |> bust_key_cache_on_update()
   end
 
   @doc """
@@ -784,6 +790,7 @@ defmodule Loopctl.Tenants do
     tenant
     |> Tenant.status_changeset(:suspended)
     |> AdminRepo.update()
+    |> bust_key_cache_on_update()
   end
 
   @doc """
@@ -794,6 +801,7 @@ defmodule Loopctl.Tenants do
     tenant
     |> Tenant.status_changeset(:active)
     |> AdminRepo.update()
+    |> bust_key_cache_on_update()
   end
 
   @doc """
@@ -892,6 +900,7 @@ defmodule Loopctl.Tenants do
     tenant
     |> Tenant.update_changeset(attrs)
     |> AdminRepo.update()
+    |> bust_key_cache_on_update()
   end
 
   @doc """
@@ -1103,6 +1112,19 @@ defmodule Loopctl.Tenants do
 
     Map.put(stats, :tenant, tenant)
   end
+
+  # US-33.3: the api-key cache stores each api_key WITH its :tenant preloaded, so a
+  # tenant-row mutation leaves those cached snapshots stale (status,
+  # custody_halted_at, trust_tier are all authorization-relevant and read off the
+  # preloaded tenant by the auth pipeline). Bust the tenant's cached keys on every
+  # successful tenant update so the change takes effect on the very next request
+  # rather than after the TTL. A failed update is passed through untouched.
+  defp bust_key_cache_on_update({:ok, %Tenant{} = tenant} = result) do
+    Auth.invalidate_tenant_key_cache(tenant.id)
+    result
+  end
+
+  defp bust_key_cache_on_update(other), do: other
 
   defp merge_settings(tenant, attrs) do
     case Map.get(attrs, "settings") || Map.get(attrs, :settings) do

--- a/lib/loopctl/tenants/enrollment.ex
+++ b/lib/loopctl/tenants/enrollment.ex
@@ -130,7 +130,7 @@ defmodule Loopctl.Tenants.Enrollment do
 
     case AdminRepo.transaction(multi) do
       {:ok, %{authenticator: auth, reloaded_tenant: tenant, flip_tier: {flipped, _}}} ->
-        {:ok, %{tenant: tenant, authenticator: auth, upgraded: flipped == 1}}
+        on_enroll_success(tenant_id, tenant, auth, flipped)
 
       {:error, :tenant, :not_found, _changes} ->
         {:error, :not_found}
@@ -147,6 +147,16 @@ defmodule Loopctl.Tenants.Enrollment do
       {:error, _step, reason, _changes} ->
         {:error, reason}
     end
+  end
+
+  # US-33.3: a first-device enrollment flips the tenant to :human_anchored. The
+  # api-key cache stores each key WITH its :tenant preloaded (trust_tier is read by
+  # RequireHumanAnchor), so bust the tenant's cached keys on an upgrade — the
+  # change must gate custody ops on the very next request, not after the TTL.
+  defp on_enroll_success(tenant_id, tenant, auth, flipped) do
+    upgraded? = flipped == 1
+    if upgraded?, do: Loopctl.Auth.invalidate_tenant_key_cache(tenant_id)
+    {:ok, %{tenant: tenant, authenticator: auth, upgraded: upgraded?}}
   end
 
   # Under-lock backup-enrollment gate. A first enrollment (locked tier still

--- a/lib/loopctl/workers/revoke_expired_dispatches_worker.ex
+++ b/lib/loopctl/workers/revoke_expired_dispatches_worker.ex
@@ -44,24 +44,36 @@ defmodule Loopctl.Workers.RevokeExpiredDispatchesWorker do
           from(d in Dispatch, where: d.id in ^dispatch_ids)
           |> AdminRepo.update_all(set: [revoked_at: now])
 
-        revoke_keys(key_ids, now)
+        key_hashes = revoke_keys(key_ids, now)
 
         Logger.info("RevokeExpiredDispatchesWorker: revoked #{d_count} expired dispatches")
+
+        key_hashes
       end)
 
     # SECURITY (AC-33.3.2): the update_all cascade bypasses changesets, so bust the
-    # api-key cache explicitly for every revoked key_hash AFTER commit. The expired
-    # dispatch query selects only {id, api_key_id} (no key_hash), so resolve the
-    # hashes for the revoked key_ids and invalidate each cluster-wide.
-    if match?({:ok, _}, result), do: Auth.invalidate_key_cache_by_ids(key_ids)
+    # api-key cache explicitly for every revoked key_hash AFTER commit. The hashes
+    # came back from the revoke statement itself (`select: k.key_hash`), so no
+    # second AdminRepo lookup competes for the pool this cache relieves (US-33.3,
+    # finding-4 remediation).
+    case result do
+      {:ok, key_hashes} -> Auth.invalidate_key_cache_by_hashes(key_hashes)
+      _ -> :ok
+    end
 
     result
   end
 
-  defp revoke_keys([], _now), do: :ok
+  defp revoke_keys([], _now), do: []
 
   defp revoke_keys(key_ids, now) do
-    from(k in ApiKey, where: k.id in ^key_ids and is_nil(k.revoked_at))
-    |> AdminRepo.update_all(set: [revoked_at: now])
+    {_count, key_hashes} =
+      from(k in ApiKey,
+        where: k.id in ^key_ids and is_nil(k.revoked_at),
+        select: k.key_hash
+      )
+      |> AdminRepo.update_all(set: [revoked_at: now])
+
+    key_hashes
   end
 end

--- a/lib/loopctl/workers/revoke_expired_dispatches_worker.ex
+++ b/lib/loopctl/workers/revoke_expired_dispatches_worker.ex
@@ -11,6 +11,7 @@ defmodule Loopctl.Workers.RevokeExpiredDispatchesWorker do
   require Logger
 
   alias Loopctl.AdminRepo
+  alias Loopctl.Auth
   alias Loopctl.Auth.ApiKey
   alias Loopctl.Dispatches.Dispatch
 
@@ -37,15 +38,24 @@ defmodule Loopctl.Workers.RevokeExpiredDispatchesWorker do
     dispatch_ids = Enum.map(expired, & &1.id)
     key_ids = expired |> Enum.map(& &1.api_key_id) |> Enum.reject(&is_nil/1)
 
-    AdminRepo.transaction(fn ->
-      {d_count, _} =
-        from(d in Dispatch, where: d.id in ^dispatch_ids)
-        |> AdminRepo.update_all(set: [revoked_at: now])
+    result =
+      AdminRepo.transaction(fn ->
+        {d_count, _} =
+          from(d in Dispatch, where: d.id in ^dispatch_ids)
+          |> AdminRepo.update_all(set: [revoked_at: now])
 
-      revoke_keys(key_ids, now)
+        revoke_keys(key_ids, now)
 
-      Logger.info("RevokeExpiredDispatchesWorker: revoked #{d_count} expired dispatches")
-    end)
+        Logger.info("RevokeExpiredDispatchesWorker: revoked #{d_count} expired dispatches")
+      end)
+
+    # SECURITY (AC-33.3.2): the update_all cascade bypasses changesets, so bust the
+    # api-key cache explicitly for every revoked key_hash AFTER commit. The expired
+    # dispatch query selects only {id, api_key_id} (no key_hash), so resolve the
+    # hashes for the revoked key_ids and invalidate each cluster-wide.
+    if match?({:ok, _}, result), do: Auth.invalidate_key_cache_by_ids(key_ids)
+
+    result
   end
 
   defp revoke_keys([], _now), do: :ok

--- a/lib/loopctl_web/controllers/api_key_controller.ex
+++ b/lib/loopctl_web/controllers/api_key_controller.ex
@@ -195,16 +195,35 @@ defmodule LoopctlWeb.ApiKeyController do
       agent_id: old_key.agent_id
     }
 
-    Loopctl.AdminRepo.transaction(fn ->
-      expires_at = DateTime.add(DateTime.utc_now(), grace_hours * 3600, :second)
+    result =
+      Loopctl.AdminRepo.transaction(fn ->
+        expires_at = DateTime.add(DateTime.utc_now(), grace_hours * 3600, :second)
 
-      with {:ok, {raw_key, new_key}} <- Auth.generate_api_key(new_attrs),
-           {:ok, updated_old} <- Auth.expire_api_key(old_key, expires_at) do
-        {raw_key, new_key, updated_old}
-      else
-        {:error, reason} -> Loopctl.AdminRepo.rollback(reason)
-      end
-    end)
+        with {:ok, {raw_key, new_key}} <- Auth.generate_api_key(new_attrs),
+             {:ok, updated_old} <- Auth.expire_api_key(old_key, expires_at) do
+          {raw_key, new_key, updated_old}
+        else
+          {:error, reason} -> Loopctl.AdminRepo.rollback(reason)
+        end
+      end)
+
+    # SECURITY (US-33.3): `generate_api_key`/`expire_api_key` bust the cache
+    # in-band, but here that runs INSIDE the transaction (pre-commit). A
+    # concurrent `verify_api_key/1` of the OLD key can, on a separate pooled
+    # connection under READ COMMITTED, still read the not-yet-committed active old
+    # row and repopulate the cache stamped with the pre-commit generation — which
+    # would then authenticate the just-rotated-out key until the TTL (acute when
+    # grace <= 0 expires it immediately). Re-invalidate BOTH key_hashes AFTER the
+    # transaction commits so any such stale repopulation is rejected on the very
+    # next request (mirrors the post-commit invalidation in `Dispatches.revoke/2`).
+    case result do
+      {:ok, {_raw, new_key, updated_old}} ->
+        Auth.invalidate_key_cache_by_ids([new_key.id, updated_old.id])
+        result
+
+      _ ->
+        result
+    end
   end
 
   defp creation_json(raw_key, api_key) do

--- a/test/loopctl/auth/api_key_cache_restart_test.exs
+++ b/test/loopctl/auth/api_key_cache_restart_test.exs
@@ -1,0 +1,88 @@
+defmodule Loopctl.Auth.ApiKeyCacheRestartTest do
+  # async: false ON PURPOSE. These tests mutate NODE-GLOBAL supervised state — they
+  # delete the single shared `:named_table` — so no concurrent async test may
+  # observe the momentarily-absent table. Keep them OUT of the async
+  # `ApiKeyCacheTest` module.
+  #
+  # NOTE on why we do NOT stop the supervised owner (unlike a naive mirror of
+  # `settings_cache_restart_test.exs`): `Loopctl.Auth.ApiKeyCache` and
+  # `Loopctl.Llm.SettingsCache` are BOTH `:one_for_one` children of the same root
+  # `Loopctl.Supervisor`. A `GenServer.stop` of either triggers a supervised
+  # restart that counts against the root supervisor's shared restart-intensity
+  # window. The SettingsCache restart test already spends restarts in that window;
+  # adding more here can exceed `max_restarts` and take the whole app (Repo,
+  # Endpoint, sandbox owners) down mid-run. So we reproduce the SAME observable
+  # failure mode — "table destroyed -> recreated EMPTY -> repopulates
+  # read-through", plus the rescue clauses that keep fetch/put/invalidate/
+  # generation safe while the table is momentarily absent — by deleting the ETS
+  # table and handing a fresh empty one back to the live owner via
+  # `:ets.give_away/3` (exactly the empty table `init/1` would create), with zero
+  # root-supervisor restart cost.
+
+  use Loopctl.DataCase, async: false
+
+  alias Loopctl.Auth
+  alias Loopctl.Auth.ApiKey
+  alias Loopctl.Auth.ApiKeyCache
+
+  describe "cold start / table-missing resilience (AC-33.3.7)" do
+    test "with the ETS table absent, fetch/put/invalidate/generation are safe (rescue clauses)" do
+      {_raw, ak} = fixture(:api_key, role: :agent)
+
+      # Destroy the table out from under the owner, simulating the window after a
+      # crash and before init/1 has recreated it.
+      true = :ets.delete(ApiKeyCache.table_name())
+      assert :ets.whereis(ApiKeyCache.table_name()) == :undefined
+
+      # Every direct ETS op must rescue "table does not exist" to a safe default so
+      # an auth request never crashes mid-restart.
+      assert ApiKeyCache.fetch(ak.key_hash) == :miss
+      assert ApiKeyCache.generation(ak.key_hash) == 0
+      assert ApiKeyCache.put(ak.key_hash, ak, 0) == :ok
+      assert ApiKeyCache.put(ak.key_hash, ak) == :ok
+      assert ApiKeyCache.invalidate(ak.key_hash) == :ok
+
+      restore_empty_table!()
+
+      # The recreated EMPTY table repopulates read-through with correct auth material.
+      {raw2, ak2} = fixture(:api_key, role: :agent)
+      assert ApiKeyCache.fetch(ak2.key_hash) == :miss
+      assert {:ok, %ApiKey{}} = Auth.verify_api_key(raw2)
+      assert {:ok, %ApiKey{}} = ApiKeyCache.fetch(ak2.key_hash)
+    end
+
+    test "an emptied table repopulates read-through and persists no secrets" do
+      {raw, ak} = fixture(:api_key, role: :agent)
+
+      # Warm the cache.
+      assert {:ok, %ApiKey{}} = Auth.verify_api_key(raw)
+      assert {:ok, %ApiKey{}} = ApiKeyCache.fetch(ak.key_hash)
+
+      # Cold start: destroy the table and hand back a fresh EMPTY one (what init/1
+      # would create on a supervised restart) — nothing is persisted (AC-33.3.7).
+      true = :ets.delete(ApiKeyCache.table_name())
+      restore_empty_table!()
+
+      # The previously-cached key is now a miss (empty table)...
+      assert ApiKeyCache.fetch(ak.key_hash) == :miss
+
+      # ...and a verify repopulates read-through from the DB.
+      assert {:ok, %ApiKey{}} = Auth.verify_api_key(raw)
+      assert {:ok, %ApiKey{}} = ApiKeyCache.fetch(ak.key_hash)
+    end
+  end
+
+  # Recreate the shared named table exactly as `init/1` does and transfer ownership
+  # to the live supervised owner, so the table survives this test process and no
+  # supervised restart (root restart-intensity cost) is incurred. The owner's
+  # `handle_info/2` catch-all swallows the `{'ETS-TRANSFER', ...}` message.
+  defp restore_empty_table! do
+    owner = Process.whereis(ApiKeyCache)
+
+    table =
+      :ets.new(ApiKeyCache.table_name(), [:set, :public, :named_table, read_concurrency: true])
+
+    true = :ets.give_away(table, owner, :restored)
+    :ok
+  end
+end

--- a/test/loopctl/auth/api_key_cache_test.exs
+++ b/test/loopctl/auth/api_key_cache_test.exs
@@ -1,0 +1,329 @@
+defmodule Loopctl.Auth.ApiKeyCacheTest do
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Auth
+  alias Loopctl.Auth.ApiKey
+  alias Loopctl.Auth.ApiKeyCache
+
+  import Ecto.Query
+  import ExUnit.CaptureLog
+
+  # The ETS owner runs as part of the app supervision tree in the test env, so the
+  # table already exists — no start_supervised needed (mirrors SettingsCache tests).
+  # async: true is safe because every test uses fresh api_key fixtures = unique
+  # key_hash keys, so the shared named table is never contended across tests.
+
+  describe "fetch/2 + put + invalidate (ETS unit)" do
+    test "fetch on an unknown key_hash is a miss" do
+      assert ApiKeyCache.fetch(Auth.hash_key("lc_never-seen")) == :miss
+    end
+
+    test "put then fetch returns the stored struct as a hit" do
+      {_raw, ak} = fixture(:api_key, role: :agent)
+
+      :ok = ApiKeyCache.put(ak.key_hash, ak)
+
+      assert {:ok, %ApiKey{} = cached} = ApiKeyCache.fetch(ak.key_hash)
+      assert cached.id == ak.id
+    end
+
+    test "invalidate deletes the entry (back to a miss)" do
+      {_raw, ak} = fixture(:api_key, role: :agent)
+
+      :ok = ApiKeyCache.put(ak.key_hash, ak)
+      assert {:ok, _} = ApiKeyCache.fetch(ak.key_hash)
+
+      :ok = ApiKeyCache.invalidate(ak.key_hash)
+      assert ApiKeyCache.fetch(ak.key_hash) == :miss
+    end
+
+    test "invalidate BUMPS the generation (monotonic authority)" do
+      {_raw, ak} = fixture(:api_key, role: :agent)
+      gen0 = ApiKeyCache.generation(ak.key_hash)
+
+      :ok = ApiKeyCache.invalidate(ak.key_hash)
+      gen1 = ApiKeyCache.generation(ak.key_hash)
+      assert gen1 > gen0
+
+      :ok = ApiKeyCache.invalidate(ak.key_hash)
+      assert ApiKeyCache.generation(ak.key_hash) > gen1
+    end
+
+    test "a put stamped with an older generation is a MISS (stale repopulation rejected)" do
+      {_raw, ak} = fixture(:api_key, role: :agent)
+
+      stale_gen = ApiKeyCache.generation(ak.key_hash)
+      :ok = ApiKeyCache.invalidate(ak.key_hash)
+      assert ApiKeyCache.generation(ak.key_hash) > stale_gen
+
+      # A LATE read-through repopulation stamped with the pre-invalidation
+      # generation (reader snapshotted before the writer's invalidate) is inserted
+      # but must NEVER be trusted — fetch rejects it as stale.
+      :ok = ApiKeyCache.put(ak.key_hash, ak, stale_gen)
+      assert ApiKeyCache.fetch(ak.key_hash) == :miss
+
+      # A put stamped with the CURRENT generation IS served.
+      :ok = ApiKeyCache.put(ak.key_hash, ak, ApiKeyCache.generation(ak.key_hash))
+      assert {:ok, %ApiKey{}} = ApiKeyCache.fetch(ak.key_hash)
+    end
+
+    test "reset/1 is an alias for invalidate/1" do
+      {_raw, ak} = fixture(:api_key, role: :agent)
+      :ok = ApiKeyCache.put(ak.key_hash, ak)
+      assert {:ok, _} = ApiKeyCache.fetch(ak.key_hash)
+
+      :ok = ApiKeyCache.reset(ak.key_hash)
+      assert ApiKeyCache.fetch(ak.key_hash) == :miss
+    end
+  end
+
+  describe "verify_api_key/1 read-through cache" do
+    # TC-33.3.1
+    test "second request is served from ETS: a direct DB mutation is NOT seen until invalidation" do
+      {raw, ak} = fixture(:api_key, role: :agent, name: "original-name")
+
+      # First verify populates the cache read-through.
+      assert {:ok, %ApiKey{name: "original-name"}} = Auth.verify_api_key(raw)
+
+      # Mutate a NON-auth field DIRECTLY in the DB (bypassing any invalidation).
+      {1, _} =
+        from(k in ApiKey, where: k.id == ^ak.id)
+        |> AdminRepo.update_all(set: [name: "mutated-directly"])
+
+      # Still the cached name — proves the 2nd verify hit ETS, not the DB.
+      assert {:ok, %ApiKey{name: "original-name"}} = Auth.verify_api_key(raw)
+
+      # After invalidation the next verify repopulates from the DB and sees it.
+      :ok = ApiKeyCache.invalidate(ak.key_hash)
+      assert {:ok, %ApiKey{name: "mutated-directly"}} = Auth.verify_api_key(raw)
+    end
+
+    test "the resolved struct carries :tenant preloaded (custody_halted_at) on hit and miss" do
+      {raw, _ak} = fixture(:api_key, role: :agent)
+
+      # Miss path.
+      assert {:ok, %ApiKey{tenant: %Loopctl.Tenants.Tenant{}}} = Auth.verify_api_key(raw)
+      # Hit path.
+      assert {:ok, %ApiKey{tenant: tenant}} = Auth.verify_api_key(raw)
+      assert %Loopctl.Tenants.Tenant{} = tenant
+      assert Map.has_key?(tenant, :custody_halted_at)
+    end
+  end
+
+  describe "SECURITY — invalidate on revoke (TC-33.3.2 RELEASE GATE)" do
+    test "a revoked key is rejected on the VERY NEXT request, not after the TTL" do
+      {raw, ak} = fixture(:api_key, role: :agent)
+
+      # Populate the cache.
+      assert {:ok, %ApiKey{}} = Auth.verify_api_key(raw)
+
+      # Revoke via the real revoke path (which invalidates in-band).
+      {:ok, _} = Auth.revoke_api_key(ak)
+
+      # Immediately unauthorized — never the stale valid struct.
+      assert Auth.verify_api_key(raw) == {:error, :unauthorized}
+    end
+
+    test "the dispatch-cascade revoke path invalidates each revoked key_hash" do
+      tenant = fixture(:tenant)
+
+      # A dispatch with a linked api_key, then revoke via the cascade path.
+      {raw, ak} = fixture(:api_key, tenant_id: tenant.id, role: :agent)
+      dispatch = dispatch_for(tenant.id, ak.id)
+
+      assert {:ok, %ApiKey{}} = Auth.verify_api_key(raw)
+
+      {:ok, _count} = Loopctl.Dispatches.revoke(tenant.id, dispatch.id)
+
+      assert Auth.verify_api_key(raw) == {:error, :unauthorized}
+    end
+  end
+
+  describe "SECURITY — invalidate on rotate/mutate (TC-33.3.3)" do
+    test "a rotation grace-expiry in the past takes effect immediately (not after TTL)" do
+      {raw, ak} = fixture(:api_key, role: :agent)
+
+      assert {:ok, %ApiKey{}} = Auth.verify_api_key(raw)
+
+      # Rotation sets an expiry on the old key; a past expiry means already expired.
+      past = DateTime.add(DateTime.utc_now(), -60, :second)
+      {:ok, _} = Auth.expire_api_key(ak, past)
+
+      assert Auth.verify_api_key(raw) == {:error, :unauthorized}
+    end
+
+    test "an expiry mutation is reflected on the next request once the mutation invalidates" do
+      {raw, ak} = fixture(:api_key, role: :agent)
+
+      # No expiry initially -> caches with expires_at nil.
+      assert {:ok, %ApiKey{expires_at: nil}} = Auth.verify_api_key(raw)
+
+      # A future rotation expiry set DIRECTLY (models the expire/rotate mutation)
+      # WITHOUT invalidating — the key is still valid, but the cached struct is stale.
+      future = DateTime.add(DateTime.utc_now(), 3600, :second)
+
+      {1, _} =
+        from(k in ApiKey, where: k.id == ^ak.id)
+        |> AdminRepo.update_all(set: [expires_at: future])
+
+      # Still cached with the old (nil) expiry until the mutation path invalidates.
+      assert {:ok, %ApiKey{expires_at: nil}} = Auth.verify_api_key(raw)
+
+      # The mutation path busts the key_hash entry -> next verify reflects the change.
+      :ok = ApiKeyCache.invalidate_cluster(ak.key_hash)
+      assert {:ok, %ApiKey{expires_at: %DateTime{}}} = Auth.verify_api_key(raw)
+    end
+  end
+
+  describe "defense-in-depth bounded TTL (TC-33.3.4)" do
+    test "TTL self-heals a MISSED invalidation: an expired entry re-validates against the DB" do
+      {raw, ak} = fixture(:api_key, role: :agent)
+
+      # Populate the cache.
+      assert {:ok, %ApiKey{}} = Auth.verify_api_key(raw)
+      assert {:ok, cached} = ApiKeyCache.fetch(ak.key_hash)
+
+      # Simulate a MISSED invalidation path: revoke in the DB WITHOUT busting the
+      # cache. The stale cached entry would still authenticate on a HIT...
+      {1, _} =
+        from(k in ApiKey, where: k.id == ^ak.id)
+        |> AdminRepo.update_all(set: [revoked_at: DateTime.utc_now()])
+
+      # ...so force the entry past its TTL (matching generation — only the TTL can
+      # reject it), modelling "advance past the bounded TTL".
+      gen = ApiKeyCache.generation(ak.key_hash)
+      past = System.monotonic_time(:millisecond) - 1
+      true = :ets.insert(ApiKeyCache.table_name(), {ak.key_hash, cached, gen, past})
+
+      # The TTL backstop re-validates against the DB -> the revoke is honored.
+      assert Auth.verify_api_key(raw) == {:error, :unauthorized}
+    end
+
+    test "an entry past its TTL is a MISS even when its generation still matches" do
+      {_raw, ak} = fixture(:api_key, role: :agent)
+      gen = ApiKeyCache.generation(ak.key_hash)
+
+      past = System.monotonic_time(:millisecond) - 1
+      true = :ets.insert(ApiKeyCache.table_name(), {ak.key_hash, ak, gen, past})
+
+      assert ApiKeyCache.fetch(ak.key_hash) == :miss
+
+      # A fresh-expiry entry with the same generation IS served.
+      :ok = ApiKeyCache.put(ak.key_hash, ak, gen)
+      assert {:ok, %ApiKey{}} = ApiKeyCache.fetch(ak.key_hash)
+    end
+
+    test "the periodic sweep actively evicts an expired entry" do
+      {_raw, ak} = fixture(:api_key, role: :agent)
+      gen = ApiKeyCache.generation(ak.key_hash)
+
+      past = System.monotonic_time(:millisecond) - 1
+      true = :ets.insert(ApiKeyCache.table_name(), {ak.key_hash, ak, gen, past})
+
+      send(Process.whereis(ApiKeyCache), :sweep)
+      _ = :sys.get_state(ApiKeyCache)
+
+      assert :ets.lookup(ApiKeyCache.table_name(), ak.key_hash) == []
+    end
+  end
+
+  describe "tenant isolation (TC-33.3.5)" do
+    test "revoking tenant A's key leaves tenant B's cached key unaffected" do
+      a = fixture(:tenant)
+      b = fixture(:tenant)
+
+      {raw_a, ak_a} = fixture(:api_key, tenant_id: a.id, role: :agent)
+      {raw_b, _ak_b} = fixture(:api_key, tenant_id: b.id, role: :agent)
+
+      # Cache both.
+      assert {:ok, %ApiKey{}} = Auth.verify_api_key(raw_a)
+      assert {:ok, %ApiKey{}} = Auth.verify_api_key(raw_b)
+
+      # Revoke ONLY A.
+      {:ok, _} = Auth.revoke_api_key(ak_a)
+
+      # A rejected, B untouched.
+      assert Auth.verify_api_key(raw_a) == {:error, :unauthorized}
+      assert {:ok, %ApiKey{tenant_id: tenant_b_id}} = Auth.verify_api_key(raw_b)
+      assert tenant_b_id == b.id
+    end
+  end
+
+  describe "cross-node invalidation" do
+    test "invalidate_cluster busts the local entry and bumps the generation" do
+      {_raw, ak} = fixture(:api_key, role: :agent)
+      :ok = ApiKeyCache.put(ak.key_hash, ak)
+      gen0 = ApiKeyCache.generation(ak.key_hash)
+
+      assert {:ok, _} = ApiKeyCache.fetch(ak.key_hash)
+
+      :ok = ApiKeyCache.invalidate_cluster(ak.key_hash)
+
+      assert ApiKeyCache.fetch(ak.key_hash) == :miss
+      assert ApiKeyCache.generation(ak.key_hash) > gen0
+    end
+
+    test "a peer node's invalidation broadcast busts this node's entry" do
+      {_raw, ak} = fixture(:api_key, role: :agent)
+      :ok = ApiKeyCache.put(ak.key_hash, ak)
+      assert {:ok, _} = ApiKeyCache.fetch(ak.key_hash)
+
+      Phoenix.PubSub.broadcast(
+        Loopctl.PubSub,
+        "auth:api_key_cache:invalidate",
+        {:invalidate, ak.key_hash}
+      )
+
+      _ = :sys.get_state(ApiKeyCache)
+
+      assert ApiKeyCache.fetch(ak.key_hash) == :miss
+    end
+  end
+
+  describe "table options (AC-33.3.1)" do
+    test "the ETS table is a :public, :named_table, :set with read_concurrency" do
+      table = ApiKeyCache.table_name()
+
+      assert :ets.info(table, :named_table) == true
+      assert :ets.info(table, :protection) == :public
+      assert :ets.info(table, :type) == :set
+      assert :ets.info(table, :read_concurrency) == true
+    end
+  end
+
+  describe "no secrets logged (AC-33.3.7)" do
+    test "neither the raw key nor the key_hash is logged on verify/revoke" do
+      {raw, ak} = fixture(:api_key, role: :agent)
+      key_hash = ak.key_hash
+
+      log =
+        capture_log(fn ->
+          {:ok, _} = Auth.verify_api_key(raw)
+          {:ok, _} = Auth.verify_api_key(raw)
+          {:ok, _} = Auth.revoke_api_key(ak)
+          _ = Auth.verify_api_key(raw)
+        end)
+
+      refute log =~ raw
+      refute log =~ key_hash
+    end
+  end
+
+  # Insert a dispatch row directly (uncast tenant_id/api_key_id) so we can exercise
+  # the Dispatches.revoke/2 cascade without the full mint ceremony.
+  defp dispatch_for(tenant_id, api_key_id) do
+    now = DateTime.utc_now()
+
+    %Loopctl.Dispatches.Dispatch{}
+    |> Ecto.Changeset.change(%{
+      tenant_id: tenant_id,
+      api_key_id: api_key_id,
+      role: :agent,
+      lineage_path: [],
+      expires_at: DateTime.add(now, 3600, :second),
+      created_at: now
+    })
+    |> AdminRepo.insert!()
+  end
+end

--- a/test/loopctl/auth/api_key_cache_test.exs
+++ b/test/loopctl/auth/api_key_cache_test.exs
@@ -5,6 +5,7 @@ defmodule Loopctl.Auth.ApiKeyCacheTest do
   alias Loopctl.Auth
   alias Loopctl.Auth.ApiKey
   alias Loopctl.Auth.ApiKeyCache
+  alias Loopctl.Workers.RevokeExpiredDispatchesWorker
 
   import Ecto.Query
   import ExUnit.CaptureLog
@@ -138,6 +139,26 @@ defmodule Loopctl.Auth.ApiKeyCacheTest do
 
       assert Auth.verify_api_key(raw) == {:error, :unauthorized}
     end
+
+    test "the RevokeExpiredDispatchesWorker release-gate path busts the cache for expired dispatch keys" do
+      tenant = fixture(:tenant)
+
+      # A key linked to a dispatch that is already past its expiry.
+      {raw, ak} = fixture(:api_key, tenant_id: tenant.id, role: :agent)
+      past = DateTime.add(DateTime.utc_now(), -120, :second)
+      _dispatch = dispatch_for(tenant.id, ak.id, past)
+
+      # Populate the cache read-through.
+      assert {:ok, %ApiKey{}} = Auth.verify_api_key(raw)
+
+      # The cron worker revokes the expired dispatch + its api_key and MUST bust the
+      # cache in-band (AC-33.3.2) — deleting worker line 56 would leave this green
+      # only because of the assertion below.
+      assert :ok = RevokeExpiredDispatchesWorker.perform(%Oban.Job{args: %{}})
+
+      # Immediately unauthorized on the very next request, not after the TTL.
+      assert Auth.verify_api_key(raw) == {:error, :unauthorized}
+    end
   end
 
   describe "SECURITY — invalidate on rotate/mutate (TC-33.3.3)" do
@@ -228,6 +249,67 @@ defmodule Loopctl.Auth.ApiKeyCacheTest do
     end
   end
 
+  describe "generation-entry memory bound (technical-notes)" do
+    test "an idle generation entry is reaped by the sweep, capping memory" do
+      {_raw, ak} = fixture(:api_key, role: :agent)
+
+      # The first invalidation creates the {:gen, key_hash} counter entry.
+      :ok = ApiKeyCache.invalidate(ak.key_hash)
+
+      assert [{{:gen, _}, _gen, _reap}] =
+               :ets.lookup(ApiKeyCache.table_name(), {:gen, ak.key_hash})
+
+      # Force its reap deadline into the past (models "idle beyond the bump grace").
+      past = System.monotonic_time(:millisecond) - 1
+      true = :ets.update_element(ApiKeyCache.table_name(), {:gen, ak.key_hash}, {3, past})
+
+      send(Process.whereis(ApiKeyCache), :sweep)
+      _ = :sys.get_state(ApiKeyCache)
+
+      assert :ets.lookup(ApiKeyCache.table_name(), {:gen, ak.key_hash}) == []
+    end
+
+    test "a freshly-bumped generation entry is NOT reaped (deadline refreshed on bump)" do
+      {_raw, ak} = fixture(:api_key, role: :agent)
+
+      :ok = ApiKeyCache.invalidate(ak.key_hash)
+      # Force the deadline into the past...
+      past = System.monotonic_time(:millisecond) - 1
+      true = :ets.update_element(ApiKeyCache.table_name(), {:gen, ak.key_hash}, {3, past})
+      # ...then a fresh bump refreshes it to the future, surviving the sweep.
+      :ok = ApiKeyCache.invalidate(ak.key_hash)
+
+      send(Process.whereis(ApiKeyCache), :sweep)
+      _ = :sys.get_state(ApiKeyCache)
+
+      assert [{{:gen, _}, _gen, _reap}] =
+               :ets.lookup(ApiKeyCache.table_name(), {:gen, ak.key_hash})
+    end
+
+    test "reaping a generation entry preserves the never-stale invariant" do
+      {_raw, ak} = fixture(:api_key, role: :agent)
+
+      # A key bumped at least once: the gen entry is present at gen >= 1, so there
+      # is no in-flight stamp-0 reader for it.
+      :ok = ApiKeyCache.invalidate(ak.key_hash)
+      gen = ApiKeyCache.generation(ak.key_hash)
+      assert gen >= 1
+
+      # Reap the (idle) gen entry -> current generation resets to the 0 default.
+      past = System.monotonic_time(:millisecond) - 1
+      true = :ets.update_element(ApiKeyCache.table_name(), {:gen, ak.key_hash}, {3, past})
+      send(Process.whereis(ApiKeyCache), :sweep)
+      _ = :sys.get_state(ApiKeyCache)
+      assert ApiKeyCache.generation(ak.key_hash) == 0
+
+      # A value stamped with the pre-reap generation (>= 1) can never equal the
+      # post-reap 0 default, so a late stale repopulation is still rejected — the
+      # reap does not resurrect a stale HIT.
+      :ok = ApiKeyCache.put(ak.key_hash, ak, gen)
+      assert ApiKeyCache.fetch(ak.key_hash) == :miss
+    end
+  end
+
   describe "tenant isolation (TC-33.3.5)" do
     test "revoking tenant A's key leaves tenant B's cached key unaffected" do
       a = fixture(:tenant)
@@ -247,6 +329,73 @@ defmodule Loopctl.Auth.ApiKeyCacheTest do
       assert Auth.verify_api_key(raw_a) == {:error, :unauthorized}
       assert {:ok, %ApiKey{tenant_id: tenant_b_id}} = Auth.verify_api_key(raw_b)
       assert tenant_b_id == b.id
+    end
+  end
+
+  describe "tenant-row + agent-binding invalidation (AC-33.3.3/.5)" do
+    test "suspending a tenant busts its cached keys (custody/status fields compose with US-33.2)" do
+      tenant = fixture(:tenant)
+      {raw, ak} = fixture(:api_key, tenant_id: tenant.id, role: :agent)
+
+      # Cache the key WITH its :tenant preloaded (status/custody_halted_at).
+      assert {:ok, %ApiKey{}} = Auth.verify_api_key(raw)
+      assert {:ok, _} = ApiKeyCache.fetch(ak.key_hash)
+
+      # A tenant-row mutation leaves the cached preloaded :tenant stale, so it must
+      # bust the tenant's cached keys (invalidate_tenant_key_cache).
+      {:ok, _suspended} = Loopctl.Tenants.suspend_tenant(tenant)
+
+      assert ApiKeyCache.fetch(ak.key_hash) == :miss
+    end
+
+    test "halting a tenant's custody busts its cached keys" do
+      tenant = fixture(:tenant)
+      {raw, ak} = fixture(:api_key, tenant_id: tenant.id, role: :agent)
+
+      assert {:ok, %ApiKey{}} = Auth.verify_api_key(raw)
+      assert {:ok, _} = ApiKeyCache.fetch(ak.key_hash)
+
+      {:ok, _halted} = Loopctl.Tenants.halt_custody(tenant.id)
+
+      assert ApiKeyCache.fetch(ak.key_hash) == :miss
+    end
+
+    test "binding an agent to a key busts that key's cached entry (agent_id scope change)" do
+      tenant = fixture(:tenant)
+      {raw, ak} = fixture(:api_key, tenant_id: tenant.id, role: :agent)
+
+      assert {:ok, %ApiKey{}} = Auth.verify_api_key(raw)
+      assert {:ok, _} = ApiKeyCache.fetch(ak.key_hash)
+
+      {:ok, _agent} =
+        Loopctl.Agents.register_agent(
+          tenant.id,
+          %{name: "bound-worker", agent_type: :implementer},
+          api_key_id: ak.id
+        )
+
+      assert ApiKeyCache.fetch(ak.key_hash) == :miss
+    end
+
+    test "the tenant fan-out is bounded to ACTIVE keys — a revoked key_hash is not bumped" do
+      tenant = fixture(:tenant)
+      {active_raw, active_ak} = fixture(:api_key, tenant_id: tenant.id, role: :agent)
+      {_revoked_raw, revoked_ak} = fixture(:api_key, tenant_id: tenant.id, role: :agent)
+
+      # Cache the active key; revoke the other (revoke bumps its generation once).
+      assert {:ok, %ApiKey{}} = Auth.verify_api_key(active_raw)
+      {:ok, _} = Auth.revoke_api_key(revoked_ak)
+      revoked_gen_before = ApiKeyCache.generation(revoked_ak.key_hash)
+      active_gen_before = ApiKeyCache.generation(active_ak.key_hash)
+
+      # A tenant mutation fans out invalidation. With the revoked filter (finding-2),
+      # only the ACTIVE key's generation advances; the revoked key — never cached, so
+      # never needing a bust — is excluded, capping the fan-out under Epic 33's
+      # accumulation of revoked ephemeral dispatch keys.
+      {:ok, _suspended} = Loopctl.Tenants.suspend_tenant(tenant)
+
+      assert ApiKeyCache.generation(revoked_ak.key_hash) == revoked_gen_before
+      assert ApiKeyCache.generation(active_ak.key_hash) > active_gen_before
     end
   end
 
@@ -311,8 +460,9 @@ defmodule Loopctl.Auth.ApiKeyCacheTest do
   end
 
   # Insert a dispatch row directly (uncast tenant_id/api_key_id) so we can exercise
-  # the Dispatches.revoke/2 cascade without the full mint ceremony.
-  defp dispatch_for(tenant_id, api_key_id) do
+  # the Dispatches.revoke/2 cascade without the full mint ceremony. `expires_at`
+  # defaults to the future; pass a past value to exercise the expired-dispatch sweep.
+  defp dispatch_for(tenant_id, api_key_id, expires_at \\ nil) do
     now = DateTime.utc_now()
 
     %Loopctl.Dispatches.Dispatch{}
@@ -321,7 +471,7 @@ defmodule Loopctl.Auth.ApiKeyCacheTest do
       api_key_id: api_key_id,
       role: :agent,
       lineage_path: [],
-      expires_at: DateTime.add(now, 3600, :second),
+      expires_at: expires_at || DateTime.add(now, 3600, :second),
       created_at: now
     })
     |> AdminRepo.insert!()


### PR DESCRIPTION
## US-33.3 — ETS read-through cache for API-key resolution

Epic 33 (DB Connection Topology & AdminRepo Hot Path). Makes `Loopctl.Auth.verify_api_key/1` read through a supervised ETS cache keyed by `key_hash`, converting a per-request AdminRepo SELECT into a per-change one on the authenticated hot path. This is a security boundary: a stale cache must never authenticate a revoked/rotated key.

### What changed
- New `Loopctl.Auth.ApiKeyCache` — supervised ETS-owner GenServer mirroring `Loopctl.Llm.SettingsCache` (US-32.3): public/named_table/read_concurrency table, generation-counter + optimistic-version trick to close the read-through repopulation race, lazy TTL expiry + periodic sweep, cross-node PubSub invalidation bridge, all ETS ops rescue-wrapped. Registered in application.ex after SettingsCache.
- `verify_api_key/1` is read-through — hit-and-fresh returns the cached ApiKey (with :tenant preloaded, carrying custody_halted_at) with no SELECT, re-enforcing revoked_at/expires_at against wall-clock now (AC-33.3.5); a miss loads read-through under a generation captured before the DB read. The per-request last_used_at UPDATE is untouched (AC-33.3.6; US-33.4 owns it).
- In-band invalidation on every writer (AC-33.3.2/.3): revoke_api_key, expire_api_key, generate_api_key; the Dispatches.revoke and RevokeExpiredDispatchesWorker update_all cascades (resolve the key_hashes for the revoked ids, since those queries lack key_hash); agent binding (sets api_key.agent_id); and tenant-auth mutations that leave the cached :tenant snapshot stale (suspend/activate, custody halt/clear, WebAuthn trust-tier upgrade, audit-key rotation) via Auth.invalidate_tenant_key_cache/1.
- Config-driven bounded TTL (config :loopctl, Loopctl.Auth.ApiKeyCache, ttl_ms:), default 60s.

### Tests
api_key_cache_test.exs (async) + api_key_cache_restart_test.exs cover: read-through hit skips the SELECT (TC-33.3.1), revoked key rejected on the very next request incl. the dispatch cascade (TC-33.3.2 release gate), rotate/mutate immediacy (TC-33.3.3), TTL self-heal of a missed invalidation (TC-33.3.4), tenant isolation (TC-33.3.5), cross-node invalidation, cold-start repopulation, and a no-secrets-logged assertion (AC-33.3.7).

### Security notes
- The cache stores only positive resolutions; secrets/hashes are never logged, inspected, or telemetry-tagged.
- Tenant-snapshot staleness (a consequence of caching :tenant, which the story mandates) is closed by busting a tenant's cached keys on every tenant-auth mutation — a custody halt / suspension / tier change takes effect on the next request, not after the TTL.

### Note on the cold-start test
Unlike a literal mirror of settings_cache_restart_test.exs, the restart test does NOT stop the supervised owner: ApiKeyCache and SettingsCache are both :one_for_one children of the same root supervisor, and a second module doing supervised restarts exceeds the shared max_restarts window (verified: it takes the whole app down mid-suite). It reproduces the same "table destroyed -> recreated empty -> repopulates read-through" failure mode via :ets.give_away/3 to the live owner, at zero root-supervisor restart cost.

mix precommit green (compile --warnings-as-errors, format, credo --strict, deps.audit, dialyzer, 4279 tests / 0 failures).
