### PR TITLE
docs(epic_38): horizontal-scaling readiness stories (US-38.1..38.4, CODE-ONLY)

### DIFF
--- a/docs/user_stories/epic_38_horizontal_scaling/epic.json
+++ b/docs/user_stories/epic_38_horizontal_scaling/epic.json
@@ -1,0 +1,24 @@
+{
+  "number": 38,
+  "title": "Horizontal scaling readiness (multi-node + read replica) — code only",
+  "description": "Code-readiness preparation for horizontal scaling to multiple nodes without infrastructure changes. Prepares config/code paths for multi-node BEAM clustering, read replica DSN switchability, and cluster-global rate limiting. No Fly provisioning, no replica deployment, no `fly scale count > 1` until verified.",
+  "findings": {
+    "high": [
+      "DB connection budget hard-caps the fleet at ~3 nodes / ~30 RLS connections",
+      "Single physical Postgres for writes + vector reads + Oban; no read replica separation"
+    ],
+    "medium": [
+      "HeavyReadRepo is a second pool on the same primary, not a replica",
+      "BEAM clustering disabled by default — scaling breaks cross-node PubSub",
+      "Rate limiter is per-node ETS — global limits multiply by node count",
+      "Embedding write throughput capped at 5 + dual HNSW index maintenance"
+    ]
+  },
+  "acceptance_criteria": [
+    "All code paths are replica-aware (config gatable; BYPASSRLS parity maintained)",
+    "DbCapacity models primary vs replica separately",
+    "BEAM clustering can be enabled via config; Node.list/0 verifiable",
+    "Rate limiter is cluster-global (not per-node ETS)",
+    "HNSW index justification (dual vs single) is documented; tuning parameters documented"
+  ]
+}

--- a/docs/user_stories/epic_38_horizontal_scaling/us_38.1.json
+++ b/docs/user_stories/epic_38_horizontal_scaling/us_38.1.json
@@ -1,0 +1,18 @@
+{
+  "number": "38.1",
+  "title": "Model primary vs replica database capacity separately in DbCapacity",
+  "description": "Add replica-aware capacity modeling to DbCapacity so it can represent both primary (write-capable, RLS enforced) and replica (read-only, eventual consistency) separately. Enables config-driven DSN switching for HeavyReadRepo without code duplication.",
+  "acceptance_criteria": [
+    "DbCapacity.t() is extended with replica fields (connection pool size, latency assumptions, read-only flag, DSN source)",
+    "DbCapacity.load/1 queries both primary and (optional) replica pools to derive capacity",
+    "Config :db_primary and :db_replica are distinct; :db_replica is optional (defaults to nil, falls back to primary DSN)",
+    "BYPASSRLS role (for AdminRepo/HeavyReadRepo) maintains parity; schema_admin user pool is modeled same way on both",
+    "Tests verify that capacity model reflects separate pool budgets; primary=30conn, replica=30conn on same cluster instance yields 60 total",
+    "Documentation clarifies eventual consistency implications for HeavyReadRepo reads"
+  ],
+  "story_type": "feature",
+  "effort": "medium",
+  "depends_on": [],
+  "epic": 38,
+  "tags": ["database", "scale", "config"]
+}

--- a/docs/user_stories/epic_38_horizontal_scaling/us_38.2.json
+++ b/docs/user_stories/epic_38_horizontal_scaling/us_38.2.json
@@ -1,0 +1,19 @@
+{
+  "number": "38.2",
+  "title": "Support replica DSN via config; gate HeavyReadRepo switchover",
+  "description": "Add runtime config knobs to support a separate replica DSN (read-only Postgres), and conditionally route HeavyReadRepo queries to it without changing application code. Maintains single-node behavior when replica is absent; enables switchover via config secret.",
+  "acceptance_criteria": [
+    "New config `:replica_dsn` (env var REPLICA_DSN or blank) is optional; absence means HeavyReadRepo == primary Repo DSN",
+    "HeavyReadRepo.Repo is initialized once at boot with replica DSN if present, primary DSN otherwise",
+    "No runtime branching (if replica_dsn? do X else Y) in query paths — config decides at boot, not per-query",
+    "All read-only code paths (enumeration, export, vector search, HeavyRead context) use HeavyReadRepo; writes always use Repo (never HeavyReadRepo)",
+    "Tests verify queries on HeavyReadRepo hit the intended pool; mocks can inject replica DSN and assert pool switching",
+    "Secrets manager (Fly secrets, or .env for dev) documents replica DSN as an optional knob; deploy instructions mention it does NOT auto-create a replica (manual provisioning step)",
+    "No code changes needed in query modules — all routing happens via Repo selection (HeavyReadRepo vs Repo module aliases)"
+  ],
+  "story_type": "feature",
+  "effort": "medium",
+  "depends_on": ["38.1"],
+  "epic": 38,
+  "tags": ["database", "scale", "config", "replica"]
+}

--- a/docs/user_stories/epic_38_horizontal_scaling/us_38.3.json
+++ b/docs/user_stories/epic_38_horizontal_scaling/us_38.3.json
@@ -1,0 +1,20 @@
+{
+  "number": "38.3",
+  "title": "Enable BEAM clustering via DNS_CLUSTER_QUERY config; verify Node.list/0 across machines",
+  "description": "Add support for BEAM clustering so multiple Fly instances can discover each other and share cross-node PubSub, audit-chain fan-out, and distributed state. Gated by a deploy secret (DNS_CLUSTER_QUERY) that can be unset to run single-node.",
+  "acceptance_criteria": [
+    "New config `:dns_cluster_query` (env var DNS_CLUSTER_QUERY or nil); when present, sets Cluster.Strategy.DNSPollAgent strategy to poll that domain",
+    "Fly 6PN internal DNS (loopctl.internal) is documented as the target domain for clustered deployments",
+    "When DNS_CLUSTER_QUERY is nil (default), clustering is disabled; Node.list/0 returns [Node.self()] only (no cross-node calls)",
+    "When DNS_CLUSTER_QUERY is set to a valid domain, Node.list/0 after boot includes peer nodes; PubSub and audit-chain broadcast to all nodes",
+    "Integration test verifies: when two instances in the same Fly app discover each other via DNS, PubSub.broadcast/3 from node A reaches subscribers on node B",
+    "Health check includes Node.list/0 count in the status response (info only, not a failure; but observable for ops)",
+    "Tests are gatable: in single-node test suite (no DNS_CLUSTER_QUERY), Node.list/0 == [Node.self()]; in cluster suite (with mock domain), multiple nodes appear",
+    "Documentation clarifies: enabling clustering is a binary choice (DNS_CLUSTER_QUERY set), not a gradual toggle; mixed single+clustered fleets will fail to stabilize"
+  ],
+  "story_type": "feature",
+  "effort": "medium",
+  "depends_on": [],
+  "epic": 38,
+  "tags": ["clustering", "otp", "scale"]
+}

