### PR TITLE
docs(epic_35): STH & cron fleet-cost redesign stories (US-35.1..35.3)

### DIFF
--- a/docs/user_stories/epic_35_sth_cron_redesign/README.md
+++ b/docs/user_stories/epic_35_sth_cron_redesign/README.md
@@ -1,0 +1,69 @@
+# Epic 35 — STH & Cron Fleet-Cost Redesign
+
+Remediation of GitHub issue **#350** (roadmap Epic 3, tracked **#355**) — the
+per-minute Signed-Tree-Head machinery contains a self-inflicted critical that
+worsens quadratically as each tenant's audit chain grows.
+
+## Scope reconciliation (verified against `master` before authoring)
+
+Issue #350 predates recent work; **3 of its 6 findings are already done** and are
+**excluded**:
+
+| #350 finding | Status | Evidence |
+|--------------|--------|----------|
+| Fanout uses N single-row inserts instead of `insert_all` | ✅ done | US-32.5 — `compute_sth_worker.ex:59-68` uses `Oban.insert_all/1`, chunked at 5000 |
+| Zero-jitter thundering herd at the `:00` tick | ✅ done (jitter part) | US-32.5 — `schedule_in: jitter(tenant_id)`, deterministic `phash2` over a 56s window (`compute_sth_worker.ex:45,57,113`) |
+| `RevokeExpiredDispatchesWorker` query can't use its index | ✅ done | US-32.1 — `20260713000000_add_dispatches_expires_at_active_index.exs` adds `CREATE INDEX CONCURRENTLY … ON dispatches (expires_at) WHERE revoked_at IS NULL`; worker test asserts Index Scan (not Seq Scan) |
+| `dispatches` missing partial index `(expires_at) WHERE revoked_at IS NULL` | ✅ done | Same migration — exact predicate match, not a different one |
+
+The **genuinely-remaining** work is the three findings the audit rated as the
+actual fleet-cost drivers:
+
+| #350 finding | Status | Story |
+|--------------|--------|-------|
+| `ComputeSthWorker` rebuilds the **entire** per-tenant Merkle tree on every append (O(chain) per active tenant, forever) | ❌ open (guarded only by `sth_needed?/1` skip-if-unchanged) | **US-35.1** |
+| STH is **poll-based** per-tenant-per-minute rather than event-driven; the fanout does not gate to tenants with new activity (N idle-tenant jobs enqueued every minute) | ❌ open (`ChainPubSub` broadcasts on append but nothing consumes it to enqueue STH) | **US-35.2** |
+| The blanket per-minute all-tenants cron poll should become a low-frequency safety sweep once the event path exists | ❌ open (`config/config.exs:331` = `"* * * * *"`) | **US-35.3** |
+
+## Stories
+
+| Story | Title | Depends |
+|-------|-------|---------|
+| US-35.1 | Incremental STH: checkpointed Merkle peaks, folding only entries above the last STH — **root byte-identical** to the current construction | — |
+| US-35.2 | Event-driven STH: audit-append firehose topic + supervised debounce-enqueuer; cron becomes the fallback, not the only path | — |
+| US-35.3 | Reduce the all-tenants cron from every-minute to a low-frequency, config-driven safety sweep (primary path is now US-35.2) | US-35.2 |
+
+## Non-negotiable constraints (system is LIVE, audit chain is security-critical)
+
+- **US-35.1 is the highest-risk change in the whole roadmap.** The current
+  Merkle construction is **Bitcoin-style** (`merkle_tree/2`,
+  `audit_chain.ex:273-285` — pad odd levels by duplicating the last element),
+  **not** RFC-6962. A naive Merkle-Mountain-Range frontier produces a
+  **different** root. The incremental path MUST emit a **byte-identical**
+  `merkle_root` to `compute_merkle_root/1` for **every** chain length, or:
+  (a) already-signed historical STHs and external witness caches stop
+  verifying, and (b) a divergent STH can trip the L6 byzantine/custody-halt
+  path. The safety net is a **property test** using the existing
+  `merkle_tree/2` as the reference oracle over random append counts (including
+  odd/even/power-of-2 boundaries and single-leaf). `merkle_tree/2` stays the
+  source of truth; the checkpoint is a cache that must never change the answer.
+- The one migration (US-35.1's checkpoint table) is an **additive
+  `CREATE TABLE`** — it does **not** touch the hot `audit_log_entries` /
+  `audit_signed_tree_heads` tables and blocks no writes.
+- US-35.2 adds a **firehose broadcast alongside** the existing per-tenant
+  `audit_chain:<id>` topic — the per-tenant topic and its `{:audit_chain_entry, …}`
+  / `{:sth_updated, …}` messages are **unchanged** so external agent witness
+  caches are unaffected.
+- Debounce/coalescing must be **Basic-Engine-safe**: the event path enqueues via
+  single `Oban.insert/2` (where `unique` *is* honored, unlike the `insert_all`
+  fanout), with a short `schedule_in` so an append burst collapses to one
+  compute. No Smart-Engine assumption.
+- US-35.3 only **lowers the safety-sweep frequency** — the `sth_needed?/1` gate
+  plus the sweep still guarantee eventual STH for any tenant the event path
+  missed. It is independently revertible (config only).
+- Every merge is smoke-gated with a `knowledge_count` / STH-endpoint health check
+  either side. Every new query runs on a read path (`HeavyRead` / short
+  `SET LOCAL statement_timeout`, per-query — never a startup `:parameter`,
+  pgbouncer-safe).
+- **This epic's review MUST include the security-adversary lens** (root
+  divergence, replay, byzantine-halt) on US-35.1 — not optional.

