### PR TITLE
Reduce the all-tenants STH cron from every-minute to a low-frequency safety sweep

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -300,54 +300,17 @@ config :loopctl, Oban,
     knowledge: 5,
     memory: 3,
     audit: 3
-  ],
-  plugins: [
-    {Oban.Plugins.Cron,
-     crontab: [
-       {"0 * * * *", Loopctl.Workers.IdempotencyCleanupWorker},
-       {"0 * * * *", Loopctl.Workers.BulkDeleteTokenCleanupWorker},
-       {"0 * * * *", Loopctl.Workers.ReauthChallengeCleanupWorker},
-       {"0 2 * * *", Loopctl.Workers.AuditPartitionWorker},
-       {"0 2 * * *", Loopctl.Workers.CostRollupWorker},
-       {"0 3 * * *", Loopctl.Workers.WebhookCleanupWorker},
-       {"0 3 * * 0", Loopctl.Workers.TokenDataArchivalWorker},
-       {"0 4 * * *", Loopctl.Workers.KnowledgeLintWorker, args: %{"mode" => "all_tenants"}},
-       {"0 5 * * 0", Loopctl.Workers.KnowledgeMocWorker, args: %{"mode" => "all_tenants"}},
-       {"30 4 * * *", Loopctl.Workers.RetrievalMetricsWorker, args: %{"mode" => "all_tenants"}},
-       # Daily promotion-compile-quality eval (Epic 29 / US-29.5): precision/recall of
-       # Loopctl.Memory.Promoter against the committed labeled dataset. Calibration/
-       # observability only — never gates promotion.
-       {"45 4 * * *", Loopctl.Workers.PromotionEvalWorker, args: %{"mode" => "all_tenants"}},
-       {"*/5 * * * *", Loopctl.Workers.PendingEnrollmentCleanupWorker},
-       {"*/5 * * * *", Loopctl.Workers.SessionMemoryPruneWorker},
-       # Cross-tenant memory-promotion sweep (Epic 29 / US-29.2). Runs every 10 min —
-       # KEEP this in sync with :memory_promotion_sweep_interval_seconds (600) below,
-       # which is the data form of this schedule that the boot invariant reasons over.
-       # The expiry floor MUST exceed this interval and stay shorter than
-       # :session_memory_ttl_seconds (both asserted at boot) so session turns are
-       # promoted before SessionMemoryPruneWorker can delete them (no silent
-       # golden-nugget loss).
-       {"*/10 * * * *", Loopctl.Workers.MemoryPromotionSweepWorker},
-       {"* * * * *", Loopctl.Workers.ComputeSthWorker, args: %{"mode" => "all_tenants"}},
-       {"* * * * *", Loopctl.Workers.RevokeExpiredDispatchesWorker},
-       {"* * * * *", Loopctl.Workers.SystemConfigRefreshWorker}
-     ]},
-    # Rescue jobs orphaned in :executing when a node dies mid-run (e.g. a deploy).
-    # Without Lifeline these rows stay `executing` forever — 110 such orphans (from
-    # 2026-06-22) were found still clogging the queues on 2026-07-10. Reset a stuck
-    # job back to `available` (or discard if attempts are exhausted) after 30 min so
-    # the slot frees and it re-runs instead of leaking.
-    {Oban.Plugins.Lifeline, rescue_after: :timer.minutes(30)},
-    # Prune terminal (completed/discarded/cancelled) jobs older than 7 days so the
-    # oban_jobs table doesn't grow unbounded.
-    {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 7},
-    # US-34.1 (AC-34.1.4): periodically REINDEX CONCURRENTLY the oban_jobs indexes
-    # (default: oban_jobs_args_index + oban_jobs_meta_index, once daily at midnight
-    # UTC) so index bloat from this table's high churn (state transitions on every
-    # job) doesn't silently degrade the queries the new US-34.1 gauges themselves
-    # depend on. Purely additive — no job semantics change.
-    Oban.Plugins.Reindexer
   ]
+
+# US-35.3: the Oban `:plugins` list (Cron crontab + Lifeline + Pruner + Reindexer)
+# moved to `Loopctl.ObanConfig.plugins/0` and is set at RUNTIME in `config/runtime.exs`
+# (`config :loopctl, Oban, plugins: Loopctl.ObanConfig.plugins()`). It lives there —
+# not here — so the all-tenants ComputeSthWorker safety-sweep schedule is driven by
+# `STH_SWEEP_CRON` (`Loopctl.ObanConfig.sth_sweep_cron/0`, default `*/5 * * * *`) and is
+# tunable/revertible per environment without a deploy. NB: unlike `queues:` (a keyword
+# list that `Config` deep-merges), `:plugins` is a plain list that `Config` REPLACES
+# wholesale, so it must be owned entirely by whichever layer sets it last (runtime.exs).
+# Do NOT re-add a compile-time `plugins:` here — it would be overwritten at boot.
 
 # US-34.1 (AC-34.1.4): Stager is NOT a `plugins:` entry in this Oban version
 # (2.21) — it was absorbed into Oban's core engine and is now configured via the
@@ -389,8 +352,19 @@ config :loopctl, :oban_orphan_health_threshold, 10
 # `unique` `period`, so a burst of appends for one tenant within this window
 # collapses to a single scheduled job (Basic-Engine-safe dedup). Short by design:
 # it only delays the activity-driven STH sign by a few seconds while coalescing
