### PR TITLE
Batch-ingest backpressure: 429 when a tenant's in-flight ingestion backlog is too large

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -63,6 +63,16 @@ config :loopctl, Oban,
 # introspectable; the gate itself re-reads env at call time (config-based DI).
 config :loopctl, :fair_share_config, Loopctl.ObanConfig.fair_share_config()
 
+# US-36.3: validate the batch-ingest backlog knob (OBAN_INGEST_BACKLOG_MAX) at BOOT,
+# alongside the fair-share knobs above and the queue widths. `ingest_backlog_max/0`
+# calls `queue_size/2`, which RAISES on a present-but-malformed value — so a
+# fat-fingered live-tuning typo aborts the node LOUD here (like a bad OBAN_QUEUE_* or
+# OBAN_TENANT_FAIRSHARE_*), instead of surfacing only at CALL time as a stream of
+# per-request 500s on the batch-ingest endpoint at the worst possible moment. Stored so
+# the resolved boot value is introspectable; the gate re-reads env at call time
+# (config-based DI).
+config :loopctl, :ingest_backlog_max, Loopctl.ObanConfig.ingest_backlog_max()
+
 # Cloak Vault — key from environment in all environments where CLOAK_KEY is set.
 # In production, CLOAK_KEY is required — startup fails if it is missing.
 if config_env() == :prod do

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -73,6 +73,15 @@ config :loopctl, :fair_share_config, Loopctl.ObanConfig.fair_share_config()
 # (config-based DI).
 config :loopctl, :ingest_backlog_max, Loopctl.ObanConfig.ingest_backlog_max()
 
+# US-36.3 (review): validate the backlog-429 Retry-After knob
+# (OBAN_INGEST_BACKLOG_RETRY_AFTER) at BOOT too, same rationale as the threshold above —
+# a fat-fingered value aborts the node LOUD here instead of surfacing as per-request 500s
+# on the ingest endpoints. Stored so the resolved boot value is introspectable; the gate
+# re-reads env at call time (config-based DI).
+config :loopctl,
+       :ingest_backlog_retry_after_seconds,
+       Loopctl.ObanConfig.ingest_backlog_retry_after_seconds()
+
 # Cloak Vault — key from environment in all environments where CLOAK_KEY is set.
 # In production, CLOAK_KEY is required — startup fails if it is missing.
 if config_env() == :prod do

--- a/config/test.exs
+++ b/config/test.exs
@@ -268,6 +268,11 @@ config :loopctl, :scale_alerts_config_checker, Loopctl.MockScaleAlertsConfigChec
 # ScaleMetrics.count_oban_executing_orphans/0.
 config :loopctl, :oban_orphan_count_checker, Loopctl.MockObanOrphanCountChecker
 
+# US-36.3: batch-ingest backlog admission gate's count DI seam. Default stub in
+# DataCase.stub_all_defaults/0 delegates to the real FairShare.in_flight_count/2;
+# the fail-open test overrides it to raise.
+config :loopctl, :ingestion_backlog_counter, Loopctl.MockBacklogCounter
+
 # DI: Use mock rate limiter in tests
 config :loopctl, :rate_limiter, Loopctl.MockRateLimiter
 

--- a/lib/loopctl/api_spec/schemas.ex
+++ b/lib/loopctl/api_spec/schemas.ex
@@ -125,6 +125,61 @@ defmodule Loopctl.ApiSpec.Schemas do
     })
   end
 
+  defmodule IngestionBacklogError do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "IngestionBacklogError",
+      description:
+        "Batch-ingest backlog backpressure (HTTP 429). Distinct from the generic " <>
+          "request RateLimitError: this is triggered BEFORE any item is enqueued when " <>
+          "the calling tenant's in-flight `:ingestion` backlog (non-terminal Oban jobs) " <>
+          "is at/over the `OBAN_INGEST_BACKLOG_MAX` threshold. The rejection is " <>
+          "all-or-nothing — NO jobs from the request are enqueued (no partial pile-up). " <>
+          "The check is tenant-scoped: only the caller's own backlog counts. Unlike the " <>
+          "Hammer request-rate limiter, this response carries a machine-readable " <>
+          "`error.code` of `ingestion_backlog_exceeded`, so dashboards/clients can tell " <>
+          "backlog backpressure apart from the request-rate 429. It DOES set " <>
+          "`Retry-After` (seconds) — back off and retry once the backlog drains.",
+      type: :object,
+      required: [:error],
+      properties: %{
+        error: %Schema{
+          type: :object,
+          required: [:status, :code, :message],
+          properties: %{
+            status: %Schema{type: :integer, example: 429},
+            code: %Schema{
+              type: :string,
+              enum: ["ingestion_backlog_exceeded"],
+              example: "ingestion_backlog_exceeded"
+            },
+            message: %Schema{
+              type: :string,
+              example:
+                "This tenant already has too many in-flight ingestion jobs queued. " <>
+                  "No items from this batch were enqueued. Retry after 5 seconds " <>
+                  "once the backlog drains."
+            },
+            retry_after_seconds: %Schema{type: :integer, example: 5}
+          }
+        }
+      },
+      example: %{
+        error: %{
+          status: 429,
+          code: "ingestion_backlog_exceeded",
+          message:
+            "This tenant already has too many in-flight ingestion jobs queued. " <>
+              "No items from this batch were enqueued. Retry after 5 seconds " <>
+              "once the backlog drains.",
+          retry_after_seconds: 5
+        }
+      }
+    })
+  end
+
   defmodule PaginationMeta do
     @moduledoc false
     require OpenApiSpex

--- a/lib/loopctl/oban/backlog_counter_behaviour.ex
+++ b/lib/loopctl/oban/backlog_counter_behaviour.ex
@@ -1,0 +1,17 @@
+defmodule Loopctl.Oban.BacklogCounterBehaviour do
+  @moduledoc """
+  Behaviour for the in-flight backlog count the batch-ingest admission gate
+  (US-36.3, `LoopctlWeb.KnowledgeIngestionController.create_batch/2`) consults.
+
+  Extracted purely so the count is a config-swappable DI seam. Production/dev
+  resolve it to `Loopctl.Oban.FairShare` (the real bounded, tenant-scoped count);
+  `config/test.exs` maps a Mox mock whose default stub delegates back to the real
+  `FairShare.in_flight_count/2` (so the existing backlog tests exercise the real
+  count unchanged), while the fail-open test overrides it with `Mox.expect/3` to
+  RAISE — deterministically driving the gate's fail-open path (an unmeasurable
+  count must ADMIT the batch, never surface as a generic HTTP 500), mirroring the
+  US-36.2 fair-share gate's own count rescue.
+  """
+  @callback in_flight_count(tenant_id :: binary(), queue :: atom() | binary()) ::
+              non_neg_integer()
+end

--- a/lib/loopctl/oban/backlog_counter_behaviour.ex
+++ b/lib/loopctl/oban/backlog_counter_behaviour.ex
@@ -4,14 +4,18 @@ defmodule Loopctl.Oban.BacklogCounterBehaviour do
   (US-36.3, `LoopctlWeb.KnowledgeIngestionController.create_batch/2`) consults.
 
   Extracted purely so the count is a config-swappable DI seam. Production/dev
