### PR TITLE
Incremental STH: checkpointed Merkle peaks, root byte-identical to the current construction

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -132,7 +132,14 @@ config :loopctl, :heavy_read_statement_timeout_overrides, %{
   # LOCAL persisting into the enclosing sandbox transaction (same rationale as
   # :llm_usage/:memory_recall). No test asserts an :ingestion_jobs timeout, so this
   # cannot mask a real one.
-  ingestion_jobs: 5_000
+  ingestion_jobs: 5_000,
+  # US-35.1: the incremental-STH tail read and the keyset-paged full-rebuild read
+  # over audit_chain (Loopctl.HeavyRead.opts(:sth_incremental)). A few-hundred-row
+  # indexed range scan is sub-ms on the sandbox, but a generous 5s override keeps it
+  # off the aggressive 250ms pool default under parallel contention (same rationale
+  # as the endpoints above). No test asserts a :sth_incremental timeout, so this
+  # cannot mask a real one.
+  sth_incremental: 5_000
 }
 
 # US-27.6b: the over-fetch pool sizing knobs (`Loopctl.Knowledge.VectorSearch.pool_size/2`).

--- a/lib/loopctl/audit_chain.ex
+++ b/lib/loopctl/audit_chain.ex
@@ -174,8 +174,25 @@ defmodule Loopctl.AuditChain do
   Falls back to a correct FULL rebuild — over `compute_merkle_root/1`'s oracle
   construction — whenever there is no checkpoint, or the checkpoint is stale /
   structurally inconsistent with the actual chain (AC-35.1.1 / AC-35.1.5). The
-  checkpoint is a pure performance cache: an inconsistency degrades to a correct
+  checkpoint is a pure performance cache: a STRUCTURAL inconsistency (position
+  ahead of the head, wrong peak count, non-32-byte peak) degrades to a correct
   root, never a wrong one.
+
+  ## Trust boundary — the cache has no content-integrity check
+
+  Validation (`valid_checkpoint?/2`) is STRUCTURAL only. Unlike `entry_hash`
+  values — which are hash-CHAINED to `prev_entry_hash` and therefore
+  self-verifying against the source of truth — the cached peak VALUES link to
+  nothing verifiable and are NOT re-derived from `entry_hashes`. A checkpoint
+  with the right peak count and 32-byte peaks but WRONG bytes (bit-rot, a bad
+  write, or a tampered `audit_sth_checkpoints` row) passes validation and would
+  be folded into the signed root; the next incremental sign folds those corrupt
+  peaks into new peaks, so the taint could propagate forward. The cache's
+  integrity therefore rests on the invariant that its row is only ever written by
+  the trusted, same-transaction `sign_and_store_tree_head/1` path and never
+  silently corrupted at rest — NOT on a self-check here. A divergent-STH signal
+  (an incremental root that disagrees with an independent full recompute) is the
+  L6 byzantine/custody-halt condition, detected out-of-band, not by this fold.
 
   ## Returns
 
@@ -222,17 +239,27 @@ defmodule Loopctl.AuditChain do
   # Fallback: rebuild from the whole chain. `root` is the oracle
   # `merkle_tree/2` construction (byte-identical guarantee); the peaks are folded
   # from the same load so a fresh checkpoint can be persisted for next time.
+  #
+  # This is the O(n) whole-chain read that fires for EVERY tenant on its first STH
+  # after deploy (no checkpoint yet) and on any checkpoint loss/corruption — the
+  # heaviest read on this path. It is routed through `HeavyRead` for the SAME
+  # per-query `SET LOCAL statement_timeout` protection the incremental tail read
+  # gets (AC-35.1.6: "Reads run on a read path with a per-query statement_timeout"),
+  # so the fleet-wide unbounded read GH #350 / epic 35 exist to guard can never run
+  # untimed on the BYPASSRLS admin pool. Its `where` is conjunctively tenant-scoped,
+  # so it passes the HeavyRead structural guard.
   defp full_rebuild_root(tenant_id, latest_pos) do
     # Bounded by `latest_pos` (the head read a moment ago) so a concurrent append
     # can't pull leaves beyond the position we're about to sign — the loaded set
     # is a consistent snapshot of [0..latest_pos].
-    hashes =
+    query =
       from(e in Entry,
         where: e.tenant_id == ^tenant_id and e.chain_position <= ^latest_pos,
         order_by: [asc: e.chain_position],
         select: e.entry_hash
       )
-      |> AdminRepo.all()
+
+    hashes = HeavyRead.all(tenant_id, query, HeavyRead.opts(:sth_incremental))
 
     root = merkle_tree(hashes)
     peaks = mmr_append_all([], hashes)

--- a/lib/loopctl/audit_chain.ex
+++ b/lib/loopctl/audit_chain.ex
@@ -18,6 +18,7 @@ defmodule Loopctl.AuditChain do
       })
   """
 
+  import Bitwise
   import Ecto.Query
 
   alias Ecto.Multi
@@ -25,6 +26,8 @@ defmodule Loopctl.AuditChain do
   alias Loopctl.AuditChain.Entry
   alias Loopctl.AuditChain.PubSub, as: ChainPubSub
   alias Loopctl.AuditChain.SignedTreeHead
+  alias Loopctl.AuditChain.SthCheckpoint
+  alias Loopctl.HeavyRead
   alias Loopctl.TenantKeys
 
   @zero_hash :binary.copy(<<0>>, 32)
@@ -159,6 +162,132 @@ defmodule Loopctl.AuditChain do
   end
 
   @doc """
