### PR TITLE
Batch background embeddings into arrays (~100), map results back by index

### DIFF
--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -60,7 +60,7 @@ defmodule Loopctl.Knowledge do
   alias Loopctl.Llm.ProviderError
   alias Loopctl.Projects.Project
   alias Loopctl.Webhooks.EventGenerator
-  alias Loopctl.Workers.ArticleEmbeddingWorker
+  alias Loopctl.Workers.BatchEmbeddingWorker
 
   # Maximum page size for the article list endpoint (`list_articles/2`). Larger
   # limits are HONORED up to this cap so callers can paginate to exhaustion at
@@ -792,6 +792,37 @@ defmodule Loopctl.Knowledge do
       nil -> {:error, :not_found}
       article -> {:ok, article}
     end
+  end
+
+  @doc """
+  US-37.4: lists up to `limit` PUBLISHED articles for `tenant_id` that still need
+  an embedding — those with `embedding IS NULL`. A brand-new published article
+  starts NULL; a content change re-nulls the vector at the enqueue site (see
+  `maybe_enqueue_embedding/3`) so the article re-enters this pending set and the
+  batch drainer re-embeds it.
+
+  `embedding IS NULL` (NOT `embedding_content_hash IS NULL`) is the deliberate
+  signal: `update_embedding/3` legitimately sets a vector with a nil hash, so a
+  hash-based predicate would loop-re-embed those rows forever.
+
+  Returns lightweight `%{id, title, body}` rows (tenant-scoped by the explicit
+  predicate — AC-37.4.4 isolation) for `Loopctl.Workers.BatchEmbeddingWorker` to
+  batch into one array call. Uses `AdminRepo` like the other embedding-worker
+  readers; the WHERE `tenant_id` keeps a batch to exactly one tenant's texts.
+  """
+  @spec list_articles_pending_embedding(Ecto.UUID.t(), pos_integer()) :: [
+          %{id: Ecto.UUID.t(), title: String.t(), body: String.t()}
+        ]
+  def list_articles_pending_embedding(tenant_id, limit)
+      when is_binary(tenant_id) and is_integer(limit) and limit > 0 do
+    from(a in Article,
+      where: a.tenant_id == ^tenant_id and a.status == :published,
+      where: is_nil(a.embedding),
+      order_by: [asc: a.updated_at, asc: a.id],
+      limit: ^limit,
+      select: %{id: a.id, title: a.title, body: a.body}
+    )
+    |> AdminRepo.all()
   end
 
   @doc """
@@ -3420,12 +3451,13 @@ defmodule Loopctl.Knowledge do
   # chunk.
   defp enqueue_bulk_embeddings(_tenant_id, []), do: :ok
 
-  defp enqueue_bulk_embeddings(tenant_id, published) do
-    Enum.each(published, fn article ->
-      %{article_id: article.id, tenant_id: tenant_id}
-      |> ArticleEmbeddingWorker.new()
-      |> Oban.insert()
-    end)
+  defp enqueue_bulk_embeddings(tenant_id, _published) do
+    # US-37.4: the just-published rows all have embedding=NULL, so a single
+    # per-tenant batch worker drains them in array batches — no per-row fan-out.
+    BatchEmbeddingWorker.new(%{tenant_id: tenant_id, kind: "article"})
+    |> Oban.insert()
+
+    :ok
   rescue
     e ->
       Logger.error("bulk_publish: embedding enqueue failed: #{Exception.message(e)}")
@@ -7370,6 +7402,92 @@ defmodule Loopctl.Knowledge do
     end
   end
 
+  @doc """
+  US-37.4: guarded BATCH embedding entry — the plural sibling of
+  `generate_embedding/3`. Embeds a LIST of texts in ONE provider array call and
+  returns the vectors in input order (`{:ok, [vector]}`), or `{:error, reason}`
+  for the WHOLE batch (atomicity: the caller writes nothing on error).
+
+  Routes through the SAME guard as the single-text path so background batching
+  never bypasses the breaker or the concurrency ceiling:
+
+    * per-tenant circuit breaker (fast `{:error, :circuit_open}` when tripped);
+    * ONE US-37.2 per-node concurrency slot for the whole batch (not one per text);
+    * the `[:loopctl, :llm, :provider_error]` telemetry signal recorded ONCE for
+      the batch via the same `breaker_countable?/1` gate.
+
+  An empty list short-circuits to `{:ok, []}` (no slot, no breaker, no call). The
+  interactive single-text callers are UNCHANGED — this is a background-only path.
+
+  `opts`:
+    * `:timeout` — Task.yield budget in ms (default `#{@embedding_yield_ms}`).
+  """
+  @spec generate_embeddings(Ecto.UUID.t(), [String.t()], keyword()) ::
+          {:ok, [[float()]]} | {:error, term()}
+  def generate_embeddings(tenant_id, texts, opts \\ [])
+      when is_binary(tenant_id) and is_list(texts) do
+    try_generate_embeddings(tenant_id, texts, opts)
+  end
+
+  defp try_generate_embeddings(_tenant_id, [], _opts), do: {:ok, []}
+
+  defp try_generate_embeddings(tenant_id, texts, opts) do
+    ensure_circuit_breaker_table()
+
+    if circuit_open?(tenant_id) do
+      {:error, :circuit_open}
+    else
+      timeout = Keyword.get(opts, :timeout, @embedding_yield_ms)
+      run_embedding_batch_task(tenant_id, texts, timeout)
+    end
+  end
+
+  # Mirrors run_embedding_task/3: acquire ONE concurrency slot for the whole array
+  # call (AC-37.4.4), release in `after` so a yield-timeout or in-task crash frees it.
+  defp run_embedding_batch_task(tenant_id, texts, timeout) do
+    case embedding_concurrency().acquire(tenant_id) do
+      :ok ->
+        try do
+          run_capped_embedding_batch_task(tenant_id, texts, timeout)
+        after
+          embedding_concurrency().release(tenant_id)
+        end
+
+      {:error, :rate_limited_local} = err ->
+        err
+    end
+  end
+
+  defp run_capped_embedding_batch_task(tenant_id, texts, timeout) do
+    task =
+      Task.Supervisor.async_nolink(Loopctl.Knowledge.EmbeddingTaskSupervisor, fn ->
+        try do
+          embedding_client().generate_embeddings(tenant_id, texts)
+        rescue
+          e -> {:error, {:embedding_crash, Exception.message(e)}}
+        end
+      end)
+
+    case Task.yield(task, timeout) || Task.shutdown(task) do
+      {:ok, {:ok, embeddings}} ->
+        record_success(tenant_id)
+        {:ok, embeddings}
+
+      {:ok, {:error, :no_api_key}} ->
+        {:error, :no_api_key}
+
+      {:ok, {:error, reason} = err} ->
+        maybe_record_failure(tenant_id, reason)
+        maybe_record_provider_error(reason)
+        err
+
+      _ ->
+        record_failure(tenant_id)
+        maybe_record_provider_error(:timeout)
+        {:error, :timeout}
+    end
+  end
+
   # US-37.2: gate EVERY outbound embedding on a per-node concurrency cap BEFORE
   # spawning the task, so the interactive query path AND both Oban embedding workers
   # (which route through here via generate_embedding/3) share ONE real node ceiling
@@ -7601,9 +7719,20 @@ defmodule Loopctl.Knowledge do
   defp maybe_enqueue_embedding(multi, _tenant_id, false), do: multi
 
   defp maybe_enqueue_embedding(multi, tenant_id, true) do
-    Multi.run(multi, :embedding_job, fn _repo, %{article: article} ->
+    Multi.run(multi, :embedding_job, fn repo, %{article: article} ->
       if article.status == :published do
-        ArticleEmbeddingWorker.new(%{article_id: article.id, tenant_id: tenant_id})
+        # US-37.4: re-null an ALREADY-embedded article's vector (+hash) after a
+        # content change so it re-enters the `embedding IS NULL` pending set and the
+        # per-tenant batch drainer re-embeds it. A brand-new article already has
+        # embedding=NULL, so restrict the update to embedded rows. Then enqueue ONE
+        # per-tenant batch worker (unique per tenant+kind) instead of a per-article
+        # job, so many near-simultaneous writes coalesce into a single array call.
+        repo.update_all(
+          from(a in Article, where: a.id == ^article.id and not is_nil(a.embedding)),
+          set: [embedding: nil, embedding_content_hash: nil]
+        )
+
+        BatchEmbeddingWorker.new(%{tenant_id: tenant_id, kind: "article"})
         |> Oban.insert()
       else
         {:ok, :skipped}

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -53,6 +53,7 @@ defmodule Loopctl.Knowledge do
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.ArticleLink
   alias Loopctl.Knowledge.ConflictResolution
+  alias Loopctl.Knowledge.EmbeddingClient
   alias Loopctl.Knowledge.EmbeddingConcurrency
   alias Loopctl.Knowledge.KbCuration
   alias Loopctl.Knowledge.OKF
@@ -796,14 +797,18 @@ defmodule Loopctl.Knowledge do
 
   @doc """
   US-37.4: lists up to `limit` PUBLISHED articles for `tenant_id` that still need
