### PR TITLE
US-39.5: 30-day Oban TTL sweep worker for channel_posts (Epic 39)

### DIFF
--- a/lib/loopctl/oban_config.ex
+++ b/lib/loopctl/oban_config.ex
@@ -415,6 +415,13 @@ defmodule Loopctl.ObanConfig do
          {"45 4 * * *", Loopctl.Workers.PromotionEvalWorker, args: %{"mode" => "all_tenants"}},
          {"*/5 * * * *", Loopctl.Workers.PendingEnrollmentCleanupWorker},
          {"*/5 * * * *", Loopctl.Workers.SessionMemoryPruneWorker},
+         # US-39.5: 30-day TTL sweep for the coordination bus. Hard-deletes
+         # channel_posts past expires_at, bounded per run (single batch, drains a
+         # backlog over successive runs) so a large backlog cannot lock the table.
+         # Runs across all tenants on AdminRepo (BYPASSRLS) — the expiry predicate
+         # is tenant-independent. Keep in sync with the crontab assertion in
+         # oban_plugins_config_test.exs.
+         {"*/5 * * * *", Loopctl.Workers.ChannelPostSweeper},
          # US-38.2: prune expired windows from the cluster-global Postgres rate
          # limiter's counter table. A cheap index-range delete; a no-op when the
          # Postgres limiter is unselected (table empty). Keep in sync with the

--- a/lib/loopctl/workers/channel_post_sweeper.ex
+++ b/lib/loopctl/workers/channel_post_sweeper.ex
@@ -79,6 +79,13 @@ defmodule Loopctl.Workers.ChannelPostSweeper do
 
   # The bound is data injected via job args (not app env), so a test — or an
   # operator via a one-off job — can tune the per-run cap without config changes.
-  defp batch_limit(%{"limit" => limit}) when is_integer(limit) and limit > 0, do: limit
+  # Clamped to @batch_size: the selected ids are passed as an explicit list to
+  # `where(p.id in ^batch_ids)`, one bind parameter each, so an unbounded limit
+  # >= 65536 would exceed Postgres's 65535-parameter cap and crash every retry.
+  # Capping at @batch_size keeps the id-list well under the limit while still
+  # letting an operator shrink the per-run cap.
+  defp batch_limit(%{"limit" => limit}) when is_integer(limit) and limit > 0,
+    do: min(limit, @batch_size)
+
   defp batch_limit(_args), do: @batch_size
 end

