### PR TITLE
feat(epic_34): US-34.4 wire emitted-but-dead telemetry events into ScaleMetrics

### DIFF
--- a/lib/loopctl/llm.ex
+++ b/lib/loopctl/llm.ex
@@ -263,7 +263,8 @@ defmodule Loopctl.Llm do
 
     :telemetry.execute([:loopctl, :llm, :blocked], %{count: 1}, %{
       tenant_id: tenant_id,
-      operation: operation
+      operation: operation,
+      provider: blocked_credential_provider(operation)
     })
 
     Audit.create_log_entry(tenant_id, %{
@@ -288,6 +289,14 @@ defmodule Loopctl.Llm do
   # (review MED #3). The structured audit already carries the exact operation.
   defp blocked_credential(:embedding), do: "embedding API key"
   defp blocked_credential(_anthropic_op), do: "Anthropic API key"
+
+  # US-34.4 (AC-34.4.4): the ONE bounded metadata tag added to this emit site — a
+  # `provider` label for the `[:loopctl, :llm, :blocked]` counter
+  # (`Loopctl.Telemetry.ScaleMetrics`). Mirrors `blocked_credential/1`'s existing
+  # bounded 2-way split (embedding vs Anthropic) rather than introducing a new
+  # dimension, so the label stays a fixed, small set.
+  defp blocked_credential_provider(:embedding), do: "embedding"
+  defp blocked_credential_provider(_anthropic_op), do: "anthropic"
 
   @doc """
   A safe view of the tenant's settings for API responses: the model choices,

--- a/lib/loopctl/telemetry/scale_metrics.ex
+++ b/lib/loopctl/telemetry/scale_metrics.ex
@@ -18,10 +18,18 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   `queue_time` (native time spent WAITING for a pooled connection) on every query
   telemetry event; before this branch only `heavy_read_repo.query.duration` was
   scraped, so there was no way to see where checkout contention lands between the
-  two pools. See "Per-pool checkout queue_time (US-33.1)" below. `scale_metrics/0`
-  now returns 7 metrics total.
+  two pools. See "Per-pool checkout queue_time (US-33.1)" below. US-34.4 adds TEN
+  more, purely-additive counters: several `:telemetry.execute/3` calls already fire
+  at the right code sites (LLM/embedding BYO-key blocks, a nightly index-health
+  check, secret-rotation cleanup failures, witness-header divergence, and the
+  Epic 29 memory-promotion pipeline) but had no `Telemetry.Metrics` definition
+  consuming them, so the signal terminated in a no-op handler-less event — invisible
+  to Prometheus/dashboards despite already being emitted. See "Wiring emitted-but-dead
+  events (US-34.4)" below for the full inventory, including the events deliberately
+  left OUT of scope with a cited reason. `scale_metrics/0` now returns 17 metrics
+  total.
 
-  ## The metrics (7 total)
+  ## The metrics (17 total)
 
     1. **Timeout / DB-error counter** — `loopctl.db.error.count`, keyed by
        `[:endpoint, :mapped_code]` (+ a cap-gated `:tenant_id`). `mapped_code`
@@ -48,6 +56,43 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
     7. **AdminRepo-pool checkout `queue_time` distribution** (US-33.1) —
        `loopctl.admin_repo.checkout.queue_time`, with a static `[:repo]` tag (no cap
        gate needed). Sourced from `[:loopctl, :admin_repo, :query]`.
+    8. **LLM/embedding blocked counter** (US-34.4, AC-34.4.1/.3) —
+       `loopctl.llm.blocked.count`, keyed by `[:operation, :provider]` (NEVER
+       `:tenant_id`). Sourced from `[:loopctl, :llm, :blocked]` (`Loopctl.Llm.record_blocked/2`).
+    9. **Embedding-skipped-no-key counter** (US-34.4, AC-34.4.1) —
+       `loopctl.embedding.skipped_no_key.count`, keyed by `[:source]` (`"article"` /
+       `"memory"`). Sourced from `[:loopctl, :embedding, :skipped_no_key]`
+       (`ArticleEmbeddingWorker` / `MemoryEmbeddingWorker`).
+    10. **Index-health-invalid counter** (US-34.4, AC-34.4.1) —
+        `loopctl.index_health.invalid.count`, keyed by `[:index, :purpose, :state]`
+        (all three bounded, fixed sets). Sourced from `[:loopctl, :index_health, :invalid]`
+        (`Loopctl.IndexHealth.emit/3`).
+    11. **Secret-orphan-cleanup-failed counter** (US-34.4, AC-34.4.2) —
+        `loopctl.secrets.orphan_cleanup_failed.count`, keyed by `[:op, :reason]` —
+        `reason` is CLASSIFIED into a bounded set (never the raw, potentially
+        free-text Fly API error term). Sourced from
+        `[:loopctl, :secrets, :orphan_cleanup_failed]` (`Loopctl.Tenants`).
+    12. **Witness-divergence counter** (US-34.4, AC-34.4.2) —
+        `loopctl.witness.divergence.count`, keyed by `[:reason]` ONLY (never
+        `:tenant_id`/`:position`, both unbounded). Sourced from
+        `[:loopctl, :witness, :divergence]` (`ValidateWitnessHeader.resync_required/5`).
+    13. **Witness-bootstrap-already-consumed counter** (US-34.4, AC-34.4.2) —
+        `loopctl.witness.bootstrap_already_consumed.count`, UNTAGGED (the only
+        metadata is `tenant_id`, which is never a label). Sourced from
+        `[:loopctl, :witness, :bootstrap_already_consumed]`.
+    14. **Memory-promotion-failed counter** (US-34.4, AC-34.4.2) —
+        `loopctl.memory_promotion.failed.count`, keyed by `[:stage]` (a bounded
+        3-value enum: `:compile`/`:persist`/`:enqueue`). Sourced from
+        `[:loopctl, :memory_promotion, :failed]`.
+    15. **Memory-promotion-degraded counter** (US-34.4, AC-34.4.2) —
+        `loopctl.memory_promotion.degraded.count`, UNTAGGED. Sourced from
+        `[:loopctl, :memory_promotion, :degraded]`.
+    16. **Memory-promotion-quota-exceeded counter** (US-34.4, AC-34.4.2) —
+        `loopctl.memory_promotion.quota_exceeded.count`, UNTAGGED. Sourced from
+        `[:loopctl, :memory_promotion, :quota_exceeded]`.
+    17. **Memory-promotion-budget-exceeded counter** (US-34.4, AC-34.4.2) —
+        `loopctl.memory_promotion.budget_exceeded.count`, UNTAGGED. Sourced from
+        `[:loopctl, :memory_promotion, :budget_exceeded]`.
 
   ## Bounded cardinality (AC-27.15.3) — the no-leak contract
 
@@ -85,6 +130,101 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   gated keeps the series shape stable AND pins the tenant dimension's cardinality to
   exactly 1 when over the cap. Below the cap the cardinality is bounded by the cap
   itself (≤ #{1000} by default).
+
+  ## Wiring emitted-but-dead events (US-34.4)
+
+  Producer code already fires `:telemetry.execute/3` at seven distinct code sites
+  (AC-34.4.2's full inventory below); this story does NOT change what is emitted
+  (with the two narrow, documented metadata additions noted per-event below) — it
+  is PURELY additive metric-definition work that gives each event a consumer.
+
+    * `[:loopctl, :llm, :blocked]` (metric 8) — `Loopctl.Llm.record_blocked/2`
+      already carried `tenant_id` + `operation`; this story adds ONE bounded
+      metadata key, `provider` (`"embedding"` or `"anthropic"`, derived from the
+      same 2-way split `blocked_credential/1` already uses), so the counter can be
+      windowed by provider. **IMPORTANT — this is NOT a provider-error signal.**
+      `record_blocked/2` fires ONLY when a tenant has no BYO API/embedding key
+      configured (a missing-credential CONFIG state, checked before any provider
+      call is made); `provider` here is the credential TYPE (`"embedding"` /
+      `"anthropic"`), not the LLM vendor. There is currently NO runtime
+      provider-error telemetry event anywhere in the codebase —
+      `Loopctl.Llm.ProviderError` only sanitizes error terms for logging/discard
+      reasons and emits nothing. **AC-34.4.3 coordination with US-34.3 (unwritten
+      as of this story)**: US-34.3's "provider-error rate" signal must NOT window
+      this counter as a proxy for provider throttling — a tenant that simply
+      never configured a key would inflate the signal (false paging on a
+      non-incident), while an actual 429/5xx/transport-error storm (key present,
+      so `llm.blocked` never fires at all) would go completely undetected — the
+      exact incident class this epic exists to catch. US-34.3 must instead either
+      (a) introduce its own genuine provider-error event (e.g. from the
+      transient branch of `Loopctl.Llm.permanent_provider_error?/1`) and window
+      THAT, or (b) if it chooses to consume `llm.blocked` anyway, scope its
+      language to mean "missing-key blocks" explicitly rather than "provider
+      errors". Should a future handler attach to `[:loopctl, :llm, :blocked]`
+      for the missing-key case specifically, it would do so independently via
+      telemetry fan-out (this counter's handler does not re-emit the event, so
+      no double-count) — but that remains a DIFFERENT signal than "provider
+      error" and must be named accordingly wherever it is consumed.
+    * `[:loopctl, :embedding, :skipped_no_key]` (metric 9) — both emit sites
+      (`ArticleEmbeddingWorker`, `MemoryEmbeddingWorker`) already carried
+      `tenant_id` + an unbounded id (`article_id`/`memory_id`); this story adds ONE
+      bounded metadata key, `source` (`"article"`/`"memory"`), at each site so the
+      counter can distinguish the two without ever tagging the id. **Known overlap
+      with metric 8**: both emit sites also call `Llm.record_blocked/2`
+      immediately afterward, so a single missing-embedding-key skip increments
+      BOTH `loopctl.embedding.skipped_no_key.count{source=...}` AND
+      `loopctl.llm.blocked.count{operation="embedding"}`. This is intentional —
+      the two counters answer different questions ("embedding work skipped" vs
+      "LLM operation blocked for a key") — but an operator building a single
+      "blocked operations" panel that sums across both series will double-count
+      this one condition; do not sum them without accounting for the overlap.
+    * `[:loopctl, :index_health, :invalid]` (metric 10) — wired AS-IS; `index`,
+      `purpose`, and `state` are already three bounded, fixed sets (no metadata
+      change needed).
+    * `[:loopctl, :secrets, :orphan_cleanup_failed]` (metric 11) — wired, but NOT
+      as-is: `reason` here is `{:error, term()}` from `Loopctl.Secrets.Behaviour`
+      and can carry a raw Fly GraphQL error payload (`{:fly_api_error, errors}` —
+      free text) or an arbitrary transport-error struct, so this story does NOT
+      trust it as a label directly. `secrets_orphan_cleanup_tags/1` CLASSIFIES it
+      into a small fixed set (`"fly_not_configured"`, `"http_error"`,
+      `"fly_api_error"`, `"old_value_unavailable"`, `"other"`) before it ever
+      reaches a tag — the same "mapped_code" classification precedent as the
+      original DB-error counter. `secret_name` (unbounded) is never tagged.
+    * `[:loopctl, :witness, :divergence]` (metric 12) — wired by `reason` ONLY
+      (`"prefix_mismatch"` / `"future_position"`, a genuinely fixed 2-value set);
+      `tenant_id` and `position` are dropped from the tag set (both unbounded).
+    * `[:loopctl, :witness, :bootstrap_already_consumed]` (metric 13) — wired
+      UNTAGGED. Its only metadata is `tenant_id`; rather than skip it, this story
+      counts total occurrences with zero labels (cardinality exactly 1) — still
+      useful trend data (how often fresh clients consume the one-time bootstrap
+      grace) without ever exposing the tenant dimension.
+    * `[:loopctl, :memory_promotion, *]` (`Loopctl.Memory.PromotionTelemetry`,
+      11 possible event names) — a SUBSET is wired (metrics 14-17): the four
+      DEGRADATION/failure signals an operator would actually want to alert on —
+      `:failed` (tagged by the bounded `:stage` enum, present on every `:failed`
+      emission), `:degraded`, `:quota_exceeded`, and `:budget_exceeded` (all three
+      untagged — their only metadata besides the `:count` measurement is
+      per-tenant/session identifiers, which are never tagged). **Explicitly
+      OUT OF SCOPE, no silent omission**: `:swept`, `:skipped`, `:compiled`,
+      `:promoted`, `:superseded`, `:gated_out`, and `:eval` are routine
+      steady-state VOLUME/quality telemetry, not degradation signals — wiring all
+      eleven sub-events would triple this module's metric count for observability
+      value this story's scope does not need (a future story can extend the
+      subset; the events remain available via `:telemetry.attach` in the
+      meantime).
+    * `[:loopctl, :knowledge, :keyset_byte_truncated]` — **explicitly OUT OF
+      SCOPE, no silent omission**. Its ONLY metadata is `tenant_id`; there is no
+      bounded dimension available to key a useful counter by (unlike
+      `bootstrap_already_consumed` above, byte-truncation volume without ANY
+      breakdown is not actionable trend data on its own), so wiring it would add
+      a metric definition purely to avoid an omission rather than to serve
+      observability. Cites the bounded-cardinality rule (AC-27.15.3): a metric
+      whose only non-fixed dimension is `tenant_id` either drops the dimension
+      (as `bootstrap_already_consumed` does, where the RAW event-name volume is
+      itself the signal an operator watches) or stays unwired; this event's
+      truncation volume is expected to correlate with the already-instrumented
+      `loopctl.knowledge.vector_search.under_fill.count`/hybrid-provenance
+      signals rather than needing its own series.
   """
 
   import Telemetry.Metrics
@@ -103,9 +243,11 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   @default_tenant_label_cap 1_000
 
   @doc """
-  All 7 scale metrics: the original US-27.15 trio, #297's semantic-fallback
-  counter, US-31.2's hybrid-provenance counter, and US-33.1's two per-pool
-  checkout `queue_time` distributions. Appended to `LoopctlWeb.Telemetry.metrics/0`.
+  All 17 scale metrics: the original US-27.15 trio, #297's semantic-fallback
+  counter, US-31.2's hybrid-provenance counter, US-33.1's two per-pool checkout
+  `queue_time` distributions, and US-34.4's ten emitted-but-dead-event counters
+  (LLM/embedding-blocked, index-health, secrets/witness/memory-promotion
+  degradation signals). Appended to `LoopctlWeb.Telemetry.metrics/0`.
   """
   @spec scale_metrics() :: [Telemetry.Metrics.t()]
   def scale_metrics do
@@ -209,6 +351,119 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
         reporter_options: [
           buckets: [1, 5, 10, 25, 50, 100, 250, 500, 1_000]
         ]
+      ),
+
+      # 8. LLM/embedding blocked counter (US-34.4, AC-34.4.1/.3). `operation` is the
+      #    existing bounded 4-value enum (`Loopctl.Llm.operation()`); `provider` is the
+      #    ONE bounded metadata tag this story adds at the `record_blocked/2` emit
+      #    site. NEVER `tenant_id`. NOTE: this is a MISSING-BYO-KEY config gate, NOT
+      #    a runtime provider-error (429/5xx/transport) signal — no such event exists
+      #    today. See moduledoc "AC-34.4.3 coordination" for why US-34.3 must not
+      #    window this counter as a provider-error-rate proxy.
+      counter("loopctl.llm.blocked.count",
+        event_name: [:loopctl, :llm, :blocked],
+        measurement: :count,
+        description:
+          "Tenant LLM/embedding operations blocked for a missing BYO key, by operation and provider.",
+        tags: [:operation, :provider],
+        tag_values: &llm_blocked_tags/1
+      ),
+
+      # 9. Embedding-skipped-no-key counter (US-34.4, AC-34.4.1). `source`
+      #    ("article"/"memory") is the ONE bounded metadata tag this story adds at
+      #    both emit sites; the unbounded `article_id`/`memory_id` is never tagged.
+      counter("loopctl.embedding.skipped_no_key.count",
+        event_name: [:loopctl, :embedding, :skipped_no_key],
+        measurement: :count,
+        description:
+          "Article/memory embedding generation skipped for a missing BYO embedding key, by source.",
+        tags: [:source],
+        tag_values: &embedding_skipped_tags/1
+      ),
+
+      # 10. Index-health-invalid counter (US-34.4, AC-34.4.1). `index`, `purpose`,
+      #     and `state` are already three bounded, fixed sets in `Loopctl.IndexHealth`
+      #     — wired as-is, no metadata change needed.
+      counter("loopctl.index_health.invalid.count",
+        event_name: [:loopctl, :index_health, :invalid],
+        measurement: :count,
+        description:
+          "Index-health check results, by index, purpose, and state (valid/invalid/missing).",
+        tags: [:index, :purpose, :state],
+        tag_values: &index_health_tags/1
+      ),
+
+      # 11. Secret-orphan-cleanup-failed counter (US-34.4, AC-34.4.2). `reason` is
+      #     CLASSIFIED into a bounded set (never the raw `{:error, term()}`, which
+      #     can carry a free-text Fly API error payload) — see
+      #     `secrets_orphan_cleanup_tags/1`. `secret_name` is never tagged.
+      counter("loopctl.secrets.orphan_cleanup_failed.count",
+        event_name: [:loopctl, :secrets, :orphan_cleanup_failed],
+        measurement: :count,
+        description:
+          "Compensating audit-key secret delete/restore failures, by op and classified reason.",
+        tags: [:op, :reason],
+        tag_values: &secrets_orphan_cleanup_tags/1
+      ),
+
+      # 12. Witness-divergence counter (US-34.4, AC-34.4.2). `reason` is a genuinely
+      #     fixed 2-value set (`"prefix_mismatch"`/`"future_position"`); `tenant_id`
+      #     and `position` are dropped (both unbounded).
+      counter("loopctl.witness.divergence.count",
+        event_name: [:loopctl, :witness, :divergence],
+        measurement: :count,
+        description:
+          "Client-reported witness-header divergence (resync, not custody halt), by reason.",
+        tags: [:reason],
+        tag_values: &witness_divergence_tags/1
+      ),
+
+      # 13. Witness-bootstrap-already-consumed counter (US-34.4, AC-34.4.2).
+      #     UNTAGGED — the only metadata is `tenant_id`, which is never a label; the
+      #     raw occurrence count is still useful trend data.
+      counter("loopctl.witness.bootstrap_already_consumed.count",
+        event_name: [:loopctl, :witness, :bootstrap_already_consumed],
+        measurement: :count,
+        description: "One-time witness bootstrap grace already consumed (412, retryable).",
+        tags: []
+      ),
+
+      # 14. Memory-promotion-failed counter (US-34.4, AC-34.4.2). `stage` is a
+      #     bounded 3-value enum (`:compile`/`:persist`/`:enqueue`) present on every
+      #     `:failed` emission.
+      counter("loopctl.memory_promotion.failed.count",
+        event_name: [:loopctl, :memory_promotion, :failed],
+        measurement: :count,
+        description: "Memory-promotion compile/persist/enqueue failures, by stage.",
+        tags: [:stage],
+        tag_values: &memory_promotion_failed_tags/1
+      ),
+
+      # 15. Memory-promotion-degraded counter (US-34.4, AC-34.4.2). UNTAGGED — only
+      #     per-tenant/session metadata besides the measurement, none of it bounded.
+      counter("loopctl.memory_promotion.degraded.count",
+        event_name: [:loopctl, :memory_promotion, :degraded],
+        measurement: :count,
+        description: "Memory-promotion runs snoozed for degraded (unavailable) embeddings.",
+        tags: []
+      ),
+
+      # 16. Memory-promotion-quota-exceeded counter (US-34.4, AC-34.4.2). UNTAGGED.
+      counter("loopctl.memory_promotion.quota_exceeded.count",
+        event_name: [:loopctl, :memory_promotion, :quota_exceeded],
+        measurement: :count,
+        description:
+          "Memory-promotion runs terminally discarded for hitting the subject memory quota.",
+        tags: []
+      ),
+
+      # 17. Memory-promotion-budget-exceeded counter (US-34.4, AC-34.4.2). UNTAGGED.
+      counter("loopctl.memory_promotion.budget_exceeded.count",
+        event_name: [:loopctl, :memory_promotion, :budget_exceeded],
+        measurement: :count,
+        description:
+          "Memory-promotion enqueues refused for hitting the tenant compiles/hour budget.",
+        tags: []
       )
     ]
   end
