### PR TITLE
Per-(tenant, provider) token-bucket admission gate before every provider Req.post

### DIFF
--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -6311,6 +6311,7 @@ defmodule Loopctl.Knowledge do
 
     * `:no_api_key` → `"no_embedding_key"`
     * `:circuit_open` → `"embedding_circuit_open"`
+    * `:rate_limited_local` → `"embedding_rate_limited_local"` (US-37.1 admission gate)
     * `:timeout` → `"embedding_timeout"`
     * `{:api_error, status, _}` → `"embedding_provider_error_<status>"` (status only)
     * `{:request_failed, _}` → `"embedding_request_failed"`
@@ -6349,6 +6350,7 @@ defmodule Loopctl.Knowledge do
 
   defp reason_to_tag(:no_api_key), do: "no_embedding_key"
   defp reason_to_tag(:circuit_open), do: "embedding_circuit_open"
+  defp reason_to_tag(:rate_limited_local), do: "embedding_rate_limited_local"
   defp reason_to_tag(:timeout), do: "embedding_timeout"
 
   defp reason_to_tag({:api_error, status, _}) when is_integer(status),
@@ -7416,6 +7418,12 @@ defmodule Loopctl.Knowledge do
   defp breaker_countable?({:embedding_crash, _}), do: true
   defp breaker_countable?(:timeout), do: true
   defp breaker_countable?(:circuit_open), do: false
+  # US-37.1 (AC-37.1.3): a node-local admission rate-limit is a self-imposed,
+  # defensive fast-fail — NOT a provider failure. It must never count toward the
+  # circuit breaker NOR the `[:loopctl, :llm, :provider_error]` storm signal
+  # (both gate on `breaker_countable?/1`); otherwise our own backpressure would
+  # trip the breaker and degrade every tenant.
+  defp breaker_countable?(:rate_limited_local), do: false
   # Unknown/other transport-ish failures: count (conservative — a real outage).
   defp breaker_countable?(_), do: true
 

--- a/lib/loopctl/knowledge/embedding_client.ex
+++ b/lib/loopctl/knowledge/embedding_client.ex
@@ -34,6 +34,7 @@ defmodule Loopctl.Knowledge.EmbeddingClient do
 
   alias Loopctl.Llm
   alias Loopctl.Llm.ProviderError
+  alias Loopctl.Provider.Admission
   alias Loopctl.SystemConfig
 
   @default_base_url "https://api.openai.com/v1"
@@ -51,6 +52,17 @@ defmodule Loopctl.Knowledge.EmbeddingClient do
   end
 
   defp post(tenant_id, api_key, model, text) do
+    # US-37.1: per-(tenant, provider) token-bucket admission gate. On an empty
+    # node-local bucket, fast-fail WITHOUT building/sending the request so the
+    # caller degrades cheaply (interactive search → keyword fallback; embedding
+    # jobs → snooze/retry). This return is breaker-EXEMPT (see Knowledge's
+    # `breaker_countable?/1`).
+    with :ok <- Admission.admit(tenant_id, :embedding) do
+      do_post(tenant_id, api_key, model, text)
+    end
+  end
+
+  defp do_post(tenant_id, api_key, model, text) do
     base_url = provider_config()[:base_url] || @default_base_url
 
     # Kept STRICTLY BELOW `Knowledge`'s Task.yield budget (review #10): a single

--- a/lib/loopctl/llm/anthropic.ex
+++ b/lib/loopctl/llm/anthropic.ex
@@ -31,6 +31,7 @@ defmodule Loopctl.Llm.Anthropic do
 
   alias Loopctl.Llm
   alias Loopctl.Llm.ProviderError
+  alias Loopctl.Provider.Admission
 
   @base_url "https://api.anthropic.com/v1"
   @anthropic_version "2023-06-01"
@@ -57,6 +58,7 @@ defmodule Loopctl.Llm.Anthropic do
   @spec message(Ecto.UUID.t(), Llm.operation(), (String.t() -> map()), usage_meta(), keyword()) ::
           {:ok, String.t()}
           | {:error, :no_api_key}
+          | {:error, :rate_limited_local}
           | {:error, {:api_error, integer(), term()}}
           | {:error, {:request_failed, term()}}
   def message(tenant_id, operation, body_fun, usage_meta \\ %{}, req_opts \\ [])
@@ -86,6 +88,7 @@ defmodule Loopctl.Llm.Anthropic do
           keyword()
         ) ::
           {:ok, String.t()}
+          | {:error, :rate_limited_local}
           | {:error, {:api_error, integer(), term()}}
           | {:error, {:request_failed, term()}}
   def call(tenant_id, operation, api_key, model, body_fun, usage_meta \\ %{}, req_opts \\ [])
@@ -95,6 +98,18 @@ defmodule Loopctl.Llm.Anthropic do
   end
 
   defp post(tenant_id, operation, model, body, usage_meta, api_key, req_opts) do
