### PR TITLE
channel_recent read endpoint + context (AdminRepo + explicit tenant filter, since/limit, live-only, oracle-safe)

### DIFF
--- a/lib/loopctl/api_spec/schemas.ex
+++ b/lib/loopctl/api_spec/schemas.ex
@@ -972,6 +972,31 @@ defmodule Loopctl.ApiSpec.Schemas do
     })
   end
 
+  defmodule ChannelPostListItem do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "ChannelPostListItem",
+      description:
+        "One coordination channel post as returned by the channel_recent read endpoint. " <>
+          "agent_id is the only server-stamped (authoritative) attribution; session_id and host " <>
+          "are client-supplied and informational.",
+      type: :object,
+      properties: %{
+        id: %Schema{type: :string, format: :uuid},
+        agent_id: %Schema{type: :string, format: :uuid},
+        session_id: %Schema{type: :string, nullable: true},
+        host: %Schema{type: :string, nullable: true},
+        key: %Schema{type: :string, nullable: true},
+        body: %Schema{type: :string},
+        refs: %Schema{type: :object, nullable: true, additionalProperties: true},
+        inserted_at: %Schema{type: :string, format: :"date-time"},
+        updated_at: %Schema{type: :string, format: :"date-time"}
+      }
+    })
+  end
+
   # ---------- Epics ----------
 
   defmodule EpicResponse do

--- a/lib/loopctl/coordination.ex
+++ b/lib/loopctl/coordination.ex
@@ -34,8 +34,12 @@ defmodule Loopctl.Coordination do
   # per-type retentions were unused).
   @retention_days 30
 
-  @default_recent_limit 50
-  @max_recent_limit 200
+  # Read-bound convention (US-39.3): the `channel_recent` endpoint defaults to 25
+  # rows and CLAMPS a larger `?limit=` to 100 (not a 400) — see AC-39.3.3. These
+  # are the single source of truth for both the context primitive and the HTTP
+  # endpoint's `meta.limit`.
+  @default_recent_limit 25
+  @max_recent_limit 100
 
   @doc "The uniform retention window, in days, applied to every post."
   @spec retention_days() :: pos_integer()
@@ -282,15 +286,25 @@ defmodule Loopctl.Coordination do
 
   Isolation is the explicit `tenant_id` filter (AdminRepo path); expired posts
   are filtered defensively even before the TTL sweep runs. A non-UUID
