### PR TITLE
Cluster-safe SthEnqueuer singleton + clustering-readiness verification gate + DNSCluster test

### DIFF
--- a/docs/user_stories/epic_38_scaling_readiness/README.md
+++ b/docs/user_stories/epic_38_scaling_readiness/README.md
@@ -81,15 +81,47 @@ silent split-brain, not a hard failure — hence this documented gate + boot WAR
 
 **The signal.** `Loopctl.ClusterReadiness.readiness/0` returns a bounded, no-node-name
 map: `%{dns_cluster_query_configured, peers, expected_nodes, status}` where `status`
-is `:single_node` (clustering not required — `EXPECTED_APP_NODES <= 1` or
-`DNS_CLUSTER_QUERY` unset), `:clustered` (configured + expected peers connected), or
-`:expected_peers_missing` (configured + `EXPECTED_APP_NODES > 1` but too few peers).
+is one of:
+
+- `:single_node` — clustering not required: `EXPECTED_APP_NODES <= 1`, OR
+  `DNS_CLUSTER_QUERY` unset with `EXPECTED_APP_NODES` at/below the default (2). At the
+  default count a forgotten `DNS_CLUSTER_QUERY` is indistinguishable from "never
+  intended to cluster", so it stays quiet.
+- `:clustered` — configured + expected peers connected.
+- `:expected_peers_missing` — configured + `EXPECTED_APP_NODES > 1` but too few peers.
+- `:clustering_expected_dns_unconfigured` — `EXPECTED_APP_NODES` explicitly raised
+  ABOVE the default (`> 2`) but `DNS_CLUSTER_QUERY` UNSET. This is the "count bumped
+  but clustering forgotten" case: the node runs un-clustered and, unlike
+  `:expected_peers_missing`, will NOT self-clear (peers can never connect until DNS is
+  set). **Detection limit:** at the DEFAULT count (2) this case is indistinguishable
+  from a normal single-node deploy and reports `:single_node` — so the ONLY guaranteed
+  guard against silently-un-clustered is *set `DNS_CLUSTER_QUERY` FIRST* (step 1
+  below), before raising the count. This status catches the raised-count-plus-forgotten
+  -DNS slice; it does not substitute for setting DNS first.
+
 It is also exported as the `loopctl.cluster.peers.count` Prometheus gauge (tagged by
 `status`, on the internal `:9568/metrics` port — no node names, no query string).
 
 **Boot WARN.** On prod boot, `Loopctl.ClusterReadiness.warn_if_expected_peers_missing/0`
-logs a WARNING when `EXPECTED_APP_NODES > 1` but `Node.list/0` is empty (running
-un-clustered). It is a WARN + this runbook, NOT a crash.
+logs a WARNING on the two un-clustered classifications and an INFO otherwise:
+`:expected_peers_missing` (clustering configured — `DNS_CLUSTER_QUERY` set — AND
+`EXPECTED_APP_NODES > 1` yet `Node.list/0` shows too few peers) and
+`:clustering_expected_dns_unconfigured` (`EXPECTED_APP_NODES` above the default of 2
+but `DNS_CLUSTER_QUERY` forgotten — its WARN names the "set `DNS_CLUSTER_QUERY` first"
+guard and that it will not self-clear). It is DNS-aware and mirrors `readiness/0`, so
+the standard single-node prod deploy (`DNS_CLUSTER_QUERY` unset, default
+`EXPECTED_APP_NODES` 2, no peers → `:single_node`) does NOT warn. It is a WARN + this
+runbook, NOT a crash.
+
+> **Boot-time transient — do not chase a lone boot WARN.** The boot check samples
+> `Node.list/0` ONCE, synchronously, at the end of `Application.start/2`, but
+> `DNSCluster` connects peers a few seconds LATER (its periodic DNS poll). So on a
+> genuinely-healthy multi-node deploy this WARN can fire briefly on each node during
+> the startup window before peers connect, then self-clear. The reliable
+> steady-state signal is the 10s-polled `loopctl.cluster.peers.count{status}` gauge
+> (and `readiness/0.status`), NOT this point-in-time boot line. Only a **persistent**
+> `:expected_peers_missing` on the gauge is a real alarm; a boot WARN that clears
+> within the first poll cycle is the expected transient.
 
 **Steps to scale past 1 machine (gated, infra — Mark's hands, out of Epic 38's code scope):**
 

--- a/docs/user_stories/epic_38_scaling_readiness/README.md
+++ b/docs/user_stories/epic_38_scaling_readiness/README.md
@@ -68,3 +68,47 @@ The **genuinely-remaining CODE-ONLY** work:
 - Env-driven knobs via `SystemConfig`/config-based DI; assert outcome classes,
   not timing (async-suite flake lesson); watch master **Deploy + Post-deploy
   Smoke** to green (runtime.exs env changes only fail at release boot).
+
+## Runbook: verify clustering before scaling (US-38.3)
+
+`fly scale count > 1` MUST be preceded by verifying BEAM clustering is GREEN.
+Without clustering, PubSub is node-local: cross-node cache invalidation still works
+(TTL-backstopped, cluster-correct by design — see the scope table above), but the
+`SthEnqueuer` cluster singleton and the shared rate limiter only behave correctly
+once the nodes actually form a cluster. Running multiple machines UN-clustered is a
+silent split-brain, not a hard failure — hence this documented gate + boot WARN
+(loopctl never crash-enforces it; a single node must always boot).
+
+**The signal.** `Loopctl.ClusterReadiness.readiness/0` returns a bounded, no-node-name
+map: `%{dns_cluster_query_configured, peers, expected_nodes, status}` where `status`
+is `:single_node` (clustering not required — `EXPECTED_APP_NODES <= 1` or
+`DNS_CLUSTER_QUERY` unset), `:clustered` (configured + expected peers connected), or
+`:expected_peers_missing` (configured + `EXPECTED_APP_NODES > 1` but too few peers).
+It is also exported as the `loopctl.cluster.peers.count` Prometheus gauge (tagged by
+`status`, on the internal `:9568/metrics` port — no node names, no query string).
+
+**Boot WARN.** On prod boot, `Loopctl.ClusterReadiness.warn_if_expected_peers_missing/0`
+logs a WARNING when `EXPECTED_APP_NODES > 1` but `Node.list/0` is empty (running
+un-clustered). It is a WARN + this runbook, NOT a crash.
+
+**Steps to scale past 1 machine (gated, infra — Mark's hands, out of Epic 38's code scope):**
+
+1. Set the `DNS_CLUSTER_QUERY` Fly secret (the `<app>.internal` 6PN query) — the code
+   is already wired (`application.ex`, `runtime.exs`); this story does NOT set it.
+2. Set `EXPECTED_APP_NODES` to the target machine count so the readiness signal and
+   the `DbCapacity` connection-budget check reflect it.
+3. Deploy, then confirm clustering is GREEN: `readiness/0.status == :clustered` (or
+   the `loopctl.cluster.peers.count{status="clustered"}` gauge shows the expected
+   peers) and NO `expected_peers_missing` boot WARN in the logs.
+4. Only then raise `fly scale count`. If the readiness signal is
+   `:expected_peers_missing`, clustering is not formed — fix DNS clustering before
+   scaling, or you are running node-local PubSub across N machines.
+
+### DNSCluster wiring (verified by test)
+
+`DNSCluster` is a child in `Loopctl.Application`'s supervision tree
+(`{DNSCluster, query: Application.get_env(:loopctl, :dns_cluster_query) || :ignore}`),
+and `:dns_cluster_query` resolves from the `DNS_CLUSTER_QUERY` env in `runtime.exs`
+(unset → `nil` → `:ignore`, so `DNSCluster` runs inert with no process started). This
+is asserted by `test/loopctl/cluster_readiness_test.exs` so the wiring can't silently
+regress. `DNS_CLUSTER_QUERY` is NOT set by this story.

--- a/lib/loopctl/application.ex
+++ b/lib/loopctl/application.ex
@@ -35,11 +35,14 @@ defmodule Loopctl.Application do
       # with no other dependency.
       Loopctl.RateLimiter.FailOpenLog,
       {Oban, Application.fetch_env!(:loopctl, Oban)},
-      # US-35.2: supervised, node-local singleton that subscribes to the fixed
-      # audit-chain firehose topic and debounce-enqueues one ComputeSthWorker job
-      # per tenant that appends, making STH computation event-driven and
-      # activity-gated. After PubSub (it subscribes in init) and Oban (it inserts
-      # jobs). Purely additive — the per-minute cron is unchanged.
+      # US-35.2 / US-38.3: supervised, CLUSTER-WIDE singleton (leadership via
+      # :global, negotiated in init) that subscribes to the fixed audit-chain
+      # firehose topic and debounce-enqueues one ComputeSthWorker job per tenant
+      # that appends, making STH computation event-driven and activity-gated.
+      # Every node keeps a live process, but exactly ONE (the leader) drains the
+      # firehose cluster-wide; the rest stand by and fail over on leader death.
+      # After PubSub (the leader subscribes in init) and Oban (it inserts jobs).
+      # Purely additive — the per-minute cron is unchanged.
       Loopctl.AuditChain.SthEnqueuer,
       # US-37.5: owns the public ETS table holding the per-tenant in-flight HeavyRead
       # counters so a stable, long-lived owner survives the transient request/worker

--- a/lib/loopctl/application.ex
+++ b/lib/loopctl/application.ex
@@ -125,6 +125,14 @@ defmodule Loopctl.Application do
     if Application.get_env(:loopctl, :env) == :prod,
       do: Loopctl.IndexHealth.warn_if_invalid_indexes()
 
+    # US-38.3 (AC-38.3.3): clustering-readiness gate. When the app is told to expect
+    # peers (EXPECTED_APP_NODES > 1) but Node.list/0 is empty, WARN that this node is
+    # running un-clustered (node-local PubSub) so a machine-count bump can't silently
+    # run un-clustered. WARN + runbook, NEVER a crash — a single node always boots.
+    # Prod only, rescue-wrapped, mirroring DbCapacity.warn_if_over_budget/0.
+    if Application.get_env(:loopctl, :env) == :prod,
+      do: Loopctl.ClusterReadiness.warn_if_expected_peers_missing()
+
     result
   end
 

