### PR TITLE
feat(epic_34): US-34.2 surface Oban orphan/queue health in /health degraded path

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -366,6 +366,17 @@ config :loopctl, Oban,
 config :loopctl, :oban_metrics_poll_statement_timeout_ms, 2_000
 config :loopctl, :oban_metrics_orphan_threshold_minutes, 45
 
+# US-34.2: the COUNT threshold that trips `Loopctl.HealthCheck.Default`'s
+# `oban_orphans` readiness sub-check into "error" — distinct from the AGE
+# threshold above (`oban_metrics_orphan_threshold_minutes`: WHICH jobs count as
+# orphans). This one decides HOW MANY of those orphans must pile up before the
+# node reports degraded readiness. Default 10 is safe even though modest: the
+# age threshold already restricts the count to jobs stuck in `executing` for
+# 45+ minutes, so a normal transient backlog (a few slow jobs mid-retry) never
+# reaches double digits and won't flap readiness — but the sustained 17-day/
+# 110-orphan stall this story addresses trips it immediately.
+config :loopctl, :oban_orphan_health_threshold, 10
+
 # Cloak Vault — key configured per environment
 # Generate a key: :crypto.strong_rand_bytes(32) |> Base.encode64()
 # The actual cipher is set in config/runtime.exs (prod) or config/test.exs (test).

--- a/config/test.exs
+++ b/config/test.exs
@@ -248,6 +248,11 @@ config :loopctl, :health_checker, Loopctl.MockHealthChecker
 # coverage). Default stub in DataCase delegates to the real config_status/0.
 config :loopctl, :scale_alerts_config_checker, Loopctl.MockScaleAlertsConfigChecker
 
+# US-34.2: Oban orphan-count DI (Loopctl.HealthCheck.Default's oban_orphans
+# degraded-branch coverage). Default stub in DataCase delegates to the real
+# ScaleMetrics.count_oban_executing_orphans/0.
+config :loopctl, :oban_orphan_count_checker, Loopctl.MockObanOrphanCountChecker
+
 # DI: Use mock rate limiter in tests
 config :loopctl, :rate_limiter, Loopctl.MockRateLimiter
 

--- a/lib/loopctl/health_check/default.ex
+++ b/lib/loopctl/health_check/default.ex
@@ -33,14 +33,28 @@ defmodule Loopctl.HealthCheck.Default do
   `check_oban/0` below is a GenServer liveness ping (`Oban.check_queue/1`) — it stays
   "ok" even when the `:default` queue is full of jobs wedged in `:executing` (the real
   17-day/110-orphan stall this story addresses). `check_oban_orphans/0` closes that
-  gap by counting `:executing` jobs older than the AGE threshold
-  (`Loopctl.Telemetry.ScaleMetrics.oban_metrics_orphan_threshold_minutes/0`) and
-  comparing against a separate COUNT threshold
-  (`:oban_orphan_health_threshold`, AC-34.2.4). Per AC-34.2.2, a queue backlog must
-  NOT depool a node from Fly's LB — a node with a backlog can still serve HTTP
-  requests — so `oban_orphans` is folded into `ready` (readiness) ONLY, exactly
-  mirroring how `scale_alerts` was wired in US-32.4. `status` (liveness) is
-  UNCHANGED by this story: still database/oban only.
+  gap by comparing the `:executing`-older-than-N-minutes orphan count against a
+  configurable COUNT threshold (`:oban_orphan_health_threshold`, AC-34.2.4). Per
+  AC-34.2.2, a queue backlog must NOT depool a node from Fly's LB — a node with a
+  backlog can still serve HTTP requests — so `oban_orphans` is folded into `ready`
+  (readiness) ONLY, exactly mirroring how `scale_alerts` was wired in US-32.4.
+  `status` (liveness) is UNCHANGED by this story: still database/oban only.
+
+  Post-review (request-amplification finding): `check_oban_orphans/0` does NOT run
+  its own DB query. Both `/health` (continuous, unauthenticated, hit by Fly's LB
+  every 10s AND reachable at any rate from the internet) and `/health/ready` share
+  this SAME `check/0`, so an unauthenticated caller flooding `/health` would
+  otherwise force a fresh `SELECT count(*) FROM oban_jobs` on every hit — pool
+  pressure that only ever benefits `ready`, which liveness `status` doesn't even
+  consult. Instead it reads the count US-34.1's `poll_oban_executing_orphans/0`
+  (a `telemetry_poller` measurement, already ticking every 10s) cached in
+  `:persistent_term` on its last successful poll
+  (`Loopctl.Telemetry.ScaleMetrics.cached_executing_orphan_count/0`) — exactly the
+  reuse this story's technical_notes preferred over a second bounded query. The
+  cached count and the configured threshold are never disclosed verbatim in the
+  public `reasons.oban_orphans` string (both endpoints are unauthenticated); the
+  exact figures are available via the `loopctl.oban.jobs.executing_orphan.count`
+  Prometheus gauge on the internal, non-public metrics port instead.
   """
 
   @behaviour Loopctl.HealthCheck.Behaviour
@@ -135,28 +149,53 @@ defmodule Loopctl.HealthCheck.Default do
   defp scale_alerts_config_checker,
     do: Application.get_env(:loopctl, :scale_alerts_config_checker, ScaleAlerts)
 
-  # US-34.2 (AC-34.2.1/.3): counts the same `:executing`-older-than-N-minutes orphan
-  # signal US-34.1 already polls, by calling the SAME bounded query function
-  # (`ScaleMetrics.count_oban_executing_orphans/0`) — only the QUERY CODE is shared,
-  # not a stored value: this executes a fresh `Repo.transaction` + `SELECT count(*)`
-  # against `oban_jobs` on every call (US-34.1's poller calls the identical function
-  # and only emits its result as telemetry; neither caller caches it). Reports
-  # "degraded" when the count exceeds the configurable COUNT threshold; below
-  # threshold it stays "ok". Folded
-  # into `ready` (readiness) ONLY — see the moduledoc's "Oban orphan backlog is a
-  # READINESS signal" section on why this must never flip liveness `status`.
+  # US-34.2 (AC-34.2.1/.3): reads the same `:executing`-older-than-N-minutes orphan
+  # SIGNAL US-34.1 already polls, from the CACHED value
+  # `ScaleMetrics.poll_oban_executing_orphans/0` writes to `:persistent_term` on its
+  # last successful 10s poll (`ScaleMetrics.cached_executing_orphan_count/0`) —
+  # NOT a fresh `Repo.transaction` + `SELECT count(*)` per call. Post-review
+  # (request-amplification finding): this `check/0` backs BOTH the continuous,
+  # unauthenticated `/health` liveness probe and `/health/ready`; an unauthenticated
+  # caller can hit `/health` at any rate, so a per-call DB round-trip here would be
+  # unbounded request-amplification pressure on the Ecto pool for a value that
+  # only ever feeds `ready` (liveness `status` never consults it — see the
+  # moduledoc). This mirrors the story's technical_notes, which explicitly prefer
+  # reuse ("avoid a second query") over a bounded query of its own.
+  #
+  # `:not_yet_polled` (the brief window between app boot and the poller's first
+  # tick — sub-second in practice, see `cached_executing_orphan_count/0`'s doc) is
+  # treated as "ok": there is no evidence of a backlog yet, and flapping readiness
+  # for that sub-second boot window would be worse than a brief false-healthy read
+  # the very next poll corrects.
+  #
+  # Reports "degraded" when the cached count exceeds the configurable COUNT
+  # threshold; below threshold it stays "ok". Folded into `ready` (readiness) ONLY
+  # — see the moduledoc's "Oban orphan backlog is a READINESS signal" section on
+  # why this must never flip liveness `status`.
+  #
+  # The reason string deliberately omits the exact count/threshold (review
+  # finding: both endpoints are unauthenticated, so any internet caller could
+  # otherwise read the live stuck-job count and the configured trip point off a
+  # 200 OR 503 body). Operators who need the exact figures already have them via
+  # the `loopctl.oban.jobs.executing_orphan.count` Prometheus gauge (metric 19,
+  # `ScaleMetrics`), scraped off the internal, non-public `:9568/metrics` port —
+  # not this public endpoint.
   #
   # Self-rescuing like its `check_database`/`check_oban`/`check_scale_alerts` siblings:
-  # any unexpected raise (a DB timeout, an unavailable checker) must degrade cleanly to
-  # an "error" check, never crash the whole endpoint into a 500 (AC-34.2.3).
+  # any unexpected raise (an unavailable checker) must degrade cleanly to an "error"
+  # check, never crash the whole endpoint into a 500 (AC-34.2.3).
   defp check_oban_orphans do
-    count = orphan_count_checker().count_oban_executing_orphans()
     threshold = oban_orphan_health_threshold()
 
-    if count > threshold do
-      {"error", "oban executing-orphan count #{count} exceeds threshold #{threshold}"}
-    else
-      {"ok"}
+    case orphan_count_checker().cached_executing_orphan_count() do
+      {:ok, count} when count > threshold ->
+        {"error", "oban executing-orphan count exceeds configured threshold"}
+
+      {:ok, _count} ->
+        {"ok"}
+
+      :not_yet_polled ->
+        {"ok"}
     end
   rescue
     _ -> {"error", "oban orphan count check raised unexpectedly"}
@@ -165,7 +204,9 @@ defmodule Loopctl.HealthCheck.Default do
   # DI seam (Loopctl.Telemetry.ScaleMetrics.OrphanCountBehaviour) so the degraded
   # branch above is exercisable in tests via Mox.expect/3 without inserting real
   # `oban_jobs` rows or the forbidden `Application.put_env`. Defaults to the real
-  # `ScaleMetrics` module (unchanged behavior in dev/prod).
+  # `ScaleMetrics` module (unchanged behavior in dev/prod) — the SAME process that
+  # already runs `poll_oban_executing_orphans/0`, so the cache it reads is always
+  # its own poller's output.
   defp orphan_count_checker,
     do: Application.get_env(:loopctl, :oban_orphan_count_checker, ScaleMetrics)
 

--- a/lib/loopctl/health_check/default.ex
+++ b/lib/loopctl/health_check/default.ex
@@ -20,45 +20,75 @@ defmodule Loopctl.HealthCheck.Default do
   still surfaced in `checks` (and `reasons` on failure) for visibility, but it does
   NOT flip `status`.
 
-  A separate `ready` boolean additionally folds in `scale_alerts`, and is acted on
-  ONLY by `GET /health/ready` (`LoopctlWeb.HealthController.ready/2`) — a genuine
-  deploy-time smoke gate an operator or deploy pipeline can poll explicitly, distinct
-  from the endpoint Fly's proxy continuously checks. This satisfies AC-32.4.1's
-  "flip a readiness flag so /health (or the readiness endpoint) reports NOT-ready"
-  via the readiness-endpoint branch of that disjunction.
+  A separate `ready` boolean additionally folds in `scale_alerts` and (US-34.2)
+  `oban_orphans`, and is acted on ONLY by `GET /health/ready`
+  (`LoopctlWeb.HealthController.ready/2`) — a genuine deploy-time smoke gate an
+  operator or deploy pipeline can poll explicitly, distinct from the endpoint Fly's
+  proxy continuously checks. This satisfies AC-32.4.1's "flip a readiness flag so
+  /health (or the readiness endpoint) reports NOT-ready" via the readiness-endpoint
+  branch of that disjunction.
+
+  ## Oban orphan backlog is a READINESS signal, not a liveness one (US-34.2)
+
+  `check_oban/0` below is a GenServer liveness ping (`Oban.check_queue/1`) — it stays
+  "ok" even when the `:default` queue is full of jobs wedged in `:executing` (the real
+  17-day/110-orphan stall this story addresses). `check_oban_orphans/0` closes that
+  gap by counting `:executing` jobs older than the AGE threshold
+  (`Loopctl.Telemetry.ScaleMetrics.oban_metrics_orphan_threshold_minutes/0`) and
+  comparing against a separate COUNT threshold
+  (`:oban_orphan_health_threshold`, AC-34.2.4). Per AC-34.2.2, a queue backlog must
+  NOT depool a node from Fly's LB — a node with a backlog can still serve HTTP
+  requests — so `oban_orphans` is folded into `ready` (readiness) ONLY, exactly
+  mirroring how `scale_alerts` was wired in US-32.4. `status` (liveness) is
+  UNCHANGED by this story: still database/oban only.
   """
 
   @behaviour Loopctl.HealthCheck.Behaviour
 
   alias Ecto.Adapters.SQL
   alias Loopctl.Telemetry.ScaleAlerts