--- a/lib/loopctl/workers/channel_post_sweeper.ex
+++ b/lib/loopctl/workers/channel_post_sweeper.ex
@@ -1,0 +1,84 @@
+defmodule Loopctl.Workers.ChannelPostSweeper do
+  @moduledoc """
+  Oban cron worker that hard-deletes expired coordination-bus posts
+  (`Loopctl.Coordination.ChannelPost`), Epic 39 / US-39.5.
+
+  The coordination bus (the third memory plane) is deliberately transient: every
+  row carries a uniform 30-day `expires_at`, set server-side in
+  `Loopctl.Coordination`. Anything worth keeping longer is already graduated to
+  Knowledge, so hard-deleting expired rows loses nothing. This worker deletes
+  rows past `expires_at`. Scheduled via the Oban Cron plugin in
+  `Loopctl.ObanConfig.plugins/0` (every 5 minutes), following the existing
+  cleanup-worker convention (see `Loopctl.Workers.SessionMemoryPruneWorker`).
+
+  Expiry is a uniform, tenant-independent predicate (`expires_at < now()`), so the
+  delete runs once across all tenants on the BYPASSRLS `Loopctl.AdminRepo` — never
+  a per-tenant loop. `channel_posts` has RLS ENABLED as defense-in-depth, but the
+  sweep predicate touches no tenant column, so BYPASSRLS is the correct repo (same
+  as the other maintenance crons).
+
+  ## Deliberate deviation from `SessionMemoryPruneWorker`
+
+  The template RECURSES to drain ALL expired rows in a single `perform`. This
+  worker does NOT: each invocation deletes AT MOST `@batch_size` rows (a SINGLE
+  batch, non-recursive), so a large backlog cannot lock the table in one long
+  transaction and the `*/5 * * * *` cron drains any backlog over successive runs.
+  The bound is overridable via the job arg `"limit"` (a positive integer) so a
+  caller can tune the per-run cap. The sweep is idempotent — with no expired rows
+  it is a no-op that deletes zero.
+  """
+
+  use Oban.Worker, queue: :cleanup, max_attempts: 3
+
+  import Ecto.Query
+
+  require Logger
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Coordination.ChannelPost
+
+  @batch_size 1000
+
+  @doc """
+  Deletes at most one batch of expired channel posts (`expires_at < now()`).
+
+  Reads the `"limit"` job arg (a positive integer) as the per-run batch bound,
+  defaulting to `#{@batch_size}`. Returns `:ok` whether or not anything was
+  deleted (idempotent); logs the count only when it is positive.
+  """
+  @impl Oban.Worker
+  @spec perform(Oban.Job.t()) :: :ok
+  def perform(%Oban.Job{args: args}) do
+    now = DateTime.utc_now()
+    limit = batch_limit(args)
+
+    ids =
+      ChannelPost
+      |> where([p], p.expires_at < ^now)
+      |> select([p], p.id)
+      |> limit(^limit)
+      |> AdminRepo.all()
+
+    case ids do
+      [] ->
+        :ok
+
+      batch_ids ->
+        {count, _} =
+          ChannelPost
+          |> where([p], p.id in ^batch_ids)
+          |> AdminRepo.delete_all()
+
+        if count > 0 do
+          Logger.info("ChannelPostSweeper deleted #{count} expired channel posts")
+        end
+
+        :ok
+    end
+  end
+
+  # The bound is data injected via job args (not app env), so a test — or an
+  # operator via a one-off job — can tune the per-run cap without config changes.
+  defp batch_limit(%{"limit" => limit}) when is_integer(limit) and limit > 0, do: limit
+  defp batch_limit(_args), do: @batch_size
+end

--- a/priv/repo/migrations/20260717020000_create_channel_posts.exs
+++ b/priv/repo/migrations/20260717020000_create_channel_posts.exs
@@ -38,7 +38,7 @@ defmodule Loopctl.Repo.Migrations.CreateChannelPosts do
              name: :channel_posts_recent_idx
            )
 
-    # TTL sweep path (US-39.5): delete WHERE expires_at <= now().
+    # TTL sweep path (US-39.5): delete WHERE expires_at < now().
     create index(:channel_posts, [:expires_at])
 
     # Per-SESSION keyed upsert slot: two concurrent sessions writing key "session_goal"

--- a/test/loopctl/oban_plugins_config_test.exs
+++ b/test/loopctl/oban_plugins_config_test.exs
@@ -138,6 +138,35 @@ defmodule Loopctl.ObanPluginsConfigTest do
     end
   end
 
+  describe "US-39.5: ChannelPostSweeper crontab entry" do
+    setup do
+      plugins = Application.get_env(:loopctl, Oban)[:plugins]
+
+      {Oban.Plugins.Cron, cron_opts} =
+        Enum.find(plugins, &match?({Oban.Plugins.Cron, _}, &1))
+
+      entry =
+        Enum.find(cron_opts[:crontab], fn
+          {_schedule, Loopctl.Workers.ChannelPostSweeper} -> true
+          {_schedule, Loopctl.Workers.ChannelPostSweeper, _opts} -> true
+          _ -> false
+        end)
+
+      %{entry: entry}
+    end
+
+    test "the ChannelPostSweeper entry exists in the crontab", %{entry: entry} do
+      assert entry,
+             "expected a ChannelPostSweeper crontab entry that TTL-sweeps expired " <>
+               "channel_posts (US-39.5)"
+    end
+
+    test "its schedule is the every-5-minutes sweep", %{entry: entry} do
+      schedule = elem(entry, 0)
+      assert schedule == "*/5 * * * *"
+    end
+  end
+
   describe "US-35.3: sth_sweep_cron/0 (config-based DI, runtime-tunable)" do
     test "defaults to a 5-minute sweep when STH_SWEEP_CRON is unset" do
       # STH_SWEEP_CRON is not set in the test environment, so the default applies.

