### PR TITLE
docs: epic 38 — horizontal scaling readiness (code-only)

### DIFF
--- a/docs/user_stories/epic_38_horizontal_scaling/epic.json
+++ b/docs/user_stories/epic_38_horizontal_scaling/epic.json
@@ -1,0 +1,24 @@
+{
+  "number": 38,
+  "title": "Horizontal scaling readiness (multi-node + read replica) — code only",
+  "description": "Code-readiness preparation for horizontal scaling to multiple nodes without infrastructure changes. Prepares config/code paths for multi-node BEAM clustering, read replica DSN switchability, and cluster-global rate limiting. No Fly provisioning, no replica deployment, no `fly scale count > 1` until verified.",
+  "findings": {
+    "high": [
+      "DB connection budget hard-caps the fleet at ~3 nodes / ~30 RLS connections",
+      "Single physical Postgres for writes + vector reads + Oban; no read replica separation"
+    ],
+    "medium": [
+      "HeavyReadRepo is a second pool on the same primary, not a replica",
+      "BEAM clustering disabled by default — scaling breaks cross-node PubSub",
+      "Rate limiter is per-node ETS — global limits multiply by node count",
+      "Embedding write throughput capped at 5 + dual HNSW index maintenance"
+    ]
+  },
+  "acceptance_criteria": [
+    "All code paths are replica-aware (config gatable; BYPASSRLS parity maintained)",
+    "DbCapacity models primary vs replica separately",
+    "BEAM clustering can be enabled via config; Node.list/0 verifiable",
+    "Rate limiter is cluster-global (not per-node ETS)",
+    "HNSW index justification (dual vs single) is documented; tuning parameters documented"
+  ]
+}

--- a/docs/user_stories/epic_38_horizontal_scaling/us_38.1.json
+++ b/docs/user_stories/epic_38_horizontal_scaling/us_38.1.json
@@ -1,0 +1,18 @@
+{
+  "number": "38.1",
+  "title": "Model primary vs replica database capacity separately in DbCapacity",
+  "description": "Add replica-aware capacity modeling to DbCapacity so it can represent both primary (write-capable, RLS enforced) and replica (read-only, eventual consistency) separately. Enables config-driven DSN switching for HeavyReadRepo without code duplication.",
+  "acceptance_criteria": [
+    "DbCapacity.t() is extended with replica fields (connection pool size, latency assumptions, read-only flag, DSN source)",
+    "DbCapacity.load/1 queries both primary and (optional) replica pools to derive capacity",
+    "Config :db_primary and :db_replica are distinct; :db_replica is optional (defaults to nil, falls back to primary DSN)",
+    "BYPASSRLS role (for AdminRepo/HeavyReadRepo) maintains parity; schema_admin user pool is modeled same way on both",
+    "Tests verify that capacity model reflects separate pool budgets; primary=30conn, replica=30conn on same cluster instance yields 60 total",
+    "Documentation clarifies eventual consistency implications for HeavyReadRepo reads"
+  ],
+  "story_type": "feature",
+  "effort": "medium",
+  "depends_on": [],
+  "epic": 38,
+  "tags": ["database", "scale", "config"]
+}

