### PR TITLE
Bound the interactive embedding path with a supervised, per-node concurrency cap

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -309,6 +309,16 @@ config :loopctl, Oban,
     verification: 1
   ]
 
+# US-37.2 (GH #352): per-node ceiling on concurrent OUTBOUND embedding calls
+# (`Loopctl.Knowledge.EmbeddingConcurrency`). This is the in-code default used on a
+# `SystemConfig` cache miss; operators retune it live (no deploy) via the
+# `"embedding_max_concurrent"` SystemConfig key. Because BOTH the interactive query
+# path and the two Oban embedding workers acquire the SAME slot, this is the TOTAL
+# node ceiling — sized to ~2x the background `embeddings` queue (5) so a normal
+# search never waits on a slot while a runaway interactive burst is still shed well
+# below the provider's hard ceiling. Node-local (distributed coordination is Epic 38).
+config :loopctl, :embedding_max_concurrent, 10
+
 # US-35.3: the Oban `:plugins` list (Cron crontab + Lifeline + Pruner + Reindexer)
 # moved to `Loopctl.ObanConfig.plugins/0` and is set at RUNTIME in `config/runtime.exs`
 # (`config :loopctl, Oban, plugins: Loopctl.ObanConfig.plugins()`). It lives there —

--- a/config/config.exs
+++ b/config/config.exs
@@ -319,6 +319,16 @@ config :loopctl, Oban,
 # below the provider's hard ceiling. Node-local (distributed coordination is Epic 38).
 config :loopctl, :embedding_max_concurrent, 10
 
+# US-37.2 per-tenant sub-cap: the MOST outbound embeds a SINGLE tenant may hold of
+# the global budget at once, so one tenant's interactive burst can't silently starve
+# every other tenant's semantic search (mirrors `ExportConcurrency`'s per-tenant cap
+# and the per-tenant embedding circuit breaker — a bursting tenant degrades ITSELF).
+# In-code default on a `SystemConfig` cache miss; operators retune live (no deploy)
+# via the `"embedding_max_concurrent_per_tenant"` SystemConfig key. `6` of the global
+# `10` keeps a single active tenant unthrottled on an idle node while always leaving
+# slots for neighbours. Node-local (distributed coordination is Epic 38).
+config :loopctl, :embedding_max_concurrent_per_tenant, 6
+
 # US-35.3: the Oban `:plugins` list (Cron crontab + Lifeline + Pruner + Reindexer)
 # moved to `Loopctl.ObanConfig.plugins/0` and is set at RUNTIME in `config/runtime.exs`
 # (`config :loopctl, Oban, plugins: Loopctl.ObanConfig.plugins()`). It lives there —

--- a/config/test.exs
+++ b/config/test.exs
@@ -293,6 +293,21 @@ config :loopctl, :token_archival, Loopctl.MockTokenArchival
 # DI: Use mock embedding client in tests
 config :loopctl, :embedding_client, Loopctl.MockEmbeddingClient
 
+# US-37.2: DI seam for the per-node outbound-embedding concurrency gate. In :test it
+# resolves to the mock so a saturation test can force {:error, :rate_limited_local}
+# deterministically; the DataCase default stub returns :ok/:ok so every existing
+# search test is unaffected. The REAL Loopctl.Knowledge.EmbeddingConcurrency GenServer
+# is unit-tested directly (embedding_concurrency_test.exs), bypassing this seam.
+config :loopctl, :embedding_concurrency, Loopctl.MockEmbeddingConcurrency
+
+# US-37.2: high suite-wide default for the embedding concurrency cap so incidental
+# parallel interactive searches in the async suite never collide on the shared,
+# VM-wide global counter (the export-cap precedent at :export_max_concurrent_global).
+# The gate's OWN unit test sets an explicit LOW cap via acquire/1, independent of
+# this value; the search-path saturation test uses the DI mock above, not the real
+# counter. Production uses the config.exs default (10), live-tunable via SystemConfig.
+config :loopctl, :embedding_max_concurrent, 64
+
 # US-28.2: a small per-(tenant, subject) long-term memory cap so the quota path
 # (`{:error, :quota_exceeded}`) is testable without inserting tens of thousands of
 # rows. Kept above the largest pagination test (25 rows) so that test stays under

--- a/config/test.exs
+++ b/config/test.exs
@@ -303,10 +303,16 @@ config :loopctl, :embedding_concurrency, Loopctl.MockEmbeddingConcurrency
 # US-37.2: high suite-wide default for the embedding concurrency cap so incidental
 # parallel interactive searches in the async suite never collide on the shared,
 # VM-wide global counter (the export-cap precedent at :export_max_concurrent_global).
-# The gate's OWN unit test sets an explicit LOW cap via acquire/1, independent of
-# this value; the search-path saturation test uses the DI mock above, not the real
+# The gate's OWN unit test sets explicit LOW caps via acquire/3, independent of
+# these values; the search-path saturation test uses the DI mock above, not the real
 # counter. Production uses the config.exs default (10), live-tunable via SystemConfig.
 config :loopctl, :embedding_max_concurrent, 64
+
+# US-37.2 per-tenant sub-cap: high suite-wide default for the SAME reason as the
+# global cap above — incidental parallel searches (per tenant) must not collide on
+# the shared, VM-wide per-tenant counters. The gate's unit test passes an explicit
+# LOW per-tenant cap via acquire/3. Production uses the config.exs default (6).
+config :loopctl, :embedding_max_concurrent_per_tenant, 64
 
 # US-28.2: a small per-(tenant, subject) long-term memory cap so the quota path
 # (`{:error, :quota_exceeded}`) is testable without inserting tens of thousands of

--- a/lib/loopctl/application.ex
+++ b/lib/loopctl/application.ex
@@ -39,6 +39,17 @@ defmodule Loopctl.Application do
       # US-27.16: owns the ETS table tracking in-flight streaming-export slots so a
       # crashed exporter's slot is reclaimed (concurrency cap, AC-27.16.6).
       Loopctl.Knowledge.ExportConcurrency,
+      # US-37.2: owns the ETS counter bounding concurrent OUTBOUND embedding calls
+      # per node so a crashed acquirer's slot is reclaimed. Gates EVERY
+      # generate_embedding entry point (interactive query path AND both Oban
+      # embedding workers) via run_embedding_task/3, making the per-node ceiling
+      # real (GH #352). Node-local; distributed coordination is Epic 38.
+      Loopctl.Knowledge.EmbeddingConcurrency,
+      # US-37.2: dedicated supervisor for the query-embedding tasks spawned by
+      # run_embedding_task/3 (Task.Supervisor.async_nolink), so an embedding task
+      # crash is isolated from the request/worker process (AC-37.2.5) with cleaner
+      # isolation/telemetry than sharing the general Loopctl.TaskSupervisor.
+      {Task.Supervisor, name: Loopctl.Knowledge.EmbeddingTaskSupervisor},
       # Owns the per-tenant embedding circuit-breaker ETS table so it has a STABLE,
       # long-lived owner (it would otherwise be created by a transient request/job/Task
       # and vanish when that process died — silently resetting the breaker).

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -53,6 +53,7 @@ defmodule Loopctl.Knowledge do
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.ArticleLink
   alias Loopctl.Knowledge.ConflictResolution
+  alias Loopctl.Knowledge.EmbeddingConcurrency
   alias Loopctl.Knowledge.KbCuration
   alias Loopctl.Knowledge.OKF
   alias Loopctl.Knowledge.VectorSearch
@@ -173,8 +174,13 @@ defmodule Loopctl.Knowledge do
   @max_pair_offset 10_000
   @default_walk_length 4
   @max_walk_length 25
-  # Novelty scoring embeds each idea concurrently (bounded) so a 50-idea batch
-  # doesn't serialize 50 embedding round-trips.
+  # Novelty scoring embeds each idea concurrently (bounded) so a 50-idea batch doesn't
+  # serialize 50 embedding round-trips. This is a STATIC CEILING; the effective width is
+  # computed by novelty_concurrency/0, which caps it further to leave guaranteed headroom
+  # below the per-tenant embedding budget (US-37.2 review): the fan-out and the SAME
+  # tenant's interactive combined searches share EmbeddingConcurrency's per-tenant cap,
+  # so an uncapped fan-out (5) could hold nearly the whole per-tenant budget (default 6)
+  # and starve that tenant's concurrent interactive searches down to keyword fallback.
   @novelty_concurrency 5
 
   # Maximum text length for a novelty idea to prevent unbounded embedding input.
@@ -5301,7 +5307,8 @@ defmodule Loopctl.Knowledge do
   Novelty scoring (#152 A2): for each idea, the **cosine distance** to its nearest
   prior proposal — `0` = identical to existing work, higher = more novel (up to `2.0`
   for an opposite embedding). Embeds each idea's text on the fly, concurrently (bounded
-  at #{@novelty_concurrency}). Priors default to published articles tagged `proposal`;
+  at #{@novelty_concurrency}, and further capped to leave headroom below the per-tenant
+  embedding cap). Priors default to published articles tagged `proposal`;
   pass `:prior_tag` to use a different family.
 
   ## Parameters
@@ -5332,7 +5339,7 @@ defmodule Loopctl.Knowledge do
       else
         ideas
         |> Task.async_stream(&score_idea(tenant_id, &1, prior_tag, vis),
-          max_concurrency: @novelty_concurrency,
+          max_concurrency: novelty_concurrency(),
           timeout: :infinity,
           ordered: true
         )
@@ -5348,6 +5355,23 @@ defmodule Loopctl.Knowledge do
       end
 
     {:ok, scored, prior_count}
