### PR TITLE
channel_post write endpoint + context (agent role, per-session upsert, server-stamped agent_id, ownership, rate-limit)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ mcp-server/node_modules/
 
 # Playwright MCP session output (transient)
 .playwright-mcp/
+.claude/implement-plan.run.json

--- a/lib/loopctl/api_spec/schemas.ex
+++ b/lib/loopctl/api_spec/schemas.ex
@@ -893,6 +893,85 @@ defmodule Loopctl.ApiSpec.Schemas do
     })
   end
 
+  # ---------- Coordination Bus (Epic 39) ----------
+
+  defmodule ChannelPostRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "ChannelPostRequest",
+      description:
+        "Request body for posting to a repo coordination channel. agent_id and tenant_id are " <>
+          "stamped server-side from the verified key and are ignored if present in the body.",
+      type: :object,
+      required: [:project_id, :body],
+      properties: %{
+        project_id: %Schema{
+          type: :string,
+          format: :uuid,
+          description: "The channel — a project the caller's tenant owns"
+        },
+        body: %Schema{type: :string, description: "Free-text message (<= 16KB)"},
+        key: %Schema{
+          type: :string,
+          nullable: true,
+          description:
+            "Optional working-state slot key; a repeat post from the same session upserts it"
+        },
+        session_id: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Client-supplied session id (required when key is set)"
+        },
+        host: %Schema{type: :string, nullable: true, description: "Client-supplied hostname"},
+        refs: %Schema{
+          type: :object,
+          nullable: true,
+          description: "Optional structured refs; allowed keys: file, pr, branch, commit",
+          additionalProperties: %Schema{type: :string}
+        }
+      },
+      example: %{
+        project_id: "c3d4e5f6-a7b8-9012-cdef-123456789012",
+        body: "pushed PR #107, CI green",
+        key: "session_goal",
+        session_id: "S1",
+        refs: %{pr: "107", branch: "feature/us-39-2"}
+      }
+    })
+  end
+
+  defmodule ChannelPostResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "ChannelPostResponse",
+      description: "A coordination channel post",
+      type: :object,
+      properties: %{
+        post: %Schema{
+          type: :object,
+          properties: %{
+            id: %Schema{type: :string, format: :uuid},
+            tenant_id: %Schema{type: :string, format: :uuid},
+            project_id: %Schema{type: :string, format: :uuid},
+            agent_id: %Schema{type: :string, format: :uuid},
+            session_id: %Schema{type: :string, nullable: true},
+            host: %Schema{type: :string, nullable: true},
+            key: %Schema{type: :string, nullable: true},
+            body: %Schema{type: :string},
+            refs: %Schema{type: :object, nullable: true, additionalProperties: true},
+            expires_at: %Schema{type: :string, format: :"date-time"},
+            inserted_at: %Schema{type: :string, format: :"date-time"},
+            updated_at: %Schema{type: :string, format: :"date-time"}
+          }
+        }
+      }
+    })
+  end
+
   # ---------- Epics ----------
 
   defmodule EpicResponse do

--- a/lib/loopctl/coordination.ex
+++ b/lib/loopctl/coordination.ex
@@ -22,8 +22,10 @@ defmodule Loopctl.Coordination do
 
   import Ecto.Query
 
+  alias Ecto.Multi
   alias Loopctl.AdminRepo
   alias Loopctl.Agents
+  alias Loopctl.Audit
   alias Loopctl.Coordination.ChannelPost
   alias Loopctl.Projects
 
@@ -75,6 +77,158 @@ defmodule Loopctl.Coordination do
       |> AdminRepo.insert()
       |> tap_secret_blocked()
     end
+  end
+
+  @doc """
+  Writes a coordination post on behalf of a **verified agent identity**, with
+  ownership enforcement, audit, and per-session upsert — the HTTP write path
+  (US-39.2). This is the richer sibling of `create_post/4`: it runs the insert
+  (or keyed upsert) and the audit-log write in a single `AdminRepo.transaction`
+  so authorship is tamper-evident, and it distinguishes a freshly-created post
+  from an in-place slot update so the endpoint can answer 201 vs 200.
+
+  `tenant_id` and `agent_id` are server-stamped by the caller (from the verified
+  key identity — never the request body). `attrs` carries the caller-supplied
+  fields plus two context keys the changeset never casts:
+
+    * `:project_id` — the channel; ownership is checked via
+      `Projects.get_project/2`. A missing OR cross-tenant project returns the
+      SAME `{:error, :not_found}` (no existence oracle — the endpoint maps both
+      to one byte-identical 422).
+    * `:audit` — the actor context keyword list (from
+      `LoopctlWeb.AuditContext.from_conn/1`) written into the audit entry.
+
+  `expires_at` is fixed server-side at `now + #{@retention_days} days`.
+
+  ## Upsert semantics
+
+  With a `key` present the write UPSERTS on the LIVE partial unique index
+  `(tenant_id, project_id, agent_id, session_id, key) WHERE key IS NOT NULL` —
+  `agent_id` participates (it is server-stamped and constant per session, so
+  this changes nothing observable versus the doc's stale
+  `(tenant, project, session, key)` target, but it MUST match the live index or
+  the insert raises). A repeat write from the SAME session refreshes its own
+  slot (`body`/`refs`/`updated_at`/`expires_at`); a different session's same key
+  is a distinct row. Without a `key` every post is a new append-only row.
+
+  ## Returns
+
+    * `{:ok, %ChannelPost{}, :created}` — a new row was inserted (HTTP 201)
+    * `{:ok, %ChannelPost{}, :updated}` — an existing session slot was upserted
+      in place (HTTP 200)
+    * `{:error, :not_found}` — the project is missing or belongs to another
+      tenant (endpoint → shared 422)
+    * `{:error, %Ecto.Changeset{}}` — a size/shape bound, denylist hit, or NUL
+      byte was rejected; nothing was persisted (endpoint → 422)
+  """
+  @spec post(Ecto.UUID.t(), Ecto.UUID.t(), map()) ::
+          {:ok, ChannelPost.t(), :created | :updated}
+          | {:error, :not_found}
+          | {:error, Ecto.Changeset.t()}
+  def post(tenant_id, agent_id, attrs) do
+    project_id = Map.get(attrs, :project_id)
+    audit = Map.get(attrs, :audit, [])
+
+    with {:ok, _project} <- Projects.get_project(tenant_id, project_id),
+         {:ok, _agent} <- Agents.get_agent(tenant_id, agent_id) do
+      changeset =
+        %ChannelPost{
+          tenant_id: tenant_id,
+          project_id: project_id,
+          agent_id: agent_id,
+          expires_at: default_expires_at()
+        }
+        |> ChannelPost.create_changeset(attrs)
+
+      run_post(tenant_id, changeset, audit)
+    end
+  end
+
+  # Insert (or keyed upsert) + audit in one transaction. The created/updated
+  # outcome is resolved from a pre-existence check on the slot rather than the
+  # returned row's timestamps: with `on_conflict: {:replace, ...}` Ecto does NOT
+  # read `inserted_at` back, so `inserted_at == updated_at` cannot distinguish an
+  # insert from an update. The slot is keyed on `agent_id + session_id`, and a
+  # single session is single-threaded, so the check is race-free in practice
+  # (a different session targets a different slot).
+  defp run_post(tenant_id, changeset, audit) do
+    key = Ecto.Changeset.get_field(changeset, :key)
+
+    {insert_opts, outcome} =
+      if is_nil(key) do
+        {[], :created}
+      else
+        # The LIVE arbiter is a PARTIAL unique index
+        # (`... WHERE key IS NOT NULL`, index `channel_posts_session_key_uidx`).
+        # Postgres cannot INFER a partial index from a bare column list — the
+        # ON CONFLICT must carry the matching predicate — so the conflict_target
+        # is an unsafe_fragment mirroring the index columns AND its WHERE clause
+        # (same pattern as memory.ex:2510). agent_id participates so a spoofed
+        # session_id can never overwrite another agent's slot.
+        {[
+           on_conflict: {:replace, [:body, :refs, :updated_at, :expires_at]},
+           conflict_target:
+             {:unsafe_fragment,
+              "(tenant_id, project_id, agent_id, session_id, key) WHERE key IS NOT NULL"},
+           # `returning: true` is REQUIRED on the upsert path: on a DO UPDATE,
+           # Ecto otherwise leaves the returned struct's autogenerated `id` (and
+           # timestamps) at the values it generated for the INSERT ATTEMPT — a
+           # phantom id that was never persisted (the existing row kept its own).
+           # Reading the row back makes the returned struct (and the response
+           # JSON / audit entity_id) reflect the real persisted row.
+           returning: true
+         ], slot_outcome(changeset)}
+      end
+
+    multi =
+      Multi.new()
+      |> Multi.insert(:post, changeset, insert_opts)
+      |> Audit.log_in_multi(:audit, fn %{post: post} ->
+        audit_attrs(tenant_id, post, outcome, audit)
+      end)
+
+    case AdminRepo.transaction(multi) do
+      {:ok, %{post: post}} ->
+        {:ok, post, outcome}
+
+      {:error, :post, %Ecto.Changeset{} = changeset, _changes} ->
+        tap_secret_blocked({:error, changeset})
+
+      {:error, _step, reason, _changes} ->
+        {:error, reason}
+    end
+  end
+
+  # Does the keyed working-state slot already exist? Determines 201 (created) vs
+  # 200 (upsert-updated). Matches the LIVE partial unique index columns exactly.
+  defp slot_outcome(changeset) do
+    tenant_id = Ecto.Changeset.get_field(changeset, :tenant_id)
+    project_id = Ecto.Changeset.get_field(changeset, :project_id)
+    agent_id = Ecto.Changeset.get_field(changeset, :agent_id)
+    session_id = Ecto.Changeset.get_field(changeset, :session_id)
+    key = Ecto.Changeset.get_field(changeset, :key)
+
+    exists? =
+      ChannelPost
+      |> where([p], p.tenant_id == ^tenant_id and p.project_id == ^project_id)
+      |> where([p], p.agent_id == ^agent_id and p.session_id == ^session_id and p.key == ^key)
+      |> AdminRepo.exists?()
+
+    if exists?, do: :updated, else: :created
+  end
+
+  defp audit_attrs(tenant_id, post, outcome, audit) do
+    %{
+      tenant_id: tenant_id,
+      project_id: post.project_id,
+      entity_type: "channel_post",
+      entity_id: post.id,
+      action: if(outcome == :created, do: "posted", else: "upserted"),
+      actor_type: Keyword.get(audit, :actor_type, "api_key"),
+      actor_id: Keyword.get(audit, :actor_id),
+      actor_label: Keyword.get(audit, :actor_label),
+      metadata: Keyword.get(audit, :metadata, %{})
+    }
   end
 
   # Fire the "credential blocked" security signal once, at the point a write is

