### PR TITLE
HNSW m/ef_construction tuning + memories.embedding dual-index justification review

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -14,6 +14,17 @@ config :loopctl,
   env: config_env(),
   generators: [timestamp_type: :utc_datetime, binary_id: true],
   embedding_dimensions: 1536,
+  # US-38.4: EXPLICIT pgvector HNSW build parameters for every `CREATE INDEX ... USING
+  # hnsw` (`Loopctl.Repo.HnswIndex`). These EQUAL pgvector's implicit defaults (m=16,
+  # ef_construction=64) — a deliberate, documented "keep the defaults" tuning outcome
+  # (docs/hnsw-tuning-evaluation.md) — but making them config-driven means the choice is
+  # intentional and single-sourced. m = graph connectivity (recall/size/build-cost up
+  # with m); ef_construction = build-time candidate breadth (recall/build-cost up with
+  # it). BUILD-time only: changing either requires an ONLINE reindex migration (CREATE
+  # INDEX CONCURRENTLY new, drop old), never an in-place ALTER. The per-QUERY recall knob
+  # is `hnsw.ef_search` (SystemConfig `hnsw_ef_search`, applied per-read by HeavyRead).
+  hnsw_m: 16,
+  hnsw_ef_construction: 64,
   # Cosine similarity threshold for auto-linking articles.
   # 0.6 is calibrated for relationship discovery (related topics).
   # 0.8+ is only useful for near-duplicate detection.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -210,8 +210,11 @@ if config_env() == :prod do
   # pgvector custom GUC `hnsw.ef_search` is NOT settable via :parameters on managed PG — it
   # is applied per-ANN-read via `SET LOCAL hnsw.ef_search` inside that SAME heavy-read
   # transaction (US-38.4), configured live via the SystemConfig `hnsw_ef_search` key
-  # (default 40). The role-level `ALTER ROLE` lever also still works; see
-  # docs/runbooks/knowledge-scale.md.
+  # (default 40) — emitted ONLY when that value differs from the pgvector default. Because a
+  # `SET LOCAL` overrides any role/session default for its transaction, a role-level
+  # `ALTER ROLE <role> SET hnsw.ef_search` lever still works AND is honored whenever
+  # SystemConfig is left at the default (the per-read SET LOCAL never shadows it); a
+  # non-default SystemConfig value wins per-read. See docs/runbooks/knowledge-scale.md.
   #
   # Pool sizes here MUST stay in lockstep with `Loopctl.DbCapacity` (which models the
   # connection budget and is asserted in db_capacity_test.exs). Sizing (AC-27.11.1/.5),

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -206,9 +206,12 @@ if config_env() == :prod do
   # `:parameters` crash-loops EVERY HeavyReadRepo connection (the pool never establishes
   # one) and 503/504s every heavy endpoint (suggested_links, semantic search,
   # distant_pairs, novelty, heavy enumeration). `SET LOCAL` inside a transaction is the
-  # pgbouncer-safe path and is verified to enforce against the live pool. Likewise
-  # `ef_search` is NOT settable via :parameters on managed PG (a pgvector custom GUC);
-  # see docs/runbooks/knowledge-scale.md for the ALTER ROLE mechanism if it must change.
+  # pgbouncer-safe path and is verified to enforce against the live pool. Likewise the
+  # pgvector custom GUC `hnsw.ef_search` is NOT settable via :parameters on managed PG — it
+  # is applied per-ANN-read via `SET LOCAL hnsw.ef_search` inside that SAME heavy-read
+  # transaction (US-38.4), configured live via the SystemConfig `hnsw_ef_search` key
+  # (default 40). The role-level `ALTER ROLE` lever also still works; see
+  # docs/runbooks/knowledge-scale.md.
   #
   # Pool sizes here MUST stay in lockstep with `Loopctl.DbCapacity` (which models the
   # connection budget and is asserted in db_capacity_test.exs). Sizing (AC-27.11.1/.5),

--- a/docs/hnsw-tuning-evaluation.md
+++ b/docs/hnsw-tuning-evaluation.md
@@ -11,7 +11,7 @@ technical notes (do not churn indexes without evidence).
 |------|--------|-------|-------------------------|
 | `m` (graph connectivity) | implicit default 16 | **explicit** `config :loopctl, :hnsw_m` = 16 | none (value unchanged) |
 | `ef_construction` (build breadth) | implicit default 64 | **explicit** `config :loopctl, :hnsw_ef_construction` = 64 | none (value unchanged) |
-| `hnsw.ef_search` (query recall breadth) | implicit default 40, only raisable via `ALTER ROLE` | **live-tunable** `SystemConfig "hnsw_ef_search"` = 40, applied per-ANN-read via `SET LOCAL` | none (value unchanged) |
+| `hnsw.ef_search` (query recall breadth) | implicit default 40, only raisable via `ALTER ROLE` | **live-tunable** `SystemConfig "hnsw_ef_search"` = 40, applied per-ANN-read via `SET LOCAL` **only when non-default** (`ALTER ROLE` still honored at the default) | none (value unchanged) |
 | `memories.embedding` dual HNSW index | full + partial | **keep both** (both serve distinct live paths) | none |
 
 Because every chosen value EQUALS today's implicit default, **no reindex DDL is
@@ -37,7 +37,64 @@ from now on (a fresh `mix ecto.reset` or a future table). This keeps the hot
   (default 40), read by `Loopctl.HeavyRead.hnsw_ef_search/0` and applied per-read
   via `SET LOCAL hnsw.ef_search = N` **inside the heavy read's existing
   `SET LOCAL statement_timeout` transaction** (`run_timed_transaction/4`), for the
-  pgvector-ANN endpoints only (`HeavyRead.ann_endpoints/0`).
+  pgvector-ANN endpoints only (`HeavyRead.ann_endpoints/0` — `suggested_links`,
+  `semantic_search`, `novelty`, `vector_search`, `memory_recall`). The `distant_pairs` /
+  `distant_pairs_bridge` self-joins are **excluded**: they are column-to-column
+  (`a.embedding <=> b.embedding`) with no `$const` target, so pgvector's HNSW index — and
+  thus `hnsw.ef_search` — cannot apply (the `Loopctl.Knowledge.CosineLintExceptions`
+  registry records this "no $const target, HNSW N/A" invariant for `do_distant_pairs/7`).
+  The `SET LOCAL` is emitted **only when the configured value differs from the pgvector
+  default** (see the precedence contract below), so at the default no ANN GUC round-trip
+  occurs at all.
+
+### `SystemConfig` vs `ALTER ROLE` precedence (US-38.4 review fix)
+
+An unconditional per-read `SET LOCAL hnsw.ef_search = 40` would silently **shadow** a
+role-level `ALTER ROLE <role> SET hnsw.ef_search = N` — `SET LOCAL` overrides any
+role/session default for its transaction — regressing recall for an operator who raised
+it via the historically-documented (US-27.11/27.13) `ALTER ROLE` lever. The emission is
+therefore gated: `maybe_put_ef_search/2` attaches `:hnsw_ef_search` (→ the `SET LOCAL`)
+**only when `hnsw_ef_search/0` differs from the pgvector default 40**. Resulting contract:
+
+| `SystemConfig hnsw_ef_search` | Per-read `SET LOCAL`? | Effective `ef_search` on an ANN read |
+|-------------------------------|-----------------------|--------------------------------------|
+| 40 (default)                  | no                    | the session/role default → `ALTER ROLE` value if set, else 40 |
+| non-default (e.g. 100)        | `SET LOCAL … = 100`   | 100 (SET LOCAL wins over any role default) |
+
+So `SystemConfig` is the live, no-redeploy **fleet-wide** override; `ALTER ROLE` is a
+role-scoped default that is honored whenever `SystemConfig` is left at 40. (Edge case: to
+force ANN reads to exactly 40 while a higher `ALTER ROLE` default exists, lower the role
+default — `SystemConfig = 40` is treated as "no override".)
+
+### Live-pool verification of `SET LOCAL hnsw.ef_search` (US-38.4 review fix)
+
+The `statement_timeout` `SET LOCAL` was recorded as "verified to enforce against the live
+pool"; the same evidence is now recorded for the `hnsw.ef_search` `SET LOCAL`:
+
+- **Mechanism equivalence (structural).** `hnsw.ef_search` is set by the **same in-transaction
+  `SET LOCAL`** path as `statement_timeout` (`run_timed_transaction/4`: `BEGIN; SET LOCAL
+  statement_timeout; SET LOCAL hnsw.ef_search; SELECT; COMMIT`). pgbouncer's startup-parameter
+  allowlist — the US-27.13 outage's root cause — applies ONLY to connection **startup**
+  parameters, NOT to in-transaction `SET` commands, which pass through transparently under both
+  transaction and session pooling. So the US-27.13 failure mode (a rejected startup parameter
+  crash-looping the pool) is **structurally out of scope** for a `SET LOCAL`, exactly as it is
+  for the already-live-verified `statement_timeout` `SET LOCAL`.
+- **Round-trip evidence (real Postgres + pgvector, through the pooled heavy-read repo).**
+  Confirmed via `Loopctl.HeavyRead.repo()` (the pooled repo): inside a transaction,
+  `SET LOCAL hnsw.ef_search = 123` succeeds and `SHOW hnsw.ef_search` returns `"123"`; after
+  `COMMIT` the value resets (a fresh checkout does not carry it). This holds even though
+  `hnsw.ef_search` is a **namespaced (dotted) placeholder** GUC that Postgres accepts a `SET`
+  for before the extension's shared library has registered it in the backend — the
+  pgvector-documented order the code relies on. The heavy-read test suite exercises the same
+  path (`heavy_read_test.exs` — an ANN read issues `SET LOCAL hnsw.ef_search` against real
+  Postgres; the pin asserts the emitted value).
+- **Live fly-mpg confirmation (operator step, tied to the runbook).** Under the precedence
+  contract above, prod at the default 40 issues **no** `SET LOCAL hnsw.ef_search` — the
+  managed-PG assumption is only exercised once an operator raises the knob. The recall-lever
+  section of `docs/runbooks/knowledge-scale.md` makes that raise step include the live
+  `SET LOCAL … ; SHOW hnsw.ef_search` confirmation through the fly-mpg heavy-read pool (inside
+  a transaction), so the first non-default use IS the recorded live round-trip check before
+  reliance.
 
 ### Why per-request `SET LOCAL hnsw.ef_search` is now safe (the stale objection)
 
@@ -81,8 +138,10 @@ the default graph under-recalling at a materially larger corpus.
 `m`/`ef_construction`/`ef_search` are all unchanged, so recall is unchanged by
 construction. The recall gate (`test/loopctl/memory/scale_recall_test.exs`,
 `test/loopctl/knowledge/vector_search_test.exs`) continues to pass; the builder unit
-test asserts the emitted DDL carries the configured `WITH (...)` and that the ANN
-read path issues `SET LOCAL hnsw.ef_search`.
+test asserts the emitted DDL carries the configured `WITH (...)`, and `heavy_read_test.exs`
+asserts the ANN read path issues `SET LOCAL hnsw.ef_search = N` for a NON-default
+`SystemConfig` value, issues NONE at the default (so a role-level `ALTER ROLE` default is
+not shadowed), and that `hnsw_ef_search/0` clamps an out-of-range value into `[1, 1000]`.
 
 ---
 