+  US-35.1 — Incremental Merkle root: byte-identical to `compute_merkle_root/1`.
+
+  Computes the tenant's current Merkle root using the persisted checkpoint of
+  stable peaks, loading ONLY entries with `chain_position` above the checkpoint
+  (a bounded, tenant-scoped, statement-timeout-guarded read via
+  `Loopctl.HeavyRead`) and folding them into those peaks. Returns the root AND
+  the refreshed checkpoint data (`%{chain_position, peaks}`) so the caller can
+  persist it atomically with the STH it signs.
+
+  Falls back to a correct FULL rebuild — over `compute_merkle_root/1`'s oracle
+  construction — whenever there is no checkpoint, or the checkpoint is stale /
+  structurally inconsistent with the actual chain (AC-35.1.1 / AC-35.1.5). The
+  checkpoint is a pure performance cache: an inconsistency degrades to a correct
+  root, never a wrong one.
+
+  ## Returns
+
+  - `{:ok, root_bytes, %{chain_position: pos, peaks: [binary]}}` for a non-empty chain
+  - `{:ok, nil, nil}` for an empty chain
+  """
+  @spec compute_merkle_root_incremental(Ecto.UUID.t()) ::
+          {:ok, binary(), %{chain_position: non_neg_integer(), peaks: [binary()]}}
+          | {:ok, nil, nil}
+  def compute_merkle_root_incremental(tenant_id) when is_binary(tenant_id) do
+    case latest_entry(tenant_id) do
+      nil ->
+        {:ok, nil, nil}
+
+      %Entry{chain_position: latest_pos} ->
+        case load_valid_checkpoint(tenant_id, latest_pos) do
+          {:ok, %SthCheckpoint{chain_position: cp_pos, peaks: cp_peaks}} ->
+            incremental_root(tenant_id, latest_pos, cp_pos, cp_peaks)
+
+          :fallback ->
+            full_rebuild_root(tenant_id, latest_pos)
+        end
+    end
+  end
+
+  # Incremental path: fold ONLY the tail (positions above the checkpoint) into
+  # the checkpoint's stable peaks. When the checkpoint is already at the head
+  # (no tail) the peaks are bagged directly.
+  defp incremental_root(tenant_id, latest_pos, cp_pos, cp_peaks) do
+    peaks0 = peaks_with_heights(cp_peaks, cp_pos + 1)
+
+    tail_hashes =
+      if latest_pos > cp_pos do
+        load_tail_hashes(tenant_id, cp_pos, latest_pos)
+      else
+        []
+      end
+
+    peaks = mmr_append_all(peaks0, tail_hashes)
+    root = bag_peaks(peaks)
+    {:ok, root, %{chain_position: latest_pos, peaks: peak_hashes(peaks)}}
+  end
+
+  # Fallback: rebuild from the whole chain. `root` is the oracle
+  # `merkle_tree/2` construction (byte-identical guarantee); the peaks are folded
+  # from the same load so a fresh checkpoint can be persisted for next time.
+  defp full_rebuild_root(tenant_id, latest_pos) do
+    # Bounded by `latest_pos` (the head read a moment ago) so a concurrent append
+    # can't pull leaves beyond the position we're about to sign — the loaded set
+    # is a consistent snapshot of [0..latest_pos].
+    hashes =
+      from(e in Entry,
+        where: e.tenant_id == ^tenant_id and e.chain_position <= ^latest_pos,
+        order_by: [asc: e.chain_position],
+        select: e.entry_hash
+      )
+      |> AdminRepo.all()
+
+    root = merkle_tree(hashes)
+    peaks = mmr_append_all([], hashes)
+    {:ok, root, %{chain_position: latest_pos, peaks: peak_hashes(peaks)}}
+  end
+
+  # Bounded, tenant-scoped tail read: entries strictly above the checkpoint
+  # position, up to and INCLUDING the chain head read a moment ago (`latest_pos`)
+  # so a concurrent append can't fold in leaves beyond the position we sign.
+  # Ordered ascending. Routed through `HeavyRead` so it runs under a per-query
+  # `SET LOCAL statement_timeout` (pgbouncer-safe) and its structural guard proves
+  # the `tenant_id` predicate is present (AC-35.1.6). In test env
+  # `:heavy_read_repo` is aliased to `AdminRepo`, so this shares the sandbox.
+  defp load_tail_hashes(tenant_id, cp_pos, latest_pos) do
+    query =
+      from(e in Entry,
+        where:
+          e.tenant_id == ^tenant_id and e.chain_position > ^cp_pos and
+            e.chain_position <= ^latest_pos,
+        order_by: [asc: e.chain_position],
+        select: e.entry_hash
+      )
+
+    HeavyRead.all(tenant_id, query, HeavyRead.opts(:sth_incremental))
+  end
+
+  # Loads the tenant's checkpoint and validates it against the actual chain
+  # head. Returns `{:ok, checkpoint}` only when it is safe to fold onto;
+  # otherwise `:fallback` so the caller does a full recompute (AC-35.1.5).
+  defp load_valid_checkpoint(tenant_id, latest_pos) do
+    checkpoint =
+      from(c in SthCheckpoint, where: c.tenant_id == ^tenant_id)
+      |> AdminRepo.one()
+
+    if valid_checkpoint?(checkpoint, latest_pos), do: {:ok, checkpoint}, else: :fallback
+  end
+
+  # A checkpoint is usable iff:
+  #   * it exists with a non-negative position that is NOT ahead of the chain
+  #     head (a position ahead signals a stale/partial write), and
+  #   * every stored peak is a 32-byte hash, and
+  #   * the number of peaks equals the popcount of the covered leaf count
+  #     (`chain_position + 1`) — the structural invariant of the peak set.
+  # Anything else is treated as corrupt and ignored in favour of a full rebuild.
+  defp valid_checkpoint?(nil, _latest_pos), do: false
+
+  defp valid_checkpoint?(%SthCheckpoint{chain_position: cp_pos, peaks: peaks}, latest_pos)
+       when is_integer(cp_pos) and cp_pos >= 0 and cp_pos <= latest_pos and is_list(peaks) do
+    Enum.all?(peaks, &(is_binary(&1) and byte_size(&1) == 32)) and
+      length(peaks) == popcount(cp_pos + 1)
+  end
+
+  defp valid_checkpoint?(_checkpoint, _latest_pos), do: false
+
+  @doc """
   Signs a tree head for a tenant using the tenant's audit-signing key.
   Stores the result in `audit_signed_tree_heads`.
 
