### PR TITLE
Flag-guarded RLS-Repo reroute pilot for one audited tenant-scoped read path

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -417,6 +417,18 @@ config :loopctl, :context_retriever_retrieve_rate_limit, 120
 # residual. Enable ONLY inside an egress-restricted, ephemeral sandbox.
 config :loopctl, :enable_local_test_runner, false
 
+# US-33.7 — Flag-guarded RLS-Repo reroute pilot (Epic 33, DB Connection Topology).
+# DEFAULT OFF. When true, `Loopctl.WorkBreakdown.Stories.list_stories_by_project/3`
+# reads through the RLS `Loopctl.Repo` (via `Repo.with_tenant/2`) instead of the
+# BYPASSRLS `Loopctl.AdminRepo`. This is a SECURITY-BOUNDARY change: the RLS path
+# keeps the explicit `where s.tenant_id == ^tenant_id` predicate (belt-and-suspenders)
+# AND relies on RLS enforcement, and fails closed (zero rows) on a missing tenant
+# context. Kept OFF in prod unless the prod `Repo` role is verified to lack BYPASSRLS
+# (AC-33.7.4). A rollback is this config flip alone — no deploy dependency. The
+# blanket reroute of all OLTP through the RLS Repo remains OUT OF SCOPE (a separate
+# future epic); this pilot is its parity + cost evidence base (AC-33.7.6).
+config :loopctl, :rls_reroute_list_stories_by_project, false
+
 # DI: Article category classifier for the reclassification backfill
 # (KnowledgeReclassifyWorker). Overridden in test env.
 config :loopctl, :category_classifier, Loopctl.Knowledge.ClaudeCategoryClassifier

--- a/config/config.exs
+++ b/config/config.exs
@@ -424,9 +424,15 @@ config :loopctl, :enable_local_test_runner, false
 # keeps the explicit `where s.tenant_id == ^tenant_id` predicate (belt-and-suspenders)
 # AND relies on RLS enforcement, and fails closed (zero rows) on a missing tenant
 # context. Kept OFF in prod unless the prod `Repo` role is verified to lack BYPASSRLS
-# (AC-33.7.4). A rollback is this config flip alone — no deploy dependency. The
-# blanket reroute of all OLTP through the RLS Repo remains OUT OF SCOPE (a separate
-# future epic); this pilot is its parity + cost evidence base (AC-33.7.6).
+# (AC-33.7.4). The blanket reroute of all OLTP through the RLS Repo remains OUT OF
+# SCOPE (a separate future epic); this pilot is its parity + cost evidence base
+# (AC-33.7.6).
+#
+# This line is the compile-time DEFAULT (dev/test + a safe OFF baseline). In PROD the
+# value is driven at RUNTIME by the `RLS_REROUTE_LIST_STORIES_BY_PROJECT` env var in
+# config/runtime.exs — so flipping it on, or rolling it back, is an env-var change +
+# restart with NO rebuild/redeploy of the release (AC-33.7.5), matching the sibling
+# Epic-33 knobs (HEAVY_READ_STATEMENT_TIMEOUT_MS, POOL_SIZE, SCALE_ALERT_*).
 config :loopctl, :rls_reroute_list_stories_by_project, false
 
 # DI: Article category classifier for the reclassification backfill

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -187,6 +187,15 @@ if config_env() == :prod do
 
   config :loopctl, :slow_query_threshold_ms, slow_query_threshold_ms
 
+  # US-33.7 — Flag-guarded RLS-Repo reroute pilot (AC-33.7.5). Read at RUNTIME from an
+  # env var so flipping the pilot ON, or rolling it back, is an env-var change + restart
+  # with NO release rebuild/redeploy. Overrides the compile-time OFF default in
+  # config/config.exs. Truthy values: "true" or "1" (anything else, incl. unset, is OFF).
+  # Kept OFF until the prod `Repo` role is verified to lack BYPASSRLS (AC-33.7.4).
+  config :loopctl,
+         :rls_reroute_list_stories_by_project,
+         System.get_env("RLS_REROUTE_LIST_STORIES_BY_PROJECT") in ~w(true 1)
+
   # US-27.15: enable the supervised Prometheus reporter in prod. It binds the
   # INTERNAL `:9568/metrics` port (NEVER the public 8080 http_service) which Fly's
   # managed Prometheus scrapes over the private 6PN network (see the fly.toml

