### PR TITLE
Agent-managed KB-scope lifecycle: archive + restore (reclaim budget)

### DIFF
--- a/lib/loopctl/projects.ex
+++ b/lib/loopctl/projects.ex
@@ -293,7 +293,16 @@ defmodule Loopctl.Projects do
   """
   @spec archive_project(Ecto.UUID.t(), Project.t(), keyword()) ::
           {:ok, Project.t()} | {:error, Ecto.Changeset.t()}
-  def archive_project(tenant_id, %Project{} = project, opts \\ []) do
+  def archive_project(tenant_id, project, opts \\ [])
+
+  def archive_project(tenant_id, %Project{status: :archived} = project, _opts) do
+    # Idempotent: archiving an already-archived project is a no-op and writes NO new audit
+    # row, so a repeated DELETE can't inflate the append-only audit log.
+    _ = tenant_id
+    {:ok, project}
+  end
+
+  def archive_project(tenant_id, %Project{} = project, opts) do
     actor_id = Keyword.get(opts, :actor_id)
     actor_label = Keyword.get(opts, :actor_label)
     actor_type = Keyword.get(opts, :actor_type, "api_key")
@@ -322,6 +331,66 @@ defmodule Loopctl.Projects do
     case AdminRepo.transaction(multi) do
       {:ok, %{project: archived}} ->
         {:ok, archived}
+
+      {:error, :project, changeset, _changes} ->
+        {:error, changeset}
+    end
+  end
+
+  @doc """
+  Re-activates (un-archives) an archived project, scoped to a tenant.
+
+  Idempotent for an already-active project (no-op, no audit row). Re-activating consumes an
+  active `max_projects` slot, so it enforces the same limit as create and returns
+  `{:error, :project_limit_reached}` when the tenant is at its cap. Writes an audit entry in
+  the same transaction.
+  """
+  @spec unarchive_project(Ecto.UUID.t(), Project.t(), keyword()) ::
+          {:ok, Project.t()} | {:error, Ecto.Changeset.t() | :project_limit_reached}
+  def unarchive_project(tenant_id, project, opts \\ [])
+
+  def unarchive_project(_tenant_id, %Project{status: :active} = project, _opts) do
+    {:ok, project}
+  end
+
+  def unarchive_project(tenant_id, %Project{} = project, opts) do
+    actor_id = Keyword.get(opts, :actor_id)
+    actor_label = Keyword.get(opts, :actor_label)
+    actor_type = Keyword.get(opts, :actor_type, "api_key")
+    metadata = Keyword.get(opts, :metadata, %{})
+
+    changeset = Project.activate_changeset(project)
+
+    multi =
+      Multi.new()
+      |> Multi.run(:check_limit, fn _repo, _changes ->
+        count = count_projects(tenant_id, status: :active)
+        max = get_project_limit(tenant_id)
+
+        if count < max, do: {:ok, count}, else: {:error, :project_limit_reached}
+      end)
+      |> Multi.update(:project, changeset)
+      |> Audit.log_in_multi(:audit, fn %{project: activated} ->
+        %{
+          tenant_id: tenant_id,
+          entity_type: "project",
+          entity_id: activated.id,
+          action: "unarchived",
+          actor_type: actor_type,
+          actor_id: actor_id,
+          actor_label: actor_label,
+          metadata: metadata,
+          old_state: %{"status" => to_string(project.status)},
+          new_state: %{"status" => to_string(activated.status)}
+        }
+      end)
+
+    case AdminRepo.transaction(multi) do
+      {:ok, %{project: activated}} ->
+        {:ok, activated}
+
+      {:error, :check_limit, :project_limit_reached, _changes} ->
+        {:error, :project_limit_reached}
 
       {:error, :project, changeset, _changes} ->
         {:error, changeset}

--- a/lib/loopctl/projects/project.ex
+++ b/lib/loopctl/projects/project.ex
@@ -109,6 +109,14 @@ defmodule Loopctl.Projects.Project do
   end
 
   @doc """