--- a/docs/user_stories/epic_38_horizontal_scaling/us_38.4.json
+++ b/docs/user_stories/epic_38_horizontal_scaling/us_38.4.json
@@ -1,0 +1,21 @@
+{
+  "number": "38.4",
+  "title": "Back rate limiter with cluster-global store (Postgres window); remove per-node ETS",
+  "description": "Replace the per-node ETS rate limiter with a cluster-global Postgres-backed window function so that global limits are enforced across all nodes, not multiplied by node count. A single agent's token limit remains constant whether it runs on 1 or N nodes.",
+  "acceptance_criteria": [
+    "New Postgres window function `rate_limit_check(key, limit, window_seconds)` returns {allowed: bool, remaining: int, reset_at: timestamptz}",
+    "Window function uses Postgres 15+ `RANGE BETWEEN CURRENT_TIMESTAMP - INTERVAL ... AND CURRENT_TIMESTAMP` to count requests in the window",
+    "RateLimiter.Behaviour callback updated: `check/3` now calls the window function via `Repo.query!/2` instead of ETS lookup",
+    "Configuration `:rate_limiter_backend` can be `:ets` (single-node legacy) or `:postgres` (cluster-global); defaults to `:postgres`",
+    "ETS code paths remain for backward compat but are NO LONGER used in production config; tests can switch backends",
+    "Rate limit keys include tenant_id and provider (e.g. `rate_limit:tenant:123:provider:anthropic`) for isolation",
+    "Tests verify: with `:postgres` backend, two concurrent nodes checking the same limit key both see the same `remaining` counter; one request increments the count on both",
+    "Performance: Postgres window function is indexed on (key, created_at DESC) for fast scans; measure latency vs ETS and document expected p99 (should be <2ms per check)",
+    "Failover: if Postgres is unreachable (timeout/conn error), rate limiting fails CLOSED (deny all requests, log error) to protect the provider from a rogue burst when metrics are unavailable"
+  ],
+  "story_type": "feature",
+  "effort": "large",
+  "depends_on": ["38.1"],
+  "epic": 38,
+  "tags": ["rate-limiting", "scale", "postgres", "cluster"]
+}

--- a/docs/user_stories/epic_38_horizontal_scaling/us_38.5.json
+++ b/docs/user_stories/epic_38_horizontal_scaling/us_38.5.json
@@ -1,0 +1,20 @@
+{
+  "number": "38.5",
+  "title": "Analyze and document HNSW index config; justify dual-index design or consolidate",
+  "description": "Review the dual-HNSW-index configuration on `memories.embedding` (and any other dual-indexed vectors) to confirm it is necessary or consolidate to a single partial index. Document HNSW parameters (m, ef_construction) and confirm they are not left at pgvector defaults; tune for query latency vs memory footprint.",
+  "acceptance_criteria": [
+    "Document the current index topology: identify all HNSW indexes on vector columns, their m/ef_construction values, and whether they are duplicated",
+    "For each dual index: explain the business case (different query strategies, different k values, different freshness SLAs) or consolidate to single",
+    "Benchmark query latency on a 1M-row memory embedding set: measure p50/p95/p99 latency for semantic_recall with current m/ef_construction, then test m=8/16 and ef_construction=32/64 variants",
+    "Confirm memory footprint vs latency tradeoff: if m=16/ef=64 is necessary for sub-5ms p95, document it; if m=8/ef=32 achieves <10ms p95 with 40% less memory, switch to it",
+    "Update migration docs to specify explicit m/ef_construction values (never rely on pgvector defaults) when creating new HNSW indexes",
+    "Add a periodic telemetry report: index_stats (index name, size_bytes, m, ef_construction, row_count, last_vacuumed) at :telemetry.execute([:loopctl, :index, :stats], %{...})",
+    "Tests verify that index params are queryable from the information schema (pg_indexes system view); snapshot current config in version-control comments",
+    "Documentation: 'HNSW Configuration & Scaling' section in docs/ clarifies m/ef tuning and when to revisit as row count grows"
+  ],
+  "story_type": "feature",
+  "effort": "medium",
+  "depends_on": [],
+  "epic": 38,
+  "tags": ["vector-search", "postgres", "performance", "scale"]
+}

