### PR TITLE
docs(epic_37): provider admission control & backpressure stories (US-37.1..37.5)

### DIFF
--- a/docs/user_stories/epic_37_provider_admission/README.md
+++ b/docs/user_stories/epic_37_provider_admission/README.md
@@ -1,0 +1,68 @@
+# Epic 37 — Outbound Provider Admission Control & Backpressure
+
+Remediation of GitHub issue **#352** (roadmap Epic 5, tracked **#355**) — the
+direct mechanism of the provider-side 429 / `:transport_error` storm. Nothing
+today sits between agent demand and the provider socket: provider calls fire
+immediately, 429s are ignored by the circuit breaker, retries ignore
+`Retry-After`, and the interactive search path embeds synchronously in the web
+request process with no concurrency cap.
+
+## Scope reconciliation (verified against `master` before authoring)
+
+| #352 finding | Status | Evidence |
+|--------------|--------|----------|
+| Per-tenant LLM settings re-read + Cloak-decrypt on every provider call | ✅ done | **US-32.3** — `Loopctl.Llm.SettingsCache` ETS cache, generation-bump + PubSub bust + TTL |
+| HeavyRead pool isolation / per-read `statement_timeout` / 503 crash-loop | ✅ done (topology only) | **Epic 33** — dedicated BYPASSRLS pool (size 8), `SET LOCAL` timeout, DbCapacity budget. **Per-tenant fairness within the pool NOT done → US-37.5** |
+| Genuine-outage `provider_error` telemetry signal | ✅ done | **US-34.3** — `Llm.record_provider_error/2` choke points (`anthropic.ex:169`, `knowledge.ex:7393`) |
+| Per-tenant Oban queue monopolization (background jobs) | ✅ done | **US-36.2** — `Loopctl.Oban.FairShare` |
+| Inbound ingest backpressure (429 + Retry-After to the caller) | ✅ done | **US-36.3** — admission gate on `/knowledge/ingest*` |
+| Distributed (cluster-wide) limiter/breaker store | ⏸ deferred to Epic 38 | breaker + settings cache + fair-share are all node-local by design; a shared store is the multi-node concern |
+
+The **genuinely-remaining** work (the core of #352 — all about the outbound 429-storm):
+
+| Finding | Status | Story |
+|---------|--------|-------|
+| No client-side admission control / token bucket before provider `Req.post` | ❌ open | **US-37.1** |
+| Query-path embedding runs unbounded in the request process (bare `Task.async`, no cap) | ❌ open | **US-37.2** |
+| Breaker deliberately ignores 429 (all 4xx exempt as one bucket) | ❌ open | **US-37.3** |
+| Retry backoff ignores provider `Retry-After` (blind `attempt^4`) | ❌ open | **US-37.3** |
+| Embeddings issued one text per request; no array batching | ❌ open | **US-37.4** |
+| No per-tenant in-flight cap on the shared HeavyRead pool (one tenant can hold all 8 slots) | ❌ open | **US-37.5** |
+
+## Stories
+
+| Story | Title | Depends |
+|-------|-------|---------|
+| US-37.1 | Per-`(tenant, provider)` token-bucket admission gate (Hammer) before every provider `Req.post`; empty → fast-fail `:rate_limited_local` (breaker-exempt) → keyword fallback | — |
+| US-37.2 | Bound the interactive embedding path: supervised, per-node concurrency-capped `generate_embedding` (web *and* Oban), replacing the bare `Task.async` | — |
+| US-37.3 | Throttle-aware circuit breaker + honor provider `Retry-After` (count 429/408, exempt 401/403; Retry-After drives breaker cooldown *and* Oban snooze/backoff; latency trip) | US-37.1 |
+| US-37.4 | Batch background embeddings into arrays (~100), map results back by index | — |
+| US-37.5 | Per-tenant in-flight concurrency cap (semaphore) + cost-weighted limiter on the HeavyRead pool | — |
+
+## Non-negotiable constraints (system is LIVE)
+
+- **Fail SAFE, never fail the user.** A full/empty token bucket, an open breaker,
+  or a saturated concurrency cap must degrade gracefully: the interactive search
+  path falls back to **keyword search** (the existing `:circuit_open` fallback),
+  never a 500. `:rate_limited_local` is **breaker-exempt** — a local admission
+  decision is not a provider failure.
+- **Node-local is the target** (Hammer buckets, breaker ETS, semaphores are
+  per-node) — consistent with the epic_36 stock-fallback decision. A cluster-wide
+  shared store is **out of scope, deferred to Epic 38 (#353)**. Size the buckets
+  per node against the tenant's known RPM/TPM.
+- **All limits env-driven** (extend `SystemConfig` / config-based DI: RPM/TPM,
+  concurrency caps, breaker thresholds, batch size, HeavyRead per-tenant slice)
+  so ops can tune during an incident with no deploy. **Never set a secret to a
+  doc placeholder** (epic_35 `STH_SWEEP_CRON` lesson).
+- **Provider-request semantics unchanged** on the happy path — a call that would
+  succeed today still succeeds, same request body (except US-37.4's array
+  batching, which must map results back to inputs by index with a correctness
+  test). US-37.3 keeps `401/403` breaker-exempt (a bad key is not a provider
+  outage) while making `429/408` count.
+- **Assert outcome classes, not timing** — breaker/backoff/concurrency tests run
+  in the async suite; assert the behavior class (fell back to keyword, snoozed
+  with the Retry-After delay, capped at N concurrent) not exact instants (the
+  Mox/async-supervisor flake lesson).
+- Every merge is smoke-gated (`knowledge_count` / search-path health either
+  side) and the master **Deploy + Post-deploy Smoke** watched to green
+  (runtime.exs/env changes only fail at release boot — epic_35 lesson).

--- a/docs/user_stories/epic_37_provider_admission/us_37.1.json
+++ b/docs/user_stories/epic_37_provider_admission/us_37.1.json
@@ -1,0 +1,57 @@
+{
+  "id": "US-37.1",
+  "title": "Per-(tenant, provider) token-bucket admission gate before every provider Req.post",
+  "epic": { "id": "epic_37", "name": "Outbound Provider Admission Control & Backpressure" },
+  "priority": "high",
+  "phase": "scalability",
+  "priority_note": "The core admission control #352 asks for: today NOTHING sits between agent demand and the provider socket, so a burst fires unbounded provider calls and triggers the 429/:transport_error storm. A per-(tenant,provider) token bucket in front of Req.post is the direct fix.",
+  "background": {
+    "reference": "GH #352. Both provider clients fire Req.post directly after resolving the key, with no admission gate: EmbeddingClient (lib/loopctl/knowledge/embedding_client.ex:74 Req.post(\"#{base_url}/embeddings\", ...)) and Anthropic (lib/loopctl/llm/anthropic.ex:113 Req.post(\"#{@base_url}/messages\", ...)). Hammer IS a dep but is used INBOUND-only (LoopctlWeb.Plugs.RateLimiter and a few controllers via Loopctl.RateLimiter.Behaviour / lib/loopctl/rate_limiter/hammer.ex) — never in front of an outbound provider call.",
+    "includes": "US-32.3's SettingsCache already gives cheap per-tenant settings; this story adds admission ON TOP. Empty bucket must FAST-FAIL locally so callers degrade (interactive search → keyword fallback) rather than queue forever. The local rejection must be breaker-EXEMPT (it is not a provider failure) — this is the same exemption US-37.3 relies on."
+  },
+  "story": {
+    "as_a": "loopctl operator",
+    "i_want_to": "require every outbound embedding and Anthropic call to first take a token from a per-(tenant, provider) bucket sized to that tenant's known RPM/TPM, and fast-fail locally when the bucket is empty",
+    "so_that": "one tenant's burst cannot fire unbounded provider requests and trigger a provider-side 429 storm — excess demand is shed locally and cheaply instead of hammering the provider"
+  },
+  "rationale": "A token bucket (Hammer, already a dep) in front of Req.post converts an unbounded outbound firehose into a bounded, per-tenant-fair stream sized to what the provider will actually accept. Fast-failing on an empty bucket with a distinct {:error, :rate_limited_local} lets the interactive path fall back to keyword search and lets background jobs snooze/retry, all WITHOUT counting against the circuit breaker (a local admission decision is not a provider outage).",
+  "acceptance_criteria": [
+    { "id": "AC-37.1.1", "description": "A per-(tenant, provider) token-bucket admission check (Hammer-based) is invoked immediately BEFORE the Req.post in both EmbeddingClient (embedding_client.ex) and the Anthropic client (anthropic.ex). On an empty bucket the call returns {:error, :rate_limited_local} WITHOUT issuing the HTTP request. Bucket key is scoped by tenant_id AND provider so one tenant/provider cannot consume another's allowance.", "status": "pending" },
+    { "id": "AC-37.1.2", "description": "Bucket capacity/refill (RPM and/or TPM) is env-driven via SystemConfig/config-based DI with sensible defaults, tunable per environment (and ideally per tenant tier) with no deploy. Defaults documented. No Application.put_env in tests.", "status": "pending" },
+    { "id": "AC-37.1.3", "description": "{:error, :rate_limited_local} is breaker-EXEMPT: it never counts toward the circuit breaker's failure tally (breaker_countable?/maybe_record_provider_error must treat it as non-countable). A test asserts repeated local rate-limits do NOT trip the breaker.", "status": "pending" },
+    { "id": "AC-37.1.4", "description": "Graceful degradation: the interactive search path, on {:error, :rate_limited_local}, falls back to keyword search (the SAME fallback path as :circuit_open) — never a 500. Background embedding jobs treat it as a retryable/snooze condition (no discard). Tests assert both: interactive → keyword fallback result; worker → retry/snooze not discard.", "status": "pending" },
+    { "id": "AC-37.1.5", "description": "Happy path unchanged: when the bucket has tokens, the provider request is issued exactly as today (same body/headers). A single call under normal load takes a token and proceeds with no behavior change (test).", "status": "pending" },
+    { "id": "AC-37.1.6", "description": "Node-local by design (Hammer node-local buckets) — a cluster-wide shared bucket is explicitly OUT OF SCOPE (deferred to Epic 38). Size defaults per node. The gate is defensive: a Hammer/limiter error fails OPEN (allows the call) rather than blocking all provider traffic, and logs.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-37.1.1", "name": "empty bucket fast-fails without HTTP", "type": "integration",
+      "preconditions": ["tenant bucket exhausted"],
+      "steps": ["call generate_embedding / Anthropic completion"],
+      "expected_results": ["{:error, :rate_limited_local}; no Req.post issued (mock asserts zero provider calls)"], "status": "pending" },
+    { "id": "TC-37.1.2", "name": "local rate-limit is breaker-exempt", "type": "unit",
+      "preconditions": ["repeatedly exhaust the bucket"],
+      "steps": ["trigger many :rate_limited_local in the window"],
+      "expected_results": ["breaker stays closed (not tripped)"], "status": "pending" },
+    { "id": "TC-37.1.3", "name": "interactive path degrades to keyword", "type": "integration",
+      "preconditions": ["bucket empty for the tenant"],
+      "steps": ["run default combined knowledge search"],
+      "expected_results": ["keyword-search results returned (same shape as circuit-open fallback); no 500"], "status": "pending" },
+    { "id": "TC-37.1.4", "name": "token available → provider called normally", "type": "integration",
+      "preconditions": ["bucket has tokens"],
+      "steps": ["call the provider client"],
+      "expected_results": ["Req.post issued with unchanged body; success path unchanged"], "status": "pending" },
+    { "id": "TC-37.1.5", "name": "per-(tenant,provider) isolation", "type": "unit",
+      "preconditions": ["tenant A bucket empty; tenant B full"],
+      "steps": ["A and B each call"],
+      "expected_results": ["A rate-limited, B proceeds; embedding vs anthropic buckets independent"], "status": "pending" }
+  ],
+  "technical_notes": [
+    "Files: lib/loopctl/knowledge/embedding_client.ex (before :74 Req.post), lib/loopctl/llm/anthropic.ex (before :113 Req.post), a new admission helper (e.g. lib/loopctl/provider/admission.ex wrapping Loopctl.RateLimiter.Behaviour/Hammer), lib/loopctl/knowledge.ex (breaker exemption + interactive fallback), SystemConfig for limits.",
+    "Reuse the existing Loopctl.RateLimiter.Behaviour + Hammer wrapper (rate_limiter/hammer.ex) rather than a new limiter dep; it already supports check_rate/3. Key: {tenant_id, :embedding|:anthropic}.",
+    "The breaker-exempt classification lives in knowledge.ex breaker_countable?/maybe_record_provider_error (~:7406) — US-37.3 refactors that; keep :rate_limited_local exempt in both stories (note the dependency: US-37.3 depends on US-37.1).",
+    "Fail-open on limiter error (rule: a monitoring/limiter fault must not take down provider traffic). Config-based DI; document RPM/TPM defaults.",
+    "Node-local only; cluster-wide shared bucket deferred to Epic 38 (#353)."
+  ],
+  "dependencies": [],
+  "estimated_tokens": 350000
+}

--- a/docs/user_stories/epic_37_provider_admission/us_37.2.json
+++ b/docs/user_stories/epic_37_provider_admission/us_37.2.json
@@ -1,0 +1,52 @@
+{
+  "id": "US-37.2",
+  "title": "Bound the interactive embedding path with a supervised, per-node concurrency cap",
+  "epic": { "id": "epic_37", "name": "Outbound Provider Admission Control & Backpressure" },
+  "priority": "high",
+  "phase": "scalability",
+  "priority_note": "The default `combined` search embeds the query SYNCHRONOUSLY in the web/MCP request process via a bare Task.async with no pool or cap — so the Oban embeddings:5 limit that appears to bound outbound embedding load is ILLUSORY for interactive traffic. A traffic spike spawns unbounded concurrent outbound embedding calls, directly feeding the 429 storm.",
+  "background": {
+    "reference": "GH #352. Interactive path: knowledge.ex search_combined/3 (:6186) -> do_combined_search/5 -> try_generate_embedding -> generate_embedding/3 (:7326) -> run_embedding_task/3 (:7341), call site knowledge.ex:7343 Task.async(fn -> embedding_client().generate_embedding(...) end) with Task.yield||Task.shutdown at :7351 (5s budget). One UNBOUNDED Task per request; no Task.Supervisor, no semaphore. hybrid_search/3 (:6636) reuses search_combined so it inherits this. The Oban embeddings:5 cap (config/config.exs:304) bounds ONLY background jobs (ArticleEmbeddingWorker/MemoryEmbeddingWorker), not interactive web/MCP embeddings.",
+    "includes": "The fix is a per-node bound on concurrent outbound embedding calls that gates EVERY generate_embedding entry (web AND Oban), e.g. a supervised Task.Supervisor + a counting semaphore (or a small pool). When the cap is reached, the interactive path degrades to keyword search (same as :circuit_open / US-37.1's :rate_limited_local), never blocking the request indefinitely."
+  },
+  "story": {
+    "as_a": "loopctl operator",
+    "i_want_to": "cap the number of concurrent outbound embedding calls per node and run them under a supervisor, gating both the interactive query path and the Oban workers through the same bound",
+    "so_that": "a spike of interactive searches can't spawn unbounded concurrent provider embedding requests — outbound embedding concurrency is bounded everywhere, not just in background jobs"
+  },
+  "rationale": "Bounding interactive embedding concurrency closes the biggest hole in outbound load control: the query path currently bypasses every limit. A supervised, capped mechanism (Task.Supervisor + semaphore) that both web and Oban call gives one real ceiling on concurrent provider embedding calls per node, and lets the interactive path shed load to keyword search when saturated instead of piling on the provider or blocking the request.",
+  "acceptance_criteria": [
+    { "id": "AC-37.2.1", "description": "Concurrent outbound embedding calls are bounded per node by a config-driven cap. The bare Task.async at knowledge.ex:7343 is replaced with a supervised task (Task.Supervisor) whose concurrency is gated by a semaphore/pool so at most N embedding calls run at once across the node. The interactive request keeps its bounded wait (existing ~5s yield budget) and does not block indefinitely.", "status": "pending" },
+    { "id": "AC-37.2.2", "description": "The SAME bound gates every generate_embedding entry point — both the interactive path AND the Oban embedding workers (ArticleEmbeddingWorker/MemoryEmbeddingWorker) go through it — so the per-node ceiling is real, not bypassable by the query path. A test asserts interactive embedding calls are subject to the cap.", "status": "pending" },
+    { "id": "AC-37.2.3", "description": "Saturation degrades gracefully: when the cap is reached (or the acquire times out within the request budget), the interactive search falls back to keyword search (same path as :circuit_open / :rate_limited_local) — never a 500 and never an unbounded wait. Test asserts the fallback under saturation.", "status": "pending" },
+    { "id": "AC-37.2.4", "description": "The cap is env-driven (SystemConfig/config-based DI) with a sensible default sized against the pool/provider budget; no Application.put_env in tests. Node-local (a supervisor + semaphore per node) — distributed coordination is out of scope (Epic 38).", "status": "pending" },
+    { "id": "AC-37.2.5", "description": "Resilience: an embedding task crash never crashes the request process or the supervisor (isolated under Task.Supervisor; failures surface as the existing embedding-error/fallback, not a caller crash). Happy path (under the cap) is unchanged — a normal search still returns semantic results with no added latency beyond acquiring an available slot. Assert OUTCOME class (capped/fell-back), not exact concurrency at an instant.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-37.2.1", "name": "interactive embedding is bounded", "type": "integration",
+      "preconditions": ["cap set low (e.g. 1); a slow embedding stub"],
+      "steps": ["fire several concurrent combined searches"],
+      "expected_results": ["no more than the cap run concurrently; excess either wait briefly or fall back — never unbounded fan-out"], "status": "pending" },
+    { "id": "TC-37.2.2", "name": "saturation → keyword fallback", "type": "integration",
+      "preconditions": ["cap saturated"],
+      "steps": ["issue another combined search"],
+      "expected_results": ["keyword-search results returned; no 500; no indefinite block"], "status": "pending" },
+    { "id": "TC-37.2.3", "name": "embedding task crash is isolated", "type": "integration",
+      "preconditions": ["embedding stub raises"],
+      "steps": ["run a combined search"],
+      "expected_results": ["request survives; returns fallback/empty-semantic, not a caller crash"], "status": "pending" },
+    { "id": "TC-37.2.4", "name": "happy path unchanged", "type": "integration",
+      "preconditions": ["cap ample; embedding stub returns a vector"],
+      "steps": ["run a combined search"],
+      "expected_results": ["semantic results returned as today"], "status": "pending" }
+  ],
+  "technical_notes": [
+    "Files: lib/loopctl/knowledge.ex (run_embedding_task/3 ~:7341-7351 — replace Task.async with Task.Supervisor.async_nolink under a semaphore), a new supervised concurrency limiter (semaphore/pool) added to the app supervision tree, the Oban embedding workers to route through the same acquire, SystemConfig for the cap.",
+    "A DynamicSupervisor/Task.Supervisor needs a name: in its child spec (Elixir guideline). Keep the existing yield/shutdown timeout so the request budget is preserved.",
+    "Gate acquire must be non-blocking-with-timeout for the interactive path (fall back on timeout) but may block briefly for background workers (or they snooze). Reuse US-36.2 FairShare-style outcome-class testing; do NOT assert exact instantaneous concurrency (async-suite flake lesson).",
+    "Config-based DI for the cap; document default. Node-local; cluster-wide coordination deferred to Epic 38.",
+    "Careful with Task.Supervisor.async_stream_nolink + Mox $callers under the parallel suite (known flake) — assert outcome class, allow stub via set_mox_from_context."
+  ],
+  "dependencies": [],
+  "estimated_tokens": 350000
+}

--- a/docs/user_stories/epic_37_provider_admission/us_37.3.json
+++ b/docs/user_stories/epic_37_provider_admission/us_37.3.json
@@ -1,0 +1,55 @@
+{
+  "id": "US-37.3",
+  "title": "Throttle-aware circuit breaker + honor provider Retry-After",
+  "epic": { "id": "epic_37", "name": "Outbound Provider Admission Control & Backpressure" },
+  "priority": "high",
+  "phase": "scalability",
+  "priority_note": "Today the breaker deliberately IGNORES 429 (all 4xx exempt), so a provider rate-limit storm never triggers backoff, and retry backoff is a blind attempt^4 that DISCARDS the provider's Retry-After. The system fights a 429 storm by immediately retrying into it. This story makes throttling actually back off.",
+  "background": {
+    "reference": "GH #352. Breaker classification breaker_countable?/1 (knowledge.ex:7406-7420): status>=500 -> true; any 4xx -> false (so 429/408 EXEMPT); request_failed/crash/timeout -> true. Docstring (:7304-7308) states 4xx are intentionally exempt. maybe_record_provider_error/1 (:7393) reuses the same gate. Retry-After is NOT read anywhere (grep retry.after finds only the INBOUND US-36.3 header loopctl SENDS). Oban backoff is blind polynomial: article_embedding_worker.ex:87-89 trunc(:math.pow(attempt,4)+15+:rand.uniform(30)*attempt), memory_embedding_worker.ex:89-91 identical. The {:snooze,n} in those workers is the US-36.2 FairShare gate, NOT a provider Retry-After.",
+    "includes": "Split the blanket 4xx exemption into CRED errors (401/403 — a bad/forbidden key, still exempt: retrying or backing off won't help and it's not an outage) vs THROTTLE errors (429/408 — count toward the breaker AND back off). Extract provider Retry-After (seconds or HTTP-date) from the 429/503 response and use it for (a) the breaker cooldown and (b) the Oban worker backoff/snooze in place of the blind attempt^4. Add a latency-based trip for slow-but-alive providers. Depends on US-37.1 so :rate_limited_local stays exempt in the refactored classifier."
+  },
+  "story": {
+    "as_a": "loopctl operator",
+    "i_want_to": "count provider throttle responses (429/408) toward the circuit breaker, keep credential errors (401/403) exempt, and honor the provider's Retry-After for both the breaker cooldown and Oban retry backoff",
+    "so_that": "a provider rate-limit storm actually trips the breaker and backs off for the interval the provider asked for, instead of being ignored and hammered with immediate blind retries"
+  },
+  "rationale": "The current breaker is blind to the exact failure mode #352 is about. Distinguishing throttle from credential errors lets 429/408 drive backoff while 401/403 (unfixable by retry) stay exempt. Honoring Retry-After aligns loopctl's backoff with what the provider will actually accept — the single most effective way to end a 429 storm — and a latency trip catches degraded-but-200 providers before they cascade.",
+  "acceptance_criteria": [
+    { "id": "AC-37.3.1", "description": "breaker_countable?/maybe_record_provider_error is refactored to split 4xx: 429 and 408 COUNT toward the breaker (throttle); 401 and 403 remain EXEMPT (credential). Other 4xx keep today's behavior (document the choice). US-37.1's {:error, :rate_limited_local} stays EXEMPT. 5xx/transport/timeout/crash still count. Unit tests cover each status class.", "status": "pending" },
+    { "id": "AC-37.3.2", "description": "The provider Retry-After header (delta-seconds OR HTTP-date) is parsed from 429/503 responses in both provider clients into a normalized seconds value (defensive: missing/garbage header -> nil, fall back to existing backoff). A parser unit test covers seconds, HTTP-date, absent, and malformed.", "status": "pending" },
+    { "id": "AC-37.3.3", "description": "When Retry-After is present, the breaker cooldown for that (tenant,provider) is set to at least the Retry-After interval (bounded by a sane max), and the Oban embedding/ingestion worker backoff (article_embedding_worker.ex / memory_embedding_worker.ex / content_ingestion_worker.ex) uses it — via {:snooze, retry_after} or backoff/1 — INSTEAD of the blind attempt^4, when a throttle error carried one. Absent Retry-After keeps the existing polynomial backoff. Tests assert a 429-with-Retry-After yields a snooze/backoff of ~that interval.", "status": "pending" },
+    { "id": "AC-37.3.4", "description": "A latency-based trip is added: if provider calls for a (tenant,provider) exceed a config latency threshold for a config number of consecutive/window calls, the breaker trips (slow-but-alive protection). Config-driven; documented default; disabled-safe (a 0/unset threshold means no latency trip). Test asserts the latency trip fires and recovers.", "status": "pending" },
+    { "id": "AC-37.3.5", "description": "Fail-safe: when the breaker is open (from throttle or latency), the interactive path falls back to keyword search and workers snooze/retry — never a 500, never a hot retry loop into a throttling provider. Existing :circuit_open fallback is preserved. Thresholds/cooldowns are env-driven (SystemConfig); no Application.put_env in tests. Assert outcome classes, not exact timing.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-37.3.1", "name": "429/408 count, 401/403 exempt", "type": "unit",
+      "preconditions": [],
+      "steps": ["classify each status via breaker_countable?"],
+      "expected_results": ["429 & 408 countable=true; 401 & 403 countable=false; :rate_limited_local false; 500 true"], "status": "pending" },
+    { "id": "TC-37.3.2", "name": "Retry-After parser", "type": "unit",
+      "preconditions": [],
+      "steps": ["parse '30', an HTTP-date ~30s out, '', 'garbage'"],
+      "expected_results": ["~30, ~30, nil, nil"], "status": "pending" },
+    { "id": "TC-37.3.3", "name": "429 storm trips breaker and backs off by Retry-After", "type": "integration",
+      "preconditions": ["provider stub returns 429 + Retry-After: 30 repeatedly"],
+      "steps": ["drive embedding calls past the threshold"],
+      "expected_results": ["breaker trips; worker snoozes/backs off ~30s (not attempt^4); interactive path falls back to keyword"], "status": "pending" },
+    { "id": "TC-37.3.4", "name": "latency trip", "type": "integration",
+      "preconditions": ["provider stub returns 200 but slow, over the latency threshold"],
+      "steps": ["make repeated calls"],
+      "expected_results": ["breaker trips on latency; recovers after cooldown"], "status": "pending" },
+    { "id": "TC-37.3.5", "name": "bad key does not trip breaker", "type": "integration",
+      "preconditions": ["provider stub returns 401"],
+      "steps": ["make repeated calls"],
+      "expected_results": ["breaker stays closed (credential error exempt); error surfaced to caller as today"], "status": "pending" }
+  ],
+  "technical_notes": [
+    "Files: lib/loopctl/knowledge.ex (breaker_countable?/maybe_record_provider_error ~:7393-7420, breaker cooldown ~:7241-7266), lib/loopctl/knowledge/embedding_circuit_breaker.ex, lib/loopctl/knowledge/embedding_client.ex + lib/loopctl/llm/anthropic.ex (extract Retry-After from the response), the Oban workers' backoff/1 (article_embedding_worker.ex:87, memory_embedding_worker.ex:89, content_ingestion_worker.ex:229), SystemConfig for thresholds.",
+    "Retry-After: RFC 7231 — either delta-seconds or an HTTP-date. Parse both with stdlib (no new dep); clamp to a sane max cooldown so a hostile/huge header can't wedge a queue.",
+    "Keep 401/403 exempt: retrying a forbidden key wastes calls and a bad key is not a provider outage. Note the Anthropic client has no breaker today (only telemetry via Llm.permanent_provider_error?/1 :170) — decide whether to extend the breaker to it or keep embedding-only; document.",
+    "Depends on US-37.1 (the refactored classifier must keep :rate_limited_local exempt). Config-based DI; no Application.put_env in tests. Assert outcome class, not exact timing (async-suite flake lesson)."
+  ],
+  "dependencies": ["US-37.1"],
+  "estimated_tokens": 400000
+}

--- a/docs/user_stories/epic_37_provider_admission/us_37.4.json
+++ b/docs/user_stories/epic_37_provider_admission/us_37.4.json
@@ -1,0 +1,51 @@
+{
+  "id": "US-37.4",
+  "title": "Batch background embeddings into arrays (~100), map results back by index",
+  "epic": { "id": "epic_37", "name": "Outbound Provider Admission Control & Backpressure" },
+  "priority": "medium",
+  "phase": "scalability",
+  "priority_note": "Embeddings go out one text per request even though the endpoint accepts arrays of ~100. Under a bulk ingest that is 100x the request count against the provider — pure amplification of the outbound load this epic is trying to bound. Batching collapses it.",
+  "background": {
+    "reference": "GH #352. embedding_client.ex:65 json: %{input: text, model: model} — a SINGLE string per request; generate_embedding/2 takes one text (:42). No array/batch path. Background embedding workers (ArticleEmbeddingWorker, MemoryEmbeddingWorker) each embed one record's text per job, so N ingested items = N separate provider round-trips.",
+    "includes": "OpenAI-compatible embedding endpoints accept `input` as an ARRAY and return data entries with an `index` field. Batching background embeddings into arrays of ~100 (config) and mapping each returned vector back to its source record BY INDEX cuts provider round-trips ~100x for bulk work. This composes with US-37.1 (each batch takes one token) and US-37.2 (fewer concurrent calls). Interactive single-query embedding stays single (latency-sensitive)."
+  },
+  "story": {
+    "as_a": "loopctl operator",
+    "i_want_to": "send background embedding requests as arrays of up to ~100 texts and map each returned vector back to its source record by the response index",
+    "so_that": "a bulk ingest makes ~1 provider request per 100 items instead of one per item, drastically cutting outbound request volume (and the 429 pressure) without changing which vectors each record gets"
+  },
+  "rationale": "The endpoint already supports array input; issuing one text per request is the single biggest multiplier on background provider request count. Batching is a well-bounded, correctness-preserving change (same model, same per-text vector, just fewer HTTP calls) that directly reduces the outbound storm surface and pairs with the admission/concurrency controls in this epic.",
+  "acceptance_criteria": [
+    { "id": "AC-37.4.1", "description": "EmbeddingClient gains a batch path that sends `input` as an array of up to a config-driven max (~100) texts in one Req.post and returns vectors mapped to inputs BY the response `index` field (never by array position assumption — use the returned index), preserving input order. A test with a multi-item batch asserts each input gets its correct vector.", "status": "pending" },
+    { "id": "AC-37.4.2", "description": "Background embedding generation uses the batch path: the embedding worker(s) accumulate/receive multiple records and embed them in array batches (chunked to the max). The interactive single-query path is UNCHANGED (still single-text, latency-sensitive). A test asserts background embedding of M records issues ceil(M/batch_max) provider calls, not M.", "status": "pending" },
+    { "id": "AC-37.4.3", "description": "Correctness preserved: each record receives the same vector it would have from a single-text call (same model/dimensions). A test compares single-vs-batch vectors for identical inputs (with a deterministic stub) and asserts equality per index. Partial failure handling: if the provider errors, the batch fails/retries as a unit (no silent half-write of vectors).", "status": "pending" },
+    { "id": "AC-37.4.4", "description": "Batch size is env-driven (SystemConfig) with a documented default (~100); chunking respects both the size cap and any provider/token limits. Each batch takes ONE token from the US-37.1 bucket. Tenant isolation preserved (a batch only contains one tenant's texts). No Application.put_env in tests.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-37.4.1", "name": "array request maps vectors by index", "type": "integration",
+      "preconditions": ["embedding stub returns data entries with index + vector for an array input"],
+      "steps": ["embed a batch of 3 distinct texts"],
+      "expected_results": ["each text gets its corresponding vector by response index; order preserved"], "status": "pending" },
+    { "id": "TC-37.4.2", "name": "M records => ceil(M/batch) calls", "type": "integration",
+      "preconditions": ["batch_max e.g. 100; 250 records"],
+      "steps": ["run background embedding"],
+      "expected_results": ["3 provider calls, not 250"], "status": "pending" },
+    { "id": "TC-37.4.3", "name": "batch vector == single vector", "type": "integration",
+      "preconditions": ["deterministic embedding stub"],
+      "steps": ["embed the same texts single vs batched"],
+      "expected_results": ["identical vector per input"], "status": "pending" },
+    { "id": "TC-37.4.4", "name": "batch failure retries as a unit", "type": "integration",
+      "preconditions": ["provider errors mid-batch"],
+      "steps": ["run the batch"],
+      "expected_results": ["no partial vector writes; batch retried/failed as a whole"], "status": "pending" }
+  ],
+  "technical_notes": [
+    "Files: lib/loopctl/knowledge/embedding_client.ex (:42/:65 — add generate_embeddings/2 array path alongside the single generate_embedding/2), the background embedding worker(s) (article_embedding_worker.ex / memory_embedding_worker.ex — batch accumulation or a batch worker), SystemConfig for batch_max.",
+    "Map by the response `index` field, not by position — OpenAI-compatible responses include it and order is not guaranteed. Chunk_every(batch_max); watch provider token limits per request.",
+    "Keep the single-text interactive path for latency. Background batching should compose with US-37.1 (one token per batch) and US-37.2 (one concurrency slot per batch).",
+    "Partial-failure: treat a batch atomically (retry/fail whole) so no record is left with a wrong/missing vector. Config-based DI; document default; no Application.put_env in tests.",
+    "Correctness test (single==batch per index) is the safety net — this is an efficiency change, not a semantic one."
+  ],
+  "dependencies": [],
+  "estimated_tokens": 350000
+}

--- a/docs/user_stories/epic_37_provider_admission/us_37.5.json
+++ b/docs/user_stories/epic_37_provider_admission/us_37.5.json
@@ -1,0 +1,52 @@
+{
+  "id": "US-37.5",
+  "title": "Per-tenant in-flight concurrency cap + cost-weighted limiter on the HeavyRead pool",
+  "epic": { "id": "epic_37", "name": "Outbound Provider Admission Control & Backpressure" },
+  "priority": "high",
+  "phase": "scalability",
+  "priority_note": "Epic 33 gave HeavyRead its own isolated pool + statement_timeout, but the pool (size 8) has NO per-tenant slice: one tenant's heavy read burst can hold all 8 connections and effectively 503 every other tenant. The limiter that exists counts inbound REQUESTS (rate), not in-flight CONCURRENCY on this pool.",
+  "background": {
+    "reference": "GH #352. Loopctl.HeavyRead (lib/loopctl/heavy_read.ex) is a tenant-scoping GUARD (guard!/2 :263 proves tenant_id predicate) + per-read SET LOCAL statement_timeout (opts/1 :89, default 10s), NOT a limiter. Concurrency is bounded only by the pool size HEAVY_READ_POOL_SIZE (default 8, config/runtime.exs:301, modeled in Loopctl.DbCapacity). That is a GLOBAL pool with no per-tenant slice — one tenant can hold all 8 slots. grep in_flight|semaphore|per_tenant.*concurren over heavy_read.ex/db_capacity.ex/vector_search.ex finds nothing. The only per-tenant fairness (US-36.2 Loopctl.Oban.FairShare) applies to Oban queue slots, not this synchronous pool.",
+    "includes": "Add a per-tenant in-flight concurrency cap (semaphore) so no single tenant can hold more than K of the N HeavyRead slots, plus a cost-weighted limiter (heavier queries count for more of the tenant's budget). Over-cap requests fail fast / degrade rather than exhausting the pool and 503-ing everyone. Node-local (per-node pool); a cluster-wide budget is deferred to Epic 38."
+  },
+  "story": {
+    "as_a": "loopctl operator",
+    "i_want_to": "cap how many HeavyRead connections a single tenant can hold in flight at once (a per-tenant slice of the pool), weighted by query cost, and fast-fail/degrade over-cap requests",
+    "so_that": "one tenant's burst of heavy vector/analytic reads cannot occupy the whole HeavyRead pool and cause every other tenant's heavy reads to time out or 503"
+  },
+  "rationale": "Isolating the pool (Epic 33) stopped heavy reads from starving the MAIN pool, but did nothing for fairness WITHIN the heavy pool — a single tenant can still monopolize all 8 slots. A per-tenant in-flight semaphore (with cost weighting so a few very heavy queries count like many light ones) gives each tenant a bounded share and converts monopolization into a fast, per-tenant-local shed, keeping the pool available to everyone. This mirrors US-36.2's fair-share idea on the synchronous read path.",
+  "acceptance_criteria": [
+    { "id": "AC-37.5.1", "description": "A per-tenant in-flight concurrency cap gates HeavyRead pool checkouts: a tenant may hold at most K of the N pool slots at once (K config-driven, K < N so no tenant can take the whole pool). Enforced via a semaphore/counter acquired before the checkout and released after. A test asserts tenant A holding K slots cannot acquire a K+1th while tenant B can still acquire.", "status": "pending" },
+    { "id": "AC-37.5.2", "description": "The limiter is cost-WEIGHTED: heavier reads (e.g. vector/kNN or large scans) consume more of the tenant's in-flight budget than light ones, via a per-query weight (config/heuristic). A test asserts a heavy query consumes more budget than a light one (fewer concurrent heavy queries allowed than light).", "status": "pending" },
+    { "id": "AC-37.5.3", "description": "Over-cap behavior fails fast / degrades rather than exhausting the pool: an over-budget tenant request returns a clear {:error, :heavy_read_overloaded} (or bounded-wait-then-shed), and callers map it to a graceful response (e.g. keyword fallback for search, or a 429/503 with the app error envelope for API reads) — never a pool-exhaustion crash for OTHER tenants. Test asserts an over-cap tenant is shed while other tenants still get service.", "status": "pending" },
+    { "id": "AC-37.5.4", "description": "Isolation + fairness OUTCOME (the invariant): with tenant A saturating its HeavyRead cap, tenant B's heavy read still completes within a bounded time (B is not starved). Assert the OUTCOME class (B makes progress while A is capped), NOT exact instantaneous slot counts (async-suite flake lesson). Tenant isolation of the counter is preserved (A's count never includes B).", "status": "pending" },
+    { "id": "AC-37.5.5", "description": "Caps/weights are env-driven (SystemConfig/config-based DI: per-tenant slice K, weights) with documented defaults; K defaults < HEAVY_READ_POOL_SIZE. Node-local (per-node pool + per-node semaphore) — cluster-wide budget deferred to Epic 38. The guard is defensive: a limiter fault fails OPEN (allows the read) rather than blocking all heavy reads, and logs. No Application.put_env in tests.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-37.5.1", "name": "per-tenant slice caps in-flight", "type": "integration",
+      "preconditions": ["K=2, pool N=8; slow heavy-read stub"],
+      "steps": ["tenant A starts 3 concurrent heavy reads"],
+      "expected_results": ["A holds at most 2 concurrently; the 3rd waits/sheds; tenant B can still acquire"], "status": "pending" },
+    { "id": "TC-37.5.2", "name": "cost weighting", "type": "integration",
+      "preconditions": ["heavy vs light query weights configured"],
+      "steps": ["run heavy vs light reads for a tenant"],
+      "expected_results": ["fewer concurrent heavy than light allowed within the same budget"], "status": "pending" },
+    { "id": "TC-37.5.3", "name": "over-cap sheds, others unaffected", "type": "integration",
+      "preconditions": ["tenant A over its cap"],
+      "steps": ["A issues another heavy read while B issues one"],
+      "expected_results": ["A gets :heavy_read_overloaded / graceful degrade; B succeeds; pool not exhausted"], "status": "pending" },
+    { "id": "TC-37.5.4", "name": "fairness outcome — B not starved by A", "type": "integration",
+      "preconditions": ["A saturating its cap continuously"],
+      "steps": ["B issues a heavy read"],
+      "expected_results": ["B completes within bounded time (outcome class), not stuck behind A"], "status": "pending" }
+  ],
+  "technical_notes": [
+    "Files: lib/loopctl/heavy_read.ex (acquire/release around the pool checkout in the read path), a new per-tenant semaphore/limiter module (e.g. lib/loopctl/heavy_read/tenant_gate.ex), lib/loopctl/db_capacity.ex (budget model), callers of HeavyRead (knowledge search / analytics / vector_search.ex) to handle :heavy_read_overloaded, SystemConfig for K/weights.",
+    "K MUST be < HEAVY_READ_POOL_SIZE (default 8) so the pool can serve multiple tenants; pick a default like ceil(N/2) or a small fixed K and document. Weight heavy (vector/kNN, large scans) higher.",
+    "Fail-open on limiter fault (a monitoring bug must not block all heavy reads). Release the slot in an after/ensure so a crashing query never leaks budget.",
+    "Mirror US-36.2 FairShare semantics but for the SYNCHRONOUS HeavyRead pool (not Oban). Node-local; cluster-wide deferred to Epic 38.",
+    "Assert OUTCOME class not exact concurrency (async-suite flake lesson). Config-based DI; no Application.put_env in tests."
+  ],
+  "dependencies": [],
+  "estimated_tokens": 400000
+}


### PR DESCRIPTION
## Summary

Authors the user stories for **Epic 37 — Outbound Provider Admission Control & Backpressure**, remediating GH #352 (roadmap Epic 5, tracked #355). Docs only, no code change.

This is the **429-storm/backpressure** reading of #352 (per the issue's actual findings), decomposed from a fresh read-only grounding of the current outbound-provider handling.

### Scope reconciliation (verified against master)
Already done, excluded: ETS LLM-settings cache (**US-32.3**), HeavyRead pool isolation + `statement_timeout` (**Epic 33**), `provider_error` telemetry (**US-34.3**), inbound ingest backpressure (**US-36.3**). Cluster-wide/distributed limiter store **deferred to Epic 38 (#353)** — all breaker/cache/fair-share state is node-local by design.

### Stories (the genuinely-remaining findings)
- **US-37.1** — Per-`(tenant, provider)` **token-bucket admission gate** (Hammer, already a dep) before every provider `Req.post`; empty bucket → fast-fail `:rate_limited_local` (breaker-exempt) → keyword fallback.
- **US-37.2** — Bound the **interactive embedding path**: the default `combined` search embeds synchronously in the request process via a bare `Task.async` with no cap. Replace with a supervised, per-node concurrency-capped path gating web *and* Oban.
- **US-37.3** — **Throttle-aware breaker + honor `Retry-After`**: today the breaker ignores all 4xx (so 429 storms never trip it) and retries on a blind `attempt^4` that discards `Retry-After`. Split 429/408 (count) vs 401/403 (exempt); drive breaker cooldown *and* Oban backoff from the provider's `Retry-After`; add a latency trip.
- **US-37.4** — **Batch background embeddings** into arrays (~100), map vectors back by response index (endpoint already supports arrays; today it's one text per request).
- **US-37.5** — **Per-tenant in-flight cap + cost-weighted limiter** on the HeavyRead pool so one tenant can't hold all 8 slots and 503 everyone (Epic 33 isolated the pool but added no per-tenant fairness within it).

### Constraints baked in
- Fail **safe**, never fail the user — a full bucket / open breaker / saturated cap degrades to keyword search, never a 500. `:rate_limited_local` is breaker-exempt.
- Node-local target (consistent with the epic_36 stock-fallback decision); cluster-wide store deferred to Epic 38.
- All limits env-driven (tune live, no deploy) — **never set a secret to a doc placeholder** (epic_35 `STH_SWEEP_CRON` lesson).
- Assert outcome classes, not timing (async-suite flake lesson); watch master **Deploy + Post-deploy Smoke** to green.

Next: `implement-plan` on the epic folder (WIP=1, review-gated).
