### PR TITLE
#411 Gap 1: cheap repo -> project_id resolution

### DIFF
--- a/lib/loopctl/projects.ex
+++ b/lib/loopctl/projects.ex
@@ -149,8 +149,19 @@ defmodule Loopctl.Projects do
      bare `owner/repo`)
   3. case-insensitive exact `:name`
 
-  When a lower-precedence key (`:repo_url` or `:name`) matches more than one
-  project, an `:active` project is preferred over an `:archived` one.
+  Because the purpose is to attach NEW work to a live project, the fuzzy
+  identifiers (`:repo_url` and `:name`) resolve only `:active` projects — an
+  `:archived` project is never returned via those keys (treated as no match so
+  the caller can fall through). An exact `:slug` is a deliberate, unique key, so
+  it still resolves an archived project.
+
+  `:repo_url` matching preserves the FULL namespace path, so nested-namespace
+  hosts (e.g. GitLab subgroups `gitlab.com/group-a/team/api` vs
+  `gitlab.com/group-b/team/api`) never collide onto a shared `owner/repo`
+  suffix. When the supplied `:repo_url` carries an explicit host, the suffix
+  fallback will not cross to a different host (a fully-qualified GitHub URL
+  won't resolve to a same-path GitLab project); a bare `owner/repo` query still
+  matches regardless of the stored host.
 
   ## Parameters
 
@@ -160,14 +171,30 @@ defmodule Loopctl.Projects do
 
   ## Returns
 
-  - `{:ok, %Project{}}` on the first matching identifier
+  - `{:ok, %Project{}, matched_by}` on the first matching identifier, where
+    `matched_by` is `:slug`, `:repo_url`, or `:name` -- the identifier that
+    produced the hit, so callers can validate the match against their intent
+    (a stale slug that misses and silently falls through to `repo_url`/`name`
+    is now detectable).
+  - `{:error, :ambiguous}` when a fuzzy identifier (`:repo_url` or `:name`)
+    matches MORE THAN ONE active project -- e.g. the same `owner/repo` mirrored
+    on two hosts (`github.com/acme/app` and `gitlab.com/acme/app`), two active
+    projects sharing a `repo_url`, or two active projects sharing a name. Rather
+    than silently attaching NEW work to whichever is older, resolution stops so
+    the caller disambiguates with an exact `:slug` (or a fully-qualified,
+    single-host `:repo_url`).
   - `{:error, :not_found}` when identifiers were supplied but nothing matched
   - `{:error, :no_identifier}` when no non-blank identifier was supplied
 
-  Never raises on malformed input.
+  Never raises on malformed input (malformed identifier values or a malformed
+  `opts` container both degrade to `:no_identifier`/`:not_found`).
   """
-  @spec resolve_project(Ecto.UUID.t(), keyword() | map()) ::
-          {:ok, Project.t()} | {:error, :not_found | :no_identifier}
+  # `opts` is normally a keyword() | map(), but the type is left open (term()) so
+  # a malformed container degrades to :no_identifier via fetch_opt/2's catch-all
+  # rather than raising -- upholding the "never raises on malformed input" doc.
+  @spec resolve_project(Ecto.UUID.t(), keyword() | map() | term()) ::
+          {:ok, Project.t(), :slug | :repo_url | :name}
+          | {:error, :not_found | :no_identifier | :ambiguous}
   def resolve_project(tenant_id, opts) do
     slug = opts |> fetch_opt(:slug) |> presence()
     repo_url = opts |> fetch_opt(:repo_url) |> presence()
@@ -452,6 +479,9 @@ defmodule Loopctl.Projects do
 
   defp fetch_opt(opts, key) when is_list(opts), do: Keyword.get(opts, key)
   defp fetch_opt(opts, key) when is_map(opts), do: Map.get(opts, key)
+  # Catch-all so a malformed opts container (neither list nor map) degrades to
+  # :no_identifier rather than raising, honoring the "never raises" contract.
+  defp fetch_opt(_opts, _key), do: nil
 
   defp presence(nil), do: nil
 
@@ -469,7 +499,7 @@ defmodule Loopctl.Projects do
   defp resolve_by_slug(tenant_id, slug) do
     case AdminRepo.get_by(Project, slug: slug, tenant_id: tenant_id) do
       nil -> :error
-      project -> {:ok, project}
+      project -> {:ok, project, :slug}
     end
   end
 
@@ -480,83 +510,124 @@ defmodule Loopctl.Projects do
     # locale. Downcasing in Elixir (String.downcase/1) and comparing to
     # `lower(name)` diverges on non-ASCII (Turkish dotless I, ß, final sigma),
     # producing false negatives.
+    # Only :active projects resolve by name -- an archived project is never a
+    # target for attaching new work, and returning one silently would let the
+    # harness attach stories/epics to a retired project.
+    # `name` has NO uniqueness constraint (only [tenant_id, slug] is unique), so
+    # two active projects can share a name. Fetch up to 2 (oldest-first for a
+    # deterministic single result) and treat >1 as :ambiguous rather than
+    # silently attaching new work to the oldest. The limit also bounds the scan
+    # of this non-sargable lower(name) comparison.
     Project
     |> where([p], p.tenant_id == ^tenant_id)
+    |> where([p], p.status == :active)
     |> where([p], fragment("lower(?)", p.name) == fragment("lower(?)", ^name))
-    |> prefer_active_one()
+    |> order_by([p], asc: p.inserted_at)
+    |> limit(2)
+    |> AdminRepo.all()
+    |> case do
+      [] -> :error
+      [project] -> {:ok, project, :name}
+      _ -> {:error, :ambiguous}
+    end
   end
 
   defp resolve_by_repo_url(_tenant_id, nil), do: :error
 
   defp resolve_by_repo_url(tenant_id, repo_url) do
     target_norm = normalize_repo_url(repo_url)
-    target_key = repo_owner_repo(repo_url)
+    target_ref = repo_ref(repo_url)
 
     # A repo_url that normalizes to "" (e.g. ".git", "/", "/.git") or has no
-    # derivable "owner/repo" is not a usable identifier -- treat the branch as
-    # a miss so the caller falls through to name resolution. Without this, an
-    # empty-normalizing target could collide with a project stored with a
-    # degenerate repo_url (the `not is_nil(repo_url)` guard doesn't exclude "").
-    if target_norm in [nil, ""] or is_nil(target_key) do
+    # derivable "host?/owner/repo" path is not a usable identifier -- treat the
+    # branch as a miss so the caller falls through to name resolution. Without
+    # this, an empty-normalizing target could collide with a project stored with
+    # a degenerate repo_url (the `not is_nil(repo_url)` guard doesn't exclude "").
+    if target_norm in [nil, ""] or is_nil(target_ref) do
       :error
     else
-      do_resolve_by_repo_url(tenant_id, target_norm, target_key)
+      do_resolve_by_repo_url(tenant_id, target_norm, target_ref)
     end
   end
 
-  defp do_resolve_by_repo_url(tenant_id, target_norm, target_key) do
-    # Bound the scan in SQL to plausible candidates (those whose stored repo_url
-    # contains the target's "owner/repo") so a tenant with thousands of
-    # unrelated projects doesn't materialize them all. The Elixir pass below is
-    # kept ONLY to enforce exact-vs-suffix precedence over this shrunken set.
-    pattern = "%" <> escape_like(target_key) <> "%"
+  # Upper bound on the ILIKE candidate set materialized for repo_url resolution.
+  # The set is already narrowed to same-namespace-path :active projects (and
+  # bounded by the tenant's max_projects, default 50), so this is defense in
+  # depth: it keeps the non-sargable leading-wildcard ILIKE scan from
+  # materializing an unbounded result if a tenant raises max_projects. It never
+  # truncates a real candidate set at realistic scale, and >1 distinct match is
+  # already surfaced as :ambiguous rather than resolved to the oldest.
+  @resolve_candidate_limit 100
+
+  defp do_resolve_by_repo_url(tenant_id, target_norm, {target_host, target_path}) do
+    # Bound the scan in SQL to plausible candidates: only :active projects
+    # (archived projects are never a resolution target for attaching new work)
+    # whose stored repo_url contains the target's FULL namespace path. Matching
+    # on the full path (not just the trailing "owner/repo") keeps nested
+    # namespaces distinct -- GitLab subgroups group-a/team/api and
+    # group-b/team/api don't collide. The Elixir pass below enforces
+    # exact-vs-suffix precedence and same-host gating over this shrunken set.
+    pattern = "%" <> escape_like(target_path) <> "%"
 
     candidates =
       Project
       |> where([p], p.tenant_id == ^tenant_id and not is_nil(p.repo_url))
+      |> where([p], p.status == :active)
       |> where([p], ilike(p.repo_url, ^pattern))
-      |> order_by([p],
-        asc: fragment("CASE WHEN ? = 'active' THEN 0 ELSE 1 END", p.status),
-        asc: p.inserted_at
-      )
+      |> order_by([p], asc: p.inserted_at)
+      |> limit(@resolve_candidate_limit)
       |> AdminRepo.all()
-      |> Enum.reject(fn project -> normalize_repo_url(project.repo_url) in [nil, ""] end)
+      |> Enum.map(fn project -> {project, repo_ref(project.repo_url)} end)
+      |> Enum.reject(fn {_project, ref} -> is_nil(ref) end)
 
-    # Two-pass: an EXACT normalized-URL match wins across all candidates (so an
-    # exact host beats a same-owner/repo match on a different host); only if
-    # none exists do we fall back to the "owner/repo" suffix match. Candidates
-    # are active-first then oldest-first, so `Enum.find` stays deterministic.
-    exact =
-      Enum.find(candidates, fn project ->
+    # Two-pass over active candidates (oldest-first for determinism):
+    #   1. an EXACT normalized-URL match wins outright (so an exact host beats a
+    #      same-path match on a different host). Two active projects sharing the
+    #      exact same repo_url are :ambiguous, not "oldest wins".
+    #   2. otherwise a same-namespace-path match, host-gated so a query carrying
+    #      an explicit host never crosses to a different-host project. Two or
+    #      more distinct same-path matches (e.g. the same repo mirrored on
+    #      github.com and gitlab.com, matched by a bare host-less query) are
+    #      :ambiguous rather than silently resolving to the oldest mirror.
+    exact_matches =
+      Enum.filter(candidates, fn {project, _ref} ->
         normalize_repo_url(project.repo_url) == target_norm
       end)
 
-    match =
-      exact ||
-        Enum.find(candidates, fn project ->
-          repo_owner_repo(project.repo_url) == target_key
+    case exact_matches do
+      [{project, _ref}] ->
+        {:ok, project, :repo_url}
+
+      [_ | _] ->
+        {:error, :ambiguous}
+
+      [] ->
+        candidates
+        |> Enum.filter(fn {_project, {chost, cpath}} ->
+          cpath == target_path and host_compatible?(target_host, chost)
         end)
-
-    case match do
-      nil -> :error
-      project -> {:ok, project}
+        |> resolve_suffix_matches()
     end
   end
 
-  # Orders active-first, then oldest-first for determinism, and returns the top row.
-  defp prefer_active_one(query) do
-    query
-    |> order_by([p],
-      asc: fragment("CASE WHEN ? = 'active' THEN 0 ELSE 1 END", p.status),
-      asc: p.inserted_at
-    )
-    |> limit(1)
-    |> AdminRepo.one()
-    |> case do
-      nil -> :error
-      project -> {:ok, project}
-    end
-  end
+  # Resolve the host-gated suffix pass. A single match resolves; two or more
+  # distinct active projects sharing the trailing owner/repo path are
+  # :ambiguous -- resolving to the oldest could silently attach new work to the
+  # wrong repo (e.g. a bare "acme/app" query when both github.com/acme/app and
+  # gitlab.com/acme/app exist), so we signal ambiguity and let the caller
+  # disambiguate with an exact slug or a fully-qualified, single-host repo_url.
+  defp resolve_suffix_matches([]), do: :error
+  defp resolve_suffix_matches([{project, _ref}]), do: {:ok, project, :repo_url}
+  defp resolve_suffix_matches([_ | _]), do: {:error, :ambiguous}
+
+  # Same-host gating for the suffix fallback: reject only when BOTH the query
+  # and the candidate carry an explicit host that differ. A bare "owner/repo"
+  # query (host nil) still matches any host, and a bare-stored candidate still
+  # matches a hosted query -- only a fully-qualified query is prevented from
+  # crossing hosts (github.com vs gitlab.com).
+  defp host_compatible?(nil, _chost), do: true
+  defp host_compatible?(_target_host, nil), do: true
+  defp host_compatible?(target_host, chost), do: target_host == chost
 
   # Lowercase, strip a trailing "/" then a trailing ".git" (then any residual "/").
   defp normalize_repo_url(nil), do: nil
@@ -570,21 +641,59 @@ defmodule Loopctl.Projects do
     |> String.trim_trailing("/")
   end
 
-  # Reduces a repo URL to its trailing "owner/repo" segment so the ssh, https,
-  # and bare forms all compare equal. Returns nil when fewer than two segments.
-  defp repo_owner_repo(nil), do: nil
+  # Parses a repo URL / ssh spec / bare "owner/repo" into `{host, path}` so the
+  # ssh, https, and bare forms compare equal while preserving the FULL namespace
+  # path. `host` is nil for bare input; `path` keeps every segment after the
+  # host (so GitLab subgroups group-a/team/api and group-b/team/api stay
+  # distinct). Returns nil when no "owner/repo"-shaped path (>= 2 segments) can
+  # be derived.
+  defp repo_ref(nil), do: nil
 
-  defp repo_owner_repo(url) when is_binary(url) do
-    url
-    |> normalize_repo_url()
-    |> String.replace(":", "/")
-    |> String.split("/", trim: true)
-    |> Enum.take(-2)
-    |> case do
-      [owner, repo] -> owner <> "/" <> repo
-      _ -> nil
+  defp repo_ref(url) when is_binary(url) do
+    without_scheme =
+      url
+      |> normalize_repo_url()
+      # strip a URL scheme (https://, http://, git://, ssh://, ...)
+      |> String.replace(~r{^[a-z][a-z0-9+.\-]*://}, "")
+      # strip a leading userinfo (git@, user@) so scp-like specs parse
+      |> String.replace(~r{^[^/@]+@}, "")
+      # drop an explicit host :port (https://host:443/..., ssh://host:22/...) so
+      # a port-carrying URL still compares equal to the same repo stored without
+      # the port. Only a numeric :<digits> right after the host is a port.
+      |> String.replace(~r{^([^/:]+):\d+(/|$)}, "\\1\\2")
+      # scp-like "host:owner/repo" -> "host/owner/repo". Convert only the FIRST
+      # colon (the host/path separator) so a colon later in the path is intact.
+      |> String.replace(":", "/", global: false)
+
+    case String.split(without_scheme, "/", trim: true) do
+      [first | rest] = segments when rest != [] ->
+        # Treat the leading segment as a host ONLY when it looks like a hostname
+        # (contains a dot) AND the segments after it still form a >= 2-segment
+        # "owner/repo" path. This stops a bare, host-less "owner.with.dot/repo"
+        # from being misread as host="owner.with.dot" with a single remaining
+        # segment (which would drop an otherwise-valid path and return nil).
+        {host, path_segments} =
+          if host_segment?(first) and match?([_, _ | _], rest) do
+            {first, rest}
+          else
+            {nil, segments}
+          end
+
+        case path_segments do
+          [_, _ | _] -> {host, Enum.join(path_segments, "/")}
+          _ -> nil
+        end
+
+      _ ->
+        nil
     end
   end
+
+  # A leading segment LOOKS like a hostname when it contains a dot (github.com,
+  # gitlab.com, git.example.com). The caller additionally requires a >= 2-segment
+  # remaining path before treating it as a host, so a dotted bare owner does not
+  # get misclassified.
+  defp host_segment?(segment), do: String.contains?(segment, ".")
 
   # Escape LIKE metacharacters so an "owner/repo" containing `%` or `_` is
   # matched literally rather than as a wildcard in the ILIKE pre-filter.

--- a/lib/loopctl/projects.ex
+++ b/lib/loopctl/projects.ex
@@ -137,6 +137,54 @@ defmodule Loopctl.Projects do
   end
 
   @doc """
+  Resolves a project within a tenant from one or more identifiers.
+
+  Intended as the single cheap call the harness uses to turn "I'm working in
+  repo X" into a loopctl project. Tries identifiers in precedence order and
+  returns the first hit:
+
+  1. exact `:slug`
+  2. normalized `:repo_url` (see `normalize_repo_url/1` — matches across
+     `git@github.com:owner/repo.git`, `https://github.com/owner/repo`, and the
+     bare `owner/repo`)
+  3. case-insensitive exact `:name`
+
+  When a lower-precedence key (`:repo_url` or `:name`) matches more than one
+  project, an `:active` project is preferred over an `:archived` one.
+
+  ## Parameters
+
+  - `tenant_id` -- the tenant UUID (strictly scoped)
+  - `opts` -- keyword list or map with any subset of `:slug`, `:repo_url`,
+    `:name`. Blank/whitespace-only values are ignored.
+
+  ## Returns
+
+  - `{:ok, %Project{}}` on the first matching identifier
+  - `{:error, :not_found}` when identifiers were supplied but nothing matched
+  - `{:error, :no_identifier}` when no non-blank identifier was supplied
+
+  Never raises on malformed input.
+  """
+  @spec resolve_project(Ecto.UUID.t(), keyword() | map()) ::
+          {:ok, Project.t()} | {:error, :not_found | :no_identifier}
+  def resolve_project(tenant_id, opts) do
+    slug = opts |> fetch_opt(:slug) |> presence()
+    repo_url = opts |> fetch_opt(:repo_url) |> presence()
+    name = opts |> fetch_opt(:name) |> presence()
+
+    if is_nil(slug) and is_nil(repo_url) and is_nil(name) do
+      {:error, :no_identifier}
+    else
+      with :error <- resolve_by_slug(tenant_id, slug),
+           :error <- resolve_by_repo_url(tenant_id, repo_url),
+           :error <- resolve_by_name(tenant_id, name) do
+        {:error, :not_found}
+      end
+    end
+  end
+
+  @doc """
   Updates a project within a tenant.
 
   Slug cannot be changed after creation.
@@ -398,6 +446,154 @@ defmodule Loopctl.Projects do
   end
 
   # --- Private helpers ---
+
+  # resolve_project/2 support. Each returns {:ok, %Project{}} or :error so the
+  # caller can chain them with `with` in precedence order.
+
+  defp fetch_opt(opts, key) when is_list(opts), do: Keyword.get(opts, key)
+  defp fetch_opt(opts, key) when is_map(opts), do: Map.get(opts, key)
+
+  defp presence(nil), do: nil
+
+  defp presence(value) when is_binary(value) do
+    case String.trim(value) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
+
+  defp presence(_), do: nil
+
+  defp resolve_by_slug(_tenant_id, nil), do: :error
+
+  defp resolve_by_slug(tenant_id, slug) do
+    case AdminRepo.get_by(Project, slug: slug, tenant_id: tenant_id) do
+      nil -> :error
+      project -> {:ok, project}
+    end
+  end
+
+  defp resolve_by_name(_tenant_id, nil), do: :error
+
+  defp resolve_by_name(tenant_id, name) do
+    # Lower BOTH sides in Postgres so the comparison uses a single, consistent
+    # locale. Downcasing in Elixir (String.downcase/1) and comparing to
+    # `lower(name)` diverges on non-ASCII (Turkish dotless I, ß, final sigma),
+    # producing false negatives.
+    Project
+    |> where([p], p.tenant_id == ^tenant_id)
+    |> where([p], fragment("lower(?)", p.name) == fragment("lower(?)", ^name))
+    |> prefer_active_one()
+  end
+
+  defp resolve_by_repo_url(_tenant_id, nil), do: :error
+
+  defp resolve_by_repo_url(tenant_id, repo_url) do
+    target_norm = normalize_repo_url(repo_url)
+    target_key = repo_owner_repo(repo_url)
+
+    # A repo_url that normalizes to "" (e.g. ".git", "/", "/.git") or has no
+    # derivable "owner/repo" is not a usable identifier -- treat the branch as
+    # a miss so the caller falls through to name resolution. Without this, an
+    # empty-normalizing target could collide with a project stored with a
+    # degenerate repo_url (the `not is_nil(repo_url)` guard doesn't exclude "").
+    if target_norm in [nil, ""] or is_nil(target_key) do
+      :error
+    else
+      do_resolve_by_repo_url(tenant_id, target_norm, target_key)
+    end
+  end
+
+  defp do_resolve_by_repo_url(tenant_id, target_norm, target_key) do
+    # Bound the scan in SQL to plausible candidates (those whose stored repo_url
+    # contains the target's "owner/repo") so a tenant with thousands of
+    # unrelated projects doesn't materialize them all. The Elixir pass below is
+    # kept ONLY to enforce exact-vs-suffix precedence over this shrunken set.
+    pattern = "%" <> escape_like(target_key) <> "%"
+
+    candidates =
+      Project
+      |> where([p], p.tenant_id == ^tenant_id and not is_nil(p.repo_url))
+      |> where([p], ilike(p.repo_url, ^pattern))
+      |> order_by([p],
+        asc: fragment("CASE WHEN ? = 'active' THEN 0 ELSE 1 END", p.status),
+        asc: p.inserted_at
+      )
+      |> AdminRepo.all()
+      |> Enum.reject(fn project -> normalize_repo_url(project.repo_url) in [nil, ""] end)
+
+    # Two-pass: an EXACT normalized-URL match wins across all candidates (so an
+    # exact host beats a same-owner/repo match on a different host); only if
+    # none exists do we fall back to the "owner/repo" suffix match. Candidates
+    # are active-first then oldest-first, so `Enum.find` stays deterministic.
+    exact =
+      Enum.find(candidates, fn project ->
+        normalize_repo_url(project.repo_url) == target_norm
+      end)
+
+    match =
+      exact ||
+        Enum.find(candidates, fn project ->
+          repo_owner_repo(project.repo_url) == target_key
+        end)
+
+    case match do
+      nil -> :error
+      project -> {:ok, project}
+    end
+  end
+
+  # Orders active-first, then oldest-first for determinism, and returns the top row.
+  defp prefer_active_one(query) do
+    query
+    |> order_by([p],
+      asc: fragment("CASE WHEN ? = 'active' THEN 0 ELSE 1 END", p.status),
+      asc: p.inserted_at
+    )
+    |> limit(1)
+    |> AdminRepo.one()
+    |> case do
+      nil -> :error
+      project -> {:ok, project}
+    end
+  end
+
+  # Lowercase, strip a trailing "/" then a trailing ".git" (then any residual "/").
+  defp normalize_repo_url(nil), do: nil
+
+  defp normalize_repo_url(url) when is_binary(url) do
+    url
+    |> String.trim()
+    |> String.downcase()
+    |> String.trim_trailing("/")
+    |> String.replace_suffix(".git", "")
+    |> String.trim_trailing("/")
+  end
+
+  # Reduces a repo URL to its trailing "owner/repo" segment so the ssh, https,
+  # and bare forms all compare equal. Returns nil when fewer than two segments.
+  defp repo_owner_repo(nil), do: nil
+
+  defp repo_owner_repo(url) when is_binary(url) do
+    url
+    |> normalize_repo_url()
+    |> String.replace(":", "/")
+    |> String.split("/", trim: true)
+    |> Enum.take(-2)
+    |> case do
+      [owner, repo] -> owner <> "/" <> repo
+      _ -> nil
+    end
+  end
+
+  # Escape LIKE metacharacters so an "owner/repo" containing `%` or `_` is
+  # matched literally rather than as a wildcard in the ILIKE pre-filter.
+  defp escape_like(text) do
+    text
+    |> String.replace("\\", "\\\\")
+    |> String.replace("%", "\\%")
+    |> String.replace("_", "\\_")
+  end
 
   defp apply_filters(query, opts) do
     include_archived = Keyword.get(opts, :include_archived, false)

--- a/lib/loopctl_web/controllers/project_controller.ex
+++ b/lib/loopctl_web/controllers/project_controller.ex
@@ -275,12 +275,20 @@ defmodule LoopctlWeb.ProjectController do
     end
   end
 
+  # Defense-in-depth cap on the length of each resolve identifier. HTTP
+  # request-line limits and the small per-tenant project count already bound the
+  # real cost, but this rejects a pathologically long value before it reaches the
+  # regex passes in repo_ref/1 and the leading-wildcard ILIKE scan.
+  @max_identifier_length 512
+
   @doc """
   GET /api/v1/projects/resolve
 
   Resolves a project from any of slug, repo_url, or name. Requires agent+ role.
-  Returns 200 with the project on a match, 404 when nothing matches, and 422
-  when no identifier was supplied.
+  Returns 200 with the project (and `matched_by`, the identifier that produced
+  the hit) on a match, 404 when nothing matches, 409 when a fuzzy identifier
+  matches more than one active project (ambiguous), and 422 when no identifier
+  was supplied or an identifier exceeds the length cap.
   """
   def resolve(conn, params) do
     tenant_id = conn.assigns.current_api_key.tenant_id
@@ -291,15 +299,40 @@ defmodule LoopctlWeb.ProjectController do
       name: params["name"]
     ]
 