--- a/docs/user_stories/epic_38_scaling_readiness/README.md
+++ b/docs/user_stories/epic_38_scaling_readiness/README.md
@@ -1,0 +1,70 @@
+# Epic 38 — Horizontal Scaling Readiness (CODE-ONLY)
+
+Remediation of GitHub issue **#353** (roadmap Epic 6, tracked **#355**) — making
+loopctl multi-node-**safe in code** so `fly scale count > 1` is a config/secret
+flip when the time comes. The last roadmap epic.
+
+## Decision: code-readiness only, NO infra (Mark, 2026-07-15)
+
+#353 mixes code with infrastructure. Per Mark's decision this epic is
+**CODE-ONLY** — build the multi-node-safe code paths, **all flag/env-gated to
+today's single-node behavior**, with **zero infra provisioning and zero spend**.
+It is "not urgent at current node count" (the issue's own words). The infra
+actions are explicitly **OUT OF SCOPE**, left as documented, gated steps for when
+Mark decides to scale:
+
+- Provisioning a Fly MPG read replica.
+- Setting the `DNS_CLUSTER_QUERY` Fly secret (code is already wired).
+- Raising machine `count` past the ~3-node ceiling / upgrading the MPG plan.
+- Any real pgbouncer connection-multiplexing tuning.
+
+## Scope reconciliation (verified against `master` before authoring)
+
+| #353 finding | Status | Evidence |
+|--------------|--------|----------|
+| `DNS_CLUSTER_QUERY` / BEAM clustering code wiring | ✅ done | Epic 32 — `DNSCluster` in `application.ex:28`, env at `runtime.exs:345` (unset → `:ignore`). Needs only the Fly secret (infra, out of scope). |
+| HeavyRead dedicated isolated pool + `DbCapacity` budget | ✅ done | Epic 27/33 — but shares the primary DSN (`runtime.exs:299-305`); no replica DSN |
+| pgbouncer-safe params (`SET LOCAL`, `prepare: :unnamed`) | ✅ done + guarded | Epic 27/33 — `pgbouncer_startup_params_test.exs` |
+| **PubSub cross-node cache invalidation** (SettingsCache, ApiKeyCache) | ✅ done — cluster-correct BY DESIGN | Epic 32/33 — `broadcast_from` + node-local ETS bust + TTL backstop. **Do NOT re-scope.** |
+| PubSub adapter is cross-node | ✅ done | default `Phoenix.PubSub.PG2` (`:pg`) — fans out once clustered |
+| Actual replica / plan / scale-count / secret | ⏸ infra — OUT OF SCOPE | Mark's hands; documented gated steps |
+
+The **genuinely-remaining CODE-ONLY** work:
+
+| Finding | Status | Story |
+|---------|--------|-------|
+| Rate limiter is per-node ETS → a global limit becomes `limit × N` across nodes (defeats the DB-pool protection it exists for) | ❌ open | **US-38.2** |
+| `SthEnqueuer` is a node-local singleton → N nodes each enqueue off the same firehose (duplicate STH work) | ❌ open | **US-38.3** |
+| No clustering verification / health gate; no DNSCluster test | ❌ open | **US-38.3** |
+| `HeavyReadRepo` hardcoded to the primary DSN; no `REPLICA_DATABASE_URL` plumbing; `DbCapacity` has no replica dimension | ❌ open | **US-38.1** |
+| HNSW indexes use pgvector defaults (`m=16, ef_construction=64`), untuned; `memories.embedding` carries a dual HNSW index | ❌ open (review) | **US-38.4** |
+
+## Stories
+
+| Story | Title | Depends |
+|-------|-------|---------|
+| US-38.1 | Replica-ready read config: `REPLICA_DATABASE_URL` plumbing for HeavyReadRepo (defaults to primary when unset) + `DbCapacity` replica dimension | — |
+| US-38.2 | Cluster-global rate limiter: a shared **Postgres**-backed `RateLimiter` behind the existing behaviour (default node-local ETS), covering the web limiter *and* `Provider.Admission` | — |
+| US-38.3 | Cluster-safe `SthEnqueuer` singleton + clustering-readiness verification/health gate + DNSCluster wiring test | — |
+| US-38.4 | HNSW `m`/`ef_construction` tuning + `memories.embedding` dual-index justification review | — |
+
+## Non-negotiable constraints (system is LIVE; single-node today)
+
+- **DEFAULT = today's behavior, exactly.** Every new capability (replica DSN,
+  shared limiter, singleton mode) is **flag/env-gated and defaults OFF** so a
+  single-node deploy behaves byte-for-byte as it does now. Enabling any of them
+  is a deliberate future op, tested here but not turned on.
+- **No infra, no spend, no scaling.** This epic provisions nothing and does NOT
+  set `DNS_CLUSTER_QUERY`, does NOT raise `scale count`, does NOT change the MPG
+  plan. Those stay documented gated steps. **Never set a secret to a doc
+  placeholder** (epic_35 `STH_SWEEP_CRON` lesson).
+- **Correctness on both sides of every flag.** The shared limiter (US-38.2) must
+  give identical results to the ETS path for a single node, and cluster-global
+  results only when enabled; the replica config (US-38.1) must be
+  read-only-safe (never route a write to a replica) and fall back to primary.
+- Any HNSW/index migration (US-38.4) is **online** (`CONCURRENTLY`,
+  `@disable_ddl_transaction`) on the hot `articles`/`memories` tables and must
+  not degrade recall (a recall test either side).
+- Env-driven knobs via `SystemConfig`/config-based DI; assert outcome classes,
+  not timing (async-suite flake lesson); watch master **Deploy + Post-deploy
+  Smoke** to green (runtime.exs env changes only fail at release boot).

