### PR TITLE
Debounce last_seen_at / last_used_at touch-writes off the request path

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -133,6 +133,13 @@ config :loopctl,
 # 30-60s range the AC specifies); overridable per-env.
 config :loopctl, Loopctl.Auth.ApiKeyCache, ttl_ms: :timer.seconds(60)
 
+# US-33.4: flush interval (ms) for the debounced liveness touch buffer
+# (agents.last_seen_at / api_keys.last_used_at). Per-request touch-writes are
+# collapsed into one batched, monotonic UPDATE per active id every interval, so
+# these liveness heuristics are at most one interval stale (AC-33.4.4). Default a
+# few seconds; overridable per-env.
+config :loopctl, Loopctl.TouchBuffer, flush_interval_ms: :timer.seconds(5)
+
 # AdminRepo shares the same database but uses a role with BYPASSRLS in production.
 # In dev/test, it uses the same credentials as Repo.
 config :loopctl, Loopctl.AdminRepo,

--- a/config/test.exs
+++ b/config/test.exs
@@ -52,6 +52,14 @@ config :loopctl, Loopctl.HeavyReadRepo,
 # tests stay sub-second.
 config :loopctl, :heavy_read_statement_timeout_ms, 250
 
+# US-33.4: set the touch-buffer flush interval very high in tests so the
+# app-tree singleton NEVER auto-flushes during a run — its timer would fire in
+# the GenServer process without a checked-out sandbox connection and could drain
+# other async tests' buffered entries. Tests drive an isolated per-test buffer
+# instance and flush it explicitly in-process (which owns the sandbox
+# connection); integration tests assert on the buffer contents directly.
+config :loopctl, Loopctl.TouchBuffer, flush_interval_ms: :timer.hours(1)
+
 # Keep the L3 local test runner DISABLED in tests (it clones repos + runs
 # `mix test` on untrusted code). TestRunner's tests exercise the disabled path
 # and the validation-rejection paths WITHOUT ever cloning a real repo; input

--- a/lib/loopctl/agents.ex
+++ b/lib/loopctl/agents.ex
@@ -146,29 +146,28 @@ defmodule Loopctl.Agents do
   end
 
   @doc """
-  Updates the `last_seen_at` timestamp for an agent.
+  Records a debounced `last_seen_at` touch for an agent (US-33.4).
 
-  This is a best-effort operation -- failures are logged but do not
-  propagate to the caller. Used by the UpdateLastSeen plug.
+  This no longer performs a synchronous DB write on the request path. It records
+  `now` into `Loopctl.TouchBuffer` (an in-memory ETS buffer, no `AdminRepo`
+  SELECT and no UPDATE); a supervised periodic flusher writes the buffered maxima
+  in one batched, monotonic `UPDATE`. `last_seen_at` is a liveness heuristic, so
+  bounded staleness (at most one flush interval) is acceptable. Best-effort — it
+  never raises and never blocks the request. Used by the `UpdateLastSeen` plug.
+
+  `tenant_id` is accepted for the caller's convenience but is not needed for
+  scoping: `agent_id` is a globally-unique UUID, so the flush's `WHERE id = ...`
+  is self-scoping (no cross-tenant write is possible).
 
   ## Parameters
 
-  - `tenant_id` -- the tenant UUID
+  - `tenant_id` -- the tenant UUID (unused; agent_id is globally unique)
   - `agent_id` -- the agent UUID
   - `now` -- the current timestamp
   """
-  @spec touch_last_seen(Ecto.UUID.t(), Ecto.UUID.t(), DateTime.t()) ::
-          {:ok, Agent.t()} | {:error, term()}
-  def touch_last_seen(tenant_id, agent_id, now) do
-    case AdminRepo.get_by(Agent, id: agent_id, tenant_id: tenant_id) do
-      nil ->
-        {:error, :not_found}
-
-      agent ->
-        agent
-        |> Agent.touch_changeset(now)
-        |> AdminRepo.update()
-    end
+  @spec touch_last_seen(Ecto.UUID.t(), Ecto.UUID.t(), DateTime.t()) :: :ok
+  def touch_last_seen(_tenant_id, agent_id, %DateTime{} = now) do
+    Loopctl.TouchBuffer.record_agent(agent_id, now)
   end
 
   @allowed_sort_fields ~w(name agent_type status last_seen_at inserted_at)

--- a/lib/loopctl/agents/agent.ex
+++ b/lib/loopctl/agents/agent.ex
@@ -81,14 +81,6 @@ defmodule Loopctl.Agents.Agent do
   end
 
   @doc """
-  Changeset for updating last_seen_at timestamp.
-  """
-  @spec touch_changeset(%__MODULE__{}, DateTime.t()) :: Ecto.Changeset.t()
-  def touch_changeset(agent, now) do
-    change(agent, last_seen_at: now)
-  end
-
-  @doc """
   Returns the list of valid agent types.
   """
   @spec agent_types() :: [atom()]

--- a/lib/loopctl/application.ex
+++ b/lib/loopctl/application.ex
@@ -50,6 +50,13 @@ defmodule Loopctl.Application do
       # After PubSub + AdminRepo: it subscribes in init and its values preload
       # :tenant (custody_halted_at) for the CheckCustodyHalt plug (US-33.2).
       Loopctl.Auth.ApiKeyCache,
+      # US-33.4: owns the ETS buffer that debounces the two per-request liveness
+      # touch-writes (agents.last_seen_at, api_keys.last_used_at) off the auth
+      # hot path — the request records into ETS and a periodic flusher writes the
+      # buffered maxima in one batched, monotonic UPDATE. After AdminRepo (it
+      # writes via AdminRepo at flush); stable owner survives the request/Task/
+      # Oban process that recorded a touch.
+      Loopctl.TouchBuffer,
       LoopctlWeb.Endpoint
     ]
 

--- a/lib/loopctl/auth.ex
+++ b/lib/loopctl/auth.ex
@@ -18,7 +18,8 @@ defmodule Loopctl.Auth do
   1. Hash the provided raw key with SHA-256
   2. Look up by `key_hash`
   3. Reject if revoked or expired
-  4. Update `last_used_at` on success
+  4. Record a debounced `last_used_at` touch on success (US-33.4 — no
+     synchronous write on the request path)
   """
 
   import Ecto.Query
@@ -26,6 +27,7 @@ defmodule Loopctl.Auth do
   alias Loopctl.AdminRepo
   alias Loopctl.Auth.ApiKey
   alias Loopctl.Auth.ApiKeyCache
+  alias Loopctl.TouchBuffer
 
   @key_prefix "lc_"
   @random_bytes 30
@@ -89,8 +91,11 @@ defmodule Loopctl.Auth do
   revoke/rotate/mutate writer invalidates the `key_hash` entry in-band, with a
   bounded TTL as the defense-in-depth backstop. See `Loopctl.Auth.ApiKeyCache`.
 
-  The per-request `last_used_at` UPDATE still fires on every request — this
-  story removes ONLY the SELECT (AC-33.3.6; US-33.4 owns debouncing the write).
+  The per-request `last_used_at` UPDATE is debounced off the hot path (US-33.4):
+  `verify_and_touch/2` records the touch into `Loopctl.TouchBuffer` (no
+  synchronous AdminRepo write) and a periodic batched flush advances the row.
+  Combined with the read-through cache (US-33.3), the auth touch path is now net
+  ZERO AdminRepo statements per request.
   """
   @spec verify_api_key(String.t()) :: {:ok, ApiKey.t()} | {:error, :unauthorized}
   def verify_api_key(raw_key) when is_binary(raw_key) do
