### PR TITLE
Throttle-aware circuit breaker + honor provider Retry-After

### DIFF
--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -59,6 +59,8 @@ defmodule Loopctl.Knowledge do
   alias Loopctl.Knowledge.VectorSearch
   alias Loopctl.Llm.ProviderError
   alias Loopctl.Projects.Project
+  alias Loopctl.Provider.RetryAfter
+  alias Loopctl.SystemConfig
   alias Loopctl.Webhooks.EventGenerator
   alias Loopctl.Workers.ArticleEmbeddingWorker
 
@@ -4206,6 +4208,11 @@ defmodule Loopctl.Knowledge do
 
   defp permanent_merge_error?(:unparseable_merge), do: true
 
+  # US-37.3: a throttle 4-tuple (429/503 + Retry-After) is transient — it must NOT
+  # match the permanent 4xx clause below (that clause is arity-3 only, but be
+  # explicit so the widened shape can never be misclassified as permanent).
+  defp permanent_merge_error?({:api_error, _status, _tag, _retry_after}), do: false
+
   defp permanent_merge_error?({:api_error, status, _body})
        when is_integer(status) and status >= 400 and status < 500 and status != 408 and
               status != 429,
@@ -6429,6 +6436,10 @@ defmodule Loopctl.Knowledge do
   defp reason_to_tag(:heavy_read_overloaded), do: "heavy_read_overloaded"
   defp reason_to_tag(:timeout), do: "embedding_timeout"
 
+  # US-37.3: the throttle 4-tuple carries a Retry-After — the tag is still status-only.
+  defp reason_to_tag({:api_error, status, _, _}) when is_integer(status),
+    do: "embedding_provider_error_#{status}"
+
   defp reason_to_tag({:api_error, status, _}) when is_integer(status),
     do: "embedding_provider_error_#{status}"
 
@@ -7318,7 +7329,17 @@ defmodule Loopctl.Knowledge do
   @circuit_breaker_table :loopctl_embedding_circuit_breaker
   @failure_threshold 3
   @failure_window_seconds 60
+  # Base breaker cooldown (seconds). US-37.3: env-driven via SystemConfig
+  # (`"embedding_breaker_cooldown_seconds"`) so it is tunable without a deploy; the
+  # in-code default doubles as the documented default. A provider Retry-After
+  # RAISES this floor (see `cooldown_seconds/1`), clamped to the SystemConfig max.
   @cooldown_seconds 30
+  # US-37.3 latency trip (AC-37.3.4): consecutive/windowed slow-but-successful
+  # provider calls trip the breaker (slow-but-alive protection). Both knobs are
+  # env-driven via SystemConfig; a threshold of 0 (the default) DISABLES the
+  # latency trip entirely (disabled-safe).
+  @default_latency_threshold_ms 0
+  @default_latency_count 5
 
   @doc false
   def init_circuit_breaker do
@@ -7385,13 +7406,33 @@ defmodule Loopctl.Knowledge do
     #10; US-37.2 supervises the task so its crash never crashes the caller).
   - A crash rescue handler.
 