--- a/lib/loopctl/audit_chain/sth_enqueuer.ex
+++ b/lib/loopctl/audit_chain/sth_enqueuer.ex
@@ -2,7 +2,7 @@ defmodule Loopctl.AuditChain.SthEnqueuer do
   @moduledoc """
   US-35.2 — Event-driven, activity-gated STH enqueuer.
 
-  A supervised, node-local singleton GenServer that subscribes to the fixed
+  A supervised, CLUSTER-WIDE singleton GenServer that subscribes to the fixed
   cross-tenant audit-chain firehose topic (`Loopctl.AuditChain.PubSub`) and, on
   each `{:audit_chain_entry, entry}` message, debounce-enqueues one
   `Loopctl.Workers.ComputeSthWorker` job for `entry.tenant_id`. This makes STH
@@ -10,6 +10,39 @@ defmodule Loopctl.AuditChain.SthEnqueuer do
   per-minute `all_tenants` cron. The firehose message is a MINIMAL
   `%{tenant_id: _}` map (not the full `%Entry{}`) — `tenant_id` is the only field
   this subscriber reads, so nothing else needs to cross the shared topic.
+
+  ## Cluster singleton (US-38.3, AC-38.3.1) — why `:global`, and single-node behavior
+
+  The app-boot instance registers under `name: {:global, __MODULE__}` so that
+  across N clustered nodes EXACTLY ONE instance actually subscribes to and drains
+  the firehose. Before this change every node subscribed and enqueued, so an
+  append fanned out to all N nodes did N redundant `Oban.insert/2` calls (safe —
+  Oban `unique` dedups them — but N× wasteful work on the DB); with a single
+  cluster-wide drainer the firehose is consumed once. On a SINGLE node behavior is
+  byte-for-byte unchanged: that one node wins the global registration and is the
+  singleton, subscribing and enqueuing exactly as before.
+
+  `start_link/1` pattern-matches the `GenServer.start_link` result: on
+  `{:error, {:already_started, _pid}}` — another node already holds the global
+  name — it returns `:ignore` so the local supervisor treats the child as started
+  (NOT a crash). A naive `name: {:global, __MODULE__}` WITHOUT this handling would
+  crash every node after the first (CrashLoopBackOff), so it is mandatory.
+
+  Failover: if the owning process crashes, ITS node's supervisor restarts it and
+  it re-registers the (now-free) global name. `:global` de-registers the name when
+  the owning node goes down, so the name becomes claimable again by a surviving
+  node's (re)starting instance — the cluster is never left permanently without a
+  drainer, and correctness is backstopped regardless by the idempotent per-minute
+  cron (below) while any gap is open.
+
+  ## Test seam — explicit `:name` opt yields a plain LOCAL name
+
+  Only the DEFAULT (app-boot) instance is globally registered. Passing an explicit
+  `name:` (a per-test unique atom) yields an ordinary node-local registration, so
+  the async suite can start many isolated instances via `start_supervised!` without
+  colliding on the one global name. Tests SIMULATE a multi-node collision by
+  starting a second instance under the SAME `{:global, ...}` name and asserting it
+  returns `:ignore` (one active enqueuer).
 
   ## Why a GenServer (OTP Iron Law)
 
@@ -70,8 +103,25 @@ defmodule Loopctl.AuditChain.SthEnqueuer do
   @doc false
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts \\ []) do
-    name = Keyword.get(opts, :name, __MODULE__)
-    GenServer.start_link(__MODULE__, opts, name: name)
+    # DEFAULT to the cluster-wide global name so exactly one instance across the
+    # cluster drains the firehose (US-38.3). An explicit `name:` opt (per-test
+    # unique atom) yields an ordinary LOCAL name, preserving the async-test seam.
+    name = Keyword.get(opts, :name, {:global, __MODULE__})
+
+    case GenServer.start_link(__MODULE__, opts, name: name) do
+      {:ok, pid} ->
+        {:ok, pid}
+
+      {:error, {:already_started, _pid}} ->
+        # Another node already runs the cluster singleton under this global name.
+        # Treat the collision as success (`:ignore`) so THIS node's supervisor
+        # considers the child started rather than crash-looping. Mandatory with
+        # `{:global, _}` — see the moduledoc "Cluster singleton" section.
+        :ignore
+
+      {:error, _reason} = error ->
+        error
+    end
   end
 
   @doc """

--- a/lib/loopctl/audit_chain/sth_enqueuer.ex
+++ b/lib/loopctl/audit_chain/sth_enqueuer.ex
@@ -11,38 +11,57 @@ defmodule Loopctl.AuditChain.SthEnqueuer do
   `%{tenant_id: _}` map (not the full `%Entry{}`) — `tenant_id` is the only field
   this subscriber reads, so nothing else needs to cross the shared topic.
 
-  ## Cluster singleton (US-38.3, AC-38.3.1) — why `:global`, and single-node behavior
+  ## Cluster singleton with real failover (US-38.3, AC-38.3.1)
 
-  The app-boot instance registers under `name: {:global, __MODULE__}` so that
-  across N clustered nodes EXACTLY ONE instance actually subscribes to and drains
-  the firehose. Before this change every node subscribed and enqueued, so an
-  append fanned out to all N nodes did N redundant `Oban.insert/2` calls (safe —
-  Oban `unique` dedups them — but N× wasteful work on the DB); with a single
+  Across N clustered nodes EXACTLY ONE instance actually subscribes to and drains
+  the firehose. Before this, every node subscribed and enqueued, so an append
+  fanned out to all N nodes did N redundant `Oban.insert/2` calls (safe — Oban
+  `unique` dedups them — but N× wasteful work on the DB); with a single
   cluster-wide drainer the firehose is consumed once. On a SINGLE node behavior is
-  byte-for-byte unchanged: that one node wins the global registration and is the
-  singleton, subscribing and enqueuing exactly as before.
+  byte-for-byte unchanged: that one node wins leadership and is the singleton,
+  subscribing and enqueuing exactly as before.
 
-  `start_link/1` pattern-matches the `GenServer.start_link` result: on
-  `{:error, {:already_started, _pid}}` — another node already holds the global
-  name — it returns `:ignore` so the local supervisor treats the child as started
-  (NOT a crash). A naive `name: {:global, __MODULE__}` WITHOUT this handling would
-  crash every node after the first (CrashLoopBackOff), so it is mandatory.
+  ### How leadership + failover work (self-hosted Starter+Monitor, no `:ignore`)
 
-  Failover: if the owning process crashes, ITS node's supervisor restarts it and
-  it re-registers the (now-free) global name. `:global` de-registers the name when
-  the owning node goes down, so the name becomes claimable again by a surviving
-  node's (re)starting instance — the cluster is never left permanently without a
-  drainer, and correctness is backstopped regardless by the idempotent per-minute
-  cron (below) while any gap is open.
+  EVERY node's supervisor keeps a `SthEnqueuer` process ALIVE — there is no
+  `:ignore`, so no node is ever left without a live process. `start_link/1` always
+  returns `{:ok, pid}` (a plain, node-local start); leadership is then negotiated
+  IN `init` (via `handle_continue/2`, keeping `init` light), not by the registered
+  name of `start_link`. Each `:singleton`-mode instance calls
+  `:global.register_name(leadership_key, self())`:
 
-  ## Test seam — explicit `:name` opt yields a plain LOCAL name
+    * `:yes` → it is the **leader**: it subscribes to the firehose and drains it.
+    * `:no`  → another node holds leadership, so it becomes a **standby**: it
+      `Process.monitor/1`s the current holder (a cross-node monitor) and does
+      NOT subscribe. It sits idle but ALIVE.
 
-  Only the DEFAULT (app-boot) instance is globally registered. Passing an explicit
-  `name:` (a per-test unique atom) yields an ordinary node-local registration, so
-  the async suite can start many isolated instances via `start_supervised!` without
-  colliding on the one global name. Tests SIMULATE a multi-node collision by
-  starting a second instance under the SAME `{:global, ...}` name and asserting it
-  returns `:ignore` (one active enqueuer).
+  When the leader — or its whole node — goes down, `:global` frees the name
+  cluster-wide and every standby's monitor fires `{:DOWN, ...}`. On that message a
+  standby re-runs the registration: exactly one wins and becomes the new leader
+  (subscribing and resuming the drain); the rest re-monitor the new holder. THIS
+  is the failover AC-38.3.1 requires — a surviving node's standby takes over, not
+  merely the same-node process-crash case. A brief `:retry_leadership` timer
+  covers the race where the old holder's name has not yet been freed at the moment
+  a standby retries. Correctness is additionally backstopped by the idempotent
+  per-minute `ComputeSthWorker` cron (below), so any sub-second takeover gap only
+  defers an activity-driven enqueue to the next cron tick — never data loss.
+
+  ## Mode / test seam — explicit `:name` opt yields a plain LOCAL standalone
+
+  Two modes, resolved from opts in `start_link/1`:
+
+    * `:singleton` (the app-boot default: no `:name`, or an explicit
+      `:leadership_key`) — the global-leadership + standby/failover behavior above,
+      keyed on `leadership_key` (default `__MODULE__`).
+    * `:standalone` (an explicit `:name` with no `:leadership_key`) — an ordinary
+      node-local instance that is always active and subscribes per `:subscribe`.
+      This preserves the async-suite seam: the US-35.2 tests start isolated,
+      always-subscribing instances via `start_supervised!` without contending on
+      the one global leadership name.
+
+  Failover itself is driven directly by starting TWO `:singleton`-mode instances
+  under one isolated `leadership_key`, asserting exactly one leads, killing it, and
+  asserting the standby takes over (see the test module).
 
   ## Why a GenServer (OTP Iron Law)
 
@@ -98,29 +117,24 @@ defmodule Loopctl.AuditChain.SthEnqueuer do
   # runtime via Application.get_env/3, never Application.put_env in tests.
   @default_debounce_seconds 5
 
+  # Fallback delay (ms) before a standby re-attempts leadership when it lost the
+  # register race but the current holder had already vanished (so there was no pid
+  # to monitor). Config-driven per the DI rules; kept short — this only covers a
+  # narrow transient window, steady state is monitor-driven.
+  @default_leadership_retry_ms 200
+
   # --- Client API ---
 
   @doc false
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts \\ []) do
-    # DEFAULT to the cluster-wide global name so exactly one instance across the
-    # cluster drains the firehose (US-38.3). An explicit `name:` opt (per-test
-    # unique atom) yields an ordinary LOCAL name, preserving the async-test seam.
-    name = Keyword.get(opts, :name, {:global, __MODULE__})
-
-    case GenServer.start_link(__MODULE__, opts, name: name) do
-      {:ok, pid} ->
-        {:ok, pid}
-
-      {:error, {:already_started, _pid}} ->
-        # Another node already runs the cluster singleton under this global name.
-        # Treat the collision as success (`:ignore`) so THIS node's supervisor
-        # considers the child started rather than crash-looping. Mandatory with
-        # `{:global, _}` — see the moduledoc "Cluster singleton" section.
-        :ignore
-
-      {:error, _reason} = error ->
-        error
+    # ALWAYS a plain node-local start (never `:ignore`) so every node keeps a live
+    # process that can lead OR stand by. Leadership is negotiated in `init` via
+    # `:global.register_name/2`, not by the registered name here. An explicit
+    # `:name` (a per-test unique atom) is honored for local addressing.
+    case Keyword.fetch(opts, :name) do
+      {:ok, name} -> GenServer.start_link(__MODULE__, opts, name: name)
+      :error -> GenServer.start_link(__MODULE__, opts)
     end
   end
 
@@ -165,20 +179,32 @@ defmodule Loopctl.AuditChain.SthEnqueuer do
     |> Oban.insert()
   end
 
+  @doc """
+  Fallback leadership-retry delay (ms), read at runtime from application config.
+
+  Only used by a standby that lost the register race to a holder that had already
+  vanished (no pid to monitor) — a rare transient. Steady-state takeover is
+  monitor-driven, not timer-driven.
+  """
+  @spec leadership_retry_ms() :: pos_integer()
+  def leadership_retry_ms do
+    Application.get_env(
+      :loopctl,
+      :sth_enqueuer_leadership_retry_ms,
+      @default_leadership_retry_ms
+    )
+  end
+
   # --- Server callbacks ---
 
   @impl true
   def init(opts) do
-    # Subscribe to the fixed cross-tenant firehose so we observe every tenant's
-    # appends through ONE subscription. `Phoenix.PubSub` starts strictly before
-    # this owner in the supervision tree, so the subscribe here is safe.
-    #
-    # Subscription is config-gated (default ON) so the app's boot singleton can
-    # be kept from reacting under the Ecto Sandbox in the test suite — where its
-    # `Oban.insert` would run without an owned connection — while production
-    # always subscribes. Tests that need a LIVE subscriber start their OWN named
-    # instance with `subscribe: true`, and the config default stays true so the
-    # production supervision-tree child subscribes normally.
+    # Subscription is config-gated (default ON) so the app's boot singleton can be
+    # kept from reacting under the Ecto Sandbox in the test suite — where its
+    # `Oban.insert` would run without an owned connection — while production always
+    # subscribes. Tests that need a LIVE subscriber start their OWN instance with
+    # `subscribe: true`, and the config default stays true so the production
+    # supervision-tree child subscribes normally.
     subscribe? =
       Keyword.get(
         opts,
@@ -186,9 +212,70 @@ defmodule Loopctl.AuditChain.SthEnqueuer do
         Application.get_env(:loopctl, :sth_enqueuer_subscribe, true)
       )
 
