### PR TITLE
Oban queue/state gauges + :executing orphan gauge (Prometheus); add Reindexer, pin Stager

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -334,8 +334,37 @@ config :loopctl, Oban,
     {Oban.Plugins.Lifeline, rescue_after: :timer.minutes(30)},
     # Prune terminal (completed/discarded/cancelled) jobs older than 7 days so the
     # oban_jobs table doesn't grow unbounded.
-    {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 7}
+    {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 7},
+    # US-34.1 (AC-34.1.4): periodically REINDEX CONCURRENTLY the oban_jobs indexes
+    # (default: oban_jobs_args_index + oban_jobs_meta_index, once daily at midnight
+    # UTC) so index bloat from this table's high churn (state transitions on every
+    # job) doesn't silently degrade the queries the new US-34.1 gauges themselves
+    # depend on. Purely additive — no job semantics change.
+    Oban.Plugins.Reindexer
   ]
+
+# US-34.1 (AC-34.1.4): Stager is NOT a `plugins:` entry in this Oban version
+# (2.21) — it was absorbed into Oban's core engine and is now configured via the
+# top-level `:stage_interval` key (default 1s, unset here so Oban's own default
+# applies). Documenting this explicitly rather than silently relying on it: an
+# older Oban release configured `{Oban.Stager, ...}` as a plugin, so a reader
+# coming from that era would otherwise wonder why it's missing from the list
+# above. No change intended here — the default staging interval is fine.
+
+# US-34.1 (AC-34.1.2/.3): tunables for the two Oban queue/state/orphan telemetry
+# pollers (`Loopctl.Telemetry.ScaleMetrics.poll_oban_queue_state/0` and
+# `poll_oban_executing_orphans/0`), wired into `LoopctlWeb.Telemetry`'s shared
+# `telemetry_poller` (every 10s).
+#
+# - poll_statement_timeout_ms: the per-query SET LOCAL statement_timeout each poll
+#   applies — short and bounded, so a slow poll can never itself saturate the
+#   AdminRepo pool.
+# - orphan_threshold_minutes: how old an `executing` job's `attempted_at` must be to
+#   count as an orphan. Deliberately ABOVE the Lifeline `rescue_after` window (30
+#   min, above) so a non-zero reading means Lifeline is genuinely falling behind or
+#   a job is wedged past Lifeline's own rescue point.
+config :loopctl, :oban_metrics_poll_statement_timeout_ms, 2_000
+config :loopctl, :oban_metrics_orphan_threshold_minutes, 45
 
 # Cloak Vault — key configured per environment
 # Generate a key: :crypto.strong_rand_bytes(32) |> Base.encode64()

--- a/lib/loopctl/telemetry/scale_metrics.ex
+++ b/lib/loopctl/telemetry/scale_metrics.ex
@@ -26,13 +26,14 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   consuming them, so the signal terminated in a no-op handler-less event — invisible
   to Prometheus/dashboards despite already being emitted. See "Wiring emitted-but-dead
   events (US-34.4)" below for the full inventory, including the events deliberately
-  left OUT of scope with a cited reason. US-34.1 adds TWO more, purely-additive
-  gauges: a periodic per-{state, queue} poll of `oban_jobs` (nothing previously
-  exported ANY Oban queue/state metric) and an `:executing`-older-than-N-min orphan
-  gauge — see "Oban queue/state gauges + `:executing` orphan gauge (US-34.1)" below.
-  `scale_metrics/0` now returns 19 metrics total.
+  left OUT of scope with a cited reason. US-34.1 adds THREE more, purely-additive
+  metrics: a periodic per-{state, queue} poll of `oban_jobs` (nothing previously
+  exported ANY Oban queue/state metric), an `:executing`-older-than-N-min orphan
+  gauge, and a poll-failure counter so a frozen gauge is distinguishable from a
+  genuinely stable one — see "Oban queue/state gauges + `:executing` orphan gauge
+  (US-34.1)" below. `scale_metrics/0` now returns 20 metrics total.
 
-  ## The metrics (19 total)
+  ## The metrics (20 total)
 
     1. **Timeout / DB-error counter** — `loopctl.db.error.count`, keyed by
        `[:endpoint, :mapped_code]` (+ a cap-gated `:tenant_id`). `mapped_code`
@@ -240,41 +241,89 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
 
   Two periodic pollers (wired into `LoopctlWeb.Telemetry.periodic_measurements/0`,
   the SAME shared `telemetry_poller` process that already refreshes the tenant-label
-  gate every 10s) run a single lightweight raw-SQL query each against `Loopctl.AdminRepo`
+  gate every 10s) run a single lightweight raw-SQL query each against `Loopctl.Repo`
   (never `Loopctl.HeavyRead`, which structurally REJECTS any query whose base table
   lacks a `tenant_id` Ecto field — `oban_jobs` is not even an Ecto-queryable schema
-  here, it's raw SQL, following the `Loopctl.IndexHealth` precedent). Each poll wraps
-  its query in an `AdminRepo.transaction/1` that first issues a per-query
-  `SET LOCAL statement_timeout` (config `:oban_metrics_poll_statement_timeout_ms`,
-  default #{2_000}ms) — NEVER a connection-startup `:parameters` override, which
-  Fly MPG's pgbouncer rejects with `FATAL 08P01` (the US-27.13 outage class). Both
-  pollers are defensive: `poll_oban_queue_state/0` and
-  `poll_oban_executing_orphans/0` each narrowly rescue ONLY the known DB-fault
-  classes (`Postgrex.Error`, `DBConnection.ConnectionError`,
-  `DBConnection.OwnershipError` — the same set `refresh_tenant_label_gate/0`
-  rescues), `Logger.warning` and return `:ok` — `telemetry_poller` runs every
-  measurement in ONE shared process and does NOT isolate them, so an uncaught raise
-  here would crash the poller and, with it, the tenant-label gate refresh (TC-34.1.3).
+  here, it's raw SQL, following the `Loopctl.IndexHealth` precedent). `Loopctl.Repo`
+  — not `Loopctl.AdminRepo` — is used DELIBERATELY (review finding): `oban_jobs` has
+  `relrowsecurity = false` (verified live), so RLS enforcement is a non-issue either
+  way, and `Loopctl.Repo`'s pool (size 10) is more than 3x `Loopctl.AdminRepo`'s
+  (size 3, the smallest pool in the app, shared with superadmin/BYPASSRLS work) — a
+  recurring 10s poll has no business landing on the app's tightest pool when a
+  larger, equally-permissioned one is available. Each poll wraps its query in a
+  `Repo.transaction/1` that first issues a per-query `SET LOCAL statement_timeout`
+  (config `:oban_metrics_poll_statement_timeout_ms`, default #{2_000}ms, validated
+  to be a positive integer at read time before it is interpolated into the raw SQL
+  string — Postgres's `SET` cannot take a bound parameter — the same guard
+  `Loopctl.HeavyRead.transaction/2` applies before its identical interpolation) —
+  NEVER a connection-startup `:parameters` override, which Fly MPG's pgbouncer
+  rejects with `FATAL 08P01` (the US-27.13 outage class).
+
+  `poll_oban_queue_state/0` restricts its `GROUP BY` and zero-fill to the
+  NON-TERMINAL states (`oban_active_states/0` — `suspended`/`scheduled`/
+  `available`/`executing`/`retryable`; review finding) rather than all 8 states:
+  under normal pruner retention (`config/config.exs`, `max_age` 7 days) the
+  terminal states (`completed`/`discarded`/`cancelled`) can hold hundreds of
+  thousands of rows, forcing a full `Seq Scan` that at scale exceeds the 2s
+  statement_timeout — `EXPLAIN` confirms the non-terminal restriction instead
+  produces an `Index Only Scan` on `oban_jobs_state_queue_priority_scheduled_at_id_index`
+  (the existing `(state, queue, priority, scheduled_at, id)` index Oban itself
+  maintains), so the query stays cheap regardless of how large the terminal-state
+  partitions grow. This also shrinks the zero-fill matrix (`oban_active_states/0` x
+  `oban_queues/0` instead of the full `oban_states/0` x `oban_queues/0`) — terminal
+  states never produce a Prometheus series under this gauge (their volume isn't the
+  operational backlog signal this gauge exists to surface, and 7-day-retained
+  terminal counts are not actionable trend data on a 10s cadence).
+
+  Both pollers are defensive: `poll_oban_queue_state/0` and
+  `poll_oban_executing_orphans/0` each `rescue` on ANY exception (review finding —
+  broadened from a narrow DB-fault-only rescue), `Logger.warning`, EMIT the new
+  poll-failure counter (metric 20 below), and return `:ok`.
+
+  **Why a catch-all rescue, and what "crash the poller" actually means (review
+  finding — the previous docs here were factually wrong):** `telemetry_poller`
+  (verified against the vendored `telemetry_poller` 1.3.0 source,
+  `src/telemetry_poller.erl`) wraps EVERY periodic measurement's
+  `erlang:apply/3` in its OWN `try/catch` (`make_measurements_and_filter_misbehaving/1`)
+  and keeps only the measurements that did NOT raise — so an uncaught raise here
+  does NOT crash the shared poller process and does NOT take down the tenant-label
+  gate refresh. What actually happens is worse for THIS specific measurement: the
+  raising MFA is logged once by `telemetry_poller` itself and then PERMANENTLY
+  DROPPED from the poll rotation until the next app restart — the gauge goes dark
+  forever, silently, with no crash and no alert. A narrow rescue (the previous
+  version, catching only `Postgrex.Error`/`DBConnection.ConnectionError`/
+  `DBConnection.OwnershipError`) left every OTHER error class (a config shape
+  error like `oban_queues/0` raising on a malformed `:queues` option, an
+  `ArgumentError` from a bad config tunable, etc.) to propagate straight into that
+  permanent-drop fate — precisely the invisible-failure class this observability
+  epic exists to eliminate. The catch-all rescue below ensures NO measurement is
+  ever silently dropped from the rotation: every exception is caught, logged, and
+  reported via the poll-failure counter, and the gauge simply keeps its
+  last-recorded value for one more cycle.
 
     18. **Oban queue/state gauge** (US-34.1, AC-34.1.1) —
         `loopctl.oban.jobs.count`, a `last_value/2` GAUGE keyed by `[:state, :queue]`
-        — BOTH bounded, fixed sets (`Oban.Job.states/0`'s 8-value state enum; the 9
-        queues declared in `config :loopctl, Oban, queues: [...]`, resolved at call
-        time via `Application.get_env/2`) — NEVER tenant/args-derived.
+        — BOTH bounded, fixed sets (`oban_active_states/0`'s 5 non-terminal states;
+        the 9 queues declared in `config :loopctl, Oban, queues: [...]`, resolved at
+        call time via `Application.get_env/2`) — NEVER tenant/args-derived.
         `poll_oban_queue_state/0` runs
-        `SELECT state, queue, count(*) FROM oban_jobs GROUP BY state, queue`, then
-        ZERO-FILLS: it emits one `[:loopctl, :oban, :jobs, :count]` measurement for
-        EVERY `{state, queue}` pair in the full 8x9 matrix, substituting `count: 0`
-        for any pair the `GROUP BY` did not return a row for (a `count(*) GROUP BY`
-        can only ever return rows with count >= 1, so the zero case is never present
-        in `rows` — it must be synthesized). A drained combination is therefore
-        explicitly reset to `0` every poll cycle rather than retaining a stale
-        last-seen value — the correct gauge semantics for "how many jobs are in this
-        state right now" (a `last_value/2` gauge itself has no expiry; without this
-        zero-fill a drained `{state, queue}` pair would read stale-high forever). The
-        one exception is a poll that FAILS outright (DB fault, `rescue`d below): no
-        measurement fires that cycle, so the gauge intentionally keeps its prior
-        reading until the next successful poll — there is no fresher truth to report.
+        `SELECT state, queue, count(*) FROM oban_jobs WHERE state = ANY($1) GROUP BY state, queue`
+        (`$1` bound to `oban_active_states/0`), then ZERO-FILLS: it emits one
+        `[:loopctl, :oban, :jobs, :count]` measurement for EVERY `{state, queue}`
+        pair in the `oban_active_states/0` x `oban_queues/0` matrix, substituting
+        `count: 0` for any pair the `GROUP BY` did not return a row for (a
+        `count(*) GROUP BY` can only ever return rows with count >= 1, so the zero
+        case is never present in `rows` — it must be synthesized). A drained
+        combination is therefore explicitly reset to `0` every poll cycle rather
+        than retaining a stale last-seen value — the correct gauge semantics for
+        "how many jobs are in this state right now" (a `last_value/2` gauge itself
+        has no expiry; without this zero-fill a drained `{state, queue}` pair would
+        read stale-high forever). The one exception is a poll that FAILS outright
+        (`rescue`d below): no measurement fires that cycle, so the gauge
+        intentionally keeps its prior reading until the next successful poll —
+        there is no fresher truth to report, and the poll-failure counter (metric
+        20) makes that staleness detectable rather than silently indistinguishable
+        from a genuinely stable reading.
     19. **`:executing`-older-than-N-min orphan gauge** (US-34.1, AC-34.1.2) —
         `loopctl.oban.jobs.executing_orphan.count`, an UNTAGGED `last_value/2` gauge.
         `poll_oban_executing_orphans/0` counts `oban_jobs` rows in state `executing`
@@ -282,13 +331,25 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
         (default #{45} minutes — deliberately ABOVE the Lifeline `rescue_after` window,
         30 min, so a non-zero reading means Lifeline is falling behind or a job is
         genuinely wedged past Lifeline's own rescue point, not merely mid-flight).
+        `EXPLAIN` confirms this query is already an `Index Scan` over the tiny
+        `executing` partition — unaffected by the Seq Scan risk metric 18 fixes.
+    20. **Oban poll-failure counter** (US-34.1, review finding) —
+        `loopctl.oban.poll.error.count`, keyed by `[:poller, :error_class]` — BOTH
+        bounded, fixed sets (`poller` is `"queue_state"`/`"executing_orphans"`;
+        `error_class` is CLASSIFIED via `oban_poll_error_class/1` into
+        `"db_error"`/`"config_error"`/`"other"`, never the raw exception message).
+        Emitted from BOTH pollers' catch-all `rescue` clause, so a frozen gauge
+        (metrics 18/19 retaining their last value because a poll cycle failed) is
+        now distinguishable in Prometheus from a genuinely stable reading — a
+        non-zero, incrementing rate on this counter means the OTHER two gauges are
+        stale, not that the system is actually quiet.
   """
 
   import Telemetry.Metrics
 
   require Logger
 
-  alias Loopctl.AdminRepo
+  alias Loopctl.Repo
   alias Loopctl.Tenants
 
   @persistent_term_key {__MODULE__, :tenant_label?}
@@ -302,7 +363,7 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
 
   # US-34.1: per-query SET LOCAL statement_timeout for the two Oban pollers below —
   # short and bounded (AC-34.1.3), so a slow poll can never itself saturate the
-  # AdminRepo pool. Configurable via :oban_metrics_poll_statement_timeout_ms.
+  # Repo pool. Configurable via :oban_metrics_poll_statement_timeout_ms.
   @default_oban_metrics_poll_timeout_ms 2_000
 
   # US-34.1: the `:executing` orphan gauge's age threshold (minutes). Deliberately
@@ -312,14 +373,22 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   # Configurable via :oban_metrics_orphan_threshold_minutes.
   @default_oban_metrics_orphan_threshold_minutes 45
 
+  # US-34.1: the terminal Oban job states EXCLUDED from the live poll/zero-fill
+  # matrix (review finding). A job in one of these states will never transition
+  # again, and under the pruner's 7-day retention these partitions can grow to
+  # hundreds of thousands of rows — polling them forces a Seq Scan at scale. The
+  # non-terminal complement (`oban_active_states/0`) is what `poll_oban_queue_state/0`
+  # actually queries/zero-fills.
+  @oban_terminal_states [:completed, :discarded, :cancelled]
+
   @doc """
-  All 19 scale metrics: the original US-27.15 trio, #297's semantic-fallback
+  All 20 scale metrics: the original US-27.15 trio, #297's semantic-fallback
   counter, US-31.2's hybrid-provenance counter, US-33.1's two per-pool checkout
   `queue_time` distributions, US-34.4's ten emitted-but-dead-event counters
   (LLM/embedding-blocked, index-health, secrets/witness/memory-promotion
-  degradation signals), and US-34.1's two Oban queue/state gauges (per-{state,
-  queue} counts + the `:executing` orphan gauge). Appended to
-  `LoopctlWeb.Telemetry.metrics/0`.
+  degradation signals), and US-34.1's three Oban metrics (per-{state, queue}
+  gauge over the non-terminal states, the `:executing` orphan gauge, and a
+  poll-failure counter). Appended to `LoopctlWeb.Telemetry.metrics/0`.
   """
   @spec scale_metrics() :: [Telemetry.Metrics.t()]
   def scale_metrics do
@@ -541,18 +610,19 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
       # 18. Oban queue/state gauge (US-34.1, AC-34.1.1). `poll_oban_queue_state/0` (a
       #     periodic measurement wired into
       #     `LoopctlWeb.Telemetry.periodic_measurements/0`) runs a single
-      #     `GROUP BY state, queue` poll against the GLOBAL `oban_jobs` table, then
-      #     ZERO-FILLS the full state x queue matrix (emitting `count: 0` for any pair
-      #     the GROUP BY didn't return) before emitting. `last_value/2` is a
+      #     `GROUP BY state, queue` poll (restricted to the non-terminal states —
+      #     review finding) against the GLOBAL `oban_jobs` table, then ZERO-FILLS the
+      #     `oban_active_states/0` x `oban_queues/0` matrix (emitting `count: 0` for
+      #     any pair the GROUP BY didn't return) before emitting. `last_value/2` is a
       #     Prometheus GAUGE — every poll records/overwrites the series for that
       #     `{state, queue}` pair, so a drained combination is explicitly reset to `0`
       #     instead of retaining a stale non-zero reading. Both tags are BOUNDED,
-      #     FIXED sets (`Oban.Job.states/0`'s 8-value state enum; the 9 configured
-      #     queues) — NEVER tenant/args-derived (AC-34.1.5).
+      #     FIXED sets (`oban_active_states/0`'s 5-value non-terminal state enum; the
+      #     9 configured queues) — NEVER tenant/args-derived (AC-34.1.5).
       last_value("loopctl.oban.jobs.count",
         event_name: [:loopctl, :oban, :jobs, :count],
         measurement: :count,
-        description: "Oban job counts by state and queue (periodic GROUP BY poll).",
+        description: "Oban job counts by non-terminal state and queue (periodic GROUP BY poll).",
         tags: [:state, :queue],
         tag_values: &oban_queue_state_tags/1
       ),
@@ -569,6 +639,19 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
         measurement: :count,
         description: "Oban jobs stuck in :executing older than the orphan threshold.",
         tags: []
+      ),
+
+      # 20. Oban poll-failure counter (US-34.1, review finding). Emitted from BOTH
+      #     pollers' catch-all rescue clause so a stale (frozen) gauge above is
+      #     distinguishable in Prometheus from a genuinely stable reading. `poller`
+      #     identifies which poll failed; `error_class` is CLASSIFIED (never the raw
+      #     exception message/struct) into a small bounded set.
+      counter("loopctl.oban.poll.error.count",
+        event_name: [:loopctl, :oban, :poll, :error],
+        measurement: :count,
+        description: "Oban metrics poll failures, by poller and classified error class.",
+        tags: [:poller, :error_class],
+        tag_values: &oban_poll_error_tags/1
       )
     ]
   end
@@ -757,85 +840,130 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   end
 
   @doc """