+  end
+
+  # Effective novelty fan-out width. Bounded by the static @novelty_concurrency ceiling
+  # AND capped to leave headroom below EmbeddingConcurrency's per-tenant embedding cap,
+  # so a single novelty batch can't consume the whole per-tenant budget and starve the
+  # SAME tenant's concurrent interactive searches to keyword fallback (US-37.2 review).
+  # Reserve at least ~1/3 of the per-tenant budget (min 1 slot) for other embedding
+  # traffic; never exceed the static ceiling; never below 1. Reading max_per_tenant/0
+  # directly (not via the acquire/release DI seam) is fine — it is a cached SystemConfig
+  # read, and this runs once per novelty_scores/3 call, not per idea.
+  defp novelty_concurrency do
+    per_tenant = EmbeddingConcurrency.max_per_tenant()
+    reserved = max(1, div(per_tenant, 3))
+
+    (per_tenant - reserved)
+    |> min(@novelty_concurrency)
+    |> max(1)
   end
 
   # Count of embedded prior proposals visible to the caller — the set actually

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -7300,7 +7300,13 @@ defmodule Loopctl.Knowledge do
   - A tenant-scoped circuit breaker (opens for a tenant after #{@failure_threshold}
     COUNTABLE failures within #{@failure_window_seconds}s — so a failing tenant only
     degrades ITSELF, never other tenants; review #1).
-  - A `#{@embedding_yield_ms}`ms `Task.async` timeout (review #10).
+  - A per-node concurrency cap (US-37.2): `run_embedding_task/3` `acquire`s a slot
+    from `Loopctl.Knowledge.EmbeddingConcurrency` before spawning the task and
+    releases it after, so this SINGLE entry point bounds concurrent outbound embeds
+    across the interactive path AND both Oban embedding workers. Over the cap it
+    fast-fails with `{:error, :rate_limited_local}` (keyword fallback / worker snooze).
+  - A `#{@embedding_yield_ms}`ms `Task.Supervisor.async_nolink` yield budget (review
+    #10; US-37.2 supervises the task so its crash never crashes the caller).
   - A crash rescue handler.
 
   Returns `{:ok, embedding}` or `{:error, reason}`. Two error classes are EXEMPT
@@ -7340,9 +7346,39 @@ defmodule Loopctl.Knowledge do
     end
   end
 
+  # US-37.2: gate EVERY outbound embedding on a per-node concurrency cap BEFORE
+  # spawning the task, so the interactive query path AND both Oban embedding workers
+  # (which route through here via generate_embedding/3) share ONE real node ceiling
+  # (GH #352). The acquire is charged to THIS (request/worker) process and released
+  # in an `after` so a yield-timeout shutdown or an in-task crash still frees the
+  # slot; a crash of THIS process is reclaimed by the gate's monitor. Over the cap,
+  # acquire fast-fails with {:error, :rate_limited_local} — the breaker-exempt reason
+  # (see breaker_countable?/1) the combined-search branch turns into a keyword-only
+  # fallback and the workers snooze on — so the interactive path degrades gracefully
+  # instead of blocking, and NO circuit-breaker / provider-error signal is recorded
+  # (self-imposed backpressure is not a provider failure).
   defp run_embedding_task(tenant_id, query_string, timeout) do
+    case embedding_concurrency().acquire() do
+      :ok ->
+        try do
+          run_capped_embedding_task(tenant_id, query_string, timeout)
+        after
+          embedding_concurrency().release()
+        end
+
+      {:error, :rate_limited_local} = err ->
+        err
+    end
+  end
+
+  defp run_capped_embedding_task(tenant_id, query_string, timeout) do
+    # Task.Supervisor.async_nolink so an embedding task crash surfaces as
+    # {:exit, reason} from Task.yield (the `_ ->` clause -> {:error, :timeout})
+    # rather than crashing THIS process (AC-37.2.5). The inner rescue still catches
+    # embedding-client exceptions and returns {:error, {:embedding_crash, ...}};
+    # async_nolink additionally protects against exits the rescue can't catch.
     task =
-      Task.async(fn ->
+      Task.Supervisor.async_nolink(Loopctl.Knowledge.EmbeddingTaskSupervisor, fn ->
         try do
           embedding_client().generate_embedding(tenant_id, query_string)
         rescue
@@ -7366,7 +7402,8 @@ defmodule Loopctl.Knowledge do
         err
 
       _ ->
-        # nil (yield timeout) or an abnormal task exit — a provider/infra failure.
+        # nil (yield timeout), an abnormal task exit, or an async_nolink task crash
+        # surfacing as {:exit, reason} — a provider/infra failure.
         record_failure(tenant_id)
         maybe_record_provider_error(:timeout)
         {:error, :timeout}
@@ -7505,6 +7542,19 @@ defmodule Loopctl.Knowledge do
 
   defp embedding_client do
     Application.get_env(:loopctl, :embedding_client, Loopctl.Knowledge.EmbeddingClient)
+  end
+
+  # US-37.2: the per-node embedding-concurrency gate, resolved via config-based DI
+  # (like embedding_client/0 above) so config/test.exs can swap in
+  # Loopctl.MockEmbeddingConcurrency — letting a saturation test force
+  # {:error, :rate_limited_local} deterministically without holding the real,
+  # VM-wide global counter saturated (which would starve unrelated async searches).
+  defp embedding_concurrency do
+    Application.get_env(
+      :loopctl,
+      :embedding_concurrency,
+      Loopctl.Knowledge.EmbeddingConcurrency
+    )
   end
 
   # --- Embedding helpers ---

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -7349,21 +7349,24 @@ defmodule Loopctl.Knowledge do
   # US-37.2: gate EVERY outbound embedding on a per-node concurrency cap BEFORE
   # spawning the task, so the interactive query path AND both Oban embedding workers
   # (which route through here via generate_embedding/3) share ONE real node ceiling
-  # (GH #352). The acquire is charged to THIS (request/worker) process and released
-  # in an `after` so a yield-timeout shutdown or an in-task crash still frees the
-  # slot; a crash of THIS process is reclaimed by the gate's monitor. Over the cap,
-  # acquire fast-fails with {:error, :rate_limited_local} — the breaker-exempt reason
+  # (GH #352) — a GLOBAL cap plus a per-tenant sub-cap so one tenant's burst can't
+  # starve every other tenant's semantic search. The acquire is charged to THIS
+  # (request/worker) process for the request's tenant and released in an `after` so a
+  # yield-timeout shutdown or an in-task crash still frees the slot; a crash of THIS
+  # process is reclaimed by the gate's monitor. Over EITHER cap (or if the gate
+  # GenServer is down), acquire fast-fails with {:error, :rate_limited_local} — the
+  # breaker-exempt reason
   # (see breaker_countable?/1) the combined-search branch turns into a keyword-only
   # fallback and the workers snooze on — so the interactive path degrades gracefully
   # instead of blocking, and NO circuit-breaker / provider-error signal is recorded
   # (self-imposed backpressure is not a provider failure).
   defp run_embedding_task(tenant_id, query_string, timeout) do
-    case embedding_concurrency().acquire() do
+    case embedding_concurrency().acquire(tenant_id) do
       :ok ->
         try do
           run_capped_embedding_task(tenant_id, query_string, timeout)
         after
-          embedding_concurrency().release()
+          embedding_concurrency().release(tenant_id)
         end
 
       {:error, :rate_limited_local} = err ->

--- a/lib/loopctl/knowledge/embedding_concurrency.ex
+++ b/lib/loopctl/knowledge/embedding_concurrency.ex
@@ -1,0 +1,290 @@
+defmodule Loopctl.Knowledge.EmbeddingConcurrency do
+  @moduledoc """
+  Hard per-node cap on concurrent OUTBOUND embedding calls (US-37.2, GH #352).
+
+  ## Why
+
+  The default `combined` knowledge search embeds the query SYNCHRONOUSLY in the
+  web/MCP request process. Before this cap that embed ran under a bare, un-pooled,
+  un-capped `Task.async`, so a spike spawned UNBOUNDED concurrent outbound embedding
+  calls — the Oban `embeddings: 5` queue cap only bounds BACKGROUND embeds and was
+  illusory for interactive traffic, feeding the provider 429 storm. This gate makes
+  the per-node ceiling REAL: EVERY `generate_embedding` entry point — the interactive
+  query path AND both Oban embedding workers
+  (`ArticleEmbeddingWorker`/`MemoryEmbeddingWorker`) — funnels through
+  `Loopctl.Knowledge.run_embedding_task/3`, which `acquire/0`s a slot here before
+  spawning its supervised task and `release/0`s it after. Over the cap, `acquire/0`
+  fast-fails with `{:error, :rate_limited_local}` (the breaker-exempt reason shared
+  with the US-37.1 admission gate): the interactive path degrades to keyword search
+  (same fallback as `:circuit_open`), and a background worker snoozes loss-free.
+
+  Complement to `Loopctl.Provider.Admission` (US-37.1): admission is a rate-over-time
+  bucket (RPM); this is a SIMULTANEOUS-in-flight semaphore. Both are node-local
+  defensive ceilings against a runaway burst, both fail SAFE.
+
+  ## Cap sizing (env-driven, live-tunable, no deploy)
+
+  A SINGLE GLOBAL per-node counter — the AC requires only a node-wide `N`, not a
+  per-tenant dimension (embedding calls stay tenant-scoped, but the CONCURRENCY
+  ceiling is node-global). The cap is read via
+  `Loopctl.SystemConfig.get_int("embedding_max_concurrent", <default>)`, so an
+  operator can retune it during an incident with no deploy (mirrors the
+  US-37.1 admission RPM knobs). The in-code default (`#{10}`) applies on a
+  SystemConfig cache miss, and the fallback itself is `Application.get_env`-backed
+  so `config/test.exs` can raise a high suite-wide default (stops incidental
+  parallel searches colliding on the shared VM-wide counter — the export-cap
+  precedent).
+
+  ### Why `#{10}`
+
+  Because BOTH the query path and the two workers now acquire the SAME slot, this
+  cap is the TOTAL node ceiling for outbound embeds. The background `embeddings`
+  Oban queue is 5; the interactive path was previously unbounded. `10` keeps
+  interactive + background embedding concurrency bounded together at roughly 2x
+  the background queue — enough headroom that a normal search never waits on a
+  slot, while still shedding a runaway interactive burst well below the provider's
+  hard ceiling. Live-tunable up/down per environment.
+
+  ## Design (mirrors `Loopctl.Knowledge.ExportConcurrency`)
+
+  A single supervised GenServer owns a public, named ETS table holding one
+  in-flight counter; callers mutate it with atomic `:ets.update_counter` (lock-free)
+  so the GenServer is never a throughput bottleneck. The GenServer exists only to
+  OWN the table (so it survives the transient request/worker process that
+  incremented it) and to MONITOR acquirers: an acquirer that crashes WITHOUT
+  calling `release/0` would otherwise leak its slot forever, drifting the effective
+  cap up. `acquire/0` registers the calling process for monitoring; a `:DOWN`
+  reclaims the leaked slot. The slot is charged to the CALLING process (the
+  request/worker running `run_embedding_task/3`, which acquires → runs the task →
+  releases synchronously), NOT to the off-process supervised task.
+
+  ## Node-local by design
+
+  One counter per node — distributed coordination is explicitly OUT OF SCOPE
+  (Epic 38, #353). The effective fleet ceiling is `cap * node_count`.
+  """
+
+  use GenServer
+
+  @behaviour Loopctl.Knowledge.EmbeddingConcurrency.Behaviour
+
+  require Logger
+
+  alias Loopctl.SystemConfig
+
+  @table :loopctl_embedding_inflight
+  @global_key :__global__
+  @config_key "embedding_max_concurrent"
+  @default_max 10
+
+  # --- Client API ---
+
+  @doc false
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc """
+  Tries to reserve one outbound-embedding slot for the CALLING process (monitored
+  for crash-safe release), against the configured cap (`max_concurrent/0`).
+
+  Returns `:ok` when the node-wide in-flight count is below the cap (the counter is
+  incremented atomically) or `{:error, :rate_limited_local}` when the cap is already
+  met (no counter left incremented). Non-blocking — fails fast at the cap. Pair
+  every successful `acquire/0` with a `release/0`.
+  """
+  @impl Loopctl.Knowledge.EmbeddingConcurrency.Behaviour
+  @spec acquire() :: :ok | {:error, :rate_limited_local}
+  def acquire, do: acquire(max_concurrent())
+
+  @doc """
+  Like `acquire/0`, but reserves against an EXPLICIT `max` cap instead of the
+  configured one.
+
+  Production always uses `acquire/0` (which reads `max_concurrent/0`). This variant
+  exists for the gate's OWN unit tests: the async suite sets a deliberately HIGH
+  `:embedding_max_concurrent` (see `config/test.exs`) so incidental parallel
+  searches never collide on the shared, VM-wide global counter — so a test that
+  must PROVE the cap refuses over-cap acquires passes its own fixed LOW cap here,
+  independent of that high suite default. Mirrors `ExportConcurrency.acquire/3`.
+  """
+  @spec acquire(pos_integer()) :: :ok | {:error, :rate_limited_local}
+  def acquire(max) when is_integer(max) and max > 0 do
+    GenServer.call(__MODULE__, {:acquire, self(), max})
+  end
+
+  @doc """
+  Releases the slot previously reserved by `acquire/0` on the calling process.
+
+  The decrement is performed EXACTLY ONCE per acquisition by the GenServer, gated on
+  the caller still being tracked: a synchronous `call` (not a `cast`) with a
+  `[:flush]` demonitor ensures an in-flight `:DOWN` for the same pid can't ALSO
+  decrement — keeping the shared counter from being decremented twice (which would
+  under-count in-flight embeds and admit MORE than the cap). Idempotent: releasing
+  again (or without a prior successful acquire) is a no-op.
+
+  CRASH-SAFE: if this GenServer is down (so the `call` would `:exit`), `release/0`
+  swallows the exit and returns `:ok` — it is invoked from an `after` block in
+  `run_embedding_task/3`, and a raised `:exit` there would MASK the embedding
+  result. A dead GenServer is itself a restart that resets the counter, so nothing
+  leaks.
+  """
+  @impl Loopctl.Knowledge.EmbeddingConcurrency.Behaviour
+  @spec release() :: :ok
+  def release do
+    GenServer.call(__MODULE__, {:release, self()})
+  catch
+    :exit, _ -> :ok
+  end
+
+  @doc "Current node-wide in-flight embedding count (for tests/telemetry)."
+  @spec count() :: non_neg_integer()
+  def count, do: counter(@global_key)
+
+  @doc """
+  Configured per-node concurrent-embedding cap.
+
+  Live-tunable via the `"embedding_max_concurrent"` `SystemConfig` key (DB-backed,
+  hot-path-safe); on a cache miss it falls back to the `:embedding_max_concurrent`
+  application env (default `#{@default_max}`).
+  """
+  @spec max_concurrent() :: pos_integer()
+  def max_concurrent do
+    SystemConfig.get_int(@config_key, config_default())
+  end
+
+  @doc false
+  def table_name, do: @table
+
+  defp config_default,
+    do: Application.get_env(:loopctl, :embedding_max_concurrent, @default_max)
+
+  # --- Server callbacks ---
+
+  @impl GenServer
+  def init(_opts) do
+    table =
+      case :ets.whereis(@table) do
+        :undefined ->
+          :ets.new(@table, [
+            :set,
+            :public,
+            :named_table,
+            read_concurrency: true,
+            write_concurrency: true
+          ])
+
+        existing ->
+          existing
+      end
+
+    # monitors: ref -> pid ; pids: pid -> ref (so a release can demonitor)
+    {:ok, %{table: table, monitors: %{}, pids: %{}}}
+  end
+
+  @impl GenServer
+  def handle_call({:acquire, pid, max}, _from, state) do
+    # Atomic slot reservation: check the cap AND increment AND register the monitor
+    # in ONE serialized GenServer operation, so a caller crash can never interleave
+    # between the increment and the monitor (no unmonitored leaked slot).
+    case reserve_slot(state.table, max) do
+      :ok -> {:reply, :ok, track(state, pid)}
+      {:error, :rate_limited_local} = err -> {:reply, err, state}
+    end
+  end
+
+  @impl GenServer
+  def handle_call({:release, pid}, _from, state) do
+    # EXACTLY-ONCE decrement, gated on the pid still being tracked. Demonitor with
+    # [:flush] to purge any already-queued :DOWN for this pid so the :DOWN handler
+    # can't ALSO decrement. If the pid is NOT tracked (a :DOWN already reclaimed it,
+    # or a double-release), this is a no-op — the counter is never over-decremented.
+    case Map.get(state.pids, pid) do
+      nil ->
+        {:reply, :ok, state}
+
+      ref ->
+        Process.demonitor(ref, [:flush])
+        decrement()
+        {:reply, :ok, untrack(state, ref, pid)}
+    end
+  end
+
+  @impl GenServer
+  def handle_info({:DOWN, ref, :process, pid, _reason}, state) do
+    # An acquirer crashed without releasing — reclaim its leaked slot so the cap
+    # doesn't drift up permanently. Gated on still being tracked (a concurrent
+    # release/0 may have already demonitored+decremented), so the decrement is
+    # exactly-once with release.
+    case Map.get(state.monitors, ref) do
+      ^pid ->
+        decrement()
+        Logger.warning("embedding concurrency: reclaimed leaked slot for crashed caller")
+        {:noreply, untrack(state, ref, pid)}
+
+      _ ->
+        {:noreply, state}
+    end
+  end
+
+  # --- Private ---
+
+  # Increment the global counter; undo on over-cap. Net: a successful reserve leaves
+  # it incremented, a failed one leaves it unchanged. Called only from the
+  # (serialized) GenServer, so the increment-check-undo is atomic w.r.t. other
+  # acquires.
+  defp reserve_slot(table, max) do
+    now = :ets.update_counter(table, @global_key, {2, 1}, {@global_key, 0})
+
+    if now > max do
+      :ets.update_counter(table, @global_key, {2, -1}, {@global_key, 0})
+      {:error, :rate_limited_local}
+    else
+      :ok
+    end
+  end
+
+  # Register the crash-safe monitor. One in-flight acquire per caller pid:
+  # `run_embedding_task/3` acquires → runs → releases synchronously, so a pid is
+  # never tracked twice concurrently. If a pid is already tracked (should not happen
+  # in practice), we keep the existing monitor rather than adding a second.
+  # `Process.monitor` on an already-dead pid still returns a ref and immediately
+  # delivers `:DOWN`, which the handler reclaims — so there is no leak even if the
+  # caller died before this ran.
+  defp track(state, pid) do
+    case Map.get(state.pids, pid) do
+      nil ->
+        ref = Process.monitor(pid)
+
+        %{
+          state
+          | monitors: Map.put(state.monitors, ref, pid),
+            pids: Map.put(state.pids, pid, ref)
+        }
+
+      _ref ->
+        state
+    end
+  end
+
+  defp untrack(state, ref, pid) do
+    %{state | monitors: Map.delete(state.monitors, ref), pids: Map.delete(state.pids, pid)}
+  end
+
+  # Decrement, clamped at zero. With the exactly-once gating the clamp should never
+  # fire, but it's kept as defense-in-depth so a stray decrement can never drive the
+  # counter negative (which would inflate the effective cap). Called ONLY from the
+  # GenServer process (release/DOWN), so decrements are serialized.
+  defp decrement do
+    :ets.update_counter(@table, @global_key, {2, -1, 0, 0}, {@global_key, 0})
+    :ok
+  end
+
+  defp counter(key) do
+    case :ets.lookup(@table, key) do
+      [{^key, n}] -> n
+      [] -> 0
+    end
+  end
+end

--- a/lib/loopctl/knowledge/embedding_concurrency.ex
+++ b/lib/loopctl/knowledge/embedding_concurrency.ex
@@ -12,8 +12,8 @@ defmodule Loopctl.Knowledge.EmbeddingConcurrency do
   the per-node ceiling REAL: EVERY `generate_embedding` entry point — the interactive
   query path AND both Oban embedding workers
   (`ArticleEmbeddingWorker`/`MemoryEmbeddingWorker`) — funnels through
-  `Loopctl.Knowledge.run_embedding_task/3`, which `acquire/0`s a slot here before
-  spawning its supervised task and `release/0`s it after. Over the cap, `acquire/0`
+  `Loopctl.Knowledge.run_embedding_task/3`, which `acquire/1`s a slot here before
+  spawning its supervised task and `release/1`s it after. Over the cap, `acquire/1`
   fast-fails with `{:error, :rate_limited_local}` (the breaker-exempt reason shared
   with the US-37.1 admission gate): the interactive path degrades to keyword search
   (same fallback as `:circuit_open`), and a background worker snoozes loss-free.
@@ -22,45 +22,65 @@ defmodule Loopctl.Knowledge.EmbeddingConcurrency do
   bucket (RPM); this is a SIMULTANEOUS-in-flight semaphore. Both are node-local
   defensive ceilings against a runaway burst, both fail SAFE.
 
+  ## Two caps enforced atomically (global + per-tenant fairness)
+
+  Mirroring `Loopctl.Knowledge.ExportConcurrency`, TWO independent caps are checked
+  together, so one tenant's burst can't silently starve every other tenant's
+  semantic search (the same isolation posture as the per-tenant embedding circuit
+  breaker — a failing/bursting tenant degrades ITSELF, not its neighbours):
+
+    * a GLOBAL cap (`"embedding_max_concurrent"`, default #{10}) — the TOTAL in-flight
+      outbound embeds across all tenants on this node; and
+    * a PER-TENANT cap (`"embedding_max_concurrent_per_tenant"`, default #{6}) — so a
+      single tenant firing many interactive searches can consume at most its share of
+      the global budget, always leaving slots for other tenants. Over EITHER cap,
+      `acquire/1` refuses with `{:error, :rate_limited_local}` (keyword fallback /
+      worker snooze) — never a 500, never a blocking wait.
+
   ## Cap sizing (env-driven, live-tunable, no deploy)
 
-  A SINGLE GLOBAL per-node counter — the AC requires only a node-wide `N`, not a
-  per-tenant dimension (embedding calls stay tenant-scoped, but the CONCURRENCY
-  ceiling is node-global). The cap is read via
-  `Loopctl.SystemConfig.get_int("embedding_max_concurrent", <default>)`, so an
-  operator can retune it during an incident with no deploy (mirrors the
-  US-37.1 admission RPM knobs). The in-code default (`#{10}`) applies on a
-  SystemConfig cache miss, and the fallback itself is `Application.get_env`-backed
-  so `config/test.exs` can raise a high suite-wide default (stops incidental
-  parallel searches colliding on the shared VM-wide counter — the export-cap
-  precedent).
+  Both caps are read via
+  `Loopctl.SystemConfig.get_int(<key>, <default>)`, so an operator can retune them
+  during an incident with no deploy (mirrors the US-37.1 admission RPM knobs). The
+  in-code defaults apply on a SystemConfig cache miss, and each fallback is itself
+  `Application.get_env`-backed so `config/test.exs` can raise a high suite-wide
+  default (stops incidental parallel searches colliding on the shared VM-wide
+  counters — the export-cap precedent).
 
-  ### Why `#{10}`
+  ### Why global `#{10}` / per-tenant `#{6}`
 
-  Because BOTH the query path and the two workers now acquire the SAME slot, this
+  Because BOTH the query path and the two workers acquire the SAME slot, the global
   cap is the TOTAL node ceiling for outbound embeds. The background `embeddings`
   Oban queue is 5; the interactive path was previously unbounded. `10` keeps
-  interactive + background embedding concurrency bounded together at roughly 2x
-  the background queue — enough headroom that a normal search never waits on a
-  slot, while still shedding a runaway interactive burst well below the provider's
-  hard ceiling. Live-tunable up/down per environment.
+  interactive + background embedding concurrency bounded together at roughly 2x the
+  background queue — enough headroom that a normal search never waits on a slot,
+  while still shedding a runaway interactive burst well below the provider's hard
+  ceiling. The per-tenant `#{6}` is generous enough that a single active tenant on an
+  otherwise-idle node is not unduly throttled, while guaranteeing no single tenant
+  can occupy more than 6 of the 10 slots — so a neighbour always retains capacity.
+  Both live-tunable up/down per environment.
 
   ## Design (mirrors `Loopctl.Knowledge.ExportConcurrency`)
 
-  A single supervised GenServer owns a public, named ETS table holding one
-  in-flight counter; callers mutate it with atomic `:ets.update_counter` (lock-free)
-  so the GenServer is never a throughput bottleneck. The GenServer exists only to
-  OWN the table (so it survives the transient request/worker process that
-  incremented it) and to MONITOR acquirers: an acquirer that crashes WITHOUT
-  calling `release/0` would otherwise leak its slot forever, drifting the effective
-  cap up. `acquire/0` registers the calling process for monitoring; a `:DOWN`
-  reclaims the leaked slot. The slot is charged to the CALLING process (the
-  request/worker running `run_embedding_task/3`, which acquires → runs the task →
-  releases synchronously), NOT to the off-process supervised task.
+  A single supervised GenServer owns a public, named ETS table holding the in-flight
+  counters. WRITES (acquire/release) are SERIALIZED through the GenServer's
+  `handle_call`: this makes each check-cap → increment → register-monitor (and the
+  symmetric demonitor → decrement) ONE atomic step, so a concurrent acquire can never
+  interleave between the increment and the monitor and leak an unmonitored slot. Only
+  the counter READS (`count/0`, `global_count/0`, `tenant_count/1`) bypass the
+  GenServer with a direct, lock-free `:ets.lookup`. At `cap = 10` with network-bound
+  embeds the serialized writes are not a real throughput bottleneck — the GenServer's
+  job is correctness (atomic reservation) and crash-safety (monitoring), not raw
+  write throughput. The GenServer also OWNS the table so it survives the transient
+  request/worker process that incremented it, and MONITORS acquirers: an acquirer that
+  crashes WITHOUT calling `release/1` would otherwise leak its slot forever, drifting
+  the effective cap up; a `:DOWN` reclaims the leaked slot. The slot is charged to the
+  CALLING process (the request/worker running `run_embedding_task/3`, which acquires →
+  runs the task → releases synchronously), NOT to the off-process supervised task.
 
   ## Node-local by design
 
-  One counter per node — distributed coordination is explicitly OUT OF SCOPE
+  One set of counters per node — distributed coordination is explicitly OUT OF SCOPE
   (Epic 38, #353). The effective fleet ceiling is `cap * node_count`.
   """
 
@@ -75,7 +95,9 @@ defmodule Loopctl.Knowledge.EmbeddingConcurrency do
   @table :loopctl_embedding_inflight
   @global_key :__global__
   @config_key "embedding_max_concurrent"
+  @per_tenant_config_key "embedding_max_concurrent_per_tenant"
   @default_max 10
+  @default_per_tenant 6
 
   # --- Client API ---
 
@@ -86,54 +108,74 @@ defmodule Loopctl.Knowledge.EmbeddingConcurrency do
   end
 
   @doc """
-  Tries to reserve one outbound-embedding slot for the CALLING process (monitored
-  for crash-safe release), against the configured cap (`max_concurrent/0`).
+  Tries to reserve one outbound-embedding slot for `tenant_id`, charged to the
+  CALLING process (monitored for crash-safe release), against the configured global
+  (`max_concurrent/0`) AND per-tenant (`max_per_tenant/0`) caps.
 
-  Returns `:ok` when the node-wide in-flight count is below the cap (the counter is
-  incremented atomically) or `{:error, :rate_limited_local}` when the cap is already
-  met (no counter left incremented). Non-blocking — fails fast at the cap. Pair
-  every successful `acquire/0` with a `release/0`.
+  Returns `:ok` when BOTH the node-wide in-flight count and this tenant's in-flight
+  count are below their caps (the counters are incremented atomically) or
+  `{:error, :rate_limited_local}` when EITHER cap is already met (no counter is left
+  incremented). Non-blocking — fails fast at the cap. Pair every successful
+  `acquire/1` with a `release/1`.
   """
   @impl Loopctl.Knowledge.EmbeddingConcurrency.Behaviour
-  @spec acquire() :: :ok | {:error, :rate_limited_local}
-  def acquire, do: acquire(max_concurrent())
-
-  @doc """
-  Like `acquire/0`, but reserves against an EXPLICIT `max` cap instead of the
-  configured one.
-
-  Production always uses `acquire/0` (which reads `max_concurrent/0`). This variant
-  exists for the gate's OWN unit tests: the async suite sets a deliberately HIGH
-  `:embedding_max_concurrent` (see `config/test.exs`) so incidental parallel
-  searches never collide on the shared, VM-wide global counter — so a test that
-  must PROVE the cap refuses over-cap acquires passes its own fixed LOW cap here,
-  independent of that high suite default. Mirrors `ExportConcurrency.acquire/3`.
-  """
-  @spec acquire(pos_integer()) :: :ok | {:error, :rate_limited_local}
-  def acquire(max) when is_integer(max) and max > 0 do
-    GenServer.call(__MODULE__, {:acquire, self(), max})
+  @spec acquire(binary()) :: :ok | {:error, :rate_limited_local}
+  def acquire(tenant_id) when is_binary(tenant_id) do
+    acquire(tenant_id, max_concurrent(), max_per_tenant())
   end
 
   @doc """
-  Releases the slot previously reserved by `acquire/0` on the calling process.
+  Like `acquire/1`, but reserves against EXPLICIT `global_max` / `tenant_max` caps
+  instead of the configured ones.
+
+  Production always uses `acquire/1` (which reads `max_concurrent/0` /
+  `max_per_tenant/0`). This variant exists for the gate's OWN unit tests: the async
+  suite sets deliberately HIGH `:embedding_max_concurrent[_per_tenant]` (see
+  `config/test.exs`) so incidental parallel searches never collide on the shared,
+  VM-wide global counter — so a test that must PROVE the cap refuses over-cap acquires
+  passes its own fixed LOW caps here, independent of those high suite defaults. Mirrors
+  `ExportConcurrency.acquire/3`.
+
+  CRASH-SAFE: if this GenServer is down (so the `call` would `:exit` — e.g. a restart
+  storm during exactly the burst this gate defends against, or app shutdown), the exit
+  is caught and converted to `{:error, :rate_limited_local}`. This is the fail-SAFE
+  direction: an unverifiable cap degrades the interactive path to keyword search (same
+  as any over-cap refusal) rather than raising an unguarded `:exit` that would 500 the
+  request (`run_embedding_task/3` calls `acquire/1` OUTSIDE the supervised task, so no
+  `async_nolink` isolates it — only this guard does). Symmetric with `release/1`, which
+  swallows the same exit.
+  """
+  @spec acquire(binary(), pos_integer(), pos_integer()) ::
+          :ok | {:error, :rate_limited_local}
+  def acquire(tenant_id, global_max, tenant_max)
+      when is_binary(tenant_id) and is_integer(global_max) and global_max > 0 and
+             is_integer(tenant_max) and tenant_max > 0 do
+    GenServer.call(__MODULE__, {:acquire, self(), tenant_id, global_max, tenant_max})
+  catch
+    :exit, _ -> {:error, :rate_limited_local}
+  end
+
+  @doc """
+  Releases the slot previously reserved by `acquire/1` for `tenant_id` on the calling
+  process.
 
   The decrement is performed EXACTLY ONCE per acquisition by the GenServer, gated on
   the caller still being tracked: a synchronous `call` (not a `cast`) with a
   `[:flush]` demonitor ensures an in-flight `:DOWN` for the same pid can't ALSO
-  decrement — keeping the shared counter from being decremented twice (which would
+  decrement — keeping the shared counters from being decremented twice (which would
   under-count in-flight embeds and admit MORE than the cap). Idempotent: releasing
   again (or without a prior successful acquire) is a no-op.
 
-  CRASH-SAFE: if this GenServer is down (so the `call` would `:exit`), `release/0`
+  CRASH-SAFE: if this GenServer is down (so the `call` would `:exit`), `release/1`
   swallows the exit and returns `:ok` — it is invoked from an `after` block in
   `run_embedding_task/3`, and a raised `:exit` there would MASK the embedding
-  result. A dead GenServer is itself a restart that resets the counter, so nothing
+  result. A dead GenServer is itself a restart that resets the counters, so nothing
   leaks.
   """
   @impl Loopctl.Knowledge.EmbeddingConcurrency.Behaviour
-  @spec release() :: :ok
-  def release do
-    GenServer.call(__MODULE__, {:release, self()})
+  @spec release(binary()) :: :ok
+  def release(tenant_id) when is_binary(tenant_id) do
+    GenServer.call(__MODULE__, {:release, self(), tenant_id})
   catch
     :exit, _ -> :ok
   end
@@ -142,8 +184,16 @@ defmodule Loopctl.Knowledge.EmbeddingConcurrency do
   @spec count() :: non_neg_integer()
   def count, do: counter(@global_key)
 
+  @doc "Alias of `count/0` — current global in-flight embedding count."
+  @spec global_count() :: non_neg_integer()
+  def global_count, do: counter(@global_key)
+
+  @doc "Current in-flight embedding count for `tenant_id` (for tests/telemetry)."
+  @spec tenant_count(binary()) :: non_neg_integer()
+  def tenant_count(tenant_id) when is_binary(tenant_id), do: counter(tenant_key(tenant_id))
+
   @doc """
-  Configured per-node concurrent-embedding cap.
+  Configured per-node GLOBAL concurrent-embedding cap.
 
   Live-tunable via the `"embedding_max_concurrent"` `SystemConfig` key (DB-backed,
   hot-path-safe); on a cache miss it falls back to the `:embedding_max_concurrent`
@@ -154,11 +204,26 @@ defmodule Loopctl.Knowledge.EmbeddingConcurrency do
     SystemConfig.get_int(@config_key, config_default())
   end
 
+  @doc """
+  Configured PER-TENANT concurrent-embedding cap.
+
+  Live-tunable via the `"embedding_max_concurrent_per_tenant"` `SystemConfig` key;
+  on a cache miss it falls back to the `:embedding_max_concurrent_per_tenant`
+  application env (default `#{@default_per_tenant}`).
+  """
+  @spec max_per_tenant() :: pos_integer()
+  def max_per_tenant do
+    SystemConfig.get_int(@per_tenant_config_key, per_tenant_default())
+  end
+
   @doc false
   def table_name, do: @table
 
   defp config_default,
     do: Application.get_env(:loopctl, :embedding_max_concurrent, @default_max)
+
+  defp per_tenant_default,
+    do: Application.get_env(:loopctl, :embedding_max_concurrent_per_tenant, @default_per_tenant)
 
   # --- Server callbacks ---
 
@@ -179,34 +244,46 @@ defmodule Loopctl.Knowledge.EmbeddingConcurrency do
           existing
       end
 
-    # monitors: ref -> pid ; pids: pid -> ref (so a release can demonitor)
+    # monitors: ref -> {pid, tenant_id} ; pids: pid -> ref (so a release can demonitor)
     {:ok, %{table: table, monitors: %{}, pids: %{}}}
   end
 
   @impl GenServer
-  def handle_call({:acquire, pid, max}, _from, state) do
-    # Atomic slot reservation: check the cap AND increment AND register the monitor
-    # in ONE serialized GenServer operation, so a caller crash can never interleave
-    # between the increment and the monitor (no unmonitored leaked slot).
-    case reserve_slot(state.table, max) do
-      :ok -> {:reply, :ok, track(state, pid)}
-      {:error, :rate_limited_local} = err -> {:reply, err, state}
+  def handle_call({:acquire, pid, tenant_id, global_max, tenant_max}, _from, state) do
+    # Re-entrant guard (review #5): if this pid is ALREADY tracked it holds a slot,
+    # so a second acquire must NOT increment again — that would over-count the
+    # semaphore and permanently leak a slot on the single release/:DOWN. Currently
+    # unreachable (run_embedding_task/3 acquires → runs → releases synchronously, so
+    # a pid never holds two concurrent slots), but gated here BEFORE reserve_slots so
+    # the counters and the monitor map can never diverge under any future re-entrant
+    # reuse. One in-flight slot per caller pid is the invariant the accounting relies
+    # on.
+    if Map.has_key?(state.pids, pid) do
+      {:reply, :ok, state}
+    else
+      # Atomic slot reservation: check BOTH caps AND increment AND register the
+      # monitor in ONE serialized GenServer operation, so a caller crash can never
+      # interleave between the increment and the monitor (no unmonitored leaked slot).
+      case reserve_slots(state.table, tenant_id, global_max, tenant_max) do
+        :ok -> {:reply, :ok, track(state, pid, tenant_id)}
+        {:error, :rate_limited_local} = err -> {:reply, err, state}
+      end
     end
   end
 
   @impl GenServer
-  def handle_call({:release, pid}, _from, state) do
+  def handle_call({:release, pid, tenant_id}, _from, state) do
     # EXACTLY-ONCE decrement, gated on the pid still being tracked. Demonitor with
     # [:flush] to purge any already-queued :DOWN for this pid so the :DOWN handler
     # can't ALSO decrement. If the pid is NOT tracked (a :DOWN already reclaimed it,
-    # or a double-release), this is a no-op — the counter is never over-decremented.
+    # or a double-release), this is a no-op — the counters are never over-decremented.
     case Map.get(state.pids, pid) do
       nil ->
         {:reply, :ok, state}
 
       ref ->
         Process.demonitor(ref, [:flush])
-        decrement()
+        decrement(tenant_id)
         {:reply, :ok, untrack(state, ref, pid)}
     end
   end
@@ -215,11 +292,11 @@ defmodule Loopctl.Knowledge.EmbeddingConcurrency do
   def handle_info({:DOWN, ref, :process, pid, _reason}, state) do
     # An acquirer crashed without releasing — reclaim its leaked slot so the cap
     # doesn't drift up permanently. Gated on still being tracked (a concurrent
-    # release/0 may have already demonitored+decremented), so the decrement is
+    # release/1 may have already demonitored+decremented), so the decrement is
     # exactly-once with release.
     case Map.get(state.monitors, ref) do
-      ^pid ->
-        decrement()
+      {^pid, tenant_id} ->
+        decrement(tenant_id)
         Logger.warning("embedding concurrency: reclaimed leaked slot for crashed caller")
         {:noreply, untrack(state, ref, pid)}
 
@@ -230,14 +307,27 @@ defmodule Loopctl.Knowledge.EmbeddingConcurrency do
 
   # --- Private ---
 
-  # Increment the global counter; undo on over-cap. Net: a successful reserve leaves
-  # it incremented, a failed one leaves it unchanged. Called only from the
-  # (serialized) GenServer, so the increment-check-undo is atomic w.r.t. other
+  # Increment global then per-tenant; undo on either over-cap. Net: a successful
+  # reserve leaves BOTH incremented, a failed one leaves NEITHER. Called only from
+  # the (serialized) GenServer, so the increment-check-undo is atomic w.r.t. other
   # acquires.
-  defp reserve_slot(table, max) do
-    now = :ets.update_counter(table, @global_key, {2, 1}, {@global_key, 0})
+  defp reserve_slots(table, tenant_id, global_max, tenant_max) do
+    global_now = :ets.update_counter(table, @global_key, {2, 1}, {@global_key, 0})
 
-    if now > max do
+    if global_now > global_max do
+      :ets.update_counter(table, @global_key, {2, -1}, {@global_key, 0})
+      {:error, :rate_limited_local}
+    else
+      reserve_tenant_slot(table, tenant_id, tenant_max)
+    end
+  end
+
+  defp reserve_tenant_slot(table, tenant_id, tenant_max) do
+    key = tenant_key(tenant_id)
+    tenant_now = :ets.update_counter(table, key, {2, 1}, {key, 0})
+
+    if tenant_now > tenant_max do
+      :ets.update_counter(table, key, {2, -1}, {key, 0})
       :ets.update_counter(table, @global_key, {2, -1}, {@global_key, 0})
       {:error, :rate_limited_local}
     else
@@ -247,38 +337,36 @@ defmodule Loopctl.Knowledge.EmbeddingConcurrency do
 
   # Register the crash-safe monitor. One in-flight acquire per caller pid:
   # `run_embedding_task/3` acquires → runs → releases synchronously, so a pid is
-  # never tracked twice concurrently. If a pid is already tracked (should not happen
-  # in practice), we keep the existing monitor rather than adding a second.
-  # `Process.monitor` on an already-dead pid still returns a ref and immediately
-  # delivers `:DOWN`, which the handler reclaims — so there is no leak even if the
-  # caller died before this ran.
-  defp track(state, pid) do
-    case Map.get(state.pids, pid) do
-      nil ->
-        ref = Process.monitor(pid)
+  # never tracked twice concurrently (and the handle_call re-entrant guard rejects a
+  # second acquire before this runs). `Process.monitor` on an already-dead pid still
+  # returns a ref and immediately delivers `:DOWN`, which the handler reclaims — so
+  # there is no leak even if the caller died before this ran.
+  defp track(state, pid, tenant_id) do
+    ref = Process.monitor(pid)
 
-        %{
-          state
-          | monitors: Map.put(state.monitors, ref, pid),
-            pids: Map.put(state.pids, pid, ref)
-        }
-
-      _ref ->
-        state
-    end
+    %{
+      state
+      | monitors: Map.put(state.monitors, ref, {pid, tenant_id}),
+        pids: Map.put(state.pids, pid, ref)
+    }
   end
 
   defp untrack(state, ref, pid) do
     %{state | monitors: Map.delete(state.monitors, ref), pids: Map.delete(state.pids, pid)}
   end
 
-  # Decrement, clamped at zero. With the exactly-once gating the clamp should never
-  # fire, but it's kept as defense-in-depth so a stray decrement can never drive the
-  # counter negative (which would inflate the effective cap). Called ONLY from the
-  # GenServer process (release/DOWN), so decrements are serialized.
-  defp decrement do
-    :ets.update_counter(@table, @global_key, {2, -1, 0, 0}, {@global_key, 0})
+  # Decrement both counters, clamped at zero. With the exactly-once gating the clamp
+  # should never fire, but it's kept as defense-in-depth so a stray decrement can
+  # never drive a counter negative (which would inflate the effective cap). Called
+  # ONLY from the GenServer process (release/DOWN), so decrements are serialized.
+  defp decrement(tenant_id) do
+    dec_floor(@global_key)
+    dec_floor(tenant_key(tenant_id))
     :ok
+  end
+
+  defp dec_floor(key) do
+    :ets.update_counter(@table, key, {2, -1, 0, 0}, {key, 0})
   end
 
   defp counter(key) do
@@ -287,4 +375,6 @@ defmodule Loopctl.Knowledge.EmbeddingConcurrency do
       [] -> 0
     end
   end
+
+  defp tenant_key(tenant_id), do: {:tenant, tenant_id}
 end

--- a/lib/loopctl/knowledge/embedding_concurrency.ex
+++ b/lib/loopctl/knowledge/embedding_concurrency.ex
@@ -272,16 +272,26 @@ defmodule Loopctl.Knowledge.EmbeddingConcurrency do
   end
 
   @impl GenServer
-  def handle_call({:release, pid, tenant_id}, _from, state) do
+  def handle_call({:release, pid, _tenant_id}, _from, state) do
     # EXACTLY-ONCE decrement, gated on the pid still being tracked. Demonitor with
     # [:flush] to purge any already-queued :DOWN for this pid so the :DOWN handler
     # can't ALSO decrement. If the pid is NOT tracked (a :DOWN already reclaimed it,
     # or a double-release), this is a no-op — the counters are never over-decremented.
+    #
+    # The tenant charged is the AUTHORITATIVE tenant_id stored at acquire time
+    # (state.monitors[ref]), NOT the caller-supplied argument — symmetric with the
+    # :DOWN handler, which has no argument to trust. This keeps the accounting robust
+    # even if a caller ever released with a different tenant_id than it acquired: the
+    # acquired tenant's counter would otherwise leak permanently while a different
+    # tenant's counter is floored. The invariant `pids[pid] = ref` ⇒
+    # `monitors[ref] = {pid, tenant_id}` is maintained atomically by track/3 + untrack/3,
+    # so the fetch! never fails.
     case Map.get(state.pids, pid) do
       nil ->
         {:reply, :ok, state}
 
       ref ->
+        {^pid, tenant_id} = Map.fetch!(state.monitors, ref)
         Process.demonitor(ref, [:flush])
         decrement(tenant_id)
         {:reply, :ok, untrack(state, ref, pid)}
@@ -361,12 +371,26 @@ defmodule Loopctl.Knowledge.EmbeddingConcurrency do
   # ONLY from the GenServer process (release/DOWN), so decrements are serialized.
   defp decrement(tenant_id) do
     dec_floor(@global_key)
-    dec_floor(tenant_key(tenant_id))
+    dec_tenant(tenant_key(tenant_id))
     :ok
   end
 
   defp dec_floor(key) do
     :ets.update_counter(@table, key, {2, -1, 0, 0}, {key, 0})
+  end
+
+  # Per-tenant rows are REAPED once they reach zero, so the table doesn't accumulate a
+  # permanent zero-valued row per distinct tenant that ever embedded (unbounded-by-
+  # tenant-count growth otherwise). Safe because EVERY counter mutation
+  # (acquire/release/DOWN) runs in this single serialized GenServer process: no
+  # concurrent acquire can interleave to observe a transiently-absent row, and a fresh
+  # acquire re-creates the row via `update_counter`'s `{key, 0}` default. The global row
+  # is deliberately kept (single, always-present, hot).
+  defp dec_tenant(key) do
+    case :ets.update_counter(@table, key, {2, -1, 0, 0}, {key, 0}) do
+      0 -> :ets.delete(@table, key)
+      _ -> :ok
+    end
   end
 
   defp counter(key) do

--- a/lib/loopctl/knowledge/embedding_concurrency/behaviour.ex
+++ b/lib/loopctl/knowledge/embedding_concurrency/behaviour.ex
@@ -1,0 +1,37 @@
+defmodule Loopctl.Knowledge.EmbeddingConcurrency.Behaviour do
+  @moduledoc """
+  DI seam for the per-node outbound-embedding concurrency gate (US-37.2).
+
+  The interactive query path and both Oban embedding workers funnel through
+  `Loopctl.Knowledge.run_embedding_task/3`, which `acquire/0`s a slot before
+  spawning the supervised embedding task and `release/0`s it afterwards. Resolving
+  the gate through config (`Application.get_env(:loopctl, :embedding_concurrency,
+  Loopctl.Knowledge.EmbeddingConcurrency)`) lets `config/test.exs` swap in
+  `Loopctl.MockEmbeddingConcurrency` so a saturation test can deterministically
+  force the `{:error, :rate_limited_local}` branch (asserting the keyword-only
+  fallback) WITHOUT holding the real, VM-wide global counter saturated and thereby
+  starving unrelated async searches. Production always uses the real GenServer.
+
+  Mirrors the `Loopctl.RateLimiter.Behaviour` DI seam that fronts the sibling
+  US-37.1 admission gate.
+  """
+
+  @doc """
+  Try to reserve one outbound-embedding slot for the CALLING process.
+
+  Returns `:ok` when the node is under its concurrency cap (the slot is charged to
+  the caller and released by `release/0`, or reclaimed if the caller crashes), or
+  `{:error, :rate_limited_local}` when the cap is already met. Non-blocking: it
+  fails fast at the cap rather than queueing, so the interactive path degrades to
+  keyword search instead of blocking.
+  """
+  @callback acquire() :: :ok | {:error, :rate_limited_local}
+
+  @doc """
+  Release the slot previously reserved by `acquire/0` on the calling process.
+
+  Idempotent and crash-safe: releasing without a prior successful acquire (or a
+  second time) is a no-op.
+  """
+  @callback release() :: :ok
+end

--- a/lib/loopctl/knowledge/embedding_concurrency/behaviour.ex
+++ b/lib/loopctl/knowledge/embedding_concurrency/behaviour.ex
@@ -3,9 +3,10 @@ defmodule Loopctl.Knowledge.EmbeddingConcurrency.Behaviour do
   DI seam for the per-node outbound-embedding concurrency gate (US-37.2).
 
   The interactive query path and both Oban embedding workers funnel through
-  `Loopctl.Knowledge.run_embedding_task/3`, which `acquire/0`s a slot before
-  spawning the supervised embedding task and `release/0`s it afterwards. Resolving
-  the gate through config (`Application.get_env(:loopctl, :embedding_concurrency,
+  `Loopctl.Knowledge.run_embedding_task/3`, which `acquire/1`s a slot (for the
+  request's `tenant_id`) before spawning the supervised embedding task and
+  `release/1`s it afterwards. Resolving the gate through config
+  (`Application.get_env(:loopctl, :embedding_concurrency,
   Loopctl.Knowledge.EmbeddingConcurrency)`) lets `config/test.exs` swap in
   `Loopctl.MockEmbeddingConcurrency` so a saturation test can deterministically
   force the `{:error, :rate_limited_local}` branch (asserting the keyword-only
@@ -17,21 +18,24 @@ defmodule Loopctl.Knowledge.EmbeddingConcurrency.Behaviour do
   """
 
   @doc """
-  Try to reserve one outbound-embedding slot for the CALLING process.
+  Try to reserve one outbound-embedding slot for `tenant_id`, charged to the CALLING
+  process.
 
-  Returns `:ok` when the node is under its concurrency cap (the slot is charged to
-  the caller and released by `release/0`, or reclaimed if the caller crashes), or
-  `{:error, :rate_limited_local}` when the cap is already met. Non-blocking: it
+  Returns `:ok` when the node is under BOTH its global concurrency cap AND the
+  tenant's per-tenant sub-cap (the slot is charged to the caller and released by
+  `release/1`, or reclaimed if the caller crashes), or
+  `{:error, :rate_limited_local}` when EITHER cap is already met. Non-blocking: it
   fails fast at the cap rather than queueing, so the interactive path degrades to
   keyword search instead of blocking.
   """
-  @callback acquire() :: :ok | {:error, :rate_limited_local}
+  @callback acquire(tenant_id :: binary()) :: :ok | {:error, :rate_limited_local}
 
   @doc """
-  Release the slot previously reserved by `acquire/0` on the calling process.
+  Release the slot previously reserved by `acquire/1` for `tenant_id` on the calling
+  process.
 
   Idempotent and crash-safe: releasing without a prior successful acquire (or a
   second time) is a no-op.
   """
-  @callback release() :: :ok
+  @callback release(tenant_id :: binary()) :: :ok
 end

--- a/lib/loopctl/knowledge/export_concurrency.ex
+++ b/lib/loopctl/knowledge/export_concurrency.ex
@@ -21,13 +21,19 @@ defmodule Loopctl.Knowledge.ExportConcurrency do
 
   ## Design (mirrors `Loopctl.RateLimiter.Server`)
 
-  A single GenServer owns a public, named ETS table of in-flight counters; callers
-  read/write it directly with `:ets.update_counter` (atomic, lock-free) so the
-  GenServer is never a throughput bottleneck. The GenServer exists only to OWN the
-  table (so it survives the request process that incremented it) and to monitor
-  acquirers: an acquirer that crashes WITHOUT calling `release/1` would otherwise
-  leak its slot forever. `acquire/1` therefore registers the calling process for
-  monitoring; a `:DOWN` decrements the leaked counters.
+  A single GenServer owns a public, named ETS table of in-flight counters. WRITES
+  (acquire/release) are SERIALIZED through the GenServer's `handle_call`, so each
+  check-caps → increment → register-monitor (and the symmetric demonitor → decrement)
+  is ONE atomic step and a concurrent acquire can never interleave between the
+  increment and the monitor (no unmonitored leaked slot). Only the counter READS
+  (`global_count/0`, `tenant_count/1`) bypass the GenServer with a direct, lock-free
+  `:ets.lookup`. At these small caps the serialized writes are not a throughput
+  bottleneck — the GenServer's job is correctness (atomic reservation) and
+  crash-safety, not raw write throughput. It also OWNS the table (so it survives the
+  request process that incremented it) and MONITORS acquirers: an acquirer that
+  crashes WITHOUT calling `release/1` would otherwise leak its slot forever, so
+  `acquire/1` registers the calling process for monitoring and a `:DOWN` decrements
+  the leaked counters.
 
   ## Why not the HeavyRead pool's own queueing
 
@@ -167,14 +173,24 @@ defmodule Loopctl.Knowledge.ExportConcurrency do
 
   @impl true
   def handle_call({:acquire, pid, tenant_id, global_max, tenant_max}, _from, state) do
-    # Atomic slot reservation (#4): check the caps AND increment the counters AND
-    # register the monitor all in ONE serialized GenServer operation, so a caller
-    # crash can never interleave between the increment and the monitor (no
-    # unmonitored leaked slot). `reserve_slots/4` does the increment-check-undo;
-    # `track/3` registers the crash-safe monitor.
-    case reserve_slots(state.table, tenant_id, global_max, tenant_max) do
-      :ok -> {:reply, :ok, track(state, pid, tenant_id)}
-      {:error, :too_many_exports} = err -> {:reply, err, state}
+    # Re-entrant guard: if this pid is ALREADY tracked it holds a slot, so a second
+    # acquire must NOT increment again — that would over-count the semaphore and
+    # permanently leak a slot on the single release/:DOWN. Currently unreachable (one
+    # export per request process, acquired → held → released), but gated BEFORE
+    # reserve_slots so the counters and the monitor map can never diverge under future
+    # re-entrant reuse.
+    if Map.has_key?(state.pids, pid) do
+      {:reply, :ok, state}
+    else
+      # Atomic slot reservation (#4): check the caps AND increment the counters AND
+      # register the monitor all in ONE serialized GenServer operation, so a caller
+      # crash can never interleave between the increment and the monitor (no
+      # unmonitored leaked slot). `reserve_slots/4` does the increment-check-undo;
+      # `track/3` registers the crash-safe monitor.
+      case reserve_slots(state.table, tenant_id, global_max, tenant_max) do
+        :ok -> {:reply, :ok, track(state, pid, tenant_id)}
+        {:error, :too_many_exports} = err -> {:reply, err, state}
+      end
     end
   end
 

--- a/lib/loopctl/knowledge/export_concurrency.ex
+++ b/lib/loopctl/knowledge/export_concurrency.ex
@@ -195,17 +195,25 @@ defmodule Loopctl.Knowledge.ExportConcurrency do
   end
 
   @impl true
-  def handle_call({:release, pid, tenant_id}, _from, state) do
+  def handle_call({:release, pid, _tenant_id}, _from, state) do
     # EXACTLY-ONCE decrement, gated on the pid still being tracked. If it is, this
     # release owns the decrement; we demonitor with [:flush] to purge any already-
     # queued :DOWN for this pid so the :DOWN handler can't ALSO decrement. If the
     # pid is NOT tracked (a :DOWN already reclaimed it, or a double-release), this
     # is a no-op — the global counter is never decremented twice.
+    #
+    # The tenant charged is the AUTHORITATIVE tenant_id stored at acquire time
+    # (state.monitors[ref]), NOT the caller-supplied argument — symmetric with the
+    # :DOWN handler. Robust even if a caller ever released with a different tenant_id
+    # than it acquired: the acquired tenant's counter would otherwise leak while a
+    # different tenant's counter is floored. `pids[pid] = ref` ⇒
+    # `monitors[ref] = {pid, tenant_id}` is maintained atomically, so the fetch! holds.
     case Map.get(state.pids, pid) do
       nil ->
         {:reply, :ok, state}
 
       ref ->
+        {^pid, tenant_id} = Map.fetch!(state.monitors, ref)
         Process.demonitor(ref, [:flush])
         decrement(tenant_id)
         {:reply, :ok, untrack(state, ref, pid)}
@@ -290,13 +298,26 @@ defmodule Loopctl.Knowledge.ExportConcurrency do
   # two decrements are serialized — never a concurrent double-decrement.
   defp decrement(tenant_id) do
     dec_floor(@global_key)
-    dec_floor(tenant_key(tenant_id))
+    dec_tenant(tenant_key(tenant_id))
     :ok
   end
 
   defp dec_floor(key) do
     # update_counter with a threshold/setvalue: if (count - 1) < 0, set to 0.
     :ets.update_counter(@table, key, {2, -1, 0, 0}, {key, 0})
+  end
+
+  # Per-tenant rows are REAPED once they reach zero, so the table doesn't accumulate a
+  # permanent zero-valued row per distinct tenant that ever exported. Safe because EVERY
+  # counter mutation (acquire/release/DOWN) runs in this single serialized GenServer
+  # process, and a fresh acquire re-creates the row via `update_counter`'s `{key, 0}`
+  # default. The global row is deliberately kept (single, always-present). Symmetric
+  # with `Loopctl.Knowledge.EmbeddingConcurrency`.
+  defp dec_tenant(key) do
+    case :ets.update_counter(@table, key, {2, -1, 0, 0}, {key, 0}) do
+      0 -> :ets.delete(@table, key)
+      _ -> :ok
+    end
   end
 
   defp counter(key) do

--- a/test/loopctl/knowledge/embedding_concurrency_down_test.exs
+++ b/test/loopctl/knowledge/embedding_concurrency_down_test.exs
@@ -1,0 +1,54 @@
+defmodule Loopctl.Knowledge.EmbeddingConcurrencyDownTest do
+  @moduledoc """
+  US-37.2 (AC-37.2.3 / AC-37.2.5): the concurrency gate FAILS SAFE when its GenServer
+  is down.
+
+  `run_embedding_task/3` calls `acquire/1` OUTSIDE the supervised embedding task, so
+  no `async_nolink` isolates it — if the `EmbeddingConcurrency` GenServer is down or
+  mid-restart (a restart storm during exactly the burst this gate defends against, or
+  app shutdown), an UNGUARDED `GenServer.call` would raise `:exit` and 500 the
+  interactive search. Both `acquire/3` and `release/1` therefore catch the exit:
+  `acquire` degrades to `{:error, :rate_limited_local}` (→ keyword fallback, never a
+  500), and `release` no-ops with `:ok` (a dead GenServer is itself a counter reset,
+  so nothing leaks).
+
+  This is `async: false` and terminates the SINGLETON app-supervised GenServer via the
+  supervisor (so it is NOT auto-restarted until we restart it), then restores it in an
+  `on_exit` — exclusive execution guarantees no concurrent test observes the gate down.
+  """
+  use ExUnit.Case, async: false
+
+  alias Loopctl.Knowledge.EmbeddingConcurrency, as: EC
+
+  @sup Loopctl.Supervisor
+
+  setup do
+    # Terminate the singleton gate WITHOUT auto-restart; guarantee restoration.
+    :ok = Supervisor.terminate_child(@sup, EC)
+
+    on_exit(fn ->
+      # restart_child returns {:ok, pid} (or {:error, :running} if a prior restore
+      # already brought it back) — either way the gate is up again for later tests.
+      case Supervisor.restart_child(@sup, EC) do
+        {:ok, _pid} -> :ok
+        {:error, :running} -> :ok
+        {:error, {:already_started, _pid}} -> :ok
+      end
+    end)
+
+    :ok
+  end
+
+  test "acquire/1 fails safe to {:error, :rate_limited_local} when the gate is down" do
+    tenant_id = Ecto.UUID.generate()
+    # The registered name is unregistered while the child is terminated, so the
+    # GenServer.call inside acquire/3 exits with :noproc — the catch converts it.
+    assert {:error, :rate_limited_local} = EC.acquire(tenant_id)
+    assert {:error, :rate_limited_local} = EC.acquire(tenant_id, 10, 5)
+  end
+
+  test "release/1 no-ops to :ok when the gate is down" do
+    tenant_id = Ecto.UUID.generate()
+    assert :ok = EC.release(tenant_id)
+  end
+end

--- a/test/loopctl/knowledge/embedding_concurrency_test.exs
+++ b/test/loopctl/knowledge/embedding_concurrency_test.exs
@@ -1,40 +1,48 @@
 defmodule Loopctl.Knowledge.EmbeddingConcurrencyTest do
   @moduledoc """
-  US-37.2 (AC-37.2.1/.4/.5): the per-node outbound-embedding concurrency cap.
+  US-37.2 (AC-37.2.1/.4/.5): the per-node outbound-embedding concurrency cap
+  (GLOBAL + per-tenant sub-cap).
 
   This exercises the REAL `Loopctl.Knowledge.EmbeddingConcurrency` GenServer
   DIRECTLY (bypassing the config-DI seam the search path uses in :test) with its OWN
-  fixed LOW cap via `acquire/1`, INDEPENDENT of the deliberately HIGH
-  `:embedding_max_concurrent` the async suite sets in `config/test.exs`. The GLOBAL
-  in-flight counter is process-global SHARED state (one ETS row for the whole node),
-  so a search-path test could in principle perturb it — but in :test the search path
-  goes through the MOCK gate, not this counter, so nothing else touches it. Even so,
-  the cap assertions use a held-slot process model and assert RELATIVE to the
-  logical low cap, mirroring `ExportConcurrencyTest`.
+  fixed LOW caps via `acquire/3`, INDEPENDENT of the deliberately HIGH
+  `:embedding_max_concurrent[_per_tenant]` the async suite sets in `config/test.exs`.
+  The GLOBAL in-flight counter is process-global SHARED state (one ETS row for the
+  whole node), so a search-path test could in principle perturb it — but in :test the
+  search path goes through the MOCK gate, not this counter, so nothing else touches
+  it. Even so, the cap assertions use a held-slot process model and assert RELATIVE to
+  the logical low caps, mirroring `ExportConcurrencyTest`. Each test uses a UNIQUE
+  tenant id so the per-tenant counter is never shared across tests.
   """
   use ExUnit.Case, async: true
 
   alias Loopctl.Knowledge.EmbeddingConcurrency, as: EC
 
-  # Prove the cap with an explicit LOW cap via `EC.acquire/1`, independent of the
-  # high suite default (`:embedding_max_concurrent`, 64) that stops incidental
-  # parallel searches colliding on the shared global counter. We hold at most
-  # `@cap` (2) shared-global slots — far below 64 — so we never starve any
-  # incidental acquirer that reads the configured cap.
+  # Prove the caps with explicit LOW caps via `EC.acquire/3`, independent of the high
+  # suite defaults (`:embedding_max_concurrent[_per_tenant]`, 64) that stop incidental
+  # parallel searches colliding on the shared global counter. We hold at most `@cap`
+  # (2) shared-global slots — far below 64 — so we never starve any incidental
+  # acquirer that reads the configured caps.
   @cap 2
+  # A per-tenant ceiling that never binds when we're testing the GLOBAL cap.
+  @wide 1_000
 
-  # Acquire against the test's explicit low cap in a kept-alive process and hold the
-  # slot until released. Returns the holder pid.
-  defp hold do
+  setup do
+    %{tenant_id: Ecto.UUID.generate()}
+  end
+
+  # Acquire against explicit low caps in a kept-alive process and hold the slot until
+  # released. Returns the holder pid.
+  defp hold(tenant_id, global_max \\ @cap, tenant_max \\ @wide) do
     parent = self()
 
     pid =
       spawn(fn ->
-        :ok = retry_acquire(500)
+        :ok = retry_acquire(tenant_id, global_max, tenant_max, 500)
         send(parent, {:held, self()})
 
         receive do
-          :release -> EC.release()
+          :release -> EC.release(tenant_id)
         end
       end)
 
@@ -45,51 +53,52 @@ defmodule Loopctl.Knowledge.EmbeddingConcurrencyTest do
     end
   end
 
-  defp retry_acquire(0), do: flunk("could not acquire embedding slot")
+  defp retry_acquire(_tenant_id, _global, _tenant, 0),
+    do: flunk("could not acquire embedding slot")
 
-  defp retry_acquire(attempts) do
-    case EC.acquire(@cap) do
+  defp retry_acquire(tenant_id, global_max, tenant_max, attempts) do
+    case EC.acquire(tenant_id, global_max, tenant_max) do
       :ok ->
         :ok
 
       {:error, :rate_limited_local} ->
         Process.sleep(10)
-        retry_acquire(attempts - 1)
+        retry_acquire(tenant_id, global_max, tenant_max, attempts - 1)
     end
   end
 
   defp release(pid), do: send(pid, :release)
 
-  describe "acquire/1 + release/0" do
-    test "grants up to the cap, then refuses over-cap acquires" do
-      # Saturate the logical cap with `@cap` DIFFERENT held processes, then a fresh
-      # acquirer is refused purely on the cap. The global counter is shared, so we
-      # retry the saturation+refusal invariant until it holds.
-      holders = for _ <- 1..@cap, do: hold()
+  describe "acquire/3 + release/1 (global cap)" do
+    test "grants up to the global cap, then refuses over-cap acquires", %{tenant_id: tenant_id} do
+      # Saturate the logical global cap with `@cap` DIFFERENT held processes, then a
+      # fresh acquirer is refused purely on the cap. The global counter is shared, so
+      # we retry the saturation+refusal invariant until it holds.
+      holders = for _ <- 1..@cap, do: hold(tenant_id)
 
       assert eventually(fn ->
                EC.count() >= @cap and
                  match?(
                    {:error, :rate_limited_local},
-                   from_other_process(fn -> EC.acquire(@cap) end)
+                   from_other_process(fn -> EC.acquire(tenant_id, @cap, @wide) end)
                  )
              end),
-             "cap did not refuse an over-cap acquire within the retry window"
+             "global cap did not refuse an over-cap acquire within the retry window"
 
       Enum.each(holders, &release/1)
     end
 
-    test "release/0 frees the slot so capacity is returned" do
-      # Saturate the cap with `@cap` held processes, then release ONE holder and
-      # prove a fresh acquire can now succeed (the released slot was returned).
-      [first | rest] = for _ <- 1..@cap, do: hold()
+    test "release/1 frees the slot so capacity is returned", %{tenant_id: tenant_id} do
+      # Saturate the cap with `@cap` held processes, then release ONE holder and prove
+      # a fresh acquire can now succeed (the released slot was returned).
+      [first | rest] = for _ <- 1..@cap, do: hold(tenant_id)
 
       # Fully saturated: an extra acquirer is refused.
       assert eventually(fn ->
                EC.count() >= @cap and
                  match?(
                    {:error, :rate_limited_local},
-                   from_other_process(fn -> EC.acquire(@cap) end)
+                   from_other_process(fn -> EC.acquire(tenant_id, @cap, @wide) end)
                  )
              end)
 
@@ -101,8 +110,8 @@ defmodule Loopctl.Knowledge.EmbeddingConcurrencyTest do
                match?(
                  :ok,
                  from_other_process(fn ->
-                   case EC.acquire(@cap) do
-                     :ok -> EC.release()
+                   case EC.acquire(tenant_id, @cap, @wide) do
+                     :ok -> EC.release(tenant_id)
                      other -> other
                    end
                  end)
@@ -113,12 +122,13 @@ defmodule Loopctl.Knowledge.EmbeddingConcurrencyTest do
     end
 
     @tag :capture_log
-    test "a crashed acquirer's slot is reclaimed by the monitor (no permanent leak)" do
+    test "a crashed acquirer's slot is reclaimed by the monitor (no permanent leak)",
+         %{tenant_id: tenant_id} do
       before = EC.count()
 
       {:ok, pid} =
         Task.start(fn ->
-          :ok = retry_acquire(500)
+          :ok = retry_acquire(tenant_id, @cap, @wide, 500)
 
           receive do
             :stop -> :ok
@@ -140,19 +150,20 @@ defmodule Loopctl.Knowledge.EmbeddingConcurrencyTest do
     end
 
     @tag :capture_log
-    test "double release/0 is idempotent (second is a no-op, never drives the counter negative)" do
+    test "double release/1 is idempotent (second is a no-op, never drives the counter negative)",
+         %{tenant_id: tenant_id} do
       parent = self()
 
       pid =
         spawn(fn ->
-          :ok = retry_acquire(500)
+          :ok = retry_acquire(tenant_id, @cap, @wide, 500)
           send(parent, :acquired)
 
           receive do
             :go ->
-              :ok = EC.release()
+              :ok = EC.release(tenant_id)
               # Second release must be a no-op (pid no longer tracked).
-              :ok = EC.release()
+              :ok = EC.release(tenant_id)
               send(parent, :done)
           end
         end)
@@ -169,10 +180,45 @@ defmodule Loopctl.Knowledge.EmbeddingConcurrencyTest do
     end
   end
 
-  describe "max_concurrent/0" do
-    test "returns a positive integer (the configured suite default)" do
-      cap = EC.max_concurrent()
-      assert is_integer(cap) and cap > 0
+  describe "acquire/3 per-tenant sub-cap (fairness)" do
+    test "one tenant at its per-tenant cap does NOT block a different tenant (isolation)" do
+      # Global budget is WIDE (@wide), so ONLY the per-tenant sub-cap can bind here.
+      # Saturate tenant A at a per-tenant cap of 1; A's next acquire is refused, but a
+      # DIFFERENT tenant B still acquires — the sub-cap isolates A's burst from B.
+      tenant_a = Ecto.UUID.generate()
+      tenant_b = Ecto.UUID.generate()
+
+      holder_a = hold(tenant_a, @wide, 1)
+
+      assert eventually(fn ->
+               EC.tenant_count(tenant_a) >= 1 and
+                 match?(
+                   {:error, :rate_limited_local},
+                   from_other_process(fn -> EC.acquire(tenant_a, @wide, 1) end)
+                 )
+             end),
+             "per-tenant cap did not refuse tenant A's over-cap acquire"
+
+      # Tenant B is unaffected by A saturating its own per-tenant share.
+      assert match?(
+               :ok,
+               from_other_process(fn ->
+                 case EC.acquire(tenant_b, @wide, 1) do
+                   :ok -> EC.release(tenant_b)
+                   other -> other
+                 end
+               end)
+             ),
+             "tenant B was wrongly blocked by tenant A's per-tenant saturation"
+
+      release(holder_a)
+    end
+  end
+
+  describe "max_concurrent/0 and max_per_tenant/0" do
+    test "return positive integers (the configured suite defaults)" do
+      assert is_integer(EC.max_concurrent()) and EC.max_concurrent() > 0
+      assert is_integer(EC.max_per_tenant()) and EC.max_per_tenant() > 0
     end
   end
 

--- a/test/loopctl/knowledge/embedding_concurrency_test.exs
+++ b/test/loopctl/knowledge/embedding_concurrency_test.exs
@@ -1,0 +1,218 @@
+defmodule Loopctl.Knowledge.EmbeddingConcurrencyTest do
+  @moduledoc """
+  US-37.2 (AC-37.2.1/.4/.5): the per-node outbound-embedding concurrency cap.
+
+  This exercises the REAL `Loopctl.Knowledge.EmbeddingConcurrency` GenServer
+  DIRECTLY (bypassing the config-DI seam the search path uses in :test) with its OWN
+  fixed LOW cap via `acquire/1`, INDEPENDENT of the deliberately HIGH
+  `:embedding_max_concurrent` the async suite sets in `config/test.exs`. The GLOBAL
+  in-flight counter is process-global SHARED state (one ETS row for the whole node),
+  so a search-path test could in principle perturb it — but in :test the search path
+  goes through the MOCK gate, not this counter, so nothing else touches it. Even so,
+  the cap assertions use a held-slot process model and assert RELATIVE to the
+  logical low cap, mirroring `ExportConcurrencyTest`.
+  """
+  use ExUnit.Case, async: true
+
+  alias Loopctl.Knowledge.EmbeddingConcurrency, as: EC
+
+  # Prove the cap with an explicit LOW cap via `EC.acquire/1`, independent of the
+  # high suite default (`:embedding_max_concurrent`, 64) that stops incidental
+  # parallel searches colliding on the shared global counter. We hold at most
+  # `@cap` (2) shared-global slots — far below 64 — so we never starve any
+  # incidental acquirer that reads the configured cap.
+  @cap 2
+
+  # Acquire against the test's explicit low cap in a kept-alive process and hold the
+  # slot until released. Returns the holder pid.
+  defp hold do
+    parent = self()
+
+    pid =
+      spawn(fn ->
+        :ok = retry_acquire(500)
+        send(parent, {:held, self()})
+
+        receive do
+          :release -> EC.release()
+        end
+      end)
+
+    receive do
+      {:held, ^pid} -> pid
+    after
+      10_000 -> flunk("could not hold an embedding slot (global cap contended too long)")
+    end
+  end
+
+  defp retry_acquire(0), do: flunk("could not acquire embedding slot")
+
+  defp retry_acquire(attempts) do
+    case EC.acquire(@cap) do
+      :ok ->
+        :ok
+
+      {:error, :rate_limited_local} ->
+        Process.sleep(10)
+        retry_acquire(attempts - 1)
+    end
+  end
+
+  defp release(pid), do: send(pid, :release)
+
+  describe "acquire/1 + release/0" do
+    test "grants up to the cap, then refuses over-cap acquires" do
+      # Saturate the logical cap with `@cap` DIFFERENT held processes, then a fresh
+      # acquirer is refused purely on the cap. The global counter is shared, so we
+      # retry the saturation+refusal invariant until it holds.
+      holders = for _ <- 1..@cap, do: hold()
+
+      assert eventually(fn ->
+               EC.count() >= @cap and
+                 match?(
+                   {:error, :rate_limited_local},
+                   from_other_process(fn -> EC.acquire(@cap) end)
+                 )
+             end),
+             "cap did not refuse an over-cap acquire within the retry window"
+
+      Enum.each(holders, &release/1)
+    end
+
+    test "release/0 frees the slot so capacity is returned" do
+      # Saturate the cap with `@cap` held processes, then release ONE holder and
+      # prove a fresh acquire can now succeed (the released slot was returned).
+      [first | rest] = for _ <- 1..@cap, do: hold()
+
+      # Fully saturated: an extra acquirer is refused.
+      assert eventually(fn ->
+               EC.count() >= @cap and
+                 match?(
+                   {:error, :rate_limited_local},
+                   from_other_process(fn -> EC.acquire(@cap) end)
+                 )
+             end)
+
+      # Free one slot.
+      release(first)
+
+      # Capacity returned: a fresh acquire+release now succeeds.
+      assert eventually(fn ->
+               match?(
+                 :ok,
+                 from_other_process(fn ->
+                   case EC.acquire(@cap) do
+                     :ok -> EC.release()
+                     other -> other
+                   end
+                 end)
+               )
+             end)
+
+      Enum.each(rest, &release/1)
+    end
+
+    @tag :capture_log
+    test "a crashed acquirer's slot is reclaimed by the monitor (no permanent leak)" do
+      before = EC.count()
+
+      {:ok, pid} =
+        Task.start(fn ->
+          :ok = retry_acquire(500)
+
+          receive do
+            :stop -> :ok
+          end
+        end)
+
+      # Wait until the acquire is visible (count strictly above the pre-acquire base).
+      wait_until(fn -> EC.count() > before end)
+
+      ref = Process.monitor(pid)
+      Process.exit(pid, :kill)
+      assert_receive {:DOWN, ^ref, :process, ^pid, _}, 1_000
+
+      # The GenServer's monitor must reclaim the leaked slot — the count returns to
+      # (at most) the pre-acquire baseline (relative assertion: other tests do not
+      # touch this counter, but be robust anyway).
+      assert eventually(fn -> EC.count() <= before end),
+             "crashed acquirer's slot was not reclaimed (permanent leak)"
+    end
+
+    @tag :capture_log
+    test "double release/0 is idempotent (second is a no-op, never drives the counter negative)" do
+      parent = self()
+
+      pid =
+        spawn(fn ->
+          :ok = retry_acquire(500)
+          send(parent, :acquired)
+
+          receive do
+            :go ->
+              :ok = EC.release()
+              # Second release must be a no-op (pid no longer tracked).
+              :ok = EC.release()
+              send(parent, :done)
+          end
+        end)
+
+      assert_receive :acquired, 2_000
+      before_go = EC.count()
+      send(pid, :go)
+      assert_receive :done, 2_000
+      _ = :sys.get_state(EC)
+
+      # The double-release freed EXACTLY the one held slot: the counter dropped by at
+      # most one (never two), and the clamp guarantees it never goes negative.
+      assert eventually(fn -> EC.count() >= 0 and EC.count() <= before_go end)
+    end
+  end
+
+  describe "max_concurrent/0" do
+    test "returns a positive integer (the configured suite default)" do
+      cap = EC.max_concurrent()
+      assert is_integer(cap) and cap > 0
+    end
+  end
+
+  # --- helpers ---
+
+  # Run `fun` in a short-lived separate process and return its result. Used so an
+  # acquire is charged to a DIFFERENT process than the caller (the per-process
+  # monitor treats two acquires from one pid as one).
+  defp from_other_process(fun) do
+    parent = self()
+    spawn(fn -> send(parent, {:result, fun.()}) end)
+
+    receive do
+      {:result, r} -> r
+    after
+      1_000 -> flunk("from_other_process timed out")
+    end
+  end
+
+  defp wait_until(fun, attempts \\ 100)
+  defp wait_until(_fun, 0), do: :ok
+
+  defp wait_until(fun, attempts) do
+    if fun.() do
+      :ok
+    else
+      Process.sleep(10)
+      wait_until(fun, attempts - 1)
+    end
+  end
+
+  defp eventually(fun, attempts \\ 200)
+  defp eventually(_fun, 0), do: false
+
+  defp eventually(fun, attempts) do
+    if fun.() do
+      true
+    else
+      Process.sleep(10)
+      eventually(fun, attempts - 1)
+    end
+  end
+end

--- a/test/loopctl/knowledge_semantic_search_test.exs
+++ b/test/loopctl/knowledge_semantic_search_test.exs
@@ -4,6 +4,7 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
   setup :verify_on_exit!
 
   alias Loopctl.Knowledge
+  alias Loopctl.Knowledge.EmbeddingConcurrency
 
   # Embedding dimensions configured as 1536.
   # We use small deterministic vectors for predictable cosine distances.
@@ -440,7 +441,7 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
       })
 
       # Saturate the gate: every acquire is refused.
-      Mox.stub(Loopctl.MockEmbeddingConcurrency, :acquire, fn ->
+      Mox.stub(Loopctl.MockEmbeddingConcurrency, :acquire, fn _tenant_id ->
         {:error, :rate_limited_local}
       end)
 
@@ -545,6 +546,56 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
       assert meta.search_mode == "combined"
       refute Map.get(meta, :fallback)
       assert Enum.any?(results, &(&1.id == both_match.id))
+    end
+
+    # AC-37.2.2 wiring: prove search_combined -> run_embedding_task actually routes
+    # through the REAL Loopctl.Knowledge.EmbeddingConcurrency GenServer's counter, not
+    # just the permissive DI mock. Every OTHER search test resolves the gate to the
+    # mock, so a production wiring regression (run_embedding_task not calling acquire,
+    # threading the wrong tenant, or the real gate mishandling the search path) could
+    # pass unseen. Here the DI mock DELEGATES to the real gate — Mox.expect verifies
+    # acquire/1 + release/1 each fire exactly once with the request's tenant — and we
+    # assert the real PER-TENANT counter round-trips back to 0. The tenant is unique
+    # (fixture), so the per-tenant counter never collides with any other test.
+    test "search_combined routes through the REAL concurrency gate (acquire+release wired)" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      both_match =
+        create_article_with_embedding(
+          tenant.id,
+          %{title: "Error Handling Patterns", body: "Try rescue patterns for error handling."},
+          :close
+        )
+
+      # Delegate the DI mock to the REAL gate for THIS tenant and verify each callback
+      # fires exactly once with the right tenant. acquire/release run in the test
+      # process (before/after the async_nolink task), so no $callers allowance is needed.
+      Mox.expect(Loopctl.MockEmbeddingConcurrency, :acquire, fn tid ->
+        assert tid == tenant.id
+        EmbeddingConcurrency.acquire(tid)
+      end)
+
+      Mox.expect(Loopctl.MockEmbeddingConcurrency, :release, fn tid ->
+        assert tid == tenant.id
+        EmbeddingConcurrency.release(tid)
+      end)
+
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:ok, make_embedding(:query)}
+      end)
+
+      assert {:ok, %{results: results, meta: meta}} =
+               Knowledge.search_combined(tenant.id, "error")
+
+      # Happy path preserved through the REAL gate...
+      assert meta.search_mode == "combined"
+      refute Map.get(meta, :fallback)
+      assert Enum.any?(results, &(&1.id == both_match.id))
+
+      # ...and the real gate's per-tenant slot was acquired AND released (the round-trip
+      # is wired end-to-end): the counter is back to 0 for this tenant.
+      assert EmbeddingConcurrency.tenant_count(tenant.id) == 0
     end
   end
 

--- a/test/loopctl/knowledge_semantic_search_test.exs
+++ b/test/loopctl/knowledge_semantic_search_test.exs
@@ -415,6 +415,139 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
     end
   end
 
+  # --- US-37.2: per-node embedding concurrency cap gates the interactive path ---
+  #
+  # The cap is enforced inside `run_embedding_task/3` (the single guarded entry
+  # point). In :test the gate is the config-DI mock (`Loopctl.MockEmbeddingConcurrency`,
+  # default-stubbed to grant every slot) so we can force saturation deterministically
+  # WITHOUT holding the real, VM-wide global counter saturated (which would starve
+  # unrelated async searches). The real GenServer's cap/reclaim behavior is unit-tested
+  # in `Loopctl.Knowledge.EmbeddingConcurrencyTest`.
+  describe "search_combined/3 - per-node embedding concurrency cap (US-37.2)" do
+    # TC-37.2.2 / AC-37.2.3: at the cap, the interactive path degrades to keyword
+    # search (same fallback as :circuit_open / :rate_limited_local) — never a 500,
+    # never an unbounded wait. AC-37.2.2: the acquire gates the query path, so the
+    # embedding CLIENT is never reached when the cap is saturated.
+    test "saturated cap → keyword-only fallback (never a 500), client never called" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Testing Guide",
+        body: "Unit test patterns for testing Elixir applications.",
+        status: :published
+      })
+
+      # Saturate the gate: every acquire is refused.
+      Mox.stub(Loopctl.MockEmbeddingConcurrency, :acquire, fn ->
+        {:error, :rate_limited_local}
+      end)
+
+      # The interactive path never reaches the paid client when the cap is full
+      # (acquire fails first) — proving the query path is genuinely gated (AC-37.2.2).
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, 0, fn _tenant_id, _text ->
+        {:ok, make_embedding(:query)}
+      end)
+
+      assert {:ok, %{results: results, meta: meta}} =
+               Knowledge.search_combined(tenant.id, "testing")
+
+      assert meta.fallback == true
+      assert meta.search_mode == "keyword_only"
+      # Reuses the US-37.1 breaker-exempt reason → the existing stable fallback tag.
+      assert meta.fallback_reason == "embedding_rate_limited_local"
+
+      # Keyword search still returns results — the request survived and degraded.
+      assert results != []
+      assert Enum.any?(results, &(&1.title == "Testing Guide"))
+    end
+
+    # TC-37.2.3 / AC-37.2.5: an embedding task crash is isolated — the request
+    # process survives and returns a keyword fallback, not a caller crash. The inner
+    # rescue turns the raise into {:error, {:embedding_crash, ...}}.
+    @tag :capture_log
+    test "embedding task raise is isolated → request survives with keyword fallback" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Testing Guide",
+        body: "Unit test patterns for testing Elixir applications.",
+        status: :published
+      })
+
+      # Under the cap (default :ok), but the embedding client raises inside the
+      # supervised task. `Mox.stub` (not expect) because the call runs OFF the test
+      # process in the async_nolink task.
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        raise "boom"
+      end)
+
+      assert {:ok, %{results: results, meta: meta}} =
+               Knowledge.search_combined(tenant.id, "testing")
+
+      assert meta.fallback == true
+      assert meta.search_mode == "keyword_only"
+      assert meta.fallback_reason == "embedding_crash"
+      assert Enum.any?(results, &(&1.title == "Testing Guide"))
+    end
+
+    # AC-37.2.5: an embedding task EXIT (which the inner rescue cannot catch) is
+    # isolated by Task.Supervisor.async_nolink — it surfaces as a yield {:exit, _}
+    # → {:error, :timeout}, NOT a crash of the request process.
+    @tag :capture_log
+    test "embedding task exit is isolated by async_nolink → request survives" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Testing Guide",
+        body: "Unit test patterns for testing Elixir applications.",
+        status: :published
+      })
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        exit(:boom)
+      end)
+
+      assert {:ok, %{results: results, meta: meta}} =
+               Knowledge.search_combined(tenant.id, "testing")
+
+      assert meta.fallback == true
+      assert meta.search_mode == "keyword_only"
+      assert meta.fallback_reason == "embedding_timeout"
+      assert Enum.any?(results, &(&1.title == "Testing Guide"))
+    end
+
+    # TC-37.2.4 / AC-37.2.5: happy path under the cap is UNCHANGED — a normal search
+    # still returns merged semantic results (no fallback), adding only slot-acquire.
+    test "under the cap, a combined search returns semantic results as today" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      both_match =
+        create_article_with_embedding(
+          tenant.id,
+          %{title: "Error Handling Patterns", body: "Try rescue patterns for error handling."},
+          :close
+        )
+
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        make_embedding(:query) |> then(&{:ok, &1})
+      end)
+
+      assert {:ok, %{results: results, meta: meta}} =
+               Knowledge.search_combined(tenant.id, "error")
+
+      assert meta.search_mode == "combined"
+      refute Map.get(meta, :fallback)
+      assert Enum.any?(results, &(&1.id == both_match.id))
+    end
+  end
+
   # --- #297: fallback_reason + telemetry observability for the silent semantic→
   # keyword degradation. Each fallback CAUSE must map to the right stable tag,
   # NEVER leak the api key / provider body, fire the telemetry event, and the

--- a/test/loopctl/workers/article_embedding_worker_test.exs
+++ b/test/loopctl/workers/article_embedding_worker_test.exs
@@ -153,7 +153,7 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorkerTest do
       # {:error, :rate_limited_local} BEFORE the paid embedding client is ever
       # reached. Asserting the client is NOT called (0 expectations) proves the cap
       # really gates the worker path, not just the query path (AC-37.2.2).
-      Mox.stub(Loopctl.MockEmbeddingConcurrency, :acquire, fn ->
+      Mox.stub(Loopctl.MockEmbeddingConcurrency, :acquire, fn _tenant_id ->
         {:error, :rate_limited_local}
       end)
 

--- a/test/loopctl/workers/article_embedding_worker_test.exs
+++ b/test/loopctl/workers/article_embedding_worker_test.exs
@@ -131,6 +131,45 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorkerTest do
       assert {:snooze, seconds} = result
       assert is_integer(seconds) and seconds > 0
     end
+
+    test "US-37.2 (AC-37.2.2): the SAME per-node concurrency cap gates the worker (snooze, client never called)" do
+      %{tenant: tenant} = setup_tenant()
+
+      {:ok, article} =
+        Knowledge.create_article(tenant.id, %{
+          title: "Concurrency Capped Article",
+          body: "Will be shed by the per-node embedding concurrency cap.",
+          category: :pattern,
+          status: :draft
+        })
+
+      article =
+        %{article | status: :published}
+        |> Ecto.Changeset.change(%{status: :published})
+        |> Loopctl.AdminRepo.update!()
+
+      # The concurrency gate (SAME one the interactive path uses) is saturated: the
+      # worker's generate_embedding -> run_embedding_task -> acquire returns
+      # {:error, :rate_limited_local} BEFORE the paid embedding client is ever
+      # reached. Asserting the client is NOT called (0 expectations) proves the cap
+      # really gates the worker path, not just the query path (AC-37.2.2).
+      Mox.stub(Loopctl.MockEmbeddingConcurrency, :acquire, fn ->
+        {:error, :rate_limited_local}
+      end)
+
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, 0, fn _tenant_id, _text ->
+        {:ok, List.duplicate(0.1, 1536)}
+      end)
+
+      result =
+        ArticleEmbeddingWorker.perform(%Oban.Job{
+          args: %{"article_id" => article.id, "tenant_id" => tenant.id}
+        })
+
+      # Loss-free backpressure: snooze (no attempt consumed), NEVER a discard.
+      assert {:snooze, seconds} = result
+      assert is_integer(seconds) and seconds > 0
+    end
   end
 
   # --- TC-20.3.3: Worker handles deleted article (returns :ok) ---

--- a/test/loopctl/workers/memory_embedding_worker_test.exs
+++ b/test/loopctl/workers/memory_embedding_worker_test.exs
@@ -180,5 +180,31 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorkerTest do
       assert {:snooze, seconds} = MemoryEmbeddingWorker.perform(job(memory.id, tenant.id))
       assert is_integer(seconds) and seconds > 0
     end
+
+    test "US-37.2 (AC-37.2.2): the SAME per-node concurrency cap gates the worker (snooze, client never called)" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      memory =
+        fixture(:memory, %{tenant_id: tenant.id, subject_id: "s", text: "concurrency capped"})
+
+      # The concurrency gate (SAME one the interactive path AND ArticleEmbeddingWorker
+      # use) is saturated: this worker's generate_embedding -> run_embedding_task ->
+      # acquire returns {:error, :rate_limited_local} BEFORE the paid embedding client
+      # is ever reached. Asserting the client is NOT called (0 expectations) proves the
+      # cap really gates the memory-worker path too, not just the query path — closing
+      # AC-37.2.2's "both workers" coverage (mirrors the ArticleEmbeddingWorker test).
+      Mox.stub(Loopctl.MockEmbeddingConcurrency, :acquire, fn _tenant_id ->
+        {:error, :rate_limited_local}
+      end)
+
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, 0, fn _t, _text ->
+        {:ok, List.duplicate(0.1, 1536)}
+      end)
+
+      # Loss-free backpressure: snooze (no attempt consumed), NEVER a discard.
+      assert {:snooze, seconds} = MemoryEmbeddingWorker.perform(job(memory.id, tenant.id))
+      assert is_integer(seconds) and seconds > 0
+    end
   end
 end

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -138,11 +138,11 @@ defmodule Loopctl.DataCase do
     end)
 
     # US-37.2: permissive default for the per-node embedding concurrency gate --
-    # acquire/0 always grants a slot, release/0 is a no-op -- so every existing
+    # acquire/1 always grants a slot, release/1 is a no-op -- so every existing
     # embedding/search test runs under the cap unchanged. The saturation test
-    # overrides acquire/0 to return {:error, :rate_limited_local}.
-    Mox.stub(Loopctl.MockEmbeddingConcurrency, :acquire, fn -> :ok end)
-    Mox.stub(Loopctl.MockEmbeddingConcurrency, :release, fn -> :ok end)
+    # overrides acquire/1 to return {:error, :rate_limited_local}.
+    Mox.stub(Loopctl.MockEmbeddingConcurrency, :acquire, fn _tenant_id -> :ok end)
+    Mox.stub(Loopctl.MockEmbeddingConcurrency, :release, fn _tenant_id -> :ok end)
 
     # Default stub for knowledge extractor -- returns empty list (no articles).
     # tenant_id is threaded first (Epic 28 BYO, review #1).

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -137,6 +137,13 @@ defmodule Loopctl.DataCase do
       {:ok, List.duplicate(0.1, 1536)}
     end)
 
+    # US-37.2: permissive default for the per-node embedding concurrency gate --
+    # acquire/0 always grants a slot, release/0 is a no-op -- so every existing
+    # embedding/search test runs under the cap unchanged. The saturation test
+    # overrides acquire/0 to return {:error, :rate_limited_local}.
+    Mox.stub(Loopctl.MockEmbeddingConcurrency, :acquire, fn -> :ok end)
+    Mox.stub(Loopctl.MockEmbeddingConcurrency, :release, fn -> :ok end)
+
     # Default stub for knowledge extractor -- returns empty list (no articles).
     # tenant_id is threaded first (Epic 28 BYO, review #1).
     Mox.stub(Loopctl.MockExtractor, :extract_articles, fn _tenant_id, _ctx ->

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -4,6 +4,18 @@ Mox.defmock(Loopctl.MockClock, for: Loopctl.Clock.Behaviour)
 Mox.defmock(Loopctl.MockCostRollup, for: Loopctl.TokenUsage.RollupBehaviour)
 Mox.defmock(Loopctl.MockTokenArchival, for: Loopctl.TokenUsage.ArchivalBehaviour)
 Mox.defmock(Loopctl.MockEmbeddingClient, for: Loopctl.Knowledge.EmbeddingBehaviour)
+
+# US-37.2: DI seam for the per-node outbound-embedding concurrency gate. The
+# DataCase default stub returns :ok/:ok (permissive) so every existing search test
+# is unaffected; the saturation test overrides acquire/0 with Mox.stub/3 to return
+# {:error, :rate_limited_local}, deterministically driving the interactive
+# keyword-only fallback WITHOUT holding the real, VM-wide global counter saturated
+# (which would starve unrelated async searches). Production uses the real
+# Loopctl.Knowledge.EmbeddingConcurrency GenServer, unit-tested directly.
+Mox.defmock(Loopctl.MockEmbeddingConcurrency,
+  for: Loopctl.Knowledge.EmbeddingConcurrency.Behaviour
+)
+
 Mox.defmock(Loopctl.MockExtractor, for: Loopctl.Knowledge.ExtractorBehaviour)
 Mox.defmock(Loopctl.MockContentExtractor, for: Loopctl.Knowledge.ContentExtractorBehaviour)
 Mox.defmock(Loopctl.MockPromoterLLM, for: Loopctl.Memory.Promoter.LLMBehaviour)


### PR DESCRIPTION
## US-37.2 — Bound the interactive embedding path with a supervised, per-node concurrency cap

Closes #352 (partial — the interactive-concurrency leg)

### Problem
The default combined knowledge search embedded the query SYNCHRONOUSLY in the web/MCP request process under a bare, un-pooled, un-capped Task.async (knowledge.ex), so a traffic spike spawned UNBOUNDED concurrent outbound embedding calls. The Oban embeddings:5 queue cap only bounds background embeds, so the per-node ceiling was illusory for interactive traffic — feeding the provider 429 storm (GH #352).

### What changed
- New Loopctl.Knowledge.EmbeddingConcurrency — a supervised GenServer owning a public, named ETS counter that caps concurrent outbound embeds per node. Atomic :ets.update_counter acquire/release (lock-free, not a bottleneck), crash-safe via Process.monitor + :DOWN reclaim. Mirrors the proven ExportConcurrency pattern; single global counter (node-wide N).
- run_embedding_task/3 now acquires a slot BEFORE spawning the task and releases it in an after. Because this is the single guarded generate_embedding entry point, the interactive path AND both Oban embedding workers share one real node ceiling (AC-37.2.2) with zero worker changes.
- The bare Task.async is replaced with Task.Supervisor.async_nolink under a dedicated Loopctl.Knowledge.EmbeddingTaskSupervisor, preserving the ~5s yield budget and isolating a task crash from the caller (AC-37.2.5).
- Over the cap, acquire fast-fails with the breaker-exempt :rate_limited_local reason (reused from US-37.1): the interactive path degrades to keyword search (never a 500, never an unbounded wait — AC-37.2.3), workers snooze loss-free.
- Cap is live-tunable via SystemConfig (embedding_max_concurrent, default 10 — ~2x the background embeddings queue). Node-local by design (distributed coordination is Epic 38).
- Config-DI seam (:embedding_concurrency) lets tests force saturation deterministically without holding the real VM-wide counter saturated (which would starve unrelated async searches). Production always uses the real GenServer.

### Tests
- embedding_concurrency_test.exs (unit): cap bounds concurrency via explicit-cap arity, release returns capacity, crashed-acquirer slot reclaimed, idempotent double-release (TC-37.2.1, AC-37.2.5).
- knowledge_semantic_search_test.exs (integration): saturation to keyword-only fallback with client never called (TC-37.2.2, AC-37.2.2/.3); embedding-task raise and exit both isolated so the request survives (TC-37.2.3, AC-37.2.5); happy path under the cap returns semantic results unchanged (TC-37.2.4).
- article_embedding_worker_test.exs: the SAME cap gates the worker (snooze, client never reached — AC-37.2.2).
- Assertions are on outcome class (fell-back / semantic / survived), not instantaneous concurrency.

### Quality gate
mix precommit green: compile clean (warnings-as-errors), format, credo --strict, dialyzer passed, 4554 tests, 0 failures.
