### PR TITLE
Event-driven STH: audit-append firehose topic + supervised debounce-enqueuer

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -383,6 +383,15 @@ config :loopctl, :oban_metrics_orphan_threshold_minutes, 45
 # 110-orphan stall this story addresses trips it immediately.
 config :loopctl, :oban_orphan_health_threshold, 10
 
+# US-35.2: debounce window (seconds) for the event-driven STH enqueuer
+# (`Loopctl.AuditChain.SthEnqueuer`). Read at runtime via Application.get_env/3.
+# Drives BOTH the enqueued ComputeSthWorker job's `schedule_in` AND its Oban
+# `unique` `period`, so a burst of appends for one tenant within this window
+# collapses to a single scheduled job (Basic-Engine-safe dedup). Short by design:
+# it only delays the activity-driven STH sign by a few seconds while coalescing
+# bursts; the per-minute cron poll remains the correctness backstop.
+config :loopctl, :sth_enqueuer_debounce_seconds, 5
+
 # Cloak Vault — key configured per environment
 # Generate a key: :crypto.strong_rand_bytes(32) |> Base.encode64()
 # The actual cipher is set in config/runtime.exs (prod) or config/test.exs (test).

--- a/config/test.exs
+++ b/config/test.exs
@@ -227,6 +227,14 @@ config :logger, :default_formatter,
 # Oban: inline testing mode (jobs execute synchronously in tests)
 config :loopctl, Oban, testing: :inline
 
+# US-35.2: keep the boot SthEnqueuer singleton from subscribing to the audit-chain
+# firehose in the test suite. It runs in the app supervision tree (not a per-test
+# sandbox owner), so reacting to a test's `AuditChain.append/1` would fire an
+# `Oban.insert` without an owned Sandbox connection. Tests that exercise the live
+# subscriber start their OWN named instance with `subscribe: true`; production
+# leaves this unset (defaults true) so the tree child subscribes normally.
+config :loopctl, :sth_enqueuer_subscribe, false
+
 # Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime
 

--- a/lib/loopctl/application.ex
+++ b/lib/loopctl/application.ex
@@ -29,6 +29,12 @@ defmodule Loopctl.Application do
       {Phoenix.PubSub, name: Loopctl.PubSub},
       {Task.Supervisor, name: Loopctl.TaskSupervisor},
       {Oban, Application.fetch_env!(:loopctl, Oban)},
+      # US-35.2: supervised, node-local singleton that subscribes to the fixed
+      # audit-chain firehose topic and debounce-enqueues one ComputeSthWorker job
+      # per tenant that appends, making STH computation event-driven and
+      # activity-gated. After PubSub (it subscribes in init) and Oban (it inserts
+      # jobs). Purely additive — the per-minute cron is unchanged.
+      Loopctl.AuditChain.SthEnqueuer,
       Loopctl.RateLimiter.Server,
       # US-27.16: owns the ETS table tracking in-flight streaming-export slots so a
       # crashed exporter's slot is reclaimed (concurrency cap, AC-27.16.6).

--- a/lib/loopctl/audit_chain.ex
+++ b/lib/loopctl/audit_chain.ex
@@ -77,8 +77,10 @@ defmodule Loopctl.AuditChain do
       {:ok, %{insert_entry: entry}} ->
         # US-26.5.1: broadcast new entry to the tenant's per-tenant subscribers.
         ChainPubSub.broadcast_entry(tenant_id, entry)
-        # US-35.2: ALSO broadcast to the fixed cross-tenant firehose so the
-        # supervised SthEnqueuer can activity-gate STH computation. Additive and
+        # US-35.2: ALSO broadcast a MINIMAL tenant-scoped notification to the
+        # fixed cross-tenant firehose so the supervised SthEnqueuer can
+        # activity-gate STH computation. Only entry.tenant_id crosses this shared
+        # topic (never the entry payload/actor_lineage). Additive and
         # fire-and-forget — it never changes or gates the existing per-tenant
         # broadcast, and a firehose delivery fault never affects the append.
         ChainPubSub.broadcast_entry_firehose(entry)

--- a/lib/loopctl/audit_chain.ex
+++ b/lib/loopctl/audit_chain.ex
@@ -75,8 +75,13 @@ defmodule Loopctl.AuditChain do
 
     case AdminRepo.transaction(multi) do
       {:ok, %{insert_entry: entry}} ->
-        # US-26.5.1: broadcast new entry to PubSub subscribers
+        # US-26.5.1: broadcast new entry to the tenant's per-tenant subscribers.
         ChainPubSub.broadcast_entry(tenant_id, entry)
+        # US-35.2: ALSO broadcast to the fixed cross-tenant firehose so the
+        # supervised SthEnqueuer can activity-gate STH computation. Additive and
+        # fire-and-forget — it never changes or gates the existing per-tenant
+        # broadcast, and a firehose delivery fault never affects the append.
+        ChainPubSub.broadcast_entry_firehose(entry)
         {:ok, entry}
 
       {:error, _step, reason, _changes} ->

--- a/lib/loopctl/audit_chain/pubsub.ex
+++ b/lib/loopctl/audit_chain/pubsub.ex
@@ -12,17 +12,24 @@ defmodule Loopctl.AuditChain.PubSub do
   (`"audit_chain:events"`). This lets one supervised, node-local subscriber
   (`Loopctl.AuditChain.SthEnqueuer`) observe appends across ALL tenants without
   subscribing to N per-tenant topics, so STH computation can be driven by real
-  append activity instead of only the per-minute cron. The firehose carries the
-  SAME `{:audit_chain_entry, entry}` message shape as the per-tenant topic; the
-  per-tenant topic and its subscribers are UNCHANGED.
+  append activity instead of only the per-minute cron.
+
+  The firehose keeps the SAME `{:audit_chain_entry, _}` tuple TAG as the
+  per-tenant topic, but its payload is MINIMIZED to `%{tenant_id: entry.tenant_id}`
+  — the only field the sole subscriber reads. The full `%Entry{}` (with its
+  arbitrary `:payload` map and `:actor_lineage`) is therefore never placed on
+  this fixed, non-tenant-scoped topic, so no tenant's entry contents fan out
+  across nodes on it or become visible to any future firehose subscriber. The
+  per-tenant topic still carries the full entry and its subscribers are
+  UNCHANGED.
   """
 
   @topic_prefix "audit_chain:"
 
   # US-35.2: single fixed cross-tenant firehose topic. Fixed (not per-tenant) so
   # a single supervised subscriber can watch every tenant's appends. The message
-  # itself carries `entry.tenant_id`, so the subscriber stays fully tenant-scoped
-  # without any per-tenant subscription.
+  # carries ONLY `tenant_id` (the subscriber's sole tenant-scoping input), so this
+  # shared topic never transports per-tenant entry payloads across nodes.
   @firehose_topic "#{@topic_prefix}events"
 
   @doc "Broadcasts a new audit chain entry to the tenant's topic."
@@ -36,16 +43,23 @@ defmodule Loopctl.AuditChain.PubSub do
   end
 
   @doc """