@@ -166,15 +295,20 @@ defmodule Loopctl.AuditChain do
   """
   @spec sign_and_store_tree_head(Ecto.UUID.t()) :: {:ok, SignedTreeHead.t()} | {:error, term()}
   def sign_and_store_tree_head(tenant_id) do
-    with {:ok, merkle_root} when not is_nil(merkle_root) <- compute_merkle_root(tenant_id),
-         %Entry{chain_position: position} <- latest_entry(tenant_id),
+    with {:ok, merkle_root, %{chain_position: position, peaks: peaks}}
+         when not is_nil(merkle_root) <- compute_merkle_root_incremental(tenant_id),
          {:ok, private_key} <- TenantKeys.get_private_key(tenant_id) do
       now = DateTime.utc_now()
 
+      # US-35.1: sign the SAME position the incremental root was computed at (both
+      # derived from one `latest_entry` read), so the checkpoint we persist is
+      # consistent with the position just signed. The signed message and ed25519
+      # signing are UNCHANGED — a verifier that recomputes the root the old way
+      # still validates (AC-35.1.4).
       message = build_sth_message(tenant_id, position, merkle_root, now)
       signature = :crypto.sign(:eddsa, :sha512, message, [private_key, :ed25519])
 
-      sth =
+      sth_changeset =
         %SignedTreeHead{tenant_id: tenant_id}
         |> SignedTreeHead.changeset(%{
           chain_position: position,
@@ -182,23 +316,35 @@ defmodule Loopctl.AuditChain do
           signed_at: now,
           signature: signature
         })
-        |> AdminRepo.insert(
+
+      checkpoint_changeset =
+        %SthCheckpoint{tenant_id: tenant_id}
+        |> SthCheckpoint.changeset(%{chain_position: position, peaks: peaks})
+
+      # US-35.1: the STH insert and the checkpoint upsert happen in ONE logical
+      # operation, so the persisted peaks are always consistent with a signed STH.
+      multi =
+        Multi.new()
+        |> Multi.insert(:sth, sth_changeset,
           on_conflict: {:replace, [:merkle_root, :signed_at, :signature]},
           conflict_target: [:tenant_id, :chain_position]
         )
+        |> Multi.insert(:checkpoint, checkpoint_changeset,
+          on_conflict: {:replace, [:chain_position, :peaks, :updated_at]},
+          conflict_target: [:tenant_id]
+        )
 
-      # US-26.5.1: broadcast STH to PubSub subscribers
-      case sth do
-        {:ok, stored_sth} ->
+      case AdminRepo.transaction(multi) do
+        {:ok, %{sth: stored_sth}} ->
+          # US-26.5.1: broadcast STH to PubSub subscribers
           ChainPubSub.broadcast_sth(tenant_id, stored_sth)
           {:ok, stored_sth}
 
-        error ->
-          error
+        {:error, _step, reason, _changes} ->
+          {:error, reason}
       end
     else
-      {:ok, nil} -> {:error, :empty_chain}
-      nil -> {:error, :empty_chain}
+      {:ok, nil, nil} -> {:error, :empty_chain}
       {:error, reason} -> {:error, reason}
     end
   end
@@ -283,6 +429,80 @@ defmodule Loopctl.AuditChain do
 
     merkle_tree(next_level)
   end
+
+  # --- US-35.1 incremental Merkle peaks ---
+  #
+  # A peak is `{height, hash}`: the root of a complete left-aligned 2^height
+  # block. Peaks are kept left-to-right by DESCENDING height (an MMR frontier);
+  # the heights are exactly the set-bit positions of the leaf count.
+  #
+  # `mmr_append_all/2` appends leaves to the frontier — pairwise-merging equal
+  # height neighbours — producing peaks whose values are byte-identical to the
+  # corresponding complete-subtree roots of `merkle_tree/2`. `bag_peaks/1` folds
+  # the frontier into the final root, replicating `merkle_tree/2`'s EXACT
+  # Bitcoin-style per-level pad-and-hash order (verified byte-for-byte by the
+  # property test, TC-35.1.1). `merkle_tree/2` remains the reference oracle and
+  # is NOT modified.
+
+  # Rehydrate `{height, hash}` peaks from stored hashes + covered leaf count.
+  # Heights are the set-bit positions of `count`, descending — the same order
+  # `mmr_append_all/2` maintains. Caller has already checked the count matches.
+  defp peaks_with_heights(hashes, count) do
+    Enum.zip(heights_from_count(count), hashes)
+  end
+
+  defp peak_hashes(peaks), do: Enum.map(peaks, fn {_height, hash} -> hash end)
+
+  defp mmr_append_all(peaks, leaves) do
+    Enum.reduce(leaves, peaks, fn leaf, acc -> mmr_append(acc, leaf) end)
+  end
+
+  # Push a height-0 leaf onto the frontier and merge equal-height neighbours
+  # from the right (left element first in the hash: left <> right).
+  defp mmr_append(peaks, leaf), do: mmr_merge(peaks ++ [{0, leaf}])
+
+  defp mmr_merge(peaks) do
+    case Enum.reverse(peaks) do
+      [{height, right}, {height, left} | rest] ->
+        merged = {height + 1, :crypto.hash(:sha256, left <> right)}
+        mmr_merge(Enum.reverse([merged | rest]))
+
+      _ ->
+        peaks
+    end
+  end
+
+  # Fold a descending-height frontier into the single Bitcoin-style root.
+  # Starting from the rightmost (lowest) peak as the carry, each peak to the left
+  # is combined after lifting the carry up to that peak's height by repeated
+  # self-pairing (replicating merkle_tree's "duplicate the last element" pad).
+  defp bag_peaks([{_height, hash}]), do: hash
+
+  defp bag_peaks(peaks) do
+    [{low_h, low_v} | rest_right_to_left] = Enum.reverse(peaks)
+
+    {_height, root} =
+      Enum.reduce(rest_right_to_left, {low_h, low_v}, fn {peak_h, peak_v}, {carry_h, carry_v} ->
+        lifted = lift_carry(carry_h, carry_v, peak_h)
+        {peak_h + 1, :crypto.hash(:sha256, peak_v <> lifted)}
+      end)
+
+    root
+  end
+
+  defp lift_carry(height, value, target) when height < target do
+    lift_carry(height + 1, :crypto.hash(:sha256, value <> value), target)
+  end
+
+  defp lift_carry(_height, value, _target), do: value
+
+  defp heights_from_count(count) do
+    0..63
+    |> Enum.filter(fn bit -> (count >>> bit &&& 1) == 1 end)
+    |> Enum.reverse()
+  end
+
+  defp popcount(count), do: count |> heights_from_count() |> length()
 
   # --- Private ---
 

--- a/lib/loopctl/audit_chain.ex
+++ b/lib/loopctl/audit_chain.ex
@@ -21,6 +21,8 @@ defmodule Loopctl.AuditChain do
   import Bitwise
   import Ecto.Query
 
+  require Logger
+
   alias Ecto.Multi
   alias Loopctl.AdminRepo
   alias Loopctl.AuditChain.Entry
@@ -178,21 +180,24 @@ defmodule Loopctl.AuditChain do
   ahead of the head, wrong peak count, non-32-byte peak) degrades to a correct
   root, never a wrong one.
 
-  ## Trust boundary — the cache has no content-integrity check
+  ## Trust boundary — checkpoint peaks are re-derived against the signed STH
 
-  Validation (`valid_checkpoint?/2`) is STRUCTURAL only. Unlike `entry_hash`
-  values — which are hash-CHAINED to `prev_entry_hash` and therefore
-  self-verifying against the source of truth — the cached peak VALUES link to
-  nothing verifiable and are NOT re-derived from `entry_hashes`. A checkpoint
-  with the right peak count and 32-byte peaks but WRONG bytes (bit-rot, a bad
-  write, or a tampered `audit_sth_checkpoints` row) passes validation and would
-  be folded into the signed root; the next incremental sign folds those corrupt
-  peaks into new peaks, so the taint could propagate forward. The cache's
-  integrity therefore rests on the invariant that its row is only ever written by
-  the trusted, same-transaction `sign_and_store_tree_head/1` path and never
-  silently corrupted at rest — NOT on a self-check here. A divergent-STH signal
-  (an incremental root that disagrees with an independent full recompute) is the
-  L6 byzantine/custody-halt condition, detected out-of-band, not by this fold.
+  Validation is two-layered. `valid_checkpoint?/2` first rejects a STRUCTURALLY
+  impossible checkpoint (position ahead of the head, wrong peak count, non-32-byte
+  peak). Then `checkpoint_root_matches_sth?/2` performs a CHEAP EXACT
+  content-integrity check IN-BAND before the peaks are ever folded into a signed
+  root: the checkpoint at `cp_pos` is always co-written with the STH at `cp_pos`
+  (whose `merkle_root` is retained in `audit_signed_tree_heads`), so we rehydrate
+  the cached peaks, bag them, and require the result to equal that stored,
+  independently-derived root. A checkpoint with the right peak count and 32-byte
+  peaks but WRONG bytes (bit-rot, a bad write, or a direct write to
+  `audit_sth_checkpoints` by anyone WITHOUT the tenant signing key) therefore
+  FAILS this check and degrades to a correct full rebuild — the legitimate signer
+  never signs a wrong root off a corrupt cache. This upholds the "never emit a
+  wrong root" invariant in-band; it does NOT replace the out-of-band L6
+  divergent-STH byzantine/custody-halt detection, which still guards against a
+  corruption of the STH root itself. The check costs one indexed STH lookup plus
+  O(log n) hashing — still O(Δ), dominated by the tail read it precedes.
 
   ## Returns
 
@@ -236,34 +241,69 @@ defmodule Loopctl.AuditChain do
     {:ok, root, %{chain_position: latest_pos, peaks: peak_hashes(peaks)}}
   end
 
+  # Whole-chain rebuild page size. Each keyset page is ONE bounded HeavyRead
+  # statement, so no single statement's cost grows with total chain length.
+  @rebuild_page_size 10_000
+
   # Fallback: rebuild from the whole chain. `root` is the oracle
   # `merkle_tree/2` construction (byte-identical guarantee); the peaks are folded
   # from the same load so a fresh checkpoint can be persisted for next time.
   #
   # This is the O(n) whole-chain read that fires for EVERY tenant on its first STH
   # after deploy (no checkpoint yet) and on any checkpoint loss/corruption — the
-  # heaviest read on this path. It is routed through `HeavyRead` for the SAME
-  # per-query `SET LOCAL statement_timeout` protection the incremental tail read
-  # gets (AC-35.1.6: "Reads run on a read path with a per-query statement_timeout"),
-  # so the fleet-wide unbounded read GH #350 / epic 35 exist to guard can never run
-  # untimed on the BYPASSRLS admin pool. Its `where` is conjunctively tenant-scoped,
-  # so it passes the HeavyRead structural guard.
+  # heaviest read on this path. It is KEYSET-PAGED (`load_all_hashes_paged/2`): each
+  # page is a separate bounded, tenant-scoped, `SET LOCAL statement_timeout`-guarded
+  # `HeavyRead` statement of at most `@rebuild_page_size` rows, so a very large chain
+  # can NEVER trip a self-reinforcing STH lockout — the failure mode where a single
+  # unbounded whole-chain read exceeds the pool statement_timeout, aborts the sign
+  # job forever, and so never persists the first checkpoint that would shrink the
+  # read. (On master this read went un-timed via `AdminRepo` and always completed;
+  # routing it through the timed `HeavyRead` path without paging would reintroduce
+  # exactly that lockout for the large-chain tenant #350 / epic 35 exist to help.)
+  # Paging across transactions is safe because `audit_chain` is append-only and
+  # immutable (DB triggers forbid update/delete), so the [0..latest_pos] prefix is a
+  # stable, gap-free snapshot regardless of how many statements read it.
   defp full_rebuild_root(tenant_id, latest_pos) do
-    # Bounded by `latest_pos` (the head read a moment ago) so a concurrent append
-    # can't pull leaves beyond the position we're about to sign — the loaded set
-    # is a consistent snapshot of [0..latest_pos].
-    query =
-      from(e in Entry,
-        where: e.tenant_id == ^tenant_id and e.chain_position <= ^latest_pos,
-        order_by: [asc: e.chain_position],
-        select: e.entry_hash
-      )
-
-    hashes = HeavyRead.all(tenant_id, query, HeavyRead.opts(:sth_incremental))
+    hashes = load_all_hashes_paged(tenant_id, latest_pos)
 
     root = merkle_tree(hashes)
     peaks = mmr_append_all([], hashes)
     {:ok, root, %{chain_position: latest_pos, peaks: peak_hashes(peaks)}}
+  end
+
+  # Reads entry_hashes for [0..latest_pos] ascending in bounded keyset pages, each a
+  # single `HeavyRead` statement (tenant-scoped, timeout-guarded). Bounded by
+  # `latest_pos` (the head read a moment ago) so a concurrent append can't pull
+  # leaves beyond the position we're about to sign.
+  defp load_all_hashes_paged(tenant_id, latest_pos) do
+    load_all_hashes_paged(tenant_id, latest_pos, -1, [])
+  end
+
+  defp load_all_hashes_paged(tenant_id, latest_pos, after_pos, acc) do
+    query =
+      from(e in Entry,
+        where:
+          e.tenant_id == ^tenant_id and e.chain_position > ^after_pos and
+            e.chain_position <= ^latest_pos,
+        order_by: [asc: e.chain_position],
+        limit: ^@rebuild_page_size,
+        select: {e.chain_position, e.entry_hash}
+      )
+
+    case HeavyRead.all(tenant_id, query, HeavyRead.opts(:sth_incremental)) do
+      [] ->
+        Enum.reverse(acc)
+
+      rows ->
+        {last_pos, _} = List.last(rows)
+        acc = Enum.reduce(rows, acc, fn {_pos, hash}, a -> [hash | a] end)
+
+        if length(rows) < @rebuild_page_size do
+          Enum.reverse(acc)
+        else
+          load_all_hashes_paged(tenant_id, latest_pos, last_pos, acc)
+        end
+    end
   end
 
   # Bounded, tenant-scoped tail read: entries strictly above the checkpoint
@@ -289,12 +329,58 @@ defmodule Loopctl.AuditChain do
   # Loads the tenant's checkpoint and validates it against the actual chain
   # head. Returns `{:ok, checkpoint}` only when it is safe to fold onto;
   # otherwise `:fallback` so the caller does a full recompute (AC-35.1.5).
+  #
+  # Two gates, cheapest first: (1) STRUCTURAL — position not ahead of the head,
+  # right peak count, 32-byte peaks; then (2) EXACT CONTENT — the cached peaks,
+  # bagged, must equal the `merkle_root` of the STH co-written at `cp_pos`. Gate 2
+  # catches right-shape/wrong-bytes corruption (bit-rot / bad or unauthorized
+  # write to `audit_sth_checkpoints`) that gate 1 cannot, so a corrupt cache
+  # degrades to a correct rebuild instead of being folded into a signed root.
   defp load_valid_checkpoint(tenant_id, latest_pos) do
     checkpoint =
       from(c in SthCheckpoint, where: c.tenant_id == ^tenant_id)
       |> AdminRepo.one()
 
-    if valid_checkpoint?(checkpoint, latest_pos), do: {:ok, checkpoint}, else: :fallback
+    if valid_checkpoint?(checkpoint, latest_pos) and
+         checkpoint_root_matches_sth?(tenant_id, checkpoint) do
+      {:ok, checkpoint}
+    else
+      :fallback
+    end
+  end
+
+  # EXACT content-integrity check: rehydrate the cached peaks, bag them, and require
+  # the result to byte-match the `merkle_root` of the STH signed at the checkpoint's
+  # own position (co-written in `sign_and_store_tree_head/1`, retained forever in
+  # `audit_signed_tree_heads`). If no such STH row exists we cannot prove the cache
+  # is authentic, so we conservatively reject it and full-rebuild. One indexed
+  # lookup + O(log n) hashing — O(Δ), dominated by the tail read it precedes.
+  defp checkpoint_root_matches_sth?(tenant_id, %SthCheckpoint{
+         chain_position: cp_pos,
+         peaks: cp_peaks
+       }) do
+    case sth_at_exact_position(tenant_id, cp_pos) do
+      %SignedTreeHead{merkle_root: stored_root} when is_binary(stored_root) ->
+        rebuilt =
+          cp_peaks
+          |> peaks_with_heights(cp_pos + 1)
+          |> bag_peaks()
+
+        rebuilt == stored_root
+
+      _ ->
+        false
+    end
+  end
+
+  # The STH at EXACTLY this position (not `>=`, unlike `get_sth_at_position/2`) —
+  # the one co-written with the checkpoint at `cp_pos`.
+  defp sth_at_exact_position(tenant_id, position) do
+    from(s in SignedTreeHead,
+      where: s.tenant_id == ^tenant_id and s.chain_position == ^position,
+      limit: 1
+    )
+    |> AdminRepo.one()
   end
 
   # A checkpoint is usable iff:
@@ -344,36 +430,85 @@ defmodule Loopctl.AuditChain do
           signature: signature
         })
 
-      checkpoint_changeset =
-        %SthCheckpoint{tenant_id: tenant_id}
-        |> SthCheckpoint.changeset(%{chain_position: position, peaks: peaks})
-
-      # US-35.1: the STH insert and the checkpoint upsert happen in ONE logical
-      # operation, so the persisted peaks are always consistent with a signed STH.
-      multi =
-        Multi.new()
-        |> Multi.insert(:sth, sth_changeset,
-          on_conflict: {:replace, [:merkle_root, :signed_at, :signature]},
-          conflict_target: [:tenant_id, :chain_position]
-        )
-        |> Multi.insert(:checkpoint, checkpoint_changeset,
-          on_conflict: {:replace, [:chain_position, :peaks, :updated_at]},
-          conflict_target: [:tenant_id]
-        )
-
-      case AdminRepo.transaction(multi) do
-        {:ok, %{sth: stored_sth}} ->
+      # US-35.1: the STH (source of truth) is committed FIRST and ON ITS OWN; the
+      # checkpoint (a pure performance cache) is upserted best-effort AFTERWARD.
+      # This deliberately does NOT share a transaction with the STH insert so a
+      # cache-write fault (FK, serialization/lock under the concurrent per-tenant
+      # fanout, disk error, a future constraint) can never roll back the
+      # custody-critical STH signing (priority inversion). AC-35.1.3's atomicity
+      # requirement is about the DANGEROUS direction — a checkpoint AHEAD of any
+      # signed STH — which STH-first ordering makes impossible: the checkpoint at
+      # `position` only ever appears after the STH at `position` has committed. A
+      # lost checkpoint write merely makes the NEXT sign do a (correct) full
+      # rebuild; `sth_needed?/1` re-fires so nothing is lost.
+      case AdminRepo.insert(sth_changeset,
+             on_conflict: {:replace, [:merkle_root, :signed_at, :signature]},
+             conflict_target: [:tenant_id, :chain_position]
+           ) do
+        {:ok, stored_sth} ->
+          upsert_checkpoint_best_effort(tenant_id, position, peaks)
           # US-26.5.1: broadcast STH to PubSub subscribers
           ChainPubSub.broadcast_sth(tenant_id, stored_sth)
           {:ok, stored_sth}
 
-        {:error, _step, reason, _changes} ->
+        {:error, reason} ->
           {:error, reason}
       end
     else
       {:ok, nil, nil} -> {:error, :empty_chain}
       {:error, reason} -> {:error, reason}
     end
+  end
+
+  # Best-effort, MONOTONIC checkpoint cache upsert (US-35.1). Runs AFTER the STH
+  # commit and never raises into the caller — a cache write is not allowed to fail
+  # the sign.
+  #
+  # `on_conflict` replaces the row only when the incoming `chain_position` is
+  # STRICTLY GREATER than the stored one, so a slower concurrent sign job that
+  # computed at an earlier position can never regress the checkpoint backward
+  # (the per-tenant fanout is not `unique`-deduped on the Basic Engine, so two
+  # sign jobs can race). When the guard holds (incoming position not newer),
+  # Postgres updates nothing and RETURNING is empty, which Ecto surfaces as
+  # `Ecto.StaleEntryError`; that is the EXPECTED monotonic no-op — a newer
+  # checkpoint already won — so we swallow it silently.
+  defp upsert_checkpoint_best_effort(tenant_id, position, peaks) do
+    changeset =
+      %SthCheckpoint{tenant_id: tenant_id}
+      |> SthCheckpoint.changeset(%{chain_position: position, peaks: peaks})
+
+    case AdminRepo.insert(changeset,
+           on_conflict: monotonic_checkpoint_on_conflict(),
+           conflict_target: [:tenant_id]
+         ) do
+      {:ok, _checkpoint} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning(
+          "AuditChain: STH signed for tenant #{tenant_id} at position #{position} but " <>
+            "checkpoint cache write failed (#{inspect(reason)}); next sign will full-rebuild"
+        )
+
+        :ok
+    end
+  rescue
+    Ecto.StaleEntryError -> :ok
+  end
+
+  # DO UPDATE ... WHERE the stored position is older than the incoming one — the
+  # monotonic guard. `EXCLUDED.*` is the row we tried to insert.
+  defp monotonic_checkpoint_on_conflict do
+    from(c in SthCheckpoint,
+      update: [
+        set: [
+          chain_position: fragment("EXCLUDED.chain_position"),
+          peaks: fragment("EXCLUDED.peaks"),
+          updated_at: fragment("EXCLUDED.updated_at")
+        ]
+      ],
+      where: c.chain_position < fragment("EXCLUDED.chain_position")
+    )
   end
 
   @doc """