--- a/docs/user_stories/epic_35_sth_cron_redesign/us_35.1.json
+++ b/docs/user_stories/epic_35_sth_cron_redesign/us_35.1.json
@@ -1,0 +1,59 @@
+{
+  "id": "US-35.1",
+  "title": "Incremental STH: checkpointed Merkle peaks, root byte-identical to the current construction",
+  "epic": { "id": "epic_35", "name": "STH & Cron Fleet-Cost Redesign" },
+  "priority": "critical",
+  "phase": "scalability",
+  "priority_note": "The self-inflicted critical of #350. Every STH recompute re-reads and re-hashes a tenant's ENTIRE audit chain; cost grows with chain length, so a long-lived active tenant pays O(chain) per append forever. This is the one change that removes the quadratic. Highest-risk story in the roadmap — a wrong root breaks STH verification and can trip the L6 byzantine halt.",
+  "background": {
+    "reference": "GH #350. AuditChain.compute_merkle_root/1 (lib/loopctl/audit_chain.ex:145-159) loads EVERY entry_hash for the tenant (ORDER BY chain_position) and rebuilds the whole tree via merkle_tree/2 (audit_chain.ex:273-285). sign_and_store_tree_head/1 (:167-204) calls it on each run. ComputeSthWorker per-tenant clause (lib/loopctl/workers/compute_sth_worker.ex:73-93) guards with AuditChain.sth_needed?/1 (audit_chain.ex:254-264) so IDLE tenants are a cheap 2-lookup no-op — but any tenant that appended even one entry pays a full O(chain) rebuild.",
+    "includes": "CRITICAL CONSTRAINT: merkle_tree/2 is Bitcoin-style — on an odd-length level it duplicates the LAST element (audit_chain.ex:276-277), then hashes pairs with SHA-256, recursing to a single root. This is NOT RFC-6962. A standard Merkle-Mountain-Range frontier yields a DIFFERENT root. Historical STHs (audit_signed_tree_heads) were signed over roots from THIS construction; the public verifier (Loopctl.AuditChain.Verifier / audit_sth_controller) and external witness caches verify against it. The incremental result MUST be byte-identical for every chain length or prior STHs stop verifying and divergent STHs can trip custody halt.",
+    "already_done": "insert_all + jitter fanout (US-32.5) and the dispatches partial index (US-32.1) are EXCLUDED — see epic README scope-reconciliation table. This story is ONLY the incremental compute."
+  },
+  "story": {
+    "as_a": "loopctl operator running tenants with long, actively-growing audit chains",
+    "i_want_to": "compute each new Signed Tree Head by folding only the entries added since the last STH into a persisted checkpoint of stable Merkle sub-tree peaks, instead of re-reading and re-hashing the whole chain",
+    "so_that": "STH cost scales with new-entry count (O(Δ)) rather than total chain length (O(n)), removing the per-append quadratic — while every signed root stays byte-identical to today's construction so no historical STH or external witness breaks"
+  },
+  "rationale": "In the Bitcoin-style tree, a complete left-aligned subtree of 2^k leaves has a root that never changes as more leaves are appended. Persisting those stable 'peaks' plus the last chain_position lets a recompute load only entries above the checkpoint, fold them into the peaks using the SAME pad-and-hash rules, and combine peaks into the final root identically to merkle_tree/2. The existing full recompute stays as the reference oracle (property-tested equality) and as the fallback when no checkpoint exists, so the change is a pure performance cache with zero semantic drift.",
+  "acceptance_criteria": [
+    { "id": "AC-35.1.1", "description": "A new incremental path computes the tenant's current Merkle root by loading ONLY entries with chain_position > the checkpoint's position (not the whole chain) and folding them into the persisted peak set. For a tenant with no checkpoint it falls back to the existing full compute_merkle_root/1 — backward compatible on first run and after any checkpoint loss.", "status": "pending" },
+    { "id": "AC-35.1.2", "description": "BYTE-IDENTICAL ROOT (the safety invariant): a property/generative test builds a chain of N entries for N across a wide range INCLUDING 1, 2, 3, odd counts, even counts, and 2^k boundaries (e.g. 1..40 plus a few large values), computes the root both incrementally (with checkpoints taken at arbitrary intermediate positions) and via the current merkle_tree/2 full rebuild, and asserts the two roots are equal for every N and every checkpoint split point. merkle_tree/2 is the reference oracle and is NOT modified.", "status": "pending" },
+    { "id": "AC-35.1.3", "description": "The checkpoint (per tenant: last chain_position + serialized stable peaks) is persisted in a NEW additive table (e.g. audit_sth_checkpoints) created by an online CREATE TABLE migration that does not touch or lock audit_log_entries / audit_signed_tree_heads. Checkpoint writes happen in the same logical operation as signing/storing the STH (consistent with the position just signed). The peaks are stored as raw binary hashes; no plaintext leakage of entry contents.", "status": "pending" },
+    { "id": "AC-35.1.4", "description": "sign_and_store_tree_head/1 uses the incremental root; the signed message (build_sth_message/4: tenant_id <> position <> merkle_root <> unix_ts) and the ed25519 signing are UNCHANGED, so a verifier that recomputes the root the old way still validates the signature. An end-to-end test signs an STH via the incremental path and verifies it with the existing Verifier.verify_sth (or the public /audit/sth endpoint) successfully.", "status": "pending" },
+    { "id": "AC-35.1.5", "description": "Correctness under concurrency and drift: the append path serializes per tenant via SELECT…FOR UPDATE (audit_chain.ex:60-61) so positions are gap-free. If the checkpoint's position is ever ahead of or inconsistent with the latest entry (e.g. partial write), the code detects the mismatch and safely falls back to a full recompute for that run rather than emitting a wrong root. A test simulates a stale/corrupt checkpoint and asserts the correct (full-rebuild) root is still produced.", "status": "pending" },
+    { "id": "AC-35.1.6", "description": "Reads run on a read path with a per-query SET LOCAL statement_timeout (never a startup :parameter — pgbouncer-safe). Tenant isolation is preserved: checkpoints are per tenant_id and an incremental compute for tenant A can never read tenant B's entries or peaks (tenant-isolation test). No change to job semantics, queues, or the fanout.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-35.1.1", "name": "incremental root == full-rebuild root for all chain lengths and split points", "type": "unit",
+      "preconditions": ["deterministic entry_hash fixtures for a synthetic chain of length N"],
+      "steps": ["for N in {1,2,3,4,5,7,8,9,15,16,17,31,32,33,40}: build chain, take a checkpoint at an arbitrary position p<N, compute root incrementally from p, compute root via merkle_tree/2 over all N"],
+      "expected_results": ["the two roots are byte-identical for every N and every p"], "status": "pending" },
+    { "id": "TC-35.1.2", "name": "signed STH from incremental path verifies", "type": "integration",
+      "preconditions": ["a tenant with an audit key and a non-empty chain"],
+      "steps": ["append entries", "sign_and_store_tree_head/1 (incremental)", "fetch the STH and verify via Verifier.verify_sth / the public endpoint"],
+      "expected_results": ["signature verifies; merkle_root equals the full-rebuild root at that position"], "status": "pending" },
+    { "id": "TC-35.1.3", "name": "no checkpoint → full-compute fallback", "type": "unit",
+      "preconditions": ["a chain with no checkpoint row"],
+      "steps": ["compute the root"],
+      "expected_results": ["equals merkle_tree/2 output; a checkpoint is then persisted for next time"], "status": "pending" },
+    { "id": "TC-35.1.4", "name": "stale/corrupt checkpoint → safe full recompute", "type": "unit",
+      "preconditions": ["a checkpoint whose position/peaks are inconsistent with the actual chain"],
+      "steps": ["compute the root"],
+      "expected_results": ["mismatch detected; correct full-rebuild root returned; no wrong root emitted"], "status": "pending" },
+    { "id": "TC-35.1.5", "name": "tenant isolation on checkpoints", "type": "integration",
+      "preconditions": ["tenant A and tenant B each with chains + checkpoints"],
+      "steps": ["incremental compute for tenant A"],
+      "expected_results": ["uses only A's entries and A's peaks; B's data never read; A's root correct"], "status": "pending" }
+  ],
+  "technical_notes": [
+    "Files: lib/loopctl/audit_chain.ex (compute_merkle_root/1, merkle_tree/2, sign_and_store_tree_head/1 — add incremental helper + checkpoint read/write); new schema lib/loopctl/audit_chain/sth_checkpoint.ex; new migration priv/repo/migrations/*_create_audit_sth_checkpoints.exs (additive CREATE TABLE, per-tenant unique on tenant_id).",
+    "Approach: keep a list of stable subtree peaks (roots of complete left-aligned 2^k blocks). merkle_tree/2's odd-level last-element duplication means the peak-combination step must replicate that EXACT fold order — implement it against the oracle, do not assume RFC-6962. The property test (AC-35.1.2) is the gate; write it first.",
+    "Do NOT modify merkle_tree/2 — it is the reference oracle and the on-disk history depends on it. The checkpoint is a cache; a bug must degrade to a correct full recompute, never a wrong root.",
+    "AdminRepo (BYPASSRLS) is used by the existing STH path; keep it, but add a per-query SET LOCAL statement_timeout on the bounded incremental read. Checkpoint table uses ENABLE (not FORCE) ROW LEVEL SECURITY per project RLS rule; but since STH runs via AdminRepo, scope explicitly by tenant_id in every query.",
+    "SECURITY REVIEW REQUIRED: this story's review must include the security-adversary lens on root divergence, replay, and byzantine/custody-halt (docs/chain-of-custody-v2.md L2/L3/L6). Config-based DI for the statement_timeout; no Application.put_env in tests.",
+    "Reference: KB article 397cf0d4 'Append-only audit log with hash chaining and Signed Tree Heads — loopctl'."
+  ],
+  "dependencies": [],
+  "estimated_tokens": 450000
+}