+    # US-37.1: per-(tenant, provider) token-bucket admission gate. On an empty
+    # node-local bucket, short-circuit with `{:error, :rate_limited_local}` BEFORE
+    # building/sending the request — and crucially BEFORE the `record_provider_error/1`
+    # branches below, so a local rate-limit never inflates the
+    # `[:loopctl, :llm, :provider_error]` storm signal (parallel to the breaker
+    # exemption in AC-37.1.3).
+    with :ok <- Admission.admit(tenant_id, :anthropic) do
+      do_post(tenant_id, operation, model, body, usage_meta, api_key, req_opts)
+    end
+  end
+
+  defp do_post(tenant_id, operation, model, body, usage_meta, api_key, req_opts) do
     opts =
       [
         json: body,

--- a/lib/loopctl/provider/admission.ex
+++ b/lib/loopctl/provider/admission.ex
@@ -75,8 +75,21 @@ defmodule Loopctl.Provider.Admission do
 
   ## Fail-OPEN (AC-37.1.6)
 
-  The `check_rate/3` call is wrapped in `try/rescue`: on ANY limiter error (a
-  Hammer/ETS fault) the gate LOGS a warning and returns `:ok` (allows the call).
+  The `check_rate/3` call is wrapped in `try/rescue/catch`: on ANY limiter error
+  the gate LOGS a warning and returns `:ok` (allows the call). "ANY" is
+  deliberate and covers every failure mode Hammer can surface:
+
+    * a raised exception (Hammer/ETS fault) — caught by `rescue`;
+    * Hammer's documented `{:error, reason}` soft-error return — matched by an
+      explicit `case` clause;
+    * an `exit` — Hammer reaches its backend via `:poolboy.transaction/3`, a
+      `gen_server:call` that EXITS (does not raise) with `:noproc` when the pool
+      is down/unstarted and `{:timeout, _}` on checkout timeout; caught by
+      `catch :exit`. `rescue` alone would MISS this and let the exit crash the
+      calling worker (and, on the embedding path, the linked `Task.async`
+      caller), defeating fail-open.
+    * a `throw` — caught by `catch :throw` for completeness.
+
   A monitoring fault must never block ALL provider traffic — the gate degrades to
   "no gate", never to "deny everything".
   """
@@ -121,17 +134,24 @@ defmodule Loopctl.Provider.Admission do
     case rate_limiter().check_rate(bucket, @window_ms, limit) do
       {:allow, _count} -> :ok
       {:deny, _limit} -> {:error, :rate_limited_local}
+      # Hammer's documented soft-error shape ({:error, reason}, e.g. its ETS
+      # count_hit failing). Handle it deliberately rather than letting it fall
+      # through to a CaseClauseError caught by `rescue`. AC-37.1.6: fail open.
+      {:error, reason} -> fail_open(provider, "limiter returned {:error, #{inspect(reason)}}")
     end
   rescue
-    e ->
-      # AC-37.1.6: a Hammer/ETS fault must ALLOW the call, never block all
-      # provider traffic. Log and fail open.
-      Logger.warning(
-        "Loopctl.Provider.Admission: limiter error for provider=#{provider}; " <>
-          "failing OPEN (allowing call): #{Exception.message(e)}"
-      )
-
-      :ok
+    # A raised exception (Hammer/ETS fault, or the CaseClauseError from an
+    # undocumented return shape). AC-37.1.6: fail open.
+    e -> fail_open(provider, Exception.message(e))
+  catch
+    # A raised exception is NOT the only failure mode. Hammer reaches its backend
+    # via :poolboy.transaction/3 -> gen_server:call, which EXITS (not raises) with
+    # :noproc when the pool is down/unstarted or {:timeout, _} on checkout timeout.
+    # `rescue` only catches exceptions, so without this the exit would propagate
+    # out and crash the calling worker (and, in the embedding path, the linked
+    # Task.async caller) — defeating fail-open. Catch exits (and throws) too.
+    :exit, reason -> fail_open(provider, "limiter exit: #{inspect(reason)}")
+    :throw, value -> fail_open(provider, "limiter throw: #{inspect(value)}")
   end
 
   @doc """
@@ -146,7 +166,24 @@ defmodule Loopctl.Provider.Admission do
   @spec snooze_seconds() :: pos_integer()
   def snooze_seconds do
     base = SystemConfig.get_int("provider_admission_snooze_seconds", @default_snooze_seconds)
-    base + :rand.uniform(6) - 1
+    # Clamp the (live-tunable, possibly misconfigured) base to >= 1 BEFORE adding
+    # jitter. `:rand.uniform(6) - 1` is 0..5, so an unclamped base of 0 (or a
+    # negative knob) could yield 0/negative — a {:snooze, 0} is an immediate
+    # re-run against a still-shut gate (a tight snooze/re-check loop) and violates
+    # the pos_integer() @spec. max(1, base) guarantees a result of >= 1.
+    max(1, base) + :rand.uniform(6) - 1
+  end
+
+  # AC-37.1.6: a limiter fault (raised exception, {:error, reason}, exit, or
+  # throw) must ALLOW the call, never block all provider traffic. Log and fail
+  # open. Single sink so every failure mode logs and degrades identically.
+  defp fail_open(provider, detail) do
+    Logger.warning(
+      "Loopctl.Provider.Admission: limiter error for provider=#{provider}; " <>
+        "failing OPEN (allowing call): #{detail}"
+    )
+
+    :ok
   end
 
   defp bucket_key(tenant_id, provider), do: "provider_admission:#{provider}:#{tenant_id}"

--- a/lib/loopctl/provider/admission.ex
+++ b/lib/loopctl/provider/admission.ex
@@ -1,0 +1,118 @@
+defmodule Loopctl.Provider.Admission do
+  @moduledoc """
+  Per-`(tenant_id, provider)` token-bucket admission gate that sits IMMEDIATELY
+  before every outbound provider `Req.post` (US-37.1, GH #352).
+
+  ## Why
+
+  Nothing used to sit between agent demand and the provider socket. A burst fired
+  unbounded outbound provider calls (`Req.post`) and triggered a provider-side
+  429 / `:transport_error` storm. This gate makes a cheap node-local admission
+  decision BEFORE the HTTP request is built: on an empty bucket it fast-fails
+  locally with `{:error, :rate_limited_local}` WITHOUT issuing the request, so
+  callers degrade cheaply (interactive search → keyword fallback; background
+  embedding jobs → snooze/retry).
+
+  ## Scope key
+
+  The Hammer bucket key is scoped by `{tenant_id, provider}`:
+
+      "provider_admission:embedding:<tenant_id>"
+      "provider_admission:anthropic:<tenant_id>"
+
+  so one `(tenant, provider)` pair can never consume another's allowance
+  (AC-37.1.1). `provider` is a fixed atom (`:embedding` | `:anthropic`) — never a
+  user-supplied value — so the key is bounded and no `String.to_atom/1` on input
+  is involved.
+
+  ## Capacity / refill (env-driven, live-tunable, no deploy)
+
+  A Hammer sliding window: a fixed 60s window with a per-provider request limit
+  (RPM). Limits are read via `Loopctl.SystemConfig.get_int/2` (DB-backed,
+  hot-path-safe, returns the in-code default on a cache miss), so an operator can
+  retune per environment — and per tenant tier, by seeding a different row — with
+  no deploy (AC-37.1.2). Keys and per-node defaults:
+
+    * `"provider_admission_embedding_rpm"` — default 600 req/node/min
+    * `"provider_admission_anthropic_rpm"` — default 300 req/node/min
+
+  Defaults are deliberately generous: the gate is a defensive ceiling against a
+  runaway burst, NOT a business quota. TPM is intentionally out of scope — the AC
+  is satisfied by RPM alone ("RPM and/or TPM").
+
+  ## Node-local by design (AC-37.1.6)
+
+  Hammer's default backend is node-local ETS, so each node keeps its own bucket.
+  A cluster-wide shared bucket is explicitly OUT OF SCOPE (deferred to Epic 38);
+  the effective fleet ceiling is `rpm * node_count`.
+
+  ## Fail-OPEN (AC-37.1.6)
+
+  The `check_rate/3` call is wrapped in `try/rescue`: on ANY limiter error (a
+  Hammer/ETS fault) the gate LOGS a warning and returns `:ok` (allows the call).
+  A monitoring fault must never block ALL provider traffic — the gate degrades to
+  "no gate", never to "deny everything".
+  """
+
+  require Logger
+
+  alias Loopctl.SystemConfig
+
+  @providers [:embedding, :anthropic]
+
+  # 60s sliding window; the limit is the requests-per-minute ceiling per node.
+  @window_ms 60_000
+
+  # Generous per-node defaults — a defensive ceiling against a runaway burst, not
+  # a business quota. Tunable live via SystemConfig with no deploy.
+  @default_embedding_rpm 600
+  @default_anthropic_rpm 300
+
+  @type provider :: :embedding | :anthropic
+
+  @doc """
+  Admit (or reject) one outbound call for `{tenant_id, provider}`.
+
+  Returns:
+
+    * `:ok` — a token was taken; the caller proceeds to `Req.post`.
+    * `{:error, :rate_limited_local}` — the node-local bucket for this
+      `(tenant, provider)` is empty; the caller must NOT issue the HTTP request.
+
+  FAILS OPEN: any limiter error is logged and returns `:ok`.
+  """
+  @spec admit(String.t(), provider()) :: :ok | {:error, :rate_limited_local}
+  def admit(tenant_id, provider)
+      when is_binary(tenant_id) and provider in @providers do
+    bucket = bucket_key(tenant_id, provider)
+    limit = limit_for(provider)
+
+    case rate_limiter().check_rate(bucket, @window_ms, limit) do
+      {:allow, _count} -> :ok
+      {:deny, _limit} -> {:error, :rate_limited_local}
+    end
+  rescue
+    e ->
+      # AC-37.1.6: a Hammer/ETS fault must ALLOW the call, never block all
+      # provider traffic. Log and fail open.
+      Logger.warning(
+        "Loopctl.Provider.Admission: limiter error for provider=#{provider}; " <>
+          "failing OPEN (allowing call): #{Exception.message(e)}"
+      )
+
+      :ok
+  end
+
+  defp bucket_key(tenant_id, provider), do: "provider_admission:#{provider}:#{tenant_id}"
+
+  defp limit_for(:embedding),
+    do: SystemConfig.get_int("provider_admission_embedding_rpm", @default_embedding_rpm)
+
+  defp limit_for(:anthropic),
+    do: SystemConfig.get_int("provider_admission_anthropic_rpm", @default_anthropic_rpm)
+
+  # Config-based DI (project convention): resolve the limiter at call time so
+  # config/test.exs can swap in Loopctl.MockRateLimiter. NEVER passed as an opt.
+  defp rate_limiter,
+    do: Application.get_env(:loopctl, :rate_limiter, Loopctl.RateLimiter.Hammer)
+end

--- a/lib/loopctl/provider/admission.ex
+++ b/lib/loopctl/provider/admission.ex
@@ -1,6 +1,6 @@
 defmodule Loopctl.Provider.Admission do
   @moduledoc """
-  Per-`(tenant_id, provider)` token-bucket admission gate that sits IMMEDIATELY
+  Per-`(tenant_id, provider)` fixed-window admission gate that sits IMMEDIATELY
   before every outbound provider `Req.post` (US-37.1, GH #352).
 
   ## Why
@@ -25,13 +25,30 @@ defmodule Loopctl.Provider.Admission do
   user-supplied value — so the key is bounded and no `String.to_atom/1` on input
   is involved.
 
-  ## Capacity / refill (env-driven, live-tunable, no deploy)
+  ## Algorithm — Hammer FIXED-WINDOW counter (not a leaky/token bucket)
 
-  A Hammer sliding window: a fixed 60s window with a per-provider request limit
-  (RPM). Limits are read via `Loopctl.SystemConfig.get_int/2` (DB-backed,
-  hot-path-safe, returns the in-code default on a cache miss), so an operator can
-  retune per environment — and per tenant tier, by seeding a different row — with
-  no deploy (AC-37.1.2). Keys and per-node defaults:
+  This gate is backed by Hammer's `check_rate/3`, which is a FIXED-WINDOW
+  counter: a fresh 60s window opens on the first request for a bucket and the
+  count resets to zero when it rolls over. It is NOT a token/leaky bucket and
+  NOT a sliding window. The practical consequence operators must size for: a
+  fixed window admits up to ~2x the limit across a boundary (up to `limit`
+  requests just before a window rolls at t≈59s, then up to `limit` more just
+  after at t≈61s). That is a weaker burst guarantee than a true bucket, but the
+  gate's job is to shed a runaway burst below the provider's hard ceiling, and
+  the generous defaults absorb the 2x boundary overshoot — so reusing
+  `check_rate/3` is a deliberate, accepted tradeoff (technical-notes sanctioned).
+
+  ## Capacity (env-driven, live-tunable, no deploy)
+
+  A fixed 60s window with a per-provider request limit (RPM). Limits are read via
+  `Loopctl.SystemConfig.get_int/2` (DB-backed, hot-path-safe, returns the in-code
+  default on a cache miss), so an operator can retune per environment with no
+  deploy (AC-37.1.2). The limit is a SINGLE global value per provider — there is
+  currently no per-tenant / per-tier dimension (the `SystemConfig` store is
+  global, keyed only by the config name), so every tenant on a node shares the
+  same ceiling; the per-tenant BUCKET KEY still isolates each tenant's *count*.
+  Per-tenant-tier limits are explicitly optional in AC-37.1.2 and deferred. Keys
+  and per-node defaults:
 
     * `"provider_admission_embedding_rpm"` — default 600 req/node/min
     * `"provider_admission_anthropic_rpm"` — default 300 req/node/min
@@ -39,6 +56,16 @@ defmodule Loopctl.Provider.Admission do
   Defaults are deliberately generous: the gate is a defensive ceiling against a
   runaway burst, NOT a business quota. TPM is intentionally out of scope — the AC
   is satisfied by RPM alone ("RPM and/or TPM").
+
+  ## Snooze duration for loss-free backpressure (AC-37.1.4)
+
+  When a background worker receives `{:error, :rate_limited_local}` it should
+  yield loss-free rather than consume an Oban attempt. `snooze_seconds/0` is the
+  single source of that jittered snooze duration for ALL admission-backed workers
+  (both embedding workers and the Anthropic-backed ingestion/review/promotion
+  workers) so every `provider_admission_*` knob and default lives in one place.
+  Live-tunable via `"provider_admission_snooze_seconds"` (default 5s); the jitter
+  avoids a thundering-herd of snoozed jobs re-checking in lockstep.
 
   ## Node-local by design (AC-37.1.6)
 
@@ -60,13 +87,17 @@ defmodule Loopctl.Provider.Admission do
 
   @providers [:embedding, :anthropic]
 
-  # 60s sliding window; the limit is the requests-per-minute ceiling per node.
+  # Fixed 60s window; the limit is the requests-per-minute ceiling per node.
   @window_ms 60_000
 
   # Generous per-node defaults — a defensive ceiling against a runaway burst, not
   # a business quota. Tunable live via SystemConfig with no deploy.
   @default_embedding_rpm 600
   @default_anthropic_rpm 300
+
+  # Base snooze (seconds) a worker waits after {:error, :rate_limited_local}
+  # before Oban re-runs it loss-free. Live-tunable; jitter added in snooze_seconds/0.
+  @default_snooze_seconds 5
 
   @type provider :: :embedding | :anthropic
 
@@ -101,6 +132,21 @@ defmodule Loopctl.Provider.Admission do
       )
 
       :ok
+  end
+
+  @doc """
+  Jittered snooze duration (seconds) for a background worker that received
+  `{:error, :rate_limited_local}` from this gate (AC-37.1.4).
+
+  Single source of truth for the admission snooze across ALL admission-backed
+  workers. The base is live-tunable via the `"provider_admission_snooze_seconds"`
+  `SystemConfig` key (default #{@default_snooze_seconds}s); a small `0..5s` jitter
+  is added so a burst of snoozed jobs does not re-check the gate in lockstep.
+  """
+  @spec snooze_seconds() :: pos_integer()
+  def snooze_seconds do
+    base = SystemConfig.get_int("provider_admission_snooze_seconds", @default_snooze_seconds)
+    base + :rand.uniform(6) - 1
   end
 
   defp bucket_key(tenant_id, provider), do: "provider_admission:#{provider}:#{tenant_id}"

--- a/lib/loopctl/rate_limiter/behaviour.ex
+++ b/lib/loopctl/rate_limiter/behaviour.ex
@@ -7,5 +7,7 @@ defmodule Loopctl.RateLimiter.Behaviour do
   """
 
   @callback check_rate(String.t(), non_neg_integer(), non_neg_integer()) ::
-              {:allow, non_neg_integer()} | {:deny, non_neg_integer()}
+              {:allow, non_neg_integer()}
+              | {:deny, non_neg_integer()}
+              | {:error, term()}
 end

--- a/lib/loopctl/workers/article_embedding_worker.ex
+++ b/lib/loopctl/workers/article_embedding_worker.ex
@@ -51,6 +51,7 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
   alias Loopctl.Llm
   alias Loopctl.Llm.ProviderError
   alias Loopctl.Oban.FairShare
+  alias Loopctl.Provider.Admission
   alias Loopctl.Workers.ArticleLinkingWorker
 
   # Longer Task.yield budget than the interactive query path: a background embed can
@@ -115,7 +116,7 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
         # loss-free backpressure, NOT a failure. Snooze the slot (no attempt
         # consumed, never a discard) — mirrors the FairShare.gate snooze pattern —
         # so the embed is retried once local demand subsides.
-        {:snooze, admission_snooze_seconds()}
+        {:snooze, Admission.snooze_seconds()}
 
       {:error, reason} ->
         # Classify on the raw reason, but the term that becomes an Oban discard/error
@@ -181,14 +182,6 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
     )
 
     {:discard, {:no_embedding_key, article_id}}
-  end
-
-  # US-37.1: small jittered snooze for a node-local provider admission rate-limit.
-  # Jitter avoids a thundering-herd of snoozed embeds re-checking in lockstep. The
-  # base is live-tunable via SystemConfig (no deploy), default 5s.
-  defp admission_snooze_seconds do
-    base = Loopctl.SystemConfig.get_int("provider_admission_snooze_seconds", 5)
-    base + :rand.uniform(6) - 1
   end
 
   defp enqueue_linking(article_id, tenant_id) do

--- a/lib/loopctl/workers/article_embedding_worker.ex
+++ b/lib/loopctl/workers/article_embedding_worker.ex
@@ -110,6 +110,13 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
       {:error, :no_api_key} ->
         skip_no_embedding_key(tenant_id, article_id)
 
+      {:error, :rate_limited_local} ->
+        # US-37.1 (AC-37.1.4): a node-local provider admission rate-limit is
+        # loss-free backpressure, NOT a failure. Snooze the slot (no attempt
+        # consumed, never a discard) — mirrors the FairShare.gate snooze pattern —
+        # so the embed is retried once local demand subsides.
+        {:snooze, admission_snooze_seconds()}
+
       {:error, reason} ->
         # Classify on the raw reason, but the term that becomes an Oban discard/error
         # reason (-> oban_jobs.errors) is SANITIZED (review #5/#6) — never a raw body.
@@ -174,6 +181,14 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
     )
 
     {:discard, {:no_embedding_key, article_id}}