+  Changeset for re-activating an archived project (setting status to :active).
+  """
+  @spec activate_changeset(%__MODULE__{}) :: Ecto.Changeset.t()
+  def activate_changeset(project) do
+    change(project, status: :active)
+  end
+
+  @doc """
   Returns the list of valid statuses.
   """
   @spec statuses() :: [atom()]

--- a/lib/loopctl_web/controllers/project_controller.ex
+++ b/lib/loopctl_web/controllers/project_controller.ex
@@ -23,7 +23,16 @@ defmodule LoopctlWeb.ProjectController do
   plug LoopctlWeb.Plugs.RequireRole, [role: :user] when action in [:delete]
 
   plug LoopctlWeb.Plugs.RequireRole,
-       [role: :agent] when action in [:index, :show, :progress, :resolve, :create_kb_scope]
+       [role: :agent]
+       when action in [
+              :index,
+              :show,
+              :progress,
+              :resolve,
+              :create_kb_scope,
+              :archive_kb_scope,
+              :restore_kb_scope
+            ]
 
   # US-26.7.1 — work-breakdown surface requires a human-anchored tenant.
   # NOTE: :create_kb_scope is deliberately NOT gated here — a :kb scope carries no
@@ -56,6 +65,40 @@ defmodule LoopctlWeb.ProjectController do
       201 => {"KB scope created", "application/json", Schemas.ProjectResponse},
       422 =>
         {"Validation error or project limit reached", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  operation(:archive_kb_scope,
+    summary: "Archive a knowledge-only project scope",
+    description:
+      "Archives (soft-deletes, reversible) a kind: kb project scope owned by the tenant. " <>
+        "Agent+ role and NOT human-anchor gated (extends #331 / create_kb_scope). Archiving " <>
+        "frees the scope's slot in the tenant's max_projects budget so agents can reclaim " <>
+        "KB-scope capacity. A kind: work project is rejected (422) — archiving a work project " <>
+        "remains human-anchored via DELETE /projects/:id.",
+    parameters: [id: [in: :path, type: :string, description: "KB scope (project) UUID"]],
+    responses: %{
+      200 => {"Archived KB scope", "application/json", Schemas.ProjectResponse},
+      404 => {"Not found", "application/json", Schemas.ErrorResponse},
+      422 => {"Not a KB scope", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  operation(:restore_kb_scope,
+    summary: "Restore (un-archive) a knowledge-only project scope",
+    description:
+      "Re-activates an archived kind: kb scope owned by the tenant (the reverse of DELETE " <>
+        "/kb-scopes/:id). Agent+ role, not human-anchor gated. Re-activating consumes an " <>
+        "active max_projects slot, so it is rejected 422 when the tenant is at its cap. A " <>
+        "kind: work project is rejected 422.",
+    parameters: [id: [in: :path, type: :string, description: "KB scope (project) UUID"]],
+    responses: %{
+      200 => {"Restored KB scope", "application/json", Schemas.ProjectResponse},
+      404 => {"Not found", "application/json", Schemas.ErrorResponse},
+      422 =>
+        {"Not a KB scope, or project limit reached", "application/json", Schemas.ErrorResponse},
       429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
     }
   )
@@ -221,6 +264,75 @@ defmodule LoopctlWeb.ProjectController do
         {:error, changeset}
     end
   end
+
+  @doc """
+  DELETE /api/v1/kb-scopes/:id
+
+  Archives (soft-deletes, reversible) a `kind: :kb` project scope owned by the tenant.
+  Agent+ role, NOT human-anchor gated — a KB scope is agent-managed (extends owner decision
+  #331 / create_kb_scope, and archive is a reversible, audited soft-delete, the class of KB
+  op #331 keeps agent-usable). Archiving frees the scope's slot in the tenant's max_projects
+  active budget, so an agent can reclaim KB-scope capacity it created. A `kind: :work` project
+  is rejected with 422 — archiving a work project stays human-anchored via DELETE /projects/:id.
+  A missing or cross-tenant id is a clean 404 (get_project is tenant-scoped). Reverse it with
+  POST /kb-scopes/:id/restore (also agent role), so the KB-scope lifecycle is fully
+  agent-managed. Idempotent: archiving an already-archived scope is a no-op with no new audit
+  row.
+  """
+  def archive_kb_scope(conn, %{"id" => project_id}) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+    audit_opts = AuditContext.from_conn(conn)
+
+    with {:ok, project} <- Projects.get_project(tenant_id, project_id),
+         :ok <- ensure_kb_scope(project),
+         {:ok, archived} <- Projects.archive_project(tenant_id, project, audit_opts) do
+      json(conn, %{project: project_json(archived)})
+    end
+  end
+
+  @doc """
+  POST /api/v1/kb-scopes/:id/restore
+
+  Re-activates an archived `kind: :kb` scope owned by the tenant — the reverse of
+  DELETE /kb-scopes/:id, so the KB-scope lifecycle is fully agent-managed. Agent+ role, NOT
+  human-anchor gated. Re-activating consumes an active max_projects slot, so it is rejected
+  422 (project limit reached) when the tenant is at its cap. A `kind: :work` project is
+  rejected 422; a missing or cross-tenant id is a clean 404.
+  """
+  def restore_kb_scope(conn, %{"id" => project_id}) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+    audit_opts = AuditContext.from_conn(conn)
+
+    with {:ok, project} <- Projects.get_project(tenant_id, project_id),
+         :ok <- ensure_kb_scope(project),
+         {:ok, activated} <- restore_result(tenant_id, project, audit_opts) do
+      json(conn, %{project: project_json(activated)})
+    end
+  end
+
+  defp restore_result(tenant_id, project, opts) do
+    case Projects.unarchive_project(tenant_id, project, opts) do
+      {:ok, activated} ->
+        {:ok, activated}
+
+      {:error, :project_limit_reached} ->
+        {:error, :unprocessable_entity, "Project limit reached for this tenant"}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:error, changeset}
+    end
+  end
+
+  # Only a knowledge-only scope may be archived/restored at agent role. A work project falls
+  # through to this 422 so it can never be archived or restored without the human-anchored
+  # DELETE/PATCH /projects/:id path.
+  defp ensure_kb_scope(%{kind: :kb}), do: :ok
+
+  defp ensure_kb_scope(_project),
+    do:
+      {:error, :unprocessable_entity,
+       "Only a knowledge-only project scope (kind: kb) can be managed (archive/restore) at " <>
+         "agent role; a work project requires a human-anchored tenant."}
 
   @doc """
   GET /api/v1/projects

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -224,6 +224,10 @@ defmodule LoopctlWeb.Router do
     # KB-only project scope: agent-createable (agent+ role, no human-anchor gate), forces
     # kind: :kb. Separate route so the human-anchored `POST /projects` stays untouched.
     post "/kb-scopes", ProjectController, :create_kb_scope
+    # Archive (reversible soft-delete) an agent-owned :kb scope to reclaim its budget slot;
+    # restore re-activates it (re-consumes a slot). Both agent-managed, no custody surface.
+    delete "/kb-scopes/:id", ProjectController, :archive_kb_scope
+    post "/kb-scopes/:id/restore", ProjectController, :restore_kb_scope
     resources "/projects", ProjectController, only: [:create, :index, :show, :update, :delete]
     get "/projects/:id/progress", ProjectController, :progress
 

--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to `loopctl-mcp-server` are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 2.44.0 — 2026-07-17 (KB-scope lifecycle: agent archive + restore)
+
+### Added
+
+- **`archive_kb_scope`** — archive (reversible soft-delete) a `kind: kb` scope you own,
+  on the agent key, over `DELETE /api/v1/kb-scopes/:id`. Frees the scope's slot in the
+  tenant's `max_projects` budget so an agent-rooted tenant can reclaim KB-scope capacity
+  (closes the one-way ratchet from 2.43.0). Rejects a `kind: work` project (422); idempotent
+  on an already-archived scope.
+- **`restore_kb_scope`** — re-activate an archived `kind: kb` scope (the reverse of archive),
+  over `POST /api/v1/kb-scopes/:id/restore`. Re-consumes an active `max_projects` slot (422
+  at the cap). Rejects a `kind: work` project (422).
+
 ## 2.43.0 — 2026-07-16 (#418 — KB-only project scopes for agent-rooted tenants)
 
 ### Added

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -413,6 +413,30 @@ async function createKbScope({ name, slug, repo_url, description, tech_stack }) 
   return toContent(result);
 }
 
