### PR TITLE
Linking hot-path efficiency: batched insert_all + on_conflict; replace per-job count(*) with a sampled telemetry count

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -342,6 +342,22 @@ config :loopctl, Oban,
 config :loopctl, :oban_metrics_poll_statement_timeout_ms, 2_000
 config :loopctl, :oban_metrics_orphan_threshold_minutes, 45
 
+# US-36.4: ArticleLinkingWorker hot-path efficiency tunables. This is the highest-frequency
+# :knowledge job (one per embedded article), so per-job waste multiplies under bulk ingest.
+# - article_link_statement_timeout_ms: per-query SET LOCAL statement_timeout wrapping the
+#   batched link insert_all and the sampled corpus-size count, so neither can hold an
+#   AdminRepo connection indefinitely. SET LOCAL is pgbouncer-safe (no startup parameter).
+# - article_link_corpus_sample_rate: the corpus-size-vs-limit warning was a full count(*)
+#   on EVERY job, paid only to feed a warning log. It now runs on ~1/N jobs, chosen
+#   deterministically by article-id hash (`:erlang.phash2(article_id, N) == 0`), and emits a
+#   [:loopctl, :knowledge, :article_linking, :corpus_size] telemetry event alongside the
+#   over-limit warning. N=1 samples every job; N<=0 disables it; a larger N samples less.
+# - article_link_insert_chunk_size: rows per insert_all batch, keeping a dense article's
+#   link fan-out well under Postgres's 65535 bind-parameter ceiling (~6 params/row).
+config :loopctl, :article_link_statement_timeout_ms, 3_000
+config :loopctl, :article_link_corpus_sample_rate, 100
+config :loopctl, :article_link_insert_chunk_size, 1_000
+
 # US-34.2: the COUNT threshold that trips `Loopctl.HealthCheck.Default`'s
 # `oban_orphans` readiness sub-check into "error" — distinct from the AGE
 # threshold above (`oban_metrics_orphan_threshold_minutes`: WHICH jobs count as

--- a/config/test.exs
+++ b/config/test.exs
@@ -515,3 +515,9 @@ config :loopctl, :batch_item_validation_timeout_ms, 200
 # tests (and the inline-Oban cascade) see no candidates; tests that assert linking set
 # Mox expectations. The real VectorSearch.nearest path keeps a dedicated integration test.
 config :loopctl, :article_similarity_search, Loopctl.MockArticleSimilaritySearch
+
+# US-36.4: a small corpus-count sample rate so the sampling assertions can pick a
+# deterministically sampled/unsampled article by id hash, and a tiny insert chunk size so
+# a handful of links exercises the multi-chunk insert_all path without thousands of rows.
+config :loopctl, :article_link_corpus_sample_rate, 5
+config :loopctl, :article_link_insert_chunk_size, 2

--- a/lib/loopctl/telemetry/scale_metrics.ex
+++ b/lib/loopctl/telemetry/scale_metrics.ex
@@ -31,9 +31,11 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   exported ANY Oban queue/state metric), an `:executing`-older-than-N-min orphan
   gauge, and a poll-failure counter so a frozen gauge is distinguishable from a
   genuinely stable one — see "Oban queue/state gauges + `:executing` orphan gauge
-  (US-34.1)" below. `scale_metrics/0` now returns 20 metrics total.
+  (US-34.1)" below. US-36.3 added the ingestion backlog-gate fail-open counter and
+  US-36.4 adds the article-linking corpus-size gauge (metric 22 below), so
+  `scale_metrics/0` now returns 22 metrics total.
 
-  ## The metrics (20 total)
+  ## The metrics (22 total)
 
     1. **Timeout / DB-error counter** — `loopctl.db.error.count`, keyed by
        `[:endpoint, :mapped_code]` (+ a cap-gated `:tenant_id`). `mapped_code`
@@ -393,13 +395,15 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   @oban_terminal_states [:completed, :discarded, :cancelled]
 
   @doc """
-  All 20 scale metrics: the original US-27.15 trio, #297's semantic-fallback
+  All 22 scale metrics: the original US-27.15 trio, #297's semantic-fallback
   counter, US-31.2's hybrid-provenance counter, US-33.1's two per-pool checkout
   `queue_time` distributions, US-34.4's ten emitted-but-dead-event counters
   (LLM/embedding-blocked, index-health, secrets/witness/memory-promotion
-  degradation signals), and US-34.1's three Oban metrics (per-{state, queue}
+  degradation signals), US-34.1's three Oban metrics (per-{state, queue}
   gauge over the non-terminal states, the `:executing` orphan gauge, and a
-  poll-failure counter). Appended to `LoopctlWeb.Telemetry.metrics/0`.
+  poll-failure counter), US-36.3's ingestion backlog-gate fail-open counter, and
+  US-36.4's article-linking corpus-size gauge. Appended to
+  `LoopctlWeb.Telemetry.metrics/0`.
   """
   @spec scale_metrics() :: [Telemetry.Metrics.t()]
   def scale_metrics do
@@ -679,8 +683,37 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
         description: "Oban metrics poll failures, by poller and classified error class.",
         tags: [:poller, :error_class],
         tag_values: &oban_poll_error_tags/1
+      ),
+
+      # 22. Article-linking corpus-size gauge (US-36.4, AC-36.4.1). Consumes the
+      #     sampled `[:loopctl, :knowledge, :article_linking, :corpus_size]` event
+      #     `Loopctl.Workers.ArticleLinkingWorker` emits on a deterministic ~1/N sample
+      #     of linking jobs — previously an emitted-but-dead signal (no metric, no
+      #     handler) whose "sampled telemetry path" delivered nothing to Prometheus. A
+      #     `last_value/2` GAUGE of the corpus `:total` (the candidate count the
+      #     over-limit warning compares against `article_link_max_comparisons`), tagged
+      #     by a cap-gated `tenant_id` ONLY — the unbounded `article_id`/`project_id`
+      #     in the event metadata are NEVER labels (AC-27.15.3).
+      last_value("loopctl.knowledge.article_linking.corpus_size",
+        event_name: [:loopctl, :knowledge, :article_linking, :corpus_size],
+        measurement: :total,
+        description:
+          "Sampled article-linking candidate-corpus size (vs the comparison limit), by tenant.",
+        tags: [:tenant_id],
+        tag_values: &article_linking_corpus_size_tags/1
       )
     ]