@@ -148,10 +153,14 @@ defmodule Loopctl.Auth do
     # Constant-time comparison to prevent timing-based side channels.
     # Both sides are SHA-256 hex strings of equal length.
     if Plug.Crypto.secure_compare(api_key.key_hash, key_hash) do
-      case update_last_used(api_key) do
-        {:ok, updated} -> {:ok, updated}
-        _error -> {:ok, api_key}
-      end
+      # US-33.4: the per-request `last_used_at` UPDATE is debounced off the hot
+      # path — record the touch into the batched buffer (no synchronous
+      # AdminRepo write) instead of updating the row here. Reflect `now` on the
+      # in-memory struct for response fidelity (callers/serializers see a fresh
+      # `last_used_at`); the DB row is advanced by the periodic batched flush.
+      now = DateTime.utc_now()
+      TouchBuffer.record_api_key(api_key.id, now)
+      {:ok, %{api_key | last_used_at: now}}
     else
       {:error, :unauthorized}
     end
@@ -323,11 +332,5 @@ defmodule Loopctl.Auth do
   @spec hash_key(String.t()) :: String.t()
   def hash_key(raw_key) do
     :crypto.hash(:sha256, raw_key) |> Base.encode16(case: :lower)
-  end
-
-  defp update_last_used(api_key) do
-    api_key
-    |> ApiKey.touch_changeset()
-    |> AdminRepo.update()
   end
 end

--- a/lib/loopctl/auth/api_key.ex
+++ b/lib/loopctl/auth/api_key.ex
@@ -63,14 +63,6 @@ defmodule Loopctl.Auth.ApiKey do
   end
 
   @doc """
-  Changeset for updating last_used_at timestamp.
-  """
-  @spec touch_changeset(%__MODULE__{}) :: Ecto.Changeset.t()
-  def touch_changeset(api_key) do
-    change(api_key, last_used_at: DateTime.utc_now())
-  end
-
-  @doc """
   Changeset for setting expires_at (used during key rotation).
   """
   @spec expire_changeset(%__MODULE__{}, DateTime.t()) :: Ecto.Changeset.t()

--- a/lib/loopctl/auth/api_key_cache.ex
+++ b/lib/loopctl/auth/api_key_cache.ex
@@ -13,9 +13,9 @@ defmodule Loopctl.Auth.ApiKeyCache do
   that revokes/rotates/mutates a key invalidates the entry so the next request
   re-loads read-through.
 
-  This module removes ONLY the SELECT. The per-request `last_used_at` UPDATE
-  (`Loopctl.Auth` `update_last_used/1`) is untouched and still fires on every
-  request — US-33.4 owns debouncing that write (AC-33.3.6).
+  This module removes the per-request SELECT. The per-request `last_used_at`
+  UPDATE is debounced off the hot path by `Loopctl.TouchBuffer` (US-33.4), so
+  together the auth touch path is now net ZERO AdminRepo statements per request.
 
   ## Security — a stale cache must NEVER authenticate a revoked/rotated key
 

--- a/lib/loopctl/touch_buffer.ex
+++ b/lib/loopctl/touch_buffer.ex
@@ -30,6 +30,19 @@ defmodule Loopctl.TouchBuffer do
       `CheckCustodyHalt`) gates on `revoked_at`/`expires_at`/`custody_halted_at`
       — NEVER on `last_used_at`/`last_seen_at`.
 
+  ### Collateral: a liveness touch no longer bumps `updated_at`
+
+  The OLD touch path went through a changeset (`change(agent, last_seen_at:
+  now) |> AdminRepo.update()`), so `timestamps()` auto-advanced
+  `agents.updated_at` / `api_keys.updated_at` on every authenticated request.
+  The batched flush issues a RAW `UPDATE` that sets ONLY
+  `last_seen_at`/`last_used_at` (below), so a liveness touch no longer moves
+  `updated_at`. `updated_at` is a serialized field (`Jason.Encoder` derive), so
+  this is a deliberate, observable behavior change — but benign: no reader gates
+  liveness on `agents`/`api_keys` `updated_at` (`count_active_agents/0` filters
+  `last_seen_at`), and `updated_at` now tracks only real record mutations
+  (role/expiry/revoke changes) rather than being churned by every request.
+
   NOT in scope (left synchronous): the WebAuthn authenticator `last_used_at`
   (`root_authenticator`, `web_authn/reauth`) is a custody-critical assertion
   alongside `sign_count` and is unrelated to these two liveness columns.
@@ -53,14 +66,33 @@ defmodule Loopctl.TouchBuffer do
   ## Flush — batched, monotonic, tenant-safe
 
   On each interval (and on graceful shutdown) the buffer is DRAINED atomically
-  (`:ets.take` per key) and grouped by target table. Each target issues ONE
-  `UPDATE ... FROM (VALUES ...)` statement over ALL its drained ids — so a flush
-  is O(1) statements per table (O(scopes), NOT O(ids)):
+  (`:ets.take` per key) and grouped by target table. Each target issues
+  `UPDATE ... FROM (VALUES ...)` statements over its drained ids — so a flush is
+  O(scopes) tables and, per table, O(ceil(ids / chunk_size)) chunked
+  statements (NOT one statement per id).
+
+  Each target is flushed inside its OWN rescue (`flush_target/3`). `drain/1`
+  `:ets.take`'d BOTH targets' entries up front, so a raise while flushing one
+  target — a sustained per-table lock-timeout, or a latent `build_values` bug
+  for that column — must NOT unwind past its sibling and skip the sibling's
+  already-drained window. Without per-target isolation a DETERMINISTIC agents
+  failure would starve `api_keys.last_used_at` EVERY interval indefinitely (the
+  targets share one flush). Isolated, the failing target loses `<= 1` interval
+  (AC-33.4.4) and the sibling still flushes:
 
       UPDATE agents AS t
       SET last_seen_at = GREATEST(t.last_seen_at, v.ts)
       FROM (VALUES ($1::uuid, $2::timestamp), ...) AS v(id, ts)
       WHERE t.id = v.id