-  resolve it to `Loopctl.Oban.FairShare` (the real bounded, tenant-scoped count);
-  `config/test.exs` maps a Mox mock whose default stub delegates back to the real
-  `FairShare.in_flight_count/2` (so the existing backlog tests exercise the real
-  count unchanged), while the fail-open test overrides it with `Mox.expect/3` to
-  RAISE — deterministically driving the gate's fail-open path (an unmeasurable
-  count must ADMIT the batch, never surface as a generic HTTP 500), mirroring the
-  US-36.2 fair-share gate's own count rescue.
+  resolve it to `Loopctl.Oban.FairShare` (the real bounded, tenant-scoped,
+  index-backed count); `config/test.exs` maps a Mox mock whose default stub delegates
+  back to the real `FairShare.in_flight_ingestion_backlog/1` (so the existing backlog
+  tests exercise the real count unchanged), while the fail-open test overrides it with
+  `Mox.expect/3` to RAISE a DB timeout/connection error — deterministically driving the
+  gate's fail-open path (an unmeasurable count must ADMIT the batch, never surface as a
+  generic HTTP 500).
+
+  The count is WORKER-scoped (`worker = ContentIngestionWorker`, the sole `:ingestion`
+  worker) rather than queue-scoped, so it rides the partial index
+  `oban_jobs_ingestion_tenant_idx` and its cost is bounded to the CALLER's own ingestion
+  backlog — see `Loopctl.Oban.FairShare`'s "Cost / index justification".
   """
-  @callback in_flight_count(tenant_id :: binary(), queue :: atom() | binary()) ::
-              non_neg_integer()
+  @callback in_flight_ingestion_backlog(tenant_id :: binary()) :: non_neg_integer()
 end

--- a/lib/loopctl/oban/fair_share.ex
+++ b/lib/loopctl/oban/fair_share.ex
@@ -72,9 +72,9 @@ defmodule Loopctl.Oban.FairShare do
       lowest-id executing job for a tenant always has rank 0 → runs → completes, then
       the next, so every job drains in id (≈ FIFO) order and none starves.
 
-  The public `executing_count/2` / `in_flight_count/2` helpers (`in_flight_count/2`
-  is reused by US-36.3's batch-ingest backlog admission gate — see below) are
-  UNSCOPED counts — they intentionally do NOT apply the
+  The public `executing_count/2` / `in_flight_count/2` / `in_flight_ingestion_backlog/1`
+  helpers (the last is consulted by US-36.3's batch-ingest backlog admission gate — see
+  below) are UNSCOPED counts — they intentionally do NOT apply the
   rank predicate; `id < job_id` belongs only to the gate's decision path. `job_id`
   may be `nil` (a bare `perform/1` struct in a test, off the real dispatch path) —
   then the gate falls back to the plain unscoped executing count `>= cap`.
@@ -88,51 +88,64 @@ defmodule Loopctl.Oban.FairShare do
   text compare. Two counts are exposed:
 
     * `in_flight_count/2` — the broad 4-state set
-      (`available`/`scheduled`/`executing`/`retryable`), the GENERAL helper reused by
-      US-36.3's batch-ingest backlog admission gate (the 429 backpressure check in
-      `LoopctlWeb.KnowledgeIngestionController.create_batch/2`).
+      (`available`/`scheduled`/`executing`/`retryable`) scoped by `queue` — the
+      GENERAL fair-share helper (AC-36.2.1).
+    * `in_flight_ingestion_backlog/1` — the SAME broad 4-state set but scoped by
+      `worker = ContentIngestionWorker` (the sole worker on the `:ingestion` queue),
+      the count US-36.3's batch-ingest backlog admission gate consults (the 429
+      backpressure check in `LoopctlWeb.KnowledgeIngestionController`). Filtering by
+      `worker` rather than `queue` lets the count ride the partial index
+      `oban_jobs_ingestion_tenant_idx` — see "Cost / index justification".
     * `executing_count/2` — only `executing`, the slot-occupancy the fair-share gate
       decides on (AC-36.2.2).
 
   ### Cost / index justification
 
-  The query filters `queue = $1 AND state (= or IN) ... AND args->>'tenant_id' = $2`.
-  Oban's own default index `oban_jobs_state_queue_priority_scheduled_at_id_index`
-  leads with `(state, queue)`, so the planner Index-Scans exactly the NON-TERMINAL
-  population for that `(state, queue)` and applies `args->>'tenant_id'` as a filter
-  over it — the enormous `completed`/`discarded` backlog (pruned after 7 days, but
-  still the bulk of the table) is never touched because `state` is the leading column.
+  Two count SHAPES with two DIFFERENT cost profiles, because US-36.2 and US-36.3 scope
+  the count differently:
 
-  The cost is therefore O(non-terminal rows on that `(state, queue)`), NOT sub-ms
-  unconditionally. Two regimes, both measured on the dev DB:
+  **QUEUE-scoped (`in_flight_count/2`, `executing_count/2` — the fair-share gate).**
+  Filters `queue = $1 AND state (= or IN) ... AND args->>'tenant_id' = $2`. Oban's own
+  default index `oban_jobs_state_queue_priority_scheduled_at_id_index` leads with
+  `(state, queue)`, so the planner Index-Scans exactly the NON-TERMINAL population for
+  that `(state, queue)` and applies `args->>'tenant_id'` as a filter over it. The cost
+  is O(non-terminal rows on that `(state, queue)`) — NOT reduced by the tenant filter
+  under a single-tenant flood — but HARD-BOUNDED by the 2 s statement_timeout. Measured:
+  ~0.05 ms benign (~18k terminal/pruned jobs); ~3.5 ms at a synthesised 10k-non-terminal
+  `:embeddings` flood (`Index Scan … Index Cond ((state,queue))`, tenant a post-Filter,
+  `shared hit≈5591`). This is the gate-internal cost; the gate is off the request path
+  (it runs inside `perform/1`) and already FAILS OPEN on the count, so O(queue-depth)
+  here is acceptable. No new index is warranted for it (a count of N matching rows is
+  inherently O(N) index entries; a `(tenant, queue, state)` index would lead with the
+  high-cardinality tenant expression and fold the whole completed backlog under each
+  tenant — strictly worse for the common case).
 
-    * BENIGN (~18k jobs, all terminal/pruned): the `executing` count is
-      `Index Scan … Index Cond ((state,queue)) … shared hit≈3`, ~0.05 ms; the 4-state
-      count `shared hit≈12`, ~0.05 ms.
-    * ONE-TENANT FLOOD (the scenario this story targets — a 50-item ingest fanning
-      out thousands of contiguous `available` rows): synthesised 5k `available`
-      `:embeddings` rows for one tenant (10k non-terminal on the queue in total) and
-      EXPLAIN-ANALYZEd the 4-state `in_flight_count`. Result: still an
-      `Index Scan using …_state_queue_… (Index Cond ((state,queue)))` with the tenant
-      as a post-Filter — `shared hit≈5591`, **~3.5 ms** at 10k scanned rows. It scans
-      every non-terminal row on the queue (the tenant filter does NOT reduce a
-      single-tenant flood), so the count grows LINEARLY with the queue's non-terminal
-      depth, but stays low-single-digit-ms at the flood sizes this feature contends
-      with and is HARD-BOUNDED by the 2 s `SET LOCAL statement_timeout` below — it can
-      never pin a connection. This bound makes it safe for US-36.3's synchronous
-      per-request admission-gate use; that gate additionally FAILS OPEN if this count
-      raises/times out (an unmeasurable backlog admits the batch, never 500 — see
-      `LoopctlWeb.KnowledgeIngestionController`), and if it ever needs a flood-
-      independent cost it should cap the count (e.g. `LIMIT`-bounded existence probe),
-      not add an index (see next).
+  **WORKER-scoped (`in_flight_ingestion_backlog/1` — US-36.3's SYNCHRONOUS request-path
+  admission gate).** This one runs on `POST /knowledge/ingest[/batch]`, so its cost must
+  be bounded by the CALLER's own backlog, not the fleet-wide `:ingestion` depth. It
+  therefore filters `worker = 'Loopctl.Workers.ContentIngestionWorker' AND state IN ...
+  AND args->>'tenant_id' = $1` — `worker` instead of `queue` (equivalent, since
+  ContentIngestionWorker is the SOLE worker on the `:ingestion` queue). That predicate
+  matches the partial COMPOSITE index `oban_jobs_ingestion_tenant_idx`
+  (`((args->>'tenant_id'), inserted_at DESC, id DESC) WHERE worker = ContentIngestionWorker`,
+  migration 20260713020000): the planner does a Bitmap/Index Scan with
+  `Index Cond ((args->>'tenant_id') = $1)` — seeking straight to the caller's own
+  ingestion rows and folding `state` as a cheap recheck. Cost is therefore O(the CALLER's
+  own ingestion rows in the partial index — its recent history, since the index carries
+  no `state` predicate but Oban prunes terminal `:ingestion` jobs after 7 days), NOT
+  O(fleet-wide non-terminal on the `:ingestion` queue). A noisy tenant's flood inflates
+  only its OWN scan. This is what makes AC-36.3.4's "cheap (single bounded count)" TRUE in cost, not
+  merely in wall-clock: a noisy tenant's flood inflates only that tenant's own count, and
+  the query no longer scans other tenants' rows — materially shrinking both the per-query
+  cost AND the time it holds one of AdminRepo's 3 connections (the auth-hot-path pool), so
+  the cross-tenant noisy-neighbor amplification of a fleet-wide scan is removed. Still
+  HARD-BOUNDED by the 2 s statement_timeout and the gate still FAILS OPEN on
+  raise/timeout (see `LoopctlWeb.KnowledgeIngestionController`), so the timeout is now
+  only reachable at a per-tenant backlog far larger than the threshold the gate enforces.
 
-  NO new index is warranted. A count of N matching rows is inherently O(N) index
-  entries even with a perfect covering index, so no index makes a single-tenant flood
-  count sub-linear; and a `(args->>'tenant_id', queue, state)` index would be strictly
-  WORSE for the common case, leading with the high-cardinality tenant expression and
-  folding the whole completed backlog under each tenant. Each count runs under a
-  per-query `SET LOCAL statement_timeout` (pgbouncer-safe — a startup `:parameters`
-  timeout is rejected by Fly's pgbouncer with 08P01; see `Loopctl.HeavyRead`).
+  Each count runs under a per-query `SET LOCAL statement_timeout` (pgbouncer-safe — a
+  startup `:parameters` timeout is rejected by Fly's pgbouncer with 08P01; see
+  `Loopctl.HeavyRead`).
   """
 
   import Ecto.Query, only: [from: 2]
@@ -142,14 +155,21 @@ defmodule Loopctl.Oban.FairShare do
   alias Loopctl.AdminRepo
   alias Loopctl.ObanConfig
 
-  # `in_flight_count/2` is the broad non-terminal count US-36.3's batch-ingest
-  # admission gate consults; declaring the behaviour makes FairShare the default
-  # (production) implementation of that config-swappable DI seam.
+  # `in_flight_ingestion_backlog/1` is the worker-scoped, index-backed backlog count
+  # US-36.3's batch-ingest admission gate consults; declaring the behaviour makes
+  # FairShare the default (production) implementation of that config-swappable DI seam.
   @behaviour Loopctl.Oban.BacklogCounterBehaviour
 
   # The four non-terminal Oban states — the GENERAL in-flight set (AC-36.2.1),
   # shared with US-36.3's batch-ingest backlog admission gate.
   @non_terminal_states ~w(available scheduled executing retryable)
+
+  # The sole worker on the `:ingestion` queue. US-36.3's admission-gate count scopes
+  # by this worker (not by queue) so the count rides the partial index
+  # `oban_jobs_ingestion_tenant_idx` (WHERE worker = this) — see the moduledoc's
+  # "Cost / index justification" (WORKER-scoped). Kept in sync with
+  # `Loopctl.Workers.ContentIngestionWorker`'s `queue: :ingestion`.
+  @ingestion_worker "Loopctl.Workers.ContentIngestionWorker"
 
   # Bound the read on the hot, Oban-owned oban_jobs table. Generous vs the measured
   # sub-ms cost, but a hard ceiling so a pathological plan can never pin a slot on
@@ -219,13 +239,30 @@ defmodule Loopctl.Oban.FairShare do
 
   @doc """
   Broad in-flight count for `tenant_id` on `queue` across the four non-terminal
-  states (`available`/`scheduled`/`executing`/`retryable`) — AC-36.2.1. This is the
-  GENERAL helper US-36.3's batch-ingest backlog admission gate reuses (the 429
-  backpressure check in `LoopctlWeb.KnowledgeIngestionController.create_batch/2`).
+  states (`available`/`scheduled`/`executing`/`retryable`) — AC-36.2.1. QUEUE-scoped
+  (the fair-share cost regime; see the moduledoc). US-36.3's admission gate uses the
+  WORKER-scoped `in_flight_ingestion_backlog/1` instead.
   """
   @spec in_flight_count(binary(), atom() | binary()) :: non_neg_integer()
   def in_flight_count(tenant_id, queue) do
-    count(tenant_id, queue, @non_terminal_states, :all)
+    count(tenant_id, {:queue, to_string(queue)}, @non_terminal_states, :all)
+  end
+
+  @doc """
+  Broad in-flight `:ingestion` backlog for `tenant_id` across the four non-terminal
+  states — the count US-36.3's SYNCHRONOUS batch-ingest admission gate consults (the
+  429 backpressure check in `LoopctlWeb.KnowledgeIngestionController`).
+
+  Scoped by `worker = ContentIngestionWorker` (the sole `:ingestion` worker) rather
+  than by queue, so it rides the partial index `oban_jobs_ingestion_tenant_idx` and
+  costs O(the caller's OWN ingestion backlog), not O(fleet-wide non-terminal on the
+  `:ingestion` queue) — see the moduledoc's "Cost / index justification" (WORKER-scoped).
+  This is the production implementation of `Loopctl.Oban.BacklogCounterBehaviour`.
+  """
+  @impl Loopctl.Oban.BacklogCounterBehaviour
+  @spec in_flight_ingestion_backlog(binary()) :: non_neg_integer()
+  def in_flight_ingestion_backlog(tenant_id) do
+    count(tenant_id, {:worker, @ingestion_worker}, @non_terminal_states, :all)
   end
 
   @doc """
@@ -233,11 +270,11 @@ defmodule Loopctl.Oban.FairShare do
   UNSCOPED slot-occupancy (counts every executing job, including any running caller).
   Used only by the fair-share gate's fallback (a `nil` `job_id`); the gate's normal
   decision path uses the self-excluding rank count instead (see `over_fair_share?/3`).
-  Not currently reused outside this module (US-36.3 reuses `in_flight_count/2` only).
+  Not currently reused outside this module (US-36.3 uses `in_flight_ingestion_backlog/1`).
   """
   @spec executing_count(binary(), atom() | binary()) :: non_neg_integer()
   def executing_count(tenant_id, queue) do
-    count(tenant_id, queue, ["executing"], :all)
+    count(tenant_id, {:queue, to_string(queue)}, ["executing"], :all)
   end
 
   # The gate's rank input: how many of the tenant's OTHER executing jobs on `queue`
