### PR TITLE
US-37.4: batch background embeddings (article-ingest path only) — write-then-recall safe

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -538,10 +538,20 @@ config :loopctl, :dns_resolver, Loopctl.MockDnsResolver
 # lookup can't hang the suite.
 config :loopctl, :dns_resolve_timeout_ms, 2_000
 
-# Batch ingestion per-item validation deadline (FIX 2). Short in tests so the
-# validation_timeout path (a stubbed slow/failing resolver) is exercised in
-# ~200ms instead of the 5s production default. Config-based DI — no put_env.
-config :loopctl, :batch_item_validation_timeout_ms, 200
+# Batch ingestion per-item validation deadline (FIX 2). Shorter than the 5s
+# production default so the validation_timeout path (a resolver stubbed to
+# `Process.sleep(:infinity)`) is exercised without a 5s wait — the hung item does
+# UNBOUNDED work, so it deterministically hits ANY finite deadline. But it must
+# NOT sit inside the range of normal load jitter for the HAPPY path: a batch's
+# items run 10-way concurrent through `async_stream_nolink`, each doing real
+# inline-Oban work (serialized on this test's single sandboxed DB connection), so
+# the aggregate can spike past a tight deadline under full-suite load and flip an
+# innocent "queued" item to a spurious validation_timeout. 200ms was inside that
+# jitter band (reproducibly all-timeout at 1ms; observed flaking at 200ms under
+# load). 2s gives the bounded fast path ~10x headroom over the observed failure
+# point while keeping the (sleep-:infinity) timeout tests fast. Config-based DI —
+# no put_env.
+config :loopctl, :batch_item_validation_timeout_ms, 2_000
 
 # DI: swap ArticleLinkingWorker's similarity lookup for a Mox mock so the worker's
 # linking logic (relates_to / potential_conflict thresholds, dedup, audit, idempotency)

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -814,19 +814,23 @@ defmodule Loopctl.Knowledge do
   end
 
   @doc """
-  Batch variant of `get_article_with_embedding/2` (US-37.4): fetches every article
-  in `article_ids` for the tenant, WITH its `embedding` column select-merged (the
-  default query excludes the vector for cost — #4f356938). Silently drops ids that
-  don't resolve (deleted / wrong tenant). Order is NOT guaranteed — the caller keys
-  by `id`. Scoped to ONE tenant (RLS + explicit predicate).
+  Batch presence-check variant for the bulk-embedding path (US-37.4): fetches every
+  article in `article_ids` for the tenant with the virtual `has_embedding` boolean
+  set to `not is_nil(embedding)` — WITHOUT transferring the 1536-dim vector itself.
+  The batch worker only needs to know whether a row is already embedded (and compare
+  the separate `embedding_content_hash`); loading up to `embedding_batch_max` (~100)
+  full pgvectors per job just to null-check them is avoidable I/O on this hot
+  bulk-ingest path. Silently drops ids that don't resolve (deleted / wrong tenant).
+  Order is NOT guaranteed — the caller keys by `id`. Scoped to ONE tenant (RLS +
+  explicit predicate).
   """
-  @spec get_articles_with_embedding(Ecto.UUID.t(), [Ecto.UUID.t()]) :: [Article.t()]
-  def get_articles_with_embedding(tenant_id, article_ids)
+  @spec get_articles_with_embedding_status(Ecto.UUID.t(), [Ecto.UUID.t()]) :: [Article.t()]
+  def get_articles_with_embedding_status(tenant_id, article_ids)
       when is_binary(tenant_id) and is_list(article_ids) do
     query =
       from(a in Article,
         where: a.id in ^article_ids and a.tenant_id == ^tenant_id,
-        select_merge: %{embedding: a.embedding}
+        select_merge: %{has_embedding: not is_nil(a.embedding)}
       )
 
     AdminRepo.all(query)

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -63,6 +63,23 @@ defmodule Loopctl.Knowledge do
   alias Loopctl.SystemConfig
   alias Loopctl.Webhooks.EventGenerator
   alias Loopctl.Workers.ArticleEmbeddingWorker
+  alias Loopctl.Workers.BatchArticleEmbeddingWorker
+
+  # US-37.4: default texts-per-array-batch for background embedding (`embedding_batch_max/0`).
+  # Env-driven via SystemConfig (`"embedding_batch_max"`); this in-code default doubles
+  # as the documented default and applies on a cache miss.
+  @default_embedding_batch_max 100
+
+  # US-37.4 (AC-37.4.4 review): CUMULATIVE per-request character budget for a single
+  # provider array call (`embedding_batch_max_chars/0`). The count cap
+  # (`embedding_batch_max/0`) alone does not bound aggregate tokens — 100 inputs each
+  # sliced to ~32K chars is ~3.2M chars (~800k tokens), which can exceed an
+  # OpenAI-compatible per-request token ceiling (~300k tokens) and return a permanent
+  # HTTP 400. The worker sub-splits each count-chunk so no single array call exceeds
+  # this many characters. Default ~1,000,000 chars (~250k tokens at ~4 chars/token)
+  # keeps every request comfortably under the ceiling. Env-driven via SystemConfig
+  # (`"embedding_batch_max_chars"`).
+  @default_embedding_batch_max_chars 1_000_000
 
   # Maximum page size for the article list endpoint (`list_articles/2`). Larger
   # limits are HONORED up to this cap so callers can paginate to exhaustion at
@@ -794,6 +811,25 @@ defmodule Loopctl.Knowledge do
       nil -> {:error, :not_found}
       article -> {:ok, article}
     end
