### PR TITLE
US-36.2: Per-tenant in-flight fair-share gate on contended Oban queues (Basic-engine snooze)

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -54,6 +54,15 @@ config :loopctl, Oban,
   queues: Loopctl.ObanConfig.queues(),
   plugins: Loopctl.ObanConfig.plugins()
 
+# US-36.2: validate the per-tenant fair-share knobs (OBAN_TENANT_FAIRSHARE_<QUEUE> caps
+# + SNOOZE base/jitter) at BOOT, alongside the queue widths above. Evaluating
+# `fair_share_config/0` calls each knob's parser, which RAISES on a present-but-malformed
+# value — so a fat-fingered cap aborts the node LOUD here (like a bad OBAN_QUEUE_*),
+# instead of surfacing only at gate call-time where the count path fails OPEN and would
+# silently disable fairness on that queue. Stored so the resolved boot config is
+# introspectable; the gate itself re-reads env at call time (config-based DI).
+config :loopctl, :fair_share_config, Loopctl.ObanConfig.fair_share_config()
+
 # Cloak Vault — key from environment in all environments where CLOAK_KEY is set.
 # In production, CLOAK_KEY is required — startup fails if it is missing.
 if config_env() == :prod do

--- a/lib/loopctl/oban/fair_share.ex
+++ b/lib/loopctl/oban/fair_share.ex
@@ -23,33 +23,60 @@ defmodule Loopctl.Oban.FairShare do
   to stop MONOPOLIZATION, not to enforce an exact slot count. A byzantine tenant can
   still get service — just not all of it.
 
-  ## Never wedges a queue
+  ## Never wedges a queue — and never fails open on a bad CAP
 
   The cap (`Loopctl.ObanConfig.tenant_fair_share_cap/1`) is ALWAYS `>= 1`, so a
-  tenant may always hold at least one slot and the gate can never drive every job to
-  snooze forever. The gate additionally FAILS OPEN: if the count query errors or
-  times out, `over_fair_share?/3` returns `false` (the job proceeds) rather than
-  blocking — an unmeasurable count must never stall work.
+  tenant may always hold at least one slot and (with the rank decision below) the
+  gate can never drive every job to snooze forever — even at jitter=0. The gate
+  FAILS OPEN on the COUNT only: if the executing-count query errors or times out,
+  `over_fair_share?/3` returns `false` (the job proceeds) rather than blocking — an
+  unmeasurable count must never stall work.
 
-  ## The gate MUST exclude the running job from its own count
+  The CAP, by contrast, FAILS LOUD. It is read in `over_fair_share?/3` OUTSIDE the
+  count's rescue (in `over_cap?/4`), so a malformed `OBAN_TENANT_FAIRSHARE_<QUEUE>`
+  crashes the job (visible, like a malformed snooze knob) instead of being swallowed
+  into a silent fail-open that would DISABLE fairness during the very incident an
+  operator is tuning. `Loopctl.ObanConfig.fair_share_config/0` additionally validates
+  every fair-share knob at BOOT (invoked from `config/runtime.exs`), so a typo aborts
+  the node like `OBAN_QUEUE_*` — it never even reaches a running gate.
 
-  Under Oban's Basic engine the fetched job is committed to `state = 'executing'`
-  INSIDE `fetch_jobs`' `Repo.transaction` BEFORE it is dispatched to the worker
-  Task — the same reason Lifeline can find orphaned `executing` rows after a node
-  dies. So a naive `count(... state='executing' AND tenant ...)` run from inside
-  `perform/1` COUNTS THE RUNNING JOB ITSELF. That is catastrophic:
+  ## Rank-based decision — deterministic, no co-fetch livelock
 
-    * Effective per-tenant concurrency becomes `cap - 1`, not `cap` (off-by-one on
-      every gated queue: embeddings 3→2, knowledge 2→1).
-    * For a queue whose derived cap is 1 (`:ingestion`, width 2 → `ceil(2/2)=1`)
-      EVERY job — even a single uncontended one — sees `1 >= 1` and snoozes
-      FOREVER: the queue is permanently WEDGED, the exact anti-goal above.
+  Under Oban's Basic engine the fetched jobs are committed to `state = 'executing'`
+  INSIDE `fetch_jobs`' `Repo.transaction` BEFORE they are dispatched to worker Tasks
+  (the same reason Lifeline finds orphaned `executing` rows after a node dies). So a
+  whole `width`-sized fetch — and under the story's one-tenant bulk fan-out, ALL of
+  one tenant's co-fetched jobs — are already `executing` when each `perform/1` runs
+  its gate.
 
-  The gate therefore threads the current `Oban.Job.id` through to the count and
-  excludes it (`j.id != ^job_id`), so a lone job sees `others = 0 < cap` and runs.
+  A naive "count OTHER executing peers `>= cap`" decision MISBEHAVES on that co-fetch:
+  every co-fetched same-tenant job sees the others, so on a cap=1 queue BOTH see
+  `1 >= 1` and BOTH snooze — both slots idle. Under the default jitter that thrashes
+  and self-heals; at the PERMITTED jitter=0 the two stay lockstep, are co-fetched
+  every cycle, and NEVER complete — a permanent livelock that falsifies the "never
+  snooze forever" invariant.
+
+  The gate therefore decides by RANK, not by a raw peer count: a job snoozes only if
+  it is NOT among the lowest-`cap` executing job ids for its `(tenant, queue)` — i.e.
+  `cap` or more of the tenant's OTHER executing jobs have a strictly LOWER id
+  (`count(... state='executing' AND tenant AND j.id < ^job_id) >= cap`). This:
+
+    * EXCLUDES the running job from its own count for free (`id < job_id` can never
+      count `id == job_id`), so a lone job (`rank 0`) always runs — cap=1 queues
+      never wedge, and gated queues give the full `cap`, not `cap - 1` (no off-by-one:
+      embeddings stays 3, knowledge 2).
+    * BREAKS the co-fetch symmetry DETERMINISTICALLY: of M co-fetched same-tenant
+      jobs, exactly the lowest `cap` by id proceed and the rest snooze — regardless of
+      which `perform/1` reads first, and regardless of jitter. No "all snooze" outcome
+      exists, so jitter=0 is SAFE and the "never snooze forever" invariant HOLDS: the
+      lowest-id executing job for a tenant always has rank 0 → runs → completes, then
+      the next, so every job drains in id (≈ FIFO) order and none starves.
+
   The public `executing_count/2` / `in_flight_count/2` helpers (reused by US-36.3's
-  `/queue-health` endpoint) are UNSCOPED counts — they intentionally do NOT exclude
-  any job; self-exclusion belongs only to the gate's decision path.
+  `/queue-health` endpoint) are UNSCOPED counts — they intentionally do NOT apply the
+  rank predicate; `id < job_id` belongs only to the gate's decision path. `job_id`
+  may be `nil` (a bare `perform/1` struct in a test, off the real dispatch path) —
+  then the gate falls back to the plain unscoped executing count `>= cap`.
 
   ## The count helper (AC-36.2.1)
 
@@ -69,18 +96,39 @@ defmodule Loopctl.Oban.FairShare do
 
   The query filters `queue = $1 AND state (= or IN) ... AND args->>'tenant_id' = $2`.
   Oban's own default index `oban_jobs_state_queue_priority_scheduled_at_id_index`