--- a/docs/user_stories/epic_38_horizontal_scaling/us_38.2.json
+++ b/docs/user_stories/epic_38_horizontal_scaling/us_38.2.json
@@ -1,0 +1,19 @@
+{
+  "number": "38.2",
+  "title": "Support replica DSN via config; gate HeavyReadRepo switchover",
+  "description": "Add runtime config knobs to support a separate replica DSN (read-only Postgres), and conditionally route HeavyReadRepo queries to it without changing application code. Maintains single-node behavior when replica is absent; enables switchover via config secret.",
+  "acceptance_criteria": [
+    "New config `:replica_dsn` (env var REPLICA_DSN or blank) is optional; absence means HeavyReadRepo == primary Repo DSN",
+    "HeavyReadRepo.Repo is initialized once at boot with replica DSN if present, primary DSN otherwise",
+    "No runtime branching (if replica_dsn? do X else Y) in query paths — config decides at boot, not per-query",
+    "All read-only code paths (enumeration, export, vector search, HeavyRead context) use HeavyReadRepo; writes always use Repo (never HeavyReadRepo)",
+    "Tests verify queries on HeavyReadRepo hit the intended pool; mocks can inject replica DSN and assert pool switching",
+    "Secrets manager (Fly secrets, or .env for dev) documents replica DSN as an optional knob; deploy instructions mention it does NOT auto-create a replica (manual provisioning step)",
+    "No code changes needed in query modules — all routing happens via Repo selection (HeavyReadRepo vs Repo module aliases)"
+  ],
+  "story_type": "feature",
+  "effort": "medium",
+  "depends_on": ["38.1"],
+  "epic": 38,
+  "tags": ["database", "scale", "config", "replica"]
+}

--- a/docs/user_stories/epic_38_horizontal_scaling/us_38.3.json
+++ b/docs/user_stories/epic_38_horizontal_scaling/us_38.3.json
@@ -1,0 +1,20 @@
+{
+  "number": "38.3",
+  "title": "Enable BEAM clustering via DNS_CLUSTER_QUERY config; verify Node.list/0 across machines",
+  "description": "Add support for BEAM clustering so multiple Fly instances can discover each other and share cross-node PubSub, audit-chain fan-out, and distributed state. Gated by a deploy secret (DNS_CLUSTER_QUERY) that can be unset to run single-node.",
+  "acceptance_criteria": [
+    "New config `:dns_cluster_query` (env var DNS_CLUSTER_QUERY or nil); when present, sets Cluster.Strategy.DNSPollAgent strategy to poll that domain",
+    "Fly 6PN internal DNS (loopctl.internal) is documented as the target domain for clustered deployments",
+    "When DNS_CLUSTER_QUERY is nil (default), clustering is disabled; Node.list/0 returns [Node.self()] only (no cross-node calls)",
+    "When DNS_CLUSTER_QUERY is set to a valid domain, Node.list/0 after boot includes peer nodes; PubSub and audit-chain broadcast to all nodes",
+    "Integration test verifies: when two instances in the same Fly app discover each other via DNS, PubSub.broadcast/3 from node A reaches subscribers on node B",
+    "Health check includes Node.list/0 count in the status response (info only, not a failure; but observable for ops)",
+    "Tests are gatable: in single-node test suite (no DNS_CLUSTER_QUERY), Node.list/0 == [Node.self()]; in cluster suite (with mock domain), multiple nodes appear",
+    "Documentation clarifies: enabling clustering is a binary choice (DNS_CLUSTER_QUERY set), not a gradual toggle; mixed single+clustered fleets will fail to stabilize"
+  ],
+  "story_type": "feature",
+  "effort": "medium",
+  "depends_on": [],
+  "epic": 38,
+  "tags": ["clustering", "otp", "scale"]
+}