-    if subscribe?, do: ChainPubSub.subscribe_firehose()
-    {:ok, %{}}
+    # Mode resolution (see moduledoc): an explicit `:leadership_key` opts into
+    # :singleton with a contendable/isolated key (used by failover tests); an
+    # explicit `:name` with no key is the local :standalone seam; the bare
+    # app-boot default is :singleton keyed on `__MODULE__`.
+    leadership_key = Keyword.get(opts, :leadership_key)
+
+    mode =
+      cond do
+        not is_nil(leadership_key) -> :singleton
+        Keyword.has_key?(opts, :name) -> :standalone
+        true -> :singleton
+      end
+
+    state = %{
+      mode: mode,
+      leadership_key: leadership_key || __MODULE__,
+      subscribe?: subscribe?,
+      role: :starting,
+      leader_ref: nil
+    }
+
+    # Negotiate leadership in handle_continue to keep init lightweight (cluster
+    # init should not block on :global). Phoenix.PubSub starts strictly before
+    # this owner in the tree, so subscribing from the continue is safe.
+    {:ok, state, {:continue, :establish_role}}
   end
+
+  # :standalone — always the active drainer for its local scope; no global
+  # leadership, no standby. Preserves the async-suite seam.
+  @impl true
+  def handle_continue(:establish_role, %{mode: :standalone} = state) do
+    if state.subscribe?, do: ChainPubSub.subscribe_firehose()
+    {:noreply, %{state | role: :leader}}
+  end
+
+  # :singleton — contend for cluster-wide leadership; lead (subscribe) or stand by.
+  @impl true
+  def handle_continue(:establish_role, %{mode: :singleton} = state) do
+    {:noreply, try_become_leader(state)}
+  end
+
+  # The monitored leader (its process, or its whole node) went down. `:global` has
+  # freed the leadership name cluster-wide, so re-contend: exactly one surviving
+  # standby wins and becomes the new drainer (real failover, AC-38.3.1); the rest
+  # re-monitor the new holder.
+  @impl true
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, %{leader_ref: ref} = state) do
+    Logger.info(
+      "SthEnqueuer: observed leader down; attempting cluster-singleton takeover " <>
+        "(#{inspect(state.leadership_key)})"
+    )
+
+    {:noreply, try_become_leader(%{state | leader_ref: nil})}
+  end
+
+  # Fallback retry for the narrow race where a standby lost the register but the
+  # holder had already vanished (nothing to monitor). Only meaningful while still a
+  # standby singleton — otherwise a stale timer is a no-op.
+  @impl true
+  def handle_info(:retry_leadership, %{mode: :singleton, role: :standby} = state) do
+    {:noreply, try_become_leader(state)}
+  end
+
+  def handle_info(:retry_leadership, state), do: {:noreply, state}
 
   @impl true
   def handle_info({:audit_chain_entry, %{tenant_id: tenant_id} = entry}, state)
@@ -246,5 +333,44 @@ defmodule Loopctl.AuditChain.SthEnqueuer do
   def handle_info(msg, state) do
     Logger.debug("SthEnqueuer: ignoring unexpected message: #{inspect(msg)}")
     {:noreply, state}
+  end
+
+  # --- Leadership (cluster singleton) ---
+
+  # Attempt to claim the cluster-wide leadership name. On success we are the sole
+  # drainer and subscribe; on failure we become a monitoring standby ready to take
+  # over. Called both at boot (establish_role) and on takeover (leader :DOWN).
+  defp try_become_leader(state) do
+    case :global.register_name(state.leadership_key, self()) do
+      :yes ->
+        if state.subscribe?, do: ChainPubSub.subscribe_firehose()
+
+        Logger.info(
+          "SthEnqueuer: acquired cluster-singleton leadership (#{inspect(state.leadership_key)})"
+        )
+
+        %{state | role: :leader, leader_ref: nil}
+
+      :no ->
+        become_standby(state)
+    end
+  end
+
+  # Lost (or did not attempt) leadership: monitor the current holder so its death
+  # triggers failover. If the holder already vanished (undefined) or somehow is us,
+  # fall back to a short retry / self-promotion rather than monitoring a ghost.
+  defp become_standby(state) do
+    case :global.whereis_name(state.leadership_key) do
+      :undefined ->
+        Process.send_after(self(), :retry_leadership, leadership_retry_ms())
+        %{state | role: :standby, leader_ref: nil}
+
+      leader_pid when leader_pid == self() ->
+        %{state | role: :leader, leader_ref: nil}
+
+      leader_pid ->
+        ref = Process.monitor(leader_pid)
+        %{state | role: :standby, leader_ref: ref}
+    end
   end
 end

--- a/lib/loopctl/cluster_readiness.ex
+++ b/lib/loopctl/cluster_readiness.ex
@@ -14,11 +14,16 @@ defmodule Loopctl.ClusterReadiness do
 
   It NEVER crashes and NEVER enforces. On a single node it reports `:single_node`
   ("clustering not required"), not an error. The boot check
-  (`warn_if_expected_peers_missing/0`, called from `Loopctl.Application`) only
-  `Logger.warning`s when you've told the app to expect peers (`EXPECTED_APP_NODES > 1`)
-  but `Node.list/0` is empty — it is a WARN + runbook, not a crash. A single node
-  must always boot. It does NOT set `DNS_CLUSTER_QUERY` and does NOT scale (both
-  infra, out of scope).
+  (`warn_if_expected_peers_missing/0`, called from `Loopctl.Application`)
+  `Logger.warning`s on exactly the two un-clustered classifications `readiness/0`
+  reports and stays silent (INFO) otherwise: `:expected_peers_missing` (clustering
+  configured — `DNS_CLUSTER_QUERY` set — AND expected — `EXPECTED_APP_NODES > 1` —
+  yet peers missing) and `:clustering_expected_dns_unconfigured` (`EXPECTED_APP_NODES`
+  raised above the single-node default of 2 but `DNS_CLUSTER_QUERY` forgotten). The
+  standard `DNS_CLUSTER_QUERY`-unset single-node prod deploy (default
+  `EXPECTED_APP_NODES` 2, no peers → `:single_node`) does NOT cry wolf. It is a WARN +
+  runbook, not a crash. A single node must always boot. It does NOT set
+  `DNS_CLUSTER_QUERY` and does NOT scale (both infra, out of scope).
 
   ## No sensitive data
 
@@ -30,20 +35,37 @@ defmodule Loopctl.ClusterReadiness do
 
   ## Status classification
 
-    * `:single_node` — `EXPECTED_APP_NODES <= 1` OR `DNS_CLUSTER_QUERY` unset:
-      clustering is not required/enabled, so an empty `Node.list/0` is expected and
-      correct — NOT an error.
+    * `:single_node` — `EXPECTED_APP_NODES <= 1`, OR `DNS_CLUSTER_QUERY` unset with an
+      expected count at/below the single-node default (2): clustering is not
+      required/enabled and the default count is indistinguishable from "never intended
+      to cluster", so an empty `Node.list/0` is expected and correct — NOT an error.
     * `:clustered` — clustering configured, `EXPECTED_APP_NODES > 1`, and at least
       the expected number of peers (`peers >= expected_nodes - 1`) are connected.
     * `:expected_peers_missing` — clustering configured and `EXPECTED_APP_NODES > 1`
       but fewer peers than expected are connected (e.g. running un-clustered after a
       count bump). This is the state the boot WARN and the runbook gate exist to
       surface BEFORE it becomes a silent split-brain.
+    * `:clustering_expected_dns_unconfigured` — `EXPECTED_APP_NODES` explicitly raised
+      ABOVE the single-node default (`> 2`) yet `DNS_CLUSTER_QUERY` is UNSET. An
+      operator bumped the node count but forgot to wire clustering, so the node runs
+      un-clustered and — unlike `:expected_peers_missing` — peers can NEVER connect
+      until DNS is set (it will not self-clear). Distinct from `:single_node` so the
+      "silently un-clustered after a machine-count bump" case is not swallowed. The
+      one detectable slice of the forgot-DNS class: at the DEFAULT count (2) it is
+      indistinguishable from a normal single-node deploy and stays `:single_node`.
   """
 
   require Logger
 
   alias Loopctl.DbCapacity
+
+  # The single-node baseline == `Loopctl.DbCapacity.expected_app_nodes/0`'s default
+  # when `EXPECTED_APP_NODES` is unset (2). An expected count AT OR BELOW this with
+  # `DNS_CLUSTER_QUERY` unset is indistinguishable from the standard single-node prod
+  # deploy, so it classifies `:single_node` (no cry-wolf). Only a count strictly ABOVE
+  # it proves an operator deliberately raised the node count — the DNS-forgotten case
+  # this signal must surface. Kept in lockstep with the DbCapacity default by test.
+  @single_node_baseline 2
 
   @doc """
   Whether BEAM clustering is configured via `DNS_CLUSTER_QUERY` (wired to
@@ -74,6 +96,7 @@ defmodule Loopctl.ClusterReadiness do
         peers: non_neg_integer(),   # length(Node.list/0), never node names
         expected_nodes: pos_integer(),
         status: :single_node | :clustered | :expected_peers_missing
+                | :clustering_expected_dns_unconfigured
       }
 
   Resolves the live inputs (`expected_app_nodes/0`, `Node.list/0`, the DNS-query
@@ -83,7 +106,11 @@ defmodule Loopctl.ClusterReadiness do
           dns_cluster_query_configured: boolean(),
           peers: non_neg_integer(),
           expected_nodes: pos_integer(),
-          status: :single_node | :clustered | :expected_peers_missing
+          status:
+            :single_node
+            | :clustered
+            | :expected_peers_missing
+            | :clustering_expected_dns_unconfigured
         }
   def readiness do
     readiness(DbCapacity.expected_app_nodes(), peers(), dns_cluster_query_configured?())
@@ -98,7 +125,11 @@ defmodule Loopctl.ClusterReadiness do
           dns_cluster_query_configured: boolean(),
           peers: non_neg_integer(),
           expected_nodes: pos_integer(),
-          status: :single_node | :clustered | :expected_peers_missing
+          status:
+            :single_node
+            | :clustered
+            | :expected_peers_missing
+            | :clustering_expected_dns_unconfigured
         }
   def readiness(expected_nodes, peers, dns_configured?)
       when is_integer(expected_nodes) and is_list(peers) and is_boolean(dns_configured?) do
@@ -112,11 +143,29 @@ defmodule Loopctl.ClusterReadiness do
     }
   end
 
-  # <= 1 expected node OR clustering not configured => single-node / not required.
+  # <= 1 expected node => single-node / not required (clustering never applies).
   defp clustering_status(expected_nodes, _peer_count, _dns?) when expected_nodes <= 1,
     do: :single_node
 
-  defp clustering_status(_expected_nodes, _peer_count, false), do: :single_node
+  # Clustering NOT configured (DNS_CLUSTER_QUERY unset). Two sub-cases, split on the
+  # single-node baseline so the signal is actionable WITHOUT crying wolf:
+  #
+  #   * expected <= baseline (2, the DbCapacity default): INDISTINGUISHABLE from the
+  #     standard single-node prod deploy (default `EXPECTED_APP_NODES` 2, DNS unset).
+  #     Stay quiet as `:single_node` — a forgotten `DNS_CLUSTER_QUERY` at the default
+  #     count cannot be told apart from "operator never intended to cluster", so
+  #     warning here would fire on every normal boot (the cry-wolf we removed).
+  #   * expected  > baseline: the operator EXPLICITLY raised `EXPECTED_APP_NODES` above
+  #     the single-node default but left `DNS_CLUSTER_QUERY` unset — the exact
+  #     "machine-count bump silently running un-clustered" failure this module exists
+  #     to surface. This IS distinguishable, so it gets its own status
+  #     (`:clustering_expected_dns_unconfigured`) and a boot WARN whose only guard is
+  #     "set DNS_CLUSTER_QUERY first" (peers can never connect until it is set).
+  defp clustering_status(expected_nodes, _peer_count, false) do
+    if expected_nodes > @single_node_baseline,
+      do: :clustering_expected_dns_unconfigured,
+      else: :single_node
+  end
 
   defp clustering_status(expected_nodes, peer_count, true) do
     if peer_count >= expected_nodes - 1, do: :clustered, else: :expected_peers_missing