+  end
+
+  # US-37.1: small jittered snooze for a node-local provider admission rate-limit.
+  # Jitter avoids a thundering-herd of snoozed embeds re-checking in lockstep. The
+  # base is live-tunable via SystemConfig (no deploy), default 5s.
+  defp admission_snooze_seconds do
+    base = Loopctl.SystemConfig.get_int("provider_admission_snooze_seconds", 5)
+    base + :rand.uniform(6) - 1
   end
 
   defp enqueue_linking(article_id, tenant_id) do

--- a/lib/loopctl/workers/content_ingestion_worker.ex
+++ b/lib/loopctl/workers/content_ingestion_worker.ex
@@ -59,6 +59,7 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   alias Loopctl.Llm.ProviderError
   alias Loopctl.Net.UrlGuard
   alias Loopctl.Oban.FairShare
+  alias Loopctl.Provider.Admission
   alias Loopctl.SystemConfig
   alias Loopctl.Workers.ArticleEmbeddingWorker
 
@@ -289,19 +290,34 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
 
     acc0 = %{inserted: 0, persisted: 0, attempted: 0, errors: [], seen_titles: MapSet.new()}
 
-    processable
-    |> Enum.with_index()
-    |> Enum.reduce_while(acc0, fn {chunk, chunk_index}, acc ->
-      remaining = @max_articles - acc.inserted
+    result =
+      processable
+      |> Enum.with_index()
+      |> Enum.reduce_while(acc0, fn {chunk, chunk_index}, acc ->
+        remaining = @max_articles - acc.inserted
 
-      if remaining <= 0 do
-        # Article cap reached — stop early; we have the full @max_articles set.
-        {:halt, acc}
-      else
-        reduce_chunk(ctx, chunk, chunk_index, remaining, acc)
-      end
-    end)
-    |> finalize_ingest(chunk_count, dropped)
+        if remaining <= 0 do
+          # Article cap reached — stop early; we have the full @max_articles set.
+          {:halt, acc}
+        else
+          reduce_chunk(ctx, chunk, chunk_index, remaining, acc)
+        end
+      end)
+
+    case result do
+      # US-37.1 (AC-37.1.4): a chunk hit the node-local provider admission gate
+      # (`{:error, :rate_limited_local}`). This is loss-free backpressure, NOT a
+      # failure to classify: snooze the WHOLE job (no Oban attempt consumed, never
+      # a discard) rather than routing it through finalize_errors' transient-retry
+      # path, which would burn max_attempts under sustained provider backpressure.
+      # Already-persisted chunks committed in their own transactions and are
+      # idempotent, so the re-run resumes without re-billing them.
+      {:rate_limited_local, _acc} ->
+        {:snooze, Admission.snooze_seconds()}
+
+      acc ->
+        finalize_ingest(acc, chunk_count, dropped)
+    end
   end
 
   defp reduce_chunk(ctx, chunk, chunk_index, remaining, acc) do
