### PR TITLE
Harness: thin-complement reframe + 3 domain skills + doc-aware gate

### DIFF
--- a/.claude/skills/chain-of-custody/SKILL.md
+++ b/.claude/skills/chain-of-custody/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: chain-of-custody
+description: Use when changing anything in loopctl's trust model — role requirements, the auth pipeline, story lifecycle transitions (report / review-complete / verify), capability tokens, dispatch lineage, WebAuthn/human-anchor gates, or the audit chain. Covers who may do what, why the self-* 409s are correct, and the capability/dispatch mechanics. Triggers on: chain of custody, self_report_blocked, self_review_blocked, self_verify_blocked, RequireRole, role hierarchy, capability token, dispatch, lineage, WebAuthn, human anchor, custody halt, superadmin, orchestrator, agent role, verify_story, report_story.
+---
+
+# Chain of Custody & Trust Model
+
+loopctl's core product guarantee: **nobody marks their own work as done.** An agent implements, an
+*independently-lineaged* verifier confirms. Weakening any custody gate is the single most dangerous
+change class here. Full spec: `docs/chain-of-custody-v2.md` (Epic 26). This skill is the code map +
+invariants — read the cited code and the spec before touching auth/custody.
+
+## Role hierarchy — `superadmin (4) > user (3) > orchestrator (2) > agent (1)`
+
+Ranks and `role_at_least?/2` live in `lib/loopctl/auth/role.ex:7-30`; enforcement is the
+`LoopctlWeb.Plugs.RequireRole` plug (`lib/loopctl_web/plugs/require_role.ex`). Higher roles inherit
+lower-role endpoints. Human-rooted operations additionally pass `RequireHumanAnchor`
+(`lib/loopctl_web/plugs/require_human_anchor.ex`, WebAuthn L0).
+
+**Where the line sits (CLAUDE.md "Security & Trust Model" checklist — the authority):**
+- `role: :user` (or WebAuthn): anything IRREVERSIBLE or that is itself a custody gate — tenant/project
+  delete, budget/token corrections, cost-anomaly resolution, audit-key rotation, break-glass, and the
+  irreversible **HARD** bulk KB delete.
+- `role: :orchestrator`: constructive/metadata work-breakdown (create/update epics, stories, deps,
+  imports, backfills) so an autonomous orchestrator composes projects without a human.
+- `role: :agent`: read work-breakdown only; **KB-content curation is the carve-out** — create/update/
+  soft-archive/resolve-conflict are agent-role because each is reversible + audited (see `knowledge-wiki`).
+
+Rule of thumb before lowering any role: *does this let one session both implement AND verify/report?*
+If yes, the change is wrong.
+
+## The self-* gates — the 409s are the system working
+
+Enforced in `lib/loopctl/progress.ex`, **lineage-first** (dispatch model), agent-id equality only as the
+pre-dispatch fallback:
+- **verify** — `validate_not_self_verify/2` `progress.ex:1613-1648`. Compares implementer vs verifier
+  **dispatch lineage** via `Dispatches.lineage_shares_prefix?/2`; a shared prefix ⇒ `:self_verify_blocked`.
+  A `nil` orchestrator identity is untrusted (`:1613`); a custody-orphaned story fails closed
+  (`:1626-1628`, "nil is never permissive").
+- **report** — `validate_not_self_report/2` `progress.ex:2107-2123`.
+- **review-complete** — `:self_review_blocked` `progress.ex:2154`.
+
+CLAUDE.md still phrases these as "409 if caller == assigned_agent_id" — that's the fallback branch
+(`progress.ex:1642`); the primary check is lineage-prefix, not id equality. **The MCP server must NEVER
+hold both an implementer and a reviewer key in one process** — the 409s are correct behavior; do not add
+a workaround.
+
+## Capability tokens (L1) — signed, scoped, single-use
+
+`lib/loopctl/capabilities.ex`:
+- `mint/4` (`:17-42`) — per-`(typ, story_id, lineage)` token (`start_cap` / `report_cap` / `verify_cap` /
+  `review_complete_cap`), signed, nonce'd, bounded TTL.
+- `verify/2` (`:52-69`) — type match + story match + **lineage exact match** + not-expired + not-consumed
+  + nonce exists.
+- `consume/1` (`:76-89`) — **atomic** `update_all ... where consumed_at IS NULL`; the `{0, _}` branch
+  returns `:replay`. This is the TOCTOU-safe single-use guard — never replace it with a read-then-write.
+
+## Dispatch lineage (L4) — structural verifier separation
+
+`lib/loopctl/dispatches.ex`: each dispatch carries a `lineage_path` (root → self);
+`lineage_shares_prefix?/2` (`:269-273`) is the primitive the self-verify check uses; `select_verifier/3`
+(`:288`) picks a verifier off the implementer's lineage. Ephemeral per-dispatch keys (minted via
+`POST /api/v1/dispatches`, MCP `dispatch` tool) replace long-lived env-var keys.
+
+## Anti-patterns
+
+- Lowering a role on a destructive/custody endpoint "for convenience" — re-check the CLAUDE.md checklist.
+- "Fixing" a `self_*_blocked` 409 by sharing keys or collapsing lineage — that defeats the product.
+- A capability `consume` that isn't the atomic conditional update — reintroduces replay.
+- New table in the audit/custody path without the hash-chain / DB CHECK backstops (`audit_chain/`).
+- Trusting a `nil` identity as permissive anywhere in custody — every gate fails closed on nil.
+
+## Related
+
+- **`tenancy-rls`** — custody writes/consume run on `AdminRepo`; every custody row is tenant-scoped.
+- **`knowledge-wiki`** — the KB-content carve-out (#331) is the one agent-role exception to archive/delete⇒:user.
+- Security review of a custody change: dispatch the global `security-adversary` agent.

--- a/.claude/skills/knowledge-wiki/SKILL.md
+++ b/.claude/skills/knowledge-wiki/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: knowledge-wiki
+description: Use when working on loopctl's knowledge/retrieval product — the shared Knowledge Wiki, agent memory, the context retriever, hybrid (curated + RAG) search, the novelty/dedup gate, embeddings, conflict resolution, or KB curation permissions. Covers the three agent information surfaces and how to pick between them. Triggers on: knowledge, wiki, knowledge_create, knowledge_search, hybrid_search, novelty, dedup, proposal gate, embedding, vector search, conflict, curation, memory_remember, memory_recall, retrieve_, context retriever, entity, RAG, progressive disclosure, OKF.
+---
+
+# Knowledge Wiki & Retrieval Surfaces
+
+The knowledge/retrieval stack is loopctl's product core (it *is* the second brain). It is large
+(`lib/loopctl/knowledge/` ≈ 40 modules) and split across three distinct agent-facing surfaces plus a
+hybrid retrieval capability. This skill routes you to the right surface and the load-bearing invariants;
+full references live in `docs/agent-memory.md`, `docs/context-retriever.md`,
+`docs/knowledge-hybrid-retrieval.md`. AGENTS.md carries the same three-surface routing for quick recall.
+
+## Three surfaces — pick by WHAT THE DATA IS
+
+| Surface | Module / tables | What it is | Pick when |
+|---------|-----------------|------------|-----------|
+| `retrieve_*` **Context Retriever** (Epic 30) | `Loopctl.ContextRetriever`, `entity_definitions` | governed, structured access to loopctl's own live rows (projects/stories/epics) | you'd query live operational state by a structured filter / full-text search |
+| `knowledge_*` **Knowledge Wiki** | `Loopctl.Knowledge` (`lib/loopctl/knowledge.ex`) | SHARED, curated tenant DOCUMENTS, deduped + linked | the insight is worth ANOTHER agent reading |
+| `memory_*` **Agent Memory** (Epic 28) | `Loopctl.Memory`, `memories`/`session_memories` | PRIVATE `(tenant, subject_id)` working memory | a fact only THIS agent needs to recall about its own work |
+
+Rule of thumb: *live structured business row?* → `retrieve_*`. *worth another agent reading?* →
+`knowledge_create`. *a fact only I need?* → `memory_remember`. Scope is **key-derived server-side** — you
+never pass `tenant_id`/`subject_id`.
+
+## Invariants (cited)
+
+1. **Novelty / dedup gate on create** — `Knowledge.propose_article/3` → `gate_proposal/4`
+   (`knowledge.ex:411-445`). `:duplicate` returns the canonical neighbor without creating; `:low_novelty`
+   is created but **forced to `status: "draft"`** with novelty stamped into `metadata.proposal_novelty`
+   (so a smarter consumer decides), and only `:novel`/`:unknown` proceed normally. The assessor is
+   config-injected (`Loopctl.Knowledge.ProposalGate`) — do not hardcode it.
+2. **Hybrid search provenance** — `Loopctl.Knowledge.hybrid_search/3`. `:curated` wins ONLY when a
+   governed curated source's **absolute** (never pool-relative) confidence clears a scale-matched
+   threshold AND beats the best retrieved candidate by a margin AND is authoritative
+   (not superseded/conflicted). Otherwise `:retrieved`. Both branches return identical `results`/`meta`
+   key sets — callers branch on `meta.provenance` alone. A sparse pool must never let a near-but-wrong
+   curated doc win.
+3. **All heavy KB reads route through `Loopctl.HeavyRead`** — semantic search, novelty, suggest-links,
+   distant-pairs, enumeration (`knowledge.ex:12`). See the `tenancy-rls` skill for the pool/pgbouncer
+   reasoning; never run these on `Repo`/`AdminRepo`.
+4. **KB-content curation is agent-role and reversible (#331)** — `knowledge_create`, `knowledge_update`
+   (ID-preserving in-place edit), `knowledge_archive`/`knowledge_delete` (soft delete → `status:
+   :archived`, row retained), and `knowledge_resolve_conflict` in all dispositions are agent-role because
+   each is reversible + audited. The one `:user`-gated exception is the **irreversible HARD bulk delete**.
+   Agent edits are visibility-scoped: an agent can only touch an article it can see. (See `chain-of-custody`.)
+
+## Anti-patterns
+
+- Writing a private, task-local fact via `knowledge_create` (pollutes shared KB) — use `memory_remember`.
+- Curating a live operational row into the wiki instead of exposing it via a Context Retriever entity.
+- Branching caller logic on which subsystem answered instead of `meta.provenance`.
+- Bypassing `propose_article`'s gate to force-create a near-duplicate.
+- A heavy vector read on `Repo`/`AdminRepo` (starves the admin pool) — route through `HeavyRead`.
+- Treating `hybrid_search` confidence as pool-relative — it is absolute, scale-matched, margin-gated.
+
+## Related
+
+- **`tenancy-rls`** — the `HeavyRead`/`HeavyReadRepo` pool every KB read uses; RLS scoping.
+- **`chain-of-custody`** — the role model and the #331 KB-content carve-out.
+- Ecto query composition behind `list_*`/search: the global `patterns-ecto` skill.

--- a/.claude/skills/tenancy-rls/SKILL.md
+++ b/.claude/skills/tenancy-rls/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: tenancy-rls
+description: Use when touching data access, tenant scoping, RLS policies, migrations, or the repo topology in loopctl — anything that reads/writes tenant-scoped rows, adds a table, or runs heavy analytical/vector reads. Covers the three Ecto repos (Repo/AdminRepo/HeavyReadRepo), the SET LOCAL RLS mechanism, the transaction-owner invariant, and the pgbouncer statement_timeout gotcha. Triggers on: tenant_id, RLS, row level security, with_tenant, set_rls_context, SET LOCAL, app.current_tenant_id, BYPASSRLS, AdminRepo, HeavyReadRepo, heavy read, statement_timeout, pgbouncer, migration, new table.
+---
+
+# Multi-Tenancy & Repo Topology
+
+loopctl isolates every tenant's data with PostgreSQL Row-Level Security. Getting the scoping
+mechanics wrong is a **cross-tenant data leak** — the highest-severity bug class in this codebase.
+This skill is pointers + invariants, not restated logic; read the cited code before changing it.
+
+## The three repos — pick by intent
+
+| Repo | Role | RLS | Use for |
+|------|------|-----|---------|
+| `Loopctl.Repo` (`lib/loopctl/repo.ex`) | tenant-scoped app queries | **enforced** (RLS role, no BYPASSRLS) | everything a tenant does |
+| `Loopctl.AdminRepo` (`lib/loopctl/admin_repo.ex`) | cross-tenant superadmin ops | BYPASSRLS | superadmin API, custody writes, capability consume |
+| `Loopctl.HeavyReadRepo` (`lib/loopctl/heavy_read_repo.ex`) | heavy analytical/vector reads | BYPASSRLS, own pool | semantic search, novelty, suggest-links, distant-pairs |
+
+CLAUDE.md's "Two Repos" line predates `HeavyReadRepo` (US-27.11) — there are **three**. Never route a
+heavy vector/enumeration read through `AdminRepo`: that shares a tiny 3-connection pool with every
+other admin op and three concurrent heavy reads starve it (`heavy_read_repo.ex:5-17`). Route heavy
+reads through `Loopctl.HeavyRead` (`lib/loopctl/heavy_read.ex`), which owns the `HeavyReadRepo` pool.
+
+## Invariants (must hold — cited)
+
+1. **`with_tenant/2` must OWN its transaction** — `repo.ex:95-118`. The RLS context is set with
+   `SET LOCAL app.current_tenant_id` / `SET LOCAL ROLE`, which are transaction-scoped. If `with_tenant`
+   runs *inside* an existing transaction, its `SET LOCAL` lands in a SAVEPOINT and **persists past the
+   savepoint into the outer transaction** — overriding the outer tenant/role for the rest of its life
+   (a cross-tenant / role leak). `assert_not_nested!/0` (`repo.ex:110-118`) fails loud to prevent it.
+   Inside an enclosing transaction, call `Repo.set_rls_context/1` (`repo.ex:132-142`) directly instead.
+2. **RLS context = `set_config('app.current_tenant_id', $1, true)`** — `repo.ex:133-138`. In dev/test the
+   connection is a superuser, so `maybe_set_local_role/0` (`repo.ex:152-160`) additionally `SET LOCAL ROLE`
+   to a non-superuser (`:rls_role`) so policies actually apply; prod connects as a non-superuser natively.
+3. **New tables: `ENABLE ROW LEVEL SECURITY`, never `FORCE`** — the prod role (`schema_admin`) owns the
+   tables without BYPASSRLS, so `ENABLE` already applies to it; `FORCE` would also gate the admin paths.
+   (CLAUDE.md "Multi-Tenant Rules" #4.)
+4. **`tenant_id` is set programmatically, never in `cast`** — set it on the struct, keep it out of every
+   changeset's `cast` allowlist (CLAUDE.md "Multi-Tenant Rules" #4; mirrors the Ecto convention in
+   AGENTS.md). A user-supplied `tenant_id` in params must never win.
+5. **Every context function takes `tenant_id` as its first argument**, and every tenant-scoped test
+   includes a "tenant A cannot see tenant B" isolation case (CLAUDE.md #2/#5).
+
+## The pgbouncer gotcha (US-27.13 — production outage, do not regress)
+
+`HeavyReadRepo` enforces a server-side `statement_timeout` **per-read via `SET LOCAL` inside the
+transaction** (`heavy_read.ex:387-418`, `heavy_read_repo.ex:19-30`) — NOT as a connection startup
+`:parameters` value. Fly MPG fronts Postgres with **pgbouncer**, which rejects a `statement_timeout`
+startup parameter with `FATAL 08P01 unsupported startup parameter`, crash-looping the whole pool so it
+never connects. If you need any per-connection GUC on a pgbouncer-fronted pool, apply it with `SET LOCAL`
+inside a transaction, never via `:parameters`.
+
+## Anti-patterns
+
+- Calling `Loopctl.Repo.with_tenant/2` from inside another `Repo.transaction` — raises by design; use
+  `set_rls_context/1` in the enclosing transaction.
+- Reaching for `AdminRepo` "because RLS is in the way." If a tenant query can't see its own rows, the
+  tenant context isn't set — fix the `with_tenant` boundary, don't bypass RLS.
+- A heavy vector/semantic/enumeration read on `Repo` or `AdminRepo` instead of `HeavyRead`.
+- Adding `statement_timeout` (or any GUC) to a repo's `:parameters` — pgbouncer 08P01.
+- A migration that creates a tenant-scoped table without a `tenant_id` column + RLS policy.
+
+## Related
+
+- **`chain-of-custody`** — custody writes/consume run on `AdminRepo`; roles gate who may write.
+- **`knowledge-wiki`** — all heavy KB reads route through `HeavyRead`/`HeavyReadRepo`.
+- Deep Ecto/OTP mechanics: the global `patterns-ecto` / `patterns-elixir-otp` skills.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Repo-local pre-commit — DOC-AWARE quality gate.
+#
+# Replaces the machine-global mix-precommit hook for THIS repo's checkout
+# (activate with: git config core.hooksPath .githooks). It keeps the FULL gate
+# for code, but for a docs/harness-only commit (CLAUDE.md, .claude/**, *.md) it
+# runs a light leak scan instead of the whole Elixir toolchain + Dialyzer + a
+# test DB. It NEVER bypasses: any staged Elixir source runs the real
+# `mix precommit`, exactly as CI does.
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+if [ -n "${GIT_COMMIT_NO_VERIFY:-}" ]; then
+  echo "❌ Pre-commit bypass detected — fix the issues instead."; exit 1
+fi
+
+STAGED=$(git diff --cached --name-only --diff-filter=ACM)
+[ -z "$STAGED" ] && exit 0
+
+# --- Code staged? -> full mix precommit (the same gate CI runs) ---------------
+if echo "$STAGED" | grep -qE '\.(ex|exs|heex|eex)$'; then
+  echo "🔍 code change detected — running full mix precommit"
+  if [ -f "/usr/local/opt/asdf/libexec/asdf.sh" ]; then source /usr/local/opt/asdf/libexec/asdf.sh
+  elif [ -f "$HOME/.asdf/asdf.sh" ]; then source "$HOME/.asdf/asdf.sh"; fi
+  exec mix precommit
+fi
+
+# --- Docs/harness-only -> light gate: secret/leak scan on ADDED lines ---------
+echo "🔍 docs-only commit — skipping mix precommit; leak-scanning staged additions"
+LEAK_RE='(AKIA[0-9A-Z]{16}|-----BEGIN [A-Z ]*PRIVATE KEY-----|xox[baprs]-[0-9A-Za-z-]{10,}|gh[pousr]_[0-9A-Za-z]{20,}|eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,})'
+ADDED=$(git diff --cached --unified=0 -- $STAGED | grep '^+' | grep -v '^+++' || true)
+if printf '%s\n' "$ADDED" | grep -InE "$LEAK_RE" >/dev/null 2>&1; then
+  echo "❌ leak scan: a possible secret was added — remove it before committing:"
+  printf '%s\n' "$ADDED" | grep -InE "$LEAK_RE" | head -5
+  exit 1
+fi
+
+echo "✅ docs-only pre-commit passed (leak scan clean)"
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,21 @@ Refer to `docs/design-system.md` for full specifications. Key points:
 
 ---
 
+## Load Orchestration State on Every Session Start
+
+Load the orchestration protocol and build status from memory-keeper at the start of every conversation:
+
+```
+mcp__memory-keeper__context_get({ key: "CRITICAL_ALWAYS_READ_FIRST_PRINCIPLES", channel: "loopctl" })
+mcp__memory-keeper__context_get({ key: "build_status", channel: "loopctl" })
+```
+
+These hold the orchestration loop rules (you are READ-ONLY on code, you dispatch agents), current build
+progress (which epics/stories are done), architectural decisions made during implementation, and the DI /
+fixture / mock patterns to enforce. Load and read both before starting implementation work.
+
+---
+
 ## Agents, workflow, and domain routing
 
 This is a **thin, repo-specific** layer. The Elixir engineering roster, thinking/pattern skills, and
@@ -215,10 +230,11 @@ mix ecto.reset         # Drop, create, migrate
 ## Key Documents
 
 - **PRD**: `docs/prd.md` — full product requirements
-- **User Stories**: `docs/user_stories/epic_N_name/us_N.M.json` — 200+ stories across 36 epics
-- **Skills**: `skills/loopctl-*.md` — 6 orchestration skills
+- **User Stories**: `docs/user_stories/epic_N_name/us_N.M.json` — one JSON file per story, grouped by epic folder
+- **Skills**: `skills/loopctl-*.md` — orchestration skills
 - **Orchestration Guide**: `docs/orchestration-guide.md` — methodology: loop, trust model, checkpointing
-- **MCP Server**: `mcp-server/` — 87 typed tools for Claude Code agents (no curl needed), published as `loopctl-mcp-server` on npm
+- **Build Status**: memory-keeper key `build_status`, channel `loopctl`
+- **MCP Server**: `mcp-server/` — typed tools for Claude Code agents (no curl needed), published as `loopctl-mcp-server` on npm
 
 ## MCP Server
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,22 +19,26 @@ Refer to `docs/design-system.md` for full specifications. Key points:
 
 ---
 
-## CRITICAL: Load Orchestration State on Every Session Start
+## Agents, workflow, and domain routing
 
-**YOU MUST** load the orchestration protocol and build status from memory-keeper at the start of every conversation:
+This is a **thin, repo-specific** layer. The Elixir engineering roster, thinking/pattern skills, and
+review/ship pipelines live in the machine-global `~/.claude` and are used by name — this file does not
+re-declare them:
 
-```
-mcp__memory-keeper__context_get({ key: "CRITICAL_ALWAYS_READ_FIRST_PRINCIPLES", channel: "loopctl" })
-mcp__memory-keeper__context_get({ key: "build_status", channel: "loopctl" })
-```
+- **Agents:** `elixir-engineer` (implement/fix), `elixir-systems-architect` (design/OTP review),
+  `elixir-test-writer` (ExUnit/TDD), `security-adversary` (custody/security pass), `business-analyst`.
+- **Workflow:** `/review:enhanced-review-workflow` (stack-aware review gate), `implement-plan`
+  (epic → implement → review → merge). Pattern skills: `patterns-ecto`, `patterns-elixir-otp`,
+  `patterns-phoenix-web`, and the `elixir:*-thinking` skills.
 
-These contain:
-- The orchestration loop rules (you are READ-ONLY on code, you dispatch agents)
-- Current build progress (which epics/stories are done)
-- Architectural decisions made during implementation
-- The DI, fixture, and mock patterns to enforce
+Repo-specific domain skills (grounded at `file:line` in the code) — load the matching one before working
+in that area:
 
-**Do NOT proceed with any implementation work until you have loaded and read both keys.**
+| When you touch… | Skill |
+|-----------------|-------|
+| tenant scoping, RLS, migrations, repo choice, heavy/vector reads | `.claude/skills/tenancy-rls` |
+| roles, auth pipeline, story lifecycle, capabilities, dispatch lineage, WebAuthn | `.claude/skills/chain-of-custody` |
+| the wiki, agent memory, context retriever, hybrid search, novelty, curation | `.claude/skills/knowledge-wiki` |
 
 ---
 
@@ -56,8 +60,17 @@ lib/loopctl/
 ├── skills/            # Skill versioning and performance
 ├── quality_assurance/ # UI test runs and findings (project-level QA)
 ├── token_usage/       # Token consumption tracking, budgets, cost anomalies
+├── knowledge/         # Knowledge Wiki: articles, embeddings, novelty gate, hybrid search, curation
+├── memory/            # Agent Memory: private per-agent long_term + session memory
+├── context_retriever/ # Governed structured access to live rows (retrieve_* / entities)
+├── capabilities/      # Signed, single-use capability tokens (custody L1)
+├── dispatches/        # Per-dispatch ephemeral keys + lineage (custody L4)
+├── audit_chain/       # Hash-chained append-only audit log
+├── llm/               # LLM provider clients + config
+├── verification/      # Independent re-execution (custody L3)
 ├── schema.ex          # Base schema macro
-└── repo.ex            # Ecto Repo
+├── repo.ex            # RLS-enforced Ecto Repo (also admin_repo.ex, heavy_read_repo.ex)
+└── heavy_read.ex      # Heavy/vector read path on the dedicated HeavyReadRepo pool
 
 lib/loopctl_web/
 ├── controllers/       # JSON API controllers
@@ -83,7 +96,7 @@ lib/loopctl_web/
 3. **EVERY** query is scoped by RLS policies (SET LOCAL per transaction)
 4. `tenant_id` is **NEVER** in changeset `cast` — always set programmatically
 5. **EVERY** test includes a tenant isolation test case
-6. Two Repos: `Loopctl.Repo` (RLS enforced) and `Loopctl.AdminRepo` (BYPASSRLS for superadmin)
+6. Three Repos: `Loopctl.Repo` (RLS enforced) and `Loopctl.AdminRepo` (BYPASSRLS for superadmin), plus `Loopctl.HeavyReadRepo` (BYPASSRLS, dedicated pool for heavy analytical/vector reads via `Loopctl.HeavyRead` — US-27.11). RLS mechanics and the `with_tenant/2` transaction-owner invariant: `.claude/skills/tenancy-rls`.
 
 ## Security & Trust Model — Mandatory Review Checklist
 
@@ -102,12 +115,14 @@ Higher roles can access lower-role endpoints. The hierarchy is enforced by `Requ
 
 ### Chain-of-Custody Enforcement
 
-The API enforces that nobody marks their own work as done:
-- `POST /stories/:id/report` — `409 self_report_blocked` if caller == assigned_agent_id
-- `POST /stories/:id/review-complete` — `409 self_review_blocked` if caller == assigned_agent_id
-- `POST /stories/:id/verify` — `409 self_verify_blocked` if caller == assigned_agent_id
+The API enforces that nobody marks their own work as done. The check is **dispatch-lineage first**
+(shared lineage prefix between implementer and actor ⇒ blocked), with `assigned_agent_id` equality as the
+pre-dispatch fallback, and it fails closed on a `nil` identity (`lib/loopctl/progress.ex`):
+- `POST /stories/:id/report` — `409 self_report_blocked`
+- `POST /stories/:id/review-complete` — `409 self_review_blocked`
+- `POST /stories/:id/verify` — `409 self_verify_blocked`
 
-**The MCP server must NEVER hold both implementer and reviewer keys in the same process.** The 409 errors are the system working correctly — do not add workarounds.
+**The MCP server must NEVER hold both implementer and reviewer keys in the same process.** The 409 errors are the system working correctly — do not add workarounds. Full model: `.claude/skills/chain-of-custody`.
 
 ### Before Changing Any Role Requirement
 
@@ -184,7 +199,8 @@ Opts are for query parameters (limit, offset, filters) only.
 ## Run Commands
 
 ```bash
-mix precommit          # Full quality gate (compile, format, credo --strict, dialyzer, test)
+mix precommit          # Full quality gate: compile --warnings-as-errors, deps.unlock --check-unused,
+                       # format --check-formatted, credo --strict, deps.audit, dialyzer, test
 mix test               # Run all tests
 mix test --failed      # Re-run failed tests
 mix ecto.reset         # Drop, create, migrate
@@ -199,11 +215,10 @@ mix ecto.reset         # Drop, create, migrate
 ## Key Documents
 
 - **PRD**: `docs/prd.md` — full product requirements
-- **User Stories**: `docs/user_stories/epic_N_name/us_N.M.json` — 60 stories across 15 epics
+- **User Stories**: `docs/user_stories/epic_N_name/us_N.M.json` — 200+ stories across 36 epics
 - **Skills**: `skills/loopctl-*.md` — 6 orchestration skills
 - **Orchestration Guide**: `docs/orchestration-guide.md` — methodology: loop, trust model, checkpointing
-- **MCP Server**: `mcp-server/` — 84 typed tools for Claude Code agents (no curl needed), published as `loopctl-mcp-server` on npm
-- **Build Status**: memory-keeper key `build_status`, channel `loopctl`
+- **MCP Server**: `mcp-server/` — 87 typed tools for Claude Code agents (no curl needed), published as `loopctl-mcp-server` on npm
 
 ## MCP Server
 
@@ -213,11 +228,11 @@ Claude Code agents should use the loopctl MCP tools instead of curl. Install via
 {"mcpServers": {"loopctl": {"command": "npx", "args": ["loopctl-mcp-server"], "env": {"LOOPCTL_SERVER": "https://loopctl.com", "LOOPCTL_ORCH_KEY": "...", "LOOPCTL_AGENT_KEY": "..."}}}}
 ```
 
-Tools: `mcp__loopctl__list_projects`, `mcp__loopctl__list_stories`, `mcp__loopctl__verify_story`, etc. (84 total). See `mcp-server/README.md` for the full list.
+Tools: `mcp__loopctl__list_projects`, `mcp__loopctl__list_stories`, `mcp__loopctl__verify_story`, etc. (87 total). See `mcp-server/README.md` for the full list.
 
 ---
 
-## Epic 17: Orchestrator Observability
+## Orchestrator Observability
 
 loopctl supports external observability tooling through its API and data model:
 
@@ -234,81 +249,15 @@ loopctl supports external observability tooling through its API and data model:
   start/end, rule violations, review outcomes) and query them back via the audit API. This allows
   post-run analysis of orchestrator behavior without coupling to any specific AI tool's log format.
 
-## Epic 28: Agent Memory — `memory_*` vs `knowledge_*`
+## Agent information surfaces (three) — memory vs knowledge vs retrieve
 
-loopctl gives agents a **private per-agent memory** subsystem (`Loopctl.Memory`,
-tables `memories` / `session_memories`) that is DISTINCT from the shared Knowledge
-Wiki. Full reference: [`docs/agent-memory.md`](docs/agent-memory.md). Pick the
-right surface:
-
-- **`memory_*` (Agent Memory)** — PRIVATE to the caller's `(tenant, subject_id)`
-  scope. Use for facts/preferences/observations THIS agent learned about ITS task
-  or user and needs to recall later — not worth curating for others. `long_term`
-  facts are vector-embedded + semantically recalled; `session` turns are
-  chronological + TTL-pruned. Tools: `memory_remember`, `memory_recall`,
-  `memory_list`, `memory_forget`.
-- **`knowledge_*` (Knowledge Wiki)** — SHARED, curated tenant knowledge (patterns,
-  decisions, findings, references), deduped by the novelty gate, linked and
-  conflict-resolved. Use when the insight is worth ANOTHER agent reading. Tools:
-  `knowledge_create`, `knowledge_search`, etc.
-
-Rule of thumb: *"worth another agent reading?"* → `knowledge_create`. *"a fact only
-I need to recall about my own work?"* → `memory_remember`. Scope is derived from
-your key server-side — you never pass `tenant_id`/`subject_id`. loopctl is
-agent-native (no memory UI); operator oversight is the superadmin API path.
-
-## Epic 30: Context Retriever — three surfaces (`retrieve_*` vs `knowledge_*` vs `memory_*`)
-
-Epic 30 adds a THIRD agent information surface (`Loopctl.ContextRetriever`, tables
-`entity_definitions`) alongside the Knowledge Wiki and Agent Memory. Full
-reference: [`docs/context-retriever.md`](docs/context-retriever.md). Pick by what
-the data IS:
-
-- **`retrieve_*` (Context Retriever)** — GOVERNED, structured access to loopctl's
-  own live rows (`projects`/`stories`/`epics`). A tenant admin declares an
-  **entity** (typed, server-allowlisted fields) over `/api/v1/entities`; the
-  generator emits per-entity `cr_filter_*`/`cr_search_*` tools (dynamic,
-  per-tenant, appended to ListTools from `GET /api/v1/retrieve/tools`); a `cr_*`
-  call dispatches to `POST /api/v1/retrieve/:entity`. Every query is
-  parameterized (no model SQL), dual tenant-scoped (RLS `loopctl_app` role +
-  explicit predicate), execute-time allowlist-rechecked, shaped to declared
-  columns only, audited (fail-closed), and rate-limited. Use when you'd query
-  live operational state by a structured filter or full-text search.
-- **`knowledge_*` (Knowledge Wiki)** — SHARED, curated tenant DOCUMENTS. Use when
-  the insight is worth another agent reading.
-- **`memory_*` (Agent Memory)** — PRIVATE `(tenant, subject_id)` working memory.
-  Use for facts only THIS agent needs to recall about its own work.
-
-Rule of thumb: *live structured business row?* → `retrieve_*`. *worth another
-agent reading?* → `knowledge_create`. *a fact only I need?* → `memory_remember`.
-Defining an entity is a security root (role ≥ `user` + human-anchor); querying is
-authenticated-only. You never pass `tenant_id` — scope is key-derived.
-
-## Epic 31: Hybrid (curated + RAG) Knowledge Retrieval
-
-Epic 31 adds a **capability of the Knowledge Wiki layer** — not a fourth agent
-surface — that resolves a query to EITHER a governed **curated** answer OR a
-semantic/keyword **retrieval** result, on one uniform shape carrying
-`meta.provenance` (`:curated`/`:retrieved`). Full reference:
-[`docs/knowledge-hybrid-retrieval.md`](docs/knowledge-hybrid-retrieval.md).
-
-- **`Loopctl.Knowledge.hybrid_search/3`** (`knowledge_hybrid_search` tool /
-  `POST /api/v1/knowledge/hybrid_search`) — `:curated` wins ONLY when a governed
-  curated source's ABSOLUTE (never pool-relative) confidence score clears a
-  scale-matched threshold AND beats the best retrieved candidate by a margin AND
-  is authoritative (not superseded/conflicted). Otherwise `:retrieved` — a
-  near-but-wrong curated doc NEVER wins by default just because a pool is
-  sparse. Both branches share identical `results`/`meta` key sets — callers
-  branch on `meta.provenance` alone, never on which subsystem answered.
-- **Progressive disclosure** (`knowledge_progressive_index` /
-  `knowledge_progressive_drill`, `GET /api/v1/knowledge/progressive_index` /
-  `GET /api/v1/knowledge/progressive/:id`) — a cheap, top-K-capped, curated-
-  preferred topic browse (compact stubs, no bodies) with one hop of `:relates_to`
-  hub enrichment, then a full-body drill into a chosen stub. A fuzzy/paraphrased
-  topic can miss a lexically-dissimilar curated article — use `hybrid_search/3`
-  when you need the governed provenance decision instead.
-- **#305/#306 are the same feature** (this epic implements both) — recommend
-  closing one as a duplicate of the other rather than tracking them separately.
+loopctl exposes three distinct agent-facing information surfaces plus a hybrid retrieval capability.
+Pick by **what the data is**: a private fact only this agent needs (`memory_*`), a shared document worth
+another agent reading (`knowledge_*`), or a governed query over loopctl's own live rows (`retrieve_*`).
+The routing rules, the novelty/dedup gate, hybrid-search provenance, and the KB-content curation
+carve-out are grounded and cited in **`.claude/skills/knowledge-wiki`**; AGENTS.md carries the same
+quick-reference routing. Full references: `docs/agent-memory.md`, `docs/context-retriever.md`,
+`docs/knowledge-hybrid-retrieval.md`.
 
 ## Elixir / Phoenix guidelines
 


### PR DESCRIPTION
## What

Reshapes the existing CLAUDE.md into a **thin, repo-specific layer** that defers to the machine-global `~/.claude` Elixir toolset by name (no roster/pipelines re-declared), adds 3 code-grounded domain skills, and refreshes drift. Docs/harness-only; no application code touched.

## Changes

**CLAUDE.md**
- Thin-complement reframe: defer to global `elixir-engineer`/`-systems-architect`/`-test-writer`/`security-adversary`/`business-analyst`, `/review:enhanced-review-workflow`, `implement-plan`, `patterns-*` + `elixir:*-thinking` — plus a domain routing table to the new skills.
- **memory-keeper orchestration preserved**: the session-start `context_get` protocol (`CRITICAL_ALWAYS_READ_FIRST_PRINCIPLES` + `build_status`) and the Build Status key reference are kept (memory-keeper is part of the standard toolbox).
- Module map expanded to the real dirs (`knowledge/`, `memory/`, `context_retriever/`, `capabilities/`, `dispatches/`, `audit_chain/`, `llm/`, `verification/`, `heavy_read.ex`).
- **Three** Repos, not two: adds `Loopctl.HeavyReadRepo` (BYPASSRLS heavy/vector pool, US-27.11).
- Chain-of-custody made accurate: **dispatch-lineage-first** check (`lib/loopctl/progress.ex`), not just `assigned_agent_id` equality; fails closed on `nil` identity.
- Gate: `mix precommit`'s real steps spelled out (compile `--warnings-as-errors`, `deps.unlock --check-unused`, format, `credo --strict`, `deps.audit`, dialyzer, test).
- **De-numbered volatile counts** (story/epic totals, skill count, tool count) — in-flight planning numbers are rot sources, not facts worth keeping accurate. Structure and pointers stay.

**3 new domain skills** (`.claude/skills/`, grounded at `file:line`, pointers + invariants + anti-patterns):
- `tenancy-rls` — RLS, the `with_tenant/2` transaction-owner invariant (`repo.ex:95`), the three repos, the heavy/vector read path.
- `chain-of-custody` — the self-report/review/verify 409 model, dispatch lineage, capability tokens, WebAuthn, hash-chained audit.
- `knowledge-wiki` — the wiki engine (`lib/loopctl/knowledge/*`): articles, embeddings/hybrid search, novelty gate, agent memory, context retriever, curation.

**.githooks/pre-commit** — doc-aware gate: full `mix precommit` when Elixir source is staged, a light secret/leak scan for docs-only commits. Activate with `git config core.hooksPath .githooks`.

## How it was produced

Ran the `claude-harness-kit` appraisal engine against the code (thin-complement mode); every new skill's citations were human-verified against the repo. Docs-only → gate string-verified, not executed; CI runs the real gate.