@@ -125,39 +174,88 @@ defmodule Loopctl.ClusterReadiness do
   @doc """
   Boot-time clustering-readiness WARN gate (AC-38.3.3). Called from
   `Loopctl.Application` after `Supervisor.start_link` (prod-guarded, mirroring
-  `Loopctl.DbCapacity.warn_if_over_budget/0`): logs an actionable WARNING when the
-  app is told to expect peers (`EXPECTED_APP_NODES > 1`) but `Node.list/0` is empty
-  (running un-clustered), and an INFO otherwise. It NEVER raises and NEVER blocks
-  boot — a single node always boots.
+  `Loopctl.DbCapacity.warn_if_over_budget/0`): logs an actionable WARNING on exactly
+  the two un-clustered classifications `readiness/0` reports — `:expected_peers_missing`
+  (clustering configured, `EXPECTED_APP_NODES > 1`, peers short) and
+  `:clustering_expected_dns_unconfigured` (`EXPECTED_APP_NODES` raised above the
+  single-node default of 2 but `DNS_CLUSTER_QUERY` forgotten) — and an INFO otherwise.
+  It NEVER raises and NEVER blocks boot — a single node always boots.
+
+  Delegates to the DNS-aware `warn_if_expected_peers_missing/3` so the boot WARN and
+  the readiness signal can never disagree about the same node (a `DNS_CLUSTER_QUERY`
+  -unset single-node prod deploy at the DEFAULT count — `EXPECTED_APP_NODES` 2, no
+  peers — is `:single_node`, so it does NOT warn; only a genuinely-configured-but-
+  unclustered fleet, or a count explicitly bumped above the default with DNS
+  forgotten, does).
   """
   @spec warn_if_expected_peers_missing() :: :ok
   def warn_if_expected_peers_missing do
-    warn_if_expected_peers_missing(DbCapacity.expected_app_nodes(), peers())
+    warn_if_expected_peers_missing(
+      DbCapacity.expected_app_nodes(),
+      peers(),
+      dns_cluster_query_configured?()
+    )
   end
 
   @doc """
-  Pure boot-WARN gate over injected inputs — the seam TC-38.3.3 drives directly with
-  an expected-node count and a peer list, asserting a WARN is logged and `:ok` is
-  returned (never a raise), without mutating `EXPECTED_APP_NODES`. Logs only bounded,
-  non-sensitive values (counts) — never node names.
-  """
-  @spec warn_if_expected_peers_missing(pos_integer(), [node()]) :: :ok
-  def warn_if_expected_peers_missing(expected_nodes, peers)
-      when is_integer(expected_nodes) and is_list(peers) do
-    peer_count = length(peers)
+  Pure, DNS-aware boot-WARN gate over injected inputs — the seam TC-38.3.3 drives
+  directly with an expected-node count, a peer list, and whether `DNS_CLUSTER_QUERY`
+  is configured, without mutating any env. Warns on the two un-clustered
+  classifications — `:expected_peers_missing` (DNS configured + `EXPECTED_APP_NODES >
+  1` + too few peers) and `:clustering_expected_dns_unconfigured` (`EXPECTED_APP_NODES`
+  above the single-node default of 2 + DNS unset) — returns `:ok`, and never raises.
+  Logs only bounded, non-sensitive values (counts) — never node names.
 
-    if expected_nodes > 1 and peer_count == 0 do
-      Logger.warning(
-        "Clustering readiness: EXPECTED_APP_NODES=#{expected_nodes} but Node.list/0 is empty — " <>
-          "this node is running UN-CLUSTERED (PubSub is node-local; the SthEnqueuer/rate-limiter " <>
-          "cluster paths are inert). Verify clustering is GREEN before raising machine count. " <>
-          "See docs/user_stories/epic_38_scaling_readiness/README.md 'Runbook: verify clustering " <>
-          "before scaling'. This is a WARN, not a crash — a single node always boots."
-      )
-    else
-      Logger.info(
-        "Clustering readiness OK: expected_nodes=#{expected_nodes}, connected_peers=#{peer_count}"
-      )
+  ## Boot-time transient (why a lone WARN is not proof of a broken cluster)
+
+  This is sampled ONCE, synchronously, at the end of `Application.start/2`.
+  `DNSCluster` discovers and connects peers a few seconds LATER (its periodic DNS
+  poll), so on a genuinely-healthy multi-node deploy `Node.list/0` can still be empty
+  at this instant and this WARN can fire transiently during the startup window before
+  peers connect. The reliable STEADY-STATE signal is the 10s-polled
+  `loopctl.cluster.peers.count{status}` gauge (and `readiness/0`), NOT this
+  point-in-time boot line — see the runbook. A persistent `:expected_peers_missing`
+  on the gauge is the real alarm; a single boot WARN that clears is expected.
+  """
+  @spec warn_if_expected_peers_missing(pos_integer(), [node()], boolean()) :: :ok
+  def warn_if_expected_peers_missing(expected_nodes, peers, dns_configured?)
+      when is_integer(expected_nodes) and is_list(peers) and is_boolean(dns_configured?) do
+    peer_count = length(peers)
+    status = clustering_status(expected_nodes, peer_count, dns_configured?)
+
+    case status do
+      :expected_peers_missing ->
+        Logger.warning(
+          "Clustering readiness: EXPECTED_APP_NODES=#{expected_nodes} and DNS_CLUSTER_QUERY is " <>
+            "configured but Node.list/0 shows #{peer_count} peer(s) — this node may be running " <>
+            "UN-CLUSTERED (PubSub is node-local; the SthEnqueuer/rate-limiter cluster paths are " <>
+            "inert). NOTE: peers connect a few seconds AFTER boot (async DNS poll), so a lone boot " <>
+            "WARN that clears is the expected startup transient — trust the steady-state " <>
+            "loopctl.cluster.peers.count{status} gauge, not this point-in-time line. If the gauge " <>
+            "stays :expected_peers_missing, verify clustering is GREEN before raising machine count. " <>
+            "See docs/user_stories/epic_38_scaling_readiness/README.md 'Runbook: verify clustering " <>
+            "before scaling'. This is a WARN, not a crash — a single node always boots."
+        )
+
+      :clustering_expected_dns_unconfigured ->
+        Logger.warning(
+          "Clustering readiness: EXPECTED_APP_NODES=#{expected_nodes} (above the single-node " <>
+            "default of #{@single_node_baseline}) but DNS_CLUSTER_QUERY is UNSET — BEAM clustering " <>
+            "is NOT configured, so this node runs UN-CLUSTERED (PubSub is node-local; the " <>
+            "SthEnqueuer/rate-limiter cluster paths are inert). An operator raised the node count " <>
+            "without wiring clustering: unlike a missing-peers WARN, this will NOT self-clear — " <>
+            "peers can never connect until DNS_CLUSTER_QUERY is set. GUARD: set the " <>
+            "DNS_CLUSTER_QUERY Fly secret FIRST, then confirm the steady-state " <>
+            "loopctl.cluster.peers.count{status=\"clustered\"} gauge before raising machine count. " <>
+            "See docs/user_stories/epic_38_scaling_readiness/README.md 'Runbook: verify clustering " <>
+            "before scaling'. This is a WARN, not a crash — a single node always boots."
+        )
+
+      _single_node_or_clustered ->
+        Logger.info(
+          "Clustering readiness OK (status=#{status}): expected_nodes=#{expected_nodes}, " <>
+            "connected_peers=#{peer_count}, dns_configured=#{dns_configured?}"
+        )
     end
 
     :ok

--- a/lib/loopctl/cluster_readiness.ex
+++ b/lib/loopctl/cluster_readiness.ex
@@ -1,0 +1,167 @@
+defmodule Loopctl.ClusterReadiness do
+  @moduledoc """
+  US-38.3 (AC-38.3.2/.3) — clustering-readiness verification signal + boot WARN gate.
+
+  loopctl runs single-node today. Every horizontal-scaling capability in Epic 38 is
+  code-only and env/flag-gated to that single-node behavior; this module adds the
+  MISSING SIGNAL so a machine-count bump can't silently run un-clustered (node-local
+  PubSub) with nobody noticing. It reports whether BEAM clustering is configured
+  (`DNS_CLUSTER_QUERY`) and whether `Node.list/0` actually shows the expected peers
+  (vs `EXPECTED_APP_NODES`, reused from `Loopctl.DbCapacity.expected_app_nodes/0` so
+  the node count is parsed in exactly one place).
+
+  ## What it is NOT
+
+  It NEVER crashes and NEVER enforces. On a single node it reports `:single_node`
+  ("clustering not required"), not an error. The boot check
+  (`warn_if_expected_peers_missing/0`, called from `Loopctl.Application`) only
+  `Logger.warning`s when you've told the app to expect peers (`EXPECTED_APP_NODES > 1`)
+  but `Node.list/0` is empty — it is a WARN + runbook, not a crash. A single node
+  must always boot. It does NOT set `DNS_CLUSTER_QUERY` and does NOT scale (both
+  infra, out of scope).
+
+  ## No sensitive data
+
+  Everything this module exposes publicly is a BOUNDED, non-sensitive summary — a
+  peer COUNT and a fixed-set `status` atom. It NEVER emits node NAMES or the query
+  string, so it is safe to surface on the unauthenticated observability surface
+  (the `loopctl.cluster.peers.count` Prometheus gauge on the internal metrics port,
+  fed by `Loopctl.Telemetry.ScaleMetrics.poll_cluster_readiness/0`).
+
+  ## Status classification
+
+    * `:single_node` — `EXPECTED_APP_NODES <= 1` OR `DNS_CLUSTER_QUERY` unset:
+      clustering is not required/enabled, so an empty `Node.list/0` is expected and
+      correct — NOT an error.
+    * `:clustered` — clustering configured, `EXPECTED_APP_NODES > 1`, and at least
+      the expected number of peers (`peers >= expected_nodes - 1`) are connected.
+    * `:expected_peers_missing` — clustering configured and `EXPECTED_APP_NODES > 1`
+      but fewer peers than expected are connected (e.g. running un-clustered after a
+      count bump). This is the state the boot WARN and the runbook gate exist to
+      surface BEFORE it becomes a silent split-brain.
+  """
+
+  require Logger
+
+  alias Loopctl.DbCapacity
+
+  @doc """
+  Whether BEAM clustering is configured via `DNS_CLUSTER_QUERY` (wired to
+  `:dns_cluster_query` in `config/runtime.exs`; unset/empty → not configured →
+  `DNSCluster` runs as `:ignore`). This story does NOT set the env.
+  """
+  @spec dns_cluster_query_configured?() :: boolean()
+  def dns_cluster_query_configured? do
+    case Application.get_env(:loopctl, :dns_cluster_query) do
+      nil -> false
+      "" -> false
+      _ -> true
+    end
+  end
+
+  @doc """
+  The currently-connected cluster peers (`Node.list/0`). Node names are used ONLY to
+  derive a count in this module — they are never logged or exposed publicly.
+  """
+  @spec peers() :: [node()]
+  def peers, do: Node.list()
+
+  @doc """
+  The clustering-readiness signal as a BOUNDED, non-sensitive map:
+
+      %{
+        dns_cluster_query_configured: boolean(),
+        peers: non_neg_integer(),   # length(Node.list/0), never node names
+        expected_nodes: pos_integer(),
+        status: :single_node | :clustered | :expected_peers_missing
+      }
+
+  Resolves the live inputs (`expected_app_nodes/0`, `Node.list/0`, the DNS-query
+  config) and delegates to the pure `readiness/3`.
+  """
+  @spec readiness() :: %{
+          dns_cluster_query_configured: boolean(),
+          peers: non_neg_integer(),
+          expected_nodes: pos_integer(),
+          status: :single_node | :clustered | :expected_peers_missing
+        }
+  def readiness do
+    readiness(DbCapacity.expected_app_nodes(), peers(), dns_cluster_query_configured?())
+  end
+
+  @doc """
+  Pure readiness classification from injected inputs — the seam tests drive directly
+  (no env mutation, no real cluster) per the async-suite lesson: assert the outcome
+  CLASS, not real timing/topology.
+  """
+  @spec readiness(pos_integer(), [node()], boolean()) :: %{
+          dns_cluster_query_configured: boolean(),
+          peers: non_neg_integer(),
+          expected_nodes: pos_integer(),
+          status: :single_node | :clustered | :expected_peers_missing
+        }
+  def readiness(expected_nodes, peers, dns_configured?)
+      when is_integer(expected_nodes) and is_list(peers) and is_boolean(dns_configured?) do
+    peer_count = length(peers)
+
+    %{
+      dns_cluster_query_configured: dns_configured?,
+      peers: peer_count,
+      expected_nodes: expected_nodes,
+      status: clustering_status(expected_nodes, peer_count, dns_configured?)
+    }
+  end
+
+  # <= 1 expected node OR clustering not configured => single-node / not required.
+  defp clustering_status(expected_nodes, _peer_count, _dns?) when expected_nodes <= 1,
+    do: :single_node
+
+  defp clustering_status(_expected_nodes, _peer_count, false), do: :single_node
+
+  defp clustering_status(expected_nodes, peer_count, true) do
+    if peer_count >= expected_nodes - 1, do: :clustered, else: :expected_peers_missing
+  end
+
+  @doc """
+  Boot-time clustering-readiness WARN gate (AC-38.3.3). Called from
+  `Loopctl.Application` after `Supervisor.start_link` (prod-guarded, mirroring
+  `Loopctl.DbCapacity.warn_if_over_budget/0`): logs an actionable WARNING when the
+  app is told to expect peers (`EXPECTED_APP_NODES > 1`) but `Node.list/0` is empty
+  (running un-clustered), and an INFO otherwise. It NEVER raises and NEVER blocks
+  boot — a single node always boots.
+  """
+  @spec warn_if_expected_peers_missing() :: :ok
+  def warn_if_expected_peers_missing do
+    warn_if_expected_peers_missing(DbCapacity.expected_app_nodes(), peers())
+  end
+
+  @doc """
+  Pure boot-WARN gate over injected inputs — the seam TC-38.3.3 drives directly with
+  an expected-node count and a peer list, asserting a WARN is logged and `:ok` is
+  returned (never a raise), without mutating `EXPECTED_APP_NODES`. Logs only bounded,
+  non-sensitive values (counts) — never node names.
+  """
+  @spec warn_if_expected_peers_missing(pos_integer(), [node()]) :: :ok
+  def warn_if_expected_peers_missing(expected_nodes, peers)
+      when is_integer(expected_nodes) and is_list(peers) do
+    peer_count = length(peers)
+
+    if expected_nodes > 1 and peer_count == 0 do
+      Logger.warning(
+        "Clustering readiness: EXPECTED_APP_NODES=#{expected_nodes} but Node.list/0 is empty — " <>
+          "this node is running UN-CLUSTERED (PubSub is node-local; the SthEnqueuer/rate-limiter " <>
+          "cluster paths are inert). Verify clustering is GREEN before raising machine count. " <>
+          "See docs/user_stories/epic_38_scaling_readiness/README.md 'Runbook: verify clustering " <>
+          "before scaling'. This is a WARN, not a crash — a single node always boots."
+      )
+    else
+      Logger.info(
+        "Clustering readiness OK: expected_nodes=#{expected_nodes}, connected_peers=#{peer_count}"
+      )
+    end
+
+    :ok
+  rescue
+    e -> Logger.warning("ClusterReadiness boot check skipped: #{Exception.message(e)}")
+  end
+end

--- a/lib/loopctl/telemetry/scale_metrics.ex
+++ b/lib/loopctl/telemetry/scale_metrics.ex
@@ -32,10 +32,13 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   gauge, and a poll-failure counter so a frozen gauge is distinguishable from a
   genuinely stable one — see "Oban queue/state gauges + `:executing` orphan gauge
   (US-34.1)" below. US-36.3 added the ingestion backlog-gate fail-open counter and
-  US-36.4 adds the article-linking corpus-size gauge (metric 22 below), so
-  `scale_metrics/0` now returns 22 metrics total.
+  US-36.4 adds the article-linking corpus-size gauge (metric 22 below). US-38.3 adds
+  the clustering-readiness peer gauge (metric 23 below — `loopctl.cluster.peers.count`,
+  a `last_value/2` gauge of `length(Node.list/0)` tagged by the bounded readiness
+  `status`, fed by `poll_cluster_readiness/0`), so `scale_metrics/0` now returns 23
+  metrics total.
 
-  ## The metrics (22 total)
+  ## The metrics (23 total)
 
     1. **Timeout / DB-error counter** — `loopctl.db.error.count`, keyed by
        `[:endpoint, :mapped_code]` (+ a cap-gated `:tenant_id`). `mapped_code`
@@ -395,15 +398,15 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
   @oban_terminal_states [:completed, :discarded, :cancelled]
 
   @doc """
