### PR TITLE
Epic 39 design brief + stories: repo coordination bus (v1)

### DIFF
--- a/docs/repo-coordination-bus.md
+++ b/docs/repo-coordination-bus.md
@@ -1,0 +1,145 @@
+# Design Brief: Repo Coordination Bus (the third memory plane)
+
+**Status:** draft / proposal · **Author:** derived with Mark, 2026-07-17
+**Related:** `docs/agent-memory.md` (#411 memory substrate), `docs/knowledge-hybrid-retrieval.md`, owner decision #331 (KB content surface is fully agent-usable)
+
+---
+
+## 1. Problem
+
+When Mark works the **same repo from more than one machine and/or more than one session**, the sessions can't talk to each other. Today that coordination happens by hand — literally copy-pasting one session's finding into another (e.g. relaying a beelink session's note about a hook to a blockit session). There is no shared, transient, repo-scoped place for sessions to leave each other messages, hand off work, or avoid stepping on the same files.
+
+The stopgap that half-covers this — **memory-keeper** — is a **local SQLite MCP server, one DB per machine**. So it structurally *cannot* bridge machines: context saved on mac-mini is invisible on beelink.
+
+### 1.1 The fragmentation is real and measured (fleet audit, 2026-07-17)
+
+memory-keeper `context_items`, per project × machine (richest DB on each: `~/mcp-data/memory-keeper/context.db`):
+
+| Project | blockit | mac-mini | beelink | total |
+|---|---|---|---|---|
+| home_care_billing | 444 | 3163 | 679 | **4,286** |
+| loopctl | 50 | 332 | 94 | 476 |
+| cron_books | 0 | 504 | 38 | 542 |
+| claude-config | ~6 | 6 | 5 | ~17 |
+
+**home_care_billing's memory is 4,286 items split three ways, none shared** — and beelink's slice is active *today* while mac-mini's spans Dec–Jul. Working HCB from beelink, you cannot see 3,163 items of mac-mini context. One project, three disconnected memories, for seven months.
+
+### 1.2 What is actually used (so we don't rebuild what nobody touches)
+
+Feature-table row counts across all three machines:
+
+- **Used:** `context_items` (key/value working state, *mostly uncategorized*), `checkpoints` (build→ship handoff: 64 / 73 / 3), `vector_embeddings` (auto, ≈ item count → semantic search).
+- **Zero rows on every machine:** `journal_entries`, `entities`, `relations`, `compressed_context`, `observations`, `agent_tasks`. `file_cache` = 0 / 0 / 6.
+
+The real footprint is **3 of ~15 feature areas.** RGN's own `.claude/SETUP.md` already demotes memory-keeper to *"a mirror, not the source of truth"* (files in `.claude/checkpoints/` + `.claude/state/*.md` are primary), and names the only thing that degrades without it: *"cross-session history and search."*
+
+---
+
+## 2. The model: a third memory plane
+
+loopctl already hosts two memory planes. This adds the missing third:
+
+| Plane | Scope | Lifetime | Purpose | Status |
+|---|---|---|---|---|
+| **Knowledge** | tenant-wide, curated | durable (months+) | reusable lessons | exists |
+| **Memory** | one agent, private | working state | *my* accumulated context | exists (`memory_*`) |
+| **Channel / Bus** | one **repo/project**, shared | **transient** (≤30d) | situational awareness *between* concurrent/sequential sessions | **new** |
+
+The bus is not "Slack for agents." It is a **project-scoped coordination log**: append-only, attributed, typed, read at the moments an agent can act on it.
+
+---
+
+## 3. Design
+
+### 3.1 Channel = a repo
+A channel is a `project_id` (a work project, or the KB scope created via `create_kb_scope` for repos with no work project). Every session on `claude-config` shares one channel. Tenant-isolated by RLS, exactly like knowledge/memory.
+
+### 3.2 Message = one simple, attributed post (no type taxonomy)
+Deliberately minimal (owner decision, 2026-07-17: *"I wouldn't bother with message types and their specific retentions. It's really that simple."*). A post carries, server-stamped: `agent_id` (from the key — tamper-evident, never from the body), `host`, `session_id`, `created_at`, `project_id`; plus a free-text `body`, an **optional** `key`, and **optional** structured `refs` (`{file, pr, branch, commit}`).
+
+- **No `kind` enum.** A post is just a message on the repo's channel. Whether it's a heads-up, a status, a hand-off, or a working-state note is expressed in the body/refs, not a required taxonomy — the fleet audit showed the 6-category taxonomy in memory-keeper was barely used, so we don't reintroduce one.
+- **`key` is optional and enables upsert.** Posting with the same `(project_id, key)` overwrites — that covers memory-keeper's dominant keyed working-state pattern (`session_goal`, `test_plan`, `build-complete-<ticket>`) without a schema. Omit `key` for a plain append-only message.
+- **Advisory locks / presence are NOT in this model.** ("Who's editing what / who's live" is a later refinement built on `refs` + `UpdateLastSeen`, not a message type — see §7. v1 is: post and read.)
+
+### 3.3 Read model — pull at the moments an agent can use it
+- **SessionStart injection.** The existing recall-pack hook gains a **TEAM CHANNEL** section: active claims + recent posts from *other* sessions on this repo (self-deduped). A fresh session on any machine opens with "beelink, 20m ago: working X, opened PR #107, claimed `foo.ex`." This is the killer integration and it reuses machinery that already ships.
+- **On-demand** via MCP (`channel_recent`, `presence`).
+- **Turn-boundary freshness (v2).** A `UserPromptSubmit` (or `Stop`) hook pulls `channel_recent(since=last_seen)` each turn and injects deltas, so a long session stays current at **turn granularity — the finest granularity an agent can actually consume** — with no persistent connection. See §5.
+
+### 3.4 Retention — uniform 30 days
+Every post expires 30 days after its last write (`created_at`/`updated_at` + 30d). No per-type tiers — flat and simple (owner decision). A cheap Oban TTL sweep (same shape as the #411 graduation sweep) deletes expired rows.
+
+30 days is safe *because* the memory→knowledge graduation path (#411) already exists: the rare post worth keeping is promoted to the durable Knowledge plane; the rest was always disposable. This keeps the roll small and sharpens the three-plane separation instead of muddying it.
+
+### 3.5 Schema (sketch)
+```
+channel_posts
+  id            uuid pk
+  tenant_id     uuid  (RLS)
+  project_id    uuid  (the channel)
+  agent_id      uuid  (server-stamped from key identity; never from body)
+  session_id    text
+  host          text
+  key           text  null    -- optional; upsert on (tenant_id, project_id, key)
+  body          text  not null
+  refs          jsonb null     -- optional {file,pr,branch,commit}
+  expires_at    timestamptz    -- created_at/updated_at + 30d (uniform)
+  created_at    timestamptz
+  updated_at    timestamptz
+  -- indexes: (tenant_id, project_id, created_at desc), (expires_at) for the sweep,
+  --          unique (tenant_id, project_id, key) where key is not null
+```
+Ordering + tamper-evidence come from the existing audit chain + STH — no separate message-ordering system needed.
+
+### 3.6 Tool surface
+- **v1 (solves the pain):** `channel_post(project, body, key?, refs?)`, `channel_recent(project, since?, limit?)`, and the SessionStart TEAM CHANNEL block (default-on for every repo).
+- **later:** `presence(project)` (from the existing `UpdateLastSeen` plug), a turn-boundary freshness hook (§5), and — if collisions prove painful in real use — an advisory soft-lock built on `refs`.
+
+---
+
+## 4. Security / tier posture
+
+This is a **coordination surface, not chain-of-custody.** Posting/reading your own tenant's channel is not "approving your own work" — it is the same *content* class as the KB surface that owner decision #331 already made fully agent-usable. So: **agent-role, no `RequireHumanAnchor`**, RLS tenant-scoped, `agent_id` stamped server-side (never from the body). Cross-tenant isolation is the existing RLS boundary. No new trust surface.
+
+---
+
+## 5. The realtime question (resolved: no websockets for agents)
+
+The store is mandatory either way (late joiners, replay, audit, offline). The debate is only "store-and-pull" vs "store + push."
+
+- **Agents consume at turn boundaries.** Unlike a human in Slack, an agent can't react to a mid-turn push — it reads context only at a turn boundary. Realtime's sub-second delivery is *wasted* on a consumer that can't look until its next turn.
+- **Fly `auto_stop_machines = suspend`** is at war with long-lived connections; a stateless HTTP-read model is native to suspend-on-idle. (And beelink is reached over SSH — one more fragile socket.)
+- **Ordering/atomicity/audit come from the DB,** which loopctl already has; WS would need its own.
+
+**Decision:** store-and-poll, plus a turn-boundary freshness pull (§3.3). Push is deferred and, when built, is **for a human dashboard only** — an SSE feed (one-way, reconnects trivially, suspend-friendly) so Mark can *watch* his fleet coordinate. Agents never need it.
+
+---
+
+## 6. Retiring memory-keeper (a 3-item rebuild, not a parity project)
+
+The audit (§1.2) makes this concrete. memory-keeper's used surface is three things, each with a home:
+
+1. **key/value working state** (`context_items`, mostly uncategorized) → `kind:state` posts.
+2. **checkpoint handoff** (`build-complete-<ticket>`) → `kind:handoff` posts (and this is the piece that becomes **multi-machine** — the file checkpoint never was).
+3. **cross-session history + search** → the 30-day roll is queryable; keepers graduate to Knowledge (permanent semantic search — the exact capability SETUP.md says degrades without memory-keeper).
+
+Everything else (entities, relations, journal, compression, observations, agent-tasks, file-cache) has **zero fleet usage** — nothing to preserve.
+
+**Honest tradeoff:** memory-keeper works offline (local SQLite); a hosted bus needs the network. Mitigation + sequencing:
+- Files (`.claude/checkpoints/`, `.claude/state/*.md`) **stay as the local/offline source of truth**; the bus is the shared **multi-machine layer** over them (and supersedes the optional memory-keeper mirror immediately).
+- The bus's own capture/writes degrade gracefully when loopctl is unreachable (same pattern as the capture hook), reconciling on reconnect.
+
+**Sequencing (low-risk):** ship the bus v1 as the *wedge*; run it in real multi-machine use for a few weeks; if it delivers, migrate the three uses deliberately and retire the (already-demoted, optional) memory-keeper mirror. Never bet the memory system on an unproven design.
+
+---
+
+## 7. v1 scope (the wedge) — decisions locked
+
+**v1 = two tools + one hook block:** `channel_post`, `channel_recent`, and SessionStart TEAM CHANNEL injection. That alone kills the manual-relay pain and unifies cross-machine awareness. Presence, turn-boundary freshness, and any advisory-lock refinement come later.
+
+**Decisions (resolved with Mark, 2026-07-17):**
+1. **Channel identity = `project_id`** (including `:kb` scopes). ✔
+2. **Retention = 30 days**, uniform. ✔
+3. **TEAM CHANNEL injection is created/on by default for every repo** (no per-repo opt-in). ✔
+4. **memory-keeper retirement gate:** full migration of agent/skill references follows *flawless* real use of the new channels — the bus must prove itself first. ✔
+5. **Keep it simple:** no message-type taxonomy, no per-type retention (§3.2, §3.4). ✔

--- a/docs/user_stories/epic_39_repo_coordination_bus/README.md
+++ b/docs/user_stories/epic_39_repo_coordination_bus/README.md
@@ -1,0 +1,50 @@
+# Epic 39 — Repo Coordination Bus (v1)
+
+Design source of truth: **`docs/repo-coordination-bus.md`**.
+
+## The problem (measured)
+
+When the same repo is worked from **more than one machine and/or more than one session**, the sessions can't talk to each other — coordination happens by hand (copy-pasting one session's finding into another). The stopgap, memory-keeper, is **local SQLite, one DB per machine**, so it structurally can't bridge machines. Fleet audit (2026-07-17) quantified the fragmentation: `home_care_billing` memory is **4,286 items split 444 / 3163 / 679 across three machines, none shared**.
+
+This epic adds the missing **third memory plane**: a project-scoped, append-only, short-lived coordination channel — hosted on loopctl so it is multi-machine by construction.
+
+## The model (v1, deliberately minimal)
+
+A **channel = a `project_id`** (including `:kb` scopes). A **post** is one attributed message: `agent_id` (server-stamped from the key), `host`, `session_id`, `body`, an optional `key` (upsert), optional structured `refs`. **No message-type taxonomy; uniform 30-day retention** (owner decision — the fleet audit showed the category taxonomy was barely used). Durable keepers **graduate to Knowledge** (#411); the rest expires. Sessions read the channel at **SessionStart** (a new TEAM CHANNEL block) and on demand. Realtime/websockets are deliberately excluded — agents consume at turn boundaries (see the design brief §5).
+
+## Decomposition
+
+| Story | Title | Repo | Risk | Depends |
+|-------|-------|------|------|---------|
+| US-39.1 | `channel_posts` schema + migration (RLS, indexes, 30d `expires_at`, optional-key upsert) | loopctl | Low-Med (migration + RLS) | — |
+| US-39.2 | `channel_post` write endpoint + context (agent role, upsert, `agent_id` stamped, ownership) | loopctl | **Med — auth boundary** | US-39.1 |
+| US-39.3 | `channel_recent` read endpoint + context (tenant+project scoped, `since`/`limit`) | loopctl | Low-Med | US-39.1 |
+| US-39.4 | MCP tools `channel_post` + `channel_recent` (Node proxy, agent key) + publish | loopctl | Low | US-39.2, US-39.3 |
+| US-39.5 | 30-day Oban TTL sweep worker | loopctl | Low | US-39.1 |
+| US-39.6 | SessionStart **TEAM CHANNEL** injection (default-on, injection-safe, fail-open) | **claude-config** | Med (hook; untrusted-content injection) | US-39.3 |
+| US-39.7 | Delete/redact a channel post (remove a leaked post before its 30-day expiry) | loopctl | Med (secret backstop) | US-39.2, US-39.4 |
+
+US-39.6 lives in the **claude-config** repo (the SessionStart hook), not loopctl — it is the consumer of the loopctl API and ships/reviews on its own delivery loop; it is listed here for epic completeness.
+
+Total: 7 stories, ~1.5M estimated tokens. Both a technical-accuracy review (grounding every assumption against loopctl code) and a completeness/security review were run over these stories before this epic was committed; their findings are folded in (see the constraints below).
+
+## Non-negotiable constraints (release gates)
+
+- **Tenant isolation = AdminRepo + explicit `tenant_id` filter (RLS is defense-in-depth).** Runtime isolation is the loopctl content pattern: query via `AdminRepo` (BYPASSRLS) with an explicit `tenant_id` filter in EVERY query — exactly like Knowledge/Projects — with RLS ENABLED on `channel_posts` as a second layer. A query missing the tenant filter is a bug even though RLS would also stop it. Isolation is tested on BOTH paths.
+- **`agent_id` is server-stamped from the verified key identity, ALWAYS and NEVER from the body** — a caller cannot post as another agent; a key without an agent identity is 403 (channel posts require identity unconditionally, unlike the conditional memory-metadata gate). `host`/`session_id` are client-supplied, informational, and spoofable — never used as authorization or as authoritative attribution.
+- **Project ownership validated on write** via `Projects.get_project/2` (public; `validate_project_ownership` is private) — a missing OR cross-tenant `project_id` returns a **byte-identical 422** (no existence oracle).
+- **No cross-tenant existence oracle anywhere:** read of an unowned/nonexistent project → uniform **200 empty**; delete of one → uniform **404**; write → uniform **422**. Same status AND body for "not yours" and "does not exist".
+- **Body, `refs`, and `key` are all secret-scanned and bounded:** `body` ≤16KB; `refs` constrained to `{file,pr,branch,commit}` string values with per-value + total-size caps; `key` ≤200. The knowledge secret-denylist runs over `body` AND `refs` values AND `key`; a hit is an explicit **422 rejection** (never a silent drop).
+- **Write is rate-limited** (per `(tenant, agent)`, 429 + Retry-After) so an agent cannot spam posts, thrash a key, or inflate the audit chain.
+- **A delete/redact path exists (US-39.7)** so a leaked/regretted post — including one the denylist missed — is removable immediately, not stuck (and auto-injected) for 30 days.
+- **Agent-role, no human-anchor:** coordination/content surface (owner decision #331). Exposes NO work-breakdown surface. The default-deny guard test allowlists the mutating routes (`POST /channel/posts`, `DELETE /channel/posts/:id`); the GET is not walked by that test.
+- **Security events are logged:** denylist hits, ownership/tenant rejections, `agent_identity_required`, and rate-limit trips are emitted as structured telemetry.
+- **Retention enforced:** `expires_at = now + 30d`; reads filter `expires_at > now()` defensively; the sweep (US-39.5, template `SessionMemoryPruneWorker`) is idempotent, batch-bounded, and only deletes expired rows.
+- **The claude-config injection (US-39.6) treats post bodies as UNTRUSTED, agent-authored content rendered into a bash hook + a new session's context:** every field injected as JSON-encoded data (`jq --arg`, never shell-interpolated → no command injection), truncated + fenced (no prompt-injection breakout, bounded volume), fail-open + latency-bounded, and off-switch-aware (`CLAUDE_MEMORY`, `.claude/memory-off`, and a dedicated `CLAUDE_TEAM_CHANNEL=0`).
+- **OpenAPI:** each new endpoint declares an `operation/1` spec (loopctl maintains OpenAPI; `openapi_test.exs` must pass).
+- Every loopctl merge auto-deploys behind the smoke gate; no schema change here is destructive (new table + online indexes).
+
+## Out of scope for v1 (deliberate)
+
+- **Knowledge-graduation bridge** (`channel_post → knowledge_create` for a keeper): deferred per design §6 sequencing. The "30-day hard delete loses nothing" claim rests on this existing as a *manual* path today; a first-class bridge is a follow-up.
+- **Presence, turn-boundary freshness pull, advisory soft-locks, realtime/SSE** (design §5): later — v1 is post + read + inject + delete.

--- a/docs/user_stories/epic_39_repo_coordination_bus/us_39.1.json
+++ b/docs/user_stories/epic_39_repo_coordination_bus/us_39.1.json
@@ -1,0 +1,44 @@
+{
+  "id": "US-39.1",
+  "title": "channel_posts schema + migration (RLS + explicit-tenant-filter, indexes, 30-day expires_at, per-session keyed upsert)",
+  "epic": { "id": "epic_39", "name": "Repo Coordination Bus" },
+  "priority": "high",
+  "phase": "coordination_bus_v1",
+  "story": {
+    "as_a": "loopctl platform developer",
+    "i_want_to": "add a tenant-scoped channel_posts table (RLS enabled, but queried via AdminRepo with an explicit tenant_id filter like all other tenant content) whose rows are project-scoped messages with an optional per-session upsert key and a uniform 30-day expires_at",
+    "so_that": "agent sessions on the same repo (across machines) have a shared, short-lived, multi-machine coordination store to build the post/read API on"
+  },
+  "rationale": "The coordination bus is the third memory plane (Knowledge=durable, Memory=agent-private, Channel=repo-scoped/transient). It must be hosted (multi-machine) and tenant-isolated by the same discipline as every other loopctl content table — AdminRepo (BYPASSRLS) plus explicit tenant_id filtering in every query, with RLS enabled as defense-in-depth. The schema is deliberately minimal — no message-type taxonomy — because the fleet audit showed the category taxonomy was essentially unused; an optional key gives per-session upsert for keyed working-state without a type system.",
+  "background": {
+    "reference": "docs/repo-coordination-bus.md §3.1, §3.4, §3.5; technical review D1/D2/M2/M6/M7",
+    "includes": "Mirrors the tenant_id + AdminRepo pattern of Loopctl.Knowledge.Article and Loopctl.Projects.Project; RLS enabled via Loopctl.Repo.RlsHelpers.enable_rls/1 (rls_helpers.ex:38) exactly as create_projects (20260327154649) and create_articles (20260410002347) do."
+  },
+  "acceptance_criteria": [
+    { "id": "AC-39.1.1", "description": "A migration creates channel_posts with columns: id (binary_id pk), tenant_id (binary_id, references(:tenants, on_delete: :delete_all), not null), project_id (binary_id, references(:projects, on_delete: :delete_all), not null), agent_id (binary_id, not null), session_id (text, null), host (text, null), key (text, null), body (text, not null), refs (map/jsonb, null), expires_at (utc_datetime_usec, not null), inserted_at/updated_at timestamps.", "status": "pending" },
+    { "id": "AC-39.1.2", "description": "RLS is ENABLED on channel_posts via RlsHelpers.enable_rls(:channel_posts) (defense-in-depth). NOTE: production isolation is NOT RLS — it is AdminRepo + an explicit tenant_id filter in every Coordination query (the Knowledge/Projects pattern). Both must hold: a query missing the tenant_id filter is a bug even though RLS would also stop it.", "status": "pending" },
+    { "id": "AC-39.1.3", "description": "Indexes exist: (tenant_id, project_id, inserted_at DESC) for recent reads; (expires_at) for the sweep; and a UNIQUE index on (tenant_id, project_id, session_id, key) WHERE key IS NOT NULL. The key slot is per (tenant, project, SESSION) — NOT project-global — so two concurrent sessions writing key \"session_goal\" do not clobber each other (see M7).", "status": "pending" },
+    { "id": "AC-39.1.4", "description": "Loopctl.Coordination.ChannelPost schema defines the fields, @derive Jason.Encoder exposing id/tenant_id/project_id/agent_id/session_id/host/key/body/refs/expires_at/inserted_at/updated_at, and a create_changeset that casts ONLY [:session_id, :host, :key, :body, :refs] — tenant_id, project_id, agent_id, expires_at are set programmatically on the struct, never via cast. There is NO :kind/:category/:type field.", "status": "pending" },
+    { "id": "AC-39.1.5", "description": "create_changeset validates: body present and length <= 16384; key (when present) length <= 200; refs (when present) is a map whose keys are a subset of the allowlist {file, pr, branch, commit}, each value a string <= 512 chars, with a total serialized refs size <= 4KB (larger/other-keyed refs are invalid).", "status": "pending" },
+    { "id": "AC-39.1.6", "description": "A secret denylist (the same regex set the knowledge extractor uses: Bearer/sk-/lc_/gh[pousr]_/AKIA/PEM/xox) is run over body AND every refs value AND key. A match REJECTS the write with a 422 (does not persist) so the caller learns the info did not land — it is NOT silently dropped.", "status": "pending" },
+    { "id": "AC-39.1.7", "description": "The new table + indexes are online-safe (new table; no destructive rewrite) and the migration runs clean via the release migrate path.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-39.1.1", "name": "row inserts with programmatic tenant/project/agent/expires", "type": "integration", "preconditions": ["tenant = fixture(:tenant)", "project = fixture(:project, %{tenant_id: tenant.id})"], "steps": ["Insert a ChannelPost via Coordination with tenant_id/project_id/agent_id/expires_at set on the struct and body cast from attrs"], "expected_results": ["{:ok, post}", "expires_at ~30 days out", "key/refs nullable"] },
+    { "id": "TC-39.1.2", "name": "isolation holds on BOTH paths (AdminRepo+filter AND RLS)", "type": "integration", "preconditions": ["tenant_a = fixture(:tenant); tenant_b = fixture(:tenant)", "a post exists for tenant_a's project"], "steps": ["Coordination.recent(tenant_b.id, ...) via AdminRepo+explicit filter", "AND query channel_posts through the RLS Repo under tenant_b scope"], "expected_results": ["AdminRepo path: zero rows (explicit tenant filter)", "RLS Repo path: zero rows (belt-and-suspenders)"] },
+    { "id": "TC-39.1.3", "name": "per-session keyed slot: two sessions do not clobber", "type": "integration", "preconditions": ["tenant = fixture(:tenant); project = fixture(:project, %{tenant_id: tenant.id})", "session A post key \"session_goal\"; session B post same key"], "steps": ["Insert both keyed posts with different session_id"], "expected_results": ["both rows persist (unique index includes session_id)", "neither overwrites the other"] },
+    { "id": "TC-39.1.4", "name": "over-large / wrong-keyed refs rejected", "type": "unit", "preconditions": ["tenant = fixture(:tenant); project = fixture(:project, %{tenant_id: tenant.id})"], "steps": ["create_changeset with refs %{\"evil\" => String.duplicate(\"x\", 9000)}"], "expected_results": ["invalid; error on :refs (key not in allowlist AND size)"] },
+    { "id": "TC-39.1.5", "name": "secret in refs.branch is rejected 422", "type": "unit", "preconditions": ["tenant = fixture(:tenant); project = fixture(:project, %{tenant_id: tenant.id})"], "steps": ["create_changeset with refs %{\"branch\" => \"lc_\" <> String.duplicate(\"a\", 30)}"], "expected_results": ["invalid; denylist match on a refs value; not persisted"] },
+    { "id": "TC-39.1.6", "name": "no kind/type field exists", "type": "unit", "preconditions": [], "steps": ["Inspect Loopctl.Coordination.ChannelPost.__schema__(:fields)"], "expected_results": ["only the minimal set; no :kind/:category/:type"] }
+  ],
+  "technical_notes": [
+    "Schema: Loopctl.Coordination.ChannelPost; context: Loopctl.Coordination; table: channel_posts (no existing collision — verified).",
+    "RLS: RlsHelpers.enable_rls(:channel_posts) — ENABLE (not FORCE) like other tables; runtime isolation is AdminRepo + explicit tenant_id filter, NOT RLS (see Knowledge/Projects). RLS is defense-in-depth.",
+    "project_id references(:projects, on_delete: :delete_all) — same FK/cascade as articles.project_id, but NOT NULL here (articles.project_id is nullable; a channel post always has a channel).",
+    "expires_at set in the context as now + @retention_days (30) — one authoritative constant in code, not a DB default.",
+    "Factor the knowledge secret-denylist regex into a shared helper and run it over body + refs values + key.",
+    "Unique key slot is (tenant_id, project_id, session_id, key) WHERE key IS NOT NULL — per-session, decided under M7 to avoid cross-session clobber."
+  ],
+  "dependencies": [],
+  "estimated_tokens": 220000
+}

--- a/docs/user_stories/epic_39_repo_coordination_bus/us_39.2.json
+++ b/docs/user_stories/epic_39_repo_coordination_bus/us_39.2.json
@@ -1,0 +1,47 @@
+{
+  "id": "US-39.2",
+  "title": "channel_post write endpoint + context (agent role, per-session upsert, unconditional server-stamped agent_id, ownership, rate-limit)",
+  "epic": { "id": "epic_39", "name": "Repo Coordination Bus" },
+  "priority": "high",
+  "phase": "coordination_bus_v1",
+  "story": {
+    "as_a": "coding agent working a repo",
+    "i_want_to": "POST a short message to my repo's coordination channel, optionally under a key that upserts my own working-state",
+    "so_that": "other sessions on the same repo — on any machine — can see what I found, did, or am doing"
+  },
+  "rationale": "This is the write half and the primary trust boundary. It must stamp the author identity from the verified key (not the body), confine the post to a project the caller's tenant owns, set the 30-day TTL server-side, and resist abuse (post spam / upsert thrash) — so no caller can forge authorship, post into another tenant's channel, evade retention, or exhaust the store/audit chain.",
+  "background": {
+    "reference": "docs/repo-coordination-bus.md §3.2, §3.6; owner decision #331; reviews D1/D2/D3/M1/M3/M6/M7/M9/N1",
+    "includes": "Auth/role mirrors create_kb_scope (project_controller.ex:23-40): role: :agent, NOT under RequireHumanAnchor. Writes use AdminRepo + explicit tenant filter (Knowledge/Projects pattern). Ownership via Projects.get_project/2. Audit via Audit.log_in_multi/3 (audit.ex:105)."
+  },
+  "acceptance_criteria": [
+    { "id": "AC-39.2.1", "description": "POST /api/v1/channel/posts accepts {project_id, body, key?, refs?, session_id?, host?}. RequireRole :agent, NOT behind RequireHumanAnchor (coordination surface, #331). An OpenApiSpex operation/1 spec is declared so it appears in the API docs and passes openapi_test.exs (loopctl maintains OpenAPI — same requirement create_kb_scope had).", "status": "pending" },
+    { "id": "AC-39.2.2", "description": "tenant_id = conn.assigns.current_api_key.tenant_id and agent_id = the key's api_key.agent_id, stamped server-side. agent_id is required UNCONDITIONALLY (channel_posts.agent_id is NOT NULL) — a key with no agent_id gets 403 agent_identity_required. (Note: do NOT copy article_controller bind_agent_identity's CONDITIONAL gate, which only fires when memory metadata is present; here identity is always required.) Any agent_id/tenant_id in the body is ignored.", "status": "pending" },
+    { "id": "AC-39.2.3", "description": "project_id must exist and belong to the caller's tenant, checked via Projects.get_project(tenant_id, project_id). A missing project AND a cross-tenant project both return 422 with a BYTE-IDENTICAL error body (no oracle distinguishing 'not yours' from 'does not exist') and NO row is created.", "status": "pending" },
+    { "id": "AC-39.2.4", "description": "expires_at = now + 30 days, set server-side (never from body).", "status": "pending" },
+    { "id": "AC-39.2.5", "description": "With key present the write UPSERTS on (tenant_id, project_id, session_id, key) — PER SESSION: a second post from the SAME session with the same key updates body/refs/updated_at and resets expires_at, returning the same row id; a different session's same key is a distinct row (no cross-session clobber). Without key, every post is a new append-only row.", "status": "pending" },
+    { "id": "AC-39.2.6", "description": "Returns 201 (created) or 200 (upsert-updated) with the post JSON incl. server-stamped agent_id/tenant_id/expires_at. Missing body / body>16KB / invalid refs (US-39.1 AC-39.1.5) / denylist hit (US-39.1 AC-39.1.6) → 422, not persisted.", "status": "pending" },
+    { "id": "AC-39.2.7", "description": "The write is audited (Audit.log_in_multi, entity_type \"channel_post\", action \"posted\"/\"upserted\", actor = the agent) in the same AdminRepo.transaction, so authorship is tamper-evident.", "status": "pending" },
+    { "id": "AC-39.2.8", "description": "The endpoint is rate-limited: per (tenant_id, agent_id) writes are capped per rolling window (returning 429 with Retry-After) using the project's existing limiter (the :authenticated pipeline RateLimiter / Hammer convention), so an agent cannot spam unbounded posts nor thrash a single key. The cap is a config value, not hardcoded.", "status": "pending" },
+    { "id": "AC-39.2.9", "description": "Security-relevant events are emitted as structured logs/telemetry: denylist rejection, cross-tenant/not-found ownership rejection (422), agent_identity_required (403), and rate-limit trip (429) — so exfil attempts and enumeration scans are observable.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-39.2.1", "name": "agent posts to own project channel", "type": "integration", "preconditions": ["tenant = fixture(:tenant, %{trust_tier: :agent_rooted})", "project = fixture(:project, %{tenant_id: tenant.id})", "{key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})"], "steps": ["POST {project_id: project.id, body: \"pushed PR #107, CI green\"}"], "expected_results": ["201", "agent_id == the key's agent_id", "expires_at ~30d"] },
+    { "id": "TC-39.2.2", "name": "body-supplied agent_id/tenant_id ignored", "type": "integration", "preconditions": ["tenant = fixture(:tenant); project = fixture(:project, %{tenant_id: tenant.id})", "{key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})"], "steps": ["POST with a foreign agent_id + tenant_id in the body"], "expected_results": ["stored agent_id/tenant_id are the key's"] },
+    { "id": "TC-39.2.3", "name": "cross-tenant AND not-found project both 422, identical body", "type": "integration", "preconditions": ["tenant = fixture(:tenant); other = fixture(:tenant)", "foreign = fixture(:project, %{tenant_id: other.id})", "{key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})"], "steps": ["POST with foreign.id", "POST with a random nonexistent UUID"], "expected_results": ["both 422", "response bodies are identical (no existence oracle)", "no row created either time"] },
+    { "id": "TC-39.2.4", "name": "keyed post upserts within a session, not across", "type": "integration", "preconditions": ["tenant = fixture(:tenant); project = fixture(:project, %{tenant_id: tenant.id})", "{key,_} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})", "an existing post session_id \"S1\" key \"session_goal\" body \"v1\""], "steps": ["POST session_id \"S1\" key \"session_goal\" body \"v2\"", "POST session_id \"S2\" key \"session_goal\" body \"other\""], "expected_results": ["S1 row updated in place to v2 (same id, one row)", "S2 is a distinct row", "no clobber across sessions"] },
+    { "id": "TC-39.2.5", "name": "agent key without agent_id is 403", "type": "integration", "preconditions": ["{key,_} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent, agent_id: nil})"], "steps": ["POST a channel post"], "expected_results": ["403 agent_identity_required; no row"] },
+    { "id": "TC-39.2.6", "name": "over-cap writes are 429", "type": "integration", "preconditions": ["tenant + project + agent key", "write cap set low for the test"], "steps": ["POST more than the cap in the window"], "expected_results": ["excess returns 429 with Retry-After", "a security-event log is emitted"] }
+  ],
+  "technical_notes": [
+    "Controller: LoopctlWeb.ChannelPostController; route POST /api/v1/channel/posts in :authenticated.",
+    "Context: Loopctl.Coordination.post(tenant_id, agent_id, attrs) using AdminRepo (NOT the RLS Repo — matches Knowledge/Projects). Wrap insert/upsert + audit in Ecto.Multi (Audit.log_in_multi/3).",
+    "Upsert: AdminRepo.insert(cs, on_conflict: {:replace, [:body, :refs, :updated_at, :expires_at]}, conflict_target: [:tenant_id, :project_id, :session_id, :key]) only when key present; keyless plain-insert. Precedent: knowledge.ex:4066, memory.ex:2262.",
+    "Ownership: Projects.get_project/2 (projects.ex:107) returns {:ok,%Project{}}|{:error,:not_found}; UUID-cast-guarded (no 500 on malformed id). Map :not_found -> the shared 422 (same body as cross-tenant). Do NOT call Knowledge.validate_project_ownership (it is defp/private).",
+    "agent_id per #163 = api_key.agent_id; REQUIRED here (not the conditional memory-metadata gate).",
+    "Default-deny guard test: allowlist {:post, \"/api/v1/channel/posts\"} with the coordination-surface justification.",
+    "Rate limit: reuse the :authenticated pipeline RateLimiter/Hammer; make the per-(tenant,agent) write cap configurable."
+  ],
+  "dependencies": ["US-39.1"],
+  "estimated_tokens": 300000
+}

--- a/docs/user_stories/epic_39_repo_coordination_bus/us_39.3.json
+++ b/docs/user_stories/epic_39_repo_coordination_bus/us_39.3.json
@@ -1,0 +1,42 @@
+{
+  "id": "US-39.3",
+  "title": "channel_recent read endpoint + context (AdminRepo + explicit tenant filter, since/limit, live-only, oracle-safe)",
+  "epic": { "id": "epic_39", "name": "Repo Coordination Bus" },
+  "priority": "high",
+  "phase": "coordination_bus_v1",
+  "story": {
+    "as_a": "coding agent starting or resuming work on a repo",
+    "i_want_to": "read the recent, non-expired posts on my repo's channel, optionally only those since a timestamp",
+    "so_that": "I can see what other sessions (on any machine) said or did without anyone hand-relaying it to me"
+  },
+  "rationale": "This is the read half and the payload behind the SessionStart TEAM CHANNEL block. It must be strictly tenant+project scoped (AdminRepo + explicit tenant_id filter, the loopctl content pattern), cheap, return only live posts newest-first with a since delta, and never leak whether another tenant's project exists.",
+  "background": {
+    "reference": "docs/repo-coordination-bus.md §3.3, §3.6; reviews D1/D4/M3/M9/N1",
+    "includes": "Read scoping mirrors ProjectController agent-open, tenant-scoped reads; queried via AdminRepo + explicit tenant_id filter (NOT RLS Repo)."
+  },
+  "acceptance_criteria": [
+    { "id": "AC-39.3.1", "description": "GET /api/v1/channel/posts?project_id=&since=&limit= is RequireRole :agent, tenant-scoped from the key, and returns posts for that project_id ordered inserted_at DESC. An OpenApiSpex operation/1 spec is declared (passes openapi_test.exs).", "status": "pending" },
+    { "id": "AC-39.3.2", "description": "Only LIVE posts are returned: the query filters expires_at > now() defensively (independent of the sweep), so an expired-but-not-yet-swept post never appears.", "status": "pending" },
+    { "id": "AC-39.3.3", "description": "since (ISO8601) filters to greatest(inserted_at, updated_at) > since; limit defaults to 25 and is CLAMPED to a max of 100 (a larger value is clamped to 100, matching the read-bound convention — not a 400).", "status": "pending" },
+    { "id": "AC-39.3.4", "description": "ORACLE-SAFE: a project_id belonging to another tenant, or a nonexistent project_id, returns 200 with an EMPTY list — UNIFORMLY, identical to an owned-but-empty project. It NEVER returns 404 and never a different status/body that would reveal whether the project exists in another tenant.", "status": "pending" },
+    { "id": "AC-39.3.5", "description": "Each returned post includes id, agent_id, session_id, host, key, body, refs, inserted_at, updated_at — enough to render 'who / which machine / which session / when' and to self-dedupe by session_id. agent_id is the only server-stamped (authoritative) attribution; session_id/host are client-supplied and informational.", "status": "pending" },
+    { "id": "AC-39.3.6", "description": "The response is a standard {data: [...], meta: {...}} envelope; meta carries the applied limit and returned count.", "status": "pending" },
+    { "id": "AC-39.3.7", "description": "Query uses AdminRepo with an EXPLICIT tenant_id filter (never relies on RLS as the isolation mechanism), consistent with Knowledge/Projects reads.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-39.3.1", "name": "returns own project's live posts newest-first", "type": "integration", "preconditions": ["tenant = fixture(:tenant); project = fixture(:project, %{tenant_id: tenant.id})", "{key,_} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})", "three live posts t1<t2<t3"], "steps": ["GET ?project_id=#{project.id}"], "expected_results": ["data has 3, ordered t3,t2,t1"] },
+    { "id": "TC-39.3.2", "name": "expired posts excluded", "type": "integration", "preconditions": ["one expired + one live post"], "steps": ["GET the channel"], "expected_results": ["only the live post returned"] },
+    { "id": "TC-39.3.3", "name": "since returns only the delta", "type": "integration", "preconditions": ["posts at t1 and t3; since=t2"], "steps": ["GET ...&since=<t2>"], "expected_results": ["only t3"] },
+    { "id": "TC-39.3.4", "name": "cross-tenant AND nonexistent project both 200 empty (no oracle)", "type": "integration", "preconditions": ["tenant = fixture(:tenant); other = fixture(:tenant)", "a post on other's project", "{key,_} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})"], "steps": ["GET with other's project_id", "GET with a random nonexistent UUID"], "expected_results": ["both 200 with empty data, identical responses"] },
+    { "id": "TC-39.3.5", "name": "limit clamped to 100", "type": "integration", "preconditions": ["150 live posts"], "steps": ["GET ...&limit=1000"], "expected_results": ["exactly 100 returned (clamped, not a 400)"] }
+  ],
+  "technical_notes": [
+    "Context: Loopctl.Coordination.recent(tenant_id, project_id, opts) — AdminRepo query filtering tenant_id + project_id + expires_at > now(), order inserted_at desc, limit clamped to 100.",
+    "Oracle-safety: return {:ok, []} for a project the tenant doesn't own — do NOT branch to :not_found. This keeps cross-tenant existence unobservable and simplifies the consumer.",
+    "Do NOT self-dedup server-side — that is the consumer's job (US-39.6).",
+    "This GET is NOT covered by require_human_anchor_default_deny_test (it only walks POST/PUT/PATCH/DELETE) — no allowlist entry needed (correcting the earlier note).",
+    "Emit a security-event log on any internal error but never leak cross-tenant existence."
+  ],
+  "dependencies": ["US-39.1"],
+  "estimated_tokens": 180000
+}

--- a/docs/user_stories/epic_39_repo_coordination_bus/us_39.4.json
+++ b/docs/user_stories/epic_39_repo_coordination_bus/us_39.4.json
@@ -1,0 +1,39 @@
+{
+  "id": "US-39.4",
+  "title": "MCP tools channel_post + channel_recent (Node proxy, agent key) + publish",
+  "epic": { "id": "epic_39", "name": "Repo Coordination Bus" },
+  "priority": "high",
+  "phase": "coordination_bus_v1",
+  "story": {
+    "as_a": "coding agent using the loopctl MCP tools",
+    "i_want_to": "call channel_post and channel_recent directly as MCP tools",
+    "so_that": "I can leave and read repo coordination messages from inside a session without hand-crafting HTTP calls"
+  },
+  "rationale": "The MCP proxy is how agents actually reach loopctl. The two v1 tools must map 1:1 onto the endpoints on the agent key, fill host from the local machine automatically, and ship via the existing version-bump autopublish so a fresh session picks them up.",
+  "background": {
+    "reference": "docs/repo-coordination-bus.md §3.6; mcp-server/index.js create_kb_scope pattern (US-39.2/39.3 endpoints)",
+    "includes": "Mirrors the create_kb_scope tool: agent-key apiCall, tool def, dispatch case, node --test source-regex tests, package.json version bump, CHANGELOG, mcp-autopublish."
+  },
+  "acceptance_criteria": [
+    { "id": "AC-39.4.1", "description": "channel_post(project_id, body, key?, refs?) posts to POST /api/v1/channel/posts on the AGENT key. host is auto-filled from os.hostname(). session_id is auto-filled by the proxy from the SAME identifier SessionStart sees (CLAUDE_SESSION_ID env when Claude Code sets it; else omitted) — NOT a caller argument — so US-39.6 self-dedup can match. It carries no authority (client-supplied, informational only).", "status": "pending" },
+    { "id": "AC-39.4.2", "description": "channel_recent(project_id, since?, limit?) GETs /api/v1/channel/posts on the agent key and returns the recent posts.", "status": "pending" },
+    { "id": "AC-39.4.6", "description": "The session_id the tool writes and the session_id US-39.6 reads from the SessionStart stdin payload are the SAME value (both the Claude Code session id). If unavailable, session_id is null and self-dedup gracefully no-ops (a session may see its own posts echoed) — never an error, never a security dependency.", "status": "pending" },
+    { "id": "AC-39.4.3", "description": "Both tools are declared in TOOLS and wired in the dispatch switch; node --test source-regex tests assert each tool is declared, dispatched, and hits the correct path/method on the agent key (mirroring the create_kb_scope tests).", "status": "pending" },
+    { "id": "AC-39.4.4", "description": "mcp-server/package.json version is bumped and a CHANGELOG entry added, so mcp-autopublish publishes the new version on merge (the version-change-on-master trigger).", "status": "pending" },
+    { "id": "AC-39.4.5", "description": "The full mcp-server node --test suite is green.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-39.4.1", "name": "channel_post tool declared + dispatched on agent key", "type": "unit", "preconditions": ["read mcp-server/index.js source"], "steps": ["assert TOOLS has name: \"channel_post\"", "assert dispatch case returns channelPost(args)", "assert channelPost POSTs /api/v1/channel/posts with LOOPCTL_AGENT_KEY"], "expected_results": ["all three source-regex assertions pass"] },
+    { "id": "TC-39.4.2", "name": "channel_recent tool declared + dispatched on agent key", "type": "unit", "preconditions": ["read source"], "steps": ["assert TOOLS has name: \"channel_recent\"", "assert dispatch case returns channelRecent(args)", "assert channelRecent GETs /api/v1/channel/posts"], "expected_results": ["assertions pass"] },
+    { "id": "TC-39.4.3", "name": "host is auto-filled from os.hostname()", "type": "unit", "preconditions": ["read channelPost source"], "steps": ["assert body sets host from os.hostname() when not provided"], "expected_results": ["host is populated by the proxy"] },
+    { "id": "TC-39.4.4", "name": "version bumped so autopublish fires", "type": "unit", "preconditions": ["compare package.json version to the previous published version"], "steps": ["read mcp-server/package.json version + CHANGELOG top entry"], "expected_results": ["version is greater; CHANGELOG documents channel_post/channel_recent"] }
+  ],
+  "technical_notes": [
+    "Edit mcp-server/index.js: two async helpers (channelPost/channelRecent), two tool defs, two dispatch cases — copy the create_kb_scope shape exactly.",
+    "Use process.env.LOOPCTL_AGENT_KEY for both (coordination is agent-role).",
+    "Add tests to mcp-server/test/mcp_arg_forwarding.test.js in the same source-regex style as the create_kb_scope block.",
+    "Bump mcp-server/package.json version + add a CHANGELOG.md entry; mcp-autopublish.yml publishes on the package.json version change on master."
+  ],
+  "dependencies": ["US-39.2", "US-39.3"],
+  "estimated_tokens": 150000
+}

--- a/docs/user_stories/epic_39_repo_coordination_bus/us_39.5.json
+++ b/docs/user_stories/epic_39_repo_coordination_bus/us_39.5.json
@@ -1,0 +1,35 @@
+{
+  "id": "US-39.5",
+  "title": "30-day Oban TTL sweep worker for channel_posts",
+  "epic": { "id": "epic_39", "name": "Repo Coordination Bus" },
+  "priority": "medium",
+  "phase": "coordination_bus_v1",
+  "story": {
+    "as_a": "loopctl operator",
+    "i_want_to": "have expired channel posts deleted automatically on a schedule",
+    "so_that": "the coordination roll stays small and honors the uniform 30-day retention without manual cleanup"
+  },
+  "rationale": "Retention is a release gate, not a nicety. A scheduled, idempotent, bounded sweep keeps the table lean and enforces the 30-day window; anything worth keeping longer has already been graduated to Knowledge, so hard-deleting expired rows loses nothing.",
+  "background": {
+    "reference": "docs/repo-coordination-bus.md §3.4; review D5",
+    "includes": "Drop-in template is Loopctl.Workers.SessionMemoryPruneWorker (session_memory_prune_worker.ex): use Oban.Worker, @batch_size 1000, delete_in_batches/2 that loops limit(@batch_size) |> AdminRepo.all() then where(id in ^ids) |> AdminRepo.delete_all(), all-tenants on BYPASSRLS AdminRepo, scheduled {\"*/5 * * * *\"} in oban_config crontab. NOTE: the #411 MemoryGraduationSweepWorker is a scan-and-graduate job, NOT a TTL delete — do not copy it."
+  },
+  "acceptance_criteria": [
+    { "id": "AC-39.5.1", "description": "An Oban worker Loopctl.Workers.ChannelPostSweeper deletes channel_posts WHERE expires_at < now(). Scheduled via the Oban crontab in lib/loopctl/oban_config.ex plugins/0 at a fixed cadence (mirror SessionMemoryPruneWorker's {\"*/5 * * * *\"}).", "status": "pending" },
+    { "id": "AC-39.5.2", "description": "The sweep is bounded per run (deletes in batches with a max, logging the count) so a large backlog cannot lock the table; it is safe to run repeatedly (idempotent).", "status": "pending" },
+    { "id": "AC-39.5.3", "description": "The sweep runs across all tenants (admin/BYPASSRLS repo, like other maintenance workers) but only ever touches rows past expires_at — it never deletes a live post.", "status": "pending" },
+    { "id": "AC-39.5.4", "description": "The worker is registered in the Oban config/cron plugin and appears in Oban observability like the other periodic workers.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-39.5.1", "name": "sweep deletes expired, keeps live", "type": "integration", "preconditions": ["tenant = fixture(:tenant); project = fixture(:project, %{tenant_id: tenant.id})", "one post with expires_at in the past", "one post with expires_at in the future"], "steps": ["perform ChannelPostSweeper"], "expected_results": ["expired post deleted", "live post remains"] },
+    { "id": "TC-39.5.2", "name": "sweep is idempotent (second run no-ops)", "type": "integration", "preconditions": ["no expired rows"], "steps": ["perform the worker twice"], "expected_results": ["{:ok, ...} both times; zero deletions on the second"] },
+    { "id": "TC-39.5.3", "name": "batch bound is honored", "type": "integration", "preconditions": ["more expired rows than the batch max"], "steps": ["perform once"], "expected_results": ["at most batch-max deleted in one run; remaining swept next run"] }
+  ],
+  "technical_notes": [
+    "Worker: Loopctl.Workers.ChannelPostSweeper (use Oban.Worker); schedule in the Oban :crontab.",
+    "Delete via the admin repo with a LIMIT/returning-based batch (or delete_all with a subquery LIMIT) to bound each run.",
+    "Mirror the existing memory-graduation / retention sweep worker for cadence, logging, and test style."
+  ],
+  "dependencies": ["US-39.1"],
+  "estimated_tokens": 150000
+}

--- a/docs/user_stories/epic_39_repo_coordination_bus/us_39.6.json
+++ b/docs/user_stories/epic_39_repo_coordination_bus/us_39.6.json
@@ -1,0 +1,44 @@
+{
+  "id": "US-39.6",
+  "title": "SessionStart TEAM CHANNEL injection in claude-config (default-on, injection-safe, fail-open)",
+  "epic": { "id": "epic_39", "name": "Repo Coordination Bus" },
+  "priority": "high",
+  "phase": "coordination_bus_v1",
+  "story": {
+    "as_a": "coding agent starting a session on a repo",
+    "i_want_to": "automatically see, at SessionStart, the recent coordination posts from OTHER sessions on this repo",
+    "so_that": "cross-machine / cross-session context arrives without anyone hand-relaying it — the whole point of the bus"
+  },
+  "rationale": "This is the consumer that makes the bus pay off. It reuses the SessionStart recall-pack delivery to inject a TEAM CHANNEL block. Two hard constraints: (1) post bodies are UNTRUSTED, agent-authored content rendered into a bash hook and into a new session's context — so they must be injected as JSON-encoded data (never shell-interpolated), fenced, and truncated (prompt-injection + command-injection surface, not just prompt hygiene); (2) it is a READ (recall half) — fail-open, off-switch-aware, latency-bounded, never blocks SessionStart. It lives in claude-config (session-start.sh) and ships on claude-config's own delivery loop.",
+  "background": {
+    "reference": "docs/repo-coordination-bus.md §3.3; claude-config hooks/session-start.sh (recall pack, jq additionalContext, memory-policy off-switches, STH witness cache); reviews M5/M8/N3/N4",
+    "includes": "Reuse the capture hook's resolve (git origin -> /projects/resolve, strip creds) and STH witness header handling."
+  },
+  "acceptance_criteria": [
+    { "id": "AC-39.6.1", "description": "session-start.sh resolves the current repo to its project_id (git remote origin -> GET /projects/resolve, as the capture hook does) and calls GET /api/v1/channel/posts?project_id=&limit=N to fetch recent posts.", "status": "pending" },
+    { "id": "AC-39.6.2", "description": "It injects a 'TEAM CHANNEL' section into the SessionStart additionalContext listing recent posts from OTHER sessions (drop posts whose session_id == this session's), newest first, capped at N (e.g. 5). Each post renders as agent / host / short-age / body (+ refs). CRITICAL: every post field is passed to jq as a JSON-encoded value (jq --arg / --argjson), NEVER shell-interpolated or string-concatenated — a body containing backticks, $(...), quotes, or newlines cannot break the render, the JSON, or execute in the hook.", "status": "pending" },
+    { "id": "AC-39.6.3", "description": "Each post's body is TRUNCATED in the render (e.g. <= 500 chars, ellipsized) — the 16KB write cap is not a render cap — so the injected block is bounded regardless of post size (bounds prompt-injection volume: N posts x 500 chars, not N x 16KB).", "status": "pending" },
+    { "id": "AC-39.6.4", "description": "The block is fenced with clear BEGIN/END delimiters and a wrapper line stating the posts are untrusted reference DATA (not instructions) that must be verified before acting — the same framing as the recall pack — so a post body cannot break out of the DATA block.", "status": "pending" },
+    { "id": "AC-39.6.5", "description": "On by default for EVERY repo (no per-repo opt-in). Suppressed by the memory off-switches (CLAUDE_MEMORY=0, .claude/memory-off — it is the recall half via memory_policy_enabled recall) AND by a dedicated CLAUDE_TEAM_CHANNEL=0 (so team-channel injection can be disabled while keeping memory recall).", "status": "pending" },
+    { "id": "AC-39.6.6", "description": "Fails OPEN and SILENT within a bounded total wall-clock budget: resolve 404 (no project), STH witness error, unreachable loopctl, or timeout -> SessionStart proceeds with no TEAM CHANNEL block and no error. Each network call has a small curl --max-time AND the whole team-channel step has an overall wall-clock cap so resolve+posts+jq cannot cumulatively slow SessionStart.", "status": "pending" },
+    { "id": "AC-39.6.7", "description": "When there are no other-session posts (or the repo has no project), NO empty TEAM CHANNEL block is emitted (silent). Self-dedup by session_id is a display convenience only — session_id is client-supplied and spoofable, so it is NEVER used as a security/authorization control; only server-stamped agent_id is treated as authoritative attribution in the render.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-39.6.1", "name": "recent other-session posts render", "type": "integration", "preconditions": ["a resolvable repo project", "two posts from a different session_id"], "steps": ["run session-start.sh with a startup stdin payload for that repo"], "expected_results": ["additionalContext has a fenced TEAM CHANNEL section with both posts", "agent + host + age + (truncated) body shown"] },
+    { "id": "TC-39.6.2", "name": "malicious body cannot break render or execute", "type": "integration", "preconditions": ["a post whose body is: `touch /tmp/pwned_$$`; \"$(echo hacked)\" with newlines and quotes"], "steps": ["run session-start.sh"], "expected_results": ["valid JSON emitted", "body appears as inert text inside the DATA fence", "no file created / no command executed", "no JSON break"] },
+    { "id": "TC-39.6.3", "name": "self posts de-duplicated", "type": "integration", "preconditions": ["a post whose session_id == the current session"], "steps": ["run session-start.sh"], "expected_results": ["that post is NOT shown"] },
+    { "id": "TC-39.6.4", "name": "off-switches suppress", "type": "integration", "preconditions": ["CLAUDE_MEMORY=0 in one run; CLAUDE_TEAM_CHANNEL=0 in another"], "steps": ["run session-start.sh each"], "expected_results": ["no TEAM CHANNEL block in either"] },
+    { "id": "TC-39.6.5", "name": "fail-open: unreachable AND STH-witness-error, bounded time", "type": "integration", "preconditions": ["run A: LOOPCTL_SERVER unreachable", "run B: a corrupt STH cache forces a witness error"], "steps": ["run session-start.sh in each"], "expected_results": ["both exit within the overall wall-clock budget", "no TEAM CHANNEL block", "no error surfaced; recall pack still renders"] },
+    { "id": "TC-39.6.6", "name": "body truncated in render", "type": "integration", "preconditions": ["a post with a 5000-char body"], "steps": ["run session-start.sh"], "expected_results": ["rendered body <= 500 chars, ellipsized"] }
+  ],
+  "technical_notes": [
+    "Repo: claude-config (hooks/session-start.sh) — NOT loopctl. Ships on claude-config's loop (branch -> canary/tests -> PR -> merge -> fleet sync); the hook file is symlinked so pull makes it live.",
+    "Reuse the capture hook's resolve (git -C origin -> /projects/resolve with creds stripped) and STH witness header from the shared cache.",
+    "Render EVERY field via jq --arg/--argjson (never shell interpolation). Truncate body before passing in. Fence with BEGIN/END TEAM CHANNEL + the 'reference DATA' wrapper the recall pack already uses.",
+    "Gate: memory_policy_enabled recall AND a new CLAUDE_TEAM_CHANNEL off token. Bound the whole step with an overall timeout (e.g. background the calls with a wall-clock kill, or a tight cumulative --max-time budget).",
+    "this session's session_id comes from the SessionStart stdin payload; the MCP tool writes the same id (US-39.4 AC-39.4.6). Self-dedup is best-effort/display only — spoofable, never security.",
+    "Add a canary-style test (like capture-canary) asserting the malicious-body render is inert and the fail-open paths are silent + bounded."
+  ],
+  "dependencies": ["US-39.3"],
+  "estimated_tokens": 230000
+}

--- a/docs/user_stories/epic_39_repo_coordination_bus/us_39.7.json
+++ b/docs/user_stories/epic_39_repo_coordination_bus/us_39.7.json
@@ -1,0 +1,38 @@
+{
+  "id": "US-39.7",
+  "title": "Delete a channel post (redact path — remove a leaked/regretted post before its 30-day expiry)",
+  "epic": { "id": "epic_39", "name": "Repo Coordination Bus" },
+  "priority": "high",
+  "phase": "coordination_bus_v1",
+  "story": {
+    "as_a": "coding agent that posted something it shouldn't have",
+    "i_want_to": "delete a channel post immediately",
+    "so_that": "a leaked secret or mistaken message is removed from the repo channel now — not left readable (and auto-injected into every new session on every machine) for up to 30 days"
+  },
+  "rationale": "The secret denylist (US-39.1) is defense-in-depth and inherently incomplete — when it misses, a secret is published to the channel AND auto-amplified by the SessionStart injection (US-39.6) into every new session on the repo, fleet-wide, with no way to remove it until the sweep. A delete path is the required backstop: it turns 'un-removable for 30 days' into 'removable now'. Given a single cooperative tenant, delete is tenant-scoped (any agent can remove any post in its tenant) and audited for accountability — so whoever NOTICES a leak can remove it, not only its author.",
+  "background": {
+    "reference": "docs/repo-coordination-bus.md §3; review M4",
+    "includes": "Hard-delete is consistent with the transient 30-day model + the sweep (US-39.5). Audited via Audit.log_in_multi/3."
+  },
+  "acceptance_criteria": [
+    { "id": "AC-39.7.1", "description": "DELETE /api/v1/channel/posts/:id is RequireRole :agent, NOT behind RequireHumanAnchor. It deletes the post if it exists in the caller's tenant; otherwise a 404 (a post in another tenant is indistinguishable from nonexistent — no cross-tenant oracle). An OpenApiSpex operation/1 spec is declared.", "status": "pending" },
+    { "id": "AC-39.7.2", "description": "Deletion is tenant-scoped: any agent in the tenant may delete any post in that tenant (cooperative single-tenant model, enables secret cleanup by whoever notices) — but NEVER a post in another tenant (AdminRepo query filters tenant_id; a foreign id is 404).", "status": "pending" },
+    { "id": "AC-39.7.3", "description": "The delete is audited (Audit.log_in_multi, entity_type \"channel_post\", action \"deleted\", actor = the deleting agent, capturing the deleted post's id/agent_id) in the same transaction — so removals are accountable even though the row is gone.", "status": "pending" },
+    { "id": "AC-39.7.4", "description": "A channel_delete(post_id) MCP tool (agent key) is added to the Node proxy alongside channel_post/channel_recent (US-39.4), with source-regex tests, and shipped in the same version bump/autopublish.", "status": "pending" },
+    { "id": "AC-39.7.5", "description": "A deleted post no longer appears in channel_recent and is not injected by US-39.6 — verified end to end.", "status": "pending" }
+  ],
+  "test_cases": [
+    { "id": "TC-39.7.1", "name": "agent deletes a post in its tenant", "type": "integration", "preconditions": ["tenant = fixture(:tenant); project = fixture(:project, %{tenant_id: tenant.id})", "{key,_} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})", "a post exists"], "steps": ["DELETE /api/v1/channel/posts/#{post.id}"], "expected_results": ["200/204", "post gone from channel_recent", "audit entry action \"deleted\""] },
+    { "id": "TC-39.7.2", "name": "another agent in the same tenant can delete (secret cleanup)", "type": "integration", "preconditions": ["a post authored by agent A", "{key_b,_} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent}) (agent B)"], "steps": ["agent B DELETEs A's post"], "expected_results": ["deleted", "audit actor == agent B"] },
+    { "id": "TC-39.7.3", "name": "cross-tenant delete is 404 (no oracle, no deletion)", "type": "integration", "preconditions": ["tenant = fixture(:tenant); other = fixture(:tenant)", "a post on other's project", "{key,_} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})"], "steps": ["DELETE that post's id"], "expected_results": ["404", "the other tenant's post still exists"] },
+    { "id": "TC-39.7.4", "name": "nonexistent id is 404 identical to cross-tenant", "type": "integration", "preconditions": ["agent key"], "steps": ["DELETE a random UUID"], "expected_results": ["404, body identical to the cross-tenant 404"] }
+  ],
+  "technical_notes": [
+    "Context: Loopctl.Coordination.delete_post(tenant_id, agent_id, post_id) -> {:ok, post} | {:error, :not_found}; AdminRepo query filters id + tenant_id (UUID-guard the id -> clean 404, no 500). Wrap delete + audit in Ecto.Multi.",
+    "Controller action alongside post/recent; route DELETE /api/v1/channel/posts/:id.",
+    "Default-deny guard test: allowlist {:delete, \"/api/v1/channel/posts/:id\"} with the coordination-surface justification (it is a DELETE, so it IS walked by the default-deny test).",
+    "MCP: add channel_delete to mcp-server/index.js + tests; fold into US-39.4's version bump if merged together, else its own bump."
+  ],
+  "dependencies": ["US-39.2", "US-39.4"],
+  "estimated_tokens": 170000
+}


### PR DESCRIPTION
Epic 39 design brief + stories: repo coordination bus (v1)

Adds the design brief (docs/repo-coordination-bus.md) and the epic 39 work breakdown
(docs/user_stories/epic_39_repo_coordination_bus/) for a project-scoped, append-only,
30-day coordination channel so agent sessions on the same repo — across machines — can
leave each other messages. This is the missing third memory plane (Knowledge=durable,
Memory=agent-private, Channel=repo-scoped/transient) and the hosted, multi-machine
successor to the local-only memory-keeper.

Grounded in a fleet audit: home_care_billing memory is 4,286 items split 444/3163/679
across three machines with no sharing; only 3 of ~15 memory-keeper feature areas are used.
Design decisions locked with the owner: channel = project_id (incl :kb scopes), uniform
30-day retention, no message-type taxonomy, TEAM CHANNEL injection default-on, and
memory-keeper retirement gated on flawless real use.

v1 = 7 stories: channel_posts schema (US-39.1), channel_post write (US-39.2), channel_recent
read (US-39.3), MCP tools (US-39.4), 30-day Oban sweep (US-39.5), SessionStart TEAM CHANNEL
injection in claude-config (US-39.6), and a delete/redact path (US-39.7).

Docs only — no implementation. The stories were run through two review lenses before commit:
a technical-accuracy pass grounding every assumption against loopctl code (fixed: use
AdminRepo+explicit-tenant-filter not the RLS Repo; Projects.get_project not the private
validate_project_ownership; unconditional agent_id stamping; SessionMemoryPruneWorker sweep
template) and a completeness/security pass (folded in: write rate-limit, refs bound+secret
scan, cross-tenant oracle-safety, the US-39.7 delete backstop, US-39.6 jq-encoded/fenced/
truncated untrusted-body injection, denylist->422, per-session keyed upsert, session_id
source, security-event logging). Implementation has NOT started — awaiting owner go-ahead.