-  an embedding — those with `embedding IS NULL`. A brand-new published article
-  starts NULL; a content change re-nulls the vector at the enqueue site (see
-  `maybe_enqueue_embedding/3`) so the article re-enters this pending set and the
-  batch drainer re-embeds it.
+  an embedding — those with `embedding IS NULL` (never embedded) OR
+  `embedding_stale_at IS NOT NULL` (embedded, but content changed since — the
+  vector is present-but-stale). A brand-new published article starts NULL; a
+  content change sets `embedding_stale_at` at the enqueue site (see
+  `maybe_enqueue_embedding/3`) WITHOUT destroying the current vector (review MED
+  #2), so the article stays searchable until the batch drainer re-embeds it and
+  clears the flag.
 
-  `embedding IS NULL` (NOT `embedding_content_hash IS NULL`) is the deliberate
-  signal: `update_embedding/3` legitimately sets a vector with a nil hash, so a
-  hash-based predicate would loop-re-embed those rows forever.
+  The predicate deliberately keys on `embedding IS NULL`/`embedding_stale_at`
+  (NOT `embedding_content_hash IS NULL`): `update_embedding/3` legitimately sets a
+  vector with a nil hash, so a hash-based predicate would loop-re-embed those rows
+  forever.
 
   Returns lightweight `%{id, title, body}` rows (tenant-scoped by the explicit
   predicate — AC-37.4.4 isolation) for `Loopctl.Workers.BatchEmbeddingWorker` to
@@ -817,10 +822,31 @@ defmodule Loopctl.Knowledge do
       when is_binary(tenant_id) and is_integer(limit) and limit > 0 do
     from(a in Article,
       where: a.tenant_id == ^tenant_id and a.status == :published,
-      where: is_nil(a.embedding),
+      where: is_nil(a.embedding) or not is_nil(a.embedding_stale_at),
       order_by: [asc: a.updated_at, asc: a.id],
       limit: ^limit,
       select: %{id: a.id, title: a.title, body: a.body}
+    )
+    |> AdminRepo.all()
+  end
+
+  @doc """
+  US-37.4 (review HIGH #1): the DISTINCT set of tenant_ids that still have at
+  least one PUBLISHED article needing an embedding (`embedding IS NULL` or
+  `embedding_stale_at IS NOT NULL`). Drives the periodic
+  `Loopctl.Workers.PendingEmbeddingSweepWorker` backstop, which re-enqueues a
+  per-tenant batch drainer — the real safety net against a coalesced drainer
+  never being re-inserted (Oban uniqueness dedup) after a post-drain write.
+
+  Cross-tenant read via `AdminRepo`; backed by `articles_pending_embedding_idx`.
+  """
+  @spec tenant_ids_with_pending_article_embeddings() :: [Ecto.UUID.t()]
+  def tenant_ids_with_pending_article_embeddings do
+    from(a in Article,
+      where: a.status == :published,
+      where: is_nil(a.embedding) or not is_nil(a.embedding_stale_at),
+      distinct: true,
+      select: a.tenant_id
     )
     |> AdminRepo.all()
   end
@@ -7347,6 +7373,17 @@ defmodule Loopctl.Knowledge do
   # never killed-then-miscounted as a breaker failure (review #10).
   @embedding_yield_ms 5_000
 
+  # Task.yield budget for a BATCH (array) embedding call is DERIVED at call time
+  # from `EmbeddingClient.batch_yield_budget_ms/0` (review MED #1) — never a fixed
+  # constant. That budget is computed from the SAME live-tunable SystemConfig knobs
+  # the batch request uses (`embedding_batch_receive_timeout_ms` *
+  # (`embedding_max_retries` + 1) + backoff + slack), so an operator raising either
+  # knob raises the yield in lockstep and a slow-but-valid array response always
+  # returns before the guard kills the task (which would mis-record a breaker /
+  # provider-error failure — review LOW #7). The single-text `@embedding_yield_ms`
+  # (5s) would wrongly shut a legitimate 30s+ array call down.
+  defp batch_embedding_yield_ms, do: EmbeddingClient.batch_yield_budget_ms()
+
   @doc """
   Generate an embedding for the given text with a PER-TENANT circuit breaker and
   timeout protection.
@@ -7420,7 +7457,10 @@ defmodule Loopctl.Knowledge do
   interactive single-text callers are UNCHANGED — this is a background-only path.
 
   `opts`:
-    * `:timeout` — Task.yield budget in ms (default `#{@embedding_yield_ms}`).
+    * `:timeout` — Task.yield budget in ms. Defaults to
+      `EmbeddingClient.batch_yield_budget_ms/0`, DERIVED from the batch client's
+      live-tunable receive-timeout and retry knobs so it always stays above the
+      client's worst case (review MED #1 / LOW #7).
   """
   @spec generate_embeddings(Ecto.UUID.t(), [String.t()], keyword()) ::
           {:ok, [[float()]]} | {:error, term()}
@@ -7437,7 +7477,10 @@ defmodule Loopctl.Knowledge do
     if circuit_open?(tenant_id) do
       {:error, :circuit_open}
     else
-      timeout = Keyword.get(opts, :timeout, @embedding_yield_ms)
+      # Default DERIVED from the batch client's live-tunable receive_timeout/retry
+      # knobs (review MED #1) — never the single-text 5s budget, which would kill a
+      # valid in-flight array request.
+      timeout = Keyword.get(opts, :timeout, batch_embedding_yield_ms())
       run_embedding_batch_task(tenant_id, texts, timeout)
     end
   end
@@ -7686,7 +7729,7 @@ defmodule Loopctl.Knowledge do
   end
 
   defp embedding_client do
-    Application.get_env(:loopctl, :embedding_client, Loopctl.Knowledge.EmbeddingClient)
+    Application.get_env(:loopctl, :embedding_client, EmbeddingClient)
   end
 
   # US-37.2: the per-node embedding-concurrency gate, resolved via config-based DI
@@ -7721,15 +7764,18 @@ defmodule Loopctl.Knowledge do
   defp maybe_enqueue_embedding(multi, tenant_id, true) do
     Multi.run(multi, :embedding_job, fn repo, %{article: article} ->
       if article.status == :published do
-        # US-37.4: re-null an ALREADY-embedded article's vector (+hash) after a
-        # content change so it re-enters the `embedding IS NULL` pending set and the
-        # per-tenant batch drainer re-embeds it. A brand-new article already has
-        # embedding=NULL, so restrict the update to embedded rows. Then enqueue ONE
-        # per-tenant batch worker (unique per tenant+kind) instead of a per-article
-        # job, so many near-simultaneous writes coalesce into a single array call.
+        # US-37.4 (review MED #2): mark an ALREADY-embedded article's vector STALE
+        # (non-destructively) after a content change so it re-enters the pending set
+        # WITHOUT dropping out of vector search / novelty scoring during the async
+        # gap. The CURRENT vector stays searchable until the batch drainer computes
+        # and overwrites it (which clears `embedding_stale_at`). A brand-new article
+        # already has embedding=NULL, so restrict the mark to embedded rows. Then
+        # enqueue ONE per-tenant batch worker (unique per tenant+kind) instead of a
+        # per-article job, so many near-simultaneous writes coalesce into a single
+        # array call.
         repo.update_all(
           from(a in Article, where: a.id == ^article.id and not is_nil(a.embedding)),
-          set: [embedding: nil, embedding_content_hash: nil]
+          set: [embedding_stale_at: DateTime.utc_now()]
         )
 
         BatchEmbeddingWorker.new(%{tenant_id: tenant_id, kind: "article"})

--- a/lib/loopctl/knowledge/article.ex
+++ b/lib/loopctl/knowledge/article.ex
@@ -64,6 +64,11 @@ defmodule Loopctl.Knowledge.Article do
     # SHA-256 hex of the exact text that produced `embedding` — the idempotency key
     # that lets ArticleEmbeddingWorker skip re-calling the paid provider on retry.
     field :embedding_content_hash, :string
+    # US-37.4 (review MED #2): non-destructive staleness marker. A content edit of
+    # an already-embedded article sets this instead of nulling `embedding`, so the
+    # CURRENT vector stays searchable until the batch drainer computes the new one.
+    # Storing a fresh vector CLEARS it (`embedding_changeset/3`).
+    field :embedding_stale_at, :utc_datetime_usec
 
     # GOVERNED curated (authoritative) marker (US-31.1). Deliberately EXCLUDED from
     # `@cast_fields` and `update_changeset/2` — writable ONLY via `curation_changeset/3`
@@ -278,8 +283,14 @@ defmodule Loopctl.Knowledge.Article do
   @spec embedding_changeset(%__MODULE__{}, list(number()) | nil, String.t() | nil) ::
           Ecto.Changeset.t()
   def embedding_changeset(article, embedding, content_hash \\ nil) do
+    # Writing a fresh vector clears the staleness marker (review MED #2): the new
+    # vector is, by definition, current — so the row leaves the pending set.
     article
-    |> change(%{embedding: embedding, embedding_content_hash: content_hash})
+    |> change(%{
+      embedding: embedding,
+      embedding_content_hash: content_hash,
+      embedding_stale_at: nil
+    })
     |> validate_embedding_dimensions()
   end
 

--- a/lib/loopctl/knowledge/embedding_behaviour.ex
+++ b/lib/loopctl/knowledge/embedding_behaviour.ex
@@ -25,4 +25,19 @@ defmodule Loopctl.Knowledge.EmbeddingBehaviour do
 
   @callback generate_embedding(tenant_id :: Ecto.UUID.t(), text :: String.t()) ::
               {:ok, [float()]} | {:error, :no_api_key} | {:error, term()}
+
+  @doc """
+  Batch variant (US-37.4): embeds a LIST of texts in ONE provider round-trip,
+  returning a list of vectors in the SAME order as the input `texts` (mapped back
+  from the provider's per-entry `index`, never by array position). Used by the
+  background batch embedding worker to cut N provider calls down to
+  `ceil(N / batch_max)`. The interactive single-text path stays
+  `generate_embedding/2` (latency-sensitive).
+
+  An empty `texts` list returns `{:ok, []}` WITHOUT any provider call. A single
+  provider error fails the whole batch as a unit (`{:error, reason}`) so no
+  partial set of vectors is written.
+  """
+  @callback generate_embeddings(tenant_id :: Ecto.UUID.t(), texts :: [String.t()]) ::
+              {:ok, [[float()]]} | {:error, :no_api_key} | {:error, term()}
 end

--- a/lib/loopctl/knowledge/embedding_client.ex
+++ b/lib/loopctl/knowledge/embedding_client.ex
@@ -39,6 +39,60 @@ defmodule Loopctl.Knowledge.EmbeddingClient do
 
   @default_base_url "https://api.openai.com/v1"
 
+  # Default batch HTTP knobs — a literal mirror of the seeded SystemConfig rows;
+  # these in-code defaults apply on a cache miss (safe degrade). Kept here (not in
+  # the guard) so the guard's Task.yield budget can be DERIVED from the SAME
+  # numbers the request actually uses (review MED #1).
+  @default_batch_receive_timeout_ms 30_000
+  @default_batch_max_retries 0
+  # Per-retry backoff allowance: `retry: :transient` sleeps between attempts
+  # (Req's exponential backoff), so each extra retry adds a receive window PLUS a
+  # backoff sleep. Budget generously for the sleep so a retrying-but-valid call
+  # still returns before the guard fires.
+  @batch_retry_backoff_ms 4_000
+  # Fixed slack above the worst-case HTTP budget for task scheduling / DB overhead.
+  @batch_yield_slack_ms 2_000
+
+  @doc """
+  The live-tunable per-request receive timeout (ms) the batch array call uses
+  (`embedding_batch_receive_timeout_ms`, default #{@default_batch_receive_timeout_ms}).
+  """
+  @spec batch_receive_timeout_ms() :: pos_integer()
+  def batch_receive_timeout_ms do
+    SystemConfig.get_int("embedding_batch_receive_timeout_ms", @default_batch_receive_timeout_ms)
+  end
+
+  @doc """
+  The live-tunable client-side retry count for a batch array call
+  (`embedding_max_retries`, default #{@default_batch_max_retries}). Floored at 0.
+  """
+  @spec batch_max_retries() :: non_neg_integer()
+  def batch_max_retries do
+    max(SystemConfig.get_int("embedding_max_retries", @default_batch_max_retries), 0)
+  end
+
+  @doc """
+  Worst-case wall-clock budget (ms) for a batch array call, DERIVED from the same
+  live-tunable SystemConfig knobs `do_post_batch/4` actually reads:
+  `receive_timeout * (max_retries + 1)` plus a per-retry backoff allowance and a
+  fixed slack.
+
+  The guarded batch path (`Loopctl.Knowledge.generate_embeddings/3`) uses this as
+  its `Task.yield` budget, so raising `embedding_batch_receive_timeout_ms` or
+  `embedding_max_retries` can NEVER make the yield fire BEFORE a valid in-flight
+  response returns (review MED #1). Previously the yield was a compile-time 32s
+  constant while these knobs were operator-tunable with no coupling — an operator
+  raising either defeated the guard, killing valid slow responses and
+  mis-counting them as breaker / provider-error failures.
+  """
+  @spec batch_yield_budget_ms() :: pos_integer()
+  def batch_yield_budget_ms do
+    retries = batch_max_retries()
+
+    batch_receive_timeout_ms() * (retries + 1) + @batch_retry_backoff_ms * retries +
+      @batch_yield_slack_ms
+  end
+
   @impl true
   def generate_embedding(tenant_id, text) when is_binary(tenant_id) do
     case Llm.resolve(tenant_id, :embedding) do
@@ -85,8 +139,8 @@ defmodule Loopctl.Knowledge.EmbeddingClient do
         json: %{input: texts, model: model},
         headers: [{"authorization", "Bearer #{api_key}"}],
         retry: :transient,
-        max_retries: SystemConfig.get_int("embedding_max_retries", 0),
-        receive_timeout: SystemConfig.get_int("embedding_batch_receive_timeout_ms", 30_000)
+        max_retries: batch_max_retries(),
+        receive_timeout: batch_receive_timeout_ms()
       ]
       |> maybe_put_plug()
 

--- a/lib/loopctl/knowledge/embedding_client.ex
+++ b/lib/loopctl/knowledge/embedding_client.ex
@@ -51,6 +51,84 @@ defmodule Loopctl.Knowledge.EmbeddingClient do
     end
   end
 
+  @impl true
+  def generate_embeddings(_tenant_id, []), do: {:ok, []}
+
+  def generate_embeddings(tenant_id, texts) when is_binary(tenant_id) and is_list(texts) do
+    case Llm.resolve(tenant_id, :embedding) do
+      {:error, :no_api_key} ->
+        # Mandatory BYO: no tenant key => no provider call, no operator spend.
+        {:error, :no_api_key}
+
+      {:ok, %{api_key: api_key, model: model}} ->
+        post_batch(tenant_id, api_key, model, texts)
+    end
+  end
+
+  # US-37.4: one admission token for the WHOLE array call (AC-37.4.4) — the batch
+  # is a single provider round-trip, so it takes exactly one token from the US-37.1
+  # bucket, exactly like the single-text path.
+  defp post_batch(tenant_id, api_key, model, texts) do
+    with :ok <- Admission.admit(tenant_id, :embedding) do
+      do_post_batch(tenant_id, api_key, model, texts)
+    end
+  end
+
+  defp do_post_batch(tenant_id, api_key, model, texts) do
+    base_url = provider_config()[:base_url] || @default_base_url
+
+    # The array call is a single HTTP request carrying up to ~100 texts, so it
+    # needs a longer receive budget than the single-text path (kept behind its own
+    # live-tunable SystemConfig key; the in-code default applies on a cache miss).
+    opts =
+      [
+        json: %{input: texts, model: model},
+        headers: [{"authorization", "Bearer #{api_key}"}],
+        retry: :transient,
+        max_retries: SystemConfig.get_int("embedding_max_retries", 0),
+        receive_timeout: SystemConfig.get_int("embedding_batch_receive_timeout_ms", 30_000)
+      ]
+      |> maybe_put_plug()
+
+    case Req.post("#{base_url}/embeddings", opts) do
+      {:ok, %{status: 200, body: %{"data" => data} = resp}} when is_list(data) ->
+        record_usage_safe(tenant_id, model, resp["usage"])
+        map_embeddings_by_index(data, length(texts))
+
+      {:ok, %{status: status, body: body}} ->
+        Logger.warning("Loopctl.Knowledge.EmbeddingClient: batch API error (status=#{status})")
+        {:error, ProviderError.sanitize({:api_error, status, body})}
+
+      {:error, reason} ->
+        Logger.warning(
+          "Loopctl.Knowledge.EmbeddingClient: batch request failed (#{ProviderError.log_tag({:request_failed, reason})})"
+        )
+
+        {:error, {:request_failed, reason}}
+    end
+  end
+
+  # AC-37.4.1: map each returned vector back to its input BY the response `index`
+  # field — never by array position — since OpenAI-compatible endpoints do NOT
+  # guarantee `data` is index-ordered. Reassemble in input order (0..n-1). A
+  # missing index means the provider returned an incomplete batch: fail as a unit
+  # so the caller never writes a partial/misaligned set of vectors.
+  defp map_embeddings_by_index(data, count) do
+    by_index =
+      Enum.reduce(data, %{}, fn
+        %{"index" => i, "embedding" => vec}, acc when is_integer(i) -> Map.put(acc, i, vec)
+        _entry, acc -> acc
+      end)
+
+    vectors = Enum.map(0..(count - 1), &Map.get(by_index, &1))
+
+    if Enum.any?(vectors, &is_nil/1) do
+      {:error, {:embedding_batch_incomplete, count}}
+    else
+      {:ok, vectors}
+    end
+  end
+
   defp post(tenant_id, api_key, model, text) do
     # US-37.1: per-(tenant, provider) token-bucket admission gate. On an empty
     # node-local bucket, fast-fail WITHOUT building/sending the request so the

--- a/lib/loopctl/memory.ex
+++ b/lib/loopctl/memory.ex
@@ -286,6 +286,16 @@ defmodule Loopctl.Memory do
       # US-37.4: enqueue ONE per-tenant batch drainer (unique per tenant+kind)
       # instead of a per-memory job, so a bulk `remember` burst coalesces into
       # array batches (~100/call) rather than one provider round-trip per memory.
+      #
+      # ACCEPTED BOUNDED-STALENESS TRADEOFF (review LOW #3): the drainer's Oban
+      # uniqueness spans non-terminal states, so a memory written just after an
+      # EXECUTING drainer's final fetch (but before it finishes) dedupes against that
+      # still-running job and isn't embedded by it. Until re-embedded the row is
+      # `embedding IS NULL` and invisible to semantic `Memory.recall/2`. This is
+      # SELF-HEALING and time-bounded: `PendingEmbeddingSweepWorker` (cron `*/5`)
+      # re-enqueues a drainer for any tenant with pending memories, so recall
+      # staleness is capped at ~one sweep interval — not a correctness loss. (The
+      # narrower snooze-continuation window is even shorter; see BatchEmbeddingWorker.)
       BatchEmbeddingWorker.new(%{tenant_id: memory.tenant_id, kind: "memory"})
     end)
     |> AdminRepo.transaction()
@@ -1516,6 +1526,26 @@ defmodule Loopctl.Memory do
       order_by: [asc: m.inserted_at, asc: m.id],
       limit: ^limit,
       select: %{id: m.id, text: m.text}