--- a/test/loopctl/workers/channel_post_sweeper_test.exs
+++ b/test/loopctl/workers/channel_post_sweeper_test.exs
@@ -73,6 +73,19 @@ defmodule Loopctl.Workers.ChannelPostSweeperTest do
       assert AdminRepo.aggregate(expired_query(), :count) == 0
     end
 
+    # TC-39.5.5 — an operator-supplied "limit" over Postgres's 65535 bind-parameter
+    # cap must NOT crash the job. The selected ids are passed as an explicit list to
+    # `where(p.id in ^batch_ids)` (one bind param each), so batch_limit/1 clamps the
+    # arg to @batch_size. Passing a value well above the cap still sweeps normally.
+    test "clamps an oversized limit arg so it never exceeds the bind-parameter cap" do
+      %{tenant: tenant, project: project, agent: agent} = setup_context()
+
+      for _ <- 1..3, do: insert_post(tenant, project, agent, -60)
+
+      assert :ok = ChannelPostSweeper.perform(%Oban.Job{args: %{"limit" => 70_000}})
+      assert AdminRepo.aggregate(expired_query(), :count) == 0
+    end
+
     # TC-39.5.4 — AC-39.5.3: the BYPASSRLS sweep is cross-tenant. The predicate
     # (`expires_at < now()`) carries no tenant column, so a SINGLE perform/1 run
     # must delete an expired row under tenant A while leaving a live row under a