--- a/docs/user_stories/epic_38_scaling_readiness/us_38.1.json
+++ b/docs/user_stories/epic_38_scaling_readiness/us_38.1.json
@@ -1,0 +1,51 @@
+{
+  "id": "US-38.1",
+  "title": "Replica-ready read config: REPLICA_DATABASE_URL plumbing (defaults to primary) + DbCapacity replica dimension",
+  "epic": { "id": "epic_38", "name": "Horizontal Scaling Readiness (code-only)" },
+  "priority": "medium",
+  "phase": "scalability",
+  "priority_note": "Makes loopctl replica-READY in code without provisioning a replica: HeavyReadRepo can target a separate read DSN when one is configured, and DbCapacity can model primary-vs-replica budgets. Until an operator sets REPLICA_DATABASE_URL, behavior is byte-for-byte identical to today (reads hit the primary).",
+  "background": {
+    "reference": "GH #353. HeavyReadRepo (config/runtime.exs:299-305) uses `url: admin_database_url` where admin_database_url = ADMIN_DATABASE_URL || database_url (runtime.exs:134-135) — the SAME physical primary as the write-capable AdminRepo. It is pool isolation (US-27.11), not a replica. No REPLICA_DATABASE_URL plumbing exists. DbCapacity (lib/loopctl/db_capacity.ex) models a SINGLE physical Postgres: @prod_pool_sizes %{repo: 10, admin_repo: 3, heavy_read_repo: 8}, @verified_live_max_connections 100, max_supported_nodes ~3.",
+    "includes": "CODE-ONLY: add REPLICA_DATABASE_URL env plumbing so HeavyReadRepo targets a replica DSN WHEN SET, falling back to the primary (admin_database_url) when unset — so nothing changes today. Keep BYPASSRLS role parity + the pgbouncer-safe SET LOCAL timeout design. Extend DbCapacity to model a replica connection dimension (config-only) so the budget accountant is ready before a replica exists. Actually provisioning the replica is INFRA and OUT OF SCOPE."
+  },
+  "story": {
+    "as_a": "loopctl operator preparing to scale out",
+    "i_want_to": "point HeavyReadRepo (and pure-read/vector/enumeration/export paths) at a read replica DSN via REPLICA_DATABASE_URL when one exists, defaulting to the primary when it is unset",
+    "so_that": "when I later provision a Fly MPG read replica the app already routes heavy reads to it with a single env change — and until then the app behaves exactly as it does today (reads on the primary)"
+  },
+  "rationale": "The only thing standing between loopctl and replica offload is config plumbing: HeavyReadRepo is already an isolated, read-only-shaped pool, so giving it an optional separate DSN (default = primary) makes the app replica-ready with zero behavior change today and zero infra. Modeling the replica budget in DbCapacity now means the connection accountant is correct the moment a replica is added.",
+  "acceptance_criteria": [
+    { "id": "AC-38.1.1", "description": "HeavyReadRepo's DSN is resolved as REPLICA_DATABASE_URL when set, else admin_database_url (today's value). When REPLICA_DATABASE_URL is UNSET, the resolved config is IDENTICAL to today (a test asserts byte-identical repo config / same DSN as before). BYPASSRLS role parity and the SET LOCAL statement_timeout / prepare: :unnamed pgbouncer-safety are preserved on the replica path.", "status": "pending" },
+    { "id": "AC-38.1.2", "description": "Write-safety: nothing that writes can be routed to the replica. HeavyReadRepo remains read-only in usage (it already is); a guard/test asserts the replica DSN is only ever used for reads (no AdminRepo/Repo writes rerouted). If REPLICA_DATABASE_URL points somewhere unreachable, the app fails loud at boot (clear error) rather than silently degrading — OR documents a primary-fallback; pick and test one.", "status": "pending" },
+    { "id": "AC-38.1.3", "description": "DbCapacity is extended to model a replica connection dimension: primary budget (Repo + AdminRepo + write-side) vs replica budget (HeavyReadRepo when REPLICA_DATABASE_URL set). When no replica is configured, the model and max_supported_nodes math are UNCHANGED from today (regression test on the existing numbers). When a replica is modeled, HeavyReadRepo connections count against the replica budget, not the primary — raising the effective primary headroom. Config-only; no pool sizes actually changed.", "status": "pending" },
+    { "id": "AC-38.1.4", "description": "Purely additive config plumbing behind an env var that DEFAULTS OFF (unset → primary). No infra provisioned, no scaling, no pool-size change to production defaults. Documented: setting REPLICA_DATABASE_URL is a future gated op. No Application.put_env in tests; config-based DI.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-38.1.1", "name": "unset REPLICA_DATABASE_URL → identical to today", "type": "unit",
+      "preconditions": ["REPLICA_DATABASE_URL not set"],
+      "steps": ["resolve HeavyReadRepo config"],
+      "expected_results": ["DSN == admin_database_url; config identical to current behavior"], "status": "pending" },
+    { "id": "TC-38.1.2", "name": "set REPLICA_DATABASE_URL → HeavyRead targets replica", "type": "unit",
+      "preconditions": ["REPLICA_DATABASE_URL set to a distinct DSN"],
+      "steps": ["resolve HeavyReadRepo config"],
+      "expected_results": ["HeavyReadRepo DSN == replica; prepare: :unnamed + SET LOCAL timeout preserved; Repo/AdminRepo unchanged (primary)"], "status": "pending" },
+    { "id": "TC-38.1.3", "name": "DbCapacity replica dimension", "type": "unit",
+      "preconditions": ["model with and without a replica configured"],
+      "steps": ["compute budgets"],
+      "expected_results": ["no replica → numbers unchanged from today; with replica → HeavyRead conns counted against replica, primary headroom rises"], "status": "pending" },
+    { "id": "TC-38.1.4", "name": "no write routed to replica", "type": "integration",
+      "preconditions": ["replica DSN configured (can be same physical in test)"],
+      "steps": ["exercise a write path"],
+      "expected_results": ["writes go via Repo/AdminRepo (primary), never HeavyReadRepo"], "status": "pending" }
+  ],
+  "technical_notes": [
+    "Files: config/runtime.exs (:134-135 admin_database_url, :299-305 HeavyReadRepo — add REPLICA_DATABASE_URL || admin_database_url), lib/loopctl/db_capacity.ex (replica dimension in the budget model + max_supported_nodes), lib/loopctl/heavy_read_repo.ex.",
+    "Default MUST be unset → primary (admin_database_url) so today is unchanged. Keep BYPASSRLS parity: the replica must use the same read role capabilities as HeavyReadRepo today.",
+    "Eventual-consistency is acceptable for HeavyRead paths (vector/enumeration/export/analytics) — but confirm no path reads-its-own-write in a way that would break on replica lag; if one does, it must stay on the primary or tolerate lag (document).",
+    "DbCapacity: model replica connections separately but do NOT change production pool sizes in this story (that needs the infra/plan). Keep the existing db_capacity_test numbers green when no replica configured.",
+    "No infra: this story does NOT provision a replica. Config-based DI; no Application.put_env in tests."
+  ],
+  "dependencies": [],
+  "estimated_tokens": 350000
+}