-  leads with `(state, queue)`, so the planner Index-Scans exactly the small
-  NON-TERMINAL population for that `(state, queue)` and applies `args->>'tenant_id'`
-  as a cheap filter over it — the enormous `completed`/`discarded` backlog (pruned
-  after 7 days, but still the bulk of the table) is never touched because `state` is
-  the leading column. Measured on the dev DB (~18k jobs): the `executing` count is
-  `Index Scan … Index Cond ((state,queue)) … shared hit=3`, ~0.05 ms; the 4-state
-  count is `shared hit=12`, ~0.05 ms. NO new index is warranted — a
-  `(args->>'tenant_id', queue, state)` index would be strictly worse, leading with
-  the high-cardinality tenant expression and folding the whole completed backlog
-  under each tenant. Each count runs under a per-query `SET LOCAL statement_timeout`
-  (pgbouncer-safe — a startup `:parameters` timeout is rejected by Fly's pgbouncer
-  with 08P01; see `Loopctl.HeavyRead`).
+  leads with `(state, queue)`, so the planner Index-Scans exactly the NON-TERMINAL
+  population for that `(state, queue)` and applies `args->>'tenant_id'` as a filter
+  over it — the enormous `completed`/`discarded` backlog (pruned after 7 days, but
+  still the bulk of the table) is never touched because `state` is the leading column.
+
+  The cost is therefore O(non-terminal rows on that `(state, queue)`), NOT sub-ms
+  unconditionally. Two regimes, both measured on the dev DB:
+
+    * BENIGN (~18k jobs, all terminal/pruned): the `executing` count is
+      `Index Scan … Index Cond ((state,queue)) … shared hit≈3`, ~0.05 ms; the 4-state
+      count `shared hit≈12`, ~0.05 ms.
+    * ONE-TENANT FLOOD (the scenario this story targets — a 50-item ingest fanning
+      out thousands of contiguous `available` rows): synthesised 5k `available`
+      `:embeddings` rows for one tenant (10k non-terminal on the queue in total) and
+      EXPLAIN-ANALYZEd the 4-state `in_flight_count`. Result: still an
+      `Index Scan using …_state_queue_… (Index Cond ((state,queue)))` with the tenant
+      as a post-Filter — `shared hit≈5591`, **~3.5 ms** at 10k scanned rows. It scans
+      every non-terminal row on the queue (the tenant filter does NOT reduce a
+      single-tenant flood), so the count grows LINEARLY with the queue's non-terminal
+      depth, but stays low-single-digit-ms at the flood sizes this feature contends
+      with and is HARD-BOUNDED by the 2 s `SET LOCAL statement_timeout` below — it can
+      never pin a connection. This bound makes it safe for US-36.3's synchronous
+      `/queue-health` per-request use; if that endpoint ever needs a flood-independent
+      cost it should cap the count (e.g. `LIMIT`-bounded existence probe), not add an
+      index (see next).
+
+  NO new index is warranted. A count of N matching rows is inherently O(N) index
+  entries even with a perfect covering index, so no index makes a single-tenant flood
+  count sub-linear; and a `(args->>'tenant_id', queue, state)` index would be strictly
+  WORSE for the common case, leading with the high-cardinality tenant expression and
+  folding the whole completed backlog under each tenant. Each count runs under a
+  per-query `SET LOCAL statement_timeout` (pgbouncer-safe — a startup `:parameters`
+  timeout is rejected by Fly's pgbouncer with 08P01; see `Loopctl.HeavyRead`).
   """
 
   import Ecto.Query, only: [from: 2]
@@ -123,20 +171,35 @@ defmodule Loopctl.Oban.FairShare do
   end
 
   @doc """
-  True when `tenant_id` already occupies at or above its fair-share cap of `queue`'s
-  EXECUTING slots (AC-36.2.2), EXCLUDING the job identified by `job_id` (the running
-  job — see the moduledoc). FAILS OPEN (`false`) on any count error/timeout so the
-  gate can never wedge a queue.
+  True when `tenant_id` is NOT among the lowest-`cap` holders of `queue`'s EXECUTING
+  slots (AC-36.2.2) — i.e. `cap` or more of the tenant's OTHER executing jobs have a
+  strictly lower `oban_jobs.id` than the running job (`job_id`). This RANK-based
+  decision self-excludes the running job for free (`id < job_id`) AND breaks the
+  co-fetch symmetry deterministically, so no set of co-fetched same-tenant jobs can
+  ever all snooze together (see the moduledoc — "Rank-based decision").
+
+  The CAP is read here, OUTSIDE the fail-open rescue below, so a malformed
+  `OBAN_TENANT_FAIRSHARE_<QUEUE>` fails LOUD (crashes the job → visible) exactly like
+  the snooze knobs, rather than being swallowed into a silent fail-open that disables
+  fairness. Only the COUNT query FAILS OPEN (`false`) on error/timeout so the gate can
+  never wedge a queue. `ObanConfig.fair_share_config/0` also validates every cap at
+  BOOT, so at runtime this parse cannot fail anyway.
   """
   @spec over_fair_share?(binary(), atom(), pos_integer() | nil) :: boolean()
   def over_fair_share?(tenant_id, queue, job_id \\ nil)
       when is_binary(tenant_id) and is_atom(queue) do
     cap = ObanConfig.tenant_fair_share_cap(queue)
-    executing_count_excluding(tenant_id, queue, job_id) >= cap
+    over_cap?(tenant_id, queue, job_id, cap)
+  end
+
+  # The count-bearing half of the decision. FAILS OPEN (`false`) on any count
+  # error/timeout — an unmeasurable count must NEVER block a job (SECURITY note: the
+  # gate must not be able to wedge a queue). A malformed CAP is deliberately NOT caught
+  # here (it is read in `over_fair_share?/3`, above this rescue) so it fails loud.
+  defp over_cap?(tenant_id, queue, job_id, cap) do
+    lower_ranked_executing_count(tenant_id, queue, job_id) >= cap
   rescue
     e ->
-      # Best-effort fairness: an unmeasurable count must NEVER block a job (SECURITY
-      # note — the gate must not be able to wedge a queue). Proceed and log.
       Logger.warning(
         "FairShare gate failed open on queue=#{queue} tenant=#{tenant_id}: " <>
           Exception.message(e)
@@ -152,7 +215,7 @@ defmodule Loopctl.Oban.FairShare do
   """
   @spec in_flight_count(binary(), atom() | binary()) :: non_neg_integer()
   def in_flight_count(tenant_id, queue) do
-    count(tenant_id, queue, @non_terminal_states, nil)
+    count(tenant_id, queue, @non_terminal_states, :all)
   end
 
   @doc """
@@ -163,14 +226,21 @@ defmodule Loopctl.Oban.FairShare do
   """
   @spec executing_count(binary(), atom() | binary()) :: non_neg_integer()
   def executing_count(tenant_id, queue) do
-    count(tenant_id, queue, ["executing"], nil)
+    count(tenant_id, queue, ["executing"], :all)
   end
 
-  # Executing-count for the gate's decision: excludes the running job (`job_id`) so a
-  # job never counts itself and wedges a cap=1 queue (see the moduledoc). `job_id` nil
-  # excludes nothing.
-  defp executing_count_excluding(tenant_id, queue, job_id) do
-    count(tenant_id, queue, ["executing"], job_id)
+  # The gate's rank input: how many of the tenant's OTHER executing jobs on `queue`
+  # have a strictly LOWER id than the running job (`job_id`). `< job_id` self-excludes
+  # the running job for free and yields the deterministic co-fetch tie-break (see the
+  # moduledoc). A `nil` job_id (bare `perform/1` struct in a test — off the real
+  # dispatch path) has no rank, so we fall back to the plain unscoped executing count
+  # (counts every executing job, including the caller).
+  defp lower_ranked_executing_count(tenant_id, queue, job_id) when is_integer(job_id) do
+    count(tenant_id, queue, ["executing"], {:lower_than, job_id})
+  end
+
+  defp lower_ranked_executing_count(tenant_id, queue, nil) do
+    count(tenant_id, queue, ["executing"], :all)
   end
 
   @doc """
@@ -191,7 +261,12 @@ defmodule Loopctl.Oban.FairShare do
   # (BYPASSRLS — the table has no RLS), run under a per-query SET LOCAL
   # statement_timeout inside a transaction (pgbouncer-safe). `queue` may be an atom
   # (worker config) or string (raw); oban_jobs.queue is text, so it's stringified.
-  defp count(tenant_id, queue, states, exclude_job_id) do
+  #
+  # `id_predicate` narrows the count: `:all` (public helpers — no id filter) or
+  # `{:lower_than, job_id}` (the gate's rank input — only executing jobs with a
+  # strictly lower id, which both self-excludes the caller and gives the deterministic
+  # co-fetch tie-break; see the moduledoc).
+  defp count(tenant_id, queue, states, id_predicate) do
     queue_str = to_string(queue)
     tenant_id_str = to_string(tenant_id)
 
@@ -203,15 +278,7 @@ defmodule Loopctl.Oban.FairShare do
         select: count(j.id)
       )
 
-    # Exclude the running job from its own count (the gate's self-exclusion). Under
-    # the Basic engine the caller is already `executing` when it reads this, so
-    # without `j.id != ^exclude_job_id` a lone job self-counts and wedges cap=1.
-    query =
-      if is_integer(exclude_job_id) do
-        from(j in base, where: j.id != ^exclude_job_id)
-      else
-        base
-      end
+    query = apply_id_predicate(base, id_predicate)
 
     {:ok, result} =
       AdminRepo.transaction(fn ->
@@ -220,5 +287,11 @@ defmodule Loopctl.Oban.FairShare do
       end)
 
     result || 0
+  end
+
+  defp apply_id_predicate(query, :all), do: query
+
+  defp apply_id_predicate(query, {:lower_than, job_id}) when is_integer(job_id) do
+    from(j in query, where: j.id < ^job_id)
   end
 end

--- a/lib/loopctl/oban/fair_share.ex
+++ b/lib/loopctl/oban/fair_share.ex
@@ -1,0 +1,224 @@
+defmodule Loopctl.Oban.FairShare do
+  @moduledoc """
+  Per-tenant in-flight fair-share gate for the contended Oban queues (US-36.2, #351).
+
+  Stock Oban 2.19's Basic engine is plain FIFO per queue — no partitioning, no
+  per-args concurrency limits (those are Smart-engine only, deferred to Epic 38).
+  One tenant's bulk burst (a 50-item ingest fans out to hundreds of embedding +
+  linking jobs, all one `tenant_id`, inserted contiguously) therefore sits at the
+  head of a shared queue and starves every other tenant indefinitely.
+
+  The Basic-engine-idiomatic, LOSS-FREE fix is COOPERATIVE YIELDING: at the START
+  of `perform/1` a contended-queue worker asks `gate/2` whether its tenant already
+  occupies at or above its fair share of that queue's EXECUTING slots. If so, the
+  worker returns `{:snooze, n}` — Oban reschedules the job WITHOUT consuming an
+  attempt and NEVER drops it, freeing the slot for a waiting tenant. Fairness thus
+  degrades to LATENCY, never to loss/correctness.
+
+  ## Fair share is a TARGET, not an invariant
+
+  The count is inherently racy (it reflects a moment that has already passed by the
+  time the gate acts — see the wiki finding "Race condition: querying Oban job count
+  from inside a running job gives a stale result"). That is ACCEPTABLE: the goal is
+  to stop MONOPOLIZATION, not to enforce an exact slot count. A byzantine tenant can
+  still get service — just not all of it.
+
+  ## Never wedges a queue
+
+  The cap (`Loopctl.ObanConfig.tenant_fair_share_cap/1`) is ALWAYS `>= 1`, so a
+  tenant may always hold at least one slot and the gate can never drive every job to
+  snooze forever. The gate additionally FAILS OPEN: if the count query errors or
+  times out, `over_fair_share?/3` returns `false` (the job proceeds) rather than
+  blocking — an unmeasurable count must never stall work.
+
+  ## The gate MUST exclude the running job from its own count
+
+  Under Oban's Basic engine the fetched job is committed to `state = 'executing'`
+  INSIDE `fetch_jobs`' `Repo.transaction` BEFORE it is dispatched to the worker
+  Task — the same reason Lifeline can find orphaned `executing` rows after a node
+  dies. So a naive `count(... state='executing' AND tenant ...)` run from inside
+  `perform/1` COUNTS THE RUNNING JOB ITSELF. That is catastrophic:
+
+    * Effective per-tenant concurrency becomes `cap - 1`, not `cap` (off-by-one on
+      every gated queue: embeddings 3→2, knowledge 2→1).
+    * For a queue whose derived cap is 1 (`:ingestion`, width 2 → `ceil(2/2)=1`)
+      EVERY job — even a single uncontended one — sees `1 >= 1` and snoozes
+      FOREVER: the queue is permanently WEDGED, the exact anti-goal above.
+
+  The gate therefore threads the current `Oban.Job.id` through to the count and
+  excludes it (`j.id != ^job_id`), so a lone job sees `others = 0 < cap` and runs.
+  The public `executing_count/2` / `in_flight_count/2` helpers (reused by US-36.3's
+  `/queue-health` endpoint) are UNSCOPED counts — they intentionally do NOT exclude
+  any job; self-exclusion belongs only to the gate's decision path.
+
+  ## The count helper (AC-36.2.1)
+
+  `oban_jobs` is Oban-owned, schemaless, has NO RLS and is NOT tenant-scoped by
+  schema. We query it as a string source through `Loopctl.AdminRepo` (BYPASSRLS),
+  scoping by `args->>'tenant_id'` — the same precedent as
+  `Loopctl.Knowledge.count_pending_extractions/1`. `tenant_id` is stringified for the
+  text compare. Two counts are exposed:
+
+    * `in_flight_count/2` — the broad 4-state set
+      (`available`/`scheduled`/`executing`/`retryable`), the GENERAL helper reused by
+      US-36.3's `/queue-health` endpoint.
+    * `executing_count/2` — only `executing`, the slot-occupancy the fair-share gate
+      decides on (AC-36.2.2).
+
+  ### Cost / index justification
+
+  The query filters `queue = $1 AND state (= or IN) ... AND args->>'tenant_id' = $2`.
+  Oban's own default index `oban_jobs_state_queue_priority_scheduled_at_id_index`
+  leads with `(state, queue)`, so the planner Index-Scans exactly the small
+  NON-TERMINAL population for that `(state, queue)` and applies `args->>'tenant_id'`
+  as a cheap filter over it — the enormous `completed`/`discarded` backlog (pruned
+  after 7 days, but still the bulk of the table) is never touched because `state` is
+  the leading column. Measured on the dev DB (~18k jobs): the `executing` count is
+  `Index Scan … Index Cond ((state,queue)) … shared hit=3`, ~0.05 ms; the 4-state
+  count is `shared hit=12`, ~0.05 ms. NO new index is warranted — a
+  `(args->>'tenant_id', queue, state)` index would be strictly worse, leading with
+  the high-cardinality tenant expression and folding the whole completed backlog
+  under each tenant. Each count runs under a per-query `SET LOCAL statement_timeout`
+  (pgbouncer-safe — a startup `:parameters` timeout is rejected by Fly's pgbouncer
+  with 08P01; see `Loopctl.HeavyRead`).
+  """
+
+  import Ecto.Query, only: [from: 2]
+
+  require Logger
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.ObanConfig
+
+  # The four non-terminal Oban states — the GENERAL in-flight set (AC-36.2.1),
+  # shared with US-36.3's queue-health endpoint.
+  @non_terminal_states ~w(available scheduled executing retryable)
+
+  # Bound the read on the hot, Oban-owned oban_jobs table. Generous vs the measured
+  # sub-ms cost, but a hard ceiling so a pathological plan can never pin a slot on
+  # the fairness check itself.
+  @count_statement_timeout_ms 2_000
+
+  @doc """
+  The fair-share gate a contended-queue worker calls at the TOP of its
+  tenant-scoped `perform/1`.
+
+  Pass the current `Oban.Job.id` as `job_id` so the running job is EXCLUDED from its
+  own executing-count — otherwise, because the Basic engine commits the job to
+  `executing` before dispatching it, a job would count itself and wedge cap=1 queues
+  (see the moduledoc). `job_id` may be `nil` (e.g. a bare `perform/1` struct in a
+  test) — then nothing is excluded.
+
+  Returns `:ok` to proceed, or `{:snooze, n}` (bounded, jittered seconds) when the
+  tenant is at or above its fair share of the queue's EXECUTING slots — the worker
+  returns that snooze verbatim, yielding the slot without consuming an attempt.
+  """
+  @spec gate(binary(), atom(), pos_integer() | nil) :: :ok | {:snooze, pos_integer()}
+  def gate(tenant_id, queue, job_id \\ nil) when is_binary(tenant_id) and is_atom(queue) do
+    if over_fair_share?(tenant_id, queue, job_id) do
+      {:snooze, snooze_seconds()}
+    else
+      :ok
+    end
+  end
+
+  @doc """
+  True when `tenant_id` already occupies at or above its fair-share cap of `queue`'s
+  EXECUTING slots (AC-36.2.2), EXCLUDING the job identified by `job_id` (the running
+  job — see the moduledoc). FAILS OPEN (`false`) on any count error/timeout so the
+  gate can never wedge a queue.
+  """
+  @spec over_fair_share?(binary(), atom(), pos_integer() | nil) :: boolean()
+  def over_fair_share?(tenant_id, queue, job_id \\ nil)
+      when is_binary(tenant_id) and is_atom(queue) do
+    cap = ObanConfig.tenant_fair_share_cap(queue)
+    executing_count_excluding(tenant_id, queue, job_id) >= cap
+  rescue
+    e ->
+      # Best-effort fairness: an unmeasurable count must NEVER block a job (SECURITY
+      # note — the gate must not be able to wedge a queue). Proceed and log.
+      Logger.warning(
+        "FairShare gate failed open on queue=#{queue} tenant=#{tenant_id}: " <>
+          Exception.message(e)
+      )
+
+      false
+  end
+
+  @doc """
+  Broad in-flight count for `tenant_id` on `queue` across the four non-terminal
+  states (`available`/`scheduled`/`executing`/`retryable`) — AC-36.2.1. This is the
+  GENERAL helper US-36.3's endpoint reuses.
+  """
+  @spec in_flight_count(binary(), atom() | binary()) :: non_neg_integer()
+  def in_flight_count(tenant_id, queue) do
+    count(tenant_id, queue, @non_terminal_states, nil)
+  end
+
+  @doc """
+  Count of `tenant_id`'s currently-EXECUTING jobs on `queue` (AC-36.2.2) — the
+  UNSCOPED slot-occupancy (counts every executing job, including any running caller).
+  US-36.3's `/queue-health` endpoint reuses this. The gate's decision path uses the
+  self-excluding count instead (see `over_fair_share?/3`).
+  """
+  @spec executing_count(binary(), atom() | binary()) :: non_neg_integer()
+  def executing_count(tenant_id, queue) do
+    count(tenant_id, queue, ["executing"], nil)
+  end
+
+  # Executing-count for the gate's decision: excludes the running job (`job_id`) so a
+  # job never counts itself and wedges a cap=1 queue (see the moduledoc). `job_id` nil
+  # excludes nothing.
+  defp executing_count_excluding(tenant_id, queue, job_id) do
+    count(tenant_id, queue, ["executing"], job_id)
+  end
+
+  @doc """
+  A bounded, jittered snooze interval in seconds (AC-36.2.5): `base + rand(0..jitter)`
+  where both `base` (`> 0`) and `jitter` (`>= 0`) come from `Loopctl.ObanConfig`
+  (env-tunable). Jitter avoids a thundering-herd of snoozed jobs re-checking in
+  lockstep; the small bound keeps a yielded job from starving.
+  """
+  @spec snooze_seconds() :: pos_integer()
+  def snooze_seconds do
+    base = ObanConfig.fair_share_snooze_base_seconds()
+    jitter = ObanConfig.fair_share_snooze_jitter_seconds()
+    # :rand.uniform(jitter + 1) ∈ 1..jitter+1 → -1 gives 0..jitter (0 when jitter=0).
+    base + :rand.uniform(jitter + 1) - 1
+  end
+
+  # Tenant-scoped, bounded count over the Oban-owned oban_jobs table via AdminRepo
+  # (BYPASSRLS — the table has no RLS), run under a per-query SET LOCAL
+  # statement_timeout inside a transaction (pgbouncer-safe). `queue` may be an atom
+  # (worker config) or string (raw); oban_jobs.queue is text, so it's stringified.
+  defp count(tenant_id, queue, states, exclude_job_id) do
+    queue_str = to_string(queue)
+    tenant_id_str = to_string(tenant_id)
+
+    base =
+      from(j in "oban_jobs",
+        where:
+          j.queue == ^queue_str and j.state in ^states and
+            fragment("? ->> 'tenant_id' = ?", j.args, ^tenant_id_str),
+        select: count(j.id)
+      )
+
+    # Exclude the running job from its own count (the gate's self-exclusion). Under
+    # the Basic engine the caller is already `executing` when it reads this, so
+    # without `j.id != ^exclude_job_id` a lone job self-counts and wedges cap=1.
+    query =
+      if is_integer(exclude_job_id) do
+        from(j in base, where: j.id != ^exclude_job_id)
+      else
+        base
+      end
+
+    {:ok, result} =
+      AdminRepo.transaction(fn ->
+        AdminRepo.query!("SET LOCAL statement_timeout = #{@count_statement_timeout_ms}")
+        AdminRepo.one(query)
+      end)
+
+    result || 0
+  end
+end

--- a/lib/loopctl/oban_config.ex
+++ b/lib/loopctl/oban_config.ex
@@ -131,6 +131,93 @@ defmodule Loopctl.ObanConfig do
     end
   end
 
+  # --- US-36.2: per-tenant in-flight fair-share caps + snooze backoff ---
+  #
+  # The contended-queue workers (ArticleEmbeddingWorker on :embeddings,
+  # ContentIngestionWorker on :ingestion, the :knowledge relationship/cron-child
+  # workers) yield `{:snooze, n}` at the top of their tenant-scoped perform/1 when
+  # the tenant already occupies at/above its fair share of that queue's EXECUTING
+  # slots (see `Loopctl.Oban.FairShare`). Cap K is DERIVED from the queue width so it
+  # scales automatically when a width is retuned via `OBAN_QUEUE_<NAME>`.
+  #
+  # Default cap = `ceil(width / 2)`, floored at 1 — a single tenant may hold at most
+  # ~half a contended queue's concurrency, leaving the rest for other tenants, e.g.
+  # embeddings(5)->3, knowledge(3)->2, ingestion(2)->1. The floor of 1 is CRITICAL:
+  # the cap must ALWAYS admit at least one slot per tenant so the gate can never wedge
+  # a queue (all jobs snoozing forever) — see the US-36.2 SECURITY note.
+  #
+  # Live-tunable per queue via `OBAN_TENANT_FAIRSHARE_<NAME>` (e.g. loosen fairness
+  # during an incident with `fly secrets set OBAN_TENANT_FAIRSHARE_EMBEDDINGS=5` +
+  # restart — no deploy). Snooze backoff (default 5s base + 0..5s jitter → 5–10s) is
+  # tunable via `OBAN_TENANT_FAIRSHARE_SNOOZE_SECONDS` / `_SNOOZE_JITTER`. Config-based
+  # DI (read via `System.get_env/1` at call time), same as `queues/0` — NEVER
+  # `Application.compile_env`, which would record a boot-aborting compile-env
+  # dependency (see the @default_queues note above).
+  @default_fair_share_snooze_base_seconds 5
+  @default_fair_share_snooze_jitter_seconds 5
+
+  @doc """
+  The per-tenant fair-share cap (K) for `queue`: the number of that queue's EXECUTING
+  slots one tenant may occupy before its next job snoozes (US-36.2).
+
+  Resolves `OBAN_TENANT_FAIRSHARE_<QUEUE>` if set (positive integer, else raises like
+  `queue_size/2`), otherwise DERIVES `ceil(width / 2)` from the current queue width,
+  floored at 1. Always `>= 1` so the gate can never wedge the queue.
+  """
+  @spec tenant_fair_share_cap(atom()) :: pos_integer()
+  def tenant_fair_share_cap(queue) when is_atom(queue) do
+    width = Keyword.get(queues(), queue, 1)
+    # div(width + 1, 2) == ceil(width / 2) for positive widths; max(_, 1) is defensive
+    # (a width of 1 already yields 1) and encodes the "always >= 1 slot" invariant.
+    derived = max(div(width + 1, 2), 1)
+    env_var = "OBAN_TENANT_FAIRSHARE_" <> String.upcase(Atom.to_string(queue))
+    queue_size(System.get_env(env_var), derived)
+  end
+
+  @doc """
+  The base (minimum) fair-share snooze interval in seconds (US-36.2), from
+  `OBAN_TENANT_FAIRSHARE_SNOOZE_SECONDS` (positive integer, else raises), default
+  #{@default_fair_share_snooze_base_seconds}.
+  """
+  @spec fair_share_snooze_base_seconds() :: pos_integer()
+  def fair_share_snooze_base_seconds do
+    queue_size(
+      System.get_env("OBAN_TENANT_FAIRSHARE_SNOOZE_SECONDS"),
+      @default_fair_share_snooze_base_seconds
+    )
+  end
+
+  @doc """
+  The fair-share snooze JITTER span in seconds (US-36.2): the snooze is
+  `base + rand(0..jitter)`. From `OBAN_TENANT_FAIRSHARE_SNOOZE_JITTER` (NON-negative
+  integer — 0 disables jitter — else raises), default
+  #{@default_fair_share_snooze_jitter_seconds}.
+  """
+  @spec fair_share_snooze_jitter_seconds() :: non_neg_integer()
+  def fair_share_snooze_jitter_seconds do
+    non_neg_size(
+      System.get_env("OBAN_TENANT_FAIRSHARE_SNOOZE_JITTER"),
+      @default_fair_share_snooze_jitter_seconds
+    )
+  end
+
+  # Like `queue_size/2` but admits 0 (a valid "no jitter" value). Still fails loud on
+  # a present-but-malformed / negative value rather than silently defaulting.
+  @spec non_neg_size(String.t() | nil, non_neg_integer()) :: non_neg_integer()
+  defp non_neg_size(nil, default) when is_integer(default) and default >= 0, do: default
+
+  defp non_neg_size(value, default) when is_binary(value) do
+    case Integer.parse(value) do
+      {size, ""} when size >= 0 ->
+        size
+
+      _ ->
+        raise ArgumentError,
+              "OBAN_TENANT_FAIRSHARE_SNOOZE_JITTER must be a non-negative integer, " <>
+                "got: #{inspect(value)} (default: #{default})"
+    end
+  end
+
   # US-35.3: default safety-sweep interval for the all-tenants ComputeSthWorker cron.
   # Every 5 minutes — a low-frequency backstop that only catches appends the
   # event-driven enqueuer (US-35.2) missed. Down from the old `"* * * * *"` per-minute

--- a/lib/loopctl/oban_config.ex
+++ b/lib/loopctl/oban_config.ex
@@ -133,9 +133,11 @@ defmodule Loopctl.ObanConfig do
 
   # --- US-36.2: per-tenant in-flight fair-share caps + snooze backoff ---
   #
-  # The contended-queue workers (ArticleEmbeddingWorker on :embeddings,
-  # ContentIngestionWorker on :ingestion, the :knowledge relationship/cron-child
-  # workers) yield `{:snooze, n}` at the top of their tenant-scoped perform/1 when
+  # The contended-queue workers (ArticleEmbeddingWorker AND MemoryEmbeddingWorker on
+  # :embeddings — BOTH tenant-scoped per-item fan-out producers must gate or one can
+  # still monopolize the shared queue — ContentIngestionWorker on :ingestion, the
+  # :knowledge relationship/cron-child workers) yield `{:snooze, n}` at the top of
+  # their tenant-scoped perform/1 when
   # the tenant already occupies at/above its fair share of that queue's EXECUTING
   # slots (see `Loopctl.Oban.FairShare`). Cap K is DERIVED from the queue width so it
   # scales automatically when a width is retuned via `OBAN_QUEUE_<NAME>`.
@@ -172,6 +174,40 @@ defmodule Loopctl.ObanConfig do
     derived = max(div(width + 1, 2), 1)
     env_var = "OBAN_TENANT_FAIRSHARE_" <> String.upcase(Atom.to_string(queue))
     queue_size(System.get_env(env_var), derived)
+  end
+
+  @doc """
+  Force-validates EVERY fair-share knob at BOOT and returns their resolved values.
+
+  Invoked from `config/runtime.exs` (which runs before the system starts, in every
+  env) alongside `queues/0`, so a malformed `OBAN_TENANT_FAIRSHARE_<QUEUE>` cap,
+  `OBAN_TENANT_FAIRSHARE_SNOOZE_SECONDS`, or `OBAN_TENANT_FAIRSHARE_SNOOZE_JITTER`
+  aborts the node LOUD at boot — exactly like a malformed `OBAN_QUEUE_*` (which
+  `queues/0` already validates at boot). Without this, a fat-fingered cap var would
+  only surface at CALL time inside `Loopctl.Oban.FairShare.over_cap?/4`, whose count
+  path FAILS OPEN and would SILENTLY disable fairness on that queue — during the exact
+  incident an operator is trying to tune. Reading each knob here calls its parser
+  (`queue_size/2` / `non_neg_size/2`), which raises `ArgumentError` on a
+  present-but-malformed value, so evaluating this function IS the validation.
+
+  Returns a map of the resolved caps (one per configured queue) plus the snooze
+  base/jitter, purely so the boot config is introspectable; the gate re-reads env at
+  call time (config-based DI), so the returned values are a boot-time snapshot, not a
+  cache the gate consults.
+  """
+  @spec fair_share_config() :: %{
+          caps: keyword(pos_integer()),
+          snooze_base_seconds: pos_integer(),
+          snooze_jitter_seconds: non_neg_integer()
+        }
+  def fair_share_config do
+    caps = Enum.map(queues(), fn {queue, _width} -> {queue, tenant_fair_share_cap(queue)} end)
+
+    %{
+      caps: caps,
+      snooze_base_seconds: fair_share_snooze_base_seconds(),
+      snooze_jitter_seconds: fair_share_snooze_jitter_seconds()
+    }
   end
 
   @doc """

--- a/lib/loopctl/workers/article_embedding_worker.ex
+++ b/lib/loopctl/workers/article_embedding_worker.ex
@@ -50,6 +50,7 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
   alias Loopctl.Knowledge
   alias Loopctl.Llm
   alias Loopctl.Llm.ProviderError
+  alias Loopctl.Oban.FairShare
   alias Loopctl.Workers.ArticleLinkingWorker
 
   # Longer Task.yield budget than the interactive query path: a background embed can
@@ -60,7 +61,18 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
   @max_text_length 32_000
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"article_id" => article_id, "tenant_id" => tenant_id}}) do
+  def perform(%Oban.Job{id: id, args: %{"article_id" => article_id, "tenant_id" => tenant_id}}) do
+    # US-36.2: per-tenant fair-share gate. Yield the :embeddings slot (loss-free
+    # {:snooze, n}, no attempt consumed) when this tenant already holds at/above its
+    # fair share of executing slots, so one tenant's bulk burst can't monopolize.
+    # `id` excludes THIS (already-executing) job from its own count — see FairShare.
+    case FairShare.gate(tenant_id, :embeddings, id) do
+      {:snooze, _n} = snooze -> snooze
+      :ok -> embed(tenant_id, article_id)
+    end
+  end
+
+  defp embed(tenant_id, article_id) do
     case Knowledge.get_article_with_embedding(tenant_id, article_id) do
       {:error, :not_found} ->
         # Article deleted -- no-op