-  Broadcasts a new audit chain entry to the fixed cross-tenant firehose topic
-  (US-35.2). Additive: callers still broadcast to the per-tenant topic via
-  `broadcast_entry/2`. Fire-and-forget — the append path never depends on it.
+  Broadcasts a MINIMAL tenant-scoped notification to the fixed cross-tenant
+  firehose topic (US-35.2). Additive: callers still broadcast the full entry to
+  the per-tenant topic via `broadcast_entry/2`. Fire-and-forget — the append
+  path never depends on it.
+
+  Only `entry.tenant_id` is placed on the wire (as `%{tenant_id: tenant_id}`,
+  keeping the `{:audit_chain_entry, _}` tuple tag) because that is the single
+  field the sole subscriber (`SthEnqueuer`) reads. This keeps the shared,
+  non-tenant-scoped topic from ever carrying an entry's `:payload`/`:actor_lineage`
+  and halves the per-append cross-node bytes the firehose fans out.
   """
   @spec broadcast_entry_firehose(map()) :: :ok
-  def broadcast_entry_firehose(entry) do
+  def broadcast_entry_firehose(%{tenant_id: tenant_id}) do
     Phoenix.PubSub.broadcast(
       Loopctl.PubSub,
       @firehose_topic,
-      {:audit_chain_entry, entry}
+      {:audit_chain_entry, %{tenant_id: tenant_id}}
     )
   end
 

--- a/lib/loopctl/audit_chain/pubsub.ex
+++ b/lib/loopctl/audit_chain/pubsub.ex
@@ -4,9 +4,26 @@ defmodule Loopctl.AuditChain.PubSub do
 
   Broadcasts new audit chain entries and STH computations to per-tenant
   topics so agents can maintain an STH cache for witness verification.
+
+  ## Firehose topic (US-35.2)
+
+  In addition to the per-tenant `"audit_chain:<tenant_id>"` topics, every
+  audit-chain append is ALSO broadcast to a single fixed firehose topic
+  (`"audit_chain:events"`). This lets one supervised, node-local subscriber
+  (`Loopctl.AuditChain.SthEnqueuer`) observe appends across ALL tenants without
+  subscribing to N per-tenant topics, so STH computation can be driven by real
+  append activity instead of only the per-minute cron. The firehose carries the
+  SAME `{:audit_chain_entry, entry}` message shape as the per-tenant topic; the
+  per-tenant topic and its subscribers are UNCHANGED.
   """
 
   @topic_prefix "audit_chain:"
+
+  # US-35.2: single fixed cross-tenant firehose topic. Fixed (not per-tenant) so
+  # a single supervised subscriber can watch every tenant's appends. The message
+  # itself carries `entry.tenant_id`, so the subscriber stays fully tenant-scoped
+  # without any per-tenant subscription.
+  @firehose_topic "#{@topic_prefix}events"
 
   @doc "Broadcasts a new audit chain entry to the tenant's topic."
   @spec broadcast_entry(Ecto.UUID.t(), map()) :: :ok
@@ -14,6 +31,20 @@ defmodule Loopctl.AuditChain.PubSub do
     Phoenix.PubSub.broadcast(
       Loopctl.PubSub,
       topic(tenant_id),
+      {:audit_chain_entry, entry}
+    )
+  end
+
+  @doc """
+  Broadcasts a new audit chain entry to the fixed cross-tenant firehose topic
+  (US-35.2). Additive: callers still broadcast to the per-tenant topic via
+  `broadcast_entry/2`. Fire-and-forget — the append path never depends on it.
+  """
+  @spec broadcast_entry_firehose(map()) :: :ok
+  def broadcast_entry_firehose(entry) do
+    Phoenix.PubSub.broadcast(
+      Loopctl.PubSub,
+      @firehose_topic,
       {:audit_chain_entry, entry}
     )
   end
@@ -34,7 +65,17 @@ defmodule Loopctl.AuditChain.PubSub do
     Phoenix.PubSub.subscribe(Loopctl.PubSub, topic(tenant_id))
   end
 
+  @doc "Subscribes to the fixed cross-tenant audit-chain firehose topic (US-35.2)."
+  @spec subscribe_firehose() :: :ok | {:error, term()}
+  def subscribe_firehose do
+    Phoenix.PubSub.subscribe(Loopctl.PubSub, @firehose_topic)
+  end
+
   @doc "Returns the PubSub topic for a tenant."
   @spec topic(Ecto.UUID.t()) :: String.t()
   def topic(tenant_id), do: "#{@topic_prefix}#{tenant_id}"
+
+  @doc "Returns the fixed cross-tenant audit-chain firehose topic (US-35.2)."
+  @spec firehose_topic() :: String.t()
+  def firehose_topic, do: @firehose_topic
 end

--- a/lib/loopctl/audit_chain/sth_enqueuer.ex
+++ b/lib/loopctl/audit_chain/sth_enqueuer.ex
@@ -35,8 +35,17 @@ defmodule Loopctl.AuditChain.SthEnqueuer do
   ## Resilience (fire-and-forget)
 
   The append path broadcasts to the firehose fire-and-forget, so this process can
-  never crash an append. In turn, an enqueue failure (Oban error or a malformed/
-  unknown message) is caught, LOGGED, and ignored — the process stays alive.
+  never crash an append. In turn, `handle_info/2` classifies every message so the
+  process stays alive across all of them:
+
+    * a genuine enqueue fault on a well-formed entry — an Oban `{:error, _}` tuple
+      (WARNING), a RAISE (rescued, ERROR "crashed"), or an :exit/throw (caught,
+      ERROR) — is logged and swallowed;
+    * a correctly-shaped but MALFORMED entry (no binary `tenant_id`) is logged at
+      WARNING and ignored (never the ERROR/"crashed" path, which is reserved for
+      real faults);
+    * any unknown-shape message is logged at DEBUG and ignored.
+
   Correctness is preserved even if this enqueuer is down or misses events,
   because the per-minute cron poll (unchanged by this story) still runs and the
   per-tenant `ComputeSthWorker.perform/1` clause is idempotent