--- a/docs/user_stories/epic_35_sth_cron_redesign/us_35.2.json
+++ b/docs/user_stories/epic_35_sth_cron_redesign/us_35.2.json
@@ -1,0 +1,54 @@
+{
+  "id": "US-35.2",
+  "title": "Event-driven STH: audit-append firehose topic + supervised debounce-enqueuer",
+  "epic": { "id": "epic_35", "name": "STH & Cron Fleet-Cost Redesign" },
+  "priority": "high",
+  "phase": "scalability",
+  "priority_note": "Turns STH from a per-minute all-tenants poll into an event-driven, activity-gated path. Absorbs #350's 'poll-based rather than event-driven' finding AND the remaining 'gate to tenants with new activity' part of the fanout finding. Additive — the existing cron keeps running unchanged until US-35.3 slows it.",
+  "background": {
+    "reference": "GH #350. AuditChain.append/1 already broadcasts on chain growth: ChainPubSub.broadcast_entry(tenant_id, entry) (audit_chain.ex:74) → Phoenix.PubSub topic \"audit_chain:<tenant_id>\", message {:audit_chain_entry, entry} (lib/loopctl/audit_chain/pubsub.ex:11-19). NOTHING consumes it to enqueue STH — the only subscribers are external agent witness caches. ComputeSthWorker is enqueued ONLY by the per-minute cron (config/config.exs:331). So every minute N per-tenant jobs are enqueued for ALL active tenants (compute_sth_worker.ex:51-53), each self-gating via sth_needed?/1 — N idle-tenant no-op jobs/min.",
+    "includes": "Design wrinkle: today's broadcast is PER-TENANT topic, so a singleton subscriber would have to know and subscribe to every tenant's topic. Cleanest fix: broadcast ALSO to a single fixed firehose topic carrying the entry (which already includes tenant_id), and subscribe one supervised GenServer to that. Debounce must be Basic-Engine-safe: enqueue via single Oban.insert/2 (where `unique` IS honored) with a short schedule_in so an append burst coalesces to one compute per tenant."
+  },
+  "story": {
+    "as_a": "loopctl operator",
+    "i_want_to": "enqueue a debounced per-tenant ComputeSthWorker job in response to the audit-append broadcast, instead of relying on the blanket per-minute poll",
+    "so_that": "an STH is computed promptly after real activity, only tenants that actually appended get a job, and the fleet stops enqueuing N idle-tenant no-op jobs every minute"
+  },
+  "rationale": "The append path already fires a PubSub event on chain growth; wiring a supervised subscriber that debounce-enqueues the existing worker makes STH event-driven and activity-gated with no change to the compute itself. Doing it additively (new firehose topic alongside the per-tenant topic, cron left intact) means this story carries no latency risk on its own — US-35.3 later reduces the poll once this path is proven.",
+  "acceptance_criteria": [
+    { "id": "AC-35.2.1", "description": "AuditChain.append/1 broadcasts the new entry to a single fixed firehose topic (e.g. \"audit_chain:events\") IN ADDITION to the existing per-tenant \"audit_chain:<tenant_id>\" topic. The existing per-tenant topic, its {:audit_chain_entry, …} and {:sth_updated, …} messages, and external subscribers are UNCHANGED (verified by an existing-behavior test).", "status": "pending" },
+    { "id": "AC-35.2.2", "description": "A new supervised singleton GenServer (e.g. Loopctl.AuditChain.SthEnqueuer) subscribes to the firehose topic on start and, on each {:audit_chain_entry, entry}, enqueues ComputeSthWorker for entry.tenant_id via a single Oban.insert/2 (NOT insert_all) with a short config-driven schedule_in debounce. It is added to the application supervision tree.", "status": "pending" },
+    { "id": "AC-35.2.3", "description": "Debounce/coalescing is Basic-Engine-safe: the insert uses `unique: [fields: [:worker, :args], period: …, states: [:available, :scheduled]]` so a burst of appends for one tenant within the window collapses to a single scheduled job. A test appends several entries for one tenant in quick succession and asserts exactly one ComputeSthWorker job is scheduled for that tenant (not one per append).", "status": "pending" },
+    { "id": "AC-35.2.4", "description": "Correctness: after the debounced job runs, the tenant's STH reflects the latest chain_position (the enqueued per-tenant job path is the existing idempotent perform/1 clause — unchanged). An integration test appends, lets the enqueuer fire, drains the queue, and asserts an STH exists at the new position.", "status": "pending" },
+    { "id": "AC-35.2.5", "description": "Resilience: the enqueuer never crashes the append path (broadcast is fire-and-forget) and never crashes itself on a malformed/unknown message (logs + ignores). If the enqueuer is down or misses an event, correctness is preserved because the existing cron poll still runs (this story does NOT touch the cron) — a test asserts the enqueuer tolerates an enqueue error without dying.", "status": "pending" },
+    { "id": "AC-35.2.6", "description": "Multi-node safe: with the firehose delivered to every node, each node's enqueuer may insert, but Oban `unique` dedups at the DB so at most one job per tenant per window survives. No tenant-scoped tags or unbounded state in the GenServer (it holds no per-tenant map that grows without bound). Purely additive; no job semantics change.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-35.2.1", "name": "append broadcasts to both per-tenant and firehose topics", "type": "integration",
+      "preconditions": ["subscribe a test process to both \"audit_chain:<id>\" and \"audit_chain:events\""],
+      "steps": ["AuditChain.append/1"],
+      "expected_results": ["both topics receive {:audit_chain_entry, entry}; per-tenant message shape unchanged"], "status": "pending" },
+    { "id": "TC-35.2.2", "name": "burst of appends coalesces to one scheduled job", "type": "integration",
+      "preconditions": ["enqueuer running; Oban in manual/testing mode"],
+      "steps": ["append 5 entries for tenant A within the debounce window"],
+      "expected_results": ["exactly one ComputeSthWorker job scheduled with args tenant_id=A"], "status": "pending" },
+    { "id": "TC-35.2.3", "name": "event-driven STH reaches latest position", "type": "integration",
+      "preconditions": ["tenant with audit key"],
+      "steps": ["append", "allow enqueuer to fire", "drain :audit queue"],
+      "expected_results": ["an STH exists at the appended chain_position"], "status": "pending" },
+    { "id": "TC-35.2.4", "name": "enqueuer survives an enqueue error", "type": "unit",
+      "preconditions": ["stub the enqueue to raise/return error"],
+      "steps": ["deliver a firehose message"],
+      "expected_results": ["error logged; GenServer stays alive; append path unaffected"], "status": "pending" }
+  ],
+  "technical_notes": [
+    "Files: lib/loopctl/audit_chain/pubsub.ex (add firehose topic + broadcast), lib/loopctl/audit_chain.ex:74 (also broadcast to firehose), new lib/loopctl/audit_chain/sth_enqueuer.ex (supervised GenServer), lib/loopctl/application.ex (add to tree).",
+    "Basic Engine: `unique` IS honored by Oban.insert/2 (single insert) — that's exactly this path, unlike the insert_all fanout in compute_sth_worker.ex where it's inert. Rely on it for cross-node dedup.",
+    "schedule_in debounce + unique period should be aligned (e.g. a few seconds) so coalescing and dedup agree; make both config-driven (config-based DI, no Application.put_env in tests).",
+    "Do NOT change ComputeSthWorker.perform/1's per-tenant clause or the cron — this story only adds the event path. US-35.3 (depends on this) reduces the cron.",
+    "GenServer must be a singleton child with a name; per Elixir guidelines a named process in the child spec. Hold no unbounded per-tenant state — dedup lives in Oban, not the GenServer.",
+    "Tenant isolation: the firehose carries entry.tenant_id and the enqueued job is per-tenant; no cross-tenant read occurs here."
+  ],
+  "dependencies": [],
+  "estimated_tokens": 350000
+}