-# bursts; the per-minute cron poll remains the correctness backstop.
+# bursts; the low-frequency cron sweep (US-35.3, below) remains the correctness backstop.
 config :loopctl, :sth_enqueuer_debounce_seconds, 5
+
+# US-35.3: all-tenants ComputeSthWorker safety-sweep cron. Reduced from `"* * * * *"`
+# (every minute) to a low-frequency, config-driven backstop (default `*/5 * * * *`) that
+# only catches audit appends the event-driven enqueuer (US-35.2, above) missed. The
+# expression is NOT set here — it is read from the `STH_SWEEP_CRON` env var at runtime by
+# `Loopctl.ObanConfig.sth_sweep_cron/0` and installed into the Oban crontab via
+# `Loopctl.ObanConfig.plugins/0` in `config/runtime.exs`, so an operator can slow or
+# revert the sweep with `fly secrets set STH_SWEEP_CRON=... && restart` — no deploy.
+# Correctness is interval-independent: every fanned-out per-tenant job still self-gates on
+# `Loopctl.AuditChain.sth_needed?/1`, so a slower poll can only delay (never corrupt) an
+# STH, and only for a tenant the event path also missed, by up to one sweep interval.
 
 # Cloak Vault — key configured per environment
 # Generate a key: :crypto.strong_rand_bytes(32) |> Base.encode64()

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -43,7 +43,16 @@ config :loopctl, LoopctlWeb.Endpoint,
 # with the compile-time one (a queue key present in config.exs but omitted here would
 # be preserved, not dropped), but `Loopctl.ObanConfig.queues/0` always re-lists every
 # default queue anyway so the env-tunability guarantee holds unconditionally.
-config :loopctl, Oban, queues: Loopctl.ObanConfig.queues()
+#
+# US-35.3: the Oban `:plugins` list (Cron crontab + Lifeline + Pruner + Reindexer) is
+# ALSO owned here, via `Loopctl.ObanConfig.plugins/0`, so the all-tenants
+# ComputeSthWorker safety-sweep schedule is driven by `STH_SWEEP_CRON` and is
+# tunable/revertible per environment without a deploy. Unlike `queues:` (a keyword list
+# `Config` deep-merges), `:plugins` is a plain list `Config` REPLACES wholesale — so it
+# must be set from a single owner (here). `config/config.exs` no longer sets `plugins:`.
+config :loopctl, Oban,
+  queues: Loopctl.ObanConfig.queues(),
+  plugins: Loopctl.ObanConfig.plugins()
 
 # Cloak Vault — key from environment in all environments where CLOAK_KEY is set.
 # In production, CLOAK_KEY is required — startup fails if it is missing.

--- a/lib/loopctl/oban_config.ex
+++ b/lib/loopctl/oban_config.ex
@@ -31,6 +31,8 @@ defmodule Loopctl.ObanConfig do
   interval is a load/latency knob only — it can never produce a wrong STH.
   """
 
+  alias Oban.Cron.Expression
+
   # Default widths are a literal, hand-maintained mirror of config/config.exs's
   # compile-time `config :loopctl, Oban, queues: [...]` (AC-32.2.3). Sum = 38
   # (10+5+2+3+2+5+5+3+3). Keep the two lists in sync when adding/removing/resizing
@@ -110,9 +112,15 @@ defmodule Loopctl.ObanConfig do
   interval is a load/latency knob only — worst case it delays (never corrupts) an STH
   for a tenant the event path also missed, by up to one sweep interval.
 
-  Raises `ArgumentError` (like `queue_size/2`) when the env var is present but not a
-  well-formed 5-field cron string — a malformed non-nil value must fail loud at boot,
-  not silently fall back to the default.
+  Raises `ArgumentError` (like `queue_size/2`) when the env var is present but not an
+  expression Oban itself accepts — a malformed non-nil value must fail loud at boot,
+  not silently fall back to the default. Validation delegates to Oban's own parser
+  (`Oban.Cron.Expression.parse/1`), so any form Oban's Cron plugin would accept is
+  accepted here: a standard 5-field expression (`*/30 * * * *`), the extended
+  step/range syntax, OR an `@`-nickname (`@hourly`, `@daily`, `@weekly`, `@monthly`,
+  `@yearly`, `@annually`, `@midnight`, `@reboot`). Semantically-invalid values that
+  happen to have 5 fields (e.g. `99 99 99 99 99`) are rejected too, because the parser
+  range-checks each field. The validator can never be stricter than its consumer.
   """
   @spec sth_sweep_cron() :: String.t()
   def sth_sweep_cron do
@@ -122,13 +130,14 @@ defmodule Loopctl.ObanConfig do
   defp validate_cron(nil, default), do: default
 
   defp validate_cron(value, _default) when is_binary(value) do
-    fields = value |> String.trim() |> String.split(~r/\s+/, trim: true)
+    case Expression.parse(String.trim(value)) do
+      {:ok, _expression} ->
+        value
 
-    if length(fields) == 5 do
-      value
-    else
-      raise ArgumentError,
-            "STH_SWEEP_CRON must be a 5-field cron expression, got: #{inspect(value)}"
+      {:error, %{message: message}} ->
+        raise ArgumentError,
+              "STH_SWEEP_CRON must be a cron expression Oban accepts " <>
+                "(5-field or @nickname), got: #{inspect(value)} (#{message})"
     end
   end
 

