### PR TITLE
feat(mcp): add get_ingestion_anomalies tool (v2.45.0)

### DIFF
--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to `loopctl-mcp-server` are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 2.45.0 — 2026-07-18 (ingestion-health anomalies)
+
+### Added
+
+- **`get_ingestion_anomalies`** — list ingestion-health anomalies (capture-silence: a
+  `source_type` that was producing articles has gone silent; and high article-write
+  rejection rate) over `GET /api/v1/ingestion-anomalies` (orchestrator key). Use it to
+  check whether knowledge capture is still landing. Paginated (`page`/`page_size`), with
+  optional `source_type`, `anomaly_type`, `resolved` (`false`/`true`/`all`), and
+  `include_archived` filters. Complements `get_cost_anomalies`.
+
 ## 2.44.0 — 2026-07-17 (KB-scope lifecycle: agent archive + restore)
 
 ### Added

--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -10,8 +10,8 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ### Added
 
 - **`get_ingestion_anomalies`** — list ingestion-health anomalies (capture-silence: a
-  `source_type` that was producing articles has gone silent; and high article-write
-  rejection rate) over `GET /api/v1/ingestion-anomalies` (orchestrator key). Use it to
+  `source_type` that was producing articles has gone silent) over
+  `GET /api/v1/ingestion-anomalies` (orchestrator key). Use it to
   check whether knowledge capture is still landing. Paginated (`page`/`page_size`), with
   optional `source_type`, `anomaly_type`, `resolved` (`false`/`true`/`all`), and
   `include_archived` filters. Complements `get_cost_anomalies`.

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -188,6 +188,7 @@ autonomous agent) can self-remediate without a human. Full agent-tenant lifecycl
 | `get_cost_summary` | orch | Get cost/token usage summary for a project, optionally broken down by `agent`, `epic`, or `model`. |
 | `get_story_token_usage` | orch | Get all token usage records for a single story. |
 | `get_cost_anomalies` | orch | Get cost anomaly alerts — stories or agents exceeding expected budgets. Optionally filter by project. |
+| `get_ingestion_anomalies` | orch | Get ingestion-health anomalies — capture-silence (a source_type stopped producing articles) and high write-rejection rate. Check whether knowledge capture is still landing. |
 | `set_token_budget` | orch | Set a token budget (in millicents) for a project, epic, story, or agent scope. Requires orchestrator role. |
 
 ### Knowledge Wiki Tools (agent key)

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -188,7 +188,7 @@ autonomous agent) can self-remediate without a human. Full agent-tenant lifecycl
 | `get_cost_summary` | orch | Get cost/token usage summary for a project, optionally broken down by `agent`, `epic`, or `model`. |
 | `get_story_token_usage` | orch | Get all token usage records for a single story. |
 | `get_cost_anomalies` | orch | Get cost anomaly alerts — stories or agents exceeding expected budgets. Optionally filter by project. |