+  alias Loopctl.Telemetry.ScaleMetrics
+
+  # US-34.2 (AC-34.2.4): default COUNT threshold for `check_oban_orphans/0`, distinct
+  # from `ScaleMetrics`'s 45-minute AGE threshold (which decides WHICH jobs count as
+  # orphans in the first place). Safe even though modest — see the config.exs comment
+  # for the full rationale.
+  @default_oban_orphan_health_threshold 10
 
   @impl true
   def check do
     db_check = check_database()
     oban_check = check_oban()
     scale_alerts_check = check_scale_alerts()
+    oban_orphans_check = check_oban_orphans()
 
     checks = %{
       database: elem(db_check, 0),
       oban: elem(oban_check, 0),
-      scale_alerts: elem(scale_alerts_check, 0)
+      scale_alerts: elem(scale_alerts_check, 0),
+      oban_orphans: elem(oban_orphans_check, 0)
     }
 
-    # Liveness: database/oban only — see the moduledoc on why scale_alerts must NOT
-    # participate here (it would let a benign config-only issue depool a healthy node
-    # on Fly's continuous load-balancer check).
+    # Liveness: database/oban only — see the moduledoc on why scale_alerts/oban_orphans
+    # must NOT participate here (either would let a benign or backlog-only issue depool
+    # a healthy node on Fly's continuous load-balancer check).
     status =
       if checks.database == "ok" and checks.oban == "ok",
         do: "ok",
         else: "degraded"
 
-    # Readiness: liveness AND the scale-alerts config-guard. Only `/health/ready` acts
-    # on this — it is the deploy-time smoke signal, not the traffic-routing one.
-    ready = status == "ok" and checks.scale_alerts == "ok"
+    # Readiness: liveness AND the scale-alerts config-guard AND the oban-orphans
+    # backlog guard. Only `/health/ready` acts on this — it is the deploy-time smoke
+    # signal, not the traffic-routing one.
+    ready =
+      status == "ok" and checks.scale_alerts == "ok" and checks.oban_orphans == "ok"
 
     result = %{status: status, ready: ready, version: app_version(), checks: checks}
-    result = maybe_put_reasons(result, scale_alerts_check)
+
+    result =
+      result
+      |> maybe_put_reason(:scale_alerts, scale_alerts_check)
+      |> maybe_put_reason(:oban_orphans, oban_orphans_check)
 
     {:ok, result}
   end
@@ -105,16 +135,65 @@ defmodule Loopctl.HealthCheck.Default do
   defp scale_alerts_config_checker,
     do: Application.get_env(:loopctl, :scale_alerts_config_checker, ScaleAlerts)
 
