### PR TITLE
Three ScaleAlerts signals: Repo queue_time p95, job discard/retry rate, provider-error rate

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -132,7 +132,13 @@ config :loopctl,
   scale_alert_timeout_rate_per_min: 5,
   scale_alert_p95_latency_ms: 2_000,
   scale_alert_under_fill_rate_per_min: 30,
-  scale_alert_renotify_interval_ms: 15 * 60_000
+  scale_alert_renotify_interval_ms: 15 * 60_000,
+  # US-34.3: three additional signals (documented defaults) — Repo checkout
+  # queue_time p95 (ms), fleet-wide Oban discard/retry rate (events/min), and
+  # LLM/embedding provider-error rate (events/min).
+  scale_alert_queue_time_p95_ms: 500,
+  scale_alert_oban_discard_rate_per_min: 10,
+  scale_alert_provider_error_rate_per_min: 10
 
 # US-33.3: bounded TTL (ms) for the ETS read-through api-key cache. This is the
 # defense-in-depth backstop, NOT the primary invalidation — every revoke/rotate/

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -243,6 +243,22 @@ if config_env() == :prod do
          :scale_alert_renotify_interval_ms,
          String.to_integer(System.get_env("SCALE_ALERT_RENOTIFY_INTERVAL_MS") || "900000")
 