-  All 22 scale metrics: the original US-27.15 trio, #297's semantic-fallback
+  All 23 scale metrics: the original US-27.15 trio, #297's semantic-fallback
   counter, US-31.2's hybrid-provenance counter, US-33.1's two per-pool checkout
   `queue_time` distributions, US-34.4's ten emitted-but-dead-event counters
   (LLM/embedding-blocked, index-health, secrets/witness/memory-promotion
   degradation signals), US-34.1's three Oban metrics (per-{state, queue}
   gauge over the non-terminal states, the `:executing` orphan gauge, and a
-  poll-failure counter), US-36.3's ingestion backlog-gate fail-open counter, and
-  US-36.4's article-linking corpus-size gauge. Appended to
-  `LoopctlWeb.Telemetry.metrics/0`.
+  poll-failure counter), US-36.3's ingestion backlog-gate fail-open counter,
+  US-36.4's article-linking corpus-size gauge, and US-38.3's clustering-readiness
+  peer gauge. Appended to `LoopctlWeb.Telemetry.metrics/0`.
   """
   @spec scale_metrics() :: [Telemetry.Metrics.t()]
   def scale_metrics do
@@ -701,8 +704,38 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
           "Sampled article-linking candidate-corpus size (vs the comparison limit), by tenant.",
         tags: [:tenant_id],
         tag_values: &article_linking_corpus_size_tags/1
+      ),
+
+      # 23. Clustering-readiness peer gauge (US-38.3, AC-38.3.2). Fed by
+      #     `poll_cluster_readiness/0` (a periodic measurement wired into
+      #     `LoopctlWeb.Telemetry.periodic_measurements/0`) from
+      #     `Loopctl.ClusterReadiness.readiness/0`. The measurement is the connected
+      #     BEAM peer COUNT (`length(Node.list/0)`); the ONLY tag is the bounded 3-value
+      #     `status` set (`:single_node`/`:clustered`/`:expected_peers_missing`) — NEVER
+      #     a node NAME or the DNS query string (both endpoints/ports are non-public,
+      #     but the no-sensitive-data + bounded-cardinality contract AC-27.15.3 holds
+      #     regardless). On a single node this reads `{status="single_node", count=0}`,
+      #     the correct "clustering not required" signal rather than an error.
+      last_value("loopctl.cluster.peers.count",
+        event_name: [:loopctl, :cluster, :peers],
+        measurement: :count,
+        description:
+          "Connected BEAM cluster peers (Node.list/0 length), by clustering-readiness status.",
+        tags: [:status],
+        tag_values: &cluster_peers_tags/1
       )
     ]
+  end
+
+  @doc """
+  `tag_values` for the clustering-readiness peer gauge (US-38.3). Emits ONLY the
+  bounded `status` label (`:single_node`/`:clustered`/`:expected_peers_missing`) —
+  NEVER a node name or the DNS query string. Defaults a missing status to `"unknown"`
+  so a direct `:telemetry.execute/3` with a partial map never raises or emits blank.
+  """
+  @spec cluster_peers_tags(map()) :: map()
+  def cluster_peers_tags(metadata) do
+    %{status: Map.get(metadata, :status, "unknown")}
   end
 
   @doc """
@@ -1185,6 +1218,36 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
       )
 
       emit_oban_poll_error(:executing_orphans, e)
+
+      :ok
+  end
+
+  @doc """
+  Periodic measurement (US-38.3, AC-38.3.2) feeding the `loopctl.cluster.peers.count`
+  gauge (metric 23). Reads `Loopctl.ClusterReadiness.readiness/0` and emits the
+  connected BEAM peer COUNT with the bounded readiness `status` as the sole tag —
+  NEVER a node name or the DNS query string. Wired into
+  `LoopctlWeb.Telemetry.periodic_measurements/0` (the same 10s poller as the Oban
+  gauges). Self-rescuing (catch-all, per the periodic-measurements invariant): a
+  raise here must never let `telemetry_poller` permanently drop this MFA — the gauge
+  simply keeps its last value for one cycle. On a single node it reads
+  `{status="single_node", count=0}`.
+  """
+  @spec poll_cluster_readiness() :: :ok
+  def poll_cluster_readiness do
+    readiness = Loopctl.ClusterReadiness.readiness()
+
+    :telemetry.execute([:loopctl, :cluster, :peers], %{count: readiness.peers}, %{
+      status: readiness.status
+    })
+
+    :ok
+  rescue
+    e ->
+      Logger.warning(
+        "Clustering-readiness poll failed (#{inspect(e.__struct__)}); skipping this cycle — " <>
+          "the cluster.peers gauge keeps its last-recorded value until the next successful poll"
+      )
 
       :ok
   end

--- a/lib/loopctl/telemetry/scale_metrics.ex
+++ b/lib/loopctl/telemetry/scale_metrics.ex
@@ -710,8 +710,9 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
       #     `poll_cluster_readiness/0` (a periodic measurement wired into
       #     `LoopctlWeb.Telemetry.periodic_measurements/0`) from
       #     `Loopctl.ClusterReadiness.readiness/0`. The measurement is the connected
-      #     BEAM peer COUNT (`length(Node.list/0)`); the ONLY tag is the bounded 3-value
-      #     `status` set (`:single_node`/`:clustered`/`:expected_peers_missing`) — NEVER
+      #     BEAM peer COUNT (`length(Node.list/0)`); the ONLY tag is the bounded 4-value
+      #     `status` set (`:single_node`/`:clustered`/`:expected_peers_missing`/
+      #     `:clustering_expected_dns_unconfigured`) — NEVER
       #     a node NAME or the DNS query string (both endpoints/ports are non-public,
       #     but the no-sensitive-data + bounded-cardinality contract AC-27.15.3 holds
       #     regardless). On a single node this reads `{status="single_node", count=0}`,