--- a/docs/user_stories/epic_38_horizontal_scaling/us_38.4.json
+++ b/docs/user_stories/epic_38_horizontal_scaling/us_38.4.json
@@ -1,0 +1,21 @@
+{
+  "number": "38.4",
+  "title": "Back rate limiter with cluster-global store (Postgres window); remove per-node ETS",
+  "description": "Replace the per-node ETS rate limiter with a cluster-global Postgres-backed window function so that global limits are enforced across all nodes, not multiplied by node count. A single agent's token limit remains constant whether it runs on 1 or N nodes.",
+  "acceptance_criteria": [
+    "New Postgres window function `rate_limit_check(key, limit, window_seconds)` returns {allowed: bool, remaining: int, reset_at: timestamptz}",
+    "Window function uses Postgres 15+ `RANGE BETWEEN CURRENT_TIMESTAMP - INTERVAL ... AND CURRENT_TIMESTAMP` to count requests in the window",
+    "RateLimiter.Behaviour callback updated: `check/3` now calls the window function via `Repo.query!/2` instead of ETS lookup",
+    "Configuration `:rate_limiter_backend` can be `:ets` (single-node legacy) or `:postgres` (cluster-global); defaults to `:postgres`",
+    "ETS code paths remain for backward compat but are NO LONGER used in production config; tests can switch backends",
+    "Rate limit keys include tenant_id and provider (e.g. `rate_limit:tenant:123:provider:anthropic`) for isolation",
+    "Tests verify: with `:postgres` backend, two concurrent nodes checking the same limit key both see the same `remaining` counter; one request increments the count on both",
+    "Performance: Postgres window function is indexed on (key, created_at DESC) for fast scans; measure latency vs ETS and document expected p99 (should be <2ms per check)",
+    "Failover: if Postgres is unreachable (timeout/conn error), rate limiting fails CLOSED (deny all requests, log error) to protect the provider from a rogue burst when metrics are unavailable"
+  ],
+  "story_type": "feature",
+  "effort": "large",
+  "depends_on": ["38.1"],
+  "epic": 38,
+  "tags": ["rate-limiting", "scale", "postgres", "cluster"]
+}

--- a/docs/user_stories/epic_38_horizontal_scaling/us_38.5.json
+++ b/docs/user_stories/epic_38_horizontal_scaling/us_38.5.json
@@ -1,0 +1,20 @@
+{
+  "number": "38.5",
+  "title": "Analyze and document HNSW index config; justify dual-index design or consolidate",
+  "description": "Review the dual-HNSW-index configuration on `memories.embedding` (and any other dual-indexed vectors) to confirm it is necessary or consolidate to a single partial index. Document HNSW parameters (m, ef_construction) and confirm they are not left at pgvector defaults; tune for query latency vs memory footprint.",
+  "acceptance_criteria": [
+    "Document the current index topology: identify all HNSW indexes on vector columns, their m/ef_construction values, and whether they are duplicated",
+    "For each dual index: explain the business case (different query strategies, different k values, different freshness SLAs) or consolidate to single",
+    "Benchmark query latency on a 1M-row memory embedding set: measure p50/p95/p99 latency for semantic_recall with current m/ef_construction, then test m=8/16 and ef_construction=32/64 variants",
+    "Confirm memory footprint vs latency tradeoff: if m=16/ef=64 is necessary for sub-5ms p95, document it; if m=8/ef=32 achieves <10ms p95 with 40% less memory, switch to it",
+    "Update migration docs to specify explicit m/ef_construction values (never rely on pgvector defaults) when creating new HNSW indexes",
+    "Add a periodic telemetry report: index_stats (index name, size_bytes, m, ef_construction, row_count, last_vacuumed) at :telemetry.execute([:loopctl, :index, :stats], %{...})",
+    "Tests verify that index params are queryable from the information schema (pg_indexes system view); snapshot current config in version-control comments",
+    "Documentation: 'HNSW Configuration & Scaling' section in docs/ clarifies m/ef tuning and when to revisit as row count grows"
+  ],
+  "story_type": "feature",
+  "effort": "medium",
+  "depends_on": [],
+  "epic": 38,
+  "tags": ["vector-search", "postgres", "performance", "scale"]
+}


### PR DESCRIPTION
## Summary

5 user stories for epic 38 covering horizontal scaling readiness (code only, no Fly provisioning):
- US-38.1: DbCapacity model primary vs replica separately
- US-38.2: Config support for replica DSN via HeavyReadRepo switchover
- US-38.3: BEAM clustering via DNS_CLUSTER_QUERY; Node.list/0 verification
- US-38.4: Cluster-global rate limiting (Postgres window function)
- US-38.5: HNSW index analysis & tuning documentation

## Test plan

- Pre-commit gate passes (4660 tests, 0 failures)
- CI-required checks pass