@@ -290,6 +545,97 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   """
   @spec queue_time_tags_admin_repo(map()) :: map()
   def queue_time_tags_admin_repo(_metadata), do: %{repo: "admin_repo"}
+
+  @doc """
+  `tag_values` for the LLM/embedding blocked counter (US-34.4). Returns ONLY
+  `operation` (`Loopctl.Llm`'s existing bounded 4-value enum) and `provider`
+  (the ONE bounded metadata tag this story adds at the `Loopctl.Llm.record_blocked/2`
+  emit site) — NEVER `tenant_id`, even if one leaks into metadata. Both default to
+  `"unknown"` so a direct `:telemetry.execute/3` missing either key (e.g. TC-34.4.1)
+  never raises and never emits a blank label.
+  """
+  @spec llm_blocked_tags(map()) :: map()
+  def llm_blocked_tags(metadata) do
+    %{
+      operation: Map.get(metadata, :operation) || "unknown",
+      provider: Map.get(metadata, :provider) || "unknown"
+    }
+  end
+
+  @doc """
+  `tag_values` for the embedding-skipped-no-key counter (US-34.4). Returns ONLY the
+  bounded `source` label (`"article"`/`"memory"`, the ONE bounded metadata tag this
+  story adds at both emit sites) — NEVER the unbounded `article_id`/`memory_id`,
+  and NEVER `tenant_id`. Defaults a missing `source` to `"unknown"`.
+  """
+  @spec embedding_skipped_tags(map()) :: map()
+  def embedding_skipped_tags(metadata) do
+    %{source: Map.get(metadata, :source) || "unknown"}
+  end
+
+  @doc """
+  `tag_values` for the index-health-invalid counter (US-34.4). `index`, `purpose`,
+  and `state` are already three bounded, fixed sets in `Loopctl.IndexHealth` — this
+  is wired as-is (no metadata change), defaulting any missing key to `"unknown"`.
+  """
+  @spec index_health_tags(map()) :: map()
+  def index_health_tags(metadata) do
+    %{
+      index: Map.get(metadata, :index) || "unknown",
+      purpose: Map.get(metadata, :purpose) || "unknown",
+      state: Map.get(metadata, :state) || "unknown"
+    }
+  end
+
+  @doc """
+  `tag_values` for the secret-orphan-cleanup-failed counter (US-34.4). `op` is
+  normalized to the bounded `:delete`/`:restore` set. `reason` is CLASSIFIED (never
+  passed through raw) — `Loopctl.Secrets.Behaviour`'s `{:error, term()}` can carry a
+  free-text Fly GraphQL error payload (`{:fly_api_error, errors}`) or an arbitrary
+  transport-error struct, so `secrets_reason_class/1` collapses anything outside
+  the known bounded shapes to `"other"` rather than ever emitting raw error content
+  as a label (the same "mapped_code" classification precedent as the DB-error
+  counter). `secret_name` is never tagged (unbounded).
+  """
+  @spec secrets_orphan_cleanup_tags(map()) :: map()
+  def secrets_orphan_cleanup_tags(metadata) do
+    %{
+      op: normalize_secrets_op(Map.get(metadata, :op)),
+      reason: secrets_reason_class(Map.get(metadata, :reason))
+    }
+  end
+
+  defp normalize_secrets_op(op) when op in [:delete, :restore], do: op
+  defp normalize_secrets_op(_other), do: :unknown
+
+  defp secrets_reason_class(:fly_not_configured), do: "fly_not_configured"
+  defp secrets_reason_class(:old_value_unavailable), do: "old_value_unavailable"
+  defp secrets_reason_class({:http_error, _status}), do: "http_error"
+  defp secrets_reason_class({:fly_api_error, _errors}), do: "fly_api_error"
+  defp secrets_reason_class(nil), do: "unknown"
+  defp secrets_reason_class(_other), do: "other"
+
+  @doc """
+  `tag_values` for the witness-divergence counter (US-34.4). Returns ONLY the
+  bounded `reason` label (`"prefix_mismatch"`/`"future_position"`, a genuinely
+  fixed 2-value set) — NEVER `tenant_id`/`position` (both unbounded). Defaults a
+  missing reason to `"unknown"`.
+  """
+  @spec witness_divergence_tags(map()) :: map()
+  def witness_divergence_tags(metadata) do
+    %{reason: Map.get(metadata, :reason) || "unknown"}
+  end
+
+  @doc """
+  `tag_values` for the memory-promotion-failed counter (US-34.4). Returns ONLY the
+  bounded `stage` label (`:compile`/`:persist`/`:enqueue`, present on every
+  `:failed` emission) — NEVER `tenant_id`/`subject_id`/`session_id`. Defaults a
+  missing stage to `"unknown"`.
+  """
+  @spec memory_promotion_failed_tags(map()) :: map()
+  def memory_promotion_failed_tags(metadata) do
+    %{stage: Map.get(metadata, :stage) || "unknown"}
+  end
 
   # The cap gate read on the hot path: a lock-free O(1) persistent_term lookup,
   # defaulting to `false` (aggregate) if unseeded — an un-warmed boot can never emit

--- a/lib/loopctl/workers/article_embedding_worker.ex
+++ b/lib/loopctl/workers/article_embedding_worker.ex
@@ -143,7 +143,11 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
     :telemetry.execute(
       [:loopctl, :embedding, :skipped_no_key],
       %{count: 1},
-      %{tenant_id: tenant_id, article_id: article_id}
+      # `source: "article"` is the ONE bounded metadata tag US-34.4 (AC-34.4.4) adds at
+      # this emit site — lets the `loopctl.embedding.skipped_no_key.count` counter
+      # (`Loopctl.Telemetry.ScaleMetrics`) distinguish article vs memory skips without
+      # tagging the unbounded `article_id`.
+      %{tenant_id: tenant_id, article_id: article_id, source: "article"}
     )
 
     Llm.record_blocked(tenant_id, :embedding)

--- a/lib/loopctl/workers/memory_embedding_worker.ex
+++ b/lib/loopctl/workers/memory_embedding_worker.ex
@@ -131,7 +131,11 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorker do
     :telemetry.execute(
       [:loopctl, :embedding, :skipped_no_key],
       %{count: 1},
-      %{tenant_id: tenant_id, memory_id: memory_id}
+      # `source: "memory"` is the ONE bounded metadata tag US-34.4 (AC-34.4.4) adds at
+      # this emit site — mirrors `ArticleEmbeddingWorker`'s addition so the
+      # `loopctl.embedding.skipped_no_key.count` counter can distinguish article vs
+      # memory skips without tagging the unbounded `memory_id`.
+      %{tenant_id: tenant_id, memory_id: memory_id, source: "memory"}
     )
 
     Llm.record_blocked(tenant_id, :embedding)

--- a/test/loopctl/telemetry/scale_metrics_test.exs
+++ b/test/loopctl/telemetry/scale_metrics_test.exs
@@ -19,12 +19,19 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
   defs.
 
   Mostly pure metric-definition / `tag_values` inspection — no DB. The US-33.1
-  queue_time "reporter round-trip" describe is the one exception: it boots a REAL,
-  privately-named `TelemetryMetricsPrometheus.Core` instance (never the app's
-  `:9568`-bound singleton) to prove the definitions/`tag_values`/measurement wiring
-  actually record and scrape correctly, rather than asserting `:telemetry.execute/3 ==
-  :ok` against zero attached handlers (which the framework guarantees regardless of
-  whether the code under test is correct).
+  queue_time "reporter round-trip" describe (and the US-34.4 one below it) are the
+  exceptions: they boot a REAL, privately-named `TelemetryMetricsPrometheus.Core`
+  instance (never the app's `:9568`-bound singleton) to prove the
+  definitions/`tag_values`/measurement wiring actually record and scrape correctly,
+  rather than asserting `:telemetry.execute/3 == :ok` against zero attached
+  handlers (which the framework guarantees regardless of whether the code under
+  test is correct).
+
+  US-34.4 adds ten counters wiring emitted-but-dead events (LLM/embedding-blocked,
+  index-health, secrets/witness/memory-promotion degradation signals) into
+  Prometheus — see `@allowed_tags`/`@scale_metric_names` below and
+  `Loopctl.Telemetry.ScaleMetrics`'s moduledoc "Wiring emitted-but-dead events" for
+  the full inventory, including the events deliberately left out of scope.
 
   `async: false` (R2 review): the cap-gate tests MUTATE the process-global
   `:persistent_term` gate (`{ScaleMetrics, :tenant_label?}`), which is shared across the
@@ -43,17 +50,32 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
     "loopctl.knowledge.semantic_fallback.count",
     "loopctl.knowledge.hybrid_provenance.count",
     "loopctl.repo.checkout.queue_time",
-    "loopctl.admin_repo.checkout.queue_time"
+    "loopctl.admin_repo.checkout.queue_time",
+    "loopctl.llm.blocked.count",
+    "loopctl.embedding.skipped_no_key.count",
+    "loopctl.index_health.invalid.count",
+    "loopctl.secrets.orphan_cleanup_failed.count",
+    "loopctl.witness.divergence.count",
+    "loopctl.witness.bootstrap_already_consumed.count",
+    "loopctl.memory_promotion.failed.count",
+    "loopctl.memory_promotion.degraded.count",
+    "loopctl.memory_promotion.quota_exceeded.count",
+    "loopctl.memory_promotion.budget_exceeded.count"
   ]
 
   # The ONLY labels any scale metric may ever carry (AC-27.15.3). Anything outside this
   # set — especially an unbounded `:article_id` or a raw vector/body — is a hard fail.
-  # `:reason` (#297 semantic-fallback counter) is a BOUNDED, sanitized tag set (never a
-  # key/body/query), so it is a safe dimension. `:provenance` (`"curated"`/`"retrieved"`)
-  # and `:hit` (`true`/`false`) — US-31.2's hybrid-provenance counter — are likewise
-  # small, fixed-cardinality dimensions. `:repo` (US-33.1) is a static, fixed 2-value
-  # tag ("repo"/"admin_repo") — the repo identity is encoded in the event name, not
-  # read from metadata.
+  # `:reason` (#297 semantic-fallback counter; US-34.4's witness-divergence counter) is
+  # a BOUNDED, sanitized tag set (never a key/body/query), so it is a safe dimension.
+  # `:provenance` (`"curated"`/`"retrieved"`) and `:hit` (`true`/`false`) — US-31.2's
+  # hybrid-provenance counter — are likewise small, fixed-cardinality dimensions.
+  # `:repo` (US-33.1) is a static, fixed 2-value tag ("repo"/"admin_repo") — the repo
+  # identity is encoded in the event name, not read from metadata. US-34.4 adds:
+  # `:operation`/`:provider` (llm.blocked — bounded 4-value op enum + 2-value
+  # provider), `:source` (embedding.skipped_no_key — "article"/"memory"), `:index`/
+  # `:purpose`/`:state` (index_health.invalid — three bounded fixed sets), `:op`
+  # (secrets.orphan_cleanup_failed — normalized `:delete`/`:restore`/`:unknown`), and
+  # `:stage` (memory_promotion.failed — bounded `:compile`/`:persist`/`:enqueue`).
   @allowed_tags MapSet.new([
                   :endpoint,
                   :mapped_code,
@@ -61,7 +83,15 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
                   :reason,
                   :provenance,
                   :hit,
-                  :repo
+                  :repo,
+                  :operation,
+                  :provider,
+                  :source,
+                  :index,
+                  :purpose,
+                  :state,
+                  :op,
+                  :stage
                 ])
 
   defp scale_metrics, do: ScaleMetrics.scale_metrics()
@@ -433,8 +463,331 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
     end
   end
 
+  describe "llm.blocked counter (US-34.4, AC-34.4.1, TC-34.4.1)" do
+    test "the counter is defined, tagged by operation and provider only" do
+      counter = metric("loopctl.llm.blocked.count")
+
+      assert %Telemetry.Metrics.Counter{} = counter
+      assert counter.event_name == [:loopctl, :llm, :blocked]
+      assert MapSet.new(counter.tags) == MapSet.new([:operation, :provider])
+      refute :tenant_id in counter.tags
+    end
+
+    test "llm.blocked increments a counter (TC-34.4.1): :telemetry.execute runs the handler without error" do
+      reporter_name = :"llm_blocked_test_#{System.unique_integer([:positive])}"
+      counter = metric("loopctl.llm.blocked.count")
+
+      pid =
+        start_supervised!(
+          {TelemetryMetricsPrometheus.Core,
+           [metrics: [counter], name: reporter_name, start_async: false]}
+        )
+
+      :telemetry.execute([:loopctl, :llm, :blocked], %{count: 1}, %{provider: "anthropic"})
+
+      scrape = TelemetryMetricsPrometheus.Core.scrape(reporter_name)
+
+      assert scrape =~
+               ~s(loopctl_llm_blocked_count{operation="unknown",provider="anthropic"} 1)
+
+      assert Process.alive?(pid)
+    end
+
+    test "llm_blocked_tags/1 defaults missing operation/provider to \"unknown\", never tenant_id" do
+      assert ScaleMetrics.llm_blocked_tags(%{}) == %{operation: "unknown", provider: "unknown"}
+
+      assert ScaleMetrics.llm_blocked_tags(%{operation: :embedding, provider: "embedding"}) == %{
+               operation: :embedding,
+               provider: "embedding"
+             }
+
+      tags = ScaleMetrics.llm_blocked_tags(%{operation: :extraction, tenant_id: "t-1"})
+      refute Map.has_key?(tags, :tenant_id)
+    end
+  end
+
+  describe "embedding.skipped_no_key counter (US-34.4, AC-34.4.1, TC-34.4.2)" do
+    test "the counter is defined, tagged by source only" do
+      counter = metric("loopctl.embedding.skipped_no_key.count")
+
+      assert %Telemetry.Metrics.Counter{} = counter
+      assert counter.event_name == [:loopctl, :embedding, :skipped_no_key]
+      assert counter.tags == [:source]
+    end
+
+    test "embedding_skipped_tags/1 defaults a missing source to \"unknown\", never tags ids/tenant_id" do
+      assert ScaleMetrics.embedding_skipped_tags(%{}) == %{source: "unknown"}
+      assert ScaleMetrics.embedding_skipped_tags(%{source: "article"}) == %{source: "article"}
+
+      tags =
+        ScaleMetrics.embedding_skipped_tags(%{
+          source: "memory",
+          tenant_id: "t-1",
+          memory_id: "m-1"
+        })
+
+      assert tags == %{source: "memory"}
+    end
+  end
+
+  describe "index_health.invalid counter (US-34.4, AC-34.4.1, TC-34.4.2)" do
+    test "the counter is defined, tagged by index/purpose/state" do
+      counter = metric("loopctl.index_health.invalid.count")
+
+      assert %Telemetry.Metrics.Counter{} = counter
+      assert counter.event_name == [:loopctl, :index_health, :invalid]
+      assert MapSet.new(counter.tags) == MapSet.new([:index, :purpose, :state])
+    end
+
+    test "index_health_tags/1 passes through present keys and defaults missing ones to \"unknown\"" do
+      assert ScaleMetrics.index_health_tags(%{
+               index: "articles_embedding_idx",
+               purpose: "vector_search",
+               state: :invalid
+             }) == %{index: "articles_embedding_idx", purpose: "vector_search", state: :invalid}
+
+      assert ScaleMetrics.index_health_tags(%{}) == %{
+               index: "unknown",
+               purpose: "unknown",
+               state: "unknown"
+             }
+    end
+  end
+
+  describe "secrets.orphan_cleanup_failed counter (US-34.4, AC-34.4.2)" do
+    test "the counter is defined, tagged by op and reason only — never secret_name" do
+      counter = metric("loopctl.secrets.orphan_cleanup_failed.count")
+
+      assert %Telemetry.Metrics.Counter{} = counter
+      assert counter.event_name == [:loopctl, :secrets, :orphan_cleanup_failed]
+      assert MapSet.new(counter.tags) == MapSet.new([:op, :reason])
+      refute :secret_name in counter.tags
+    end
+
+    test "secrets_orphan_cleanup_tags/1 normalizes op and CLASSIFIES reason (never raw free-text)" do
+      assert ScaleMetrics.secrets_orphan_cleanup_tags(%{
+               op: :restore,
+               reason: :old_value_unavailable
+             }) == %{op: :restore, reason: "old_value_unavailable"}
+
+      assert ScaleMetrics.secrets_orphan_cleanup_tags(%{op: :delete, reason: :fly_not_configured}) ==
+               %{op: :delete, reason: "fly_not_configured"}
+
+      assert ScaleMetrics.secrets_orphan_cleanup_tags(%{op: :delete, reason: {:http_error, 503}}) ==
+               %{op: :delete, reason: "http_error"}
+
+      # A raw Fly GraphQL error payload is free-text — classified to a bounded
+      # sentinel, never passed through as a label.
+      assert ScaleMetrics.secrets_orphan_cleanup_tags(%{
+               op: :restore,
+               reason: {:fly_api_error, [%{"message" => "arbitrary free text from Fly"}]}
+             }) == %{op: :restore, reason: "fly_api_error"}
+
+      # An unrecognized/unbounded shape (e.g. a raw transport-error struct) still
+      # collapses to the bounded "other" sentinel rather than ever leaking through.
+      assert ScaleMetrics.secrets_orphan_cleanup_tags(%{
+               op: :delete,
+               reason: %{unexpected: "shape"}
+             }) == %{op: :delete, reason: "other"}
+
+      assert ScaleMetrics.secrets_orphan_cleanup_tags(%{}) == %{op: :unknown, reason: "unknown"}
+
+      # secret_name is never present in the returned tags even if it leaks into metadata.
+      tags =
+        ScaleMetrics.secrets_orphan_cleanup_tags(%{
+          op: :delete,
+          reason: :fly_not_configured,
+          secret_name: "tenant_audit_key_123"
+        })
+
+      refute Map.has_key?(tags, :secret_name)
+    end
+  end
+
+  describe "witness.divergence counter (US-34.4, AC-34.4.2)" do
+    test "the counter is defined, tagged by reason ONLY — never tenant_id/position" do
+      counter = metric("loopctl.witness.divergence.count")
+
+      assert %Telemetry.Metrics.Counter{} = counter
+      assert counter.event_name == [:loopctl, :witness, :divergence]
+      assert counter.tags == [:reason]
+    end
+
+    test "witness_divergence_tags/1 defaults a missing reason to \"unknown\", never tags tenant_id/position" do
+      assert ScaleMetrics.witness_divergence_tags(%{reason: "prefix_mismatch"}) == %{
+               reason: "prefix_mismatch"
+             }
+
+      assert ScaleMetrics.witness_divergence_tags(%{}) == %{reason: "unknown"}
+
+      tags =
+        ScaleMetrics.witness_divergence_tags(%{
+          reason: "future_position",
+          tenant_id: "t-1",
+          position: 42
+        })
+
+      assert tags == %{reason: "future_position"}
+    end
+  end
+
+  describe "witness.bootstrap_already_consumed counter (US-34.4, AC-34.4.2)" do
+    test "the counter is defined, UNTAGGED — its only metadata (tenant_id) is never a label" do
+      counter = metric("loopctl.witness.bootstrap_already_consumed.count")
+
+      assert %Telemetry.Metrics.Counter{} = counter
+      assert counter.event_name == [:loopctl, :witness, :bootstrap_already_consumed]
+      assert counter.tags == []
+    end
+  end
+
+  describe "memory_promotion.{failed,degraded,quota_exceeded,budget_exceeded} counters (US-34.4, AC-34.4.2)" do
+    test "the :failed counter is tagged by :stage ONLY" do
+      counter = metric("loopctl.memory_promotion.failed.count")
+
+      assert %Telemetry.Metrics.Counter{} = counter
+      assert counter.event_name == [:loopctl, :memory_promotion, :failed]
+      assert counter.tags == [:stage]
+    end
+
+    test "the :degraded, :quota_exceeded, and :budget_exceeded counters are UNTAGGED" do
+      for {name, event} <- [
+            {"loopctl.memory_promotion.degraded.count", [:loopctl, :memory_promotion, :degraded]},
+            {"loopctl.memory_promotion.quota_exceeded.count",
+             [:loopctl, :memory_promotion, :quota_exceeded]},
+            {"loopctl.memory_promotion.budget_exceeded.count",
+             [:loopctl, :memory_promotion, :budget_exceeded]}
+          ] do
+        counter = metric(name)
+
+        assert %Telemetry.Metrics.Counter{} = counter
+        assert counter.event_name == event
+        assert counter.tags == []
+      end
+    end
+
+    test "memory_promotion_failed_tags/1 defaults a missing stage to \"unknown\", never tags tenant_id" do
+      assert ScaleMetrics.memory_promotion_failed_tags(%{stage: :compile}) == %{stage: :compile}
+      assert ScaleMetrics.memory_promotion_failed_tags(%{}) == %{stage: "unknown"}
+
+      tags =
+        ScaleMetrics.memory_promotion_failed_tags(%{
+          stage: :enqueue,
+          tenant_id: "t-1",
+          subject_id: "s-1",
+          session_id: "sess-1"
+        })
+
+      assert tags == %{stage: :enqueue}
+    end
+  end
+
+  describe "US-34.4 reporter round-trip — real Prometheus scrape, not a no-handler no-op" do
+    setup do
+      reporter_name = :"scale_metrics_us_34_4_test_#{System.unique_integer([:positive])}"
+
+      metrics = [
+        metric("loopctl.embedding.skipped_no_key.count"),
+        metric("loopctl.index_health.invalid.count"),
+        metric("loopctl.secrets.orphan_cleanup_failed.count"),
+        metric("loopctl.witness.divergence.count"),
+        metric("loopctl.witness.bootstrap_already_consumed.count"),
+        metric("loopctl.memory_promotion.failed.count"),
+        metric("loopctl.memory_promotion.degraded.count"),
+        metric("loopctl.memory_promotion.quota_exceeded.count"),
+        metric("loopctl.memory_promotion.budget_exceeded.count")
+      ]
+
+      pid =
+        start_supervised!(
+          {TelemetryMetricsPrometheus.Core,
+           [metrics: metrics, name: reporter_name, start_async: false]}
+        )
+
+      %{reporter: reporter_name, reporter_pid: pid}
+    end
+
+    test "each new counter records and scrapes end to end", %{
+      reporter: reporter,
+      reporter_pid: pid
+    } do
+      :telemetry.execute(
+        [:loopctl, :embedding, :skipped_no_key],
+        %{count: 1},
+        %{tenant_id: "t-1", article_id: "a-1", source: "article"}
+      )
+
+      :telemetry.execute(
+        [:loopctl, :index_health, :invalid],
+        %{count: 1},
+        %{index: "articles_embedding_idx", purpose: "vector_search", state: :invalid}
+      )
+
+      :telemetry.execute(
+        [:loopctl, :secrets, :orphan_cleanup_failed],
+        %{count: 1},
+        %{op: :restore, secret_name: "k", reason: :old_value_unavailable}
+      )
+
+      :telemetry.execute(
+        [:loopctl, :witness, :divergence],
+        %{count: 1},
+        %{tenant_id: "t-1", position: 1, reason: "prefix_mismatch"}
+      )
+
+      :telemetry.execute(
+        [:loopctl, :witness, :bootstrap_already_consumed],
+        %{count: 1},
+        %{tenant_id: "t-1"}
+      )
+
+      :telemetry.execute(
+        [:loopctl, :memory_promotion, :failed],
+        %{count: 1},
+        %{tenant_id: "t-1", subject_id: "s-1", session_id: "sess-1", stage: :compile}
+      )
+
+      :telemetry.execute(
+        [:loopctl, :memory_promotion, :degraded],
+        %{count: 1},
+        %{tenant_id: "t-1", subject_id: "s-1", session_id: "sess-1"}
+      )
+
+      :telemetry.execute(
+        [:loopctl, :memory_promotion, :quota_exceeded],
+        %{count: 1},
+        %{tenant_id: "t-1", subject_id: "s-1", session_id: "sess-1"}
+      )
+
+      :telemetry.execute(
+        [:loopctl, :memory_promotion, :budget_exceeded],
+        %{count: 1},
+        %{tenant_id: "t-1", subject_id: "s-1", session_id: "sess-1"}
+      )
+
+      scrape = TelemetryMetricsPrometheus.Core.scrape(reporter)
+
+      assert scrape =~ ~s(loopctl_embedding_skipped_no_key_count{source="article"} 1)
+
+      assert scrape =~
+               ~s(loopctl_index_health_invalid_count{index="articles_embedding_idx",purpose="vector_search",state="invalid"} 1)
+
+      assert scrape =~
+               ~s(loopctl_secrets_orphan_cleanup_failed_count{op="restore",reason="old_value_unavailable"} 1)
+
+      assert scrape =~ ~s(loopctl_witness_divergence_count{reason="prefix_mismatch"} 1)
+      assert scrape =~ ~s(loopctl_witness_bootstrap_already_consumed_count 1)
+      assert scrape =~ ~s(loopctl_memory_promotion_failed_count{stage="compile"} 1)
+      assert scrape =~ ~s(loopctl_memory_promotion_degraded_count 1)
+      assert scrape =~ ~s(loopctl_memory_promotion_quota_exceeded_count 1)
+      assert scrape =~ ~s(loopctl_memory_promotion_budget_exceeded_count 1)
+
+      assert Process.alive?(pid)
+    end
+  end
+
   describe "metrics/0 wiring + test-env reporter guard" do
-    test "LoopctlWeb.Telemetry.metrics/0 includes the three scale metrics" do
+    test "LoopctlWeb.Telemetry.metrics/0 includes all scale metrics" do
       names = Enum.map(LoopctlWeb.Telemetry.metrics(), &Enum.join(&1.name, "."))
       for scale_name <- @scale_metric_names, do: assert(scale_name in names)
     end


### PR DESCRIPTION
## US-34.4 — Wire emitted-but-dead telemetry events into exported metrics

Adds ten purely-additive counters for signals that were already emitted via `:telemetry.execute/3` but had no `Telemetry.Metrics` definition consuming them:

- LLM/embedding blocked
- embedding-skipped-no-key
- index-health-invalid
- secrets-orphan-cleanup-failed
- witness divergence / bootstrap-already-consumed
- the four memory-promotion degradation signals (failed / degraded / quota_exceeded / budget_exceeded)

All tags are bounded per AC-27.15.3 (no `tenant_id` / free-text on any new counter).

### Review fixes folded in
- Corrected the AC-34.4.3 coordination note: `llm.blocked` fires on a missing-BYO-key CONFIG gate, not a runtime provider-error event — documents that US-34.3 must not window this counter as a provider-error-rate proxy.
- Documented the known double-count overlap between `embedding.skipped_no_key` and `llm.blocked` for the missing-embedding-key case.
- Added end-to-end scrape assertions for `quota_exceeded` and `budget_exceeded` to the reporter round-trip test.