### PR TITLE
feat(epic_34): US-34.1 Oban queue/state gauges + :executing orphan gauge; Reindexer

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -129,6 +129,13 @@ config :loopctl,
   # `telemetry_poller` instance in LoopctlWeb.Telemetry (NOT the shared
   # tenant-label-gate poller — a review finding flagged inheriting that cadence as a
   # deviation from the AC's "bounded interval (config)" wording).
+  # - oban_metrics_poll_enabled: start the SUPERVISED oban poller child. ON by
+  #   default (purely additive in prod/dev). Forced OFF in :test (config/test.exs)
+  #   — a review finding: the poller fires at boot via `dispatch_oban_stats/0`'s
+  #   `Loopctl.MockObanStats` Mox seam, before any ExUnit test process holds the
+  #   private-mode allowance, so it would raise `Mox.UnexpectedCallError` on every
+  #   collect for the whole suite. Integration coverage instead calls
+  #   `dispatch_oban_stats/0` directly (scale_metrics_oban_test.exs).
   # - oban_metrics_poll_interval_ms: how often oban_jobs is polled. Kept at the same
   #   10s default as the shared poller (no behavior change), but now a dedicated knob
   #   so the cadence of this specific, heavier (unindexed GROUP BY aggregate) query
@@ -145,6 +152,7 @@ config :loopctl,
   #   equating the threshold to rescue_after would conflate that steady state with
   #   "Lifeline is falling behind / a job is wedged" (the actual alert condition this
   #   gauge exists to signal, feeding US-34.3 alerting).
+  oban_metrics_poll_enabled: true,
   oban_metrics_poll_interval_ms: 10_000,
   oban_metrics_query_timeout_ms: 5_000,
   oban_metrics_orphan_threshold_minutes: 40

--- a/config/config.exs
+++ b/config/config.exs
@@ -123,7 +123,31 @@ config :loopctl,
   scale_alert_check_interval_ms: 60_000,
   scale_alert_timeout_rate_per_min: 5,
   scale_alert_p95_latency_ms: 2_000,
-  scale_alert_under_fill_rate_per_min: 30
+  scale_alert_under_fill_rate_per_min: 30,
+  # US-34.1: the Oban `oban_jobs` observability poll (Loopctl.Telemetry.ScaleMetrics
+  # .dispatch_oban_stats/0), wired into its OWN independently-configurable
+  # `telemetry_poller` instance in LoopctlWeb.Telemetry (NOT the shared
+  # tenant-label-gate poller — a review finding flagged inheriting that cadence as a
+  # deviation from the AC's "bounded interval (config)" wording).
+  # - oban_metrics_poll_interval_ms: how often oban_jobs is polled. Kept at the same
+  #   10s default as the shared poller (no behavior change), but now a dedicated knob
+  #   so the cadence of this specific, heavier (unindexed GROUP BY aggregate) query
+  #   can be tuned independently of the cheap tenant-count gate refresh.
+  # - oban_metrics_query_timeout_ms: the per-query SERVER-SIDE `SET LOCAL
+  #   statement_timeout` (and matching client-side timeout) for both the per-(state,
+  #   queue) count query and the :executing orphan count query — keeps the poll from
+  #   being able to saturate the RLS Repo pool (AC-34.1.3) even if oban_jobs grows
+  #   large or a query plan degrades.
+  # - oban_metrics_orphan_threshold_minutes: how long a job may sit `executing`
+  #   before it counts as an orphan (AC-34.1.2). Deliberately set ABOVE (not equal to)
+  #   Oban.Plugins.Lifeline's `rescue_after` (30 min) below — a job that has merely
+  #   crossed 30 min is still awaiting Lifeline's next periodic sweep (normal), and
+  #   equating the threshold to rescue_after would conflate that steady state with
+  #   "Lifeline is falling behind / a job is wedged" (the actual alert condition this
+  #   gauge exists to signal, feeding US-34.3 alerting).
+  oban_metrics_poll_interval_ms: 10_000,
+  oban_metrics_query_timeout_ms: 5_000,
+  oban_metrics_orphan_threshold_minutes: 40
 
 # US-33.3: bounded TTL (ms) for the ETS read-through api-key cache. This is the
 # defense-in-depth backstop, NOT the primary invalidation — every revoke/rotate/
@@ -325,8 +349,21 @@ config :loopctl, Oban,
     {Oban.Plugins.Lifeline, rescue_after: :timer.minutes(30)},
     # Prune terminal (completed/discarded/cancelled) jobs older than 7 days so the
     # oban_jobs table doesn't grow unbounded.
-    {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 7}
+    {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 7},
+    # US-34.1: periodically REINDEX CONCURRENTLY the oban_jobs args/meta indexes so
+    # they don't accumulate bloat as jobs churn through Cron/Lifeline/Pruner. Default
+    # schedule (@midnight UTC) is fine — this is maintenance, not latency-critical.
+    Oban.Plugins.Reindexer
   ]
+
+# US-34.1: `Oban.Stager` is NOT a plugin in Oban 2.21 — it's a core, always-running
+# GenServer (`@moduledoc false`, deps/oban/lib/oban/stager.ex) controlled by the
+# top-level `:stage_interval` config, not the `plugins:` list (adding
+# `Oban.Stager` there would be a config error). The default `stage_interval`
+# (1s) is intentionally relied upon to promote `scheduled` jobs to `available` —
+# pinning it explicitly here documents that reliance rather than leaving it
+# implicit, without changing behavior.
+# stage_interval: :timer.seconds(1)
 
 # Cloak Vault — key configured per environment
 # Generate a key: :crypto.strong_rand_bytes(32) |> Base.encode64()

--- a/config/test.exs
+++ b/config/test.exs
@@ -474,6 +474,12 @@ config :loopctl, :dns_resolve_timeout_ms, 2_000
 # ~200ms instead of the 5s production default. Config-based DI — no put_env.
 config :loopctl, :batch_item_validation_timeout_ms, 200
 
+# US-34.1: Oban `oban_jobs` observability poll DI. The DataCase default stub
+# delegates both callbacks to the real Loopctl.Telemetry.ObanStats so integration
+# tests exercise the genuine raw-SQL read against the sandbox connection; the
+# poller-resilience test overrides a callback with Mox.expect/3 to raise.
+config :loopctl, :oban_stats_query, Loopctl.MockObanStats
+
 # DI: swap ArticleLinkingWorker's similarity lookup for a Mox mock so the worker's
 # linking logic (relates_to / potential_conflict thresholds, dedup, audit, idempotency)
 # is unit-tested with deterministic candidate lists — never through the real pgvector kNN,

--- a/config/test.exs
+++ b/config/test.exs
@@ -480,6 +480,17 @@ config :loopctl, :batch_item_validation_timeout_ms, 200
 # poller-resilience test overrides a callback with Mox.expect/3 to raise.
 config :loopctl, :oban_stats_query, Loopctl.MockObanStats
 
+# US-34.1 review finding: the background oban poller is NOT started in :test (see
+# `oban_metrics_poll_enabled` in config/config.exs for the full rationale) — its
+# `telemetry_poller` fires at boot, before any ExUnit process owns the private-mode
+# `Loopctl.MockObanStats` Mox allowance, so an always-on poller would raise
+# `Mox.UnexpectedCallError` on every collect for the whole suite (and, given the
+# widened rescue in `ScaleMetrics.dispatch_oban_stats/0`, would just log-and-skip
+# forever rather than crash — permanently freezing the gauge). Integration
+# coverage of the poll itself lives in `scale_metrics_oban_test.exs`, which calls
+# `dispatch_oban_stats/0` directly from the owning test process.
+config :loopctl, :oban_metrics_poll_enabled, false
+
 # DI: swap ArticleLinkingWorker's similarity lookup for a Mox mock so the worker's
 # linking logic (relates_to / potential_conflict thresholds, dedup, audit, idempotency)
 # is unit-tested with deterministic candidate lists — never through the real pgvector kNN,