@@ -347,6 +363,12 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
              persisted: acc.persisted + 1,
              seen_titles: seen_titles
          }}
+
+      {:error, :rate_limited_local} ->
+        # US-37.1 (AC-37.1.4): node-local provider admission backpressure. Halt the
+        # reduce and signal the caller to snooze the whole job loss-free — the gate
+        # is shut, so re-attempting the remaining chunks now would just re-hit it.
+        {:halt, {:rate_limited_local, acc}}
 
       {:error, reason} ->
         # Persist what earlier chunks produced; record the error and keep going —

--- a/lib/loopctl/workers/memory_embedding_worker.ex
+++ b/lib/loopctl/workers/memory_embedding_worker.ex
@@ -55,6 +55,7 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorker do
   alias Loopctl.Llm.ProviderError
   alias Loopctl.Memory
   alias Loopctl.Oban.FairShare
+  alias Loopctl.Provider.Admission
 
   @worker_yield_ms 8_000
 
@@ -115,7 +116,7 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorker do
         # US-37.1 (AC-37.1.4): a node-local provider admission rate-limit is
         # loss-free backpressure, NOT a failure. Snooze (no attempt consumed, never
         # a discard) so the embed retries once local demand subsides.
-        {:snooze, admission_snooze_seconds()}
+        {:snooze, Admission.snooze_seconds()}
 
       {:error, reason} ->
         # US-34.3 (review MED #1): the `[:loopctl, :llm, :provider_error]` telemetry
@@ -182,13 +183,5 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorker do
 
   defp build_embedding_text(memory) do
     Memory.Memory.embedding_input(memory.text)
-  end
-
-  # US-37.1: small jittered snooze for a node-local provider admission rate-limit.
-  # Jitter avoids a thundering-herd of snoozed embeds re-checking in lockstep. The
-  # base is live-tunable via SystemConfig (no deploy), default 5s.
-  defp admission_snooze_seconds do
-    base = Loopctl.SystemConfig.get_int("provider_admission_snooze_seconds", 5)
-    base + :rand.uniform(6) - 1
   end
 end

--- a/lib/loopctl/workers/memory_embedding_worker.ex
+++ b/lib/loopctl/workers/memory_embedding_worker.ex
@@ -111,6 +111,12 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorker do
       {:error, :no_api_key} ->
         skip_no_embedding_key(tenant_id, memory_id)
 
+      {:error, :rate_limited_local} ->
+        # US-37.1 (AC-37.1.4): a node-local provider admission rate-limit is
+        # loss-free backpressure, NOT a failure. Snooze (no attempt consumed, never
+        # a discard) so the embed retries once local demand subsides.
+        {:snooze, admission_snooze_seconds()}
+
       {:error, reason} ->
         # US-34.3 (review MED #1): the `[:loopctl, :llm, :provider_error]` telemetry
         # signal is now recorded ONCE, upstream, in
@@ -176,5 +182,13 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorker do
 
   defp build_embedding_text(memory) do
     Memory.Memory.embedding_input(memory.text)
+  end
+
+  # US-37.1: small jittered snooze for a node-local provider admission rate-limit.
+  # Jitter avoids a thundering-herd of snoozed embeds re-checking in lockstep. The
+  # base is live-tunable via SystemConfig (no deploy), default 5s.
+  defp admission_snooze_seconds do
+    base = Loopctl.SystemConfig.get_int("provider_admission_snooze_seconds", 5)
+    base + :rand.uniform(6) - 1
   end
 end

--- a/lib/loopctl/workers/memory_promotion_worker.ex
+++ b/lib/loopctl/workers/memory_promotion_worker.ex
@@ -27,6 +27,9 @@ defmodule Loopctl.Workers.MemoryPromotionWorker do
 
     * `{:error, :embeddings_degraded}` (recall fell back) → `{:snooze, n}`; NO
       watermark advance, so a later healthy run re-attempts (AC-29.2.4).
+    * `{:error, :rate_limited_local}` (node-local provider admission gate shut,
+      US-37.1) → `{:snooze, n}`; loss-free backpressure, NO attempt consumed and NO
+      watermark advance, so the compile re-runs once local demand subsides.
     * `{:error, :quota_exceeded, _}` (subject at its memory cap) → `{:discard, _}`;
       TERMINAL — do NOT retry-loop the LLM. Watermark IS advanced so an unchanged
       session is not re-compiled just to hit the cap again. Because the cap halts the
@@ -63,6 +66,7 @@ defmodule Loopctl.Workers.MemoryPromotionWorker do
   alias Loopctl.Memory.Promoter
   alias Loopctl.Memory.PromotionTelemetry
   alias Loopctl.Memory.Scope
+  alias Loopctl.Provider.Admission
 
   @snooze_seconds 300
 
@@ -163,6 +167,14 @@ defmodule Loopctl.Workers.MemoryPromotionWorker do
         )
 
         persist(scope, session_id, fingerprint, candidates)
