### PR TITLE
#411 Gap 2 (PR B): single merged global-union-project recall endpoint

### DIFF
--- a/lib/loopctl/api_spec/schemas.ex
+++ b/lib/loopctl/api_spec/schemas.ex
@@ -3380,6 +3380,123 @@ defmodule Loopctl.ApiSpec.Schemas do
     })
   end
 
+  defmodule RecallContextRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "RecallContextRequest",
+      description:
+        "Params for POST /recall (merged memory ∪ knowledge recall, #411 Gap 2). " <>
+          "Query supplied in the body; scope (tenant_id/subject_id) is derived from the " <>
+          "API key, never the body.",
+      type: :object,
+      properties: %{
+        query: %Schema{
+          type: :string,
+          description: "Text to embed / match against on BOTH the memory and knowledge sides."
+        },
+        limit: %Schema{
+          type: :integer,
+          description:
+            "Overall merged page size, clamped to [1, 50] (default 10). Applied " <>
+              "per-source first, then to the merged, re-ranked list."
+        },
+        project_id: %Schema{
+          type: :string,
+          format: :uuid,
+          nullable: true,
+          description:
+            "Optional project scope (a UUID PARTITION key, NOT an isolation boundary). " <>
+              "Present → both sides return the merged global ∪ that-project set; " <>
+              "absent/blank → global-only. A malformed value is a 422 invalid_project_id."
+        }
+      }
+    })
+  end
+
+  defmodule RecallContextResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "RecallContextResponse",
+      description:
+        "Merged recall: `data` is the re-ranked union across memory + knowledge (each " <>
+          "item tagged `source`, sorted by a heuristically-comparable `score` DESC), " <>
+          "with the untouched per-source `memory` and `knowledge` envelopes for " <>
+          "re-ranking, plus `meta` (counts + degraded flag). Cross-source scores are " <>
+          "heuristic, not calibrated: memory `score` is cosine similarity in [0,1] " <>
+          "(null on the fallback path); knowledge `score` is a pool-normalized " <>
+          "keyword+semantic score.",
+      type: :object,
+      properties: %{
+        data: %Schema{
+          type: :array,
+          description: "Merged, re-ranked results across both sources.",
+          items: %Schema{
+            type: :object,
+            properties: %{
+              source: %Schema{type: :string, enum: ["memory", "knowledge"]},
+              score: %Schema{type: :number, format: :float, nullable: true},
+              memory: %Schema{
+                type: :object,
+                nullable: true,
+                description: "Present on `source: memory` items (see Memory schema)."
+              },
+              article: %Schema{
+                type: :object,
+                nullable: true,
+                description:
+                  "Present on `source: knowledge` items — the combined-search result " <>
+                    "map (article summary + scores)."
+              }
+            }
+          }
+        },
+        memory: %Schema{
+          type: :object,
+          description: "The unchanged /memory/recall envelope (data + meta).",
+          properties: %{
+            data: %Schema{
+              type: :array,
+              items: %Schema{
+                type: :object,
+                properties: %{
+                  memory: Memory,
+                  score: %Schema{type: :number, format: :float, nullable: true}
+                }
+              }
+            },
+            meta: %Schema{type: :object}
+          }
+        },
+        knowledge: %Schema{
+          type: :object,
+          description: "The unchanged combined-search envelope (data + meta).",
+          properties: %{
+            data: %Schema{type: :array, items: %Schema{type: :object}},
+            meta: %Schema{type: :object}
+          }
+        },
+        meta: %Schema{
+          type: :object,
+          properties: %{
+            query: %Schema{type: :string},
+            project_id: %Schema{type: :string, format: :uuid, nullable: true},
+            total_count: %Schema{type: :integer},
+            memory_count: %Schema{type: :integer},
+            knowledge_count: %Schema{type: :integer},
+            degraded: %Schema{
+              type: :boolean,
+              description: "True when the knowledge side errored or fell back to keyword-only."
+            }
+          }
+        }
+      }
+    })
+  end
+
   defmodule MemoryDeleteResponse do
     @moduledoc false
     require OpenApiSpex

--- a/lib/loopctl/api_spec/schemas.ex
+++ b/lib/loopctl/api_spec/schemas.ex
@@ -3423,12 +3423,16 @@ defmodule Loopctl.ApiSpec.Schemas do
       title: "RecallContextResponse",
       description:
         "Merged recall: `data` is the re-ranked union across memory + knowledge (each " <>
-          "item tagged `source`, sorted by a heuristically-comparable `score` DESC), " <>
-          "with the untouched per-source `memory` and `knowledge` envelopes for " <>
-          "re-ranking, plus `meta` (counts + degraded flag). Cross-source scores are " <>
-          "heuristic, not calibrated: memory `score` is cosine similarity in [0,1] " <>
-          "(null on the fallback path); knowledge `score` is a pool-normalized " <>
-          "keyword+semantic score.",
+          "item tagged `source`, sorted by a heuristically-comparable `score` DESC — " <>
+          "`meta.results_ranking` is `heuristic_cross_source`), with the untouched " <>
+          "per-source `memory` and `knowledge` envelopes for re-ranking, plus `meta` " <>
+          "(counts + degraded flag). Cross-source scores are heuristic, not calibrated: " <>
+          "memory `score` is ABSOLUTE cosine similarity in [0,1] (null on the fallback " <>
+          "path); knowledge `score` is a POOL-NORMALIZED keyword+semantic score (biases " <>
+          "knowledge upward in the default order). The knowledge `article`/`data` items " <>
+          "are combined-search SUMMARIES (id/title/category/tags/score + a truncated " <>
+          "snippet) — the same shape `/knowledge/search` returns, NOT full bodies or " <>
+          "linked references; call `/knowledge/context` for those.",
       type: :object,
       properties: %{
         data: %Schema{
@@ -3448,8 +3452,9 @@ defmodule Loopctl.ApiSpec.Schemas do
                 type: :object,
                 nullable: true,
                 description:
-                  "Present on `source: knowledge` items — the combined-search result " <>
-                    "map (article summary + scores)."
+                  "Present on `source: knowledge` items — the combined-search summary " <>
+                    "(id/title/category/tags/score + truncated snippet), the same " <>
+                    "whitelisted shape `/knowledge/search` returns."
               }
             }
           }
@@ -3473,7 +3478,10 @@ defmodule Loopctl.ApiSpec.Schemas do
         },
         knowledge: %Schema{
           type: :object,
-          description: "The unchanged combined-search envelope (data + meta).",
+          description:
+            "The combined-search envelope (data + meta). Each `data` item is the " <>
+              "whitelisted summary shape (id/title/category/tags/score + truncated " <>
+              "snippet), NOT the raw internal result map.",
           properties: %{
             data: %Schema{type: :array, items: %Schema{type: :object}},
             meta: %Schema{type: :object}
@@ -3490,6 +3498,13 @@ defmodule Loopctl.ApiSpec.Schemas do
             degraded: %Schema{
               type: :boolean,
               description: "True when the knowledge side errored or fell back to keyword-only."
+            },
+            results_ranking: %Schema{
+              type: :string,
+              description:
+                "Stable tag (`heuristic_cross_source`) warning that the merged `data` " <>
+                  "order mixes memory's absolute cosine with knowledge's pool-normalized " <>
+                  "score and is NOT a calibrated cross-source ranking."
             }
           }
         }

--- a/lib/loopctl/api_spec/schemas.ex
+++ b/lib/loopctl/api_spec/schemas.ex
@@ -3497,7 +3497,19 @@ defmodule Loopctl.ApiSpec.Schemas do
             knowledge_count: %Schema{type: :integer},
             degraded: %Schema{
               type: :boolean,
-              description: "True when the knowledge side errored or fell back to keyword-only."
+              description:
+                "True when EITHER half degraded: the knowledge side errored or fell back " <>
+                  "to keyword-only, OR the memory heavy-read pool was shed under the " <>
+                  "per-tenant cap (empty by capacity, never a whole-endpoint 429)."
+            },
+            degraded_reason: %Schema{
+              type: :string,
+              nullable: true,
+              description:
+                "Bounded, non-sensitive tag naming WHY the merged recall degraded " <>
+                  "(e.g. `heavy_read_overloaded`, `no_embedding_key`, `invalid_weights`), " <>
+                  "or `null` when healthy. Lets a caller tell a scope-empty half from a " <>
+                  "fault-empty one without parsing the per-source envelopes."
             },
             results_ranking: %Schema{
               type: :string,

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -2180,7 +2180,10 @@ defmodule Loopctl.Knowledge do
   defp apply_search_filters(query, status, opts) do
     query
     |> maybe_filter_by_status(status)
-    |> maybe_filter_by_project_id(Keyword.get(opts, :project_id))
+    |> apply_project_scope(
+      Keyword.get(opts, :project_id),
+      Keyword.get(opts, :project_scope, :strict)
+    )
     |> maybe_filter_by_category(Keyword.get(opts, :category))
     |> maybe_filter_by_tags(Keyword.get(opts, :tags), Keyword.get(opts, :match, :any))
     |> maybe_filter_by_memory_types(Keyword.get(opts, :memory_types))
@@ -5807,6 +5810,27 @@ defmodule Loopctl.Knowledge do
     )
   end
 
+  # Dispatch the project filter between the STRICT (project-only) and the MERGED
+  # (`global ∪ project`) predicate based on the `:project_scope` opt (#411 Gap 2, PR B).
+  #
+  #   * `:strict` (DEFAULT) → `maybe_filter_by_project_id/2` — `project_id == ^id`,
+  #     the historical behaviour every existing search/list caller relies on. Absent
+  #     `:project_scope` resolves here, so EVERY pre-existing caller is byte-identical.
+  #   * `:with_global` → `scope_project_or_global/2` — `project_id IS NULL OR == ^id`,
+  #     the merged-recall semantics `Loopctl.Memory.recall_context/2` needs so a
+  #     project-scoped combined search ALSO surfaces tenant-wide (global) articles.
+  #
+  # Threaded from `search_combined/3` through its `sub_opts` into BOTH the keyword +
+  # semantic-count filter set (`apply_search_filters/3`) and the semantic results pool
+  # (`apply_semantic_pool_filters/2`), so results and `total_count` stay consistent.
+  # A `nil` project_id is a no-op under either mode (strict short-circuits on nil;
+  # `scope_project_or_global(query, nil)` returns the query unchanged).
+  defp apply_project_scope(query, project_id, :with_global),
+    do: scope_project_or_global(query, project_id)
+
+  defp apply_project_scope(query, project_id, _strict),
+    do: maybe_filter_by_project_id(query, project_id)
+
   defp maybe_filter_by_project_id(query, nil), do: query
 
   defp maybe_filter_by_project_id(query, project_id) do
@@ -6264,7 +6288,10 @@ defmodule Loopctl.Knowledge do
   # select carries `project_id`/`category`/`tags`/`metadata`).
   defp apply_semantic_pool_filters(query, opts) do
     query
-    |> maybe_filter_by_project_id(Keyword.get(opts, :project_id))
+    |> apply_project_scope(
+      Keyword.get(opts, :project_id),
+      Keyword.get(opts, :project_scope, :strict)
+    )
     |> maybe_filter_by_category(Keyword.get(opts, :category))
     |> maybe_filter_by_tags(Keyword.get(opts, :tags), Keyword.get(opts, :match, :any))
     |> maybe_filter_by_memory_types(Keyword.get(opts, :memory_types))
@@ -6334,6 +6361,11 @@ defmodule Loopctl.Knowledge do
     - `:keyword_weight` -- weight for keyword scores (default 0.5)
     - `:semantic_weight` -- weight for semantic scores (default 0.5)
     - `:project_id`, `:category`, `:status`, `:tags` -- standard filters