--- a/lib/loopctl/workers/article_linking_worker.ex
+++ b/lib/loopctl/workers/article_linking_worker.ex
@@ -69,6 +69,7 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.ArticleLink
   alias Loopctl.Knowledge.VectorSearch
+  alias Loopctl.Oban.FairShare
 
   # Compile-time DI for the similarity lookup. The worker uses this to fetch
   # nearest-neighbour candidates; in tests it resolves to a Mox mock, in prod to VectorSearch.
@@ -79,7 +80,21 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
                      )
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"article_id" => article_id, "tenant_id" => tenant_id} = args}) do
+  def perform(%Oban.Job{
+        id: id,
+        args: %{"article_id" => article_id, "tenant_id" => tenant_id} = args
+      }) do
+    # US-36.2: per-tenant fair-share gate on the hot :knowledge queue (this worker
+    # fires on every knowledge_create). Yield loss-free ({:snooze, n}, no attempt
+    # consumed) when this tenant is at/above its fair share of executing slots.
+    # `id` excludes THIS (already-executing) job from its own count — see FairShare.
+    case FairShare.gate(tenant_id, :knowledge, id) do
+      {:snooze, _n} = snooze -> snooze
+      :ok -> link(article_id, tenant_id, args)
+    end
+  end
+
+  defp link(article_id, tenant_id, args) do
     case Knowledge.get_article_with_embedding(tenant_id, article_id) do
       {:error, :not_found} ->
         # Article deleted -- no-op