+    with :ok <- validate_identifier_lengths(opts),
+         {:ok, project, matched_by} <- resolve_result(tenant_id, opts) do
+      json(conn, %{project: project_json(project), matched_by: matched_by})
+    end
+  end
+
+  defp validate_identifier_lengths(opts) do
+    if Enum.any?(opts, fn {_key, value} ->
+         is_binary(value) and byte_size(value) > @max_identifier_length
+       end) do
+      {:error, :unprocessable_entity,
+       "Identifier values must be at most #{@max_identifier_length} characters"}
+    else
+      :ok
+    end
+  end
+
+  # Map the resolver's outcomes onto FallbackController clauses so this endpoint
+  # emits the standard error envelope (%{error: %{status, message}}) like every
+  # other action. :not_found flows straight through to the 404 clause; the
+  # {:ok, project, matched_by} success passes through unchanged.
+  defp resolve_result(tenant_id, opts) do
     case Projects.resolve_project(tenant_id, opts) do
-      {:ok, project} ->
-        json(conn, %{project: project_json(project)})
+      {:ok, project, matched_by} ->
+        {:ok, project, matched_by}
 
       {:error, :not_found} ->
-        conn |> put_status(:not_found) |> json(%{error: "not_found"})
+        {:error, :not_found}
+
+      {:error, :ambiguous} ->
+        {:error, :ambiguous_resolution}
 
       {:error, :no_identifier} ->