--- a/lib/loopctl/telemetry/oban_stats.ex
+++ b/lib/loopctl/telemetry/oban_stats.ex
@@ -1,0 +1,92 @@
+defmodule Loopctl.Telemetry.ObanStats do
+  @moduledoc """
+  Real `oban_jobs` reads for the US-34.1 observability poll.
+
+  `oban_jobs` is a GLOBAL infra table — no `tenant_id`, no RLS policy (it is not a
+  tenant schema) — so this goes through plain `Loopctl.Repo` with raw SQL, NEVER
+  `Loopctl.HeavyRead` (which STRUCTURALLY REQUIRES a `tenant_id`-scoped query and would
+  raise on a query with no tenant predicate at all).
+
+  Every query runs under a per-call SERVER-SIDE `SET LOCAL statement_timeout`
+  (config `:oban_metrics_query_timeout_ms`, default 5s) inside its own short
+  transaction — never a connection-startup `:parameters` timeout, which Fly MPG's
+  pgbouncer rejects with `08P01 unsupported startup parameter` (the same rationale
+  `Loopctl.HeavyRead` documents). This keeps the poll from being able to saturate the
+  RLS pool (AC-34.1.3) even if `oban_jobs` grows large or a query plan degrades.
+  """
+
+  @behaviour Loopctl.Telemetry.ObanStatsBehaviour
+
+  @default_query_timeout_ms 5_000
+
+  @impl true
+  @spec job_state_counts() :: [
+          {state :: String.t(), queue :: String.t(), count :: non_neg_integer()}
+        ]
+  def job_state_counts do
+    with_statement_timeout(fn ->
+      %Postgrex.Result{rows: rows} =
+        Loopctl.Repo.query!(
+          "SELECT state::text, queue, count(*) FROM oban_jobs GROUP BY state, queue"
+        )
+
+      Enum.map(rows, fn [state, queue, count] -> {state, queue, count} end)
+    end)
+  end
+
+  @impl true
+  @spec executing_orphan_count(pos_integer()) :: non_neg_integer()
+  def executing_orphan_count(threshold_minutes)
+      when is_integer(threshold_minutes) and threshold_minutes > 0 do
+    # The cutoff is computed HERE, in Elixir, as a naive (no-tz) UTC timestamp, and
+    # bound as a plain query parameter — NEVER `now() - interval` compared directly
+    # against `attempted_at` in SQL. `oban_jobs.attempted_at` is a `timestamp without
+    # time zone` column that Oban always stores as naive UTC; comparing it to a
+    # `timestamptz` expression (what `now() - interval` produces) makes Postgres
+    # convert one side through the SESSION timezone, which is NOT UTC in this deploy
+    # (`America/Denver` observed) — silently shifting the comparison by several hours
+    # and making a genuinely stale job read as "not stale". Binding a naive
+    # `NaiveDateTime` parameter sidesteps timezone interpretation entirely: it's
+    # compared wall-clock-to-wall-clock against the naive column, matching exactly
+    # how Oban itself writes `attempted_at`.
+    cutoff =
+      DateTime.utc_now()
+      |> DateTime.add(-threshold_minutes * 60, :second)
+      |> DateTime.to_naive()
+
+    with_statement_timeout(fn ->
+      %Postgrex.Result{rows: [[count]]} =
+        Loopctl.Repo.query!(
+          "SELECT count(*) FROM oban_jobs WHERE state = 'executing' AND attempted_at < $1",
+          [cutoff]
+        )
+
+      count
+    end)
+  end
+
+  # Runs `fun` inside a short transaction that first issues `SET LOCAL
+  # statement_timeout`, scoping the server-side timeout to THIS poll only (never
+  # relaxing/tightening it for any other query on the shared Repo pool).
+  defp with_statement_timeout(fun) do
+    ms = query_timeout_ms()
+
+    {:ok, result} =
+      Loopctl.Repo.transaction(
+        fn ->
+          Loopctl.Repo.query!("SET LOCAL statement_timeout = #{ms}")
+          fun.()
+        end,
+        timeout: ms + 1_000
+      )
+
+    result
+  end
+
+  defp query_timeout_ms do
+    case Application.get_env(:loopctl, :oban_metrics_query_timeout_ms, @default_query_timeout_ms) do
+      ms when is_integer(ms) and ms > 0 -> ms
+      _ -> @default_query_timeout_ms
+    end
+  end
+end

--- a/lib/loopctl/telemetry/oban_stats_behaviour.ex
+++ b/lib/loopctl/telemetry/oban_stats_behaviour.ex
@@ -1,0 +1,26 @@
+defmodule Loopctl.Telemetry.ObanStatsBehaviour do
+  @moduledoc """
+  DI seam (US-34.1) for the `oban_jobs` observability poll.
+
+  Split out from `Loopctl.Telemetry.ScaleMetrics.dispatch_oban_stats/0` purely so the
+  poller's error-resilience (AC-34.1.3 / TC-34.1.3) can be exercised deterministically
+  via `Mox.expect/3` raising — without needing to reproduce a real Postgres failure
+  (connection loss, statement_timeout race) to test the rescue path. Resolved via
+  `Application.get_env(:loopctl, :oban_stats_query, Loopctl.Telemetry.ObanStats)`; the
+  real implementation is `Loopctl.Telemetry.ObanStats`, the test double is
+  `Loopctl.MockObanStats` (the DataCase default stub delegates to the real module so
+  every other test still exercises the genuine `oban_jobs` read).
+  """
+
+  @doc "Per-(state, queue) row counts from `oban_jobs` (AC-34.1.1)."
+  @callback job_state_counts() :: [
+              {state :: String.t(), queue :: String.t(), count :: non_neg_integer()}
+            ]
+
+  @doc """
+  Count of `executing` jobs whose `attempted_at` is older than `threshold_minutes`
+  (AC-34.1.2 — the signal that `Oban.Plugins.Lifeline` is falling behind, or a job is
+  genuinely wedged).
+  """
+  @callback executing_orphan_count(threshold_minutes :: pos_integer()) :: non_neg_integer()
+end

--- a/lib/loopctl/telemetry/scale_metrics.ex
+++ b/lib/loopctl/telemetry/scale_metrics.ex
@@ -18,10 +18,15 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   `queue_time` (native time spent WAITING for a pooled connection) on every query
   telemetry event; before this branch only `heavy_read_repo.query.duration` was
   scraped, so there was no way to see where checkout contention lands between the
-  two pools. See "Per-pool checkout queue_time (US-33.1)" below. `scale_metrics/0`
-  now returns 7 metrics total.
+  two pools. See "Per-pool checkout queue_time (US-33.1)" below. US-34.1 adds TWO
+  more, purely-additive: a per-(state, queue) `oban_jobs` depth gauge and an
+  `:executing` orphan gauge — loopctl exported ZERO Oban metrics before this branch,
+  so a stalled queue or a growing orphan pile-up (the motivating incident: a 17-day /
+  110-orphan `:executing` stall went undetected for days) was invisible until users
+  hit it. See "Oban observability (US-34.1)" below. `scale_metrics/0` now returns 9
+  metrics total.
 
-  ## The metrics (7 total)
+  ## The metrics (9 total)
 
     1. **Timeout / DB-error counter** — `loopctl.db.error.count`, keyed by
        `[:endpoint, :mapped_code]` (+ a cap-gated `:tenant_id`). `mapped_code`
@@ -48,6 +53,24 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
     7. **AdminRepo-pool checkout `queue_time` distribution** (US-33.1) —
        `loopctl.admin_repo.checkout.queue_time`, with a static `[:repo]` tag (no cap
        gate needed). Sourced from `[:loopctl, :admin_repo, :query]`.
