### PR TITLE
US-39.1: channel_posts schema + Coordination context (Epic 39 Repo Coordination Bus)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ mcp-server/node_modules/
 !.claude/commands/**
 !.claude/agents/
 !.claude/agents/**
+
+# Playwright MCP session output (transient)
+.playwright-mcp/

--- a/lib/loopctl/coordination.ex
+++ b/lib/loopctl/coordination.ex
@@ -1,0 +1,118 @@
+defmodule Loopctl.Coordination do
+  @moduledoc """
+  Context for the coordination bus — a project-scoped, append-only, short-lived
+  channel that lets agent sessions on the same repo (across machines) see each
+  other's working-state.
+
+  A **channel is a `project_id`**. A post is one attributed message with a
+  uniform 30-day TTL; there is no message-type taxonomy. Durable keepers
+  graduate to Knowledge — the rest expires.
+
+  ## Isolation
+
+  Like Knowledge and Projects, every query runs via `AdminRepo` (BYPASSRLS) with
+  an **explicit `tenant_id` filter** — RLS on `channel_posts` is defense-in-depth,
+  not the primary boundary. A query that omits the tenant filter is a bug.
+
+  This module (US-39.1) provides the schema-level primitives — programmatic
+  insert and a minimal tenant/project-scoped read. The write endpoint's ownership
+  check, audit, per-session upsert, and rate limiting (US-39.2) and the full
+  `channel_recent` read endpoint (US-39.3) build on these.
+  """
+
+  import Ecto.Query
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Coordination.ChannelPost
+  alias Loopctl.Projects
+
+  # Uniform retention for every post — one authoritative constant in code, not a
+  # DB default (owner decision; the fleet audit showed the category taxonomy and
+  # per-type retentions were unused).
+  @retention_days 30
+
+  @default_recent_limit 50
+  @max_recent_limit 200
+
+  @doc "The uniform retention window, in days, applied to every post."
+  @spec retention_days() :: pos_integer()
+  def retention_days, do: @retention_days
+
+  @doc """
+  Creates a channel post.
+
+  `tenant_id`, `project_id`, `agent_id`, and `expires_at` are set programmatically
+  on the struct (never from caller input); only `body` and the optional
+  `session_id`/`host`/`key`/`refs` are cast from `attrs`. `expires_at` is fixed at
+  `now + #{@retention_days} days`.
+
+  The `project_id` must belong to `tenant_id`; a mispaired call returns
+  `{:error, :not_found}` rather than inserting a cross-tenant-shaped row (the
+  primitive asserts its own ownership invariant — the write endpoint's fuller
+  ownership/audit path is US-39.2).
+
+  Returns `{:ok, %ChannelPost{}}`, `{:error, %Ecto.Changeset{}}` (size/shape
+  bound violation, a secret-denylist hit, or a session-key slot collision — the
+  caller learns the content did not land), or `{:error, :not_found}` when the
+  project does not belong to the tenant.
+  """
+  @spec create_post(Ecto.UUID.t(), Ecto.UUID.t(), Ecto.UUID.t(), map()) ::
+          {:ok, ChannelPost.t()} | {:error, Ecto.Changeset.t()} | {:error, :not_found}
+  def create_post(tenant_id, project_id, agent_id, attrs) do
+    with {:ok, _project} <- Projects.get_project(tenant_id, project_id) do
+      %ChannelPost{
+        tenant_id: tenant_id,
+        project_id: project_id,
+        agent_id: agent_id,
+        expires_at: default_expires_at()
+      }
+      |> ChannelPost.create_changeset(attrs)
+      |> AdminRepo.insert()
+    end
+  end
+
+  @doc """
+  Returns recent, non-expired posts for a tenant's project channel, newest first.
+
+  Isolation is the explicit `tenant_id` filter (AdminRepo path); expired posts
+  are filtered defensively even before the TTL sweep runs. A non-UUID
+  `tenant_id`/`project_id` (e.g. a malformed path segment once US-39.3 wires an
+  endpoint) yields `[]` rather than an `Ecto.Query.CastError` — mirroring the
+  `valid_uuid?` guard in `Projects.get_project`. `opts`:
+
+    * `:limit` — max rows (default #{@default_recent_limit}, capped at
+      #{@max_recent_limit}); `limit: 0` (or negative) returns `[]`.
+  """
+  @spec recent(term(), term(), keyword()) :: [ChannelPost.t()]
+  def recent(tenant_id, project_id, opts \\ []) do
+    if valid_uuid?(tenant_id) and valid_uuid?(project_id) do
+      limit = opts |> Keyword.get(:limit, @default_recent_limit) |> clamp_limit()
+      now = DateTime.utc_now()
+
+      ChannelPost
+      |> where([p], p.tenant_id == ^tenant_id and p.project_id == ^project_id)
+      |> where([p], p.expires_at > ^now)
+      |> order_by([p], desc: p.inserted_at, desc: p.id)
+      |> limit(^limit)
+      |> AdminRepo.all()
+    else
+      []
+    end
+  end
+
+  defp default_expires_at do
+    DateTime.add(DateTime.utc_now(), @retention_days * 24 * 60 * 60, :second)
+  end
+
+  defp clamp_limit(limit) when is_integer(limit) and limit > 0,
+    do: min(limit, @max_recent_limit)
+
+  # An explicit non-positive limit means "no rows" — honour it rather than
+  # silently coercing to the default (LIMIT 0 returns []).
+  defp clamp_limit(limit) when is_integer(limit) and limit <= 0, do: 0
+
+  defp clamp_limit(_), do: @default_recent_limit
+
+  defp valid_uuid?(value) when is_binary(value), do: match?({:ok, _}, Ecto.UUID.cast(value))
+  defp valid_uuid?(_), do: false
+end

--- a/lib/loopctl/coordination/channel_post.ex
+++ b/lib/loopctl/coordination/channel_post.ex
@@ -1,0 +1,286 @@
+defmodule Loopctl.Coordination.ChannelPost do
+  @moduledoc """
+  Schema for the `channel_posts` table — the coordination bus (the third memory
+  plane: Knowledge = durable, Memory = agent-private, Channel = repo-scoped and
+  transient).
+
+  A post is one attributed, short-lived message on a project's coordination
+  channel. A **channel is a `project_id`**; sessions on the same repo — across
+  machines — read the channel to see what other sessions found, did, or are
+  doing. Retention is a uniform 30 days (`expires_at`); there is deliberately
+  **no message-type taxonomy** (`:kind`/`:category`/`:type`) — the fleet audit
+  showed the category taxonomy was essentially unused. An optional `key` reserves
+  a per-session working-state slot: in US-39.1 a second write to the same
+  `(tenant, project, session, key)` is **rejected** by the partial unique index
+  (`{:error, changeset}`), not merged; the `on_conflict` upsert that lets a
+  session refresh its own slot lands in US-39.2.
+
+  ## Trust boundary
+
+  `tenant_id`, `project_id`, `agent_id`, and `expires_at` are set programmatically
+  on the struct in `Loopctl.Coordination` — NEVER via `cast/3`. `agent_id` is the
+  verified key identity (a caller can never post as another agent); `host` and
+  `session_id` are client-supplied, informational, and spoofable — never used for
+  authorization or as authoritative attribution.
+
+  ## Isolation
+
+  Runtime isolation is `AdminRepo` (BYPASSRLS) + an explicit `tenant_id` filter in
+  every `Loopctl.Coordination` query (the Knowledge/Projects pattern). RLS is
+  ENABLED on the table as defense-in-depth — a query missing the tenant filter is
+  a bug even though RLS would also stop it.
+  """
+
+  use Loopctl.Schema
+
+  require Logger
+
+  alias Loopctl.Security.SecretDenylist
+
+  @type t :: %__MODULE__{}
+
+  @body_max_length 16_384
+  @key_max_length 200
+  @session_id_max_length 200
+  @host_max_length 255
+  @ref_value_max_length 512
+  @refs_serialized_max_bytes 4_096
+  @allowed_ref_keys ~w(file pr branch commit)
+
+  # Text fields that must never carry a NUL byte (Postgres rejects them at insert
+  # time with a raw Postgrex.Error/500) nor a denylisted credential shape.
+  @scanned_text_fields [:body, :key, :session_id, :host]
+
+  @derive {Jason.Encoder,
+           only: [
+             :id,
+             :tenant_id,
+             :project_id,
+             :agent_id,
+             :session_id,
+             :host,
+             :key,
+             :body,
+             :refs,
+             :expires_at,
+             :inserted_at,
+             :updated_at
+           ]}
+
+  schema "channel_posts" do
+    tenant_field()
+    field :project_id, :binary_id
+    field :agent_id, :binary_id
+    field :session_id, :string
+    field :host, :string
+    field :key, :string
+    field :body, :string
+    field :refs, :map
+
+    field :expires_at, :utc_datetime_usec
+
+    timestamps()
+  end
+
+  @doc """
+  Changeset for creating a channel post.
+
+  Casts ONLY the caller-supplied fields `[:session_id, :host, :key, :body, :refs]`.
+  `tenant_id`, `project_id`, `agent_id`, and `expires_at` are set programmatically
+  on the struct by the context and are validated for presence here as a guard
+  against a context bug — they are never castable.
+
+  Enforces the size/shape bounds (`body` <= 16KB, `key` <= 200 bytes,
+  `session_id` <= 200 bytes, `host` <= 255 bytes, constrained `refs`), rejects
+  NUL bytes in every text field (Postgres cannot store them — the guard turns a
+  raw 500 into a 422), and runs the shared secret denylist over `body`, `key`,
+  `session_id`, `host`, and every `refs` value — a match rejects the write
+  (surfaced as a 422) rather than silently dropping the content or leaking a
+  credential onto the shared, cross-session-readable channel.
+
+  A blank (`""`/whitespace) `key` is normalised to `nil` so it means "no keyed
+  slot" rather than occupying the `(tenant, project, session, key)` slot with an
+  empty string. A keyed post is a per-session working-state slot, so `session_id`
+  is required whenever `key` is present — without it the partial unique index
+  (which treats a NULL `session_id` as distinct) can never dedupe the slot. The
+  DB constraints (the session-key partial unique index and the
+  tenant/project/agent foreign keys) are declared here so a collision or missing
+  parent surfaces as `{:error, changeset}` (422) rather than an unhandled
+  `Ecto.ConstraintError` (500).
+  """
+  @spec create_changeset(t(), map()) :: Ecto.Changeset.t()
+  def create_changeset(post, attrs) do
+    post
+    |> cast(attrs, [:session_id, :host, :key, :body, :refs])
+    |> normalize_blank([:key, :session_id, :host])
+    |> validate_required([:tenant_id, :project_id, :agent_id, :body, :expires_at])
+    |> validate_length(:body, max: @body_max_length, count: :bytes)
+    |> validate_length(:key, max: @key_max_length, count: :bytes)
+    |> validate_length(:session_id, max: @session_id_max_length, count: :bytes)
+    |> validate_length(:host, max: @host_max_length, count: :bytes)
+    |> validate_no_null_bytes()
+    |> maybe_require_session_for_key()
+    |> validate_refs()
+    |> validate_no_secrets()
+    |> foreign_key_constraint(:tenant_id)
+    |> foreign_key_constraint(:project_id)
+    |> foreign_key_constraint(:agent_id)
+    |> unique_constraint(:key,
+      name: :channel_posts_session_key_uidx,
+      message: "has already been used by this session (working-state slot)"
+    )
+  end
+
+  @doc "Maximum allowed `body` length in bytes."
+  @spec body_max_length() :: pos_integer()
+  def body_max_length, do: @body_max_length
+
+  @doc "Allowed keys for the `refs` map."
+  @spec allowed_ref_keys() :: [String.t()]
+  def allowed_ref_keys, do: @allowed_ref_keys
+
+  # JSON clients routinely send `""` for an absent field, and in Elixir `""` is
+  # truthy — so a blank `key` would force `session_id` to be required AND occupy a
+  # real `(tenant, project, session, key)` slot (the partial index keys on
+  # `key IS NOT NULL`), colliding on the next blank-key post. Normalise blank text
+  # to `nil` so `""` means "no value", not a real slot / spoofable field.
+  defp normalize_blank(changeset, fields) do
+    Enum.reduce(fields, changeset, &blank_change_to_nil/2)
+  end
+
+  defp blank_change_to_nil(field, changeset) do
+    case get_change(changeset, field) do
+      value when is_binary(value) and value != "" ->
+        if String.trim(value) == "", do: put_change(changeset, field, nil), else: changeset
+
+      "" ->
+        put_change(changeset, field, nil)
+
+      _ ->
+        changeset
+    end
+  end
+
+  # Postgres `text`/`varchar` columns cannot store a NUL byte and raise a raw
+  # Postgrex.Error (500) at insert time. JSON permits a NUL byte and Elixir strings
+  # accept it, so reject it in the changeset — the caller learns it did not land
+  # as a 422, honouring the create_post error contract.
+  defp validate_no_null_bytes(changeset) do
+    Enum.reduce(@scanned_text_fields, changeset, &reject_null_bytes/2)
+  end
+
+  defp reject_null_bytes(field, changeset) do
+    value = get_field(changeset, field)
+
+    if is_binary(value) and String.contains?(value, <<0>>) do
+      add_error(changeset, field, "must not contain NUL bytes")
+    else
+      changeset
+    end
+  end
+
+  # A keyed post occupies a per-(tenant, project, session) working-state slot. The
+  # partial unique index includes session_id, and Postgres treats a NULL session_id
+  # as distinct — so without a session_id a keyed post can never upsert/dedupe and
+  # would accumulate unbounded duplicate rows. Require session_id whenever key is set.
+  defp maybe_require_session_for_key(changeset) do
+    if get_field(changeset, :key) do
+      validate_required(changeset, :session_id)
+    else
+      changeset
+    end
+  end
+
+  defp validate_refs(changeset) do
+    validate_change(changeset, :refs, fn :refs, refs ->
+      cond do
+        not (is_map(refs) and not is_struct(refs)) ->
+          [refs: "must be a map"]
+
+        not (Map.keys(refs) |> Enum.map(&to_string/1) |> Enum.all?(&(&1 in @allowed_ref_keys))) ->
+          [refs: "may only contain keys #{Enum.join(@allowed_ref_keys, ", ")}"]
+
+        not Enum.all?(Map.values(refs), &valid_ref_value?/1) ->
+          [refs: "values must be strings of at most #{@ref_value_max_length} characters"]
+
+        Enum.any?(Map.values(refs), &(is_binary(&1) and String.contains?(&1, <<0>>))) ->
+          # jsonb cannot store a NUL ( ) in a string value — Postgres raises a
+          # raw Postgrex.Error (500) at insert. Reject it as a 422 here, matching the
+          # text-field NUL guard, so no field is a 500 vector.
+          [refs: "must not contain NUL bytes"]
+
+        refs_serialized_size(refs) > @refs_serialized_max_bytes ->
+          [refs: "serialized size exceeds #{@refs_serialized_max_bytes} bytes"]
+
+        true ->
+          []
+      end
+    end)
+  end
+
+  defp valid_ref_value?(value) when is_binary(value),
+    do: String.length(value) <= @ref_value_max_length
+
+  defp valid_ref_value?(_), do: false
+
+  defp refs_serialized_size(refs) do
+    case Jason.encode(refs) do
+      {:ok, json} -> byte_size(json)
+      # Unencodable refs are already rejected by the key/value checks above; treat
+      # an encode failure as over-limit so it can never slip through.
+      {:error, _} -> @refs_serialized_max_bytes + 1
+    end
+  end
+
+  # Scan every persisted, JSON-served field for a credential shape. `session_id`
+  # and `host` are client-supplied and echoed to every peer session reading the
+  # channel, so they must be scanned too — a Bearer/`sk-`/`lc_` token stuffed into
+  # them would otherwise exfiltrate onto the shared bus with no rejection.
+  #
+  # Errors are ACCUMULATED (not short-circuited) so a caller learns about every
+  # offending field in one round trip. A hit emits telemetry + a structured log
+  # (no secret value) so an operator can see repeated credential-leak attempts.
+  defp validate_no_secrets(changeset) do
+    changeset
+    |> add_secret_errors(@scanned_text_fields, &get_field(changeset, &1))
+    |> add_secret_errors([:refs], fn :refs ->
+      changeset |> get_field(:refs) |> Kernel.||(%{}) |> Map.values()
+    end)
+  end
+
+  defp add_secret_errors(changeset, fields, extractor) do
+    Enum.reduce(fields, changeset, fn field, acc ->
+      value = extractor.(field)
+
+      has_secret? =
+        if is_list(value),
+          do: SecretDenylist.any_contains_secret?(value),
+          else: SecretDenylist.contains_secret?(value)
+
+      if has_secret? do
+        emit_secret_blocked(acc, field)
+        add_error(acc, field, "must not contain a secret or credential")
+      else
+        acc
+      end
+    end)
+  end
+
+  defp emit_secret_blocked(changeset, field) do
+    metadata = %{
+      tenant_id: get_field(changeset, :tenant_id),
+      project_id: get_field(changeset, :project_id),
+      agent_id: get_field(changeset, :agent_id),
+      field: field
+    }
+
+    :telemetry.execute([:loopctl, :coordination, :secret_blocked], %{count: 1}, metadata)
+
+    Logger.warning(
+      "coordination denylist hit: blocked #{field} carrying a credential shape " <>
+        "(tenant=#{metadata.tenant_id} project=#{metadata.project_id} agent=#{metadata.agent_id})"
+    )
+
+    :ok
+  end
+end

--- a/lib/loopctl/security/secret_denylist.ex
+++ b/lib/loopctl/security/secret_denylist.ex
@@ -1,0 +1,71 @@
+defmodule Loopctl.Security.SecretDenylist do
+  @moduledoc """
+  Shared secret-pattern denylist.
+
+  The canonical credential-shape set lives in the bash knowledge-capture
+  summarizer at `claude-config/hooks/knowledge-capture.sh` (the "knowledge
+  extractor"); this module re-implements those credential patterns in Elixir so
+  the same shapes are blocked on the coordination plane. A hit means the scanned
+  text almost certainly carries a credential and must NOT be persisted. Used by
+  the coordination bus (`Loopctl.Coordination.ChannelPost`) to scan `body`,
+  `key`, `session_id`, `host`, and every `refs` value before a post lands — a
+  match is an explicit rejection (surfaced as a 422), never a silent drop.
+
+  The two lists live in separate repos with no shared compile-time source, so
+  parity is a CONVENTION, not a guarantee: when you add a credential shape to one,
+  add it to the other. (The bash script additionally scans for destructive shell
+  commands — that is deletion-guard scope, not credential-denylist scope, and is
+  intentionally absent here.) It targets high-confidence credential shapes (long,
+  prefixed tokens / key material), not general "looks secret-ish" heuristics, to
+  keep false positives near zero on ordinary coordination chatter.
+  """
+
+  # High-confidence credential patterns. Keep in sync (by convention) with the
+  # credential shapes in claude-config/hooks/knowledge-capture.sh.
+  @patterns [
+    # Bearer <token>
+    ~r/Bearer\s+[A-Za-z0-9_\-]{20,}/i,
+    # OpenAI / Anthropic style sk- keys
+    ~r/\bsk-[A-Za-z0-9_\-]{20,}/i,
+    # Stripe secret keys (sk_live_ / sk_test_) and restricted keys (rk_live_/rk_test_)
+    ~r/\b[rs]k_(live|test)_[A-Za-z0-9]{20,}/,
+    # loopctl agent/orchestrator keys
+    ~r/\blc_[A-Za-z0-9_\-]{20,}/,
+    # GitHub personal-access / OAuth / server / refresh tokens
+    ~r/\b(ghp|gho|ghu|ghs|ghr|github_pat)_[A-Za-z0-9_]{20,}/i,
+    # AWS access key id
+    ~r/\bAKIA[0-9A-Z]{16}\b/,
+    # PEM private key blocks
+    ~r/-----BEGIN [A-Z ]*PRIVATE KEY-----/,
+    # Slack tokens (bot/user/app/refresh/legacy)
+    ~r/\bxox[baprs]-[A-Za-z0-9\-]{10,}/i,
+    # JWTs (header.payload.signature, all base64url) — often bearer credentials
+    ~r/\beyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}/,
+    # URL-embedded credentials, e.g. postgres://user:s3cret@host, https://u:p@host
+    ~r/\b[a-z][a-z0-9+.\-]*:\/\/[^\s:\/@]+:[^\s:\/@]+@/i
+  ]
+
+  @doc """
+  Returns `true` when `value` matches any denylisted secret pattern.
+
+  Non-binary input (including `nil`) is treated as "no secret" so callers can
+  scan optional fields without pre-filtering.
+  """
+  @spec contains_secret?(term()) :: boolean()
+  def contains_secret?(value) when is_binary(value) do
+    Enum.any?(@patterns, &Regex.match?(&1, value))
+  end
+
+  def contains_secret?(_), do: false
+
+  @doc """
+  Returns `true` when ANY string in `values` matches a denylisted pattern.
+
+  Non-binary members are ignored. Useful for scanning a heterogeneous set such
+  as `[body, key | Map.values(refs)]` in one call.
+  """
+  @spec any_contains_secret?(Enumerable.t()) :: boolean()
+  def any_contains_secret?(values) do
+    Enum.any?(values, &contains_secret?/1)
+  end
+end

--- a/priv/repo/migrations/20260717020000_create_channel_posts.exs
+++ b/priv/repo/migrations/20260717020000_create_channel_posts.exs
@@ -1,0 +1,56 @@
+defmodule Loopctl.Repo.Migrations.CreateChannelPosts do
+  use Ecto.Migration
+  import Loopctl.Repo.RlsHelpers
+
+  def change do
+    create table(:channel_posts, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      add :tenant_id, references(:tenants, type: :binary_id, on_delete: :delete_all), null: false
+
+      add :project_id, references(:projects, type: :binary_id, on_delete: :delete_all),
+        null: false
+
+      # Server-stamped from the verified key identity — a post always has an author.
+      # FK to agents so attribution can never dangle (matches token_usage_reports).
+      add :agent_id, references(:agents, type: :binary_id, on_delete: :delete_all), null: false
+
+      # Client-supplied, informational, spoofable — never used for authorization.
+      # Length-bounded in the changeset (see ChannelPost.create_changeset).
+      add :session_id, :text, null: true
+      add :host, :text, null: true
+
+      # Optional per-session working-state slot key. No message-type taxonomy.
+      # Insert-with-unique-reject in US-39.1; on_conflict upsert lands in US-39.2.
+      add :key, :text, null: true
+
+      add :body, :text, null: false
+      add :refs, :map, null: true
+
+      # Uniform 30-day retention; set server-side in Loopctl.Coordination.
+      add :expires_at, :utc_datetime_usec, null: false
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    # Recent-reads path: WHERE tenant_id = ? AND project_id = ? ORDER BY inserted_at DESC.
+    create index(:channel_posts, [:tenant_id, :project_id, "inserted_at DESC"],
+             name: :channel_posts_recent_idx
+           )
+
+    # TTL sweep path (US-39.5): delete WHERE expires_at <= now().
+    create index(:channel_posts, [:expires_at])
+
+    # Per-SESSION keyed upsert slot: two concurrent sessions writing key "session_goal"
+    # do not clobber each other (session_id participates in the uniqueness). Partial —
+    # only keyed posts are constrained; keyless posts are append-only.
+    create unique_index(:channel_posts, [:tenant_id, :project_id, :session_id, :key],
+             where: "key IS NOT NULL",
+             name: :channel_posts_session_key_uidx
+           )
+
+    # Defense-in-depth: production isolation is AdminRepo + explicit tenant_id filter;
+    # RLS is the second layer (ENABLE, not FORCE — same as every other tenant table).
+    enable_rls(:channel_posts)
+  end
+end

--- a/test/loopctl/coordination/channel_post_test.exs
+++ b/test/loopctl/coordination/channel_post_test.exs
@@ -1,0 +1,238 @@
+defmodule Loopctl.Coordination.ChannelPostTest do
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.Coordination.ChannelPost
+
+  # A minimally-valid programmatic struct; create_changeset casts only the
+  # caller fields on top of it.
+  defp base_struct do
+    %ChannelPost{
+      tenant_id: Ecto.UUID.generate(),
+      project_id: Ecto.UUID.generate(),
+      agent_id: Ecto.UUID.generate(),
+      expires_at: DateTime.utc_now()
+    }
+  end
+
+  describe "create_changeset/2 validations" do
+    test "valid with just a body" do
+      cs = ChannelPost.create_changeset(base_struct(), %{"body" => "hello"})
+      assert cs.valid?
+    end
+
+    test "requires body" do
+      cs = ChannelPost.create_changeset(base_struct(), %{})
+      refute cs.valid?
+      assert %{body: _} = errors_on(cs)
+    end
+
+    test "rejects body over 16KB" do
+      big = String.duplicate("x", 16_385)
+      cs = ChannelPost.create_changeset(base_struct(), %{"body" => big})
+      refute cs.valid?
+      assert %{body: _} = errors_on(cs)
+    end
+
+    test "rejects key over 200 chars" do
+      cs =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "ok",
+          "key" => String.duplicate("k", 201)
+        })
+
+      refute cs.valid?
+      assert %{key: _} = errors_on(cs)
+    end
+
+    test "rejects a keyed post without a session_id (per-session slot needs a session)" do
+      cs = ChannelPost.create_changeset(base_struct(), %{"body" => "ok", "key" => "session_goal"})
+      refute cs.valid?
+      assert %{session_id: _} = errors_on(cs)
+    end
+
+    test "accepts a keyed post that carries a session_id" do
+      cs =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "ok",
+          "key" => "session_goal",
+          "session_id" => "S1"
+        })
+
+      assert cs.valid?
+    end
+
+    test "body cap is byte-based, not grapheme-based" do
+      # 8_193 multibyte (2-byte) chars = 16_386 bytes > 16_384, but only 8_193
+      # graphemes — a grapheme-based cap would wrongly accept it.
+      big = String.duplicate("é", 8_193)
+      assert byte_size(big) > 16_384
+      assert String.length(big) < 16_384
+      cs = ChannelPost.create_changeset(base_struct(), %{"body" => big})
+      refute cs.valid?
+      assert %{body: _} = errors_on(cs)
+    end
+
+    test "rejects refs with a key outside the allowlist" do
+      cs =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "ok",
+          "refs" => %{"evil" => "value"}
+        })
+
+      refute cs.valid?
+      assert %{refs: _} = errors_on(cs)
+    end
+
+    test "rejects an over-large refs value" do
+      cs =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "ok",
+          "refs" => %{"branch" => String.duplicate("x", 9_000)}
+        })
+
+      refute cs.valid?
+      assert %{refs: _} = errors_on(cs)
+    end
+
+    test "no kind/category/type field exists on the schema" do
+      fields = ChannelPost.__schema__(:fields)
+      refute :kind in fields
+      refute :category in fields
+      refute :type in fields
+    end
+
+    test "rejects an over-long session_id (bounds the keyed-slot btree index row)" do
+      cs =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "ok",
+          "session_id" => String.duplicate("s", 201)
+        })
+
+      refute cs.valid?
+      assert %{session_id: _} = errors_on(cs)
+    end
+
+    test "rejects an over-long host" do
+      cs =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "ok",
+          "host" => String.duplicate("h", 256)
+        })
+
+      refute cs.valid?
+      assert %{host: _} = errors_on(cs)
+    end
+
+    test "a blank key is normalised to nil (no keyed slot, no forced session_id)" do
+      cs = ChannelPost.create_changeset(base_struct(), %{"body" => "ok", "key" => ""})
+      assert cs.valid?
+      assert is_nil(Ecto.Changeset.get_field(cs, :key))
+      # blank key must NOT force session_id to be required
+      refute Map.has_key?(errors_on(cs), :session_id)
+    end
+
+    test "a whitespace-only key is normalised to nil" do
+      cs = ChannelPost.create_changeset(base_struct(), %{"body" => "ok", "key" => "   "})
+      assert cs.valid?
+      assert is_nil(Ecto.Changeset.get_field(cs, :key))
+    end
+
+    test "rejects a NUL byte in the body (would 500 at insert otherwise)" do
+      cs = ChannelPost.create_changeset(base_struct(), %{"body" => "before" <> <<0>> <> "after"})
+      refute cs.valid?
+      assert %{body: _} = errors_on(cs)
+    end
+
+    test "rejects a NUL byte in a refs value (jsonb would 500 otherwise)" do
+      cs =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "ok",
+          "refs" => %{"branch" => "main" <> <<0>> <> "x"}
+        })
+
+      refute cs.valid?
+      assert %{refs: _} = errors_on(cs)
+    end
+
+    test "rejects a NUL byte in session_id" do
+      cs =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "ok",
+          "session_id" => "S" <> <<0>> <> "1"
+        })
+
+      refute cs.valid?
+      assert %{session_id: _} = errors_on(cs)
+    end
+  end
+
+  describe "secret denylist" do
+    test "rejects a secret in the body (422 path)" do
+      cs =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "here is my key sk-" <> String.duplicate("a", 30)
+        })
+
+      refute cs.valid?
+      assert %{body: _} = errors_on(cs)
+    end
+
+    test "rejects a secret in a refs value" do
+      cs =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "ok",
+          "refs" => %{"branch" => "lc_" <> String.duplicate("a", 30)}
+        })
+
+      refute cs.valid?
+      assert %{refs: _} = errors_on(cs)
+    end
+
+    test "rejects a secret in the key" do
+      cs =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "ok",
+          "key" => "ghp_" <> String.duplicate("a", 30)
+        })
+
+      refute cs.valid?
+      assert %{key: _} = errors_on(cs)
+    end
+
+    test "rejects a secret in session_id (persisted + echoed to peer sessions)" do
+      cs =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "ok",
+          "session_id" => "sk-" <> String.duplicate("a", 30)
+        })
+
+      refute cs.valid?
+      assert %{session_id: _} = errors_on(cs)
+    end
+
+    test "rejects a secret in host" do
+      cs =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "ok",
+          "host" => "Bearer " <> String.duplicate("a", 30)
+        })
+
+      refute cs.valid?
+      assert %{host: _} = errors_on(cs)
+    end
+
+    test "accumulates errors across every offending field in one pass" do
+      cs =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "sk-" <> String.duplicate("a", 30),
+          "session_id" => "S1",
+          "key" => "lc_" <> String.duplicate("a", 30)
+        })
+
+      refute cs.valid?
+      errors = errors_on(cs)
+      assert %{body: _} = errors
+      assert %{key: _} = errors
+    end
+  end
+end

--- a/test/loopctl/coordination_test.exs
+++ b/test/loopctl/coordination_test.exs
@@ -1,0 +1,169 @@
+defmodule Loopctl.CoordinationTest do
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.Coordination
+  alias Loopctl.Coordination.ChannelPost
+  alias Loopctl.Repo
+
+  describe "create_post/4" do
+    test "inserts with programmatic tenant/project/agent/expires and cast body" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      agent_id = fixture(:agent, %{tenant_id: tenant.id}).id
+
+      assert {:ok, post} =
+               Coordination.create_post(tenant.id, project.id, agent_id, %{
+                 "body" => "pushed PR #107, CI green"
+               })
+
+      assert post.tenant_id == tenant.id
+      assert post.project_id == project.id
+      assert post.agent_id == agent_id
+      assert post.body == "pushed PR #107, CI green"
+      assert is_nil(post.key)
+      assert is_nil(post.refs)
+
+      # expires_at is ~30 days out (server-set, uniform retention).
+      expected = DateTime.add(DateTime.utc_now(), Coordination.retention_days() * 86_400, :second)
+      assert_in_delta DateTime.to_unix(post.expires_at), DateTime.to_unix(expected), 120
+    end
+
+    test "a mispaired project (belongs to another tenant) returns {:error, :not_found}" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      project_b = fixture(:project, %{tenant_id: tenant_b.id})
+
+      assert {:error, :not_found} =
+               Coordination.create_post(tenant_a.id, project_b.id, Ecto.UUID.generate(), %{
+                 "body" => "cross-tenant attempt"
+               })
+    end
+
+    test "a duplicate same-session keyed post returns {:error, changeset}, not a raise" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      agent_id = fixture(:agent, %{tenant_id: tenant.id}).id
+      attrs = %{"body" => "goal", "session_id" => "S1", "key" => "session_goal"}
+
+      assert {:ok, _post} = Coordination.create_post(tenant.id, project.id, agent_id, attrs)
+
+      assert {:error, %Ecto.Changeset{} = cs} =
+               Coordination.create_post(tenant.id, project.id, agent_id, attrs)
+
+      assert %{key: _} = errors_on(cs)
+    end
+
+    test "accepts valid refs restricted to the allowlist" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      agent_id = fixture(:agent, %{tenant_id: tenant.id}).id
+
+      assert {:ok, post} =
+               Coordination.create_post(tenant.id, project.id, agent_id, %{
+                 "body" => "see the fix",
+                 "refs" => %{"pr" => "107", "branch" => "epic-39-us-39.1"}
+               })
+
+      assert post.refs == %{"pr" => "107", "branch" => "epic-39-us-39.1"}
+    end
+  end
+
+  describe "tenant isolation (both paths)" do
+    test "recent/3 (AdminRepo + explicit filter) and RLS Repo both hide another tenant's posts" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      project_a = fixture(:project, %{tenant_id: tenant_a.id})
+      agent_a = fixture(:agent, %{tenant_id: tenant_a.id}).id
+
+      {:ok, _post} =
+        Coordination.create_post(tenant_a.id, project_a.id, agent_a, %{
+          "body" => "tenant A only"
+        })
+
+      # AdminRepo path: tenant_b's explicit filter yields zero rows for A's project.
+      assert Coordination.recent(tenant_b.id, project_a.id) == []
+      # And tenant_a sees its own post.
+      assert [%ChannelPost{body: "tenant A only"}] =
+               Coordination.recent(tenant_a.id, project_a.id)
+
+      # RLS Repo path (belt-and-suspenders): scoped to tenant_b, the row is invisible.
+      {:ok, rows} =
+        Repo.with_tenant(tenant_b.id, fn ->
+          Repo.all(from(p in ChannelPost, where: p.project_id == ^project_a.id))
+        end)
+
+      assert rows == []
+    end
+  end
+
+  describe "recent/3 limit and guard behavior" do
+    test "limit: 0 returns an empty list (honours the explicit request)" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      agent_id = fixture(:agent, %{tenant_id: tenant.id}).id
+
+      {:ok, _} =
+        Coordination.create_post(tenant.id, project.id, agent_id, %{"body" => "hi"})
+
+      assert Coordination.recent(tenant.id, project.id, limit: 0) == []
+    end
+
+    test "a malformed (non-UUID) project_id yields [] rather than a CastError" do
+      tenant = fixture(:tenant)
+      assert Coordination.recent(tenant.id, "not-a-uuid") == []
+    end
+
+    test "a malformed (non-UUID) tenant_id yields []" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      assert Coordination.recent("not-a-uuid", project.id) == []
+    end
+
+    test "a blank key posts as a keyless append-only post (no slot collision)" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      agent_id = fixture(:agent, %{tenant_id: tenant.id}).id
+
+      assert {:ok, p1} =
+               Coordination.create_post(tenant.id, project.id, agent_id, %{
+                 "body" => "one",
+                 "key" => ""
+               })
+
+      assert is_nil(p1.key)
+
+      # A second blank-key post in the same session must NOT collide.
+      assert {:ok, _p2} =
+               Coordination.create_post(tenant.id, project.id, agent_id, %{
+                 "body" => "two",
+                 "key" => ""
+               })
+    end
+  end
+
+  describe "per-session keyed slot" do
+    test "two sessions with the same key do not clobber each other" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      agent_id = fixture(:agent, %{tenant_id: tenant.id}).id
+
+      assert {:ok, post_a} =
+               Coordination.create_post(tenant.id, project.id, agent_id, %{
+                 "body" => "goal A",
+                 "session_id" => "S1",
+                 "key" => "session_goal"
+               })
+
+      assert {:ok, post_b} =
+               Coordination.create_post(tenant.id, project.id, agent_id, %{
+                 "body" => "goal B",
+                 "session_id" => "S2",
+                 "key" => "session_goal"
+               })
+
+      assert post_a.id != post_b.id
+      posts = Coordination.recent(tenant.id, project.id)
+      assert length(posts) == 2
+    end
+  end
+end

--- a/test/loopctl/security/secret_denylist_test.exs
+++ b/test/loopctl/security/secret_denylist_test.exs
@@ -1,0 +1,68 @@
+defmodule Loopctl.Security.SecretDenylistTest do
+  use ExUnit.Case, async: true
+
+  alias Loopctl.Security.SecretDenylist
+
+  describe "contains_secret?/1" do
+    test "flags each denylisted credential shape" do
+      secrets = [
+        "Authorization: Bearer " <> String.duplicate("a", 30),
+        "sk-" <> String.duplicate("a", 30),
+        "lc_" <> String.duplicate("a", 30),
+        "ghp_" <> String.duplicate("a", 30),
+        "github_pat_" <> String.duplicate("a", 30),
+        "AKIA" <> String.duplicate("A", 16),
+        "-----BEGIN RSA PRIVATE KEY-----",
+        "xoxb-" <> String.duplicate("a", 20),
+        # Stripe secret / restricted keys (underscore prefix, not sk-)
+        "sk_live_" <> String.duplicate("a", 24),
+        "sk_test_" <> String.duplicate("a", 24),
+        "rk_live_" <> String.duplicate("a", 24),
+        # JWT (header.payload.signature). Assembled at runtime, NOT written as a
+        # contiguous literal, so no scannable secret-shaped string lands in
+        # source — this is what keeps GitGuardian (which scans source literals)
+        # from flagging these intentional denylist fixtures. Do NOT "simplify"
+        # these back into full string literals; that re-breaks the secret scan.
+        "eyJ" <>
+          String.duplicate("a", 20) <>
+          "." <> String.duplicate("b", 20) <> "." <> String.duplicate("c", 20),
+        # URL-embedded credentials. Same runtime-assembly rule as the JWT above:
+        # never let a contiguous scheme://user:pass@ literal land in source, or
+        # GitGuardian flags these intentional fixtures as real credentials.
+        "DATABASE_URL=postgres://user:" <> String.duplicate("z", 8) <> "@db.internal:5432/app",
+        "clone https://mark:" <> String.duplicate("z", 12) <> "@github.com/acme/repo"
+      ]
+
+      for s <- secrets do
+        assert SecretDenylist.contains_secret?(s), "expected a secret match in: #{s}"
+      end
+    end
+
+    test "does not flag ordinary coordination chatter" do
+      clean = [
+        "pushed PR #107, CI green",
+        "reviewing epic 39 on branch epic-39-us-39.1",
+        "found a race in the sweep worker",
+        "sk-too-short",
+        nil,
+        %{"not" => "a string"}
+      ]
+
+      for c <- clean do
+        refute SecretDenylist.contains_secret?(c), "unexpected secret match in: #{inspect(c)}"
+      end
+    end
+  end
+
+  describe "any_contains_secret?/1" do
+    test "true when any member matches, ignoring non-binaries" do
+      assert SecretDenylist.any_contains_secret?([
+               nil,
+               "clean",
+               "sk-" <> String.duplicate("a", 30)
+             ])
+
+      refute SecretDenylist.any_contains_secret?([nil, "clean", 42, %{}])
+    end
+  end
+end


### PR DESCRIPTION
## US-39.1: channel_posts schema + Coordination context (Epic 39 Repo Coordination Bus)

Supersedes #424, which is being closed. Same reviewed code, recreated as one
clean commit off master so the secret-scan gate stays green (see below).

### What this adds
- `channel_posts` table + migration with hardened changeset constraints (bounded
  lengths, FK to projects, deterministic read ordering), tenant-scoped under RLS.
- `Loopctl.Coordination` context — agents post short coordination messages to a
  per-repo channel and read recent posts.
- `Loopctl.Security.SecretDenylist` — scans `body`, `key`, `session_id`, `host`
  and every `refs` value before a post lands. A match is an explicit `422`
  rejection, never a silent drop. Rejects NUL bytes in `refs` values (jsonb 500
  vector).

### Why a new PR instead of #424
#424 accumulated the same fix across several review-fix commits. Two denylist
test fixtures (a JWT and a `scheme://user:pass@host` URL) were introduced as
contiguous credential-shaped string literals in an intermediate commit, which
the GitGuardian App flags as real secrets. GitGuardian scans the PR's entire
commit history, so de-fanging the tip could not clear the finding while the
literals lived in an earlier commit. Recreating clean off master collapses the
history to one commit whose diff contains no scannable credential literal.

All denylist fixtures are now assembled at runtime
(`prefix <> String.duplicate(...)`) so no contiguous credential-shaped literal
lands in source, while still matching the denylist regexes at runtime.

### Verification
- `mix format --check-formatted` clean
- `mix compile --warnings-as-errors` clean
- 36 tests pass (denylist + coordination + channel_post)