@@ -729,7 +730,8 @@ defmodule Loopctl.Telemetry.ScaleMetrics do
 
   @doc """
   `tag_values` for the clustering-readiness peer gauge (US-38.3). Emits ONLY the
-  bounded `status` label (`:single_node`/`:clustered`/`:expected_peers_missing`) —
+  bounded `status` label (`:single_node`/`:clustered`/`:expected_peers_missing`/
+  `:clustering_expected_dns_unconfigured`) —
   NEVER a node name or the DNS query string. Defaults a missing status to `"unknown"`
   so a direct `:telemetry.execute/3` with a partial map never raises or emits blank.
   """

--- a/lib/loopctl_web/telemetry.ex
+++ b/lib/loopctl_web/telemetry.ex
@@ -176,7 +176,12 @@ defmodule LoopctlWeb.Telemetry do
       # US-34.1 (AC-34.1.2/.3): the `:executing`-older-than-N-min orphan poll,
       # feeding the `loopctl.oban.jobs.executing_orphan.count` gauge. Same
       # self-rescuing contract.
-      {ScaleMetrics, :poll_oban_executing_orphans, []}
+      {ScaleMetrics, :poll_oban_executing_orphans, []},
+
+      # US-38.3 (AC-38.3.2): the clustering-readiness peer poll, feeding the
+      # `loopctl.cluster.peers.count` gauge from `Loopctl.ClusterReadiness.readiness/0`
+      # (peer COUNT + bounded `status`, never node names). Self-rescuing, same contract.
+      {ScaleMetrics, :poll_cluster_readiness, []}
     ]
   end
 end

--- a/test/loopctl/audit_chain/sth_enqueuer_test.exs
+++ b/test/loopctl/audit_chain/sth_enqueuer_test.exs
@@ -410,42 +410,108 @@ defmodule Loopctl.AuditChain.SthEnqueuerTest do
       assert enqueued_tid == tenant.id
     end
 
-    test "TC-38.3.1: a second instance under the SAME {:global, _} name yields :ignore (one active enqueuer)" do
-      # Simulate a multi-node collision on the cluster-global name: the first instance
-      # wins the {:global, _} registration; a second start under the SAME global name
-      # collides and start_link/1 maps the {:already_started, _} to :ignore, so the
-      # local supervisor treats the child as started rather than crash-looping. Net:
-      # exactly ONE active enqueuer across the (simulated) cluster.
-      global_atom = :"sth_singleton_#{System.unique_integer([:positive])}"
-      global_name = {:global, global_atom}
+    test "TC-38.3.1: two :singleton instances contend → exactly ONE leader, one live standby (one active enqueuer)" do
+      # Simulate a multi-node cluster on ONE test node: two :singleton-mode instances
+      # contend for one isolated leadership_key via :global.register_name/2. Exactly
+      # one wins leadership (the sole drainer); the OTHER is a LIVE standby monitoring
+      # the leader — NOT :ignore, NOT dead. That live standby is what makes real
+      # failover possible (see the failover test below).
+      key = :"sth_lead_#{System.unique_integer([:positive])}"
 
-      first =
-        start_supervised!(
-          Supervisor.child_spec({SthEnqueuer, [name: global_name, subscribe: false]},
-            id: :sth_global_singleton
-          )
-        )
+      {a, b} = start_two_singletons(key)
 
-      assert is_pid(first)
-      assert :global.whereis_name(global_atom) == first
+      # Barrier: :sys.get_state blocks until each handle_continue(:establish_role) ran.
+      roles = Enum.sort([:sys.get_state(a).role, :sys.get_state(b).role])
+      assert roles == [:leader, :standby]
 
-      # Second registration under the same global name → :ignore (NOT a crash, NOT a
-      # second process).
-      assert :ignore == SthEnqueuer.start_link(name: global_name, subscribe: false)
+      leader = :global.whereis_name(key)
+      assert leader in [a, b]
 
-      # The original remains the one and only globally-registered, alive instance.
-      assert :global.whereis_name(global_atom) == first
-      assert Process.alive?(first)
+      # BOTH remain alive — the loser is a standby, not a terminated/ignored child.
+      assert Process.alive?(a)
+      assert Process.alive?(b)
     end
 
-    test "TC-38.3.1: the DEFAULT (unnamed) start is the cluster-global singleton the app already holds" do
-      # The app-boot instance started with default opts, so it registered under
-      # {:global, SthEnqueuer}. A fresh DEFAULT start therefore collides and returns
-      # :ignore — proving the default name IS the cluster-wide global singleton
-      # (exactly one active across the cluster), and that a redundant node start is a
-      # graceful no-op rather than a crash.
-      assert is_pid(:global.whereis_name(SthEnqueuer))
-      assert :ignore == SthEnqueuer.start_link(subscribe: false)
+    test "TC-38.3.1: FAILOVER — killing the leader promotes a surviving standby that resumes draining" do
+      # The behavior AC-38.3.1 actually requires: 'If the singleton's node dies,
+      # another node takes over (failover).' Kill the leader (:temporary child ⇒ NOT
+      # restarted, so this cleanly simulates the OWNER NODE dying, not a same-node
+      # process crash). :global frees the name; the standby's cross-node monitor fires
+      # {:DOWN, ...}; it re-registers, becomes the new leader, and can still enqueue.
+      tenant = fixture(:tenant)
+      key = :"sth_failover_#{System.unique_integer([:positive])}"
+
+      {a, b} = start_two_singletons(key)
+      _ = :sys.get_state(a)
+      _ = :sys.get_state(b)
+
+      leader = :global.whereis_name(key)
+      standby = if leader == a, do: b, else: a
+      assert :sys.get_state(standby).role == :standby
+
+      # Kill the leader and wait for its death to be observed.
+      ref = Process.monitor(leader)
+      Process.exit(leader, :kill)
+      assert_receive {:DOWN, ^ref, :process, ^leader, _reason}, 2_000
+
+      # The standby takes over the cluster-global leadership name (real failover).
+      assert eventually(fn -> :global.whereis_name(key) == standby end)
+      assert :sys.get_state(standby).role == :leader
+
+      # And the new leader still drains: the enqueue path works after takeover.
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert {:ok, _job} = SthEnqueuer.enqueue_sth_job(%{tenant_id: tenant.id})
+      end)
+
+      assert [%{args: %{"tenant_id" => enqueued_tid}}] = all_enqueued(worker: ComputeSthWorker)
+      assert enqueued_tid == tenant.id
+    end
+
+    test "TC-38.3.1: the app-boot instance holds the cluster-global {:global, SthEnqueuer} leadership" do
+      # The app-boot instance started with default opts (:singleton mode keyed on
+      # __MODULE__), so it registered under {:global, SthEnqueuer} and is the live
+      # cluster singleton — exactly one active drainer across the (single-node) cluster.
+      leader = :global.whereis_name(SthEnqueuer)
+      assert is_pid(leader)
+      assert Process.alive?(leader)
+    end
+  end
+
+  # Start two :singleton-mode instances contending on one isolated leadership_key.
+  # :temporary so a killed leader is NOT restarted (clean node-death simulation);
+  # subscribe: false so neither touches the sandbox from its own process.
+  defp start_two_singletons(key) do
+    a =
+      start_supervised!(
+        Supervisor.child_spec({SthEnqueuer, [leadership_key: key, subscribe: false]},
+          id: :sth_singleton_a,
+          restart: :temporary
+        )
+      )
+
+    b =
+      start_supervised!(
+        Supervisor.child_spec({SthEnqueuer, [leadership_key: key, subscribe: false]},
+          id: :sth_singleton_b,
+          restart: :temporary
+        )
+      )
+
+    {a, b}
+  end
+
+  # Poll a predicate until true or a bounded deadline — assert outcome CLASS, not
+  # exact timing (the async-suite flake lesson): failover is asynchronous (:global
+  # de-register + monitor :DOWN + re-register), so we wait for the end state.
+  defp eventually(fun, attempts \\ 100, sleep_ms \\ 20)
+  defp eventually(_fun, 0, _sleep_ms), do: false
+
+  defp eventually(fun, attempts, sleep_ms) do
+    if fun.() do
+      true
+    else
+      Process.sleep(sleep_ms)
+      eventually(fun, attempts - 1, sleep_ms)
     end
   end
 end

--- a/test/loopctl/audit_chain/sth_enqueuer_test.exs
+++ b/test/loopctl/audit_chain/sth_enqueuer_test.exs
@@ -383,4 +383,69 @@ defmodule Loopctl.AuditChain.SthEnqueuerTest do
       assert Process.alive?(pid)
     end
   end
+
+  describe "cluster singleton (US-38.3, AC-38.3.1)" do
+    test "TC-38.3.1: a single node still enqueues — an explicit local name starts and enqueues" do
+      # Single-node behavior is unchanged: an explicit `name:` yields an ordinary
+      # LOCAL registration (the async-test seam) and the enqueue path works exactly
+      # as before the cluster-singleton change.
+      tenant = fixture(:tenant)
+      name = :"sth_local_#{System.unique_integer([:positive])}"
+
+      pid =
+        start_supervised!(
+          Supervisor.child_spec({SthEnqueuer, [name: name, subscribe: false]}, id: name)
+        )
+
+      assert is_pid(pid)
+      # Plain local registration — NOT globally registered (only the default app-boot
+      # instance claims the {:global, _} name).
+      assert Process.whereis(name) == pid
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert {:ok, _job} = SthEnqueuer.enqueue_sth_job(%{tenant_id: tenant.id})
+      end)
+
+      assert [%{args: %{"tenant_id" => enqueued_tid}}] = all_enqueued(worker: ComputeSthWorker)
+      assert enqueued_tid == tenant.id
+    end
+
+    test "TC-38.3.1: a second instance under the SAME {:global, _} name yields :ignore (one active enqueuer)" do
+      # Simulate a multi-node collision on the cluster-global name: the first instance
+      # wins the {:global, _} registration; a second start under the SAME global name
+      # collides and start_link/1 maps the {:already_started, _} to :ignore, so the
+      # local supervisor treats the child as started rather than crash-looping. Net:
+      # exactly ONE active enqueuer across the (simulated) cluster.
+      global_atom = :"sth_singleton_#{System.unique_integer([:positive])}"
+      global_name = {:global, global_atom}
+
+      first =
+        start_supervised!(
+          Supervisor.child_spec({SthEnqueuer, [name: global_name, subscribe: false]},
+            id: :sth_global_singleton
+          )
+        )
+
+      assert is_pid(first)
+      assert :global.whereis_name(global_atom) == first
+
+      # Second registration under the same global name → :ignore (NOT a crash, NOT a
+      # second process).
+      assert :ignore == SthEnqueuer.start_link(name: global_name, subscribe: false)
+
+      # The original remains the one and only globally-registered, alive instance.
+      assert :global.whereis_name(global_atom) == first
+      assert Process.alive?(first)
+    end
+
+    test "TC-38.3.1: the DEFAULT (unnamed) start is the cluster-global singleton the app already holds" do
+      # The app-boot instance started with default opts, so it registered under
+      # {:global, SthEnqueuer}. A fresh DEFAULT start therefore collides and returns
+      # :ignore — proving the default name IS the cluster-wide global singleton
+      # (exactly one active across the cluster), and that a redundant node start is a
+      # graceful no-op rather than a crash.
+      assert is_pid(:global.whereis_name(SthEnqueuer))
+      assert :ignore == SthEnqueuer.start_link(subscribe: false)
+    end
+  end
 end

--- a/test/loopctl/cluster_readiness_test.exs
+++ b/test/loopctl/cluster_readiness_test.exs
@@ -9,7 +9,7 @@ defmodule Loopctl.ClusterReadinessTest do
   unset `DNS_CLUSTER_QUERY` env resolves to `:ignore`).
 
   All classification/WARN cases are driven through the PURE `readiness/3` /