+async function archiveKbScope({ project_id }) {
+  // Reversible soft-delete of an agent-owned :kb scope on the AGENT key; frees its
+  // max_projects slot. The server rejects a :work project (422). Reverse with restore_kb_scope.
+  const result = await apiCall(
+    "DELETE",
+    `/api/v1/kb-scopes/${project_id}`,
+    null,
+    process.env.LOOPCTL_AGENT_KEY,
+  );
+  return toContent(result);
+}
+
+async function restoreKbScope({ project_id }) {
+  // Re-activate an archived :kb scope on the AGENT key (re-consumes a max_projects slot;
+  // 422 if at the cap). The server rejects a :work project (422).
+  const result = await apiCall(
+    "POST",
+    `/api/v1/kb-scopes/${project_id}/restore`,
+    {},
+    process.env.LOOPCTL_AGENT_KEY,
+  );
+  return toContent(result);
+}
+
 async function deleteProject({ project_id }) {
   const result = await apiCall(
     "DELETE",
@@ -2128,6 +2152,30 @@ const TOOLS = [
         tech_stack: { type: "string", description: "Tech stack summary." },
       },
       required: ["name", "slug"],
+    },
+  },
+  {
+    name: "archive_kb_scope",
+    description:
+      "Archive (reversible soft-delete) a knowledge-only project scope (kind: kb) you own, on the agent key. Frees the scope's slot in the tenant's max_projects budget so you can reclaim KB-scope capacity — the reverse of create_kb_scope. Its articles remain readable/writable; restore_kb_scope re-activates it. Rejects a kind: work project (422) — archiving a work project stays human-anchored. Idempotent on an already-archived scope.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        project_id: { type: "string", description: "UUID of the :kb scope to archive." },
+      },
+      required: ["project_id"],
+    },
+  },
+  {
+    name: "restore_kb_scope",
+    description:
+      "Restore (re-activate) an archived knowledge-only project scope (kind: kb) you own, on the agent key — the reverse of archive_kb_scope. Re-activating consumes an active max_projects slot, so it is rejected (422) when the tenant is at its cap. Rejects a kind: work project (422).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        project_id: { type: "string", description: "UUID of the archived :kb scope to restore." },
+      },
+      required: ["project_id"],
     },
   },
   {
@@ -4892,6 +4940,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     case "create_kb_scope":
       return await createKbScope(args);
+
+    case "archive_kb_scope":
+      return await archiveKbScope(args);
+
+    case "restore_kb_scope":
+      return await restoreKbScope(args);
 
     case "delete_project":
       return await deleteProject(args);

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.43.0",
+  "version": "2.44.0",
   "description": "MCP server for loopctl — structural trust for AI development loops",
   "type": "module",
   "main": "index.js",

--- a/mcp-server/test/mcp_arg_forwarding.test.js
+++ b/mcp-server/test/mcp_arg_forwarding.test.js
@@ -140,6 +140,34 @@ describe("#418: create_kb_scope wiring", () => {
   });
 });
 
