### PR TITLE
#411 Gap 2 (PR A): project-scope long-term memory recall

### DIFF
--- a/lib/loopctl/api_spec/schemas.ex
+++ b/lib/loopctl/api_spec/schemas.ex
@@ -3221,6 +3221,15 @@ defmodule Loopctl.ApiSpec.Schemas do
           nullable: true,
           description:
             "Optional: arbitrary structured metadata to attach to the memory (either tier)."
+        },
+        project_id: %Schema{
+          type: :string,
+          format: :uuid,
+          nullable: true,
+          description:
+            "Optional project scope (a UUID PARTITION key, NOT an isolation boundary). " <>
+              "Absent/blank writes a tenant-wide (global) memory; a malformed value is " <>
+              "rejected with a 422 invalid_project_id."
         }
       }
     })
@@ -3240,7 +3249,16 @@ defmodule Loopctl.ApiSpec.Schemas do
           type: :integer,
           description: "Max results, clamped to the vector-search max (no silent hard cap)."
         },
-        include_superseded: %Schema{type: :boolean, description: "Default false."}
+        include_superseded: %Schema{type: :boolean, description: "Default false."},
+        project_id: %Schema{
+          type: :string,
+          format: :uuid,
+          nullable: true,
+          description:
+            "Optional project scope (a UUID PARTITION key, NOT an isolation boundary). " <>
+              "Recall returns the merged global ∪ active-project set; absent/blank means " <>
+              "global-only. A malformed value is rejected with a 422 invalid_project_id."
+        }
       }
     })
   end

--- a/lib/loopctl/memory.ex
+++ b/lib/loopctl/memory.ex
@@ -472,6 +472,7 @@ defmodule Loopctl.Memory do
       select: c
     )
     |> maybe_exclude_superseded_sub(include_superseded?)
+    |> maybe_scope_project_outer(scope.project_id)
   end
 
   # Live-only filter on the INNER index-ordered ANN, applied ONLY on the default
@@ -497,6 +498,40 @@ defmodule Loopctl.Memory do
   defp maybe_exclude_superseded_sub(query, false),
     do: where(query, [c], is_nil(c.superseded_by))
 
+  # #411 Gap 2: recall returns the merged `global ∪ active-project` set (mirrors
+  # `Loopctl.Knowledge.scope_project_or_global/2`). `project_id` is a PARTITION key,
+  # NOT an isolation boundary — `tenant_id`/`subject_id` are (see `Memory.Scope`
+  # moduledoc). So a nil scope resolves to global-only (`project_id IS NULL`) and a
+  # present project merges global with that project. The `:binary_id` cast is guarded
+  # the way Knowledge does it: a malformed (non-UUID) value scopes to global-only
+  # rather than raising `Ecto.Query.CastError` (controllers 4xx at the boundary —
+  # this is defense in depth). Two arities because Ecto `where` needs the binding
+  # position at compile time: the semantic path filters the outer over-the-pool
+  # subquery's `[c]` projection, the fallback path filters the base `[m]` table.
+  #
+  # This predicate MUST stay on the OUTER over-the-pool query (like the subject and
+  # superseded filters) — never on `index_safe_knn_base`'s inner ANN, where a
+  # selective predicate would flip the planner off the HNSW index.
+  defp maybe_scope_project_outer(query, project_id) when is_binary(project_id) do
+    if valid_uuid?(project_id) do
+      where(query, [c], is_nil(c.project_id) or c.project_id == ^project_id)
+    else
+      where(query, [c], is_nil(c.project_id))
+    end
+  end
+
+  defp maybe_scope_project_outer(query, _), do: where(query, [c], is_nil(c.project_id))
+
+  defp maybe_scope_project_base(query, project_id) when is_binary(project_id) do
+    if valid_uuid?(project_id) do
+      where(query, [m], is_nil(m.project_id) or m.project_id == ^project_id)
+    else
+      where(query, [m], is_nil(m.project_id))
+    end
+  end
+
+  defp maybe_scope_project_base(query, _), do: where(query, [m], is_nil(m.project_id))
+
   # Rebuild a %Memory{} from the recalled projection map. `embedding` is
   # `load_in_query: false` so it is intentionally absent (recall never returns the
   # raw vector); `:distance` is a computed column, dropped before struct build.
@@ -516,6 +551,7 @@ defmodule Loopctl.Memory do
       )
       |> maybe_exclude_superseded_base(include_superseded?)
       |> maybe_ilike(query_text)