--- a/lib/loopctl/workers/content_ingestion_worker.ex
+++ b/lib/loopctl/workers/content_ingestion_worker.ex
@@ -58,6 +58,7 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   alias Loopctl.Llm
   alias Loopctl.Llm.ProviderError
   alias Loopctl.Net.UrlGuard
+  alias Loopctl.Oban.FairShare
   alias Loopctl.SystemConfig
   alias Loopctl.Workers.ArticleEmbeddingWorker
 
@@ -134,6 +135,7 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
 
   @impl Oban.Worker
   def perform(%Oban.Job{
+        id: id,
         args:
           %{
             "tenant_id" => tenant_id,
@@ -141,6 +143,21 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
             "content_hash" => content_hash
           } = args
       }) do
+    # US-36.2: per-tenant fair-share gate on the :ingestion queue. These are long
+    # (~6-min) LLM jobs, so one tenant's bulk ingest can otherwise hold both slots
+    # for many minutes. Yield loss-free ({:snooze, n}, no attempt consumed) BEFORE
+    # any fetch/LLM work when this tenant is at/above its fair share of executing
+    # slots; the deterministic content_hash uniqueness means the snoozed job resumes
+    # the same work later. `id` excludes THIS (already-executing) job from its own
+    # count — CRITICAL on :ingestion (cap=1), where self-counting would wedge the
+    # queue permanently (every lone job would snooze forever). See FairShare.
+    case FairShare.gate(tenant_id, :ingestion, id) do
+      {:snooze, _n} = snooze -> snooze
+      :ok -> ingest(tenant_id, source_type, content_hash, args)
+    end
+  end
+
+  defp ingest(tenant_id, source_type, content_hash, args) do
     url = args["url"]
     raw_content = args["content"]
     # Normalize "" -> nil (a blank project_id is "tenant-wide", not a value to dump

--- a/lib/loopctl/workers/knowledge_lint_worker.ex
+++ b/lib/loopctl/workers/knowledge_lint_worker.ex
@@ -59,6 +59,7 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   alias Loopctl.Knowledge
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.ArticleLink
+  alias Loopctl.Oban.FairShare
   alias Loopctl.Tenants.Tenant
   alias Loopctl.Workers.ArticleEmbeddingWorker
   alias Loopctl.Workers.ArticleLinkingWorker
@@ -89,7 +90,18 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
     :ok
   end
 
-  def perform(%Oban.Job{args: %{"tenant_id" => tenant_id}}) do
+  def perform(%Oban.Job{id: id, args: %{"tenant_id" => tenant_id}}) do
+    # US-36.2: fair-share gate on the shared :knowledge queue (do NOT gate the
+    # all_tenants dispatcher clause above — it carries no tenant_id). Yield loss-free
+    # when this tenant is at/above its fair share of executing slots. `id` excludes
+    # THIS (already-executing) job from its own count — see FairShare.
+    case FairShare.gate(tenant_id, :knowledge, id) do
+      {:snooze, _n} = snooze -> snooze
+      :ok -> lint_tenant(tenant_id)
+    end
+  end
+
+  defp lint_tenant(tenant_id) do
     {:ok, report} = Knowledge.lint(tenant_id, max_per_category: @lint_max_per_category)
 
     action = act_on_orphans(tenant_id, report)

--- a/lib/loopctl/workers/knowledge_moc_worker.ex
+++ b/lib/loopctl/workers/knowledge_moc_worker.ex
@@ -45,6 +45,7 @@ defmodule Loopctl.Workers.KnowledgeMocWorker do
   alias Loopctl.AdminRepo
   alias Loopctl.Audit
   alias Loopctl.Knowledge
+  alias Loopctl.Oban.FairShare
   alias Loopctl.Tenants.Tenant
 
   @default_min_tag_count 25
@@ -96,7 +97,17 @@ defmodule Loopctl.Workers.KnowledgeMocWorker do
     :ok
   end
 
-  def perform(%Oban.Job{args: %{"tenant_id" => tenant_id}}) do
+  def perform(%Oban.Job{id: id, args: %{"tenant_id" => tenant_id}}) do
+    # US-36.2: fair-share gate on the shared :knowledge queue (the all_tenants
+    # dispatcher clause above is NOT gated — it has no tenant_id). `id` excludes THIS
+    # (already-executing) job from its own count — see FairShare.
+    case FairShare.gate(tenant_id, :knowledge, id) do
+      {:snooze, _n} = snooze -> snooze
+      :ok -> build_moc(tenant_id)
+    end
+  end
+
+  defp build_moc(tenant_id) do
     min_count =
       Application.get_env(:loopctl, :knowledge_moc_min_tag_count, @default_min_tag_count)
 

--- a/lib/loopctl/workers/knowledge_reclassify_worker.ex
+++ b/lib/loopctl/workers/knowledge_reclassify_worker.ex
@@ -66,6 +66,7 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorker do
   alias Loopctl.AdminRepo
   alias Loopctl.Audit
   alias Loopctl.Knowledge.Article