--- a/docs/hnsw-tuning-evaluation.md
+++ b/docs/hnsw-tuning-evaluation.md
@@ -1,0 +1,150 @@
+# HNSW index tuning evaluation (US-38.4 / GH #353)
+
+Review-first, evidence-driven tuning pass for loopctl's pgvector HNSW indexes.
+Two independent tracks; the outcome of BOTH is a **documented "keep what we have,
+but make it explicit + tunable"** — an explicitly valid outcome per the story's
+technical notes (do not churn indexes without evidence).
+
+## TL;DR
+
+| Knob | Before | After | Change to live indexes? |
+|------|--------|-------|-------------------------|
+| `m` (graph connectivity) | implicit default 16 | **explicit** `config :loopctl, :hnsw_m` = 16 | none (value unchanged) |
+| `ef_construction` (build breadth) | implicit default 64 | **explicit** `config :loopctl, :hnsw_ef_construction` = 64 | none (value unchanged) |
+| `hnsw.ef_search` (query recall breadth) | implicit default 40, only raisable via `ALTER ROLE` | **live-tunable** `SystemConfig "hnsw_ef_search"` = 40, applied per-ANN-read via `SET LOCAL` | none (value unchanged) |
+| `memories.embedding` dual HNSW index | full + partial | **keep both** (both serve distinct live paths) | none |
+
+Because every chosen value EQUALS today's implicit default, **no reindex DDL is
+required** — the live `articles` / `memories` HNSW indexes were already built with
+these parameters. Re-emitting them from the builder only affects indexes created
+from now on (a fresh `mix ecto.reset` or a future table). This keeps the hot
+`articles` / `memories` tables free of any write-blocking DDL (AC-38.4.4).
+
+---
+
+## Track A — `m` / `ef_construction` / `ef_search` made explicit + configurable
+
+### What changed (code)
+
+- **`m` / `ef_construction`** are now single-sourced in `Loopctl.Repo.HnswIndex`
+  (`hnsw_m/0`, `hnsw_ef_construction/0`, `with_params_clause/0`) and interpolated
+  as an explicit `WITH (m = 16, ef_construction = 64)` storage clause on every
+  `CREATE INDEX ... USING hnsw` the module emits (articles + the full memories
+  index), plus the partial-memories-index migration. Values flow from
+  `config :loopctl, :hnsw_m` / `:hnsw_ef_construction` and are integer-validated
+  before interpolation (`validate_build_param!/2`) — never an injection surface.
+- **`ef_search`** is now the per-query recall knob `SystemConfig "hnsw_ef_search"`
+  (default 40), read by `Loopctl.HeavyRead.hnsw_ef_search/0` and applied per-read
+  via `SET LOCAL hnsw.ef_search = N` **inside the heavy read's existing
+  `SET LOCAL statement_timeout` transaction** (`run_timed_transaction/4`), for the
+  pgvector-ANN endpoints only (`HeavyRead.ann_endpoints/0`).
+
+### Why per-request `SET LOCAL hnsw.ef_search` is now safe (the stale objection)
+
+The moduledocs/runbook historically said per-request `SET LOCAL hnsw.ef_search`
+was unsafe "because it needs a transaction, re-introducing the #172 small-pool
+starvation". That objection **predates US-27.13**: since then EVERY heavy read
+already runs inside a short `SET LOCAL statement_timeout` transaction
+(`BEGIN; SET LOCAL; SELECT; COMMIT`), released at COMMIT. Adding one more
+`SET LOCAL hnsw.ef_search` to that same transaction adds no new checkout and no
+new hold — it is the opposite of a long-held connection. It remains NOT settable
+via Postgrex startup `:parameters` (pgbouncer rejects the custom GUC — the US-27.13
+outage class, still guarded by `config_pgbouncer_safe_parameters_test.exs`). The
+code and its own docs are reconciled to say so.
+
+### Recall vs latency vs build-cost / size evaluation
+
+- **`m`** governs graph connectivity. Higher `m` → higher recall AND larger index
+  + slower build + more memory. pgvector's default 16 is the balanced choice for
+  corpora up to the millions; loopctl's corpus (≈76k articles, growing memories)
+  is comfortably in the range where 16 gives strong recall without inflating index
+  size. Raising it has a permanent size/build cost for a marginal recall gain that
+  the cheaper query-time `ef_search` knob captures on demand.
+- **`ef_construction`** governs build-time candidate breadth. Higher → better graph
+  quality (recall) at higher BUILD cost only (no query-time or size cost beyond the
+  graph it produces). Default 64 builds the current corpus fast; there is no recall
+  complaint that would justify the slower builds of a higher value.
+- **`ef_search`** is the cheap, reversible, query-time recall lever. Rather than
+  bake more recall into a costly rebuild, we keep `m`/`ef_construction` at the
+  balanced defaults and expose `ef_search` as a live knob (default 40) so an
+  operator can trade latency for recall fleet-wide with a single `UPDATE` and
+  **no redeploy** — and back off just as easily. This is the correct place to
+  spend the recall/latency budget for a moderate, growing corpus.
+
+**Decision: keep `m=16`, `ef_construction=64`, `ef_search=40`** — now explicit,
+single-sourced, and (for `ef_search`) live-tunable. Revisit `m`/`ef_construction`
+(with an online reindex migration) only if a scale-representative recall gate shows
+the default graph under-recalling at a materially larger corpus.
+
+### Recall no-regression
+
+`m`/`ef_construction`/`ef_search` are all unchanged, so recall is unchanged by
+construction. The recall gate (`test/loopctl/memory/scale_recall_test.exs`,
+`test/loopctl/knowledge/vector_search_test.exs`) continues to pass; the builder unit
+test asserts the emitted DDL carries the configured `WITH (...)` and that the ANN
+read path issues `SET LOCAL hnsw.ef_search`.
+
+---
+
+## Track B — `memories.embedding` dual HNSW index justification
+
+`memories.embedding` carries TWO HNSW indexes:
+
+1. **Full** — all rows incl. superseded (migration `20260709000100`, built via
+   `HnswIndex.create_if_absent_sql("memories")`). On the live DB it is named
+   `memories_embedding_idx` (the builder's create name; no reconcile migration ran
+   for memories, unlike articles — detection is capability-based, so the name does
+   not matter).
+2. **Partial** — `WHERE superseded_by IS NULL` (migration `20260709000300`),
+   `memories_live_embedding_hnsw_idx`.
+
+### Is the full index actually queried, or do all live searches use the partial?
+
+The full index is **not** dead. `include_superseded: true` is a real,
+publicly-reachable recall path (the `memory_recall` MCP tool +
+`LoopctlWeb.MemoryController`). When `include_superseded: true`, `Loopctl.Memory`
+drops the inner `superseded_by IS NULL` filter → the query predicate no longer
+implies the partial index's predicate, so the planner CANNOT use the partial index
+and serves the ANN from the full index. The default (hot) path adds
+`superseded_by IS NULL`, exactly matching the partial index predicate, so it serves
+the smaller partial index (keeping superseded rows out of the over-fetch pool — the
+US-28.2 crowding fix).
+
+### EXPLAIN evidence (dev DB, planner forced with `enable_seqscan/enable_sort = off`
+to reveal index eligibility on the empty-scale table)
+
+Default / live-only path (`... AND superseded_by IS NULL ORDER BY embedding <=> $1`):
+
+```
+Index Scan using memories_live_embedding_hnsw_idx on memories
+  Order By: (embedding <=> $1)
+  Filter: ((embedding IS NOT NULL) AND (tenant_id = $2))
+```
+
+Include-superseded path (no `superseded_by` filter, `ORDER BY embedding <=> $1`):
+
+```
+Index Scan using memories_embedding_idx on memories
+  Order By: (embedding <=> $1)
+  Filter: ((embedding IS NOT NULL) AND (tenant_id = $2))
+```
+
+Two distinct HNSW indexes, each the ONLY HNSW option for a distinct, live code
+path. A partial index is provably ineligible for the include-superseded query
+(predicate mismatch), so dropping the full index would force `include_superseded`
+recall onto a Seq Scan + Sort — the #170/#172 timeout shape at scale.
+
+**Decision: keep both.** Whichever the outcome, semantic recall of LIVE memories is
+unchanged: the default path still serves the partial index; the test asserts the
+default and `include_superseded` recall sets are unchanged.
+
+### Rollback note (all DDL is online + reversible)
+
+- The parameter change ships **no reindex** (values unchanged), so there is nothing
+  to roll back on the live indexes. A FUTURE param change would ship an online
+  migration: `@disable_ddl_transaction true` + `@disable_migration_lock true`,
+  `CREATE INDEX CONCURRENTLY <new>` with the new `WITH (...)`, then
+  `DROP INDEX CONCURRENTLY <old>` — rollback recreates the old-param index the same
+  online way (`m`/`ef_construction` are build-time; never `ALTER ... SET` in place).
+- The `hnsw_ef_search` seed migration is a single `INSERT ... ON CONFLICT DO NOTHING`
+  with a `DELETE` down; a missing row safely falls back to the in-code default 40.

--- a/docs/runbooks/knowledge-scale.md
+++ b/docs/runbooks/knowledge-scale.md
@@ -100,7 +100,9 @@ pool self-drains within `statement_timeout`.
 > Postgres, which is why CI didn't catch it; `config_pgbouncer_safe_parameters_test.exs` +
 > the `pgbouncer-e2e` CI job now guard this.) `SET LOCAL` inside a transaction is the only
 > pgbouncer-safe way to set a server GUC; a GUC that must persist at connect goes via
-> `ALTER ROLE` (the `hnsw.ef_search` lever), never `:parameters`.
+> `ALTER ROLE` (e.g. a role-scoped `hnsw.ef_search` default — the live per-read recall
+> override is `SystemConfig` via `SET LOCAL`, see the recall-lever section), never
+> `:parameters`.
 
 Verify the per-read timeout live (it is NOT a session/pool GUC, so a bare `SHOW` reads the
 server default — read it INSIDE the SET LOCAL transaction):
@@ -167,7 +169,8 @@ param). Hard-won rules for anything touching the DB layer behind pgbouncer:
 
 - **No GUC via connection `:parameters`.** A server GUC is applied per-read via `SET LOCAL`
   inside a transaction (`Loopctl.HeavyRead`); a GUC that must persist at connect goes via
-  `ALTER ROLE` (the `hnsw.ef_search` lever). The config-lint
+  `ALTER ROLE` (e.g. a role-scoped `hnsw.ef_search` default; the live per-read recall
+  override is `SystemConfig` via `SET LOCAL` — see the recall-lever section). The config-lint
   (`config_pgbouncer_safe_parameters_test.exs`) blocks a re-added startup `:parameters` GUC —
   but that is ONLY the startup-parameter member of the class. It does NOT guard the other
   pgbouncer-sensitive paths below; those depend on the **pool mode**.
@@ -396,21 +399,40 @@ The change is live on this node on write and on every other node within a minute
 (the `SystemConfigRefreshWorker` cron). The value is clamped to pgvector's accepted
 `[1, 1000]` by `Loopctl.HeavyRead.hnsw_ef_search/0`, so a bad value can never make
 the `SET LOCAL` raise. Only the pgvector-ANN endpoints
-(`Loopctl.HeavyRead.ann_endpoints/0`) carry it; non-ANN heavy reads never set the GUC.
+(`Loopctl.HeavyRead.ann_endpoints/0` — `suggested_links`, `semantic_search`, `novelty`,
+`vector_search`, `memory_recall`; the `distant_pairs*` self-joins are NOT ANN and never
+carry it) get it, and only when the value **differs from the pgvector default 40** — at
+the default no per-read `SET LOCAL` is issued at all (see the precedence note below).
 