-| `get_ingestion_anomalies` | orch | Get ingestion-health anomalies — capture-silence (a source_type stopped producing articles) and high write-rejection rate. Check whether knowledge capture is still landing. |
+| `get_ingestion_anomalies` | orch | Get ingestion-health anomalies — capture-silence (a source_type stopped producing articles). Check whether knowledge capture is still landing. |
 | `set_token_budget` | orch | Set a token budget (in millicents) for a project, epic, story, or agent scope. Requires orchestrator role. |
 
 ### Knowledge Wiki Tools (agent key)

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -2776,9 +2776,9 @@ const TOOLS = [
     name: "get_ingestion_anomalies",
     description:
       "Get ingestion-health anomalies — capture-silence (a source_type that was producing " +
-      "articles has gone silent) and high article-write rejection rate. Use to check whether " +
-      "knowledge capture is still landing. Paginated (page/page_size); advance `page` to " +
-      "enumerate all. Filter by source_type, anomaly_type, resolved status, or include archived.",
+      "articles has gone silent). Use to check whether knowledge capture is still landing. " +
+      "Paginated (page/page_size); advance `page` to enumerate all. Filter by source_type, " +
+      "anomaly_type, resolved status, or include archived.",
     inputSchema: {
       type: "object",
       properties: {
@@ -2788,7 +2788,8 @@ const TOOLS = [
         },
         anomaly_type: {
           type: "string",
-          description: 'Optional: filter by anomaly type (e.g. "capture_silence").',
+          enum: ["capture_silence"],
+          description: 'Optional: filter by anomaly type (only "capture_silence" is currently produced).',
         },
         resolved: {
           type: "string",

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -841,7 +841,15 @@ async function getIngestionAnomalies({
   if (page_size != null) params.set("page_size", String(page_size));
 
   const query = params.toString() ? `?${params}` : "";
-  const result = await apiCall("GET", `/api/v1/ingestion-anomalies${query}`);
+  // Orchestrator-gated endpoint (RequireRole :orchestrator). Pass the ORCH key
+  // explicitly so a misconfigured single agent-role LOOPCTL_API_KEY fails loudly
+  // rather than drifting into an undiagnosable 403.
+  const result = await apiCall(
+    "GET",
+    `/api/v1/ingestion-anomalies${query}`,
+    undefined,
+    process.env.LOOPCTL_ORCH_KEY
+  );
   return toContent(result);
 }
 

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -824,6 +824,27 @@ async function getCostAnomalies({ project_id, page, page_size }) {
   return toContent(result);
 }
 
+async function getIngestionAnomalies({
+  source_type,
+  anomaly_type,
+  resolved,
+  include_archived,
+  page,
+  page_size,
+}) {
+  const params = new URLSearchParams();
+  if (source_type) params.set("source_type", source_type);
+  if (anomaly_type) params.set("anomaly_type", anomaly_type);
+  if (resolved != null) params.set("resolved", String(resolved));
+  if (include_archived != null) params.set("include_archived", String(include_archived));
+  if (page != null) params.set("page", String(page));
+  if (page_size != null) params.set("page_size", String(page_size));
+
+  const query = params.toString() ? `?${params}` : "";
+  const result = await apiCall("GET", `/api/v1/ingestion-anomalies${query}`);
+  return toContent(result);
+}
+
 async function setTokenBudget({ scope_type, scope_id, budget_millicents, alert_threshold_pct }) {
   const body = { scope_type, scope_id, budget_millicents };
   if (alert_threshold_pct != null) body.alert_threshold_pct = alert_threshold_pct;
@@ -2747,6 +2768,40 @@ const TOOLS = [
         },
         page: { type: "integer", description: "Page number (default 1)." },
         page_size: { type: "integer", description: "Anomalies per page (default 20)." },
+      },
+      required: [],
+    },
+  },
+  {
+    name: "get_ingestion_anomalies",
+    description:
+      "Get ingestion-health anomalies — capture-silence (a source_type that was producing " +
+      "articles has gone silent) and high article-write rejection rate. Use to check whether " +
+      "knowledge capture is still landing. Paginated (page/page_size); advance `page` to " +
+      "enumerate all. Filter by source_type, anomaly_type, resolved status, or include archived.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        source_type: {
+          type: "string",
+          description: 'Optional: filter to one article source_type (e.g. "session_log").',
+        },
+        anomaly_type: {
+          type: "string",
+          description: 'Optional: filter by anomaly type (e.g. "capture_silence").',
+        },
+        resolved: {
+          type: "string",
+          enum: ["false", "true", "all"],
+          description:
+            'Which anomalies to return: "false" = unresolved only (default), "true" = resolved only, "all" = both.',
+        },
+        include_archived: {
+          type: "boolean",
+          description: "Optional: include archived (retired-source) anomalies (default false).",
+        },
+        page: { type: "integer", description: "Page number (default 1)." },
+        page_size: { type: "integer", description: "Anomalies per page (default 20, max 100)." },
       },
       required: [],
     },
@@ -5018,6 +5073,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     case "get_cost_anomalies":
       return await getCostAnomalies(args);
+
+    case "get_ingestion_anomalies":
+      return await getIngestionAnomalies(args);
 
     case "set_token_budget":
       return await setTokenBudget(args);

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.44.0",
+  "version": "2.45.0",
   "description": "MCP server for loopctl — structural trust for AI development loops",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
## What

Adds the `get_ingestion_anomalies` MCP tool wrapping `GET /api/v1/ingestion-anomalies` (orchestrator key), so agents can check whether knowledge capture is still landing — surfaces the capture-silence anomalies from the ingestion-health monitor (#426). Mirrors `get_cost_anomalies`. Filters: `source_type`, `anomaly_type`, `resolved` (`false`/`true`/`all`), `include_archived`, `page`/`page_size`.

**Version bump 2.44.0 → 2.45.0** triggers the npm autopublish workflow on merge to master.

## Review (enhanced-review-workflow, ts)

- Round 1 (committed): corrected the tool description — it originally over-claimed a "high write-rejection rate" anomaly the backend does not produce yet; now advertises only `capture_silence`, with `anomaly_type` constrained accordingly.
- ORCH-key passed explicitly so an agent-role `LOOPCTL_API_KEY` misconfig fails loudly instead of an undiagnosable 403.
- Scope discipline: the review also proposed server-side hardening of the endpoint (reject malformed `resolved` with 422; echo effective filters / warn on unknown `source_type`) and flagged issues in unrelated Epic 39 story specs. Those are **deliberately not in this PR** — the server hardening moves to the follow-up detector PR (it's coupled to that work), and the Epic 39 items are being raised separately. This PR stays a single-purpose MCP-tool addition.

## Verification

- 233/233 mcp-server unit tests, smoke test (boot + tools/list + live call), and a live end-to-end call against the deployed prod endpoint (valid paginated response).
- Full `mix precommit` green (4959 tests, 0 failures) — the repo-wide gate runs on every commit.