+    8. **Oban job-count gauge** (US-34.1, AC-34.1.1) — `loopctl.oban.jobs.count`, keyed
+       by `[:state, :queue]` (BOTH fixed, small sets — no cap gate needed). Sourced
+       from `[:loopctl, :oban, :jobs]`, emitted by `dispatch_oban_stats/0` polling
+       `SELECT state, queue, count(*) FROM oban_jobs GROUP BY state, queue` and then
+       ZERO-FILLING every `(state, queue)` combination in the known, bounded cartesian
+       (7 Oban states × `Loopctl.ObanConfig.queues/0`) that the query did NOT return a
+       row for — so a group that drains to zero (e.g. Lifeline rescues a backlog) emits
+       an explicit `count: 0` instead of leaving the `last_value` gauge stuck at its
+       last-seen non-zero value forever (a `last_value` store retains state per
+       label-set with no TTL).
+    9. **Oban `:executing` orphan gauge** (US-34.1, AC-34.1.2) —
+       `loopctl.oban.executing_orphans.count`, untagged (a single scalar). Sourced
+       from `[:loopctl, :oban, :orphans]`, emitted by the same `dispatch_oban_stats/0`
+       poll — the count of `executing` jobs whose `attempted_at` is older than
+       `:oban_metrics_orphan_threshold_minutes` (default 40 — deliberately ABOVE
+       `Oban.Plugins.Lifeline`'s 30-minute `rescue_after`, so the gauge signals
+       "Lifeline is falling behind / a job is wedged" rather than "a job is merely
+       awaiting Lifeline's next normal sweep").
 
   ## Bounded cardinality (AC-27.15.3) — the no-leak contract
 
@@ -85,6 +108,44 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   gated keeps the series shape stable AND pins the tenant dimension's cardinality to
   exactly 1 when over the cap. Below the cap the cardinality is bounded by the cap
   itself (≤ #{1000} by default).
+
+  ## Oban observability (US-34.1)
+
+  `dispatch_oban_stats/0` is the periodic-measurement counterpart to
+  `refresh_tenant_label_gate/0`, but wired into its OWN, independently-configurable
+  `telemetry_poller` instance in `LoopctlWeb.Telemetry` (`:oban_metrics_poll_interval_ms`,
+  default 10s) rather than the shared tenant-label-gate poller — the heavier,
+  unindexed `oban_jobs` GROUP BY aggregate this triggers warrants its own tunable
+  cadence, and decoupling the pollers also means a raise here can never crash the
+  tenant-label gate's refresh (see below). It polls `oban_jobs` (via the
+  `Loopctl.Telemetry.ObanStatsBehaviour` DI seam, defaulting to the real
+  `Loopctl.Telemetry.ObanStats`) for:
+
+    * per-`(state, queue)` row counts (AC-34.1.1), ZERO-FILLED across the full known
+      cartesian and each combination emitted as its own `[:loopctl, :oban, :jobs]`
+      measurement — `state` is Oban's fixed 7-value enum (`available`/`scheduled`/
+      `executing`/`retryable`/`completed`/`discarded`/`cancelled`) and `queue` is the
+      fixed 9-queue set (`Loopctl.ObanConfig`), so BOTH tags are bounded WITHOUT a cap
+      gate — unlike `tenant_id` above, there is no unbounded dimension here to guard
+      against (AC-34.1.5). The GROUP BY query only returns rows for NON-EMPTY groups,
+      so `emit_oban_job_state_counts/0` fills in an explicit `count: 0` for every
+      `(state, queue)` pair the query didn't return — otherwise a group that drains to
+      zero (e.g. a backlog Lifeline just rescued) would leave the `last_value` gauge
+      permanently stuck at its last-seen non-zero value (the reporter's `LastValue`
+      store has no TTL/expiry), defeating the whole point of watching a queue clear.
+    * the `:executing` orphan count (AC-34.1.2) — jobs stuck `executing` longer than
+      `:oban_metrics_orphan_threshold_minutes` (default 40 — deliberately ABOVE
+      `Oban.Plugins.Lifeline`'s 30-minute `rescue_after` in `config/config.exs`, so a
+      job merely awaiting Lifeline's next normal sweep is never mistaken for "Lifeline
+      is falling behind / a job is wedged") — as a single untagged
+      `[:loopctl, :oban, :orphans]` measurement (unaffected by zero-fill: it is a
+      scalar that always emits, including 0).
+
+  `telemetry_poller` does NOT isolate measurements running on the SAME poller
+  instance, so `dispatch_oban_stats/0` is self-rescuing regardless (AC-34.1.3) — a
+  DB/connection fault during either query is caught, logged at `:warning`, and the
+  poll is skipped for that interval (the Prometheus gauges simply hold their
+  last-scraped value; no metric corruption).
   """
 
   import Telemetry.Metrics
@@ -103,9 +164,10 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   @default_tenant_label_cap 1_000
 
   @doc """
-  All 7 scale metrics: the original US-27.15 trio, #297's semantic-fallback
-  counter, US-31.2's hybrid-provenance counter, and US-33.1's two per-pool
-  checkout `queue_time` distributions. Appended to `LoopctlWeb.Telemetry.metrics/0`.
+  All 9 scale metrics: the original US-27.15 trio, #297's semantic-fallback
+  counter, US-31.2's hybrid-provenance counter, US-33.1's two per-pool checkout
+  `queue_time` distributions, and US-34.1's two Oban `oban_jobs` gauges. Appended to
+  `LoopctlWeb.Telemetry.metrics/0`.
   """
   @spec scale_metrics() :: [Telemetry.Metrics.t()]
   def scale_metrics do
@@ -209,6 +271,32 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
         reporter_options: [
           buckets: [1, 5, 10, 25, 50, 100, 250, 500, 1_000]
         ]
+      ),
+
+      # 8. Oban per-(state, queue) job-count gauge (US-34.1, AC-34.1.1). `last_value`
+      #    (Telemetry.Metrics' gauge type) so the reporter always reflects the MOST
+      #    RECENT poll, not a running sum. `state` (Oban's fixed 7-value enum) and
+      #    `queue` (the fixed 9-queue set, `Loopctl.ObanConfig`) are BOTH bounded — no
+      #    tenant/args-derived tag, no cap gate needed (AC-34.1.5).
+      last_value("loopctl.oban.jobs.count",
+        event_name: [:loopctl, :oban, :jobs],
+        measurement: :count,
+        description: "Oban oban_jobs row count, by state and queue (polled every 10s).",
+        tags: [:state, :queue],
+        tag_values: &oban_job_tags/1
+      ),
+
+      # 9. Oban `:executing` orphan gauge (US-34.1, AC-34.1.2): jobs stuck `executing`
+      #    past the configured threshold (default 30 min, matching
+      #    Oban.Plugins.Lifeline's rescue_after) — the signal that Lifeline is falling
+      #    behind or a job is genuinely wedged. Untagged — a single scalar value, so
+      #    there is no cardinality question at all.
+      last_value("loopctl.oban.executing_orphans.count",
+        event_name: [:loopctl, :oban, :orphans],
+        measurement: :count,
+        description:
+          "Oban jobs stuck in :executing past the orphan threshold (polled every 10s).",
+        tags: []
       )
     ]
   end
@@ -236,6 +324,21 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
       provenance: Map.get(metadata, :provenance, "unknown"),
       hit: Map.get(metadata, :hit, false),
       tenant_id: gated_tenant_id(metadata)
+    }
+  end
+
+  @doc """
+  `tag_values` for the Oban per-(state, queue) gauge (US-34.1). Both dimensions are
+  bounded, fixed-cardinality sets (7 states, 9 queues — see `Loopctl.ObanConfig`), so
+  — unlike the tenant-label-gated counters above — this needs NO cap gate. Defaults a
+  missing/nil state or queue to `"unknown"` so the label is never blank (mirrors
+  `scale_tags/1`).
+  """
+  @spec oban_job_tags(map()) :: map()
+  def oban_job_tags(metadata) do
+    %{
+      state: Map.get(metadata, :state) || "unknown",
+      queue: Map.get(metadata, :queue) || "unknown"
     }
   end
 
@@ -376,4 +479,105 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   @doc "The sentinel value a gated-off `tenant_id` label collapses to."
   @spec aggregated_sentinel() :: atom()
   def aggregated_sentinel, do: @aggregated_sentinel
+
+  @default_oban_orphan_threshold_minutes 40
+
+  # Oban's fixed, bounded state enum (7 values) — used to zero-fill the
+  # per-(state, queue) gauge's known cartesian (see `emit_oban_job_state_counts/0`).
+  @oban_states ~w(available scheduled executing retryable completed discarded cancelled)
+
+  @doc """
+  Polls `oban_jobs` for per-`(state, queue)` counts (AC-34.1.1) and the `:executing`
+  orphan count (AC-34.1.2), emitting the `[:loopctl, :oban, :jobs]` /
+  `[:loopctl, :oban, :orphans]` telemetry events the two `last_value` gauges above
+  consume. This is the `telemetry_poller` periodic measurement wired into its OWN
+  poller instance in `LoopctlWeb.Telemetry` (`:oban_metrics_poll_interval_ms`,
+  default 10s — independently configurable from the tenant-label-gate poller).
+
+  Self-rescuing (AC-34.1.3 / TC-34.1.3): `telemetry_poller` does NOT isolate
+  measurements running on the SAME poller instance — an uncaught raise here would
+  crash this poller. A DB/connection fault during either query is caught (the same
+  NARROW exception set as the tenant gate, so a genuine programmer error still
+  surfaces), logged at `:warning`, and this returns `:ok` WITHOUT emitting — the
+  Prometheus gauges simply hold their last-scraped value until the next successful
+  poll (no metric corruption).
+  """
+  @spec dispatch_oban_stats() :: :ok
+  def dispatch_oban_stats do
+    emit_oban_job_state_counts()
+    emit_oban_executing_orphans()
+    :ok
+  rescue
+    e in [Postgrex.Error, DBConnection.ConnectionError, DBConnection.OwnershipError] ->
+      Logger.warning(
+        "oban_jobs metrics poll failed (#{inspect(e.__struct__)}); skipping this interval"
+      )
+
+      :ok
+  end
+
+  # Zero-fills the bounded (state, queue) cartesian (AC-34.1.1, finding: last_value
+  # gauge going permanently stale on drain-to-zero). `job_state_counts/0`'s
+  # `GROUP BY state, queue` returns NO row for an empty group, so relying on it alone
+  # would mean a group that drains to zero (e.g. Lifeline just rescued a backlog)
+  # never emits again — the `last_value` gauge would hold its last-seen non-zero
+  # value FOREVER (the reporter's LastValue store has no TTL/expiry). Instead this
+  # emits one measurement per pair in `@oban_states × Loopctl.ObanConfig.queues/0`
+  # (both fixed, bounded sets — AC-34.1.5), defaulting to `count: 0` for any pair the
+  # query didn't return a row for. Any group the query DID return that falls OUTSIDE
+  # the known cartesian (e.g. a job queued under a name not in `ObanConfig` — a real
+  # misconfiguration, not expected in practice) is still emitted rather than silently
+  # dropped, so a genuine anomaly stays observable instead of being hidden by the
+  # zero-fill.
+  defp emit_oban_job_state_counts do
+    observed = oban_stats_impl().job_state_counts()
+    counts_by_group = Map.new(observed, fn {state, queue, count} -> {{state, queue}, count} end)
+
+    known_groups = for state <- @oban_states, queue <- oban_queue_names(), do: {state, queue}
+    observed_groups = Enum.map(observed, fn {state, queue, _count} -> {state, queue} end)
+
+    for {state, queue} <- Enum.uniq(known_groups ++ observed_groups) do
+      count = Map.get(counts_by_group, {state, queue}, 0)
+
+      :telemetry.execute(
+        [:loopctl, :oban, :jobs],
+        %{count: count},
+        %{state: state, queue: queue}
+      )
+    end
+  end
+
+  defp oban_queue_names do
+    Enum.map(Loopctl.ObanConfig.queues(), fn {queue, _size} -> Atom.to_string(queue) end)
+  end
+
+  defp emit_oban_executing_orphans do
+    count = oban_stats_impl().executing_orphan_count(oban_orphan_threshold_minutes())
+    :telemetry.execute([:loopctl, :oban, :orphans], %{count: count}, %{})
+  end
+
+  defp oban_stats_impl do
+    Application.get_env(:loopctl, :oban_stats_query, Loopctl.Telemetry.ObanStats)
+  end
+
+  @doc """
+  The `:executing` orphan threshold, in minutes (AC-34.1.2). Jobs stuck `executing`
+  longer than this are counted as orphans. Defaults to
+  #{@default_oban_orphan_threshold_minutes} minutes — deliberately ABOVE
+  `Oban.Plugins.Lifeline`'s 30-minute `rescue_after` window in `config/config.exs`,
+  so the gauge signals the case Lifeline should already have rescued but hasn't
+  (falling behind, or the job is genuinely wedged) rather than a job that has simply
+  crossed 30 minutes and is still awaiting Lifeline's next normal periodic sweep.
+  """
+  @spec oban_orphan_threshold_minutes() :: pos_integer()
+  def oban_orphan_threshold_minutes do
+    case Application.get_env(
+           :loopctl,
+           :oban_metrics_orphan_threshold_minutes,
+           @default_oban_orphan_threshold_minutes
+         ) do
+      minutes when is_integer(minutes) and minutes > 0 -> minutes
+      _ -> @default_oban_orphan_threshold_minutes
+    end
+  end
 end

--- a/lib/loopctl/telemetry/scale_metrics.ex
+++ b/lib/loopctl/telemetry/scale_metrics.ex
@@ -141,11 +141,17 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
       `[:loopctl, :oban, :orphans]` measurement (unaffected by zero-fill: it is a
       scalar that always emits, including 0).
 
-  `telemetry_poller` does NOT isolate measurements running on the SAME poller
-  instance, so `dispatch_oban_stats/0` is self-rescuing regardless (AC-34.1.3) — a
-  DB/connection fault during either query is caught, logged at `:warning`, and the
-  poll is skipped for that interval (the Prometheus gauges simply hold their
-  last-scraped value; no metric corruption).
+  `telemetry_poller` does NOT crash its poller GenServer on a raising measurement —
+  `make_measurement/1` catches `Class:Reason`, logs one error, and the poller
+  process survives. But surviving is not enough: `handle_info(:collect, ...)` then
+  drops the raising measurement from poller state and never retries it, so an
+  UNCAUGHT raise here would PERMANENTLY disable this gauge for the life of the
+  BEAM (worse than a crash, which `:one_for_one` would restart) — silently, after
+  one log line. So `dispatch_oban_stats/0` rescues `ANY` exception itself
+  (AC-34.1.3): a fault during either query is caught, logged at `:warning`, and the
+  poll is skipped for that interval — the Prometheus gauges simply hold their
+  last-scraped value (no metric corruption) and the NEXT interval's poll still
+  runs.
   """
 
   import Telemetry.Metrics
@@ -287,10 +293,10 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
       ),
 
       # 9. Oban `:executing` orphan gauge (US-34.1, AC-34.1.2): jobs stuck `executing`
