### PR TITLE
Per-tenant in-flight concurrency cap + cost-weighted limiter on the HeavyRead pool

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -314,15 +314,20 @@ config :loopctl, :embedding_max_concurrent, 64
 # LOW per-tenant cap via acquire/3. Production uses the config.exs default (6).
 config :loopctl, :embedding_max_concurrent_per_tenant, 64
 
-# US-37.5: high suite-wide default for the per-tenant in-flight HeavyRead cap (K) so
-# the gate wired into Loopctl.HeavyRead.all/one/all_memory is effectively a NO-OP for
-# incidental heavy reads across the async suite — they must not collide on the shared,
-# VM-wide per-tenant counters and spuriously shed. The gate's OWN unit test
-# (tenant_gate_test.exs) passes explicit LOW caps to acquire/3, independent of this
+# US-37.5: suite-wide default for the per-tenant in-flight HeavyRead cap (K). Set to
+# the clamp CEILING (`pool - 1`, pool = Loopctl.DbCapacity.heavy_read_budget().pool = 8),
+# the highest value `TenantGate.cap/0`'s `clamp_cap/1` admits — so the gate wired into
+# Loopctl.HeavyRead.all/one/all_memory stays as permissive as possible for incidental
+# heavy reads across the async suite (each test uses a UNIQUE fixture tenant, so
+# per-tenant, VM-wide counters do not collide across tests; a single test would need
+# >7 units of concurrent SAME-tenant heavy-read weight to shed). A former sentinel
+# (100_000) is no longer usable: `cap/0` now clamps any out-of-range value into
+# `[heavy_weight, pool - 1]` and LOGS on clamp, so an out-of-range test cap would spam
+# warnings on every heavy read AND still resolve to 7. The gate's OWN unit test
+# (tenant_gate_test.exs) passes explicit LOW caps to acquire/4, independent of this
 # value. Production uses Loopctl.DbCapacity.heavy_read_tenant_slice/0 (4), live-tunable
-# via the "heavy_read_tenant_cap" SystemConfig key. Mirrors the embedding/export
-# high-suite-cap precedent above.
-config :loopctl, :heavy_read_tenant_cap, 100_000
+# via the "heavy_read_tenant_cap" SystemConfig key.
+config :loopctl, :heavy_read_tenant_cap, 7
 
 # US-28.2: a small per-(tenant, subject) long-term memory cap so the quota path
 # (`{:error, :quota_exceeded}`) is testable without inserting tens of thousands of

--- a/config/test.exs
+++ b/config/test.exs
@@ -314,6 +314,16 @@ config :loopctl, :embedding_max_concurrent, 64
 # LOW per-tenant cap via acquire/3. Production uses the config.exs default (6).
 config :loopctl, :embedding_max_concurrent_per_tenant, 64
 
+# US-37.5: high suite-wide default for the per-tenant in-flight HeavyRead cap (K) so
+# the gate wired into Loopctl.HeavyRead.all/one/all_memory is effectively a NO-OP for
+# incidental heavy reads across the async suite — they must not collide on the shared,
+# VM-wide per-tenant counters and spuriously shed. The gate's OWN unit test
+# (tenant_gate_test.exs) passes explicit LOW caps to acquire/3, independent of this
+# value. Production uses Loopctl.DbCapacity.heavy_read_tenant_slice/0 (4), live-tunable
+# via the "heavy_read_tenant_cap" SystemConfig key. Mirrors the embedding/export
+# high-suite-cap precedent above.
+config :loopctl, :heavy_read_tenant_cap, 100_000
+
 # US-28.2: a small per-(tenant, subject) long-term memory cap so the quota path
 # (`{:error, :quota_exceeded}`) is testable without inserting tens of thousands of
 # rows. Kept above the largest pagination test (25 rows) so that test stays under

--- a/lib/loopctl/application.ex
+++ b/lib/loopctl/application.ex
@@ -36,6 +36,13 @@ defmodule Loopctl.Application do
       # jobs). Purely additive — the per-minute cron is unchanged.
       Loopctl.AuditChain.SthEnqueuer,
       Loopctl.RateLimiter.Server,
+      # US-37.5: owns the public ETS table holding the per-tenant in-flight HeavyRead
+      # counters so a stable, long-lived owner survives the transient request/worker
+      # process that incremented one. acquire/release BYPASS this owner (lock-free
+      # :ets.update_counter on the hot read path); it exists only to own the table.
+      # Node-local per-tenant, cost-weighted cap on the BYPASSRLS heavy-read pool so
+      # one tenant's vector/analytic burst can't 503 every other tenant (GH #354).
+      Loopctl.HeavyRead.TenantGate,
       # US-27.16: owns the ETS table tracking in-flight streaming-export slots so a
       # crashed exporter's slot is reclaimed (concurrency cap, AC-27.16.6).
       Loopctl.Knowledge.ExportConcurrency,

--- a/lib/loopctl/db_capacity.ex
+++ b/lib/loopctl/db_capacity.ex
@@ -61,6 +61,19 @@ defmodule Loopctl.DbCapacity do
   @heavy_read_fast_reads 6
   @heavy_read_export_reserve 2
 
+  # US-37.5: the per-tenant in-flight SLICE (K) of the heavy-read pool. No single
+  # tenant's concurrent, cost-weighted heavy reads may hold more than K of the pool's
+  # N (=8) slots at once (`Loopctl.HeavyRead.TenantGate`), so a tenant always leaves
+  # `N - K` slots for its neighbours — one tenant's vector/analytic burst can no longer
+  # 503 every other tenant on the shared BYPASSRLS pool. K MUST be `< pool` (a test
+  # pins this) so a tenant can never take the whole pool, and `>= 1` so the gate can
+  # never starve a tenant to zero heavy reads. K=4 (~half of 8) leaves at least 4 slots
+  # for other tenants while giving any one tenant ample concurrency (2 heavy reads at
+  # weight 2, or 4 light reads at weight 1). Live-tunable per node via the
+  # `"heavy_read_tenant_cap"` SystemConfig key / `:heavy_read_tenant_cap` app env
+  # (see `Loopctl.HeavyRead.TenantGate.cap/0`); this is the documented default.
+  @heavy_read_tenant_slice 4
+
   # The Oban Postgres notifier holds one dedicated LISTEN connection PER NODE (outside
   # the pools). Migrations on deploy + the remote console are a small per-cluster fixed
   # reserve.
@@ -104,6 +117,16 @@ defmodule Loopctl.DbCapacity do
       pool: @heavy_read_fast_reads + @heavy_read_export_reserve
     }
   end
+
+  @doc """
+  The per-tenant in-flight SLICE (K) of the heavy-read pool (US-37.5): the max number
+  of the pool's N slots one tenant's cost-weighted concurrent heavy reads may hold
+  before `Loopctl.HeavyRead.TenantGate` sheds the next one. Always `< heavy_read_budget().pool`
+  (no tenant can take the whole pool) and `>= 1`. The documented default the gate's
+  `cap/0` falls back to on a `SystemConfig`/app-env miss.
+  """
+  @spec heavy_read_tenant_slice() :: pos_integer()
+  def heavy_read_tenant_slice, do: @heavy_read_tenant_slice
 
   @doc "The last fly-mpg `SHOW max_connections` value verified by a human (see moduledoc)."
   @spec verified_live_max_connections() :: pos_integer()

--- a/lib/loopctl/heavy_read.ex
+++ b/lib/loopctl/heavy_read.ex
@@ -54,6 +54,8 @@ defmodule Loopctl.HeavyRead do
   docs/runbooks/knowledge-scale.md.
   """
 
+  alias Loopctl.HeavyRead.TenantGate
+
   @doc "Resolved heavy-read repo (DI). `HeavyReadRepo` in prod/dev, `AdminRepo` in test."
   @spec repo() :: module()
   def repo, do: Application.get_env(:loopctl, :heavy_read_repo, Loopctl.HeavyReadRepo)
@@ -127,23 +129,33 @@ defmodule Loopctl.HeavyRead do
   (there is no un-timed "pool default" path: pgbouncer rejects a startup-`:parameters`
   statement_timeout, so the timeout MUST be applied per-read via SET LOCAL — US-27.13).
   """
-  @spec all(binary(), Ecto.Queryable.t(), keyword()) :: [term()]
+  @spec all(binary(), Ecto.Queryable.t(), keyword()) ::
+          [term()] | {:error, :heavy_read_overloaded}
   def all(tenant_id, queryable, opts \\ []) do
     # `Keyword.pop/3` with a default cleanly distinguishes "absent → pool default" from a
     # PRESENT value (which is validated as a positive int below) — unlike `st || default`,
     # which would silently treat an explicit `0` as truthy and an explicit `nil` as "use
     # default", muddying the always-timed contract.
     {st, opts} = Keyword.pop(opts, :statement_timeout, default_statement_timeout())
+    {on_overload, opts} = Keyword.pop(opts, :on_overload, :raise)
     query = guard!(tenant_id, queryable)
-    with_statement_timeout(st, fn -> repo().all(query, opts) end)
+
+    gated(tenant_id, opts, on_overload, fn ->
+      with_statement_timeout(st, fn -> repo().all(query, opts) end)
+    end)
   end
 
   @doc "Like `Repo.one/2`, with the same tenant-scoping guard and `:statement_timeout` as `all/3`."
-  @spec one(binary(), Ecto.Queryable.t(), keyword()) :: term() | nil
+  @spec one(binary(), Ecto.Queryable.t(), keyword()) ::
+          term() | nil | {:error, :heavy_read_overloaded}
   def one(tenant_id, queryable, opts \\ []) do
     {st, opts} = Keyword.pop(opts, :statement_timeout, default_statement_timeout())
+    {on_overload, opts} = Keyword.pop(opts, :on_overload, :raise)
     query = guard!(tenant_id, queryable)
-    with_statement_timeout(st, fn -> repo().one(query, opts) end)
+
+    gated(tenant_id, opts, on_overload, fn ->
+      with_statement_timeout(st, fn -> repo().one(query, opts) end)
+    end)
   end
 
   @doc """
@@ -167,11 +179,62 @@ defmodule Loopctl.HeavyRead do
   cross-subject row is ever RETURNED, which is what the isolation boundary needs;
   tenant remains enforced on every source (the cross-tenant boundary).
   """
-  @spec all_memory(binary(), binary(), Ecto.Queryable.t(), keyword()) :: [term()]
+  @spec all_memory(binary(), binary(), Ecto.Queryable.t(), keyword()) ::
+          [term()] | {:error, :heavy_read_overloaded}
   def all_memory(tenant_id, subject_id, queryable, opts \\ []) do
     {st, opts} = Keyword.pop(opts, :statement_timeout, default_statement_timeout())
+    {on_overload, opts} = Keyword.pop(opts, :on_overload, :raise)
     query = guard_memory!(tenant_id, subject_id, queryable)
-    with_statement_timeout(st, fn -> repo().all(query, opts) end)
+
+    gated(tenant_id, opts, on_overload, fn ->
+      with_statement_timeout(st, fn -> repo().all(query, opts) end)
+    end)
+  end
+
+  # --- US-37.5: per-tenant cost-weighted in-flight limiter ---
+
+  # Wrap a heavy read with the per-tenant, cost-weighted in-flight gate
+  # (`Loopctl.HeavyRead.TenantGate`): reserve `weight` of the tenant's budget BEFORE
+  # the pool checkout, run, then RELEASE in an `after` so a query that raises (a
+  # statement_timeout CANCEL, a DB error) or times out never leaks budget. The weight
+  # is derived from the endpoint carried in `opts`' `telemetry_options` (heavy
+  # vector/analytic reads cost more than light ones); the cap (K) is the node-local
+  # per-tenant slice from config.
+  #
+  # Over the cap the acquire sheds the read (never a pool-exhaustion crash for OTHER
+  # tenants): `on_overload: :raise` (the default, for API reads) raises
+  # `OverloadedError` → a 429 with the app error envelope; `on_overload: :tag` (search
+  # callers that keyword-fall-back) returns `{:error, :heavy_read_overloaded}`. The
+  # gate itself FAILS OPEN on a limiter fault (allows the read), so a broken gate never
+  # blocks all heavy reads.
+  defp gated(tenant_id, opts, on_overload, fun) do
+    weight = TenantGate.weight_for(endpoint(opts))
+
+    case TenantGate.acquire(tenant_id, weight, TenantGate.cap()) do
+      :ok ->
+        try do
+          fun.()
+        after
+          TenantGate.release(tenant_id, weight)
+        end
+
+      {:error, :heavy_read_overloaded} = err ->
+        shed(on_overload, err, tenant_id)
+    end
+  end
+
+  defp shed(:tag, err, _tenant_id), do: err
+
+  defp shed(:raise, _err, tenant_id) do
+    raise Loopctl.HeavyRead.OverloadedError, tenant_id: tenant_id
+  end
+
+  # The endpoint atom `opts/1` stamps into `telemetry_options` — the natural per-query
+  # weight key. Absent (a bare call with no `opts/1`) → nil → TenantGate weights it light.
+  defp endpoint(opts) do
+    opts
+    |> Keyword.get(:telemetry_options, [])
+    |> Keyword.get(:endpoint)
   end
 
   # Run `fun` under a per-read SET LOCAL statement_timeout. There is NO un-timed path:

--- a/lib/loopctl/heavy_read.ex
+++ b/lib/loopctl/heavy_read.ex
@@ -86,7 +86,9 @@ defmodule Loopctl.HeavyRead do
   `GET /knowledge/ingestion-jobs` COUNT + list over the Oban-owned `oban_jobs` table,
   bounded by a partial expression index), `:sth_incremental` (the US-35.1 bounded
   "entries above the STH checkpoint" tail read over `audit_chain`, folded into the
-  persisted Merkle peaks), and `:export` (the US-27.16 long streamed-export scans).
+  persisted Merkle peaks), `:export` (the US-27.16 long streamed-export scans), and
+  `:llm_usage` (the customer-facing LLM-usage aggregate over `llm_usage_events`, a
+  bounded indexed COUNT/GROUP BY — classified LIGHT by the gate).
   """
   @spec opts(atom()) :: keyword()
   def opts(endpoint) when is_atom(endpoint) do
@@ -114,6 +116,7 @@ defmodule Loopctl.HeavyRead do
     ingestion_jobs
     sth_incremental
     export
+    llm_usage
   )a
 
   @doc """
@@ -309,6 +312,21 @@ defmodule Loopctl.HeavyRead do
   precisely to AVOID holding one transaction (and `xmin`) for the whole client-paced
   download. `stream/3` + `transaction/2` are reserved for a future async/Oban export
   job that builds to object storage off the request path.
+
+  ## GATE EXEMPTION (US-37.5) — deliberate, and the future caller's responsibility
+
+  Unlike `all/3` / `one/3` / `all_memory/4`, `stream/3` is NOT wrapped in the per-tenant
+  `TenantGate` in-flight limiter. Wrapping it correctly is not a simple acquire→run→release
+  `after`: a stream returns a LAZY `Enumerable` enumerated later inside an enclosing
+  `transaction/2`, so the pool connection is held for the whole (client-paced) enumeration,
+  not for this call — a synchronous acquire/release around this function would release the
+  budget BEFORE the read actually runs. It is left ungated ON PURPOSE because there is no
+  production request-path caller today (see the moduledoc: reserved for a future off-request
+  async/Oban export job). That future caller MUST acquire the gate itself for the duration of
+  the enumeration — `TenantGate.acquire(tenant_id, weight, TenantGate.cap())` before opening
+  the transaction and `release/2` in an `after` around the whole stream — or route the read
+  through `all/3` keyset paging (which IS gated) as the current export does. Do NOT add a
+  request-path `stream/3` caller without one of those.
   """
   @spec stream(binary(), Ecto.Queryable.t(), keyword()) :: Enumerable.t()
   def stream(tenant_id, queryable, opts \\ []) do
@@ -325,6 +343,13 @@ defmodule Loopctl.HeavyRead do
   relaxing it for everyone else. `0`/unlimited is intentionally NOT allowed (an
   unbounded hold on the small heavy pool is a DoS surface — set an explicit upper
   bound). Only supported with a 0- or 1-arity function (not an `Ecto.Multi`).
+
+  GATE EXEMPTION (US-37.5): this bare `transaction/2` lever is NOT wrapped in the
+  per-tenant `TenantGate` limiter (it has no `tenant_id` argument and holds the connection
+  for the whole caller-supplied body). Like `stream/3`, it is reserved for a future
+  off-request export job; that caller MUST acquire/release the gate around the transaction
+  itself (see `stream/3`'s "GATE EXEMPTION" note) so a `stream/3` read taken through it is
+  still bounded by the per-tenant slice. Do NOT add a request-path caller without it.
   """
   @spec transaction((-> any()) | (module() -> any()) | Ecto.Multi.t(), keyword()) ::
           {:ok, any()} | {:error, any()}

--- a/lib/loopctl/heavy_read.ex
+++ b/lib/loopctl/heavy_read.ex
@@ -77,21 +77,54 @@ defmodule Loopctl.HeavyRead do
   This is the SINGLE source of truth for heavy-read opts — every consumer
   (`Loopctl.Knowledge`, `Loopctl.Audit`) builds opts via this function so the
   `[timeout, telemetry_options, statement_timeout]` shape can't drift between callers.