-**Alternative lever: role-level `ALTER ROLE`** (applies per-session after the
-extension loads) — still works, e.g. for a change that must persist independent of
-the app config table:
+**Alternative lever: role-level `ALTER ROLE`** (a role-scoped default that applies
+per-session after the extension loads) — still works, and is HONORED because the
+`SystemConfig` per-read `SET LOCAL` is emitted **only for a non-default value**. This is a
+real precedence contract, not two competing levers:
+
+- `SystemConfig = 40` (default) → **no** per-read `SET LOCAL` → the session/role default
+  governs, so `ALTER ROLE ... SET hnsw.ef_search = N` is honored fleet-wide.
+- `SystemConfig = <non-default>` → a per-read `SET LOCAL hnsw.ef_search = <value>` is issued
+  and, because `SET LOCAL` overrides any role/session default for its transaction, that
+  value wins for the ANN read.
+
+So use `ALTER ROLE` for a role-scoped default that must persist independent of the app
+config table (leaving `SystemConfig` at 40); use `SystemConfig` for a live, no-redeploy
+fleet-wide override. NB: to pin ANN reads to exactly 40 while a higher `ALTER ROLE` default
+exists, lower the role default — setting `SystemConfig = 40` is treated as "no override" and
+will NOT force the reads back down (that is the whole point of not shadowing the role lever).
 
 ```sql
 ALTER ROLE <heavy_read_role> SET hnsw.ef_search = 100;
 ```
 
-Then confirm a per-ANN-read value through the pool (inside a transaction, since the
-value is `SET LOCAL`):
+Then confirm the value through the pool. A role default shows on a plain `SHOW`; a
+`SystemConfig` per-read value is `SET LOCAL`, so confirm it inside a transaction:
 
 ```sh
+# Role default (ALTER ROLE) — plain SHOW on a fresh checkout:
 fly ssh console -a loopctl -C "/app/bin/loopctl rpc 'IO.inspect(Loopctl.HeavyReadRepo.query!(\"SHOW hnsw.ef_search\").rows)'"
+# SystemConfig per-read value — inside a transaction (as the ANN read runs it):
+fly ssh console -a loopctl -C "/app/bin/loopctl rpc 'Loopctl.HeavyReadRepo.transaction(fn r -> r.query!(\"SET LOCAL hnsw.ef_search = #{Loopctl.HeavyRead.hnsw_ef_search()}\"); IO.inspect(r.query!(\"SHOW hnsw.ef_search\").rows) end)'"
 ```
 
 ### Recall ceiling + the under-fill signal (US-27.6b)
@@ -452,12 +474,13 @@ connectivity/timeout fault on this advisory probe is fail-soft: the suggestions 
 returned with no truncation signal rather than failing the request.
 
 **Raising recall** (US-38.4) is the live `SystemConfig hnsw_ef_search` knob (or the
-`ALTER ROLE … SET hnsw.ef_search` lever) documented above — applied per-ANN-read via
-`SET LOCAL hnsw.ef_search` inside the heavy read's EXISTING short transaction, so it no
-longer re-introduces the #172 small-pool starvation (that objection predated US-27.13's
-per-read transaction). It is still never a startup `:parameters` value (pgbouncer rejects
-that). Until an operator raises it, recall stays at the default 40 and is handled by
-over-fetch + this under-fill signal.
+`ALTER ROLE … SET hnsw.ef_search` role default, honored while `SystemConfig` sits at 40 —
+see the precedence contract above) documented above. A non-default `SystemConfig` value is
+applied per-ANN-read via `SET LOCAL hnsw.ef_search` inside the heavy read's EXISTING short
+transaction, so it no longer re-introduces the #172 small-pool starvation (that objection
+predated US-27.13's per-read transaction). It is still never a startup `:parameters` value
+(pgbouncer rejects that). Until an operator raises it, recall stays at the default 40, NO
+per-read `SET LOCAL` is issued, and recall is handled by over-fetch + this under-fill signal.
 
 ## Metrics & alerting (US-27.15)
 
@@ -725,6 +748,7 @@ and `semantic` search:
   `@prod_article_floor` in `Loopctl.Knowledge.ScaleSeed` (a documented step).
 - **`hnsw.ef_search` parity.** The under-fill gate asserts the EFFECTIVE `ef_search`
   (`SHOW hnsw.ef_search`) is identical on the gate connection and a prod-shaped one; the
-  calibration test proves the FAILURE direction (a divergent value RAISES). When US-27.11's
-  `ALTER ROLE … SET hnsw.ef_search = N` lands a non-default value, update the `== "40"` pin
-  in `vector_search_under_fill_scale_test.exs` to the new value.
+  calibration test proves the FAILURE direction (a divergent value RAISES). When EITHER
+  recall lever lands a non-default value — a role-scoped `ALTER ROLE … SET hnsw.ef_search = N`
+  default, OR the live `SystemConfig hnsw_ef_search` per-read `SET LOCAL` (US-38.4) — update
+  the `== "40"` pin in `vector_search_under_fill_scale_test.exs` to the new effective value.

--- a/docs/runbooks/knowledge-scale.md
+++ b/docs/runbooks/knowledge-scale.md
@@ -376,18 +376,38 @@ frees the connection rather than holding it.
 
 `hnsw.ef_search` is a pgvector **custom** GUC that does not exist until the
 extension loads per-session, so it is **NOT** settable via Postgrex `:parameters`
-on managed PG (fly mpg/RDS reject it: *"unrecognized configuration parameter"*).
-It currently stays at the pgvector **default (40)**; recall is handled by
-over-fetch + the US-27.6b under-fill signal.
+on managed PG (fly mpg/RDS reject it: *"unrecognized configuration parameter"* —
+still guarded by `config_pgbouncer_safe_parameters_test.exs`).
 