-      #    past the configured threshold (default 30 min, matching
-      #    Oban.Plugins.Lifeline's rescue_after) — the signal that Lifeline is falling
-      #    behind or a job is genuinely wedged. Untagged — a single scalar value, so
-      #    there is no cardinality question at all.
+      #    past the configured threshold (default 40 min, deliberately above
+      #    Oban.Plugins.Lifeline's 30-minute rescue_after) — the signal that Lifeline is
+      #    falling behind or a job is genuinely wedged. Untagged — a single scalar value,
+      #    so there is no cardinality question at all.
       last_value("loopctl.oban.executing_orphans.count",
         event_name: [:loopctl, :oban, :orphans],
         measurement: :count,
@@ -494,13 +500,16 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   poller instance in `LoopctlWeb.Telemetry` (`:oban_metrics_poll_interval_ms`,
   default 10s — independently configurable from the tenant-label-gate poller).
 
-  Self-rescuing (AC-34.1.3 / TC-34.1.3): `telemetry_poller` does NOT isolate
-  measurements running on the SAME poller instance — an uncaught raise here would
-  crash this poller. A DB/connection fault during either query is caught (the same
-  NARROW exception set as the tenant gate, so a genuine programmer error still
-  surfaces), logged at `:warning`, and this returns `:ok` WITHOUT emitting — the
-  Prometheus gauges simply hold their last-scraped value until the next successful
-  poll (no metric corruption).
+  Self-rescuing (AC-34.1.3 / TC-34.1.3), and DELIBERATELY WIDE: `telemetry_poller`
+  catches any raise from a periodic measurement itself, but its recovery is to log
+  once and drop that measurement from poller state FOREVER — it does not retry, and
+  the poller process never crashes, so `:one_for_one` never gets a chance to
+  restart it either. An uncaught raise here would therefore permanently freeze both
+  gauges at their last-scraped value for the rest of the BEAM's lifetime, which is
+  worse than a crash. So this rescues ANY exception (not just the DB-connection
+  classes) — logs at `:warning` and returns `:ok` WITHOUT emitting, leaving the
+  Prometheus gauges holding their last-scraped value until the next poll interval,
+  which still runs.
   """
   @spec dispatch_oban_stats() :: :ok
   def dispatch_oban_stats do
@@ -508,7 +517,7 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
     emit_oban_executing_orphans()
     :ok
   rescue
-    e in [Postgrex.Error, DBConnection.ConnectionError, DBConnection.OwnershipError] ->
+    e ->
       Logger.warning(
         "oban_jobs metrics poll failed (#{inspect(e.__struct__)}); skipping this interval"
       )

--- a/lib/loopctl_web/telemetry.ex
+++ b/lib/loopctl_web/telemetry.ex
@@ -29,19 +29,41 @@ defmodule LoopctlWeb.Telemetry do
           {:telemetry_poller,
            measurements: periodic_measurements(), period: 10_000, name: :loopctl_telemetry_poller},
           id: :loopctl_telemetry_poller
-        ),
-        # US-34.1: the Oban `oban_jobs` poll runs on its OWN `telemetry_poller`
-        # instance, with an INDEPENDENTLY configurable interval
-        # (`:oban_metrics_poll_interval_ms`, default 10s) rather than inheriting the
-        # tenant-label-gate poller's cadence above (AC-34.1.3 calls for a "bounded
-        # interval (config)"). Two `:telemetry_poller` instances can coexist under one
-        # Supervisor as long as each has a distinct `:name` (registered by
-        # `:telemetry_poller`'s own `start_link/1`) and a distinct Supervisor child
-        # `:id` (both default to `:telemetry_poller` otherwise, which would collide) —
-        # `Supervisor.child_spec/2` overrides the id for exactly that reason. This also
-        # shrinks the blast radius from the shared-poller crash risk documented on
-        # `ScaleMetrics.dispatch_oban_stats/0`: a raise here can no longer take down
-        # `refresh_tenant_label_gate/0`'s poller (still self-rescued regardless).
+        )
+      ] ++ oban_poller_children() ++ reporter_children() ++ scale_alerts_children()
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  # US-34.1: the Oban `oban_jobs` poll runs on its OWN `telemetry_poller` instance,
+  # with an INDEPENDENTLY configurable interval (`:oban_metrics_poll_interval_ms`,
+  # default 10s) rather than inheriting the tenant-label-gate poller's cadence above
+  # (AC-34.1.3 calls for a "bounded interval (config)"). Two `:telemetry_poller`
+  # instances can coexist under one Supervisor as long as each has a distinct
+  # `:name` (registered by `:telemetry_poller`'s own `start_link/1`) and a distinct
+  # Supervisor child `:id` (both default to `:telemetry_poller` otherwise, which
+  # would collide) — `Supervisor.child_spec/2` overrides the id for exactly that
+  # reason. Splitting the poller also shrinks the blast radius from the shared-
+  # poller failure-mode documented on `ScaleMetrics.dispatch_oban_stats/0`: a raise
+  # there can no longer touch `refresh_tenant_label_gate/0`'s poller (still
+  # self-rescued regardless, and self-rescued WIDE per the same doc).
+  #
+  # Gated on `:oban_metrics_poll_enabled` (default true; forced `false` in
+  # `config/test.exs`) — review finding (US-34.1): `dispatch_oban_stats/0` polls
+  # through the `Loopctl.MockObanStats` Mox DI seam, and `telemetry_poller`'s
+  # `init_delay` defaults to 0, so an always-on poller fires `:collect` at boot,
+  # BEFORE any ExUnit test process owns the private-mode Mox allowance. The
+  # resulting `Mox.UnexpectedCallError` is not in `dispatch_oban_stats/0`'s rescue
+  # set's spirit (it's a test-harness artifact, not a poll fault) and — per the
+  # same widened-rescue fix above — would otherwise be caught, logged once, and
+  # PERMANENTLY drop the gauge for the rest of the suite (and re-log every
+  # interval). Omitting the child in `:test` (same pattern as `reporter_children/0`
+  # / `scale_alerts_children/0` below) keeps the suite quiet and the gauge intact;
+  # the poller -> dispatch_oban_stats/0 -> DB wiring is covered directly by
+  # `scale_metrics_oban_test.exs`, which calls `dispatch_oban_stats/0` in-process.
+  defp oban_poller_children do
+    if oban_metrics_poll_enabled?() do
+      [
         Supervisor.child_spec(
           {:telemetry_poller,
            measurements: oban_periodic_measurements(),
@@ -49,9 +71,14 @@ defmodule LoopctlWeb.Telemetry do
            name: :loopctl_oban_telemetry_poller},
           id: :loopctl_oban_telemetry_poller
         )
-      ] ++ reporter_children() ++ scale_alerts_children()
+      ]
+    else
+      []
+    end
+  end
 
-    Supervisor.init(children, strategy: :one_for_one)
+  defp oban_metrics_poll_enabled? do
+    Application.get_env(:loopctl, :oban_metrics_poll_enabled, true)
   end
 
   # US-27.15: the Prometheus reporter is a SUPERVISED child that binds the internal
@@ -171,11 +198,15 @@ defmodule LoopctlWeb.Telemetry do
   end
 
   defp periodic_measurements do
-    # NOTE: `telemetry_poller` runs every measurement in its OWN process and does NOT
-    # isolate them — an uncaught raise in any measurement crashes ITS poller. So EVERY
-    # measurement added here MUST be self-rescuing. `refresh_tenant_label_gate/0`
-    # guards its only raising op (the DB count) with try/rescue (fail-soft to a
-    # bounded gate); keep that invariant for future additions to THIS poller.
+    # NOTE: `telemetry_poller` does NOT crash its poller process on a raising
+    # measurement — it catches the raise, logs one error, and then PERMANENTLY
+    # drops that measurement from poller state (never retried, no restart to
+    # recover it). So EVERY measurement added here MUST rescue for itself, or an
+    # uncaught raise silently disables it for the rest of the BEAM's lifetime.
+    # `refresh_tenant_label_gate/0` guards its only raising op (the DB count) with
+    # try/rescue (fail-soft to a bounded gate); keep that invariant — and rescue
+    # WIDE, not just the DB-error classes (see `ScaleMetrics.dispatch_oban_stats/0`
+    # for the fuller rationale) — for future additions to THIS poller.
     [
       # US-27.15: refresh the metrics tenant-label cardinality gate (Tenants.count()
       # <= cap), caching the boolean in :persistent_term so the per-emit tag_values
@@ -184,10 +215,13 @@ defmodule LoopctlWeb.Telemetry do
     ]
   end
 
-  # US-34.1: split onto its OWN `telemetry_poller` instance (see `init/1`) so its
-  # cadence is independently configurable and a raise here can never crash the
-  # tenant-label-gate poller above. `dispatch_oban_stats/0` is fully self-rescuing
-  # regardless (a poll error logs + skips rather than crashing this poller).
+  # US-34.1: split onto its OWN `telemetry_poller` instance (see `init/1` /
+  # `oban_poller_children/0`, gated off in `:test`) so its cadence is independently
+  # configurable and a fault here can never touch the tenant-label-gate poller
+  # above. `dispatch_oban_stats/0` is fully self-rescuing regardless — and WIDE
+  # (any exception, not just DB-error classes), because `telemetry_poller` reacts
+  # to an uncaught raise by permanently dropping the measurement rather than
+  # crashing/restarting this poller.
   defp oban_periodic_measurements do
     [
       # US-34.1: poll oban_jobs for per-(state, queue) counts + the :executing orphan

--- a/lib/loopctl_web/telemetry.ex
+++ b/lib/loopctl_web/telemetry.ex
@@ -11,6 +11,10 @@ defmodule LoopctlWeb.Telemetry do
   # `[metrics]` block). Tunable via `:metrics_port`.
   @default_metrics_port 9568
 
+  # US-34.1: default cadence for the Oban `oban_jobs` poll's OWN `telemetry_poller`
+  # instance — see `oban_poll_interval_ms/0`.
+  @default_oban_poll_interval_ms 10_000
+
   def start_link(arg) do
     Supervisor.start_link(__MODULE__, arg, name: __MODULE__)
   end
@@ -21,7 +25,30 @@ defmodule LoopctlWeb.Telemetry do
       [
         # Telemetry poller will execute the given period measurements
         # every 10_000ms. Learn more here: https://hexdocs.pm/telemetry_metrics
-        {:telemetry_poller, measurements: periodic_measurements(), period: 10_000}
+        Supervisor.child_spec(
+          {:telemetry_poller,
+           measurements: periodic_measurements(), period: 10_000, name: :loopctl_telemetry_poller},
+          id: :loopctl_telemetry_poller
+        ),
+        # US-34.1: the Oban `oban_jobs` poll runs on its OWN `telemetry_poller`
+        # instance, with an INDEPENDENTLY configurable interval
+        # (`:oban_metrics_poll_interval_ms`, default 10s) rather than inheriting the
+        # tenant-label-gate poller's cadence above (AC-34.1.3 calls for a "bounded
+        # interval (config)"). Two `:telemetry_poller` instances can coexist under one
+        # Supervisor as long as each has a distinct `:name` (registered by
+        # `:telemetry_poller`'s own `start_link/1`) and a distinct Supervisor child
+        # `:id` (both default to `:telemetry_poller` otherwise, which would collide) —
+        # `Supervisor.child_spec/2` overrides the id for exactly that reason. This also
+        # shrinks the blast radius from the shared-poller crash risk documented on
+        # `ScaleMetrics.dispatch_oban_stats/0`: a raise here can no longer take down
+        # `refresh_tenant_label_gate/0`'s poller (still self-rescued regardless).
+        Supervisor.child_spec(
+          {:telemetry_poller,
+           measurements: oban_periodic_measurements(),
+           period: oban_poll_interval_ms(),
+           name: :loopctl_oban_telemetry_poller},
+          id: :loopctl_oban_telemetry_poller
+        )
       ] ++ reporter_children() ++ scale_alerts_children()
 
     Supervisor.init(children, strategy: :one_for_one)
@@ -145,15 +172,42 @@ defmodule LoopctlWeb.Telemetry do
 
   defp periodic_measurements do
     # NOTE: `telemetry_poller` runs every measurement in its OWN process and does NOT
-    # isolate them — an uncaught raise in any measurement crashes the shared poller (and
-    # with it the gate refresh). So EVERY measurement added here MUST be self-rescuing.
-    # `refresh_tenant_label_gate/0` guards its only raising op (the DB count) with
-    # try/rescue (fail-soft to a bounded gate); keep that invariant for future additions.
+    # isolate them — an uncaught raise in any measurement crashes ITS poller. So EVERY
+    # measurement added here MUST be self-rescuing. `refresh_tenant_label_gate/0`
+    # guards its only raising op (the DB count) with try/rescue (fail-soft to a
+    # bounded gate); keep that invariant for future additions to THIS poller.
     [
       # US-27.15: refresh the metrics tenant-label cardinality gate (Tenants.count()
       # <= cap), caching the boolean in :persistent_term so the per-emit tag_values
       # path needs no DB hit. This is the ONLY DB read in the gating mechanism.
       {ScaleMetrics, :refresh_tenant_label_gate, []}
     ]
+  end
+
+  # US-34.1: split onto its OWN `telemetry_poller` instance (see `init/1`) so its
+  # cadence is independently configurable and a raise here can never crash the
+  # tenant-label-gate poller above. `dispatch_oban_stats/0` is fully self-rescuing
+  # regardless (a poll error logs + skips rather than crashing this poller).
+  defp oban_periodic_measurements do
+    [
+      # US-34.1: poll oban_jobs for per-(state, queue) counts + the :executing orphan
+      # count, emitting the two gauges ScaleMetrics.scale_metrics/0 defines.
+      {ScaleMetrics, :dispatch_oban_stats, []}
+    ]
+  end
+
+  # The Oban poll's OWN configurable interval (`:oban_metrics_poll_interval_ms`,
+  # default `@default_oban_poll_interval_ms`) — see `config/config.exs` for the
+  # full rationale. Falls back to the default for any non-positive-integer value
+  # rather than crashing supervisor init on a bad config.
+  defp oban_poll_interval_ms do
+    case Application.get_env(
+           :loopctl,
+           :oban_metrics_poll_interval_ms,
+           @default_oban_poll_interval_ms
+         ) do
+      ms when is_integer(ms) and ms > 0 -> ms
+      _ -> @default_oban_poll_interval_ms
+    end
   end
 end

--- a/test/loopctl/oban_plugins_test.exs
+++ b/test/loopctl/oban_plugins_test.exs
@@ -1,0 +1,55 @@
+defmodule Loopctl.ObanPluginsTest do
+  @moduledoc """
+  US-34.1 (AC-34.1.4, TC-34.1.4): `Oban.Plugins.Reindexer` is configured (periodic
+  `REINDEX CONCURRENTLY` on the `oban_jobs` args/meta indexes), and this change left
+  `Oban.Plugins.Lifeline` and `Oban.Plugins.Pruner` unchanged. Pure config read — no
+  DB needed, so this is plain `ExUnit.Case` (mirrors `Loopctl.ObanConfigTest`).
+  """
+  use ExUnit.Case, async: true
+
+  describe "Oban plugins (compile-time config)" do
+    test "Oban.Plugins.Reindexer is configured" do
+      plugins = Application.get_env(:loopctl, Oban)[:plugins]
+
+      assert Enum.any?(plugins, fn
+               Oban.Plugins.Reindexer -> true
+               {Oban.Plugins.Reindexer, _opts} -> true
+               _ -> false
+             end)
+    end
+
+    test "Oban.Plugins.Lifeline is unchanged (rescue_after: 30 minutes)" do
+      plugins = Application.get_env(:loopctl, Oban)[:plugins]
+
+      assert {Oban.Plugins.Lifeline, opts} =
+               Enum.find(plugins, &match?({Oban.Plugins.Lifeline, _}, &1))
+
+      assert Keyword.get(opts, :rescue_after) == :timer.minutes(30)
+    end
+
+    test "Oban.Plugins.Pruner is unchanged (max_age: 7 days)" do
+      plugins = Application.get_env(:loopctl, Oban)[:plugins]
+
+      assert {Oban.Plugins.Pruner, opts} =
+               Enum.find(plugins, &match?({Oban.Plugins.Pruner, _}, &1))
+
+      assert Keyword.get(opts, :max_age) == 60 * 60 * 24 * 7
+    end
+
+    test "Oban.Plugins.Cron is unchanged (still configured)" do
+      plugins = Application.get_env(:loopctl, Oban)[:plugins]
+
+      assert Enum.any?(plugins, &match?({Oban.Plugins.Cron, _}, &1))
+    end
+
+    test "Oban.Stager is NOT listed in plugins (it is a core GenServer, not a plugin, in Oban 2.21)" do
+      plugins = Application.get_env(:loopctl, Oban)[:plugins]
+
+      refute Enum.any?(plugins, fn
+               Oban.Stager -> true
+               {Oban.Stager, _opts} -> true
+               _ -> false
+             end)
+    end
+  end
+end

--- a/test/loopctl/telemetry/oban_stats_test.exs
+++ b/test/loopctl/telemetry/oban_stats_test.exs
@@ -1,0 +1,55 @@
+defmodule Loopctl.Telemetry.ObanStatsTest do
+  @moduledoc """
+  US-34.1 (AC-34.1.1/.2): `Loopctl.Telemetry.ObanStats` is the real `oban_jobs`
+  read behind the US-34.1 observability poll — the per-(state, queue) count query
+  and the `:executing` orphan-age query. `oban_jobs` is a GLOBAL infra table (no
+  `tenant_id`, no RLS), so these tests seed via `fixture(:oban_job, ...)` (which
+  inserts through `Loopctl.Repo`, matching the module under test) rather than the
+  usual `AdminRepo`-backed fixtures.
+  """
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.Telemetry.ObanStats
+
+  describe "job_state_counts/0 (AC-34.1.1, TC-34.1.1)" do
+    test "returns one {state, queue, count} tuple per seeded (state, queue) group" do
+      fixture(:oban_job, state: "available", queue: "default")
+      fixture(:oban_job, state: "available", queue: "default")
+      fixture(:oban_job, state: "completed", queue: "webhooks")
+
+      counts = ObanStats.job_state_counts()
+
+      assert {"available", "default", 2} in counts
+      assert {"completed", "webhooks", 1} in counts
+      assert length(counts) == 2
+    end
+
+    test "returns an empty list when oban_jobs has no rows" do
+      assert ObanStats.job_state_counts() == []
+    end
+  end
+
+  describe "executing_orphan_count/1 (AC-34.1.2, TC-34.1.2)" do
+    test "counts only :executing jobs whose attempted_at is older than the threshold" do
+      stale_attempted_at = DateTime.add(DateTime.utc_now(), -35 * 60, :second)
+      recent_attempted_at = DateTime.add(DateTime.utc_now(), -5 * 60, :second)
+
+      fixture(:oban_job, state: "executing", attempted_at: stale_attempted_at)
+      fixture(:oban_job, state: "executing", attempted_at: recent_attempted_at)
+      # A non-executing job, even with a stale attempted_at, must never count.
+      fixture(:oban_job, state: "completed", attempted_at: stale_attempted_at)
+
+      assert ObanStats.executing_orphan_count(30) == 1
+    end
+
+    test "returns 0 when no executing job is stale" do
+      fixture(:oban_job, state: "executing", attempted_at: DateTime.utc_now())
+
+      assert ObanStats.executing_orphan_count(30) == 0
+    end
+
+    test "returns 0 when oban_jobs has no rows at all" do
+      assert ObanStats.executing_orphan_count(30) == 0
+    end
+  end
+end

--- a/test/loopctl/telemetry/scale_metrics_oban_test.exs
+++ b/test/loopctl/telemetry/scale_metrics_oban_test.exs
@@ -1,0 +1,180 @@
+defmodule Loopctl.Telemetry.ScaleMetricsObanTest do
+  @moduledoc """
+  US-34.1 (AC-34.1.1/.2/.3): `Loopctl.Telemetry.ScaleMetrics.dispatch_oban_stats/0`
+  — the periodic measurement wired into `LoopctlWeb.Telemetry.periodic_measurements/0`
+  — polls real `oban_jobs` rows and emits the per-(state, queue) job-count gauge
+  event and the `:executing` orphan-count gauge event, and is defensive against a
+  poll-time DB error (never crashes the shared `telemetry_poller`).
+
+  Uses `Loopctl.DataCase` (needs the DB for the integration-style TC-34.1.1/.2
+  cases); TC-34.1.3 overrides the `Loopctl.MockObanStats` DI seam with
+  `Mox.expect/3` to force a raise deterministically, matching the project's
+  established pattern for exercising an otherwise-unreproducible DB-error path
+  (see `Loopctl.MockSuggestLinks`'s DB-error-surfacing test).
+  """
+  use Loopctl.DataCase, async: true
+
+  import ExUnit.CaptureLog
+
+  alias Loopctl.Telemetry.ScaleMetrics
+
+  setup :verify_on_exit!
+
+  # Captures every `event_name` telemetry emission that occurs while `fun` runs,
+  # scoped to THIS test process (mirrors the existing under-fill / admin_repo
+  # probe pattern used elsewhere in the suite, e.g.
+  # vector_search_under_fill_test.exs).
+  defp capture_events(event_name, fun) do
+    test_pid = self()
+    handler_id = {__MODULE__, event_name, make_ref()}
+
+    :telemetry.attach(
+      handler_id,
+      event_name,
+      fn ^event_name, measurements, metadata, _config ->
+        if self() == test_pid do
+          send(test_pid, {:telemetry_event, measurements, metadata})
+        end
+      end,
+      nil
+    )
+
+    try do
+      fun.()
+      collect_events([])
+    after
+      :telemetry.detach(handler_id)
+    end
+  end
+
+  defp collect_events(acc) do
+    receive do
+      {:telemetry_event, measurements, metadata} ->
+        collect_events([{measurements, metadata} | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
+  end
+
+  # US-34.1 review finding: `job_state_counts/0`'s `GROUP BY state, queue` returns NO
+  # row for an empty (state, queue) group, so the gauge must ZERO-FILL the full known
+  # cartesian (7 Oban states x the configured queue set) or a group that drains to
+  # zero (e.g. Lifeline just rescued a backlog) would leave the `last_value` gauge
+  # stuck at its last-seen non-zero value forever.
+  @known_cartesian_size 7 * length(Loopctl.ObanConfig.queues())
+
+  describe "dispatch_oban_stats/0 — per-(state, queue) job-count gauge (AC-34.1.1, TC-34.1.1)" do
+    test "emits a [:loopctl, :oban, :jobs] measurement per group reflecting real oban_jobs rows" do
+      fixture(:oban_job, state: "available", queue: "default")
+      fixture(:oban_job, state: "available", queue: "default")
+      fixture(:oban_job, state: "completed", queue: "webhooks")
+
+      events =
+        capture_events([:loopctl, :oban, :jobs], fn ->
+          assert ScaleMetrics.dispatch_oban_stats() == :ok
+        end)
+
+      assert {%{count: 2}, %{state: "available", queue: "default"}} in events
+      assert {%{count: 1}, %{state: "completed", queue: "webhooks"}} in events
+    end
+
+    test "zero-fills the entire known cartesian (all counts 0) when oban_jobs has no rows" do
+      events =
+        capture_events([:loopctl, :oban, :jobs], fn ->
+          assert ScaleMetrics.dispatch_oban_stats() == :ok
+        end)
+
+      refute events == []
+      assert length(events) == @known_cartesian_size
+      assert Enum.all?(events, fn {%{count: count}, _metadata} -> count == 0 end)
+    end
+
+    test "zero-fills a group that drained to zero, alongside the real non-zero counts" do
+      fixture(:oban_job, state: "executing", queue: "default")
+
+      events =
+        capture_events([:loopctl, :oban, :jobs], fn ->
+          assert ScaleMetrics.dispatch_oban_stats() == :ok
+        end)
+
+      # The one seeded group is non-zero...
+      assert {%{count: 1}, %{state: "executing", queue: "default"}} in events
+      # ...but every OTHER known (state, queue) combination — e.g. a drained group —
+      # still emits an explicit 0 instead of being silently omitted.
+      assert {%{count: 0}, %{state: "completed", queue: "default"}} in events
+      assert {%{count: 0}, %{state: "available", queue: "webhooks"}} in events
+      assert length(events) == @known_cartesian_size
+    end
+  end
+
+  describe "dispatch_oban_stats/0 — :executing orphan gauge (AC-34.1.2, TC-34.1.2)" do
+    test "emits a [:loopctl, :oban, :orphans] measurement counting ONLY the stale executing job" do
+      # Older than the default 40-minute orphan threshold (ScaleMetrics.
+      # oban_orphan_threshold_minutes/0), which is deliberately ABOVE Lifeline's
+      # 30-minute rescue_after.
+      stale = DateTime.add(DateTime.utc_now(), -45 * 60, :second)
+      recent = DateTime.add(DateTime.utc_now(), -5 * 60, :second)
+
+      fixture(:oban_job, state: "executing", attempted_at: stale)
+      fixture(:oban_job, state: "executing", attempted_at: recent)
+
+      events =
+        capture_events([:loopctl, :oban, :orphans], fn ->
+          assert ScaleMetrics.dispatch_oban_stats() == :ok
+        end)
+
+      assert [{%{count: 1}, %{}}] = events
+    end
+  end
+
+  describe "dispatch_oban_stats/0 — defensive on poll error (AC-34.1.3, TC-34.1.3)" do
+    test "logs and returns :ok (never raises) when the state-count query raises" do
+      expect(Loopctl.MockObanStats, :job_state_counts, fn ->
+        raise DBConnection.ConnectionError, message: "boom"
+      end)
+
+      log =
+        capture_log(fn ->
+          assert ScaleMetrics.dispatch_oban_stats() == :ok
+        end)
+
+      assert log =~ "oban_jobs metrics poll failed"
+      assert log =~ "DBConnection.ConnectionError"
+    end
+
+    test "logs and returns :ok (never raises) when the orphan-count query raises" do
+      expect(Loopctl.MockObanStats, :job_state_counts, fn -> [] end)
+
+      expect(Loopctl.MockObanStats, :executing_orphan_count, fn _minutes ->
+        raise Postgrex.Error, message: "boom"
+      end)
+
+      log =
+        capture_log(fn ->
+          assert ScaleMetrics.dispatch_oban_stats() == :ok
+        end)
+
+      assert log =~ "oban_jobs metrics poll failed"
+      assert log =~ "Postgrex.Error"
+    end
+
+    test "a poll error never emits a stale/corrupt measurement" do
+      expect(Loopctl.MockObanStats, :job_state_counts, fn ->
+        raise DBConnection.ConnectionError, message: "boom"
+      end)
+
+      events =
+        capture_events([:loopctl, :oban, :jobs], fn ->
+          capture_log(fn -> ScaleMetrics.dispatch_oban_stats() end)
+        end)
+
+      assert events == []
+    end
+
+    test "an unexpected (non-DB) exception still propagates — the narrow rescue never masks a real bug" do
+      expect(Loopctl.MockObanStats, :job_state_counts, fn -> raise ArgumentError, "boom" end)
+
+      assert_raise ArgumentError, fn -> ScaleMetrics.dispatch_oban_stats() end
+    end
+  end
+end

--- a/test/loopctl/telemetry/scale_metrics_oban_test.exs
+++ b/test/loopctl/telemetry/scale_metrics_oban_test.exs
@@ -171,10 +171,16 @@ defmodule Loopctl.Telemetry.ScaleMetricsObanTest do
       assert events == []
     end
 
-    test "an unexpected (non-DB) exception still propagates — the narrow rescue never masks a real bug" do
+    test "an unexpected (non-DB) exception is ALSO rescued (logs + :ok, review finding #1)" do
       expect(Loopctl.MockObanStats, :job_state_counts, fn -> raise ArgumentError, "boom" end)
 
-      assert_raise ArgumentError, fn -> ScaleMetrics.dispatch_oban_stats() end
+      log =
+        capture_log(fn ->
+          assert ScaleMetrics.dispatch_oban_stats() == :ok
+        end)
+
+      assert log =~ "oban_jobs metrics poll failed"
+      assert log =~ "ArgumentError"
     end
   end
 end

--- a/test/loopctl/telemetry/scale_metrics_test.exs
+++ b/test/loopctl/telemetry/scale_metrics_test.exs
@@ -531,24 +531,29 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
       assert :ets.info(:loopctl_scale_alerts) == :undefined
     end
 
-    test "the Oban oban_jobs poll runs on its OWN telemetry_poller instance (US-34.1 review fix)" do
+    test "the Oban oban_jobs poll's OWN telemetry_poller is NOT auto-started in :test (US-34.1 review fix)" do
+      refute Application.get_env(:loopctl, :oban_metrics_poll_enabled, true),
+             "oban_metrics_poll_enabled must stay false in :test — an always-on poller fires " <>
+               "dispatch_oban_stats/0 (and its Loopctl.MockObanStats Mox call) at boot, before " <>
+               "any ExUnit test process holds the private-mode allowance, raising " <>
+               "Mox.UnexpectedCallError on every collect for the whole suite"
+
       children = Supervisor.which_children(LoopctlWeb.Telemetry)
       child_ids = Enum.map(children, fn {id, _pid, _type, _mods} -> id end)
 
-      # Two DISTINCT poller child ids — proves the Oban poll is no longer sharing the
-      # tenant-label-gate poller's process/cadence (a raise in one can't crash the other).
+      # The tenant-label-gate poller is unaffected — still its own, independently
+      # registered, running process (proving the two-poller split still holds; the
+      # oban poller is simply omitted rather than sharing this process/cadence).
       assert :loopctl_telemetry_poller in child_ids
-      assert :loopctl_oban_telemetry_poller in child_ids
 
-      # And each is a genuinely distinct, independently-registered, running process.
+      refute :loopctl_oban_telemetry_poller in child_ids,
+             "the oban poller must not be supervised in :test — " <>
+               "scale_metrics_oban_test.exs exercises dispatch_oban_stats/0 directly instead"
+
       tenant_gate_pid = Process.whereis(:loopctl_telemetry_poller)
-      oban_pid = Process.whereis(:loopctl_oban_telemetry_poller)
-
       assert is_pid(tenant_gate_pid)
-      assert is_pid(oban_pid)
-      assert tenant_gate_pid != oban_pid
       assert Process.alive?(tenant_gate_pid)
-      assert Process.alive?(oban_pid)
+      assert Process.whereis(:loopctl_oban_telemetry_poller) == nil
     end
   end
 

--- a/test/loopctl/telemetry/scale_metrics_test.exs
+++ b/test/loopctl/telemetry/scale_metrics_test.exs
@@ -43,7 +43,9 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
     "loopctl.knowledge.semantic_fallback.count",
     "loopctl.knowledge.hybrid_provenance.count",
     "loopctl.repo.checkout.queue_time",
-    "loopctl.admin_repo.checkout.queue_time"
+    "loopctl.admin_repo.checkout.queue_time",
+    "loopctl.oban.jobs.count",
+    "loopctl.oban.executing_orphans.count"
   ]
 
   # The ONLY labels any scale metric may ever carry (AC-27.15.3). Anything outside this
@@ -53,7 +55,9 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
   # and `:hit` (`true`/`false`) — US-31.2's hybrid-provenance counter — are likewise
   # small, fixed-cardinality dimensions. `:repo` (US-33.1) is a static, fixed 2-value
   # tag ("repo"/"admin_repo") — the repo identity is encoded in the event name, not
-  # read from metadata.
+  # read from metadata. `:state` (Oban's fixed 7-value enum) and `:queue` (the fixed
+  # 9-queue set, `Loopctl.ObanConfig`) — US-34.1's Oban job-count gauge — are likewise
+  # bounded, fixed-cardinality dimensions (AC-34.1.5).
   @allowed_tags MapSet.new([
                   :endpoint,
                   :mapped_code,
@@ -61,7 +65,9 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
                   :reason,
                   :provenance,
                   :hit,
-                  :repo
+                  :repo,
+                  :state,
+                  :queue
                 ])
 
   defp scale_metrics, do: ScaleMetrics.scale_metrics()
@@ -322,6 +328,58 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
     end
   end
 
+  describe "Oban job-count gauge (US-34.1, AC-34.1.1)" do
+    test "loopctl.oban.jobs.count is a last_value gauge tagged by state and queue" do
+      gauge = metric("loopctl.oban.jobs.count")
+
+      assert %Telemetry.Metrics.LastValue{} = gauge
+      assert gauge.event_name == [:loopctl, :oban, :jobs]
+      assert gauge.measurement == :count
+      assert MapSet.new(gauge.tags) == MapSet.new([:state, :queue])
+    end
+  end
+
+  describe "Oban :executing orphan gauge (US-34.1, AC-34.1.2)" do
+    test "loopctl.oban.executing_orphans.count is an UNTAGGED last_value gauge" do
+      gauge = metric("loopctl.oban.executing_orphans.count")
+
+      assert %Telemetry.Metrics.LastValue{} = gauge
+      assert gauge.event_name == [:loopctl, :oban, :orphans]
+      assert gauge.measurement == :count
+      assert gauge.tags == []
+    end
+  end
+
+  describe "oban_job_tags/1 — bounded, defaults never blank (US-34.1, AC-34.1.5)" do
+    test "reads :state and :queue straight through when present" do
+      assert ScaleMetrics.oban_job_tags(%{state: "executing", queue: "webhooks"}) == %{
+               state: "executing",
+               queue: "webhooks"
+             }
+    end
+
+    test "defaults a missing state or queue to \"unknown\" (never blank)" do
+      assert ScaleMetrics.oban_job_tags(%{}) == %{state: "unknown", queue: "unknown"}
+
+      assert ScaleMetrics.oban_job_tags(%{state: nil, queue: nil}) == %{
+               state: "unknown",
+               queue: "unknown"
+             }
+    end
+
+    test "carries NO tenant_id even if one leaks into metadata" do
+      tags = ScaleMetrics.oban_job_tags(%{state: "available", queue: "default", tenant_id: "t-9"})
+      refute Map.has_key?(tags, :tenant_id)
+    end
+  end
+
+  describe "oban_orphan_threshold_minutes/0 (US-34.1, AC-34.1.2)" do
+    test "defaults to 40 (strictly above Oban.Plugins.Lifeline's 30-minute rescue_after)" do
+      assert ScaleMetrics.oban_orphan_threshold_minutes() == 40
+      assert ScaleMetrics.oban_orphan_threshold_minutes() > 30
+    end
+  end
+
   describe "queue_time reporter round-trip — a REAL Prometheus reporter, not a no-handler no-op (TC-33.1.2, raw finding #3)" do
     # R2 review: the prior version of this describe only asserted `:telemetry.execute/3
     # == :ok` with ZERO handlers attached in :test — that assertion holds even if the
@@ -471,6 +529,35 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
 
       # The default ScaleAlerts ETS table is not owned by anyone in :test.
       assert :ets.info(:loopctl_scale_alerts) == :undefined
+    end
+
+    test "the Oban oban_jobs poll runs on its OWN telemetry_poller instance (US-34.1 review fix)" do
+      children = Supervisor.which_children(LoopctlWeb.Telemetry)
+      child_ids = Enum.map(children, fn {id, _pid, _type, _mods} -> id end)
+
+      # Two DISTINCT poller child ids — proves the Oban poll is no longer sharing the
+      # tenant-label-gate poller's process/cadence (a raise in one can't crash the other).
+      assert :loopctl_telemetry_poller in child_ids
+      assert :loopctl_oban_telemetry_poller in child_ids
+
+      # And each is a genuinely distinct, independently-registered, running process.
+      tenant_gate_pid = Process.whereis(:loopctl_telemetry_poller)
+      oban_pid = Process.whereis(:loopctl_oban_telemetry_poller)
+
+      assert is_pid(tenant_gate_pid)
+      assert is_pid(oban_pid)
+      assert tenant_gate_pid != oban_pid
+      assert Process.alive?(tenant_gate_pid)
+      assert Process.alive?(oban_pid)
+    end
+  end
+
+  describe "oban_metrics_poll_interval_ms config (US-34.1, AC-34.1.3: bounded interval (config))" do
+    test "the poll interval is an independently configurable positive integer, defaulting to 10s" do
+      interval = Application.get_env(:loopctl, :oban_metrics_poll_interval_ms, 10_000)
+
+      assert is_integer(interval)
+      assert interval > 0
     end
   end
 end

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -17,6 +17,7 @@ defmodule Loopctl.DataCase do
   use ExUnit.CaseTemplate
 
   alias Ecto.Adapters.SQL.Sandbox
+  alias Loopctl.Telemetry.ObanStats
   alias Loopctl.Telemetry.ScaleAlerts
   alias Loopctl.Webhooks.ReqDelivery
 
@@ -269,6 +270,18 @@ defmodule Loopctl.DataCase do
     # REAL plug wired via config/test.exs that delegates to LoopctlWeb.Router for
     # every request and only raises when an opt-in `x-test-raise-db-error` header
     # is present — so there is NO global router mock to stub here.
+
+    # US-34.1: the Oban `oban_jobs` observability poll's DI seam. Default delegates
+    # both callbacks to the real `Loopctl.Telemetry.ObanStats`, so every integration
+    # test exercises the genuine raw-SQL read against the sandbox connection; the
+    # poller-resilience test overrides a callback with `Mox.expect/3` to raise.
+    Mox.stub(Loopctl.MockObanStats, :job_state_counts, fn ->
+      ObanStats.job_state_counts()
+    end)
+
+    Mox.stub(Loopctl.MockObanStats, :executing_orphan_count, fn threshold_minutes ->
+      ObanStats.executing_orphan_count(threshold_minutes)
+    end)
   end
 
   @doc """

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -1645,6 +1645,36 @@ defmodule Loopctl.Fixtures do
     end
   end
 
+  # US-34.1: inserts a raw `oban_jobs` row with an arbitrary `state`/`queue`/
+  # `attempted_at`, bypassing Oban's public `new/2` API (which only ever produces an
+  # `available`/`scheduled` job) so tests can seed the full state space the
+  # observability poll (`Loopctl.Telemetry.ObanStats`) reads.
+  #
+  # `oban_jobs` is a GLOBAL infra table with NO `tenant_id` and NO RLS policy, so —
+  # unlike every other fixture in this module — this inserts via `Loopctl.Repo`
+  # (never `AdminRepo`), matching the connection `Loopctl.Telemetry.ObanStats` itself
+  # reads through. Accepted attrs: `:state` (default `"available"`), `:queue`
+  # (default `"default"`), `:worker` (default a fake string — never resolved/run),
+  # `:attempted_at` (default `nil`).
+  def fixture(:oban_job, attrs) do
+    attrs = Enum.into(attrs, %{})
+    now = DateTime.utc_now()
+
+    %Oban.Job{}
+    |> Ecto.Changeset.change(%{
+      state: Map.get(attrs, :state, "available"),
+      queue: Map.get(attrs, :queue, "default"),
+      worker: Map.get(attrs, :worker, "Loopctl.Test.FakeWorker"),
+      args: Map.get(attrs, :args, %{}),
+      attempt: Map.get(attrs, :attempt, 0),
+      max_attempts: Map.get(attrs, :max_attempts, 20),
+      inserted_at: now,
+      scheduled_at: now,
+      attempted_at: Map.get(attrs, :attempted_at)
+    })
+    |> Loopctl.Repo.insert!()
+  end
+
   @doc """
   Generates a fresh binary UUID for use in tests.
   """

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -55,3 +55,11 @@ Mox.defmock(Loopctl.MockScaleAlertsConfigChecker,
 # wired via config/test.exs), NOT a Mox mock — so the production router stays on
 # the hot path for every request and the catch/log/sanitize path is exercised by
 # an opt-in `x-test-raise-db-error` request header rather than a global mock.
+
+# US-34.1: the Oban `oban_jobs` observability poll's DI seam. The DataCase default
+# stub delegates both callbacks to the real `Loopctl.Telemetry.ObanStats`, so every
+# integration test exercises the genuine raw-SQL read against the sandbox
+# connection; the dedicated poller-resilience test (TC-34.1.3) overrides a callback
+# with `Mox.expect/3` to raise, proving `dispatch_oban_stats/0` logs + skips instead
+# of crashing the shared `telemetry_poller`.
+Mox.defmock(Loopctl.MockObanStats, for: Loopctl.Telemetry.ObanStatsBehaviour)


### PR DESCRIPTION
US-34.1 (Epic 34, #349) — Oban queue/state observability.

## What
- Per-queue / per-state Oban job-count gauges (`SELECT state, count(*) FROM oban_jobs GROUP BY state`) exported to Prometheus via ScaleMetrics, bounded tags only.
- `:executing`-older-than-N-minutes **orphan gauge** — the signal that Lifeline is falling behind / a job is wedged (the 17-day/110-orphan stall was previously invisible).
- `Oban.Plugins.Reindexer` added (index bloat control); Stager handling documented.

## Why escalated to a session-level PR
The workflow implemented + review-fixed this story and pushed the branch (`d0bcce6`, incl. review-fix commit "widen dispatch_oban_stats/0 rescue, gate poller off in :test"), but its merge agent's grant didn't include `gh pr create`, so no PR was opened. The branch is clean, fully pushed, and already carries its review fixes — this PR just opens + merges the completed work. US-34.2 and US-34.3 depend on this and were skipped; they run once this lands.

## Safety
Purely additive observability + one Oban plugin (Reindexer). Bounded-cardinality metrics (state/queue only, no tenant/args tags). Poller gated off in :test. No job semantics change.