--- a/lib/loopctl/oban_config.ex
+++ b/lib/loopctl/oban_config.ex
@@ -4,8 +4,7 @@ defmodule Loopctl.ObanConfig do
 
   Queue concurrency is retuned during an incident via `OBAN_QUEUE_<NAME>` env vars
   (e.g. `fly secrets set OBAN_QUEUE_DEFAULT=20` + restart) WITHOUT a code change or
-  deploy — the substrate for Epic 4 per-tenant fairness (#351). Scope is queue WIDTHS
-  ONLY; plugins/cron stay compile-time in `config/config.exs`.
+  deploy — the substrate for Epic 4 per-tenant fairness (#351).
 
   `config/runtime.exs` sets `config :loopctl, Oban, queues: Loopctl.ObanConfig.queues()`
   at the top level (outside any prod-only guard) so every queue is re-listed from
@@ -14,6 +13,22 @@ defmodule Loopctl.ObanConfig do
   would actually be PRESERVED, not dropped — `queues/0` still always returns the full
   keyword list, one entry per default queue, so every queue stays env-tunable rather
   than silently falling back to its compile-time (non-tunable) width.
+
+  ## Plugins / cron (US-35.3)
+
+  `plugins/0` OWNS the full Oban `:plugins` list (Cron crontab + Lifeline + Pruner +
+  Reindexer), and `config/runtime.exs` sets
+  `config :loopctl, Oban, plugins: Loopctl.ObanConfig.plugins()` alongside `queues:`.
+  Unlike `queues:`, the `:plugins` value is a plain list of bare atoms/tuples (NOT a
+  keyword list), so Elixir `Config` REPLACES it wholesale rather than merging
+  element-wise — whichever layer sets `plugins:` LAST wins. Therefore the crontab
+  lives here (read at runtime) and `config/config.exs` no longer sets `plugins:`.
+
+  This exists so the all-tenants `ComputeSthWorker` safety-sweep cron is runtime-tunable
+  via `STH_SWEEP_CRON` (see `sth_sweep_cron/0`): an operator can slow/revert the sweep
+  with `fly secrets set STH_SWEEP_CRON=... && restart`, no deploy. Every per-tenant job
+  the sweep fans out still self-gates on `Loopctl.AuditChain.sth_needed?/1`, so the
+  interval is a load/latency knob only — it can never produce a wrong STH.
   """
 
   # Default widths are a literal, hand-maintained mirror of config/config.exs's
@@ -75,5 +90,114 @@ defmodule Loopctl.ObanConfig do
         raise ArgumentError,
               "OBAN queue size must be a positive integer, got: #{inspect(value)} (default: #{default})"
     end
+  end
+
+  # US-35.3: default safety-sweep interval for the all-tenants ComputeSthWorker cron.
+  # Every 5 minutes — a low-frequency backstop that only catches appends the
+  # event-driven enqueuer (US-35.2) missed. Down from the old `"* * * * *"` per-minute
+  # poll, which fanned out one no-op job per active tenant every minute.
+  @default_sth_sweep_cron "*/5 * * * *"
+
+  @doc """
+  Resolves the all-tenants `ComputeSthWorker` sweep cron expression from
+  `STH_SWEEP_CRON`, falling back to `#{@default_sth_sweep_cron}` (every 5 minutes)
+  when unset.
+
+  Runtime-tunable (read via `System.get_env/1` at call time, invoked from
+  `config/runtime.exs`) so an operator can slow/revert the safety sweep with
+  `fly secrets set STH_SWEEP_CRON=... && restart`, no deploy. Because every
+  per-tenant job the sweep fans out self-gates on `AuditChain.sth_needed?/1`, the
+  interval is a load/latency knob only — worst case it delays (never corrupts) an STH
+  for a tenant the event path also missed, by up to one sweep interval.
+
+  Raises `ArgumentError` (like `queue_size/2`) when the env var is present but not a
+  well-formed 5-field cron string — a malformed non-nil value must fail loud at boot,
+  not silently fall back to the default.
+  """
+  @spec sth_sweep_cron() :: String.t()
+  def sth_sweep_cron do
+    validate_cron(System.get_env("STH_SWEEP_CRON"), @default_sth_sweep_cron)
+  end
+
+  defp validate_cron(nil, default), do: default
+
+  defp validate_cron(value, _default) when is_binary(value) do
+    fields = value |> String.trim() |> String.split(~r/\s+/, trim: true)
+
+    if length(fields) == 5 do
+      value
+    else
+      raise ArgumentError,
+            "STH_SWEEP_CRON must be a 5-field cron expression, got: #{inspect(value)}"
+    end
+  end
+
+  @doc """
+  Returns the full Oban `:plugins` list (US-35.3).
+
+  Owns the crontab so the all-tenants `ComputeSthWorker` safety-sweep schedule is
+  driven by `sth_sweep_cron/0` (runtime-tunable via `STH_SWEEP_CRON`). All other
+  crontab entries and the Lifeline/Pruner/Reindexer plugins are moved here VERBATIM
+  from the former `config/config.exs` block — no schedule or option changed except the
+  ComputeSthWorker entry, which went from `"* * * * *"` (every minute) to
+  `sth_sweep_cron/0` (default `#{@default_sth_sweep_cron}`).
+  """
+  @spec plugins() :: list()
+  def plugins do
+    [
+      {Oban.Plugins.Cron,
+       crontab: [
+         {"0 * * * *", Loopctl.Workers.IdempotencyCleanupWorker},
+         {"0 * * * *", Loopctl.Workers.BulkDeleteTokenCleanupWorker},
+         {"0 * * * *", Loopctl.Workers.ReauthChallengeCleanupWorker},
+         {"0 2 * * *", Loopctl.Workers.AuditPartitionWorker},
+         {"0 2 * * *", Loopctl.Workers.CostRollupWorker},
+         {"0 3 * * *", Loopctl.Workers.WebhookCleanupWorker},
+         {"0 3 * * 0", Loopctl.Workers.TokenDataArchivalWorker},
+         {"0 4 * * *", Loopctl.Workers.KnowledgeLintWorker, args: %{"mode" => "all_tenants"}},
+         {"0 5 * * 0", Loopctl.Workers.KnowledgeMocWorker, args: %{"mode" => "all_tenants"}},
+         {"30 4 * * *", Loopctl.Workers.RetrievalMetricsWorker, args: %{"mode" => "all_tenants"}},
+         # Daily promotion-compile-quality eval (Epic 29 / US-29.5): precision/recall of
+         # Loopctl.Memory.Promoter against the committed labeled dataset. Calibration/
+         # observability only — never gates promotion.
+         {"45 4 * * *", Loopctl.Workers.PromotionEvalWorker, args: %{"mode" => "all_tenants"}},
+         {"*/5 * * * *", Loopctl.Workers.PendingEnrollmentCleanupWorker},
+         {"*/5 * * * *", Loopctl.Workers.SessionMemoryPruneWorker},
+         # Cross-tenant memory-promotion sweep (Epic 29 / US-29.2). Runs every 10 min —
+         # KEEP this in sync with :memory_promotion_sweep_interval_seconds (600) below,
+         # which is the data form of this schedule that the boot invariant reasons over.
+         # The expiry floor MUST exceed this interval and stay shorter than
+         # :session_memory_ttl_seconds (both asserted at boot) so session turns are
+         # promoted before SessionMemoryPruneWorker can delete them (no silent
+         # golden-nugget loss).
+         {"*/10 * * * *", Loopctl.Workers.MemoryPromotionSweepWorker},
+         # US-35.3: all-tenants STH safety sweep. Reduced from `"* * * * *"` (every
+         # minute) to a low-frequency, config-driven backstop (default `*/5 * * * *`)
+         # that only catches appends the event-driven enqueuer (US-35.2) missed. Each
+         # fanned-out per-tenant job still self-gates on `AuditChain.sth_needed?/1`, so
+         # slowing the poll can never produce a wrong STH — worst case it delays an STH
+         # (for a tenant the event path also missed) by up to one sweep interval. Driven
+         # by `sth_sweep_cron/0` (env `STH_SWEEP_CRON`) so it's tunable/revertible per
+         # environment without a deploy.
+         {sth_sweep_cron(), Loopctl.Workers.ComputeSthWorker, args: %{"mode" => "all_tenants"}},
+         {"* * * * *", Loopctl.Workers.RevokeExpiredDispatchesWorker},
+         {"* * * * *", Loopctl.Workers.SystemConfigRefreshWorker}
+       ]},
+      # Rescue jobs orphaned in :executing when a node dies mid-run (e.g. a deploy).
+      # Without Lifeline these rows stay `executing` forever — 110 such orphans (from
+      # 2026-06-22) were found still clogging the queues on 2026-07-10. Reset a stuck
+      # job back to `available` (or discard if attempts are exhausted) after 30 min so
+      # the slot frees and it re-runs instead of leaking.
+      {Oban.Plugins.Lifeline, rescue_after: :timer.minutes(30)},
+      # Prune terminal (completed/discarded/cancelled) jobs older than 7 days so the
+      # oban_jobs table doesn't grow unbounded.
+      {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 7},
+      # US-34.1 (AC-34.1.4): periodically REINDEX CONCURRENTLY the oban_jobs indexes
+      # (default: oban_jobs_args_index + oban_jobs_meta_index, once daily at midnight
+      # UTC) so index bloat from this table's high churn (state transitions on every
+      # job) doesn't silently degrade the queries the new US-34.1 gauges themselves
+      # depend on. Purely additive — no job semantics change.
+      Oban.Plugins.Reindexer
+    ]
   end
 end

--- a/lib/loopctl/oban_config.ex
+++ b/lib/loopctl/oban_config.ex
@@ -130,9 +130,15 @@ defmodule Loopctl.ObanConfig do
   defp validate_cron(nil, default), do: default
 
   defp validate_cron(value, _default) when is_binary(value) do
-    case Expression.parse(String.trim(value)) do
+    trimmed = String.trim(value)
+
+    case Expression.parse(trimmed) do
       {:ok, _expression} ->
-        value
+        # Return the TRIMMED value — Oban's Cron plugin re-parses whatever we hand it,
+        # and it rejects trailing whitespace/newlines. Returning the raw `value` would
+        # pass validation here but crash the plugin at boot with an unattributed
+        # "unrecognized cron expression" error. Hand Oban exactly what we validated.
+        trimmed
 
       {:error, %{message: message}} ->
         raise ArgumentError,

--- a/lib/loopctl/workers/compute_sth_worker.ex
+++ b/lib/loopctl/workers/compute_sth_worker.ex
@@ -7,11 +7,16 @@ defmodule Loopctl.Workers.ComputeSthWorker do
 
   ## Scheduling
 
-  Configured via Oban Cron to run every minute in `all_tenants` mode,
-  which fans out individual per-tenant jobs via a single `Oban.insert_all/1`
-  batch. Each per-tenant job is scheduled with a small deterministic jitter
-  (see `jitter/1`) so the fanout doesn't thundering-herd the `:audit` queue
-  and the primary DB at the exact `:00` instant of the cron tick.
+  Configured via Oban Cron to run in `all_tenants` mode on a low-frequency,
+  config-driven safety-sweep interval (US-35.3, default every 5 minutes via
+  `STH_SWEEP_CRON` / `Loopctl.ObanConfig.sth_sweep_cron/0`) — reduced from the
+  former per-minute poll now that US-35.2's event-driven enqueuer signs STHs on
+  real audit appends. The sweep fans out individual per-tenant jobs via a single
+  `Oban.insert_all/1` batch. Each per-tenant job is scheduled with a small
+  deterministic jitter (see `jitter/1`) so the fanout doesn't thundering-herd the
+  `:audit` queue and the primary DB at the exact `:00` instant of the cron tick,
+  and self-gates on `AuditChain.sth_needed?/1` so a slower sweep can only delay
+  (never corrupt) an STH.
 
   ## `unique` does NOT apply to this fanout
 

--- a/test/loopctl/oban_config_test.exs
+++ b/test/loopctl/oban_config_test.exs
@@ -181,6 +181,37 @@ defmodule Loopctl.ObanConfigTest do
     end
 
     @tag :tmp_dir
+    test "TC-35.3.7: a STH_SWEEP_CRON padded with trailing whitespace/newline is trimmed to a value Oban accepts",
+         %{tmp_dir: tmp_dir} do
+      # Regression: validate_cron/2 validated `String.trim(value)` but previously
+      # returned the RAW `value`. Oban's Cron plugin re-parses whatever it's handed and
+      # REJECTS trailing whitespace/newlines, so a padded STH_SWEEP_CRON (common from
+      # $(cat file), piped secrets, YAML quoting, copy-paste) passed boot validation
+      # then crashed the Cron plugin fleet-wide with an unattributed "unrecognized cron
+      # expression" error. sth_sweep_cron/0 must return the TRIMMED value, and that
+      # value must be one Oban's own parser accepts.
+      result =
+        run_elixir_script(
+          tmp_dir,
+          """
+          returned = Loopctl.ObanConfig.sth_sweep_cron()
+
+          result = %{
+            returned: returned,
+            oban_accepts?: match?({:ok, _}, Oban.Cron.Expression.parse(returned))
+          }
+          """,
+          [{"STH_SWEEP_CRON", "*/5 * * * *\n"}]
+        )
+
+      assert result.returned == "*/5 * * * *"
+
+      assert result.oban_accepts?,
+             "the value handed to Oban's Cron plugin must parse cleanly — a trailing " <>
+               "newline would crash the plugin at boot"
+    end
+
+    @tag :tmp_dir
     test "TC-35.3.5: a malformed 5-field STH_SWEEP_CRON (out-of-range) aborts boot with ArgumentError",
          %{tmp_dir: tmp_dir} do
       # `config/runtime.exs` calls plugins/0 -> sth_sweep_cron/0 while loading config,

--- a/test/loopctl/oban_config_test.exs
+++ b/test/loopctl/oban_config_test.exs
@@ -146,6 +146,63 @@ defmodule Loopctl.ObanConfigTest do
     end
   end
 
+  describe "sth_sweep_cron/0 (US-35.3, runtime-tunable via STH_SWEEP_CRON)" do
+    test "TC-35.3.2: defaults to the 5-minute sweep when STH_SWEEP_CRON is unset" do
+      # STH_SWEEP_CRON is not set in the test environment, so the default applies.
+      assert ObanConfig.sth_sweep_cron() == "*/5 * * * *"
+    end
+
+    @tag :tmp_dir
+    test "TC-35.3.3: a valid 5-field STH_SWEEP_CRON override is read at runtime and returned",
+         %{tmp_dir: tmp_dir} do
+      result =
+        run_elixir_script(
+          tmp_dir,
+          "result = Loopctl.ObanConfig.sth_sweep_cron()",
+          [{"STH_SWEEP_CRON", "0 * * * *"}]
+        )
+
+      assert result == "0 * * * *"
+    end
+
+    @tag :tmp_dir
+    test "TC-35.3.4: an @nickname STH_SWEEP_CRON override is accepted (Oban parses nicknames)",
+         %{tmp_dir: tmp_dir} do
+      # Regression: validate_cron/2 previously counted fields and false-rejected the
+      # single-field @nickname forms that Oban's own Cron parser accepts.
+      result =
+        run_elixir_script(
+          tmp_dir,
+          "result = Loopctl.ObanConfig.sth_sweep_cron()",
+          [{"STH_SWEEP_CRON", "@hourly"}]
+        )
+
+      assert result == "@hourly"
+    end
+
+    @tag :tmp_dir
+    test "TC-35.3.5: a malformed 5-field STH_SWEEP_CRON (out-of-range) aborts boot with ArgumentError",
+         %{tmp_dir: tmp_dir} do
+      # `config/runtime.exs` calls plugins/0 -> sth_sweep_cron/0 while loading config,
+      # so a malformed value fails LOUD at boot (non-zero exit) rather than silently
+      # falling back to the default — even under `mix run --no-start`.
+      {output, exit_code} = run_boot(tmp_dir, [{"STH_SWEEP_CRON", "99 99 99 99 99"}])
+
+      assert exit_code != 0
+      assert output =~ "STH_SWEEP_CRON"
+      assert output =~ "out of range"
+    end
+
+    @tag :tmp_dir
+    test "TC-35.3.6: a non-cron STH_SWEEP_CRON string aborts boot with ArgumentError",
+         %{tmp_dir: tmp_dir} do
+      {output, exit_code} = run_boot(tmp_dir, [{"STH_SWEEP_CRON", "not a cron"}])
+
+      assert exit_code != 0
+      assert output =~ "STH_SWEEP_CRON"
+    end
+  end
+
   # Runs `script` (must bind a `result` variable) in a fresh `mix run --no-start`
   # subprocess with `env` applied ONLY to that child process, then reads back the
   # term `script` wrote to `result_path` via :erlang.term_to_binary/1. Keeps this
@@ -168,5 +225,21 @@ defmodule Loopctl.ObanConfigTest do
     assert exit_code == 0, "subprocess script failed (exit #{exit_code}):\n#{output}"
 
     result_path |> File.read!() |> :erlang.binary_to_term()
+  end
+
+  # Boots a fresh `mix run --no-start` subprocess (which still evaluates
+  # `config/runtime.exs`, and thus `ObanConfig.plugins/0 -> sth_sweep_cron/0`) with
+  # `env` applied ONLY to that child process, and returns `{output, exit_code}` WITHOUT
+  # asserting success — for tests that assert a malformed env value aborts boot. Keeps
+  # this async: true file free of any global env mutation.
+  defp run_boot(tmp_dir, env) do
+    result_path = Path.join(tmp_dir, "booted.bin")
+
+    System.cmd(
+      "mix",
+      ["run", "--no-start", "-e", "File.write!(#{inspect(result_path)}, <<>>)"],
+      env: [{"MIX_ENV", "test"} | env],
+      stderr_to_stdout: true
+    )
   end
 end

--- a/test/loopctl/oban_plugins_config_test.exs
+++ b/test/loopctl/oban_plugins_config_test.exs
@@ -4,8 +4,13 @@ defmodule Loopctl.ObanPluginsConfigTest do
   pre-existing Lifeline/Pruner plugins are unchanged.
 
   Pure config read — no DB, no running Oban needed (`config/test.exs` sets
-  `testing: :inline`, under which plugins are not started, but the KEYWORD LIST
-  configured in `config/config.exs` still merges into `Application.get_env/2`).
+  `testing: :inline`, under which plugins are not started). As of US-35.3 the
+  `:plugins` list is owned exclusively by `Loopctl.ObanConfig.plugins/0` and set at
+  RUNTIME in `config/runtime.exs` (`config :loopctl, Oban, plugins:
+  Loopctl.ObanConfig.plugins()`); `config/config.exs` no longer sets `plugins:`.
+  `runtime.exs` runs in every environment (test included), so the crontab / Lifeline /
+  Pruner / Reindexer this module asserts on are read straight from that runtime-set
+  value via `Application.get_env/2`.
   """
   use ExUnit.Case, async: true
 

--- a/test/loopctl/oban_plugins_config_test.exs
+++ b/test/loopctl/oban_plugins_config_test.exs
@@ -39,6 +39,47 @@ defmodule Loopctl.ObanPluginsConfigTest do
     end
   end
 
+  describe "US-35.3: all-tenants ComputeSthWorker safety-sweep cron (AC-35.3.1, TC-35.3.1)" do
+    setup do
+      plugins = Application.get_env(:loopctl, Oban)[:plugins]
+
+      {Oban.Plugins.Cron, cron_opts} =
+        Enum.find(plugins, &match?({Oban.Plugins.Cron, _}, &1))
+
+      entry =
+        Enum.find(cron_opts[:crontab], fn
+          {_schedule, Loopctl.Workers.ComputeSthWorker, opts} ->
+            Keyword.get(opts, :args) == %{"mode" => "all_tenants"}
+
+          _ ->
+            false
+        end)
+
+      %{entry: entry}
+    end
+
+    test "the all_tenants ComputeSthWorker entry exists in the crontab", %{entry: entry} do
+      assert entry, "expected an all_tenants ComputeSthWorker crontab entry"
+    end
+
+    test "its schedule is no longer the per-minute poll", %{entry: entry} do
+      {schedule, _worker, _opts} = entry
+      refute schedule == "* * * * *"
+    end
+
+    test "its schedule is config-driven (equals ObanConfig.sth_sweep_cron/0)", %{entry: entry} do
+      {schedule, _worker, _opts} = entry
+      assert schedule == Loopctl.ObanConfig.sth_sweep_cron()
+    end
+  end
+
+  describe "US-35.3: sth_sweep_cron/0 (config-based DI, runtime-tunable)" do
+    test "defaults to a 5-minute sweep when STH_SWEEP_CRON is unset" do
+      # STH_SWEEP_CRON is not set in the test environment, so the default applies.
+      assert Loopctl.ObanConfig.sth_sweep_cron() == "*/5 * * * *"
+    end
+  end
+
   defp reindexer?(Oban.Plugins.Reindexer), do: true
   defp reindexer?({Oban.Plugins.Reindexer, _opts}), do: true
   defp reindexer?(_other), do: false

--- a/test/loopctl/workers/compute_sth_worker_test.exs
+++ b/test/loopctl/workers/compute_sth_worker_test.exs
@@ -142,4 +142,102 @@ defmodule Loopctl.Workers.ComputeSthWorkerTest do
       assert sth.chain_position == 0
     end
   end
+
+  # US-35.3: the reduced-frequency cron is only a SCHEDULING change; the
+  # all-tenants fanout + per-tenant self-gating is unchanged. These tests prove
+  # the bounded-lag safety net: with the event-driven enqueuer (US-35.2) OFF
+  # (config/test.exs sets :sth_enqueuer_subscribe = false, so the event path is
+  # already disabled here — no runtime toggling), running ONE sweep still signs
+  # an STH at the latest chain position for any tenant that appended between
+  # sweeps, and never produces a spurious STH when nothing changed.
+  describe "US-35.3: reduced-frequency safety sweep (AC-35.3.2/.3, TC-35.3.2/.3)" do
+    test "TC-35.3.2: a tenant that appended between sweeps gets an STH by the next sweep" do
+      {tenant, _priv} = signing_tenant()
+
+      # Two appends -> latest chain_position is 1.
+      {:ok, _} = AuditChain.append(tenant.id, append_attrs())
+      {:ok, _} = AuditChain.append(tenant.id, append_attrs())
+
+      # No STH yet: the event path is off and no sweep has run.
+      assert AuditChain.get_latest_sth(tenant.id) == nil
+
+      # Run exactly ONE all-tenants safety sweep and drain the fanned-out
+      # per-tenant jobs (persist under :manual, then execute via drain).
+      run_one_sweep()
+
+      sth = AuditChain.get_latest_sth(tenant.id)
+      assert %AuditChain.SignedTreeHead{} = sth
+      # Bounded-lag guarantee: STH lands at the LATEST appended position.
+      assert sth.chain_position == 1
+      assert sth_count(tenant.id) == 1
+    end
+
+    test "TC-35.3.3: a tenant already at head gets no new STH from a sweep (self-gated)" do
+      {tenant, _priv} = signing_tenant()
+
+      {:ok, _} = AuditChain.append(tenant.id, append_attrs())
+
+      # Sign an STH at head first (via the per-tenant path).
+      assert :ok = ComputeSthWorker.perform(%Oban.Job{args: %{"tenant_id" => tenant.id}})
+      sth_before = AuditChain.get_latest_sth(tenant.id)
+      assert %AuditChain.SignedTreeHead{chain_position: 0} = sth_before
+      assert sth_count(tenant.id) == 1
+      refute AuditChain.sth_needed?(tenant.id)
+
+      # A subsequent sweep with no new entries must be a no-op (self-gated).
+      run_one_sweep()
+
+      sth_after = AuditChain.get_latest_sth(tenant.id)
+      assert sth_after.chain_position == 0
+      assert sth_count(tenant.id) == 1
+    end
+  end
+
+  # Sets up an active tenant whose stored audit_signing_public_key matches the
+  # private key returned by MockSecrets, so `sign_and_store_tree_head/1`
+  # succeeds. `append/3` does not touch the signing key, so a single key set is
+  # sufficient (unlike the two-step dance TC-32.5.3 uses for illustration).
+  defp signing_tenant do
+    tenant = fixture(:tenant, %{slug: "sth-sweep-#{System.unique_integer([:positive])}"})
+    {_pub, priv} = :crypto.generate_key(:eddsa, :ed25519)
+    {matching_pub, _} = :crypto.generate_key(:eddsa, :ed25519, priv)
+
+    tenant =
+      tenant
+      |> Ecto.Changeset.change(audit_signing_public_key: matching_pub)
+      |> AdminRepo.update!()
+
+    # Stub (not expect) so any number of sign calls resolve the same key.
+    Mox.stub(Loopctl.MockSecrets, :get, fn _name -> {:ok, priv} end)
+    Loopctl.TenantKeys.init_cache()
+
+    {tenant, priv}
+  end
+
+  defp append_attrs do
+    %{
+      action: "test_event",
+      actor_lineage: ["test"],
+      entity_type: "test",
+      payload: %{"k" => "v"}
+    }
+  end
+
+  # Runs one all-tenants sweep and drains the fanned-out per-tenant :audit jobs.
+  # Under :manual the fanout persists jobs (instead of executing inline), then
+  # `drain_queue(with_scheduled: true)` executes them past their jitter delay --
+  # the deterministic analogue of the cron sweep + queue draining in production.
+  defp run_one_sweep do
+    Oban.Testing.with_testing_mode(:manual, fn ->
+      assert :ok = ComputeSthWorker.perform(%Oban.Job{args: %{"mode" => "all_tenants"}})
+      Oban.drain_queue(queue: :audit, with_scheduled: true)
+    end)
+  end
+
+  defp sth_count(tenant_id) do
+    AdminRepo.aggregate(
+      from(s in AuditChain.SignedTreeHead, where: s.tenant_id == ^tenant_id),
+      :count
+    )
+  end
 end

--- a/test/loopctl_web/plugs/validate_witness_header_test.exs
+++ b/test/loopctl_web/plugs/validate_witness_header_test.exs
@@ -414,8 +414,10 @@ defmodule LoopctlWeb.Plugs.ValidateWitnessHeaderTest do
     @zero_prefix Base.url_encode64(:binary.copy(<<0>>, 16), padding: false)
 
     test "echoing the zero-STH placeholder PASSES when the tenant has no sealed STH" do
-      # A new tenant has a ~60s window (before ComputeSthWorker seals its first
-      # STH) where the bootstrap hands out `0:<zero_prefix>`. A subsequent request
+      # A new tenant has a bootstrap-grace window (before its first STH is sealed —
+      # via the US-35.2 event path on first append, or at worst one configurable
+      # all-tenants sweep interval, default `*/5 * * * *`, of the ComputeSthWorker)
+      # where the bootstrap hands out `0:<zero_prefix>`. A subsequent request
       # echoing exactly that must NOT 409 — there is nothing to diverge from, and
       # the 412-only client retry could never recover from a 409 here.
       {_raw, api_key} = fixture(:api_key, %{role: :agent})


### PR DESCRIPTION
## US-35.3 — Reduce all-tenants STH cron to a low-frequency safety sweep

loopctl signs a per-tenant Signed Tree Head (STH) over each tenant's audit chain. Since US-35.2 the fast path is **event-driven** (`SthEnqueuer` debounce-enqueues on real audit appends). The all-tenants cron poll — previously `"* * * * *"` (every minute), fanning out one per-tenant job for every active tenant — became a redundant backstop that emitted N no-op jobs/min for idle tenants.

This story slows that poll to a **low-frequency, config-driven safety sweep** (default `*/5 * * * *`) that only catches appends the event path missed. It is a **scheduling/config-only** change: worker logic, queues, jitter, and `insert_all` chunking are untouched, and every fanned-out per-tenant job still self-gates on `AuditChain.sth_needed?/1` — so a slower poll can only ever *delay* (never corrupt) an STH, and only for a tenant the event path also missed, by up to one sweep interval.

### What changed
- **`Loopctl.ObanConfig.sth_sweep_cron/0`** — reads `STH_SWEEP_CRON` (default `*/5 * * * *`), raising `ArgumentError` on a malformed non-nil value (mirrors `queue_size/2`'s fail-loud behavior).
- **`Loopctl.ObanConfig.plugins/0`** — now owns the full Oban `:plugins` list (Cron crontab + Lifeline + Pruner + Reindexer), verbatim from the old `config.exs` block with all comments; the `ComputeSthWorker` `all_tenants` entry uses `sth_sweep_cron/0`.
- **`config/runtime.exs`** — sets both `queues:` and `plugins:` from `ObanConfig`, so the crontab is **runtime-tunable without a deploy** (`fly secrets set STH_SWEEP_CRON=... && restart`). Mirrors the established US-32.2 runtime-tunable-queues pattern.
- **`config/config.exs`** — no longer sets `plugins:` (a plain list `Config` REPLACES wholesale, so a single runtime owner must win); adds a pointer comment + an `STH_SWEEP_CRON` config-doc comment in the US-35.2 doc style.
- **`ComputeSthWorker` moduledoc** — updated stale "every minute" wording (doc only, no logic change).

### Acceptance criteria
- **AC-35.3.1** — cron runs on a reduced, configurable interval (default `*/5`), config-driven (DI), tunable/revertible per env without code change.
- **AC-35.3.2** — fanout semantics unchanged (insert_all + jitter, US-32.5; per-tenant `sth_needed?/1` gate). Test proves a tenant that appended between sweeps still gets an STH by the next sweep with the event path disabled.
- **AC-35.3.3** — correctness is interval-independent: with the event enqueuer OFF, one sweep produces an STH at the latest position per affected tenant (bounded-lag).
- **AC-35.3.4** — purely scheduling/config; jitter window and insert_all chunking intact.

### Tests
- `test/loopctl/oban_plugins_config_test.exs` (TC-35.3.1, pure config read): asserts the `all_tenants` `ComputeSthWorker` schedule is no longer `"* * * * *"` and equals `ObanConfig.sth_sweep_cron/0` (proving config-driven); asserts the default is `*/5 * * * *`. Existing Cron/Lifeline/Pruner/Reindexer assertions stay green.
- `test/loopctl/workers/compute_sth_worker_test.exs` (TC-35.3.2/.3, integration, event path off via `config/test.exs`): one sweep signs an STH at the latest `chain_position` after appends; a sweep at head is a self-gated no-op (no new STH row).

### Quality gate
`mix precommit` green (compile, format, credo --strict, dialyzer, 4449 tests, 0 failures). One unrelated pre-existing telemetry cross-talk flake in `Loopctl.Llm.AnthropicTest` surfaced on the first hook run and passed in isolation + on re-run; not caused by this change.

Part of epic #350 (STH & cron fleet-cost redesign) — implements the US-35.3 low-frequency safety-sweep task. Does not close the epic; other stories remain.
