### PR TITLE
#411 Gap 3: graduate hot long-term memories into durable knowledge articles

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -489,6 +489,12 @@ config :loopctl, :memory_graduation_recall_threshold, 3
 config :loopctl, :memory_graduation_max_per_run, 50
 config :loopctl, :memory_graduation_scan_limit, 500
 
+# Dedup window (seconds) for the recall-count hotness bump (`Loopctl.Memory.bump_recall_counts/2`).
+# A memory's `recall_count` is bumped at most once per window, so a single agent replaying the
+# same query in a tight loop cannot inflate the "frequently-recalled" signal and force premature
+# graduation. Genuine repeated value across sessions/time still accumulates across windows.
+config :loopctl, :memory_recall_bump_cooldown_seconds, 3600
+
 # Epic 30 / US-30.1: per-tenant cap on entity definitions
 # (`Loopctl.ContextRetriever.Registry`). Bounds the dynamic ListTools payload/
 # latency of the generated agent query surface so a tenant admin cannot inflate

--- a/config/config.exs
+++ b/config/config.exs
@@ -484,7 +484,10 @@ config :loopctl, :session_memory_ttl_seconds, 3600
 # - recall_threshold: recall-count at/above which a memory is eligible to graduate.
 # - max_per_run: per-tick execution budget — the max memories one hourly sweep processes,
 #   bounding the novelty-gate embedding spend per run.
-# - scan_limit: max candidate rows a sweep tick scans across all tenants.
+# - scan_limit: max distinct TENANTS a sweep tick considers (a tenant cap, NOT a row cap).
+#   The sweep needs at most max_per_run tenants and pulls ~ceil(max_per_run / n_tenants)
+#   rows each, so worst-case candidate rows fetched per tick is ~2*max_per_run, not
+#   scan_limit*max_per_run.
 config :loopctl, :memory_graduation_recall_threshold, 3
 config :loopctl, :memory_graduation_max_per_run, 50
 config :loopctl, :memory_graduation_scan_limit, 500
@@ -494,6 +497,19 @@ config :loopctl, :memory_graduation_scan_limit, 500
 # same query in a tight loop cannot inflate the "frequently-recalled" signal and force premature
 # graduation. Genuine repeated value across sessions/time still accumulates across windows.
 config :loopctl, :memory_recall_bump_cooldown_seconds, 3600
+
+# Minimum cosine similarity a recalled memory must clear for its hotness bump to count
+# (`Loopctl.Memory.recall_bump_min_score/0`). recall returns the top-k by distance
+# regardless of absolute relevance, so without a floor a sparse subject scope (fewer than
+# k live memories) would auto-graduate low-relevance NOISE. Only a recall at/above this
+# similarity (`max(0.0, 1.0 - distance)`) bumps recall_count.
+config :loopctl, :memory_recall_bump_min_score, 0.6
+
+# Max concurrent in-flight recall-count bump tasks per node
+# (`Loopctl.Memory.RecallBumpTaskSupervisor` max_children). Bounds the fan-out of the
+# fire-and-forget async bump so a recall burst cannot spawn unbounded background writes
+# that starve the write pool — over the cap the bump is simply dropped (best-effort).
+config :loopctl, :memory_recall_bump_max_tasks, 200
 
 # Epic 30 / US-30.1: per-tenant cap on entity definitions
 # (`Loopctl.ContextRetriever.Registry`). Bounds the dynamic ListTools payload/

--- a/config/config.exs
+++ b/config/config.exs
@@ -476,6 +476,19 @@ config :loopctl, :memory_promotion_sweep_interval_seconds, 600
 config :loopctl, :memory_promotion_sweep_window_seconds, 900
 config :loopctl, :session_memory_ttl_seconds, 3600
 
+# Memory GRADUATION tunables (#411 Gap 3 — Loopctl.Workers.MemoryGraduationSweepWorker).
+# A DISTINCT, higher tier than the promotion loop above: a long-term memory recalled at
+# least `recall_threshold` times (via a HEALTHY semantic recall — the ILIKE fallback does
+# NOT bump the counter, so a provider outage cannot skew the signal) is graduated into a
+# durable Knowledge Wiki article, deduped by the novelty gate.
+# - recall_threshold: recall-count at/above which a memory is eligible to graduate.
+# - max_per_run: per-tick execution budget — the max memories one hourly sweep processes,
+#   bounding the novelty-gate embedding spend per run.
+# - scan_limit: max candidate rows a sweep tick scans across all tenants.
+config :loopctl, :memory_graduation_recall_threshold, 3
+config :loopctl, :memory_graduation_max_per_run, 50
+config :loopctl, :memory_graduation_scan_limit, 500
+
 # Epic 30 / US-30.1: per-tenant cap on entity definitions
 # (`Loopctl.ContextRetriever.Registry`). Bounds the dynamic ListTools payload/
 # latency of the generated agent query surface so a tenant admin cannot inflate

--- a/config/test.exs
+++ b/config/test.exs
@@ -517,6 +517,10 @@ config :loopctl, :cli_req_plug, {Req.Test, Loopctl.CLI.Client}
 # inserts run inside the test process and share its sandbox connection.
 config :loopctl, :analytics_recording_mode, :sync
 
+# #411 Gap 3: bump memory recall_count synchronously in tests so the UPDATE runs
+# inside the test process and shares its sandbox connection (a spawned task would not).
+config :loopctl, :memory_recall_bump_mode, :sync
+
 # RLS: Switch to non-superuser role within transactions so RLS is enforced
 # The loopctl_app role must exist and have access to all tables.
 config :loopctl, :rls_role, "loopctl_app"

--- a/lib/loopctl/application.ex
+++ b/lib/loopctl/application.ex
@@ -28,6 +28,21 @@ defmodule Loopctl.Application do
       {DNSCluster, query: Application.get_env(:loopctl, :dns_cluster_query) || :ignore},
       {Phoenix.PubSub, name: Loopctl.PubSub},
       {Task.Supervisor, name: Loopctl.TaskSupervisor},
+      # #411 Gap 3: owns the public ETS table that pre-filters recall-count hotness
+      # bumps already inside their per-memory cooldown window, so an idle-window
+      # recall issues ZERO background tasks and ZERO DB writes (the DB-side
+      # `WHERE last_recalled_at < cutoff` stays the source of truth). Node-local
+      # pure ETS owner; survives the transient recall/task process that wrote to it.
+      Loopctl.Memory.RecallBumpCache,
+      # #411 Gap 3: BOUNDED supervisor for the fire-and-forget recall-count bump
+      # tasks. `max_children` caps the fan-out so a burst of healthy recalls cannot
+      # spawn an unbounded set of background writes that starve the write pool —
+      # over the cap `start_child` returns `{:error, :max_children}` and the bump is
+      # dropped (best-effort analytics, never fails the recall). Separate from the
+      # general `Loopctl.TaskSupervisor` so bump backpressure is isolated.
+      {Task.Supervisor,
+       name: Loopctl.Memory.RecallBumpTaskSupervisor,
+       max_children: Application.get_env(:loopctl, :memory_recall_bump_max_tasks, 200)},
       # US-38.2: owns the public ETS table backing the throttled, PII-safe
       # rate-limiter fail-open logger, so a sustained limiter/DB outage emits a
       # bounded heartbeat per bucket-family instead of one warning per request

--- a/lib/loopctl/knowledge.ex
+++ b/lib/loopctl/knowledge.ex
@@ -392,6 +392,12 @@ defmodule Loopctl.Knowledge do
   articles, and it falls open (`:unknown`) rather than blocking a write when the
   embedding backend is unavailable.
 