--- a/lib/loopctl/coordination.ex
+++ b/lib/loopctl/coordination.ex
@@ -118,29 +118,37 @@ defmodule Loopctl.Coordination do
       in place (HTTP 200)
     * `{:error, :not_found}` — the project is missing or belongs to another
       tenant (endpoint → shared 422)
+    * `{:error, :agent_not_found}` — the server-stamped `agent_id` does not belong
+      to `tenant_id` (a misconfigured key; endpoint → 403, attributed as an
+      identity fault, NOT a cross-tenant project probe)
     * `{:error, %Ecto.Changeset{}}` — a size/shape bound, denylist hit, or NUL
       byte was rejected; nothing was persisted (endpoint → 422)
   """
   @spec post(Ecto.UUID.t(), Ecto.UUID.t(), map()) ::
           {:ok, ChannelPost.t(), :created | :updated}
           | {:error, :not_found}
+          | {:error, :agent_not_found}
           | {:error, Ecto.Changeset.t()}
   def post(tenant_id, agent_id, attrs) do
     project_id = Map.get(attrs, :project_id)
     audit = Map.get(attrs, :audit, [])
 
-    # Only `project_id` is ownership-checked here. `agent_id` is NOT re-verified:
-    # unlike `create_post/4` (a general primitive that asserts BOTH ids), this HTTP
-    # path receives `agent_id` server-stamped from the ALREADY-verified key identity
-    # and tenant-paired at key creation, so an `Agents.get_agent/2` guard would be
-    # redundant. Worse, folding its failure into the same `{:error, :not_found}`
-    # would make a caller with a perfectly valid project get a 422 blaming
-    # `project_id` (and misattribute the `:ownership_rejected` security signal) on
-    # the low-reachability "agent row deleted while its api_key persists" case —
-    # conflating an identity fault with a cross-tenant probe. The NOT NULL FK to
-    # `agents` (surfaced as an `:agent_id` changeset error via
-    # `foreign_key_constraint/2`) remains the real, correctly-attributed guard.
-    with {:ok, _project} <- Projects.get_project(tenant_id, project_id) do
+    # Ownership is enforced for BOTH the project and the agent, each mapped to a
+    # DISTINCT error so the endpoint attributes the failure correctly — a missing/
+    # cross-tenant project is `:not_found` (→ 422 `:ownership_rejected`), a
+    # foreign-tenant agent is `:agent_not_found` (→ 403 `:agent_identity_required`).
+    # Folding both into one `{:error, :not_found}` would blame `project_id` (and
+    # misfire the project security signal) for an identity fault. `agent_id` is
+    # server-stamped from the ALREADY-verified key identity and tenant-paired at key
+    # creation, so the agent check is defense-in-depth — BUT that pairing is not
+    # enforced by any DB constraint (the `agents`/`api_keys`/`channel_posts` agent
+    # FKs are all non-composite on `id` alone), so a misconfigured key carrying a
+    # foreign-tenant `agent_id` would otherwise persist a post mis-attributed to
+    # that foreign agent. Restoring the guard (mirroring sibling `create_post/4`)
+    # closes that regression; the NOT NULL FK to `agents` remains the backstop for
+    # the "agent row deleted while its api_key persists" race.
+    with {:ok, _project} <- Projects.get_project(tenant_id, project_id),
+         {:ok, _agent} <- agent_owned(tenant_id, agent_id) do
       changeset =
         %ChannelPost{
           tenant_id: tenant_id,
@@ -154,52 +162,44 @@ defmodule Loopctl.Coordination do
     end
   end
 
-  # Insert (or keyed upsert) + audit in one transaction. The created/updated
-  # outcome is resolved from a pre-existence check on the slot rather than the
-  # returned row's timestamps: with `on_conflict: {:replace, ...}` Ecto does NOT
-  # read `inserted_at` back, so `inserted_at == updated_at` cannot distinguish an
-  # insert from an update. The slot is keyed on `agent_id + session_id`, and a
-  # single session is single-threaded, so the check is race-free in practice
-  # (a different session targets a different slot).
+  # Assert the server-stamped agent belongs to the tenant, mapped to a DISTINCT
+  # error from the project guard so the endpoint separates an identity fault (403)
+  # from a cross-tenant project probe (422).
+  defp agent_owned(tenant_id, agent_id) do
+    case Agents.get_agent(tenant_id, agent_id) do
+      {:ok, agent} -> {:ok, agent}
+      {:error, :not_found} -> {:error, :agent_not_found}
+    end
+  end
+
+  # Insert (or keyed upsert) + audit in one transaction. The created-vs-updated
+  # outcome is derived from the PERSISTED row returned by the write itself — never
+  # from a pre-transaction existence probe. A pre-read was a TOCTOU race: two
+  # concurrent same-session writes could both read `exists? == false` and both
+  # report 201 (even though the partial unique index turns one into a DO UPDATE),
+  # and a US-39.5 TTL sweep deleting the slot between the read and the insert
+  # produced the inverse mislabel — mis-stamping both the 201/200 status and the
+  # audit action. Instead: on a fresh INSERT Ecto stamps `inserted_at` and
+  # `updated_at` to the SAME instant; the ON CONFLICT DO UPDATE refreshes
+  # `updated_at` (a new now) but never `inserted_at` (kept from the original
+  # insert). So on the keyed path (`returning: true` reads the real persisted row)
+  # equal timestamps ⇒ created and divergent ⇒ in-place update. This reflects the
+  # actual write outcome atomically, so the label is correct even under a concurrent
+  # same-session race or a sweep deleting the slot mid-flight.
   defp run_post(tenant_id, changeset, audit) do
     key = Ecto.Changeset.get_field(changeset, :key)
-
-    {insert_opts, outcome} =
-      if is_nil(key) do
-        {[], :created}
-      else
-        # The LIVE arbiter is a PARTIAL unique index
-        # (`... WHERE key IS NOT NULL`, index `channel_posts_session_key_uidx`).
-        # Postgres cannot INFER a partial index from a bare column list — the
-        # ON CONFLICT must carry the matching predicate — so the conflict_target
-        # is an unsafe_fragment mirroring the index columns AND its WHERE clause
-        # (same pattern as memory.ex:2510). agent_id participates so a spoofed
-        # session_id can never overwrite another agent's slot.
-        {[
-           on_conflict: {:replace, [:body, :refs, :updated_at, :expires_at]},
-           conflict_target:
-             {:unsafe_fragment,
-              "(tenant_id, project_id, agent_id, session_id, key) WHERE key IS NOT NULL"},
-           # `returning: true` is REQUIRED on the upsert path: on a DO UPDATE,
-           # Ecto otherwise leaves the returned struct's autogenerated `id` (and
-           # timestamps) at the values it generated for the INSERT ATTEMPT — a
-           # phantom id that was never persisted (the existing row kept its own).
-           # Reading the row back makes the returned struct (and the response
-           # JSON / audit entity_id) reflect the real persisted row.
-           returning: true
-         ], slot_outcome(changeset)}
-      end
+    insert_opts = insert_opts(key)
 
     multi =
       Multi.new()
       |> Multi.insert(:post, changeset, insert_opts)
       |> Audit.log_in_multi(:audit, fn %{post: post} ->
-        audit_attrs(tenant_id, post, outcome, audit)
+        audit_attrs(tenant_id, post, post_outcome(post), audit)
       end)
 
     case AdminRepo.transaction(multi) do
       {:ok, %{post: post}} ->
-        {:ok, post, outcome}
+        {:ok, post, post_outcome(post)}
 
       {:error, :post, %Ecto.Changeset{} = changeset, _changes} ->
         tap_secret_blocked({:error, changeset})
@@ -216,23 +216,36 @@ defmodule Loopctl.Coordination do
     end
   end
 
-  # Does the keyed working-state slot already exist? Determines 201 (created) vs
-  # 200 (upsert-updated). Matches the LIVE partial unique index columns exactly.
-  defp slot_outcome(changeset) do
-    tenant_id = Ecto.Changeset.get_field(changeset, :tenant_id)
-    project_id = Ecto.Changeset.get_field(changeset, :project_id)
-    agent_id = Ecto.Changeset.get_field(changeset, :agent_id)
-    session_id = Ecto.Changeset.get_field(changeset, :session_id)
-    key = Ecto.Changeset.get_field(changeset, :key)
+  # Keyless posts are always a new append-only row. A keyed post UPSERTS on the
+  # LIVE PARTIAL unique index (`... WHERE key IS NOT NULL`, index
+  # `channel_posts_session_key_uidx`). Postgres cannot INFER a partial index from a
+  # bare column list — the ON CONFLICT must carry the matching predicate — so the
+  # conflict_target is an unsafe_fragment mirroring the index columns AND its WHERE
+  # clause (same pattern as memory.ex:2510). `agent_id` participates so a spoofed
+  # session_id can never overwrite another agent's slot. `returning: true` is
+  # REQUIRED on the upsert path: on a DO UPDATE Ecto otherwise leaves the returned
+  # struct's autogenerated `id` and timestamps at the phantom values it generated
+  # for the INSERT ATTEMPT (the existing row kept its own). Reading the row back
+  # makes the returned struct — the response JSON, the audit entity_id, AND the
+  # `post_outcome/1` timestamp comparison — reflect the real persisted row.
+  defp insert_opts(nil), do: []
 
-    exists? =
-      ChannelPost
-      |> where([p], p.tenant_id == ^tenant_id and p.project_id == ^project_id)
-      |> where([p], p.agent_id == ^agent_id and p.session_id == ^session_id and p.key == ^key)
-      |> AdminRepo.exists?()
-
-    if exists?, do: :updated, else: :created
+  defp insert_opts(_key) do
+    [
+      on_conflict: {:replace, [:body, :refs, :updated_at, :expires_at]},
+      conflict_target:
+        {:unsafe_fragment,
+         "(tenant_id, project_id, agent_id, session_id, key) WHERE key IS NOT NULL"},
+      returning: true
+    ]
   end
+
+  # Created vs in-place update, read from the PERSISTED row (see run_post/3). A
+  # fresh insert stamps both timestamps to the same instant; a keyed upsert's DO
+  # UPDATE refreshes `updated_at` while preserving the original `inserted_at`, so
+  # equal ⇒ created, divergent ⇒ updated.
+  defp post_outcome(%ChannelPost{inserted_at: ts, updated_at: ts}), do: :created
+  defp post_outcome(%ChannelPost{}), do: :updated
 
   defp audit_attrs(tenant_id, post, outcome, audit) do
     %{

--- a/lib/loopctl/coordination.ex
+++ b/lib/loopctl/coordination.ex
@@ -129,8 +129,18 @@ defmodule Loopctl.Coordination do
     project_id = Map.get(attrs, :project_id)
     audit = Map.get(attrs, :audit, [])
 
-    with {:ok, _project} <- Projects.get_project(tenant_id, project_id),
-         {:ok, _agent} <- Agents.get_agent(tenant_id, agent_id) do
+    # Only `project_id` is ownership-checked here. `agent_id` is NOT re-verified:
+    # unlike `create_post/4` (a general primitive that asserts BOTH ids), this HTTP
+    # path receives `agent_id` server-stamped from the ALREADY-verified key identity
+    # and tenant-paired at key creation, so an `Agents.get_agent/2` guard would be
+    # redundant. Worse, folding its failure into the same `{:error, :not_found}`
+    # would make a caller with a perfectly valid project get a 422 blaming
+    # `project_id` (and misattribute the `:ownership_rejected` security signal) on
+    # the low-reachability "agent row deleted while its api_key persists" case —
+    # conflating an identity fault with a cross-tenant probe. The NOT NULL FK to
+    # `agents` (surfaced as an `:agent_id` changeset error via
+    # `foreign_key_constraint/2`) remains the real, correctly-attributed guard.
+    with {:ok, _project} <- Projects.get_project(tenant_id, project_id) do
       changeset =
         %ChannelPost{
           tenant_id: tenant_id,
@@ -194,8 +204,15 @@ defmodule Loopctl.Coordination do
       {:error, :post, %Ecto.Changeset{} = changeset, _changes} ->
         tap_secret_blocked({:error, changeset})
 
-      {:error, _step, reason, _changes} ->
-        {:error, reason}
+      # Any OTHER failed step (today only `:audit`, whose only failure mode is a
+      # changeset) is normalised to the SAME documented `{:error, %Ecto.Changeset{}}`
+      # shape — `run_post/3` never leaks an off-spec `{:error, reason}` to the
+      # controller, so no controller catch-all (which dialyzer would reject as dead
+      # code) is needed. If `Audit.log_in_multi/3` is ever changed to fail with a
+      # non-changeset error, this clause stops covering it and dialyzer fails the
+      # build here (a compile-gate guard, stronger than a runtime 500 fallback).
+      {:error, _step, %Ecto.Changeset{} = changeset, _changes} ->
+        {:error, changeset}
     end
   end
 

--- a/lib/loopctl_web/controllers/channel_post_controller.ex
+++ b/lib/loopctl_web/controllers/channel_post_controller.ex
@@ -1,0 +1,239 @@
+defmodule LoopctlWeb.ChannelPostController do
+  @moduledoc """
+  Write endpoint for the repo coordination bus (Epic 39, the third memory plane).
+
+  - `POST /api/v1/channel/posts` — agent+, posts one short coordination message
+    to a project's channel (a channel IS a `project_id`), optionally under a
+    `key` that upserts the caller's own per-session working-state slot.
+
+  ## Trust posture (owner decision #331, design brief §4)
+
+  This is a COORDINATION surface, NOT chain-of-custody: posting to your own
+  tenant's channel is the same content class as the KB surface #331 made fully
+  agent-usable. So the route is `role: :agent` and is deliberately NOT behind
+  `RequireHumanAnchor`. Authorship is stamped server-side from the verified key
+  identity (`tenant_id`/`agent_id`) — never from the request body — so no caller
+  can forge authorship or post into another tenant's channel.
+
+  ## Security signals (AC-39.2.9)
+
+  Every abuse-relevant outcome emits a `[:loopctl, :coordination, event]`
+  telemetry event + a structured warning so exfil attempts and enumeration scans
+  are observable: `:agent_identity_required` (403), `:ownership_rejected` (422,
+  cross-tenant/not-found — no existence oracle), and `:rate_limited` (429). The
+  denylist rejection (422) signal is emitted from `Loopctl.Coordination` at the
+  point the write is rejected.
+  """
+
+  use LoopctlWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  require Logger
+
+  alias Loopctl.ApiSpec.Schemas
+  alias Loopctl.Coordination
+  alias Loopctl.Tenants
+  alias LoopctlWeb.AuditContext
+
+  action_fallback LoopctlWeb.FallbackController
+
+  # Coordination surface (#331): agent role, NO RequireHumanAnchor. See the
+  # coordination-surface allowlist entry in require_human_anchor_default_deny_test.
+  plug LoopctlWeb.Plugs.RequireRole, [role: :agent] when action in [:create]
+
+  # Per-write rate limit (AC-39.2.8): a TIGHTER, config-driven cap on top of the
+  # generic per-key/per-tenant pipeline RateLimiter, reusing the same
+  # `Loopctl.RateLimiter` behaviour seam. Bounds post spam / upsert thrash.
+  plug :rate_limit_write when action in [:create]
+
+  tags(["Coordination"])
+
+  # A missing project and a cross-tenant project return this ONE message — no
+  # existence oracle distinguishing "not yours" from "does not exist" (AC-39.2.3).
+  @ownership_error_message "project_id does not exist or does not belong to your tenant"
+
+  # 60s fixed window, matching the ETS/Hammer contract the pipeline limiter uses.
+  @write_window_ms 60_000
+
+  # Config-default per-minute write cap; a tenant may override via the
+  # `channel_post_write_limit_per_minute` setting (mirrors the pipeline limiter's
+  # `rate_limit_requests_per_minute`). Not hardcoded at the call site.
+  @default_write_limit 120
+
+  operation(:create,
+    summary: "Post to a repo coordination channel",
+    description:
+      "Posts one short, attributed coordination message to a project's channel (a channel IS a " <>
+        "project_id). Agent+ role, NOT behind the human-anchor tier (coordination surface, owner " <>
+        "decision #331). tenant_id and agent_id are stamped server-side from the verified key — " <>
+        "any agent_id/tenant_id in the body is ignored. With a `key` the write upserts the " <>
+        "caller's own per-session working-state slot (200); without a key it is a new " <>
+        "append-only row (201). expires_at is set server-side to now + 30 days.",
+    request_body: {"Channel post params", "application/json", Schemas.ChannelPostRequest},
+    responses: %{
+      201 => {"Post created", "application/json", Schemas.ChannelPostResponse},
+      200 => {"Session slot upserted in place", "application/json", Schemas.ChannelPostResponse},
+      403 => {"Agent identity required", "application/json", Schemas.ErrorResponse},
+      422 =>
+        {"Validation error or unknown/cross-tenant project", "application/json",
+         Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  @doc """
+  POST /api/v1/channel/posts
+
+  Writes a coordination post. Requires agent+ role and a key that carries an
+  agent identity (403 `agent_identity_required` otherwise).
+  """
+  def create(conn, params) do
+    api_key = conn.assigns.current_api_key
+    tenant_id = api_key.tenant_id
+
+    case api_key.agent_id do
+      nil ->
+        # AC-39.2.2: agent_id is required UNCONDITIONALLY (channel_posts.agent_id
+        # is NOT NULL). Unlike article_controller's conditional memory-metadata
+        # gate, coordination authorship is always required — no row is persisted.
+        emit_security_event(:agent_identity_required, %{
+          tenant_id: tenant_id,
+          api_key_id: api_key.id
+        })
+
+        conn
+        |> put_status(:forbidden)
+        |> json(%{
+          error: %{
+            status: 403,
+            code: "agent_identity_required",
+            message:
+              "This API key has no agent identity; it cannot post an attributed channel message"
+          }
+        })
+
+      agent_id ->
+        write_post(conn, tenant_id, agent_id, params)
+    end
+  end
+
+  defp write_post(conn, tenant_id, agent_id, params) do
+    # Only caller-supplied fields are threaded through; project_id is validated
+    # for ownership in the context, and audit carries the verified actor context.
+    # agent_id/tenant_id in the body are never read.
+    attrs = %{
+      project_id: params["project_id"],
+      body: params["body"],
+      key: params["key"],
+      refs: params["refs"],
+      session_id: params["session_id"],
+      host: params["host"],
+      audit: AuditContext.from_conn(conn)
+    }
+
+    case Coordination.post(tenant_id, agent_id, attrs) do
+      {:ok, post, :created} ->
+        conn
+        |> put_status(:created)
+        |> json(%{post: post})
+
+      {:ok, post, :updated} ->
+        conn
+        |> put_status(:ok)
+        |> json(%{post: post})
+
+      {:error, :not_found} ->
+        # AC-39.2.3: missing AND cross-tenant collapse to one byte-identical 422.
+        emit_security_event(:ownership_rejected, %{
+          tenant_id: tenant_id,
+          agent_id: agent_id,
+          project_id: params["project_id"]
+        })
+
+        {:error, :unprocessable_entity, @ownership_error_message}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:error, changeset}
+    end
+  end
+
+  # --- Rate limiting (function plug) ---
+
+  defp rate_limit_write(conn, _opts) do
+    api_key = conn.assigns.current_api_key
+    tenant = conn.assigns[:current_tenant]
+    limit = write_limit(tenant)
+    identifier = "channel_post_write:key:#{api_key.id}"
+
+    case check_rate(identifier, limit) do
+      {:allow, _count} ->
+        conn
+
+      {:deny, _limit} ->
+        reset_at = window_reset_at()
+        retry_after = max(1, reset_at - System.system_time(:second))
+
+        emit_security_event(:rate_limited, %{
+          tenant_id: api_key.tenant_id,
+          api_key_id: api_key.id
+        })
+
+        conn
+        |> put_resp_header("retry-after", to_string(retry_after))
+        |> put_status(:too_many_requests)
+        |> json(%{error: %{status: 429, message: "Rate limit exceeded"}})
+        |> halt()
+    end
+  end
+
+  # Reuse the RateLimiter behaviour seam (config-based DI). Fail OPEN on any
+  # limiter fault — a limiter outage must degrade to "no gate", never block
+  # writes (parity with LoopctlWeb.Plugs.RateLimiter).
+  defp check_rate(identifier, limit) do
+    case Loopctl.RateLimiter.impl().check_rate(identifier, @write_window_ms, limit) do
+      {:allow, count} when is_integer(count) -> {:allow, count}
+      {:deny, denied} when is_integer(denied) -> {:deny, denied}
+      _other -> {:allow, 0}
+    end
+  rescue
+    _ -> {:allow, 0}
+  catch
+    :exit, _ -> {:allow, 0}
+    :throw, _ -> {:allow, 0}
+  end
+
+  defp write_limit(nil), do: default_write_limit()
+
+  defp write_limit(tenant) do
+    Tenants.get_tenant_settings(
+      tenant,
+      "channel_post_write_limit_per_minute",
+      default_write_limit()
+    )
+  end
+
+  defp default_write_limit do
+    Application.get_env(:loopctl, :channel_post_write_limit_per_minute, @default_write_limit)
+  end
+
+  defp window_reset_at do
+    now = System.system_time(:second)
+    (div(now, 60) + 1) * 60
+  end
+
+  # --- Security telemetry (AC-39.2.9) ---
+
+  defp emit_security_event(event, metadata) do
+    :telemetry.execute([:loopctl, :coordination, event], %{count: 1}, metadata)
+
+    Logger.warning(
+      "coordination security event: #{event} " <>
+        "(tenant=#{Map.get(metadata, :tenant_id)} " <>
+        "api_key=#{Map.get(metadata, :api_key_id)} " <>
+        "agent=#{Map.get(metadata, :agent_id)} " <>
+        "project=#{Map.get(metadata, :project_id)})"
+    )
+
+    :ok
+  end
+end

--- a/lib/loopctl_web/controllers/channel_post_controller.ex
+++ b/lib/loopctl_web/controllers/channel_post_controller.ex
@@ -19,10 +19,12 @@ defmodule LoopctlWeb.ChannelPostController do
 
   Every abuse-relevant outcome emits a `[:loopctl, :coordination, event]`
   telemetry event + a structured warning so exfil attempts and enumeration scans
-  are observable: `:agent_identity_required` (403), `:ownership_rejected` (422,
-  cross-tenant/not-found — no existence oracle), and `:rate_limited` (429). The
-  denylist rejection (422) signal is emitted from `Loopctl.Coordination` at the
-  point the write is rejected.
+  are observable: `:agent_identity_required` (403 — the key carries no agent
+  identity, OR its agent belongs to another tenant), `:ownership_rejected` (422,
+  cross-tenant/not-found project — no existence oracle), and `:rate_limited`
+  (429). The denylist rejection (422) signal is emitted from `Loopctl.Coordination`
+  at the point the write is rejected. A rate-limiter fault degrades to "no gate"
+  but is logged via the shared throttled `FailOpenLog`, never swallowed silently.
   """
 
   use LoopctlWeb, :controller