-  Known endpoints: `:suggested_links`, `:semantic_search`, `:distant_pairs`,
-  `:distant_pairs_bridge` (the slower `bridge_path=true` branch — its own key so its
-  statement_timeout/slow-query telemetry are distinct), `:novelty`, `:enumeration`,
-  `:change_feed`, `:vector_search` (the shared kNN helper path), `:memory_recall`
-  (the US-28.2 agent-memory HNSW recall via `all_memory/4`), `:ingestion_jobs`
-  (the US-34.6 `GET /knowledge/ingestion-jobs` COUNT + list over the Oban-owned
-  `oban_jobs` table, bounded by a partial expression index), `:sth_incremental`
-  (the US-35.1 bounded "entries above the STH checkpoint" tail read over
-  `audit_chain`, folded into the persisted Merkle peaks).
+  Known endpoints are enumerated in `known_endpoints/0`: `:suggested_links`,
+  `:semantic_search`, `:distant_pairs`, `:distant_pairs_bridge` (the slower
+  `bridge_path=true` branch — its own key so its statement_timeout/slow-query
+  telemetry are distinct), `:novelty`, `:enumeration`, `:change_feed`,
+  `:vector_search` (the shared kNN helper path), `:memory_recall` (the US-28.2
+  agent-memory HNSW recall via `all_memory/4`), `:ingestion_jobs` (the US-34.6
+  `GET /knowledge/ingestion-jobs` COUNT + list over the Oban-owned `oban_jobs` table,
+  bounded by a partial expression index), `:sth_incremental` (the US-35.1 bounded
+  "entries above the STH checkpoint" tail read over `audit_chain`, folded into the
+  persisted Merkle peaks), and `:export` (the US-27.16 long streamed-export scans).
   """
   @spec opts(atom()) :: keyword()
   def opts(endpoint) when is_atom(endpoint) do
     base = [timeout: 15_000, telemetry_options: [endpoint: endpoint]]
     Keyword.put(base, :statement_timeout, statement_timeout_for(endpoint))
   end
+
+  # Every endpoint atom a caller passes to `opts/1` / stamps into `telemetry_options`.
+  # `opts/1` itself accepts ANY atom (the timeout defaults are endpoint-agnostic), but
+  # `Loopctl.HeavyRead.TenantGate.weight_for/1` partitions these into heavy vs light
+  # cost weights — so this list is the SOURCE OF TRUTH the gate's drift guard
+  # (`tenant_gate_test.exs`) checks its `@heavy_endpoints` against: a new endpoint
+  # added here without a deliberate heavy/light weight decision fails that test rather
+  # than silently defaulting to light weight and under-charging a heavy read.
+  @known_endpoints ~w(
+    suggested_links
+    semantic_search
+    distant_pairs
+    distant_pairs_bridge
+    novelty
+    enumeration
+    change_feed
+    vector_search
+    memory_recall
+    ingestion_jobs
+    sth_incremental
+    export
+  )a
+
+  @doc """
+  The known heavy-read endpoint atoms (documented in `opts/1`).
+
+  The canonical set `Loopctl.HeavyRead.TenantGate` assigns cost weights to; the gate's
+  drift guard test partitions exactly this set into heavy vs light so a newly-added
+  endpoint can't silently fall through to light weight.
+  """
+  @spec known_endpoints() :: [atom()]
+  def known_endpoints, do: @known_endpoints
 
   # The per-endpoint override if a positive int, else the pool-wide default. Always a
   # positive int → every heavy read runs under a SET LOCAL statement_timeout (the

--- a/lib/loopctl/heavy_read/overloaded_error.ex
+++ b/lib/loopctl/heavy_read/overloaded_error.ex
@@ -1,0 +1,21 @@
+defmodule Loopctl.HeavyRead.OverloadedError do
+  @moduledoc """
+  Raised when a tenant is over its per-tenant in-flight HeavyRead cap (US-37.5).
+
+  `Loopctl.HeavyRead.all/3` / `one/3` / `all_memory/4` raise this (the default
+  over-cap behaviour, `on_overload: :raise`) when
+  `Loopctl.HeavyRead.TenantGate.acquire/3` sheds the read, so an API read degrades to
+  a clean 429 (with the app error envelope) instead of a pool-exhaustion crash for
+  OTHER tenants. The web status mapping lives in
+  `LoopctlWeb.Plugs.HeavyReadOverloadHandler` (a `Plug.Exception` impl → 429, the
+  same pattern as `LoopctlWeb.Plugs.DBErrorHandler`), and the body is rendered by
+  `LoopctlWeb.ErrorJSON` (`"429.json"`).
+
+  Search callers that degrade to keyword fallback instead pass `on_overload: :tag`
+  and receive `{:error, :heavy_read_overloaded}` rather than this raise.
+
+  The message and `tenant_id` are safe to log — no query, params, or vector text.
+  """
+  defexception message: "heavy-read pool over the per-tenant in-flight capacity for this tenant",
+               tenant_id: nil
+end

--- a/lib/loopctl/heavy_read/tenant_gate.ex
+++ b/lib/loopctl/heavy_read/tenant_gate.ex
@@ -72,12 +72,20 @@ defmodule Loopctl.HeavyRead.TenantGate do
   `acquire/3` returns `:ok` (allow the read), `release/2` returns `:ok`. An
   unmeasurable limiter degrades to "no limit", never to "all reads blocked".
 
-  By contrast, a MALFORMED CAP fails LOUD: `cap/0`/`weight_for/1` read config
-  OUTSIDE any rescue, so a bad `heavy_read_tenant_cap` (a non-positive int) surfaces
-  rather than being swallowed into a silent fail-open that disables fairness during
-  the very incident an operator is tuning. `Loopctl.SystemConfig.get_int/2` itself
-  never raises (returns the default on miss), and the app-env default is a positive
-  literal, so in practice the cap is always valid.
+  A MALFORMED CAP is CLAMPED (not trusted, not fail-loud): `cap/0` runs the
+  live-tunable `"heavy_read_tenant_cap"` value through `clamp_cap/1` into the
+  structurally valid range `[heavy_weight/0, pool - 1]` — logging a warning when it
+  clamps. This is deliberate and load-bearing for AC-37.5.5: an operator setting a
+  NON-POSITIVE cap (`0`/negative) would otherwise make `acquire/4`'s `cap > 0` guard
+  match no clause and raise a `FunctionClauseError` — which is NOT an
+  `OverloadedError`, so the 429 handler never fires and EVERY heavy read on the node
+  500s (the exact "limiter fault blocks all heavy reads" AC-37.5.5 forbids). Flooring
+  at `heavy_weight/0` also prevents a `K < heavy_weight` value making every heavy read
+  shed for all tenants, and the `pool - 1` ceiling stops a `K >= pool` value silently
+  re-enabling the single-tenant monopolization this gate exists to prevent (it
+  guarantees `N - K >= 1` slots always remain for neighbours). `Loopctl.SystemConfig.get_int/2`
+  itself never raises (returns the default on miss); the clamp turns any out-of-range
+  operator knob into a safe, logged value rather than a node-wide outage.
 
   ## Config — env-driven, live-tunable, node-local (AC-37.5.5)
 
@@ -132,10 +140,16 @@ defmodule Loopctl.HeavyRead.TenantGate do
 
   # HeavyRead endpoints whose queries are the EXPENSIVE ones — vector/kNN scans,
   # semantic ranking, HNSW memory recall, the novelty/suggested-links ANN probes,
-  # and the distant-pairs analytic reads. They consume `heavy_weight/0` of a tenant's
-  # in-flight budget; every other (lighter, bounded, fast-releasing) endpoint —
-  # change feed, enumeration, ingestion-jobs count, STH tail, LLM usage — consumes
-  # `light_weight/0`. Kept in sync with `Loopctl.HeavyRead.opts/1`'s known endpoints.
+  # the distant-pairs analytic reads, and the long (60s) streamed-export scans. They
+  # consume `heavy_weight/0` of a tenant's in-flight budget; every other (lighter,
+  # bounded, fast-releasing) endpoint — change feed, enumeration, ingestion-jobs
+  # count, STH tail, LLM usage — consumes `light_weight/0`.
+  #
+  # DRIFT GUARD: every atom here MUST be a `Loopctl.HeavyRead.known_endpoints/0`
+  # member, and that full known set is partitioned (heavy vs light) by
+  # `tenant_gate_test.exs`'s endpoint-weight guard — so a NEW heavy endpoint a caller
+  # adds (registered in `known_endpoints/0`) cannot silently fall through
+  # `weight_for/1` to light weight and under-charge a genuinely heavy read.
   @heavy_endpoints ~w(
     vector_search
     semantic_search
@@ -144,6 +158,7 @@ defmodule Loopctl.HeavyRead.TenantGate do
     suggested_links
     distant_pairs
     distant_pairs_bridge
+    export
   )a
 
   # --- Client API ---
@@ -245,12 +260,44 @@ defmodule Loopctl.HeavyRead.TenantGate do
   Live-tunable via the `"heavy_read_tenant_cap"` `SystemConfig` key; on a cache miss
   it falls back to the `:heavy_read_tenant_cap` application env, whose default is
   `Loopctl.DbCapacity.heavy_read_tenant_slice/0` (pinned `< HEAVY_READ_POOL_SIZE`).
-  Read OUTSIDE any rescue so a malformed cap fails loud rather than silently
-  disabling fairness.
+  The configured value is CLAMPED via `clamp_cap/1` into `[heavy_weight/0, pool - 1]`
+  so a malformed operator knob (non-positive → node-wide 500; `< heavy_weight` →
+  every read sheds; `>= pool` → monopolization) is turned into a safe, LOGGED value
+  rather than an outage or a silently-defeated gate (AC-37.5.5). Always returns a
+  positive integer `>= heavy_weight/0`, so `acquire/4`'s `cap > 0` guard always matches.
   """
   @spec cap() :: pos_integer()
   def cap do
