### PR TITLE
feat(observability): high-reject-rate ingestion detector + write-outcome rollup (v2.46.0)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -179,7 +179,11 @@ config :loopctl, :ingestion_health,
   establishment_window_hours: 720,
   reject_rate_threshold: 0.5,
   min_attempts: 10,
-  reject_window_days: 7
+  reject_window_days: 7,
+  # Retention (days) for the append-only `ingestion_write_stats` rollup; the hourly
+  # worker prunes older rows so the table (and the cross-tenant reject-rate scan) stays
+  # bounded. Only the rolling `reject_window_days` window is ever read.
+  write_stats_retention_days: 90
 
 # US-33.3: bounded TTL (ms) for the ETS read-through api-key cache. This is the
 # defense-in-depth backstop, NOT the primary invalidation — every revoke/rotate/

--- a/config/config.exs
+++ b/config/config.exs
@@ -165,11 +165,21 @@ config :loopctl,
 # established source_type may go without a new article before `IngestionHealthWorker`
 # flags a `:capture_silence` anomaly; `:establishment_window_hours` scopes
 # establishment to RECENT activity so a wound-down source_type is not flagged forever.
+#
+# PR B2 (no-persist / high-rejection-rate detector): `:reject_rate_threshold` is the
+# fraction of window write attempts above which a source_type is flagged
+# `:high_reject_rate` (rejects / total_attempts > threshold); `:min_attempts` is the
+# minimum window write attempts before that ratio is trusted (noise floor);
+# `:reject_window_days` is the rolling window (days) over the `ingestion_write_stats`
+# rollup the reject-rate scan reads.
 config :loopctl, :ingestion_health,
   monitored_source_types: :all,
   established_threshold: 5,
   staleness_threshold_hours: 72,
-  establishment_window_hours: 720
+  establishment_window_hours: 720,
+  reject_rate_threshold: 0.5,
+  min_attempts: 10,
+  reject_window_days: 7
 
 # US-33.3: bounded TTL (ms) for the ETS read-through api-key cache. This is the
 # defense-in-depth backstop, NOT the primary invalidation — every revoke/rotate/

--- a/config/test.exs
+++ b/config/test.exs
@@ -213,6 +213,11 @@ config :loopctl, :ingestion_health,
   min_attempts: 10,
   reject_window_days: 7
 
+# Run the write-outcome rollup upsert INLINE in test (prod dispatches it to a
+# supervised task): inline shares the emitting test process's sandboxed connection, so
+# the rollup row is readable back synchronously in specs.
+config :loopctl, Loopctl.Telemetry.IngestionWriteStats, async: false
+
 # Use simple formatter in test (override JSON default from config.exs).
 # The template prints only level + message (custom metadata is asserted via the
 # message string in tests), but declare `metadata: :all` so Credo's

--- a/config/test.exs
+++ b/config/test.exs
@@ -207,7 +207,11 @@ config :loopctl, :ingestion_health,
   monitored_source_types: ["session_log"],
   established_threshold: 5,
   staleness_threshold_hours: 72,
-  establishment_window_hours: 720
+  establishment_window_hours: 720,
+  # PR B2 reject-rate detector pins (deterministic thresholds for specs).
+  reject_rate_threshold: 0.5,
+  min_attempts: 10,
+  reject_window_days: 7
 
 # Use simple formatter in test (override JSON default from config.exs).
 # The template prints only level + message (custom metadata is asserted via the

--- a/lib/loopctl/application.ex
+++ b/lib/loopctl/application.ex
@@ -35,6 +35,20 @@ defmodule Loopctl.Application do
       {DNSCluster, query: Application.get_env(:loopctl, :dns_cluster_query) || :ignore},
       {Phoenix.PubSub, name: Loopctl.PubSub},
       {Task.Supervisor, name: Loopctl.TaskSupervisor},
+      # PR B2: BOUNDED supervisor for the fire-and-forget `ingestion_write_stats`
+      # rollup upserts spawned by `Loopctl.Telemetry.IngestionWriteStats`. The
+      # high_reject_rate detector's trigger condition is a client HAMMERING create in a
+      # retry loop (a title_conflict/validation storm) — i.e. exactly when write volume
+      # spikes — so an UNBOUNDED per-write task fan-out would flood the small BYPASSRLS
+      # AdminRepo pool (also serving the rate limiter + auth) precisely during the
+      # incident this feature detects, amplifying the outage. `max_children` caps the
+      # fan-out: over the cap `start_child` returns `{:error, :max_children}` and the
+      # increment is DROPPED (best-effort analytics, never blocks/fails the observed
+      # write). Separate from the general `Loopctl.TaskSupervisor` so this backpressure
+      # is isolated, mirroring `Loopctl.Memory.RecallBumpTaskSupervisor`.
+      {Task.Supervisor,
+       name: Loopctl.Telemetry.IngestionWriteStatsTaskSupervisor,
+       max_children: Application.get_env(:loopctl, :ingestion_write_stats_max_tasks, 200)},
       # #411 Gap 3: owns the public ETS table that pre-filters recall-count hotness
       # bumps already inside their per-memory cooldown window, so an idle-window
       # recall issues ZERO background tasks and ZERO DB writes (the DB-side

--- a/lib/loopctl/application.ex
+++ b/lib/loopctl/application.ex
@@ -5,6 +5,7 @@ defmodule Loopctl.Application do
 
   use Application
 
+  alias Loopctl.Telemetry.IngestionWriteStats
   alias Loopctl.Telemetry.SlowQueryLogger
 
   @impl true
@@ -18,6 +19,12 @@ defmodule Loopctl.Application do
 
     # US-27.4: uniform slow-query logging across all repos via one telemetry handler.
     SlowQueryLogger.attach()
+
+    # PR B2: fold every KB article write OUTCOME into the durable
+    # `ingestion_write_stats` rollup (the no-persist / high-rejection-rate detector's
+    # data source). Self-rescuing, so a dropped rollup increment never affects the
+    # write it observes.
+    IngestionWriteStats.attach()
 
     children = [
       LoopctlWeb.Telemetry,

--- a/lib/loopctl/index_health.ex
+++ b/lib/loopctl/index_health.ex
@@ -24,7 +24,15 @@ defmodule Loopctl.IndexHealth do
   # Add to this list whenever a new CONCURRENTLY-built index becomes load-bearing.
   @critical_indexes [
     {"articles_tenant_inserted_id_idx", "US-27.9a article keyset pagination"},
-    {"articles_tenant_source_inserted_id_idx", "US-27.9b by-source keyset pagination"}
+    {"articles_tenant_source_inserted_id_idx", "US-27.9b by-source keyset pagination"},
+    # PR B2 ingestion-health monitors: their hourly cross-tenant scans claim window
+    # boundedness via these range-seek indexes. If one is silently missing/invalid
+    # (a CONCURRENTLY build that failed, an IF-NOT-EXISTS no-op over an invalid index),
+    # the "never silently stop monitoring" detector itself degrades to an unbounded
+    # Seq Scan of the largest tables — so probe them at boot like any other hot path.
+    {"articles_inserted_tenant_source_idx",
+     "PR B2 capture-silence hourly scan (inserted_at range seek)"},
+    {"ingestion_write_stats_day_index", "PR B2 high-reject-rate hourly scan (day range seek)"}
   ]
 
   @doc """

--- a/lib/loopctl/knowledge/ingestion_anomaly.ex
+++ b/lib/loopctl/knowledge/ingestion_anomaly.ex
@@ -16,16 +16,27 @@ defmodule Loopctl.Knowledge.IngestionAnomaly do
   ## Anomaly Types
 
   - `capture_silence` -- an established source_type produced no new article for
-    longer than the configured staleness threshold.
+    longer than the configured staleness threshold (writes STOPPED).
+  - `high_reject_rate` -- writes of a source_type were ATTEMPTED but REJECTED at high
+    rate over a rolling window (the OTHER outage signature: 409 title_conflict /
+    validation drops that persist NO article row). Detected off the durable
+    `ingestion_write_stats` rollup, not the `articles` table. For this type the
+    freshness fields are repurposed: `sample_count` = total write attempts in the
+    window; `hours_stale` is not meaningful (set to 0); `last_event_at` is nil. The
+    reject figures (reject_rate, total_attempts, rejects, window_days,
+    dominant_reason) live in `metadata`.
 
   ## Fields
 
-  - `source_type` -- the article `source_type` whose capture stream went silent
+  - `source_type` -- the article `source_type` whose capture stream went silent /
+    whose writes are being rejected
   - `anomaly_type` -- one of the types above
-  - `last_event_at` -- `max(inserted_at)` of that source_type's articles (nil if none)
-  - `hours_stale` -- whole hours between `last_event_at` and detection time
+  - `last_event_at` -- `max(inserted_at)` of that source_type's articles (nil if none;
+    always nil for `high_reject_rate`)
+  - `hours_stale` -- whole hours between `last_event_at` and detection time (0 for
+    `high_reject_rate`)
   - `sample_count` -- articles of that source_type within the recency/establishment
-    window (the "recently established" evidence)
+    window (capture_silence), or total write attempts in the window (high_reject_rate)
   - `resolved` -- whether the anomaly has been acknowledged/resolved
   - `archived` -- archived anomalies are excluded from the default list and
     suppress re-detection for a retired source_type until un-archived
@@ -40,9 +51,10 @@ defmodule Loopctl.Knowledge.IngestionAnomaly do
 
   @type t :: %__MODULE__{}
 
-  # Extensible list — a future detector (e.g. `:capture_drop_rate`) can be added
-  # here alongside the CHECK constraint in the migration.
-  @anomaly_types [:capture_silence]
+  # Extensible list — kept in sync with the `ingestion_anomalies_anomaly_type_check`
+  # DB CHECK constraint (widened per new value via migration). A future detector can
+  # be added here alongside a CHECK-widening migration.
+  @anomaly_types [:capture_silence, :high_reject_rate]
 
   @derive {Jason.Encoder,
            only: [
@@ -100,15 +112,26 @@ defmodule Loopctl.Knowledge.IngestionAnomaly do
     ])
     |> validate_required([:source_type, :anomaly_type, :hours_stale, :sample_count])
     |> validate_inclusion(:anomaly_type, @anomaly_types)
-    # A capture-silence anomaly is, by definition, a source_type that WENT stale —
-    # so it must have been established (>= 1 captured article) and stale (> 0 hours).
-    # sample_count: 0 ("never established") / hours_stale: 0 ("not actually stale")
-    # are logically impossible anomalies; reject them at the invariant boundary
-    # even though the detection layer already only feeds established+stale figures.
-    |> validate_number(:hours_stale, greater_than: 0)
+    # Both types carry at least one sample: capture_silence needs >= 1 established
+    # article; high_reject_rate needs >= 1 (in practice >= min_attempts) write attempt.
     |> validate_number(:sample_count, greater_than_or_equal_to: 1)
+    |> validate_type_invariants()
     |> validate_metadata_size()
     |> foreign_key_constraint(:tenant_id)
+  end
+
+  # Per-type invariant on `hours_stale`. A capture-silence anomaly is, by definition,
+  # a source_type that WENT stale — so it must be stale (> 0 hours); hours_stale: 0
+  # ("not actually stale") is a logically impossible anomaly, rejected at the boundary
+  # even though detection already only feeds stale figures. A high_reject_rate anomaly
+  # has no staleness dimension (its evidence is the reject ratio in metadata), so
+  # hours_stale is a non-meaningful 0 — allow >= 0.
+  defp validate_type_invariants(changeset) do
+    case get_field(changeset, :anomaly_type) do
+      :capture_silence -> validate_number(changeset, :hours_stale, greater_than: 0)
+      :high_reject_rate -> validate_number(changeset, :hours_stale, greater_than_or_equal_to: 0)
+      _ -> changeset
+    end
   end
 
   @doc """

--- a/lib/loopctl/knowledge/ingestion_anomaly.ex
+++ b/lib/loopctl/knowledge/ingestion_anomaly.ex
@@ -24,7 +24,10 @@ defmodule Loopctl.Knowledge.IngestionAnomaly do
     freshness fields are repurposed: `sample_count` = total write attempts in the
     window; `hours_stale` is not meaningful (set to 0); `last_event_at` is nil. The
     reject figures (reject_rate, total_attempts, rejects, window_days,
-    dominant_reason) live in `metadata`.
+    dominant_reason) live in `metadata`. `last_event_at` starts nil while the reject
+    episode is ACTIVE and is stamped with the recovery time (episode ENDED) by
+    `Loopctl.Knowledge.IngestionHealth.auto_resolve_recovered_reject_rate/1` — that
+    stamp is what re-arms detection so a future reject storm re-fires.
 
   ## Fields
 
@@ -140,6 +143,19 @@ defmodule Loopctl.Knowledge.IngestionAnomaly do
   @spec resolve_changeset(%__MODULE__{}) :: Ecto.Changeset.t()
   def resolve_changeset(anomaly) do
     change(anomaly, resolved: true)
+  end
+
+  @doc """
+  Changeset closing a RECOVERED `:high_reject_rate` anomaly.
+
+  Sets `resolved: true` (closing an open row) AND stamps `last_event_at` with the
+  recovery time. The `last_event_at` stamp marks the reject episode as ENDED so it
+  no longer suppresses re-detection — a future storm for the same source_type
+  re-fires. Applied by `IngestionHealth.auto_resolve_recovered_reject_rate/1`.
+  """
+  @spec reject_recovered_changeset(%__MODULE__{}, DateTime.t()) :: Ecto.Changeset.t()
+  def reject_recovered_changeset(anomaly, recovered_at) do
+    change(anomaly, resolved: true, last_event_at: recovered_at)
   end
 
   @doc """

--- a/lib/loopctl/knowledge/ingestion_health.ex
+++ b/lib/loopctl/knowledge/ingestion_health.ex
@@ -88,6 +88,16 @@ defmodule Loopctl.Knowledge.IngestionHealth do
   @default_reject_rate_threshold 0.5
   @default_min_attempts 10
   @default_reject_window_days 7
+  @default_write_stats_retention_days 90
+
+  # Sentinel `source_type` for the NULL/unstamped write bucket. `source_type` on a
+  # KB write is advisory + nullable, so the MAJORITY of agent captures (patterns,
+  # decisions, session findings) omit it — those rejected writes land in the
+  # COALESCE('') bucket of `ingestion_write_stats`. `ingestion_anomalies.source_type`
+  # is NOT NULL (and `validate_required` rejects ""), so a reject-rate outage on
+  # unstamped writes is recorded under THIS sentinel rather than being a permanent
+  # blind spot (the exact 409 title_conflict outage class this detector exists to catch).
+  @unstamped_source_type "(unstamped)"
 
   @type candidate :: %{
           tenant_id: Ecto.UUID.t(),
@@ -180,6 +190,22 @@ defmodule Loopctl.Knowledge.IngestionHealth do
   @spec reject_window_days() :: pos_integer()
   def reject_window_days,
     do: Keyword.get(config(), :reject_window_days, @default_reject_window_days)
+
+  @doc """
+  Retention (in days) for the `ingestion_write_stats` rollup. Rows older than this are
+  pruned by the hourly worker so the table does not grow unbounded (only the rolling
+  `reject_window_days` window is ever read). Default 90.
+  """
+  @spec write_stats_retention_days() :: pos_integer()
+  def write_stats_retention_days,
+    do: Keyword.get(config(), :write_stats_retention_days, @default_write_stats_retention_days)
+
+  @doc """
+  Sentinel `source_type` under which reject-rate anomalies for NULL/unstamped writes
+  are recorded (see the module attribute for why the NULL bucket needs a sentinel).
+  """
+  @spec unstamped_source_type() :: String.t()
+  def unstamped_source_type, do: @unstamped_source_type
 
   defp config, do: Application.get_env(:loopctl, :ingestion_health, [])
 
@@ -306,9 +332,12 @@ defmodule Loopctl.Knowledge.IngestionHealth do
   sums `title_conflict + validation_error` into `rejects`, and flags when
   `total_attempts >= min_attempts` AND `rejects / total_attempts > reject_rate_threshold`.
 
-  NULL-`source_type` buckets are excluded (an `ingestion_anomalies` row requires a
-  non-null source_type, mirroring the capture-silence monitor's stamped-source_type
-  contract).
+  NULL/unstamped `source_type` writes are NOT excluded: since `source_type` is optional
+  on a KB write, the reject path's source_type is chosen by the FAILING client, so
+  "just stamp it" is no mitigation. The NULL bucket (`COALESCE(source_type, '')`) is
+  folded into a single candidate under `unstamped_source_type/0` (`ingestion_anomalies`
+  requires a non-null source_type, so the sentinel stands in), ensuring an unstamped
+  reject outage is not a permanent blind spot.
   """
   @spec detect_high_reject_rate() :: [reject_candidate()]
   def detect_high_reject_rate do
@@ -334,17 +363,20 @@ defmodule Loopctl.Knowledge.IngestionHealth do
         reject_window_days: window_days
       }) do
     # Inclusive rolling window of `window_days` days ending today. The day-leading
-    # index makes this predicate a range seek, so the read is bounded to the window.
+    # index (`ingestion_write_stats_day_index`) makes `day >= window_start` a range
+    # seek, so the read is bounded to the window rather than a seq-scan of the rollup.
     window_start = Date.add(Date.utc_today(), -(window_days - 1))
 
+    # Group by COALESCE(source_type, '') so NULL and empty-string writes fold into ONE
+    # bucket (surfaced as `unstamped_source_type/0` downstream) — an unstamped reject
+    # outage is caught, not silently dropped into a NULL rollup row no detector scans.
     IngestionWriteStats
     |> join(:inner, [s], t in Tenant, on: t.id == s.tenant_id and t.status == :active)
-    |> where([s], not is_nil(s.source_type))
     |> where([s], s.day >= ^window_start)