@@ -32,6 +34,7 @@ defmodule LoopctlWeb.ChannelPostController do
 
   alias Loopctl.ApiSpec.Schemas
   alias Loopctl.Coordination
+  alias Loopctl.RateLimiter.FailOpenLog
   alias Loopctl.Tenants
   alias LoopctlWeb.AuditContext
 
@@ -59,6 +62,11 @@ defmodule LoopctlWeb.ChannelPostController do
   # `channel_post_write_limit_per_minute` setting (mirrors the pipeline limiter's
   # `rate_limit_requests_per_minute`). Not hardcoded at the call site.
   @default_write_limit 120
+
+  # Fallback for the generic per-key pipeline limit, kept in sync with
+  # LoopctlWeb.Plugs.RateLimiter's @default_per_key_limit. Used to clamp the
+  # coordination cap so it stays the binding (and observable) constraint.
+  @pipeline_per_key_limit_default 300
 
   operation(:create,
     summary: "Post to a repo coordination channel",
@@ -152,6 +160,30 @@ defmodule LoopctlWeb.ChannelPostController do
 
         {:error, :unprocessable_entity, @ownership_error_message}
 
+      {:error, :agent_not_found} ->
+        # Defense-in-depth: the key's server-stamped agent_id does not belong to
+        # this tenant (a misconfigured key — the agent FKs are non-composite, so
+        # the DB alone would accept the mis-attributed row). This is an IDENTITY
+        # fault, not a project probe, so it emits the :agent_identity_required
+        # signal + a 403 — never the :ownership_rejected project signal — keeping
+        # the two failure modes correctly attributed.
+        emit_security_event(:agent_identity_required, %{
+          tenant_id: tenant_id,
+          agent_id: agent_id,
+          project_id: params["project_id"]
+        })
+
+        conn
+        |> put_status(:forbidden)
+        |> json(%{
+          error: %{
+            status: 403,
+            code: "agent_identity_required",
+            message:
+              "This API key's agent identity is not valid for this tenant; it cannot post an attributed channel message"
+          }
+        })
+
       {:error, %Ecto.Changeset{} = changeset} ->
         {:error, changeset}
     end
@@ -188,33 +220,81 @@ defmodule LoopctlWeb.ChannelPostController do
 
   # Reuse the RateLimiter behaviour seam (config-based DI). Fail OPEN on any
   # limiter fault — a limiter outage must degrade to "no gate", never block
-  # writes (parity with LoopctlWeb.Plugs.RateLimiter).
+  # writes — but route every fail-open through the SHARED throttled, PII-safe
+  # `FailOpenLog` (full parity with LoopctlWeb.Plugs.RateLimiter) so a sustained
+  # write-cap limiter outage stays observable (AC-39.2.9) instead of being
+  # silently swallowed.
   defp check_rate(identifier, limit) do
     case Loopctl.RateLimiter.impl().check_rate(identifier, @write_window_ms, limit) do
       {:allow, count} when is_integer(count) -> {:allow, count}
       {:deny, denied} when is_integer(denied) -> {:deny, denied}
-      _other -> {:allow, 0}
+      other -> fail_open(identifier, "limiter returned #{inspect(other)}")
     end
   rescue
-    _ -> {:allow, 0}
+    e -> fail_open(identifier, Exception.message(e))
   catch
-    :exit, _ -> {:allow, 0}
-    :throw, _ -> {:allow, 0}
+    :exit, reason -> fail_open(identifier, "limiter exit: #{inspect(reason)}")
+    :throw, value -> fail_open(identifier, "limiter throw: #{inspect(value)}")
+  end
+
+  # Degrade to "no gate" on a limiter fault, but emit a throttled, PII-safe warning
+  # (the bucket family reduces to `channel_post_write:key`, UUID suffix stripped)
+  # so the outage is not invisible.
+  defp fail_open(identifier, detail) do
+    FailOpenLog.warn(:coordination, identifier, detail)
+    {:allow, 0}
   end
 
   defp write_limit(nil), do: default_write_limit()
 
   defp write_limit(tenant) do
-    Tenants.get_tenant_settings(
-      tenant,
-      "channel_post_write_limit_per_minute",
-      default_write_limit()
-    )
+    configured =
+      tenant
+      |> Tenants.get_tenant_settings("channel_post_write_limit_per_minute", default_write_limit())
+      |> coerce_positive_int(default_write_limit())
+
+    # AC-39.2.8/9: the coordination write cap must remain a TIGHTER constraint than
+    # the generic per-key pipeline limiter (LoopctlWeb.Plugs.RateLimiter), which
+    # runs FIRST in the pipeline and emits no coordination-specific security signal.
+    # If a tenant set this above the pipeline limit, every coordination rate-limit
+    # trip would be shadowed by an anonymous pipeline 429 — blinding the AC-39.2.9
+    # abuse detectors. Clamp so the coordination cap can never exceed (and thus be
+    # shadowed by) the pipeline cap.
+    min(configured, pipeline_per_key_limit(tenant))
   end
 
   defp default_write_limit do
     Application.get_env(:loopctl, :channel_post_write_limit_per_minute, @default_write_limit)
   end
+
+  # The generic per-key pipeline limit that runs before this controller plug. Read
+  # from the SAME tenant setting the pipeline limiter uses; default kept in sync
+  # with LoopctlWeb.Plugs.RateLimiter's @default_per_key_limit.
+  defp pipeline_per_key_limit(tenant) do
+    tenant
+    |> Tenants.get_tenant_settings(
+      "rate_limit_requests_per_minute",
+      @pipeline_per_key_limit_default
+    )
+    |> coerce_positive_int(@pipeline_per_key_limit_default)
+  end
+
+  # A tenant setting stored as a non-integer (e.g. the JSON string "3") would
+  # silently NEUTER the cap: `get_tenant_settings/3` is a bare Map.get on raw jsonb,
+  # so the Hammer limiter would then compare via Elixir term ordering (every integer
+  # < every binary → never denies) and the Postgres limiter's `is_integer` guard
+  # would raise (swallowed to fail-open). Coerce an integer or an integer STRING to
+  # a positive integer; a zero/negative/garbage value falls back to `default`.
+  defp coerce_positive_int(value, _default) when is_integer(value) and value > 0, do: value
+
+  defp coerce_positive_int(value, default) when is_binary(value) do
+    case Integer.parse(value) do
+      {n, ""} when n > 0 -> n
+      _ -> default
+    end
+  end
+
+  defp coerce_positive_int(_value, default), do: default
 
   defp window_reset_at do
     now = System.system_time(:second)

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -123,6 +123,13 @@ defmodule LoopctlWeb.Router do
 
     get "/routes", RouteDiscoveryController, :index
 
+    # Repo Coordination Bus (Epic 39) — the third memory plane. Agent-role write
+    # to a project's transient coordination channel. NOT human-anchor gated
+    # (coordination surface, owner decision #331). Per-key/per-tenant rate
+    # limiting comes from the :authenticated pipeline RateLimiter; the controller
+    # adds a tighter, config-driven per-write cap.
+    post "/channel/posts", ChannelPostController, :create
+
     get "/tenants/me", TenantController, :show
     patch "/tenants/me", TenantController, :update
 

--- a/test/loopctl/coordination_test.exs
+++ b/test/loopctl/coordination_test.exs
@@ -1,6 +1,10 @@
 defmodule Loopctl.CoordinationTest do
   use Loopctl.DataCase, async: true
 
+  import Ecto.Query
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Audit.AuditLog
   alias Loopctl.Coordination
   alias Loopctl.Coordination.ChannelPost
   alias Loopctl.Repo
@@ -230,5 +234,159 @@ defmodule Loopctl.CoordinationTest do
       posts = Coordination.recent(tenant.id, project.id)
       assert length(posts) == 2
     end
+  end
+
+  describe "post/3" do
+    setup do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      agent_id = fixture(:agent, %{tenant_id: tenant.id}).id
+
+      audit = [
+        actor_type: "api_key",
+        actor_id: Ecto.UUID.generate(),
+        actor_label: "agent:worker-1"
+      ]
+
+      %{tenant: tenant, project: project, agent_id: agent_id, audit: audit}
+    end
+
+    test "a keyless post is created (201) and writes a 'posted' audit row", ctx do
+      %{tenant: tenant, project: project, agent_id: agent_id, audit: audit} = ctx
+
+      assert {:ok, post, :created} =
+               Coordination.post(tenant.id, agent_id, %{
+                 project_id: project.id,
+                 body: "pushed PR #107",
+                 audit: audit
+               })
+
+      assert post.tenant_id == tenant.id
+      assert post.agent_id == agent_id
+
+      expected = DateTime.add(DateTime.utc_now(), Coordination.retention_days() * 86_400, :second)
+      assert_in_delta DateTime.to_unix(post.expires_at), DateTime.to_unix(expected), 120
+
+      entry = one_audit_entry(tenant.id, post.id)
+      assert entry.action == "posted"
+      assert entry.entity_type == "channel_post"
+      assert entry.actor_label == "agent:worker-1"
+    end
+
+    test "a repeat keyed post from the same session upserts (200), same id, 'upserted' audit",
+         ctx do
+      %{tenant: tenant, project: project, agent_id: agent_id, audit: audit} = ctx
+
+      base = %{project_id: project.id, session_id: "S1", key: "session_goal", audit: audit}
+
+      assert {:ok, first, :created} =
+               Coordination.post(tenant.id, agent_id, Map.put(base, :body, "v1"))
+
+      assert {:ok, second, :updated} =
+               Coordination.post(tenant.id, agent_id, Map.put(base, :body, "v2"))
+
+      assert second.id == first.id
+      assert second.body == "v2"
+
+      # exactly one row for the slot
+      assert AdminRepo.aggregate(
+               from(p in ChannelPost, where: p.project_id == ^project.id),
+               :count,
+               :id
+             ) == 1
+
+      # Append-only audit chain: the same slot id now carries "posted" (create)
+      # then "upserted" (the in-place refresh).
+      assert audit_actions(tenant.id, second.id) == ["posted", "upserted"]
+    end
+
+    test "a different session's same key is a distinct row (no cross-session clobber)", ctx do
+      %{tenant: tenant, project: project, agent_id: agent_id, audit: audit} = ctx
+
+      assert {:ok, s1, :created} =
+               Coordination.post(tenant.id, agent_id, %{
+                 project_id: project.id,
+                 session_id: "S1",
+                 key: "session_goal",
+                 body: "v1",
+                 audit: audit
+               })
+
+      assert {:ok, s2, :created} =
+               Coordination.post(tenant.id, agent_id, %{
+                 project_id: project.id,
+                 session_id: "S2",
+                 key: "session_goal",
+                 body: "other",
+                 audit: audit
+               })
+
+      assert s1.id != s2.id
+    end
+
+    test "a missing project returns {:error, :not_found} and writes nothing", ctx do
+      %{tenant: tenant, agent_id: agent_id, audit: audit} = ctx
+
+      assert {:error, :not_found} =
+               Coordination.post(tenant.id, agent_id, %{
+                 project_id: Ecto.UUID.generate(),
+                 body: "x",
+                 audit: audit
+               })
+
+      assert AdminRepo.aggregate(ChannelPost, :count, :id) == 0
+    end
+
+    test "a cross-tenant project returns {:error, :not_found} (same as missing)", ctx do
+      %{tenant: tenant, agent_id: agent_id, audit: audit} = ctx
+      other = fixture(:tenant)
+      foreign = fixture(:project, %{tenant_id: other.id})
+
+      assert {:error, :not_found} =
+               Coordination.post(tenant.id, agent_id, %{
+                 project_id: foreign.id,
+                 body: "x",
+                 audit: audit
+               })
+    end
+
+    test "a missing body returns {:error, changeset} and writes no post or audit row", ctx do
+      %{tenant: tenant, project: project, agent_id: agent_id, audit: audit} = ctx
+
+      assert {:error, %Ecto.Changeset{} = changeset} =
+               Coordination.post(tenant.id, agent_id, %{
+                 project_id: project.id,
+                 audit: audit
+               })
+
+      refute changeset.valid?
+      assert AdminRepo.aggregate(ChannelPost, :count, :id) == 0
+
+      assert AdminRepo.aggregate(
+               from(a in AuditLog, where: a.entity_type == "channel_post"),
+               :count,
+               :id
+             ) == 0
+    end
+  end
+
+  defp one_audit_entry(tenant_id, entity_id) do
+    AdminRepo.one!(
+      from(a in AuditLog,
+        where: a.tenant_id == ^tenant_id and a.entity_type == "channel_post",
+        where: a.entity_id == ^entity_id
+      )
+    )
+  end
+
+  defp audit_actions(tenant_id, entity_id) do
+    AdminRepo.all(
+      from(a in AuditLog,
+        where: a.tenant_id == ^tenant_id and a.entity_type == "channel_post",
+        where: a.entity_id == ^entity_id,
+        order_by: [asc: a.inserted_at],
+        select: a.action
+      )
+    )
   end
 end

--- a/test/loopctl/coordination_test.exs
+++ b/test/loopctl/coordination_test.exs
@@ -350,6 +350,62 @@ defmodule Loopctl.CoordinationTest do
                })
     end
 
