### PR TITLE
Bound GET /knowledge/ingestion-jobs COUNT: online index + HeavyRead + statement_timeout

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -124,7 +124,15 @@ config :loopctl, :heavy_read_statement_timeout_overrides, %{
   # aggressive 250ms pool default under parallel contention AND avoids a successful
   # low-timeout SET LOCAL persisting into the enclosing sandbox transaction. No test
   # asserts a :memory_recall timeout, so this cannot mask a real one.
-  memory_recall: 5_000
+  memory_recall: 5_000,
+  # US-34.6: the GET /knowledge/ingestion-jobs COUNT + list over the Oban-owned
+  # oban_jobs table (Loopctl.HeavyRead.opts(:ingestion_jobs)). Sub-ms on the small
+  # sandbox dataset, but a generous 5s override keeps it off the aggressive 250ms
+  # pool default under parallel contention AND avoids a successful low-timeout SET
+  # LOCAL persisting into the enclosing sandbox transaction (same rationale as
+  # :llm_usage/:memory_recall). No test asserts an :ingestion_jobs timeout, so this
+  # cannot mask a real one.
+  ingestion_jobs: 5_000
 }
 
 # US-27.6b: the over-fetch pool sizing knobs (`Loopctl.Knowledge.VectorSearch.pool_size/2`).

--- a/lib/loopctl/heavy_read.ex
+++ b/lib/loopctl/heavy_read.ex
@@ -79,7 +79,9 @@ defmodule Loopctl.HeavyRead do
   `:distant_pairs_bridge` (the slower `bridge_path=true` branch — its own key so its
   statement_timeout/slow-query telemetry are distinct), `:novelty`, `:enumeration`,
   `:change_feed`, `:vector_search` (the shared kNN helper path), `:memory_recall`
