### PR TITLE
Harden ScaleAlerts delivery: retry with backoff + periodic re-notify while breached

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -118,12 +118,21 @@ config :loopctl,
   # - the three thresholds (documented defaults): timeouts/min, p95 heavy-read ms,
   #   under-fill events/min. Edge-triggered debounce: an alert fires on the transition
   #   INTO breach, re-arming once the metric clears (no per-interval spam).
+  # - scale_alert_renotify_interval_ms (US-34.5, AC-34.5.2): while a breach remains
+  #   sustained, re-fire once this interval has elapsed since the last notification
+  #   instead of firing exactly once — an hours-long breach keeps paging. Floored at
+  #   60_000ms in `ScaleAlerts.renotify_interval_ms/0` so misconfiguration can't turn
+  #   this into per-tick spam. Delivery (US-34.5, AC-34.5.1) is durable: alerts are
+  #   enqueued through `Loopctl.Workers.ScaleAlertDeliveryWorker` (Oban `:webhooks`
+  #   queue) rather than POSTed synchronously, so a transient failure retries with
+  #   Oban's backoff instead of being logged-and-dropped.
   scale_alerts_enabled: false,
   scale_alert_webhook_url: nil,
   scale_alert_check_interval_ms: 60_000,
   scale_alert_timeout_rate_per_min: 5,
   scale_alert_p95_latency_ms: 2_000,
-  scale_alert_under_fill_rate_per_min: 30
+  scale_alert_under_fill_rate_per_min: 30,
+  scale_alert_renotify_interval_ms: 15 * 60_000
 
 # US-33.3: bounded TTL (ms) for the ETS read-through api-key cache. This is the
 # defense-in-depth backstop, NOT the primary invalidation — every revoke/rotate/

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -236,6 +236,13 @@ if config_env() == :prod do
          :scale_alert_under_fill_rate_per_min,
          String.to_integer(System.get_env("SCALE_ALERT_UNDER_FILL_RATE_PER_MIN") || "30")
 
+  # US-34.5 (AC-34.5.2): bounded periodic re-notify interval while a breach stays
+  # sustained. `ScaleAlerts.renotify_interval_ms/0` floors this at 60_000ms, so a
+  # misconfigured near-zero value can't turn re-notify into per-tick spam.
+  config :loopctl,
+         :scale_alert_renotify_interval_ms,
+         String.to_integer(System.get_env("SCALE_ALERT_RENOTIFY_INTERVAL_MS") || "900000")
+
   config :loopctl, Loopctl.HeavyReadRepo,
     url: admin_database_url,
     pool_size: String.to_integer(System.get_env("HEAVY_READ_POOL_SIZE") || "8"),

--- a/lib/loopctl/telemetry/scale_alerts.ex
+++ b/lib/loopctl/telemetry/scale_alerts.ex
@@ -53,18 +53,26 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
          95% of `:lat_total` — skipped (`nil`) when `lat_total` is below a small floor
          (`@p95_min_samples`) to avoid alerting on statistical noise,
     3. compares each to its configured threshold,