+    test "a foreign-tenant agent_id returns {:error, :agent_not_found}, distinct from the project error",
+         ctx do
+      %{tenant: tenant, project: project, audit: audit} = ctx
+      other = fixture(:tenant)
+      foreign_agent = fixture(:agent, %{tenant_id: other.id}).id
+
+      # A valid project but an agent that belongs to another tenant: the ownership
+      # guard is restored (defense-in-depth — the agent FKs are non-composite) and
+      # maps to a DISTINCT error so the endpoint attributes an identity fault, not a
+      # cross-tenant project probe.
+      assert {:error, :agent_not_found} =
+               Coordination.post(tenant.id, foreign_agent, %{
+                 project_id: project.id,
+                 body: "x",
+                 audit: audit
+               })
+
+      assert AdminRepo.aggregate(ChannelPost, :count, :id) == 0
+
+      assert AdminRepo.aggregate(
+               from(a in AuditLog, where: a.entity_type == "channel_post"),
+               :count,
+               :id
+             ) == 0
+    end
+
+    test "the created/updated outcome is derived from the persisted row, not a pre-transaction probe",
+         ctx do
+      %{tenant: tenant, project: project, agent_id: agent_id, audit: audit} = ctx
+
+      # Pre-seed the keyed slot directly, then post/3 the SAME slot: the outcome
+      # must reflect the row that actually persists (an in-place update via
+      # ON CONFLICT), read from the returned row's timestamps rather than a
+      # pre-transaction existence check that a concurrent write or TTL sweep could
+      # invalidate between the read and the insert.
+      assert {:ok, seed} =
+               Coordination.create_post(tenant.id, project.id, agent_id, %{
+                 "body" => "seed",
+                 "session_id" => "S1",
+                 "key" => "session_goal"
+               })
+
+      assert {:ok, post, :updated} =
+               Coordination.post(tenant.id, agent_id, %{
+                 project_id: project.id,
+                 session_id: "S1",
+                 key: "session_goal",
+                 body: "v2",
+                 audit: audit
+               })
+
+      assert post.id == seed.id
+      assert post.body == "v2"
+      assert audit_actions(tenant.id, post.id) == ["upserted"]
+    end
+
     test "a missing body returns {:error, changeset} and writes no post or audit row", ctx do
       %{tenant: tenant, project: project, agent_id: agent_id, audit: audit} = ctx
 