+  end
+
+  @doc """
+  Batch variant of `get_article_with_embedding/2` (US-37.4): fetches every article
+  in `article_ids` for the tenant, WITH its `embedding` column select-merged (the
+  default query excludes the vector for cost — #4f356938). Silently drops ids that
+  don't resolve (deleted / wrong tenant). Order is NOT guaranteed — the caller keys
+  by `id`. Scoped to ONE tenant (RLS + explicit predicate).
+  """
+  @spec get_articles_with_embedding(Ecto.UUID.t(), [Ecto.UUID.t()]) :: [Article.t()]
+  def get_articles_with_embedding(tenant_id, article_ids)
+      when is_binary(tenant_id) and is_list(article_ids) do
+    query =
+      from(a in Article,
+        where: a.id in ^article_ids and a.tenant_id == ^tenant_id,
+        select_merge: %{embedding: a.embedding}
+      )
+
+    AdminRepo.all(query)
   end
 
   @doc """
@@ -3416,22 +3452,87 @@ defmodule Loopctl.Knowledge do
   # transaction has committed. Best-effort and crash-proof: the publish is
   # already durable, so a transient enqueue failure must never 500 the request or
   # abort the remaining chunks — we log and move on (the embedding is
-  # re-derivable). Per-row `Oban.insert/1` (NOT `insert_all`) so the worker's
-  # `unique: [keys: [:article_id], period: 300]` window is honored — the basic
-  # Oban engine ignores `unique:` for `insert_all`. Bounded to <= 100 inserts per
-  # chunk.
+  # re-derivable).
+  #
+  # US-37.4: this is the truly-bulk background ingest path, so it BATCHES —
+  # chunk the published rows into groups of `embedding_batch_max/0` (~100) and
+  # enqueue ONE `BatchArticleEmbeddingWorker` per chunk. That worker embeds the
+  # whole chunk in a single provider array call (one admission token + one
+  # concurrency slot per batch), cutting provider round-trips ~100x vs. the old
+  # per-article fan-out. Per-chunk `Oban.insert/1` (NOT `insert_all`) so the
+  # worker's `unique:` window is honored — the basic Oban engine ignores `unique:`
+  # for `insert_all`.
+  #
+  # NB: the INTERACTIVE single-article publish path (`maybe_enqueue_embedding/2`)
+  # stays on the per-record `ArticleEmbeddingWorker` — batching is only for bulk.
   defp enqueue_bulk_embeddings(_tenant_id, []), do: :ok
 
   defp enqueue_bulk_embeddings(tenant_id, published) do
-    Enum.each(published, fn article ->
-      %{article_id: article.id, tenant_id: tenant_id}
-      |> ArticleEmbeddingWorker.new()
+    published
+    |> Enum.chunk_every(embedding_batch_max())
+    |> Enum.each(fn chunk ->
+      %{article_ids: Enum.map(chunk, & &1.id), tenant_id: tenant_id}
+      |> BatchArticleEmbeddingWorker.new()
       |> Oban.insert()
     end)
   rescue
     e ->
       Logger.error("bulk_publish: embedding enqueue failed: #{Exception.message(e)}")
       :ok
+  end
+
+  @doc """
+  Max number of texts per background embedding array batch (US-37.4).
+
+  DB-backed + live-tunable via `Loopctl.SystemConfig` (`"embedding_batch_max"`); the
+  in-code default (#{@default_embedding_batch_max}) matches the seeded row and
+  applies on a cache miss. Floored at 1 (a non-positive tuned value can't wedge into
+  an empty chunk).
+
+  Respects both provider limits (AC-37.4.4) via TWO caps applied together — the
+  worker chunks by the smaller of them, so neither the array size NOR the aggregate
+  per-request tokens can overflow:
+
+    * **Per-input token limit** — each text is sliced to 32K chars (~8k tokens) in
+      the worker's `build_embedding_text/1`, at/under the embedder's ~8191-token
+      per-input window, so no single array element overflows.
+    * **Array-size limit (this knob)** — OpenAI-compatible `/embeddings` accepts up
+      to ~2048 inputs per request; ~100 keeps each request small and bounds the
+      per-batch blast radius on a provider error. Operators can lower this knob live
+      (no redeploy).
+    * **Cumulative per-request token limit** — `embedding_batch_max_chars/0` bounds
+      the SUM of characters across a single array call, so a chunk of many
+      large-text articles is sub-split before it can exceed the provider's
+      per-request token ceiling. The count cap alone does NOT bound aggregate tokens
+      (100 × ~8k tokens ≈ 800k > a ~300k ceiling), which is why this second cap
+      exists.
+  """
+  @spec embedding_batch_max() :: pos_integer()
+  def embedding_batch_max do
+    "embedding_batch_max"
+    |> SystemConfig.get_int(@default_embedding_batch_max)
+    |> max(1)
+  end
+
+  @doc """
+  Cumulative CHARACTER budget for a single background embedding array call (US-37.4,
+  AC-37.4.4).
+
+  Bounds the SUM of input characters per provider request, in addition to the
+  `embedding_batch_max/0` count cap. `BatchArticleEmbeddingWorker` sub-splits each
+  count-chunk so no single array call exceeds this many characters, keeping aggregate
+  per-request tokens under an OpenAI-compatible ceiling (~300k tokens) that the count
+  cap alone cannot guarantee. DB-backed + live-tunable via `Loopctl.SystemConfig`
+  (`"embedding_batch_max_chars"`); the in-code default
+  (#{@default_embedding_batch_max_chars}) applies on a cache miss. Floored at
+  `@max_text_length` in the worker so a single oversized (already-sliced) input still
+  forms its own chunk rather than wedging into an empty one.
+  """
+  @spec embedding_batch_max_chars() :: pos_integer()
+  def embedding_batch_max_chars do
+    "embedding_batch_max_chars"
+    |> SystemConfig.get_int(@default_embedding_batch_max_chars)
+    |> max(1)
   end
 
   defp add_bulk_audit_entries(
@@ -7557,6 +7658,108 @@ defmodule Loopctl.Knowledge do
       _ ->
         # nil (yield timeout), an abnormal task exit, or an async_nolink task crash
         # surfacing as {:exit, reason} — a provider/infra failure.
+        record_failure(tenant_id)
+        maybe_record_provider_error(:timeout)
+        {:error, :timeout}
+    end
+  end
+
+  @doc """
+  US-37.4: batch variant of `generate_embedding/3` — embeds a LIST of texts in ONE
+  provider round-trip, reusing the SAME per-tenant circuit breaker, per-node
+  concurrency gate, latency telemetry, and error classification as the single-text
+  path (ONE slot + ONE breaker signal per batch, not per text).
+
+  Used ONLY by the truly-bulk background ingest path (`BatchArticleEmbeddingWorker`).
+  The interactive single-query path stays on `generate_embedding/3` (latency-sensitive).
+
+  Returns `{:ok, vectors}` with vectors in the SAME order as `texts`, or
+  `{:error, reason}` (the whole batch fails/retries as a unit — never a partial
+  half-write of vectors). An empty list returns `{:ok, []}` WITHOUT acquiring a slot
+  or hitting the breaker.
+
+  `opts`:
+    * `:timeout` — Task.yield budget in ms (default `#{@embedding_yield_ms}`).
+  """
+  @spec generate_embeddings(Ecto.UUID.t(), [String.t()], keyword()) ::
+          {:ok, [[float()]]} | {:error, term()}
+  def generate_embeddings(tenant_id, texts, opts \\ [])
+      when is_binary(tenant_id) and is_list(texts) do
+    if texts == [] do
+      {:ok, []}
+    else
+      try_generate_embeddings(tenant_id, texts, opts)
+    end
+  end
+
+  defp try_generate_embeddings(tenant_id, texts, opts) do
+    ensure_circuit_breaker_table()
+
+    if circuit_open?(tenant_id) do
+      {:error, :circuit_open}
+    else
+      timeout = Keyword.get(opts, :timeout, @embedding_yield_ms)
+      run_embeddings_task(tenant_id, texts, timeout)
+    end
+  end
+
+  # Mirrors `run_embedding_task/3`: ONE concurrency slot for the WHOLE batch
+  # (US-37.2 — a batch is one outbound call, so it charges one slot), released in an
+  # `after`. Over the cap → `{:error, :rate_limited_local}` (worker snoozes).
+  defp run_embeddings_task(tenant_id, texts, timeout) do
+    case embedding_concurrency().acquire(tenant_id) do
+      :ok ->
+        try do
+          run_capped_embeddings_task(tenant_id, texts, timeout)
+        after
+          embedding_concurrency().release(tenant_id)
+        end
+
+      {:error, :rate_limited_local} = err ->
+        err
+    end
+  end
+
+  # Mirrors `run_capped_embedding_task/3` (supervised async_nolink, breaker/
+  # provider-error recording) but calls the client's BATCH callback. ONE breaker
+  # signal per batch — a batch failure counts once, not per text. UNLIKE the single
+  # path it is EXEMPT from latency-based tripping (a batch's wall-clock is inherently
+  # larger than one text; see the success clause below).
+  defp run_capped_embeddings_task(tenant_id, texts, timeout) do
+    started_ms = System.monotonic_time(:millisecond)
+
+    task =
+      Task.Supervisor.async_nolink(Loopctl.Knowledge.EmbeddingTaskSupervisor, fn ->
+        try do
+          embedding_client().generate_embeddings(tenant_id, texts)
+        rescue
+          e -> {:error, {:embedding_crash, Exception.message(e)}}
+        end
+      end)
+
+    case Task.yield(task, timeout) || Task.shutdown(task) do
+      {:ok, {:ok, vectors}} ->
+        # Review (LOW #5): the batch path is EXEMPT from latency-based breaker
+        # tripping. `started_ms` here is the WHOLE-batch wall-clock (~100 texts),
+        # inherently far larger than one interactive text; scoring it against the
+        # single-call `embedding_breaker_latency_threshold_ms` would treat normal
+        # batch latency as a "slow call" and could falsely trip the per-tenant
+        # breaker (degrading that tenant to keyword search). A successful batch is
+        # full health → just clear the tenant's breaker state (no slow-call count).
+        # (Failure/timeout still counts below, exactly like the single path.)
+        _elapsed_ms = System.monotonic_time(:millisecond) - started_ms
+        record_success(tenant_id)
+        {:ok, vectors}
+
+      {:ok, {:error, :no_api_key}} ->
+        {:error, :no_api_key}
+
+      {:ok, {:error, reason} = err} ->
+        maybe_record_failure(tenant_id, reason)
+        maybe_record_provider_error(reason)
+        err
+
+      _ ->
         record_failure(tenant_id)
         maybe_record_provider_error(:timeout)
         {:error, :timeout}

--- a/lib/loopctl/knowledge/article.ex
+++ b/lib/loopctl/knowledge/article.ex
@@ -61,6 +61,11 @@ defmodule Loopctl.Knowledge.Article do
     field :metadata, :map, default: %{}
 
     field :embedding, Pgvector.Ecto.Vector, load_in_query: false
+    # Virtual boolean projection of `not is_nil(embedding)` — lets the bulk-embedding
+    # path (US-37.4) null-check presence WITHOUT transferring the 1536-dim vector for
+    # every article in a ~100-record chunk. Populated by
+    # `Knowledge.get_articles_with_embedding_status/2`.
+    field :has_embedding, :boolean, virtual: true
     # SHA-256 hex of the exact text that produced `embedding` — the idempotency key
     # that lets ArticleEmbeddingWorker skip re-calling the paid provider on retry.
     field :embedding_content_hash, :string

--- a/lib/loopctl/knowledge/embedding_behaviour.ex
+++ b/lib/loopctl/knowledge/embedding_behaviour.ex
@@ -25,4 +25,26 @@ defmodule Loopctl.Knowledge.EmbeddingBehaviour do
 
   @callback generate_embedding(tenant_id :: Ecto.UUID.t(), text :: String.t()) ::
               {:ok, [float()]} | {:error, :no_api_key} | {:error, term()}
+
+  @doc """
+  Batch variant: embeds a LIST of texts in ONE provider round-trip (US-37.4).
+
+  OpenAI-compatible `/embeddings` accepts `input` as an array and returns a `data`
+  array whose entries each carry an `index` field. Implementations MUST map every
+  returned vector back to its input BY that `index` (never by array position), and
+  return the vectors in the SAME order as the input `texts` — so the caller can zip
+  `Enum.zip(texts, vectors)` safely.
+
+  Used ONLY on the truly-bulk background ingest path (one admission token + one
+  concurrency slot per batch). The interactive single-query path stays on
+  `generate_embedding/2` (latency-sensitive, one text per call).
+
+  A partial provider response (fewer/mismatched indices than inputs) MUST fail the
+  whole batch (`{:error, _}`) rather than silently returning a short/misaligned
+  list — the caller retries/fails the batch as a unit (no half-written vectors).
+
+  An empty input list returns `{:ok, []}` WITHOUT a provider call (no token spent).
+  """
+  @callback generate_embeddings(tenant_id :: Ecto.UUID.t(), texts :: [String.t()]) ::
+              {:ok, [[float()]]} | {:error, :no_api_key} | {:error, term()}
 end

--- a/lib/loopctl/knowledge/embedding_client.ex
+++ b/lib/loopctl/knowledge/embedding_client.ex
@@ -40,6 +40,18 @@ defmodule Loopctl.Knowledge.EmbeddingClient do
 
   @default_base_url "https://api.openai.com/v1"
 
+  # Single (interactive) path receive_timeout default — kept tight (latency-sensitive).
+  @default_receive_timeout_ms 4_000
+
+  # Batch path receive_timeout defaults (review MED #3). The batch path gets its OWN,
+  # count-SCALED receive_timeout instead of reusing the single-text-tuned
+  # `embedding_receive_timeout_ms` (raising that would also loosen the latency-sensitive
+  # interactive path). base + per-item mirrors the worker's yield shape; the base is
+  # kept strictly BELOW the worker's yield base so the HTTP call fails cleanly before
+  # the worker's Task.yield shuts the task down. Live-tunable via SystemConfig.
+  @default_batch_receive_base_ms 6_000
+  @default_batch_receive_per_item_ms 100
+
   @impl true
   def generate_embedding(tenant_id, text) when is_binary(tenant_id) do
     case Llm.resolve(tenant_id, :embedding) do
@@ -49,6 +61,24 @@ defmodule Loopctl.Knowledge.EmbeddingClient do
 
       {:ok, %{api_key: api_key, model: model}} ->
         post(tenant_id, api_key, model, text)
+    end
+  end
+
+  @impl true
+  def generate_embeddings(tenant_id, texts)
+      when is_binary(tenant_id) and is_list(texts) do
+    # An empty batch never touches the provider (no admission token spent).
+    if texts == [] do
+      {:ok, []}
+    else
+      case Llm.resolve(tenant_id, :embedding) do
+        {:error, :no_api_key} ->
+          # Mandatory BYO: no tenant key => no provider call, no operator spend.
+          {:error, :no_api_key}
+
+        {:ok, %{api_key: api_key, model: model}} ->
+          post_batch(tenant_id, api_key, model, texts)
+      end
     end
   end
 
@@ -63,51 +93,156 @@ defmodule Loopctl.Knowledge.EmbeddingClient do
     end
   end
 
+  # US-37.4: batch variant. ONE admission token is taken for the WHOLE array
+  # (AC-37.4.4) — the same single gate as the single-text path — so a ~100-text
+  # batch is one bucket draw, not 100. Same breaker-exempt fast-fail on an empty
+  # bucket.
+  defp post_batch(tenant_id, api_key, model, texts) do
+    with :ok <- Admission.admit(tenant_id, :embedding) do
+      do_post_batch(tenant_id, api_key, model, texts)
+    end
+  end
+
   defp do_post(tenant_id, api_key, model, text) do
-    base_url = provider_config()[:base_url] || @default_base_url
+    opts = request_opts(api_key, %{input: text, model: model}, single_receive_timeout_ms())
 
-    # Kept STRICTLY BELOW `Knowledge`'s Task.yield budget (review #10): a single
-    # attempt, no client-side retries by default. The embedding endpoint is fast;
-    # job-level retry is Oban's responsibility for the worker, and the query path
-    # fast-fails to keyword search. This guarantees a valid embed returns before
-    # the guard kills it. Both knobs are DB-backed and live-tunable via
-    # Loopctl.SystemConfig; the in-code defaults match the seeded rows and apply on
-    # a cache miss (safe degrade) — keep any raised timeout under the yield budget.
-    opts =
-      [
-        json: %{input: text, model: model},
-        # NOTE: never log `opts` / `api_key` — the key is a tenant secret.
-        headers: [{"authorization", "Bearer #{api_key}"}],
-        retry: :transient,
-        max_retries: SystemConfig.get_int("embedding_max_retries", 0),
-        receive_timeout: SystemConfig.get_int("embedding_receive_timeout_ms", 4_000)
-      ]
-      |> maybe_put_plug()
-
-    case Req.post("#{base_url}/embeddings", opts) do
+    case Req.post(embeddings_url(), opts) do
       {:ok, %{status: 200, body: %{"data" => [%{"embedding" => embedding} | _]} = resp}} ->
         record_usage_safe(tenant_id, model, resp["usage"])
         {:ok, embedding}
 
-      {:ok, %{status: status, body: body} = resp} ->
-        Logger.warning("Loopctl.Knowledge.EmbeddingClient: API error (status=#{status})")
-        # US-37.3: on a throttle response (429/503) parse the provider Retry-After
-        # and thread it (clamped, value-free) into the sanitized error so the
-        # tenant-scoped breaker cooldown AND the Oban worker snooze honor it instead
-        # of blind polynomial backoff. Absent/garbage → nil → the legacy 3-tuple.
-        # SANITIZE either way: the provider error body can echo a masked key fragment
-        # (review #3). Drop it — keep only status (+ Retry-After) — so it never
-        # reaches the caller / an Oban `{:error, reason}` persisted into oban_jobs.errors.
-        retry_after = RetryAfter.from_response(status, resp)
-        {:error, ProviderError.sanitize({:api_error, status, body}, retry_after)}
-
-      {:error, reason} ->
-        Logger.warning(
-          "Loopctl.Knowledge.EmbeddingClient: request failed (#{ProviderError.log_tag({:request_failed, reason})})"
-        )
-
-        {:error, {:request_failed, reason}}
+      other ->
+        handle_error(other)
     end
+  end
+
+  # Sends `input` as an ARRAY and maps each returned `%{"index" => i, "embedding" =>
+  # v}` back to input position `i` — sorting/looking up BY the response index, NEVER
+  # by array position (AC-37.4.1). Returns vectors in INPUT ORDER so the caller can
+  # zip them against `texts`. A short/mismatched `data` array (any input index with
+  # no returned vector) fails the WHOLE batch (AC-37.4.3) — no partial/misaligned
+  # result reaches the caller.
+  defp do_post_batch(tenant_id, api_key, model, texts) do
+    opts =
+      request_opts(
+        api_key,
+        %{input: texts, model: model},
+        batch_receive_timeout_ms(length(texts))
+      )
+
+    case Req.post(embeddings_url(), opts) do
+      {:ok, %{status: 200, body: %{"data" => data} = resp}} when is_list(data) ->
+        case map_vectors_by_index(data, length(texts)) do
+          {:ok, vectors} ->
+            record_usage_safe(tenant_id, model, resp["usage"])
+            {:ok, vectors}
+
+          :error ->
+            Logger.warning(
+              "Loopctl.Knowledge.EmbeddingClient: batch response index mismatch " <>
+                "(#{length(data)} vectors for #{length(texts)} inputs)"
+            )
+
+            {:error, {:embedding_index_mismatch, length(texts), length(data)}}
+        end
+
+      other ->
+        handle_error(other)
+    end
+  end
+
+  # `receive_timeout` is caller-supplied and kept STRICTLY BELOW `Knowledge`'s
+  # Task.yield budget (review #10): a single attempt, no client-side retries by
+  # default. The single (interactive) path uses a tight, latency-sensitive budget;
+  # the batch path a count-SCALED one (see the callers). Job-level retry is Oban's
+  # responsibility for the worker, and the query path fast-fails to keyword search.
+  # All knobs are DB-backed and live-tunable via Loopctl.SystemConfig; the in-code
+  # defaults match the seeded rows and apply on a cache miss (safe degrade).
+  defp request_opts(api_key, json_body, receive_timeout) do
+    [
+      json: json_body,
+      # NOTE: never log `opts` / `api_key` — the key is a tenant secret.
+      headers: [{"authorization", "Bearer #{api_key}"}],
+      retry: :transient,
+      max_retries: SystemConfig.get_int("embedding_max_retries", 0),
+      receive_timeout: receive_timeout
+    ]
+    |> maybe_put_plug()
+  end
+
+  defp single_receive_timeout_ms do
+    SystemConfig.get_int("embedding_receive_timeout_ms", @default_receive_timeout_ms)
+  end
+
+  # Batch path receive_timeout: base + per-item, scaled by the array size so a large
+  # ~100-input request gets proportionally more wire time than one text — WITHOUT
+  # loosening the single-path timeout. Mirrors the worker's yield shape (smaller base)
+  # so it always fails before the worker's yield.
+  defp batch_receive_timeout_ms(count) do
+    base = SystemConfig.get_int("embedding_batch_receive_base_ms", @default_batch_receive_base_ms)
+
+    per_item =
+      SystemConfig.get_int(
+        "embedding_batch_receive_per_item_ms",
+        @default_batch_receive_per_item_ms
+      )
+
+    base + per_item * max(count, 1)
+  end
+
+  defp embeddings_url do
+    base_url = provider_config()[:base_url] || @default_base_url
+    "#{base_url}/embeddings"
+  end
+
+  # Builds the map index -> embedding from the (order-unguaranteed) `data` array,
+  # then pulls one vector per input position 0..count-1. Any missing index halts
+  # with `:error` (batch fails as a unit). Non-integer/malformed entries are dropped
+  # from the lookup, which surfaces as a missing index below.
+  defp map_vectors_by_index(data, count) do
+    by_index =
+      Enum.reduce(data, %{}, fn
+        %{"index" => i, "embedding" => v}, acc when is_integer(i) and is_list(v) ->
+          Map.put(acc, i, v)
+
+        _, acc ->
+          acc
+      end)
+
+    result =
+      Enum.reduce_while(0..(count - 1)//1, [], fn i, acc ->
+        case Map.fetch(by_index, i) do
+          {:ok, v} -> {:cont, [v | acc]}
+          :error -> {:halt, :error}
+        end
+      end)
+
+    case result do
+      :error -> :error
+      list -> {:ok, Enum.reverse(list)}
+    end
+  end
+
+  # Shared non-200 / transport handling for BOTH the single and batch paths.
+  defp handle_error({:ok, %{status: status, body: body} = resp}) do
+    Logger.warning("Loopctl.Knowledge.EmbeddingClient: API error (status=#{status})")
+    # US-37.3: on a throttle response (429/503) parse the provider Retry-After
+    # and thread it (clamped, value-free) into the sanitized error so the
+    # tenant-scoped breaker cooldown AND the Oban worker snooze honor it instead
+    # of blind polynomial backoff. Absent/garbage → nil → the legacy 3-tuple.
+    # SANITIZE either way: the provider error body can echo a masked key fragment
+    # (review #3). Drop it — keep only status (+ Retry-After) — so it never
+    # reaches the caller / an Oban `{:error, reason}` persisted into oban_jobs.errors.
+    retry_after = RetryAfter.from_response(status, resp)
+    {:error, ProviderError.sanitize({:api_error, status, body}, retry_after)}
+  end
+
+  defp handle_error({:error, reason}) do
+    Logger.warning(
+      "Loopctl.Knowledge.EmbeddingClient: request failed (#{ProviderError.log_tag({:request_failed, reason})})"
+    )
+
+    {:error, {:request_failed, reason}}
   end
 
   # BEST-EFFORT usage recording: the embedding call has already SUCCEEDED (and been

--- a/lib/loopctl/workers/batch_article_embedding_worker.ex
+++ b/lib/loopctl/workers/batch_article_embedding_worker.ex
@@ -105,7 +105,7 @@ defmodule Loopctl.Workers.BatchArticleEmbeddingWorker do
   end
 
   defp embed_batch(tenant_id, article_ids) do
-    articles = Knowledge.get_articles_with_embedding(tenant_id, article_ids)
+    articles = Knowledge.get_articles_with_embedding_status(tenant_id, article_ids)
 
     # Split into (a) already-embedded (idempotent skip — re-ensure linking) and
     # (b) to-embed `{article, text, content_hash}` tuples. The paid provider only
@@ -269,8 +269,8 @@ defmodule Loopctl.Workers.BatchArticleEmbeddingWorker do
     {:discard, {:no_embedding_key, Enum.map(to_embed, fn {a, _t, _h} -> a.id end)}}
   end
 
-  defp already_embedded?(%{embedding: embedding, embedding_content_hash: hash}, content_hash)
-       when not is_nil(embedding) and is_binary(hash),
+  defp already_embedded?(%{has_embedding: true, embedding_content_hash: hash}, content_hash)
+       when is_binary(hash),
        do: hash == content_hash
 
   defp already_embedded?(_article, _content_hash), do: false

--- a/lib/loopctl/workers/batch_article_embedding_worker.ex
+++ b/lib/loopctl/workers/batch_article_embedding_worker.ex
@@ -1,0 +1,306 @@
+defmodule Loopctl.Workers.BatchArticleEmbeddingWorker do
+  @moduledoc """
+  Oban worker that embeds a BATCH of articles in ONE provider array call (US-37.4).
+
+  This is the truly-bulk background ingest counterpart to
+  `Loopctl.Workers.ArticleEmbeddingWorker` (which embeds a single article on the
+  interactive publish path). Enqueued by every BULK background path — `Knowledge`
+  bulk publish (`enqueue_bulk_embeddings/2`), `ContentIngestionWorker` auto-publish
+  ingest, and the `KnowledgeLintWorker` orphan-embedding backfill — each of which
+  chunks its rows into groups of `Knowledge.embedding_batch_max/0` (~100) and
+  enqueues one job per chunk. The interactive single-article/memory/promotion paths
+  stay per-record (write-then-recall guarantee).
+
+  Each chunk is embedded via the GUARDED `Knowledge.generate_embeddings/3`, which
+  sends `input` as an array and maps each returned vector back to its input BY the
+  response `index` field (never by position). Within a job the chunk is further
+  sub-split by a cumulative CHARACTER budget (`Knowledge.embedding_batch_max_chars/0`)
+  so no single array call exceeds the provider's per-request token ceiling; each
+  sub-batch takes one admission token (US-37.1) and one concurrency slot (US-37.2),
+  cutting provider round-trips ~100x vs. per-article fan-out.
+
+  ## Flow
+
+  1. US-36.2 per-tenant `FairShare.gate` for the `:embeddings` slot — ONE gate for
+     the batch (loss-free `{:snooze, n}` when this tenant is at/above its fair share).
+  2. Fetch every article in the chunk (with `embedding` + content-hash). Deleted /
+     wrong-tenant ids are silently dropped.
+  3. IDEMPOTENCY: articles whose stored content-hash already matches the current
+     content are skipped (no provider call, re-ensure linking) — an Oban retry after
+     a post-embed failure never re-bills the tenant.
+  4. Embed the remaining texts in ONE `Knowledge.generate_embeddings/3` array call;
+     zip the returned vectors (input order, guaranteed by the client's by-index map)
+     back onto their articles and store each via `Knowledge.update_embedding/4`, then
+     enqueue linking.
+
+  ## Partial failure = whole-batch retry (AC-37.4.3)
+
+  Vectors are written ONLY after a successful provider call returns every vector, so
+  a provider error means ZERO writes — the batch fails/retries as a unit (no silent
+  half-write). On a retry the already-stored rows are idempotent no-ops.
+
+  ## Error taxonomy (MIRRORS `ArticleEmbeddingWorker` exactly)
+
+  - `{:error, :no_api_key}` (mandatory BYO) → `{:discard, {:no_embedding_key, _}}`.
+  - `{:error, :rate_limited_local}` (US-37.1 node-local admission) → `{:snooze, n}`.
+  - `{:error, :circuit_open}` (US-37.3 breaker open) → `{:snooze, remaining_cooldown}`.
+  - throttle 4-tuple with a provider `Retry-After` → `{:snooze, retry_after}`.
+  - permanent provider error (4xx bad/revoked key) → `{:discard, {:embedding_permanent_error, _}}`.
+  - transient (5xx / network / timeout) → `{:error, reason}` for Oban retry.
+
+  ## Uniqueness
+
+  Unique per `article_ids` within a 300-second window; a duplicate chunk while one is
+  pending replaces the existing job.
+  """
+
+  use Oban.Worker,
+    queue: :embeddings,
+    max_attempts: 4,
+    unique: [keys: [:article_ids], period: 300],
+    replace: [scheduled: [:args, :scheduled_at]]
+
+  require Logger
+
+  alias Loopctl.Knowledge
+  alias Loopctl.Llm
+  alias Loopctl.Llm.ProviderError
+  alias Loopctl.Oban.FairShare
+  alias Loopctl.Provider.Admission
+  alias Loopctl.Provider.RetryAfter
+  alias Loopctl.SystemConfig
+  alias Loopctl.Workers.ArticleLinkingWorker
+
+  # Task.yield budget for a batch provider call. Review (MED #3): this was a
+  # hardcoded 8s compile-time constant tuned for a SINGLE text — it neither scaled
+  # with the ~100-input array the batch path sends nor could an operator raise it,
+  # so it would shut the task down before a raised `embedding_receive_timeout_ms`
+  # could take effect and would systematically time out a legitimately slow large
+  # batch. Now: live-tunable via SystemConfig AND scaled by the sub-batch text count
+  # (base + per-item), so the yield grows with the payload. The client's batch
+  # receive_timeout is derived from the SAME shape (a strictly smaller base) so the
+  # HTTP call always fails cleanly BEFORE the yield shuts the task — see
+  # `EmbeddingClient.batch_receive_timeout_ms/1`.
+  @default_yield_base_ms 8_000
+  @default_yield_per_item_ms 100
+  @max_text_length 32_000
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{
+        id: id,
+        args: %{"article_ids" => article_ids, "tenant_id" => tenant_id}
+      })
+      when is_list(article_ids) do
+    # US-36.2: ONE per-tenant fair-share gate for the whole batch. `id` excludes THIS
+    # already-executing job from its own count — see FairShare.
+    case FairShare.gate(tenant_id, :embeddings, id) do
+      {:snooze, _n} = snooze -> snooze
+      :ok -> embed_batch(tenant_id, article_ids)
+    end
+  end
+
+  @impl Oban.Worker
+  def backoff(%Oban.Job{attempt: attempt}) do
+    trunc(:math.pow(attempt, 4) + 15 + :rand.uniform(30) * attempt)
+  end
+
+  defp embed_batch(tenant_id, article_ids) do
+    articles = Knowledge.get_articles_with_embedding(tenant_id, article_ids)
+
+    # Split into (a) already-embedded (idempotent skip — re-ensure linking) and
+    # (b) to-embed `{article, text, content_hash}` tuples. The paid provider only
+    # sees (b).
+    {to_embed, already} =
+      articles
+      |> Enum.map(fn article ->
+        text = build_embedding_text(article)
+        {article, text, content_hash(text)}
+      end)
+      |> Enum.split_with(fn {article, _text, hash} -> not already_embedded?(article, hash) end)
+
+    Enum.each(already, fn {article, _text, _hash} -> enqueue_linking(article.id, tenant_id) end)
+
+    generate_and_store(tenant_id, to_embed)
+  end
+
+  defp generate_and_store(_tenant_id, []), do: :ok
+
+  # AC-37.4.4 (review MED #2): in ADDITION to the count cap applied at enqueue
+  # (`Knowledge.embedding_batch_max/0`), bound each provider array call by a
+  # CUMULATIVE character budget (`Knowledge.embedding_batch_max_chars/0`). A chunk of
+  # many large-text articles (100 × ~32K chars ≈ 3.2M chars ≈ 800k tokens) can
+  # otherwise exceed an OpenAI-compatible per-request token ceiling (~300k) and return
+  # a permanent HTTP 400 that discards the whole chunk. Sub-split into groups under the
+  # char budget; each sub-batch is ONE provider call (one admission token + one slot)
+  # embedded+stored before the next, so an Oban retry idempotently skips already-stored
+  # sub-batches (no re-bill). Stops at the first non-`:ok` sub-batch result
+  # (snooze/discard/error), which the perform/1 caller returns to Oban.
+  defp generate_and_store(tenant_id, to_embed) do
+    to_embed
+    |> chunk_by_char_budget(Knowledge.embedding_batch_max_chars())
+    |> Enum.reduce_while(:ok, fn sub_batch, :ok ->
+      case embed_and_store_sub_batch(tenant_id, sub_batch) do
+        :ok -> {:cont, :ok}
+        other -> {:halt, other}
+      end
+    end)
+  end
+
+  # Greedy split of `to_embed` tuples into sub-batches whose cumulative text
+  # `byte_size` stays at/under `max_chars`. A single input larger than the budget
+  # (already sliced to `@max_text_length`) still forms its own sub-batch rather than
+  # wedging into an empty one.
+  defp chunk_by_char_budget(to_embed, max_chars) do
+    chunk_fun = fn {_article, text, _hash} = item, {acc, size} ->
+      len = byte_size(text)
+
+      cond do
+        acc == [] -> {:cont, {[item], len}}
+        size + len > max_chars -> {:cont, Enum.reverse(acc), {[item], len}}
+        true -> {:cont, {[item | acc], size + len}}
+      end
+    end
+
+    after_fun = fn
+      {[], _size} -> {:cont, [], {[], 0}}
+      {acc, _size} -> {:cont, Enum.reverse(acc), {[], 0}}
+    end
+
+    Enum.chunk_while(to_embed, {[], 0}, chunk_fun, after_fun)
+  end
+
+  defp embed_and_store_sub_batch(tenant_id, to_embed) do
+    texts = Enum.map(to_embed, fn {_article, text, _hash} -> text end)
+
+    case Knowledge.generate_embeddings(tenant_id, texts, timeout: batch_yield_ms(length(texts))) do
+      {:ok, vectors} when length(vectors) == length(to_embed) ->
+        store_all(tenant_id, Enum.zip(to_embed, vectors))
+
+      {:ok, _mismatch} ->
+        # Defensive: the guarded client already fails a short/misaligned batch with an
+        # error; a length mismatch here is a contract violation — retry the batch.
+        {:error, :embedding_batch_length_mismatch}
+
+      {:error, :no_api_key} ->
+        skip_no_embedding_key(tenant_id, to_embed)
+
+      {:error, :rate_limited_local} ->
+        # US-37.1 (AC-37.1.4): node-local admission backpressure is loss-free — snooze
+        # the slot (no attempt consumed) so the batch retries once demand subsides.
+        {:snooze, Admission.snooze_seconds()}
+
+      {:error, :circuit_open} ->
+        # US-37.3 (AC-37.3.5): breaker OPEN — snooze loss-free for ~the remaining open
+        # window rather than {:error, ...} (which could burn every attempt and DISCARD
+        # the batch while the breaker stays open, stranding the articles un-embedded).
+        {:snooze, circuit_open_snooze_seconds(tenant_id)}
+
+      {:error, {:api_error, _status, :provider_error, retry_after}}
+      when is_integer(retry_after) ->
+        # US-37.3 (AC-37.3.3): provider throttle with a Retry-After — snooze loss-free
+        # for ~that interval instead of the blind polynomial backoff.
+        {:snooze, RetryAfter.snooze_seconds(retry_after)}
+
+      {:error, reason} ->
+        # No partial writes happened (we only store after a full success), so the whole
+        # batch fails/retries as a unit (AC-37.4.3). The Oban error term is SANITIZED.
+        sanitized = ProviderError.sanitize(reason)
+
+        if Llm.permanent_provider_error?(reason) do
+          Logger.debug(
+            "BatchArticleEmbeddingWorker: tenant=#{tenant_id} batch=#{length(to_embed)} permanent " <>
+              "embedding error (#{ProviderError.log_tag(reason)}); discarding."
+          )
+
+          {:discard, {:embedding_permanent_error, sanitized}}
+        else
+          {:error, sanitized}
+        end
+    end
+  end
+
+  # Store every vector against its article + enqueue linking. A store failure (other
+  # than :not_found, which means the row was deleted mid-flight — a benign skip)
+  # returns {:error, _} so Oban retries the whole batch; already-stored rows are
+  # idempotent no-ops on the retry.
+  defp store_all(tenant_id, article_vector_pairs) do
+    Enum.reduce_while(article_vector_pairs, :ok, fn {{article, _text, hash}, vector}, :ok ->
+      case Knowledge.update_embedding(tenant_id, article.id, vector, hash) do
+        {:ok, _updated} ->
+          enqueue_linking(article.id, tenant_id)
+          {:cont, :ok}
+
+        {:error, :not_found} ->
+          {:cont, :ok}
+
+        {:error, reason} ->
+          {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  # Snooze interval (seconds) for the OPEN-breaker path: ~the remaining cooldown,
+  # floored at `Admission.snooze_seconds/0` (always >= 1) so a just-expired/raced
+  # window still yields a positive, loss-free re-snooze.
+  defp circuit_open_snooze_seconds(tenant_id) do
+    max(Knowledge.circuit_breaker_cooldown_remaining(tenant_id), Admission.snooze_seconds())
+  end
+
+  # Mandatory BYO: the tenant has no embedding key. Cleanly DISCARD the whole batch
+  # (no retry, no crash, no operator-key fallback), emitting one telemetry signal +
+  # audit entry per article so keyless-tenant volume stays observable and consistent
+  # with the per-article worker.
+  defp skip_no_embedding_key(tenant_id, to_embed) do
+    Enum.each(to_embed, fn {article, _text, _hash} ->
+      :telemetry.execute(
+        [:loopctl, :embedding, :skipped_no_key],
+        %{count: 1},
+        %{tenant_id: tenant_id, article_id: article.id, source: "article"}
+      )
+
+      Llm.record_blocked(tenant_id, :embedding)
+    end)
+
+    Logger.debug(
+      "BatchArticleEmbeddingWorker: tenant=#{tenant_id} batch=#{length(to_embed)} skipped — no " <>
+        "embedding API key configured (mandatory BYO)."
+    )
+
+    {:discard, {:no_embedding_key, Enum.map(to_embed, fn {a, _t, _h} -> a.id end)}}
+  end
+
+  defp already_embedded?(%{embedding: embedding, embedding_content_hash: hash}, content_hash)
+       when not is_nil(embedding) and is_binary(hash),
+       do: hash == content_hash
+
+  defp already_embedded?(_article, _content_hash), do: false
+
+  defp content_hash(text) do
+    :sha256 |> :crypto.hash(text) |> Base.encode16(case: :lower)
+  end
+
+  defp enqueue_linking(article_id, tenant_id) do
+    ArticleLinkingWorker.new(%{article_id: article_id, tenant_id: tenant_id})
+    |> Oban.insert()
+  end
+
+  defp build_embedding_text(article) do
+    "#{article.title}\n\n#{article.body}"
+    |> String.slice(0, @max_text_length)
+  end
+
+  # Task.yield budget (ms) for a sub-batch provider call — live-tunable via
+  # SystemConfig and SCALED by the input count so a ~100-array call gets
+  # proportionally more slack than a single text (review MED #3). Both knobs default
+  # to the in-code values on a cache miss. The client's batch receive_timeout uses
+  # the same base+per-item shape with a strictly smaller base, so the HTTP call
+  # always fails cleanly before this yield shuts the task down.
+  defp batch_yield_ms(text_count) do
+    base = SystemConfig.get_int("embedding_batch_yield_base_ms", @default_yield_base_ms)
+
+    per_item =
+      SystemConfig.get_int("embedding_batch_yield_per_item_ms", @default_yield_per_item_ms)
+
+    base + per_item * max(text_count, 1)
+  end
+end

--- a/lib/loopctl/workers/content_ingestion_worker.ex
+++ b/lib/loopctl/workers/content_ingestion_worker.ex
@@ -53,6 +53,7 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   alias Ecto.Multi
   alias Loopctl.AdminRepo
   alias Loopctl.Audit
+  alias Loopctl.Knowledge
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.ContentChunker
   alias Loopctl.Llm
@@ -62,7 +63,7 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
   alias Loopctl.Provider.Admission
   alias Loopctl.Provider.RetryAfter
   alias Loopctl.SystemConfig
-  alias Loopctl.Workers.ArticleEmbeddingWorker
+  alias Loopctl.Workers.BatchArticleEmbeddingWorker
 
   @content_extractor Application.compile_env(
                        :loopctl,
@@ -944,13 +945,26 @@ defmodule Loopctl.Workers.ContentIngestionWorker do
     }
   end
 
-  # Enqueue an embedding job for each just-inserted (published) article. Runs
+  # Enqueue embedding jobs for the just-inserted (published) articles. Runs
   # post-commit and is best-effort: a transient enqueue failure is logged, never
   # raised, so it can't fail/retry the whole ingestion job.
+  #
+  # US-37.4 (HIGH review): this is the PRIMARY automated bulk article-ingest path
+  # (up to ~60 articles per job), so it BATCHES — chunk the inserted rows into groups
+  # of `Knowledge.embedding_batch_max/0` (~100) and enqueue ONE
+  # `BatchArticleEmbeddingWorker` per chunk, which embeds the whole chunk in a single
+  # provider array call (one admission token + one concurrency slot per batch). This
+  # collapses the old per-article `ArticleEmbeddingWorker` fan-out that issued one
+  # provider round-trip per ingested article — the exact amplification US-37.4
+  # targets. Per-chunk `Oban.insert/1` (NOT `insert_all`) so the batch worker's
+  # `unique:` window is honored (the basic Oban engine ignores `unique:` for
+  # `insert_all`). The interactive single-article publish path stays per-record.
   defp enqueue_embeddings(tenant_id, returned) do
-    Enum.each(returned, fn article ->
-      %{article_id: article.id, tenant_id: tenant_id}
-      |> ArticleEmbeddingWorker.new()
+    returned
+    |> Enum.chunk_every(Knowledge.embedding_batch_max())
+    |> Enum.each(fn chunk ->
+      %{article_ids: Enum.map(chunk, & &1.id), tenant_id: tenant_id}
+      |> BatchArticleEmbeddingWorker.new()
       |> Oban.insert()
     end)
   rescue

--- a/lib/loopctl/workers/knowledge_lint_worker.ex
+++ b/lib/loopctl/workers/knowledge_lint_worker.ex
@@ -61,8 +61,8 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
   alias Loopctl.Knowledge.ArticleLink
   alias Loopctl.Oban.FairShare
   alias Loopctl.Tenants.Tenant
-  alias Loopctl.Workers.ArticleEmbeddingWorker
   alias Loopctl.Workers.ArticleLinkingWorker
+  alias Loopctl.Workers.BatchArticleEmbeddingWorker
 
   # Ask lint for the ceiling so we act on as many orphans per run as the engine
   # will return; the true (pre-cap) totals still come back in the summary.
@@ -167,9 +167,17 @@ defmodule Loopctl.Workers.KnowledgeLintWorker do
       |> Oban.insert()
     end)
 
-    Enum.each(without_embedding, fn id ->
-      %{"article_id" => id, "tenant_id" => tenant_id}
-      |> ArticleEmbeddingWorker.new()
+    # US-37.4 (LOW review): batch the orphan-embedding backfill instead of fanning
+    # out one single-text `ArticleEmbeddingWorker` per orphan. A corpus backfill can
+    # otherwise issue N per-record provider round-trips — the exact background
+    # amplification US-37.4 collapses. Chunk into groups of
+    # `Knowledge.embedding_batch_max/0` and enqueue ONE `BatchArticleEmbeddingWorker`
+    # per chunk (one provider array call, one admission token + one slot per batch).
+    without_embedding
+    |> Enum.chunk_every(Knowledge.embedding_batch_max())
+    |> Enum.each(fn chunk ->
+      %{article_ids: chunk, tenant_id: tenant_id}
+      |> BatchArticleEmbeddingWorker.new()
       |> Oban.insert()
     end)
 

--- a/priv/repo/migrations/20260714180000_seed_embedding_batch_max_config.exs
+++ b/priv/repo/migrations/20260714180000_seed_embedding_batch_max_config.exs
@@ -1,0 +1,25 @@
+defmodule Loopctl.Repo.Migrations.SeedEmbeddingBatchMaxConfig do
+  use Ecto.Migration
+
+  # US-37.4: seed the live-tunable `embedding_batch_max` knob (~100) that bounds how
+  # many texts the background embedding path sends per provider array call. Read on
+  # the hot path via SystemConfig.get_int/2; a missing row falls back to the in-code
+  # default (Knowledge.embedding_batch_max/0), so seeding here only makes the value
+  # operator-visible/tunable from day one. Global table, AdminRepo-only (see
+  # CreateSystemConfigs). ON CONFLICT keeps re-runs safe.
+  def change do
+    execute(
+      """
+      INSERT INTO system_configs (id, key, value, description, inserted_at, updated_at)
+      VALUES
+        (gen_random_uuid(), 'embedding_batch_max', 100,
+          'Max texts per background embedding array batch (BatchArticleEmbeddingWorker)',
+          now() AT TIME ZONE 'UTC', now() AT TIME ZONE 'UTC')
+      ON CONFLICT (key) DO NOTHING
+      """,
+      """
+      DELETE FROM system_configs WHERE key = 'embedding_batch_max'
+      """
+    )
+  end
+end

--- a/priv/repo/migrations/20260714190000_seed_embedding_batch_tuning_configs.exs
+++ b/priv/repo/migrations/20260714190000_seed_embedding_batch_tuning_configs.exs
@@ -1,0 +1,54 @@
+defmodule Loopctl.Repo.Migrations.SeedEmbeddingBatchTuningConfigs do
+  use Ecto.Migration
+
+  # US-37.4 (review): seed the live-tunable knobs added to bound and time the
+  # background embedding BATCH path beyond the simple count cap.
+  #
+  #   * embedding_batch_max_chars — cumulative per-request CHARACTER budget so a
+  #     chunk of large-text articles is sub-split before it can exceed an
+  #     OpenAI-compatible per-request TOKEN ceiling (which the count cap alone can't
+  #     guarantee). ~1,000,000 chars ≈ 250k tokens, comfortably under ~300k.
+  #   * embedding_batch_yield_base_ms / _per_item_ms — the worker's Task.yield budget
+  #     (base + per-input), scaled by array size so a large batch gets proportionally
+  #     more slack than one text.
+  #   * embedding_batch_receive_base_ms / _per_item_ms — the client's batch-path Req
+  #     receive_timeout (base + per-input). Base kept BELOW the yield base so the HTTP
+  #     call fails cleanly before the worker's yield shuts the task down.
+  #
+  # Read on the hot path via SystemConfig.get_int/2; a missing row falls back to the
+  # in-code default (safe degrade), so seeding here only makes the values
+  # operator-visible/tunable from day one. Global table, AdminRepo-only. ON CONFLICT
+  # keeps re-runs safe.
+  def change do
+    execute(
+      """
+      INSERT INTO system_configs (id, key, value, description, inserted_at, updated_at)
+      VALUES
+        (gen_random_uuid(), 'embedding_batch_max_chars', 1000000,
+          'Cumulative per-request character budget for a background embedding array call',
+          now() AT TIME ZONE 'UTC', now() AT TIME ZONE 'UTC'),
+        (gen_random_uuid(), 'embedding_batch_yield_base_ms', 8000,
+          'BatchArticleEmbeddingWorker Task.yield base budget (ms)',
+          now() AT TIME ZONE 'UTC', now() AT TIME ZONE 'UTC'),
+        (gen_random_uuid(), 'embedding_batch_yield_per_item_ms', 100,
+          'BatchArticleEmbeddingWorker Task.yield per-input slack (ms)',
+          now() AT TIME ZONE 'UTC', now() AT TIME ZONE 'UTC'),
+        (gen_random_uuid(), 'embedding_batch_receive_base_ms', 6000,
+          'EmbeddingClient batch-path Req receive_timeout base (ms)',
+          now() AT TIME ZONE 'UTC', now() AT TIME ZONE 'UTC'),
+        (gen_random_uuid(), 'embedding_batch_receive_per_item_ms', 100,
+          'EmbeddingClient batch-path Req receive_timeout per-input slack (ms)',
+          now() AT TIME ZONE 'UTC', now() AT TIME ZONE 'UTC')
+      ON CONFLICT (key) DO NOTHING
+      """,
+      """
+      DELETE FROM system_configs
+      WHERE key IN (
+        'embedding_batch_max_chars',
+        'embedding_batch_yield_base_ms', 'embedding_batch_yield_per_item_ms',
+        'embedding_batch_receive_base_ms', 'embedding_batch_receive_per_item_ms'
+      )
+      """
+    )
+  end
+end

--- a/test/loopctl/knowledge/embedding_client_test.exs
+++ b/test/loopctl/knowledge/embedding_client_test.exs
@@ -207,4 +207,119 @@ defmodule Loopctl.Knowledge.EmbeddingClientTest do
 
     assert is_integer(seconds) and seconds >= 25 and seconds <= 30
   end
+
+  # --- US-37.4 (AC-37.4.1): batch path — array in, map back BY response index ---
+
+  test "TC-37.4.1: batch sends input as an array and maps each vector BY response index" do
+    tenant = fixture(:tenant)
+    test_pid = self()
+    set_embedding_key(tenant, "test-openai-key-BATCH")
+
+    texts = ["alpha", "beta", "gamma"]
+
+    # SHUFFLED indices + DISTINCT vectors so a by-POSITION assumption would fail:
+    # index 0 -> [1.0], 1 -> [2.0], 2 -> [3.0], returned out of order.
+    Req.Test.stub(EmbeddingClient, fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      send(test_pid, {:req_body, JSON.decode!(body)})
+
+      Req.Test.json(conn, %{
+        "data" => [
+          %{"index" => 2, "embedding" => [3.0]},
+          %{"index" => 0, "embedding" => [1.0]},
+          %{"index" => 1, "embedding" => [2.0]}
+        ],
+        "usage" => %{"prompt_tokens" => 9, "total_tokens" => 9}
+      })
+    end)
+
+    assert {:ok, [[1.0], [2.0], [3.0]]} = EmbeddingClient.generate_embeddings(tenant.id, texts)
+
+    # The request body carried `input` as an ARRAY of all three texts (not one call each).
+    assert_received {:req_body, %{"input" => ^texts}}
+  end
+
+  test "batch: empty input list returns {:ok, []} with NO provider call" do
+    tenant = fixture(:tenant)
+    test_pid = self()
+    set_embedding_key(tenant, "test-openai-key-EMPTY")
+
+    Req.Test.stub(EmbeddingClient, fn conn ->
+      send(test_pid, :unexpected_http_call)
+      Req.Test.json(conn, %{"data" => []})
+    end)
+
+    assert {:ok, []} = EmbeddingClient.generate_embeddings(tenant.id, [])
+    refute_received :unexpected_http_call
+  end
+
+  test "batch: mandatory BYO keyless tenant → {:error, :no_api_key}, NO provider call" do
+    tenant = fixture(:tenant)
+    test_pid = self()
+
+    Req.Test.stub(EmbeddingClient, fn conn ->
+      send(test_pid, :unexpected_http_call)
+      Req.Test.json(conn, %{"data" => [%{"index" => 0, "embedding" => [0.0]}]})
+    end)
+
+    assert {:error, :no_api_key} = EmbeddingClient.generate_embeddings(tenant.id, ["a", "b"])
+    refute_received :unexpected_http_call
+  end
+
+  test "TC-37.4.4: a SHORT data array (missing an index) fails the WHOLE batch, no partial" do
+    tenant = fixture(:tenant)
+    set_embedding_key(tenant, "test-openai-key-SHORT")
+
+    # 3 inputs, but the provider returns only 2 vectors (index 2 missing).
+    Req.Test.stub(EmbeddingClient, fn conn ->
+      Req.Test.json(conn, %{
+        "data" => [
+          %{"index" => 0, "embedding" => [1.0]},
+          %{"index" => 1, "embedding" => [2.0]}
+        ]
+      })
+    end)
+
+    assert {:error, {:embedding_index_mismatch, 3, 2}} =
+             EmbeddingClient.generate_embeddings(tenant.id, ["a", "b", "c"])
+  end
+
+  test "batch: one admission token per batch — an empty bucket fast-fails :rate_limited_local" do
+    tenant = fixture(:tenant)
+    test_pid = self()
+    set_embedding_key(tenant, "test-openai-key-BATCH-GATED")
+
+    stub(Loopctl.MockRateLimiter, :check_rate, fn _bucket, _window, _limit -> {:deny, 0} end)
+
+    Req.Test.stub(EmbeddingClient, fn conn ->
+      send(test_pid, :unexpected_http_call)
+      Req.Test.json(conn, %{"data" => [%{"index" => 0, "embedding" => [0.0]}]})
+    end)
+
+    assert {:error, :rate_limited_local} =
+             EmbeddingClient.generate_embeddings(tenant.id, ["a", "b"])
+
+    refute_received :unexpected_http_call
+  end
+
+  test "batch: records a single :embedding usage event for the whole array" do
+    tenant = fixture(:tenant)
+    set_embedding_key(tenant, "test-openai-key-BATCH-USAGE")
+
+    Req.Test.stub(EmbeddingClient, fn conn ->
+      Req.Test.json(conn, %{
+        "data" => [
+          %{"index" => 0, "embedding" => [0.1]},
+          %{"index" => 1, "embedding" => [0.2]}
+        ],
+        "usage" => %{"prompt_tokens" => 20, "total_tokens" => 20}
+      })
+    end)
+
+    assert {:ok, [[0.1], [0.2]]} = EmbeddingClient.generate_embeddings(tenant.id, ["a", "b"])
+
+    %{data: rows} = Llm.usage_summary(tenant.id, [])
+    embedding = Enum.find(rows, &(&1.operation == :embedding))
+    assert embedding.input_tokens == 20
+  end
 end

--- a/test/loopctl/memory_context_test.exs
+++ b/test/loopctl/memory_context_test.exs
@@ -47,6 +47,41 @@ defmodule Loopctl.MemoryContextTest do
       assert is_binary(reloaded.embedding_content_hash)
     end
 
+    test "US-37.4 (AC-37.4.5): a just-written memory is embedded + recallable in the same run, never left NULL" do
+      # The batch-embedding story (US-37.4) batches ONLY the bulk article-ingest path
+      # and deliberately keeps the interactive `remember` path PER-RECORD/synchronous
+      # (no coalescing drainer that could drop a just-written row). This guards that
+      # invariant: a memory written now — and a SECOND one written immediately after,
+      # as if a background ingest were already in flight — are BOTH embedded within
+      # the run and immediately recallable, with non-null embeddings (no bounded
+      # staleness, no wait for a periodic sweep).
+      scope = fixture(:memory_scope)
+      Knowledge.reset_circuit_breaker(scope.tenant_id)
+
+      {:ok, first} =
+        Memory.remember(scope, %{tier: :long_term, text: "batch drainer in flight one"})
+
+      {:ok, second} =
+        Memory.remember(scope, %{tier: :long_term, text: "written during a drain two"})
+
+      # Both rows carry a non-null embedding + content hash RIGHT AWAY.
+      for id <- [first.id, second.id] do
+        {:ok, reloaded} = Memory.get_memory_for_embedding(scope.tenant_id, id)
+        refute is_nil(reloaded.embedding), "memory #{id} left embedding IS NULL"
+        assert is_binary(reloaded.embedding_content_hash)
+      end
+
+      # And both are recallable (found, not []).
+      recalled_ids =
+        scope
+        |> Memory.recall(query: "drain", limit: 10)
+        |> Map.fetch!(:results)
+        |> Enum.map(fn {m, _score} -> m.id end)
+
+      assert first.id in recalled_ids
+      assert second.id in recalled_ids
+    end
+
     test "a legitimately empty scope on the healthy path returns [] with fallback: false" do
       scope = fixture(:memory_scope)
       Knowledge.reset_circuit_breaker(scope.tenant_id)

--- a/test/loopctl/workers/batch_article_embedding_worker_test.exs
+++ b/test/loopctl/workers/batch_article_embedding_worker_test.exs
@@ -1,0 +1,397 @@
+defmodule Loopctl.Workers.BatchArticleEmbeddingWorkerTest do
+  @moduledoc """
+  US-37.4: the batch background embedding worker. Embeds a chunk of articles in ONE
+  provider array call, maps vectors back by index, and mirrors the single-article
+  worker's error taxonomy — while keeping the interactive memory/promotion path
+  per-record (that write-then-recall guarantee is covered by the memory suite).
+  """
+  use Loopctl.DataCase, async: true
+  use Oban.Testing, repo: Loopctl.Repo
+
+  setup :verify_on_exit!
+
+  alias Loopctl.Knowledge
+  alias Loopctl.Workers.BatchArticleEmbeddingWorker
+
+  # A deterministic 1536-dim vector keyed to the text, so single-call and batch-call
+  # embeddings of the SAME input are byte-for-byte equal (TC-37.4.3). The first slot
+  # encodes the text's hash; the rest pad to the model's dimensionality.
+  defp vec_for(text) do
+    seed = :erlang.phash2(text) / 1_000_000
+    [seed | List.duplicate(0.1, 1535)]
+  end
+
+  # Create a published article WITHOUT the inline create-time embedding enqueue
+  # firing: create as draft, then flip to published via a bare changeset (bypasses
+  # the context's enqueue) — mirrors ArticleEmbeddingWorkerTest.
+  defp create_published_article(tenant_id, attrs \\ %{}) do
+    base = %{
+      title: "Batch Article #{System.unique_integer([:positive])}",
+      body: "Body #{System.unique_integer([:positive])}",
+      category: :pattern,
+      status: :draft
+    }
+
+    {:ok, article} = Knowledge.create_article(tenant_id, Map.merge(base, attrs))
+
+    article
+    |> Ecto.Changeset.change(%{status: :published})
+    |> Loopctl.AdminRepo.update!()
+  end
+
+  defp perform(tenant_id, article_ids) do
+    BatchArticleEmbeddingWorker.perform(%Oban.Job{
+      id: System.unique_integer([:positive]),
+      args: %{"article_ids" => article_ids, "tenant_id" => tenant_id}
+    })
+  end
+
+  describe "batch efficiency (AC-37.4.2)" do
+    test "embeds N articles in ONE provider array call, storing each" do
+      tenant = fixture(:tenant)
+      test_pid = self()
+
+      articles = for _ <- 1..5, do: create_published_article(tenant.id)
+      ids = Enum.map(articles, & &1.id)
+
+      # A single batch call for all 5 texts (not 5 calls). Send a message per call so
+      # we count WITHOUT a Mox exact-count race across the async_nolink task.
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embeddings, fn _tenant_id, texts ->
+        send(test_pid, {:batch_call, length(texts)})
+        {:ok, Enum.map(texts, &vec_for/1)}
+      end)
+
+      assert :ok = perform(tenant.id, ids)
+
+      # Exactly ONE provider round-trip covered all 5 records.
+      assert_received {:batch_call, 5}
+      refute_received {:batch_call, _}
+
+      for a <- articles do
+        {:ok, loaded} = Knowledge.get_article_with_embedding(tenant.id, a.id)
+        assert loaded.embedding != nil
+      end
+    end
+
+    test "TC-37.4.2: bulk publish of M records issues ceil(M/batch_max) provider calls, not M" do
+      tenant = fixture(:tenant)
+      test_pid = self()
+
+      # Drive batch_max from the SystemConfig cache directly (the documented key
+      # format) — env-driven WITHOUT Application.put_env — and erase on exit. Small
+      # value keeps the test cheap: 5 records / batch_max 2 => ceil = 3 calls.
+      pt_key = {Loopctl.SystemConfig, "embedding_batch_max"}
+      :persistent_term.put(pt_key, 2)
+      on_exit(fn -> :persistent_term.erase(pt_key) end)
+
+      # 5 DRAFTS (no create-time enqueue), published together via bulk_publish. Oban is
+      # :inline in test, so the enqueued batch workers execute synchronously.
+      drafts =
+        for _ <- 1..5 do
+          {:ok, a} =
+            Knowledge.create_article(tenant.id, %{
+              title: "Bulk #{System.unique_integer([:positive])}",
+              body: "bulk body",
+              category: :pattern,
+              status: :draft
+            })
+
+          a
+        end
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embeddings, fn _tenant_id, texts ->
+        send(test_pid, {:batch_call, length(texts)})
+        {:ok, Enum.map(texts, &vec_for/1)}
+      end)
+
+      assert {:ok, %{counts: %{published: 5}}} =
+               Knowledge.bulk_publish(tenant.id, Enum.map(drafts, & &1.id), [])
+
+      # ceil(5 / 2) = 3 provider calls (chunks of 2, 2, 1) — NOT 5.
+      calls = drain_batch_calls([])
+      assert length(calls) == 3
+      assert Enum.sort(calls, :desc) == [2, 2, 1]
+    end
+  end
+
+  describe "correctness (TC-37.4.3)" do
+    test "each record gets the SAME vector it would from a single-text call" do
+      tenant = fixture(:tenant)
+
+      texts = ["distinct alpha", "distinct beta", "distinct gamma"]
+
+      # Deterministic per-text vectors on BOTH the single and batch callbacks.
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, text ->
+        {:ok, vec_for(text)}
+      end)
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embeddings, fn _t, batch ->
+        {:ok, Enum.map(batch, &vec_for/1)}
+      end)
+
+      singles =
+        Enum.map(texts, fn t ->
+          {:ok, v} = Knowledge.generate_embedding(tenant.id, t)
+          v
+        end)
+
+      {:ok, batched} = Knowledge.generate_embeddings(tenant.id, texts)
+
+      # Per-index equality: batch vectors == the single-call vectors, in input order.
+      assert batched == singles
+    end
+  end
+
+  describe "partial-failure = whole-batch retry (TC-37.4.4)" do
+    test "a provider error writes NO vectors and returns {:error, _} (retry as a unit)" do
+      tenant = fixture(:tenant)
+
+      articles = for _ <- 1..3, do: create_published_article(tenant.id)
+      ids = Enum.map(articles, & &1.id)
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embeddings, fn _t, _texts ->
+        {:error, {:api_error, 500, :provider_error}}
+      end)
+
+      assert {:error, {:api_error, 500, :provider_error}} = perform(tenant.id, ids)
+
+      # No half-write: every article is still un-embedded.
+      for a <- articles do
+        {:ok, loaded} = Knowledge.get_article_with_embedding(tenant.id, a.id)
+        assert loaded.embedding == nil
+      end
+    end
+  end
+
+  describe "error taxonomy (mirrors ArticleEmbeddingWorker)" do
+    setup do
+      tenant = fixture(:tenant)
+      article = create_published_article(tenant.id)
+      %{tenant: tenant, ids: [article.id]}
+    end
+
+    test "no_api_key → discard (mandatory BYO), no crash", %{tenant: tenant, ids: ids} do
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embeddings, fn _t, _texts ->
+        {:error, :no_api_key}
+      end)
+
+      assert {:discard, {:no_embedding_key, _ids}} = perform(tenant.id, ids)
+    end
+
+    test "rate_limited_local → loss-free snooze", %{tenant: tenant, ids: ids} do
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embeddings, fn _t, _texts ->
+        {:error, :rate_limited_local}
+      end)
+
+      assert {:snooze, s} = perform(tenant.id, ids)
+      assert is_integer(s) and s > 0
+    end
+
+    test "permanent 4xx → discard (not retried)", %{tenant: tenant, ids: ids} do
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embeddings, fn _t, _texts ->
+        {:error, {:api_error, 401, :provider_error}}
+      end)
+
+      assert {:discard, {:embedding_permanent_error, {:api_error, 401, _}}} =
+               perform(tenant.id, ids)
+    end
+
+    test "throttle with Retry-After → snooze ~that interval", %{tenant: tenant, ids: ids} do
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embeddings, fn _t, _texts ->
+        {:error, {:api_error, 429, :provider_error, 30}}
+      end)
+
+      assert {:snooze, 30} = perform(tenant.id, ids)
+    end
+
+    test "OPEN breaker → loss-free snooze without a provider call", %{tenant: tenant, ids: ids} do
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      # Trip the tenant breaker via 3 countable 429s on the SINGLE path, then the batch
+      # entry short-circuits on the OPEN breaker (deterministic ETS) before any call.
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
+        {:error, {:api_error, 429, :provider_error}}
+      end)
+
+      for _ <- 1..3, do: Knowledge.generate_embedding(tenant.id, "x")
+      assert {:error, :circuit_open} = Knowledge.generate_embedding(tenant.id, "x")
+
+      assert {:snooze, s} = perform(tenant.id, ids)
+      assert is_integer(s) and s > 0
+    end
+  end
+
+  describe "idempotency" do
+    test "an already-embedded article (matching content hash) is not re-embedded" do
+      tenant = fixture(:tenant)
+      test_pid = self()
+      article = create_published_article(tenant.id)
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embeddings, fn _t, texts ->
+        send(test_pid, {:batch_call, length(texts)})
+        {:ok, Enum.map(texts, &vec_for/1)}
+      end)
+
+      # First run embeds the one article.
+      assert :ok = perform(tenant.id, [article.id])
+      assert_received {:batch_call, 1}
+
+      # Second run (same content): the provider is NOT called — content-hash matches.
+      assert :ok = perform(tenant.id, [article.id])
+      refute_received {:batch_call, _}
+    end
+  end
+
+  describe "tenant isolation" do
+    test "batch worker only touches its own tenant's articles" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      test_pid = self()
+
+      article = create_published_article(tenant_a.id)
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embeddings, fn _t, texts ->
+        send(test_pid, {:batch_call, length(texts)})
+        {:ok, Enum.map(texts, &vec_for/1)}
+      end)
+
+      # Run under tenant B with tenant A's article id: the scoped fetch returns nothing,
+      # so no provider call and A's article is untouched.
+      assert :ok = perform(tenant_b.id, [article.id])
+      refute_received {:batch_call, _}
+
+      {:ok, loaded} = Knowledge.get_article_with_embedding(tenant_a.id, article.id)
+      assert loaded.embedding == nil
+    end
+  end
+
+  describe "cumulative char budget (AC-37.4.4 review MED #2)" do
+    test "sub-splits a count-chunk so no single array call exceeds embedding_batch_max_chars" do
+      tenant = fixture(:tenant)
+      test_pid = self()
+
+      # Budget fits ~2 of these ~320-char texts per array call, not all 3. env-driven
+      # WITHOUT Application.put_env (SystemConfig cache), erased on exit.
+      put_cfg("embedding_batch_max_chars", 700)
+
+      body = String.duplicate("a", 300)
+
+      articles =
+        for i <- 1..3, do: create_published_article(tenant.id, %{title: "Chars #{i}", body: body})
+
+      ids = Enum.map(articles, & &1.id)
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embeddings, fn _t, texts ->
+        # No single provider array call exceeds the cumulative budget.
+        assert Enum.sum(Enum.map(texts, &byte_size/1)) <= 700
+        send(test_pid, {:batch_call, length(texts)})
+        {:ok, Enum.map(texts, &vec_for/1)}
+      end)
+
+      assert :ok = perform(tenant.id, ids)
+
+      # 3 texts, budget fits 2 per call => 2 provider calls (sizes 2 + 1), NOT 1.
+      assert Enum.sort(drain_batch_calls([]), :desc) == [2, 1]
+
+      for a <- articles do
+        {:ok, loaded} = Knowledge.get_article_with_embedding(tenant.id, a.id)
+        assert loaded.embedding != nil
+      end
+    end
+  end
+
+  describe "batch yield budget (review MED #3)" do
+    test "the Task.yield budget is live-tunable via SystemConfig and bounds a slow batch" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      a1 = create_published_article(tenant.id)
+      a2 = create_published_article(tenant.id)
+
+      # Every provider call takes ~200ms.
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embeddings, fn _t, texts ->
+        Process.sleep(200)
+        {:ok, Enum.map(texts, &vec_for/1)}
+      end)
+
+      # Tiny yield (20ms base + 1ms/item) < 200ms call => the guard shuts the task down
+      # => transient error, NO vector written.
+      put_cfg("embedding_batch_yield_base_ms", 20)
+      put_cfg("embedding_batch_yield_per_item_ms", 1)
+      assert {:error, _} = perform(tenant.id, [a1.id])
+      {:ok, l1} = Knowledge.get_article_with_embedding(tenant.id, a1.id)
+      assert l1.embedding == nil
+
+      # Raise the SAME knob live (no redeploy): yield now 2000ms > 200ms => success.
+      put_cfg("embedding_batch_yield_base_ms", 2000)
+      assert :ok = perform(tenant.id, [a2.id])
+      {:ok, l2} = Knowledge.get_article_with_embedding(tenant.id, a2.id)
+      assert l2.embedding != nil
+    end
+  end
+
+  describe "latency-breaker exemption (review LOW #5)" do
+    test "a slow batch success does NOT trip the per-tenant latency breaker" do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      # Enable the latency trip aggressively: any call slower than 1ms is 'slow', and a
+      # single slow call would trip — so the OLD (record_call_outcome) batch path would
+      # have opened the breaker here.
+      put_cfg("embedding_breaker_latency_threshold_ms", 1)
+      put_cfg("embedding_breaker_latency_count", 1)
+
+      article = create_published_article(tenant.id)
+
+      # Guarantee wall-clock > 1ms.
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embeddings, fn _t, texts ->
+        Process.sleep(10)
+        {:ok, Enum.map(texts, &vec_for/1)}
+      end)
+
+      assert :ok = perform(tenant.id, [article.id])
+
+      # Batch path is EXEMPT: the breaker stays CLOSED — a follow-up embedding call
+      # reaches the provider instead of short-circuiting on {:error, :circuit_open}.
+      refute match?({:error, :circuit_open}, Knowledge.generate_embeddings(tenant.id, ["probe"]))
+    end
+  end
+
+  describe "embedding_batch_max/0 (AC-37.4.4)" do
+    test "reads the live SystemConfig value" do
+      pt_key = {Loopctl.SystemConfig, "embedding_batch_max"}
+      :persistent_term.put(pt_key, 42)
+      on_exit(fn -> :persistent_term.erase(pt_key) end)
+
+      assert Knowledge.embedding_batch_max() == 42
+    end
+
+    test "floors a non-positive tuned value at 1 (never an empty chunk)" do
+      pt_key = {Loopctl.SystemConfig, "embedding_batch_max"}
+      :persistent_term.put(pt_key, 0)
+      on_exit(fn -> :persistent_term.erase(pt_key) end)
+
+      assert Knowledge.embedding_batch_max() == 1
+    end
+  end
+
+  # Collect all {:batch_call, n} messages currently in the mailbox (batch workers ran
+  # inline before bulk_publish returned, so they're all already delivered).
+  defp drain_batch_calls(acc) do
+    receive do
+      {:batch_call, n} -> drain_batch_calls([n | acc])
+    after
+      0 -> acc
+    end
+  end
+
+  # Drive a SystemConfig knob from the persistent_term cache (the documented key
+  # format) — env-driven WITHOUT Application.put_env — and erase on exit.
+  defp put_cfg(key, value) do
+    pt_key = {Loopctl.SystemConfig, key}
+    :persistent_term.put(pt_key, value)
+    on_exit(fn -> :persistent_term.erase(pt_key) end)
+  end
+end

--- a/test/loopctl/workers/batch_article_embedding_worker_test.exs
+++ b/test/loopctl/workers/batch_article_embedding_worker_test.exs
@@ -4,8 +4,18 @@ defmodule Loopctl.Workers.BatchArticleEmbeddingWorkerTest do
   provider array call, maps vectors back by index, and mirrors the single-article
   worker's error taxonomy — while keeping the interactive memory/promotion path
   per-record (that write-then-recall guarantee is covered by the memory suite).
+
+  `async: false` ON PURPOSE. The `TC-37.4.2` test seeds the NODE-GLOBAL
+  `{Loopctl.SystemConfig, "embedding_batch_max"}` `:persistent_term` knob (the
+  documented key format, erased on exit) to drive the batch-size math. That key
+  is VM-global — NOT ExUnit-sandbox/transaction scoped — and is read globally by
+  `Knowledge.embedding_batch_max/0`, so mutating it while an async peer (e.g.
+  `KnowledgeLintWorkerTest`, which relies on the default batch_max) runs
+  concurrently would cross-contaminate the peer's chunk math. A sync test never
+  runs concurrently with any other test, so the seed can't leak — mirrors
+  `Loopctl.KnowledgeBreakerLatencyTest`.
   """
-  use Loopctl.DataCase, async: true
+  use Loopctl.DataCase, async: false
   use Oban.Testing, repo: Loopctl.Repo
 
   setup :verify_on_exit!

--- a/test/loopctl/workers/content_ingestion_worker_test.exs
+++ b/test/loopctl/workers/content_ingestion_worker_test.exs
@@ -138,9 +138,66 @@ defmodule Loopctl.Workers.ContentIngestionWorkerTest do
       assert article.status == :published
 
       # Published articles are embedded (Oban runs :inline in tests, so the
-      # enqueued ArticleEmbeddingWorker has already populated the vector).
+      # enqueued BatchArticleEmbeddingWorker has already populated the vector).
       {:ok, with_embedding} = Knowledge.get_article_with_embedding(tenant.id, article.id)
       refute is_nil(with_embedding.embedding)
+    end
+
+    test "US-37.4: auto-published ingest BATCHES embeddings — M articles => ceil(M/batch_max) provider calls, not M" do
+      %{tenant: tenant} = setup_tenant()
+      test_pid = self()
+
+      # env-driven batch_max WITHOUT Application.put_env: drive the SystemConfig cache
+      # directly and erase on exit. 5 ingested articles / batch_max 2 => ceil = 3 calls.
+      pt_key = {Loopctl.SystemConfig, "embedding_batch_max"}
+      :persistent_term.put(pt_key, 2)
+      on_exit(fn -> :persistent_term.erase(pt_key) end)
+
+      expect(Loopctl.MockContentExtractor, :extract_from_content, fn _t, _c, _o ->
+        {:ok,
+         for i <- 1..5 do
+           %{title: "Ingested #{i}", body: "body #{i}", category: :pattern, tags: []}
+         end}
+      end)
+
+      # Count provider round-trips via a message per BATCH call (the array path),
+      # avoiding a Mox exact-count race across the async_nolink task.
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embeddings, fn _tenant_id, texts ->
+        send(test_pid, {:batch_call, length(texts)})
+        {:ok, Enum.map(texts, fn _ -> List.duplicate(0.1, 1536) end)}
+      end)
+
+      # The single-text path must NEVER be used for bulk ingest.
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
+        flunk("bulk ingest must use the batch path, not per-article generate_embedding/2")
+      end)
+
+      assert :ok =
+               ContentIngestionWorker.perform(%Oban.Job{
+                 id: 44,
+                 args: %{
+                   "tenant_id" => tenant.id,
+                   "content" => "raw",
+                   "content_hash" => "batch123",
+                   "source_type" => "newsletter",
+                   "publish" => true
+                 }
+               })
+
+      # ceil(5 / 2) = 3 provider calls (chunks of 2, 2, 1) — NOT 5.
+      calls = drain_batch_calls([])
+      assert length(calls) == 3
+      assert Enum.sort(calls, :desc) == [2, 2, 1]
+    end
+  end
+
+  # Collect all {:batch_call, n} messages currently in the mailbox (batch workers ran
+  # inline before perform/1 returned, so they're all already delivered).
+  defp drain_batch_calls(acc) do
+    receive do
+      {:batch_call, n} -> drain_batch_calls([n | acc])
+    after
+      0 -> acc
     end
   end
 

--- a/test/loopctl/workers/content_ingestion_worker_test.exs
+++ b/test/loopctl/workers/content_ingestion_worker_test.exs
@@ -1,5 +1,16 @@
 defmodule Loopctl.Workers.ContentIngestionWorkerTest do
-  use Loopctl.DataCase, async: true
+  @moduledoc """
+  `async: false` ON PURPOSE. The US-37.4 batching test seeds the NODE-GLOBAL
+  `{Loopctl.SystemConfig, "embedding_batch_max"}` `:persistent_term` knob (the
+  documented key format, erased on exit) to drive the batch-size math. That key
+  is VM-global — NOT ExUnit-sandbox/transaction scoped — and is read globally by
+  `Knowledge.embedding_batch_max/0`, so mutating it while an async peer (e.g.
+  `KnowledgeLintWorkerTest`, which relies on the default batch_max) runs
+  concurrently would cross-contaminate the peer's chunk math. A sync test never
+  runs concurrently with any other test, so the seed can't leak — mirrors
+  `Loopctl.KnowledgeBreakerLatencyTest`.
+  """
+  use Loopctl.DataCase, async: false
   use Oban.Testing, repo: Loopctl.Repo
 
   setup :verify_on_exit!

--- a/test/loopctl/workers/knowledge_lint_worker_test.exs
+++ b/test/loopctl/workers/knowledge_lint_worker_test.exs
@@ -148,6 +148,40 @@ defmodule Loopctl.Workers.KnowledgeLintWorkerTest do
       assert entry.new_state["orphans_embedding_enqueued"] == 1
     end
 
+    test "US-37.4: BATCHES the orphan-embedding backfill — N orphans => one array call, not N" do
+      tenant = fixture(:tenant)
+      test_pid = self()
+
+      orphans = for _ <- 1..3, do: published_without_embedding(tenant.id)
+
+      # Count provider round-trips via a message per BATCH call.
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embeddings, fn _t, texts ->
+        send(test_pid, {:batch_call, length(texts)})
+        {:ok, Enum.map(texts, fn _ -> List.duplicate(0.1, 1536) end)}
+      end)
+
+      # The per-article path must NOT be used for the bulk backfill.
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
+        flunk("orphan backfill must batch, not use per-article generate_embedding/2")
+      end)
+
+      assert :ok =
+               KnowledgeLintWorker.perform(%Oban.Job{args: %{"tenant_id" => tenant.id}})
+
+      # ONE array call covered all 3 orphans (batch_max default ~100), not 3 calls.
+      assert drain_batch_calls([]) == [3]
+
+      for o <- orphans do
+        assert {:ok, %{embedding: emb}} =
+                 Loopctl.Knowledge.get_article_with_embedding(tenant.id, o.id)
+
+        refute is_nil(emb)
+      end
+
+      assert [entry] = lint_audit_entries(tenant.id)
+      assert entry.new_state["orphans_embedding_enqueued"] == 3
+    end
+
     test "handles a tenant with no published articles" do
       tenant = fixture(:tenant)
 