@@ -247,11 +284,11 @@ defmodule Loopctl.Oban.FairShare do
   # dispatch path) has no rank, so we fall back to the plain unscoped executing count
   # (counts every executing job, including the caller).
   defp lower_ranked_executing_count(tenant_id, queue, job_id) when is_integer(job_id) do
-    count(tenant_id, queue, ["executing"], {:lower_than, job_id})
+    count(tenant_id, {:queue, to_string(queue)}, ["executing"], {:lower_than, job_id})
   end
 
   defp lower_ranked_executing_count(tenant_id, queue, nil) do
-    count(tenant_id, queue, ["executing"], :all)
+    count(tenant_id, {:queue, to_string(queue)}, ["executing"], :all)
   end
 
   @doc """
@@ -270,26 +307,32 @@ defmodule Loopctl.Oban.FairShare do
 
   # Tenant-scoped, bounded count over the Oban-owned oban_jobs table via AdminRepo
   # (BYPASSRLS — the table has no RLS), run under a per-query SET LOCAL
-  # statement_timeout inside a transaction (pgbouncer-safe). `queue` may be an atom
-  # (worker config) or string (raw); oban_jobs.queue is text, so it's stringified.
+  # statement_timeout inside a transaction (pgbouncer-safe).
+  #
+  # `scope` selects which population the count leads on, and thus which index backs it
+  # (see the moduledoc's "Cost / index justification"):
+  #   * `{:queue, queue_str}`  — the fair-share regime; rides Oban's (state,queue) index.
+  #   * `{:worker, worker_str}` — US-36.3's admission gate; rides the partial
+  #     `oban_jobs_ingestion_tenant_idx` (WHERE worker = ContentIngestionWorker),
+  #     bounding cost to the CALLER's own ingestion backlog.
+  # Both `oban_jobs.queue` and `oban_jobs.worker` are text columns.
   #
   # `id_predicate` narrows the count: `:all` (public helpers — no id filter) or
   # `{:lower_than, job_id}` (the gate's rank input — only executing jobs with a
   # strictly lower id, which both self-excludes the caller and gives the deterministic
   # co-fetch tie-break; see the moduledoc).
-  defp count(tenant_id, queue, states, id_predicate) do
-    queue_str = to_string(queue)
+  defp count(tenant_id, scope, states, id_predicate) do
     tenant_id_str = to_string(tenant_id)
 
     base =
       from(j in "oban_jobs",
         where:
-          j.queue == ^queue_str and j.state in ^states and
+          j.state in ^states and
             fragment("? ->> 'tenant_id' = ?", j.args, ^tenant_id_str),
         select: count(j.id)
       )
 
-    query = apply_id_predicate(base, id_predicate)
+    query = base |> apply_scope(scope) |> apply_id_predicate(id_predicate)
 
     {:ok, result} =
       AdminRepo.transaction(fn ->
@@ -298,6 +341,14 @@ defmodule Loopctl.Oban.FairShare do
       end)
 
     result || 0
+  end
+
+  defp apply_scope(query, {:queue, queue_str}) do
+    from(j in query, where: j.queue == ^queue_str)
+  end
+
+  defp apply_scope(query, {:worker, worker_str}) do
+    from(j in query, where: j.worker == ^worker_str)
   end
 
   defp apply_id_predicate(query, :all), do: query

--- a/lib/loopctl/oban/fair_share.ex
+++ b/lib/loopctl/oban/fair_share.ex
@@ -72,8 +72,9 @@ defmodule Loopctl.Oban.FairShare do
       lowest-id executing job for a tenant always has rank 0 → runs → completes, then
       the next, so every job drains in id (≈ FIFO) order and none starves.
 
-  The public `executing_count/2` / `in_flight_count/2` helpers (reused by US-36.3's
-  `/queue-health` endpoint) are UNSCOPED counts — they intentionally do NOT apply the
+  The public `executing_count/2` / `in_flight_count/2` helpers (`in_flight_count/2`
+  is reused by US-36.3's batch-ingest backlog admission gate — see below) are
+  UNSCOPED counts — they intentionally do NOT apply the
   rank predicate; `id < job_id` belongs only to the gate's decision path. `job_id`
   may be `nil` (a bare `perform/1` struct in a test, off the real dispatch path) —
   then the gate falls back to the plain unscoped executing count `>= cap`.
@@ -88,7 +89,8 @@ defmodule Loopctl.Oban.FairShare do
 
     * `in_flight_count/2` — the broad 4-state set
       (`available`/`scheduled`/`executing`/`retryable`), the GENERAL helper reused by
-      US-36.3's `/queue-health` endpoint.
+      US-36.3's batch-ingest backlog admission gate (the 429 backpressure check in
+      `LoopctlWeb.KnowledgeIngestionController.create_batch/2`).
     * `executing_count/2` — only `executing`, the slot-occupancy the fair-share gate
       decides on (AC-36.2.2).
 
@@ -118,9 +120,11 @@ defmodule Loopctl.Oban.FairShare do
       depth, but stays low-single-digit-ms at the flood sizes this feature contends
       with and is HARD-BOUNDED by the 2 s `SET LOCAL statement_timeout` below — it can
       never pin a connection. This bound makes it safe for US-36.3's synchronous
-      `/queue-health` per-request use; if that endpoint ever needs a flood-independent
-      cost it should cap the count (e.g. `LIMIT`-bounded existence probe), not add an
-      index (see next).
+      per-request admission-gate use; that gate additionally FAILS OPEN if this count
+      raises/times out (an unmeasurable backlog admits the batch, never 500 — see
+      `LoopctlWeb.KnowledgeIngestionController`), and if it ever needs a flood-
+      independent cost it should cap the count (e.g. `LIMIT`-bounded existence probe),
+      not add an index (see next).
 
   NO new index is warranted. A count of N matching rows is inherently O(N) index
   entries even with a perfect covering index, so no index makes a single-tenant flood
@@ -138,8 +142,13 @@ defmodule Loopctl.Oban.FairShare do
   alias Loopctl.AdminRepo
   alias Loopctl.ObanConfig
 
+  # `in_flight_count/2` is the broad non-terminal count US-36.3's batch-ingest
+  # admission gate consults; declaring the behaviour makes FairShare the default
+  # (production) implementation of that config-swappable DI seam.
+  @behaviour Loopctl.Oban.BacklogCounterBehaviour
+
   # The four non-terminal Oban states — the GENERAL in-flight set (AC-36.2.1),
-  # shared with US-36.3's queue-health endpoint.
+  # shared with US-36.3's batch-ingest backlog admission gate.
   @non_terminal_states ~w(available scheduled executing retryable)
 
   # Bound the read on the hot, Oban-owned oban_jobs table. Generous vs the measured
@@ -211,7 +220,8 @@ defmodule Loopctl.Oban.FairShare do
   @doc """
   Broad in-flight count for `tenant_id` on `queue` across the four non-terminal
   states (`available`/`scheduled`/`executing`/`retryable`) — AC-36.2.1. This is the
-  GENERAL helper US-36.3's endpoint reuses.
+  GENERAL helper US-36.3's batch-ingest backlog admission gate reuses (the 429
+  backpressure check in `LoopctlWeb.KnowledgeIngestionController.create_batch/2`).
   """
   @spec in_flight_count(binary(), atom() | binary()) :: non_neg_integer()
   def in_flight_count(tenant_id, queue) do
@@ -221,8 +231,9 @@ defmodule Loopctl.Oban.FairShare do
   @doc """
   Count of `tenant_id`'s currently-EXECUTING jobs on `queue` (AC-36.2.2) — the
   UNSCOPED slot-occupancy (counts every executing job, including any running caller).
-  US-36.3's `/queue-health` endpoint reuses this. The gate's decision path uses the
-  self-excluding count instead (see `over_fair_share?/3`).
+  Used only by the fair-share gate's fallback (a `nil` `job_id`); the gate's normal
+  decision path uses the self-excluding rank count instead (see `over_fair_share?/3`).
+  Not currently reused outside this module (US-36.3 reuses `in_flight_count/2` only).
   """
   @spec executing_count(binary(), atom() | binary()) :: non_neg_integer()
   def executing_count(tenant_id, queue) do

--- a/lib/loopctl/oban_config.ex
+++ b/lib/loopctl/oban_config.ex
@@ -258,8 +258,13 @@ defmodule Loopctl.ObanConfig do
   Max in-flight `:ingestion` backlog (non-terminal jobs) a single tenant may have
   before the batch-ingest endpoint rejects a new batch with 429 (US-36.3).
 
-  From `OBAN_INGEST_BACKLOG_MAX` (positive integer, else raises `ArgumentError` at
-  read time like `queue_size/2`), default #{@default_ingest_backlog_max}.
+  From `OBAN_INGEST_BACKLOG_MAX` (positive integer, else raises `ArgumentError` like
+  `queue_size/2`), default #{@default_ingest_backlog_max}.
+
+  Validated at BOOT: `config/runtime.exs` evaluates this function (via
+  `config :loopctl, :ingest_backlog_max, ...`), so a malformed value aborts the node
+  LOUD at startup — like `OBAN_QUEUE_*` / `OBAN_TENANT_FAIRSHARE_*` — instead of
+  surfacing only at call time as per-request 500s on the batch endpoint.
 
   Config-based DI: read via `System.get_env/1` at call time (NEVER
   `Application.compile_env`, which would record a boot-aborting compile-env

--- a/lib/loopctl/oban_config.ex
+++ b/lib/loopctl/oban_config.ex
@@ -240,9 +240,10 @@ defmodule Loopctl.ObanConfig do
   # --- US-36.3: batch-ingest backlog backpressure (429) ---
   #
   # Max in-flight :ingestion backlog (the broad non-terminal set —
-  # available/scheduled/executing/retryable, via `Loopctl.Oban.FairShare.in_flight_count/2`)
-  # a SINGLE tenant may have accumulated before the batch-ingest endpoint
-  # (POST /api/v1/knowledge/ingest/batch) rejects a NEW batch all-or-nothing with 429.
+  # available/scheduled/executing/retryable, via the worker-scoped, index-backed
+  # `Loopctl.Oban.FairShare.in_flight_ingestion_backlog/1`) a SINGLE tenant may have
+  # accumulated before the ingest endpoints (POST /api/v1/knowledge/ingest and
+  # /ingest/batch) reject a NEW request with 429.
   #
   # This bounds ACCUMULATION, complementing US-36.2's fair-share gate (which bounds
   # per-tenant CONCURRENCY of executing slots). A 50-item batch fans each item out to
@@ -255,8 +256,15 @@ defmodule Loopctl.ObanConfig do
   @default_ingest_backlog_max 500
 
   @doc """
-  Max in-flight `:ingestion` backlog (non-terminal jobs) a single tenant may have
-  before the batch-ingest endpoint rejects a new batch with 429 (US-36.3).
+  In-flight `:ingestion` backlog (non-terminal jobs) at/above which a single tenant's
+  ingest requests start being rejected with 429 (US-36.3).
+
+  SOFT admission FLOOR, not a hard cap. The gate is a lock-free read-then-enqueue, so
+  concurrent same-tenant requests can each pass the check and overshoot this value by up
+  to the in-flight request concurrency (a benign TOCTOU). Read it as "start shedding
+  around here", not "the backlog can never exceed this" — it is a backpressure valve to
+  stop runaway monopolization, not an enforced ceiling. Gated on BOTH the batch and the
+  single-item ingest paths so neither can be looped to bypass the other.
 
   From `OBAN_INGEST_BACKLOG_MAX` (positive integer, else raises `ArgumentError` like
   `queue_size/2`), default #{@default_ingest_backlog_max}.