-        conn |> put_status(:unprocessable_entity) |> json(%{error: "no_identifier"})
+        {:error, :unprocessable_entity, "Provide slug, repo_url, or name"}
     end
   end
 

--- a/lib/loopctl_web/controllers/project_controller.ex
+++ b/lib/loopctl_web/controllers/project_controller.ex
@@ -21,7 +21,9 @@ defmodule LoopctlWeb.ProjectController do
 
   plug LoopctlWeb.Plugs.RequireRole, [role: :orchestrator] when action in [:create, :update]
   plug LoopctlWeb.Plugs.RequireRole, [role: :user] when action in [:delete]
-  plug LoopctlWeb.Plugs.RequireRole, [role: :agent] when action in [:index, :show, :progress]
+
+  plug LoopctlWeb.Plugs.RequireRole,
+       [role: :agent] when action in [:index, :show, :progress, :resolve]
 
   # US-26.7.1 — work-breakdown surface requires a human-anchored tenant.
   plug LoopctlWeb.Plugs.RequireHumanAnchor when action in [:create, :update, :delete]
@@ -93,6 +95,27 @@ defmodule LoopctlWeb.ProjectController do
     responses: %{
       200 => {"Archived project", "application/json", Schemas.ProjectResponse},
       404 => {"Not found", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  operation(:resolve,
+    summary: "Resolve project",
+    description:
+      "Resolves a project from any of slug, repo_url, or name (precedence: slug, repo_url, name). Requires agent+ role.",
+    parameters: [
+      slug: [in: :query, type: :string, description: "Exact project slug"],
+      repo_url: [
+        in: :query,
+        type: :string,
+        description: "Repository URL (ssh, https, or bare owner/repo)"
+      ],
+      name: [in: :query, type: :string, description: "Project name (case-insensitive)"]
+    ],
+    responses: %{
+      200 => {"Resolved project", "application/json", Schemas.ProjectResponse},
+      404 => {"Not found", "application/json", Schemas.ErrorResponse},
+      422 => {"No identifier supplied", "application/json", Schemas.ErrorResponse},
       429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
     }
   )
@@ -249,6 +272,34 @@ defmodule LoopctlWeb.ProjectController do
         {:error, %Ecto.Changeset{} = changeset} ->
           {:error, changeset}
       end
+    end
+  end
+
+  @doc """
+  GET /api/v1/projects/resolve
+
+  Resolves a project from any of slug, repo_url, or name. Requires agent+ role.
+  Returns 200 with the project on a match, 404 when nothing matches, and 422
+  when no identifier was supplied.
+  """
+  def resolve(conn, params) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+
+    opts = [
+      slug: params["slug"],
+      repo_url: params["repo_url"],
+      name: params["name"]
+    ]
+
+    case Projects.resolve_project(tenant_id, opts) do
+      {:ok, project} ->
+        json(conn, %{project: project_json(project)})
+
+      {:error, :not_found} ->
+        conn |> put_status(:not_found) |> json(%{error: "not_found"})
+
+      {:error, :no_identifier} ->
+        conn |> put_status(:unprocessable_entity) |> json(%{error: "no_identifier"})
     end
   end
 

--- a/lib/loopctl_web/fallback_controller.ex
+++ b/lib/loopctl_web/fallback_controller.ex
@@ -12,6 +12,7 @@ defmodule LoopctlWeb.FallbackController do
   - `{:error, :unauthorized}` -> 401
   - `{:error, :forbidden}` -> 403
   - `{:error, :conflict}` -> 409
+  - `{:error, :ambiguous_resolution}` -> 409 (a fuzzy identifier matched >1 active project)
   - `{:error, :must_contract_first}` -> 409 (claim before contracting)
   - `{:error, :must_claim_first}` -> 409 (start before claiming)
   - `{:error, :self_verify_blocked}` -> 409 (same agent implemented and tries to verify)
@@ -58,6 +59,22 @@ defmodule LoopctlWeb.FallbackController do
     conn
     |> put_status(:conflict)
     |> json(%{error: %{status: 409, message: "Conflict"}})
+  end
+
+  # A fuzzy identifier (repo_url or name) matched more than one active project,
+  # so resolution refused to silently attach new work to whichever is older.
+  def call(conn, {:error, :ambiguous_resolution}) do
+    conn
+    |> put_status(:conflict)
+    |> json(%{
+      error: %{
+        status: 409,
+        code: "ambiguous_resolution",
+        message:
+          "The supplied identifier matches more than one active project. " <>
+            "Disambiguate with an exact slug (or a fully-qualified, single-host repo_url)."
+      }
+    })
   end
 
   def call(conn, {:error, {:invalid_transition, ctx}}) do

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -218,6 +218,9 @@ defmodule LoopctlWeb.Router do
     get "/agents/:id", AgentController, :show
 
     # Project management
+    # Cheap repo -> project_id resolution (Gap 1 of #411). Must precede the
+    # resources block so /projects/resolve is not captured by GET /projects/:id.
+    get "/projects/resolve", ProjectController, :resolve
     resources "/projects", ProjectController, only: [:create, :index, :show, :update, :delete]
     get "/projects/:id/progress", ProjectController, :progress
 

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -376,6 +376,22 @@ async function listProjects(args = {}) {
   return toContent(result);
 }
 
+async function resolveProject({ slug, repo_url, name } = {}) {
+  // Cheap repo -> project_id resolution (loopctl #411 Gap 1). Server tries
+  // slug -> repo_url -> name and returns the first match; agent-role read.
+  const params = new URLSearchParams();
+  if (slug) params.set("slug", slug);
+  if (repo_url) params.set("repo_url", repo_url);
+  if (name) params.set("name", name);
+  const result = await apiCall(
+    "GET",
+    `/api/v1/projects/resolve?${params}`,
+    null,
+    process.env.LOOPCTL_AGENT_KEY,
+  );
+  return toContent(result);
+}
+
 async function createProject({ name, slug, repo_url, description, tech_stack, mission }) {
   const body = { name, slug };
   if (repo_url) body.repo_url = repo_url;
@@ -1994,6 +2010,34 @@ const TOOLS = [
       properties: {
         page: { type: "integer", description: "Page number (default 1)." },
         page_size: { type: "integer", description: "Items per page (default 20)." },
+      },
+      required: [],
+    },
+  },
+  {
+    name: "resolve_project",
+    description:
+      "Resolve a repo to its project in one cheap call. Provide any of slug, " +
+      "repo_url (git@github.com:owner/repo.git, https://github.com/owner/repo, " +
+      "and bare owner/repo all match), or name. Precedence: slug > repo_url > " +
+      "name; first match wins. Returns the project (use its id to scope " +
+      "captures/recall), 404 not_found if nothing matches, 422 no_identifier " +
+      "if none supplied.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        slug: {
+          type: "string",
+          description: "Exact project slug (often the repo basename).",
+        },
+        repo_url: {
+          type: "string",
+          description: "Git remote URL or bare owner/repo.",
+        },
+        name: {
+          type: "string",
+          description: "Exact project name (case-insensitive).",
+        },
       },
       required: [],
     },
