### PR TITLE
Publish create_kb_scope: bump loopctl-mcp-server to 2.43.0

### DIFF
--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to `loopctl-mcp-server` are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 2.43.0 — 2026-07-16 (#418 — KB-only project scopes for agent-rooted tenants)
+
+### Added
+
+- **`create_kb_scope`** — create a knowledge-only project scope (`kind: kb`) for
+  the current tenant over `POST /api/v1/kb-scopes`, using the AGENT key. Unlike
+  `create_project` (a work project, orchestrator+ / human-anchored), a KB scope is
+  available to an agent-rooted (KB-tier) tenant: it carries NO work-breakdown /
+  chain-of-custody surface (it cannot host epics/stories/dispatch/ui-tests) and
+  exists only to partition knowledge articles by repo. Resolve it with
+  `resolve_project` and pass the returned `id` as `project_id` on article/knowledge
+  writes. Counts toward the tenant's `max_projects` budget.
+
 ## 2.42.0 — 2026-07-16 (#411 — agent-memory substrate: resolve_project, recall_context, memory_graduate)
 
 ### Added

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.42.0",
+  "version": "2.43.0",
   "description": "MCP server for loopctl — structural trust for AI development loops",
   "type": "module",
   "main": "index.js",

--- a/mcp-server/test/mcp_arg_forwarding.test.js
+++ b/mcp-server/test/mcp_arg_forwarding.test.js
@@ -115,6 +115,32 @@ describe("#411 gap1: resolve_project wiring", () => {
 });
 
 // ---------------------------------------------------------------------------
+// #418: create_kb_scope (KB-only project scope, agent-createable)
+// ---------------------------------------------------------------------------
+
+describe("#418: create_kb_scope wiring", () => {
+  test("TOOLS declares a create_kb_scope tool", () => {
+    assert.match(INDEX_SRC, /name: "create_kb_scope",/, 'must declare a "create_kb_scope" tool');
+  });
+
+  test("createKbScope POSTs /kb-scopes on the AGENT key (not the orch key)", () => {
+    assert.match(
+      INDEX_SRC,
+      /async function createKbScope\([\s\S]*?"POST",\s*"\/api\/v1\/kb-scopes",\s*body,\s*process\.env\.LOOPCTL_AGENT_KEY/,
+      "createKbScope must POST /api/v1/kb-scopes with the agent key",
+    );
+  });
+
+  test("the create_kb_scope dispatch case calls createKbScope(args)", () => {
+    assert.match(
+      INDEX_SRC,
+      /case "create_kb_scope":\s*\n\s*return await createKbScope\(args\);/,
+      "the create_kb_scope dispatch case must call createKbScope(args)",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // #411 gap2 (PR B): recall_context (merged memory ∪ knowledge, one round-trip)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
#418 added the create_kb_scope MCP tool to index.js but did not bump the package version, so mcp-autopublish (triggered on a mcp-server/package.json version change on master) never fired. Bump 2.42.0 to 2.43.0 to publish it, add the CHANGELOG entry, and add unit tests asserting the tool is declared, dispatched, and POSTs /api/v1/kb-scopes on the agent key. Full mcp-server suite green (229 tests). On merge, mcp-autopublish publishes 2.43.0 to npm and creates the record tag.