@@ -275,6 +283,35 @@ defmodule Loopctl.ObanConfig do
   @spec ingest_backlog_max() :: pos_integer()
   def ingest_backlog_max do
     queue_size(System.get_env("OBAN_INGEST_BACKLOG_MAX"), @default_ingest_backlog_max)
+  end
+
+  # Retry-After hint (seconds) advised to a client 429'd by the ingest backlog gate.
+  # Deliberately tied to the :ingestion queue's DRAIN cadence, NOT the sub-second
+  # fair-share snooze base: ContentIngestionWorker jobs are ~6-min LLM calls on a
+  # width-2 queue, so a backlog drains over minutes-to-hours. A 5s hint would hot-loop a
+  # compliant client into a steady stream of 429s (each re-running the admission count);
+  # a ~1-min default keeps a Retry-After-honoring client off the endpoint between real
+  # drains while staying a bounded, sensible "back off for a while" value.
+  @default_ingest_backlog_retry_after_seconds 60
+
+  @doc """
+  Retry-After (seconds) advised to a client rejected by the batch/single-item ingest
+  backlog gate (US-36.3). Scaled to the `:ingestion` queue's drain cadence rather than
+  the fair-share snooze base, so a compliant client does not hot-loop retry->429.
+
+  From `OBAN_INGEST_BACKLOG_RETRY_AFTER` (positive integer, else raises `ArgumentError`
+  like `queue_size/2`), default #{@default_ingest_backlog_retry_after_seconds}.
+
+  Validated at BOOT (via `config/runtime.exs`), so a malformed value aborts the node
+  LOUD at startup instead of surfacing only at call time. Config-based DI: read via
+  `System.get_env/1` at call time so ops can retune live with no deploy.
+  """
+  @spec ingest_backlog_retry_after_seconds() :: pos_integer()
+  def ingest_backlog_retry_after_seconds do
+    queue_size(
+      System.get_env("OBAN_INGEST_BACKLOG_RETRY_AFTER"),
+      @default_ingest_backlog_retry_after_seconds
+    )
   end
 
   # Like `queue_size/2` but admits 0 (a valid "no jitter" value). Still fails loud on

--- a/lib/loopctl/oban_config.ex
+++ b/lib/loopctl/oban_config.ex
@@ -237,6 +237,41 @@ defmodule Loopctl.ObanConfig do
     )
   end
 
+  # --- US-36.3: batch-ingest backlog backpressure (429) ---
+  #
+  # Max in-flight :ingestion backlog (the broad non-terminal set —
+  # available/scheduled/executing/retryable, via `Loopctl.Oban.FairShare.in_flight_count/2`)
+  # a SINGLE tenant may have accumulated before the batch-ingest endpoint
+  # (POST /api/v1/knowledge/ingest/batch) rejects a NEW batch all-or-nothing with 429.
+  #
+  # This bounds ACCUMULATION, complementing US-36.2's fair-share gate (which bounds
+  # per-tenant CONCURRENCY of executing slots). A 50-item batch fans each item out to
+  # a ~6-min LLM ContentIngestionWorker job on the `:ingestion` queue (default width 2,
+  # env OBAN_QUEUE_INGESTION). Default 500 lets a normal caller loop the 50-item
+  # endpoint ~10 times before backpressure kicks in — generous headroom for legitimate
+  # bulk work, while still stopping a runaway loop from piling up an unbounded backlog
+  # that would starve the queue's drain and inflate memory/DB footprint. Ops retune
+  # live via OBAN_INGEST_BACKLOG_MAX (no deploy) to loosen/tighten during an incident.
+  @default_ingest_backlog_max 500
+
+  @doc """
+  Max in-flight `:ingestion` backlog (non-terminal jobs) a single tenant may have
+  before the batch-ingest endpoint rejects a new batch with 429 (US-36.3).
+
+  From `OBAN_INGEST_BACKLOG_MAX` (positive integer, else raises `ArgumentError` at
+  read time like `queue_size/2`), default #{@default_ingest_backlog_max}.
+
+  Config-based DI: read via `System.get_env/1` at call time (NEVER
+  `Application.compile_env`, which would record a boot-aborting compile-env
+  dependency — see the `@default_queues` note above), so an operator can loosen/tighten
+  the threshold during an incident with `fly secrets set OBAN_INGEST_BACKLOG_MAX=... &&
+  restart`, no deploy.
+  """
+  @spec ingest_backlog_max() :: pos_integer()
+  def ingest_backlog_max do
+    queue_size(System.get_env("OBAN_INGEST_BACKLOG_MAX"), @default_ingest_backlog_max)
+  end
+
   # Like `queue_size/2` but admits 0 (a valid "no jitter" value). Still fails loud on
   # a present-but-malformed / negative value rather than silently defaulting.
   @spec non_neg_size(String.t() | nil, non_neg_integer()) :: non_neg_integer()

--- a/lib/loopctl/telemetry/scale_metrics.ex
+++ b/lib/loopctl/telemetry/scale_metrics.ex
@@ -469,6 +469,22 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
         tag_values: &hybrid_provenance_tags/1
       ),
 
+      # US-36.3 (review): the batch/single ingest backlog admission gate FAILED OPEN —
+      # it could not measure the tenant's in-flight :ingestion backlog (count timed out /
+      # lost its connection) and ADMITTED the request rather than shedding it. Makes "the
+      # ingestion backpressure valve is currently admitting because it can't measure" an
+      # alertable signal instead of a silent warning log. `error_class` is a bounded
+      # 2-value tag; `tenant_id` is cap-gated to a sentinel (same convention as the other
+      # scale counters).
+      counter("loopctl.ingestion.backlog_gate.failed_open.count",
+        event_name: [:loopctl, :ingestion, :backlog_gate, :failed_open],
+        measurement: :count,
+        description:
+          "Ingestion backlog admission gate failed open (unmeasurable backlog count), by error_class and tenant.",
+        tags: [:error_class, :tenant_id],
+        tag_values: &ingestion_backlog_failed_open_tags/1
+      ),
+
       # 6. Per-pool checkout queue_time (US-33.1): the RLS `Loopctl.Repo` pool (size
       #    10). Sourced from Ecto's default query event for that repo module
       #    (`[:loopctl, :repo, :query]`). `repo` is a STATIC single-value tag (not
@@ -689,6 +705,20 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
     %{
       provenance: Map.get(metadata, :provenance, "unknown"),
       hit: Map.get(metadata, :hit, false),
+      tenant_id: gated_tenant_id(metadata)
+    }
+  end
+
+  @doc """
+  `tag_values` for the ingestion backlog gate fail-open counter (US-36.3 review).
+  `error_class` is a small fixed-cardinality tag (`"timeout"` | `"connection"`, default
+  `"unknown"`); `tenant_id` reuses the same cap-gated sentinel collapse as the other
+  scale counters to keep cardinality bounded.
+  """
+  @spec ingestion_backlog_failed_open_tags(map()) :: map()
+  def ingestion_backlog_failed_open_tags(metadata) do
+    %{
+      error_class: Map.get(metadata, :error_class, "unknown"),
       tenant_id: gated_tenant_id(metadata)
     }
   end