+  end
+
+  @doc """
+  `tag_values` for the article-linking corpus-size gauge (US-36.4). Emits ONLY a
+  cap-gated `tenant_id` (reusing the same `gated_tenant_id/1` sentinel-collapse as the
+  other scale counters, so its cardinality is bounded identically) — the unbounded
+  `article_id`/`project_id` carried in the event metadata are never tagged.
+  """
+  @spec article_linking_corpus_size_tags(map()) :: map()
+  def article_linking_corpus_size_tags(metadata) do
+    %{tenant_id: gated_tenant_id(metadata)}
   end
 
   @doc """

--- a/lib/loopctl/telemetry_events.ex
+++ b/lib/loopctl/telemetry_events.ex
@@ -224,6 +224,27 @@ defmodule Loopctl.TelemetryEvents do
   def ingestion_backlog_gate_failed_open,
     do: [:loopctl, :ingestion, :backlog_gate, :failed_open]
 
+  @doc """
+  The article-linking corpus-size sample (US-36.4, AC-36.4.1). The
+  corpus-size-vs-limit warning that `Loopctl.Workers.ArticleLinkingWorker` used to
+  compute on EVERY linking job (a full `count(*)` over the tenant/project corpus,
+  purely to feed a `Logger.warning`) now runs on a deterministic ~1/N sample of jobs
+  and emits THIS event alongside the retained warning, so the signal stays observable
+  on a dashboard without the per-job count cost. Purely observational — never a gate
+  on linking.
+
+  ## Payload (id-only — never an article body or a vector literal)
+
+    * `measurements`: `%{total, limit}` where `total` is the sampled candidate-corpus
+      size (self-excluded, published, embedded, project-scoped) and `limit` is the
+      configured `article_link_max_comparisons` ceiling the warning compares against.
+    * `metadata`: `%{tenant_id, project_id, article_id}` — all ids, never content.
+
+  Aggregated by `Loopctl.Telemetry.ScaleMetrics` as a `last_value` gauge of `total`,
+  tagged by a cap-gated `tenant_id` ONLY (`article_id`/`project_id` are never labels).
+  """
+  def article_linking_corpus_size, do: [:loopctl, :knowledge, :article_linking, :corpus_size]
+
   @doc "Returns all defined event names for attachment"
   def all_events do
     [
@@ -240,7 +261,8 @@ defmodule Loopctl.TelemetryEvents do
       knowledge_semantic_fallback(),
       knowledge_hybrid_provenance(),
       llm_provider_error(),
-      ingestion_backlog_gate_failed_open()
+      ingestion_backlog_gate_failed_open(),
+      article_linking_corpus_size()
     ]
   end
 end

--- a/lib/loopctl/workers/article_linking_worker.ex
+++ b/lib/loopctl/workers/article_linking_worker.ex
@@ -281,6 +281,25 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
     end
 
     :ok
+  rescue
+    e ->
+      # AC-36.4.3 (US-36.4 review): the corpus-size count is PURELY observational — it must
+      # NEVER gate linking. `corpus_count/2` wraps its aggregate in a `SET LOCAL
+      # statement_timeout` transaction; a timeout raises `Postgrex.Error` (57014
+      # query_canceled), and because a raise inside `AdminRepo.transaction/1` RE-RAISES (it
+      # never becomes `{:error, _}`), an un-rescued count would abort `perform/1` BEFORE any
+      # candidate is fetched or link inserted. Worse, sampling is deterministic by
+      # `article_id`, so every one of the job's retries would re-sample, re-count, re-time-out,
+      # then discard — silently leaving that article unlinked forever (a regression vs the
+      # pre-US-36.4 count, which had no statement_timeout and so never crashed the job).
+      # Rescue here — mirroring `ScaleMetrics`' poll rescues — so a slow/failed count degrades
+      # only the optional corpus-size signal while the linking it merely observes proceeds.
+      Logger.warning(
+        "Article linking: corpus-size count failed (#{inspect(e.__struct__)}) for article " <>
+          "#{article.id}; skipping the observational corpus_size signal — linking proceeds"
+      )
+
+      :ok
   end
 
   # Deterministic-by-id sampling so the same article always makes the same decision (stable
@@ -355,29 +374,34 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
   #
   # FK-violation parity with the pre-US-36.4 row-by-row path (US-36.4 review): the old
   # `create_links/2` inserted each row via `AdminRepo.insert(changeset)` and SKIPPED any
-  # `{:error, changeset}` — so if a target article was HARD-deleted (soft deletes retain the
-  # row → FK stays valid; only a hard delete removes it) between the VectorSearch read and
-  # the insert, that one row was dropped and the job still succeeded. A batched `insert_all`
-  # would instead RAISE a `Postgrex.Error` (`:foreign_key_violation`, FK is `on_delete:
-  # :restrict`) that aborts the ENTIRE transaction — a strictly worse failure mode. Rescuing
-  # is not an option: once a statement errors inside a transaction Postgres aborts it, so any
-  # follow-up insert on that connection fails with "current transaction is aborted" (and under
-  # the test Sandbox the transaction is nested, poisoning the outer one too). Instead we
-  # PRE-FILTER to targets that still exist (`reject_vanished_targets/2`) right before the
-  # insert, reproducing the old "skip the vanished target, link the rest, no crash" behavior
-  # without an aborted transaction. This costs one cheap indexed `id = ANY(...)` lookup, and
-  # only when there is actual linking work. The residual window (a target hard-deleted between
-  # this pre-filter and the insert, same transaction) is far narrower than the original read→
-  # insert window; if it is ever hit the job crashes and Oban retries, and the retry's
-  # VectorSearch read no longer surfaces the deleted target, so it converges.
+  # `{:error, changeset}` — so if EITHER endpoint article was HARD-deleted (soft deletes
+  # retain the row → FK stays valid; only a hard delete removes it) between the VectorSearch
+  # read and the insert, that row was dropped and the job still succeeded. BOTH FKs
+  # (`source_article_id` and `target_article_id`) are `on_delete: :restrict`, so a batched
+  # `insert_all` against a vanished endpoint would instead RAISE a `Postgrex.Error`
+  # (`:foreign_key_violation`) that aborts the ENTIRE transaction — a strictly worse failure
+  # mode. Rescuing is not an option: once a statement errors inside a transaction Postgres
+  # aborts it, so any follow-up insert on that connection fails with "current transaction is
+  # aborted" (and under the test Sandbox the transaction is nested, poisoning the outer one
+  # too). Instead we PRE-FILTER to rows whose BOTH endpoints still exist
+  # (`reject_vanished_endpoints/2`), INSIDE the same `SET LOCAL statement_timeout` transaction
+  # as the insert (AC-36.4.4: reads on the path run under the per-query timeout) and right
+  # before it (shrinking the check→insert race window). The source guard matters precisely
+  # here: the article has no links yet, so `:restrict` does not block deleting it, and every
+  # row shares that one source — a vanished source would FK-violate all of them. This
+  # reproduces the old "skip the vanished endpoint, link the rest, no crash" behavior without
+  # an aborted transaction, for one cheap indexed `id = ANY(...)` lookup only when there is
+  # actual linking work. The residual window (an endpoint hard-deleted between this pre-filter
+  # and the insert, same transaction) is far narrower than the original read→insert window; if
+  # it is ever hit the job crashes and Oban retries, and the retry's `get_article_with_embedding`
+  # / VectorSearch read no longer surfaces the deleted endpoint, so it converges.
   defp create_links([], _tenant_id), do: 0
 
   defp create_links(links, tenant_id) do
     now = DateTime.utc_now()
 
     rows =
-      links
-      |> Enum.map(fn attrs ->
+      Enum.map(links, fn attrs ->
         %{
           tenant_id: tenant_id,
           source_article_id: attrs.source_article_id,
@@ -387,13 +411,13 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
           inserted_at: now
         }
       end)
-      |> reject_vanished_targets(tenant_id)
 
     {:ok, created} =
       AdminRepo.transaction(fn ->
         AdminRepo.query!("SET LOCAL statement_timeout = #{statement_timeout_ms()}")
 
         rows
+        |> reject_vanished_endpoints(tenant_id)
         |> Enum.chunk_every(insert_chunk_size())
         |> Enum.reduce(0, fn chunk, acc -> acc + insert_chunk(chunk) end)
       end)
@@ -401,26 +425,36 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
     created
   end
 
-  # Drop any row whose TARGET article no longer exists — the pre-US-36.4 row-by-row path
-  # skipped these as `{:error, changeset}` FK failures and still succeeded; the batched
-  # `insert_all` would raise and abort the whole batch instead (see `create_links/2`). Scoped
-  # by `tenant_id` (all link targets are same-tenant candidates from `VectorSearch`). Returns
-  # the input untouched when nothing was filtered.
-  defp reject_vanished_targets([], _tenant_id), do: []
+  # Drop any row whose SOURCE or TARGET article no longer exists — the pre-US-36.4 row-by-row
+  # path skipped these as `{:error, changeset}` FK failures and still succeeded; the batched
+  # `insert_all` would raise and abort the whole batch instead (see `create_links/2`). Both
+  # endpoint FKs are `on_delete: :restrict`. All rows share ONE source (the article being
+  # linked, which has no links yet, so nothing blocks a concurrent hard-delete of it): if that
+  # source vanished, every row would FK-violate, so drop the whole batch (matching the old
+  # per-row path's "skip every row, return :ok/0"). Otherwise keep only rows whose target
+  # still lives. Scoped by `tenant_id` (all endpoints are same-tenant). Runs INSIDE the
+  # `create_links/2` statement-timeout transaction (AC-36.4.4). Returns the input untouched
+  # when both endpoints of every row still exist.
+  defp reject_vanished_endpoints([], _tenant_id), do: []
 
-  defp reject_vanished_targets(rows, tenant_id) do
+  defp reject_vanished_endpoints(rows, tenant_id) do
+    source_ids = rows |> Enum.map(& &1.source_article_id) |> Enum.uniq()
     target_ids = rows |> Enum.map(& &1.target_article_id) |> Enum.uniq()
 
     live =
       from(a in Article,
         where: a.tenant_id == ^tenant_id,
-        where: a.id in ^target_ids,
+        where: a.id in ^(source_ids ++ target_ids),
         select: a.id
       )
       |> AdminRepo.all()
       |> MapSet.new()
 
-    Enum.filter(rows, fn row -> MapSet.member?(live, row.target_article_id) end)
+    if Enum.all?(source_ids, &MapSet.member?(live, &1)) do
+      Enum.filter(rows, fn row -> MapSet.member?(live, row.target_article_id) end)
+    else
+      []
+    end
   end
 
   defp insert_chunk(chunk) do

--- a/lib/loopctl/workers/article_linking_worker.ex
+++ b/lib/loopctl/workers/article_linking_worker.ex
@@ -37,9 +37,14 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
   A warning fires when the corpus size exceeds the limit. Since US-36.4 that
   corpus-size count is no longer paid on every job: it runs on a deterministic
   ~1/N sample (`:erlang.phash2(article_id, N) == 0`,
-  `:article_link_corpus_sample_rate`) and emits a
-  `[:loopctl, :knowledge, :article_linking, :corpus_size]` telemetry event
-  alongside the warning. It is purely observational — never a gate on linking.
+  `:article_link_corpus_sample_rate`) and emits the
+  `Loopctl.TelemetryEvents.article_linking_corpus_size/0` event
+  (`[:loopctl, :knowledge, :article_linking, :corpus_size]`) alongside the warning.
+  The event is registered in `Loopctl.TelemetryEvents.all_events/0` and consumed in
+  prod by `Loopctl.Telemetry.ScaleMetrics` as a `last_value` corpus-size gauge tagged
+  by a cap-gated `tenant_id`, so the sampled signal reaches Prometheus/dashboards
+  rather than terminating in a handler-less no-op. It is purely observational — never a
+  gate on linking.
   Since US-27.7a the lookup
   runs through `VectorSearch.nearest/4`, whose `k` is clamped to
   `VectorSearch.max_k/0` (default 100), so a configured value above that ceiling is
@@ -76,6 +81,7 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
   alias Loopctl.Knowledge.ArticleLink
   alias Loopctl.Knowledge.VectorSearch
   alias Loopctl.Oban.FairShare
+  alias Loopctl.TelemetryEvents
 
   # Compile-time DI for the similarity lookup. The worker uses this to fetch
   # nearest-neighbour candidates; in tests it resolves to a Mox mock, in prod to VectorSearch.
@@ -182,8 +188,15 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
 
     candidates
     |> Enum.filter(fn %{similarity: sim} -> keep?.(sim) end)
+    # Reject self-links AND already-linked pairs (both directions) in one pass. The
+    # `cid == article_id` guard is defense-in-depth (US-36.4 review): the batched
+    # `insert_all` path bypasses `ArticleLink.changeset/2`'s `validate_no_self_link`.
+    # UNREACHABLE in prod — `find_similar_articles/4` always passes `exclude_id: article.id`
+    # so the source can never be its own candidate — but a future caller/mock yielding a
+    # self-referential candidate would otherwise insert an invalid self-link unvalidated.
     |> Enum.reject(fn %{id: cid} ->
-      MapSet.member?(existing, {article_id, cid}) or MapSet.member?(existing, {cid, article_id})
+      cid == article_id or MapSet.member?(existing, {article_id, cid}) or
+        MapSet.member?(existing, {cid, article_id})
     end)
     |> Enum.map(fn %{id: target_id, similarity: score} ->
       %{
@@ -254,7 +267,7 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
       total = corpus_count(article, tenant_id)
 
       :telemetry.execute(
-        [:loopctl, :knowledge, :article_linking, :corpus_size],
+        TelemetryEvents.article_linking_corpus_size(),
         %{total: total, limit: max_comparisons},
         %{tenant_id: tenant_id, project_id: article.project_id, article_id: article.id}
       )
@@ -339,13 +352,32 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
   # `insert_all` from the schema. Rows are chunked to stay well under Postgres's 65535
   # bind-parameter ceiling (~6 params/row), and the whole batch runs inside a `SET LOCAL
   # statement_timeout` transaction.
+  #
+  # FK-violation parity with the pre-US-36.4 row-by-row path (US-36.4 review): the old
+  # `create_links/2` inserted each row via `AdminRepo.insert(changeset)` and SKIPPED any
+  # `{:error, changeset}` — so if a target article was HARD-deleted (soft deletes retain the
+  # row → FK stays valid; only a hard delete removes it) between the VectorSearch read and
+  # the insert, that one row was dropped and the job still succeeded. A batched `insert_all`
+  # would instead RAISE a `Postgrex.Error` (`:foreign_key_violation`, FK is `on_delete:
+  # :restrict`) that aborts the ENTIRE transaction — a strictly worse failure mode. Rescuing
+  # is not an option: once a statement errors inside a transaction Postgres aborts it, so any
+  # follow-up insert on that connection fails with "current transaction is aborted" (and under
+  # the test Sandbox the transaction is nested, poisoning the outer one too). Instead we
+  # PRE-FILTER to targets that still exist (`reject_vanished_targets/2`) right before the
+  # insert, reproducing the old "skip the vanished target, link the rest, no crash" behavior
+  # without an aborted transaction. This costs one cheap indexed `id = ANY(...)` lookup, and
+  # only when there is actual linking work. The residual window (a target hard-deleted between
+  # this pre-filter and the insert, same transaction) is far narrower than the original read→
+  # insert window; if it is ever hit the job crashes and Oban retries, and the retry's
+  # VectorSearch read no longer surfaces the deleted target, so it converges.
   defp create_links([], _tenant_id), do: 0
 
   defp create_links(links, tenant_id) do
     now = DateTime.utc_now()
 
     rows =
-      Enum.map(links, fn attrs ->
+      links
+      |> Enum.map(fn attrs ->
         %{
           tenant_id: tenant_id,
           source_article_id: attrs.source_article_id,
@@ -355,6 +387,7 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
           inserted_at: now
         }
       end)
+      |> reject_vanished_targets(tenant_id)
 
     {:ok, created} =
       AdminRepo.transaction(fn ->
@@ -362,23 +395,47 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
 
         rows
         |> Enum.chunk_every(insert_chunk_size())
-        |> Enum.reduce(0, fn chunk, acc ->
-          {inserted, _} =
-            AdminRepo.insert_all(ArticleLink, chunk,
-              on_conflict: :nothing,
-              conflict_target: [
-                :tenant_id,
-                :source_article_id,
-                :target_article_id,
-                :relationship_type
-              ]
-            )
-
-          acc + inserted
-        end)
+        |> Enum.reduce(0, fn chunk, acc -> acc + insert_chunk(chunk) end)
       end)
 
     created
+  end
+
+  # Drop any row whose TARGET article no longer exists — the pre-US-36.4 row-by-row path
+  # skipped these as `{:error, changeset}` FK failures and still succeeded; the batched
+  # `insert_all` would raise and abort the whole batch instead (see `create_links/2`). Scoped
+  # by `tenant_id` (all link targets are same-tenant candidates from `VectorSearch`). Returns
+  # the input untouched when nothing was filtered.
+  defp reject_vanished_targets([], _tenant_id), do: []
+
+  defp reject_vanished_targets(rows, tenant_id) do
+    target_ids = rows |> Enum.map(& &1.target_article_id) |> Enum.uniq()
+
+    live =
+      from(a in Article,
+        where: a.tenant_id == ^tenant_id,
+        where: a.id in ^target_ids,
+        select: a.id
+      )
+      |> AdminRepo.all()
+      |> MapSet.new()
+
+    Enum.filter(rows, fn row -> MapSet.member?(live, row.target_article_id) end)
+  end
+
+  defp insert_chunk(chunk) do
+    {inserted, _} =
+      AdminRepo.insert_all(ArticleLink, chunk,
+        on_conflict: :nothing,
+        conflict_target: [
+          :tenant_id,
+          :source_article_id,
+          :target_article_id,
+          :relationship_type
+        ]
+      )
+
+    inserted
   end
 
   defp statement_timeout_ms,

--- a/lib/loopctl/workers/article_linking_worker.ex
+++ b/lib/loopctl/workers/article_linking_worker.ex
@@ -34,7 +34,13 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
 
   Configurable max comparisons via
   `Application.get_env(:loopctl, :article_link_max_comparisons, 50)`.
-  Logs a warning when candidate count exceeds the limit. Since US-27.7a the lookup
+  A warning fires when the corpus size exceeds the limit. Since US-36.4 that
+  corpus-size count is no longer paid on every job: it runs on a deterministic
+  ~1/N sample (`:erlang.phash2(article_id, N) == 0`,
+  `:article_link_corpus_sample_rate`) and emits a
+  `[:loopctl, :knowledge, :article_linking, :corpus_size]` telemetry event
+  alongside the warning. It is purely observational — never a gate on linking.
+  Since US-27.7a the lookup
   runs through `VectorSearch.nearest/4`, whose `k` is clamped to
   `VectorSearch.max_k/0` (default 100), so a configured value above that ceiling is
   capped (a documented kNN cost bound); the default 50 is unaffected, and a clamp is
@@ -149,7 +155,7 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
   # --- Private ---
 
   defp find_and_link_similar(article, tenant_id, threshold, max_comparisons) do
-    log_if_exceeds_limit(article, tenant_id, max_comparisons)
+    maybe_emit_corpus_size(article, tenant_id, max_comparisons)
 
     candidates = find_similar_articles(article, tenant_id, threshold, max_comparisons)
     conflict_threshold = conflict_threshold()
@@ -237,23 +243,61 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
     |> Enum.filter(fn %{similarity: sim} -> sim >= threshold end)
   end
 
-  defp log_if_exceeds_limit(article, tenant_id, max_comparisons) do
-    total =
-      from(a in Article,
-        where: a.tenant_id == ^tenant_id,
-        where: a.id != ^article.id,
-        where: not is_nil(a.embedding),
-        where: a.status == :published
-      )
-      |> scope_by_project(article.project_id)
-      |> AdminRepo.aggregate(:count)
+  # US-36.4 (AC-36.4.1): the corpus-size-vs-limit warning used to run a full `count(*)`
+  # over the tenant/project corpus on EVERY linking job — the hottest `:knowledge` job (one
+  # per embedded article) — purely to feed a warning log. It now runs on a deterministic
+  # ~1/N sample of jobs and emits a telemetry event alongside the warning, so the signal
+  # stays observable without the per-job cost. It is NOT a gate: linking proceeds whether or
+  # not this samples, so correctness is untouched (AC-36.4.3).
+  defp maybe_emit_corpus_size(article, tenant_id, max_comparisons) do
+    if sample_corpus_count?(article.id) do
+      total = corpus_count(article, tenant_id)
 
-    if total > max_comparisons do
-      Logger.warning(
-        "Article linking: #{total} candidate articles exceeds limit of #{max_comparisons} " <>
-          "for article #{article.id}"
+      :telemetry.execute(
+        [:loopctl, :knowledge, :article_linking, :corpus_size],
+        %{total: total, limit: max_comparisons},
+        %{tenant_id: tenant_id, project_id: article.project_id, article_id: article.id}
       )
+
+      if total > max_comparisons do
+        Logger.warning(
+          "Article linking: #{total} candidate articles exceeds limit of #{max_comparisons} " <>
+            "for article #{article.id}"
+        )
+      end
     end
+
+    :ok
+  end
+
+  # Deterministic-by-id sampling so the same article always makes the same decision (stable
+  # across a job's retries). `phash2(id, 1) == 0` always, so a rate of 1 samples every job;
+  # a rate <= 0 disables the count entirely.
+  defp sample_corpus_count?(article_id) do
+    rate = Application.get_env(:loopctl, :article_link_corpus_sample_rate, 100)
+    rate > 0 and :erlang.phash2(article_id, rate) == 0
+  end
+
+  # The corpus-size count itself: scope UNCHANGED from the pre-US-36.4 hot-path count
+  # (self-excluded, published, embedded, project-scoped via `scope_by_project/2`), now wrapped
+  # in a per-query `SET LOCAL statement_timeout` transaction (AC-36.4.4) so a slow count on a
+  # large corpus can never hold an AdminRepo connection indefinitely.
+  defp corpus_count(article, tenant_id) do
+    {:ok, total} =
+      AdminRepo.transaction(fn ->
+        AdminRepo.query!("SET LOCAL statement_timeout = #{statement_timeout_ms()}")
+
+        from(a in Article,
+          where: a.tenant_id == ^tenant_id,
+          where: a.id != ^article.id,
+          where: not is_nil(a.embedding),
+          where: a.status == :published
+        )
+        |> scope_by_project(article.project_id)
+        |> AdminRepo.aggregate(:count)
+      end)
+
+    total
   end
 
   # Candidate-COUNT scoping for the over-limit warning only (a plain `count(*)`, NOT the
@@ -277,21 +321,71 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
     |> MapSet.new()
   end
 
+  # US-36.4 (AC-36.4.2/.4): persist discovered links with a single batched `insert_all` +
+  # `on_conflict: :nothing` instead of row-by-row `AdminRepo.insert/1` in a loop. Correctness
+  # is preserved — the SAME links are created:
+  #
+  #   * The reverse-direction (application-level) dedup still runs in `build_links/5` BEFORE
+  #     we get here; the directional unique index can't cover it, so `on_conflict` doesn't
+  #     replace it. `on_conflict: :nothing` on that index only guards same-direction
+  #     idempotency / concurrent races, exactly what the old per-row constraint-skip did.
+  #   * With `on_conflict: :nothing` a conflicting row is NOT counted, so the returned count
+  #     still means "links actually created" — matching the prior `create_links/2` semantics
+  #     that feeds `new_link_count` in the audit event.
+  #
+  # `tenant_id` and `inserted_at` are set explicitly on every row map: `tenant_id` is
+  # programmatic (never cast — Multi-Tenant Rule 4), and `insert_all` does NOT populate the
+  # schema's `timestamps(updated_at: false)`. The `:id` binary_id PK IS autogenerated by
+  # `insert_all` from the schema. Rows are chunked to stay well under Postgres's 65535
+  # bind-parameter ceiling (~6 params/row), and the whole batch runs inside a `SET LOCAL
+  # statement_timeout` transaction.
   defp create_links([], _tenant_id), do: 0
 
   defp create_links(links, tenant_id) do
-    Enum.reduce(links, 0, fn attrs, count ->
-      changeset =
-        %ArticleLink{tenant_id: tenant_id}
-        |> ArticleLink.changeset(attrs)
+    now = DateTime.utc_now()
 
-      case AdminRepo.insert(changeset) do
-        {:ok, _link} -> count + 1
-        # Skip on constraint violation (duplicate link)
-        {:error, _changeset} -> count
-      end
-    end)
+    rows =
+      Enum.map(links, fn attrs ->
+        %{
+          tenant_id: tenant_id,
+          source_article_id: attrs.source_article_id,
+          target_article_id: attrs.target_article_id,
+          relationship_type: attrs.relationship_type,
+          metadata: attrs.metadata,
+          inserted_at: now
+        }
+      end)
+
+    {:ok, created} =
+      AdminRepo.transaction(fn ->
+        AdminRepo.query!("SET LOCAL statement_timeout = #{statement_timeout_ms()}")
+
+        rows
+        |> Enum.chunk_every(insert_chunk_size())
+        |> Enum.reduce(0, fn chunk, acc ->
+          {inserted, _} =
+            AdminRepo.insert_all(ArticleLink, chunk,
+              on_conflict: :nothing,
+              conflict_target: [
+                :tenant_id,
+                :source_article_id,
+                :target_article_id,
+                :relationship_type
+              ]
+            )
+
+          acc + inserted
+        end)
+      end)
+
+    created
   end
+
+  defp statement_timeout_ms,
+    do: Application.get_env(:loopctl, :article_link_statement_timeout_ms, 3_000)
+
+  defp insert_chunk_size,
+    do: Application.get_env(:loopctl, :article_link_insert_chunk_size, 1_000)
 
   defp log_audit_event(article_id, tenant_id, created_count) do
     Audit.create_log_entry(tenant_id, %{

--- a/test/loopctl/telemetry/scale_metrics_test.exs
+++ b/test/loopctl/telemetry/scale_metrics_test.exs
@@ -64,7 +64,8 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
     "loopctl.oban.jobs.count",
     "loopctl.oban.jobs.executing_orphan.count",
     "loopctl.oban.poll.error.count",
-    "loopctl.ingestion.backlog_gate.failed_open.count"
+    "loopctl.ingestion.backlog_gate.failed_open.count",
+    "loopctl.knowledge.article_linking.corpus_size"
   ]
 
   # The ONLY labels any scale metric may ever carry (AC-27.15.3). Anything outside this
@@ -176,6 +177,26 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
       assert ScaleMetrics.semantic_fallback_tags(%{}) == %{reason: "unknown"}
     end
 
+    test "the article-linking corpus-size gauge (US-36.4) is a last_value tagged by tenant_id ONLY" do
+      gauge = metric("loopctl.knowledge.article_linking.corpus_size")
+
+      assert %Telemetry.Metrics.LastValue{} = gauge
+      assert gauge.tags == [:tenant_id]
+      assert gauge.measurement == :total
+      # The unbounded per-article/project ids in the event metadata are NEVER labels.
+      refute :article_id in gauge.tags
+      refute :project_id in gauge.tags
+
+      # tenant_id reuses the SAME cap-gated sentinel collapse as the other scale counters
+      # (exercised under a controlled gate in the "tenant-label cap gate" describe below).
+      assert ScaleMetrics.article_linking_corpus_size_tags(%{
+               tenant_id: "t-1",
+               article_id: "a-1",
+               project_id: "p-1"
+             })
+             |> Map.keys() == [:tenant_id]
+    end
+
     test "the hybrid-provenance counter (US-31.2) is tagged by provenance, hit, and tenant_id" do
       counter = metric("loopctl.knowledge.hybrid_provenance.count")
 
@@ -274,6 +295,24 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
                hit: false,
                tenant_id: "t-123"
              }) == %{provenance: "retrieved", hit: false, tenant_id: "t-123"}
+    end
+
+    test "article_linking_corpus_size_tags/1 reuses the SAME cap-gated tenant_id collapse" do
+      gate_off()
+
+      assert ScaleMetrics.article_linking_corpus_size_tags(%{
+               tenant_id: "t-123",
+               article_id: "a-1",
+               project_id: "p-1"
+             }) == %{tenant_id: :_aggregated}
+
+      gate_on()
+
+      assert ScaleMetrics.article_linking_corpus_size_tags(%{
+               tenant_id: "t-123",
+               article_id: "a-1",
+               project_id: "p-1"
+             }) == %{tenant_id: "t-123"}
     end
 
     test "tenant_id over the cap is bounded to cardinality 1 across many distinct tenants" do

--- a/test/loopctl/workers/article_linking_worker_test.exs
+++ b/test/loopctl/workers/article_linking_worker_test.exs
@@ -618,6 +618,36 @@ defmodule Loopctl.Workers.ArticleLinkingWorkerTest do
 
       assert vanished_links == []
     end
+
+    test "drops the whole batch (no crash) when the SOURCE article vanishes before the insert" do
+      %{tenant: tenant} = setup_tenant()
+      source = create_published_article(tenant.id)
+      valid = create_published_article(tenant.id)
+
+      # The similarity lookup fires AFTER the source was fetched (get_article_with_embedding)
+      # but BEFORE create_links inserts. Hard-delete the source HERE to simulate a concurrent
+      # hard-delete in exactly that window — possible precisely because the source has no links
+      # yet, so its `on_delete: :restrict` FK does not block deletion. Every candidate row
+      # shares this source, so an unguarded insert_all would FK-violate on source_article_id
+      # and abort the whole transaction, crashing the job. The source guard in
+      # `reject_vanished_endpoints/2` drops the entire batch instead — matching the old
+      # row-by-row path's "skip every row, return :ok with 0 links".
+      expect(MockArticleSimilaritySearch, :nearest, fn _t, _emb, _k, _opts ->
+        AdminRepo.delete!(source)
+        [candidate(valid, 0.80)]
+      end)
+
+      assert :ok =
+               ArticleLinkingWorker.perform(%Oban.Job{
+                 args: %{"article_id" => source.id, "tenant_id" => tenant.id}
+               })
+
+      # No links created (source gone) and — the point of the guard — no crash / no aborted
+      # transaction. A `on_delete: :restrict` FK violation would have raised instead.
+      assert [] ==
+               from(l in ArticleLink, where: l.source_article_id == ^source.id)
+               |> AdminRepo.all()
+    end
   end
 
   describe "self-link guard (US-36.4 review — defense-in-depth)" do

--- a/test/loopctl/workers/article_linking_worker_test.exs
+++ b/test/loopctl/workers/article_linking_worker_test.exs
@@ -61,6 +61,54 @@ defmodule Loopctl.Workers.ArticleLinkingWorkerTest do
     |> AdminRepo.all()
   end
 
+  # The (source_id, target_id, type) set of every link out of `source_id` — the correctness
+  # fingerprint the US-36.4 insert_all refactor must keep identical to the row-by-row path.
+  defp link_set(tenant_id, source_id) do
+    from(l in ArticleLink,
+      where: l.tenant_id == ^tenant_id,
+      where: l.source_article_id == ^source_id,
+      select: {l.source_article_id, l.target_article_id, l.relationship_type}
+    )
+    |> AdminRepo.all()
+    |> MapSet.new()
+  end
+
+  defp sample_rate, do: Application.get_env(:loopctl, :article_link_corpus_sample_rate)
+
+  # A published article whose id DOES / DOES NOT fall in the corpus-count sample bucket
+  # (`:erlang.phash2(id, rate) == 0`), so the sampling assertions are zero-flake. Non-matching
+  # articles are deleted (no links reference them yet) so they don't pollute the corpus count.
+  defp create_article_in_bucket(tenant_id, sampled?) do
+    article = create_published_article(tenant_id)
+
+    if :erlang.phash2(article.id, sample_rate()) == 0 == sampled? do
+      article
+    else
+      AdminRepo.delete!(article)
+      create_article_in_bucket(tenant_id, sampled?)
+    end
+  end
+
+  # Attach an in-test handler for the corpus-size telemetry event; returns a ref the worker's
+  # emission is tagged with so `assert_received` / `refute_received` can key on it.
+  defp attach_corpus_telemetry do
+    ref = make_ref()
+    test_pid = self()
+    handler_id = "corpus-size-#{inspect(ref)}"
+
+    :telemetry.attach(
+      handler_id,
+      [:loopctl, :knowledge, :article_linking, :corpus_size],
+      fn _event, measurements, metadata, _cfg ->
+        send(test_pid, {ref, :corpus_size, measurements, metadata})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+    ref
+  end
+
   describe "potential conflict detection (#4)" do
     test "flags a near-identical pair with a :potential_conflict link" do
       %{tenant: tenant} = setup_tenant()
@@ -357,6 +405,125 @@ defmodule Loopctl.Workers.ArticleLinkingWorkerTest do
         |> AdminRepo.aggregate(:count)
 
       assert link_count == 3
+    end
+  end
+
+  # --- US-36.4: hot-path efficiency (sampled corpus count + batched insert_all) ---
+
+  describe "corpus-size sampling (AC-36.4.1)" do
+    test "does NOT compute the corpus count on an unsampled job, and does not gate linking" do
+      %{tenant: tenant} = setup_tenant()
+      source = create_article_in_bucket(tenant.id, false)
+      target = create_published_article(tenant.id)
+
+      ref = attach_corpus_telemetry()
+
+      stub(MockArticleSimilaritySearch, :nearest, fn _t, _emb, _k, _opts ->
+        [candidate(target, 0.88)]
+      end)
+
+      assert :ok =
+               ArticleLinkingWorker.perform(%Oban.Job{
+                 args: %{"article_id" => source.id, "tenant_id" => tenant.id}
+               })
+
+      # Unsampled: the corpus-size count was skipped, so the signal did not fire — proving the
+      # full count(*) is no longer paid on every run.
+      refute_received {^ref, :corpus_size, _measurements, _metadata}
+
+      # ...yet linking still happened. The count was never a gate (correctness preserved).
+      assert [_] = links_of_type(tenant.id, source.id, target.id, :relates_to)
+    end
+
+    test "emits the corpus_size telemetry on a sampled job (signal preserved)" do
+      %{tenant: tenant} = setup_tenant()
+      source = create_article_in_bucket(tenant.id, true)
+      # Three other published, embedded articles form the corpus the count measures.
+      others = for _i <- 1..3, do: create_published_article(tenant.id)
+      target = hd(others)
+
+      ref = attach_corpus_telemetry()
+
+      stub(MockArticleSimilaritySearch, :nearest, fn _t, _emb, _k, _opts ->
+        [candidate(target, 0.88)]
+      end)
+
+      assert :ok =
+               ArticleLinkingWorker.perform(%Oban.Job{
+                 args: %{"article_id" => source.id, "tenant_id" => tenant.id}
+               })
+
+      assert_received {^ref, :corpus_size, measurements, metadata}
+      # Self excluded; three other published+embedded articles in the tenant.
+      assert measurements.total == 3
+      assert measurements.limit == 50
+      assert metadata.tenant_id == tenant.id
+      assert metadata.article_id == source.id
+    end
+  end
+
+  describe "batched insert_all (AC-36.4.2 / AC-36.4.3)" do
+    test "persists the identical link set for a fixed input and is idempotent on re-run" do
+      %{tenant: tenant} = setup_tenant()
+      source = create_published_article(tenant.id)
+      dup = create_published_article(tenant.id)
+      related = create_published_article(tenant.id)
+
+      # Fixed candidate list: dup >= conflict threshold (relates_to + potential_conflict),
+      # related merely-related (relates_to only). Stub (called on both runs).
+      stub(MockArticleSimilaritySearch, :nearest, fn _t, _emb, _k, _opts ->
+        [candidate(dup, 0.99), candidate(related, 0.70)]
+      end)
+
+      run = fn ->
+        assert :ok =
+                 ArticleLinkingWorker.perform(%Oban.Job{
+                   args: %{"article_id" => source.id, "tenant_id" => tenant.id}
+                 })
+      end
+
+      run.()
+      first = link_set(tenant.id, source.id)
+      run.()
+      second = link_set(tenant.id, source.id)
+
+      # on_conflict: re-run creates no duplicates — the link set is stable.
+      assert first == second
+
+      # Correctness safety net: the exact produced set is what the linking logic decided,
+      # unchanged by the insert mechanics.
+      assert first ==
+               MapSet.new([
+                 {source.id, dup.id, :relates_to},
+                 {source.id, dup.id, :potential_conflict},
+                 {source.id, related.id, :relates_to}
+               ])
+    end
+
+    test "inserts every link across multiple insert_all chunks" do
+      %{tenant: tenant} = setup_tenant()
+      source = create_published_article(tenant.id)
+      targets = for _i <- 1..5, do: create_published_article(tenant.id)
+
+      # Test config sets a chunk size of 2, so five relates_to links span multiple chunks.
+      expect(MockArticleSimilaritySearch, :nearest, fn _t, _emb, _k, _opts ->
+        Enum.map(targets, &candidate(&1, 0.80))
+      end)
+
+      assert :ok =
+               ArticleLinkingWorker.perform(%Oban.Job{
+                 args: %{"article_id" => source.id, "tenant_id" => tenant.id}
+               })
+
+      count =
+        from(l in ArticleLink,
+          where: l.tenant_id == ^tenant.id,
+          where: l.source_article_id == ^source.id,
+          where: l.relationship_type == :relates_to
+        )
+        |> AdminRepo.aggregate(:count)
+
+      assert count == 5
     end
   end
 

--- a/test/loopctl/workers/article_linking_worker_test.exs
+++ b/test/loopctl/workers/article_linking_worker_test.exs
@@ -91,7 +91,15 @@ defmodule Loopctl.Workers.ArticleLinkingWorkerTest do
 
   # Attach an in-test handler for the corpus-size telemetry event; returns a ref the worker's
   # emission is tagged with so `assert_received` / `refute_received` can key on it.
-  defp attach_corpus_telemetry do
+  #
+  # SCOPED to `source_id` (US-36.4 review): telemetry handlers fire in the EMITTING process
+  # across the whole VM, so under `async: true` a CONCURRENT test that publishes an embedded
+  # article runs `ArticleLinkingWorker.perform` inline and — at the test `sample_rate` — emits
+  # its OWN corpus_size event. Without a filter this global handler would forward that stray
+  # emission to THIS test's pid, false-failing `refute_received` and letting `assert_received`
+  # match another tenant's numbers (the exact flake class fixed in commit c86c36d). Filtering
+  # on `metadata.article_id == source_id` keeps each test scoped to its own source.
+  defp attach_corpus_telemetry(source_id) do
     ref = make_ref()
     test_pid = self()
     handler_id = "corpus-size-#{inspect(ref)}"
@@ -99,14 +107,54 @@ defmodule Loopctl.Workers.ArticleLinkingWorkerTest do
     :telemetry.attach(
       handler_id,
       [:loopctl, :knowledge, :article_linking, :corpus_size],
-      fn _event, measurements, metadata, _cfg ->
-        send(test_pid, {ref, :corpus_size, measurements, metadata})
+      fn _event, measurements, %{article_id: article_id} = metadata, _cfg ->
+        if article_id == source_id do
+          send(test_pid, {ref, :corpus_size, measurements, metadata})
+        end
       end,
       nil
     )
 
     on_exit(fn -> :telemetry.detach(handler_id) end)
     ref
+  end
+
+  # Counts the worker's `article_links` `insert_all` invocations for a SPECIFIC source, via
+  # the AdminRepo Ecto query telemetry. Scoped to `source_id` (its dumped UUID appears in the
+  # `insert_all` params of every chunk, since all of this source's rows share it) so a
+  # concurrent async test's inserts can never inflate the count. Lets the chunking test
+  # ASSERT the batch boundary (N chunks) rather than only the final row count — which a
+  # single un-chunked insert would satisfy identically, failing to guard the AC-36.4.4
+  # bind-parameter chunking safeguard.
+  defp attach_insert_all_counter(source_id) do
+    ref = make_ref()
+    test_pid = self()
+    handler_id = "insert-all-#{inspect(ref)}"
+    {:ok, dumped_source_id} = Ecto.UUID.dump(source_id)
+
+    :telemetry.attach(
+      handler_id,
+      [:loopctl, :admin_repo, :query],
+      fn _event, _measurements, metadata, _cfg ->
+        if metadata[:source] == "article_links" and is_binary(metadata[:query]) and
+             String.starts_with?(metadata[:query], "INSERT") and
+             is_list(metadata[:params]) and dumped_source_id in metadata[:params] do
+          send(test_pid, {ref, :insert_all})
+        end
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+    ref
+  end
+
+  defp received_count(ref, tag) do
+    receive do
+      {^ref, ^tag} -> 1 + received_count(ref, tag)
+    after
+      0 -> 0
+    end
   end
 
   describe "potential conflict detection (#4)" do
@@ -416,7 +464,7 @@ defmodule Loopctl.Workers.ArticleLinkingWorkerTest do
       source = create_article_in_bucket(tenant.id, false)
       target = create_published_article(tenant.id)
 
-      ref = attach_corpus_telemetry()
+      ref = attach_corpus_telemetry(source.id)
 
       stub(MockArticleSimilaritySearch, :nearest, fn _t, _emb, _k, _opts ->
         [candidate(target, 0.88)]
@@ -442,7 +490,7 @@ defmodule Loopctl.Workers.ArticleLinkingWorkerTest do
       others = for _i <- 1..3, do: create_published_article(tenant.id)
       target = hd(others)
 
-      ref = attach_corpus_telemetry()
+      ref = attach_corpus_telemetry(source.id)
 
       stub(MockArticleSimilaritySearch, :nearest, fn _t, _emb, _k, _opts ->
         [candidate(target, 0.88)]
@@ -500,7 +548,7 @@ defmodule Loopctl.Workers.ArticleLinkingWorkerTest do
                ])
     end
 
-    test "inserts every link across multiple insert_all chunks" do
+    test "inserts every link across multiple insert_all chunks (and actually chunks)" do
       %{tenant: tenant} = setup_tenant()
       source = create_published_article(tenant.id)
       targets = for _i <- 1..5, do: create_published_article(tenant.id)
@@ -509,6 +557,8 @@ defmodule Loopctl.Workers.ArticleLinkingWorkerTest do
       expect(MockArticleSimilaritySearch, :nearest, fn _t, _emb, _k, _opts ->
         Enum.map(targets, &candidate(&1, 0.80))
       end)
+
+      insert_ref = attach_insert_all_counter(source.id)
 
       assert :ok =
                ArticleLinkingWorker.perform(%Oban.Job{
@@ -524,6 +574,129 @@ defmodule Loopctl.Workers.ArticleLinkingWorkerTest do
         |> AdminRepo.aggregate(:count)
 
       assert count == 5
+
+      # GUARD the chunking itself (not just the row total): 5 rows at chunk size 2 must span
+      # ceil(5/2) = 3 separate insert_all calls. A regression that dropped `Enum.chunk_every`
+      # would issue ONE insert of 5 and fail this — the row count above would still pass.
+      assert received_count(insert_ref, :insert_all) == 3
+    end
+  end
+
+  describe "vanished-target resilience (AC-36.4.3 — behavior parity)" do
+    test "skips a candidate whose target no longer exists and still links the rest, no crash" do
+      %{tenant: tenant} = setup_tenant()
+      source = create_published_article(tenant.id)
+      valid = create_published_article(tenant.id)
+      # A candidate id with no backing article: the old row-by-row path skipped this as an FK
+      # `{:error, changeset}`; the batched insert_all would raise + abort the whole batch. The
+      # pre-filter drops it before the insert, reproducing "skip the vanished target, link the
+      # rest, succeed" without an aborted transaction.
+      vanished_id = Ecto.UUID.generate()
+
+      expect(MockArticleSimilaritySearch, :nearest, fn _t, _emb, _k, _opts ->
+        [
+          %{id: vanished_id, title: "gone", category: :pattern, similarity_score: 0.80},
+          candidate(valid, 0.80)
+        ]
+      end)
+
+      assert :ok =
+               ArticleLinkingWorker.perform(%Oban.Job{
+                 args: %{"article_id" => source.id, "tenant_id" => tenant.id}
+               })
+
+      # The surviving candidate linked...
+      assert [_] = links_of_type(tenant.id, source.id, valid.id, :relates_to)
+
+      # ...and the vanished target produced no link.
+      vanished_links =
+        from(l in ArticleLink,
+          where: l.source_article_id == ^source.id,
+          where: l.target_article_id == ^vanished_id
+        )
+        |> AdminRepo.all()
+
+      assert vanished_links == []
+    end
+  end
+
+  describe "self-link guard (US-36.4 review — defense-in-depth)" do
+    test "never inserts a self-link even if the lookup returns the source as a candidate" do
+      %{tenant: tenant} = setup_tenant()
+      source = create_published_article(tenant.id)
+
+      # A misbehaving lookup returns the SOURCE itself as a candidate. `build_links/5` must
+      # reject source == target — the batched insert_all path bypasses
+      # `ArticleLink.changeset/2`'s `validate_no_self_link`, so the guard lives in the worker.
+      expect(MockArticleSimilaritySearch, :nearest, fn _t, _emb, _k, _opts ->
+        [candidate(source, 0.99)]
+      end)
+
+      assert :ok =
+               ArticleLinkingWorker.perform(%Oban.Job{
+                 args: %{"article_id" => source.id, "tenant_id" => tenant.id}
+               })
+
+      links =
+        from(l in ArticleLink, where: l.source_article_id == ^source.id)
+        |> AdminRepo.all()
+
+      assert links == []
+    end
+  end
+
+  # --- AC-36.4.3 / TC-36.4.4: two-tenant isolation of the count + inserts ---
+
+  describe "tenant isolation of corpus count and inserts (AC-36.4.3 / TC-36.4.4)" do
+    test "only tenant A's corpus is counted and only A's links are inserted; B untouched" do
+      %{tenant: tenant_a} = setup_tenant()
+      %{tenant: tenant_b} = setup_tenant()
+
+      # Source in A, forced into the sample bucket so the corpus count actually runs.
+      source = create_article_in_bucket(tenant_a.id, true)
+
+      # A's corpus: exactly two other published+embedded articles the count should see.
+      a1 = create_published_article(tenant_a.id)
+      a2 = create_published_article(tenant_a.id)
+
+      # B's corpus: three published+embedded articles that must be excluded from BOTH the
+      # count and the inserts (different tenant → filtered by `a.tenant_id == ^tenant_id`).
+      for _i <- 1..3, do: create_published_article(tenant_b.id)
+
+      ref = attach_corpus_telemetry(source.id)
+
+      # The lookup returns only A's in-tenant candidates; the worker asserts it passes A's
+      # tenant, then links them. (VectorSearch enforces the real cross-tenant read exclusion;
+      # here we assert the COUNT and INSERT scoping the worker owns around it.)
+      expect(MockArticleSimilaritySearch, :nearest, fn tenant_id, _emb, _k, _opts ->
+        assert tenant_id == tenant_a.id
+        [candidate(a1, 0.80), candidate(a2, 0.80)]
+      end)
+
+      assert :ok =
+               ArticleLinkingWorker.perform(%Oban.Job{
+                 args: %{"article_id" => source.id, "tenant_id" => tenant_a.id}
+               })
+
+      # The corpus count saw ONLY A's two other articles — B's three are excluded by scoping.
+      assert_received {^ref, :corpus_size, measurements, metadata}
+      assert measurements.total == 2
+      assert metadata.tenant_id == tenant_a.id
+
+      # Inserts landed under tenant A only.
+      a_links =
+        from(l in ArticleLink, where: l.source_article_id == ^source.id)
+        |> AdminRepo.all()
+
+      assert length(a_links) == 2
+      assert Enum.all?(a_links, &(&1.tenant_id == tenant_a.id))
+
+      # Tenant B has NO links at all — nothing leaked across the tenant boundary.
+      b_link_count =
+        from(l in ArticleLink, where: l.tenant_id == ^tenant_b.id)
+        |> AdminRepo.aggregate(:count)
+
+      assert b_link_count == 0
     end
   end
 


### PR DESCRIPTION
## US-36.4 — Linking hot-path efficiency

Efficiency-only refactor of `Loopctl.Workers.ArticleLinkingWorker`, the highest-frequency `:knowledge` Oban job (one per embedded article), where per-job waste multiplies under bulk ingest. **Correctness is preserved** — same links created, same kNN/threshold decisions (`VectorSearch.nearest` and the linking logic untouched), same tenant/project scoping.

### What changed
- **AC-36.4.1** — Removed the per-job full `count(*)` from the hot path. The corpus-size-vs-limit warning now runs on a deterministic ~1/N sample of jobs (`:erlang.phash2(article_id, N) == 0`) and emits a `[:loopctl, :knowledge, :article_linking, :corpus_size]` telemetry event alongside the warning. It is purely observational — never a gate on linking.
- **AC-36.4.2** — Discovered links are persisted with a single batched `insert_all` + `on_conflict: :nothing` on the directional unique index instead of row-by-row `AdminRepo.insert/1`. Idempotent on re-run (conflicting rows skipped, not counted — so the returned count still means "links created", matching the prior `new_link_count` audit semantics). The reverse-direction application-level dedup in `build_links/5` is unchanged.
- **AC-36.4.3** — No change to which links are created or the kNN/threshold logic; tenant/project scoping preserved.
- **AC-36.4.4** — Both the sampled count and the batched insert run inside a per-query `SET LOCAL statement_timeout` transaction (pgbouncer-safe, no startup parameter); the insert is chunked to stay under Postgres's 65535 bind-parameter ceiling.

### Config tunables (`config/config.exs`)
- `article_link_statement_timeout_ms` (default 3000)
- `article_link_corpus_sample_rate` (default 100; N=1 samples every job, N<=0 disables)
- `article_link_insert_chunk_size` (default 1000)

### Tests
- Sampled/unsampled corpus telemetry (zero-flake via deterministic id-bucket setup).
- Link-set equality for a fixed input + idempotency on re-run (correctness safety net).
- Multi-chunk `insert_all` path (small chunk size in test config).
- Existing conflict-detection, threshold, both-direction dedup, tenant-isolation, and audit tests stay green.

Verified: `mix precommit` green (credo --strict no issues, dialyzer passed, 4515 tests 0 failures). `insert_all` id-autogen + on_conflict idempotency confirmed against the running dev DB.

Part of #351 (Epic 4 — per-tenant Oban fairness & queue topology). No dedicated per-story issue; do not auto-close the epic.