+    )
+    |> Loopctl.AdminRepo.all()
+  end
+
+  @doc """
+  US-37.4 (review HIGH #1): the DISTINCT set of tenant_ids with at least one
+  long-term memory still needing an embedding (`embedding IS NULL`). Drives the
+  periodic `Loopctl.Workers.PendingEmbeddingSweepWorker` backstop — the real
+  safety net for MEMORIES, which (unlike articles) had NO nightly re-embed path,
+  so a coalesced drainer deduped away by Oban uniqueness after a post-drain write
+  would otherwise strand `embedding IS NULL` memories indefinitely.
+
+  Cross-tenant read via `AdminRepo`; backed by `memories_pending_embedding_idx`.
+  """
+  @spec tenant_ids_with_pending_embeddings() :: [String.t()]
+  def tenant_ids_with_pending_embeddings do
+    from(m in MemorySchema,
+      where: is_nil(m.embedding),
+      distinct: true,
+      select: m.tenant_id
     )
     |> Loopctl.AdminRepo.all()
   end

--- a/lib/loopctl/memory.ex
+++ b/lib/loopctl/memory.ex
@@ -56,7 +56,7 @@ defmodule Loopctl.Memory do
   alias Loopctl.Memory.Scope
   alias Loopctl.Memory.SessionMemory
   alias Loopctl.Memory.SessionPromotion
-  alias Loopctl.Workers.MemoryEmbeddingWorker
+  alias Loopctl.Workers.BatchEmbeddingWorker
   alias Loopctl.Workers.MemoryPromotionWorker
 
   @default_near_dup_threshold 0.92
@@ -283,7 +283,10 @@ defmodule Loopctl.Memory do
     end)
     |> Multi.insert(:memory, long_term_changeset(scope, attrs))
     |> Oban.insert(:embedding_job, fn %{memory: memory} ->
-      MemoryEmbeddingWorker.new(%{memory_id: memory.id, tenant_id: memory.tenant_id})
+      # US-37.4: enqueue ONE per-tenant batch drainer (unique per tenant+kind)
+      # instead of a per-memory job, so a bulk `remember` burst coalesces into
+      # array batches (~100/call) rather than one provider round-trip per memory.
+      BatchEmbeddingWorker.new(%{tenant_id: memory.tenant_id, kind: "memory"})
     end)
     |> AdminRepo.transaction()
     |> case do
@@ -1494,6 +1497,27 @@ defmodule Loopctl.Memory do
       nil -> {:error, :not_found}
       memory -> {:ok, memory}
     end
+  end
+
+  @doc """
+  US-37.4: lists up to `limit` long-term memories for `tenant_id` that still need
+  an embedding (`embedding IS NULL`). Returns lightweight `%{id, text}` rows for
+  `Loopctl.Workers.BatchEmbeddingWorker` to batch into one array call. Tenant-scoped
+  by the explicit predicate (AC-37.4.4 isolation) via `AdminRepo`, mirroring
+  `get_memory_for_embedding/2`.
+  """
+  @spec list_memories_pending_embedding(String.t(), pos_integer()) :: [
+          %{id: String.t(), text: String.t()}
+        ]
+  def list_memories_pending_embedding(tenant_id, limit)
+      when is_binary(tenant_id) and is_integer(limit) and limit > 0 do
+    from(m in MemorySchema,
+      where: m.tenant_id == ^tenant_id and is_nil(m.embedding),
+      order_by: [asc: m.inserted_at, asc: m.id],
+      limit: ^limit,
+      select: %{id: m.id, text: m.text}
+    )
+    |> Loopctl.AdminRepo.all()
   end
 
   @doc """

--- a/lib/loopctl/oban_config.ex
+++ b/lib/loopctl/oban_config.ex
@@ -415,6 +415,13 @@ defmodule Loopctl.ObanConfig do
          {"45 4 * * *", Loopctl.Workers.PromotionEvalWorker, args: %{"mode" => "all_tenants"}},
          {"*/5 * * * *", Loopctl.Workers.PendingEnrollmentCleanupWorker},
          {"*/5 * * * *", Loopctl.Workers.SessionMemoryPruneWorker},
+         # US-37.4 (review HIGH #1): periodic backstop that re-enqueues a per-tenant
+         # BatchEmbeddingWorker drainer for any tenant with pending/stale embeddings —
+         # the real safety net for records a coalesced drainer's Oban-uniqueness
+         # deduped away after a post-drain write (indefinite stranding for memories,
+         # which have no other re-embed path). Enqueues are unique-deduped, so a tick
+         # overlapping a live drainer is a cheap no-op.
+         {"*/5 * * * *", Loopctl.Workers.PendingEmbeddingSweepWorker},
          # Cross-tenant memory-promotion sweep (Epic 29 / US-29.2). Runs every 10 min —
          # KEEP this in sync with :memory_promotion_sweep_interval_seconds (600) below,
          # which is the data form of this schedule that the boot invariant reasons over.

--- a/lib/loopctl/workers/article_embedding_worker.ex
+++ b/lib/loopctl/workers/article_embedding_worker.ex
@@ -1,6 +1,14 @@
 defmodule Loopctl.Workers.ArticleEmbeddingWorker do
   @moduledoc """
-  Oban worker that generates and stores vector embeddings for articles.
+  Oban worker that generates and stores the vector embedding for a SINGLE article.
+
+  > **US-37.4:** background embedding is now driven by the per-tenant
+  > `Loopctl.Workers.BatchEmbeddingWorker`, which drains a tenant's pending
+  > articles in array batches (~100/provider call). The create/update/publish/
+  > ingestion enqueue sites route through that batch worker; this single-item
+  > worker is retained as the one-record embedding primitive (and is exercised
+  > directly by the fair-share gate tests). Both share the same guarded embed
+  > path, content-hash idempotency, and BYO/permanent-error semantics.
 
   Runs in the `:embeddings` queue with concurrency 5. When an article is
   created or updated with content changes (title/body) and is in `:published`

--- a/lib/loopctl/workers/batch_embedding_worker.ex
+++ b/lib/loopctl/workers/batch_embedding_worker.ex
@@ -16,21 +16,36 @@ defmodule Loopctl.Workers.BatchEmbeddingWorker do
   used by search, novelty scoring, `Memory.recall/2`) is UNCHANGED — still
   single-text and latency-sensitive.
 
-  ## Flow (one `perform/1`)
+  ## Flow (one `perform/1` drains ONE fetch, then yields the slot)
 
   1. US-36.2 per-tenant fair-share gate on the contended `:embeddings` queue —
      yields the slot (loss-free `{:snooze, n}`) when this tenant is over its share.
   2. Fetch up to `batch_max` pending records for `(tenant, kind)`.
   3. Build the sliced embedding texts + content hashes.
-  4. Embed the whole chunk in ONE array call via the GUARDED batch path
-     `Knowledge.generate_embeddings/3` (per-tenant circuit breaker + ONE US-37.2
-     concurrency slot + provider-error telemetry recorded once — never bypass it).
+  4. Sub-chunk the fetch by a per-request TOKEN budget (review MED #4) so a full
+     count-batch of large texts can't 400 the provider (over the ~300k token/
+     request cap) and get permanently discarded. Embed each sub-chunk in ONE array
+     call via the GUARDED batch path `Knowledge.generate_embeddings/3` (per-tenant
+     circuit breaker + ONE US-37.2 concurrency slot + provider-error telemetry
+     recorded once — never bypass it).
   5. Map each vector back to its record BY the response index (done in the client)
      and store each via `Knowledge.update_embedding/4` / `Memory.update_memory_embedding/4`.