--- a/lib/loopctl/audit_chain/sth_checkpoint.ex
+++ b/lib/loopctl/audit_chain/sth_checkpoint.ex
@@ -1,0 +1,49 @@
+defmodule Loopctl.AuditChain.SthCheckpoint do
+  @moduledoc """
+  US-35.1 — Per-tenant incremental STH checkpoint (a pure performance CACHE).
+
+  Persists the stable Merkle sub-tree "peaks" that cover the first
+  `chain_position + 1` audit entries of a tenant's chain, so a Signed Tree
+  Head recompute can fold ONLY the entries appended above the checkpoint into
+  those peaks instead of re-reading and re-hashing the entire chain (GH #350).
+
+  ## Peaks representation
+
+  `peaks` is a list of raw 32-byte SHA-256 hashes — the roots of the complete
+  left-aligned power-of-2 blocks that make up the checkpointed prefix, ordered
+  left-to-right by DESCENDING block height. A block of `2^k` leaves is fully
+  paired internally by `Loopctl.AuditChain.merkle_tree/2` (Bitcoin-style
+  padding only ever touches the rightmost element), so its subtree root is
+  stable as leaves are appended to the right.
+
+  The peaks' heights are NOT stored — they are exactly the set-bit positions of
+  the leaf count (`chain_position + 1`), reconstructed at read time. A checkpoint
+  whose `length(peaks)` disagrees with the popcount of `chain_position + 1` is
+  structurally corrupt and MUST be ignored in favour of a full recompute
+  (AC-35.1.5).
+
+  Only raw hashes are stored — no entry contents / plaintext leak.
+
+  This is a CACHE: any inconsistency degrades to a correct full recompute,
+  never a wrong root.
+  """
+
+  use Loopctl.Schema
+
+  @type t :: %__MODULE__{}
+
+  schema "audit_sth_checkpoints" do
+    field :tenant_id, Ecto.UUID
+    field :chain_position, :integer
+    field :peaks, {:array, :binary}
+    timestamps()
+  end
+
+  @doc false
+  def changeset(checkpoint \\ %__MODULE__{}, attrs) do
+    checkpoint
+    |> cast(attrs, [:chain_position, :peaks])
+    |> validate_required([:chain_position, :peaks])
+    |> validate_number(:chain_position, greater_than_or_equal_to: 0)
+  end
+end