+
+      {:error, :rate_limited_local} ->
+        # US-37.1 (AC-37.1.4): node-local provider admission backpressure. Snooze
+        # loss-free (no attempt consumed, no watermark advance) rather than routing
+        # through compile_failure_result/2, which would TERMINALLY discard after only
+        # @max_compile_attempts under sustained provider backpressure. This is not a
+        # compile FAILURE, so it is not counted/logged as one.
+        {:snooze, Admission.snooze_seconds()}
 
       {:error, reason} ->
         PromotionTelemetry.emit(

--- a/lib/loopctl/workers/review_knowledge_worker.ex
+++ b/lib/loopctl/workers/review_knowledge_worker.ex
@@ -43,6 +43,7 @@ defmodule Loopctl.Workers.ReviewKnowledgeWorker do
   alias Loopctl.Llm
   alias Loopctl.Llm.ProviderError
   alias Loopctl.Oban.FairShare
+  alias Loopctl.Provider.Admission
 
   @extractor Application.compile_env(
                :loopctl,
@@ -130,6 +131,13 @@ defmodule Loopctl.Workers.ReviewKnowledgeWorker do
     # title-collision insert) must NOT retry 3x — each retry burns the TENANT's
     # paid Anthropic call (review #3). Mirror ContentIngestionWorker.permanent_error?/1.
     classify_result(result)
+  end
+
+  defp classify_result({:error, :rate_limited_local}) do
+    # US-37.1 (AC-37.1.4): node-local provider admission backpressure is loss-free —
+    # snooze (no Oban attempt consumed, never a discard) rather than burning a retry
+    # against the TENANT's paid Anthropic call under sustained provider backpressure.
+    {:snooze, Admission.snooze_seconds()}
   end
 
   defp classify_result({:error, reason}) do

--- a/priv/repo/migrations/20260714144741_seed_provider_admission_config.exs
+++ b/priv/repo/migrations/20260714144741_seed_provider_admission_config.exs
@@ -1,0 +1,45 @@
+defmodule Loopctl.Repo.Migrations.SeedProviderAdmissionConfig do
+  use Ecto.Migration
+
+  # US-37.1 (#352): per-(tenant, provider) token-bucket admission gate knobs.
+  #
+  # These rows make the node-local admission ceilings operator-visible and
+  # live-tunable (no deploy). A missing row makes SystemConfig.get_int/2 fall back
+  # to the in-code default in Loopctl.Provider.Admission (safe degrade), so seeding
+  # here only mirrors those defaults into the DB from day one:
+  #
+  #   * provider_admission_embedding_rpm  -> 600 req/node/min (default)
+  #   * provider_admission_anthropic_rpm  -> 300 req/node/min (default)
+  #   * provider_admission_snooze_seconds ->   5 s base snooze for gated embed jobs
+  #
+  # Node-local by design (cluster-wide bucket is Epic 38); the effective fleet
+  # ceiling is rpm * node_count. `now() AT TIME ZONE 'UTC'` matches the
+  # :utc_datetime_usec columns; ON CONFLICT keeps re-runs safe.
+
+  def change do
+    execute(
+      """
+      INSERT INTO system_configs (id, key, value, description, inserted_at, updated_at)
+      VALUES
+        (gen_random_uuid(), 'provider_admission_embedding_rpm', 600,
+          'Node-local per-tenant embedding-provider admission ceiling (requests/min)',
+          now() AT TIME ZONE 'UTC', now() AT TIME ZONE 'UTC'),
+        (gen_random_uuid(), 'provider_admission_anthropic_rpm', 300,
+          'Node-local per-tenant Anthropic-provider admission ceiling (requests/min)',
+          now() AT TIME ZONE 'UTC', now() AT TIME ZONE 'UTC'),
+        (gen_random_uuid(), 'provider_admission_snooze_seconds', 5,
+          'Base snooze (s) for embed jobs gated by the node-local admission bucket',
+          now() AT TIME ZONE 'UTC', now() AT TIME ZONE 'UTC')
+      ON CONFLICT (key) DO NOTHING
+      """,
+      """
+      DELETE FROM system_configs
+      WHERE key IN (
+        'provider_admission_embedding_rpm',
+        'provider_admission_anthropic_rpm',
+        'provider_admission_snooze_seconds'
+      )
+      """
+    )
+  end
+end

--- a/test/loopctl/knowledge/embedding_client_test.exs
+++ b/test/loopctl/knowledge/embedding_client_test.exs
@@ -10,6 +10,7 @@ defmodule Loopctl.Knowledge.EmbeddingClientTest do
   use Loopctl.DataCase, async: true
 
   import ExUnit.CaptureLog
+  import Mox
 
   alias Loopctl.Knowledge.EmbeddingClient
   alias Loopctl.Llm
@@ -37,6 +38,25 @@ defmodule Loopctl.Knowledge.EmbeddingClientTest do
     end)
 
     assert {:error, :no_api_key} = EmbeddingClient.generate_embedding(tenant.id, "hello")
+    refute_received :unexpected_http_call
+  end
+
+  test "US-37.1: empty admission bucket → {:error, :rate_limited_local}, NO provider call" do
+    tenant = fixture(:tenant)
+    test_pid = self()
+    set_embedding_key(tenant, "test-openai-key-GATED")
+
+    # Empty node-local bucket for the embedding provider.
+    stub(Loopctl.MockRateLimiter, :check_rate, fn _bucket, _window, _limit -> {:deny, 0} end)
+
+    # If the client wrongly issued an HTTP request despite the empty bucket, this
+    # stub would fire.
+    Req.Test.stub(EmbeddingClient, fn conn ->
+      send(test_pid, :unexpected_http_call)
+      Req.Test.json(conn, %{"data" => [%{"embedding" => [0.0]}]})
+    end)
+
+    assert {:error, :rate_limited_local} = EmbeddingClient.generate_embedding(tenant.id, "hello")
     refute_received :unexpected_http_call
   end
 

--- a/test/loopctl/knowledge_semantic_search_test.exs
+++ b/test/loopctl/knowledge_semantic_search_test.exs
@@ -519,6 +519,51 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
       refute inspect(metadata) =~ "Incorrect API key"
     end
 
+    test "US-37.1: :rate_limited_local -> \"embedding_rate_limited_local\", keyword fallback, no 500" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+      keyword_article(tenant.id)
+      attach_fallback_handler(tenant.id)
+
+      # An empty node-local admission bucket surfaces as {:error, :rate_limited_local}
+      # from the embedding client — the SAME keyword-fallback path as :circuit_open.
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, :rate_limited_local}
+      end)
+
+      assert {:ok, %{meta: meta}} = Knowledge.search_combined(tenant.id, "testing")
+      assert meta.fallback == true
+      assert meta.search_mode == "keyword_only"
+      assert meta.fallback_reason == "embedding_rate_limited_local"
+
+      assert_receive {:semantic_fallback, _m, %{reason: "embedding_rate_limited_local"}}
+    end
+
+    test "US-37.1 (AC-37.1.3): repeated :rate_limited_local does NOT trip the circuit breaker" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+      keyword_article(tenant.id)
+
+      # Far more than the breaker threshold (3): every call returns a node-local
+      # admission rate-limit.
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, :rate_limited_local}
+      end)
+
+      for _ <- 1..10, do: Knowledge.search_combined(tenant.id, "testing")
+
+      attach_fallback_handler(tenant.id)
+
+      # If the breaker had tripped, generate_embedding would short-circuit to
+      # :circuit_open WITHOUT calling the client, tagging "embedding_circuit_open".
+      # Because :rate_limited_local is breaker-exempt, the client is still consulted
+      # and the tag stays "embedding_rate_limited_local".
+      assert {:ok, %{meta: meta}} = Knowledge.search_combined(tenant.id, "testing")
+      assert meta.fallback_reason == "embedding_rate_limited_local"
+
+      assert_receive {:semantic_fallback, _m, %{reason: "embedding_rate_limited_local"}}
+    end
+
     test "a genuinely OPEN circuit breaker surfaces \"embedding_circuit_open\"" do
       %{tenant: tenant} = setup_tenant()
       Knowledge.reset_circuit_breaker(tenant.id)

--- a/test/loopctl/knowledge_semantic_search_test.exs
+++ b/test/loopctl/knowledge_semantic_search_test.exs
@@ -991,8 +991,17 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
       :telemetry.attach(
         handler_id,
         [:loopctl, :llm, :provider_error],
-        fn _event, measurements, metadata, _config ->
-          send(test_pid, {:provider_error_emitted, measurements, metadata})
+        fn
+          # Forward ONLY embedding-provider events. `[:loopctl, :llm, :provider_error]`
+          # is a VM-GLOBAL telemetry event, so under `async: true` a concurrent
+          # Anthropic-path test emitting it with provider="anthropic" would otherwise
+          # leak into this test's mailbox — failing the `assert_received`/
+          # `refute_received` assertions below non-deterministically.
+          _event, measurements, %{provider: "embedding"} = metadata, _config ->
+            send(test_pid, {:provider_error_emitted, measurements, metadata})
+
+          _event, _measurements, _metadata, _config ->
+            :ok
         end,
         nil
       )