+  alias Loopctl.Oban.FairShare
   alias Loopctl.Tenants.Tenant
 
   @classifier Application.compile_env(
@@ -103,7 +104,17 @@ defmodule Loopctl.Workers.KnowledgeReclassifyWorker do
     :ok
   end
 
-  def perform(%Oban.Job{args: %{"tenant_id" => tenant_id} = args}) do
+  def perform(%Oban.Job{id: id, args: %{"tenant_id" => tenant_id} = args}) do
+    # US-36.2: fair-share gate on the shared :knowledge queue (the all_tenants
+    # dispatcher clause above is NOT gated — it has no tenant_id). `id` excludes THIS
+    # (already-executing) job from its own count — see FairShare.
+    case FairShare.gate(tenant_id, :knowledge, id) do
+      {:snooze, _n} = snooze -> snooze
+      :ok -> reclassify_tenant(tenant_id, args)
+    end
+  end
+
+  defp reclassify_tenant(tenant_id, args) do
     # Resolve the tenant's key + classification model ONCE per kick (review #19):
     # this both enforces mandatory BYO (Epic 28, #179) AND avoids a per-article
     # Loopctl.Llm.resolve/2 DB read across the batch — the resolved credentials are

--- a/lib/loopctl/workers/memory_embedding_worker.ex
+++ b/lib/loopctl/workers/memory_embedding_worker.ex
@@ -6,7 +6,13 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorker do
   Runs in the `:embeddings` queue. Enqueued by `Loopctl.Memory.remember/2` when a
   long-term memory is written (the row's `embedding` starts NULL). Mirrors
   `Loopctl.Workers.ArticleEmbeddingWorker` — same guarded embed path, content-hash
-  idempotency, and BYO-key / permanent-error discard semantics.
+  idempotency, BYO-key / permanent-error discard semantics, AND the US-36.2 per-tenant
+  fair-share gate at the top of `perform/1`. The gate is load-bearing here, not
+  cosmetic: `:embeddings` is shared by TWO tenant-scoped per-item fan-out producers
+  (this worker and `ArticleEmbeddingWorker`), and the gate counts executing slots by
+  `(queue, state, tenant)` regardless of worker — so an ungated memory-embed burst
+  would monopolize the queue against BOTH producers. Both must gate for fairness to
+  hold (see `Loopctl.Oban.FairShare`).
 
   ## Flow
 
@@ -48,18 +54,34 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorker do
   alias Loopctl.Llm
   alias Loopctl.Llm.ProviderError
   alias Loopctl.Memory
+  alias Loopctl.Oban.FairShare
 
   @worker_yield_ms 8_000
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"memory_id" => memory_id, "tenant_id" => tenant_id}}) do
-    case Memory.get_memory_for_embedding(tenant_id, memory_id) do
-      {:error, :not_found} ->
-        # Memory deleted -- no-op.
-        :ok
+  def perform(%Oban.Job{id: id, args: %{"memory_id" => memory_id, "tenant_id" => tenant_id}}) do
+    # US-36.2: per-tenant fair-share gate. `:embeddings` is a CONTENDED queue with TWO
+    # tenant-scoped per-item fan-out producers — this worker (one job per long-term
+    # memory, Memory.remember/2) AND ArticleEmbeddingWorker. Gating only the article
+    # worker would leave this producer free to monopolize all executing slots with one
+    # tenant's memory-embed burst (a bulk `memory_remember` or a MemoryPromotionSweep
+    # promoting many session memories), starving other tenants — the exact
+    # monopolization the story exists to stop. Yield the slot (loss-free {:snooze, n},
+    # no attempt consumed) when this tenant already holds at/above its fair share.
+    # `id` excludes THIS (already-executing) job from its own count — see FairShare.
+    case FairShare.gate(tenant_id, :embeddings, id) do
+      {:snooze, _n} = snooze ->
+        snooze
 
-      {:ok, memory} ->
-        generate_and_store(memory, tenant_id, memory_id)
+      :ok ->
+        case Memory.get_memory_for_embedding(tenant_id, memory_id) do
+          {:error, :not_found} ->
+            # Memory deleted -- no-op.
+            :ok
+
+          {:ok, memory} ->
+            generate_and_store(memory, tenant_id, memory_id)
+        end
     end
   end
 

--- a/lib/loopctl/workers/promotion_eval_worker.ex
+++ b/lib/loopctl/workers/promotion_eval_worker.ex
@@ -35,6 +35,7 @@ defmodule Loopctl.Workers.PromotionEvalWorker do
   alias Loopctl.AdminRepo
   alias Loopctl.Llm.TenantLlmSettings
   alias Loopctl.Memory.PromotionEval
+  alias Loopctl.Oban.FairShare
   alias Loopctl.Tenants.Tenant
 
   @impl Oban.Worker
@@ -58,7 +59,21 @@ defmodule Loopctl.Workers.PromotionEvalWorker do
     :ok
   end
 