-    SystemConfig.get_int(@cap_config_key, cap_default())
+    @cap_config_key
+    |> SystemConfig.get_int(cap_default())
+    |> clamp_cap()
+  end
+
+  @doc """
+  Clamps a configured cap into the structurally valid range `[heavy_weight/0, pool - 1]`,
+  logging a warning when the input was out of range.
+
+  The lower floor (`heavy_weight/0`) guarantees a single heavy read always fits AND
+  keeps `acquire/4`'s `cap > 0` guard satisfied (a non-positive cap would otherwise
+  raise a `FunctionClauseError` OUTSIDE the acquire rescue → a node-wide 500, the
+  AC-37.5.5 fail-open violation). The upper ceiling (`pool - 1`) guarantees at least
+  one pool slot always remains for a tenant's neighbours, so no cap value can
+  re-enable single-tenant monopolization. Exposed for the drift/range guard test.
+  """
+  @spec clamp_cap(integer()) :: pos_integer()
+  def clamp_cap(configured) when is_integer(configured) do
+    lower = heavy_weight()
+    upper = max(lower, pool_size() - 1)
+    clamped = configured |> max(lower) |> min(upper)
+
+    if clamped != configured do
+      Logger.warning(
+        "HeavyRead.TenantGate: configured cap #{inspect(configured)} out of range " <>
+          "[#{lower}, #{upper}] (heavy_weight..pool-1); clamped to #{clamped}"
+      )
+    end
+
+    clamped
   end
 
   @doc """
@@ -265,6 +312,10 @@ defmodule Loopctl.HeavyRead.TenantGate do
   def weight_for(endpoint) when endpoint in @heavy_endpoints, do: heavy_weight()
   def weight_for(_endpoint), do: light_weight()
 
+  @doc "The endpoint atoms weighted `heavy_weight/0` (for the drift/range guard test)."
+  @spec heavy_endpoints() :: [atom()]
+  def heavy_endpoints, do: @heavy_endpoints
+
   @doc "The in-flight budget a HEAVY endpoint's read consumes (env `:heavy_read_weight_heavy`, default #{@default_heavy_weight})."
   @spec heavy_weight() :: pos_integer()
   def heavy_weight, do: Application.get_env(:loopctl, @heavy_weight_env, @default_heavy_weight)
@@ -278,6 +329,11 @@ defmodule Loopctl.HeavyRead.TenantGate do
 
   defp cap_default,
     do: Application.get_env(:loopctl, @cap_env, DbCapacity.heavy_read_tenant_slice())
+
+  # The heavy-read pool size the cap ceiling is derived from (`pool - 1`). The
+  # documented budget (`DbCapacity.heavy_read_budget/0`) is the same reference
+  # `heavy_read_tenant_slice/0` is pinned against, so cap and default stay coherent.
+  defp pool_size, do: DbCapacity.heavy_read_budget().pool
 
   # --- Server callbacks (table-owner only; acquire/release bypass this process) ---
 

--- a/lib/loopctl/heavy_read/tenant_gate.ex
+++ b/lib/loopctl/heavy_read/tenant_gate.ex
@@ -1,0 +1,303 @@
+defmodule Loopctl.HeavyRead.TenantGate do
+  @moduledoc """
+  Per-tenant, cost-weighted, node-local in-flight limiter on the HeavyRead pool
+  (US-37.5, #354).
+
+  ## Why
+
+  Epic 33 gave heavy/BYPASSRLS reads their own isolated Ecto pool
+  (`Loopctl.HeavyReadRepo`, `HEAVY_READ_POOL_SIZE` default 8) with a per-read
+  `SET LOCAL statement_timeout`. But that pool is GLOBAL: one tenant's burst of
+  heavy vector/analytic reads can hold all N connections and effectively 503 every
+  OTHER tenant. `Loopctl.HeavyRead` was only a tenant-scoping GUARD + timeout
+  wrapper, NOT a limiter. The only prior per-tenant fairness
+  (`Loopctl.Oban.FairShare`, US-36.2) bounds Oban *queue* slots, not this
+  synchronous pool.
+
+  This gate is a NODE-LOCAL per-tenant in-flight semaphore: no tenant may hold more
+  than `cap` (K) of the pool's N slots at once, so a tenant always leaves `N - K`
+  slots for its neighbours. It is COST-WEIGHTED — a heavier read (vector/kNN,
+  semantic ranking, memory recall) consumes MORE of a tenant's budget than a light
+  one (change feed, enumeration) — so a tenant can run fewer concurrent heavy reads
+  than light ones within the same K. Over the cap the acquire FAILS FAST with
+  `{:error, :heavy_read_overloaded}` (a bounded-wait-then-shed variant is
+  acceptable); `Loopctl.HeavyRead` maps that to a graceful degrade (keyword fallback
+  for search, a 429 with the app error envelope for API reads) rather than a
+  pool-exhaustion crash for other tenants.
+
+  ## Design — lock-free ETS atomic counter (NOT a serialized GenServer)
+
+  Mirrors the OTP-thinking "ETS counter" pattern (and the `Iron Law`): a GenServer
+  that served every acquire/release would serialize EVERY heavy read through one
+  process — a throughput bottleneck on the hot read path. Instead a single public,
+  named ETS table holds one `{tenant_id, in_flight_weight}` counter per tenant, and
+  `acquire/3` / `release/2` mutate it with `:ets.update_counter/4`, which is ATOMIC
+  — so concurrent acquirers never lose an update and the cap can never be exceeded:
+
+    * `acquire/3` atomically adds `weight`; if the new total exceeds `cap` it
+      atomically subtracts it back and returns `{:error, :heavy_read_overloaded}`.
+      Two concurrent over-cap acquires each add-then-undo, so NEITHER is admitted
+      and the counter returns to its prior value — safe (never admits over `cap`;
+      at worst a transient high value sheds an acquire that could have squeaked in,
+      an acceptable fairness cost, never a safety one).
+    * `release/2` atomically subtracts `weight`, FLOORED at 0 so a stray/double
+      release can never drive the counter negative (which would inflate the
+      effective cap).
+
+  A tiny supervised process (started in `Loopctl.Application`) OWNS the table so it
+  outlives the transient request/worker process that incremented it; acquire/release
+  BYPASS that owner entirely (direct ETS ops). Zero-valued rows are intentionally
+  NOT reaped: reaping under lock-free access races a concurrent re-acquire
+  (`update_counter`'s `{key, 0}` default would recreate the row between the read-0
+  and the delete, losing a live slot). The table therefore holds at most one small
+  `{uuid, int}` row per distinct tenant that has ever done a heavy read on this node
+  — bounded by tenant count, not by request volume.
+
+  ## Crash-safety — `after`, not process monitors
+
+  `Loopctl.HeavyRead` wraps `acquire → run → release` with `release/2` in an
+  `after`, so a query that raises (statement_timeout CANCEL, DB error) or times out
+  still releases its budget. Unlike `Loopctl.Knowledge.EmbeddingConcurrency` (a
+  GenServer that MONITORS acquirers), this gate does not reclaim budget on a HARD
+  process kill between acquire and the `after` — a rare, node-local drift the
+  fail-open posture and owner restart tolerate. The simplicity of a lock-free
+  counter on the hot read path is the deliberate trade.
+
+  ## Fail-OPEN on a limiter fault (AC-37.5.5)
+
+  A limiter that BLOCKS all heavy reads when it breaks is worse than no limiter. So,
+  like `FairShare` failing open on an unmeasurable count, `acquire/3` and
+  `release/2` are defensive: if the ETS op raises (e.g. the owner process is
+  momentarily down and the table is gone), they LOG a warning and fail OPEN —
+  `acquire/3` returns `:ok` (allow the read), `release/2` returns `:ok`. An
+  unmeasurable limiter degrades to "no limit", never to "all reads blocked".
+
+  By contrast, a MALFORMED CAP fails LOUD: `cap/0`/`weight_for/1` read config
+  OUTSIDE any rescue, so a bad `heavy_read_tenant_cap` (a non-positive int) surfaces
+  rather than being swallowed into a silent fail-open that disables fairness during
+  the very incident an operator is tuning. `Loopctl.SystemConfig.get_int/2` itself
+  never raises (returns the default on miss), and the app-env default is a positive
+  literal, so in practice the cap is always valid.
+
+  ## Config — env-driven, live-tunable, node-local (AC-37.5.5)
+
+    * `cap/0` (K) — the per-tenant slice. Read via the `"heavy_read_tenant_cap"`
+      `SystemConfig` key (DB-backed, hot-path-safe, live-tunable with no deploy); on
+      a cache miss it falls back to the `:heavy_read_tenant_cap` application env,
+      whose default is `Loopctl.DbCapacity.heavy_read_tenant_slice/0` (`4`), which is
+      pinned `< HEAVY_READ_POOL_SIZE` (8) so no tenant can take the whole pool. K is
+      always `>= heavy_weight/0` so a single heavy read always fits (the gate can
+      never starve a tenant to zero heavy reads).
+    * `weight_for/1` — the per-endpoint cost weight, derived from the `endpoint`
+      atom `Loopctl.HeavyRead.opts/1` already carries in `telemetry_options`.
+      Heavy endpoints (vector/kNN, semantic ranking, memory recall, novelty,
+      suggested-links, distant-pairs) cost `heavy_weight/0` (`2`); everything else
+      (change feed, enumeration, ingestion-jobs, STH tail, LLM usage) costs
+      `light_weight/0` (`1`). Both weights are `Application.get_env`-backed so
+      `config/test.exs` can tune them.
+
+  Node-local by design — one set of counters per node. Cluster-wide budget is
+  explicitly deferred to Epic 38 (#353); the effective fleet ceiling is
+  `cap * node_count`.
+
+  ## Testing (async-safe, no `Application.put_env`)
+
+  The core `acquire/3` / `release/2` take EXPLICIT `cap`/`weight` args, so the gate's
+  own tests exercise K=2 and heavy-vs-light weights against fixed caps WITHOUT any
+  global config mutation. The counters are VM-wide (public ETS), so the suite-wide
+  `config/test.exs` `:heavy_read_tenant_cap` is set HIGH — the wired
+  `Loopctl.HeavyRead` gate is then a no-op across incidental parallel heavy reads in
+  the async suite (the `EmbeddingConcurrency`/`ExportConcurrency` precedent), while
+  the dedicated cap tests pass their own low caps to the core functions. Tenant
+  isolation holds structurally: the counter is keyed by `tenant_id`, so A's count
+  never includes B's.
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias Loopctl.DbCapacity
+  alias Loopctl.SystemConfig
+
+  @table :loopctl_heavy_read_inflight
+
+  @cap_config_key "heavy_read_tenant_cap"
+  @heavy_weight_env :heavy_read_weight_heavy
+  @light_weight_env :heavy_read_weight_light
+  @cap_env :heavy_read_tenant_cap
+
+  @default_heavy_weight 2
+  @default_light_weight 1
+
+  # HeavyRead endpoints whose queries are the EXPENSIVE ones — vector/kNN scans,
+  # semantic ranking, HNSW memory recall, the novelty/suggested-links ANN probes,
+  # and the distant-pairs analytic reads. They consume `heavy_weight/0` of a tenant's
+  # in-flight budget; every other (lighter, bounded, fast-releasing) endpoint —
+  # change feed, enumeration, ingestion-jobs count, STH tail, LLM usage — consumes
+  # `light_weight/0`. Kept in sync with `Loopctl.HeavyRead.opts/1`'s known endpoints.
+  @heavy_endpoints ~w(
+    vector_search
+    semantic_search
+    memory_recall
+    novelty
+    suggested_links
+    distant_pairs
+    distant_pairs_bridge
+  )a
+
+  # --- Client API ---
+
+  @doc false
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc """
+  Tries to reserve `weight` units of `tenant_id`'s in-flight HeavyRead budget against
+  `cap` (K).
+
+  Atomically adds `weight` to the tenant's counter; returns `:ok` when the new total
+  stays `<= cap` (the slot is held) or `{:error, :heavy_read_overloaded}` when it
+  would exceed `cap` (the add is atomically undone — no budget is left reserved).
+  Non-blocking: fails fast at the cap. Pair every successful `acquire/3` with a
+  matching `release/2` (do it in an `after` so a crashing read never leaks budget).
+
+  FAILS OPEN (`:ok`) — logging a warning — if the ETS op raises (owner momentarily
+  down), so a broken limiter never blocks all heavy reads (AC-37.5.5).
+  """
+  @spec acquire(binary(), pos_integer(), pos_integer()) ::
+          :ok | {:error, :heavy_read_overloaded}
+  def acquire(tenant_id, weight, cap), do: acquire(tenant_id, weight, cap, @table)
+
+  @doc false
+  # Table-parameterized core (the production API is `acquire/3`, using @table). The
+  # explicit `table` arg exists so the gate's own fail-open test can pass a NON-existent
+  # table to exercise the rescue WITHOUT deleting the shared, VM-wide production table
+  # (which every parallel async test reads/writes).
+  @spec acquire(binary(), pos_integer(), pos_integer(), atom()) ::
+          :ok | {:error, :heavy_read_overloaded}
+  def acquire(tenant_id, weight, cap, table)
+      when is_binary(tenant_id) and is_integer(weight) and weight > 0 and
+             is_integer(cap) and cap > 0 and is_atom(table) do
+    now = :ets.update_counter(table, tenant_id, {2, weight}, {tenant_id, 0})
+
+    if now > cap do
+      # Undo the reservation atomically (floored at 0 defensively). The transient
+      # over-count is invisible to admitted reads and self-corrects here.
+      :ets.update_counter(table, tenant_id, {2, -weight, 0, 0}, {tenant_id, 0})
+      {:error, :heavy_read_overloaded}
+    else
+      :ok
+    end
+  rescue
+    e ->
+      Logger.warning(
+        "HeavyRead.TenantGate acquire failed OPEN for tenant=#{tenant_id}: " <>
+          Exception.message(e)
+      )
+
+      :ok
+  end
+
+  @doc """
+  Releases `weight` units of `tenant_id`'s in-flight budget previously reserved by
+  `acquire/3`.
+
+  Atomically subtracts `weight`, FLOORED at 0 so a stray or double release can never
+  drive the counter negative (which would inflate the effective cap). Idempotent
+  enough for the crash path: releasing without a prior successful acquire just floors
+  at 0. FAILS OPEN (`:ok`) if the ETS op raises — invoked from an `after` where a
+  raised error would mask the read result.
+  """
+  @spec release(binary(), pos_integer()) :: :ok
+  def release(tenant_id, weight), do: release(tenant_id, weight, @table)
+
+  @doc false
+  @spec release(binary(), pos_integer(), atom()) :: :ok
+  def release(tenant_id, weight, table)
+      when is_binary(tenant_id) and is_integer(weight) and weight > 0 and is_atom(table) do
+    :ets.update_counter(table, tenant_id, {2, -weight, 0, 0}, {tenant_id, 0})
+    :ok
+  rescue
+    _ -> :ok
+  end
+
+  @doc "Current in-flight budget held by `tenant_id` on this node (for tests/telemetry)."
+  @spec count(binary()) :: non_neg_integer()
+  def count(tenant_id) when is_binary(tenant_id), do: count(tenant_id, @table)
+
+  @doc false
+  @spec count(binary(), atom()) :: non_neg_integer()
+  def count(tenant_id, table) when is_binary(tenant_id) and is_atom(table) do
+    case :ets.lookup(table, tenant_id) do
+      [{^tenant_id, n}] -> n
+      [] -> 0
+    end
+  rescue
+    _ -> 0
+  end
+
+  @doc """
+  The per-tenant in-flight cap (K) — the max HeavyRead budget one tenant may hold.
+
+  Live-tunable via the `"heavy_read_tenant_cap"` `SystemConfig` key; on a cache miss
+  it falls back to the `:heavy_read_tenant_cap` application env, whose default is
+  `Loopctl.DbCapacity.heavy_read_tenant_slice/0` (pinned `< HEAVY_READ_POOL_SIZE`).
+  Read OUTSIDE any rescue so a malformed cap fails loud rather than silently
+  disabling fairness.
+  """
+  @spec cap() :: pos_integer()
+  def cap do
+    SystemConfig.get_int(@cap_config_key, cap_default())
+  end
+
+  @doc """
+  The cost weight an endpoint's read consumes from a tenant's in-flight budget.
+
+  Heavy endpoints (vector/kNN, semantic ranking, memory recall, novelty,
+  suggested-links, distant-pairs) cost `heavy_weight/0`; every other endpoint (and an
+  unknown/`nil` endpoint) costs `light_weight/0`. Derived from the `endpoint` atom
+  `Loopctl.HeavyRead.opts/1` carries in `telemetry_options`.
+  """
+  @spec weight_for(atom() | nil) :: pos_integer()
+  def weight_for(endpoint) when endpoint in @heavy_endpoints, do: heavy_weight()
+  def weight_for(_endpoint), do: light_weight()
+
+  @doc "The in-flight budget a HEAVY endpoint's read consumes (env `:heavy_read_weight_heavy`, default #{@default_heavy_weight})."
+  @spec heavy_weight() :: pos_integer()
+  def heavy_weight, do: Application.get_env(:loopctl, @heavy_weight_env, @default_heavy_weight)
+
+  @doc "The in-flight budget a LIGHT endpoint's read consumes (env `:heavy_read_weight_light`, default #{@default_light_weight})."
+  @spec light_weight() :: pos_integer()
+  def light_weight, do: Application.get_env(:loopctl, @light_weight_env, @default_light_weight)
+
+  @doc false
+  def table_name, do: @table
+
+  defp cap_default,
+    do: Application.get_env(:loopctl, @cap_env, DbCapacity.heavy_read_tenant_slice())
+
+  # --- Server callbacks (table-owner only; acquire/release bypass this process) ---
+
+  @impl GenServer
+  def init(_opts) do
+    table =
+      case :ets.whereis(@table) do
+        :undefined ->
+          :ets.new(@table, [
+            :set,
+            :public,
+            :named_table,
+            read_concurrency: true,
+            write_concurrency: true
+          ])
+
+        existing ->
+          existing
+      end
+
+    {:ok, %{table: table}}
+  end
+end

--- a/lib/loopctl/heavy_read/tenant_gate.ex
+++ b/lib/loopctl/heavy_read/tenant_gate.ex
@@ -87,6 +87,15 @@ defmodule Loopctl.HeavyRead.TenantGate do
   itself never raises (returns the default on miss); the clamp turns any out-of-range
   operator knob into a safe, logged value rather than a node-wide outage.
 
+  The COST WEIGHTS get the same defense: `heavy_weight/0` and `light_weight/0` are FLOORED
+  at 1, so a non-positive `:heavy_read_weight_heavy`/`:heavy_read_weight_light` app-env
+  misconfiguration can never flow through `weight_for/1` into `acquire/4`'s `weight > 0`
+  guard, miss every clause, and raise a `FunctionClauseError` OUTSIDE the acquire rescue
+  (the same node-wide-500 fail-open violation the cap clamp guards against). `clamp_cap/1`
+  additionally caps `heavy_weight/0` at the `pool - 1` ceiling when deriving its floor, so a
+  `heavy_weight >= pool` can't push the cap floor to/above `pool` and silently re-enable
+  monopolization (AC-37.5.5 bundles caps AND weights into the fail-open guarantee).
+
   ## Config — env-driven, live-tunable, node-local (AC-37.5.5)
 
     * `cap/0` (K) — the per-tenant slice. Read via the `"heavy_read_tenant_cap"`
@@ -286,14 +295,21 @@ defmodule Loopctl.HeavyRead.TenantGate do
   """
   @spec clamp_cap(integer()) :: pos_integer()
   def clamp_cap(configured) when is_integer(configured) do
-    lower = heavy_weight()
-    upper = max(lower, pool_size() - 1)
-    clamped = configured |> max(lower) |> min(upper)
+    # The `pool - 1` ceiling ALWAYS wins: it guarantees `N - K >= 1` slots remain for a
+    # tenant's neighbours (no single-tenant monopolization). `heavy_weight/0` is floored at
+    # 1 (weight accessors) AND capped at that ceiling here, so a misconfigured
+    # `heavy_weight >= pool` can't push the clamp FLOOR to/above `pool` and silently yield a
+    # `cap >= pool` (which would re-enable the monopolization the ceiling exists to prevent).
+    # Result: `clamped` always lands in `[1, pool - 1]`, a positive int satisfying
+    # `acquire/4`'s `cap > 0` guard (AC-37.5.5).
+    ceiling = max(1, pool_size() - 1)
+    lower = min(heavy_weight(), ceiling)
+    clamped = configured |> max(lower) |> min(ceiling)
 
     if clamped != configured do
       Logger.warning(
         "HeavyRead.TenantGate: configured cap #{inspect(configured)} out of range " <>
-          "[#{lower}, #{upper}] (heavy_weight..pool-1); clamped to #{clamped}"
+          "[#{lower}, #{ceiling}] (heavy_weight..pool-1); clamped to #{clamped}"
       )
     end
 
@@ -316,13 +332,29 @@ defmodule Loopctl.HeavyRead.TenantGate do
   @spec heavy_endpoints() :: [atom()]
   def heavy_endpoints, do: @heavy_endpoints
 
-  @doc "The in-flight budget a HEAVY endpoint's read consumes (env `:heavy_read_weight_heavy`, default #{@default_heavy_weight})."
-  @spec heavy_weight() :: pos_integer()
-  def heavy_weight, do: Application.get_env(:loopctl, @heavy_weight_env, @default_heavy_weight)
+  @doc """
+  The in-flight budget a HEAVY endpoint's read consumes (env `:heavy_read_weight_heavy`,
+  default #{@default_heavy_weight}).
 
-  @doc "The in-flight budget a LIGHT endpoint's read consumes (env `:heavy_read_weight_light`, default #{@default_light_weight})."
+  FLOORED at 1 (AC-37.5.5): a non-positive operator misconfiguration would otherwise flow
+  through `weight_for/1` into `acquire/4`'s `weight > 0` guard, matching NO clause and
+  raising a `FunctionClauseError` OUTSIDE the acquire rescue — a node-wide 500 on every
+  heavy read of that class (the exact fail-open violation the cap's `clamp_cap/1` was added
+  to prevent). A bad knob degrades to weight 1, not an outage.
+  """
+  @spec heavy_weight() :: pos_integer()
+  def heavy_weight,
+    do: max(1, Application.get_env(:loopctl, @heavy_weight_env, @default_heavy_weight))
+
+  @doc """
+  The in-flight budget a LIGHT endpoint's read consumes (env `:heavy_read_weight_light`,
+  default #{@default_light_weight}). FLOORED at 1 for the same fail-open reason as
+  `heavy_weight/0` — a non-positive knob can never make `acquire/4`'s `weight > 0` guard
+  miss (AC-37.5.5).
+  """
   @spec light_weight() :: pos_integer()
-  def light_weight, do: Application.get_env(:loopctl, @light_weight_env, @default_light_weight)
+  def light_weight,
+    do: max(1, Application.get_env(:loopctl, @light_weight_env, @default_light_weight))
 
   @doc false
   def table_name, do: @table

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -5445,10 +5445,20 @@ defmodule Loopctl.Knowledge do
   # (`a.tenant_id == ^tenant_id`) and is bounded by prior-tag selectivity — NEVER a
   # full-corpus read (the verified plan shape is documented on novelty_distance_query/4).
   defp nearest_prior_distance(tenant_id, embedding, prior_tag, vis) do
-    tenant_id
-    |> novelty_distance_query(embedding, prior_tag, vis)
+    query = novelty_distance_query(tenant_id, embedding, prior_tag, vis)
     # Heavy vector aggregate — dedicated pool via Loopctl.HeavyRead (US-27.11).
-    |> then(&HeavyRead.one(tenant_id, &1, heavy_read_opts(:novelty)))
+    # `on_overload: :tag` (US-37.5): over the tenant's HeavyRead slice the read is SHED
+    # and returns `{:error, :heavy_read_overloaded}` — mapped to a DELIBERATE `nil` novelty
+    # score here (the same graceful degrade a genuinely unscorable idea gets), rather than
+    # RAISING an OverloadedError that the `Task.async_stream` in `novelty_scores/3` would
+    # catch as an incidental `{:exit, _}` and log as a scary task crash. Non-destructive:
+    # nil already means "not scored".
+    opts = Keyword.put(heavy_read_opts(:novelty), :on_overload, :tag)
+
+    case HeavyRead.one(tenant_id, query, opts) do
+      {:error, :heavy_read_overloaded} -> nil
+      distance -> distance
+    end
   end
 
   # The `MIN(embedding <=> $const::vector)` aggregate query, scoped to the prior-tag set.

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -5974,6 +5974,7 @@ defmodule Loopctl.Knowledge do
   """
   @spec search_semantic(Ecto.UUID.t(), [float()], keyword()) ::
           {:ok, %{results: [map()], meta: map()}}
+          | {:error, :heavy_read_overloaded}
   def search_semantic(tenant_id, query_embedding, opts \\ []) do
     limit = opts |> Keyword.get(:limit, 10) |> max(1) |> min(@max_relevance_page_size)
     offset = opts |> Keyword.get(:offset, 0) |> max(0)
@@ -5996,10 +5997,12 @@ defmodule Loopctl.Knowledge do
     # in-contract page (limit ≤ #{@max_relevance_page_size}) is served; only an
     # unusually-deep offset beyond the pool cap is affected — the documented post-ANN-filter
     # tradeoff `VectorSearch` already carries (see its moduledoc).
-    results =
-      tenant_id
-      |> semantic_results_query(query_embedding, opts)
-      |> then(&HeavyRead.all(tenant_id, &1, heavy_read_opts(:semantic_search)))
+    # US-37.5: pass `on_overload: :tag` so an over-cap heavy-read shed returns
+    # `{:error, :heavy_read_overloaded}` (rather than raising a 429) — semantic search
+    # degrades gracefully to KEYWORD-only fallback on overload, exactly as it does on
+    # an embedding failure. Either heavy read's shed short-circuits to the tagged error
+    # the callers map to keyword fallback.
+    results_query = semantic_results_query(tenant_id, query_embedding, opts)
 
     # COUNT — kept as a SEPARATE full-corpus filtered `count(*)` so `total_count` PRESERVES
     # its pre-27.7a meaning (the size of the whole embedded+filtered ranked corpus, NOT the
@@ -6009,27 +6012,45 @@ defmodule Loopctl.Knowledge do
     # category+tags count is a BitmapAnd bounded by selectivity; the unfiltered count is a
     # bounded tenant scan — inherently O(tenant rows) for a true `count(*)`).
     count_query = semantic_count_query(tenant_id, query_embedding, status, opts)
-    total_count = HeavyRead.one(tenant_id, count_query, heavy_read_opts(:semantic_search))
 
-    maybe_record_search_access(tenant_id, results, nil, opts, "semantic")
+    case HeavyRead.all(tenant_id, results_query, semantic_heavy_read_opts()) do
+      {:error, :heavy_read_overloaded} = err ->
+        err
 
-    {:ok,
-     %{
-       results: results,
-       meta: %{
-         total_count: total_count,
-         limit: limit,
-         offset: offset,
-         search_mode: "semantic_only",
-         # Every EMBEDDED article passing the filters is ranked by similarity
-         # (no relevance cutoff), so total_count is the size of that embedded
-         # set — NOT a match count, and <= the total published count (articles
-         # without an embedding are excluded). Use knowledge_stats for the
-         # full wiki size.
-         total_count_scope: "ranked_corpus",
-         pool_capped: semantic_pool_capped?(total_count, length(results), limit, offset)
-       }
-     }}
+      results ->
+        case HeavyRead.one(tenant_id, count_query, semantic_heavy_read_opts()) do
+          {:error, :heavy_read_overloaded} = err ->
+            err
+
+          total_count ->
+            maybe_record_search_access(tenant_id, results, nil, opts, "semantic")
+
+            {:ok,
+             %{
+               results: results,
+               meta: %{
+                 total_count: total_count,
+                 limit: limit,
+                 offset: offset,
+                 search_mode: "semantic_only",
+                 # Every EMBEDDED article passing the filters is ranked by similarity
+                 # (no relevance cutoff), so total_count is the size of that embedded
+                 # set — NOT a match count, and <= the total published count (articles
+                 # without an embedding are excluded). Use knowledge_stats for the
+                 # full wiki size.
+                 total_count_scope: "ranked_corpus",
+                 pool_capped: semantic_pool_capped?(total_count, length(results), limit, offset)
+               }
+             }}
+        end
+    end
+  end
+
+  # US-37.5: heavy-read opts for the semantic search reads with the graceful-degrade
+  # flag — an over-cap shed returns `{:error, :heavy_read_overloaded}` (search falls
+  # back to keyword-only) instead of raising a 429.
+  defp semantic_heavy_read_opts do
+    [{:on_overload, :tag} | heavy_read_opts(:semantic_search)]
   end
 
   # Relevance-pool truncation signal (US-27.7a — NOT silent; mirrors the suggested-links
@@ -6260,60 +6281,78 @@ defmodule Loopctl.Knowledge do
 
     case {keyword_result, embedding_result} do
       {{:ok, kw}, {:ok, embedding}} ->
-        {:ok, semantic} = search_semantic(tenant_id, embedding, sub_opts)
+        # US-37.5: the semantic heavy read can be SHED when the tenant is over its
+        # per-tenant in-flight HeavyRead cap. That returns `{:error,
+        # :heavy_read_overloaded}` (rather than raising a 429) so combined search
+        # degrades to keyword-only — the SAME graceful fallback as an embedding
+        # failure, keeping OTHER tenants' access to the shared BYPASSRLS pool.
+        case search_semantic(tenant_id, embedding, sub_opts) do
+          {:ok, semantic} ->
+            # Distinguish the OTHER silent-degradation cause (#297): the embedding
+            # SUCCEEDED but semantic ranking returned nothing (a recall/HNSW problem,
+            # NOT an embed failure). Combined does NOT fall back here — keyword still
+            # merges — so this sets no fallback/fallback_reason; it only emits the
+            # alertable signal and the meta carries `semantic_result_count`.
+            maybe_emit_semantic_empty(tenant_id, length(semantic.results), query_string)
 
-        # Distinguish the OTHER silent-degradation cause (#297): the embedding
-        # SUCCEEDED but semantic ranking returned nothing (a recall/HNSW problem,
-        # NOT an embed failure). Combined does NOT fall back here — keyword still
-        # merges — so this sets no fallback/fallback_reason; it only emits the
-        # alertable signal and the meta carries `semantic_result_count`.
-        maybe_emit_semantic_empty(tenant_id, length(semantic.results), query_string)
+            {:ok, merged} = merge_results(kw, semantic, keyword_weight, semantic_weight, opts)
 
-        {:ok, merged} = merge_results(kw, semantic, keyword_weight, semantic_weight, opts)
+            maybe_record_search_access(
+              tenant_id,
+              merged.results,
+              query_string,
+              opts,
+              "combined"
+            )
 
-        maybe_record_search_access(
-          tenant_id,
-          merged.results,
-          query_string,
-          opts,
-          "combined"
-        )
+            {:ok, merged}
 
-        {:ok, merged}
+          {:error, :heavy_read_overloaded} ->
+            combined_keyword_fallback(tenant_id, kw, :heavy_read_overloaded, query_string, opts)
+        end
 
       {{:ok, kw}, {:error, reason}} ->
         # Fallback to keyword-only. Capture the discarded embedding-error reason as
         # a stable, non-sensitive tag (sanitized via ProviderError so no api key /
         # provider body leaks), surface it in meta, and emit telemetry + a log so a
         # silent degradation becomes alertable (#297).
-        fallback_reason = record_semantic_fallback(tenant_id, reason, query_string)
-        paginated = paginate_results(kw.results, opts)
-
-        maybe_record_search_access(
-          tenant_id,
-          paginated.results,
-          query_string,
-          opts,
-          "combined_fallback"
-        )
-
-        {:ok,
-         %{
-           results: paginated.results,
-           meta:
-             Map.merge(kw.meta, %{
-               fallback: true,
-               search_mode: "keyword_only",
-               fallback_reason: fallback_reason,
-               total_count: kw.meta.total_count,
-               limit: paginated.limit,
-               offset: paginated.offset
-             })
-         }}
+        combined_keyword_fallback(tenant_id, kw, reason, query_string, opts)
 
       {kw_error, _} ->
         kw_error
     end
+  end
+
+  # Degrade combined search to keyword-only when the semantic side is unavailable —
+  # either an embedding-generation error (#297) OR an over-cap HeavyRead shed
+  # (US-37.5, `:heavy_read_overloaded`). Records the discarded reason as a stable,
+  # non-sensitive `fallback_reason` tag (sanitized via ProviderError), surfaces it in
+  # meta, and emits telemetry + a log so the degradation is alertable, not silent.
+  defp combined_keyword_fallback(tenant_id, kw, reason, query_string, opts) do
+    fallback_reason = record_semantic_fallback(tenant_id, reason, query_string)
+    paginated = paginate_results(kw.results, opts)
+
+    maybe_record_search_access(
+      tenant_id,
+      paginated.results,
+      query_string,
+      opts,
+      "combined_fallback"
+    )
+
+    {:ok,
+     %{
+       results: paginated.results,
+       meta:
+         Map.merge(kw.meta, %{
+           fallback: true,
+           search_mode: "keyword_only",
+           fallback_reason: fallback_reason,
+           total_count: kw.meta.total_count,
+           limit: paginated.limit,
+           offset: paginated.offset
+         })
+     }}
   end
 
   # -- Semantic → keyword fallback observability (#297) ------------------------
@@ -6375,6 +6414,9 @@ defmodule Loopctl.Knowledge do
   defp reason_to_tag(:no_api_key), do: "no_embedding_key"
   defp reason_to_tag(:circuit_open), do: "embedding_circuit_open"
   defp reason_to_tag(:rate_limited_local), do: "embedding_rate_limited_local"
+  # US-37.5: the semantic heavy read was shed because the tenant is over its
+  # per-tenant in-flight HeavyRead cap; search degraded to keyword-only.
+  defp reason_to_tag(:heavy_read_overloaded), do: "heavy_read_overloaded"
   defp reason_to_tag(:timeout), do: "embedding_timeout"
 
   defp reason_to_tag({:api_error, status, _}) when is_integer(status),

--- a/lib/loopctl/knowledge/proposal_gate.ex
+++ b/lib/loopctl/knowledge/proposal_gate.ex
@@ -20,6 +20,15 @@ defmodule Loopctl.Knowledge.ProposalGate do
   Embedding requires a network call. On ANY failure — API down, power/internet
   outage, system-scoped proposal with no tenant — `assess/3` falls **open**:
   `%{verdict: :unknown, ...}`, so write-back is never blocked by the gate.
+
+  The SAME fall-open covers the novelty NEAREST-NEIGHBOUR read: `assess/3` runs
+  SYNCHRONOUSLY in the `knowledge_create` write path, and that vector read goes
+  through the per-tenant HeavyRead gate (US-37.5). It passes `on_overload: :tag`, so
+  an over-cap shed returns `{:error, :heavy_read_overloaded}` and the gate falls open
+  — a per-tenant READ limiter must NEVER 429 a WRITE (`knowledge_create`), and the
+  gate's "never block write-back" invariant holds during exactly the high-load
+  incident it exists to survive. (Contrast a plain API kNN read, which defaults to
+  `:raise` → a legitimate 429.)
   """
 
   @behaviour Loopctl.Knowledge.ProposalAssessorBehaviour
@@ -52,14 +61,26 @@ defmodule Loopctl.Knowledge.ProposalGate do
     # timeout.
     case Knowledge.generate_embedding(tenant_id, build_text(attrs)) do
       {:ok, vector} when is_list(vector) and vector != [] ->
-        neighbors =
-          VectorSearch.nearest(tenant_id, vector, @neighbors_k,
-            threshold: overlap,
-            visibility_agent_id: Keyword.get(opts, :visibility_agent_id)
-          )
+        # `on_overload: :tag` (US-37.5): assess/3 runs SYNCHRONOUSLY in the
+        # knowledge_create write path, so an over-cap HeavyRead shed must NOT raise a
+        # 429 on a WRITE — it returns `{:error, :heavy_read_overloaded}` and the gate
+        # falls OPEN, consistent with its treatment of every other novelty-check failure.
+        case VectorSearch.nearest(tenant_id, vector, @neighbors_k,
+               threshold: overlap,
+               on_overload: :tag,
+               visibility_agent_id: Keyword.get(opts, :visibility_agent_id)
+             ) do
+          {:error, :heavy_read_overloaded} ->
+            Logger.warning(
+              "ProposalGate: novelty read shed (heavy_read_overloaded), falling open"
+            )
 
-        score = neighbors |> List.first() |> neighbor_score()
-        %{verdict: classify(score, dup, overlap), score: score, neighbors: neighbors}
+            open_verdict()
+
+          neighbors when is_list(neighbors) ->
+            score = neighbors |> List.first() |> neighbor_score()
+            %{verdict: classify(score, dup, overlap), score: score, neighbors: neighbors}
+        end
 
       {:error, :no_api_key} ->
         # Mandatory BYO: keyless tenant — fall open (never block write-back) and audit

--- a/lib/loopctl/knowledge/similarity_search_behaviour.ex
+++ b/lib/loopctl/knowledge/similarity_search_behaviour.ex
@@ -49,12 +49,15 @@ defmodule Loopctl.Knowledge.SimilaritySearchBehaviour do
   highest similarity first, scoped to `tenant_id`.
 
   Mirrors `Loopctl.Knowledge.VectorSearch.nearest/4`: `opts` may carry
-  `:exclude_id`, `:project_or_global`, `:threshold`, `:pool`, etc.
+  `:exclude_id`, `:project_or_global`, `:threshold`, `:pool`, etc. When a caller
+  passes `on_overload: :tag` (US-37.5), an over-cap heavy-read shed returns
+  `{:error, :heavy_read_overloaded}` instead of raising — the graceful-degrade path
+  (the auto-link worker snoozes; the ProposalGate write-back gate falls open).
   """
   @callback nearest(
               tenant_id :: binary(),
               target_embedding :: term(),
               k :: pos_integer(),
               opts :: keyword()
-            ) :: [candidate()]
+            ) :: [candidate()] | {:error, :heavy_read_overloaded}
 end

--- a/lib/loopctl/knowledge/streaming_export.ex
+++ b/lib/loopctl/knowledge/streaming_export.ex
@@ -45,6 +45,23 @@ defmodule Loopctl.Knowledge.StreamingExport do
   so a consumer detects truncation. The error is mapped through `LoopctlWeb.DBError`
   semantics by the controller so no SQL/params/vector-literals/stack-traces reach
   the partial bytes.
+
+  ## Per-tenant heavy-read weight + overload disposition (US-37.5)
+
+  Every export scan is a genuinely HEAVY, long (60s) read, so it is stamped with the
+  `:export` endpoint (`export_read_opts/0`) — weighted `heavy` (2) by
+  `Loopctl.HeavyRead.TenantGate` (an unweighted read defaults to LIGHT, letting a
+  tenant hold more concurrent export slots than the cost model intends). The reads
+  keep HeavyRead's default `on_overload: :raise`, so when a tenant is over its
+  per-tenant in-flight slice an export scan sheds by RAISING
+  `Loopctl.HeavyRead.OverloadedError`. That is a DELIBERATE fail-closed disposition:
+  the raise is caught by the same page/aggregate/link `rescue` clauses that fail
+  closed on any DB error (`safe_fetch_page/5`, `emit_index/4`, `emit_article_page/5`)
+  — the writer is aborted, the consumer detects truncation, and the export is
+  re-run once the tenant's heavy-read load subsides. (Since the scan is released
+  between keyset pages, an export mostly coexists; a shed only occurs when the tenant
+  is ALREADY saturating its slice — failing that one export is the correct fairness
+  outcome.)
   """
 
   import Ecto.Query
@@ -60,6 +77,15 @@ defmodule Loopctl.Knowledge.StreamingExport do
   @default_chunk_size 200
   @default_max_links_per_article 100
   @default_max_stream_duration_ms :timer.minutes(10)
+
+  # Export pages/aggregates/link preloads get a longer per-read timeout than fast reads
+  # (60s vs the 10s fast-read default) — a single page (even a dense graph at prod
+  # scale) completes well under 60s, so this only prevents a legitimately slow page
+  # timing out mid-export. The `:export` endpoint makes `Loopctl.HeavyRead.TenantGate`
+  # weight these HEAVY (US-37.5) — an unstamped read would default to LIGHT and let a
+  # tenant hold more concurrent export slots than the heavy-scan cost model intends.
+  @export_statement_timeout_ms 60_000
+  @export_endpoint :export
 
   @doc "Configured keyset page size (articles held in memory per page). Tunable for tests."
   @spec chunk_size() :: pos_integer()
@@ -188,8 +214,9 @@ defmodule Loopctl.Knowledge.StreamingExport do
       |> group_by([a], a.category)
       |> select([a], %{category: a.category, count: count(a.id)})
 
-    # Export aggregations use the same extended 60s timeout as export pages.
-    HeavyRead.all(tenant_id, query, statement_timeout: 60_000)
+    # Export aggregations use the same extended 60s timeout + heavy `:export` weight as
+    # export pages. A shed (OverloadedError) is caught by `emit_index/4`'s rescue → fail-closed.
+    HeavyRead.all(tenant_id, query, export_read_opts())
   end
 
   # --- article pages (keyset walk) ---
@@ -288,11 +315,10 @@ defmodule Loopctl.Knowledge.StreamingExport do
       })
       |> limit(^(page_size + 1))
 
-    # Export pages have a longer per-page timeout than fast reads: 60s instead of the
-    # 10s fast-read default. A single page read (even with `export_max_links_per_article: 100`
-    # and dense graph) should complete in well under 60s at realistic prod scale; this
-    # prevents a legitimate slow page from timing out mid-export.
-    rows = HeavyRead.all(tenant_id, query, statement_timeout: 60_000)
+    # Export pages carry the extended 60s per-read timeout + heavy `:export` weight
+    # (see `export_read_opts/0`). A shed (OverloadedError) is caught by
+    # `safe_fetch_page/5`'s rescue → fail-closed abort.
+    rows = HeavyRead.all(tenant_id, query, export_read_opts())
 
     if length(rows) > page_size do
       page = Enum.take(rows, page_size)
@@ -455,13 +481,27 @@ defmodule Loopctl.Knowledge.StreamingExport do
         }
       )
 
-    # Export link queries use the same extended 60s timeout as export pages.
+    # Export link queries use the same extended 60s timeout + heavy `:export` weight as
+    # export pages. A shed (OverloadedError) is caught by `emit_article_page/5`'s rescue
+    # (this runs inside its per-page link preload) → fail-closed abort.
     tenant_id
-    |> HeavyRead.all(query, statement_timeout: 60_000)
+    |> HeavyRead.all(query, export_read_opts())
     |> Enum.map(&Map.put(&1, :direction, direction))
   end
 
   # --- shared query + helpers ---
+
+  # Heavy-read opts shared by every export scan (page / aggregate / link preload): the
+  # extended 60s `SET LOCAL statement_timeout` AND the `:export` telemetry endpoint that
+  # weights the read HEAVY on `Loopctl.HeavyRead.TenantGate` (US-37.5). The default
+  # `on_overload: :raise` disposition is deliberate — the raise fails closed via the
+  # caller's rescue (see the moduledoc "overload disposition" section).
+  defp export_read_opts do
+    [
+      statement_timeout: @export_statement_timeout_ms,
+      telemetry_options: [endpoint: @export_endpoint]
+    ]
+  end
 
   @doc """
   The export base query: the EXACT WHERE of the legacy `export_base_query/2`