-If recall must be raised, set it on the **role** (applies per-session after the
-extension loads), NOT via `:parameters`:
+**Primary lever (US-38.4): the live-tunable SystemConfig `hnsw_ef_search` key.**
+It is applied per-ANN-read via `SET LOCAL hnsw.ef_search = <value>` inside the
+SAME short heavy-read transaction that already scopes `SET LOCAL statement_timeout`
+(`Loopctl.HeavyRead.run_timed_transaction/4`) — so there is **no** new
+pool-starvation risk (the pre-US-27.13 "SET LOCAL needs a transaction → #172
+starvation" objection is stale; the transaction is already there). It defaults to
+the pgvector default **40**; recall is handled by over-fetch + the US-27.6b
+under-fill signal + this knob. To raise recall fleet-wide with **no redeploy**:
+
+```sql
+UPDATE system_configs SET value = 100, updated_at = now() WHERE key = 'hnsw_ef_search';
+```
+
+The change is live on this node on write and on every other node within a minute
+(the `SystemConfigRefreshWorker` cron). The value is clamped to pgvector's accepted
+`[1, 1000]` by `Loopctl.HeavyRead.hnsw_ef_search/0`, so a bad value can never make
+the `SET LOCAL` raise. Only the pgvector-ANN endpoints
+(`Loopctl.HeavyRead.ann_endpoints/0`) carry it; non-ANN heavy reads never set the GUC.
+
+**Alternative lever: role-level `ALTER ROLE`** (applies per-session after the
+extension loads) — still works, e.g. for a change that must persist independent of
+the app config table:
 
 ```sql
 ALTER ROLE <heavy_read_role> SET hnsw.ef_search = 100;
 ```
 
-Then confirm through the pool:
+Then confirm a per-ANN-read value through the pool (inside a transaction, since the
+value is `SET LOCAL`):
 
 ```sh
 fly ssh console -a loopctl -C "/app/bin/loopctl rpc 'IO.inspect(Loopctl.HeavyReadRepo.query!(\"SHOW hnsw.ef_search\").rows)'"
@@ -431,10 +451,13 @@ dedicated heavy-read pool. It is an ANN-class read (same plan shape as the main 
 connectivity/timeout fault on this advisory probe is fail-soft: the suggestions are still
 returned with no truncation signal rather than failing the request.
 
-**Raising recall** is the `ALTER ROLE … SET hnsw.ef_search` lever above (US-27.11), never a
-per-request `:parameters` or `SET LOCAL` (the latter needs a transaction and re-introduces
-the #172 small-pool starvation). Until ef_search is raised (and verified on fly mpg),
-recall stays at the default and is handled by over-fetch + this under-fill signal.
+**Raising recall** (US-38.4) is the live `SystemConfig hnsw_ef_search` knob (or the
+`ALTER ROLE … SET hnsw.ef_search` lever) documented above — applied per-ANN-read via
+`SET LOCAL hnsw.ef_search` inside the heavy read's EXISTING short transaction, so it no
+longer re-introduces the #172 small-pool starvation (that objection predated US-27.13's
+per-read transaction). It is still never a startup `:parameters` value (pgbouncer rejects
+that). Until an operator raises it, recall stays at the default 40 and is handled by
+over-fetch + this under-fill signal.
 
 ## Metrics & alerting (US-27.15)
 

--- a/lib/loopctl/heavy_read.ex
+++ b/lib/loopctl/heavy_read.ex
@@ -181,8 +181,10 @@ defmodule Loopctl.HeavyRead do
 
   For a pgvector-ANN endpoint (`ann_endpoints/0`) it ALSO carries `:hnsw_ef_search`
   (US-38.4) — the per-query recall breadth applied via `SET LOCAL hnsw.ef_search` inside
-  the same heavy-read transaction. `all/3`/`one/3`/`all_memory/4` pop it (like
-  `:statement_timeout`) before handing the remaining opts to the repo.
+  the same heavy-read transaction — but ONLY when the live `SystemConfig` value differs
+  from pgvector's default (at the default no key is attached, so a role-level `ALTER ROLE`
+  override is not shadowed; see `hnsw_ef_search/0`). `all/3`/`one/3`/`all_memory/4` pop it
+  (like `:statement_timeout`) before handing the remaining opts to the repo.
 
   This is the SINGLE source of truth for heavy-read opts — every consumer
   (`Loopctl.Knowledge`, `Loopctl.Audit`) builds opts via this function so the
@@ -204,17 +206,25 @@ defmodule Loopctl.HeavyRead do
   `:llm_usage` (the customer-facing LLM-usage aggregate over `llm_usage_events`, a
   bounded indexed COUNT/GROUP BY — classified LIGHT by the gate).
   """
-  # US-38.4: the pgvector-ANN (kNN) endpoints whose reads order by cosine distance
-  # against the HNSW index and are therefore governed by `hnsw.ef_search`. ONLY these get a per-read
-  # `SET LOCAL hnsw.ef_search` (see `maybe_put_ef_search/2`) — the non-ANN heavy reads
+  # US-38.4: the pgvector-ANN (kNN) endpoints whose reads run an index-ordered
+  # `ORDER BY (embedding cosine-distance $const) LIMIT k` scan against the HNSW index and are
+  # therefore governed by `hnsw.ef_search`. ONLY these get a per-read `SET LOCAL hnsw.ef_search`
+  # (see `maybe_put_ef_search/2`), and only when the configured value differs from the
+  # pgvector default. The non-ANN heavy reads
   # (enumeration/change_feed/ingestion_jobs/sth_incremental/export/llm_usage) never touch
-  # the HNSW index, so setting the GUC on them would be dead work. A subset of
-  # `@known_endpoints` (asserted by the ann-endpoints test).
+  # the HNSW index, so setting the GUC on them would be dead work.
+  #
+  # `distant_pairs`/`distant_pairs_bridge` are DELIBERATELY EXCLUDED even though they read
+  # `articles.embedding`: they are column-to-column (embedding-to-embedding) cosine-distance
+  # self-joins with NO `$const` target vector, so pgvector's HNSW index cannot apply to them
+  # by nature — the codebase's own `Loopctl.Knowledge.CosineLintExceptions` registers
+  # `do_distant_pairs/7` with exactly that rationale ("no $const target, HNSW N/A").
+  # `hnsw.ef_search` only affects index-ordered `ORDER BY <distance> LIMIT k` kNN scans, so a
+  # `SET LOCAL hnsw.ef_search` on those self-joins would be a no-op round-trip with zero
+  # recall/latency effect. A subset of `@known_endpoints` (asserted by the ann-endpoints test).
   @ann_endpoints ~w(
     suggested_links
     semantic_search
-    distant_pairs
-    distant_pairs_bridge
     novelty
     vector_search
     memory_recall
@@ -233,17 +243,41 @@ defmodule Loopctl.HeavyRead do
   end
 
   # US-38.4: attach the per-QUERY `hnsw.ef_search` recall breadth ONLY to the
-  # pgvector-ANN endpoints (`ann_endpoints/0`) — a `SET LOCAL hnsw.ef_search = N`
-  # then piggybacks on the SAME short `SET LOCAL statement_timeout` transaction every
-  # heavy read already runs in (US-27.13), so it adds NO new pool-starvation risk (the
-  # historical objection that per-request `SET LOCAL` "needs a transaction" is stale —
-  # the transaction is already there). Non-ANN endpoints (audit/enumeration/export) get
-  # no ef_search key, so an unused GUC is never set on their connections.
+  # pgvector-ANN endpoints (`ann_endpoints/0`), and ONLY when the live SystemConfig value
+  # DIFFERS from pgvector's built-in default. A `SET LOCAL hnsw.ef_search = N` then
+  # piggybacks on the SAME short `SET LOCAL statement_timeout` transaction every heavy read
+  # already runs in (US-27.13), so it adds NO new pool-starvation risk (the historical
+  # objection that per-request `SET LOCAL` "needs a transaction" is stale — the transaction
+  # is already there). Non-ANN endpoints (audit/enumeration/export) get no ef_search key, so
+  # an unused GUC is never set on their connections.
+  #
+  # Emitting SET LOCAL ONLY for a NON-default value is deliberate (US-38.4 review fix): a
+  # `SET LOCAL` overrides any role/session default for the duration of its transaction, so
+  # unconditionally setting the pgvector default would silently SHADOW a role-level
+  # `ALTER ROLE <role> SET hnsw.ef_search = N` on every ANN read. Skipping the emission at
+  # the default keeps `SystemConfig` the fleet-wide lever (a non-default value wins per-read)
+  # WITHOUT clobbering a role-level override when `SystemConfig` is left at the default — and
+  # it means the common (default) path issues no ANN GUC round-trip at all.
   defp maybe_put_ef_search(opts, endpoint) do
     if endpoint in @ann_endpoints do
-      Keyword.put(opts, :hnsw_ef_search, hnsw_ef_search())
+      case ef_search_override() do
+        nil -> opts
+        ef -> Keyword.put(opts, :hnsw_ef_search, ef)
+      end
     else
       opts
+    end
+  end
+
+  # The per-read `hnsw.ef_search` value to APPLY via `SET LOCAL`, or `nil` to leave the
+  # session/role default untouched. `nil` exactly when the configured (clamped) value equals
+  # pgvector's built-in default — so a role-level `ALTER ROLE ... SET hnsw.ef_search` override
+  # is honored rather than shadowed by an identical-to-default per-read `SET LOCAL`.
+  @spec ef_search_override() :: pos_integer() | nil
+  defp ef_search_override do
+    case hnsw_ef_search() do
+      @default_hnsw_ef_search -> nil
+      ef -> ef
     end
   end
 
@@ -288,15 +322,21 @@ defmodule Loopctl.HeavyRead do
   def ann_endpoints, do: @ann_endpoints
 
   @doc """
-  The configured per-query `hnsw.ef_search` recall breadth (US-38.4).
+  The configured per-query `hnsw.ef_search` recall breadth (US-38.4), clamped to
+  pgvector's accepted `[1, 1000]` range.
 
   Read from the live-tunable `SystemConfig` key `"hnsw_ef_search"` (a missing row →
   the pgvector default #{@default_hnsw_ef_search}), so an operator can raise recall
-  fleet-wide with a single `UPDATE` — no redeploy, no per-role `ALTER ROLE`. Clamped to
-  pgvector's accepted `[1, 1000]` range so a bad config value can never make the
-  `SET LOCAL hnsw.ef_search` raise and roll back the read; a value outside the range is
-  pulled to the nearest bound. Applied per-read via `SET LOCAL` inside the heavy-read
-  transaction (`run_timed_transaction/4`).
+  fleet-wide with a single `UPDATE` — no redeploy. Clamped so a bad config value can
+  never make the `SET LOCAL hnsw.ef_search` raise and roll back the read; a value outside
+  the range is pulled to the nearest bound.
+
+  NB: this returns the configured value even when it EQUALS the default. Whether a per-read
+  `SET LOCAL` is actually issued is decided by `maybe_put_ef_search/2`: at the default NO
+  `SET LOCAL` fires (so a role-level `ALTER ROLE <role> SET hnsw.ef_search` is honored,
+  never shadowed); a NON-default value is applied per-read via `SET LOCAL` inside the
+  heavy-read transaction (`run_timed_transaction/4`), taking precedence over any role/session
+  default for that ANN read.
   """
   @spec hnsw_ef_search() :: pos_integer()
   def hnsw_ef_search do

--- a/lib/loopctl/heavy_read.ex
+++ b/lib/loopctl/heavy_read.ex
@@ -179,9 +179,15 @@ defmodule Loopctl.HeavyRead do
   server-side statement_timeout. Also passes the endpoint key via `telemetry_options` so
   slow-query logs can trace which endpoint triggered the query.
 
+  For a pgvector-ANN endpoint (`ann_endpoints/0`) it ALSO carries `:hnsw_ef_search`
+  (US-38.4) — the per-query recall breadth applied via `SET LOCAL hnsw.ef_search` inside
+  the same heavy-read transaction. `all/3`/`one/3`/`all_memory/4` pop it (like
+  `:statement_timeout`) before handing the remaining opts to the repo.
+
   This is the SINGLE source of truth for heavy-read opts — every consumer
   (`Loopctl.Knowledge`, `Loopctl.Audit`) builds opts via this function so the
-  `[timeout, telemetry_options, statement_timeout]` shape can't drift between callers.
+  `[timeout, telemetry_options, statement_timeout, hnsw_ef_search]` shape can't drift
+  between callers.
   Known endpoints are enumerated in `known_endpoints/0`: `:suggested_links`,
   `:semantic_search`, `:distant_pairs`, `:distant_pairs_bridge` (the slower
   `bridge_path=true` branch — its own key so its statement_timeout/slow-query
@@ -198,10 +204,47 @@ defmodule Loopctl.HeavyRead do
   `:llm_usage` (the customer-facing LLM-usage aggregate over `llm_usage_events`, a
   bounded indexed COUNT/GROUP BY — classified LIGHT by the gate).
   """
+  # US-38.4: the pgvector-ANN (kNN) endpoints whose reads order by cosine distance
+  # against the HNSW index and are therefore governed by `hnsw.ef_search`. ONLY these get a per-read
+  # `SET LOCAL hnsw.ef_search` (see `maybe_put_ef_search/2`) — the non-ANN heavy reads
+  # (enumeration/change_feed/ingestion_jobs/sth_incremental/export/llm_usage) never touch
+  # the HNSW index, so setting the GUC on them would be dead work. A subset of
+  # `@known_endpoints` (asserted by the ann-endpoints test).
+  @ann_endpoints ~w(
+    suggested_links
+    semantic_search
+    distant_pairs
+    distant_pairs_bridge
+    novelty
+    vector_search
+    memory_recall
+  )a
+
+  # pgvector's default `hnsw.ef_search` (the per-query search breadth / recall ceiling).
+  @default_hnsw_ef_search 40
+
   @spec opts(atom()) :: keyword()
   def opts(endpoint) when is_atom(endpoint) do
     base = [timeout: 15_000, telemetry_options: [endpoint: endpoint]]
-    Keyword.put(base, :statement_timeout, statement_timeout_for(endpoint))
+
+    base
+    |> Keyword.put(:statement_timeout, statement_timeout_for(endpoint))
+    |> maybe_put_ef_search(endpoint)
+  end
+
+  # US-38.4: attach the per-QUERY `hnsw.ef_search` recall breadth ONLY to the
+  # pgvector-ANN endpoints (`ann_endpoints/0`) — a `SET LOCAL hnsw.ef_search = N`
+  # then piggybacks on the SAME short `SET LOCAL statement_timeout` transaction every
+  # heavy read already runs in (US-27.13), so it adds NO new pool-starvation risk (the
+  # historical objection that per-request `SET LOCAL` "needs a transaction" is stale —
+  # the transaction is already there). Non-ANN endpoints (audit/enumeration/export) get
+  # no ef_search key, so an unused GUC is never set on their connections.
+  defp maybe_put_ef_search(opts, endpoint) do
+    if endpoint in @ann_endpoints do
+      Keyword.put(opts, :hnsw_ef_search, hnsw_ef_search())
+    else
+      opts
+    end
   end
 
   # Every endpoint atom a caller passes to `opts/1` / stamps into `telemetry_options`.
@@ -236,6 +279,31 @@ defmodule Loopctl.HeavyRead do
   """
   @spec known_endpoints() :: [atom()]
   def known_endpoints, do: @known_endpoints
+
+  @doc """
+  The pgvector-ANN endpoints that carry a per-read `hnsw.ef_search` (subset of
+  `known_endpoints/0`).
+  """
+  @spec ann_endpoints() :: [atom()]
+  def ann_endpoints, do: @ann_endpoints
+
+  @doc """
+  The configured per-query `hnsw.ef_search` recall breadth (US-38.4).
+
+  Read from the live-tunable `SystemConfig` key `"hnsw_ef_search"` (a missing row →
+  the pgvector default #{@default_hnsw_ef_search}), so an operator can raise recall
+  fleet-wide with a single `UPDATE` — no redeploy, no per-role `ALTER ROLE`. Clamped to
+  pgvector's accepted `[1, 1000]` range so a bad config value can never make the
+  `SET LOCAL hnsw.ef_search` raise and roll back the read; a value outside the range is
+  pulled to the nearest bound. Applied per-read via `SET LOCAL` inside the heavy-read
+  transaction (`run_timed_transaction/4`).
+  """
+  @spec hnsw_ef_search() :: pos_integer()
+  def hnsw_ef_search do
+    Loopctl.SystemConfig.get_int("hnsw_ef_search", @default_hnsw_ef_search)
+    |> max(1)
+    |> min(1000)
+  end
 
   # The per-endpoint override if a positive int, else the pool-wide default. Always a
   # positive int → every heavy read runs under a SET LOCAL statement_timeout (the
@@ -281,12 +349,13 @@ defmodule Loopctl.HeavyRead do
     # which would silently treat an explicit `0` as truthy and an explicit `nil` as "use
     # default", muddying the always-timed contract.
     {st, opts} = Keyword.pop(opts, :statement_timeout, default_statement_timeout())
+    {ef, opts} = Keyword.pop(opts, :hnsw_ef_search, nil)
     {on_overload, opts} = Keyword.pop(opts, :on_overload, :raise)
     query = guard!(tenant_id, queryable)
     read_repo = repo_for(endpoint(opts))
 
     gated(tenant_id, opts, on_overload, fn ->
-      with_statement_timeout(read_repo, st, fn -> read_repo.all(query, opts) end)
+      with_statement_timeout(read_repo, st, ef, fn -> read_repo.all(query, opts) end)
     end)
   end
 
@@ -295,12 +364,13 @@ defmodule Loopctl.HeavyRead do
           term() | nil | {:error, :heavy_read_overloaded}
   def one(tenant_id, queryable, opts \\ []) do
     {st, opts} = Keyword.pop(opts, :statement_timeout, default_statement_timeout())
+    {ef, opts} = Keyword.pop(opts, :hnsw_ef_search, nil)
     {on_overload, opts} = Keyword.pop(opts, :on_overload, :raise)
     query = guard!(tenant_id, queryable)
     read_repo = repo_for(endpoint(opts))
 
     gated(tenant_id, opts, on_overload, fn ->
-      with_statement_timeout(read_repo, st, fn -> read_repo.one(query, opts) end)
+      with_statement_timeout(read_repo, st, ef, fn -> read_repo.one(query, opts) end)
     end)
   end
 
@@ -329,12 +399,13 @@ defmodule Loopctl.HeavyRead do
           [term()] | {:error, :heavy_read_overloaded}
   def all_memory(tenant_id, subject_id, queryable, opts \\ []) do
     {st, opts} = Keyword.pop(opts, :statement_timeout, default_statement_timeout())
+    {ef, opts} = Keyword.pop(opts, :hnsw_ef_search, nil)
     {on_overload, opts} = Keyword.pop(opts, :on_overload, :raise)
     query = guard_memory!(tenant_id, subject_id, queryable)
     read_repo = repo_for(endpoint(opts))
 
     gated(tenant_id, opts, on_overload, fn ->
-      with_statement_timeout(read_repo, st, fn -> read_repo.all(query, opts) end)
+      with_statement_timeout(read_repo, st, ef, fn -> read_repo.all(query, opts) end)
     end)
   end
 
@@ -390,8 +461,8 @@ defmodule Loopctl.HeavyRead do
   # positive default, and a non-positive/`nil` value (an explicit mis-call) raises rather than
   # silently running un-timed (US-27.13: every heavy read MUST carry a server-side timeout
   # since the pgbouncer-rejected startup `:parameters` lever is gone).
-  defp with_statement_timeout(read_repo, ms, fun) when is_integer(ms) and ms > 0 do
-    case run_timed_transaction(read_repo, ms, fun) do
+  defp with_statement_timeout(read_repo, ms, ef, fun) when is_integer(ms) and ms > 0 do
+    case run_timed_transaction(read_repo, ms, ef, fun) do
       {:ok, result} ->
         result
 
@@ -404,20 +475,36 @@ defmodule Loopctl.HeavyRead do
     end
   end
 
-  defp with_statement_timeout(_read_repo, ms, _fun) do
+  defp with_statement_timeout(_read_repo, ms, _ef, _fun) do
     raise ArgumentError,
           ":statement_timeout (got #{inspect(ms)}) must be a positive integer (ms)"
   end
 
   # A transaction on `read_repo` that first scopes `SET LOCAL statement_timeout` to THIS
-  # transaction (pgbouncer-safe, US-27.13), then runs `fun`. Mirrors the public
-  # `transaction/2` SET LOCAL, but pinned to the caller-resolved read repo so a
+  # transaction (pgbouncer-safe, US-27.13), then — for a pgvector-ANN read (US-38.4) —
+  # `SET LOCAL hnsw.ef_search` in the SAME transaction, then runs `fun`. Mirrors the
+  # public `transaction/2` SET LOCAL, but pinned to the caller-resolved read repo so a
   # primary-pinned read (US-38.1) both times AND executes on the primary.
-  defp run_timed_transaction(read_repo, ms, fun) do
+  defp run_timed_transaction(read_repo, ms, ef, fun) do
     read_repo.transaction(fn ->
       read_repo.query!("SET LOCAL statement_timeout = #{ms}")
+      maybe_set_ef_search(read_repo, ef)
       fun.()
     end)
+  end
+
+  # `SET LOCAL hnsw.ef_search = N` for an ANN read (US-38.4). Only fired when the caller
+  # (via `HeavyRead.opts/1` for an `ann_endpoints/0` endpoint) supplies a positive integer
+  # — non-ANN reads pass `nil` and set nothing. The value is pre-clamped to pgvector's
+  # accepted `[1, 1000]` by `hnsw_ef_search/0`, and is an integer (not user text), so the
+  # interpolation is injection-safe. Transaction-scoped, so it resets at COMMIT and never
+  # leaks across pooled checkouts. pgvector accepts setting this GUC before the vector
+  # module has loaded in the backend (namespaced placeholder), and the value applies when
+  # the cosine-distance operator in `fun` loads it — the pgvector-documented order.
+  defp maybe_set_ef_search(_read_repo, nil), do: :ok
+
+  defp maybe_set_ef_search(read_repo, ef) when is_integer(ef) and ef > 0 do
+    read_repo.query!("SET LOCAL hnsw.ef_search = #{ef}")
   end
 
   @doc """

--- a/lib/loopctl/knowledge/vector_search.ex
+++ b/lib/loopctl/knowledge/vector_search.ex
@@ -83,9 +83,16 @@ defmodule Loopctl.Knowledge.VectorSearch do
   piggybacks on that EXISTING bounded, self-draining transaction with **no new
   starvation risk**. `Loopctl.HeavyRead.opts/1` therefore attaches `:hnsw_ef_search`
   (config `SystemConfig "hnsw_ef_search"`, default 40 = pgvector's default) to every
-  ANN endpoint, applied per-read. An operator raises recall fleet-wide with a single
-  `UPDATE system_configs` — no redeploy, no per-role `ALTER ROLE` (that lever still
-  works too, see `docs/runbooks/knowledge-scale.md`). Recall is thus handled by
+  ANN endpoint **whenever that value differs from the default**, applied per-read. An
+  operator raises recall fleet-wide with a single
+  `UPDATE system_configs` — no redeploy. A role-level
+  `ALTER ROLE <role> SET hnsw.ef_search = N` still works as a role-scoped default and is
+  honored whenever `SystemConfig` is left at the default: the per-read `SET LOCAL` is emitted
+  ONLY for a NON-default `SystemConfig` value, so it never silently shadows the role override
+  (an unconditional `SET LOCAL` at the default would override that role default per-read —
+  the bug this guard avoids). When both are set to non-default values the per-read
+  `SystemConfig` `SET LOCAL` wins for that ANN read; see `docs/runbooks/knowledge-scale.md`.
+  Recall is thus handled by
   **over-fetch + the under-fill signal + the ef_search knob**; the current value stays
   at the default until an operator raises it.
 

--- a/lib/loopctl/knowledge/vector_search.ex
+++ b/lib/loopctl/knowledge/vector_search.ex
@@ -72,16 +72,22 @@ defmodule Loopctl.Knowledge.VectorSearch do
   count of above-threshold neighbors the anti-join removed — the recall-loss metric
   US-27.15 aggregates, computed from the single bounded under-fill probe.
 
-  **Raising recall is deliberately NOT done per-request here.** `hnsw.ef_search` is
-  a pgvector **custom GUC** that does not exist until the extension loads per
-  session, so it **cannot** be set via a Postgrex startup `:parameters` entry
-  (managed PG rejects it: *"unrecognized configuration parameter"* — see
-  `docs/runbooks/knowledge-scale.md`). Setting it per-request would require a
-  `SET LOCAL` inside a transaction, re-introducing the #172 pool-starvation
-  anti-pattern on the small heavy-read pool. The only safe non-transaction lever is
-  `ALTER ROLE <heavy_read_role> SET hnsw.ef_search = N` (US-27.11), and only if
-  verified to apply on fly mpg. Until then recall stays at the default and is
-  handled by **over-fetch + the under-fill signal**.
+  **Raising recall (US-38.4): `hnsw.ef_search` is now a per-query, live-tunable knob.**
+  `hnsw.ef_search` is a pgvector **custom GUC** that still **cannot** be set via a
+  Postgrex startup `:parameters` entry (managed PG/pgbouncer rejects it — the US-27.13
+  outage class, guarded by `config_pgbouncer_safe_parameters_test.exs`). The historical
+  objection that setting it per-request via `SET LOCAL` "needs a transaction and so
+  re-introduces the #172 pool-starvation anti-pattern" is now **stale**: since US-27.13
+  every heavy read ALREADY runs inside a short `SET LOCAL statement_timeout` transaction
+  (`Loopctl.HeavyRead.run_timed_transaction/4`), so a `SET LOCAL hnsw.ef_search = N`
+  piggybacks on that EXISTING bounded, self-draining transaction with **no new
+  starvation risk**. `Loopctl.HeavyRead.opts/1` therefore attaches `:hnsw_ef_search`
+  (config `SystemConfig "hnsw_ef_search"`, default 40 = pgvector's default) to every
+  ANN endpoint, applied per-read. An operator raises recall fleet-wide with a single
+  `UPDATE system_configs` — no redeploy, no per-role `ALTER ROLE` (that lever still
+  works too, see `docs/runbooks/knowledge-scale.md`). Recall is thus handled by
+  **over-fetch + the under-fill signal + the ef_search knob**; the current value stays
+  at the default until an operator raises it.
 
   ## Caller-cost bounds (AC-27.6a.4 — OWASP A06, insecure design)
 

--- a/lib/loopctl/repo/hnsw_index.ex
+++ b/lib/loopctl/repo/hnsw_index.ex
@@ -30,7 +30,66 @@ defmodule Loopctl.Repo.HnswIndex do
   Index names are derived from the table: `\#{table}_embedding_idx` (the old
   migration's create name) and `\#{table}_embedding_hnsw_idx` (the canonical
   reconciled name).