-  6. If the chunk was full (`>= batch_max`), loop to drain the next chunk — so the
-     whole backlog is embedded in one job, `ceil(N / batch_max)` calls total, with
-     only `batch_max` records held in memory at a time. Stored records leave the
-     pending set, so the loop terminates.
+  6. If the fetch was full (`>= batch_max`) there may be more pending, so the job
+     RELEASES its `:embeddings` slot with `{:snooze, n}` (review MED #2) instead of
+     looping in-process. The snoozed job re-runs, re-passes the fair-share gate at
+     step 1, and drains the next fetch — already-stored records are excluded, so it
+     makes progress and terminates on a short (tail) fetch. Releasing the slot
+     between fetches is what actually enforces fairness: a single per-tenant drainer
+     always ranks 0 in the fair-share gate (it is unique per `(tenant, kind)`), so a
+     between-fetch RE-GATE would be a no-op and would let one tenant's bulk backlog
+     hold a slot for the whole drain (minutes-to-hours), starving other tenants'
+     drainers waiting for one of the 5 `:embeddings` slots. Snoozing frees the slot
+     so Oban's queue dispatcher round-robins the next tenant's drainer in.
+
+  Only `batch_max` records are held in memory per perform. Because a snooze re-runs
+  the SAME unique job (kept in a non-terminal state), a record written DURING a
+  snooze gap is picked up by the very next fetch — the narrow residual staleness is
+  a write racing the FINAL (tail) perform, backstopped by `PendingEmbeddingSweepWorker`.
 
   ## Atomicity (AC-37.4.3)
 
@@ -56,10 +71,23 @@ defmodule Loopctl.Workers.BatchEmbeddingWorker do
   tenant's texts (BYO key is per-tenant anyway).
   """
 
+  # review HIGH #1: scope uniqueness to NON-TERMINAL states only. Oban's default
+  # `unique` states include `:completed` (and `:cancelled`/`:discarded`), so a
+  # record written within `period` of a drainer that already FINISHED would be
+  # deduped against that terminal job and NO fresh drainer inserted — stranding the
+  # record (indefinitely for memories, which have no other re-embed path). By
+  # restricting to in-flight states, a write after a drain completes always
+  # re-enqueues a drainer; the periodic `PendingEmbeddingSweepWorker` is the
+  # backstop for the narrow window where a write races an EXECUTING drainer's final
+  # fetch (that job's uniqueness still coalesces, but the sweep re-enqueues later).
   use Oban.Worker,
     queue: :embeddings,
     max_attempts: 4,
-    unique: [keys: [:tenant_id, :kind], period: 300],
+    unique: [
+      keys: [:tenant_id, :kind],
+      states: [:available, :scheduled, :executing, :retryable],
+      period: 300
+    ],
     replace: [scheduled: [:args, :scheduled_at]]
 
   require Logger
@@ -73,20 +101,31 @@ defmodule Loopctl.Workers.BatchEmbeddingWorker do
   alias Loopctl.SystemConfig
   alias Loopctl.Workers.ArticleLinkingWorker
 
-  # Task.yield budget for the guarded batch path. Larger than the single-item
-  # worker's 8s: the array call carries up to ~100 texts, and must stay strictly
-  # above the client's batch receive_timeout (default 30s) so a valid response
-  # returns before the guard kills the task.
-  @batch_yield_ms 32_000
   @max_text_length 32_000
   @default_batch_max 100
+  # Snooze (seconds) used to RELEASE the :embeddings slot between drain fetches
+  # (review MED #2) so a lone per-tenant drainer can't hold a slot for its whole
+  # backlog. Small by design — it is a fairness yield, not a backoff; the snoozed
+  # job re-runs promptly and drains the next fetch. Live-tunable.
+  @default_drain_continue_snooze_s 1
+  # review MED #4: per-request token budget. An OpenAI-compatible embeddings
+  # request 400s (a PERMANENT error → whole chunk discarded) when the array's
+  # combined tokens exceed ~300k. A full count-batch of large articles (100 * ~8k
+  # tokens) blows past that, so we ALSO sub-chunk a fetched batch by an estimated
+  # token budget. Default 200k keeps ~33% headroom under the ~300k ceiling for
+  # estimation error. A single text is already sliced to `@max_text_length` chars
+  # (~8k tokens), so it can never alone exceed the budget.
+  @default_batch_max_tokens 200_000
 
   @impl Oban.Worker
   def perform(%Oban.Job{id: id, args: %{"tenant_id" => tenant_id, "kind" => kind}})
       when kind in ["article", "memory"] do
     # US-36.2: yield the :embeddings slot when this tenant is at/above its fair
     # share (loss-free {:snooze, n}, no attempt consumed). `id` excludes THIS
-    # already-executing job from its own count.
+    # already-executing job from its own count. Each perform drains only ONE fetch
+    # and snoozes to release the slot if more remains (review MED #2), so this gate
+    # is re-evaluated on every continuation — a large backlog can't monopolize a
+    # slot for minutes.
     case FairShare.gate(tenant_id, :embeddings, id) do
       {:snooze, _n} = snooze -> snooze
       :ok -> drain(tenant_id, kind, batch_max())
@@ -102,10 +141,22 @@ defmodule Loopctl.Workers.BatchEmbeddingWorker do
     max(SystemConfig.get_int("embedding_batch_max", @default_batch_max), 1)
   end
 
-  # Drain the tenant's pending records one chunk (<= batch_max) at a time. Each
-  # chunk is exactly one provider array call, so N records => ceil(N/batch_max)
-  # calls in this single perform. Stored records leave the pending set, so the
-  # loop terminates; a non-:ok chunk result (error/discard/snooze) short-circuits.
+  defp batch_max_tokens do
+    max(SystemConfig.get_int("embedding_batch_max_tokens", @default_batch_max_tokens), 1)
+  end
+
+  defp drain_continue_snooze_s do
+    max(
+      SystemConfig.get_int("embedding_drain_continue_snooze_s", @default_drain_continue_snooze_s),
+      1
+    )
+  end
+
+  # Drain ONE fetch (<= batch_max) of the tenant's pending records. The fetch is
+  # embedded via one-or-more provider array calls (token sub-chunking, review MED
+  # #4). A full fetch snoozes to release the slot and continue on re-run (review MED
+  # #2); a short (tail) fetch returns :ok. A non-:ok embed result
+  # (error/discard/snooze) short-circuits.
   defp drain(tenant_id, kind, batch_max) do
     case pending(tenant_id, kind, batch_max) do
       [] -> :ok
@@ -114,24 +165,68 @@ defmodule Loopctl.Workers.BatchEmbeddingWorker do
   end
 
   defp embed_and_continue(tenant_id, kind, batch_max, records) do
-    case embed_chunk(tenant_id, kind, records) do
-      :ok -> maybe_continue_drain(tenant_id, kind, batch_max, length(records))
+    case embed_records(tenant_id, kind, records) do
+      :ok -> maybe_continue_drain(length(records), batch_max)
       other -> other
     end
   end
 
-  # A full chunk means there may be more pending — loop. A short chunk drained the
-  # tail. Stored records leave the pending set, so this terminates.
-  defp maybe_continue_drain(tenant_id, kind, batch_max, chunk_size)
-       when chunk_size >= batch_max,
-       do: drain(tenant_id, kind, batch_max)
+  # Split a fetched batch into token-bounded sub-chunks (review MED #4) and embed
+  # each as its own provider array call, storing between. A sub-chunk error halts
+  # the reduce and returns the error/discard/snooze; sub-chunks stored earlier keep
+  # their vectors and are excluded from the pending set on retry (AC-37.4.3).
+  defp embed_records(tenant_id, kind, records) do
+    records
+    |> chunk_by_token_budget(batch_max_tokens())
+    |> Enum.reduce_while(:ok, fn sub_chunk, _acc ->
+      case embed_chunk(tenant_id, kind, sub_chunk) do
+        :ok -> {:cont, :ok}
+        other -> {:halt, other}
+      end
+    end)
+  end
 
-  defp maybe_continue_drain(_tenant_id, _kind, _batch_max, _chunk_size), do: :ok
+  # Greedily pack records into sub-chunks whose combined estimated tokens stay
+  # under `max_tokens`. Every sub-chunk holds at least one record (a lone
+  # already-sliced text can never exceed the budget), so this always makes progress.
+  defp chunk_by_token_budget(records, max_tokens) do
+    {chunks, current, _tokens} =
+      Enum.reduce(records, {[], [], 0}, fn record, {chunks, current, tokens} ->
+        t = est_tokens(record.text)
+
+        cond do
+          current == [] -> {chunks, [record], t}
+          tokens + t > max_tokens -> {[Enum.reverse(current) | chunks], [record], t}
+          true -> {chunks, [record | current], tokens + t}
+        end
+      end)
+
+    [Enum.reverse(current) | chunks] |> Enum.reverse()
+  end
+
+  # ~4 bytes/token heuristic (OpenAI-compatible). Deliberately a slight OVER-count
+  # (`+ 1`) so the budget errs toward smaller, safe requests.
+  defp est_tokens(text), do: div(byte_size(text), 4) + 1
+
+  # A full fetch means there may be more pending — RELEASE the :embeddings slot with
+  # `{:snooze, n}` (review MED #2) rather than looping in-process. The snoozed job
+  # re-runs, re-passes the top fair-share gate, and drains the next fetch (already-
+  # stored records excluded). Freeing the slot between fetches is what enforces
+  # fairness: a lone per-tenant drainer always ranks 0, so a between-fetch RE-GATE
+  # was a no-op that let one tenant hold a slot for its entire backlog. A short
+  # fetch drained the tail → :ok.
+  defp maybe_continue_drain(fetch_size, batch_max) when fetch_size >= batch_max do
+    {:snooze, drain_continue_snooze_s()}
+  end
+
+  defp maybe_continue_drain(_fetch_size, _batch_max), do: :ok
 
   defp embed_chunk(tenant_id, kind, records) do
     texts = Enum.map(records, & &1.text)
 
-    case Knowledge.generate_embeddings(tenant_id, texts, timeout: @batch_yield_ms) do
+    # No explicit :timeout — the guarded batch path derives its Task.yield budget
+    # from the client's live-tunable receive-timeout/retry knobs (review MED #1).
+    case Knowledge.generate_embeddings(tenant_id, texts) do
       {:ok, vectors} ->
         store_all(tenant_id, kind, records, vectors)
 

--- a/lib/loopctl/workers/batch_embedding_worker.ex
+++ b/lib/loopctl/workers/batch_embedding_worker.ex
@@ -1,0 +1,259 @@
+defmodule Loopctl.Workers.BatchEmbeddingWorker do
+  @moduledoc """
+  US-37.4: per-tenant BATCH embedding worker. Drains a tenant's pending
+  (un-embedded / content-stale) records in ARRAY batches of up to
+  `embedding_batch_max` (~100), issuing `ceil(N / batch_max)` provider calls
+  instead of N — the efficiency win that replaces the per-item fan-out of
+  `ArticleEmbeddingWorker` / `MemoryEmbeddingWorker` for background embedding.
+
+  ## Why a per-tenant batch worker (not per-item)
+
+  The single-item workers embedded one record per job (one provider round-trip
+  each). Under bulk ingest that is N round-trips for N records. This worker is
+  enqueued ONCE per tenant + `kind` (`unique: [keys: [:tenant_id, :kind]]`), so
+  many near-simultaneous writes coalesce into a single drainer that batches the
+  provider calls. The interactive single-query path (`Knowledge.generate_embedding/3`
+  used by search, novelty scoring, `Memory.recall/2`) is UNCHANGED — still
+  single-text and latency-sensitive.
+
+  ## Flow (one `perform/1`)
+
+  1. US-36.2 per-tenant fair-share gate on the contended `:embeddings` queue —
+     yields the slot (loss-free `{:snooze, n}`) when this tenant is over its share.
+  2. Fetch up to `batch_max` pending records for `(tenant, kind)`.
+  3. Build the sliced embedding texts + content hashes.
+  4. Embed the whole chunk in ONE array call via the GUARDED batch path
+     `Knowledge.generate_embeddings/3` (per-tenant circuit breaker + ONE US-37.2
+     concurrency slot + provider-error telemetry recorded once — never bypass it).
+  5. Map each vector back to its record BY the response index (done in the client)
+     and store each via `Knowledge.update_embedding/4` / `Memory.update_memory_embedding/4`.
+  6. If the chunk was full (`>= batch_max`), loop to drain the next chunk — so the
+     whole backlog is embedded in one job, `ceil(N / batch_max)` calls total, with
+     only `batch_max` records held in memory at a time. Stored records leave the
+     pending set, so the loop terminates.
+
+  ## Atomicity (AC-37.4.3)
+
+  If the provider array call errors, NOTHING is written for that chunk — the job
+  returns `{:error, ...}` and Oban retries the whole batch as a unit. Chunks
+  already stored in earlier loop iterations have their embedding+hash set, so they
+  are excluded from the pending set on retry and are never re-billed.
+
+  ## BYO / permanent-error / rate-limit semantics (mirrors the single-item workers)
+
+  - `{:error, :no_api_key}` (mandatory BYO) → `{:discard, {:no_embedding_key, kind}}`
+    (clean skip, no crash, no operator-key fallback).
+  - `{:error, :rate_limited_local}` (US-37.1 node-local admission) → `{:snooze, n}`
+    (loss-free backpressure, no attempt consumed).
+  - permanent 4xx (bad/revoked key — tenant-wide, so the whole batch fails
+    identically) → `{:discard, {:embedding_permanent_error, sanitized}}`.
+  - transient (5xx / network / timeout / circuit-open) → `{:error, sanitized}` for
+    retry. The sanitized-away raw body is NEVER logged or persisted.
+
+  ## Tenant isolation (AC-37.4.4)
+
+  The pending readers filter by `tenant_id`, so a batch array contains exactly one
+  tenant's texts (BYO key is per-tenant anyway).
+  """
+
+  use Oban.Worker,
+    queue: :embeddings,
+    max_attempts: 4,
+    unique: [keys: [:tenant_id, :kind], period: 300],
+    replace: [scheduled: [:args, :scheduled_at]]
+
+  require Logger
+
+  alias Loopctl.Knowledge
+  alias Loopctl.Llm
+  alias Loopctl.Llm.ProviderError
+  alias Loopctl.Memory
+  alias Loopctl.Oban.FairShare
+  alias Loopctl.Provider.Admission
+  alias Loopctl.SystemConfig
+  alias Loopctl.Workers.ArticleLinkingWorker
+
+  # Task.yield budget for the guarded batch path. Larger than the single-item
+  # worker's 8s: the array call carries up to ~100 texts, and must stay strictly
+  # above the client's batch receive_timeout (default 30s) so a valid response
+  # returns before the guard kills the task.
+  @batch_yield_ms 32_000
+  @max_text_length 32_000
+  @default_batch_max 100
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{id: id, args: %{"tenant_id" => tenant_id, "kind" => kind}})
+      when kind in ["article", "memory"] do
+    # US-36.2: yield the :embeddings slot when this tenant is at/above its fair
+    # share (loss-free {:snooze, n}, no attempt consumed). `id` excludes THIS
+    # already-executing job from its own count.
+    case FairShare.gate(tenant_id, :embeddings, id) do
+      {:snooze, _n} = snooze -> snooze
+      :ok -> drain(tenant_id, kind, batch_max())
+    end
+  end
+
+  @impl Oban.Worker
+  def backoff(%Oban.Job{attempt: attempt}) do
+    trunc(:math.pow(attempt, 4) + 15 + :rand.uniform(30) * attempt)
+  end
+
+  defp batch_max do
+    max(SystemConfig.get_int("embedding_batch_max", @default_batch_max), 1)
+  end
+
+  # Drain the tenant's pending records one chunk (<= batch_max) at a time. Each
+  # chunk is exactly one provider array call, so N records => ceil(N/batch_max)
+  # calls in this single perform. Stored records leave the pending set, so the
+  # loop terminates; a non-:ok chunk result (error/discard/snooze) short-circuits.
+  defp drain(tenant_id, kind, batch_max) do
+    case pending(tenant_id, kind, batch_max) do
+      [] -> :ok
+      records -> embed_and_continue(tenant_id, kind, batch_max, records)
+    end
+  end
+
+  defp embed_and_continue(tenant_id, kind, batch_max, records) do
+    case embed_chunk(tenant_id, kind, records) do
+      :ok -> maybe_continue_drain(tenant_id, kind, batch_max, length(records))
+      other -> other
+    end
+  end
+
+  # A full chunk means there may be more pending — loop. A short chunk drained the
+  # tail. Stored records leave the pending set, so this terminates.
+  defp maybe_continue_drain(tenant_id, kind, batch_max, chunk_size)
+       when chunk_size >= batch_max,
+       do: drain(tenant_id, kind, batch_max)
+
+  defp maybe_continue_drain(_tenant_id, _kind, _batch_max, _chunk_size), do: :ok
+
+  defp embed_chunk(tenant_id, kind, records) do
+    texts = Enum.map(records, & &1.text)
+
+    case Knowledge.generate_embeddings(tenant_id, texts, timeout: @batch_yield_ms) do
+      {:ok, vectors} ->
+        store_all(tenant_id, kind, records, vectors)
+
+      {:error, :no_api_key} ->
+        skip_no_embedding_key(tenant_id, kind, length(records))
+
+      {:error, :rate_limited_local} ->
+        # US-37.1 (AC-37.1.4): node-local admission rate-limit is loss-free
+        # backpressure, NOT a failure — snooze (no attempt consumed).
+        {:snooze, Admission.snooze_seconds()}
+
+      {:error, reason} ->
+        # The provider errored for the WHOLE array call, so NO vectors were written
+        # (AC-37.4.3). The term that becomes an Oban discard/error reason is
+        # SANITIZED — never a raw body. Provider-error telemetry was already recorded
+        # once, upstream, in Knowledge.run_capped_embedding_batch_task/3.
+        sanitized = ProviderError.sanitize(reason)
+
+        if Llm.permanent_provider_error?(reason) do
+          Logger.debug(
+            "BatchEmbeddingWorker: tenant=#{tenant_id} kind=#{kind} permanent embedding " <>
+              "error (#{ProviderError.log_tag(reason)}); discarding batch."
+          )
+
+          {:discard, {:embedding_permanent_error, sanitized}}
+        else
+          {:error, sanitized}
+        end
+    end
+  end
+
+  # Store every vector, mapped to its record by input order (the client already
+  # reassembled vectors in input order from the response index). A store failure
+  # halts and returns {:error, _} so Oban retries the whole batch; records stored
+  # before the failure keep their embedding+hash and are excluded on retry.
+  defp store_all(tenant_id, kind, records, vectors) do
+    records
+    |> Enum.zip(vectors)
+    |> Enum.reduce_while(:ok, fn {record, vector}, _acc ->
+      case store_one(tenant_id, kind, record, vector) do
+        :ok -> {:cont, :ok}
+        {:error, _reason} = err -> {:halt, err}
+      end
+    end)
+  end
+
+  defp store_one(tenant_id, "article", %{id: article_id} = record, vector) do
+    hash = content_hash(record.text)
+
+    case Knowledge.update_embedding(tenant_id, article_id, vector, hash) do
+      {:ok, _article} ->
+        enqueue_linking(article_id, tenant_id)
+        :ok
+
+      # Article deleted between fetch and store — nothing to do.
+      {:error, :not_found} ->
+        :ok
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp store_one(tenant_id, "memory", %{id: memory_id} = record, vector) do
+    hash = Memory.Memory.embedding_content_hash(record.text)
+
+    case Memory.update_memory_embedding(tenant_id, memory_id, vector, hash) do
+      {:ok, _memory} -> :ok
+      {:error, :not_found} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp pending(tenant_id, "article", limit) do
+    tenant_id
+    |> Knowledge.list_articles_pending_embedding(limit)
+    |> Enum.map(fn %{id: id, title: title, body: body} ->
+      %{id: id, text: build_article_text(title, body)}
+    end)
+  end
+
+  defp pending(tenant_id, "memory", limit) do
+    tenant_id
+    |> Memory.list_memories_pending_embedding(limit)
+    |> Enum.map(fn %{id: id, text: text} ->
+      %{id: id, text: Memory.Memory.embedding_input(text)}
+    end)
+  end
+
+  defp build_article_text(title, body) do
+    "#{title}\n\n#{body}"
+    |> String.slice(0, @max_text_length)
+  end
+
+  # Article content hash: sha256 over the sliced embedding text (matches the
+  # per-item ArticleEmbeddingWorker so the two never disagree on staleness).
+  defp content_hash(text) do
+    :sha256 |> :crypto.hash(text) |> Base.encode16(case: :lower)
+  end
+
+  # Mandatory BYO: the tenant has no embedding key, so no provider call was made
+  # and NOTHING was billed. Emit the skipped_no_key signal for the whole chunk and
+  # record a single blocked event, then cleanly discard (no crash, no retry).
+  defp skip_no_embedding_key(tenant_id, kind, count) do
+    :telemetry.execute(
+      [:loopctl, :embedding, :skipped_no_key],
+      %{count: count},
+      %{tenant_id: tenant_id, source: kind}
+    )
+
+    Llm.record_blocked(tenant_id, :embedding)
+
+    Logger.debug(
+      "BatchEmbeddingWorker: tenant=#{tenant_id} kind=#{kind} skipped #{count} record(s) — " <>
+        "no embedding API key configured (mandatory BYO)."
+    )
+
+    {:discard, {:no_embedding_key, kind}}
+  end
+
+  defp enqueue_linking(article_id, tenant_id) do
+    ArticleLinkingWorker.new(%{article_id: article_id, tenant_id: tenant_id})
+    |> Oban.insert()
+  end
+end

--- a/lib/loopctl/workers/content_ingestion_worker.ex
+++ b/lib/loopctl/workers/content_ingestion_worker.ex
@@ -61,7 +61,7 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   alias Loopctl.Oban.FairShare
   alias Loopctl.Provider.Admission
   alias Loopctl.SystemConfig
-  alias Loopctl.Workers.ArticleEmbeddingWorker
+  alias Loopctl.Workers.BatchEmbeddingWorker
 
   @content_extractor Application.compile_env(
                        :loopctl,
@@ -926,12 +926,16 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   # Enqueue an embedding job for each just-inserted (published) article. Runs
   # post-commit and is best-effort: a transient enqueue failure is logged, never
   # raised, so it can't fail/retry the whole ingestion job.
-  defp enqueue_embeddings(tenant_id, returned) do
-    Enum.each(returned, fn article ->
-      %{article_id: article.id, tenant_id: tenant_id}
-      |> ArticleEmbeddingWorker.new()
-      |> Oban.insert()
-    end)
+  defp enqueue_embeddings(_tenant_id, []), do: :ok
+
+  defp enqueue_embeddings(tenant_id, _returned) do
+    # US-37.4: the just-inserted published rows all have embedding=NULL, so a
+    # single per-tenant batch worker drains them in array batches (~100/call)
+    # instead of one provider round-trip per ingested article.
+    BatchEmbeddingWorker.new(%{tenant_id: tenant_id, kind: "article"})
+    |> Oban.insert()
+
+    :ok
   rescue
     e ->
       Logger.error("ContentIngestionWorker: embedding enqueue failed: #{Exception.message(e)}")

--- a/lib/loopctl/workers/knowledge_lint_worker.ex
+++ b/lib/loopctl/workers/knowledge_lint_worker.ex
@@ -26,9 +26,10 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
      reason a nightly pass is valuable rather than a no-op: an article orphaned
      in January (no neighbor cleared the similarity threshold at the time) can
      find neighbors that were ingested months later. Re-linking is deterministic,
-     cheap, and makes **no** embedding-API calls (orphans missing an embedding
-     simply no-op in the linking worker — backfilling those is a separate
-     concern, out of scope here).
+     cheap, and makes **no** embedding-API calls. Orphans missing an embedding
+     can't link until they have one, so they are routed to the per-tenant BATCH
+     drainer (`Loopctl.Workers.BatchEmbeddingWorker`, one job per tenant — review
+     MED #3) rather than one embedding job per article.
   3. **Surfaces all findings** via an immutable audit event
      (`knowledge.lint_completed`) carrying the full lint summary, so
      contradictions / coverage gaps / broken sources / stale counts are
@@ -61,8 +62,8 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   alias Loopctl.Knowledge.ArticleLink
   alias Loopctl.Oban.FairShare
   alias Loopctl.Tenants.Tenant
-  alias Loopctl.Workers.ArticleEmbeddingWorker
   alias Loopctl.Workers.ArticleLinkingWorker
+  alias Loopctl.Workers.BatchEmbeddingWorker
 
   # Ask lint for the ceiling so we act on as many orphans per run as the engine
   # will return; the true (pre-cap) totals still come back in the summary.
@@ -132,9 +133,10 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   # Orphans split two ways:
   #   * has an embedding -> re-link at the lenient orphan threshold (its nearest
   #     neighbor is usually a near-miss of the default 0.6 cutoff).
-  #   * no embedding -> it can NEVER link until it has one, so enqueue the
-  #     embedding worker (which chains to linking on success). These are the
-  #     articles a plain re-link silently no-ops on.
+  #   * no embedding -> it can NEVER link until it has one, so route it through the
+  #     per-tenant BATCH drainer (a SINGLE job coalesces the whole orphan backlog
+  #     into array calls — review MED #3; the drainer chains linking on store).
+  #     These are the articles a plain re-link silently no-ops on.
   defp act_on_orphans(tenant_id, report) do
     max_relink =
       Application.get_env(:loopctl, :knowledge_lint_max_orphan_relink, @default_max_orphan_relink)
@@ -167,11 +169,16 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
       |> Oban.insert()
     end)
 
-    Enum.each(without_embedding, fn id ->
-      %{"article_id" => id, "tenant_id" => tenant_id}
-      |> ArticleEmbeddingWorker.new()
+    # review MED #3 (AC-37.4.2): route orphans that still need an embedding through
+    # the BATCH path, NOT one ArticleEmbeddingWorker per article. These orphans are
+    # published with `embedding IS NULL`, so they are already in the per-tenant
+    # pending set — a single batch drainer (unique per tenant+kind) coalesces the
+    # whole orphan backlog into array calls instead of re-introducing the per-item,
+    # N-provider-round-trip fan-out this story exists to eliminate.
+    if without_embedding != [] do
+      BatchEmbeddingWorker.new(%{tenant_id: tenant_id, kind: "article"})
       |> Oban.insert()
-    end)
+    end
 
     %{relinked: length(with_embedding), embedding_enqueued: length(without_embedding)}
   end

--- a/lib/loopctl/workers/memory_embedding_worker.ex
+++ b/lib/loopctl/workers/memory_embedding_worker.ex
@@ -3,8 +3,14 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorker do
   Oban worker that generates and stores the vector embedding for a long-term
   agent memory (`Loopctl.Memory.Memory`), Epic 28 / US-28.2.
 
-  Runs in the `:embeddings` queue. Enqueued by `Loopctl.Memory.remember/2` when a
-  long-term memory is written (the row's `embedding` starts NULL). Mirrors
+  > **US-37.4:** background memory embedding is now driven by the per-tenant
+  > `Loopctl.Workers.BatchEmbeddingWorker` (array batches, ~100/provider call);
+  > `Loopctl.Memory.remember/2` enqueues that batch worker. This single-item
+  > worker is retained as the one-record embedding primitive and still shares the
+  > guarded embed path, content-hash idempotency, and BYO/permanent-error
+  > semantics described below.
+
+  Runs in the `:embeddings` queue. Mirrors
   `Loopctl.Workers.ArticleEmbeddingWorker` — same guarded embed path, content-hash
   idempotency, BYO-key / permanent-error discard semantics, AND the US-36.2 per-tenant
   fair-share gate at the top of `perform/1`. The gate is load-bearing here, not

--- a/lib/loopctl/workers/pending_embedding_sweep_worker.ex
+++ b/lib/loopctl/workers/pending_embedding_sweep_worker.ex
@@ -1,0 +1,65 @@
+defmodule Loopctl.Workers.PendingEmbeddingSweepWorker do
+  @moduledoc """
+  US-37.4 (review HIGH #1): periodic backstop that re-enqueues a per-tenant
+  `Loopctl.Workers.BatchEmbeddingWorker` drainer for every tenant that still has
+  un-embedded (or content-stale) records.
+
+  ## Why a sweep is required
+
+  All background embedding is now triggered by enqueuing the per-tenant, `unique`
+  batch drainer. Oban dedups a drainer against an in-flight sibling for the same
+  `(tenant, kind)`. That coalescing is the point — but it opens a narrow race:
+  a record written AFTER an executing drainer's final pending-fetch (but before
+  it finishes) is deduped against that still-executing job, which never sees it.
+  With no re-trigger the record stays `embedding IS NULL` — indefinitely for
+  MEMORIES, which (unlike articles, self-healed nightly by
+  `KnowledgeLintWorker`'s orphan relink) had no other re-embed path.
+
+  Restricting the drainer's uniqueness to non-terminal states already ensures a
+  post-COMPLETION write re-enqueues; this sweep closes the remaining EXECUTING-race
+  window (and any dropped enqueue) by re-enqueuing a drainer whenever pending work
+  exists. Enqueues are `unique`-deduped, so a sweep tick that overlaps a live
+  drainer is a cheap no-op.
+
+  ## Scale
+
+  The `tenant_ids_with_pending_*` readers are DISTINCT scans backed by partial
+  indexes (`articles_pending_embedding_idx` / `memories_pending_embedding_idx`),
+  so a tick only fans out drainers for tenants that actually have pending work —
+  usually none. Runs on `:maintenance` (a fast enqueue-only dispatcher, off the
+  contended `:embeddings` lane) and is itself `unique` so overlapping cron ticks
+  can't stack.
+  """
+
+  use Oban.Worker,
+    queue: :maintenance,
+    max_attempts: 3,
+    unique: [period: 60]
+
+  require Logger
+
+  alias Loopctl.Knowledge
+  alias Loopctl.Memory
+  alias Loopctl.Workers.BatchEmbeddingWorker
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{}) do
+    article_tenants = Knowledge.tenant_ids_with_pending_article_embeddings()
+    memory_tenants = Memory.tenant_ids_with_pending_embeddings()
+
+    Enum.each(article_tenants, &enqueue_drainer(&1, "article"))
+    Enum.each(memory_tenants, &enqueue_drainer(&1, "memory"))
+
+    Logger.info(
+      "PendingEmbeddingSweepWorker: enqueued drainers " <>
+        "article_tenants=#{length(article_tenants)} memory_tenants=#{length(memory_tenants)}"
+    )
+
+    :ok
+  end
+
+  defp enqueue_drainer(tenant_id, kind) do
+    BatchEmbeddingWorker.new(%{tenant_id: tenant_id, kind: kind})
+    |> Oban.insert()
+  end
+end

--- a/priv/repo/migrations/20260714160000_seed_embedding_batch_config.exs
+++ b/priv/repo/migrations/20260714160000_seed_embedding_batch_config.exs
@@ -1,0 +1,33 @@
+defmodule Loopctl.Repo.Migrations.SeedEmbeddingBatchConfig do
+  use Ecto.Migration
+
+  # US-37.4 (#352): background embedding batch-size knob.
+  #
+  # `embedding_batch_max` caps how many texts the per-tenant BatchEmbeddingWorker
+  # sends in ONE OpenAI-compatible array call (`input: [...]`). At ~100 this cuts
+  # provider round-trips ~100x under bulk ingest while each batch still takes
+  # exactly one US-37.1 admission token.
+  #
+  # A missing row makes SystemConfig.get_int/2 fall back to the in-code default
+  # (100 in Loopctl.Workers.BatchEmbeddingWorker), so seeding here only mirrors that
+  # default into the DB from day one, operator-visible and live-tunable (no deploy).
+  # `now() AT TIME ZONE 'UTC'` matches the :utc_datetime_usec columns; ON CONFLICT
+  # keeps re-runs safe.
+
+  def change do
+    execute(
+      """
+      INSERT INTO system_configs (id, key, value, description, inserted_at, updated_at)
+      VALUES
+        (gen_random_uuid(), 'embedding_batch_max', 100,
+          'Max texts per background embedding array call (BatchEmbeddingWorker); one admission token per batch',
+          now() AT TIME ZONE 'UTC', now() AT TIME ZONE 'UTC')
+      ON CONFLICT (key) DO NOTHING
+      """,
+      """
+      DELETE FROM system_configs
+      WHERE key = 'embedding_batch_max'
+      """
+    )
+  end
+end

--- a/priv/repo/migrations/20260714170000_add_articles_embedding_stale_at.exs
+++ b/priv/repo/migrations/20260714170000_add_articles_embedding_stale_at.exs
@@ -1,0 +1,32 @@
+defmodule Loopctl.Repo.Migrations.AddArticlesEmbeddingStaleAt do
+  use Ecto.Migration
+
+  # US-37.4 (review MED #2): a content edit of an ALREADY-embedded published
+  # article must NOT destroy its existing vector while it waits for the async
+  # batch drainer to re-embed it — otherwise the article drops out of vector
+  # search / novelty scoring for the whole (batching-lengthened) async gap.
+  #
+  # `embedding_stale_at` is a non-destructive staleness marker: on a content
+  # change we set it (keeping the CURRENT vector searchable) instead of nulling
+  # `embedding`. The row re-enters the pending set via
+  # `list_articles_pending_embedding/2`'s `embedding IS NULL OR embedding_stale_at
+  # IS NOT NULL` predicate; the batch worker overwrites the vector and CLEARS the
+  # flag (`Article.embedding_changeset/3`). The old vector survives until the
+  # replacement lands.
+  #
+  # The partial index backs BOTH the per-tenant pending reader and the
+  # cross-tenant `tenant_ids_with_pending_*` sweep query (review HIGH #1), so the
+  # periodic backstop sweep is an index scan, not a seq scan over every article.
+
+  def change do
+    alter table(:articles) do
+      add :embedding_stale_at, :utc_datetime_usec
+    end
+
+    create index(:articles, [:tenant_id, :updated_at, :id],
+             where:
+               "status = 'published' AND (embedding IS NULL OR embedding_stale_at IS NOT NULL)",
+             name: :articles_pending_embedding_idx
+           )
+  end
+end

--- a/priv/repo/migrations/20260714170100_add_memories_pending_embedding_index.exs
+++ b/priv/repo/migrations/20260714170100_add_memories_pending_embedding_index.exs
@@ -1,0 +1,17 @@
+defmodule Loopctl.Repo.Migrations.AddMemoriesPendingEmbeddingIndex do
+  use Ecto.Migration
+
+  # US-37.4 (review HIGH #1): the periodic pending-embedding sweep enumerates
+  # tenants that still have un-embedded long-term memories
+  # (`Memory.tenant_ids_with_pending_embeddings/0` — `DISTINCT tenant_id WHERE
+  # embedding IS NULL`). This partial index keeps that backstop (and the
+  # per-tenant `list_memories_pending_embedding/2` reader) an index scan rather
+  # than a seq scan over the whole memories table on every sweep tick.
+
+  def change do
+    create index(:memories, [:tenant_id, :inserted_at, :id],
+             where: "embedding IS NULL",
+             name: :memories_pending_embedding_idx
+           )
+  end
+end

--- a/priv/repo/migrations/20260714170200_seed_embedding_batch_max_tokens_config.exs
+++ b/priv/repo/migrations/20260714170200_seed_embedding_batch_max_tokens_config.exs
@@ -1,0 +1,35 @@
+defmodule Loopctl.Repo.Migrations.SeedEmbeddingBatchMaxTokensConfig do
+  use Ecto.Migration
+
+  # US-37.4 (review MED #4): background embedding batches must respect the
+  # provider's PER-REQUEST token cap, not just the item-count cap
+  # (`embedding_batch_max`). An OpenAI-compatible embeddings request rejects an
+  # array whose combined token count exceeds ~300k with HTTP 400 — a permanent
+  # error that would DISCARD the whole chunk and strand every record in it.
+  #
+  # `embedding_batch_max_tokens` bounds the ESTIMATED combined tokens
+  # (~bytes/4) the BatchEmbeddingWorker packs into one array call; it sub-chunks
+  # a fetched batch further when the token budget is hit. Default 200_000 keeps a
+  # ~33% headroom under the ~300k provider ceiling to absorb estimation error.
+  #
+  # A missing row makes SystemConfig.get_int/2 fall back to the in-code default
+  # (200_000 in Loopctl.Workers.BatchEmbeddingWorker), so seeding only mirrors the
+  # default into the DB — operator-visible and live-tunable, no deploy.
+
+  def change do
+    execute(
+      """
+      INSERT INTO system_configs (id, key, value, description, inserted_at, updated_at)
+      VALUES
+        (gen_random_uuid(), 'embedding_batch_max_tokens', 200000,
+          'Max estimated combined tokens per background embedding array call (BatchEmbeddingWorker); sub-chunks a batch to stay under the provider per-request token cap',
+          now() AT TIME ZONE 'UTC', now() AT TIME ZONE 'UTC')
+      ON CONFLICT (key) DO NOTHING
+      """,
+      """
+      DELETE FROM system_configs
+      WHERE key = 'embedding_batch_max_tokens'
+      """
+    )
+  end
+end

--- a/test/loopctl/knowledge/embedding_client_test.exs
+++ b/test/loopctl/knowledge/embedding_client_test.exs
@@ -154,4 +154,103 @@ defmodule Loopctl.Knowledge.EmbeddingClientTest do
     refute log =~ secret
     refute log =~ masked
   end
+
+  describe "generate_embeddings/2 (US-37.4 batch path)" do
+    test "TC-37.4.1: sends `input` as an ARRAY and maps each vector back BY response index" do
+      tenant = fixture(:tenant)
+      test_pid = self()
+      set_embedding_key(tenant, "test-openai-key-BATCH-1")
+
+      va = [0.1, 0.1, 0.1]
+      vb = [0.2, 0.2, 0.2]
+      vc = [0.3, 0.3, 0.3]
+
+      Req.Test.stub(EmbeddingClient, fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        send(test_pid, {:body, JSON.decode!(body)})
+
+        # Return data DELIBERATELY out of order — the client must reassemble by the
+        # `index` field, not by array position.
+        Req.Test.json(conn, %{
+          "data" => [
+            %{"index" => 2, "embedding" => vc},
+            %{"index" => 0, "embedding" => va},
+            %{"index" => 1, "embedding" => vb}
+          ],
+          "usage" => %{"prompt_tokens" => 9, "total_tokens" => 9}
+        })
+      end)
+
+      assert {:ok, [^va, ^vb, ^vc]} =
+               EmbeddingClient.generate_embeddings(tenant.id, ["alpha", "beta", "gamma"])
+
+      # The request body carried `input` as a JSON ARRAY, in input order.
+      assert_received {:body, %{"input" => ["alpha", "beta", "gamma"]}}
+    end
+
+    test "empty list short-circuits to {:ok, []} with NO provider call" do
+      tenant = fixture(:tenant)
+      test_pid = self()
+      set_embedding_key(tenant, "test-openai-key-BATCH-EMPTY")
+
+      Req.Test.stub(EmbeddingClient, fn conn ->
+        send(test_pid, :unexpected_http_call)
+        Req.Test.json(conn, %{"data" => []})
+      end)
+
+      assert {:ok, []} = EmbeddingClient.generate_embeddings(tenant.id, [])
+      refute_received :unexpected_http_call
+    end
+
+    test "mandatory BYO: a keyless tenant gets {:error, :no_api_key} with NO provider call" do
+      tenant = fixture(:tenant)
+      test_pid = self()
+
+      Req.Test.stub(EmbeddingClient, fn conn ->
+        send(test_pid, :unexpected_http_call)
+        Req.Test.json(conn, %{"data" => [%{"index" => 0, "embedding" => [0.0]}]})
+      end)
+
+      assert {:error, :no_api_key} =
+               EmbeddingClient.generate_embeddings(tenant.id, ["a", "b"])
+
+      refute_received :unexpected_http_call
+    end
+
+    test "a provider error fails the WHOLE batch as a unit (no partial vectors)" do
+      tenant = fixture(:tenant)
+      set_embedding_key(tenant, "test-openai-key-BATCH-500")
+
+      Req.Test.stub(EmbeddingClient, fn conn ->
+        conn
+        |> Plug.Conn.put_status(500)
+        |> Req.Test.json(%{"error" => %{"message" => "upstream boom"}})
+      end)
+
+      assert {:error, {:api_error, 500, :provider_error}} =
+               EmbeddingClient.generate_embeddings(tenant.id, ["a", "b", "c"])
+    end
+
+    test "cross-tenant: tenant A's batch uses A's key, never B's" do
+      a = fixture(:tenant)
+      b = fixture(:tenant)
+      test_pid = self()
+
+      set_embedding_key(a, "test-openai-key-AAAA")
+      set_embedding_key(b, "test-openai-key-BBBB")
+
+      Req.Test.stub(EmbeddingClient, fn conn ->
+        send(test_pid, {:auth, Plug.Conn.get_req_header(conn, "authorization")})
+
+        Req.Test.json(conn, %{
+          "data" => [%{"index" => 0, "embedding" => [1.0]}],
+          "usage" => %{"prompt_tokens" => 1}
+        })
+      end)
+
+      assert {:ok, [[1.0]]} = EmbeddingClient.generate_embeddings(a.id, ["x"])
+      assert_received {:auth, ["Bearer test-openai-key-AAAA"]}
+      refute_received {:auth, ["Bearer test-openai-key-BBBB"]}
+    end
+  end
 end

--- a/test/loopctl/knowledge/embedding_client_test.exs
+++ b/test/loopctl/knowledge/embedding_client_test.exs
@@ -253,4 +253,48 @@ defmodule Loopctl.Knowledge.EmbeddingClientTest do
       refute_received {:auth, ["Bearer test-openai-key-BBBB"]}
     end
   end
+
+  describe "review MED #1: batch_yield_budget_ms/0 is DERIVED from the live client knobs" do
+    # We set the persistent_term cache directly (the documented SystemConfig key
+    # format) and erase it on exit — same pattern as admission_test.exs. Intra-file
+    # tests run serially so the default is restored before the next test; the only
+    # cross-file reader of these keys is this derivation and the (mocked) client, so
+    # a transient value can never flake another test.
+    defp put_config(key, value) do
+      pt_key = {Loopctl.SystemConfig, key}
+      :persistent_term.put(pt_key, value)
+      on_exit(fn -> :persistent_term.erase(pt_key) end)
+    end
+
+    test "the default budget stays strictly ABOVE the client's default receive window" do
+      # Defaults: 30_000 * (0 + 1) + 4_000*0 + 2_000 = 32_000 (the old hard-coded yield).
+      assert EmbeddingClient.batch_max_retries() == 0
+      assert EmbeddingClient.batch_receive_timeout_ms() == 30_000
+      assert EmbeddingClient.batch_yield_budget_ms() == 32_000
+      assert EmbeddingClient.batch_yield_budget_ms() > EmbeddingClient.batch_receive_timeout_ms()
+    end
+
+    test "raising receive_timeout raises the yield in lockstep (no longer a 32s constant)" do
+      # The exact regression: an operator raising the receive timeout above the old
+      # 32s constant would have made the guard's Task.yield fire FIRST, killing a
+      # valid slow response. The derived budget must track it and stay above.
+      put_config("embedding_batch_receive_timeout_ms", 60_000)
+
+      budget = EmbeddingClient.batch_yield_budget_ms()
+      assert budget == 62_000
+      assert budget > EmbeddingClient.batch_receive_timeout_ms()
+    end
+
+    test "each client-side retry widens the yield by another receive window + backoff" do
+      put_config("embedding_batch_receive_timeout_ms", 30_000)
+      put_config("embedding_max_retries", 2)
+
+      # 30_000 * (2 + 1) + 4_000 * 2 + 2_000 = 100_000, comfortably above the
+      # worst-case HTTP window of receive_timeout * attempts = 90_000.
+      assert EmbeddingClient.batch_yield_budget_ms() == 100_000
+
+      worst_case_http = EmbeddingClient.batch_receive_timeout_ms() * (2 + 1)
+      assert EmbeddingClient.batch_yield_budget_ms() > worst_case_http
+    end
+  end
 end

--- a/test/loopctl/knowledge_embedding_test.exs
+++ b/test/loopctl/knowledge_embedding_test.exs
@@ -133,6 +133,63 @@ defmodule Loopctl.KnowledgeEmbeddingTest do
       assert length(Pgvector.to_list(reloaded.embedding)) == 1536
     end
 
+    test "review MED #2: a published content update marks the vector STALE without destroying it" do
+      %{tenant: tenant} = setup_tenant()
+      article = fixture(:article, %{tenant_id: tenant.id, status: :published})
+      embedding = List.duplicate(0.1, 1536)
+
+      assert {:ok, _} = Knowledge.update_embedding(tenant.id, article.id, embedding, "old-hash")
+
+      # Manual Oban mode: the content-change enqueues the batch drainer but does NOT
+      # run it, so we can observe the intermediate state — the OLD vector must still
+      # be present (searchable) with a staleness marker, not nulled.
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert {:ok, _updated} =
+                 Knowledge.update_article(tenant.id, article.id, %{body: "brand new body"})
+      end)
+
+      assert {:ok, reloaded} = Knowledge.get_article_with_embedding(tenant.id, article.id)
+      # Old vector SURVIVES the async gap (does not drop out of vector search).
+      assert reloaded.embedding != nil
+      assert length(Pgvector.to_list(reloaded.embedding)) == 1536
+      # But it is flagged stale so the drainer re-embeds it.
+      assert reloaded.embedding_stale_at != nil
+
+      # And it re-enters the pending set on that stale marker (vector still present).
+      pending_ids = Knowledge.list_articles_pending_embedding(tenant.id, 50) |> Enum.map(& &1.id)
+      assert article.id in pending_ids
+    end
+
+    test "review MED #2: storing a fresh vector clears the staleness marker" do
+      %{tenant: tenant} = setup_tenant()
+      article = fixture(:article, %{tenant_id: tenant.id, status: :published})
+
+      assert {:ok, _} =
+               Knowledge.update_embedding(
+                 tenant.id,
+                 article.id,
+                 List.duplicate(0.1, 1536),
+                 "hash"
+               )
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert {:ok, _} = Knowledge.update_article(tenant.id, article.id, %{body: "changed"})
+      end)
+
+      # The drainer's store path re-embeds and must clear the stale flag.
+      assert {:ok, _} =
+               Knowledge.update_embedding(
+                 tenant.id,
+                 article.id,
+                 List.duplicate(0.2, 1536),
+                 "new-hash"
+               )
+
+      assert {:ok, reloaded} = Knowledge.get_article_with_embedding(tenant.id, article.id)
+      assert reloaded.embedding_stale_at == nil
+      assert Knowledge.list_articles_pending_embedding(tenant.id, 50) == []
+    end
+
     test "create_changeset does not include embedding in cast fields" do
       # Verify :embedding is not in @cast_fields by attempting to cast it
       changeset =

--- a/test/loopctl/oban/fair_share_test.exs
+++ b/test/loopctl/oban/fair_share_test.exs
@@ -16,8 +16,15 @@ defmodule Loopctl.Oban.FairShareTest do
   # Oban-owned and has no RLS, so we insert through AdminRepo (as FairShare reads).
   # Direct struct/changeset insert does NOT run the job (unlike Oban.insert under
   # :inline), which is exactly what we need to simulate occupied slots.
+  # FairShare counts by (queue, state, tenant) regardless of worker, so the seeded
+  # worker string is arbitrary. Use a synthetic placeholder (NOT a real worker
+  # module) so these fixtures don't couple to any specific worker's lifecycle — e.g.
+  # a future removal of the now-batch-superseded single-item ArticleEmbeddingWorker
+  # (US-37.4 review LOW) can't silently break them.
+  @seed_worker "Loopctl.Test.FairShareSeedWorker"
+
   defp seed_job(tenant_id, queue, state, opts \\ []) do
-    worker = Keyword.get(opts, :worker, "Loopctl.Workers.ArticleEmbeddingWorker")
+    worker = Keyword.get(opts, :worker, @seed_worker)
 
     %{"tenant_id" => tenant_id}
     |> Oban.Job.new(worker: worker, queue: to_string(queue))
@@ -78,7 +85,7 @@ defmodule Loopctl.Oban.FairShareTest do
       # A different worker (even on the same queue string) must not be counted by the
       # worker-scoped backlog — the count keys on `worker`, so it rides the partial index.
       seed_job(tenant, :ingestion, "available", worker: "Loopctl.Workers.SomeOtherWorker")
-      seed_job(tenant, :embeddings, "available", worker: "Loopctl.Workers.ArticleEmbeddingWorker")
+      seed_job(tenant, :embeddings, "available", worker: @seed_worker)
 
       assert FairShare.in_flight_ingestion_backlog(tenant) == 1
     end

--- a/test/loopctl/workers/article_embedding_worker_test.exs
+++ b/test/loopctl/workers/article_embedding_worker_test.exs
@@ -232,9 +232,11 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorkerTest do
       %{tenant: tenant} = setup_tenant()
       article = create_published_article(tenant.id)
 
-      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, text ->
+      # US-37.4: the create/update enqueue now routes through the per-tenant
+      # BatchEmbeddingWorker, which calls the plural `generate_embeddings/2`.
+      expect(Loopctl.MockEmbeddingClient, :generate_embeddings, fn _tenant_id, [text] ->
         assert text =~ "Updated Title"
-        {:ok, List.duplicate(0.2, 1536)}
+        {:ok, [List.duplicate(0.2, 1536)]}
       end)
 
       assert {:ok, updated} =
@@ -247,9 +249,9 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorkerTest do
       %{tenant: tenant} = setup_tenant()
       article = create_published_article(tenant.id)
 
-      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, text ->
+      expect(Loopctl.MockEmbeddingClient, :generate_embeddings, fn _tenant_id, [text] ->
         assert text =~ "Updated body content"
-        {:ok, List.duplicate(0.3, 1536)}
+        {:ok, [List.duplicate(0.3, 1536)]}
       end)
 
       assert {:ok, _updated} =
@@ -270,9 +272,9 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorkerTest do
 
       assert draft.embedding == nil
 
-      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, text ->
+      expect(Loopctl.MockEmbeddingClient, :generate_embeddings, fn _tenant_id, [text] ->
         assert text =~ "Draft to Publish"
-        {:ok, List.duplicate(0.4, 1536)}
+        {:ok, [List.duplicate(0.4, 1536)]}
       end)
 
       assert {:ok, published} =

--- a/test/loopctl/workers/batch_embedding_worker_test.exs
+++ b/test/loopctl/workers/batch_embedding_worker_test.exs
@@ -15,18 +15,44 @@ defmodule Loopctl.Workers.BatchEmbeddingWorkerTest do
   alias Loopctl.Knowledge
   alias Loopctl.Memory
   alias Loopctl.Memory.Memory, as: MemorySchema
+  alias Loopctl.ObanConfig
   alias Loopctl.Workers.BatchEmbeddingWorker
 
-  defp job(tenant_id, kind) do
+  defp job(tenant_id, kind, id \\ System.unique_integer([:positive])) do
     %Oban.Job{
-      id: System.unique_integer([:positive]),
+      id: id,
       args: %{"tenant_id" => tenant_id, "kind" => kind}
     }
   end
 
+  # review MED #2: each perform drains ONE fetch and returns {:snooze, n} to RELEASE
+  # the :embeddings slot when the backlog exceeds `batch_max`, so a lone drainer
+  # can't hold a slot for its whole backlog. In inline tests (no Oban re-dispatch) we
+  # drive the continuation ourselves: re-run perform on a snooze until a terminal
+  # result (:ok / {:error, _} / {:discard, _}). The record set shrinks each fetch, so
+  # this terminates. Fair-share (top-gate) snoozes are exercised separately.
+  defp drain_fully(job) do
+    case BatchEmbeddingWorker.perform(job) do
+      {:snooze, _n} -> drain_fully(job)
+      other -> other
+    end
+  end
+
+  # Simulate occupied executing :embeddings slots for a tenant without running a
+  # job (a direct insert does not trigger the inline executor). Mirrors
+  # fair_share_gate_test.exs.
+  defp seed_executing(tenant_id, n) do
+    for _ <- 1..n do
+      %{"tenant_id" => tenant_id}
+      |> Oban.Job.new(worker: "Loopctl.Workers.BatchEmbeddingWorker", queue: "embeddings")
+      |> Ecto.Changeset.put_change(:state, "executing")
+      |> AdminRepo.insert!()
+    end
+  end
+
   # Insert N un-embedded long-term memories directly (no remember/2 → no inline
-  # enqueue), one query.
-  defp seed_memories(tenant_id, n) do
+  # enqueue), one query. `text_fun` builds each row's text from its index.
+  defp seed_memories(tenant_id, n, text_fun \\ &"durable fact number #{&1}") do
     now = DateTime.utc_now()
 
     rows =
@@ -35,7 +61,7 @@ defmodule Loopctl.Workers.BatchEmbeddingWorkerTest do
           id: Ecto.UUID.generate(),
           tenant_id: tenant_id,
           subject_id: "subj",
-          text: "durable fact number #{i}",
+          text: text_fun.(i),
           confidence: 1.0,
           source: :explicit,
           tags: [],
@@ -65,12 +91,15 @@ defmodule Loopctl.Workers.BatchEmbeddingWorkerTest do
 
       # EXACTLY 3 batched calls expected (ceil(250/100)); verify_on_exit! fails on
       # 250 (per-item) or any other count. Each call returns one vector per input.
+      # The drain spans 3 performs (each fetch snoozes to yield the slot — review
+      # MED #2); drain_fully drives the continuations, so the CALL COUNT (3, not 250)
+      # is what proves array batching regardless of how many performs it took.
       expect(Loopctl.MockEmbeddingClient, :generate_embeddings, 3, fn _tenant_id, texts ->
         assert length(texts) <= 100
         {:ok, Enum.map(texts, fn _ -> List.duplicate(0.1, 1536) end)}
       end)
 
-      assert :ok = BatchEmbeddingWorker.perform(job(tenant.id, "memory"))
+      assert :ok = drain_fully(job(tenant.id, "memory"))
 
       # Every memory got embedded — the pending set is drained.
       assert [] = Memory.list_memories_pending_embedding(tenant.id, 500)
@@ -221,6 +250,187 @@ defmodule Loopctl.Workers.BatchEmbeddingWorkerTest do
       end)
 
       assert :ok = BatchEmbeddingWorker.perform(job(tenant.id, "memory"))
+    end
+  end
+
+  describe "review HIGH #1: uniqueness is scoped to NON-TERMINAL states" do
+    test "resolved unique.states excludes :completed / :cancelled / :discarded" do
+      # The stranding bug: Oban's DEFAULT unique states include :completed, so a
+      # record written within `period` of a FINISHED drainer is deduped against
+      # that terminal job and no fresh drainer is inserted. Guard the scoping fix.
+      unique =
+        BatchEmbeddingWorker.new(%{tenant_id: Ecto.UUID.generate(), kind: "memory"})
+        |> Ecto.Changeset.get_field(:unique)
+
+      assert :available in unique.states
+      assert :scheduled in unique.states
+      assert :executing in unique.states
+      assert :retryable in unique.states
+
+      refute :completed in unique.states
+      refute :cancelled in unique.states
+      refute :discarded in unique.states
+    end
+
+    test "two enqueues for the same (tenant, kind) coalesce; a different kind is distinct" do
+      tenant = fixture(:tenant)
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert {:ok, j1} =
+                 BatchEmbeddingWorker.new(%{tenant_id: tenant.id, kind: "memory"})
+                 |> Oban.insert()
+
+        assert {:ok, j2} =
+                 BatchEmbeddingWorker.new(%{tenant_id: tenant.id, kind: "memory"})
+                 |> Oban.insert()
+
+        # Same (tenant, kind) in a non-terminal state → deduped to the SAME job.
+        assert j1.id == j2.id
+
+        # A different kind is a distinct dedup key → its own job.
+        assert {:ok, j3} =
+                 BatchEmbeddingWorker.new(%{tenant_id: tenant.id, kind: "article"})
+                 |> Oban.insert()
+
+        refute j3.id == j1.id
+      end)
+    end
+  end
+
+  describe "review MED #4: a fetched batch is sub-chunked by a per-request TOKEN budget" do
+    test "records well under the count cap still split into multiple array calls by tokens" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      # 30 records is far below the default count cap (batch_max=100), so a single
+      # drain fetches all 30 at once. Each text is sliced to 32_000 chars
+      # (~8k est tokens); 30 * 8k ≈ 240k tokens > the 200k default budget, so the
+      # SINGLE fetch MUST split into >1 provider call — proving token sub-chunking,
+      # not count chunking. Without it, this would be one ~240k-token call that a
+      # real provider 400s (permanent) and discards.
+      big = String.duplicate("x", 40_000)
+      assert 30 = seed_memories(tenant.id, 30, fn i -> "#{i} #{big}" end)
+
+      test_pid = self()
+      budget = 200_000
+
+      stub(Loopctl.MockEmbeddingClient, :generate_embeddings, fn _tenant_id, texts ->
+        est = Enum.reduce(texts, 0, fn t, acc -> acc + div(byte_size(t), 4) + 1 end)
+        send(test_pid, {:chunk, length(texts), est})
+        {:ok, Enum.map(texts, &det_vec/1)}
+      end)
+
+      assert :ok = BatchEmbeddingWorker.perform(job(tenant.id, "memory"))
+
+      chunks = drain_chunk_messages([])
+
+      # More than one call for 30 (< 100 count-cap) records ⇒ token-driven split.
+      assert length(chunks) >= 2
+      # Every array call stayed within the per-request token budget.
+      assert Enum.all?(chunks, fn {_n, est} -> est <= budget end)
+      # All 30 embedded — nothing stranded.
+      assert Memory.list_memories_pending_embedding(tenant.id, 100) == []
+    end
+  end
+
+  describe "review MED #6: cross-chunk partial progress (AC-37.4.3 atomicity across the drain loop)" do
+    test "chunk 1+2 stored, chunk 3 errors → the first 200 keep vectors, the last 50 stay pending" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+      assert 250 = seed_memories(tenant.id, 250)
+
+      # 250 records, batch_max=100 → three drain fetches ACROSS three performs (each
+      # full fetch snoozes to yield the slot — review MED #2; drain_fully drives the
+      # continuations). Mox uses expectations in order: the first two fetches succeed
+      # and STORE, the third errors — so the job returns {:error, _} for an Oban retry
+      # while the already-stored 200 keep their vectors (excluded from the pending
+      # set) and only the last 50 remain.
+      expect(Loopctl.MockEmbeddingClient, :generate_embeddings, 2, fn _tenant_id, texts ->
+        {:ok, Enum.map(texts, &det_vec/1)}
+      end)
+
+      expect(Loopctl.MockEmbeddingClient, :generate_embeddings, 1, fn _tenant_id, _texts ->
+        {:error, {:api_error, 500, :provider_error}}
+      end)
+
+      assert {:error, {:api_error, 500, :provider_error}} =
+               drain_fully(job(tenant.id, "memory"))
+
+      # Exactly the 50 un-stored records remain pending; the 200 stored are excluded.
+      assert length(Memory.list_memories_pending_embedding(tenant.id, 500)) == 50
+    end
+  end
+
+  describe "review MED #2: a full fetch YIELDS the :embeddings slot (snooze) instead of looping the whole backlog" do
+    test "one perform drains ONE fetch then snoozes while more remains pending" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+      # 150 > batch_max (100): the FIRST fetch is full, so the drainer must release
+      # its slot ({:snooze, n}) rather than loop in-process and hold the slot for the
+      # rest of the backlog (the head-of-line-blocking regression this fix removes).
+      assert 150 = seed_memories(tenant.id, 150)
+
+      # EXACTLY one array call in this single perform — the second fetch happens only
+      # on the (snoozed) re-run.
+      expect(Loopctl.MockEmbeddingClient, :generate_embeddings, 1, fn _tenant_id, texts ->
+        assert length(texts) == 100
+        {:ok, Enum.map(texts, &det_vec/1)}
+      end)
+
+      assert {:snooze, n} = BatchEmbeddingWorker.perform(job(tenant.id, "memory"))
+      assert is_integer(n) and n > 0
+
+      # Exactly the first 100 were embedded; 50 remain for the continuation — the
+      # slot is freed between fetches so another tenant's drainer can run.
+      assert length(Memory.list_memories_pending_embedding(tenant.id, 500)) == 50
+    end
+
+    test "a short (tail) fetch returns :ok without snoozing" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+      # 40 < batch_max: a single short fetch drains the tail, so the perform returns
+      # :ok directly (no continuation snooze).
+      assert 40 = seed_memories(tenant.id, 40)
+
+      expect(Loopctl.MockEmbeddingClient, :generate_embeddings, 1, fn _tenant_id, texts ->
+        {:ok, Enum.map(texts, &det_vec/1)}
+      end)
+
+      assert :ok = BatchEmbeddingWorker.perform(job(tenant.id, "memory"))
+      assert Memory.list_memories_pending_embedding(tenant.id, 500) == []
+    end
+  end
+
+  describe "review MED #5: fair share gates the drain (same path re-checked between chunks)" do
+    test "over-share yields the slot (snooze) before any provider call — nothing embedded" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+      cap = ObanConfig.tenant_fair_share_cap(:embeddings)
+
+      # Tenant already holds `cap` executing :embeddings slots (low ids). A drainer
+      # with a HIGHER id is over its rank → the gate snoozes. This is the exact
+      # `FairShare.gate/3` call re-run between drain chunks (review MED #5), so the
+      # re-gate cannot let a large backlog monopolize a slot for minutes.
+      seed_executing(tenant.id, cap)
+      seed_memories(tenant.id, 3)
+
+      # The gate short-circuits BEFORE any embedding call.
+      expect(Loopctl.MockEmbeddingClient, :generate_embeddings, 0, fn _t, _texts -> {:ok, []} end)
+
+      assert {:snooze, n} = BatchEmbeddingWorker.perform(job(tenant.id, "memory", 2_000_000_000))
+      assert is_integer(n) and n > 0
+
+      # Loss-free: the memories are untouched and still pending for a later drain.
+      assert length(Memory.list_memories_pending_embedding(tenant.id, 10)) == 3
+    end
+  end
+
+  # Collect the {:chunk, count, est_tokens} messages emitted by the token-budget stub.
+  defp drain_chunk_messages(acc) do
+    receive do
+      {:chunk, n, est} -> drain_chunk_messages([{n, est} | acc])
+    after
+      0 -> Enum.reverse(acc)
     end
   end
 end

--- a/test/loopctl/workers/batch_embedding_worker_test.exs
+++ b/test/loopctl/workers/batch_embedding_worker_test.exs
@@ -1,0 +1,226 @@
+defmodule Loopctl.Workers.BatchEmbeddingWorkerTest do
+  @moduledoc """
+  US-37.4: the per-tenant BATCH embedding worker drains a tenant's pending records
+  in array batches of up to `embedding_batch_max` (~100), issuing
+  `ceil(N / batch_max)` provider calls instead of N.
+  """
+  use Loopctl.DataCase, async: true
+  use Oban.Testing, repo: Loopctl.Repo
+
+  setup :verify_on_exit!
+
+  import Mox
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge
+  alias Loopctl.Memory
+  alias Loopctl.Memory.Memory, as: MemorySchema
+  alias Loopctl.Workers.BatchEmbeddingWorker
+
+  defp job(tenant_id, kind) do
+    %Oban.Job{
+      id: System.unique_integer([:positive]),
+      args: %{"tenant_id" => tenant_id, "kind" => kind}
+    }
+  end
+
+  # Insert N un-embedded long-term memories directly (no remember/2 → no inline
+  # enqueue), one query.
+  defp seed_memories(tenant_id, n) do
+    now = DateTime.utc_now()
+
+    rows =
+      for i <- 1..n do
+        %{
+          id: Ecto.UUID.generate(),
+          tenant_id: tenant_id,
+          subject_id: "subj",
+          text: "durable fact number #{i}",
+          confidence: 1.0,
+          source: :explicit,
+          tags: [],
+          metadata: %{},
+          inserted_at: now,
+          updated_at: now
+        }
+      end
+
+    {count, _} = AdminRepo.insert_all(MemorySchema, rows)
+    count
+  end
+
+  # Deterministic 1536-dim vector seeded by the input text — lets a single-text
+  # call and a batched call be compared for byte-identical vectors per index.
+  defp det_vec(text) do
+    base = :erlang.phash2(text, 100_000) / 100_000
+    List.duplicate(base, 1536)
+  end
+
+  describe "AC-37.4.2: M records → ceil(M/batch_max) provider calls" do
+    test "TC-37.4.2: 250 memories with batch_max=100 → exactly 3 array calls, not 250" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      assert 250 = seed_memories(tenant.id, 250)
+
+      # EXACTLY 3 batched calls expected (ceil(250/100)); verify_on_exit! fails on
+      # 250 (per-item) or any other count. Each call returns one vector per input.
+      expect(Loopctl.MockEmbeddingClient, :generate_embeddings, 3, fn _tenant_id, texts ->
+        assert length(texts) <= 100
+        {:ok, Enum.map(texts, fn _ -> List.duplicate(0.1, 1536) end)}
+      end)
+
+      assert :ok = BatchEmbeddingWorker.perform(job(tenant.id, "memory"))
+
+      # Every memory got embedded — the pending set is drained.
+      assert [] = Memory.list_memories_pending_embedding(tenant.id, 500)
+    end
+  end
+
+  describe "AC-37.4.3: correctness — single vs batched vectors are identical per index" do
+    test "TC-37.4.3: the guarded single and batch paths return the same vector per input" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      # Same deterministic function drives both the single and the batch stub.
+      stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, text ->
+        {:ok, det_vec(text)}
+      end)
+
+      stub(Loopctl.MockEmbeddingClient, :generate_embeddings, fn _tenant_id, texts ->
+        {:ok, Enum.map(texts, &det_vec/1)}
+      end)
+
+      texts = ["alpha fact", "beta fact", "gamma fact"]
+
+      singles =
+        Enum.map(texts, fn t ->
+          {:ok, v} = Knowledge.generate_embedding(tenant.id, t)
+          v
+        end)
+
+      assert {:ok, batched} = Knowledge.generate_embeddings(tenant.id, texts)
+
+      # Equality PER INDEX (order preserved).
+      assert batched == singles
+
+      Enum.zip(batched, singles)
+      |> Enum.each(fn {b, s} -> assert b == s end)
+    end
+
+    test "the worker stores a non-nil embedding for every drained memory" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+      seed_memories(tenant.id, 3)
+
+      stub(Loopctl.MockEmbeddingClient, :generate_embeddings, fn _tenant_id, texts ->
+        {:ok, Enum.map(texts, &det_vec/1)}
+      end)
+
+      assert :ok = BatchEmbeddingWorker.perform(job(tenant.id, "memory"))
+
+      memories = AdminRepo.all(MemorySchema)
+
+      assert length(memories) == 3
+
+      Enum.each(memories, fn m ->
+        {:ok, reloaded} = Memory.get_memory_for_embedding(tenant.id, m.id)
+        refute is_nil(reloaded.embedding)
+        assert is_binary(reloaded.embedding_content_hash)
+      end)
+    end
+  end
+
+  describe "AC-37.4.3 / TC-37.4.4: a provider error writes NO vectors (batch fails as a unit)" do
+    test "a mid-batch provider error leaves every memory un-embedded and errors for retry" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+      seed_memories(tenant.id, 3)
+
+      expect(Loopctl.MockEmbeddingClient, :generate_embeddings, fn _tenant_id, _texts ->
+        {:error, {:api_error, 500, :provider_error}}
+      end)
+
+      # Transient 5xx → the whole batch errors so Oban retries it as a unit.
+      assert {:error, {:api_error, 500, :provider_error}} =
+               BatchEmbeddingWorker.perform(job(tenant.id, "memory"))
+
+      # NO partial writes: all three memories are still pending (embedding NULL).
+      assert length(Memory.list_memories_pending_embedding(tenant.id, 10)) == 3
+    end
+
+    test "a permanent 4xx discards the batch (no retry, no writes)" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+      seed_memories(tenant.id, 2)
+
+      expect(Loopctl.MockEmbeddingClient, :generate_embeddings, fn _tenant_id, _texts ->
+        {:error, {:api_error, 401, :provider_error}}
+      end)
+
+      assert {:discard, {:embedding_permanent_error, {:api_error, 401, _}}} =
+               BatchEmbeddingWorker.perform(job(tenant.id, "memory"))
+
+      assert length(Memory.list_memories_pending_embedding(tenant.id, 10)) == 2
+    end
+
+    test "a keyless tenant (mandatory BYO) discards cleanly and writes nothing" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+      seed_memories(tenant.id, 2)
+
+      expect(Loopctl.MockEmbeddingClient, :generate_embeddings, fn _tenant_id, _texts ->
+        {:error, :no_api_key}
+      end)
+
+      assert {:discard, {:no_embedding_key, "memory"}} =
+               BatchEmbeddingWorker.perform(job(tenant.id, "memory"))
+
+      assert length(Memory.list_memories_pending_embedding(tenant.id, 10)) == 2
+    end
+  end
+
+  describe "AC-37.4.4: tenant isolation — a batch contains exactly one tenant's texts" do
+    test "running the drainer for tenant A never embeds or reads tenant B's texts" do
+      a = fixture(:tenant)
+      b = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(a.id)
+      Knowledge.reset_circuit_breaker(b.id)
+
+      seed_memories(a.id, 2)
+      seed_memories(b.id, 2)
+
+      test_pid = self()
+
+      stub(Loopctl.MockEmbeddingClient, :generate_embeddings, fn _tenant_id, texts ->
+        send(test_pid, {:batch_texts, texts})
+        {:ok, Enum.map(texts, &det_vec/1)}
+      end)
+
+      assert :ok = BatchEmbeddingWorker.perform(job(a.id, "memory"))
+
+      assert_received {:batch_texts, texts}
+      # A's texts ONLY — exactly A's 2 records, B's are never in the array
+      # (AC-37.4.4 isolation). B has 2 pending too, so a leak would make this 4.
+      assert length(texts) == 2
+      assert Enum.all?(texts, &String.contains?(&1, "durable fact"))
+
+      # B's memories are untouched (still pending); A's are all embedded.
+      assert Memory.list_memories_pending_embedding(a.id, 10) == []
+      assert length(Memory.list_memories_pending_embedding(b.id, 10)) == 2
+    end
+  end
+
+  describe "empty pending set" do
+    test "returns :ok without any provider call when nothing is pending" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      expect(Loopctl.MockEmbeddingClient, :generate_embeddings, 0, fn _tenant_id, _texts ->
+        {:ok, []}
+      end)
+
+      assert :ok = BatchEmbeddingWorker.perform(job(tenant.id, "memory"))
+    end
+  end
+end

--- a/test/loopctl/workers/pending_embedding_sweep_worker_test.exs
+++ b/test/loopctl/workers/pending_embedding_sweep_worker_test.exs
@@ -1,0 +1,109 @@
+defmodule Loopctl.Workers.PendingEmbeddingSweepWorkerTest do
+  @moduledoc """
+  US-37.4 (review HIGH #1): the periodic backstop re-enqueues a per-tenant
+  BatchEmbeddingWorker drainer for any tenant that still has un-embedded records,
+  so a coalesced drainer deduped away after a post-drain write can't strand
+  records (indefinitely for memories, which have no other re-embed path).
+  """
+  use Loopctl.DataCase, async: true
+  use Oban.Testing, repo: Loopctl.Repo
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Memory.Memory, as: MemorySchema
+  alias Loopctl.Workers.BatchEmbeddingWorker
+  alias Loopctl.Workers.PendingEmbeddingSweepWorker
+
+  defp seed_memory(tenant_id) do
+    now = DateTime.utc_now()
+
+    {1, _} =
+      AdminRepo.insert_all(MemorySchema, [
+        %{
+          id: Ecto.UUID.generate(),
+          tenant_id: tenant_id,
+          subject_id: "subj",
+          text: "pending fact",
+          confidence: 1.0,
+          source: :explicit,
+          tags: [],
+          metadata: %{},
+          inserted_at: now,
+          updated_at: now
+        }
+      ])
+
+    :ok
+  end
+
+  defp seed_published_article(tenant_id, overrides) do
+    now = DateTime.utc_now()
+
+    row =
+      Map.merge(
+        %{
+          id: Ecto.UUID.generate(),
+          tenant_id: tenant_id,
+          title: "Pending Article",
+          body: "body",
+          category: :pattern,
+          status: :published,
+          scope: :tenant,
+          slug: "pending-#{System.unique_integer([:positive])}",
+          tags: [],
+          metadata: %{},
+          inserted_at: now,
+          updated_at: now
+        },
+        overrides
+      )
+
+    {1, _} = AdminRepo.insert_all(Article, [row])
+    :ok
+  end
+
+  test "enqueues a drainer for a tenant with pending memories" do
+    tenant = fixture(:tenant)
+    seed_memory(tenant.id)
+
+    Oban.Testing.with_testing_mode(:manual, fn ->
+      assert :ok = PendingEmbeddingSweepWorker.perform(%Oban.Job{args: %{}})
+
+      assert_enqueued(worker: BatchEmbeddingWorker, args: %{tenant_id: tenant.id, kind: "memory"})
+    end)
+  end
+
+  test "enqueues a drainer for a tenant with a content-stale published article (embedding intact)" do
+    tenant = fixture(:tenant)
+    # An embedded-but-stale article: vector present, embedding_stale_at set. The
+    # backstop must still re-enqueue it (review MED #2 keeps the vector alive).
+    seed_published_article(tenant.id, %{
+      embedding_content_hash: "abc",
+      embedding_stale_at: DateTime.utc_now()
+    })
+
+    Oban.Testing.with_testing_mode(:manual, fn ->
+      assert :ok = PendingEmbeddingSweepWorker.perform(%Oban.Job{args: %{}})
+
+      assert_enqueued(
+        worker: BatchEmbeddingWorker,
+        args: %{tenant_id: tenant.id, kind: "article"}
+      )
+    end)
+  end
+
+  test "enqueues no drainer for a tenant that has no pending work" do
+    tenant = fixture(:tenant)
+
+    Oban.Testing.with_testing_mode(:manual, fn ->
+      assert :ok = PendingEmbeddingSweepWorker.perform(%Oban.Job{args: %{}})
+
+      refute_enqueued(worker: BatchEmbeddingWorker, args: %{tenant_id: tenant.id, kind: "memory"})
+
+      refute_enqueued(
+        worker: BatchEmbeddingWorker,
+        args: %{tenant_id: tenant.id, kind: "article"}
+      )
+    end)
+  end
+end

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -137,6 +137,12 @@ defmodule Loopctl.DataCase do
       {:ok, List.duplicate(0.1, 1536)}
     end)
 
+    # US-37.4: default stub for the BATCH embedding path -- returns one 1536-dim
+    # vector of 0.1 per input text, in input order (matching the single-text stub).
+    Mox.stub(Loopctl.MockEmbeddingClient, :generate_embeddings, fn _tenant_id, texts ->
+      {:ok, Enum.map(texts, fn _ -> List.duplicate(0.1, 1536) end)}
+    end)
+
     # US-37.2: permissive default for the per-node embedding concurrency gate --
     # acquire/1 always grants a slot, release/1 is a no-op -- so every existing
     # embedding/search test runs under the cap unchanged. The saturation test


### PR DESCRIPTION
## US-37.4 — Batch background embeddings into arrays (~100), map results back by index

Background embedding previously issued one provider round-trip per record
(`ArticleEmbeddingWorker`/`MemoryEmbeddingWorker` per-item fan-out). Under bulk
ingest that is N calls for N records. This adds an array batch path that sends
`input` as a list of up to a config-driven max (~100) texts in ONE `Req.post` and
maps each returned vector back to its input **by the response `index` field**
(never by array position), cutting provider round-trips ~100x. Same model, same
per-text vector — an efficiency change, not a semantic one. The interactive
single-query path stays single-text and byte-for-byte unchanged.

### What changed
- **`EmbeddingClient.generate_embeddings/2`** (+ behaviour callback + default test
  stub): sends `input` as an array, reassembles vectors in input order from each
  entry's `index` (out-of-order `data` handled), one admission token per batch,
  empty list short-circuits with no call.
- **`Knowledge.generate_embeddings/3`**: guarded batch entry that shares the
  single-text circuit breaker, takes ONE US-37.2 concurrency slot for the whole
  batch, and records the `[:loopctl, :llm, :provider_error]` signal once per batch.
- **`Loopctl.Workers.BatchEmbeddingWorker`** (new): per-tenant drainer (unique per
  `tenant+kind`) that embeds a tenant's pending records in chunks of `batch_max`,
  issuing `ceil(N/batch_max)` calls per run. Atomic — a provider error writes no
  vectors and retries the batch as a unit. Preserves content-hash idempotency,
  BYO / permanent-error / rate-limit semantics, the US-36.2 fair-share gate, and
  tenant isolation (a batch array holds exactly one tenant's texts).
- **Enqueue sites** (article create/update/publish, bulk publish, content
  ingestion, memory `remember`) now enqueue the batch worker. Pending set is
  `embedding IS NULL`; a content change re-nulls the vector so the record
  re-enters the set (deliberately not a `hash IS NULL` predicate, which would
  loop-re-embed `update_embedding/3`'s valid nil-hash writes).
- **Migration** seeds `embedding_batch_max` = 100 (live-tunable via SystemConfig;
  in-code default applies on cache miss).
- The single-item workers are retained as the one-record embedding primitive
  (still exercised by the fair-share gate tests) and documented as superseded for
  background use.

### Acceptance criteria
- **AC-37.4.1** — array `input`, index-mapped reassembly, order preserved. Client
  test drives the real `EmbeddingClient` with deliberately out-of-order `data`.
- **AC-37.4.2** — background embedding uses the batch path; test asserts 250
  records → exactly 3 provider calls (not 250).
- **AC-37.4.3** — single-vs-batch vectors identical per index (deterministic
  stub); a provider error writes no vectors and errors/retries as a unit.
- **AC-37.4.4** — env-driven batch size, one token per batch, tenant isolation,
  no `Application.put_env` in tests.

### Quality gate
`mix precommit` green (compile clean, format, credo --strict, dialyzer, full
test — 4572 tests, 0 failures). New tests in
`test/loopctl/knowledge/embedding_client_test.exs` and
`test/loopctl/workers/batch_embedding_worker_test.exs`; three enqueue tests in
`article_embedding_worker_test.exs` updated to the batch path.

Note: the suite contains a pre-existing seed-dependent flake in
`memory_promotion_worker_test.exs` (Mox async-supervisor `$callers` race,
unrelated to this change) that passes in isolation and on most seeds.