--- a/test/loopctl_web/controllers/channel_post_controller_test.exs
+++ b/test/loopctl_web/controllers/channel_post_controller_test.exs
@@ -122,6 +122,42 @@ defmodule LoopctlWeb.ChannelPostControllerTest do
       assert AdminRepo.aggregate(ChannelPost, :count, :id) == 0
     end
 
+    # TC-39.2.3b — the cross-tenant/not-found 422 emits the :ownership_rejected
+    # security signal (AC-39.2.9 enumeration-scan detector). Without this the
+    # detector could be silently dropped and the suite would still pass.
+    test "a cross-tenant project 422 emits the ownership_rejected security signal" do
+      tenant = fixture(:tenant)
+      other = fixture(:tenant)
+      foreign = fixture(:project, %{tenant_id: other.id})
+      {raw, _key, _agent} = agent_key(tenant)
+
+      handler_id = "coord-ownership-#{System.unique_integer([:positive])}"
+      test_pid = self()
+      tenant_id = tenant.id
+
+      :telemetry.attach(
+        handler_id,
+        [:loopctl, :coordination, :ownership_rejected],
+        fn _event, measurements, meta, _cfg ->
+          if meta[:tenant_id] == tenant_id,
+            do: send(test_pid, {:ownership_rejected, measurements, meta})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      log =
+        capture_log(fn ->
+          conn = post_json(raw, %{"project_id" => foreign.id, "body" => "x"})
+          assert json_response(conn, 422)
+        end)
+
+      assert log =~ "ownership_rejected"
+      assert_receive {:ownership_rejected, %{count: 1}, meta}
+      assert meta.project_id == foreign.id
+    end
+
     # TC-39.2.4
     test "keyed post upserts within a session (200, same id) and is distinct across sessions (201)" do
       tenant = fixture(:tenant)
@@ -212,6 +248,47 @@ defmodule LoopctlWeb.ChannelPostControllerTest do
         post_json(raw, %{"project_id" => project.id, "body" => String.duplicate("a", 16_385)})
 
       assert json_response(conn, 422)
+      assert AdminRepo.aggregate(ChannelPost, :count, :id) == 0
+    end
+
+    # AC-39.2.9 — a denylist hit on the real HTTP write path (post/3 -> run_post ->
+    # tap_secret_blocked) emits the secret_blocked signal + structured log at
+    # rejection time. Previously only create_post/4 exercised this; a regression
+    # dropping the HTTP-path emission would otherwise pass the suite.
+    test "a secret-shaped body is rejected 422 and emits the secret_blocked security signal" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, _agent} = agent_key(tenant)
+
+      handler_id = "coord-secret-http-#{System.unique_integer([:positive])}"
+      test_pid = self()
+      tenant_id = tenant.id
+
+      :telemetry.attach(
+        handler_id,
+        [:loopctl, :coordination, :secret_blocked],
+        fn _event, measurements, meta, _cfg ->
+          if meta[:tenant_id] == tenant_id,
+            do: send(test_pid, {:secret_blocked, measurements, meta})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      log =
+        capture_log(fn ->
+          conn =
+            post_json(raw, %{
+              "project_id" => project.id,
+              "body" => "sk-" <> String.duplicate("a", 30)
+            })
+
+          assert json_response(conn, 422)
+        end)
+
+      assert log =~ "coordination denylist hit"
+      assert_receive {:secret_blocked, %{count: 1}, %{field: :body}}
       assert AdminRepo.aggregate(ChannelPost, :count, :id) == 0
     end
 

--- a/test/loopctl_web/controllers/channel_post_controller_test.exs
+++ b/test/loopctl_web/controllers/channel_post_controller_test.exs
@@ -213,6 +213,71 @@ defmodule LoopctlWeb.ChannelPostControllerTest do
       assert log =~ "agent_identity_required"
     end
 
+    # AC-39.2.2 (defense-in-depth) — a key whose server-stamped agent_id belongs to
+    # another tenant (a misconfigured key; the agent FKs are non-composite) is a 403
+    # agent_identity_required IDENTITY fault, NOT a 422 project probe.
+    test "a key whose agent belongs to another tenant -> 403 agent_identity_required, no row" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      other = fixture(:tenant)
+      foreign_agent = fixture(:agent, %{tenant_id: other.id})
+
+      {raw, _key} =
+        fixture(:api_key, %{tenant_id: tenant.id, role: :agent, agent_id: foreign_agent.id})
+
+      log =
+        capture_log(fn ->
+          conn = post_json(raw, %{"project_id" => project.id, "body" => "x"})
+
+          assert %{"error" => %{"code" => "agent_identity_required", "status" => 403}} =
+                   json_response(conn, 403)
+        end)
+
+      assert AdminRepo.aggregate(ChannelPost, :count, :id) == 0
+      assert log =~ "agent_identity_required"
+    end
+
+    # AC-39.2.8 — a per-write cap stored as a JSON STRING must still enforce. Without
+    # coercion the string flows to the limiter verbatim, where Elixir term ordering
+    # (int < binary) never denies (Hammer) or the is_integer guard raises and is
+    # swallowed to fail-open (Postgres) — either way silently neutering the cap.
+    test "a coordination write cap stored as a STRING is coerced and still enforces (429)" do
+      stub_counting_limiter()
+      tenant = fixture(:tenant, %{settings: %{"channel_post_write_limit_per_minute" => "3"}})
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, _agent} = agent_key(tenant)
+
+      for _ <- 1..3 do
+        conn = post_json(raw, %{"project_id" => project.id, "body" => "x"})
+        assert conn.status in [200, 201]
+      end
+
+      conn = post_json(raw, %{"project_id" => project.id, "body" => "x"})
+      assert %{"error" => %{"status" => 429}} = json_response(conn, 429)
+    end
+
+    # AC-39.2.9 — a rate-limiter fault must fail OPEN (write allowed) but stay
+    # OBSERVABLE via the shared throttled FailOpenLog, never be silently swallowed.
+    test "a rate-limiter fault fails open (write allowed) and is logged, not swallowed" do
+      stub(Loopctl.MockRateLimiter, :check_rate, fn _bucket, _window, _limit ->
+        raise "limiter boom"
+      end)
+
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, _agent} = agent_key(tenant)
+
+      log =
+        capture_log(fn ->
+          conn = post_json(raw, %{"project_id" => project.id, "body" => "x"})
+          # Fail-open: the write still lands despite the limiter fault.
+          assert conn.status in [200, 201]
+        end)
+
+      assert log =~ "RateLimiter fail-open"
+      assert log =~ "channel_post_write:key"
+    end
+
     # TC-39.2.6
     test "over-cap writes are 429 with Retry-After and emit a security-event log" do
       stub_counting_limiter()

