### PR TITLE
De-flake the test suite: 12 flaky tests fixed (fixes #421), no prod changes

### DIFF
--- a/test/loopctl/knowledge_semantic_search_provider_error_test.exs
+++ b/test/loopctl/knowledge_semantic_search_provider_error_test.exs
@@ -1,0 +1,131 @@
+defmodule Loopctl.KnowledgeSemanticSearchProviderErrorTest do
+  @moduledoc """
+  US-34.3 (review fix MED #1): `Knowledge.generate_embedding/3` emits the
+  `[:loopctl, :llm, :provider_error]` telemetry event ONLY for genuine, countable
+  provider incidents (a 5xx `:transient` class) and NEVER for per-tenant config
+  faults (4xx credential/quota, `:no_api_key`) or the breaker's own derived
+  `:circuit_open` short-circuit.
+
+  ## Why `async: false` (deliberate, not an oversight)
+
+  These tests attach a GLOBAL `:telemetry` handler on the VM-global event
+  `[:loopctl, :llm, :provider_error]` and assert on what lands in the test
+  process mailbox (`assert_received` / `refute_received`). The emitter in
+  `Loopctl.LLM.record_provider_error/2` DELIBERATELY puts NO `tenant_id` (nor any
+  high-cardinality id) in the event metadata — see the "NEVER `tenant_id`" note
+  in `lib/loopctl/llm.ex`. Because the metadata carries no tenant, the handler
+  CANNOT be tenant-scoped: the best it can do is filter on `provider:
+  "embedding"` (which it does). Under `async: true` that filter is not enough —
+  ANY concurrently-running test whose embedding path emits a `provider_error`
+  with `provider: "embedding"` would leak a `{:provider_error_emitted, ...}`
+  message into this test's mailbox and trip the `refute_received` assertions
+  non-deterministically. A non-async module never runs concurrently with any
+  other module (`ExUnit.Case` `:async` docs), so no cross-file embedding emitter
+  is running while these listeners are attached. This mirrors how
+  `test/loopctl/heavy_read_hnsw_ef_search_test.exs` documents `async: false` for
+  shared VM-global state.
+
+  Extracted from `test/loopctl/knowledge_semantic_search_test.exs` (which stays
+  `async: true`) precisely so the rest of that file's semantic-search tests keep
+  running concurrently.
+  """
+  use Loopctl.DataCase, async: false
+
+  setup :verify_on_exit!
+
+  alias Loopctl.Knowledge
+
+  defp setup_tenant do
+    tenant = fixture(:tenant)
+    %{tenant: tenant}
+  end
+
+  describe "generate_embedding/3 - provider_error telemetry (US-34.3 review fix MED #1)" do
+    defp attach_provider_error_listener(test_pid) do
+      handler_id = {:generate_embedding_provider_error_test, System.unique_integer([:positive])}
+
+      :telemetry.attach(
+        handler_id,
+        [:loopctl, :llm, :provider_error],
+        fn
+          # Forward ONLY embedding-provider events. `[:loopctl, :llm, :provider_error]`
+          # is a VM-GLOBAL telemetry event, so under `async: true` a concurrent
+          # Anthropic-path test emitting it with provider="anthropic" would otherwise
+          # leak into this test's mailbox — failing the `assert_received`/
+          # `refute_received` assertions below non-deterministically. (This module is
+          # `async: false` for exactly that reason; see @moduledoc.)
+          _event, measurements, %{provider: "embedding"} = metadata, _config ->
+            send(test_pid, {:provider_error_emitted, measurements, metadata})
+
+          _event, _measurements, _metadata, _config ->
+            :ok
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+    end
+
+    test "a genuine 5xx failure emits provider=embedding class=:transient" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+      attach_provider_error_listener(self())
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, {:api_error, 500, :provider_error}}
+      end)
+
+      assert {:error, {:api_error, 500, _}} = Knowledge.generate_embedding(tenant.id, "q")
+
+      assert_received {:provider_error_emitted, %{count: 1}, metadata}
+      assert metadata == %{provider: "embedding", class: :transient}
+    end
+
+    test "a per-tenant 4xx (credential/quota) NEVER emits provider_error (gated by breaker_countable?/1, mirrors the circuit breaker exemption)" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+      attach_provider_error_listener(self())
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, {:api_error, 401, :provider_error}}
+      end)
+
+      assert {:error, {:api_error, 401, _}} = Knowledge.generate_embedding(tenant.id, "q")
+
+      refute_received {:provider_error_emitted, _measurements, _metadata}
+    end
+
+    test "a keyless tenant's :no_api_key never emits provider_error (a config gap, not a provider incident)" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+      attach_provider_error_listener(self())
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, :no_api_key}
+      end)
+
+      assert {:error, :no_api_key} = Knowledge.generate_embedding(tenant.id, "q")
+
+      refute_received {:provider_error_emitted, _measurements, _metadata}
+    end
+
+    test "the circuit breaker's own :circuit_open short-circuit never emits provider_error (a derived, already-counted consequence)" do
+      %{tenant: tenant} = setup_tenant()
+      Knowledge.reset_circuit_breaker(tenant.id)
+
+      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
+        {:error, {:api_error, 500, :provider_error}}
+      end)
+
+      # Trip the breaker first (3 failures).
+      for _i <- 1..3 do
+        Knowledge.generate_embedding(tenant.id, "q")
+      end
+
+      attach_provider_error_listener(self())
+      assert {:error, :circuit_open} = Knowledge.generate_embedding(tenant.id, "q")
+
+      refute_received {:provider_error_emitted, _measurements, _metadata}
+    end
+  end
+end

--- a/test/loopctl/knowledge_semantic_search_test.exs
+++ b/test/loopctl/knowledge_semantic_search_test.exs
@@ -1229,100 +1229,15 @@ defmodule Loopctl.KnowledgeSemanticSearchTest do
     end
   end
 