+  # US-34.2 (AC-34.2.1/.3): counts the same `:executing`-older-than-N-minutes orphan
+  # signal US-34.1 already polls, by calling the SAME bounded query function
+  # (`ScaleMetrics.count_oban_executing_orphans/0`) — only the QUERY CODE is shared,
+  # not a stored value: this executes a fresh `Repo.transaction` + `SELECT count(*)`
+  # against `oban_jobs` on every call (US-34.1's poller calls the identical function
+  # and only emits its result as telemetry; neither caller caches it). Reports
+  # "degraded" when the count exceeds the configurable COUNT threshold; below
+  # threshold it stays "ok". Folded
+  # into `ready` (readiness) ONLY — see the moduledoc's "Oban orphan backlog is a
+  # READINESS signal" section on why this must never flip liveness `status`.
+  #
+  # Self-rescuing like its `check_database`/`check_oban`/`check_scale_alerts` siblings:
+  # any unexpected raise (a DB timeout, an unavailable checker) must degrade cleanly to
+  # an "error" check, never crash the whole endpoint into a 500 (AC-34.2.3).
+  defp check_oban_orphans do
+    count = orphan_count_checker().count_oban_executing_orphans()
+    threshold = oban_orphan_health_threshold()
+
+    if count > threshold do
+      {"error", "oban executing-orphan count #{count} exceeds threshold #{threshold}"}
+    else
+      {"ok"}
+    end
+  rescue
+    _ -> {"error", "oban orphan count check raised unexpectedly"}
+  end
+
+  # DI seam (Loopctl.Telemetry.ScaleMetrics.OrphanCountBehaviour) so the degraded
+  # branch above is exercisable in tests via Mox.expect/3 without inserting real
+  # `oban_jobs` rows or the forbidden `Application.put_env`. Defaults to the real
+  # `ScaleMetrics` module (unchanged behavior in dev/prod).
+  defp orphan_count_checker,
+    do: Application.get_env(:loopctl, :oban_orphan_count_checker, ScaleMetrics)
+
+  # US-34.2 (AC-34.2.4): the configured COUNT threshold — distinct from
+  # `ScaleMetrics.oban_metrics_orphan_threshold_minutes/0`'s AGE threshold, which
+  # decides WHICH jobs count as orphans in the first place. This one decides HOW MANY
+  # of those orphans must pile up before readiness degrades.
+  defp oban_orphan_health_threshold,
+    do:
+      Application.get_env(
+        :loopctl,
+        :oban_orphan_health_threshold,
+        @default_oban_orphan_health_threshold
+      )
+
   defp app_version do
     Application.spec(:loopctl, :vsn) |> to_string()
   end
 
-  # Only attach a `reasons` field when a check actually failed with a reason — keeps the
-  # healthy-path response shape unchanged (AC-32.4.2/3). No secret is included: the reason
-  # string names the env var only (see `ScaleAlerts.config_status/2`).
-  defp maybe_put_reasons(result, {"error", reason}) do
-    Map.put(result, :reasons, %{scale_alerts: reason})
+  # Only attach a `reasons.<key>` entry when a check actually failed with a reason —
+  # keeps the healthy-path response shape unchanged (AC-32.4.2/3). Generalized (US-34.2)
+  # to merge ANY failing check's reason under its own key without dropping a
+  # previously-added one (e.g. both scale_alerts and oban_orphans can fail at once). No
+  # secret is included: reason strings name only the env var (scale_alerts) or the
+  # orphan count/threshold (oban_orphans).
+  defp maybe_put_reason(result, key, {"error", reason}) do
+    Map.update(result, :reasons, %{key => reason}, &Map.put(&1, key, reason))
   end
 
-  defp maybe_put_reasons(result, _check), do: result
+  defp maybe_put_reason(result, _key, _check), do: result
 end

--- a/lib/loopctl/telemetry/scale_metrics.ex
+++ b/lib/loopctl/telemetry/scale_metrics.ex
@@ -347,6 +347,8 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
 
   import Telemetry.Metrics
 
+  @behaviour Loopctl.Telemetry.ScaleMetrics.OrphanCountBehaviour
+
   require Logger
 
   alias Loopctl.Repo
@@ -989,46 +991,73 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
 
   @doc """
   Counts `oban_jobs` rows stuck in state `executing` whose `attempted_at` is older
-  than the configured orphan threshold, and emits a single (untagged) telemetry
-  measurement (US-34.1, AC-34.1.2).
+  than the configured orphan AGE threshold (`oban_metrics_orphan_threshold_minutes/0`).
 
-  Same defensive/bounded-interval contract as `poll_oban_queue_state/0` — a single
-  `SET LOCAL statement_timeout`-wrapped `Loopctl.Repo` query (review finding —
-  moved off the tiny `AdminRepo` pool alongside the other poller), catch-all
-  rescue, `Logger.warning` + poll-failure counter + `:ok` on failure, never
-  crashing the shared poller. The age comparison (`attempted_at < now() - N
-  minutes`) is done IN SQL, not in Elixir, so only genuinely stale rows are
-  counted. Always returns `:ok`.
+  Extracted from `poll_oban_executing_orphans/0` (US-34.2, AC-34.2.3) so
+  `Loopctl.HealthCheck.Default`'s `check_oban_orphans/0` health sub-check can reuse
+  the EXACT same bounded, tz-correct query rather than duplicating it —
+  `poll_oban_executing_orphans/0` below calls this too, unchanged behavior.
+
+  Implements the `Loopctl.Telemetry.ScaleMetrics.OrphanCountBehaviour` callback.
+  Deliberately does NOT rescue here: `poll_oban_executing_orphans/0` keeps its own
+  catch-all rescue around this call (US-34.1 behavior, unchanged), and the health
+  check wraps its own call with its own defensive rescue (AC-34.2.3) — a shared
+  rescue here would hide which caller actually needs to degrade vs. skip-a-cycle.
+
+  Post-review (US-34.2): `Loopctl.HealthCheck.Default.check_oban_orphans/0` calls
+  this from `check/0`, which backs BOTH the continuous `/health` liveness probe and
+  `/health/ready`. `statement_timeout` (set via `SET LOCAL` below) only bounds the
+  query AFTER a connection is checked out — under pool pressure the checkout wait
+  itself would fall back to the Ecto pool's default (~15s), a heavier and
+  less-strictly-bounded DB wait than its liveness sibling `check_database/0` (which
+  passes an explicit `timeout: 5_000`). The `:timeout` option below bounds
+  `Repo.transaction/2`'s checkout-and-run the same way, so this shares the same
+  bound as `check_database/0` instead of falling back to the pool default.
   """
-  @spec poll_oban_executing_orphans() :: :ok
-  def poll_oban_executing_orphans do
+  @impl true
+  @spec count_oban_executing_orphans() :: non_neg_integer()
+  def count_oban_executing_orphans do
     timeout_ms = oban_metrics_poll_statement_timeout_ms()
     threshold_minutes = oban_metrics_orphan_threshold_minutes()
 
+    # `:timeout` bounds this transaction's checkout-and-run the same way
+    # `check_database/0` bounds its `SQL.query/4` call with `timeout: 5_000` — see
+    # the moduledoc above. `statement_timeout` (SET LOCAL below) only bounds the
+    # query itself, AFTER a connection is already checked out.
     {:ok, count} =
-      Repo.transaction(fn ->
-        Repo.query!("SET LOCAL statement_timeout = #{timeout_ms}")
+      Repo.transaction(
+        fn ->
+          Repo.query!("SET LOCAL statement_timeout = #{timeout_ms}")
 
-        # `attempted_at` is a `timestamp without time zone` column populated by
-        # Ecto's `:utc_datetime_usec` dump — i.e. it holds a UTC wall-clock reading
-        # with no tz attached. `now()` is `timestamptz`; comparing it directly
-        # against a naive column implicitly casts `now()` using the CONNECTION's
-        # `TimeZone` GUC (e.g. Fly Postgres defaults can be non-UTC), which skews
-        # the comparison by that offset. `now() AT TIME ZONE 'UTC'` converts to a
-        # naive UTC wall-clock timestamp first, matching what's actually stored.
-        %{rows: [[count]]} =
-          Repo.query!(
-            """
-            SELECT count(*)
-            FROM oban_jobs
-            WHERE state = 'executing'
-              AND attempted_at < (now() AT TIME ZONE 'UTC') - ($1 * interval '1 minute')
-            """,
-            [threshold_minutes]
-          )
+          # `attempted_at` is a `timestamp without time zone` column populated by
+          # Ecto's `:utc_datetime_usec` dump — i.e. it holds a UTC wall-clock reading
+          # with no tz attached. `now()` is `timestamptz`; comparing it directly
+          # against a naive column implicitly casts `now()` using the CONNECTION's
+          # `TimeZone` GUC (e.g. Fly Postgres defaults can be non-UTC), which skews
+          # the comparison by that offset. `now() AT TIME ZONE 'UTC'` converts to a
+          # naive UTC wall-clock timestamp first, matching what's actually stored.
+          %{rows: [[count]]} =
+            Repo.query!(
+              """
+              SELECT count(*)
+              FROM oban_jobs
+              WHERE state = 'executing'
+                AND attempted_at < (now() AT TIME ZONE 'UTC') - ($1 * interval '1 minute')
+              """,
+              [threshold_minutes]
+            )
 
-        count
-      end)
+          count
+        end,
+        timeout: 5_000
+      )
+
+    count
+  end
+
+  @spec poll_oban_executing_orphans() :: :ok
+  def poll_oban_executing_orphans do
+    count = count_oban_executing_orphans()
 
     :telemetry.execute([:loopctl, :oban, :jobs, :executing_orphan, :count], %{count: count}, %{})
 