--- a/test/loopctl_web/controllers/channel_post_controller_test.exs
+++ b/test/loopctl_web/controllers/channel_post_controller_test.exs
@@ -1,0 +1,230 @@
+defmodule LoopctlWeb.ChannelPostControllerTest do
+  @moduledoc """
+  US-39.2 — the coordination bus write endpoint `POST /api/v1/channel/posts`.
+
+  Everything (auth resolution AND the channel write) runs through
+  `Loopctl.AdminRepo`, one sandbox connection, so this stays `async: true`.
+  """
+  use LoopctlWeb.ConnCase, async: true
+
+  setup :verify_on_exit!
+
+  import Ecto.Query
+  import ExUnit.CaptureLog
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Coordination.ChannelPost
+
+  @path "/api/v1/channel/posts"
+  @sth_header "0:AAAAAAAAAAAAAAAAAAAAAA"
+
+  # A role:agent key whose api_key.agent_id points at a real agent in the tenant
+  # (generate_api_key does not auto-assign one, so we wire it explicitly — the
+  # endpoint requires an agent identity).
+  defp agent_key(tenant, attrs \\ %{}) do
+    agent = fixture(:agent, %{tenant_id: tenant.id})
+
+    {raw, key} =
+      fixture(
+        :api_key,
+        Map.merge(%{tenant_id: tenant.id, role: :agent, agent_id: agent.id}, attrs)
+      )
+
+    {raw, key, agent}
+  end
+
+  defp authed_conn(raw) do
+    build_conn()
+    |> put_req_header("x-loopctl-last-known-sth", @sth_header)
+    |> put_req_header("authorization", "Bearer #{raw}")
+  end
+
+  defp post_json(raw, params), do: authed_conn(raw) |> post(@path, params)
+
+  # Stateful counting stub for the DI-resolved rate limiter (config/test.exs maps
+  # `:rate_limiter` to Loopctl.MockRateLimiter, whose default stub always allows).
+  # Reproduces the fixed-window post-increment-per-bucket contract so the
+  # controller's per-write cap actually trips — mirrors rate_limiter_test.exs.
+  defp stub_counting_limiter do
+    {:ok, counts} = Agent.start_link(fn -> %{} end)
+
+    stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window_ms, limit ->
+      count =
+        Agent.get_and_update(counts, fn m ->
+          c = Map.get(m, bucket, 0) + 1
+          {c, Map.put(m, bucket, c)}
+        end)
+
+      if count <= limit, do: {:allow, count}, else: {:deny, limit}
+    end)
+
+    counts
+  end
+
+  describe "POST /api/v1/channel/posts" do
+    # TC-39.2.1
+    test "agent posts to own project channel -> 201 with server-stamped identity + ~30d expiry" do
+      tenant = fixture(:tenant, %{trust_tier: :agent_rooted})
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, agent} = agent_key(tenant)
+
+      conn = post_json(raw, %{"project_id" => project.id, "body" => "pushed PR #107, CI green"})
+
+      assert %{"post" => post} = json_response(conn, 201)
+      assert post["agent_id"] == agent.id
+      assert post["tenant_id"] == tenant.id
+      assert post["project_id"] == project.id
+      assert post["body"] == "pushed PR #107, CI green"
+
+      {:ok, expires, _} = DateTime.from_iso8601(post["expires_at"])
+      expected = DateTime.add(DateTime.utc_now(), 30 * 86_400, :second)
+      assert_in_delta DateTime.to_unix(expires), DateTime.to_unix(expected), 120
+    end
+
+    # TC-39.2.2
+    test "agent_id/tenant_id in the body are ignored (server-stamped from the key)" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, agent} = agent_key(tenant)
+
+      foreign_tenant = fixture(:tenant)
+      foreign_agent = fixture(:agent, %{tenant_id: foreign_tenant.id})
+
+      conn =
+        post_json(raw, %{
+          "project_id" => project.id,
+          "body" => "x",
+          "agent_id" => foreign_agent.id,
+          "tenant_id" => foreign_tenant.id
+        })
+
+      assert %{"post" => post} = json_response(conn, 201)
+      assert post["agent_id"] == agent.id
+      assert post["tenant_id"] == tenant.id
+    end
+
+    # TC-39.2.3
+    test "cross-tenant AND not-found project both 422 with a byte-identical body, no row" do
+      tenant = fixture(:tenant)
+      other = fixture(:tenant)
+      foreign = fixture(:project, %{tenant_id: other.id})
+      {raw, _key, _agent} = agent_key(tenant)
+
+      cross_body =
+        post_json(raw, %{"project_id" => foreign.id, "body" => "x"}) |> json_response(422)
+
+      missing_body =
+        post_json(raw, %{"project_id" => Ecto.UUID.generate(), "body" => "x"})
+        |> json_response(422)
+
+      # No existence oracle: the "not yours" and "does not exist" bodies are identical.
+      assert cross_body == missing_body
+      assert AdminRepo.aggregate(ChannelPost, :count, :id) == 0
+    end
+
+    # TC-39.2.4
+    test "keyed post upserts within a session (200, same id) and is distinct across sessions (201)" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, _agent} = agent_key(tenant)
+
+      slot = fn session, body ->
+        %{
+          "project_id" => project.id,
+          "session_id" => session,
+          "key" => "session_goal",
+          "body" => body
+        }
+      end
+
+      c1 = post_json(raw, slot.("S1", "v1"))
+      assert %{"post" => p1} = json_response(c1, 201)
+
+      c2 = post_json(raw, slot.("S1", "v2"))
+      assert %{"post" => p2} = json_response(c2, 200)
+      assert p2["id"] == p1["id"]
+      assert p2["body"] == "v2"
+
+      c3 = post_json(raw, slot.("S2", "other"))
+      assert %{"post" => p3} = json_response(c3, 201)
+      assert p3["id"] != p1["id"]
+
+      count =
+        AdminRepo.aggregate(
+          from(p in ChannelPost, where: p.project_id == ^project.id),
+          :count,
+          :id
+        )
+
+      assert count == 2
+    end
+
+    # TC-39.2.5
+    test "an agent key with no agent identity -> 403 agent_identity_required, no row + security log" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent, agent_id: nil})
+
+      log =
+        capture_log(fn ->
+          conn = post_json(raw, %{"project_id" => project.id, "body" => "x"})
+
+          assert %{"error" => %{"code" => "agent_identity_required", "status" => 403}} =
+                   json_response(conn, 403)
+        end)
+
+      assert AdminRepo.aggregate(ChannelPost, :count, :id) == 0
+      assert log =~ "agent_identity_required"
+    end
+
+    # TC-39.2.6
+    test "over-cap writes are 429 with Retry-After and emit a security-event log" do
+      stub_counting_limiter()
+      tenant = fixture(:tenant, %{settings: %{"channel_post_write_limit_per_minute" => 3}})
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, _agent} = agent_key(tenant)
+
+      # First 3 writes are within the per-write cap.
+      for _ <- 1..3 do
+        conn = post_json(raw, %{"project_id" => project.id, "body" => "x"})
+        assert conn.status in [200, 201]
+      end
+
+      log =
+        capture_log(fn ->
+          conn = post_json(raw, %{"project_id" => project.id, "body" => "x"})
+
+          assert %{"error" => %{"status" => 429}} = json_response(conn, 429)
+          assert [retry] = get_resp_header(conn, "retry-after")
+          assert String.to_integer(retry) >= 1
+        end)
+
+      assert log =~ "rate_limited"
+    end
+
+    # AC-39.2.6 — a denylist hit / oversized body is a 422 (validation), not persisted.
+    test "an oversized body is rejected 422 and not persisted" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, _agent} = agent_key(tenant)
+
+      conn =
+        post_json(raw, %{"project_id" => project.id, "body" => String.duplicate("a", 16_385)})
+
+      assert json_response(conn, 422)
+      assert AdminRepo.aggregate(ChannelPost, :count, :id) == 0
+    end
+
+    test "the route requires agent role (a lower/unauthenticated caller cannot post)" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+
+      conn =
+        build_conn()
+        |> put_req_header("x-loopctl-last-known-sth", @sth_header)
+        |> post(@path, %{"project_id" => project.id, "body" => "x"})
+
+      assert conn.status in [401, 403]
+    end
+  end
+end