-  The fixed, bounded set of Oban job states (`Oban.Job.states/0` — 8 values),
-  used to zero-fill the per-`{state, queue}` gauge every poll cycle so a drained
-  combination reports `0` instead of a `last_value/2` gauge retaining a stale
-  non-zero reading forever (US-34.1, AC-34.1.1).
+  The fixed, bounded set of ALL Oban job states (`Oban.Job.states/0` — 8 values,
+  including the terminal `:completed`/`:discarded`/`:cancelled`). This is a
+  documentation/reference enum — the LIVE poll/zero-fill matrix uses the
+  narrower `oban_active_states/0` (review finding), NOT this function.
   """
   @spec oban_states() :: [atom()]
   def oban_states, do: Oban.Job.states()
+
+  @doc """
+  The NON-TERMINAL Oban job states (`oban_states/0` minus `:completed`,
+  `:discarded`, `:cancelled` — 5 values: `:suspended`, `:scheduled`, `:available`,
+  `:executing`, `:retryable`) — the set `poll_oban_queue_state/0` actually queries
+  and zero-fills (US-34.1, review finding).
+
+  Restricting to these states keeps the poll on the cheap `Index Only Scan` path
+  over `oban_jobs_state_queue_priority_scheduled_at_id_index` (Oban's own
+  `(state, queue, priority, scheduled_at, id)` index) regardless of how large the
+  terminal-state partitions grow under the pruner's 7-day retention — a bare
+  `GROUP BY state, queue` over ALL 8 states forces a full `Seq Scan` once the
+  terminal partitions dominate the table (verified via `EXPLAIN` on production
+  scale data), which at scale exceeds the poll's own `SET LOCAL statement_timeout`.
+  """
+  @spec oban_active_states() :: [atom()]
+  def oban_active_states, do: oban_states() -- @oban_terminal_states
 
   @doc """
   The fixed, bounded set of configured Oban queue names, resolved at CALL time
   via `Application.get_env/2` (never `Application.compile_env/2` — queue WIDTHS
   are env-tunable at runtime per `Loopctl.ObanConfig`/`config/runtime.exs`, but
   the set of queue NAMES itself is static across every environment). Used
-  together with `oban_states/0` to zero-fill the per-`{state, queue}` gauge —
-  this also structurally bounds the `:queue` label to the configured set, so an
-  unconfigured/ad-hoc queue name can never appear as a Prometheus series
-  (US-34.1, AC-34.1.1/.5).
+  together with `oban_active_states/0` to zero-fill the per-`{state, queue}`
+  gauge — this also structurally bounds the `:queue` label to the configured
+  set, so an unconfigured/ad-hoc queue name can never appear as a Prometheus
+  series (US-34.1, AC-34.1.1/.5).
+
+  Defensive against a malformed `:queues` shape (review finding): Oban documents
+  `queues: false` as a valid option to disable all queues, and `Keyword.keys/1`
+  raises `FunctionClauseError` on a non-list. Rather than let that propagate,
+  any non-list `:queues` value (including `false`) resolves to an empty queue
+  set — a zero-queue poll, not a crash.
   """
   @spec oban_queues() :: [atom()]
   def oban_queues do
     :loopctl
     |> Application.get_env(Oban, [])
     |> Keyword.get(:queues, [])
-    |> Keyword.keys()
+    |> queues_from_config()
   end
 
   @doc """
-  Polls `oban_jobs` for per-`{state, queue}` counts and emits one ZERO-FILLED
-  telemetry measurement for every pair in the full `oban_states/0` x
-  `oban_queues/0` matrix (US-34.1, AC-34.1.1).
+  Pure helper for `oban_queues/0`'s defensive shape guard (review finding),
+  exposed directly so the `queues: false` case is testable WITHOUT mutating the
+  global `:loopctl, Oban` application config. A list `:queues` keyword resolves
+  to its keys as usual; anything else (notably the documented `queues: false`
+  option, which `Keyword.keys/1` would raise `FunctionClauseError` on) resolves
+  to an empty queue set instead of raising.
+  """
+  @spec queues_from_config(term()) :: [atom()]
+  def queues_from_config(queues) when is_list(queues), do: Keyword.keys(queues)
+  def queues_from_config(_other), do: []
+
+  @doc """
+  Polls `oban_jobs` for per-`{state, queue}` counts, restricted to the
+  non-terminal states (`oban_active_states/0` — review finding), and emits one
+  ZERO-FILLED telemetry measurement for every pair in the
+  `oban_active_states/0` x `oban_queues/0` matrix (US-34.1, AC-34.1.1).
 
   This is a `telemetry_poller` periodic measurement (wired in
   `LoopctlWeb.Telemetry.periodic_measurements/0`, the SAME shared process that
   refreshes the tenant-label gate every 10s). It runs a SINGLE lightweight