--- a/docs/user_stories/epic_38_scaling_readiness/us_38.2.json
+++ b/docs/user_stories/epic_38_scaling_readiness/us_38.2.json
@@ -1,0 +1,52 @@
+{
+  "id": "US-38.2",
+  "title": "Cluster-global rate limiter: shared Postgres-backed RateLimiter behind the existing behaviour (default node-local ETS)",
+  "epic": { "id": "epic_38", "name": "Horizontal Scaling Readiness (code-only)" },
+  "priority": "high",
+  "phase": "scalability",
+  "priority_note": "The single biggest correctness gap on scale-out: the rate limiter is per-node ETS, so any global limit becomes limit×N across nodes — defeating the DB-pool and provider-429 protection the limiter exists to provide. A shared store makes limits cluster-global. Flag-gated: default stays node-local ETS (today's behavior) until an operator opts in.",
+  "background": {
+    "reference": "GH #353. Hammer backend is per-node ETS (config/config.exs:286-288 Hammer.Backend.ETS). The web limiter (lib/loopctl/rate_limiter/hammer.ex) AND US-37.1's outbound token bucket (lib/loopctl/provider/admission.ex:134 rate_limiter().check_rate) both resolve through Loopctl.RateLimiter.Behaviour → the node-local Hammer. admission.ex:70-74 explicitly documents the fleet ceiling is rpm×node_count and defers cluster-global to Epic 38. No Redis in the stack (avoid adding one — Postgres is already there).",
+    "includes": "The Behaviour abstraction already exists (check_rate/3), so this is a clean config-based-DI swap: add a Postgres-backed RateLimiter implementation (a windowed counter table with atomic upsert/increment, tenant+key+window scoped) selectable via config, defaulting to the current ETS/Hammer impl. Both the web limiter and Provider.Admission get cluster-global limits when the Postgres impl is selected, with zero change when it isn't."
+  },
+  "story": {
+    "as_a": "loopctl operator preparing to scale out",
+    "i_want_to": "optionally back the rate limiter with a shared Postgres store so a tenant's limit is enforced across the whole fleet, selectable via config and defaulting to the current per-node ETS",
+    "so_that": "when I run more than one node, a global limit (inbound RPM, or the US-37.1 outbound provider token bucket) stays global instead of multiplying by node count — without adding Redis and without changing single-node behavior today"
+  },
+  "rationale": "Because both limiter call sites already go through Loopctl.RateLimiter.Behaviour, adding a Postgres-backed implementation and selecting it via config gives cluster-global limits with no call-site changes and a trivially safe default (keep ETS). Postgres is already in the stack, so no new infra/dep (no Redis). This closes the limit×N gap that would otherwise silently defeat the DB-pool and provider-429 protections the moment loopctl scales past one node.",
+  "acceptance_criteria": [
+    { "id": "AC-38.2.1", "description": "A new Postgres-backed RateLimiter implements Loopctl.RateLimiter.Behaviour (check_rate/3 + any other callbacks): a windowed counter (tenant/key/window bucket) with an ATOMIC increment-and-check (single upsert or INSERT ... ON CONFLICT ... DO UPDATE ... RETURNING) so concurrent nodes cannot exceed the limit (no read-modify-write race). Old windows are pruned/expired cheaply (partial index / periodic cleanup).", "status": "pending" },
+    { "id": "AC-38.2.2", "description": "The limiter implementation is selected via config (config-based DI, e.g. Application.get_env :loopctl, :rate_limiter, defaulting to the existing ETS/Hammer impl). BOTH the web plug limiter (rate_limiter/hammer.ex callers) AND Provider.Admission (admission.ex) resolve through the behaviour, so BOTH become cluster-global when the Postgres impl is selected — no call-site changes. Default config = ETS (today).", "status": "pending" },
+    { "id": "AC-38.2.3", "description": "DEFAULT-OFF safety: with default config (ETS), behavior is byte-for-byte today's — a test asserts the resolved limiter is the ETS impl by default and single-node results are identical. Fail-OPEN parity: like the ETS/Hammer path and US-37.1, a Postgres-limiter fault (DB error) fails OPEN (allows the request) and logs, never blocking all traffic on a limiter outage.", "status": "pending" },
+    { "id": "AC-38.2.4", "description": "Cluster-global correctness (the point): a test simulates two callers/processes sharing the Postgres store and asserts the COMBINED count is limited to the global budget (not 2×). Window semantics (fixed or sliding) match the existing Hammer contract closely enough that a limit configured today means the same thing. Tenant/key isolation preserved.", "status": "pending" },
+    { "id": "AC-38.2.5", "description": "Bounded cost: the limiter query is a single indexed atomic op per check on a small counter table (not a scan); a migration creates the table + index ONLINE (CONCURRENTLY where needed). No hot-path N+1. The counter table is app-owned (RLS per project rules; but limiter runs cross-tenant via a scoped key — document the access path). No Application.put_env in tests.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-38.2.1", "name": "default is ETS / unchanged", "type": "unit",
+      "preconditions": ["default config"],
+      "steps": ["resolve the rate limiter impl; run a single-node check"],
+      "expected_results": ["ETS/Hammer impl; results identical to today"], "status": "pending" },
+    { "id": "TC-38.2.2", "name": "postgres limiter is atomic / cluster-global", "type": "integration",
+      "preconditions": ["Postgres impl selected; limit=N"],
+      "steps": ["two concurrent processes issue N+ checks against the same tenant/key"],
+      "expected_results": ["combined allowed count == N (not 2N); the rest are limited"], "status": "pending" },
+    { "id": "TC-38.2.3", "name": "both web + admission use the selected impl", "type": "integration",
+      "preconditions": ["Postgres impl selected"],
+      "steps": ["exercise the web plug limiter and Provider.Admission"],
+      "expected_results": ["both go through the Postgres limiter (cluster-global)"], "status": "pending" },
+    { "id": "TC-38.2.4", "name": "fail-open on limiter DB error", "type": "unit",
+      "preconditions": ["Postgres impl; simulate a DB/limiter error"],
+      "steps": ["issue a check"],
+      "expected_results": ["request allowed (fail-open) + logged; not blocked"], "status": "pending" }
+  ],
+  "technical_notes": [
+    "Files: new lib/loopctl/rate_limiter/postgres.ex (impl of Loopctl.RateLimiter.Behaviour), config wiring (config/config.exs + config/runtime.exs) to select the impl, a migration for the counter table + index, lib/loopctl/provider/admission.ex + lib/loopctl/rate_limiter/hammer.ex callers already resolve via the behaviour (confirm the resolution point).",
+    "Atomic increment: INSERT INTO rate_limit_counters (key, window_start, count) VALUES (...) ON CONFLICT (key, window_start) DO UPDATE SET count = rate_limit_counters.count + 1 RETURNING count — then compare to the limit. No SELECT-then-UPDATE race.",
+    "Do NOT add Redis — Postgres is in-stack. Keep the ETS/Hammer impl as the DEFAULT; the Postgres impl is opt-in via config for when clustered.",
+    "Match the Hammer window contract (fixed-window is fine and matches Hammer.Backend.ETS) so an existing configured limit keeps its meaning. Prune old windows (periodic cleanup worker or partial-index + TTL).",
+    "Fail-OPEN on limiter error (consistency with US-37.1 admission + the ETS path). config-based DI; no Application.put_env in tests; assert outcome class not exact timing."
+  ],
+  "dependencies": [],
+  "estimated_tokens": 450000
+}