-  # US-34.3 review fix (MED #1): `run_embedding_task/3` is the single choke point
-  # for the `[:loopctl, :llm, :provider_error]` signal's embedding half — it must
-  # fire for EVERY embedding call site (not just the two Oban workers), including
-  # `Knowledge.generate_embedding/3` called directly, which is what every
-  # query-time caller (combined/semantic search, novelty scoring, `Memory.recall/2`,
-  # promotion) ultimately does. Prior to the fix, none of these calls emitted the
-  # signal at all — only the workers did.
-  describe "generate_embedding/3 - provider_error telemetry (US-34.3 review fix MED #1)" do
-    defp attach_provider_error_listener(test_pid) do
-      handler_id = {:generate_embedding_provider_error_test, System.unique_integer([:positive])}
-
-      :telemetry.attach(
-        handler_id,
-        [:loopctl, :llm, :provider_error],
-        fn
-          # Forward ONLY embedding-provider events. `[:loopctl, :llm, :provider_error]`
-          # is a VM-GLOBAL telemetry event, so under `async: true` a concurrent
-          # Anthropic-path test emitting it with provider="anthropic" would otherwise
-          # leak into this test's mailbox — failing the `assert_received`/
-          # `refute_received` assertions below non-deterministically.
-          _event, measurements, %{provider: "embedding"} = metadata, _config ->
-            send(test_pid, {:provider_error_emitted, measurements, metadata})
-
-          _event, _measurements, _metadata, _config ->
-            :ok
-        end,
-        nil
-      )
-
-      on_exit(fn -> :telemetry.detach(handler_id) end)
-    end
-
-    test "a genuine 5xx failure emits provider=embedding class=:transient" do
-      %{tenant: tenant} = setup_tenant()
-      Knowledge.reset_circuit_breaker(tenant.id)
-      attach_provider_error_listener(self())
-
-      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
-        {:error, {:api_error, 500, :provider_error}}
-      end)
-
-      assert {:error, {:api_error, 500, _}} = Knowledge.generate_embedding(tenant.id, "q")
-
-      assert_received {:provider_error_emitted, %{count: 1}, metadata}
-      assert metadata == %{provider: "embedding", class: :transient}
-    end
-
-    test "a per-tenant 4xx (credential/quota) NEVER emits provider_error (gated by breaker_countable?/1, mirrors the circuit breaker exemption)" do
-      %{tenant: tenant} = setup_tenant()
-      Knowledge.reset_circuit_breaker(tenant.id)
-      attach_provider_error_listener(self())
-
-      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
-        {:error, {:api_error, 401, :provider_error}}
-      end)
-
-      assert {:error, {:api_error, 401, _}} = Knowledge.generate_embedding(tenant.id, "q")
-
-      refute_received {:provider_error_emitted, _measurements, _metadata}
-    end
-
-    test "a keyless tenant's :no_api_key never emits provider_error (a config gap, not a provider incident)" do
-      %{tenant: tenant} = setup_tenant()
-      Knowledge.reset_circuit_breaker(tenant.id)
-      attach_provider_error_listener(self())
-
-      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
-        {:error, :no_api_key}
-      end)
-
-      assert {:error, :no_api_key} = Knowledge.generate_embedding(tenant.id, "q")
-
-      refute_received {:provider_error_emitted, _measurements, _metadata}
-    end
-
-    test "the circuit breaker's own :circuit_open short-circuit never emits provider_error (a derived, already-counted consequence)" do
-      %{tenant: tenant} = setup_tenant()
-      Knowledge.reset_circuit_breaker(tenant.id)
-
-      Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
-        {:error, {:api_error, 500, :provider_error}}
-      end)
-
-      # Trip the breaker first (3 failures).
-      for _i <- 1..3 do
-        Knowledge.generate_embedding(tenant.id, "q")
-      end
-
-      attach_provider_error_listener(self())
-      assert {:error, :circuit_open} = Knowledge.generate_embedding(tenant.id, "q")
-
-      refute_received {:provider_error_emitted, _measurements, _metadata}
-    end
-  end
+  # NOTE: the `generate_embedding/3 - provider_error telemetry (US-34.3 review fix
+  # MED #1)` describe block was EXTRACTED to the sibling module
+  # `test/loopctl/knowledge_semantic_search_provider_error_test.exs`, which runs
+  # `async: false`. Those tests attach a handler on the VM-global
+  # `[:loopctl, :llm, :provider_error]` telemetry event, whose metadata carries no
+  # `tenant_id` (see `Loopctl.LLM.record_provider_error/2`), so the handler cannot
+  # be tenant-scoped and a concurrent embedding emitter would leak into its mailbox
+  # and trip `refute_received`. Keeping this file `async: true` requires them to
+  # live in the non-async sibling.
 
   # --- Score normalization edge case ---
 

--- a/test/loopctl/llm/anthropic_test.exs
+++ b/test/loopctl/llm/anthropic_test.exs
@@ -2,8 +2,33 @@ defmodule Loopctl.Llm.AnthropicTest do
   @moduledoc """
   The tenant's API key is a secret — it must NEVER appear in any log line, across
   ALL response branches of the client (review #16).
+
+  ## Why `async: false` (deliberate, not an oversight)
+
+  Most tests here attach a GLOBAL `:telemetry` handler on the VM-global event
+  `[:loopctl, :llm, :provider_error]` and assert on what lands in the test
+  process mailbox (`assert_received` / `refute_received`). The emitter in
+  `Loopctl.LLM.record_provider_error/2` DELIBERATELY puts NO `tenant_id` (nor any
+  high-cardinality id) in the event metadata — see the "NEVER `tenant_id`" note
+  in `lib/loopctl/llm.ex`. Because the metadata carries no tenant, the handlers
+  CANNOT be tenant-scoped: the best they can do is filter on `provider:
+  "anthropic"` (which they do). Under `async: true` that filter is not enough —
+  ANY concurrently-running test whose Anthropic path emits a `provider_error`
+  with `provider: "anthropic"` (content extraction/classification/merge/
+  memory-promotion all funnel through this shared client) would leak a
+  `{:provider_error_emitted, ...}` / `:unexpected_provider_error` message into a
+  listener's mailbox and trip the `refute_received` / metadata assertions
+  non-deterministically. The admission-gate listener does not even filter by
+  provider, so an embedding-path emission would leak into it too. This file is
+  ALSO an emitter: its 401/429/500/transport capture_log tests each record a
+  `provider_error`, so under async it would leak INTO other files' listeners.
+  A non-async module never runs concurrently with any other module
+  (`ExUnit.Case` `:async` docs), so no cross-file emitter is running while these
+  listeners are attached and no other file's listener is attached while these
+  emitters run. This mirrors `test/loopctl/knowledge_semantic_search_provider_error_test.exs`,
+  which documents `async: false` for exactly this VM-global-telemetry reason.
   """
-  use Loopctl.DataCase, async: true
+  use Loopctl.DataCase, async: false
 
   import ExUnit.CaptureLog
 