+  # US-34.3: three additional ScaleAlerts signals — Repo checkout queue_time p95
+  # (ms), fleet-wide Oban discard/retry rate (events/min), and LLM/embedding
+  # provider-error rate (events/min). Same tunable-per-environment pattern as the
+  # original three thresholds above.
+  config :loopctl,
+         :scale_alert_queue_time_p95_ms,
+         String.to_integer(System.get_env("SCALE_ALERT_QUEUE_TIME_P95_MS") || "500")
+
+  config :loopctl,
+         :scale_alert_oban_discard_rate_per_min,
+         String.to_integer(System.get_env("SCALE_ALERT_OBAN_DISCARD_RATE_PER_MIN") || "10")
+
+  config :loopctl,
+         :scale_alert_provider_error_rate_per_min,
+         String.to_integer(System.get_env("SCALE_ALERT_PROVIDER_ERROR_RATE_PER_MIN") || "10")
+
   config :loopctl, Loopctl.HeavyReadRepo,
     url: admin_database_url,
     pool_size: String.to_integer(System.get_env("HEAVY_READ_POOL_SIZE") || "8"),

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -7309,6 +7309,15 @@ defmodule Loopctl.Knowledge do
   the proposal gate route through it too (review #4) so circuit-open is both
   respected AND contributed to.
 
+  It is ALSO the single choke point for the `[:loopctl, :llm, :provider_error]`
+  telemetry signal's embedding half (US-34.3 AC-34.3.3, review MED #1): both Oban
+  workers (`ArticleEmbeddingWorker`/`MemoryEmbeddingWorker`) AND every query-time
+  caller (combined/semantic search, novelty scoring, `Memory.recall/2`, promotion
+  near-dup lookup) funnel through here, so recording the signal in
+  `run_embedding_task/3` — rather than per-worker after this function returns —
+  covers every embedding path exactly once, with the same breaker-countable gate
+  (a per-tenant 4xx never contributes) and no double-count.
+
   `opts`:
     * `:timeout` — Task.yield budget in ms (default `#{@embedding_yield_ms}`).
   """
@@ -7351,17 +7360,42 @@ defmodule Loopctl.Knowledge do
 
       {:ok, {:error, reason} = err} ->
         maybe_record_failure(tenant_id, reason)
+        maybe_record_provider_error(reason)
         err
 
       _ ->
         # nil (yield timeout) or an abnormal task exit — a provider/infra failure.
         record_failure(tenant_id)
+        maybe_record_provider_error(:timeout)
         {:error, :timeout}
     end
   end
 
   defp maybe_record_failure(tenant_id, reason) do
     if breaker_countable?(reason), do: record_failure(tenant_id)
+    :ok
+  end
+
+  # US-34.3 (AC-34.3.3) fix (review MED #1): the SINGLE choke point for the
+  # embedding half of the `[:loopctl, :llm, :provider_error]` signal. Both Oban
+  # workers (`ArticleEmbeddingWorker`/`MemoryEmbeddingWorker`) AND every query-time
+  # caller (combined/semantic search, novelty scoring, `Memory.recall/2`, promotion
+  # near-dup lookup) funnel through `run_embedding_task/3`, so recording here —
+  # instead of per-worker after `generate_embedding/3` returns — covers every
+  # embedding path exactly once with no double-count.
+  #
+  # Gated by the SAME `breaker_countable?/1` classification the circuit breaker
+  # uses: a per-tenant credential/quota 4xx (401/403/429) is never a systemic
+  # provider incident, so it must never inflate this fleet-wide storm signal —
+  # exactly like it must never trip the breaker. `:no_api_key` and `:circuit_open`
+  # never reach this function (handled by earlier `case` clauses in
+  # `run_embedding_task/3`), so no explicit exclusion clause is needed here.
+  defp maybe_record_provider_error(reason) do
+    if breaker_countable?(reason) do
+      class = if Loopctl.Llm.permanent_provider_error?(reason), do: :permanent, else: :transient
+      Loopctl.Llm.record_provider_error("embedding", class)
+    end
+
     :ok
   end
 

--- a/lib/loopctl/llm.ex
+++ b/lib/loopctl/llm.ex
@@ -297,10 +297,13 @@ defmodule Loopctl.Llm do
   `record_blocked/2` at all). See `Loopctl.Telemetry.ScaleMetrics`'s "AC-34.4.3
   coordination" moduledoc note.
 
-  Call this from EXACTLY ONE choke point per failure at each call site (currently
-  `ArticleEmbeddingWorker`/`MemoryEmbeddingWorker`'s embedding-provider branch, never
-  for the circuit breaker's own `:circuit_open` skip) so the emitted count matches
-  the actual failure count 1:1 — no double-counting.
+  Call this from EXACTLY ONE choke point per failure at each call site — currently
+  `ArticleEmbeddingWorker`/`MemoryEmbeddingWorker`'s embedding-provider branch
+  (`provider: "embedding"`, never for the circuit breaker's own `:circuit_open`
+  skip) and `Loopctl.Llm.Anthropic`'s shared HTTP client (`provider: "anthropic"`,
+  the ONE choke point for every Anthropic call site — content extraction/
+  classification/merge/memory-promotion) — so the emitted count matches the actual
+  failure count 1:1 — no double-counting.
 
   Emits `[:loopctl, :llm, :provider_error]` with BOUNDED metadata ONLY: `provider`
   (`"anthropic"` | `"embedding"`) and `class` (`:transient` | `:permanent`, per

--- a/lib/loopctl/llm.ex
+++ b/lib/loopctl/llm.ex
@@ -298,12 +298,16 @@ defmodule Loopctl.Llm do
   coordination" moduledoc note.
 
   Call this from EXACTLY ONE choke point per failure at each call site — currently
-  `ArticleEmbeddingWorker`/`MemoryEmbeddingWorker`'s embedding-provider branch
-  (`provider: "embedding"`, never for the circuit breaker's own `:circuit_open`
-  skip) and `Loopctl.Llm.Anthropic`'s shared HTTP client (`provider: "anthropic"`,
-  the ONE choke point for every Anthropic call site — content extraction/
-  classification/merge/memory-promotion) — so the emitted count matches the actual
-  failure count 1:1 — no double-counting.
+  `Loopctl.Knowledge.run_embedding_task/3` (`provider: "embedding"`) — the SINGLE
+  guarded entry point shared by both Oban workers (`ArticleEmbeddingWorker`/
+  `MemoryEmbeddingWorker`) AND every query-time embedding caller (combined/semantic
+  search, novelty scoring, `Memory.recall/2`, promotion near-dup lookup), gated by
+  the same `breaker_countable?/1` classification the circuit breaker uses so a
+  per-tenant 4xx never contributes, and never for the circuit breaker's own
+  `:circuit_open` skip — and `Loopctl.Llm.Anthropic`'s shared HTTP client
+  (`provider: "anthropic"`, the ONE choke point for every Anthropic call site —
+  content extraction/classification/merge/memory-promotion) — so the emitted count
+  matches the actual failure count 1:1 — no double-counting.
 
   Emits `[:loopctl, :llm, :provider_error]` with BOUNDED metadata ONLY: `provider`
   (`"anthropic"` | `"embedding"`) and `class` (`:transient` | `:permanent`, per

--- a/lib/loopctl/llm.ex
+++ b/lib/loopctl/llm.ex
@@ -284,6 +284,46 @@ defmodule Loopctl.Llm do
       :ok
   end
 
+  @doc """
+  Records a GENUINE provider failure — a real 4xx/5xx/transport/timeout error
+  returned by a provider call that WAS ACTUALLY ATTEMPTED (a key was configured and
+  present). US-34.3 (AC-34.3.3)'s provider-error-rate `Loopctl.Telemetry.ScaleAlerts`
+  signal windows this event.
+
+  Distinct from `record_blocked/2`, which fires for a MISSING-key config state
+  checked BEFORE any provider call — conflating the two would both false-page (a
+  keyless tenant looks like a provider incident) and mask the real incident class
+  (a genuine 429/5xx/transport storm on a tenant WITH a key never touches
+  `record_blocked/2` at all). See `Loopctl.Telemetry.ScaleMetrics`'s "AC-34.4.3
+  coordination" moduledoc note.
+
+  Call this from EXACTLY ONE choke point per failure at each call site (currently
+  `ArticleEmbeddingWorker`/`MemoryEmbeddingWorker`'s embedding-provider branch, never
+  for the circuit breaker's own `:circuit_open` skip) so the emitted count matches
+  the actual failure count 1:1 — no double-counting.
+
+  Emits `[:loopctl, :llm, :provider_error]` with BOUNDED metadata ONLY: `provider`
+  (`"anthropic"` | `"embedding"`) and `class` (`:transient` | `:permanent`, per
+  `permanent_provider_error?/1`) — NEVER `tenant_id`, an article/memory id, or any
+  provider response body (the caller has already run the reason through
+  `Loopctl.Llm.ProviderError.sanitize/1` before classifying it). Best-effort: a
+  telemetry failure never propagates to the caller (mirrors `record_blocked/2`).
+  """
+  @spec record_provider_error(String.t(), :transient | :permanent) :: :ok
+  def record_provider_error(provider, class)
+      when provider in ["anthropic", "embedding"] and class in [:transient, :permanent] do
+    :telemetry.execute([:loopctl, :llm, :provider_error], %{count: 1}, %{
+      provider: provider,
+      class: class
+    })
+
+    :ok
+  rescue
+    e ->
+      Logger.error("Loopctl.Llm.record_provider_error failed: #{Exception.message(e)}")
+      :ok
+  end
+
   # The two BYO credentials are SEPARATE — name the right one in the block log so an
   # operator isn't misled into checking the Anthropic key for an embedding block
   # (review MED #3). The structured audit already carries the exact operation.

--- a/lib/loopctl/llm/anthropic.ex
+++ b/lib/loopctl/llm/anthropic.ex
@@ -120,14 +120,18 @@ defmodule Loopctl.Llm.Anthropic do
         # A 200 with the wrong shape can STILL be a misconfigured/compromised
         # endpoint echoing a masked key fragment in an error-shaped body (review
         # CRIT #1). Sanitize it exactly like a non-200 — never return the raw body.
-        {:error, ProviderError.sanitize({:api_error, 200, body})}
+        reason = {:api_error, 200, body}
+        record_provider_error(reason)
+        {:error, ProviderError.sanitize(reason)}
 
       {:ok, %{status: status, body: body}} ->
         Logger.warning("Loopctl.Llm.Anthropic: API error (op=#{operation}, status=#{status})")
         # SANITIZE the provider error body (review #11): it can echo a masked key
         # fragment, and callers surface it as an Oban `{:error, reason}` persisted
         # into oban_jobs.errors. Drop the body; keep only the status.
-        {:error, ProviderError.sanitize({:api_error, status, body})}
+        reason = {:api_error, status, body}
+        record_provider_error(reason)
+        {:error, ProviderError.sanitize(reason)}
 
       {:error, reason} ->
         # Never inspect the raw transport reason (review MED #4) — log a value-free
@@ -137,8 +141,24 @@ defmodule Loopctl.Llm.Anthropic do
             "#{ProviderError.log_tag({:request_failed, reason})})"
         )
 
+        record_provider_error({:request_failed, reason})
         {:error, {:request_failed, reason}}
     end
+  end
+
+  # Review fix (MEDIUM, AC-34.3.3): this is the ONE choke point for EVERY Anthropic
+  # call site (content extraction/classification/merge/memory-promotion all funnel
+  # through `message/5` -> `call/7` -> `post/7`), so wiring the genuine-provider-error
+  # signal HERE — rather than duplicating it across each of the 4+ call sites —
+  # guarantees a real 429/5xx/transport storm on the primary Anthropic surface (the
+  # incident class US-34.3's story background names) is never invisible to
+  # `[:loopctl, :llm, :provider_error]`. Classifies on the RAW (pre-sanitize) reason,
+  # mirroring `ArticleEmbeddingWorker`/`MemoryEmbeddingWorker`'s own
+  # `record_provider_error/1` helper — `Llm.record_provider_error/2` itself only
+  # windows bounded `provider`/`class` metadata, never the reason term.
+  defp record_provider_error(reason) do
+    class = if Llm.permanent_provider_error?(reason), do: :permanent, else: :transient
+    Llm.record_provider_error("anthropic", class)
   end
 
   # BEST-EFFORT usage recording (review #3). The Anthropic call has already

--- a/lib/loopctl/llm/anthropic.ex
+++ b/lib/loopctl/llm/anthropic.ex
@@ -121,7 +121,17 @@ defmodule Loopctl.Llm.Anthropic do
         # endpoint echoing a masked key fragment in an error-shaped body (review
         # CRIT #1). Sanitize it exactly like a non-200 — never return the raw body.
         reason = {:api_error, 200, body}
-        record_provider_error(reason)
+        # Review fix (LOW): deliberately do NOT `record_provider_error/1` here. A 200
+        # is, semantically, a provider SUCCESS — `permanent_provider_error?/1` has no
+        # 4xx/5xx clause for it, so it would fall through and window into
+        # `provider_error_rate` (AC-34.3.3's genuine-OUTAGE storm signal) as
+        # `:transient`. A legitimate-but-unexpected response shape (a non-text first
+        # content block, or empty content on a refusal/max_tokens stop) is not a
+        # 429/5xx/transport incident, so counting it would over-count the storm
+        # signal on a real provider-SUCCESS path. The `Logger.warning` above plus the
+        # sanitized `{:error, _}` return (still routed through the same
+        # possible-compromised-endpoint handling as review CRIT #1) already keep this
+        # anomaly observable/actionable without polluting the outage counter.
         {:error, ProviderError.sanitize(reason)}
 
       {:ok, %{status: status, body: body}} ->

--- a/lib/loopctl/telemetry/scale_alerts.ex
+++ b/lib/loopctl/telemetry/scale_alerts.ex
@@ -90,28 +90,45 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
       (native units, the SAME metric US-33.1's `loopctl.repo.checkout.queue_time`
       distribution reads). Bucketed exactly like the heavy-read p95 (SAME `@buckets`,
       `bucket_index/1`), but into a SEPARATE counter set (`{:qt_bucket, idx}` /
-      `:qt_total`) so it never collides with the heavy-read histogram.
-    * **(b) fleet-wide Oban job discard/retry rate** — sourced from
-      `[:oban, :job, :exception]`, which Oban's own `Executor` emits for BOTH a
-      retryable failure (`meta.state == :failure`) AND an exhausted job that just
-      converted to a terminal discard (`meta.state == :discard`, normalized from
-      `:exhausted`) — so a single unconditional counter (`:oban_discard_count`)
-      already captures both halves of "discard/retry rate" without any metadata
-      filtering. `oban_jobs` has no tenant dimension on this event (only bounded
-      `worker`/`queue`/`state` labels, none of which we tag — the counter is a pure
-      increment, mirroring `:under_fill_count`).
+      `:qt_total`) so it never collides with the heavy-read histogram. **`:queue_time`
+      is SKIPPED (not defaulted to 0) when absent from `measurements`** (review fix,
+      HIGH): Ecto's `log_measurements/3` drops a measurement key entirely when its
+      value is `nil`, which happens whenever the connection was already checked out
+      (e.g. every statement after the first inside a transaction — the common case
+      under loopctl's per-request RLS `SET LOCAL` transactions). Counting that absent
+      case as a synthetic 0ms sample would flood the histogram and dilute the p95
+      downward, masking the exact checkout-contention storm this signal exists to
+      catch. Mirrors the `Telemetry.Metrics` distribution in `ScaleMetrics`, which
+      likewise skips a datapoint when the measurement is absent.
+    * **(b) fleet-wide Oban job discard/retry rate** — sourced from BOTH
+      `[:oban, :job, :exception]` (Oban's own `Executor` emits this for a retryable
+      failure, `meta.state == :failure`, AND an exhausted job that just converted to
+      a terminal discard, `meta.state == :discard`, normalized from `:exhausted`) AND
+      `[:oban, :job, :stop]` filtered to `meta.state in [:discard, :cancelled]`
+      (review fix, MEDIUM): a DELIBERATE `{:discard, reason}` / bare `:discard` or
+      `{:cancel, reason}` return — e.g. `ArticleEmbeddingWorker`/
+      `MemoryEmbeddingWorker`'s own permanent-provider-error discard path — is
+      terminal from its FIRST attempt and never touches `:exception` at all; only the
+      `:stop` event covers it. Together the two attachments genuinely cover both
+      halves of "discard/retry rate": every retryable failure/exhaustion (`:exception`)
+      and every deliberate discard/cancel (`:stop`). `:success`/`:snoozed` `:stop`
+      states are excluded. `oban_jobs` has no tenant dimension on either event (only
+      bounded `worker`/`queue`/`state` labels, none of which we tag — the counter is a
+      pure increment, mirroring `:under_fill_count`).
     * **(c) LLM/embedding provider-error rate** — sourced from the NEW
       `[:loopctl, :llm, :provider_error]` event (`Loopctl.TelemetryEvents.llm_provider_error/0`),
-      emitted from EXACTLY ONE choke point, `Loopctl.Llm.record_provider_error/2`,
-      by `ArticleEmbeddingWorker`/`MemoryEmbeddingWorker` on a genuine provider
-      failure. **Deliberately NOT `[:loopctl, :llm, :blocked]`**: that event fires
-      when a tenant has no BYO key configured (a config state checked BEFORE any
-      provider call), so windowing it as a provider-error proxy would false-page on
-      keyless tenants while missing a real 429/5xx/transport storm entirely (see
-      `Loopctl.Telemetry.ScaleMetrics`'s "AC-34.4.3 coordination" note). A single
-      unconditional counter (`:provider_error_count`) mirrors `:under_fill_count`;
-      the emit site alone decides transient vs permanent (`:class` metadata, unused
-      by this counter, which windows total volume).
+      emitted from the shared `Loopctl.Llm.Anthropic` HTTP client (every Anthropic
+      call site — content extraction/classification/merge/memory-promotion — funnels
+      through it) AND from `ArticleEmbeddingWorker`/`MemoryEmbeddingWorker`'s
+      embedding-provider branch, both via `Loopctl.Llm.record_provider_error/2`, on a
+      genuine provider failure. **Deliberately NOT `[:loopctl, :llm, :blocked]`**: that
+      event fires when a tenant has no BYO key configured (a config state checked
+      BEFORE any provider call), so windowing it as a provider-error proxy would
+      false-page on keyless tenants while missing a real 429/5xx/transport storm
+      entirely (see `Loopctl.Telemetry.ScaleMetrics`'s "AC-34.4.3 coordination" note).
+      A single unconditional counter (`:provider_error_count`) mirrors
+      `:under_fill_count`; the emit site alone decides transient vs permanent
+      (`:class` metadata, unused by this counter, which windows total volume).
 
   All three plug into the exact same `step/8` / `step_p95/8` edge-fire helpers and
   `notify/7` delivery path — no new delivery code, no change to the existing three
@@ -151,6 +168,14 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
   # US-34.3: the three additional signals.
   @repo_query_event [:loopctl, :repo, :query]
   @oban_exception_event [:oban, :job, :exception]
+  # Review fix (MEDIUM): a deliberate `{:discard, reason}` / bare `:discard` return
+  # (loopctl's OWN permanent-failure path, e.g. `ArticleEmbeddingWorker`/
+  # `MemoryEmbeddingWorker` on a revoked key) — and an explicit `{:cancel, reason}` —
+  # is emitted by Oban's Executor as `[:oban, :job, :stop]` with `state: :discard` /
+  # `:cancelled`, NEVER `[:oban, :job, :exception]` (that event is reserved for
+  # `:failure`/`:exhausted`). Without this, a mass permanent-discard storm (e.g. a
+  # revoked/invalid provider key) increments NOTHING on this "discard rate" signal.
+  @oban_stop_event [:oban, :job, :stop]
   @provider_error_event [:loopctl, :llm, :provider_error]
 
   # The latency buckets — the SAME bounded set as the ScaleMetrics histogram so the
@@ -453,6 +478,7 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
       @heavy_read_event,
       @repo_query_event,
       @oban_exception_event,
+      @oban_stop_event,
       @provider_error_event
     ]
 
@@ -507,34 +533,70 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
       :ok
   end
 
-  # US-34.3 (AC-34.3.1): mirrors the `@heavy_read_event` clause EXACTLY, but reads
+  # US-34.3 (AC-34.3.1): mirrors the `@heavy_read_event` clause, but reads
   # `measurements.queue_time` (Ecto's per-query connection-checkout wait, native
   # units) and writes to a SEPARATE bucket set (`{:qt_bucket, idx}` / `:qt_total`) so
   # it never collides with the heavy-read histogram.
+  #
+  # Review fix (HIGH): `queue_time` is DROPPED by Ecto's own `log_measurements/3`
+  # (`deps/ecto_sql/lib/ecto/adapters/sql.ex`) whenever the connection was already
+  # checked out — i.e. every statement inside a transaction after the first checkout.
+  # loopctl runs virtually every tenant query inside a transaction (RLS `SET LOCAL`
+  # per CLAUDE.md), so the majority of these events carry NO `:queue_time` key at
+  # all (absent, not `nil`). Defaulting the absent case to `0` (the prior behavior)
+  # floods the histogram with synthetic 0ms samples and biases the bucketed p95
+  # sharply downward — during a real checkout-contention storm (the leading
+  # indicator AC-34.3.1 exists to surface), genuinely-high-queue_time samples can be
+  # a small minority, so the diluted p95 may never cross the threshold. Skip the
+  # sample entirely when `:queue_time` is absent — mirroring `Loopctl.Telemetry.
+  # ScaleMetrics`'s `Telemetry.Metrics` distribution, which silently skips a
+  # datapoint when its measurement key is absent — instead of counting a phantom 0ms
+  # checkout.
   def handle_event(@repo_query_event, measurements, _metadata, %{table: table}) do
-    total_native = Map.get(measurements, :queue_time, 0)
-    duration_ms = System.convert_time_unit(total_native, :native, :millisecond)
-    idx = bucket_index(duration_ms)
+    case Map.fetch(measurements, :queue_time) do
+      :error ->
+        :ok
 
-    :ets.update_counter(table, {:qt_bucket, idx}, 1)
-    :ets.update_counter(table, :qt_total, 1)
-    :ok
+      {:ok, total_native} ->
+        duration_ms = System.convert_time_unit(total_native, :native, :millisecond)
+        idx = bucket_index(duration_ms)
+
+        :ets.update_counter(table, {:qt_bucket, idx}, 1)
+        :ets.update_counter(table, :qt_total, 1)
+        :ok
+    end
   rescue
     e ->
       Logger.error("ScaleAlerts repo_query handler error: #{Exception.message(e)}")
       :ok
   end
 
-  # US-34.3 (AC-34.3.2): fleet-wide Oban job discard/retry rate. Oban's own Executor
-  # emits `[:oban, :job, :exception]` for BOTH a retryable failure and an exhausted
-  # job converting to a terminal discard, so a single unconditional counter already
-  # covers "discard/retry rate" — no metadata filtering, mirrors `:under_fill_count`.
+  # US-34.3 (AC-34.3.2): fleet-wide Oban job discard/retry rate, half (a). Oban's own
+  # Executor emits `[:oban, :job, :exception]` for a retryable failure AND an
+  # exhausted job converting to a terminal discard — no metadata filtering, mirrors
+  # `:under_fill_count`. See the `@oban_stop_event` clause below for half (b): a
+  # DELIBERATE discard/cancel, which this event never observes.
   def handle_event(@oban_exception_event, _measurements, _metadata, %{table: table}) do
     :ets.update_counter(table, :oban_discard_count, 1)
     :ok
   rescue
     e ->
       Logger.error("ScaleAlerts oban_exception handler error: #{Exception.message(e)}")
+      :ok
+  end
+
+  # Review fix (MEDIUM, AC-34.3.2): the sibling half of the discard signal — a
+  # deliberate `{:discard, _}`/bare `:discard` or `{:cancel, _}` job return emits
+  # `[:oban, :job, :stop]` (`meta.state` `:discard` / `:cancelled`), never the
+  # `:exception` event above. Only these two terminal, non-retryable states count;
+  # `:success` and `:snoozed` (the OTHER `:stop` states) are explicitly excluded.
+  def handle_event(@oban_stop_event, _measurements, %{state: state}, %{table: table})
+      when state in [:discard, :cancelled] do
+    :ets.update_counter(table, :oban_discard_count, 1)
+    :ok
+  rescue
+    e ->
+      Logger.error("ScaleAlerts oban_stop handler error: #{Exception.message(e)}")
       :ok
   end
 

--- a/lib/loopctl/telemetry/scale_alerts.ex
+++ b/lib/loopctl/telemetry/scale_alerts.ex
@@ -79,6 +79,44 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
   URL is `nil` alerting is OFF (opt-in): the breach is logged at `:warning` synchronously
   and nothing is enqueued or POSTed — this path is unchanged by US-34.5.
 
+  ## Three additional signals (US-34.3) — same machinery, no changes to the above
+
+  US-34.3 is purely additive plumbing on top of the same windowed-ETS-counter →
+  periodic `:evaluate` → edge-fire → bounded re-notify → Oban delivery pipeline. It
+  does NOT change the three signals documented above.
+
+    * **(a) primary Repo checkout `queue_time` p95** — sourced from Ecto's own query
+      event for `Loopctl.Repo`, `[:loopctl, :repo, :query]`, measurement `:queue_time`
+      (native units, the SAME metric US-33.1's `loopctl.repo.checkout.queue_time`
+      distribution reads). Bucketed exactly like the heavy-read p95 (SAME `@buckets`,
+      `bucket_index/1`), but into a SEPARATE counter set (`{:qt_bucket, idx}` /
+      `:qt_total`) so it never collides with the heavy-read histogram.
+    * **(b) fleet-wide Oban job discard/retry rate** — sourced from
+      `[:oban, :job, :exception]`, which Oban's own `Executor` emits for BOTH a
+      retryable failure (`meta.state == :failure`) AND an exhausted job that just
+      converted to a terminal discard (`meta.state == :discard`, normalized from
+      `:exhausted`) — so a single unconditional counter (`:oban_discard_count`)
+      already captures both halves of "discard/retry rate" without any metadata
+      filtering. `oban_jobs` has no tenant dimension on this event (only bounded
+      `worker`/`queue`/`state` labels, none of which we tag — the counter is a pure
+      increment, mirroring `:under_fill_count`).
+    * **(c) LLM/embedding provider-error rate** — sourced from the NEW
+      `[:loopctl, :llm, :provider_error]` event (`Loopctl.TelemetryEvents.llm_provider_error/0`),
+      emitted from EXACTLY ONE choke point, `Loopctl.Llm.record_provider_error/2`,
+      by `ArticleEmbeddingWorker`/`MemoryEmbeddingWorker` on a genuine provider
+      failure. **Deliberately NOT `[:loopctl, :llm, :blocked]`**: that event fires
+      when a tenant has no BYO key configured (a config state checked BEFORE any
+      provider call), so windowing it as a provider-error proxy would false-page on
+      keyless tenants while missing a real 429/5xx/transport storm entirely (see
+      `Loopctl.Telemetry.ScaleMetrics`'s "AC-34.4.3 coordination" note). A single
+      unconditional counter (`:provider_error_count`) mirrors `:under_fill_count`;
+      the emit site alone decides transient vs permanent (`:class` metadata, unused
+      by this counter, which windows total volume).
+
+  All three plug into the exact same `step/8` / `step_p95/8` edge-fire helpers and
+  `notify/7` delivery path — no new delivery code, no change to the existing three
+  signals' behavior.
+
   ## Operator / system scope — NOT tenant-scoped
 
   This component is operator/system-scoped: it observes fleet-wide degradation, not a
@@ -110,6 +148,11 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
   @under_fill_event [:loopctl, :knowledge, :vector_search, :under_fill]
   @heavy_read_event [:loopctl, :heavy_read_repo, :query]
 
+  # US-34.3: the three additional signals.
+  @repo_query_event [:loopctl, :repo, :query]
+  @oban_exception_event [:oban, :job, :exception]
+  @provider_error_event [:loopctl, :llm, :provider_error]
+
   # The latency buckets — the SAME bounded set as the ScaleMetrics histogram so the
   # bucket-based p95 here matches what Prometheus' histogram_quantile would report. A
   # value above the last bound lands in the implicit `+Inf` overflow bucket (index 9),
@@ -133,10 +176,18 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
   @default_renotify_interval_ms 15 * 60_000
   @renotify_interval_floor_ms 60_000
 
+  # US-34.3: documented DEFAULTS for the three additional signals.
+  @default_queue_time_p95_ms 500
+  @default_oban_discard_rate_per_min 10
+  @default_provider_error_rate_per_min 10
+
   @metrics %{
     timeout: "db_statement_timeout_rate",
     p95: "heavy_read_p95_latency_ms",
-    under_fill: "under_fill_rate"
+    under_fill: "under_fill_rate",
+    queue_time_p95: "repo_queue_time_p95_ms",
+    oban_discard_rate: "oban_discard_rate",
+    provider_error_rate: "provider_error_rate"
   }
 
   # --- Client API ---
@@ -212,6 +263,45 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
         :loopctl,
         :scale_alert_under_fill_rate_per_min,
         @default_under_fill_rate_per_min
+      )
+
+  @doc """
+  Repo checkout `queue_time` p95 threshold (ms, `:scale_alert_queue_time_p95_ms`,
+  US-34.3 AC-34.3.1).
+  """
+  @spec queue_time_p95_threshold() :: number()
+  def queue_time_p95_threshold,
+    do:
+      Application.get_env(
+        :loopctl,
+        :scale_alert_queue_time_p95_ms,
+        @default_queue_time_p95_ms
+      )
+
+  @doc """
+  Fleet-wide Oban job discard/retry-exception rate threshold (events/min,
+  `:scale_alert_oban_discard_rate_per_min`, US-34.3 AC-34.3.2).
+  """
+  @spec oban_discard_rate_threshold() :: number()
+  def oban_discard_rate_threshold,
+    do:
+      Application.get_env(
+        :loopctl,
+        :scale_alert_oban_discard_rate_per_min,
+        @default_oban_discard_rate_per_min
+      )
+
+  @doc """
+  LLM/embedding provider-error rate threshold (events/min,
+  `:scale_alert_provider_error_rate_per_min`, US-34.3 AC-34.3.3).
+  """
+  @spec provider_error_rate_threshold() :: number()
+  def provider_error_rate_threshold,
+    do:
+      Application.get_env(
+        :loopctl,
+        :scale_alert_provider_error_rate_per_min,
+        @default_provider_error_rate_per_min
       )
 
   @doc "The operator webhook URL (`:scale_alert_webhook_url`), or `nil` (alerting off)."
@@ -325,7 +415,10 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
        breaching: %{
          timeout: %{breaching?: false, last_notified_at: nil},
          p95: %{breaching?: false, last_notified_at: nil},
-         under_fill: %{breaching?: false, last_notified_at: nil}
+         under_fill: %{breaching?: false, last_notified_at: nil},
+         queue_time_p95: %{breaching?: false, last_notified_at: nil},
+         oban_discard_rate: %{breaching?: false, last_notified_at: nil},
+         provider_error_rate: %{breaching?: false, last_notified_at: nil}
        }
      }}
   end
@@ -354,7 +447,14 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
   # --- Telemetry attach (idempotent, per-table handler id) ---
 
   defp attach_handlers(table) do
-    events = [@db_error_event, @under_fill_event, @heavy_read_event]
+    events = [
+      @db_error_event,
+      @under_fill_event,
+      @heavy_read_event,
+      @repo_query_event,
+      @oban_exception_event,
+      @provider_error_event
+    ]
 
     case :telemetry.attach_many(handler_id(table), events, &__MODULE__.handle_event/4, %{
            table: table
@@ -407,6 +507,51 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
       :ok
   end
 
+  # US-34.3 (AC-34.3.1): mirrors the `@heavy_read_event` clause EXACTLY, but reads
+  # `measurements.queue_time` (Ecto's per-query connection-checkout wait, native
+  # units) and writes to a SEPARATE bucket set (`{:qt_bucket, idx}` / `:qt_total`) so
+  # it never collides with the heavy-read histogram.
+  def handle_event(@repo_query_event, measurements, _metadata, %{table: table}) do
+    total_native = Map.get(measurements, :queue_time, 0)
+    duration_ms = System.convert_time_unit(total_native, :native, :millisecond)
+    idx = bucket_index(duration_ms)
+
+    :ets.update_counter(table, {:qt_bucket, idx}, 1)
+    :ets.update_counter(table, :qt_total, 1)
+    :ok
+  rescue
+    e ->
+      Logger.error("ScaleAlerts repo_query handler error: #{Exception.message(e)}")
+      :ok
+  end
+
+  # US-34.3 (AC-34.3.2): fleet-wide Oban job discard/retry rate. Oban's own Executor
+  # emits `[:oban, :job, :exception]` for BOTH a retryable failure and an exhausted
+  # job converting to a terminal discard, so a single unconditional counter already
+  # covers "discard/retry rate" — no metadata filtering, mirrors `:under_fill_count`.
+  def handle_event(@oban_exception_event, _measurements, _metadata, %{table: table}) do
+    :ets.update_counter(table, :oban_discard_count, 1)
+    :ok
+  rescue
+    e ->
+      Logger.error("ScaleAlerts oban_exception handler error: #{Exception.message(e)}")
+      :ok
+  end
+
+  # US-34.3 (AC-34.3.3): genuine LLM/embedding provider-error rate, sourced from the
+  # NEW `[:loopctl, :llm, :provider_error]` event (emitted from exactly one choke
+  # point, `Loopctl.Llm.record_provider_error/2`) — deliberately NOT
+  # `[:loopctl, :llm, :blocked]` (a missing-key config signal, not a provider-error
+  # one; see the moduledoc). A single unconditional counter mirrors `:under_fill_count`.
+  def handle_event(@provider_error_event, _measurements, _metadata, %{table: table}) do
+    :ets.update_counter(table, :provider_error_count, 1)
+    :ok
+  rescue
+    e ->
+      Logger.error("ScaleAlerts provider_error handler error: #{Exception.message(e)}")
+      :ok
+  end
+
   def handle_event(_event, _measurements, _metadata, _config), do: :ok
 
   # --- Window evaluation + edge-triggered firing + bounded re-notify (US-34.5) ---
@@ -426,7 +571,12 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
 
     timeout_rate = window.timeout_count / window_min
     under_fill_rate = window.under_fill_count / window_min
-    p95 = p95_from_buckets(window)
+    p95 = p95_from_buckets(window.lat_total, window.buckets)
+
+    # US-34.3: the three additional signals, computed the SAME way as their siblings.
+    queue_time_p95 = p95_from_buckets(window.qt_total, window.qt_buckets)
+    oban_discard_rate = window.oban_discard_count / window_min
+    provider_error_rate = window.provider_error_count / window_min
 
     # A single clock read per evaluate: every metric in this tick is judged against the
     # SAME "now", so two metrics breaching in the same window re-notify in lockstep.
@@ -452,7 +602,34 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
         renotify_interval,
         insert_fn
       )
-      |> step_p95(p95, p95_latency_threshold(), url, now, renotify_interval, insert_fn)
+      |> step_p95(:p95, p95, p95_latency_threshold(), url, now, renotify_interval, insert_fn)
+      |> step(
+        :oban_discard_rate,
+        oban_discard_rate,
+        oban_discard_rate_threshold(),
+        url,
+        now,
+        renotify_interval,
+        insert_fn
+      )
+      |> step(
+        :provider_error_rate,
+        provider_error_rate,
+        provider_error_rate_threshold(),
+        url,
+        now,
+        renotify_interval,
+        insert_fn
+      )
+      |> step_p95(
+        :queue_time_p95,
+        queue_time_p95,
+        queue_time_p95_threshold(),
+        url,
+        now,
+        renotify_interval,
+        insert_fn
+      )
 
     %{state | breaching: breaching}
   end
@@ -504,12 +681,14 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
     do: now - last_notified_at >= renotify_interval
 
   # p95 is `nil` when below the sample floor — treat as "not breaching" and re-arm so a
-  # quiet window clears the breach state (a later busy window can fire again).
-  defp step_p95(breaching, nil, _threshold, _url, _now, _renotify_interval, _insert_fn),
-    do: Map.put(breaching, :p95, %{breaching?: false, last_notified_at: nil})
+  # quiet window clears the breach state (a later busy window can fire again). Takes
+  # `metric` as an explicit arg (US-34.3) so the SAME helper serves both the
+  # heavy-read p95 (`:p95`) and the repo checkout queue_time p95 (`:queue_time_p95`).
+  defp step_p95(breaching, metric, nil, _threshold, _url, _now, _renotify_interval, _insert_fn),
+    do: Map.put(breaching, metric, %{breaching?: false, last_notified_at: nil})
 
-  defp step_p95(breaching, p95, threshold, url, now, renotify_interval, insert_fn),
-    do: step(breaching, :p95, p95, threshold, url, now, renotify_interval, insert_fn)
+  defp step_p95(breaching, metric, p95, threshold, url, now, renotify_interval, insert_fn),
+    do: step(breaching, metric, p95, threshold, url, now, renotify_interval, insert_fn)
 
   # Fires the alert and stamps `last_notified_at` to `now` ONLY on a genuine successful
   # delivery/enqueue; otherwise keeps `fallback` (either `nil` for a never-notified edge
@@ -607,9 +786,22 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
   # --- Counter table helpers ---
 
   defp reset_counters(table) do
-    :ets.insert(table, [{:timeout_count, 0}, {:under_fill_count, 0}, {:lat_total, 0}])
+    :ets.insert(table, [
+      {:timeout_count, 0},
+      {:under_fill_count, 0},
+      {:lat_total, 0},
+      # US-34.3: the three additional signals' scalar counters.
+      {:qt_total, 0},
+      {:oban_discard_count, 0},
+      {:provider_error_count, 0}
+    ])
 
-    for idx <- 0..@bucket_count, do: :ets.insert(table, {{:lat_bucket, idx}, 0})
+    for idx <- 0..@bucket_count do
+      :ets.insert(table, {{:lat_bucket, idx}, 0})
+      # US-34.3: a SEPARATE bucket set for the repo checkout queue_time p95, so it
+      # never collides with the heavy-read latency histogram above.
+      :ets.insert(table, {{:qt_bucket, idx}, 0})
+    end
 
     :ok
   end
@@ -625,11 +817,21 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
     lat_total = read_zero(table, :lat_total)
     buckets = for idx <- 0..@bucket_count, do: read_zero(table, {:lat_bucket, idx})
 
+    # US-34.3: the three additional signals.
+    qt_total = read_zero(table, :qt_total)
+    qt_buckets = for idx <- 0..@bucket_count, do: read_zero(table, {:qt_bucket, idx})
+    oban_discard_count = read_zero(table, :oban_discard_count)
+    provider_error_count = read_zero(table, :provider_error_count)
+
     %Window{
       timeout_count: timeout_count,
       under_fill_count: under_fill_count,
       lat_total: lat_total,
-      buckets: buckets
+      buckets: buckets,
+      qt_total: qt_total,
+      qt_buckets: qt_buckets,
+      oban_discard_count: oban_discard_count,
+      provider_error_count: provider_error_count
     }
   end
 
@@ -651,10 +853,13 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
 
   # --- p95 from buckets (cumulative crossing of the 95th percentile) ---
 
-  defp p95_from_buckets(%Window{lat_total: lat_total}) when lat_total < @p95_min_samples, do: nil
+  # Takes the total sample count + bucket list as explicit args (US-34.3) so the SAME
+  # helper serves both the heavy-read latency histogram and the repo checkout
+  # queue_time histogram (a separate counter set, same layout).
+  defp p95_from_buckets(total, _buckets) when total < @p95_min_samples, do: nil
 
-  defp p95_from_buckets(%Window{lat_total: lat_total, buckets: buckets}) do
-    target = lat_total * 0.95
+  defp p95_from_buckets(total, buckets) do
+    target = total * 0.95
     cumulative_cross(buckets, target, 0, 0)
   end
 

--- a/lib/loopctl/telemetry/scale_alerts.ex
+++ b/lib/loopctl/telemetry/scale_alerts.ex
@@ -114,21 +114,34 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
       and every deliberate discard/cancel (`:stop`). `:success`/`:snoozed` `:stop`
       states are excluded. `oban_jobs` has no tenant dimension on either event (only
       bounded `worker`/`queue`/`state` labels, none of which we tag — the counter is a
-      pure increment, mirroring `:under_fill_count`).
+      pure increment, mirroring `:under_fill_count`). BOTH handlers additionally
+      exclude `meta.worker == "Loopctl.Workers.ScaleAlertDeliveryWorker"` (review fix,
+      LOW): without this, a degraded operator webhook — exactly the condition under
+      which alerts fire — would inflate the very "fleet-wide Oban discard rate" this
+      signal watches, self-referentially coupling the alerter's own delivery health
+      into the application signal it feeds. `worker` is the same bounded label
+      already named above (no new unbounded dimension).
     * **(c) LLM/embedding provider-error rate** — sourced from the NEW
       `[:loopctl, :llm, :provider_error]` event (`Loopctl.TelemetryEvents.llm_provider_error/0`),
       emitted from the shared `Loopctl.Llm.Anthropic` HTTP client (every Anthropic
       call site — content extraction/classification/merge/memory-promotion — funnels
-      through it) AND from `ArticleEmbeddingWorker`/`MemoryEmbeddingWorker`'s
-      embedding-provider branch, both via `Loopctl.Llm.record_provider_error/2`, on a
-      genuine provider failure. **Deliberately NOT `[:loopctl, :llm, :blocked]`**: that
+      through it) AND from `Loopctl.Knowledge.run_embedding_task/3` (review fix,
+      MEDIUM: the single guarded entry point shared by BOTH embedding Oban workers
+      — `ArticleEmbeddingWorker`/`MemoryEmbeddingWorker` — AND every query-time
+      embedding caller — combined/semantic search, novelty scoring,
+      `Memory.recall/2`, promotion near-dup lookup — so a real provider-error storm
+      hitting query-time paths is no longer under-counted), both via
+      `Loopctl.Llm.record_provider_error/2`, on a genuine provider failure.
+      **Deliberately NOT `[:loopctl, :llm, :blocked]`**: that
       event fires when a tenant has no BYO key configured (a config state checked
       BEFORE any provider call), so windowing it as a provider-error proxy would
       false-page on keyless tenants while missing a real 429/5xx/transport storm
       entirely (see `Loopctl.Telemetry.ScaleMetrics`'s "AC-34.4.3 coordination" note).
       A single unconditional counter (`:provider_error_count`) mirrors
       `:under_fill_count`; the emit site alone decides transient vs permanent
-      (`:class` metadata, unused by this counter, which windows total volume).
+      (`:class` metadata, unused by this counter, which windows total volume) —
+      gated by the same breaker-countable classification as the circuit breaker, so
+      a per-tenant 4xx credential/quota problem never contributes.
 
   All three plug into the exact same `step/8` / `step_p95/8` edge-fire helpers and
   `notify/7` delivery path — no new delivery code, no change to the existing three
@@ -177,6 +190,17 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
   # revoked/invalid provider key) increments NOTHING on this "discard rate" signal.
   @oban_stop_event [:oban, :job, :stop]
   @provider_error_event [:loopctl, :llm, :provider_error]
+
+  # Review fix (LOW): exclude ScaleAlerts' OWN delivery worker from the discard-rate
+  # signal it feeds. Without this, a degraded operator webhook — exactly the
+  # condition under which alerts fire — inflates the very "fleet-wide Oban discard
+  # rate" this signal watches, self-referentially coupling the alerter's own
+  # observability health into an application signal. `meta.job.worker` is a bounded
+  # label (mirrors the existing `state`-only filtering already applied to these two
+  # events), so filtering on it stays AC-34.3.5-compliant (no unbounded tenant/id
+  # dimension is added). `Oban.Worker.to_string/1` strips the "Elixir." prefix Oban
+  # persists on `oban_jobs.worker`.
+  @scale_alert_delivery_worker Oban.Worker.to_string(ScaleAlertDeliveryWorker)
 
   # The latency buckets — the SAME bounded set as the ScaleMetrics histogram so the
   # bucket-based p95 here matches what Prometheus' histogram_quantile would report. A
@@ -576,7 +600,8 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
   # exhausted job converting to a terminal discard — no metadata filtering, mirrors
   # `:under_fill_count`. See the `@oban_stop_event` clause below for half (b): a
   # DELIBERATE discard/cancel, which this event never observes.
-  def handle_event(@oban_exception_event, _measurements, _metadata, %{table: table}) do
+  def handle_event(@oban_exception_event, _measurements, %{worker: worker}, %{table: table})
+      when worker != @scale_alert_delivery_worker do
     :ets.update_counter(table, :oban_discard_count, 1)
     :ok
   rescue
@@ -585,13 +610,20 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
       :ok
   end
 
+  # Review fix (LOW): the alerter's OWN delivery worker — excluded above so a
+  # degraded operator webhook (exactly when alerts are firing) never inflates the
+  # discard-rate signal it feeds. See `@scale_alert_delivery_worker`.
+  def handle_event(@oban_exception_event, _measurements, _metadata, _config), do: :ok
+
   # Review fix (MEDIUM, AC-34.3.2): the sibling half of the discard signal — a
   # deliberate `{:discard, _}`/bare `:discard` or `{:cancel, _}` job return emits
   # `[:oban, :job, :stop]` (`meta.state` `:discard` / `:cancelled`), never the
   # `:exception` event above. Only these two terminal, non-retryable states count;
   # `:success` and `:snoozed` (the OTHER `:stop` states) are explicitly excluded.
-  def handle_event(@oban_stop_event, _measurements, %{state: state}, %{table: table})
-      when state in [:discard, :cancelled] do
+  def handle_event(@oban_stop_event, _measurements, %{state: state, worker: worker}, %{
+        table: table
+      })
+      when state in [:discard, :cancelled] and worker != @scale_alert_delivery_worker do
     :ets.update_counter(table, :oban_discard_count, 1)
     :ok
   rescue
@@ -599,6 +631,10 @@ defmodule Loopctl.Telemetry.ScaleAlerts do
       Logger.error("ScaleAlerts oban_stop handler error: #{Exception.message(e)}")
       :ok
   end
+
+  # Review fix (LOW): mirrors the `@oban_exception_event` exclusion above — the
+  # alerter's own delivery worker never inflates the discard-rate signal it feeds.
+  def handle_event(@oban_stop_event, _measurements, _metadata, _config), do: :ok
 
   # US-34.3 (AC-34.3.3): genuine LLM/embedding provider-error rate, sourced from the
   # NEW `[:loopctl, :llm, :provider_error]` event (emitted from exactly one choke

--- a/lib/loopctl/telemetry/scale_alerts/window.ex
+++ b/lib/loopctl/telemetry/scale_alerts/window.ex
@@ -11,14 +11,33 @@ defmodule Loopctl.Telemetry.ScaleAlerts.Window do
     * `:lat_total` — heavy-read latency samples this window.
     * `:buckets` — per-bucket sample counts, indexed to match
       `Loopctl.Telemetry.ScaleAlerts.buckets/0` plus a trailing `+Inf` overflow bucket.
+    * `:qt_total` (US-34.3) — primary Repo checkout `queue_time` samples this window.
+    * `:qt_buckets` (US-34.3) — per-bucket `queue_time` sample counts, SAME bucket
+      layout as `:buckets` (a separate set so it never collides with the heavy-read
+      histogram).
+    * `:oban_discard_count` (US-34.3) — fleet-wide `[:oban, :job, :exception]` events
+      this window (retry failures + exhausted-to-discard transitions).
+    * `:provider_error_count` (US-34.3) — genuine LLM/embedding provider failures
+      (`[:loopctl, :llm, :provider_error]`) this window.
   """
 
   @type t :: %__MODULE__{
           timeout_count: non_neg_integer(),
           under_fill_count: non_neg_integer(),
           lat_total: non_neg_integer(),
-          buckets: [non_neg_integer()]
+          buckets: [non_neg_integer()],
+          qt_total: non_neg_integer(),
+          qt_buckets: [non_neg_integer()],
+          oban_discard_count: non_neg_integer(),
+          provider_error_count: non_neg_integer()
         }
 
-  defstruct timeout_count: 0, under_fill_count: 0, lat_total: 0, buckets: []
+  defstruct timeout_count: 0,
+            under_fill_count: 0,
+            lat_total: 0,
+            buckets: [],
+            qt_total: 0,
+            qt_buckets: [],
+            oban_discard_count: 0,
+            provider_error_count: 0
 end

--- a/lib/loopctl/telemetry_events.ex
+++ b/lib/loopctl/telemetry_events.ex
@@ -161,11 +161,14 @@ defmodule Loopctl.TelemetryEvents do
   A genuine LLM/embedding PROVIDER failure (a REAL 4xx/5xx/transport/timeout error
   returned by a provider call that WAS ACTUALLY ATTEMPTED — a key was configured and
   present). Introduced by US-34.3 (AC-34.3.3) as the provider-error-rate ScaleAlerts
-  signal. Emitted from EXACTLY ONE choke point, `Loopctl.Llm.record_provider_error/2`,
-  called by `Loopctl.Workers.ArticleEmbeddingWorker` / `Loopctl.Workers.MemoryEmbeddingWorker`
-  once per genuine provider failure — never for the circuit breaker's own
-  `:circuit_open` skip (a DERIVED consequence of prior failures already counted when
-  they happened, not a fresh one).
+  signal. Emitted via `Loopctl.Llm.record_provider_error/2` from TWO choke points,
+  each the ONE call site for its provider: `Loopctl.Llm.Anthropic`'s shared HTTP
+  client (`provider: "anthropic"` — every Anthropic call site, content extraction/
+  classification/merge/memory-promotion, funnels through it) and
+  `Loopctl.Workers.ArticleEmbeddingWorker` / `Loopctl.Workers.MemoryEmbeddingWorker`
+  (`provider: "embedding"`) once per genuine provider failure — never for the
+  circuit breaker's own `:circuit_open` skip (a DERIVED consequence of prior
+  failures already counted when they happened, not a fresh one).
 
   Distinct from `[:loopctl, :llm, :blocked]` (`Loopctl.Llm.record_blocked/2`), which
   fires when NO key is configured — a missing-credential CONFIG state checked BEFORE

--- a/lib/loopctl/telemetry_events.ex
+++ b/lib/loopctl/telemetry_events.ex
@@ -157,6 +157,37 @@ defmodule Loopctl.TelemetryEvents do
   """
   def knowledge_hybrid_provenance, do: [:loopctl, :knowledge, :hybrid_provenance]
 
+  @doc """
+  A genuine LLM/embedding PROVIDER failure (a REAL 4xx/5xx/transport/timeout error
+  returned by a provider call that WAS ACTUALLY ATTEMPTED — a key was configured and
+  present). Introduced by US-34.3 (AC-34.3.3) as the provider-error-rate ScaleAlerts
+  signal. Emitted from EXACTLY ONE choke point, `Loopctl.Llm.record_provider_error/2`,
+  called by `Loopctl.Workers.ArticleEmbeddingWorker` / `Loopctl.Workers.MemoryEmbeddingWorker`
+  once per genuine provider failure — never for the circuit breaker's own
+  `:circuit_open` skip (a DERIVED consequence of prior failures already counted when
+  they happened, not a fresh one).
+
+  Distinct from `[:loopctl, :llm, :blocked]` (`Loopctl.Llm.record_blocked/2`), which
+  fires when NO key is configured — a missing-credential CONFIG state checked BEFORE
+  any provider call is attempted. Conflating the two would both false-page (a keyless
+  tenant looks like a provider incident) and mask the real incident class (a genuine
+  429/5xx/transport storm on a tenant WITH a key never touches `record_blocked/2` at
+  all). See `Loopctl.Telemetry.ScaleMetrics`'s "AC-34.4.3 coordination" moduledoc note.
+
+  ## Payload (id-free — never a tenant id, article/memory id, or provider body)
+
+    * `measurements`: `%{count: 1}` — a pure increment.
+    * `metadata`: `%{provider, class}` where `provider` is `"anthropic"` |
+      `"embedding"` (a BOUNDED 2-value set, the same credential/vendor split
+      `Loopctl.Llm.blocked_credential_provider/1` already uses) and `class` is
+      `:transient` | `:permanent` (per `Loopctl.Llm.permanent_provider_error?/1`).
+      The reason feeding classification has already been run through
+      `Loopctl.Llm.ProviderError.sanitize/1`, so no key/body ever reaches this event.
+
+  Windowed by `Loopctl.Telemetry.ScaleAlerts` as a per-minute rate.
+  """
+  def llm_provider_error, do: [:loopctl, :llm, :provider_error]
+
   @doc "Returns all defined event names for attachment"
   def all_events do
     [
@@ -171,7 +202,8 @@ defmodule Loopctl.TelemetryEvents do
       vector_search_under_fill(),
       db_error(),
       knowledge_semantic_fallback(),
-      knowledge_hybrid_provenance()
+      knowledge_hybrid_provenance(),
+      llm_provider_error()
     ]
   end
 end

--- a/lib/loopctl/telemetry_events.ex
+++ b/lib/loopctl/telemetry_events.ex
@@ -165,8 +165,13 @@ defmodule Loopctl.TelemetryEvents do
   each the ONE call site for its provider: `Loopctl.Llm.Anthropic`'s shared HTTP
   client (`provider: "anthropic"` — every Anthropic call site, content extraction/
   classification/merge/memory-promotion, funnels through it) and
-  `Loopctl.Workers.ArticleEmbeddingWorker` / `Loopctl.Workers.MemoryEmbeddingWorker`
-  (`provider: "embedding"`) once per genuine provider failure — never for the
+  `Loopctl.Knowledge.run_embedding_task/3` (`provider: "embedding"`) — the SINGLE
+  guarded entry point shared by both embedding Oban workers
+  (`Loopctl.Workers.ArticleEmbeddingWorker` / `Loopctl.Workers.MemoryEmbeddingWorker`)
+  AND every query-time embedding caller (combined/semantic search, novelty scoring,
+  `Memory.recall/2`, promotion near-dup lookup) — once per genuine provider failure,
+  gated by the same breaker-countable classification the circuit breaker uses
+  (a per-tenant 4xx credential/quota problem never contributes), and never for the
   circuit breaker's own `:circuit_open` skip (a DERIVED consequence of prior
   failures already counted when they happened, not a fresh one).
 

--- a/lib/loopctl/workers/article_embedding_worker.ex
+++ b/lib/loopctl/workers/article_embedding_worker.ex
@@ -101,8 +101,11 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
       {:error, reason} ->
         # Classify on the raw reason, but the term that becomes an Oban discard/error
         # reason (-> oban_jobs.errors) is SANITIZED (review #5/#6) — never a raw body.
+        # US-34.3 (review MED #1): the `[:loopctl, :llm, :provider_error]` telemetry
+        # signal is now recorded ONCE, upstream, in
+        # `Loopctl.Knowledge.run_embedding_task/3` — the single choke point shared by
+        # this worker AND every query-time embedding caller. Do NOT re-record here.
         sanitized = ProviderError.sanitize(reason)
-        record_provider_error(reason)
 
         if Llm.permanent_provider_error?(reason) do
           # A revoked/invalid tenant key (4xx) will never succeed on retry (review #5).
@@ -116,17 +119,6 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
           {:error, sanitized}
         end
     end
-  end
-
-  # US-34.3 (AC-34.3.3): a genuine provider failure — never the circuit breaker's
-  # own `:circuit_open` skip (a DERIVED consequence of prior failures already
-  # counted when they happened, not a fresh one; counting it too would inflate the
-  # rate every retry while the breaker stays open on a single underlying incident).
-  defp record_provider_error(:circuit_open), do: :ok
-
-  defp record_provider_error(reason) do
-    class = if Llm.permanent_provider_error?(reason), do: :permanent, else: :transient
-    Llm.record_provider_error("embedding", class)
   end
 
   defp store(tenant_id, article_id, embedding, content_hash) do

--- a/lib/loopctl/workers/article_embedding_worker.ex
+++ b/lib/loopctl/workers/article_embedding_worker.ex
@@ -102,6 +102,7 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
         # Classify on the raw reason, but the term that becomes an Oban discard/error
         # reason (-> oban_jobs.errors) is SANITIZED (review #5/#6) — never a raw body.
         sanitized = ProviderError.sanitize(reason)
+        record_provider_error(reason)
 
         if Llm.permanent_provider_error?(reason) do
           # A revoked/invalid tenant key (4xx) will never succeed on retry (review #5).
@@ -115,6 +116,17 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
           {:error, sanitized}
         end
     end
+  end
+
+  # US-34.3 (AC-34.3.3): a genuine provider failure — never the circuit breaker's
+  # own `:circuit_open` skip (a DERIVED consequence of prior failures already
+  # counted when they happened, not a fresh one; counting it too would inflate the
+  # rate every retry while the breaker stays open on a single underlying incident).
+  defp record_provider_error(:circuit_open), do: :ok
+
+  defp record_provider_error(reason) do
+    class = if Llm.permanent_provider_error?(reason), do: :permanent, else: :transient
+    Llm.record_provider_error("embedding", class)
   end
 
   defp store(tenant_id, article_id, embedding, content_hash) do

--- a/lib/loopctl/workers/memory_embedding_worker.ex
+++ b/lib/loopctl/workers/memory_embedding_worker.ex
@@ -91,6 +91,7 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorker do
 
       {:error, reason} ->
         sanitized = ProviderError.sanitize(reason)
+        record_provider_error(reason)
 
         if Llm.permanent_provider_error?(reason) do
           Logger.debug(
@@ -103,6 +104,17 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorker do
           {:error, sanitized}
         end
     end
+  end
+
+  # US-34.3 (AC-34.3.3): a genuine provider failure — never the circuit breaker's
+  # own `:circuit_open` skip (a DERIVED consequence of prior failures already
+  # counted when they happened, not a fresh one; counting it too would inflate the
+  # rate every retry while the breaker stays open on a single underlying incident).
+  defp record_provider_error(:circuit_open), do: :ok
+
+  defp record_provider_error(reason) do
+    class = if Llm.permanent_provider_error?(reason), do: :permanent, else: :transient
+    Llm.record_provider_error("embedding", class)
   end
 
   defp store(tenant_id, memory_id, embedding, content_hash) do

--- a/lib/loopctl/workers/memory_embedding_worker.ex
+++ b/lib/loopctl/workers/memory_embedding_worker.ex
@@ -90,8 +90,11 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorker do
         skip_no_embedding_key(tenant_id, memory_id)
 
       {:error, reason} ->
+        # US-34.3 (review MED #1): the `[:loopctl, :llm, :provider_error]` telemetry
+        # signal is now recorded ONCE, upstream, in
+        # `Loopctl.Knowledge.run_embedding_task/3` — the single choke point shared by
+        # this worker AND every query-time embedding caller. Do NOT re-record here.
         sanitized = ProviderError.sanitize(reason)
-        record_provider_error(reason)
 
         if Llm.permanent_provider_error?(reason) do
           Logger.debug(
@@ -104,17 +107,6 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorker do
           {:error, sanitized}
         end
     end
-  end
-
-  # US-34.3 (AC-34.3.3): a genuine provider failure — never the circuit breaker's
-  # own `:circuit_open` skip (a DERIVED consequence of prior failures already
-  # counted when they happened, not a fresh one; counting it too would inflate the
-  # rate every retry while the breaker stays open on a single underlying incident).
-  defp record_provider_error(:circuit_open), do: :ok
-
-  defp record_provider_error(reason) do
-    class = if Llm.permanent_provider_error?(reason), do: :permanent, else: :transient
-    Llm.record_provider_error("embedding", class)
   end
 
   defp store(tenant_id, memory_id, embedding, content_hash) do

--- a/test/loopctl/knowledge_semantic_search_test.exs
+++ b/test/loopctl/knowledge_semantic_search_test.exs
@@ -932,6 +932,92 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
     end
   end
 
+  # US-34.3 review fix (MED #1): `run_embedding_task/3` is the single choke point
+  # for the `[:loopctl, :llm, :provider_error]` signal's embedding half — it must
+  # fire for EVERY embedding call site (not just the two Oban workers), including
+  # `Knowledge.generate_embedding/3` called directly, which is what every
+  # query-time caller (combined/semantic search, novelty scoring, `Memory.recall/2`,
+  # promotion) ultimately does. Prior to the fix, none of these calls emitted the
+  # signal at all — only the workers did.
+  describe "generate_embedding/3 - provider_error telemetry (US-34.3 review fix MED #1)" do
+    defp attach_provider_error_listener(test_pid) do
+      handler_id = {:generate_embedding_provider_error_test, System.unique_integer([:positive])}
+
+      :telemetry.attach(
+        handler_id,
+        [:loopctl, :llm, :provider_error],
+        fn _event, measurements, metadata, _config ->
+          send(test_pid, {:provider_error_emitted, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+    end
+
+    test "a genuine 5xx failure emits provider=embedding class=:transient" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+      attach_provider_error_listener(self())
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, {:api_error, 500, :provider_error}}
+      end)
+
+      assert {:error, {:api_error, 500, _}} = Knowledge.generate_embedding(tenant.id, "q")
+
+      assert_received {:provider_error_emitted, %{count: 1}, metadata}
+      assert metadata == %{provider: "embedding", class: :transient}
+    end
+
+    test "a per-tenant 4xx (credential/quota) NEVER emits provider_error (gated by breaker_countable?/1, mirrors the circuit breaker exemption)" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+      attach_provider_error_listener(self())
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, {:api_error, 401, :provider_error}}
+      end)
+
+      assert {:error, {:api_error, 401, _}} = Knowledge.generate_embedding(tenant.id, "q")
+
+      refute_received {:provider_error_emitted, _measurements, _metadata}
+    end
+
+    test "a keyless tenant's :no_api_key never emits provider_error (a config gap, not a provider incident)" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+      attach_provider_error_listener(self())
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, :no_api_key}
+      end)
+
+      assert {:error, :no_api_key} = Knowledge.generate_embedding(tenant.id, "q")
+
+      refute_received {:provider_error_emitted, _measurements, _metadata}
+    end
+
+    test "the circuit breaker's own :circuit_open short-circuit never emits provider_error (a derived, already-counted consequence)" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, {:api_error, 500, :provider_error}}
+      end)
+
+      # Trip the breaker first (3 failures).
+      for _i <- 1..3 do
+        Knowledge.generate_embedding(tenant.id, "q")
+      end
+
+      attach_provider_error_listener(self())
+      assert {:error, :circuit_open} = Knowledge.generate_embedding(tenant.id, "q")
+
+      refute_received {:provider_error_emitted, _measurements, _metadata}
+    end
+  end
+
   # --- Score normalization edge case ---
 
   describe "score normalization" do

--- a/test/loopctl/llm/anthropic_test.exs
+++ b/test/loopctl/llm/anthropic_test.exs
@@ -100,4 +100,124 @@ defmodule Loopctl.Llm.AnthropicTest do
     log = capture_log(fn -> assert {:error, {:request_failed, _}} = run(tenant) end)
     refute log =~ @secret
   end
+
+  describe "US-34.3 review fix (AC-34.3.3): wires [:loopctl, :llm, :provider_error]" do
+    # Prior to this fix, a real 429/5xx/transport storm on the primary Anthropic
+    # surface (content extraction/classification/merge/memory-promotion — every one
+    # funnels through this shared client) was invisible to the provider-error-rate
+    # ScaleAlerts signal: only the embedding worker path recorded it. Attaching a
+    # listener here proves the client itself is now the single choke point for
+    # every Anthropic call site.
+    defp attach_provider_error_listener(test_pid) do
+      handler_id = {:anthropic_provider_error_test, System.unique_integer([:positive])}
+
+      :telemetry.attach(
+        handler_id,
+        [:loopctl, :llm, :provider_error],
+        fn _event, measurements, metadata, _config ->
+          send(test_pid, {:provider_error_emitted, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+    end
+
+    test "a permanent 4xx API error (e.g. revoked key) is recorded provider=anthropic class=:permanent" do
+      tenant = tenant_with_key()
+      attach_provider_error_listener(self())
+
+      Req.Test.stub(Loopctl.Llm.Anthropic, fn conn ->
+        conn |> Plug.Conn.put_status(401) |> Req.Test.json(%{"error" => "bad key"})
+      end)
+
+      assert {:error, {:api_error, 401, :provider_error}} = run(tenant)
+
+      assert_received {:provider_error_emitted, %{count: 1}, metadata}
+      assert metadata == %{provider: "anthropic", class: :permanent}
+    end
+
+    test "a 5xx API error is recorded provider=anthropic class=:transient" do
+      tenant = tenant_with_key()
+      attach_provider_error_listener(self())
+
+      Req.Test.stub(Loopctl.Llm.Anthropic, fn conn ->
+        conn |> Plug.Conn.put_status(500) |> Req.Test.json(%{"error" => "boom"})
+      end)
+
+      assert {:error, {:api_error, 500, :provider_error}} = run(tenant)
+
+      assert_received {:provider_error_emitted, %{count: 1}, metadata}
+      assert metadata == %{provider: "anthropic", class: :transient}
+    end
+
+    test "a 429 rate-limit is classified :transient (not permanent — it can succeed on retry)" do
+      tenant = tenant_with_key()
+      attach_provider_error_listener(self())
+
+      Req.Test.stub(Loopctl.Llm.Anthropic, fn conn ->
+        conn |> Plug.Conn.put_status(429) |> Req.Test.json(%{"error" => "rate limited"})
+      end)
+
+      assert {:error, {:api_error, 429, :provider_error}} = run(tenant)
+
+      assert_received {:provider_error_emitted, %{count: 1}, metadata}
+      assert metadata == %{provider: "anthropic", class: :transient}
+    end
+
+    test "a transport error is recorded provider=anthropic class=:transient" do
+      tenant = tenant_with_key()
+      attach_provider_error_listener(self())
+
+      Req.Test.stub(Loopctl.Llm.Anthropic, fn conn ->
+        Req.Test.transport_error(conn, :econnrefused)
+      end)
+
+      assert {:error, {:request_failed, _}} = run(tenant)
+
+      assert_received {:provider_error_emitted, %{count: 1}, metadata}
+      assert metadata == %{provider: "anthropic", class: :transient}
+    end
+
+    test "a 200-with-unexpected-shape response is ALSO recorded (a genuine anomaly)" do
+      tenant = tenant_with_key()
+      attach_provider_error_listener(self())
+
+      Req.Test.stub(Loopctl.Llm.Anthropic, fn conn ->
+        Req.Test.json(conn, %{"error" => %{"message" => "unexpected"}})
+      end)
+
+      assert {:error, {:api_error, 200, :provider_error}} = run(tenant)
+
+      assert_received {:provider_error_emitted, %{count: 1}, metadata}
+      assert metadata == %{provider: "anthropic", class: :transient}
+    end
+
+    test "a successful 200 call never emits provider_error" do
+      tenant = tenant_with_key()
+      test_pid = self()
+      handler_id = {:anthropic_provider_error_success_test, System.unique_integer([:positive])}
+
+      :telemetry.attach(
+        handler_id,
+        [:loopctl, :llm, :provider_error],
+        fn _event, _measurements, _metadata, _config ->
+          send(test_pid, :unexpected_provider_error)
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      Req.Test.stub(Loopctl.Llm.Anthropic, fn conn ->
+        Req.Test.json(conn, %{
+          "content" => [%{"type" => "text", "text" => "ok"}],
+          "usage" => %{"input_tokens" => 1, "output_tokens" => 1}
+        })
+      end)
+
+      assert {:ok, "ok"} = run(tenant)
+      refute_received :unexpected_provider_error
+    end
+  end
 end

--- a/test/loopctl/llm/anthropic_test.exs
+++ b/test/loopctl/llm/anthropic_test.exs
@@ -179,7 +179,7 @@ defmodule Loopctl.Llm.AnthropicTest do
       assert metadata == %{provider: "anthropic", class: :transient}
     end
 
-    test "a 200-with-unexpected-shape response is ALSO recorded (a genuine anomaly)" do
+    test "a 200-with-unexpected-shape response is NEVER recorded (review fix LOW: a 200 is a provider SUCCESS, not an outage)" do
       tenant = tenant_with_key()
       attach_provider_error_listener(self())
 
@@ -189,8 +189,7 @@ defmodule Loopctl.Llm.AnthropicTest do
 
       assert {:error, {:api_error, 200, :provider_error}} = run(tenant)
 
-      assert_received {:provider_error_emitted, %{count: 1}, metadata}
-      assert metadata == %{provider: "anthropic", class: :transient}
+      refute_received {:provider_error_emitted, _measurements, _metadata}
     end
 
     test "a successful 200 call never emits provider_error" do

--- a/test/loopctl/telemetry/scale_alerts_test.exs
+++ b/test/loopctl/telemetry/scale_alerts_test.exs
@@ -105,6 +105,37 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
     end
   end
 
+  # US-34.3: mirror helpers for the three additional signals.
+
+  # Repo checkout queue_time in ms → native units the real `[:loopctl, :repo, :query]`
+  # event carries.
+  defp emit_queue_time(ms, n) do
+    native = System.convert_time_unit(ms, :millisecond, :native)
+
+    for _ <- 1..n do
+      :telemetry.execute([:loopctl, :repo, :query], %{queue_time: native}, %{repo: Loopctl.Repo})
+    end
+  end
+
+  defp emit_oban_exception(n) do
+    for _ <- 1..n do
+      :telemetry.execute([:oban, :job, :exception], %{duration: 1}, %{
+        worker: "Loopctl.Workers.SomeWorker",
+        queue: "default",
+        state: :failure
+      })
+    end
+  end
+
+  defp emit_provider_error(n) do
+    for _ <- 1..n do
+      :telemetry.execute([:loopctl, :llm, :provider_error], %{count: 1}, %{
+        provider: "embedding",
+        class: :transient
+      })
+    end
+  end
+
   defp expect_delivery(test_pid) do
     expect(Loopctl.MockDelivery, :deliver, fn url, body, headers ->
       send(test_pid, {:alert_delivered, url, body, headers})
@@ -186,6 +217,157 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
 
       keys = body |> Jason.decode!() |> Map.keys() |> Enum.sort()
       assert keys == ["alert", "at", "metric", "threshold", "value", "window_seconds"]
+    end
+  end
+
+  describe "US-34.3: three additional signals" do
+    test "TC-34.3.1: repo queue_time p95 breach fires", %{server: server} do
+      test_pid = self()
+      expect_delivery(test_pid)
+
+      # 30 samples (> @p95_min_samples = 20) at 1000ms: well above the 500ms default
+      # threshold. 1000ms lands exactly in the 1000 bucket -> p95 estimate 1000 > 500.
+      emit_queue_time(1_000, 30)
+      assert :ok = ScaleAlerts.evaluate(server)
+
+      assert_received {:alert_delivered, _url, body, _headers}
+      payload = Jason.decode!(body)
+      assert payload["metric"] == "repo_queue_time_p95_ms"
+      assert payload["value"] == 1_000
+      assert payload["threshold"] == 500
+    end
+
+    test "TC-34.3.2: Oban discard/retry rate breach fires", %{server: server} do
+      test_pid = self()
+      expect_delivery(test_pid)
+
+      # 11 > the 10/min default threshold.
+      emit_oban_exception(11)
+      assert :ok = ScaleAlerts.evaluate(server)
+
+      assert_received {:alert_delivered, _url, body, _headers}
+      payload = Jason.decode!(body)
+      assert payload["metric"] == "oban_discard_rate"
+      assert payload["value"] == 11.0
+      assert payload["threshold"] == 10
+    end
+
+    test "TC-34.3.3: provider-error rate breach fires", %{server: server} do
+      test_pid = self()
+      expect_delivery(test_pid)
+
+      # 11 > the 10/min default threshold.
+      emit_provider_error(11)
+      assert :ok = ScaleAlerts.evaluate(server)
+
+      assert_received {:alert_delivered, _url, body, _headers}
+      payload = Jason.decode!(body)
+      assert payload["metric"] == "provider_error_rate"
+      assert payload["value"] == 11.0
+      assert payload["threshold"] == 10
+    end
+
+    test "TC-34.3.4: no false fire under threshold for all three new signals", %{server: server} do
+      test_pid = self()
+
+      stub(Loopctl.MockDelivery, :deliver, fn _url, _body, _headers ->
+        send(test_pid, :unexpected_delivery)
+        {:ok, %{status: 200, body: "ok"}}
+      end)
+
+      # At threshold (strict `>` check, so exactly-threshold does NOT breach).
+      emit_queue_time(100, 30)
+      emit_oban_exception(10)
+      emit_provider_error(10)
+
+      assert :ok = ScaleAlerts.evaluate(server)
+      refute_received :unexpected_delivery
+    end
+
+    test "queue_time p95 below the sample floor is skipped (no noise alert)", %{server: server} do
+      test_pid = self()
+
+      stub(Loopctl.MockDelivery, :deliver, fn _u, _b, _h ->
+        send(test_pid, :unexpected_delivery)
+        {:ok, %{status: 200, body: "ok"}}
+      end)
+
+      # Only 5 samples (< @p95_min_samples = 20), even though each is 9000ms.
+      emit_queue_time(9_000, 5)
+      assert :ok = ScaleAlerts.evaluate(server)
+
+      refute_received :unexpected_delivery
+    end
+
+    test "the provider-error alert payload carries NO tenant/vector/SQL content", %{
+      server: server
+    } do
+      test_pid = self()
+      expect_delivery(test_pid)
+
+      emit_provider_error(11)
+      assert :ok = ScaleAlerts.evaluate(server)
+
+      assert_received {:alert_delivered, _url, body, _headers}
+      refute body =~ "tenant"
+      refute body =~ "vector"
+      refute body =~ "SELECT"
+
+      keys = body |> Jason.decode!() |> Map.keys() |> Enum.sort()
+      assert keys == ["alert", "at", "metric", "threshold", "value", "window_seconds"]
+    end
+  end
+
+  describe "US-34.3: Loopctl.TelemetryEvents.llm_provider_error/0" do
+    test "returns the bounded event name" do
+      assert TelemetryEvents.llm_provider_error() == [:loopctl, :llm, :provider_error]
+    end
+
+    test "is included in all_events/0" do
+      assert [:loopctl, :llm, :provider_error] in TelemetryEvents.all_events()
+    end
+  end
+
+  describe "US-34.3: Loopctl.Llm.record_provider_error/2 (AC-34.3.3, AC-34.3.5)" do
+    test "emits [:loopctl, :llm, :provider_error] with ONLY bounded provider/class metadata" do
+      test_pid = self()
+      handler_id = {:record_provider_error_test, System.unique_integer([:positive])}
+
+      :telemetry.attach(
+        handler_id,
+        [:loopctl, :llm, :provider_error],
+        fn _event, measurements, metadata, _config ->
+          send(test_pid, {:emitted, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      assert :ok = Loopctl.Llm.record_provider_error("embedding", :transient)
+
+      assert_received {:emitted, measurements, metadata}
+      assert measurements == %{count: 1}
+      assert metadata == %{provider: "embedding", class: :transient}
+      # Bounded cardinality guard: no tenant/id dimension ever reaches this event.
+      refute Map.has_key?(metadata, :tenant_id)
+      refute Map.has_key?(metadata, :article_id)
+      refute Map.has_key?(metadata, :memory_id)
+    end
+
+    test "is best-effort: a raising downstream handler never propagates to the caller" do
+      handler_id = {:record_provider_error_raising, System.unique_integer([:positive])}
+
+      :telemetry.attach(
+        handler_id,
+        [:loopctl, :llm, :provider_error],
+        fn _event, _measurements, _metadata, _config -> raise "boom" end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      assert :ok = Loopctl.Llm.record_provider_error("embedding", :permanent)
     end
   end
 

--- a/test/loopctl/telemetry/scale_alerts_test.exs
+++ b/test/loopctl/telemetry/scale_alerts_test.exs
@@ -365,6 +365,37 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
       refute_received :unexpected_delivery
     end
 
+    test "review fix (LOW): ScaleAlertDeliveryWorker's OWN discards/exceptions do NOT " <>
+           "inflate the discard rate it feeds (self-referential coupling)",
+         %{server: server} do
+      test_pid = self()
+
+      stub(Loopctl.MockDelivery, :deliver, fn _url, _body, _headers ->
+        send(test_pid, :unexpected_delivery)
+        {:ok, %{status: 200, body: "ok"}}
+      end)
+
+      worker = Oban.Worker.to_string(ScaleAlertDeliveryWorker)
+
+      for _ <- 1..11 do
+        :telemetry.execute([:oban, :job, :exception], %{duration: 1}, %{
+          worker: worker,
+          queue: "webhooks",
+          state: :failure
+        })
+
+        :telemetry.execute([:oban, :job, :stop], %{duration: 1}, %{
+          worker: worker,
+          queue: "webhooks",
+          state: :discard
+        })
+      end
+
+      assert :ok = ScaleAlerts.evaluate(server)
+
+      refute_received :unexpected_delivery
+    end
+
     test "TC-34.3.3: provider-error rate breach fires", %{server: server} do
       test_pid = self()
       expect_delivery(test_pid)

--- a/test/loopctl/telemetry/scale_alerts_test.exs
+++ b/test/loopctl/telemetry/scale_alerts_test.exs
@@ -117,12 +117,35 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
     end
   end
 
+  # Review fix regression coverage: the REAL reused-connection/in-transaction case,
+  # where Ecto's own `log_measurements/3` DROPS the `:queue_time` key entirely
+  # (never `nil` — absent). Mirrors an actual `[:loopctl, :repo, :query]` event fired
+  # for a statement inside a transaction after the first checkout.
+  defp emit_queue_time_absent(n) do
+    for _ <- 1..n do
+      :telemetry.execute([:loopctl, :repo, :query], %{}, %{repo: Loopctl.Repo})
+    end
+  end
+
   defp emit_oban_exception(n) do
     for _ <- 1..n do
       :telemetry.execute([:oban, :job, :exception], %{duration: 1}, %{
         worker: "Loopctl.Workers.SomeWorker",
         queue: "default",
         state: :failure
+      })
+    end
+  end
+
+  # Review fix regression coverage: a deliberate `{:discard, _}` / bare `:discard` or
+  # `{:cancel, _}` job return — the terminal, non-retryable path Oban's own Executor
+  # emits as `[:oban, :job, :stop]` (never `:exception`).
+  defp emit_oban_stop(state, n) do
+    for _ <- 1..n do
+      :telemetry.execute([:oban, :job, :stop], %{duration: 1}, %{
+        worker: "Loopctl.Workers.SomeWorker",
+        queue: "embeddings",
+        state: state
       })
     end
   end
@@ -237,6 +260,45 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
       assert payload["threshold"] == 500
     end
 
+    test "TC-34.3.5 (review fix, HIGH): ABSENT queue_time samples are skipped, not counted " <>
+           "as phantom 0ms — no p95 dilution",
+         %{server: server} do
+      test_pid = self()
+      expect_delivery(test_pid)
+
+      # 30 REAL samples at 1000ms (same as TC-34.3.1) breach the 500ms threshold on
+      # their own. A large volume of events with queue_time ABSENT (the realistic
+      # reused-connection/in-transaction case) is mixed in — under the prior bug
+      # (`Map.get(measurements, :queue_time, 0)`), these would be counted as
+      # synthetic 0ms samples, dominating the histogram and dragging the p95 well
+      # under the 500ms threshold, masking the breach entirely.
+      emit_queue_time(1_000, 30)
+      emit_queue_time_absent(500)
+
+      assert :ok = ScaleAlerts.evaluate(server)
+
+      assert_received {:alert_delivered, _url, body, _headers}
+      payload = Jason.decode!(body)
+      assert payload["metric"] == "repo_queue_time_p95_ms"
+      assert payload["value"] == 1_000
+      assert payload["threshold"] == 500
+    end
+
+    test "queue_time samples that are ALL absent are never counted (no false fire, no crash)",
+         %{server: server} do
+      test_pid = self()
+
+      stub(Loopctl.MockDelivery, :deliver, fn _u, _b, _h ->
+        send(test_pid, :unexpected_delivery)
+        {:ok, %{status: 200, body: "ok"}}
+      end)
+
+      emit_queue_time_absent(1_000)
+      assert :ok = ScaleAlerts.evaluate(server)
+
+      refute_received :unexpected_delivery
+    end
+
     test "TC-34.3.2: Oban discard/retry rate breach fires", %{server: server} do
       test_pid = self()
       expect_delivery(test_pid)
@@ -250,6 +312,57 @@ defmodule Loopctl.Telemetry.ScaleAlertsTest do
       assert payload["metric"] == "oban_discard_rate"
       assert payload["value"] == 11.0
       assert payload["threshold"] == 10
+    end
+
+    test "TC-34.3.6 (review fix, MEDIUM): a deliberate {:discard,_} job return " <>
+           "([:oban, :job, :stop] state: :discard) counts toward the discard rate",
+         %{server: server} do
+      test_pid = self()
+      expect_delivery(test_pid)
+
+      # 11 > the 10/min default threshold — via the STOP event (never :exception),
+      # the path a job takes when it deliberately returns {:discard, reason} on its
+      # FIRST attempt (e.g. ArticleEmbeddingWorker's permanent-provider-error
+      # discard) — the prior bug counted NOTHING for this path.
+      emit_oban_stop(:discard, 11)
+      assert :ok = ScaleAlerts.evaluate(server)
+
+      assert_received {:alert_delivered, _url, body, _headers}
+      payload = Jason.decode!(body)
+      assert payload["metric"] == "oban_discard_rate"
+      assert payload["value"] == 11.0
+      assert payload["threshold"] == 10
+    end
+
+    test "a deliberate {:cancel,_} job return ([:oban, :job, :stop] state: :cancelled) also counts",
+         %{server: server} do
+      test_pid = self()
+      expect_delivery(test_pid)
+
+      emit_oban_stop(:cancelled, 11)
+      assert :ok = ScaleAlerts.evaluate(server)
+
+      assert_received {:alert_delivered, _url, body, _headers}
+      payload = Jason.decode!(body)
+      assert payload["metric"] == "oban_discard_rate"
+      assert payload["value"] == 11.0
+      assert payload["threshold"] == 10
+    end
+
+    test "[:oban, :job, :stop] :success / :snoozed states do NOT count toward the discard rate",
+         %{server: server} do
+      test_pid = self()
+
+      stub(Loopctl.MockDelivery, :deliver, fn _url, _body, _headers ->
+        send(test_pid, :unexpected_delivery)
+        {:ok, %{status: 200, body: "ok"}}
+      end)
+
+      emit_oban_stop(:success, 50)
+      emit_oban_stop(:snoozed, 50)
+      assert :ok = ScaleAlerts.evaluate(server)
+
+      refute_received :unexpected_delivery
     end
 
     test "TC-34.3.3: provider-error rate breach fires", %{server: server} do


### PR DESCRIPTION
## Summary

Extends the existing FIRING alert pipeline `Loopctl.Telemetry.ScaleAlerts` with 3 additional signals, on top of the existing 3 (timeout rate, heavy-read p95, under-fill rate) — purely additive, no changes to the existing signals or the delivery/re-notify path.

- **AC-34.3.1** Repo checkout `queue_time` p95, sourced from `[:loopctl, :repo, :query]` (measurement `:queue_time`, the same metric US-33.1 emits). Bucketed identically to the existing heavy-read p95, but into a separate counter set so it never collides.
- **AC-34.3.2** Fleet-wide Oban job discard/retry rate, sourced from `[:oban, :job, :exception]` (Oban's Executor emits this for both retryable failures AND exhausted-to-discard transitions, so a single unconditional counter covers both halves of "discard/retry rate").
- **AC-34.3.3** LLM/embedding provider-error rate, sourced from a NEW `[:loopctl, :llm, :provider_error]` event emitted from exactly one choke point (`Loopctl.Llm.record_provider_error/2`), called by `ArticleEmbeddingWorker`/`MemoryEmbeddingWorker` on a genuine provider failure. Deliberately NOT `[:loopctl, :llm, :blocked]` — that event fires on a missing-BYO-key config state (checked before any provider call), not a real provider error, per US-34.4's explicit coordination note in `scale_metrics.ex`.
- **AC-34.3.4** All three reuse the existing `step/8`/`step_p95/8` edge-fire + bounded re-notify + Oban delivery machinery unchanged; thresholds are config (mirroring the existing 3).
- **AC-34.3.5** Every new telemetry handler is self-rescuing (a raise logs and returns `:ok`); the new provider-error emit site never propagates a telemetry failure to its caller.

## Test plan

- [x] `mix precommit` (compile --warnings-as-errors, format, credo --strict, deps.audit, dialyzer, full test suite) — all green, 4403 tests, 0 failures.
- [x] TC-34.3.1 repo queue_time p95 breach fires (correct metric/value/threshold).
- [x] TC-34.3.2 Oban discard/retry rate breach fires.
- [x] TC-34.3.3 provider-error rate breach fires.
- [x] TC-34.3.4 no false fire under threshold for all 3 new signals.
- [x] queue_time p95 below the sample floor is skipped (no noise alert).
- [x] provider-error alert payload carries no tenant/vector/SQL content.
- [x] `Loopctl.Llm.record_provider_error/2` emits only bounded `provider`/`class` metadata (no tenant/article/memory id) and is best-effort (a raising downstream handler never propagates).
- [x] `Loopctl.TelemetryEvents.llm_provider_error/0` unit test + `all_events/0` inclusion.