--- a/lib/loopctl/knowledge/vector_search.ex
+++ b/lib/loopctl/knowledge/vector_search.ex
@@ -249,12 +249,11 @@ defmodule Loopctl.Knowledge.VectorSearch do
   a bound `^[float()]` param via `to_embedding_list/1` (never the struct — #168).
   """
   @impl true
-  @spec nearest(Ecto.UUID.t(), target_embedding(), pos_integer(), keyword()) :: [
-          candidate()
-        ]
+  @spec nearest(Ecto.UUID.t(), target_embedding(), pos_integer(), keyword()) ::
+          [candidate()] | {:error, :heavy_read_overloaded}
   def nearest(tenant_id, target_embedding, k, opts \\ []) when is_binary(tenant_id) do
     query = candidate_query(tenant_id, target_embedding, k, opts)
-    HeavyRead.all(tenant_id, query, heavy_read_opts())
+    HeavyRead.all(tenant_id, query, heavy_read_opts(opts))
   end
 
   @doc """
@@ -639,7 +638,18 @@ defmodule Loopctl.Knowledge.VectorSearch do
   # (per-endpoint override else the pool default, applied via SET LOCAL) AND the endpoint key
   # for slow-query telemetry — rather than hand-rolling a list that drifts from every other
   # heavy consumer. `HeavyRead.opts/1` carries the 15s client-timeout backstop itself.
-  defp heavy_read_opts do
-    HeavyRead.opts(:vector_search)
+  #
+  # US-37.5: a caller MAY pass `on_overload: :tag` (or `:raise`) in `nearest/4`'s opts to
+  # choose the over-cap disposition. `:tag` makes the shed return
+  # `{:error, :heavy_read_overloaded}` (the graceful-degrade path — the ProposalGate
+  # write-back gate falls OPEN, the auto-link worker snoozes) instead of raising a 429.
+  # Absent, it defaults to `HeavyRead`'s `:raise` (a plain API kNN read → 429).
+  defp heavy_read_opts(opts) do
+    base = HeavyRead.opts(:vector_search)
+
+    case Keyword.fetch(opts, :on_overload) do
+      {:ok, disposition} -> Keyword.put(base, :on_overload, disposition)
+      :error -> base
+    end
   end
 end

--- a/lib/loopctl/memory.ex
+++ b/lib/loopctl/memory.ex
@@ -1104,7 +1104,10 @@ defmodule Loopctl.Memory do
        scoped to prior `:promoted` rows (`nearest_live/2`). If embedding generation is
        unavailable (circuit open / no key / provider error), NO near-dup answer is
        authoritative, so the whole run aborts with `{:error, :embeddings_degraded}` (the
-       worker snoozes/retries rather than risk inserting a duplicate). On a genuine
+       worker snoozes/retries rather than risk inserting a duplicate). Likewise, if the
+       per-tenant HeavyRead gate SHEDS the recall (tenant over its slice), the run aborts
+       with `{:error, :heavy_read_overloaded}` (the recall requests `on_overload: :tag`,
+       so it never raises on this write path) for the same loss-free snooze. On a genuine
        near-match (score ≥ `:memory_promotion_near_dup_threshold`) the new row is inserted
        and the prior memory is `supersede/3`d.
     3. Otherwise the candidate is inserted fresh (`promoted`).