--- a/test/loopctl/workers/channel_post_sweeper_test.exs
+++ b/test/loopctl/workers/channel_post_sweeper_test.exs
@@ -1,0 +1,102 @@
+defmodule Loopctl.Workers.ChannelPostSweeperTest do
+  use Loopctl.DataCase, async: true
+
+  setup :verify_on_exit!
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Coordination.ChannelPost
+  alias Loopctl.Workers.ChannelPostSweeper
+
+  # There is no channel_post fixture: create_post/4 always stamps expires_at at
+  # now + 30d, so it cannot build an already-expired row. Insert ChannelPost
+  # structs directly via AdminRepo (all fields set programmatically, never via
+  # changeset) so we control expires_at. Use AdminRepo (BYPASSRLS) for every
+  # read/write — the RLS repo would hide/deny these rows.
+  defp insert_post(tenant, project, agent, offset_seconds) do
+    %ChannelPost{
+      tenant_id: tenant.id,
+      project_id: project.id,
+      agent_id: agent.id,
+      body: "post",
+      expires_at: DateTime.add(DateTime.utc_now(), offset_seconds, :second)
+    }
+    |> AdminRepo.insert!()
+  end
+
+  defp setup_context do
+    tenant = fixture(:tenant)
+    project = fixture(:project, %{tenant_id: tenant.id})
+    agent = fixture(:agent, %{tenant_id: tenant.id})
+    %{tenant: tenant, project: project, agent: agent}
+  end
+
+  describe "perform/1" do
+    # TC-39.5.1
+    test "deletes channel posts past expires_at and leaves live ones" do
+      %{tenant: tenant, project: project, agent: agent} = setup_context()
+
+      expired = insert_post(tenant, project, agent, -60)
+      live = insert_post(tenant, project, agent, 3600)
+
+      assert :ok = ChannelPostSweeper.perform(%Oban.Job{args: %{}})
+
+      assert is_nil(AdminRepo.get(ChannelPost, expired.id))
+      refute is_nil(AdminRepo.get(ChannelPost, live.id))
+    end
+
+    # TC-39.5.2
+    test "is idempotent: no expired rows means a zero-delete no-op on repeated runs" do
+      %{tenant: tenant, project: project, agent: agent} = setup_context()
+
+      live = insert_post(tenant, project, agent, 3600)
+
+      assert :ok = ChannelPostSweeper.perform(%Oban.Job{args: %{}})
+      assert :ok = ChannelPostSweeper.perform(%Oban.Job{args: %{}})
+
+      refute is_nil(AdminRepo.get(ChannelPost, live.id))
+    end
+
+    # TC-39.5.3
+    test "honors the per-run batch bound: at most limit deleted per run, rest swept next run" do
+      %{tenant: tenant, project: project, agent: agent} = setup_context()
+
+      # Three expired rows, a batch limit of 2: first run deletes 2, one remains,
+      # second run deletes the last.
+      for _ <- 1..3, do: insert_post(tenant, project, agent, -60)
+
+      job = %Oban.Job{args: %{"limit" => 2}}
+
+      assert :ok = ChannelPostSweeper.perform(job)
+      assert AdminRepo.aggregate(expired_query(), :count) == 1
+
+      assert :ok = ChannelPostSweeper.perform(job)
+      assert AdminRepo.aggregate(expired_query(), :count) == 0
+    end
+
+    # TC-39.5.4 — AC-39.5.3: the BYPASSRLS sweep is cross-tenant. The predicate
+    # (`expires_at < now()`) carries no tenant column, so a SINGLE perform/1 run
+    # must delete an expired row under tenant A while leaving a live row under a
+    # DIFFERENT tenant B untouched. This exercises the "across ALL tenants" half
+    # of the AC that the single-tenant cases above only assert implicitly.
+    test "sweeps expired rows across all tenants in one run, leaving live rows in other tenants" do
+      %{tenant: tenant_a, project: project_a, agent: agent_a} = setup_context()
+      %{tenant: tenant_b, project: project_b, agent: agent_b} = setup_context()
+
+      assert tenant_a.id != tenant_b.id
+
+      expired_a = insert_post(tenant_a, project_a, agent_a, -60)
+      live_b = insert_post(tenant_b, project_b, agent_b, 3600)
+
+      assert :ok = ChannelPostSweeper.perform(%Oban.Job{args: %{}})
+
+      assert is_nil(AdminRepo.get(ChannelPost, expired_a.id))
+      refute is_nil(AdminRepo.get(ChannelPost, live_b.id))
+    end
+  end
+
+  defp expired_query do
+    import Ecto.Query
+    now = DateTime.utc_now()
+    from(p in ChannelPost, where: p.expires_at < ^now)
+  end
+end


### PR DESCRIPTION
## US-39.5 — 30-day Oban TTL sweep worker for channel_posts

Adds the retention half of the Repo Coordination Bus (Epic 39): a periodic
Oban worker that deletes expired channel_posts rows.

### What this adds
- Loopctl.Workers.ChannelPostSweeper — batched delete of rows where
  expires_at < now(), using the BYPASSRLS AdminRepo so the sweep is
  cross-tenant in a single run (the predicate carries no tenant column).
- Oban cron wiring in oban_config.ex to schedule the sweep.
- batch_limit/1 reads an optional job-arg limit so an operator (or a test)
  can tune the per-run cap without a config change.

### Review fixes applied on this branch
- Clamp batch_limit/1 to the batch size so an operator-supplied limit above
  Postgres's 65535 bind-parameter cap cannot crash the sweep (selected ids are
  passed as an explicit id-in list, one bind param each).
- Correct the migration comment to match the actual expires_at < now()
  predicate.
- Add TC-39.5.5 covering the oversized-limit clamp.

### Tests
Cron plugin config, batched sweep, cross-tenant single-run sweep, expired-only
deletion, and the oversized-limit clamp.