--- a/test/loopctl_web/controllers/openapi_test.exs
+++ b/test/loopctl_web/controllers/openapi_test.exs
@@ -109,6 +109,21 @@ defmodule LoopctlWeb.OpenApiTest do
       assert Map.has_key?(schemas, "RetrieveToolsResponse")
       assert Map.has_key?(schemas, "RetrieveResponse")
     end
+
+    # US-39.2 (AC-39.2.1) — the Coordination Bus write endpoint (Epic 39) must
+    # render in the OpenAPI spec (declared via `operation(...)` in
+    # ChannelPostController) so it shows up at /swaggerui.
+    test "includes the Coordination Bus (Epic 39) write endpoint", %{conn: conn} do
+      body = conn |> get("/api/v1/openapi") |> json_response(200)
+      paths = body["paths"]
+
+      assert Map.has_key?(paths, "/api/v1/channel/posts")
+      assert Map.has_key?(paths["/api/v1/channel/posts"], "post")
+
+      schemas = body["components"]["schemas"]
+      assert Map.has_key?(schemas, "ChannelPostRequest")
+      assert Map.has_key?(schemas, "ChannelPostResponse")
+    end
   end
 
   describe "GET /swaggerui" do

--- a/test/loopctl_web/require_human_anchor_default_deny_test.exs
+++ b/test/loopctl_web/require_human_anchor_default_deny_test.exs
@@ -187,6 +187,14 @@ defmodule LoopctlWeb.RequireHumanAnchorDefaultDenyTest do
                {:delete, "/api/v1/webhooks/:id"},
                {:post, "/api/v1/webhooks/:id/test"},
 