+  Pass `on_gate_unavailable: :skip` (default `:create`) so a fell-open `:unknown`
+  assessment returns `{:error, :gate_unavailable}` WITHOUT creating — for automated
+  callers that must not inject an un-deduplicated article during an embedding outage and
+  would rather retry once the gate can assess. Pass `embedding: vector` to reuse an
+  already-computed embedding of the assessed text instead of generating a new one.
+
   Returns `{:ok, result}` where `result` is a map:
 
       %{
@@ -407,6 +413,7 @@ defmodule Loopctl.Knowledge do
   @spec propose_article(Ecto.UUID.t() | nil, map(), keyword()) ::
           {:ok, map()}
           | {:error, :duplicate_title, Article.t()}
+          | {:error, :gate_unavailable}
           | {:error, Ecto.Changeset.t()}
   def propose_article(tenant_id, attrs, opts \\ []) do
     attrs = stringify_top_keys(attrs)
@@ -442,7 +449,21 @@ defmodule Loopctl.Knowledge do
     create_proposal(tenant_id, gated_attrs, assessment, opts, :gated_to_draft)
   end
 
-  # :novel or :unknown (gate fell open) — proceed on the requested path.
+  # :unknown — the gate FELL OPEN (embedding backend unavailable; it could not actually
+  # assess novelty). By DEFAULT this proceeds like :novel (create), preserving the
+  # never-block-a-write contract for interactive callers. An AUTOMATED caller that must
+  # not inject an un-deduplicated article during an outage passes
+  # `on_gate_unavailable: :skip`, which returns `{:error, :gate_unavailable}` WITHOUT
+  # creating, so the caller can retry once embeddings recover and dedup then.
+  defp gate_proposal(tenant_id, attrs, %{verdict: :unknown} = assessment, opts) do
+    if Keyword.get(opts, :on_gate_unavailable, :create) == :skip do
+      {:error, :gate_unavailable}
+    else
+      create_proposal(tenant_id, attrs, assessment, opts, :created)
+    end
+  end
+
+  # :novel — the gate assessed the proposal as genuinely new; create on the requested path.
   defp gate_proposal(tenant_id, attrs, assessment, opts) do
     create_proposal(tenant_id, attrs, assessment, opts, :created)
   end

--- a/lib/loopctl/knowledge/proposal_gate.ex
+++ b/lib/loopctl/knowledge/proposal_gate.ex
@@ -58,8 +58,9 @@ defmodule Loopctl.Knowledge.ProposalGate do
     # Route through the GUARDED embedding path (review #4): tenant-scoped circuit
     # breaker + timeout, so a provider outage fast-fails here (this runs SYNCHRONOUSLY
     # in the HTTP write path) instead of hammering a dead provider and risking an LB
-    # timeout.
-    case Knowledge.generate_embedding(tenant_id, build_text(attrs)) do
+    # timeout. A caller (e.g. memory graduation) that already holds a computed embedding
+    # of the assessed text may pass it via `:embedding` to skip this round-trip.
+    case reuse_or_generate_embedding(tenant_id, attrs, opts) do
       {:ok, vector} when is_list(vector) and vector != [] ->
         # `on_overload: :tag` (US-37.5): assess/3 runs SYNCHRONOUSLY in the
         # knowledge_create write path, so an over-cap HeavyRead shed must NOT raise a
@@ -112,6 +113,17 @@ defmodule Loopctl.Knowledge.ProposalGate do
 
   defp neighbor_score(nil), do: nil
   defp neighbor_score(%{similarity_score: s}), do: s
+
+  # Reuse a caller-supplied embedding when present (avoids a second embedding round-trip
+  # for text already embedded upstream — e.g. a memory's stored vector on graduation);
+  # otherwise embed the proposal text through the guarded path. A non-list / empty
+  # `:embedding` is ignored and we fall back to generating.
+  defp reuse_or_generate_embedding(tenant_id, attrs, opts) do
+    case Keyword.get(opts, :embedding) do
+      vector when is_list(vector) and vector != [] -> {:ok, vector}
+      _ -> Knowledge.generate_embedding(tenant_id, build_text(attrs))
+    end
+  end
 
   defp build_text(attrs) do
     title = attrs["title"] || attrs[:title] || ""

--- a/lib/loopctl/memory.ex
+++ b/lib/loopctl/memory.ex
@@ -496,13 +496,96 @@ defmodule Loopctl.Memory do
 
     # Reuse a precomputed embedding when the caller supplies one (the merged recall
     # generates it ONCE for both halves — #411 Gap 2); otherwise generate here.
-    case opt(opts, :embedding, nil) || Knowledge.generate_embedding(scope.tenant_id, query_text) do
-      {:ok, embedding} ->
-        recall_semantic(scope, embedding, k, include_superseded?, on_overload)
+    envelope =
+      case opt(opts, :embedding, nil) ||
+             Knowledge.generate_embedding(scope.tenant_id, query_text) do
+        {:ok, embedding} ->
+          recall_semantic(scope, embedding, k, include_superseded?, on_overload)
 
-      {:error, reason} ->
-        recall_fallback(scope, reason, query_text, k, include_superseded?, on_overload)
+        {:error, reason} ->
+          recall_fallback(scope, reason, query_text, k, include_superseded?, on_overload)
+      end
+
+    maybe_bump_recall(scope, envelope, include_superseded?)
+    envelope
+  end
+
+  # #411 Gap 3: bump the recall-count / last_recalled_at for the rows this recall
+  # returned — the "hotness" signal the graduation sweep thresholds on. Deliberately
+  # OFF the response path (best-effort, fire-and-forget) and gated so it never pollutes
+  # the signal or affects the response:
+  #
+  #   * ONLY the HEALTHY semantic path bumps (`meta.fallback == false`). A degraded
+  #     ILIKE fallback OR a HeavyRead-shed empty envelope both set `fallback: true`, so
+  #     neither bumps: a memory surfaced only because embeddings were down (a text
+  #     substring match) is NOT evidence of genuine semantic hotness, and counting it
+  #     would let a provider outage skew which memories graduate.
+  #   * `include_superseded: true` oversight reads do NOT bump — an admin/superadmin
+  #     inspecting the full (incl. superseded) corpus must not inflate live memories'
+  #     hotness. Only the default live recall counts.
+  #   * A bump failure is swallowed (logged at most): a recall response must NEVER fail
+  #     because the analytics-style counter write failed. Mirrors the Knowledge
+  #     `Analytics.record_access/6` fire-and-forget off-hot-path mechanism.
+  defp maybe_bump_recall(_scope, %{meta: %{fallback: true}}, _include_superseded?), do: :ok
+  defp maybe_bump_recall(_scope, _envelope, true), do: :ok
+
+  defp maybe_bump_recall(scope, %{results: results}, false) do
+    ids = for {%MemorySchema{id: id}, _score} <- results, is_binary(id), do: id
+    bump_recall_counts(scope.tenant_id, ids)
+  end
+
+  @doc """
+  Best-effort, OFF-hot-path increment of `recall_count` (+1) and refresh of
+  `last_recalled_at` for the given live memory `ids` in `tenant_id`.
+
+  Mirrors `Loopctl.Knowledge.Analytics.record_access/6`: the write is fire-and-forget
+  and can NEVER fail a recall. Under the default `:async` mode it runs in a supervised
+  `Loopctl.TaskSupervisor` task; tests set `:memory_recall_bump_mode` to `:sync` so the
+  write shares the Ecto sandbox connection (a spawned task would not — the classic
+  external-process sandbox gotcha). Any error is logged and swallowed. The single UPDATE
+  is scoped by `(tenant_id, id IN ...)` and is a no-op for an empty id list.
+  """
+  @spec bump_recall_counts(String.t(), [String.t()]) :: :ok
+  def bump_recall_counts(_tenant_id, []), do: :ok
+
+  def bump_recall_counts(tenant_id, ids) when is_binary(tenant_id) and is_list(ids) do
+    case Application.get_env(:loopctl, :memory_recall_bump_mode, :async) do
+      :sync ->
+        do_bump_recall_counts(tenant_id, ids)
+
+      _async ->
+        Task.Supervisor.start_child(Loopctl.TaskSupervisor, fn ->
+          do_bump_recall_counts(tenant_id, ids)
+        end)
+
+        :ok
     end
+  rescue
+    error ->
+      Logger.warning("Memory.bump_recall_counts failed to spawn: #{Exception.message(error)}")
+      :ok
+  end
+
+  defp do_bump_recall_counts(tenant_id, ids) do
+    now = DateTime.utc_now()
+
+    from(m in MemorySchema,
+      where: m.tenant_id == ^tenant_id and m.id in ^ids
+    )
+    |> AdminRepo.update_all(set: [last_recalled_at: now], inc: [recall_count: 1])
+
+    :ok
+  rescue
+    error ->
+      # A recall-count bump is analytics-shaped: never let a counter-write failure
+      # surface (the recall already returned). Log at :warning so a persistently
+      # failing bump is visible in production, then swallow.
+      Logger.warning(
+        "Memory.bump_recall_counts write failed (bump dropped): " <>
+          Exception.message(error)
+      )
+
+      :ok
   end
 
   # `:on_overload` controls how a per-tenant HeavyRead cap SHED is handled (US-37.5):
@@ -1395,6 +1478,183 @@ defmodule Loopctl.Memory do
       {:ok, memory} -> memory
       {:error, changeset} -> AdminRepo.rollback(changeset)
     end
+  end
+
+  # ===========================================================================
+  # Graduation — HOT long-term memories → durable knowledge articles (#411 Gap 3)
+  # ===========================================================================
+  #
+  # DISTINCT from the Epic 29 promotion pipeline below (session turns → long-term
+  # `memories`). Graduation is the NEXT tier up: a long-term memory that has been
+  # recalled often enough (`recall_count >= graduation_recall_threshold/0`) is written
+  # back into the curated Knowledge Wiki as a durable article, DEDUPED by the same
+  # novelty gate (`Loopctl.Knowledge.propose_article/3`) that guards every agent
+  # write-back — so re-graduation races and semantically-duplicate memories cannot
+  # bloat the corpus. The scheduled cadence is `Loopctl.Workers.MemoryGraduationSweepWorker`;
+  # `graduate_memory/3` is the explicit (per-memory) trigger the `memory_promote`-class
+  # primitive maps onto, and is where the local→global re-scope option lives.
+
+  @doc """
+  Explicit graduation of ONE memory (by id, within `scope`) into a durable knowledge
+  article.
+
+  The `scope` `(tenant_id, subject_id)` is the isolation boundary — a caller may only
+  graduate its OWN memory; a foreign/nonexistent id returns `{:error, :not_found}`
+  (no cross-subject existence oracle). On success returns `{:ok, verdict, article}`
+  where `verdict` is the novelty-gate outcome
+  (`:created | :gated_to_draft | :duplicate | :deduplicated`).
+
+  ## local→global re-scope (`:re_scope`)
+
+  By DEFAULT the article inherits the memory's scope (`project_id`) — a project memory
+  graduates to a project article, a global memory to a global article. Pass
+  `re_scope: :global` to promote a PROJECT-scoped memory to a tenant-wide (global,
+  `project_id: nil`) article. This is the ONLY way a memory changes scope on
+  graduation: the automated sweep NEVER re-scopes (it always keeps the memory's scope),
+  because over-generalizing a project fact to tenant-wide is a mis-scoping the novelty
+  gate cannot catch — it must be an explicit, deliberate caller action.
+  """
+  @spec graduate_memory(Scope.t(), String.t(), keyword()) ::
+          {:ok, atom(), Loopctl.Knowledge.Article.t()} | {:error, :not_found | term()}
+  def graduate_memory(%Scope{} = scope, memory_id, opts \\ []) when is_binary(memory_id) do
+    case fetch_owned_memory(scope, memory_id) do
+      nil -> {:error, :not_found}
+      %MemorySchema{} = memory -> graduate_memory_record(memory, opts)
+    end
+  end
+
+  @doc """
+  Graduates a `%Memory{}` record into a durable knowledge article via the novelty gate.
+
+  Shared by `graduate_memory/3` (explicit) and `MemoryGraduationSweepWorker` (cadence).
+  Builds the article attrs from the memory (title = first line of the text, body = the
+  full text, category `:finding`, the memory's tags), threads a stable `idempotency_key`
+  so re-graduating the same memory is a no-op dedup, then calls
+  `Loopctl.Knowledge.propose_article/3`.
+
+  On ANY successful verdict — `:created`, `:gated_to_draft`, `:duplicate`, or
+  `:deduplicated` — the memory's content is now durable, so `graduated_at` is stamped
+  (idempotently, only if still NULL) and the memory is never re-processed by the sweep.
+  A `{:error, _}` from the write is returned WITHOUT stamping, so a later run retries.
+
+  Options: `:re_scope` (`:global` → `project_id: nil`); `:actor_id`/`:actor_label`/
+  `:actor_type` are forwarded to `propose_article/3` for audit attribution.
+  """
+  @spec graduate_memory_record(MemorySchema.t(), keyword()) ::
+          {:ok, atom(), Loopctl.Knowledge.Article.t()} | {:error, term()}
+  def graduate_memory_record(%MemorySchema{} = memory, opts \\ []) do
+    project_id = graduation_project_id(memory, opts)
+    attrs = memory_to_article_attrs(memory, project_id)
+
+    case Knowledge.propose_article(memory.tenant_id, attrs, propose_opts(opts)) do
+      {:ok, %{verdict: verdict, article: article}} ->
+        stamp_graduated(memory)
+        {:ok, verdict, article}
+
+      {:error, :duplicate_title, existing} ->
+        # A same-title / different-body collision. The stable per-memory
+        # idempotency_key makes this effectively unreachable for a DISTINCT memory (the
+        # title also carries the memory id suffix), but if it ever fires the content is
+        # already represented under that title — treat as durable and stamp so the sweep
+        # does not livelock retrying a title that will always collide.
+        stamp_graduated(memory)
+        {:ok, :duplicate, existing}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc "Recall-count at/above which the graduation sweep graduates a memory."
+  @spec graduation_recall_threshold() :: pos_integer()
+  def graduation_recall_threshold do
+    Application.get_env(:loopctl, :memory_graduation_recall_threshold, 3)
+  end
+
+  @doc "Per-run cap on memories graduated by one sweep tick (execution budget)."
+  @spec graduation_max_per_run() :: pos_integer()
+  def graduation_max_per_run do
+    Application.get_env(:loopctl, :memory_graduation_max_per_run, 50)
+  end
+
+  @doc "Max candidate rows a graduation sweep tick scans across all tenants."
+  @spec graduation_scan_limit() :: pos_integer()
+  def graduation_scan_limit do
+    Application.get_env(:loopctl, :memory_graduation_scan_limit, 500)
+  end
+
+  # A caller may only graduate a memory it OWNS: scoped by (tenant_id, subject_id) on
+  # the BYPASSRLS AdminRepo (the explicit-predicate isolation this context uses).
+  defp fetch_owned_memory(%Scope{} = scope, memory_id) do
+    AdminRepo.one(
+      from(m in MemorySchema,
+        where:
+          m.id == ^memory_id and m.tenant_id == ^scope.tenant_id and
+            m.subject_id == ^scope.subject_id
+      )
+    )
+  end
+
+  defp graduation_project_id(%MemorySchema{} = memory, opts) do
+    case Keyword.get(opts, :re_scope) do
+      :global -> nil
+      _ -> memory.project_id
+    end
+  end
+
+  defp memory_to_article_attrs(%MemorySchema{} = memory, project_id) do
+    %{
+      title: graduation_title(memory),
+      body: memory.text,
+      category: :finding,
+      tags: memory.tags || [],
+      project_id: project_id,
+      # Stable per-memory key: re-graduation (a race, a retry, or a second sweep before
+      # graduated_at commits) is an idempotent no-op dedup rather than a partial dup.
+      idempotency_key: "memory-graduation-" <> memory.id,
+      metadata: %{
+        "source" => "memory_graduation",
+        "graduated_from_memory_id" => memory.id,
+        "graduated_from_subject_id" => memory.subject_id,
+        "recall_count" => memory.recall_count
+      }
+    }
+  end
+
+  # Title = the memory's first line, trimmed and byte-bounded, with a short memory-id
+  # suffix so two DISTINCT memories whose first lines coincide do not collide on the
+  # (tenant_id, title) unique index (the novelty gate still catches genuine SEMANTIC
+  # duplicates — the suffix only prevents a mechanical DB title clash). Bounded to the
+  # Article 500-char title limit.
+  @graduation_title_max 500
+  defp graduation_title(%MemorySchema{text: text, id: id}) do
+    suffix = " (memory " <> String.slice(id, 0, 8) <> ")"
+
+    base =
+      text
+      |> String.split("\n", parts: 2)
+      |> List.first()
+      |> to_string()
+      |> String.trim()
+
+    base = if base == "", do: "Memory", else: base
+    String.slice(base, 0, @graduation_title_max - String.length(suffix)) <> suffix
+  end
+
+  defp propose_opts(opts), do: Keyword.take(opts, [:actor_id, :actor_label, :actor_type])
+
+  # Idempotent, conditional stamp: mark the memory graduated ONLY if still NULL, so a
+  # concurrent stamp (two sweep ticks, or explicit + sweep) is a harmless no-op and the
+  # memory is graduated at most once.
+  defp stamp_graduated(%MemorySchema{id: id, tenant_id: tenant_id}) do
+    now = DateTime.utc_now()
+
+    from(m in MemorySchema,
+      where: m.id == ^id and m.tenant_id == ^tenant_id and is_nil(m.graduated_at)
+    )
+    |> AdminRepo.update_all(set: [graduated_at: now, updated_at: now])
+
+    :ok
   end
 
   # ===========================================================================

--- a/lib/loopctl/memory.ex
+++ b/lib/loopctl/memory.ex
@@ -536,7 +536,9 @@ defmodule Loopctl.Memory do
 
   @doc """
   Best-effort, OFF-hot-path increment of `recall_count` (+1) and refresh of
-  `last_recalled_at` for the given live memory `ids` in `tenant_id`.
+  `last_recalled_at` for the given live memory `ids` in `tenant_id`, DEDUPED to at most
+  once per memory per `recall_bump_cooldown_seconds/0` so a tight single-agent recall loop
+  cannot game the hotness signal that drives graduation.
 
   Mirrors `Loopctl.Knowledge.Analytics.record_access/6`: the write is fire-and-forget
   and can NEVER fail a recall. Under the default `:async` mode it runs in a supervised
@@ -568,9 +570,20 @@ defmodule Loopctl.Memory do
 
   defp do_bump_recall_counts(tenant_id, ids) do
     now = DateTime.utc_now()
+    cutoff = DateTime.add(now, -recall_bump_cooldown_seconds(), :second)
 
+    # DEDUP the bump to at most once per memory per cooldown window. `recall_count` is the
+    # "frequently-recalled / proven-valuable" signal the graduation sweep thresholds on, so
+    # it must reflect BROAD, repeated value across sessions/time — not a tight single-agent
+    # loop. Without this window a single agent issuing the same query N times in one loop
+    # would force graduation (default threshold 3), letting one agent flood the wiki. Only
+    # a recall whose row was last counted BEFORE the cooldown (or never) bumps; recalls
+    # inside the window are ignored for hotness. `last_recalled_at` therefore marks the last
+    # COUNTED recall, so it doubles as the dedup cursor.
     from(m in MemorySchema,
-      where: m.tenant_id == ^tenant_id and m.id in ^ids
+      where:
+        m.tenant_id == ^tenant_id and m.id in ^ids and
+          (is_nil(m.last_recalled_at) or m.last_recalled_at < ^cutoff)
     )
     |> AdminRepo.update_all(set: [last_recalled_at: now], inc: [recall_count: 1])
 
@@ -1532,10 +1545,23 @@ defmodule Loopctl.Memory do
   so re-graduating the same memory is a no-op dedup, then calls
   `Loopctl.Knowledge.propose_article/3`.
 
-  On ANY successful verdict — `:created`, `:gated_to_draft`, `:duplicate`, or
-  `:deduplicated` — the memory's content is now durable, so `graduated_at` is stamped
-  (idempotently, only if still NULL) and the memory is never re-processed by the sweep.
-  A `{:error, _}` from the write is returned WITHOUT stamping, so a later run retries.
+  On ANY successful verdict `graduated_at` is stamped (idempotently, only if still NULL)
+  and the memory is never re-processed by the sweep — but the DURABILITY guarantee differs
+  by verdict:
+
+    * `:created` / `:duplicate` / `:deduplicated` — the content is represented by a
+      PUBLISHED article (a fresh one, or the canonical existing one), i.e. searchable now.
+    * `:gated_to_draft` — the novelty gate judged the content a near-duplicate and created
+      it as an UNPUBLISHED draft in the human-review queue. It is NOT yet searchable; a
+      reviewer publishes or discards it. Stamping is still correct: the content IS
+      represented (as a draft), and re-selecting the memory would only re-spend embedding
+      budget to hit the idempotency no-op — but the sweep does NOT re-materialize a draft
+      that a reviewer later discards.
+
+  A STRUCTURAL `{:error, changeset}` (the only error the novelty gate surfaces — a
+  backend outage falls open to a create, not an error tuple) IS stamped, because it can
+  never succeed on retry; leaving it un-stamped would livelock the hottest-first sweep on
+  a permanently-invalid candidate, re-spending embedding budget every run.
 
   Options: `:re_scope` (`:global` → `project_id: nil`); `:actor_id`/`:actor_label`/
   `:actor_type` are forwarded to `propose_article/3` for audit attribution.
@@ -1546,22 +1572,36 @@ defmodule Loopctl.Memory do
     project_id = graduation_project_id(memory, opts)
     attrs = memory_to_article_attrs(memory, project_id)
 
-    case Knowledge.propose_article(memory.tenant_id, attrs, propose_opts(opts)) do
+    case Knowledge.propose_article(memory.tenant_id, attrs, propose_opts(memory, opts)) do
       {:ok, %{verdict: verdict, article: article}} ->
         stamp_graduated(memory)
         {:ok, verdict, article}
 
       {:error, :duplicate_title, existing} ->
-        # A same-title / different-body collision. The stable per-memory
-        # idempotency_key makes this effectively unreachable for a DISTINCT memory (the
-        # title also carries the memory id suffix), but if it ever fires the content is
-        # already represented under that title — treat as durable and stamp so the sweep
+        # A same-title / different-body collision. The per-memory idempotency_key +
+        # the FULL memory id in the title suffix make this unreachable for a DISTINCT
+        # memory (two distinct memories can no longer collide on title), so if it ever
+        # fires the content is already represented under that title — stamp so the sweep
         # does not livelock retrying a title that will always collide.
         stamp_graduated(memory)
         {:ok, :duplicate, existing}
 
-      {:error, reason} ->
-        {:error, reason}
+      {:error, %Ecto.Changeset{} = changeset} ->
+        # A STRUCTURAL (validation) failure is DETERMINISTIC — the same attrs fail
+        # identically on every retry. Left un-stamped, the sweep would re-select this
+        # (hottest-first, `graduated_at IS NULL`) memory every hour and re-spend the
+        # novelty-gate embedding budget on a candidate that can NEVER succeed (a per-slot
+        # livelock). Tags are already sanitized in `memory_to_article_attrs/2`; stamping
+        # here terminally records any OTHER structural impossibility (e.g. an over-size
+        # body) so it is not retried forever. `graduated_at` here means "graduation was
+        # terminally attempted", not "a live article exists".
+        Logger.warning(
+          "Memory.graduate_memory_record structural failure (stamping to avoid livelock): " <>
+            "tenant=#{memory.tenant_id} memory=#{memory.id} errors=#{inspect(changeset.errors)}"
+        )
+
+        stamp_graduated(memory)
+        {:error, changeset}
     end
   end
 
@@ -1581,6 +1621,18 @@ defmodule Loopctl.Memory do
   @spec graduation_scan_limit() :: pos_integer()
   def graduation_scan_limit do
     Application.get_env(:loopctl, :memory_graduation_scan_limit, 500)
+  end
+
+  @doc """
+  Cooldown window (seconds) that dedups recall-count bumps per memory.
+
+  A memory's `recall_count` is bumped at most once per this window (see
+  `bump_recall_counts/2`), so a single agent replaying the same query in a tight loop
+  cannot inflate the "frequently-recalled" hotness signal and force premature graduation.
+  """
+  @spec recall_bump_cooldown_seconds() :: pos_integer()
+  def recall_bump_cooldown_seconds do
+    Application.get_env(:loopctl, :memory_recall_bump_cooldown_seconds, 3600)
   end
 
   # A caller may only graduate a memory it OWNS: scoped by (tenant_id, subject_id) on
@@ -1607,7 +1659,19 @@ defmodule Loopctl.Memory do
       title: graduation_title(memory),
       body: memory.text,
       category: :finding,
-      tags: memory.tags || [],
+      # PUBLISHED, not draft: knowledge_search/knowledge_context return PUBLISHED articles
+      # only, so a draft graduation would be invisible and the wiki would never grow.
+      # create_article/3 TRUSTS attrs[:status] and the Article moduledoc requires a
+      # non-controller caller to sanitize it server-side — this IS that sanitization. The
+      # novelty gate may still downgrade to :draft on a :low_novelty verdict (the
+      # human-review queue), which is the ONE intended unpublished outcome.
+      status: :published,
+      # Memory tags are unvalidated at the memory tier, but the Article changeset enforces
+      # count (<=50), length (<=100), and format. Copying arbitrary client-set tags verbatim
+      # would make a structurally-impossible candidate fail the changeset on EVERY sweep — a
+      # per-slot livelock that re-spends embedding budget hourly. Sanitize to Article's
+      # limits so graduation can never be poisoned by a hostile/oversized tag set.
+      tags: sanitize_graduation_tags(memory.tags),
       project_id: project_id,
       # Stable per-memory key: re-graduation (a race, a retry, or a second sweep before
       # graduated_at commits) is an idempotent no-op dedup rather than a partial dup.
@@ -1616,19 +1680,52 @@ defmodule Loopctl.Memory do
         "source" => "memory_graduation",
         "graduated_from_memory_id" => memory.id,
         "graduated_from_subject_id" => memory.subject_id,
-        "recall_count" => memory.recall_count
+        "recall_count" => memory.recall_count,
+        # PRESERVE SUBJECT-level isolation. A Memory is agent-private working memory scoped
+        # by (tenant_id, subject_id); graduating it into a tenant-wide SHARED article would
+        # expose one agent's private memory to every peer in the tenant (cross-subject
+        # leak). Stamp OWNER visibility keyed to the memory's subject so the graduated
+        # article stays discoverable by its owner (durable) but is NOT peer-readable —
+        # `Knowledge.propose_article/3` is passed the matching `visibility_agent_id` so the
+        # idempotency/dedup lookups resolve against the owner-visible row.
+        "agent_id" => memory.subject_id,
+        "visibility" => "owner",
+        "memory_type" => "finding"
       }
     }
   end
 
-  # Title = the memory's first line, trimmed and byte-bounded, with a short memory-id
-  # suffix so two DISTINCT memories whose first lines coincide do not collide on the
-  # (tenant_id, title) unique index (the novelty gate still catches genuine SEMANTIC
-  # duplicates — the suffix only prevents a mechanical DB title clash). Bounded to the
-  # Article 500-char title limit.
+  # Article tag constraints (mirror `Loopctl.Knowledge.Article`'s @max_tags/@max_tag_length/
+  # @tag_pattern). Memory tags are unbounded/unvalidated, so clamp+filter to what the Article
+  # changeset accepts: drop non-binary, empty, over-long, and format-invalid tags, then cap
+  # the count. Keeping only ALREADY-VALID tags (rather than mangling) guarantees the article
+  # changeset's tag validation cannot fail on a graduated memory.
+  @graduation_max_tags 50
+  @graduation_max_tag_length 100
+  @graduation_tag_pattern ~r/^[a-zA-Z0-9_-]+$/
+  defp sanitize_graduation_tags(tags) when is_list(tags) do
+    tags
+    |> Enum.filter(fn tag ->
+      is_binary(tag) and byte_size(tag) > 0 and
+        String.length(tag) <= @graduation_max_tag_length and
+        Regex.match?(@graduation_tag_pattern, tag)
+    end)
+    |> Enum.take(@graduation_max_tags)
+  end
+
+  defp sanitize_graduation_tags(_), do: []
+
+  # Title = the memory's first line, trimmed and byte-bounded, with the FULL memory-id
+  # suffix so two DISTINCT memories whose first lines coincide can never collide on the
+  # (tenant_id, title) unique index. A truncated (8-char) suffix left a birthday-bounded
+  # collision window in which a distinct memory's body was silently dropped (it hit the
+  # title index, returned the FIRST memory's article, and got stamped without ever being
+  # captured); the full UUID closes that data-loss path. The novelty gate still catches
+  # genuine SEMANTIC duplicates — the suffix only prevents a mechanical DB title clash.
+  # Bounded to the Article 500-char title limit.
   @graduation_title_max 500
   defp graduation_title(%MemorySchema{text: text, id: id}) do
-    suffix = " (memory " <> String.slice(id, 0, 8) <> ")"
+    suffix = " (memory " <> id <> ")"
 
     base =
       text
@@ -1641,7 +1738,13 @@ defmodule Loopctl.Memory do
     String.slice(base, 0, @graduation_title_max - String.length(suffix)) <> suffix
   end
 
-  defp propose_opts(opts), do: Keyword.take(opts, [:actor_id, :actor_label, :actor_type])
+  # Forward audit attribution to propose_article/3, plus the OWNER visibility agent id
+  # (= the memory's subject) so the create dedup/idempotency lookups resolve against the
+  # owner-visible graduated article (matches metadata.visibility = "owner").
+  defp propose_opts(%MemorySchema{subject_id: subject_id}, opts) do
+    [visibility_agent_id: subject_id] ++
+      Keyword.take(opts, [:actor_id, :actor_label, :actor_type])
+  end
 
   # Idempotent, conditional stamp: mark the memory graduated ONLY if still NULL, so a
   # concurrent stamp (two sweep ticks, or explicit + sweep) is a harmless no-op and the

--- a/lib/loopctl/memory.ex
+++ b/lib/loopctl/memory.ex
@@ -55,6 +55,7 @@ defmodule Loopctl.Memory do
   alias Loopctl.Llm.ProviderError
   alias Loopctl.Memory.Memory, as: MemorySchema
   alias Loopctl.Memory.PromotionTelemetry
+  alias Loopctl.Memory.RecallBumpCache
   alias Loopctl.Memory.Scope
   alias Loopctl.Memory.SessionMemory
   alias Loopctl.Memory.SessionPromotion
@@ -529,8 +530,29 @@ defmodule Loopctl.Memory do
   defp maybe_bump_recall(_scope, %{meta: %{fallback: true}}, _include_superseded?), do: :ok
   defp maybe_bump_recall(_scope, _envelope, true), do: :ok
 
-  defp maybe_bump_recall(scope, %{results: results}, false) do
-    ids = for {%MemorySchema{id: id}, _score} <- results, is_binary(id), do: id
+  defp maybe_bump_recall(scope, envelope, false) do
+    # `Map.get(envelope, :results, [])` (not a `%{results: results}` head): a recall
+    # response must NEVER fail because of the analytics-shaped bump, so an unexpected
+    # `fallback: false` envelope shape lacking `results` degrades to a no-op here instead
+    # of raising a FunctionClauseError on the recall hot path.
+    #
+    # RELEVANCE FLOOR (not just top-k page membership). A healthy recall returns the
+    # top-k by cosine distance REGARDLESS of absolute relevance, so a subject with fewer
+    # than k live memories has ALL of them returned on every query — making a naive bump
+    # track the subject's query VOLUME, not any individual memory's value, and letting a
+    # sparse scope (the common case for a new agent/project) auto-graduate low-relevance
+    # NOISE after ~threshold recalls. Only bump rows whose similarity clears
+    # `recall_bump_min_score/0`, so "frequently-recalled = proven-valuable" holds even
+    # for tiny scopes. `score` is `max(0.0, 1.0 - distance)` (see `recall_semantic/5`),
+    # so higher = more similar.
+    floor = recall_bump_min_score()
+
+    ids =
+      for {%MemorySchema{id: id}, score} <- Map.get(envelope, :results, []),
+          is_binary(id),
+          is_number(score) and score >= floor,
+          do: id
+
     bump_recall_counts(scope.tenant_id, ids)
   end
 
@@ -541,11 +563,35 @@ defmodule Loopctl.Memory do
   cannot game the hotness signal that drives graduation.
 
   Mirrors `Loopctl.Knowledge.Analytics.record_access/6`: the write is fire-and-forget
-  and can NEVER fail a recall. Under the default `:async` mode it runs in a supervised
-  `Loopctl.TaskSupervisor` task; tests set `:memory_recall_bump_mode` to `:sync` so the
-  write shares the Ecto sandbox connection (a spawned task would not — the classic
-  external-process sandbox gotcha). Any error is logged and swallowed. The single UPDATE
-  is scoped by `(tenant_id, id IN ...)` and is a no-op for an empty id list.
+  and can NEVER fail a recall. Under the default `:async` mode it runs in a task on the
+  BOUNDED `Loopctl.Memory.RecallBumpTaskSupervisor` (a `max_children` cap bounds the
+  fan-out so a recall burst can't spawn an unbounded set of background writes that starve
+  the write pool — over the cap the bump is simply dropped); tests set
+  `:memory_recall_bump_mode` to `:sync` so the write shares the Ecto sandbox connection
+  (a spawned task would not — the classic external-process sandbox gotcha). Any error is
+  logged and swallowed. The single UPDATE is scoped by `(tenant_id, id IN ...)` and is a
+  no-op for an empty id list.
+
+  ## Cooldown pre-filter (async path)
+
+  Before spawning, the async path drops ids already bumped within their cooldown window
+  via the node-local `Loopctl.Memory.RecallBumpCache`, so an idle-window recall issues
+  ZERO tasks and ZERO DB writes — the cooldown no-op no longer amplifies a read 1:1 into
+  a connection checkout. The DB-side `WHERE last_recalled_at < cutoff` REMAINS the source
+  of truth (the ETS cache is node-local and lost on restart), so a cross-node or
+  post-restart recall still dedups correctly at the DB.
+
+  ## Dedup is best-effort under concurrency (by design)
+
+  Two concurrent recalls of the same memory within one window can both read
+  `last_recalled_at` as stale (Postgres READ COMMITTED evaluates the WHERE once per
+  statement) and each increment +1, over-counting past the intended "at most once per
+  window". The ETS pre-filter narrows this to a same-node, same-instant race, and the
+  over-count is bounded by the concurrency, so the hotness signal is BEST-EFFORT: it
+  raises the bar against a single-agent tight loop (the anti-gaming goal) without
+  claiming a hard exactly-once guarantee. A hard guarantee would need a per-memory
+  advisory lock / single-writer path, which is not worth its cost for an analytics-shaped
+  counter.
   """
   @spec bump_recall_counts(String.t(), [String.t()]) :: :ok
   def bump_recall_counts(_tenant_id, []), do: :ok