-    4. **edge-triggered DEBOUNCE**: per-metric breach state is held in the GenServer; an
-       alert FIRES only on the transition INTO breach, not every interval while a breach
-       is sustained (avoids alert spam). The metric re-arms (can fire again) once it
-       clears back below threshold.
+    4. **edge-triggered fire + bounded periodic RE-NOTIFY (US-34.5)**: per-metric
+       breach state (`breaching?`, `last_notified_at`) is held in the GenServer. An
+       alert fires on the transition INTO breach (edge-triggered semantics unchanged
+       from US-27.15). While the breach remains SUSTAINED, it re-fires once
+       `renotify_interval_ms/0` has elapsed since the last notification — so an
+       hours-long breach keeps paging instead of going silent after the first alert —
+       and stays silent in between (bounded, not per-tick spam). The metric re-arms
+       (`last_notified_at` cleared) once it clears back below threshold, so a later
+       breach fires immediately again.
 
   On a firing breach the alert is an id-only map — `%{alert, metric, value, threshold,
-  window_seconds, at}` — JSON-encoded and POSTed via the webhook delivery DI
-  (`Application.get_env(:loopctl, :webhook_delivery, Loopctl.Webhooks.ReqDelivery)`, the
-  SAME key the webhook worker uses) to `:scale_alert_webhook_url`. **No tenant content,
+  window_seconds, at}` — JSON-encoded and delivered via `Loopctl.Workers.ScaleAlertDeliveryWorker`
+  (US-34.5, AC-34.5.1): the payload is enqueued through Oban's `:webhooks` queue rather
+  than POSTed synchronously in-process, so a transient failure retries with Oban's
+  backoff instead of being logged-and-dropped. The worker resolves the SAME
+  `:webhook_delivery` DI (`Application.get_env(:loopctl, :webhook_delivery,
+  Loopctl.Webhooks.ReqDelivery)`) the webhook worker uses. **No tenant content,
   vectors, bodies, params, or SQL ever appears in the payload.** When the URL is `nil`
-  alerting is OFF (opt-in): the breach is logged at `:warning` and nothing is POSTed. A
-  delivery `{:error, _}` is logged, never raised.
+  alerting is OFF (opt-in): the breach is logged at `:warning` synchronously and
+  nothing is enqueued or POSTed — this path is unchanged by US-34.5.
 
   ## Operator / system scope — NOT tenant-scoped
 
@@ -88,6 +96,7 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
   require Logger
 
   alias Loopctl.Telemetry.ScaleAlerts.Window
+  alias Loopctl.Workers.ScaleAlertDeliveryWorker
 
   @table :loopctl_scale_alerts
 
@@ -112,6 +121,12 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
   @default_timeout_rate_per_min 5
   @default_p95_latency_ms 2_000
   @default_under_fill_rate_per_min 30
+
+  # US-34.5 (AC-34.5.2): bounded periodic re-notify while a breach stays sustained.
+  # Default 15 minutes; floored at 1 minute so a misconfigured near-zero value can't
+  # turn re-notify into per-tick spam.
+  @default_renotify_interval_ms 15 * 60_000
+  @renotify_interval_floor_ms 60_000
 
   @metrics %{
     timeout: "db_statement_timeout_rate",
@@ -150,6 +165,24 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
   """
   @spec window_ms() :: pos_integer()
   def window_ms, do: Application.get_env(:loopctl, :scale_alert_window_ms, check_interval_ms())
+
+  @doc """
+  Bounded periodic re-notify interval in ms while a breach remains sustained
+  (`:scale_alert_renotify_interval_ms`, default #{@default_renotify_interval_ms} = 15
+  min). Floored at #{@renotify_interval_floor_ms}ms (AC-34.5.2) so an operator
+  misconfiguration can't turn re-notify into per-tick alert spam.
+  """
+  @spec renotify_interval_ms() :: pos_integer()
+  def renotify_interval_ms do
+    configured =
+      Application.get_env(
+        :loopctl,
+        :scale_alert_renotify_interval_ms,
+        @default_renotify_interval_ms
+      )
+
+    max(configured, @renotify_interval_floor_ms)
+  end
 
   @doc "Timeout-rate threshold (timeouts/min, `:scale_alert_timeout_rate_per_min`)."
   @spec timeout_rate_threshold() :: number()
@@ -229,12 +262,6 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
   # in `Loopctl.HealthCheck.Default` must degrade cleanly, never crash the endpoint.
   defp blank?(_other), do: true
 
-  # The webhook delivery client — the SAME DI key the webhook worker uses, so the test
-  # mock applies. Operator/system-scoped: only the DeliveryBehaviour POST is reused, NOT
-  # the tenant-scoped EventGenerator.
-  defp delivery_client,
-    do: Application.get_env(:loopctl, :webhook_delivery, Loopctl.Webhooks.ReqDelivery)
-
   # --- GenServer callbacks ---
 
   @impl true
@@ -273,8 +300,22 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
        # configured `:scale_alert_webhook_url`. Resolved ONCE at init — a URL change needs
        # a restart, which is fine for an operator config.
        webhook_url: Keyword.get(opts, :webhook_url, webhook_url()),
-       # per-metric breach flags for the edge-triggered debounce (false = armed).
-       breaching: %{timeout: false, p95: false, under_fill: false}
+       # US-34.5: clock seam. Defaults to a real monotonic-ms clock; tests inject a
+       # per-instance override (mirrors `webhook_url` above) so the re-notify interval
+       # can be crossed deterministically without sleeping or mutating global config.
+       now_fn: Keyword.get(opts, :now_fn, &default_now/0),
+       # US-34.5 (AC-34.5.2): an optional per-instance override of the bounded re-notify
+       # interval, same pattern as `webhook_url`/`now_fn` — lets a test cross the
+       # interval quickly. Defaults to the (floored) configured value.
+       renotify_interval_ms: Keyword.get(opts, :renotify_interval_ms, renotify_interval_ms()),
+       # Per-metric breach state for the edge-triggered fire + bounded re-notify
+       # (US-34.5): `breaching?` false = armed; `last_notified_at` is the clock value
+       # (per `now_fn`) of the last delivered notification, `nil` while armed.
+       breaching: %{
+         timeout: %{breaching?: false, last_notified_at: nil},
+         p95: %{breaching?: false, last_notified_at: nil},
+         under_fill: %{breaching?: false, last_notified_at: nil}
+       }
      }}
   end
 
@@ -357,9 +398,17 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
 
   def handle_event(_event, _measurements, _metadata, _config), do: :ok
 
-  # --- Window evaluation + edge-triggered firing ---
+  # --- Window evaluation + edge-triggered firing + bounded re-notify (US-34.5) ---
 
-  defp do_evaluate(%{table: table, breaching: breaching, webhook_url: url} = state) do
+  defp do_evaluate(
+         %{
+           table: table,
+           breaching: breaching,
+           webhook_url: url,
+           now_fn: now_fn,
+           renotify_interval_ms: renotify_interval
+         } = state
+       ) do
     window = read_and_reset(table)
     window_min = window_minutes()
 
@@ -367,37 +416,67 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
     under_fill_rate = window.under_fill_count / window_min
     p95 = p95_from_buckets(window)
 
+    # A single clock read per evaluate: every metric in this tick is judged against the
+    # SAME "now", so two metrics breaching in the same window re-notify in lockstep.
+    now = now_fn.()
+
     breaching =
       breaching
-      |> step(:timeout, timeout_rate, timeout_rate_threshold(), url)
-      |> step(:under_fill, under_fill_rate, under_fill_rate_threshold(), url)
-      |> step_p95(p95, p95_latency_threshold(), url)
+      |> step(:timeout, timeout_rate, timeout_rate_threshold(), url, now, renotify_interval)
+      |> step(
+        :under_fill,
+        under_fill_rate,
+        under_fill_rate_threshold(),
+        url,
+        now,
+        renotify_interval
+      )
+      |> step_p95(p95, p95_latency_threshold(), url, now, renotify_interval)
 
     %{state | breaching: breaching}
   end
 
-  # Edge-triggered: fire only on the transition false -> true; re-arm on true -> false.
-  defp step(breaching, metric, value, threshold, url) do
+  # Edge-triggered fire on the transition false -> true; while sustained (still over
+  # threshold), re-fire once `renotify_interval` has elapsed since the last
+  # notification (AC-34.5.2), otherwise stay debounced. Re-arms (clears
+  # `last_notified_at`) on the transition back under threshold (AC-34.5.3: WHICH
+  # breaches fire is unchanged — only the sustained-breach behavior is new).
+  defp step(breaching, metric, value, threshold, url, now, renotify_interval) do
+    %{breaching?: was_breaching?, last_notified_at: last_notified_at} =
+      Map.fetch!(breaching, metric)
+
     over? = value > threshold
 
     cond do
-      over? and not breaching[metric] ->
+      over? and not was_breaching? ->
         fire(metric, value, threshold, url)
-        Map.put(breaching, metric, true)
+        Map.put(breaching, metric, %{breaching?: true, last_notified_at: now})
 
-      not over? ->
-        Map.put(breaching, metric, false)
+      over? and renotify_due?(last_notified_at, now, renotify_interval) ->
+        fire(metric, value, threshold, url)
+        Map.put(breaching, metric, %{breaching?: true, last_notified_at: now})
+
+      over? ->
+        # sustained breach, re-notify interval not yet elapsed — debounced
+        breaching
 
       true ->
-        # sustained breach — debounced, do not re-fire
-        breaching
+        Map.put(breaching, metric, %{breaching?: false, last_notified_at: nil})
     end
   end
 
+  defp renotify_due?(nil, _now, _renotify_interval), do: false
+
+  defp renotify_due?(last_notified_at, now, renotify_interval),
+    do: now - last_notified_at >= renotify_interval
+
   # p95 is `nil` when below the sample floor — treat as "not breaching" and re-arm so a
   # quiet window clears the breach state (a later busy window can fire again).
-  defp step_p95(breaching, nil, _threshold, _url), do: Map.put(breaching, :p95, false)
-  defp step_p95(breaching, p95, threshold, url), do: step(breaching, :p95, p95, threshold, url)
+  defp step_p95(breaching, nil, _threshold, _url, _now, _renotify_interval),
+    do: Map.put(breaching, :p95, %{breaching?: false, last_notified_at: nil})
+
+  defp step_p95(breaching, p95, threshold, url, now, renotify_interval),
+    do: step(breaching, :p95, p95, threshold, url, now, renotify_interval)
 
   defp fire(metric, value, threshold, url) do
     payload = %{
@@ -412,33 +491,32 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
     deliver(payload, url)
   end
 
-  defp deliver(payload, url) do
-    case url do
-      nil ->
-        # Opt-in: no URL configured → log the breach, POST nothing.
+  # AC-34.5.4: no URL configured → alerting is OFF. This stays a SYNCHRONOUS log-only
+  # no-op — never enqueue when the URL is nil (US-32.4 readiness guard unchanged).
+  defp deliver(payload, nil) do
+    Logger.warning(
+      "scale alert (no webhook configured): #{payload.metric}=#{payload.value} " <>
+        "> threshold #{payload.threshold} over #{payload.window_seconds}s"
+    )
+
+    :ok
+  end
+
+  # AC-34.5.1: durable delivery — enqueue through Oban's `:webhooks` queue instead of
+  # POSTing synchronously in-process, so a transient failure retries with Oban's
+  # backoff (`ScaleAlertDeliveryWorker`) rather than being logged-and-dropped.
+  defp deliver(payload, url) when is_binary(url) do
+    case %{url: url, payload: payload} |> ScaleAlertDeliveryWorker.new() |> Oban.insert() do
+      {:ok, _job} ->
+        Logger.info("scale alert enqueued for delivery: #{payload.metric}=#{payload.value}")
+        :ok
+
+      {:error, reason} ->
         Logger.warning(
-          "scale alert (no webhook configured): #{payload.metric}=#{payload.value} " <>
-            "> threshold #{payload.threshold} over #{payload.window_seconds}s"
+          "scale alert enqueue failed (#{inspect(reason)}): #{payload.metric}=#{payload.value}"
         )
 
         :ok
-
-      url ->
-        body = Jason.encode!(payload)
-        headers = [{"content-type", "application/json"}]
-
-        case delivery_client().deliver(url, body, headers) do
-          {:ok, _resp} ->
-            Logger.info("scale alert delivered: #{payload.metric}=#{payload.value}")
-            :ok
-
-          {:error, reason} ->
-            Logger.warning(
-              "scale alert delivery failed (#{inspect(reason)}): #{payload.metric}=#{payload.value}"
-            )
-
-            :ok
-        end
     end
   end
 
@@ -534,6 +612,10 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
   defp round_value(value), do: value
 
   defp schedule_tick, do: Process.send_after(self(), :tick, check_interval_ms())
+
+  # Real clock for the `now_fn` seam (US-34.5): monotonic ms — immune to wall-clock
+  # adjustments and cheap to call every evaluate.
+  defp default_now, do: System.monotonic_time(:millisecond)
 
   defp name(opts), do: Keyword.get(opts, :name, __MODULE__)
 end

--- a/lib/loopctl/telemetry/scale_alerts.ex
+++ b/lib/loopctl/telemetry/scale_alerts.ex
@@ -68,7 +68,7 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
   (US-34.5, AC-34.5.1): the payload is enqueued through Oban's `:webhooks` queue rather
   than POSTed synchronously in-process, so a transient failure retries with Oban's
   backoff instead of being logged-and-dropped. The worker resolves the SAME
-  `:webhook_delivery` DI (`Application.get_env(:loopctl, :webhook_delivery,
+  `:webhook_delivery` DI (`Application.compile_env(:loopctl, :webhook_delivery,
   Loopctl.Webhooks.ReqDelivery)`) the webhook worker uses. **No tenant content,
   vectors, bodies, params, or SQL ever appears in the payload.** When the URL is `nil`
   alerting is OFF (opt-in): the breach is logged at `:warning` synchronously and
@@ -308,6 +308,12 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
        # interval, same pattern as `webhook_url`/`now_fn` — lets a test cross the
        # interval quickly. Defaults to the (floored) configured value.
        renotify_interval_ms: Keyword.get(opts, :renotify_interval_ms, renotify_interval_ms()),
+       # Test seam (same pattern as `webhook_url`/`now_fn`): the function used to durably
+       # enqueue a `ScaleAlertDeliveryWorker` job. Defaults to `Oban.insert/1`. Lets a test
+       # deterministically simulate an enqueue failure (`{:error, _}`) or a raised
+       # connection error WITHOUT touching the real DB pool, to prove `last_notified_at`
+       # is only advanced on a genuine `{:ok, _}` enqueue (review fix, US-34.5).
+       insert_fn: Keyword.get(opts, :insert_fn, &Oban.insert/1),
        # Per-metric breach state for the edge-triggered fire + bounded re-notify
        # (US-34.5): `breaching?` false = armed; `last_notified_at` is the clock value
        # (per `now_fn`) of the last delivered notification, `nil` while armed.
@@ -406,7 +412,8 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
            breaching: breaching,
            webhook_url: url,
            now_fn: now_fn,
-           renotify_interval_ms: renotify_interval
+           renotify_interval_ms: renotify_interval,
+           insert_fn: insert_fn
          } = state
        ) do
     window = read_and_reset(table)