-  `warn_if_expected_peers_missing/2` seams with injected inputs — no real cluster,
+  `warn_if_expected_peers_missing/3` seams with injected inputs — no real cluster,
   no `EXPECTED_APP_NODES` env mutation — so the async suite asserts outcome CLASS,
   not real topology/timing (the async-suite flake lesson).
   """
@@ -30,9 +30,26 @@ defmodule Loopctl.ClusterReadinessTest do
       assert %{status: :single_node} = ClusterReadiness.readiness(1, [:peer@host], true)
     end
 
-    test "DNS query unset ⇒ :single_node regardless of expected count (clustering not enabled)" do
-      assert %{status: :single_node} = ClusterReadiness.readiness(3, [], false)
-      assert %{status: :single_node} = ClusterReadiness.readiness(3, [:a@h, :b@h], false)
+    test "DNS unset at/below the single-node default (2) ⇒ :single_node (indistinguishable from a normal single-node deploy)" do
+      # EXPECTED_APP_NODES unset defaults to 2 (DbCapacity). DNS unset at count 2 is
+      # the standard single-node prod state — it must NOT be flagged, because a
+      # forgotten DNS_CLUSTER_QUERY at the default count cannot be told apart from
+      # "never intended to cluster".
+      assert %{status: :single_node} = ClusterReadiness.readiness(2, [], false)
+      assert %{status: :single_node} = ClusterReadiness.readiness(1, [], false)
+    end
+
+    test "MEDIUM FINDING: DNS unset with EXPECTED_APP_NODES raised ABOVE the default (>2) ⇒ :clustering_expected_dns_unconfigured (not silently :single_node)" do
+      # The 'machine-count bump silently un-clustered' case the story exists to
+      # surface: an operator explicitly raised the node count but left
+      # DNS_CLUSTER_QUERY unset. This is distinguishable from the default single-node
+      # deploy (count 2), so it gets its own status rather than being swallowed as
+      # :single_node. Peer count is irrelevant — peers can never connect without DNS.
+      assert %{status: :clustering_expected_dns_unconfigured} =
+               ClusterReadiness.readiness(3, [], false)
+
+      assert %{status: :clustering_expected_dns_unconfigured} =
+               ClusterReadiness.readiness(5, [:a@h, :b@h], false)
     end
 
     test ":clustered when configured and the expected peers are connected" do
@@ -58,7 +75,13 @@ defmodule Loopctl.ClusterReadinessTest do
       # `peers` is a COUNT (integer), never the node-name list.
       assert readiness.peers == 2
       assert is_integer(readiness.peers)
-      assert readiness.status in [:single_node, :clustered, :expected_peers_missing]
+
+      assert readiness.status in [
+               :single_node,
+               :clustered,
+               :expected_peers_missing,
+               :clustering_expected_dns_unconfigured
+             ]
 
       # No value in the map is (or contains) a node name atom/string.
       refute Enum.any?(Map.values(readiness), fn v ->
@@ -82,13 +105,26 @@ defmodule Loopctl.ClusterReadinessTest do
     test "dns_cluster_query_configured?/0 is false when DNS_CLUSTER_QUERY is unset (test env)" do
       refute ClusterReadiness.dns_cluster_query_configured?()
     end
+
+    test "the single-node baseline stays in lockstep with the DbCapacity default count" do
+      # ClusterReadiness's :single_node vs :clustering_expected_dns_unconfigured split
+      # hinges on the DbCapacity default node count (2). If that default ever changes,
+      # this behavioral coupling catches it: at EXACTLY the default count with DNS
+      # unset the signal must stay quiet (:single_node), and one above it must flag.
+      default = Loopctl.DbCapacity.expected_app_nodes()
+
+      assert %{status: :single_node} = ClusterReadiness.readiness(default, [], false)
+
+      assert %{status: :clustering_expected_dns_unconfigured} =
+               ClusterReadiness.readiness(default + 1, [], false)
+    end
   end
 
-  describe "warn_if_expected_peers_missing/2 boot gate (AC-38.3.3, TC-38.3.3)" do
-    test "TC-38.3.3: EXPECTED_APP_NODES > 1 with an empty Node.list WARNs and returns :ok (never raises)" do
+  describe "warn_if_expected_peers_missing/3 boot gate (AC-38.3.3, TC-38.3.3)" do
+    test "TC-38.3.3: DNS configured + EXPECTED_APP_NODES > 1 + empty Node.list WARNs and returns :ok (never raises)" do
       log =
         capture_log(fn ->
-          assert :ok == ClusterReadiness.warn_if_expected_peers_missing(3, [])
+          assert :ok == ClusterReadiness.warn_if_expected_peers_missing(3, [], true)
         end)
 
       assert log =~ "Clustering readiness"
@@ -96,8 +132,76 @@ defmodule Loopctl.ClusterReadinessTest do
       assert log =~ "UN-CLUSTERED"
       # It is documented as a WARN, not a crash.
       assert log =~ "WARN, not a crash"
+      # The boot-time transient is self-described so operators don't chase a lone WARN.
+      assert log =~ "gauge"
       # No node names are ever emitted (there are none here, but pin the contract).
       refute log =~ "@"
+    end
+
+    test "REGRESSION (medium finding): the standard single-node prod default does NOT warn" do
+      # DNS_CLUSTER_QUERY unset (dns_configured? == false) with the DbCapacity default
+      # EXPECTED_APP_NODES=2 and no peers is the EXACT current/correct prod state. It
+      # must NOT fire the UN-CLUSTERED alarm — it is :single_node, matching readiness/0
+      # (previously this path cried wolf on every normal single-node boot).
+      log =
+        capture_log(fn ->
+          assert :ok == ClusterReadiness.warn_if_expected_peers_missing(2, [], false)
+        end)
+
+      refute log =~ "UN-CLUSTERED"
+      refute log =~ "EXPECTED_APP_NODES"
+    end
+
+    test "MEDIUM FINDING: DNS unset + EXPECTED_APP_NODES raised above the default (>2) WARNs with a 'set DNS_CLUSTER_QUERY first' guard" do
+      # The forgot-DNS-after-count-bump case must now produce a boot WARN (previously
+      # it was swallowed as :single_node and emitted nothing). The message tells the
+      # operator the specific guard and that it will NOT self-clear.
+      log =
+        capture_log(fn ->
+          assert :ok == ClusterReadiness.warn_if_expected_peers_missing(3, [], false)
+        end)
+
+      assert log =~ "EXPECTED_APP_NODES=3"
+      assert log =~ "UN-CLUSTERED"
+      assert log =~ "DNS_CLUSTER_QUERY"
+      # Distinct from the missing-peers WARN: this one cannot self-clear.
+      assert log =~ "will NOT self-clear"
+      assert log =~ "WARN, not a crash"
+      refute log =~ "@"
+    end
+
+    test "the boot WARN mirrors readiness/3's un-clustered classifications exactly (DNS-gated)" do
+      # For every (expected, peers, dns) triple the boot WARN fires IFF the readiness
+      # classification is one of the two un-clustered states — :expected_peers_missing
+      # or :clustering_expected_dns_unconfigured — so the two functions can never
+      # disagree about the same node (the crux of the medium finding).
+      warning_statuses = [:expected_peers_missing, :clustering_expected_dns_unconfigured]
+
+      for {expected, peers, dns} <- [
+            {1, [], false},
+            {1, [], true},
+            {2, [], false},
+            {2, [], true},
+            {2, [:peer@host], true},
+            {3, [:a@h], true},
+            {3, [:a@h, :b@h], true},
+            {3, [], false},
+            {5, [], false}
+          ] do
+        status = ClusterReadiness.readiness(expected, peers, dns).status
+
+        log =
+          capture_log(fn ->
+            assert :ok == ClusterReadiness.warn_if_expected_peers_missing(expected, peers, dns)
+          end)
+
+        warned? = log =~ "UN-CLUSTERED"
+        expected_warn? = status in warning_statuses
+
+        assert warned? == expected_warn?,
+               "expected warn?=#{expected_warn?} for " <>
+                 "(#{expected}, #{inspect(peers)}, dns=#{dns}) [status=#{status}], got warn?=#{warned?}"
+      end
     end
 
     test "a single expected node does NOT WARN and returns :ok" do
@@ -106,7 +210,7 @@ defmodule Loopctl.ClusterReadinessTest do
       # un-clustered WARNING.
       log =
         capture_log(fn ->
-          assert :ok == ClusterReadiness.warn_if_expected_peers_missing(1, [])
+          assert :ok == ClusterReadiness.warn_if_expected_peers_missing(1, [], true)
         end)
 
       refute log =~ "UN-CLUSTERED"
@@ -116,7 +220,7 @@ defmodule Loopctl.ClusterReadinessTest do
     test "expected > 1 WITH the peers connected does NOT WARN and returns :ok" do
       log =
         capture_log(fn ->
-          assert :ok == ClusterReadiness.warn_if_expected_peers_missing(2, [:peer@host])
+          assert :ok == ClusterReadiness.warn_if_expected_peers_missing(2, [:peer@host], true)
         end)
 
       refute log =~ "UN-CLUSTERED"

--- a/test/loopctl/cluster_readiness_test.exs
+++ b/test/loopctl/cluster_readiness_test.exs
@@ -1,0 +1,158 @@
+defmodule Loopctl.ClusterReadinessTest do
+  @moduledoc """
+  US-38.3 — clustering-readiness verification signal, boot WARN gate, and the
+  DNSCluster supervision-tree wiring test.
+
+  Covers TC-38.3.2 (readiness reports single-node / not-required, no sensitive
+  data), TC-38.3.3 (EXPECTED_APP_NODES > 1 + empty Node.list → WARN, app still
+  boots, never raises), and TC-38.3.4 (DNSCluster present in the supervision tree;
+  unset `DNS_CLUSTER_QUERY` env resolves to `:ignore`).
+
+  All classification/WARN cases are driven through the PURE `readiness/3` /
+  `warn_if_expected_peers_missing/2` seams with injected inputs — no real cluster,
+  no `EXPECTED_APP_NODES` env mutation — so the async suite asserts outcome CLASS,
+  not real topology/timing (the async-suite flake lesson).
+  """
+
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  alias Loopctl.ClusterReadiness
+
+  describe "readiness/3 classification (AC-38.3.2)" do
+    test "TC-38.3.2: <= 1 expected node is :single_node (clustering not required), never an error" do
+      assert %{status: :single_node, expected_nodes: 1, peers: 0} =
+               ClusterReadiness.readiness(1, [], false)
+
+      # Even with a peer connected and DNS configured, a single expected node stays
+      # :single_node — clustering is not required at count 1.
+      assert %{status: :single_node} = ClusterReadiness.readiness(1, [:peer@host], true)
+    end
+
+    test "DNS query unset ⇒ :single_node regardless of expected count (clustering not enabled)" do
+      assert %{status: :single_node} = ClusterReadiness.readiness(3, [], false)
+      assert %{status: :single_node} = ClusterReadiness.readiness(3, [:a@h, :b@h], false)
+    end
+
+    test ":clustered when configured and the expected peers are connected" do
+      # expected 2 nodes ⇒ need >= 1 peer.
+      assert %{status: :clustered} = ClusterReadiness.readiness(2, [:peer@host], true)
+      # expected 3 nodes ⇒ need >= 2 peers.
+      assert %{status: :clustered} = ClusterReadiness.readiness(3, [:a@h, :b@h], true)
+    end
+
+    test ":expected_peers_missing when configured, > 1 expected, but too few peers" do
+      assert %{status: :expected_peers_missing} = ClusterReadiness.readiness(2, [], true)
+      assert %{status: :expected_peers_missing} = ClusterReadiness.readiness(3, [:a@h], true)
+    end
+
+    test "the signal is BOUNDED and carries NO sensitive data (no node names)" do
+      readiness =
+        ClusterReadiness.readiness(3, [:"secret-node@10.0.0.5", :"other@10.0.0.6"], true)
+
+      # Exactly the four documented keys — nothing leaks a node name or a query string.
+      assert readiness |> Map.keys() |> Enum.sort() ==
+               [:dns_cluster_query_configured, :expected_nodes, :peers, :status]
+
+      # `peers` is a COUNT (integer), never the node-name list.
+      assert readiness.peers == 2
+      assert is_integer(readiness.peers)
+      assert readiness.status in [:single_node, :clustered, :expected_peers_missing]
+
+      # No value in the map is (or contains) a node name atom/string.
+      refute Enum.any?(Map.values(readiness), fn v ->
+               is_atom(v) and String.contains?(to_string(v), "@")
+             end)
+    end
+  end
+
+  describe "readiness/0 on this (single) node (AC-38.3.2, TC-38.3.2)" do
+    test "reports single-node / clustering-not-required, not an error" do
+      readiness = ClusterReadiness.readiness()
+
+      # The test node runs un-clustered with DNS_CLUSTER_QUERY unset, so this is the
+      # 'clustering not required' state — never :expected_peers_missing (which would
+      # be a false alarm on a single node) and never a raise.
+      assert readiness.status == :single_node
+      assert readiness.dns_cluster_query_configured == false
+      assert is_integer(readiness.peers)
+    end
+
+    test "dns_cluster_query_configured?/0 is false when DNS_CLUSTER_QUERY is unset (test env)" do
+      refute ClusterReadiness.dns_cluster_query_configured?()
+    end
+  end
+
+  describe "warn_if_expected_peers_missing/2 boot gate (AC-38.3.3, TC-38.3.3)" do
+    test "TC-38.3.3: EXPECTED_APP_NODES > 1 with an empty Node.list WARNs and returns :ok (never raises)" do
+      log =
+        capture_log(fn ->
+          assert :ok == ClusterReadiness.warn_if_expected_peers_missing(3, [])
+        end)
+
+      assert log =~ "Clustering readiness"
+      assert log =~ "EXPECTED_APP_NODES=3"
+      assert log =~ "UN-CLUSTERED"
+      # It is documented as a WARN, not a crash.
+      assert log =~ "WARN, not a crash"
+      # No node names are ever emitted (there are none here, but pin the contract).
+      refute log =~ "@"
+    end
+
+    test "a single expected node does NOT WARN and returns :ok" do
+      # The OK case logs at INFO, which the suite's :warning primary level filters
+      # out — so assert the behavioral contract instead: returns :ok and emits NO
+      # un-clustered WARNING.
+      log =
+        capture_log(fn ->
+          assert :ok == ClusterReadiness.warn_if_expected_peers_missing(1, [])
+        end)
+
+      refute log =~ "UN-CLUSTERED"
+      refute log =~ "EXPECTED_APP_NODES"
+    end
+
+    test "expected > 1 WITH the peers connected does NOT WARN and returns :ok" do
+      log =
+        capture_log(fn ->
+          assert :ok == ClusterReadiness.warn_if_expected_peers_missing(2, [:peer@host])
+        end)
+
+      refute log =~ "UN-CLUSTERED"
+      refute log =~ "EXPECTED_APP_NODES"
+    end
+
+    test "the app is booted and its top supervisor is alive (the WARN never blocks boot)" do
+      # The boot-time call in Loopctl.Application is prod-guarded and rescue-wrapped;
+      # this asserts the running app (which invoked the boot path) is healthy.
+      assert is_pid(Process.whereis(Loopctl.Supervisor))
+    end
+  end
+
+  describe "DNSCluster supervision-tree wiring (AC-38.3.4, TC-38.3.4)" do
+    test "DNSCluster is a child of the app supervision tree" do
+      children = Supervisor.which_children(Loopctl.Supervisor)
+
+      # GOTCHA (documented in the story): with query :ignore, DNSCluster.start_link
+      # returns :ignore and starts NO process — so its child pid is :undefined. Assert
+      # on the CHILD SPEC presence (it IS wired into the tree), not on a running pid.
+      dns_child = Enum.find(children, fn {id, _pid, _type, _mods} -> id == DNSCluster end)
+
+      assert {DNSCluster, _pid, :worker, [DNSCluster]} = dns_child
+    end
+
+    test ":dns_cluster_query resolves from env — unset ⇒ :ignore" do
+      # DNS_CLUSTER_QUERY is NOT set by this story; in the test env it is unset, so the
+      # config resolves to nil and the child's query falls back to :ignore — exactly the
+      # `{DNSCluster, query: Application.get_env(:loopctl, :dns_cluster_query) || :ignore}`
+      # expression in Loopctl.Application.
+      assert Application.get_env(:loopctl, :dns_cluster_query) == nil
+      assert (Application.get_env(:loopctl, :dns_cluster_query) || :ignore) == :ignore
+    end
+
+    test "the dns_cluster dependency is available" do
+      assert Code.ensure_loaded?(DNSCluster)
+    end
+  end
+end

--- a/test/loopctl/telemetry/scale_metrics_test.exs
+++ b/test/loopctl/telemetry/scale_metrics_test.exs
@@ -65,7 +65,8 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
     "loopctl.oban.jobs.executing_orphan.count",
     "loopctl.oban.poll.error.count",
     "loopctl.ingestion.backlog_gate.failed_open.count",
-    "loopctl.knowledge.article_linking.corpus_size"
+    "loopctl.knowledge.article_linking.corpus_size",
+    "loopctl.cluster.peers.count"
   ]
 
   # The ONLY labels any scale metric may ever carry (AC-27.15.3). Anything outside this
@@ -102,7 +103,10 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
                   :state,
                   :queue,
                   :poller,
-                  :error_class
+                  :error_class,
+                  # US-38.3: clustering-readiness peer gauge — bounded 3-value status
+                  # (`:single_node`/`:clustered`/`:expected_peers_missing`), never a node name.
+                  :status
                 ])
 
   defp scale_metrics, do: ScaleMetrics.scale_metrics()
@@ -1056,6 +1060,47 @@ defmodule Loopctl.Telemetry.ScaleMetricsTest do
 
       # The default ScaleAlerts ETS table is not owned by anyone in :test.
       assert :ets.info(:loopctl_scale_alerts) == :undefined
+    end
+  end
+
+  describe "cluster-readiness peer gauge (US-38.3, AC-38.3.2)" do
+    test "the gauge is a last_value tagged by :status ONLY (bounded, no node names)" do
+      gauge = metric("loopctl.cluster.peers.count")
+
+      assert %Telemetry.Metrics.LastValue{} = gauge
+      assert gauge.tags == [:status]
+      refute :tenant_id in gauge.tags
+    end
+
+    test "cluster_peers_tags/1 emits ONLY the bounded status (defaults missing to \"unknown\")" do
+      assert ScaleMetrics.cluster_peers_tags(%{status: :single_node}) == %{status: :single_node}
+      assert ScaleMetrics.cluster_peers_tags(%{status: :clustered}) == %{status: :clustered}
+      assert ScaleMetrics.cluster_peers_tags(%{}) == %{status: "unknown"}
+    end
+
+    test "poll_cluster_readiness/0 emits the peer-count gauge with the readiness status and returns :ok" do
+      ref = make_ref()
+      handler_id = {:cluster_peers_test, ref}
+      parent = self()
+
+      :telemetry.attach(
+        handler_id,
+        [:loopctl, :cluster, :peers],
+        fn _event, measurements, metadata, _cfg ->
+          send(parent, {:cluster_peers, ref, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      assert :ok == ScaleMetrics.poll_cluster_readiness()
+
+      assert_receive {:cluster_peers, ^ref, %{count: count}, %{status: status}}
+      # On the (single) test node this is the 'clustering not required' state — a
+      # peer COUNT (never a node-name list) and a bounded status.
+      assert is_integer(count)
+      assert status in [:single_node, :clustered, :expected_peers_missing]
     end
   end
 end

--- a/test/loopctl_web/telemetry_test.exs
+++ b/test/loopctl_web/telemetry_test.exs
@@ -26,5 +26,9 @@ defmodule LoopctlWeb.TelemetryTest do
     test "also still includes the pre-existing tenant-label gate refresh (regression guard)" do
       assert {ScaleMetrics, :refresh_tenant_label_gate, []} in LoopctlWeb.Telemetry.periodic_measurements()
     end
+
+    test "includes poll_cluster_readiness/0 (US-38.3, AC-38.3.2)" do
+      assert {ScaleMetrics, :poll_cluster_readiness, []} in LoopctlWeb.Telemetry.periodic_measurements()
+    end
   end
 end


### PR DESCRIPTION
## US-38.3 — Cluster-safe SthEnqueuer singleton + clustering-readiness gate + DNSCluster test

Epic 38 (horizontal-scaling readiness, CODE-ONLY). Fixes two scale-out sharp edges — both pure code, zero infra, zero behavior change on a single node.

### 1. SthEnqueuer becomes a CLUSTER singleton (AC-38.3.1)
`Loopctl.AuditChain.SthEnqueuer` now registers under `name: {:global, __MODULE__}`, so across N clustered nodes exactly ONE instance subscribes to / drains the audit firehose — eliminating the N× duplicate STH-enqueue work (previously safe-but-wasteful; Oban `unique` dedups the jobs). `start_link/1` maps `{:error, {:already_started, _}}` → `:ignore` so the local supervisor treats a collision as started (NOT a crash — mandatory, otherwise every node after the first CrashLoopBackOffs). An explicit `:name` opt still yields a plain local name, preserving the async-test seam. **Single-node behavior is byte-for-byte unchanged** (that one node wins the global name and is the singleton). Intra-node process crash → supervised restart re-registers the freed name; `:global` frees the name on node death.

### 2. Clustering-readiness signal + boot WARN gate + DNSCluster test (AC-38.3.2/.3/.4)
- **`Loopctl.ClusterReadiness`** — `readiness/0` returns a bounded, no-node-name map `%{dns_cluster_query_configured, peers (count), expected_nodes, status}` where `status ∈ {:single_node, :clustered, :expected_peers_missing}`. On a single node it reports `:single_node` ("clustering not required"), never an error. Reuses `DbCapacity.expected_app_nodes/0`.
- **Boot WARN** — `warn_if_expected_peers_missing/0` logs a WARNING when `EXPECTED_APP_NODES > 1` but `Node.list/0` is empty (running un-clustered), wired prod-guarded + rescue-wrapped into `application.ex` (mirrors `DbCapacity.warn_if_over_budget/0`). WARN + runbook, **never a crash** — a single node always boots.
- **Observability** — `loopctl.cluster.peers.count` `last_value` gauge (tagged by the bounded `status` only, never node names) fed by `ScaleMetrics.poll_cluster_readiness/0` on the existing 10s telemetry poller.
- **Runbook** — "verify clustering GREEN before `fly scale count > 1`" added to the epic README.
- **DNSCluster wiring test** — asserts `DNSCluster` is a child of the supervision tree (child spec present with `:undefined` pid under the `:ignore` case) and that `:dns_cluster_query` resolves unset → `:ignore`.

### Out of scope (unchanged)
`DNS_CLUSTER_QUERY` is NOT set, nothing is scaled, the MPG plan is untouched — those stay documented, gated infra steps.

### Tests
`test/loopctl/cluster_readiness_test.exs` (readiness classification, single-node/no-sensitive-data, boot WARN never-raises, DNSCluster wiring), singleton assertions added to `test/loopctl/audit_chain/sth_enqueuer_test.exs`, gauge + wiring assertions in `scale_metrics_test.exs` / `telemetry_test.exs`. Full `mix precommit` green (4727 tests, 0 failures; credo --strict clean; dialyzer passed).

Part of #355 (roadmap Epic 6) / #353. Does NOT close the epic tracker — US-38.4 remains.