+
+    * **Chunked** — each `VALUES` row contributes 2 bound params (id + ts) and
+      Postgres caps a statement at 65,535 bound params, so a single UPDATE could
+      carry at most ~32k ids. At epic_33 scale (tens of thousands of
+      concurrently-active agents per flush interval) one unbounded UPDATE would
+      exceed that cap and raise — and because `drain/1` has already removed the
+      entries from ETS, the swallowed raise would silently lose the whole
+      window. So drained entries are `Enum.chunk_every(@flush_chunk_size)` and
+      each chunk is its own bounded UPDATE.
 
     * **Monotonic** — `GREATEST(col, v.ts)` (Postgres `GREATEST` ignores NULLs,
       so it also seeds a previously-NULL column) means a delayed flush can only
@@ -112,6 +144,19 @@ defmodule Loopctl.TouchBuffer do
   # so interpolating them into the UPDATE is safe — only the ids/timestamps are
   # parameterized.
   @targets [agent: {"agents", "last_seen_at"}, api_key: {"api_keys", "last_used_at"}]
+
+  # Max drained entries per UPDATE statement. Each entry emits 2 bound params
+  # (id + ts) and the Postgres wire protocol caps a statement at 65,535 bound
+  # params, so one UPDATE could carry at most ~32k ids before AdminRepo.query!/2
+  # raises. drain/1 has ALREADY :ets.take'd the entries before the UPDATE runs
+  # and do_flush/1 swallows a raise, so an over-limit statement would silently
+  # lose the entire drained window — and at epic_33 scale (tens of thousands of
+  # concurrently-active agents/keys per flush interval) it would fail EVERY
+  # interval, freezing last_seen_at/last_used_at. Chunk well under the cap (2 *
+  # 5_000 = 10_000 params/statement) so a flush issues O(ids/chunk) bounded
+  # UPDATEs instead. (Canonical: KB "Chunk bulk inserts to respect database
+  # parameter limits".)
+  @flush_chunk_size 5_000
 
   # --- Client API ---
 
@@ -243,9 +288,14 @@ defmodule Loopctl.TouchBuffer do
   defp schedule_flush(_), do: nil
 
   # Flush core — atomically drain the buffer, group by target table, and issue
-  # ONE batched monotonic UPDATE per non-empty target. Runs in the caller so the
-  # DB write uses the caller's connection (prod: the GenServer; tests: the test
-  # process that owns the sandbox connection).
+  # batched monotonic chunked UPDATEs per non-empty target. Runs in the caller so
+  # the DB write uses the caller's connection (prod: the GenServer; tests: the
+  # test process that owns the sandbox connection).
+  #
+  # Each target flushes inside its OWN rescue (flush_target/3), so one target's
+  # failure cannot swallow the sibling's already-drained window (see moduledoc).
+  # This outer rescue is a final safety net for drain/group_by only — a flush
+  # must never crash the owner (or a caller).
   defp do_flush(table) do
     drained = drain(table)
     grouped = Enum.group_by(drained, fn {{tag, _id}, _ts} -> tag end)
@@ -256,8 +306,6 @@ defmodule Loopctl.TouchBuffer do
 
     :ok
   rescue
-    # A flush must never crash the owner (or a caller). The drained ids for a
-    # failed flush are lost (best-effort, <= one interval — AC-33.4.4).
     e ->
       Logger.warning("TouchBuffer flush failed: #{inspect(e)}")
       :ok
@@ -275,7 +323,28 @@ defmodule Loopctl.TouchBuffer do
 
   defp flush_target(_sql_table, _column, []), do: :ok
 
+  # Chunk the drained ids so no single UPDATE exceeds the Postgres bound-param
+  # cap (see @flush_chunk_size). Each chunk is its own bounded statement.
+  #
+  # Rescue is PER-TARGET on purpose: drain/1 has already :ets.take'd every
+  # target's entries, so a raise here (lock-timeout, or a latent build_values
+  # bug for this column) must be contained to THIS target — it must not unwind
+  # into do_flush and skip the sibling target's already-drained window. We log
+  # and return :ok; this target loses <= one interval (AC-33.4.4), the sibling
+  # still flushes.
   defp flush_target(sql_table, column, entries) do
+    entries
+    |> Enum.chunk_every(@flush_chunk_size)
+    |> Enum.each(fn chunk -> flush_chunk(sql_table, column, chunk) end)
+
+    :ok
+  rescue
+    e ->
+      Logger.warning("TouchBuffer flush failed for #{sql_table}: #{inspect(e)}")
+      :ok
+  end
+
+  defp flush_chunk(sql_table, column, entries) do
     {values_sql, params} = build_values(entries)
 
     sql =