--- a/docs/user_stories/epic_35_sth_cron_redesign/us_35.3.json
+++ b/docs/user_stories/epic_35_sth_cron_redesign/us_35.3.json
@@ -1,0 +1,47 @@
+{
+  "id": "US-35.3",
+  "title": "Reduce the all-tenants STH cron from every-minute to a low-frequency safety sweep",
+  "epic": { "id": "epic_35", "name": "STH & Cron Fleet-Cost Redesign" },
+  "priority": "medium",
+  "phase": "scalability",
+  "priority_note": "The fleet-cost payoff. Once US-35.2 makes STH event-driven, the per-minute all-tenants poll is redundant for the common case and only needs to exist as a safety net for events the enqueuer missed. Lowering its frequency cuts idle-tenant no-op job churn dramatically. Config-only behavior change; independently revertible.",
+  "background": {
+    "reference": "GH #350. config/config.exs:331 schedules {\"* * * * *\", ComputeSthWorker, args: %{\"mode\" => \"all_tenants\"}} — every minute, fanning out one per-tenant job for EVERY active tenant (compute_sth_worker.ex:51-53), each a no-op via sth_needed?/1 unless the chain grew. With US-35.2 handling the fast path, this poll's only remaining job is to catch tenants whose broadcast was missed (enqueuer restart, delivery gap).",
+    "includes": "Because every per-tenant job self-gates on sth_needed?/1, slowing the poll cannot produce a WRONG STH — it can only, in the worst case, delay an STH for a tenant the event path also missed, bounded by the new sweep interval. The :audit queue is concurrency 3; fewer enqueued no-ops also relieves that queue and the primary DB."
+  },
+  "story": {
+    "as_a": "loopctl operator",
+    "i_want_to": "run the all-tenants ComputeSthWorker cron on a low, configurable interval (a safety sweep) instead of every minute",
+    "so_that": "the fleet stops enqueuing N idle-tenant no-op jobs every single minute, while a bounded-lag safety net still guarantees eventual STH for any activity the event-driven path missed"
+  },
+  "rationale": "US-35.2 provides the primary, activity-gated STH path; the blanket per-minute poll then contributes almost only no-op churn. Reducing its cadence to a config-driven interval (e.g. every 5 minutes) is a minimal, reversible change that captures most of the fleet-cost win from #350's cron findings, with the sth_needed?/1 gate guaranteeing correctness regardless of interval.",
+  "acceptance_criteria": [
+    { "id": "AC-35.3.1", "description": "The all-tenants ComputeSthWorker cron entry runs on a reduced, configurable interval (default e.g. every 5 minutes) rather than \"* * * * *\". The interval/cron expression is driven by config (config-based DI) so it can be tuned per environment and reverted without code changes.", "status": "pending" },
+    { "id": "AC-35.3.2", "description": "The safety-sweep semantics are unchanged from today's fanout: it still enqueues per-tenant jobs for active tenants via the existing insert_all+jitter path (US-32.5), and each job still self-gates via sth_needed?/1. No change to the per-tenant compute. A test asserts a tenant that appended between sweeps still gets an STH by the next sweep even if the event path is disabled.", "status": "pending" },
+    { "id": "AC-35.3.3", "description": "Correctness is interval-independent: a test with the event-driven enqueuer (US-35.2) OFF and the reduced cron ON asserts that after appends, running one safety sweep produces an STH at the latest position for each affected tenant (bounded-lag guarantee). Slowing the poll never yields a wrong or missing-forever STH.", "status": "pending" },
+    { "id": "AC-35.3.4", "description": "Purely a scheduling/config change — no change to worker logic, queues, or the fanout mechanics. The jitter window (US-32.5) and insert_all chunking remain intact and still apply to each sweep.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-35.3.1", "name": "cron interval comes from config", "type": "unit",
+      "preconditions": [],
+      "steps": ["read the Oban cron config for the all_tenants ComputeSthWorker entry"],
+      "expected_results": ["the schedule reflects the configured low-frequency interval, not \"* * * * *\"; value is config-driven"], "status": "pending" },
+    { "id": "TC-35.3.2", "name": "safety sweep still produces STH with event path off", "type": "integration",
+      "preconditions": ["event-driven enqueuer disabled/not firing", "tenant appended new entries"],
+      "steps": ["run one all_tenants sweep", "drain the :audit queue"],
+      "expected_results": ["an STH exists at the latest chain_position for the tenant"], "status": "pending" },
+    { "id": "TC-35.3.3", "name": "idle tenant sweep is a no-op", "type": "integration",
+      "preconditions": ["tenant with an existing STH at head, no new entries"],
+      "steps": ["run one sweep, drain queue"],
+      "expected_results": ["no new STH row created (sth_needed?/1 false)"], "status": "pending" }
+  ],
+  "technical_notes": [
+    "Files: config/config.exs (the Oban Cron plugin entry at ~:331) and/or config/runtime.exs so the interval is a runtime env var (consistent with US-32.2 moving Oban concurrencies to runtime.exs). Keep args: %{\"mode\" => \"all_tenants\"}.",
+    "Prefer a runtime-configurable cron expression / interval (env var with a safe default) so ops can tune or revert without a deploy; document the default.",
+    "Do not touch ComputeSthWorker.perform/1, the jitter, or the insert_all chunking — only the schedule.",
+    "This story DEPENDS on US-35.2 (the event path must exist and be proven before the poll is slowed). Sequence it after 35.2 in implement-plan.",
+    "Smoke-gate: after merge, confirm STHs still advance for an active tenant within the new interval; knowledge_count / STH endpoint health either side."
+  ],
+  "dependencies": ["US-35.2"],
+  "estimated_tokens": 250000
+}