@@ -130,10 +139,15 @@ defmodule Loopctl.AuditChain.SthEnqueuer do
   end
 
   @impl true
-  def handle_info({:audit_chain_entry, entry}, state) do
-    # Enqueue is wrapped so neither an Oban error tuple NOR a raise (malformed
-    # entry, transient DB/pool fault, serialization error) can crash the
-    # subscriber. Correctness is backstopped by the idempotent cron poll.
+  def handle_info({:audit_chain_entry, %{tenant_id: tenant_id} = entry}, state)
+      when is_binary(tenant_id) do
+    # Well-formed entry. The enqueue is wrapped so NO failure mode can crash the
+    # subscriber (AC-35.2.5): an Oban `{:error, _}` tuple is logged at WARNING; a
+    # RAISE (transient DB/pool fault, serialization error) is rescued; and an
+    # :exit or throw surfacing from the enqueue path (e.g. a checkout/GenServer
+    # timeout raised as an exit) is caught. Correctness is backstopped by the
+    # idempotent per-minute cron poll, so swallowing here only trades a missed
+    # activity-driven enqueue for a slightly later cron-driven one.
     try do
       case enqueue_sth_job(entry) do
         {:ok, _job} ->
@@ -148,12 +162,34 @@ defmodule Loopctl.AuditChain.SthEnqueuer do
           "SthEnqueuer: crashed while enqueuing ComputeSthWorker (ignored): " <>
             Exception.message(error)
         )
+    catch
+      kind, reason ->
+        # :exit / throw from the enqueue path — never let it kill the singleton.
+        Logger.error(
+          "SthEnqueuer: caught #{kind} while enqueuing ComputeSthWorker (ignored): " <>
+            inspect(reason)
+        )
     end
 
     {:noreply, state}
   end
 
-  # Malformed/unknown messages are logged-and-ignored, never a crash (AC-35.2.5).
+  # A correctly-shaped firehose message whose entry carries no binary tenant_id is
+  # MALFORMED but benign (AC-35.2.5). Audit entries always carry a binary
+  # tenant_id in practice, so this indicates upstream corruption — not an enqueue
+  # fault. Log at WARNING (never ERROR/"crashed", which is reserved for genuine
+  # enqueue faults in the clause above) and ignore. Never raise/crash.
+  @impl true
+  def handle_info({:audit_chain_entry, malformed}, state) do
+    Logger.warning(
+      "SthEnqueuer: ignoring malformed audit_chain_entry (no binary tenant_id): " <>
+        inspect(malformed)
+    )
+
+    {:noreply, state}
+  end
+
+  # Any other (unknown-shape) message is logged at DEBUG and ignored (AC-35.2.5).
   @impl true
   def handle_info(msg, state) do
     Logger.debug("SthEnqueuer: ignoring unexpected message: #{inspect(msg)}")