-  def perform(%Oban.Job{args: %{"tenant_id" => tenant_id}}) do
+  def perform(%Oban.Job{id: id, args: %{"tenant_id" => tenant_id}}) do
+    # US-36.2: fair-share gate on the shared :knowledge queue — this is the SEVENTH
+    # tenant-scoped :knowledge worker (oban_config.ex enumerates it as a reason to
+    # size the lane at width 3), a not-sub-second per-tenant extraction LLM call fanned
+    # out over all keyed tenants daily. Gate it consistently with the other six so a
+    # tenant's promotion-eval can't exceed its fair share of executing :knowledge slots
+    # (the all_tenants dispatcher clause above stays UNGATED — it has no tenant_id).
+    # `id` excludes THIS (already-executing) job from its own count — see FairShare.
+    case FairShare.gate(tenant_id, :knowledge, id) do
+      {:snooze, _n} = snooze -> snooze
+      :ok -> run_eval(tenant_id)
+    end
+  end
+
+  defp run_eval(tenant_id) do
     case PromotionEval.run(tenant_id: tenant_id) do
       {:ok, snap} ->
         Logger.info(

--- a/lib/loopctl/workers/retrieval_metrics_worker.ex
+++ b/lib/loopctl/workers/retrieval_metrics_worker.ex
@@ -19,6 +19,7 @@ defmodule Loopctl.Workers.RetrievalMetricsWorker do
 
   alias Loopctl.AdminRepo
   alias Loopctl.Knowledge.RetrievalMetrics
+  alias Loopctl.Oban.FairShare
   alias Loopctl.Tenants.Tenant
 
   @impl Oban.Worker
@@ -32,7 +33,17 @@ defmodule Loopctl.Workers.RetrievalMetricsWorker do
     :ok
   end
 
-  def perform(%Oban.Job{args: %{"tenant_id" => tenant_id} = args}) do
+  def perform(%Oban.Job{id: id, args: %{"tenant_id" => tenant_id} = args}) do
+    # US-36.2: fair-share gate on the shared :knowledge queue (the all_tenants
+    # dispatcher clause above is NOT gated — it has no tenant_id). `id` excludes THIS
+    # (already-executing) job from its own count — see FairShare.
+    case FairShare.gate(tenant_id, :knowledge, id) do
+      {:snooze, _n} = snooze -> snooze
+      :ok -> snapshot_tenant(tenant_id, args)
+    end
+  end
+
+  defp snapshot_tenant(tenant_id, args) do
     day = day_arg(args)
 
     case RetrievalMetrics.snapshot(tenant_id, day) do

--- a/lib/loopctl/workers/review_knowledge_worker.ex
+++ b/lib/loopctl/workers/review_knowledge_worker.ex
@@ -42,6 +42,7 @@ defmodule Loopctl.Workers.ReviewKnowledgeWorker do
   alias Loopctl.Knowledge.Article
   alias Loopctl.Llm
   alias Loopctl.Llm.ProviderError
+  alias Loopctl.Oban.FairShare
 
   @extractor Application.compile_env(
                :loopctl,
@@ -60,8 +61,20 @@ defmodule Loopctl.Workers.ReviewKnowledgeWorker do
 
   @impl Oban.Worker
   def perform(%Oban.Job{
+        id: id,
         args: %{"review_record_id" => review_record_id, "tenant_id" => tenant_id}
       }) do
+    # US-36.2: fair-share gate on the shared :knowledge queue. Yield loss-free
+    # ({:snooze, n}, no attempt consumed) when this tenant is at/above its fair share
+    # of executing slots, before any (billed) extraction work.
+    # `id` excludes THIS (already-executing) job from its own count — see FairShare.
+    case FairShare.gate(tenant_id, :knowledge, id) do
+      {:snooze, _n} = snooze -> snooze
+      :ok -> extract_review_knowledge(tenant_id, review_record_id)
+    end
+  end
+
+  defp extract_review_knowledge(tenant_id, review_record_id) do
     cond do
       already_extracted?(tenant_id, review_record_id) ->
         Logger.info(

--- a/test/loopctl/oban/fair_share_test.exs
+++ b/test/loopctl/oban/fair_share_test.exs
@@ -1,0 +1,197 @@
+defmodule Loopctl.Oban.FairShareTest do
+  @moduledoc """
+  US-36.2 — per-tenant in-flight fair-share gate.
+
+  Covers the shared count helper (TC-36.2.1 / AC-36.2.1), tenant isolation
+  (AC-36.2.6), the derived caps + bounded/jittered snooze (AC-36.2.4 / AC-36.2.5),
+  and the `gate/2` snooze decision (AC-36.2.2).
+  """
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Oban.FairShare
+  alias Loopctl.ObanConfig
+
+  # Seed a raw oban_jobs row in a given state/queue for a tenant. oban_jobs is
+  # Oban-owned and has no RLS, so we insert through AdminRepo (as FairShare reads).
+  # Direct struct/changeset insert does NOT run the job (unlike Oban.insert under
+  # :inline), which is exactly what we need to simulate occupied slots.
+  defp seed_job(tenant_id, queue, state, opts \\ []) do
+    worker = Keyword.get(opts, :worker, "Loopctl.Workers.ArticleEmbeddingWorker")
+
+    %{"tenant_id" => tenant_id}
+    |> Oban.Job.new(worker: worker, queue: to_string(queue))
+    |> Ecto.Changeset.put_change(:state, state)
+    |> AdminRepo.insert!()
+  end
+
+  describe "in_flight_count/2 + executing_count/2 (TC-36.2.1, AC-36.2.1)" do
+    test "counts only the tenant's non-terminal jobs; excludes completed/discarded" do
+      tenant_a = Ecto.UUID.generate()
+
+      seed_job(tenant_a, :embeddings, "available")
+      seed_job(tenant_a, :embeddings, "scheduled")
+      seed_job(tenant_a, :embeddings, "executing")
+      seed_job(tenant_a, :embeddings, "retryable")
+      # Terminal states must NOT be counted.
+      seed_job(tenant_a, :embeddings, "completed")
+      seed_job(tenant_a, :embeddings, "discarded")
+      seed_job(tenant_a, :embeddings, "cancelled")
+
+      assert FairShare.in_flight_count(tenant_a, :embeddings) == 4
+      assert FairShare.executing_count(tenant_a, :embeddings) == 1
+    end
+
+    test "is scoped to the given queue" do
+      tenant_a = Ecto.UUID.generate()
+
+      seed_job(tenant_a, :embeddings, "executing")
+      seed_job(tenant_a, :knowledge, "executing")
+      seed_job(tenant_a, :knowledge, "executing")
+
+      assert FairShare.executing_count(tenant_a, :embeddings) == 1
+      assert FairShare.executing_count(tenant_a, :knowledge) == 2
+    end
+  end
+
+  describe "tenant isolation (AC-36.2.6)" do
+    test "tenant A's count never includes tenant B's jobs" do
+      tenant_a = Ecto.UUID.generate()
+      tenant_b = Ecto.UUID.generate()
+
+      seed_job(tenant_a, :embeddings, "executing")
+      # A pile of B's jobs on the same queue must be invisible to A's count.
+      for _ <- 1..5, do: seed_job(tenant_b, :embeddings, "executing")
+
+      assert FairShare.executing_count(tenant_a, :embeddings) == 1
+      assert FairShare.executing_count(tenant_b, :embeddings) == 5
+      # A's fair-share decision reads only A's count → A (1) is under cap (3).
+      refute FairShare.over_fair_share?(tenant_a, :embeddings)
+      # B (5) is over its cap (3) — decided purely on B's own count.
+      assert FairShare.over_fair_share?(tenant_b, :embeddings)
+    end
+  end
+
+  describe "tenant_fair_share_cap/1 (AC-36.2.4)" do
+    test "derives ceil(width/2), floored at 1, from the queue width" do
+      # Default widths (US-36.1): embeddings 5, knowledge 3, ingestion 2.
+      assert ObanConfig.tenant_fair_share_cap(:embeddings) == 3
+      assert ObanConfig.tenant_fair_share_cap(:knowledge) == 2
+      assert ObanConfig.tenant_fair_share_cap(:ingestion) == 1
+    end
+
+    test "never returns a cap below 1 (the gate can never wedge a queue)" do
+      for queue <- [:embeddings, :knowledge, :ingestion, :verification] do
+        assert ObanConfig.tenant_fair_share_cap(queue) >= 1
+      end
+    end
+  end
+
+  describe "snooze_seconds/0 (AC-36.2.5)" do
+    test "is bounded within [base, base + jitter] and jittered" do
+      base = ObanConfig.fair_share_snooze_base_seconds()
+      jitter = ObanConfig.fair_share_snooze_jitter_seconds()
+
+      values = for _ <- 1..200, do: FairShare.snooze_seconds()
+
+      assert Enum.all?(values, &(&1 >= base and &1 <= base + jitter))
+      assert Enum.all?(values, &(&1 >= 1))
+      # With the default 5s jitter the sample must show more than one distinct value.
+      assert values |> Enum.uniq() |> length() > 1
+    end
+
+    test "defaults are sensible (5s base, 5s jitter → 5-10s)" do
+      assert ObanConfig.fair_share_snooze_base_seconds() == 5
+      assert ObanConfig.fair_share_snooze_jitter_seconds() == 5
+    end
+  end
+
+  describe "gate/2 decision (AC-36.2.2)" do
+    test "returns :ok when the tenant is under its fair share" do
+      tenant_a = Ecto.UUID.generate()
+      # cap for :embeddings is 3; seed 2 executing → under cap.
+      seed_job(tenant_a, :embeddings, "executing")
+      seed_job(tenant_a, :embeddings, "executing")
+
+      assert FairShare.gate(tenant_a, :embeddings) == :ok
+    end
+
+    test "returns {:snooze, n} (bounded) when the tenant is at/above its fair share" do
+      tenant_a = Ecto.UUID.generate()
+      cap = ObanConfig.tenant_fair_share_cap(:embeddings)
+      for _ <- 1..cap, do: seed_job(tenant_a, :embeddings, "executing")
+
+      assert {:snooze, n} = FairShare.gate(tenant_a, :embeddings)
+      assert n >= ObanConfig.fair_share_snooze_base_seconds()
+
+      assert n <=
+               ObanConfig.fair_share_snooze_base_seconds() +
+                 ObanConfig.fair_share_snooze_jitter_seconds()
+    end
+
+    test "an uncontended tenant (no in-flight jobs) is never gated" do
+      assert FairShare.gate(Ecto.UUID.generate(), :embeddings) == :ok
+    end
+  end
+
+  # Under Oban's Basic engine the fetched job is committed to state="executing" BEFORE
+  # perform/1 runs, so a job reads its OWN row when it counts executing slots. Without
+  # self-exclusion the running job counts itself: cap=1 (:ingestion) wedges forever and
+  # every gated queue silently loses one slot (effective cap-1). gate/3 threads the
+  # job_id so the running job is excluded. These tests seed the job-under-test's own
+  # executing row — the real executing-state semantics the bare-perform tests miss.
+  describe "self-exclusion: the running job never counts itself (US-36.2 wedge fix)" do
+    test "a lone executing :ingestion job (cap=1) is NOT gated once it excludes itself" do
+      tenant = Ecto.UUID.generate()
+
+      job =
+        seed_job(tenant, :ingestion, "executing",
+          worker: "Loopctl.Workers.ContentIngestionWorker"
+        )
+
+      # cap for :ingestion is 1. The UNSCOPED count includes the running job...
+      assert FairShare.executing_count(tenant, :ingestion) == 1
+      # ...so a naive `>= cap` (no exclusion) WEDGES: 1 >= 1 → over → snooze forever.
+      assert FairShare.over_fair_share?(tenant, :ingestion, nil)
+      # Excluding the job itself: 0 >= 1 → false → the lone job RUNS immediately.
+      refute FairShare.over_fair_share?(tenant, :ingestion, job.id)
+      assert FairShare.gate(tenant, :ingestion, job.id) == :ok
+    end
+
+    test "a SECOND concurrent executing job for the same tenant on cap=1 IS still gated" do
+      tenant = Ecto.UUID.generate()
+
+      running =
+        seed_job(tenant, :ingestion, "executing",
+          worker: "Loopctl.Workers.ContentIngestionWorker"
+        )
+
+      # Another of the tenant's jobs is genuinely executing concurrently.
+      seed_job(tenant, :ingestion, "executing", worker: "Loopctl.Workers.ContentIngestionWorker")
+
+      # Excluding self still leaves 1 real peer >= cap(1) → snooze. Contention detected,
+      # queue not wedged: the self-exclusion narrows the count, it doesn't disable it.
+      assert {:snooze, _n} = FairShare.gate(tenant, :ingestion, running.id)
+    end
+
+    test "self-exclusion gives a tenant its FULL cap (embeddings 3), not cap-1" do
+      tenant = Ecto.UUID.generate()
+      cap = ObanConfig.tenant_fair_share_cap(:embeddings)
+
+      # cap-1 OTHER executing jobs plus THIS running job = cap rows in the table.
+      for _ <- 1..(cap - 1), do: seed_job(tenant, :embeddings, "executing")
+      running = seed_job(tenant, :embeddings, "executing")
+
+      # Unscoped count = cap; a naive `cap >= cap` would snooze — the silent
+      # under-utilization (effective cap-1) the medium finding describes.
+      assert FairShare.executing_count(tenant, :embeddings) == cap
+      # Excluding self = cap-1 < cap → the tenant's cap-th job RUNS: it gets all `cap`
+      # concurrent slots, exactly as documented.
+      refute FairShare.over_fair_share?(tenant, :embeddings, running.id)
+
+      # One genuinely-additional concurrent job (cap peers + self) → cap >= cap → snooze.
+      seed_job(tenant, :embeddings, "executing")
+      assert FairShare.over_fair_share?(tenant, :embeddings, running.id)
+    end
+  end
+end

--- a/test/loopctl/oban/fair_share_test.exs
+++ b/test/loopctl/oban/fair_share_test.exs
@@ -135,12 +135,14 @@ defmodule Loopctl.Oban.FairShareTest do
   end
 
   # Under Oban's Basic engine the fetched job is committed to state="executing" BEFORE
-  # perform/1 runs, so a job reads its OWN row when it counts executing slots. Without
-  # self-exclusion the running job counts itself: cap=1 (:ingestion) wedges forever and
-  # every gated queue silently loses one slot (effective cap-1). gate/3 threads the
-  # job_id so the running job is excluded. These tests seed the job-under-test's own
-  # executing row — the real executing-state semantics the bare-perform tests miss.
-  describe "self-exclusion: the running job never counts itself (US-36.2 wedge fix)" do
+  # perform/1 runs, so a job reads its OWN row when it counts executing slots. The gate
+  # decides by RANK: a job snoozes only if `cap` or more of the tenant's OTHER executing
+  # jobs have a strictly LOWER id (`id < job_id`). That self-excludes the running job
+  # for free (cap=1 :ingestion never wedges; a gated queue gives the full cap, not
+  # cap-1) AND deterministically breaks the co-fetch symmetry (see the next describe).
+  # These tests seed the job-under-test's own executing row — the real executing-state
+  # semantics the bare-perform tests miss.
+  describe "rank self-exclusion: the running job never counts itself (US-36.2 wedge fix)" do
     test "a lone executing :ingestion job (cap=1) is NOT gated once it excludes itself" do
       tenant = Ecto.UUID.generate()
 
@@ -151,47 +153,101 @@ defmodule Loopctl.Oban.FairShareTest do
 
       # cap for :ingestion is 1. The UNSCOPED count includes the running job...
       assert FairShare.executing_count(tenant, :ingestion) == 1
-      # ...so a naive `>= cap` (no exclusion) WEDGES: 1 >= 1 → over → snooze forever.
+      # ...so a naive `>= cap` (nil job_id, no rank) WEDGES: 1 >= 1 → over → snooze forever.
       assert FairShare.over_fair_share?(tenant, :ingestion, nil)
-      # Excluding the job itself: 0 >= 1 → false → the lone job RUNS immediately.
+      # Rank of the lone job: 0 lower-id peers >= 1 → false → the lone job RUNS immediately.
       refute FairShare.over_fair_share?(tenant, :ingestion, job.id)
       assert FairShare.gate(tenant, :ingestion, job.id) == :ok
     end
 
-    test "a SECOND concurrent executing job for the same tenant on cap=1 IS still gated" do
+    test "of two concurrent same-tenant jobs on cap=1, the LOWER-id runs and the HIGHER-id snoozes" do
       tenant = Ecto.UUID.generate()
 
-      running =
+      first =
         seed_job(tenant, :ingestion, "executing",
           worker: "Loopctl.Workers.ContentIngestionWorker"
         )
 
-      # Another of the tenant's jobs is genuinely executing concurrently.
-      seed_job(tenant, :ingestion, "executing", worker: "Loopctl.Workers.ContentIngestionWorker")
+      second =
+        seed_job(tenant, :ingestion, "executing",
+          worker: "Loopctl.Workers.ContentIngestionWorker"
+        )
 
-      # Excluding self still leaves 1 real peer >= cap(1) → snooze. Contention detected,
-      # queue not wedged: the self-exclusion narrows the count, it doesn't disable it.
-      assert {:snooze, _n} = FairShare.gate(tenant, :ingestion, running.id)
+      # `first` (lowest id) has 0 lower-id peers >= cap(1) → false → RUNS.
+      assert FairShare.gate(tenant, :ingestion, first.id) == :ok
+      # `second` has 1 lower-id peer (`first`) >= cap(1) → snoozes. Exactly ONE of the
+      # two concurrent jobs is gated — contention detected, queue not wedged, and the
+      # older job (not an arbitrary one) keeps its slot.
+      assert {:snooze, _n} = FairShare.gate(tenant, :ingestion, second.id)
     end
 
-    test "self-exclusion gives a tenant its FULL cap (embeddings 3), not cap-1" do
+    test "rank gives a tenant its FULL cap (embeddings 3), not cap-1; a NEWER job snoozes" do
       tenant = Ecto.UUID.generate()
       cap = ObanConfig.tenant_fair_share_cap(:embeddings)
 
-      # cap-1 OTHER executing jobs plus THIS running job = cap rows in the table.
+      # cap-1 OTHER executing jobs (lower ids) plus THIS running job = cap rows.
       for _ <- 1..(cap - 1), do: seed_job(tenant, :embeddings, "executing")
       running = seed_job(tenant, :embeddings, "executing")
 
       # Unscoped count = cap; a naive `cap >= cap` would snooze — the silent
       # under-utilization (effective cap-1) the medium finding describes.
       assert FairShare.executing_count(tenant, :embeddings) == cap
-      # Excluding self = cap-1 < cap → the tenant's cap-th job RUNS: it gets all `cap`
-      # concurrent slots, exactly as documented.
+      # Rank of `running` = cap-1 lower-id peers < cap → the tenant's cap-th job RUNS:
+      # it gets all `cap` concurrent slots, exactly as documented.
       refute FairShare.over_fair_share?(tenant, :embeddings, running.id)
 
-      # One genuinely-additional concurrent job (cap peers + self) → cap >= cap → snooze.
-      seed_job(tenant, :embeddings, "executing")
-      assert FairShare.over_fair_share?(tenant, :embeddings, running.id)
+      # One genuinely-additional, NEWER concurrent job (higher id). The rank decision
+      # gates the NEWER arrival (rank cap >= cap → snooze), NOT the already-running
+      # `running` (still rank cap-1 → runs): an executing job is never retroactively
+      # pushed to snooze by a later arrival.
+      newer = seed_job(tenant, :embeddings, "executing")
+      assert FairShare.over_fair_share?(tenant, :embeddings, newer.id)
+      refute FairShare.over_fair_share?(tenant, :embeddings, running.id)
+    end
+  end
+
+  # The Basic engine commits a whole width-sized fetch to state="executing" in ONE txn
+  # BEFORE dispatch, so under a one-tenant burst ALL co-fetched jobs are executing when
+  # each runs its gate. A naive "count OTHER peers >= cap" would make every co-fetched
+  # job see the others and snooze together — both slots idle. Under the default jitter
+  # that desyncs and self-heals, but at the PERMITTED jitter=0 the jobs stay lockstep,
+  # are co-fetched every cycle, and NEVER complete: a permanent livelock. The rank
+  # decision admits exactly the lowest `cap` by id, DETERMINISTICALLY — independent of
+  # read order AND of jitter — so "all snooze" is impossible and jitter=0 is safe.
+  describe "co-fetch determinism: exactly the lowest-cap proceed, the rest snooze (US-36.2 livelock fix)" do
+    test "cap=1 (:ingestion): of a co-fetched batch exactly ONE proceeds — never all-snooze" do
+      tenant = Ecto.UUID.generate()
+
+      jobs =
+        for _ <- 1..4 do
+          seed_job(tenant, :ingestion, "executing",
+            worker: "Loopctl.Workers.ContentIngestionWorker"
+          )
+        end
+
+      results = Enum.map(jobs, &FairShare.gate(tenant, :ingestion, &1.id))
+      proceeded = Enum.count(results, &(&1 == :ok))
+      snoozed = Enum.count(results, &match?({:snooze, _}, &1))
+
+      # cap=1 → exactly one proceeds, three snooze. Crucially NOT zero proceeding (the
+      # all-snooze livelock the medium finding describes).
+      assert proceeded == 1
+      assert snoozed == 3
+      # And it is deterministically the LOWEST-id job that proceeds.
+      lowest = Enum.min_by(jobs, & &1.id)
+      assert FairShare.gate(tenant, :ingestion, lowest.id) == :ok
+    end
+
+    test "cap=3 (:embeddings): exactly the lowest 3 of a co-fetched batch of 5 proceed" do
+      tenant = Ecto.UUID.generate()
+      cap = ObanConfig.tenant_fair_share_cap(:embeddings)
+      assert cap == 3
+
+      jobs = for _ <- 1..5, do: seed_job(tenant, :embeddings, "executing")
+      {lowest_cap, rest} = jobs |> Enum.sort_by(& &1.id) |> Enum.split(cap)
+
+      assert Enum.all?(lowest_cap, &(FairShare.gate(tenant, :embeddings, &1.id) == :ok))
+      assert Enum.all?(rest, &match?({:snooze, _}, FairShare.gate(tenant, :embeddings, &1.id)))
     end
   end
 end

--- a/test/loopctl/oban_config_test.exs
+++ b/test/loopctl/oban_config_test.exs
@@ -236,6 +236,57 @@ defmodule Loopctl.ObanConfigTest do
     end
   end
 
+  describe "tenant_fair_share_cap/1 + fair_share_config/0 (US-36.2)" do
+    test "derives ceil(width/2) floored at 1 from the queue width when unset" do
+      assert ObanConfig.tenant_fair_share_cap(:embeddings) == 3
+      assert ObanConfig.tenant_fair_share_cap(:knowledge) == 2
+      assert ObanConfig.tenant_fair_share_cap(:ingestion) == 1
+      assert ObanConfig.tenant_fair_share_cap(:verification) == 1
+    end
+
+    test "a malformed cap fails LOUD (raises) rather than silently defaulting" do
+      # Called at gate time, but the crash surfaces there rather than fail-open — and
+      # fair_share_config/0 (below) forces this same parse at BOOT so it never gets
+      # that far in a running node.
+      assert_raise ArgumentError, ~r/positive integer/, fn ->
+        ObanConfig.queue_size("bogus", 3)
+      end
+    end
+
+    test "fair_share_config/0 resolves every cap + the snooze base/jitter (CI defaults)" do
+      config = ObanConfig.fair_share_config()
+
+      # One cap per configured queue, all >= 1 (the never-wedge invariant).
+      assert Keyword.keys(config.caps) == Keyword.keys(ObanConfig.queues())
+      assert Enum.all?(config.caps, fn {_q, cap} -> cap >= 1 end)
+      assert Keyword.get(config.caps, :embeddings) == 3
+      assert config.snooze_base_seconds == 5
+      assert config.snooze_jitter_seconds == 5
+    end
+
+    @tag :tmp_dir
+    test "a malformed OBAN_TENANT_FAIRSHARE_<QUEUE> cap aborts boot (fail-loud, like OBAN_QUEUE_*)",
+         %{tmp_dir: tmp_dir} do
+      # config/runtime.exs evaluates `ObanConfig.fair_share_config()` at the top level,
+      # so a fat-fingered cap fails LOUD at boot (non-zero exit) instead of surviving to
+      # gate call-time where the count path fails OPEN and would SILENTLY disable
+      # fairness on that queue. This is the US-36.2 medium finding's fix.
+      {output, exit_code} = run_boot(tmp_dir, [{"OBAN_TENANT_FAIRSHARE_EMBEDDINGS", "lots"}])
+
+      assert exit_code != 0
+      assert output =~ "positive integer"
+    end
+
+    @tag :tmp_dir
+    test "a malformed OBAN_TENANT_FAIRSHARE_SNOOZE_JITTER aborts boot too",
+         %{tmp_dir: tmp_dir} do
+      {output, exit_code} = run_boot(tmp_dir, [{"OBAN_TENANT_FAIRSHARE_SNOOZE_JITTER", "-1"}])
+
+      assert exit_code != 0
+      assert output =~ "non-negative integer"
+    end
+  end
+
   # Runs `script` (must bind a `result` variable) in a fresh `mix run --no-start`
   # subprocess with `env` applied ONLY to that child process, then reads back the
   # term `script` wrote to `result_path` via :erlang.term_to_binary/1. Keeps this

--- a/test/loopctl/workers/fair_share_gate_test.exs
+++ b/test/loopctl/workers/fair_share_gate_test.exs
@@ -1,0 +1,199 @@
+defmodule Loopctl.Workers.FairShareGateTest do
+  @moduledoc """
+  US-36.2 — the per-tenant fair-share gate as exercised through the contended-queue
+  workers themselves.
+
+  Covers: a worker snoozes when its tenant is over fair share and runs after a drain
+  (TC-36.2.2 / AC-36.2.2), the FAIRNESS OUTCOME CLASS — a flooding tenant does not
+  starve another (TC-36.2.3 / AC-36.2.3), and the no-op-when-uncontended guarantee
+  (TC-36.2.4 / AC-36.2.5). We assert outcome CLASSES (snooze vs runs), never an exact
+  instantaneous slot count, per the async/inline-drain flake lesson.
+  """
+  use Loopctl.DataCase, async: true
+  use Oban.Testing, repo: Loopctl.Repo
+
+  setup :verify_on_exit!
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge
+  alias Loopctl.ObanConfig
+  alias Loopctl.Workers.ArticleEmbeddingWorker
+  alias Loopctl.Workers.PromotionEvalWorker
+
+  # Simulate an occupied executing slot without running a job (a direct insert does
+  # NOT trigger the inline test executor).
+  defp seed_executing(tenant_id, queue, n) do
+    for _ <- 1..n do
+      %{"tenant_id" => tenant_id}
+      |> Oban.Job.new(worker: "Loopctl.Workers.ArticleEmbeddingWorker", queue: to_string(queue))
+      |> Ecto.Changeset.put_change(:state, "executing")
+      |> AdminRepo.insert!()
+    end
+  end
+
+  defp published_article(tenant_id) do
+    # Create as :draft (avoids the inline embedding enqueue during create), then
+    # flip to :published directly so perform/1 is tested in isolation.
+    {:ok, article} =
+      Knowledge.create_article(tenant_id, %{
+        title: "Fair-share Article #{System.unique_integer([:positive])}",
+        body: "Body for fair-share gate test.",
+        category: :pattern,
+        status: :draft
+      })
+
+    article
+    |> Ecto.Changeset.change(%{status: :published})
+    |> AdminRepo.update!()
+  end
+
+  defp run_embedding(article_id, tenant_id, job_id \\ nil) do
+    ArticleEmbeddingWorker.perform(%Oban.Job{
+      id: job_id,
+      args: %{"article_id" => article_id, "tenant_id" => tenant_id}
+    })
+  end
+
+  # Seed the job-under-test's OWN row as `executing` (what the Basic engine commits
+  # before dispatching perform/1) and return it, so the worker exercises the real
+  # self-count path — not a detached %Oban.Job{} that is absent from the table.
+  defp seed_self_executing(article_id, tenant_id) do
+    %{"article_id" => article_id, "tenant_id" => tenant_id}
+    |> Oban.Job.new(worker: "Loopctl.Workers.ArticleEmbeddingWorker", queue: "embeddings")
+    |> Ecto.Changeset.put_change(:state, "executing")
+    |> AdminRepo.insert!()
+  end
+
+  describe "TC-36.2.2 — worker snoozes when over fair share, then runs on drain" do
+    test "returns {:snooze, n} (job not failed/discarded) and runs once under cap" do
+      tenant = fixture(:tenant)
+      cap = ObanConfig.tenant_fair_share_cap(:embeddings)
+
+      # Tenant is AT its cap of executing :embeddings slots.
+      seed_executing(tenant.id, :embeddings, cap)
+      article = published_article(tenant.id)
+
+      # The gate yields the slot: a snooze reschedules WITHOUT consuming an attempt
+      # and never fails/discards the job — fairness degrades to latency, not loss.
+      assert {:snooze, n} = run_embedding(article.id, tenant.id)
+      assert is_integer(n) and n > 0
+
+      # Drain: the executing slots free up (simulate the queue moving on).
+      AdminRepo.delete_all(from(j in "oban_jobs", where: j.state == "executing"))
+
+      # Now under cap, the SAME job runs to completion (loss-free — it was never
+      # dropped). One embedding client call for the real run.
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:ok, List.duplicate(0.1, 1536)}
+      end)
+
+      assert :ok = run_embedding(article.id, tenant.id)
+      {:ok, stored} = Knowledge.get_article_with_embedding(tenant.id, article.id)
+      assert stored.embedding != nil
+    end
+  end
+
+  describe "TC-36.2.4 — no snooze / no latency when uncontended (AC-36.2.5)" do
+    test "an uncontended single-tenant job runs immediately without snoozing" do
+      tenant = fixture(:tenant)
+      article = published_article(tenant.id)
+
+      # No executing slots seeded → the gate is a pure no-op.
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:ok, List.duplicate(0.2, 1536)}
+      end)
+
+      assert :ok = run_embedding(article.id, tenant.id)
+    end
+
+    test "runs even when its OWN row is already `executing` (self-count must not gate)" do
+      # Regression for the US-36.2 wedge: the Basic engine commits the job to
+      # `executing` before perform/1, so it reads its OWN row. A single uncontended
+      # job (its own row is the ONLY executing row) must still run, not snooze. On a
+      # cap=1 queue this is the difference between working and a permanent wedge; here
+      # on :embeddings it also proves the worker threads its job id into the gate.
+      tenant = fixture(:tenant)
+      article = published_article(tenant.id)
+      self_job = seed_self_executing(article.id, tenant.id)
+
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:ok, List.duplicate(0.25, 1536)}
+      end)
+
+      # Without self-exclusion the worker would see 1 executing (itself) and, on any
+      # cap=1 queue, snooze forever. With the fix its own row is excluded → runs.
+      assert :ok = run_embedding(article.id, tenant.id, self_job.id)
+      {:ok, stored} = Knowledge.get_article_with_embedding(tenant.id, article.id)
+      assert stored.embedding != nil
+    end
+
+    test "gets its FULL cap: cap-1 peers + its OWN executing row still runs (not cap-1)" do
+      # Finding-3 regression: with self-counting, cap-1 real peers + the job itself =
+      # cap → `cap >= cap` → snooze, so effective concurrency is cap-1. Excluding self
+      # → cap-1 < cap → the cap-th job runs, giving the tenant its documented `cap`.
+      tenant = fixture(:tenant)
+      cap = ObanConfig.tenant_fair_share_cap(:embeddings)
+      article = published_article(tenant.id)
+
+      # cap-1 OTHER executing peers for this tenant, plus the job's own executing row.
+      seed_executing(tenant.id, :embeddings, cap - 1)
+      self_job = seed_self_executing(article.id, tenant.id)
+
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:ok, List.duplicate(0.35, 1536)}
+      end)
+
+      assert :ok = run_embedding(article.id, tenant.id, self_job.id)
+      {:ok, stored} = Knowledge.get_article_with_embedding(tenant.id, article.id)
+      assert stored.embedding != nil
+    end
+  end
+
+  describe "TC-36.2.3 — flooding tenant does not starve another (OUTCOME CLASS)" do
+    test "tenant B makes progress while tenant A is over its fair share" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      cap = ObanConfig.tenant_fair_share_cap(:embeddings)
+
+      # Tenant A floods the queue: at/over its fair share of executing slots.
+      seed_executing(tenant_a.id, :embeddings, cap + 2)
+
+      article_a = published_article(tenant_a.id)
+      article_b = published_article(tenant_b.id)
+
+      # A's next job YIELDS (snooze) — A cannot monopolize beyond its share...
+      assert {:snooze, _} = run_embedding(article_a.id, tenant_a.id)
+
+      # ...while B — whose OWN executing count is 0, well under cap — RUNS. B is not
+      # stuck behind all of A's in-flight work (the fairness invariant that matters).
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:ok, List.duplicate(0.3, 1536)}
+      end)
+
+      assert :ok = run_embedding(article_b.id, tenant_b.id)
+      {:ok, stored_b} = Knowledge.get_article_with_embedding(tenant_b.id, article_b.id)
+      assert stored_b.embedding != nil
+    end
+  end
+
+  describe "PromotionEvalWorker per-tenant clause is fair-share-gated (7th :knowledge worker)" do
+    test "snoozes BEFORE any extraction LLM call when the tenant is over its :knowledge share" do
+      # PromotionEvalWorker is the seventh tenant-scoped :knowledge worker; its per-tenant
+      # clause runs a not-sub-second extraction LLM call. It must observe the same gate as
+      # the other six. Over the tenant's :knowledge fair share, it yields {:snooze, n}
+      # BEFORE PromotionEval.run — so no extraction expectation is set here; reaching
+      # run_eval (an unstubbed LLM call) would raise and fail the test.
+      tenant = fixture(:tenant)
+      cap = ObanConfig.tenant_fair_share_cap(:knowledge)
+      seed_executing(tenant.id, :knowledge, cap)
+
+      assert {:snooze, n} =
+               PromotionEvalWorker.perform(%Oban.Job{
+                 id: nil,
+                 args: %{"tenant_id" => tenant.id}
+               })
+
+      assert is_integer(n) and n > 0
+    end
+  end
+end

