### PR TITLE
KB-only project scope creatable by agent-rooted tenants (kind: work | kb)

### DIFF
--- a/lib/loopctl/api_spec/schemas.ex
+++ b/lib/loopctl/api_spec/schemas.ex
@@ -868,6 +868,11 @@ defmodule Loopctl.ApiSpec.Schemas do
         description: %Schema{type: :string, nullable: true},
         tech_stack: %Schema{type: :string, nullable: true},
         status: %Schema{type: :string, enum: ["active", "archived"]},
+        kind: %Schema{
+          type: :string,
+          enum: ["work", "kb"],
+          description: "work = full work-breakdown project; kb = knowledge-only scope"
+        },
         metadata: %Schema{type: :object, additionalProperties: true},
         inserted_at: %Schema{type: :string, format: :"date-time"},
         updated_at: %Schema{type: :string, format: :"date-time"}

--- a/lib/loopctl/projects.ex
+++ b/lib/loopctl/projects.ex
@@ -46,9 +46,12 @@ defmodule Loopctl.Projects do
     actor_label = Keyword.get(opts, :actor_label)
     actor_type = Keyword.get(opts, :actor_type, "api_key")
     metadata = Keyword.get(opts, :metadata, %{})
+    # `kind` is set on the struct, NOT via cast — a request body can never mint or elevate
+    # a scope's kind. Defaults to :work; the KB-scope create path passes `kind: :kb`.
+    kind = Keyword.get(opts, :kind, :work)
 
     changeset =
-      %Project{tenant_id: tenant_id}
+      %Project{tenant_id: tenant_id, kind: kind}
       |> Project.create_changeset(attrs)
 
     multi =
@@ -73,7 +76,8 @@ defmodule Loopctl.Projects do
           new_state: %{
             "name" => project.name,
             "slug" => project.slug,
-            "status" => to_string(project.status)
+            "status" => to_string(project.status),
+            "kind" => to_string(project.kind)
           }
         }
       end)

--- a/lib/loopctl/projects/project.ex
+++ b/lib/loopctl/projects/project.ex
@@ -27,6 +27,7 @@ defmodule Loopctl.Projects.Project do
   @type t :: %__MODULE__{}
 
   @statuses [:active, :archived]
+  @kinds [:work, :kb]
   @slug_format ~r/^[a-z0-9][a-z0-9-]*[a-z0-9]$/
   @mission_max_length 2_000
 
@@ -40,6 +41,7 @@ defmodule Loopctl.Projects.Project do
              :description,
              :tech_stack,
              :status,
+             :kind,
              :mission,
              :metadata,
              :inserted_at,
@@ -54,6 +56,11 @@ defmodule Loopctl.Projects.Project do
     field :description, :string
     field :tech_stack, :string
     field :status, Ecto.Enum, values: @statuses, default: :active
+    # `:work` (default) carries the chain-of-custody surface; `:kb` is a knowledge-only
+    # scope. Deliberately NOT in any `cast/3` list — it is set programmatically in
+    # `Projects.create_project/3` (mirroring how `tenant_id` and `trust_tier` are kept
+    # out of cast), so a request body can never elevate a `:kb` scope into a `:work` one.
+    field :kind, Ecto.Enum, values: @kinds, default: :work
     field :mission, :string
     field :metadata, :map, default: %{}
 