--- a/lib/loopctl/audit_chain/sth_enqueuer.ex
+++ b/lib/loopctl/audit_chain/sth_enqueuer.ex
@@ -1,0 +1,162 @@
+defmodule Loopctl.AuditChain.SthEnqueuer do
+  @moduledoc """
+  US-35.2 — Event-driven, activity-gated STH enqueuer.
+
+  A supervised, node-local singleton GenServer that subscribes to the fixed
+  cross-tenant audit-chain firehose topic (`Loopctl.AuditChain.PubSub`) and, on
+  each `{:audit_chain_entry, entry}` message, debounce-enqueues one
+  `Loopctl.Workers.ComputeSthWorker` job for `entry.tenant_id`. This makes STH
+  computation react to real append activity instead of relying solely on the
+  per-minute `all_tenants` cron.
+
+  ## Why a GenServer (OTP Iron Law)
+
+  It owns a durable PubSub subscription that must persist for the node's lifetime
+  and survive the transient request/Task/Oban process that produced an append —
+  a stable subscriber is exactly the "mutable state persisting across calls +
+  fault isolation" case a process is for. It holds NO per-tenant state (see
+  below), never sits on a hot read path, and does one cheap `Oban.insert/2` per
+  message.
+
+  ## Debounce / coalescing is Oban-`unique`, not GenServer state
+
+  All burst-coalescing lives in the DB via Oban's `unique` option, NOT in this
+  process. Each enqueue is a single `Oban.insert/2` (NOT `insert_all/1`, which is
+  inert for `unique` on the Basic Engine — see `ComputeSthWorker` moduledoc) with
+  `unique: [fields: [:worker, :args], period: …, states: [:available,
+  :scheduled]]` and a short `schedule_in` debounce. A burst of appends for one
+  tenant within the window therefore collapses to a SINGLE scheduled job at the
+  DB level. Because the dedup is in Postgres, this is both burst-safe on one node
+  AND multi-node safe: with the firehose delivered to every node, each node's
+  enqueuer may insert, but `unique` lets at most one job per tenant per window
+  survive. Consequently this GenServer holds no per-tenant map that could grow
+  without bound — its state is a minimal, fixed map.
+
+  ## Resilience (fire-and-forget)
+
+  The append path broadcasts to the firehose fire-and-forget, so this process can
+  never crash an append. In turn, an enqueue failure (Oban error or a malformed/
+  unknown message) is caught, LOGGED, and ignored — the process stays alive.
+  Correctness is preserved even if this enqueuer is down or misses events,
+  because the per-minute cron poll (unchanged by this story) still runs and the
+  per-tenant `ComputeSthWorker.perform/1` clause is idempotent
+  (`AuditChain.sth_needed?/1`-gated).
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias Loopctl.AuditChain.PubSub, as: ChainPubSub
+  alias Loopctl.Workers.ComputeSthWorker
+
+  # Default debounce (seconds). Config-driven per CLAUDE.md DI rules — read at
+  # runtime via Application.get_env/3, never Application.put_env in tests.
+  @default_debounce_seconds 5
+
+  # --- Client API ---
+
+  @doc false
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc """
+  The debounce window (seconds), read at runtime from application config.
+
+  Drives BOTH the job's `schedule_in` and the Oban `unique` `period`, so a burst
+  of appends for one tenant within this window collapses to a single scheduled
+  `ComputeSthWorker` job.
+  """
+  @spec debounce_seconds() :: pos_integer()
+  def debounce_seconds do
+    Application.get_env(:loopctl, :sth_enqueuer_debounce_seconds, @default_debounce_seconds)
+  end
+
+  @doc """
+  Enqueues a single debounced `ComputeSthWorker` job for `entry.tenant_id`.
+
+  Exposed (rather than kept private in `handle_info/2`) so tests can drive the
+  exact enqueue path directly from the test process — where the Ecto Sandbox
+  connection and Oban testing mode apply — without racing the separate GenServer
+  process. Returns the raw `Oban.insert/2` result.
+
+  Builds the job with a short `schedule_in` debounce and the Basic-Engine-honored
+  `unique: [fields: [:worker, :args], period: …, states: [:available,
+  :scheduled]]` so bursts coalesce at the DB. String arg keys per the Oban
+  JSON-serialization Iron Law.
+  """
+  @spec enqueue_sth_job(map()) :: {:ok, Oban.Job.t()} | {:error, term()}
+  def enqueue_sth_job(%{tenant_id: tenant_id}) when is_binary(tenant_id) do
+    debounce = debounce_seconds()
+
+    %{"tenant_id" => tenant_id}
+    |> ComputeSthWorker.new(
+      schedule_in: debounce,
+      unique: [
+        fields: [:worker, :args],
+        period: debounce,
+        states: [:available, :scheduled]
+      ]
+    )
+    |> Oban.insert()
+  end
+
+  # --- Server callbacks ---
+
+  @impl true
+  def init(opts) do
+    # Subscribe to the fixed cross-tenant firehose so we observe every tenant's
+    # appends through ONE subscription. `Phoenix.PubSub` starts strictly before
+    # this owner in the supervision tree, so the subscribe here is safe.
+    #
+    # Subscription is config-gated (default ON) so the app's boot singleton can
+    # be kept from reacting under the Ecto Sandbox in the test suite — where its
+    # `Oban.insert` would run without an owned connection — while production
+    # always subscribes. Tests that need a LIVE subscriber start their OWN named
+    # instance with `subscribe: true`, and the config default stays true so the
+    # production supervision-tree child subscribes normally.
+    subscribe? =
+      Keyword.get(
+        opts,
+        :subscribe,
+        Application.get_env(:loopctl, :sth_enqueuer_subscribe, true)
+      )
+
+    if subscribe?, do: ChainPubSub.subscribe_firehose()
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_info({:audit_chain_entry, entry}, state) do
+    # Enqueue is wrapped so neither an Oban error tuple NOR a raise (malformed
+    # entry, transient DB/pool fault, serialization error) can crash the
+    # subscriber. Correctness is backstopped by the idempotent cron poll.
+    try do
+      case enqueue_sth_job(entry) do
+        {:ok, _job} ->
+          :ok
+
+        {:error, reason} ->
+          Logger.warning("SthEnqueuer: failed to enqueue ComputeSthWorker: #{inspect(reason)}")
+      end
+    rescue
+      error ->
+        Logger.error(
+          "SthEnqueuer: crashed while enqueuing ComputeSthWorker (ignored): " <>
+            Exception.message(error)
+        )
+    end
+
+    {:noreply, state}
+  end
+
+  # Malformed/unknown messages are logged-and-ignored, never a crash (AC-35.2.5).
+  @impl true
+  def handle_info(msg, state) do
+    Logger.debug("SthEnqueuer: ignoring unexpected message: #{inspect(msg)}")
+    {:noreply, state}
+  end
+end

--- a/lib/loopctl/audit_chain/sth_enqueuer.ex
+++ b/lib/loopctl/audit_chain/sth_enqueuer.ex
@@ -7,7 +7,9 @@ defmodule Loopctl.AuditChain.SthEnqueuer do
   each `{:audit_chain_entry, entry}` message, debounce-enqueues one
   `Loopctl.Workers.ComputeSthWorker` job for `entry.tenant_id`. This makes STH
   computation react to real append activity instead of relying solely on the
-  per-minute `all_tenants` cron.
+  per-minute `all_tenants` cron. The firehose message is a MINIMAL
+  `%{tenant_id: _}` map (not the full `%Entry{}`) — `tenant_id` is the only field
+  this subscriber reads, so nothing else needs to cross the shared topic.
 
   ## Why a GenServer (OTP Iron Law)
 

--- a/test/loopctl/audit_chain/sth_enqueuer_test.exs
+++ b/test/loopctl/audit_chain/sth_enqueuer_test.exs
@@ -1,0 +1,287 @@
+defmodule Loopctl.AuditChain.SthEnqueuerTest do
+  @moduledoc """
+  US-35.2 — Event-driven STH: audit-append firehose topic + supervised
+  debounce-enqueuer.
+
+  Covers TC-35.2.1..4:
+    * the append firehose broadcast (additive to the per-tenant topic),
+    * Basic-Engine-safe burst coalescing via Oban `unique`,
+    * end-to-end correctness (a firehose append drives an STH at the new
+      position through the LIVE GenServer), and
+    * resilience (malformed/unknown messages and enqueue errors never crash the
+      subscriber).
+
+  The app's boot `SthEnqueuer` singleton does NOT subscribe under the test
+  sandbox (`config :loopctl, :sth_enqueuer_subscribe, false`), so tests that need
+  a live subscriber start their OWN named instance with `subscribe: true` and
+  grant it the sandbox connection.
+  """
+
+  use Loopctl.DataCase, async: true
+  use Oban.Testing, repo: Loopctl.Repo
+
+  import ExUnit.CaptureLog
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Loopctl.AdminRepo
+  alias Loopctl.AuditChain
+  alias Loopctl.AuditChain.PubSub, as: ChainPubSub
+  alias Loopctl.AuditChain.SthEnqueuer
+  alias Loopctl.TenantKeys
+  alias Loopctl.Workers.ComputeSthWorker
+
+  setup :verify_on_exit!
+
+  defp append_attrs(overrides \\ %{}) do
+    Map.merge(
+      %{
+        action: "test_event",
+        actor_lineage: ["test"],
+        entity_type: "test",
+        payload: %{"k" => "v"}
+      },
+      overrides
+    )
+  end
+
+  # Set up a tenant whose audit-signing key is primed in the TenantKeys ETS
+  # cache (in THIS owner process, consuming the single MockSecrets expectation),
+  # so a DIFFERENT process (the live enqueuer) can sign its STH via a pure cache
+  # read — no cross-process Mox allowance needed.
+  defp setup_keyed_tenant do
+    tenant = fixture(:tenant, %{slug: "sth-enq-#{System.unique_integer([:positive])}"})
+    {_pub, priv} = :crypto.generate_key(:eddsa, :ed25519)
+    {matching_pub, _} = :crypto.generate_key(:eddsa, :ed25519, priv)
+
+    tenant =
+      tenant
+      |> Ecto.Changeset.change(audit_signing_public_key: matching_pub)
+      |> AdminRepo.update!()
+
+    Mox.expect(Loopctl.MockSecrets, :get, fn _name -> {:ok, priv} end)
+    TenantKeys.init_cache()
+    {:ok, _priv} = TenantKeys.get_private_key(tenant.id)
+
+    tenant
+  end
+
+  describe "AuditChain.append/1 firehose broadcast (AC-35.2.1)" do
+    # The firehose is a SINGLE fixed topic shared by every tenant (and, in the
+    # async suite, every concurrently-running test that appends). Assertions here
+    # therefore SELECT this test's own tenant via a guard and use a generous
+    # timeout, so foreign firehose traffic and PubSub delivery latency under
+    # parallel load can never cause a spurious miss.
+    test "TC-35.2.1: append broadcasts the entry to BOTH the per-tenant and firehose topics" do
+      tenant = fixture(:tenant)
+
+      :ok = ChainPubSub.subscribe(tenant.id)
+      :ok = ChainPubSub.subscribe_firehose()
+
+      {:ok, entry} = AuditChain.append(tenant.id, append_attrs())
+      entry_id = entry.id
+
+      # Existing per-tenant behavior is unchanged: the same {:audit_chain_entry,
+      # entry} message still lands on the per-tenant topic (which is unique to
+      # this tenant).
+      assert_receive {:audit_chain_entry, %{id: ^entry_id} = per_tenant_entry}, 1_000
+      assert per_tenant_entry.tenant_id == tenant.id
+      assert per_tenant_entry.chain_position == entry.chain_position
+
+      # New: the SAME message shape ALSO lands on the fixed firehose topic,
+      # carrying entry.tenant_id (the subscriber's only tenant-scoping input).
+      # Select this entry by id to ignore concurrent tests' firehose traffic.
+      assert_receive {:audit_chain_entry, %{id: ^entry_id} = firehose_entry}, 1_000
+      assert firehose_entry.tenant_id == tenant.id
+    end
+
+    test "TC-35.2.1b: the firehose topic is a single fixed cross-tenant topic (not per-tenant)" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+
+      :ok = ChainPubSub.subscribe_firehose()
+
+      {:ok, entry_a} = AuditChain.append(tenant_a.id, append_attrs())
+      {:ok, entry_b} = AuditChain.append(tenant_b.id, append_attrs())
+
+      a_id = entry_a.id
+      b_id = entry_b.id
+
+      # One firehose subscription observes appends from EVERY tenant. Select by
+      # entry id (unique) to tolerate other async tests broadcasting concurrently.
+      assert_receive {:audit_chain_entry, %{id: ^a_id, tenant_id: a_tid}}, 1_000
+      assert_receive {:audit_chain_entry, %{id: ^b_id, tenant_id: b_tid}}, 1_000
+
+      assert a_tid == tenant_a.id
+      assert b_tid == tenant_b.id
+    end
+  end
+
+  describe "enqueue_sth_job/1 burst coalescing (AC-35.2.3 / AC-35.2.6)" do
+    test "TC-35.2.2: a burst of appends for one tenant collapses to exactly one scheduled job" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        # Five appends for tenant A within the debounce window (simulated by five
+        # direct enqueue calls, the exact path handle_info/2 drives). Oban
+        # `unique` dedups at the DB, so only one job survives.
+        for _ <- 1..5 do
+          assert {:ok, _job} = SthEnqueuer.enqueue_sth_job(%{tenant_id: tenant_a.id})
+        end
+
+        # A different tenant gets its OWN independent job (strictly per-tenant).
+        assert {:ok, _job} = SthEnqueuer.enqueue_sth_job(%{tenant_id: tenant_b.id})
+      end)
+
+      jobs = all_enqueued(worker: ComputeSthWorker)
+
+      a_jobs = Enum.filter(jobs, &(&1.args["tenant_id"] == tenant_a.id))
+      b_jobs = Enum.filter(jobs, &(&1.args["tenant_id"] == tenant_b.id))
+
+      # Exactly one scheduled ComputeSthWorker job for A (coalesced), not five.
+      assert length(a_jobs) == 1
+      # Tenant isolation: B's append produced a strictly separate, per-tenant job;
+      # the coalescing never merged across tenants.
+      assert length(b_jobs) == 1
+
+      # The job is scheduled with the debounce delay (not run immediately).
+      [a_job] = a_jobs
+      assert a_job.state in ["scheduled", "available"]
+    end
+
+    test "TC-35.2.2b: the enqueued job uses string arg keys (Oban JSON Iron Law)" do
+      tenant = fixture(:tenant)
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert {:ok, _job} = SthEnqueuer.enqueue_sth_job(%{tenant_id: tenant.id})
+      end)
+
+      [job] = all_enqueued(worker: ComputeSthWorker)
+      assert job.args == %{"tenant_id" => tenant.id}
+    end
+  end
+
+  describe "live enqueuer end-to-end (AC-35.2.2 / AC-35.2.4)" do
+    test "TC-35.2.3: a firehose entry drives the enqueuer to compute an STH at the new position" do
+      tenant = setup_keyed_tenant()
+
+      # An entry must exist on the chain for there to be something to sign.
+      {:ok, entry} = AuditChain.append(tenant.id, append_attrs())
+
+      name = :"sth_enqueuer_e2e_#{System.unique_integer([:positive])}"
+
+      # subscribe: false so this test drives handle_info/2 with EXACTLY its own
+      # message (the shared firehose would otherwise flood the enqueuer with
+      # concurrent tests' appends and force it to share this test's single
+      # sandbox connection while we query). We grant it the sandbox so its inline
+      # Oban run (ComputeSthWorker.perform → sign_and_store_tree_head via
+      # AdminRepo, reading the pre-primed TenantKeys cache) is visible here.
+      pid =
+        start_supervised!(
+          Supervisor.child_spec({SthEnqueuer, [name: name, subscribe: false]}, id: name)
+        )
+
+      Sandbox.allow(Loopctl.Repo, self(), pid)
+      Sandbox.allow(Loopctl.AdminRepo, self(), pid)
+
+      # Deliver the firehose message shape directly, then synchronize on the
+      # GenServer: :sys.get_state is handled AFTER the queued handle_info, so the
+      # inline STH computation is complete (and this process was NOT querying the
+      # shared connection during it) before we read the result.
+      send(pid, {:audit_chain_entry, entry})
+      :sys.get_state(pid)
+
+      sth = AuditChain.get_latest_sth(tenant.id)
+
+      assert %AuditChain.SignedTreeHead{} = sth
+      assert sth.chain_position == entry.chain_position
+    end
+
+    test "TC-35.2.3b: a started enqueuer subscribes to the firehose and reacts to a real append" do
+      # A subscribe: true enqueuer NOT granted the sandbox: a real append's
+      # firehose broadcast reaches it (proving on-start subscription), its
+      # Oban.insert fails without an owned connection, and it logs-and-survives
+      # (resilience) rather than crashing. This exercises the actual PubSub wiring
+      # without the shared-connection hazard of asserting the STH here.
+      tenant = fixture(:tenant)
+
+      name = :"sth_enqueuer_sub_#{System.unique_integer([:positive])}"
+
+      pid =
+        start_supervised!(
+          Supervisor.child_spec({SthEnqueuer, [name: name, subscribe: true]}, id: name)
+        )
+
+      log =
+        capture_log(fn ->
+          {:ok, _entry} = AuditChain.append(tenant.id, append_attrs())
+          # Barrier: the firehose message is enqueued into pid's mailbox before
+          # append/1 returns (local PubSub delivery is a synchronous send), so
+          # this system message is processed strictly after that handle_info.
+          :sys.get_state(pid)
+        end)
+
+      assert Process.alive?(pid)
+      assert log =~ "SthEnqueuer"
+    end
+  end
+
+  describe "resilience (AC-35.2.5)" do
+    test "TC-35.2.4: an enqueue error is logged and never crashes the enqueuer" do
+      name = :"sth_enqueuer_resilient_#{System.unique_integer([:positive])}"
+
+      # subscribe: false so we drive handle_info/2 directly; the instance is NOT
+      # granted the sandbox, so Oban.insert raises an ownership error — exactly
+      # the "enqueue fails" condition the enqueuer must tolerate.
+      pid =
+        start_supervised!(
+          Supervisor.child_spec({SthEnqueuer, [name: name, subscribe: false]}, id: name)
+        )
+
+      log =
+        capture_log(fn ->
+          send(pid, {:audit_chain_entry, %{tenant_id: Ecto.UUID.generate()}})
+          # Synchronization barrier: :sys.get_state is handled after the queued
+          # handle_info, so by the time it returns the enqueue attempt is done.
+          :sys.get_state(pid)
+        end)
+
+      assert Process.alive?(pid)
+      assert log =~ "SthEnqueuer"
+    end
+
+    test "TC-35.2.4b: a malformed entry (no/invalid tenant_id) is logged and ignored" do
+      name = :"sth_enqueuer_malformed_#{System.unique_integer([:positive])}"
+
+      pid =
+        start_supervised!(
+          Supervisor.child_spec({SthEnqueuer, [name: name, subscribe: false]}, id: name)
+        )
+
+      capture_log(fn ->
+        # No tenant_id key at all.
+        send(pid, {:audit_chain_entry, %{}})
+        # Non-binary tenant_id.
+        send(pid, {:audit_chain_entry, %{tenant_id: make_ref()}})
+        :sys.get_state(pid)
+      end)
+
+      assert Process.alive?(pid)
+    end
+
+    test "TC-35.2.4c: an unknown message is ignored and never crashes the enqueuer" do
+      name = :"sth_enqueuer_unknown_#{System.unique_integer([:positive])}"
+
+      pid =
+        start_supervised!(
+          Supervisor.child_spec({SthEnqueuer, [name: name, subscribe: false]}, id: name)
+        )
+
+      send(pid, :some_unexpected_message)
+      send(pid, {:not, :a, :known, :shape})
+      # Barrier: both messages processed by the time this returns.
+      assert %{} = :sys.get_state(pid)
+      assert Process.alive?(pid)
+    end
+  end
+end

--- a/test/loopctl/audit_chain/sth_enqueuer_test.exs
+++ b/test/loopctl/audit_chain/sth_enqueuer_test.exs
@@ -92,6 +92,20 @@ defmodule Loopctl.AuditChain.SthEnqueuerTest do
       # Select this entry by id to ignore concurrent tests' firehose traffic.
       assert_receive {:audit_chain_entry, %{id: ^entry_id} = firehose_entry}, 1_000
       assert firehose_entry.tenant_id == tenant.id
+
+      # AC-35.2.1 also names {:sth_updated,…} and external (witness-cache)
+      # subscribers as UNCHANGED. broadcast_sth/2 is untouched by this story, so
+      # an STH broadcast must still reach the per-tenant subscriber and must NOT
+      # leak onto the firehose (which carries only {:audit_chain_entry,…}). Prove
+      # both from the one process subscribed to BOTH topics: consume the
+      # per-tenant {:sth_updated}, then refute any further {:sth_updated} (i.e.
+      # the firehose did not also deliver one).
+      sth = %{id: entry_id, tenant_id: tenant.id, chain_position: entry.chain_position}
+      :ok = ChainPubSub.broadcast_sth(tenant.id, sth)
+
+      assert_receive {:sth_updated, %{id: ^entry_id, tenant_id: sth_tid}}, 1_000
+      assert sth_tid == tenant.id
+      refute_receive {:sth_updated, _}, 200
     end
 
     test "TC-35.2.1b: the firehose topic is a single fixed cross-tenant topic (not per-tenant)" do
@@ -159,36 +173,105 @@ defmodule Loopctl.AuditChain.SthEnqueuerTest do
       [job] = all_enqueued(worker: ComputeSthWorker)
       assert job.args == %{"tenant_id" => tenant.id}
     end
+
+    test "TC-35.2.2c: a burst of REAL appends for one tenant, through the LIVE subscribed enqueuer, coalesces to exactly one scheduled job" do
+      # AC-35.2.3 verbatim: append several entries for one tenant in quick
+      # succession and assert exactly one ComputeSthWorker job is scheduled — but
+      # driven through the WHOLE real path (append/1 -> firehose broadcast -> the
+      # live GenServer's handle_info -> enqueue_sth_job -> Oban.insert), not five
+      # direct enqueue calls. This catches a regression that mangled handle_info's
+      # call into enqueue_sth_job (e.g. dropping the unique/schedule_in opts),
+      # which the direct-call TC-35.2.2 cannot see.
+      tenant = fixture(:tenant)
+      other = fixture(:tenant)
+
+      name = :"sth_enqueuer_coalesce_#{System.unique_integer([:positive])}"
+
+      pid =
+        start_supervised!(
+          Supervisor.child_spec({SthEnqueuer, [name: name, subscribe: true]}, id: name)
+        )
+
+      # Grant the live enqueuer this test's sandbox so its Oban.insert lands in
+      # our transaction and is visible to all_enqueued below. append/1 writes via
+      # AdminRepo; the enqueue writes oban_jobs via Loopctl.Repo — distinct repos,
+      # so the two never contend on one connection.
+      Sandbox.allow(Loopctl.Repo, self(), pid)
+      Sandbox.allow(Loopctl.AdminRepo, self(), pid)
+
+      # The app-wide Oban testing mode is :inline, which EXECUTES each insert
+      # immediately and so bypasses both `unique` and `schedule_in` — the very
+      # DB-level coalescing under test. Oban resolves the engine from the
+      # INSERTING process's dictionary, so seed the LIVE enqueuer's own dictionary
+      # to :manual (Basic engine) via :sys.replace_state/2, which runs the fun
+      # inside that process. No production knob — the seam is test-only.
+      :sys.replace_state(pid, fn state ->
+        Process.put(:oban_testing, :manual)
+        state
+      end)
+
+      # Five real appends for ONE tenant in quick succession (within the debounce
+      # window). Local PubSub delivery is a synchronous send, so each firehose
+      # message is in the enqueuer's mailbox before append/1 returns; :sys.get_state
+      # then drains that handle_info (and its insert) before the next append, so
+      # the enqueuer never processes our message while we run the next append.
+      for _ <- 1..5 do
+        {:ok, _entry} = AuditChain.append(tenant.id, append_attrs())
+        :sys.get_state(pid)
+      end
+
+      # A different tenant's real append produces its OWN independent job.
+      {:ok, _entry} = AuditChain.append(other.id, append_attrs())
+      :sys.get_state(pid)
+
+      jobs = all_enqueued(worker: ComputeSthWorker)
+      tenant_jobs = Enum.filter(jobs, &(&1.args["tenant_id"] == tenant.id))
+      other_jobs = Enum.filter(jobs, &(&1.args["tenant_id"] == other.id))
+
+      # Exactly one scheduled ComputeSthWorker job for the bursting tenant
+      # (coalesced by Oban `unique`), not five — proving the real handle_info path
+      # forwards the unique/schedule_in opts.
+      assert length(tenant_jobs) == 1
+      # Tenant isolation: the burst never merged the other tenant's job away.
+      assert length(other_jobs) == 1
+
+      [job] = tenant_jobs
+      assert job.state in ["scheduled", "available"]
+    end
   end
 
   describe "live enqueuer end-to-end (AC-35.2.2 / AC-35.2.4)" do
-    test "TC-35.2.3: a firehose entry drives the enqueuer to compute an STH at the new position" do
+    test "TC-35.2.3: a REAL append, through the live firehose subscription, drives the enqueuer to compute an STH at the new position" do
       tenant = setup_keyed_tenant()
-
-      # An entry must exist on the chain for there to be something to sign.
-      {:ok, entry} = AuditChain.append(tenant.id, append_attrs())
 
       name = :"sth_enqueuer_e2e_#{System.unique_integer([:positive])}"
 
-      # subscribe: false so this test drives handle_info/2 with EXACTLY its own
-      # message (the shared firehose would otherwise flood the enqueuer with
-      # concurrent tests' appends and force it to share this test's single
-      # sandbox connection while we query). We grant it the sandbox so its inline
-      # Oban run (ComputeSthWorker.perform → sign_and_store_tree_head via
-      # AdminRepo, reading the pre-primed TenantKeys cache) is visible here.
+      # A LIVE, subscribe: true enqueuer — this exercises the FULL join AC-35.2.4
+      # names (real append -> firehose broadcast -> on-start subscription ->
+      # handle_info -> STH computed), not a hand-delivered send. Granted the
+      # sandbox so its inline Oban run (ComputeSthWorker.perform ->
+      # sign_and_store_tree_head via AdminRepo, reading the pre-primed TenantKeys
+      # cache) is visible here. start_supervised! returns only after init/1 (and
+      # its subscribe_firehose) has completed, so the subscription is live before
+      # the append below.
       pid =
         start_supervised!(
-          Supervisor.child_spec({SthEnqueuer, [name: name, subscribe: false]}, id: name)
+          Supervisor.child_spec({SthEnqueuer, [name: name, subscribe: true]}, id: name)
         )
 
       Sandbox.allow(Loopctl.Repo, self(), pid)
       Sandbox.allow(Loopctl.AdminRepo, self(), pid)
 
-      # Deliver the firehose message shape directly, then synchronize on the
-      # GenServer: :sys.get_state is handled AFTER the queued handle_info, so the
-      # inline STH computation is complete (and this process was NOT querying the
-      # shared connection during it) before we read the result.
-      send(pid, {:audit_chain_entry, entry})
+      # Real append: broadcasts {:audit_chain_entry, entry} to the fixed firehose
+      # the live enqueuer subscribed to in init. Local PubSub delivery is a
+      # synchronous send, so the message is in pid's mailbox before append/1
+      # returns; :sys.get_state is then handled AFTER that queued handle_info, so
+      # the inline STH computation is complete (and this process was NOT querying
+      # the shared connection during it) before we read the result. Concurrent
+      # tests' firehose entries also reach this subscriber, but each is a fast
+      # no-op perform (their tenant's rows are invisible in our sandbox), so they
+      # only add serialized latency, never a wrong result.
+      {:ok, entry} = AuditChain.append(tenant.id, append_attrs())
       :sys.get_state(pid)
 
       sth = AuditChain.get_latest_sth(tenant.id)
@@ -258,15 +341,24 @@ defmodule Loopctl.AuditChain.SthEnqueuerTest do
           Supervisor.child_spec({SthEnqueuer, [name: name, subscribe: false]}, id: name)
         )
 
-      capture_log(fn ->
-        # No tenant_id key at all.
-        send(pid, {:audit_chain_entry, %{}})
-        # Non-binary tenant_id.
-        send(pid, {:audit_chain_entry, %{tenant_id: make_ref()}})
-        :sys.get_state(pid)
-      end)
+      log =
+        capture_log(fn ->
+          # No tenant_id key at all.
+          send(pid, {:audit_chain_entry, %{}})
+          # Non-binary tenant_id.
+          send(pid, {:audit_chain_entry, %{tenant_id: make_ref()}})
+          :sys.get_state(pid)
+        end)
 
       assert Process.alive?(pid)
+
+      # A malformed-but-correctly-shaped entry is a benign, expected case: it is
+      # logged as MALFORMED (at warning), NOT via the ERROR/"crashed" path that is
+      # reserved for a genuine enqueue fault. This pins that distinction so a
+      # regression that routed malformed entries through enqueue_sth_job's raising
+      # guard (logging "crashed") would fail here.
+      assert log =~ "malformed audit_chain_entry"
+      refute log =~ "crashed while enqueuing"
     end
 
     test "TC-35.2.4c: an unknown message is ignored and never crashes the enqueuer" do

--- a/test/loopctl/audit_chain/sth_enqueuer_test.exs
+++ b/test/loopctl/audit_chain/sth_enqueuer_test.exs
@@ -87,11 +87,19 @@ defmodule Loopctl.AuditChain.SthEnqueuerTest do
       assert per_tenant_entry.tenant_id == tenant.id
       assert per_tenant_entry.chain_position == entry.chain_position
 
-      # New: the SAME message shape ALSO lands on the fixed firehose topic,
-      # carrying entry.tenant_id (the subscriber's only tenant-scoping input).
-      # Select this entry by id to ignore concurrent tests' firehose traffic.
-      assert_receive {:audit_chain_entry, %{id: ^entry_id} = firehose_entry}, 1_000
-      assert firehose_entry.tenant_id == tenant.id
+      # New: a MINIMAL tenant-scoped notification ALSO lands on the fixed firehose
+      # topic — same {:audit_chain_entry, _} tuple tag, but the payload is
+      # minimized to %{tenant_id: ...} (the subscriber's only tenant-scoping
+      # input). Select by this test's unique tenant_id to ignore concurrent tests'
+      # firehose traffic.
+      firehose_tid = tenant.id
+      assert_receive {:audit_chain_entry, %{tenant_id: ^firehose_tid} = firehose_msg}, 1_000
+
+      # The full entry — its :id, arbitrary :payload map, and :actor_lineage —
+      # is NEVER placed on the shared cross-tenant firehose (only tenant_id is).
+      refute Map.has_key?(firehose_msg, :id)
+      refute Map.has_key?(firehose_msg, :payload)
+      refute Map.has_key?(firehose_msg, :actor_lineage)
 
       # AC-35.2.1 also names {:sth_updated,…} and external (witness-cache)
       # subscribers as UNCHANGED. broadcast_sth/2 is untouched by this story, so
@@ -114,19 +122,18 @@ defmodule Loopctl.AuditChain.SthEnqueuerTest do
 
       :ok = ChainPubSub.subscribe_firehose()
 
-      {:ok, entry_a} = AuditChain.append(tenant_a.id, append_attrs())
-      {:ok, entry_b} = AuditChain.append(tenant_b.id, append_attrs())
+      {:ok, _entry_a} = AuditChain.append(tenant_a.id, append_attrs())
+      {:ok, _entry_b} = AuditChain.append(tenant_b.id, append_attrs())
 
-      a_id = entry_a.id
-      b_id = entry_b.id
+      a_tid = tenant_a.id
+      b_tid = tenant_b.id
 
-      # One firehose subscription observes appends from EVERY tenant. Select by
-      # entry id (unique) to tolerate other async tests broadcasting concurrently.
-      assert_receive {:audit_chain_entry, %{id: ^a_id, tenant_id: a_tid}}, 1_000
-      assert_receive {:audit_chain_entry, %{id: ^b_id, tenant_id: b_tid}}, 1_000
-
-      assert a_tid == tenant_a.id
-      assert b_tid == tenant_b.id
+      # One firehose subscription observes appends from EVERY tenant. The firehose
+      # payload is minimized to %{tenant_id: ...}, so select by each test-unique
+      # tenant_id (not entry id) to tolerate other async tests broadcasting
+      # concurrently.
+      assert_receive {:audit_chain_entry, %{tenant_id: ^a_tid}}, 1_000
+      assert_receive {:audit_chain_entry, %{tenant_id: ^b_tid}}, 1_000
     end
   end
 


### PR DESCRIPTION
## US-35.2 — Event-driven STH: audit-append firehose topic + supervised debounce-enqueuer

Makes STH (Signed Tree Head) computation **event-driven and activity-gated** instead of relying solely on the per-minute `all_tenants` cron. **Purely additive** — the cron is UNCHANGED (US-35.3 later slows it), so this change carries no latency risk on its own and no trust-boundary/RLS/role/job-semantics change.

### What changed
- **`AuditChain.PubSub`** — new fixed cross-tenant firehose topic `"audit_chain:events"` with `broadcast_entry_firehose/1`, `subscribe_firehose/0`, `firehose_topic/0`. The existing per-tenant `"audit_chain:<tenant_id>"` topic and its `{:audit_chain_entry, …}` / `{:sth_updated, …}` messages are unchanged.
- **`AuditChain.append/1`** — the append success branch now ALSO broadcasts the new entry to the firehose (fire-and-forget), in addition to the unchanged per-tenant broadcast.
- **`Loopctl.AuditChain.SthEnqueuer`** (new) — supervised, node-local singleton GenServer. Subscribes to the firehose on start; on each `{:audit_chain_entry, entry}` it debounce-enqueues one `ComputeSthWorker` for `entry.tenant_id` via a single `Oban.insert/2` with `unique: [fields: [:worker, :args], period: …, states: [:available, :scheduled]]` and a config-driven `schedule_in`. A burst of appends for one tenant within the window collapses to a single scheduled job (Basic-Engine-safe; multi-node safe since dedup is at the DB). Holds no per-tenant state. Enqueue errors and malformed/unknown messages are logged and ignored — never crashing the subscriber or the append path.
- **`application.ex`** — `SthEnqueuer` added to the supervision tree after `Phoenix.PubSub` and `Oban`.
- **config** — `:sth_enqueuer_debounce_seconds` (default 5), read at runtime. `config/test.exs` disables the boot singleton's firehose subscription so it doesn't `Oban.insert` without an owned sandbox connection during the suite.

### Acceptance criteria
- AC-35.2.1 firehose broadcast additive to per-tenant (existing behavior guarded) ✓
- AC-35.2.2 supervised singleton subscribes + single `Oban.insert/2` per tenant ✓
- AC-35.2.3 Basic-Engine-safe burst coalescing via `unique` ✓
- AC-35.2.4 correctness: STH reflects the latest `chain_position` ✓
- AC-35.2.5 resilience: never crashes the append path or itself ✓
- AC-35.2.6 multi-node safe; no unbounded GenServer state ✓

### Tests (TC-35.2.1..4)
Firehose broadcast to both topics; single fixed cross-tenant topic; burst coalescing to one scheduled job; string arg keys; live end-to-end STH at the new position; subscription-on-start; enqueue-error / malformed / unknown-message resilience; per-tenant isolation. Full `mix precommit` green (compile warnings-as-errors, format, credo --strict, dialyzer, 4442 tests).

Part of Epic 3 (#350) — STH & cron fleet-cost redesign. No dedicated per-story issue; this is the additive event-driven trigger US-35.3 depends on. Does not close #350 (epic spans multiple stories).