--- a/lib/loopctl/telemetry/scale_metrics.ex
+++ b/lib/loopctl/telemetry/scale_metrics.ex
@@ -356,6 +356,15 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
 
   @persistent_term_key {__MODULE__, :tenant_label?}
 
+  # US-34.2 (review finding): the `:persistent_term` slot `poll_oban_executing_orphans/0`
+  # writes on every SUCCESSFUL poll, and `cached_executing_orphan_count/0` reads —
+  # lets `Loopctl.HealthCheck.Default`'s orphan sub-check reuse the last-polled value
+  # instead of issuing its OWN fresh `Repo.transaction` + `SELECT count(*)` on every
+  # `/health`/`/health/ready` hit (the shared `check/0` backs BOTH the continuous,
+  # unauthenticated liveness probe AND readiness — a fresh DB round-trip on every
+  # liveness hit is unwarranted request-amplification pressure on the Ecto pool).
+  @executing_orphan_cache_key {__MODULE__, :cached_executing_orphan_count}
+
   # The fixed sentinel a `tenant_id` label collapses to when the gate is OFF (over the
   # tenant-count cap, or the gate is unseeded). Keeps the tenant label's cardinality at
   # exactly 1 while preserving a consistent Prometheus series shape.
@@ -993,28 +1002,33 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   Counts `oban_jobs` rows stuck in state `executing` whose `attempted_at` is older
   than the configured orphan AGE threshold (`oban_metrics_orphan_threshold_minutes/0`).
 
-  Extracted from `poll_oban_executing_orphans/0` (US-34.2, AC-34.2.3) so
-  `Loopctl.HealthCheck.Default`'s `check_oban_orphans/0` health sub-check can reuse
-  the EXACT same bounded, tz-correct query rather than duplicating it —
-  `poll_oban_executing_orphans/0` below calls this too, unchanged behavior.
+  Extracted from `poll_oban_executing_orphans/0` (US-34.2, AC-34.2.3) originally so
+  `Loopctl.HealthCheck.Default`'s `check_oban_orphans/0` health sub-check could
+  reuse the EXACT same bounded, tz-correct query rather than duplicating it.
 
-  Implements the `Loopctl.Telemetry.ScaleMetrics.OrphanCountBehaviour` callback.
+  Post-review (US-34.2, request-amplification finding): the health check no longer
+  calls this directly on every `/health`/`/health/ready` hit — it reads
+  `cached_executing_orphan_count/0`'s `:persistent_term` cache instead (populated
+  by `poll_oban_executing_orphans/0` below, unchanged 10s cadence), so this
+  function's only remaining caller in dev/prod is the poller. It stays public and
+  directly callable (unchanged signature/behavior) because
+  `test/support/data_case.ex`'s default Mox stub for
+  `Loopctl.MockObanOrphanCountChecker.cached_executing_orphan_count/0` deliberately
+  calls THIS fresh-query function rather than the shared `:persistent_term` cache —
+  reading the true global cache from every async `DataCase` test would leak state
+  across concurrently running tests (the cache is one VM-wide slot, not
+  per-sandboxed-transaction); calling this function fresh keeps each test scoped to
+  its own sandboxed connection, exactly like every other health sub-check's default
+  stub.
+
   Deliberately does NOT rescue here: `poll_oban_executing_orphans/0` keeps its own
-  catch-all rescue around this call (US-34.1 behavior, unchanged), and the health
-  check wraps its own call with its own defensive rescue (AC-34.2.3) — a shared
-  rescue here would hide which caller actually needs to degrade vs. skip-a-cycle.
-
-  Post-review (US-34.2): `Loopctl.HealthCheck.Default.check_oban_orphans/0` calls
-  this from `check/0`, which backs BOTH the continuous `/health` liveness probe and
-  `/health/ready`. `statement_timeout` (set via `SET LOCAL` below) only bounds the
-  query AFTER a connection is checked out — under pool pressure the checkout wait
-  itself would fall back to the Ecto pool's default (~15s), a heavier and
-  less-strictly-bounded DB wait than its liveness sibling `check_database/0` (which
-  passes an explicit `timeout: 5_000`). The `:timeout` option below bounds
-  `Repo.transaction/2`'s checkout-and-run the same way, so this shares the same
-  bound as `check_database/0` instead of falling back to the pool default.
+  catch-all rescue around this call (US-34.1 behavior, unchanged). `statement_timeout`
+  (set via `SET LOCAL` below) only bounds the query AFTER a connection is checked
+  out — under pool pressure the checkout wait itself would fall back to the Ecto
+  pool's default (~15s). The `:timeout` option below bounds `Repo.transaction/2`'s
+  checkout-and-run the same way `check_database/0` bounds its own call with an
+  explicit `timeout: 5_000`.
   """
-  @impl true
   @spec count_oban_executing_orphans() :: non_neg_integer()
   def count_oban_executing_orphans do
     timeout_ms = oban_metrics_poll_statement_timeout_ms()
@@ -1055,9 +1069,46 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
     count
   end
 
+  @doc """
+  Reads the `:executing`-orphan count that `poll_oban_executing_orphans/0` cached
+  in `:persistent_term` on its last SUCCESSFUL poll (US-34.2 review finding).
+
+  `Loopctl.HealthCheck.Default.check_oban_orphans/0` calls this (via the
+  `Loopctl.Telemetry.ScaleMetrics.OrphanCountBehaviour` DI seam) instead of
+  `count_oban_executing_orphans/0` directly — the health check backs BOTH the
+  continuous, unauthenticated `/health` liveness probe and `/health/ready`, so
+  issuing a fresh `Repo.transaction` + `SELECT count(*)` on every hit is
+  unwarranted request-amplification pressure on the Ecto pool; reading a cache
+  the poller already refreshes every 10s (`telemetry_poller`'s `period: 10_000`)
+  costs a lock-free `:persistent_term.get/2` instead.
+
+  Returns `{:ok, count}` once at least one poll has completed, or
+  `:not_yet_polled` in the brief window between app boot and the poller's first
+  tick — `telemetry_poller`'s `init_delay: 0` schedules that first collection
+  essentially immediately (not after the full 10s period), so this window is
+  sub-second in practice, not a sustained gap.
+
+  Never touches the database itself. A FAILED poll intentionally leaves the
+  prior cached value in place (identical staleness semantics to the
+  `last_value/2` Prometheus gauge this same count also feeds) — the cache is
+  never reset to a false "no orphans" reading just because a poll cycle failed.
+
+  Implements the `Loopctl.Telemetry.ScaleMetrics.OrphanCountBehaviour` callback.
+  """
+  @impl true
+  @spec cached_executing_orphan_count() :: {:ok, non_neg_integer()} | :not_yet_polled
+  def cached_executing_orphan_count do
+    case :persistent_term.get(@executing_orphan_cache_key, :not_yet_polled) do
+      :not_yet_polled -> :not_yet_polled
+      count when is_integer(count) -> {:ok, count}
+    end
+  end
+
   @spec poll_oban_executing_orphans() :: :ok
   def poll_oban_executing_orphans do
     count = count_oban_executing_orphans()
+
+    :persistent_term.put(@executing_orphan_cache_key, count)
 
     :telemetry.execute([:loopctl, :oban, :jobs, :executing_orphan, :count], %{count: count}, %{})
 
@@ -1066,7 +1117,8 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
     e ->
       Logger.warning(
         "Oban executing-orphan poll failed (#{inspect(e.__struct__)}); skipping this cycle — " <>
-          "the executing_orphan gauge simply keeps its last-recorded value until the next poll"
+          "the executing_orphan gauge AND the health-check cache simply keep their last-recorded " <>
+          "value until the next successful poll"
       )
 
       emit_oban_poll_error(:executing_orphans, e)

--- a/lib/loopctl/telemetry/scale_metrics/orphan_count_behaviour.ex
+++ b/lib/loopctl/telemetry/scale_metrics/orphan_count_behaviour.ex
@@ -7,10 +7,19 @@ defmodule Loopctl.Telemetry.ScaleMetrics.OrphanCountBehaviour do
   degraded branch — the `oban_jobs` `:executing` orphan count exceeding the
   configured `:oban_orphan_health_threshold` — is exercisable in tests via
   `Mox.expect/3` without inserting real `oban_jobs` rows or the forbidden
-  `Application.put_env`. The default resolution (`Loopctl.Telemetry.ScaleMetrics`,
-  which already implements `count_oban_executing_orphans/0` for US-34.1) is
-  untouched in dev/prod.
+  `Application.put_env`.
+
+  Post-review (US-34.2, finding: "readiness-only query on the shared, continuous,
+  unauthenticated liveness probe"): the callback reads the value US-34.1's
+  `poll_oban_executing_orphans/0` (a `telemetry_poller` periodic measurement,
+  ticking every 10s) already cached in `:persistent_term` after its last
+  SUCCESSFUL poll, instead of the health check issuing its OWN fresh
+  `Repo.transaction` + `SELECT count(*)` on every call — exactly the reuse the
+  story's technical_notes preferred ("avoid a second query"). The default
+  resolution (`Loopctl.Telemetry.ScaleMetrics`, which implements
+  `cached_executing_orphan_count/0`) is untouched in dev/prod: it is the SAME
+  process that already runs the poller, so the cache it reads is always its own.
   """
 
-  @callback count_oban_executing_orphans() :: non_neg_integer()
+  @callback cached_executing_orphan_count() :: {:ok, non_neg_integer()} | :not_yet_polled
 end

--- a/lib/loopctl/telemetry/scale_metrics/orphan_count_behaviour.ex
+++ b/lib/loopctl/telemetry/scale_metrics/orphan_count_behaviour.ex
@@ -1,0 +1,16 @@
+defmodule Loopctl.Telemetry.ScaleMetrics.OrphanCountBehaviour do
+  @moduledoc """
+  DI seam for the US-34.2 Oban orphan-count health sub-check.
+
+  `Loopctl.HealthCheck.Default` calls this (not
+  `Loopctl.Telemetry.ScaleMetrics.count_oban_executing_orphans/0` directly) so the
+  degraded branch — the `oban_jobs` `:executing` orphan count exceeding the
+  configured `:oban_orphan_health_threshold` — is exercisable in tests via
+  `Mox.expect/3` without inserting real `oban_jobs` rows or the forbidden
+  `Application.put_env`. The default resolution (`Loopctl.Telemetry.ScaleMetrics`,
+  which already implements `count_oban_executing_orphans/0` for US-34.1) is
+  untouched in dev/prod.
+  """
+
+  @callback count_oban_executing_orphans() :: non_neg_integer()
+end

--- a/lib/loopctl_web/controllers/health_controller.ex
+++ b/lib/loopctl_web/controllers/health_controller.ex
@@ -10,11 +10,15 @@ defmodule LoopctlWeb.HealthController do
   `Loopctl.HealthCheck.Default`'s moduledoc: a benign config-only issue must never
   depool an otherwise-healthy node).
 