+
+  ## Build-time HNSW parameters (`m` / `ef_construction`) — US-38.4
+
+  Every `CREATE INDEX ... USING hnsw` this module emits now carries an EXPLICIT
+  `WITH (m = .., ef_construction = ..)` storage clause instead of relying on
+  pgvector's implicit defaults. The chosen values EQUAL pgvector's defaults
+  (`m = 16`, `ef_construction = 64`) — a deliberate, documented "keep the
+  defaults" outcome (see `docs/hnsw-tuning-evaluation.md`) — but making them
+  explicit means they are now an intentional, single-sourced, operator-tunable
+  decision rather than an implicit accident. Because the values are unchanged, no
+  reindex of the live `articles` / `memories` indexes is needed: they were built
+  with these exact defaults, so re-emitting them here only affects indexes created
+  FROM NOW ON (a fresh `mix ecto.reset`, or a future table). To change them, set
+  `config :loopctl, :hnsw_m` / `:hnsw_ef_construction` AND ship an ONLINE reindex
+  migration (`CREATE INDEX CONCURRENTLY` a new index with the new params, then drop
+  the old) — `m`/`ef_construction` are BUILD-time and cannot be `ALTER`ed in place.
+
+  `ef_search` (the per-QUERY recall breadth) is a separate, query-time knob and
+  lives on the read path (`Loopctl.HeavyRead`), NOT here.
   """
+
+  # pgvector's own defaults. Kept explicit + configurable (US-38.4) — see the
+  # moduledoc and docs/hnsw-tuning-evaluation.md for the keep-the-defaults rationale.
+  @default_hnsw_m 16
+  @default_hnsw_ef_construction 64
+
+  @doc """
+  The configured HNSW `m` build parameter (config `:hnsw_m`, default
+  #{@default_hnsw_m} = pgvector's default). Integer-validated.
+  """
+  @spec hnsw_m() :: pos_integer()
+  def hnsw_m,
+    do: validate_build_param!(:m, Application.get_env(:loopctl, :hnsw_m, @default_hnsw_m))
+
+  @doc """
+  The configured HNSW `ef_construction` build parameter (config
+  `:hnsw_ef_construction`, default #{@default_hnsw_ef_construction} = pgvector's
+  default). Integer-validated.
+  """
+  @spec hnsw_ef_construction() :: pos_integer()
+  def hnsw_ef_construction do
+    validate_build_param!(
+      :ef_construction,
+      Application.get_env(:loopctl, :hnsw_ef_construction, @default_hnsw_ef_construction)
+    )
+  end
+
+  @doc """
+  The `WITH (m = .., ef_construction = ..)` storage-parameter clause appended to
+  every `CREATE INDEX ... USING hnsw` this module (and the partial-index migration)
+  emits.
+
+  Both values are integer-validated (`validate_build_param!/2`) before
+  interpolation — mirroring the `validate!/1` SQL-identifier guard, they can NEVER
+  carry anything but a positive integer, so this is not an injection surface even
+  though the values flow from application config.
+  """
+  @spec with_params_clause() :: String.t()
+  def with_params_clause,
+    do: "WITH (m = #{hnsw_m()}, ef_construction = #{hnsw_ef_construction()})"
 
   @doc "The canonical (reconciled) HNSW index name for `table`."
   @spec canonical_index_name(String.t()) :: String.t()
@@ -63,7 +122,7 @@ defmodule Loopctl.Repo.HnswIndex do
           JOIN pg_am    am ON am.oid = i.relam
           WHERE t.relname = '#{table}' AND n.nspname = 'public' AND am.amname = 'hnsw'
         ) THEN
-          CREATE INDEX #{table}_embedding_idx ON #{table} USING hnsw (embedding vector_cosine_ops);
+          CREATE INDEX #{table}_embedding_idx ON #{table} USING hnsw (embedding vector_cosine_ops) #{with_params_clause()};
         END IF;
       END IF;
     END $$;
@@ -155,5 +214,19 @@ defmodule Loopctl.Repo.HnswIndex do
     else
       raise ArgumentError, "invalid table identifier: #{inspect(table)}"
     end
+  end
+
+  # HNSW build params (`m` / `ef_construction`) are interpolated into a CREATE INDEX
+  # storage clause, so — like the table identifier — they are validated to be a plain
+  # positive integer before ever reaching SQL. They come from application config (an
+  # operator knob), never user input, but a mistyped config value fails LOUDLY here
+  # rather than emitting malformed DDL. (pgvector further bounds them at build time:
+  # m ∈ [2,100], ef_construction ∈ [4,1000] with ef_construction ≥ 2*m; an out-of-range
+  # positive integer surfaces as a clear CREATE INDEX error, not an injection.)
+  defp validate_build_param!(_name, value) when is_integer(value) and value > 0, do: value
+
+  defp validate_build_param!(name, value) do
+    raise ArgumentError,
+          "HNSW #{name} must be a positive integer (config), got: #{inspect(value)}"
   end
 end

--- a/priv/repo/migrations/20260709000300_add_memories_live_embedding_partial_hnsw_index.exs
+++ b/priv/repo/migrations/20260709000300_add_memories_live_embedding_partial_hnsw_index.exs
@@ -25,6 +25,12 @@ defmodule Loopctl.Repo.Migrations.AddMemoriesLiveEmbeddingPartialHnswIndex do
   # Detected by EXACT NAME (not by `amname = 'hnsw'` capability, which the sibling
   # full-index migration uses) because there are now intentionally TWO HNSW indexes on
   # `memories.embedding` — a capability check would see the full index and skip this.
+  #
+  # US-38.4: the CREATE now carries the EXPLICIT `WITH (m = .., ef_construction = ..)`
+  # storage clause from `Loopctl.Repo.HnswIndex.with_params_clause/0` (values == pgvector
+  # defaults, so on the prod DB where this migration already ran it is a pure no-op — the
+  # existing index is unchanged; only a fresh `mix ecto.reset` builds with the explicit,
+  # identical params). See docs/hnsw-tuning-evaluation.md.
 
   @index "memories_live_embedding_hnsw_idx"
 
@@ -43,6 +49,7 @@ defmodule Loopctl.Repo.Migrations.AddMemoriesLiveEmbeddingPartialHnswIndex do
         ) THEN
           CREATE INDEX #{@index} ON memories
             USING hnsw (embedding vector_cosine_ops)
+            #{Loopctl.Repo.HnswIndex.with_params_clause()}
             WHERE superseded_by IS NULL;
         END IF;
       END IF;

--- a/priv/repo/migrations/20260715120000_seed_hnsw_ef_search_config.exs
+++ b/priv/repo/migrations/20260715120000_seed_hnsw_ef_search_config.exs
@@ -1,0 +1,34 @@
+defmodule Loopctl.Repo.Migrations.SeedHnswEfSearchConfig do
+  use Ecto.Migration
+
+  # US-38.4: seed the live-tunable per-query pgvector recall knob `hnsw_ef_search`.
+  #
+  # `hnsw.ef_search` is the per-QUERY HNSW search breadth (recall ceiling) — raising it
+  # inspects more graph nodes per kNN, trading latency for recall. The seeded value 40
+  # EQUALS pgvector's default (a deliberate "keep the default" tuning outcome — see
+  # docs/hnsw-tuning-evaluation.md), but seeding it makes the knob operator-visible and
+  # tunable fleet-wide from day one: an operator raises recall with a single
+  # `UPDATE system_configs SET value = 100 WHERE key = 'hnsw_ef_search'` — no redeploy,
+  # no per-role `ALTER ROLE`. It is read on the read path by
+  # `Loopctl.HeavyRead.hnsw_ef_search/0` (SystemConfig.get_int, persistent_term hot read;
+  # a missing row falls back to the in-code default 40, so this seed is a safe no-op if
+  # absent) and applied per-ANN-read via `SET LOCAL hnsw.ef_search` inside the existing
+  # heavy-read transaction (US-27.13), which is why per-request SET LOCAL is now safe.
+  #
+  # Global table, AdminRepo-only. ON CONFLICT keeps re-runs safe; DELETE down.
+  def change do
+    execute(
+      """
+      INSERT INTO system_configs (id, key, value, description, inserted_at, updated_at)
+      VALUES
+        (gen_random_uuid(), 'hnsw_ef_search', 40,
+          'Per-query pgvector hnsw.ef_search recall breadth, applied via SET LOCAL on ANN heavy reads',
+          now() AT TIME ZONE 'UTC', now() AT TIME ZONE 'UTC')
+      ON CONFLICT (key) DO NOTHING
+      """,
+      """
+      DELETE FROM system_configs WHERE key = 'hnsw_ef_search'
+      """
+    )
+  end
+end

--- a/test/loopctl/heavy_read_hnsw_ef_search_test.exs
+++ b/test/loopctl/heavy_read_hnsw_ef_search_test.exs
@@ -1,0 +1,162 @@
+defmodule Loopctl.HeavyReadHnswEfSearchTest do
+  @moduledoc """
+  US-38.4 (TC-38.4.1, query side): per-query `hnsw.ef_search` — `opts/1` attaches
+  `:hnsw_ef_search` for ANN endpoints ONLY on a non-default `SystemConfig` value, the
+  clamp keeps it inside pgvector's accepted `[1, 1000]`, and an ANN heavy read issues
+  `SET LOCAL hnsw.ef_search` on its own transaction (never at the default, so a
+  role-level `ALTER ROLE ... SET hnsw.ef_search` is honored, not shadowed).
+
+  ## Why `async: false` (deliberate, not an oversight)
+
+  `hnsw_ef_search/0` reads `SystemConfig.get_int("hnsw_ef_search", ...)`, which reads the
+  VM-global `:persistent_term` key `{Loopctl.SystemConfig, "hnsw_ef_search"}`. The tests
+  below PRIME that key to a non-default value (see `prime_ef_search/1`). That key is the
+  SAME global read by every `@ann_endpoint` heavy read fleet-wide — including the REAL
+  ANN reads in the `async: true` files `test/loopctl/memory/dual_index_recall_test.exs`
+  and `test/loopctl/knowledge/vector_search_test.exs`. Priming it from an `async: true`
+  module would let a concurrently-running cross-file ANN reader observe the primed value
+  and emit a different `SET LOCAL hnsw.ef_search` in its own transaction — an
+  async-global-state flake. The `[1, 1000]` clamp in `hnsw_ef_search/0` does NOT provide
+  cross-test isolation: it only prevents pgvector from RAISING on an out-of-range GUC; a
+  primed in-range value still bleeds into a concurrent reader's recall breadth. So these
+  persistent_term-mutating tests live here, isolated: a non-async module never runs
+  concurrently with any other module (`ExUnit.Case` `:async` docs), so no ANN reader is
+  running while the global is primed. The purely-structural sibling assertions on the
+  same wrapper stay in the `async: true` `HeavyReadTest`.
+  """
+  use Loopctl.DataCase, async: false
+
+  alias Loopctl.HeavyRead
+  alias Loopctl.Knowledge.Article
+
+  import Ecto.Query
+
+  describe "per-query hnsw.ef_search (US-38.4, TC-38.4.1 query side)" do
+    test "opts/1 attaches :hnsw_ef_search for ANN endpoints ONLY on a non-default value" do
+      # At the pgvector default (40) NO ef_search key is attached — so an unconditional
+      # SET LOCAL never shadows a role-level `ALTER ROLE SET hnsw.ef_search` (US-38.4 review).
+      assert HeavyRead.hnsw_ef_search() == 40, "precondition: default config"
+
+      for endpoint <- HeavyRead.ann_endpoints() do
+        refute Keyword.has_key?(HeavyRead.opts(endpoint), :hnsw_ef_search),
+               "expected #{endpoint} opts to carry NO :hnsw_ef_search at the default"
+      end
+
+      # A non-default SystemConfig value → every ANN endpoint carries it (the fleet-wide
+      # override), and every non-ANN endpoint still never does.
+      prime_ef_search(100)
+      assert HeavyRead.hnsw_ef_search() == 100
+
+      for endpoint <- HeavyRead.ann_endpoints() do
+        assert Keyword.get(HeavyRead.opts(endpoint), :hnsw_ef_search) == 100,
+               "expected non-default #{endpoint} opts to carry :hnsw_ef_search = 100"
+      end
+
+      for endpoint <- HeavyRead.known_endpoints() -- HeavyRead.ann_endpoints() do
+        refute Keyword.has_key?(HeavyRead.opts(endpoint), :hnsw_ef_search),
+               "expected non-ANN #{endpoint} opts to NOT carry :hnsw_ef_search"
+      end
+    end
+
+    test "ann_endpoints/0 is a subset of known_endpoints/0 (no drift)" do
+      assert HeavyRead.ann_endpoints() -- HeavyRead.known_endpoints() == []
+    end
+
+    test "distant_pairs / distant_pairs_bridge are NOT ANN endpoints (column-to-column self-join, HNSW N/A)" do
+      # They read articles.embedding but are `a.embedding <=> b.embedding` self-joins with no
+      # $const target, so hnsw.ef_search cannot apply (mirrors CosineLintExceptions). Guards
+      # against them being re-added to @ann_endpoints (a dead SET LOCAL round-trip).
+      refute :distant_pairs in HeavyRead.ann_endpoints()
+      refute :distant_pairs_bridge in HeavyRead.ann_endpoints()
+      # ...but they remain known (still weight-classified heavy reads).
+      assert :distant_pairs in HeavyRead.known_endpoints()
+      assert :distant_pairs_bridge in HeavyRead.known_endpoints()
+    end
+
+    test "hnsw_ef_search/0 reads the SystemConfig default (40)" do
+      assert HeavyRead.hnsw_ef_search() == 40
+    end
+
+    test "hnsw_ef_search/0 clamps an out-of-range SystemConfig value into [1, 1000]" do
+      # pgvector REJECTS ef_search outside [1, 1000] (raising + rolling back the whole heavy
+      # read), so the max(1) |> min(1000) clamp is load-bearing for availability. Exercise
+      # both bounds AND the interior via the live-tunable SystemConfig cache.
+      prime_ef_search(5_000)
+      assert HeavyRead.hnsw_ef_search() == 1_000, "above-range value clamps to the max bound"
+
+      prime_ef_search(0)
+      assert HeavyRead.hnsw_ef_search() == 1, "zero clamps to the min bound"
+
+      prime_ef_search(-5)
+      assert HeavyRead.hnsw_ef_search() == 1, "a negative value clamps to the min bound"
+
+      prime_ef_search(100)
+      assert HeavyRead.hnsw_ef_search() == 100, "an in-range value passes through unclamped"
+    end
+
+    test "an ANN heavy read issues SET LOCAL hnsw.ef_search for a non-default value" do
+      prime_ef_search(100)
+      tenant = fixture(:tenant)
+      q = from(a in Article, where: a.tenant_id == ^tenant.id, select: %{id: a.id})
+
+      captured =
+        Loopctl.PlanAssertions.capture_repo_queries(fn ->
+          HeavyRead.all(tenant.id, q, HeavyRead.opts(:vector_search))
+        end)
+
+      sqls = Enum.map(captured, fn {sql, _params} -> sql end)
+
+      assert Enum.any?(sqls, &(&1 =~ ~r/SET LOCAL hnsw\.ef_search = 100/)),
+             "expected the ANN read to issue SET LOCAL hnsw.ef_search = 100, got: #{inspect(sqls)}"
+    end
+
+    test "an ANN heavy read at the default value issues NO SET LOCAL hnsw.ef_search (ALTER ROLE preserved)" do
+      assert HeavyRead.hnsw_ef_search() == 40, "precondition: default config"
+      tenant = fixture(:tenant)
+      q = from(a in Article, where: a.tenant_id == ^tenant.id, select: %{id: a.id})
+
+      captured =
+        Loopctl.PlanAssertions.capture_repo_queries(fn ->
+          HeavyRead.all(tenant.id, q, HeavyRead.opts(:vector_search))
+        end)
+
+      sqls = Enum.map(captured, fn {sql, _params} -> sql end)
+
+      refute Enum.any?(sqls, &(&1 =~ ~r/hnsw\.ef_search/)),
+             "expected an ANN read at the default to NOT set hnsw.ef_search (so a role-level " <>
+               "ALTER ROLE default is honored, not shadowed), got: #{inspect(sqls)}"
+    end
+
+    test "a non-ANN heavy read does NOT issue SET LOCAL hnsw.ef_search" do
+      # Even with a non-default value primed, a non-ANN endpoint never touches the GUC.
+      prime_ef_search(100)
+      tenant = fixture(:tenant)
+      q = from(a in Article, where: a.tenant_id == ^tenant.id, select: %{id: a.id})
+
+      captured =
+        Loopctl.PlanAssertions.capture_repo_queries(fn ->
+          HeavyRead.all(tenant.id, q, HeavyRead.opts(:change_feed))
+        end)
+
+      sqls = Enum.map(captured, fn {sql, _params} -> sql end)
+
+      refute Enum.any?(sqls, &(&1 =~ ~r/hnsw\.ef_search/)),
+             "expected a non-ANN read to NOT touch hnsw.ef_search, got: #{inspect(sqls)}"
+    end
+  end
+
+  # US-38.4: prime the live-tunable `SystemConfig "hnsw_ef_search"` cache directly (the
+  # documented persistent_term key format) rather than `SystemConfig.put/2`, to avoid a
+  # leaked DB row, and erase on exit. This module is `async: false` precisely BECAUSE this
+  # mutates a VM-global key that concurrent cross-file ANN readers also read (see the
+  # @moduledoc); the `[1, 1000]` clamp in `hnsw_ef_search/0` prevents pgvector raising on an
+  # out-of-range GUC but provides NO cross-test isolation, so async isolation is what keeps a
+  # primed value from bleeding into another file's recall. Mirrors the
+  # `provider_admission_snooze_seconds` precedent in `provider/admission_test.exs` (which is
+  # safe under `async: true` only because no concurrent file reads that key for real behavior).
+  defp prime_ef_search(value) do
+    pt_key = {Loopctl.SystemConfig, "hnsw_ef_search"}
+    :persistent_term.put(pt_key, value)
+    on_exit(fn -> :persistent_term.erase(pt_key) end)
+  end
+end

--- a/test/loopctl/heavy_read_test.exs
+++ b/test/loopctl/heavy_read_test.exs
@@ -406,58 +406,11 @@ defmodule Loopctl.HeavyReadTest do
     end
   end
 
-  describe "per-query hnsw.ef_search (US-38.4, TC-38.4.1 query side)" do
-    test "opts/1 attaches :hnsw_ef_search only for pgvector-ANN endpoints" do
-      # Every ANN endpoint carries the configured recall breadth (default 40)...
-      for endpoint <- HeavyRead.ann_endpoints() do
-        assert Keyword.get(HeavyRead.opts(endpoint), :hnsw_ef_search) ==
-                 HeavyRead.hnsw_ef_search(),
-               "expected #{endpoint} opts to carry :hnsw_ef_search"
-      end
-
-      # ...and non-ANN heavy reads never set the GUC.
-      for endpoint <- HeavyRead.known_endpoints() -- HeavyRead.ann_endpoints() do
-        refute Keyword.has_key?(HeavyRead.opts(endpoint), :hnsw_ef_search),
-               "expected non-ANN #{endpoint} opts to NOT carry :hnsw_ef_search"
-      end
-    end
-
-    test "ann_endpoints/0 is a subset of known_endpoints/0 (no drift)" do
-      assert HeavyRead.ann_endpoints() -- HeavyRead.known_endpoints() == []
-    end
-
-    test "hnsw_ef_search/0 reads the SystemConfig default (40) and is clamped to [1, 1000]" do
-      assert HeavyRead.hnsw_ef_search() == 40
-    end
-
-    test "an ANN heavy read issues SET LOCAL hnsw.ef_search inside its transaction" do
-      tenant = fixture(:tenant)
-      q = from(a in Article, where: a.tenant_id == ^tenant.id, select: %{id: a.id})
-
-      captured =
-        Loopctl.PlanAssertions.capture_repo_queries(fn ->
-          HeavyRead.all(tenant.id, q, HeavyRead.opts(:vector_search))
-        end)
-
-      sqls = Enum.map(captured, fn {sql, _params} -> sql end)
-
-      assert Enum.any?(sqls, &(&1 =~ ~r/SET LOCAL hnsw\.ef_search = 40/)),
-             "expected the ANN read to issue SET LOCAL hnsw.ef_search = 40, got: #{inspect(sqls)}"
-    end
-
-    test "a non-ANN heavy read does NOT issue SET LOCAL hnsw.ef_search" do
-      tenant = fixture(:tenant)
-      q = from(a in Article, where: a.tenant_id == ^tenant.id, select: %{id: a.id})
-
-      captured =
-        Loopctl.PlanAssertions.capture_repo_queries(fn ->
-          HeavyRead.all(tenant.id, q, HeavyRead.opts(:change_feed))
-        end)
-
-      sqls = Enum.map(captured, fn {sql, _params} -> sql end)
-
-      refute Enum.any?(sqls, &(&1 =~ ~r/hnsw\.ef_search/)),
-             "expected a non-ANN read to NOT touch hnsw.ef_search, got: #{inspect(sqls)}"
-    end
-  end
+  # NOTE (US-38.4): the per-query `hnsw.ef_search` tests that PRIME the VM-global
+  # `SystemConfig "hnsw_ef_search"` persistent_term key live in the sibling `async: false`
+  # `Loopctl.HeavyReadHnswEfSearchTest` (test/loopctl/heavy_read_hnsw_ef_search_test.exs).
+  # They were split out because that key is also read by real ANN reads in other `async: true`
+  # files (dual_index_recall_test, vector_search_test), so priming it from an async module
+  # would let a concurrent cross-file reader observe the primed value. This file stays
+  # `async: true` — it mutates no global state.
 end

--- a/test/loopctl/heavy_read_test.exs
+++ b/test/loopctl/heavy_read_test.exs
@@ -405,4 +405,59 @@ defmodule Loopctl.HeavyReadTest do
       end
     end
   end
+
+  describe "per-query hnsw.ef_search (US-38.4, TC-38.4.1 query side)" do
+    test "opts/1 attaches :hnsw_ef_search only for pgvector-ANN endpoints" do
+      # Every ANN endpoint carries the configured recall breadth (default 40)...
+      for endpoint <- HeavyRead.ann_endpoints() do
+        assert Keyword.get(HeavyRead.opts(endpoint), :hnsw_ef_search) ==
+                 HeavyRead.hnsw_ef_search(),
+               "expected #{endpoint} opts to carry :hnsw_ef_search"
+      end
+
+      # ...and non-ANN heavy reads never set the GUC.
+      for endpoint <- HeavyRead.known_endpoints() -- HeavyRead.ann_endpoints() do
+        refute Keyword.has_key?(HeavyRead.opts(endpoint), :hnsw_ef_search),
+               "expected non-ANN #{endpoint} opts to NOT carry :hnsw_ef_search"
+      end
+    end
+
+    test "ann_endpoints/0 is a subset of known_endpoints/0 (no drift)" do
+      assert HeavyRead.ann_endpoints() -- HeavyRead.known_endpoints() == []
+    end
+
+    test "hnsw_ef_search/0 reads the SystemConfig default (40) and is clamped to [1, 1000]" do
+      assert HeavyRead.hnsw_ef_search() == 40
+    end
+
+    test "an ANN heavy read issues SET LOCAL hnsw.ef_search inside its transaction" do
+      tenant = fixture(:tenant)
+      q = from(a in Article, where: a.tenant_id == ^tenant.id, select: %{id: a.id})
+
+      captured =
+        Loopctl.PlanAssertions.capture_repo_queries(fn ->
+          HeavyRead.all(tenant.id, q, HeavyRead.opts(:vector_search))
+        end)
+
+      sqls = Enum.map(captured, fn {sql, _params} -> sql end)
+
+      assert Enum.any?(sqls, &(&1 =~ ~r/SET LOCAL hnsw\.ef_search = 40/)),
+             "expected the ANN read to issue SET LOCAL hnsw.ef_search = 40, got: #{inspect(sqls)}"
+    end
+
+    test "a non-ANN heavy read does NOT issue SET LOCAL hnsw.ef_search" do
+      tenant = fixture(:tenant)
+      q = from(a in Article, where: a.tenant_id == ^tenant.id, select: %{id: a.id})
+
+      captured =
+        Loopctl.PlanAssertions.capture_repo_queries(fn ->
+          HeavyRead.all(tenant.id, q, HeavyRead.opts(:change_feed))
+        end)
+
+      sqls = Enum.map(captured, fn {sql, _params} -> sql end)
+
+      refute Enum.any?(sqls, &(&1 =~ ~r/hnsw\.ef_search/)),
+             "expected a non-ANN read to NOT touch hnsw.ef_search, got: #{inspect(sqls)}"
+    end
+  end
 end

--- a/test/loopctl/memory/dual_index_recall_test.exs
+++ b/test/loopctl/memory/dual_index_recall_test.exs
@@ -1,0 +1,87 @@
+defmodule Loopctl.Memory.DualIndexRecallTest do
+  @moduledoc """
+  US-38.4 / TC-38.4.3 — `memories.embedding` dual-index justification.
+
+  The dual HNSW index on `memories.embedding` (FULL + partial `WHERE superseded_by
+  IS NULL`) is KEPT because each serves a distinct, live recall path:
+
+    * default `recall/2` (`include_superseded: false`) adds `superseded_by IS NULL`
+      on the inner ANN, exactly matching the PARTIAL index predicate → served by
+      `memories_live_embedding_hnsw_idx`;
+    * `recall/2` with `include_superseded: true` drops that filter → the query
+      predicate no longer implies the partial index's, so the planner serves the
+      ANN from the FULL index (proven by EXPLAIN in docs/hnsw-tuning-evaluation.md).
+
+  This test proves the BEHAVIOUR that justifies keeping both: default recall of LIVE
+  memories is unchanged (superseded rows excluded), and the include-superseded path
+  still surfaces superseded rows — so the full index is not dead. Whichever the
+  dual-index outcome, LIVE-memory recall is identical (AC-38.4.3 / AC-38.4.4).
+
+  Async: `recall/2` routes through `Loopctl.HeavyRead` (→ `AdminRepo` in test), so it
+  shares the sandbox connection the fixtures insert through.
+  """
+  use Loopctl.DataCase, async: true
+  use Oban.Testing, repo: Loopctl.Repo
+
+  setup :verify_on_exit!
+
+  alias Loopctl.Knowledge
+  alias Loopctl.Memory
+
+  describe "dual-index recall (keep both — TC-38.4.3)" do
+    test "default recall returns only LIVE memories; include_superseded surfaces superseded too" do
+      scope = fixture(:memory_scope)
+      Knowledge.reset_circuit_breaker(scope.tenant_id)
+
+      {:ok, old} = Memory.remember(scope, %{tier: :long_term, text: "old truth about ecto"})
+      {:ok, new} = Memory.remember(scope, %{tier: :long_term, text: "new truth about ecto"})
+
+      assert {:ok, superseded} = Memory.supersede(scope, old.id, new.id)
+      assert superseded.superseded_by == new.id
+
+      # Default recall (partial index path): the superseded `old` is EXCLUDED; live
+      # `new` is present — the live-memory recall set is unchanged by the dual index.
+      default_ids =
+        scope
+        |> Memory.recall(query: "ecto", limit: 10)
+        |> recalled_ids()
+
+      assert new.id in default_ids
+      refute old.id in default_ids
+
+      # include_superseded recall (full index path): BOTH the superseded and live rows
+      # are recalled — proof the full index still serves a live code path.
+      all_ids =
+        scope
+        |> Memory.recall(query: "ecto", limit: 10, include_superseded: true)
+        |> recalled_ids()
+
+      assert old.id in all_ids
+      assert new.id in all_ids
+    end
+
+    test "include_superseded recall is tenant + subject isolated" do
+      scope_a = fixture(:memory_scope)
+      scope_b = fixture(:memory_scope)
+      Knowledge.reset_circuit_breaker(scope_a.tenant_id)
+      Knowledge.reset_circuit_breaker(scope_b.tenant_id)
+
+      {:ok, a_old} = Memory.remember(scope_a, %{tier: :long_term, text: "shared secret alpha"})
+      {:ok, a_new} = Memory.remember(scope_a, %{tier: :long_term, text: "shared secret beta"})
+      assert {:ok, _} = Memory.supersede(scope_a, a_old.id, a_new.id)
+
+      {:ok, _b} = Memory.remember(scope_b, %{tier: :long_term, text: "shared secret gamma"})
+
+      # Tenant B's include_superseded recall never sees tenant A's superseded row.
+      b_ids =
+        scope_b
+        |> Memory.recall(query: "secret", limit: 10, include_superseded: true)
+        |> recalled_ids()
+
+      refute a_old.id in b_ids
+      refute a_new.id in b_ids
+    end
+  end
+
+  defp recalled_ids(%{results: results}), do: Enum.map(results, fn {m, _score} -> m.id end)
+end

--- a/test/loopctl/repo/hnsw_index_params_test.exs
+++ b/test/loopctl/repo/hnsw_index_params_test.exs
@@ -1,0 +1,69 @@
+defmodule Loopctl.Repo.HnswIndexParamsTest do
+  @moduledoc """
+  US-38.4 / TC-38.4.1 (build side) — the HNSW `m` / `ef_construction` build
+  parameters are EXPLICIT + configurable in the `Loopctl.Repo.HnswIndex` builder.
+
+  Asserts the builder emits `WITH (m = .., ef_construction = ..)` driven by the
+  configured `hnsw_m/0` / `hnsw_ef_construction/0` (not a hard-coded literal), and
+  that the emitted DDL is valid Postgres that actually builds an HNSW index carrying
+  those storage parameters — exercised on a PER-TEST THROWAWAY table (mirroring
+  `Loopctl.Repo.ReconcileHnswIndexMigrationTest`), never the shared live index.
+  """
+  use ExUnit.Case, async: true
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Loopctl.AdminRepo
+  alias Loopctl.Repo.HnswIndex
+
+  setup do
+    pid = Sandbox.start_owner!(AdminRepo, shared: false)
+    on_exit(fn -> Sandbox.stop_owner(pid) end)
+
+    table = "hnsw_params_test_#{System.unique_integer([:positive])}"
+    AdminRepo.query!("CREATE TABLE #{table} (id bigserial PRIMARY KEY, embedding vector(1536))")
+
+    %{table: table}
+  end
+
+  describe "with_params_clause/0 + configured build params" do
+    test "emits WITH (m, ef_construction) from the configured functions (default 16/64)" do
+      # Config/test.exs inherits config/config.exs defaults 16 / 64.
+      assert HnswIndex.hnsw_m() == 16
+      assert HnswIndex.hnsw_ef_construction() == 64
+
+      # Driven by the functions, not a stray literal — the clause is exactly the
+      # configured values interpolated, so this proves the builder is config-driven
+      # (a future config change would be reflected here) without an Application.put_env.
+      expected =
+        "WITH (m = #{HnswIndex.hnsw_m()}, ef_construction = #{HnswIndex.hnsw_ef_construction()})"
+
+      assert HnswIndex.with_params_clause() == expected
+      assert HnswIndex.with_params_clause() == "WITH (m = 16, ef_construction = 64)"
+    end
+
+    test "create_if_absent_sql carries the explicit WITH clause on the CREATE INDEX" do
+      sql = HnswIndex.create_if_absent_sql("articles")
+
+      assert sql =~ "USING hnsw (embedding vector_cosine_ops) WITH (m = 16, ef_construction = 64)"
+    end
+  end
+
+  describe "the emitted DDL is valid Postgres and builds an HNSW index with the params" do
+    test "create_if_absent_sql builds an hnsw index whose reloptions carry m/ef_construction",
+         %{table: table} do
+      AdminRepo.query!(HnswIndex.create_if_absent_sql(table))
+
+      # The index exists, is HNSW, and its definition carries the explicit storage params.
+      %{rows: [[indexdef]]} =
+        AdminRepo.query!(
+          "SELECT indexdef FROM pg_indexes WHERE tablename = $1 AND indexdef ILIKE '%USING hnsw%'",
+          [table]
+        )
+
+      assert indexdef =~ "USING hnsw"
+      # Postgres renders reloptions as quoted strings: WITH (m='16', ef_construction='64').
+      assert indexdef =~ ~r/m\s*=\s*'?16'?/
+      assert indexdef =~ ~r/ef_construction\s*=\s*'?64'?/
+    end
+  end
+end


### PR DESCRIPTION
## US-38.4 (GH #353) — review-first, evidence-driven HNSW tuning

Two independent tracks; the evidenced outcome of both is **"keep what we have, but make it explicit + tunable"** — an explicitly valid outcome per the story's technical notes. Full evaluation: `docs/hnsw-tuning-evaluation.md`.

### Track A — m / ef_construction / ef_search made explicit + configurable (AC-38.4.1/.2)
- **m / ef_construction**: every `CREATE INDEX ... USING hnsw` now emits an explicit `WITH (m = 16, ef_construction = 64)`, single-sourced + integer-validated in `Loopctl.Repo.HnswIndex` (`config :loopctl, :hnsw_m` / `:hnsw_ef_construction`). Values EQUAL pgvector's implicit defaults — a deliberate, documented "keep the defaults" decision — so **no reindex of the live `articles`/`memories` indexes is needed** (they were already built with these params; re-emitting only affects fresh builds). Verified on a fresh `mix ecto.reset`: all three HNSW indexes carry `WITH (m='16', ef_construction='64')`.
- **ef_search**: now a live-tunable per-query knob (`SystemConfig "hnsw_ef_search"`, default 40) applied via `SET LOCAL hnsw.ef_search` **inside the heavy read's existing `SET LOCAL statement_timeout` transaction** (US-27.13) for the ANN endpoints only. The historical "per-request `SET LOCAL` is unsafe / re-starves the pool" claim is **stale** (the transaction is already there); moduledocs (`vector_search.ex`), `runtime.exs`, and `docs/runbooks/knowledge-scale.md` are reconciled so code and docs agree.

**Recall/latency/build-cost evaluation** and the keep-defaults rationale are in `docs/hnsw-tuning-evaluation.md`. No recall regression: values are unchanged, and the recall gates pass.

### Track B — memories.embedding dual HNSW index: KEEP BOTH (AC-38.4.3/.4)
EXPLAIN evidence (forced planner on the dev DB to reveal eligibility):
- `include_superseded: true` recall -> `Index Scan using memories_embedding_idx` (FULL index)
- default live recall (`superseded_by IS NULL`) -> `Index Scan using memories_live_embedding_hnsw_idx` (PARTIAL index)

Each index is the ONLY HNSW option for a distinct, live code path (`include_superseded` is publicly reachable via the `memory_recall` MCP tool + `MemoryController`). The partial index is provably ineligible for the include-superseded query (predicate mismatch), so dropping the full index would Seq-Scan that path at scale. **Decision: keep both**; live-memory recall is unchanged either way (test).

> NB (finding): the live FULL memories index is named `memories_embedding_idx`, not `_hnsw_idx` — no reconcile migration ran for `memories` (unlike `articles`). Detection is capability-based, so the name is immaterial.

### Migrations (online + reversible — AC-38.4.4)
Only new DDL is a trivial `hnsw_ef_search` SystemConfig seed (`INSERT ... ON CONFLICT DO NOTHING`, `DELETE` down; missing row falls back to the in-code default 40). No write-blocking DDL on the hot tables. A FUTURE param change would ship an online `CREATE INDEX CONCURRENTLY` + drop — rollback path noted in the eval doc.

### Tests (TC-38.4.1/2/3)
- `test/loopctl/repo/hnsw_index_params_test.exs` — builder emits/validates the `WITH (...)` clause and builds a real params-carrying HNSW index.
- `test/loopctl/heavy_read_test.exs` — `opts/1` attaches `hnsw_ef_search` only to ANN endpoints; the ANN read path issues `SET LOCAL hnsw.ef_search = 40`; non-ANN reads do not.
- `test/loopctl/memory/dual_index_recall_test.exs` — default recall returns only live memories; `include_superseded` still surfaces superseded rows; tenant/subject isolated.

`mix precommit` green (compile, format, credo --strict, dialyzer, 4743 tests).

Closes #353