--- a/test/loopctl/workers/memory_embedding_worker_test.exs
+++ b/test/loopctl/workers/memory_embedding_worker_test.exs
@@ -4,12 +4,24 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorkerTest do
 
   setup :verify_on_exit!
 
+  alias Loopctl.AdminRepo
   alias Loopctl.Knowledge
   alias Loopctl.Memory
+  alias Loopctl.ObanConfig
   alias Loopctl.Workers.MemoryEmbeddingWorker
 
   defp job(memory_id, tenant_id) do
     %Oban.Job{args: %{"memory_id" => memory_id, "tenant_id" => tenant_id}}
+  end
+
+  # Seed a raw executing oban_jobs row (no RLS on oban_jobs → AdminRepo) to occupy a
+  # tenant's :embeddings slot, exactly as FairShare counts it. Direct insert does NOT
+  # run the job (unlike Oban.insert under :inline).
+  defp seed_executing_embedding(tenant_id, worker) do
+    %{"tenant_id" => tenant_id}
+    |> Oban.Job.new(worker: worker, queue: "embeddings")
+    |> Ecto.Changeset.put_change(:state, "executing")
+    |> AdminRepo.insert!()
   end
 
   describe "perform/1 success" do
@@ -31,6 +43,58 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorkerTest do
       {:ok, reloaded} = Memory.get_memory_for_embedding(tenant.id, memory.id)
       refute is_nil(reloaded.embedding)
       assert is_binary(reloaded.embedding_content_hash)