+    - `:project_scope` -- how `:project_id` filters (default `:strict`). `:strict`
+      matches `project_id == id` (the historical behaviour); `:with_global` matches
+      `project_id IS NULL OR == id`, so a project-scoped search ALSO surfaces
+      tenant-wide (global) articles. Used by the merged `Loopctl.Memory.recall_context/2`
+      recall (#411 Gap 2). No-op when `:project_id` is absent.
     - `:limit` -- max ranked results to return (default 10, max
       #{@max_relevance_page_size}, min 1); relevance top-N, capped well below the
       enumeration page size

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -5823,8 +5823,19 @@ defmodule Loopctl.Knowledge do
   # Threaded from `search_combined/3` through its `sub_opts` into BOTH the keyword +
   # semantic-count filter set (`apply_search_filters/3`) and the semantic results pool
   # (`apply_semantic_pool_filters/2`), so results and `total_count` stay consistent.
-  # A `nil` project_id is a no-op under either mode (strict short-circuits on nil;
-  # `scope_project_or_global(query, nil)` returns the query unchanged).
+  #
+  # `nil` project_id behaviour DIFFERS by mode (deliberately):
+  #   * `:strict` — a no-op (`maybe_filter_by_project_id/2` short-circuits nil), so an
+  #     absent project matches ALL projects — the historical list/search behaviour.
+  #   * `:with_global` — scopes to GLOBAL-ONLY (`project_id IS NULL`), NOT the query
+  #     unchanged. The merged-recall contract (the OpenAPI RecallContextRequest and the
+  #     MCP recall_context tool both promise "absent/blank project → global-only") and
+  #     the memory half (`Memory.maybe_scope_project/2`, nil → `project_id IS NULL`)
+  #     require the union to be global-only with no active project — NOT every project's
+  #     articles flooding the merged limit for a multi-project tenant.
+  defp apply_project_scope(query, nil, :with_global),
+    do: where(query, [a], is_nil(a.project_id))
+
   defp apply_project_scope(query, project_id, :with_global),
     do: scope_project_or_global(query, project_id)
 
@@ -6365,7 +6376,13 @@ defmodule Loopctl.Knowledge do
       matches `project_id == id` (the historical behaviour); `:with_global` matches
       `project_id IS NULL OR == id`, so a project-scoped search ALSO surfaces
       tenant-wide (global) articles. Used by the merged `Loopctl.Memory.recall_context/2`
-      recall (#411 Gap 2). No-op when `:project_id` is absent.
+      recall (#411 Gap 2). Under `:strict` an absent `:project_id` is a no-op (all
+      projects); under `:with_global` an absent `:project_id` scopes to GLOBAL-ONLY
+      (`project_id IS NULL`), matching the documented `global ∪ active-project` union.
+    - `:embedding` -- an optional precomputed `{:ok, embedding} | {:error, reason}`
+      for `query_string`. When supplied the semantic half reuses it instead of making
+      an outbound provider call (the merged recall shares ONE embedding across both
+      halves — #411 Gap 2); an `{:error, _}` degrades to keyword-only as usual.
     - `:limit` -- max ranked results to return (default 10, max
       #{@max_relevance_page_size}, min 1); relevance top-N, capped well below the
       enumeration page size
@@ -6431,7 +6448,15 @@ defmodule Loopctl.Knowledge do
       |> Keyword.put(:_skip_record_access, true)
 
     keyword_result = search_keyword(tenant_id, query_string, sub_opts)
-    embedding_result = try_generate_embedding(tenant_id, query_string, [])
+
+    # Reuse a caller-supplied embedding when present (the merged recall generates ONE
+    # embedding for both its memory + knowledge halves — #411 Gap 2) instead of making
+    # a second outbound provider call; otherwise generate here as before.
+    embedding_result =
+      case Keyword.get(opts, :embedding) do
+        nil -> try_generate_embedding(tenant_id, query_string, [])
+        precomputed -> precomputed
+      end
 
     case {keyword_result, embedding_result} do
       {{:ok, kw}, {:ok, embedding}} ->

--- a/lib/loopctl/memory.ex
+++ b/lib/loopctl/memory.ex
@@ -72,6 +72,13 @@ defmodule Loopctl.Memory do
   @default_list_limit 50
   @max_list_limit 200
 
+  # `recall_context/2` (the merged memory ∪ knowledge recall, #411 Gap 2 PR B) clamps
+  # its overall limit here. The per-source sub-recalls clamp independently (memory via
+  # `clamp_k/1`, knowledge inside `search_combined/3`); this bounds the merged, re-ranked
+  # page returned to the caller so a large `limit` cannot blow up the sort/take.
+  @default_context_limit 10
+  @max_context_limit 50
+
   # The reserved subject_id the promotion-quality eval (US-29.5) seeds its synthetic
   # labeled sessions under. It lives HERE — the shared memory context — so the eval, the
   # cross-tenant auto-promotion sweep, and the durable-promotion write path all reference
@@ -733,6 +740,185 @@ defmodule Loopctl.Memory do
     do: "embedding_provider_error_#{status}"
 
   defp api_error_tag(_other), do: "embedding_error"
+
+  # ===========================================================================
+  # Merged recall (memory ∪ knowledge) — #411 Gap 2 PR B
+  # ===========================================================================
+
+  @doc """
+  Runs BOTH the long-term memory recall AND the knowledge combined search for one
+  `(query, project_id)` and returns a single merged, re-ranked result — the
+  `global ∪ active-project` recall the harness previously had to assemble by calling
+  `memory_recall` and `knowledge_context`/`knowledge_search` separately (#411 Gap 2).
+
+  Both sub-recalls merge global with the active project:
+
+    * memory — `recall/2` (already merges `global ∪ scope.project_id`; PR A).
+    * knowledge — `Loopctl.Knowledge.search_combined/3` with
+      `project_scope: :with_global`, so a project-scoped combined search ALSO surfaces
+      tenant-wide (global) articles rather than project-only.
+
+  `project_id` is the PARTITION key on both sides, NOT the isolation boundary
+  (`tenant_id`/`subject_id` are — they come from `scope`, never the body). A nil
+  `scope.project_id` is global-only on the memory side and no-project-filter on the
+  knowledge side; a present one merges global with that project on both.
+
+  ## Scores are heuristically comparable, NOT calibrated
+
+  The merged list is sorted by a single `score` DESC across BOTH sources, but the two
+  scores come from different scales:
+
+    * memory `score` = `max(0, 1 - cosine_distance)` — an absolute per-row similarity
+      in `[0, 1]` (or `nil` on the ILIKE text-match fallback path, treated as `0.0`
+      for ranking only).
+    * knowledge `score` = the combined search's `final_score` — a weighted
+      keyword+semantic score, MIN-MAX normalized WITHIN the returned pool (so it is
+      pool-relative, not an absolute similarity).
+
+  Treat the cross-source ordering as a useful heuristic, not a calibrated ranking.
+  Callers that need to re-rank get BOTH the merged view AND the untouched per-source
+  envelopes (`:memory`, `:knowledge`) to do so.
+
+  ## Degradation, never a 500
+
+  If `search_combined/3` returns an error (empty query, invalid weights, etc.) the
+  knowledge side degrades to empty results with `meta.degraded?: true` and the memory
+  side is still returned — the merged call never crashes on a knowledge fault. A
+  keyword-only knowledge fallback (embedding unavailable) also sets `degraded?: true`.
+
+  ## Options
+
+    * `:query` — the query text (default `""`); embedded/ILIKE'd on the memory side and
+      passed to the knowledge combined search.
+    * `:limit` — overall merged page size, clamped to `[1, #{@max_context_limit}]`
+      (default #{@default_context_limit}). Applied per-source first, then to the merged,
+      re-ranked list.
+    * `:status` — knowledge status filter (controllers force `:published` for agent/
+      orchestrator roles, mirroring `knowledge/context`).
+    * `:visibility_agent_id` — knowledge agent-memory visibility scope (#163), passed
+      through to `search_combined/3` exactly as the knowledge context controller does.
+
+  ## Returns
+
+      %{
+        results: [
+          %{source: :memory, score: float, memory: %Memory{}}
+          | %{source: :knowledge, score: float, article: map()}
+        ],                                   # merged, sorted score DESC, capped at limit
+        memory: <the recall/2 envelope, unchanged>,
+        knowledge: <the search_combined envelope (results + meta), or a degraded stub>,
+        meta: %{
+          query: String.t(),
+          project_id: String.t() | nil,
+          total_count: non_neg_integer(),    # length(results) after the merged cap
+          memory_count: non_neg_integer(),   # memory rows BEFORE the merged cap
+          knowledge_count: non_neg_integer(),# knowledge rows BEFORE the merged cap
+          degraded?: boolean()               # knowledge errored or fell back to keyword
+        }
+      }
+
+  NB the `:article` on a `:knowledge` merged item is the `search_combined/3` result map
+  (article summary — id/title/category/tags/snippet + scores), the same shape the
+  knowledge search endpoints serialize, NOT a hydrated `%Loopctl.Knowledge.Article{}`
+  with a full body. The per-source `:knowledge` envelope carries the identical maps;
+  callers wanting full bodies deep-read via `knowledge/context`.
+  """
+  @spec recall_context(Scope.t(), keyword() | map()) :: %{
+          results: [map()],
+          memory: result_envelope(),
+          knowledge: %{results: [map()], meta: map()},
+          meta: map()
+        }
+  def recall_context(%Scope{} = scope, opts \\ []) do
+    query = to_string(opt(opts, :query, ""))
+    limit = clamp_context_limit(opt(opts, :limit, @default_context_limit))
+
+    memory_env = recall(scope, query: query, limit: limit)
+    knowledge_env = knowledge_recall(scope, query, limit, opts)
+
+    memory_items =
+      Enum.map(memory_env.results, fn {memory, score} ->
+        %{source: :memory, score: score, memory: memory}
+      end)
+
+    knowledge_items =
+      Enum.map(knowledge_env.results, fn result ->
+        %{source: :knowledge, score: knowledge_score(result), article: result}
+      end)
+
+    merged =
+      (memory_items ++ knowledge_items)
+      # `score` can be nil on the memory ILIKE fallback path — rank it as 0.0 without
+      # mutating the per-source envelope (which preserves the honest nil).
+      |> Enum.sort_by(&(&1.score || 0.0), :desc)
+      |> Enum.take(limit)
+
+    %{
+      results: merged,
+      memory: memory_env,
+      knowledge: knowledge_env,
+      meta: %{
+        query: query,
+        project_id: scope.project_id,
+        total_count: length(merged),
+        memory_count: length(memory_items),
+        knowledge_count: length(knowledge_items),
+        degraded?: knowledge_degraded?(knowledge_env)
+      }
+    }
+  end
+
+  # Run the knowledge half via `search_combined/3` with the merged `:with_global`
+  # project scope, translating its `{:ok, env} | {:error, ...}` result into a UNIFORM
+  # `%{results: [...], meta: %{...}}` envelope. On ANY error (empty query, invalid
+  # weights, bad_request) the knowledge side degrades to empty results tagged
+  # `degraded?: true` — the merged call never propagates a knowledge fault as a crash.
+  defp knowledge_recall(scope, query, limit, opts) do
+    kopts =
+      [
+        project_id: scope.project_id,
+        project_scope: :with_global,
+        limit: limit
+      ]
+      |> maybe_put_opt(:status, opt(opts, :status, nil))
+      |> maybe_put_opt(:visibility_agent_id, opt(opts, :visibility_agent_id, nil))
+
+    case Knowledge.search_combined(scope.tenant_id, query, kopts) do
+      {:ok, %{results: results, meta: meta}} ->
+        # A keyword-only fallback (embedding unavailable) sets meta.fallback; carry
+        # that forward as degraded? so the merged meta reflects a degraded knowledge side.
+        %{results: results, meta: Map.put(meta, :degraded?, Map.get(meta, :fallback, false))}
+
+      {:error, reason} ->
+        degraded_knowledge_env(reason)
+
+      {:error, reason, _message} ->
+        degraded_knowledge_env(reason)
+    end
+  end
+
+  # The uniform empty/degraded knowledge envelope used when `search_combined/3` cannot
+  # run (empty query, invalid weights, over-long query, ...). `error` carries the
+  # underlying reason atom for observability; `degraded?: true` drives the merged
+  # meta flag and tells the caller the knowledge side is empty by fault, not by scope.
+  defp degraded_knowledge_env(reason) do
+    %{results: [], meta: %{total_count: 0, degraded?: true, error: reason, fallback: false}}
+  end
+
+  defp knowledge_degraded?(%{meta: meta}), do: Map.get(meta, :degraded?, false) == true
+
+  # Knowledge combined `final_score` — a pool-normalized weighted keyword+semantic
+  # score in [0, 1]. Defaults to 0.0 for a malformed result map (defensive).
+  defp knowledge_score(%{final_score: score}) when is_number(score), do: score
+  defp knowledge_score(_), do: 0.0
+
+  defp clamp_context_limit(limit),
+    do: limit |> to_int(@default_context_limit) |> max(1) |> min(@max_context_limit)
+
+  # Add `{key, value}` to the opts only when value is non-nil, so an absent status /
+  # visibility scope leaves `search_combined/3` on its own defaults.
+  defp maybe_put_opt(opts, _key, nil), do: opts
+  defp maybe_put_opt(opts, key, value), do: Keyword.put(opts, key, value)
 
   # ===========================================================================
   # forget / list / session_history / supersede (RLS OLTP path)

--- a/lib/loopctl/memory.ex
+++ b/lib/loopctl/memory.ex
@@ -44,6 +44,8 @@ defmodule Loopctl.Memory do
 
   import Ecto.Query
 
+  require Logger
+
   alias Ecto.Multi
   alias Loopctl.AdminRepo
   alias Loopctl.Auth.ApiKey
@@ -57,6 +59,7 @@ defmodule Loopctl.Memory do
   alias Loopctl.Memory.SessionMemory
   alias Loopctl.Memory.SessionPromotion
   alias Loopctl.Projects
+  alias Loopctl.TelemetryEvents
   alias Loopctl.Workers.MemoryEmbeddingWorker
   alias Loopctl.Workers.MemoryPromotionWorker
 
@@ -489,46 +492,86 @@ defmodule Loopctl.Memory do
     query_text = to_string(opt(opts, :query, ""))
     k = clamp_k(opt(opts, :limit, @default_recall_k))
     include_superseded? = truthy?(opt(opts, :include_superseded, false))
+    on_overload = recall_on_overload(opt(opts, :on_overload, :raise))
 
     # Reuse a precomputed embedding when the caller supplies one (the merged recall
     # generates it ONCE for both halves — #411 Gap 2); otherwise generate here.
     case opt(opts, :embedding, nil) || Knowledge.generate_embedding(scope.tenant_id, query_text) do
       {:ok, embedding} ->
-        recall_semantic(scope, embedding, k, include_superseded?)
+        recall_semantic(scope, embedding, k, include_superseded?, on_overload)
 
       {:error, reason} ->
-        recall_fallback(scope, reason, query_text, k, include_superseded?)
+        recall_fallback(scope, reason, query_text, k, include_superseded?, on_overload)
     end
   end
 
-  defp recall_semantic(scope, embedding, k, include_superseded?) do
+  # `:on_overload` controls how a per-tenant HeavyRead cap SHED is handled (US-37.5):
+  # `:raise` (the DEFAULT, standalone `/memory/recall`) raises `OverloadedError` → a 429;
+  # `:tag` (the merged `/recall`, #411 Gap 2) degrades to an empty envelope so one shed
+  # pool cannot sink the whole merged endpoint. Only these two values are honored.
+  defp recall_on_overload(:tag), do: :tag
+  defp recall_on_overload(_), do: :raise
+
+  defp recall_semantic(scope, embedding, k, include_superseded?, on_overload) do
     query = memory_candidate_query(scope, embedding, k, include_superseded?)
 
-    rows =
-      HeavyRead.all_memory(
-        scope.tenant_id,
-        scope.subject_id,
-        query,
-        HeavyRead.opts(:memory_recall)
-      )
+    case HeavyRead.all_memory(
+           scope.tenant_id,
+           scope.subject_id,
+           query,
+           memory_recall_opts(on_overload)
+         ) do
+      {:error, :heavy_read_overloaded} ->
+        overloaded_memory_env(scope.tenant_id, k)
 
-    results =
-      Enum.map(rows, fn row ->
-        # Clamp to [0, 1]: pgvector cosine distance ranges [0, 2], so a distance > 1
-        # would make `1 - distance` NEGATIVE. Mirror VectorSearch's `:knn` score
-        # contract (GREATEST of 0 and `1 - distance`) so the [{memory, score}]
-        # envelope surfaced to US-28.3/US-28.4 never carries a negative similarity.
-        # Ordering is by ascending distance (below), so the clamp cannot reorder.
-        {row_to_memory(row), max(0.0, 1.0 - row.distance)}
-      end)
+      rows when is_list(rows) ->
+        results =
+          Enum.map(rows, fn row ->
+            # Clamp to [0, 1]: pgvector cosine distance ranges [0, 2], so a distance > 1
+            # would make `1 - distance` NEGATIVE. Mirror VectorSearch's `:knn` score
+            # contract (GREATEST of 0 and `1 - distance`) so the [{memory, score}]
+            # envelope surfaced to US-28.3/US-28.4 never carries a negative similarity.
+            # Ordering is by ascending distance (below), so the clamp cannot reorder.
+            {row_to_memory(row), max(0.0, 1.0 - row.distance)}
+          end)
+
+        %{
+          results: results,
+          meta: %{
+            total_count: length(results),
+            fallback: false,
+            reason: nil,
+            underfilled: length(results) < k
+          }
+        }
+    end
+  end
+
+  # HeavyRead opts for a memory recall, with the caller's shed policy layered on. `:raise`
+  # is `all_memory`'s own default, so it is only threaded explicitly for `:tag`.
+  defp memory_recall_opts(:tag),
+    do: Keyword.put(HeavyRead.opts(:memory_recall), :on_overload, :tag)
+
+  defp memory_recall_opts(_), do: HeavyRead.opts(:memory_recall)
+
+  # The empty, degraded memory envelope returned when the per-tenant HeavyRead cap SHED
+  # the memory read on the merged `/recall` path (`on_overload: :tag`). Emits an
+  # alertable telemetry event + log (the shed is otherwise silent here — a `:raise` shed
+  # would have surfaced as a 429) so operators can see a memory-half degradation, then
+  # returns empty so the knowledge half of the merged recall is still served rather than
+  # the whole endpoint 429-ing. `reason` mirrors the memory `meta.reason` fallback-tag
+  # contract (like the embedding-fallback tags), so callers can tell the memory side is
+  # empty by capacity, not by scope.
+  defp overloaded_memory_env(tenant_id, k) do
+    emit_recall_degraded(tenant_id, "memory", "heavy_read_overloaded")
 
     %{
-      results: results,
+      results: [],
       meta: %{
-        total_count: length(results),
-        fallback: false,
-        reason: nil,
-        underfilled: length(results) < k
+        total_count: 0,
+        fallback: true,
+        reason: "heavy_read_overloaded",
+        underfilled: k > 0
       }
     }
   end
@@ -664,7 +707,7 @@ defmodule Loopctl.Memory do
     struct(MemorySchema, Map.drop(row, [:distance]))
   end
 
-  defp recall_fallback(scope, reason, query_text, k, include_superseded?) do
+  defp recall_fallback(scope, reason, query_text, k, include_superseded?, on_overload) do
     reason_tag = fallback_reason_tag(reason)
 
     query =
@@ -679,25 +722,28 @@ defmodule Loopctl.Memory do
       |> maybe_ilike(query_text)
       |> maybe_scope_project(scope.project_id)
 
-    rows =
-      HeavyRead.all_memory(
-        scope.tenant_id,
-        scope.subject_id,
-        query,
-        HeavyRead.opts(:memory_recall)
-      )
+    case HeavyRead.all_memory(
+           scope.tenant_id,
+           scope.subject_id,
+           query,
+           memory_recall_opts(on_overload)
+         ) do
+      {:error, :heavy_read_overloaded} ->
+        overloaded_memory_env(scope.tenant_id, k)
 
-    results = Enum.map(rows, fn memory -> {memory, nil} end)
+      rows when is_list(rows) ->
+        results = Enum.map(rows, fn memory -> {memory, nil} end)
 
-    %{
-      results: results,
-      meta: %{
-        total_count: length(results),
-        fallback: true,
-        reason: reason_tag,
-        underfilled: length(results) < k
-      }
-    }
+        %{
+          results: results,
+          meta: %{
+            total_count: length(results),
+            fallback: true,
+            reason: reason_tag,
+            underfilled: length(results) < k
+          }
+        }
+    end
   end
 
   defp maybe_ilike(query, ""), do: query
@@ -792,12 +838,41 @@ defmodule Loopctl.Memory do
   Callers that need a calibrated re-rank get BOTH the merged view AND the untouched
   per-source envelopes (`:memory`, `:knowledge`), each carrying its own native scores.
 
-  ## Degradation, never a 500
+  ## Degradation, never a 500 (and never a whole-endpoint 429)
 
-  If `search_combined/3` returns an error (empty query, invalid weights, etc.) the
-  knowledge side degrades to empty results with `meta.degraded?: true` and the memory
-  side is still returned — the merged call never crashes on a knowledge fault. A
-  keyword-only knowledge fallback (embedding unavailable) also sets `degraded?: true`.
+  Degradation is SYMMETRIC across both halves — one degraded half never fails the whole
+  call:
+
+    * If `search_combined/3` returns an error (invalid weights, etc.) the knowledge side
+      degrades to empty results with `meta.degraded?: true` and the memory side is still
+      returned — the merged call never crashes on a knowledge fault. A keyword-only
+      knowledge fallback (embedding unavailable) also sets `degraded?: true`.
+    * If the per-tenant HeavyRead cap SHEDS the memory read, the merged path threads
+      `on_overload: :tag` so the memory side degrades to an EMPTY envelope (with
+      `degraded?: true`) instead of raising `OverloadedError` — so a shed memory pool
+      429-ing cannot discard the knowledge results the caller could still have gotten.
+      (The standalone `/memory/recall` keeps `on_overload: :raise` → a 429.)
+
+  `meta.degraded_reason` names WHY (a bounded tag), and the knowledge/memory-half
+  degradation each emits a `[:loopctl, :memory, :recall_context, :degraded]` telemetry
+  event + log so a silent partial failure is alertable.
+
+  ## Concurrency & cost
+
+  The two halves run SEQUENTIALLY (memory read, then knowledge combined read), not
+  Task-parallel — a deliberate cap-friendly choice that holds at most ONE per-tenant
+  HeavyRead slot at a time. The tradeoff: additive (not max) wall-clock latency and ~2x
+  the governed heavy-read throughput of a single search per `/recall`. Parallelizing is
+  intentionally NOT done, because two simultaneous slots would double a single request's
+  peak pressure under the very cap that shields other tenants.
+
+  ## Known bias on the degraded path
+
+  On a degraded knowledge side (keyword-only fallback) memory rows carry absolute cosine
+  scores while knowledge rows carry raw (un-normalized) keyword `relevance_score`, which
+  can exceed memory's cosine max of 1.0 and outrank memory in the merged `data`. A caller
+  needing memory-first ordering under degradation should read the per-source `:memory`
+  envelope (it preserves the honest native scores/nils), disclosed via `meta.degraded?`.
 
   ## Options
 
@@ -826,7 +901,8 @@ defmodule Loopctl.Memory do
           total_count: non_neg_integer(),    # length(results) after the merged cap
           memory_count: non_neg_integer(),   # memory rows BEFORE the merged cap
           knowledge_count: non_neg_integer(),# knowledge rows BEFORE the merged cap
-          degraded?: boolean(),              # knowledge errored or fell back to keyword
+          degraded?: boolean(),              # knowledge errored/fell back OR memory shed
+          degraded_reason: String.t() | nil, # bounded tag naming why (nil when healthy)
           results_ranking: String.t()        # "heuristic_cross_source" (see KNOWN BIAS)
         }
       }
@@ -856,7 +932,20 @@ defmodule Loopctl.Memory do
     # memory side could succeed while the knowledge side independently fell back).
     embedding_result = Knowledge.generate_embedding(scope.tenant_id, query)
 
-    memory_env = recall(scope, query: query, limit: limit, embedding: embedding_result)
+    # The two halves run SEQUENTIALLY (memory heavy-read, then the knowledge combined
+    # keyword+semantic reads) rather than Task-parallel — a DELIBERATE cap-friendly
+    # choice, NOT an oversight. Parallelizing would hold TWO per-tenant HeavyRead slots
+    # simultaneously under the very cap that shields other tenants (US-37.5), doubling a
+    # single /recall's peak concurrent slot pressure and raising the shed probability the
+    # cap exists to bound; sequential holds at most ONE slot at a time. The tradeoff is
+    # additive (not max) wall-clock latency and ~2x the governed heavy-read THROUGHPUT of
+    # a single search per /recall — acceptable while the endpoint is throughput/cap-bound
+    # rather than latency-bound. `on_overload: :tag` degrades a memory-half shed to an
+    # empty envelope so it never sinks the whole endpoint (symmetric with the knowledge
+    # half's keyword-only degrade).
+    memory_env =
+      recall(scope, query: query, limit: limit, embedding: embedding_result, on_overload: :tag)
+
     knowledge_env = knowledge_recall(scope, query, limit, opts, embedding_result)
 
     memory_items =
@@ -886,7 +975,14 @@ defmodule Loopctl.Memory do
         total_count: length(merged),
         memory_count: length(memory_items),
         knowledge_count: length(knowledge_items),
-        degraded?: knowledge_degraded?(knowledge_env),
+        # `degraded?` is true when EITHER half degraded: the knowledge side errored/fell
+        # back to keyword-only, OR the memory heavy-read pool was shed (empty by capacity).
+        degraded?: knowledge_degraded?(knowledge_env) or memory_degraded?(memory_env),
+        # A BOUNDED, non-sensitive tag naming WHY the merged recall degraded (or `nil`
+        # when it did not), so a caller can distinguish a scope-empty half from a
+        # fault-empty one without parsing the per-source envelopes. Knowledge degradation
+        # is reported first (it drives the documented `degraded?`), then memory.
+        degraded_reason: merged_degraded_reason(memory_env, knowledge_env),
         # The merged `results` order sorts memory's ABSOLUTE cosine similarity against
         # knowledge's POOL-NORMALIZED final_score — a heuristic, not a calibrated
         # cross-source ranking (knowledge is biased upward; see the moduledoc). Surface
@@ -925,22 +1021,89 @@ defmodule Loopctl.Memory do
         %{results: results, meta: Map.put(meta, :degraded?, Map.get(meta, :fallback, false))}
 
       {:error, reason} ->
-        degraded_knowledge_env(reason)
+        degraded_knowledge_env(scope.tenant_id, reason, limit)
 
       {:error, reason, _message} ->
-        degraded_knowledge_env(reason)
+        degraded_knowledge_env(scope.tenant_id, reason, limit)
     end
   end
 
-  # The uniform empty/degraded knowledge envelope used when `search_combined/3` cannot
-  # run (empty query, invalid weights, over-long query, ...). `error` carries the
-  # underlying reason atom for observability; `degraded?: true` drives the merged
-  # meta flag and tells the caller the knowledge side is empty by fault, not by scope.
-  defp degraded_knowledge_env(reason) do
-    %{results: [], meta: %{total_count: 0, degraded?: true, error: reason, fallback: false}}
+  # The uniform empty/degraded knowledge envelope used when `search_combined/3` returns
+  # a hard `{:error, _}` (empty query, invalid weights, ...) rather than a keyword-only
+  # fallback. Emits an alertable telemetry event + log (this branch was otherwise
+  # SILENT — no signal for operators, unlike the keyword-fallback path which records a
+  # reason) and builds a meta that is SHAPE-COMPATIBLE with the healthy
+  # `search_combined/3` meta (`total_count`/`limit`/`offset`) so the endpoint serializer
+  # can project it through the SAME `KnowledgeSearchJSON.render_meta` whitelist the
+  # standalone knowledge endpoints use. The reason is carried ONLY as a BOUNDED,
+  # non-sensitive `fallback_reason` tag — the raw internal reason atom is NEVER placed
+  # in the client-facing meta (it lives only in telemetry/logs), so `/recall` no longer
+  # leaks an internal atom the equivalent `/knowledge/search` would have stripped.
+  defp degraded_knowledge_env(tenant_id, reason, limit) do
+    tag = knowledge_degraded_reason_tag(reason)
+    emit_recall_degraded(tenant_id, "knowledge", tag)
+
+    %{
+      results: [],
+      meta: %{
+        total_count: 0,
+        limit: limit,
+        offset: 0,
+        degraded?: true,
+        fallback: true,
+        fallback_reason: tag
+      }
+    }
+  end
+
+  # Map a `search_combined/3` hard-error reason atom to a BOUNDED, non-sensitive tag safe
+  # to surface in `meta`/telemetry (never the raw atom). These three atoms are the FULL
+  # error contract of `search_combined/3` (dialyzer-verified) — with the controller now
+  # rejecting blank AND over-length queries up front, `:empty_query`/`:bad_request` are
+  # unreachable via `/recall`, but any of the contract's reasons is coerced to this set.
+  defp knowledge_degraded_reason_tag(:empty_query), do: "empty_query"
+  defp knowledge_degraded_reason_tag(:invalid_weights), do: "invalid_weights"
+  defp knowledge_degraded_reason_tag(:bad_request), do: "bad_request"
+
+  # Emit the merged-recall degradation signal (telemetry + log) for ONE degraded half so
+  # a silent partial failure of `/recall` is alertable. `reason`/`side` are BOUNDED tags;
+  # the query TEXT is never included (matching the other knowledge/memory telemetry).
+  defp emit_recall_degraded(tenant_id, side, reason) do
+    :telemetry.execute(
+      TelemetryEvents.recall_context_degraded(),
+      %{count: 1},
+      %{tenant_id: tenant_id, side: side, reason: reason}
+    )
+
+    Logger.warning(
+      "memory.recall_context degraded side=#{side} reason=#{reason} tenant_id=#{tenant_id}"
+    )
+
+    :ok
   end
 
   defp knowledge_degraded?(%{meta: meta}), do: Map.get(meta, :degraded?, false) == true
+
+  # The memory half is "degraded" for the merged `degraded?`/`degraded_reason` ONLY when
+  # its heavy read was SHED by the per-tenant cap (empty by capacity). An ordinary
+  # embedding-unavailable ILIKE fallback is NOT counted here — that path degrades BOTH
+  # halves and is already reflected via the knowledge side's keyword-only fallback.
+  defp memory_degraded?(%{meta: meta}), do: Map.get(meta, :reason) == "heavy_read_overloaded"
+
+  # A BOUNDED, non-sensitive tag naming why the merged recall degraded, or `nil`. Reports
+  # the knowledge side first (it drives the documented `degraded?`), then memory.
+  defp merged_degraded_reason(memory_env, knowledge_env) do
+    cond do
+      knowledge_degraded?(knowledge_env) ->
+        knowledge_env.meta[:fallback_reason] || "knowledge_degraded"
+
+      memory_degraded?(memory_env) ->
+        memory_env.meta[:reason]
+
+      true ->
+        nil
+    end
+  end
 
   # Knowledge combined ranking score. Normal combined results carry `:final_score`
   # (pool-normalized weighted keyword+semantic, in [0, 1]); when combined DEGRADES to a

--- a/lib/loopctl/memory.ex
+++ b/lib/loopctl/memory.ex
@@ -490,7 +490,9 @@ defmodule Loopctl.Memory do
     k = clamp_k(opt(opts, :limit, @default_recall_k))
     include_superseded? = truthy?(opt(opts, :include_superseded, false))
 
-    case Knowledge.generate_embedding(scope.tenant_id, query_text) do
+    # Reuse a precomputed embedding when the caller supplies one (the merged recall
+    # generates it ONCE for both halves — #411 Gap 2); otherwise generate here.
+    case opt(opts, :embedding, nil) || Knowledge.generate_embedding(scope.tenant_id, query_text) do
       {:ok, embedding} ->
         recall_semantic(scope, embedding, k, include_superseded?)
 
@@ -760,8 +762,11 @@ defmodule Loopctl.Memory do
 
   `project_id` is the PARTITION key on both sides, NOT the isolation boundary
   (`tenant_id`/`subject_id` are — they come from `scope`, never the body). A nil
-  `scope.project_id` is global-only on the memory side and no-project-filter on the
-  knowledge side; a present one merges global with that project on both.
+  `scope.project_id` is GLOBAL-ONLY on BOTH sides (memory: `project_id IS NULL`;
+  knowledge: `:with_global` with a nil project also scopes to `project_id IS NULL`),
+  so with no active project the union is global-only — matching the published
+  RecallContextRequest / MCP recall_context contract. A present project merges global
+  with that project on both.
 
   ## Scores are heuristically comparable, NOT calibrated
 
@@ -775,9 +780,17 @@ defmodule Loopctl.Memory do
       keyword+semantic score, MIN-MAX normalized WITHIN the returned pool (so it is
       pool-relative, not an absolute similarity).
 
+  KNOWN BIAS: because the knowledge `final_score` is min-max normalized within the
+  returned pool, the top knowledge row is ~1.0 regardless of its ABSOLUTE relevance,
+  so knowledge items systematically outrank memory items in the default `results`
+  ordering even when the memory matches are strong. This is a documented heuristic,
+  NOT a calibrated cross-source ranking — do NOT read the merged `results` order as
+  "knowledge was more relevant than memory". `meta.results_ranking` carries the stable
+  tag `"heuristic_cross_source"` so consumers can detect this programmatically.
+
   Treat the cross-source ordering as a useful heuristic, not a calibrated ranking.
-  Callers that need to re-rank get BOTH the merged view AND the untouched per-source
-  envelopes (`:memory`, `:knowledge`) to do so.
+  Callers that need a calibrated re-rank get BOTH the merged view AND the untouched
+  per-source envelopes (`:memory`, `:knowledge`), each carrying its own native scores.
 
   ## Degradation, never a 500
 
@@ -813,7 +826,8 @@ defmodule Loopctl.Memory do
           total_count: non_neg_integer(),    # length(results) after the merged cap
           memory_count: non_neg_integer(),   # memory rows BEFORE the merged cap
           knowledge_count: non_neg_integer(),# knowledge rows BEFORE the merged cap
-          degraded?: boolean()               # knowledge errored or fell back to keyword
+          degraded?: boolean(),              # knowledge errored or fell back to keyword
+          results_ranking: String.t()        # "heuristic_cross_source" (see KNOWN BIAS)
         }
       }
 
@@ -833,8 +847,17 @@ defmodule Loopctl.Memory do
     query = to_string(opt(opts, :query, ""))
     limit = clamp_context_limit(opt(opts, :limit, @default_context_limit))
 
-    memory_env = recall(scope, query: query, limit: limit)
-    knowledge_env = knowledge_recall(scope, query, limit, opts)
+    # Generate the query embedding ONCE and thread it into BOTH halves. This
+    # single-round-trip endpoint otherwise made TWO uncached outbound provider calls
+    # for the identical query (recall/2 → generate_embedding AND knowledge_recall →
+    # search_combined → try_generate_embedding), doubling embedding latency/cost and
+    # consuming two per-tenant embedding-concurrency slots. Sharing one embedding also
+    # makes the two halves' semantic-vs-keyword degradation AGREE (previously the
+    # memory side could succeed while the knowledge side independently fell back).
+    embedding_result = Knowledge.generate_embedding(scope.tenant_id, query)
+
+    memory_env = recall(scope, query: query, limit: limit, embedding: embedding_result)
+    knowledge_env = knowledge_recall(scope, query, limit, opts, embedding_result)
 
     memory_items =
       Enum.map(memory_env.results, fn {memory, score} ->
@@ -863,7 +886,12 @@ defmodule Loopctl.Memory do
         total_count: length(merged),
         memory_count: length(memory_items),
         knowledge_count: length(knowledge_items),
-        degraded?: knowledge_degraded?(knowledge_env)
+        degraded?: knowledge_degraded?(knowledge_env),
+        # The merged `results` order sorts memory's ABSOLUTE cosine similarity against
+        # knowledge's POOL-NORMALIZED final_score — a heuristic, not a calibrated
+        # cross-source ranking (knowledge is biased upward; see the moduledoc). Surface
+        # a stable tag so consumers don't mistake the order for calibrated relevance.
+        results_ranking: "heuristic_cross_source"
       }
     }
   end