-  Returns `{:ok, embedding}` or `{:error, reason}`. Two error classes are EXEMPT
-  from the breaker: `{:error, :no_api_key}` (a per-tenant config gap) and 4xx
-  provider responses (per-tenant credential/quota problems — 401/403/429). Only
-  5xx / transport / timeout / crash failures count toward opening the breaker
-  (review #1). This is the single guarded entry point — the embedding worker and
-  the proposal gate route through it too (review #4) so circuit-open is both
-  respected AND contributed to.
+  Returns `{:ok, embedding}` or `{:error, reason}`.
+
+  ## What counts toward the breaker (US-37.3 — 4xx SPLIT)
+
+  The blanket "all 4xx are exempt" rule is GONE. The 4xx class is now split by
+  cause:
+
+    * **429 / 408 (THROTTLE)** — COUNT toward the breaker. A sustained rate-limit
+      storm is a systemic signal: counting it lets the breaker open so the
+      interactive path sheds to keyword search and the workers snooze, instead of
+      hot-retrying into a throttling provider. When the throttle response carried a
+      provider `Retry-After`, that value RAISES the cooldown (see
+      `cooldown_seconds/1`).
+    * **401 / 403 (and other 4xx) — CREDENTIAL/request problems** — remain EXEMPT.
+      A per-tenant bad/revoked key must never open a breaker that would degrade
+      every tenant (review #1).
+    * `{:error, :no_api_key}` (a per-tenant config gap) and
+      `{:error, :rate_limited_local}` (US-37.1 node-local admission backpressure —
+      self-imposed, not a provider failure) remain EXEMPT.
+    * 5xx / transport / timeout / crash still count.
+    * **Latency (AC-37.3.4)** — a run of slow-but-SUCCESSFUL calls (over the
+      configured `"embedding_breaker_latency_threshold_ms"`, disabled at 0) also
+      trips the breaker (slow-but-alive protection).
+
+  This is the single guarded entry point — the embedding worker and the proposal
+  gate route through it too (review #4) so circuit-open is both respected AND
+  contributed to.
 
   It is ALSO the single choke point for the `[:loopctl, :llm, :provider_error]`
   telemetry signal's embedding half (US-34.3 AC-34.3.3, review MED #1): both Oban
@@ -7400,7 +7441,9 @@ defmodule Loopctl.Knowledge do
   near-dup lookup) funnel through here, so recording the signal in
   `run_embedding_task/3` — rather than per-worker after this function returns —
   covers every embedding path exactly once, with the same breaker-countable gate
-  (a per-tenant 4xx never contributes) and no double-count.
+  and no double-count. NOTE (US-37.3): because 429/408 now COUNT, they also emit
+  the storm signal as `:transient` (throttle IS a systemic signal now) — the
+  intended consequence of the split; a per-tenant 401/403 still never contributes.
 
   `opts`:
     * `:timeout` — Task.yield budget in ms (default `#{@embedding_yield_ms}`).
@@ -7456,6 +7499,10 @@ defmodule Loopctl.Knowledge do
     # rather than crashing THIS process (AC-37.2.5). The inner rescue still catches
     # embedding-client exceptions and returns {:error, {:embedding_crash, ...}};
     # async_nolink additionally protects against exits the rescue can't catch.
+    # US-37.3 (AC-37.3.4): measure wall-clock per guarded call so a slow-but-alive
+    # provider can trip the breaker on latency (not just on hard failures).
+    started_ms = System.monotonic_time(:millisecond)
+
     task =
       Task.Supervisor.async_nolink(Loopctl.Knowledge.EmbeddingTaskSupervisor, fn ->
         try do
@@ -7467,7 +7514,7 @@ defmodule Loopctl.Knowledge do
 
     case Task.yield(task, timeout) || Task.shutdown(task) do
       {:ok, {:ok, embedding}} ->
-        record_success(tenant_id)
+        record_call_outcome(tenant_id, System.monotonic_time(:millisecond) - started_ms)
         {:ok, embedding}
 
       # A missing tenant key is a config gap, not a provider failure — do NOT
@@ -7490,7 +7537,11 @@ defmodule Loopctl.Knowledge do
   end
 
   defp maybe_record_failure(tenant_id, reason) do
-    if breaker_countable?(reason), do: record_failure(tenant_id)
+    # US-37.3: a throttle error may carry a provider Retry-After — thread it so the
+    # breaker cooldown honors it (see `record_failure/2` -> `cooldown_seconds/1`).
+    if breaker_countable?(reason),
+      do: record_failure(tenant_id, RetryAfter.from_error(reason))
+
     :ok
   end
 
@@ -7503,11 +7554,12 @@ defmodule Loopctl.Knowledge do
   # embedding path exactly once with no double-count.
   #
   # Gated by the SAME `breaker_countable?/1` classification the circuit breaker
-  # uses: a per-tenant credential/quota 4xx (401/403/429) is never a systemic
-  # provider incident, so it must never inflate this fleet-wide storm signal —
-  # exactly like it must never trip the breaker. `:no_api_key` and `:circuit_open`
-  # never reach this function (handled by earlier `case` clauses in
-  # `run_embedding_task/3`), so no explicit exclusion clause is needed here.
+  # uses: a per-tenant CREDENTIAL 4xx (401/403) is never a systemic provider
+  # incident, so it must never inflate this fleet-wide storm signal — exactly like
+  # it must never trip the breaker. US-37.3: a THROTTLE 4xx (429/408) now DOES
+  # count (throttle is a systemic signal), so it is recorded here as `:transient`.
+  # `:no_api_key` and `:circuit_open` never reach this function (handled by earlier
+  # `case` clauses in `run_embedding_task/3`), so no explicit exclusion is needed.
   defp maybe_record_provider_error(reason) do
     if breaker_countable?(reason) do
       class = if Loopctl.Llm.permanent_provider_error?(reason), do: :permanent, else: :transient
@@ -7517,14 +7569,33 @@ defmodule Loopctl.Knowledge do
     :ok
   end
 
-  # Only systemic provider/infra failures count toward the breaker. A 4xx is a
-  # per-tenant credential/quota problem (401/403/429) and must NEVER contribute —
-  # otherwise one tenant's bad key would open the breaker and degrade every tenant
-  # sharing it (review #1). Mirrors the `:no_api_key` exemption.
+  # US-37.3 — 4xx SPLIT. The blanket 4xx exemption is gone; the class is split by
+  # cause:
+  #   * 429 (Too Many Requests) / 408 (Request Timeout) are THROTTLE signals — they
+  #     COUNT. A sustained rate-limit storm is systemic, not per-tenant: counting it
+  #     lets the breaker open so the interactive path sheds to keyword and the
+  #     workers snooze, instead of hot-retrying into a throttling provider.
+  #   * 401 / 403 (and every other 4xx) are per-tenant CREDENTIAL/request problems —
+  #     EXEMPT, so one tenant's bad/revoked key never opens a breaker that would
+  #     degrade every tenant sharing it (review #1). Mirrors the `:no_api_key` exemption.
+  #   * 5xx counts (systemic outage). The throttle 4-tuple carries a Retry-After but
+  #     classifies identically to its 3-tuple form.
+  defp breaker_countable?({:api_error, status, _, _}) when status in [408, 429], do: true
+
+  defp breaker_countable?({:api_error, status, _, _})
+       when is_integer(status) and status >= 500,
+       do: true
+
+  defp breaker_countable?({:api_error, status, _, _}) when is_integer(status), do: false
+
+  defp breaker_countable?({:api_error, status, _}) when status in [408, 429], do: true
+
   defp breaker_countable?({:api_error, status, _}) when is_integer(status) and status >= 500,
     do: true
 
   defp breaker_countable?({:api_error, status, _}) when is_integer(status), do: false
+
+  defp breaker_countable?({:api_error, status}) when status in [408, 429], do: true
 
   defp breaker_countable?({:api_error, status}) when is_integer(status) and status >= 500,
     do: true
@@ -7564,12 +7635,18 @@ defmodule Loopctl.Knowledge do
     end
   end
 
+  defp record_failure(tenant_id), do: record_failure(tenant_id, nil)
+
   # The failure counter is keyed by the WINDOW PERIOD (review #2): each rolling
   # window is a DISTINCT ETS key, so an expired window is simply a different key —
   # there is no non-atomic "check the timestamp, then reset the counter in place"
   # step to race. `update_counter/4` is the sole, atomic mutation, so a burst of
   # concurrent failures for one tenant counts reliably to the threshold.
-  defp record_failure(tenant_id) do
+  #
+  # US-37.3: `retry_after` (seconds, or nil) is a provider Retry-After parsed from a
+  # throttle response — it RAISES the cooldown floor when the breaker opens (see
+  # `cooldown_seconds/1`) so we back off for at least as long as the provider asked.
+  defp record_failure(tenant_id, retry_after) do
     ensure_circuit_breaker_table()
     now = System.monotonic_time(:second)
     period = period_for(now)
@@ -7587,10 +7664,81 @@ defmodule Loopctl.Knowledge do
       )
 
     if count >= @failure_threshold do
-      :ets.insert(@circuit_breaker_table, {{tenant_id, :open_until}, now + @cooldown_seconds})
+      open_breaker(tenant_id, now, retry_after)
     end
 
     :ok
+  end
+
+  # US-37.3 (AC-37.3.4): classify a SUCCESSFUL call's latency. A fast/normal
+  # success clears the tenant's breaker state (full health); a SLOW success
+  # (over the configured threshold) records a slow-call toward the latency trip.
+  # Disabled-safe: a threshold of 0/unset means the latency trip never fires and a
+  # success always just clears state (identical to pre-US-37.3 behavior).
+  defp record_call_outcome(tenant_id, elapsed_ms) do
+    threshold = latency_threshold_ms()
+
+    if threshold > 0 and elapsed_ms > threshold do
+      record_slow_call(tenant_id)
+    else
+      record_success(tenant_id)
+    end
+  end
+
+  # Slow-but-alive protection. Mirrors the failure-window counter but on a distinct
+  # `:slow` key, so a run of slow successes within the window trips the breaker
+  # WITHOUT a fast success in between resetting it (a fast success clears both
+  # counters via `record_success/1` -> `clear_tenant_breaker/2`). The cooldown here
+  # uses the base cooldown (no provider Retry-After on a 200).
+  defp record_slow_call(tenant_id) do
+    ensure_circuit_breaker_table()
+    now = System.monotonic_time(:second)
+    period = period_for(now)
+
+    :ets.delete(@circuit_breaker_table, slow_key(tenant_id, period - 1))
+
+    count =
+      :ets.update_counter(
+        @circuit_breaker_table,
+        slow_key(tenant_id, period),
+        {2, 1},
+        {slow_key(tenant_id, period), 0}
+      )
+
+    if count >= latency_count() do
+      open_breaker(tenant_id, now, nil)
+    end
+
+    :ok
+  end
+
+  defp open_breaker(tenant_id, now, retry_after) do
+    :ets.insert(
+      @circuit_breaker_table,
+      {{tenant_id, :open_until}, now + cooldown_seconds(retry_after)}
+    )
+  end
+
+  # Cooldown (seconds) the breaker stays open. US-37.3: a provider Retry-After
+  # RAISES the floor (back off at least as long as asked), bounded by the
+  # SystemConfig max so a hostile header can't wedge the breaker open. Absent
+  # Retry-After keeps the base cooldown.
+  defp cooldown_seconds(nil), do: base_cooldown_seconds()
+
+  defp cooldown_seconds(retry_after) when is_integer(retry_after) do
+    retry_after |> max(base_cooldown_seconds()) |> min(RetryAfter.max_seconds())
+  end
+
+  defp base_cooldown_seconds do
+    SystemConfig.get_int("embedding_breaker_cooldown_seconds", @cooldown_seconds)
+  end
+
+  defp latency_threshold_ms do
+    SystemConfig.get_int("embedding_breaker_latency_threshold_ms", @default_latency_threshold_ms)
+  end
+
+  defp latency_count do
+    SystemConfig.get_int("embedding_breaker_latency_count", @default_latency_count)
   end
 
   defp record_success(tenant_id) do
@@ -7600,16 +7748,20 @@ defmodule Loopctl.Knowledge do
   end
 
   # Delete ALL of a tenant's breaker state: the open flag + the current and previous
-  # window counters (a failure is always in one of those two periods).
+  # window counters for BOTH the failure and the slow (latency) windows (a failure /
+  # slow call is always in one of the two periods).
   defp clear_tenant_breaker(tenant_id, now) do
     period = period_for(now)
     :ets.delete(@circuit_breaker_table, {tenant_id, :open_until})
     :ets.delete(@circuit_breaker_table, failures_key(tenant_id, period))
     :ets.delete(@circuit_breaker_table, failures_key(tenant_id, period - 1))
+    :ets.delete(@circuit_breaker_table, slow_key(tenant_id, period))
+    :ets.delete(@circuit_breaker_table, slow_key(tenant_id, period - 1))
     :ok
   end
 
   defp failures_key(tenant_id, period), do: {tenant_id, :failures, period}
+  defp slow_key(tenant_id, period), do: {tenant_id, :slow, period}
 
   defp period_for(now), do: div(now, @failure_window_seconds)
 

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -7334,6 +7334,10 @@ defmodule Loopctl.Knowledge do
   # in-code default doubles as the documented default. A provider Retry-After
   # RAISES this floor (see `cooldown_seconds/1`), clamped to the SystemConfig max.
   @cooldown_seconds 30
+  # Ceiling (seconds) the breaker's open cooldown is clamped to — the embedding-
+  # breaker-specific max, env-driven via `"embedding_breaker_max_cooldown_seconds"`.
+  # Deliberately distinct from the provider-generic `RetryAfter.max_seconds/0`.
+  @max_cooldown_seconds 300
   # US-37.3 latency trip (AC-37.3.4): consecutive/windowed slow-but-successful
   # provider calls trip the breaker (slow-but-alive protection). Both knobs are
   # env-driven via SystemConfig; a threshold of 0 (the default) DISABLES the
@@ -7380,6 +7384,29 @@ defmodule Loopctl.Knowledge do
     end
 
     :ok
+  end
+
+  @doc """
+  Remaining open-cooldown (seconds) for a tenant's embedding circuit breaker, or
+  `0` when the breaker is closed/absent.
+
+  US-37.3 (AC-37.3.5): lets an Oban embedding worker snooze for ~the remaining open
+  window on `{:error, :circuit_open}` — a LOSS-FREE reschedule that consumes no
+  attempt — instead of returning `{:error, ...}`, which burns a `max_attempts`
+  budget. With a honored Retry-After cooldown up to the breaker max (300s) able to
+  exceed a job's whole 4-attempt window, the `{:error, ...}` path would DISCARD the
+  job and leave the article/memory permanently un-embedded (there is no embedding
+  backfill). Snoozing avoids that.
+  """
+  @spec circuit_breaker_cooldown_remaining(Ecto.UUID.t()) :: non_neg_integer()
+  def circuit_breaker_cooldown_remaining(tenant_id) when is_binary(tenant_id) do
+    ensure_circuit_breaker_table()
+    key = {tenant_id, :open_until}
+
+    case :ets.lookup(@circuit_breaker_table, key) do
+      [{^key, open_until}] -> max(0, open_until - System.monotonic_time(:second))
+      [] -> 0
+    end
   end
 
   # Task.yield budget for a query embedding. Kept STRICTLY ABOVE the embedding
@@ -7726,11 +7753,20 @@ defmodule Loopctl.Knowledge do
   defp cooldown_seconds(nil), do: base_cooldown_seconds()
 
   defp cooldown_seconds(retry_after) when is_integer(retry_after) do
-    retry_after |> max(base_cooldown_seconds()) |> min(RetryAfter.max_seconds())
+    retry_after |> max(base_cooldown_seconds()) |> min(max_cooldown_seconds())
   end
 
   defp base_cooldown_seconds do
     SystemConfig.get_int("embedding_breaker_cooldown_seconds", @cooldown_seconds)
+  end
+
+  # The breaker's OWN open-cooldown ceiling — an embedding-breaker-specific key,
+  # NOT the provider-generic `RetryAfter.max_seconds/0` (which serves the Anthropic
+  # client too). Keeping them separate lets an operator cap how long the embedding
+  # breaker stays open without moving the shared Retry-After parser's ceiling.
+  # Defaults to the same 300s, so behavior is unchanged until the key is tuned.
+  defp max_cooldown_seconds do
+    SystemConfig.get_int("embedding_breaker_max_cooldown_seconds", @max_cooldown_seconds)
   end
 
   defp latency_threshold_ms do

--- a/lib/loopctl/knowledge/embedding_client.ex
+++ b/lib/loopctl/knowledge/embedding_client.ex
@@ -35,6 +35,7 @@ defmodule Loopctl.Knowledge.EmbeddingClient do
   alias Loopctl.Llm
   alias Loopctl.Llm.ProviderError
   alias Loopctl.Provider.Admission
+  alias Loopctl.Provider.RetryAfter
   alias Loopctl.SystemConfig
 
   @default_base_url "https://api.openai.com/v1"
@@ -88,12 +89,17 @@ defmodule Loopctl.Knowledge.EmbeddingClient do
         record_usage_safe(tenant_id, model, resp["usage"])
         {:ok, embedding}
 
-      {:ok, %{status: status, body: body}} ->
+      {:ok, %{status: status, body: body} = resp} ->
         Logger.warning("Loopctl.Knowledge.EmbeddingClient: API error (status=#{status})")
-        # SANITIZE: the provider error body can echo a masked key fragment (review
-        # #3). Drop it — keep only the status — so it never reaches the caller / an
-        # Oban `{:error, reason}` persisted into oban_jobs.errors.
-        {:error, ProviderError.sanitize({:api_error, status, body})}
+        # US-37.3: on a throttle response (429/503) parse the provider Retry-After
+        # and thread it (clamped, value-free) into the sanitized error so the
+        # tenant-scoped breaker cooldown AND the Oban worker snooze honor it instead
+        # of blind polynomial backoff. Absent/garbage → nil → the legacy 3-tuple.
+        # SANITIZE either way: the provider error body can echo a masked key fragment
+        # (review #3). Drop it — keep only status (+ Retry-After) — so it never
+        # reaches the caller / an Oban `{:error, reason}` persisted into oban_jobs.errors.
+        retry_after = RetryAfter.from_response(status, resp)
+        {:error, ProviderError.sanitize({:api_error, status, body}, retry_after)}
 
       {:error, reason} ->
         Logger.warning(

--- a/lib/loopctl/llm.ex
+++ b/lib/loopctl/llm.ex
@@ -233,6 +233,16 @@ defmodule Loopctl.Llm do
   else (5xx, transport, timeout, crash) is transient.
   """
   @spec permanent_provider_error?(term()) :: boolean()
+  # US-37.3: the throttle 4-tuple (`{:api_error, status, :provider_error,
+  # retry_after}`) only ever carries a 429/503 (see `Loopctl.Provider.RetryAfter`)
+  # — both transient. Classify it explicitly so the widened arity never falls
+  # through to a misleading verdict.
+  def permanent_provider_error?({:api_error, status, _, _}) when status in [408, 429], do: false
+
+  def permanent_provider_error?({:api_error, status, _, _})
+      when is_integer(status) and status >= 400 and status < 500,
+      do: true
+
   def permanent_provider_error?({:api_error, status, _}) when status in [408, 429], do: false
 
   def permanent_provider_error?({:api_error, status, _})

--- a/lib/loopctl/llm/anthropic.ex
+++ b/lib/loopctl/llm/anthropic.ex
@@ -53,15 +53,20 @@ defmodule Loopctl.Llm.Anthropic do
   Returns:
     * `{:ok, text}` on a 200 (usage recorded best-effort)
     * `{:error, :no_api_key}` when the tenant has no key (mandatory BYO)
-    * `{:error, {:api_error, status, body}}` on a non-200
+    * `{:error, :rate_limited_local}` when the local admission bucket is empty
+    * `{:error, {:api_error, status, :provider_error}}` on a non-200 (sanitized)
+    * `{:error, {:api_error, status, :provider_error, retry_after}}` on a throttle
+      response (429/503) carrying a parsed provider Retry-After (US-37.3)
     * `{:error, {:request_failed, reason}}` on a transport error
+
+  All returned error terms are sanitized via `Loopctl.Llm.ProviderError` and never
+  carry a raw provider body — the error union below is `ProviderError.t()`.
   """
   @spec message(Ecto.UUID.t(), Llm.operation(), (String.t() -> map()), usage_meta(), keyword()) ::
           {:ok, String.t()}
           | {:error, :no_api_key}
           | {:error, :rate_limited_local}
-          | {:error, {:api_error, integer(), term()}}
-          | {:error, {:request_failed, term()}}
+          | {:error, ProviderError.t()}
   def message(tenant_id, operation, body_fun, usage_meta \\ %{}, req_opts \\ [])
       when is_function(body_fun, 1) do
     case Llm.resolve(tenant_id, operation) do
@@ -78,6 +83,12 @@ defmodule Loopctl.Llm.Anthropic do
   per-call `Loopctl.Llm.resolve/2` DB read. Used to resolve ONCE per batch and
   thread the resolved credentials through many calls (review #19). The caller is
   responsible for having resolved the tenant's credentials.
+
+  Returns the same shapes as `message/5` (minus `{:error, :no_api_key}`, which is
+  resolved by the caller). On a throttle response (429/503) the error is the
+  sanitized 4-tuple `{:error, {:api_error, status, :provider_error, retry_after}}`
+  carrying a parsed provider Retry-After (US-37.3). The error union is
+  `ProviderError.t()` — every returned error term is sanitized and body-free.
   """
   @spec call(
           Ecto.UUID.t(),
@@ -90,8 +101,7 @@ defmodule Loopctl.Llm.Anthropic do
         ) ::
           {:ok, String.t()}
           | {:error, :rate_limited_local}
-          | {:error, {:api_error, integer(), term()}}
-          | {:error, {:request_failed, term()}}
+          | {:error, ProviderError.t()}
   def call(tenant_id, operation, api_key, model, body_fun, usage_meta \\ %{}, req_opts \\ [])
       when is_binary(api_key) and is_binary(model) and is_function(body_fun, 1) do
     body = model |> body_fun.() |> Map.put(:model, model)

--- a/lib/loopctl/llm/anthropic.ex
+++ b/lib/loopctl/llm/anthropic.ex
@@ -32,6 +32,7 @@ defmodule Loopctl.Llm.Anthropic do
   alias Loopctl.Llm
   alias Loopctl.Llm.ProviderError
   alias Loopctl.Provider.Admission
+  alias Loopctl.Provider.RetryAfter
 
   @base_url "https://api.anthropic.com/v1"
   @anthropic_version "2023-06-01"
@@ -149,14 +150,25 @@ defmodule Loopctl.Llm.Anthropic do
         # anomaly observable/actionable without polluting the outage counter.
         {:error, ProviderError.sanitize(reason)}
 
-      {:ok, %{status: status, body: body}} ->
+      {:ok, %{status: status, body: body} = resp} ->
         Logger.warning("Loopctl.Llm.Anthropic: API error (op=#{operation}, status=#{status})")
         # SANITIZE the provider error body (review #11): it can echo a masked key
         # fragment, and callers surface it as an Oban `{:error, reason}` persisted
         # into oban_jobs.errors. Drop the body; keep only the status.
+        #
+        # US-37.3: on a throttle response (429/503) parse the provider Retry-After and
+        # thread it (clamped, value-free) into the sanitized error so a snooze-capable
+        # worker (ContentIngestionWorker) yields loss-free for ~that interval instead
+        # of the blind `attempt^4` backoff. The breaker itself stays embedding-only
+        # (it lives in `Knowledge` and only guards `generate_embedding/3`); the
+        # Anthropic path has never had a breaker and this story does not add one —
+        # `record_provider_error/1` still feeds the fleet-wide provider-error storm
+        # signal, and honoring Retry-After on the worker snooze is the win here.
+        # `record_provider_error/1` classifies on the RAW 3-tuple reason (429 →
+        # transient), unchanged; only the RETURNED term widens to the 4-tuple.
         reason = {:api_error, status, body}
         record_provider_error(reason)
-        {:error, ProviderError.sanitize(reason)}
+        {:error, ProviderError.sanitize(reason, RetryAfter.from_response(status, resp))}
 
       {:error, reason} ->
         # Never inspect the raw transport reason (review MED #4) — log a value-free

--- a/lib/loopctl/llm/provider_error.ex
+++ b/lib/loopctl/llm/provider_error.ex
@@ -30,6 +30,7 @@ defmodule Loopctl.Llm.ProviderError do
   @typedoc "A sanitized provider error term (never carries a response body)."
   @type t ::
           {:api_error, integer(), :provider_error}
+          | {:api_error, integer(), :provider_error, non_neg_integer() | nil}
           | {:request_failed, atom()}
           | {:embedding_crash, :exception}
           | atom()
@@ -41,6 +42,13 @@ defmodule Loopctl.Llm.ProviderError do
   structured domain-error tuples (which are provably key-free).
   """
   @spec sanitize(term()) :: t()
+  # US-37.3: an already-sanitized throttle 4-tuple carries only a status + a
+  # parsed Retry-After integer (both value-free) — preserve it idempotently so a
+  # second sanitize pass at a worker boundary never drops the Retry-After.
+  def sanitize({:api_error, status, :provider_error, retry_after})
+      when is_integer(status) and (is_integer(retry_after) or is_nil(retry_after)),
+      do: {:api_error, status, :provider_error, retry_after}
+
   def sanitize({:api_error, status, _body}) when is_integer(status),
     do: {:api_error, status, :provider_error}
 
@@ -66,11 +74,33 @@ defmodule Loopctl.Llm.ProviderError do
   def sanitize(other), do: other
 
   @doc """
+  Sanitize an `{:api_error, status, body}` while attaching a parsed provider
+  `Retry-After` (US-37.3). A `nil` Retry-After collapses to the arity-preserving
+  3-tuple (unchanged legacy shape); a present one produces the throttle 4-tuple
+  `{:api_error, status, :provider_error, retry_after}` that the breaker cooldown
+  and Oban worker snooze read via `Loopctl.Provider.RetryAfter.from_error/1`.
+  """
+  @spec sanitize(term(), non_neg_integer() | nil) :: t()
+  def sanitize(reason, nil), do: sanitize(reason)
+
+  def sanitize({:api_error, status, _body}, retry_after)
+      when is_integer(status) and is_integer(retry_after),
+      do: {:api_error, status, :provider_error, retry_after}
+
+  def sanitize({:api_error, status}, retry_after)
+      when is_integer(status) and is_integer(retry_after),
+      do: {:api_error, status, :provider_error, retry_after}
+
+  # A Retry-After on any non-api_error shape is meaningless — sanitize normally.
+  def sanitize(reason, _retry_after), do: sanitize(reason)
+
+  @doc """
   A short, log-safe tag for a provider error (never includes a body). Accepts a
   bare error term or an `{:error, term}` tuple.
   """
   @spec log_tag(term()) :: String.t()
   def log_tag({:error, inner}), do: log_tag(inner)
+  def log_tag({:api_error, status, _, _}), do: "api_error status=#{status}"
   def log_tag({:api_error, status, _}), do: "api_error status=#{status}"
   def log_tag({:api_error, status}), do: "api_error status=#{status}"
   def log_tag({:request_failed, _}), do: "request_failed"

--- a/lib/loopctl/memory.ex
+++ b/lib/loopctl/memory.ex
@@ -562,13 +562,24 @@ defmodule Loopctl.Memory do
       :no_api_key -> "no_embedding_key"
       :circuit_open -> "embedding_circuit_open"
       :timeout -> "embedding_timeout"
-      {:api_error, status, _} when is_integer(status) -> "embedding_provider_error_#{status}"
-      {:api_error, status} when is_integer(status) -> "embedding_provider_error_#{status}"
       {:request_failed, _} -> "embedding_request_failed"
       {:embedding_crash, _} -> "embedding_crash"
-      _ -> "embedding_error"
+      other -> api_error_tag(other)
     end
   end
+
+  # US-37.3: an `{:api_error, ...}` (3-tuple, or the throttle 4-tuple carrying a
+  # Retry-After) tags by status only; anything else is the generic tag.
+  defp api_error_tag({:api_error, status, _, _}) when is_integer(status),
+    do: "embedding_provider_error_#{status}"
+
+  defp api_error_tag({:api_error, status, _}) when is_integer(status),
+    do: "embedding_provider_error_#{status}"
+
+  defp api_error_tag({:api_error, status}) when is_integer(status),
+    do: "embedding_provider_error_#{status}"
+
+  defp api_error_tag(_other), do: "embedding_error"
 
   # ===========================================================================
   # forget / list / session_history / supersede (RLS OLTP path)

--- a/lib/loopctl/provider/retry_after.ex
+++ b/lib/loopctl/provider/retry_after.ex
@@ -9,9 +9,12 @@ defmodule Loopctl.Provider.RetryAfter do
 
   The parser is DEFENSIVE: a missing, empty, or malformed header yields `nil`, so
   callers fall back to their existing backoff. The result is CLAMPED to a sane
-  maximum (`embedding_breaker_max_cooldown_seconds`, SystemConfig, default
-  #{300}s) so a hostile `Retry-After: 999999999` can never wedge a breaker open
-  or pin an Oban queue.
+  maximum (`provider_retry_after_max_seconds`, SystemConfig, default #{300}s) so a
+  hostile `Retry-After: 999999999` can never wedge a breaker open or pin an Oban
+  queue. NOTE: this parser is provider-GENERIC (it serves BOTH the embedding client
+  AND the Anthropic client), so its clamp ceiling is a provider-neutral key —
+  distinct from the embedding-breaker-specific `embedding_breaker_max_cooldown_seconds`
+  that governs how long the embedding circuit breaker stays open.
 
   Both provider clients (`Loopctl.Knowledge.EmbeddingClient`,
   `Loopctl.Llm.Anthropic`) call `from_response/2` on a throttle response
@@ -74,12 +77,30 @@ defmodule Loopctl.Provider.RetryAfter do
   def from_error(_other), do: nil
 
   @doc """
+  Normalize a parsed Retry-After into a POSITIVE Oban snooze interval (seconds).
+
+  A provider may legitimately send `Retry-After: 0` (parsed to `0`), and RFC 7231
+  permits it. But `{:snooze, 0}` reschedules effectively immediately AND bumps
+  `max_attempts`, so on a breaker-LESS path (the Anthropic content-ingestion
+  worker) a provider persistently returning `429/503` + `Retry-After: 0` would
+  hot-loop with no attempt cap — the exact behavior AC-37.3.5 says to avoid.
+  Floor at `1` so every throttle snooze makes forward progress. (US-37.3 review.)
+  """
+  @spec snooze_seconds(non_neg_integer()) :: pos_integer()
+  def snooze_seconds(retry_after) when is_integer(retry_after), do: max(retry_after, 1)
+
+  @doc """
   The clamp ceiling (seconds) for a parsed Retry-After. Live-tunable via the
-  `"embedding_breaker_max_cooldown_seconds"` SystemConfig key.
+  provider-neutral `"provider_retry_after_max_seconds"` SystemConfig key.
+
+  This parser is shared by every provider client, so its ceiling is deliberately
+  NOT the embedding-breaker key: an operator tuning the embedding breaker's open
+  cooldown (`embedding_breaker_max_cooldown_seconds`) must not silently move the
+  Anthropic ingestion snooze ceiling too.
   """
   @spec max_seconds() :: pos_integer()
   def max_seconds do
-    SystemConfig.get_int("embedding_breaker_max_cooldown_seconds", @default_max_seconds)
+    SystemConfig.get_int("provider_retry_after_max_seconds", @default_max_seconds)
   end
 
   defp clamp(seconds), do: seconds |> max(0) |> min(max_seconds())

--- a/lib/loopctl/provider/retry_after.ex
+++ b/lib/loopctl/provider/retry_after.ex
@@ -1,0 +1,116 @@
+defmodule Loopctl.Provider.RetryAfter do
+  @moduledoc """
+  Parse a provider `Retry-After` header into a normalized, clamped seconds value
+  (US-37.3). RFC 7231 allows two forms:
+
+    * **delta-seconds** — a non-negative integer, e.g. `"30"`.
+    * **HTTP-date** (IMF-fixdate) — e.g. `"Wed, 21 Oct 2026 07:28:00 GMT"`; the
+      resulting delay is `max(0, seconds_until(date))`.
+
+  The parser is DEFENSIVE: a missing, empty, or malformed header yields `nil`, so
+  callers fall back to their existing backoff. The result is CLAMPED to a sane
+  maximum (`embedding_breaker_max_cooldown_seconds`, SystemConfig, default
+  #{300}s) so a hostile `Retry-After: 999999999` can never wedge a breaker open
+  or pin an Oban queue.
+
+  Both provider clients (`Loopctl.Knowledge.EmbeddingClient`,
+  `Loopctl.Llm.Anthropic`) call `from_response/2` on a throttle response
+  (`429`/`503`) to attach the parsed seconds to the sanitized error term; the
+  breaker cooldown and the Oban worker snooze read it back via `from_error/1`.
+  """
+
+  alias Loopctl.SystemConfig
+
+  # Statuses that carry a meaningful Retry-After (throttle / temporarily
+  # unavailable). Other statuses' Retry-After (if any) is ignored.
+  @throttle_statuses [429, 503]
+
+  # Clamp ceiling for a parsed Retry-After (seconds). Live-tunable; the in-code
+  # default doubles as the documented default.
+  @default_max_seconds 300
+
+  @doc """
+  Parse a raw `Retry-After` header value into non-negative clamped seconds, or
+  `nil` when absent/malformed.
+  """
+  @spec parse(String.t() | nil) :: non_neg_integer() | nil
+  def parse(nil), do: nil
+
+  def parse(value) when is_binary(value) do
+    case parse_value(String.trim(value)) do
+      nil -> nil
+      seconds -> clamp(seconds)
+    end
+  end
+
+  def parse(_other), do: nil
+
+  @doc """
+  Extract the parsed Retry-After from a throttle response, but ONLY for a
+  throttle status (`429`/`503`). Returns `nil` otherwise. `resp` is a
+  `%Req.Response{}`; its `retry-after` header is a list of values (lowercased by
+  Req) — the first is used.
+  """
+  @spec from_response(integer(), Req.Response.t()) :: non_neg_integer() | nil
+  def from_response(status, %Req.Response{} = resp) when status in @throttle_statuses do
+    resp
+    |> Req.Response.get_header("retry-after")
+    |> List.first()
+    |> parse()
+  end
+
+  def from_response(_status, _resp), do: nil
+
+  @doc """
+  Read a parsed Retry-After back out of a sanitized throttle error term (the
+  4-tuple `{:api_error, status, :provider_error, retry_after}`). Any other term
+  yields `nil`.
+  """
+  @spec from_error(term()) :: non_neg_integer() | nil
+  def from_error({:api_error, _status, _tag, retry_after})
+      when is_integer(retry_after) and retry_after >= 0,
+      do: retry_after
+
+  def from_error(_other), do: nil
+
+  @doc """
+  The clamp ceiling (seconds) for a parsed Retry-After. Live-tunable via the
+  `"embedding_breaker_max_cooldown_seconds"` SystemConfig key.
+  """
+  @spec max_seconds() :: pos_integer()
+  def max_seconds do
+    SystemConfig.get_int("embedding_breaker_max_cooldown_seconds", @default_max_seconds)
+  end
+
+  defp clamp(seconds), do: seconds |> max(0) |> min(max_seconds())
+
+  defp parse_value(""), do: nil
+
+  defp parse_value(str) do
+    case Integer.parse(str) do
+      {n, ""} when n >= 0 -> n
+      # Not a bare non-negative integer — try the HTTP-date form. A negative or
+      # fractional value (e.g. "-5", "30.5") is malformed per RFC → nil.
+      _ -> parse_http_date(str)
+    end
+  end
+
+  # IMF-fixdate parsing with Erlang stdlib (no new dep, no manual date math):
+  # `:httpd_util.convert_request_date/1` returns a UTC erlang datetime or
+  # `:bad_date`. It also RAISES (FunctionClauseError) on some non-date charlists
+  # (e.g. `~c"-5"`), so rescue defensively — any parse failure is `nil`.
+  defp parse_http_date(str) do
+    case :httpd_util.convert_request_date(String.to_charlist(str)) do
+      {{_y, _mo, _d}, {_h, _mi, _s}} = erl_datetime ->
+        case DateTime.from_naive(NaiveDateTime.from_erl!(erl_datetime), "Etc/UTC") do
+          {:ok, dt} -> max(0, DateTime.diff(dt, DateTime.utc_now()))
+          _ -> nil
+        end
+
+      _ ->
+        nil
+    end
+  rescue
+    _ -> nil
+  end
+end

--- a/lib/loopctl/workers/article_embedding_worker.ex
+++ b/lib/loopctl/workers/article_embedding_worker.ex
@@ -24,8 +24,14 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
      vector-searchable until the tenant configures a key.
   7. On a PERMANENT provider error (a 4xx other than 408/429 — bad/revoked key),
      `{:discard, {:embedding_permanent_error, _}}` (review #5): retrying a revoked
-     key 3× is pointless. Transient errors (5xx / network / timeout / circuit-open)
-     return `{:error, reason}` for Oban retry.
+     key 3× is pointless. Transient errors (5xx / network / timeout) return
+     `{:error, reason}` for Oban retry.
+  8. On `{:error, :circuit_open}` (the tenant breaker is OPEN — a throttle/latency
+     storm) the worker `{:snooze, remaining_cooldown}`s (US-37.3, AC-37.3.5): a
+     loss-free reschedule that consumes NO attempt. This is deliberately NOT the
+     `{:error, reason}` retry path — a honored Retry-After can hold the breaker open
+     up to 300s, exceeding a job's 4-attempt window, so `{:error, ...}` would discard
+     the job and leave the article permanently un-embedded (no embedding backfill).
 
   ## Retry Strategy
 
@@ -58,6 +64,7 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
   alias Loopctl.Llm.ProviderError
   alias Loopctl.Oban.FairShare
   alias Loopctl.Provider.Admission
+  alias Loopctl.Provider.RetryAfter
   alias Loopctl.Workers.ArticleLinkingWorker
 
   # Longer Task.yield budget than the interactive query path: a background embed can
@@ -124,15 +131,29 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
         # so the embed is retried once local demand subsides.
         {:snooze, Admission.snooze_seconds()}
 
+      {:error, :circuit_open} ->
+        # US-37.3 (AC-37.3.5): the tenant's embedding breaker is OPEN (a throttle /
+        # latency storm short-circuited the guarded call before any provider hit).
+        # Snooze loss-free for ~the remaining open window (no Oban attempt consumed)
+        # rather than returning {:error, ...}: since this story makes 429/408 COUNT
+        # toward the breaker AND lets a honored Retry-After raise the open cooldown up
+        # to 300s — which can exceed a job's whole 4-attempt window — an {:error, ...}
+        # here would burn every attempt against the still-open breaker and DISCARD the
+        # job, leaving the article permanently un-embedded (there is no embedding
+        # backfill). The snooze is floored positive by cooldown-remaining's caller.
+        {:snooze, circuit_open_snooze_seconds(tenant_id)}
+
       {:error, {:api_error, _status, :provider_error, retry_after}}
       when is_integer(retry_after) ->
         # US-37.3 (AC-37.3.3): the provider signalled a throttle (429/503) with a
         # Retry-After. Snooze loss-free for ~that interval (no Oban attempt consumed)
         # INSTEAD of the blind `attempt^4` backoff, so we don't hot-retry into a
         # throttling provider. The value is already clamped to the SystemConfig max
-        # at parse time. A throttle WITHOUT a Retry-After falls through to the generic
-        # branch below and keeps the polynomial backoff.
-        {:snooze, retry_after}
+        # at parse time; `RetryAfter.snooze_seconds/1` floors it POSITIVE so a
+        # provider `Retry-After: 0` can't produce a `{:snooze, 0}` hot-reschedule. A
+        # throttle WITHOUT a Retry-After falls through to the generic branch below and
+        # keeps the polynomial backoff.
+        {:snooze, RetryAfter.snooze_seconds(retry_after)}
 
       {:error, reason} ->
         # Classify on the raw reason, but the term that becomes an Oban discard/error
@@ -163,6 +184,14 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
       enqueue_linking(article_id, tenant_id)
       :ok
     end
+  end
+
+  # Snooze interval (seconds) for the OPEN-breaker path: ~the remaining cooldown so
+  # the job wakes right as the breaker closes. Floored at `Admission.snooze_seconds/0`
+  # (always >= 1) so a just-expired/raced window still yields a positive snooze — a
+  # short re-snooze is loss-free (no attempt consumed), never a `{:snooze, 0}` loop.
+  defp circuit_open_snooze_seconds(tenant_id) do
+    max(Knowledge.circuit_breaker_cooldown_remaining(tenant_id), Admission.snooze_seconds())
   end
 
   defp already_embedded?(%{embedding: embedding, embedding_content_hash: hash}, content_hash)

--- a/lib/loopctl/workers/article_embedding_worker.ex
+++ b/lib/loopctl/workers/article_embedding_worker.ex
@@ -32,6 +32,12 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
   Uses a custom polynomial backoff: `attempt^4 + 15 + rand(0..30*attempt)`.
   With `max_attempts: 4`, approximate delays are ~16s, ~31s, ~96s, ~271s.
 
+  US-37.3: when a throttle error (429/503) carries a provider `Retry-After`, the
+  worker instead `{:snooze, retry_after}`s (loss-free, no Oban attempt consumed)
+  for ~that interval rather than the blind polynomial backoff — so it never
+  hot-retries into a throttling provider. A throttle WITHOUT a Retry-After keeps
+  the polynomial backoff.
+
   ## Uniqueness
 
   Unique per `article_id` within a 300-second window. If a new job is
@@ -117,6 +123,16 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorker do
         # consumed, never a discard) — mirrors the FairShare.gate snooze pattern —
         # so the embed is retried once local demand subsides.
         {:snooze, Admission.snooze_seconds()}
+
+      {:error, {:api_error, _status, :provider_error, retry_after}}
+      when is_integer(retry_after) ->
+        # US-37.3 (AC-37.3.3): the provider signalled a throttle (429/503) with a
+        # Retry-After. Snooze loss-free for ~that interval (no Oban attempt consumed)
+        # INSTEAD of the blind `attempt^4` backoff, so we don't hot-retry into a
+        # throttling provider. The value is already clamped to the SystemConfig max
+        # at parse time. A throttle WITHOUT a Retry-After falls through to the generic
+        # branch below and keeps the polynomial backoff.
+        {:snooze, retry_after}
 
       {:error, reason} ->
         # Classify on the raw reason, but the term that becomes an Oban discard/error

--- a/lib/loopctl/workers/content_ingestion_worker.ex
+++ b/lib/loopctl/workers/content_ingestion_worker.ex
@@ -315,6 +315,12 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
       {:rate_limited_local, _acc} ->
         {:snooze, Admission.snooze_seconds()}
 
+      # US-37.3 (AC-37.3.3): a chunk's Anthropic extraction was throttled with a
+      # provider Retry-After. Snooze the whole job loss-free for ~that interval
+      # (no attempt consumed) instead of the blind `attempt^4` backoff.
+      {:throttled, retry_after, _acc} ->
+        {:snooze, retry_after}
+
       acc ->
         finalize_ingest(acc, chunk_count, dropped)
     end
@@ -369,6 +375,16 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
         # reduce and signal the caller to snooze the whole job loss-free — the gate
         # is shut, so re-attempting the remaining chunks now would just re-hit it.
         {:halt, {:rate_limited_local, acc}}
+
+      {:error, {:api_error, _status, :provider_error, retry_after}}
+      when is_integer(retry_after) ->
+        # US-37.3 (AC-37.3.3): the Anthropic extraction call was throttled (429/503)
+        # with a provider Retry-After. Halt and snooze the WHOLE job loss-free for
+        # ~that interval (no Oban attempt consumed) rather than routing it through
+        # finalize_errors' transient-retry path, which would burn max_attempts under
+        # sustained throttling. Already-persisted chunks stay committed and are
+        # idempotent, so the re-run resumes without re-billing them.
+        {:halt, {:throttled, retry_after, acc}}
 
       {:error, reason} ->
         # Persist what earlier chunks produced; record the error and keep going —

--- a/lib/loopctl/workers/content_ingestion_worker.ex
+++ b/lib/loopctl/workers/content_ingestion_worker.ex
@@ -60,6 +60,7 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   alias Loopctl.Net.UrlGuard
   alias Loopctl.Oban.FairShare
   alias Loopctl.Provider.Admission
+  alias Loopctl.Provider.RetryAfter
   alias Loopctl.SystemConfig
   alias Loopctl.Workers.ArticleEmbeddingWorker
 
@@ -318,8 +319,12 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
       # US-37.3 (AC-37.3.3): a chunk's Anthropic extraction was throttled with a
       # provider Retry-After. Snooze the whole job loss-free for ~that interval
       # (no attempt consumed) instead of the blind `attempt^4` backoff.
+      # `RetryAfter.snooze_seconds/1` floors the value POSITIVE: this Anthropic path
+      # has NO circuit breaker, so a provider persistently returning `Retry-After: 0`
+      # would otherwise `{:snooze, 0}` hot-loop (each snooze bumps max_attempts, so it
+      # never terminates by attempt cap) — the exact behavior AC-37.3.5 forbids.
       {:throttled, retry_after, _acc} ->
-        {:snooze, retry_after}
+        {:snooze, RetryAfter.snooze_seconds(retry_after)}
 
       acc ->
         finalize_ingest(acc, chunk_count, dropped)

--- a/lib/loopctl/workers/memory_embedding_worker.ex
+++ b/lib/loopctl/workers/memory_embedding_worker.ex
@@ -33,8 +33,14 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorker do
      a clean skip: no crash, no retry, no operator-key fallback. The memory stays
      stored; it is simply not vector-recallable until the tenant configures a key.
   7. On a PERMANENT provider error (a 4xx other than 408/429), `{:discard,
-     {:embedding_permanent_error, _}}`. Transient errors (5xx / network / timeout /
-     circuit-open) return `{:error, reason}` for retry.
+     {:embedding_permanent_error, _}}`. Transient errors (5xx / network / timeout)
+     return `{:error, reason}` for retry.
+  8. On `{:error, :circuit_open}` (the tenant breaker is OPEN) the worker
+     `{:snooze, remaining_cooldown}`s (US-37.3, AC-37.3.5) — a loss-free reschedule
+     consuming NO attempt. NOT the `{:error, reason}` retry path: a honored
+     Retry-After can hold the breaker open up to 300s (beyond the 4-attempt window),
+     so `{:error, ...}` would discard the job and leave the memory permanently
+     un-embedded (no embedding backfill).
 
   ## Uniqueness
 
@@ -56,6 +62,7 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorker do
   alias Loopctl.Memory
   alias Loopctl.Oban.FairShare
   alias Loopctl.Provider.Admission
+  alias Loopctl.Provider.RetryAfter
 
   @worker_yield_ms 8_000
 
@@ -118,12 +125,23 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorker do
         # a discard) so the embed retries once local demand subsides.
         {:snooze, Admission.snooze_seconds()}
 
+      {:error, :circuit_open} ->
+        # US-37.3 (AC-37.3.5): the tenant's embedding breaker is OPEN. Snooze
+        # loss-free for ~the remaining open window (no Oban attempt consumed) rather
+        # than {:error, ...}: with 429/408 now counting toward the breaker and a
+        # honored Retry-After raising the open cooldown up to 300s (able to exceed a
+        # job's 4-attempt window), {:error, ...} would burn every attempt and DISCARD
+        # the job, leaving the memory permanently un-embedded (no embedding backfill).
+        {:snooze, circuit_open_snooze_seconds(tenant_id)}
+
       {:error, {:api_error, _status, :provider_error, retry_after}}
       when is_integer(retry_after) ->
         # US-37.3 (AC-37.3.3): provider throttle (429/503) with a Retry-After —
         # snooze loss-free for ~that interval (no attempt consumed) instead of the
-        # blind `attempt^4` backoff. Already clamped to the SystemConfig max at parse.
-        {:snooze, retry_after}
+        # blind `attempt^4` backoff. Already clamped to the SystemConfig max at parse;
+        # `RetryAfter.snooze_seconds/1` floors it POSITIVE so a `Retry-After: 0` can't
+        # produce a `{:snooze, 0}` hot-reschedule.
+        {:snooze, RetryAfter.snooze_seconds(retry_after)}
 
       {:error, reason} ->
         # US-34.3 (review MED #1): the `[:loopctl, :llm, :provider_error]` telemetry
@@ -151,6 +169,14 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorker do
       {:error, :not_found} -> :ok
       {:error, reason} -> {:error, reason}
     end
+  end
+
+  # Snooze interval (seconds) for the OPEN-breaker path: ~the remaining cooldown so
+  # the job wakes right as the breaker closes. Floored at `Admission.snooze_seconds/0`
+  # (always >= 1) so a just-expired/raced window still yields a positive snooze — a
+  # short re-snooze is loss-free (no attempt consumed), never a `{:snooze, 0}` loop.
+  defp circuit_open_snooze_seconds(tenant_id) do
+    max(Knowledge.circuit_breaker_cooldown_remaining(tenant_id), Admission.snooze_seconds())
   end
 
   defp already_embedded?(%{embedding: embedding, embedding_content_hash: hash}, content_hash)

--- a/lib/loopctl/workers/memory_embedding_worker.ex
+++ b/lib/loopctl/workers/memory_embedding_worker.ex
@@ -118,6 +118,13 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorker do
         # a discard) so the embed retries once local demand subsides.
         {:snooze, Admission.snooze_seconds()}
 
+      {:error, {:api_error, _status, :provider_error, retry_after}}
+      when is_integer(retry_after) ->
+        # US-37.3 (AC-37.3.3): provider throttle (429/503) with a Retry-After —
+        # snooze loss-free for ~that interval (no attempt consumed) instead of the
+        # blind `attempt^4` backoff. Already clamped to the SystemConfig max at parse.
+        {:snooze, retry_after}
+
       {:error, reason} ->
         # US-34.3 (review MED #1): the `[:loopctl, :llm, :provider_error]` telemetry
         # signal is now recorded ONCE, upstream, in

--- a/test/loopctl/knowledge/embedding_client_test.exs
+++ b/test/loopctl/knowledge/embedding_client_test.exs
@@ -154,4 +154,57 @@ defmodule Loopctl.Knowledge.EmbeddingClientTest do
     refute log =~ secret
     refute log =~ masked
   end
+
+  # --- US-37.3 (AC-37.3.2): parse the provider Retry-After on a throttle response ---
+
+  test "a 429 with a Retry-After header surfaces the throttle 4-tuple (parsed seconds)" do
+    tenant = fixture(:tenant)
+    set_embedding_key(tenant, "test-openai-key-THROTTLED")
+
+    Req.Test.stub(EmbeddingClient, fn conn ->
+      conn
+      |> Plug.Conn.put_resp_header("retry-after", "30")
+      |> Plug.Conn.put_status(429)
+      |> Req.Test.json(%{"error" => %{"message" => "Rate limit reached"}})
+    end)
+
+    assert {:error, {:api_error, 429, :provider_error, 30}} =
+             EmbeddingClient.generate_embedding(tenant.id, "x")
+  end
+
+  test "a 429 WITHOUT a Retry-After header keeps the legacy value-free 3-tuple" do
+    tenant = fixture(:tenant)
+    set_embedding_key(tenant, "test-openai-key-THROTTLED-NOHDR")
+
+    Req.Test.stub(EmbeddingClient, fn conn ->
+      conn
+      |> Plug.Conn.put_status(429)
+      |> Req.Test.json(%{"error" => %{"message" => "Rate limit reached"}})
+    end)
+
+    assert {:error, {:api_error, 429, :provider_error}} =
+             EmbeddingClient.generate_embedding(tenant.id, "x")
+  end
+
+  test "a 503 with a Retry-After HTTP-date surfaces the throttle 4-tuple (~seconds out)" do
+    tenant = fixture(:tenant)
+    set_embedding_key(tenant, "test-openai-key-UNAVAILABLE")
+
+    date =
+      DateTime.utc_now()
+      |> DateTime.add(30, :second)
+      |> Calendar.strftime("%a, %d %b %Y %H:%M:%S GMT")
+
+    Req.Test.stub(EmbeddingClient, fn conn ->
+      conn
+      |> Plug.Conn.put_resp_header("retry-after", date)
+      |> Plug.Conn.put_status(503)
+      |> Req.Test.json(%{"error" => %{"message" => "Service unavailable"}})
+    end)
+
+    assert {:error, {:api_error, 503, :provider_error, seconds}} =
+             EmbeddingClient.generate_embedding(tenant.id, "x")
+
+    assert is_integer(seconds) and seconds >= 25 and seconds <= 30
+  end
 end

--- a/test/loopctl/knowledge_breaker_latency_test.exs
+++ b/test/loopctl/knowledge_breaker_latency_test.exs
@@ -1,0 +1,78 @@
+defmodule Loopctl.KnowledgeBreakerLatencyTest do
+  @moduledoc """
+  US-37.3 (TC-37.3.4): the latency-based breaker trip (slow-but-alive protection).
+
+  `async: false` ON PURPOSE. The latency threshold / count / base cooldown are
+  NODE-GLOBAL SystemConfig knobs read from `:persistent_term`; this test seeds them
+  directly (the documented key format, NO leaked DB row — mirrors
+  `Loopctl.Provider.AdmissionTest`) and erases them on exit. A sync test never runs
+  concurrently with any other test, so the global seed can't leak into async peers,
+  and the default (threshold 0 = latency trip DISABLED) is restored afterward.
+  """
+  use Loopctl.DataCase, async: false
+
+  import Mox
+
+  setup :verify_on_exit!
+
+  alias Loopctl.Knowledge
+
+  @threshold_key {Loopctl.SystemConfig, "embedding_breaker_latency_threshold_ms"}
+  @count_key {Loopctl.SystemConfig, "embedding_breaker_latency_count"}
+  @cooldown_key {Loopctl.SystemConfig, "embedding_breaker_cooldown_seconds"}
+
+  setup do
+    # Enable a low latency threshold, trip after 2 slow calls, recover after 1s.
+    :persistent_term.put(@threshold_key, 40)
+    :persistent_term.put(@count_key, 2)
+    :persistent_term.put(@cooldown_key, 1)
+
+    on_exit(fn ->
+      :persistent_term.erase(@threshold_key)
+      :persistent_term.erase(@count_key)
+      :persistent_term.erase(@cooldown_key)
+    end)
+
+    :ok
+  end
+
+  test "slow-but-successful calls trip the breaker on latency, then recover after cooldown" do
+    tenant = fixture(:tenant)
+    Knowledge.reset_circuit_breaker(tenant.id)
+
+    # A SUCCESSFUL but SLOW embed (over the 40ms threshold). The call still returns
+    # {:ok, _}; the breaker trips as a side effect of the slow-window count.
+    Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+      Process.sleep(60)
+      {:ok, List.duplicate(0.1, 1536)}
+    end)
+
+    # Two slow successes reach the latency count (2) and trip the breaker.
+    assert {:ok, _} = Knowledge.generate_embedding(tenant.id, "x")
+    assert {:ok, _} = Knowledge.generate_embedding(tenant.id, "x")
+
+    # Breaker now OPEN: short-circuits to :circuit_open WITHOUT calling the (slow)
+    # client — the fail-safe against a slow-but-alive provider.
+    assert {:error, :circuit_open} = Knowledge.generate_embedding(tenant.id, "x")
+
+    # Recover: after the 1s cooldown the breaker clears on the next probe and the
+    # call proceeds again (a single slow success is below the count-2 trip).
+    Process.sleep(1_100)
+    assert {:ok, _} = Knowledge.generate_embedding(tenant.id, "x")
+  end
+
+  test "disabled-safe: threshold 0 means a slow success never trips (just clears state)" do
+    tenant = fixture(:tenant)
+    Knowledge.reset_circuit_breaker(tenant.id)
+    :persistent_term.put(@threshold_key, 0)
+
+    Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+      Process.sleep(60)
+      {:ok, List.duplicate(0.1, 1536)}
+    end)
+
+    # Many slow successes — with the trip disabled the breaker NEVER opens.
+    results = for _ <- 1..5, do: Knowledge.generate_embedding(tenant.id, "x")
+    assert Enum.all?(results, &match?({:ok, _}, &1))
+  end
+end

--- a/test/loopctl/knowledge_breaker_throttle_test.exs
+++ b/test/loopctl/knowledge_breaker_throttle_test.exs
@@ -1,0 +1,138 @@
+defmodule Loopctl.KnowledgeBreakerThrottleTest do
+  @moduledoc """
+  US-37.3 (TC-37.3.1 / TC-37.3.5): the throttle-aware embedding circuit breaker.
+
+  Drives the PUBLIC `Knowledge.generate_embedding/3` (routed to
+  `Loopctl.MockEmbeddingClient`) and observes the breaker via its short-circuit
+  return: once the breaker is open, `generate_embedding/3` returns
+  `{:error, :circuit_open}` WITHOUT calling the client. So a class that COUNTS
+  yields `:circuit_open` after `@failure_threshold` (3) failures; an EXEMPT class
+  never does.
+  """
+  use Loopctl.DataCase, async: true
+
+  import Mox
+
+  setup :verify_on_exit!
+
+  alias Loopctl.Knowledge
+
+  @breaker_table :loopctl_embedding_circuit_breaker
+
+  defp always_return(term) do
+    Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text -> term end)
+  end
+
+  # Trip attempt: call the threshold count, then probe once more.
+  defp probe_after_threshold(tenant_id) do
+    for _ <- 1..3, do: Knowledge.generate_embedding(tenant_id, "x")
+    Knowledge.generate_embedding(tenant_id, "x")
+  end
+
+  describe "breaker COUNTS throttle + systemic failures (AC-37.3.1)" do
+    for {label, term} <- [
+          {"429 (throttle)", {:error, {:api_error, 429, :provider_error}}},
+          {"408 (throttle)", {:error, {:api_error, 408, :provider_error}}},
+          {"429 + Retry-After 4-tuple", {:error, {:api_error, 429, :provider_error, 30}}},
+          {"500 (systemic)", {:error, {:api_error, 500, :provider_error}}},
+          {"request_failed (transport)", {:error, {:request_failed, :econnrefused}}},
+          {"embedding_crash", {:error, {:embedding_crash, :exception}}},
+          {"timeout", {:error, :timeout}}
+        ] do
+      test "#{label} counts → breaker opens after threshold" do
+        tenant = fixture(:tenant)
+        Knowledge.reset_circuit_breaker(tenant.id)
+        always_return(unquote(Macro.escape(term)))
+
+        assert {:error, :circuit_open} = probe_after_threshold(tenant.id)
+      end
+    end
+  end
+
+  describe "breaker EXEMPTS credential + self-imposed reasons (AC-37.3.1 / AC-37.3.5)" do
+    for {label, term} <- [
+          {"401 (credential)", {:error, {:api_error, 401, :provider_error}}},
+          {"403 (credential)", {:error, {:api_error, 403, :provider_error}}},
+          {"rate_limited_local (US-37.1)", {:error, :rate_limited_local}}
+        ] do
+      test "#{label} is exempt → breaker stays closed (client still consulted)" do
+        tenant = fixture(:tenant)
+        Knowledge.reset_circuit_breaker(tenant.id)
+        always_return(unquote(Macro.escape(term)))
+
+        # Far beyond the threshold: the breaker must NEVER open, so every call keeps
+        # returning the underlying error, never :circuit_open.
+        results = for _ <- 1..6, do: Knowledge.generate_embedding(tenant.id, "x")
+
+        refute Enum.any?(results, &match?({:error, :circuit_open}, &1))
+        assert Enum.all?(results, &match?(unquote(Macro.escape(term)), &1))
+      end
+    end
+
+    test "no_api_key never reaches the breaker and surfaces cleanly" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+      always_return({:error, :no_api_key})
+
+      results = for _ <- 1..6, do: Knowledge.generate_embedding(tenant.id, "x")
+
+      assert Enum.all?(results, &(&1 == {:error, :no_api_key}))
+    end
+  end
+
+  describe "Retry-After raises the breaker cooldown (AC-37.3.3)" do
+    test "a throttle 4-tuple with a large Retry-After sets a cooldown ~that interval" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+      # 200s is above the base cooldown (30s) and below the clamp max (300s).
+      always_return({:error, {:api_error, 429, :provider_error, 200}})
+
+      # Trip the breaker.
+      for _ <- 1..3, do: Knowledge.generate_embedding(tenant.id, "x")
+      assert {:error, :circuit_open} = Knowledge.generate_embedding(tenant.id, "x")
+
+      # Read the open_until back out (monotonic seconds) — class assertion: the
+      # cooldown honors the Retry-After (>= ~200), never below base, never above max.
+      now = System.monotonic_time(:second)
+      [{_key, open_until}] = :ets.lookup(@breaker_table, {tenant.id, :open_until})
+      remaining = open_until - now
+
+      assert remaining >= 195, "expected cooldown to honor Retry-After (~200s), got #{remaining}"
+      assert remaining <= 300, "expected cooldown clamped to max (300s), got #{remaining}"
+    end
+
+    test "a throttle WITHOUT a Retry-After uses the base cooldown (~30s), not longer" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+      always_return({:error, {:api_error, 429, :provider_error}})
+
+      for _ <- 1..3, do: Knowledge.generate_embedding(tenant.id, "x")
+      assert {:error, :circuit_open} = Knowledge.generate_embedding(tenant.id, "x")
+
+      now = System.monotonic_time(:second)
+      [{_key, open_until}] = :ets.lookup(@breaker_table, {tenant.id, :open_until})
+      remaining = open_until - now
+
+      # Base cooldown class: ~30s, well under the honored-Retry-After case above.
+      assert remaining > 0 and remaining <= 30
+    end
+  end
+
+  describe "tenant isolation" do
+    test "one tenant's throttle storm does not open another tenant's breaker" do
+      a = fixture(:tenant)
+      b = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(a.id)
+      Knowledge.reset_circuit_breaker(b.id)
+      always_return({:error, {:api_error, 429, :provider_error}})
+
+      # Trip tenant A only.
+      for _ <- 1..4, do: Knowledge.generate_embedding(a.id, "x")
+      assert {:error, :circuit_open} = Knowledge.generate_embedding(a.id, "x")
+
+      # Tenant B's breaker is untouched — the client is still consulted for B.
+      assert {:error, {:api_error, 429, :provider_error}} =
+               Knowledge.generate_embedding(b.id, "x")
+    end
+  end
+end

--- a/test/loopctl/knowledge_breaker_throttle_test.exs
+++ b/test/loopctl/knowledge_breaker_throttle_test.exs
@@ -69,6 +69,28 @@ defmodule Loopctl.KnowledgeBreakerThrottleTest do
       end
     end
 
+    # AC-37.3.1: a non-throttle, non-credential 4xx (400/404/422) is a per-request
+    # client error, NOT a systemic provider incident — it must stay EXEMPT ("other
+    # 4xx keep today's behavior"). Guards the catch-all `breaker_countable?/1`
+    # is_integer(status) -> false clause against a future refactor silently making a
+    # generic 4xx trip the breaker.
+    for {label, term} <- [
+          {"400 (bad request)", {:error, {:api_error, 400, :provider_error}}},
+          {"404 (not found)", {:error, {:api_error, 404, :provider_error}}},
+          {"422 (unprocessable)", {:error, {:api_error, 422, :provider_error}}}
+        ] do
+      test "#{label} is exempt → breaker stays closed" do
+        tenant = fixture(:tenant)
+        Knowledge.reset_circuit_breaker(tenant.id)
+        always_return(unquote(Macro.escape(term)))
+
+        results = for _ <- 1..6, do: Knowledge.generate_embedding(tenant.id, "x")
+
+        refute Enum.any?(results, &match?({:error, :circuit_open}, &1))
+        assert Enum.all?(results, &match?(unquote(Macro.escape(term)), &1))
+      end
+    end
+
     test "no_api_key never reaches the breaker and surfaces cleanly" do
       tenant = fixture(:tenant)
       Knowledge.reset_circuit_breaker(tenant.id)

--- a/test/loopctl/knowledge_semantic_search_test.exs
+++ b/test/loopctl/knowledge_semantic_search_test.exs
@@ -812,6 +812,33 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
       assert_receive {:semantic_fallback, _m, %{reason: "embedding_circuit_open"}}
     end
 
+    test "US-37.3 (AC-37.3.5): a 429 throttle storm trips the breaker → keyword fallback, never a 500" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+      keyword_article(tenant.id)
+
+      # US-37.3: 429 is now a COUNTABLE (throttle) failure — three trip the breaker.
+      # Before the split it was breaker-exempt, so a 429 storm never opened it.
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, {:api_error, 429, :provider_error, 30}}
+      end)
+
+      # Each call degrades to keyword-only (never a 500) — tagged by the provider
+      # status while the breaker is still closed.
+      for _ <- 1..3 do
+        assert {:ok, %{meta: _}} = Knowledge.search_combined(tenant.id, "testing")
+      end
+
+      attach_fallback_handler(tenant.id)
+
+      # Breaker now open: generate_embedding short-circuits to :circuit_open (no
+      # client call, no hot retry into the throttling provider) and combined search
+      # still returns {:ok, ...} keyword results — the fail-safe.
+      assert {:ok, %{meta: meta}} = Knowledge.search_combined(tenant.id, "testing")
+      assert meta.fallback_reason == "embedding_circuit_open"
+      assert_receive {:semantic_fallback, _m, %{reason: "embedding_circuit_open"}}
+    end
+
     test "embedding OK but semantic EMPTY -> semantic_result_count: 0, no fallback, distinct telemetry" do
       %{tenant: tenant} = setup_tenant()
       Knowledge.reset_circuit_breaker(tenant.id)

--- a/test/loopctl/provider/retry_after_test.exs
+++ b/test/loopctl/provider/retry_after_test.exs
@@ -62,6 +62,20 @@ defmodule Loopctl.Provider.RetryAfterTest do
     end
   end
 
+  describe "snooze_seconds/1 (positive floor)" do
+    test "floors at 1 so a provider Retry-After: 0 never yields {:snooze, 0}" do
+      # A legitimate `Retry-After: 0` parses to 0; snooze_seconds/1 floors it to 1 so
+      # the breaker-less Anthropic ingestion path can't hot-reschedule with no attempt
+      # cap (US-37.3 review).
+      assert RetryAfter.snooze_seconds(0) == 1
+    end
+
+    test "passes through a positive Retry-After unchanged" do
+      assert RetryAfter.snooze_seconds(30) == 30
+      assert RetryAfter.snooze_seconds(1) == 1
+    end
+  end
+
   describe "from_response/2" do
     test "parses Retry-After only for throttle statuses (429/503)" do
       resp = %Req.Response{status: 429, headers: %{"retry-after" => ["30"]}}

--- a/test/loopctl/provider/retry_after_test.exs
+++ b/test/loopctl/provider/retry_after_test.exs
@@ -1,0 +1,84 @@
+defmodule Loopctl.Provider.RetryAfterTest do
+  @moduledoc "US-37.3 (TC-37.3.2): the provider Retry-After parser."
+  use ExUnit.Case, async: true
+
+  alias Loopctl.Provider.RetryAfter
+
+  describe "parse/1" do
+    test "delta-seconds integer string parses to that many seconds" do
+      assert RetryAfter.parse("30") == 30
+      assert RetryAfter.parse("0") == 0
+      assert RetryAfter.parse("  15  ") == 15
+    end
+
+    test "an IMF-fixdate HTTP-date ~30s out parses to ~30s (max(0, diff))" do
+      target =
+        DateTime.utc_now()
+        |> DateTime.add(30, :second)
+        |> Calendar.strftime("%a, %d %b %Y %H:%M:%S GMT")
+
+      seconds = RetryAfter.parse(target)
+      # Class assertion (not an exact instant): within a small window of 30s.
+      assert seconds >= 27 and seconds <= 30
+    end
+
+    test "an HTTP-date in the PAST clamps to 0 (never negative)" do
+      past =
+        DateTime.utc_now()
+        |> DateTime.add(-120, :second)
+        |> Calendar.strftime("%a, %d %b %Y %H:%M:%S GMT")
+
+      assert RetryAfter.parse(past) == 0
+    end
+
+    test "absent / empty / malformed values → nil (defensive fallback)" do
+      assert RetryAfter.parse(nil) == nil
+      assert RetryAfter.parse("") == nil
+      assert RetryAfter.parse("   ") == nil
+      assert RetryAfter.parse("garbage") == nil
+      # Fractional and negative delta-seconds are malformed per RFC → nil.
+      assert RetryAfter.parse("30.5") == nil
+      assert RetryAfter.parse("-5") == nil
+      # A non-binary is defensively nil.
+      assert RetryAfter.parse(:not_a_string) == nil
+    end
+
+    test "clamps a hostile huge value to the SystemConfig max (default 300s)" do
+      assert RetryAfter.parse("999999999") == RetryAfter.max_seconds()
+      assert RetryAfter.max_seconds() == 300
+    end
+  end
+
+  describe "from_error/1" do
+    test "extracts the Retry-After from the throttle 4-tuple" do
+      assert RetryAfter.from_error({:api_error, 429, :provider_error, 42}) == 42
+    end
+
+    test "returns nil for the legacy 3-tuple and any other term" do
+      assert RetryAfter.from_error({:api_error, 429, :provider_error}) == nil
+      assert RetryAfter.from_error({:api_error, 500}) == nil
+      assert RetryAfter.from_error(:timeout) == nil
+      assert RetryAfter.from_error({:api_error, 429, :provider_error, nil}) == nil
+    end
+  end
+
+  describe "from_response/2" do
+    test "parses Retry-After only for throttle statuses (429/503)" do
+      resp = %Req.Response{status: 429, headers: %{"retry-after" => ["30"]}}
+      assert RetryAfter.from_response(429, resp) == 30
+
+      resp503 = %Req.Response{status: 503, headers: %{"retry-after" => ["45"]}}
+      assert RetryAfter.from_response(503, resp503) == 45
+    end
+
+    test "ignores Retry-After for non-throttle statuses" do
+      resp = %Req.Response{status: 401, headers: %{"retry-after" => ["30"]}}
+      assert RetryAfter.from_response(401, resp) == nil
+    end
+
+    test "a throttle status with no Retry-After header → nil" do
+      resp = %Req.Response{status: 429, headers: %{}}
+      assert RetryAfter.from_response(429, resp) == nil
+    end
+  end
+end

--- a/test/loopctl/workers/article_embedding_worker_test.exs
+++ b/test/loopctl/workers/article_embedding_worker_test.exs
@@ -561,6 +561,44 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorkerTest do
     end
   end
 
+  # --- US-37.3 (AC-37.3.5): OPEN breaker → loss-free snooze, never an attempt-consuming discard ---
+
+  describe "open breaker (US-37.3)" do
+    test "snoozes (loss-free) when the tenant breaker is OPEN, without calling the provider" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      article =
+        create_draft_then_publish(tenant.id, %{
+          title: "Breaker Open Article",
+          body: "The tenant breaker is open from a throttle storm."
+        })
+
+      # Trip the tenant breaker with @failure_threshold (3) countable 429 failures.
+      # `stub` (not an exact `expect`) deliberately avoids the Mox async-supervisor
+      # $callers exact-count race — the embed runs in a Task under async_nolink.
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
+        {:error, {:api_error, 429, :provider_error}}
+      end)
+
+      for _ <- 1..3, do: Knowledge.generate_embedding(tenant.id, "x")
+      assert {:error, :circuit_open} = Knowledge.generate_embedding(tenant.id, "x")
+
+      # Breaker OPEN → the worker snoozes loss-free (no Oban attempt consumed), NOT
+      # {:error, ...} — which would consume an attempt and, under a long honored
+      # cooldown exceeding the 4-attempt window, DISCARD the job and leave the article
+      # permanently un-embedded. The provider is never hit here: generate_embedding
+      # short-circuits on the OPEN breaker (deterministic ETS state) BEFORE spawning
+      # the embed task, so the snooze is reached without a client call.
+      assert {:snooze, seconds} =
+               ArticleEmbeddingWorker.perform(%Oban.Job{
+                 args: %{"article_id" => article.id, "tenant_id" => tenant.id}
+               })
+
+      assert is_integer(seconds) and seconds > 0
+    end
+  end
+
   # --- Idempotency: a retry with unchanged content never re-calls the provider (#12) ---
 
   describe "idempotent re-runs" do

--- a/test/loopctl/workers/article_embedding_worker_test.exs
+++ b/test/loopctl/workers/article_embedding_worker_test.exs
@@ -511,6 +511,56 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorkerTest do
     end
   end
 
+  # --- US-37.3 (AC-37.3.3): honor a provider Retry-After via loss-free snooze ---
+
+  describe "throttle Retry-After (US-37.3)" do
+    test "a 429 carrying a Retry-After snoozes ~that interval instead of attempt^4" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      article =
+        create_draft_then_publish(tenant.id, %{
+          title: "Throttled Article",
+          body: "The provider is rate-limiting and asked us to back off."
+        })
+
+      # The client surfaces the throttle 4-tuple (429 + parsed, clamped Retry-After).
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, {:api_error, 429, :provider_error, 30}}
+      end)
+
+      # Snooze (loss-free — no Oban attempt consumed), NOT the polynomial backoff /
+      # {:error, _} retry. The snooze is the parsed Retry-After.
+      assert {:snooze, 30} =
+               ArticleEmbeddingWorker.perform(%Oban.Job{
+                 args: %{"article_id" => article.id, "tenant_id" => tenant.id}
+               })
+    end
+
+    test "a 429 WITHOUT a Retry-After keeps the transient {:error, _} retry path" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      article =
+        create_draft_then_publish(tenant.id, %{
+          title: "Throttled No Header Article",
+          body: "Rate-limited but no Retry-After header present."
+        })
+
+      expect(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, {:api_error, 429, :provider_error}}
+      end)
+
+      # No Retry-After → falls through to the generic transient branch (429 is
+      # transient per Llm.permanent_provider_error?/1) → {:error, _} for Oban's
+      # polynomial backoff, NOT a discard and NOT a snooze.
+      assert {:error, {:api_error, 429, :provider_error}} =
+               ArticleEmbeddingWorker.perform(%Oban.Job{
+                 args: %{"article_id" => article.id, "tenant_id" => tenant.id}
+               })
+    end
+  end
+
   # --- Idempotency: a retry with unchanged content never re-calls the provider (#12) ---
 
   describe "idempotent re-runs" do

--- a/test/loopctl/workers/content_ingestion_worker_test.exs
+++ b/test/loopctl/workers/content_ingestion_worker_test.exs
@@ -472,6 +472,32 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
       assert {:snooze, seconds} = result
       assert is_integer(seconds) and seconds > 0
     end
+
+    test "US-37.3 (AC-37.3.3): an extraction throttle carrying a Retry-After SNOOZES ~that interval" do
+      %{tenant: tenant} = setup_tenant()
+
+      # The Anthropic extraction was throttled (429/503) and surfaced the throttle
+      # 4-tuple with a parsed, clamped Retry-After. The whole job snoozes loss-free
+      # (no attempt consumed) for ~that interval instead of the blind attempt^4 backoff.
+      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _tenant_id,
+                                                                     _content,
+                                                                     _opts ->
+        {:error, {:api_error, 429, :provider_error, 30}}
+      end)
+
+      result =
+        ContentIngestionWorker.perform(%Oban.Job{
+          id: 108,
+          args: %{
+            "tenant_id" => tenant.id,
+            "content" => "Throttled content",
+            "content_hash" => "throttle_retry_after_test",
+            "source_type" => "ingestion"
+          }
+        })
+
+      assert {:snooze, 30} = result
+    end
   end
 
   # --- Project scoping ---

--- a/test/loopctl/workers/memory_embedding_worker_test.exs
+++ b/test/loopctl/workers/memory_embedding_worker_test.exs
@@ -195,6 +195,30 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorkerTest do
       assert {:snooze, 30} = MemoryEmbeddingWorker.perform(job(memory.id, tenant.id))
     end
 
+    test "US-37.3 (AC-37.3.5): an OPEN breaker snoozes (loss-free), never calling the provider" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+      memory = fixture(:memory, %{tenant_id: tenant.id, subject_id: "s", text: "breaker open"})
+
+      # Trip the tenant breaker with @failure_threshold (3) countable 429 failures.
+      # `stub` (not an exact `expect`) deliberately avoids the Mox async-supervisor
+      # $callers exact-count race — the embed runs in a Task under async_nolink.
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
+        {:error, {:api_error, 429, :provider_error}}
+      end)
+
+      for _ <- 1..3, do: Knowledge.generate_embedding(tenant.id, "x")
+      assert {:error, :circuit_open} = Knowledge.generate_embedding(tenant.id, "x")
+
+      # Breaker OPEN → loss-free snooze (no attempt consumed), NOT {:error, ...} —
+      # which under a long honored cooldown would discard the job and leave the memory
+      # permanently un-embedded. The provider is never hit: generate_embedding
+      # short-circuits on the OPEN breaker (deterministic ETS state) BEFORE spawning
+      # the embed task.
+      assert {:snooze, seconds} = MemoryEmbeddingWorker.perform(job(memory.id, tenant.id))
+      assert is_integer(seconds) and seconds > 0
+    end
+
     test "US-37.2 (AC-37.2.2): the SAME per-node concurrency cap gates the worker (snooze, client never called)" do
       tenant = fixture(:tenant)
       Knowledge.reset_circuit_breaker(tenant.id)

--- a/test/loopctl/workers/memory_embedding_worker_test.exs
+++ b/test/loopctl/workers/memory_embedding_worker_test.exs
@@ -181,6 +181,20 @@ defmodule Loopctl.Workers.MemoryEmbeddingWorkerTest do
       assert is_integer(seconds) and seconds > 0
     end
 
+    test "US-37.3 (AC-37.3.3): a throttle 429 with a Retry-After snoozes ~that interval" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+      memory = fixture(:memory, %{tenant_id: tenant.id, subject_id: "s", text: "throttled"})
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
+        {:error, {:api_error, 429, :provider_error, 30}}
+      end)
+
+      # Loss-free snooze for the provider Retry-After (no attempt consumed), NOT the
+      # polynomial backoff and NOT a discard.
+      assert {:snooze, 30} = MemoryEmbeddingWorker.perform(job(memory.id, tenant.id))
+    end
+
     test "US-37.2 (AC-37.2.2): the SAME per-node concurrency cap gates the worker (snooze, client never called)" do
       tenant = fixture(:tenant)
       Knowledge.reset_circuit_breaker(tenant.id)


### PR DESCRIPTION
## US-37.3 — Throttle-aware circuit breaker + honor provider Retry-After

Part of Epic 37 (GH #352, outbound 429-storm remediation). Fixes the "fight a 429 storm by immediately retrying into it" behavior: the embedding breaker exempted **all** 4xx, and Oban backoff was a blind `attempt^4` that discarded the provider's `Retry-After`.

### What changed (by AC)
- **AC-37.3.1 — 4xx split.** `breaker_countable?` now COUNTS 429/408 (throttle) and EXEMPTS 401/403 (credential). `:rate_limited_local` (US-37.1) and `:no_api_key` stay exempt; 5xx/transport/timeout/crash still count. Throttle now also emits the `provider_error` storm signal as `:transient` — documented; the stale "all 4xx exempt" moduledoc/comments are updated.
- **AC-37.3.2 — Retry-After parser.** New `Loopctl.Provider.RetryAfter` parses delta-seconds OR IMF-fixdate (stdlib `:httpd_util`, defensive: missing/garbage → `nil`), clamped to a SystemConfig max. Both provider clients parse it on 429/503 and thread it into a sanitized throttle 4-tuple `{:api_error, status, :provider_error, retry_after}`.
- **AC-37.3.3 — cooldown + worker snooze.** Breaker cooldown = `min(max(base, retry_after), max)` (base now SystemConfig-driven). The Article/Memory/ContentIngestion workers `{:snooze, retry_after}` loss-free (no Oban attempt consumed) on a throttle carrying a Retry-After instead of `attempt^4`; absent → existing polynomial backoff.
- **AC-37.3.4 — latency trip.** Slow-but-successful calls over `embedding_breaker_latency_threshold_ms` (default **0 = disabled**) trip the breaker after `embedding_breaker_latency_count` windowed calls; recovers on cooldown. Disabled-safe.
- **AC-37.3.5 — fail-safe.** Open breaker → interactive path keyword fallback (existing `:circuit_open` path) + workers snooze; never a 500, never a hot retry loop. All thresholds/cooldowns env-driven via `SystemConfig` (no `Application.put_env` in tests).

### Error-term arity ripple
The throttle 4-tuple only appears for 429/503 **with** a Retry-After; the legacy 3-tuple is unchanged otherwise. Explicit clauses added everywhere a 4-tuple can flow: `ProviderError.sanitize/1`+new `sanitize/2`+`log_tag`, `Llm.permanent_provider_error?`, `Knowledge.breaker_countable?`/`reason_to_tag`/`permanent_merge_error?`, `Memory` fallback tag. `@type`/`@spec` updated; no catch-all reliance.

### Design decision
The breaker stays **embedding-only** (it lives in `Knowledge` and only guards `generate_embedding/3`); the Anthropic path has never had a breaker and this story does not add one — but it still parses+honors Retry-After so a snooze-capable worker yields loss-free. Justified in the moduledocs. Node-local by design (cluster-wide store deferred to Epic 38).

### Tests
RetryAfter parser (seconds/HTTP-date/absent/malformed/clamp); breaker classification per status class; 429-storm → keyword fallback; latency trip + recovery (`async: false`, SystemConfig seeded via `persistent_term`, no leaked DB row); worker snooze for all three workers; embedding-client 429/503 Retry-After parsing; tenant isolation. Full `mix precommit` (format, credo --strict, dialyzer, 4628 tests) green.