+    end
+  end
+
+  # --- US-36.2: per-tenant fair-share gate on the contended :embeddings queue ---
+  #
+  # :embeddings has TWO tenant-scoped per-item fan-out producers — this worker AND
+  # ArticleEmbeddingWorker — and the gate counts executing slots by (queue, state,
+  # tenant) regardless of worker. So this worker MUST gate too, else a one-tenant
+  # memory-embed burst monopolizes the queue against BOTH producers.
+  describe "perform/1 fair-share gate (US-36.2)" do
+    test "snoozes (loss-free) when the tenant is at/above its :embeddings fair share" do
+      tenant = fixture(:tenant)
+      cap = ObanConfig.tenant_fair_share_cap(:embeddings)
+
+      # `cap` of the tenant's embedding jobs are already executing (lower ids)...
+      for _ <- 1..cap do
+        seed_executing_embedding(tenant.id, "Loopctl.Workers.ArticleEmbeddingWorker")
+      end
+
+      # ...so THIS memory-embed job (higher id → rank cap >= cap) is over its fair share.
+      # It must snooze at the TOP of perform/1 — no provider call, no memory fetch.
+      this_job = seed_executing_embedding(tenant.id, "Loopctl.Workers.MemoryEmbeddingWorker")
+
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, 0, fn _t, _text ->
+        flunk("provider must not be called when the fair-share gate snoozes")
+      end)
+
+      assert {:snooze, _n} =
+               MemoryEmbeddingWorker.perform(%Oban.Job{
+                 id: this_job.id,
+                 args: %{"memory_id" => Ecto.UUID.generate(), "tenant_id" => tenant.id}
+               })
+    end
+
+    test "runs (embeds) when the tenant is under its :embeddings fair share" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+      memory = fixture(:memory, %{tenant_id: tenant.id, subject_id: "s", text: "under cap"})
+
+      # No other executing embedding jobs for this tenant → rank 0 < cap → gate passes.
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
+        {:ok, List.duplicate(0.2, 1536)}
+      end)
+
+      assert :ok =
+               MemoryEmbeddingWorker.perform(%Oban.Job{
+                 id: 1,
+                 args: %{"memory_id" => memory.id, "tenant_id" => tenant.id}
+               })
+
+      {:ok, reloaded} = Memory.get_memory_for_embedding(tenant.id, memory.id)
+      refute is_nil(reloaded.embedding)
     end
   end
 


### PR DESCRIPTION
## US-36.2 — Per-tenant in-flight fair-share gate on the contended queues

Adds a cooperative-yield fair-share gate (`Loopctl.Oban.FairShare`) for the contended `:embeddings` / `:knowledge` / `:ingestion` queues on Oban's Basic engine. At the top of a contended-queue worker's tenant-scoped `perform/1`, the gate asks whether the tenant already holds at/above its fair share (`ceil(width/2)`, floored at 1) of that queue's executing slots; if so it returns `{:snooze, n}` (loss-free — no attempt consumed), yielding the slot so one tenant's bulk burst cannot starve others. Fairness degrades to latency, never to loss.

### Review fixes folded in
- **Self-count wedge**: Basic engine commits a job to `executing` before dispatching `perform/1`; `gate/3` threads `Oban.Job.id` and excludes it (`j.id != ^job_id`) so a lone job on `:ingestion` (cap=1) is not wedged and gated queues keep full concurrency.
- **Rank-based fair-share**: replaced count-of-executing-peers with a deterministic rank (snooze only if cap-or-more same-tenant executing jobs have a strictly lower id), fixing a permanent livelock at jitter=0 when the Basic engine co-fetches a width-sized batch.
- **Gate the memory-embed producer**: `MemoryEmbeddingWorker` (the second tenant-scoped fan-out producer on `:embeddings`) is now gated alongside `ArticleEmbeddingWorker`.
- **Boot-validate caps**: `OBAN_TENANT_FAIRSHARE_*` knobs validated at boot via `ObanConfig.fair_share_config/0` from `runtime.exs`, so a malformed cap aborts the node loudly instead of failing open at call-time.
- Corrected the `in_flight_count` moduledoc cost claim after measuring under a one-tenant flood (Index Scan on `(state,queue)`, ~3.5ms, bounded by the 2s statement_timeout).

Adds gate tests for `MemoryEmbeddingWorker`, rank/co-fetch determinism tests, and boot-abort tests for malformed fair-share env vars.