--- a/docs/user_stories/epic_38_scaling_readiness/us_38.3.json
+++ b/docs/user_stories/epic_38_scaling_readiness/us_38.3.json
@@ -1,0 +1,51 @@
+{
+  "id": "US-38.3",
+  "title": "Cluster-safe SthEnqueuer singleton + clustering-readiness verification gate + DNSCluster test",
+  "epic": { "id": "epic_38", "name": "Horizontal Scaling Readiness (code-only)" },
+  "priority": "medium",
+  "phase": "scalability",
+  "priority_note": "Two scale-out sharp edges: (1) the US-35.2 SthEnqueuer is a node-local singleton, so on N nodes each node's subscriber enqueues off the same audit firehose = N× duplicate STH-enqueue work; (2) there is NO clustering verification anywhere, so a machine-count increase could silently run un-clustered (node-local PubSub) with no signal. Both are code-fixable now; neither sets the cluster secret or scales anything.",
+  "background": {
+    "reference": "GH #353. SthEnqueuer (lib/loopctl/audit_chain/sth_enqueuer.ex) is a supervised node-local singleton subscribing to the audit firehose (US-35.2); on N nodes all N subscribe and enqueue (dup work; safe via sth_needed?/Oban unique but wasteful). DNSCluster is wired (application.ex:28, runtime.exs:345) but unset → :ignore; there is NO Node.list/clustering health check or gate and NO DNSCluster test. PubSub is cross-node PG2 (correct); SettingsCache/ApiKeyCache invalidation is already cluster-correct (do NOT touch).",
+    "includes": "CODE-ONLY: make SthEnqueuer a CLUSTER singleton (e.g. :global registration or a leadership check) so exactly one node enqueues off the firehose regardless of node count; add a clustering-readiness verification (a health/status check that reports whether DNS_CLUSTER_QUERY is set and Node.list/0 shows peers) + a documented gate ('do not raise scale count until clustering verified'); add the missing DNSCluster wiring test. Does NOT set DNS_CLUSTER_QUERY (infra) and does NOT scale."
+  },
+  "story": {
+    "as_a": "loopctl operator preparing to scale out",
+    "i_want_to": "have exactly one node process the audit firehose (a cluster singleton), and a clustering-readiness signal that tells me whether the fleet is actually clustered before I raise the node count",
+    "so_that": "scaling out doesn't silently duplicate STH-enqueue work on every node or run un-clustered (node-local PubSub) without warning — the readiness to go multi-node is verifiable in code"
+  },
+  "rationale": "The audit firehose should be drained once per cluster, not once per node; a :global singleton (or leader election) fixes the duplication cheaply and safely (single-node behavior unchanged — one node is still the singleton). A clustering-readiness check + gate turns 'is the fleet actually clustered?' from an invisible assumption into an observable signal, so the eventual scale-out is deliberate and verified rather than a silent degradation. Both are pure code and change nothing on a single node.",
+  "acceptance_criteria": [
+    { "id": "AC-38.3.1", "description": "SthEnqueuer becomes a cluster singleton: across N clustered nodes, exactly ONE instance subscribes to / drains the audit firehose (via :global registration or a leadership check), eliminating the N× duplicate enqueue. On a SINGLE node behavior is unchanged (that node is the singleton). If the singleton's node dies, another node takes over (failover). A test asserts single-node still enqueues, and (simulated) multi-registration yields one active enqueuer.", "status": "pending" },
+    { "id": "AC-38.3.2", "description": "A clustering-readiness verification exists: a function/health signal reports whether DNS_CLUSTER_QUERY is configured and whether Node.list/0 shows the expected peers (vs EXPECTED_APP_NODES). Exposed via the existing health/observability surface (e.g. a field in /health or a ScaleMetrics gauge) — bounded, no sensitive data. On a single node it reports 'single-node / clustering not required', not an error.", "status": "pending" },
+    { "id": "AC-38.3.3", "description": "A documented gate: raising machine count past 1 should be preceded by verifying clustering (the readiness signal green). This is DOCUMENTED (README/runbook + a boot log when EXPECTED_APP_NODES > 1 but Node.list is empty → WARN, not crash) — it does NOT enforce-by-crashing (single-node must always boot) and does NOT set the secret or scale.", "status": "pending" },
+    { "id": "AC-38.3.4", "description": "The missing DNSCluster wiring test is added: asserts DNSCluster is in the supervision tree and that :dns_cluster_query resolves from env (unset → :ignore). Purely additive; no behavior change on a single node; DNS_CLUSTER_QUERY is NOT set by this story.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-38.3.1", "name": "single node still enqueues; cluster = one enqueuer", "type": "integration",
+      "preconditions": ["single node"],
+      "steps": ["append audit entries; let the enqueuer run"],
+      "expected_results": ["STH enqueued as today; with simulated :global registration only one enqueuer is active"], "status": "pending" },
+    { "id": "TC-38.3.2", "name": "clustering-readiness signal", "type": "unit",
+      "preconditions": ["single node, DNS_CLUSTER_QUERY unset"],
+      "steps": ["query the readiness signal"],
+      "expected_results": ["reports single-node / not-required (not an error); no sensitive data"], "status": "pending" },
+    { "id": "TC-38.3.3", "name": "WARN when EXPECTED_APP_NODES>1 but no peers", "type": "unit",
+      "preconditions": ["EXPECTED_APP_NODES=2, Node.list empty"],
+      "steps": ["run the boot check"],
+      "expected_results": ["logs a WARN; app still boots (no crash)"], "status": "pending" },
+    { "id": "TC-38.3.4", "name": "DNSCluster wiring test", "type": "unit",
+      "preconditions": [],
+      "steps": ["inspect supervision tree + :dns_cluster_query resolution"],
+      "expected_results": ["DNSCluster present; unset env → :ignore"], "status": "pending" }
+  ],
+  "technical_notes": [
+    "Files: lib/loopctl/audit_chain/sth_enqueuer.ex (:global name or leadership gate), lib/loopctl/application.ex, lib/loopctl/telemetry/scale_metrics.ex or the /health path (readiness signal), a new test/loopctl/cluster_readiness_test.exs + DNSCluster wiring test.",
+    ":global registration is simplest for a single logical enqueuer; handle the name-clash on register (one wins, others idle) and failover on node down. Alternatively a leader check via Node.self() == hd(Enum.sort([node()|Node.list()])). Keep single-node a no-op-equivalent.",
+    "Readiness gate is a WARN + documented runbook step, NOT a hard crash — single-node must always boot (EXPECTED_APP_NODES default 2 already only WARNs in db_capacity; mirror that).",
+    "Do NOT set DNS_CLUSTER_QUERY (infra/out of scope). Do NOT touch SettingsCache/ApiKeyCache PubSub invalidation — already cluster-correct.",
+    "Assert outcome class not exact timing; config-based DI; no Application.put_env in tests."
+  ],
+  "dependencies": [],
+  "estimated_tokens": 350000
+}