@@ -116,13 +141,14 @@ defmodule Loopctl.Llm.AnthropicTest do
         [:loopctl, :llm, :provider_error],
         fn
           # Forward ONLY this provider's events. `[:loopctl, :llm, :provider_error]`
-          # is a VM-GLOBAL telemetry event, so under `async: true` a concurrent
-          # embedding-path test (Knowledge.generate_embedding / the US-37.1
-          # embedding worker tests) emitting it with provider="embedding" would
-          # otherwise leak into THIS test's mailbox and fail the
-          # `assert_received {:provider_error_emitted, ...}` (received "embedding",
-          # expected "anthropic"). Filtering at the handler makes the assertion
-          # deterministic regardless of test scheduling.
+          # is a VM-GLOBAL telemetry event: a concurrent embedding-path test
+          # (Knowledge.generate_embedding / the US-37.1 embedding worker tests)
+          # emitting it with provider="embedding" must NOT be mistaken for this
+          # test's Anthropic call. Filtering at the handler keeps the
+          # `assert_received {:provider_error_emitted, ...}` assertion targeting
+          # only anthropic events. (This module is `async: false` — so no
+          # cross-file emitter runs concurrently at all — for exactly this
+          # VM-global-telemetry reason; see @moduledoc.)
           _event, measurements, %{provider: "anthropic"} = metadata, _config ->
             send(test_pid, {:provider_error_emitted, measurements, metadata})
 
@@ -213,9 +239,10 @@ defmodule Loopctl.Llm.AnthropicTest do
         handler_id,
         [:loopctl, :llm, :provider_error],
         fn
-          # Filter to this provider — the event is VM-global, so a concurrent
+          # Filter to this provider — the event is VM-global, so an unrelated
           # embedding-path emission must NOT be mistaken for this test's call
-          # emitting a provider_error on a successful 200.
+          # emitting a provider_error on a successful 200. (Module is
+          # `async: false` so no concurrent emitter runs; see @moduledoc.)
           _event, _measurements, %{provider: "anthropic"}, _config ->
             send(test_pid, :unexpected_provider_error)
 

--- a/test/loopctl/memory_context_test.exs
+++ b/test/loopctl/memory_context_test.exs
@@ -416,8 +416,40 @@ defmodule Loopctl.MemoryContextTest do
       # the horizon. `meta.underfilled` MUST surface that (the SAME accepted tradeoff
       # as the cross-subject case verified at prod scale in `ScaleRecallTest` /
       # US-28.5, here made deterministic with a tiny fixed pool + fixed embeddings).
-      near = List.replace_at(List.duplicate(0.0, 1536), 0, 1.0)
-      far = List.replace_at(List.duplicate(0.0, 1536), 1, 1.0)
+      # TEST-UNIQUE, well-separated embedding points. `near`/`far` must NOT sit on the
+      # globally-common dim-0/dim-1 one-hots: the `memories` pgvector HNSW index is a
+      # SINGLE index physically shared across every tenant/test, and its ef_search
+      # candidate set is filled BEFORE the tenant/project filter. Other tests writing
+      # rows at a shared point (e.g. the per-tenant default embedding's hot dims, or any
+      # dim-0 one-hot) would crowd this test's candidate set and non-deterministically
+      # evict its 6 NEAR fillers → the under-fill assertion flakes. Mirroring the
+      # per-tenant `deterministic_embedding/1` fix (test/support/data_case.ex), derive
+      # the hot dimensions from THIS test's tenant — shared by projects a and b, which
+      # share a tenant_id, so both projects' rows land on the SAME points — via 16
+      # independent hashes, so another test collides only if all sixteen hashes collide
+      # (negligible). `near` and `far` are kept ORTHOGONAL (disjoint hot dims) so the
+      # intended geometry is EXACT: every "NEAR" text is cosine-distance 0 from the
+      # query, `far` is distance 1.
+      near_dims =
+        for salt <- 0..15,
+            into: MapSet.new(),
+            do: rem(:erlang.phash2({a.tenant_id, :near, salt}), 1536)
+
+      far_dims =
+        for salt <- 0..15,
+            into: MapSet.new(),
+            do: rem(:erlang.phash2({a.tenant_id, :far, salt}), 1536)
+
+      # Guarantee near ⊥ far even if a hash lands a near dim and a far dim on the same
+      # index (both vectors stay multi-hot and test-unique).
+      far_dims = MapSet.difference(far_dims, near_dims)
+
+      one_hot = fn dims ->
+        Enum.map(0..1535, fn i -> if MapSet.member?(dims, i), do: 1.0, else: 0.0 end)
+      end
+
+      near = one_hot.(near_dims)
+      far = one_hot.(far_dims)
 
       # Deterministic distances: "NEAR"-tagged text (query + the 6 pool fillers) embeds
       # to `near` (cosine distance 0), everything else to the orthogonal `far`

--- a/test/loopctl/orchestrator/orchestrator_test.exs
+++ b/test/loopctl/orchestrator/orchestrator_test.exs
@@ -3,6 +3,7 @@ defmodule Loopctl.OrchestratorTest do
 
   setup :verify_on_exit!
 
+  alias Ecto.Adapters.SQL.Sandbox
   alias Loopctl.Orchestrator
 
   describe "save_state/4" do
@@ -155,8 +156,28 @@ defmodule Loopctl.OrchestratorTest do
         version: 1
       })
 
