### PR TITLE
feat(observability): ingestion capture-silence monitor (dead-man's switch)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -152,17 +152,24 @@ config :loopctl,
   scale_alert_provider_error_rate_per_min: 10
 
 # Ingestion capture-silence monitor (dead-man's-switch for knowledge capture).
-# Config-based DI for `Loopctl.Knowledge.IngestionHealth` — all three tunables have
+# Config-based DI for `Loopctl.Knowledge.IngestionHealth` — all tunables have
 # in-code defaults in that module, so this block is an override point, not a boot
-# dependency. `:monitored_source_types` are article `source_type`s watched for
-# silence; `:established_threshold` is the minimum article count before a source_type
-# is considered "established" (and thus eligible to be flagged when it goes silent);
-# `:staleness_threshold_hours` is how long an established source_type may go without a
-# new article before `IngestionHealthWorker` flags a `:capture_silence` anomaly.
+# dependency. `:monitored_source_types` are the article `source_type`s watched for
+# silence; `:all` (the default) monitors EVERY source_type that crosses the
+# established threshold — a silent-capture outage affects any source_type
+# (knowledge_create 409 drops hit web_article/newsletter/session_log alike), so the
+# monitor defaults to broad coverage rather than session_log-only. A list narrows it.
+# `:established_threshold` is the minimum article count (within the establishment
+# window) before a source_type is considered "established" (and thus eligible to be
+# flagged when it goes silent); `:staleness_threshold_hours` is how long an
+# established source_type may go without a new article before `IngestionHealthWorker`
+# flags a `:capture_silence` anomaly; `:establishment_window_hours` scopes
+# establishment to RECENT activity so a wound-down source_type is not flagged forever.
 config :loopctl, :ingestion_health,
-  monitored_source_types: ["session_log"],
+  monitored_source_types: :all,
   established_threshold: 5,
-  staleness_threshold_hours: 72
+  staleness_threshold_hours: 72,
+  establishment_window_hours: 720
 
 # US-33.3: bounded TTL (ms) for the ETS read-through api-key cache. This is the
 # defense-in-depth backstop, NOT the primary invalidation — every revoke/rotate/

--- a/config/config.exs
+++ b/config/config.exs
@@ -151,6 +151,19 @@ config :loopctl,
   scale_alert_oban_discard_rate_per_min: 10,
   scale_alert_provider_error_rate_per_min: 10
 
+# Ingestion capture-silence monitor (dead-man's-switch for knowledge capture).
+# Config-based DI for `Loopctl.Knowledge.IngestionHealth` — all three tunables have
+# in-code defaults in that module, so this block is an override point, not a boot
+# dependency. `:monitored_source_types` are article `source_type`s watched for
+# silence; `:established_threshold` is the minimum article count before a source_type
+# is considered "established" (and thus eligible to be flagged when it goes silent);
+# `:staleness_threshold_hours` is how long an established source_type may go without a
+# new article before `IngestionHealthWorker` flags a `:capture_silence` anomaly.
+config :loopctl, :ingestion_health,
+  monitored_source_types: ["session_log"],
+  established_threshold: 5,
+  staleness_threshold_hours: 72
+
 # US-33.3: bounded TTL (ms) for the ETS read-through api-key cache. This is the
 # defense-in-depth backstop, NOT the primary invalidation — every revoke/rotate/
 # mutate writer busts the key_hash entry in-band. A cached entry is re-validated

--- a/config/test.exs
+++ b/config/test.exs
@@ -200,6 +200,15 @@ config :loopctl, LoopctlWeb.Endpoint,
 # Print only warnings and errors during test
 config :logger, level: :warning
 
+# Narrow capture-silence monitoring to `session_log` in tests so specs can assert
+# that OTHER source_types are not flagged (the prod default is `:all`). The `:all`
+# behavior is covered by passing explicit config to `IngestionHealth.detect/1`.
+config :loopctl, :ingestion_health,
+  monitored_source_types: ["session_log"],
+  established_threshold: 5,
+  staleness_threshold_hours: 72,
+  establishment_window_hours: 720
+
 # Use simple formatter in test (override JSON default from config.exs).
 # The template prints only level + message (custom metadata is asserted via the
 # message string in tests), but declare `metadata: :all` so Credo's

--- a/lib/loopctl/knowledge/ingestion_anomaly.ex
+++ b/lib/loopctl/knowledge/ingestion_anomaly.ex
@@ -24,9 +24,11 @@ defmodule Loopctl.Knowledge.IngestionAnomaly do
   - `anomaly_type` -- one of the types above
   - `last_event_at` -- `max(inserted_at)` of that source_type's articles (nil if none)
   - `hours_stale` -- whole hours between `last_event_at` and detection time
-  - `sample_count` -- total articles of that source_type (the "established" evidence)
+  - `sample_count` -- articles of that source_type within the recency/establishment
+    window (the "recently established" evidence)
   - `resolved` -- whether the anomaly has been acknowledged/resolved
-  - `archived` -- archived anomalies are excluded from the default list
+  - `archived` -- archived anomalies are excluded from the default list and
+    permanently suppress re-detection for a retired source_type
   - `metadata` -- extensible JSONB map
   """
 
@@ -92,8 +94,13 @@ defmodule Loopctl.Knowledge.IngestionAnomaly do
     ])
     |> validate_required([:source_type, :anomaly_type, :hours_stale, :sample_count])
     |> validate_inclusion(:anomaly_type, @anomaly_types)
-    |> validate_number(:hours_stale, greater_than_or_equal_to: 0)
-    |> validate_number(:sample_count, greater_than_or_equal_to: 0)
+    # A capture-silence anomaly is, by definition, a source_type that WENT stale —
+    # so it must have been established (>= 1 captured article) and stale (> 0 hours).
+    # sample_count: 0 ("never established") / hours_stale: 0 ("not actually stale")
+    # are logically impossible anomalies; reject them at the invariant boundary
+    # even though the detection layer already only feeds established+stale figures.
+    |> validate_number(:hours_stale, greater_than: 0)
+    |> validate_number(:sample_count, greater_than_or_equal_to: 1)
     |> validate_metadata_size()
     |> foreign_key_constraint(:tenant_id)
   end
@@ -104,6 +111,20 @@ defmodule Loopctl.Knowledge.IngestionAnomaly do
   @spec resolve_changeset(%__MODULE__{}) :: Ecto.Changeset.t()
   def resolve_changeset(anomaly) do
     change(anomaly, resolved: true)
+  end
+
+  @doc """
+  Changeset for archiving an anomaly.
+
+  Archiving is the operator's PERMANENT escape hatch for a legitimately-retired
+  `source_type`: an archived anomaly is excluded from the default list AND
+  suppresses re-detection for that source_type (see
+  `Loopctl.Workers.IngestionHealthWorker`), so a wound-down workflow is not
+  re-flagged on every hourly run.
+  """
+  @spec archive_changeset(%__MODULE__{}) :: Ecto.Changeset.t()
+  def archive_changeset(anomaly) do
+    change(anomaly, archived: true)
   end
 
   @metadata_max_bytes 65_536

--- a/lib/loopctl/knowledge/ingestion_anomaly.ex
+++ b/lib/loopctl/knowledge/ingestion_anomaly.ex
@@ -28,7 +28,11 @@ defmodule Loopctl.Knowledge.IngestionAnomaly do
     window (the "recently established" evidence)
   - `resolved` -- whether the anomaly has been acknowledged/resolved
   - `archived` -- archived anomalies are excluded from the default list and
-    permanently suppress re-detection for a retired source_type
+    suppress re-detection for a retired source_type until un-archived
+  - `alerted` -- whether the out-of-band operator alert + webhook were fired.
+    Makes notification AT-LEAST-ONCE: a worker crash between the atomic row
+    insert and the post-commit enqueues leaves `alerted: false`, so a later run
+    re-fires the notifications instead of losing them on the no-notify path.
   - `metadata` -- extensible JSONB map
   """
 
@@ -51,6 +55,7 @@ defmodule Loopctl.Knowledge.IngestionAnomaly do
              :sample_count,
              :resolved,
              :archived,
+             :alerted,
              :metadata,
              :inserted_at,
              :updated_at
@@ -66,6 +71,7 @@ defmodule Loopctl.Knowledge.IngestionAnomaly do
     field :sample_count, :integer
     field :resolved, :boolean, default: false
     field :archived, :boolean, default: false
+    field :alerted, :boolean, default: false
     field :metadata, :map, default: %{}
 
     timestamps()
@@ -116,15 +122,42 @@ defmodule Loopctl.Knowledge.IngestionAnomaly do
   @doc """
   Changeset for archiving an anomaly.
 
-  Archiving is the operator's PERMANENT escape hatch for a legitimately-retired
+  Archiving is the operator's escape hatch for a legitimately-retired
   `source_type`: an archived anomaly is excluded from the default list AND
   suppresses re-detection for that source_type (see
   `Loopctl.Workers.IngestionHealthWorker`), so a wound-down workflow is not
-  re-flagged on every hourly run.
+  re-flagged on every hourly run. It is REVERSIBLE via `unarchive_changeset/1`
+  so a mistaken archive (e.g. a workflow later revived) can restore monitoring.
   """
   @spec archive_changeset(%__MODULE__{}) :: Ecto.Changeset.t()
   def archive_changeset(anomaly) do
     change(anomaly, archived: true)
+  end
+
+  @doc """
+  Changeset for un-archiving an anomaly — the inverse of `archive_changeset/1`.
+
+  Restores monitoring for a source_type whose anomaly was archived: once
+  `archived` is false again, `Loopctl.Workers.IngestionHealthWorker` no longer
+  suppresses re-detection, so a revived workflow that goes silent is caught
+  again. Without this the archive escape hatch would be a permanent, irreversible
+  blind spot — the exact failure the dead-man's-switch exists to eliminate.
+  """
+  @spec unarchive_changeset(%__MODULE__{}) :: Ecto.Changeset.t()
+  def unarchive_changeset(anomaly) do
+    change(anomaly, archived: false)
+  end
+
+  @doc """
+  Changeset that records the out-of-band operator alert + webhook were fired.
+
+  Used to make notification at-least-once: set only AFTER the post-commit
+  enqueues succeed, so a crash before this leaves `alerted: false` and a later
+  run re-fires the notifications rather than losing them.
+  """
+  @spec mark_alerted_changeset(%__MODULE__{}) :: Ecto.Changeset.t()
+  def mark_alerted_changeset(anomaly) do
+    change(anomaly, alerted: true)
   end
 
   @metadata_max_bytes 65_536

--- a/lib/loopctl/knowledge/ingestion_anomaly.ex
+++ b/lib/loopctl/knowledge/ingestion_anomaly.ex
@@ -1,0 +1,118 @@
+defmodule Loopctl.Knowledge.IngestionAnomaly do
+  @moduledoc """
+  Schema for the `ingestion_anomalies` table.
+
+  A capture-silence anomaly is a **dead-man's-switch** for knowledge ingestion:
+  it records that a tenant which HISTORICALLY produced captured articles of a
+  given `source_type` (e.g. `"session_log"`) has gone silent — no new article of
+  that source_type has been written for longer than the staleness threshold.
+
+  This is the sibling detector-class to `Loopctl.TokenUsage.CostAnomaly`. Where
+  CostAnomaly (and ScaleAlerts) detect the *presence of errors*, this detects the
+  *absence of expected success* — the failure mode where session-knowledge capture
+  silently stopped (articles rejected/dropped) and nothing noticed the missing writes.
+  Created by `Loopctl.Workers.IngestionHealthWorker`.
+
+  ## Anomaly Types
+
+  - `capture_silence` -- an established source_type produced no new article for
+    longer than the configured staleness threshold.
+
+  ## Fields
+
+  - `source_type` -- the article `source_type` whose capture stream went silent
+  - `anomaly_type` -- one of the types above
+  - `last_event_at` -- `max(inserted_at)` of that source_type's articles (nil if none)
+  - `hours_stale` -- whole hours between `last_event_at` and detection time
+  - `sample_count` -- total articles of that source_type (the "established" evidence)
+  - `resolved` -- whether the anomaly has been acknowledged/resolved
+  - `archived` -- archived anomalies are excluded from the default list
+  - `metadata` -- extensible JSONB map
+  """
+
+  use Loopctl.Schema
+
+  @type t :: %__MODULE__{}
+
+  # Extensible list — a future detector (e.g. `:capture_drop_rate`) can be added
+  # here alongside the CHECK constraint in the migration.
+  @anomaly_types [:capture_silence]
+
+  @derive {Jason.Encoder,
+           only: [
+             :id,
+             :tenant_id,
+             :source_type,
+             :anomaly_type,
+             :last_event_at,
+             :hours_stale,
+             :sample_count,
+             :resolved,
+             :archived,
+             :metadata,
+             :inserted_at,
+             :updated_at
+           ]}
+
+  schema "ingestion_anomalies" do
+    tenant_field()
+
+    field :source_type, :string
+    field :anomaly_type, Ecto.Enum, values: @anomaly_types
+    field :last_event_at, :utc_datetime_usec
+    field :hours_stale, :integer
+    field :sample_count, :integer
+    field :resolved, :boolean, default: false
+    field :archived, :boolean, default: false
+    field :metadata, :map, default: %{}
+
+    timestamps()
+  end
+
+  @doc "The known anomaly types."
+  @spec anomaly_types() :: [atom()]
+  def anomaly_types, do: @anomaly_types
+
+  @doc """
+  Changeset for creating a capture-silence anomaly.
+
+  The `tenant_id` is set programmatically and must not be in cast.
+  """
+  @spec create_changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
+  def create_changeset(anomaly \\ %__MODULE__{}, attrs) do
+    anomaly
+    |> cast(attrs, [
+      :source_type,
+      :anomaly_type,
+      :last_event_at,
+      :hours_stale,
+      :sample_count,
+      :resolved,
+      :metadata
+    ])
+    |> validate_required([:source_type, :anomaly_type, :hours_stale, :sample_count])
+    |> validate_inclusion(:anomaly_type, @anomaly_types)
+    |> validate_number(:hours_stale, greater_than_or_equal_to: 0)
+    |> validate_number(:sample_count, greater_than_or_equal_to: 0)
+    |> validate_metadata_size()
+    |> foreign_key_constraint(:tenant_id)
+  end
+
+  @doc """
+  Changeset for resolving an anomaly.
+  """
+  @spec resolve_changeset(%__MODULE__{}) :: Ecto.Changeset.t()
+  def resolve_changeset(anomaly) do
+    change(anomaly, resolved: true)
+  end
+
+  @metadata_max_bytes 65_536
+
+  defp validate_metadata_size(changeset) do
+    validate_change(changeset, :metadata, fn :metadata, value ->
+      if byte_size(Jason.encode!(value)) > @metadata_max_bytes,
+        do: [metadata: "must be smaller than 64KB"],
+        else: []
+    end)
+  end
+end

--- a/lib/loopctl/knowledge/ingestion_health.ex
+++ b/lib/loopctl/knowledge/ingestion_health.ex
@@ -1,0 +1,310 @@
+defmodule Loopctl.Knowledge.IngestionHealth do
+  @moduledoc """
+  Capture-silence detection + query context for `ingestion_anomalies`.
+
+  A **dead-man's-switch** for knowledge ingestion. loopctl already detects the
+  *presence of errors* (`Loopctl.TokenUsage.CostAnomaly`, `Loopctl.Telemetry.ScaleAlerts`)
+  but had no detector for the *absence of expected success* — the failure mode
+  where session-knowledge capture silently stopped (articles rejected/dropped)
+  and nothing noticed the missing writes for months.
+
+  `detect/1` scans every active tenant and each monitored article `source_type`.
+  For a source_type that is **established** (has produced at least
+  `established_threshold` articles) but whose most recent article is older than
+  `staleness_threshold_hours`, it emits a `:capture_silence` candidate. A tenant
+  that never produced captures of a source_type is never flagged (it was never
+  established), so this fires only on genuine *went-silent* regressions.
+
+  The persistence + notification (audit / operator alert / per-tenant webhook) of a
+  candidate lives in `Loopctl.Workers.IngestionHealthWorker`, mirroring how
+  `Loopctl.Workers.CostAnomalyWorker` owns anomaly creation. This module owns the
+  detection query and the `list_anomalies/2` / `resolve_anomaly/3` read+resolve
+  surface the API exposes.
+
+  ## Config-based DI
+
+  The three tunables resolve from `Application.get_env(:loopctl, :ingestion_health, [])`
+  with in-code defaults (never opts, never `Application.put_env` in tests):
+
+  - `:monitored_source_types` -- default `["session_log"]`
+  - `:established_threshold` -- default `5`
+  - `:staleness_threshold_hours` -- default `72`
+  """
+
+  import Ecto.Query
+
+  alias Ecto.Multi
+  alias Loopctl.AdminRepo
+  alias Loopctl.Audit
+  alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.IngestionAnomaly
+  alias Loopctl.Tenants.Tenant
+
+  @default_monitored_source_types ["session_log"]
+  @default_established_threshold 5
+  @default_staleness_threshold_hours 72
+
+  @type candidate :: %{
+          tenant_id: Ecto.UUID.t(),
+          source_type: String.t(),
+          last_event_at: DateTime.t(),
+          hours_stale: non_neg_integer(),
+          sample_count: non_neg_integer()
+        }
+
+  # --- Config accessors (documented defaults) ---
+
+  @doc "Article `source_type`s monitored for capture silence (default `[\"session_log\"]`)."
+  @spec monitored_source_types() :: [String.t()]
+  def monitored_source_types,
+    do: Keyword.get(config(), :monitored_source_types, @default_monitored_source_types)
+
+  @doc "Minimum article count for a source_type to count as ESTABLISHED (default 5)."
+  @spec established_threshold() :: pos_integer()
+  def established_threshold,
+    do: Keyword.get(config(), :established_threshold, @default_established_threshold)
+
+  @doc "Hours since the last article beyond which an established source_type is stale (default 72)."
+  @spec staleness_threshold_hours() :: pos_integer()
+  def staleness_threshold_hours,
+    do: Keyword.get(config(), :staleness_threshold_hours, @default_staleness_threshold_hours)
+
+  defp config, do: Application.get_env(:loopctl, :ingestion_health, [])
+
+  # --- Detection ---
+
+  @doc """
+  Scans every active tenant for capture-silence candidates using the configured
+  tunables. Returns a flat list of `t:candidate/0` maps — PURE, no DB writes.
+
+  The worker turns each candidate into a persisted anomaly (race-safe) and notifies.
+  """
+  @spec detect() :: [candidate()]
+  def detect do
+    detect(%{
+      monitored_source_types: monitored_source_types(),
+      established_threshold: established_threshold(),
+      staleness_threshold_hours: staleness_threshold_hours()
+    })
+  end
+
+  @doc """
+  `detect/0` with explicit config (`:monitored_source_types`, `:established_threshold`,
+  `:staleness_threshold_hours`). Exposed so a caller can drive detection with a
+  specific configuration without touching global app env.
+  """
+  @spec detect(%{
+          monitored_source_types: [String.t()],
+          established_threshold: pos_integer(),
+          staleness_threshold_hours: pos_integer()
+        }) :: [candidate()]
+  def detect(%{
+        monitored_source_types: source_types,
+        established_threshold: established,
+        staleness_threshold_hours: staleness_hours
+      }) do
+    now = DateTime.utc_now()
+
+    active_tenant_ids()
+    |> Enum.flat_map(&detect_for_tenant(&1, source_types, established, staleness_hours, now))
+  end
+
+  # Groups the tenant's monitored-source_type articles by source_type in ONE query,
+  # yielding sample_count + last_event_at, then keeps only the established+stale ones.
+  # A source_type with zero articles never appears in the grouped result, so it is
+  # correctly never flagged (not established).
+  defp detect_for_tenant(tenant_id, source_types, established, staleness_hours, now) do
+    Article
+    |> where([a], a.tenant_id == ^tenant_id)
+    |> where([a], a.source_type in ^source_types)
+    |> group_by([a], a.source_type)
+    |> select([a], %{
+      source_type: a.source_type,
+      sample_count: count(a.id),
+      last_event_at: max(a.inserted_at)
+    })
+    |> AdminRepo.all()
+    |> Enum.flat_map(fn %{source_type: st, sample_count: count, last_event_at: last} ->
+      candidate_or_skip(tenant_id, st, count, last, established, staleness_hours, now)
+    end)
+  end
+
+  defp candidate_or_skip(
+         tenant_id,
+         source_type,
+         sample_count,
+         last_event_at,
+         established,
+         staleness_hours,
+         now
+       ) do
+    hours_stale = hours_between(last_event_at, now)
+
+    if sample_count >= established and is_integer(hours_stale) and hours_stale > staleness_hours do
+      [
+        %{
+          tenant_id: tenant_id,
+          source_type: source_type,
+          last_event_at: to_utc_datetime(last_event_at),
+          hours_stale: hours_stale,
+          sample_count: sample_count
+        }
+      ]
+    else
+      []
+    end
+  end
+
+  # --- Query surface (mirrors Loopctl.TokenUsage.list_anomalies/resolve_anomaly) ---
+
+  @doc """
+  Lists capture-silence anomalies for a tenant.
+
+  ## Options (keyword list)
+
+  - `:source_type` -- filter by source_type
+  - `:anomaly_type` -- filter by anomaly type (`:capture_silence`)
+  - `:resolved` -- filter by resolved status (default `false`)
+  - `:include_archived` -- when `true`, include archived anomalies (default `false`)
+  - `:page` -- page number (default 1)
+  - `:page_size` -- entries per page (default 20, max 100)
+
+  ## Returns
+
+  `{:ok, %{data: [IngestionAnomaly.t()], total: integer, page: integer, page_size: integer}}`
+  """
+  @spec list_anomalies(Ecto.UUID.t(), keyword()) ::
+          {:ok,
+           %{
+             data: [IngestionAnomaly.t()],
+             total: non_neg_integer(),
+             page: pos_integer(),
+             page_size: pos_integer()
+           }}
+  def list_anomalies(tenant_id, opts \\ []) do
+    page = max(Keyword.get(opts, :page, 1), 1)
+    page_size = opts |> Keyword.get(:page_size, 20) |> max(1) |> min(100)
+    offset = (page - 1) * page_size
+    resolved = Keyword.get(opts, :resolved, false)
+    include_archived = Keyword.get(opts, :include_archived, false)
+
+    base_query =
+      IngestionAnomaly
+      |> where([a], a.tenant_id == ^tenant_id)
+      |> where([a], a.resolved == ^resolved)
+      |> apply_archive_filter(include_archived)
+      |> apply_filter(:source_type, Keyword.get(opts, :source_type))
+      |> apply_filter(:anomaly_type, Keyword.get(opts, :anomaly_type))
+
+    total = AdminRepo.aggregate(base_query, :count, :id)
+
+    data =
+      base_query
+      |> order_by([a], desc: a.inserted_at)
+      |> limit(^page_size)
+      |> offset(^offset)
+      |> AdminRepo.all()
+
+    {:ok, %{data: data, total: total, page: page, page_size: page_size}}
+  end
+
+  @doc """
+  Gets a single ingestion anomaly by ID, scoped to a tenant.
+
+  Returns `{:ok, %IngestionAnomaly{}}` or `{:error, :not_found}`.
+  """
+  @spec get_anomaly(Ecto.UUID.t(), Ecto.UUID.t()) ::
+          {:ok, IngestionAnomaly.t()} | {:error, :not_found}
+  def get_anomaly(tenant_id, anomaly_id) do
+    case AdminRepo.get_by(IngestionAnomaly, id: anomaly_id, tenant_id: tenant_id) do
+      nil -> {:error, :not_found}
+      anomaly -> {:ok, anomaly}
+    end
+  end
+
+  @doc """
+  Marks an ingestion anomaly as resolved, writing an audit entry in the same transaction.
+
+  ## Options (keyword list)
+
+  - `:actor_id` -- audit actor ID
+  - `:actor_label` -- audit actor label
+  - `:actor_type` -- audit actor type (default "api_key")
+
+  Returns `{:ok, %IngestionAnomaly{}}` or `{:error, :not_found}` / `{:error, changeset}`.
+  """
+  @spec resolve_anomaly(Ecto.UUID.t(), Ecto.UUID.t(), keyword()) ::
+          {:ok, IngestionAnomaly.t()} | {:error, :not_found} | {:error, Ecto.Changeset.t()}
+  def resolve_anomaly(tenant_id, anomaly_id, opts \\ []) do
+    with {:ok, anomaly} <- get_anomaly(tenant_id, anomaly_id) do
+      changeset = IngestionAnomaly.resolve_changeset(anomaly)
+
+      multi =
+        Multi.new()
+        |> Multi.update(:anomaly, changeset)
+        |> Audit.log_in_multi(:audit, fn %{anomaly: resolved} ->
+          %{
+            tenant_id: tenant_id,
+            entity_type: "ingestion_anomaly",
+            entity_id: resolved.id,
+            action: "resolved",
+            actor_type: Keyword.get(opts, :actor_type, "api_key"),
+            actor_id: Keyword.get(opts, :actor_id),
+            actor_label: Keyword.get(opts, :actor_label),
+            old_state: %{"resolved" => false},
+            new_state: %{"resolved" => true}
+          }
+        end)
+
+      case AdminRepo.transaction(multi) do
+        {:ok, %{anomaly: anomaly}} -> {:ok, anomaly}
+        {:error, :anomaly, changeset, _} -> {:error, changeset}
+        {:error, _step, error, _} -> {:error, error}
+      end
+    end
+  end
+
+  # --- Private helpers ---
+
+  defp active_tenant_ids do
+    Tenant
+    |> where([t], t.status == :active)
+    |> select([t], t.id)
+    |> AdminRepo.all()
+  end
+
+  # Exclude archived anomalies by default; include them when requested.
+  defp apply_archive_filter(query, true), do: query
+  defp apply_archive_filter(query, _), do: where(query, [a], a.archived == false)
+
+  defp apply_filter(query, _field, nil), do: query
+  defp apply_filter(query, _field, ""), do: query
+
+  defp apply_filter(query, :source_type, value) when is_binary(value),
+    do: where(query, [a], a.source_type == ^value)
+
+  defp apply_filter(query, :anomaly_type, value) when is_binary(value) do
+    known = Enum.map(IngestionAnomaly.anomaly_types(), &Atom.to_string/1)
+
+    if value in known do
+      atom_val = String.to_existing_atom(value)
+      where(query, [a], a.anomaly_type == ^atom_val)
+    else
+      where(query, [_a], false)
+    end
+  end
+
+  defp apply_filter(query, :anomaly_type, value) when is_atom(value),
+    do: where(query, [a], a.anomaly_type == ^value)
+
+  # Whole hours between an aggregate max(inserted_at) and now. `max/1` over a
+  # :utc_datetime_usec column can come back as a NaiveDateTime, so normalize both.
+  defp hours_between(nil, _now), do: nil
+
+  defp hours_between(last, now) do
+    div(DateTime.diff(now, to_utc_datetime(last), :second), 3600)
+  end
+
+  defp to_utc_datetime(%DateTime{} = dt), do: dt
+  defp to_utc_datetime(%NaiveDateTime{} = ndt), do: DateTime.from_naive!(ndt, "Etc/UTC")
+end

--- a/lib/loopctl/knowledge/ingestion_health.ex
+++ b/lib/loopctl/knowledge/ingestion_health.ex
@@ -17,6 +17,25 @@ defmodule Loopctl.Knowledge.IngestionHealth do
   source_type is never flagged (it was never established), so this fires only on
   genuine *went-silent* regressions.
 
+  ## Index / scan cost
+
+  The grouped scan filters `articles.inserted_at >= window_start`; the supporting
+  index (`articles_inserted_tenant_source_idx`) LEADS with `inserted_at` so that
+  predicate is an index RANGE SEEK — the read is bounded to the rolling window
+  (recent activity), NOT the whole corpus, so cost does not grow unbounded as the
+  article table ages.
+
+  ## Monitoring contract: source_type must be stamped
+
+  detect/1 only sees articles with a NON-NULL `source_type` (`where not is_nil`).
+  `source_type` is an advisory, nullable field on `Loopctl.Knowledge.Article`, so
+  a write path that omits it produces articles this monitor CANNOT see — a silent
+  outage on such a path would go undetected. Any ingestion path you want covered
+  by the dead-man's-switch (session capture, batch ingest, content ingestion)
+  MUST stamp a known `source_type` (see `Article.known_source_types/0`). Whether a
+  given upstream writer is required to stamp one is a product/contract decision;
+  this module's guarantee is scoped to paths that do.
+
   ## Recency window (no perpetual false positives)
 
   Establishment is scoped to a rolling `establishment_window_hours` window, not an
@@ -25,8 +44,9 @@ defmodule Loopctl.Knowledge.IngestionHealth do
   window once its last capture ages past it, so it stops being flagged instead of
   being reported as stale forever. Genuine regressions (recently active, now
   silent) still fire because their captures are inside the window. For a
-  source_type an operator KNOWS is retired, archiving its anomaly permanently
-  suppresses re-detection (see `Loopctl.Workers.IngestionHealthWorker`).
+  source_type an operator KNOWS is retired, archiving its anomaly suppresses
+  re-detection (see `Loopctl.Workers.IngestionHealthWorker`); archiving is
+  REVERSIBLE via `unarchive_anomaly/3` so a mistaken suppression can be lifted.
 
   The persistence + notification (audit / operator alert / per-tenant webhook) of a
   candidate lives in `Loopctl.Workers.IngestionHealthWorker`, mirroring how
@@ -42,6 +62,8 @@ defmodule Loopctl.Knowledge.IngestionHealth do
   - `:monitored_source_types` -- default `:all` (every source_type that crosses the
     established threshold; a list narrows monitoring to specific source_types)
   - `:established_threshold` -- default `5`
+  - `:established_threshold_overrides` -- default `%{}` (per-source-type establishment
+    thresholds, e.g. `%{"session_log" => 2}` to monitor a low-volume critical source)
   - `:staleness_threshold_hours` -- default `72`
   - `:establishment_window_hours` -- default `720` (30 days)
   """
@@ -50,7 +72,7 @@ defmodule Loopctl.Knowledge.IngestionHealth do
 
   alias Ecto.Multi
   alias Loopctl.AdminRepo
-  alias Loopctl.Audit
+  alias Loopctl.Audit.AuditLog
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.IngestionAnomaly
   alias Loopctl.Tenants.Tenant
@@ -59,6 +81,7 @@ defmodule Loopctl.Knowledge.IngestionHealth do
   @default_established_threshold 5
   @default_staleness_threshold_hours 72
   @default_establishment_window_hours 720
+  @default_established_threshold_overrides %{}
 
   @type candidate :: %{
           tenant_id: Ecto.UUID.t(),
@@ -84,6 +107,24 @@ defmodule Loopctl.Knowledge.IngestionHealth do
   @spec established_threshold() :: pos_integer()
   def established_threshold,
     do: Keyword.get(config(), :established_threshold, @default_established_threshold)
+
+  @doc """
+  Per-source-type overrides for the establishment threshold.
+
+  A map of `source_type => pos_integer`. A low-volume but critical source_type
+  (e.g. 3-4 captures/month) would never cross the global `established_threshold`
+  and so would never be monitored; an override lets an operator lower the bar for
+  that specific source_type without weakening the default for noisy ones. Default
+  `%{}` (no overrides — every source_type uses the global threshold).
+  """
+  @spec established_threshold_overrides() :: %{optional(String.t()) => pos_integer()}
+  def established_threshold_overrides,
+    do:
+      Keyword.get(
+        config(),
+        :established_threshold_overrides,
+        @default_established_threshold_overrides
+      )
 
   @doc "Hours since the last article beyond which an established source_type is stale (default 72)."
   @spec staleness_threshold_hours() :: pos_integer()
@@ -114,6 +155,7 @@ defmodule Loopctl.Knowledge.IngestionHealth do
     detect(%{
       monitored_source_types: monitored_source_types(),
       established_threshold: established_threshold(),
+      established_threshold_overrides: established_threshold_overrides(),
       staleness_threshold_hours: staleness_threshold_hours(),
       establishment_window_hours: establishment_window_hours()
     })
@@ -129,6 +171,7 @@ defmodule Loopctl.Knowledge.IngestionHealth do
           required(:monitored_source_types) => :all | [String.t()],
           required(:established_threshold) => pos_integer(),
           required(:staleness_threshold_hours) => pos_integer(),
+          optional(:established_threshold_overrides) => %{optional(String.t()) => pos_integer()},
           optional(:establishment_window_hours) => pos_integer()
         }) :: [candidate()]
   def detect(
@@ -141,12 +184,15 @@ defmodule Loopctl.Knowledge.IngestionHealth do
     now = DateTime.utc_now()
     window_hours = Map.get(opts, :establishment_window_hours, establishment_window_hours())
     window_start = DateTime.add(now, -window_hours * 3600, :second)
+    overrides = Map.get(opts, :established_threshold_overrides, %{})
 
     # ONE grouped query across ALL active tenants (no per-tenant fan-out): the
     # join to active tenants + group_by (tenant_id, source_type) yields
     # sample_count + last_event_at per (tenant, source_type). Establishment is
     # scoped to the recency window (inserted_at >= window_start) so wound-down
-    # source_types age out instead of being flagged forever. A source_type with
+    # source_types age out instead of being flagged forever, AND so the read is
+    # bounded to the window via the inserted_at-leading index (articles_inserted_
+    # tenant_source_idx) rather than scanning the whole corpus. A source_type with
     # no recent articles never appears in the result (not recently established).
     Article
     |> join(:inner, [a], t in Tenant, on: t.id == a.tenant_id and t.status == :active)
@@ -167,7 +213,8 @@ defmodule Loopctl.Knowledge.IngestionHealth do
                           sample_count: count,
                           last_event_at: last
                         } ->
-      candidate_or_skip(tid, st, count, last, established, staleness_hours, now)
+      threshold = Map.get(overrides, st, established)
+      candidate_or_skip(tid, st, count, last, threshold, staleness_hours, now)
     end)
   end
 
@@ -212,10 +259,16 @@ defmodule Loopctl.Knowledge.IngestionHealth do
 
   - `:source_type` -- filter by source_type
   - `:anomaly_type` -- filter by anomaly type (`:capture_silence`)
-  - `:resolved` -- filter by resolved status (default `false`)
+  - `:resolved` -- filter by resolved status: `false` (default, unresolved only),
+    `true` (resolved only), or `:all` (both — the complete timeline in one call)
   - `:include_archived` -- when `true`, include archived anomalies (default `false`)
   - `:page` -- page number (default 1)
   - `:page_size` -- entries per page (default 20, max 100)
+
+  For UNRESOLVED rows, `hours_stale` is recomputed at read time from
+  `last_event_at` to now, so a long-running outage reports its TRUE current age
+  rather than the frozen detection-time snapshot. Resolved rows keep their
+  historical (detection-time) figures.
 
   ## Returns
 
@@ -239,7 +292,7 @@ defmodule Loopctl.Knowledge.IngestionHealth do
     base_query =
       IngestionAnomaly
       |> where([a], a.tenant_id == ^tenant_id)
-      |> where([a], a.resolved == ^resolved)
+      |> apply_resolved_filter(resolved)
       |> apply_archive_filter(include_archived)
       |> apply_filter(:source_type, Keyword.get(opts, :source_type))
       |> apply_filter(:anomaly_type, Keyword.get(opts, :anomaly_type))
@@ -252,9 +305,31 @@ defmodule Loopctl.Knowledge.IngestionHealth do
       |> limit(^page_size)
       |> offset(^offset)
       |> AdminRepo.all()
+      |> Enum.map(&refresh_staleness(&1, DateTime.utc_now()))
 
     {:ok, %{data: data, total: total, page: page, page_size: page_size}}
   end
+
+  # `resolved: :all` returns both resolved and unresolved (the complete timeline);
+  # a boolean narrows to that status. Default (false) is unresolved-only.
+  defp apply_resolved_filter(query, :all), do: query
+  defp apply_resolved_filter(query, resolved), do: where(query, [a], a.resolved == ^resolved)
+
+  # Recompute hours_stale for an UNRESOLVED anomaly from its last_event_at to now,
+  # so a long outage reports its true current age instead of the frozen
+  # detection-time snapshot. Resolved rows keep their historical figures.
+  defp refresh_staleness(%IngestionAnomaly{resolved: false, last_event_at: last} = anomaly, now)
+       when not is_nil(last) do
+    case hours_between(last, now) do
+      hours when is_integer(hours) and hours > anomaly.hours_stale ->
+        %{anomaly | hours_stale: hours}
+
+      _ ->
+        anomaly
+    end
+  end
+
+  defp refresh_staleness(anomaly, _now), do: anomaly
 
   @doc """
   Gets a single ingestion anomaly by ID, scoped to a tenant.
@@ -295,25 +370,27 @@ defmodule Loopctl.Knowledge.IngestionHealth do
   end
 
   defp do_resolve(tenant_id, anomaly, opts) do
-    Multi.new()
-    |> Multi.update(:anomaly, IngestionAnomaly.resolve_changeset(anomaly))
-    |> Audit.log_in_multi(:audit, fn %{anomaly: resolved} ->
-      audit_attrs(tenant_id, resolved.id, "resolved", opts, %{
-        # Derive old_state from the actual prior value (guaranteed false here).
-        old_state: %{"resolved" => anomaly.resolved},
-        new_state: %{"resolved" => true}
-      })
-    end)
-    |> run_anomaly_multi()
+    transition(
+      tenant_id,
+      anomaly,
+      opts,
+      :resolved,
+      false,
+      true,
+      "resolved",
+      &IngestionAnomaly.resolve_changeset/1
+    )
   end
 
   @doc """
   Archives an ingestion anomaly, writing an audit entry in the same transaction.
 
-  Archiving is the operator's PERMANENT escape hatch for a legitimately-retired
+  Archiving is the operator's escape hatch for a legitimately-retired
   `source_type`: an archived anomaly is hidden from the default list AND suppresses
   re-detection for that source_type in `Loopctl.Workers.IngestionHealthWorker`, so a
-  wound-down workflow is not re-flagged on every hourly run.
+  wound-down workflow is not re-flagged on every hourly run. It is REVERSIBLE via
+  `unarchive_anomaly/3` — a mistaken archive (e.g. a workflow later revived) can be
+  undone to restore monitoring, so the escape hatch is not a permanent blind spot.
 
   ## Options (keyword list)
 
@@ -335,18 +412,160 @@ defmodule Loopctl.Knowledge.IngestionHealth do
   end
 
   defp do_archive(tenant_id, anomaly, opts) do
+    transition(
+      tenant_id,
+      anomaly,
+      opts,
+      :archived,
+      false,
+      true,
+      "archived",
+      &IngestionAnomaly.archive_changeset/1
+    )
+  end
+
+  @doc """
+  Un-archives an ingestion anomaly — the inverse of `archive_anomaly/3`.
+
+  Restores monitoring for a source_type whose anomaly was archived: once
+  un-archived, `Loopctl.Workers.IngestionHealthWorker` no longer suppresses
+  re-detection, so a revived-then-silent workflow is caught again. This is what
+  keeps archive from being an irreversible, permanent blind spot. Writes an
+  audit entry in the same transaction. Un-archiving a non-archived anomaly is an
+  idempotent no-op.
+
+  ## Options (keyword list)
+
+  - `:actor_id` -- audit actor ID
+  - `:actor_label` -- audit actor label
+  - `:actor_type` -- audit actor type (default "api_key")
+
+  Returns `{:ok, %IngestionAnomaly{}}` or `{:error, :not_found}` / `{:error, changeset}`.
+  """
+  @spec unarchive_anomaly(Ecto.UUID.t(), Ecto.UUID.t(), keyword()) ::
+          {:ok, IngestionAnomaly.t()} | {:error, :not_found} | {:error, Ecto.Changeset.t()}
+  def unarchive_anomaly(tenant_id, anomaly_id, opts \\ []) do
+    with {:ok, anomaly} <- get_anomaly(tenant_id, anomaly_id) do
+      if anomaly.archived,
+        do: do_unarchive(tenant_id, anomaly, opts),
+        else: {:ok, anomaly}
+    end
+  end
+
+  defp do_unarchive(tenant_id, anomaly, opts) do
+    transition(
+      tenant_id,
+      anomaly,
+      opts,
+      :archived,
+      true,
+      false,
+      "unarchived",
+      &IngestionAnomaly.unarchive_changeset/1
+    )
+  end
+
+  @doc """
+  Auto-resolves open anomalies whose captures have RESUMED.
+
+  Scans every unresolved, non-archived capture-silence anomaly and, when at least
+  one article of that `(tenant, source_type)` has arrived AFTER the anomaly's
+  `last_event_at`, resolves it (actor_type "system"). Without this an anomaly for
+  a fully-recovered stream would stay open forever showing frozen figures, so an
+  operator could not tell "recovered" from "still silent". Called by the hourly
+  worker. Returns the number of anomalies auto-resolved.
+  """
+  @spec auto_resolve_recovered() :: non_neg_integer()
+  def auto_resolve_recovered do
+    open =
+      IngestionAnomaly
+      |> where([a], a.resolved == false and a.archived == false)
+      |> where([a], a.anomaly_type == :capture_silence)
+      |> AdminRepo.all()
+
+    Enum.reduce(open, 0, fn anomaly, acc -> acc + resolve_if_recovered(anomaly) end)
+  end
+
+  # Returns 1 if the anomaly's captures resumed AND it was resolved, else 0.
+  defp resolve_if_recovered(anomaly) do
+    with true <- captures_resumed?(anomaly),
+         {:ok, _} <-
+           do_resolve(anomaly.tenant_id, anomaly,
+             actor_type: "system",
+             actor_label: "ingestion_health:auto_resolve"
+           ) do
+      1
+    else
+      _ -> 0
+    end
+  end
+
+  defp captures_resumed?(%IngestionAnomaly{last_event_at: nil}), do: false
+
+  defp captures_resumed?(%IngestionAnomaly{
+         tenant_id: tenant_id,
+         source_type: source_type,
+         last_event_at: last
+       }) do
+    Article
+    |> where(
+      [a],
+      a.tenant_id == ^tenant_id and a.source_type == ^source_type and a.inserted_at > ^last
+    )
+    |> AdminRepo.exists?()
+  end
+
+  # --- Private helpers ---
+
+  # Locked, audit-honest boolean flip: re-reads the row FOR UPDATE inside the
+  # transaction and only updates + audits when it is actually in the `from` state.
+  # Two concurrent callers therefore serialize — the first transitions and audits,
+  # the second observes the row already at `to` and is a no-op with NO bogus audit
+  # entry (the append-only log never records a transition that did not happen).
+  defp transition(tenant_id, anomaly, opts, field, from, to, action, changeset_fun) do
     Multi.new()
-    |> Multi.update(:anomaly, IngestionAnomaly.archive_changeset(anomaly))
-    |> Audit.log_in_multi(:audit, fn %{anomaly: archived} ->
-      audit_attrs(tenant_id, archived.id, "archived", opts, %{
-        old_state: %{"archived" => anomaly.archived},
-        new_state: %{"archived" => true}
-      })
+    |> Multi.run(:locked, fn repo, _changes ->
+      locked =
+        IngestionAnomaly
+        |> where([a], a.id == ^anomaly.id and a.tenant_id == ^tenant_id)
+        |> lock("FOR UPDATE")
+        |> repo.one()
+
+      {:ok, locked}
+    end)
+    |> Multi.run(:anomaly, fn repo, %{locked: locked} ->
+      cond do
+        is_nil(locked) -> {:error, :not_found}
+        Map.fetch!(locked, field) == from -> repo.update(changeset_fun.(locked))
+        true -> {:ok, locked}
+      end
+    end)
+    |> Multi.run(:audit, fn repo, %{locked: locked, anomaly: updated} ->
+      if not is_nil(locked) and Map.fetch!(locked, field) == from do
+        audit_insert(
+          repo,
+          audit_attrs(tenant_id, updated.id, action, opts, %{
+            old_state: %{Atom.to_string(field) => from},
+            new_state: %{Atom.to_string(field) => to}
+          })
+        )
+      else
+        {:ok, :skipped}
+      end
     end)
     |> run_anomaly_multi()
   end
 
-  # --- Private helpers ---
+  # Inserts an audit entry via the transaction's repo (keeps audit atomic with the
+  # anomaly update), mirroring Loopctl.Audit.log_in_multi's changeset construction.
+  defp audit_insert(repo, attrs) do
+    {tenant_id, attrs} = Map.pop(attrs, :tenant_id)
+
+    attrs
+    |> AuditLog.create_changeset()
+    |> Ecto.Changeset.put_change(:tenant_id, tenant_id)
+    |> repo.insert()
+  end
 
   defp audit_attrs(tenant_id, entity_id, action, opts, states) do
     Map.merge(

--- a/lib/loopctl/knowledge/ingestion_health.ex
+++ b/lib/loopctl/knowledge/ingestion_health.ex
@@ -8,12 +8,25 @@ defmodule Loopctl.Knowledge.IngestionHealth do
   where session-knowledge capture silently stopped (articles rejected/dropped)
   and nothing noticed the missing writes for months.
 
-  `detect/1` scans every active tenant and each monitored article `source_type`.
-  For a source_type that is **established** (has produced at least
-  `established_threshold` articles) but whose most recent article is older than
-  `staleness_threshold_hours`, it emits a `:capture_silence` candidate. A tenant
-  that never produced captures of a source_type is never flagged (it was never
-  established), so this fires only on genuine *went-silent* regressions.
+  `detect/1` scans every active tenant and each monitored article `source_type`
+  in ONE grouped query (joined against active tenants — no per-tenant fan-out).
+  For a source_type that is **recently established** (has produced at least
+  `established_threshold` articles WITHIN `establishment_window_hours`) but whose
+  most recent article is older than `staleness_threshold_hours`, it emits a
+  `:capture_silence` candidate. A tenant that never produced captures of a
+  source_type is never flagged (it was never established), so this fires only on
+  genuine *went-silent* regressions.
+
+  ## Recency window (no perpetual false positives)
+
+  Establishment is scoped to a rolling `establishment_window_hours` window, not an
+  all-time count. A source_type that produced captures long ago and then
+  legitimately wound down (project completed, workflow retired) drops out of the
+  window once its last capture ages past it, so it stops being flagged instead of
+  being reported as stale forever. Genuine regressions (recently active, now
+  silent) still fire because their captures are inside the window. For a
+  source_type an operator KNOWS is retired, archiving its anomaly permanently
+  suppresses re-detection (see `Loopctl.Workers.IngestionHealthWorker`).
 
   The persistence + notification (audit / operator alert / per-tenant webhook) of a
   candidate lives in `Loopctl.Workers.IngestionHealthWorker`, mirroring how
@@ -23,12 +36,14 @@ defmodule Loopctl.Knowledge.IngestionHealth do
 
   ## Config-based DI
 
-  The three tunables resolve from `Application.get_env(:loopctl, :ingestion_health, [])`
+  The tunables resolve from `Application.get_env(:loopctl, :ingestion_health, [])`
   with in-code defaults (never opts, never `Application.put_env` in tests):
 
-  - `:monitored_source_types` -- default `["session_log"]`
+  - `:monitored_source_types` -- default `:all` (every source_type that crosses the
+    established threshold; a list narrows monitoring to specific source_types)
   - `:established_threshold` -- default `5`
   - `:staleness_threshold_hours` -- default `72`
+  - `:establishment_window_hours` -- default `720` (30 days)
   """
 
   import Ecto.Query
@@ -40,9 +55,10 @@ defmodule Loopctl.Knowledge.IngestionHealth do
   alias Loopctl.Knowledge.IngestionAnomaly
   alias Loopctl.Tenants.Tenant
 
-  @default_monitored_source_types ["session_log"]
+  @default_monitored_source_types :all
   @default_established_threshold 5
   @default_staleness_threshold_hours 72
+  @default_establishment_window_hours 720
 
   @type candidate :: %{
           tenant_id: Ecto.UUID.t(),
@@ -54,12 +70,17 @@ defmodule Loopctl.Knowledge.IngestionHealth do
 
   # --- Config accessors (documented defaults) ---
 
-  @doc "Article `source_type`s monitored for capture silence (default `[\"session_log\"]`)."
-  @spec monitored_source_types() :: [String.t()]
+  @doc """
+  Article `source_type`s monitored for capture silence.
+
+  `:all` (the default) monitors every source_type that crosses the established
+  threshold; a list narrows monitoring to specific source_types.
+  """
+  @spec monitored_source_types() :: :all | [String.t()]
   def monitored_source_types,
     do: Keyword.get(config(), :monitored_source_types, @default_monitored_source_types)
 
-  @doc "Minimum article count for a source_type to count as ESTABLISHED (default 5)."
+  @doc "Minimum article count (within the establishment window) for a source_type to count as ESTABLISHED (default 5)."
   @spec established_threshold() :: pos_integer()
   def established_threshold,
     do: Keyword.get(config(), :established_threshold, @default_established_threshold)
@@ -68,6 +89,15 @@ defmodule Loopctl.Knowledge.IngestionHealth do
   @spec staleness_threshold_hours() :: pos_integer()
   def staleness_threshold_hours,
     do: Keyword.get(config(), :staleness_threshold_hours, @default_staleness_threshold_hours)
+
+  @doc """
+  Rolling window (in hours) within which a source_type's captures must fall to
+  count toward establishment (default 720 = 30 days). Scopes establishment to
+  RECENT activity so a wound-down source_type is not perpetually flagged.
+  """
+  @spec establishment_window_hours() :: pos_integer()
+  def establishment_window_hours,
+    do: Keyword.get(config(), :establishment_window_hours, @default_establishment_window_hours)
 
   defp config, do: Application.get_env(:loopctl, :ingestion_health, [])
 
@@ -84,50 +114,68 @@ defmodule Loopctl.Knowledge.IngestionHealth do
     detect(%{
       monitored_source_types: monitored_source_types(),
       established_threshold: established_threshold(),
-      staleness_threshold_hours: staleness_threshold_hours()
+      staleness_threshold_hours: staleness_threshold_hours(),
+      establishment_window_hours: establishment_window_hours()
     })
   end
 
   @doc """
   `detect/0` with explicit config (`:monitored_source_types`, `:established_threshold`,
-  `:staleness_threshold_hours`). Exposed so a caller can drive detection with a
-  specific configuration without touching global app env.
+  `:staleness_threshold_hours`, optional `:establishment_window_hours`). Exposed so a
+  caller can drive detection with a specific configuration without touching global
+  app env.
   """
   @spec detect(%{
-          monitored_source_types: [String.t()],
-          established_threshold: pos_integer(),
-          staleness_threshold_hours: pos_integer()
+          required(:monitored_source_types) => :all | [String.t()],
+          required(:established_threshold) => pos_integer(),
+          required(:staleness_threshold_hours) => pos_integer(),
+          optional(:establishment_window_hours) => pos_integer()
         }) :: [candidate()]
-  def detect(%{
-        monitored_source_types: source_types,
-        established_threshold: established,
-        staleness_threshold_hours: staleness_hours
-      }) do
+  def detect(
+        %{
+          monitored_source_types: source_types,
+          established_threshold: established,
+          staleness_threshold_hours: staleness_hours
+        } = opts
+      ) do
     now = DateTime.utc_now()
+    window_hours = Map.get(opts, :establishment_window_hours, establishment_window_hours())
+    window_start = DateTime.add(now, -window_hours * 3600, :second)
 
-    active_tenant_ids()
-    |> Enum.flat_map(&detect_for_tenant(&1, source_types, established, staleness_hours, now))
-  end
-
-  # Groups the tenant's monitored-source_type articles by source_type in ONE query,
-  # yielding sample_count + last_event_at, then keeps only the established+stale ones.
-  # A source_type with zero articles never appears in the grouped result, so it is
-  # correctly never flagged (not established).
-  defp detect_for_tenant(tenant_id, source_types, established, staleness_hours, now) do
+    # ONE grouped query across ALL active tenants (no per-tenant fan-out): the
+    # join to active tenants + group_by (tenant_id, source_type) yields
+    # sample_count + last_event_at per (tenant, source_type). Establishment is
+    # scoped to the recency window (inserted_at >= window_start) so wound-down
+    # source_types age out instead of being flagged forever. A source_type with
+    # no recent articles never appears in the result (not recently established).
     Article
-    |> where([a], a.tenant_id == ^tenant_id)
-    |> where([a], a.source_type in ^source_types)
-    |> group_by([a], a.source_type)
+    |> join(:inner, [a], t in Tenant, on: t.id == a.tenant_id and t.status == :active)
+    |> where([a], not is_nil(a.source_type))
+    |> where([a], a.inserted_at >= ^window_start)
+    |> filter_source_types(source_types)
+    |> group_by([a], [a.tenant_id, a.source_type])
     |> select([a], %{
+      tenant_id: a.tenant_id,
       source_type: a.source_type,
       sample_count: count(a.id),
       last_event_at: max(a.inserted_at)
     })
     |> AdminRepo.all()
-    |> Enum.flat_map(fn %{source_type: st, sample_count: count, last_event_at: last} ->
-      candidate_or_skip(tenant_id, st, count, last, established, staleness_hours, now)
+    |> Enum.flat_map(fn %{
+                          tenant_id: tid,
+                          source_type: st,
+                          sample_count: count,
+                          last_event_at: last
+                        } ->
+      candidate_or_skip(tid, st, count, last, established, staleness_hours, now)
     end)
   end
+
+  # `:all` monitors every source_type; a list narrows to the given source_types.
+  defp filter_source_types(query, :all), do: query
+
+  defp filter_source_types(query, source_types) when is_list(source_types),
+    do: where(query, [a], a.source_type in ^source_types)
 
   defp candidate_or_skip(
          tenant_id,
@@ -237,40 +285,90 @@ defmodule Loopctl.Knowledge.IngestionHealth do
           {:ok, IngestionAnomaly.t()} | {:error, :not_found} | {:error, Ecto.Changeset.t()}
   def resolve_anomaly(tenant_id, anomaly_id, opts \\ []) do
     with {:ok, anomaly} <- get_anomaly(tenant_id, anomaly_id) do
-      changeset = IngestionAnomaly.resolve_changeset(anomaly)
-
-      multi =
-        Multi.new()
-        |> Multi.update(:anomaly, changeset)
-        |> Audit.log_in_multi(:audit, fn %{anomaly: resolved} ->
-          %{
-            tenant_id: tenant_id,
-            entity_type: "ingestion_anomaly",
-            entity_id: resolved.id,
-            action: "resolved",
-            actor_type: Keyword.get(opts, :actor_type, "api_key"),
-            actor_id: Keyword.get(opts, :actor_id),
-            actor_label: Keyword.get(opts, :actor_label),
-            old_state: %{"resolved" => false},
-            new_state: %{"resolved" => true}
-          }
-        end)
-
-      case AdminRepo.transaction(multi) do
-        {:ok, %{anomaly: anomaly}} -> {:ok, anomaly}
-        {:error, :anomaly, changeset, _} -> {:error, changeset}
-        {:error, _step, error, _} -> {:error, error}
-      end
+      # Idempotent + audit-honest: re-resolving an already-resolved anomaly is a
+      # no-op that returns it as-is, so we never write a bogus `false -> true`
+      # audit transition for a row that was already resolved.
+      if anomaly.resolved,
+        do: {:ok, anomaly},
+        else: do_resolve(tenant_id, anomaly, opts)
     end
+  end
+
+  defp do_resolve(tenant_id, anomaly, opts) do
+    Multi.new()
+    |> Multi.update(:anomaly, IngestionAnomaly.resolve_changeset(anomaly))
+    |> Audit.log_in_multi(:audit, fn %{anomaly: resolved} ->
+      audit_attrs(tenant_id, resolved.id, "resolved", opts, %{
+        # Derive old_state from the actual prior value (guaranteed false here).
+        old_state: %{"resolved" => anomaly.resolved},
+        new_state: %{"resolved" => true}
+      })
+    end)
+    |> run_anomaly_multi()
+  end
+
+  @doc """
+  Archives an ingestion anomaly, writing an audit entry in the same transaction.
+
+  Archiving is the operator's PERMANENT escape hatch for a legitimately-retired
+  `source_type`: an archived anomaly is hidden from the default list AND suppresses
+  re-detection for that source_type in `Loopctl.Workers.IngestionHealthWorker`, so a
+  wound-down workflow is not re-flagged on every hourly run.
+
+  ## Options (keyword list)
+
+  - `:actor_id` -- audit actor ID
+  - `:actor_label` -- audit actor label
+  - `:actor_type` -- audit actor type (default "api_key")
+
+  Returns `{:ok, %IngestionAnomaly{}}` or `{:error, :not_found}` / `{:error, changeset}`.
+  Re-archiving an already-archived anomaly is an idempotent no-op.
+  """
+  @spec archive_anomaly(Ecto.UUID.t(), Ecto.UUID.t(), keyword()) ::
+          {:ok, IngestionAnomaly.t()} | {:error, :not_found} | {:error, Ecto.Changeset.t()}
+  def archive_anomaly(tenant_id, anomaly_id, opts \\ []) do
+    with {:ok, anomaly} <- get_anomaly(tenant_id, anomaly_id) do
+      if anomaly.archived,
+        do: {:ok, anomaly},
+        else: do_archive(tenant_id, anomaly, opts)
+    end
+  end
+
+  defp do_archive(tenant_id, anomaly, opts) do
+    Multi.new()
+    |> Multi.update(:anomaly, IngestionAnomaly.archive_changeset(anomaly))
+    |> Audit.log_in_multi(:audit, fn %{anomaly: archived} ->
+      audit_attrs(tenant_id, archived.id, "archived", opts, %{
+        old_state: %{"archived" => anomaly.archived},
+        new_state: %{"archived" => true}
+      })
+    end)
+    |> run_anomaly_multi()
   end
 
   # --- Private helpers ---
 
-  defp active_tenant_ids do
-    Tenant
-    |> where([t], t.status == :active)
-    |> select([t], t.id)
-    |> AdminRepo.all()
+  defp audit_attrs(tenant_id, entity_id, action, opts, states) do
+    Map.merge(
+      %{
+        tenant_id: tenant_id,
+        entity_type: "ingestion_anomaly",
+        entity_id: entity_id,
+        action: action,
+        actor_type: Keyword.get(opts, :actor_type, "api_key"),
+        actor_id: Keyword.get(opts, :actor_id),
+        actor_label: Keyword.get(opts, :actor_label)
+      },
+      states
+    )
+  end
+
+  defp run_anomaly_multi(multi) do
+    case AdminRepo.transaction(multi) do
+      {:ok, %{anomaly: anomaly}} -> {:ok, anomaly}
+      {:error, :anomaly, changeset, _} -> {:error, changeset}
+      {:error, _step, error, _} -> {:error, error}
+    end
   end
 
   # Exclude archived anomalies by default; include them when requested.

--- a/lib/loopctl/oban_config.ex
+++ b/lib/loopctl/oban_config.ex
@@ -436,6 +436,12 @@ defmodule Loopctl.ObanConfig do
          # :memory_graduation_max_per_run. Keep in sync with the crontab assertion in
          # oban_plugins_config_test.exs.
          {"0 * * * *", Loopctl.Workers.MemoryGraduationSweepWorker},
+         # Ingestion capture-silence dead-man's-switch: hourly scan for tenants whose
+         # established article source_types (e.g. session_log) went silent. HARDCODED
+         # schedule (no env var) so app boot never depends on a new env var. Detection
+         # self-gates on "established + stale", so the interval is a latency knob only.
+         # Keep in sync with the crontab assertion in oban_plugins_config_test.exs.
+         {"7 * * * *", Loopctl.Workers.IngestionHealthWorker},
          # US-35.3: all-tenants STH safety sweep. Reduced from `"* * * * *"` (every
          # minute) to a low-frequency, config-driven backstop (default `*/5 * * * *`)
          # that only catches appends the event-driven enqueuer (US-35.2) missed. Each

--- a/lib/loopctl/webhooks/webhook.ex
+++ b/lib/loopctl/webhooks/webhook.ex
@@ -46,6 +46,7 @@ defmodule Loopctl.Webhooks.Webhook do
     article.superseded
     article_link.created
     article_link.deleted
+    knowledge.ingestion_anomaly_detected
   )
 
   @doc """

--- a/lib/loopctl/workers/ingestion_health_worker.ex
+++ b/lib/loopctl/workers/ingestion_health_worker.ex
@@ -10,15 +10,26 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
 
   - a `Loopctl.Audit` entry (`entity_type: "ingestion_anomaly"`, `action: "detected"`,
     `actor_type: "system"`),
+  - an always-on operator-visible `Logger.error` (so a detected silence surfaces in
+    logs/monitoring even when no optional alert channel or webhook is configured),
   - an OPERATOR alert enqueued via `Loopctl.Workers.ScaleAlertDeliveryWorker` (which
     resolves `SCALE_ALERT_WEBHOOK_URL` itself and no-ops when unset — channel-agnostic
     and safe when unconfigured; this worker never reads the URL), and
   - a per-tenant `knowledge.ingestion_anomaly_detected` webhook event.
 
   On an EXISTING unresolved anomaly it silently refreshes the figures — NO re-notify
-  (anti-alarm-fatigue), exactly like `CostAnomalyWorker`.
+  (anti-alarm-fatigue), exactly like `CostAnomalyWorker` — UNLESS that row was never
+  successfully alerted (`alerted: false`), in which case it re-fires the operator
+  alert + webhook once (at-least-once recovery; see "Alert durability" below).
 
-  ## Suppression: resolve sticks, archive is permanent
+  ## Recovery: auto-resolve when captures resume
+
+  After detection, `Loopctl.Knowledge.IngestionHealth.auto_resolve_recovered/0`
+  closes any open anomaly whose `(tenant, source_type)` has produced an article
+  newer than the anomaly's `last_event_at`. Without this a fully-recovered stream
+  would keep a stale open anomaly forever, indistinguishable from an ongoing outage.
+
+  ## Suppression: resolve sticks, archive suppresses (reversibly)
 
   A resolved anomaly is NOT re-created on the next run just because the source_type
   is still silent — that would re-fire audit + operator alert + webhook every hour
@@ -27,9 +38,18 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
   `last_event_at` snapshot is at/after the candidate's), and only re-flags once
   captures RESUME (advancing `last_event_at`) and then go silent again.
 
-  An **archived** anomaly permanently suppresses re-detection for that source_type
-  (the operator's escape hatch for a legitimately-retired workflow) — regardless of
-  its resolved flag.
+  An **archived** anomaly suppresses re-detection for that source_type (the operator's
+  escape hatch for a legitimately-retired workflow) — regardless of its resolved flag.
+  Archiving is REVERSIBLE (`IngestionHealth.unarchive_anomaly/3`): un-archiving lifts
+  the suppression, so it is not a permanent blind spot.
+
+  ## Alert durability (at-least-once)
+
+  The anomaly row + `detected` audit are inserted atomically, but the operator alert
+  + webhook enqueues run POST-commit (they can't join the AdminRepo transaction — Oban
+  jobs insert through `Loopctl.Repo`). A crash between commit and enqueue would leave
+  an unresolved row with `alerted: false`; the next run detects that and re-fires the
+  notifications rather than silently losing them on the no-notify update path.
 
   ## Race-safety
 
@@ -76,6 +96,22 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
 
   @impl Oban.Worker
   def perform(%Oban.Job{}) do
+    if anomalies_table_ready?() do
+      run()
+    else
+      # Version skew: code deployed on the hourly crontab before its table
+      # migration landed. Skip quietly (self-heals next run) instead of crashing
+      # the job and burning Oban retries on an UndefinedTable error.
+      Logger.warning(
+        "IngestionHealthWorker: ingestion_anomalies table not present yet " <>
+          "(migration pending); skipping this run"
+      )
+
+      :ok
+    end
+  end
+
+  defp run do
     candidates = IngestionHealth.detect()
 
     Logger.info(
@@ -84,7 +120,25 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
 
     Enum.each(candidates, &flag_candidate/1)
 
+    # Close anomalies whose captures have resumed (recovered streams), so an open
+    # anomaly always means "still silent" and not "recovered but never cleared".
+    resolved = IngestionHealth.auto_resolve_recovered()
+
+    if resolved > 0 do
+      Logger.info("IngestionHealthWorker: auto-resolved #{resolved} recovered anomaly(ies)")
+    end
+
     :ok
+  end
+
+  # `to_regclass` returns NULL when the relation does not exist (no exception),
+  # so this is a cheap, crash-free readiness probe for the version-skew window.
+  defp anomalies_table_ready? do
+    case AdminRepo.query("SELECT to_regclass('ingestion_anomalies')", []) do
+      {:ok, %{rows: [[nil]]}} -> false
+      {:ok, _} -> true
+      _ -> false
+    end
   end
 
   defp flag_candidate(%{
@@ -109,8 +163,15 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
 
     cond do
       archived_suppression?(tenant_id, source_type) ->
-        # Operator archived this source_type — permanent escape hatch, never re-flag.
+        # Operator archived this source_type — escape hatch, never re-flag (until un-archived).
         :suppressed
+
+      existing && not existing.alerted ->
+        # The row was persisted (+ audited atomically) but its POST-commit operator
+        # alert + webhook never fired (worker crashed in the gap). Re-fire them now —
+        # at-least-once recovery — then refresh figures. Without this, a genuine
+        # capture-silence alert would be lost across all retries.
+        recover_lost_notification(tenant_id, existing, last_event_at, hours_stale, sample_count)
 
       existing ->
         update_existing(existing, last_event_at, hours_stale, sample_count)
@@ -127,8 +188,9 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
     end
   end
 
-  # An archived anomaly (resolved or not) permanently suppresses re-detection for
-  # that source_type — the operator's escape hatch for a retired workflow.
+  # An archived anomaly (resolved or not) suppresses re-detection for that
+  # source_type — the operator's escape hatch for a retired workflow, reversible
+  # via IngestionHealth.unarchive_anomaly/3.
   defp archived_suppression?(tenant_id, source_type) do
     IngestionAnomaly
     |> where([a], a.tenant_id == ^tenant_id)
@@ -149,6 +211,49 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
     |> where([a], a.archived == false)
     |> where([a], not is_nil(a.last_event_at) and a.last_event_at >= ^last_event_at)
     |> AdminRepo.exists?()
+  end
+
+  # Recovery path: the row exists but its post-commit notifications never fired
+  # (alerted=false). Re-fire the operator alert + webhook (at-least-once), mark it
+  # alerted, and refresh figures. Idempotent audit already exists from the atomic
+  # detection insert, so we do NOT re-log "detected".
+  defp recover_lost_notification(tenant_id, existing, last_event_at, hours_stale, sample_count) do
+    notify(tenant_id, existing)
+    update_existing(existing, last_event_at, hours_stale, sample_count)
+  end
+
+  # Fire the out-of-band operator alert + webhook, then flip `alerted` so a healthy
+  # run never re-fires. Ordering makes notification at-least-once: if the process
+  # dies before mark_alerted, the next run's recovery branch re-fires.
+  defp notify(tenant_id, anomaly) do
+    fire_operator_alert(tenant_id, anomaly)
+    fire_anomaly_webhook(tenant_id, anomaly)
+    mark_alerted(anomaly)
+  end
+
+  defp mark_alerted(anomaly) do
+    case anomaly |> IngestionAnomaly.mark_alerted_changeset() |> AdminRepo.update() do
+      {:ok, _updated} ->
+        :ok
+
+      {:error, changeset} ->
+        Logger.warning(
+          "IngestionHealthWorker: failed to mark anomaly #{anomaly.id} alerted: " <>
+            "#{inspect(changeset.errors)}"
+        )
+    end
+  end
+
+  # Always-on operator-visible signal, independent of the optional webhook URL and
+  # per-tenant webhook subscriptions: a detected capture-silence is a genuine
+  # operational event, so it must surface in logs/monitoring even when no alert
+  # channel is wired.
+  defp log_detected_alarm(tenant_id, anomaly) do
+    Logger.error(
+      "IngestionHealthWorker: capture-silence detected — tenant=#{tenant_id} " <>
+        "source_type=#{anomaly.source_type} hours_stale=#{anomaly.hours_stale} " <>
+        "sample_count=#{anomaly.sample_count} anomaly_id=#{anomaly.id}"
+    )
   end
 
   # Silently refresh the figures on an existing unresolved anomaly — no re-notify.
@@ -250,10 +355,12 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
         nil
 
       {:ok, %{anomaly: %IngestionAnomaly{} = anomaly}} ->
-        # Audit is now committed atomically with the row; the operator alert + webhook
-        # are Oban-durable once enqueued, so keep them post-commit.
-        fire_operator_alert(tenant_id, anomaly)
-        fire_anomaly_webhook(tenant_id, anomaly)
+        # Audit is committed atomically with the row. The operator alert + webhook
+        # can't join that transaction (Oban jobs insert via Loopctl.Repo), so they run
+        # post-commit and `alerted` is flipped only after they're enqueued — a crash in
+        # the gap leaves alerted=false and the next run re-fires (at-least-once).
+        log_detected_alarm(tenant_id, anomaly)
+        notify(tenant_id, anomaly)
         anomaly
 
       {:error, step, reason, _changes} ->

--- a/lib/loopctl/workers/ingestion_health_worker.ex
+++ b/lib/loopctl/workers/ingestion_health_worker.ex
@@ -18,6 +18,19 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
   On an EXISTING unresolved anomaly it silently refreshes the figures — NO re-notify
   (anti-alarm-fatigue), exactly like `CostAnomalyWorker`.
 
+  ## Suppression: resolve sticks, archive is permanent
+
+  A resolved anomaly is NOT re-created on the next run just because the source_type
+  is still silent — that would re-fire audit + operator alert + webhook every hour
+  and defeat the whole point of resolving. `flag_candidate/1` suppresses re-creation
+  while the current silence is already covered by a resolved anomaly (its
+  `last_event_at` snapshot is at/after the candidate's), and only re-flags once
+  captures RESUME (advancing `last_event_at`) and then go silent again.
+
+  An **archived** anomaly permanently suppresses re-detection for that source_type
+  (the operator's escape hatch for a legitimately-retired workflow) — regardless of
+  its resolved flag.
+
   ## Race-safety
 
   Creation uses the same `insert_all` + `on_conflict: :nothing` against a unique
@@ -25,6 +38,14 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
   uses: `{1, [row]}` means we genuinely inserted (notify); `{0, _}` means a concurrent
   run already inserted + notified (skip). We still check-first so an update never emits
   audit/webhook.
+
+  ## Atomic detection record
+
+  The anomaly row insert and its `detected` audit entry are written in ONE
+  `AdminRepo` transaction, so a crash mid-notify can never leave a persisted anomaly
+  without its audit record (an Oban retry would otherwise find the row and take the
+  no-notify update path, permanently losing the audit entry). The operator alert and
+  webhook enqueues stay post-commit — they are Oban-durable once enqueued.
 
   ## Schedule
 
@@ -41,6 +62,7 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
 
   import Ecto.Query
 
+  alias Ecto.Multi
   alias Loopctl.AdminRepo
   alias Loopctl.Audit
   alias Loopctl.Knowledge.IngestionAnomaly
@@ -74,19 +96,59 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
        }) do
     # Check first (like CostAnomalyWorker) so an UPDATE never emits audit/webhook/alert.
     # The unique partial index still guards against races on the insert path below.
+    # NB: exclude archived rows here — an archived-but-unresolved row must not be
+    # silently update-refreshed; archival is handled explicitly below.
     existing =
       IngestionAnomaly
       |> where([a], a.tenant_id == ^tenant_id)
       |> where([a], a.source_type == ^source_type)
       |> where([a], a.anomaly_type == :capture_silence)
       |> where([a], a.resolved == false)
+      |> where([a], a.archived == false)
       |> AdminRepo.one()
 
-    if existing do
-      update_existing(existing, last_event_at, hours_stale, sample_count)
-    else
-      create_new(tenant_id, source_type, last_event_at, hours_stale, sample_count)
+    cond do
+      archived_suppression?(tenant_id, source_type) ->
+        # Operator archived this source_type — permanent escape hatch, never re-flag.
+        :suppressed
+
+      existing ->
+        update_existing(existing, last_event_at, hours_stale, sample_count)
+
+      acknowledged_silence?(tenant_id, source_type, last_event_at) ->
+        # This exact silence is already covered by a resolved anomaly (no capture
+        # since it was resolved) — suppress re-creation to avoid re-firing audit +
+        # operator alert + webhook every hour. Re-flags only once captures resume
+        # (last_event_at advances) and the source goes silent again.
+        :suppressed
+
+      true ->
+        create_new(tenant_id, source_type, last_event_at, hours_stale, sample_count)
     end
+  end
+
+  # An archived anomaly (resolved or not) permanently suppresses re-detection for
+  # that source_type — the operator's escape hatch for a retired workflow.
+  defp archived_suppression?(tenant_id, source_type) do
+    IngestionAnomaly
+    |> where([a], a.tenant_id == ^tenant_id)
+    |> where([a], a.source_type == ^source_type)
+    |> where([a], a.anomaly_type == :capture_silence)
+    |> where([a], a.archived == true)
+    |> AdminRepo.exists?()
+  end
+
+  # True when a resolved (non-archived) anomaly's snapshot is at/after the current
+  # silence's last_event_at, i.e. no NEW capture has arrived since it was resolved.
+  defp acknowledged_silence?(tenant_id, source_type, last_event_at) do
+    IngestionAnomaly
+    |> where([a], a.tenant_id == ^tenant_id)
+    |> where([a], a.source_type == ^source_type)
+    |> where([a], a.anomaly_type == :capture_silence)
+    |> where([a], a.resolved == true)
+    |> where([a], a.archived == false)
+    |> where([a], not is_nil(a.last_event_at) and a.last_event_at >= ^last_event_at)
+    |> AdminRepo.exists?()
   end
 
   # Silently refresh the figures on an existing unresolved anomaly — no re-notify.
@@ -137,8 +199,11 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
     end
   end
 
-  # insert_all + on_conflict: :nothing against the unresolved unique partial index.
-  # {1, [row]} = we inserted (notify); {0, _} = concurrent run won the race (skip).
+  # insert_all + on_conflict: :nothing against the unresolved unique partial index,
+  # with the `detected` audit entry in the SAME transaction so the anomaly row can
+  # never be persisted without its audit record (an Oban retry would otherwise find
+  # the row, take the no-notify update path, and lose the audit entry permanently).
+  # {1, [row]} = we inserted (audit + notify); {0, _} = concurrent run won the race.
   defp insert_new_anomaly(tenant_id, changeset) do
     now = DateTime.utc_now()
 
@@ -158,26 +223,51 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
       ])
       |> Map.merge(%{id: Ecto.UUID.generate(), inserted_at: now, updated_at: now})
 
-    case AdminRepo.insert_all(IngestionAnomaly, [entry],
-           on_conflict: :nothing,
-           conflict_target:
-             {:unsafe_fragment,
-              ~s|("tenant_id","source_type","anomaly_type") WHERE resolved = false|},
-           returning: true
-         ) do
-      {1, [anomaly]} ->
-        notify_new_anomaly(tenant_id, anomaly)
+    multi =
+      Multi.new()
+      |> Multi.run(:anomaly, fn repo, _changes ->
+        case repo.insert_all(IngestionAnomaly, [entry],
+               on_conflict: :nothing,
+               conflict_target:
+                 {:unsafe_fragment,
+                  ~s|("tenant_id","source_type","anomaly_type") WHERE resolved = false|},
+               returning: true
+             ) do
+          {1, [anomaly]} -> {:ok, anomaly}
+          {0, _} -> {:ok, :conflict}
+        end
+      end)
+      |> Multi.run(:audit, fn _repo, %{anomaly: anomaly} ->
+        case anomaly do
+          :conflict -> {:ok, :skipped}
+          %IngestionAnomaly{} = row -> log_detected(tenant_id, row)
+        end
+      end)
+
+    case AdminRepo.transaction(multi) do
+      {:ok, %{anomaly: :conflict}} ->
+        # Lost the race: the concurrent inserter already emitted audit + alert + webhook.
+        nil
+
+      {:ok, %{anomaly: %IngestionAnomaly{} = anomaly}} ->
+        # Audit is now committed atomically with the row; the operator alert + webhook
+        # are Oban-durable once enqueued, so keep them post-commit.
+        fire_operator_alert(tenant_id, anomaly)
+        fire_anomaly_webhook(tenant_id, anomaly)
         anomaly
 
-      {0, _} ->
-        # Lost the race: the concurrent inserter already emitted audit + alert + webhook.
+      {:error, step, reason, _changes} ->
+        Logger.warning(
+          "IngestionHealthWorker: failed to persist anomaly for tenant #{tenant_id} " <>
+            "(step #{inspect(step)}): #{inspect(reason)}"
+        )
+
         nil
     end
   end
 
-  # Audit + operator alert + per-tenant webhook. Called ONLY for a genuinely persisted
-  # anomaly, never for a conflict/no-op insert.
-  defp notify_new_anomaly(tenant_id, anomaly) do
+  # Writes the `detected` audit entry inside the create transaction (AdminRepo).
+  defp log_detected(tenant_id, anomaly) do
     Audit.create_log_entry(tenant_id, %{
       entity_type: "ingestion_anomaly",
       entity_id: anomaly.id,
@@ -197,19 +287,25 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
         "hours_stale" => anomaly.hours_stale
       }
     })
-
-    fire_operator_alert(tenant_id, anomaly)
-    fire_anomaly_webhook(tenant_id, anomaly)
-
-    :ok
   end
 
   # Enqueue an operator alert through ScaleAlertDeliveryWorker with an id-only payload.
   # That worker resolves SCALE_ALERT_WEBHOOK_URL itself and no-ops when unset, so this
   # is channel-agnostic and safe when unconfigured — we never read/require the URL here.
   defp fire_operator_alert(tenant_id, anomaly) do
+    # Conform to the ScaleAlert operator-alert contract (%{alert, metric, value,
+    # threshold, window_seconds, at}) so the shared alert channel — including
+    # ScaleAlertDeliveryWorker's no-URL skip log that reads metric=value — renders
+    # meaningful values. Extra context fields (tenant_id/source_type/last_event_at)
+    # ride alongside; consumers branch on the `alert` discriminator.
+    staleness_hours = IngestionHealth.staleness_threshold_hours()
+
     payload = %{
       "alert" => "ingestion.capture_silence",
+      "metric" => "ingestion.capture_silence.hours_stale",
+      "value" => anomaly.hours_stale,
+      "threshold" => staleness_hours,
+      "window_seconds" => staleness_hours * 3600,
       "tenant_id" => tenant_id,
       "source_type" => anomaly.source_type,
       "hours_stale" => anomaly.hours_stale,

--- a/lib/loopctl/workers/ingestion_health_worker.ex
+++ b/lib/loopctl/workers/ingestion_health_worker.ex
@@ -1,0 +1,276 @@
+defmodule Loopctl.Workers.IngestionHealthWorker do
+  @moduledoc """
+  Oban worker that runs the ingestion **capture-silence** dead-man's-switch.
+
+  Sibling of `Loopctl.Workers.CostAnomalyWorker`. Each run asks
+  `Loopctl.Knowledge.IngestionHealth.detect/0` for capture-silence candidates
+  (an established article `source_type` for a tenant whose most recent article is
+  older than the staleness threshold) and, for each genuinely-new anomaly, records
+  it and raises the alarm:
+
+  - a `Loopctl.Audit` entry (`entity_type: "ingestion_anomaly"`, `action: "detected"`,
+    `actor_type: "system"`),
+  - an OPERATOR alert enqueued via `Loopctl.Workers.ScaleAlertDeliveryWorker` (which
+    resolves `SCALE_ALERT_WEBHOOK_URL` itself and no-ops when unset — channel-agnostic
+    and safe when unconfigured; this worker never reads the URL), and
+  - a per-tenant `knowledge.ingestion_anomaly_detected` webhook event.
+
+  On an EXISTING unresolved anomaly it silently refreshes the figures — NO re-notify
+  (anti-alarm-fatigue), exactly like `CostAnomalyWorker`.
+
+  ## Race-safety
+
+  Creation uses the same `insert_all` + `on_conflict: :nothing` against a unique
+  partial index (`ingestion_anomalies_unresolved_unique`) that `CostAnomalyWorker`
+  uses: `{1, [row]}` means we genuinely inserted (notify); `{0, _}` means a concurrent
+  run already inserted + notified (skip). We still check-first so an update never emits
+  audit/webhook.
+
+  ## Schedule
+
+  Registered on the Oban crontab (hourly) in `Loopctl.ObanConfig.plugins/0` with a
+  hardcoded schedule — no new env var gates app boot.
+  """
+
+  use Oban.Worker,
+    queue: :analytics,
+    max_attempts: 3,
+    unique: [period: 600, fields: [:worker, :queue]]
+
+  require Logger
+
+  import Ecto.Query
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Audit
+  alias Loopctl.Knowledge.IngestionAnomaly
+  alias Loopctl.Knowledge.IngestionHealth
+  alias Loopctl.Webhooks.EventGenerator
+  alias Loopctl.Webhooks.WebhookEvent
+  alias Loopctl.Workers.ScaleAlertDeliveryWorker
+  alias Loopctl.Workers.WebhookDeliveryWorker
+
+  @webhook_event_type "knowledge.ingestion_anomaly_detected"
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{}) do
+    candidates = IngestionHealth.detect()
+
+    Logger.info(
+      "IngestionHealthWorker: #{length(candidates)} capture-silence candidate(s) detected"
+    )
+
+    Enum.each(candidates, &flag_candidate/1)
+
+    :ok
+  end
+
+  defp flag_candidate(%{
+         tenant_id: tenant_id,
+         source_type: source_type,
+         last_event_at: last_event_at,
+         hours_stale: hours_stale,
+         sample_count: sample_count
+       }) do
+    # Check first (like CostAnomalyWorker) so an UPDATE never emits audit/webhook/alert.
+    # The unique partial index still guards against races on the insert path below.
+    existing =
+      IngestionAnomaly
+      |> where([a], a.tenant_id == ^tenant_id)
+      |> where([a], a.source_type == ^source_type)
+      |> where([a], a.anomaly_type == :capture_silence)
+      |> where([a], a.resolved == false)
+      |> AdminRepo.one()
+
+    if existing do
+      update_existing(existing, last_event_at, hours_stale, sample_count)
+    else
+      create_new(tenant_id, source_type, last_event_at, hours_stale, sample_count)
+    end
+  end
+
+  # Silently refresh the figures on an existing unresolved anomaly — no re-notify.
+  defp update_existing(existing, last_event_at, hours_stale, sample_count) do
+    case existing
+         |> IngestionAnomaly.create_changeset(%{
+           last_event_at: last_event_at,
+           hours_stale: hours_stale,
+           sample_count: sample_count
+         })
+         |> AdminRepo.update() do
+      {:ok, updated} ->
+        updated
+
+      {:error, changeset} ->
+        Logger.warning(
+          "IngestionHealthWorker: failed to update anomaly #{existing.id}: #{inspect(changeset.errors)}"
+        )
+
+        existing
+    end
+  end
+
+  # Validate through the changeset (create == update symmetry — insert_all bypasses it)
+  # then write race-safely; notify ONLY on a genuine insert.
+  defp create_new(tenant_id, source_type, last_event_at, hours_stale, sample_count) do
+    changeset =
+      IngestionAnomaly.create_changeset(
+        %IngestionAnomaly{tenant_id: tenant_id},
+        %{
+          source_type: source_type,
+          anomaly_type: :capture_silence,
+          last_event_at: last_event_at,
+          hours_stale: hours_stale,
+          sample_count: sample_count
+        }
+      )
+
+    if changeset.valid? do
+      insert_new_anomaly(tenant_id, changeset)
+    else
+      Logger.warning(
+        "IngestionHealthWorker: invalid anomaly for tenant #{tenant_id}/#{source_type}, " <>
+          "skipping: #{inspect(changeset.errors)}"
+      )
+
+      nil
+    end
+  end
+
+  # insert_all + on_conflict: :nothing against the unresolved unique partial index.
+  # {1, [row]} = we inserted (notify); {0, _} = concurrent run won the race (skip).
+  defp insert_new_anomaly(tenant_id, changeset) do
+    now = DateTime.utc_now()
+
+    entry =
+      changeset
+      |> Ecto.Changeset.apply_changes()
+      |> Map.take([
+        :tenant_id,
+        :source_type,
+        :anomaly_type,
+        :last_event_at,
+        :hours_stale,
+        :sample_count,
+        :resolved,
+        :archived,
+        :metadata
+      ])
+      |> Map.merge(%{id: Ecto.UUID.generate(), inserted_at: now, updated_at: now})
+
+    case AdminRepo.insert_all(IngestionAnomaly, [entry],
+           on_conflict: :nothing,
+           conflict_target:
+             {:unsafe_fragment,
+              ~s|("tenant_id","source_type","anomaly_type") WHERE resolved = false|},
+           returning: true
+         ) do
+      {1, [anomaly]} ->
+        notify_new_anomaly(tenant_id, anomaly)
+        anomaly
+
+      {0, _} ->
+        # Lost the race: the concurrent inserter already emitted audit + alert + webhook.
+        nil
+    end
+  end
+
+  # Audit + operator alert + per-tenant webhook. Called ONLY for a genuinely persisted
+  # anomaly, never for a conflict/no-op insert.
+  defp notify_new_anomaly(tenant_id, anomaly) do
+    Audit.create_log_entry(tenant_id, %{
+      entity_type: "ingestion_anomaly",
+      entity_id: anomaly.id,
+      action: "detected",
+      actor_type: "system",
+      new_state: %{
+        "anomaly_type" => to_string(anomaly.anomaly_type),
+        "source_type" => anomaly.source_type,
+        "hours_stale" => anomaly.hours_stale,
+        "sample_count" => anomaly.sample_count,
+        "last_event_at" => iso8601(anomaly.last_event_at)
+      },
+      metadata: %{
+        "anomaly_id" => anomaly.id,
+        "source_type" => anomaly.source_type,
+        "anomaly_type" => to_string(anomaly.anomaly_type),
+        "hours_stale" => anomaly.hours_stale
+      }
+    })
+
+    fire_operator_alert(tenant_id, anomaly)
+    fire_anomaly_webhook(tenant_id, anomaly)
+
+    :ok
+  end
+
+  # Enqueue an operator alert through ScaleAlertDeliveryWorker with an id-only payload.
+  # That worker resolves SCALE_ALERT_WEBHOOK_URL itself and no-ops when unset, so this
+  # is channel-agnostic and safe when unconfigured — we never read/require the URL here.
+  defp fire_operator_alert(tenant_id, anomaly) do
+    payload = %{
+      "alert" => "ingestion.capture_silence",
+      "tenant_id" => tenant_id,
+      "source_type" => anomaly.source_type,
+      "hours_stale" => anomaly.hours_stale,
+      "last_event_at" => iso8601(anomaly.last_event_at),
+      "at" => DateTime.utc_now() |> DateTime.to_iso8601()
+    }
+
+    case %{payload: payload} |> ScaleAlertDeliveryWorker.new() |> Oban.insert() do
+      {:ok, _job} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning(
+          "IngestionHealthWorker: failed to enqueue operator alert for anomaly " <>
+            "#{anomaly.id}: #{inspect(reason)}"
+        )
+    end
+  end
+
+  # Fires a tenant-scoped knowledge.ingestion_anomaly_detected webhook. Ingestion
+  # anomalies are tenant-wide (no project), so project_id is nil — only tenant-wide
+  # webhook subscriptions match. Errors are logged, not raised (the anomaly is already
+  # persisted; losing the webhook must not lose the anomaly).
+  defp fire_anomaly_webhook(tenant_id, anomaly) do
+    webhooks = EventGenerator.matching_webhooks(tenant_id, @webhook_event_type, nil)
+
+    if webhooks != [] do
+      payload = %{
+        "anomaly_id" => anomaly.id,
+        "source_type" => anomaly.source_type,
+        "anomaly_type" => to_string(anomaly.anomaly_type),
+        "hours_stale" => anomaly.hours_stale,
+        "sample_count" => anomaly.sample_count,
+        "last_event_at" => iso8601(anomaly.last_event_at)
+      }
+
+      Enum.each(webhooks, &deliver_anomaly_event(tenant_id, &1, payload, anomaly.id))
+    end
+  end
+
+  defp deliver_anomaly_event(tenant_id, webhook, payload, anomaly_id) do
+    with {:ok, event} <-
+           %WebhookEvent{tenant_id: tenant_id, webhook_id: webhook.id}
+           |> WebhookEvent.create_changeset(%{
+             event_type: @webhook_event_type,
+             payload: payload
+           })
+           |> AdminRepo.insert(),
+         {:ok, _job} <-
+           WebhookDeliveryWorker.new(%{webhook_event_id: event.id, tenant_id: tenant_id})
+           |> Oban.insert() do
+      :ok
+    else
+      {:error, reason} ->
+        Logger.warning(
+          "IngestionHealthWorker: failed to create #{@webhook_event_type} webhook event " <>
+            "for anomaly #{anomaly_id}: #{inspect(reason)}"
+        )
+    end
+  end
+
+  defp iso8601(nil), do: nil
+  defp iso8601(%DateTime{} = dt), do: DateTime.to_iso8601(dt)
+end

--- a/lib/loopctl_web/controllers/ingestion_anomaly_controller.ex
+++ b/lib/loopctl_web/controllers/ingestion_anomaly_controller.ex
@@ -3,8 +3,9 @@ defmodule LoopctlWeb.IngestionAnomalyController do
   Controller for ingestion capture-silence anomaly management.
 
   - `GET /api/v1/ingestion-anomalies` -- list unresolved anomalies (orchestrator+)
-  - `PATCH /api/v1/ingestion-anomalies/:id` -- mark anomaly as resolved, or
-    `?archived=true` to permanently archive a retired source_type (user+)
+  - `PATCH /api/v1/ingestion-anomalies/:id` -- mark anomaly as resolved;
+    `?archived=true` archives a retired source_type, `?archived=false` un-archives
+    it (restoring monitoring) (user+)
 
   Role gating mirrors `LoopctlWeb.CostAnomalyController` exactly: listing at the
   same read role cost anomalies use, and resolution at `:user` (a custody-adjacent
@@ -51,9 +52,10 @@ defmodule LoopctlWeb.IngestionAnomalyController do
       ],
       resolved: [
         in: :query,
-        type: :boolean,
+        type: :string,
         description:
-          "Filter by resolved status. true = resolved only, false = unresolved only (default: false)"
+          "Filter by resolved status: true = resolved only, false = unresolved only " <>
+            "(default: false), all = both resolved and unresolved (complete timeline)"
       ],
       page: [in: :query, type: :integer, description: "Page number"],
       page_size: [in: :query, type: :integer, description: "Items per page"]
@@ -73,17 +75,21 @@ defmodule LoopctlWeb.IngestionAnomalyController do
   )
 
   operation(:update,
-    summary: "Resolve or archive ingestion anomaly",
+    summary: "Resolve, archive, or un-archive ingestion anomaly",
     description:
       "Marks an ingestion capture-silence anomaly as resolved. Pass ?archived=true to " <>
-        "instead ARCHIVE it — the permanent escape hatch for a retired source_type, which " <>
-        "hides it from the default list and suppresses re-detection.",
+        "instead ARCHIVE it — the escape hatch for a retired source_type, which hides it " <>
+        "from the default list and suppresses re-detection. Pass ?archived=false to " <>
+        "UN-ARCHIVE it, restoring monitoring for a mistakenly-archived source_type. A " <>
+        "malformed ?archived value is rejected with 422.",
     parameters: [
       id: [in: :path, type: :string, description: "Anomaly UUID"],
       archived: [
         in: :query,
         type: :boolean,
-        description: "When true, archive (permanently suppress) instead of resolve"
+        description:
+          "true = archive (suppress re-detection); false = un-archive (restore monitoring); " <>
+            "omit = resolve"
       ]
     ],
     responses: %{
@@ -123,7 +129,7 @@ defmodule LoopctlWeb.IngestionAnomalyController do
       |> maybe_add_opt(:source_type, params["source_type"])
       |> maybe_add_opt(:anomaly_type, params["anomaly_type"])
       |> maybe_add_opt(:include_archived, parse_bool(params["include_archived"]))
-      |> maybe_add_opt(:resolved, parse_bool(params["resolved"]))
+      |> maybe_add_opt(:resolved, parse_resolved(params["resolved"]))
       |> maybe_add_opt(:page, parse_int(params["page"]))
       |> maybe_add_opt(:page_size, parse_int(params["page_size"]))
 
@@ -143,7 +149,9 @@ defmodule LoopctlWeb.IngestionAnomalyController do
   @doc """
   PATCH /api/v1/ingestion-anomalies/:id
 
-  Marks an ingestion anomaly as resolved, or archives it when `?archived=true`.
+  Resolves the anomaly, or (with `?archived=true`) archives it, or (with
+  `?archived=false`) un-archives it. A malformed `?archived` value yields 422 so a
+  state-changing intent is never silently downgraded to a resolve.
   """
   def update(conn, %{"id" => id} = params) do
     api_key = conn.assigns.current_api_key
@@ -155,14 +163,8 @@ defmodule LoopctlWeb.IngestionAnomalyController do
       actor_type: "api_key"
     ]
 
-    result =
-      if parse_bool(params["archived"]) == true do
-        IngestionHealth.archive_anomaly(tenant_id, id, audit_opts)
-      else
-        IngestionHealth.resolve_anomaly(tenant_id, id, audit_opts)
-      end
-
-    with {:ok, anomaly} <- result do
+    with {:ok, action} <- archived_action(params),
+         {:ok, anomaly} <- apply_action(action, tenant_id, id, audit_opts) do
       json(conn, %{
         ingestion_anomaly: %{
           id: anomaly.id,
@@ -174,6 +176,38 @@ defmodule LoopctlWeb.IngestionAnomalyController do
     end
   end
 
+  # Determine intent from ?archived. Absent -> resolve. Explicit true/false ->
+  # archive/unarchive. Any other (malformed) value is rejected — never silently
+  # downgraded to resolve, which would be a wrong state change for the operator.
+  defp archived_action(params) do
+    case Map.fetch(params, "archived") do
+      :error ->
+        {:ok, :resolve}
+
+      {:ok, raw} ->
+        case parse_bool(raw) do
+          true ->
+            {:ok, :archive}
+
+          false ->
+            {:ok, :unarchive}
+
+          nil ->
+            {:error, :unprocessable_entity,
+             "Invalid 'archived' value #{inspect(raw)}; expected true or false."}
+        end
+    end
+  end
+
+  defp apply_action(:archive, tenant_id, id, opts),
+    do: IngestionHealth.archive_anomaly(tenant_id, id, opts)
+
+  defp apply_action(:unarchive, tenant_id, id, opts),
+    do: IngestionHealth.unarchive_anomaly(tenant_id, id, opts)
+
+  defp apply_action(:resolve, tenant_id, id, opts),
+    do: IngestionHealth.resolve_anomaly(tenant_id, id, opts)
+
   # --- Private helpers ---
 
   defp parse_bool(nil), do: nil
@@ -182,6 +216,11 @@ defmodule LoopctlWeb.IngestionAnomalyController do
   defp parse_bool(true), do: true
   defp parse_bool(false), do: false
   defp parse_bool(_), do: nil
+
+  # `resolved=all` is a sentinel meaning "both resolved and unresolved"; anything
+  # else parses as a boolean (nil -> omitted -> context default of unresolved-only).
+  defp parse_resolved("all"), do: :all
+  defp parse_resolved(other), do: parse_bool(other)
 
   defp parse_int(nil), do: nil
 

--- a/lib/loopctl_web/controllers/ingestion_anomaly_controller.ex
+++ b/lib/loopctl_web/controllers/ingestion_anomaly_controller.ex
@@ -1,0 +1,183 @@
+defmodule LoopctlWeb.IngestionAnomalyController do
+  @moduledoc """
+  Controller for ingestion capture-silence anomaly management.
+
+  - `GET /api/v1/ingestion-anomalies` -- list unresolved anomalies (orchestrator+)
+  - `PATCH /api/v1/ingestion-anomalies/:id` -- mark anomaly as resolved (user+)
+
+  Role gating mirrors `LoopctlWeb.CostAnomalyController` exactly: listing at the
+  same read role cost anomalies use, and resolution at `:user` (a custody-adjacent
+  action, additionally human-anchor gated).
+  """
+
+  use LoopctlWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Loopctl.ApiSpec.Schemas
+  alias Loopctl.Knowledge.IngestionHealth
+
+  action_fallback LoopctlWeb.FallbackController
+
+  plug LoopctlWeb.Plugs.RequireRole, [role: :orchestrator] when action in [:index]
+  plug LoopctlWeb.Plugs.RequireRole, [role: :user] when action in [:update]
+
+  # Work-breakdown / custody-adjacent surface requires a human-anchored tenant.
+  plug LoopctlWeb.Plugs.RequireHumanAnchor when action in [:update]
+
+  tags(["Knowledge Wiki"])
+
+  operation(:index,
+    summary: "List ingestion capture-silence anomalies",
+    description:
+      "Returns unresolved ingestion capture-silence anomalies for the tenant. " <>
+        "Filterable by source_type and anomaly_type. " <>
+        "Archived anomalies are excluded by default; use ?include_archived=true to include them.",
+    parameters: [
+      source_type: [
+        in: :query,
+        type: :string,
+        description: "Filter by monitored article source_type (e.g. session_log)"
+      ],
+      anomaly_type: [
+        in: :query,
+        type: :string,
+        description: "Filter by anomaly type: capture_silence"
+      ],
+      include_archived: [
+        in: :query,
+        type: :boolean,
+        description: "Include archived anomalies (default: false)"
+      ],
+      resolved: [
+        in: :query,
+        type: :boolean,
+        description:
+          "Filter by resolved status. true = resolved only, false = unresolved only (default: false)"
+      ],
+      page: [in: :query, type: :integer, description: "Page number"],
+      page_size: [in: :query, type: :integer, description: "Items per page"]
+    ],
+    responses: %{
+      200 =>
+        {"Anomaly list", "application/json",
+         %OpenApiSpex.Schema{
+           type: :object,
+           properties: %{
+             data: %OpenApiSpex.Schema{type: :array, items: %OpenApiSpex.Schema{type: :object}},
+             meta: Schemas.PaginationMeta
+           }
+         }},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  operation(:update,
+    summary: "Resolve ingestion anomaly",
+    description: "Marks an ingestion capture-silence anomaly as resolved.",
+    parameters: [
+      id: [in: :path, type: :string, description: "Anomaly UUID"]
+    ],
+    responses: %{
+      200 =>
+        {"Anomaly resolved", "application/json",
+         %OpenApiSpex.Schema{
+           type: :object,
+           description: "Confirmation of resolution",
+           properties: %{
+             ingestion_anomaly: %OpenApiSpex.Schema{
+               type: :object,
+               properties: %{
+                 id: %OpenApiSpex.Schema{type: :string, format: :uuid},
+                 resolved: %OpenApiSpex.Schema{type: :boolean, example: true},
+                 updated_at: %OpenApiSpex.Schema{type: :string, format: :"date-time"}
+               }
+             }
+           }
+         }},
+      404 => {"Anomaly not found", "application/json", Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  @doc """
+  GET /api/v1/ingestion-anomalies
+
+  Lists unresolved ingestion capture-silence anomalies for the tenant.
+  """
+  def index(conn, params) do
+    api_key = conn.assigns.current_api_key
+    tenant_id = api_key.tenant_id
+
+    opts =
+      []
+      |> maybe_add_opt(:source_type, params["source_type"])
+      |> maybe_add_opt(:anomaly_type, params["anomaly_type"])
+      |> maybe_add_opt(:include_archived, parse_bool(params["include_archived"]))
+      |> maybe_add_opt(:resolved, parse_bool(params["resolved"]))
+      |> maybe_add_opt(:page, parse_int(params["page"]))
+      |> maybe_add_opt(:page_size, parse_int(params["page_size"]))
+
+    {:ok, result} = IngestionHealth.list_anomalies(tenant_id, opts)
+
+    json(conn, %{
+      data: result.data,
+      meta: %{
+        page: result.page,
+        page_size: result.page_size,
+        total_count: result.total,
+        total_pages: ceil_div(result.total, result.page_size)
+      }
+    })
+  end
+
+  @doc """
+  PATCH /api/v1/ingestion-anomalies/:id
+
+  Marks an ingestion anomaly as resolved.
+  """
+  def update(conn, %{"id" => id}) do
+    api_key = conn.assigns.current_api_key
+    tenant_id = api_key.tenant_id
+
+    audit_opts = [
+      actor_id: api_key.id,
+      actor_label: api_key.name,
+      actor_type: "api_key"
+    ]
+
+    with {:ok, anomaly} <- IngestionHealth.resolve_anomaly(tenant_id, id, audit_opts) do
+      json(conn, %{
+        ingestion_anomaly: %{
+          id: anomaly.id,
+          resolved: anomaly.resolved,
+          updated_at: anomaly.updated_at
+        }
+      })
+    end
+  end
+
+  # --- Private helpers ---
+
+  defp parse_bool(nil), do: nil
+  defp parse_bool("true"), do: true
+  defp parse_bool("false"), do: false
+  defp parse_bool(true), do: true
+  defp parse_bool(false), do: false
+  defp parse_bool(_), do: nil
+
+  defp parse_int(nil), do: nil
+
+  defp parse_int(val) when is_binary(val) do
+    case Integer.parse(val) do
+      {n, _} -> n
+      :error -> nil
+    end
+  end
+
+  defp parse_int(val) when is_integer(val), do: val
+
+  defp maybe_add_opt(opts, _key, nil), do: opts
+  defp maybe_add_opt(opts, key, value), do: Keyword.put(opts, key, value)
+
+  defp ceil_div(numerator, denominator), do: ceil(numerator / denominator)
+end

--- a/lib/loopctl_web/controllers/ingestion_anomaly_controller.ex
+++ b/lib/loopctl_web/controllers/ingestion_anomaly_controller.ex
@@ -3,7 +3,8 @@ defmodule LoopctlWeb.IngestionAnomalyController do
   Controller for ingestion capture-silence anomaly management.
 
   - `GET /api/v1/ingestion-anomalies` -- list unresolved anomalies (orchestrator+)
-  - `PATCH /api/v1/ingestion-anomalies/:id` -- mark anomaly as resolved (user+)
+  - `PATCH /api/v1/ingestion-anomalies/:id` -- mark anomaly as resolved, or
+    `?archived=true` to permanently archive a retired source_type (user+)
 
   Role gating mirrors `LoopctlWeb.CostAnomalyController` exactly: listing at the
   same read role cost anomalies use, and resolution at `:user` (a custody-adjacent
@@ -72,23 +73,32 @@ defmodule LoopctlWeb.IngestionAnomalyController do
   )
 
   operation(:update,
-    summary: "Resolve ingestion anomaly",
-    description: "Marks an ingestion capture-silence anomaly as resolved.",
+    summary: "Resolve or archive ingestion anomaly",
+    description:
+      "Marks an ingestion capture-silence anomaly as resolved. Pass ?archived=true to " <>
+        "instead ARCHIVE it — the permanent escape hatch for a retired source_type, which " <>
+        "hides it from the default list and suppresses re-detection.",
     parameters: [
-      id: [in: :path, type: :string, description: "Anomaly UUID"]
+      id: [in: :path, type: :string, description: "Anomaly UUID"],
+      archived: [
+        in: :query,
+        type: :boolean,
+        description: "When true, archive (permanently suppress) instead of resolve"
+      ]
     ],
     responses: %{
       200 =>
-        {"Anomaly resolved", "application/json",
+        {"Anomaly resolved or archived", "application/json",
          %OpenApiSpex.Schema{
            type: :object,
-           description: "Confirmation of resolution",
+           description: "Confirmation of resolution or archival",
            properties: %{
              ingestion_anomaly: %OpenApiSpex.Schema{
                type: :object,
                properties: %{
                  id: %OpenApiSpex.Schema{type: :string, format: :uuid},
                  resolved: %OpenApiSpex.Schema{type: :boolean, example: true},
+                 archived: %OpenApiSpex.Schema{type: :boolean, example: false},
                  updated_at: %OpenApiSpex.Schema{type: :string, format: :"date-time"}
                }
              }
@@ -133,9 +143,9 @@ defmodule LoopctlWeb.IngestionAnomalyController do
   @doc """
   PATCH /api/v1/ingestion-anomalies/:id
 
-  Marks an ingestion anomaly as resolved.
+  Marks an ingestion anomaly as resolved, or archives it when `?archived=true`.
   """
-  def update(conn, %{"id" => id}) do
+  def update(conn, %{"id" => id} = params) do
     api_key = conn.assigns.current_api_key
     tenant_id = api_key.tenant_id
 
@@ -145,11 +155,19 @@ defmodule LoopctlWeb.IngestionAnomalyController do
       actor_type: "api_key"
     ]
 
-    with {:ok, anomaly} <- IngestionHealth.resolve_anomaly(tenant_id, id, audit_opts) do
+    result =
+      if parse_bool(params["archived"]) == true do
+        IngestionHealth.archive_anomaly(tenant_id, id, audit_opts)
+      else
+        IngestionHealth.resolve_anomaly(tenant_id, id, audit_opts)
+      end
+
+    with {:ok, anomaly} <- result do
       json(conn, %{
         ingestion_anomaly: %{
           id: anomaly.id,
           resolved: anomaly.resolved,
+          archived: anomaly.archived,
           updated_at: anomaly.updated_at
         }
       })

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -308,6 +308,10 @@ defmodule LoopctlWeb.Router do
     get "/cost-anomalies", CostAnomalyController, :index
     patch "/cost-anomalies/:id", CostAnomalyController, :update
 
+    # Ingestion capture-silence anomalies (dead-man's-switch for knowledge capture)
+    get "/ingestion-anomalies", IngestionAnomalyController, :index
+    patch "/ingestion-anomalies/:id", IngestionAnomalyController, :update
+
     # Token analytics (Epic 21)
     get "/analytics/agents", AnalyticsController, :agents
     get "/analytics/epics", AnalyticsController, :epics

--- a/priv/repo/migrations/20260717183313_create_ingestion_anomalies.exs
+++ b/priv/repo/migrations/20260717183313_create_ingestion_anomalies.exs
@@ -1,0 +1,51 @@
+defmodule Loopctl.Repo.Migrations.CreateIngestionAnomalies do
+  use Ecto.Migration
+  import Loopctl.Repo.RlsHelpers
+
+  def change do
+    create table(:ingestion_anomalies, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      add :tenant_id, references(:tenants, type: :binary_id, on_delete: :delete_all), null: false
+
+      # WHAT went silent: the article `source_type` (e.g. "session_log") whose
+      # captured-write stream stopped, and WHY it was flagged.
+      add :source_type, :string, null: false
+      add :anomaly_type, :string, null: false
+
+      # The freshness snapshot at detection time.
+      add :last_event_at, :utc_datetime_usec
+      add :hours_stale, :integer, null: false
+      add :sample_count, :integer, null: false
+
+      add :resolved, :boolean, default: false, null: false
+      # Mirror cost_anomalies: archived rows are excluded from the default list.
+      add :archived, :boolean, default: false, null: false
+      add :metadata, :map, default: %{}
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    # anomaly_type CHECK constraint (extensible list — mirrors cost_anomalies).
+    execute(
+      "ALTER TABLE ingestion_anomalies ADD CONSTRAINT ingestion_anomalies_anomaly_type_check CHECK (anomaly_type IN ('capture_silence'))",
+      "ALTER TABLE ingestion_anomalies DROP CONSTRAINT ingestion_anomalies_anomaly_type_check"
+    )
+
+    # Lookup indexes for common queries.
+    create index(:ingestion_anomalies, [:tenant_id])
+    create index(:ingestion_anomalies, [:tenant_id, :resolved])
+    create index(:ingestion_anomalies, [:tenant_id, :source_type])
+
+    # Race-safe create: ONE unresolved anomaly per (tenant, source_type, anomaly_type).
+    # `insert_all` + `on_conflict: :nothing` targets this exact partial index so a
+    # concurrent detector run reports 0 rows written (skip notify) instead of
+    # duplicating. Mirrors :cost_anomalies_unresolved_unique exactly.
+    create unique_index(:ingestion_anomalies, [:tenant_id, :source_type, :anomaly_type],
+             where: "resolved = false",
+             name: :ingestion_anomalies_unresolved_unique
+           )
+
+    enable_rls(:ingestion_anomalies)
+  end
+end

--- a/priv/repo/migrations/20260717190000_add_articles_source_type_index.exs
+++ b/priv/repo/migrations/20260717190000_add_articles_source_type_index.exs
@@ -1,15 +1,42 @@
 defmodule Loopctl.Repo.Migrations.AddArticlesSourceTypeIndex do
   use Ecto.Migration
 
-  # Supports the hourly IngestionHealth capture-silence scan
-  # (Loopctl.Knowledge.IngestionHealth.detect/1): it joins articles to active
-  # tenants, filters `inserted_at >= window_start`, groups by
-  # (tenant_id, source_type) and reads max(inserted_at). The existing articles
-  # indexes cover (tenant_id) and (tenant_id, source_id, inserted_at, id) but none
-  # include source_type, so without this the scan reads ALL of a large-corpus
-  # tenant's articles via the (tenant_id) index and filters source_type on the heap.
-  # This composite makes the grouped scan selective on the hot read path.
-  def change do
-    create index(:articles, [:tenant_id, :source_type, :inserted_at])
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  @moduledoc """
+  Index backing the hourly IngestionHealth capture-silence scan
+  (`Loopctl.Knowledge.IngestionHealth.detect/1`).
+
+  detect/1 is a GLOBAL scan: it filters `articles.inserted_at >= window_start`
+  (the rolling 30-day establishment window), joins to active tenants, groups by
+  (tenant_id, source_type) and reads max(inserted_at). The COST that matters is the
+  read must be bounded to the recency window, NOT the whole corpus.
+
+  Column order therefore LEADS with `inserted_at` so the `inserted_at >= window_start`
+  predicate is an index RANGE SEEK — the planner reads only the last-30-days slice of
+  the index instead of full-scanning `articles` (which would grow O(total articles ever)
+  as the corpus ages). `(tenant_id, source_type)` trail the range column so the scan is
+  covering for the group/select (index-only), avoiding heap fetches. An earlier draft
+  put `inserted_at` LAST, which gave the planner no leading equality/range column to
+  seek on — that could not bound the read to the window at scale.
+
+  Built CONCURRENTLY (outside a DDL transaction) so the build does not take a SHARE
+  lock that blocks INSERT/UPDATE/DELETE on the hot, growing `articles` table — i.e. so
+  the migration for a capture-silence monitor does not itself cause capture silence at
+  deploy time. Mirrors the existing articles-index convention (metadata GIN, source
+  keyset, general keyset), all of which use @disable_ddl_transaction + CONCURRENTLY.
+  """
+
+  def up do
+    execute("""
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS articles_inserted_tenant_source_idx
+    ON articles (inserted_at, tenant_id, source_type)
+    WHERE source_type IS NOT NULL
+    """)
+  end
+
+  def down do
+    execute("DROP INDEX CONCURRENTLY IF EXISTS articles_inserted_tenant_source_idx")
   end
 end

--- a/priv/repo/migrations/20260717190000_add_articles_source_type_index.exs
+++ b/priv/repo/migrations/20260717190000_add_articles_source_type_index.exs
@@ -1,0 +1,15 @@
+defmodule Loopctl.Repo.Migrations.AddArticlesSourceTypeIndex do
+  use Ecto.Migration
+
+  # Supports the hourly IngestionHealth capture-silence scan
+  # (Loopctl.Knowledge.IngestionHealth.detect/1): it joins articles to active
+  # tenants, filters `inserted_at >= window_start`, groups by
+  # (tenant_id, source_type) and reads max(inserted_at). The existing articles
+  # indexes cover (tenant_id) and (tenant_id, source_id, inserted_at, id) but none
+  # include source_type, so without this the scan reads ALL of a large-corpus
+  # tenant's articles via the (tenant_id) index and filters source_type on the heap.
+  # This composite makes the grouped scan selective on the hot read path.
+  def change do
+    create index(:articles, [:tenant_id, :source_type, :inserted_at])
+  end
+end

--- a/priv/repo/migrations/20260717200000_add_ingestion_anomalies_alerted.exs
+++ b/priv/repo/migrations/20260717200000_add_ingestion_anomalies_alerted.exs
@@ -1,0 +1,22 @@
+defmodule Loopctl.Repo.Migrations.AddIngestionAnomaliesAlerted do
+  use Ecto.Migration
+
+  @moduledoc """
+  Adds `alerted` to `ingestion_anomalies` to make operator-alert + webhook
+  notification AT-LEAST-ONCE across worker crashes/retries.
+
+  The anomaly row + its `detected` audit entry are inserted atomically, but the
+  operator alert and webhook enqueues run POST-commit. If the worker crashed
+  between commit and enqueue, the Oban retry would find the now-committed
+  unresolved row and take the no-notify update path — silently losing the alert
+  for a genuine capture-silence event across all retries. `alerted` records
+  whether the out-of-band notifications were successfully fired, so a later run
+  that sees an unresolved-but-unalerted row re-fires them (idempotent recovery).
+  """
+
+  def change do
+    alter table(:ingestion_anomalies) do
+      add :alerted, :boolean, default: false, null: false
+    end
+  end
+end

--- a/test/loopctl/knowledge/ingestion_health_test.exs
+++ b/test/loopctl/knowledge/ingestion_health_test.exs
@@ -68,6 +68,24 @@ defmodule Loopctl.Knowledge.IngestionHealthTest do
       assert length(candidates) == 1
     end
 
+    test "honors a per-source-type establishment threshold override" do
+      tenant = fixture(:tenant)
+      # Only 2 stale captures — below the global threshold of 5, but an override
+      # lowers the bar for this low-volume-but-critical source_type.
+      for _ <- 1..2, do: captured(tenant.id, "session_log", @stale_hours)
+
+      candidates =
+        IngestionHealth.detect(%{
+          monitored_source_types: ["session_log"],
+          established_threshold: 5,
+          established_threshold_overrides: %{"session_log" => 2},
+          staleness_threshold_hours: 72
+        })
+        |> Enum.filter(&(&1.tenant_id == tenant.id))
+
+      assert [%{source_type: "session_log", sample_count: 2}] = candidates
+    end
+
     test "tenant isolation — a stale tenant does not surface another tenant's data" do
       tenant_a = fixture(:tenant)
       tenant_b = fixture(:tenant)
@@ -183,6 +201,128 @@ defmodule Loopctl.Knowledge.IngestionHealthTest do
 
       assert data == []
       assert total == 0
+    end
+
+    test "resolved: :all returns both resolved and unresolved" do
+      tenant = fixture(:tenant)
+      fixture(:ingestion_anomaly, %{tenant_id: tenant.id, source_type: "session_log"})
+
+      fixture(:ingestion_anomaly, %{
+        tenant_id: tenant.id,
+        source_type: "manual",
+        resolved: true
+      })
+
+      {:ok, %{total: default_total}} = IngestionHealth.list_anomalies(tenant.id)
+      assert default_total == 1
+
+      {:ok, %{total: all_total}} = IngestionHealth.list_anomalies(tenant.id, resolved: :all)
+      assert all_total == 2
+    end
+
+    test "recomputes hours_stale for an unresolved anomaly at read time" do
+      tenant = fixture(:tenant)
+      # last_event_at 200h ago but a stale detection-time snapshot of only 80h.
+      anomaly =
+        fixture(:ingestion_anomaly, %{
+          tenant_id: tenant.id,
+          source_type: "session_log",
+          hours_stale: 80,
+          last_event_at: DateTime.add(DateTime.utc_now(), -200, :hour)
+        })
+
+      {:ok, %{data: [read]}} = IngestionHealth.list_anomalies(tenant.id)
+      assert read.id == anomaly.id
+      # Read-time recompute reports the TRUE current age (~200h), not the frozen 80h.
+      assert read.hours_stale >= 199
+    end
+  end
+
+  describe "unarchive_anomaly/3" do
+    test "flips archived back to false and restores monitoring, with an audit entry" do
+      tenant = fixture(:tenant)
+      anomaly = fixture(:ingestion_anomaly, %{tenant_id: tenant.id, archived: true})
+
+      assert {:ok, unarchived} =
+               IngestionHealth.unarchive_anomaly(tenant.id, anomaly.id, actor_type: "api_key")
+
+      assert unarchived.archived == false
+
+      audit_count =
+        from(a in AuditLog,
+          where:
+            a.tenant_id == ^tenant.id and a.entity_type == "ingestion_anomaly" and
+              a.action == "unarchived" and a.entity_id == ^anomaly.id
+        )
+        |> AdminRepo.aggregate(:count)
+
+      assert audit_count == 1
+    end
+
+    test "un-archiving a non-archived anomaly is an idempotent no-op (no bogus audit)" do
+      tenant = fixture(:tenant)
+      anomaly = fixture(:ingestion_anomaly, %{tenant_id: tenant.id, archived: false})
+
+      assert {:ok, result} = IngestionHealth.unarchive_anomaly(tenant.id, anomaly.id)
+      assert result.archived == false
+
+      audit_count =
+        from(a in AuditLog,
+          where:
+            a.tenant_id == ^tenant.id and a.entity_type == "ingestion_anomaly" and
+              a.action == "unarchived"
+        )
+        |> AdminRepo.aggregate(:count)
+
+      assert audit_count == 0
+    end
+
+    test "returns :not_found for another tenant's anomaly" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      anomaly = fixture(:ingestion_anomaly, %{tenant_id: tenant_a.id, archived: true})
+
+      assert {:error, :not_found} = IngestionHealth.unarchive_anomaly(tenant_b.id, anomaly.id)
+    end
+  end
+
+  describe "auto_resolve_recovered/0" do
+    test "resolves an open anomaly whose captures have resumed" do
+      tenant = fixture(:tenant)
+
+      anomaly =
+        fixture(:ingestion_anomaly, %{
+          tenant_id: tenant.id,
+          source_type: "session_log",
+          last_event_at: DateTime.add(DateTime.utc_now(), -100, :hour)
+        })
+
+      # A capture ARRIVES after the anomaly's last_event_at → the stream recovered.
+      captured(tenant.id, "session_log", 1)
+
+      assert IngestionHealth.auto_resolve_recovered() >= 1
+
+      {:ok, reloaded} = IngestionHealth.get_anomaly(tenant.id, anomaly.id)
+      assert reloaded.resolved == true
+    end
+
+    test "leaves an open anomaly untouched while the source is still silent" do
+      tenant = fixture(:tenant)
+
+      anomaly =
+        fixture(:ingestion_anomaly, %{
+          tenant_id: tenant.id,
+          source_type: "session_log",
+          last_event_at: DateTime.add(DateTime.utc_now(), -100, :hour)
+        })
+
+      # Only OLD captures (older than last_event_at) — no recovery.
+      captured(tenant.id, "session_log", 150)
+
+      IngestionHealth.auto_resolve_recovered()
+
+      {:ok, reloaded} = IngestionHealth.get_anomaly(tenant.id, anomaly.id)
+      assert reloaded.resolved == false
     end
   end
 

--- a/test/loopctl/knowledge/ingestion_health_test.exs
+++ b/test/loopctl/knowledge/ingestion_health_test.exs
@@ -1,0 +1,173 @@
+defmodule Loopctl.Knowledge.IngestionHealthTest do
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Audit.AuditLog
+  alias Loopctl.Knowledge.IngestionHealth
+
+  import Ecto.Query
+
+  @stale_hours 96
+  @fresh_hours 1
+
+  defp captured(tenant_id, source_type, hours_ago) do
+    captured_article(%{
+      tenant_id: tenant_id,
+      source_type: source_type,
+      status: :published,
+      inserted_at: DateTime.add(DateTime.utc_now(), -hours_ago, :hour)
+    })
+  end
+
+  describe "detect/0" do
+    test "returns a candidate for an established + stale source_type" do
+      tenant = fixture(:tenant)
+      for _ <- 1..5, do: captured(tenant.id, "session_log", @stale_hours)
+
+      candidates = IngestionHealth.detect()
+
+      assert [%{tenant_id: tid, source_type: "session_log"} = candidate] =
+               Enum.filter(candidates, &(&1.tenant_id == tenant.id))
+
+      assert tid == tenant.id
+      assert candidate.sample_count == 5
+      assert candidate.hours_stale >= 72
+      assert %DateTime{} = candidate.last_event_at
+    end
+
+    test "returns no candidate for a fresh source_type" do
+      tenant = fixture(:tenant)
+      for _ <- 1..5, do: captured(tenant.id, "session_log", @fresh_hours)
+
+      assert IngestionHealth.detect() |> Enum.filter(&(&1.tenant_id == tenant.id)) == []
+    end
+
+    test "returns no candidate below the established threshold" do
+      tenant = fixture(:tenant)
+      for _ <- 1..4, do: captured(tenant.id, "session_log", @stale_hours)
+
+      assert IngestionHealth.detect() |> Enum.filter(&(&1.tenant_id == tenant.id)) == []
+    end
+
+    test "honors an explicit config passed to detect/1" do
+      tenant = fixture(:tenant)
+      for _ <- 1..3, do: captured(tenant.id, "session_log", @stale_hours)
+
+      # Lower the established threshold so 3 samples qualify.
+      candidates =
+        IngestionHealth.detect(%{
+          monitored_source_types: ["session_log"],
+          established_threshold: 3,
+          staleness_threshold_hours: 72
+        })
+        |> Enum.filter(&(&1.tenant_id == tenant.id))
+
+      assert length(candidates) == 1
+    end
+
+    test "tenant isolation — a stale tenant does not surface another tenant's data" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+
+      for _ <- 1..5, do: captured(tenant_a.id, "session_log", @stale_hours)
+      for _ <- 1..5, do: captured(tenant_b.id, "session_log", @fresh_hours)
+
+      candidate_tenants =
+        IngestionHealth.detect() |> Enum.map(& &1.tenant_id) |> Enum.uniq()
+
+      assert tenant_a.id in candidate_tenants
+      refute tenant_b.id in candidate_tenants
+    end
+  end
+
+  describe "list_anomalies/2" do
+    test "excludes resolved and archived by default" do
+      tenant = fixture(:tenant)
+
+      unresolved =
+        fixture(:ingestion_anomaly, %{tenant_id: tenant.id, source_type: "session_log"})
+
+      _resolved =
+        fixture(:ingestion_anomaly, %{
+          tenant_id: tenant.id,
+          source_type: "manual",
+          resolved: true
+        })
+
+      _archived =
+        fixture(:ingestion_anomaly, %{
+          tenant_id: tenant.id,
+          source_type: "newsletter",
+          archived: true
+        })
+
+      {:ok, %{data: data, total: total}} = IngestionHealth.list_anomalies(tenant.id)
+
+      assert total == 1
+      assert [%{id: id}] = data
+      assert id == unresolved.id
+    end
+
+    test "filters by source_type" do
+      tenant = fixture(:tenant)
+      fixture(:ingestion_anomaly, %{tenant_id: tenant.id, source_type: "session_log"})
+      fixture(:ingestion_anomaly, %{tenant_id: tenant.id, source_type: "newsletter"})
+
+      {:ok, %{data: data, total: total}} =
+        IngestionHealth.list_anomalies(tenant.id, source_type: "session_log")
+
+      assert total == 1
+      assert hd(data).source_type == "session_log"
+    end
+
+    test "tenant isolation — never returns another tenant's anomalies" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      fixture(:ingestion_anomaly, %{tenant_id: tenant_a.id})
+
+      {:ok, %{data: data, total: total}} = IngestionHealth.list_anomalies(tenant_b.id)
+
+      assert data == []
+      assert total == 0
+    end
+  end
+
+  describe "resolve_anomaly/3" do
+    test "flips resolved and writes an audit entry" do
+      tenant = fixture(:tenant)
+      anomaly = fixture(:ingestion_anomaly, %{tenant_id: tenant.id})
+
+      assert {:ok, resolved} =
+               IngestionHealth.resolve_anomaly(tenant.id, anomaly.id, actor_type: "api_key")
+
+      assert resolved.resolved == true
+
+      audit_count =
+        from(a in AuditLog,
+          where:
+            a.tenant_id == ^tenant.id and a.entity_type == "ingestion_anomaly" and
+              a.action == "resolved" and a.entity_id == ^anomaly.id
+        )
+        |> AdminRepo.aggregate(:count)
+
+      assert audit_count == 1
+    end
+
+    test "returns :not_found for another tenant's anomaly" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      anomaly = fixture(:ingestion_anomaly, %{tenant_id: tenant_a.id})
+
+      assert {:error, :not_found} = IngestionHealth.resolve_anomaly(tenant_b.id, anomaly.id)
+    end
+
+    test "returns :not_found for a non-existent anomaly" do
+      tenant = fixture(:tenant)
+
+      assert {:error, :not_found} =
+               IngestionHealth.resolve_anomaly(tenant.id, Ecto.UUID.generate())
+    end
+  end
+end

--- a/test/loopctl/knowledge/ingestion_health_test.exs
+++ b/test/loopctl/knowledge/ingestion_health_test.exs
@@ -5,6 +5,7 @@ defmodule Loopctl.Knowledge.IngestionHealthTest do
 
   alias Loopctl.AdminRepo
   alias Loopctl.Audit.AuditLog
+  alias Loopctl.Knowledge.IngestionAnomaly
   alias Loopctl.Knowledge.IngestionHealth
 
   import Ecto.Query
@@ -79,6 +80,57 @@ defmodule Loopctl.Knowledge.IngestionHealthTest do
 
       assert tenant_a.id in candidate_tenants
       refute tenant_b.id in candidate_tenants
+    end
+
+    test "monitored_source_types :all flags any established + stale source_type" do
+      tenant = fixture(:tenant)
+      # "newsletter" is NOT in the test-env narrow monitoring list, so it is only
+      # flagged when detect/1 is given `:all` (the prod default).
+      for _ <- 1..5, do: captured(tenant.id, "newsletter", @stale_hours)
+
+      cfg = %{
+        monitored_source_types: :all,
+        established_threshold: 5,
+        staleness_threshold_hours: 72
+      }
+
+      candidates = IngestionHealth.detect(cfg) |> Enum.filter(&(&1.tenant_id == tenant.id))
+
+      assert [%{source_type: "newsletter"}] = candidates
+    end
+
+    test "recency window excludes a wound-down source_type silent past the window" do
+      tenant = fixture(:tenant)
+      # Established long ago (well beyond the establishment window) and silent since:
+      # a legitimately wound-down workflow, NOT a fresh regression — must not flag.
+      for _ <- 1..5, do: captured(tenant.id, "session_log", 24 * 60)
+
+      cfg = %{
+        monitored_source_types: ["session_log"],
+        established_threshold: 5,
+        staleness_threshold_hours: 72,
+        # 30-day window; captures 60 days old age out of establishment.
+        establishment_window_hours: 720
+      }
+
+      assert IngestionHealth.detect(cfg) |> Enum.filter(&(&1.tenant_id == tenant.id)) == []
+    end
+  end
+
+  describe "IngestionAnomaly.create_changeset/2 invariants" do
+    test "rejects sample_count 0 (never established) and hours_stale 0 (not stale)" do
+      base = %{
+        source_type: "session_log",
+        anomaly_type: :capture_silence,
+        hours_stale: 96,
+        sample_count: 5
+      }
+
+      refute IngestionAnomaly.create_changeset(%IngestionAnomaly{}, %{base | sample_count: 0}).valid?
+
+      refute IngestionAnomaly.create_changeset(%IngestionAnomaly{}, %{base | hours_stale: 0}).valid?
+
+      assert IngestionAnomaly.create_changeset(%IngestionAnomaly{}, base).valid?
     end
   end
 
@@ -168,6 +220,73 @@ defmodule Loopctl.Knowledge.IngestionHealthTest do
 
       assert {:error, :not_found} =
                IngestionHealth.resolve_anomaly(tenant.id, Ecto.UUID.generate())
+    end
+
+    test "re-resolving an already-resolved anomaly is an idempotent no-op (no bogus audit)" do
+      tenant = fixture(:tenant)
+      anomaly = fixture(:ingestion_anomaly, %{tenant_id: tenant.id, resolved: true})
+
+      assert {:ok, resolved} = IngestionHealth.resolve_anomaly(tenant.id, anomaly.id)
+      assert resolved.resolved == true
+
+      # No `false -> true` audit transition is written for a row already resolved.
+      audit_count =
+        from(a in AuditLog,
+          where:
+            a.tenant_id == ^tenant.id and a.entity_type == "ingestion_anomaly" and
+              a.action == "resolved" and a.entity_id == ^anomaly.id
+        )
+        |> AdminRepo.aggregate(:count)
+
+      assert audit_count == 0
+    end
+  end
+
+  describe "archive_anomaly/3" do
+    test "flips archived and writes an audit entry" do
+      tenant = fixture(:tenant)
+      anomaly = fixture(:ingestion_anomaly, %{tenant_id: tenant.id})
+
+      assert {:ok, archived} =
+               IngestionHealth.archive_anomaly(tenant.id, anomaly.id, actor_type: "api_key")
+
+      assert archived.archived == true
+
+      audit_count =
+        from(a in AuditLog,
+          where:
+            a.tenant_id == ^tenant.id and a.entity_type == "ingestion_anomaly" and
+              a.action == "archived" and a.entity_id == ^anomaly.id
+        )
+        |> AdminRepo.aggregate(:count)
+
+      assert audit_count == 1
+    end
+
+    test "re-archiving an already-archived anomaly is an idempotent no-op" do
+      tenant = fixture(:tenant)
+      anomaly = fixture(:ingestion_anomaly, %{tenant_id: tenant.id, archived: true})
+
+      assert {:ok, archived} = IngestionHealth.archive_anomaly(tenant.id, anomaly.id)
+      assert archived.archived == true
+
+      audit_count =
+        from(a in AuditLog,
+          where:
+            a.tenant_id == ^tenant.id and a.entity_type == "ingestion_anomaly" and
+              a.action == "archived" and a.entity_id == ^anomaly.id
+        )
+        |> AdminRepo.aggregate(:count)
+
+      assert audit_count == 0
+    end
+
+    test "returns :not_found for another tenant's anomaly" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      anomaly = fixture(:ingestion_anomaly, %{tenant_id: tenant_a.id})
+
+      assert {:error, :not_found} = IngestionHealth.archive_anomaly(tenant_b.id, anomaly.id)
     end
   end
 end

--- a/test/loopctl/workers/ingestion_health_worker_test.exs
+++ b/test/loopctl/workers/ingestion_health_worker_test.exs
@@ -1,0 +1,162 @@
+defmodule Loopctl.Workers.IngestionHealthWorkerTest do
+  use Loopctl.DataCase, async: true
+  use Oban.Testing, repo: Loopctl.Repo
+
+  setup :verify_on_exit!
+
+  import Ecto.Query
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Audit.AuditLog
+  alias Loopctl.Knowledge.IngestionAnomaly
+  alias Loopctl.Workers.IngestionHealthWorker
+  alias Loopctl.Workers.ScaleAlertDeliveryWorker
+  alias Loopctl.Workers.WebhookDeliveryWorker
+
+  # Defaults: established_threshold 5, staleness_threshold_hours 72, source ["session_log"].
+  @stale_hours 96
+  @fresh_hours 1
+
+  defp captured(tenant_id, source_type, hours_ago) do
+    captured_article(%{
+      tenant_id: tenant_id,
+      source_type: source_type,
+      status: :published,
+      inserted_at: DateTime.add(DateTime.utc_now(), -hours_ago, :hour)
+    })
+  end
+
+  defp seed_captures(tenant_id, source_type, count, hours_ago) do
+    for _ <- 1..count, do: captured(tenant_id, source_type, hours_ago)
+  end
+
+  defp detected_audit_count(tenant_id, source_type) do
+    from(a in AuditLog,
+      where:
+        a.tenant_id == ^tenant_id and a.entity_type == "ingestion_anomaly" and
+          a.action == "detected" and
+          fragment("?->>'source_type' = ?", a.metadata, ^source_type)
+    )
+    |> AdminRepo.aggregate(:count)
+  end
+
+  defp anomalies_for(tenant_id) do
+    from(a in IngestionAnomaly, where: a.tenant_id == ^tenant_id) |> AdminRepo.all()
+  end
+
+  describe "perform/1 — capture-silence detection" do
+    test "flags an established + stale source_type, writing audit + operator alert" do
+      tenant = fixture(:tenant)
+      seed_captures(tenant.id, "session_log", 5, @stale_hours)
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert :ok = IngestionHealthWorker.perform(%Oban.Job{args: %{}})
+
+        # An operator alert was ENQUEUED (id-only payload) — assert the job, not the network.
+        assert_enqueued(worker: ScaleAlertDeliveryWorker)
+      end)
+
+      [anomaly] = anomalies_for(tenant.id)
+      assert anomaly.anomaly_type == :capture_silence
+      assert anomaly.source_type == "session_log"
+      assert anomaly.sample_count == 5
+      assert anomaly.hours_stale >= 72
+      assert anomaly.resolved == false
+
+      assert detected_audit_count(tenant.id, "session_log") == 1
+    end
+
+    test "fires a per-tenant knowledge.ingestion_anomaly_detected webhook when subscribed" do
+      tenant = fixture(:tenant)
+
+      webhook =
+        fixture(:webhook, %{
+          tenant_id: tenant.id,
+          events: ["knowledge.ingestion_anomaly_detected"]
+        })
+
+      seed_captures(tenant.id, "session_log", 5, @stale_hours)
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert :ok = IngestionHealthWorker.perform(%Oban.Job{args: %{}})
+        assert_enqueued(worker: WebhookDeliveryWorker, args: %{tenant_id: tenant.id})
+      end)
+
+      events =
+        from(e in Loopctl.Webhooks.WebhookEvent,
+          where: e.tenant_id == ^tenant.id and e.webhook_id == ^webhook.id
+        )
+        |> AdminRepo.all()
+
+      assert length(events) == 1
+      assert hd(events).event_type == "knowledge.ingestion_anomaly_detected"
+    end
+
+    test "does not flag an established source_type that is still fresh" do
+      tenant = fixture(:tenant)
+      seed_captures(tenant.id, "session_log", 5, @fresh_hours)
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert :ok = IngestionHealthWorker.perform(%Oban.Job{args: %{}})
+        refute_enqueued(worker: ScaleAlertDeliveryWorker)
+      end)
+
+      assert anomalies_for(tenant.id) == []
+    end
+
+    test "does not flag a source_type that never became established (below threshold)" do
+      tenant = fixture(:tenant)
+      # 4 stale captures — below the established_threshold of 5.
+      seed_captures(tenant.id, "session_log", 4, @stale_hours)
+
+      assert :ok = IngestionHealthWorker.perform(%Oban.Job{args: %{}})
+
+      assert anomalies_for(tenant.id) == []
+      assert detected_audit_count(tenant.id, "session_log") == 0
+    end
+
+    test "does not monitor an unmonitored source_type even when established + stale" do
+      tenant = fixture(:tenant)
+      seed_captures(tenant.id, "manual", 5, @stale_hours)
+
+      assert :ok = IngestionHealthWorker.perform(%Oban.Job{args: %{}})
+
+      assert anomalies_for(tenant.id) == []
+    end
+
+    test "a second run on the same stale condition updates in place and does NOT re-notify" do
+      tenant = fixture(:tenant)
+      seed_captures(tenant.id, "session_log", 5, @stale_hours)
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert :ok = IngestionHealthWorker.perform(%Oban.Job{args: %{}})
+        assert :ok = IngestionHealthWorker.perform(%Oban.Job{args: %{}})
+
+        # Exactly ONE operator alert across the two runs (anti-alarm-fatigue).
+        assert length(all_enqueued(worker: ScaleAlertDeliveryWorker)) == 1
+      end)
+
+      # Still exactly one anomaly row and one detected audit entry.
+      assert length(anomalies_for(tenant.id)) == 1
+      assert detected_audit_count(tenant.id, "session_log") == 1
+    end
+
+    test "tenant isolation — tenant A's silence never flags tenant B" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+
+      # A is established + stale; B is established + fresh.
+      seed_captures(tenant_a.id, "session_log", 5, @stale_hours)
+      seed_captures(tenant_b.id, "session_log", 5, @fresh_hours)
+
+      assert :ok = IngestionHealthWorker.perform(%Oban.Job{args: %{}})
+
+      assert length(anomalies_for(tenant_a.id)) == 1
+      assert anomalies_for(tenant_b.id) == []
+    end
+
+    test "succeeds when no tenants exist" do
+      assert :ok = IngestionHealthWorker.perform(%Oban.Job{args: %{}})
+    end
+  end
+end

--- a/test/loopctl/workers/ingestion_health_worker_test.exs
+++ b/test/loopctl/workers/ingestion_health_worker_test.exs
@@ -9,6 +9,7 @@ defmodule Loopctl.Workers.IngestionHealthWorkerTest do
   alias Loopctl.AdminRepo
   alias Loopctl.Audit.AuditLog
   alias Loopctl.Knowledge.IngestionAnomaly
+  alias Loopctl.Knowledge.IngestionHealth
   alias Loopctl.Workers.IngestionHealthWorker
   alias Loopctl.Workers.ScaleAlertDeliveryWorker
   alias Loopctl.Workers.WebhookDeliveryWorker
@@ -139,6 +140,84 @@ defmodule Loopctl.Workers.IngestionHealthWorkerTest do
       # Still exactly one anomaly row and one detected audit entry.
       assert length(anomalies_for(tenant.id)) == 1
       assert detected_audit_count(tenant.id, "session_log") == 1
+    end
+
+    test "a resolved anomaly is NOT re-created/re-notified while silence persists" do
+      tenant = fixture(:tenant)
+      seed_captures(tenant.id, "session_log", 5, @stale_hours)
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert :ok = IngestionHealthWorker.perform(%Oban.Job{args: %{}})
+        [anomaly] = anomalies_for(tenant.id)
+
+        # Operator resolves it; the source_type is still silent (no new capture).
+        assert {:ok, _} = IngestionHealth.resolve_anomaly(tenant.id, anomaly.id)
+
+        # Next hourly run must NOT create a fresh anomaly or re-fire the alarm.
+        assert :ok = IngestionHealthWorker.perform(%Oban.Job{args: %{}})
+
+        assert length(all_enqueued(worker: ScaleAlertDeliveryWorker)) == 1
+      end)
+
+      # Still exactly one (now-resolved) row and one detected audit entry.
+      assert length(anomalies_for(tenant.id)) == 1
+      assert detected_audit_count(tenant.id, "session_log") == 1
+    end
+
+    test "re-flags only after captures resume and the source goes silent again" do
+      tenant = fixture(:tenant)
+      seed_captures(tenant.id, "session_log", 5, @stale_hours)
+
+      assert :ok = IngestionHealthWorker.perform(%Oban.Job{args: %{}})
+      [anomaly] = anomalies_for(tenant.id)
+      assert {:ok, _} = IngestionHealth.resolve_anomaly(tenant.id, anomaly.id)
+
+      # Captures RESUME (a newer article) then the source goes silent again past
+      # the staleness threshold — this is a genuinely new regression.
+      captured(tenant.id, "session_log", 80)
+
+      assert :ok = IngestionHealthWorker.perform(%Oban.Job{args: %{}})
+
+      # A second (unresolved) anomaly is created for the new silence episode.
+      unresolved = anomalies_for(tenant.id) |> Enum.reject(& &1.resolved)
+      assert length(unresolved) == 1
+      assert detected_audit_count(tenant.id, "session_log") == 2
+    end
+
+    test "an archived anomaly permanently suppresses re-detection for that source_type" do
+      tenant = fixture(:tenant)
+      seed_captures(tenant.id, "session_log", 5, @stale_hours)
+
+      assert :ok = IngestionHealthWorker.perform(%Oban.Job{args: %{}})
+      [anomaly] = anomalies_for(tenant.id)
+      assert {:ok, _} = IngestionHealth.archive_anomaly(tenant.id, anomaly.id)
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert :ok = IngestionHealthWorker.perform(%Oban.Job{args: %{}})
+        # No new operator alert — the archived source_type is suppressed.
+        assert all_enqueued(worker: ScaleAlertDeliveryWorker) == []
+      end)
+
+      # No new anomaly rows were created (still just the archived one).
+      assert length(anomalies_for(tenant.id)) == 1
+    end
+
+    test "operator-alert payload conforms to the ScaleAlert contract (metric/value/threshold)" do
+      tenant = fixture(:tenant)
+      seed_captures(tenant.id, "session_log", 5, @stale_hours)
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert :ok = IngestionHealthWorker.perform(%Oban.Job{args: %{}})
+
+        [job] = all_enqueued(worker: ScaleAlertDeliveryWorker)
+        payload = job.args["payload"]
+
+        assert payload["alert"] == "ingestion.capture_silence"
+        assert payload["metric"] == "ingestion.capture_silence.hours_stale"
+        assert is_integer(payload["value"])
+        assert payload["threshold"] == 72
+        assert payload["window_seconds"] == 72 * 3600
+      end)
     end
 
     test "tenant isolation — tenant A's silence never flags tenant B" do

--- a/test/loopctl/workers/ingestion_health_worker_test.exs
+++ b/test/loopctl/workers/ingestion_health_worker_test.exs
@@ -202,6 +202,56 @@ defmodule Loopctl.Workers.IngestionHealthWorkerTest do
       assert length(anomalies_for(tenant.id)) == 1
     end
 
+    test "re-fires a lost operator alert for an unresolved-but-unalerted row (at-least-once)" do
+      tenant = fixture(:tenant)
+      seed_captures(tenant.id, "session_log", 5, @stale_hours)
+
+      # Simulate a crash between the atomic anomaly insert and the post-commit
+      # enqueues: the row exists, unresolved, but was never alerted.
+      last_event = DateTime.add(DateTime.utc_now(), -@stale_hours, :hour)
+
+      anomaly =
+        fixture(:ingestion_anomaly, %{
+          tenant_id: tenant.id,
+          source_type: "session_log",
+          hours_stale: @stale_hours,
+          sample_count: 5,
+          last_event_at: last_event
+        })
+
+      refute anomaly.alerted
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert :ok = IngestionHealthWorker.perform(%Oban.Job{args: %{}})
+        # The lost operator alert is recovered on this run.
+        assert_enqueued(worker: ScaleAlertDeliveryWorker)
+      end)
+
+      # The row is now marked alerted so a healthy subsequent run won't re-fire.
+      [reloaded] = anomalies_for(tenant.id)
+      assert reloaded.alerted == true
+    end
+
+    test "auto-resolves an open anomaly whose captures resumed" do
+      tenant = fixture(:tenant)
+
+      anomaly =
+        fixture(:ingestion_anomaly, %{
+          tenant_id: tenant.id,
+          source_type: "session_log",
+          last_event_at: DateTime.add(DateTime.utc_now(), -100, :hour)
+        })
+
+      # A fresh capture after the anomaly's snapshot — the stream recovered.
+      captured(tenant.id, "session_log", 1)
+
+      assert :ok = IngestionHealthWorker.perform(%Oban.Job{args: %{}})
+
+      [reloaded] = anomalies_for(tenant.id)
+      assert reloaded.id == anomaly.id
+      assert reloaded.resolved == true
+    end
+
     test "operator-alert payload conforms to the ScaleAlert contract (metric/value/threshold)" do
       tenant = fixture(:tenant)
       seed_captures(tenant.id, "session_log", 5, @stale_hours)

--- a/test/loopctl_web/controllers/ingestion_anomaly_controller_test.exs
+++ b/test/loopctl_web/controllers/ingestion_anomaly_controller_test.exs
@@ -136,6 +136,21 @@ defmodule LoopctlWeb.IngestionAnomalyControllerTest do
       assert body["ingestion_anomaly"]["resolved"] == true
     end
 
+    test "archives an anomaly with ?archived=true (user)", %{conn: conn} do
+      ctx = setup_tenant_with_anomalies()
+
+      conn =
+        conn
+        |> auth_conn(ctx.user_key)
+        |> patch(~p"/api/v1/ingestion-anomalies/#{ctx.anomaly1.id}?archived=true")
+
+      body = json_response(conn, 200)
+      assert body["ingestion_anomaly"]["id"] == ctx.anomaly1.id
+      assert body["ingestion_anomaly"]["archived"] == true
+      # Archiving does not resolve — it is a distinct disposition.
+      assert body["ingestion_anomaly"]["resolved"] == false
+    end
+
     test "returns 403 for orchestrator (resolve requires :user)", %{conn: conn} do
       ctx = setup_tenant_with_anomalies()
 

--- a/test/loopctl_web/controllers/ingestion_anomaly_controller_test.exs
+++ b/test/loopctl_web/controllers/ingestion_anomaly_controller_test.exs
@@ -1,6 +1,8 @@
 defmodule LoopctlWeb.IngestionAnomalyControllerTest do
   use LoopctlWeb.ConnCase, async: true
 
+  alias Loopctl.Knowledge.IngestionHealth
+
   setup :verify_on_exit!
 
   defp auth_conn(conn, raw_key) do
@@ -149,6 +151,61 @@ defmodule LoopctlWeb.IngestionAnomalyControllerTest do
       assert body["ingestion_anomaly"]["archived"] == true
       # Archiving does not resolve — it is a distinct disposition.
       assert body["ingestion_anomaly"]["resolved"] == false
+    end
+
+    test "un-archives an anomaly with ?archived=false (user)", %{conn: conn} do
+      ctx = setup_tenant_with_anomalies()
+
+      archived =
+        fixture(:ingestion_anomaly, %{
+          tenant_id: ctx.tenant.id,
+          source_type: "manual",
+          archived: true
+        })
+
+      conn =
+        conn
+        |> auth_conn(ctx.user_key)
+        |> patch(~p"/api/v1/ingestion-anomalies/#{archived.id}?archived=false")
+
+      body = json_response(conn, 200)
+      assert body["ingestion_anomaly"]["id"] == archived.id
+      assert body["ingestion_anomaly"]["archived"] == false
+    end
+
+    test "malformed ?archived value is rejected with 422, not silently resolved", %{conn: conn} do
+      ctx = setup_tenant_with_anomalies()
+
+      conn =
+        conn
+        |> auth_conn(ctx.user_key)
+        |> patch(~p"/api/v1/ingestion-anomalies/#{ctx.anomaly1.id}?archived=1")
+
+      assert json_response(conn, 422)
+
+      # The anomaly was NOT resolved as a side effect of the malformed request:
+      # it still appears in the default (unresolved-only) list.
+      {:ok, %{data: data}} = IngestionHealth.list_anomalies(ctx.tenant.id)
+      assert ctx.anomaly1.id in Enum.map(data, & &1.id)
+    end
+
+    test "resolved=all returns both resolved and unresolved in one call", %{conn: conn} do
+      ctx = setup_tenant_with_anomalies()
+
+      fixture(:ingestion_anomaly, %{
+        tenant_id: ctx.tenant.id,
+        source_type: "manual",
+        resolved: true
+      })
+
+      conn =
+        conn
+        |> auth_conn(ctx.user_key)
+        |> get(~p"/api/v1/ingestion-anomalies?resolved=all")
+
+      body = json_response(conn, 200)
+      # 2 unresolved (from setup) + 1 resolved = 3.
+      assert body["meta"]["total_count"] == 3
     end
 
     test "returns 403 for orchestrator (resolve requires :user)", %{conn: conn} do

--- a/test/loopctl_web/controllers/ingestion_anomaly_controller_test.exs
+++ b/test/loopctl_web/controllers/ingestion_anomaly_controller_test.exs
@@ -1,0 +1,186 @@
+defmodule LoopctlWeb.IngestionAnomalyControllerTest do
+  use LoopctlWeb.ConnCase, async: true
+
+  setup :verify_on_exit!
+
+  defp auth_conn(conn, raw_key) do
+    put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  defp setup_tenant_with_anomalies do
+    tenant = fixture(:tenant)
+
+    anomaly1 =
+      fixture(:ingestion_anomaly, %{tenant_id: tenant.id, source_type: "session_log"})
+
+    anomaly2 =
+      fixture(:ingestion_anomaly, %{tenant_id: tenant.id, source_type: "newsletter"})
+
+    {user_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+    {orch_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :orchestrator})
+    {agent_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+    %{
+      tenant: tenant,
+      anomaly1: anomaly1,
+      anomaly2: anomaly2,
+      user_key: user_key,
+      orch_key: orch_key,
+      agent_key: agent_key
+    }
+  end
+
+  # --- GET /api/v1/ingestion-anomalies ---
+
+  describe "GET /api/v1/ingestion-anomalies" do
+    test "lists unresolved anomalies for a user", %{conn: conn} do
+      ctx = setup_tenant_with_anomalies()
+
+      conn = conn |> auth_conn(ctx.user_key) |> get(~p"/api/v1/ingestion-anomalies")
+      body = json_response(conn, 200)
+
+      assert length(body["data"]) == 2
+      assert body["meta"]["total_count"] == 2
+      assert body["meta"]["page"] == 1
+    end
+
+    test "orchestrator (the cost-anomaly read role) can list", %{conn: conn} do
+      ctx = setup_tenant_with_anomalies()
+
+      conn = conn |> auth_conn(ctx.orch_key) |> get(~p"/api/v1/ingestion-anomalies")
+      assert json_response(conn, 200)["meta"]["total_count"] == 2
+    end
+
+    test "excludes resolved and archived by default", %{conn: conn} do
+      ctx = setup_tenant_with_anomalies()
+
+      fixture(:ingestion_anomaly, %{
+        tenant_id: ctx.tenant.id,
+        source_type: "manual",
+        resolved: true
+      })
+
+      fixture(:ingestion_anomaly, %{
+        tenant_id: ctx.tenant.id,
+        source_type: "skill",
+        archived: true
+      })
+
+      conn = conn |> auth_conn(ctx.user_key) |> get(~p"/api/v1/ingestion-anomalies")
+      body = json_response(conn, 200)
+
+      assert body["meta"]["total_count"] == 2
+    end
+
+    test "filters by source_type", %{conn: conn} do
+      ctx = setup_tenant_with_anomalies()
+
+      conn =
+        conn
+        |> auth_conn(ctx.user_key)
+        |> get(~p"/api/v1/ingestion-anomalies?source_type=session_log")
+
+      body = json_response(conn, 200)
+      assert length(body["data"]) == 1
+      assert hd(body["data"])["source_type"] == "session_log"
+    end
+
+    test "supports pagination", %{conn: conn} do
+      ctx = setup_tenant_with_anomalies()
+
+      conn =
+        conn
+        |> auth_conn(ctx.user_key)
+        |> get(~p"/api/v1/ingestion-anomalies?page=1&page_size=1")
+
+      body = json_response(conn, 200)
+      assert length(body["data"]) == 1
+      assert body["meta"]["total_count"] == 2
+      assert body["meta"]["page_size"] == 1
+    end
+
+    test "returns 403 for agent role", %{conn: conn} do
+      ctx = setup_tenant_with_anomalies()
+
+      conn = conn |> auth_conn(ctx.agent_key) |> get(~p"/api/v1/ingestion-anomalies")
+      assert json_response(conn, 403)
+    end
+
+    test "tenant isolation — empty for a different tenant", %{conn: conn} do
+      _ctx = setup_tenant_with_anomalies()
+
+      other = fixture(:tenant)
+      {other_key, _} = fixture(:api_key, %{tenant_id: other.id, role: :user})
+
+      conn = conn |> auth_conn(other_key) |> get(~p"/api/v1/ingestion-anomalies")
+      body = json_response(conn, 200)
+
+      assert body["data"] == []
+      assert body["meta"]["total_count"] == 0
+    end
+  end
+
+  # --- PATCH /api/v1/ingestion-anomalies/:id ---
+
+  describe "PATCH /api/v1/ingestion-anomalies/:id" do
+    test "marks anomaly as resolved (user)", %{conn: conn} do
+      ctx = setup_tenant_with_anomalies()
+
+      conn =
+        conn
+        |> auth_conn(ctx.user_key)
+        |> patch(~p"/api/v1/ingestion-anomalies/#{ctx.anomaly1.id}")
+
+      body = json_response(conn, 200)
+      assert body["ingestion_anomaly"]["id"] == ctx.anomaly1.id
+      assert body["ingestion_anomaly"]["resolved"] == true
+    end
+
+    test "returns 403 for orchestrator (resolve requires :user)", %{conn: conn} do
+      ctx = setup_tenant_with_anomalies()
+
+      conn =
+        conn
+        |> auth_conn(ctx.orch_key)
+        |> patch(~p"/api/v1/ingestion-anomalies/#{ctx.anomaly1.id}")
+
+      assert json_response(conn, 403)
+    end
+
+    test "returns 403 for agent role", %{conn: conn} do
+      ctx = setup_tenant_with_anomalies()
+
+      conn =
+        conn
+        |> auth_conn(ctx.agent_key)
+        |> patch(~p"/api/v1/ingestion-anomalies/#{ctx.anomaly1.id}")
+
+      assert json_response(conn, 403)
+    end
+
+    test "returns 404 for wrong tenant", %{conn: conn} do
+      ctx = setup_tenant_with_anomalies()
+
+      other = fixture(:tenant)
+      {other_key, _} = fixture(:api_key, %{tenant_id: other.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(other_key)
+        |> patch(~p"/api/v1/ingestion-anomalies/#{ctx.anomaly1.id}")
+
+      assert json_response(conn, 404)
+    end
+
+    test "returns 404 for non-existent anomaly", %{conn: conn} do
+      ctx = setup_tenant_with_anomalies()
+
+      conn =
+        conn
+        |> auth_conn(ctx.user_key)
+        |> patch(~p"/api/v1/ingestion-anomalies/#{Ecto.UUID.generate()}")
+
+      assert json_response(conn, 404)
+    end
+  end
+end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -20,6 +20,7 @@ defmodule Loopctl.Fixtures do
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.ArticleAccessEvent
   alias Loopctl.Knowledge.ArticleLink
+  alias Loopctl.Knowledge.IngestionAnomaly
   alias Loopctl.Llm.SettingsCache
   alias Loopctl.Llm.TenantLlmSettings
   alias Loopctl.Llm.UsageEvent, as: LlmUsageEvent
@@ -493,6 +494,21 @@ defmodule Loopctl.Fixtures do
         story_cost_millicents: 75_000,
         reference_avg_millicents: 25_000,
         deviation_factor: Decimal.new("3.0"),
+        resolved: false,
+        metadata: %{}
+      },
+      Enum.into(attrs, %{})
+    )
+  end
+
+  def build(:ingestion_anomaly, attrs) do
+    Map.merge(
+      %{
+        source_type: "session_log",
+        anomaly_type: :capture_silence,
+        last_event_at: DateTime.add(DateTime.utc_now(), -96, :hour),
+        hours_stale: 96,
+        sample_count: 5,
         resolved: false,
         metadata: %{}
       },
@@ -1226,6 +1242,32 @@ defmodule Loopctl.Fixtures do
     AdminRepo.insert!(changeset)
   end
 
+  def fixture(:ingestion_anomaly, attrs) do
+    attrs = Enum.into(attrs, %{})
+
+    {tenant_id, attrs} =
+      case Map.get(attrs, :tenant_id) do
+        nil ->
+          tenant = fixture(:tenant)
+          {tenant.id, Map.put(attrs, :tenant_id, tenant.id)}
+
+        tid ->
+          {tid, attrs}
+      end
+
+    data = build(:ingestion_anomaly, attrs)
+
+    # `archived` is not cast by create_changeset (mirrors CostAnomaly — it's set by
+    # the archival path, not the create surface), so put it on the changeset directly
+    # when a test needs an archived row.
+    changeset =
+      %IngestionAnomaly{tenant_id: tenant_id}
+      |> IngestionAnomaly.create_changeset(data)
+      |> Ecto.Changeset.put_change(:archived, Map.get(data, :archived, false))
+
+    AdminRepo.insert!(changeset)
+  end
+
   def fixture(:review_record, attrs) do
     attrs = Enum.into(attrs, %{})
 
@@ -1649,6 +1691,32 @@ defmodule Loopctl.Fixtures do
   Generates a fresh binary UUID for use in tests.
   """
   def uuid, do: Ecto.UUID.generate()
+
+  @doc """
+  Inserts a knowledge `Article` with a controlled `inserted_at` and `source_type`.
+
+  The normal `fixture(:article, ...)` path auto-sets `inserted_at` to now via
+  timestamps; the ingestion capture-silence detector reasons over `inserted_at`, so
+  tests need to backdate captured articles. Pass `:inserted_at` (a DateTime) and
+  `:source_type`; auto-creates a tenant when `:tenant_id` is absent.
+  """
+  def captured_article(attrs) do
+    attrs = Enum.into(attrs, %{})
+    {inserted_at, attrs} = Map.pop(attrs, :inserted_at)
+    article = fixture(:article, attrs)
+
+    if inserted_at do
+      import Ecto.Query
+
+      {1, [updated]} =
+        from(a in Article, where: a.id == ^article.id, select: a)
+        |> AdminRepo.update_all(set: [inserted_at: inserted_at])
+
+      updated
+    else
+      article
+    end
+  end
 
   # --- Private helpers ---
 


### PR DESCRIPTION
## Why

Session-knowledge capture failed **silently for ~3 months** because articles were rejected (409 `title_conflict`) and dropped, and **nothing detected the absence of expected writes**. loopctl had detectors for the *presence* of errors (`ScaleAlerts`, `CostAnomaly`) but none for the *absence of expected success* — the hardest failure mode and the one that let a total-loss regression hide. This adds that missing detector class.

## What

A scheduled **capture-silence monitor** (dead-man's switch), structurally a sibling of the `CostAnomaly` subsystem:

- **Detection** (`Loopctl.Knowledge.IngestionHealth`): per active tenant × monitored `source_type`, flags `:capture_silence` when a source that is *established* (≥ `established_threshold` articles within a recency window) has gone silent (`hours_stale > staleness_threshold_hours`). Prod default monitors **all** source_types; thresholds are config-DI (`established_threshold: 5`, `staleness_threshold_hours: 72`, `establishment_window_hours: 720`).
- **Durable record** (`ingestion_anomalies`, RLS-scoped, unresolved unique partial index): the anomaly is queryable **regardless of whether any alert channel is wired** — the signal is never lost.
- **Notification** (`Loopctl.Workers.IngestionHealthWorker`, hourly Oban cron with a hardcoded default so boot never depends on a new env var): on a genuinely-new anomaly, atomically writes the row + `detected` audit entry (one `Ecto.Multi`), fires the operator alert via the existing channel-agnostic `ScaleAlertDeliveryWorker` (no-ops until `SCALE_ALERT_WEBHOOK_URL` is set), and a per-tenant `knowledge.ingestion_anomaly_detected` webhook. An existing unresolved anomaly is refreshed **silently — no re-notify** (anti-alarm-fatigue). An `alerted` flag gives **at-least-once** delivery: a run that sees an unresolved-but-unalerted row re-fires, closing the crash-between-commit-and-enqueue hole.
- **API**: `GET /api/v1/ingestion-anomalies` (role `orchestrator`) and `PATCH /api/v1/ingestion-anomalies/:id` resolve/archive (role `user` + human anchor), mirroring the cost-anomaly surface. Resolve suppresses re-alerting until a NEW capture arrives and re-silences; archive permanently retires a source_type and is **reversible** (un-archive path).

Delivery channel (email vs Slack) is intentionally **deferred to operator config** — the detector is channel-agnostic by design.

## Review

Ran `/review:enhanced-review-workflow` (Elixir). Round 1: 15 confirmed, 15 fixed (`f29f5cc`). Round 2 (adversarial + security): 14 confirmed, 12 fixed (`6898c57`), 4 disproved, **0 invalid deferrals**. Highlights fixed: alarm-fatigue re-fire on resolved anomalies, at-least-once alert delivery, `CREATE INDEX CONCURRENTLY` + `@disable_ddl_transaction` on the articles read-path index (deploy can't block ingestion), oban-config table-existence guard for the code-before-migration skew window, and concurrent resolve/archive row-locking to prevent fabricated audit transitions.

Two items deferred with valid excuses: (1) the monitor only sees articles carrying a non-null `source_type` — the motivating `session_log` capture always stamps it, and *which other write paths must be required to stamp it* is a monitoring-policy decision (documented in the moduledoc); (2) read/resolve uses `AdminRepo` with explicit tenant predicates — this **matches the mandated `CostAnomaly` convention** and is isolation-tested, not a new deviation.

## Verification

`mix precommit` green post-review: **4923 tests, 0 failures**, credo/dialyzer/format clean, 3 migrations applied cleanly in dev + test.

## Follow-ups (separate, intentionally not in this PR)

- Wire an actual alert **channel** (`SCALE_ALERT_WEBHOOK_URL` → Slack, or an email adapter) — operator decision.
- A `no-persist / rejection-rate` detector (complements silence detection) and an MCP `get_ingestion_anomalies` tool for agent querying.