@@ -1120,6 +1123,8 @@ defmodule Loopctl.Memory do
   contract).
 
   Returns `{:ok, summary}` on full success, `{:error, :embeddings_degraded}`,
+  `{:error, :heavy_read_overloaded}` (the per-tenant HeavyRead gate shed the near-dup
+  recall — a loss-free snooze for the worker, treated like `:embeddings_degraded`),
   `{:error, :quota_exceeded, summary}`, or `{:error, other}` (a bad write —
   retryable). `summary` is `%{promoted, superseded, deduped}` (promoted = fresh
   inserts; superseded = insert-and-supersede pairs; deduped = exact-dup skips).
@@ -1127,6 +1132,7 @@ defmodule Loopctl.Memory do
   @spec persist_promotion(Scope.t(), [map()]) ::
           {:ok, map()}
           | {:error, :embeddings_degraded}
+          | {:error, :heavy_read_overloaded}
           | {:error, :quota_exceeded, map()}
           | {:error, term()}
   def persist_promotion(%Scope{subject_id: @eval_subject_id}, _candidates) do
@@ -1147,6 +1153,7 @@ defmodule Loopctl.Memory do
         {:ok, :promoted} -> {:cont, {:ok, %{acc | promoted: acc.promoted + 1}}}
         {:ok, :superseded} -> {:cont, {:ok, %{acc | superseded: acc.superseded + 1}}}
         {:error, :embeddings_degraded} -> {:halt, {:error, :embeddings_degraded}}
+        {:error, :heavy_read_overloaded} -> {:halt, {:error, :heavy_read_overloaded}}
         {:error, :quota_exceeded} -> {:halt, {:error, :quota_exceeded, acc}}
         {:error, other} -> {:halt, {:error, other}}
       end
@@ -1162,6 +1169,9 @@ defmodule Loopctl.Memory do
       case nearest_live(scope, candidate.text) do
         {:error, :embeddings_degraded} ->
           {:error, :embeddings_degraded}
+
+        {:error, :heavy_read_overloaded} = err ->
+          err
 
         {:ok, near_dup_id, embedding} ->
           insert_promoted(scope, candidate, hash, near_dup_id, embedding)
@@ -1197,7 +1207,15 @@ defmodule Loopctl.Memory do
         {:error, :embeddings_degraded}
 
       {:ok, embedding} ->
-        {:ok, find_promoted_near_dup(scope, embedding), embedding}
+        # The near-dup HNSW recall runs on the shared HeavyRead pool behind the
+        # per-tenant TenantGate. Over the tenant's slice the read is SHED
+        # (`on_overload: :tag`) and surfaces as `{:error, :heavy_read_overloaded}` —
+        # propagate it up so the worker snoozes LOSS-FREE rather than raising (which
+        # would burn an Oban attempt on the promotion WRITE path, US-37.5).
+        case find_promoted_near_dup(scope, embedding) do
+          {:error, :heavy_read_overloaded} = err -> err
+          near_dup_id -> {:ok, near_dup_id, embedding}
+        end
     end
   end
 
@@ -1207,10 +1225,22 @@ defmodule Loopctl.Memory do
   # cannot drift from ordinary recall.
   defp find_promoted_near_dup(scope, embedding) do
     query = memory_candidate_query(scope, embedding, @near_dup_recall_pool, false)
+    # `on_overload: :tag` so an over-cap TenantGate shed returns
+    # `{:error, :heavy_read_overloaded}` (mapped to a loss-free snooze upstream)
+    # instead of RAISING an OverloadedError on the promotion write path (US-37.5).
+    opts = Keyword.put(HeavyRead.opts(:memory_recall), :on_overload, :tag)
 