-  `tenant_id`/`project_id` (e.g. a malformed path segment once US-39.3 wires an
-  endpoint) yields `[]` rather than an `Ecto.Query.CastError` — mirroring the
-  `valid_uuid?` guard in `Projects.get_project`. `opts`:
+  `tenant_id`/`project_id` (e.g. a malformed path segment from the
+  `channel_recent` endpoint) yields `[]` rather than an `Ecto.Query.CastError` —
+  mirroring the `valid_uuid?` guard in `Projects.get_project`. This is also the
+  oracle-safe path: a cross-tenant or nonexistent (but well-formed) `project_id`
+  is simply excluded by the explicit `tenant_id`/`project_id` filter and yields
+  `[]` — identical to an owned-but-empty channel, revealing nothing about whether
+  the project exists in another tenant. `opts`:
 
     * `:limit` — max rows (default #{@default_recent_limit}, capped at
       #{@max_recent_limit}); `limit: 0` (or negative) returns `[]`. Accepts an
-      integer or an integer STRING (e.g. `"0"`/`"1000"` from a `?limit=` query
-      param once US-39.3 wires an endpoint) so the documented contract holds for
-      the real endpoint input; any other value falls back to the default.
+      integer or an integer STRING (e.g. `"0"`/`"1000"` from the `?limit=` query
+      param) so the documented contract holds for the real endpoint input; any
+      other value falls back to the default.
+    * `:since` — when present, returns only posts touched AFTER this instant,
+      filtering `GREATEST(inserted_at, updated_at) > since` so a keyed slot
+      upserted after `since` (its `updated_at` advanced) still surfaces as a
+      delta. Accepts a `DateTime` or an ISO8601 string (as a `?since=` query
+      param arrives); a malformed or absent value is a NO-OP filter (never a
+      400).
   """
   @spec recent(term(), term(), keyword()) :: [ChannelPost.t()]
   def recent(tenant_id, project_id, opts \\ []) do
@@ -301,6 +315,7 @@ defmodule Loopctl.Coordination do
       ChannelPost
       |> where([p], p.tenant_id == ^tenant_id and p.project_id == ^project_id)
       |> where([p], p.expires_at > ^now)
+      |> apply_since(Keyword.get(opts, :since))
       |> order_by([p], desc: p.inserted_at, desc: p.seq)
       |> limit(^limit)
       |> AdminRepo.all()
@@ -308,6 +323,34 @@ defmodule Loopctl.Coordination do
       []
     end
   end
+
+  @doc """
+  Clamps a `:limit` value to the `channel_recent` read-bound contract (default
+  #{@default_recent_limit}, cap #{@max_recent_limit}), accepting an integer or an
+  integer string. Exposed so the HTTP endpoint can report the ACTUALLY-applied
+  limit in its `meta` envelope from the SAME source of truth `recent/3` uses,
+  never a divergent second copy.
+  """
+  @spec clamp_recent_limit(term()) :: non_neg_integer()
+  def clamp_recent_limit(limit), do: clamp_limit(limit)
+
+  # `:since` delta filter. A DateTime (or a parseable ISO8601 string) filters to
+  # posts whose most-recent touch — GREATEST(inserted_at, updated_at) — is strictly
+  # after `since`, so a session slot upserted after `since` still surfaces even
+  # though its `inserted_at` predates it. Anything else (nil, malformed string) is
+  # a no-op so a bad `?since=` degrades to "no filter", never a 400.
+  defp apply_since(query, %DateTime{} = since) do
+    where(query, [p], fragment("GREATEST(?, ?)", p.inserted_at, p.updated_at) > ^since)
+  end
+
+  defp apply_since(query, since) when is_binary(since) do
+    case DateTime.from_iso8601(since) do
+      {:ok, dt, _offset} -> apply_since(query, dt)
+      _ -> query
+    end
+  end
+
+  defp apply_since(query, _since), do: query
 
   defp default_expires_at do
     DateTime.add(DateTime.utc_now(), @retention_days * 24 * 60 * 60, :second)
@@ -320,11 +363,11 @@ defmodule Loopctl.Coordination do
   # silently coercing to the default (LIMIT 0 returns []).
   defp clamp_limit(limit) when is_integer(limit) and limit <= 0, do: 0
 
-  # US-39.3 will wire this to an HTTP endpoint where `?limit=` arrives as a string.
+  # The `channel_recent` endpoint (US-39.3) passes `?limit=` through as a string.
   # Parse an integer string and re-clamp so the documented contract (`"0"` -> [],
   # `"1000"` capped at #{@max_recent_limit}) holds; a non-integer / trailing-garbage
-  # value falls back to the default rather than silently returning the default 50
-  # for a well-formed `"0"`.
+  # value falls back to the default rather than silently returning the default for
+  # a well-formed `"0"`.
   defp clamp_limit(limit) when is_binary(limit) do
     case Integer.parse(limit) do
       {n, ""} -> clamp_limit(n)

--- a/lib/loopctl/coordination.ex
+++ b/lib/loopctl/coordination.ex
@@ -302,25 +302,52 @@ defmodule Loopctl.Coordination do
     * `:since` — when present, returns only posts touched AFTER this instant,
       filtering `GREATEST(inserted_at, updated_at) > since` so a keyed slot
       upserted after `since` (its `updated_at` advanced) still surfaces as a
-      delta. Accepts a `DateTime` or an ISO8601 string (as a `?since=` query
-      param arrives); a malformed or absent value is a NO-OP filter (never a
-      400).
+      delta. In this delta mode the ORDER BY is also `GREATEST(inserted_at,
+      updated_at) DESC` (not plain `inserted_at DESC`) so a re-touched slot ranks
+      by its most-recent touch and is not the first row dropped by `:limit`.
+      Accepts a `DateTime` or a full ISO8601 INSTANT string (as a `?since=` query
+      param arrives) — an OFFSET-LESS but valid instant (e.g.
+      `"2026-07-18T00:00:00"`) is interpreted as UTC. A malformed, absent, or
+      wrong-granularity value (e.g. a date-only `"2026-07-18"`) is a NO-OP filter
+      that returns the whole live channel — never a 400; supply a full instant to
+      get a delta.
   """
   @spec recent(term(), term(), keyword()) :: [ChannelPost.t()]
   def recent(tenant_id, project_id, opts \\ []) do
+    {posts, _has_more} = recent_page(tenant_id, project_id, opts)
+    posts
+  end
+
+  @doc """
+  Like `recent/3` but also reports whether the `:limit` TRUNCATED the result.
+
+  Returns `{posts, has_more}` where `has_more` is `true` iff at least one more
+  live, matching post exists beyond the applied `:limit`. Detected by fetching
+  `limit + 1` rows and checking for the overflow row (no extra COUNT query), so
+  the endpoint can surface an HONEST truncation signal in its `meta` envelope
+  rather than leaving consumers to infer it from `count == limit`. A full cursor
+  (paging past the truncation) is out of scope — US-39.6 owns dedup/paging; this
+  is only the cheap "there is more" flag.
+  """
+  @spec recent_page(term(), term(), keyword()) :: {[ChannelPost.t()], boolean()}
+  def recent_page(tenant_id, project_id, opts \\ []) do
     if valid_uuid?(tenant_id) and valid_uuid?(project_id) do
       limit = opts |> Keyword.get(:limit, @default_recent_limit) |> clamp_limit()
+      since = opts |> Keyword.get(:since) |> normalize_since()
       now = DateTime.utc_now()
 
-      ChannelPost
-      |> where([p], p.tenant_id == ^tenant_id and p.project_id == ^project_id)
-      |> where([p], p.expires_at > ^now)
-      |> apply_since(Keyword.get(opts, :since))
-      |> order_by([p], desc: p.inserted_at, desc: p.seq)
-      |> limit(^limit)
-      |> AdminRepo.all()
+      rows =
+        ChannelPost
+        |> where([p], p.tenant_id == ^tenant_id and p.project_id == ^project_id)
+        |> where([p], p.expires_at > ^now)
+        |> apply_since(since)
+        |> order_recent(since)
+        |> limit(^(limit + 1))
+        |> AdminRepo.all()
+
+      {Enum.take(rows, limit), length(rows) > limit}
     else
-      []
+      {[], false}
     end
   end
 
@@ -334,23 +361,77 @@ defmodule Loopctl.Coordination do
   @spec clamp_recent_limit(term()) :: non_neg_integer()
   def clamp_recent_limit(limit), do: clamp_limit(limit)
 
-  # `:since` delta filter. A DateTime (or a parseable ISO8601 string) filters to
-  # posts whose most-recent touch — GREATEST(inserted_at, updated_at) — is strictly
-  # after `since`, so a session slot upserted after `since` still surfaces even
-  # though its `inserted_at` predates it. Anything else (nil, malformed string) is
-  # a no-op so a bad `?since=` degrades to "no filter", never a 400.
+  # Resolve the caller's `:since` (a `DateTime`, an ISO8601 string, or
+  # nil/garbage) to a single `%DateTime{}` or `nil`, ONCE, so the delta FILTER
+  # (`apply_since/2`) and the delta ORDERING (`order_recent/2`) agree on the same
+  # value. A malformed, absent, or wrong-granularity (date-only) value resolves to
+  # `nil` — a no-op filter with the default ordering, never a 400.
+  defp normalize_since(%DateTime{} = since), do: since
+
+  defp normalize_since(since) when is_binary(since) do
+    case parse_since(since) do
+      {:ok, dt} -> dt
+      :error -> nil
+    end
+  end
+
+  defp normalize_since(_since), do: nil
+
+  # `:since` delta filter. Filters to posts whose most-recent touch —
+  # GREATEST(inserted_at, updated_at) — is strictly after `since`, so a session
+  # slot upserted after `since` still surfaces even though its `inserted_at`
+  # predates it. `nil` (absent/malformed/date-only) is a no-op so a bad `?since=`
+  # degrades to "no filter", never a 400.
   defp apply_since(query, %DateTime{} = since) do
     where(query, [p], fragment("GREATEST(?, ?)", p.inserted_at, p.updated_at) > ^since)
   end
 
-  defp apply_since(query, since) when is_binary(since) do
-    case DateTime.from_iso8601(since) do
-      {:ok, dt, _offset} -> apply_since(query, dt)
-      _ -> query
-    end
+  defp apply_since(query, nil), do: query
+
+  # AC-39.3.1 orders the plain read `inserted_at DESC`. But a DELTA read (`since`
+  # present) filters on GREATEST(inserted_at, updated_at) — so a keyed slot whose
+  # `updated_at` (not `inserted_at`) advanced past `since` MATCHES the filter yet,
+  # ordered by its stale `inserted_at`, would rank last among matched rows and be
+  # the FIRST dropped by LIMIT — the exact SessionStart working-state slot the bus
+  # exists to surface (US-39.6 dedup). In delta mode we therefore order by the SAME
+  # GREATEST(inserted_at, updated_at) the filter uses, so a re-touched slot ranks
+  # by its most-recent touch and is not silently truncated. The non-delta read
+  # keeps the AC-mandated `inserted_at DESC`. `seq` (bigserial) DESC tie-breaks.
+  defp order_recent(query, %DateTime{}) do
+    order_by(query, [p],
+      desc: fragment("GREATEST(?, ?)", p.inserted_at, p.updated_at),
+      desc: p.seq
+    )
   end
 
-  defp apply_since(query, _since), do: query
+  defp order_recent(query, nil) do
+    order_by(query, [p], desc: p.inserted_at, desc: p.seq)
+  end
+
+  # Parse an ISO8601 `since` into a UTC DateTime. `DateTime.from_iso8601/1` only
+  # accepts an offset-bearing instant (the `...Z`/`+HH:MM` form that
+  # `DateTime.to_iso8601/1` emits on the programmatic path). A hand-crafted or
+  # tool-supplied but otherwise-valid OFFSET-LESS instant (e.g.
+  # "2026-07-18T00:00:00") returns `{:error, :missing_offset}` there — so without
+  # this fallback it would fall through to the no-op clause and SILENTLY disable
+  # the delta filter, returning the whole channel and defeating the "read only
+  # what's new" contract. Interpret an offset-less-but-valid ISO8601 instant as
+  # UTC (loopctl stores every timestamp in UTC) rather than dropping the filter.
+  defp parse_since(since) do
+    case DateTime.from_iso8601(since) do
+      {:ok, dt, _offset} ->
+        {:ok, dt}
+
+      {:error, :missing_offset} ->
+        case NaiveDateTime.from_iso8601(since) do
+          {:ok, naive} -> {:ok, DateTime.from_naive!(naive, "Etc/UTC")}
+          _ -> :error
+        end
+
+      _ ->
+        :error
+    end
+  end
 
   defp default_expires_at do
     DateTime.add(DateTime.utc_now(), @retention_days * 24 * 60 * 60, :second)

--- a/lib/loopctl/rate_limiter/fail_open_log.ex
+++ b/lib/loopctl/rate_limiter/fail_open_log.ex
@@ -73,6 +73,20 @@ defmodule Loopctl.RateLimiter.FailOpenLog do
     :ok
   end
 
+  @doc false
+  # Test seam: clear the throttle entry for one `(source, family)` so a test that
+  # asserts a fail-open warning IS emitted cannot be silently throttled by a
+  # concurrent async test that tripped the SAME node-local `(source, family)`
+  # window first (the ETS table is process-independent and lives for the whole
+  # run). Best-effort — a missing table is a no-op, mirroring `should_emit?/2`.
+  @spec reset(atom(), String.t()) :: :ok
+  def reset(source, family) when is_atom(source) and is_binary(family) do
+    :ets.delete(@table, {source, family})
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
   # Reduce a bucket to a NON-identifying family token by dropping the trailing
   # id/IP segment. Bucket shapes: "key:<uuid>", "tenant:<uuid>",
   # "api_signup:ip:1.2.3.4", "signup:webauthn:<key>", "signup:actions:<key>",

--- a/lib/loopctl_web/controllers/channel_post_controller.ex
+++ b/lib/loopctl_web/controllers/channel_post_controller.ex
@@ -25,6 +25,10 @@ defmodule LoopctlWeb.ChannelPostController do
   (429). The denylist rejection (422) signal is emitted from `Loopctl.Coordination`
   at the point the write is rejected. A rate-limiter fault degrades to "no gate"
   but is logged via the shared throttled `FailOpenLog`, never swallowed silently.
+
+  The READ (`:index`) emits `:read_error` on any internal fault (US-39.3
+  technical_notes) before re-raising to the sanitizing DB-error backstop — the
+  errored read stays tenant-agnostic, never a cross-tenant existence oracle.
   """
 
   use LoopctlWeb, :controller
@@ -113,7 +117,11 @@ defmodule LoopctlWeb.ChannelPostController do
       since: [
         in: :query,
         type: :string,
-        description: "ISO8601 instant; return only posts touched after it (delta read)"
+        description:
+          "Full ISO8601 INSTANT (e.g. 2026-07-18T00:00:00Z or 2026-07-18T00:00:00); " <>
+            "return only posts touched after it (delta read). A date-only value " <>
+            "(e.g. 2026-07-18) is the wrong granularity and is IGNORED — the whole " <>
+            "live channel is returned, not a delta. Supply a full instant."
       ],
       limit: [
         in: :query,
@@ -132,7 +140,12 @@ defmodule LoopctlWeb.ChannelPostController do
                type: :object,
                properties: %{
                  limit: %OpenApiSpex.Schema{type: :integer},
-                 count: %OpenApiSpex.Schema{type: :integer}
+                 count: %OpenApiSpex.Schema{type: :integer},
+                 has_more: %OpenApiSpex.Schema{
+                   type: :boolean,
+                   description:
+                     "True when the limit truncated the result — more live matching posts exist"
+                 }
                }
              }
            }
@@ -161,16 +174,43 @@ defmodule LoopctlWeb.ChannelPostController do
     # passed back into `recent/3`, which re-clamps harmlessly.
     applied_limit = Coordination.clamp_recent_limit(params["limit"])
 
-    posts =
-      Coordination.recent(tenant_id, params["project_id"],
+    # `has_more` is an HONEST truncation signal: `recent_page/3` fetches
+    # `limit + 1` and reports whether a matching post exists beyond the applied
+    # limit, so a consumer never mistakes a truncated page for the whole channel
+    # (it can re-read with a tighter `since` / smaller window). A full cursor is
+    # US-39.6's job; this is the cheap "there is more" flag.
+    {posts, has_more} =
+      Coordination.recent_page(tenant_id, params["project_id"],
         limit: applied_limit,
         since: params["since"]
       )
 
     json(conn, %{
       data: Enum.map(posts, &channel_post_json/1),
-      meta: %{limit: applied_limit, count: length(posts)}
+      meta: %{limit: applied_limit, count: length(posts), has_more: has_more}
     })
+  rescue
+    e ->
+      # US-39.3 technical_notes: "Emit a security-event log on any internal error
+      # but never leak cross-tenant existence." `recent/3` is total for well-formed
+      # input (a non-UUID, missing, cross-tenant, or nonexistent project_id all
+      # yield an empty list, never a raise — the oracle-safe guard), so the only
+      # path that reaches here is a genuine server-side fault (e.g. a DB outage).
+      # Emit the coordination-surface security signal (parity with the create
+      # path's :ownership_rejected / :agent_identity_required / :rate_limited),
+      # then RE-RAISE so the existing DBErrorBackstop/ErrorJSON machinery renders
+      # the SAME sanitized, tenant-agnostic 500/503/504 body it renders today — the
+      # errored read stays uniform regardless of tenant or project, so it never
+      # becomes a cross-tenant existence oracle.
+      api_key = conn.assigns.current_api_key
+
+      emit_security_event(:read_error, %{
+        tenant_id: api_key.tenant_id,
+        api_key_id: api_key.id,
+        project_id: params["project_id"]
+      })
+
+      reraise e, __STACKTRACE__
   end
 
   # AC-39.3.5: the exact read field set — enough to render "who / which machine /

--- a/lib/loopctl_web/controllers/channel_post_controller.ex
+++ b/lib/loopctl_web/controllers/channel_post_controller.ex
@@ -42,11 +42,16 @@ defmodule LoopctlWeb.ChannelPostController do
 
   # Coordination surface (#331): agent role, NO RequireHumanAnchor. See the
   # coordination-surface allowlist entry in require_human_anchor_default_deny_test.
-  plug LoopctlWeb.Plugs.RequireRole, [role: :agent] when action in [:create]
+  # The read (`:index`) is the same agent-role, tenant-scoped coordination surface
+  # as the write — never human-anchor gated (the human-anchor default-deny test
+  # only walks POST/PUT/PATCH/DELETE, so this GET needs no allowlist entry).
+  plug LoopctlWeb.Plugs.RequireRole, [role: :agent] when action in [:create, :index]
 
   # Per-write rate limit (AC-39.2.8): a TIGHTER, config-driven cap on top of the
   # generic per-key/per-tenant pipeline RateLimiter, reusing the same
-  # `Loopctl.RateLimiter` behaviour seam. Bounds post spam / upsert thrash.
+  # `Loopctl.RateLimiter` behaviour seam. Bounds post spam / upsert thrash. The
+  # read is NOT behind this write cap — it is covered by the generic pipeline
+  # per-key/per-tenant limiter like every other read.
   plug :rate_limit_write when action in [:create]
 
   tags(["Coordination"])
@@ -88,6 +93,104 @@ defmodule LoopctlWeb.ChannelPostController do
       429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
     }
   )
+
+  operation(:index,
+    summary: "Read a repo coordination channel (channel_recent)",
+    description:
+      "Returns LIVE coordination posts for a project's channel (a channel IS a project_id), " <>
+        "newest-first (inserted_at DESC). Agent+ role, tenant-scoped from the verified key — " <>
+        "project_id is a query param but the tenant is NEVER taken from params. ORACLE-SAFE: a " <>
+        "project_id belonging to another tenant, or a nonexistent one, returns 200 with an empty " <>
+        "list — identical to an owned-but-empty channel, never a 404. Only non-expired posts are " <>
+        "returned (expires_at > now, independent of the TTL sweep). `since` (ISO8601) returns only " <>
+        "posts touched after that instant; `limit` defaults to 25 and is clamped to a max of 100.",
+    parameters: [
+      project_id: [
+        in: :query,
+        type: :string,
+        description: "The channel — a project the caller's tenant owns"
+      ],
+      since: [
+        in: :query,
+        type: :string,
+        description: "ISO8601 instant; return only posts touched after it (delta read)"
+      ],
+      limit: [
+        in: :query,
+        type: :integer,
+        description: "Max posts (default 25, clamped to 100)"
+      ]
+    ],
+    responses: %{
+      200 =>
+        {"Channel posts", "application/json",
+         %OpenApiSpex.Schema{
+           type: :object,
+           properties: %{
+             data: %OpenApiSpex.Schema{type: :array, items: Schemas.ChannelPostListItem},
+             meta: %OpenApiSpex.Schema{
+               type: :object,
+               properties: %{
+                 limit: %OpenApiSpex.Schema{type: :integer},
+                 count: %OpenApiSpex.Schema{type: :integer}
+               }
+             }
+           }
+         }},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  @doc """
+  GET /api/v1/channel/posts
+
+  Reads a project's coordination channel. Requires agent+ role. The channel is a
+  `project_id` query param; the tenant is always derived from the verified key.
+
+  ORACLE-SAFE: a cross-tenant or nonexistent `project_id` returns 200 with an
+  empty list — uniform with an owned-but-empty channel, never a 404. There is NO
+  ownership pre-check and NO branch to 404: the explicit `tenant_id` filter in
+  `Coordination.recent/3` simply excludes any post not in the caller's tenant, so
+  a probe learns nothing about whether the project exists elsewhere.
+  """
+  def index(conn, params) do
+    tenant_id = conn.assigns.current_api_key.tenant_id
+
+    # The applied limit for the `meta` envelope comes from the SAME clamp
+    # `recent/3` uses (default 25, cap 100) — never a divergent second copy. It is
+    # passed back into `recent/3`, which re-clamps harmlessly.
+    applied_limit = Coordination.clamp_recent_limit(params["limit"])
+
+    posts =
+      Coordination.recent(tenant_id, params["project_id"],
+        limit: applied_limit,
+        since: params["since"]
+      )
+
+    json(conn, %{
+      data: Enum.map(posts, &channel_post_json/1),
+      meta: %{limit: applied_limit, count: length(posts)}
+    })
+  end
+
+  # AC-39.3.5: the exact read field set — enough to render "who / which machine /
+  # which session / when" and to self-dedupe by session_id. Deliberately narrower
+  # than the schema's `@derive Jason.Encoder` (which also carries
+  # tenant_id/project_id/expires_at): a dedicated builder keeps the response to the
+  # AC's contract, matching the project_json/1 convention.
+  defp channel_post_json(post) do
+    %{
+      id: post.id,
+      agent_id: post.agent_id,
+      session_id: post.session_id,
+      host: post.host,
+      key: post.key,
+      body: post.body,
+      refs: post.refs,
+      inserted_at: post.inserted_at,
+      updated_at: post.updated_at
+    }
+  end
 
   @doc """
   POST /api/v1/channel/posts

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -129,6 +129,10 @@ defmodule LoopctlWeb.Router do
     # limiting comes from the :authenticated pipeline RateLimiter; the controller
     # adds a tighter, config-driven per-write cap.
     post "/channel/posts", ChannelPostController, :create
+    # channel_recent read (US-39.3): agent-role, tenant-scoped, oracle-safe read
+    # of a project's live channel. project_id/since/limit query params; the tenant
+    # is key-derived, never from params.
+    get "/channel/posts", ChannelPostController, :index
 
     get "/tenants/me", TenantController, :show
     patch "/tenants/me", TenantController, :update

--- a/test/loopctl/coordination_test.exs
+++ b/test/loopctl/coordination_test.exs
@@ -316,6 +316,34 @@ defmodule Loopctl.CoordinationTest do
       assert bodies == ["new"]
     end
 
+    test "since accepts an OFFSET-LESS ISO8601 string, interpreted as UTC", %{
+      tenant: tenant,
+      project: project,
+      agent_id: agent_id
+    } do
+      base = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+      t1 = DateTime.add(base, -300, :second)
+      t2 = DateTime.add(base, -200, :second)
+      t3 = DateTime.add(base, -100, :second)
+
+      seed_post(tenant, project, agent_id, "old", t1)
+      seed_post(tenant, project, agent_id, "new", t3)
+
+      # A hand-crafted / tool-supplied offset-less instant (no `Z`/`+HH:MM`) must
+      # STILL apply the delta filter (interpreted as UTC), not silently degrade to
+      # "no filter" and return the whole channel. `NaiveDateTime.to_iso8601/1`
+      # emits exactly this offset-less form.
+      offset_less = NaiveDateTime.to_iso8601(DateTime.to_naive(t2))
+      refute offset_less =~ ~r/(Z|[+-]\d\d:\d\d)$/
+
+      bodies =
+        tenant.id
+        |> Coordination.recent(project.id, since: offset_less)
+        |> Enum.map(& &1.body)
+
+      assert bodies == ["new"]
+    end
+
     test "a malformed since string is a no-op filter (not an error)", %{
       tenant: tenant,
       project: project,
@@ -330,6 +358,87 @@ defmodule Loopctl.CoordinationTest do
       )
 
       assert [%ChannelPost{}] = Coordination.recent(tenant.id, project.id, since: "not-a-date")
+    end
+
+    test "a date-only since (wrong granularity) is a no-op filter, returns the whole channel", %{
+      tenant: tenant,
+      project: project,
+      agent_id: agent_id
+    } do
+      base = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+      seed_post(tenant, project, agent_id, "old", DateTime.add(base, -300, :second))
+      seed_post(tenant, project, agent_id, "new", DateTime.add(base, -100, :second))
+
+      # "2026-07-18" is a valid ISO8601 DATE but not an INSTANT: it resolves to
+      # neither an offset-bearing nor an offset-less DateTime, so the delta filter
+      # is a no-op and the WHOLE live channel comes back (documented contract —
+      # never a 400, never a silent partial delta). Supply a full instant to
+      # actually get a delta.
+      date_only = base |> DateTime.to_date() |> Date.to_iso8601()
+      refute date_only =~ ~r/T/
+
+      bodies =
+        tenant.id
+        |> Coordination.recent(project.id, since: date_only)
+        |> Enum.map(& &1.body)
+        |> Enum.sort()
+
+      assert bodies == ["new", "old"]
+    end
+
+    test "delta ORDER BY GREATEST keeps a re-touched slot from being truncated by limit", %{
+      tenant: tenant,
+      project: project,
+      agent_id: agent_id
+    } do
+      base = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+      since = DateTime.add(base, -200, :second)
+
+      # A keyed slot whose inserted_at PREDATES `since` but whose updated_at is the
+      # MOST RECENT touch of all — it matches the GREATEST(...) > since filter.
+      {:ok, slot} =
+        Coordination.create_post(tenant.id, project.id, agent_id, %{"body" => "slot"})
+
+      {:ok, _} =
+        slot
+        |> Ecto.Changeset.change(
+          inserted_at: DateTime.add(base, -300, :second),
+          updated_at: DateTime.add(base, -10, :second)
+        )
+        |> AdminRepo.update()
+
+      # Two ordinary posts inserted AFTER `since` but BEFORE the slot's touch.
+      seed_post(tenant, project, agent_id, "p1", DateTime.add(base, -100, :second))
+      seed_post(tenant, project, agent_id, "p2", DateTime.add(base, -50, :second))
+
+      # limit 2 with 3 matching rows: under a plain inserted_at DESC order the slot
+      # (stale inserted_at) would rank last and be dropped; under the delta's
+      # GREATEST DESC order it ranks FIRST (most-recent touch) and survives.
+      bodies =
+        tenant.id
+        |> Coordination.recent(project.id, since: since, limit: 2)
+        |> Enum.map(& &1.body)
+
+      assert "slot" in bodies
+      assert bodies == ["slot", "p2"]
+    end
+
+    test "recent_page reports has_more when the limit truncates, false otherwise", %{
+      tenant: tenant,
+      project: project,
+      agent_id: agent_id
+    } do
+      base = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+
+      for n <- 1..3 do
+        seed_post(tenant, project, agent_id, "p#{n}", DateTime.add(base, -n, :second))
+      end
+
+      assert {truncated, true} = Coordination.recent_page(tenant.id, project.id, limit: 2)
+      assert length(truncated) == 2
+
+      assert {full, false} = Coordination.recent_page(tenant.id, project.id, limit: 5)
+      assert length(full) == 3
     end
 
     test "clamp_recent_limit reflects the applied default (25) and cap (100)" do

--- a/test/loopctl/coordination_test.exs
+++ b/test/loopctl/coordination_test.exs
@@ -210,6 +210,163 @@ defmodule Loopctl.CoordinationTest do
     end
   end
 
+  describe "recent/3 since and limit contract (US-39.3)" do
+    setup do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      agent_id = fixture(:agent, %{tenant_id: tenant.id}).id
+      %{tenant: tenant, project: project, agent_id: agent_id}
+    end
+
+    defp seed_post(tenant, project, agent_id, body, inserted_at) do
+      # Seed a post at a controlled inserted_at/updated_at so ordering + since
+      # deltas are deterministic (create_post always stamps "now").
+      {:ok, post} =
+        Coordination.create_post(tenant.id, project.id, agent_id, %{"body" => body})
+
+      {:ok, post} =
+        post
+        |> Ecto.Changeset.change(inserted_at: inserted_at, updated_at: inserted_at)
+        |> AdminRepo.update()
+
+      post
+    end
+
+    test "orders newest-first by inserted_at", %{
+      tenant: tenant,
+      project: project,
+      agent_id: agent_id
+    } do
+      base = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+      t1 = DateTime.add(base, -300, :second)
+      t2 = DateTime.add(base, -200, :second)
+      t3 = DateTime.add(base, -100, :second)
+
+      seed_post(tenant, project, agent_id, "one", t1)
+      seed_post(tenant, project, agent_id, "two", t2)
+      seed_post(tenant, project, agent_id, "three", t3)
+
+      bodies = tenant.id |> Coordination.recent(project.id) |> Enum.map(& &1.body)
+      assert bodies == ["three", "two", "one"]
+    end
+
+    test "since filters on GREATEST(inserted_at, updated_at) > since", %{
+      tenant: tenant,
+      project: project,
+      agent_id: agent_id
+    } do
+      base = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+      t1 = DateTime.add(base, -300, :second)
+      t2 = DateTime.add(base, -200, :second)
+      t3 = DateTime.add(base, -100, :second)
+
+      seed_post(tenant, project, agent_id, "old", t1)
+      seed_post(tenant, project, agent_id, "new", t3)
+
+      bodies =
+        tenant.id |> Coordination.recent(project.id, since: t2) |> Enum.map(& &1.body)
+
+      assert bodies == ["new"]
+    end
+
+    test "since surfaces a slot whose updated_at (not inserted_at) advanced past since", %{
+      tenant: tenant,
+      project: project,
+      agent_id: agent_id
+    } do
+      base = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+      old = DateTime.add(base, -300, :second)
+      since = DateTime.add(base, -200, :second)
+      touched = DateTime.add(base, -100, :second)
+
+      # inserted_at predates `since`, but updated_at (a later upsert) is after it —
+      # GREATEST(inserted_at, updated_at) surfaces it as a delta.
+      {:ok, post} =
+        Coordination.create_post(tenant.id, project.id, agent_id, %{"body" => "slot"})
+
+      {:ok, _} =
+        post
+        |> Ecto.Changeset.change(inserted_at: old, updated_at: touched)
+        |> AdminRepo.update()
+
+      bodies =
+        tenant.id |> Coordination.recent(project.id, since: since) |> Enum.map(& &1.body)
+
+      assert bodies == ["slot"]
+    end
+
+    test "since accepts an ISO8601 string (as a ?since= query param arrives)", %{
+      tenant: tenant,
+      project: project,
+      agent_id: agent_id
+    } do
+      base = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+      t1 = DateTime.add(base, -300, :second)
+      t2 = DateTime.add(base, -200, :second)
+      t3 = DateTime.add(base, -100, :second)
+
+      seed_post(tenant, project, agent_id, "old", t1)
+      seed_post(tenant, project, agent_id, "new", t3)
+
+      bodies =
+        tenant.id
+        |> Coordination.recent(project.id, since: DateTime.to_iso8601(t2))
+        |> Enum.map(& &1.body)
+
+      assert bodies == ["new"]
+    end
+
+    test "a malformed since string is a no-op filter (not an error)", %{
+      tenant: tenant,
+      project: project,
+      agent_id: agent_id
+    } do
+      seed_post(
+        tenant,
+        project,
+        agent_id,
+        "a",
+        DateTime.utc_now() |> DateTime.truncate(:microsecond)
+      )
+
+      assert [%ChannelPost{}] = Coordination.recent(tenant.id, project.id, since: "not-a-date")
+    end
+
+    test "clamp_recent_limit reflects the applied default (25) and cap (100)" do
+      assert Coordination.clamp_recent_limit(nil) == 25
+      assert Coordination.clamp_recent_limit(10) == 10
+      assert Coordination.clamp_recent_limit(1000) == 100
+      assert Coordination.clamp_recent_limit("1000") == 100
+      assert Coordination.clamp_recent_limit("0") == 0
+    end
+
+    test "limit clamps to 100 even when more than 100 live posts exist", %{
+      tenant: tenant,
+      project: project,
+      agent_id: agent_id
+    } do
+      for n <- 1..105 do
+        {:ok, _} =
+          Coordination.create_post(tenant.id, project.id, agent_id, %{"body" => "p#{n}"})
+      end
+
+      assert length(Coordination.recent(tenant.id, project.id, limit: 1000)) == 100
+    end
+
+    test "default limit (no opt) is 25", %{
+      tenant: tenant,
+      project: project,
+      agent_id: agent_id
+    } do
+      for n <- 1..30 do
+        {:ok, _} =
+          Coordination.create_post(tenant.id, project.id, agent_id, %{"body" => "p#{n}"})
+      end
+
+      assert length(Coordination.recent(tenant.id, project.id)) == 25
+    end
+  end
+
   describe "per-session keyed slot" do
     test "two sessions with the same key do not clobber each other" do
       tenant = fixture(:tenant)

--- a/test/loopctl_web/controllers/channel_post_controller_test.exs
+++ b/test/loopctl_web/controllers/channel_post_controller_test.exs
@@ -471,13 +471,46 @@ defmodule LoopctlWeb.ChannelPostControllerTest do
       cross_body = json_response(cross, 200)
       missing_body = json_response(missing, 200)
 
-      assert cross_body == %{"data" => [], "meta" => %{"limit" => 25, "count" => 0}}
+      assert cross_body == %{
+               "data" => [],
+               "meta" => %{"limit" => 25, "count" => 0, "has_more" => false}
+             }
+
       assert cross_body == missing_body
 
       # And identical to an owned-but-empty project of the caller's own tenant.
       own_empty = fixture(:project, %{tenant_id: tenant.id})
       owned = authed_conn(raw) |> get(@path, %{"project_id" => own_empty.id})
       assert json_response(owned, 200) == cross_body
+    end
+
+    # TC-39.3.4 (edge): a NON-UUID and a MISSING project_id take the same
+    # oracle-safe path — `recent/3`'s `valid_uuid?` guard short-circuits to `[]`,
+    # so `index/2` returns the byte-identical empty envelope, never a 500 or an
+    # Ecto.Query.CastError. Locks the uniform-empty contract at the HTTP boundary
+    # so a future refactor of the guard can't silently regress it.
+    test "a non-UUID project_id returns 200 with the identical empty envelope" do
+      tenant = fixture(:tenant)
+      {raw, _key, _agent} = agent_key(tenant)
+
+      conn = authed_conn(raw) |> get(@path, %{"project_id" => "garbage-not-a-uuid"})
+
+      assert json_response(conn, 200) == %{
+               "data" => [],
+               "meta" => %{"limit" => 25, "count" => 0, "has_more" => false}
+             }
+    end
+
+    test "a missing project_id returns 200 with the identical empty envelope" do
+      tenant = fixture(:tenant)
+      {raw, _key, _agent} = agent_key(tenant)
+
+      conn = authed_conn(raw) |> get(@path, %{})
+
+      assert json_response(conn, 200) == %{
+               "data" => [],
+               "meta" => %{"limit" => 25, "count" => 0, "has_more" => false}
+             }
     end
 
     # TC-39.3.5
@@ -496,6 +529,9 @@ defmodule LoopctlWeb.ChannelPostControllerTest do
       assert length(data) == 100
       assert meta["limit"] == 100
       assert meta["count"] == 100
+      # 150 live posts but only 100 returned -> the envelope tells the caller the
+      # page was truncated (honest signal, not left to infer from count == limit).
+      assert meta["has_more"] == true
     end
 
     test "another tenant's posts are never visible (tenant isolation)" do

--- a/test/loopctl_web/controllers/channel_post_controller_test.exs
+++ b/test/loopctl_web/controllers/channel_post_controller_test.exs
@@ -13,6 +13,7 @@ defmodule LoopctlWeb.ChannelPostControllerTest do
   import ExUnit.CaptureLog
 
   alias Loopctl.AdminRepo
+  alias Loopctl.Coordination
   alias Loopctl.Coordination.ChannelPost
 
   @path "/api/v1/channel/posts"
@@ -365,6 +366,173 @@ defmodule LoopctlWeb.ChannelPostControllerTest do
         build_conn()
         |> put_req_header("x-loopctl-last-known-sth", @sth_header)
         |> post(@path, %{"project_id" => project.id, "body" => "x"})
+
+      assert conn.status in [401, 403]
+    end
+  end
+
+  describe "GET /api/v1/channel/posts (channel_recent)" do
+    # Seed a live post with a controlled inserted_at/updated_at for deterministic
+    # ordering + since deltas (create_post always stamps "now").
+    defp seed_post(tenant, project, agent_id, body, at) do
+      {:ok, post} =
+        Coordination.create_post(tenant.id, project.id, agent_id, %{"body" => body})
+
+      {:ok, post} =
+        post
+        |> Ecto.Changeset.change(inserted_at: at, updated_at: at)
+        |> AdminRepo.update()
+
+      post
+    end
+
+    # TC-39.3.1
+    test "3 live posts t1<t2<t3 -> data has 3, ordered t3,t2,t1" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, agent} = agent_key(tenant)
+
+      base = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+      seed_post(tenant, project, agent.id, "one", DateTime.add(base, -300, :second))
+      seed_post(tenant, project, agent.id, "two", DateTime.add(base, -200, :second))
+      seed_post(tenant, project, agent.id, "three", DateTime.add(base, -100, :second))
+
+      conn = authed_conn(raw) |> get(@path, %{"project_id" => project.id})
+      assert %{"data" => data, "meta" => meta} = json_response(conn, 200)
+
+      assert Enum.map(data, & &1["body"]) == ["three", "two", "one"]
+      assert meta["count"] == 3
+      assert meta["limit"] == 25
+
+      # AC-39.3.5: the exact read field set, and only that set.
+      first = hd(data)
+
+      assert Map.keys(first) |> Enum.sort() ==
+               ~w(agent_id body host id inserted_at key refs session_id updated_at)
+
+      assert first["agent_id"] == agent.id
+    end
+
+    # TC-39.3.2
+    test "one expired + one live -> only the live post" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, agent} = agent_key(tenant)
+
+      {:ok, live} =
+        Coordination.create_post(tenant.id, project.id, agent.id, %{"body" => "live"})
+
+      {:ok, expired} =
+        Coordination.create_post(tenant.id, project.id, agent.id, %{"body" => "expired"})
+
+      # Force the second post's expires_at into the past (an expired-but-not-swept row).
+      {:ok, _} =
+        expired
+        |> Ecto.Changeset.change(expires_at: DateTime.add(DateTime.utc_now(), -60, :second))
+        |> AdminRepo.update()
+
+      conn = authed_conn(raw) |> get(@path, %{"project_id" => project.id})
+      assert %{"data" => [post]} = json_response(conn, 200)
+      assert post["id"] == live.id
+      assert post["body"] == "live"
+    end
+
+    # TC-39.3.3
+    test "posts at t1 and t3; since=t2 -> only t3" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, agent} = agent_key(tenant)
+
+      base = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+      t2 = DateTime.add(base, -200, :second)
+      seed_post(tenant, project, agent.id, "old", DateTime.add(base, -300, :second))
+      seed_post(tenant, project, agent.id, "new", DateTime.add(base, -100, :second))
+
+      conn =
+        authed_conn(raw)
+        |> get(@path, %{"project_id" => project.id, "since" => DateTime.to_iso8601(t2)})
+
+      assert %{"data" => [post]} = json_response(conn, 200)
+      assert post["body"] == "new"
+    end
+
+    # TC-39.3.4 — oracle-safety: cross-tenant AND nonexistent both 200 empty,
+    # byte-identical to each other (and to an owned-but-empty channel).
+    test "cross-tenant AND nonexistent project_id both 200 with an identical empty envelope" do
+      tenant = fixture(:tenant)
+      {raw, _key, _agent} = agent_key(tenant)
+
+      other = fixture(:tenant)
+      foreign = fixture(:project, %{tenant_id: other.id})
+
+      cross = authed_conn(raw) |> get(@path, %{"project_id" => foreign.id})
+      missing = authed_conn(raw) |> get(@path, %{"project_id" => Ecto.UUID.generate()})
+
+      cross_body = json_response(cross, 200)
+      missing_body = json_response(missing, 200)
+
+      assert cross_body == %{"data" => [], "meta" => %{"limit" => 25, "count" => 0}}
+      assert cross_body == missing_body
+
+      # And identical to an owned-but-empty project of the caller's own tenant.
+      own_empty = fixture(:project, %{tenant_id: tenant.id})
+      owned = authed_conn(raw) |> get(@path, %{"project_id" => own_empty.id})
+      assert json_response(owned, 200) == cross_body
+    end
+
+    # TC-39.3.5
+    test "150 live posts, limit=1000 -> exactly 100 returned (clamped, not a 400)" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, agent} = agent_key(tenant)
+
+      for n <- 1..150 do
+        {:ok, _} =
+          Coordination.create_post(tenant.id, project.id, agent.id, %{"body" => "p#{n}"})
+      end
+
+      conn = authed_conn(raw) |> get(@path, %{"project_id" => project.id, "limit" => "1000"})
+      assert %{"data" => data, "meta" => meta} = json_response(conn, 200)
+      assert length(data) == 100
+      assert meta["limit"] == 100
+      assert meta["count"] == 100
+    end
+
+    test "another tenant's posts are never visible (tenant isolation)" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, agent} = agent_key(tenant)
+
+      {:ok, _} =
+        Coordination.create_post(tenant.id, project.id, agent.id, %{"body" => "mine"})
+
+      other = fixture(:tenant)
+      other_project = fixture(:project, %{tenant_id: other.id})
+      other_agent = fixture(:agent, %{tenant_id: other.id})
+
+      {:ok, _} =
+        Coordination.create_post(other.id, other_project.id, other_agent.id, %{
+          "body" => "theirs"
+        })
+
+      # The caller sees only its own post on its own channel...
+      conn = authed_conn(raw) |> get(@path, %{"project_id" => project.id})
+      assert %{"data" => [post]} = json_response(conn, 200)
+      assert post["body"] == "mine"
+
+      # ...and gets an empty list for the other tenant's channel (oracle-safe).
+      cross = authed_conn(raw) |> get(@path, %{"project_id" => other_project.id})
+      assert %{"data" => []} = json_response(cross, 200)
+    end
+
+    test "the read requires agent role (an unauthenticated caller cannot read)" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+
+      conn =
+        build_conn()
+        |> put_req_header("x-loopctl-last-known-sth", @sth_header)
+        |> get(@path, %{"project_id" => project.id})
 
       assert conn.status in [401, 403]
     end