-  GET /health/ready — READINESS (US-32.4). Same underlying check, but the HTTP code
-  is driven by `result.ready`, which additionally folds in the scale-alerts
-  config-guard (`:scale_alerts_enabled` true with no `SCALE_ALERT_WEBHOOK_URL`). This
-  is the deploy-time smoke gate an operator or deploy pipeline polls explicitly — it
-  is deliberately NOT wired into `fly.toml`'s continuous check.
+  GET /health/ready — READINESS (US-32.4, extended by US-34.2). Same underlying check,
+  but the HTTP code is driven by `result.ready`, which additionally folds in the
+  scale-alerts config-guard (`:scale_alerts_enabled` true with no
+  `SCALE_ALERT_WEBHOOK_URL`) AND (US-34.2) the Oban `:executing`-orphan backlog guard
+  (`checks.oban_orphans`) — a queue backlog is a readiness signal, not a liveness one,
+  so it never depools a node from Fly's LB even though a node with a stalled queue
+  can't finish background work. This is the deploy-time smoke gate an operator or
+  deploy pipeline polls explicitly — it is deliberately NOT wired into `fly.toml`'s
+  continuous check.
 
   Both endpoints are unauthenticated so external probes (nginx, monitoring systems,
   deploy scripts) can reach them without an API key.