@@ -556,16 +602,30 @@ defmodule Loopctl.Memory do
         do_bump_recall_counts(tenant_id, ids)
 
       _async ->
-        Task.Supervisor.start_child(Loopctl.TaskSupervisor, fn ->
-          do_bump_recall_counts(tenant_id, ids)
-        end)
-
-        :ok
+        async_bump_recall_counts(tenant_id, ids)
     end
   rescue
     error ->
       Logger.warning("Memory.bump_recall_counts failed to spawn: #{Exception.message(error)}")
       :ok
+  end
+
+  defp async_bump_recall_counts(tenant_id, ids) do
+    case RecallBumpCache.filter_uncooled(tenant_id, ids) do
+      # Every id is still inside its cooldown window on this node — a guaranteed DB no-op.
+      # Skip the task AND the connection checkout entirely.
+      [] ->
+        :ok
+
+      fresh_ids ->
+        Task.Supervisor.start_child(Loopctl.Memory.RecallBumpTaskSupervisor, fn ->
+          do_bump_recall_counts(tenant_id, fresh_ids)
+          # Record the bump only AFTER the write so the node-local window matches the DB.
+          RecallBumpCache.mark(tenant_id, fresh_ids)
+        end)
+
+        :ok
+    end
   end
 
   defp do_bump_recall_counts(tenant_id, ids) do
@@ -1558,17 +1618,71 @@ defmodule Loopctl.Memory do
       budget to hit the idempotency no-op — but the sweep does NOT re-materialize a draft
       that a reviewer later discards.
 