--- a/lib/loopctl/telemetry_events.ex
+++ b/lib/loopctl/telemetry_events.ex
@@ -196,6 +196,34 @@ defmodule Loopctl.TelemetryEvents do
   """
   def llm_provider_error, do: [:loopctl, :llm, :provider_error]
 
+  @doc """
+  The US-36.3 batch/single ingest backlog admission gate FAILED OPEN — it could not
+  measure the calling tenant's in-flight `:ingestion` backlog (the count raised a
+  `Postgrex.Error` statement_timeout or a `DBConnection.ConnectionError` pool-checkout
+  timeout) and therefore ADMITTED the request rather than 429-ing it. While this fires,
+  the backpressure valve is effectively OFF for that request: a genuine flood deep
+  enough to time the count out will admit instead of shed.
+
+  Turns an otherwise silent `:warning` log line into an alertable signal so operators
+  can see "the ingestion backpressure valve is currently admitting because it can't
+  measure" on a dashboard. Distinct from a valve that is simply BELOW threshold (that
+  path emits nothing). Fires once per failed-open admission check.
+
+  ## Payload (id/atom only — never a query, key, or PG message body)
+
+    * `measurements`: `%{count: 1}` — a pure increment.
+    * `metadata`: `%{tenant_id, error_class}` where `error_class` is a BOUNDED 2-value
+      tag (`"timeout"` for the `Postgrex.Error` statement_timeout, `"connection"` for the
+      `DBConnection.ConnectionError` pool-checkout timeout). `tenant_id` is an id, and is
+      cap-gated to a sentinel in the metric's `tag_values` so label cardinality stays
+      bounded (same convention as the other scale counters).
+
+  Aggregated by `Loopctl.Telemetry.ScaleMetrics` as a counter tagged by
+  `[:error_class, :tenant_id]`.
+  """
+  def ingestion_backlog_gate_failed_open,
+    do: [:loopctl, :ingestion, :backlog_gate, :failed_open]
+
   @doc "Returns all defined event names for attachment"
   def all_events do
     [
@@ -211,7 +239,8 @@ defmodule Loopctl.TelemetryEvents do
       db_error(),
       knowledge_semantic_fallback(),
       knowledge_hybrid_provenance(),
-      llm_provider_error()
+      llm_provider_error(),
+      ingestion_backlog_gate_failed_open()
     ]
   end
 end

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -17,6 +17,7 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   alias Loopctl.Net.UrlGuard
   alias Loopctl.Oban.FairShare
   alias Loopctl.ObanConfig
+  alias Loopctl.TelemetryEvents
   alias Loopctl.Workers.ContentIngestionWorker
 
   # Mandatory BYO (Epic 28, #179): extraction runs on the tenant's OWN Anthropic
@@ -113,7 +114,17 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
          }},
       401 => {"Unauthorized", "application/json", Schemas.ErrorResponse},
       422 => {"Validation error", "application/json", Schemas.ErrorResponse},
-      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+      429 =>
+        {"Too Many Requests — one of two DISTINCT 429s this route can return: (1) " <>
+           "US-36.3 ingestion-backlog backpressure (`error.code: " <>
+           "\"ingestion_backlog_exceeded\"`, sets `Retry-After`) — the single-item path " <>
+           "is gated on the SAME per-tenant backlog threshold as /ingest/batch so it " <>
+           "cannot be looped to bypass the valve — or (2) the generic shared Hammer " <>
+           "request-rate limiter (NO `error.code`). Branch on the presence of `error.code`.",
+         "application/json",
+         %OpenApiSpex.Schema{
+           oneOf: [Schemas.IngestionBacklogError, Schemas.RateLimitError]
+         }}
     }
   )
 
@@ -121,7 +132,14 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   def create(conn, params) do
     tenant_id = conn.assigns.current_api_key.tenant_id
 
-    with :ok <- require_llm_key(tenant_id) do
+    # Gate the SINGLE-item path on the same backlog valve as the batch path (US-36.3):
+    # otherwise a tenant that 429s on /ingest/batch could keep piling :ingestion jobs
+    # one-at-a-time by looping this endpoint, defeating the backpressure valve. Both
+    # routes now consult the same threshold, so accumulation is bounded regardless of
+    # which endpoint the flood comes through. Checked AFTER require_llm_key so a keyless
+    # tenant still gets the clearer 422 first.
+    with :ok <- require_llm_key(tenant_id),
+         :ok <- check_ingestion_backlog(tenant_id) do
       handle_create(conn, tenant_id, params)
     end
   end
@@ -232,13 +250,24 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     end
   end
 
-  # US-36.3 admission gate: reject the WHOLE batch with 429 when the calling tenant's
-  # in-flight :ingestion backlog is at/over the env-driven threshold, BEFORE enqueuing
-  # anything. Reuses the US-36.2 broad non-terminal count helper (tenant-scoped by
-  # args->>'tenant_id', bounded by a per-query statement_timeout via AdminRepo) — cheap
-  # and scoped to the caller ONLY, so one tenant's backlog never affects another. The
-  # error tuple is rendered by LoopctlWeb.FallbackController (structured 429 + Retry-After,
-  # code "ingestion_backlog_exceeded" — distinct from the Hammer request-rate 429).
+  # US-36.3 admission gate: reject with 429 when the calling tenant's in-flight
+  # :ingestion backlog is at/over the env-driven threshold, BEFORE enqueuing anything.
+  # Consults the WORKER-scoped, index-backed count (`in_flight_ingestion_backlog/1` —
+  # tenant-scoped by args->>'tenant_id', backed by the partial index
+  # oban_jobs_ingestion_tenant_idx, bounded by a per-query statement_timeout via
+  # AdminRepo) — cheap and scoped to the CALLER's own backlog ONLY, so one tenant's
+  # backlog never affects another's admission NOR the query cost. Used by BOTH the batch
+  # (create_batch/2) and single-item (create/2) ingest paths. The error tuple is rendered
+  # by LoopctlWeb.FallbackController (structured 429 + Retry-After, code
+  # "ingestion_backlog_exceeded" — distinct from the Hammer request-rate 429).
+  #
+  # SOFT ADMISSION HINT, not a hard cap. This is a plain read-then-enqueue with no lock
+  # or atomic reservation, so it bounds ACCUMULATION probabilistically, not exactly: N
+  # concurrent same-tenant requests can each observe count < max and each pass (a benign
+  # TOCTOU), overshooting the threshold by up to the in-flight request concurrency. That
+  # is by design — this is a backpressure VALVE to stop runaway monopolization, not a
+  # guaranteed ceiling. Operators tuning OBAN_INGEST_BACKLOG_MAX should read it as a
+  # "start shedding around here" floor, not an enforced maximum.
   defp check_ingestion_backlog(tenant_id) do
     max = ObanConfig.ingest_backlog_max()
 
@@ -249,39 +278,56 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     end
   end
 
-  # FAIL OPEN, mirroring the US-36.2 fair-share gate (`Loopctl.Oban.FairShare.over_cap?/4`):
-  # an unmeasurable backlog count must NEVER block work. The reused count runs under a 2s
-  # `SET LOCAL statement_timeout` and — per FairShare's cost model — scans every
-  # non-terminal `:ingestion` row FLEET-WIDE (tenant is a post-Filter), so during the
-  # deep-queue flood this feature targets it is MOST likely to hit that bound. A raised
-  # statement_timeout / transient Postgrex/DBConnection error must therefore not escape
-  # here as a generic HTTP 500 that rejects an innocent, under-threshold tenant's batch;
-  # instead we log and admit (return 0 → below any positive threshold). The count is
-  # resolved through a config-swappable DI seam (`Loopctl.Oban.FairShare` in prod, a Mox
-  # mock in test) so this fail-open path is deterministically covered.
+  # FAIL OPEN on an UNMEASURABLE count only: an unreachable/timed-out backlog count must
+  # never block work (an innocent, under-threshold tenant must never eat a generic 500
+  # because the count path is momentarily degraded). The count runs under a 2s
+  # `SET LOCAL statement_timeout`; a raised statement_timeout surfaces as `Postgrex.Error`
+  # (57014 query_canceled) and a pool-checkout timeout as `DBConnection.ConnectionError`,
+  # so we rescue ONLY those two classes — NOT a bare `rescue e ->`. A programming error
+  # in the count path (e.g. a bad query change) must therefore propagate and 500, LOUD,
+  # rather than be silently swallowed into a fleet-wide disabling of backpressure that
+  # looks healthy. On the fail-open path we ALSO emit a telemetry counter
+  # (`[:loopctl, :ingestion, :backlog_gate, :failed_open]`) so "the backpressure valve is
+  # currently admitting because it can't measure" is an alertable signal, not just a
+  # warning-log line, and a sustained per-request timeout under a real flood is visible on
+  # a dashboard instead of only as log spam. The count is resolved through a
+  # config-swappable DI seam (`Loopctl.Oban.FairShare` in prod, a Mox mock in test) so
+  # this fail-open path is deterministically covered.
   defp in_flight_ingestion_backlog(tenant_id) do
-    backlog_counter().in_flight_count(tenant_id, :ingestion)
+    backlog_counter().in_flight_ingestion_backlog(tenant_id)
   rescue
-    e ->
+    e in [DBConnection.ConnectionError, Postgrex.Error] ->
       Logger.warning(
         "ingestion backlog gate failed open for tenant=#{tenant_id}: " <>
           Exception.message(e)
       )
 
+      :telemetry.execute(
+        TelemetryEvents.ingestion_backlog_gate_failed_open(),
+        %{count: 1},
+        %{tenant_id: tenant_id, error_class: fail_open_class(e)}
+      )
+
       0
   end
+
+  defp fail_open_class(%DBConnection.ConnectionError{}), do: "connection"
+  defp fail_open_class(%Postgrex.Error{}), do: "timeout"
 
   defp backlog_counter do
     Application.get_env(:loopctl, :ingestion_backlog_counter, FairShare)
   end
 
-  # Retry-After hint (seconds) for a backlog-429. Tied to the fair-share snooze base so
-  # it tracks the drain cadence of the :ingestion queue: a snoozed/backlogged job
-  # re-checks on roughly this horizon, so advising the client to wait the same amount
-  # before retrying is a sensible, bounded, deploy-free-tunable value. Bounded to a
-  # small positive integer of seconds.
+  # Retry-After hint (seconds) for a backlog-429. Tied to the :ingestion queue's DRAIN
+  # cadence — NOT the sub-second fair-share snooze base. ContentIngestionWorker jobs are
+  # ~6-min LLM calls on a width-2 queue, so a backlog drains on the order of minutes-to-
+  # hours; advising a compliant client to retry in ~5s would just hot-loop it into a
+  # steady stream of 429s (each re-running the admission count). A drain-cadence-scaled
+  # value (env OBAN_INGEST_BACKLOG_RETRY_AFTER, default 60s, boot-validated) is an honest
+  # "back off for a while" hint that keeps a Retry-After-honoring client off the endpoint
+  # between real drains. Deploy-free-tunable like the threshold itself.
   defp backlog_retry_after_seconds do
-    ObanConfig.fair_share_snooze_base_seconds()
+    ObanConfig.ingest_backlog_retry_after_seconds()
   end
 
   # Mandatory BYO gate shared by single + batch ingest. On a miss, record the block

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -203,8 +203,15 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
       401 => {"Unauthorized", "application/json", Schemas.ErrorResponse},
       422 => {"Validation error", "application/json", Schemas.ErrorResponse},
       429 =>
-        {"Ingestion backlog backpressure OR request-rate limit", "application/json",
-         Schemas.IngestionBacklogError}
+        {"Too Many Requests — one of two DISTINCT 429s this route can return: (1) " <>
+           "US-36.3 ingestion-backlog backpressure (`error.code: " <>
+           "\"ingestion_backlog_exceeded\"`, sets `Retry-After`), or (2) the generic " <>
+           "shared Hammer request-rate limiter (NO `error.code`; `error.message: " <>
+           "\"Rate limit exceeded\"`). Branch on the presence of `error.code`.",
+         "application/json",
+         %OpenApiSpex.Schema{
+           oneOf: [Schemas.IngestionBacklogError, Schemas.RateLimitError]
+         }}
     }
   )
 
@@ -235,11 +242,37 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   defp check_ingestion_backlog(tenant_id) do
     max = ObanConfig.ingest_backlog_max()
 
-    if FairShare.in_flight_count(tenant_id, :ingestion) >= max do
+    if in_flight_ingestion_backlog(tenant_id) >= max do
       {:error, :ingestion_backlog_exceeded, backlog_retry_after_seconds()}
     else
       :ok
     end
+  end
+
+  # FAIL OPEN, mirroring the US-36.2 fair-share gate (`Loopctl.Oban.FairShare.over_cap?/4`):
+  # an unmeasurable backlog count must NEVER block work. The reused count runs under a 2s
+  # `SET LOCAL statement_timeout` and — per FairShare's cost model — scans every
+  # non-terminal `:ingestion` row FLEET-WIDE (tenant is a post-Filter), so during the
+  # deep-queue flood this feature targets it is MOST likely to hit that bound. A raised
+  # statement_timeout / transient Postgrex/DBConnection error must therefore not escape
+  # here as a generic HTTP 500 that rejects an innocent, under-threshold tenant's batch;
+  # instead we log and admit (return 0 → below any positive threshold). The count is
+  # resolved through a config-swappable DI seam (`Loopctl.Oban.FairShare` in prod, a Mox
+  # mock in test) so this fail-open path is deterministically covered.
+  defp in_flight_ingestion_backlog(tenant_id) do
+    backlog_counter().in_flight_count(tenant_id, :ingestion)
+  rescue
+    e ->
+      Logger.warning(
+        "ingestion backlog gate failed open for tenant=#{tenant_id}: " <>
+          Exception.message(e)
+      )
+
+      0
+  end
+
+  defp backlog_counter do
+    Application.get_env(:loopctl, :ingestion_backlog_counter, FairShare)
   end
 
   # Retry-After hint (seconds) for a backlog-429. Tied to the fair-share snooze base so

--- a/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_ingestion_controller.ex
@@ -15,6 +15,8 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
   alias Loopctl.HeavyRead
   alias Loopctl.Llm
   alias Loopctl.Net.UrlGuard
+  alias Loopctl.Oban.FairShare
+  alias Loopctl.ObanConfig
   alias Loopctl.Workers.ContentIngestionWorker
 
   # Mandatory BYO (Epic 28, #179): extraction runs on the tenant's OWN Anthropic
@@ -162,7 +164,13 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     description:
       "Submit multiple URLs or raw content items for knowledge extraction in a single " <>
         "request. Each item is validated and enqueued independently. " <>
-        "Max 50 items per batch. Role: orchestrator+.",
+        "Max 50 items per batch. Role: orchestrator+.\n\n" <>
+        "**Backpressure (429):** before enqueuing anything, the endpoint checks the " <>
+        "calling tenant's in-flight `:ingestion` backlog. If it is at/over the " <>
+        "`OBAN_INGEST_BACKLOG_MAX` threshold, the WHOLE request is rejected " <>
+        "all-or-nothing with 429 + `Retry-After` and `error.code: " <>
+        "\"ingestion_backlog_exceeded\"` — zero jobs are enqueued. This is distinct " <>
+        "from the generic Hammer request-rate 429 (which has no `error.code`).",
     request_body:
       {"Batch ingestion request", "application/json",
        %OpenApiSpex.Schema{
@@ -194,7 +202,9 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
          }},
       401 => {"Unauthorized", "application/json", Schemas.ErrorResponse},
       422 => {"Validation error", "application/json", Schemas.ErrorResponse},
-      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+      429 =>
+        {"Ingestion backlog backpressure OR request-rate limit", "application/json",
+         Schemas.IngestionBacklogError}
     }
   )
 
@@ -203,11 +213,42 @@ defmodule LoopctlWeb.KnowledgeIngestionController do
     tenant_id = conn.assigns.current_api_key.tenant_id
     items = params["items"]
 
+    # The backlog gate runs AFTER validate_batch_items/1 (so a malformed request still
+    # 422s first) but BEFORE process_batch_items/3 (so when the tenant is over its
+    # in-flight :ingestion backlog threshold, ZERO jobs from this request are enqueued —
+    # all-or-nothing, no partial pile-up). US-36.3.
     with :ok <- require_llm_key(tenant_id),
-         :ok <- validate_batch_items(items) do
+         :ok <- validate_batch_items(items),
+         :ok <- check_ingestion_backlog(tenant_id) do
       results = process_batch_items(tenant_id, items)
       json(conn, LoopctlWeb.KnowledgeIngestionJSON.batch(results))
     end
+  end
+
+  # US-36.3 admission gate: reject the WHOLE batch with 429 when the calling tenant's
+  # in-flight :ingestion backlog is at/over the env-driven threshold, BEFORE enqueuing
+  # anything. Reuses the US-36.2 broad non-terminal count helper (tenant-scoped by
+  # args->>'tenant_id', bounded by a per-query statement_timeout via AdminRepo) — cheap
+  # and scoped to the caller ONLY, so one tenant's backlog never affects another. The
+  # error tuple is rendered by LoopctlWeb.FallbackController (structured 429 + Retry-After,
+  # code "ingestion_backlog_exceeded" — distinct from the Hammer request-rate 429).
+  defp check_ingestion_backlog(tenant_id) do
+    max = ObanConfig.ingest_backlog_max()
+
+    if FairShare.in_flight_count(tenant_id, :ingestion) >= max do
+      {:error, :ingestion_backlog_exceeded, backlog_retry_after_seconds()}
+    else
+      :ok
+    end
+  end
+
+  # Retry-After hint (seconds) for a backlog-429. Tied to the fair-share snooze base so
+  # it tracks the drain cadence of the :ingestion queue: a snoozed/backlogged job
+  # re-checks on roughly this horizon, so advising the client to wait the same amount
+  # before retrying is a sensible, bounded, deploy-free-tunable value. Bounded to a
+  # small positive integer of seconds.
+  defp backlog_retry_after_seconds do
+    ObanConfig.fair_share_snooze_base_seconds()
   end
 
   # Mandatory BYO gate shared by single + batch ingest. On a miss, record the block

--- a/lib/loopctl_web/fallback_controller.ex
+++ b/lib/loopctl_web/fallback_controller.ex
@@ -19,6 +19,9 @@ defmodule LoopctlWeb.FallbackController do
   - `{:error, :self_review_blocked}` -> 409 (implementer tries to review their own work)
   - `{:error, :missing_assigned_agent}` -> 409 (reported_done story has no assigned agent/dispatch lineage; custody chain broken)
   - `{:error, :rate_limited}` -> 429 with retry_after_seconds from header
+  - `{:error, :ingestion_backlog_exceeded, retry_after}` -> 429 with `Retry-After` header and
+    a machine-readable `code: "ingestion_backlog_exceeded"` (US-36.3 batch-ingest backpressure —
+    distinct from the generic Hammer request-rate 429, which has no `code`)
   - `{:error, %Ecto.Changeset{}}` -> 422 with field-level details
   - `{:error, :bad_request, message}` -> 400 with custom message
   - `{:error, :unprocessable_entity, message}` -> 422 with custom message
@@ -277,6 +280,29 @@ defmodule LoopctlWeb.FallbackController do
         status: 429,
         message: "Too many requests. Retry after #{retry_after} seconds.",
         retry_after_seconds: String.to_integer(retry_after)
+      }
+    })
+  end
+
+  # US-36.3: batch-ingest backlog backpressure. The calling tenant's in-flight
+  # :ingestion backlog is at/over the OBAN_INGEST_BACKLOG_MAX threshold, so the whole
+  # batch was rejected all-or-nothing (ZERO jobs enqueued). A distinct `code` and the
+  # `Retry-After` header make this unambiguously distinguishable from the Hammer
+  # request-rate 429 (`message: "Rate limit exceeded"`, no `code`).
+  def call(conn, {:error, :ingestion_backlog_exceeded, retry_after})
+      when is_integer(retry_after) and retry_after > 0 do
+    conn
+    |> put_resp_header("retry-after", Integer.to_string(retry_after))
+    |> put_status(:too_many_requests)
+    |> json(%{
+      error: %{
+        status: 429,
+        code: "ingestion_backlog_exceeded",
+        message:
+          "This tenant already has too many in-flight ingestion jobs queued. " <>
+            "No items from this batch were enqueued. Retry after #{retry_after} seconds " <>
+            "once the backlog drains.",
+        retry_after_seconds: retry_after
       }
     })
   end

--- a/test/loopctl/oban/fair_share_test.exs
+++ b/test/loopctl/oban/fair_share_test.exs
@@ -54,6 +54,48 @@ defmodule Loopctl.Oban.FairShareTest do
     end
   end
 
+  describe "in_flight_ingestion_backlog/1 (US-36.3 — worker-scoped, index-backed)" do
+    test "counts the tenant's non-terminal ContentIngestionWorker jobs; excludes terminal" do
+      tenant = Ecto.UUID.generate()
+      w = "Loopctl.Workers.ContentIngestionWorker"
+
+      seed_job(tenant, :ingestion, "available", worker: w)
+      seed_job(tenant, :ingestion, "scheduled", worker: w)
+      seed_job(tenant, :ingestion, "executing", worker: w)
+      seed_job(tenant, :ingestion, "retryable", worker: w)
+      # Terminal states must NOT be counted.
+      seed_job(tenant, :ingestion, "completed", worker: w)
+      seed_job(tenant, :ingestion, "discarded", worker: w)
+
+      assert FairShare.in_flight_ingestion_backlog(tenant) == 4
+    end
+
+    test "is scoped to the ingestion worker, not merely the queue — other workers excluded" do
+      tenant = Ecto.UUID.generate()
+      w = "Loopctl.Workers.ContentIngestionWorker"
+
+      seed_job(tenant, :ingestion, "available", worker: w)
+      # A different worker (even on the same queue string) must not be counted by the
+      # worker-scoped backlog — the count keys on `worker`, so it rides the partial index.
+      seed_job(tenant, :ingestion, "available", worker: "Loopctl.Workers.SomeOtherWorker")
+      seed_job(tenant, :embeddings, "available", worker: "Loopctl.Workers.ArticleEmbeddingWorker")
+
+      assert FairShare.in_flight_ingestion_backlog(tenant) == 1
+    end
+
+    test "is tenant-scoped — A's ingestion backlog never includes B's" do
+      tenant_a = Ecto.UUID.generate()
+      tenant_b = Ecto.UUID.generate()
+      w = "Loopctl.Workers.ContentIngestionWorker"
+
+      seed_job(tenant_a, :ingestion, "available", worker: w)
+      for _ <- 1..3, do: seed_job(tenant_b, :ingestion, "available", worker: w)
+
+      assert FairShare.in_flight_ingestion_backlog(tenant_a) == 1
+      assert FairShare.in_flight_ingestion_backlog(tenant_b) == 3
+    end
+  end
+
   describe "tenant isolation (AC-36.2.6)" do
     test "tenant A's count never includes tenant B's jobs" do
       tenant_a = Ecto.UUID.generate()

--- a/test/loopctl/oban_config_test.exs
+++ b/test/loopctl/oban_config_test.exs
@@ -332,6 +332,39 @@ defmodule Loopctl.ObanConfigTest do
     end
   end
 
+  describe "ingest_backlog_retry_after_seconds/0 (US-36.3 review, env OBAN_INGEST_BACKLOG_RETRY_AFTER)" do
+    test "defaults to 60 (drain-cadence-scaled, not the sub-second snooze base) when unset" do
+      assert ObanConfig.ingest_backlog_retry_after_seconds() == 60
+      # Decoupled from the fair-share snooze base — a compliant client must not hot-loop.
+      assert ObanConfig.ingest_backlog_retry_after_seconds() >
+               ObanConfig.fair_share_snooze_base_seconds()
+    end
+
+    @tag :tmp_dir
+    test "a valid OBAN_INGEST_BACKLOG_RETRY_AFTER override is read at runtime", %{
+      tmp_dir: tmp_dir
+    } do
+      result =
+        run_elixir_script(
+          tmp_dir,
+          "result = Loopctl.ObanConfig.ingest_backlog_retry_after_seconds()",
+          [{"OBAN_INGEST_BACKLOG_RETRY_AFTER", "180"}]
+        )
+
+      assert result == 180
+    end
+
+    @tag :tmp_dir
+    test "a malformed OBAN_INGEST_BACKLOG_RETRY_AFTER aborts boot (fail-loud)", %{
+      tmp_dir: tmp_dir
+    } do
+      {output, exit_code} = run_boot(tmp_dir, [{"OBAN_INGEST_BACKLOG_RETRY_AFTER", "abc"}])
+
+      assert exit_code != 0
+      assert output =~ "positive integer"
+    end
+  end
+
   # Runs `script` (must bind a `result` variable) in a fresh `mix run --no-start`
   # subprocess with `env` applied ONLY to that child process, then reads back the
   # term `script` wrote to `result_path` via :erlang.term_to_binary/1. Keeps this

--- a/test/loopctl/oban_config_test.exs
+++ b/test/loopctl/oban_config_test.exs
@@ -287,6 +287,37 @@ defmodule Loopctl.ObanConfigTest do
     end
   end
 
+  describe "ingest_backlog_max/0 (US-36.3, env-tunable via OBAN_INGEST_BACKLOG_MAX)" do
+    test "TC-36.3.3: defaults to 500 when OBAN_INGEST_BACKLOG_MAX is unset" do
+      # OBAN_INGEST_BACKLOG_MAX is not set in the test environment, so the default applies.
+      assert ObanConfig.ingest_backlog_max() == 500
+    end
+
+    @tag :tmp_dir
+    test "TC-36.3.3: a valid OBAN_INGEST_BACKLOG_MAX override is read at runtime (subprocess-scoped env)",
+         %{tmp_dir: tmp_dir} do
+      result =
+        run_elixir_script(
+          tmp_dir,
+          "result = Loopctl.ObanConfig.ingest_backlog_max()",
+          [{"OBAN_INGEST_BACKLOG_MAX", "3"}]
+        )
+
+      assert result == 3
+    end
+
+    test "TC-36.3.3: a malformed value fails LOUD (raises) rather than silently defaulting" do
+      # ingest_backlog_max/0 delegates to queue_size/2, so a present-but-malformed
+      # OBAN_INGEST_BACKLOG_MAX raises at read time exactly like OBAN_QUEUE_*.
+      assert_raise ArgumentError, ~r/positive integer/, fn -> ObanConfig.queue_size("0", 500) end
+      assert_raise ArgumentError, ~r/positive integer/, fn -> ObanConfig.queue_size("-1", 500) end
+
+      assert_raise ArgumentError, ~r/positive integer/, fn ->
+        ObanConfig.queue_size("abc", 500)
+      end
+    end
+  end
+
   # Runs `script` (must bind a `result` variable) in a fresh `mix run --no-start`
   # subprocess with `env` applied ONLY to that child process, then reads back the
   # term `script` wrote to `result_path` via :erlang.term_to_binary/1. Keeps this

--- a/test/loopctl/oban_config_test.exs
+++ b/test/loopctl/oban_config_test.exs
@@ -306,9 +306,23 @@ defmodule Loopctl.ObanConfigTest do
       assert result == 3
     end
 
-    test "TC-36.3.3: a malformed value fails LOUD (raises) rather than silently defaulting" do
-      # ingest_backlog_max/0 delegates to queue_size/2, so a present-but-malformed
-      # OBAN_INGEST_BACKLOG_MAX raises at read time exactly like OBAN_QUEUE_*.
+    @tag :tmp_dir
+    test "TC-36.3.3: a malformed OBAN_INGEST_BACKLOG_MAX aborts boot (fail-loud, like OBAN_QUEUE_*)",
+         %{tmp_dir: tmp_dir} do
+      # config/runtime.exs evaluates `ObanConfig.ingest_backlog_max()` at the top level
+      # (via `config :loopctl, :ingest_backlog_max, ...`), so a fat-fingered live-tuning
+      # value fails LOUD at boot (non-zero exit) instead of surviving to the batch
+      # endpoint's call time, where an unhandled raise would surface as per-request 500s.
+      # This drives the REAL env-read path (System.get_env -> ingest_backlog_max/0 ->
+      # queue_size/2), not just the shared queue_size/2 delegate.
+      {output, exit_code} = run_boot(tmp_dir, [{"OBAN_INGEST_BACKLOG_MAX", "abc"}])
+
+      assert exit_code != 0
+      assert output =~ "positive integer"
+    end
+
+    test "TC-36.3.3: ingest_backlog_max/0 delegates to queue_size/2, which fails LOUD on a malformed value" do
+      # Direct unit-level assertion on the shared parser the env-read path uses.
       assert_raise ArgumentError, ~r/positive integer/, fn -> ObanConfig.queue_size("0", 500) end
       assert_raise ArgumentError, ~r/positive integer/, fn -> ObanConfig.queue_size("-1", 500) end
 

--- a/test/loopctl/telemetry/scale_metrics_test.exs
+++ b/test/loopctl/telemetry/scale_metrics_test.exs
@@ -63,7 +63,8 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
     "loopctl.memory_promotion.budget_exceeded.count",
     "loopctl.oban.jobs.count",
     "loopctl.oban.jobs.executing_orphan.count",
-    "loopctl.oban.poll.error.count"
+    "loopctl.oban.poll.error.count",
+    "loopctl.ingestion.backlog_gate.failed_open.count"
   ]
 
   # The ONLY labels any scale metric may ever carry (AC-27.15.3). Anything outside this

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -1,9 +1,40 @@
 defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
   use LoopctlWeb.ConnCase, async: true
 
+  alias Loopctl.AdminRepo
   alias Loopctl.Knowledge
+  alias Loopctl.Oban.FairShare
+  alias Loopctl.ObanConfig
 
   setup :verify_on_exit!
+
+  # US-36.3: seed `count` in-flight (non-terminal) :ingestion ContentIngestionWorker
+  # rows for a tenant so its backlog crosses the OBAN_INGEST_BACKLOG_MAX threshold.
+  # oban_jobs is Oban-owned + has no RLS, so we insert through AdminRepo (exactly as
+  # FairShare.in_flight_count/2 reads). A raw insert does NOT run the job (unlike
+  # Oban.insert under :inline), which is what we need to simulate a piled-up backlog.
+  # "available" is a non-terminal state counted by in_flight_count/2.
+  defp seed_ingestion_backlog(tenant_id, count) do
+    now = DateTime.utc_now()
+
+    entries =
+      for _ <- 1..count do
+        %{
+          state: "available",
+          queue: "ingestion",
+          worker: "Loopctl.Workers.ContentIngestionWorker",
+          args: %{"tenant_id" => tenant_id},
+          attempt: 0,
+          max_attempts: 20,
+          priority: 0,
+          inserted_at: now,
+          scheduled_at: now
+        }
+      end
+
+    {^count, _} = AdminRepo.insert_all(Oban.Job, entries)
+    :ok
+  end
 
   defp auth_conn(conn, raw_key) do
     put_req_header(conn, "authorization", "Bearer #{raw_key}")
@@ -650,6 +681,97 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       assert good["status"] == "queued"
       assert bad["status"] == "error"
       assert bad["error"] =~ "project_id"
+    end
+  end
+
+  # --- US-36.3: batch-ingest backlog backpressure (429) ---
+
+  describe "POST /api/v1/knowledge/ingest/batch backlog backpressure (US-36.3)" do
+    test "TC-36.3.1: tenant over threshold -> 429 + Retry-After + coded error; ZERO jobs enqueued",
+         %{conn: conn} do
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      # Seed the tenant's in-flight :ingestion backlog to the real resolved threshold
+      # (race-free: the gate reads the same env-derived value at call time — no global
+      # env mutation needed for an async test).
+      max = ObanConfig.ingest_backlog_max()
+      :ok = seed_ingestion_backlog(tenant.id, max)
+      before_count = FairShare.in_flight_count(tenant.id, :ingestion)
+      assert before_count >= max
+
+      # The extractor must never run — we reject before enqueuing anything.
+      expect(Loopctl.MockContentExtractor, :extract_from_content, 0, fn _t, _c, _o ->
+        flunk("extractor must not run when the batch is rejected for backlog backpressure")
+      end)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{
+          items: [%{content: "Over-threshold batch item", source_type: "newsletter"}]
+        })
+
+      body = json_response(conn, 429)
+      assert body["error"]["code"] == "ingestion_backlog_exceeded"
+      assert body["error"]["status"] == 429
+      assert body["error"]["message"] =~ "No items from this batch were enqueued"
+
+      # Retry-After header is a positive integer string.
+      assert [retry_after] = get_resp_header(conn, "retry-after")
+      assert {n, ""} = Integer.parse(retry_after)
+      assert n > 0
+      assert body["error"]["retry_after_seconds"] == n
+
+      # All-or-nothing: NO new ContentIngestionWorker job was enqueued for the tenant.
+      assert FairShare.in_flight_count(tenant.id, :ingestion) == before_count
+    end
+
+    test "TC-36.3.2: under the threshold, a normal batch enqueues as before (byte-for-byte)",
+         %{conn: conn} do
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      # A little backlog, well under the threshold — the gate must not fire.
+      :ok = seed_ingestion_backlog(tenant.id, 2)
+
+      items = [
+        %{content: "Under-threshold item one", source_type: "newsletter"},
+        %{content: "Under-threshold item two", source_type: "newsletter"}
+      ]
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{items: items})
+
+      body = json_response(conn, 200)
+      assert length(body["data"]) == 2
+      assert Enum.all?(body["data"], fn r -> r["status"] == "queued" end)
+    end
+
+    test "TC-36.3.4: the check is tenant-scoped — A's backlog never blocks B",
+         %{conn: conn} do
+      tenant_a = keyed_tenant()
+      tenant_b = keyed_tenant()
+      {key_b, _} = fixture(:api_key, %{tenant_id: tenant_b.id, role: :orchestrator})
+
+      # Tenant A is FAR over threshold; tenant B is empty.
+      :ok = seed_ingestion_backlog(tenant_a.id, ObanConfig.ingest_backlog_max())
+      assert FairShare.in_flight_count(tenant_b.id, :ingestion) == 0
+
+      # B posts a valid batch and succeeds — A's backlog does not affect it (the count
+      # fragment is scoped to args->>'tenant_id' = B only).
+      conn =
+        conn
+        |> auth_conn(key_b)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{
+          items: [%{content: "Tenant B item", source_type: "newsletter"}]
+        })
+
+      body = json_response(conn, 200)
+      assert length(body["data"]) == 1
+      assert Enum.all?(body["data"], fn r -> r["status"] == "queued" end)
     end
   end
 

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -773,6 +773,34 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       assert length(body["data"]) == 1
       assert Enum.all?(body["data"], fn r -> r["status"] == "queued" end)
     end
+
+    test "TC-36.3.5: the admission gate FAILS OPEN when the backlog count raises (no 500)",
+         %{conn: conn} do
+      # The count runs under a 2s statement_timeout on a fleet-wide (state,queue) index
+      # scan, so during the deep-queue flood this feature targets it can time out and
+      # RAISE. Mirroring the US-36.2 fair-share gate, an unmeasurable count must ADMIT
+      # the batch (an innocent tenant must never get a generic HTTP 500), not block it.
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      # Simulate a statement_timeout / transient DB error from the backlog count via the
+      # DI seam (overrides the DataCase default that delegates to the real count).
+      expect(Loopctl.MockBacklogCounter, :in_flight_count, fn _tenant_id, _queue ->
+        raise DBConnection.ConnectionError, "simulated statement_timeout"
+      end)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{
+          items: [%{content: "Fail-open batch item", source_type: "newsletter"}]
+        })
+
+      # Fail OPEN: the batch is admitted (200) and the item enqueues, rather than 500.
+      body = json_response(conn, 200)
+      assert length(body["data"]) == 1
+      assert Enum.all?(body["data"], fn r -> r["status"] == "queued" end)
+    end
   end
 
   # --- GET /api/v1/knowledge/ingestion-jobs ---

--- a/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_ingestion_controller_test.exs
@@ -717,13 +717,42 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       assert body["error"]["status"] == 429
       assert body["error"]["message"] =~ "No items from this batch were enqueued"
 
-      # Retry-After header is a positive integer string.
+      # Retry-After header is a positive integer string, tied to the ingestion drain
+      # cadence (NOT the sub-second fair-share snooze base) so a compliant client does
+      # not hot-loop retry->429.
       assert [retry_after] = get_resp_header(conn, "retry-after")
       assert {n, ""} = Integer.parse(retry_after)
       assert n > 0
       assert body["error"]["retry_after_seconds"] == n
+      assert n == ObanConfig.ingest_backlog_retry_after_seconds()
 
       # All-or-nothing: NO new ContentIngestionWorker job was enqueued for the tenant.
+      assert FairShare.in_flight_count(tenant.id, :ingestion) == before_count
+    end
+
+    test "TC-36.3.6: the SINGLE-item ingest path is gated too (no bypass of the valve)",
+         %{conn: conn} do
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      max = ObanConfig.ingest_backlog_max()
+      :ok = seed_ingestion_backlog(tenant.id, max)
+      before_count = FairShare.in_flight_count(tenant.id, :ingestion)
+
+      # Looping the single-item endpoint must NOT bypass the batch backpressure valve.
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest", %{
+          content: "Over-threshold single item",
+          source_type: "newsletter"
+        })
+
+      body = json_response(conn, 429)
+      assert body["error"]["code"] == "ingestion_backlog_exceeded"
+      assert [_retry_after] = get_resp_header(conn, "retry-after")
+
+      # No new job enqueued — the single-item path shed the request like the batch path.
       assert FairShare.in_flight_count(tenant.id, :ingestion) == before_count
     end
 
@@ -783,9 +812,29 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       tenant = keyed_tenant()
       {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
 
+      # The fail-open path emits an alertable telemetry counter so "the valve is currently
+      # admitting because it can't measure" is observable, not just a warning log.
+      test_pid = self()
+      handler_id = "backlog-failopen-#{System.unique_integer([:positive])}"
+      event = [:loopctl, :ingestion, :backlog_gate, :failed_open]
+
+      :telemetry.attach(
+        handler_id,
+        event,
+        fn ^event, measurements, metadata, _ ->
+          if metadata.tenant_id == tenant.id,
+            do: send(test_pid, {:backlog_failed_open, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
       # Simulate a statement_timeout / transient DB error from the backlog count via the
-      # DI seam (overrides the DataCase default that delegates to the real count).
-      expect(Loopctl.MockBacklogCounter, :in_flight_count, fn _tenant_id, _queue ->
+      # DI seam (overrides the DataCase default that delegates to the real count). The
+      # controller now rescues ONLY DB timeout/connection classes, so this must raise one
+      # of them (a bare error would propagate and 500 by design).
+      expect(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn _tenant_id ->
         raise DBConnection.ConnectionError, "simulated statement_timeout"
       end)
 
@@ -800,6 +849,31 @@ defmodule LoopctlWeb.KnowledgeIngestionControllerTest do
       body = json_response(conn, 200)
       assert length(body["data"]) == 1
       assert Enum.all?(body["data"], fn r -> r["status"] == "queued" end)
+
+      # ...and the fail-open telemetry fired with the bounded error_class tag.
+      assert_receive {:backlog_failed_open, %{count: 1}, metadata}
+      assert metadata.error_class == "connection"
+    end
+
+    test "TC-36.3.7: a NON-DB error in the backlog count propagates (500), not fail-open",
+         %{conn: conn} do
+      # A programming error in the count path must NOT be silently swallowed into a
+      # fleet-wide disabling of backpressure — it must surface (rescue is narrowed to DB
+      # timeout/connection classes only).
+      tenant = keyed_tenant()
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      expect(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn _tenant_id ->
+        raise ArgumentError, "simulated bug in count path"
+      end)
+
+      assert_raise ArgumentError, fn ->
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/knowledge/ingest/batch", %{
+          items: [%{content: "Bug batch item", source_type: "newsletter"}]
+        })
+      end
     end
   end
 

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -17,6 +17,7 @@ defmodule Loopctl.DataCase do
   use ExUnit.CaseTemplate
 
   alias Ecto.Adapters.SQL.Sandbox
+  alias Loopctl.Oban.FairShare
   alias Loopctl.Telemetry.ScaleAlerts
   alias Loopctl.Telemetry.ScaleMetrics
   alias Loopctl.Webhooks.ReqDelivery
@@ -93,6 +94,15 @@ defmodule Loopctl.DataCase do
     # tests. The degraded-branch test overrides this with Mox.expect/3.
     Mox.stub(Loopctl.MockObanOrphanCountChecker, :cached_executing_orphan_count, fn ->
       {:ok, ScaleMetrics.count_oban_executing_orphans()}
+    end)
+
+    # US-36.3: default delegates to the real FairShare.in_flight_count/2 — a fresh,
+    # per-call count scoped to THIS test's own sandboxed transaction — so every
+    # existing batch-ingest backlog test (seeded oban_jobs rows) exercises the real
+    # count unchanged. The fail-open test overrides this with Mox.expect/3 to raise,
+    # deterministically driving the controller's fail-open (count error -> admit) path.
+    Mox.stub(Loopctl.MockBacklogCounter, :in_flight_count, fn tenant_id, queue ->
+      FairShare.in_flight_count(tenant_id, queue)
     end)
 
     Mox.stub(Loopctl.MockRateLimiter, :check_rate, fn _bucket, _window, _limit ->

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -96,13 +96,13 @@ defmodule Loopctl.DataCase do
       {:ok, ScaleMetrics.count_oban_executing_orphans()}
     end)
 
-    # US-36.3: default delegates to the real FairShare.in_flight_count/2 — a fresh,
-    # per-call count scoped to THIS test's own sandboxed transaction — so every
+    # US-36.3: default delegates to the real FairShare.in_flight_ingestion_backlog/1 — a
+    # fresh, per-call count scoped to THIS test's own sandboxed transaction — so every
     # existing batch-ingest backlog test (seeded oban_jobs rows) exercises the real
     # count unchanged. The fail-open test overrides this with Mox.expect/3 to raise,
     # deterministically driving the controller's fail-open (count error -> admit) path.
-    Mox.stub(Loopctl.MockBacklogCounter, :in_flight_count, fn tenant_id, queue ->
-      FairShare.in_flight_count(tenant_id, queue)
+    Mox.stub(Loopctl.MockBacklogCounter, :in_flight_ingestion_backlog, fn tenant_id ->
+      FairShare.in_flight_ingestion_backlog(tenant_id)
     end)
 
     Mox.stub(Loopctl.MockRateLimiter, :check_rate, fn _bucket, _window, _limit ->

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -65,10 +65,11 @@ Mox.defmock(Loopctl.MockObanOrphanCountChecker,
   for: Loopctl.Telemetry.ScaleMetrics.OrphanCountBehaviour
 )
 
-# US-36.3: DI seam for the batch-ingest backlog admission gate's in-flight count.
-# The DataCase default stub delegates to the real `Loopctl.Oban.FairShare.in_flight_count/2`
-# (so the existing backlog tests exercise the real, sandboxed count unchanged);
-# the fail-open test overrides it with Mox.expect/3 to RAISE, deterministically
+# US-36.3: DI seam for the ingest backlog admission gate's in-flight count.
+# The DataCase default stub delegates to the real
+# `Loopctl.Oban.FairShare.in_flight_ingestion_backlog/1` (so the existing backlog tests
+# exercise the real, sandboxed, index-backed count unchanged); the fail-open test
+# overrides it with Mox.expect/3 to RAISE a DB timeout/connection error, deterministically
 # driving the controller's fail-open path (count error -> admit, never 500).
 Mox.defmock(Loopctl.MockBacklogCounter, for: Loopctl.Oban.BacklogCounterBehaviour)
 

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -65,6 +65,13 @@ Mox.defmock(Loopctl.MockObanOrphanCountChecker,
   for: Loopctl.Telemetry.ScaleMetrics.OrphanCountBehaviour
 )
 
+# US-36.3: DI seam for the batch-ingest backlog admission gate's in-flight count.
+# The DataCase default stub delegates to the real `Loopctl.Oban.FairShare.in_flight_count/2`
+# (so the existing backlog tests exercise the real, sandboxed count unchanged);
+# the fail-open test overrides it with Mox.expect/3 to RAISE, deterministically
+# driving the controller's fail-open path (count error -> admit, never 500).
+Mox.defmock(Loopctl.MockBacklogCounter, for: Loopctl.Oban.BacklogCounterBehaviour)
+
 # US-27.3: the DBErrorBackstop test seam is a REAL plug (Loopctl.Test.BackstopRouter,
 # wired via config/test.exs), NOT a Mox mock — so the production router stays on
 # the hot path for every request and the catch/log/sanitize path is exercised by


### PR DESCRIPTION
## US-36.3 — Batch-ingest backlog backpressure (429)

Adds an admission gate to `POST /api/v1/knowledge/ingest/batch`. Before enqueuing **any** item, the endpoint checks the calling tenant's in-flight `:ingestion` backlog (the broad non-terminal Oban set — `available`/`scheduled`/`executing`/`retryable`) via the US-36.2 `Loopctl.Oban.FairShare.in_flight_count/2` helper. If it is at/over an env-driven threshold, the whole request is rejected **all-or-nothing** with HTTP 429 + `Retry-After` and a structured error — zero jobs enqueued. Under threshold, behavior is byte-for-byte unchanged.

This bounds **accumulation**, complementing US-36.2's fair-share gate (which bounds per-tenant executing **concurrency**).

### Acceptance criteria
- **AC-36.3.1** — Backlog checked before enqueue; `>= threshold` -> 429 + `Retry-After`, no jobs enqueued (all-or-nothing).
- **AC-36.3.2** — Under threshold: unchanged response shape/status. The existing "queues all three items successfully" test passes unchanged.
- **AC-36.3.3** — Threshold is env-driven (`OBAN_INGEST_BACKLOG_MAX`, default 500) via `Loopctl.ObanConfig` config-based DI (read at call time, fail-loud on malformed). The 429 body carries `code: "ingestion_backlog_exceeded"`, distinct from the Hammer request-rate 429.
- **AC-36.3.4** — Tenant-scoped (only the caller's backlog counts) and cheap (single bounded count under a per-query `statement_timeout`). OpenApiSpex documents the backlog-429 (`IngestionBacklogError` schema). Tests cover over/under threshold + tenant isolation.

### Changes
- `lib/loopctl/oban_config.ex` — `ingest_backlog_max/0` (reads `OBAN_INGEST_BACKLOG_MAX`, default 500, reuses `queue_size/2` fail-loud parser).
- `lib/loopctl_web/controllers/knowledge_ingestion_controller.ex` — `check_ingestion_backlog/1` inserted into the `create_batch/2` `with` (after item validation, before enqueue); `Retry-After` tied to the fair-share snooze base; operation doc updated.
- `lib/loopctl_web/fallback_controller.ex` — new `{:error, :ingestion_backlog_exceeded, retry_after}` clause -> structured 429 + `Retry-After` header + `code`.
- `lib/loopctl/api_spec/schemas.ex` — `IngestionBacklogError` schema (mirrors `PromotionBudgetError`).
- Tests — unit (`oban_config_test.exs`: default/env-override/malformed) + integration (`knowledge_ingestion_controller_test.exs`: over threshold -> 429 + Retry-After + zero enqueued, under threshold normal, tenant isolation).

### Quality gate
`mix precommit` green — format clean, `credo --strict` clean, dialyzer clean, **4501 tests, 0 failures**.

Note: the suite has a documented, **pre-existing** intermittent flake (`extracted articles default to draft`, a single-ingest test unrelated to this change) from a Mox `$callers` inline-worker race — reproduced on `master` without these changes. The commit landed on a clean full-suite run.

Part of epic #351 (per-tenant Oban fairness & queue topology). Follows US-36.2 (#390).