+      |> maybe_scope_project_base(scope.project_id)
 
     rows =
       HeavyRead.all_memory(

--- a/lib/loopctl/memory.ex
+++ b/lib/loopctl/memory.ex
@@ -320,8 +320,24 @@ defmodule Loopctl.Memory do
     |> case do
       {:ok, %{memory: memory}} -> {:ok, memory}
       {:error, :quota, :quota_exceeded, _changes} -> {:error, :quota_exceeded}
-      {:error, :memory, %Ecto.Changeset{} = changeset, _changes} -> {:error, changeset}
+      {:error, :memory, %Ecto.Changeset{} = changeset, _changes} -> memory_insert_error(changeset)
       {:error, :embedding_job, reason, _changes} -> {:error, reason}
+    end
+  end
+
+  # `validate_project_scope/1` runs BEFORE this advisory-locked Multi (check-then-act),
+  # so a project deleted in the window between that read and the insert trips the
+  # BYPASSRLS `foreign_key_constraint(:project_id)` at insert time — surfacing as a
+  # changeset error on `:project_id` rather than the intended `:project_not_found`. Map
+  # that back so the deleted-mid-write RACE returns the SAME `{:error, :project_not_found}`
+  # envelope (controller → `invalid_project_id`) as a foreign/nonexistent `project_id`
+  # caught pre-insert, keeping the caller contract consistent (#411 review). Any other
+  # changeset error (e.g. a `:text` validation) passes through unchanged.
+  defp memory_insert_error(%Ecto.Changeset{errors: errors} = changeset) do
+    if Keyword.has_key?(errors, :project_id) do
+      {:error, :project_not_found}
+    else
+      {:error, changeset}
     end
   end
 
@@ -374,6 +390,30 @@ defmodule Loopctl.Memory do
   `Loopctl.HeavyRead.all_memory/4`'s structural guard. Superseded rows are
   excluded unless `opts[:include_superseded]` is true.
 
+  ## `project_id` is a partition key here — recall does NOT tenant-validate it
+
+  `scope.project_id` selects a PARTITION, it is not the isolation boundary
+  (`tenant_id`/`subject_id` are). Recall therefore deliberately does NOT check
+  project ownership, and its `nil`/foreign/nonexistent semantics differ from the
+  write path ON PURPOSE:
+
+    * `project_id: nil` → GLOBAL-ONLY: only rows whose `project_id` column is NULL
+      (NOT a union across the subject's projects — see `Loopctl.Memory.Scope`).
+    * a present, well-formed `project_id` → `global ∪ that project`.
+    * a well-formed `project_id` that is a TYPO, STALE, or belongs to ANOTHER
+      tenant → treated as global-only (it simply matches no in-tenant rows), with
+      NO error. This is safe — the `(tenant_id, subject_id)` predicate still bounds
+      every result, so a foreign project_id can never surface another tenant's or
+      subject's rows — but it is INTENTIONALLY ASYMMETRIC with `remember/2`, which
+      validates ownership up front and 422s a foreign/nonexistent `project_id`
+      (`:project_not_found` → `invalid_project_id`). Recall stays validation-free so
+      an unowned partition is a quiet empty-partition read rather than a DB round-trip
+      on the hot recall path; the trade is that a client bug (wrong-tenant
+      `project_id`) is masked on recall where it would 422 on create. Callers that
+      need an unowned-project error must validate the id before recall.
+    * a malformed (non-UUID) `project_id` → global-only (the `:binary_id` cast is
+      guarded rather than raising; controllers 422 it at the boundary first).
+
   ## Index-safety (AC-28.2.3)
 
   A selective `(tenant_id, subject_id)` btree on the inner index-ordered subquery
@@ -390,9 +430,15 @@ defmodule Loopctl.Memory do
   kept), so superseded rows never occupy pool slots and default recall does not
   under-fill with live rows for a heavily-superseding subject. `include_superseded:
   true` uses the full index. `meta.underfilled` is `true` when fewer than the
-  requested `k` rows were recalled — a small live scope, a cross-SUBJECT pool
-  under-fill, OR (since #411 Gap 2) a cross-PROJECT pool under-fill — so callers can
-  distinguish it from a genuinely capped page.
+  requested `k` rows were recalled — nothing more. It is a single boolean
+  (`length(results) < k`) and DOES NOT distinguish WHY the page is short: a
+  genuinely small live scope, a cross-SUBJECT pool under-fill, and (since #411
+  Gap 2) a cross-PROJECT pool under-fill all raise it identically. So `underfilled:
+  true` means only "fewer than `k` here" — a caller CANNOT read it as "there is
+  nothing more" vs "matching rows exist beyond the pool horizon; retry wider". A
+  cause-tagged signal (`meta.underfill_reason`) is deferred to the US-28.5 pool-
+  calibration story; until then treat `underfilled` as a hint to widen `limit`, not
+  a diagnosis.
 
   ## Project scope compounds the pool under-fill window (#411 Gap 2)
 
@@ -404,10 +450,13 @@ defmodule Loopctl.Memory do
   (`global + active-project`) live memories are sparse relative to its total
   cross-project corpus can under-fill recall (`meta.underfilled: true`) even when ≥ k
   in-scope memories exist beyond the pool horizon — the SAME accepted tradeoff as the
-  subject filter, now compounded. Widening `pool_size` when a project scope is active
-  (and re-verifying the combined subject×project dilution bound) is deferred to the
-  US-28.5-class scale story that owns pool calibration; recall SIGNALS the short page
-  via `meta.underfilled` regardless.
+  subject filter, now compounded. MITIGATION (`recall_pool_size/2`): when a project
+  scope is active the over-fetch factor is DOUBLED so the project filter draws from a
+  larger candidate pool, strictly REDUCING (never eliminating) the compounded
+  under-fill window — bounded by `:max_vector_pool` so worst-case recall cost is
+  unchanged. FULL pool re-calibration with a VERIFIED combined subject×project dilution
+  bound remains the US-28.5-class scale story that owns pool calibration; recall
+  SIGNALS any residual short page via `meta.underfilled` regardless.
 
   ## Degradation (AC-28.2.4)
 
@@ -488,16 +537,7 @@ defmodule Loopctl.Memory do
   # trivial filters on a tiny set that cannot defeat the index.
   defp memory_candidate_query(scope, embedding, k, include_superseded?) do
     target = VectorSearch.to_embedding_list(embedding)
-    # POOL SIZING CAVEAT (#411 Gap 2): `pool_size/1` is calibrated for SUBJECT dilution
-    # ONLY (the subject filter lives on the OUTER query, off the HNSW inner ANN). The
-    # project scope (`maybe_scope_project/2` below) is a SECOND, independent outer
-    # filter over this SAME pool, but the pool is NOT enlarged for it — so a subject
-    # whose in-scope (global + active-project) rows are sparse relative to its total
-    # cross-project corpus can under-fill (surfaced via `meta.underfilled`). Enlarging
-    # the pool when a project scope is active + re-verifying the combined
-    # subject×project dilution bound is deferred to the US-28.5-class scale story that
-    # owns pool calibration (see `recall/2` moduledoc "Project scope compounds ...").
-    pool = VectorSearch.pool_size(k)
+    pool = recall_pool_size(scope, k)
 
     inner =
       MemorySchema
@@ -522,6 +562,7 @@ defmodule Loopctl.Memory do
       |> VectorSearch.put_distance(target)
 
     from(c in subquery(inner),
+      as: :memory,
       where: c.subject_id == ^scope.subject_id,
       order_by: [asc: c.distance],
       limit: ^k,
@@ -530,6 +571,25 @@ defmodule Loopctl.Memory do
     |> maybe_exclude_superseded_sub(include_superseded?)
     |> maybe_scope_project(scope.project_id)
   end
+
+  # POOL SIZING (#411 Gap 2): `VectorSearch.pool_size/2` is calibrated for SUBJECT
+  # dilution ONLY (the subject filter lives on the OUTER query, off the HNSW inner ANN).
+  # The project scope (`maybe_scope_project/2`) is a SECOND, independent outer filter
+  # over this SAME pool, so a subject whose in-scope (global + active-project) rows are
+  # sparse relative to its total cross-project corpus can under-fill (surfaced via
+  # `meta.underfilled`). MITIGATION: when a project scope is ACTIVE we DOUBLE the
+  # over-fetch factor so the project filter draws from more candidate rows before
+  # LIMIT k — strictly REDUCING (never eliminating) the compounded under-fill window.
+  # It stays bounded by `:max_vector_pool` (the `min(cap)` in `pool_size/2`), so
+  # worst-case recall cost is unchanged and the deterministic under-fill test (whose
+  # cap pins the pool) is unaffected. FULL pool re-calibration with a VERIFIED combined
+  # subject×project dilution bound remains the US-28.5 scale story that owns pool
+  # calibration; this is the safe interim mitigation, not that calibration.
+  defp recall_pool_size(%Scope{project_id: project_id}, k) when is_binary(project_id) do
+    VectorSearch.pool_size(k, factor: VectorSearch.pool_factor() * 2)
+  end
+
+  defp recall_pool_size(%Scope{}, k), do: VectorSearch.pool_size(k)
 
   # Live-only filter on the INNER index-ordered ANN, applied ONLY on the default
   # (exclude-superseded) path. This is the ONE additional inner predicate that is
@@ -563,26 +623,30 @@ defmodule Loopctl.Memory do
   # 4xx at the boundary — this is defense in depth).
   #
   # ONE helper (was two hand-copied `_outer`/`_base` clauses — a silent-drift hazard
-  # on an isolation-adjacent path, #411 review). It binds the FIRST query binding
-  # (`[x]` — a purely local name), which serves BOTH call sites: the semantic path's
-  # outer over-the-pool subquery (whose `select` projects `project_id`) and the
-  # fallback path's base `memories` table. NB: Memory's nil semantics (nil → global-only)
-  # DELIBERATELY differ from `Loopctl.Knowledge.scope_project_or_global/2` (nil → no
-  # project filter at all); they are different features, so this is intentionally NOT
-  # shared across the two contexts.
+  # on an isolation-adjacent path, #411 review). It targets the NAMED `:memory`
+  # binding, which BOTH call sites declare (`as: :memory`): the semantic path's outer
+  # over-the-pool subquery (whose `select` projects `project_id`) and the fallback
+  # path's base `memories` table. Naming the binding (rather than the former positional
+  # `[x]` first-binding) makes the "this must filter the memories relation" dependency
+  # EXPLICIT and compile-checked: a future refactor that introduces a join with a
+  # different first binding, or drops the `as: :memory`, fails to compile here instead
+  # of silently filtering the wrong table on an isolation-adjacent path (#411 review).
+  # NB: Memory's nil semantics (nil → global-only) DELIBERATELY differ from
+  # `Loopctl.Knowledge.scope_project_or_global/2` (nil → no project filter at all);
+  # they are different features, so this is intentionally NOT shared across contexts.
   #
   # This predicate MUST stay on the OUTER over-the-pool query (like the subject and
   # superseded filters) — never on `index_safe_knn_base`'s inner ANN, where a
   # selective predicate would flip the planner off the HNSW index.
   defp maybe_scope_project(query, project_id) when is_binary(project_id) do
     if valid_uuid?(project_id) do
-      where(query, [x], is_nil(x.project_id) or x.project_id == ^project_id)
+      where(query, [memory: m], is_nil(m.project_id) or m.project_id == ^project_id)
     else
-      where(query, [x], is_nil(x.project_id))
+      where(query, [memory: m], is_nil(m.project_id))
     end
   end
 
-  defp maybe_scope_project(query, _), do: where(query, [x], is_nil(x.project_id))
+  defp maybe_scope_project(query, _), do: where(query, [memory: m], is_nil(m.project_id))
 
   # Rebuild a %Memory{} from the recalled projection map. `embedding` is
   # `load_in_query: false` so it is intentionally absent (recall never returns the
@@ -596,6 +660,7 @@ defmodule Loopctl.Memory do
 
     query =
       from(m in MemorySchema,
+        as: :memory,
         where: m.tenant_id == ^scope.tenant_id,
         where: m.subject_id == ^scope.subject_id,
         order_by: [desc: m.inserted_at, desc: m.id],
@@ -1221,9 +1286,17 @@ defmodule Loopctl.Memory do
   worker; the rows written so far stand, matching the resumable-not-all-or-nothing
   contract).
 
+  A present `scope.project_id` is tenant-ownership-validated FIRST (same
+  `validate_project_scope/1` gate as `remember/2`) so this BYPASSRLS write can never
+  point a promoted row at another tenant's project; a foreign/nonexistent id short-
+  circuits the run with `{:error, :project_not_found}` (TERMINAL for the worker — a
+  bad `project_id` is not fixed by retrying). `nil` (today's only caller value) skips
+  the check.
+
   Returns `{:ok, summary}` on full success, `{:error, :embeddings_degraded}`,
   `{:error, :heavy_read_overloaded}` (the per-tenant HeavyRead gate shed the near-dup
   recall — a loss-free snooze for the worker, treated like `:embeddings_degraded`),
+  `{:error, :project_not_found}` (foreign/nonexistent `project_id` — terminal),
   `{:error, :quota_exceeded, summary}`, or `{:error, other}` (a bad write —
   retryable). `summary` is `%{promoted, superseded, deduped}` (promoted = fresh
   inserts; superseded = insert-and-supersede pairs; deduped = exact-dup skips).
@@ -1232,6 +1305,7 @@ defmodule Loopctl.Memory do
           {:ok, map()}
           | {:error, :embeddings_degraded}
           | {:error, :heavy_read_overloaded}
+          | {:error, :project_not_found}
           | {:error, :quota_exceeded, map()}
           | {:error, term()}
   def persist_promotion(%Scope{subject_id: @eval_subject_id}, _candidates) do
@@ -1245,6 +1319,24 @@ defmodule Loopctl.Memory do
   end
 
   def persist_promotion(%Scope{} = scope, candidates) when is_list(candidates) do
+    with :ok <- validate_project_scope(scope) do
+      persist_promotion_candidates(scope, candidates)
+    end
+  end
+
+  # #411 Gap 2 (security): `scope.project_id` reaches this BYPASSRLS durable-write
+  # chokepoint straight from the promotion worker's Oban args (`Map.get(args,
+  # "project_id")`) and is set on the row via `long_term_changeset/2` → the SAME
+  # `AdminRepo` insert `remember/2` uses. The schema's `foreign_key_constraint(:project_id)`
+  # runs BYPASSRLS and is explicitly "never the tenant-boundary gate" (schema moduledoc),
+  # so this path MUST run the SAME `validate_project_scope/1` ownership check `remember/2`
+  # does BEFORE the write — otherwise a future change that threads a `project_id` into
+  # promotion (mirroring exactly what Gap 2 did for create) would persist an unvalidated,
+  # possibly cross-tenant `project_id` with no compile-time signal, reopening the
+  # cross-tenant graph edge / FK existence oracle on a promoted row. Today every caller
+  # passes `project_id: nil` (short-circuits to `:ok` with no query), so this is a
+  # future-proofing guard with no hot-path cost.
+  defp persist_promotion_candidates(%Scope{} = scope, candidates) do
     Enum.reduce_while(candidates, {:ok, %{promoted: 0, superseded: 0, deduped: 0}}, fn candidate,
                                                                                        {:ok, acc} ->
       case promote_one(scope, candidate) do

--- a/lib/loopctl/memory.ex
+++ b/lib/loopctl/memory.ex
@@ -56,6 +56,7 @@ defmodule Loopctl.Memory do
   alias Loopctl.Memory.Scope
   alias Loopctl.Memory.SessionMemory
   alias Loopctl.Memory.SessionPromotion
+  alias Loopctl.Projects
   alias Loopctl.Workers.MemoryEmbeddingWorker
   alias Loopctl.Workers.MemoryPromotionWorker
 
@@ -117,7 +118,17 @@ defmodule Loopctl.Memory do
       `embedding` starts NULL and is populated asynchronously).
 
   `tenant_id`, `subject_id`, and `project_id` come from `scope` and are set
-  programmatically on the struct — never cast from `attrs`. A long-term write is
+  programmatically on the struct — never cast from `attrs`. `tenant_id`/`subject_id`
+  are the key-derived isolation boundary; `project_id` is a partition key that MAY
+  originate from the request body (see the controller), so — because the insert runs
+  on the BYPASSRLS `AdminRepo` and its `foreign_key_constraint(:project_id)` would
+  otherwise validate against EVERY tenant's projects — a present `project_id` is
+  validated tenant-ownership FIRST (`Loopctl.Projects.get_project/2`) and refused with
+  `{:error, :project_not_found}` when it is malformed, nonexistent, or belongs to
+  another tenant. This closes the cross-tenant FK existence oracle + cross-tenant graph
+  edge the FK check would otherwise permit; the DB FK constraint is defense-in-depth,
+  never the tenant-boundary gate (mirrors `Loopctl.Knowledge.validate_project_ownership/2`).
+  A long-term write is
   refused with `{:error, :quota_exceeded}` once the per-`(tenant, subject)` cap
   (`:max_long_term_memories_per_subject`, default 10_000) is reached. The cap counts
   ONLY live (non-superseded) rows, so it bounds the recallable tier; superseded rows
@@ -129,11 +140,31 @@ defmodule Loopctl.Memory do
   """
   @spec remember(Scope.t(), map()) ::
           {:ok, MemorySchema.t() | SessionMemory.t()}
-          | {:error, Ecto.Changeset.t() | :quota_exceeded}
+          | {:error, Ecto.Changeset.t() | :quota_exceeded | :project_not_found}
   def remember(%Scope{} = scope, attrs) when is_map(attrs) do
-    case normalize_tier(opt(attrs, :tier, :long_term)) do
-      :session -> remember_session(scope, attrs)
-      :long_term -> remember_long_term(scope, attrs)
+    with :ok <- validate_project_scope(scope) do
+      case normalize_tier(opt(attrs, :tier, :long_term)) do
+        :session -> remember_session(scope, attrs)
+        :long_term -> remember_long_term(scope, attrs)
+      end
+    end
+  end
+
+  # `project_id` is a body-suppliable partition key that is INSERTED via the BYPASSRLS
+  # `AdminRepo`, so the schema's `foreign_key_constraint(:project_id)` evaluates against
+  # projects in EVERY tenant. Validating tenant-ownership HERE — before the write —
+  # means the FK is never the tenant-boundary gate: a well-formed UUID that exists in
+  # ANOTHER tenant (an existence oracle + a cross-tenant graph edge) and a nonexistent
+  # UUID both take the SAME `{:error, :project_not_found}` path, so neither leaks nor
+  # partitions across the isolation boundary. `nil` (global/tenant-wide) is always
+  # allowed. Mirrors `Loopctl.Knowledge.validate_project_ownership/2`; a malformed
+  # value is caught by `get_project/2`'s own UUID guard (→ `:not_found`).
+  defp validate_project_scope(%Scope{project_id: nil}), do: :ok
+
+  defp validate_project_scope(%Scope{tenant_id: tenant_id, project_id: project_id}) do
+    case Projects.get_project(tenant_id, project_id) do
+      {:ok, _project} -> :ok
+      {:error, :not_found} -> {:error, :project_not_found}
     end
   end
 
@@ -359,8 +390,24 @@ defmodule Loopctl.Memory do
   kept), so superseded rows never occupy pool slots and default recall does not
   under-fill with live rows for a heavily-superseding subject. `include_superseded:
   true` uses the full index. `meta.underfilled` is `true` when fewer than the
-  requested `k` rows were recalled (a small live scope OR cross-subject pool
-  under-fill) so callers can distinguish it from a genuinely capped page.
+  requested `k` rows were recalled — a small live scope, a cross-SUBJECT pool
+  under-fill, OR (since #411 Gap 2) a cross-PROJECT pool under-fill — so callers can
+  distinguish it from a genuinely capped page.
+
+  ## Project scope compounds the pool under-fill window (#411 Gap 2)
+
+  The `global ∪ active-project` merge is a SECOND selective filter applied on the OUTER
+  over-the-pool query (`maybe_scope_project/2`), stacked on the subject filter. The
+  inner over-fetch pool (`VectorSearch.pool_size/1`) is calibrated for SUBJECT dilution
+  only and is project-AGNOSTIC (a selective project predicate on the inner ANN would
+  flip the planner off HNSW — #170/#172). So a subject whose in-scope
+  (`global + active-project`) live memories are sparse relative to its total
+  cross-project corpus can under-fill recall (`meta.underfilled: true`) even when ≥ k
+  in-scope memories exist beyond the pool horizon — the SAME accepted tradeoff as the
+  subject filter, now compounded. Widening `pool_size` when a project scope is active
+  (and re-verifying the combined subject×project dilution bound) is deferred to the
+  US-28.5-class scale story that owns pool calibration; recall SIGNALS the short page
+  via `meta.underfilled` regardless.
 
   ## Degradation (AC-28.2.4)
 
@@ -441,6 +488,15 @@ defmodule Loopctl.Memory do
   # trivial filters on a tiny set that cannot defeat the index.
   defp memory_candidate_query(scope, embedding, k, include_superseded?) do
     target = VectorSearch.to_embedding_list(embedding)
+    # POOL SIZING CAVEAT (#411 Gap 2): `pool_size/1` is calibrated for SUBJECT dilution
+    # ONLY (the subject filter lives on the OUTER query, off the HNSW inner ANN). The
+    # project scope (`maybe_scope_project/2` below) is a SECOND, independent outer
+    # filter over this SAME pool, but the pool is NOT enlarged for it — so a subject
+    # whose in-scope (global + active-project) rows are sparse relative to its total
+    # cross-project corpus can under-fill (surfaced via `meta.underfilled`). Enlarging
+    # the pool when a project scope is active + re-verifying the combined
+    # subject×project dilution bound is deferred to the US-28.5-class scale story that
+    # owns pool calibration (see `recall/2` moduledoc "Project scope compounds ...").
     pool = VectorSearch.pool_size(k)
 
     inner =
@@ -472,7 +528,7 @@ defmodule Loopctl.Memory do
       select: c
     )
     |> maybe_exclude_superseded_sub(include_superseded?)
-    |> maybe_scope_project_outer(scope.project_id)
+    |> maybe_scope_project(scope.project_id)
   end
 
   # Live-only filter on the INNER index-ordered ANN, applied ONLY on the default
@@ -498,39 +554,35 @@ defmodule Loopctl.Memory do
   defp maybe_exclude_superseded_sub(query, false),
     do: where(query, [c], is_nil(c.superseded_by))
 
-  # #411 Gap 2: recall returns the merged `global ∪ active-project` set (mirrors
-  # `Loopctl.Knowledge.scope_project_or_global/2`). `project_id` is a PARTITION key,
-  # NOT an isolation boundary — `tenant_id`/`subject_id` are (see `Memory.Scope`
-  # moduledoc). So a nil scope resolves to global-only (`project_id IS NULL`) and a
-  # present project merges global with that project. The `:binary_id` cast is guarded
-  # the way Knowledge does it: a malformed (non-UUID) value scopes to global-only
-  # rather than raising `Ecto.Query.CastError` (controllers 4xx at the boundary —
-  # this is defense in depth). Two arities because Ecto `where` needs the binding
-  # position at compile time: the semantic path filters the outer over-the-pool
-  # subquery's `[c]` projection, the fallback path filters the base `[m]` table.
+  # #411 Gap 2: recall returns the merged `global ∪ active-project` set. `project_id`
+  # is a PARTITION key, NOT an isolation boundary — `tenant_id`/`subject_id` are (see
+  # `Memory.Scope` moduledoc). So a nil scope resolves to global-only
+  # (`project_id IS NULL`) and a present project merges global with that project. The
+  # `:binary_id` cast is guarded the way Knowledge does it: a malformed (non-UUID)
+  # value scopes to global-only rather than raising `Ecto.Query.CastError` (controllers
+  # 4xx at the boundary — this is defense in depth).
+  #
+  # ONE helper (was two hand-copied `_outer`/`_base` clauses — a silent-drift hazard
+  # on an isolation-adjacent path, #411 review). It binds the FIRST query binding
+  # (`[x]` — a purely local name), which serves BOTH call sites: the semantic path's
+  # outer over-the-pool subquery (whose `select` projects `project_id`) and the
+  # fallback path's base `memories` table. NB: Memory's nil semantics (nil → global-only)
+  # DELIBERATELY differ from `Loopctl.Knowledge.scope_project_or_global/2` (nil → no
+  # project filter at all); they are different features, so this is intentionally NOT
+  # shared across the two contexts.
   #
   # This predicate MUST stay on the OUTER over-the-pool query (like the subject and
   # superseded filters) — never on `index_safe_knn_base`'s inner ANN, where a
   # selective predicate would flip the planner off the HNSW index.
-  defp maybe_scope_project_outer(query, project_id) when is_binary(project_id) do
+  defp maybe_scope_project(query, project_id) when is_binary(project_id) do
     if valid_uuid?(project_id) do
-      where(query, [c], is_nil(c.project_id) or c.project_id == ^project_id)
+      where(query, [x], is_nil(x.project_id) or x.project_id == ^project_id)
     else
-      where(query, [c], is_nil(c.project_id))
+      where(query, [x], is_nil(x.project_id))
     end
   end
 
-  defp maybe_scope_project_outer(query, _), do: where(query, [c], is_nil(c.project_id))
-
-  defp maybe_scope_project_base(query, project_id) when is_binary(project_id) do
-    if valid_uuid?(project_id) do
-      where(query, [m], is_nil(m.project_id) or m.project_id == ^project_id)
-    else
-      where(query, [m], is_nil(m.project_id))
-    end
-  end
-
-  defp maybe_scope_project_base(query, _), do: where(query, [m], is_nil(m.project_id))
+  defp maybe_scope_project(query, _), do: where(query, [x], is_nil(x.project_id))
 
   # Rebuild a %Memory{} from the recalled projection map. `embedding` is
   # `load_in_query: false` so it is intentionally absent (recall never returns the
@@ -551,7 +603,7 @@ defmodule Loopctl.Memory do
       )
       |> maybe_exclude_superseded_base(include_superseded?)
       |> maybe_ilike(query_text)
-      |> maybe_scope_project_base(scope.project_id)
+      |> maybe_scope_project(scope.project_id)
 
     rows =
       HeavyRead.all_memory(

--- a/lib/loopctl/memory/memory.ex
+++ b/lib/loopctl/memory/memory.ex
@@ -114,15 +114,21 @@ defmodule Loopctl.Memory.Memory do
 
   `tenant_id`, `subject_id`, and `project_id` are set programmatically on the
   struct and must NOT appear in `attrs`. Both `project_id` and `superseded_by`
-  are FKs whose Postgres constraint is checked with RLS BYPASSED, so accepting
+  are FKs whose Postgres constraint is checked with RLS BYPASSED, so casting
   either from request params would let a caller point at ANOTHER tenant's row (a
   cross-tenant graph edge + INSERT-time existence oracle). `superseded_by` is
-  set by `forget/2` (US-28.2); `project_id` is set by the US-28.2 write path from
-  the caller's already-authorized context — never cast — mirroring the sibling
+  set by `forget/2` (US-28.2); `project_id` is set programmatically on the struct
+  from `Loopctl.Memory.Scope` — never cast — mirroring the sibling
   `Loopctl.WorkBreakdown.Story` schema, which likewise sets `project_id`
   programmatically rather than casting it. (The Knowledge Wiki `Article` casts
   `project_id`, but a `Memory` is a stricter per-subject security boundary and
-  matches `Story`, not `Article`, here.) `embedding` is never cast here — it is
+  matches `Story`, not `Article`, here.) NB (#411 Gap 2): a `project_id` MAY now
+  originate from the request body as an explicit partition input, but it is
+  validated for tenant-ownership at the context write path
+  (`Loopctl.Memory.remember/2` → `Loopctl.Projects.get_project/2`) BEFORE the insert,
+  so the RLS-bypassing FK check below is never the tenant-boundary gate — it is
+  defense-in-depth behind an already-authorized value, preserving the "never point at
+  another tenant's project" invariant. `embedding` is never cast here — it is
   populated asynchronously via `embedding_changeset/3` in US-28.2. `metadata` is
   cast (mirrors `SessionMemory`) so the generic `metadata` contract advertised by
   the memory HTTP API / `memory_remember` MCP tool persists for this tier too.

--- a/lib/loopctl/memory/scope.ex
+++ b/lib/loopctl/memory/scope.ex
@@ -21,7 +21,12 @@ defmodule Loopctl.Memory.Scope do
 
   - `tenant_id` — the owning tenant UUID (required)
   - `subject_id` — the memory scope owner = the API-key identity (required)
-  - `project_id` — optional project UUID (`nil` = tenant-wide)
+  - `project_id` — optional project UUID. It is a PARTITION key, NOT an isolation
+    boundary (`tenant_id`/`subject_id` are). `nil` means GLOBAL — the rows whose
+    `project_id` column is NULL — NOT "every project in the tenant". On `recall/2`
+    a `nil` scope is therefore GLOBAL-ONLY (it does not union across projects), and
+    a present `project_id` recalls `global ∪ that project`. (#411 Gap 2 — see
+    `Loopctl.Memory.recall/2`.)
   - `session_id` — optional session identifier. Not an isolation key; carried on the
     scope only so the explicit promotion trigger `Loopctl.Memory.promote_session/1`
     (US-29.2) can accept a `%{scope | session_id: ...}` struct without a second

--- a/lib/loopctl/workers/memory_promotion_worker.ex
+++ b/lib/loopctl/workers/memory_promotion_worker.ex
@@ -233,6 +233,20 @@ defmodule Loopctl.Workers.MemoryPromotionWorker do
         PromotionTelemetry.emit(:degraded, %{count: 1}, meta(scope, session_id))
         {:snooze, @snooze_seconds}
 
+      {:error, :project_not_found} ->
+        # #411 Gap 2: `persist_promotion/2` refused a foreign/nonexistent `project_id`
+        # (today unreachable — every enqueue passes `project_id: nil` — but terminal if a
+        # future change threads one through). Retrying cannot fix a bad partition id, so
+        # DISCARD rather than loop toward max_attempts. No watermark advance: the row was
+        # never written.
+        PromotionTelemetry.emit(
+          :failed,
+          %{count: 1},
+          Map.put(meta(scope, session_id), :stage, :persist)
+        )
+
+        {:discard, :project_not_found}
+
       {:error, :quota_exceeded, summary} ->
         emit_summary(scope, session_id, summary)
         # The subject hit its hard live-memory cap mid-run, so `persist_promotion/2`

--- a/lib/loopctl_web/controllers/memory_controller.ex
+++ b/lib/loopctl_web/controllers/memory_controller.ex
@@ -73,8 +73,8 @@ defmodule LoopctlWeb.MemoryController do
     responses: %{
       201 => {"Memory created", "application/json", Schemas.MemoryResponse},
       422 =>
-        {"Validation error, quota exceeded, or subject unresolvable", "application/json",
-         Schemas.ErrorResponse},
+        {"Validation error, quota exceeded, invalid project_id, or subject unresolvable",
+         "application/json", Schemas.ErrorResponse},
       429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError},
       503 => {"Tenant custody halted", "application/json", Schemas.ErrorResponse}
     }
@@ -94,7 +94,8 @@ defmodule LoopctlWeb.MemoryController do
     responses: %{
       200 => {"Recall results", "application/json", Schemas.MemoryRecallResponse},
       422 =>
-        {"Subject unresolvable or non-string query", "application/json", Schemas.ErrorResponse},
+        {"Subject unresolvable, non-string query, or invalid project_id", "application/json",
+         Schemas.ErrorResponse},
       429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError},
       503 => {"Tenant custody halted", "application/json", Schemas.ErrorResponse}
     }
@@ -188,7 +189,17 @@ defmodule LoopctlWeb.MemoryController do
 
   @doc "POST /api/v1/memory"
   def create(conn, params) do
-    with_scope(conn, fn scope ->
+    case parse_project_id(params["project_id"]) do
+      {:ok, project_id} ->
+        create_with_project(conn, params, project_id)
+
+      :error ->
+        invalid_project_id(conn)
+    end
+  end
+
+  defp create_with_project(conn, params, project_id) do
+    with_scope(conn, project_id, fn scope ->
       case Memory.remember(scope, memory_attrs(params)) do
         {:ok, memory} ->
           conn |> put_status(:created) |> json(MemoryJSON.show(%{memory: memory}))
@@ -225,7 +236,17 @@ defmodule LoopctlWeb.MemoryController do
 
   @doc "POST /api/v1/memory/recall"
   def recall(conn, params) do
-    with_scope(conn, fn scope ->
+    case parse_project_id(params["project_id"]) do
+      {:ok, project_id} ->
+        recall_with_project(conn, params, project_id)
+
+      :error ->
+        invalid_project_id(conn)
+    end
+  end
+
+  defp recall_with_project(conn, params, project_id) do
+    with_scope(conn, project_id, fn scope ->
       case coerce_query(params["query"]) do
         {:ok, query} ->
           opts = [
@@ -389,20 +410,25 @@ defmodule LoopctlWeb.MemoryController do
   # nil is forbidden") — escaping as a bare HTTP 500. Guard it here, mirroring the
   # index/2 + delete/2 oversight guards, so a tenant-less key gets the deterministic
   # 422 impersonation envelope instead of a null-scoped op (AC-28.3.2 / .5).
-  defp with_scope(conn, fun) do
+  # `project_id` is an OPTIONAL, UUID-validated scope input — a PARTITION key, NOT an
+  # isolation boundary. It is threaded onto the `%Scope{}` for create + recall (the
+  # only paths where project scoping is meaningful); `index/2` and `delete/2` pass
+  # `nil`. Unlike `project_id`, `tenant_id`/`subject_id` are NEVER read from the body —
+  # they are the isolation boundary and stay key-derived.
+  defp with_scope(conn, project_id \\ nil, fun) do
     api_key = conn.assigns.current_api_key
 
     if is_nil(api_key.tenant_id) do
       impersonation_tenant_required(conn)
     else
-      resolve_scope(conn, api_key, fun)
+      resolve_scope(conn, api_key, project_id, fun)
     end
   end
 
-  defp resolve_scope(conn, api_key, fun) do
+  defp resolve_scope(conn, api_key, project_id, fun) do
     case Memory.subject_id_for(api_key) do
       {:ok, subject_id} ->
-        fun.(%Scope{tenant_id: api_key.tenant_id, subject_id: subject_id, project_id: nil})
+        fun.(%Scope{tenant_id: api_key.tenant_id, subject_id: subject_id, project_id: project_id})
 
       {:error, :subject_id_unresolvable} ->
         conn
@@ -459,9 +485,42 @@ defmodule LoopctlWeb.MemoryController do
     })
   end
 
-  # Pass only the recognized memory attributes through to the context — any
-  # tenant_id/subject_id/scope/project_id in the body is dropped here (scope is
-  # derived from the key). `tier` is read by `Memory.remember/2`.
+  # Parse the optional `project_id` scope input (#411 Gap 2). `project_id` is a
+  # PARTITION key (recall merges `global ∪ active-project`), NOT an isolation
+  # boundary — so, unlike tenant_id/subject_id, it MAY come from the body, but it is
+  # validated as a UUID here so a malformed value is a deterministic 422 rather than
+  # a downstream cast error. Absent/blank → global scope (`nil`); a valid UUID string
+  # → that project; anything else → `:error`.
+  defp parse_project_id(nil), do: {:ok, nil}
+  defp parse_project_id(""), do: {:ok, nil}
+
+  defp parse_project_id(value) when is_binary(value) do
+    case Ecto.UUID.cast(value) do
+      {:ok, uuid} -> {:ok, uuid}
+      :error -> :error
+    end
+  end
+
+  defp parse_project_id(_), do: :error
+
+  defp invalid_project_id(conn) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{
+      error: %{
+        status: 422,
+        code: "invalid_project_id",
+        message: "The `project_id` field must be a valid UUID."
+      }
+    })
+  end
+
+  # Pass only the recognized memory attributes through to the context. tenant_id and
+  # subject_id in the body are always dropped here — they are the isolation boundary
+  # and are derived from the key. `project_id` is NOT a memory attribute either: it is
+  # now an explicit, UUID-validated scope input on create/recall (#411 Gap 2), threaded
+  # via the `%Scope{}` (see `parse_project_id/1` + `with_scope/3`), never cast from
+  # `attrs`. `tier` is read by `Memory.remember/2`.
   defp memory_attrs(params), do: Map.take(params, @memory_attr_keys)
 
   defp all_subjects?(params), do: params["all_subjects"] in [true, "true"]

--- a/lib/loopctl_web/controllers/memory_controller.ex
+++ b/lib/loopctl_web/controllers/memory_controller.ex
@@ -66,7 +66,12 @@ defmodule LoopctlWeb.MemoryController do
         "similarity) or `session` (short-term; requires `session_id` and `content`; " <>
         "`expires_at` is OPTIONAL — the server defaults it to now + the session-memory " <>
         "TTL and floors any supplied value up to the promotion sweep window, so a turn " <>
-        "is always promoted before it can be pruned). Returns 201 with the created " <>
+        "is always promoted before it can be pruned). An optional `project_id` (UUID) " <>
+        "partitions the memory to a project; absent/blank writes a tenant-wide (global) " <>
+        "memory. `project_id` is a partition key, NOT an isolation boundary, but it is " <>
+        "validated for tenant-ownership — a malformed value, or a well-formed UUID that " <>
+        "is not a project in the caller's own tenant, is rejected with a 422 " <>
+        "(`invalid_project_id`) rather than persisted. Returns 201 with the created " <>
         "memory. Subject to the full " <>
         ":authenticated chain (custody halt, witness header, rate limiting).",
     request_body: {"Memory params", "application/json", Schemas.MemoryCreateRequest},
@@ -85,11 +90,16 @@ defmodule LoopctlWeb.MemoryController do
     description:
       "Recalls the caller's own long-term memories most similar to `query` " <>
         "(cosine over an HNSW index), scoped to the key's `(tenant_id, subject_id)`. " <>
-        "The query is supplied in the request BODY. When embedding generation is " <>
+        "An optional `project_id` (UUID) partitions the result: absent/blank returns " <>
+        "GLOBAL (tenant-wide) memories only, while a present `project_id` returns the " <>
+        "merged `global ∪ that-project` set; another project's memories are excluded. " <>
+        "A malformed `project_id` is a 422 (`invalid_project_id`). The query is " <>
+        "supplied in the request BODY. When embedding generation is " <>
         "unavailable the response degrades to a recent-first text match with " <>
         "`meta.fallback: true` and a stable `meta.reason` (score is null on that " <>
         "path) — never a silent empty result. No silent hard cap: `limit` is " <>
-        "clamped to the vector-search max and `meta.underfilled` flags a short page.",
+        "clamped to the vector-search max and `meta.underfilled` flags a short page " <>
+        "(a small live scope, or a cross-subject/cross-project pool under-fill).",
     request_body: {"Recall params", "application/json", Schemas.MemoryRecallRequest},
     responses: %{
       200 => {"Recall results", "application/json", Schemas.MemoryRecallResponse},
@@ -220,16 +230,26 @@ defmodule LoopctlWeb.MemoryController do
             }
           })
 
-          # NOTE (review finding, disproven): the three clauses above are EXHAUSTIVE
+        # A body-supplied `project_id` that is malformed, nonexistent, or belongs to
+        # ANOTHER tenant (#411 Gap 2 tenancy fix): `Memory.remember/2` validates
+        # tenant-ownership BEFORE the RLS-bypassing insert, so the cross-tenant FK
+        # check is never the boundary gate. Both "foreign" and "nonexistent" collapse
+        # to the SAME 422 (no cross-tenant existence oracle), reusing the malformed-UUID
+        # `invalid_project_id` envelope so the three cases are indistinguishable.
+        {:error, :project_not_found} ->
+          invalid_project_id(conn)
+
+          # NOTE (review finding, disproven): the four clauses above are EXHAUSTIVE
           # for `Memory.remember/2`. Dialyzer's success typing proves the return is
           # exactly `{:ok, memory} | {:error, :quota_exceeded} | {:error,
-          # %Ecto.Changeset{}}` — the `remember_long_term/2` `:embedding_job` Multi
-          # step can only fail with an `Ecto.Changeset` (Oban validates the job via a
-          # changeset), so no non-changeset error term can reach here. A catch-all
-          # would be unreachable dead code (`pattern_match_cov`), and `@dialyzer`
-          # suppressions are forbidden. Dialyzer is the compile-time guard: if
-          # `remember/2` ever gains a new error shape, this case stops being total and
-          # the build breaks — a stronger contract than a runtime catch-all.
+          # :project_not_found} | {:error, %Ecto.Changeset{}}` — the
+          # `remember_long_term/2` `:embedding_job` Multi step can only fail with an
+          # `Ecto.Changeset` (Oban validates the job via a changeset), so no
+          # non-changeset error term can reach here. A catch-all would be unreachable
+          # dead code (`pattern_match_cov`), and `@dialyzer` suppressions are forbidden.
+          # Dialyzer is the compile-time guard: if `remember/2` ever gains a new error
+          # shape, this case stops being total and the build breaks — a stronger
+          # contract than a runtime catch-all.
       end
     end)
   end
@@ -489,15 +509,24 @@ defmodule LoopctlWeb.MemoryController do
   # PARTITION key (recall merges `global ∪ active-project`), NOT an isolation
   # boundary — so, unlike tenant_id/subject_id, it MAY come from the body, but it is
   # validated as a UUID here so a malformed value is a deterministic 422 rather than
-  # a downstream cast error. Absent/blank → global scope (`nil`); a valid UUID string
-  # → that project; anything else → `:error`.
+  # a downstream cast error. Absent/blank (including whitespace-only) → global scope
+  # (`nil`) — the value is trimmed before the blank check so `"   "` matches the
+  # schema's documented "absent/blank writes a tenant-wide (global) memory" wording
+  # rather than falling through to a spurious 422; a valid UUID string → that project;
+  # anything else → `:error`. (Tenant-ownership of a well-formed UUID is enforced
+  # separately at the context write path — see `Memory.remember/2`.)
   defp parse_project_id(nil), do: {:ok, nil}
-  defp parse_project_id(""), do: {:ok, nil}
 
   defp parse_project_id(value) when is_binary(value) do
-    case Ecto.UUID.cast(value) do
-      {:ok, uuid} -> {:ok, uuid}
-      :error -> :error
+    case String.trim(value) do
+      "" ->
+        {:ok, nil}
+
+      trimmed ->
+        case Ecto.UUID.cast(trimmed) do
+          {:ok, uuid} -> {:ok, uuid}
+          :error -> :error
+        end
     end
   end
 
@@ -510,7 +539,9 @@ defmodule LoopctlWeb.MemoryController do
       error: %{
         status: 422,
         code: "invalid_project_id",
-        message: "The `project_id` field must be a valid UUID."
+        message:
+          "The `project_id` field must be a valid UUID identifying a project in your " <>
+            "own tenant."
       }
     })
   end

--- a/lib/loopctl_web/controllers/memory_controller.ex
+++ b/lib/loopctl_web/controllers/memory_controller.ex
@@ -91,9 +91,17 @@ defmodule LoopctlWeb.MemoryController do
       "Recalls the caller's own long-term memories most similar to `query` " <>
         "(cosine over an HNSW index), scoped to the key's `(tenant_id, subject_id)`. " <>
         "An optional `project_id` (UUID) partitions the result: absent/blank returns " <>
-        "GLOBAL (tenant-wide) memories only, while a present `project_id` returns the " <>
+        "GLOBAL memories only (the rows whose `project_id` is NULL — NOT a union across " <>
+        "all your projects), while a present `project_id` returns the " <>
         "merged `global ∪ that-project` set; another project's memories are excluded. " <>
-        "A malformed `project_id` is a 422 (`invalid_project_id`). The query is " <>
+        "A malformed `project_id` is a 422 (`invalid_project_id`). NOTE the deliberate " <>
+        "asymmetry with `POST /memory` (create): recall does NOT tenant-validate a " <>
+        "well-formed `project_id`, because it is a partition key, not the isolation " <>
+        "boundary. A well-formed `project_id` that is a typo, stale, or owned by another " <>
+        "tenant is treated as an empty partition and returns your GLOBAL rows only with " <>
+        "NO error (never any other tenant's/subject's rows — the `(tenant_id, subject_id)` " <>
+        "predicate still bounds every result), whereas create 422s the same value. " <>
+        "The query is " <>
         "supplied in the request BODY. When embedding generation is " <>
         "unavailable the response degrades to a recent-first text match with " <>
         "`meta.fallback: true` and a stable `meta.reason` (score is null on that " <>
@@ -513,24 +521,39 @@ defmodule LoopctlWeb.MemoryController do
   # (`nil`) — the value is trimmed before the blank check so `"   "` matches the
   # schema's documented "absent/blank writes a tenant-wide (global) memory" wording
   # rather than falling through to a spurious 422; a valid UUID string → that project;
-  # anything else → `:error`. (Tenant-ownership of a well-formed UUID is enforced
-  # separately at the context write path — see `Memory.remember/2`.)
+  # anything else → `:error`. This gate is FORMAT-only. Tenant-ownership of a
+  # well-formed UUID is enforced separately AND ASYMMETRICALLY: the write path
+  # (`Memory.remember/2`) validates it and 422s a foreign/nonexistent project; the
+  # recall path deliberately does NOT (project_id is a partition key there, so an
+  # unowned id reads as an empty partition → global-only, no error). See
+  # `Loopctl.Memory.recall/2` for why.
   defp parse_project_id(nil), do: {:ok, nil}
 
   defp parse_project_id(value) when is_binary(value) do
     case String.trim(value) do
-      "" ->
-        {:ok, nil}
-
-      trimmed ->
-        case Ecto.UUID.cast(trimmed) do
-          {:ok, uuid} -> {:ok, uuid}
-          :error -> :error
-        end
+      "" -> {:ok, nil}
+      trimmed -> cast_project_uuid(trimmed)
     end
   end
 
   defp parse_project_id(_), do: :error
+
+  # Require the CANONICAL 36-char hyphenated form BEFORE `Ecto.UUID.cast`. `cast/1`
+  # alone also accepts a raw 16-BYTE binary (e.g. a 16-char ASCII string) and
+  # hex-encodes it, so a plainly-non-UUID value would slip through the format gate.
+  # Matching the hyphenated shape first makes the boundary a deterministic 422 for
+  # such input rather than deferring to a downstream lookup.
+  defp cast_project_uuid(trimmed) do
+    with true <- canonical_uuid?(trimmed),
+         {:ok, uuid} <- Ecto.UUID.cast(trimmed) do
+      {:ok, uuid}
+    else
+      _ -> :error
+    end
+  end
+
+  @uuid_format ~r/\A[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\z/
+  defp canonical_uuid?(value), do: Regex.match?(@uuid_format, value)
 
   defp invalid_project_id(conn) do
     conn

--- a/test/loopctl/memory_context_test.exs
+++ b/test/loopctl/memory_context_test.exs
@@ -361,6 +361,53 @@ defmodule Loopctl.MemoryContextTest do
       assert g.id in fb_ids
       refute ma.id in fb_ids
     end
+
+    test "semantic path: project scoping compounds pool under-fill — meta.underfilled flags a project-scoped page starved by other-project pool dominance",
+         %{a: a, b: b} do
+      # The inner ANN over-fetch pool is sized for SUBJECT dilution only and is
+      # project-AGNOSTIC (project scoping is a SECOND outer filter, #411 Gap 2). So a
+      # subject whose nearest neighbours are dominated by OTHER-project rows can
+      # under-fill a project-scoped recall even when >= k in-scope rows exist beyond
+      # the pool horizon. In test the pool is capped at 6 (config/test.exs), so 6
+      # nearer other-project rows fully occupy it and push the one in-scope row past
+      # the horizon. `meta.underfilled` MUST surface that (the SAME accepted tradeoff
+      # as the cross-subject case verified at prod scale in `ScaleRecallTest` /
+      # US-28.5, here made deterministic with a tiny fixed pool + fixed embeddings).
+      near = List.replace_at(List.duplicate(0.0, 1536), 0, 1.0)
+      far = List.replace_at(List.duplicate(0.0, 1536), 1, 1.0)
+
+      # Deterministic distances: "NEAR"-tagged text (query + the 6 pool fillers) embeds
+      # to `near` (cosine distance 0), everything else to the orthogonal `far`
+      # (distance 1). Used at BOTH write time (inline embedding worker) and recall time.
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, text ->
+        if String.contains?(text, "NEAR"), do: {:ok, near}, else: {:ok, far}
+      end)
+
+      # 6 other-project (proj_b) rows are the globally-nearest → they fill the whole
+      # size-6 pool.
+      for i <- 1..6 do
+        {:ok, _} = Memory.remember(b, %{tier: :long_term, text: "NEAR pool filler #{i}"})
+      end
+
+      # One in-scope (proj_a) row, FARTHER than every pool row → rank 7, beyond the
+      # size-6 pool horizon.
+      {:ok, in_scope} =
+        Memory.remember(a, %{tier: :long_term, text: "far in-scope alpha fact"})
+
+      %{results: results, meta: meta} = Memory.recall(a, query: "NEAR needle", limit: 1)
+
+      # The size-6 pool held only other-project rows, which the outer project filter
+      # discards → an empty page, flagged under-filled, even though an in-scope row
+      # exists beyond the horizon. This is the compounded post-pool selectivity the
+      # subject-only pool sizing does not account for.
+      assert meta.fallback == false
+      assert results == []
+      assert meta.underfilled
+
+      # Proof the in-scope row genuinely exists (it is simply beyond the pool horizon,
+      # not absent): the subject-scoped list surfaces it.
+      assert in_scope.id in default_list_ids(a)
+    end
   end
 
   # --- TC-28.2.5: supersede ---

--- a/test/loopctl/memory_context_test.exs
+++ b/test/loopctl/memory_context_test.exs
@@ -18,6 +18,7 @@ defmodule Loopctl.MemoryContextTest do
   alias Loopctl.Knowledge
   alias Loopctl.Memory
   alias Loopctl.Memory.Memory, as: MemorySchema
+  alias Loopctl.Memory.Scope
 
   import Ecto.Query
 
@@ -246,6 +247,119 @@ defmodule Loopctl.MemoryContextTest do
 
       assert %{results: [], meta: %{fallback: true, reason: _}} =
                Memory.recall(empty_scope, query: "alamo")
+    end
+  end
+
+  # --- #411 Gap 2: recall merges global ∪ active-project ---
+
+  describe "recall/2 project scoping (merged global ∪ active-project, #411 Gap 2)" do
+    setup do
+      tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(tenant.id)
+      proj_a = fixture(:project, %{tenant_id: tenant.id})
+      proj_b = fixture(:project, %{tenant_id: tenant.id})
+      subject_id = "subject-#{System.unique_integer([:positive])}"
+
+      global = %Scope{tenant_id: tenant.id, subject_id: subject_id, project_id: nil}
+      a = %{global | project_id: proj_a.id}
+      b = %{global | project_id: proj_b.id}
+
+      %{global: global, a: a, b: b, proj_a: proj_a, proj_b: proj_b}
+    end
+
+    test "semantic path: an active project_id merges global ∪ that project, excludes another project",
+         %{global: global, a: a, b: b} do
+      {:ok, g} = Memory.remember(global, %{tier: :long_term, text: "global widgets fact"})
+      {:ok, ma} = Memory.remember(a, %{tier: :long_term, text: "project alpha widgets fact"})
+      {:ok, mb} = Memory.remember(b, %{tier: :long_term, text: "project beta widgets fact"})
+
+      ids = default_recall_ids(a, "widgets")
+
+      assert %{meta: %{fallback: false}} = Memory.recall(a, query: "widgets", limit: 10)
+      assert g.id in ids
+      assert ma.id in ids
+      refute mb.id in ids
+    end
+
+    test "semantic path: a nil project_id returns global-only (excludes any project-scoped memory)",
+         %{global: global, a: a, b: b} do
+      {:ok, g} = Memory.remember(global, %{tier: :long_term, text: "global widgets fact"})
+      {:ok, ma} = Memory.remember(a, %{tier: :long_term, text: "project alpha widgets fact"})
+      {:ok, mb} = Memory.remember(b, %{tier: :long_term, text: "project beta widgets fact"})
+
+      ids = default_recall_ids(global, "widgets")
+
+      assert g.id in ids
+      refute ma.id in ids
+      refute mb.id in ids
+    end
+
+    test "fallback path: an active project_id merges global ∪ that project, excludes another project",
+         %{global: global, a: a, b: b} do
+      # Force the ILIKE fallback for the whole test.
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
+        {:error, :no_api_key}
+      end)
+
+      {:ok, g} = Memory.remember(global, %{tier: :long_term, text: "global widgets fact"})
+      {:ok, ma} = Memory.remember(a, %{tier: :long_term, text: "project alpha widgets fact"})
+      {:ok, mb} = Memory.remember(b, %{tier: :long_term, text: "project beta widgets fact"})
+
+      assert %{results: results, meta: %{fallback: true}} =
+               Memory.recall(a, query: "widgets", limit: 10)
+
+      ids = Enum.map(results, fn {m, _} -> m.id end)
+
+      assert g.id in ids
+      assert ma.id in ids
+      refute mb.id in ids
+    end
+
+    test "fallback path: a nil project_id returns global-only", %{global: global, a: a, b: b} do
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
+        {:error, :no_api_key}
+      end)
+
+      {:ok, g} = Memory.remember(global, %{tier: :long_term, text: "global widgets fact"})
+      {:ok, ma} = Memory.remember(a, %{tier: :long_term, text: "project alpha widgets fact"})
+      {:ok, mb} = Memory.remember(b, %{tier: :long_term, text: "project beta widgets fact"})
+
+      assert %{results: results, meta: %{fallback: true}} =
+               Memory.recall(global, query: "widgets", limit: 10)
+
+      ids = Enum.map(results, fn {m, _} -> m.id end)
+
+      assert g.id in ids
+      refute ma.id in ids
+      refute mb.id in ids
+    end
+
+    test "a malformed project_id does not raise and is treated as global-only", %{
+      global: global,
+      a: a
+    } do
+      {:ok, g} = Memory.remember(global, %{tier: :long_term, text: "global widgets fact"})
+      {:ok, ma} = Memory.remember(a, %{tier: :long_term, text: "project alpha widgets fact"})
+
+      malformed = %{global | project_id: "not-a-uuid"}
+
+      # Semantic path.
+      assert %{results: results} = Memory.recall(malformed, query: "widgets", limit: 10)
+      ids = Enum.map(results, fn {m, _} -> m.id end)
+      assert g.id in ids
+      refute ma.id in ids
+
+      # Fallback path.
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
+        {:error, :no_api_key}
+      end)
+
+      assert %{results: fb_results, meta: %{fallback: true}} =
+               Memory.recall(malformed, query: "widgets", limit: 10)
+
+      fb_ids = Enum.map(fb_results, fn {m, _} -> m.id end)
+      assert g.id in fb_ids
+      refute ma.id in fb_ids
     end
   end
 

--- a/test/loopctl/memory_context_test.exs
+++ b/test/loopctl/memory_context_test.exs
@@ -362,6 +362,49 @@ defmodule Loopctl.MemoryContextTest do
       refute ma.id in fb_ids
     end
 
+    test "a well-formed project_id owned by ANOTHER tenant (and a nonexistent one) recalls global-only with no cross-tenant/partition leak",
+         %{global: global, a: a} do
+      # Recall deliberately does NOT tenant-validate project_id (it is a partition key,
+      # not the isolation boundary — see Memory.recall/2). Its safety therefore rests
+      # ENTIRELY on the (tenant_id, subject_id) predicate bounding results. Prove it:
+      # a project_id belonging to a FOREIGN tenant, and a nonexistent well-formed UUID,
+      # must each yield exactly the caller's GLOBAL rows — never the foreign row, never
+      # the caller's OWN project-scoped row.
+      {:ok, g} = Memory.remember(global, %{tier: :long_term, text: "global widgets fact"})
+      {:ok, ma} = Memory.remember(a, %{tier: :long_term, text: "project alpha widgets fact"})
+
+      # A separate tenant with its own project + a memory under the SAME subject_id
+      # string, so only the (tenant_id) predicate — not a subject mismatch — keeps it out.
+      other_tenant = fixture(:tenant)
+      Knowledge.reset_circuit_breaker(other_tenant.id)
+      foreign_proj = fixture(:project, %{tenant_id: other_tenant.id})
+
+      foreign_scope = %Scope{
+        tenant_id: other_tenant.id,
+        subject_id: global.subject_id,
+        project_id: foreign_proj.id
+      }
+
+      {:ok, foreign} =
+        Memory.remember(foreign_scope, %{tier: :long_term, text: "foreign widgets fact"})
+
+      # Caller (our tenant/subject) passes the FOREIGN tenant's project_id.
+      cross = %{global | project_id: foreign_proj.id}
+      cross_ids = default_recall_ids(cross, "widgets")
+
+      assert g.id in cross_ids
+      refute ma.id in cross_ids
+      refute foreign.id in cross_ids
+
+      # A well-formed but NONEXISTENT project_id → same global-only result.
+      nonexistent = %{global | project_id: Ecto.UUID.generate()}
+      nonexistent_ids = default_recall_ids(nonexistent, "widgets")
+
+      assert g.id in nonexistent_ids
+      refute ma.id in nonexistent_ids
+      refute foreign.id in nonexistent_ids
+    end
+
     test "semantic path: project scoping compounds pool under-fill — meta.underfilled flags a project-scoped page starved by other-project pool dominance",
          %{a: a, b: b} do
       # The inner ANN over-fetch pool is sized for SUBJECT dilution only and is

--- a/test/loopctl_web/controllers/memory_controller_test.exs
+++ b/test/loopctl_web/controllers/memory_controller_test.exs
@@ -509,6 +509,67 @@ defmodule LoopctlWeb.MemoryControllerTest do
       assert body["error"]["code"] == "invalid_project_id"
       assert body["error"]["status"] == 422
     end
+
+    test "create with another tenant's project_id is rejected (no cross-tenant FK oracle/edge)",
+         %{conn: conn} do
+      # #411 Gap 2 tenancy fix: a well-formed UUID that exists in ANOTHER tenant must
+      # NOT be accepted. The insert runs on the BYPASSRLS AdminRepo, so the FK check
+      # would otherwise validate cross-tenant (a 201 for a foreign project = existence
+      # oracle + cross-tenant graph edge). Ownership is validated before the write, so
+      # a foreign project collapses to the SAME 422 as a nonexistent one (no oracle).
+      tenant = fixture(:tenant)
+      other_tenant = fixture(:tenant)
+      foreign_project = fixture(:project, %{tenant_id: other_tenant.id})
+      {raw, _key, _agent} = agent_key(tenant.id)
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      body =
+        conn
+        |> auth(raw)
+        |> post(~p"/api/v1/memory", %{
+          "tier" => "long_term",
+          "text" => "should not persist under a foreign project",
+          "project_id" => foreign_project.id
+        })
+        |> json_response(422)
+
+      assert body["error"]["code"] == "invalid_project_id"
+      assert body["error"]["status"] == 422
+
+      # A well-formed, nonexistent project_id (in no tenant) is indistinguishable —
+      # same 422, so the response is not an existence oracle.
+      nonexistent =
+        base_conn()
+        |> auth(raw)
+        |> post(~p"/api/v1/memory", %{
+          "tier" => "long_term",
+          "text" => "should not persist under a nonexistent project",
+          "project_id" => Ecto.UUID.generate()
+        })
+        |> json_response(422)
+
+      assert nonexistent["error"]["code"] == "invalid_project_id"
+    end
+
+    test "create with a whitespace-only project_id is treated as global (blank), not a 422", %{
+      conn: conn
+    } do
+      tenant = fixture(:tenant)
+      {raw, _key, _agent} = agent_key(tenant.id)
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      created =
+        conn
+        |> auth(raw)
+        |> post(~p"/api/v1/memory", %{
+          "tier" => "long_term",
+          "text" => "blank project writes global",
+          "project_id" => "   "
+        })
+        |> json_response(201)
+
+      assert created["data"]["project_id"] == nil
+    end
   end
 
   # --- Quota-exceeded envelope over HTTP (create/2) ---

--- a/test/loopctl_web/controllers/memory_controller_test.exs
+++ b/test/loopctl_web/controllers/memory_controller_test.exs
@@ -393,6 +393,124 @@ defmodule LoopctlWeb.MemoryControllerTest do
     end
   end
 
+  # --- #411 Gap 2: project_id on create + recall (merged global ∪ active-project) ---
+
+  describe "POST /api/v1/memory + /recall project_id scoping (#411 Gap 2)" do
+    test "create persists a valid project_id", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw, _key, _agent} = agent_key(tenant.id)
+      Knowledge.reset_circuit_breaker(tenant.id)
+      project = fixture(:project, %{tenant_id: tenant.id})
+
+      created =
+        conn
+        |> auth(raw)
+        |> post(~p"/api/v1/memory", %{
+          "tier" => "long_term",
+          "text" => "prefers reshipments",
+          "project_id" => project.id
+        })
+        |> json_response(201)
+
+      assert created["data"]["project_id"] == project.id
+    end
+
+    test "recall with a valid project_id returns merged global ∪ project", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw, _key, _agent} = agent_key(tenant.id)
+      Knowledge.reset_circuit_breaker(tenant.id)
+      project = fixture(:project, %{tenant_id: tenant.id})
+
+      # Global memory (no project_id).
+      conn
+      |> auth(raw)
+      |> post(~p"/api/v1/memory", %{"tier" => "long_term", "text" => "global widgets fact"})
+      |> json_response(201)
+
+      # Project-scoped memory.
+      base_conn()
+      |> auth(raw)
+      |> post(~p"/api/v1/memory", %{
+        "tier" => "long_term",
+        "text" => "project widgets fact",
+        "project_id" => project.id
+      })
+      |> json_response(201)
+
+      body =
+        base_conn()
+        |> auth(raw)
+        |> post(~p"/api/v1/memory/recall", %{"query" => "widgets", "project_id" => project.id})
+        |> json_response(200)
+
+      texts = Enum.map(body["data"], & &1["memory"]["text"])
+      assert "global widgets fact" in texts
+      assert "project widgets fact" in texts
+    end
+
+    test "recall with a different project_id excludes that project's memory", %{conn: _conn} do
+      tenant = fixture(:tenant)
+      {raw, _key, _agent} = agent_key(tenant.id)
+      Knowledge.reset_circuit_breaker(tenant.id)
+      project_a = fixture(:project, %{tenant_id: tenant.id})
+      project_b = fixture(:project, %{tenant_id: tenant.id})
+
+      base_conn()
+      |> auth(raw)
+      |> post(~p"/api/v1/memory", %{
+        "tier" => "long_term",
+        "text" => "project alpha widgets fact",
+        "project_id" => project_a.id
+      })
+      |> json_response(201)
+
+      body =
+        base_conn()
+        |> auth(raw)
+        |> post(~p"/api/v1/memory/recall", %{"query" => "widgets", "project_id" => project_b.id})
+        |> json_response(200)
+
+      texts = Enum.map(body["data"], & &1["memory"]["text"])
+      refute "project alpha widgets fact" in texts
+    end
+
+    test "a malformed project_id on recall returns a deterministic 422 invalid_project_id", %{
+      conn: conn
+    } do
+      tenant = fixture(:tenant)
+      {raw, _key, _agent} = agent_key(tenant.id)
+
+      body =
+        conn
+        |> auth(raw)
+        |> post(~p"/api/v1/memory/recall", %{"query" => "widgets", "project_id" => "not-a-uuid"})
+        |> json_response(422)
+
+      assert body["error"]["code"] == "invalid_project_id"
+      assert body["error"]["status"] == 422
+    end
+
+    test "a malformed project_id on create returns a deterministic 422 invalid_project_id", %{
+      conn: conn
+    } do
+      tenant = fixture(:tenant)
+      {raw, _key, _agent} = agent_key(tenant.id)
+
+      body =
+        conn
+        |> auth(raw)
+        |> post(~p"/api/v1/memory", %{
+          "tier" => "long_term",
+          "text" => "x",
+          "project_id" => "not-a-uuid"
+        })
+        |> json_response(422)
+
+      assert body["error"]["code"] == "invalid_project_id"
+      assert body["error"]["status"] == 422
+    end
+  end
+
   # --- Quota-exceeded envelope over HTTP (create/2) ---
 
   describe "POST /api/v1/memory quota" do


### PR DESCRIPTION
## #411 Gap 2 (PR A of 2): project-scope long-term memory recall

First of two PRs delivering the single merged global-union-project recall call
(issue #411 Gap 2). This PR makes memory recall project-aware; the follow-up adds
the single endpoint that merges memory with knowledge into one round-trip.

### What changed
- **Recall merges global-union-active-project.** `Memory.recall/2` now honors
  `scope.project_id` (it previously ignored it). Predicate mirrors
  `Knowledge.scope_project_or_global/2`: nil scope -> global-only
  (project_id IS NULL); a present project merges global with that project;
  malformed -> global-only (defense in depth, no cast error).
- Applied on the **outer** over-the-pool semantic query and the fallback base
  query only. The inner index-safe ANN subquery is untouched so the predicate
  cannot flip the planner off the HNSW index (same rationale as subject_id being
  outer-only). tenant_id/subject_id enforcement unchanged.
- **Controller** create + recall accept an optional, UUID-validated `project_id`
  from the body (a partition key, not an isolation boundary), threaded onto the
  Scope. Malformed -> deterministic 422 invalid_project_id. index/delete stay
  global. tenant_id/subject_id remain key-derived only.
- OpenAPI request schemas gain the project_id property.

### Tests
Merged recall (global-union-project, excludes another project) and global-only
(nil) on both the semantic and fallback paths, malformed-no-raise, plus
controller create-persists / recall-merge / 422. Deterministic across seeds
111, 99999, default.

### Design authority
Second-brain article 5bf264d5 (Hermes memory teardown) and issue #411 Gap 2:
recall merges global-union-active-project; scope decided at capture.

Part of #411.