--- a/docs/user_stories/epic_38_scaling_readiness/us_38.4.json
+++ b/docs/user_stories/epic_38_scaling_readiness/us_38.4.json
@@ -1,0 +1,47 @@
+{
+  "id": "US-38.4",
+  "title": "HNSW m/ef_construction tuning + memories.embedding dual-index justification review",
+  "epic": { "id": "epic_38", "name": "Horizontal Scaling Readiness (code-only)" },
+  "priority": "medium",
+  "phase": "scalability",
+  "priority_note": "All vector indexes use pgvector defaults (m=16, ef_construction=64) — untuned — and memories.embedding carries TWO HNSW indexes (full + live-only partial). Index build/maintenance cost and recall quality both scale with the corpus, so tuning params and confirming the dual index is warranted is a scaling-readiness concern. Review-first: only change what's justified.",
+  "background": {
+    "reference": "GH #353. All HNSW indexes go through lib/loopctl/repo/hnsw_index.ex (capability-based) or inline migration SQL; NONE specify m/ef_construction (grep finds no WITH (m/ef_construction) — all pgvector defaults m=16, ef_construction=64). articles.embedding: ONE index articles_embedding_hnsw_idx (vector_cosine_ops). memories.embedding: DUAL — memories_embedding_hnsw_idx (full, 20260709000100) + memories_live_embedding_hnsw_idx (partial WHERE superseded_by IS NULL, 20260709000300). The partial migration's comment says both coexist deliberately (full = historical incl. superseded; partial = live-only fast path).",
+    "includes": "CODE-ONLY, review-first: (a) evaluate whether tuning m/ef_construction (and query-time ef_search) improves recall/latency/build-cost enough to justify a reindex, and either apply it (online) or document why defaults stay; (b) confirm the memories dual-index is justified vs a single (partial) index — if the full index is rarely used (superseded rows seldom searched), dropping it saves build/maintenance cost. Any index change is an ONLINE migration and must not regress recall."
+  },
+  "story": {
+    "as_a": "loopctl operator whose vector corpus grows over time",
+    "i_want_to": "tune the HNSW index parameters where it measurably helps and confirm the memories.embedding dual index is warranted (dropping the redundant one if not)",
+    "so_that": "vector index build/maintenance cost and recall quality are deliberate engineering choices sized for scale, not unexamined pgvector defaults and an unquestioned duplicate index"
+  },
+  "rationale": "HNSW m/ef_construction trade build time + index size + recall; leaving them at defaults across a growing corpus is an unexamined scaling risk, and a dual HNSW index on one column doubles build/maintenance cost — worth confirming it earns its keep. A review-first story avoids churn: change parameters or drop an index only where evidence (recall/latency/usage) justifies it, with an online migration and a recall guard so nothing regresses.",
+  "acceptance_criteria": [
+    { "id": "AC-38.4.1", "description": "The HNSW parameters are made configurable/explicit (m, ef_construction on the index; ef_search at query time) via SystemConfig or the hnsw_index.ex builder — even if the chosen values equal the current defaults, they are now intentional and documented, not implicit. A test asserts the index/query builder uses the configured values.", "status": "pending" },
+    { "id": "AC-38.4.2", "description": "A documented evaluation of m/ef_construction/ef_search for loopctl's corpus (recall vs latency vs build/size) is captured (in the PR / a doc), and any change is applied via an ONLINE migration (CONCURRENTLY, @disable_ddl_transaction) on articles/memories. If defaults are kept, the rationale is documented. A recall test (nearest-neighbour quality on a fixture set) passes before and after — no recall regression.", "status": "pending" },
+    { "id": "AC-38.4.3", "description": "The memories.embedding dual-index is reviewed with evidence (is the full index — including superseded rows — actually queried, or do all live searches use the partial WHERE superseded_by IS NULL?). Outcome: EITHER keep both with a documented justification, OR drop the redundant one via an online migration if searches never need superseded rows. Whichever, semantic recall of LIVE memories is unchanged (test).", "status": "pending" },
+    { "id": "AC-38.4.4", "description": "Any migration is online and reversible-safe on the hot memories/articles tables (no write-blocking DDL, no long lock); a rollback path is noted. No behavior change beyond index tuning; query results (recall set) for a fixed fixture are equivalent before/after (test). No infra; purely DB/migration + config code.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-38.4.1", "name": "HNSW params are explicit/configurable", "type": "unit",
+      "preconditions": ["configured m/ef_construction/ef_search"],
+      "steps": ["build an index def / issue a vector query"],
+      "expected_results": ["the configured params are used (WITH (m=.., ef_construction=..); SET LOCAL hnsw.ef_search)"], "status": "pending" },
+    { "id": "TC-38.4.2", "name": "recall not regressed by tuning", "type": "integration",
+      "preconditions": ["fixture corpus with known nearest neighbours"],
+      "steps": ["run kNN before and after the tuning/migration"],
+      "expected_results": ["the expected neighbours are still returned (no recall regression)"], "status": "pending" },
+    { "id": "TC-38.4.3", "name": "live-memory recall unchanged after dual-index decision", "type": "integration",
+      "preconditions": ["memories with superseded + live rows"],
+      "steps": ["semantic recall of live memories"],
+      "expected_results": ["live recall identical regardless of the dual-index outcome"], "status": "pending" }
+  ],
+  "technical_notes": [
+    "Files: lib/loopctl/repo/hnsw_index.ex (parameterize m/ef_construction), the vector query path (VectorSearch / knowledge.ex / memory.ex — ef_search via SET LOCAL hnsw.ef_search), migrations under priv/repo/migrations for any reindex, SystemConfig for the params.",
+    "pgvector: index params via WITH (m = .., ef_construction = ..); query-time recall/latency via SET LOCAL hnsw.ef_search = .. (per-query, pgbouncer-safe). Reindex to change m/ef_construction (CREATE INDEX CONCURRENTLY new, drop old) — online.",
+    "Dual memories index: check actual query predicates — if every live search filters superseded_by IS NULL, the partial index serves them and the full index only matters for historical/superseded lookups (are there any?). Decide with evidence; drop only if truly redundant.",
+    "Review-FIRST: this story may legitimately conclude 'keep defaults / keep both' WITH documented justification — that is a valid outcome, not a non-fix. Any change must be online + recall-guarded.",
+    "No infra. Online migrations only. Config-based DI; no Application.put_env in tests."
+  ],
+  "dependencies": [],
+  "estimated_tokens": 400000
+}


