### PR TITLE
docs(epic_34): Oban Resilience & Observability stories (US-34.1..34.6)

### DIFF
--- a/docs/user_stories/epic_34_oban_observability/README.md
+++ b/docs/user_stories/epic_34_oban_observability/README.md
@@ -1,0 +1,33 @@
+# Epic 34 — Oban Resilience, Retention & Observability
+
+Remediation of GitHub issue **#349** (roadmap Epic 2, tracked **#355**) — the alerting/observability that would have made every other incident non-silent.
+
+## Scope reconciliation (verified against `master` before authoring)
+
+Issue #349 predates recent work; three items are already done and are **excluded**:
+
+| #349 item | Status | Evidence |
+|-----------|--------|----------|
+| Oban Lifeline | ✅ done | `config/config.exs:325` (via #323) |
+| Oban Pruner | ✅ done | `config/config.exs:328` (via #323) |
+| Fail-loud on missing `SCALE_ALERT_WEBHOOK_URL` | ✅ done | US-32.4 (#361) — readiness guard in `health_check/default.ex` + `scale_alerts.ex:206-215` |
+
+US-33.1 (#366) also already exports per-pool `queue_time` **telemetry** — US-34.3 adds the missing **alert** on it.
+
+## Stories (the genuinely-remaining work)
+
+| Story | Title | Depends |
+|-------|-------|---------|
+| US-34.1 | Oban queue/state + `:executing` orphan gauges; add Reindexer, pin Stager | — |
+| US-34.2 | Surface Oban orphan/queue health in the `/health` degraded path | US-34.1 |
+| US-34.3 | 3 ScaleAlerts signals: Repo queue_time p95, discard/retry rate, provider-error rate | US-34.1 |
+| US-34.4 | Wire emitted-but-dead telemetry (`llm.blocked`, `embedding.skipped_no_key`, `index_health.invalid`, …) into metrics | — |
+| US-34.5 | Harden alert delivery: retry/backoff (via Oban) + periodic re-notify while breached | — |
+| US-34.6 | Bound `GET /knowledge/ingestion-jobs` COUNT: online index + HeavyRead + statement_timeout | — |
+
+## Non-negotiable constraints (system is LIVE)
+
+- Nearly all stories are **additive observability** — no job semantics change.
+- The one migration (US-34.6) is **online** (`CONCURRENTLY`, `@disable_ddl_transaction`) on the hot `oban_jobs` table.
+- All new metrics use **bounded tags** (no tenant/args/free-text) — cardinality is the multi-tenant risk; every metric story tests it.
+- Every merge is smoke-gated with a KB-health check either side; `statement_timeout` stays a per-query `SET LOCAL` (pgbouncer-safe).

--- a/docs/user_stories/epic_34_oban_observability/us_34.1.json
+++ b/docs/user_stories/epic_34_oban_observability/us_34.1.json
@@ -1,0 +1,52 @@
+{
+  "id": "US-34.1",
+  "title": "Oban queue/state gauges + :executing orphan gauge (Prometheus); add Reindexer, pin Stager",
+  "epic": { "id": "epic_34", "name": "Oban Resilience, Retention & Observability" },
+  "priority": "high",
+  "phase": "scalability",
+  "priority_note": "The measurement layer — nothing currently exports ANY Oban queue/state/orphan metric. Prerequisite for US-34.2 (health) and US-34.3 (alerts).",
+  "background": {
+    "reference": "GH #349. config/config.exs:276-329 (Oban: Cron + Lifeline + Pruner present; no Stager pinned, no Reindexer). No Oban metrics exist — ScaleMetrics.scale_metrics/0 (lib/loopctl/telemetry/scale_metrics.ex:111-214) has 7 metrics, none Oban. periodic_measurements/0 (lib/loopctl_web/telemetry.ex:152-157) has one poller (refresh_tenant_label_gate).",
+    "includes": "Lifeline RESCUES orphaned :executing jobs but nothing MEASURES them; there is no per-queue depth or per-state count. A stalled queue is invisible until an incident. The 17-day/110-orphan stall was undetectable for days."
+  },
+  "story": {
+    "as_a": "loopctl operator",
+    "i_want_to": "export per-queue / per-state Oban job counts and an :executing-older-than-N-minutes orphan gauge to Prometheus, and pin Stager + add the Reindexer plugin",
+    "so_that": "a stalled queue, a growing backlog, or an orphan pile-up is visible on a dashboard within one poll interval instead of surfacing days later as an outage"
+  },
+  "rationale": "Oban's own state lives in oban_jobs, but loopctl exports none of it, so the exact failure that motivated Lifeline (jobs stuck :executing) is still invisible to monitoring. A cheap periodic GROUP BY poll plus an orphan-age gauge turns the queue into an observable system; adding Reindexer keeps the oban_jobs indexes from bloating under churn, and pinning Stager removes reliance on the implicit default.",
+  "acceptance_criteria": [
+    { "id": "AC-34.1.1", "description": "A periodic poller (added to telemetry periodic_measurements or a supervised GenServer) runs `SELECT state, count(*) FROM oban_jobs GROUP BY state` (and optionally by queue) on a bounded interval and emits a telemetry measurement; ScaleMetrics exports it as a per-state (and/or per-queue) gauge. Tag cardinality is bounded (state is a small fixed set; queue is a small fixed set) — NEVER tenant/args-derived tags.", "status": "pending" },
+    { "id": "AC-34.1.2", "description": "An orphan gauge counts jobs in state `executing` whose `attempted_at` is older than N minutes (config, e.g. > the Lifeline rescue_after window) — the signal that Lifeline is falling behind or a job is wedged. Exported as a gauge.", "status": "pending" },
+    { "id": "AC-34.1.3", "description": "The poll uses a single lightweight query on a bounded interval (config), runs on a read path (HeavyRead or Repo with a short timeout) so it can't itself saturate a pool, and is defensive (a poll error logs + skips, never crashes the poller).", "status": "pending" },
+    { "id": "AC-34.1.4", "description": "`{Oban.Plugins.Reindexer, ...}` is added to the Oban plugins list (default schedule) so oban_jobs indexes are periodically rebuilt; Stager is explicitly listed (or a comment documents the default is intentionally relied upon). No change to Lifeline/Pruner/Cron.", "status": "pending" },
+    { "id": "AC-34.1.5", "description": "Purely additive observability + plugin config; no job semantics change. Metrics are global infra (not tenant-scoped); a cardinality test asserts bounded tags.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-34.1.1", "name": "per-state gauge is emitted", "type": "integration",
+      "preconditions": ["oban_jobs rows in a couple of states (available, completed) via fixtures/inserts"],
+      "steps": ["invoke the poller measurement fn"],
+      "expected_results": ["a telemetry measurement/gauge reflects the per-state counts; the metric is defined in metrics/0 with bounded tags"], "status": "pending" },
+    { "id": "TC-34.1.2", "name": "orphan gauge counts stuck executing jobs", "type": "integration",
+      "preconditions": ["one oban_jobs row state=executing, attempted_at older than the orphan threshold; one recent executing"],
+      "steps": ["invoke the orphan measurement"],
+      "expected_results": ["orphan gauge = 1 (only the stale one)"], "status": "pending" },
+    { "id": "TC-34.1.3", "name": "poller is defensive on query error", "type": "unit",
+      "preconditions": ["simulate the poll query raising"],
+      "steps": ["invoke the poller"],
+      "expected_results": ["logs + returns without crashing; no metric corruption"], "status": "pending" },
+    { "id": "TC-34.1.4", "name": "Reindexer present in plugins", "type": "unit",
+      "preconditions": [],
+      "steps": ["read the Oban plugins config"],
+      "expected_results": ["Oban.Plugins.Reindexer is configured; Lifeline+Pruner unchanged"], "status": "pending" }
+  ],
+  "technical_notes": [
+    "Files: lib/loopctl/telemetry/scale_metrics.ex (metric defs), lib/loopctl_web/telemetry.ex (periodic_measurements / poller), config/config.exs (plugins).",
+    "Query oban_jobs directly (it's not an Ecto schema) via a raw fragment; run on HeavyRead or Repo with SET LOCAL statement_timeout (per-query, never a startup :parameter — pgbouncer-safe).",
+    "Bounded tags only (state, queue). Cardinality is the multi-tenant risk — test it.",
+    "Config-based DI for intervals/thresholds; no Application.put_env in tests.",
+    "Reindexer default schedule is fine; document the choice."
+  ],
+  "dependencies": [],
+  "estimated_tokens": 300000
+}

--- a/docs/user_stories/epic_34_oban_observability/us_34.2.json
+++ b/docs/user_stories/epic_34_oban_observability/us_34.2.json
@@ -1,0 +1,46 @@
+{
+  "id": "US-34.2",
+  "title": "Surface Oban orphan/queue health in the /health degraded path",
+  "epic": { "id": "epic_34", "name": "Oban Resilience, Retention & Observability" },
+  "priority": "medium",
+  "phase": "scalability",
+  "priority_note": "Today /health reports HEALTHY for a queue full of orphans — the check is a shallow liveness ping.",
+  "background": {
+    "reference": "GH #349. HealthCheck.Default.check_oban/0 (lib/loopctl/health_check/default.ex:75-82) only calls Oban.check_queue(queue: :default) and checks it responds with a :paused key — a GenServer ping, not queue health. health_controller.ex:44-59 drives 503 off status (db+oban).",
+    "includes": "The Oban health check cannot detect the exact failure that motivated Lifeline: jobs wedged :executing / a growing backlog. It returns ok as long as the queue process answers."
+  },
+  "story": {
+    "as_a": "loopctl operator",
+    "i_want_to": "have the Oban health check report degraded when the orphan (stuck-executing) count exceeds a threshold",
+    "so_that": "a stalled queue shows up as a degraded readiness/health signal instead of a green check that hides the problem"
+  },
+  "rationale": "A health check that only pings the queue GenServer gives false confidence — it was green throughout the 17-day orphan stall. Folding the orphan count (from US-34.1's signal) into the health check's degraded path makes a wedged queue a first-class, visible health state, consistent with how db/oban already gate readiness.",
+  "acceptance_criteria": [
+    { "id": "AC-34.2.1", "description": "check_oban (or a new sub-check) computes the :executing-older-than-N-minutes orphan count and reports degraded (not ok) when it exceeds a configurable threshold; below threshold it stays ok. The existing queue-responsive ping is retained (a non-responsive queue is still a hard error).", "status": "pending" },
+    { "id": "AC-34.2.2", "description": "The orphan-degraded state is surfaced consistently with the existing liveness-vs-readiness split (default.ex:9-28): decide and document whether orphan-degraded belongs in liveness /health (affects Fly LB depool) or readiness /health/ready. Prefer NOT depooling a node from Fly's LB for a queue backlog (a node with a backlog can still serve requests) — route it to the readiness/degraded reason, not a liveness 503, unless justified.", "status": "pending" },
+    { "id": "AC-34.2.3", "description": "The check is cheap (reuses US-34.1's already-polled orphan value or a bounded query) and defensive (a check error does not crash the health endpoint; it degrades gracefully).", "status": "pending" },
+    { "id": "AC-34.2.4", "description": "Threshold is config; default chosen so a normal transient backlog does not flap the health state. No change to db/scale_alerts checks.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-34.2.1", "name": "orphan pile-up reports degraded", "type": "integration",
+      "preconditions": ["oban_jobs with orphan count above threshold"],
+      "steps": ["run the health check"],
+      "expected_results": ["oban sub-check reports degraded with an orphan reason; overall status/readiness reflects it per the chosen liveness/readiness split"], "status": "pending" },
+    { "id": "TC-34.2.2", "name": "healthy queue reports ok", "type": "integration",
+      "preconditions": ["no orphans, queue responsive"],
+      "steps": ["run the health check"],
+      "expected_results": ["oban check ok; /health 200"], "status": "pending" },
+    { "id": "TC-34.2.3", "name": "unresponsive queue is still a hard error", "type": "unit",
+      "preconditions": ["simulate check_queue failing/raising"],
+      "steps": ["run check_oban"],
+      "expected_results": ["reports error (retained behavior)"], "status": "pending" }
+  ],
+  "technical_notes": [
+    "Files: lib/loopctl/health_check/default.ex (check_oban), lib/loopctl_web/controllers/health_controller.ex (readiness vs liveness wiring).",
+    "Reuse the orphan measurement from US-34.1 if available (avoid a second query); else a bounded count with a short timeout.",
+    "Respect the documented liveness/readiness rationale (default.ex:9-28) — do not turn a benign backlog into a Fly-LB depool.",
+    "Config-based DI threshold; defensive rescue; no Application.put_env in tests."
+  ],
+  "dependencies": ["US-34.1"],
+  "estimated_tokens": 200000
+}

--- a/docs/user_stories/epic_34_oban_observability/us_34.3.json
+++ b/docs/user_stories/epic_34_oban_observability/us_34.3.json
@@ -1,0 +1,52 @@
+{
+  "id": "US-34.3",
+  "title": "Three ScaleAlerts signals: Repo queue_time p95, job discard/retry rate, provider-error rate",
+  "epic": { "id": "epic_34", "name": "Oban Resilience, Retention & Observability" },
+  "priority": "high",
+  "phase": "scalability",
+  "priority_note": "The alerting that would have made every other incident non-silent. US-33.1 already exports Repo queue_time; this adds the alert.",
+  "background": {
+    "reference": "GH #349. ScaleAlerts (lib/loopctl/telemetry/scale_alerts.ex) fires on 3 signals today (db_statement_timeout_rate, heavy_read_p95_latency_ms, under_fill_rate; attach_handlers/1 at :304-313). US-33.1 added per-pool queue_time telemetry ([:loopctl, :repo, :query]) to scale_metrics but ScaleAlerts does not ingest it.",
+    "includes": "The canonical 'one heavy agent' leading indicator (primary Repo checkout queue_time) is now measured but not ALERTED. There is no discard/retry-rate signal (Oban job failures) and no provider-error-rate signal (the 429/transport_error storm)."
+  },
+  "story": {
+    "as_a": "loopctl operator",
+    "i_want_to": "fire ScaleAlerts on (a) primary-Repo queue_time p95, (b) fleet-wide Oban job discard/retry rate, and (c) provider-error rate",
+    "so_that": "the three leading indicators of the known incident classes page me at breach instead of being discovered after the fact"
+  },
+  "rationale": "loopctl already has the alert machinery (windowed breach detection + delivery) but only watches 3 signals, none of which is the primary-pool checkout wait, Oban failure rate, or provider throttling — the exact precursors of the incidents this epic exists to prevent. Adding these three ingests to the existing ScaleAlerts pipeline closes the detection gap with the plumbing that already works.",
+  "acceptance_criteria": [
+    { "id": "AC-34.3.1", "description": "(a) A signal on primary Repo checkout queue_time p95 (from [:loopctl, :repo, :query] queue_time, the metric US-33.1 emits) fires when p95 over the window exceeds a configurable threshold. Uses the existing bucketed-p95 approach (mirror heavy_read_p95_latency_ms).", "status": "pending" },
+    { "id": "AC-34.3.2", "description": "(b) A signal on fleet-wide Oban job discard/retry rate: attach to [:oban, :job, :exception] (and/or discard) telemetry, window the count/min, fire above a threshold. Bounded tags (no per-tenant/per-args).", "status": "pending" },
+    { "id": "AC-34.3.3", "description": "(c) A signal on provider-error rate: window provider failures (from the LLM/embedding error telemetry — coordinate with US-34.4's wiring of [:loopctl, :llm, :blocked] / provider errors) and fire above a threshold.", "status": "pending" },
+    { "id": "AC-34.3.4", "description": "All three plug into the existing ScaleAlerts windowing + edge-fire + delivery path (scale_alerts.ex step/5); thresholds are config (mirroring the existing @thresholds). No change to the 3 existing signals.", "status": "pending" },
+    { "id": "AC-34.3.5", "description": "Additive + bounded-cardinality; a signal handler error never propagates into the emitting code path (defensive attach).", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-34.3.1", "name": "Repo queue_time p95 breach fires", "type": "integration",
+      "preconditions": ["ScaleAlerts started; delivery mocked"],
+      "steps": ["feed [:loopctl, :repo, :query] events with high queue_time above threshold over the window"],
+      "expected_results": ["the queue_time alert fires once on breach (edge-triggered), with the delivery client called"], "status": "pending" },
+    { "id": "TC-34.3.2", "name": "Oban discard/retry rate breach fires", "type": "integration",
+      "preconditions": ["ScaleAlerts started"],
+      "steps": ["emit [:oban, :job, :exception] events above the per-min threshold"],
+      "expected_results": ["the discard-rate alert fires on breach"], "status": "pending" },
+    { "id": "TC-34.3.3", "name": "provider-error rate breach fires", "type": "integration",
+      "preconditions": ["ScaleAlerts started"],
+      "steps": ["emit provider-error telemetry above threshold"],
+      "expected_results": ["the provider-error alert fires on breach"], "status": "pending" },
+    { "id": "TC-34.3.4", "name": "no false fire under threshold", "type": "integration",
+      "preconditions": ["ScaleAlerts started"],
+      "steps": ["feed sub-threshold events for all three"],
+      "expected_results": ["no alert fires"], "status": "pending" }
+  ],
+  "technical_notes": [
+    "File: lib/loopctl/telemetry/scale_alerts.ex — extend @thresholds + attach_handlers/1 + step/5; reuse the windowing/bucketing already there (heavy_read p95 is the template for (a)).",
+    "(b) attaches to Oban's [:oban, :job, :exception]/[:oban, :job, :stop] with state=discarded; window per-minute.",
+    "(c) coordinate with US-34.4 so the provider-error event is emitted+consumed once; do not double-count.",
+    "Config thresholds; delivery via the existing (US-34.5-hardened) path. Defensive handlers, bounded tags.",
+    "No Application.put_env in tests; drive via emitted telemetry + mocked delivery."
+  ],
+  "dependencies": ["US-34.1"],
+  "estimated_tokens": 340000
+}

--- a/docs/user_stories/epic_34_oban_observability/us_34.4.json
+++ b/docs/user_stories/epic_34_oban_observability/us_34.4.json
@@ -1,0 +1,47 @@
+{
+  "id": "US-34.4",
+  "title": "Wire emitted-but-dead telemetry events into exported metrics",
+  "epic": { "id": "epic_34", "name": "Oban Resilience, Retention & Observability" },
+  "priority": "medium",
+  "phase": "scalability",
+  "priority_note": "Several degradation signals are already emitted but terminate in no-ops — free observability that's currently thrown away.",
+  "background": {
+    "reference": "GH #349. Emitted-but-unconsumed telemetry: [:loopctl, :llm, :blocked] (llm.ex:264), [:loopctl, :embedding, :skipped_no_key] (article_embedding_worker.ex:144, memory_embedding_worker.ex:132), [:loopctl, :index_health, :invalid] (index_health.ex:103), plus [:loopctl, :secrets, :orphan_cleanup_failed], [:loopctl, :witness, :divergence]/:bootstrap_already_consumed, [:loopctl, :knowledge, :keyset_byte_truncated], [:loopctl, :memory_promotion, *] (promotion_telemetry.ex:48).",
+    "includes": "The producers already fire these events at the right moments; no metric or handler consumes them, so provider blocks, missing-key embedding skips, invalid HNSW indexes, and witness divergences are invisible to monitoring."
+  },
+  "story": {
+    "as_a": "loopctl operator",
+    "i_want_to": "export the already-emitted degradation telemetry events as Prometheus counters with bounded tags",
+    "so_that": "provider blocks, embedding skips, invalid indexes, and witness/secrets anomalies show up on dashboards instead of being silently dropped"
+  },
+  "rationale": "These events are the cheapest possible observability — the instrumentation already exists at the exact right code sites; only the metric definition is missing. Wiring them into ScaleMetrics.metrics/0 turns latent, discarded signals into live counters, and feeds US-34.3's provider-error alert.",
+  "acceptance_criteria": [
+    { "id": "AC-34.4.1", "description": "ScaleMetrics/metrics defines counters for at least: [:loopctl, :llm, :blocked], [:loopctl, :embedding, :skipped_no_key], [:loopctl, :index_health, :invalid]. Each is exported to Prometheus with BOUNDED tags (a small fixed label set — e.g. provider or reason — NEVER tenant_id/args/free-text).", "status": "pending" },
+    { "id": "AC-34.4.2", "description": "The additional dead events ([:loopctl, :secrets, :orphan_cleanup_failed], [:loopctl, :witness, :divergence]/:bootstrap_already_consumed, [:loopctl, :knowledge, :keyset_byte_truncated], [:loopctl, :memory_promotion, *]) are either wired similarly OR explicitly listed as out-of-scope with a reason (no silent omission).", "status": "pending" },
+    { "id": "AC-34.4.3", "description": "The [:loopctl, :llm, :blocked] (and any provider-error) counter is shaped so US-34.3's provider-error-rate alert can consume it without double-counting; coordinate the event/metric contract between the two stories.", "status": "pending" },
+    { "id": "AC-34.4.4", "description": "Purely additive; no producer code changes except (if needed) adding a bounded metadata tag to an emit site. A cardinality test asserts tags are bounded.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-34.4.1", "name": "llm.blocked increments a counter", "type": "unit",
+      "preconditions": ["metric attached"],
+      "steps": ["execute :telemetry.execute([:loopctl, :llm, :blocked], %{count: 1}, %{provider: \"anthropic\"})"],
+      "expected_results": ["counter defined in metrics/0; handler runs without error; bounded tags"], "status": "pending" },
+    { "id": "TC-34.4.2", "name": "embedding.skipped_no_key + index_health.invalid counters exist", "type": "unit",
+      "preconditions": [],
+      "steps": ["inspect metrics/0"],
+      "expected_results": ["counters defined for both events with bounded tags"], "status": "pending" },
+    { "id": "TC-34.4.3", "name": "no unbounded tag", "type": "unit",
+      "preconditions": [],
+      "steps": ["inspect the new metrics' :tags"],
+      "expected_results": ["no tenant_id / args / free-text tags"], "status": "pending" }
+  ],
+  "technical_notes": [
+    "File: lib/loopctl/telemetry/scale_metrics.ex (+ merged into LoopctlWeb.Telemetry.metrics/0).",
+    "Prefer Telemetry.Metrics.counter/sum with a small tag set; confirm each emit site's metadata carries a bounded label (add one if missing, keep it bounded).",
+    "Cardinality is the multi-tenant risk — test bounded tags for each.",
+    "Coordinate the llm.blocked/provider-error contract with US-34.3.",
+    "No Application.put_env in tests; drive via :telemetry.execute."
+  ],
+  "dependencies": [],
+  "estimated_tokens": 220000
+}

--- a/docs/user_stories/epic_34_oban_observability/us_34.5.json
+++ b/docs/user_stories/epic_34_oban_observability/us_34.5.json
@@ -1,0 +1,50 @@
+{
+  "id": "US-34.5",
+  "title": "Harden ScaleAlerts delivery: retry with backoff + periodic re-notify while a breach persists",
+  "epic": { "id": "epic_34", "name": "Oban Resilience, Retention & Observability" },
+  "priority": "medium",
+  "phase": "scalability",
+  "priority_note": "An alert that's dropped or fires exactly once is nearly as bad as no alert. fail-loud-on-missing-URL (US-32.4) is already done — this is the delivery reliability.",
+  "background": {
+    "reference": "GH #349. ScaleAlerts delivery (lib/loopctl/telemetry/scale_alerts.ex:415-443): synchronous in-process delivery_client().deliver(...); on {:error,_} it only logs :warning and returns :ok (435-441) — no retry, no Oban, no backoff. step/5 (380-395) is pure edge-trigger fire-once with debounce on sustained breach ('do not re-fire').",
+    "includes": "A single dropped webhook POST is lost forever, and a breach that persists for hours pages once at the edge and never again — so a still-firing incident goes quiet."
+  },
+  "story": {
+    "as_a": "loopctl operator",
+    "i_want_to": "have alert deliveries retry with backoff and re-notify periodically while a breach is still active",
+    "so_that": "a transient webhook failure doesn't silently drop an alert and a sustained incident keeps reminding me instead of going quiet after the first page"
+  },
+  "rationale": "The alert pipeline's last mile is its weakest: a best-effort synchronous POST that's logged-and-forgotten on failure, and a fire-once edge trigger. Both mean a real, ongoing incident can become invisible — the exact failure mode this epic exists to eliminate. Routing delivery through the existing Oban webhook-delivery path (with backoff) and adding a bounded periodic re-notify makes alerting durable and persistent without spamming.",
+  "acceptance_criteria": [
+    { "id": "AC-34.5.1", "description": "Alert delivery is retried with backoff on failure — preferably by enqueuing through the existing Oban webhook-delivery worker path (WebhookDeliveryWorker or equivalent) rather than the synchronous in-process POST, so a transient failure retries per Oban's backoff instead of being logged-and-dropped.", "status": "pending" },
+    { "id": "AC-34.5.2", "description": "While a breach remains active, the alert re-notifies on a bounded periodic interval (config, e.g. every N minutes) instead of firing exactly once — with a sane floor so it can't spam. On clearing below threshold it re-arms (and optionally sends a resolved notice).", "status": "pending" },
+    { "id": "AC-34.5.3", "description": "Backward compatible: the existing edge-fire semantics (fire on false→true) are preserved; this adds re-notify and durable delivery, not a behavior change to WHICH breaches fire. The 3 existing signals and the US-34.3 signals all benefit uniformly.", "status": "pending" },
+    { "id": "AC-34.5.4", "description": "The nil-URL / disabled paths remain safe (no delivery attempts; US-32.4 readiness guard unchanged). Delivery via the config-based delivery_client behaviour DI is preserved (mockable in tests).", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-34.5.1", "name": "failed delivery is retried (not dropped)", "type": "integration",
+      "preconditions": ["ScaleAlerts started; delivery client mocked to fail once then succeed (or an Oban job enqueued)"],
+      "steps": ["trigger a breach"],
+      "expected_results": ["delivery is retried/enqueued with backoff rather than logged-and-forgotten; eventually delivered"], "status": "pending" },
+    { "id": "TC-34.5.2", "name": "sustained breach re-notifies periodically", "type": "integration",
+      "preconditions": ["a breach held active across the re-notify interval"],
+      "steps": ["advance time past the re-notify interval while still breached"],
+      "expected_results": ["a second notification fires (bounded), not silence after the first"], "status": "pending" },
+    { "id": "TC-34.5.3", "name": "clears and re-arms below threshold", "type": "integration",
+      "preconditions": ["breach then recovery"],
+      "steps": ["breach, then drop below threshold"],
+      "expected_results": ["re-arms; a later breach fires again"], "status": "pending" },
+    { "id": "TC-34.5.4", "name": "disabled/nil-url attempts no delivery", "type": "unit",
+      "preconditions": ["scale_alerts enabled false OR url nil"],
+      "steps": ["trigger a breach condition"],
+      "expected_results": ["no delivery attempt; US-32.4 readiness behavior intact"], "status": "pending" }
+  ],
+  "technical_notes": [
+    "File: lib/loopctl/telemetry/scale_alerts.ex (delivery + step/5 re-notify state). Reuse Loopctl.Workers.WebhookDeliveryWorker (or the webhooks delivery behaviour) for durable retry/backoff.",
+    "Re-notify: track last-notified-at per signal in the alert state; re-fire only after the interval AND while still breached; floor to prevent spam.",
+    "Keep delivery behind the config delivery_client DI so tests mock it; no Application.put_env.",
+    "Do not change which breaches fire (edge semantics preserved); add durability + persistence."
+  ],
+  "dependencies": [],
+  "estimated_tokens": 300000
+}

--- a/docs/user_stories/epic_34_oban_observability/us_34.6.json
+++ b/docs/user_stories/epic_34_oban_observability/us_34.6.json
@@ -1,0 +1,47 @@
+{
+  "id": "US-34.6",
+  "title": "Bound GET /knowledge/ingestion-jobs: index the args->>'tenant_id' COUNT + route through HeavyRead with a statement_timeout",
+  "epic": { "id": "epic_34", "name": "Oban Resilience, Retention & Observability" },
+  "priority": "medium",
+  "phase": "scalability",
+  "priority_note": "An unbounded COUNT(*) over unindexed JSONB on the growing oban_jobs table, on the request path — a slow query that worsens with history.",
+  "background": {
+    "reference": "GH #349. LoopctlWeb.KnowledgeIngestionController.list_ingestion_jobs/2 (lib/loopctl_web/controllers/knowledge_ingestion_controller.ex:562-597): `from(j in \"oban_jobs\", where: worker == ContentIngestionWorker and args->>'tenant_id' = ^tenant_id)` then `select count(j.id) |> Repo.one` over ALL matching history (since_days defaults nil). No oban_jobs index exists (grep of priv/repo/migrations → none). Runs on Repo, no HeavyRead, no statement_timeout.",
+    "includes": "Every ingestion-jobs list call seq-scans oban_jobs filtering by a JSONB field with no supporting index and COUNTs the entire matching history — a per-request cost that grows unbounded as oban_jobs grows (bounded only by Pruner's 7-day terminal retention)."
+  },
+  "story": {
+    "as_a": "loopctl operator",
+    "i_want_to": "back the ingestion-jobs count with a supporting index and run it through HeavyRead with a statement_timeout",
+    "so_that": "the endpoint uses an index range scan with a hard time bound instead of an unbounded seq-scan COUNT that degrades as oban_jobs grows"
+  },
+  "rationale": "The endpoint's COUNT(*) over an unindexed JSONB predicate on the ever-growing oban_jobs table is a classic slow-query-on-the-request-path that gets worse over time and can tie up a connection. An expression/partial index matching the exact predicate turns it into a range scan, and routing through HeavyRead with a bounded statement_timeout caps the worst case so a heavy history can't stall a request pool.",
+  "acceptance_criteria": [
+    { "id": "AC-34.6.1", "description": "An online (CONCURRENTLY, @disable_ddl_transaction) expression/partial index supports the query predicate — e.g. an index on oban_jobs over ((args->>'tenant_id')) filtered to worker = 'Loopctl.Workers.ContentIngestionWorker' (partial), so both the filter and count use it. EXPLAIN shows an index scan, not a seq scan. (Alternatively, a dedicated ingestion_jobs projection table — but prefer the index for minimal blast radius.)", "status": "pending" },
+    { "id": "AC-34.6.2", "description": "The count/list query is routed through HeavyRead (or Repo) with a per-query SET LOCAL statement_timeout so a pathological count can't run unbounded; on timeout it fails closed with a clean error (not a 500 that leaks), or returns a bounded/approximate result documented as such.", "status": "pending" },
+    { "id": "AC-34.6.3", "description": "Tenant isolation preserved: the query still filters to the caller's tenant_id (via args->>'tenant_id' with the caller's tenant); no cross-tenant job leakage. pgbouncer-safe: statement_timeout is a per-query SET LOCAL, never a startup :parameter.", "status": "pending" },
+    { "id": "AC-34.6.4", "description": "Response shape/pagination unchanged (limit/offset + meta, no hard 50 cap — matching the existing tested contract); only the query cost characteristics change.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-34.6.1", "name": "ingestion-jobs list still returns the tenant's jobs, paginated", "type": "integration",
+      "preconditions": ["tenant = fixture(:tenant)", "several ContentIngestionWorker oban_jobs with args tenant_id = tenant.id"],
+      "steps": ["GET /api/v1/knowledge/ingestion-jobs with limit/offset"],
+      "expected_results": ["returns the tenant's jobs with correct pagination + meta; count reflects the tenant's jobs"], "status": "pending" },
+    { "id": "TC-34.6.2", "name": "tenant isolation", "type": "integration",
+      "preconditions": ["tenant_a and tenant_b each with ingestion jobs"],
+      "steps": ["GET ingestion-jobs as tenant_a"],
+      "expected_results": ["only tenant_a's jobs/count; tenant_b never appears"], "status": "pending" },
+    { "id": "TC-34.6.3", "name": "index supports the predicate", "type": "integration",
+      "preconditions": ["the partial/expression index migrated"],
+      "steps": ["EXPLAIN the count query (test asserts behavior parity; index usage is a planner concern verified via EXPLAIN in the migration/PR)"],
+      "expected_results": ["query returns correct counts; index exists"], "status": "pending" }
+  ],
+  "technical_notes": [
+    "Controller: lib/loopctl_web/controllers/knowledge_ingestion_controller.ex:562-597. Migration: new online migration (CONCURRENTLY, @disable_ddl_transaction, DROP INDEX CONCURRENTLY IF EXISTS before CREATE) adding the partial/expression index on oban_jobs.",
+    "Index note: oban_jobs is Oban-owned; a partial index on ((args->>'tenant_id')) WHERE worker='Loopctl.Workers.ContentIngestionWorker' is low-risk and reversible. Confirm it doesn't conflict with Oban's own indexes.",
+    "HeavyRead + SET LOCAL statement_timeout per query (pgbouncer-safe); the config_pgbouncer_safe_parameters guard must still pass.",
+    "Preserve the existing 'no hard 50 cap' pagination contract (there is a test for it).",
+    "This is the one migration in Epic 34 — keep it online; oban_jobs is a hot table."
+  ],
+  "dependencies": [],
+  "estimated_tokens": 280000
+}


### PR DESCRIPTION
Remediation of #349 (Epic 2, tracked #355). Lifeline/Pruner (#323) + US-32.4 fail-loud already done and excluded; US-33.1 telemetry gets its alert in US-34.3. 6 remaining stories: Oban gauges+orphan+Reindexer, health degraded path, 3 alert signals, wire dead telemetry, delivery retry/re-notify, ingestion-jobs COUNT hardening. Docs-only; standard implement→review→CI-merge loop; live system, smoke-gated.