@@ -325,6 +359,16 @@ defmodule Loopctl.Workers.KnowledgeLintWorkerTest do
       assert [_only_one] = conflict_links(tenant.id, a.id, b.id)
       assert [_, second] = lint_audit_entries(tenant.id) |> Enum.sort_by(& &1.inserted_at)
       assert second.new_state["conflicts_promoted"] == 0
+    end
+  end
+
+  # Collect all {:batch_call, n} messages currently in the mailbox (batch workers ran
+  # inline before perform/1 returned, so they're all already delivered).
+  defp drain_batch_calls(acc) do
+    receive do
+      {:batch_call, n} -> drain_batch_calls([n | acc])
+    after
+      0 -> acc
     end
   end
 end

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -137,6 +137,14 @@ defmodule Loopctl.DataCase do
       {:ok, List.duplicate(0.1, 1536)}
     end)
 
+    # US-37.4: permissive default for the BATCH embedding path -- one 1536-dim vector
+    # per input text, preserving input order (the real client maps by response index;
+    # this deterministic stub returns them aligned so batch worker/store tests run
+    # unchanged). An empty batch returns [].
+    Mox.stub(Loopctl.MockEmbeddingClient, :generate_embeddings, fn _tenant_id, texts ->
+      {:ok, Enum.map(texts, fn _text -> List.duplicate(0.1, 1536) end)}
+    end)
+
     # US-37.2: permissive default for the per-node embedding concurrency gate --
     # acquire/1 always grants a slot, release/1 is a no-op -- so every existing
     # embedding/search test runs under the cap unchanged. The saturation test


### PR DESCRIPTION
Re-implementation of US-37.4 against the amended story (AC-37.4.5 no-stranding / write-then-recall guarantee, #399). Supersedes the blocked first attempt PR #396.

Key difference from #396: batching is scoped to the **article / content-ingest** path via a new `BatchArticleEmbeddingWorker`; the interactive **memory** write/recall path is left on its per-record embedding, so a just-written memory is never stranded `embedding IS NULL` (the regression that blocked #396). Adds a memory write-then-recall test plus batch worker/client tests, a cumulative token guard, and batch timeout/latency tuning.

The full-suite CI `Test` job is the arbiter — the prior regression only surfaced under the full parallel suite (memory_context / promotion_e2e / promotion_isolation / Memory.E2E).