@@ -873,7 +901,7 @@ defmodule Loopctl.Memory do
   # `%{results: [...], meta: %{...}}` envelope. On ANY error (empty query, invalid
   # weights, bad_request) the knowledge side degrades to empty results tagged
   # `degraded?: true` — the merged call never propagates a knowledge fault as a crash.
-  defp knowledge_recall(scope, query, limit, opts) do
+  defp knowledge_recall(scope, query, limit, opts, embedding_result) do
     kopts =
       [
         project_id: scope.project_id,
@@ -882,6 +910,13 @@ defmodule Loopctl.Memory do
       ]
       |> maybe_put_opt(:status, opt(opts, :status, nil))
       |> maybe_put_opt(:visibility_agent_id, opt(opts, :visibility_agent_id, nil))
+      # Thread the read-attribution key so `search_combined/3` records knowledge-access
+      # analytics for /recall traffic (the guard in `maybe_record_search_access/5` skips
+      # recording when `:api_key_id` is nil). Sibling search/context endpoints set it too.
+      |> maybe_put_opt(:api_key_id, opt(opts, :api_key_id, nil))
+      # Reuse the embedding generated ONCE in `recall_context/2` so the knowledge half
+      # does not make a second provider call for the identical query (#411 Gap 2).
+      |> maybe_put_opt(:embedding, embedding_result)
 
     case Knowledge.search_combined(scope.tenant_id, query, kopts) do
       {:ok, %{results: results, meta: meta}} ->