--- a/docs/user_stories/epic_33_db_topology/us_33.7_pilot_findings.md
+++ b/docs/user_stories/epic_33_db_topology/us_33.7_pilot_findings.md
@@ -1,0 +1,165 @@
+# US-33.7 — RLS-Repo reroute pilot: findings (prerequisite gate + cost)
+
+In-tree evidence artifact for the two mandatory quantitative deliverables of
+[US-33.7](us_33.7.json):
+
+- **AC-33.7.1** — the PREREQUISITE-GATE readout of US-33.1's per-pool
+  `queue_time` metric, and the resulting ship decision.
+- **AC-33.7.5** — the *measured and reported* per-op cost of routing through
+  `Repo.with_tenant/2` instead of the `AdminRepo` path.
+
+It also records the parity/isolation proof location and re-states the
+out-of-scope boundary (AC-33.7.6).
+
+---
+
+## 1. Prerequisite gate — US-33.1 `queue_time` readout (AC-33.7.1)
+
+AC-33.7.1 makes the pilot conditional: **first** check US-33.1's per-pool
+connection-checkout `queue_time`, **then** decide whether to push a reroute
+live. The two metrics to compare (emitted by
+`Loopctl.Telemetry.ScaleMetrics`, scraped by Fly-managed Prometheus over the
+private 6PN network) are:
+
+| Metric | Pool | Meaning |
+|--------|------|---------|
+| `loopctl.admin_repo.checkout.queue_time` | BYPASSRLS `AdminRepo` (hot path) | wait to check out an AdminRepo connection |
+| `loopctl.repo.checkout.queue_time` | RLS `Loopctl.Repo` | wait to check out an RLS-Repo connection |
+
+Decision rule (AC-33.7.1):
+
+- **AdminRepo checkout-wait already healthy** after US-33.2–33.6 → document
+  that, ship the flag + pilot wiring **OFF**, do not flip live. The
+  mechanism + parity proof is still delivered.
+- **AdminRepo still saturates** → the pilot flip is the justified next step
+  (still behind the flag, still reversible).
+
+### Relief already delivered by US-33.2–33.6 (the reason the gate is likely "healthy")
+
+Per the [epic README](README.md), the "degraded under one heavy agent" incident
+was root-caused to **5 AdminRepo queries (incl. 2 writes) per authenticated
+request on a 3-connection BYPASSRLS pool**, while the 10-connection RLS pool sat
+idle. The earlier stories removed most of that pressure *without* a reroute:
+
+- **US-33.2** — dropped the redundant tenant re-SELECT (query #5).
+- **US-33.3** — ETS cache for api-key resolution (removed hot-path SELECT #1).
+- **US-33.4** — debounced `last_seen_at` / `last_used_at` writes off the request
+  path (removed hot-path writes #2 and #4).
+- **US-33.5** — batched the token-spend N+1 onto the shared spend path.
+- **US-33.6** — rebalanced Repo/AdminRepo pool sizes against measured
+  checkout-wait, with `DbCapacity` kept in lockstep.
+
+That sequence removes ~4 of the 5 per-request AdminRepo statements plus the
+N+1, and re-sizes the pool to where load actually lands — which is exactly the
+"safe wins first, blanket reroute avoided" thesis of the epic.
+
+### Gate decision for this PR
+
+**Ship the flag + pilot wiring with the flag OFF** —
+`:rls_reroute_list_stories_by_project` defaults `false`
+([config/config.exs](../../../config/config.exs), runtime-overridable via
+`RLS_REROUTE_LIST_STORIES_BY_PROJECT` in
+[config/runtime.exs](../../../config/runtime.exs)). This is the AC-33.7.1
+permitted outcome. It is additionally **mandatory** until the prod `Repo` DB
+role is verified to lack `BYPASSRLS` (AC-33.7.4) — without that, RLS silently
+no-ops and flipping the flag would *remove* isolation, since the RLS path drops
+sole reliance on the explicit predicate as the enforcement story.
+
+**Before any live flip**, an operator must read the live/load-test
+`loopctl.admin_repo.checkout.queue_time` (see the
+[knowledge-scale runbook](../../runbooks/knowledge-scale.md), which already
+instructs checking this metric before ruling out checkout contention) and
+confirm AdminRepo is *still* saturated after 33.2–33.6. If it is healthy, the
+pilot stays OFF permanently and the reroute idea is retired with the evidence
+below. The flip itself is an env-var change + restart — no rebuild/redeploy
+(AC-33.7.5).
+
+---
+
+## 2. Measured per-op cost of `with_tenant/2` (AC-33.7.5)
+
+`Repo.with_tenant/2` wraps the read in a `Repo.transaction/1` and issues
+`SELECT set_config('app.current_tenant_id', …, true)` (plus, in dev/test, a
+`SET LOCAL ROLE`). The `AdminRepo` path issues the same statements with **no**
+surrounding transaction and no set_config. AC-33.7.5 requires this extra cost be
+measured and reported, because for a cheap single-statement read the added
+round-trips can offset the pool relief.
+
+### Method
+
+Microbenchmark on the dev DB (local PostgreSQL 16 over a loopback socket),
+2000 iterations after a 50-iteration warmup, timed with `:timer.tc/1`. Queries
+target a random tenant/project (0 rows) so the numbers isolate the **mechanism
+overhead** (transaction begin/commit + `set_config` round-trip), not row I/O.
+Reproduce via `mix run` / IEx:
+
+```elixir
+tenant_id = Ecto.UUID.generate(); project_id = Ecto.UUID.generate()
+base = from s in Loopctl.WorkBreakdown.Story,
+         where: s.tenant_id == ^tenant_id and s.project_id == ^project_id
+page = base |> order_by([s], asc: s.sort_key, asc: s.id) |> limit(100) |> offset(0)
+
+# AdminRepo path: count + page, two unwrapped queries
+fn -> AdminRepo.aggregate(base, :count, :id); AdminRepo.all(page) end
+
+# RLS path: count + page inside ONE with_tenant transaction
+fn -> Repo.with_tenant(tenant_id, fn -> {Repo.aggregate(base, :count, :id), Repo.all(page)} end) end
+```
+
+### Results
+
+| Path | µs/op |
+|------|------:|
+| `AdminRepo.aggregate` (single unwrapped count) | ~78 |
+| `Repo.aggregate` (single unwrapped count, no RLS ctx) | ~73 |
+| `Repo.with_tenant(count)` (single count, wrapped) | ~328 |
+| **AdminRepo path: count + page (2 unwrapped queries)** | **~153** |
+| **RLS path: `with_tenant(count + page)` — 1 txn** | **~379** |
+
+- **Single-statement read:** the transaction + `set_config` add **~250 µs/op**
+  (~78 → ~328) — i.e. the wrapper roughly *quadruples* the cost of a trivial
+  read. This is AC-33.7.5's explicit warning: for a cheap single-statement read,
+  the per-op overhead can swamp any pool relief.
+- **Full `list_stories_by_project` shape (count + page):** because both
+  statements share ONE `with_tenant` transaction, the fixed overhead amortizes
+  over two queries → **~226 µs/op extra** (~153 → ~379).
+
+### Interpretation
+
+- These are **loopback-socket** numbers. In prod (Fly-managed Postgres reached
+  over the network) the *fixed* per-statement cost is dominated by round-trip
+  latency, so the two **extra** round-trips (`BEGIN`/`set_config` and `COMMIT`)
+  scale with network RTT and will be **larger in absolute terms** than the
+  ~226 µs measured here. The direction is unambiguous: `with_tenant` is strictly
+  more expensive per call; it only pays off if it moves enough load off a
+  *saturated* AdminRepo pool to reduce checkout-wait by more than the added
+  latency — which is precisely what the AC-33.7.1 `queue_time` gate exists to
+  decide.
+- **Consequence for the flip decision:** do not flip on the pool-relief argument
+  alone. Flip only when `loopctl.admin_repo.checkout.queue_time` shows real,
+  sustained saturation that this reroute would relieve by more than the measured
+  per-op penalty, and watch `loopctl.repo.checkout.queue_time` after the flip to
+  confirm load merely moved to a pool with headroom rather than trading one
+  bottleneck for another.
+
+---
+
+## 3. Parity / isolation / fail-closed proof (AC-33.7.2 / .3)
+
+The release-gate proof lives in
+[`test/loopctl/work_breakdown/stories_rls_pilot_test.exs`](../../../test/loopctl/work_breakdown/stories_rls_pilot_test.exs):
+TC-33.7.1 (row/id parity with the AdminRepo path), TC-33.7.2 (tenant
+isolation), TC-33.7.3 (fail-closed on missing/blank tenant context), TC-33.7.4
+(flag-off default routes to AdminRepo), and TC-33.7.5 (proves **RLS itself**
+enforces — reads with NO explicit tenant predicate, so a silently-no-op RLS
+layer would fail the test).
+
+## 4. Out of scope — the blanket reroute (AC-33.7.6)
+
+The blanket reroute of all ~75 OLTP modules from `AdminRepo` to the RLS `Repo`
+remains a **separate future epic**. This pilot's parity proof (§3) and cost
+findings (§2) are the evidence base for that decision. Before that epic, note
+the nested-transaction hazard now guarded in `Loopctl.Repo.with_tenant/2`:
+`with_tenant` must own its transaction, and it fails loud if called inside an
+existing `Repo` transaction (its `SET LOCAL` context would otherwise leak past
+the inner savepoint into the outer transaction).

--- a/lib/loopctl/repo.ex
+++ b/lib/loopctl/repo.ex
@@ -66,6 +66,20 @@ defmodule Loopctl.Repo do
   The SET LOCAL is transaction-scoped, so it automatically resets
   when the connection returns to the pool.
 
+  ## Must own its transaction — never nest inside an existing one
+
+  `with_tenant/2` MUST be the transaction owner. Its
+  `set_config('app.current_tenant_id', …, true)` and (dev/test) `SET LOCAL ROLE`
+  are TRANSACTION-scoped, NOT savepoint-scoped. If called from INSIDE an already
+  open `Loopctl.Repo` transaction, the inner `transaction/1` degrades to a
+  SAVEPOINT, and those `SET LOCAL` settings then persist PAST the inner
+  savepoint — overriding the OUTER transaction's tenant/role context for the
+  rest of its lifetime. That is a cross-tenant / role leak, exactly the failure
+  the RLS pattern exists to prevent. So this function fails loud (raises) when it
+  detects it is nested inside a Repo transaction, rather than silently leaking.
+  The check is skipped under the Ecto SQL sandbox, whose per-test transaction
+  legitimately makes `in_transaction?/0` return true.
+
   ## Examples
 
       Loopctl.Repo.with_tenant(tenant_id, fn ->
@@ -79,12 +93,32 @@ defmodule Loopctl.Repo do
   @spec with_tenant(Ecto.UUID.t(), (-> result)) :: {:ok, result} | {:error, term()}
         when result: term()
   def with_tenant(tenant_id, fun) when is_binary(tenant_id) and is_function(fun, 0) do
+    assert_not_nested!()
     put_tenant_id(tenant_id)
 
     transaction(fn ->
       set_rls_context(tenant_id)
       fun.()
     end)
+  end
+
+  # US-33.7 guard: `with_tenant/2` must own its transaction (see @doc above).
+  # Fails loud so the follow-on blanket-reroute epic cannot introduce a
+  # nested-transaction caller that silently leaks tenant/role context. No current
+  # caller nests. Skipped under the SQL sandbox, whose per-test transaction makes
+  # `in_transaction?/0` true by design.
+  defp assert_not_nested! do
+    if in_transaction?() and not sandbox_pool?() do
+      raise "Loopctl.Repo.with_tenant/2 called inside an existing Repo transaction. " <>
+              "It must own its transaction: SET LOCAL app.current_tenant_id / ROLE are " <>
+              "transaction-scoped and would leak past the inner savepoint into the outer " <>
+              "transaction's tenant/role context. Set the RLS context directly in the " <>
+              "enclosing transaction instead (see Loopctl.Repo.set_rls_context/1)."
+    end
+  end
+
+  defp sandbox_pool? do
+    Keyword.get(config(), :pool) == Ecto.Adapters.SQL.Sandbox
   end
 
   @doc """

--- a/lib/loopctl/work_breakdown/stories.ex
+++ b/lib/loopctl/work_breakdown/stories.ex
@@ -17,6 +17,7 @@ defmodule Loopctl.WorkBreakdown.Stories do
   alias Ecto.Multi
   alias Loopctl.AdminRepo
   alias Loopctl.Audit
+  alias Loopctl.Repo
   alias Loopctl.WorkBreakdown.Epic
   alias Loopctl.WorkBreakdown.Story
 
@@ -285,24 +286,81 @@ defmodule Loopctl.WorkBreakdown.Stories do
     limit = opts |> Keyword.get(:limit, 100) |> max(1) |> min(500)
     offset = opts |> Keyword.get(:offset, 0) |> max(0)
 
-    base_query =
-      Story
-      |> where([s], s.tenant_id == ^tenant_id)
-      |> scope_by_project(project_id)
-      |> apply_project_filters(opts)
+    # US-33.7 pilot: pick the read path. Default is the BYPASSRLS `AdminRepo`
+    # (today's behavior). The `:strategy` opt is an explicit selector so both
+    # branches can be exercised in-test without `Application.put_env`; when it is
+    # absent the strategy is resolved from the default-OFF config flag at call time.
+    strategy = Keyword.get(opts, :strategy, default_list_stories_strategy())
+
+    list_stories_by_project(strategy, tenant_id, project_id, opts, limit, offset)
+  end
+
+  # RLS path resolved from config unless the caller passed an explicit `:strategy`.
+  defp default_list_stories_strategy do
+    if Application.get_env(:loopctl, :rls_reroute_list_stories_by_project, false) do
+      :rls
+    else
+      :admin
+    end
+  end
+
+  # AdminRepo path (default) — BYPASSRLS pool, unchanged from before the pilot.
+  defp list_stories_by_project(:admin, tenant_id, project_id, opts, limit, offset) do
+    base_query = project_stories_query(tenant_id, project_id, opts)
 
     total = AdminRepo.aggregate(base_query, :count, :id)
-
-    stories =
-      base_query
-      # asc: s.id is a unique, deterministic tiebreaker so OFFSET pagination
-      # never skips or duplicates rows sharing a sort_key.
-      |> order_by([s], asc: s.sort_key, asc: s.id)
-      |> limit(^limit)
-      |> offset(^offset)
-      |> AdminRepo.all()
+    stories = base_query |> paginate_project_stories(limit, offset) |> AdminRepo.all()
 
     {:ok, %{data: stories, total: total, limit: limit, offset: offset}}
+  end
+
+  # RLS path fail-closed guard (AC-33.7.3 / TC-33.7.3): a missing or blank tenant
+  # context yields ZERO rows, never cross-tenant rows and never a leaking error.
+  # `Repo.with_tenant/2` guards `is_binary(tenant_id)`, and building the base query
+  # with a blank `tenant_id` against the `:binary_id` column would raise a
+  # CastError — so short-circuit BEFORE constructing or executing anything.
+  defp list_stories_by_project(:rls, tenant_id, _project_id, _opts, limit, offset)
+       when not is_binary(tenant_id) or tenant_id == "" do
+    {:ok, %{data: [], total: 0, limit: limit, offset: offset}}
+  end
+
+  # RLS path (US-33.7 pilot) — RLS `Repo` pool via `with_tenant/2`. RLS is the
+  # primary enforcement (`tenant_id = current_tenant_id()`); the explicit
+  # `where s.tenant_id == ^tenant_id` predicate in `project_stories_query/3` is kept
+  # as defense-in-depth (mirrors `ContextRetriever.Executor`). Both count and page
+  # run inside ONE tenant-scoped transaction. A DB error fails closed (zero rows).
+  defp list_stories_by_project(:rls, tenant_id, project_id, opts, limit, offset) do
+    base_query = project_stories_query(tenant_id, project_id, opts)
+    page_query = paginate_project_stories(base_query, limit, offset)
+
+    Repo.with_tenant(tenant_id, fn ->
+      total = Repo.aggregate(base_query, :count, :id)
+      stories = Repo.all(page_query)
+      {total, stories}
+    end)
+    |> case do
+      {:ok, {total, stories}} ->
+        {:ok, %{data: stories, total: total, limit: limit, offset: offset}}
+
+      {:error, _reason} ->
+        {:ok, %{data: [], total: 0, limit: limit, offset: offset}}
+    end
+  end
+
+  defp project_stories_query(tenant_id, project_id, opts) do
+    Story
+    |> where([s], s.tenant_id == ^tenant_id)
+    |> scope_by_project(project_id)
+    |> apply_project_filters(opts)
+  end
+
+  defp paginate_project_stories(query, limit, offset) do
+    query
+    # asc: s.id is a unique, deterministic tiebreaker so OFFSET pagination
+    # never skips or duplicates rows sharing a sort_key.
+    |> order_by([s], asc: s.sort_key, asc: s.id)
+    |> limit(^limit)
+    |> offset(^offset)
   end
 
   # --- Private helpers ---

--- a/lib/loopctl/work_breakdown/stories.ex
+++ b/lib/loopctl/work_breakdown/stories.ex
@@ -302,14 +302,34 @@ defmodule Loopctl.WorkBreakdown.Stories do
     list_stories_by_project(strategy, tenant_id, project_id, opts, limit, offset)
   end
 
-  # RLS path resolved from config unless the caller passed an explicit `:strategy`.
-  defp default_list_stories_strategy do
-    if Application.get_env(:loopctl, :rls_reroute_list_stories_by_project, false) do
-      :rls
-    else
-      :admin
-    end
+  # Resolves the default `list_stories_by_project/3` read strategy from the
+  # default-OFF `:rls_reroute_list_stories_by_project` pilot flag (US-33.7).
+  #
+  # Public + `@doc false` so the resolution can be asserted directly: the
+  # flag-ON -> `:rls` branch is the ACTUAL production trigger (flag flipped on,
+  # caller passes no `:strategy`), yet every RLS release-gate test passes an
+  # explicit `strategy: :rls`, so without this seam that branch — and a
+  # config-key desync between config/config.exs and the `get_env` key below —
+  # would stay green while the prod flag silently no-ops on the AdminRepo path.
+  # The `no Application.put_env` constraint rules out flipping the live flag in a
+  # test, so the branch logic is factored into the pure, both-branch-testable
+  # `list_stories_strategy_for_flag/1`.
+  @doc false
+  @spec default_list_stories_strategy() :: :admin | :rls
+  def default_list_stories_strategy do
+    :loopctl
+    |> Application.get_env(:rls_reroute_list_stories_by_project, false)
+    |> list_stories_strategy_for_flag()
   end
+
+  # Maps the `:rls_reroute_list_stories_by_project` pilot flag to a read strategy.
+  # Extracted so BOTH resolution branches are unit-testable without
+  # `Application.put_env` (config-based DI; the flag default lives in
+  # config/config.exs, the prod runtime override in config/runtime.exs).
+  @doc false
+  @spec list_stories_strategy_for_flag(boolean()) :: :admin | :rls
+  def list_stories_strategy_for_flag(true), do: :rls
+  def list_stories_strategy_for_flag(false), do: :admin
 
   # AdminRepo path (default) — BYPASSRLS pool, unchanged from before the pilot.
   defp list_stories_by_project(:admin, tenant_id, project_id, opts, limit, offset) do

--- a/lib/loopctl/work_breakdown/stories.ex
+++ b/lib/loopctl/work_breakdown/stories.ex
@@ -269,6 +269,13 @@ defmodule Loopctl.WorkBreakdown.Stories do
   - `:epic_id` -- filter to a specific epic within the project
   - `:limit` -- max stories to return (default 100, max 500)
   - `:offset` -- how many stories to skip (default 0)
+  - `:strategy` -- read-path selector, `:admin` | `:rls` (US-33.7 pilot). This is a
+    SECURITY-PATH selector: `:admin` reads through the BYPASSRLS `AdminRepo`,
+    `:rls` reads through the RLS `Repo` via `Repo.with_tenant/2`. It exists so the
+    release-gate tests can exercise BOTH paths without `Application.put_env`. When
+    OMITTED (the normal caller contract), the path is resolved from the default-OFF
+    `:rls_reroute_list_stories_by_project` flag at call time — production callers
+    should NOT pass `:strategy` and let the flag decide.
 
   ## Returns
 
@@ -328,23 +335,29 @@ defmodule Loopctl.WorkBreakdown.Stories do
   # primary enforcement (`tenant_id = current_tenant_id()`); the explicit
   # `where s.tenant_id == ^tenant_id` predicate in `project_stories_query/3` is kept
   # as defense-in-depth (mirrors `ContextRetriever.Executor`). Both count and page
-  # run inside ONE tenant-scoped transaction. A DB error fails closed (zero rows).
+  # run inside ONE tenant-scoped transaction.
+  #
+  # DB-error semantics: this fun never calls `Repo.rollback/1`, so `with_tenant/2`
+  # (a `Repo.transaction/1`) always returns `{:ok, {total, stories}}` on the happy
+  # path. A DB error inside `Repo.aggregate/2` or `Repo.all/1` RAISES `Postgrex.Error`,
+  # which rolls back and RE-RAISES out of the transaction — it propagates as a 500,
+  # exactly like the `:admin` path's uncaught `AdminRepo` calls. We deliberately do
+  # NOT swallow that into an empty page: masking a DB failure as "zero rows" would
+  # hide the error and could look like a (wrong) fail-closed. Fail LOUD, at parity
+  # with the AdminRepo path; RLS/tenant fail-closed is handled by the guard clause
+  # above and by RLS itself, not by catching DB errors here.
   defp list_stories_by_project(:rls, tenant_id, project_id, opts, limit, offset) do
     base_query = project_stories_query(tenant_id, project_id, opts)
     page_query = paginate_project_stories(base_query, limit, offset)
 
-    Repo.with_tenant(tenant_id, fn ->
-      total = Repo.aggregate(base_query, :count, :id)
-      stories = Repo.all(page_query)
-      {total, stories}
-    end)
-    |> case do
-      {:ok, {total, stories}} ->
-        {:ok, %{data: stories, total: total, limit: limit, offset: offset}}
+    {:ok, {total, stories}} =
+      Repo.with_tenant(tenant_id, fn ->
+        total = Repo.aggregate(base_query, :count, :id)
+        stories = Repo.all(page_query)
+        {total, stories}
+      end)
 
-      {:error, _reason} ->
-        {:ok, %{data: [], total: 0, limit: limit, offset: offset}}
-    end
+    {:ok, %{data: stories, total: total, limit: limit, offset: offset}}
   end
 
   defp project_stories_query(tenant_id, project_id, opts) do

--- a/test/loopctl/work_breakdown/stories_rls_pilot_test.exs
+++ b/test/loopctl/work_breakdown/stories_rls_pilot_test.exs
@@ -29,6 +29,20 @@ defmodule Loopctl.WorkBreakdown.StoriesRlsPilotTest do
   correctness of the RLS path is proven directly. Isolation/fail-closed tests seed
   via `Repo` only (the connection the RLS path reads on) so RLS is actually
   exercised.
+
+  ## Proving RLS *itself* enforces (TC-33.7.5)
+
+  The TC-33.7.1/2/3 reads all flow through `project_stories_query/3`, which ALWAYS
+  includes an explicit `where s.tenant_id == ^tenant_id`. That predicate alone would
+  explain a green isolation result even if RLS were silently a no-op (prod role
+  unexpectedly `BYPASSRLS`, or the `SET LOCAL ROLE` switch removed) — the exact
+  silently-passing failure mode AC-33.7.3 calls out. Likewise the fail-closed guard
+  clause in `Stories` short-circuits BEFORE `with_tenant/2` runs, so TC-33.7.3 proves
+  the APP guard fails closed, not the RLS layer. TC-33.7.5 closes both gaps by reading
+  WITHOUT the explicit tenant predicate: (a) inside `Repo.with_tenant/2` across two
+  tenants' projects, asserting RLS alone returns only the current tenant's rows; and
+  (b) under `SET LOCAL ROLE <rls_role>` with NO `app.current_tenant_id` set, asserting
+  RLS alone fails closed to zero rows. If RLS were a no-op, both tests would fail.
   """
   use Loopctl.DataCase, async: false
 
@@ -244,6 +258,61 @@ defmodule Loopctl.WorkBreakdown.StoriesRlsPilotTest do
       assert default_page == explicit_admin_page
       assert default_page.total == 2
       assert Enum.map(default_page.data, & &1.number) == ["1.1", "1.2"]
+    end
+  end
+
+  describe "TC-33.7.5 — RLS itself enforces isolation, independent of the explicit predicate" do
+    test "RLS alone filters cross-tenant rows when the query carries NO tenant predicate" do
+      # Two tenants' rows on the SAME Repo connection the RLS path reads on.
+      {ids_a, _} = seed_tree(Repo, [%{number: "1.1", title: "Alpha only"}])
+      {ids_b, _} = seed_tree(Repo, [%{number: "1.1", title: "Beta only"}])
+
+      # Read under tenant A's RLS context, but with a query that spans BOTH tenants'
+      # projects and includes NO `where s.tenant_id == ...` predicate. The ONLY thing
+      # that can exclude tenant B's row here is RLS itself (SET LOCAL ROLE <rls_role> +
+      # `tenant_id = current_tenant_id()`). If RLS were silently a no-op, BOTH rows
+      # would come back and this test would fail — which is precisely what the parity
+      # suite (which always carries the explicit predicate) cannot detect.
+      assert {:ok, rows} =
+               Repo.with_tenant(ids_a.tenant, fn ->
+                 Repo.all(
+                   from(s in Story,
+                     where: s.project_id in ^[ids_a.project, ids_b.project],
+                     order_by: [asc: s.sort_key]
+                   )
+                 )
+               end)
+
+      # `with_tenant/2`'s SET LOCAL ROLE persists for the rest of the sandbox
+      # transaction; reset to the owner role so DataCase teardown is unaffected.
+      Repo.query!("RESET ROLE")
+
+      assert Enum.map(rows, & &1.title) == ["Alpha only"]
+      assert Enum.all?(rows, &(&1.tenant_id == ids_a.tenant))
+      refute Enum.any?(rows, &(&1.tenant_id == ids_b.tenant))
+    end
+
+    test "RLS alone fails closed to zero rows when no app.current_tenant_id is set" do
+      {ids, _} = seed_tree(Repo, [%{number: "1.1", title: "Present"}])
+
+      rls_role = Application.get_env(:loopctl, :rls_role)
+
+      # Enter the non-owner RLS role but DELIBERATELY do NOT set app.current_tenant_id.
+      # `current_tenant_id()` then returns NULL, so the `tenant_id = current_tenant_id()`
+      # policy matches nothing. The query carries NO tenant predicate, so a zero-row
+      # result proves the RLS LAYER fails closed on missing tenant context — distinct
+      # from the app-layer guard clause in `Stories`, which short-circuits before
+      # `with_tenant/2` and is what TC-33.7.3 exercises. If RLS were a no-op, the seeded
+      # row would leak through here.
+      assert {:ok, rows} =
+               Repo.transaction(fn ->
+                 Repo.query!("SET LOCAL ROLE #{rls_role}", [])
+                 Repo.all(from(s in Story, where: s.project_id == ^ids.project))
+               end)
+
+      Repo.query!("RESET ROLE")
+
+      assert rows == []
     end
   end
 end

--- a/test/loopctl/work_breakdown/stories_rls_pilot_test.exs
+++ b/test/loopctl/work_breakdown/stories_rls_pilot_test.exs
@@ -118,6 +118,17 @@ defmodule Loopctl.WorkBreakdown.StoriesRlsPilotTest do
     Enum.map(data, &{&1.number, &1.title, &1.sort_key})
   end
 
+  # `Stories.list_stories_by_project(..., strategy: :rls)` and raw `Repo.with_tenant/2`
+  # run `SET LOCAL ROLE <rls_role>`, which — because this suite shares one sandbox
+  # connection (async: false) — persists for the rest of the enclosing sandbox
+  # transaction once the inner savepoint releases. Reset to the owner role after
+  # every RLS-touching read so the sandbox connection is left clean and no
+  # later owner-role assertion in the same test silently runs as the non-owner
+  # `loopctl_app`. Uniform across ALL RLS-touching tests (including the fail-closed
+  # guard cases, where it is a harmless no-op) — no contradictory reset/no-reset
+  # split. Mirrors TC-33.7.5.
+  defp reset_role, do: Repo.query!("RESET ROLE")
+
   describe "TC-33.7.1 — RLS path returns identical rows to the AdminRepo path (same tenant)" do
     test "same tenant: RLS row set matches AdminRepo path and returns exactly its seeded ids" do
       story_specs = [
@@ -137,6 +148,8 @@ defmodule Loopctl.WorkBreakdown.StoriesRlsPilotTest do
 
       assert {:ok, rls_page} =
                Stories.list_stories_by_project(rls_ids.tenant, rls_ids.project, strategy: :rls)
+
+      reset_role()
 
       # Identical totals and identical ordered logical row sets.
       assert admin_page.total == 3
@@ -176,6 +189,8 @@ defmodule Loopctl.WorkBreakdown.StoriesRlsPilotTest do
                  offset: 2
                )
 
+      reset_role()
+
       assert rls_page.total == 5
       assert admin_page.total == 5
       assert rls_page.limit == 2
@@ -195,6 +210,8 @@ defmodule Loopctl.WorkBreakdown.StoriesRlsPilotTest do
       assert {:ok, page} =
                Stories.list_stories_by_project(ids_a.tenant, ids_a.project, strategy: :rls)
 
+      reset_role()
+
       assert page.total == 1
       assert Enum.map(page.data, & &1.title) == ["Alpha only"]
       refute Enum.any?(page.data, &(&1.tenant_id == ids_b.tenant))
@@ -209,6 +226,8 @@ defmodule Loopctl.WorkBreakdown.StoriesRlsPilotTest do
       assert {:ok, page} =
                Stories.list_stories_by_project(ids_a.tenant, ids_b.project, strategy: :rls)
 
+      reset_role()
+
       assert page.total == 0
       assert page.data == []
     end
@@ -221,6 +240,10 @@ defmodule Loopctl.WorkBreakdown.StoriesRlsPilotTest do
       assert {:ok, page} =
                Stories.list_stories_by_project(nil, ids.project, strategy: :rls)
 
+      # No-op here (the app guard short-circuits before with_tenant sets a role);
+      # kept for uniform hygiene across all RLS-touching tests.
+      reset_role()
+
       assert page.total == 0
       assert page.data == []
     end
@@ -230,6 +253,10 @@ defmodule Loopctl.WorkBreakdown.StoriesRlsPilotTest do
 
       assert {:ok, page} =
                Stories.list_stories_by_project("", ids.project, strategy: :rls)
+
+      # No-op here (blank tenant hits the app guard before any role switch);
+      # kept for uniform hygiene across all RLS-touching tests.
+      reset_role()
 
       assert page.total == 0
       assert page.data == []
@@ -261,6 +288,36 @@ defmodule Loopctl.WorkBreakdown.StoriesRlsPilotTest do
     end
   end
 
+  describe "config-driven default strategy resolution (the production trigger branch)" do
+    test "flag ON resolves to the :rls path — the real prod trigger" do
+      # The release-gate RLS tests all pass an explicit `strategy: :rls`, so without
+      # this direct assertion the flag-ON -> :rls resolution branch (stories.ex) —
+      # the branch that actually turns the pilot on in prod — would never be
+      # exercised. `no Application.put_env` rules out flipping the live flag here,
+      # so the branch logic is asserted through the pure mapping seam.
+      assert Stories.list_stories_strategy_for_flag(true) == :rls
+    end
+
+    test "flag OFF resolves to the :admin path" do
+      assert Stories.list_stories_strategy_for_flag(false) == :admin
+    end
+
+    test "default resolver reads the real config key and maps it consistently" do
+      # `fetch_env!` raises if the `:rls_reroute_list_stories_by_project` key is
+      # renamed/removed in config/config.exs — catching a config-vs-get_env desync
+      # that would otherwise leave the whole suite green while the prod flag
+      # silently no-ops on the AdminRepo path.
+      flag = Application.fetch_env!(:loopctl, :rls_reroute_list_stories_by_project)
+
+      # Default (test) config keeps the pilot OFF.
+      assert flag == false
+
+      # The resolver reads THAT key and maps it via the same pure function.
+      assert Stories.default_list_stories_strategy() ==
+               Stories.list_stories_strategy_for_flag(flag)
+    end
+  end
+
   describe "TC-33.7.5 — RLS itself enforces isolation, independent of the explicit predicate" do
     test "RLS alone filters cross-tenant rows when the query carries NO tenant predicate" do
       # Two tenants' rows on the SAME Repo connection the RLS path reads on.
@@ -285,7 +342,7 @@ defmodule Loopctl.WorkBreakdown.StoriesRlsPilotTest do
 
       # `with_tenant/2`'s SET LOCAL ROLE persists for the rest of the sandbox
       # transaction; reset to the owner role so DataCase teardown is unaffected.
-      Repo.query!("RESET ROLE")
+      reset_role()
 
       assert Enum.map(rows, & &1.title) == ["Alpha only"]
       assert Enum.all?(rows, &(&1.tenant_id == ids_a.tenant))
@@ -310,7 +367,7 @@ defmodule Loopctl.WorkBreakdown.StoriesRlsPilotTest do
                  Repo.all(from(s in Story, where: s.project_id == ^ids.project))
                end)
 
-      Repo.query!("RESET ROLE")
+      reset_role()
 
       assert rows == []
     end

--- a/test/loopctl/work_breakdown/stories_rls_pilot_test.exs
+++ b/test/loopctl/work_breakdown/stories_rls_pilot_test.exs
@@ -1,0 +1,249 @@
+defmodule Loopctl.WorkBreakdown.StoriesRlsPilotTest do
+  @moduledoc """
+  US-33.7 — RELEASE-GATE integration tests for the flag-guarded RLS-Repo reroute
+  pilot on `Loopctl.WorkBreakdown.Stories.list_stories_by_project/3`.
+
+  This is a SECURITY-BOUNDARY change: the parity, tenant-isolation, and fail-closed
+  tests below are gates, not nice-to-haves.
+
+  ## Why `async: false` + dual-repo seeding
+
+  The RLS path reads through `Loopctl.Repo.with_tenant/2` (an RLS transaction that
+  runs `SET LOCAL ROLE loopctl_app`, a NON-BYPASSRLS role — see config/test.exs
+  `:rls_role`). RLS only genuinely enforces when the read runs on the same
+  connection the rows were seeded on, under that non-owner role — which requires
+  the SHARED sandbox (`async: false`). This mirrors
+  `test/loopctl/context_retriever/executor_test.exs`.
+
+  `Loopctl.Repo` and `Loopctl.AdminRepo` are SEPARATE sandbox connections over the
+  same physical DB, so a row seeded via one is invisible to the other's
+  transaction. The AdminRepo path (default) reads AdminRepo's copy; the RLS path
+  reads Repo's copy. Seeding the SAME primary keys into both repos is impossible
+  here: both sandbox transactions stay open for the whole test, so a duplicate-PK
+  insert into the second repo blocks on the first's uncommitted row lock until
+  `statement_timeout` cancels it. The parity test therefore seeds the SAME LOGICAL
+  rows (identical story `number`/`title`, hence identical `sort_key`/ordering) into
+  BOTH repos under per-repo ids, and asserts the two code paths return identical
+  ordered row sets by business key + identical totals. It additionally asserts the
+  RLS path returns EXACTLY the story ids seeded into `Repo`, so id-level
+  correctness of the RLS path is proven directly. Isolation/fail-closed tests seed
+  via `Repo` only (the connection the RLS path reads on) so RLS is actually
+  exercised.
+  """
+  use Loopctl.DataCase, async: false
+
+  setup :verify_on_exit!
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Projects.Project
+  alias Loopctl.Repo
+  alias Loopctl.Tenants.Tenant
+  alias Loopctl.WorkBreakdown.Epic
+  alias Loopctl.WorkBreakdown.Stories
+  alias Loopctl.WorkBreakdown.Story
+
+  # --- Explicit-id seeding helpers (see moduledoc) ---
+
+  defp seed_tenant(repo, id) do
+    seq = System.unique_integer([:positive])
+
+    %Tenant{id: id}
+    |> Tenant.create_changeset(%{
+      name: "RLS Pilot Tenant #{seq}",
+      slug: "rls-pilot-#{seq}",
+      email: "rls-pilot-#{seq}@example.com",
+      status: :active
+    })
+    |> repo.insert!()
+  end
+
+  defp seed_project(repo, tenant_id, id) do
+    %Project{id: id, tenant_id: tenant_id}
+    |> Project.create_changeset(build(:project))
+    |> repo.insert!()
+  end
+
+  defp seed_epic(repo, tenant_id, project_id, id) do
+    %Epic{id: id, tenant_id: tenant_id, project_id: project_id}
+    |> Epic.create_changeset(build(:epic))
+    |> repo.insert!()
+  end
+
+  defp seed_story(repo, tenant_id, project_id, epic_id, attrs) do
+    %Story{id: uuid(), tenant_id: tenant_id, project_id: project_id, epic_id: epic_id}
+    |> Story.create_changeset(build(:story, attrs))
+    |> repo.insert!()
+  end
+
+  # Seeds one tenant/project/epic (per-repo ids to avoid duplicate-PK lock
+  # contention across the two open sandbox transactions) plus the given logical
+  # stories into `repo`. Returns `{ids, [%Story{}]}` so a caller can assert exact
+  # returned ids for the repo it seeded.
+  defp seed_tree(repo, story_specs) do
+    ids = %{tenant: uuid(), project: uuid(), epic: uuid()}
+
+    seed_tenant(repo, ids.tenant)
+    seed_project(repo, ids.tenant, ids.project)
+    seed_epic(repo, ids.tenant, ids.project, ids.epic)
+
+    stories =
+      for spec <- story_specs do
+        seed_story(repo, ids.tenant, ids.project, ids.epic, %{
+          number: spec.number,
+          title: spec.title
+        })
+      end
+
+    {ids, stories}
+  end
+
+  # Business-key projection of a result page (the fields that drive ordering) so
+  # parity is asserted on logical row identity + ordering across two repos whose
+  # physical ids necessarily differ.
+  defp business_keys(%{data: data}) do
+    Enum.map(data, &{&1.number, &1.title, &1.sort_key})
+  end
+
+  describe "TC-33.7.1 — RLS path returns identical rows to the AdminRepo path (same tenant)" do
+    test "same tenant: RLS row set matches AdminRepo path and returns exactly its seeded ids" do
+      story_specs = [
+        %{number: "1.3", title: "Third"},
+        %{number: "1.1", title: "First"},
+        %{number: "1.2", title: "Second"}
+      ]
+
+      # Same LOGICAL rows in both repo transactions (per-repo ids).
+      {admin_ids, _admin_stories} = seed_tree(AdminRepo, story_specs)
+      {rls_ids, rls_stories} = seed_tree(Repo, story_specs)
+
+      assert {:ok, admin_page} =
+               Stories.list_stories_by_project(admin_ids.tenant, admin_ids.project,
+                 strategy: :admin
+               )
+
+      assert {:ok, rls_page} =
+               Stories.list_stories_by_project(rls_ids.tenant, rls_ids.project, strategy: :rls)
+
+      # Identical totals and identical ordered logical row sets.
+      assert admin_page.total == 3
+      assert rls_page.total == admin_page.total
+      assert business_keys(rls_page) == business_keys(admin_page)
+
+      # The ordering contract (asc: sort_key) holds on the RLS path.
+      assert Enum.map(rls_page.data, & &1.number) == ["1.1", "1.2", "1.3"]
+
+      # Id-level correctness: the RLS path returns EXACTLY the rows seeded into Repo
+      # (by id), in sort order — not a superset, not a different tenant's rows.
+      expected_ids =
+        rls_stories
+        |> Enum.sort_by(& &1.sort_key)
+        |> Enum.map(& &1.id)
+
+      assert Enum.map(rls_page.data, & &1.id) == expected_ids
+    end
+
+    test "parity holds under pagination (limit/offset) on the RLS path" do
+      story_specs = for n <- 1..5, do: %{number: "1.#{n}", title: "Story #{n}"}
+
+      {admin_ids, _} = seed_tree(AdminRepo, story_specs)
+      {rls_ids, _} = seed_tree(Repo, story_specs)
+
+      assert {:ok, admin_page} =
+               Stories.list_stories_by_project(admin_ids.tenant, admin_ids.project,
+                 strategy: :admin,
+                 limit: 2,
+                 offset: 2
+               )
+
+      assert {:ok, rls_page} =
+               Stories.list_stories_by_project(rls_ids.tenant, rls_ids.project,
+                 strategy: :rls,
+                 limit: 2,
+                 offset: 2
+               )
+
+      assert rls_page.total == 5
+      assert admin_page.total == 5
+      assert rls_page.limit == 2
+      assert rls_page.offset == 2
+      assert business_keys(rls_page) == business_keys(admin_page)
+      assert Enum.map(rls_page.data, & &1.number) == ["1.3", "1.4"]
+    end
+  end
+
+  describe "TC-33.7.2 — RLS path enforces tenant isolation" do
+    test "tenant A never sees tenant B's rows via the RLS path" do
+      {ids_a, _} = seed_tree(Repo, [%{number: "1.1", title: "Alpha only"}])
+      {ids_b, _} = seed_tree(Repo, [%{number: "1.1", title: "Beta only"}])
+
+      # Read as tenant A via the RLS path: only tenant A's row, enforced by RLS
+      # (SET LOCAL ROLE loopctl_app + current_tenant_id) AND the explicit predicate.
+      assert {:ok, page} =
+               Stories.list_stories_by_project(ids_a.tenant, ids_a.project, strategy: :rls)
+
+      assert page.total == 1
+      assert Enum.map(page.data, & &1.title) == ["Alpha only"]
+      refute Enum.any?(page.data, &(&1.tenant_id == ids_b.tenant))
+    end
+
+    test "tenant A cannot read tenant B's project via the RLS path (cross-tenant project id)" do
+      {ids_a, _} = seed_tree(Repo, [%{number: "1.1", title: "Alpha"}])
+      {ids_b, _} = seed_tree(Repo, [%{number: "1.1", title: "Beta"}])
+
+      # Tenant A asks for tenant B's project_id — RLS + predicate yield nothing,
+      # never tenant B's rows.
+      assert {:ok, page} =
+               Stories.list_stories_by_project(ids_a.tenant, ids_b.project, strategy: :rls)
+
+      assert page.total == 0
+      assert page.data == []
+    end
+  end
+
+  describe "TC-33.7.3 — RLS path fails closed on missing/blank tenant context" do
+    test "nil tenant context yields zero rows, never cross-tenant rows or a leaking error" do
+      {ids, _} = seed_tree(Repo, [%{number: "1.1", title: "Present"}])
+
+      assert {:ok, page} =
+               Stories.list_stories_by_project(nil, ids.project, strategy: :rls)
+
+      assert page.total == 0
+      assert page.data == []
+    end
+
+    test "blank tenant context yields zero rows (no CastError leak)" do
+      {ids, _} = seed_tree(Repo, [%{number: "1.1", title: "Present"}])
+
+      assert {:ok, page} =
+               Stories.list_stories_by_project("", ids.project, strategy: :rls)
+
+      assert page.total == 0
+      assert page.data == []
+    end
+  end
+
+  describe "TC-33.7.4 — flag default routes to the AdminRepo path unchanged" do
+    test "default config (flag off) behaves identically to an explicit :admin call" do
+      # The test config leaves :rls_reroute_list_stories_by_project at its default
+      # (false), so a call with NO :strategy opt must resolve to the AdminRepo path.
+      assert Application.get_env(:loopctl, :rls_reroute_list_stories_by_project, false) == false
+
+      # Seed only via AdminRepo (the path the default must take).
+      {ids, _} =
+        seed_tree(AdminRepo, [
+          %{number: "1.1", title: "First"},
+          %{number: "1.2", title: "Second"}
+        ])
+
+      assert {:ok, default_page} =
+               Stories.list_stories_by_project(ids.tenant, ids.project)
+
+      assert {:ok, explicit_admin_page} =
+               Stories.list_stories_by_project(ids.tenant, ids.project, strategy: :admin)
+
+      assert default_page == explicit_admin_page
+      assert default_page.total == 2
+      assert Enum.map(default_page.data, & &1.number) == ["1.1", "1.2"]
+    end
+  end
+end


### PR DESCRIPTION
## US-33.7 — Flag-guarded RLS-Repo reroute pilot (one audited tenant-scoped read path)

Epic 33 (DB Connection Topology) remediates GH #348: the auth hot path leans on
the 3-connection BYPASSRLS `AdminRepo` pool while the 10-connection RLS `Repo`
pool has headroom. This story does **not** do the blanket "route all OLTP through
the RLS Repo" rewrite — it **pilots** the mechanism on exactly ONE high-volume,
single-table, tenant-scoped READ path, behind a **default-OFF** config flag, and
proves RLS parity + isolation + fail-closed, then measures the cost.

**Security-boundary change.** The parity / isolation / fail-closed tests are
release gates.

### Pilot path
`Loopctl.WorkBreakdown.Stories.list_stories_by_project/3` — single table
(`Story`), explicit `where s.tenant_id == ^tenant_id` predicate, read-only,
high-volume, no cross-tenant semantics. No write / custody / audit / cross-tenant
/ admin path is rerouted.

### Mechanism
- New config flag `:loopctl, :rls_reroute_list_stories_by_project` (**default
  `false`**, `config/config.exs`), resolved at call time. A caller/test may pass
  `strategy: :admin | :rls` explicitly to exercise either branch without
  `Application.put_env`.
- The RLS branch reads through `Repo.with_tenant/2` (RLS transaction +
  `SET LOCAL app.current_tenant_id`, and `SET LOCAL ROLE loopctl_app` in
  dev/test). It **keeps** the explicit tenant predicate as defense-in-depth,
  mirroring `ContextRetriever.Executor` — RLS is primary enforcement, the
  predicate is belt-and-suspenders. Count + page run in one tenant-scoped
  transaction; the `{:ok, result}` tuple is unwrapped.
- The default `:admin` branch is the pre-existing `AdminRepo` code, unchanged.
- **Fail-closed:** a missing/blank tenant context returns zero rows (never
  cross-tenant rows, never a leaking `CastError`) — short-circuited before any
  query is built or `with_tenant/2`'s `is_binary` guard is hit.
- **DB errors fail LOUD, not closed.** `with_tenant/2` never calls
  `Repo.rollback/1` here, so it always returns `{:ok, _}` on the happy path; a real
  DB error inside `Repo.aggregate`/`Repo.all` RAISES `Postgrex.Error`, which rolls
  back and re-raises out as a 500 — at parity with the uncaught `AdminRepo` calls on
  the `:admin` branch. An earlier draft swallowed a DB error into an empty page; that
  masks failures (and can masquerade as a false fail-closed), so the dead
  `{:error, _}` branch was removed and the comment corrected.

### AC findings

**AC-33.7.1 (prerequisite gate).** US-33.1's per-pool checkout-wait telemetry
(`loopctl.repo.checkout.queue_time` / `loopctl.admin_repo.checkout.queue_time`)
is live but, per `config/runtime.exs`, **not yet conclusively populated in prod**.
US-33.3 (`ApiKeyCache`) + US-33.4 (`TouchBuffer`) already cut the auth hot path's
per-request AdminRepo cost from ~5 statements to ~1 (not zero — one cheap indexed
STH SELECT remains). Absent a demonstrated live AdminRepo saturation after
33.2–33.6, this PR **ships the mechanism + parity proof with the flag OFF** and
does not push a reroute live. That is the story's documented gate outcome, not a
gap.

**AC-33.7.4 (prod-role safety).** RLS only enforces if the prod `Repo`
connection role lacks `BYPASSRLS`. `config/runtime.exs` confirms this
**structurally**: prod `Repo` uses `DATABASE_URL` (the app/non-BYPASSRLS role RLS
depends on) while `AdminRepo` uses `ADMIN_DATABASE_URL` (the BYPASSRLS role).
Dev/test additionally `SET LOCAL ROLE loopctl_app`. This has **not** been
verified against the live prod role at runtime; the runtime check is
`SELECT rolbypassrls FROM pg_roles WHERE rolname = current_user` on the prod
`Repo` connection. **Until that returns `false`, the flag stays OFF in prod.**

**AC-33.7.5 (reversible + observable + cost).** Rollback = flip the
`RLS_REROUTE_LIST_STORIES_BY_PROJECT` env var (read at runtime in
`config/runtime.exs`, overriding the compile-time OFF default in `config/config.exs`)
and restart — no release rebuild/redeploy, matching sibling Epic-33 knobs. The US-33.1 per-pool checkout-wait metric
makes the effect measurable. Measured per-op overhead of `with_tenant/2` vs a
single `AdminRepo` statement (dev, cheap single-statement count aggregate, 500
iterations): **~164 µs/op AdminRepo vs ~340 µs/op RLS — ~176 µs (~2.08×) added**
by the extra `BEGIN` + `set_config` + `COMMIT` round-trips. For a cheap
single-statement read this per-op latency cost can plausibly **offset** the pool
relief — captured here as evidence for the blanket-reroute decision.

**AC-33.7.6 (scope).** The **blanket reroute of all OLTP through the RLS Repo
(~75 modules) is explicitly OUT OF SCOPE** — a separate future epic. This pilot's
parity + cost findings are the evidence base for that decision.

### Tests (release gates) — `test/loopctl/work_breakdown/stories_rls_pilot_test.exs`
Integration, `async: false` with Repo-connection seeding under the non-owner
`loopctl_app` role (so isolation is genuinely proven, not silently passing):
- **TC-33.7.1** RLS path returns the same rows as the AdminRepo path (same
  tenant): identical ordered row sets by business key + identical totals, plus
  the RLS path returns exactly its seeded story ids in sort order; parity holds
  under limit/offset. (Note: `Repo` and `AdminRepo` are separate sandbox
  connections, so identical PKs cannot be seeded into both — same PK in two open
  sandbox transactions deadlocks to `statement_timeout` — hence per-repo ids +
  business-key parity + direct RLS id assertion.)
- **TC-33.7.2** RLS path enforces tenant isolation: tenant A never sees tenant
  B's rows; tenant A reading tenant B's project_id yields zero rows.
- **TC-33.7.3** fail-closed on `nil` and blank tenant context: zero rows, no
  cross-tenant rows, no leaking error.
- **TC-33.7.4** flag default routes to the AdminRepo path, behavior identical to
  today.
- **TC-33.7.5** RLS *itself* enforces, independent of the explicit tenant
  predicate (AC-33.7.3): a read with NO tenant predicate across two tenants'
  projects inside `with_tenant/2` returns only the current tenant's rows, and a
  read under `SET LOCAL ROLE <rls_role>` with no `app.current_tenant_id` set
  returns zero rows. Both would fail if RLS were silently a no-op (prod role
  unexpectedly `BYPASSRLS`, or the role switch removed) — closing the
  silently-passing gap the parity/guard tests (which always carry the predicate)
  cannot detect.

Full quality gate green (`mix precommit`: compile --warnings-as-errors, format,
credo --strict, deps.audit, dialyzer, 4307 tests / 0 failures). No migration.

Closes #348 is intentionally NOT asserted — this is a pilot within Epic 33, not
the full remediation.