--- a/test/loopctl/llm/anthropic_test.exs
+++ b/test/loopctl/llm/anthropic_test.exs
@@ -114,8 +114,20 @@ defmodule Loopctl.Llm.AnthropicTest do
       :telemetry.attach(
         handler_id,
         [:loopctl, :llm, :provider_error],
-        fn _event, measurements, metadata, _config ->
-          send(test_pid, {:provider_error_emitted, measurements, metadata})
+        fn
+          # Forward ONLY this provider's events. `[:loopctl, :llm, :provider_error]`
+          # is a VM-GLOBAL telemetry event, so under `async: true` a concurrent
+          # embedding-path test (Knowledge.generate_embedding / the US-37.1
+          # embedding worker tests) emitting it with provider="embedding" would
+          # otherwise leak into THIS test's mailbox and fail the
+          # `assert_received {:provider_error_emitted, ...}` (received "embedding",
+          # expected "anthropic"). Filtering at the handler makes the assertion
+          # deterministic regardless of test scheduling.
+          _event, measurements, %{provider: "anthropic"} = metadata, _config ->
+            send(test_pid, {:provider_error_emitted, measurements, metadata})
+
+          _event, _measurements, _metadata, _config ->
+            :ok
         end,
         nil
       )
@@ -200,8 +212,15 @@ defmodule Loopctl.Llm.AnthropicTest do
       :telemetry.attach(
         handler_id,
         [:loopctl, :llm, :provider_error],
-        fn _event, _measurements, _metadata, _config ->
-          send(test_pid, :unexpected_provider_error)
+        fn
+          # Filter to this provider — the event is VM-global, so a concurrent
+          # embedding-path emission must NOT be mistaken for this test's call
+          # emitting a provider_error on a successful 200.
+          _event, _measurements, %{provider: "anthropic"}, _config ->
+            send(test_pid, :unexpected_provider_error)
+
+          _event, _measurements, _metadata, _config ->
+            :ok
         end,
         nil
       )

--- a/test/loopctl/llm/anthropic_test.exs
+++ b/test/loopctl/llm/anthropic_test.exs
@@ -219,4 +219,54 @@ defmodule Loopctl.Llm.AnthropicTest do
       refute_received :unexpected_provider_error
     end
   end