@@ -106,6 +113,12 @@ defmodule Loopctl.Projects.Project do
   """
   @spec statuses() :: [atom()]
   def statuses, do: @statuses
+
+  @doc """
+  Returns the list of valid project kinds.
+  """
+  @spec kinds() :: [atom()]
+  def kinds, do: @kinds
 
   defp validate_slug(changeset) do
     changeset

--- a/lib/loopctl_web/controllers/epic_controller.ex
+++ b/lib/loopctl_web/controllers/epic_controller.ex
@@ -28,6 +28,10 @@ defmodule LoopctlWeb.EpicController do
   # US-26.7.1 — work-breakdown surface requires a human-anchored tenant.
   plug LoopctlWeb.Plugs.RequireHumanAnchor when action in [:create, :update, :delete]
 
+  # Belt-and-suspenders: a :kb scope can never host epics (positive invariant, independent
+  # of the tier gate above).
+  plug LoopctlWeb.Plugs.RequireWorkProject when action in [:create]
+
   tags(["Epics"])
 
   operation(:create,

--- a/lib/loopctl_web/controllers/import_export_controller.ex
+++ b/lib/loopctl_web/controllers/import_export_controller.ex
@@ -26,6 +26,9 @@ defmodule LoopctlWeb.ImportExportController do
   # NOT applied to :export_project — export is a read-only KB-tier-safe op.
   plug LoopctlWeb.Plugs.RequireHumanAnchor when action in [:import_project]
 
+  # A :kb scope can never receive an imported work breakdown. Import uses the :id path param.
+  plug LoopctlWeb.Plugs.RequireWorkProject, [param: "id"] when action in [:import_project]
+
   tags(["Import/Export"])
 
   operation(:import_project,

--- a/lib/loopctl_web/controllers/orchestrator_state_controller.ex
+++ b/lib/loopctl_web/controllers/orchestrator_state_controller.ex
@@ -21,6 +21,10 @@ defmodule LoopctlWeb.OrchestratorStateController do
   # US-26.7.1 — work-breakdown surface requires a human-anchored tenant.
   plug LoopctlWeb.Plugs.RequireHumanAnchor when action in [:save, :show, :history]
 
+  # Orchestrator state is chain-of-custody coordination — a :kb scope can never carry it.
+  # Guards the write; :show/:history are reads (a :kb scope simply has no state to return).
+  plug LoopctlWeb.Plugs.RequireWorkProject when action in [:save]
+
   tags(["Orchestrator"])
 
   operation(:save,

--- a/lib/loopctl_web/controllers/project_controller.ex
+++ b/lib/loopctl_web/controllers/project_controller.ex
@@ -23,9 +23,12 @@ defmodule LoopctlWeb.ProjectController do
   plug LoopctlWeb.Plugs.RequireRole, [role: :user] when action in [:delete]
 
   plug LoopctlWeb.Plugs.RequireRole,
-       [role: :agent] when action in [:index, :show, :progress, :resolve]
+       [role: :agent] when action in [:index, :show, :progress, :resolve, :create_kb_scope]
 
   # US-26.7.1 — work-breakdown surface requires a human-anchored tenant.
+  # NOTE: :create_kb_scope is deliberately NOT gated here — a :kb scope carries no
+  # chain-of-custody surface (RequireWorkProject bars work attachment), so an agent-rooted
+  # tenant may create one to partition its own knowledge. Extends owner decision #331.
   plug LoopctlWeb.Plugs.RequireHumanAnchor when action in [:create, :update, :delete]
 
   tags(["Projects"])
@@ -37,6 +40,22 @@ defmodule LoopctlWeb.ProjectController do
     responses: %{
       201 => {"Project created", "application/json", Schemas.ProjectResponse},
       422 => {"Validation error", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  operation(:create_kb_scope,
+    summary: "Create knowledge-only project scope",
+    description:
+      "Creates a knowledge-only project scope (kind: kb). Available at agent+ role and NOT " <>
+        "gated by the human-anchor tier, because a kb scope is structurally barred from the " <>
+        "work-breakdown / chain-of-custody surface. Use it to partition knowledge articles " <>
+        "by repo on the agent-rooted KB tier.",
+    request_body: {"KB scope params", "application/json", Schemas.ProjectCreateRequest},
+    responses: %{
+      201 => {"KB scope created", "application/json", Schemas.ProjectResponse},
+      422 =>
+        {"Validation error or project limit reached", "application/json", Schemas.ErrorResponse},
       429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
     }
   )
@@ -153,6 +172,43 @@ defmodule LoopctlWeb.ProjectController do
     }
 
     case Projects.create_project(tenant_id, attrs, audit_opts) do
+      {:ok, project} ->
+        conn
+        |> put_status(:created)
+        |> json(%{project: project_json(project)})
+
+      {:error, :project_limit_reached} ->
+        {:error, :unprocessable_entity, "Project limit reached for this tenant"}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:error, changeset}
+    end
+  end
+
+  @doc """
+  POST /api/v1/kb-scopes
+
+  Creates a knowledge-only project scope (`kind: :kb`). Available at agent+ role and NOT
+  gated by `RequireHumanAnchor`: a `:kb` scope carries no chain-of-custody surface
+  (`RequireWorkProject` bars work attachment), so an agent-rooted (KB-tier) tenant may
+  create one to partition its knowledge articles by repo. Delete stays user + human-anchored.
+  Extends owner decision #331 (the KB content surface is fully agent-usable) to KB scoping.
+  """
+  def create_kb_scope(conn, params) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+    audit_opts = AuditContext.from_conn(conn)
+
+    # No `mission`: a mission cascades into story context, and a :kb scope has no stories.
+    attrs = %{
+      name: params["name"],
+      slug: params["slug"],
+      repo_url: params["repo_url"],
+      description: params["description"],
+      tech_stack: params["tech_stack"],
+      metadata: params["metadata"] || %{}
+    }
+
+    case Projects.create_project(tenant_id, attrs, Keyword.put(audit_opts, :kind, :kb)) do
       {:ok, project} ->
         conn
         |> put_status(:created)
@@ -365,6 +421,7 @@ defmodule LoopctlWeb.ProjectController do
       description: project.description,
       tech_stack: project.tech_stack,
       status: project.status,
+      kind: project.kind,
       mission: project.mission,
       metadata: project.metadata,
       inserted_at: project.inserted_at,

--- a/lib/loopctl_web/controllers/story_controller.ex
+++ b/lib/loopctl_web/controllers/story_controller.ex
@@ -36,6 +36,10 @@ defmodule LoopctlWeb.StoryController do
   plug LoopctlWeb.Plugs.RequireHumanAnchor
        when action in [:create, :create_in_project, :update, :delete]
 
+  # A :kb scope can never host stories created directly under a project. (`create` goes
+  # through :epic_id, and epics cannot exist on a :kb scope, so it is transitively barred.)
+  plug LoopctlWeb.Plugs.RequireWorkProject when action in [:create_in_project]
+
   tags(["Stories"])
 
   operation(:create,

--- a/lib/loopctl_web/controllers/ui_test_controller.ex
+++ b/lib/loopctl_web/controllers/ui_test_controller.ex
@@ -24,6 +24,11 @@ defmodule LoopctlWeb.UiTestController do
   plug LoopctlWeb.Plugs.RequireRole,
        [role: :agent] when action in [:create, :index, :show, :add_finding, :complete]
 
+  # A :kb scope can never host ui-test runs (a work-breakdown surface). This is the
+  # load-bearing guard: ui-tests are agent-accessible and NOT human-anchor gated, so once
+  # agent-rooted tenants can create :kb scopes, this plug is what keeps work off them.
+  plug LoopctlWeb.Plugs.RequireWorkProject when action in [:create, :add_finding, :complete]
+
   tags(["UI Tests"])
 
   operation(:create,

--- a/lib/loopctl_web/plugs/require_work_project.ex
+++ b/lib/loopctl_web/plugs/require_work_project.ex
@@ -1,0 +1,49 @@
+defmodule LoopctlWeb.Plugs.RequireWorkProject do
+  @moduledoc """
+  Rejects attaching work-breakdown entities (epics, stories, ui-tests, imported work
+  breakdowns) to a knowledge-only (`kind: :kb`) project.
+
+  A `:kb` scope exists ONLY to partition knowledge articles by repo; it is structurally
+  barred from the chain-of-custody surface. This plug makes that a POSITIVE invariant at
+  the web boundary, independent of `RequireHumanAnchor`: a KB project can never host work
+  even if a nested `/projects/:id/*` route forgets its own tier gate. That closes the trap
+  where "a project exists" was previously equated with "custody is unlocked" (the
+  default-deny test's old unreachability premise).
+
+  Reads the project id from a path param — default `"project_id"`; pass `param: "id"` for
+  routes that use `:id` (e.g. import). A missing or not-found project is left untouched so
+  the controller can 404 as usual; a `:work` project passes through; a `:kb` project halts
+  with `422 kb_project_no_work`. Order it AFTER `RequireHumanAnchor` so agent-rooted callers
+  still hit the tier gate first.
+  """
+
+  @behaviour Plug
+
+  import Plug.Conn
+
+  @impl true
+  def init(opts), do: Keyword.get(opts, :param, "project_id")
+
+  @impl true
+  def call(conn, param) do
+    with %{tenant_id: tenant_id} <- conn.assigns[:current_api_key],
+         project_id when is_binary(project_id) <- conn.params[param],
+         {:ok, %{kind: :kb}} <- Loopctl.Projects.get_project(tenant_id, project_id) do
+      conn
+      |> put_status(:unprocessable_entity)
+      |> Phoenix.Controller.json(%{
+        error: %{
+          status: 422,
+          code: "kb_project_no_work",
+          message:
+            "This is a knowledge-only project scope (kind: kb) and cannot host " <>
+              "work-breakdown items (epics, stories, dispatch, ui-tests, imports). " <>
+              "Use a work project (kind: work) for chain-of-custody work."
+        }
+      })
+      |> halt()
+    else
+      _ -> conn
+    end
+  end
+end

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -221,6 +221,9 @@ defmodule LoopctlWeb.Router do
     # Cheap repo -> project_id resolution (Gap 1 of #411). Must precede the
     # resources block so /projects/resolve is not captured by GET /projects/:id.
     get "/projects/resolve", ProjectController, :resolve
+    # KB-only project scope: agent-createable (agent+ role, no human-anchor gate), forces
+    # kind: :kb. Separate route so the human-anchored `POST /projects` stays untouched.
+    post "/kb-scopes", ProjectController, :create_kb_scope
     resources "/projects", ProjectController, only: [:create, :index, :show, :update, :delete]
     get "/projects/:id/progress", ProjectController, :progress
 

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -402,6 +402,17 @@ async function createProject({ name, slug, repo_url, description, tech_stack, mi
   return toContent(result);
 }
 
+async function createKbScope({ name, slug, repo_url, description, tech_stack }) {
+  const body = { name, slug };
+  if (repo_url) body.repo_url = repo_url;
+  if (description) body.description = description;
+  if (tech_stack) body.tech_stack = tech_stack;
+  // Uses the AGENT key (not ORCH): a KB scope is agent-createable on the KB tier — that is
+  // the whole point. The server forces kind: :kb; a body-supplied kind is ignored.
+  const result = await apiCall("POST", "/api/v1/kb-scopes", body, process.env.LOOPCTL_AGENT_KEY);
+  return toContent(result);
+}
+
 async function deleteProject({ project_id }) {
   const result = await apiCall(
     "DELETE",
@@ -2096,6 +2107,25 @@ const TOOLS = [
           description:
             "Optional project mission/goal statement that cascades into story context. Surfaces in get_story responses as project_mission so agents see the why without a second fetch. Max 2000 chars.",
         },
+      },
+      required: ["name", "slug"],
+    },
+  },
+  {
+    name: "create_kb_scope",
+    description:
+      "Create a knowledge-only project scope (kind: kb) for the current tenant. Unlike create_project (work project, orchestrator+ / human-anchored), this is available to an agent-rooted (KB-tier) tenant with an agent key: a kb scope carries NO chain-of-custody / work-breakdown surface (it cannot host epics/stories/dispatch/ui-tests), it exists only to partition knowledge articles by repo so captured/created articles can be project-scoped. Then resolve_project by its repo_url/slug and pass the returned id as project_id on article/knowledge writes. Counts toward the tenant's max_projects budget.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Scope name (often the repo name)." },
+        slug: { type: "string", description: "URL-safe slug (often the repo basename)." },
+        repo_url: {
+          type: "string",
+          description: "Repo URL, so resolve_project can map a repo to this scope.",
+        },
+        description: { type: "string", description: "Scope description." },
+        tech_stack: { type: "string", description: "Tech stack summary." },
       },
       required: ["name", "slug"],
     },
@@ -4859,6 +4889,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     case "create_project":
       return await createProject(args);
+
+    case "create_kb_scope":
+      return await createKbScope(args);
 
     case "delete_project":
       return await deleteProject(args);

--- a/priv/repo/migrations/20260717010000_add_kind_to_projects.exs
+++ b/priv/repo/migrations/20260717010000_add_kind_to_projects.exs
@@ -1,0 +1,16 @@
+defmodule Loopctl.Repo.Migrations.AddKindToProjects do
+  use Ecto.Migration
+
+  # `kind` distinguishes a work-breakdown project (:work — the default, which carries the
+  # chain-of-custody surface: epics, stories, dispatch, ui-tests) from a knowledge-only
+  # scope (:kb — creatable by agent-rooted tenants, structurally barred from hosting any
+  # work-breakdown item). Stored as a string like `status`. Every existing row is a work
+  # project, so the NOT NULL default backfills them correctly.
+  def change do
+    alter table(:projects) do
+      add :kind, :string, null: false, default: "work"
+    end
+
+    create index(:projects, [:tenant_id, :kind])
+  end
+end

--- a/test/loopctl_web/controllers/project_controller_test.exs
+++ b/test/loopctl_web/controllers/project_controller_test.exs
@@ -30,6 +30,7 @@ defmodule LoopctlWeb.ProjectControllerTest do
       assert project["name"] == "loopctl"
       assert project["slug"] == "loopctl"
       assert project["status"] == "active"
+      assert project["kind"] == "work"
       assert project["repo_url"] == "https://github.com/mkreyman/loopctl"
       assert project["tech_stack"] == "elixir/phoenix"
       assert project["tenant_id"] == tenant.id
@@ -142,6 +143,183 @@ defmodule LoopctlWeb.ProjectControllerTest do
       project = json_response(conn, 201)["project"]
       assert Map.has_key?(project, "mission")
       assert project["mission"] == nil
+    end
+  end
+
+  describe "POST /api/v1/kb-scopes" do
+    test "agent-rooted tenant creates a KB scope with an agent key", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/kb-scopes", %{
+          "name" => "memory-loop-testbed",
+          "slug" => "memory-loop-testbed",
+          "repo_url" => "https://github.com/mkreyman/memory-loop-testbed"
+        })
+
+      project = json_response(conn, 201)["project"]
+      assert project["kind"] == "kb"
+      assert project["slug"] == "memory-loop-testbed"
+      assert project["status"] == "active"
+      assert project["tenant_id"] == tenant.id
+    end
+
+    test "KB scope is resolvable by repo_url (feeds capture project scoping)", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn
+      |> auth_conn(raw_key)
+      |> post(~p"/api/v1/kb-scopes", %{
+        "name" => "tb",
+        "slug" => "tb",
+        "repo_url" => "https://github.com/mkreyman/tb"
+      })
+
+      assert {:ok, project, _matched_by} =
+               Projects.resolve_project(tenant.id, repo_url: "https://github.com/mkreyman/tb")
+
+      assert project.kind == :kb
+    end
+
+    test "kind cannot be forced to :work via the request body", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/kb-scopes", %{"name" => "xx", "slug" => "xx", "kind" => "work"})
+
+      assert json_response(conn, 201)["project"]["kind"] == "kb"
+    end
+
+    test "KB scopes share the max_projects budget", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted, settings: %{"max_projects" => 1}})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      {:ok, _} = Projects.create_project(tenant.id, %{name: "first", slug: "first"}, kind: :kb)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/kb-scopes", %{"name" => "second", "slug" => "second"})
+
+      assert json_response(conn, 422)["error"]["message"] =~ "Project limit reached"
+    end
+
+    test "a KB scope is a valid article scope", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      {:ok, kb} = Projects.create_project(tenant.id, %{name: "kb", slug: "kb"}, kind: :kb)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/projects/#{kb.id}/articles", %{
+          "title" => "Testbed convention",
+          "body" => "A durable project-scoped fact for the testbed.",
+          "category" => "pattern"
+        })
+
+      assert json_response(conn, 201)["data"]["project_id"] == kb.id
+    end
+
+    test "existing POST /projects is unchanged: agent-rooted still 403s", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/projects", %{"name" => "w", "slug" => "w"})
+
+      assert json_response(conn, 403)["error"]["code"] == "custody_tier_required"
+    end
+  end
+
+  describe "kind: :kb rejects work-breakdown (RequireWorkProject)" do
+    test "ui-test create on a :kb scope 422s (agent-rooted, the reachable surface)", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      {:ok, kb} = Projects.create_project(tenant.id, %{name: "kb", slug: "kb"}, kind: :kb)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/projects/#{kb.id}/ui-tests", %{"name" => "run"})
+
+      assert json_response(conn, 422)["error"]["code"] == "kb_project_no_work"
+    end
+
+    test "epic create on a :kb scope 422s (human-anchored caller)", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+      {orch_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+      {:ok, kb} = Projects.create_project(tenant.id, %{name: "kb", slug: "kb"}, kind: :kb)
+
+      conn =
+        conn
+        |> auth_conn(orch_key)
+        |> post(~p"/api/v1/projects/#{kb.id}/epics", %{"name" => "e"})
+
+      assert json_response(conn, 422)["error"]["code"] == "kb_project_no_work"
+    end
+
+    test "story create_in_project on a :kb scope 422s (human-anchored caller)", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+      {orch_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+      {:ok, kb} = Projects.create_project(tenant.id, %{name: "kb", slug: "kb"}, kind: :kb)
+
+      conn =
+        conn
+        |> auth_conn(orch_key)
+        |> post(~p"/api/v1/projects/#{kb.id}/stories", %{"epic_number" => 1, "title" => "s"})
+
+      assert json_response(conn, 422)["error"]["code"] == "kb_project_no_work"
+    end
+
+    test "import on a :kb scope 422s (human-anchored caller)", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+      {user_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      {:ok, kb} = Projects.create_project(tenant.id, %{name: "kb", slug: "kb"}, kind: :kb)
+
+      conn =
+        conn
+        |> auth_conn(user_key)
+        |> post(~p"/api/v1/projects/#{kb.id}/import", %{"epics" => []})
+
+      assert json_response(conn, 422)["error"]["code"] == "kb_project_no_work"
+    end
+
+    test "orchestrator-state save on a :kb scope 422s (human-anchored caller)", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+      {orch_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+      {:ok, kb} = Projects.create_project(tenant.id, %{name: "kb", slug: "kb"}, kind: :kb)
+
+      conn =
+        conn
+        |> auth_conn(orch_key)
+        |> put(~p"/api/v1/orchestrator/state/#{kb.id}", %{"state" => %{}})
+
+      assert json_response(conn, 422)["error"]["code"] == "kb_project_no_work"
+    end
+
+    test "a work project (kind: :work) is NOT rejected by the guard", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      work = fixture(:project, %{tenant_id: tenant.id, slug: "work"})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/projects/#{work.id}/ui-tests", %{"name" => "run"})
+
+      # It passes RequireWorkProject and reaches the action; whatever the action returns,
+      # it must NOT be the kb_project_no_work rejection.
+      refute conn.status == 422 and
+               Jason.decode!(conn.resp_body)["error"]["code"] == "kb_project_no_work"
     end
   end
 

--- a/test/loopctl_web/require_human_anchor_default_deny_test.exs
+++ b/test/loopctl_web/require_human_anchor_default_deny_test.exs
@@ -147,12 +147,25 @@ defmodule LoopctlWeb.RequireHumanAnchorDefaultDenyTest do
                # are (correctly) absent from this allowlist and asserted to 403.
                {:post, "/api/v1/retrieve/:entity"},
 
+               # KB-only project scope: agent-createable by design (extends owner
+               # decision #331 — the KB surface is fully agent-usable). It forces
+               # kind: :kb and carries NO chain-of-custody surface, so it is correctly
+               # OUTSIDE the tier gate. A :kb scope is structurally barred from work by
+               # RequireWorkProject (see the :kb-rejection test), which is what lets the
+               # ui-tests exemption below stay safe now that agent-rooted tenants CAN
+               # create a project.
+               {:post, "/api/v1/kb-scopes"},
+
                # UI test runs (#4/#5 reviewed rationale): a QA/tooling surface,
                # NOT work-breakdown state. Every route is nested under
-               # `/projects/:project_id/...` and creating a project
-               # (`ProjectController.create`) is ALREADY tier-gated, so an
-               # agent-rooted tenant has no project to attach a UI test to —
-               # the surface is unreachable for it even without a per-route gate.
+               # `/projects/:project_id/...`. PREVIOUSLY justified as "unreachable
+               # because agent-rooted tenants can't create a project" — that premise
+               # NO LONGER HOLDS (they can now create a :kb scope). The surface stays
+               # safe because `RequireWorkProject` rejects a :kb project with
+               # 422 kb_project_no_work, so an agent-rooted tenant's only projects
+               # (:kb scopes) still cannot host a UI test. The `:kb`-rejection test
+               # (project_controller_test.exs) guards that positive invariant so this
+               # exemption cannot silently rot.
                {:post, "/api/v1/projects/:project_id/ui-tests"},
                {:post, "/api/v1/projects/:project_id/ui-tests/:id/findings"},
                {:post, "/api/v1/projects/:project_id/ui-tests/:id/complete"},


### PR DESCRIPTION
## What

Lets an agent-rooted (KB-tier) tenant obtain a project scope to partition knowledge articles by, without unlocking the work-breakdown / chain-of-custody surface. Extends owner decision #331 (the KB content surface is fully agent-usable) to KB scoping. Unblocks project-scoped session-capture on the KB tier.

## How

- New non-castable `projects.kind` column (:work default | :kb), set server-side only (mirrors trust_tier), immutable after creation.
- New agent-gated `POST /api/v1/kb-scopes` that forces `kind: :kb` and is NOT behind RequireHumanAnchor. Existing `POST /projects` is untouched (still orchestrator+ / human-anchored, still :work).
- New `RequireWorkProject` plug: every work-breakdown attach point rejects a :kb project with `422 kb_project_no_work` — ui-tests (create/add_finding/complete), epics create, stories create_in_project, project import, and orchestrator-state save. Dispatch and epic-scoped story create are transitively barred (a :kb scope can hold no epics/stories). This makes the invariant positive/structural instead of relying on "agents can't make projects."
- Knowledge/article/recall path unchanged (validate_project_ownership checks tenant, not kind). KB scopes share the max_projects budget.
- `create_kb_scope` MCP tool (agent key); `kind` declared in the ProjectResponse OpenAPI schema.

## Security

The naive "let agents create projects" would silently break the default-deny guard test's premise that agent-rooted tenants have no project to attach work to. This PR repairs that premise and enforces the barrier positively via RequireWorkProject. Reviewed by an adversarial security pass (kind non-castability, tenant isolation, quota, fail-safe plug, MCP key — all held) and a correctness pass; the one real finding (orchestrator-state save missing the guard) is fixed here, with a rejection test for every guarded surface.

## Tests / gate

`mix precommit` green on a stable seed: compile --warnings-as-errors, format, credo --strict, dialyzer, deps.audit, and the full suite (4859/0). New tests cover KB-scope create/resolve/quota, article-scoping on a :kb project, and :kb rejection on every work surface, plus the repaired default-deny premise.

Note: a pre-existing seed-dependent flake in the #411 memory-promotion worker tests is unrelated to this change (green on seed 0 and in isolation).

## Follow-up (not in this PR)

An agent-rooted tenant can create :kb scopes but cannot delete/archive them (delete stays human-anchored per #331), and they share the 50-project cap — a one-way ratchet for heavy per-repo capture. Candidate fast-follow: let agents archive their own :kb scopes.