@@ -4693,6 +4737,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     case "list_projects":
       return await listProjects(args);
+
+    case "resolve_project":
+      return await resolveProject(args);
 
     case "create_project":
       return await createProject(args);

--- a/mcp-server/test/mcp_arg_forwarding.test.js
+++ b/mcp-server/test/mcp_arg_forwarding.test.js
@@ -86,6 +86,35 @@ describe("#247 mcp-01: list_projects pagination (real projectsPath)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// #411 gap1: resolve_project (cheap repo -> project_id resolution)
+// ---------------------------------------------------------------------------
+
+describe("#411 gap1: resolve_project wiring", () => {
+  test("TOOLS declares a resolve_project tool", () => {
+    assert.match(INDEX_SRC, /name: "resolve_project",/, 'must declare a "resolve_project" tool');
+  });
+
+  test("resolveProject GETs /projects/resolve with slug/repo_url/name on the agent key", () => {
+    assert.match(
+      INDEX_SRC,
+      /async function resolveProject\(\{ slug, repo_url, name \} = \{\}\) \{[\s\S]*?\/api\/v1\/projects\/resolve\?\$\{params\}[\s\S]*?LOOPCTL_AGENT_KEY/,
+      "resolveProject must GET /api/v1/projects/resolve with a query string on the agent key",
+    );
+    assert.match(INDEX_SRC, /if \(slug\) params\.set\("slug", slug\);/);
+    assert.match(INDEX_SRC, /if \(repo_url\) params\.set\("repo_url", repo_url\);/);
+    assert.match(INDEX_SRC, /if \(name\) params\.set\("name", name\);/);
+  });
+
+  test("the resolve_project dispatch case calls resolveProject(args)", () => {
+    assert.match(
+      INDEX_SRC,
+      /case "resolve_project":\s*\n\s*return await resolveProject\(args\);/,
+      "the resolve_project dispatch case must call resolveProject(args)",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // #248 (mcp-02): knowledge_ingestion_jobs forwards limit/offset/since_days
 // ---------------------------------------------------------------------------
 

--- a/priv/repo/migrations/20260715120000_add_projects_tenant_lower_name_index.exs
+++ b/priv/repo/migrations/20260715120000_add_projects_tenant_lower_name_index.exs
@@ -1,0 +1,18 @@
+defmodule Loopctl.Repo.Migrations.AddProjectsTenantLowerNameIndex do
+  use Ecto.Migration
+
+  @moduledoc """
+  Functional index on `(tenant_id, lower(name))` so the case-insensitive
+  name resolution in `Projects.resolve_by_name/2` (`lower(name) = lower($1)`
+  scoped to a tenant) uses an index instead of a sequential scan. Without it
+  the `lower(name)` comparison is non-sargable and each resolve seq-scans the
+  tenant's projects; the resolve endpoint is the cheap per-repo call the harness
+  makes frequently, so keep it O(log n) rather than O(tenant projects).
+  """
+
+  def change do
+    create index(:projects, [:tenant_id, "lower(name)"],
+             name: :projects_tenant_id_lower_name_index
+           )
+  end
+end

--- a/priv/repo/migrations/20260716060000_add_projects_tenant_lower_name_index.exs
+++ b/priv/repo/migrations/20260716060000_add_projects_tenant_lower_name_index.exs
@@ -11,8 +11,8 @@ defmodule Loopctl.Repo.Migrations.AddProjectsTenantLowerNameIndex do
   """
 
   def change do
-    create index(:projects, [:tenant_id, "lower(name)"],
-             name: :projects_tenant_id_lower_name_index
-           )
+    create_if_not_exists index(:projects, [:tenant_id, "lower(name)"],
+                           name: :projects_tenant_id_lower_name_index
+                         )
   end
 end

--- a/test/loopctl/projects/projects_test.exs
+++ b/test/loopctl/projects/projects_test.exs
@@ -221,7 +221,7 @@ defmodule Loopctl.ProjectsTest do
       tenant = fixture(:tenant)
       project = fixture(:project, %{tenant_id: tenant.id, slug: "loopctl"})
 
-      assert {:ok, found} = Projects.resolve_project(tenant.id, slug: "loopctl")
+      assert {:ok, found, _} = Projects.resolve_project(tenant.id, slug: "loopctl")
       assert found.id == project.id
     end
 
@@ -235,7 +235,7 @@ defmodule Loopctl.ProjectsTest do
           repo_url: "https://github.com/mkreyman/loopctl"
         })
 
-      assert {:ok, found} =
+      assert {:ok, found, _} =
                Projects.resolve_project(tenant.id,
                  repo_url: "https://github.com/mkreyman/loopctl"
                )
@@ -253,7 +253,7 @@ defmodule Loopctl.ProjectsTest do
           repo_url: "https://github.com/mkreyman/loopctl"
         })
 
-      assert {:ok, found} =
+      assert {:ok, found, _} =
                Projects.resolve_project(tenant.id,
                  repo_url: "git@github.com:mkreyman/loopctl.git"
                )
@@ -271,7 +271,7 @@ defmodule Loopctl.ProjectsTest do
           repo_url: "git@github.com:mkreyman/loopctl.git"
         })
 
-      assert {:ok, found} =
+      assert {:ok, found, _} =
                Projects.resolve_project(tenant.id, repo_url: "mkreyman/loopctl")
 
       assert found.id == project.id
@@ -281,10 +281,10 @@ defmodule Loopctl.ProjectsTest do
       tenant = fixture(:tenant)
       project = fixture(:project, %{tenant_id: tenant.id, name: "LoopCtl", slug: "loopctl"})
 
-      assert {:ok, found} = Projects.resolve_project(tenant.id, name: "loopctl")
+      assert {:ok, found, _} = Projects.resolve_project(tenant.id, name: "loopctl")
       assert found.id == project.id
 
-      assert {:ok, found2} = Projects.resolve_project(tenant.id, name: "LOOPCTL")
+      assert {:ok, found2, _} = Projects.resolve_project(tenant.id, name: "LOOPCTL")
       assert found2.id == project.id
     end
 
@@ -297,7 +297,7 @@ defmodule Loopctl.ProjectsTest do
       _by_name =
         fixture(:project, %{tenant_id: tenant.id, name: "the-slug", slug: "other-slug"})
 
-      assert {:ok, found} =
+      assert {:ok, found, _} =
                Projects.resolve_project(tenant.id, slug: "the-slug", name: "the-slug")
 
       assert found.id == by_slug.id
@@ -317,7 +317,7 @@ defmodule Loopctl.ProjectsTest do
       _by_name =
         fixture(:project, %{tenant_id: tenant.id, name: "mkreyman/loopctl", slug: "name-project"})
 
-      assert {:ok, found} =
+      assert {:ok, found, _} =
                Projects.resolve_project(tenant.id,
                  repo_url: "mkreyman/loopctl",
                  name: "mkreyman/loopctl"
@@ -345,7 +345,7 @@ defmodule Loopctl.ProjectsTest do
           repo_url: "git@github.com:mkreyman/loopctl.git"
         })
 
-      assert {:ok, found} =
+      assert {:ok, found, _} =
                Projects.resolve_project(tenant.id, repo_url: "mkreyman/loopctl")
 
       assert found.id == active.id
@@ -362,7 +362,7 @@ defmodule Loopctl.ProjectsTest do
 
       active = fixture(:project, %{tenant_id: tenant.id, name: "Shared", slug: "active-name"})
 
-      assert {:ok, found} = Projects.resolve_project(tenant.id, name: "shared")
+      assert {:ok, found, _} = Projects.resolve_project(tenant.id, name: "shared")
       assert found.id == active.id
       assert found.status == :active
     end
@@ -394,7 +394,7 @@ defmodule Loopctl.ProjectsTest do
       tenant = fixture(:tenant)
       project = fixture(:project, %{tenant_id: tenant.id, slug: "map-opts"})
 
-      assert {:ok, found} = Projects.resolve_project(tenant.id, %{slug: "map-opts"})
+      assert {:ok, found, _} = Projects.resolve_project(tenant.id, %{slug: "map-opts"})
       assert found.id == project.id
     end
 
@@ -455,15 +455,131 @@ defmodule Loopctl.ProjectsTest do
         })
 
       # Exact host should win over the mere owner/repo suffix match.
-      assert {:ok, found} =
+      assert {:ok, found, _} =
                Projects.resolve_project(tenant.id, repo_url: "https://gitlab.com/acme/app")
 
       assert found.id == gitlab.id
 
-      assert {:ok, found2} =
+      assert {:ok, found2, _} =
                Projects.resolve_project(tenant.id, repo_url: "https://github.com/acme/app")
 
       assert found2.id == github.id
+    end
+
+    test "a fully-qualified URL does not cross-resolve to a different-host project" do
+      tenant = fixture(:tenant)
+
+      # Only the GitLab project exists; a fully-qualified GitHub query carries an
+      # explicit host and must NOT resolve to the same-path GitLab project.
+      _gitlab =
+        fixture(:project, %{
+          tenant_id: tenant.id,
+          slug: "gl-only",
+          repo_url: "https://gitlab.com/acme/app"
+        })
+
+      assert {:error, :not_found} =
+               Projects.resolve_project(tenant.id, repo_url: "https://github.com/acme/app")
+
+      # A bare owner/repo query has no host, so it still resolves.
+      assert {:ok, found, _} = Projects.resolve_project(tenant.id, repo_url: "acme/app")
+      assert found.slug == "gl-only"
+    end
+
+    test "nested-namespace (GitLab subgroup) URLs do not collide on a shared suffix" do
+      tenant = fixture(:tenant)
+
+      group_a =
+        fixture(:project, %{
+          tenant_id: tenant.id,
+          slug: "group-a-api",
+          repo_url: "https://gitlab.com/group-a/team/api"
+        })
+
+      group_b =
+        fixture(:project, %{
+          tenant_id: tenant.id,
+          slug: "group-b-api",
+          repo_url: "https://gitlab.com/group-b/team/api"
+        })
+
+      assert {:ok, found_a, _} =
+               Projects.resolve_project(tenant.id,
+                 repo_url: "https://gitlab.com/group-a/team/api"
+               )
+
+      assert found_a.id == group_a.id
+
+      assert {:ok, found_b, _} =
+               Projects.resolve_project(tenant.id, repo_url: "group-b/team/api")
+
+      assert found_b.id == group_b.id
+
+      # The bare trailing "team/api" suffix must NOT resolve either subgroup.
+      assert {:error, :not_found} =
+               Projects.resolve_project(tenant.id, repo_url: "team/api")
+    end
+
+    test "does not resolve an archived-only project by repo_url (attach-new-work guardrail)" do
+      tenant = fixture(:tenant)
+
+      archived =
+        fixture(:project, %{
+          tenant_id: tenant.id,
+          slug: "archived-only-repo",
+          repo_url: "https://github.com/mkreyman/loopctl"
+        })
+
+      Projects.archive_project(tenant.id, archived)
+
+      assert {:error, :not_found} =
+               Projects.resolve_project(tenant.id, repo_url: "mkreyman/loopctl")
+    end
+
+    test "does not resolve an archived-only project by name (attach-new-work guardrail)" do
+      tenant = fixture(:tenant)
+
+      archived =
+        fixture(:project, %{tenant_id: tenant.id, name: "Retired", slug: "archived-only-name"})
+
+      Projects.archive_project(tenant.id, archived)
+
+      assert {:error, :not_found} = Projects.resolve_project(tenant.id, name: "retired")
+    end
+
+    test "an active owner/repo match wins even when an archived project has an exact-URL match" do
+      tenant = fixture(:tenant)
+
+      # Archived stores the bare form that normalizes EXACTLY to the query; the
+      # active project stores the full URL form of the same repo. Active must win.
+      archived =
+        fixture(:project, %{
+          tenant_id: tenant.id,
+          slug: "archived-exact",
+          repo_url: "mkreyman/loopctl"
+        })
+
+      Projects.archive_project(tenant.id, archived)
+
+      active =
+        fixture(:project, %{
+          tenant_id: tenant.id,
+          slug: "active-full",
+          repo_url: "https://github.com/mkreyman/loopctl"
+        })
+
+      assert {:ok, found, _} =
+               Projects.resolve_project(tenant.id, repo_url: "mkreyman/loopctl")
+
+      assert found.id == active.id
+      assert found.status == :active
+    end
+
+    test "resolves a malformed opts container to :no_identifier without raising" do
+      tenant = fixture(:tenant)
+
+      assert {:error, :no_identifier} = Projects.resolve_project(tenant.id, "not-a-container")
+      assert {:error, :no_identifier} = Projects.resolve_project(tenant.id, 123)
     end
 
     test "ignores decoy projects whose owner/repo does not match (bounded scan)" do
@@ -491,7 +607,7 @@ defmodule Loopctl.ProjectsTest do
           repo_url: "https://github.com/mkreyman/loopctl"
         })
 
-      assert {:ok, found} =
+      assert {:ok, found, _} =
                Projects.resolve_project(tenant.id, repo_url: "mkreyman/loopctl")
 
       assert found.id == target.id
@@ -524,12 +640,12 @@ defmodule Loopctl.ProjectsTest do
       project =
         fixture(:project, %{tenant_id: tenant.id, name: "MixedCase Project", slug: "mixed-case"})
 
-      assert {:ok, found} =
+      assert {:ok, found, _} =
                Projects.resolve_project(tenant.id, name: "mixedcase project")
 
       assert found.id == project.id
 
-      assert {:ok, found2} =
+      assert {:ok, found2, _} =
                Projects.resolve_project(tenant.id, name: "MIXEDCASE PROJECT")
 
       assert found2.id == project.id
@@ -540,6 +656,131 @@ defmodule Loopctl.ProjectsTest do
       # The fix's value is that BOTH sides now fold through the same Postgres
       # `lower()` rather than mixing Elixir String.downcase/1 with SQL lower(),
       # eliminating the cross-locale divergence regardless of the active locale.
+    end
+
+    test "reports which identifier produced the match via matched_by" do
+      tenant = fixture(:tenant)
+
+      _project =
+        fixture(:project, %{
+          tenant_id: tenant.id,
+          name: "Matched By Project",
+          slug: "matched-by",
+          repo_url: "https://github.com/mkreyman/matched"
+        })
+
+      assert {:ok, _, :slug} = Projects.resolve_project(tenant.id, slug: "matched-by")
+
+      assert {:ok, _, :repo_url} =
+               Projects.resolve_project(tenant.id, repo_url: "mkreyman/matched")
+
+      assert {:ok, _, :name} =
+               Projects.resolve_project(tenant.id, name: "matched by project")
+    end
+
+    test "returns :ambiguous when a bare owner/repo matches active projects on two hosts" do
+      tenant = fixture(:tenant)
+
+      _github =
+        fixture(:project, %{
+          tenant_id: tenant.id,
+          slug: "gh-mirror",
+          repo_url: "https://github.com/acme/app"
+        })
+
+      _gitlab =
+        fixture(:project, %{
+          tenant_id: tenant.id,
+          slug: "gl-mirror",
+          repo_url: "https://gitlab.com/acme/app"
+        })
+
+      # A bare, host-less query matches both mirrors -- refuse to silently attach
+      # to whichever is older.
+      assert {:error, :ambiguous} =
+               Projects.resolve_project(tenant.id, repo_url: "acme/app")
+
+      # A fully-qualified query is unambiguous and still resolves the right one.
+      assert {:ok, found, :repo_url} =
+               Projects.resolve_project(tenant.id, repo_url: "https://gitlab.com/acme/app")
+
+      assert found.slug == "gl-mirror"
+    end
+
+    test "returns :ambiguous when two active projects share a repo_url" do
+      tenant = fixture(:tenant)
+
+      _one =
+        fixture(:project, %{
+          tenant_id: tenant.id,
+          slug: "dup-repo-one",
+          repo_url: "https://github.com/acme/dup"
+        })
+
+      _two =
+        fixture(:project, %{
+          tenant_id: tenant.id,
+          slug: "dup-repo-two",
+          repo_url: "https://github.com/acme/dup"
+        })
+
+      assert {:error, :ambiguous} =
+               Projects.resolve_project(tenant.id, repo_url: "https://github.com/acme/dup")
+    end
+
+    test "returns :ambiguous when two active projects share a name" do
+      tenant = fixture(:tenant)
+
+      _one = fixture(:project, %{tenant_id: tenant.id, name: "Twin", slug: "twin-one"})
+      _two = fixture(:project, %{tenant_id: tenant.id, name: "Twin", slug: "twin-two"})
+
+      assert {:error, :ambiguous} = Projects.resolve_project(tenant.id, name: "twin")
+    end
+
+    test "resolves a repo_url that carries an explicit host port" do
+      tenant = fixture(:tenant)
+
+      project =
+        fixture(:project, %{
+          tenant_id: tenant.id,
+          slug: "ported",
+          repo_url: "https://git.example.com/acme/ported"
+        })
+
+      # The stored URL has no port; a query carrying an explicit :port on the
+      # host must still resolve to it (the port is stripped, not treated as a
+      # path segment).
+      assert {:ok, found, :repo_url} =
+               Projects.resolve_project(tenant.id,
+                 repo_url: "https://git.example.com:8080/acme/ported"
+               )
+
+      assert found.id == project.id
+
+      assert {:ok, found2, :repo_url} =
+               Projects.resolve_project(tenant.id,
+                 repo_url: "ssh://git@git.example.com:22/acme/ported.git"
+               )
+
+      assert found2.id == project.id
+    end
+
+    test "resolves a bare owner/repo whose owner contains a dot" do
+      tenant = fixture(:tenant)
+
+      project =
+        fixture(:project, %{
+          tenant_id: tenant.id,
+          slug: "dotted-owner",
+          repo_url: "my.org/repo"
+        })
+
+      # A dotted owner must not be misread as a hostname (which would drop the
+      # path); the bare identifier still resolves.
+      assert {:ok, found, :repo_url} =
+               Projects.resolve_project(tenant.id, repo_url: "my.org/repo")
+
+      assert found.id == project.id
     end
   end
 

--- a/test/loopctl/projects/projects_test.exs
+++ b/test/loopctl/projects/projects_test.exs
@@ -216,6 +216,333 @@ defmodule Loopctl.ProjectsTest do
     end
   end
 
+  describe "resolve_project/2" do
+    test "resolves by exact slug" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id, slug: "loopctl"})
+
+      assert {:ok, found} = Projects.resolve_project(tenant.id, slug: "loopctl")
+      assert found.id == project.id
+    end
+
+    test "resolves by repo_url in https form" do
+      tenant = fixture(:tenant)
+
+      project =
+        fixture(:project, %{
+          tenant_id: tenant.id,
+          slug: "loopctl",
+          repo_url: "https://github.com/mkreyman/loopctl"
+        })
+
+      assert {:ok, found} =
+               Projects.resolve_project(tenant.id,
+                 repo_url: "https://github.com/mkreyman/loopctl"
+               )
+
+      assert found.id == project.id
+    end
+
+    test "resolves by repo_url in git@ ssh form (with .git suffix)" do
+      tenant = fixture(:tenant)
+
+      project =
+        fixture(:project, %{
+          tenant_id: tenant.id,
+          slug: "loopctl",
+          repo_url: "https://github.com/mkreyman/loopctl"
+        })
+
+      assert {:ok, found} =
+               Projects.resolve_project(tenant.id,
+                 repo_url: "git@github.com:mkreyman/loopctl.git"
+               )
+
+      assert found.id == project.id
+    end
+
+    test "resolves by repo_url in bare owner/repo form" do
+      tenant = fixture(:tenant)
+
+      project =
+        fixture(:project, %{
+          tenant_id: tenant.id,
+          slug: "loopctl",
+          repo_url: "git@github.com:mkreyman/loopctl.git"
+        })
+
+      assert {:ok, found} =
+               Projects.resolve_project(tenant.id, repo_url: "mkreyman/loopctl")
+
+      assert found.id == project.id
+    end
+
+    test "resolves by name case-insensitively" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id, name: "LoopCtl", slug: "loopctl"})
+
+      assert {:ok, found} = Projects.resolve_project(tenant.id, name: "loopctl")
+      assert found.id == project.id
+
+      assert {:ok, found2} = Projects.resolve_project(tenant.id, name: "LOOPCTL")
+      assert found2.id == project.id
+    end
+
+    test "slug takes precedence over name when both point to different projects" do
+      tenant = fixture(:tenant)
+
+      by_slug =
+        fixture(:project, %{tenant_id: tenant.id, name: "Slug Project", slug: "the-slug"})
+
+      _by_name =
+        fixture(:project, %{tenant_id: tenant.id, name: "the-slug", slug: "other-slug"})
+
+      assert {:ok, found} =
+               Projects.resolve_project(tenant.id, slug: "the-slug", name: "the-slug")
+
+      assert found.id == by_slug.id
+    end
+
+    test "repo_url takes precedence over name" do
+      tenant = fixture(:tenant)
+
+      by_repo =
+        fixture(:project, %{
+          tenant_id: tenant.id,
+          name: "Repo Project",
+          slug: "repo-project",
+          repo_url: "https://github.com/mkreyman/loopctl"
+        })
+
+      _by_name =
+        fixture(:project, %{tenant_id: tenant.id, name: "mkreyman/loopctl", slug: "name-project"})
+
+      assert {:ok, found} =
+               Projects.resolve_project(tenant.id,
+                 repo_url: "mkreyman/loopctl",
+                 name: "mkreyman/loopctl"
+               )
+
+      assert found.id == by_repo.id
+    end
+
+    test "prefers active project when multiple match by repo_url" do
+      tenant = fixture(:tenant)
+
+      archived =
+        fixture(:project, %{
+          tenant_id: tenant.id,
+          slug: "archived-repo",
+          repo_url: "https://github.com/mkreyman/loopctl"
+        })
+
+      Projects.archive_project(tenant.id, archived)
+
+      active =
+        fixture(:project, %{
+          tenant_id: tenant.id,
+          slug: "active-repo",
+          repo_url: "git@github.com:mkreyman/loopctl.git"
+        })
+
+      assert {:ok, found} =
+               Projects.resolve_project(tenant.id, repo_url: "mkreyman/loopctl")
+
+      assert found.id == active.id
+      assert found.status == :active
+    end
+
+    test "prefers active project when multiple match by name" do
+      tenant = fixture(:tenant)
+
+      archived =
+        fixture(:project, %{tenant_id: tenant.id, name: "Shared", slug: "archived-name"})
+
+      Projects.archive_project(tenant.id, archived)
+
+      active = fixture(:project, %{tenant_id: tenant.id, name: "Shared", slug: "active-name"})
+
+      assert {:ok, found} = Projects.resolve_project(tenant.id, name: "shared")
+      assert found.id == active.id
+      assert found.status == :active
+    end
+
+    test "returns not_found when no project matches" do
+      tenant = fixture(:tenant)
+      fixture(:project, %{tenant_id: tenant.id, slug: "exists"})
+
+      assert {:error, :not_found} =
+               Projects.resolve_project(tenant.id, slug: "missing")
+
+      assert {:error, :not_found} =
+               Projects.resolve_project(tenant.id, repo_url: "someone/else")
+
+      assert {:error, :not_found} = Projects.resolve_project(tenant.id, name: "nope")
+    end
+
+    test "returns no_identifier when no identifier supplied" do
+      tenant = fixture(:tenant)
+
+      assert {:error, :no_identifier} = Projects.resolve_project(tenant.id, [])
+      assert {:error, :no_identifier} = Projects.resolve_project(tenant.id, %{})
+
+      assert {:error, :no_identifier} =
+               Projects.resolve_project(tenant.id, slug: "", repo_url: "  ", name: nil)
+    end
+
+    test "accepts a map of options as well as a keyword list" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id, slug: "map-opts"})
+
+      assert {:ok, found} = Projects.resolve_project(tenant.id, %{slug: "map-opts"})
+      assert found.id == project.id
+    end
+
+    test "never resolves another tenant's project (slug)" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      _project = fixture(:project, %{tenant_id: tenant_b.id, slug: "cross-tenant"})
+
+      assert {:error, :not_found} =
+               Projects.resolve_project(tenant_a.id, slug: "cross-tenant")
+    end
+
+    test "never resolves another tenant's project (repo_url and name)" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+
+      _project =
+        fixture(:project, %{
+          tenant_id: tenant_b.id,
+          name: "Cross Tenant",
+          slug: "cross-tenant",
+          repo_url: "https://github.com/mkreyman/loopctl"
+        })
+
+      assert {:error, :not_found} =
+               Projects.resolve_project(tenant_a.id, repo_url: "mkreyman/loopctl")
+
+      assert {:error, :not_found} =
+               Projects.resolve_project(tenant_a.id, name: "cross tenant")
+    end
+
+    test "does not raise on malformed repo_url input" do
+      tenant = fixture(:tenant)
+      fixture(:project, %{tenant_id: tenant.id, slug: "safe"})
+
+      assert {:error, :not_found} =
+               Projects.resolve_project(tenant.id, repo_url: ":::")
+
+      assert {:error, :not_found} =
+               Projects.resolve_project(tenant.id, repo_url: "just-one-segment")
+    end
+
+    test "exact repo_url match beats a same-owner/repo match on a different host" do
+      tenant = fixture(:tenant)
+
+      github =
+        fixture(:project, %{
+          tenant_id: tenant.id,
+          slug: "gh-app",
+          repo_url: "https://github.com/acme/app"
+        })
+
+      gitlab =
+        fixture(:project, %{
+          tenant_id: tenant.id,
+          slug: "gl-app",
+          repo_url: "https://gitlab.com/acme/app"
+        })
+
+      # Exact host should win over the mere owner/repo suffix match.
+      assert {:ok, found} =
+               Projects.resolve_project(tenant.id, repo_url: "https://gitlab.com/acme/app")
+
+      assert found.id == gitlab.id
+
+      assert {:ok, found2} =
+               Projects.resolve_project(tenant.id, repo_url: "https://github.com/acme/app")
+
+      assert found2.id == github.id
+    end
+
+    test "ignores decoy projects whose owner/repo does not match (bounded scan)" do
+      tenant = fixture(:tenant)
+
+      # Decoys with a different owner/repo must never be considered.
+      _decoy1 =
+        fixture(:project, %{
+          tenant_id: tenant.id,
+          slug: "decoy-1",
+          repo_url: "https://github.com/other/thing"
+        })
+
+      _decoy2 =
+        fixture(:project, %{
+          tenant_id: tenant.id,
+          slug: "decoy-2",
+          repo_url: "https://github.com/unrelated/repo"
+        })
+
+      target =
+        fixture(:project, %{
+          tenant_id: tenant.id,
+          slug: "target",
+          repo_url: "https://github.com/mkreyman/loopctl"
+        })
+
+      assert {:ok, found} =
+               Projects.resolve_project(tenant.id, repo_url: "mkreyman/loopctl")
+
+      assert found.id == target.id
+    end
+
+    test "degenerate repo_url normalizing to empty does not collide with a degenerate stored repo_url" do
+      tenant = fixture(:tenant)
+
+      # ".git" is a non-empty (castable) string that normalizes to "".
+      _degenerate =
+        fixture(:project, %{
+          tenant_id: tenant.id,
+          slug: "degenerate",
+          repo_url: ".git"
+        })
+
+      assert {:error, :not_found} =
+               Projects.resolve_project(tenant.id, repo_url: ".git")
+
+      assert {:error, :not_found} =
+               Projects.resolve_project(tenant.id, repo_url: "/")
+
+      assert {:error, :not_found} =
+               Projects.resolve_project(tenant.id, repo_url: "/.git")
+    end
+
+    test "resolves by name with mixed case (Postgres lower on both sides)" do
+      tenant = fixture(:tenant)
+
+      project =
+        fixture(:project, %{tenant_id: tenant.id, name: "MixedCase Project", slug: "mixed-case"})
+
+      assert {:ok, found} =
+               Projects.resolve_project(tenant.id, name: "mixedcase project")
+
+      assert found.id == project.id
+
+      assert {:ok, found2} =
+               Projects.resolve_project(tenant.id, name: "MIXEDCASE PROJECT")
+
+      assert found2.id == project.id
+
+      # NOTE: A non-ASCII case-folding assertion (e.g. "Café Ölçek" vs
+      # "café ölçek") is intentionally omitted: this DB's `lower()` locale does
+      # not fold accented uppercase, so such an assertion is not portable here.
+      # The fix's value is that BOTH sides now fold through the same Postgres
+      # `lower()` rather than mixing Elixir String.downcase/1 with SQL lower(),
+      # eliminating the cross-locale divergence regardless of the active locale.
+    end
+  end
+
   describe "update_project/4" do
     test "updates project name" do
       tenant = fixture(:tenant)

--- a/test/loopctl_web/controllers/project_controller_test.exs
+++ b/test/loopctl_web/controllers/project_controller_test.exs
@@ -540,6 +540,7 @@ defmodule LoopctlWeb.ProjectControllerTest do
       body = json_response(conn, 200)
       assert body["project"]["id"] == project.id
       assert body["project"]["slug"] == "loopctl"
+      assert body["matched_by"] == "slug"
     end
 
     test "resolves by repo_url in ssh form", %{conn: conn} do
@@ -580,7 +581,8 @@ defmodule LoopctlWeb.ProjectControllerTest do
       conn = conn |> auth_conn(raw_key) |> get(~p"/api/v1/projects/resolve?slug=missing")
 
       body = json_response(conn, 404)
-      assert body["error"] == "not_found"
+      assert body["error"]["status"] == 404
+      assert is_binary(body["error"]["message"])
     end
 
     test "returns 422 with no_identifier error when no identifier supplied", %{conn: conn} do
@@ -590,7 +592,8 @@ defmodule LoopctlWeb.ProjectControllerTest do
       conn = conn |> auth_conn(raw_key) |> get(~p"/api/v1/projects/resolve")
 
       body = json_response(conn, 422)
-      assert body["error"] == "no_identifier"
+      assert body["error"]["status"] == 422
+      assert is_binary(body["error"]["message"])
     end
 
     test "respects tenant isolation (never resolves another tenant's project)", %{conn: conn} do
@@ -606,14 +609,51 @@ defmodule LoopctlWeb.ProjectControllerTest do
         })
 
       conn = conn |> auth_conn(key_a) |> get(~p"/api/v1/projects/resolve?slug=cross-tenant")
-      assert json_response(conn, 404)["error"] == "not_found"
+      assert json_response(conn, 404)["error"]["status"] == 404
 
       conn2 =
         build_conn()
         |> auth_conn(key_a)
         |> get(~p"/api/v1/projects/resolve?repo_url=mkreyman/loopctl")
 
-      assert json_response(conn2, 404)["error"] == "not_found"
+      assert json_response(conn2, 404)["error"]["status"] == 404
+    end
+
+    test "returns 409 ambiguous_resolution when a bare repo_url matches two hosts", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _api_key} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      fixture(:project, %{
+        tenant_id: tenant.id,
+        slug: "gh-mirror",
+        repo_url: "https://github.com/acme/app"
+      })
+
+      fixture(:project, %{
+        tenant_id: tenant.id,
+        slug: "gl-mirror",
+        repo_url: "https://gitlab.com/acme/app"
+      })
+
+      conn = conn |> auth_conn(raw_key) |> get(~p"/api/v1/projects/resolve?repo_url=acme/app")
+
+      body = json_response(conn, 409)
+      assert body["error"]["status"] == 409
+      assert body["error"]["code"] == "ambiguous_resolution"
+    end
+
+    test "returns 422 when an identifier exceeds the length cap", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _api_key} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      long_name = String.duplicate("a", 513)
+
+      conn =
+        conn |> auth_conn(raw_key) |> get(~p"/api/v1/projects/resolve?name=#{long_name}")
+
+      body = json_response(conn, 422)
+      assert body["error"]["status"] == 422
+      assert is_binary(body["error"]["message"])
     end
 
     test "requires authentication", %{conn: conn} do

--- a/test/loopctl_web/controllers/project_controller_test.exs
+++ b/test/loopctl_web/controllers/project_controller_test.exs
@@ -529,6 +529,99 @@ defmodule LoopctlWeb.ProjectControllerTest do
     end
   end
 
+  describe "GET /api/v1/projects/resolve" do
+    test "resolves by slug and returns the project", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _api_key} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      project = fixture(:project, %{tenant_id: tenant.id, slug: "loopctl", name: "loopctl"})
+
+      conn = conn |> auth_conn(raw_key) |> get(~p"/api/v1/projects/resolve?slug=loopctl")
+
+      body = json_response(conn, 200)
+      assert body["project"]["id"] == project.id
+      assert body["project"]["slug"] == "loopctl"
+    end
+
+    test "resolves by repo_url in ssh form", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _api_key} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      project =
+        fixture(:project, %{
+          tenant_id: tenant.id,
+          slug: "loopctl",
+          repo_url: "https://github.com/mkreyman/loopctl"
+        })
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> get(~p"/api/v1/projects/resolve?repo_url=git@github.com:mkreyman/loopctl.git")
+
+      body = json_response(conn, 200)
+      assert body["project"]["id"] == project.id
+    end
+
+    test "resolves by name case-insensitively", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _api_key} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      project = fixture(:project, %{tenant_id: tenant.id, name: "LoopCtl", slug: "loopctl"})
+
+      conn = conn |> auth_conn(raw_key) |> get(~p"/api/v1/projects/resolve?name=loopctl")
+
+      body = json_response(conn, 200)
+      assert body["project"]["id"] == project.id
+    end
+
+    test "returns 404 with not_found error when no match", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _api_key} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn = conn |> auth_conn(raw_key) |> get(~p"/api/v1/projects/resolve?slug=missing")
+
+      body = json_response(conn, 404)
+      assert body["error"] == "not_found"
+    end
+
+    test "returns 422 with no_identifier error when no identifier supplied", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _api_key} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn = conn |> auth_conn(raw_key) |> get(~p"/api/v1/projects/resolve")
+
+      body = json_response(conn, 422)
+      assert body["error"] == "no_identifier"
+    end
+
+    test "respects tenant isolation (never resolves another tenant's project)", %{conn: conn} do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      {key_a, _api_key} = fixture(:api_key, %{tenant_id: tenant_a.id, role: :agent})
+
+      _project_b =
+        fixture(:project, %{
+          tenant_id: tenant_b.id,
+          slug: "cross-tenant",
+          repo_url: "https://github.com/mkreyman/loopctl"
+        })
+
+      conn = conn |> auth_conn(key_a) |> get(~p"/api/v1/projects/resolve?slug=cross-tenant")
+      assert json_response(conn, 404)["error"] == "not_found"
+
+      conn2 =
+        build_conn()
+        |> auth_conn(key_a)
+        |> get(~p"/api/v1/projects/resolve?repo_url=mkreyman/loopctl")
+
+      assert json_response(conn2, 404)["error"] == "not_found"
+    end
+
+    test "requires authentication", %{conn: conn} do
+      conn = get(conn, ~p"/api/v1/projects/resolve?slug=loopctl")
+      assert json_response(conn, 401)
+    end
+  end
+
   describe "cross-tenant isolation" do
     test "cannot list another tenant's projects", %{conn: conn} do
       tenant_a = fixture(:tenant)


### PR DESCRIPTION
#411 Gap 1: cheap repo -> project_id resolution

Adds the single lookup the harness needs to turn "I'm working in repo X" into a
loopctl project, so captured knowledge can be scoped (unblocks claude-config #91
Gap 1). Today the only lookup was exact-slug.

- Context: Projects.resolve_project/2 resolves by slug -> repo_url -> name,
  first hit wins; tenant-scoped on every branch. repo_url matches across
  git@github.com:owner/repo.git, https://github.com/owner/repo, and bare
  owner/repo; an EXACT normalized-URL match wins over a same-owner/repo match on
  a different host (two-pass); candidate scan is bounded in SQL via an escaped
  ILIKE prefilter; active project preferred over archived. Returns
  {:ok, project} | {:error, :not_found | :no_identifier}; never raises.
- HTTP: GET /api/v1/projects/resolve (query: any of slug, repo_url, name),
  agent-role read, routed before resources "/projects" so it is not parsed as
  an :id. 200 project / 404 not_found / 422 no_identifier.
- MCP: resolve_project tool proxying the endpoint on the agent key.
- Tests: resolve_project/2 context (incl. cross-host exact-wins, bounded-scan
  decoys, degenerate repo_url, case-insensitive name, tenant isolation),
  controller (200/404/422/auth/isolation), and MCP wiring.

Adversarial security review: confidentiality clean (no cross-tenant leak; tenant
filter on every AdminRepo/BYPASSRLS branch). Four within-tenant defects it found
were fixed in-branch (no deferrals): exact-URL-beats-suffix, unbounded scan,
empty-normalized repo_url collision, and Elixir/Postgres lowercase divergence.

Gate: mix precommit green (4772 tests, 0 failures; credo --strict, dialyzer,
format, deps.audit all pass). MCP node suite 219/0.