@@ -422,16 +429,25 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
 
     breaching =
       breaching
-      |> step(:timeout, timeout_rate, timeout_rate_threshold(), url, now, renotify_interval)
+      |> step(
+        :timeout,
+        timeout_rate,
+        timeout_rate_threshold(),
+        url,
+        now,
+        renotify_interval,
+        insert_fn
+      )
       |> step(
         :under_fill,
         under_fill_rate,
         under_fill_rate_threshold(),
         url,
         now,
-        renotify_interval
+        renotify_interval,
+        insert_fn
       )
-      |> step_p95(p95, p95_latency_threshold(), url, now, renotify_interval)
+      |> step_p95(p95, p95_latency_threshold(), url, now, renotify_interval, insert_fn)
 
     %{state | breaching: breaching}
   end
@@ -441,7 +457,15 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
   # notification (AC-34.5.2), otherwise stay debounced. Re-arms (clears
   # `last_notified_at`) on the transition back under threshold (AC-34.5.3: WHICH
   # breaches fire is unchanged — only the sustained-breach behavior is new).
-  defp step(breaching, metric, value, threshold, url, now, renotify_interval) do
+  #
+  # Review fix (US-34.5): `fire/5` only returns `true` when the alert was ACTUALLY
+  # delivered/durably enqueued (`deliver/3` -> `:ok`). A dropped enqueue (Oban.insert
+  # returns `{:error, _}` or raises) must NOT be recorded as a successful notification —
+  # doing so would advance `last_notified_at` to `now` and silence the sustained breach
+  # for a full `renotify_interval` even though nobody was actually paged. Instead we keep
+  # the PRIOR `last_notified_at` (via `notify/6`'s `fallback`) so the very next `:evaluate`
+  # retries the enqueue rather than waiting out the interval.
+  defp step(breaching, metric, value, threshold, url, now, renotify_interval, insert_fn) do
     %{breaching?: was_breaching?, last_notified_at: last_notified_at} =
       Map.fetch!(breaching, metric)
 
@@ -449,12 +473,12 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
 
     cond do
       over? and not was_breaching? ->
-        fire(metric, value, threshold, url)
-        Map.put(breaching, metric, %{breaching?: true, last_notified_at: now})
+        last_notified_at = notify(metric, value, threshold, url, insert_fn, now, nil)
+        Map.put(breaching, metric, %{breaching?: true, last_notified_at: last_notified_at})
 
       over? and renotify_due?(last_notified_at, now, renotify_interval) ->
-        fire(metric, value, threshold, url)
-        Map.put(breaching, metric, %{breaching?: true, last_notified_at: now})
+        last_notified_at = notify(metric, value, threshold, url, insert_fn, now, last_notified_at)
+        Map.put(breaching, metric, %{breaching?: true, last_notified_at: last_notified_at})
 
       over? ->
         # sustained breach, re-notify interval not yet elapsed — debounced
@@ -465,20 +489,27 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
     end
   end
 
-  defp renotify_due?(nil, _now, _renotify_interval), do: false
+  # `nil` while still breaching means the metric was NEVER successfully notified (its
+  # edge-trigger or a prior renotify attempt had its enqueue dropped) — retry on the very
+  # NEXT evaluate rather than waiting out a full interval that was never actually served.
+  defp renotify_due?(nil, _now, _renotify_interval), do: true
 
   defp renotify_due?(last_notified_at, now, renotify_interval),
     do: now - last_notified_at >= renotify_interval
 
   # p95 is `nil` when below the sample floor — treat as "not breaching" and re-arm so a
   # quiet window clears the breach state (a later busy window can fire again).
-  defp step_p95(breaching, nil, _threshold, _url, _now, _renotify_interval),
+  defp step_p95(breaching, nil, _threshold, _url, _now, _renotify_interval, _insert_fn),
     do: Map.put(breaching, :p95, %{breaching?: false, last_notified_at: nil})
 
-  defp step_p95(breaching, p95, threshold, url, now, renotify_interval),
-    do: step(breaching, :p95, p95, threshold, url, now, renotify_interval)
+  defp step_p95(breaching, p95, threshold, url, now, renotify_interval, insert_fn),
+    do: step(breaching, :p95, p95, threshold, url, now, renotify_interval, insert_fn)
 
-  defp fire(metric, value, threshold, url) do
+  # Fires the alert and stamps `last_notified_at` to `now` ONLY on a genuine successful
+  # delivery/enqueue; otherwise keeps `fallback` (either `nil` for a never-notified edge
+  # fire, or the previous notification's timestamp for a failed renotify attempt) so the
+  # breach stays "due" and is retried on the next tick instead of going silent.
+  defp notify(metric, value, threshold, url, insert_fn, now, fallback) do
     payload = %{
       alert: "scale_degradation",
       metric: Map.fetch!(@metrics, metric),
@@ -488,12 +519,12 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
       at: DateTime.utc_now() |> DateTime.to_iso8601()
     }
 
-    deliver(payload, url)
+    if deliver(payload, url, insert_fn) == :ok, do: now, else: fallback
   end
 
   # AC-34.5.4: no URL configured → alerting is OFF. This stays a SYNCHRONOUS log-only
   # no-op — never enqueue when the URL is nil (US-32.4 readiness guard unchanged).
-  defp deliver(payload, nil) do
+  defp deliver(payload, nil, _insert_fn) do
     Logger.warning(
       "scale alert (no webhook configured): #{payload.metric}=#{payload.value} " <>
         "> threshold #{payload.threshold} over #{payload.window_seconds}s"
@@ -505,8 +536,20 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
   # AC-34.5.1: durable delivery — enqueue through Oban's `:webhooks` queue instead of
   # POSTing synchronously in-process, so a transient failure retries with Oban's
   # backoff (`ScaleAlertDeliveryWorker`) rather than being logged-and-dropped.
-  defp deliver(payload, url) when is_binary(url) do
-    case %{url: url, payload: payload} |> ScaleAlertDeliveryWorker.new() |> Oban.insert() do
+  #
+  # Review fix: `insert_fn.(job)` (default `Oban.insert/1`, `Repo.insert/1` underneath)
+  # can RAISE (e.g. `DBConnection.ConnectionError` on pool exhaustion / DB down) rather
+  # than returning `{:error, _}` — it only returns an error tuple for changeset
+  # validation failures. `do_evaluate/1` runs inside `handle_call(:evaluate)` /
+  # `handle_info(:tick)`, which are NOT rescue-wrapped (unlike the request-path
+  # `handle_event/4` telemetry handlers), so an unrescued raise here would crash the
+  # GenServer and discard all breach/re-notify state on restart. Rescue here, log, and
+  # report `:error` like any other dropped enqueue — the caller (`notify/6`) already
+  # treats that as "not notified" and retries on the next tick.
+  defp deliver(payload, url, insert_fn) when is_binary(url) do
+    job = %{url: url, payload: payload} |> ScaleAlertDeliveryWorker.new()
+
+    case insert_fn.(job) do
       {:ok, _job} ->
         Logger.info("scale alert enqueued for delivery: #{payload.metric}=#{payload.value}")
         :ok
@@ -516,8 +559,15 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
           "scale alert enqueue failed (#{inspect(reason)}): #{payload.metric}=#{payload.value}"
         )
 