-  A STRUCTURAL `{:error, changeset}` (the only error the novelty gate surfaces — a
-  backend outage falls open to a create, not an error tuple) IS stamped, because it can
-  never succeed on retry; leaving it un-stamped would livelock the hottest-first sweep on
-  a permanently-invalid candidate, re-spending embedding budget every run.
+  A STRUCTURAL `{:error, changeset}` IS stamped, because it can never succeed on retry;
+  leaving it un-stamped would livelock the hottest-first sweep on a permanently-invalid
+  candidate, re-spending embedding budget every run.
+
+  A TRANSIENT `{:error, :gate_unavailable}` — the novelty gate FELL OPEN because the
+  embedding backend was down and could not actually assess novelty — is NOT stamped and
+  NO article is created (`on_gate_unavailable: :skip` is passed to the gate). The memory
+  stays eligible so a later tick RE-graduates and dedups once embeddings recover, instead
+  of injecting an un-deduplicated published article during the outage and burning the
+  memory's one-shot graduation.
+
+  ## Embedding reuse
+
+  The memory already stores its own `vector(1536)` embedding (populated async by
+  `MemoryEmbeddingWorker`). When present it is threaded into the novelty gate
+  (`propose_article/3` → `assess/3`) so graduation reuses it instead of paying a second
+  embedding round-trip for the identical text; when the memory has not been embedded yet
+  (NULL) the gate embeds as before.
+
+  ## re_scope on an already-graduated memory refuses LOUDLY
+
+  A memory has AT MOST ONE graduated article — the `(tenant_id, title)` unique index
+  admits only one article per memory-title, so a project article and a global article of
+  the SAME memory cannot coexist. `re_scope: :global` on a memory whose `graduated_at` is
+  already set therefore returns `{:error, :already_graduated}` instead of silently
+  hitting the existing article's idempotency/title path and returning the WRONG-scoped
+  article as success. Globalize a memory by passing `re_scope: :global` on its FIRST
+  graduation (before the sweep graduates it project-scoped); re-pointing an
+  already-published article's scope is a separate, deliberate curation action. The
+  per-memory, per-scope `idempotency_key` keeps a same-scope re-graduation an idempotent
+  no-op.
+
+  ## Reachability
+
+  This is a PROGRAMMATIC primitive: `graduate_memory/3` (explicit, incl. `re_scope:
+  :global`) and `MemoryGraduationSweepWorker` (the hourly cadence, which never re-scopes)
+  are its only callers. It is NOT wired to an HTTP/MCP endpoint today, so the `re_scope:
+  :global` path is reachable only from code — exposing an on-demand graduate primitive to
+  agents is a deliberate, un-taken product decision.
 
   Options: `:re_scope` (`:global` → `project_id: nil`); `:actor_id`/`:actor_label`/
   `:actor_type` are forwarded to `propose_article/3` for audit attribution.
   """
   @spec graduate_memory_record(MemorySchema.t(), keyword()) ::
-          {:ok, atom(), Loopctl.Knowledge.Article.t()} | {:error, term()}
+          {:ok, atom(), Loopctl.Knowledge.Article.t()}
+          | {:error, :already_graduated | :gate_unavailable | term()}
   def graduate_memory_record(%MemorySchema{} = memory, opts \\ []) do
+    if re_scope_conflict?(memory, opts) do
+      # An already-graduated memory cannot gain a second, differently-scoped article (one
+      # article per memory-title). Refuse LOUDLY rather than silently returning the
+      # existing wrong-scoped article as success.
+      {:error, :already_graduated}
+    else
+      do_graduate_memory_record(memory, opts)
+    end
+  end
+
+  # `re_scope: :global` only takes effect on a memory that has not yet graduated; on an
+  # already-graduated memory it would collide with the existing article, so it is refused.
+  # The sweep only ever calls with ungraduated memories (its query filters
+  # `graduated_at IS NULL`), so this never affects the automated cadence.
+  defp re_scope_conflict?(%MemorySchema{graduated_at: nil}, _opts), do: false
+  defp re_scope_conflict?(%MemorySchema{}, opts), do: Keyword.get(opts, :re_scope) == :global
+
+  defp do_graduate_memory_record(%MemorySchema{} = memory, opts) do
     project_id = graduation_project_id(memory, opts)
     attrs = memory_to_article_attrs(memory, project_id)
 
@@ -1576,6 +1690,13 @@ defmodule Loopctl.Memory do
       {:ok, %{verdict: verdict, article: article}} ->
         stamp_graduated(memory)
         {:ok, verdict, article}
+
+      {:error, :gate_unavailable} ->
+        # The gate FELL OPEN (embedding backend down) — it could not assess novelty, so
+        # nothing was created. Do NOT stamp: leave the memory eligible so a later tick
+        # re-graduates and dedups once embeddings recover, rather than permanently marking
+        # it graduated on an un-assessed (and un-deduplicated) outcome.
+        {:error, :gate_unavailable}
 
       {:error, :duplicate_title, existing} ->
         # A same-title / different-body collision. The per-memory idempotency_key +
@@ -1617,10 +1738,34 @@ defmodule Loopctl.Memory do
     Application.get_env(:loopctl, :memory_graduation_max_per_run, 50)
   end
 
-  @doc "Max candidate rows a graduation sweep tick scans across all tenants."
+  @doc """
+  Max distinct TENANTS a graduation sweep tick considers (a tenant cap, NOT a row cap).
+
+  The sweep only ever needs `graduation_max_per_run/0` tenants (round-robin serves at
+  least one memory per tenant, so no more than the per-run budget of tenants can
+  contribute in one tick), and it pulls only ~`ceil(max_per_run / n_tenants)` rows per
+  tenant, so the WORST-CASE candidate rows fetched per tick is bounded at roughly
+  `2 * max_per_run` — NOT `scan_limit * max_per_run`. This knob only bounds how wide the
+  DISTINCT-tenant scan may fan out before the random per-tick sample.
+  """
   @spec graduation_scan_limit() :: pos_integer()
   def graduation_scan_limit do
     Application.get_env(:loopctl, :memory_graduation_scan_limit, 500)
+  end
+
+  @doc """
+  Minimum cosine similarity a recalled memory must clear for its hotness bump to count.
+
+  `recall/2` returns the top-k by distance regardless of absolute relevance, so without a
+  floor a sparse subject scope (fewer than k live memories) would have ALL of its
+  memories bumped on every query — auto-graduating low-relevance noise. Only a recall
+  whose similarity (`max(0.0, 1.0 - distance)`) is at or above this floor bumps
+  `recall_count`, keeping the "frequently-recalled = proven-valuable" premise honest for
+  small scopes.
+  """
+  @spec recall_bump_min_score() :: float()
+  def recall_bump_min_score do
+    Application.get_env(:loopctl, :memory_recall_bump_min_score, 0.6)
   end
 
   @doc """
@@ -1673,9 +1818,14 @@ defmodule Loopctl.Memory do
       # limits so graduation can never be poisoned by a hostile/oversized tag set.
       tags: sanitize_graduation_tags(memory.tags),
       project_id: project_id,