+               # Repo Coordination Bus (Epic 39, US-39.2) — the channel write is a
+               # COORDINATION surface, NOT chain-of-custody: posting to your own
+               # tenant's channel is the same content class the KB surface (owner
+               # decision #331) is fully agent-usable for. Agent-role, authorship
+               # server-stamped from the verified key, tenant-scoped — so it is
+               # deliberately OUTSIDE the human-anchor tier gate (design brief §4).
+               {:post, "/api/v1/channel/posts"},
+
                # Superadmin-only admin scope — RequireRole already pins these
                # to superadmin; Impersonate explicitly skips
                # /api/v1/admin/*, so current_tenant is always nil


### PR DESCRIPTION
## US-39.2 — channel_post write endpoint + Coordination.post context

Adds the HTTP write half of the Repo Coordination Bus (Epic 39, the third memory plane). Agents POST short, attributed coordination messages to a project's channel (a channel IS a `project_id`) so other sessions on the same repo — on any machine — see what they found, did, or are doing. Builds on US-39.1 (schema, context primitives, denylist).

### What landed
- **New route** `POST /api/v1/channel/posts` (`LoopctlWeb.ChannelPostController`), `role: :agent`, NOT behind `RequireHumanAnchor` — coordination surface, owner decision #331 (same class as the KB content surface).
- **`Loopctl.Coordination.post/3`**: project ownership via `Projects.get_project`, server-stamped `tenant_id`/`agent_id`, 30-day server-set `expires_at`, per-session keyed upsert, and `Audit.log_in_multi` (action `posted`/`upserted`) all in one `AdminRepo.transaction`. Returns created (201) vs upsert-updated (200).
- **Upsert** `conflict_target` matches the LIVE partial unique index `(tenant_id, project_id, agent_id, session_id, key) WHERE key IS NOT NULL` via an `unsafe_fragment`; `returning: true` so the upserted struct reflects the real persisted row (avoids Ecto's phantom-id on-conflict gotcha — verified with a 1-row DB assertion).
- **Unconditional agent-identity gate**: a key with no `agent_id` gets `403 agent_identity_required`, no row persisted (distinct from article_controller's conditional memory-metadata gate).
- **No existence oracle**: a missing project and a cross-tenant project both return a byte-identical 422.
- **Rate limit**: config-driven per-write cap (per-api_key bucket, tenant-overridable `channel_post_write_limit_per_minute`) reusing the `Loopctl.RateLimiter` behaviour seam; 429 with `Retry-After`. The generic per-key/per-tenant pipeline limiter still applies.
- **Security signals** (telemetry + structured logs): `agent_identity_required` (403), ownership rejection (422), rate-limit trip (429); denylist rejection emitted from the context.
- **OpenApiSpex** `operation/1` + `ChannelPostRequest`/`ChannelPostResponse` schemas; default-deny allowlist entry with justification; openapi + context + controller tests (TC-39.2.1..6, tenant isolation).

### Acceptance criteria
All 9 ACs (AC-39.2.1 .. AC-39.2.9) satisfied.

### Quality gate
`mix precommit` green: compile (warnings-as-errors), format, credo --strict (no issues), dialyzer (passed), 5018 tests / 0 failures.

Closes #US-39.2