+      parent = self()
+
+      # This file is `async: true`, so DataCase starts the sandbox owner
+      # connections with `shared: false` (per-test ownership). A spawned
+      # `Task.async` process is NOT auto-granted the owner's sandboxed
+      # connection — without an explicit `Sandbox.allow/3` it runs on a
+      # different connection that cannot see the seeded version-1 row inside
+      # this test's transaction, so the two writers race nondeterministically
+      # (two successes, two conflicts, or an ownership crash). `save_state/3`
+      # performs all its work through `Loopctl.AdminRepo`; both repos are
+      # allowed here to share this test's single sandboxed connection, which
+      # is what serializes the two atomic `UPDATE ... WHERE version = 1`
+      # statements at the DB and makes the winner/conflict split deterministic.
+      allow_sandbox = fn ->
+        Sandbox.allow(Loopctl.Repo, parent, self())
+        Sandbox.allow(Loopctl.AdminRepo, parent, self())
+      end
+
       task1 =
         Task.async(fn ->
+          allow_sandbox.()
+
           Orchestrator.save_state(tenant.id, project.id, %{
             state_key: "main",
             state_data: %{"writer" => 1},
@@ -166,6 +187,8 @@ defmodule Loopctl.OrchestratorTest do
 
       task2 =
         Task.async(fn ->
+          allow_sandbox.()
+
           Orchestrator.save_state(tenant.id, project.id, %{
             state_key: "main",
             state_data: %{"writer" => 2},

--- a/test/loopctl/progress/claim_lock_test.exs
+++ b/test/loopctl/progress/claim_lock_test.exs
@@ -1,0 +1,162 @@
+defmodule Loopctl.Progress.ClaimLockTest do
+  @moduledoc """
+  Deterministic proof that `Loopctl.Progress.claim_story/3`'s
+  `SELECT ... FOR UPDATE` story-row lock (see `lock_story/2`) genuinely
+  serializes concurrent claims across SEPARATE DB sessions, so exactly one
+  agent wins the claim and the loser is turned away with `:invalid_transition`.
+
+  A two-`Task.async` race under `Ecto.Adapters.SQL.Sandbox`'s default shared
+  mode cannot test this: the sandbox multiplexes every allowed process onto ONE
+  checked-out connection, so connection-level serialization alone already makes
+  the loser re-read the winner's committed row REGARDLESS of any application
+  lock — the same reasoning documented in
+  `token_usage/correction_lock_test.exs` and `tenants/enrollment_lock_test.exs`.
+  Worse, two processes issuing a `FOR UPDATE` transaction on that single shared
+  connection interleave nondeterministically (the old HTTP-layer race test in
+  `story_status_controller_test.exs` was flaky for exactly this reason).
+
+  So this uses two genuinely independent `sandbox: false` sessions,
+  `async: false`, and cleans up its own real (committed) rows via `on_exit`
+  (deleting the tenant cascades ON DELETE CASCADE to its project/epic/story/
+  agent rows; the audit-log rows have no tenant FK and are harmless orphans).
+  Without the lock, two separate sessions could both read `:contracted`, both
+  write `:assigned`, and both commit — this test would then see two winners.
+  """
+
+  use ExUnit.Case, async: false
+
+  import Ecto.Query, only: [from: 2]
+  import Loopctl.Fixtures
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Loopctl.AdminRepo
+  alias Loopctl.Capabilities.CapabilityToken
+  alias Loopctl.Progress
+  alias Loopctl.Tenants.Tenant
+  alias Loopctl.WorkBreakdown.Story
+
+  setup do
+    # This test uses ExUnit.Case (NOT DataCase), so it does not get DataCase's
+    # default Mox stubs. claim_story/3 mints a best-effort capability, whose path
+    # (Capabilities.mint -> TenantKeys.fetch_and_cache) calls MockSecrets.get; an
+    # unstubbed mock raises. Stub it exactly as DataCase does (audit key
+    # unavailable -> mint returns {:error, _} -> best-effort no-op). Global mode
+    # because the two claimers run in SEPARATE Task processes that must see the
+    # stub; safe here since the module is async: false.
+    Mox.set_mox_global()
+    Mox.stub(Loopctl.MockSecrets, :get, fn _name -> {:error, :not_found} end)
+
+    :ok = Sandbox.checkout(AdminRepo, sandbox: false)
+    :ok
+  end
+
+  # Mirrors Progress.lock_story/2: the same `SELECT ... FOR UPDATE` on the story
+  # row, scoped by (id, tenant_id).
+  defp lock_row(tenant_id, story_id) do
+    from(s in Story,
+      where: s.id == ^story_id and s.tenant_id == ^tenant_id,
+      lock: "FOR UPDATE"
+    )
+    |> AdminRepo.one()
+  end
+
+  defp contracted_story_with_two_agents do
+    tenant = fixture(:tenant)
+    project = fixture(:project, %{tenant_id: tenant.id})
+    epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
+
+    story =
+      fixture(:story, %{tenant_id: tenant.id, epic_id: epic.id, agent_status: :contracted})
+
+    agent_a = fixture(:agent, %{tenant_id: tenant.id, agent_type: :implementer})
+    agent_b = fixture(:agent, %{tenant_id: tenant.id, agent_type: :implementer})
+
+    cleanup(tenant)
+
+    %{tenant: tenant, story: story, agent_a: agent_a, agent_b: agent_b}
+  end
+
+  defp cleanup(tenant) do
+    on_exit(fn ->
+      :ok = Sandbox.checkout(AdminRepo, sandbox: false)
+      # capability_tokens has ON DELETE :nothing, so clear any row a best-effort
+      # start_cap mint may have created before deleting the tenant.
+      AdminRepo.delete_all(from(c in CapabilityToken, where: c.tenant_id == ^tenant.id))
+      AdminRepo.delete_all(from(t in Tenant, where: t.id == ^tenant.id))
+    end)
+  end
+
+  test "the story-row FOR UPDATE lock blocks a second real session while held" do
+    %{tenant: tenant, story: story} = contracted_story_with_two_agents()
+
+    parent = self()
+
+    holder =
+      Task.async(fn ->
+        :ok = Sandbox.checkout(AdminRepo, sandbox: false)
+
+        AdminRepo.transaction(fn ->
+          lock_row(tenant.id, story.id)
+          send(parent, :locked)
+
+          receive do
+            :release -> :ok
+          end
+        end)
+      end)
+
+    assert_receive :locked, 2_000
+
+    # A different real session attempting the SAME row lock must NOT complete
+    # instantly — it blocks until the holder's transaction ends.
+    waiter =
+      Task.async(fn ->
+        :ok = Sandbox.checkout(AdminRepo, sandbox: false)
+        start = System.monotonic_time(:millisecond)
+        AdminRepo.transaction(fn -> lock_row(tenant.id, story.id) end)
+        System.monotonic_time(:millisecond) - start
+      end)
+
+    Process.sleep(200)
+    send(holder.pid, :release)
+    Task.await(holder, 2_000)
+
+    elapsed_ms = Task.await(waiter, 2_000)
+    assert elapsed_ms >= 150
+  end
+
+  test "concurrent claim: exactly one agent wins, the loser is rejected :invalid_transition" do
+    %{tenant: tenant, story: story, agent_a: agent_a, agent_b: agent_b} =
+      contracted_story_with_two_agents()
+
+    task_a =
+      Task.async(fn ->
+        :ok = Sandbox.checkout(AdminRepo, sandbox: false)
+        Progress.claim_story(tenant.id, story.id, agent_id: agent_a.id)
+      end)
+
+    task_b =
+      Task.async(fn ->
+        :ok = Sandbox.checkout(AdminRepo, sandbox: false)
+        Progress.claim_story(tenant.id, story.id, agent_id: agent_b.id)
+      end)
+
+    results = [Task.await(task_a, 5_000), Task.await(task_b, 5_000)]
+
+    winners = Enum.filter(results, &match?({:ok, %{agent_status: :assigned}}, &1))
+    losers = Enum.filter(results, &match?({:error, {:invalid_transition, _}}, &1))
+
+    # The FOR UPDATE lock guarantees the SECOND claim to acquire it re-reads the
+    # winner's already-committed :assigned row and fails validation — so it can
+    # never also win. Exactly one succeeds, one is refused. NOT both-succeed.
+    assert length(winners) == 1
+    assert length(losers) == 1
+
+    # The winning agent is the one recorded on the persisted row.
+    [{:ok, won}] = winners
+    reloaded = AdminRepo.get!(Story, story.id)
+    assert reloaded.agent_status == :assigned
+    assert reloaded.assigned_agent_id == won.assigned_agent_id
+    assert won.assigned_agent_id in [agent_a.id, agent_b.id]
+  end
+end

--- a/test/loopctl/rate_limiter/postgres_test.exs
+++ b/test/loopctl/rate_limiter/postgres_test.exs
@@ -26,8 +26,22 @@ defmodule Loopctl.RateLimiter.PostgresTest do
 
   defp bucket(prefix), do: "test:#{prefix}:#{Ecto.UUID.generate()}"
 
+  # Pin the DI clock to a fixed instant well inside a single unix-minute window so
+  # a multi-call `check_rate` SEQUENCE cannot straddle a real 60s window boundary
+  # mid-test. Without this the default `MockClock` stub (DataCase) returns real
+  # `DateTime.utc_now/0`; under full-suite load the several sequential AdminRepo
+  # round-trips can cross the boundary, roll the counter to a fresh window_start,
+  # and reset the count mid-sequence — the source of the intermittent
+  # off-by-a-count / unexpected-allow failures. The instant is mid-window (t=30s)
+  # so it is nowhere near either edge.
+  defp pin_clock(instant \\ ~U[2026-07-15 10:00:30Z]) do
+    stub(Loopctl.MockClock, :utc_now, fn -> instant end)
+    :ok
+  end
+
   describe "check_rate/3 fixed-window counting" do
     test "allows up to the limit then denies within the same window" do
+      pin_clock()
       b = bucket("count")
       limit = 5
 
@@ -52,6 +66,7 @@ defmodule Loopctl.RateLimiter.PostgresTest do
     end
 
     test "tenant/key isolation: different buckets do not share a counter" do
+      pin_clock()
       b1 = bucket("iso-a")
       b2 = bucket("iso-b")
       limit = 2
@@ -165,6 +180,7 @@ defmodule Loopctl.RateLimiter.PostgresTest do
       # allow/deny sequence single-node — so selecting it changes only the STORE
       # (per-node → shared), never the per-request decision a limit yields. This
       # runs the real `Postgres.check_rate/3`, so deleting it fails the test.
+      pin_clock()
       b = bucket("parity")
       limit = 4
 

--- a/test/loopctl/workers/article_embedding_worker_test.exs
+++ b/test/loopctl/workers/article_embedding_worker_test.exs
@@ -436,12 +436,21 @@ defmodule Loopctl.Workers.ArticleEmbeddingWorkerTest do
       ref = make_ref()
       handler_id = "test-skip-#{inspect(ref)}"
       parent = self()
+      this_tenant_id = tenant.id
 
+      # Telemetry handlers are VM-GLOBAL and this event name is shared across the
+      # article/memory/batch embedding workers, so a CONCURRENT async test's emission
+      # would otherwise fire THIS handler and leak into the mailbox — tripping the
+      # assert_received below. Forward ONLY events for this test's tenant (the emit
+      # site tags metadata.tenant_id) so recall stays deterministic under full-suite
+      # load, matching the memory_promotion_worker_test attach_telemetry pattern.
       :telemetry.attach(
         handler_id,
         [:loopctl, :embedding, :skipped_no_key],
         fn _event, measurements, metadata, _cfg ->
-          send(parent, {:telemetry, ref, measurements, metadata})
+          if metadata[:tenant_id] == this_tenant_id do
+            send(parent, {:telemetry, ref, measurements, metadata})
+          end
         end,
         nil
       )

--- a/test/loopctl/workers/knowledge_lint_worker_test.exs
+++ b/test/loopctl/workers/knowledge_lint_worker_test.exs
@@ -356,9 +356,28 @@ defmodule Loopctl.Workers.KnowledgeLintWorkerTest do
       assert :ok = KnowledgeLintWorker.perform(%Oban.Job{args: %{"tenant_id" => tenant.id}})
       assert :ok = KnowledgeLintWorker.perform(%Oban.Job{args: %{"tenant_id" => tenant.id}})
 
+      # The pair is promoted exactly ONCE no matter how many times the worker runs
+      # (guarded by promote_conflicts/1's `not exists` check AND the article_links
+      # unique index — a same-direction re-insert can never mint a second row).
       assert [_only_one] = conflict_links(tenant.id, a.id, b.id)
-      assert [_, second] = lint_audit_entries(tenant.id) |> Enum.sort_by(& &1.inserted_at)
-      assert second.new_state["conflicts_promoted"] == 0
+
+      # Idempotency is ORDER-INDEPENDENT: across the two runs exactly one promotion
+      # happened (the first); the other run promoted nothing new. Assert the MULTISET of
+      # per-run promotion counts, not positional order. `lint_audit_entries/1` is
+      # unordered and audit `inserted_at` is NOT a total order across two same-tenant
+      # runs — the audit_log column carries a DB-side `now()` (transaction-timestamp)
+      # default, so two entries written in this test's single sandbox transaction can
+      # share an `inserted_at` to the microsecond. Sorting on that key alone then leaves
+      # the "second" slot at the mercy of arbitrary heap return order and can surface the
+      # first run's entry (conflicts_promoted == 1) — the intermittent failure. (The
+      # production audit-history reader guards the same collision with a mandatory
+      # (inserted_at, id) tiebreak.)
+      promotions =
+        lint_audit_entries(tenant.id)
+        |> Enum.map(& &1.new_state["conflicts_promoted"])
+        |> Enum.sort()
+
+      assert promotions == [0, 1]
     end
   end
 

--- a/test/loopctl/workers/memory_promotion_worker_test.exs
+++ b/test/loopctl/workers/memory_promotion_worker_test.exs
@@ -54,14 +54,26 @@ defmodule Loopctl.Workers.MemoryPromotionWorkerTest do
 
   # A 1536-dim unit vector keyed on `seed` — distinct seeds are orthogonal (cosine
   # score 0, not near-dup), identical seeds are identical (score 1.0, near-dup).
+  # A 16-hot 1536-dim vector keyed on the full seed term. Two seeds collide only if
+  # all sixteen independent hashes collide (negligible), so distinct seeds are
+  # near-orthogonal and equal seeds are identical (distance 0) — exactly what the
+  # near-dup assertions need.
   defp unit_vec(seed) do
-    idx = rem(:erlang.phash2(seed), 1536)
-    Enum.map(0..1535, fn i -> if i == idx, do: 1.0, else: 0.0 end)
+    hot = for salt <- 0..15, into: MapSet.new(), do: rem(:erlang.phash2({seed, salt}), 1536)
+    Enum.map(0..1535, fn i -> if MapSet.member?(hot, i), do: 1.0, else: 0.0 end)
   end
 
+  # Fold `tenant_id` into the embedding seed so THIS test's vectors live in their
+  # own well-separated region of the globally-shared pgvector HNSW index. Without
+  # this the text-only seed puts every tenant's "shared" near-dup at the SAME
+  # index point, where other tenants' concurrent rows crowd it and the ef_search
+  # graph walk non-deterministically misses the exact match under full-suite load
+  # (issue #421). Per-tenant seeding preserves the WITHIN-test geometry (equal
+  # text_to_seed → identical vector → near-dup; distinct → near-orthogonal) while
+  # isolating it across tenants, so near-dup recall is deterministic.
   defp stub_embeddings(text_to_seed) do
-    stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, text ->
-      {:ok, unit_vec(text_to_seed.(text))}
+    stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn tenant_id, text ->
+      {:ok, unit_vec({tenant_id, text_to_seed.(text)})}
     end)
   end
 

--- a/test/loopctl_web/controllers/story_status_controller_test.exs
+++ b/test/loopctl_web/controllers/story_status_controller_test.exs
@@ -3,7 +3,6 @@ defmodule LoopctlWeb.StoryStatusControllerTest do
 
   import Ecto.Query
 
-  alias Ecto.Adapters.SQL.Sandbox
   alias Loopctl.AdminRepo
   alias Loopctl.Audit.AuditLog
   alias Loopctl.Skills
@@ -1058,57 +1057,11 @@ defmodule LoopctlWeb.StoryStatusControllerTest do
     end
   end
 
-  # --- Concurrent claim race condition test ---
-
-  describe "concurrent claim race condition" do
-    @tag :capture_log
-    test "only one agent wins the claim", %{conn: _conn} do
-      tenant = fixture(:tenant)
-      project = fixture(:project, %{tenant_id: tenant.id})
-      epic = fixture(:epic, %{tenant_id: tenant.id, project_id: project.id})
-
-      story =
-        fixture(:story, %{tenant_id: tenant.id, epic_id: epic.id, agent_status: :contracted})
-
-      agent_a = fixture(:agent, %{tenant_id: tenant.id, agent_type: :implementer})
-      agent_b = fixture(:agent, %{tenant_id: tenant.id, agent_type: :implementer})
-
-      {raw_key_a, _} =
-        fixture(:api_key, %{tenant_id: tenant.id, role: :agent, agent_id: agent_a.id})
-
-      {raw_key_b, _} =
-        fixture(:api_key, %{tenant_id: tenant.id, role: :agent, agent_id: agent_b.id})
-
-      # Allow sandbox access for spawned tasks
-      parent = self()
-
-      task_a =
-        Task.async(fn ->
-          Sandbox.allow(Loopctl.Repo, parent, self())
-          Sandbox.allow(Loopctl.AdminRepo, parent, self())
-
-          build_conn()
-          |> auth_conn(raw_key_a)
-          |> post(~p"/api/v1/stories/#{story.id}/claim")
-        end)
-
-      task_b =
-        Task.async(fn ->
-          Sandbox.allow(Loopctl.Repo, parent, self())
-          Sandbox.allow(Loopctl.AdminRepo, parent, self())
-
-          build_conn()
-          |> auth_conn(raw_key_b)
-          |> post(~p"/api/v1/stories/#{story.id}/claim")
-        end)
-
-      result_a = Task.await(task_a, 10_000)
-      result_b = Task.await(task_b, 10_000)
-
-      statuses = Enum.sort([result_a.status, result_b.status])
-
-      # Exactly one 200 and one 409
-      assert statuses == [200, 409]
-    end
-  end
+  # The concurrent-claim race invariant ("only one agent wins the claim") is
+  # proven deterministically in `test/loopctl/progress/claim_lock_test.exs`
+  # using two independent `sandbox: false` DB sessions. It CANNOT be tested at
+  # the HTTP layer here: the sandbox multiplexes every allowed Task onto ONE
+  # shared connection, so the claim's `SELECT ... FOR UPDATE` lock can neither
+  # serialize the two requests nor be distinguished from no lock at all — the
+  # old two-`Task.async` POST test was flaky for exactly that reason.
 end

--- a/test/loopctl_web/controllers/tenant_authenticator_controller_test.exs
+++ b/test/loopctl_web/controllers/tenant_authenticator_controller_test.exs
@@ -9,7 +9,6 @@ defmodule LoopctlWeb.TenantAuthenticatorControllerTest do
 
   import Loopctl.Fixtures
 
-  alias Ecto.Adapters.SQL.Sandbox
   alias Loopctl.AdminRepo
   alias Loopctl.Audit
   alias Loopctl.Tenants
@@ -617,70 +616,25 @@ defmodule LoopctlWeb.TenantAuthenticatorControllerTest do
     end
   end
 
-  # review #1 regression: the residual double-first-enroll race, at the HTTP
-  # layer. Two concurrent POST .../authenticators against an agent_rooted
-  # tenant, BOTH with NO reauth_assertion (both are first-enroll attempts).
-  # Exactly one must 201 (flip to human_anchored + enroll); the loser must be
-  # rejected 401 reauth_required by the under-lock gate — it must NOT get a
-  # 201 grafting a second, possession-unproven device.
-  describe "concurrent double-first-enroll at the HTTP layer (review #1)" do
-    @tag :capture_log
-    test "exactly one 201; the loser gets 401 reauth_required, never 201", %{conn: _conn} do
-      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
-      {raw_key, _} = fixture(:api_key, tenant_id: tenant.id, role: :user)
-
-      # Two independent single-use challenges, issued sequentially before the race.
-      issue_challenge = fn ->
-        build_conn()
-        |> authed(raw_key)
-        |> post(~p"/api/v1/tenants/#{tenant.id}/authenticators/challenge", %{})
-        |> json_response(200)
-        |> Map.fetch!("data")
-        |> Map.fetch!("challenge_id")
-      end
-
-      challenge_a = issue_challenge.()
-      challenge_b = issue_challenge.()
-
-      parent = self()
-
-      fire = fn challenge_id ->
-        Task.async(fn ->
-          Sandbox.allow(Loopctl.Repo, parent, self())
-          Sandbox.allow(Loopctl.AdminRepo, parent, self())
-          Mox.allow(Loopctl.MockWebAuthn, parent, self())
-          Mox.allow(Loopctl.MockRateLimiter, parent, self())
-
-          build_conn()
-          |> authed(raw_key)
-          |> post(
-            ~p"/api/v1/tenants/#{tenant.id}/authenticators",
-            attestation_body(challenge_id)
-          )
-        end)
-      end
-
-      task_a = fire.(challenge_a)
-      task_b = fire.(challenge_b)
-
-      result_a = Task.await(task_a, 10_000)
-      result_b = Task.await(task_b, 10_000)
-
-      assert Enum.sort([result_a.status, result_b.status]) == [201, 401]
-
-      loser = Enum.find([result_a, result_b], &(&1.status == 401))
-      assert Jason.decode!(loser.resp_body)["error"]["code"] == "reauth_required"
-
-      # Exactly ONE device was grafted on; the tenant is human_anchored with a
-      # single upgrade entry.
-      assert RootAuthenticators.count_by_tenant(tenant.id) == 1
-      {:ok, reloaded} = Tenants.get_tenant(tenant.id)
-      assert reloaded.trust_tier == :human_anchored
-
-      {:ok, upgraded} =
-        Audit.list_entries(tenant.id, entity_type: "tenant", action: "tenant_trust_upgraded")
-
-      assert upgraded.total == 1
-    end
-  end
+  # review #1 regression — the residual double-first-enroll race: two concurrent
+  # first-enrollments on an agent_rooted tenant must result in EXACTLY ONE 201
+  # (flip to human_anchored + enroll) with the loser rejected :reauth_required by
+  # the under-lock gate, never a second possession-unproven device grafted on.
+  #
+  # This invariant is proven DETERMINISTICALLY by
+  # `test/loopctl/tenants/enrollment_lock_test.exs`, which races the enroll path
+  # over two GENUINELY independent DB sessions (`async: false` +
+  # `Sandbox.checkout(AdminRepo, sandbox: false)`). It cannot be proven at this
+  # HTTP layer under `use ConnCase, async: true`: a `Task.async` race there
+  # multiplexes every `Sandbox.allow`-shared process onto ONE checked-out
+  # sandbox connection, so the two enroll transactions never truly contend on the
+  # tenant-row `FOR UPDATE` lock — the outcome is decided by nondeterministic
+  # DBConnection interleaving (intermittently both-201 / both-401 / a deadlock
+  # crash), NOT by the production lock. That is exactly the sandbox limitation
+  # documented in `test/loopctl/rate_limiter/postgres_concurrency_test.exs` and in
+  # `enrollment_lock_test.exs`'s own moduledoc, so this describe block was a
+  # structurally-flaky duplicate and was removed. The controller's mapping of
+  # `Enrollment.enroll -> {:error, :reauth_required}` to HTTP 401
+  # (`error.code == "reauth_required"`) is covered deterministically by the
+  # "subsequent enrollment gate (TC-26.7.2.2)" test above.
 end

--- a/test/loopctl_web/plugs/validate_witness_header_test.exs
+++ b/test/loopctl_web/plugs/validate_witness_header_test.exs
@@ -212,9 +212,29 @@ defmodule LoopctlWeb.Plugs.ValidateWitnessHeaderTest do
       assert Jason.decode!(conn.resp_body)["error"]["code"] == "witness_header_missing"
 
       # Log records the failure but leaks no SQL — struct name / sqlstate only.
+      #
+      # `ExUnit.CaptureLog.with_log` installs a PROCESS-GLOBAL logger handler for
+      # the duration of the block, so under `async: true` a concurrently-running
+      # test module's warning/error log (e.g. `LoopctlWeb.DBErrorLogger`, which
+      # can interpolate raw query text, or the slow-query logger) would land in
+      # this captured buffer. Asserting the ABSENCE of SQL across the whole global
+      # buffer is therefore non-deterministic. The security guarantee under test
+      # is that the PLUG's own emitted line is sanitized — so scope the SQL-absence
+      # checks to exactly the plug's log line(s). A foreign concurrent line can
+      # neither satisfy nor violate this, and the guarantee stays genuinely tested.
       assert log =~ "atomic bootstrap consume failed"
-      refute log =~ "query:"
-      refute log =~ ~r/SELECT|INSERT|UPDATE/
+
+      plug_log_lines =
+        log
+        |> String.split("\n")
+        |> Enum.filter(&String.contains?(&1, "atomic bootstrap consume failed"))
+
+      assert plug_log_lines != [], "expected the plug to log its consume-failure line"
+
+      for line <- plug_log_lines do
+        refute line =~ "query:", "plug log line leaked a query: #{line}"
+        refute line =~ ~r/SELECT|INSERT|UPDATE/, "plug log line leaked SQL: #{line}"
+      end
     end
 
     test "a second bootstrap request from the same key is rejected 412" do

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -131,18 +131,30 @@ defmodule Loopctl.DataCase do
       {:ok, 0}
     end)
 
-    # Default stub for embedding client -- returns a 1536-dim vector of 0.1.
+    # Default stub for embedding client -- a DETERMINISTIC FUNCTION OF THE INPUT
+    # TENANT (see `deterministic_embedding/1`), never a global constant. The old
+    # constant `List.duplicate(0.1, 1536)` made EVERY memory in EVERY tenant
+    # identical, so the single, globally-shared pgvector HNSW index on `memories`
+    # became one giant all-ties clique. Under concurrent full-suite load the graph
+    # walk cannot navigate that clique and non-deterministically MISSED exact
+    # matches, so near-dup supersede duplicated and scoped recalls came back empty
+    # (issue #421). Keying the vector on `tenant_id` gives each tenant its OWN
+    # well-separated point: within a tenant every text still maps to the SAME
+    # vector (so cross-text recall — query "drain" finding "batch drainer" — keeps
+    # working exactly as before, no test rewrites), but tenants no longer crowd
+    # each other's region of the index, so recall is deterministic under load.
     # tenant_id is threaded first (BYO embeddings, #294 extended).
-    Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn _tenant_id, _text ->
-      {:ok, List.duplicate(0.1, 1536)}
+    Mox.stub(Loopctl.MockEmbeddingClient, :generate_embedding, fn tenant_id, _text ->
+      {:ok, deterministic_embedding(tenant_id)}
     end)
 
     # US-37.4: permissive default for the BATCH embedding path -- one 1536-dim vector
     # per input text, preserving input order (the real client maps by response index;
     # this deterministic stub returns them aligned so batch worker/store tests run
-    # unchanged). An empty batch returns [].
-    Mox.stub(Loopctl.MockEmbeddingClient, :generate_embeddings, fn _tenant_id, texts ->
-      {:ok, Enum.map(texts, fn _text -> List.duplicate(0.1, 1536) end)}
+    # unchanged). Keyed on `tenant_id` (never a global constant) for the same
+    # index-navigability reason as the single path above. An empty batch returns [].
+    Mox.stub(Loopctl.MockEmbeddingClient, :generate_embeddings, fn tenant_id, texts ->
+      {:ok, Enum.map(texts, fn _text -> deterministic_embedding(tenant_id) end)}
     end)
 
     # US-37.2: permissive default for the per-node embedding concurrency gate --
@@ -324,5 +336,22 @@ defmodule Loopctl.DataCase do
         opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
       end)
     end)
+  end
+
+  # A DETERMINISTIC per-TENANT embedding for the default MockEmbeddingClient stubs
+  # (stub_all_defaults/0). Returns a 1536-dim vector that is a PURE FUNCTION of the
+  # `tenant_id`, so every tenant occupies its own well-separated point in the
+  # shared pgvector HNSW index while every text WITHIN a tenant maps to the SAME
+  # vector. That separation is what keeps the index navigable (no global all-ties
+  # clique → the issue-#421 recall flake disappears), and the within-tenant
+  # sameness is what preserves the permissive default's existing semantics: a
+  # recall in a tenant matches any of that tenant's memories regardless of query
+  # text, so no recall test needs to set explicit embeddings. Sixteen
+  # hash-selected dimensions are set so two tenants collide only if all sixteen
+  # independent hashes collide (negligible). A non-binary input still hashes fine
+  # via :erlang.phash2/1.
+  defp deterministic_embedding(tenant_id) do
+    hot = for salt <- 0..15, into: MapSet.new(), do: rem(:erlang.phash2({tenant_id, salt}), 1536)
+    Enum.map(0..1535, fn i -> if MapSet.member?(hot, i), do: 1.0, else: 0.0 end)
   end
 end


### PR DESCRIPTION
## What this does

Fixes #421 (flaky MemoryPromotionWorkerTest near-dup supersede) and, in the same pass, de-flakes the rest of the suite's rare tail. Twelve independent flaky tests across seven root-cause classes are fixed. **Every fix is test-side — no production code is changed.**

## Verification

- **0 failures across 60 consecutive full-suite runs** at varied seeds (~292k test executions) after the fixes. Before, the tail produced ~2–3 distinct flaky failures per 25–50 runs.
- `mix precommit` green: 4867 tests, 0 failures, format clean, credo --strict clean, dialyzer 0.

## Root causes and fixes (by class)

**Shared pgvector HNSW index — degenerate/crowded embeddings**
- The DataCase default MockEmbeddingClient stub returned a constant vector for every text, so every memory in every tenant was identical and the single, physically-shared HNSW index became an unnavigable all-ties clique. Under concurrent load the near-dup and semantic recalls non-deterministically missed exact matches. Fixed by keying the default embedding on the stub's tenant_id input (each tenant a well-separated point; within-tenant sameness preserved, so no recall test needed rewriting). The memory promotion fixtures and the memory_context pool-underfill test were given the same tenant/test-unique isolation for their explicit vectors.

**VM-global telemetry leakage**
- Tests attaching a global handler on a VM-global telemetry event and asserting on the mailbox flaked when a concurrent test emitted the same event. Where the metadata carries tenant_id (embedding skip signal), fixed by scoping the handler to the test's tenant (keeps async). Where it carries none by design (llm provider_error), the affected tests were isolated in async:false modules.

**ExUnit.CaptureLog under async**
- CaptureLog installs a process-global log handler, so a whole-buffer "log contains no SQL" assertion caught sibling tests' SQL-bearing log lines. Fixed by scoping the assertion to the plug's own log line — deterministic and a stronger security check.

**Task.async concurrency vs the SQL sandbox**
- orchestrator concurrent-writes: the optimistic lock is correct; the tasks just lacked Sandbox.allow. Added it.
- story_status concurrent-claim and tenant_authenticator double-enroll: these rely on SELECT ... FOR UPDATE, which cannot serialize two processes multiplexed onto one shared sandbox connection, so the HTTP-layer race tests were structurally unable to test their invariant. The enroll invariant was already covered deterministically by enrollment_lock_test (real sandbox:false sessions), so that test was removed. The claim invariant had no such coverage, so its broken HTTP test was replaced with a new deterministic claim_lock_test (real sessions, proves the row lock blocks a second session and yields exactly one winner).

**Injected-clock straddle**
- rate_limiter multi-call counting sequences derived the fixed 60s window from an unpinned MockClock (real time), so a sequence could straddle a minute boundary and reset the counter mid-test. Pinned the clock to a mid-window instant.

**DB-timestamp ordering tie**
- knowledge_lint idempotency sorted audit rows by inserted_at, which defaults to the DB transaction timestamp (constant within the test's single transaction), so the sort was not a total order. Replaced with an order-independent multiset assertion.

## Notes

- The delivery is intentionally atomized into commits per root-cause wave for reviewability; squash-merge is fine.
- Flakiness is probabilistic, so "0 across 60 runs" is strong empirical evidence rather than a proof; the recurring classes above are documented so any future straggler can be triaged quickly.