--- a/lib/loopctl/touch_buffer.ex
+++ b/lib/loopctl/touch_buffer.ex
@@ -1,0 +1,313 @@
+defmodule Loopctl.TouchBuffer do
+  @moduledoc """
+  Debounces the two per-request *liveness* touch-writes off the authentication
+  hot path (US-33.4): `agents.last_seen_at` and `api_keys.last_used_at`.
+
+  Every authenticated request previously issued TWO synchronous `UPDATE`s on the
+  small (3-connection) BYPASSRLS `AdminRepo` pool — one per touched row. A
+  fast-looping agent hammers the SAME two rows on every request, producing
+  row-lock contention and dead-tuple bloat for a value nobody reads with
+  per-request precision. This module collapses N per-request writes into ONE
+  batched periodic write per active id.
+
+  ## Not custody-critical
+
+  `last_seen_at`/`last_used_at` are declared LIVENESS HEURISTICS, never custody
+  or audit signals. No auth/custody gate reads them (see the consumer audit
+  below), so bounded staleness is acceptable. **Do NOT** apply this debounce to
+  any custody/audit write.
+
+  ## Consumer audit (AC-33.4.5)
+
+  Every reader of `last_seen_at`/`last_used_at` in `lib/` tolerates
+  seconds-scale staleness, so debouncing is safe:
+
+    * `Loopctl.Tenants.count_active_agents/0` — `where: last_seen_at > (now -
+      24h)`, a 24h liveness window; seconds of staleness is irrelevant.
+    * API serializers only (`api_key_controller`, `agent_controller`,
+      `api_spec/schemas`) — display fields, never a gate.
+    * The auth/custody path (`verify_api_key/1`, `valid_now?/1`, `RequireAuth`,
+      `CheckCustodyHalt`) gates on `revoked_at`/`expires_at`/`custody_halted_at`
+      — NEVER on `last_used_at`/`last_seen_at`.
+
+  NOT in scope (left synchronous): the WebAuthn authenticator `last_used_at`
+  (`root_authenticator`, `web_authn/reauth`) is a custody-critical assertion
+  alongside `sign_count` and is unrelated to these two liveness columns.
+
+  ## Design (mirrors `Loopctl.Auth.ApiKeyCache`, US-33.3)
+
+  A single `use GenServer` OWNS a `:public`, `:named_table` ETS table. The
+  request path writes the table DIRECTLY (`record_agent/2` / `record_api_key/2`
+  are `:ets.insert` from the request process) — the GenServer is NEVER on the
+  hot path and can't bottleneck throughput. It exists only to be the stable
+  owner of the table (so it survives the transient request/Task/Oban process
+  that populated it) and to run the periodic flush timer.
+
+  Each request records `{:agent, agent_id} => now` / `{:api_key, api_key_id} =>
+  now` in ETS. A later request for the same id always carries a `>=` timestamp,
+  so an unconditional `:ets.insert` keeps (approximately) the max in the buffer;
+  any sub-interval out-of-order write is irrelevant for a liveness heuristic, and
+  the flush's monotonic `GREATEST` guard (below) prevents regression versus the
+  DB across flushes.
+
+  ## Flush — batched, monotonic, tenant-safe
+
+  On each interval (and on graceful shutdown) the buffer is DRAINED atomically
+  (`:ets.take` per key) and grouped by target table. Each target issues ONE
+  `UPDATE ... FROM (VALUES ...)` statement over ALL its drained ids — so a flush
+  is O(1) statements per table (O(scopes), NOT O(ids)):
+
+      UPDATE agents AS t
+      SET last_seen_at = GREATEST(t.last_seen_at, v.ts)
+      FROM (VALUES ($1::uuid, $2::timestamp), ...) AS v(id, ts)
+      WHERE t.id = v.id
+
+    * **Monotonic** — `GREATEST(col, v.ts)` (Postgres `GREATEST` ignores NULLs,
+      so it also seeds a previously-NULL column) means a delayed flush can only
+      advance a timestamp FORWARD, never regress it below what is already in the
+      DB.
+    * **Tenant-safe** — ids are globally-unique UUIDs, so `WHERE t.id = v.id`
+      is self-scoping: a cross-tenant write is impossible and no `tenant_id`
+      predicate is needed. Writes go through `AdminRepo` (BYPASSRLS) exactly as
+      the previous synchronous touch writers did.
+
+  ## Bounded staleness (config, default a few seconds)
+
+  The flush interval is config-driven (`config :loopctl, Loopctl.TouchBuffer,
+  flush_interval_ms: ...`). `last_seen_at`/`last_used_at` are therefore at most
+  one interval stale — documented and acceptable for a liveness heuristic. On
+  graceful shutdown `terminate/2` flushes the buffer; on a crash at most one
+  interval of buffered touches is lost (best-effort).
+
+  ## Sandbox / testing
+
+  Unlike `ApiKeyCache`, the flush DOES hit the DB. To keep it Ecto-Sandbox-safe,
+  the flush core runs in the CALLING process — the periodic timer calls it inside
+  the GenServer (real pool in prod), but `flush/1` can be invoked directly from a
+  test process (which owns the sandbox connection) against a per-test table, so
+  no cross-process sandbox ownership is required. `record/3`, `peek/2` and
+  `flush/1` all take an explicit table so a test can drive an isolated instance.
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias Loopctl.AdminRepo
+
+  @table :loopctl_touch_buffer
+
+  # Config-driven flush interval (a few seconds default). Bounded staleness of
+  # last_seen_at/last_used_at is at most this long (AC-33.4.4). Overridable per
+  # env in config; test env sets it high so the app-tree singleton never
+  # auto-flushes and interferes with the sandbox (tests flush explicitly).
+  @default_flush_interval_ms Application.compile_env(
+                               :loopctl,
+                               [__MODULE__, :flush_interval_ms],
+                               :timer.seconds(5)
+                             )
+
+  # ETS key tag => {sql_table, timestamp_column}. Drives the batched flush; the
+  # table/column names are compile-time constants owned here (never user input),
+  # so interpolating them into the UPDATE is safe — only the ids/timestamps are
+  # parameterized.
+  @targets [agent: {"agents", "last_seen_at"}, api_key: {"api_keys", "last_used_at"}]
+
+  # --- Client API ---
+
+  @doc false
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc """
+  Records the latest `last_seen_at` for `agent_id` in the buffer (no DB write on
+  the request path). Best-effort — never raises, never blocks the request.
+  """
+  @spec record_agent(binary(), DateTime.t()) :: :ok
+  def record_agent(agent_id, %DateTime{} = ts) when is_binary(agent_id),
+    do: record(@table, {:agent, agent_id}, ts)
+
+  @doc """
+  Records the latest `last_used_at` for `api_key_id` in the buffer (no DB write
+  on the request path). Best-effort — never raises, never blocks the request.
+  """
+  @spec record_api_key(binary(), DateTime.t()) :: :ok
+  def record_api_key(api_key_id, %DateTime{} = ts) when is_binary(api_key_id),
+    do: record(@table, {:api_key, api_key_id}, ts)
+
+  @doc """
+  Core buffer write into `table`. Unconditional insert keeps the latest
+  timestamp per key (a later request always carries a `>=` timestamp). Wrapped
+  so a vanished table (mid-restart) never crashes the request.
+  """
+  @spec record(atom(), {:agent | :api_key, binary()}, DateTime.t()) :: :ok
+  def record(table, {tag, id} = key, %DateTime{} = ts)
+      when tag in [:agent, :api_key] and is_binary(id) do
+    :ets.insert(table, {key, ts})
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
+  @doc """
+  Reads the buffered (pending, un-flushed) timestamp for `key` from `table`.
+  Returns `{:ok, ts}` or `:miss`. Used by tests to assert a request recorded
+  into the buffer without a synchronous DB write.
+  """
+  @spec peek(atom(), {:agent | :api_key, binary()}) :: {:ok, DateTime.t()} | :miss
+  def peek(table \\ @table, key) do
+    case :ets.lookup(table, key) do
+      [{^key, ts}] -> {:ok, ts}
+      [] -> :miss
+    end
+  rescue
+    ArgumentError -> :miss
+  end
+
+  @doc """
+  Flushes the singleton buffer NOW (drains it and writes the batched maxima).
+  Runs in the CALLING process so it uses that process's DB connection.
+  """
+  @spec flush() :: :ok
+  def flush, do: do_flush(@table)
+
+  @doc """
+  Flushes an explicit `table` NOW — for a per-test isolated instance.
+  """
+  @spec flush(atom()) :: :ok
+  def flush(table) when is_atom(table), do: do_flush(table)
+
+  @doc false
+  def table_name, do: @table
+
+  # --- Server callbacks ---
+
+  @impl true
+  def init(opts) do
+    # Trap exits so terminate/2 fires on supervisor-initiated shutdown and can do
+    # the final flush (AC-33.4.4). Without this a shutdown signal would kill the
+    # process without running terminate/2.
+    Process.flag(:trap_exit, true)
+
+    table = Keyword.get(opts, :table, @table)
+    ensure_table(table)
+
+    interval = Keyword.get(opts, :flush_interval_ms, @default_flush_interval_ms)
+    schedule_flush(interval)
+
+    {:ok, %{table: table, interval: interval}}
+  end
+
+  @impl true
+  def handle_info(:flush, state) do
+    do_flush(state.table)
+    schedule_flush(state.interval)
+    {:noreply, state}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  @impl true
+  def terminate(_reason, state) do
+    # Best-effort final flush so buffered touches survive graceful shutdown.
+    do_flush(state.table)
+    :ok
+  end
+
+  # --- Private ---
+
+  defp ensure_table(table) do
+    case :ets.whereis(table) do
+      :undefined ->
+        :ets.new(table, [
+          :set,
+          :public,
+          :named_table,
+          read_concurrency: true,
+          write_concurrency: true
+        ])
+
+      existing ->
+        existing
+    end
+  end
+
+  # A non-integer interval (e.g. a test that never wants an auto-flush) disables
+  # the timer; the buffer is then flushed only explicitly via flush/1.
+  defp schedule_flush(interval) when is_integer(interval),
+    do: Process.send_after(self(), :flush, interval)
+
+  defp schedule_flush(_), do: nil
+
+  # Flush core — atomically drain the buffer, group by target table, and issue
+  # ONE batched monotonic UPDATE per non-empty target. Runs in the caller so the
+  # DB write uses the caller's connection (prod: the GenServer; tests: the test
+  # process that owns the sandbox connection).
+  defp do_flush(table) do
+    drained = drain(table)
+    grouped = Enum.group_by(drained, fn {{tag, _id}, _ts} -> tag end)
+
+    Enum.each(@targets, fn {tag, {sql_table, column}} ->
+      flush_target(sql_table, column, Map.get(grouped, tag, []))
+    end)
+
+    :ok
+  rescue
+    # A flush must never crash the owner (or a caller). The drained ids for a
+    # failed flush are lost (best-effort, <= one interval — AC-33.4.4).
+    e ->
+      Logger.warning("TouchBuffer flush failed: #{inspect(e)}")
+      :ok
+  end
+
+  # Atomically remove and return every buffered entry. `:ets.take/2` deletes the
+  # key and returns its object in one operation, so a concurrent newer write for
+  # a key already drained lands in the NEXT window (never silently dropped).
+  defp drain(table) do
+    keys = :ets.select(table, [{{:"$1", :_}, [], [:"$1"]}])
+    Enum.flat_map(keys, fn key -> :ets.take(table, key) end)
+  rescue
+    ArgumentError -> []
+  end
+
+  defp flush_target(_sql_table, _column, []), do: :ok
+
+  defp flush_target(sql_table, column, entries) do
+    {values_sql, params} = build_values(entries)
+
+    sql =
+      "UPDATE #{sql_table} AS t SET #{column} = GREATEST(t.#{column}, v.ts) " <>
+        "FROM (VALUES #{values_sql}) AS v(id, ts) WHERE t.id = v.id"
+
+    AdminRepo.query!(sql, params)
+    :ok
+  end
+
+  # Builds the `(VALUES ...)` list and the flat parameter list. Ids are dumped to
+  # 16-byte binaries (the `::uuid` param type) and timestamps to NaiveDateTime
+  # (the `::timestamp` column type, matching the utc_datetime_usec storage). Only
+  # the first row carries the type casts; the rest are inferred from it.
+  defp build_values(entries) do
+    params =
+      Enum.flat_map(entries, fn {{_tag, id}, ts} ->
+        [Ecto.UUID.dump!(id), DateTime.to_naive(DateTime.truncate(ts, :microsecond))]
+      end)
+
+    rows =
+      entries
+      |> Enum.with_index(1)
+      |> Enum.map_join(", ", fn {_entry, idx} ->
+        id_pos = idx * 2 - 1
+        ts_pos = idx * 2
+
+        if idx == 1,
+          do: "($#{id_pos}::uuid, $#{ts_pos}::timestamp)",
+          else: "($#{id_pos}, $#{ts_pos})"
+      end)
+
+    {rows, params}
+  end
+end

--- a/lib/loopctl_web/plugs/update_last_seen.ex
+++ b/lib/loopctl_web/plugs/update_last_seen.ex
@@ -1,12 +1,15 @@
 defmodule LoopctlWeb.Plugs.UpdateLastSeen do
   @moduledoc """