-    |> group_by([s], [s.tenant_id, s.source_type])
+    |> group_by([s], [s.tenant_id, fragment("COALESCE(?, '')", s.source_type)])
     |> select([s], %{
       tenant_id: s.tenant_id,
-      source_type: s.source_type,
+      source_type: fragment("COALESCE(?, '')", s.source_type),
       created: sum(s.created_count),
       deduplicated: sum(s.deduplicated_count),
       drafted: sum(s.drafted_count),
@@ -370,7 +402,7 @@ defmodule Loopctl.Knowledge.IngestionHealth do
       [
         %{
           tenant_id: row.tenant_id,
-          source_type: row.source_type,
+          source_type: reject_source_type(row.source_type),
           anomaly_type: :high_reject_rate,
           total_attempts: total_attempts,
           rejects: rejects,
@@ -383,6 +415,11 @@ defmodule Loopctl.Knowledge.IngestionHealth do
       []
     end
   end
+
+  # The COALESCE('') NULL/empty bucket surfaces under the sentinel so it can be
+  # persisted as an anomaly (non-null source_type) and matched by the worker's queries.
+  defp reject_source_type(""), do: @unstamped_source_type
+  defp reject_source_type(source_type), do: source_type
 
   # The reject reason that contributed the most drops (ties -> title_conflict).
   defp dominant_reason(title_conflict, validation_error) do
@@ -671,6 +708,102 @@ defmodule Loopctl.Knowledge.IngestionHealth do
       a.tenant_id == ^tenant_id and a.source_type == ^source_type and a.inserted_at > ^last
     )
     |> AdminRepo.exists?()
+  end
+
+  @doc """
+  Closes `:high_reject_rate` anomalies whose reject rate has RECOVERED.
+
+  A rejected write has no natural "resumed" signal like capture-silence's newer
+  article, so recovery is defined as: the `(tenant, source_type)` is no longer a
+  current reject candidate (rate dropped back below threshold, or volume fell below
+  the noise floor). `current_candidates` is the SAME list the worker just computed,
+  so this shares one scan of the rollup.
+
+  For each ACTIVE reject anomaly (archived == false and `last_event_at IS NULL`, which
+  covers both open rows and operator-resolved-but-still-active episodes) whose
+  `(tenant, source_type)` is NOT in the candidate set, it stamps `last_event_at` with
+  the recovery time (marking the episode ENDED) and sets `resolved: true`. Two
+  problems are fixed at once:
+
+  - **Open anomalies never froze open**: a recovered stream's open anomaly is resolved
+    instead of staying `resolved: false` forever with stale figures.
+  - **Resolved-suppression re-arms**: `Loopctl.Workers.IngestionHealthWorker`'s
+    `resolved_reject_suppression?` only counts resolved rows with `last_event_at IS
+    NULL`, so once recovery stamps `last_event_at` the resolved row stops suppressing —
+    a FUTURE reject storm for the same source_type re-fires instead of being silenced
+    forever. Mirrors how capture-silence re-arms when `last_event_at` advances.
+
+  Returns the number of anomalies closed. Called by the hourly worker.
+  """
+  @spec auto_resolve_recovered_reject_rate([reject_candidate()]) :: non_neg_integer()
+  def auto_resolve_recovered_reject_rate(current_candidates) do
+    active_keys = MapSet.new(current_candidates, &{&1.tenant_id, &1.source_type})
+    now = DateTime.utc_now()
+
+    IngestionAnomaly
+    |> where([a], a.anomaly_type == :high_reject_rate)
+    |> where([a], a.archived == false)
+    |> where([a], is_nil(a.last_event_at))
+    |> AdminRepo.all()
+    |> Enum.reduce(0, fn anomaly, acc ->
+      if MapSet.member?(active_keys, {anomaly.tenant_id, anomaly.source_type}),
+        do: acc,
+        else: acc + close_recovered_reject(anomaly, now)
+    end)
+  end
+
+  # Stamp the recovery time (episode ended) + mark resolved, auditing the resolve
+  # transition only when the row was previously unresolved (an already-resolved row is
+  # a system bookkeeping mark, not a state change worth a resolved-audit entry).
+  defp close_recovered_reject(%IngestionAnomaly{tenant_id: tenant_id} = anomaly, now) do
+    was_resolved = anomaly.resolved
+
+    multi =
+      Multi.new()
+      |> Multi.run(:anomaly, fn repo, _changes ->
+        anomaly |> IngestionAnomaly.reject_recovered_changeset(now) |> repo.update()
+      end)
+      |> Multi.run(:audit, fn repo, %{anomaly: updated} ->
+        if was_resolved do
+          {:ok, :skipped}
+        else
+          audit_insert(
+            repo,
+            audit_attrs(
+              tenant_id,
+              updated.id,
+              "resolved",
+              [actor_type: "system", actor_label: "ingestion_health:auto_resolve_reject_rate"],
+              %{old_state: %{"resolved" => false}, new_state: %{"resolved" => true}}
+            )
+          )
+        end
+      end)
+
+    case AdminRepo.transaction(multi) do
+      {:ok, _} -> 1
+      {:error, _step, _reason, _changes} -> 0
+    end
+  end
+
+  @doc """
+  Prunes `ingestion_write_stats` rows older than `write_stats_retention_days`.
+
+  The rollup is append-only (one row per tenant/source_type/day) and only the rolling
+  `reject_window_days` window is ever read, so without pruning it would grow forever.
+  Deletes by the day-leading index (`day < cutoff`). Called by the hourly worker.
+  Returns the number of rows deleted.
+  """
+  @spec prune_write_stats() :: non_neg_integer()
+  def prune_write_stats do
+    cutoff = Date.add(Date.utc_today(), -write_stats_retention_days())
+
+    {deleted, _} =
+      IngestionWriteStats
+      |> where([s], s.day < ^cutoff)
+      |> AdminRepo.delete_all()
+
+    deleted
   end
 
   # --- Private helpers ---

--- a/lib/loopctl/knowledge/ingestion_health.ex
+++ b/lib/loopctl/knowledge/ingestion_health.ex
@@ -75,6 +75,7 @@ defmodule Loopctl.Knowledge.IngestionHealth do
   alias Loopctl.Audit.AuditLog
   alias Loopctl.Knowledge.Article
   alias Loopctl.Knowledge.IngestionAnomaly
+  alias Loopctl.Knowledge.IngestionWriteStats
   alias Loopctl.Tenants.Tenant
 
   @default_monitored_source_types :all
@@ -83,12 +84,29 @@ defmodule Loopctl.Knowledge.IngestionHealth do
   @default_establishment_window_hours 720
   @default_established_threshold_overrides %{}
 
+  # High-reject-rate detector defaults (PR B2).
+  @default_reject_rate_threshold 0.5
+  @default_min_attempts 10
+  @default_reject_window_days 7
+
   @type candidate :: %{
           tenant_id: Ecto.UUID.t(),
           source_type: String.t(),
+          anomaly_type: :capture_silence,
           last_event_at: DateTime.t(),
           hours_stale: non_neg_integer(),
           sample_count: non_neg_integer()
+        }
+
+  @type reject_candidate :: %{
+          tenant_id: Ecto.UUID.t(),
+          source_type: String.t(),
+          anomaly_type: :high_reject_rate,
+          total_attempts: non_neg_integer(),
+          rejects: non_neg_integer(),
+          reject_rate: float(),
+          window_days: pos_integer(),
+          dominant_reason: String.t()
         }
 
   # --- Config accessors (documented defaults) ---
@@ -139,6 +157,29 @@ defmodule Loopctl.Knowledge.IngestionHealth do
   @spec establishment_window_hours() :: pos_integer()
   def establishment_window_hours,
     do: Keyword.get(config(), :establishment_window_hours, @default_establishment_window_hours)
+
+  @doc """
+  Fraction of write attempts (0.0-1.0) above which a source_type's rolling window is
+  flagged `:high_reject_rate` (`rejects / total_attempts > threshold`). Default 0.5.
+  """
+  @spec reject_rate_threshold() :: float()
+  def reject_rate_threshold,
+    do: Keyword.get(config(), :reject_rate_threshold, @default_reject_rate_threshold)
+
+  @doc """
+  Minimum total write attempts in the window before a reject rate is trusted enough
+  to flag (avoids alerting on statistical noise from a handful of writes). Default 10.
+  """
+  @spec min_attempts() :: pos_integer()
+  def min_attempts, do: Keyword.get(config(), :min_attempts, @default_min_attempts)
+
+  @doc """
+  Rolling window (in days) over the `ingestion_write_stats` rollup for the
+  reject-rate scan. Default 7.
+  """
+  @spec reject_window_days() :: pos_integer()
+  def reject_window_days,
+    do: Keyword.get(config(), :reject_window_days, @default_reject_window_days)
 
   defp config, do: Application.get_env(:loopctl, :ingestion_health, [])
 
@@ -240,6 +281,7 @@ defmodule Loopctl.Knowledge.IngestionHealth do
         %{
           tenant_id: tenant_id,
           source_type: source_type,
+          anomaly_type: :capture_silence,
           last_event_at: to_utc_datetime(last_event_at),
           hours_stale: hours_stale,
           sample_count: sample_count
@@ -248,6 +290,122 @@ defmodule Loopctl.Knowledge.IngestionHealth do
     else
       []
     end
+  end
+
+  # --- High-reject-rate detection (PR B2) ---
+
+  @doc """
+  Scans the `ingestion_write_stats` rollup for `:high_reject_rate` candidates using
+  the configured tunables. Returns a flat list of `t:reject_candidate/0` maps — PURE,
+  no DB writes.
+
+  A rejected write leaves NO article row, so the capture-silence detector (which reads
+  `articles`) is blind to it. This complementary detector reads the durable write-
+  outcome rollup instead: for each `(tenant, non-null source_type)` over a rolling
+  `reject_window_days` window, it sums all outcome counters into `total_attempts`,
+  sums `title_conflict + validation_error` into `rejects`, and flags when
+  `total_attempts >= min_attempts` AND `rejects / total_attempts > reject_rate_threshold`.
+
+  NULL-`source_type` buckets are excluded (an `ingestion_anomalies` row requires a
+  non-null source_type, mirroring the capture-silence monitor's stamped-source_type
+  contract).
+  """
+  @spec detect_high_reject_rate() :: [reject_candidate()]
+  def detect_high_reject_rate do
+    detect_high_reject_rate(%{
+      reject_rate_threshold: reject_rate_threshold(),
+      min_attempts: min_attempts(),
+      reject_window_days: reject_window_days()
+    })
+  end
+
+  @doc """
+  `detect_high_reject_rate/0` with explicit config. Exposed so a caller can drive
+  detection with a specific configuration without touching global app env.
+  """
+  @spec detect_high_reject_rate(%{
+          required(:reject_rate_threshold) => float(),
+          required(:min_attempts) => pos_integer(),
+          required(:reject_window_days) => pos_integer()
+        }) :: [reject_candidate()]
+  def detect_high_reject_rate(%{
+        reject_rate_threshold: threshold,
+        min_attempts: min_attempts,
+        reject_window_days: window_days
+      }) do
+    # Inclusive rolling window of `window_days` days ending today. The day-leading
+    # index makes this predicate a range seek, so the read is bounded to the window.
+    window_start = Date.add(Date.utc_today(), -(window_days - 1))
+
+    IngestionWriteStats
+    |> join(:inner, [s], t in Tenant, on: t.id == s.tenant_id and t.status == :active)
+    |> where([s], not is_nil(s.source_type))
+    |> where([s], s.day >= ^window_start)
+    |> group_by([s], [s.tenant_id, s.source_type])
+    |> select([s], %{
+      tenant_id: s.tenant_id,
+      source_type: s.source_type,
+      created: sum(s.created_count),
+      deduplicated: sum(s.deduplicated_count),
+      drafted: sum(s.drafted_count),
+      title_conflict: sum(s.title_conflict_count),
+      validation_error: sum(s.validation_error_count)
+    })
+    |> AdminRepo.all()
+    |> Enum.flat_map(&reject_candidate_or_skip(&1, threshold, min_attempts, window_days))
+  end
+
+  defp reject_candidate_or_skip(row, threshold, min_attempts, window_days) do
+    created = to_int(row.created)
+    deduplicated = to_int(row.deduplicated)
+    drafted = to_int(row.drafted)
+    title_conflict = to_int(row.title_conflict)
+    validation_error = to_int(row.validation_error)
+
+    total_attempts = created + deduplicated + drafted + title_conflict + validation_error
+    rejects = title_conflict + validation_error
+    reject_rate = if total_attempts > 0, do: rejects / total_attempts, else: 0.0
+
+    if total_attempts >= min_attempts and reject_rate > threshold do
+      [
+        %{
+          tenant_id: row.tenant_id,
+          source_type: row.source_type,
+          anomaly_type: :high_reject_rate,
+          total_attempts: total_attempts,
+          rejects: rejects,
+          reject_rate: reject_rate,
+          window_days: window_days,
+          dominant_reason: dominant_reason(title_conflict, validation_error)
+        }
+      ]
+    else
+      []
+    end
+  end
+
+  # The reject reason that contributed the most drops (ties -> title_conflict).
+  defp dominant_reason(title_conflict, validation_error) do
+    if title_conflict >= validation_error, do: "title_conflict", else: "validation_error"
+  end
+
+  # A `sum(bigint)` comes back from Postgres as `numeric` -> Ecto `Decimal`; normalize
+  # to an integer (nil when a group somehow has no rows).
+  defp to_int(nil), do: 0
+  defp to_int(%Decimal{} = d), do: Decimal.to_integer(d)
+  defp to_int(n) when is_integer(n), do: n
+
+  @doc """
+  Whether the tenant has EVER recorded a write-outcome for `source_type` (any row in
+  `ingestion_write_stats`). Used by the controller to warn when a `source_type`
+  filter names a never-seen source, so an empty anomaly list is not mistaken for
+  "healthy".
+  """
+  @spec source_type_seen?(Ecto.UUID.t(), String.t()) :: boolean()
+  def source_type_seen?(tenant_id, source_type) when is_binary(source_type) do
+    IngestionWriteStats
+    |> where([s], s.tenant_id == ^tenant_id and s.source_type == ^source_type)
+    |> AdminRepo.exists?()
   end
 
   # --- Query surface (mirrors Loopctl.TokenUsage.list_anomalies/resolve_anomaly) ---

--- a/lib/loopctl/knowledge/ingestion_health.ex
+++ b/lib/loopctl/knowledge/ingestion_health.ex
@@ -23,7 +23,12 @@ defmodule Loopctl.Knowledge.IngestionHealth do
   index (`articles_inserted_tenant_source_idx`) LEADS with `inserted_at` so that
   predicate is an index RANGE SEEK — the read is bounded to the rolling window
   (recent activity), NOT the whole corpus, so cost does not grow unbounded as the
-  article table ages.
+  article table ages. This boundedness holds ONLY while that index is present and
+  valid; because a silently-missing index would degrade this monitor to a Seq Scan
+  (the very "silently stop monitoring" failure it exists to prevent), it — and the
+  reject-rate detector's `ingestion_write_stats_day_index` — are registered
+  in `Loopctl.IndexHealth`'s critical-index list so a boot probe alarms if either is
+  missing/invalid rather than letting the scan quietly go unbounded.
 
   ## Monitoring contract: source_type must be stamped
 
@@ -66,6 +71,13 @@ defmodule Loopctl.Knowledge.IngestionHealth do
     thresholds, e.g. `%{"session_log" => 2}` to monitor a low-volume critical source)
   - `:staleness_threshold_hours` -- default `72`
   - `:establishment_window_hours` -- default `720` (30 days)
+  - `:reject_rate_threshold` -- default `0.5` (reject fraction that flags high_reject_rate)
+  - `:min_attempts` -- default `10` (window write-attempt floor before a reject rate is trusted)
+  - `:min_attempts_overrides` -- default `%{}` (per-source-type overrides of the attempt
+    floor, e.g. `%{"session_log" => 3}` to monitor a low-volume critical source that
+    would otherwise fall below `min_attempts` and evade high_reject_rate detection)
+  - `:reject_window_days` -- default `7`
+  - `:write_stats_retention_days` -- default `90`
   """
 
   import Ecto.Query
@@ -87,6 +99,7 @@ defmodule Loopctl.Knowledge.IngestionHealth do
   # High-reject-rate detector defaults (PR B2).
   @default_reject_rate_threshold 0.5
   @default_min_attempts 10
+  @default_min_attempts_overrides %{}
   @default_reject_window_days 7
   @default_write_stats_retention_days 90
 
@@ -182,6 +195,23 @@ defmodule Loopctl.Knowledge.IngestionHealth do
   """
   @spec min_attempts() :: pos_integer()
   def min_attempts, do: Keyword.get(config(), :min_attempts, @default_min_attempts)
+
+  @doc """
+  Per-source-type overrides for the minimum-attempts floor (mirrors
+  `established_threshold_overrides/0` for the capture-silence detector).
+
+  A map of `source_type => pos_integer`. A LOW-VOLUME but critical source (fewer than
+  the global `min_attempts` write attempts in the window) that is 100% rejecting would
+  otherwise fall between BOTH detectors — never enough attempts for high_reject_rate,
+  and (if it never established) never a capture_silence candidate either — leaving a
+  full-reject outage silent for the whole window. An override lets an operator monitor
+  such a source at a lower attempt floor without lowering the bar for noisy ones. The
+  unstamped bucket is addressed under the `unstamped_source_type/0` sentinel key.
+  Default `%{}` (no overrides — every source_type uses the global floor).
+  """
+  @spec min_attempts_overrides() :: %{optional(String.t()) => pos_integer()}
+  def min_attempts_overrides,
+    do: Keyword.get(config(), :min_attempts_overrides, @default_min_attempts_overrides)
 
   @doc """
   Rolling window (in days) over the `ingestion_write_stats` rollup for the
@@ -344,6 +374,7 @@ defmodule Loopctl.Knowledge.IngestionHealth do
     detect_high_reject_rate(%{
       reject_rate_threshold: reject_rate_threshold(),
       min_attempts: min_attempts(),
+      min_attempts_overrides: min_attempts_overrides(),
       reject_window_days: reject_window_days()
     })
   end
@@ -355,13 +386,17 @@ defmodule Loopctl.Knowledge.IngestionHealth do
   @spec detect_high_reject_rate(%{
           required(:reject_rate_threshold) => float(),
           required(:min_attempts) => pos_integer(),
-          required(:reject_window_days) => pos_integer()
+          required(:reject_window_days) => pos_integer(),
+          optional(:min_attempts_overrides) => %{optional(String.t()) => pos_integer()}
         }) :: [reject_candidate()]
-  def detect_high_reject_rate(%{
-        reject_rate_threshold: threshold,
-        min_attempts: min_attempts,
-        reject_window_days: window_days
-      }) do
+  def detect_high_reject_rate(
+        %{
+          reject_rate_threshold: threshold,
+          min_attempts: min_attempts,
+          reject_window_days: window_days
+        } = opts
+      ) do
+    overrides = Map.get(opts, :min_attempts_overrides, %{})
     # Inclusive rolling window of `window_days` days ending today. The day-leading
     # index (`ingestion_write_stats_day_index`) makes `day >= window_start` a range
     # seek, so the read is bounded to the window rather than a seq-scan of the rollup.
@@ -384,10 +419,12 @@ defmodule Loopctl.Knowledge.IngestionHealth do
       validation_error: sum(s.validation_error_count)
     })
     |> AdminRepo.all()
-    |> Enum.flat_map(&reject_candidate_or_skip(&1, threshold, min_attempts, window_days))
+    |> Enum.flat_map(
+      &reject_candidate_or_skip(&1, threshold, min_attempts, overrides, window_days)
+    )
   end
 
-  defp reject_candidate_or_skip(row, threshold, min_attempts, window_days) do
+  defp reject_candidate_or_skip(row, threshold, min_attempts, overrides, window_days) do
     created = to_int(row.created)
     deduplicated = to_int(row.deduplicated)
     drafted = to_int(row.drafted)
@@ -398,11 +435,16 @@ defmodule Loopctl.Knowledge.IngestionHealth do
     rejects = title_conflict + validation_error
     reject_rate = if total_attempts > 0, do: rejects / total_attempts, else: 0.0
 
-    if total_attempts >= min_attempts and reject_rate > threshold do
+    # A low-volume critical source can be monitored below the global floor via a
+    # per-source override (keyed by the operator-facing source_type, sentinel included).
+    source_type = reject_source_type(row.source_type)
+    effective_min_attempts = Map.get(overrides, source_type, min_attempts)
+
+    if total_attempts >= effective_min_attempts and reject_rate > threshold do
       [
         %{
           tenant_id: row.tenant_id,
-          source_type: reject_source_type(row.source_type),
+          source_type: source_type,
           anomaly_type: :high_reject_rate,
           total_attempts: total_attempts,
           rejects: rejects,
@@ -433,15 +475,44 @@ defmodule Loopctl.Knowledge.IngestionHealth do
   defp to_int(n) when is_integer(n), do: n
 
   @doc """
-  Whether the tenant has EVER recorded a write-outcome for `source_type` (any row in
-  `ingestion_write_stats`). Used by the controller to warn when a `source_type`
-  filter names a never-seen source, so an empty anomaly list is not mistaken for
-  "healthy".
+  Whether the tenant has EVER seen ingestion activity for `source_type` — either a
+  recorded write-outcome (`ingestion_write_stats`, the create-path telemetry) OR a
+  persisted `articles` row (which covers non-create write paths like bulk/content
+  ingestion that never emit create telemetry). Used by the controller to warn when a
+  `source_type` filter names a genuinely never-seen source, so an EMPTY anomaly list is
+  not mistaken for "healthy".
+
+  The `unstamped_source_type/0` sentinel (`"(unstamped)"`) is special-cased: unstamped
+  writes are stored with a NULL/empty `source_type`, so it probes those rows rather than
+  matching the literal sentinel string (which no row carries) — otherwise a tenant with
+  real unstamped traffic would be falsely warned "no recorded activity".
   """
   @spec source_type_seen?(Ecto.UUID.t(), String.t()) :: boolean()
   def source_type_seen?(tenant_id, source_type) when is_binary(source_type) do
+    write_stats_seen?(tenant_id, source_type) or articles_seen?(tenant_id, source_type)
+  end
+
+  defp write_stats_seen?(tenant_id, @unstamped_source_type) do
+    IngestionWriteStats
+    |> where([s], s.tenant_id == ^tenant_id and (is_nil(s.source_type) or s.source_type == ""))
+    |> AdminRepo.exists?()
+  end
+
+  defp write_stats_seen?(tenant_id, source_type) do
     IngestionWriteStats
     |> where([s], s.tenant_id == ^tenant_id and s.source_type == ^source_type)
+    |> AdminRepo.exists?()
+  end
+
+  defp articles_seen?(tenant_id, @unstamped_source_type) do
+    Article
+    |> where([a], a.tenant_id == ^tenant_id and is_nil(a.source_type))
+    |> AdminRepo.exists?()
+  end
+
+  defp articles_seen?(tenant_id, source_type) do
+    Article
+    |> where([a], a.tenant_id == ^tenant_id and a.source_type == ^source_type)
     |> AdminRepo.exists?()
   end
 
@@ -672,42 +743,38 @@ defmodule Loopctl.Knowledge.IngestionHealth do
   """
   @spec auto_resolve_recovered() :: non_neg_integer()
   def auto_resolve_recovered do
-    open =
-      IngestionAnomaly
-      |> where([a], a.resolved == false and a.archived == false)
-      |> where([a], a.anomaly_type == :capture_silence)
+    # Set-based recovery filter: load ONLY the anomalies that already have a newer
+    # article (i.e. captures genuinely resumed), via a correlated EXISTS — ONE query
+    # instead of an `exists?` per open anomaly (the previous N+1 that grew with the
+    # open-anomaly count during a widespread incident). The per-row resolve below is
+    # then necessary work (locked flip + audit entry) run only for recovered rows.
+    recovered =
+      from(a in IngestionAnomaly, as: :anomaly)
+      |> where([anomaly: a], a.resolved == false and a.archived == false)
+      |> where([anomaly: a], a.anomaly_type == :capture_silence)
+      |> where([anomaly: a], not is_nil(a.last_event_at))
+      |> where(
+        [anomaly: a],
+        exists(
+          from(art in Article,
+            where:
+              art.tenant_id == parent_as(:anomaly).tenant_id and
+                art.source_type == parent_as(:anomaly).source_type and
+                art.inserted_at > parent_as(:anomaly).last_event_at
+          )
+        )
+      )
       |> AdminRepo.all()
 
-    Enum.reduce(open, 0, fn anomaly, acc -> acc + resolve_if_recovered(anomaly) end)
-  end
-
-  # Returns 1 if the anomaly's captures resumed AND it was resolved, else 0.
-  defp resolve_if_recovered(anomaly) do
-    with true <- captures_resumed?(anomaly),
-         {:ok, _} <-
-           do_resolve(anomaly.tenant_id, anomaly,
+    Enum.reduce(recovered, 0, fn anomaly, acc ->
+      case do_resolve(anomaly.tenant_id, anomaly,
              actor_type: "system",
              actor_label: "ingestion_health:auto_resolve"
            ) do
-      1
-    else
-      _ -> 0
-    end
-  end
-
-  defp captures_resumed?(%IngestionAnomaly{last_event_at: nil}), do: false
-
-  defp captures_resumed?(%IngestionAnomaly{
-         tenant_id: tenant_id,
-         source_type: source_type,
-         last_event_at: last
-       }) do
-    Article
-    |> where(
-      [a],
-      a.tenant_id == ^tenant_id and a.source_type == ^source_type and a.inserted_at > ^last
-    )
-    |> AdminRepo.exists?()
+        {:ok, _} -> acc + 1
+        _ -> acc
+      end
+    end)
   end
 
   @doc """

--- a/lib/loopctl/knowledge/ingestion_write_stats.ex
+++ b/lib/loopctl/knowledge/ingestion_write_stats.ex
@@ -1,0 +1,97 @@
+defmodule Loopctl.Knowledge.IngestionWriteStats do
+  @moduledoc """
+  Schema for the `ingestion_write_stats` table — a durable per-(tenant,
+  source_type, day) rollup of KB article WRITE OUTCOMES.
+
+  Where `Loopctl.Knowledge.IngestionAnomaly` (capture-silence) is a dead-man's-switch
+  read off the `articles` table ("writes STOPPED"), this rollup captures the OTHER
+  outage signature: writes ATTEMPTED but REJECTED at high rate. A rejected write
+  (409 title_conflict, changeset validation error) leaves NO article row, so it is
+  invisible to any row-count monitor. Instead the self-rescuing
+  `[:loopctl, :knowledge, :article_write]` telemetry handler
+  (`Loopctl.Telemetry.IngestionWriteStats`) increments the matching counter here on
+  EVERY write outcome, and `Loopctl.Knowledge.IngestionHealth` flags a
+  `:high_reject_rate` anomaly when rejects dominate a rolling window.
+
+  ## Outcome -> column mapping
+
+  - `:created`          -> `created_count`
+  - `:deduplicated`     -> `deduplicated_count`
+  - `:gated_to_draft`   -> `drafted_count`
+  - `:title_conflict`   -> `title_conflict_count`
+  - `:validation_error` -> `validation_error_count`
+
+  `source_type` is NULLABLE (an article write may omit the advisory field); the
+  `(tenant_id, COALESCE(source_type, ''), day)` unique index buckets NULL distinctly
+  so the per-write upsert is idempotent per bucket.
+  """
+
+  use Loopctl.Schema
+
+  @type t :: %__MODULE__{}
+
+  @counter_fields [
+    :created_count,
+    :deduplicated_count,
+    :drafted_count,
+    :title_conflict_count,
+    :validation_error_count
+  ]
+
+  # Telemetry outcome -> counter column. The single source of truth for the mapping
+  # (used by the telemetry handler and the reject-rate detector).
+  @outcome_columns %{
+    created: :created_count,
+    deduplicated: :deduplicated_count,
+    gated_to_draft: :drafted_count,
+    title_conflict: :title_conflict_count,
+    validation_error: :validation_error_count
+  }
+
+  @derive {Jason.Encoder,
+           only:
+             [
+               :id,
+               :tenant_id,
+               :source_type,
+               :day
+             ] ++ @counter_fields ++ [:inserted_at, :updated_at]}
+
+  schema "ingestion_write_stats" do
+    tenant_field()
+
+    field :source_type, :string
+    field :day, :date
+
+    field :created_count, :integer, default: 0
+    field :deduplicated_count, :integer, default: 0
+    field :drafted_count, :integer, default: 0
+    field :title_conflict_count, :integer, default: 0
+    field :validation_error_count, :integer, default: 0
+
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  @doc "The five per-outcome counter column names."
+  @spec counter_fields() :: [atom()]
+  def counter_fields, do: @counter_fields
+
+  @doc """
+  The counter column for a telemetry `outcome`, or `nil` for an unknown outcome
+  (the handler skips unknown outcomes rather than raising).
+  """
+  @spec column_for(atom()) :: atom() | nil
+  def column_for(outcome), do: Map.get(@outcome_columns, outcome)
+
+  @doc """
+  Changeset for an upsert row. `tenant_id` is set programmatically on the struct
+  (RLS rule — never cast).
+  """
+  @spec changeset(t(), map()) :: Ecto.Changeset.t()
+  def changeset(stats \\ %__MODULE__{}, attrs) do
+    stats
+    |> cast(attrs, [:source_type, :day | @counter_fields])
+    |> validate_required([:day])
+    |> foreign_key_constraint(:tenant_id)
+  end
+end

--- a/lib/loopctl/telemetry/ingestion_write_stats.ex
+++ b/lib/loopctl/telemetry/ingestion_write_stats.ex
@@ -1,0 +1,117 @@
+defmodule Loopctl.Telemetry.IngestionWriteStats do
+  @moduledoc """
+  Self-rescuing `:telemetry` handler that folds every KB article WRITE OUTCOME into
+  the durable `ingestion_write_stats` per-(tenant, source_type, day) rollup.
+
+  Attached at boot next to `Loopctl.Telemetry.SlowQueryLogger` (in
+  `Loopctl.Application.start/2`). Listens on `[:loopctl, :knowledge, :article_write]`
+  (emitted from EVERY render path of `LoopctlWeb.ArticleController.create`) and, per
+  event, upserts+increments the counter column that matches the event's `outcome`.
+
+  ## Why a direct per-write upsert (not an ETS buffer)
+
+  Article writes are LOW-FREQUENCY (a create/dedup/reject per API call, not a hot
+  request-path event like the scale signals `Loopctl.Telemetry.ScaleAlerts` windows).
+  A direct upsert per event is therefore acceptable and far simpler than an
+  ETS-buffer + periodic flush — and it keeps the rollup transactionally consistent
+  with the write it counts (the handler runs synchronously in the request process, so
+  in tests it shares that process's sandboxed connection). If write volume ever grows
+  hot, an ETS-buffer+flush (ScaleAlerts style) is the drop-in alternative.
+
+  ## Self-rescuing (never break the request path)
+
+  Like `Loopctl.Telemetry.SlowQueryLogger` / `LoopctlWeb.DBErrorLogger`, a handler
+  MUST NOT break the request it observes: a failed upsert (DB blip, pool exhaustion,
+  a raise) is logged and swallowed — the article write already succeeded/failed on
+  its own path and must not be affected by a dropped rollup increment.
+
+  ## RLS convention (BYPASSRLS + explicit tenant_id)
+
+  Writes go through `Loopctl.AdminRepo` (BYPASSRLS) with `tenant_id` set explicitly on
+  the struct — the same RLS-bypass-with-explicit-predicate convention
+  `IngestionHealth` / `CostAnomaly` use for operator/system rollups. An event with no
+  `tenant_id` (nothing to attribute) or an unmapped `outcome` is skipped.
+  """
+
+  require Logger
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge.IngestionWriteStats
+  alias Loopctl.TelemetryEvents
+
+  @handler_id __MODULE__
+  @conflict_target {:unsafe_fragment, "(tenant_id, COALESCE(source_type, ''), day)"}
+
+  @doc """
+  Attaches the article-write rollup handler. Idempotent: a duplicate attach (code
+  reload) is ignored rather than raised.
+  """
+  @spec attach() :: :ok
+  def attach do
+    case :telemetry.attach(
+           @handler_id,
+           TelemetryEvents.article_write(),
+           &__MODULE__.handle_event/4,
+           nil
+         ) do
+      :ok -> :ok
+      {:error, :already_exists} -> :ok
+    end
+  end
+
+  @doc "Detaches the handler (used in focused tests)."
+  @spec detach() :: :ok
+  def detach do
+    _ = :telemetry.detach(@handler_id)
+    :ok
+  end
+
+  @doc false
+  def handle_event(_event, _measurements, metadata, _config) do
+    tenant_id = Map.get(metadata, :tenant_id)
+    outcome = Map.get(metadata, :outcome)
+    column = outcome && IngestionWriteStats.column_for(outcome)
+
+    if is_binary(tenant_id) and not is_nil(column) do
+      upsert_increment(tenant_id, source_type_of(metadata), column)
+    end
+
+    :ok
+  rescue
+    e ->
+      # A dropped rollup increment must NEVER break the article write it observes.
+      Logger.error("IngestionWriteStats handler error: #{Exception.message(e)}")
+      :ok
+  end
+
+  defp upsert_increment(tenant_id, source_type, column) do
+    now = DateTime.utc_now()
+    day = DateTime.to_date(now)
+
+    attrs = %{source_type: source_type, day: day} |> Map.put(column, 1)
+    changeset = IngestionWriteStats.changeset(%IngestionWriteStats{tenant_id: tenant_id}, attrs)
+
+    case AdminRepo.insert(changeset,
+           on_conflict: [inc: [{column, 1}], set: [updated_at: now]],
+           conflict_target: @conflict_target
+         ) do
+      {:ok, _row} ->
+        :ok
+
+      {:error, changeset} ->
+        Logger.warning(
+          "IngestionWriteStats: failed to upsert #{column} for tenant #{tenant_id}: " <>
+            "#{inspect(changeset.errors)}"
+        )
+    end
+  end
+
+  # source_type is advisory + nullable; treat any non-binary (absent/malformed) as
+  # nil so it lands in the COALESCE('') bucket.
+  defp source_type_of(metadata) do
+    case Map.get(metadata, :source_type) do
+      st when is_binary(st) -> st
+      _ -> nil
+    end
+  end
+end

--- a/lib/loopctl/telemetry/ingestion_write_stats.ex
+++ b/lib/loopctl/telemetry/ingestion_write_stats.ex
@@ -8,15 +8,24 @@ defmodule Loopctl.Telemetry.IngestionWriteStats do
   (emitted from EVERY render path of `LoopctlWeb.ArticleController.create`) and, per
   event, upserts+increments the counter column that matches the event's `outcome`.
 
-  ## Why a direct per-write upsert (not an ETS buffer)
+  ## Off the request path (async by default) — why not a blocking per-write upsert
 
   Article writes are LOW-FREQUENCY (a create/dedup/reject per API call, not a hot
-  request-path event like the scale signals `Loopctl.Telemetry.ScaleAlerts` windows).
-  A direct upsert per event is therefore acceptable and far simpler than an
-  ETS-buffer + periodic flush — and it keeps the rollup transactionally consistent
-  with the write it counts (the handler runs synchronously in the request process, so
-  in tests it shares that process's sandboxed connection). If write volume ever grows
-  hot, an ETS-buffer+flush (ScaleAlerts style) is the drop-in alternative.
+  request-path event like the scale signals `Loopctl.Telemetry.ScaleAlerts` windows),
+  so a direct upsert per event is far simpler than an ETS-buffer + periodic flush. BUT
+  a `:telemetry` handler runs SYNCHRONOUSLY in the emitting (request) process, and the
+  BYPASSRLS `AdminRepo` pool is small (3 conns in prod) and already carries the
+  per-request rate-limiter upsert — so a blocking upsert here would couple article-write
+  tail latency to AdminRepo pool checkout (up to the checkout timeout) under pool
+  pressure or a DB blip. To decouple, the increment is dispatched to a supervised,
+  fire-and-forget `Loopctl.TaskSupervisor` task (`async?/0`, default true) so the
+  request path never blocks on it. If write volume ever grows hot enough to pressure
+  the pool from the task side, an ETS-buffer+flush (ScaleAlerts style) is the drop-in
+  next step.
+
+  In TEST the dispatch runs INLINE (`config :loopctl, #{inspect(__MODULE__)}, async:
+  false`) so the upsert shares the emitting test process's sandboxed connection and the
+  rollup row is readable back synchronously.
 
   ## Self-rescuing (never break the request path)
 
@@ -73,7 +82,7 @@ defmodule Loopctl.Telemetry.IngestionWriteStats do
     column = outcome && IngestionWriteStats.column_for(outcome)
 
     if is_binary(tenant_id) and not is_nil(column) do
-      upsert_increment(tenant_id, source_type_of(metadata), column)
+      dispatch_upsert(tenant_id, source_type_of(metadata), column)
     end
 
     :ok
@@ -82,6 +91,39 @@ defmodule Loopctl.Telemetry.IngestionWriteStats do
       # A dropped rollup increment must NEVER break the article write it observes.
       Logger.error("IngestionWriteStats handler error: #{Exception.message(e)}")
       :ok
+  end
+
+  # Async (prod default): hand the upsert to a supervised fire-and-forget task so the
+  # request process never blocks on AdminRepo pool checkout. Inline (test): run in the
+  # emitting process so it shares the sandboxed connection. `start_child` returning an
+  # error is swallowed by the caller's rescue — a lost increment must not break the write.
+  defp dispatch_upsert(tenant_id, source_type, column) do
+    if async?() do
+      Task.Supervisor.start_child(Loopctl.TaskSupervisor, fn ->
+        safe_upsert_increment(tenant_id, source_type, column)
+      end)
+
+      :ok
+    else
+      upsert_increment(tenant_id, source_type, column)
+    end
+  end
+
+  # Task body runs in its OWN process, outside handle_event's rescue, so it self-rescues:
+  # a DB blip logs instead of surfacing as a supervised-task crash report.
+  defp safe_upsert_increment(tenant_id, source_type, column) do
+    upsert_increment(tenant_id, source_type, column)
+  rescue
+    e -> Logger.error("IngestionWriteStats async upsert error: #{Exception.message(e)}")
+  end
+
+  # Whether to run the rollup upsert off the request path (default true). Test pins it
+  # false so the upsert shares the emitting process's sandboxed connection.
+  @spec async?() :: boolean()
+  def async? do
+    :loopctl
+    |> Application.get_env(__MODULE__, [])
+    |> Keyword.get(:async, true)
   end
 
   defp upsert_increment(tenant_id, source_type, column) do

--- a/lib/loopctl/telemetry/ingestion_write_stats.ex
+++ b/lib/loopctl/telemetry/ingestion_write_stats.ex
@@ -10,29 +10,51 @@ defmodule Loopctl.Telemetry.IngestionWriteStats do
 
   ## Off the request path (async by default) — why not a blocking per-write upsert
 
-  Article writes are LOW-FREQUENCY (a create/dedup/reject per API call, not a hot
-  request-path event like the scale signals `Loopctl.Telemetry.ScaleAlerts` windows),
-  so a direct upsert per event is far simpler than an ETS-buffer + periodic flush. BUT
-  a `:telemetry` handler runs SYNCHRONOUSLY in the emitting (request) process, and the
-  BYPASSRLS `AdminRepo` pool is small (3 conns in prod) and already carries the
-  per-request rate-limiter upsert — so a blocking upsert here would couple article-write
-  tail latency to AdminRepo pool checkout (up to the checkout timeout) under pool
-  pressure or a DB blip. To decouple, the increment is dispatched to a supervised,
-  fire-and-forget `Loopctl.TaskSupervisor` task (`async?/0`, default true) so the
-  request path never blocks on it. If write volume ever grows hot enough to pressure
-  the pool from the task side, an ETS-buffer+flush (ScaleAlerts style) is the drop-in
+  Article writes are typically low-frequency (a create/dedup/reject per API call, not a
+  hot request-path event like the scale signals `Loopctl.Telemetry.ScaleAlerts`
+  windows), so a direct upsert per event is far simpler than an ETS-buffer + periodic
+  flush. BUT a `:telemetry` handler runs SYNCHRONOUSLY in the emitting (request)
+  process, and the BYPASSRLS `AdminRepo` pool is small (3 conns in prod) and already
+  carries the per-request rate-limiter upsert — so a blocking upsert here would couple
+  article-write tail latency to AdminRepo pool checkout (up to the checkout timeout)
+  under pool pressure or a DB blip. To decouple, the increment is dispatched to a
+  supervised, fire-and-forget task (`async?/0`, default true) so the request path never
+  blocks on it.
+
+  ## Bounded fan-out (the reject storm is the worst case)
+
+  The `:high_reject_rate` detector this rollup feeds triggers on a client HAMMERING
+  create in a retry loop — i.e. write volume SPIKES exactly when the rollup is under
+  the most write pressure. An unbounded task fan-out would then spawn one AdminRepo
+  upsert per rejected write, contending for the 3-conn pool (shared with the rate
+  limiter + auth) and amplifying the very outage the detector exists to catch. So the
+  dispatch goes through the BOUNDED `Loopctl.Telemetry.IngestionWriteStatsTaskSupervisor`
+  (`max_children`, default 200): over the cap `start_child` returns
+  `{:error, :max_children}` and the increment is DROPPED (best-effort analytics) rather
+  than queueing unbounded checkouts. If write volume ever grows hot enough to pressure
+  the pool even under the cap, an ETS-buffer+flush (ScaleAlerts style) is the drop-in
   next step.
 
   In TEST the dispatch runs INLINE (`config :loopctl, #{inspect(__MODULE__)}, async:
   false`) so the upsert shares the emitting test process's sandboxed connection and the
   rollup row is readable back synchronously.
 
-  ## Self-rescuing (never break the request path)
+  ## Self-rescuing (never break the request path — nor let :telemetry detach us)
 
   Like `Loopctl.Telemetry.SlowQueryLogger` / `LoopctlWeb.DBErrorLogger`, a handler
   MUST NOT break the request it observes: a failed upsert (DB blip, pool exhaustion,
   a raise) is logged and swallowed — the article write already succeeded/failed on
   its own path and must not be affected by a dropped rollup increment.
+
+  Crucially, `:telemetry` PERMANENTLY DETACHES a handler that lets ANY failure escape
+  (error/exit/throw — see `telemetry:execute/3`'s invoke wrapper), which would silently
+  and permanently stop feeding this rollup for the node's lifetime and blind the
+  high_reject_rate detector — the exact silent-monitoring-death this epic exists to
+  prevent. The top-level `rescue` only catches raises (`:error`), but the async dispatch
+  (`Task.Supervisor.start_child/2`, a `GenServer.call`) can EXIT (`:noproc`) if the task
+  supervisor is momentarily down (its crash/restart, or app-shutdown ordering). So the
+  dispatch is additionally wrapped in a `try/catch` covering `:exit`/`:throw`, ensuring
+  no failure class can escape `handle_event/4`.
 
   ## RLS convention (BYPASSRLS + explicit tenant_id)
 
@@ -93,20 +115,49 @@ defmodule Loopctl.Telemetry.IngestionWriteStats do
       :ok
   end
 
-  # Async (prod default): hand the upsert to a supervised fire-and-forget task so the
-  # request process never blocks on AdminRepo pool checkout. Inline (test): run in the
-  # emitting process so it shares the sandboxed connection. `start_child` returning an
-  # error is swallowed by the caller's rescue — a lost increment must not break the write.
+  # Async (prod default): hand the upsert to the BOUNDED supervisor as a fire-and-forget
+  # task so the request process never blocks on AdminRepo pool checkout, and a write
+  # storm cannot fan out to unbounded concurrent checkouts. Inline (test): run in the
+  # emitting process so it shares the sandboxed connection.
+  #
+  # NOTHING may escape here: `start_child` is a `GenServer.call` that EXITS (`:noproc`)
+  # if the supervisor is momentarily down — an escaping exit would make `:telemetry`
+  # permanently detach this handler and silently kill the rollup. So we catch every
+  # class and swallow it; a lost increment is best-effort analytics, never a broken
+  # write nor a dead detector.
+  @task_supervisor Loopctl.Telemetry.IngestionWriteStatsTaskSupervisor
   defp dispatch_upsert(tenant_id, source_type, column) do
     if async?() do
-      Task.Supervisor.start_child(Loopctl.TaskSupervisor, fn ->
-        safe_upsert_increment(tenant_id, source_type, column)
-      end)
-
-      :ok
+      dispatch_async(tenant_id, source_type, column)
     else
       upsert_increment(tenant_id, source_type, column)
     end
+  end
+
+  defp dispatch_async(tenant_id, source_type, column) do
+    case Task.Supervisor.start_child(@task_supervisor, fn ->
+           safe_upsert_increment(tenant_id, source_type, column)
+         end) do
+      {:ok, _pid} ->
+        :ok
+
+      {:error, :max_children} ->
+        # Bounded supervisor at capacity (a write burst): DROP the increment rather
+        # than block the observed request or queue an unbounded AdminRepo checkout.
+        Logger.warning(
+          "IngestionWriteStats: task supervisor at capacity; dropping #{column} increment"
+        )
+
+      {:error, reason} ->
+        Logger.warning("IngestionWriteStats: failed to start upsert task: #{inspect(reason)}")
+    end
+
+    :ok
+  catch
+    kind, reason ->
+      # :exit (:noproc) if the supervisor is down, etc. Never let it escape to :telemetry.
+      Logger.warning("IngestionWriteStats: upsert dispatch #{kind}: #{inspect(reason)}")
+      :ok
   end
 
   # Task body runs in its OWN process, outside handle_event's rescue, so it self-rescues:

--- a/lib/loopctl/telemetry_events.ex
+++ b/lib/loopctl/telemetry_events.ex
@@ -275,6 +275,26 @@ defmodule Loopctl.TelemetryEvents do
   """
   def recall_context_degraded, do: [:loopctl, :memory, :recall_context, :degraded]
 
+  @doc """
+  A KB article WRITE OUTCOME was rendered (PR B2). Emitted from EVERY render path of
+  `LoopctlWeb.ArticleController.create` so write outcomes are observable even when
+  NOTHING is persisted (a rejected write leaves no article row). Folded into the
+  durable `ingestion_write_stats` per-(tenant, source_type, day) rollup by the
+  self-rescuing `Loopctl.Telemetry.IngestionWriteStats` handler, which
+  `Loopctl.Knowledge.IngestionHealth` reads to flag a `:high_reject_rate` anomaly —
+  the no-persist sibling of the capture-silence dead-man's-switch.
+
+  ## Payload (id/atom only — never article content)
+
+    * `measurements`: `%{count: 1}` — a pure increment.
+    * `metadata`: `%{tenant_id, source_type, outcome}` where `source_type` is the
+      article's advisory source_type or `nil`, and `outcome` is a BOUNDED atom:
+      `:created` (novel/forced create), `:deduplicated` (200 idempotent/near-dup
+      dedup), `:gated_to_draft` (novelty gate staged a draft), `:title_conflict`
+      (409 title taken), or `:validation_error` (changeset/other 4xx).
+  """
+  def article_write, do: [:loopctl, :knowledge, :article_write]
+
   @doc "Returns all defined event names for attachment"
   def all_events do
     [
@@ -293,7 +313,8 @@ defmodule Loopctl.TelemetryEvents do
       llm_provider_error(),
       ingestion_backlog_gate_failed_open(),
       article_linking_corpus_size(),
-      recall_context_degraded()
+      recall_context_degraded(),
+      article_write()
     ]
   end
 end

--- a/lib/loopctl/telemetry_events.ex
+++ b/lib/loopctl/telemetry_events.ex
@@ -276,11 +276,15 @@ defmodule Loopctl.TelemetryEvents do
   def recall_context_degraded, do: [:loopctl, :memory, :recall_context, :degraded]
 
   @doc """
-  A KB article WRITE OUTCOME was rendered (PR B2). Emitted from EVERY render path of
-  `LoopctlWeb.ArticleController.create` so write outcomes are observable even when
-  NOTHING is persisted (a rejected write leaves no article row). Folded into the
-  durable `ingestion_write_stats` per-(tenant, source_type, day) rollup by the
-  self-rescuing `Loopctl.Telemetry.IngestionWriteStats` handler, which
+  A KB article WRITE OUTCOME was rendered (PR B2). Emitted from EVERY outcome path of
+  `LoopctlWeb.ArticleController.create` — both the create-path renderers (created,
+  deduplicated, gated_to_draft, title_conflict, validation_error) AND the upfront
+  rejection paths that return before a create is attempted (system-scope 403,
+  malformed project_id 422, agent-identity-required 403, all counted as
+  `:validation_error`) — so write outcomes are observable even when NOTHING is
+  persisted (a rejected write leaves no article row). Folded into the durable
+  `ingestion_write_stats` per-(tenant, source_type, day) rollup by the self-rescuing
+  `Loopctl.Telemetry.IngestionWriteStats` handler, which
   `Loopctl.Knowledge.IngestionHealth` reads to flag a `:high_reject_rate` anomaly —
   the no-persist sibling of the capture-silence dead-man's-switch.
 
@@ -288,10 +292,13 @@ defmodule Loopctl.TelemetryEvents do
 
     * `measurements`: `%{count: 1}` — a pure increment.
     * `metadata`: `%{tenant_id, source_type, outcome}` where `source_type` is the
-      article's advisory source_type or `nil`, and `outcome` is a BOUNDED atom:
-      `:created` (novel/forced create), `:deduplicated` (200 idempotent/near-dup
-      dedup), `:gated_to_draft` (novelty gate staged a draft), `:title_conflict`
-      (409 title taken), or `:validation_error` (changeset/other 4xx).
+      article's advisory source_type NORMALIZED against `Article.known_source_types/0`
+      (any non-allowlisted value — including all rejected-write garbage — folds to
+      `nil`, i.e. the unstamped bucket, so rollup cardinality stays bounded), and
+      `outcome` is a BOUNDED atom: `:created` (novel/forced create), `:deduplicated`
+      (200 idempotent/near-dup dedup), `:gated_to_draft` (novelty gate staged a
+      draft), `:title_conflict` (409 title taken), or `:validation_error`
+      (changeset/other 4xx, and the upfront 403/422 rejection paths).
   """
   def article_write, do: [:loopctl, :knowledge, :article_write]
 

--- a/lib/loopctl/workers/ingestion_health_worker.ex
+++ b/lib/loopctl/workers/ingestion_health_worker.ex
@@ -22,12 +22,16 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
   successfully alerted (`alerted: false`), in which case it re-fires the operator
   alert + webhook once (at-least-once recovery; see "Alert durability" below).
 
-  ## Recovery: auto-resolve when captures resume
+  ## Recovery: auto-resolve when the outage clears
 
   After detection, `Loopctl.Knowledge.IngestionHealth.auto_resolve_recovered/0`
-  closes any open anomaly whose `(tenant, source_type)` has produced an article
-  newer than the anomaly's `last_event_at`. Without this a fully-recovered stream
-  would keep a stale open anomaly forever, indistinguishable from an ongoing outage.
+  closes any open capture-silence anomaly whose `(tenant, source_type)` has produced
+  an article newer than the anomaly's `last_event_at`.
+  `auto_resolve_recovered_reject_rate/1` does the analogous close for high_reject_rate
+  anomalies whose reject rate fell back below threshold (no longer a candidate).
+  Without this a fully-recovered stream would keep a stale open anomaly forever,
+  indistinguishable from an ongoing outage. The reject-rate close ALSO stamps
+  `last_event_at` (episode ended), which re-arms suppression — see below.
 
   ## Suppression: resolve sticks, archive suppresses (reversibly)
 
@@ -123,16 +127,11 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
     # PR B2: the no-persist / high-rejection-rate sibling detector. A rejected write
     # leaves no article row, so it is invisible to the capture-silence scan above;
     # this reads the durable `ingestion_write_stats` rollup instead.
-    reject_candidates = detect_reject_candidates()
+    run_reject_rate_detection()
 
-    Logger.info(
-      "IngestionHealthWorker: #{length(reject_candidates)} high-reject-rate candidate(s) detected"
-    )
-
-    Enum.each(reject_candidates, &flag_candidate/1)
-
-    # Close anomalies whose captures have resumed (recovered streams), so an open
-    # anomaly always means "still silent" and not "recovered but never cleared".
+    # Close capture-silence anomalies whose captures have resumed (recovered streams),
+    # so an open anomaly always means "still silent" and not "recovered but never
+    # cleared".
     resolved = IngestionHealth.auto_resolve_recovered()
 
     if resolved > 0 do
@@ -142,20 +141,47 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
     :ok
   end
 
-  # Reject-rate detection reads its own rollup table; guard the version-skew window
-  # (code on the hourly crontab before the migration landed) exactly like the
-  # anomalies-table probe, so a missing rollup table skips quietly instead of
-  # crashing the job.
-  defp detect_reject_candidates do
+  # Reject-rate detection, recovery, and rollup pruning all read/write the
+  # `ingestion_write_stats` table; guard the version-skew window (code on the hourly
+  # crontab before the migration landed) exactly like the anomalies-table probe, so a
+  # missing rollup table skips quietly instead of crashing the job. Crucially, recovery
+  # is guarded TOO: an empty candidate list from a MISSING table must not be read as
+  # "everything recovered" and mass-close active reject anomalies.
+  defp run_reject_rate_detection do
     if write_stats_table_ready?() do
-      IngestionHealth.detect_high_reject_rate()
+      reject_candidates = IngestionHealth.detect_high_reject_rate()
+
+      Logger.info(
+        "IngestionHealthWorker: #{length(reject_candidates)} high-reject-rate candidate(s) detected"
+      )
+
+      Enum.each(reject_candidates, &flag_candidate/1)
+
+      # Close reject-rate anomalies whose reject rate recovered (no longer a candidate).
+      # This resolves open rows that would otherwise freeze open, AND stamps the
+      # recovery time so a resolved row stops suppressing a FUTURE storm (re-arm).
+      closed = IngestionHealth.auto_resolve_recovered_reject_rate(reject_candidates)
+
+      if closed > 0 do
+        Logger.info(
+          "IngestionHealthWorker: auto-closed #{closed} recovered high-reject-rate anomaly(ies)"
+        )
+      end
+
+      # Retention: the rollup is append-only and only the rolling window is read, so
+      # prune aged rows to keep the table (and the cross-tenant scan) bounded.
+      pruned = IngestionHealth.prune_write_stats()
+
+      if pruned > 0 do
+        Logger.info("IngestionHealthWorker: pruned #{pruned} aged ingestion_write_stats row(s)")
+      end
     else
       Logger.warning(
         "IngestionHealthWorker: ingestion_write_stats table not present yet " <>
           "(migration pending); skipping reject-rate detection this run"
       )
 
-      []
+      :ok
     end
   end
 
@@ -259,10 +285,13 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
   # --- High-reject-rate flagging (PR B2) ---
 
   # Mirrors flag_capture_silence structurally, reusing the SAME persist/notify/
-  # at-least-once machinery, but with reject-rate semantics: no last_event_at/
-  # resume episode (rejects have no natural "resumed" signal), so resolve is sticky
-  # (a resolved reject-rate anomaly suppresses re-creation while rejects persist —
-  # anti-alarm-fatigue) until archived/unarchived.
+  # at-least-once machinery, but with reject-rate semantics: rejects have no natural
+  # "resumed" signal (no newer article), so recovery is defined as "no longer a
+  # candidate" and marked by stamping `last_event_at` (episode ended). A resolved
+  # reject-rate anomaly suppresses re-creation ONLY while its episode is still active
+  # (`last_event_at IS NULL`) — anti-alarm-fatigue while rejects persist — and re-arms
+  # once recovery stamps `last_event_at`, so a future storm re-fires. Archiving is the
+  # separate operator escape hatch.
   defp flag_reject_rate(%{tenant_id: tenant_id, source_type: source_type} = candidate) do
     existing =
       IngestionAnomaly
@@ -295,8 +324,14 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
     end
   end
 
-  # A resolved (non-archived) high_reject_rate anomaly suppresses re-creation while
-  # the reject condition persists — mirrors capture_silence's "resolve sticks".
+  # A resolved (non-archived) high_reject_rate anomaly suppresses re-creation while the
+  # reject condition persists — mirrors capture_silence's "resolve sticks". But only an
+  # ACTIVE episode suppresses: `last_event_at IS NULL` means the episode has not yet
+  # been marked recovered. Once IngestionHealth.auto_resolve_recovered_reject_rate/1
+  # stamps `last_event_at` (rejects fell below threshold), the resolved row stops
+  # suppressing, so a FRESH storm for the same source_type re-fires instead of being
+  # silenced forever. Without this scope a single operator resolve would blind the
+  # detector to every future outage of that source_type.
   defp resolved_reject_suppression?(tenant_id, source_type) do
     IngestionAnomaly
     |> where([a], a.tenant_id == ^tenant_id)
@@ -304,6 +339,7 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
     |> where([a], a.anomaly_type == :high_reject_rate)
     |> where([a], a.resolved == true)
     |> where([a], a.archived == false)
+    |> where([a], is_nil(a.last_event_at))
     |> AdminRepo.exists?()
   end
 

--- a/lib/loopctl/workers/ingestion_health_worker.ex
+++ b/lib/loopctl/workers/ingestion_health_worker.ex
@@ -120,6 +120,17 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
 
     Enum.each(candidates, &flag_candidate/1)
 
+    # PR B2: the no-persist / high-rejection-rate sibling detector. A rejected write
+    # leaves no article row, so it is invisible to the capture-silence scan above;
+    # this reads the durable `ingestion_write_stats` rollup instead.
+    reject_candidates = detect_reject_candidates()
+
+    Logger.info(
+      "IngestionHealthWorker: #{length(reject_candidates)} high-reject-rate candidate(s) detected"
+    )
+
+    Enum.each(reject_candidates, &flag_candidate/1)
+
     # Close anomalies whose captures have resumed (recovered streams), so an open
     # anomaly always means "still silent" and not "recovered but never cleared".
     resolved = IngestionHealth.auto_resolve_recovered()
@@ -129,6 +140,31 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
     end
 
     :ok
+  end
+
+  # Reject-rate detection reads its own rollup table; guard the version-skew window
+  # (code on the hourly crontab before the migration landed) exactly like the
+  # anomalies-table probe, so a missing rollup table skips quietly instead of
+  # crashing the job.
+  defp detect_reject_candidates do
+    if write_stats_table_ready?() do
+      IngestionHealth.detect_high_reject_rate()
+    else
+      Logger.warning(
+        "IngestionHealthWorker: ingestion_write_stats table not present yet " <>
+          "(migration pending); skipping reject-rate detection this run"
+      )
+
+      []
+    end
+  end
+
+  defp write_stats_table_ready? do
+    case AdminRepo.query("SELECT to_regclass('ingestion_write_stats')", []) do
+      {:ok, %{rows: [[nil]]}} -> false
+      {:ok, _} -> true
+      _ -> false
+    end
   end
 
   # `to_regclass` returns NULL when the relation does not exist (no exception),
@@ -141,7 +177,14 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
     end
   end
 
-  defp flag_candidate(%{
+  # Dispatch by detector type: capture_silence (writes stopped) vs high_reject_rate
+  # (writes rejected). Both reuse the same persist/notify/at-least-once machinery.
+  defp flag_candidate(%{anomaly_type: :high_reject_rate} = candidate),
+    do: flag_reject_rate(candidate)
+
+  defp flag_candidate(candidate), do: flag_capture_silence(candidate)
+
+  defp flag_capture_silence(%{
          tenant_id: tenant_id,
          source_type: source_type,
          last_event_at: last_event_at,
@@ -162,7 +205,7 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
       |> AdminRepo.one()
 
     cond do
-      archived_suppression?(tenant_id, source_type) ->
+      archived_suppression?(tenant_id, source_type, :capture_silence) ->
         # Operator archived this source_type — escape hatch, never re-flag (until un-archived).
         :suppressed
 
@@ -189,13 +232,13 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
   end
 
   # An archived anomaly (resolved or not) suppresses re-detection for that
-  # source_type — the operator's escape hatch for a retired workflow, reversible
-  # via IngestionHealth.unarchive_anomaly/3.
-  defp archived_suppression?(tenant_id, source_type) do
+  # (source_type, anomaly_type) — the operator's escape hatch for a retired
+  # workflow, reversible via IngestionHealth.unarchive_anomaly/3.
+  defp archived_suppression?(tenant_id, source_type, anomaly_type) do
     IngestionAnomaly
     |> where([a], a.tenant_id == ^tenant_id)
     |> where([a], a.source_type == ^source_type)
-    |> where([a], a.anomaly_type == :capture_silence)
+    |> where([a], a.anomaly_type == ^anomaly_type)
     |> where([a], a.archived == true)
     |> AdminRepo.exists?()
   end
@@ -211,6 +254,117 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
     |> where([a], a.archived == false)
     |> where([a], not is_nil(a.last_event_at) and a.last_event_at >= ^last_event_at)
     |> AdminRepo.exists?()
+  end
+
+  # --- High-reject-rate flagging (PR B2) ---
+
+  # Mirrors flag_capture_silence structurally, reusing the SAME persist/notify/
+  # at-least-once machinery, but with reject-rate semantics: no last_event_at/
+  # resume episode (rejects have no natural "resumed" signal), so resolve is sticky
+  # (a resolved reject-rate anomaly suppresses re-creation while rejects persist —
+  # anti-alarm-fatigue) until archived/unarchived.
+  defp flag_reject_rate(%{tenant_id: tenant_id, source_type: source_type} = candidate) do
+    existing =
+      IngestionAnomaly
+      |> where([a], a.tenant_id == ^tenant_id)
+      |> where([a], a.source_type == ^source_type)
+      |> where([a], a.anomaly_type == :high_reject_rate)
+      |> where([a], a.resolved == false)
+      |> where([a], a.archived == false)
+      |> AdminRepo.one()
+
+    cond do
+      archived_suppression?(tenant_id, source_type, :high_reject_rate) ->
+        :suppressed
+
+      existing && not existing.alerted ->
+        # At-least-once recovery: the row was persisted + audited atomically but its
+        # post-commit alert/webhook never fired. Re-fire, then refresh figures.
+        notify(tenant_id, existing)
+        update_existing_reject(existing, candidate)
+
+      existing ->
+        update_existing_reject(existing, candidate)
+
+      resolved_reject_suppression?(tenant_id, source_type) ->
+        # Operator resolved it and rejects still persist — do not re-fire every run.
+        :suppressed
+
+      true ->
+        create_new_reject(tenant_id, candidate)
+    end
+  end
+
+  # A resolved (non-archived) high_reject_rate anomaly suppresses re-creation while
+  # the reject condition persists — mirrors capture_silence's "resolve sticks".
+  defp resolved_reject_suppression?(tenant_id, source_type) do
+    IngestionAnomaly
+    |> where([a], a.tenant_id == ^tenant_id)
+    |> where([a], a.source_type == ^source_type)
+    |> where([a], a.anomaly_type == :high_reject_rate)
+    |> where([a], a.resolved == true)
+    |> where([a], a.archived == false)
+    |> AdminRepo.exists?()
+  end
+
+  defp create_new_reject(tenant_id, candidate) do
+    changeset =
+      IngestionAnomaly.create_changeset(
+        %IngestionAnomaly{tenant_id: tenant_id},
+        %{
+          source_type: candidate.source_type,
+          anomaly_type: :high_reject_rate,
+          # No staleness dimension for a reject-rate anomaly: last_event_at nil,
+          # hours_stale 0, sample_count = total write attempts in the window.
+          last_event_at: nil,
+          hours_stale: 0,
+          sample_count: candidate.total_attempts,
+          metadata: reject_metadata(candidate)
+        }
+      )
+
+    if changeset.valid? do
+      insert_new_anomaly(tenant_id, changeset)
+    else
+      Logger.warning(
+        "IngestionHealthWorker: invalid high_reject_rate anomaly for tenant " <>
+          "#{tenant_id}/#{candidate.source_type}, skipping: #{inspect(changeset.errors)}"
+      )
+
+      nil
+    end
+  end
+
+  # Silently refresh the reject figures on an existing unresolved anomaly — no re-notify.
+  defp update_existing_reject(existing, candidate) do
+    case existing
+         |> IngestionAnomaly.create_changeset(%{
+           hours_stale: 0,
+           sample_count: candidate.total_attempts,
+           metadata: reject_metadata(candidate)
+         })
+         |> AdminRepo.update() do
+      {:ok, updated} ->
+        updated
+
+      {:error, changeset} ->
+        Logger.warning(
+          "IngestionHealthWorker: failed to update high_reject_rate anomaly " <>
+            "#{existing.id}: #{inspect(changeset.errors)}"
+        )
+
+        existing
+    end
+  end
+
+  defp reject_metadata(candidate) do
+    %{
+      "reject_rate" => candidate.reject_rate,
+      "total_attempts" => candidate.total_attempts,
+      "rejects" => candidate.rejects,
+      "window_days" => candidate.window_days,
+      "dominant_reason" => candidate.dominant_reason
+    }
   end
 
   # Recovery path: the row exists but its post-commit notifications never fired
@@ -248,6 +402,17 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
   # per-tenant webhook subscriptions: a detected capture-silence is a genuine
   # operational event, so it must surface in logs/monitoring even when no alert
   # channel is wired.
+  defp log_detected_alarm(tenant_id, %IngestionAnomaly{anomaly_type: :high_reject_rate} = anomaly) do
+    md = anomaly.metadata || %{}
+
+    Logger.error(
+      "IngestionHealthWorker: high-reject-rate detected — tenant=#{tenant_id} " <>
+        "source_type=#{anomaly.source_type} reject_rate=#{md["reject_rate"]} " <>
+        "total_attempts=#{md["total_attempts"]} rejects=#{md["rejects"]} " <>
+        "dominant_reason=#{md["dominant_reason"]} anomaly_id=#{anomaly.id}"
+    )
+  end
+
   defp log_detected_alarm(tenant_id, anomaly) do
     Logger.error(
       "IngestionHealthWorker: capture-silence detected — tenant=#{tenant_id} " <>
@@ -374,6 +539,32 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
   end
 
   # Writes the `detected` audit entry inside the create transaction (AdminRepo).
+  defp log_detected(tenant_id, %IngestionAnomaly{anomaly_type: :high_reject_rate} = anomaly) do
+    md = anomaly.metadata || %{}
+
+    Audit.create_log_entry(tenant_id, %{
+      entity_type: "ingestion_anomaly",
+      entity_id: anomaly.id,
+      action: "detected",
+      actor_type: "system",
+      new_state: %{
+        "anomaly_type" => to_string(anomaly.anomaly_type),
+        "source_type" => anomaly.source_type,
+        "reject_rate" => md["reject_rate"],
+        "total_attempts" => md["total_attempts"],
+        "rejects" => md["rejects"],
+        "window_days" => md["window_days"],
+        "dominant_reason" => md["dominant_reason"]
+      },
+      metadata: %{
+        "anomaly_id" => anomaly.id,
+        "source_type" => anomaly.source_type,
+        "anomaly_type" => to_string(anomaly.anomaly_type),
+        "reject_rate" => md["reject_rate"]
+      }
+    })
+  end
+
   defp log_detected(tenant_id, anomaly) do
     Audit.create_log_entry(tenant_id, %{
       entity_type: "ingestion_anomaly",
@@ -399,6 +590,30 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
   # Enqueue an operator alert through ScaleAlertDeliveryWorker with an id-only payload.
   # That worker resolves SCALE_ALERT_WEBHOOK_URL itself and no-ops when unset, so this
   # is channel-agnostic and safe when unconfigured — we never read/require the URL here.
+  defp fire_operator_alert(
+         tenant_id,
+         %IngestionAnomaly{anomaly_type: :high_reject_rate} = anomaly
+       ) do
+    md = anomaly.metadata || %{}
+    window_days = md["window_days"] || IngestionHealth.reject_window_days()
+
+    payload = %{
+      "alert" => "ingestion.high_reject_rate",
+      "metric" => "ingestion.high_reject_rate.reject_rate",
+      "value" => md["reject_rate"],
+      "threshold" => IngestionHealth.reject_rate_threshold(),
+      "window_seconds" => window_days * 86_400,
+      "tenant_id" => tenant_id,
+      "source_type" => anomaly.source_type,
+      "total_attempts" => md["total_attempts"],
+      "rejects" => md["rejects"],
+      "dominant_reason" => md["dominant_reason"],
+      "at" => DateTime.utc_now() |> DateTime.to_iso8601()
+    }
+
+    enqueue_operator_alert(payload, anomaly)
+  end
+
   defp fire_operator_alert(tenant_id, anomaly) do
     # Conform to the ScaleAlert operator-alert contract (%{alert, metric, value,
     # threshold, window_seconds, at}) so the shared alert channel — including
@@ -420,6 +635,10 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
       "at" => DateTime.utc_now() |> DateTime.to_iso8601()
     }
 
+    enqueue_operator_alert(payload, anomaly)
+  end
+
+  defp enqueue_operator_alert(payload, anomaly) do
     case %{payload: payload} |> ScaleAlertDeliveryWorker.new() |> Oban.insert() do
       {:ok, _job} ->
         :ok
@@ -440,17 +659,35 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
     webhooks = EventGenerator.matching_webhooks(tenant_id, @webhook_event_type, nil)
 
     if webhooks != [] do
-      payload = %{
-        "anomaly_id" => anomaly.id,
-        "source_type" => anomaly.source_type,
-        "anomaly_type" => to_string(anomaly.anomaly_type),
-        "hours_stale" => anomaly.hours_stale,
-        "sample_count" => anomaly.sample_count,
-        "last_event_at" => iso8601(anomaly.last_event_at)
-      }
-
+      payload = anomaly_webhook_payload(anomaly)
       Enum.each(webhooks, &deliver_anomaly_event(tenant_id, &1, payload, anomaly.id))
     end
+  end
+
+  defp anomaly_webhook_payload(%IngestionAnomaly{anomaly_type: :high_reject_rate} = anomaly) do
+    md = anomaly.metadata || %{}
+
+    %{
+      "anomaly_id" => anomaly.id,
+      "source_type" => anomaly.source_type,
+      "anomaly_type" => to_string(anomaly.anomaly_type),
+      "reject_rate" => md["reject_rate"],
+      "total_attempts" => md["total_attempts"],
+      "rejects" => md["rejects"],
+      "window_days" => md["window_days"],
+      "dominant_reason" => md["dominant_reason"]
+    }
+  end
+
+  defp anomaly_webhook_payload(anomaly) do
+    %{
+      "anomaly_id" => anomaly.id,
+      "source_type" => anomaly.source_type,
+      "anomaly_type" => to_string(anomaly.anomaly_type),
+      "hours_stale" => anomaly.hours_stale,
+      "sample_count" => anomaly.sample_count,
+      "last_event_at" => iso8601(anomaly.last_event_at)
+    }
   end
 
   defp deliver_anomaly_event(tenant_id, webhook, payload, anomaly_id) do

--- a/lib/loopctl/workers/ingestion_health_worker.ex
+++ b/lib/loopctl/workers/ingestion_health_worker.ex
@@ -185,23 +185,44 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
     end
   end
 
+  # Reject-rate detection needs BOTH the rollup table (migration 20260717210000) AND
+  # the WIDENED anomaly_type CHECK that admits 'high_reject_rate' (migration
+  # 20260717210001). In a partial deploy where the first migration landed but the
+  # second did not, a high_reject_rate insert would raise a CHECK violation inside the
+  # Multi and fail the Oban job. Gate on both so the reject path skips quietly (and
+  # self-heals next run) until the CHECK is widened, instead of burning retries.
   defp write_stats_table_ready? do
-    case AdminRepo.query("SELECT to_regclass('ingestion_write_stats')", []) do
+    relation_present?("ingestion_write_stats") and high_reject_rate_check_ready?()
+  end
+
+  defp relation_present?(relation) do
+    case AdminRepo.query("SELECT to_regclass($1)", [relation]) do
       {:ok, %{rows: [[nil]]}} -> false
       {:ok, _} -> true
       _ -> false
     end
   end
 
-  # `to_regclass` returns NULL when the relation does not exist (no exception),
-  # so this is a cheap, crash-free readiness probe for the version-skew window.
-  defp anomalies_table_ready? do
-    case AdminRepo.query("SELECT to_regclass('ingestion_anomalies')", []) do
-      {:ok, %{rows: [[nil]]}} -> false
-      {:ok, _} -> true
-      _ -> false
+  # True once the ingestion_anomalies anomaly_type CHECK admits 'high_reject_rate'.
+  # Reads the constraint definition from the catalog (crash-free): absent constraint
+  # or a definition that does not yet mention the value ⇒ not ready.
+  defp high_reject_rate_check_ready? do
+    case AdminRepo.query(
+           "SELECT pg_get_constraintdef(oid) FROM pg_constraint " <>
+             "WHERE conname = 'ingestion_anomalies_anomaly_type_check'",
+           []
+         ) do
+      {:ok, %{rows: [[definition]]}} when is_binary(definition) ->
+        String.contains?(definition, "high_reject_rate")
+
+      _ ->
+        false
     end
   end
+
+  # `to_regclass` returns NULL when the relation does not exist (no exception),
+  # so this is a cheap, crash-free readiness probe for the version-skew window.
+  defp anomalies_table_ready?, do: relation_present?("ingestion_anomalies")
 
   # Dispatch by detector type: capture_silence (writes stopped) vs high_reject_rate
   # (writes rejected). Both reuse the same persist/notify/at-least-once machinery.

--- a/lib/loopctl_web/controllers/article_controller.ex
+++ b/lib/loopctl_web/controllers/article_controller.ex
@@ -284,6 +284,10 @@ defmodule LoopctlWeb.ArticleController do
 
     # System articles require superadmin role; everything else is agent+.
     if scope == "system" and api_key.role != :superadmin do
+      # Count the reject: an upfront authorization drop persists no article row, so
+      # without this the high_reject_rate detector would be blind to a 403 reject storm.
+      emit_write_telemetry(conn, params, :validation_error)
+
       conn
       |> put_status(:forbidden)
       |> json(%{
@@ -297,8 +301,15 @@ defmodule LoopctlWeb.ArticleController do
       # Validate project_id (path segment or JSON body) up front so a non-UUID
       # value returns a clean 422 instead of reaching validate_project_ownership/2
       # and raising Ecto.Query.CastError (500).
-      with :ok <- ProjectId.validate(params["project_id"]) do
-        create_validated(conn, api_key, params, draft?, gate?)
+      case ProjectId.validate(params["project_id"]) do
+        :ok ->
+          create_validated(conn, api_key, params, draft?, gate?)
+
+        error ->
+          # Count the upfront validation drop too, so a client hammering create with a
+          # malformed project_id (100% 422s, zero article rows) still moves reject_rate.
+          emit_write_telemetry(conn, params, :validation_error)
+          error
       end
     end
   end
@@ -325,6 +336,9 @@ defmodule LoopctlWeb.ArticleController do
         create_article(conn, tenant_id, bound_attrs, audit_opts, draft?, gate?)
 
       {:error, :no_agent_identity} ->
+        # Count the reject: an identity-required drop persists no article row.
+        emit_write_telemetry(conn, attrs, :validation_error)
+
         conn
         |> put_status(:forbidden)
         |> json(%{
@@ -499,10 +513,22 @@ defmodule LoopctlWeb.ArticleController do
     )
   end
 
+  # Normalize the telemetry source_type to the durable rollup's bucketing rules.
+  #
+  # `source_type` on a REJECTED write is arbitrary client input (the changeset
+  # already refused it), so forwarding it raw would (a) mint an unbounded number of
+  # `ingestion_write_stats` rows — one per distinct garbage value — letting a reject
+  # storm fragment across buckets below `min_attempts` and evade the high_reject_rate
+  # detector, and (b) let a literal `"(unstamped)"` collide with the NULL sentinel.
+  # Fold any value NOT in `Article.known_source_types/0` into `nil` so it lands in the
+  # single COALESCE('') unstamped bucket — only the ~8 known values key distinct rows.
   defp telemetry_source_type(attrs) do
     case attrs["source_type"] || attrs[:source_type] do
-      st when is_binary(st) -> st
-      _ -> nil
+      st when is_binary(st) ->
+        if st in Article.known_source_types(), do: st, else: nil
+
+      _ ->
+        nil
     end
   end
 

--- a/lib/loopctl_web/controllers/article_controller.ex
+++ b/lib/loopctl_web/controllers/article_controller.ex
@@ -32,6 +32,7 @@ defmodule LoopctlWeb.ArticleController do
   alias Loopctl.Auth.Role
   alias Loopctl.Knowledge
   alias Loopctl.Knowledge.Article
+  alias Loopctl.TelemetryEvents
   alias LoopctlWeb.ArticleJSON
   alias LoopctlWeb.AuditContext
   alias LoopctlWeb.Helpers.Pagination
@@ -383,8 +384,10 @@ defmodule LoopctlWeb.ArticleController do
   # Novelty-gated path: render by verdict. A near-duplicate is NOT created — the
   # caller is pointed at the canonical article. A low-novelty proposal is created as
   # a draft with the near-neighbors surfaced so a reviewer/consumer can merge.
-  defp render_proposal(conn, {:ok, %{verdict: :duplicate} = result}, _attrs, _draft?) do
+  defp render_proposal(conn, {:ok, %{verdict: :duplicate} = result}, attrs, _draft?) do
     %{article: existing, assessment: assessment} = result
+
+    emit_write_telemetry(conn, attrs, :deduplicated)
 
     conn
     |> put_status(:ok)
@@ -399,8 +402,10 @@ defmodule LoopctlWeb.ArticleController do
     })
   end
 
-  defp render_proposal(conn, {:ok, %{verdict: :gated_to_draft} = result}, _attrs, _draft?) do
+  defp render_proposal(conn, {:ok, %{verdict: :gated_to_draft} = result}, attrs, _draft?) do
     %{article: article, assessment: assessment} = result
+
+    emit_write_telemetry(conn, attrs, :gated_to_draft)
 
     conn
     |> put_status(:created)
@@ -419,13 +424,17 @@ defmodule LoopctlWeb.ArticleController do
   end
 
   defp render_proposal(conn, {:ok, %{verdict: :deduplicated, article: existing}}, attrs, draft?) do
+    emit_write_telemetry(conn, attrs, :deduplicated)
+
     conn
     |> put_status(:ok)
     |> json(dedup_response(existing, attrs, draft?))
   end
 
   # :created (novel, or gate fell open) — normal create response.
-  defp render_proposal(conn, {:ok, %{article: article}}, _attrs, _draft?) do
+  defp render_proposal(conn, {:ok, %{article: article}}, attrs, _draft?) do
+    emit_write_telemetry(conn, attrs, :created)
+
     conn
     |> put_status(:created)
     |> json(create_response(article))
@@ -435,19 +444,25 @@ defmodule LoopctlWeb.ArticleController do
     do: render_create(conn, error, attrs, draft?)
 
   # Ungated path (force: true) — the original create semantics.
-  defp render_create(conn, {:ok, article}, _attrs, _draft?) do
+  defp render_create(conn, {:ok, article}, attrs, _draft?) do
+    emit_write_telemetry(conn, attrs, :created)
+
     conn
     |> put_status(:created)
     |> json(create_response(article))
   end
 
   defp render_create(conn, {:ok, :deduplicated, existing}, attrs, draft?) do
+    emit_write_telemetry(conn, attrs, :deduplicated)
+
     conn
     |> put_status(:ok)
     |> json(dedup_response(existing, attrs, draft?))
   end
 
-  defp render_create(conn, {:error, :duplicate_title, existing}, _attrs, _draft?) do
+  defp render_create(conn, {:error, :duplicate_title, existing}, attrs, _draft?) do
+    emit_write_telemetry(conn, attrs, :title_conflict)
+
     conn
     |> put_status(:conflict)
     |> json(%{
@@ -463,8 +478,33 @@ defmodule LoopctlWeb.ArticleController do
     })
   end
 
-  defp render_create(_conn, {:error, %Ecto.Changeset{} = changeset}, _attrs, _draft?),
-    do: {:error, changeset}
+  defp render_create(conn, {:error, %Ecto.Changeset{} = changeset}, attrs, _draft?) do
+    emit_write_telemetry(conn, attrs, :validation_error)
+    {:error, changeset}
+  end
+
+  # Emit the article-write outcome telemetry (PR B2). Folded into the durable
+  # `ingestion_write_stats` rollup by `Loopctl.Telemetry.IngestionWriteStats` so a
+  # high-rejection-rate outage (which persists NO article row) stays observable.
+  # Emission must never change response behavior — it is a fire-and-forget increment.
+  defp emit_write_telemetry(conn, attrs, outcome) do
+    :telemetry.execute(
+      TelemetryEvents.article_write(),
+      %{count: 1},
+      %{
+        tenant_id: conn.assigns.current_api_key.tenant_id,
+        source_type: telemetry_source_type(attrs),
+        outcome: outcome
+      }
+    )
+  end
+
+  defp telemetry_source_type(attrs) do
+    case attrs["source_type"] || attrs[:source_type] do
+      st when is_binary(st) -> st
+      _ -> nil
+    end
+  end
 
   defp gate_meta(verdict, assessment) do
     %{

--- a/lib/loopctl_web/controllers/ingestion_anomaly_controller.ex
+++ b/lib/loopctl_web/controllers/ingestion_anomaly_controller.ex
@@ -170,27 +170,32 @@ defmodule LoopctlWeb.IngestionAnomalyController do
             include_archived: include_archived
           },
           # Warn when a source_type filter names a never-seen source, so an empty list
-          # is never mistaken for "healthy ingestion".
-          warnings: source_type_warnings(tenant_id, source_type)
+          # is never mistaken for "healthy ingestion". ONLY on an empty page — a
+          # non-empty page already carries the anomalies it would caveat, and the
+          # "empty result does not imply healthy" message would then contradict itself.
+          warnings: source_type_warnings(tenant_id, source_type, result.data)
         }
       })
     end
   end
 
-  # When a source_type filter names a source with NO recorded write activity for this
-  # tenant, an empty anomaly list does not imply healthy ingestion — surface that.
-  defp source_type_warnings(tenant_id, source_type) when is_binary(source_type) do
+  # When a source_type filter names a source with NO ingestion activity for this
+  # tenant AND the page is empty, an empty anomaly list does not imply healthy
+  # ingestion — surface that. A non-empty page needs no such caveat (it already shows
+  # anomalies), and the "empty result does not imply healthy" wording would misfire.
+  defp source_type_warnings(tenant_id, source_type, [] = _empty_data)
+       when is_binary(source_type) do
     if IngestionHealth.source_type_seen?(tenant_id, source_type) do
       []
     else
       [
-        "source_type #{inspect(source_type)} has no recorded write activity for this " <>
+        "source_type #{inspect(source_type)} has no recorded ingestion activity for this " <>
           "tenant; an empty result does not imply healthy ingestion for it."
       ]
     end
   end
 
-  defp source_type_warnings(_tenant_id, _source_type), do: []
+  defp source_type_warnings(_tenant_id, _source_type, _data), do: []
 
   @doc """
   PATCH /api/v1/ingestion-anomalies/:id

--- a/lib/loopctl_web/controllers/ingestion_anomaly_controller.ex
+++ b/lib/loopctl_web/controllers/ingestion_anomaly_controller.ex
@@ -16,6 +16,7 @@ defmodule LoopctlWeb.IngestionAnomalyController do
   use OpenApiSpex.ControllerSpecs
 
   alias Loopctl.ApiSpec.Schemas
+  alias Loopctl.Knowledge.IngestionAnomaly
   alias Loopctl.Knowledge.IngestionHealth
 
   action_fallback LoopctlWeb.FallbackController
@@ -36,7 +37,8 @@ defmodule LoopctlWeb.IngestionAnomalyController do
         "attempted but rejected at high rate, which persist no article row). " <>
         "Filterable by source_type and anomaly_type. Archived anomalies are excluded by " <>
         "default; use ?include_archived=true to include them. A malformed ?resolved value " <>
-        "is rejected with 422. The response `meta.filters` echoes the effective filters, " <>
+        "or an unknown ?anomaly_type is rejected with 422. The response `meta.filters` " <>
+        "echoes the effective filters, " <>
         "and `meta.warnings` flags a source_type filter that names a never-seen source " <>
         "(so an empty list is not mistaken for healthy).",
     parameters: [
@@ -75,7 +77,9 @@ defmodule LoopctlWeb.IngestionAnomalyController do
              meta: Schemas.PaginationMeta
            }
          }},
-      422 => {"Invalid 'resolved' filter value", "application/json", Schemas.ErrorResponse},
+      422 =>
+        {"Invalid 'resolved' or 'anomaly_type' filter value", "application/json",
+         Schemas.ErrorResponse},
       429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
     }
   )
@@ -130,11 +134,13 @@ defmodule LoopctlWeb.IngestionAnomalyController do
     api_key = conn.assigns.current_api_key
     tenant_id = api_key.tenant_id
 
-    # A malformed ?resolved value is rejected with 422 (not silently coerced to the
-    # unresolved-only default) — mirrors the update action's malformed-?archived guard.
-    with {:ok, resolved} <- parse_resolved(params["resolved"]) do
+    # A malformed ?resolved OR an unknown ?anomaly_type is rejected with 422 (not
+    # silently coerced / turned into a `where false` empty list) — so an operator who
+    # mistypes a filter sees the error, not a zero-result that reads as "healthy".
+    # Mirrors the update action's malformed-?archived guard.
+    with {:ok, resolved} <- parse_resolved(params["resolved"]),
+         {:ok, anomaly_type} <- parse_anomaly_type(params["anomaly_type"]) do
       source_type = string_filter(params["source_type"])
-      anomaly_type = string_filter(params["anomaly_type"])
       include_archived = parse_bool(params["include_archived"]) || false
 
       opts =
@@ -273,6 +279,27 @@ defmodule LoopctlWeb.IngestionAnomalyController do
     {:error, :unprocessable_entity,
      "Invalid 'resolved' value #{inspect(other)}; expected true, false, or all."}
   end
+
+  # Absent/empty -> {:ok, nil} (no filter). A known anomaly_type -> {:ok, value}. An
+  # UNKNOWN value (e.g. the natural typo "high-reject-rate") is rejected with 422 rather
+  # than flowing into the context's `where(false)` and returning an empty list that an
+  # operator would misread as healthy ingestion.
+  defp parse_anomaly_type(nil), do: {:ok, nil}
+  defp parse_anomaly_type(""), do: {:ok, nil}
+
+  defp parse_anomaly_type(value) when is_binary(value) do
+    if value in known_anomaly_types() do
+      {:ok, value}
+    else
+      {:error, :unprocessable_entity,
+       "Invalid 'anomaly_type' value #{inspect(value)}; expected one of " <>
+         "#{Enum.join(known_anomaly_types(), ", ")}."}
+    end
+  end
+
+  defp parse_anomaly_type(_), do: {:ok, nil}
+
+  defp known_anomaly_types, do: Enum.map(IngestionAnomaly.anomaly_types(), &Atom.to_string/1)
 
   # A query filter must be a non-empty string to apply; empty/absent/malformed -> nil.
   defp string_filter(value) when is_binary(value) and value != "", do: value

--- a/lib/loopctl_web/controllers/ingestion_anomaly_controller.ex
+++ b/lib/loopctl_web/controllers/ingestion_anomaly_controller.ex
@@ -29,11 +29,16 @@ defmodule LoopctlWeb.IngestionAnomalyController do
   tags(["Knowledge Wiki"])
 
   operation(:index,
-    summary: "List ingestion capture-silence anomalies",
+    summary: "List ingestion anomalies (capture-silence + high-reject-rate)",
     description:
-      "Returns unresolved ingestion capture-silence anomalies for the tenant. " <>
-        "Filterable by source_type and anomaly_type. " <>
-        "Archived anomalies are excluded by default; use ?include_archived=true to include them.",
+      "Returns unresolved ingestion anomalies for the tenant — both capture_silence " <>
+        "(a source_type that stopped producing articles) and high_reject_rate (writes " <>
+        "attempted but rejected at high rate, which persist no article row). " <>
+        "Filterable by source_type and anomaly_type. Archived anomalies are excluded by " <>
+        "default; use ?include_archived=true to include them. A malformed ?resolved value " <>
+        "is rejected with 422. The response `meta.filters` echoes the effective filters, " <>
+        "and `meta.warnings` flags a source_type filter that names a never-seen source " <>
+        "(so an empty list is not mistaken for healthy).",
     parameters: [
       source_type: [
         in: :query,
@@ -43,7 +48,7 @@ defmodule LoopctlWeb.IngestionAnomalyController do
       anomaly_type: [
         in: :query,
         type: :string,
-        description: "Filter by anomaly type: capture_silence"
+        description: "Filter by anomaly type: capture_silence or high_reject_rate"
       ],
       include_archived: [
         in: :query,
@@ -70,6 +75,7 @@ defmodule LoopctlWeb.IngestionAnomalyController do
              meta: Schemas.PaginationMeta
            }
          }},
+      422 => {"Invalid 'resolved' filter value", "application/json", Schemas.ErrorResponse},
       429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
     }
   )
@@ -124,27 +130,61 @@ defmodule LoopctlWeb.IngestionAnomalyController do
     api_key = conn.assigns.current_api_key
     tenant_id = api_key.tenant_id
 
-    opts =
-      []
-      |> maybe_add_opt(:source_type, params["source_type"])
-      |> maybe_add_opt(:anomaly_type, params["anomaly_type"])
-      |> maybe_add_opt(:include_archived, parse_bool(params["include_archived"]))
-      |> maybe_add_opt(:resolved, parse_resolved(params["resolved"]))
-      |> maybe_add_opt(:page, parse_int(params["page"]))
-      |> maybe_add_opt(:page_size, parse_int(params["page_size"]))
+    # A malformed ?resolved value is rejected with 422 (not silently coerced to the
+    # unresolved-only default) — mirrors the update action's malformed-?archived guard.
+    with {:ok, resolved} <- parse_resolved(params["resolved"]) do
+      source_type = string_filter(params["source_type"])
+      anomaly_type = string_filter(params["anomaly_type"])
+      include_archived = parse_bool(params["include_archived"]) || false
 
-    {:ok, result} = IngestionHealth.list_anomalies(tenant_id, opts)
+      opts =
+        []
+        |> maybe_add_opt(:source_type, source_type)
+        |> maybe_add_opt(:anomaly_type, anomaly_type)
+        |> maybe_add_opt(:include_archived, include_archived)
+        |> maybe_add_opt(:resolved, resolved)
+        |> maybe_add_opt(:page, parse_int(params["page"]))
+        |> maybe_add_opt(:page_size, parse_int(params["page_size"]))
 
-    json(conn, %{
-      data: result.data,
-      meta: %{
-        page: result.page,
-        page_size: result.page_size,
-        total_count: result.total,
-        total_pages: ceil_div(result.total, result.page_size)
-      }
-    })
+      {:ok, result} = IngestionHealth.list_anomalies(tenant_id, opts)
+
+      json(conn, %{
+        data: result.data,
+        meta: %{
+          page: result.page,
+          page_size: result.page_size,
+          total_count: result.total,
+          total_pages: ceil_div(result.total, result.page_size),
+          # Echo the EFFECTIVE filters (post-default) so a caller can confirm what was
+          # actually applied — an omitted `resolved` reports the unresolved-only default.
+          filters: %{
+            source_type: source_type,
+            anomaly_type: anomaly_type,
+            resolved: if(is_nil(resolved), do: false, else: resolved),
+            include_archived: include_archived
+          },
+          # Warn when a source_type filter names a never-seen source, so an empty list
+          # is never mistaken for "healthy ingestion".
+          warnings: source_type_warnings(tenant_id, source_type)
+        }
+      })
+    end
   end
+
+  # When a source_type filter names a source with NO recorded write activity for this
+  # tenant, an empty anomaly list does not imply healthy ingestion — surface that.
+  defp source_type_warnings(tenant_id, source_type) when is_binary(source_type) do
+    if IngestionHealth.source_type_seen?(tenant_id, source_type) do
+      []
+    else
+      [
+        "source_type #{inspect(source_type)} has no recorded write activity for this " <>
+          "tenant; an empty result does not imply healthy ingestion for it."
+      ]
+    end
+  end
+
+  defp source_type_warnings(_tenant_id, _source_type), do: []
 
   @doc """
   PATCH /api/v1/ingestion-anomalies/:id
@@ -217,10 +257,26 @@ defmodule LoopctlWeb.IngestionAnomalyController do
   defp parse_bool(false), do: false
   defp parse_bool(_), do: nil
 
-  # `resolved=all` is a sentinel meaning "both resolved and unresolved"; anything
-  # else parses as a boolean (nil -> omitted -> context default of unresolved-only).
-  defp parse_resolved("all"), do: :all
-  defp parse_resolved(other), do: parse_bool(other)
+  # `resolved=all` is a sentinel meaning "both resolved and unresolved"; true/false
+  # narrow to that status; absent/empty -> {:ok, nil} (context default of
+  # unresolved-only). A malformed value is rejected with 422 rather than silently
+  # coerced, so an empty result is never mistaken for a deliberate filter.
+  defp parse_resolved(nil), do: {:ok, nil}
+  defp parse_resolved(""), do: {:ok, nil}
+  defp parse_resolved("all"), do: {:ok, :all}
+  defp parse_resolved("true"), do: {:ok, true}
+  defp parse_resolved("false"), do: {:ok, false}
+  defp parse_resolved(true), do: {:ok, true}
+  defp parse_resolved(false), do: {:ok, false}
+
+  defp parse_resolved(other) do
+    {:error, :unprocessable_entity,
+     "Invalid 'resolved' value #{inspect(other)}; expected true, false, or all."}
+  end
+
+  # A query filter must be a non-empty string to apply; empty/absent/malformed -> nil.
+  defp string_filter(value) when is_binary(value) and value != "", do: value
+  defp string_filter(_), do: nil
 
   defp parse_int(nil), do: nil
 

--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to `loopctl-mcp-server` are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 2.46.0 — 2026-07-18 (high-reject-rate ingestion anomalies)
+
+### Changed
+
+- **`get_ingestion_anomalies`** — the `anomaly_type` filter now accepts
+  `high_reject_rate` alongside `capture_silence`. `high_reject_rate` flags a
+  source_type whose writes are ATTEMPTED but REJECTED at high rate over a rolling
+  window (409 title_conflict / validation drops that persist no article row) — the
+  complement to capture_silence (writes stopped). Use it to catch the OTHER outage
+  signature where knowledge capture is landing calls but silently dropping them.
+
 ## 2.45.0 — 2026-07-18 (ingestion-health anomalies)
 
 ### Added

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -188,7 +188,7 @@ autonomous agent) can self-remediate without a human. Full agent-tenant lifecycl
 | `get_cost_summary` | orch | Get cost/token usage summary for a project, optionally broken down by `agent`, `epic`, or `model`. |
 | `get_story_token_usage` | orch | Get all token usage records for a single story. |
 | `get_cost_anomalies` | orch | Get cost anomaly alerts — stories or agents exceeding expected budgets. Optionally filter by project. |
-| `get_ingestion_anomalies` | orch | Get ingestion-health anomalies — capture-silence (a source_type stopped producing articles). Check whether knowledge capture is still landing. |
+| `get_ingestion_anomalies` | orch | Get ingestion-health anomalies — capture_silence (a source_type stopped producing articles) and high_reject_rate (writes rejected at high rate, persisting no article row). Check whether knowledge capture is still landing AND being accepted. |
 | `set_token_budget` | orch | Set a token budget (in millicents) for a project, epic, story, or agent scope. Requires orchestrator role. |
 
 ### Knowledge Wiki Tools (agent key)

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -2783,10 +2783,12 @@ const TOOLS = [
   {
     name: "get_ingestion_anomalies",
     description:
-      "Get ingestion-health anomalies — capture-silence (a source_type that was producing " +
-      "articles has gone silent). Use to check whether knowledge capture is still landing. " +
-      "Paginated (page/page_size); advance `page` to enumerate all. Filter by source_type, " +
-      "anomaly_type, resolved status, or include archived.",
+      "Get ingestion-health anomalies — capture_silence (a source_type that was producing " +
+      "articles has gone silent) and high_reject_rate (writes attempted but rejected at high " +
+      "rate — 409 title_conflict / validation drops that persist no article row). Use to check " +
+      "whether knowledge capture is still landing AND being accepted. Paginated (page/page_size); " +
+      "advance `page` to enumerate all. Filter by source_type, anomaly_type, resolved status, or " +
+      "include archived.",
     inputSchema: {
       type: "object",
       properties: {
@@ -2796,8 +2798,12 @@ const TOOLS = [
         },
         anomaly_type: {
           type: "string",
-          enum: ["capture_silence"],
-          description: 'Optional: filter by anomaly type (only "capture_silence" is currently produced).',
+          // Keep in sync with Loopctl.Knowledge.IngestionAnomaly @anomaly_types (the
+          // server-side Ecto.Enum + the ingestion_anomalies_anomaly_type_check DB CHECK).
+          enum: ["capture_silence", "high_reject_rate"],
+          description:
+            'Optional: filter by anomaly type — "capture_silence" (writes stopped) or ' +
+            '"high_reject_rate" (writes rejected at high rate).',
         },
         resolved: {
           type: "string",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.45.0",
+  "version": "2.46.0",
   "description": "MCP server for loopctl — structural trust for AI development loops",
   "type": "module",
   "main": "index.js",

--- a/priv/repo/migrations/20260717210000_create_ingestion_write_stats.exs
+++ b/priv/repo/migrations/20260717210000_create_ingestion_write_stats.exs
@@ -1,0 +1,65 @@
+defmodule Loopctl.Repo.Migrations.CreateIngestionWriteStats do
+  use Ecto.Migration
+  import Loopctl.Repo.RlsHelpers
+
+  @moduledoc """
+  Durable per-(tenant, source_type, day) rollup of KB article WRITE OUTCOMES.
+
+  The capture-silence monitor (`ingestion_anomalies`) detects "writes STOPPED"
+  by reading the `articles` table — but a REJECTED write leaves no article row,
+  so a high-rejection-rate outage (the server side of the 409 title_conflict /
+  validation drops — the OTHER signature of the 3-month capture outage) is
+  invisible to a row-count monitor. This table is fed by the self-rescuing
+  `[:loopctl, :knowledge, :article_write]` telemetry handler
+  (`Loopctl.Telemetry.IngestionWriteStats`) so write OUTCOMES are counted even
+  when nothing is persisted, and `IngestionHealth` can flag a `:high_reject_rate`
+  anomaly off this rollup.
+  """
+
+  def change do
+    create table(:ingestion_write_stats, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      add :tenant_id, references(:tenants, type: :binary_id, on_delete: :delete_all), null: false
+
+      # NULLABLE: an article write may carry no source_type (the advisory field is
+      # optional). NULL buckets distinctly from any named source_type via the
+      # COALESCE expression index below.
+      add :source_type, :string
+
+      add :day, :date, null: false
+
+      # Per-outcome counters (bigint so a high-throughput tenant/day never overflows).
+      # Mapped from the telemetry `outcome`:
+      #   :created         -> created_count
+      #   :deduplicated    -> deduplicated_count
+      #   :gated_to_draft  -> drafted_count
+      #   :title_conflict  -> title_conflict_count
+      #   :validation_error-> validation_error_count
+      add :created_count, :bigint, default: 0, null: false
+      add :deduplicated_count, :bigint, default: 0, null: false
+      add :drafted_count, :bigint, default: 0, null: false
+      add :title_conflict_count, :bigint, default: 0, null: false
+      add :validation_error_count, :bigint, default: 0, null: false
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    # Lookup index for the rolling-window reject-rate scan (day-leading so the
+    # `day >= window_start` predicate is a range seek).
+    create index(:ingestion_write_stats, [:tenant_id, :day])
+
+    # Idempotent upsert key. COALESCE(source_type, '') makes a NULL source_type
+    # bucket distinctly (NULLs are never equal in a plain unique index, which would
+    # let duplicate NULL-source rows accumulate and break ON CONFLICT increment).
+    # The telemetry handler's insert targets this exact expression via
+    # `conflict_target: {:unsafe_fragment, "(tenant_id, COALESCE(source_type, ''), day)"}`.
+    create unique_index(
+             :ingestion_write_stats,
+             ["tenant_id", "COALESCE(source_type, '')", "day"],
+             name: :ingestion_write_stats_tenant_source_day_unique
+           )
+
+    enable_rls(:ingestion_write_stats)
+  end
+end

--- a/priv/repo/migrations/20260717210001_add_high_reject_rate_anomaly_type.exs
+++ b/priv/repo/migrations/20260717210001_add_high_reject_rate_anomaly_type.exs
@@ -8,8 +8,9 @@ defmodule Loopctl.Repo.Migrations.AddHighRejectRateAnomalyType do
 
   The original CHECK (from `CreateIngestionAnomalies`) only allowed
   `('capture_silence')`; inserting a `high_reject_rate` row would fail the CHECK.
-  Drop and recreate it with both values. Reversible: the `down` restores the
-  single-value CHECK.
+  Drop and recreate it with both values. Reversible: the `down` first removes any
+  persisted `high_reject_rate` rows (which the narrowed CHECK would reject, failing
+  the ADD CONSTRAINT) and then restores the single-value CHECK.
   """
 
   def up do
@@ -27,6 +28,10 @@ defmodule Loopctl.Repo.Migrations.AddHighRejectRateAnomalyType do
     execute(
       "ALTER TABLE ingestion_anomalies DROP CONSTRAINT ingestion_anomalies_anomaly_type_check"
     )
+
+    # Remove rows the narrowed CHECK can no longer admit — otherwise ADD CONSTRAINT
+    # raises on the existing high_reject_rate rows and the rollback fails.
+    execute("DELETE FROM ingestion_anomalies WHERE anomaly_type = 'high_reject_rate'")
 
     execute(
       "ALTER TABLE ingestion_anomalies ADD CONSTRAINT ingestion_anomalies_anomaly_type_check " <>

--- a/priv/repo/migrations/20260717210001_add_high_reject_rate_anomaly_type.exs
+++ b/priv/repo/migrations/20260717210001_add_high_reject_rate_anomaly_type.exs
@@ -1,0 +1,36 @@
+defmodule Loopctl.Repo.Migrations.AddHighRejectRateAnomalyType do
+  use Ecto.Migration
+
+  @moduledoc """
+  Widens the `ingestion_anomalies.anomaly_type` CHECK constraint to admit the new
+  `:high_reject_rate` detector value (the no-persist / high-rejection-rate sibling
+  of `capture_silence`).
+
+  The original CHECK (from `CreateIngestionAnomalies`) only allowed
+  `('capture_silence')`; inserting a `high_reject_rate` row would fail the CHECK.
+  Drop and recreate it with both values. Reversible: the `down` restores the
+  single-value CHECK.
+  """
+
+  def up do
+    execute(
+      "ALTER TABLE ingestion_anomalies DROP CONSTRAINT ingestion_anomalies_anomaly_type_check"
+    )
+
+    execute(
+      "ALTER TABLE ingestion_anomalies ADD CONSTRAINT ingestion_anomalies_anomaly_type_check " <>
+        "CHECK (anomaly_type IN ('capture_silence', 'high_reject_rate'))"
+    )
+  end
+
+  def down do
+    execute(
+      "ALTER TABLE ingestion_anomalies DROP CONSTRAINT ingestion_anomalies_anomaly_type_check"
+    )
+
+    execute(
+      "ALTER TABLE ingestion_anomalies ADD CONSTRAINT ingestion_anomalies_anomaly_type_check " <>
+        "CHECK (anomaly_type IN ('capture_silence'))"
+    )
+  end
+end

--- a/priv/repo/migrations/20260717220000_add_ingestion_write_stats_day_index.exs
+++ b/priv/repo/migrations/20260717220000_add_ingestion_write_stats_day_index.exs
@@ -1,0 +1,19 @@
+defmodule Loopctl.Repo.Migrations.AddIngestionWriteStatsDayIndex do
+  use Ecto.Migration
+
+  @moduledoc """
+  Day-leading index for the reject-rate scan + retention pruning.
+
+  `Loopctl.Knowledge.IngestionHealth.detect_high_reject_rate/1` filters
+  `ingestion_write_stats.day >= window_start` across ALL tenants (no tenant
+  predicate) and groups by (tenant_id, source_type). The original supporting index
+  `(tenant_id, day)` is tenant-LEADING, so a day-only predicate cannot range-seek
+  it — the scan degraded to a sequential scan over an ever-growing rollup. This
+  day-leading index makes the rolling-window predicate a true range seek and also
+  serves the retention pruner's `day < cutoff` delete.
+  """
+
+  def change do
+    create index(:ingestion_write_stats, [:day])
+  end
+end

--- a/test/loopctl/knowledge/ingestion_health_test.exs
+++ b/test/loopctl/knowledge/ingestion_health_test.exs
@@ -550,9 +550,12 @@ defmodule Loopctl.Knowledge.IngestionHealthTest do
              |> Enum.filter(&(&1.tenant_id == tenant.id)) == []
     end
 
-    test "excludes NULL source_type buckets" do
+    test "flags a NULL/unstamped source_type bucket under the sentinel source_type" do
       tenant = fixture(:tenant)
 
+      # source_type is optional on a KB write, so the majority of agent captures omit
+      # it; a reject outage on those unstamped writes must NOT be a blind spot. The NULL
+      # bucket is surfaced under the sentinel (non-null so it can persist as an anomaly).
       fixture(:ingestion_write_stats, %{
         tenant_id: tenant.id,
         source_type: nil,
@@ -560,8 +563,41 @@ defmodule Loopctl.Knowledge.IngestionHealthTest do
         title_conflict_count: 8
       })
 
-      assert IngestionHealth.detect_high_reject_rate()
-             |> Enum.filter(&(&1.tenant_id == tenant.id)) == []
+      [candidate] =
+        IngestionHealth.detect_high_reject_rate()
+        |> Enum.filter(&(&1.tenant_id == tenant.id))
+
+      assert candidate.source_type == IngestionHealth.unstamped_source_type()
+      assert candidate.total_attempts == 10
+      assert candidate.rejects == 8
+    end
+
+    test "folds NULL and empty-string source_type into ONE unstamped bucket" do
+      tenant = fixture(:tenant)
+
+      fixture(:ingestion_write_stats, %{
+        tenant_id: tenant.id,
+        source_type: nil,
+        day: Date.utc_today(),
+        created_count: 1,
+        title_conflict_count: 4
+      })
+
+      fixture(:ingestion_write_stats, %{
+        tenant_id: tenant.id,
+        source_type: "",
+        day: Date.add(Date.utc_today(), -1),
+        created_count: 1,
+        title_conflict_count: 4
+      })
+
+      [candidate] =
+        IngestionHealth.detect_high_reject_rate()
+        |> Enum.filter(&(&1.tenant_id == tenant.id))
+
+      assert candidate.source_type == IngestionHealth.unstamped_source_type()
+      assert candidate.total_attempts == 10
+      assert candidate.rejects == 8
     end
 
     test "honors an explicit config passed to detect_high_reject_rate/1" do

--- a/test/loopctl/knowledge/ingestion_health_test.exs
+++ b/test/loopctl/knowledge/ingestion_health_test.exs
@@ -429,4 +429,206 @@ defmodule Loopctl.Knowledge.IngestionHealthTest do
       assert {:error, :not_found} = IngestionHealth.archive_anomaly(tenant_b.id, anomaly.id)
     end
   end
+
+  # --- PR B2: high-reject-rate detection off the ingestion_write_stats rollup ---
+
+  describe "detect_high_reject_rate/0" do
+    test "flags an established (>= min_attempts) high-reject source_type" do
+      tenant = fixture(:tenant)
+
+      # 10 attempts, 8 rejects (title_conflict) -> rate 0.8 > 0.5.
+      fixture(:ingestion_write_stats, %{
+        tenant_id: tenant.id,
+        source_type: "web_article",
+        created_count: 2,
+        title_conflict_count: 8
+      })
+
+      candidates =
+        IngestionHealth.detect_high_reject_rate()
+        |> Enum.filter(&(&1.tenant_id == tenant.id))
+
+      assert [candidate] = candidates
+      assert candidate.anomaly_type == :high_reject_rate
+      assert candidate.source_type == "web_article"
+      assert candidate.total_attempts == 10
+      assert candidate.rejects == 8
+      assert candidate.reject_rate == 0.8
+      assert candidate.window_days == 7
+      assert candidate.dominant_reason == "title_conflict"
+    end
+
+    test "sums title_conflict + validation_error as rejects; picks the dominant reason" do
+      tenant = fixture(:tenant)
+
+      fixture(:ingestion_write_stats, %{
+        tenant_id: tenant.id,
+        source_type: "web_article",
+        created_count: 2,
+        title_conflict_count: 3,
+        validation_error_count: 6
+      })
+
+      [candidate] =
+        IngestionHealth.detect_high_reject_rate()
+        |> Enum.filter(&(&1.tenant_id == tenant.id))
+
+      assert candidate.total_attempts == 11
+      assert candidate.rejects == 9
+      assert candidate.dominant_reason == "validation_error"
+    end
+
+    test "does not flag below min_attempts" do
+      tenant = fixture(:tenant)
+
+      fixture(:ingestion_write_stats, %{
+        tenant_id: tenant.id,
+        source_type: "web_article",
+        created_count: 1,
+        title_conflict_count: 4
+      })
+
+      assert IngestionHealth.detect_high_reject_rate()
+             |> Enum.filter(&(&1.tenant_id == tenant.id)) == []
+    end
+
+    test "does not flag when reject rate is at/below the threshold" do
+      tenant = fixture(:tenant)
+
+      fixture(:ingestion_write_stats, %{
+        tenant_id: tenant.id,
+        source_type: "web_article",
+        created_count: 6,
+        title_conflict_count: 4
+      })
+
+      assert IngestionHealth.detect_high_reject_rate()
+             |> Enum.filter(&(&1.tenant_id == tenant.id)) == []
+    end
+
+    test "sums across days within the rolling window" do
+      tenant = fixture(:tenant)
+
+      # Two days inside the 7-day window, each 5 attempts / 4 rejects -> 10 / 8.
+      fixture(:ingestion_write_stats, %{
+        tenant_id: tenant.id,
+        source_type: "web_article",
+        day: Date.utc_today(),
+        created_count: 1,
+        title_conflict_count: 4
+      })
+
+      fixture(:ingestion_write_stats, %{
+        tenant_id: tenant.id,
+        source_type: "web_article",
+        day: Date.add(Date.utc_today(), -3),
+        created_count: 1,
+        validation_error_count: 4
+      })
+
+      [candidate] =
+        IngestionHealth.detect_high_reject_rate()
+        |> Enum.filter(&(&1.tenant_id == tenant.id))
+
+      assert candidate.total_attempts == 10
+      assert candidate.rejects == 8
+    end
+
+    test "excludes rows older than the rolling window" do
+      tenant = fixture(:tenant)
+
+      # A high-reject bucket 10 days ago is outside the default 7-day window.
+      fixture(:ingestion_write_stats, %{
+        tenant_id: tenant.id,
+        source_type: "web_article",
+        day: Date.add(Date.utc_today(), -10),
+        created_count: 2,
+        title_conflict_count: 8
+      })
+
+      assert IngestionHealth.detect_high_reject_rate()
+             |> Enum.filter(&(&1.tenant_id == tenant.id)) == []
+    end
+
+    test "excludes NULL source_type buckets" do
+      tenant = fixture(:tenant)
+
+      fixture(:ingestion_write_stats, %{
+        tenant_id: tenant.id,
+        source_type: nil,
+        created_count: 2,
+        title_conflict_count: 8
+      })
+
+      assert IngestionHealth.detect_high_reject_rate()
+             |> Enum.filter(&(&1.tenant_id == tenant.id)) == []
+    end
+
+    test "honors an explicit config passed to detect_high_reject_rate/1" do
+      tenant = fixture(:tenant)
+
+      # 6 attempts, 4 rejects -> rate 0.66; below default min_attempts 10 but an
+      # explicit lower min_attempts + threshold flags it.
+      fixture(:ingestion_write_stats, %{
+        tenant_id: tenant.id,
+        source_type: "web_article",
+        created_count: 2,
+        title_conflict_count: 4
+      })
+
+      candidates =
+        IngestionHealth.detect_high_reject_rate(%{
+          reject_rate_threshold: 0.5,
+          min_attempts: 5,
+          reject_window_days: 7
+        })
+        |> Enum.filter(&(&1.tenant_id == tenant.id))
+
+      assert [%{source_type: "web_article"}] = candidates
+    end
+
+    test "tenant isolation — one tenant's rejects never surface for another" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+
+      fixture(:ingestion_write_stats, %{
+        tenant_id: tenant_a.id,
+        source_type: "web_article",
+        created_count: 2,
+        title_conflict_count: 8
+      })
+
+      fixture(:ingestion_write_stats, %{
+        tenant_id: tenant_b.id,
+        source_type: "web_article",
+        created_count: 8,
+        title_conflict_count: 2
+      })
+
+      tenants =
+        IngestionHealth.detect_high_reject_rate() |> Enum.map(& &1.tenant_id) |> Enum.uniq()
+
+      assert tenant_a.id in tenants
+      refute tenant_b.id in tenants
+    end
+  end
+
+  describe "source_type_seen?/2" do
+    test "true when the tenant has a write-stats row for the source_type" do
+      tenant = fixture(:tenant)
+      fixture(:ingestion_write_stats, %{tenant_id: tenant.id, source_type: "web_article"})
+
+      assert IngestionHealth.source_type_seen?(tenant.id, "web_article")
+    end
+
+    test "false for a never-seen source_type (and is tenant-scoped)" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+      fixture(:ingestion_write_stats, %{tenant_id: tenant_a.id, source_type: "web_article"})
+
+      refute IngestionHealth.source_type_seen?(tenant_a.id, "never_seen")
+      # Tenant B never recorded web_article.
+      refute IngestionHealth.source_type_seen?(tenant_b.id, "web_article")
+    end
+  end
 end

--- a/test/loopctl/telemetry/ingestion_write_stats_test.exs
+++ b/test/loopctl/telemetry/ingestion_write_stats_test.exs
@@ -1,0 +1,112 @@
+defmodule Loopctl.Telemetry.IngestionWriteStatsTest do
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  import Ecto.Query
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Knowledge.IngestionWriteStats
+  alias Loopctl.TelemetryEvents
+
+  # The handler is attached once at app boot (Loopctl.Application) and runs
+  # synchronously in the emitting (test) process, so it shares this test's sandbox
+  # connection — emitting the event here writes a rollup row we can read back.
+  defp emit(tenant_id, source_type, outcome) do
+    :telemetry.execute(
+      TelemetryEvents.article_write(),
+      %{count: 1},
+      %{tenant_id: tenant_id, source_type: source_type, outcome: outcome}
+    )
+  end
+
+  defp stats_for(tenant_id, source_type) do
+    query =
+      from(s in IngestionWriteStats,
+        where: s.tenant_id == ^tenant_id and s.day == ^Date.utc_today()
+      )
+
+    query =
+      if is_nil(source_type),
+        do: where(query, [s], is_nil(s.source_type)),
+        else: where(query, [s], s.source_type == ^source_type)
+
+    AdminRepo.one(query)
+  end
+
+  describe "article_write telemetry -> ingestion_write_stats rollup" do
+    test "increments the matching counter per outcome" do
+      tenant = fixture(:tenant)
+
+      emit(tenant.id, "session_log", :created)
+      emit(tenant.id, "session_log", :created)
+      emit(tenant.id, "session_log", :deduplicated)
+      emit(tenant.id, "session_log", :gated_to_draft)
+      emit(tenant.id, "session_log", :title_conflict)
+      emit(tenant.id, "session_log", :title_conflict)
+      emit(tenant.id, "session_log", :validation_error)
+
+      row = stats_for(tenant.id, "session_log")
+
+      assert row.created_count == 2
+      assert row.deduplicated_count == 1
+      assert row.drafted_count == 1
+      assert row.title_conflict_count == 2
+      assert row.validation_error_count == 1
+    end
+
+    test "buckets a NULL source_type distinctly from a named source_type" do
+      tenant = fixture(:tenant)
+
+      emit(tenant.id, nil, :created)
+      emit(tenant.id, nil, :title_conflict)
+      emit(tenant.id, "session_log", :created)
+
+      null_row = stats_for(tenant.id, nil)
+      named_row = stats_for(tenant.id, "session_log")
+
+      assert null_row.source_type == nil
+      assert null_row.created_count == 1
+      assert null_row.title_conflict_count == 1
+
+      assert named_row.source_type == "session_log"
+      assert named_row.created_count == 1
+      assert named_row.title_conflict_count == 0
+    end
+
+    test "an unknown outcome is skipped (no row written)" do
+      tenant = fixture(:tenant)
+
+      emit(tenant.id, "session_log", :some_future_outcome)
+
+      assert stats_for(tenant.id, "session_log") == nil
+    end
+
+    test "an event with no tenant_id is skipped" do
+      # Nothing to attribute -> no write, no crash.
+      :telemetry.execute(
+        TelemetryEvents.article_write(),
+        %{count: 1},
+        %{tenant_id: nil, source_type: "session_log", outcome: :created}
+      )
+
+      assert AdminRepo.aggregate(IngestionWriteStats, :count, :id) == 0
+    end
+
+    test "tenant isolation — each tenant's counters are separate" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+
+      emit(tenant_a.id, "session_log", :title_conflict)
+      emit(tenant_b.id, "session_log", :created)
+
+      a_row = stats_for(tenant_a.id, "session_log")
+      b_row = stats_for(tenant_b.id, "session_log")
+
+      assert a_row.title_conflict_count == 1
+      assert a_row.created_count == 0
+      assert b_row.created_count == 1
+      assert b_row.title_conflict_count == 0
+    end
+  end
+end

--- a/test/loopctl/workers/ingestion_health_worker_test.exs
+++ b/test/loopctl/workers/ingestion_health_worker_test.exs
@@ -403,13 +403,84 @@ defmodule Loopctl.Workers.IngestionHealthWorkerTest do
       assert anomalies_for(tenant_b.id) == []
     end
 
-    test "excludes a NULL source_type reject bucket (anomaly requires a source_type)" do
+    test "flags a NULL/unstamped source_type reject bucket under the sentinel source_type" do
       tenant = fixture(:tenant)
       seed_reject_stats(tenant.id, nil, %{created_count: 2, title_conflict_count: 8})
 
       assert :ok = IngestionHealthWorker.perform(%Oban.Job{args: %{}})
 
-      assert anomalies_for(tenant.id) == []
+      [anomaly] = anomalies_for(tenant.id)
+      assert anomaly.anomaly_type == :high_reject_rate
+      assert anomaly.source_type == IngestionHealth.unstamped_source_type()
+      assert anomaly.metadata["total_attempts"] == 10
+      assert anomaly.metadata["rejects"] == 8
+    end
+  end
+
+  describe "high-reject-rate recovery + re-arm" do
+    test "auto-closes an open reject anomaly once the reject rate recovers" do
+      tenant = fixture(:tenant)
+      seed_reject_stats(tenant.id, "web_article", %{created_count: 2, title_conflict_count: 8})
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert :ok = IngestionHealthWorker.perform(%Oban.Job{args: %{}})
+      end)
+
+      [open] = anomalies_for(tenant.id)
+      assert open.resolved == false
+      assert is_nil(open.last_event_at)
+
+      # Rejects recover: replace the rollup with a healthy window (no longer a candidate).
+      Loopctl.AdminRepo.delete_all(
+        from(s in Loopctl.Knowledge.IngestionWriteStats, where: s.tenant_id == ^tenant.id)
+      )
+
+      seed_reject_stats(tenant.id, "web_article", %{created_count: 10, title_conflict_count: 0})
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert :ok = IngestionHealthWorker.perform(%Oban.Job{args: %{}})
+      end)
+
+      [closed] = anomalies_for(tenant.id)
+      assert closed.resolved == true
+      # last_event_at is stamped with the recovery time (episode ended) so the row
+      # stops suppressing a future storm.
+      assert %DateTime{} = closed.last_event_at
+    end
+
+    test "a resolved anomaly re-arms after recovery: a fresh storm re-fires" do
+      tenant = fixture(:tenant)
+      seed_reject_stats(tenant.id, "web_article", %{created_count: 2, title_conflict_count: 8})
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert :ok = IngestionHealthWorker.perform(%Oban.Job{args: %{}})
+      end)
+
+      # Operator resolves; rejects then recover so the recovery pass stamps last_event_at.
+      [open] = anomalies_for(tenant.id)
+      {:ok, _} = IngestionHealth.resolve_anomaly(tenant.id, open.id, actor_type: "system")
+
+      Loopctl.AdminRepo.delete_all(
+        from(s in Loopctl.Knowledge.IngestionWriteStats, where: s.tenant_id == ^tenant.id)
+      )
+
+      seed_reject_stats(tenant.id, "web_article", %{created_count: 10, title_conflict_count: 0})
+      assert :ok = IngestionHealthWorker.perform(%Oban.Job{args: %{}})
+
+      # A NEW storm: because the resolved row was marked recovered (last_event_at set),
+      # it no longer suppresses — a fresh unresolved anomaly is created. Clear the rollup
+      # first so the new storm reuses today's (tenant, source, day) bucket.
+      AdminRepo.delete_all(
+        from(s in Loopctl.Knowledge.IngestionWriteStats, where: s.tenant_id == ^tenant.id)
+      )
+
+      seed_reject_stats(tenant.id, "web_article", %{created_count: 2, title_conflict_count: 8})
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert :ok = IngestionHealthWorker.perform(%Oban.Job{args: %{}})
+      end)
+
+      assert Enum.any?(anomalies_for(tenant.id), &(&1.resolved == false))
     end
   end
 end

--- a/test/loopctl/workers/ingestion_health_worker_test.exs
+++ b/test/loopctl/workers/ingestion_health_worker_test.exs
@@ -288,4 +288,128 @@ defmodule Loopctl.Workers.IngestionHealthWorkerTest do
       assert :ok = IngestionHealthWorker.perform(%Oban.Job{args: %{}})
     end
   end
+
+  # --- PR B2: high-reject-rate detection ---
+
+  describe "perform/1 — high-reject-rate detection" do
+    # Reject-rate config pins (config/test.exs): min_attempts 10, threshold 0.5.
+    defp seed_reject_stats(tenant_id, source_type, counters) do
+      fixture(
+        :ingestion_write_stats,
+        Map.merge(%{tenant_id: tenant_id, source_type: source_type}, counters)
+      )
+    end
+
+    test "flags an established high-reject source_type with audit + operator alert + webhook" do
+      tenant = fixture(:tenant)
+
+      fixture(:webhook, %{
+        tenant_id: tenant.id,
+        events: ["knowledge.ingestion_anomaly_detected"]
+      })
+
+      # 10 attempts, 8 rejects (rate 0.8 > 0.5, total >= min_attempts 10).
+      seed_reject_stats(tenant.id, "web_article", %{created_count: 2, title_conflict_count: 8})
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert :ok = IngestionHealthWorker.perform(%Oban.Job{args: %{}})
+        assert_enqueued(worker: ScaleAlertDeliveryWorker)
+        assert_enqueued(worker: WebhookDeliveryWorker, args: %{tenant_id: tenant.id})
+      end)
+
+      [anomaly] = anomalies_for(tenant.id)
+      assert anomaly.anomaly_type == :high_reject_rate
+      assert anomaly.source_type == "web_article"
+      assert anomaly.resolved == false
+      assert anomaly.sample_count == 10
+      assert anomaly.metadata["total_attempts"] == 10
+      assert anomaly.metadata["rejects"] == 8
+      assert anomaly.metadata["reject_rate"] > 0.5
+      assert anomaly.metadata["dominant_reason"] == "title_conflict"
+      assert anomaly.metadata["window_days"] == 7
+
+      assert detected_audit_count(tenant.id, "web_article") == 1
+    end
+
+    test "operator-alert payload conforms to the ScaleAlert contract for high_reject_rate" do
+      tenant = fixture(:tenant)
+      seed_reject_stats(tenant.id, "web_article", %{created_count: 2, validation_error_count: 8})
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert :ok = IngestionHealthWorker.perform(%Oban.Job{args: %{}})
+
+        [job] = all_enqueued(worker: ScaleAlertDeliveryWorker)
+        payload = job.args["payload"]
+
+        assert payload["alert"] == "ingestion.high_reject_rate"
+        assert payload["metric"] == "ingestion.high_reject_rate.reject_rate"
+        assert payload["value"] > 0.5
+        assert payload["threshold"] == 0.5
+        assert payload["window_seconds"] == 7 * 86_400
+        assert payload["dominant_reason"] == "validation_error"
+      end)
+    end
+
+    test "does not flag below min_attempts even at a high reject rate" do
+      tenant = fixture(:tenant)
+      # 5 attempts, 4 rejects (rate 0.8) but total < min_attempts 10.
+      seed_reject_stats(tenant.id, "web_article", %{created_count: 1, title_conflict_count: 4})
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert :ok = IngestionHealthWorker.perform(%Oban.Job{args: %{}})
+        refute_enqueued(worker: ScaleAlertDeliveryWorker)
+      end)
+
+      assert anomalies_for(tenant.id) == []
+    end
+
+    test "does not flag when the reject rate is at/below threshold" do
+      tenant = fixture(:tenant)
+      # 10 attempts, 4 rejects (rate 0.4 <= 0.5).
+      seed_reject_stats(tenant.id, "web_article", %{created_count: 6, title_conflict_count: 4})
+
+      assert :ok = IngestionHealthWorker.perform(%Oban.Job{args: %{}})
+
+      assert anomalies_for(tenant.id) == []
+      assert detected_audit_count(tenant.id, "web_article") == 0
+    end
+
+    test "a second run on the same reject condition updates in place and does NOT re-notify" do
+      tenant = fixture(:tenant)
+      seed_reject_stats(tenant.id, "web_article", %{created_count: 2, title_conflict_count: 8})
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert :ok = IngestionHealthWorker.perform(%Oban.Job{args: %{}})
+        assert :ok = IngestionHealthWorker.perform(%Oban.Job{args: %{}})
+
+        assert length(all_enqueued(worker: ScaleAlertDeliveryWorker)) == 1
+      end)
+
+      assert length(anomalies_for(tenant.id)) == 1
+      assert detected_audit_count(tenant.id, "web_article") == 1
+    end
+
+    test "tenant isolation — tenant A's rejects never flag tenant B" do
+      tenant_a = fixture(:tenant)
+      tenant_b = fixture(:tenant)
+
+      seed_reject_stats(tenant_a.id, "web_article", %{created_count: 2, title_conflict_count: 8})
+      # B: same volume but low reject rate.
+      seed_reject_stats(tenant_b.id, "web_article", %{created_count: 8, title_conflict_count: 2})
+
+      assert :ok = IngestionHealthWorker.perform(%Oban.Job{args: %{}})
+
+      assert [%{anomaly_type: :high_reject_rate}] = anomalies_for(tenant_a.id)
+      assert anomalies_for(tenant_b.id) == []
+    end
+
+    test "excludes a NULL source_type reject bucket (anomaly requires a source_type)" do
+      tenant = fixture(:tenant)
+      seed_reject_stats(tenant.id, nil, %{created_count: 2, title_conflict_count: 8})
+
+      assert :ok = IngestionHealthWorker.perform(%Oban.Job{args: %{}})
+
+      assert anomalies_for(tenant.id) == []
+    end
+  end
 end

--- a/test/loopctl_web/controllers/article_controller_test.exs
+++ b/test/loopctl_web/controllers/article_controller_test.exs
@@ -6,11 +6,25 @@ defmodule LoopctlWeb.ArticleControllerTest do
   alias Loopctl.AdminRepo
   alias Loopctl.Audit.AuditLog
   alias Loopctl.Knowledge.Article
+  alias Loopctl.Knowledge.IngestionWriteStats
 
   import Ecto.Query
 
   defp auth_conn(conn, raw_key) do
     put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  # PR B2: the create render paths emit [:loopctl, :knowledge, :article_write], folded
+  # into the ingestion_write_stats rollup by the boot-attached telemetry handler (which
+  # runs in this request/test process, sharing its sandbox connection).
+  defp write_stats(tenant_id, source_type) do
+    AdminRepo.one(
+      from(s in IngestionWriteStats,
+        where:
+          s.tenant_id == ^tenant_id and s.source_type == ^source_type and
+            s.day == ^Date.utc_today()
+      )
+    )
   end
 
   describe "POST /api/v1/articles" do
@@ -36,6 +50,56 @@ defmodule LoopctlWeb.ArticleControllerTest do
       assert body["data"]["status"] == "published"
       assert is_nil(body["data"]["project_id"])
       assert body["note"] =~ "published"
+    end
+
+    test "a create emits article_write telemetry folded into the write-stats rollup", %{
+      conn: conn
+    } do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/articles", %{
+          "title" => "Rollup Wiring Check",
+          "body" => "prove the create render path emits article_write telemetry",
+          "category" => "pattern",
+          "source_type" => "web_article"
+        })
+
+      assert json_response(conn, 201)
+
+      row = write_stats(tenant.id, "web_article")
+      assert row.created_count == 1
+    end
+
+    test "a title_conflict emits the title_conflict outcome to the rollup", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent})
+
+      params = %{
+        "title" => "Conflicting Title",
+        "body" => "original body content for the conflict check",
+        "category" => "pattern",
+        "source_type" => "web_article",
+        # force: true takes the ungated create path so a same-title different-body
+        # second write yields a 409 title_conflict (not a novelty-gate dedup).
+        "force" => true
+      }
+
+      conn |> auth_conn(raw_key) |> post(~p"/api/v1/articles", params)
+
+      conn2 =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/articles", %{params | "body" => "a different body triggers 409"})
+
+      assert json_response(conn2, 409)
+
+      row = write_stats(tenant.id, "web_article")
+      assert row.created_count == 1
+      assert row.title_conflict_count == 1
     end
 
     test "agent can stage a draft via draft: true", %{conn: conn} do

--- a/test/loopctl_web/controllers/ingestion_anomaly_controller_test.exs
+++ b/test/loopctl_web/controllers/ingestion_anomaly_controller_test.exs
@@ -173,6 +173,20 @@ defmodule LoopctlWeb.IngestionAnomalyControllerTest do
       assert json_response(conn, 422)
     end
 
+    test "rejects an unknown ?anomaly_type value with 422 (not an empty 'healthy' list)",
+         %{conn: conn} do
+      ctx = setup_tenant_with_anomalies()
+
+      # The natural typo (hyphens instead of underscores) must not flow into a
+      # `where false` that returns [] and reads as healthy ingestion.
+      conn =
+        conn
+        |> auth_conn(ctx.user_key)
+        |> get(~p"/api/v1/ingestion-anomalies?anomaly_type=high-reject-rate")
+
+      assert json_response(conn, 422)
+    end
+
     test "echoes the effective filters in meta.filters", %{conn: conn} do
       ctx = setup_tenant_with_anomalies()
 

--- a/test/loopctl_web/controllers/ingestion_anomaly_controller_test.exs
+++ b/test/loopctl_web/controllers/ingestion_anomaly_controller_test.exs
@@ -120,6 +120,101 @@ defmodule LoopctlWeb.IngestionAnomalyControllerTest do
       assert body["data"] == []
       assert body["meta"]["total_count"] == 0
     end
+
+    test "lists and filters both anomaly types", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      fixture(:ingestion_anomaly, %{tenant_id: tenant.id, source_type: "session_log"})
+
+      fixture(:ingestion_anomaly, %{
+        tenant_id: tenant.id,
+        source_type: "web_article",
+        anomaly_type: :high_reject_rate,
+        hours_stale: 0,
+        metadata: %{"reject_rate" => 0.8}
+      })
+
+      # Both listed by default.
+      body =
+        conn |> auth_conn(key) |> get(~p"/api/v1/ingestion-anomalies") |> json_response(200)
+
+      assert body["meta"]["total_count"] == 2
+
+      # Filter to high_reject_rate only.
+      body =
+        conn
+        |> auth_conn(key)
+        |> get(~p"/api/v1/ingestion-anomalies?anomaly_type=high_reject_rate")
+        |> json_response(200)
+
+      assert length(body["data"]) == 1
+      assert hd(body["data"])["anomaly_type"] == "high_reject_rate"
+
+      # Filter to capture_silence only.
+      body =
+        conn
+        |> auth_conn(key)
+        |> get(~p"/api/v1/ingestion-anomalies?anomaly_type=capture_silence")
+        |> json_response(200)
+
+      assert length(body["data"]) == 1
+      assert hd(body["data"])["anomaly_type"] == "capture_silence"
+    end
+
+    test "rejects a malformed ?resolved value with 422", %{conn: conn} do
+      ctx = setup_tenant_with_anomalies()
+
+      conn =
+        conn
+        |> auth_conn(ctx.user_key)
+        |> get(~p"/api/v1/ingestion-anomalies?resolved=maybe")
+
+      assert json_response(conn, 422)
+    end
+
+    test "echoes the effective filters in meta.filters", %{conn: conn} do
+      ctx = setup_tenant_with_anomalies()
+
+      body =
+        conn
+        |> auth_conn(ctx.user_key)
+        |> get(~p"/api/v1/ingestion-anomalies?source_type=session_log")
+        |> json_response(200)
+
+      assert body["meta"]["filters"]["source_type"] == "session_log"
+      # Omitted resolved reports the unresolved-only default.
+      assert body["meta"]["filters"]["resolved"] == false
+      assert body["meta"]["filters"]["include_archived"] == false
+      assert body["meta"]["filters"]["anomaly_type"] == nil
+    end
+
+    test "warns when a source_type filter names a never-seen source", %{conn: conn} do
+      ctx = setup_tenant_with_anomalies()
+
+      body =
+        conn
+        |> auth_conn(ctx.user_key)
+        |> get(~p"/api/v1/ingestion-anomalies?source_type=never_written")
+        |> json_response(200)
+
+      assert body["meta"]["warnings"] != []
+      assert Enum.any?(body["meta"]["warnings"], &String.contains?(&1, "never_written"))
+    end
+
+    test "no warning when the source_type has recorded write activity", %{conn: conn} do
+      tenant = fixture(:tenant)
+      {key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+      fixture(:ingestion_write_stats, %{tenant_id: tenant.id, source_type: "web_article"})
+
+      body =
+        conn
+        |> auth_conn(key)
+        |> get(~p"/api/v1/ingestion-anomalies?source_type=web_article")
+        |> json_response(200)
+
+      assert body["meta"]["warnings"] == []
+    end
   end
 
   # --- PATCH /api/v1/ingestion-anomalies/:id ---

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -21,6 +21,7 @@ defmodule Loopctl.Fixtures do
   alias Loopctl.Knowledge.ArticleAccessEvent
   alias Loopctl.Knowledge.ArticleLink
   alias Loopctl.Knowledge.IngestionAnomaly
+  alias Loopctl.Knowledge.IngestionWriteStats
   alias Loopctl.Llm.SettingsCache
   alias Loopctl.Llm.TenantLlmSettings
   alias Loopctl.Llm.UsageEvent, as: LlmUsageEvent
@@ -511,6 +512,21 @@ defmodule Loopctl.Fixtures do
         sample_count: 5,
         resolved: false,
         metadata: %{}
+      },
+      Enum.into(attrs, %{})
+    )
+  end
+
+  def build(:ingestion_write_stats, attrs) do
+    Map.merge(
+      %{
+        source_type: "session_log",
+        day: Date.utc_today(),
+        created_count: 0,
+        deduplicated_count: 0,
+        drafted_count: 0,
+        title_conflict_count: 0,
+        validation_error_count: 0
       },
       Enum.into(attrs, %{})
     )
@@ -1266,6 +1282,26 @@ defmodule Loopctl.Fixtures do
       |> Ecto.Changeset.put_change(:archived, Map.get(data, :archived, false))
 
     AdminRepo.insert!(changeset)
+  end
+
+  def fixture(:ingestion_write_stats, attrs) do
+    attrs = Enum.into(attrs, %{})
+
+    {tenant_id, attrs} =
+      case Map.get(attrs, :tenant_id) do
+        nil ->
+          tenant = fixture(:tenant)
+          {tenant.id, Map.put(attrs, :tenant_id, tenant.id)}
+
+        tid ->
+          {tid, attrs}
+      end
+
+    data = build(:ingestion_write_stats, Map.delete(attrs, :tenant_id))
+
+    %IngestionWriteStats{tenant_id: tenant_id}
+    |> IngestionWriteStats.changeset(data)
+    |> AdminRepo.insert!()
   end
 
   def fixture(:review_record, attrs) do


### PR DESCRIPTION
## What

Adds the second failure-signature detector to the ingestion-health subsystem (#426): **writes attempted but rejected at high rate** — the server side of the 409 `title_conflict` drops that silently lost ~3 months of captures. Rejections leave no article row, so article-write **outcomes** are instrumented and rolled up, and a new `:high_reject_rate` anomaly fires off that rollup.

- **Telemetry**: `[:loopctl, :knowledge, :article_write]` emitted from every `ArticleController.create` render path (created / deduplicated / gated_to_draft / title_conflict / validation_error, incl. early-return reject paths); `source_type` is normalized against `Article.known_source_types/0` first (unknown → an `(unstamped)` sentinel bucket) so it can't blow up rollup cardinality or evade detection. Emission never alters the response.
- **Rollup**: `ingestion_write_stats` (RLS, expression unique index on `(tenant_id, coalesce(source_type,''), day)`). A self-rescuing handler dispatches the upsert-increment to a **bounded** task supervisor (drop-on-overflow) so a reject storm can't exhaust the AdminRepo pool; wrapped so it can't auto-detach and silently die. 90-day retention prune wired into the hourly worker.
- **Detection**: `:high_reject_rate` over a rolling window (`reject_rate_threshold` 0.5, `min_attempts` 10 + per-source overrides, `reject_window_days` 7), reusing the capture-silence persist/audit/operator-alert/webhook/at-least-once machinery. Auto-resolves on recovery and re-arms after an operator resolve (suppression scoped to `last_event_at IS NULL`). The `(unstamped)` bucket is a first-class monitored candidate — closing the null-source blind spot.
- **Endpoint hardening** (folded-in PR-A review carryover): malformed `?resolved` and unknown `?anomaly_type` → 422; `meta.filters` echo; `meta.warnings` on a never-seen `source_type` filter (empty ≠ healthy).
- **MCP**: `get_ingestion_anomalies` `anomaly_type` enum widened to include `high_reject_rate`; mcp-server **2.45.0 → 2.46.0** (autopublish on merge).
- Migration robustness: `anomaly_type` DB CHECK widened (with a `down/0` that deletes new-type rows before narrowing); a version-skew probe verifies the widened CHECK before the worker runs; monitor indexes registered in IndexHealth.

## Review

`/review:enhanced-review-workflow` (elixir): Round 1 — 10 confirmed/fixed (`1c57bf1`); Round 2 (adversarial + security) — 15 confirmed/fixed (`8ef5ab2`); 5 disproved; **0 invalid deferrals**. Key hardening from review: async bounded telemetry off the request path (OTP backpressure), source_type cardinality/evasion fix (security), recovery auto-resolve + re-arm, early-return telemetry coverage, migration down/0 + CHECK-skew probe.

## Verification

`mix precommit` green post-review, independently re-run: **4993 tests, 0 failures**, credo/dialyzer/format clean. mcp-server `npm test` 233/233, `node --check` OK.

## Note (dev-only, not a prod/CI issue)

Registering the monitor indexes surfaced that some local dev DBs carry a stale-named `articles` index from an edited-after-apply draft of #426's migration `20260717190000`. CI and prod migrate a fresh DB from the final (correct) migration, so both have `articles_inserted_tenant_source_idx`; only long-lived local dev DBs may need a `mix ecto.migrate`/reset (and optionally dropping the stale index).