@@ -907,9 +942,18 @@ defmodule Loopctl.Memory do
 
   defp knowledge_degraded?(%{meta: meta}), do: Map.get(meta, :degraded?, false) == true
 
-  # Knowledge combined `final_score` — a pool-normalized weighted keyword+semantic
-  # score in [0, 1]. Defaults to 0.0 for a malformed result map (defensive).
-  defp knowledge_score(%{final_score: score}) when is_number(score), do: score
+  # Knowledge combined ranking score. Normal combined results carry `:final_score`
+  # (pool-normalized weighted keyword+semantic, in [0, 1]); when combined DEGRADES to a
+  # keyword-only fallback the results carry `:relevance_score` (and no `:final_score`),
+  # so mirror `KnowledgeSearchJSON.extract_score/2`'s chain
+  # (`final_score || relevance_score || similarity_score`) via bracket access rather
+  # than scoring every degraded-path item 0.0 and sinking all knowledge below memory.
+  # Defaults to 0.0 for a malformed/scoreless result map (defensive).
+  defp knowledge_score(result) when is_map(result) do
+    score = result[:final_score] || result[:relevance_score] || result[:similarity_score]
+    if is_number(score), do: score, else: 0.0
+  end
+
   defp knowledge_score(_), do: 0.0
 
   defp clamp_context_limit(limit),