--- a/test/loopctl_web/plugs/rate_limiter_test.exs
+++ b/test/loopctl_web/plugs/rate_limiter_test.exs
@@ -4,6 +4,7 @@ defmodule LoopctlWeb.Plugs.RateLimiterTest do
   setup :verify_on_exit!
 
   alias Loopctl.Auth.ApiKey
+  alias Loopctl.RateLimiter.FailOpenLog
   alias LoopctlWeb.Plugs.RateLimiter
 
   defp auth_conn(conn, raw_key) do
@@ -133,6 +134,15 @@ defmodule LoopctlWeb.Plugs.RateLimiterTest do
 
       tenant = fixture(:tenant)
       {raw_key, _key} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      # The fail-open warning is throttled per `(source, family)` in a shared,
+      # node-local ETS window that lives for the whole run. A concurrent async
+      # test whose pipeline plug tripped a `(:plug, "key")`/`(:plug, "tenant")`
+      # fail-open within the last 60s would otherwise suppress THIS test's warning
+      # and make the log assertion flaky. Clear our two families so the emission
+      # is deterministic (the plug checks the key bucket, then the tenant bucket).
+      FailOpenLog.reset(:plug, "key")
+      FailOpenLog.reset(:plug, "tenant")
 
       log =
         capture_log(fn ->


### PR DESCRIPTION
## US-39.3 — channel_recent read endpoint

Adds the READ half of the Repo Coordination Bus (Epic 39, the third memory plane), on top of US-39.1 (schema + recent/3) and US-39.2 (write endpoint).

`GET /api/v1/channel/posts?project_id=&since=&limit=` — agent-role, tenant-scoped, oracle-safe read of a project channel's live posts, newest-first.

### Acceptance criteria
- **AC-39.3.1** RequireRole :agent, tenant-scoped from the key, `inserted_at DESC` (tie-broken by seq). OpenApiSpex `operation(:index)` declared.
- **AC-39.3.2** Only live posts — `expires_at > now()` filtered defensively, independent of the TTL sweep.
- **AC-39.3.3** `since` (ISO8601) filters `GREATEST(inserted_at, updated_at) > since`; `limit` defaults to 25, clamped to 100 (not a 400).
- **AC-39.3.4** Oracle-safe: a cross-tenant OR nonexistent `project_id` returns 200 with a byte-identical empty envelope — never 404, never a distinguishable body.
- **AC-39.3.5** Each post carries exactly `id, agent_id, session_id, host, key, body, refs, inserted_at, updated_at`.
- **AC-39.3.6** Standard `{data, meta}` envelope; `meta` carries applied `limit` and `count`.
- **AC-39.3.7** AdminRepo + explicit `tenant_id` filter (already satisfied by `recent/3`).

### Reconciliation
US-39.1 shipped the recent-limit constants at 50/200; the story technical_notes and AC-39.3.3 specify default 25 / cap 100. Changed the two module constants accordingly — verified no existing test locked the old values.

### Tests
Context: since-delta (including an updated_at that advanced past the cursor), ISO8601 string parsing, malformed-since no-op, default 25, clamp to 100. Endpoint: TC-39.3.1–TC-39.3.5 verbatim plus tenant isolation and agent-role gating.

`mix precommit` green (5040 tests, 0 failures).