### PR DESCRIPTION
## Summary

Authors the user stories for **Epic 35 — STH & Cron Fleet-Cost Redesign**, remediating GH #350 (roadmap Epic 3, tracked #355). Docs only, no code change.

### Scope reconciliation (verified against master)
#350 predates recent work — **3 of its 6 findings are already fixed** and are excluded:
- N single-row inserts → `insert_all` (chunked): done in **US-32.5**
- Zero-jitter thundering herd: deterministic `phash2` jitter over a 56s window, done in **US-32.5**
- `RevokeExpiredDispatchesWorker` index + `dispatches (expires_at) WHERE revoked_at IS NULL` partial: done in **US-32.1**

### Remaining work (3 stories)
- **US-35.1 (critical)** — Incremental STH via a checkpointed set of stable Merkle peaks, folding only entries above the last STH. Root must be **byte-identical** to the current Bitcoin-style `merkle_tree/2` (property-tested with the existing function as oracle) so historical STHs / external witnesses keep verifying and no divergent STH trips the L6 byzantine halt. Removes the per-append O(chain) rebuild.
- **US-35.2** — Event-driven STH: an audit-append firehose topic (additive, alongside the unchanged per-tenant topic) plus a supervised debounce-enqueuer using Basic-Engine-safe `Oban.insert/2` + `unique`. Cron untouched.
- **US-35.3** — Reduce the all-tenants cron from every-minute to a low-frequency, config-driven safety sweep (depends on US-35.2; `sth_needed?/1` guarantees correctness at any interval).

### Constraints baked into the stories
- US-35.1 review must include the security-adversary lens (root divergence / replay / byzantine halt).
- Its one migration is an additive `CREATE TABLE` (no hot-table lock).
- All new reads run on a read path with a per-query `SET LOCAL statement_timeout` (pgbouncer-safe).

Next: `implement-plan` on the epic folder (WIP=1, review-gated).