### PR DESCRIPTION
## Summary

Authors the user stories for **Epic 38 — Horizontal Scaling Readiness**, the final roadmap epic (GH #353, tracked #355). Docs only, no code change.

### Decision: CODE-READINESS ONLY (Mark, 2026-07-15)
This epic builds the multi-node-safe code paths, **all flag/env-gated to today's single-node behavior**, with **zero infra provisioning and zero spend**. It's "not urgent at current node count" (the issue's words). Infra is **out of scope**, left as documented gated steps for when you scale: provision the Fly MPG read replica, set the `DNS_CLUSTER_QUERY` secret (code already wired), raise `scale count`, upgrade the MPG plan.

### Scope reconciliation (verified against master)
Already done, excluded: `DNS_CLUSTER_QUERY` code wiring (Epic 32), HeavyRead isolated pool (27/33), pgbouncer-safety (27/33), and — notably — **PubSub cross-node cache invalidation is already cluster-correct by design** (SettingsCache/ApiKeyCache: `broadcast_from` + node-local ETS bust + TTL backstop). Not re-scoped.

### Stories (genuinely-remaining code-only work)
- **US-38.1** — `REPLICA_DATABASE_URL` plumbing for HeavyReadRepo (defaults to the primary DSN when unset → zero change today) + a replica dimension in `DbCapacity`. Replica-ready in code, no replica needed.
- **US-38.2** — Cluster-global rate limiter: a **Postgres**-backed `RateLimiter` behind the existing behaviour (default stays node-local ETS), covering the web limiter *and* `Provider.Admission`. Closes the `limit × N` gap on scale-out. No Redis.
- **US-38.3** — Cluster-safe `SthEnqueuer` singleton (stop N nodes duplicating firehose enqueue) + a clustering-readiness verification/gate + the missing DNSCluster wiring test.
- **US-38.4** — HNSW `m`/`ef_construction` tuning (make params explicit/configurable) + a review of the `memories.embedding` dual HNSW index (keep-both-justified or drop-redundant), online migrations, recall-guarded.

### Constraints baked in
- Default = today's behavior exactly; every new capability is flag/env-gated OFF.
- No infra, no spend, no scaling; doesn't set `DNS_CLUSTER_QUERY` — never set a secret to a doc placeholder (epic_35 lesson).
- Online migrations only; recall not regressed; watch master Deploy + Smoke to green.

Next: `implement-plan` on the epic folder (WIP=1, review-gated). This closes out the scalability roadmap.