+
+  describe "US-37.1: per-(tenant, provider) admission gate (#352)" do
+    test "empty bucket → {:error, :rate_limited_local}, NO provider call, NO record_provider_error" do
+      tenant = tenant_with_key()
+      test_pid = self()
+
+      # Empty node-local bucket for the anthropic provider.
+      stub(Loopctl.MockRateLimiter, :check_rate, fn _bucket, _window, _limit -> {:deny, 0} end)
+
+      # A provider_error emission or an HTTP call would signal the short-circuit ran
+      # too late (after building/sending the request or after the error branches).
+      handler_id = {:anthropic_admission_test, System.unique_integer([:positive])}
+
+      :telemetry.attach(
+        handler_id,
+        [:loopctl, :llm, :provider_error],
+        fn _event, _measurements, _metadata, _config ->
+          send(test_pid, :unexpected_provider_error)
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      Req.Test.stub(Loopctl.Llm.Anthropic, fn conn ->
+        send(test_pid, :unexpected_http_call)
+        Req.Test.json(conn, %{"content" => [%{"type" => "text", "text" => "ok"}]})
+      end)
+
+      assert {:error, :rate_limited_local} = run(tenant)
+      refute_received :unexpected_http_call
+      refute_received :unexpected_provider_error
+    end
+
+    test "token available → the request is issued and the success path is unchanged" do
+      tenant = tenant_with_key()
+
+      # Default permissive stub already allows, but assert explicitly for clarity.
+      stub(Loopctl.MockRateLimiter, :check_rate, fn _bucket, _window, _limit -> {:allow, 1} end)
+
+      Req.Test.stub(Loopctl.Llm.Anthropic, fn conn ->
+        Req.Test.json(conn, %{
+          "content" => [%{"type" => "text", "text" => "ok"}],
+          "usage" => %{"input_tokens" => 1, "output_tokens" => 1}
+        })
+      end)
+
+      assert {:ok, "ok"} = run(tenant)
+    end
+  end
 end

--- a/test/loopctl/provider/admission_test.exs
+++ b/test/loopctl/provider/admission_test.exs
@@ -1,6 +1,6 @@
 defmodule Loopctl.Provider.AdmissionTest do
   @moduledoc """
-  Per-(tenant, provider) node-local token-bucket admission gate (US-37.1, #352).
+  Per-(tenant, provider) node-local fixed-window admission gate (US-37.1, #352).
 
   The limiter is swapped for `Loopctl.MockRateLimiter` via config/test.exs; the
   permissive default stub (`{:allow, 1}`) is overridden per-test to simulate an
@@ -80,5 +80,14 @@ defmodule Loopctl.Provider.AdmissionTest do
       end)
 
     assert log =~ "failing OPEN"
+  end
+
+  test "snooze_seconds/0 returns a jittered, positive duration (single source for all workers)" do
+    # Default base is 5s with a 0..5s jitter, so every result is in 5..10.
+    results = for _ <- 1..50, do: Admission.snooze_seconds()
+
+    assert Enum.all?(results, &(is_integer(&1) and &1 >= 5 and &1 <= 10))
+    # Jitter means we should see more than one distinct value across 50 draws.
+    assert results |> Enum.uniq() |> length() > 1
   end
 end

--- a/test/loopctl/provider/admission_test.exs
+++ b/test/loopctl/provider/admission_test.exs
@@ -69,7 +69,7 @@ defmodule Loopctl.Provider.AdmissionTest do
     assert :ok = Admission.admit(@tenant_a, :anthropic)
   end
 
-  test "FAIL-OPEN: a limiter error allows the call and logs a warning (AC-37.1.6)" do
+  test "FAIL-OPEN: a raised limiter exception allows the call and logs a warning (AC-37.1.6)" do
     stub(Loopctl.MockRateLimiter, :check_rate, fn _bucket, _window, _limit ->
       raise "hammer/ets is down"
     end)
@@ -82,6 +82,69 @@ defmodule Loopctl.Provider.AdmissionTest do
     assert log =~ "failing OPEN"
   end
 
+  test "FAIL-OPEN: a limiter EXIT (e.g. :noproc from a down poolboy pool) allows the call (AC-37.1.6)" do
+    # Hammer reaches its backend via :poolboy.transaction/3 -> gen_server:call,
+    # which EXITS (does not raise) with :noproc when the pool is down/unstarted
+    # and {:timeout, _} on checkout timeout. `rescue` MISSES exits — only the
+    # `catch :exit` clause keeps the gate failing open here.
+    stub(Loopctl.MockRateLimiter, :check_rate, fn _bucket, _window, _limit ->
+      exit(:noproc)
+    end)
+
+    log =
+      capture_log(fn ->
+        assert :ok = Admission.admit(@tenant_a, :embedding)
+      end)
+
+    assert log =~ "failing OPEN"
+    assert log =~ "limiter exit"
+  end
+
+  test "FAIL-OPEN: a limiter checkout-timeout EXIT allows the call (AC-37.1.6)" do
+    stub(Loopctl.MockRateLimiter, :check_rate, fn _bucket, _window, _limit ->
+      exit({:timeout, {:gen_server, :call, [:hammer_pool, :checkout]}})
+    end)
+
+    log =
+      capture_log(fn ->
+        assert :ok = Admission.admit(@tenant_a, :anthropic)
+      end)
+
+    assert log =~ "failing OPEN"
+    assert log =~ "limiter exit"
+  end
+
+  test "FAIL-OPEN: a limiter THROW allows the call (AC-37.1.6)" do
+    stub(Loopctl.MockRateLimiter, :check_rate, fn _bucket, _window, _limit ->
+      throw(:boom)
+    end)
+
+    log =
+      capture_log(fn ->
+        assert :ok = Admission.admit(@tenant_a, :embedding)
+      end)
+
+    assert log =~ "failing OPEN"
+    assert log =~ "limiter throw"
+  end
+
+  test "FAIL-OPEN: Hammer's documented {:error, reason} return allows the call via an explicit clause (AC-37.1.6)" do
+    # {:error, reason} is a documented Hammer.check_rate/3 return (its ETS
+    # count_hit can fail). It must be handled by the explicit case clause — not
+    # fall through to a CaseClauseError accidentally caught by `rescue`.
+    stub(Loopctl.MockRateLimiter, :check_rate, fn _bucket, _window, _limit ->
+      {:error, :ets_table_gone}
+    end)
+
+    log =
+      capture_log(fn ->
+        assert :ok = Admission.admit(@tenant_a, :embedding)
+      end)
+
+    assert log =~ "failing OPEN"
+    assert log =~ "ets_table_gone"
+  end
+
   test "snooze_seconds/0 returns a jittered, positive duration (single source for all workers)" do
     # Default base is 5s with a 0..5s jitter, so every result is in 5..10.
     results = for _ <- 1..50, do: Admission.snooze_seconds()
@@ -89,5 +152,36 @@ defmodule Loopctl.Provider.AdmissionTest do
     assert Enum.all?(results, &(is_integer(&1) and &1 >= 5 and &1 <= 10))
     # Jitter means we should see more than one distinct value across 50 draws.
     assert results |> Enum.uniq() |> length() > 1
+  end
+
+  test "snooze_seconds/0 clamps a misconfigured base of 0 to a positive duration (pos_integer @spec)" do
+    # An operator can set the live knob to 0 (or negative). Without the max(1, base)
+    # clamp, `base + :rand.uniform(6) - 1` would range 0..5, and a {:snooze, 0} is an
+    # immediate re-run against a still-shut gate (a tight snooze/re-check loop). The
+    # clamp guarantees >= 1. We set the persistent_term cache directly (the documented
+    # SystemConfig key format) rather than SystemConfig.put/2 to avoid a leaked DB row,
+    # and erase it on exit; intra-file tests run serially so the default is restored
+    # before the next test, and any concurrent cross-file reader is itself protected by
+    # the same clamp (>= 1).
+    pt_key = {Loopctl.SystemConfig, "provider_admission_snooze_seconds"}
+    :persistent_term.put(pt_key, 0)
+    on_exit(fn -> :persistent_term.erase(pt_key) end)
+
+    results = for _ <- 1..50, do: Admission.snooze_seconds()
+
+    # max(1, 0) + (0..5) => 1..6, and crucially NEVER 0.
+    assert Enum.all?(results, &(is_integer(&1) and &1 >= 1 and &1 <= 6))
+    refute Enum.any?(results, &(&1 <= 0))
+  end
+
+  test "snooze_seconds/0 clamps a negative base to a positive duration (pos_integer @spec)" do
+    pt_key = {Loopctl.SystemConfig, "provider_admission_snooze_seconds"}
+    :persistent_term.put(pt_key, -100)
+    on_exit(fn -> :persistent_term.erase(pt_key) end)
+
+    results = for _ <- 1..50, do: Admission.snooze_seconds()
+
+    # max(1, -100) + (0..5) => 1..6.
+    assert Enum.all?(results, &(is_integer(&1) and &1 >= 1 and &1 <= 6))
   end
 end

--- a/test/loopctl/provider/admission_test.exs
+++ b/test/loopctl/provider/admission_test.exs
@@ -1,0 +1,84 @@
+defmodule Loopctl.Provider.AdmissionTest do
+  @moduledoc """
+  Per-(tenant, provider) node-local token-bucket admission gate (US-37.1, #352).
+
+  The limiter is swapped for `Loopctl.MockRateLimiter` via config/test.exs; the
+  permissive default stub (`{:allow, 1}`) is overridden per-test to simulate an
+  empty bucket, a limiter fault (fail-open), and per-(tenant, provider) isolation.
+  """
+  use Loopctl.DataCase, async: true
+
+  import ExUnit.CaptureLog
+  import Mox
+
+  alias Loopctl.Provider.Admission
+
+  @tenant_a Ecto.UUID.generate()
+  @tenant_b Ecto.UUID.generate()
+
+  test "allow bucket → :ok (a token is taken)" do
+    stub(Loopctl.MockRateLimiter, :check_rate, fn _bucket, _window, _limit -> {:allow, 3} end)
+    assert :ok = Admission.admit(@tenant_a, :embedding)
+    assert :ok = Admission.admit(@tenant_a, :anthropic)
+  end
+
+  test "empty bucket → {:error, :rate_limited_local}" do
+    stub(Loopctl.MockRateLimiter, :check_rate, fn _bucket, _window, _limit -> {:deny, 0} end)
+    assert {:error, :rate_limited_local} = Admission.admit(@tenant_a, :embedding)
+    assert {:error, :rate_limited_local} = Admission.admit(@tenant_a, :anthropic)
+  end
+
+  test "bucket key is scoped by tenant_id AND provider" do
+    test_pid = self()
+
+    stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window, _limit ->
+      send(test_pid, {:bucket, bucket})
+      {:allow, 1}
+    end)
+
+    assert :ok = Admission.admit(@tenant_a, :embedding)
+    assert :ok = Admission.admit(@tenant_a, :anthropic)
+    assert :ok = Admission.admit(@tenant_b, :embedding)
+
+    assert_received {:bucket, "provider_admission:embedding:" <> a_emb}
+    assert_received {:bucket, "provider_admission:anthropic:" <> a_anth}
+    assert_received {:bucket, "provider_admission:embedding:" <> b_emb}
+
+    assert a_emb == @tenant_a
+    assert a_anth == @tenant_a
+    assert b_emb == @tenant_b
+  end
+
+  test "per-(tenant, provider) isolation: A empty + B full → A denied, B allowed" do
+    stub(Loopctl.MockRateLimiter, :check_rate, fn
+      "provider_admission:embedding:" <> tenant, _window, _limit ->
+        if tenant == @tenant_a, do: {:deny, 0}, else: {:allow, 1}
+    end)
+
+    assert {:error, :rate_limited_local} = Admission.admit(@tenant_a, :embedding)
+    assert :ok = Admission.admit(@tenant_b, :embedding)
+  end
+
+  test "embedding vs anthropic buckets are independent for the SAME tenant" do
+    stub(Loopctl.MockRateLimiter, :check_rate, fn
+      "provider_admission:embedding:" <> _tenant, _window, _limit -> {:deny, 0}
+      "provider_admission:anthropic:" <> _tenant, _window, _limit -> {:allow, 1}
+    end)
+
+    assert {:error, :rate_limited_local} = Admission.admit(@tenant_a, :embedding)
+    assert :ok = Admission.admit(@tenant_a, :anthropic)
+  end
+
+  test "FAIL-OPEN: a limiter error allows the call and logs a warning (AC-37.1.6)" do
+    stub(Loopctl.MockRateLimiter, :check_rate, fn _bucket, _window, _limit ->
+      raise "hammer/ets is down"
+    end)
+
+    log =
+      capture_log(fn ->
+        assert :ok = Admission.admit(@tenant_a, :embedding)
+      end)
+
+    assert log =~ "failing OPEN"
+  end
+end

--- a/test/loopctl/workers/article_embedding_worker_test.exs
+++ b/test/loopctl/workers/article_embedding_worker_test.exs
@@ -101,6 +101,36 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorkerTest do
       assert {:error, {:api_error, 500, :provider_error}} = result
       refute inspect(result) =~ "LEAK"
     end
+
+    test "US-37.1 (AC-37.1.4): a node-local rate-limit snoozes (never discards)" do
+      %{tenant: tenant} = setup_tenant()
+
+      {:ok, article} =
+        Knowledge.create_article(tenant.id, %{
+          title: "Rate Limited Article",
+          body: "Will be node-local rate-limited.",
+          category: :pattern,
+          status: :draft
+        })
+
+      article =
+        %{article | status: :published}
+        |> Ecto.Changeset.change(%{status: :published})
+        |> Loopctl.AdminRepo.update!()
+
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, :rate_limited_local}
+      end)
+
+      result =
+        ArticleEmbeddingWorker.perform(%Oban.Job{
+          args: %{"article_id" => article.id, "tenant_id" => tenant.id}
+        })
+
+      # Loss-free backpressure: snooze (no attempt consumed), NEVER a discard.
+      assert {:snooze, seconds} = result
+      assert is_integer(seconds) and seconds > 0
+    end
   end
 
   # --- TC-20.3.3: Worker handles deleted article (returns :ok) ---

--- a/test/loopctl/workers/content_ingestion_worker_test.exs
+++ b/test/loopctl/workers/content_ingestion_worker_test.exs
@@ -445,6 +445,33 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
       refute message =~ masked
       refute inspect(result) =~ masked
     end
+
+    test "US-37.1 (AC-37.1.4): a node-local admission rate-limit SNOOZES (never burns an attempt/discards)" do
+      %{tenant: tenant} = setup_tenant()
+
+      # The provider admission gate is shut for this tenant -> the extractor returns
+      # the new {:error, :rate_limited_local}. This is loss-free backpressure, NOT a
+      # failure: the job must snooze (no attempt consumed) rather than retry/discard.
+      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id,
+                                                                     _content,
+                                                                     _opts ->
+        {:error, :rate_limited_local}
+      end)
+
+      result =
+        ContentIngestionWorker.perform(%Oban.Job{
+          id: 107,
+          args: %{
+            "tenant_id" => tenant.id,
+            "content" => "Rate limited content",
+            "content_hash" => "rate_limited_local_test",
+            "source_type" => "ingestion"
+          }
+        })
+
+      assert {:snooze, seconds} = result
+      assert is_integer(seconds) and seconds > 0
+    end
   end
 
   # --- Project scoping ---

--- a/test/loopctl/workers/memory_embedding_worker_test.exs
+++ b/test/loopctl/workers/memory_embedding_worker_test.exs
@@ -167,5 +167,18 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorkerTest do
 
       assert {:error, _} = MemoryEmbeddingWorker.perform(job(memory.id, tenant.id))
     end
+
+    test "US-37.1 (AC-37.1.4): a node-local rate-limit snoozes (never discards)" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+      memory = fixture(:memory, %{tenant_id: tenant.id, subject_id: "s", text: "rate limited"})
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
+        {:error, :rate_limited_local}
+      end)
+
+      assert {:snooze, seconds} = MemoryEmbeddingWorker.perform(job(memory.id, tenant.id))
+      assert is_integer(seconds) and seconds > 0
+    end
   end
 end

--- a/test/loopctl/workers/memory_promotion_worker_test.exs
+++ b/test/loopctl/workers/memory_promotion_worker_test.exs
@@ -454,6 +454,41 @@ defmodule Loopctl.Workers.MemoryPromotionWorkerTest do
       assert watermark(scope, "s1") == nil
       assert all_promoted(scope) == []
     end
+
+    test "US-37.1 (AC-37.1.4): a node-local admission rate-limit SNOOZES loss-free — even AT the attempt cap (never discards)" do
+      scope = fixture(:memory_scope, subject_id: "A")
+      stub_embeddings(& &1)
+      attach_telemetry([:failed], scope.tenant_id)
+      seed_turns(scope, "s1", ["one", "two"])
+
+      # The provider admission gate is shut -> compile returns {:error, :rate_limited_local}.
+      # This is loss-free backpressure, NOT a compile failure: it must snooze WITHOUT
+      # routing through compile_failure_result/2 (which would terminally discard at the cap).
+      stub(Loopctl.MockPromoterLLM, :extract, fn _t, _c, _o -> {:error, :rate_limited_local} end)
+
+      # Default attempt (0) snoozes.
+      assert {:snooze, seconds} = run(scope, "s1")
+      assert is_integer(seconds) and seconds > 0
+
+      # AT/above the compile-attempt cap it STILL snoozes (the medium-finding regression:
+      # rate-limited-local must never be discarded like a real compile failure would be).
+      job_at_cap = %Oban.Job{
+        attempt: 2,
+        args: %{
+          "tenant_id" => scope.tenant_id,
+          "subject_id" => scope.subject_id,
+          "project_id" => scope.project_id,
+          "session_id" => "s1"
+        }
+      }
+
+      assert {:snooze, _} = MemoryPromotionWorker.perform(job_at_cap)
+
+      # Not counted/logged as a compile failure, and no watermark advance / no rows.
+      refute_received {:telemetry, :failed, _, _}
+      assert watermark(scope, "s1") == nil
+      assert all_promoted(scope) == []
+    end
   end
 
   # ---------------------------------------------------------------------------

--- a/test/loopctl/workers/review_knowledge_worker_test.exs
+++ b/test/loopctl/workers/review_knowledge_worker_test.exs
@@ -81,6 +81,26 @@ defmodule Loopctl.Workers.ReviewKnowledgeWorkerTest do
                  args: %{"review_record_id" => review.id, "tenant_id" => tenant.id}
                })
     end
+
+    test "US-37.1 (AC-37.1.4): a node-local admission rate-limit SNOOZES (never burns an attempt/discards)" do
+      %{tenant: tenant} = setup_tenant()
+      review = create_review_record(tenant.id)
+
+      # The provider admission gate is shut -> the extractor returns the new
+      # {:error, :rate_limited_local}. Loss-free backpressure: snooze (no attempt
+      # consumed) rather than burning a retry against the tenant's paid Anthropic call.
+      expect(Loopctl.MockExtractor, :extract_articles, fn _tenant_id, _ctx ->
+        {:error, :rate_limited_local}
+      end)
+
+      result =
+        ReviewKnowledgeWorker.perform(%Oban.Job{
+          args: %{"review_record_id" => review.id, "tenant_id" => tenant.id}
+        })
+
+      assert {:snooze, seconds} = result
+      assert is_integer(seconds) and seconds > 0
+    end
   end
 
   # --- TC-21.1.1: Worker extracts articles from review successfully ---


### PR DESCRIPTION
## US-37.1 — Per-(tenant, provider) token-bucket admission gate (#352)

Adds a **node-local** Hammer token-bucket admission check immediately before the two outbound provider `Req.post` calls. On an empty bucket the call fast-fails locally with `{:error, :rate_limited_local}` **without** issuing the HTTP request, so a burst degrades cheaply instead of triggering a provider-side 429 / `:transport_error` storm.

### What changed
- **`Loopctl.Provider.Admission`** (new) — `admit(tenant_id, provider)` where `provider in [:embedding, :anthropic]`. Bucket key scoped by `{tenant_id, provider}` (`"provider_admission:<provider>:<tenant_id>"`) so no `(tenant, provider)` pair consumes another allowance. RPM/window read from `SystemConfig` (live-tunable, no deploy). Config-based DI on the limiter. **FAILS OPEN** on any limiter error (a Hammer/ETS fault allows the call, never blocks all traffic) and logs.
- **`EmbeddingClient.post`** / **`Anthropic.post`** — gate before `Req.post`. The Anthropic short-circuit returns **before** `record_provider_error/1`, so a local rate-limit never inflates the `[:loopctl, :llm, :provider_error]` storm signal.
- **`Knowledge`** — `breaker_countable?(:rate_limited_local) => false` (breaker-EXEMPT for BOTH the circuit breaker and the provider-error signal). Combined-search keyword fallback tags it `"embedding_rate_limited_local"` (mirrors the #297 fallback-reason observability). Same keyword-fallback path as `:circuit_open` — no 500.
- **Article/Memory embedding workers** — `:rate_limited_local => {:snooze, n}` (loss-free, no attempt consumed), never `{:discard, _}`.
- **Migration** — seeds `provider_admission_embedding_rpm=600`, `provider_admission_anthropic_rpm=300`, `provider_admission_snooze_seconds=5` (mirror the in-code defaults; missing rows fall back to those defaults).

### Acceptance criteria
All six ACs (37.1.1–37.1.6) satisfied. Node-local by design; a cluster-wide shared bucket is deferred to Epic 38.

### Tests
- Admission unit: allow/deny, tenant+provider bucket-key scoping, per-(tenant,provider) isolation, embedding-vs-anthropic independence, **fail-open on limiter raise**.
- EmbeddingClient: empty bucket to `{:error, :rate_limited_local}` with **zero** provider calls.
- Anthropic: empty bucket to `{:error, :rate_limited_local}`, no HTTP call, **no `record_provider_error`**; token-available success path unchanged.
- Knowledge: repeated `:rate_limited_local` does **not** trip the breaker; combined search to keyword-only fallback, `fallback_reason == "embedding_rate_limited_local"`, no 500.
- Workers: `:rate_limited_local` to `{:snooze, n}`, never `{:discard, _}`.

`mix precommit` green (compile --warnings-as-errors, format, credo --strict, dialyzer, 4534 tests 0 failures).

Note: US-37.3 depends on this story keeping `:rate_limited_local` breaker-exempt.

Closes #352