--- a/lib/loopctl/telemetry_events.ex
+++ b/lib/loopctl/telemetry_events.ex
@@ -245,6 +245,36 @@ defmodule Loopctl.TelemetryEvents do
   """
   def article_linking_corpus_size, do: [:loopctl, :knowledge, :article_linking, :corpus_size]
 
+  @doc """
+  One HALF of the merged recall (`POST /api/v1/recall`, `Loopctl.Memory.recall_context/2`,
+  #411 Gap 2) degraded to an EMPTY, non-fatal envelope so the OTHER half could still be
+  served — turning an otherwise silent partial failure into an alertable signal (the
+  merged `meta` only carries a coarse `degraded?`/`degraded_reason`, no per-side detail).
+
+  Fires when either half of the merged recall degrades:
+
+    * the KNOWLEDGE half: `search_combined/3` returned an `{:error, _}` (e.g. an
+      invalid-weights or bad-request rejection) instead of a keyword-only fallback, so
+      the knowledge side is empty by FAULT (not by scope), and
+    * the MEMORY half: the per-tenant HeavyRead cap SHED the memory read (`{:error,
+      :heavy_read_overloaded}`); on the merged path this degrades to an empty memory
+      envelope (`on_overload: :tag`) rather than raising a 429 that would sink the whole
+      endpoint.
+
+  A keyword-only knowledge fallback (embedding unavailable / a memory ILIKE embedding
+  fallback) already emits `knowledge_semantic_fallback/0` and is NOT re-emitted here —
+  this event is specifically the empty-by-fault degradations that carried no signal.
+
+  ## Payload (id/atom only — NEVER the raw query text, an api key, or a provider body)
+
+    * `measurements`: `%{count: 1}` — a pure increment.
+    * `metadata`: `%{tenant_id, side, reason}` where `side` is `"memory"` | `"knowledge"`
+      (a BOUNDED 2-value tag) and `reason` is a BOUNDED, sanitized tag
+      (`"heavy_read_overloaded"` | `"empty_query"` | `"invalid_weights"` |
+      `"bad_request"` | `"knowledge_error"`).
+  """
+  def recall_context_degraded, do: [:loopctl, :memory, :recall_context, :degraded]
+
   @doc "Returns all defined event names for attachment"
   def all_events do
     [
@@ -262,7 +292,8 @@ defmodule Loopctl.TelemetryEvents do
       knowledge_hybrid_provenance(),
       llm_provider_error(),
       ingestion_backlog_gate_failed_open(),
-      article_linking_corpus_size()
+      article_linking_corpus_size(),
+      recall_context_degraded()
     ]
   end
 end

--- a/lib/loopctl_web/controllers/knowledge_search_json.ex
+++ b/lib/loopctl_web/controllers/knowledge_search_json.ex
@@ -147,7 +147,17 @@ defmodule LoopctlWeb.KnowledgeSearchJSON do
 
   defp truncate_snippet(_), do: nil
 
-  defp render_meta(meta) do
+  @doc """
+  Projects a `search_combined/3` / `search/3` result `meta` through the canonical
+  whitelist used by the knowledge search endpoints.
+
+  Shared with `LoopctlWeb.RecallJSON` (the merged `/recall` endpoint) so its knowledge
+  envelope emits the SAME whitelisted meta shape — never the raw context meta with any
+  internal reason atom. Requires `:total_count`, `:limit`, and `:offset` on `meta` (both
+  the healthy `search_combined/3` meta and the merged endpoint's degraded stub carry
+  them); the remaining keys are optional and emitted only when present.
+  """
+  def render_meta(meta) do
     %{
       total_count: meta[:total_count] || meta.total_count,
       limit: meta[:limit] || meta.limit,

--- a/lib/loopctl_web/controllers/knowledge_search_json.ex
+++ b/lib/loopctl_web/controllers/knowledge_search_json.ex
@@ -93,7 +93,15 @@ defmodule LoopctlWeb.KnowledgeSearchJSON do
     if include_body, do: Map.put(base, :body, result.body), else: base
   end
 
-  defp render_result(result, mode) do
+  @doc """
+  Projects a single search result map into the canonical whitelisted summary shape
+  (`{id, title, category, tags, score}` plus a truncated `snippet` when present) for
+  the given `mode` (`"keyword" | "semantic" | "combined"`).
+
+  Shared with `LoopctlWeb.RecallJSON` so the merged `/recall` endpoint emits the same
+  shape as the knowledge search endpoints and never leaks raw internal result fields.
+  """
+  def render_result(result, mode) do
     base = %{
       id: result[:id] || result.id,
       title: result[:title] || result.title,

--- a/lib/loopctl_web/controllers/memory_controller.ex
+++ b/lib/loopctl_web/controllers/memory_controller.ex
@@ -132,21 +132,27 @@ defmodule LoopctlWeb.MemoryController do
       "Returns ONE merged, re-ranked result combining the caller's long-term MEMORY " <>
         "recall AND the KNOWLEDGE combined search for `(query, project_id)` — the " <>
         "`global ∪ active-project` union the harness previously assembled by calling " <>
-        "`/memory/recall` and `/knowledge/context` separately (#411 Gap 2). Both sides " <>
-        "merge global with the active project: an absent/blank `project_id` returns " <>
-        "global-only memory + no-project-filter knowledge; a present `project_id` merges " <>
-        "global with that project on BOTH sides (another project's rows are excluded). " <>
-        "`project_id` is a PARTITION key, NOT the isolation boundary — `(tenant_id, " <>
-        "subject_id)` is, and is derived from the API key, never the body. A malformed " <>
-        "`project_id` is a 422 (`invalid_project_id`); a non-string `query` is a 422 " <>
-        "(`invalid_query`). The response carries the merged `results` (each tagged " <>
-        "`source: memory|knowledge`, sorted by a heuristically-comparable `score` DESC) " <>
-        "PLUS the untouched per-source `memory` and `knowledge` envelopes so callers can " <>
-        "re-rank. Cross-source scores are heuristic, not calibrated (memory = cosine " <>
-        "similarity; knowledge = pool-normalized keyword+semantic). If the knowledge " <>
-        "search errors or degrades to keyword-only the memory side is still returned and " <>
-        "`meta.degraded?` is true — never a 500. Agent role is forced to published " <>
-        "articles and its own/`shared` memories (#163).",
+        "`/memory/recall` and `/knowledge/search` separately (#411 Gap 2). NOTE the " <>
+        "knowledge half is the COMBINED SEARCH: article SUMMARIES (id/title/category/" <>
+        "tags/score + a truncated snippet), NOT the deep-read `/knowledge/context` " <>
+        "(full article bodies + one-hop linked references + recency weighting). Callers " <>
+        "needing full bodies or linked refs must still call `/knowledge/context`. Both " <>
+        "sides merge global with the active project: an absent/blank `project_id` " <>
+        "returns GLOBAL-ONLY memory AND global-only knowledge; a present `project_id` " <>
+        "merges global with that project on BOTH sides (another project's rows are " <>
+        "excluded). `project_id` is a PARTITION key, NOT the isolation boundary — " <>
+        "`(tenant_id, subject_id)` is, and is derived from the API key, never the body. " <>
+        "A malformed `project_id` is a 422 (`invalid_project_id`); a non-string, " <>
+        "missing, or blank/whitespace-only `query` is a 422 (`invalid_query`). The " <>
+        "response carries the merged `results` (each tagged `source: memory|knowledge`, " <>
+        "sorted by a heuristically-comparable `score` DESC — `meta.results_ranking` is " <>
+        "`heuristic_cross_source`) PLUS the untouched per-source `memory` and " <>
+        "`knowledge` envelopes so callers can re-rank. Cross-source scores are " <>
+        "heuristic, not calibrated (memory = absolute cosine similarity; knowledge = " <>
+        "pool-normalized keyword+semantic, which biases knowledge UPWARD in the default " <>
+        "order). If the knowledge search errors or degrades to keyword-only the memory " <>
+        "side is still returned and `meta.degraded?` is true — never a 500. Agent role " <>
+        "is forced to published articles and its own/`shared` memories (#163).",
     request_body: {"Recall params", "application/json", Schemas.RecallContextRequest},
     responses: %{
       200 => {"Merged recall results", "application/json", Schemas.RecallContextResponse},
@@ -343,7 +349,7 @@ defmodule LoopctlWeb.MemoryController do
 
   defp context_with_project(conn, params, project_id) do
     with_scope(conn, project_id, fn scope ->
-      case coerce_query(params["query"]) do
+      case coerce_context_query(params["query"]) do
         {:ok, query} ->
           opts =
             [query: query, limit: params["limit"]]
@@ -357,16 +363,42 @@ defmodule LoopctlWeb.MemoryController do
     end)
   end
 
+  # Coerce + trim the merged-recall query ONCE at the boundary, treating blank/
+  # whitespace-only uniformly across both halves. The knowledge half
+  # (`search_combined/3`) trims and rejects blank with `{:error, :empty_query}` while
+  # the memory half would ILIKE the untrimmed whitespace — so an absent/blank query
+  # previously yielded a confusing "memory-only with a spuriously degraded knowledge
+  # side" response and false `degraded?` alerts. The merged recall REQUIRES a non-blank
+  # query (the knowledge half is its point), so blank input is a clean 422 up front —
+  # matching the sibling knowledge search/context endpoints, not the degraded path.
+  defp coerce_context_query(query) do
+    with {:ok, coerced} <- coerce_query(query),
+         trimmed = String.trim(coerced),
+         false <- trimmed == "" do
+      {:ok, trimmed}
+    else
+      _ -> :error
+    end
+  end
+
   # Knowledge-side read scoping for the merged recall, mirroring
   # `KnowledgeContextController`: agent/orchestrator keys are forced to `:published`
   # articles, and the agent-memory visibility scope (#163) hides other agents'
-  # private/owner memories. Higher roles pass neither (see everything, all statuses).
+  # private/owner memories. `:api_key_id` is threaded so `search_combined/3` records
+  # knowledge read-access analytics for /recall traffic (the sibling search/context
+  # endpoints set it too; without it the analytics guard silently records nothing).
+  #
+  # Higher roles (user/superadmin) pass NO `:status`, but `search_keyword`/
+  # `search_semantic` default `:status` to `:published`, so — unlike `/knowledge/context`
+  # (which accepts a `?status` override) — this endpoint has NO override and returns
+  # published-only knowledge for EVERY role, not "all statuses".
   defp knowledge_scope_opts(conn) do
     role = conn.assigns.current_api_key.role
     role_atom = if is_binary(role), do: String.to_existing_atom(role), else: role
 
     conn
     |> Visibility.scope_opts()
+    |> Keyword.put(:api_key_id, conn.assigns.current_api_key.id)
     |> maybe_force_published(role_atom)
   end
 

--- a/lib/loopctl_web/controllers/memory_controller.ex
+++ b/lib/loopctl_web/controllers/memory_controller.ex
@@ -8,6 +8,11 @@ defmodule LoopctlWeb.MemoryController do
   - `POST   /api/v1/memory/promote` — trigger session→long-term promotion (US-29.3)
   - `GET    /api/v1/memory`         — list (limit/offset + total_count meta)
   - `DELETE /api/v1/memory/:id`     — forget
+  - `POST   /api/v1/recall`         — MERGED recall: one round-trip returning the
+    re-ranked `global ∪ active-project` union of long-term memory AND knowledge
+    (`Loopctl.Memory.recall_context/2`, #411 Gap 2). Reuses the same key-derived
+    `(tenant_id, subject_id)` scope + `project_id` partition + 422 envelopes as
+    `/memory/recall`.
 
   ## Scope is derived from the KEY, never the body (AC-28.3.2)
 
@@ -43,7 +48,9 @@ defmodule LoopctlWeb.MemoryController do
   alias Loopctl.ApiSpec.Schemas
   alias Loopctl.Memory
   alias Loopctl.Memory.Scope
+  alias LoopctlWeb.Helpers.Visibility
   alias LoopctlWeb.MemoryJSON
+  alias LoopctlWeb.RecallJSON
 
   action_fallback LoopctlWeb.FallbackController
 
@@ -111,6 +118,38 @@ defmodule LoopctlWeb.MemoryController do
     request_body: {"Recall params", "application/json", Schemas.MemoryRecallRequest},
     responses: %{
       200 => {"Recall results", "application/json", Schemas.MemoryRecallResponse},
+      422 =>
+        {"Subject unresolvable, non-string query, or invalid project_id", "application/json",
+         Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError},
+      503 => {"Tenant custody halted", "application/json", Schemas.ErrorResponse}
+    }
+  )
+
+  operation(:context,
+    summary: "Merged recall (memory ∪ knowledge, one round-trip)",
+    description:
+      "Returns ONE merged, re-ranked result combining the caller's long-term MEMORY " <>
+        "recall AND the KNOWLEDGE combined search for `(query, project_id)` — the " <>
+        "`global ∪ active-project` union the harness previously assembled by calling " <>
+        "`/memory/recall` and `/knowledge/context` separately (#411 Gap 2). Both sides " <>
+        "merge global with the active project: an absent/blank `project_id` returns " <>
+        "global-only memory + no-project-filter knowledge; a present `project_id` merges " <>
+        "global with that project on BOTH sides (another project's rows are excluded). " <>
+        "`project_id` is a PARTITION key, NOT the isolation boundary — `(tenant_id, " <>
+        "subject_id)` is, and is derived from the API key, never the body. A malformed " <>
+        "`project_id` is a 422 (`invalid_project_id`); a non-string `query` is a 422 " <>
+        "(`invalid_query`). The response carries the merged `results` (each tagged " <>
+        "`source: memory|knowledge`, sorted by a heuristically-comparable `score` DESC) " <>
+        "PLUS the untouched per-source `memory` and `knowledge` envelopes so callers can " <>
+        "re-rank. Cross-source scores are heuristic, not calibrated (memory = cosine " <>
+        "similarity; knowledge = pool-normalized keyword+semantic). If the knowledge " <>
+        "search errors or degrades to keyword-only the memory side is still returned and " <>
+        "`meta.degraded?` is true — never a 500. Agent role is forced to published " <>
+        "articles and its own/`shared` memories (#163).",
+    request_body: {"Recall params", "application/json", Schemas.RecallContextRequest},
+    responses: %{
+      200 => {"Merged recall results", "application/json", Schemas.RecallContextResponse},
       422 =>
         {"Subject unresolvable, non-string query, or invalid project_id", "application/json",
          Schemas.ErrorResponse},
@@ -290,6 +329,51 @@ defmodule LoopctlWeb.MemoryController do
       end
     end)
   end
+
+  @doc "POST /api/v1/recall"
+  def context(conn, params) do
+    case parse_project_id(params["project_id"]) do
+      {:ok, project_id} ->
+        context_with_project(conn, params, project_id)
+
+      :error ->
+        invalid_project_id(conn)
+    end
+  end
+
+  defp context_with_project(conn, params, project_id) do
+    with_scope(conn, project_id, fn scope ->
+      case coerce_query(params["query"]) do
+        {:ok, query} ->
+          opts =
+            [query: query, limit: params["limit"]]
+            |> Keyword.merge(knowledge_scope_opts(conn))
+
+          json(conn, RecallJSON.context(Memory.recall_context(scope, opts)))
+
+        :error ->
+          invalid_query(conn)
+      end
+    end)
+  end
+
+  # Knowledge-side read scoping for the merged recall, mirroring
+  # `KnowledgeContextController`: agent/orchestrator keys are forced to `:published`
+  # articles, and the agent-memory visibility scope (#163) hides other agents'
+  # private/owner memories. Higher roles pass neither (see everything, all statuses).
+  defp knowledge_scope_opts(conn) do
+    role = conn.assigns.current_api_key.role
+    role_atom = if is_binary(role), do: String.to_existing_atom(role), else: role
+
+    conn
+    |> Visibility.scope_opts()
+    |> maybe_force_published(role_atom)
+  end
+
+  defp maybe_force_published(opts, role) when role in [:agent, :orchestrator],
+    do: Keyword.put(opts, :status, :published)
+
+  defp maybe_force_published(opts, _role), do: opts
 
   @doc "POST /api/v1/memory/promote"
   def promote(conn, params) do

--- a/lib/loopctl_web/controllers/memory_controller.ex
+++ b/lib/loopctl_web/controllers/memory_controller.ex
@@ -63,6 +63,12 @@ defmodule LoopctlWeb.MemoryController do
 
   @memory_attr_keys ~w(tier text session_id role content expires_at confidence source_session_id tags metadata)
 
+  # The merged-recall query length cap, mirroring the knowledge half's
+  # `Loopctl.Knowledge.validate_query_string/1` 500-char limit so `/recall` rejects an
+  # over-length query at the boundary (BEFORE the shared embedding call) exactly as the
+  # standalone `/knowledge/search` does — never half-degrading to a memory-only 200.
+  @max_context_query_length 500
+
   operation(:create,
     summary: "Remember (write a memory)",
     description:
@@ -143,22 +149,32 @@ defmodule LoopctlWeb.MemoryController do
         "excluded). `project_id` is a PARTITION key, NOT the isolation boundary — " <>
         "`(tenant_id, subject_id)` is, and is derived from the API key, never the body. " <>
         "A malformed `project_id` is a 422 (`invalid_project_id`); a non-string, " <>
-        "missing, or blank/whitespace-only `query` is a 422 (`invalid_query`). The " <>
+        "missing, or blank/whitespace-only `query` is a 422 (`invalid_query`); a query " <>
+        "longer than 500 characters is a 422 (`query_too_long`) — rejected up front " <>
+        "(matching `/knowledge/search`) BEFORE any embedding is generated, never a " <>
+        "half-degraded memory-only 200. The " <>
         "response carries the merged `results` (each tagged `source: memory|knowledge`, " <>
         "sorted by a heuristically-comparable `score` DESC — `meta.results_ranking` is " <>
         "`heuristic_cross_source`) PLUS the untouched per-source `memory` and " <>
         "`knowledge` envelopes so callers can re-rank. Cross-source scores are " <>
         "heuristic, not calibrated (memory = absolute cosine similarity; knowledge = " <>
         "pool-normalized keyword+semantic, which biases knowledge UPWARD in the default " <>
-        "order). If the knowledge search errors or degrades to keyword-only the memory " <>
-        "side is still returned and `meta.degraded?` is true — never a 500. Agent role " <>
+        "order). On a DEGRADED knowledge side (keyword-only fallback) memory rows carry " <>
+        "absolute cosine scores while knowledge rows carry raw (un-normalized) keyword " <>
+        "`relevance_score`, which can outrank memory in the merged `data` — callers who " <>
+        "need memory-first ordering under degradation should read the per-source `memory` " <>
+        "envelope (it preserves the honest native scores). If the knowledge search " <>
+        "errors or degrades to keyword-only, OR the memory heavy-read pool is shed under " <>
+        "the per-tenant cap, the OTHER side is still returned and `meta.degraded?` is " <>
+        "true (`meta.degraded_reason` names why) — never a 500 and never a whole-endpoint " <>
+        "429 from one shed pool. Agent role " <>
         "is forced to published articles and its own/`shared` memories (#163).",
     request_body: {"Recall params", "application/json", Schemas.RecallContextRequest},
     responses: %{
       200 => {"Merged recall results", "application/json", Schemas.RecallContextResponse},
       422 =>
-        {"Subject unresolvable, non-string query, or invalid project_id", "application/json",
-         Schemas.ErrorResponse},
+        {"Subject unresolvable, non-string/blank/over-length query, or invalid project_id",
+         "application/json", Schemas.ErrorResponse},
       429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError},
       503 => {"Tenant custody halted", "application/json", Schemas.ErrorResponse}
     }
@@ -357,27 +373,38 @@ defmodule LoopctlWeb.MemoryController do
 
           json(conn, RecallJSON.context(Memory.recall_context(scope, opts)))
 
-        :error ->
+        {:error, :query_too_long} ->
+          query_too_long(conn)
+
+        {:error, :invalid_query} ->
           invalid_query(conn)
       end
     end)
   end
 
   # Coerce + trim the merged-recall query ONCE at the boundary, treating blank/
-  # whitespace-only uniformly across both halves. The knowledge half
-  # (`search_combined/3`) trims and rejects blank with `{:error, :empty_query}` while
-  # the memory half would ILIKE the untrimmed whitespace — so an absent/blank query
-  # previously yielded a confusing "memory-only with a spuriously degraded knowledge
-  # side" response and false `degraded?` alerts. The merged recall REQUIRES a non-blank
-  # query (the knowledge half is its point), so blank input is a clean 422 up front —
-  # matching the sibling knowledge search/context endpoints, not the degraded path.
+  # whitespace-only AND over-length uniformly across both halves. The knowledge half
+  # (`search_combined/3` → `validate_query_string/1`) trims, rejects blank with
+  # `{:error, :empty_query}`, AND rejects > #{@max_context_query_length}-char queries
+  # with `{:error, :bad_request, _}`; the memory half would ILIKE/embed the untrimmed
+  # value regardless. So an absent/blank OR an over-length query previously yielded a
+  # confusing "memory-only with a spuriously degraded knowledge side" response and a
+  # false `degraded?` alert — AND the over-length case additionally spent an outbound
+  # embedding provider call on the full (multi-KB) query BEFORE the knowledge cap
+  # rejected it. The merged recall REQUIRES a non-blank, ≤ #{@max_context_query_length}-
+  # char query (the knowledge half is its point), so both are a clean 422 up front —
+  # matching the sibling knowledge search/context endpoints, not the degraded path, and
+  # rejecting BEFORE `recall_context/2` generates the shared embedding.
   defp coerce_context_query(query) do
     with {:ok, coerced} <- coerce_query(query),
          trimmed = String.trim(coerced),
-         false <- trimmed == "" do
+         {:blank, false} <- {:blank, trimmed == ""},
+         {:too_long, false} <-
+           {:too_long, String.length(trimmed) > @max_context_query_length} do
       {:ok, trimmed}
     else
-      _ -> :error
+      {:too_long, true} -> {:error, :query_too_long}
+      _ -> {:error, :invalid_query}
     end
   end
 
@@ -625,6 +652,21 @@ defmodule LoopctlWeb.MemoryController do
         status: 422,
         code: "invalid_query",
         message: "The `query` field must be a string."
+      }
+    })
+  end
+
+  # Reject an over-length merged-recall query with a distinct 422 BEFORE any embedding
+  # is generated, matching the knowledge half's 500-char cap. A generic `invalid_query`
+  # would mislead ("must be a string"), so this names the length constraint explicitly.
+  defp query_too_long(conn) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{
+      error: %{
+        status: 422,
+        code: "query_too_long",
+        message: "The `query` must be at most #{@max_context_query_length} characters."
       }
     })
   end

--- a/lib/loopctl_web/controllers/recall_json.ex
+++ b/lib/loopctl_web/controllers/recall_json.ex
@@ -10,15 +10,20 @@ defmodule LoopctlWeb.RecallJSON do
   - A `:memory` merged item pairs its long-term `%Memory{}` (rendered via
     `MemoryJSON.memory_data/1`, so the raw embedding is never leaked) with its cosine
     similarity `score` (`null` on the memory ILIKE fallback path).
-  - A `:knowledge` merged item carries the `search_combined/3` result map (article
-    summary + scores — the same shape the knowledge search endpoints return) and its
-    pool-normalized combined `score`.
+  - A `:knowledge` merged item carries the article SUMMARY — projected through
+    `KnowledgeSearchJSON.render_result/2` (the canonical combined-search view:
+    `{id, title, category, tags, score, snippet}` truncated), the EXACT shape the
+    knowledge search endpoints serialize — plus its pool-normalized combined `score`.
+    Internal scoring fields (`relevance_score`/`normalized_score`/`final_score`),
+    `status`, `tenant_id`, `project_id`, and timestamps are intentionally NOT exposed
+    here, matching those endpoints.
 
   Cross-source `score`s are heuristically comparable, not calibrated (see the context
-  function's `@doc`).
+  function's `@doc`); `meta.results_ranking` carries the `"heuristic_cross_source"`
+  tag so consumers can detect this programmatically.
   """
 
-  alias LoopctlWeb.MemoryJSON
+  alias LoopctlWeb.{KnowledgeSearchJSON, MemoryJSON}
 
   @doc """
   Renders the merged recall: `data` (merged, re-ranked), `memory` + `knowledge`
@@ -28,7 +33,7 @@ defmodule LoopctlWeb.RecallJSON do
     %{
       data: Enum.map(results, &merged_item/1),
       memory: MemoryJSON.recall(memory),
-      knowledge: %{data: knowledge.results, meta: knowledge.meta},
+      knowledge: %{data: Enum.map(knowledge.results, &knowledge_summary/1), meta: knowledge.meta},
       meta: meta_json(meta)
     }
   end
@@ -38,8 +43,14 @@ defmodule LoopctlWeb.RecallJSON do
   end
 
   defp merged_item(%{source: :knowledge, score: score, article: article}) do
-    %{source: "knowledge", score: score, article: article}
+    %{source: "knowledge", score: score, article: knowledge_summary(article)}
   end
+
+  # Project a raw `search_combined/3` result map through the canonical combined-search
+  # summary view so /recall emits the SAME whitelisted shape ({id, title, category,
+  # tags, score, snippet}) the knowledge search endpoints do — never the raw map with
+  # its internal scoring fields, status, tenant_id, project_id, and timestamps.
+  defp knowledge_summary(result), do: KnowledgeSearchJSON.render_result(result, "combined")
 
   # `degraded?` (atom key with a trailing `?`) is the internal flag; expose it as the
   # clean JSON key `degraded`.
@@ -50,7 +61,10 @@ defmodule LoopctlWeb.RecallJSON do
       total_count: meta.total_count,
       memory_count: meta.memory_count,
       knowledge_count: meta.knowledge_count,
-      degraded: meta.degraded?
+      degraded: meta.degraded?,
+      # Stable tag warning that the merged `data` order is a cross-source heuristic
+      # (memory absolute cosine vs knowledge pool-normalized), NOT calibrated relevance.
+      results_ranking: meta.results_ranking
     }
   end
 end

--- a/lib/loopctl_web/controllers/recall_json.ex
+++ b/lib/loopctl_web/controllers/recall_json.ex
@@ -21,6 +21,13 @@ defmodule LoopctlWeb.RecallJSON do
   Cross-source `score`s are heuristically comparable, not calibrated (see the context
   function's `@doc`); `meta.results_ranking` carries the `"heuristic_cross_source"`
   tag so consumers can detect this programmatically.
+
+  The knowledge envelope's `meta` is ALSO projected — through
+  `KnowledgeSearchJSON.render_meta/1`, the same whitelist the standalone knowledge
+  endpoints use — so both results AND meta match that shape. The raw context meta's
+  internal `error` reason atom is never passed through; only the bounded `fallback_reason`
+  tag survives (plus the merged-recall `degraded` flag). The top-level `meta` adds
+  `degraded_reason`, a bounded tag naming why a half degraded (or `null`).
   """
 
   alias LoopctlWeb.{KnowledgeSearchJSON, MemoryJSON}
@@ -33,9 +40,25 @@ defmodule LoopctlWeb.RecallJSON do
     %{
       data: Enum.map(results, &merged_item/1),
       memory: MemoryJSON.recall(memory),
-      knowledge: %{data: Enum.map(knowledge.results, &knowledge_summary/1), meta: knowledge.meta},
+      knowledge: %{
+        data: Enum.map(knowledge.results, &knowledge_summary/1),
+        meta: knowledge_meta(knowledge.meta)
+      },
       meta: meta_json(meta)
     }
+  end
+
+  # Project the knowledge envelope meta through the SAME `KnowledgeSearchJSON.render_meta`
+  # whitelist the standalone knowledge search endpoints use, then re-attach the merged-
+  # recall `degraded` flag. This keeps the moduledoc's promise (the knowledge side is the
+  # EXACT shape the knowledge search endpoints serialize) for META as well as results:
+  # the raw context meta's internal `error` reason atom (an internal capacity/validation
+  # signal `/knowledge/search` would strip) is NEVER passed through — only the bounded
+  # `fallback_reason` tag survives, exactly as on `/knowledge/search`.
+  defp knowledge_meta(meta) do
+    meta
+    |> KnowledgeSearchJSON.render_meta()
+    |> Map.put(:degraded, Map.get(meta, :degraded?, false))
   end
 
   defp merged_item(%{source: :memory, score: score, memory: memory}) do
@@ -62,6 +85,9 @@ defmodule LoopctlWeb.RecallJSON do
       memory_count: meta.memory_count,
       knowledge_count: meta.knowledge_count,
       degraded: meta.degraded?,
+      # A bounded, non-sensitive tag naming WHY the merged recall degraded (or `null`),
+      # so a caller can distinguish a scope-empty half from a fault-empty one.
+      degraded_reason: meta.degraded_reason,
       # Stable tag warning that the merged `data` order is a cross-source heuristic
       # (memory absolute cosine vs knowledge pool-normalized), NOT calibrated relevance.
       results_ranking: meta.results_ranking

--- a/lib/loopctl_web/controllers/recall_json.ex
+++ b/lib/loopctl_web/controllers/recall_json.ex
@@ -1,0 +1,56 @@
+defmodule LoopctlWeb.RecallJSON do
+  @moduledoc """
+  JSON rendering for the merged recall endpoint (`POST /api/v1/recall`, #411 Gap 2).
+
+  Serializes `Loopctl.Memory.recall_context/2`'s envelope: the merged, re-ranked
+  `results` (each tagged `source: "memory" | "knowledge"`) PLUS the untouched
+  per-source `memory` and `knowledge` envelopes so a caller can re-rank without a
+  second round-trip.
+
+  - A `:memory` merged item pairs its long-term `%Memory{}` (rendered via
+    `MemoryJSON.memory_data/1`, so the raw embedding is never leaked) with its cosine
+    similarity `score` (`null` on the memory ILIKE fallback path).
+  - A `:knowledge` merged item carries the `search_combined/3` result map (article
+    summary + scores — the same shape the knowledge search endpoints return) and its
+    pool-normalized combined `score`.
+
+  Cross-source `score`s are heuristically comparable, not calibrated (see the context
+  function's `@doc`).
+  """
+
+  alias LoopctlWeb.MemoryJSON
+
+  @doc """
+  Renders the merged recall: `data` (merged, re-ranked), `memory` + `knowledge`
+  (per-source envelopes), and `meta` (counts + degraded flag).
+  """
+  def context(%{results: results, memory: memory, knowledge: knowledge, meta: meta}) do
+    %{
+      data: Enum.map(results, &merged_item/1),
+      memory: MemoryJSON.recall(memory),
+      knowledge: %{data: knowledge.results, meta: knowledge.meta},
+      meta: meta_json(meta)
+    }
+  end
+
+  defp merged_item(%{source: :memory, score: score, memory: memory}) do
+    %{source: "memory", score: score, memory: MemoryJSON.memory_data(memory)}
+  end
+
+  defp merged_item(%{source: :knowledge, score: score, article: article}) do
+    %{source: "knowledge", score: score, article: article}
+  end
+
+  # `degraded?` (atom key with a trailing `?`) is the internal flag; expose it as the
+  # clean JSON key `degraded`.
+  defp meta_json(meta) do
+    %{
+      query: meta.query,
+      project_id: meta.project_id,
+      total_count: meta.total_count,
+      memory_count: meta.memory_count,
+      knowledge_count: meta.knowledge_count,
+      degraded: meta.degraded?
+    }
+  end
+end

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -325,6 +325,11 @@ defmodule LoopctlWeb.Router do
     get "/memory", MemoryController, :index
     delete "/memory/:id", MemoryController, :delete
 
+    # Merged recall (Epic 28 / #411 Gap 2) — ONE round-trip returning the re-ranked
+    # `global ∪ active-project` union of long-term memory AND knowledge. Reuses the
+    # MemoryController scope-from-key + project-partition helpers.
+    post "/recall", MemoryController, :context
+
     # Context Retriever (Epic 30, US-30.4) — entity-definition CRUD + the
     # model-invoked query surface. Literal /retrieve/tools MUST precede the
     # parameterized /retrieve/:entity so it is not captured as an :entity.

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -1222,6 +1222,26 @@ async function memoryRecall({ query, limit, include_superseded }) {
   return toContent(result);
 }
 
+async function recallContext({ query, project_id, limit }) {
+  // Merged recall (#411 Gap 2): ONE round-trip returning the re-ranked
+  // global ∪ active-project union of long-term MEMORY and KNOWLEDGE. Scope
+  // (tenant_id/subject_id) is derived server-side from the agent key; project_id is
+  // the partition key (merges global with that project on BOTH sides).
+  const payload = { query };
+  if (project_id) payload.project_id = project_id;
+  if (limit != null) payload.limit = limit;
+
+  const result = await apiCall(
+    "POST",
+    "/api/v1/recall",
+    payload,
+    process.env.LOOPCTL_AGENT_KEY,
+  );
+  // Surface both per-source metas (memory fallback/underfilled + knowledge degraded)
+  // so the caller can tell a degraded recall from a genuinely empty scope.
+  return toContent(result);
+}
+
 async function memoryList({ limit, offset, include_superseded, all_subjects }) {
   // all_subjects is superadmin-only server-side; a non-superadmin key sending
   // this is ignored (falls back to its own subject) rather than erroring — the
@@ -3529,6 +3549,45 @@ const TOOLS = [
     },
   },
   {
+    name: "recall_context",
+    description:
+      "MERGED recall in ONE round-trip: the re-ranked global ∪ active-project union of " +
+      "your long-term MEMORY (private working state) AND the shared KNOWLEDGE wiki for " +
+      "`query` — instead of calling memory_recall and knowledge_context/knowledge_search " +
+      "separately and merging by hand (#411 Gap 2). Both sides merge global with the " +
+      "active project: pass project_id to include that project's rows alongside global " +
+      "ones on BOTH sides (another project's rows are excluded); omit it for global-only. " +
+      "project_id is a PARTITION key, NOT isolation — scope (tenant/subject) is resolved " +
+      "server-side from your key. Returns `data` (merged, each item tagged source: " +
+      "memory|knowledge, sorted by a heuristically-comparable score DESC) PLUS the " +
+      "untouched per-source `memory` and `knowledge` envelopes so you can re-rank. " +
+      "Cross-source scores are heuristic, not calibrated. If the knowledge search " +
+      "degrades (embedding unavailable) or errors, the memory side is still returned and " +
+      "meta.degraded is true — never a hard failure.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "Text to embed / match against on BOTH the memory and knowledge sides.",
+        },
+        project_id: {
+          type: "string",
+          format: "uuid",
+          description:
+            "Optional: partition scope. Present → both sides return global ∪ that project; " +
+            "omit → global-only.",
+        },
+        limit: {
+          type: "integer",
+          description:
+            "Optional: overall merged page size, clamped to [1, 50] (default 10).",
+        },
+      },
+      required: ["query"],
+    },
+  },
+  {
     name: "memory_list",
     description:
       "List YOUR OWN long-term memories, newest first — private, scoped working state, " +
@@ -4880,6 +4939,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     case "memory_recall":
       return await memoryRecall(args);
+    case "recall_context":
+      return await recallContext(args);
 
     case "memory_list":
       return await memoryList(args);

--- a/mcp-server/test/mcp_arg_forwarding.test.js
+++ b/mcp-server/test/mcp_arg_forwarding.test.js
@@ -115,6 +115,39 @@ describe("#411 gap1: resolve_project wiring", () => {
 });
 
 // ---------------------------------------------------------------------------
+// #411 gap2 (PR B): recall_context (merged memory ∪ knowledge, one round-trip)
+// ---------------------------------------------------------------------------
+
+describe("#411 gap2: recall_context wiring", () => {
+  test("TOOLS declares a recall_context tool requiring query", () => {
+    assert.match(INDEX_SRC, /name: "recall_context",/, 'must declare a "recall_context" tool');
+    assert.match(
+      INDEX_SRC,
+      /name: "recall_context",[\s\S]*?required: \["query"\],/,
+      "the recall_context tool must require query",
+    );
+  });
+
+  test("recallContext POSTs /api/v1/recall with query/project_id/limit on the agent key", () => {
+    assert.match(
+      INDEX_SRC,
+      /async function recallContext\(\{ query, project_id, limit \}\) \{[\s\S]*?"POST",\s*\n\s*"\/api\/v1\/recall",[\s\S]*?LOOPCTL_AGENT_KEY/,
+      "recallContext must POST /api/v1/recall on the agent key",
+    );
+    assert.match(INDEX_SRC, /const payload = \{ query \};\s*\n\s*if \(project_id\) payload\.project_id = project_id;/);
+    assert.match(INDEX_SRC, /if \(limit != null\) payload\.limit = limit;/);
+  });
+
+  test("the recall_context dispatch case calls recallContext(args)", () => {
+    assert.match(
+      INDEX_SRC,
+      /case "recall_context":\s*\n\s*return await recallContext\(args\);/,
+      "the recall_context dispatch case must call recallContext(args)",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // #248 (mcp-02): knowledge_ingestion_jobs forwards limit/offset/since_days
 // ---------------------------------------------------------------------------
 

--- a/test/loopctl/knowledge_project_scope_test.exs
+++ b/test/loopctl/knowledge_project_scope_test.exs
@@ -1,0 +1,116 @@
+defmodule Loopctl.KnowledgeProjectScopeTest do
+  @moduledoc """
+  #411 Gap 2 (PR B): the `:project_scope` option on `search_combined/3`.
+
+  `:strict` (the DEFAULT) keeps the historical project-only filter for every existing
+  caller; `:with_global` switches to the merged `global ∪ project` predicate the merged
+  `Loopctl.Memory.recall_context/2` recall needs. These tests pin BOTH: that a default
+  strict combined search still returns project-only (regression guard) and that
+  `:with_global` additionally surfaces tenant-wide (global) articles — while a DIFFERENT
+  project's articles are excluded under either mode.
+  """
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.Knowledge
+
+  # Same-direction vectors → cosine distance 0 (all match semantically), so the project
+  # filter is the only thing separating the result sets.
+  defp query_vector, do: List.duplicate(1.0, 768) ++ List.duplicate(0.0, 768)
+
+  defp article(tenant_id, project_id, title) do
+    article =
+      fixture(:article, %{
+        tenant_id: tenant_id,
+        project_id: project_id,
+        status: :published,
+        title: title,
+        body: "telemetry deploy guide for #{title}"
+      })
+
+    {:ok, updated} = Knowledge.update_embedding(tenant_id, article.id, query_vector())
+    updated
+  end
+
+  defp stub_query_embedding do
+    Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+      {:ok, query_vector()}
+    end)
+  end
+
+  defp ids(results), do: results |> Enum.map(& &1.id) |> MapSet.new()
+
+  setup do
+    tenant = fixture(:tenant)
+    project = fixture(:project, %{tenant_id: tenant.id})
+    other_project = fixture(:project, %{tenant_id: tenant.id})
+    Knowledge.reset_circuit_breaker(tenant.id)
+    stub_query_embedding()
+
+    global = article(tenant.id, nil, "global article")
+    in_project = article(tenant.id, project.id, "project article")
+    other = article(tenant.id, other_project.id, "other project article")
+
+    %{
+      tenant: tenant,
+      project: project,
+      global: global,
+      in_project: in_project,
+      other: other
+    }
+  end
+
+  describe "search_combined/3 :project_scope" do
+    test "default (:strict) returns project-only — regression guard", ctx do
+      assert {:ok, %{results: results}} =
+               Knowledge.search_combined(ctx.tenant.id, "telemetry", project_id: ctx.project.id)
+
+      got = ids(results)
+      assert MapSet.member?(got, ctx.in_project.id)
+      refute MapSet.member?(got, ctx.global.id), "strict must NOT include the global article"
+      refute MapSet.member?(got, ctx.other.id), "strict must NOT include another project"
+    end
+
+    test "explicit :strict matches the default (project-only)", ctx do
+      assert {:ok, %{results: results}} =
+               Knowledge.search_combined(ctx.tenant.id, "telemetry",
+                 project_id: ctx.project.id,
+                 project_scope: :strict
+               )
+
+      got = ids(results)
+      assert MapSet.equal?(got, MapSet.new([ctx.in_project.id]))
+    end
+
+    test ":with_global returns global ∪ project, excludes another project", ctx do
+      assert {:ok, %{results: results}} =
+               Knowledge.search_combined(ctx.tenant.id, "telemetry",
+                 project_id: ctx.project.id,
+                 project_scope: :with_global
+               )
+
+      got = ids(results)
+
+      assert MapSet.member?(got, ctx.in_project.id),
+             "with_global must include the project article"
+
+      assert MapSet.member?(got, ctx.global.id), "with_global must include the global article"
+      refute MapSet.member?(got, ctx.other.id), "with_global must still exclude another project"
+    end
+
+    test ":with_global with a nil project_id is global ∪ everything (no project filter)", ctx do
+      # scope_project_or_global(query, nil) is a no-op, so a nil project under with_global
+      # applies no project filter at all — every in-tenant article matches.
+      assert {:ok, %{results: results}} =
+               Knowledge.search_combined(ctx.tenant.id, "telemetry", project_scope: :with_global)
+
+      got = ids(results)
+
+      assert MapSet.subset?(
+               MapSet.new([ctx.global.id, ctx.in_project.id, ctx.other.id]),
+               got
+             )
+    end
+  end
+end

--- a/test/loopctl/knowledge_project_scope_test.exs
+++ b/test/loopctl/knowledge_project_scope_test.exs
@@ -99,18 +99,23 @@ defmodule Loopctl.KnowledgeProjectScopeTest do
       refute MapSet.member?(got, ctx.other.id), "with_global must still exclude another project"
     end
 
-    test ":with_global with a nil project_id is global ∪ everything (no project filter)", ctx do
-      # scope_project_or_global(query, nil) is a no-op, so a nil project under with_global
-      # applies no project filter at all — every in-tenant article matches.
+    test ":with_global with a nil project_id is GLOBAL-ONLY (project_id IS NULL)", ctx do
+      # With no active project the `:with_global` union is global-only: a nil project_id
+      # scopes to `project_id IS NULL` (matching the merged-recall contract and the
+      # memory half), NOT the former no-op that returned every project's articles.
       assert {:ok, %{results: results}} =
                Knowledge.search_combined(ctx.tenant.id, "telemetry", project_scope: :with_global)
 
       got = ids(results)
 
-      assert MapSet.subset?(
-               MapSet.new([ctx.global.id, ctx.in_project.id, ctx.other.id]),
-               got
-             )
+      assert MapSet.member?(got, ctx.global.id),
+             "with_global + nil must include the global article"
+
+      refute MapSet.member?(got, ctx.in_project.id),
+             "with_global + nil must exclude project articles"
+
+      refute MapSet.member?(got, ctx.other.id),
+             "with_global + nil must exclude other-project articles"
     end
   end
 end

--- a/test/loopctl/memory_recall_context_test.exs
+++ b/test/loopctl/memory_recall_context_test.exs
@@ -109,11 +109,12 @@ defmodule Loopctl.MemoryRecallContextTest do
       assert %{article: %{final_score: _}, score: _} = know_item
     end
 
-    test "a nil-project scope is global-only on MEMORY; knowledge applies no project filter" do
-      # Documented asymmetry (#411 Gap 2): memory's nil semantics are global-only
-      # (`project_id IS NULL` rows), but Knowledge has no 'global-only' mode — a nil
-      # project_id under `:with_global` (or strict) is a no-op filter, so the knowledge
-      # side returns ALL the tenant's matching articles (global + project-tagged alike).
+    test "a nil-project scope is global-only on BOTH memory and knowledge" do
+      # With no active project the `global ∪ active-project` union is GLOBAL-ONLY on
+      # BOTH sides (matching the published RecallContextRequest / MCP recall_context
+      # contract). Memory's nil semantics scope to `project_id IS NULL`; knowledge's
+      # `:with_global` mode ALSO scopes a nil project to `project_id IS NULL` (rather
+      # than the former no-op that flooded the merged limit with every project's rows).
       tenant = fixture(:tenant)
       project = fixture(:project, %{tenant_id: tenant.id})
       Knowledge.reset_circuit_breaker(tenant.id)
@@ -137,10 +138,10 @@ defmodule Loopctl.MemoryRecallContextTest do
       assert MapSet.equal?(memory_ids(result.memory), MapSet.new([global_mem.id]))
       refute MapSet.member?(memory_ids(result.memory), project_mem.id)
 
-      # Knowledge: no project filter → BOTH the global and the project-tagged article.
+      # Knowledge: global-only too → the global article, NOT the project-tagged one.
       k_ids = knowledge_ids(result.knowledge)
       assert MapSet.member?(k_ids, global_art.id)
-      assert MapSet.member?(k_ids, project_art.id)
+      refute MapSet.member?(k_ids, project_art.id)
     end
   end
 

--- a/test/loopctl/memory_recall_context_test.exs
+++ b/test/loopctl/memory_recall_context_test.exs
@@ -1,0 +1,176 @@
+defmodule Loopctl.MemoryRecallContextTest do
+  @moduledoc """
+  #411 Gap 2 (PR B): `Loopctl.Memory.recall_context/2` — the merged, re-ranked
+  `global ∪ active-project` recall combining long-term MEMORY and KNOWLEDGE in one call.
+
+  Covers: both sides merge global with the active project and EXCLUDE another project;
+  the merged list is tagged per-source and sorted by score DESC; the per-source
+  envelopes are returned unchanged; and a knowledge fault degrades gracefully to a
+  memory-only result with `degraded?: true` (never a crash).
+
+  Async: memory OLTP + recall route through `Loopctl.AdminRepo`/`Loopctl.HeavyRead`
+  (AdminRepo in test) and knowledge through `AdminRepo`, so every path shares the one
+  sandbox connection; the embedding worker runs inline during `remember/2`.
+  """
+  use Loopctl.DataCase, async: true
+  use Oban.Testing, repo: Loopctl.Repo
+
+  setup :verify_on_exit!
+
+  alias Loopctl.Knowledge
+  alias Loopctl.Memory
+  alias Loopctl.Memory.Scope
+
+  defp article(tenant_id, project_id, title) do
+    art =
+      fixture(:article, %{
+        tenant_id: tenant_id,
+        project_id: project_id,
+        status: :published,
+        title: title,
+        body: "reshipment policy notes for #{title}"
+      })
+
+    {:ok, updated} = Knowledge.update_embedding(tenant_id, art.id, List.duplicate(0.1, 1536))
+    updated
+  end
+
+  defp mem(scope, project_id, text) do
+    {:ok, m} = Memory.remember(%{scope | project_id: project_id}, %{tier: :long_term, text: text})
+    m
+  end
+
+  defp memory_ids(env), do: env.results |> Enum.map(fn {m, _} -> m.id end) |> MapSet.new()
+  defp knowledge_ids(env), do: env.results |> Enum.map(& &1.id) |> MapSet.new()
+
+  setup do
+    tenant = fixture(:tenant)
+    project = fixture(:project, %{tenant_id: tenant.id})
+    other_project = fixture(:project, %{tenant_id: tenant.id})
+    Knowledge.reset_circuit_breaker(tenant.id)
+
+    scope = %Scope{
+      tenant_id: tenant.id,
+      subject_id: "subject-#{System.unique_integer([:positive])}",
+      project_id: project.id
+    }
+
+    %{tenant: tenant, project: project, other_project: other_project, scope: scope}
+  end
+
+  describe "recall_context/2 - merged global ∪ active-project" do
+    test "merges memory + knowledge, both scopes, excludes another project", ctx do
+      # Memory: global + this project + another project.
+      global_mem = mem(ctx.scope, nil, "reshipment for delayed orders global")
+      project_mem = mem(ctx.scope, ctx.project.id, "reshipment for delayed orders project")
+      other_mem = mem(ctx.scope, ctx.other_project.id, "reshipment for delayed orders other")
+
+      # Knowledge: global + this project + another project.
+      global_art = article(ctx.tenant.id, nil, "global article")
+      project_art = article(ctx.tenant.id, ctx.project.id, "project article")
+      other_art = article(ctx.tenant.id, ctx.other_project.id, "other project article")
+
+      result = Memory.recall_context(ctx.scope, query: "reshipment", limit: 20)
+
+      # Per-source memory: global ∪ project, NOT another project.
+      m_ids = memory_ids(result.memory)
+      assert MapSet.member?(m_ids, global_mem.id)
+      assert MapSet.member?(m_ids, project_mem.id)
+      refute MapSet.member?(m_ids, other_mem.id)
+
+      # Per-source knowledge: global ∪ project, NOT another project.
+      k_ids = knowledge_ids(result.knowledge)
+      assert MapSet.member?(k_ids, global_art.id)
+      assert MapSet.member?(k_ids, project_art.id)
+      refute MapSet.member?(k_ids, other_art.id)
+
+      # Merged list carries BOTH source tags.
+      sources = result.results |> Enum.map(& &1.source) |> MapSet.new()
+      assert MapSet.equal?(sources, MapSet.new([:memory, :knowledge]))
+
+      # Merged sorted by score DESC.
+      scores = Enum.map(result.results, & &1.score)
+      assert scores == Enum.sort(scores, :desc)
+
+      # Meta accounting.
+      assert result.meta.query == "reshipment"
+      assert result.meta.project_id == ctx.project.id
+      assert result.meta.degraded? == false
+      assert result.meta.memory_count == 2
+      assert result.meta.knowledge_count == 2
+      assert result.meta.total_count == length(result.results)
+
+      # Merged item shapes.
+      mem_item = Enum.find(result.results, &(&1.source == :memory))
+      assert %{memory: %Memory.Memory{}, score: score} = mem_item
+      assert is_number(score)
+
+      know_item = Enum.find(result.results, &(&1.source == :knowledge))
+      assert %{article: %{final_score: _}, score: _} = know_item
+    end
+
+    test "a nil-project scope is global-only on MEMORY; knowledge applies no project filter" do
+      # Documented asymmetry (#411 Gap 2): memory's nil semantics are global-only
+      # (`project_id IS NULL` rows), but Knowledge has no 'global-only' mode — a nil
+      # project_id under `:with_global` (or strict) is a no-op filter, so the knowledge
+      # side returns ALL the tenant's matching articles (global + project-tagged alike).
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      global_scope = %Scope{
+        tenant_id: tenant.id,
+        subject_id: "subject-#{System.unique_integer([:positive])}",
+        project_id: nil
+      }
+
+      project_scope = %{global_scope | project_id: project.id}
+
+      global_mem = mem(global_scope, nil, "reshipment global only")
+      project_mem = mem(project_scope, project.id, "reshipment project only")
+      global_art = article(tenant.id, nil, "global only article")
+      project_art = article(tenant.id, project.id, "project only article")
+
+      result = Memory.recall_context(global_scope, query: "reshipment", limit: 20)
+
+      # Memory: global-only (excludes the project-tagged memory).
+      assert MapSet.equal?(memory_ids(result.memory), MapSet.new([global_mem.id]))
+      refute MapSet.member?(memory_ids(result.memory), project_mem.id)
+
+      # Knowledge: no project filter → BOTH the global and the project-tagged article.
+      k_ids = knowledge_ids(result.knowledge)
+      assert MapSet.member?(k_ids, global_art.id)
+      assert MapSet.member?(k_ids, project_art.id)
+    end
+  end
+
+  describe "recall_context/2 - graceful knowledge degradation" do
+    test "an empty query degrades knowledge to memory-only with degraded?: true", ctx do
+      # An empty query is a knowledge fault (`search_combined/3` → {:error, :empty_query})
+      # but memory recall still returns rows — the merged call must not crash.
+      project_mem = mem(ctx.scope, ctx.project.id, "reshipment kept on empty query")
+
+      result = Memory.recall_context(ctx.scope, query: "", limit: 10)
+
+      assert result.knowledge.results == []
+      assert result.meta.knowledge_count == 0
+      assert result.meta.degraded? == true
+
+      # Memory side survived.
+      assert MapSet.member?(memory_ids(result.memory), project_mem.id)
+      assert Enum.all?(result.results, &(&1.source == :memory))
+    end
+  end
+
+  describe "recall_context/2 - overall merged limit" do
+    test "clamps the merged, re-ranked list to `limit`", ctx do
+      for i <- 1..4, do: mem(ctx.scope, ctx.project.id, "reshipment memory #{i}")
+      for i <- 1..4, do: article(ctx.tenant.id, ctx.project.id, "reshipment article #{i}")
+
+      result = Memory.recall_context(ctx.scope, query: "reshipment", limit: 3)
+
+      assert length(result.results) == 3
+      assert result.meta.total_count == 3
+    end
+  end
+end

--- a/test/loopctl_web/controllers/recall_controller_test.exs
+++ b/test/loopctl_web/controllers/recall_controller_test.exs
@@ -119,6 +119,65 @@ defmodule LoopctlWeb.RecallControllerTest do
       end
     end
 
+    test "an over-length (>500 char) query is rejected up front with a 422 query_too_long" do
+      tenant = fixture(:tenant)
+      {raw, _key, _agent} = agent_key(tenant.id)
+
+      # 501 chars: rejected at the boundary BEFORE any embedding is generated, so the
+      # knowledge half never half-degrades to an empty, spuriously-`degraded` 200.
+      body =
+        base_conn()
+        |> auth(raw)
+        |> post(~p"/api/v1/recall", %{"query" => String.duplicate("a", 501)})
+        |> json_response(422)
+
+      assert body["error"]["code"] == "query_too_long"
+      assert body["error"]["status"] == 422
+    end
+
+    test "a query of exactly 500 chars is accepted (boundary, returns 200)" do
+      tenant = fixture(:tenant)
+      {raw, _key, _agent} = agent_key(tenant.id)
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      body =
+        base_conn()
+        |> auth(raw)
+        |> post(~p"/api/v1/recall", %{"query" => String.duplicate("a", 500)})
+        |> json_response(200)
+
+      assert %{"meta" => _meta} = body
+    end
+
+    test "the knowledge envelope meta is the whitelisted search shape (no raw error atom)" do
+      tenant = fixture(:tenant)
+      {raw, _key, _agent} = agent_key(tenant.id)
+      Knowledge.reset_circuit_breaker(tenant.id)
+      _ = published_article(tenant.id, "reshipment guide")
+
+      body =
+        base_conn()
+        |> auth(raw)
+        |> post(~p"/api/v1/recall", %{"query" => "reshipments"})
+        |> json_response(200)
+
+      know_meta = body["knowledge"]["meta"]
+
+      # Projected through KnowledgeSearchJSON.render_meta: the canonical counters are
+      # present and the merged-recall `degraded` flag is re-attached...
+      assert Map.has_key?(know_meta, "total_count")
+      assert Map.has_key?(know_meta, "limit")
+      assert Map.has_key?(know_meta, "offset")
+      assert know_meta["degraded"] == false
+      # ...and the raw internal reason atom is NEVER passed through (unlike the old raw
+      # passthrough), matching what /knowledge/search would serialize.
+      refute Map.has_key?(know_meta, "error")
+
+      # The merged meta names why on degradation; healthy => null.
+      assert Map.has_key?(body["meta"], "degraded_reason")
+      assert body["meta"]["degraded_reason"] == nil
+    end
+
     test "a non-string query is rejected with a deterministic 422 invalid_query" do
       tenant = fixture(:tenant)
       {raw, _key, _agent} = agent_key(tenant.id)

--- a/test/loopctl_web/controllers/recall_controller_test.exs
+++ b/test/loopctl_web/controllers/recall_controller_test.exs
@@ -79,6 +79,44 @@ defmodule LoopctlWeb.RecallControllerTest do
       assert meta["memory_count"] >= 1
       assert meta["knowledge_count"] >= 1
       assert meta["total_count"] == length(data)
+      # The merged ordering is a documented cross-source heuristic, surfaced so callers
+      # don't read it as calibrated relevance.
+      assert meta["results_ranking"] == "heuristic_cross_source"
+
+      # Knowledge items are the whitelisted combined-search SUMMARY — never the raw
+      # result map's internal scoring fields, status, tenant_id, project_id, timestamps.
+      know_item = Enum.find(know_data, &(&1["id"] == article.id))
+
+      assert Map.keys(know_item)
+             |> Enum.sort()
+             |> Enum.all?(&(&1 in ~w(id title category tags score snippet)))
+
+      refute Map.has_key?(know_item, "tenant_id")
+      refute Map.has_key?(know_item, "status")
+      refute Map.has_key?(know_item, "final_score")
+      refute Map.has_key?(know_item, "inserted_at")
+
+      merged_know = Enum.find(data, &(&1["source"] == "knowledge"))["article"]
+      refute Map.has_key?(merged_know, "tenant_id")
+      refute Map.has_key?(merged_know, "status")
+    end
+
+    test "a missing or blank/whitespace-only query is rejected with a 422 invalid_query" do
+      tenant = fixture(:tenant)
+      {raw, _key, _agent} = agent_key(tenant.id)
+
+      for q <- [nil, "", "   ", "\t\n"] do
+        params = if is_nil(q), do: %{}, else: %{"query" => q}
+
+        body =
+          base_conn()
+          |> auth(raw)
+          |> post(~p"/api/v1/recall", params)
+          |> json_response(422)
+
+        assert body["error"]["code"] == "invalid_query"
+        assert body["error"]["status"] == 422
+      end
     end
 
     test "a non-string query is rejected with a deterministic 422 invalid_query" do

--- a/test/loopctl_web/controllers/recall_controller_test.exs
+++ b/test/loopctl_web/controllers/recall_controller_test.exs
@@ -1,0 +1,128 @@
+defmodule LoopctlWeb.RecallControllerTest do
+  @moduledoc """
+  #411 Gap 2 (PR B): the merged recall endpoint `POST /api/v1/recall`
+  (`MemoryController.context/2`). Covers the 200 merged shape, the reused 422 envelopes
+  (invalid_query / invalid_project_id), and the subject-unresolvable guard.
+  """
+  use LoopctlWeb.ConnCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.Auth.ApiKey
+  alias Loopctl.Knowledge
+  alias LoopctlWeb.MemoryController
+
+  defp auth(conn, raw_key), do: put_req_header(conn, "authorization", "Bearer #{raw_key}")
+
+  defp base_conn,
+    do: put_req_header(build_conn(), "x-loopctl-last-known-sth", "0:AAAAAAAAAAAAAAAAAAAAAA")
+
+  defp agent_key(tenant_id) do
+    agent = fixture(:agent, %{tenant_id: tenant_id})
+    {raw, key} = fixture(:api_key, %{tenant_id: tenant_id, role: :agent, agent_id: agent.id})
+    {raw, key, agent}
+  end
+
+  defp published_article(tenant_id, title) do
+    art =
+      fixture(:article, %{
+        tenant_id: tenant_id,
+        status: :published,
+        title: title,
+        body: "reshipment policy for #{title}"
+      })
+
+    {:ok, updated} = Knowledge.update_embedding(tenant_id, art.id, List.duplicate(0.1, 1536))
+    updated
+  end
+
+  describe "POST /api/v1/recall (merged memory ∪ knowledge)" do
+    test "returns the merged shape with per-source envelopes and meta", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw, _key, _agent} = agent_key(tenant.id)
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      # A long-term memory (embedded inline) + a knowledge article.
+      conn
+      |> auth(raw)
+      |> post(~p"/api/v1/memory", %{"tier" => "long_term", "text" => "prefers reshipments"})
+      |> json_response(201)
+
+      article = published_article(tenant.id, "reshipment guide")
+
+      body =
+        base_conn()
+        |> auth(raw)
+        |> post(~p"/api/v1/recall", %{"query" => "reshipments"})
+        |> json_response(200)
+
+      assert %{"data" => data, "memory" => memory, "knowledge" => knowledge, "meta" => meta} =
+               body
+
+      # Merged data is tagged per-source.
+      sources = data |> Enum.map(& &1["source"]) |> Enum.uniq() |> Enum.sort()
+      assert sources == ["knowledge", "memory"]
+
+      # Sorted by score DESC (nulls ranked as 0.0 by the context; here all are numbers).
+      scores = Enum.map(data, & &1["score"])
+      assert scores == Enum.sort(scores, :desc)
+
+      # Per-source envelopes present and shaped.
+      assert %{"data" => mem_data, "meta" => _} = memory
+      assert Enum.any?(mem_data, &(&1["memory"]["text"] == "prefers reshipments"))
+
+      assert %{"data" => know_data, "meta" => _} = knowledge
+      assert Enum.any?(know_data, &(&1["id"] == article.id))
+
+      assert meta["query"] == "reshipments"
+      assert meta["degraded"] == false
+      assert meta["memory_count"] >= 1
+      assert meta["knowledge_count"] >= 1
+      assert meta["total_count"] == length(data)
+    end
+
+    test "a non-string query is rejected with a deterministic 422 invalid_query" do
+      tenant = fixture(:tenant)
+      {raw, _key, _agent} = agent_key(tenant.id)
+
+      body =
+        base_conn()
+        |> auth(raw)
+        |> post(~p"/api/v1/recall", %{"query" => %{"nested" => "object"}})
+        |> json_response(422)
+
+      assert body["error"]["code"] == "invalid_query"
+      assert body["error"]["status"] == 422
+    end
+
+    test "a malformed project_id is rejected with a deterministic 422 invalid_project_id" do
+      tenant = fixture(:tenant)
+      {raw, _key, _agent} = agent_key(tenant.id)
+
+      body =
+        base_conn()
+        |> auth(raw)
+        |> post(~p"/api/v1/recall", %{"query" => "reshipments", "project_id" => "not-a-uuid"})
+        |> json_response(422)
+
+      assert body["error"]["code"] == "invalid_project_id"
+      assert body["error"]["status"] == 422
+    end
+
+    test "an identity-less key is refused with a deterministic 422 (subject_id_unresolvable)" do
+      tenant = fixture(:tenant)
+
+      conn =
+        build_conn()
+        |> Plug.Conn.assign(:current_api_key, %ApiKey{
+          id: nil,
+          tenant_id: tenant.id,
+          role: :agent,
+          agent_id: nil
+        })
+
+      result = MemoryController.context(conn, %{"query" => "reshipments"})
+      assert json_response(result, 422)["error"]["code"] == "subject_id_unresolvable"
+    end
+  end
+end

--- a/test/loopctl_web/require_human_anchor_default_deny_test.exs
+++ b/test/loopctl_web/require_human_anchor_default_deny_test.exs
@@ -118,6 +118,11 @@ defmodule LoopctlWeb.RequireHumanAnchorDefaultDenyTest do
                {:post, "/api/v1/memory/recall"},
                {:post, "/api/v1/memory/promote"},
                {:delete, "/api/v1/memory/:id"},
+               # Merged recall (#411 Gap 2) — a POST-shaped READ returning the
+               # re-ranked global ∪ active-project union of agent memory + knowledge,
+               # same KB-tier agent surface + (tenant, subject) key-derived scope as
+               # /memory/recall. Not a mutation.
+               {:post, "/api/v1/recall"},
 
                # Context Retriever (Epic 30, US-30.4) — `POST /retrieve/:entity` is a
                # POST-shaped READ (a governed filter/search over the tenant's OWN


### PR DESCRIPTION
## #411 Gap 2 (PR B of 2): single merged global∪project recall endpoint

Second of two PRs for #411 Gap 2. PR A (#413, merged) made memory recall
project-aware; this PR adds the single endpoint that merges memory with knowledge
into ONE round-trip, satisfying the Gap 2 acceptance:
"A single call returns merged, ranked global∪project recall for (query, project_id)."

### What changed
- **`POST /api/v1/recall`** (`MemoryController.context/2`) → `Memory.recall_context/2`
  runs the project-aware memory recall AND a `with_global` knowledge search, tags each
  result by source, sorts the union by score DESC, caps at limit, and returns both the
  merged list and per-source envelopes. Knowledge error / keyword-only fallback degrades
  to memory-only with a `degraded?` flag, never a crash.
- **Knowledge `:project_scope` opt** (`:strict` default | `:with_global`) threaded through
  `search_combined` into the keyword + semantic filter builders via one `apply_project_scope`
  helper. Default `:strict` keeps every existing caller byte-identical; only the merged
  recall opts into `:with_global`. Regression test guards the strict default.
- Reuses PR A's `with_scope/3`, `parse_project_id/1`, and 422 helpers — scope is
  key-derived, never from the body.
- MCP `recall_context` tool (handler + schema + dispatch + arg-forwarding test).
- New route allowlisted in the fail-closed human-anchor custody guard as a POST-shaped
  READ on the KB-tier agent surface (same tier + key-derived scope as `/memory/recall`).

### Known semantic note (flagged for review)
Under `:with_global` with `project_id: nil`, the knowledge side returns all-tenant
articles (the merged helper's nil→no-filter), while memory returns global-only. For the
primary use case (active project set) both merge global∪project correctly; the nil case
is documented + tested. Reviewers to confirm whether nil should be global-only for both.

### Tests
`recall_context` merge/rank/exclude-other-project/degraded-path; knowledge `:with_global`
vs `:strict` regression; endpoint 200 shape + 422s; MCP arg-forwarding. `mix precommit`
green (4812 tests); MCP tests green (222 pass).

Closes the #411 Gap 2 acceptance (single merged call). Part of #411.
