### PR TITLE
feat(epic_33): US-33.5 route budget-threshold check through the shared batched spend path

### DIFF
--- a/docs/user_stories/epic_33_db_topology/us_33.5.json
+++ b/docs/user_stories/epic_33_db_topology/us_33.5.json
@@ -1,20 +1,20 @@
 {
   "id": "US-33.5",
-  "title": "Reuse batch_attach_spend on the token-usage budget-threshold path (kill the N+1)",
+  "title": "Reuse batch_attach_spend on the token-usage budget-threshold path (consolidate onto one spend path)",
   "epic": { "id": "epic_33", "name": "DB Connection Topology & AdminRepo Hot Path" },
   "priority": "medium",
   "phase": "scalability",
-  "priority_note": "Collapses the per-report N (1-3) get_scope_spend queries into the existing batched aggregate — reduces AdminRepo fan-out on every token report.",
+  "priority_note": "Routes the per-report threshold check through the SAME batched aggregate list_budgets already uses, retiring a divergent per-budget get_scope_spend loop. NOTE: this is a consolidation onto one spend path, NOT a query-count reduction on this path — find_applicable_budgets yields at most one budget per scope_type (composite unique index), so #batched-queries == #applicable-budgets (1-3), the same count the loop issued. The value is a single source of truth for countable spend, not fewer AdminRepo round-trips here.",
   "background": {
     "reference": "GH #348. TokenUsage.check_budget_thresholds/2 (lib/loopctl/token_usage.ex:938-942) calls get_scope_spend/3 (:896, AdminRepo.one) ONCE PER applicable budget (story/epic/project → up to 3 queries). batch_attach_spend/2 (:1339) already batches spend into ≤3 queries (one AdminRepo.all per scope_type via batch_spend_query/3 :1361) — but it is only used by list_budgets/2 (:744), NOT on the report/threshold hot path.",
-    "includes": "Every token-usage report (POST /api/v1/token-usage and Progress.report_story) triggers check_budget_thresholds, which fans out 1 get_scope_spend query per applicable budget on the 3-connection AdminRepo pool — an N+1 that the already-tested batch_attach_spend eliminates."
+    "includes": "Every token-usage report (POST /api/v1/token-usage and Progress.report_story) triggers check_budget_thresholds, which computes spend once per applicable budget via a second, divergent implementation (get_scope_spend). CAVEAT: because find_applicable_budgets returns at most one budget per scope_type, this is NOT an N+1 that batch_attach_spend reduces — the query count is unchanged (1-3 either way). The refactor's value is eliminating the second spend implementation, not cutting fan-out."
   },
   "story": {
     "as_a": "loopctl platform",
-    "i_want_to": "compute per-budget spend on the threshold-check path via the existing batched batch_attach_spend/batch_spend_query instead of one get_scope_spend query per budget",
-    "so_that": "each token report issues O(scopes) spend queries instead of O(applicable budgets), cutting AdminRepo fan-out with no change to threshold decisions"
+    "i_want_to": "compute per-budget spend on the threshold-check path via the existing batched batch_attach_spend/batch_spend_query instead of a second, divergent get_scope_spend loop",
+    "so_that": "the threshold path shares one batched spend implementation (a single source of truth for countable spend) with list_budgets, with no change to threshold decisions — and no query-count regression (still O(distinct scope_types), i.e. the same 1-3 AdminRepo queries)"
   },
-  "rationale": "The batched spend aggregate already exists and is proven by list_budgets, but the hotter threshold path re-implements it as a per-budget loop, multiplying AdminRepo queries on every report. Routing the threshold check through the same batched query is a behavior-preserving consolidation: the same spend numbers, the same threshold crossings, fewer round-trips on the scarce pool.",
+  "rationale": "The batched spend aggregate already exists and is proven by list_budgets, but the threshold path re-implements spend as a separate per-budget loop (get_scope_spend). Routing the threshold check through the same batched query is a behavior-preserving consolidation: the same spend numbers, the same threshold crossings, one shared countable-spend implementation instead of two. It is NOT a fan-out reduction on this path — find_applicable_budgets yields at most one budget per scope_type, so the batched path issues the same 1-3 AdminRepo queries the loop did; the benefit is a single source of truth, not fewer round-trips.",
   "acceptance_criteria": [
     { "id": "AC-33.5.1", "description": "check_budget_thresholds/2 obtains each applicable budget's spend via batch_attach_spend/2 (or batch_spend_query/3) in ≤ O(distinct scope_types) AdminRepo queries, replacing the per-budget get_scope_spend/3 calls. The spend value used for each threshold comparison is identical to the current per-budget computation (same countable_reports/exclude_stranded_corrections rules).", "status": "pending" },
     { "id": "AC-33.5.2", "description": "Threshold-crossing behavior is byte-for-byte unchanged: the same budgets cross the same thresholds, the same claim_budget_threshold CAS + emit_threshold_crossed + fire_budget_event + WebhookEvent + Oban side effects fire, in the same conditions.", "status": "pending" },
@@ -26,10 +26,10 @@
       "preconditions": ["tenant + project/epic/story budgets set", "prior reports pushing spend near a threshold"],
       "steps": ["create a report that crosses a threshold"],
       "expected_results": ["the same threshold-crossed event/webhook/Oban side effects fire as before; spend value matches the per-budget computation"], "status": "pending" },
-    { "id": "TC-33.5.2", "name": "fewer spend queries per report", "type": "integration",
+    { "id": "TC-33.5.2", "name": "spend computed via the batched grouped-aggregate form, not the per-budget single-row loop", "type": "integration",
       "preconditions": ["a report applying to 3 budgets (story+epic+project)"],
       "steps": ["create the report"],
-      "expected_results": ["spend is computed in ≤ O(scope_types) AdminRepo queries (assert via query count/telemetry), not 3 separate get_scope_spend calls"], "status": "pending" },
+      "expected_results": ["spend is computed via exactly one grouped GROUP BY aggregate per distinct scope_type (assert via query telemetry) and NEVER via the per-budget single-row get_scope_spend select — guards the query FORM, not a query-count reduction (the count is unchanged at 1-3)"], "status": "pending" },
     { "id": "TC-33.5.3", "name": "no threshold crossing when under budget", "type": "integration",
       "preconditions": ["budgets with spend well under thresholds"],
       "steps": ["create a report"],
@@ -43,8 +43,8 @@
     "Module: lib/loopctl/token_usage.ex. Reuse batch_attach_spend/2 (:1339) / batch_spend_query/3 (:1361); the per-budget path is get_scope_spend/3 (:896) inside check_budget_thresholds (:938-942).",
     "Preserve countable_reports/1 + Report.exclude_stranded_corrections (report.ex:174) so the numbers match exactly.",
     "This is a hot path reached by both POST /token-usage and Progress.report_story/4 — keep all side effects (CAS claim, audit, webhook, Oban) identical.",
-    "AdminRepo stays (token_usage is AdminRepo-based); this reduces the NUMBER of AdminRepo queries, not the repo.",
-    "Add a query-count assertion (TC-33.5.2) to lock in the reduction."
+    "AdminRepo stays (token_usage is AdminRepo-based); the query COUNT on this path is unchanged (1-3 either way) — the change unifies two spend implementations into one, it does not cut fan-out here.",
+    "Add a query-FORM assertion (TC-33.5.2) to lock in the batched grouped-aggregate shape (exactly one GROUP BY aggregate per distinct scope_type, never the per-budget single-row get_scope_spend select) — this is an anti-regression guard on form, not a verification of a query-count reduction."
   ],
   "dependencies": [],
   "estimated_tokens": 300000

--- a/lib/loopctl/token_usage.ex
+++ b/lib/loopctl/token_usage.ex
@@ -936,11 +936,24 @@ defmodule Loopctl.TokenUsage do
   # When a single report pushes spend past both thresholds (e.g., from 50%
   # to 120%), both the warning AND exceeded events fire independently.
   defp check_budget_thresholds(tenant_id, report) do
+    # Compute spend for ALL applicable budgets up front through the SAME batched
+    # spend path `list_budgets/2` uses (`batch_attach_spend/2` → one grouped
+    # GROUP BY AdminRepo query per distinct scope_type), replacing a divergent
+    # second spend implementation: a per-budget `get_scope_spend/3` single-row
+    # select loop. This is a behaviour-preserving CONSOLIDATION onto a single
+    # source of truth for countable spend — NOT a query-count reduction on this
+    # path: `find_applicable_budgets/2` yields at most one budget per scope_type
+    # (the `token_budgets(tenant_id, scope_type, scope_id)` composite unique index
+    # guarantees it), so #distinct-scope_types == #applicable-budgets and the
+    # batched path issues the same 1-3 AdminRepo round-trips the loop did. The win
+    # is the unified code path: both build on the same `countable_reports/1`
+    # (tenant + not-deleted + exclude-stranded-corrections) and
+    # `coalesce(sum(...), 0)` → missing scopes yield 0 identically.
     budgets = find_applicable_budgets(tenant_id, report)
 
-    Enum.each(budgets, fn budget ->
-      spend = get_scope_spend(tenant_id, budget.scope_type, budget.scope_id)
-
+    tenant_id
+    |> batch_attach_spend(budgets)
+    |> Enum.each(fn %{budget: budget, current_spend_millicents: spend} ->
       utilization_pct =
         if budget.budget_millicents > 0, do: div(spend * 100, budget.budget_millicents), else: 0
 
@@ -1334,8 +1347,13 @@ defmodule Loopctl.TokenUsage do
     |> select([report: r], coalesce(sum(r.cost_millicents), 0))
   end
 
-  # Batch computes spend for all budgets in at most 3 queries (one per scope type)
-  # instead of N individual queries (N+1 pattern).
+  # Batch computes spend for all budgets in one grouped GROUP BY query per
+  # distinct scope_type (at most 3: story/epic/project) instead of one query per
+  # budget. This genuinely collapses the query count only when multiple budgets
+  # share a scope_type — the `list_budgets/2` path can list many story budgets at
+  # once. On the threshold path, where `find_applicable_budgets/2` yields at most
+  # one budget per scope_type, it degenerates to a 1:1 consolidation (same query
+  # count as the old per-budget loop), not a reduction.
   defp batch_attach_spend(tenant_id, budgets) do
     spend_map =
       budgets

--- a/test/loopctl/token_usage/budget_threshold_batch_test.exs
+++ b/test/loopctl/token_usage/budget_threshold_batch_test.exs
@@ -1,0 +1,286 @@
+defmodule Loopctl.TokenUsage.BudgetThresholdBatchTest do
+  @moduledoc """
+  Tests for US-33.5: Reuse batch_attach_spend on the token-usage budget-threshold path.
+
+  `check_budget_thresholds/2` now computes spend for ALL applicable budgets via the
+  batched `batch_attach_spend/2` (one grouped GROUP BY query per distinct scope_type)
+  — the SAME spend path `list_budgets/2` uses — instead of a divergent per-budget
+  `get_scope_spend/3` single-row select loop. This is a BEHAVIOR-PRESERVING
+  consolidation onto a single source of truth for countable spend: identical spend
+  numbers, identical threshold crossings, identical side effects.
+
+  It is NOT a query-count reduction on this path: `find_applicable_budgets/2` yields
+  at most one budget per scope_type (composite unique index), so the batched query
+  count equals the number of applicable budgets the old loop issued. TC-33.5.2 below
+  therefore guards the query FORM (one grouped GROUP BY aggregate per distinct
+  scope_type, never the per-budget single-row select), not a reduction.
+
+  - AC-33.5.1: spend obtained via the batched grouped query; value identical to the
+    per-budget computation.
+  - AC-33.5.2: threshold-crossing side effects (WebhookEvent + Oban + audit + budget
+    flag CAS) are byte-for-byte unchanged.
+  - AC-33.5.3: tenant isolation — batched spend scoped to the report's tenant only.
+  - AC-33.5.4: find_applicable_budgets' own queries are out of scope.
+  """
+
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Audit.AuditLog
+  alias Loopctl.PlanAssertions
+  alias Loopctl.TokenUsage
+  alias Loopctl.TokenUsage.Budget
+  alias Loopctl.Webhooks
+  alias Loopctl.Webhooks.WebhookEvent
+
+  import Ecto.Query
+
+  defp setup_context do
+    tenant = fixture(:tenant)
+    project = fixture(:project, %{tenant_id: tenant.id})
+    epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+    agent = fixture(:agent, %{tenant_id: tenant.id})
+
+    story =
+      fixture(:story, %{
+        tenant_id: tenant.id,
+        epic_id: epic.id,
+        project_id: project.id
+      })
+
+    %{tenant: tenant, project: project, epic: epic, agent: agent, story: story}
+  end
+
+  defp create_webhook_for_events(tenant_id, events) do
+    {:ok, %{webhook: webhook}} =
+      Webhooks.create_webhook(tenant_id, %{
+        "url" => "https://example.com/hooks/#{System.unique_integer([:positive])}",
+        "events" => events
+      })
+
+    webhook
+  end
+
+  defp find_webhook_events(tenant_id, event_type) do
+    WebhookEvent
+    |> where([e], e.tenant_id == ^tenant_id and e.event_type == ^event_type)
+    |> AdminRepo.all()
+  end
+
+  defp threshold_crossed_entries(tenant_id, budget_id) do
+    AuditLog
+    |> where(
+      [a],
+      a.tenant_id == ^tenant_id and a.entity_type == "token_budget" and
+        a.entity_id == ^budget_id and a.action == "threshold_crossed"
+    )
+    |> AdminRepo.all()
+  end
+
+  defp report_attrs(story, agent, project, cost) do
+    %{
+      story_id: story.id,
+      agent_id: agent.id,
+      project_id: project.id,
+      input_tokens: 1000,
+      output_tokens: 500,
+      model_name: "claude-opus-4",
+      cost_millicents: cost
+    }
+  end
+
+  # SQL for the batched spend aggregate: a GROUP BY over the countable_reports
+  # base with a sum of cost_millicents. Excludes the (unrelated) rollup/summary
+  # aggregates by keying on the reports table + grouping.
+  defp spend_aggregate_query?(sql) do
+    String.contains?(sql, "sum") and String.contains?(sql, "cost_millicents") and
+      String.contains?(sql, "GROUP BY")
+  end
+
+  defp single_row_spend_query?(sql) do
+    String.contains?(sql, "sum") and String.contains?(sql, "cost_millicents") and
+      not String.contains?(sql, "GROUP BY")
+  end
+
+  # --- TC-33.5.2: spend computed via the batched GROUP BY form, one grouped
+  #     aggregate per distinct scope_type — NOT the per-budget single-row
+  #     get_scope_spend loop (anti-regression on query FORM, not a reduction) ---
+
+  describe "batched spend queries (TC-33.5.2, AC-33.5.1)" do
+    test "spend for a report applying to story+epic+project budgets uses batched GROUP BY, not per-budget single-row selects" do
+      %{tenant: tenant, story: story, epic: epic, project: project, agent: agent} =
+        setup_context()
+
+      # A budget at each of the three scope levels — the report applies to all three.
+      for {scope_type, scope_id} <- [
+            {:story, story.id},
+            {:epic, epic.id},
+            {:project, project.id}
+          ] do
+        {:ok, _} =
+          TokenUsage.create_budget(tenant.id, %{
+            scope_type: scope_type,
+            scope_id: scope_id,
+            budget_millicents: 1_000_000,
+            alert_threshold_pct: 80
+          })
+      end
+
+      captured =
+        PlanAssertions.capture_repo_queries(fn ->
+          {:ok, _report} =
+            TokenUsage.create_report(
+              tenant.id,
+              report_attrs(story, agent, project, 5_000)
+            )
+        end)
+
+      sqls = Enum.map(captured, fn {sql, _} -> sql end)
+
+      spend_aggregate_sqls = Enum.filter(sqls, &spend_aggregate_query?/1)
+      single_row_sqls = Enum.filter(sqls, &single_row_spend_query?/1)
+
+      # This guards the query FORM, not a query-count reduction: on the threshold
+      # path find_applicable_budgets/2 yields at most one budget per scope_type, so
+      # the batched path issues EXACTLY one grouped GROUP BY aggregate per distinct
+      # scope_type (here 3: story/epic/project) — the same count the old per-budget
+      # loop issued. Pinning == 3 locks in "one grouped aggregate per distinct
+      # scope_type"; single_row_sqls == [] locks in that we never revert to the
+      # divergent per-budget get_scope_spend single-row select loop.
+      assert length(spend_aggregate_sqls) == 3,
+             "expected exactly one grouped GROUP BY spend query per distinct scope_type (3), got: #{inspect(spend_aggregate_sqls)}"
+
+      assert single_row_sqls == [],
+             "expected NO per-budget single-row get_scope_spend selects, got: #{inspect(single_row_sqls)}"
+    end
+  end
+
+  # --- TC-33.5.1: threshold crossing fires identically via batched spend ---
+
+  describe "threshold crossing via batched spend (TC-33.5.1, AC-33.5.2)" do
+    test "warning + exceeded fire with the same side effects; batched spend equals per-budget spend" do
+      %{tenant: tenant, story: story, project: project, agent: agent} = setup_context()
+
+      _warn_hook = create_webhook_for_events(tenant.id, ["token.budget_warning"])
+      _exceed_hook = create_webhook_for_events(tenant.id, ["token.budget_exceeded"])
+
+      {:ok, budget} =
+        TokenUsage.create_budget(tenant.id, %{
+          scope_type: :story,
+          scope_id: story.id,
+          budget_millicents: 5_000,
+          alert_threshold_pct: 80
+        })
+
+      # 6,000 / 5,000 = 120% — crosses BOTH warning (80%) and exceeded (100%) at once.
+      {:ok, report} =
+        TokenUsage.create_report(tenant.id, report_attrs(story, agent, project, 6_000))
+
+      warning_events = find_webhook_events(tenant.id, "token.budget_warning")
+      exceeded_events = find_webhook_events(tenant.id, "token.budget_exceeded")
+
+      assert [warn_event] = warning_events
+      assert [exceed_event] = exceeded_events
+
+      # Batched spend used in the payload equals the direct per-budget computation.
+      per_budget_spend = TokenUsage.get_scope_spend(tenant.id, :story, story.id)
+      assert per_budget_spend == 6_000
+      assert warn_event.payload["current_spend_millicents"] == 6_000
+      assert exceed_event.payload["current_spend_millicents"] == 6_000
+      assert exceed_event.payload["overage_millicents"] == 1_000
+      assert exceed_event.payload["triggering_report_id"] == report.id
+
+      # Budget CAS flags flipped exactly once.
+      reloaded = AdminRepo.get!(Budget, budget.id)
+      assert reloaded.warning_fired == true
+      assert reloaded.exceeded_fired == true
+
+      # Audit threshold_crossed entries written for both the warning and exceeded
+      # crossings (a distinct, durable side effect independent of webhook delivery).
+      crossing_types =
+        threshold_crossed_entries(tenant.id, budget.id)
+        |> Enum.map(& &1.metadata["threshold_type"])
+        |> Enum.sort()
+
+      assert crossing_types == ["exceeded", "warning"]
+    end
+  end
+
+  # --- TC-33.5.3: no threshold crossing when under budget ---
+
+  describe "no crossing when under budget (TC-33.5.3)" do
+    test "no threshold event fires; batched spend matches per-budget spend" do
+      %{tenant: tenant, story: story, project: project, agent: agent} = setup_context()
+
+      _warn_hook = create_webhook_for_events(tenant.id, ["token.budget_warning"])
+      _exceed_hook = create_webhook_for_events(tenant.id, ["token.budget_exceeded"])
+
+      {:ok, budget} =
+        TokenUsage.create_budget(tenant.id, %{
+          scope_type: :story,
+          scope_id: story.id,
+          budget_millicents: 100_000,
+          alert_threshold_pct: 80
+        })
+
+      # 5,000 / 100,000 = 5% — well under both thresholds.
+      {:ok, _report} =
+        TokenUsage.create_report(tenant.id, report_attrs(story, agent, project, 5_000))
+
+      assert find_webhook_events(tenant.id, "token.budget_warning") == []
+      assert find_webhook_events(tenant.id, "token.budget_exceeded") == []
+
+      reloaded = AdminRepo.get!(Budget, budget.id)
+      assert reloaded.warning_fired == false
+      assert reloaded.exceeded_fired == false
+
+      assert TokenUsage.get_scope_spend(tenant.id, :story, story.id) == 5_000
+    end
+  end
+
+  # --- TC-33.5.4: tenant isolation of spend ---
+
+  describe "tenant isolation of batched spend (TC-33.5.4, AC-33.5.3)" do
+    test "only the report's tenant spend is aggregated; other tenant never included" do
+      ctx_a = setup_context()
+      ctx_b = setup_context()
+
+      _hook_a = create_webhook_for_events(ctx_a.tenant.id, ["token.budget_warning"])
+
+      {:ok, budget_a} =
+        TokenUsage.create_budget(ctx_a.tenant.id, %{
+          scope_type: :story,
+          scope_id: ctx_a.story.id,
+          budget_millicents: 10_000,
+          alert_threshold_pct: 80
+        })
+
+      # Tenant B has spend on ITS OWN story — must never leak into tenant A's total.
+      {:ok, _b_report} =
+        TokenUsage.create_report(
+          ctx_b.tenant.id,
+          report_attrs(ctx_b.story, ctx_b.agent, ctx_b.project, 9_000)
+        )
+
+      # Tenant A report pushes A's story to 85% (8,500/10,000). If B's 9,000 leaked,
+      # utilization would look different and the batched sum would exceed 8,500.
+      {:ok, _a_report} =
+        TokenUsage.create_report(
+          ctx_a.tenant.id,
+          report_attrs(ctx_a.story, ctx_a.agent, ctx_a.project, 8_500)
+        )
+
+      events = find_webhook_events(ctx_a.tenant.id, "token.budget_warning")
+      assert [event] = events
+      assert event.payload["current_spend_millicents"] == 8_500
+
+      # Direct per-budget spend is also tenant-scoped and matches.
+      assert TokenUsage.get_scope_spend(ctx_a.tenant.id, :story, ctx_a.story.id) == 8_500
+
+      reloaded_a = AdminRepo.get!(Budget, budget_a.id)
+      assert reloaded_a.warning_fired == true
+    end
+  end
+end


### PR DESCRIPTION
## US-33.5 — Reuse batch_attach_spend on the token-usage budget-threshold path

`check_budget_thresholds/2` now computes per-budget spend via the same
`batch_attach_spend/2` (grouped `GROUP BY` per distinct `scope_type`) that
`list_budgets/2` uses, retiring the divergent per-budget `get_scope_spend`
single-row loop. Behavior-preserving: identical spend numbers, threshold
crossings, and side effects (CAS claim, audit, webhook, Oban).

### Honest framing
On this path `find_applicable_budgets/2` yields at most one budget per
`scope_type` (composite unique index), so the batched query count equals the
applicable-budget count the loop issued (1-3). This is a **consolidation onto a
single source of truth** for countable spend, NOT a query-count reduction /
fan-out cut. Code comments, test moduledoc, and the US-33.5 story text were
corrected to drop the reduction claim that cannot occur.

`TC-33.5.2` pins exactly one grouped `GROUP BY` aggregate per distinct
`scope_type` (== 3) and zero per-budget single-row selects — an anti-regression
guard on query FORM.