### PR TITLE
docs(epic_36): Oban fairness & queue topology stories (US-36.1..36.4)

### DIFF
--- a/docs/user_stories/epic_36_oban_fairness/README.md
+++ b/docs/user_stories/epic_36_oban_fairness/README.md
@@ -1,0 +1,68 @@
+# Epic 36 — Per-Tenant Oban Fairness & Queue Topology
+
+Remediation of GitHub issue **#351** (roadmap Epic 4, tracked **#355**) — the
+classic noisy-neighbor failure at loopctl's target scale: one tenant's bulk
+ingest monopolizes the shared `:embeddings` / `:knowledge` queues and starves
+every other tenant.
+
+## Decision: stock-Oban fallback (Mark, 2026-07-14)
+
+#351's target architecture recommends **Oban Pro** (Smart engine `global_limit` +
+`partition: [args: [:tenant_id]]`). loopctl runs **stock Oban 2.19 (Basic
+engine)** and Oban Pro is a **paid Enterprise dependency** (volume-priced,
+NDA/procurement). Mark chose the **stock-Oban fallback (full)**: build fairness in
+app code, no new dependency, keep per-node fairness for now, and **revisit Oban
+Pro at Epic 38 (#353, horizontal scaling)** when cluster-global limits actually
+matter (Pro's `global_limit` is cluster-global; the app-level gate here is
+per-node, which is sufficient until loopctl runs multiple nodes).
+
+## Scope reconciliation (verified against `master` before authoring)
+
+| #351 finding | Status | Evidence |
+|--------------|--------|----------|
+| Queue widths hardcoded, not in runtime.exs | ✅ done | US-32.2 — `Loopctl.ObanConfig.queues()`, `OBAN_QUEUE_*` env vars (`oban_config.ex:52-95`) |
+| No Oban queue/orphan observability | ✅ done | US-34.1/34.2 — `oban_metrics_poll_*` gauges, orphan health threshold, Reindexer |
+| Per-node vs global concurrency limit | ⏸ deferred to Epic 38 | `global_limit` is Oban Pro-only; per-node fairness is sufficient pre-multi-node |
+| **No per-tenant fairness anywhere** | ❌ open | none — `oban_config.ex:7` calls itself "the substrate for Epic 4 fairness (#351)" |
+| **Head-of-line blocking:** 6-min LLM ingestion shares 5-wide `:knowledge` with sub-second linking/lint/MOC/metrics | ❌ open | `content_ingestion_worker.ex:36 queue: :knowledge` |
+| **Unbounded per-tenant fan-out** (N items → N ingest → N embed → N linking, uncapped) | ❌ open | `content_ingestion_worker.ex:829,885`; `article_embedding_worker.ex:127` |
+| **`:embeddings`→`:knowledge` coupling** (a completed embedding enqueues a linking burst back onto `:knowledge`) | ❌ open | `article_embedding_worker.ex:167-172` |
+| **No batch-ingest backpressure** (enqueues unconditionally) | ❌ open | `knowledge_ingestion_controller.ex:395` |
+| **Per-job `count(*)`** in linking hot path | ❌ open | `article_linking_worker.ex:225-242` |
+| **Dead `:verification` queue** (declared on a worker but not in the queues list → those jobs never run) | ❌ open (latent bug surfaced during grounding) | `verification_runner_worker.ex:10 queue: :verification`; not in `@default_queues` |
+
+## Stories
+
+| Story | Title | Depends |
+|-------|-------|---------|
+| US-36.1 | Queue topology: dedicated `:ingestion` queue for long LLM jobs + register the dead `:verification` queue (env-driven widths) | — |
+| US-36.2 | Per-tenant in-flight fair-share gate on the contended queues (Basic-engine snooze/defer — no tenant holds more than K of N slots) | US-36.1 |
+| US-36.3 | Batch-ingest backpressure: `429` when a tenant's in-flight ingestion backlog exceeds a threshold | US-36.2 |
+| US-36.4 | Linking hot-path efficiency: batched `insert_all` + `on_conflict`; replace per-job `count(*)` with a sampled telemetry count | US-36.1 |
+
+## Non-negotiable constraints (system is LIVE)
+
+- **Fairness is a target, not a hard invariant.** The Basic engine has no native
+  partitioning; the mechanism is cooperative (a worker yields via `{:snooze, n}`
+  when its tenant is over fair share, plus a bounded pre-enqueue check). A job is
+  **never dropped or lost** — worst case it's delayed. Tests assert the
+  *fairness outcome* (a flooding tenant does not starve others), not an exact
+  slot count at an instant (avoid the Mox/parallel-suite flake class —
+  assert the outcome class, per prior lessons).
+- Any new index on the hot `oban_jobs` table is **online** (`CONCURRENTLY`,
+  `@disable_ddl_transaction`) and justified — prefer to avoid one; if the
+  fair-share count needs it, it's a partial/expression index on
+  `(queue, state, (args->>'tenant_id'))` and its cost is measured.
+- Queue widths and per-tenant caps/thresholds are **env-driven** (extend
+  `Loopctl.ObanConfig`, config-based DI) so ops can tune during an incident with
+  `fly secrets set … && restart` — **no deploy**. **Never set a secret to a doc
+  placeholder** (see the STH_SWEEP_CRON incident, epic_35).
+- Moving `ContentIngestionWorker` to `:ingestion` must preserve total pool
+  budget (don't blow past the DB connection budget — the new queue's width comes
+  out of / is sized against the existing budget, not added on top blindly).
+- Backpressure returns a **429 with a `Retry-After`** and does not lose the
+  caller's intent; it must not break existing batch-ingest clients that stay
+  under the threshold (existing-behavior test).
+- Every merge is smoke-gated with a `knowledge_count` / ingestion-health check
+  either side, and **the master Deploy + Post-deploy Smoke jobs are watched to
+  green** (runtime.exs env-var changes only fail at release boot — epic_35 lesson).

--- a/docs/user_stories/epic_36_oban_fairness/us_36.1.json
+++ b/docs/user_stories/epic_36_oban_fairness/us_36.1.json
@@ -1,0 +1,52 @@
+{
+  "id": "US-36.1",
+  "title": "Queue topology: dedicated :ingestion queue for long LLM jobs + register the dead :verification queue",
+  "epic": { "id": "epic_36", "name": "Per-Tenant Oban Fairness & Queue Topology" },
+  "priority": "high",
+  "phase": "scalability",
+  "priority_note": "Foundational queue-topology change that directly kills head-of-line blocking (6-min LLM ingestion no longer shares slots with sub-second linking/lint/MOC jobs) and is the substrate the fairness gate (US-36.2) and backpressure (US-36.3) build on. Also fixes a latent bug where :verification jobs never run.",
+  "background": {
+    "reference": "GH #351. ContentIngestionWorker (lib/loopctl/workers/content_ingestion_worker.ex:36) declares queue: :knowledge (width 5) and can run ~6 minutes; it shares that 5-slot queue with sub-second ArticleLinkingWorker (article_linking_worker.ex:58), KnowledgeLintWorker, KnowledgeMocWorker, RetrievalMetricsWorker, KnowledgeReclassifyWorker, ReviewKnowledgeWorker (all queue: :knowledge). A handful of concurrent ingests starve the fast jobs. Queue widths already live in Loopctl.ObanConfig.@default_queues (oban_config.ex:52-62), env-driven via OBAN_QUEUE_* (US-32.2).",
+    "includes": "Grounding also surfaced a latent bug: VerificationRunnerWorker (verification_runner_worker.ex:10) declares queue: :verification, but :verification is NOT in @default_queues / the running queues list, so those jobs are enqueued but NEVER executed (no queue consumer). This story registers that queue (or, if verification is intentionally disabled, removes the stray declaration — implementer confirms which)."
+  },
+  "story": {
+    "as_a": "loopctl operator",
+    "i_want_to": "run long-running LLM ingestion jobs on their own :ingestion queue, separate from the short :knowledge relationship jobs, and ensure every queue a worker targets actually has a consumer",
+    "so_that": "a burst of multi-minute ingestion jobs can no longer occupy all the slots that fast linking/lint/MOC/metrics jobs need (head-of-line blocking is gone), and no worker silently enqueues onto a queue that never runs"
+  },
+  "rationale": "Sizing long and short work into separate queues is the cheapest, highest-leverage fairness fix and needs no engine change: ContentIngestionWorker moves to :ingestion (sized independently against the pool budget), while linking/lint/MOC/metrics keep :knowledge. Registering (or removing) the :verification queue closes a correctness gap found during grounding. All widths stay env-tunable via ObanConfig so ops can retune during an incident with no deploy.",
+  "acceptance_criteria": [
+    { "id": "AC-36.1.1", "description": "A new :ingestion queue is added to Loopctl.ObanConfig.@default_queues with an env-driven width (OBAN_QUEUE_INGESTION), sized so the TOTAL pool budget is not exceeded (rebalance from :knowledge rather than blindly adding capacity; document the new sum and keep the config.exs mirror in sync — the existing oban_config_test sum/sync assertion must still pass).", "status": "pending" },
+    { "id": "AC-36.1.2", "description": "ContentIngestionWorker moves from queue: :knowledge to queue: :ingestion. No change to its job logic, args, uniqueness, or retry config — only the queue. A test asserts a ContentIngestionWorker job is enqueued on :ingestion and that :knowledge no longer receives ingestion jobs.", "status": "pending" },
+    { "id": "AC-36.1.3", "description": "The short :knowledge jobs (ArticleLinkingWorker, KnowledgeLintWorker, KnowledgeMocWorker, RetrievalMetricsWorker, KnowledgeReclassifyWorker, ReviewKnowledgeWorker) remain on :knowledge. A test demonstrates the head-of-line fix: with the :ingestion queue saturated by long jobs, a :knowledge linking job still executes (no longer blocked behind ingestion).", "status": "pending" },
+    { "id": "AC-36.1.4", "description": "The dead :verification queue is resolved: either add :verification to @default_queues (env-driven width) so VerificationRunnerWorker jobs actually run, OR remove the stray queue declaration if verification is intentionally inert. The implementer states which and why; a test asserts a VerificationRunnerWorker job either runs on a registered queue OR the worker no longer targets a phantom queue.", "status": "pending" },
+    { "id": "AC-36.1.5", "description": "Purely a topology/config change — widths remain env-driven via ObanConfig; no per-job semantics change. runtime.exs continues to source queues from ObanConfig.queues(). A cardinality/consistency test confirms the config.exs compile-time mirror and the ObanConfig defaults still match (TC-32.2.1 style).", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-36.1.1", "name": "ingestion queue registered + env-tunable", "type": "unit",
+      "preconditions": [],
+      "steps": ["read ObanConfig.queues()", "set OBAN_QUEUE_INGESTION and re-read"],
+      "expected_results": [":ingestion present with default width; env var overrides it; total sum documented and config.exs mirror matches"], "status": "pending" },
+    { "id": "TC-36.1.2", "name": "ingestion worker enqueues on :ingestion", "type": "integration",
+      "preconditions": ["a tenant + ingestible content"],
+      "steps": ["enqueue ContentIngestionWorker"],
+      "expected_results": ["job.queue == \"ingestion\"; no ingestion job lands on :knowledge"], "status": "pending" },
+    { "id": "TC-36.1.3", "name": "head-of-line blocking removed", "type": "integration",
+      "preconditions": [":ingestion saturated with long-running jobs"],
+      "steps": ["enqueue an ArticleLinkingWorker on :knowledge", "drain :knowledge"],
+      "expected_results": ["the linking job runs without waiting on ingestion completion"], "status": "pending" },
+    { "id": "TC-36.1.4", "name": "verification queue no longer dead", "type": "unit",
+      "preconditions": [],
+      "steps": ["inspect the queues list vs VerificationRunnerWorker.queue"],
+      "expected_results": ["either :verification is a registered queue OR the worker declares a registered queue; no worker targets an unregistered queue"], "status": "pending" }
+  ],
+  "technical_notes": [
+    "Files: lib/loopctl/oban_config.ex (@default_queues + queues/0), config/config.exs (compile-time mirror), lib/loopctl/workers/content_ingestion_worker.ex (queue), lib/loopctl/workers/verification_runner_worker.ex (queue).",
+    "Pool budget: current sum = 38 across 9 queues. Rebalance — e.g. take :ingestion width from :knowledge's 5 (split into :knowledge + :ingestion) rather than adding a 10th queue at full width; measure against the DB connection budget (see Epic 33 pool work). Document the new sum.",
+    "Confirm the :verification path: grep for VerificationRunnerWorker enqueues to see if verification is a live feature; if inert, removing the queue: :verification (or the worker) is cleaner than registering a queue nothing needs.",
+    "Env-driven via ObanConfig (config-based DI); no Application.put_env in tests. runtime.exs already sets queues: ObanConfig.queues().",
+    "No migration needed for this story."
+  ],
+  "dependencies": [],
+  "estimated_tokens": 300000
+}

--- a/docs/user_stories/epic_36_oban_fairness/us_36.2.json
+++ b/docs/user_stories/epic_36_oban_fairness/us_36.2.json
@@ -1,0 +1,54 @@
+{
+  "id": "US-36.2",
+  "title": "Per-tenant in-flight fair-share gate on the contended queues (Basic-engine snooze/defer)",
+  "epic": { "id": "epic_36", "name": "Per-Tenant Oban Fairness & Queue Topology" },
+  "priority": "critical",
+  "phase": "scalability",
+  "priority_note": "The core of #351: the per-tenant fairness mechanism that stock Oban Basic has zero of today. Without it, one tenant's 50-item bulk ingest (→ hundreds of embedding + linking jobs, all one tenant_id, inserted contiguously) sits at the head of the contended queues and starves every other tenant indefinitely.",
+  "background": {
+    "reference": "GH #351. Basic engine = plain FIFO per queue, no partitioning, no per-args limits (those are Oban Pro Smart-engine only — deferred to Epic 38 per Mark's decision). One tenant can hold all N slots of :embeddings (5) / :knowledge (5) / :ingestion (US-36.1). Grounding confirmed NO in-flight cap, token gate, or fairness anywhere (oban_config.ex:7 calls itself the substrate for this).",
+    "includes": "Basic-engine idiomatic fairness = cooperative yielding: a worker returns {:snooze, seconds} (reschedules WITHOUT consuming an attempt, never drops the job) when its tenant already occupies >= its fair share of that queue's running slots, freeing the slot for another tenant. Fair share K is derived from the queue width and a config cap (e.g. a tenant may hold at most ceil(width/2) or a fixed K of N slots). This is a TARGET, not a hard invariant (the count is racy) — that is acceptable for fairness."
+  },
+  "story": {
+    "as_a": "loopctl operator running many tenants on shared embedding/knowledge/ingestion queues",
+    "i_want_to": "have each contended-queue worker yield its slot (snooze) when its tenant is already over its fair share of that queue's concurrency, and softly defer at enqueue time when a tenant is far over budget",
+    "so_that": "one tenant's bulk burst cannot monopolize a shared queue — other tenants' jobs keep making progress during the burst — without ever dropping or losing a job"
+  },
+  "rationale": "On the Basic engine the robust, loss-free way to get per-tenant fairness is cooperative snoozing: when a job starts, it checks how many of its queue's slots its own tenant currently occupies; if that's at or above the per-tenant cap, it snoozes a bounded interval so a waiting tenant runs instead. Because snooze reschedules (no attempt consumed, no loss), fairness degrades gracefully to latency, never to correctness. A bounded enqueue-time check adds coarse backpressure for pathological bursts. Caps are env-driven so ops can retune live.",
+  "acceptance_criteria": [
+    { "id": "AC-36.2.1", "description": "A shared helper computes a tenant's current in-flight job count on a given queue (states available/scheduled/executing/retryable, args->>'tenant_id' = tenant), reused by the workers and by US-36.3's endpoint. The query is bounded, runs on a read path with a per-query SET LOCAL statement_timeout (pgbouncer-safe), and its cost is measured; if an index on oban_jobs is required it is created CONCURRENTLY (@disable_ddl_transaction) as a partial/expression index and justified.", "status": "pending" },
+    { "id": "AC-36.2.2", "description": "The contended-queue workers (ArticleEmbeddingWorker on :embeddings, ContentIngestionWorker on :ingestion, and the :knowledge relationship workers) yield via {:snooze, n} at the START of perform/1 when the caller's tenant already occupies at or above its fair share (config cap K, derived from queue width) of that queue's EXECUTING slots. Snooze reschedules without consuming an attempt — a test asserts the job is NOT failed/discarded and eventually runs.", "status": "pending" },
+    { "id": "AC-36.2.3", "description": "FAIRNESS OUTCOME (the invariant that matters): with tenant A flooding a contended queue (e.g. a 50-item batch fanned out), a tenant B job enqueued afterward still executes within a bounded time rather than waiting for all of A's jobs. The test asserts the OUTCOME CLASS (B makes progress while A is still draining) — NOT an exact slot count at an instant — to avoid parallel-suite races (per the Mox/async-supervisor flake lesson).", "status": "pending" },
+    { "id": "AC-36.2.4", "description": "Per-tenant caps and the snooze backoff are env-driven (extend Loopctl.ObanConfig, config-based DI; e.g. OBAN_TENANT_FAIRSHARE_* or per-queue caps) so an operator can loosen/tighten fairness during an incident with fly secrets set + restart, no deploy. Sensible defaults documented. No Application.put_env in tests.", "status": "pending" },
+    { "id": "AC-36.2.5", "description": "Loss-free + progress guarantees: snoozing never drops a job (no attempt consumed, no discard); a single-tenant workload (no contention) sees NO added latency (the gate is a no-op when the tenant is under its cap) — a test asserts an uncontended job runs immediately without snoozing. Snooze intervals are bounded/jittered so a snoozed job can't starve or thundering-herd on re-check.", "status": "pending" },
+    { "id": "AC-36.2.6", "description": "Tenant isolation: the in-flight count for tenant A never includes tenant B's jobs (args-scoped by tenant_id); the fair-share decision for A's job reads only A's count. Purely additive scheduling behavior; no change to what a job DOES once it runs.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-36.2.1", "name": "in-flight count helper is tenant-scoped and bounded", "type": "unit",
+      "preconditions": ["oban_jobs rows for tenant A and B on the same queue in various states"],
+      "steps": ["call the helper for tenant A on that queue"],
+      "expected_results": ["counts only A's non-terminal jobs; excludes B; excludes completed/discarded"], "status": "pending" },
+    { "id": "TC-36.2.2", "name": "worker snoozes when tenant over fair share, then runs", "type": "integration",
+      "preconditions": ["tenant A already at its cap of executing slots on the queue"],
+      "steps": ["run another A job"],
+      "expected_results": ["returns {:snooze, n}; job stays scheduled (not failed/discarded); runs on a later drain when A is under cap"], "status": "pending" },
+    { "id": "TC-36.2.3", "name": "flooding tenant does not starve another (outcome class)", "type": "integration",
+      "preconditions": ["tenant A floods a contended queue; tenant B enqueues one job after"],
+      "steps": ["drain the queue with realistic concurrency"],
+      "expected_results": ["B's job completes while A still has jobs pending — B is not stuck behind all of A"], "status": "pending" },
+    { "id": "TC-36.2.4", "name": "no snooze / no latency when uncontended", "type": "integration",
+      "preconditions": ["only tenant A, well under its cap"],
+      "steps": ["run an A job"],
+      "expected_results": ["executes immediately, no snooze"], "status": "pending" }
+  ],
+  "technical_notes": [
+    "Files: new lib/loopctl/oban/fair_share.ex (in-flight count + over-cap? decision), the contended-queue workers (article_embedding_worker.ex, content_ingestion_worker.ex, article_linking_worker.ex + the other :knowledge workers), lib/loopctl/oban_config.ex (caps), possibly a migration for an oban_jobs expression index.",
+    "Prefer the {:snooze, n} worker-level yield as the primary mechanism (loss-free, self-correcting) over a hard pre-enqueue reject; keep the enqueue-time check coarse (US-36.3 uses it for the sync endpoint's 429).",
+    "Count query: SELECT count(*) FROM oban_jobs WHERE queue = $1 AND state = ANY('{available,scheduled,executing,retryable}') AND args->>'tenant_id' = $2. Measure cost; add CREATE INDEX CONCURRENTLY ... ON oban_jobs ((args->>'tenant_id'), queue, state) only if needed. Migration online (@disable_ddl_transaction).",
+    "Assert OUTCOME CLASS, never exact instantaneous slot counts — the suite runs async and Oban draining is nondeterministic (see [[feedback-mox-async-supervisor-flake]]).",
+    "Config-based DI for caps/backoff; document defaults; env vars via ObanConfig so ops can tune live (do NOT set a secret to a doc placeholder — epic_35 STH_SWEEP_CRON lesson).",
+    "SECURITY/RESILIENCE note: fairness is a target not a guarantee; a byzantine tenant can still get service, just not monopolize. Reviewer should confirm the gate can't itself wedge a queue (all jobs snoozing forever) — the cap must always allow at least 1 slot per tenant to make progress."
+  ],
+  "dependencies": ["US-36.1"],
+  "estimated_tokens": 450000
+}

--- a/docs/user_stories/epic_36_oban_fairness/us_36.3.json
+++ b/docs/user_stories/epic_36_oban_fairness/us_36.3.json
@@ -1,0 +1,51 @@
+{
+  "id": "US-36.3",
+  "title": "Batch-ingest backpressure: 429 when a tenant's in-flight ingestion backlog is too large",
+  "epic": { "id": "epic_36", "name": "Per-Tenant Oban Fairness & Queue Topology" },
+  "priority": "high",
+  "phase": "scalability",
+  "priority_note": "Closes the loop on fan-out: the fair-share gate (US-36.2) keeps a bulk burst from monopolizing slots, but the batch endpoint still lets a single tenant pile up an unbounded backlog. Rejecting new batches with a 429 while a tenant is already deeply backed up turns silent unbounded growth into an explicit, retryable signal.",
+  "background": {
+    "reference": "GH #351. knowledge_ingestion_controller.ex create_batch/2 (:202-211) enqueues every item unconditionally via ContentIngestionWorker.new |> Oban.insert() (:395). Existing gates are BYO-LLM-key (:215), a 50-item size cap (:340-343), and per-item DNS/wall-clock validation — NONE consider the tenant's existing in-flight Oban backlog. The 429s already declared in the OpenApiSpex operations are the generic Hammer HTTP rate-limiter, NOT queue-backlog backpressure.",
+    "includes": "This reuses the tenant in-flight count helper from US-36.2. When tenant T already has >= a configured threshold of in-flight ingestion jobs (queue :ingestion after US-36.1), a new batch request is rejected with 429 + Retry-After instead of adding hundreds more jobs. Under the threshold, behavior is unchanged."
+  },
+  "story": {
+    "as_a": "loopctl operator",
+    "i_want_to": "return 429 (with Retry-After) from the batch-ingest endpoint when the calling tenant already has a large in-flight ingestion backlog",
+    "so_that": "a single tenant cannot pile an unbounded number of ingestion jobs onto the shared queue faster than the fleet drains them — backpressure is explicit and retryable, not silent queue growth"
+  },
+  "rationale": "The fair-share gate bounds concurrency but not accumulation; a client looping on the 50-item batch endpoint can still enqueue tens of thousands of jobs. A backlog-aware 429 at admission is the standard backpressure valve: it protects the shared queue and the DB, gives the client a clear, retryable signal, and leaves well-behaved (under-threshold) callers completely unaffected.",
+  "acceptance_criteria": [
+    { "id": "AC-36.3.1", "description": "create_batch/2 checks the calling tenant's in-flight ingestion backlog (via the US-36.2 helper, on the :ingestion queue) BEFORE enqueuing. If it is >= a configured threshold, the request is rejected with HTTP 429 and a Retry-After header; no jobs from that request are enqueued (all-or-nothing — no partial pile-up).", "status": "pending" },
+    { "id": "AC-36.3.2", "description": "Under the threshold, behavior is byte-for-byte unchanged: all items enqueue as today, same response shape/status. An existing-behavior test (a normal batch under the threshold) passes unchanged, so existing clients are not broken.", "status": "pending" },
+    { "id": "AC-36.3.3", "description": "The threshold is env-driven (Loopctl.ObanConfig, config-based DI; e.g. OBAN_INGEST_BACKLOG_MAX) with a sensible default, so ops can loosen/tighten during an incident with no deploy. The 429 body is a structured error (consistent with the app's error envelope) identifying it as backlog backpressure, distinct from the Hammer HTTP rate-limit 429.", "status": "pending" },
+    { "id": "AC-36.3.4", "description": "The check is tenant-scoped (only the caller's backlog counts, never other tenants') and cheap (single bounded count, per-query statement_timeout). The OpenApiSpex operation documents the backlog-429 case. A test asserts: tenant over threshold → 429 + Retry-After + zero jobs enqueued; tenant under threshold → normal enqueue.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-36.3.1", "name": "over-threshold batch is 429'd with Retry-After and enqueues nothing", "type": "integration",
+      "preconditions": ["tenant T seeded with >= threshold in-flight :ingestion jobs"],
+      "steps": ["POST a valid batch as T"],
+      "expected_results": ["429 + Retry-After header; structured backlog-backpressure error; no new ContentIngestionWorker jobs created"], "status": "pending" },
+    { "id": "TC-36.3.2", "name": "under-threshold batch unchanged", "type": "integration",
+      "preconditions": ["tenant T with little/no in-flight backlog"],
+      "steps": ["POST a valid batch as T"],
+      "expected_results": ["normal success response; all items enqueued exactly as before"], "status": "pending" },
+    { "id": "TC-36.3.3", "name": "threshold is env-tunable", "type": "unit",
+      "preconditions": [],
+      "steps": ["set OBAN_INGEST_BACKLOG_MAX and read the resolved threshold"],
+      "expected_results": ["reflects the env value; sensible default when unset"], "status": "pending" },
+    { "id": "TC-36.3.4", "name": "backlog check is tenant-scoped", "type": "integration",
+      "preconditions": ["tenant A over threshold; tenant B empty"],
+      "steps": ["B posts a batch"],
+      "expected_results": ["B succeeds (A's backlog does not affect B)"], "status": "pending" }
+  ],
+  "technical_notes": [
+    "Files: lib/loopctl_web/controllers/knowledge_ingestion_controller.ex (create_batch + the OpenApiSpex operation), lib/loopctl/oban/fair_share.ex (reuse in-flight count), lib/loopctl/oban_config.ex (threshold), fallback/error rendering for the structured 429.",
+    "Return the 429 via the app's normal error path (FallbackController / error envelope) so it's consistent; set Retry-After (seconds) to a bounded value (e.g. tied to the snooze backoff / expected drain time).",
+    "All-or-nothing: do the backlog check before enqueuing ANY item so a rejected request leaves zero partial jobs.",
+    "Distinguish this 429 from the Hammer HTTP rate-limit 429 in the body (error code/type) so clients + dashboards can tell backlog-backpressure from request-rate limiting.",
+    "Env-driven threshold via ObanConfig; document default; no Application.put_env in tests. Do NOT set the secret to a placeholder (epic_35 lesson)."
+  ],
+  "dependencies": ["US-36.2"],
+  "estimated_tokens": 300000
+}

--- a/docs/user_stories/epic_36_oban_fairness/us_36.4.json
+++ b/docs/user_stories/epic_36_oban_fairness/us_36.4.json
@@ -1,0 +1,51 @@
+{
+  "id": "US-36.4",
+  "title": "Linking hot-path efficiency: batched insert_all + on_conflict; replace per-job count(*) with a sampled telemetry count",
+  "epic": { "id": "epic_36", "name": "Per-Tenant Oban Fairness & Queue Topology" },
+  "priority": "medium",
+  "phase": "scalability",
+  "priority_note": "The linking worker is the highest-frequency :knowledge job (one per embedded article, plus it's re-triggered by the embeddings→knowledge coupling). Two per-job inefficiencies — a full count(*) and row-by-row link inserts — multiply directly with fan-out, so trimming them relieves the shared queue and the DB under exactly the bulk-ingest bursts this epic targets.",
+  "background": {
+    "reference": "GH #351. ArticleLinkingWorker (article_linking_worker.ex) runs once per embedded article on :knowledge. log_if_exceeds_limit/3 (:225-242) runs AdminRepo.aggregate(:count) over all published+embedded tenant/project articles on EVERY job — a full count(*) that grows with the tenant's corpus, feeding only a warning log (:236-241). Link creation is not batched. A bulk ingest of N items triggers N such jobs, each paying the count.",
+    "includes": "The count(*) is observability-only (a soft warning); it does not gate linking. It can be replaced by a sampled/periodic telemetry count (e.g. emit on a fraction of jobs, or move to the existing periodic Oban/knowledge metrics poller) without losing the signal. Link inserts should use insert_all + on_conflict to collapse per-row round-trips."
+  },
+  "story": {
+    "as_a": "loopctl operator",
+    "i_want_to": "stop running a full count(*) on every linking job and insert discovered links in a single batched insert_all with on_conflict, moving the corpus-size signal to a sampled telemetry path",
+    "so_that": "each linking job does bounded, near-constant DB work regardless of corpus size, so a bulk-ingest burst of linking jobs no longer amplifies into a burst of expensive full-table counts and row-by-row inserts on the shared queue"
+  },
+  "rationale": "The per-job count(*) is pure overhead on the hot path — it only powers a warning log, so it belongs on a sampled/periodic telemetry path, not every job. Batching link inserts with insert_all + on_conflict collapses many single-row writes into one statement. Both changes are transparent to link CORRECTNESS (same links created) and shrink the per-job cost that fan-out multiplies, complementing the fairness gate (US-36.2) and the queue split (US-36.1).",
+  "acceptance_criteria": [
+    { "id": "AC-36.4.1", "description": "The per-job full count(*) in log_if_exceeds_limit/3 is removed from the hot path. The corpus-size-vs-limit signal is preserved via a SAMPLED or PERIODIC telemetry path (e.g. only compute on a small fraction of jobs, or emit from the existing periodic knowledge/Oban metrics poller) so the warning is still observable but not paid per job. A test asserts the linking job no longer issues the full count on every run.", "status": "pending" },
+    { "id": "AC-36.4.2", "description": "Discovered links are persisted with a single insert_all (+ on_conflict to stay idempotent on the existing unique constraint), not row-by-row inserts. The SAME links are created as before (correctness-preserving) — a test compares the resulting link set for a fixed input against the prior behavior and asserts equality, and asserts idempotency on re-run (on_conflict, no duplicates).", "status": "pending" },
+    { "id": "AC-36.4.3", "description": "No change to WHICH links are created or the kNN/threshold logic (VectorSearch.nearest and the linking decision are untouched) — this story is purely the count and the insert mechanics. Tenant/project scoping of the count and inserts is preserved (tenant-isolation test).", "status": "pending" },
+    { "id": "AC-36.4.4", "description": "Reads/writes run on the appropriate path with a per-query statement_timeout; the batched insert stays within Postgres bind-parameter limits (chunk if a single article can produce very many links). Purely an efficiency change — no job semantics, args, or queue change.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-36.4.1", "name": "no full count(*) per linking job", "type": "integration",
+      "preconditions": ["a tenant with a sizable published+embedded corpus"],
+      "steps": ["run a linking job (unsampled)"],
+      "expected_results": ["no full-table count(*) is issued on the hot path; the corpus-size warning still reachable via the sampled/periodic path"], "status": "pending" },
+    { "id": "TC-36.4.2", "name": "links persisted via idempotent insert_all", "type": "integration",
+      "preconditions": ["an article with several qualifying neighbors"],
+      "steps": ["run linking once, then again"],
+      "expected_results": ["same link set as the prior row-by-row behavior; second run creates no duplicates (on_conflict)"], "status": "pending" },
+    { "id": "TC-36.4.3", "name": "linking decisions unchanged", "type": "integration",
+      "preconditions": ["fixed embeddings/neighbors"],
+      "steps": ["run linking"],
+      "expected_results": ["identical set of links vs the pre-change implementation for the same input"], "status": "pending" },
+    { "id": "TC-36.4.4", "name": "tenant isolation preserved", "type": "integration",
+      "preconditions": ["tenant A and B corpora"],
+      "steps": ["run linking for A"],
+      "expected_results": ["only A's articles considered/linked; B untouched"], "status": "pending" }
+  ],
+  "technical_notes": [
+    "Files: lib/loopctl/workers/article_linking_worker.ex (log_if_exceeds_limit/3 + the link-insert path), possibly lib/loopctl/knowledge.ex (link creation helper), the periodic metrics poller (config.exs oban_metrics_poll_* / telemetry) if moving the count there.",
+    "The count(*) powers only a warning log (:236-241) — safe to sample. Simplest: compute it on ~1/N jobs (deterministic by article id hash) or fold it into the daily knowledge metrics worker. Do NOT gate linking on it.",
+    "insert_all with on_conflict: {:nothing} or replace on the existing links unique index; chunk to stay under the 65535 bind-parameter ceiling if an article yields many links.",
+    "Correctness gate: a test asserting the produced link set is identical to the current implementation for a fixed input is the safety net — this is an efficiency refactor, not a behavior change.",
+    "Per-query SET LOCAL statement_timeout on the reads/writes; no startup :parameter (pgbouncer-safe)."
+  ],
+  "dependencies": ["US-36.1"],
+  "estimated_tokens": 300000
+}


### PR DESCRIPTION
## Summary

Authors the user stories for **Epic 36 — Per-Tenant Oban Fairness & Queue Topology**, remediating GH #351 (roadmap Epic 4, tracked #355). Docs only, no code change.

### Decision: stock-Oban fallback (Mark, 2026-07-14)
#351's target arch recommends **Oban Pro** (Smart engine `global_limit` + `partition: [args: [:tenant_id]]`). loopctl runs **stock Oban 2.19 Basic** and Oban Pro is a **paid Enterprise dependency**. Chosen path: **build fairness in app code**, no new dependency; per-node fairness is sufficient until multi-node — **revisit Oban Pro at Epic 38 (#353)** when cluster-global limits actually matter.

### Scope reconciliation (verified against master)
Already done, excluded: queue widths → env (**US-32.2**), Oban queue/orphan observability (**US-34.1/34.2**). Per-node-vs-global limit **deferred to Epic 38** (`global_limit` is Pro-only). Grounding also surfaced a **latent bug**: a `:verification` queue is declared on a worker but not registered, so those jobs never run.

### Stories
- **US-36.1** — Dedicated `:ingestion` queue for long (6-min) LLM jobs, split off the 5-wide `:knowledge` queue → kills head-of-line blocking; plus register/remove the dead `:verification` queue. Env-driven widths, pool-budget-neutral.
- **US-36.2 (critical)** — Per-tenant in-flight **fair-share gate**. Basic engine has no partitioning, so use the idiomatic loss-free mechanism: a worker returns `{:snooze, n}` (reschedules, no attempt consumed) when its tenant is at/above its fair share of a contended queue's slots. Tests assert the **fairness outcome class** (a flooding tenant doesn't starve others), never instantaneous slot counts (avoids the async-suite flake class).
- **US-36.3** — Batch-ingest **backpressure**: `429 + Retry-After` when a tenant's in-flight ingestion backlog exceeds a configured threshold; under threshold, unchanged.
- **US-36.4** — Linking **hot-path efficiency**: batched `insert_all` + `on_conflict`; move the per-job `count(*)` to a sampled telemetry path. Correctness-preserving (same links).

### Constraints baked in
- Fairness is a target, not a hard invariant; jobs are never dropped (snooze reschedules).
- Any `oban_jobs` index is online (`CONCURRENTLY`); caps/thresholds are env-driven (tune live, no deploy) — **never set a secret to a doc placeholder** (epic_35 `STH_SWEEP_CRON` lesson).
- Watch master **Deploy + Post-deploy Smoke** to green (runtime.exs env-var changes only fail at release boot).

Next: `implement-plan` on the epic folder (WIP=1, review-gated).