+describe("KB-scope lifecycle: archive_kb_scope / restore_kb_scope wiring", () => {
+  test("TOOLS declares archive_kb_scope and restore_kb_scope", () => {
+    assert.match(INDEX_SRC, /name: "archive_kb_scope",/, 'must declare "archive_kb_scope"');
+    assert.match(INDEX_SRC, /name: "restore_kb_scope",/, 'must declare "restore_kb_scope"');
+  });
+
+  test("archiveKbScope DELETEs /kb-scopes/:id on the AGENT key", () => {
+    assert.match(
+      INDEX_SRC,
+      /async function archiveKbScope\(\{ project_id \}\)[\s\S]*?"DELETE",\s*`\/api\/v1\/kb-scopes\/\$\{project_id\}`,\s*null,\s*process\.env\.LOOPCTL_AGENT_KEY/,
+      "archiveKbScope must DELETE /api/v1/kb-scopes/:id on the agent key",
+    );
+  });
+
+  test("restoreKbScope POSTs /kb-scopes/:id/restore on the AGENT key", () => {
+    assert.match(
+      INDEX_SRC,
+      /async function restoreKbScope\(\{ project_id \}\)[\s\S]*?"POST",\s*`\/api\/v1\/kb-scopes\/\$\{project_id\}\/restore`,[\s\S]*?process\.env\.LOOPCTL_AGENT_KEY/,
+      "restoreKbScope must POST /api/v1/kb-scopes/:id/restore on the agent key",
+    );
+  });
+
+  test("dispatch cases call archiveKbScope/restoreKbScope", () => {
+    assert.match(INDEX_SRC, /case "archive_kb_scope":\s*\n\s*return await archiveKbScope\(args\);/);
+    assert.match(INDEX_SRC, /case "restore_kb_scope":\s*\n\s*return await restoreKbScope\(args\);/);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // #411 gap2 (PR B): recall_context (merged memory ∪ knowledge, one round-trip)
 // ---------------------------------------------------------------------------

--- a/test/loopctl_web/controllers/project_controller_test.exs
+++ b/test/loopctl_web/controllers/project_controller_test.exs
@@ -240,6 +240,117 @@ defmodule LoopctlWeb.ProjectControllerTest do
     end
   end
 
+  describe "DELETE /api/v1/kb-scopes/:id (agent archive of own KB scope)" do
+    test "agent-rooted tenant archives its own :kb scope", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      {:ok, kb} = Projects.create_project(tenant.id, %{name: "kb", slug: "kb"}, kind: :kb)
+
+      conn = conn |> auth_conn(raw_key) |> delete(~p"/api/v1/kb-scopes/#{kb.id}")
+
+      project = json_response(conn, 200)["project"]
+      assert project["id"] == kb.id
+      assert project["status"] == "archived"
+      assert project["kind"] == "kb"
+    end
+
+    test "archiving a :kb scope frees the max_projects budget slot", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted, settings: %{"max_projects" => 1}})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      {:ok, kb} = Projects.create_project(tenant.id, %{name: "first", slug: "first"}, kind: :kb)
+
+      # At the cap: a second create is rejected.
+      over =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/kb-scopes", %{"name" => "second", "slug" => "second"})
+
+      assert json_response(over, 422)["error"]["message"] =~ "Project limit reached"
+
+      # Archive the first, then the create succeeds (slot reclaimed).
+      _ = conn |> auth_conn(raw_key) |> delete(~p"/api/v1/kb-scopes/#{kb.id}")
+
+      again =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/kb-scopes", %{"name" => "third", "slug" => "third"})
+
+      assert json_response(again, 201)["project"]["kind"] == "kb"
+    end
+
+    test "rejects archiving a :work project at agent role (422)", %{conn: conn} do
+      # A human-anchored tenant (so it can hold a :work project) with an agent key.
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      work = fixture(:project, %{tenant_id: tenant.id, slug: "work"})
+
+      conn = conn |> auth_conn(raw_key) |> delete(~p"/api/v1/kb-scopes/#{work.id}")
+
+      assert json_response(conn, 422)["error"]["message"] =~ "kind: kb"
+      # And it is NOT archived.
+      assert {:ok, %{status: :active}} = Projects.get_project(tenant.id, work.id)
+    end
+
+    test "404 for a cross-tenant or missing scope", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      other = fixture(:tenant, %{trust_tier: :agent_rooted})
+      {:ok, foreign} = Projects.create_project(other.id, %{name: "xx", slug: "xx"}, kind: :kb)
+
+      conn = conn |> auth_conn(raw_key) |> delete(~p"/api/v1/kb-scopes/#{foreign.id}")
+
+      assert json_response(conn, 404)
+      # The foreign scope is untouched.
+      assert {:ok, %{status: :active}} = Projects.get_project(other.id, foreign.id)
+    end
+
+    test "restore re-activates an archived :kb scope", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      {:ok, kb} = Projects.create_project(tenant.id, %{name: "kb", slug: "kb"}, kind: :kb)
+      {:ok, _} = Projects.archive_project(tenant.id, kb)
+
+      conn = conn |> auth_conn(raw_key) |> post(~p"/api/v1/kb-scopes/#{kb.id}/restore")
+
+      assert json_response(conn, 200)["project"]["status"] == "active"
+    end
+
+    test "restore is rejected 422 when the tenant is at its project cap", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted, settings: %{"max_projects" => 1}})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      {:ok, kb} = Projects.create_project(tenant.id, %{name: "a", slug: "aa"}, kind: :kb)
+      {:ok, _} = Projects.archive_project(tenant.id, kb)
+      # Fill the single active slot with another scope.
+      {:ok, _} = Projects.create_project(tenant.id, %{name: "b", slug: "bb"}, kind: :kb)
+
+      conn = conn |> auth_conn(raw_key) |> post(~p"/api/v1/kb-scopes/#{kb.id}/restore")
+
+      assert json_response(conn, 422)["error"]["message"] =~ "Project limit reached"
+      assert {:ok, %{status: :archived}} = Projects.get_project(tenant.id, kb.id)
+    end
+
+    test "archive is idempotent (no error on an already-archived scope)", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      {:ok, kb} = Projects.create_project(tenant.id, %{name: "kb", slug: "kb"}, kind: :kb)
+
+      _ = conn |> auth_conn(raw_key) |> delete(~p"/api/v1/kb-scopes/#{kb.id}")
+      again = conn |> auth_conn(raw_key) |> delete(~p"/api/v1/kb-scopes/#{kb.id}")
+
+      assert json_response(again, 200)["project"]["status"] == "archived"
+    end
+
+    test "restore rejects a :work project (422)", %{conn: conn} do
+      tenant = fixture(:tenant, %{trust_tier: :human_anchored})
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+      work = fixture(:project, %{tenant_id: tenant.id, slug: "work"})
+
+      conn = conn |> auth_conn(raw_key) |> post(~p"/api/v1/kb-scopes/#{work.id}/restore")
+
+      assert json_response(conn, 422)["error"]["message"] =~ "kind: kb"
+    end
+  end
+
   describe "kind: :kb rejects work-breakdown (RequireWorkProject)" do
     test "ui-test create on a :kb scope 422s (agent-rooted, the reachable surface)", %{conn: conn} do
       tenant = fixture(:tenant, %{trust_tier: :agent_rooted})