-        :ok
+        :error
     end
+  rescue
+    e ->
+      Logger.error(
+        "scale alert enqueue raised (#{Exception.message(e)}): #{payload.metric}=#{payload.value}"
+      )
+
+      :error
   end
 
   # --- Counter table helpers ---

--- a/lib/loopctl/telemetry/scale_alerts.ex
+++ b/lib/loopctl/telemetry/scale_alerts.ex
@@ -67,12 +67,17 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
   window_seconds, at}` — JSON-encoded and delivered via `Loopctl.Workers.ScaleAlertDeliveryWorker`
   (US-34.5, AC-34.5.1): the payload is enqueued through Oban's `:webhooks` queue rather
   than POSTed synchronously in-process, so a transient failure retries with Oban's
-  backoff instead of being logged-and-dropped. The worker resolves the SAME
-  `:webhook_delivery` DI (`Application.compile_env(:loopctl, :webhook_delivery,
-  Loopctl.Webhooks.ReqDelivery)`) the webhook worker uses. **No tenant content,
-  vectors, bodies, params, or SQL ever appears in the payload.** When the URL is `nil`
-  alerting is OFF (opt-in): the breach is logged at `:warning` synchronously and
-  nothing is enqueued or POSTed — this path is unchanged by US-34.5.
+  backoff instead of being logged-and-dropped. **The enqueued job args carry ONLY the
+  id-only `payload` — never the webhook URL** (secrets-at-rest review fix): Oban
+  persists job args as cleartext JSON with no encryption plugin configured, and the
+  webhook URL is commonly secret-bearing (Slack/PagerDuty tokens), so the worker instead
+  re-resolves the URL at run time from `webhook_url/0`, mirroring the sibling
+  `WebhookDeliveryWorker`'s pattern of never persisting a secret in `args`. The worker
+  resolves the SAME `:webhook_delivery` DI (`Application.compile_env(:loopctl,
+  :webhook_delivery, Loopctl.Webhooks.ReqDelivery)`) the webhook worker uses. **No
+  tenant content, vectors, bodies, params, or SQL ever appears in the payload.** When the
+  URL is `nil` alerting is OFF (opt-in): the breach is logged at `:warning` synchronously
+  and nothing is enqueued or POSTed — this path is unchanged by US-34.5.
 
   ## Operator / system scope — NOT tenant-scoped
 
@@ -458,13 +463,14 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
   # `last_notified_at`) on the transition back under threshold (AC-34.5.3: WHICH
   # breaches fire is unchanged — only the sustained-breach behavior is new).
   #
-  # Review fix (US-34.5): `fire/5` only returns `true` when the alert was ACTUALLY
-  # delivered/durably enqueued (`deliver/3` -> `:ok`). A dropped enqueue (Oban.insert
-  # returns `{:error, _}` or raises) must NOT be recorded as a successful notification —
-  # doing so would advance `last_notified_at` to `now` and silence the sustained breach
-  # for a full `renotify_interval` even though nobody was actually paged. Instead we keep
-  # the PRIOR `last_notified_at` (via `notify/6`'s `fallback`) so the very next `:evaluate`
-  # retries the enqueue rather than waiting out the interval.
+  # Review fix (US-34.5): `notify/7` only returns `now` when the alert was ACTUALLY
+  # delivered/durably enqueued (`deliver/3` -> `:ok`); otherwise it returns `fallback`
+  # unchanged. A dropped enqueue (Oban.insert returns `{:error, _}` or raises) must NOT
+  # be recorded as a successful notification — doing so would advance `last_notified_at`
+  # to `now` and silence the sustained breach for a full `renotify_interval` even though
+  # nobody was actually paged. Instead we keep the PRIOR `last_notified_at` (via
+  # `notify/7`'s `fallback`) so the very next `:evaluate` retries the enqueue rather than
+  # waiting out the interval.
   defp step(breaching, metric, value, threshold, url, now, renotify_interval, insert_fn) do
     %{breaching?: was_breaching?, last_notified_at: last_notified_at} =
       Map.fetch!(breaching, metric)
@@ -537,6 +543,16 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
   # POSTing synchronously in-process, so a transient failure retries with Oban's
   # backoff (`ScaleAlertDeliveryWorker`) rather than being logged-and-dropped.
   #
+  # Review fix (secrets-at-rest): the job args carry ONLY the id-only `payload` — never
+  # `url`. The webhook URL is commonly secret-bearing (Slack/PagerDuty routing tokens),
+  # and Oban persists job args as cleartext JSON in `oban_jobs` with no encryption
+  # plugin configured; `Oban.Plugins.Pruner` then retains terminal jobs for 7 days. That
+  # would leak the URL into the DB, every backup, the Oban Web dashboard, and any Oban
+  # telemetry/APM consumer. `ScaleAlertDeliveryWorker.perform/1` re-resolves the URL from
+  # `ScaleAlerts.webhook_url/0` (the SAME resolve-once operator config this GenServer
+  # already reads at `init/1`) instead, mirroring the sibling `WebhookDeliveryWorker`
+  # pattern of never persisting a secret in `args`.
+  #
   # Review fix: `insert_fn.(job)` (default `Oban.insert/1`, `Repo.insert/1` underneath)
   # can RAISE (e.g. `DBConnection.ConnectionError` on pool exhaustion / DB down) rather
   # than returning `{:error, _}` — it only returns an error tuple for changeset
@@ -544,10 +560,10 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
   # `handle_info(:tick)`, which are NOT rescue-wrapped (unlike the request-path
   # `handle_event/4` telemetry handlers), so an unrescued raise here would crash the
   # GenServer and discard all breach/re-notify state on restart. Rescue here, log, and
-  # report `:error` like any other dropped enqueue — the caller (`notify/6`) already
+  # report `:error` like any other dropped enqueue — the caller (`notify/7`) already
   # treats that as "not notified" and retries on the next tick.
   defp deliver(payload, url, insert_fn) when is_binary(url) do
-    job = %{url: url, payload: payload} |> ScaleAlertDeliveryWorker.new()
+    job = %{payload: payload} |> ScaleAlertDeliveryWorker.new()
 
     case insert_fn.(job) do
       {:ok, _job} ->
@@ -568,6 +584,24 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
       )
 
       :error
+  end
+
+  # Review fix: a non-nil, non-binary `:scale_alert_webhook_url` (e.g. a charlist/atom
+  # from a config typo) matched neither the `nil` clause above nor the `is_binary(url)`
+  # clause, so `notify/7` raised a `FunctionClauseError` OUTSIDE the `deliver/3` rescue —
+  # that raise then propagated out of `handle_call(:evaluate)`/`handle_info(:tick)`
+  # (neither rescue-wrapped) and crashed the GenServer, discarding breach/re-notify
+  # state. This mirrors the module's own defensive `blank?/1` catch-all (line ~263):
+  # treat a malformed URL as a config error, not an unset URL — log and report `:error`
+  # so `notify/7` keeps the prior `last_notified_at` and retries on the next tick,
+  # exactly like a dropped enqueue.
+  defp deliver(payload, url, _insert_fn) do
+    Logger.error(
+      "scale alert webhook url misconfigured (expected a string or nil, got #{inspect(url)}): " <>
+        "#{payload.metric}=#{payload.value} treated as a failed delivery"
+    )
+
+    :error
   end
 
   # --- Counter table helpers ---

--- a/lib/loopctl/workers/scale_alert_delivery_worker.ex
+++ b/lib/loopctl/workers/scale_alert_delivery_worker.ex
@@ -1,0 +1,58 @@
+defmodule Loopctl.Workers.ScaleAlertDeliveryWorker do
+  @moduledoc """
+  Durable delivery for `Loopctl.Telemetry.ScaleAlerts` (US-34.5, AC-34.5.1).
+
+  ScaleAlerts is operator/system-scoped: unlike `Loopctl.Workers.WebhookDeliveryWorker`
+  (tenant-scoped, backed by a `webhook_event`/`webhook` DB row it updates on every
+  attempt), a scale alert has NO row to track. This worker leans on Oban's NATIVE
+  retry/backoff instead of manual `{:snooze, _}` bookkeeping: returning `{:error, _}`
+  from `perform/1` is enough for Oban to reschedule the next attempt with its
+  (exponential + jittered) backoff, so a transient webhook failure retries instead of
+  being logged-and-dropped by a synchronous in-process POST.
+
+  ## Args
+
+  Job args round-trip through JSON, so `perform/1` pattern-matches STRING keys (atom
+  keys never survive Oban's JSON encode/decode):
+
+      %{"url" => url, "payload" => payload}
+
+  `payload` is the SAME id-only alert map `ScaleAlerts` already built (`%{alert,
+  metric, value, threshold, window_seconds, at}`) — no tenant content, vectors, SQL, or
+  request bodies are ever enqueued.
+
+  ## Delivery DI
+
+  Resolves `:webhook_delivery` via `Application.compile_env/3` — the SAME config key
+  `ScaleAlerts` and `WebhookDeliveryWorker` use, mockable in tests via
+  `Loopctl.MockDelivery` (config/test.exs).
+  """
+
+  use Oban.Worker, queue: :webhooks, max_attempts: 6
+
+  require Logger
+
+  @delivery_client Application.compile_env(
+                     :loopctl,
+                     :webhook_delivery,
+                     Loopctl.Webhooks.ReqDelivery
+                   )
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"url" => url, "payload" => payload}}) do
+    body = Jason.encode!(payload)
+    headers = [{"content-type", "application/json"}]
+
+    case @delivery_client.deliver(url, body, headers) do
+      {:ok, _resp} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning(
+          "ScaleAlertDeliveryWorker: delivery failed (#{inspect(reason)}), Oban will retry"
+        )
+
+        {:error, reason}
+    end
+  end
+end

--- a/lib/loopctl/workers/scale_alert_delivery_worker.ex
+++ b/lib/loopctl/workers/scale_alert_delivery_worker.ex
@@ -15,11 +15,28 @@ defmodule Loopctl.Workers.ScaleAlertDeliveryWorker do
   Job args round-trip through JSON, so `perform/1` pattern-matches STRING keys (atom
   keys never survive Oban's JSON encode/decode):
 
-      %{"url" => url, "payload" => payload}
+      %{"payload" => payload}
 
   `payload` is the SAME id-only alert map `ScaleAlerts` already built (`%{alert,
   metric, value, threshold, window_seconds, at}`) — no tenant content, vectors, SQL, or
   request bodies are ever enqueued.
+
+  ## No URL in args (secrets-at-rest review fix)
+
+  The webhook URL is deliberately NOT carried in job args. `ScaleAlerts` treats it as
+  resolve-once operator config (`ScaleAlerts.webhook_url/0`, read once at `init/1`);
+  Oban persists job args as cleartext JSON in `oban_jobs` with no encryption plugin
+  configured, and `Oban.Plugins.Pruner` retains terminal jobs for 7 days. A scale-alert
+  webhook URL is commonly secret-bearing (Slack incoming-webhook / PagerDuty routing
+  tokens), so persisting it in args would leak it into the DB, every backup, the Oban
+  Web dashboard, and any Oban telemetry/APM consumer. Instead `perform/1` re-resolves the
+  URL at run time via `ScaleAlerts.webhook_url/0` — behaviorally equivalent since the URL
+  is static operator config, but keeps the secret out of the database. This mirrors the
+  sibling `Loopctl.Workers.WebhookDeliveryWorker`, which stores only IDs in args and
+  re-resolves URL + signing secret from the DB. If the URL is unset by the time the job
+  runs (a config typo / race), the job logs a warning and completes as a no-op `:ok`
+  rather than erroring — alerting is opt-in, so an unconfigured URL is not a delivery
+  failure.
 
   ## Delivery DI
 
@@ -42,6 +59,8 @@ defmodule Loopctl.Workers.ScaleAlertDeliveryWorker do
 
   require Logger
 
+  alias Loopctl.Telemetry.ScaleAlerts
+
   @delivery_client Application.compile_env(
                      :loopctl,
                      :webhook_delivery,
@@ -54,7 +73,27 @@ defmodule Loopctl.Workers.ScaleAlertDeliveryWorker do
   def timeout(_job), do: :timer.seconds(30)
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"url" => url, "payload" => payload}}) do
+  def perform(%Oban.Job{args: %{"payload" => payload}}) do
+    deliver_or_skip(payload, ScaleAlerts.webhook_url())
+  end
+
+  @doc false
+  # Takes the resolved URL as an ARG (rather than reading `ScaleAlerts.webhook_url/0`
+  # internally) so both branches are unit-testable without `Application.put_env` —
+  # mirrors `ScaleAlerts.config_status/2`'s "config as args" idiom.
+  @spec deliver_or_skip(map(), String.t() | nil) :: :ok | {:error, term()}
+  def deliver_or_skip(payload, nil) do
+    Logger.warning(
+      "ScaleAlertDeliveryWorker: scale_alert_webhook_url is unset at delivery time, " <>
+        "skipping (alert already logged when enqueued): #{payload["metric"]}=#{payload["value"]}"
+    )
+
+    :ok
+  end
+
+  def deliver_or_skip(payload, url) when is_binary(url), do: deliver(url, payload)
+
+  defp deliver(url, payload) do
     body = Jason.encode!(payload)
     headers = [{"content-type", "application/json"}]
 

--- a/lib/loopctl/workers/scale_alert_delivery_worker.ex
+++ b/lib/loopctl/workers/scale_alert_delivery_worker.ex
@@ -26,6 +26,16 @@ defmodule Loopctl.Workers.ScaleAlertDeliveryWorker do
   Resolves `:webhook_delivery` via `Application.compile_env/3` — the SAME config key
   `ScaleAlerts` and `WebhookDeliveryWorker` use, mockable in tests via
   `Loopctl.MockDelivery` (config/test.exs).
+
+  ## Wall-clock timeout (review fix)
+
+  This worker shares the `:webhooks` queue with `Loopctl.Workers.WebhookDeliveryWorker`,
+  which deliberately enforces `timeout(_job), do: :timer.seconds(30)` as a backstop ON
+  TOP of Req's `receive_timeout` — a slow/hostile target must not pin a shared
+  `:webhooks` slot indefinitely (see GHSA-jh42-wf7g-f5rg). `ReqDelivery`'s `10s`
+  `receive_timeout` bounds awaiting a response but not a slow-drip connection or a
+  connect stall, so this worker enforces the SAME 30s cap to keep every occupant of the
+  shared queue under one hard ceiling.
   """
 
   use Oban.Worker, queue: :webhooks, max_attempts: 6
@@ -37,6 +47,11 @@ defmodule Loopctl.Workers.ScaleAlertDeliveryWorker do
                      :webhook_delivery,
                      Loopctl.Webhooks.ReqDelivery
                    )
+
+  # Hard per-job wall-clock cap — mirrors `WebhookDeliveryWorker.timeout/1` (same
+  # shared `:webhooks` queue, same rationale: ie-02 / GHSA-jh42-wf7g-f5rg).
+  @impl Oban.Worker
+  def timeout(_job), do: :timer.seconds(30)
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"url" => url, "payload" => payload}}) do

--- a/test/loopctl/telemetry/scale_alerts_test.exs
+++ b/test/loopctl/telemetry/scale_alerts_test.exs
@@ -486,6 +486,77 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
     end
   end
 
+  describe "no secret persisted in the enqueued job (review fix)" do
+    # Uses the `insert_fn` test seam to capture the EXACT job `deliver/3` builds, before
+    # it reaches Oban, and proves the webhook URL (potentially secret-bearing) is never
+    # part of the args that would be JSON-serialized into `oban_jobs.args`.
+    test "the job enqueued for delivery carries only :payload — never the webhook url" do
+      test_pid = self()
+
+      insert_fn = fn job ->
+        send(test_pid, {:captured_job_args, job.changes.args})
+        Oban.insert(job)
+      end
+
+      stub(Loopctl.MockDelivery, :deliver, fn _url, _body, _headers ->
+        {:ok, %{status: 200, body: "ok"}}
+      end)
+
+      table = :"scale_alerts_no_url_in_args_#{System.unique_integer([:positive])}"
+      name = :"scale_alerts_no_url_in_args_srv_#{System.unique_integer([:positive])}"
+
+      _pid =
+        start_supervised!({ScaleAlerts, table: table, name: name, insert_fn: insert_fn},
+          id: name
+        )
+
+      emit_timeout(6)
+      assert :ok = ScaleAlerts.evaluate(name)
+
+      assert_received {:captured_job_args, args}
+      assert Map.keys(args) == [:payload]
+      refute Map.has_key?(args, :url)
+    end
+  end
+
+  describe "malformed webhook url config does not crash the GenServer (review fix)" do
+    # A non-nil, non-binary `:scale_alert_webhook_url` (e.g. a charlist/atom from a
+    # config typo) must be treated as a delivery error, not raise past `deliver/3` and
+    # crash the un-rescued `handle_call(:evaluate)`.
+    test "a non-binary configured url logs, reports :error, and keeps the GenServer alive" do
+      test_pid = self()
+
+      stub(Loopctl.MockDelivery, :deliver, fn _u, _b, _h ->
+        send(test_pid, :unexpected_delivery)
+        {:ok, %{status: 200, body: "ok"}}
+      end)
+
+      table = :"scale_alerts_bad_url_#{System.unique_integer([:positive])}"
+      name = :"scale_alerts_bad_url_srv_#{System.unique_integer([:positive])}"
+
+      pid =
+        start_supervised!(
+          {ScaleAlerts, table: table, name: name, webhook_url: :not_a_url},
+          id: name
+        )
+
+      emit_timeout(6)
+      # Must complete normally (not crash/timeout) — proving the catch-all `deliver/3`
+      # clause handled the malformed config instead of raising FunctionClauseError.
+      assert :ok = ScaleAlerts.evaluate(name)
+
+      assert Process.alive?(pid)
+      refute_received :unexpected_delivery
+
+      # Sustained breach on the very next tick still doesn't crash or deliver — the
+      # misconfiguration persists, so the metric legitimately never gets marked notified.
+      emit_timeout(6)
+      assert :ok = ScaleAlerts.evaluate(name)
+      assert Process.alive?(pid)
+      refute_received :unexpected_delivery
+    end
+  end
+
   describe "bounded periodic re-notify while a breach is sustained (AC-34.5.2)" do
     test "re-fires once the re-notify interval elapses, stays silent before it, re-arms on clear" do
       test_pid = self()

--- a/test/loopctl/telemetry/scale_alerts_test.exs
+++ b/test/loopctl/telemetry/scale_alerts_test.exs
@@ -408,6 +408,84 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
     end
   end
 
+  describe "a dropped enqueue does not silence re-notify (review fix)" do
+    # Uses the `insert_fn` test seam (mirrors the existing `webhook_url`/`now_fn`
+    # per-instance overrides) to simulate `Oban.insert/1` itself failing or raising —
+    # distinct from the worker's OWN `perform/1` failing after a successful insert
+    # (covered by the "durable delivery via Oban" describe block above).
+    test "an Oban.insert {:error, _} keeps the breach 'due'; the very next evaluate retries" do
+      test_pid = self()
+
+      # Fail exactly the FIRST insert attempt, then delegate to the real Oban.insert/1.
+      failed_once? = :counters.new(1, [])
+
+      insert_fn = fn job ->
+        if :counters.get(failed_once?, 1) == 0 do
+          :counters.add(failed_once?, 1, 1)
+          {:error, %Ecto.Changeset{valid?: false}}
+        else
+          Oban.insert(job)
+        end
+      end
+
+      stub(Loopctl.MockDelivery, :deliver, fn _url, body, _headers ->
+        send(test_pid, {:delivered, Jason.decode!(body)["metric"]})
+        {:ok, %{status: 200, body: "ok"}}
+      end)
+
+      table = :"scale_alerts_dropped_enqueue_#{System.unique_integer([:positive])}"
+      name = :"scale_alerts_dropped_enqueue_srv_#{System.unique_integer([:positive])}"
+
+      _pid =
+        start_supervised!({ScaleAlerts, table: table, name: name, insert_fn: insert_fn},
+          id: name
+        )
+
+      # Edge fire: the enqueue is dropped -> nothing is ever delivered for this tick, and
+      # (the bug this finding describes) `last_notified_at` must NOT have been stamped.
+      emit_timeout(6)
+      assert :ok = ScaleAlerts.evaluate(name)
+      refute_received {:delivered, _}
+
+      # Sustained breach, very next tick: with the fix, a `nil` last_notified_at while
+      # breaching means "never successfully notified" -> retried immediately (NOT after
+      # waiting out a full `renotify_interval_ms`, which defaults to 15 minutes). This
+      # time the insert succeeds and the alert is genuinely delivered.
+      emit_timeout(6)
+      assert :ok = ScaleAlerts.evaluate(name)
+      assert_received {:delivered, "db_statement_timeout_rate"}
+    end
+
+    test "an insert_fn that raises (DB unavailable) does not crash the GenServer" do
+      test_pid = self()
+
+      insert_fn = fn _job ->
+        raise DBConnection.ConnectionError, "connection not available"
+      end
+
+      stub(Loopctl.MockDelivery, :deliver, fn _url, _body, _headers ->
+        send(test_pid, :unexpected_delivery)
+        {:ok, %{status: 200, body: "ok"}}
+      end)
+
+      table = :"scale_alerts_raise_#{System.unique_integer([:positive])}"
+      name = :"scale_alerts_raise_srv_#{System.unique_integer([:positive])}"
+
+      pid =
+        start_supervised!({ScaleAlerts, table: table, name: name, insert_fn: insert_fn},
+          id: name
+        )
+
+      emit_timeout(6)
+      # The call itself must complete normally (not crash/timeout) — proving `deliver/3`
+      # rescued the raise instead of letting it propagate out of `handle_call(:evaluate)`.
+      assert :ok = ScaleAlerts.evaluate(name)
+
+      assert Process.alive?(pid)
+      refute_received :unexpected_delivery
+    end
+  end
+
   describe "bounded periodic re-notify while a breach is sustained (AC-34.5.2)" do
     test "re-fires once the re-notify interval elapses, stays silent before it, re-arms on clear" do
       test_pid = self()

--- a/test/loopctl/telemetry/scale_alerts_test.exs
+++ b/test/loopctl/telemetry/scale_alerts_test.exs
@@ -14,6 +14,11 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
       `evaluate/0`; after the metric clears, a fresh breach fires again;
     * the bucketed p95 honors its sample floor and crosses at the right bucket.
 
+  US-34.5 extends this coverage: durable delivery via `Loopctl.Workers.ScaleAlertDeliveryWorker`
+  (AC-34.5.1 — a delivery failure is Oban's `:failure` state, not a logged-and-dropped
+  POST), bounded periodic re-notify while a breach stays sustained (AC-34.5.2), re-arm on
+  clear (AC-34.5.3), and the nil-url path still never enqueues (AC-34.5.4).
+
   `async: false`: the handlers attach GLOBAL `:telemetry` listeners on the three scale
   events, so a concurrent async test issuing a real heavy-read / db-error would pollute
   this instance's window counters. Running serially keeps the counts deterministic. It
@@ -32,6 +37,7 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
 
   alias Loopctl.Telemetry.ScaleAlerts
   alias Loopctl.TelemetryEvents
+  alias Loopctl.Workers.ScaleAlertDeliveryWorker
 
   setup :set_mox_global
   setup :verify_on_exit!
@@ -284,7 +290,7 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
   end
 
   describe "no webhook url configured (log-only opt-in)" do
-    test "with a nil url, a breach logs and does NOT POST" do
+    test "with a nil url, a breach logs and does NOT POST or enqueue (AC-34.5.4)" do
       test_pid = self()
 
       stub(Loopctl.MockDelivery, :deliver, fn _u, _b, _h ->
@@ -292,9 +298,26 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
         {:ok, %{status: 200, body: "ok"}}
       end)
 
+      # A nil-url breach must never even reach Oban — assert no [:oban, :job, :start]
+      # (or any other oban job event) fires for our worker at all (US-34.5: the nil
+      # branch stays a SYNCHRONOUS log-only no-op, it must not enqueue).
+      handler_id = {:scale_alerts_nilurl_oban, System.unique_integer([:positive])}
+
+      :telemetry.attach(
+        handler_id,
+        [:oban, :job, :start],
+        fn _event, _measurements, meta, _config ->
+          send(test_pid, {:unexpected_oban_job, meta.job.worker})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
       # Start a SEPARATE instance with the URL overridden to nil via a start opt (NO
       # put_env in the body — the override is instance config, restored automatically when
-      # this supervised process stops). A breach must log, not POST.
+      # this supervised process stops). A breach must log, not POST, and (US-34.5) must
+      # NOT enqueue a durable-delivery job either.
       table = :"scale_alerts_nilurl_#{System.unique_integer([:positive])}"
       name = :"scale_alerts_nilurl_srv_#{System.unique_integer([:positive])}"
 
@@ -310,6 +333,130 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
 
       assert :ok = ScaleAlerts.evaluate(name)
       refute_received :unexpected_delivery
+      refute_received {:unexpected_oban_job, _}
+    end
+  end
+
+  describe "durable delivery via Oban (AC-34.5.1)" do
+    # ScaleAlerts is a long-running GenServer, so `deliver/2`'s `Oban.insert/1` executes
+    # inside the SERVER process, not the test process — `Oban.Testing.with_testing_mode/2`
+    # is a process-dictionary override scoped to the CALLING process (the pattern used
+    # in `signup_test.exs`, where the enqueue happens via a plain context function call
+    # in the test process itself) and does not reach across that GenServer.call boundary.
+    # Instead we prove durability directly at Oban's own job-lifecycle telemetry: a
+    # `perform/1` failure must be classified `state: :failure` (Oban's retryable state,
+    # the trigger for its OWN backoff/retry scheduling) rather than being silently
+    # swallowed — i.e. the alert genuinely ran THROUGH Oban's Executor, not a bare
+    # logged-and-dropped POST. The worker-level test
+    # (`scale_alert_delivery_worker_test.exs`) covers the complementary unit proof that
+    # `perform/1` itself returns `{:error, _}` on failure and `:ok` on success.
+    test "a delivery failure is classified by Oban as a retryable failure, not dropped",
+         %{server: server} do
+      test_pid = self()
+
+      stub(Loopctl.MockDelivery, :deliver, fn _url, _body, _headers ->
+        {:error, "connection_refused"}
+      end)
+
+      handler_id = {:scale_alerts_oban_exception, System.unique_integer([:positive])}
+
+      :telemetry.attach(
+        handler_id,
+        [:oban, :job, :exception],
+        fn _event, _measurements, meta, _config ->
+          send(test_pid, {:oban_job_failed, meta.job.worker, meta.state})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      # 6 timeouts in a 60s window = 6/min > the 5/min default threshold.
+      emit_timeout(6)
+      assert :ok = ScaleAlerts.evaluate(server)
+
+      expected_worker = inspect(ScaleAlertDeliveryWorker)
+      assert_received {:oban_job_failed, ^expected_worker, :failure}
+    end
+
+    test "a delivery success runs through the durable worker path (not a bare POST)",
+         %{server: server} do
+      test_pid = self()
+
+      handler_id = {:scale_alerts_oban_stop, System.unique_integer([:positive])}
+
+      :telemetry.attach(
+        handler_id,
+        [:oban, :job, :stop],
+        fn _event, _measurements, meta, _config ->
+          send(test_pid, {:oban_job_succeeded, meta.job.worker, meta.state})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      expect(Loopctl.MockDelivery, :deliver, fn _url, _body, _headers ->
+        {:ok, %{status: 200, body: "ok"}}
+      end)
+
+      emit_timeout(6)
+      assert :ok = ScaleAlerts.evaluate(server)
+
+      expected_worker = inspect(ScaleAlertDeliveryWorker)
+      assert_received {:oban_job_succeeded, ^expected_worker, :success}
+    end
+  end
+
+  describe "bounded periodic re-notify while a breach is sustained (AC-34.5.2)" do
+    test "re-fires once the re-notify interval elapses, stays silent before it, re-arms on clear" do
+      test_pid = self()
+
+      stub(Loopctl.MockDelivery, :deliver, fn _url, body, _headers ->
+        send(test_pid, {:fired, Jason.decode!(body)["metric"]})
+        {:ok, %{status: 200, body: "ok"}}
+      end)
+
+      # A mutable clock (Erlang :counters, no Application.put_env involved) injected as
+      # a per-instance `now_fn` override — mirrors the existing `webhook_url` seam — so
+      # the re-notify interval can be crossed deterministically without sleeping.
+      clock = :counters.new(1, [])
+      now_fn = fn -> :counters.get(clock, 1) end
+
+      table = :"scale_alerts_renotify_#{System.unique_integer([:positive])}"
+      name = :"scale_alerts_renotify_srv_#{System.unique_integer([:positive])}"
+
+      _pid =
+        start_supervised!(
+          {ScaleAlerts, table: table, name: name, now_fn: now_fn, renotify_interval_ms: 1_000},
+          id: name
+        )
+
+      # Edge fire: false -> true.
+      emit_timeout(6)
+      assert :ok = ScaleAlerts.evaluate(name)
+      assert_received {:fired, "db_statement_timeout_rate"}
+
+      # Still breaching, interval NOT elapsed (500ms < 1_000ms) -> debounced, no 2nd fire.
+      :counters.add(clock, 1, 500)
+      emit_timeout(6)
+      assert :ok = ScaleAlerts.evaluate(name)
+      refute_received {:fired, _}
+
+      # Advance PAST the interval, still breaching -> bounded re-notify fires (TC-34.5.2).
+      :counters.add(clock, 1, 600)
+      emit_timeout(6)
+      assert :ok = ScaleAlerts.evaluate(name)
+      assert_received {:fired, "db_statement_timeout_rate"}
+
+      # Clear below threshold -> re-arms (no fire).
+      assert :ok = ScaleAlerts.evaluate(name)
+      refute_received {:fired, _}
+
+      # A later breach fires again immediately (TC-34.5.3: edge semantics preserved).
+      emit_timeout(6)
+      assert :ok = ScaleAlerts.evaluate(name)
+      assert_received {:fired, "db_statement_timeout_rate"}
     end
   end
 end

--- a/test/loopctl/workers/scale_alert_delivery_worker_test.exs
+++ b/test/loopctl/workers/scale_alert_delivery_worker_test.exs
@@ -1,0 +1,48 @@
+defmodule Loopctl.Workers.ScaleAlertDeliveryWorkerTest do
+  @moduledoc """
+  US-34.5 (AC-34.5.1) — worker-level coverage: proves Oban's NATIVE retry actually
+  applies to a ScaleAlerts delivery. A delivery failure must return `{:error, _}` (the
+  signal Oban uses to schedule the next attempt with its own backoff) rather than being
+  swallowed to `{:ok, _}` and dropped; success returns `:ok`.
+  """
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.Workers.ScaleAlertDeliveryWorker
+
+  @payload %{
+    "alert" => "scale_degradation",
+    "metric" => "db_statement_timeout_rate",
+    "value" => 6.0,
+    "threshold" => 5,
+    "window_seconds" => 60,
+    "at" => "2026-01-01T00:00:00Z"
+  }
+  @url "https://alerts.test.invalid/scale"
+
+  defp job(args), do: %Oban.Job{args: args}
+
+  describe "perform/1" do
+    test "successful delivery returns :ok and delivers the exact JSON payload + headers" do
+      expect(Loopctl.MockDelivery, :deliver, fn url, body, headers ->
+        assert url == @url
+        assert {"content-type", "application/json"} in headers
+        assert Jason.decode!(body) == @payload
+        {:ok, %{status: 200, body: "ok"}}
+      end)
+
+      assert :ok =
+               ScaleAlertDeliveryWorker.perform(job(%{"url" => @url, "payload" => @payload}))
+    end
+
+    test "delivery failure returns {:error, _} so Oban retries (not dropped)" do
+      expect(Loopctl.MockDelivery, :deliver, fn _url, _body, _headers ->
+        {:error, "connection_refused"}
+      end)
+
+      assert {:error, "connection_refused"} =
+               ScaleAlertDeliveryWorker.perform(job(%{"url" => @url, "payload" => @payload}))
+    end
+  end
+end

--- a/test/loopctl/workers/scale_alert_delivery_worker_test.exs
+++ b/test/loopctl/workers/scale_alert_delivery_worker_test.exs
@@ -23,6 +23,13 @@ defmodule Loopctl.Workers.ScaleAlertDeliveryWorkerTest do
 
   defp job(args), do: %Oban.Job{args: args}
 
+  describe "timeout/1 (review fix)" do
+    test "enforces the same 30s wall-clock cap as the sibling WebhookDeliveryWorker" do
+      assert ScaleAlertDeliveryWorker.timeout(job(%{"url" => @url, "payload" => @payload})) ==
+               :timer.seconds(30)
+    end
+  end
+
   describe "perform/1" do
     test "successful delivery returns :ok and delivers the exact JSON payload + headers" do
       expect(Loopctl.MockDelivery, :deliver, fn url, body, headers ->

--- a/test/loopctl/workers/scale_alert_delivery_worker_test.exs
+++ b/test/loopctl/workers/scale_alert_delivery_worker_test.exs
@@ -4,6 +4,10 @@ defmodule Loopctl.Workers.ScaleAlertDeliveryWorkerTest do
   applies to a ScaleAlerts delivery. A delivery failure must return `{:error, _}` (the
   signal Oban uses to schedule the next attempt with its own backoff) rather than being
   swallowed to `{:ok, _}` and dropped; success returns `:ok`.
+
+  Review fix (secrets-at-rest): job args carry ONLY `payload` — no `url` — so `perform/1`
+  re-resolves the webhook URL via `ScaleAlerts.webhook_url/0` (config/test.exs sets
+  `:scale_alert_webhook_url` to `@url` below) instead of trusting a persisted job arg.
   """
   use Loopctl.DataCase, async: true
 
@@ -19,19 +23,21 @@ defmodule Loopctl.Workers.ScaleAlertDeliveryWorkerTest do
     "window_seconds" => 60,
     "at" => "2026-01-01T00:00:00Z"
   }
+  # Matches config/test.exs's `:scale_alert_webhook_url` — proves the worker resolves
+  # the URL from config rather than from job args (which no longer carry it).
   @url "https://alerts.test.invalid/scale"
 
   defp job(args), do: %Oban.Job{args: args}
 
   describe "timeout/1 (review fix)" do
     test "enforces the same 30s wall-clock cap as the sibling WebhookDeliveryWorker" do
-      assert ScaleAlertDeliveryWorker.timeout(job(%{"url" => @url, "payload" => @payload})) ==
+      assert ScaleAlertDeliveryWorker.timeout(job(%{"payload" => @payload})) ==
                :timer.seconds(30)
     end
   end
 
   describe "perform/1" do
-    test "successful delivery returns :ok and delivers the exact JSON payload + headers" do
+    test "args carry no url — successful delivery resolves it from config and delivers the exact JSON payload + headers" do
       expect(Loopctl.MockDelivery, :deliver, fn url, body, headers ->
         assert url == @url
         assert {"content-type", "application/json"} in headers
@@ -39,8 +45,7 @@ defmodule Loopctl.Workers.ScaleAlertDeliveryWorkerTest do
         {:ok, %{status: 200, body: "ok"}}
       end)
 
-      assert :ok =
-               ScaleAlertDeliveryWorker.perform(job(%{"url" => @url, "payload" => @payload}))
+      assert :ok = ScaleAlertDeliveryWorker.perform(job(%{"payload" => @payload}))
     end
 
     test "delivery failure returns {:error, _} so Oban retries (not dropped)" do
@@ -49,7 +54,37 @@ defmodule Loopctl.Workers.ScaleAlertDeliveryWorkerTest do
       end)
 
       assert {:error, "connection_refused"} =
-               ScaleAlertDeliveryWorker.perform(job(%{"url" => @url, "payload" => @payload}))
+               ScaleAlertDeliveryWorker.perform(job(%{"payload" => @payload}))
+    end
+
+    test "a job with a persisted url arg (legacy/pre-fix job) is ignored — the config url wins" do
+      expect(Loopctl.MockDelivery, :deliver, fn url, _body, _headers ->
+        assert url == @url
+        {:ok, %{status: 200, body: "ok"}}
+      end)
+
+      assert :ok =
+               ScaleAlertDeliveryWorker.perform(
+                 job(%{"url" => "https://attacker.invalid/steal", "payload" => @payload})
+               )
+    end
+  end
+
+  describe "deliver_or_skip/2 (review fix — URL resolved at run time, not from args)" do
+    test "a nil url (unset by delivery time) logs and completes as a no-op :ok, no delivery attempted" do
+      # No expect/3 set — verify_on_exit! would fail if `deliver/3` were called unexpectedly.
+      assert :ok = ScaleAlertDeliveryWorker.deliver_or_skip(@payload, nil)
+    end
+
+    test "a binary url delivers exactly as perform/1 would" do
+      expect(Loopctl.MockDelivery, :deliver, fn url, body, headers ->
+        assert url == @url
+        assert {"content-type", "application/json"} in headers
+        assert Jason.decode!(body) == @payload
+        {:ok, %{status: 200, body: "ok"}}
+      end)
+
+      assert :ok = ScaleAlertDeliveryWorker.deliver_or_skip(@payload, @url)
     end
   end
 end


### PR DESCRIPTION
## Summary

US-34.5: hardens Loopctl.Telemetry.ScaleAlerts delivery in two ways:

- **AC-34.5.1 (durable delivery)** - alert payloads are now enqueued through a new Loopctl.Workers.ScaleAlertDeliveryWorker (Oban :webhooks queue, max_attempts: 6) instead of a synchronous in-process POST. A transient webhook failure now retries with Oban's native backoff instead of being logged and dropped. The nil-URL / disabled path is untouched -- it stays a synchronous log-only no-op (AC-34.5.4, US-32.4 readiness guard unaffected).
- **AC-34.5.2 / AC-34.5.3 (bounded periodic re-notify)** - per-metric breach state now tracks last_notified_at alongside the edge-triggered flag. A sustained breach re-fires once the configured (and floored) re-notify interval elapses, instead of firing exactly once and going silent for the rest of an hours-long breach. Clearing below threshold still re-arms immediately -- the existing edge-fire semantics (fire on false to true) are unchanged, and all three US-27.15 signals plus the US-34.3 signals benefit uniformly (the logic lives in the shared step function).

New config: scale_alert_renotify_interval_ms (default 15 min, floored at 1 min in ScaleAlerts.renotify_interval_ms/0) with a SCALE_ALERT_RENOTIFY_INTERVAL_MS runtime env override. A now_fn + renotify_interval_ms per-instance start-opt (mirroring the existing webhook_url override pattern) gives tests a deterministic clock seam without sleeping or touching global config.

### Notable adaptation from the story's test guidance

The story suggested mirroring signup_test.exs's Oban.Testing.with_testing_mode(:manual, ...) + assert_enqueued pattern for the retry-not-dropped integration test. That pattern relies on a process-dictionary override scoped to the calling process -- it works in signup_test.exs because the enqueue happens via a plain context-function call inside the test process. ScaleAlerts is a long-running GenServer, so evaluate/0's Oban.insert/1 executes inside the server process, which the override never reaches. Instead, the integration tests assert directly on Oban's own job-lifecycle telemetry ([:oban, :job, :exception] / [:oban, :job, :stop]), proving a delivery failure is classified state: :failure (Oban's retryable state) rather than silently swallowed. A complementary worker-level unit test (scale_alert_delivery_worker_test.exs) proves perform/1 itself returns {:error, _} on failure and :ok on success.

## Test plan

- [x] mix precommit (compile --warnings-as-errors, format --check-formatted, credo --strict, deps.audit, dialyzer, full test suite) -- 4333 tests, 0 failures
- [x] All pre-existing ScaleAlerts tests (edge-fire, debounce, tumbling window, p95 floor, payload-scrubbing, nil-url) pass unchanged
- [x] New: durable delivery via Oban telemetry (failure -> :failure state, success -> :success state)
- [x] New: worker-level perform/1 unit tests (success -> :ok, failure -> {:error, _})
- [x] New: bounded periodic re-notify (fires on edge, debounced before interval, re-fires after interval elapses, re-arms on clear)
- [x] Nil-URL path extended to assert no Oban job event fires at all