-    scope.tenant_id
-    |> HeavyRead.all_memory(scope.subject_id, query, HeavyRead.opts(:memory_recall))
-    |> Enum.find_value(fn row ->
+    case HeavyRead.all_memory(scope.tenant_id, scope.subject_id, query, opts) do
+      {:error, :heavy_read_overloaded} = err -> err
+      rows when is_list(rows) -> first_promoted_near_dup(rows)
+    end
+  end
+
+  # The id of the nearest `:promoted` row at/above the near-dup threshold (rows are
+  # distance-ordered, nearest first), or nil. An explicit-source near-dup is skipped —
+  # auto-promotion never supersedes a human-authored row (AC-29.2.4).
+  defp first_promoted_near_dup(rows) do
+    Enum.find_value(rows, fn row ->
       score = max(0.0, 1.0 - row.distance)
       if score >= near_dup_threshold() and row.source == :promoted, do: row.id
     end)

--- a/lib/loopctl/workers/article_linking_worker.ex
+++ b/lib/loopctl/workers/article_linking_worker.ex
@@ -163,24 +163,35 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
   defp find_and_link_similar(article, tenant_id, threshold, max_comparisons) do
     maybe_emit_corpus_size(article, tenant_id, max_comparisons)
 
-    candidates = find_similar_articles(article, tenant_id, threshold, max_comparisons)
-    conflict_threshold = conflict_threshold()
+    case find_similar_articles(article, tenant_id, threshold, max_comparisons) do
+      {:error, :heavy_read_overloaded} ->
+        # US-37.5: the tenant is over its per-tenant HeavyRead slice, so the kNN read
+        # was shed (`on_overload: :tag`). Yield LOSS-FREE with `{:snooze, n}` (no
+        # attempt consumed, same as the FairShare gate above) rather than erroring —
+        # a raised OverloadedError would burn attempts toward max_attempts and could
+        # PERMANENTLY lose this article's auto-links under a sustained heavy-read
+        # burst. Retried when the tenant's heavy-read load subsides.
+        {:snooze, FairShare.snooze_seconds()}
 
-    # A `relates_to` ambient link for everything >= the link threshold, PLUS a
-    # `:potential_conflict` flag (route-the-findings #4) for pairs >= the conflict
-    # threshold — too similar to comfortably coexist, for the consumer to resolve.
-    # Dedup is type-aware so the two link types don't crowd each other out.
-    relates =
-      build_links(article.id, candidates, tenant_id, :relates_to, fn _sim -> true end)
+      candidates when is_list(candidates) ->
+        conflict_threshold = conflict_threshold()
 
-    conflicts =
-      build_links(article.id, candidates, tenant_id, :potential_conflict, fn sim ->
-        sim >= conflict_threshold
-      end)
+        # A `relates_to` ambient link for everything >= the link threshold, PLUS a
+        # `:potential_conflict` flag (route-the-findings #4) for pairs >= the conflict
+        # threshold — too similar to comfortably coexist, for the consumer to resolve.
+        # Dedup is type-aware so the two link types don't crowd each other out.
+        relates =
+          build_links(article.id, candidates, tenant_id, :relates_to, fn _sim -> true end)
 
-    created_count = create_links(relates ++ conflicts, tenant_id)
-    log_audit_event(article.id, tenant_id, created_count)
-    :ok
+        conflicts =
+          build_links(article.id, candidates, tenant_id, :potential_conflict, fn sim ->
+            sim >= conflict_threshold
+          end)
+
+        created_count = create_links(relates ++ conflicts, tenant_id)
+        log_audit_event(article.id, tenant_id, created_count)
+        :ok
+    end
   end
 
   defp build_links(article_id, candidates, tenant_id, type, keep?) do
@@ -242,18 +253,27 @@ defmodule Loopctl.Workers.ArticleLinkingWorker do
   # project's matches all fall outside the global top-pool it could under-fill, the same
   # documented post-ANN-filter limitation `VectorSearch` carries for `tags`/`category`.
   defp find_similar_articles(article, tenant_id, threshold, max_comparisons) do
-    tenant_id
-    |> @similarity_search.nearest(article.embedding, max_comparisons,
-      exclude_id: article.id,
-      project_or_global: article.project_id,
-      threshold: 0.0,
-      pool: VectorSearch.pool_size(max_comparisons)
-    )
-    # The helper returns `%{id, title, category, similarity_score}`; the linking path
-    # keys on `:id` + `:similarity`, so map the score across and keep the inclusive
-    # `>= threshold` boundary in memory (see the threshold note above).
-    |> Enum.map(fn %{id: id, similarity_score: score} -> %{id: id, similarity: score} end)
-    |> Enum.filter(fn %{similarity: sim} -> sim >= threshold end)
+    # US-37.5: `on_overload: :tag` so an over-cap heavy-read shed returns
+    # `{:error, :heavy_read_overloaded}` (propagated up to a loss-free `{:snooze, n}`
+    # in `find_and_link_similar/4`) instead of raising and burning a job attempt.
+    case @similarity_search.nearest(tenant_id, article.embedding, max_comparisons,
+           exclude_id: article.id,
+           project_or_global: article.project_id,
+           threshold: 0.0,
+           on_overload: :tag,
+           pool: VectorSearch.pool_size(max_comparisons)
+         ) do
+      {:error, :heavy_read_overloaded} = err ->
+        err
+
+      candidates when is_list(candidates) ->
+        # The helper returns `%{id, title, category, similarity_score}`; the linking
+        # path keys on `:id` + `:similarity`, so map the score across and keep the
+        # inclusive `>= threshold` boundary in memory (see the threshold note above).
+        candidates
+        |> Enum.map(fn %{id: id, similarity_score: score} -> %{id: id, similarity: score} end)
+        |> Enum.filter(fn %{similarity: sim} -> sim >= threshold end)
+    end
   end
 
   # US-36.4 (AC-36.4.1): the corpus-size-vs-limit warning used to run a full `count(*)`

--- a/lib/loopctl/workers/compute_sth_worker.ex
+++ b/lib/loopctl/workers/compute_sth_worker.ex
@@ -43,7 +43,16 @@ defmodule Loopctl.Workers.ComputeSthWorker do
 
   alias Loopctl.AdminRepo
   alias Loopctl.AuditChain
+  alias Loopctl.HeavyRead.OverloadedError
   alias Loopctl.Tenants.Tenant
+
+  # US-37.5: bounded, jittered snooze (seconds) when a tenant's STH tail read is shed
+  # by the per-tenant HeavyRead in-flight gate. Loss-free (no attempt consumed), so a
+  # sustained heavy-read burst can never exhaust this worker's max_attempts and DROP a
+  # custody-critical STH checkpoint — it is re-attempted once the tenant's heavy-read
+  # load subsides (and `sth_needed?/1` re-fires, so nothing is lost meanwhile).
+  @overload_snooze_base_seconds 5
+  @overload_snooze_jitter_seconds 10
 
   # US-32.5: bounded jitter window (seconds) spread across the per-minute cron
   # tick, so per-tenant fanout jobs don't all land at the same `:00` instant.
@@ -77,24 +86,48 @@ defmodule Loopctl.Workers.ComputeSthWorker do
 
   def perform(%Oban.Job{args: %{"tenant_id" => tenant_id}}) do
     if AuditChain.sth_needed?(tenant_id) do
-      case AuditChain.sign_and_store_tree_head(tenant_id) do
-        {:ok, sth} ->
-          Logger.info(
-            "ComputeSthWorker: signed STH for tenant #{tenant_id} at position #{sth.chain_position}"
-          )
-
-          :ok
-
-        {:error, :empty_chain} ->
-          :ok
-
-        {:error, reason} ->
-          Logger.warning("ComputeSthWorker: failed for tenant #{tenant_id}: #{inspect(reason)}")
-          {:error, reason}
-      end
+      sign_tenant(tenant_id)
     else
       :ok
     end
+  end
+
+  # `sign_and_store_tree_head/1`'s bounded STH tail read runs through the per-tenant
+  # HeavyRead gate (endpoint `:sth_incremental`, default `on_overload: :raise`). Under
+  # a tenant's sustained heavy-read burst that read can be SHED, raising
+  # `HeavyRead.OverloadedError`. Rescue it here (the only heavy read in this call path)
+  # and yield loss-free with `{:snooze, n}` instead of erroring — an errored STH job
+  # would retry-churn and could exhaust max_attempts, dropping a custody-critical
+  # checkpoint. (An out-of-band DB error still fails normally via the `{:error, _}`
+  # tuple below; only the deliberate overload shed is turned into a snooze.)
+  defp sign_tenant(tenant_id) do
+    case AuditChain.sign_and_store_tree_head(tenant_id) do
+      {:ok, sth} ->
+        Logger.info(
+          "ComputeSthWorker: signed STH for tenant #{tenant_id} at position #{sth.chain_position}"
+        )
+
+        :ok
+
+      {:error, :empty_chain} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("ComputeSthWorker: failed for tenant #{tenant_id}: #{inspect(reason)}")
+        {:error, reason}
+    end
+  rescue
+    OverloadedError ->
+      Logger.info(
+        "ComputeSthWorker: STH read shed (heavy_read_overloaded) for tenant #{tenant_id}; snoozing"
+      )
+
+      {:snooze, overload_snooze_seconds()}
+  end
+
+  # :rand.uniform(jitter + 1) ∈ 1..jitter+1 → -1 gives 0..jitter (0 when jitter=0).
+  defp overload_snooze_seconds do
+    @overload_snooze_base_seconds + :rand.uniform(@overload_snooze_jitter_seconds + 1) - 1
   end
 
   @doc """

--- a/lib/loopctl/workers/memory_promotion_worker.ex
+++ b/lib/loopctl/workers/memory_promotion_worker.ex
@@ -27,6 +27,10 @@ defmodule Loopctl.Workers.MemoryPromotionWorker do
 
     * `{:error, :embeddings_degraded}` (recall fell back) → `{:snooze, n}`; NO
       watermark advance, so a later healthy run re-attempts (AC-29.2.4).
+    * `{:error, :heavy_read_overloaded}` (the per-tenant HeavyRead gate shed the
+      near-dup recall, US-37.5) → `{:snooze, n}`; loss-free backpressure, NO attempt
+      consumed and NO watermark advance, so the promotion re-runs once the tenant's
+      heavy-read burst subsides. Treated exactly like `:embeddings_degraded`.
     * `{:error, :rate_limited_local}` (node-local provider admission gate shut,
       US-37.1) → `{:snooze, n}`; loss-free backpressure, NO attempt consumed and NO
       watermark advance, so the compile re-runs once local demand subsides.
@@ -218,6 +222,15 @@ defmodule Loopctl.Workers.MemoryPromotionWorker do
       {:error, :embeddings_degraded} ->
         PromotionTelemetry.emit(:degraded, %{count: 1}, meta(scope, session_id))
         # No watermark advance — retry when embeddings recover.
+        {:snooze, @snooze_seconds}
+
+      {:error, :heavy_read_overloaded} ->
+        # US-37.5: the tenant is over its per-tenant HeavyRead slice, so the near-dup
+        # recall was SHED (`on_overload: :tag`). Snooze LOSS-FREE (no attempt consumed,
+        # no watermark advance) exactly like `:embeddings_degraded` — a raised
+        # OverloadedError would burn an Oban attempt toward max_attempts on the
+        # promotion WRITE path. Retried when the tenant's heavy-read load subsides.
+        PromotionTelemetry.emit(:degraded, %{count: 1}, meta(scope, session_id))
         {:snooze, @snooze_seconds}
 
       {:error, :quota_exceeded, summary} ->

--- a/lib/loopctl_web/controllers/error_json.ex
+++ b/lib/loopctl_web/controllers/error_json.ex
@@ -71,6 +71,24 @@ defmodule LoopctlWeb.ErrorJSON do
     }
   end
 
+  # US-37.5: a tenant over its per-tenant in-flight HeavyRead cap raises
+  # Loopctl.HeavyRead.OverloadedError, which LoopctlWeb.Plugs.HeavyReadOverloadHandler
+  # (Plug.Exception) maps to 429. Surface a self-identifying `code` so the client can
+  # tell this per-tenant heavy-read backpressure apart from the generic request-rate
+  # 429 (rendered by FallbackController, which carries no `code`). The read was shed to
+  # protect OTHER tenants' access to the shared BYPASSRLS pool — retrying shortly, or
+  # narrowing the query, will succeed.
+  def render("429.json", _assigns) do
+    %{
+      error: %{
+        status: 429,
+        code: "heavy_read_overloaded",
+        message:
+          "This tenant has too many concurrent heavy reads in flight. Please retry shortly."
+      }
+    }
+  end
+
   # Catch-all for any other status code templates
   def render(template, _assigns) do
     status =

--- a/lib/loopctl_web/controllers/knowledge_search_controller.ex
+++ b/lib/loopctl_web/controllers/knowledge_search_controller.ex
@@ -631,7 +631,17 @@ defmodule LoopctlWeb.KnowledgeSearchController do
   defp execute_search(tenant_id, {:search, q}, "semantic", opts) do
     case Knowledge.generate_embedding(tenant_id, q) do
       {:ok, embedding} ->
-        Knowledge.search_semantic(tenant_id, embedding, opts)
+        # US-37.5: an explicit semantic search whose heavy read is SHED (tenant over
+        # its per-tenant in-flight HeavyRead cap) degrades to keyword-only — same
+        # graceful fallback as a keyless tenant — instead of a 429, so a neighbour's
+        # burst can't hard-fail this tenant's search.
+        case Knowledge.search_semantic(tenant_id, embedding, opts) do
+          {:error, :heavy_read_overloaded} ->
+            semantic_keyword_fallback(tenant_id, q, opts, :heavy_read_overloaded)
+
+          result ->
+            result
+        end
 
       {:error, :no_api_key} ->
         # Mandatory BYO (review #8): a keyless tenant's explicit semantic search must

--- a/lib/loopctl_web/plugs/heavy_read_overload_handler.ex
+++ b/lib/loopctl_web/plugs/heavy_read_overload_handler.ex
@@ -1,0 +1,26 @@
+defmodule LoopctlWeb.Plugs.HeavyReadOverloadHandler do
+  @moduledoc """
+  `Plug.Exception` status mapping for a raised `Loopctl.HeavyRead.OverloadedError`
+  (US-37.5).
+
+  When a tenant is over its per-tenant in-flight HeavyRead cap and the read is on an
+  API path (`Loopctl.HeavyRead`'s default `on_overload: :raise`), the read raises
+  `Loopctl.HeavyRead.OverloadedError`. This supplies the HTTP status (429 Too Many
+  Requests) for that raised exception when it reaches Phoenix's `render_errors` path;
+  `LoopctlWeb.ErrorJSON` renders the safe body (`"429.json"`, with a
+  `code: "heavy_read_overloaded"`). Search callers that instead degrade to keyword
+  fallback pass `on_overload: :tag` and never raise.
+
+  Mirrors `LoopctlWeb.Plugs.DBErrorHandler`: an auto-compiled `defimpl`, no
+  router/endpoint registration needed. `status/1` is pure (no side effects) —
+  429 is a normal backpressure response, not a crash, so no structured error log is
+  warranted here (contrast the DB-error path's `DBErrorBackstop`).
+  """
+end
+
+defimpl Plug.Exception, for: Loopctl.HeavyRead.OverloadedError do
+  # 429 Too Many Requests: the tenant is over its per-tenant in-flight slice of the
+  # heavy-read pool. Backpressure/shed, not a server fault (which would be 5xx).
+  def status(_error), do: 429
+  def actions(_error), do: []
+end

--- a/test/loopctl/db_capacity_test.exs
+++ b/test/loopctl/db_capacity_test.exs
@@ -33,6 +33,16 @@ defmodule Loopctl.DbCapacityTest do
     assert pool == DbCapacity.prod_pool_sizes().heavy_read_repo
   end
 
+  test "US-37.5: per-tenant heavy-read slice K is >= 1 and strictly < the pool size" do
+    k = DbCapacity.heavy_read_tenant_slice()
+    pool = DbCapacity.heavy_read_budget().pool
+
+    assert k >= 1
+    # K < pool so no single tenant's cost-weighted concurrent heavy reads can hold the
+    # WHOLE pool — always leaving pool - K slots for other tenants (no cross-tenant 503).
+    assert k < pool
+  end
+
   test "peak budget = steady + one overlap node + per-node notifier + fixed ops" do
     # 2 nodes: 42 steady + 21 overlap + 2 notifier(1/node) + 2 fixed = 67.
     assert DbCapacity.peak_total(2) == 67

--- a/test/loopctl/heavy_read/tenant_gate_test.exs
+++ b/test/loopctl/heavy_read/tenant_gate_test.exs
@@ -13,6 +13,7 @@ defmodule Loopctl.HeavyRead.TenantGateTest do
   use Loopctl.DataCase, async: true
 
   alias Loopctl.DbCapacity
+  alias Loopctl.HeavyRead
   alias Loopctl.HeavyRead.TenantGate
 
   describe "acquire/3 per-tenant concurrency cap (AC-37.5.1)" do
@@ -205,4 +206,107 @@ defmodule Loopctl.HeavyRead.TenantGateTest do
       assert TenantGate.count(tenant, missing) == 0
     end
   end
+
+  # Finding #3 (US-37.5 review): cap/0's live-tunable value MUST be clamped so an
+  # operator knob can neither 500 every heavy read (non-positive → acquire/4's
+  # `cap > 0` guard FunctionClauseError, AC-37.5.5 fail-open violation) nor silently
+  # defeat fairness (K < heavy_weight → all shed; K >= pool → monopolization).
+  describe "clamp_cap/1 range clamp (AC-37.5.5)" do
+    setup do
+      %{lower: TenantGate.heavy_weight(), upper: max(TenantGate.heavy_weight(), pool() - 1)}
+    end
+
+    test "a NON-POSITIVE cap is floored to heavy_weight (never a FunctionClauseError 500)",
+         %{lower: lower} do
+      assert TenantGate.clamp_cap(0) == lower
+      assert TenantGate.clamp_cap(-5) == lower
+
+      # The whole point: the clamped cap is a valid `pos_integer` acquire/4 accepts —
+      # no FunctionClauseError propagates uncaught to 500 every heavy read on the node.
+      tenant = Ecto.UUID.generate()
+      assert TenantGate.acquire(tenant, 1, TenantGate.clamp_cap(0)) == :ok
+      TenantGate.release(tenant, 1)
+    end
+
+    test "a cap BELOW heavy_weight is floored (a single heavy read always fits)", %{lower: lower} do
+      assert TenantGate.clamp_cap(1) == lower
+      assert lower >= TenantGate.heavy_weight()
+    end
+
+    test "a cap AT/ABOVE the pool is capped to pool-1 (a slot always remains for neighbours)",
+         %{upper: upper} do
+      assert TenantGate.clamp_cap(pool()) == upper
+      assert TenantGate.clamp_cap(100_000) == upper
+      assert upper < pool()
+    end
+
+    test "an in-range cap passes through unchanged", %{lower: lower, upper: upper} do
+      in_range = lower..upper |> Enum.to_list() |> Enum.at(div(upper - lower, 2))
+      assert TenantGate.clamp_cap(in_range) == in_range
+    end
+
+    test "cap/0 always resolves a positive integer >= heavy_weight (guard always matches)" do
+      assert TenantGate.cap() >= TenantGate.heavy_weight()
+      assert TenantGate.cap() > 0
+    end
+  end
+
+  # Finding #6 (US-37.5 review): weight_for/1's heavy-endpoint list is hand-maintained;
+  # without a guard a NEW heavy endpoint a caller adds could silently fall through to
+  # LIGHT weight and under-charge a genuinely heavy read. These pin it to
+  # HeavyRead.known_endpoints/0 (the source-of-truth set) so drift fails the suite.
+  describe "endpoint weight drift guard (AC-37.5.2, review finding #6)" do
+    # The DELIBERATE weight for EVERY known endpoint. Adding an endpoint to
+    # HeavyRead.known_endpoints/0 without a decision here fails the coverage test below.
+    @expected_weights %{
+      vector_search: :heavy,
+      semantic_search: :heavy,
+      memory_recall: :heavy,
+      novelty: :heavy,
+      suggested_links: :heavy,
+      distant_pairs: :heavy,
+      distant_pairs_bridge: :heavy,
+      export: :heavy,
+      enumeration: :light,
+      change_feed: :light,
+      ingestion_jobs: :light,
+      sth_incremental: :light
+    }
+
+    test "every @heavy_endpoints atom is a known HeavyRead endpoint (no orphan/typo)" do
+      known = MapSet.new(HeavyRead.known_endpoints())
+
+      for ep <- TenantGate.heavy_endpoints() do
+        assert MapSet.member?(known, ep),
+               "heavy endpoint #{inspect(ep)} is not in HeavyRead.known_endpoints/0 — typo or removed caller?"
+      end
+    end
+
+    test "the expected-weight map covers EXACTLY HeavyRead.known_endpoints/0" do
+      assert MapSet.new(Map.keys(@expected_weights)) == MapSet.new(HeavyRead.known_endpoints()),
+             "a known endpoint has no deliberate heavy/light weight decision (or vice versa) — " <>
+               "update @expected_weights AND TenantGate's @heavy_endpoints together."
+    end
+
+    test "weight_for/1 classifies each known endpoint at its deliberate weight" do
+      heavy = TenantGate.heavy_weight()
+      light = TenantGate.light_weight()
+
+      for {endpoint, kind} <- @expected_weights do
+        expected = if kind == :heavy, do: heavy, else: light
+
+        assert TenantGate.weight_for(endpoint) == expected,
+               "wrong weight for #{inspect(endpoint)}"
+      end
+    end
+
+    test "an unknown/nil endpoint weights LIGHT (safe default for a bare heavy read)" do
+      assert TenantGate.weight_for(nil) == TenantGate.light_weight()
+
+      assert TenantGate.weight_for(:some_future_unregistered_endpoint) ==
+               TenantGate.light_weight()
+    end
+  end
+
+  defp pool, do: DbCapacity.heavy_read_budget().pool
 end

--- a/test/loopctl/heavy_read/tenant_gate_test.exs
+++ b/test/loopctl/heavy_read/tenant_gate_test.exs
@@ -1,0 +1,208 @@
+defmodule Loopctl.HeavyRead.TenantGateTest do
+  @moduledoc """
+  US-37.5 — per-tenant, cost-weighted, node-local in-flight limiter on the HeavyRead
+  pool.
+
+  Exercises the pure core (`acquire/3` / `release/2`) against EXPLICIT low caps and
+  explicit heavy-vs-light weights, so no global config is mutated (no
+  `Application.put_env`) and the async, VM-wide shared counters never collide (each
+  test uses fresh random `tenant_id`s). Covers the per-tenant cap (AC-37.5.1), cost
+  weighting (AC-37.5.2), over-cap shed + release (AC-37.5.3), tenant isolation +
+  fairness outcome (AC-37.5.4), and the env-driven defaults + fail-open (AC-37.5.5).
+  """
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.DbCapacity
+  alias Loopctl.HeavyRead.TenantGate
+
+  describe "acquire/3 per-tenant concurrency cap (AC-37.5.1)" do
+    test "a tenant holding K slots is shed on the K+1th, while another tenant can still acquire" do
+      tenant_a = Ecto.UUID.generate()
+      tenant_b = Ecto.UUID.generate()
+      cap = 2
+
+      # A holds K=2 (weight 1 each) — both admitted.
+      assert TenantGate.acquire(tenant_a, 1, cap) == :ok
+      assert TenantGate.acquire(tenant_a, 1, cap) == :ok
+
+      # The K+1th for A is shed — A cannot exceed its slice.
+      assert TenantGate.acquire(tenant_a, 1, cap) == {:error, :heavy_read_overloaded}
+
+      # B is a different tenant: its counter is independent, so it still acquires.
+      assert TenantGate.acquire(tenant_b, 1, cap) == :ok
+
+      assert TenantGate.count(tenant_a) == 2
+      assert TenantGate.count(tenant_b) == 1
+    end
+
+    test "the shed acquire leaves NO budget reserved (the undo is atomic)" do
+      tenant = Ecto.UUID.generate()
+      cap = 1
+
+      assert TenantGate.acquire(tenant, 1, cap) == :ok
+      assert TenantGate.acquire(tenant, 1, cap) == {:error, :heavy_read_overloaded}
+
+      # The shed acquire's transient +1 was undone: the tenant still holds exactly 1.
+      assert TenantGate.count(tenant) == 1
+    end
+  end
+
+  describe "cost weighting (AC-37.5.2)" do
+    test "a heavier read consumes more budget — fewer concurrent heavy than light within one cap" do
+      cap = 4
+      heavy = TenantGate.heavy_weight()
+      light = TenantGate.light_weight()
+
+      assert heavy > light, "heavy reads must cost strictly more than light ones"
+
+      # HEAVY: with weight #{2} and cap 4, only 2 concurrent heavy reads fit (2+2=4);
+      # the 3rd (would be 6 > 4) is shed.
+      heavy_tenant = Ecto.UUID.generate()
+      assert TenantGate.acquire(heavy_tenant, heavy, cap) == :ok
+      assert TenantGate.acquire(heavy_tenant, heavy, cap) == :ok
+      assert TenantGate.acquire(heavy_tenant, heavy, cap) == {:error, :heavy_read_overloaded}
+
+      # LIGHT: with weight 1 and the SAME cap 4, four concurrent light reads fit; the
+      # 5th is shed. Strictly MORE concurrent light reads than heavy within one budget.
+      light_tenant = Ecto.UUID.generate()
+      for _ <- 1..cap, do: assert(TenantGate.acquire(light_tenant, light, cap) == :ok)
+      assert TenantGate.acquire(light_tenant, light, cap) == {:error, :heavy_read_overloaded}
+    end
+
+    test "weight_for/1 classifies known heavy endpoints above light/unknown ones" do
+      heavy = TenantGate.heavy_weight()
+      light = TenantGate.light_weight()
+
+      for endpoint <- [
+            :vector_search,
+            :semantic_search,
+            :memory_recall,
+            :novelty,
+            :suggested_links,
+            :distant_pairs,
+            :distant_pairs_bridge
+          ] do
+        assert TenantGate.weight_for(endpoint) == heavy
+      end
+
+      for endpoint <- [:change_feed, :enumeration, :ingestion_jobs, :sth_incremental, nil] do
+        assert TenantGate.weight_for(endpoint) == light
+      end
+    end
+  end
+
+  describe "over-cap shed + release (AC-37.5.3)" do
+    test "an over-cap tenant is shed with :heavy_read_overloaded while another tenant is served" do
+      tenant_a = Ecto.UUID.generate()
+      tenant_b = Ecto.UUID.generate()
+      cap = 2
+
+      for _ <- 1..cap, do: assert(TenantGate.acquire(tenant_a, 1, cap) == :ok)
+      # A is saturated → shed with the exact tagged error the callers map to a
+      # graceful response (keyword fallback / 429), NOT a pool-exhaustion crash.
+      assert TenantGate.acquire(tenant_a, 1, cap) == {:error, :heavy_read_overloaded}
+
+      # B — sharing the same node-local gate — is unaffected and gets service.
+      assert TenantGate.acquire(tenant_b, 1, cap) == :ok
+    end
+
+    test "releasing a slot lets a previously-shed tenant acquire again" do
+      tenant = Ecto.UUID.generate()
+      cap = 1
+
+      assert TenantGate.acquire(tenant, 1, cap) == :ok
+      assert TenantGate.acquire(tenant, 1, cap) == {:error, :heavy_read_overloaded}
+
+      # Free the held slot; the tenant now fits again.
+      assert TenantGate.release(tenant, 1) == :ok
+      assert TenantGate.count(tenant) == 0
+      assert TenantGate.acquire(tenant, 1, cap) == :ok
+    end
+
+    test "release floors at 0 — a stray/extra release never drives the counter negative" do
+      tenant = Ecto.UUID.generate()
+
+      assert TenantGate.release(tenant, 5) == :ok
+      assert TenantGate.count(tenant) == 0
+
+      assert TenantGate.acquire(tenant, 1, 1) == :ok
+      # Two releases for one acquire: the second floors at 0, never negative (which
+      # would inflate the effective cap).
+      assert TenantGate.release(tenant, 1) == :ok
+      assert TenantGate.release(tenant, 1) == :ok
+      assert TenantGate.count(tenant) == 0
+    end
+  end
+
+  describe "tenant isolation + fairness outcome (AC-37.5.4)" do
+    test "tenant A's in-flight count NEVER includes tenant B's" do
+      tenant_a = Ecto.UUID.generate()
+      tenant_b = Ecto.UUID.generate()
+      cap = 3
+
+      # A saturates its own slice.
+      for _ <- 1..cap, do: assert(TenantGate.acquire(tenant_a, 1, cap) == :ok)
+      # A pile of B's acquisitions on the same node must be invisible to A's counter.
+      for _ <- 1..cap, do: assert(TenantGate.acquire(tenant_b, 1, cap) == :ok)
+
+      assert TenantGate.count(tenant_a) == cap
+      assert TenantGate.count(tenant_b) == cap
+      # A's decision reads only A's count — A is capped...
+      assert TenantGate.acquire(tenant_a, 1, cap) == {:error, :heavy_read_overloaded}
+    end
+
+    test "with A saturating its cap, B makes progress (outcome class — B is not starved)" do
+      tenant_a = Ecto.UUID.generate()
+      tenant_b = Ecto.UUID.generate()
+      cap = 2
+
+      # A continuously saturates its slice and is shed on further attempts.
+      for _ <- 1..cap, do: assert(TenantGate.acquire(tenant_a, 1, cap) == :ok)
+      assert TenantGate.acquire(tenant_a, 1, cap) == {:error, :heavy_read_overloaded}
+      assert TenantGate.acquire(tenant_a, 1, cap) == {:error, :heavy_read_overloaded}
+
+      # OUTCOME class (not exact instantaneous counts): B still acquires AND releases
+      # its full cap repeatedly while A stays capped — B makes progress, unstarved.
+      for _ <- 1..5 do
+        assert TenantGate.acquire(tenant_b, 1, cap) == :ok
+        assert TenantGate.release(tenant_b, 1) == :ok
+      end
+
+      # A releasing one of its held slots lets A make progress too — the gate is a
+      # latency bound, never a permanent wedge.
+      assert TenantGate.release(tenant_a, 1) == :ok
+      assert TenantGate.acquire(tenant_a, 1, cap) == :ok
+    end
+  end
+
+  describe "env-driven caps/weights + fail-open (AC-37.5.5)" do
+    test "the default per-tenant slice K is < the heavy-read pool size and >= 1" do
+      k = DbCapacity.heavy_read_tenant_slice()
+      pool = DbCapacity.heavy_read_budget().pool
+
+      assert k >= 1
+      assert k < pool, "K (#{k}) must be < pool (#{pool}) so no tenant can take the whole pool"
+      # K must admit at least one HEAVY read (cap >= heavy weight), else a single heavy
+      # read would always shed — the gate would starve a tenant to zero heavy reads.
+      assert k >= TenantGate.heavy_weight()
+    end
+
+    test "cap/0 resolves a positive integer from config (documented default on a miss)" do
+      assert is_integer(TenantGate.cap())
+      assert TenantGate.cap() > 0
+    end
+
+    test "acquire fails OPEN (allows the read) when the limiter faults — a broken gate never blocks" do
+      tenant = Ecto.UUID.generate()
+      # A table that was never created: :ets.update_counter raises, so the rescue must
+      # fail OPEN with :ok rather than blocking the read. Uses the table-parameterized
+      # core so the shared, VM-wide production table is untouched.
+      missing = :"loopctl_heavy_read_inflight_missing_#{System.unique_integer([:positive])}"
+
+      assert TenantGate.acquire(tenant, 1, 1, missing) == :ok
+      # release + count on a missing table are also fail-safe (no crash).
+      assert TenantGate.release(tenant, 1, missing) == :ok
+      assert TenantGate.count(tenant, missing) == 0
+    end
+  end
+end

--- a/test/loopctl/heavy_read/tenant_gate_test.exs
+++ b/test/loopctl/heavy_read/tenant_gate_test.exs
@@ -249,6 +249,28 @@ defmodule Loopctl.HeavyRead.TenantGateTest do
       assert TenantGate.cap() >= TenantGate.heavy_weight()
       assert TenantGate.cap() > 0
     end
+
+    # US-37.5 review finding: the CAP got clamp_cap/1 hardening, but the sibling WEIGHT
+    # knobs were unvalidated — a non-positive `:heavy_read_weight_heavy|_light` would flow
+    # through weight_for/1 into acquire/4's `weight > 0` guard, miss every clause, and raise
+    # a FunctionClauseError OUTSIDE the acquire rescue (not an OverloadedError → the 429
+    # handler never fires) → a node-wide 500 on every heavy read of that class. The
+    # accessors are now FLOORED at 1, so no weight_for/1 output can ever miss the guard.
+    test "weight accessors are always positive and every endpoint weight satisfies acquire's guard" do
+      assert TenantGate.heavy_weight() >= 1
+      assert TenantGate.light_weight() >= 1
+
+      cap = TenantGate.cap()
+      tenant = Ecto.UUID.generate()
+
+      for ep <- HeavyRead.known_endpoints() do
+        w = TenantGate.weight_for(ep)
+        assert is_integer(w) and w > 0, "endpoint #{inspect(ep)} yielded a non-positive weight"
+        # A positive weight the `weight > 0` guard accepts — no uncaught FunctionClauseError.
+        assert TenantGate.acquire(tenant, w, cap) == :ok
+        TenantGate.release(tenant, w)
+      end
+    end
   end
 
   # Finding #6 (US-37.5 review): weight_for/1's heavy-endpoint list is hand-maintained;
@@ -270,7 +292,8 @@ defmodule Loopctl.HeavyRead.TenantGateTest do
       enumeration: :light,
       change_feed: :light,
       ingestion_jobs: :light,
-      sth_incremental: :light
+      sth_incremental: :light,
+      llm_usage: :light
     }
 
     test "every @heavy_endpoints atom is a known HeavyRead endpoint (no orphan/typo)" do

--- a/test/loopctl/heavy_read_guard_test.exs
+++ b/test/loopctl/heavy_read_guard_test.exs
@@ -43,4 +43,46 @@ defmodule Loopctl.HeavyReadGuardTest do
         String.contains?(line, "alias Loopctl.HeavyReadRepo")
     end)
   end
+
+  # US-37.5 review finding #5: `@known_endpoints` is documented as the SOURCE OF TRUTH the
+  # TenantGate weight-drift guard partitions into heavy/light. That guard
+  # (`tenant_gate_test.exs`) only checks endpoints ALREADY in `known_endpoints/0`, so an
+  # endpoint introduced the `:llm_usage` way — a literal `HeavyRead.opts(:new_endpoint)`
+  # call added WITHOUT registering it — escaped the guard and silently got LIGHT weight,
+  # under-charging a potentially heavy read. This static scan closes that hole: every
+  # literal atom passed to `HeavyRead.opts/1` (directly or via the `heavy_read_opts/1`
+  # delegate) across `lib/` MUST be a `known_endpoints/0` member, so registering a new
+  # endpoint (and thus making a deliberate heavy/light decision) is unskippable.
+  @opts_call_regex ~r/(?:HeavyRead\.opts|heavy_read_opts)\(:([a-z_]+)\)/
+
+  test "every literal HeavyRead.opts(:endpoint) atom in lib/ is a known endpoint" do
+    known = MapSet.new(Loopctl.HeavyRead.known_endpoints())
+
+    unregistered =
+      @lib_root
+      |> Path.join("**/*.ex")
+      |> Path.wildcard()
+      |> Enum.flat_map(&opts_endpoint_atoms/1)
+      |> Enum.uniq()
+      |> Enum.reject(&MapSet.member?(known, &1))
+
+    assert unregistered == [],
+           "These endpoint atoms are passed to HeavyRead.opts/1 in lib/ but are NOT in " <>
+             "Loopctl.HeavyRead.known_endpoints/0 — register them (with a deliberate " <>
+             "heavy/light weight decision in TenantGate) so the drift guard can see them: " <>
+             inspect(unregistered)
+  end
+
+  # Literal endpoint atoms passed to `opts/1` on non-comment lines of a source file.
+  defp opts_endpoint_atoms(path) do
+    path
+    |> File.read!()
+    |> String.split("\n")
+    |> Enum.reject(&(String.trim_leading(&1) |> String.starts_with?("#")))
+    |> Enum.flat_map(fn line ->
+      @opts_call_regex
+      |> Regex.scan(line, capture: :all_but_first)
+      |> Enum.map(fn [atom] -> String.to_atom(atom) end)
+    end)
+  end
 end

--- a/test/loopctl/heavy_read_test.exs
+++ b/test/loopctl/heavy_read_test.exs
@@ -10,6 +10,8 @@ defmodule Loopctl.HeavyReadTest do
   use Loopctl.DataCase, async: true
 
   alias Loopctl.HeavyRead
+  alias Loopctl.HeavyRead.OverloadedError
+  alias Loopctl.HeavyRead.TenantGate
   alias Loopctl.Knowledge.Article
 
   import Ecto.Query
@@ -222,6 +224,79 @@ defmodule Loopctl.HeavyReadTest do
       assert_raise ArgumentError, ~r/scoped to the given tenant/, fn ->
         HeavyRead.all(Ecto.UUID.generate(), q)
       end
+    end
+  end
+
+  describe "per-tenant in-flight gate wired into the wrapper (US-37.5, AC-37.5.3)" do
+    # Force over-cap deterministically for a FRESH random tenant WITHOUT global config
+    # mutation: pre-fill its in-flight counter to exactly the configured cap with one
+    # high-weight acquire, so the very next wired heavy read (adding weight >= 1)
+    # exceeds the cap and is shed. Another tenant's counter is untouched, so it is
+    # served — the isolation the gate guarantees.
+    setup do
+      cap = TenantGate.cap()
+      {:ok, cap: cap}
+    end
+
+    test "an over-cap tenant's API read RAISES OverloadedError while another tenant is served",
+         %{cap: cap} do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      a1 = fixture(:article, %{tenant_id: tenant_a.id, title: "A-only"})
+      b1 = fixture(:article, %{tenant_id: tenant_b.id, title: "B-only"})
+
+      query_for = fn tid ->
+        from(a in Article, where: a.tenant_id == ^tid, select: %{id: a.id})
+      end
+
+      # Saturate A's slice exactly.
+      assert TenantGate.acquire(tenant_a.id, cap, cap) == :ok
+
+      # A's next heavy read (default on_overload: :raise → API path) is SHED as a 429.
+      assert_raise OverloadedError, fn ->
+        HeavyRead.all(tenant_a.id, query_for.(tenant_a.id), HeavyRead.opts(:enumeration))
+      end
+
+      # B — sharing the same node-local gate — is unaffected: it gets real rows, not a
+      # pool-exhaustion crash. Isolation: A's saturation never touched B's counter.
+      results_b =
+        HeavyRead.all(tenant_b.id, query_for.(tenant_b.id), HeavyRead.opts(:enumeration))
+
+      assert Enum.map(results_b, & &1.id) == [b1.id]
+
+      # Cleanup the pre-filled budget so the shared VM-wide counter doesn't leak.
+      TenantGate.release(tenant_a.id, cap)
+      assert a1.id
+    end
+
+    test "on_overload: :tag returns {:error, :heavy_read_overloaded} (search keyword-fallback path)",
+         %{cap: cap} do
+      tenant = fixture(:tenant)
+      _ = fixture(:article, %{tenant_id: tenant.id})
+      query = from(a in Article, where: a.tenant_id == ^tenant.id, select: %{id: a.id})
+
+      assert TenantGate.acquire(tenant.id, cap, cap) == :ok
+
+      # With :tag, an over-cap shed returns the tagged tuple (search degrades to keyword
+      # fallback) instead of raising — the graceful path for the semantic search caller.
+      assert HeavyRead.all(tenant.id, query, [
+               {:on_overload, :tag} | HeavyRead.opts(:semantic_search)
+             ]) ==
+               {:error, :heavy_read_overloaded}
+
+      TenantGate.release(tenant.id, cap)
+    end
+
+    test "under cap, the wired gate is transparent — a normal read returns rows and frees its slot" do
+      tenant = fixture(:tenant)
+      a1 = fixture(:article, %{tenant_id: tenant.id})
+      query = from(a in Article, where: a.tenant_id == ^tenant.id, select: %{id: a.id})
+
+      results = HeavyRead.all(tenant.id, query, HeavyRead.opts(:enumeration))
+      assert Enum.map(results, & &1.id) == [a1.id]
+
+      # The slot was released in the `after` — the tenant holds zero budget afterward.
+      assert TenantGate.count(tenant.id) == 0
     end
   end
 

--- a/test/loopctl/knowledge/distant_pairs_novelty_test.exs
+++ b/test/loopctl/knowledge/distant_pairs_novelty_test.exs
@@ -199,5 +199,32 @@ defmodule Loopctl.Knowledge.DistantPairsNoveltyTest do
       # Idea identical to the base-prior ⇒ MIN distance ≈ 0.
       assert_in_delta scored.novelty_score, 0.0, 1.0e-4
     end
+
+    # US-37.5: when the tenant is over its per-tenant HeavyRead slice, the novelty aggregate
+    # is SHED. `nearest_prior_distance/4` now passes `on_overload: :tag` and maps the shed to
+    # a DELIBERATE nil score — a graceful degrade, NOT a raised OverloadedError caught as an
+    # incidental Task.async_stream `{:exit, _}`. prior_count is unaffected (its count query is
+    # not gated), so a nil score under load stays distinguishable via the surrounding context.
+    test "novelty_score degrades to nil (not a crash) when the HeavyRead gate sheds the aggregate",
+         %{tenant: tenant} do
+      alias Loopctl.HeavyRead.TenantGate
+
+      idea_vec = embedding_at(:math.pi() / 6)
+
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:ok, idea_vec}
+      end)
+
+      # Saturate the tenant's in-flight HeavyRead budget so the novelty MIN(<=>) read sheds.
+      cap = TenantGate.cap()
+      assert :ok = TenantGate.acquire(tenant.id, cap, cap)
+      on_exit(fn -> TenantGate.release(tenant.id, cap) end)
+
+      assert {:ok, [scored], prior_count} =
+               Knowledge.novelty_scores(tenant.id, [%{text: "an idea"}])
+
+      assert prior_count == 2
+      assert scored.novelty_score == nil
+    end
   end
 end

--- a/test/loopctl/knowledge/proposal_gate_test.exs
+++ b/test/loopctl/knowledge/proposal_gate_test.exs
@@ -5,6 +5,7 @@ defmodule Loopctl.Knowledge.ProposalGateTest do
 
   setup :verify_on_exit!
 
+  alias Loopctl.HeavyRead.TenantGate
   alias Loopctl.Knowledge
   alias Loopctl.Knowledge.ProposalGate
 
@@ -100,6 +101,32 @@ defmodule Loopctl.Knowledge.ProposalGateTest do
     test "system scope (nil tenant) skips the gate" do
       assert %{verdict: :unknown, neighbors: []} =
                ProposalGate.assess(nil, %{"title" => "X", "body" => "Y"})
+    end
+
+    # Finding #1 (US-37.5 review): assess/3 runs SYNCHRONOUSLY in the knowledge_create
+    # write path. Its novelty read goes through the per-tenant HeavyRead gate; an
+    # over-cap tenant must NOT 429 the WRITE — the gate falls OPEN (:unknown), matching
+    # its treatment of every other novelty-check failure.
+    test "falls OPEN (:unknown) when the novelty read is SHED over-cap — never 429s a write",
+         %{tenant: tenant} do
+      stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:ok, e([1.0])}
+      end)
+
+      # Saturate this tenant's per-tenant in-flight slice so the very next heavy read
+      # (the novelty kNN) is shed. cap/0 is the clamped live value the wired gate uses.
+      cap = TenantGate.cap()
+      assert TenantGate.acquire(tenant.id, cap, cap) == :ok
+
+      assessment = ProposalGate.assess(tenant.id, %{"title" => "Supervisors", "body" => "OTP"})
+
+      # Fall OPEN: no verdict, no neighbors — the write proceeds unblocked, NOT a raise.
+      assert assessment.verdict == :unknown
+      assert assessment.score == nil
+      assert assessment.neighbors == []
+
+      # Release the pre-filled budget so the shared VM-wide counter doesn't leak.
+      TenantGate.release(tenant.id, cap)
     end
   end
 end

--- a/test/loopctl/knowledge_semantic_search_test.exs
+++ b/test/loopctl/knowledge_semantic_search_test.exs
@@ -3,6 +3,7 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
 
   setup :verify_on_exit!
 
+  alias Loopctl.HeavyRead.TenantGate
   alias Loopctl.Knowledge
   alias Loopctl.Knowledge.EmbeddingConcurrency
 
@@ -413,6 +414,46 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
       # Should still find via keyword match
       assert results != []
       assert Enum.any?(results, &(&1.title == "Testing Guide"))
+    end
+  end
+
+  # Finding #4 (US-37.5 review): the user-facing keyword-fallback-on-overload degrade
+  # (search_semantic → {:error, :heavy_read_overloaded} → combined_keyword_fallback)
+  # had no coverage. Here the embedding SUCCEEDS but the semantic heavy read is SHED
+  # over the per-tenant cap, so combined search must degrade to keyword_only and
+  # surface `meta.fallback_reason == "heavy_read_overloaded"` — the SAME graceful path
+  # as an embedding failure, keeping other tenants' access to the shared pool.
+  describe "search_combined/3 - keyword fallback on over-cap semantic shed (US-37.5)" do
+    test "an over-cap semantic shed → keyword_only + fallback_reason heavy_read_overloaded" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      fixture(:article, %{
+        tenant_id: tenant.id,
+        title: "Testing Guide",
+        body: "Unit test patterns for testing Elixir applications.",
+        status: :published
+      })
+
+      # Embedding SUCCEEDS (so the semantic branch is attempted); the semantic HeavyRead
+      # (search_semantic, on_overload: :tag) then sheds because the tenant is over-cap.
+      # Keyword search runs on AdminRepo (ungated), so it still returns matches.
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:ok, make_embedding(:query)}
+      end)
+
+      cap = TenantGate.cap()
+      assert TenantGate.acquire(tenant.id, cap, cap) == :ok
+
+      assert {:ok, %{results: results, meta: meta}} =
+               Knowledge.search_combined(tenant.id, "testing")
+
+      assert meta.search_mode == "keyword_only"
+      assert meta.fallback == true
+      assert meta.fallback_reason == "heavy_read_overloaded"
+      assert Enum.any?(results, &(&1.title == "Testing Guide"))
+
+      TenantGate.release(tenant.id, cap)
     end
   end
 

--- a/test/loopctl/memory/promotion_test.exs
+++ b/test/loopctl/memory/promotion_test.exs
@@ -150,6 +150,32 @@ defmodule Loopctl.Memory.PromotionTest do
       assert all_promoted(other.id, "A") == []
     end
 
+    # US-37.5: when the tenant is over its per-tenant HeavyRead slice, the near-dup recall
+    # is SHED (`on_overload: :tag`) and `persist_promotion/2` returns a loss-free
+    # `{:error, :heavy_read_overloaded}` — NOT a raised OverloadedError — and writes nothing.
+    test "returns {:error, :heavy_read_overloaded} (no rows) when the HeavyRead gate sheds" do
+      alias Loopctl.HeavyRead.TenantGate
+
+      tenant = fixture(:tenant)
+      scope = %{fixture(:memory_scope, tenant_id: tenant.id, subject_id: "A") | session_id: "s1"}
+
+      candidate = %{
+        text: "fact under overload",
+        when_to_apply: "",
+        tags: [],
+        confidence: 0.9,
+        cross_links: []
+      }
+
+      # Saturate the fresh tenant's in-flight budget so the near-dup recall sheds.
+      cap = TenantGate.cap()
+      assert :ok = TenantGate.acquire(tenant.id, cap, cap)
+      on_exit(fn -> TenantGate.release(tenant.id, cap) end)
+
+      assert {:error, :heavy_read_overloaded} = Memory.persist_promotion(scope, [candidate])
+      assert all_promoted(tenant.id, "A") == []
+    end
+
     test "structurally refuses the reserved promotion-eval subject (US-29.5 AC-29.5.3)" do
       tenant = fixture(:tenant)
       eval_subject = Memory.eval_subject_id()

--- a/test/loopctl/workers/article_linking_worker_test.exs
+++ b/test/loopctl/workers/article_linking_worker_test.exs
@@ -240,6 +240,33 @@ defmodule Loopctl.Workers.ArticleLinkingWorkerTest do
     end
   end
 
+  # Finding #2 (US-37.5 review): when the per-tenant HeavyRead gate sheds the kNN read
+  # (returned as `{:error, :heavy_read_overloaded}` via `on_overload: :tag`), the worker
+  # must yield LOSS-FREE with `{:snooze, n}` — not error/retry-churn toward max_attempts
+  # (which could permanently lose an article's auto-links under a sustained burst).
+  describe "perform/1 heavy-read overload (US-37.5)" do
+    test "passes on_overload: :tag and SNOOZES (no attempt consumed) when the read is shed" do
+      %{tenant: tenant} = setup_tenant()
+      source = create_published_article(tenant.id)
+
+      expect(MockArticleSimilaritySearch, :nearest, fn _t, _emb, _k, opts ->
+        # The worker asks for the graceful-degrade disposition, not a raise.
+        assert Keyword.fetch!(opts, :on_overload) == :tag
+        {:error, :heavy_read_overloaded}
+      end)
+
+      assert {:snooze, seconds} =
+               ArticleLinkingWorker.perform(%Oban.Job{
+                 args: %{"article_id" => source.id, "tenant_id" => tenant.id}
+               })
+
+      assert is_integer(seconds) and seconds > 0
+
+      # No links were created — the job made no partial progress before snoozing.
+      assert AdminRepo.all(from(l in ArticleLink, where: l.tenant_id == ^tenant.id)) == []
+    end
+  end
+
   # --- TC-21.2.2: Skips articles below threshold ---
 
   describe "perform/1 threshold filtering" do

--- a/test/loopctl/workers/compute_sth_worker_test.exs
+++ b/test/loopctl/workers/compute_sth_worker_test.exs
@@ -11,6 +11,7 @@ defmodule Loopctl.Workers.ComputeSthWorkerTest do
 
   alias Loopctl.AdminRepo
   alias Loopctl.AuditChain
+  alias Loopctl.HeavyRead.TenantGate
   alias Loopctl.Tenants.Tenant
   alias Loopctl.Workers.ComputeSthWorker
 
@@ -140,6 +141,32 @@ defmodule Loopctl.Workers.ComputeSthWorkerTest do
       sth = AuditChain.get_latest_sth(tenant.id)
       assert %AuditChain.SignedTreeHead{} = sth
       assert sth.chain_position == 0
+    end
+
+    # Finding #2 (US-37.5 review): the STH tail read goes through the per-tenant
+    # HeavyRead gate (endpoint :sth_incremental). Under a tenant's heavy-read burst it
+    # can shed (OverloadedError); the worker must SNOOZE (loss-free) rather than
+    # error/retry-churn toward max_attempts and drop a custody-critical checkpoint.
+    test "SNOOZES (no attempt consumed) when the STH read is shed over-cap" do
+      {tenant, _priv} = signing_tenant()
+      {:ok, _} = AuditChain.append(tenant.id, append_attrs())
+
+      # Reaches the sign path (an appended entry, no STH yet), then the tail read sheds.
+      assert AuditChain.sth_needed?(tenant.id)
+
+      # Saturate this tenant's per-tenant in-flight slice so the STH heavy read is shed.
+      cap = TenantGate.cap()
+      assert TenantGate.acquire(tenant.id, cap, cap) == :ok
+
+      assert {:snooze, seconds} =
+               ComputeSthWorker.perform(%Oban.Job{args: %{"tenant_id" => tenant.id}})
+
+      assert is_integer(seconds) and seconds > 0
+
+      # No STH was written — the shed happened before any signing/persistence.
+      assert AuditChain.get_latest_sth(tenant.id) == nil
+
+      TenantGate.release(tenant.id, cap)
     end
   end
 

--- a/test/loopctl/workers/memory_promotion_worker_test.exs
+++ b/test/loopctl/workers/memory_promotion_worker_test.exs
@@ -358,6 +358,37 @@ defmodule Loopctl.Workers.MemoryPromotionWorkerTest do
   end
 
   # ---------------------------------------------------------------------------
+  # US-37.5 — HeavyRead per-tenant gate shed on the promotion WRITE path
+  # ---------------------------------------------------------------------------
+
+  describe "perform/1 — HeavyRead gate shed (US-37.5)" do
+    alias Loopctl.HeavyRead.TenantGate
+
+    test "an over-cap near-dup recall SNOOZES loss-free (no attempt burned, no watermark, no rows)" do
+      scope = fixture(:memory_scope, subject_id: "A")
+      stub_embeddings(& &1)
+
+      seed_turns(scope, "s1", ["one", "two"])
+      stub_llm([%{text: "would-be fact", confidence: 0.9}])
+
+      # Saturate THIS (fresh, isolated) tenant's per-tenant HeavyRead in-flight budget so
+      # the near-dup HNSW recall is SHED. Because `find_promoted_near_dup/2` passes
+      # `on_overload: :tag`, the shed returns `{:error, :heavy_read_overloaded}` and
+      # propagates to a loss-free `{:snooze, n}` — NOT a raised OverloadedError that would
+      # burn an Oban attempt toward max_attempts on the write path.
+      cap = TenantGate.cap()
+      assert :ok = TenantGate.acquire(scope.tenant_id, cap, cap)
+      on_exit(fn -> TenantGate.release(scope.tenant_id, cap) end)
+
+      assert {:snooze, _} = run(scope, "s1")
+      # Loss-free: nothing persisted and no watermark advance, so a later run (once the
+      # tenant's heavy-read burst subsides) re-attempts the promotion.
+      assert all_promoted(scope) == []
+      assert watermark(scope, "s1") == nil
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # TC-29.2.6 — scope isolation
   # ---------------------------------------------------------------------------
 

--- a/test/loopctl_web/controllers/knowledge_suggest_links_controller_test.exs
+++ b/test/loopctl_web/controllers/knowledge_suggest_links_controller_test.exs
@@ -3,6 +3,7 @@ defmodule LoopctlWeb.KnowledgeSuggestLinksControllerTest do
 
   alias Ecto.Adapters.SQL
   alias Loopctl.AdminRepo
+  alias Loopctl.HeavyRead.TenantGate
   alias Loopctl.Knowledge
   alias Loopctl.Knowledge.ArticleLink
 
@@ -617,6 +618,42 @@ defmodule LoopctlWeb.KnowledgeSuggestLinksControllerTest do
       # (generous CI headroom; the precise timing assertion is in the unit test).
       assert elapsed_us / 1_000 < 900,
              "request should fast-fail near the timeout, took #{elapsed_us / 1_000}ms"
+    end
+  end
+
+  # Finding #4 (US-37.5 review): the user-facing OverloadedError → 429 render envelope
+  # had NO end-to-end coverage. This asserts a REAL heavy read shed over the per-tenant
+  # in-flight cap surfaces as a 429 carrying the self-identifying
+  # `code: "heavy_read_overloaded"` at the HTTP boundary (status mapping via
+  # HeavyReadOverloadHandler → ErrorJSON "429.json"). Mirrors the 504 db-timeout e2e
+  # above, but for the per-tenant shed.
+  describe "per-tenant heavy-read overload -> 429 (US-37.5, AC-37.5.3)" do
+    test "an over-cap tenant's heavy read surfaces as 429 heavy_read_overloaded", %{conn: conn} do
+      {tenant, key} = setup_tenant_key()
+      target = embedded(tenant.id, "Target", [1.0, 0.0])
+
+      # Saturate this tenant's per-tenant in-flight slice so the very next wired heavy
+      # read is shed. The DataCase default stub routes suggest_links_with_meta to the
+      # REAL Knowledge path, whose read runs with the default `on_overload: :raise` (an
+      # API read). Unlike a DB-timeout (which the controller rescues into a tuple),
+      # OverloadedError is NOT rescued — it propagates to Phoenix render_errors, which
+      # maps it via HeavyReadOverloadHandler → 429 and re-raises, so this asserts the
+      # SENT error response with `assert_error_sent`.
+      cap = TenantGate.cap()
+      assert TenantGate.acquire(tenant.id, cap, cap) == :ok
+
+      {429, _headers, body} =
+        assert_error_sent(429, fn ->
+          conn
+          |> auth_conn(key)
+          |> get(~p"/api/v1/knowledge/articles/#{target.id}/suggested_links")
+        end)
+
+      decoded = Jason.decode!(body)
+      assert decoded["error"]["status"] == 429
+      assert decoded["error"]["code"] == "heavy_read_overloaded"
+
+      TenantGate.release(tenant.id, cap)
     end
   end
 end


### PR DESCRIPTION
## US-37.5 — Per-tenant in-flight concurrency cap + cost-weighted limiter on the HeavyRead pool

Closes #354.

### Problem
Epic 33 gave heavy/BYPASSRLS reads their own isolated Ecto pool (Loopctl.HeavyReadRepo, default 8) with a per-read SET LOCAL statement_timeout, but that pool is **global**: one tenant's burst of heavy vector/analytic reads could hold all N connections and effectively 503 every other tenant. Loopctl.HeavyRead was only a tenant-scoping guard + timeout wrapper, not a limiter. Loopctl.Oban.FairShare (US-36.2) bounds Oban *queue* slots, not this synchronous pool.

### What this adds
A **node-local, per-tenant, cost-weighted in-flight semaphore** so no tenant can hold more than K of the N HeavyRead slots at once, failing fast / degrading over-cap instead of exhausting the pool.

- **NEW Loopctl.HeavyRead.TenantGate** — lock-free ETS atomic counter (NOT a serialized GenServer, per the OTP Iron Law) keyed by tenant_id. A tiny supervised owner holds the table; acquire/3 + release/2 bypass it via :ets.update_counter (atomic add-if-under-cap / floored subtract). **Fails OPEN** on a limiter fault (allows the read + logs); a malformed cap fails loud. **Cost-weighted**: heavy endpoints (vector/kNN, semantic ranking, memory recall, novelty, suggested-links, distant-pairs) cost 2, light ones cost 1 — so fewer concurrent heavy reads than light fit one K budget.
- **Wired into HeavyRead.all/3, one/3, all_memory/4** — acquire, run, release with release in an after (crash-safe). Over-cap: on_overload: :raise (default, API reads) raises Loopctl.HeavyRead.OverloadedError -> **429** with the app error envelope (Plug.Exception + ErrorJSON 429.json); search callers pass on_overload: :tag, get {:error, :heavy_read_overloaded}, and **degrade to keyword fallback** (combined + explicit-semantic controller paths).
- **DbCapacity.heavy_read_tenant_slice/0 = 4** (K < pool 8, >= 1). K/weights env-driven via the heavy_read_tenant_cap SystemConfig key + app env; config/test.exs sets a high suite-wide cap so the wired gate is a no-op across incidental parallel heavy reads (embedding/export precedent).
- Node-local by design; cluster-wide budget deferred to Epic 38.

### Acceptance criteria
- **AC-37.5.1** cap gates checkouts; A holding K is shed on K+1 while B acquires — tenant_gate_test + heavy_read_test.
- **AC-37.5.2** cost-weighted; fewer concurrent heavy than light within one budget — tenant_gate_test.
- **AC-37.5.3** over-cap -> tagged error / 429 / keyword fallback; other tenants still served, no pool-exhaustion crash — tenant_gate_test + heavy_read_test + wired callers.
- **AC-37.5.4** isolation + fairness outcome (B makes progress while A capped; A's count never includes B) — tenant_gate_test.
- **AC-37.5.5** env-driven caps/weights, K < pool, node-local, fail-OPEN + logs, no put_env in tests — tenant_gate_test + db_capacity_test + config/test.exs.

### Verification
Full mix precommit green via the pre-commit hook: compile --warnings-as-errors, format --check-formatted, credo --strict, deps.audit, dialyzer, and the full suite (**4575 tests, 0 failures**).