-      # Stable per-memory key: re-graduation (a race, a retry, or a second sweep before
-      # graduated_at commits) is an idempotent no-op dedup rather than a partial dup.
-      idempotency_key: "memory-graduation-" <> memory.id,
+      # Stable per-memory, PER-SCOPE key: re-graduation to the SAME scope (a race, a
+      # retry, or a second sweep before graduated_at commits) is an idempotent no-op
+      # dedup rather than a partial dup. The scope MUST be encoded: a `re_scope: :global`
+      # graduation of an already project-graduated memory would otherwise collide with
+      # the project-scoped article's key and hit the idempotent fast path — silently
+      # returning the wrong-scoped article and defeating the re-scope. Distinct scope =
+      # distinct key = the global article actually gets created.
+      idempotency_key: graduation_idempotency_key(memory.id, project_id),
       metadata: %{
         "source" => "memory_graduation",
         "graduated_from_memory_id" => memory.id,
@@ -1741,10 +1891,50 @@ defmodule Loopctl.Memory do
   # Forward audit attribution to propose_article/3, plus the OWNER visibility agent id
   # (= the memory's subject) so the create dedup/idempotency lookups resolve against the
   # owner-visible graduated article (matches metadata.visibility = "owner").
-  defp propose_opts(%MemorySchema{subject_id: subject_id}, opts) do
-    [visibility_agent_id: subject_id] ++
-      Keyword.take(opts, [:actor_id, :actor_label, :actor_type])
+  #
+  #   * `on_gate_unavailable: :skip` — for AUTOMATED graduation the gate must NOT fall
+  #     open and inject an un-deduplicated published article during an embedding outage;
+  #     it returns `{:error, :gate_unavailable}` so the memory re-graduates later.
+  #   * `:embedding` — reuse the memory's already-computed vector (when populated) so the
+  #     gate does not re-embed identical text; omitted (→ gate embeds) when NULL.
+  defp propose_opts(%MemorySchema{subject_id: subject_id} = memory, opts) do
+    [visibility_agent_id: subject_id, on_gate_unavailable: :skip]
+    |> maybe_put_embedding(memory)
+    |> Keyword.merge(Keyword.take(opts, [:actor_id, :actor_label, :actor_type]))
   end
+
+  defp maybe_put_embedding(propose_opts, %MemorySchema{} = memory) do
+    case fetch_memory_embedding(memory) do
+      nil -> propose_opts
+      embedding -> Keyword.put(propose_opts, :embedding, embedding)
+    end
+  end
+
+  # The memory's `embedding` column is `load_in_query: false`, so it is NOT present on the
+  # struct the sweep/fetch loaded — an EXPLICIT `select` overrides that and returns just
+  # the vector (a cheap local read that saves an embedding API round-trip). NULL until
+  # `MemoryEmbeddingWorker` has embedded the memory.
+  defp fetch_memory_embedding(%MemorySchema{id: id, tenant_id: tenant_id}) do
+    from(m in MemorySchema,
+      where: m.id == ^id and m.tenant_id == ^tenant_id,
+      select: m.embedding
+    )
+    |> AdminRepo.one()
+    |> case do
+      %Pgvector{} = vector -> Pgvector.to_list(vector)
+      list when is_list(list) and list != [] -> list
+      _ -> nil
+    end
+  end
+
+  # Per-memory, PER-SCOPE idempotency key (see `memory_to_article_attrs/2`): global vs
+  # project graduation MUST yield distinct keys so a `re_scope: :global` graduation of an
+  # already project-graduated memory creates the global article instead of colliding with
+  # (and returning) the project-scoped one.
+  defp graduation_idempotency_key(memory_id, nil), do: "memory-graduation-#{memory_id}-global"
+
+  defp graduation_idempotency_key(memory_id, project_id),
+    do: "memory-graduation-#{memory_id}-project:#{project_id}"
 
   # Idempotent, conditional stamp: mark the memory graduated ONLY if still NULL, so a
   # concurrent stamp (two sweep ticks, or explicit + sweep) is a harmless no-op and the

--- a/lib/loopctl/memory/memory.ex
+++ b/lib/loopctl/memory/memory.ex
@@ -90,6 +90,15 @@ defmodule Loopctl.Memory.Memory do
     field :tags, {:array, :string}, default: []
     field :metadata, :map, default: %{}
 
+    # #411 Gap 3: recall-count tracking + graduation. None of these are cast from
+    # request params — `recall_count`/`last_recalled_at` are bumped OFF the recall hot
+    # path by `Loopctl.Memory.bump_recall_counts/2`, and `graduated_at` is stamped by
+    # the graduation sweep / the explicit graduation primitive. `graduated_at` NULL =
+    # not yet graduated into a durable knowledge article.
+    field :recall_count, :integer, default: 0
+    field :last_recalled_at, :utc_datetime_usec
+    field :graduated_at, :utc_datetime_usec
+
     belongs_to :superseded_by_memory, __MODULE__,
       foreign_key: :superseded_by,
       references: :id,

--- a/lib/loopctl/memory/recall_bump_cache.ex
+++ b/lib/loopctl/memory/recall_bump_cache.ex
@@ -1,0 +1,139 @@
+defmodule Loopctl.Memory.RecallBumpCache do
+  @moduledoc """
+  Node-local, in-process cooldown cache for the recall-count hotness bump (#411 Gap 3).
+
+  The graduation signal (`recall_count`) is bumped OFF the recall hot path, DEDUPED to
+  at most once per memory per `Loopctl.Memory.recall_bump_cooldown_seconds/0`. That dedup
+  ultimately lives in the `UPDATE ... WHERE last_recalled_at < cutoff` predicate, but on
+  the async hot path that predicate still costs a Repo connection checkout on EVERY
+  recall — even a cooldown NO-OP that bumps zero rows. Under a burst of recalls that
+  amplifies reads 1:1 into writes on the shared write pool and fans out an unbounded set
+  of background tasks (`Loopctl.Memory.bump_recall_counts/2`).
+
+  This cache is the cheap in-process pre-filter that fixes both:
+
+    * `filter_uncooled/2` drops the ids already bumped within the cooldown window BEFORE
+      a task is spawned or a connection is taken, so an idle-window recall issues ZERO
+      tasks and ZERO DB writes. Reads bypass any process — a direct, lock-free
+      `:ets.lookup` on a `read_concurrency` table.
+    * `mark/2` records the bump instant per `(tenant_id, memory_id)` after a write, so the
+      next recall inside the window is filtered out here.
+
+  The DB-side `WHERE last_recalled_at < cutoff` REMAINS the source of truth (this cache is
+  node-local and lost on restart / not shared cross-node); the ETS layer is a spend
+  optimization + fan-out damper, not the correctness guarantee. A periodic sweep evicts
+  expired entries so the table stays bounded to memories bumped within one cooldown
+  window. Mirrors the ETS-owner pattern of `Loopctl.Llm.SettingsCache` /
+  `Loopctl.Knowledge.ExportConcurrency`: a single GenServer owns the table so it survives
+  the transient recall/task process that wrote to it.
+  """
+
+  use GenServer
+
+  require Logger
+
+  @table :loopctl_recall_bump_cooldown
+  @sweep_interval_ms :timer.minutes(5)
+
+  # --- Client API ---
+
+  @doc false
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc """
+  Returns the subset of `ids` that are NOT within their per-memory cooldown window on
+  THIS node (never bumped here, or last bumped before the cooldown elapsed).
+
+  A lock-free, read-only pre-filter: pure `:ets.lookup` per id, bypassing the owner
+  GenServer. If the table is somehow absent (owner not yet booted), it fails OPEN —
+  returning all ids — so the DB-side cooldown still guards the write.
+  """
+  @spec filter_uncooled(String.t(), [String.t()]) :: [String.t()]
+  def filter_uncooled(tenant_id, ids) when is_binary(tenant_id) and is_list(ids) do
+    now = now_ms()
+    Enum.filter(ids, fn id -> uncooled?(tenant_id, id, now) end)
+  rescue
+    ArgumentError -> ids
+  end
+
+  @doc """
+  Records a bump for each `(tenant_id, id)` so a subsequent recall inside the cooldown
+  window is filtered by `filter_uncooled/2`. Direct writes to the public table (no
+  GenServer round-trip); best-effort, swallows a missing-table error.
+  """
+  @spec mark(String.t(), [String.t()]) :: :ok
+  def mark(tenant_id, ids) when is_binary(tenant_id) and is_list(ids) do
+    expires_at = now_ms() + cooldown_ms()
+    Enum.each(ids, fn id -> :ets.insert(@table, {{tenant_id, id}, expires_at}) end)
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
+  @doc false
+  def table_name, do: @table
+
+  # --- Server callbacks ---
+
+  @impl true
+  def init(_opts) do
+    table =
+      case :ets.whereis(@table) do
+        :undefined ->
+          :ets.new(@table, [
+            :set,
+            :public,
+            :named_table,
+            read_concurrency: true,
+            write_concurrency: true
+          ])
+
+        existing ->
+          existing
+      end
+
+    schedule_sweep()
+    {:ok, %{table: table}}
+  end
+
+  @impl true
+  def handle_info(:sweep, state) do
+    sweep_expired()
+    schedule_sweep()
+    {:noreply, state}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  # --- Private ---
+
+  defp uncooled?(tenant_id, id, now) when is_binary(id) do
+    case :ets.lookup(@table, {tenant_id, id}) do
+      [{_key, expires_at}] -> now >= expires_at
+      [] -> true
+    end
+  end
+
+  defp uncooled?(_tenant_id, _id, _now), do: false
+
+  defp schedule_sweep, do: Process.send_after(self(), :sweep, @sweep_interval_ms)
+
+  # Evict entries whose cooldown has elapsed so the table stays bounded to memories
+  # bumped within roughly one cooldown window.
+  defp sweep_expired do
+    now = now_ms()
+    :ets.select_delete(@table, [{{:_, :"$1"}, [{:"=<", :"$1", now}], [true]}])
+  rescue
+    ArgumentError -> 0
+  end
+
+  defp cooldown_ms do
+    Application.get_env(:loopctl, :memory_recall_bump_cooldown_seconds, 3600) * 1000
+  end
+
+  # Monotonic clock: entries store `now_ms() + cooldown_ms`, compared against `now_ms()`.
+  defp now_ms, do: System.monotonic_time(:millisecond)
+end

--- a/lib/loopctl/oban_config.ex
+++ b/lib/loopctl/oban_config.ex
@@ -428,6 +428,14 @@ defmodule Loopctl.ObanConfig do
          # promoted before SessionMemoryPruneWorker can delete them (no silent
          # golden-nugget loss).
          {"*/10 * * * *", Loopctl.Workers.MemoryPromotionSweepWorker},
+         # #411 Gap 3: HOURLY graduation of HOT long-term memories (recall_count >=
+         # :memory_graduation_recall_threshold) into durable knowledge articles, deduped
+         # via the novelty gate. DELIBERATELY slower than the 10-min promotion sweep —
+         # graduation is not latency-sensitive and an hourly cadence keeps the
+         # novelty-gate embedding spend low. Bounded per run by
+         # :memory_graduation_max_per_run. Keep in sync with the crontab assertion in
+         # oban_plugins_config_test.exs.
+         {"0 * * * *", Loopctl.Workers.MemoryGraduationSweepWorker},
          # US-35.3: all-tenants STH safety sweep. Reduced from `"* * * * *"` (every
          # minute) to a low-frequency, config-driven backstop (default `*/5 * * * *`)
          # that only catches appends the event-driven enqueuer (US-35.2) missed. Each

--- a/lib/loopctl/workers/memory_graduation_sweep_worker.ex
+++ b/lib/loopctl/workers/memory_graduation_sweep_worker.ex
@@ -17,29 +17,41 @@ defmodule Loopctl.Workers.MemoryGraduationSweepWorker do
 
   ## Flow (mirrors the promotion sweep's cross-tenant + per-run-budget shape)
 
-  1. **Candidates (per-tenant fair)** — LIVE (`superseded_by IS NULL`), NOT-yet-graduated
-     (`graduated_at IS NULL`) memories at or above the recall threshold, gathered with
-     PER-TENANT FAIRNESS so one hot tenant cannot monopolize the per-run budget and starve
-     others. The sweep enumerates eligible tenants (bounded by
-     `Loopctl.Memory.graduation_scan_limit/0`), pulls each tenant's hottest eligible
-     memories via a `tenant_id = ? ... ORDER BY recall_count DESC` query that the partial
-     index `memories_graduation_sweep_idx (tenant_id, recall_count)` actually serves
-     (equality + in-index descending scan, no sort — a bare cross-tenant global sort could
-     NOT use this tenant-leading index), then ROUND-ROBIN interleaves the per-tenant lists
-     so every active tenant is served each tick.
+  1. **Candidates (per-tenant fair, bounded fetch)** — LIVE (`superseded_by IS NULL`),
+     NOT-yet-graduated (`graduated_at IS NULL`) memories at or above the recall threshold,
+     gathered with PER-TENANT FAIRNESS so one hot tenant cannot monopolize the per-run
+     budget and starve others. The sweep samples eligible tenants (a RANDOM per-tick
+     subset, capped at `min(scan_limit, max_per_run)` — see "Fairness" below), pulls each
+     sampled tenant's hottest eligible memories via a `tenant_id = ? ... ORDER BY
+     recall_count DESC` query that the partial index
+     `memories_graduation_sweep_idx (tenant_id, recall_count)` serves (equality +
+     in-index descending scan, no sort — a bare cross-tenant global sort could NOT use
+     this tenant-leading index), then ROUND-ROBIN interleaves the per-tenant lists so
+     every sampled tenant is served each tick. The per-tenant slice is only
+     `ceil(max_per_run / n_tenants)` rows, so the WORST-CASE candidate rows fetched per
+     tick is ~`2 * max_per_run` — NOT `scan_limit * max_per_run`.
   2. **Graduate + stamp** — each candidate goes through
      `Loopctl.Memory.graduate_memory_record/2`, which writes the article via the
      NOVELTY GATE (`Loopctl.Knowledge.propose_article/3`, so a semantically-duplicate
-     memory does not bloat the corpus) and stamps `graduated_at` on ANY successful
-     verdict so it is never re-processed. A `:created`/`:duplicate`/`:deduplicated`
-     verdict means a PUBLISHED (searchable) article represents the content;
-     `:gated_to_draft` means a review-queue draft does (not yet searchable). A structural
-     changeset failure is ALSO stamped (it can never succeed) to prevent a per-slot livelock.
+     memory does not bloat the corpus) and stamps `graduated_at` on ANY DURABLE verdict
+     so it is never re-processed. A `:created`/`:duplicate`/`:deduplicated` verdict means
+     a PUBLISHED (searchable) article represents the content; `:gated_to_draft` means a
+     review-queue draft does (not yet searchable). A structural changeset failure is ALSO
+     stamped (it can never succeed) to prevent a per-slot livelock. A TRANSIENT
+     `:gate_unavailable` (embedding backend down, gate could not assess) is NOT stamped
+     and creates nothing, so the memory re-graduates and dedups once embeddings recover.
   3. **Per-run execution budget** — at most `Loopctl.Memory.graduation_max_per_run/0`
-     memories are processed per tick, bounding the novelty-gate embedding spend per run
-     (the analogue of the promotion sweep's per-tick cap). The same value bounds each
-     tenant's candidate slice, so no single tenant contributes more than one run could
-     process.
+     memories are processed per tick, bounding the novelty-gate embedding spend per run.
+
+  ## Fairness across ticks (no tenant starvation)
+
+  Tenant selection is a RANDOM per-tick sample of the eligible tenants (`ORDER BY
+  RANDOM() LIMIT n`), NOT an ascending `tenant_id` scan. A deterministic ascending scan
+  would serve the same lowest-UUID tenants every tick and, with more sustained hot
+  tenants than the per-run budget, PERMANENTLY starve higher-UUID tenants. Random
+  sampling gives every eligible tenant a fair chance each tick, so a large cross-tenant
+  backlog drains without a persistent ordering bias. Round-robin only fixes fairness
+  AMONG the sampled tenants; the random sample is what fixes fairness ACROSS ticks.
 
   ## Scope is PRESERVED — the sweep never re-scopes
 
@@ -51,10 +63,22 @@ defmodule Loopctl.Workers.MemoryGraduationSweepWorker do
 
   ## Concurrency / idempotency
 
-  `unique: [fields: [:worker], period: 60]` prevents overlapping ticks. Across ticks,
-  double-graduation is prevented by (a) the conditional `graduated_at` stamp and (b) the
-  stable per-memory `idempotency_key` + novelty gate in `graduate_memory_record/2` — so
-  even a race that re-proposes a memory yields ONE article, not a duplicate.
+  Overlap-safety does NOT rest on the `unique: [fields: [:worker], period: 60]` guard:
+  on an HOURLY cron a 60s uniqueness window only dedups near-simultaneous ENQUEUES (it
+  never fires between hourly ticks). What actually makes two overlapping runs safe is the
+  IDEMPOTENCY of graduation: (a) the conditional `graduated_at` stamp (only if still
+  NULL) and (b) the stable per-memory, per-scope `idempotency_key` + novelty gate in
+  `graduate_memory_record/2` — so even a race that re-proposes a memory yields ONE
+  article, not a duplicate.
+
+  ## Observability
+
+  The `[:loopctl, :memory_graduation, :swept]` telemetry breaks the outcome down
+  per-verdict (`created`/`duplicate`/`deduplicated`/`gated_to_draft`/`gate_unavailable`/
+  `structural_error`/`error`) so an operator can distinguish PUBLISHED (searchable)
+  graduations from invisible review-queue DRAFTS, spot a transient embedding outage
+  (`gate_unavailable`), and detect the silent stamped-without-article path
+  (`structural_error`) rather than seeing one conflated `graduated` count.
   """
 
   use Oban.Worker,
@@ -70,85 +94,152 @@ defmodule Loopctl.Workers.MemoryGraduationSweepWorker do
   alias Loopctl.Memory
   alias Loopctl.Memory.Memory, as: MemorySchema
 
+  # Verdicts that leave a DURABLE article (published or draft) and stamp graduated_at.
+  @durable_verdicts [:created, :duplicate, :deduplicated, :gated_to_draft]
+
+  # Synthetic actor so sweep-created articles are attributable in the audit/curation log
+  # (distinct from a manual api_key-created article).
+  @actor_opts [actor_type: "system", actor_label: "memory_graduation_sweep"]
+
   @impl Oban.Worker
   def perform(%Oban.Job{}) do
-    threshold = Memory.graduation_recall_threshold()
     cap = Memory.graduation_max_per_run()
-    candidates = candidate_memories(threshold)
+    candidates = candidate_memories()
 
-    {processed, graduated} =
-      Enum.reduce_while(candidates, {0, 0}, fn memory, {processed, graduated} ->
+    {processed, tally} =
+      Enum.reduce_while(candidates, {0, %{}}, fn memory, {processed, tally} ->
         if processed >= cap do
-          {:halt, {processed, graduated}}
+          {:halt, {processed, tally}}
         else
-          {:cont, {processed + 1, graduated + graduate(memory)}}
+          outcome = graduate(memory)
+          {:cont, {processed + 1, Map.update(tally, outcome, 1, &(&1 + 1))}}
         end
       end)
 
+    graduated = @durable_verdicts |> Enum.map(&count(tally, &1)) |> Enum.sum()
+
     :telemetry.execute(
       [:loopctl, :memory_graduation, :swept],
-      %{candidates: length(candidates), processed: processed, graduated: graduated},
+      %{
+        candidates: length(candidates),
+        processed: processed,
+        graduated: graduated,
+        created: count(tally, :created),
+        duplicate: count(tally, :duplicate),
+        deduplicated: count(tally, :deduplicated),
+        gated_to_draft: count(tally, :gated_to_draft),
+        gate_unavailable: count(tally, :gate_unavailable),
+        structural_error: count(tally, :structural_error),
+        error: count(tally, :error)
+      },
       %{}
     )
 
     :ok
   end
 
-  # Returns 1 on a successful graduation (any novelty-gate verdict), 0 on a write error
-  # (left un-stamped so a later tick retries). A per-memory failure never aborts the run.
+  defp count(tally, key), do: Map.get(tally, key, 0)
+
+  # Returns the per-memory OUTCOME atom for telemetry:
+  #
+  #   * a durable verdict (`:created`/`:duplicate`/`:deduplicated`/`:gated_to_draft`) —
+  #     a durable article now represents the content (stamped);
+  #   * `:gate_unavailable` — TRANSIENT (embedding backend down), NOT stamped, retried
+  #     next tick — deliberately NOT a failure;
+  #   * `:structural_error` — a deterministic changeset failure; the memory is stamped
+  #     but NO durable article exists (a silent-drop signal worth its own counter);
+  #   * `:error` — any other write error (left un-stamped so a later tick retries).
+  #
+  # A per-memory failure — INCLUDING a raise inside the novelty gate / stamp — never
+  # aborts the run (the try/rescue matches the moduledoc's guarantee).
   defp graduate(memory) do
-    case Memory.graduate_memory_record(memory, []) do
-      {:ok, _verdict, _article} ->
-        1
+    case Memory.graduate_memory_record(memory, @actor_opts) do
+      {:ok, verdict, _article} ->
+        verdict
+
+      {:error, :gate_unavailable} ->
+        :gate_unavailable
+
+      {:error, %Ecto.Changeset{}} ->
+        # graduate_memory_record already logged the structural detail; the dedicated
+        # telemetry counter is what surfaces the stamped-without-article drop.
+        :structural_error
 
       {:error, reason} ->
-        # `tenant_id`/`id` are server-derived UUIDs (safe to interpolate); `reason` is
-        # inspected so a changeset/term can't forge log lines.
         Logger.warning(
           "MemoryGraduationSweepWorker: graduation failed tenant=#{memory.tenant_id} " <>
             "memory=#{memory.id} reason=#{inspect(reason)}"
         )
 
-        0
+        :error
+    end
+  rescue
+    error ->
+      # A pathological memory (embedding task crash, DB hiccup mid-stamp) must not abort
+      # the whole tick and force an Oban retry of already-completed work. Isolate it.
+      Logger.error(
+        "MemoryGraduationSweepWorker: graduation crashed tenant=#{memory.tenant_id} " <>
+          "memory=#{memory.id} error=#{Exception.message(error)}"
+      )
+
+      :error
+  end
+
+  # Candidate scan with PER-TENANT FAIRNESS (BYPASSRLS) and a BOUNDED fetch.
+  #
+  #   1. Sample the tenants owning at least one eligible (hot, live, ungraduated) memory —
+  #      a RANDOM per-tick subset capped at `min(scan_limit, max_per_run)`. Random (not
+  #      ascending tenant_id) so no set of tenants is permanently served first.
+  #   2. For EACH sampled tenant pull its hottest eligible memories, capped at
+  #      `ceil(max_per_run / n_tenants)` — enough to fill the per-run budget without a
+  #      50x over-fetch. This per-tenant query (`tenant_id = ? ... ORDER BY recall_count
+  #      DESC`) is exactly what the partial index serves (equality + in-index descending
+  #      scan, no sort).
+  #   3. ROUND-ROBIN interleave the per-tenant lists so the global per-run budget is
+  #      spread fairly: a tenant with few hot memories is fully served early instead of
+  #      waiting behind a hotter tenant's long tail. With one active tenant the interleave
+  #      is a no-op, so budget is still fully utilized.
+  defp candidate_memories do
+    threshold = Memory.graduation_recall_threshold()
+    cap = Memory.graduation_max_per_run()
+
+    # Round-robin serves >=1 memory per tenant and perform/1 processes at most `cap`
+    # memories, so at most `cap` tenants can contribute in one tick — never fetch more.
+    tenant_limit = min(Memory.graduation_scan_limit(), cap)
+
+    case eligible_tenant_ids(threshold, tenant_limit) do
+      [] ->
+        []
+
+      tenant_ids ->
+        per_tenant_limit = ceil_div(cap, length(tenant_ids))
+
+        tenant_ids
+        |> Enum.map(&hot_memories_for_tenant(&1, threshold, per_tenant_limit))
+        |> round_robin()
     end
   end
 
-  # Candidate scan with PER-TENANT FAIRNESS (BYPASSRLS). A single global
-  # `ORDER BY recall_count DESC` scan let one hot tenant monopolize the whole per-run
-  # budget (starving every other tenant), AND the tenant-leading partial index
-  # `memories_graduation_sweep_idx (tenant_id, recall_count)` cannot even serve a
-  # cross-tenant global sort (no tenant equality → Postgres must add a sort). So instead:
-  #
-  #   1. Enumerate the tenants with at least one eligible (hot, live, ungraduated) memory
-  #      (bounded by `graduation_scan_limit/0` tenants per tick).
-  #   2. For EACH tenant pull its hottest eligible memories, capped at
-  #      `graduation_max_per_run/0` — this per-tenant query (`tenant_id = ? ...
-  #      ORDER BY recall_count DESC`) is exactly what the partial index serves (equality +
-  #      in-index descending scan, no sort).
-  #   3. ROUND-ROBIN interleave the per-tenant lists so the global per-run budget (applied
-  #      in `perform/1`) is spread fairly: a tenant with few hot memories is fully served
-  #      early instead of waiting behind a hotter tenant's long tail. With one active
-  #      tenant the interleave is a no-op, so budget is still fully utilized.
-  defp candidate_memories(threshold) do
-    per_tenant_limit = Memory.graduation_max_per_run()
+  defp ceil_div(a, b), do: div(a + b - 1, b)
 
-    threshold
-    |> eligible_tenant_ids(Memory.graduation_scan_limit())
-    |> Enum.map(&hot_memories_for_tenant(&1, threshold, per_tenant_limit))
-    |> round_robin()
-  end
-
-  # Distinct tenants owning at least one eligible memory, bounded so the sweep cannot fan
-  # out over unbounded tenants in one tick. Ordered for determinism.
+  # A RANDOM sample of distinct tenants owning at least one eligible memory, capped so the
+  # sweep cannot fan out over unbounded tenants in one tick. `ORDER BY RANDOM()` (over the
+  # DISTINCT-tenant subquery) gives every eligible tenant a fair per-tick chance rather
+  # than permanently serving the lowest tenant_ids first.
   defp eligible_tenant_ids(threshold, tenant_limit) do
-    from(m in MemorySchema,
-      where:
-        m.recall_count >= ^threshold and is_nil(m.graduated_at) and
-          is_nil(m.superseded_by),
-      distinct: true,
-      select: m.tenant_id,
-      order_by: [asc: m.tenant_id],
-      limit: ^tenant_limit
+    distinct_q =
+      from(m in MemorySchema,
+        where:
+          m.recall_count >= ^threshold and is_nil(m.graduated_at) and
+            is_nil(m.superseded_by),
+        distinct: true,
+        select: %{tenant_id: m.tenant_id}
+      )
+
+    from(t in subquery(distinct_q),
+      order_by: fragment("RANDOM()"),
+      limit: ^tenant_limit,
+      select: t.tenant_id
     )
     |> AdminRepo.all()
   end

--- a/lib/loopctl/workers/memory_graduation_sweep_worker.ex
+++ b/lib/loopctl/workers/memory_graduation_sweep_worker.ex
@@ -17,21 +17,29 @@ defmodule Loopctl.Workers.MemoryGraduationSweepWorker do
 
   ## Flow (mirrors the promotion sweep's cross-tenant + per-run-budget shape)
 
-  1. **Candidates** — ONE cross-tenant (`Loopctl.AdminRepo`, BYPASSRLS) scan for LIVE
-     (`superseded_by IS NULL`), NOT-yet-graduated (`graduated_at IS NULL`) memories at or
-     above the recall threshold, hottest first, capped at
-     `Loopctl.Memory.graduation_scan_limit/0`. Backed by the partial index
-     `memories_graduation_sweep_idx` so already-graduated/cold rows never consume a scan
-     slot.
+  1. **Candidates (per-tenant fair)** — LIVE (`superseded_by IS NULL`), NOT-yet-graduated
+     (`graduated_at IS NULL`) memories at or above the recall threshold, gathered with
+     PER-TENANT FAIRNESS so one hot tenant cannot monopolize the per-run budget and starve
+     others. The sweep enumerates eligible tenants (bounded by
+     `Loopctl.Memory.graduation_scan_limit/0`), pulls each tenant's hottest eligible
+     memories via a `tenant_id = ? ... ORDER BY recall_count DESC` query that the partial
+     index `memories_graduation_sweep_idx (tenant_id, recall_count)` actually serves
+     (equality + in-index descending scan, no sort — a bare cross-tenant global sort could
+     NOT use this tenant-leading index), then ROUND-ROBIN interleaves the per-tenant lists
+     so every active tenant is served each tick.
   2. **Graduate + stamp** — each candidate goes through
      `Loopctl.Memory.graduate_memory_record/2`, which writes the article via the
      NOVELTY GATE (`Loopctl.Knowledge.propose_article/3`, so a semantically-duplicate
      memory does not bloat the corpus) and stamps `graduated_at` on ANY successful
-     verdict — including `:duplicate`/`:deduplicated` (the memory's content is now
-     durable either way) — so it is never re-processed.
+     verdict so it is never re-processed. A `:created`/`:duplicate`/`:deduplicated`
+     verdict means a PUBLISHED (searchable) article represents the content;
+     `:gated_to_draft` means a review-queue draft does (not yet searchable). A structural
+     changeset failure is ALSO stamped (it can never succeed) to prevent a per-slot livelock.
   3. **Per-run execution budget** — at most `Loopctl.Memory.graduation_max_per_run/0`
      memories are processed per tick, bounding the novelty-gate embedding spend per run
-     (the analogue of the promotion sweep's per-tick cap).
+     (the analogue of the promotion sweep's per-tick cap). The same value bounds each
+     tenant's candidate slice, so no single tenant contributes more than one run could
+     process.
 
   ## Scope is PRESERVED — the sweep never re-scopes
 
@@ -66,7 +74,7 @@ defmodule Loopctl.Workers.MemoryGraduationSweepWorker do
   def perform(%Oban.Job{}) do
     threshold = Memory.graduation_recall_threshold()
     cap = Memory.graduation_max_per_run()
-    candidates = candidate_memories(threshold, Memory.graduation_scan_limit())
+    candidates = candidate_memories(threshold)
 
     {processed, graduated} =
       Enum.reduce_while(candidates, {0, 0}, fn memory, {processed, graduated} ->
@@ -105,17 +113,68 @@ defmodule Loopctl.Workers.MemoryGraduationSweepWorker do
     end
   end
 
-  # Cross-tenant (BYPASSRLS) candidate scan: live, not-yet-graduated memories at/above
-  # the recall threshold, HOTTEST first (deterministic tiebreak on id), capped. The
-  # WHERE matches the partial index `memories_graduation_sweep_idx`.
-  defp candidate_memories(threshold, limit) do
+  # Candidate scan with PER-TENANT FAIRNESS (BYPASSRLS). A single global
+  # `ORDER BY recall_count DESC` scan let one hot tenant monopolize the whole per-run
+  # budget (starving every other tenant), AND the tenant-leading partial index
+  # `memories_graduation_sweep_idx (tenant_id, recall_count)` cannot even serve a
+  # cross-tenant global sort (no tenant equality → Postgres must add a sort). So instead:
+  #
+  #   1. Enumerate the tenants with at least one eligible (hot, live, ungraduated) memory
+  #      (bounded by `graduation_scan_limit/0` tenants per tick).
+  #   2. For EACH tenant pull its hottest eligible memories, capped at
+  #      `graduation_max_per_run/0` — this per-tenant query (`tenant_id = ? ...
+  #      ORDER BY recall_count DESC`) is exactly what the partial index serves (equality +
+  #      in-index descending scan, no sort).
+  #   3. ROUND-ROBIN interleave the per-tenant lists so the global per-run budget (applied
+  #      in `perform/1`) is spread fairly: a tenant with few hot memories is fully served
+  #      early instead of waiting behind a hotter tenant's long tail. With one active
+  #      tenant the interleave is a no-op, so budget is still fully utilized.
+  defp candidate_memories(threshold) do
+    per_tenant_limit = Memory.graduation_max_per_run()
+
+    threshold
+    |> eligible_tenant_ids(Memory.graduation_scan_limit())
+    |> Enum.map(&hot_memories_for_tenant(&1, threshold, per_tenant_limit))
+    |> round_robin()
+  end
+
+  # Distinct tenants owning at least one eligible memory, bounded so the sweep cannot fan
+  # out over unbounded tenants in one tick. Ordered for determinism.
+  defp eligible_tenant_ids(threshold, tenant_limit) do
     from(m in MemorySchema,
       where:
         m.recall_count >= ^threshold and is_nil(m.graduated_at) and
           is_nil(m.superseded_by),
+      distinct: true,
+      select: m.tenant_id,
+      order_by: [asc: m.tenant_id],
+      limit: ^tenant_limit
+    )
+    |> AdminRepo.all()
+  end
+
+  # Hottest eligible memories for ONE tenant (deterministic tiebreak on id), capped. The
+  # WHERE + ORDER match `memories_graduation_sweep_idx (tenant_id, recall_count)`.
+  defp hot_memories_for_tenant(tenant_id, threshold, limit) do
+    from(m in MemorySchema,
+      where:
+        m.tenant_id == ^tenant_id and m.recall_count >= ^threshold and
+          is_nil(m.graduated_at) and is_nil(m.superseded_by),
       order_by: [desc: m.recall_count, asc: m.id],
       limit: ^limit
     )
     |> AdminRepo.all()
+  end
+
+  # Round-robin flatten: [[a1,a2],[b1],[c1,c2,c3]] -> [a1,b1,c1,a2,c2,c3]. Takes one head
+  # from each non-empty list per pass, so the global budget is spread across tenants.
+  defp round_robin(lists) do
+    case Enum.reject(lists, &(&1 == [])) do
+      [] ->
+        []
+
+      nonempty ->
+        Enum.map(nonempty, &hd/1) ++ round_robin(Enum.map(nonempty, &tl/1))
+    end
   end
 end

--- a/lib/loopctl/workers/memory_graduation_sweep_worker.ex
+++ b/lib/loopctl/workers/memory_graduation_sweep_worker.ex
@@ -1,0 +1,121 @@
+defmodule Loopctl.Workers.MemoryGraduationSweepWorker do
+  @moduledoc """
+  Scheduled cadence that graduates HOT long-term memories into durable knowledge
+  articles (#411 Gap 3).
+
+  The counterpart, one tier UP, of `Loopctl.Workers.MemoryPromotionSweepWorker`:
+
+    * The promotion sweep compiles short-term SESSION turns into long-term `memories`
+      (every 10 min — it is latency-sensitive because session turns are pruned).
+    * THIS sweep graduates long-term `memories` that have been RECALLED often enough
+      (`recall_count >= Loopctl.Memory.graduation_recall_threshold/0`) into curated
+      Knowledge Wiki articles (HOURLY — graduation is NOT latency-sensitive, and a
+      slower cadence keeps the novelty-gate embedding spend low).
+
+  Do NOT conflate the two: this worker never touches sessions, and the promotion sweep
+  never writes articles.
+
+  ## Flow (mirrors the promotion sweep's cross-tenant + per-run-budget shape)
+
+  1. **Candidates** — ONE cross-tenant (`Loopctl.AdminRepo`, BYPASSRLS) scan for LIVE
+     (`superseded_by IS NULL`), NOT-yet-graduated (`graduated_at IS NULL`) memories at or
+     above the recall threshold, hottest first, capped at
+     `Loopctl.Memory.graduation_scan_limit/0`. Backed by the partial index
+     `memories_graduation_sweep_idx` so already-graduated/cold rows never consume a scan
+     slot.
+  2. **Graduate + stamp** — each candidate goes through
+     `Loopctl.Memory.graduate_memory_record/2`, which writes the article via the
+     NOVELTY GATE (`Loopctl.Knowledge.propose_article/3`, so a semantically-duplicate
+     memory does not bloat the corpus) and stamps `graduated_at` on ANY successful
+     verdict — including `:duplicate`/`:deduplicated` (the memory's content is now
+     durable either way) — so it is never re-processed.
+  3. **Per-run execution budget** — at most `Loopctl.Memory.graduation_max_per_run/0`
+     memories are processed per tick, bounding the novelty-gate embedding spend per run
+     (the analogue of the promotion sweep's per-tick cap).
+
+  ## Scope is PRESERVED — the sweep never re-scopes
+
+  A candidate graduates to the SAME scope as the memory (project memory → project
+  article, global memory → global article). The sweep NEVER promotes a project memory to
+  a tenant-wide article: over-generalizing a project fact is a mis-scoping the novelty
+  gate cannot catch, so local→global re-scope is an EXPLICIT caller action only
+  (`Loopctl.Memory.graduate_memory/3` with `re_scope: :global`).
+
+  ## Concurrency / idempotency
+
+  `unique: [fields: [:worker], period: 60]` prevents overlapping ticks. Across ticks,
+  double-graduation is prevented by (a) the conditional `graduated_at` stamp and (b) the
+  stable per-memory `idempotency_key` + novelty gate in `graduate_memory_record/2` — so
+  even a race that re-proposes a memory yields ONE article, not a duplicate.
+  """
+
+  use Oban.Worker,
+    queue: :memory,
+    max_attempts: 3,
+    unique: [fields: [:worker], period: 60]
+
+  require Logger
+
+  import Ecto.Query
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Memory
+  alias Loopctl.Memory.Memory, as: MemorySchema
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{}) do
+    threshold = Memory.graduation_recall_threshold()
+    cap = Memory.graduation_max_per_run()
+    candidates = candidate_memories(threshold, Memory.graduation_scan_limit())
+
+    {processed, graduated} =
+      Enum.reduce_while(candidates, {0, 0}, fn memory, {processed, graduated} ->
+        if processed >= cap do
+          {:halt, {processed, graduated}}
+        else
+          {:cont, {processed + 1, graduated + graduate(memory)}}
+        end
+      end)
+
+    :telemetry.execute(
+      [:loopctl, :memory_graduation, :swept],
+      %{candidates: length(candidates), processed: processed, graduated: graduated},
+      %{}
+    )
+
+    :ok
+  end
+
+  # Returns 1 on a successful graduation (any novelty-gate verdict), 0 on a write error
+  # (left un-stamped so a later tick retries). A per-memory failure never aborts the run.
+  defp graduate(memory) do
+    case Memory.graduate_memory_record(memory, []) do
+      {:ok, _verdict, _article} ->
+        1
+
+      {:error, reason} ->
+        # `tenant_id`/`id` are server-derived UUIDs (safe to interpolate); `reason` is
+        # inspected so a changeset/term can't forge log lines.
+        Logger.warning(
+          "MemoryGraduationSweepWorker: graduation failed tenant=#{memory.tenant_id} " <>
+            "memory=#{memory.id} reason=#{inspect(reason)}"
+        )
+
+        0
+    end
+  end
+
+  # Cross-tenant (BYPASSRLS) candidate scan: live, not-yet-graduated memories at/above
+  # the recall threshold, HOTTEST first (deterministic tiebreak on id), capped. The
+  # WHERE matches the partial index `memories_graduation_sweep_idx`.
+  defp candidate_memories(threshold, limit) do
+    from(m in MemorySchema,
+      where:
+        m.recall_count >= ^threshold and is_nil(m.graduated_at) and
+          is_nil(m.superseded_by),
+      order_by: [desc: m.recall_count, asc: m.id],
+      limit: ^limit
+    )
+    |> AdminRepo.all()
+  end
+end

--- a/priv/repo/migrations/20260717000000_add_memory_graduation_columns.exs
+++ b/priv/repo/migrations/20260717000000_add_memory_graduation_columns.exs
@@ -15,9 +15,24 @@ defmodule Loopctl.Repo.Migrations.AddMemoryGraduationColumns do
   #     deduplicated all mean "now durable"). NULL = not yet graduated. The sweep skips
   #     a non-NULL row so a memory is graduated at most once.
   #
-  # `create_if_not_exists` on every column keeps the migration idempotent/re-runnable.
+  # `*_if_not_exists` on every column/index keeps the migration idempotent/re-runnable.
+  #
+  # CONCURRENTLY (no table lock) since `memories` is a live, write-hot OLTP table
+  # (written on every remember() insert, updated on every recall bump) — a plain
+  # CREATE INDEX would take an ACCESS EXCLUSIVE lock for the whole build and stall
+  # those writes during deploy. The DDL transaction + migration lock are disabled
+  # because CREATE INDEX CONCURRENTLY cannot run inside a transaction, matching the
+  # sibling `20260709000400_add_memories_tenant_inserted_at_index.exs` convention on
+  # this same table.
+  @disable_ddl_transaction true
+  @disable_migration_lock true
 
-  def change do
+  @index "memories_graduation_sweep_idx"
+
+  def up do
+    # Adding a column with a CONSTANT default is a fast, metadata-only operation on
+    # PG11+ (no table rewrite), so the three column adds do not block writes; only
+    # the index build needed CONCURRENTLY.
     alter table(:memories) do
       add_if_not_exists :recall_count, :integer, null: false, default: 0
       add_if_not_exists :last_recalled_at, :utc_datetime_usec, null: true
@@ -34,9 +49,20 @@ defmodule Loopctl.Repo.Migrations.AddMemoryGraduationColumns do
     # (`graduated_at IS NULL AND superseded_by IS NULL`) so the index stays small — it
     # only holds rows still eligible for graduation — and it is a plain btree that does
     # NOT touch the HNSW embedding indexes.
-    create_if_not_exists index(:memories, [:tenant_id, :recall_count],
-                           where: "graduated_at IS NULL AND superseded_by IS NULL",
-                           name: :memories_graduation_sweep_idx
-                         )
+    execute("""
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS #{@index}
+      ON memories (tenant_id, recall_count)
+      WHERE graduated_at IS NULL AND superseded_by IS NULL
+    """)
+  end
+
+  def down do
+    execute("DROP INDEX CONCURRENTLY IF EXISTS #{@index}")
+
+    alter table(:memories) do
+      remove_if_exists :recall_count, :integer
+      remove_if_exists :last_recalled_at, :utc_datetime_usec
+      remove_if_exists :graduated_at, :utc_datetime_usec
+    end
   end
 end

--- a/priv/repo/migrations/20260717000000_add_memory_graduation_columns.exs
+++ b/priv/repo/migrations/20260717000000_add_memory_graduation_columns.exs
@@ -24,9 +24,13 @@ defmodule Loopctl.Repo.Migrations.AddMemoryGraduationColumns do
       add_if_not_exists :graduated_at, :utc_datetime_usec, null: true
     end
 
-    # Partial index backing the cross-tenant graduation sweep candidate query
-    # (`Loopctl.Workers.MemoryGraduationSweepWorker`): live, not-yet-graduated memories
-    # ordered by hotness within a tenant. The predicate matches the sweep's WHERE
+    # Partial index backing the graduation sweep's PER-TENANT candidate query
+    # (`Loopctl.Workers.MemoryGraduationSweepWorker`): for a given tenant, live,
+    # not-yet-graduated memories ordered by hotness. Because the index LEADS with
+    # tenant_id, it serves the sweep's `tenant_id = ? ... ORDER BY recall_count DESC`
+    # scan (equality + in-index descending order, no sort) but could NOT serve a bare
+    # cross-tenant global sort — which is why the sweep queries per tenant and round-robins
+    # rather than issuing one global ORDER BY. The predicate matches the sweep's WHERE
     # (`graduated_at IS NULL AND superseded_by IS NULL`) so the index stays small — it
     # only holds rows still eligible for graduation — and it is a plain btree that does
     # NOT touch the HNSW embedding indexes.

--- a/priv/repo/migrations/20260717000000_add_memory_graduation_columns.exs
+++ b/priv/repo/migrations/20260717000000_add_memory_graduation_columns.exs
@@ -1,0 +1,38 @@
+defmodule Loopctl.Repo.Migrations.AddMemoryGraduationColumns do
+  use Ecto.Migration
+
+  # #411 Gap 3 (PR C): recall-count tracking + graduation of HOT long-term memories
+  # into durable knowledge articles.
+  #
+  #   * `recall_count`    — how many times this memory has been returned by a HEALTHY
+  #     semantic recall (the hotness signal the graduation sweep thresholds on). Bumped
+  #     OFF the recall hot path (see `Loopctl.Memory.bump_recall_counts/2`), so a bump
+  #     failure never affects a recall response.
+  #   * `last_recalled_at`— the instant of the most recent counted recall (observability
+  #     + a future recency signal). NULL until first recalled.
+  #   * `graduated_at`    — set once the memory's content has been graduated to a durable
+  #     knowledge article (any novelty-gate verdict — created/gated_to_draft/duplicate/
+  #     deduplicated all mean "now durable"). NULL = not yet graduated. The sweep skips
+  #     a non-NULL row so a memory is graduated at most once.
+  #
+  # `create_if_not_exists` on every column keeps the migration idempotent/re-runnable.
+
+  def change do
+    alter table(:memories) do
+      add_if_not_exists :recall_count, :integer, null: false, default: 0
+      add_if_not_exists :last_recalled_at, :utc_datetime_usec, null: true
+      add_if_not_exists :graduated_at, :utc_datetime_usec, null: true
+    end
+
+    # Partial index backing the cross-tenant graduation sweep candidate query
+    # (`Loopctl.Workers.MemoryGraduationSweepWorker`): live, not-yet-graduated memories
+    # ordered by hotness within a tenant. The predicate matches the sweep's WHERE
+    # (`graduated_at IS NULL AND superseded_by IS NULL`) so the index stays small — it
+    # only holds rows still eligible for graduation — and it is a plain btree that does
+    # NOT touch the HNSW embedding indexes.
+    create_if_not_exists index(:memories, [:tenant_id, :recall_count],
+                           where: "graduated_at IS NULL AND superseded_by IS NULL",
+                           name: :memories_graduation_sweep_idx
+                         )
+  end
+end

--- a/test/loopctl/memory/graduation_test.exs
+++ b/test/loopctl/memory/graduation_test.exs
@@ -132,6 +132,74 @@ defmodule Loopctl.Memory.GraduationTest do
       assert article.project_id == nil
     end
 
+    test "re_scope: :global on an ALREADY-graduated memory refuses loudly (no silent wrong-scope success)",
+         %{scope: scope, project: project, tenant: tenant} do
+      memory =
+        fixture(:memory,
+          tenant_id: scope.tenant_id,
+          subject_id: scope.subject_id,
+          project_id: project.id,
+          text: "worth globalizing after it proved itself in-project"
+        )
+
+      # First: default (project) graduation → a project-scoped article.
+      assert {:ok, _v1, project_article} = Memory.graduate_memory(scope, memory.id)
+      assert project_article.project_id == project.id
+
+      # A memory has at most one graduated article (the (tenant_id, title) unique index),
+      # so re_scope: :global on the now-graduated memory must NOT silently return the
+      # project article as success — it refuses loudly, leaving the project article intact.
+      assert {:error, :already_graduated} =
+               Memory.graduate_memory(scope, memory.id, re_scope: :global)
+
+      count =
+        from(a in Article, where: a.tenant_id == ^tenant.id) |> AdminRepo.aggregate(:count, :id)
+
+      assert count == 1
+    end
+
+    test "re_scope: :global works on a FIRST (ungraduated) graduation", %{
+      scope: scope,
+      project: project
+    } do
+      memory =
+        fixture(:memory,
+          tenant_id: scope.tenant_id,
+          subject_id: scope.subject_id,
+          project_id: project.id,
+          text: "globalize me on first graduation"
+        )
+
+      assert {:ok, _v, article} = Memory.graduate_memory(scope, memory.id, re_scope: :global)
+      assert article.project_id == nil
+    end
+
+    test "a fell-open novelty gate (embedding backend down) is NOT stamped and creates no article",
+         %{scope: scope, project: project, tenant: tenant} do
+      memory =
+        fixture(:memory,
+          tenant_id: scope.tenant_id,
+          subject_id: scope.subject_id,
+          project_id: project.id,
+          text: "content the gate could not assess"
+        )
+
+      # The gate falls open with :unknown when the embedding backend is unavailable.
+      Mox.stub(Loopctl.MockProposalAssessor, :assess, fn _tenant_id, _attrs, _opts ->
+        %{verdict: :unknown, score: nil, neighbors: []}
+      end)
+
+      # Automated/graduation callers pass on_gate_unavailable: :skip, so a fell-open
+      # assessment is a retryable error — no un-deduplicated article is injected and the
+      # memory stays eligible (graduated_at NULL) for a later tick once embeddings recover.
+      assert {:error, :gate_unavailable} = Memory.graduate_memory(scope, memory.id)
+      assert is_nil(reload(memory).graduated_at)
+
+      assert 0 ==
+               from(a in Article, where: a.tenant_id == ^tenant.id)
+               |> AdminRepo.aggregate(:count, :id)
+    end
+
     test "a foreign (other-subject/tenant) memory id returns :not_found — no cross-subject oracle",
          %{scope: scope, project: project} do
       memory =

--- a/test/loopctl/memory/graduation_test.exs
+++ b/test/loopctl/memory/graduation_test.exs
@@ -37,7 +37,18 @@ defmodule Loopctl.Memory.GraduationTest do
       assert reloaded.recall_count == 1
       refute is_nil(reloaded.last_recalled_at)
 
-      # A second recall bumps again — the counter accumulates hotness.
+      # A second recall WITHIN the cooldown window does NOT bump: the dedup stops a tight
+      # single-agent loop from inflating the hotness signal and gaming graduation.
+      assert %{meta: %{fallback: false}} = Memory.recall(scope, query: "sky", limit: 5)
+      assert reload(target).recall_count == 1
+
+      # Once the cooldown has elapsed (simulated by ageing last_recalled_at past the
+      # window), a fresh recall bumps again — genuine cross-window hotness accumulates.
+      from(m in MemorySchema, where: m.id == ^target.id)
+      |> AdminRepo.update_all(
+        set: [last_recalled_at: DateTime.add(DateTime.utc_now(), -2, :hour)]
+      )
+
       assert %{meta: %{fallback: false}} = Memory.recall(scope, query: "sky", limit: 5)
       assert reload(target).recall_count == 2
     end

--- a/test/loopctl/memory/graduation_test.exs
+++ b/test/loopctl/memory/graduation_test.exs
@@ -1,0 +1,161 @@
+defmodule Loopctl.Memory.GraduationTest do
+  @moduledoc """
+  #411 Gap 3: recall-count tracking (off the recall hot path) and the explicit
+  memory→knowledge graduation primitive (`Loopctl.Memory.graduate_memory/3`), including
+  the local→global re-scope option.
+
+  Async: recall routes through `Loopctl.HeavyRead` (AdminRepo in test) and all writes
+  through `Loopctl.AdminRepo`, so everything shares the one sandbox connection. The
+  recall-count bump runs in `:sync` mode in test (config/test.exs) so it executes inside
+  the test process rather than a spawned task that would not see the sandbox.
+  """
+  use Loopctl.DataCase, async: true
+  use Oban.Testing, repo: Loopctl.Repo
+
+  import Ecto.Query
+  import Mox
+
+  setup :verify_on_exit!
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Memory
+  alias Loopctl.Memory.Memory, as: MemorySchema
+
+  defp reload(memory), do: AdminRepo.get(MemorySchema, memory.id)
+
+  describe "recall_count bump (off the hot path)" do
+    test "a healthy semantic recall increments recall_count + last_recalled_at for returned rows" do
+      scope = fixture(:memory_scope)
+      Knowledge.reset_circuit_breaker(scope.tenant_id)
+      {:ok, target} = Memory.remember(scope, %{tier: :long_term, text: "the sky is blue today"})
+
+      assert %{meta: %{fallback: false}} = Memory.recall(scope, query: "sky", limit: 5)
+
+      reloaded = reload(target)
+      assert reloaded.recall_count == 1
+      refute is_nil(reloaded.last_recalled_at)
+
+      # A second recall bumps again — the counter accumulates hotness.
+      assert %{meta: %{fallback: false}} = Memory.recall(scope, query: "sky", limit: 5)
+      assert reload(target).recall_count == 2
+    end
+
+    test "the degraded ILIKE fallback path does NOT bump (hotness signal stays clean)" do
+      scope = fixture(:memory_scope)
+      Knowledge.reset_circuit_breaker(scope.tenant_id)
+      {:ok, target} = Memory.remember(scope, %{tier: :long_term, text: "the alamo is in texas"})
+
+      # Force embedding generation to fail so recall takes the ILIKE fallback.
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _t, _text ->
+        {:error, :circuit_open}
+      end)
+
+      assert %{results: [{_m, _} | _], meta: %{fallback: true}} =
+               Memory.recall(scope, query: "alamo", limit: 5)
+
+      assert reload(target).recall_count == 0
+      assert is_nil(reload(target).last_recalled_at)
+    end
+
+    test "an include_superseded oversight read does NOT bump live memories' hotness" do
+      scope = fixture(:memory_scope)
+      Knowledge.reset_circuit_breaker(scope.tenant_id)
+      {:ok, target} = Memory.remember(scope, %{tier: :long_term, text: "oversight read fact"})
+
+      assert %{meta: %{fallback: false}} =
+               Memory.recall(scope, query: "oversight", limit: 5, include_superseded: true)
+
+      assert reload(target).recall_count == 0
+    end
+
+    test "bump_recall_counts is best-effort: a bad id is swallowed, never raised" do
+      scope = fixture(:memory_scope)
+      assert :ok = Memory.bump_recall_counts(scope.tenant_id, ["not-a-uuid"])
+      assert :ok = Memory.bump_recall_counts(scope.tenant_id, [])
+    end
+  end
+
+  describe "graduate_memory/3 (explicit primitive + local→global re-scope)" do
+    setup do
+      tenant = fixture(:tenant)
+      project = fixture(:project, tenant_id: tenant.id)
+      scope = fixture(:memory_scope, tenant_id: tenant.id, project_id: project.id)
+      %{tenant: tenant, project: project, scope: scope}
+    end
+
+    test "graduates a memory into an article inheriting its project scope by default", %{
+      scope: scope,
+      project: project
+    } do
+      memory =
+        fixture(:memory,
+          tenant_id: scope.tenant_id,
+          subject_id: scope.subject_id,
+          project_id: project.id,
+          text: "runbook: restart the worker pool"
+        )
+
+      assert {:ok, verdict, article} = Memory.graduate_memory(scope, memory.id)
+      assert verdict in [:created, :gated_to_draft, :duplicate, :deduplicated]
+      assert article.project_id == project.id
+      assert article.body == "runbook: restart the worker pool"
+      assert article.category == :finding
+      refute is_nil(reload(memory).graduated_at)
+    end
+
+    test "re_scope: :global promotes a PROJECT memory to a tenant-wide (project_id nil) article",
+         %{scope: scope, project: project} do
+      memory =
+        fixture(:memory,
+          tenant_id: scope.tenant_id,
+          subject_id: scope.subject_id,
+          project_id: project.id,
+          text: "this fact is tenant-wide worthy"
+        )
+
+      assert {:ok, _verdict, article} =
+               Memory.graduate_memory(scope, memory.id, re_scope: :global)
+
+      assert article.project_id == nil
+    end
+
+    test "a foreign (other-subject/tenant) memory id returns :not_found — no cross-subject oracle",
+         %{scope: scope, project: project} do
+      memory =
+        fixture(:memory,
+          tenant_id: scope.tenant_id,
+          subject_id: scope.subject_id,
+          project_id: project.id,
+          text: "owned by scope"
+        )
+
+      other = fixture(:memory_scope)
+      assert {:error, :not_found} = Memory.graduate_memory(other, memory.id)
+      # And it was not graduated by the failed cross-subject attempt.
+      assert is_nil(reload(memory).graduated_at)
+    end
+
+    test "graduation article count is one per memory (idempotent re-graduation)", %{
+      scope: scope,
+      tenant: tenant
+    } do
+      memory =
+        fixture(:memory,
+          tenant_id: scope.tenant_id,
+          subject_id: scope.subject_id,
+          text: "graduate me once"
+        )
+
+      assert {:ok, _v1, a1} = Memory.graduate_memory(scope, memory.id)
+      assert {:ok, _v2, a2} = Memory.graduate_memory(scope, memory.id)
+      assert a1.id == a2.id
+
+      count =
+        from(a in Article, where: a.tenant_id == ^tenant.id) |> AdminRepo.aggregate(:count, :id)
+
+      assert count == 1
+    end
+  end
+end

--- a/test/loopctl/oban_plugins_config_test.exs
+++ b/test/loopctl/oban_plugins_config_test.exs
@@ -107,6 +107,37 @@ defmodule Loopctl.ObanPluginsConfigTest do
     end
   end
 
+  describe "#411 Gap 3: MemoryGraduationSweepWorker crontab entry" do
+    setup do
+      plugins = Application.get_env(:loopctl, Oban)[:plugins]
+
+      {Oban.Plugins.Cron, cron_opts} =
+        Enum.find(plugins, &match?({Oban.Plugins.Cron, _}, &1))
+
+      entry =
+        Enum.find(cron_opts[:crontab], fn
+          {_schedule, Loopctl.Workers.MemoryGraduationSweepWorker} -> true
+          {_schedule, Loopctl.Workers.MemoryGraduationSweepWorker, _opts} -> true
+          _ -> false
+        end)
+
+      %{entry: entry}
+    end
+
+    test "the MemoryGraduationSweepWorker entry exists in the crontab", %{entry: entry} do
+      assert entry,
+             "expected a MemoryGraduationSweepWorker crontab entry that graduates hot " <>
+               "memories into durable knowledge articles (#411 Gap 3)"
+    end
+
+    test "its schedule is the hourly sweep (slower than the 10-min promotion sweep)", %{
+      entry: entry
+    } do
+      schedule = elem(entry, 0)
+      assert schedule == "0 * * * *"
+    end
+  end
+
   describe "US-35.3: sth_sweep_cron/0 (config-based DI, runtime-tunable)" do
     test "defaults to a 5-minute sweep when STH_SWEEP_CRON is unset" do
       # STH_SWEEP_CRON is not set in the test environment, so the default applies.

--- a/test/loopctl/workers/memory_graduation_sweep_worker_test.exs
+++ b/test/loopctl/workers/memory_graduation_sweep_worker_test.exs
@@ -1,0 +1,172 @@
+defmodule Loopctl.Workers.MemoryGraduationSweepWorkerTest do
+  @moduledoc """
+  #411 Gap 3: the hourly cadence that graduates HOT long-term memories
+  (`recall_count >= threshold`, not yet graduated) into durable knowledge articles via
+  the novelty gate.
+
+  Async: all writes route through `Loopctl.AdminRepo` (which points at the sandbox
+  connection in test), and the novelty gate defaults to `:novel` (DataCase stub) so a
+  candidate creates an article on the normal path unless a test overrides the assessor.
+  """
+  use Loopctl.DataCase, async: true
+  use Oban.Testing, repo: Loopctl.Repo
+
+  import Ecto.Query
+  import Mox
+
+  setup :verify_on_exit!
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Memory.Memory, as: MemorySchema
+  alias Loopctl.Workers.MemoryGraduationSweepWorker
+
+  # A live memory with a set recall_count (recall_count is not castable — it is bumped
+  # off the recall hot path — so we stamp it directly, mirroring a memory that has been
+  # recalled `count` times).
+  defp hot_memory(tenant_id, opts) do
+    count = Keyword.get(opts, :recall_count, 5)
+
+    memory =
+      fixture(:memory,
+        tenant_id: tenant_id,
+        subject_id: Keyword.get(opts, :subject_id, "subj-#{System.unique_integer([:positive])}"),
+        project_id: Keyword.get(opts, :project_id),
+        text: Keyword.get(opts, :text, "durable fact #{System.unique_integer([:positive])}"),
+        tags: Keyword.get(opts, :tags, [])
+      )
+
+    {_n, _} =
+      from(m in MemorySchema, where: m.id == ^memory.id)
+      |> AdminRepo.update_all(set: [recall_count: count])
+
+    %{memory | recall_count: count}
+  end
+
+  defp articles_for(tenant_id) do
+    from(a in Article, where: a.tenant_id == ^tenant_id) |> AdminRepo.all()
+  end
+
+  defp reload(memory), do: AdminRepo.get(MemorySchema, memory.id)
+
+  describe "perform/1 — graduation of hot memories" do
+    test "a hot, ungraduated memory is graduated into a knowledge article and stamped" do
+      tenant = fixture(:tenant)
+      memory = hot_memory(tenant.id, recall_count: 5, text: "the deploy runbook lives in ops")
+
+      assert :ok = perform_job(MemoryGraduationSweepWorker, %{})
+
+      assert [article] = articles_for(tenant.id)
+      assert article.body == "the deploy runbook lives in ops"
+      assert article.category == :finding
+      assert article.project_id == nil
+      assert article.metadata["source"] == "memory_graduation"
+      assert article.metadata["graduated_from_memory_id"] == memory.id
+
+      # The memory is stamped so a later sweep skips it.
+      refute is_nil(reload(memory).graduated_at)
+    end
+
+    test "a below-threshold memory is NOT graduated" do
+      tenant = fixture(:tenant)
+      cold = hot_memory(tenant.id, recall_count: 1, text: "rarely recalled")
+
+      assert :ok = perform_job(MemoryGraduationSweepWorker, %{})
+
+      assert [] == articles_for(tenant.id)
+      assert is_nil(reload(cold).graduated_at)
+    end
+
+    test "a project-scoped memory graduates to an article in the SAME project (no re-scope)" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, tenant_id: tenant.id)
+      _m = hot_memory(tenant.id, recall_count: 4, project_id: project.id, text: "project fact")
+
+      assert :ok = perform_job(MemoryGraduationSweepWorker, %{})
+
+      assert [article] = articles_for(tenant.id)
+      assert article.project_id == project.id
+    end
+
+    test "a second sweep does NOT re-graduate (graduated_at set) — no duplicate article" do
+      tenant = fixture(:tenant)
+      _m = hot_memory(tenant.id, recall_count: 5, text: "graduate once")
+
+      assert :ok = perform_job(MemoryGraduationSweepWorker, %{})
+      assert [_only] = articles_for(tenant.id)
+
+      # Second tick: the memory is already stamped, so it is not even a candidate.
+      assert :ok = perform_job(MemoryGraduationSweepWorker, %{})
+      assert length(articles_for(tenant.id)) == 1
+    end
+
+    test "novelty gate dedups a semantically-duplicate memory (verdict :duplicate) but still stamps it" do
+      tenant = fixture(:tenant)
+      _first = hot_memory(tenant.id, recall_count: 5, text: "the canonical durable fact")
+
+      # First sweep creates the canonical article.
+      assert :ok = perform_job(MemoryGraduationSweepWorker, %{})
+      assert [canonical] = articles_for(tenant.id)
+
+      # A second hot memory whose content the gate judges a DUPLICATE of the canonical.
+      dup = hot_memory(tenant.id, recall_count: 5, text: "the canonical durable fact (again)")
+
+      Mox.stub(Loopctl.MockProposalAssessor, :assess, fn _tenant_id, _attrs, _opts ->
+        %{
+          verdict: :duplicate,
+          score: 0.99,
+          neighbors: [%{id: canonical.id, title: canonical.title, similarity_score: 0.99}]
+        }
+      end)
+
+      assert :ok = perform_job(MemoryGraduationSweepWorker, %{})
+
+      # No NEW article — the gate deduped — but the duplicate memory is still stamped
+      # graduated so the sweep does not reprocess it forever.
+      assert length(articles_for(tenant.id)) == 1
+      refute is_nil(reload(dup).graduated_at)
+    end
+  end
+
+  describe "perform/1 — tenant isolation + budget" do
+    test "graduates within EACH tenant, attributing the article to the memory's own tenant" do
+      t1 = fixture(:tenant)
+      t2 = fixture(:tenant)
+      _m1 = hot_memory(t1.id, recall_count: 5, text: "tenant one fact")
+      _m2 = hot_memory(t2.id, recall_count: 5, text: "tenant two fact")
+
+      assert :ok = perform_job(MemoryGraduationSweepWorker, %{})
+
+      assert [a1] = articles_for(t1.id)
+      assert [a2] = articles_for(t2.id)
+      assert a1.body == "tenant one fact"
+      assert a2.body == "tenant two fact"
+    end
+
+    test "the per-run execution budget caps the number graduated in one tick" do
+      tenant = fixture(:tenant)
+      _a = hot_memory(tenant.id, recall_count: 9, text: "hot A")
+      _b = hot_memory(tenant.id, recall_count: 8, text: "hot B")
+
+      prev = Application.get_env(:loopctl, :memory_graduation_max_per_run)
+      Application.put_env(:loopctl, :memory_graduation_max_per_run, 1)
+      on_exit(fn -> restore(:memory_graduation_max_per_run, prev) end)
+
+      assert :ok = perform_job(MemoryGraduationSweepWorker, %{})
+
+      # Exactly one graduated this run (the cap); the other remains for the next tick.
+      assert length(articles_for(tenant.id)) == 1
+
+      ungraduated =
+        from(m in MemorySchema,
+          where: m.tenant_id == ^tenant.id and is_nil(m.graduated_at)
+        )
+        |> AdminRepo.aggregate(:count, :id)
+
+      assert ungraduated == 1
+    end
+  end
+
+  defp restore(key, nil), do: Application.delete_env(:loopctl, key)
+  defp restore(key, val), do: Application.put_env(:loopctl, key, val)
+end

--- a/test/loopctl/workers/memory_graduation_sweep_worker_test.exs
+++ b/test/loopctl/workers/memory_graduation_sweep_worker_test.exs
@@ -63,6 +63,15 @@ defmodule Loopctl.Workers.MemoryGraduationSweepWorkerTest do
       assert article.metadata["source"] == "memory_graduation"
       assert article.metadata["graduated_from_memory_id"] == memory.id
 
+      # PUBLISHED (not draft) so it is discoverable by knowledge_search/context — the wiki
+      # actually grows.
+      assert article.status == :published
+
+      # OWNER-visible, keyed to the memory's subject: subject-level isolation is preserved
+      # (the private working memory is NOT exposed tenant-wide to peer agents).
+      assert article.metadata["visibility"] == "owner"
+      assert article.metadata["agent_id"] == memory.subject_id
+
       # The memory is stamped so a later sweep skips it.
       refute is_nil(reload(memory).graduated_at)
     end
@@ -102,14 +111,31 @@ defmodule Loopctl.Workers.MemoryGraduationSweepWorkerTest do
 
     test "novelty gate dedups a semantically-duplicate memory (verdict :duplicate) but still stamps it" do
       tenant = fixture(:tenant)
-      _first = hot_memory(tenant.id, recall_count: 5, text: "the canonical durable fact")
+      # SAME subject for both memories: a graduated article is OWNER-visible (subject-scoped),
+      # so the gate can only dedup against an article the graduating subject can see. Two
+      # memories from the SAME subject is the case the novelty gate must collapse to one
+      # article (a distinct subject would — correctly — get its own owner-private copy rather
+      # than leak/dedup across the subject-isolation boundary).
+      subject_id = "subj-dedup-#{System.unique_integer([:positive])}"
+
+      _first =
+        hot_memory(tenant.id,
+          recall_count: 5,
+          subject_id: subject_id,
+          text: "the canonical durable fact"
+        )
 
       # First sweep creates the canonical article.
       assert :ok = perform_job(MemoryGraduationSweepWorker, %{})
       assert [canonical] = articles_for(tenant.id)
 
-      # A second hot memory whose content the gate judges a DUPLICATE of the canonical.
-      dup = hot_memory(tenant.id, recall_count: 5, text: "the canonical durable fact (again)")
+      # A second hot memory (same subject) whose content the gate judges a DUPLICATE.
+      dup =
+        hot_memory(tenant.id,
+          recall_count: 5,
+          subject_id: subject_id,
+          text: "the canonical durable fact (again)"
+        )
 
       Mox.stub(Loopctl.MockProposalAssessor, :assess, fn _tenant_id, _attrs, _opts ->
         %{
@@ -125,6 +151,30 @@ defmodule Loopctl.Workers.MemoryGraduationSweepWorkerTest do
       # graduated so the sweep does not reprocess it forever.
       assert length(articles_for(tenant.id)) == 1
       refute is_nil(reload(dup).graduated_at)
+    end
+
+    test "a memory with article-invalid tags still graduates (sanitized) — no per-slot livelock" do
+      tenant = fixture(:tenant)
+
+      # Memory tags are unvalidated at the memory tier; the Article changeset enforces
+      # count/length/format. A verbatim copy would fail the changeset EVERY sweep (a
+      # livelock re-spending embedding budget). These are all article-invalid: too many,
+      # over-long, bad format, and non-binary — only "keeper" survives sanitization.
+      bad_tags =
+        [String.duplicate("x", 200), "has spaces", "bad!char", "keeper"] ++
+          Enum.map(1..60, &"tag#{&1}")
+
+      memory =
+        hot_memory(tenant.id, recall_count: 5, text: "fact with hostile tags", tags: bad_tags)
+
+      assert :ok = perform_job(MemoryGraduationSweepWorker, %{})
+
+      assert [article] = articles_for(tenant.id)
+      assert length(article.tags) <= 50
+      assert "keeper" in article.tags
+      refute "has spaces" in article.tags
+      # Stamped, so the next tick does not re-attempt (and re-spend) forever.
+      refute is_nil(reload(memory).graduated_at)
     end
   end
 
@@ -164,6 +214,28 @@ defmodule Loopctl.Workers.MemoryGraduationSweepWorkerTest do
         |> AdminRepo.aggregate(:count, :id)
 
       assert ungraduated == 1
+    end
+
+    test "per-tenant fairness: a hotter tenant cannot starve another tenant's graduation" do
+      hot = fixture(:tenant)
+      other = fixture(:tenant)
+
+      # `hot` owns the two HOTTEST memories; `other` owns a cooler one. Under a naive
+      # global hottest-first scan with a per-run budget of 2, `hot`'s two would consume the
+      # whole budget and STARVE `other`. Round-robin across tenants must serve `other` too.
+      _h1 = hot_memory(hot.id, recall_count: 9, text: "hot tenant fact A")
+      _h2 = hot_memory(hot.id, recall_count: 8, text: "hot tenant fact B")
+      cool = hot_memory(other.id, recall_count: 5, text: "other tenant fact")
+
+      prev = Application.get_env(:loopctl, :memory_graduation_max_per_run)
+      Application.put_env(:loopctl, :memory_graduation_max_per_run, 2)
+      on_exit(fn -> restore(:memory_graduation_max_per_run, prev) end)
+
+      assert :ok = perform_job(MemoryGraduationSweepWorker, %{})
+
+      # The cooler tenant is graduated within the shared budget — not starved.
+      refute is_nil(reload(cool).graduated_at)
+      assert [_one] = articles_for(other.id)
     end
   end
 


### PR DESCRIPTION
## #411 Gap 3: graduate hot long-term memories → durable knowledge articles

Completes loopctl #411. This is the "grows after each session" mechanism — consolidate
proven-valuable memory by recall frequency, deduped via the novelty gate, rather than
accumulating raw logs. A distinct tier ABOVE the existing session→memories promotion
(untouched).

### What changed
- **Migration `20260717000000`**: `recall_count`, `last_recalled_at`, `graduated_at` on
  `memories` + a partial btree index matching the sweep predicate. No HNSW impact.
- **Off-hot-path recall bump**: `recall/2` fires a best-effort, tenant-scoped `update_all`
  under `TaskSupervisor` (async default, sync in tests), wrapped in `rescue` — a bump
  failure can never fail a recall. Bumps ONLY on the healthy semantic path (degraded
  ILIKE fallback, shed-pool empty, and `include_superseded` oversight reads do NOT bump),
  so hotness isn't polluted.
- **`MemoryGraduationSweepWorker`** (hourly Oban cron): cross-tenant candidate scan for
  live, ungraduated memories at/above the recall threshold, hottest first, bounded by a
  per-run budget. Each candidate graduates via the novelty gate (`propose_article`,
  attributed to the memory's own `tenant_id`) and stamps `graduated_at` on any success —
  graduated at most once; semantic dups dedup; Oban uniqueness + a stable per-memory
  `idempotency_key` make re-graduation races yield one article.
- **`graduate_memory/3`** primitive: `(tenant_id, subject_id)`-authorized, with a
  `re_scope: :global` option for local→global re-scoping. The sweep NEVER auto-re-scopes
  (over-generalizing a project fact is the mis-scoping the dedup gate can't catch —
  article 5bf264d5), so it's an explicit caller action.
- Config: `memory_graduation_recall_threshold` (3), `_max_per_run` (50), `_scan_limit`
  (500), `memory_recall_bump_mode`.

### Tenant isolation
The cross-tenant scan is read-only candidate selection; every write (bump `update_all`,
`propose_article`) is scoped to the source memory's own tenant. Verified.

### Tests (27)
Bump increments on healthy path / no-bump on fallback+superseded / best-effort swallow;
sweep graduates hot→article via the gate, skips below-threshold, no re-graduate/no-dup on
a 2nd run, novelty `:duplicate` dedup-but-stamp, tenant isolation + project attribution,
budget cap; primitive re-scope + `:not_found` + idempotency. `mix precommit` green (4833
tests); fresh drop/create/migrate proves no version collision.

Closes #411.