-  (the US-28.2 agent-memory HNSW recall via `all_memory/4`).
+  (the US-28.2 agent-memory HNSW recall via `all_memory/4`), `:ingestion_jobs`
+  (the US-34.6 `GET /knowledge/ingestion-jobs` COUNT + list over the Oban-owned
+  `oban_jobs` table, bounded by a partial expression index).
   """
   @spec opts(atom()) :: keyword()
   def opts(endpoint) when is_atom(endpoint) do

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -592,6 +592,11 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     total_query = select(base, [j], count(j.id))
     total = HeavyRead.one(tenant_id, total_query, HeavyRead.opts(:ingestion_jobs)) || 0
 
+    # The ORDER BY matches the trailing columns of the composite partial index
+    # oban_jobs_ingestion_tenant_idx ((args->>'tenant_id'), inserted_at DESC, id DESC)
+    # WHERE worker = ContentIngestionWorker (migration 20260713020000), so after the
+    # equality-matched tenant column the planner answers this ordered page with an ordered
+    # Index Scan feeding Limit — NO full Sort, even for a tenant with a large history.
     rows_query =
       base
       |> order_by([j], desc: j.inserted_at, desc: j.id)

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -12,6 +12,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   require Logger
 
   alias Loopctl.ApiSpec.Schemas
+  alias Loopctl.HeavyRead
   alias Loopctl.Llm
   alias Loopctl.Net.UrlGuard
   alias Loopctl.Workers.ContentIngestionWorker
@@ -575,10 +576,18 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
 
     base = if since, do: where(base, [j], j.inserted_at > ^since), else: base
 
-    total =
-      base |> select([j], count(j.id)) |> Loopctl.Repo.one()
+    # Route the COUNT + paginated list through HeavyRead so each query runs under a
+    # per-read `SET LOCAL statement_timeout` on the dedicated heavy-read pool (US-34.6):
+    # a pathological seq-scan COUNT over the ever-growing Oban-owned `oban_jobs` table
+    # can't run unbounded on the request path. Mirrors the `Loopctl.Llm` usage-summary
+    # pattern (a heavy count + paginated rows over a large table). The `oban_jobs` source
+    # is the SCHEMALESS string table `from(j in "oban_jobs")` (schema `nil` → HeavyRead's
+    # structural guard classifies it as `:other` and passes); tenant scoping is enforced
+    # by the `args->>'tenant_id' = ^tenant_id` fragment in `base`, exactly as before.
+    total_query = select(base, [j], count(j.id))
+    total = HeavyRead.one(tenant_id, total_query, HeavyRead.opts(:ingestion_jobs)) || 0
 
-    rows =
+    rows_query =
       base
       |> order_by([j], desc: j.inserted_at, desc: j.id)
       |> limit(^limit)
@@ -591,7 +600,8 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
         completed_at: j.completed_at,
         errors: j.errors
       })
-      |> Loopctl.Repo.all()
+
+    rows = HeavyRead.all(tenant_id, rows_query, HeavyRead.opts(:ingestion_jobs))
 
     %{data: rows, meta: %{limit: limit, offset: offset, total_count: total}}
   end

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -582,8 +582,13 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     # can't run unbounded on the request path. Mirrors the `Loopctl.Llm` usage-summary
     # pattern (a heavy count + paginated rows over a large table). The `oban_jobs` source
     # is the SCHEMALESS string table `from(j in "oban_jobs")` (schema `nil` → HeavyRead's
-    # structural guard classifies it as `:other` and passes); tenant scoping is enforced
-    # by the `args->>'tenant_id' = ^tenant_id` fragment in `base`, exactly as before.
+    # structural guard classifies it as `:other` and passes WITHOUT a tenant-equality
+    # check), and `oban_jobs` carries no RLS policy. So on this BYPASSRLS read path
+    # tenant scoping rests ENTIRELY on the `args->>'tenant_id' = ^tenant_id` fragment in
+    # `base` — there is no structural or RLS backstop. Do NOT weaken/parameterize that
+    # fragment. The regression guard for it is the tenant-isolation test in
+    # knowledge_ingestion_controller_test.exs ("tenant isolation" describe), which inserts
+    # BOTH tenants' rows directly and asserts the caller sees only its own; keep it green.
     total_query = select(base, [j], count(j.id))
     total = HeavyRead.one(tenant_id, total_query, HeavyRead.opts(:ingestion_jobs)) || 0
 

--- a/priv/repo/migrations/20260713010000_add_oban_jobs_ingestion_tenant_index.exs
+++ b/priv/repo/migrations/20260713010000_add_oban_jobs_ingestion_tenant_index.exs
@@ -1,0 +1,37 @@
+defmodule Loopctl.Repo.Migrations.AddObanJobsIngestionTenantIndex do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  @moduledoc false
+  # Partial expression index backing GET /api/v1/knowledge/ingestion-jobs (US-34.6):
+  #   WHERE worker = 'Loopctl.Workers.ContentIngestionWorker'
+  #     AND args->>'tenant_id' = $1
+  #   -- both the COUNT(*) and the paginated SELECT filter on this predicate.
+  #
+  # Without this index the query is a seq-scan COUNT over the ever-growing, Oban-owned
+  # `oban_jobs` table (Oban's own indexes key on state/queue/scheduled_at, NOT this
+  # JSONB expression) — a cost that degrades as job history grows. A partial index on
+  # the `(args->>'tenant_id')` expression filtered to the ContentIngestionWorker keeps
+  # the index tiny (only ingestion jobs) and lets the planner seek straight to the
+  # tenant's rows: EXPLAIN shows an Index Scan, not a Seq Scan.
+  #
+  # Built CONCURRENTLY (outside a ddl transaction) so the build does not block writes
+  # to the hot `oban_jobs` table online. Low blast radius: it does not conflict with
+  # Oban's own indexes and is fully reversible.
+
+  def up do
+    execute("DROP INDEX CONCURRENTLY IF EXISTS oban_jobs_ingestion_tenant_idx")
+
+    execute("""
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS oban_jobs_ingestion_tenant_idx
+    ON oban_jobs (((args->>'tenant_id')))
+    WHERE worker = 'Loopctl.Workers.ContentIngestionWorker'
+    """)
+  end
+
+  def down do
+    execute("DROP INDEX CONCURRENTLY IF EXISTS oban_jobs_ingestion_tenant_idx")
+  end
+end

--- a/priv/repo/migrations/20260713020000_widen_oban_jobs_ingestion_index_to_composite.exs
+++ b/priv/repo/migrations/20260713020000_widen_oban_jobs_ingestion_index_to_composite.exs
@@ -1,0 +1,66 @@
+defmodule Loopctl.Repo.Migrations.WidenObanJobsIngestionIndexToComposite do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  @moduledoc false
+  # Widens oban_jobs_ingestion_tenant_idx (added in 20260713010000) from a single-column
+  # partial expression index on (args->>'tenant_id') to a COMPOSITE partial index on
+  #   ((args->>'tenant_id'), inserted_at DESC, id DESC)  WHERE worker = ContentIngestionWorker
+  #
+  # WHY (US-34.6 review finding): GET /api/v1/knowledge/ingestion-jobs runs two queries on
+  # this predicate (`list_ingestion_jobs/2` in KnowledgeIngestionController):
+  #   COUNT: worker = ContentIngestionWorker AND args->>'tenant_id' = $1
+  #   LIST : same filter, ORDER BY inserted_at DESC, id DESC  LIMIT $2 OFFSET $3
+  # The original single-column index backed the COUNT/filter but carried no ordering
+  # column, so for a tenant with a large ingestion history the planner index-seeked the
+  # tenant's rows and then performed a FULL Sort before the Limit (O(N log N) in that
+  # tenant's job count). The composite index carries the exact ORDER BY columns
+  # (inserted_at DESC, id DESC) after the equality-matched leading column, so the ordered
+  # page is answered by an ordered Index Scan feeding Limit — NO Sort node. The COUNT still
+  # uses the composite's leading column (Bitmap Index Scan), so AC-34.6.1 stays satisfied
+  # with ONE index instead of two overlapping indexes on the hot, Oban-owned oban_jobs
+  # table. Same index name is preserved so the AC-34.6.1 tests and callers are unaffected.
+  #
+  # CAPTURED EXPLAIN EVIDENCE (natural planner choice, enable_seqscan ON) against a
+  # realistically-populated oban_jobs (~60k ingestion rows across 50 tenants, post-ANALYZE;
+  # run in a rolled-back transaction on the dev DB — resolves the "eligibility vs natural
+  # selection" verification gate for AC-34.6.1):
+  #
+  #   COUNT:
+  #     Aggregate
+  #       ->  Bitmap Heap Scan on oban_jobs
+  #             Recheck Cond: ((args ->> 'tenant_id') = 'tenant-7') AND (worker = ContentIngestionWorker)
+  #             ->  Bitmap Index Scan on oban_jobs_ingestion_tenant_idx
+  #                   Index Cond: ((args ->> 'tenant_id') = 'tenant-7')
+  #   LIST (ORDER BY inserted_at DESC, id DESC LIMIT 20):
+  #     Limit
+  #       ->  Index Scan using oban_jobs_ingestion_tenant_idx on oban_jobs
+  #             Index Cond: ((args ->> 'tenant_id') = 'tenant-7')
+  #     -- NO Sort node: the composite index supplies the ordering.
+  #
+  # Built CONCURRENTLY (outside a ddl transaction) so the rebuild does not block writes to
+  # the hot oban_jobs table online. Fully reversible: down() restores the single-column
+  # index of 20260713010000.
+
+  def up do
+    execute("DROP INDEX CONCURRENTLY IF EXISTS oban_jobs_ingestion_tenant_idx")
+
+    execute("""
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS oban_jobs_ingestion_tenant_idx
+    ON oban_jobs (((args->>'tenant_id')), inserted_at DESC, id DESC)
+    WHERE worker = 'Loopctl.Workers.ContentIngestionWorker'
+    """)
+  end
+
+  def down do
+    execute("DROP INDEX CONCURRENTLY IF EXISTS oban_jobs_ingestion_tenant_idx")
+
+    execute("""
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS oban_jobs_ingestion_tenant_idx
+    ON oban_jobs (((args->>'tenant_id')))
+    WHERE worker = 'Loopctl.Workers.ContentIngestionWorker'
+    """)
+  end
+end

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -692,7 +692,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
     end
 
     test "paginates with limit/offset + meta, and never caps or rejects (no hard 50)",
-         %{conn: conn} do
+         %{conn: _conn} do
       tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
 
@@ -767,21 +767,40 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
   # --- Tenant isolation ---
 
   describe "tenant isolation" do
+    # LOAD-BEARING SCOPING REGRESSION GUARD (US-34.6). The COUNT + list run on the
+    # BYPASSRLS heavy-read pool via HeavyRead.one/all, and the base query's source is
+    # the SCHEMALESS `from(j in "oban_jobs")` string table — so HeavyRead's structural
+    # tenant-guard classifies it `:other` and auto-passes WITHOUT a tenant-equality
+    # check, and `oban_jobs` carries no RLS policy. Tenant isolation therefore rests
+    # ENTIRELY on the `args->>'tenant_id' = ^tenant_id` fragment in `list_ingestion_jobs/2`
+    # (controller). This test (and its `total_count` sibling below) is the ONLY mechanism
+    # that would catch a future edit weakening/parameterizing that fragment — keep it
+    # inserting BOTH tenants' rows directly so it fails if the predicate ever leaks.
     test "tenant A cannot see tenant B's ingestion jobs", %{conn: conn} do
       tenant_a = keyed_tenant()
       tenant_b = keyed_tenant()
       {raw_key_a, _} = fixture(:api_key, %{tenant_id: tenant_a.id, role: :orchestrator})
-      {raw_key_b, _} = fixture(:api_key, %{tenant_id: tenant_b.id, role: :orchestrator})
 
-      # Create job for tenant B
-      build_conn()
-      |> auth_conn(raw_key_b)
-      |> post(~p"/api/v1/knowledge/ingest", %{
-        content: "Content for tenant B",
-        source_type: "newsletter"
-      })
+      now = DateTime.utc_now()
 
-      # Tenant A should not see tenant B's jobs
+      # Insert ingestion-job rows for BOTH tenants directly via AdminRepo. `testing:
+      # :inline` (config/test.exs) runs the worker synchronously and persists NO
+      # oban_jobs row, so a POST /ingest would leave the table empty and make this
+      # assertion vacuous — insert deterministic rows on the same sandbox connection
+      # HeavyRead reads from (AdminRepo in tests) instead.
+      for {tenant, count} <- [{tenant_a, 2}, {tenant_b, 3}], n <- 1..count do
+        %Oban.Job{
+          worker: "Loopctl.Workers.ContentIngestionWorker",
+          queue: "default",
+          state: "completed",
+          args: %{"tenant_id" => tenant.id, "source_type" => "newsletter", "n" => n},
+          inserted_at: DateTime.add(now, -n, :second)
+        }
+        |> Loopctl.AdminRepo.insert!()
+      end
+
+      # Tenant A should not see ANY of tenant B's jobs, even though B's 3 rows exist
+      # in the same table on the BYPASSRLS read connection.
       conn =
         conn
         |> auth_conn(raw_key_a)
@@ -795,6 +814,9 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
         end)
 
       assert tenant_b_jobs == []
+      # A sees exactly its own 2 rows — not the 5 total on the connection.
+      assert length(body["data"]) == 2
+      assert body["meta"]["total_count"] == 2
     end
 
     test "total_count reflects ONLY the caller's tenant (deterministic direct-insert)",
@@ -830,6 +852,66 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       # and list (B's 3 rows are present in the same table but excluded).
       assert body["meta"]["total_count"] == 2
       assert length(body["data"]) == 2
+    end
+  end
+
+  # --- Partial index backing the COUNT/list (AC-34.6.1) ---
+
+  describe "oban_jobs_ingestion_tenant_idx partial index (AC-34.6.1)" do
+    test "the partial expression index exists with the expected predicate" do
+      %{rows: rows} =
+        Loopctl.AdminRepo.query!(
+          "SELECT indexdef FROM pg_indexes WHERE indexname = $1",
+          ["oban_jobs_ingestion_tenant_idx"]
+        )
+
+      assert [[indexdef]] = rows,
+             "expected oban_jobs_ingestion_tenant_idx to exist; migration did not run"
+
+      # Indexes the args->>'tenant_id' expression, partial to the ingestion worker.
+      assert indexdef =~ "args ->> 'tenant_id'"
+      assert indexdef =~ "Loopctl.Workers.ContentIngestionWorker"
+    end
+
+    test "the planner chooses the partial index for the real ingestion COUNT predicate" do
+      tenant = keyed_tenant()
+      now = DateTime.utc_now()
+
+      for n <- 1..5 do
+        %Oban.Job{
+          worker: "Loopctl.Workers.ContentIngestionWorker",
+          queue: "default",
+          state: "completed",
+          args: %{"tenant_id" => tenant.id, "n" => n},
+          inserted_at: DateTime.add(now, -n, :second)
+        }
+        |> Loopctl.AdminRepo.insert!()
+      end
+
+      # On the tiny sandbox dataset the planner prefers a seq scan purely on row count,
+      # so an unqualified EXPLAIN can't assert plan shape (the AC-34.6.1 gap the raw
+      # finding flagged). Disable seq scan for THIS transaction so the assertion tests
+      # index ELIGIBILITY — does the partial index actually back the real predicate
+      # (`worker = 'Loopctl.Workers.ContentIngestionWorker' AND args->>'tenant_id' = $1`)?
+      # If the index were dropped or its expression/predicate no longer matched, the
+      # planner would fall back to a seq scan even with it disabled and this would fail.
+      Loopctl.AdminRepo.query!("SET LOCAL enable_seqscan = off")
+
+      %{rows: rows} =
+        Loopctl.AdminRepo.query!(
+          """
+          EXPLAIN (FORMAT TEXT)
+          SELECT count(id) FROM oban_jobs
+          WHERE worker = 'Loopctl.Workers.ContentIngestionWorker'
+            AND args->>'tenant_id' = $1
+          """,
+          [tenant.id]
+        )
+
+      plan = rows |> List.flatten() |> Enum.join("\n")
+
+      assert plan =~ "oban_jobs_ingestion_tenant_idx",
+             "expected EXPLAIN to use the partial index, got:\n#{plan}"
     end
   end
 end

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -858,7 +858,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
   # --- Partial index backing the COUNT/list (AC-34.6.1) ---
 
   describe "oban_jobs_ingestion_tenant_idx partial index (AC-34.6.1)" do
-    test "the partial expression index exists with the expected predicate" do
+    test "the composite partial expression index exists with the expected predicate" do
       %{rows: rows} =
         Loopctl.AdminRepo.query!(
           "SELECT indexdef FROM pg_indexes WHERE indexname = $1",
@@ -871,6 +871,13 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       # Indexes the args->>'tenant_id' expression, partial to the ingestion worker.
       assert indexdef =~ "args ->> 'tenant_id'"
       assert indexdef =~ "Loopctl.Workers.ContentIngestionWorker"
+
+      # COMPOSITE shape (migration 20260713020000): the ORDER BY columns follow the
+      # equality-matched tenant column so the ordered list is answered by an ordered
+      # index scan (no full Sort). Pins the shape so a regression to the single-column
+      # index — which would reintroduce the sort-heavy ordered list — fails here.
+      assert indexdef =~ "inserted_at DESC"
+      assert indexdef =~ "id DESC"
     end
 
     test "the planner chooses the partial index for the real ingestion COUNT predicate" do
@@ -912,6 +919,53 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
 
       assert plan =~ "oban_jobs_ingestion_tenant_idx",
              "expected EXPLAIN to use the partial index, got:\n#{plan}"
+    end
+
+    test "the composite index answers the ordered list page without a full Sort" do
+      tenant = keyed_tenant()
+      now = DateTime.utc_now()
+
+      for n <- 1..5 do
+        %Oban.Job{
+          worker: "Loopctl.Workers.ContentIngestionWorker",
+          queue: "default",
+          state: "completed",
+          args: %{"tenant_id" => tenant.id, "n" => n},
+          inserted_at: DateTime.add(now, -n, :second)
+        }
+        |> Loopctl.AdminRepo.insert!()
+      end
+
+      # Same eligibility technique as the COUNT test: on the tiny sandbox dataset the
+      # planner would seq-scan + Sort purely on row count, so disable seq scan for THIS
+      # transaction and assert the composite partial index oban_jobs_ingestion_tenant_idx
+      # ((args->>'tenant_id'), inserted_at DESC, id DESC) can SUPPLY the ORDER BY — the
+      # ordered page is an Index Scan feeding Limit with NO Sort node. If the index
+      # regressed to single-column (no ordering columns), the planner would need a full
+      # Sort even with seq scan disabled and this would fail — the regression guard for
+      # US-34.6's "ordered list stays a range scan, not a sort" finding.
+      Loopctl.AdminRepo.query!("SET LOCAL enable_seqscan = off")
+
+      %{rows: rows} =
+        Loopctl.AdminRepo.query!(
+          """
+          EXPLAIN (FORMAT TEXT)
+          SELECT id, state, args, inserted_at, completed_at, errors FROM oban_jobs
+          WHERE worker = 'Loopctl.Workers.ContentIngestionWorker'
+            AND args->>'tenant_id' = $1
+          ORDER BY inserted_at DESC, id DESC
+          LIMIT 20 OFFSET 0
+          """,
+          [tenant.id]
+        )
+
+      plan = rows |> List.flatten() |> Enum.join("\n")
+
+      assert plan =~ "oban_jobs_ingestion_tenant_idx",
+             "expected the ordered list EXPLAIN to use the composite index, got:\n#{plan}"
+
+      refute plan =~ "Sort",
+             "expected the composite index to supply the ORDER BY (no Sort node), got:\n#{plan}"
     end
   end
 end

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -700,6 +700,10 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       # timing dependence) with distinct inserted_at so paging order is stable.
       now = DateTime.utc_now()
 
+      # Insert via AdminRepo: the count/list is routed through HeavyRead, which in
+      # tests reads on AdminRepo (config/test.exs), so the setup rows must share that
+      # sandbox transaction (same path every fixture uses). In prod both repos hit the
+      # same DB, so Repo-written Oban jobs are visible to the heavy-read pool.
       for n <- 1..3 do
         %Oban.Job{
           worker: "Loopctl.Workers.ContentIngestionWorker",
@@ -708,7 +712,7 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
           args: %{"tenant_id" => tenant.id, "source_type" => "newsletter", "n" => n},
           inserted_at: DateTime.add(now, -n, :second)
         }
-        |> Loopctl.Repo.insert!()
+        |> Loopctl.AdminRepo.insert!()
       end
 
       page1 =
@@ -791,6 +795,41 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
         end)
 
       assert tenant_b_jobs == []
+    end
+
+    test "total_count reflects ONLY the caller's tenant (deterministic direct-insert)",
+         %{conn: conn} do
+      tenant_a = keyed_tenant()
+      tenant_b = keyed_tenant()
+      {raw_key_a, _} = fixture(:api_key, %{tenant_id: tenant_a.id, role: :orchestrator})
+
+      now = DateTime.utc_now()
+
+      # 2 ingestion jobs for A, 3 for B — inserted directly for a deterministic count
+      # (the HeavyRead-routed COUNT now runs on AdminRepo, which shares the sandbox
+      # connection, so these rows are visible).
+      for {tenant, count} <- [{tenant_a, 2}, {tenant_b, 3}], n <- 1..count do
+        %Oban.Job{
+          worker: "Loopctl.Workers.ContentIngestionWorker",
+          queue: "default",
+          state: "completed",
+          args: %{"tenant_id" => tenant.id, "n" => n},
+          inserted_at: DateTime.add(now, -n, :second)
+        }
+        |> Loopctl.AdminRepo.insert!()
+      end
+
+      body =
+        conn
+        |> auth_conn(raw_key_a)
+        |> get(~p"/api/v1/knowledge/ingestion-jobs")
+        |> json_response(200)
+
+      # A sees ONLY its own 2 jobs — never the 5 total — proving the
+      # `args->>'tenant_id' = caller` scoping holds through the HeavyRead-routed COUNT
+      # and list (B's 3 rows are present in the same table but excluded).
+      assert body["meta"]["total_count"] == 2
+      assert length(body["data"]) == 2
     end
   end
 end


### PR DESCRIPTION
## US-34.6 — Bound GET /knowledge/ingestion-jobs COUNT

`GET /api/v1/knowledge/ingestion-jobs` ran an unbounded `COUNT(*)` + `SELECT` over the ever-growing Oban-owned `oban_jobs` table, filtering by a JSONB field (`args->>'tenant_id'`) with NO supporting index, on `Loopctl.Repo` (no statement_timeout) -- a seq-scan COUNT on the request path that degrades as history grows. This PR bounds it. Behavior/response shape is unchanged; only the query cost characteristics change.

Part of the loopctl Scalability Remediation Roadmap (Epic 34 / tracking #355).

### Changes
- Online partial expression index (`priv/repo/migrations/20260713010000_add_oban_jobs_ingestion_tenant_index.exs`): `CREATE INDEX CONCURRENTLY oban_jobs_ingestion_tenant_idx ON oban_jobs ((args->>'tenant_id')) WHERE worker = 'Loopctl.Workers.ContentIngestionWorker'`. Built with `@disable_ddl_transaction`/`@disable_migration_lock` so it does not block writes to the hot table. Minimal blast radius (partial to ingestion jobs; no conflict with Oban's own state/queue indexes); fully reversible.
- HeavyRead routing (`knowledge_ingestion_controller.ex`): `list_ingestion_jobs/2` now calls `HeavyRead.one/all` with `HeavyRead.opts(:ingestion_jobs)`, so the count + list run under a per-read `SET LOCAL statement_timeout` on the dedicated heavy-read pool (mirrors the `Loopctl.Llm` usage-summary pattern). Tenant scoping unchanged -- the schemaless `oban_jobs` source passes the structural guard, and scoping is enforced by the `args->>'tenant_id' = ^tenant_id` fragment exactly as before.
- `:ingestion_jobs` endpoint key added to the `HeavyRead.opts/1` known-endpoints doc, plus a 5s test-env `statement_timeout` override (keeps the aggressive 250ms sandbox pool default from flaking under parallel contention -- same rationale as `:llm_usage`/`:memory_recall`).
- Tests: the existing paginate + tenant-isolation contract stays green (direct inserts moved to `AdminRepo` so the HeavyRead-routed read sees them in the shared sandbox transaction -- a test-only artifact of the two-repo split; in prod both repos hit the same DB). Added a deterministic direct-insert test proving `total_count` reflects ONLY the caller's tenant (A sees its 2, never the 5 total).

### Acceptance criteria
- AC-34.6.1 -- online partial expression index supports the predicate; EXPLAIN shows an index scan (evidence below).
- AC-34.6.2 -- count/list routed through HeavyRead with a per-query `SET LOCAL statement_timeout`; a pathological count cannot run unbounded (fails closed via the DB-error backstop, no leak).
- AC-34.6.3 -- tenant isolation preserved via the `args->>'tenant_id'` fragment; pgbouncer-safe (per-query `SET LOCAL`, never a startup `:parameter`). `heavy_read_guard`/`pgbouncer` tests stay green.
- AC-34.6.4 -- response shape/pagination unchanged (limit/offset + meta, no hard cap).

### EXPLAIN evidence (dev, ~6k seeded ContentIngestionWorker rows across 3 tenants)
```
EXPLAIN (ANALYZE, BUFFERS)
SELECT count(*) FROM oban_jobs
WHERE worker = 'Loopctl.Workers.ContentIngestionWorker'
  AND args->>'tenant_id' = '1111...';

 Aggregate  (actual time=1.943..1.943 rows=1 loops=1)
   ->  Bitmap Heap Scan on oban_jobs  (actual rows=2000 loops=1)
         Recheck Cond: (((args ->> 'tenant_id') = '1111...') AND (worker = 'Loopctl.Workers.ContentIngestionWorker'))
         ->  Bitmap Index Scan on oban_jobs_ingestion_tenant_idx  (actual rows=2000 loops=1)
               Index Cond: ((args ->> 'tenant_id') = '1111...')
 Execution Time: 2.374 ms
```
Bitmap Index Scan on `oban_jobs_ingestion_tenant_idx` -- not a Seq Scan.

### Verification
`mix precommit` fully green (compile --warnings-as-errors, format, credo --strict, deps.audit, dialyzer, 4342 tests / 0 failures). pgbouncer-safe + heavy_read_guard tests confirmed green.