@@ -59,10 +63,11 @@ defmodule LoopctlWeb.HealthController do
   end
 
   operation(:ready,
-    summary: "Readiness check (US-32.4)",
+    summary: "Readiness check (US-32.4, US-34.2)",
     description:
       "Deploy-time smoke gate distinct from the /health liveness probe. Fails when " <>
-        "scale alerts are enabled but no webhook URL is configured, in addition to " <>
+        "scale alerts are enabled but no webhook URL is configured, or when the Oban " <>
+        "`:executing`-orphan backlog exceeds its configured threshold, in addition to " <>
         "the database/oban checks. Not wired into Fly's continuous load-balancer check.",
     security: [],
     responses: %{

--- a/test/loopctl/health_check/default_test.exs
+++ b/test/loopctl/health_check/default_test.exs
@@ -87,4 +87,106 @@ defmodule Loopctl.HealthCheck.DefaultTest do
       assert result.status == baseline.status
     end
   end
+
+  describe "check/0 — Oban orphan backlog readiness signal (US-34.2)" do
+    test "TC-34.2.1: orphan count above threshold degrades checks.oban_orphans, adds reasons.oban_orphans, flips ready, and leaves liveness (status/database/oban) untouched" do
+      Mox.expect(Loopctl.MockObanOrphanCountChecker, :count_oban_executing_orphans, fn -> 0 end)
+      assert {:ok, baseline} = Default.check()
+
+      Mox.expect(Loopctl.MockObanOrphanCountChecker, :count_oban_executing_orphans, fn -> 11 end)
+      assert {:ok, degraded} = Default.check()
+
+      assert degraded.checks.oban_orphans == "error"
+      assert %{oban_orphans: reason} = degraded.reasons
+      assert reason =~ "11"
+      assert reason =~ "10"
+
+      assert degraded.ready == false
+
+      # Critical regression guard (AC-34.2.2): a queue backlog must NOT depool a node
+      # from Fly's LB — liveness (`status`) and the database/oban checks are UNCHANGED
+      # by the orphan-count result.
+      assert degraded.status == baseline.status
+      assert degraded.checks.database == baseline.checks.database
+      assert degraded.checks.oban == baseline.checks.oban
+    end
+
+    test "TC-34.2.2: no orphans / below threshold reports checks.oban_orphans = ok, no reasons.oban_orphans key, and ready tracks status" do
+      Mox.expect(Loopctl.MockObanOrphanCountChecker, :count_oban_executing_orphans, fn -> 0 end)
+
+      assert {:ok, result} = Default.check()
+
+      assert result.checks.oban_orphans == "ok"
+      refute Map.has_key?(result, :reasons)
+      assert result.ready == (result.status == "ok")
+    end
+
+    test "TC-34.2.2b: a count at exactly the threshold does not degrade (only EXCEEDING the threshold does)" do
+      Mox.expect(Loopctl.MockObanOrphanCountChecker, :count_oban_executing_orphans, fn -> 10 end)
+
+      assert {:ok, result} = Default.check()
+
+      assert result.checks.oban_orphans == "ok"
+      refute Map.has_key?(result, :reasons)
+    end
+
+    test "TC-34.2.3: an orphan-count query raising degrades cleanly (checks.oban_orphans = error) instead of crashing the endpoint" do
+      Mox.expect(Loopctl.MockObanOrphanCountChecker, :count_oban_executing_orphans, fn -> 0 end)
+      assert {:ok, baseline} = Default.check()
+
+      Mox.expect(Loopctl.MockObanOrphanCountChecker, :count_oban_executing_orphans, fn ->
+        raise "boom"
+      end)
+
+      assert {:ok, result} = Default.check()
+
+      assert result.checks.oban_orphans == "error"
+      assert result.ready == false
+      assert result.status == baseline.status
+    end
+
+    test "TC-34.2.1 (real rows, end-to-end): real orphaned oban_jobs rows counted via the real query (no Mox override) degrade checks.oban_orphans and flip ready" do
+      alias Loopctl.Telemetry.ScaleMetrics
+
+      threshold_minutes = ScaleMetrics.oban_metrics_orphan_threshold_minutes()
+      health_threshold = 10
+      now = DateTime.utc_now()
+
+      # 11 real stale `:executing` rows — above both the AGE threshold (marks them as
+      # orphans) and the COUNT threshold (11 > 10) — inserted directly, no mocking.
+      for _ <- 1..(health_threshold + 1) do
+        %Oban.Job{
+          worker: "Loopctl.Workers.IdempotencyCleanupWorker",
+          queue: "default",
+          args: %{},
+          state: "executing",
+          attempted_at: DateTime.add(now, -(threshold_minutes + 5) * 60, :second)
+        }
+        |> Repo.insert!()
+      end
+
+      # A recent executing job is legitimately mid-flight, NOT an orphan — confirms
+      # the real query's age filter, not just its count(*).
+      %Oban.Job{
+        worker: "Loopctl.Workers.IdempotencyCleanupWorker",
+        queue: "default",
+        args: %{},
+        state: "executing",
+        attempted_at: DateTime.add(now, -1, :second)
+      }
+      |> Repo.insert!()
+
+      # No Mox.expect here — `stub_all_defaults/0` (data_case.ex) delegates
+      # `Loopctl.MockObanOrphanCountChecker.count_oban_executing_orphans/0` to the
+      # REAL `ScaleMetrics.count_oban_executing_orphans/0`, so `Default.check/0`
+      # exercises the full chain: real rows -> real query -> real count -> ready=false.
+      assert {:ok, result} = Default.check()
+
+      assert result.checks.oban_orphans == "error"
+      assert %{oban_orphans: reason} = result.reasons
+      assert reason =~ "11"
+      assert reason =~ "10"
+      assert result.ready == false
+    end
+  end
 end

--- a/test/loopctl/health_check/default_test.exs
+++ b/test/loopctl/health_check/default_test.exs
@@ -90,16 +90,27 @@ defmodule Loopctl.HealthCheck.DefaultTest do
 
   describe "check/0 — Oban orphan backlog readiness signal (US-34.2)" do
     test "TC-34.2.1: orphan count above threshold degrades checks.oban_orphans, adds reasons.oban_orphans, flips ready, and leaves liveness (status/database/oban) untouched" do
-      Mox.expect(Loopctl.MockObanOrphanCountChecker, :count_oban_executing_orphans, fn -> 0 end)
+      Mox.expect(Loopctl.MockObanOrphanCountChecker, :cached_executing_orphan_count, fn ->
+        {:ok, 0}
+      end)
+
       assert {:ok, baseline} = Default.check()
 
-      Mox.expect(Loopctl.MockObanOrphanCountChecker, :count_oban_executing_orphans, fn -> 11 end)
+      Mox.expect(Loopctl.MockObanOrphanCountChecker, :cached_executing_orphan_count, fn ->
+        {:ok, 11}
+      end)
+
       assert {:ok, degraded} = Default.check()
 
       assert degraded.checks.oban_orphans == "error"
-      assert %{oban_orphans: reason} = degraded.reasons
-      assert reason =~ "11"
-      assert reason =~ "10"
+
+      # Review finding: the exact count/threshold are NOT disclosed in the reason
+      # string — both /health and /health/ready are unauthenticated, so any
+      # internet caller could otherwise read the live stuck-job count and the
+      # configured trip point directly off the response body.
+      assert degraded.reasons == %{
+               oban_orphans: "oban executing-orphan count exceeds configured threshold"
+             }
 
       assert degraded.ready == false
 
@@ -112,7 +123,9 @@ defmodule Loopctl.HealthCheck.DefaultTest do
     end
 
     test "TC-34.2.2: no orphans / below threshold reports checks.oban_orphans = ok, no reasons.oban_orphans key, and ready tracks status" do
-      Mox.expect(Loopctl.MockObanOrphanCountChecker, :count_oban_executing_orphans, fn -> 0 end)
+      Mox.expect(Loopctl.MockObanOrphanCountChecker, :cached_executing_orphan_count, fn ->
+        {:ok, 0}
+      end)
 
       assert {:ok, result} = Default.check()
 
@@ -122,7 +135,9 @@ defmodule Loopctl.HealthCheck.DefaultTest do
     end
 
     test "TC-34.2.2b: a count at exactly the threshold does not degrade (only EXCEEDING the threshold does)" do
-      Mox.expect(Loopctl.MockObanOrphanCountChecker, :count_oban_executing_orphans, fn -> 10 end)
+      Mox.expect(Loopctl.MockObanOrphanCountChecker, :cached_executing_orphan_count, fn ->
+        {:ok, 10}
+      end)
 
       assert {:ok, result} = Default.check()
 
@@ -130,11 +145,25 @@ defmodule Loopctl.HealthCheck.DefaultTest do
       refute Map.has_key?(result, :reasons)
     end
 
-    test "TC-34.2.3: an orphan-count query raising degrades cleanly (checks.oban_orphans = error) instead of crashing the endpoint" do
-      Mox.expect(Loopctl.MockObanOrphanCountChecker, :count_oban_executing_orphans, fn -> 0 end)
+    test "review finding: `:not_yet_polled` (the brief window before US-34.1's poller has run once) is treated as ok, not degraded" do
+      Mox.expect(Loopctl.MockObanOrphanCountChecker, :cached_executing_orphan_count, fn ->
+        :not_yet_polled
+      end)
+
+      assert {:ok, result} = Default.check()
+
+      assert result.checks.oban_orphans == "ok"
+      refute Map.has_key?(result, :reasons)
+    end
+
+    test "AC-34.2.3 defensive rescue (NOT story TC-34.2.3 — see the dedicated check_oban/0 hard-error test below): an orphan-count checker raising degrades cleanly instead of crashing" do
+      Mox.expect(Loopctl.MockObanOrphanCountChecker, :cached_executing_orphan_count, fn ->
+        {:ok, 0}
+      end)
+
       assert {:ok, baseline} = Default.check()
 
-      Mox.expect(Loopctl.MockObanOrphanCountChecker, :count_oban_executing_orphans, fn ->
+      Mox.expect(Loopctl.MockObanOrphanCountChecker, :cached_executing_orphan_count, fn ->
         raise "boom"
       end)
 
@@ -143,6 +172,24 @@ defmodule Loopctl.HealthCheck.DefaultTest do
       assert result.checks.oban_orphans == "error"
       assert result.ready == false
       assert result.status == baseline.status
+    end
+
+    test "TC-34.2.3: an unresponsive queue producer is still a hard error (retained behavior) — real Oban.check_queue/1, no DI seam, no mocking" do
+      # check_oban/0 is completely UNCHANGED by this story — it still calls the
+      # real `Oban.check_queue(queue: :default)` with no DI seam. Under this
+      # suite's `testing: :inline` Oban config (config/test.exs) there is no live
+      # queue producer registered, so the real call genuinely returns `nil`
+      # (verified directly: `Oban.check_queue(queue: :default) == nil` here) —
+      # exercising check_oban/0's existing `_ -> {"error"}` hard-error branch for
+      # real, not via a mock. This is the actual "queue-responsive ping still
+      # hard-errors" case the story's TC-34.2.3 asks for.
+      assert Oban.check_queue(queue: :default) == nil
+
+      assert {:ok, result} = Default.check()
+
+      assert result.checks.oban == "error"
+      assert result.status == "degraded"
+      assert result.ready == false
     end
 
     test "TC-34.2.1 (real rows, end-to-end): real orphaned oban_jobs rows counted via the real query (no Mox override) degrade checks.oban_orphans and flip ready" do
@@ -177,15 +224,20 @@ defmodule Loopctl.HealthCheck.DefaultTest do
       |> Repo.insert!()
 
       # No Mox.expect here — `stub_all_defaults/0` (data_case.ex) delegates
-      # `Loopctl.MockObanOrphanCountChecker.count_oban_executing_orphans/0` to the
-      # REAL `ScaleMetrics.count_oban_executing_orphans/0`, so `Default.check/0`
-      # exercises the full chain: real rows -> real query -> real count -> ready=false.
+      # `Loopctl.MockObanOrphanCountChecker.cached_executing_orphan_count/0` to a
+      # fresh call to the REAL `ScaleMetrics.count_oban_executing_orphans/0`
+      # (deliberately NOT the `:persistent_term` cache — see the stub's comment),
+      # so `Default.check/0` exercises the full chain: real rows -> real query ->
+      # real count -> ready=false, scoped to this test's own sandboxed transaction.
       assert {:ok, result} = Default.check()
 
       assert result.checks.oban_orphans == "error"
-      assert %{oban_orphans: reason} = result.reasons
-      assert reason =~ "11"
-      assert reason =~ "10"
+
+      # Review finding: the exact count/threshold are NOT disclosed publicly.
+      assert result.reasons == %{
+               oban_orphans: "oban executing-orphan count exceeds configured threshold"
+             }
+
       assert result.ready == false
     end
   end

--- a/test/loopctl/telemetry/oban_metrics_poller_test.exs
+++ b/test/loopctl/telemetry/oban_metrics_poller_test.exs
@@ -32,6 +32,13 @@ defmodule Loopctl.Telemetry.ObanMetricsPollerTest do
       failure (no metric corruption), and the poll-failure counter
       (`loopctl.oban.poll.error.count`) fires instead.
 
+  Also covers `cached_executing_orphan_count/0` (US-34.2 review finding): the
+  `:persistent_term` cache `poll_oban_executing_orphans/0` writes on every
+  SUCCESSFUL poll, which `Loopctl.HealthCheck.Default.check_oban_orphans/0` reads
+  instead of issuing its own fresh query — `:not_yet_polled` before the first
+  poll, `{:ok, count}` after, and a FAILED poll leaving the prior cached value in
+  place (same staleness semantics as the `last_value/2` gauge it also feeds).
+
   `oban_jobs` is a GLOBAL table (no `tenant_id` column). Both pollers now query
   it via `Loopctl.Repo` (review finding — moved off the tiny 3-connection
   `Loopctl.AdminRepo` pool, since `oban_jobs` has no RLS policy so the RLS-role
@@ -307,6 +314,58 @@ defmodule Loopctl.Telemetry.ObanMetricsPollerTest do
       assert ScaleMetrics.poll_oban_executing_orphans() == :ok
 
       assert_receive {:oban_orphan, %{count: ^direct_count}}, 1000
+    end
+  end
+
+  describe "cached_executing_orphan_count/0 (US-34.2 review finding — health-check reuse of the poller's cache)" do
+    test "returns :not_yet_polled before any poll has ever completed" do
+      :persistent_term.erase({ScaleMetrics, :cached_executing_orphan_count})
+
+      assert ScaleMetrics.cached_executing_orphan_count() == :not_yet_polled
+    end
+
+    test "returns {:ok, count} reflecting the last successful poll, without issuing a fresh query" do
+      threshold_minutes = ScaleMetrics.oban_metrics_orphan_threshold_minutes()
+      now = DateTime.utc_now()
+
+      insert_job(
+        state: "executing",
+        queue: "default",
+        attempted_at: DateTime.add(now, -(threshold_minutes + 5) * 60, :second)
+      )
+
+      assert ScaleMetrics.poll_oban_executing_orphans() == :ok
+      assert ScaleMetrics.cached_executing_orphan_count() == {:ok, 1}
+    end
+
+    test "a FAILED poll leaves the prior cached value in place (same staleness semantics as the last_value gauge)" do
+      threshold_minutes = ScaleMetrics.oban_metrics_orphan_threshold_minutes()
+      now = DateTime.utc_now()
+
+      insert_job(
+        state: "executing",
+        queue: "default",
+        attempted_at: DateTime.add(now, -(threshold_minutes + 5) * 60, :second)
+      )
+
+      assert ScaleMetrics.poll_oban_executing_orphans() == :ok
+      assert ScaleMetrics.cached_executing_orphan_count() == {:ok, 1}
+
+      # Force the NEXT poll to fail (same technique as "poller defensiveness"
+      # below): drop this test process's sandbox ownership so its next Repo call
+      # raises a genuine DBConnection.OwnershipError.
+      Sandbox.mode(Loopctl.Repo, :manual)
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert ScaleMetrics.poll_oban_executing_orphans() == :ok
+        end)
+
+      assert log =~ "Oban executing-orphan poll failed"
+
+      # The cache retains the last SUCCESSFUL value — never resets to 0/unknown
+      # just because a poll cycle failed.
+      assert ScaleMetrics.cached_executing_orphan_count() == {:ok, 1}
     end
   end
 

--- a/test/loopctl/telemetry/oban_metrics_poller_test.exs
+++ b/test/loopctl/telemetry/oban_metrics_poller_test.exs
@@ -255,6 +255,61 @@ defmodule Loopctl.Telemetry.ObanMetricsPollerTest do
     end
   end
 
+  describe "count_oban_executing_orphans/0 (US-34.2, AC-34.2.3 — extracted for reuse by the health check)" do
+    test "returns the orphan count directly (not just via telemetry), counting only the stale executing job" do
+      threshold_minutes = ScaleMetrics.oban_metrics_orphan_threshold_minutes()
+      now = DateTime.utc_now()
+
+      insert_job(
+        state: "executing",
+        queue: "default",
+        attempted_at: DateTime.add(now, -(threshold_minutes + 5) * 60, :second)
+      )
+
+      insert_job(
+        state: "executing",
+        queue: "default",
+        attempted_at: DateTime.add(now, -1, :second)
+      )
+
+      assert ScaleMetrics.count_oban_executing_orphans() == 1
+    end
+
+    test "returns 0 when there are no stale executing jobs" do
+      assert ScaleMetrics.count_oban_executing_orphans() == 0
+    end
+
+    test "poll_oban_executing_orphans/0 still emits the SAME count this function computes (unchanged behavior after the extraction)" do
+      threshold_minutes = ScaleMetrics.oban_metrics_orphan_threshold_minutes()
+      now = DateTime.utc_now()
+
+      insert_job(
+        state: "executing",
+        queue: "default",
+        attempted_at: DateTime.add(now, -(threshold_minutes + 5) * 60, :second)
+      )
+
+      test_pid = self()
+      handler_id = "test-oban-orphan-reuse-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler_id,
+        [:loopctl, :oban, :jobs, :executing_orphan, :count],
+        fn _event, measurements, _metadata, _config ->
+          send(test_pid, {:oban_orphan, measurements})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      direct_count = ScaleMetrics.count_oban_executing_orphans()
+      assert ScaleMetrics.poll_oban_executing_orphans() == :ok
+
+      assert_receive {:oban_orphan, %{count: ^direct_count}}, 1000
+    end
+  end
+
   describe "poller defensiveness (AC-34.1.3, TC-34.1.3)" do
     # DataCase's setup checks Repo out in :shared mode (this whole file is
     # async: false), under which EVERY process — including this test process for

--- a/test/loopctl_web/controllers/health_controller_test.exs
+++ b/test/loopctl_web/controllers/health_controller_test.exs
@@ -110,6 +110,25 @@ defmodule LoopctlWeb.HealthControllerTest do
       assert conn.status == 200
       assert json_response(conn, 200)["status"] == "ok"
     end
+
+    test "stays 200 even when readiness (Oban orphan backlog) is false — a queue backlog must not depool a node (AC-34.2.2)",
+         %{conn: conn} do
+      expect(Loopctl.MockHealthChecker, :check, fn ->
+        {:ok,
+         %{
+           status: "ok",
+           ready: false,
+           version: "0.1.0",
+           checks: %{database: "ok", oban: "ok", scale_alerts: "ok", oban_orphans: "error"},
+           reasons: %{oban_orphans: "oban executing-orphan count 11 exceeds threshold 10"}
+         }}
+      end)
+
+      conn = get(conn, "/health")
+
+      assert conn.status == 200
+      assert json_response(conn, 200)["status"] == "ok"
+    end
   end
 
   describe "GET /health/ready (US-32.4)" do
@@ -149,6 +168,27 @@ defmodule LoopctlWeb.HealthControllerTest do
       body = json_response(conn, 503)
       assert body["ready"] == false
       assert body["reasons"]["scale_alerts"] =~ "SCALE_ALERT_WEBHOOK_URL"
+    end
+
+    test "returns 503 when the Oban orphan backlog exceeds its threshold even though liveness is ok (AC-34.2.2)",
+         %{conn: conn} do
+      expect(Loopctl.MockHealthChecker, :check, fn ->
+        {:ok,
+         %{
+           status: "ok",
+           ready: false,
+           version: "0.1.0",
+           checks: %{database: "ok", oban: "ok", scale_alerts: "ok", oban_orphans: "error"},
+           reasons: %{oban_orphans: "oban executing-orphan count 11 exceeds threshold 10"}
+         }}
+      end)
+
+      conn = get(conn, "/health/ready")
+
+      assert conn.status == 503
+      body = json_response(conn, 503)
+      assert body["ready"] == false
+      assert body["reasons"]["oban_orphans"] =~ "exceeds threshold"
     end
 
     test "returns 503 when the underlying liveness is degraded too", %{conn: conn} do

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -18,6 +18,7 @@ defmodule Loopctl.DataCase do
 
   alias Ecto.Adapters.SQL.Sandbox
   alias Loopctl.Telemetry.ScaleAlerts
+  alias Loopctl.Telemetry.ScaleMetrics
   alias Loopctl.Webhooks.ReqDelivery
 
   using do
@@ -79,6 +80,13 @@ defmodule Loopctl.DataCase do
     # degraded-branch test overrides this with Mox.expect/3.
     Mox.stub(Loopctl.MockScaleAlertsConfigChecker, :config_status, fn ->
       ScaleAlerts.config_status()
+    end)
+
+    # US-34.2: default delegates to the real count_oban_executing_orphans/0 so the
+    # healthy path (no orphans present) is exercised unchanged. The degraded-branch
+    # test overrides this with Mox.expect/3.
+    Mox.stub(Loopctl.MockObanOrphanCountChecker, :count_oban_executing_orphans, fn ->
+      ScaleMetrics.count_oban_executing_orphans()
     end)
 
     Mox.stub(Loopctl.MockRateLimiter, :check_rate, fn _bucket, _window, _limit ->

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -82,11 +82,17 @@ defmodule Loopctl.DataCase do
       ScaleAlerts.config_status()
     end)
 
-    # US-34.2: default delegates to the real count_oban_executing_orphans/0 so the
-    # healthy path (no orphans present) is exercised unchanged. The degraded-branch
-    # test overrides this with Mox.expect/3.
-    Mox.stub(Loopctl.MockObanOrphanCountChecker, :count_oban_executing_orphans, fn ->
-      ScaleMetrics.count_oban_executing_orphans()
+    # US-34.2: default delegates to the real count_oban_executing_orphans/0 — a
+    # FRESH, per-call query scoped to THIS test's own sandboxed transaction — so
+    # the healthy path (no orphans present) and end-to-end tests inserting real
+    # `oban_jobs` rows are both exercised unchanged. Deliberately NOT
+    # `ScaleMetrics.cached_executing_orphan_count/0` (what production resolves to
+    # via the real `ScaleMetrics` module): that reads a single VM-wide
+    # `:persistent_term` slot, which is NOT sandboxed per test — stubbing the
+    # default to it would leak orphan counts across concurrently running async
+    # tests. The degraded-branch test overrides this with Mox.expect/3.
+    Mox.stub(Loopctl.MockObanOrphanCountChecker, :cached_executing_orphan_count, fn ->
+      {:ok, ScaleMetrics.count_oban_executing_orphans()}
     end)
 
     Mox.stub(Loopctl.MockRateLimiter, :check_rate, fn _bucket, _window, _limit ->

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -51,6 +51,16 @@ Mox.defmock(Loopctl.MockScaleAlertsConfigChecker,
   for: Loopctl.Telemetry.ScaleAlerts.ConfigStatusBehaviour
 )
 
+# US-34.2: Oban orphan-count DI. Lets `Loopctl.HealthCheck.Default`'s degraded
+# branch (checks.oban_orphans == "error", reasons attached, ready == false) be
+# exercised via Mox.expect/3 without inserting real `oban_jobs` rows. The
+# DataCase default stub delegates to the real
+# `Loopctl.Telemetry.ScaleMetrics.count_oban_executing_orphans/0` so every
+# existing health-check test (no orphans present) keeps passing unchanged.
+Mox.defmock(Loopctl.MockObanOrphanCountChecker,
+  for: Loopctl.Telemetry.ScaleMetrics.OrphanCountBehaviour
+)
+
 # US-27.3: the DBErrorBackstop test seam is a REAL plug (Loopctl.Test.BackstopRouter,
 # wired via config/test.exs), NOT a Mox mock — so the production router stays on
 # the hot path for every request and the catch/log/sanitize path is exercised by

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -53,10 +53,14 @@ Mox.defmock(Loopctl.MockScaleAlertsConfigChecker,
 
 # US-34.2: Oban orphan-count DI. Lets `Loopctl.HealthCheck.Default`'s degraded
 # branch (checks.oban_orphans == "error", reasons attached, ready == false) be
-# exercised via Mox.expect/3 without inserting real `oban_jobs` rows. The
-# DataCase default stub delegates to the real
-# `Loopctl.Telemetry.ScaleMetrics.count_oban_executing_orphans/0` so every
-# existing health-check test (no orphans present) keeps passing unchanged.
+# exercised via Mox.expect/3 without inserting real `oban_jobs` rows. Production
+# (no Mox override) resolves to the real `Loopctl.Telemetry.ScaleMetrics`, whose
+# `cached_executing_orphan_count/0` reads the `:persistent_term` value US-34.1's
+# poller last cached (review finding — avoids a fresh DB query per health-check
+# call). The DataCase default stub instead delegates to the real, freshly-queried
+# `count_oban_executing_orphans/0` so every existing health-check test (no
+# orphans present, or real rows inserted within the test's own sandboxed
+# transaction) keeps passing unchanged and isolated.
 Mox.defmock(Loopctl.MockObanOrphanCountChecker,
   for: Loopctl.Telemetry.ScaleMetrics.OrphanCountBehaviour
 )


### PR DESCRIPTION
## US-34.2 — Surface Oban orphan/queue health in the /health degraded path

Surfaces Oban orphan/queue health signals in the readiness check so the `/health` endpoint reports `degraded` when the executing-orphan count breaches configured thresholds.

### Changes
- `health_check/default.ex`: incorporate Oban orphan/queue health into the readiness/degraded path, reusing the cached orphan count.
- `telemetry/scale_metrics.ex` + `scale_metrics/orphan_count_behaviour.ex`: orphan-count source behind a behaviour for DI/testability.
- `health_controller.ex`: expose the degraded signal; redact exact figures.
- Config wiring in `config/config.exs` and `config/test.exs`; test mock in `test/support/mocks.ex` and `data_case.ex`.
- Tests: `default_test.exs`, `oban_metrics_poller_test.exs`, `health_controller_test.exs` (incl. TC-34.2.3 mapping fix).

### Review fixes applied
- Reuse cached orphan count instead of re-querying.
- Redact exact orphan figures in the public health payload.
- Fix TC-34.2.3 mapping.