-  `SELECT state, queue, count(*) FROM oban_jobs GROUP BY state, queue` against
-  `Loopctl.AdminRepo` (raw SQL — `oban_jobs` is a GLOBAL table with no `tenant_id`
-  column, so `Loopctl.HeavyRead` would structurally reject it; follows the
-  `Loopctl.IndexHealth` raw-SQL-on-AdminRepo precedent), wrapped in a transaction
-  that first issues a per-query `SET LOCAL statement_timeout`
+  `SELECT state, queue, count(*) FROM oban_jobs WHERE state = ANY($1) GROUP BY
+  state, queue` against `Loopctl.Repo` (raw SQL — `oban_jobs` is a GLOBAL table
+  with no `tenant_id` column, so `Loopctl.HeavyRead` would structurally reject
+  it; follows the `Loopctl.IndexHealth` raw-SQL precedent). `Loopctl.Repo` (pool
+  size 10), not `Loopctl.AdminRepo` (pool size 3, the app's smallest), is used
+  deliberately (review finding) — `oban_jobs` has no RLS policy
+  (`relrowsecurity = false`, verified live), so RLS enforcement is a non-issue
+  either way, and a recurring 10s poll should land on the larger pool. Wrapped in
+  a transaction that first issues a per-query `SET LOCAL statement_timeout`
   (`:oban_metrics_poll_statement_timeout_ms`, default
-  #{@default_oban_metrics_poll_timeout_ms}ms) so a slow poll can never itself
-  saturate the pool (AC-34.1.3).
+  #{@default_oban_metrics_poll_timeout_ms}ms, validated positive-integer at read
+  time before interpolation) so a slow poll can never itself saturate the pool
+  (AC-34.1.3).
 
   A `GROUP BY count(*)` can only ever return rows with count >= 1 — it never
   returns a row for a `{state, queue}` pair with zero jobs. So the returned rows
-  are folded into a lookup map, then EVERY pair in `oban_states/0` x
+  are folded into a lookup map, then EVERY pair in `oban_active_states/0` x
   `oban_queues/0` is emitted, substituting `count: 0` for any pair absent from
   that lookup. Without this, a `last_value/2` gauge (which has no expiry — it
   just overwrites its ETS entry, `TelemetryMetricsPrometheus.Core.LastValue`)
   would retain a drained pair's last non-zero reading forever, indistinguishable
   from a genuinely-stuck backlog.
 
-  Defensive: narrowly rescues ONLY the known DB-fault classes (`Postgrex.Error`,
-  `DBConnection.ConnectionError`, `DBConnection.OwnershipError` — the same set
-  `refresh_tenant_label_gate/0` rescues), logs a warning, and returns `:ok` without
-  emitting any telemetry — `telemetry_poller` does NOT isolate measurements from
-  each other, so an uncaught raise here would crash the shared poller (TC-34.1.3).
-  On a FAILED poll (as opposed to a successful poll that finds zero rows), no
-  zero-fill happens either — the gauge intentionally keeps its last-recorded
-  value until the next successful poll, since a failed query has no fresher
-  truth to report. Always returns `:ok`.
+  Defensive: `rescue`s ANY exception (review finding — broadened from a narrow
+  DB-fault-only rescue, since `telemetry_poller` permanently drops a raising
+  measurement from its rotation rather than crashing — see the moduledoc
+  section above), logs a warning, EMITS the poll-failure counter (metric 20),
+  and returns `:ok` without emitting the state/queue gauge. On a FAILED poll (as
+  opposed to a successful poll that finds zero rows), no zero-fill happens
+  either — the gauge intentionally keeps its last-recorded value until the next
+  successful poll, since a failed query has no fresher truth to report, and the
+  poll-failure counter makes that staleness observable. Always returns `:ok`.
   """
   @spec poll_oban_queue_state() :: :ok
   def poll_oban_queue_state do
     timeout_ms = oban_metrics_poll_statement_timeout_ms()
+    active_states = Enum.map(oban_active_states(), &Atom.to_string/1)
 
     {:ok, rows} =
-      AdminRepo.transaction(fn ->
-        AdminRepo.query!("SET LOCAL statement_timeout = #{timeout_ms}")
+      Repo.transaction(fn ->
+        Repo.query!("SET LOCAL statement_timeout = #{timeout_ms}")
 
         %{rows: rows} =
-          AdminRepo.query!("SELECT state, queue, count(*) FROM oban_jobs GROUP BY state, queue")
+          Repo.query!(
+            "SELECT state, queue, count(*) FROM oban_jobs WHERE state = ANY($1) GROUP BY state, queue",
+            [active_states]
+          )
 
         rows
       end)
 
     counts = Map.new(rows, fn [state, queue, count] -> {{state, queue}, count} end)
 
-    for state <- oban_states(), queue <- oban_queues() do
+    for state <- oban_active_states(), queue <- oban_queues() do
       state_str = Atom.to_string(state)
       queue_str = Atom.to_string(queue)
       count = Map.get(counts, {state_str, queue_str}, 0)
@@ -848,11 +976,13 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
 
     :ok
   rescue
-    e in [Postgrex.Error, DBConnection.ConnectionError, DBConnection.OwnershipError] ->
+    e ->
       Logger.warning(
         "Oban queue/state poll failed (#{inspect(e.__struct__)}); skipping this cycle — " <>
           "the oban.jobs.count gauge simply keeps its last-recorded value until the next poll"
       )
+
+      emit_oban_poll_error(:queue_state, e)
 
       :ok
   end
@@ -863,10 +993,12 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   measurement (US-34.1, AC-34.1.2).
 
   Same defensive/bounded-interval contract as `poll_oban_queue_state/0` — a single
-  `SET LOCAL statement_timeout`-wrapped `AdminRepo` query, narrowly rescued on DB
-  faults, `Logger.warning` + `:ok` on failure, never crashing the shared poller
-  (TC-34.1.3). The age comparison (`attempted_at < now() - N minutes`) is done IN
-  SQL, not in Elixir, so only genuinely stale rows are counted. Always returns `:ok`.
+  `SET LOCAL statement_timeout`-wrapped `Loopctl.Repo` query (review finding —
+  moved off the tiny `AdminRepo` pool alongside the other poller), catch-all
+  rescue, `Logger.warning` + poll-failure counter + `:ok` on failure, never
+  crashing the shared poller. The age comparison (`attempted_at < now() - N
+  minutes`) is done IN SQL, not in Elixir, so only genuinely stale rows are
+  counted. Always returns `:ok`.
   """
   @spec poll_oban_executing_orphans() :: :ok
   def poll_oban_executing_orphans do
@@ -874,8 +1006,8 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
     threshold_minutes = oban_metrics_orphan_threshold_minutes()
 
     {:ok, count} =
-      AdminRepo.transaction(fn ->
-        AdminRepo.query!("SET LOCAL statement_timeout = #{timeout_ms}")
+      Repo.transaction(fn ->
+        Repo.query!("SET LOCAL statement_timeout = #{timeout_ms}")
 
         # `attempted_at` is a `timestamp without time zone` column populated by
         # Ecto's `:utc_datetime_usec` dump — i.e. it holds a UTC wall-clock reading
@@ -885,7 +1017,7 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
         # the comparison by that offset. `now() AT TIME ZONE 'UTC'` converts to a
         # naive UTC wall-clock timestamp first, matching what's actually stored.
         %{rows: [[count]]} =
-          AdminRepo.query!(
+          Repo.query!(
             """
             SELECT count(*)
             FROM oban_jobs
@@ -902,27 +1034,90 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
 
     :ok
   rescue
-    e in [Postgrex.Error, DBConnection.ConnectionError, DBConnection.OwnershipError] ->
+    e ->
       Logger.warning(
         "Oban executing-orphan poll failed (#{inspect(e.__struct__)}); skipping this cycle — " <>
           "the executing_orphan gauge simply keeps its last-recorded value until the next poll"
       )
 
+      emit_oban_poll_error(:executing_orphans, e)
+
       :ok
   end
+
+  # Emits the poll-failure counter (metric 20) from a poller's catch-all rescue.
+  # The RAW exception struct is passed through in metadata (like
+  # `secrets_orphan_cleanup_tags/1`'s raw `{:error, term()}`) — classification into
+  # the bounded `error_class` tag happens at `tag_values` time (`oban_poll_error_tags/1`),
+  # not here, so any other handler attached to this event still sees the real error.
+  defp emit_oban_poll_error(poller, exception) do
+    :telemetry.execute([:loopctl, :oban, :poll, :error], %{count: 1}, %{
+      poller: poller,
+      exception: exception
+    })
+  end
+
+  @doc """
+  `tag_values` for the Oban poll-failure counter (US-34.1, metric 20). `poller`
+  passes through as a bounded atom (`:queue_state`/`:executing_orphans`);
+  `error_class` CLASSIFIES the raw `metadata.exception` into a small bounded set
+  (never the raw exception message/struct) — the same "mapped_code"/
+  `secrets_reason_class/1` classification precedent used elsewhere in this
+  module. Defaults missing keys to `"unknown"` so this can never raise.
+  """
+  @spec oban_poll_error_tags(map()) :: map()
+  def oban_poll_error_tags(metadata) do
+    %{
+      poller: Map.get(metadata, :poller) || "unknown",
+      error_class: oban_poll_error_class(Map.get(metadata, :exception))
+    }
+  end
+
+  defp oban_poll_error_class(%Postgrex.Error{}), do: "db_error"
+  defp oban_poll_error_class(%DBConnection.ConnectionError{}), do: "db_error"
+  defp oban_poll_error_class(%DBConnection.OwnershipError{}), do: "db_error"
+  defp oban_poll_error_class(%ArgumentError{}), do: "config_error"
+  defp oban_poll_error_class(%FunctionClauseError{}), do: "config_error"
+  defp oban_poll_error_class(nil), do: "unknown"
+  defp oban_poll_error_class(_other), do: "other"
 
   @doc """
   The configured per-poll `SET LOCAL statement_timeout` (ms) for the two Oban
   pollers above (`:oban_metrics_poll_statement_timeout_ms`, default
-  #{@default_oban_metrics_poll_timeout_ms}).
+  #{@default_oban_metrics_poll_timeout_ms}). Validated to be a POSITIVE INTEGER
+  at read time (review finding) — this value is interpolated directly into a raw
+  SQL string (Postgres's `SET` cannot take a bound parameter), the same guard
+  `Loopctl.HeavyRead.transaction/2` applies before its identical interpolation.
+  Raises `ArgumentError` on an invalid config override rather than silently
+  building malformed SQL.
   """
   @spec oban_metrics_poll_statement_timeout_ms() :: pos_integer()
   def oban_metrics_poll_statement_timeout_ms do
-    Application.get_env(
-      :loopctl,
+    :loopctl
+    |> Application.get_env(
       :oban_metrics_poll_statement_timeout_ms,
       @default_oban_metrics_poll_timeout_ms
     )
+    |> validate_positive_poll_timeout!()
+  end
+
+  @doc """
+  Pure validation helper for `oban_metrics_poll_statement_timeout_ms/0` (review
+  finding), exposed directly so the invalid-config-value case is testable
+  WITHOUT mutating the global `:loopctl, :oban_metrics_poll_statement_timeout_ms`
+  application config. Raises `ArgumentError` on anything that is not a positive
+  integer — this value is interpolated directly into a raw SQL string (Postgres's
+  `SET` cannot take a bound parameter), the same guard
+  `Loopctl.HeavyRead.transaction/2` applies before its identical interpolation.
+  """
+  @spec validate_positive_poll_timeout!(term()) :: pos_integer()
+  def validate_positive_poll_timeout!(ms) when is_integer(ms) and ms > 0, do: ms
+
+  def validate_positive_poll_timeout!(other) do
+    raise ArgumentError,
+          ":oban_metrics_poll_statement_timeout_ms (got #{inspect(other)}) must be a " <>
+            "positive integer (ms) — it is interpolated directly into a raw SQL " <>
+            "SET LOCAL statement_timeout statement"
   end
 
   @doc """

--- a/lib/loopctl/telemetry/scale_metrics.ex
+++ b/lib/loopctl/telemetry/scale_metrics.ex
@@ -26,10 +26,13 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   consuming them, so the signal terminated in a no-op handler-less event — invisible
   to Prometheus/dashboards despite already being emitted. See "Wiring emitted-but-dead
   events (US-34.4)" below for the full inventory, including the events deliberately
-  left OUT of scope with a cited reason. `scale_metrics/0` now returns 17 metrics
-  total.
+  left OUT of scope with a cited reason. US-34.1 adds TWO more, purely-additive
+  gauges: a periodic per-{state, queue} poll of `oban_jobs` (nothing previously
+  exported ANY Oban queue/state metric) and an `:executing`-older-than-N-min orphan
+  gauge — see "Oban queue/state gauges + `:executing` orphan gauge (US-34.1)" below.
+  `scale_metrics/0` now returns 19 metrics total.
 
-  ## The metrics (17 total)
+  ## The metrics (19 total)
 
     1. **Timeout / DB-error counter** — `loopctl.db.error.count`, keyed by
        `[:endpoint, :mapped_code]` (+ a cap-gated `:tenant_id`). `mapped_code`
@@ -225,12 +228,58 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
       truncation volume is expected to correlate with the already-instrumented
       `loopctl.knowledge.vector_search.under_fill.count`/hybrid-provenance
       signals rather than needing its own series.
+
+  ## Oban queue/state gauges + `:executing` orphan gauge (US-34.1)
+
+  Before this story NOTHING exported any `oban_jobs` state metric — the exact blind
+  spot that let 110 jobs sit stuck `:executing` for days (2026-06-22 → 2026-07-10)
+  before anyone noticed (the incident that motivated adding `Oban.Plugins.Lifeline`,
+  see `config/config.exs`). `oban_jobs` is a GLOBAL table — it has NO `tenant_id`
+  column (only `args` carries one, per-job, inside a JSON blob) — so this is
+  infrastructure observability, not tenant-scoped data.
+
+  Two periodic pollers (wired into `LoopctlWeb.Telemetry.periodic_measurements/0`,
+  the SAME shared `telemetry_poller` process that already refreshes the tenant-label
+  gate every 10s) run a single lightweight raw-SQL query each against `Loopctl.AdminRepo`
+  (never `Loopctl.HeavyRead`, which structurally REJECTS any query whose base table
+  lacks a `tenant_id` Ecto field — `oban_jobs` is not even an Ecto-queryable schema
+  here, it's raw SQL, following the `Loopctl.IndexHealth` precedent). Each poll wraps
+  its query in an `AdminRepo.transaction/1` that first issues a per-query
+  `SET LOCAL statement_timeout` (config `:oban_metrics_poll_statement_timeout_ms`,
+  default #{2_000}ms) — NEVER a connection-startup `:parameters` override, which
+  Fly MPG's pgbouncer rejects with `FATAL 08P01` (the US-27.13 outage class). Both
+  pollers are defensive: `poll_oban_queue_state/0` and
+  `poll_oban_executing_orphans/0` each narrowly rescue ONLY the known DB-fault
+  classes (`Postgrex.Error`, `DBConnection.ConnectionError`,
+  `DBConnection.OwnershipError` — the same set `refresh_tenant_label_gate/0`
+  rescues), `Logger.warning` and return `:ok` — `telemetry_poller` runs every
+  measurement in ONE shared process and does NOT isolate them, so an uncaught raise
+  here would crash the poller and, with it, the tenant-label gate refresh (TC-34.1.3).
+
+    18. **Oban queue/state gauge** (US-34.1, AC-34.1.1) —
+        `loopctl.oban.jobs.count`, a `last_value/2` GAUGE keyed by `[:state, :queue]`
+        — BOTH bounded, fixed sets (Oban's 7-value state enum; the 9 queues declared
+        in `config :loopctl, Oban, queues: [...]`) — NEVER tenant/args-derived.
+        `poll_oban_queue_state/0` runs
+        `SELECT state, queue, count(*) FROM oban_jobs GROUP BY state, queue` and emits
+        one `[:loopctl, :oban, :jobs, :count]` measurement per row, so `last_value`
+        records/overwrites one series per `{state, queue}` pair every poll (a drained
+        combination simply keeps its last-seen value, e.g. 0, rather than vanishing —
+        the correct gauge semantics for "how many jobs are in this state right now").
+    19. **`:executing`-older-than-N-min orphan gauge** (US-34.1, AC-34.1.2) —
+        `loopctl.oban.jobs.executing_orphan.count`, an UNTAGGED `last_value/2` gauge.
+        `poll_oban_executing_orphans/0` counts `oban_jobs` rows in state `executing`
+        whose `attempted_at` is older than `:oban_metrics_orphan_threshold_minutes`
+        (default #{45} minutes — deliberately ABOVE the Lifeline `rescue_after` window,
+        30 min, so a non-zero reading means Lifeline is falling behind or a job is
+        genuinely wedged past Lifeline's own rescue point, not merely mid-flight).
   """
 
   import Telemetry.Metrics
 
   require Logger
 
+  alias Loopctl.AdminRepo
   alias Loopctl.Tenants
 
   @persistent_term_key {__MODULE__, :tenant_label?}
@@ -242,12 +291,26 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
 
   @default_tenant_label_cap 1_000
 
+  # US-34.1: per-query SET LOCAL statement_timeout for the two Oban pollers below —
+  # short and bounded (AC-34.1.3), so a slow poll can never itself saturate the
+  # AdminRepo pool. Configurable via :oban_metrics_poll_statement_timeout_ms.
+  @default_oban_metrics_poll_timeout_ms 2_000
+
+  # US-34.1: the `:executing` orphan gauge's age threshold (minutes). Deliberately
+  # ABOVE the Lifeline `rescue_after` window (30 min, config/config.exs) so a
+  # non-zero reading means Lifeline is genuinely falling behind or a job is wedged
+  # past Lifeline's own rescue point — not merely a job that is still mid-flight.
+  # Configurable via :oban_metrics_orphan_threshold_minutes.
+  @default_oban_metrics_orphan_threshold_minutes 45
+
   @doc """
-  All 17 scale metrics: the original US-27.15 trio, #297's semantic-fallback
+  All 19 scale metrics: the original US-27.15 trio, #297's semantic-fallback
   counter, US-31.2's hybrid-provenance counter, US-33.1's two per-pool checkout
-  `queue_time` distributions, and US-34.4's ten emitted-but-dead-event counters
+  `queue_time` distributions, US-34.4's ten emitted-but-dead-event counters
   (LLM/embedding-blocked, index-health, secrets/witness/memory-promotion
-  degradation signals). Appended to `LoopctlWeb.Telemetry.metrics/0`.
+  degradation signals), and US-34.1's two Oban queue/state gauges (per-{state,
+  queue} counts + the `:executing` orphan gauge). Appended to
+  `LoopctlWeb.Telemetry.metrics/0`.
   """
   @spec scale_metrics() :: [Telemetry.Metrics.t()]
   def scale_metrics do
@@ -464,6 +527,37 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
         description:
           "Memory-promotion enqueues refused for hitting the tenant compiles/hour budget.",
         tags: []
+      ),
+
+      # 18. Oban queue/state gauge (US-34.1, AC-34.1.1). `poll_oban_queue_state/0` (a
+      #     periodic measurement wired into
+      #     `LoopctlWeb.Telemetry.periodic_measurements/0`) runs a single
+      #     `GROUP BY state, queue` poll against the GLOBAL `oban_jobs` table and emits
+      #     one measurement per row. `last_value/2` is a Prometheus GAUGE — every poll
+      #     records/overwrites the series for that `{state, queue}` pair, so a drained
+      #     combination keeps its last-seen value (e.g. 0) instead of vanishing. Both
+      #     tags are BOUNDED, FIXED sets (Oban's 7-value state enum; the 9 configured
+      #     queues) — NEVER tenant/args-derived (AC-34.1.5).
+      last_value("loopctl.oban.jobs.count",
+        event_name: [:loopctl, :oban, :jobs, :count],
+        measurement: :count,
+        description: "Oban job counts by state and queue (periodic GROUP BY poll).",
+        tags: [:state, :queue],
+        tag_values: &oban_queue_state_tags/1
+      ),
+
+      # 19. Oban `:executing`-older-than-N-min orphan gauge (US-34.1, AC-34.1.2).
+      #     `poll_oban_executing_orphans/0` counts jobs stuck in `executing` whose
+      #     `attempted_at` is older than the configured threshold (default ABOVE the
+      #     Lifeline `rescue_after` window) — the signal that Lifeline is falling
+      #     behind or a job is genuinely wedged (the 110-orphan / 17-day stall that
+      #     motivated adding Lifeline in the first place). UNTAGGED — a single global
+      #     count, never tenant-scoped.
+      last_value("loopctl.oban.jobs.executing_orphan.count",
+        event_name: [:loopctl, :oban, :jobs, :executing_orphan, :count],
+        measurement: :count,
+        description: "Oban jobs stuck in :executing older than the orphan threshold.",
+        tags: []
       )
     ]
   end
@@ -635,6 +729,158 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   @spec memory_promotion_failed_tags(map()) :: map()
   def memory_promotion_failed_tags(metadata) do
     %{stage: Map.get(metadata, :stage) || "unknown"}
+  end
+
+  @doc """
+  `tag_values` for the Oban queue/state gauge (US-34.1). Both `state` and `queue`
+  are bounded, fixed sets sourced directly from the poller's GROUP BY row — NEVER
+  derived from job `args`/tenant. Defaults a missing key to `"unknown"` so this can
+  never raise even when invoked directly with a partial map.
+  """
+  @spec oban_queue_state_tags(map()) :: map()
+  def oban_queue_state_tags(metadata) do
+    %{
+      state: Map.get(metadata, :state, "unknown"),
+      queue: Map.get(metadata, :queue, "unknown")
+    }
+  end
+
+  @doc """
+  Polls `oban_jobs` for per-`{state, queue}` counts and emits one telemetry
+  measurement per row (US-34.1, AC-34.1.1).
+
+  This is a `telemetry_poller` periodic measurement (wired in
+  `LoopctlWeb.Telemetry.periodic_measurements/0`, the SAME shared process that
+  refreshes the tenant-label gate every 10s). It runs a SINGLE lightweight
+  `SELECT state, queue, count(*) FROM oban_jobs GROUP BY state, queue` against
+  `Loopctl.AdminRepo` (raw SQL — `oban_jobs` is a GLOBAL table with no `tenant_id`
+  column, so `Loopctl.HeavyRead` would structurally reject it; follows the
+  `Loopctl.IndexHealth` raw-SQL-on-AdminRepo precedent), wrapped in a transaction
+  that first issues a per-query `SET LOCAL statement_timeout`
+  (`:oban_metrics_poll_statement_timeout_ms`, default
+  #{@default_oban_metrics_poll_timeout_ms}ms) so a slow poll can never itself
+  saturate the pool (AC-34.1.3).
+
+  Defensive: narrowly rescues ONLY the known DB-fault classes (`Postgrex.Error`,
+  `DBConnection.ConnectionError`, `DBConnection.OwnershipError` — the same set
+  `refresh_tenant_label_gate/0` rescues), logs a warning, and returns `:ok` without
+  emitting any telemetry — `telemetry_poller` does NOT isolate measurements from
+  each other, so an uncaught raise here would crash the shared poller (TC-34.1.3).
+  Always returns `:ok`.
+  """
+  @spec poll_oban_queue_state() :: :ok
+  def poll_oban_queue_state do
+    timeout_ms = oban_metrics_poll_statement_timeout_ms()
+
+    {:ok, rows} =
+      AdminRepo.transaction(fn ->
+        AdminRepo.query!("SET LOCAL statement_timeout = #{timeout_ms}")
+
+        %{rows: rows} =
+          AdminRepo.query!("SELECT state, queue, count(*) FROM oban_jobs GROUP BY state, queue")
+
+        rows
+      end)
+
+    Enum.each(rows, fn [state, queue, count] ->
+      :telemetry.execute([:loopctl, :oban, :jobs, :count], %{count: count}, %{
+        state: state,
+        queue: queue
+      })
+    end)
+
+    :ok
+  rescue
+    e in [Postgrex.Error, DBConnection.ConnectionError, DBConnection.OwnershipError] ->
+      Logger.warning(
+        "Oban queue/state poll failed (#{inspect(e.__struct__)}); skipping this cycle — " <>
+          "the oban.jobs.count gauge simply keeps its last-recorded value until the next poll"
+      )
+
+      :ok
+  end
+
+  @doc """
+  Counts `oban_jobs` rows stuck in state `executing` whose `attempted_at` is older
+  than the configured orphan threshold, and emits a single (untagged) telemetry
+  measurement (US-34.1, AC-34.1.2).
+
+  Same defensive/bounded-interval contract as `poll_oban_queue_state/0` — a single
+  `SET LOCAL statement_timeout`-wrapped `AdminRepo` query, narrowly rescued on DB
+  faults, `Logger.warning` + `:ok` on failure, never crashing the shared poller
+  (TC-34.1.3). The age comparison (`attempted_at < now() - N minutes`) is done IN
+  SQL, not in Elixir, so only genuinely stale rows are counted. Always returns `:ok`.
+  """
+  @spec poll_oban_executing_orphans() :: :ok
+  def poll_oban_executing_orphans do
+    timeout_ms = oban_metrics_poll_statement_timeout_ms()
+    threshold_minutes = oban_metrics_orphan_threshold_minutes()
+
+    {:ok, count} =
+      AdminRepo.transaction(fn ->
+        AdminRepo.query!("SET LOCAL statement_timeout = #{timeout_ms}")
+
+        # `attempted_at` is a `timestamp without time zone` column populated by
+        # Ecto's `:utc_datetime_usec` dump — i.e. it holds a UTC wall-clock reading
+        # with no tz attached. `now()` is `timestamptz`; comparing it directly
+        # against a naive column implicitly casts `now()` using the CONNECTION's
+        # `TimeZone` GUC (e.g. Fly Postgres defaults can be non-UTC), which skews
+        # the comparison by that offset. `now() AT TIME ZONE 'UTC'` converts to a
+        # naive UTC wall-clock timestamp first, matching what's actually stored.
+        %{rows: [[count]]} =
+          AdminRepo.query!(
+            """
+            SELECT count(*)
+            FROM oban_jobs
+            WHERE state = 'executing'
+              AND attempted_at < (now() AT TIME ZONE 'UTC') - ($1 * interval '1 minute')
+            """,
+            [threshold_minutes]
+          )
+
+        count
+      end)
+
+    :telemetry.execute([:loopctl, :oban, :jobs, :executing_orphan, :count], %{count: count}, %{})
+
+    :ok
+  rescue
+    e in [Postgrex.Error, DBConnection.ConnectionError, DBConnection.OwnershipError] ->
+      Logger.warning(
+        "Oban executing-orphan poll failed (#{inspect(e.__struct__)}); skipping this cycle — " <>
+          "the executing_orphan gauge simply keeps its last-recorded value until the next poll"
+      )
+
+      :ok
+  end
+
+  @doc """
+  The configured per-poll `SET LOCAL statement_timeout` (ms) for the two Oban
+  pollers above (`:oban_metrics_poll_statement_timeout_ms`, default
+  #{@default_oban_metrics_poll_timeout_ms}).
+  """
+  @spec oban_metrics_poll_statement_timeout_ms() :: pos_integer()
+  def oban_metrics_poll_statement_timeout_ms do
+    Application.get_env(
+      :loopctl,
+      :oban_metrics_poll_statement_timeout_ms,
+      @default_oban_metrics_poll_timeout_ms
+    )
+  end
+
+  @doc """
+  The configured `:executing`-orphan age threshold, in minutes
+  (`:oban_metrics_orphan_threshold_minutes`, default
+  #{@default_oban_metrics_orphan_threshold_minutes} — above the Lifeline
+  `rescue_after` window).
+  """
+  @spec oban_metrics_orphan_threshold_minutes() :: pos_integer()
+  def oban_metrics_orphan_threshold_minutes do
+    Application.get_env(
+      :loopctl,
+      :oban_metrics_orphan_threshold_minutes,
+      @default_oban_metrics_orphan_threshold_minutes
+    )
   end
 
   # The cap gate read on the hot path: a lock-free O(1) persistent_term lookup,

--- a/lib/loopctl/telemetry/scale_metrics.ex
+++ b/lib/loopctl/telemetry/scale_metrics.ex
@@ -258,14 +258,23 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
 
     18. **Oban queue/state gauge** (US-34.1, AC-34.1.1) —
         `loopctl.oban.jobs.count`, a `last_value/2` GAUGE keyed by `[:state, :queue]`
-        — BOTH bounded, fixed sets (Oban's 7-value state enum; the 9 queues declared
-        in `config :loopctl, Oban, queues: [...]`) — NEVER tenant/args-derived.
+        — BOTH bounded, fixed sets (`Oban.Job.states/0`'s 8-value state enum; the 9
+        queues declared in `config :loopctl, Oban, queues: [...]`, resolved at call
+        time via `Application.get_env/2`) — NEVER tenant/args-derived.
         `poll_oban_queue_state/0` runs
-        `SELECT state, queue, count(*) FROM oban_jobs GROUP BY state, queue` and emits
-        one `[:loopctl, :oban, :jobs, :count]` measurement per row, so `last_value`
-        records/overwrites one series per `{state, queue}` pair every poll (a drained
-        combination simply keeps its last-seen value, e.g. 0, rather than vanishing —
-        the correct gauge semantics for "how many jobs are in this state right now").
+        `SELECT state, queue, count(*) FROM oban_jobs GROUP BY state, queue`, then
+        ZERO-FILLS: it emits one `[:loopctl, :oban, :jobs, :count]` measurement for
+        EVERY `{state, queue}` pair in the full 8x9 matrix, substituting `count: 0`
+        for any pair the `GROUP BY` did not return a row for (a `count(*) GROUP BY`
+        can only ever return rows with count >= 1, so the zero case is never present
+        in `rows` — it must be synthesized). A drained combination is therefore
+        explicitly reset to `0` every poll cycle rather than retaining a stale
+        last-seen value — the correct gauge semantics for "how many jobs are in this
+        state right now" (a `last_value/2` gauge itself has no expiry; without this
+        zero-fill a drained `{state, queue}` pair would read stale-high forever). The
+        one exception is a poll that FAILS outright (DB fault, `rescue`d below): no
+        measurement fires that cycle, so the gauge intentionally keeps its prior
+        reading until the next successful poll — there is no fresher truth to report.
     19. **`:executing`-older-than-N-min orphan gauge** (US-34.1, AC-34.1.2) —
         `loopctl.oban.jobs.executing_orphan.count`, an UNTAGGED `last_value/2` gauge.
         `poll_oban_executing_orphans/0` counts `oban_jobs` rows in state `executing`
@@ -532,11 +541,13 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
       # 18. Oban queue/state gauge (US-34.1, AC-34.1.1). `poll_oban_queue_state/0` (a
       #     periodic measurement wired into
       #     `LoopctlWeb.Telemetry.periodic_measurements/0`) runs a single
-      #     `GROUP BY state, queue` poll against the GLOBAL `oban_jobs` table and emits
-      #     one measurement per row. `last_value/2` is a Prometheus GAUGE — every poll
-      #     records/overwrites the series for that `{state, queue}` pair, so a drained
-      #     combination keeps its last-seen value (e.g. 0) instead of vanishing. Both
-      #     tags are BOUNDED, FIXED sets (Oban's 7-value state enum; the 9 configured
+      #     `GROUP BY state, queue` poll against the GLOBAL `oban_jobs` table, then
+      #     ZERO-FILLS the full state x queue matrix (emitting `count: 0` for any pair
+      #     the GROUP BY didn't return) before emitting. `last_value/2` is a
+      #     Prometheus GAUGE — every poll records/overwrites the series for that
+      #     `{state, queue}` pair, so a drained combination is explicitly reset to `0`
+      #     instead of retaining a stale non-zero reading. Both tags are BOUNDED,
+      #     FIXED sets (`Oban.Job.states/0`'s 8-value state enum; the 9 configured
       #     queues) — NEVER tenant/args-derived (AC-34.1.5).
       last_value("loopctl.oban.jobs.count",
         event_name: [:loopctl, :oban, :jobs, :count],
@@ -746,8 +757,36 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   end
 
   @doc """
-  Polls `oban_jobs` for per-`{state, queue}` counts and emits one telemetry
-  measurement per row (US-34.1, AC-34.1.1).
+  The fixed, bounded set of Oban job states (`Oban.Job.states/0` — 8 values),
+  used to zero-fill the per-`{state, queue}` gauge every poll cycle so a drained
+  combination reports `0` instead of a `last_value/2` gauge retaining a stale
+  non-zero reading forever (US-34.1, AC-34.1.1).
+  """
+  @spec oban_states() :: [atom()]
+  def oban_states, do: Oban.Job.states()
+
+  @doc """
+  The fixed, bounded set of configured Oban queue names, resolved at CALL time
+  via `Application.get_env/2` (never `Application.compile_env/2` — queue WIDTHS
+  are env-tunable at runtime per `Loopctl.ObanConfig`/`config/runtime.exs`, but
+  the set of queue NAMES itself is static across every environment). Used
+  together with `oban_states/0` to zero-fill the per-`{state, queue}` gauge —
+  this also structurally bounds the `:queue` label to the configured set, so an
+  unconfigured/ad-hoc queue name can never appear as a Prometheus series
+  (US-34.1, AC-34.1.1/.5).
+  """
+  @spec oban_queues() :: [atom()]
+  def oban_queues do
+    :loopctl
+    |> Application.get_env(Oban, [])
+    |> Keyword.get(:queues, [])
+    |> Keyword.keys()
+  end
+
+  @doc """
+  Polls `oban_jobs` for per-`{state, queue}` counts and emits one ZERO-FILLED
+  telemetry measurement for every pair in the full `oban_states/0` x
+  `oban_queues/0` matrix (US-34.1, AC-34.1.1).
 
   This is a `telemetry_poller` periodic measurement (wired in
   `LoopctlWeb.Telemetry.periodic_measurements/0`, the SAME shared process that
@@ -761,12 +800,24 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   #{@default_oban_metrics_poll_timeout_ms}ms) so a slow poll can never itself
   saturate the pool (AC-34.1.3).
 
+  A `GROUP BY count(*)` can only ever return rows with count >= 1 — it never
+  returns a row for a `{state, queue}` pair with zero jobs. So the returned rows
+  are folded into a lookup map, then EVERY pair in `oban_states/0` x
+  `oban_queues/0` is emitted, substituting `count: 0` for any pair absent from
+  that lookup. Without this, a `last_value/2` gauge (which has no expiry — it
+  just overwrites its ETS entry, `TelemetryMetricsPrometheus.Core.LastValue`)
+  would retain a drained pair's last non-zero reading forever, indistinguishable
+  from a genuinely-stuck backlog.
+
   Defensive: narrowly rescues ONLY the known DB-fault classes (`Postgrex.Error`,
   `DBConnection.ConnectionError`, `DBConnection.OwnershipError` — the same set
   `refresh_tenant_label_gate/0` rescues), logs a warning, and returns `:ok` without
   emitting any telemetry — `telemetry_poller` does NOT isolate measurements from
   each other, so an uncaught raise here would crash the shared poller (TC-34.1.3).
-  Always returns `:ok`.
+  On a FAILED poll (as opposed to a successful poll that finds zero rows), no
+  zero-fill happens either — the gauge intentionally keeps its last-recorded
+  value until the next successful poll, since a failed query has no fresher
+  truth to report. Always returns `:ok`.
   """
   @spec poll_oban_queue_state() :: :ok
   def poll_oban_queue_state do
@@ -782,12 +833,18 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
         rows
       end)
 
-    Enum.each(rows, fn [state, queue, count] ->
+    counts = Map.new(rows, fn [state, queue, count] -> {{state, queue}, count} end)
+
+    for state <- oban_states(), queue <- oban_queues() do
+      state_str = Atom.to_string(state)
+      queue_str = Atom.to_string(queue)
+      count = Map.get(counts, {state_str, queue_str}, 0)
+
       :telemetry.execute([:loopctl, :oban, :jobs, :count], %{count: count}, %{
-        state: state,
-        queue: queue
+        state: state_str,
+        queue: queue_str
       })
-    end)
+    end
 
     :ok
   rescue

--- a/lib/loopctl_web/telemetry.ex
+++ b/lib/loopctl_web/telemetry.ex
@@ -148,11 +148,19 @@ defmodule LoopctlWeb.Telemetry do
   # where the metric DEFINITIONS and poller FUNCTIONS were each tested in
   # isolation but nothing asserted either was actually wired into the 10s tick.
   def periodic_measurements do
-    # NOTE: `telemetry_poller` runs every measurement in its OWN process and does NOT
-    # isolate them — an uncaught raise in any measurement crashes the shared poller (and
-    # with it the gate refresh). So EVERY measurement added here MUST be self-rescuing.
-    # `refresh_tenant_label_gate/0` guards its only raising op (the DB count) with
-    # try/rescue (fail-soft to a bounded gate); keep that invariant for future additions.
+    # NOTE: `telemetry_poller` runs every measurement through its OWN try/catch
+    # (`make_measurements_and_filter_misbehaving/1`, verified against the vendored
+    # telemetry_poller 1.3.0 source) — an uncaught raise does NOT crash the shared
+    # poller or the other measurements (including the gate refresh). What it DOES do
+    # is worse for the raising measurement specifically: telemetry_poller logs the
+    # raise once and PERMANENTLY DROPS that MFA from the poll rotation until the next
+    # app restart — the gauge/effect goes dark forever, silently. So EVERY measurement
+    # added here MUST still be self-rescuing (a catch-all rescue, not just the DB-fault
+    # classes) so it is never itself the one that goes dark. `refresh_tenant_label_gate/0`
+    # guards its only raising op (the DB count) with try/rescue (fail-soft to a bounded
+    # gate); the two Oban pollers below use a catch-all rescue (US-34.1, review finding)
+    # plus a poll-failure counter so a stale gauge is detectable. Keep that invariant
+    # for future additions.
     [
       # US-27.15: refresh the metrics tenant-label cardinality gate (Tenants.count()
       # <= cap), caching the boolean in :persistent_term so the per-emit tag_values
@@ -160,8 +168,9 @@ defmodule LoopctlWeb.Telemetry do
       {ScaleMetrics, :refresh_tenant_label_gate, []},
 
       # US-34.1 (AC-34.1.1/.3): per-{state, queue} poll of the GLOBAL `oban_jobs`
-      # table, feeding the `loopctl.oban.jobs.count` gauge. Self-rescuing (narrow
-      # DB-fault classes only) per the note above.
+      # table, feeding the `loopctl.oban.jobs.count` gauge. Self-rescuing
+      # (catch-all rescue, per the note above) and reports failures via the
+      # `loopctl.oban.poll.error.count` counter.
       {ScaleMetrics, :poll_oban_queue_state, []},
 
       # US-34.1 (AC-34.1.2/.3): the `:executing`-older-than-N-min orphan poll,

--- a/lib/loopctl_web/telemetry.ex
+++ b/lib/loopctl_web/telemetry.ex
@@ -153,7 +153,17 @@ defmodule LoopctlWeb.Telemetry do
       # US-27.15: refresh the metrics tenant-label cardinality gate (Tenants.count()
       # <= cap), caching the boolean in :persistent_term so the per-emit tag_values
       # path needs no DB hit. This is the ONLY DB read in the gating mechanism.
-      {ScaleMetrics, :refresh_tenant_label_gate, []}
+      {ScaleMetrics, :refresh_tenant_label_gate, []},
+
+      # US-34.1 (AC-34.1.1/.3): per-{state, queue} poll of the GLOBAL `oban_jobs`
+      # table, feeding the `loopctl.oban.jobs.count` gauge. Self-rescuing (narrow
+      # DB-fault classes only) per the note above.
+      {ScaleMetrics, :poll_oban_queue_state, []},
+
+      # US-34.1 (AC-34.1.2/.3): the `:executing`-older-than-N-min orphan poll,
+      # feeding the `loopctl.oban.jobs.executing_orphan.count` gauge. Same
+      # self-rescuing contract.
+      {ScaleMetrics, :poll_oban_executing_orphans, []}
     ]
   end
 end

--- a/lib/loopctl_web/telemetry.ex
+++ b/lib/loopctl_web/telemetry.ex
@@ -143,7 +143,11 @@ defmodule LoopctlWeb.Telemetry do
     ]
   end
 
-  defp periodic_measurements do
+  # Public (mirrors `metrics/0` above) so the wiring itself is testable — a test
+  # asserts the two US-34.1 Oban poller MFAs are present here, closing the gap
+  # where the metric DEFINITIONS and poller FUNCTIONS were each tested in
+  # isolation but nothing asserted either was actually wired into the 10s tick.
+  def periodic_measurements do
     # NOTE: `telemetry_poller` runs every measurement in its OWN process and does NOT
     # isolate them — an uncaught raise in any measurement crashes the shared poller (and
     # with it the gate refresh). So EVERY measurement added here MUST be self-rescuing.

--- a/test/loopctl/oban_plugins_config_test.exs
+++ b/test/loopctl/oban_plugins_config_test.exs
@@ -1,0 +1,45 @@
+defmodule Loopctl.ObanPluginsConfigTest do
+  @moduledoc """
+  US-34.1 (AC-34.1.4, TC-34.1.4): `Oban.Plugins.Reindexer` is configured, and the
+  pre-existing Lifeline/Pruner plugins are unchanged.
+
+  Pure config read — no DB, no running Oban needed (`config/test.exs` sets
+  `testing: :inline`, under which plugins are not started, but the KEYWORD LIST
+  configured in `config/config.exs` still merges into `Application.get_env/2`).
+  """
+  use ExUnit.Case, async: true
+
+  describe "Oban plugins config" do
+    setup do
+      plugins = Application.get_env(:loopctl, Oban)[:plugins]
+      %{plugins: plugins}
+    end
+
+    test "Oban.Plugins.Reindexer is configured (AC-34.1.4)", %{plugins: plugins} do
+      assert Enum.any?(plugins, &reindexer?/1),
+             "expected Oban.Plugins.Reindexer in the plugins list, got: #{inspect(plugins)}"
+    end
+
+    test "Lifeline is unchanged (rescue_after: 30 min)", %{plugins: plugins} do
+      assert {Oban.Plugins.Lifeline, opts} =
+               Enum.find(plugins, &match?({Oban.Plugins.Lifeline, _}, &1))
+
+      assert opts[:rescue_after] == :timer.minutes(30)
+    end
+
+    test "Pruner is unchanged (max_age: 7 days)", %{plugins: plugins} do
+      assert {Oban.Plugins.Pruner, opts} =
+               Enum.find(plugins, &match?({Oban.Plugins.Pruner, _}, &1))
+
+      assert opts[:max_age] == 60 * 60 * 24 * 7
+    end
+
+    test "Cron is still present (unchanged by this story)", %{plugins: plugins} do
+      assert Enum.any?(plugins, &match?({Oban.Plugins.Cron, _}, &1))
+    end
+  end
+
+  defp reindexer?(Oban.Plugins.Reindexer), do: true
+  defp reindexer?({Oban.Plugins.Reindexer, _opts}), do: true
+  defp reindexer?(_other), do: false
+end

--- a/test/loopctl/telemetry/oban_metrics_poller_test.exs
+++ b/test/loopctl/telemetry/oban_metrics_poller_test.exs
@@ -4,8 +4,14 @@ defmodule Loopctl.Telemetry.ObanMetricsPollerTest do
   (`Loopctl.Telemetry.ScaleMetrics.poll_oban_queue_state/0` and
   `poll_oban_executing_orphans/0`):
 
-    * TC-34.1.1 — rows in a couple of states (`available`, `completed`) → the
-      per-{state, queue} telemetry measurement reflects the actual counts.
+    * TC-34.1.1 — rows in a couple of NON-TERMINAL states (`available`,
+      `retryable`) → the per-{state, queue} telemetry measurement reflects the
+      actual counts.
+    * TC-34.1.1a — terminal states (`completed`/`discarded`/`cancelled`) are
+      EXCLUDED from the poll/zero-fill matrix entirely (review finding: a bare
+      `GROUP BY state, queue` over all 8 states forces a full Seq Scan once the
+      terminal partitions dominate under the pruner's 7-day retention) — a
+      `completed` row never produces ANY measurement, not even a `count: 0`.
     * TC-34.1.1b — zero-fill: a `{state, queue}` pair with NO rows still emits an
       explicit `count: 0` measurement every poll (review finding fix — a
       `last_value/2` gauge has no expiry, so without an explicit zero-fill a
@@ -19,24 +25,30 @@ defmodule Loopctl.Telemetry.ObanMetricsPollerTest do
     * TC-34.1.2 — one stale `executing` row (attempted_at older than the orphan
       threshold) + one recent `executing` row → the orphan gauge counts ONLY the
       stale one.
-    * TC-34.1.3 — the poll query raising is logged and swallowed; no telemetry is
-      emitted on failure (no metric corruption).
+    * TC-34.1.3 — the poll query raising is logged and swallowed (via a
+      CATCH-ALL rescue — review finding, broadened from a narrow DB-fault-only
+      rescue since `telemetry_poller` permanently drops a raising measurement
+      from its rotation rather than crashing); no gauge measurement is emitted on
+      failure (no metric corruption), and the poll-failure counter
+      (`loopctl.oban.poll.error.count`) fires instead.
 
-  `oban_jobs` is a GLOBAL table (no `tenant_id` column) and both pollers touch it
-  directly via `Loopctl.AdminRepo` raw SQL (the `Loopctl.IndexHealth` precedent —
-  `Loopctl.HeavyRead` structurally rejects a query with no tenant predicate).
-  Rows are inserted through `AdminRepo` too, on the SAME sandboxed connection/
-  transaction the pollers query — the standard cross-repo-visibility fix already
-  used by `knowledge_ingestion_controller_test.exs`'s tenant-isolation tests.
+  `oban_jobs` is a GLOBAL table (no `tenant_id` column). Both pollers now query
+  it via `Loopctl.Repo` (review finding — moved off the tiny 3-connection
+  `Loopctl.AdminRepo` pool, since `oban_jobs` has no RLS policy so the RLS-role
+  `Repo` reads it exactly as well). Rows are inserted through `Loopctl.Repo` too,
+  on the SAME sandboxed connection/transaction the pollers query — the standard
+  cross-repo-visibility fix already used by
+  `knowledge_ingestion_controller_test.exs`'s tenant-isolation tests (write and
+  read must share a Repo module to be visible to each other under Sandbox).
 
   Tests use a REAL configured queue name (from `ScaleMetrics.oban_queues/0`)
   rather than an ad-hoc `"test_queue_N"` string: `poll_oban_queue_state/0` now
-  zero-fills and emits ONLY the fixed `oban_states/0` x `oban_queues/0` matrix,
-  so an unconfigured queue name would never produce ANY measurement (by design —
-  AC-34.1.5). Sandbox isolation (each async test owns its own transaction/
-  connection) is what actually prevents cross-test interference, not the queue
-  name — the old per-test-unique name was defensive belt-and-suspenders, not a
-  correctness requirement.
+  zero-fills and emits ONLY the fixed `oban_active_states/0` x `oban_queues/0`
+  matrix, so an unconfigured queue name would never produce ANY measurement (by
+  design — AC-34.1.5). Sandbox isolation (each async test owns its own
+  transaction/connection) is what actually prevents cross-test interference, not
+  the queue name — the old per-test-unique name was defensive
+  belt-and-suspenders, not a correctness requirement.
 
   `async: false`: the executing_orphan gauge is UNTAGGED (a single global telemetry
   channel + Prometheus series), and `:telemetry.attach/4` registers by EVENT NAME
@@ -46,7 +58,6 @@ defmodule Loopctl.Telemetry.ObanMetricsPollerTest do
   use Loopctl.DataCase, async: false
 
   alias Ecto.Adapters.SQL.Sandbox
-  alias Loopctl.AdminRepo
   alias Loopctl.Telemetry.ScaleMetrics
 
   describe "poll_oban_queue_state/0 (AC-34.1.1, TC-34.1.1)" do
@@ -68,12 +79,39 @@ defmodule Loopctl.Telemetry.ObanMetricsPollerTest do
 
       insert_job(state: "available", queue: queue)
       insert_job(state: "available", queue: queue)
-      insert_job(state: "completed", queue: queue)
+      insert_job(state: "retryable", queue: queue)
 
       assert ScaleMetrics.poll_oban_queue_state() == :ok
 
       assert_receive {:oban_queue_state, %{state: "available", queue: ^queue}, %{count: 2}}, 1000
-      assert_receive {:oban_queue_state, %{state: "completed", queue: ^queue}, %{count: 1}}, 1000
+      assert_receive {:oban_queue_state, %{state: "retryable", queue: ^queue}, %{count: 1}}, 1000
+    end
+
+    test "terminal states (completed/discarded/cancelled) are excluded entirely — no measurement, not even zero-fill (TC-34.1.1a, review finding)" do
+      test_pid = self()
+      handler_id = "test-oban-terminal-excluded-#{System.unique_integer([:positive])}"
+      queue = configured_queue()
+
+      :telemetry.attach(
+        handler_id,
+        [:loopctl, :oban, :jobs, :count],
+        fn _event, measurements, metadata, _config ->
+          send(test_pid, {:oban_queue_state, metadata, measurements})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      insert_job(state: "completed", queue: queue)
+      insert_job(state: "discarded", queue: queue)
+      insert_job(state: "cancelled", queue: queue)
+
+      assert ScaleMetrics.poll_oban_queue_state() == :ok
+
+      refute_receive {:oban_queue_state, %{state: "completed"}, _measurements}, 300
+      refute_receive {:oban_queue_state, %{state: "discarded"}, _measurements}, 300
+      refute_receive {:oban_queue_state, %{state: "cancelled"}, _measurements}, 300
     end
 
     test "zero-fills: a {state, queue} pair with no rows still emits count: 0 (TC-34.1.1b)" do
@@ -93,9 +131,10 @@ defmodule Loopctl.Telemetry.ObanMetricsPollerTest do
       on_exit(fn -> :telemetry.detach(handler_id) end)
 
       # Only ONE row exists at all: {available, queue_a}. Every other pair in the
-      # matrix — including {available, queue_b} and {completed, queue_a} — has NO
-      # backing row, so the GROUP BY never returns them, yet the poller must still
-      # emit an explicit count: 0 for each (the fix under test).
+      # active-state matrix — including {available, queue_b} and
+      # {scheduled, queue_a} — has NO backing row, so the GROUP BY never returns
+      # them, yet the poller must still emit an explicit count: 0 for each (the
+      # fix under test).
       insert_job(state: "available", queue: queue_a)
 
       assert ScaleMetrics.poll_oban_queue_state() == :ok
@@ -106,7 +145,7 @@ defmodule Loopctl.Telemetry.ObanMetricsPollerTest do
       assert_receive {:oban_queue_state, %{state: "available", queue: ^queue_b}, %{count: 0}},
                      1000
 
-      assert_receive {:oban_queue_state, %{state: "completed", queue: ^queue_a}, %{count: 0}},
+      assert_receive {:oban_queue_state, %{state: "scheduled", queue: ^queue_a}, %{count: 0}},
                      1000
     end
 
@@ -133,7 +172,7 @@ defmodule Loopctl.Telemetry.ObanMetricsPollerTest do
       assert_receive {:oban_queue_state, %{state: "available", queue: ^queue}, %{count: 1}}, 1000
 
       # Drain the queue entirely (simulates Oban completing/removing the job).
-      AdminRepo.delete_all(from(j in Oban.Job, where: j.id == ^job_id))
+      Repo.delete_all(from(j in Oban.Job, where: j.id == ^job_id))
 
       assert ScaleMetrics.poll_oban_queue_state() == :ok
 
@@ -217,7 +256,7 @@ defmodule Loopctl.Telemetry.ObanMetricsPollerTest do
   end
 
   describe "poller defensiveness (AC-34.1.3, TC-34.1.3)" do
-    # DataCase's setup checks AdminRepo out in :shared mode (this whole file is
+    # DataCase's setup checks Repo out in :shared mode (this whole file is
     # async: false), under which EVERY process — including this test process for
     # any FURTHER call — routes to the same shared connection regardless of
     # per-process ownership, so a plain `checkin` doesn't disconnect anything.
@@ -225,11 +264,11 @@ defmodule Loopctl.Telemetry.ObanMetricsPollerTest do
     # without touching the dedicated owner process DataCase started, so THIS
     # test process (which never explicitly checked out its own connection — it
     # was only riding the shared one) has no ownership at all afterward: its
-    # very next AdminRepo call raises a genuine `DBConnection.OwnershipError` — a
+    # very next Repo call raises a genuine `DBConnection.OwnershipError` — a
     # REAL DB fault, not a stub. Self-contained: the NEXT test's `setup` calls
     # `start_owner!(shared: true)` again, which re-establishes shared mode fresh.
     setup do
-      Sandbox.mode(Loopctl.AdminRepo, :manual)
+      Sandbox.mode(Loopctl.Repo, :manual)
       :ok
     end
 
@@ -276,7 +315,56 @@ defmodule Loopctl.Telemetry.ObanMetricsPollerTest do
 
       refute_receive {:unexpected_emit, _event, _measurements, _metadata}, 200
     end
+
+    test "the poll-failure counter fires from both pollers on a DB fault (review finding)" do
+      test_pid = self()
+      handler_id = "test-oban-poll-error-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler_id,
+        [:loopctl, :oban, :poll, :error],
+        fn _event, measurements, metadata, _config ->
+          send(test_pid, {:oban_poll_error, metadata, measurements})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        ScaleMetrics.poll_oban_queue_state()
+      end)
+
+      assert_receive {:oban_poll_error, %{poller: :queue_state, exception: exception},
+                      %{count: 1}},
+                     500
+
+      assert exception.__struct__ in [DBConnection.OwnershipError, Postgrex.Error]
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        ScaleMetrics.poll_oban_executing_orphans()
+      end)
+
+      assert_receive {:oban_poll_error, %{poller: :executing_orphans, exception: exception2},
+                      %{count: 1}},
+                     500
+
+      assert exception2.__struct__ in [DBConnection.OwnershipError, Postgrex.Error]
+    end
   end
+
+  # The catch-all `rescue e ->` clause (review finding — broadened from a narrow
+  # DB-fault-only rescue) has NO type restriction, so the SAME code path proven
+  # above via `DBConnection.OwnershipError` (a real DB fault, simulated via
+  # Sandbox mode rather than any `Application.put_env` config mutation) also
+  # covers a non-DB exception class (e.g. an `ArgumentError` from an invalid
+  # config tunable, or the `FunctionClauseError` `oban_queues/0` itself now
+  # guards against). The classification of NON-DB exceptions into the bounded
+  # `error_class` tag (`"config_error"`/`"other"`) is unit-tested directly via
+  # `oban_poll_error_tags/1` in `scale_metrics_test.exs`, and the config
+  # validators themselves (`validate_positive_poll_timeout!/1`,
+  # `queues_from_config/1`) are exposed as pure functions there too — so neither
+  # needs an `Application.put_env` integration test here.
 
   defp insert_job(attrs) do
     attrs
@@ -284,6 +372,6 @@ defmodule Loopctl.Telemetry.ObanMetricsPollerTest do
     |> Map.put_new(:worker, "Loopctl.Workers.IdempotencyCleanupWorker")
     |> Map.put_new(:args, %{})
     |> then(&struct(Oban.Job, &1))
-    |> AdminRepo.insert!()
+    |> Repo.insert!()
   end
 end

--- a/test/loopctl/telemetry/oban_metrics_poller_test.exs
+++ b/test/loopctl/telemetry/oban_metrics_poller_test.exs
@@ -6,6 +6,16 @@ defmodule Loopctl.Telemetry.ObanMetricsPollerTest do
 
     * TC-34.1.1 — rows in a couple of states (`available`, `completed`) → the
       per-{state, queue} telemetry measurement reflects the actual counts.
+    * TC-34.1.1b — zero-fill: a `{state, queue}` pair with NO rows still emits an
+      explicit `count: 0` measurement every poll (review finding fix — a
+      `last_value/2` gauge has no expiry, so without an explicit zero-fill a
+      drained pair would read stale-high forever).
+    * TC-34.1.1c — drain-to-zero: a pair that HAD jobs, then drains to none,
+      reads `0` on the very next poll rather than retaining the prior non-zero
+      reading.
+    * TC-34.1.1d — the `:queue` label is structurally bounded to
+      `ScaleMetrics.oban_queues/0` (the configured set) — a job in an
+      unconfigured/ad-hoc queue name never produces a Prometheus series.
     * TC-34.1.2 — one stale `executing` row (attempted_at older than the orphan
       threshold) + one recent `executing` row → the orphan gauge counts ONLY the
       stale one.
@@ -18,6 +28,15 @@ defmodule Loopctl.Telemetry.ObanMetricsPollerTest do
   Rows are inserted through `AdminRepo` too, on the SAME sandboxed connection/
   transaction the pollers query — the standard cross-repo-visibility fix already
   used by `knowledge_ingestion_controller_test.exs`'s tenant-isolation tests.
+
+  Tests use a REAL configured queue name (from `ScaleMetrics.oban_queues/0`)
+  rather than an ad-hoc `"test_queue_N"` string: `poll_oban_queue_state/0` now
+  zero-fills and emits ONLY the fixed `oban_states/0` x `oban_queues/0` matrix,
+  so an unconfigured queue name would never produce ANY measurement (by design —
+  AC-34.1.5). Sandbox isolation (each async test owns its own transaction/
+  connection) is what actually prevents cross-test interference, not the queue
+  name — the old per-test-unique name was defensive belt-and-suspenders, not a
+  correctness requirement.
 
   `async: false`: the executing_orphan gauge is UNTAGGED (a single global telemetry
   channel + Prometheus series), and `:telemetry.attach/4` registers by EVENT NAME
@@ -34,10 +53,7 @@ defmodule Loopctl.Telemetry.ObanMetricsPollerTest do
     test "emits a telemetry measurement per {state, queue} reflecting actual oban_jobs counts" do
       test_pid = self()
       handler_id = "test-oban-queue-state-#{System.unique_integer([:positive])}"
-      # A per-test unique queue name disambiguates this test's rows/measurements
-      # from any other test's concurrent poll (belt-and-suspenders on top of
-      # async: false above).
-      queue = "test_queue_#{System.unique_integer([:positive])}"
+      queue = configured_queue()
 
       :telemetry.attach(
         handler_id,
@@ -59,6 +75,106 @@ defmodule Loopctl.Telemetry.ObanMetricsPollerTest do
       assert_receive {:oban_queue_state, %{state: "available", queue: ^queue}, %{count: 2}}, 1000
       assert_receive {:oban_queue_state, %{state: "completed", queue: ^queue}, %{count: 1}}, 1000
     end
+
+    test "zero-fills: a {state, queue} pair with no rows still emits count: 0 (TC-34.1.1b)" do
+      test_pid = self()
+      handler_id = "test-oban-zero-fill-#{System.unique_integer([:positive])}"
+      [queue_a, queue_b | _] = ScaleMetrics.oban_queues() |> Enum.map(&Atom.to_string/1)
+
+      :telemetry.attach(
+        handler_id,
+        [:loopctl, :oban, :jobs, :count],
+        fn _event, measurements, metadata, _config ->
+          send(test_pid, {:oban_queue_state, metadata, measurements})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      # Only ONE row exists at all: {available, queue_a}. Every other pair in the
+      # matrix — including {available, queue_b} and {completed, queue_a} — has NO
+      # backing row, so the GROUP BY never returns them, yet the poller must still
+      # emit an explicit count: 0 for each (the fix under test).
+      insert_job(state: "available", queue: queue_a)
+
+      assert ScaleMetrics.poll_oban_queue_state() == :ok
+
+      assert_receive {:oban_queue_state, %{state: "available", queue: ^queue_a}, %{count: 1}},
+                     1000
+
+      assert_receive {:oban_queue_state, %{state: "available", queue: ^queue_b}, %{count: 0}},
+                     1000
+
+      assert_receive {:oban_queue_state, %{state: "completed", queue: ^queue_a}, %{count: 0}},
+                     1000
+    end
+
+    test "drain-to-zero: a pair that held jobs reads 0 on the next poll once drained (TC-34.1.1c)" do
+      test_pid = self()
+      handler_id = "test-oban-drain-#{System.unique_integer([:positive])}"
+      queue = configured_queue()
+
+      :telemetry.attach(
+        handler_id,
+        [:loopctl, :oban, :jobs, :count],
+        fn _event, measurements, metadata, _config ->
+          send(test_pid, {:oban_queue_state, metadata, measurements})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      %{id: job_id} = insert_job(state: "available", queue: queue)
+
+      assert ScaleMetrics.poll_oban_queue_state() == :ok
+
+      assert_receive {:oban_queue_state, %{state: "available", queue: ^queue}, %{count: 1}}, 1000
+
+      # Drain the queue entirely (simulates Oban completing/removing the job).
+      AdminRepo.delete_all(from(j in Oban.Job, where: j.id == ^job_id))
+
+      assert ScaleMetrics.poll_oban_queue_state() == :ok
+
+      # Without the zero-fill fix, `last_value/2` would retain the stale count: 1
+      # forever since no row (not even a zero row) is ever emitted for a drained
+      # pair by a bare GROUP BY count(*).
+      assert_receive {:oban_queue_state, %{state: "available", queue: ^queue}, %{count: 0}}, 1000
+    end
+
+    test "the :queue label is bounded to the configured set — an ad-hoc queue name never emits (TC-34.1.1d)" do
+      test_pid = self()
+      handler_id = "test-oban-unconfigured-queue-#{System.unique_integer([:positive])}"
+      ad_hoc_queue = "totally_unconfigured_queue_#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler_id,
+        [:loopctl, :oban, :jobs, :count],
+        fn _event, measurements, metadata, _config ->
+          send(test_pid, {:oban_queue_state, metadata, measurements})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      insert_job(state: "available", queue: ad_hoc_queue)
+
+      assert ScaleMetrics.poll_oban_queue_state() == :ok
+
+      refute_receive {:oban_queue_state, %{queue: ^ad_hoc_queue}, _measurements}, 500
+    end
+  end
+
+  # A real, currently-configured Oban queue name (from `ScaleMetrics.oban_queues/0`)
+  # — asserted to actually be a member so a future queue-list change fails this
+  # helper loudly instead of silently testing a stale/removed queue.
+  defp configured_queue do
+    queues = ScaleMetrics.oban_queues() |> Enum.map(&Atom.to_string/1)
+    queue = "analytics"
+    assert queue in queues
+    queue
   end
 
   describe "poll_oban_executing_orphans/0 (AC-34.1.2, TC-34.1.2)" do

--- a/test/loopctl/telemetry/oban_metrics_poller_test.exs
+++ b/test/loopctl/telemetry/oban_metrics_poller_test.exs
@@ -1,0 +1,173 @@
+defmodule Loopctl.Telemetry.ObanMetricsPollerTest do
+  @moduledoc """
+  US-34.1 integration tests for the two Oban metrics pollers
+  (`Loopctl.Telemetry.ScaleMetrics.poll_oban_queue_state/0` and
+  `poll_oban_executing_orphans/0`):
+
+    * TC-34.1.1 — rows in a couple of states (`available`, `completed`) → the
+      per-{state, queue} telemetry measurement reflects the actual counts.
+    * TC-34.1.2 — one stale `executing` row (attempted_at older than the orphan
+      threshold) + one recent `executing` row → the orphan gauge counts ONLY the
+      stale one.
+    * TC-34.1.3 — the poll query raising is logged and swallowed; no telemetry is
+      emitted on failure (no metric corruption).
+
+  `oban_jobs` is a GLOBAL table (no `tenant_id` column) and both pollers touch it
+  directly via `Loopctl.AdminRepo` raw SQL (the `Loopctl.IndexHealth` precedent —
+  `Loopctl.HeavyRead` structurally rejects a query with no tenant predicate).
+  Rows are inserted through `AdminRepo` too, on the SAME sandboxed connection/
+  transaction the pollers query — the standard cross-repo-visibility fix already
+  used by `knowledge_ingestion_controller_test.exs`'s tenant-isolation tests.
+
+  `async: false`: the executing_orphan gauge is UNTAGGED (a single global telemetry
+  channel + Prometheus series), and `:telemetry.attach/4` registers by EVENT NAME
+  (not by calling process) — running serially avoids a concurrently-running test's
+  poll invocation firing through this test's attached handler.
+  """
+  use Loopctl.DataCase, async: false
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Loopctl.AdminRepo
+  alias Loopctl.Telemetry.ScaleMetrics
+
+  describe "poll_oban_queue_state/0 (AC-34.1.1, TC-34.1.1)" do
+    test "emits a telemetry measurement per {state, queue} reflecting actual oban_jobs counts" do
+      test_pid = self()
+      handler_id = "test-oban-queue-state-#{System.unique_integer([:positive])}"
+      # A per-test unique queue name disambiguates this test's rows/measurements
+      # from any other test's concurrent poll (belt-and-suspenders on top of
+      # async: false above).
+      queue = "test_queue_#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler_id,
+        [:loopctl, :oban, :jobs, :count],
+        fn _event, measurements, metadata, _config ->
+          send(test_pid, {:oban_queue_state, metadata, measurements})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      insert_job(state: "available", queue: queue)
+      insert_job(state: "available", queue: queue)
+      insert_job(state: "completed", queue: queue)
+
+      assert ScaleMetrics.poll_oban_queue_state() == :ok
+
+      assert_receive {:oban_queue_state, %{state: "available", queue: ^queue}, %{count: 2}}, 1000
+      assert_receive {:oban_queue_state, %{state: "completed", queue: ^queue}, %{count: 1}}, 1000
+    end
+  end
+
+  describe "poll_oban_executing_orphans/0 (AC-34.1.2, TC-34.1.2)" do
+    test "counts only the executing job whose attempted_at exceeds the threshold" do
+      threshold_minutes = ScaleMetrics.oban_metrics_orphan_threshold_minutes()
+      now = DateTime.utc_now()
+
+      # Stale: attempted well past the threshold — the orphan.
+      insert_job(
+        state: "executing",
+        queue: "default",
+        attempted_at: DateTime.add(now, -(threshold_minutes + 5) * 60, :second)
+      )
+
+      # Recent: attempted a second ago — still legitimately mid-flight, NOT an orphan.
+      insert_job(
+        state: "executing",
+        queue: "default",
+        attempted_at: DateTime.add(now, -1, :second)
+      )
+
+      test_pid = self()
+      handler_id = "test-oban-orphan-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler_id,
+        [:loopctl, :oban, :jobs, :executing_orphan, :count],
+        fn _event, measurements, _metadata, _config ->
+          send(test_pid, {:oban_orphan, measurements})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      assert ScaleMetrics.poll_oban_executing_orphans() == :ok
+
+      assert_receive {:oban_orphan, %{count: 1}}, 1000
+    end
+  end
+
+  describe "poller defensiveness (AC-34.1.3, TC-34.1.3)" do
+    # DataCase's setup checks AdminRepo out in :shared mode (this whole file is
+    # async: false), under which EVERY process — including this test process for
+    # any FURTHER call — routes to the same shared connection regardless of
+    # per-process ownership, so a plain `checkin` doesn't disconnect anything.
+    # Switching the pool back to `:manual` here removes that shared mapping
+    # without touching the dedicated owner process DataCase started, so THIS
+    # test process (which never explicitly checked out its own connection — it
+    # was only riding the shared one) has no ownership at all afterward: its
+    # very next AdminRepo call raises a genuine `DBConnection.OwnershipError` — a
+    # REAL DB fault, not a stub. Self-contained: the NEXT test's `setup` calls
+    # `start_owner!(shared: true)` again, which re-establishes shared mode fresh.
+    setup do
+      Sandbox.mode(Loopctl.AdminRepo, :manual)
+      :ok
+    end
+
+    test "poll_oban_queue_state/0 logs and returns :ok without raising on a DB fault" do
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert ScaleMetrics.poll_oban_queue_state() == :ok
+        end)
+
+      assert log =~ "Oban queue/state poll failed"
+    end
+
+    test "poll_oban_executing_orphans/0 logs and returns :ok without raising on a DB fault" do
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert ScaleMetrics.poll_oban_executing_orphans() == :ok
+        end)
+
+      assert log =~ "Oban executing-orphan poll failed"
+    end
+
+    test "no metric corruption: neither gauge emits when the poll fails" do
+      test_pid = self()
+      handler_id = "test-oban-no-corruption-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach_many(
+        handler_id,
+        [
+          [:loopctl, :oban, :jobs, :count],
+          [:loopctl, :oban, :jobs, :executing_orphan, :count]
+        ],
+        fn event, measurements, metadata, _config ->
+          send(test_pid, {:unexpected_emit, event, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        ScaleMetrics.poll_oban_queue_state()
+        ScaleMetrics.poll_oban_executing_orphans()
+      end)
+
+      refute_receive {:unexpected_emit, _event, _measurements, _metadata}, 200
+    end
+  end
+
+  defp insert_job(attrs) do
+    attrs
+    |> Enum.into(%{})
+    |> Map.put_new(:worker, "Loopctl.Workers.IdempotencyCleanupWorker")
+    |> Map.put_new(:args, %{})
+    |> then(&struct(Oban.Job, &1))
+    |> AdminRepo.insert!()
+  end
+end

--- a/test/loopctl/telemetry/scale_metrics_test.exs
+++ b/test/loopctl/telemetry/scale_metrics_test.exs
@@ -62,7 +62,8 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
     "loopctl.memory_promotion.quota_exceeded.count",
     "loopctl.memory_promotion.budget_exceeded.count",
     "loopctl.oban.jobs.count",
-    "loopctl.oban.jobs.executing_orphan.count"
+    "loopctl.oban.jobs.executing_orphan.count",
+    "loopctl.oban.poll.error.count"
   ]
 
   # The ONLY labels any scale metric may ever carry (AC-27.15.3). Anything outside this
@@ -77,7 +78,9 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
   # provider), `:source` (embedding.skipped_no_key — "article"/"memory"), `:index`/
   # `:purpose`/`:state` (index_health.invalid — three bounded fixed sets), `:op`
   # (secrets.orphan_cleanup_failed — normalized `:delete`/`:restore`/`:unknown`), and
-  # `:stage` (memory_promotion.failed — bounded `:compile`/`:persist`/`:enqueue`).
+  # `:stage` (memory_promotion.failed — bounded `:compile`/`:persist`/`:enqueue`). US-34.1
+  # adds `:poller` (oban.poll.error.count — bounded `:queue_state`/`:executing_orphans`)
+  # and `:error_class` (oban.poll.error.count — CLASSIFIED, never a raw exception).
   @allowed_tags MapSet.new([
                   :endpoint,
                   :mapped_code,
@@ -95,7 +98,9 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
                   :op,
                   :stage,
                   :state,
-                  :queue
+                  :queue,
+                  :poller,
+                  :error_class
                 ])
 
   defp scale_metrics, do: ScaleMetrics.scale_metrics()
@@ -833,9 +838,35 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
       assert ScaleMetrics.oban_metrics_orphan_threshold_minutes() == 45
     end
 
+    test "validate_positive_poll_timeout!/1 raises ArgumentError on a non-positive-integer value (review finding — unit-tested directly, never mutating global config)" do
+      for bad <- ["2000", -1, 0, nil] do
+        assert_raise ArgumentError,
+                     ~r/oban_metrics_poll_statement_timeout_ms/,
+                     fn -> ScaleMetrics.validate_positive_poll_timeout!(bad) end
+      end
+    end
+
+    test "validate_positive_poll_timeout!/1 passes through a positive integer unchanged" do
+      assert ScaleMetrics.validate_positive_poll_timeout!(5_000) == 5_000
+    end
+
     test "oban_states/0 returns Oban.Job.states/0's full 8-value enum (review finding: was documented as 7)" do
       assert ScaleMetrics.oban_states() == Oban.Job.states()
       assert length(ScaleMetrics.oban_states()) == 8
+    end
+
+    test "oban_active_states/0 excludes only the terminal completed/discarded/cancelled states (review finding)" do
+      active = ScaleMetrics.oban_active_states()
+
+      assert length(active) == 5
+      assert :completed not in active
+      assert :discarded not in active
+      assert :cancelled not in active
+      assert :available in active
+      assert :scheduled in active
+      assert :executing in active
+      assert :retryable in active
+      assert :suspended in active
     end
 
     test "oban_queues/0 returns the configured queue names, resolved at call time" do
@@ -849,11 +880,67 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
       assert length(ScaleMetrics.oban_queues()) == 9
     end
 
+    test "queues_from_config/1 resolves to [] instead of raising on the documented `queues: false` shape (review finding — unit-tested directly, never mutating global config)" do
+      assert ScaleMetrics.queues_from_config(false) == []
+      assert ScaleMetrics.queues_from_config(nil) == []
+    end
+
+    test "queues_from_config/1 passes a valid queues keyword through to its keys" do
+      assert ScaleMetrics.queues_from_config(default: 10, webhooks: 5) == [:default, :webhooks]
+    end
+
+    test "oban_poll_error_tags/1 CLASSIFIES the raw exception into a small bounded set (review finding — never the raw exception message/struct)" do
+      assert ScaleMetrics.oban_poll_error_tags(%{
+               poller: :queue_state,
+               exception: %Postgrex.Error{}
+             }) == %{poller: :queue_state, error_class: "db_error"}
+
+      assert ScaleMetrics.oban_poll_error_tags(%{
+               poller: :queue_state,
+               exception: %DBConnection.ConnectionError{}
+             }) == %{poller: :queue_state, error_class: "db_error"}
+
+      assert ScaleMetrics.oban_poll_error_tags(%{
+               poller: :queue_state,
+               exception: %DBConnection.OwnershipError{}
+             }) == %{poller: :queue_state, error_class: "db_error"}
+
+      assert ScaleMetrics.oban_poll_error_tags(%{
+               poller: :queue_state,
+               exception: %ArgumentError{}
+             }) == %{poller: :queue_state, error_class: "config_error"}
+
+      assert ScaleMetrics.oban_poll_error_tags(%{
+               poller: :executing_orphans,
+               exception: %FunctionClauseError{}
+             }) == %{poller: :executing_orphans, error_class: "config_error"}
+
+      assert ScaleMetrics.oban_poll_error_tags(%{
+               poller: :queue_state,
+               exception: %RuntimeError{}
+             }) == %{poller: :queue_state, error_class: "other"}
+    end
+
+    test "oban_poll_error_tags/1 defaults missing keys to \"unknown\", never raises" do
+      assert ScaleMetrics.oban_poll_error_tags(%{}) == %{
+               poller: "unknown",
+               error_class: "unknown"
+             }
+    end
+
+    test "loopctl.oban.poll.error.count is a COUNTER tagged by poller and error_class (review finding)" do
+      counter = metric("loopctl.oban.poll.error.count")
+
+      assert %Telemetry.Metrics.Counter{} = counter
+      assert counter.event_name == [:loopctl, :oban, :poll, :error]
+      assert MapSet.new(counter.tags) == MapSet.new([:poller, :error_class])
+    end
+
     # The DB-backed zero-fill / drain-to-zero behavior of poll_oban_queue_state/0
     # itself is covered in oban_metrics_poller_test.exs (TC-34.1.1b/c), which uses
-    # `Loopctl.DataCase` for AdminRepo sandbox isolation — this file is
+    # `Loopctl.DataCase` for `Loopctl.Repo` sandbox isolation — this file is
     # intentionally pure/no-DB (see moduledoc), so it only covers the fixed
-    # matrix inputs (`oban_states/0`/`oban_queues/0`) here.
+    # matrix inputs (`oban_states/0`/`oban_active_states/0`/`oban_queues/0`) here.
 
     test "the reporter round-trip: both gauges record and scrape end to end" do
       reporter_name = :"scale_metrics_oban_gauges_test_#{System.unique_integer([:positive])}"

--- a/test/loopctl/telemetry/scale_metrics_test.exs
+++ b/test/loopctl/telemetry/scale_metrics_test.exs
@@ -833,6 +833,28 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
       assert ScaleMetrics.oban_metrics_orphan_threshold_minutes() == 45
     end
 
+    test "oban_states/0 returns Oban.Job.states/0's full 8-value enum (review finding: was documented as 7)" do
+      assert ScaleMetrics.oban_states() == Oban.Job.states()
+      assert length(ScaleMetrics.oban_states()) == 8
+    end
+
+    test "oban_queues/0 returns the configured queue names, resolved at call time" do
+      configured =
+        :loopctl
+        |> Application.get_env(Oban, [])
+        |> Keyword.get(:queues, [])
+        |> Keyword.keys()
+
+      assert ScaleMetrics.oban_queues() == configured
+      assert length(ScaleMetrics.oban_queues()) == 9
+    end
+
+    # The DB-backed zero-fill / drain-to-zero behavior of poll_oban_queue_state/0
+    # itself is covered in oban_metrics_poller_test.exs (TC-34.1.1b/c), which uses
+    # `Loopctl.DataCase` for AdminRepo sandbox isolation — this file is
+    # intentionally pure/no-DB (see moduledoc), so it only covers the fixed
+    # matrix inputs (`oban_states/0`/`oban_queues/0`) here.
+
     test "the reporter round-trip: both gauges record and scrape end to end" do
       reporter_name = :"scale_metrics_oban_gauges_test_#{System.unique_integer([:positive])}"
 

--- a/test/loopctl/telemetry/scale_metrics_test.exs
+++ b/test/loopctl/telemetry/scale_metrics_test.exs
@@ -60,7 +60,9 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
     "loopctl.memory_promotion.failed.count",
     "loopctl.memory_promotion.degraded.count",
     "loopctl.memory_promotion.quota_exceeded.count",
-    "loopctl.memory_promotion.budget_exceeded.count"
+    "loopctl.memory_promotion.budget_exceeded.count",
+    "loopctl.oban.jobs.count",
+    "loopctl.oban.jobs.executing_orphan.count"
   ]
 
   # The ONLY labels any scale metric may ever carry (AC-27.15.3). Anything outside this
@@ -91,7 +93,9 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
                   :purpose,
                   :state,
                   :op,
-                  :stage
+                  :stage,
+                  :state,
+                  :queue
                 ])
 
   defp scale_metrics, do: ScaleMetrics.scale_metrics()
@@ -782,6 +786,84 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
       assert scrape =~ ~s(loopctl_memory_promotion_quota_exceeded_count 1)
       assert scrape =~ ~s(loopctl_memory_promotion_budget_exceeded_count 1)
 
+      assert Process.alive?(pid)
+    end
+  end
+
+  describe "Oban queue/state + executing_orphan gauges (US-34.1, AC-34.1.1/.2/.5)" do
+    test "loopctl.oban.jobs.count is a last_value GAUGE tagged by state and queue ONLY" do
+      gauge = metric("loopctl.oban.jobs.count")
+
+      assert %Telemetry.Metrics.LastValue{} = gauge
+      assert gauge.event_name == [:loopctl, :oban, :jobs, :count]
+      assert MapSet.new(gauge.tags) == MapSet.new([:state, :queue])
+      refute :tenant_id in gauge.tags
+    end
+
+    test "loopctl.oban.jobs.executing_orphan.count is a last_value GAUGE, UNTAGGED" do
+      gauge = metric("loopctl.oban.jobs.executing_orphan.count")
+
+      assert %Telemetry.Metrics.LastValue{} = gauge
+      assert gauge.event_name == [:loopctl, :oban, :jobs, :executing_orphan, :count]
+      assert gauge.tags == []
+    end
+
+    test "oban_queue_state_tags/1 passes through present state/queue, defaults missing to \"unknown\"" do
+      assert ScaleMetrics.oban_queue_state_tags(%{state: "available", queue: "default"}) == %{
+               state: "available",
+               queue: "default"
+             }
+
+      assert ScaleMetrics.oban_queue_state_tags(%{}) == %{state: "unknown", queue: "unknown"}
+    end
+
+    test "oban_queue_state_tags/1 never tags tenant_id even if one leaks into metadata" do
+      tags =
+        ScaleMetrics.oban_queue_state_tags(%{
+          state: "executing",
+          queue: "webhooks",
+          tenant_id: "t-1"
+        })
+
+      refute Map.has_key?(tags, :tenant_id)
+    end
+
+    test "poller config accessors default to the documented bounded values" do
+      assert ScaleMetrics.oban_metrics_poll_statement_timeout_ms() == 2_000
+      assert ScaleMetrics.oban_metrics_orphan_threshold_minutes() == 45
+    end
+
+    test "the reporter round-trip: both gauges record and scrape end to end" do
+      reporter_name = :"scale_metrics_oban_gauges_test_#{System.unique_integer([:positive])}"
+
+      metrics = [
+        metric("loopctl.oban.jobs.count"),
+        metric("loopctl.oban.jobs.executing_orphan.count")
+      ]
+
+      pid =
+        start_supervised!(
+          {TelemetryMetricsPrometheus.Core,
+           [metrics: metrics, name: reporter_name, start_async: false]}
+        )
+
+      :telemetry.execute([:loopctl, :oban, :jobs, :count], %{count: 3}, %{
+        state: "available",
+        queue: "default"
+      })
+
+      :telemetry.execute(
+        [:loopctl, :oban, :jobs, :executing_orphan, :count],
+        %{count: 1},
+        %{}
+      )
+
+      scrape = TelemetryMetricsPrometheus.Core.scrape(reporter_name)
+
+      # TelemetryMetricsPrometheus renders tags in ALPHABETICAL order, not
+      # declaration order — `queue` before `state`.
+      assert scrape =~ ~s(loopctl_oban_jobs_count{queue="default",state="available"} 3)
+      assert scrape =~ ~s(loopctl_oban_jobs_executing_orphan_count 1)
       assert Process.alive?(pid)
     end
   end

--- a/test/loopctl_web/telemetry_test.exs
+++ b/test/loopctl_web/telemetry_test.exs
@@ -1,0 +1,30 @@
+defmodule LoopctlWeb.TelemetryTest do
+  @moduledoc """
+  US-34.1 wiring test: `periodic_measurements/0` is the `telemetry_poller` MFA list
+  actually driven by the 10s tick (`LoopctlWeb.Telemetry.init/1`). Before this test,
+  `poll_oban_queue_state/0` and `poll_oban_executing_orphans/0` were each tested in
+  isolation (`oban_metrics_poller_test.exs`) and their `Telemetry.Metrics` DEFINITIONS
+  were tested in isolation (`scale_metrics_test.exs`), but nothing asserted the two
+  poller functions are actually wired into `periodic_measurements/0` — a future
+  refactor could silently drop either MFA and both gauges would go dark with no
+  failing test. Pure module — no DB needed, so this uses plain ExUnit.Case (like
+  `oban_config_test.exs`), not DataCase.
+  """
+  use ExUnit.Case, async: true
+
+  alias Loopctl.Telemetry.ScaleMetrics
+
+  describe "periodic_measurements/0 (US-34.1 poller wiring)" do
+    test "includes poll_oban_queue_state/0 (AC-34.1.1)" do
+      assert {ScaleMetrics, :poll_oban_queue_state, []} in LoopctlWeb.Telemetry.periodic_measurements()
+    end
+
+    test "includes poll_oban_executing_orphans/0 (AC-34.1.2)" do
+      assert {ScaleMetrics, :poll_oban_executing_orphans, []} in LoopctlWeb.Telemetry.periodic_measurements()
+    end
+
+    test "also still includes the pre-existing tenant-label gate refresh (regression guard)" do
+      assert {ScaleMetrics, :refresh_tenant_label_gate, []} in LoopctlWeb.Telemetry.periodic_measurements()
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds two periodic Oban observability gauges via the existing shared `telemetry_poller` (10s interval): `loopctl.oban.jobs.count` (per-{state, queue}, tags bounded to Oban's fixed state enum + the fixed queue list) and `loopctl.oban.jobs.executing_orphan.count` (untagged — jobs stuck `:executing` past a configurable threshold, default above the Lifeline `rescue_after` window). This closes the exact blind spot that let 110 jobs sit stuck `:executing` for days undetected.
- Both pollers query the global `oban_jobs` table directly via `Loopctl.AdminRepo` raw SQL (following the `Loopctl.IndexHealth` precedent — `Loopctl.HeavyRead` structurally rejects a query with no tenant predicate), wrapped in a per-query `SET LOCAL statement_timeout` transaction, and narrowly rescue known DB-fault classes (logging + skipping) so a poll failure can never crash the shared poller.
- Adds `Oban.Plugins.Reindexer` to the Oban plugin list (periodic `REINDEX CONCURRENTLY` on `oban_jobs` indexes) and documents why `Stager` is no longer a `plugins:` entry in this Oban version (absorbed into the core engine via `:stage_interval`). No change to Lifeline/Pruner/Cron.
- New config keys `:oban_metrics_poll_statement_timeout_ms` (2000) and `:oban_metrics_orphan_threshold_minutes` (45, above Lifeline's 30-min `rescue_after`).

## Test plan

- [x] `test/loopctl/telemetry/scale_metrics_test.exs` — metric definitions (gauge type, bounded tags), `tag_values` defaults, cardinality allowlist, config accessor defaults, and a real Prometheus reporter round-trip.
- [x] `test/loopctl/telemetry/oban_metrics_poller_test.exs` — integration tests inserting real `oban_jobs` rows via AdminRepo: per-{state, queue} counts (TC-34.1.1), orphan-only-when-stale (TC-34.1.2), and poll-failure defensiveness with no metric corruption (TC-34.1.3), using a genuine `DBConnection.OwnershipError` (not a stub).
- [x] `test/loopctl/oban_plugins_config_test.exs` — Reindexer is configured; Lifeline/Pruner/Cron unchanged (TC-34.1.4).
- [x] `mix precommit` green (compile, format, credo --strict, dialyzer, full test suite — 4360 tests, 0 failures).