-  Updates the `last_seen_at` timestamp for authenticated agents.
+  Records the `last_seen_at` timestamp for authenticated agents.
 
   On every authenticated API call where the API key has an `agent_id`,
-  this plug updates the corresponding agent's `last_seen_at` field.
+  this plug records the corresponding agent's `last_seen_at` touch into the
+  debounced `Loopctl.TouchBuffer` (US-33.4). It performs NO synchronous DB write
+  on the request path — a supervised periodic flusher persists the buffered
+  maxima in a single batched UPDATE. Uses the DI clock for testability.
 
-  The update is best-effort -- failures are logged but do not block
-  the request pipeline. Uses the DI clock for testability.
+  The touch is best-effort -- recording never raises and never blocks the
+  request pipeline.
 
   ## Placement
 
@@ -15,8 +18,6 @@ defmodule LoopctlWeb.Plugs.UpdateLastSeen do
   """
 
   @behaviour Plug
-
-  require Logger
 
   alias Loopctl.Agents
 
@@ -30,15 +31,7 @@ defmodule LoopctlWeb.Plugs.UpdateLastSeen do
       )
       when is_binary(agent_id) and is_binary(tenant_id) do
     now = clock().utc_now()
-
-    case Agents.touch_last_seen(tenant_id, agent_id, now) do
-      {:ok, _agent} ->
-        :ok
-
-      {:error, reason} ->
-        Logger.warning("Failed to update last_seen_at for agent #{agent_id}: #{inspect(reason)}")
-    end
-
+    :ok = Agents.touch_last_seen(tenant_id, agent_id, now)
     conn
   end
 

--- a/test/loopctl/agents/agents_test.exs
+++ b/test/loopctl/agents/agents_test.exs
@@ -166,18 +166,24 @@ defmodule Loopctl.AgentsTest do
   end
 
   describe "touch_last_seen/3" do
-    test "updates last_seen_at timestamp" do
+    test "records the touch into the debounced buffer (no synchronous DB write, US-33.4)" do
       tenant = fixture(:tenant)
       agent = fixture(:agent, %{tenant_id: tenant.id})
+      initial = agent.last_seen_at
       now = DateTime.utc_now()
 
-      assert {:ok, updated} = Agents.touch_last_seen(tenant.id, agent.id, now)
-      assert updated.last_seen_at != nil
-    end
+      # Records into the buffer and returns :ok (no AdminRepo SELECT/UPDATE).
+      assert :ok = Agents.touch_last_seen(tenant.id, agent.id, now)
 
-    test "returns not_found for nonexistent agent" do
-      tenant = fixture(:tenant)
-      assert {:error, :not_found} = Agents.touch_last_seen(tenant.id, uuid(), DateTime.utc_now())
+      # The buffer holds the pending timestamp...
+      assert {:ok, %DateTime{} = pending} =
+               Loopctl.TouchBuffer.peek(Loopctl.TouchBuffer.table_name(), {:agent, agent.id})
+
+      assert DateTime.compare(pending, now) == :eq
+
+      # ...and the DB row is unchanged until a flush (bounded-staleness heuristic).
+      {:ok, unchanged} = Agents.get_agent(tenant.id, agent.id)
+      assert DateTime.compare(unchanged.last_seen_at, initial) == :eq
     end
   end
 

--- a/test/loopctl/agents/agents_test.exs
+++ b/test/loopctl/agents/agents_test.exs
@@ -172,6 +172,13 @@ defmodule Loopctl.AgentsTest do
       initial = agent.last_seen_at
       now = DateTime.utc_now()
 
+      # touch_last_seen records into the process-wide singleton buffer; drop this
+      # agent's entry on exit so the shared singleton does not accumulate stale
+      # keys across the async suite.
+      on_exit(fn ->
+        :ets.delete(Loopctl.TouchBuffer.table_name(), {:agent, agent.id})
+      end)
+
       # Records into the buffer and returns :ok (no AdminRepo SELECT/UPDATE).
       assert :ok = Agents.touch_last_seen(tenant.id, agent.id, now)
 

--- a/test/loopctl/auth/auth_test.exs
+++ b/test/loopctl/auth/auth_test.exs
@@ -5,6 +5,7 @@ defmodule Loopctl.AuthTest do
 
   alias Loopctl.Auth
   alias Loopctl.Auth.ApiKey
+  alias Loopctl.TouchBuffer
 
   describe "generate_api_key/1" do
     test "generates API key with raw key and persisted record" do
@@ -77,6 +78,43 @@ defmodule Loopctl.AuthTest do
       assert verified.tenant.id == tenant.id
       # last_used_at should be set on verification
       assert %DateTime{} = verified.last_used_at
+    end
+
+    # TC-33.4.1 / AC-33.4.2 for the auth path: verify_api_key debounces the
+    # last_used_at touch — it records into the batched TouchBuffer and performs
+    # NO synchronous UPDATE, so the persisted row is unchanged until a flush.
+    # The in-memory struct still reflects `now` for response fidelity.
+    test "debounces last_used_at: records into buffer, no synchronous DB write (AC-33.4.2)" do
+      tenant = fixture(:tenant)
+
+      {:ok, {raw_key, original}} =
+        Auth.generate_api_key(%{
+          tenant_id: tenant.id,
+          name: "touch-debounce-test",
+          role: :user
+        })
+
+      # Clean the shared app-tree singleton buffer for this key on exit (the real
+      # verify_and_touch write site records into the process-wide singleton).
+      on_exit(fn ->
+        :ets.delete(TouchBuffer.table_name(), {:api_key, original.id})
+      end)
+
+      # Pre-request persisted value (whatever generate_api_key left it as).
+      {:ok, before} = Auth.get_api_key(tenant.id, original.id)
+
+      assert {:ok, %ApiKey{} = verified} = Auth.verify_api_key(raw_key)
+
+      # Response fidelity: the returned struct reflects a fresh last_used_at...
+      assert %DateTime{} = verified.last_used_at
+
+      # AC-33.4.2: ...but the DB row is UNCHANGED — no synchronous UPDATE.
+      {:ok, reloaded} = Auth.get_api_key(tenant.id, original.id)
+      assert reloaded.last_used_at == before.last_used_at
+
+      # AC-33.4.1: the touch was recorded into the batched buffer instead.
+      assert {:ok, %DateTime{}} =
+               TouchBuffer.peek(TouchBuffer.table_name(), {:api_key, original.id})
     end
 
     test "rejects revoked key" do

--- a/test/loopctl/touch_buffer_test.exs
+++ b/test/loopctl/touch_buffer_test.exs
@@ -1,0 +1,177 @@
+defmodule Loopctl.TouchBufferTest do
+  use Loopctl.DataCase, async: true
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Loopctl.Agents
+  alias Loopctl.Auth
+  alias Loopctl.TouchBuffer
+
+  # Each test drives its OWN isolated buffer instance (unique ETS table + name)
+  # so the shared app-tree singleton is never touched and the flush — which DOES
+  # hit the DB — is invoked directly from the test process (which owns the
+  # sandbox connection). The interval is set high so only explicit flushes fire.
+  setup do
+    i = System.unique_integer([:positive])
+    table = :"touch_buffer_test_#{i}"
+    name = :"touch_buffer_test_srv_#{i}"
+
+    server =
+      start_supervised!(
+        Supervisor.child_spec(
+          {TouchBuffer, [name: name, table: table, flush_interval_ms: :timer.hours(1)]},
+          id: name
+        )
+      )
+
+    %{table: table, server: server, name: name}
+  end
+
+  describe "record — request path (no DB write)" do
+    # TC-33.4.1
+    test "records the touch into the buffer with no synchronous DB write", %{table: table} do
+      tenant = fixture(:tenant)
+      agent = fixture(:agent, %{tenant_id: tenant.id})
+      initial = agent.last_seen_at
+      now = DateTime.utc_now()
+
+      assert :ok = TouchBuffer.record(table, {:agent, agent.id}, now)
+
+      # The buffer holds the pending timestamp in memory...
+      assert {:ok, %DateTime{} = pending} = TouchBuffer.peek(table, {:agent, agent.id})
+      assert DateTime.compare(pending, now) == :eq
+
+      # ...and the DB row is UNCHANGED until a flush.
+      {:ok, reloaded} = Agents.get_agent(tenant.id, agent.id)
+      assert DateTime.compare(reloaded.last_seen_at, initial) == :eq
+    end
+  end
+
+  describe "flush — batched, monotonic" do
+    # TC-33.4.2
+    test "flush advances to the newest buffered value and never regresses", %{table: table} do
+      tenant = fixture(:tenant)
+      agent = fixture(:agent, %{tenant_id: tenant.id})
+      {_raw, key} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent, agent_id: agent.id})
+
+      t1 = DateTime.utc_now()
+      t2 = DateTime.add(t1, 5, :second)
+
+      # Several buffered records for the same agent + key; the latest wins.
+      assert :ok = TouchBuffer.record(table, {:agent, agent.id}, t1)
+      assert :ok = TouchBuffer.record(table, {:agent, agent.id}, t2)
+      assert :ok = TouchBuffer.record(table, {:api_key, key.id}, t1)
+      assert :ok = TouchBuffer.record(table, {:api_key, key.id}, t2)
+
+      assert :ok = TouchBuffer.flush(table)
+
+      {:ok, a} = Agents.get_agent(tenant.id, agent.id)
+      assert DateTime.compare(a.last_seen_at, t2) == :eq
+
+      {:ok, k} = Auth.get_api_key(tenant.id, key.id)
+      assert DateTime.compare(k.last_used_at, t2) == :eq
+
+      # The buffer was drained (nothing pending after flush).
+      assert TouchBuffer.peek(table, {:agent, agent.id}) == :miss
+
+      # Monotonic (GREATEST): buffering an OLDER ts after the newer flush must NOT
+      # regress the persisted value.
+      t0 = DateTime.add(t1, -100, :second)
+      assert :ok = TouchBuffer.record(table, {:agent, agent.id}, t0)
+      assert :ok = TouchBuffer.flush(table)
+
+      {:ok, a2} = Agents.get_agent(tenant.id, agent.id)
+      assert DateTime.compare(a2.last_seen_at, t2) == :eq
+    end
+
+    # TC-33.4.3
+    test "flush updates many buffered agents, each to its own newest ts", %{table: table} do
+      tenant = fixture(:tenant)
+
+      pairs =
+        for i <- 1..3 do
+          agent =
+            fixture(:agent, %{
+              tenant_id: tenant.id,
+              name: "a#{i}-#{System.unique_integer([:positive])}"
+            })
+
+          ts = DateTime.add(DateTime.utc_now(), i, :second)
+          assert :ok = TouchBuffer.record(table, {:agent, agent.id}, ts)
+          {agent, ts}
+        end
+
+      # One flush persists all three (a single batched UPDATE over the agents
+      # table — O(scopes), not O(ids)).
+      assert :ok = TouchBuffer.flush(table)
+
+      for {agent, ts} <- pairs do
+        {:ok, reloaded} = Agents.get_agent(tenant.id, agent.id)
+        assert DateTime.compare(reloaded.last_seen_at, ts) == :eq
+      end
+    end
+
+    # TC-33.4.4 — tenant isolation
+    test "flush is tenant-safe: each tenant's own row is updated, no cross-tenant write",
+         %{table: table} do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      agent_a = fixture(:agent, %{tenant_id: tenant_a.id})
+      agent_b = fixture(:agent, %{tenant_id: tenant_b.id})
+
+      ts = DateTime.utc_now()
+      assert :ok = TouchBuffer.record(table, {:agent, agent_a.id}, ts)
+      assert :ok = TouchBuffer.record(table, {:agent, agent_b.id}, ts)
+
+      assert :ok = TouchBuffer.flush(table)
+
+      # Each tenant's own agent row was advanced.
+      {:ok, ra} = Agents.get_agent(tenant_a.id, agent_a.id)
+      {:ok, rb} = Agents.get_agent(tenant_b.id, agent_b.id)
+      assert DateTime.compare(ra.last_seen_at, ts) == :eq
+      assert DateTime.compare(rb.last_seen_at, ts) == :eq
+
+      # And no cross-tenant write occurred: tenant A's id is not tenant B's agent
+      # (globally-unique id ⇒ WHERE id = ... is self-scoping).
+      assert {:error, :not_found} = Agents.get_agent(tenant_b.id, agent_a.id)
+      assert {:error, :not_found} = Agents.get_agent(tenant_a.id, agent_b.id)
+    end
+
+    test "flush over an empty buffer is a no-op", %{table: table} do
+      assert :ok = TouchBuffer.flush(table)
+    end
+  end
+
+  describe "graceful shutdown" do
+    test "flushes buffered touches on terminate/2" do
+      i = System.unique_integer([:positive])
+      table = :"touch_buffer_shutdown_#{i}"
+      name = :"touch_buffer_shutdown_srv_#{i}"
+
+      server =
+        start_supervised!(
+          Supervisor.child_spec(
+            {TouchBuffer, [name: name, table: table, flush_interval_ms: :timer.hours(1)]},
+            id: name
+          )
+        )
+
+      tenant = fixture(:tenant)
+      agent = fixture(:agent, %{tenant_id: tenant.id})
+      initial = agent.last_seen_at
+      ts = DateTime.add(DateTime.utc_now(), 10, :second)
+
+      assert :ok = TouchBuffer.record(table, {:agent, agent.id}, ts)
+
+      # Let the GenServer use this test's sandbox connection so its terminate/2
+      # flush can write during the (in-process) shutdown.
+      Sandbox.allow(Loopctl.AdminRepo, self(), server)
+
+      # Graceful shutdown → trap_exit → terminate/2 → final flush.
+      assert :ok = stop_supervised!(name)
+
+      {:ok, reloaded} = Agents.get_agent(tenant.id, agent.id)
+      assert DateTime.compare(reloaded.last_seen_at, ts) == :eq
+      refute DateTime.compare(reloaded.last_seen_at, initial) == :eq
+    end
+  end
+end

--- a/test/loopctl/touch_buffer_test.exs
+++ b/test/loopctl/touch_buffer_test.exs
@@ -139,6 +139,65 @@ defmodule Loopctl.TouchBufferTest do
     test "flush over an empty buffer is a no-op", %{table: table} do
       assert :ok = TouchBuffer.flush(table)
     end
+
+    # Guards the batched flush against Postgres' 65,535 bound-param cap. At
+    # epic_33 scale a single flush interval can accumulate tens of thousands of
+    # active ids; each entry emits 2 bound params, so an UNCHUNKED UPDATE over
+    # ~40k entries (~80k params) is rejected by AdminRepo.query!. Because
+    # drain/1 has already :ets.take'd the window and do_flush swallows the
+    # raise, an over-limit statement would SILENTLY lose the whole window —
+    # including the real agent's touch. Chunking keeps every statement bounded,
+    # so the real row still advances.
+    test "flush handles a batch far larger than the bind-param cap without losing touches",
+         %{table: table} do
+      tenant = fixture(:tenant)
+      agent = fixture(:agent, %{tenant_id: tenant.id})
+      ts = DateTime.add(DateTime.utc_now(), 30, :second)
+
+      # One real agent whose row MUST actually advance...
+      assert :ok = TouchBuffer.record(table, {:agent, agent.id}, ts)
+
+      # ...buried among 40_000 buffered ids (80_000 bound params) — well past
+      # the 65_535 cap, so a single unbounded UPDATE would raise. Non-existent
+      # UUIDs match no row (harmless); they only inflate the param count.
+      for _ <- 1..40_000 do
+        :ok = TouchBuffer.record(table, {:agent, Ecto.UUID.generate()}, ts)
+      end
+
+      assert :ok = TouchBuffer.flush(table)
+
+      {:ok, reloaded} = Agents.get_agent(tenant.id, agent.id)
+      assert DateTime.compare(reloaded.last_seen_at, ts) == :eq
+    end
+
+    # Cross-target isolation: drain/1 :ets.take's BOTH targets up front, so a
+    # raise while flushing the FIRST target (agents, ordered before api_keys in
+    # @targets) must NOT swallow the second target's already-drained window. A
+    # malformed agent id forces build_values -> Ecto.UUID.dump! to raise for the
+    # agents UPDATE; the api_key row must still advance. Without per-target
+    # isolation a deterministic agents failure would starve last_used_at every
+    # interval.
+    test "one target's flush failure does not swallow the sibling target's window",
+         %{table: table} do
+      tenant = fixture(:tenant)
+      agent = fixture(:agent, %{tenant_id: tenant.id})
+      {_raw, key} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent, agent_id: agent.id})
+      ts = DateTime.add(DateTime.utc_now(), 30, :second)
+
+      # A valid api_key touch (the sibling that MUST still flush)...
+      assert :ok = TouchBuffer.record(table, {:api_key, key.id}, ts)
+
+      # ...and a MALFORMED agent entry inserted directly into ETS (bypassing
+      # record/3's is_binary UUID guard) so the agents UPDATE raises in
+      # build_values. The agents target fails; the api_keys target must survive.
+      :ets.insert(table, {{:agent, "not-a-valid-uuid"}, ts})
+
+      assert :ok = TouchBuffer.flush(table)
+
+      # Sibling target advanced despite the agents-target raise.
+      {:ok, k} = Auth.get_api_key(tenant.id, key.id)
+      assert DateTime.compare(k.last_used_at, ts) == :eq
+    end
   end
 
   describe "graceful shutdown" do

--- a/test/loopctl_web/plugs/update_last_seen_test.exs
+++ b/test/loopctl_web/plugs/update_last_seen_test.exs
@@ -4,13 +4,15 @@ defmodule LoopctlWeb.Plugs.UpdateLastSeenTest do
   setup :verify_on_exit!
 
   alias Loopctl.Agents
+  alias Loopctl.TouchBuffer
 
   defp auth_conn(conn, raw_key) do
     put_req_header(conn, "authorization", "Bearer #{raw_key}")
   end
 
   describe "UpdateLastSeen plug" do
-    test "updates last_seen_at for agent-role API key with agent_id", %{conn: conn} do
+    test "records last_seen_at into the buffer with no synchronous DB write (US-33.4)",
+         %{conn: conn} do
       tenant = fixture(:tenant)
       agent = fixture(:agent, %{tenant_id: tenant.id, name: "seen-agent"})
       initial_last_seen = agent.last_seen_at
@@ -31,9 +33,17 @@ defmodule LoopctlWeb.Plugs.UpdateLastSeenTest do
 
       assert json_response(conn, 200)
 
-      # Verify last_seen_at was updated to a newer timestamp
-      {:ok, updated} = Agents.get_agent(tenant.id, agent.id)
-      assert DateTime.compare(updated.last_seen_at, initial_last_seen) in [:gt, :eq]
+      # AC-33.4.2: the request path performs NO synchronous last_seen_at UPDATE —
+      # the DB row is unchanged from registration until a flush.
+      {:ok, unchanged} = Agents.get_agent(tenant.id, agent.id)
+      assert DateTime.compare(unchanged.last_seen_at, initial_last_seen) == :eq
+
+      # AC-33.4.1: the touch was recorded into the in-memory buffer (a pending ts
+      # >= registration time) instead.
+      assert {:ok, %DateTime{} = pending} =
+               TouchBuffer.peek(TouchBuffer.table_name(), {:agent, agent.id})
+
+      assert DateTime.compare(pending, initial_last_seen) in [:gt, :eq]
     end
 
     test "does not update for API key without agent_id", %{conn: conn} do

--- a/test/loopctl_web/plugs/update_last_seen_test.exs
+++ b/test/loopctl_web/plugs/update_last_seen_test.exs
@@ -17,6 +17,11 @@ defmodule LoopctlWeb.Plugs.UpdateLastSeenTest do
       agent = fixture(:agent, %{tenant_id: tenant.id, name: "seen-agent"})
       initial_last_seen = agent.last_seen_at
 
+      # The real request path (record_agent) writes the process-wide singleton
+      # buffer; drop this agent's entry on exit so the shared singleton does not
+      # accumulate stale keys across the async suite.
+      on_exit(fn -> :ets.delete(TouchBuffer.table_name(), {:agent, agent.id}) end)
+
       {raw_key, _api_key} =
         fixture(:api_key, %{tenant_id: tenant.id, role: :agent, agent_id: agent.id})
 


### PR DESCRIPTION
## US-33.4 — Debounce liveness touch-writes off the auth hot path

Closes #348 (Epic 33 item).

### Problem
Every authenticated request issued **two synchronous UPDATEs** on the small (3-connection) BYPASSRLS `AdminRepo` pool:
- `api_keys.last_used_at` via `Auth.verify_and_touch/2`
- `agents.last_seen_at` via the `UpdateLastSeen` plug

A fast-looping agent hammers the same two rows on every request → row-lock contention + dead-tuple bloat, for a value nobody reads with per-request precision.

### Solution — `Loopctl.TouchBuffer`
A supervised GenServer that owns a `:public` ETS buffer (mirrors the `ApiKeyCache` US-33.3 template):
- The **request path** records `{:agent, id}` / `{:api_key, id} => now` directly into ETS — **no DB write** on the hot path.
- A **periodic flusher** (config `flush_interval_ms`, default 5s) drains the buffer and issues **ONE batched** `UPDATE ... FROM (VALUES ...)` per table with `GREATEST(col, ts)`:
  - **Monotonic** — a delayed flush only advances a timestamp forward, never regresses it (also seeds a previously-NULL column, since `GREATEST` ignores NULL).
  - **Batched** — O(1) statements per table (O(scopes)), not O(ids).
  - **Tenant-safe** — globally-unique UUID ids make `WHERE id = ...` self-scoping; no cross-tenant write possible. Writes stay on `AdminRepo` (BYPASSRLS) as before.
- `terminate/2` flushes on graceful shutdown (`trap_exit`); a crash loses at most one interval (best-effort — these are liveness heuristics).

Combined with the US-33.3 read-through cache, the auth touch path is now **net zero AdminRepo statements per request**.

### Consumer audit (AC-33.4.5)
No auth/custody gate reads these columns — only `Tenants.count_active_agents/0` (a 24h liveness window) and display serializers do, both of which tolerate seconds-scale staleness. Documented in the `TouchBuffer` moduledoc. The WebAuthn authenticator `last_used_at` (custody-critical, alongside `sign_count`) is unrelated and left synchronous.

### Changes
- New `Loopctl.TouchBuffer` + supervision-tree child + config (`config.exs` default 5s, `test.exs` disables auto-flush so the singleton never interferes with the sandbox).
- `Auth.verify_and_touch` records into the buffer, returns the in-memory key with `last_used_at` set to `now`; removed `update_last_used/1`.
- `Agents.touch_last_seen` records into the buffer (no `get_by` SELECT, no UPDATE), returns `:ok`; plug records best-effort.
- Removed now-unused `ApiKey.touch_changeset/1` and `Agent.touch_changeset/2`.

### Tests
Isolated per-test buffer instances (own ETS table, in-process flush under the sandbox) cover: record-with-no-sync-write, batched + monotonic flush, multi-id batch, tenant isolation, empty-buffer no-op, and graceful-shutdown flush. Updated the plug + `touch_last_seen` integration tests to assert the buffered (non-synchronous) behavior.

`mix precommit` green: 4292 tests, 0 failures; credo --strict, dialyzer, format all clean.