--- a/test/loopctl_web/require_human_anchor_default_deny_test.exs
+++ b/test/loopctl_web/require_human_anchor_default_deny_test.exs
@@ -155,6 +155,11 @@ defmodule LoopctlWeb.RequireHumanAnchorDefaultDenyTest do
                # ui-tests exemption below stay safe now that agent-rooted tenants CAN
                # create a project.
                {:post, "/api/v1/kb-scopes"},
+               # Archive an agent-owned :kb scope (reversible soft-delete) to reclaim its
+               # max_projects slot — agent-managed, NOT custody. The action rejects a :work
+               # project (422), so it can never archive a work project without human-anchor.
+               {:delete, "/api/v1/kb-scopes/:id"},
+               {:post, "/api/v1/kb-scopes/:id/restore"},
 
                # UI test runs (#4/#5 reviewed rationale): a QA/tooling surface,
                # NOT work-breakdown state. Every route is nested under


### PR DESCRIPTION
Agent-managed KB-scope lifecycle: archive + restore (reclaim budget)

Closes the one-way ratchet from #418: an agent-rooted (KB-tier) tenant could create :kb
scopes but never reclaim them — archive/delete was user-role + human-anchored, so scopes
accumulated against the max_projects cap with no way to free a slot.

Adds, both agent+ role and NOT human-anchor gated (extends owner decision #331 — reversible,
audited soft-deletes are the class of KB op agents keep):
- DELETE /api/v1/kb-scopes/:id (archive_kb_scope): archives a kind: kb scope owned by the
  tenant via the existing Projects.archive_project. Frees the scope's active max_projects
  slot. Idempotent on an already-archived scope (no new audit row — kills the audit-flood
  loop a repeated DELETE would otherwise create).
- POST /api/v1/kb-scopes/:id/restore (restore_kb_scope): the reverse — re-activates an
  archived scope, re-consuming a slot (422 project_limit_reached at the cap), so the
  KB-scope lifecycle is fully agent-managed.
Both reject a kind: work project (422) so work projects are still only archivable via the
human-anchored DELETE/PATCH /projects/:id. A missing or cross-tenant id is a clean 404
(get_project is tenant-scoped). Article read/write is status-agnostic, so an archived
scope's articles stay usable.

Reviewed by an adversarial security pass: the two headline attacks (archive a work project;
cross-tenant archive) are refuted in code; the review's three low findings — non-idempotent
archive (audit flood), reversible-only-by-human, and the documented archive-is-human-gated
decision — are all addressed here (idempotent archive, agent restore, and the wiki decision
carve-out).

Also exposes archive_kb_scope + restore_kb_scope MCP tools (agent key) and bumps
loopctl-mcp-server to 2.44.0 so autopublish ships them. Default-deny guard test allowlists
both new routes (agent-managed, no custody surface). Full mix precommit green on seed 0
(a pre-existing seed-dependent flake in the #411 memory-promotion worker tests is unrelated:
those two tests pass in isolation and as a full file).