--- a/lib/loopctl/heavy_read.ex
+++ b/lib/loopctl/heavy_read.ex
@@ -81,7 +81,9 @@ defmodule Loopctl.HeavyRead do
   `:change_feed`, `:vector_search` (the shared kNN helper path), `:memory_recall`
   (the US-28.2 agent-memory HNSW recall via `all_memory/4`), `:ingestion_jobs`
   (the US-34.6 `GET /knowledge/ingestion-jobs` COUNT + list over the Oban-owned
-  `oban_jobs` table, bounded by a partial expression index).
+  `oban_jobs` table, bounded by a partial expression index), `:sth_incremental`
+  (the US-35.1 bounded "entries above the STH checkpoint" tail read over
+  `audit_chain`, folded into the persisted Merkle peaks).
   """
   @spec opts(atom()) :: keyword()
   def opts(endpoint) when is_atom(endpoint) do

--- a/priv/repo/migrations/20260713030000_create_audit_sth_checkpoints.exs
+++ b/priv/repo/migrations/20260713030000_create_audit_sth_checkpoints.exs
@@ -1,0 +1,39 @@
+defmodule Loopctl.Repo.Migrations.CreateAuditSthCheckpoints do
+  use Ecto.Migration
+
+  @moduledoc """
+  US-35.1 — Additive `CREATE TABLE` for the per-tenant incremental STH
+  checkpoint (stable Merkle peaks + last chain_position). CREATE TABLE does
+  not touch or lock `audit_chain` / `audit_signed_tree_heads`.
+
+  RLS is ENABLED (not FORCED) per project rule: the production role
+  (`schema_admin`) owns the table without BYPASSRLS, and the STH job path reads
+  via `Loopctl.AdminRepo` (BYPASSRLS) with an explicit `tenant_id` predicate.
+  """
+
+  def change do
+    create table(:audit_sth_checkpoints, primary_key: false) do
+      add :id, :binary_id, primary_key: true, default: fragment("gen_random_uuid()")
+      add :tenant_id, references(:tenants, type: :binary_id, on_delete: :nothing), null: false
+      add :chain_position, :bigint, null: false
+      add :peaks, {:array, :binary}, null: false
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    # One checkpoint per tenant (upserted on conflict).
+    create unique_index(:audit_sth_checkpoints, [:tenant_id])
+
+    execute(
+      "ALTER TABLE audit_sth_checkpoints ENABLE ROW LEVEL SECURITY",
+      "ALTER TABLE audit_sth_checkpoints DISABLE ROW LEVEL SECURITY"
+    )
+
+    execute(
+      """
+      CREATE POLICY tenant_isolation_policy ON audit_sth_checkpoints
+        USING (tenant_id = current_setting('app.current_tenant_id', true)::uuid)
+      """,
+      "DROP POLICY IF EXISTS tenant_isolation_policy ON audit_sth_checkpoints"
+    )
+  end
+end

--- a/test/loopctl/audit_chain/sth_checkpoint_test.exs
+++ b/test/loopctl/audit_chain/sth_checkpoint_test.exs
@@ -151,6 +151,44 @@ defmodule Loopctl.AuditChain.SthCheckpointTest do
       end
     end
 
+    # AC-35.1.2 requires the byte-identity gate to run over "a wide range INCLUDING
+    # ... 2^k boundaries (e.g. 1..40 plus a few large values)." The sweep above caps
+    # at 40 and exercises EVERY split point; large N exercises more lift_carry
+    # iterations and multi-peak bagging, and is where the O(delta) vs O(n) win the
+    # story exists for actually matters — but sweeping every p there would be slow, so
+    # here we take a single arbitrary interior split point per large N.
+    @large_ns [128, 1000]
+
+    test "matches the oracle at a large N for a single interior split point (AC-35.1.2)" do
+      for n <- @large_ns do
+        tenant =
+          fixture(:tenant, %{slug: "sth-prop-lg-#{n}-#{System.unique_integer([:positive])}"})
+
+        :ok = build_chain(tenant.id, n)
+
+        hashes = entry_hashes(tenant.id)
+        expected = oracle_root(hashes)
+
+        assert {:ok, ^expected} = AuditChain.compute_merkle_root(tenant.id)
+
+        # An interior split that is neither a power of two nor n itself, so the
+        # checkpoint carries multiple peaks and there is a real tail to fold.
+        p = div(n, 3) * 2
+        {prefix, _tail} = Enum.split(hashes, p)
+        put_checkpoint(tenant.id, p - 1, expected_peaks(prefix, p))
+
+        assert {:ok, root, %{chain_position: pos, peaks: _}} =
+                 AuditChain.compute_merkle_root_incremental(tenant.id)
+
+        assert pos == n - 1
+
+        assert root == expected,
+               "large N=#{n}, split p=#{p}: incremental root diverged from oracle"
+
+        assert byte_size(root) == 32
+      end
+    end
+
     test "folds the empty tail (checkpoint already at head) to the same root" do
       n = 33
       tenant = fixture(:tenant)

--- a/test/loopctl/audit_chain/sth_checkpoint_test.exs
+++ b/test/loopctl/audit_chain/sth_checkpoint_test.exs
@@ -1,0 +1,340 @@
+defmodule Loopctl.AuditChain.SthCheckpointTest do
+  @moduledoc """
+  US-35.1 — Incremental STH: checkpointed Merkle peaks, byte-identical root.
+
+  The BYTE-IDENTICAL invariant (AC-35.1.2) is the gate: the incremental fold
+  over a checkpoint's stable peaks must reproduce the current `merkle_tree/2`
+  construction EXACTLY, for every chain length and every checkpoint split point,
+  or historical STHs / external witness caches stop verifying.
+  """
+
+  use Loopctl.DataCase, async: true
+
+  import Loopctl.Fixtures
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.AuditChain
+  alias Loopctl.AuditChain.SthCheckpoint
+  alias Loopctl.AuditChain.Verifier
+
+  setup :verify_on_exit!
+
+  # --- helpers ---
+
+  defp make_entry(overrides \\ %{}) do
+    Map.merge(
+      %{
+        action: "test_event",
+        actor_lineage: ["test"],
+        entity_type: "test",
+        payload: %{"k" => "v"}
+      },
+      overrides
+    )
+  end
+
+  defp build_chain(tenant_id, count) do
+    for _ <- 1..count, do: {:ok, _} = AuditChain.append(tenant_id, make_entry())
+    :ok
+  end
+
+  defp entry_hashes(tenant_id) do
+    import Ecto.Query
+
+    from(e in AuditChain.Entry,
+      where: e.tenant_id == ^tenant_id,
+      order_by: [asc: e.chain_position],
+      select: e.entry_hash
+    )
+    |> AdminRepo.all()
+  end
+
+  # Independent oracle — a direct transcription of `AuditChain.merkle_tree/2`
+  # (the reference construction), used ONLY in tests to build expected peaks and
+  # roots without touching the module-under-test's internal fold.
+  defp oracle_root([single]), do: single
+
+  defp oracle_root(hashes) do
+    padded =
+      if rem(length(hashes), 2) == 1, do: hashes ++ [List.last(hashes)], else: hashes
+
+    padded
+    |> Enum.chunk_every(2)
+    |> Enum.map(fn [a, b] -> :crypto.hash(:sha256, a <> b) end)
+    |> oracle_root()
+  end
+
+  # Independent construction of a checkpoint's stable peaks for the first `count`
+  # leaves: slice into descending power-of-2 blocks (the set bits of `count`) and
+  # take the oracle Merkle root of each complete block. This does NOT reuse the
+  # module's MMR fold, so agreement is a real cross-check.
+  defp expected_peaks(hashes, count) do
+    import Bitwise
+
+    heights =
+      0..63 |> Enum.filter(fn b -> (count >>> b &&& 1) == 1 end) |> Enum.reverse()
+
+    {peaks, _rest} =
+      Enum.reduce(heights, {[], hashes}, fn h, {acc, remaining} ->
+        {block, rest} = Enum.split(remaining, Bitwise.bsl(1, h))
+        {[oracle_root(block) | acc], rest}
+      end)
+
+    Enum.reverse(peaks)
+  end
+
+  defp put_checkpoint(tenant_id, chain_position, peaks) do
+    %SthCheckpoint{tenant_id: tenant_id}
+    |> SthCheckpoint.changeset(%{chain_position: chain_position, peaks: peaks})
+    |> AdminRepo.insert!(
+      on_conflict: {:replace, [:chain_position, :peaks, :updated_at]},
+      conflict_target: [:tenant_id]
+    )
+  end
+
+  defp get_checkpoint(tenant_id) do
+    import Ecto.Query
+    AdminRepo.one(from(c in SthCheckpoint, where: c.tenant_id == ^tenant_id))
+  end
+
+  # STH-signing setup mirroring sth_test.exs: a tenant whose audit public key
+  # matches the mocked ed25519 private key, so signatures verify.
+  defp setup_signing_tenant(count) do
+    tenant = fixture(:tenant, %{slug: "sth-cp-#{System.unique_integer([:positive])}"})
+    {_pub, priv} = :crypto.generate_key(:eddsa, :ed25519)
+
+    Mox.expect(Loopctl.MockSecrets, :get, fn _name -> {:ok, priv} end)
+    Loopctl.TenantKeys.init_cache()
+
+    {matching_pub, _} = :crypto.generate_key(:eddsa, :ed25519, priv)
+
+    tenant =
+      tenant
+      |> Ecto.Changeset.change(audit_signing_public_key: matching_pub)
+      |> AdminRepo.update!()
+
+    :ok = build_chain(tenant.id, count)
+    {tenant, matching_pub}
+  end
+
+  # --- TC-35.1.1 — BYTE-IDENTICAL ROOT (the gate) ---
+
+  describe "compute_merkle_root_incremental/1 — byte-identical to merkle_tree/2 (AC-35.1.2)" do
+    @ns [1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 31, 32, 33, 40]
+
+    test "matches the full-rebuild oracle for a wide range of N and every split point" do
+      for n <- @ns do
+        tenant = fixture(:tenant, %{slug: "sth-prop-#{n}-#{System.unique_integer([:positive])}"})
+        :ok = build_chain(tenant.id, n)
+
+        hashes = entry_hashes(tenant.id)
+        expected = oracle_root(hashes)
+
+        # sanity: the current full construction equals our independent oracle
+        assert {:ok, ^expected} = AuditChain.compute_merkle_root(tenant.id)
+
+        # For every checkpoint split point p (leaves covered, 1..n-1), persist a
+        # checkpoint at position p-1 and assert the incremental fold reproduces
+        # the same root byte-for-byte. p = 0 (no checkpoint) is covered by the
+        # fallback test below.
+        for p <- 1..(n - 1)//1 do
+          {prefix, _tail} = Enum.split(hashes, p)
+          put_checkpoint(tenant.id, p - 1, expected_peaks(prefix, p))
+
+          assert {:ok, root, %{chain_position: pos, peaks: _}} =
+                   AuditChain.compute_merkle_root_incremental(tenant.id)
+
+          assert pos == n - 1
+          assert root == expected, "N=#{n}, split p=#{p}: incremental root diverged from oracle"
+          assert byte_size(root) == 32
+        end
+      end
+    end
+
+    test "folds the empty tail (checkpoint already at head) to the same root" do
+      n = 33
+      tenant = fixture(:tenant)
+      :ok = build_chain(tenant.id, n)
+      hashes = entry_hashes(tenant.id)
+      expected = oracle_root(hashes)
+
+      # checkpoint covers ALL leaves — no tail to fold, peaks bagged directly
+      put_checkpoint(tenant.id, n - 1, expected_peaks(hashes, n))
+
+      assert {:ok, ^expected, %{chain_position: 32}} =
+               AuditChain.compute_merkle_root_incremental(tenant.id)
+    end
+
+    test "returns {:ok, nil, nil} for an empty chain" do
+      tenant = fixture(:tenant)
+      assert {:ok, nil, nil} = AuditChain.compute_merkle_root_incremental(tenant.id)
+    end
+  end
+
+  # --- TC-35.1.3 — no checkpoint falls back, then persists (AC-35.1.1 / AC-35.1.3) ---
+
+  describe "no checkpoint (AC-35.1.1)" do
+    test "falls back to the full construction and equals merkle_tree/2 output" do
+      tenant = fixture(:tenant)
+      :ok = build_chain(tenant.id, 6)
+
+      refute get_checkpoint(tenant.id)
+
+      {:ok, full} = AuditChain.compute_merkle_root(tenant.id)
+
+      assert {:ok, root, %{chain_position: 5, peaks: peaks}} =
+               AuditChain.compute_merkle_root_incremental(tenant.id)
+
+      assert root == full
+      # 6 = 0b110 → two peaks
+      assert length(peaks) == 2
+    end
+
+    test "sign_and_store_tree_head persists a consistent checkpoint for next time (AC-35.1.3)" do
+      {tenant, _pub} = setup_signing_tenant(5)
+
+      refute get_checkpoint(tenant.id)
+
+      assert {:ok, sth} = AuditChain.sign_and_store_tree_head(tenant.id)
+
+      checkpoint = get_checkpoint(tenant.id)
+      assert checkpoint.chain_position == sth.chain_position
+      assert checkpoint.chain_position == 4
+      # 5 leaves = 0b101 → two peaks, each a 32-byte hash
+      assert length(checkpoint.peaks) == 2
+      assert Enum.all?(checkpoint.peaks, &(byte_size(&1) == 32))
+
+      # the stored root still equals the full oracle at that position
+      {:ok, full} = AuditChain.compute_merkle_root(tenant.id)
+      assert sth.merkle_root == full
+    end
+  end
+
+  # --- TC-35.1.2 — end-to-end sign + verify via incremental path (AC-35.1.4) ---
+
+  describe "sign_and_store_tree_head/1 via the incremental path (AC-35.1.4)" do
+    test "signs an STH whose root matches the full rebuild and verifies with Verifier" do
+      {tenant, pub_key} = setup_signing_tenant(3)
+
+      assert {:ok, sth} = AuditChain.sign_and_store_tree_head(tenant.id)
+
+      {:ok, full_root} = AuditChain.compute_merkle_root(tenant.id)
+      assert sth.merkle_root == full_root
+      assert sth.chain_position == 2
+      assert {:ok, true} = Verifier.verify_sth(sth, pub_key)
+    end
+
+    test "a later STH after more appends folds the tail and still verifies" do
+      {tenant, pub_key} = setup_signing_tenant(3)
+
+      {:ok, _first} = AuditChain.sign_and_store_tree_head(tenant.id)
+
+      # append past the checkpoint, then re-sign incrementally
+      :ok = build_chain(tenant.id, 4)
+
+      assert {:ok, sth2} = AuditChain.sign_and_store_tree_head(tenant.id)
+
+      {:ok, full_root} = AuditChain.compute_merkle_root(tenant.id)
+      assert sth2.chain_position == 6
+      assert sth2.merkle_root == full_root
+      assert {:ok, true} = Verifier.verify_sth(sth2, pub_key)
+
+      # checkpoint advanced to the head
+      assert get_checkpoint(tenant.id).chain_position == 6
+    end
+  end
+
+  # --- TC-35.1.4 — stale/corrupt checkpoint degrades to a correct rebuild (AC-35.1.5) ---
+
+  describe "corrupt/stale checkpoint (AC-35.1.5)" do
+    test "position ahead of the chain head → full rebuild, correct root" do
+      tenant = fixture(:tenant)
+      :ok = build_chain(tenant.id, 9)
+      {:ok, full} = AuditChain.compute_merkle_root(tenant.id)
+
+      # checkpoint claims a head 10 positions past reality (partial/stale write)
+      hashes = entry_hashes(tenant.id)
+      put_checkpoint(tenant.id, 18, expected_peaks(hashes, 9))
+
+      assert {:ok, root, %{chain_position: 8}} =
+               AuditChain.compute_merkle_root_incremental(tenant.id)
+
+      assert root == full
+    end
+
+    test "peaks count inconsistent with the covered leaf count → full rebuild, correct root" do
+      tenant = fixture(:tenant)
+      :ok = build_chain(tenant.id, 9)
+      {:ok, full} = AuditChain.compute_merkle_root(tenant.id)
+
+      # position 4 ⇒ 5 leaves ⇒ popcount(5)=2 peaks expected; store garbage 3
+      put_checkpoint(tenant.id, 4, [
+        :crypto.strong_rand_bytes(32),
+        :crypto.strong_rand_bytes(32),
+        :crypto.strong_rand_bytes(32)
+      ])
+
+      assert {:ok, root, %{chain_position: 8}} =
+               AuditChain.compute_merkle_root_incremental(tenant.id)
+
+      assert root == full
+    end
+
+    test "a malformed (non-32-byte) peak → full rebuild, correct root" do
+      tenant = fixture(:tenant)
+      :ok = build_chain(tenant.id, 4)
+      {:ok, full} = AuditChain.compute_merkle_root(tenant.id)
+
+      # position 3 ⇒ 4 leaves ⇒ 1 peak expected, but it's the wrong size
+      put_checkpoint(tenant.id, 3, [<<0, 1, 2>>])
+
+      assert {:ok, root, _} = AuditChain.compute_merkle_root_incremental(tenant.id)
+      assert root == full
+    end
+  end
+
+  # --- TC-35.1.5 — tenant isolation (AC-35.1.6) ---
+
+  describe "tenant isolation (AC-35.1.6)" do
+    test "incremental compute for tenant A never reads tenant B's entries or peaks" do
+      tenant_a = fixture(:tenant, %{slug: "sth-iso-a-#{System.unique_integer([:positive])}"})
+      tenant_b = fixture(:tenant, %{slug: "sth-iso-b-#{System.unique_integer([:positive])}"})
+
+      :ok = build_chain(tenant_a.id, 7)
+      :ok = build_chain(tenant_b.id, 5)
+
+      hashes_a = entry_hashes(tenant_a.id)
+      hashes_b = entry_hashes(tenant_b.id)
+      {:ok, full_a} = AuditChain.compute_merkle_root(tenant_a.id)
+      {:ok, full_b} = AuditChain.compute_merkle_root(tenant_b.id)
+
+      # both tenants carry a checkpoint at an intermediate split
+      put_checkpoint(tenant_a.id, 3, expected_peaks(Enum.take(hashes_a, 4), 4))
+      put_checkpoint(tenant_b.id, 1, expected_peaks(Enum.take(hashes_b, 2), 2))
+
+      assert {:ok, root_a, %{chain_position: 6}} =
+               AuditChain.compute_merkle_root_incremental(tenant_a.id)
+
+      assert root_a == full_a
+      # A's root is derived only from A's chain, distinct from B's
+      refute root_a == full_b
+
+      # B is unaffected and independently correct
+      assert {:ok, ^full_b, %{chain_position: 4}} =
+               AuditChain.compute_merkle_root_incremental(tenant_b.id)
+    end
+
+    test "checkpoints are one-per-tenant and isolated by tenant_id" do
+      tenant_a = fixture(:tenant, %{slug: "sth-iso2-a-#{System.unique_integer([:positive])}"})
+      tenant_b = fixture(:tenant, %{slug: "sth-iso2-b-#{System.unique_integer([:positive])}"})
+
+      :ok = build_chain(tenant_a.id, 4)
+      :ok = build_chain(tenant_b.id, 4)
+
+      put_checkpoint(tenant_a.id, 3, expected_peaks(entry_hashes(tenant_a.id), 4))
+
+      assert get_checkpoint(tenant_a.id)
+      refute get_checkpoint(tenant_b.id)
+    end
+  end
+end

--- a/test/loopctl/audit_chain/sth_checkpoint_test.exs
+++ b/test/loopctl/audit_chain/sth_checkpoint_test.exs
@@ -14,6 +14,7 @@ defmodule Loopctl.AuditChain.SthCheckpointTest do
 
   alias Loopctl.AdminRepo
   alias Loopctl.AuditChain
+  alias Loopctl.AuditChain.SignedTreeHead
   alias Loopctl.AuditChain.SthCheckpoint
   alias Loopctl.AuditChain.Verifier
 
@@ -92,6 +93,32 @@ defmodule Loopctl.AuditChain.SthCheckpointTest do
     )
   end
 
+  # Inserts an STH row at `chain_position` with the given root (signature is a
+  # placeholder — these tests don't re-verify the signature here).
+  defp put_sth(tenant_id, chain_position, merkle_root) do
+    %SignedTreeHead{tenant_id: tenant_id}
+    |> SignedTreeHead.changeset(%{
+      chain_position: chain_position,
+      merkle_root: merkle_root,
+      signed_at: DateTime.utc_now(),
+      signature: <<0::512>>
+    })
+    |> AdminRepo.insert!(
+      on_conflict: {:replace, [:merkle_root, :signed_at, :signature]},
+      conflict_target: [:tenant_id, :chain_position]
+    )
+  end
+
+  # Co-writes a checkpoint AND the matching STH at its position, mirroring
+  # `sign_and_store_tree_head/1` — the checkpoint's bagged root equals the signed
+  # STH root (both are `oracle_root(prefix)`). This is what makes the incremental
+  # fold path's EXACT content-integrity check pass, so tests that want the
+  # incremental path (not a silent fallback) exercise it for real.
+  defp put_valid_checkpoint(tenant_id, prefix, count) do
+    put_sth(tenant_id, count - 1, oracle_root(prefix))
+    put_checkpoint(tenant_id, count - 1, expected_peaks(prefix, count))
+  end
+
   defp get_checkpoint(tenant_id) do
     import Ecto.Query
     AdminRepo.one(from(c in SthCheckpoint, where: c.tenant_id == ^tenant_id))
@@ -139,7 +166,7 @@ defmodule Loopctl.AuditChain.SthCheckpointTest do
         # fallback test below.
         for p <- 1..(n - 1)//1 do
           {prefix, _tail} = Enum.split(hashes, p)
-          put_checkpoint(tenant.id, p - 1, expected_peaks(prefix, p))
+          put_valid_checkpoint(tenant.id, prefix, p)
 
           assert {:ok, root, %{chain_position: pos, peaks: _}} =
                    AuditChain.compute_merkle_root_incremental(tenant.id)
@@ -175,7 +202,7 @@ defmodule Loopctl.AuditChain.SthCheckpointTest do
         # checkpoint carries multiple peaks and there is a real tail to fold.
         p = div(n, 3) * 2
         {prefix, _tail} = Enum.split(hashes, p)
-        put_checkpoint(tenant.id, p - 1, expected_peaks(prefix, p))
+        put_valid_checkpoint(tenant.id, prefix, p)
 
         assert {:ok, root, %{chain_position: pos, peaks: _}} =
                  AuditChain.compute_merkle_root_incremental(tenant.id)
@@ -196,8 +223,11 @@ defmodule Loopctl.AuditChain.SthCheckpointTest do
       hashes = entry_hashes(tenant.id)
       expected = oracle_root(hashes)
 
-      # checkpoint covers ALL leaves — no tail to fold, peaks bagged directly
-      put_checkpoint(tenant.id, n - 1, expected_peaks(hashes, n))
+      # checkpoint covers ALL leaves — no tail to fold, peaks bagged directly.
+      # A matching STH at the head makes the exact-content check pass, so the root
+      # comes purely from bagging the CACHED peaks (no entries folded) — proving
+      # the cache path is active, not a silent full rebuild.
+      put_valid_checkpoint(tenant.id, hashes, n)
 
       assert {:ok, ^expected, %{chain_position: 32}} =
                AuditChain.compute_merkle_root_incremental(tenant.id)
@@ -329,6 +359,32 @@ defmodule Loopctl.AuditChain.SthCheckpointTest do
       assert {:ok, root, _} = AuditChain.compute_merkle_root_incremental(tenant.id)
       assert root == full
     end
+
+    test "right shape but WRONG peak bytes (a signed STH pins the position) → full rebuild, correct root" do
+      tenant = fixture(:tenant)
+      :ok = build_chain(tenant.id, 9)
+      {:ok, full} = AuditChain.compute_merkle_root(tenant.id)
+
+      hashes = entry_hashes(tenant.id)
+
+      # A genuine, consistent checkpoint + signed STH at position 4 (5 leaves ⇒ 2
+      # peaks) …
+      put_valid_checkpoint(tenant.id, Enum.take(hashes, 5), 5)
+
+      # … then corrupt ONLY the cached peaks to right-COUNT, right-SIZE, WRONG
+      # bytes — the exact kind of at-rest / unauthorized-write corruption the
+      # STRUCTURAL check cannot see (2 32-byte peaks == popcount(5)).
+      corrupt = [:crypto.strong_rand_bytes(32), :crypto.strong_rand_bytes(32)]
+      put_checkpoint(tenant.id, 4, corrupt)
+
+      # The EXACT content check (bag(peaks) != the STH's signed root at pos 4)
+      # rejects the corrupt cache and full-rebuilds, so the signer never signs a
+      # wrong root off it.
+      assert {:ok, root, %{chain_position: 8}} =
+               AuditChain.compute_merkle_root_incremental(tenant.id)
+
+      assert root == full
+    end
   end
 
   # --- TC-35.1.5 — tenant isolation (AC-35.1.6) ---
@@ -346,9 +402,9 @@ defmodule Loopctl.AuditChain.SthCheckpointTest do
       {:ok, full_a} = AuditChain.compute_merkle_root(tenant_a.id)
       {:ok, full_b} = AuditChain.compute_merkle_root(tenant_b.id)
 
-      # both tenants carry a checkpoint at an intermediate split
-      put_checkpoint(tenant_a.id, 3, expected_peaks(Enum.take(hashes_a, 4), 4))
-      put_checkpoint(tenant_b.id, 1, expected_peaks(Enum.take(hashes_b, 2), 2))
+      # both tenants carry a checkpoint (+ matching STH) at an intermediate split
+      put_valid_checkpoint(tenant_a.id, Enum.take(hashes_a, 4), 4)
+      put_valid_checkpoint(tenant_b.id, Enum.take(hashes_b, 2), 2)
 
       assert {:ok, root_a, %{chain_position: 6}} =
                AuditChain.compute_merkle_root_incremental(tenant_a.id)


### PR DESCRIPTION
## US-35.1 — Incremental STH: checkpointed Merkle peaks, byte-identical root

Every STH recompute currently re-reads and re-hashes a tenant's **entire** audit chain — O(chain length) per append forever (the quadratic in #350). This adds an incremental path: persist a per-tenant checkpoint of stable Merkle sub-tree **peaks** + the last `chain_position`, and on recompute fold **only** the entries above the checkpoint into those peaks.

### The safety invariant (byte-identical root)
`merkle_tree/2` is **Bitcoin-style** (odd level ⇒ duplicate last element, hash pairs, recurse) — NOT RFC-6962/MMR-bagging. The signed root MUST stay byte-identical to today's construction or historical STHs and external witness caches stop verifying, and a divergent root can trip the L6 byzantine/custody-halt path.

- A complete left-aligned block of `2^k` leaves is fully paired internally (padding only ever touches the rightmost element), so its subtree root is stable ⇒ valid as a peak.
- Peaks are MMR-appended, then **bagged in `merkle_tree/2`'s exact per-level pad-and-hash fold order** (carry lifted by self-pairing to replicate the "duplicate the last element" pad). `merkle_tree/2` is the unmodified reference oracle.
- **Written first as the gate:** a generative property test asserts equality across N ∈ {1,2,3,4,5,7,8,9,15,16,17,31,32,33,40} at **every** checkpoint split point, plus empty-tail and 2^k boundaries.

### Changes
- `compute_merkle_root_incremental/1` — checkpoint-folded root + refreshed peaks; falls back to a correct **full rebuild** on missing / stale / structurally-inconsistent checkpoints. The cache never emits a wrong root.
- `sign_and_store_tree_head/1` now uses the incremental root and **upserts the checkpoint atomically with the STH insert** (one `Ecto.Multi`), consistent with the exact position signed. `build_sth_message/4` + ed25519 signing are **unchanged** — existing `Verifier.verify_sth` still validates (end-to-end test).
- New additive table `audit_sth_checkpoints` (online `CREATE TABLE`, does not lock `audit_chain`/`audit_signed_tree_heads`): `ENABLE` (not FORCE) RLS + `tenant_isolation_policy`, one checkpoint per tenant, peaks stored as raw binary hashes (no plaintext leak).
- Tail read bounded to `(checkpoint, head]` and routed through `Loopctl.HeavyRead` for a per-query `SET LOCAL statement_timeout` (pgbouncer-safe) + tenant-scoping guard (AC-35.1.6).

### Hardening (adversarial review)
`latest_entry` is read once; both the tail and full-rebuild reads are bounded to `chain_position <= latest_pos` so a concurrent append can't fold leaves beyond the position being signed (avoids a root/position mismatch → L6 risk). Corruption detection: position-ahead, peaks-count ≠ popcount(count), and non-32-byte peaks all degrade to a full rebuild.

### Tests / gate
- `test/loopctl/audit_chain/sth_checkpoint_test.exs`: byte-identical property (all N × all splits), no-checkpoint fallback + persist, end-to-end sign+verify, three corrupt/stale-checkpoint fallbacks, tenant isolation.
- `mix precommit` green: compile --warnings-as-errors, format, credo --strict, dialyzer, 4431 tests / 0 failures.

Part of #350 (Epic 3: STH & cron fleet-cost redesign). This is US-35.1 only — the incremental compute + checkpoint table; does not close the epic.
