### PR TITLE
MCP tools channel_post + channel_recent (Node proxy, agent key) + publish

### DIFF
--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to `loopctl-mcp-server` are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 2.47.0 — 2026-07-18 (repo coordination bus tools)
+
+### Added
+
+- **`channel_post`** — post a coordination message to a repo coordination channel
+  (Epic 39 Repo Coordination Bus) over `POST /api/v1/channel/posts` on the agent
+  key. A channel IS a `project_id` (a work project or a kb scope); posts are
+  tenant-isolated by RLS. This is an agent-role coordination surface, not
+  chain-of-custody. `host` is auto-filled from the proxy's `os.hostname()` and
+  `session_id` from the Claude Code session id (`CLAUDE_SESSION_ID`) — both
+  proxy-supplied and informational (never caller args). Pass a `key` to upsert your
+  per-session working-state slot instead of appending a new post; pass optional
+  `refs` (`{file, pr, branch, commit}`).
+- **`channel_recent`** — read recent posts from a repo coordination channel over
+  `GET /api/v1/channel/posts` on the agent key. RLS returns only your own tenant's
+  channel (oracle-safe read). Supports `since` (a full ISO8601 instant) and `limit`
+  (default 25, max 100).
+
 ## 2.46.0 — 2026-07-18 (high-reject-rate ingestion anomalies)
 
 ### Changed

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -121,7 +121,7 @@ REST endpoint (`PATCH /api/v1/tenants/me/llm-config`), and the docs — so you (
 autonomous agent) can self-remediate without a human. Full agent-tenant lifecycle:
 [`docs/onboarding-agent-tenant.md`](../docs/onboarding-agent-tenant.md).
 
-## Tools (89)
+## Tools (95)
 
 > Plus **per-tenant generated Context Retriever tools** (`cr_*`) appended
 > dynamically at runtime — see [Dynamic per-tenant Context Retriever
@@ -138,6 +138,25 @@ autonomous agent) can self-remediate without a human. Full agent-tenant lifecycl
 | `delete_project` | **Requires `LOOPCTL_USER_KEY`.** Delete a project and all of its dependent resources (epics, stories, audit entries). Irreversible — orchestrator role is not sufficient. |
 | `get_progress` | Get progress summary for a project, including story counts by status. Pass `include_cost=true` for cost data. |
 | `import_stories` | Import stories into a project from a structured payload (Epic 12 import format). Pass `merge: true` to add stories to epics that already exist (otherwise duplicates return 409). For large payloads, use `payload_path` to read JSON from disk instead of passing it inline. |
+
+### KB Scope Tools (agent key)
+
+Knowledge-only project scopes (`kind: kb`) partition knowledge articles by repo. Unlike `create_project` (work project, orchestrator+ / human-anchored), these are available to an agent-rooted (KB-tier) tenant on an agent key and carry NO chain-of-custody / work-breakdown surface.
+
+| Tool | Description |
+|---|---|
+| `create_kb_scope` | Create a knowledge-only project scope (`kind: kb`) for the current tenant. A kb scope cannot host epics/stories/dispatch/ui-tests — it exists only to partition knowledge articles by repo. Resolve it via `resolve_project` and pass the returned id as `project_id` on article/knowledge writes. Counts toward the tenant's `max_projects` budget. |
+| `archive_kb_scope` | Archive (reversible soft-delete) a kb scope you own. Frees the scope's slot in the tenant's `max_projects` budget; its articles remain readable/writable. Rejects a `kind: work` project (422). Idempotent on an already-archived scope. |
+| `restore_kb_scope` | Restore (re-activate) an archived kb scope you own — the reverse of `archive_kb_scope`. Consumes an active `max_projects` slot, so it is rejected (422) when the tenant is at its cap. Rejects a `kind: work` project (422). |
+
+### Repo Coordination Tools (agent key)
+
+Epic 39 Repo Coordination Bus — a lightweight, tenant-isolated channel for agents to share working state. A channel IS a `project_id` (a work project or a kb scope); posts are RLS-scoped to the caller's tenant, so this is an agent-role coordination surface, not a chain-of-custody gate.
+
+| Tool | Description |
+|---|---|
+| `channel_post` | Post a message to a repo coordination channel. Provide a `key` to upsert your per-session working-state slot (200) instead of appending a new post (201); omit it to append. `host` and `session_id` are proxy-supplied — do NOT pass them. Optional structured `refs` map (`file`, `pr`, `branch`, `commit`). Required: `project_id`, `body`. |
+| `channel_recent` | Read recent posts from a repo coordination channel — RLS returns only your own tenant's channel (oracle-safe read). Use `since` (a full ISO8601 instant) to page forward and `limit` to cap results (default 25, max 100). Required: `project_id`. |
 
 ### Story Tools
 
@@ -323,6 +342,10 @@ Key distribution for the dispatch pattern (Epic 26): per-dispatch ephemeral keys
 | `dispatch` | Mint an ephemeral, scoped api_key for a sub-agent dispatch, carrying its lineage path. The `raw_key` is returned ONCE — pass it to the sub-agent's launch args, never store it in env vars; it expires after `expires_in_seconds` (default 3600, max 14400). Required: `role` (`agent`/`orchestrator`), `agent_id`. Optional: `parent_dispatch_id`, `story_id`. |
 | `recover_cap` | Re-mint a capability token for a story you're assigned to, after a session crash lost your cap. Required: `story_id`. Optional: `cap_type` (`start_cap`/`report_cap`, default `start_cap`), `lineage`. |
 | `get_sth` | Get the latest Signed Tree Head for a tenant's tamper-evident audit chain. Public — no auth required. Required: `tenant_id`. |
+| `request_authenticator_challenge` | **US-26.7.2.** Step 1 of the opt-in WebAuthn trust-tier upgrade ceremony: issues a registration challenge for enrolling a hardware authenticator against an EXISTING agent-rooted (KB-tier) tenant, promoting it to `human_anchored` on success. Requires an interactive WebAuthn client. |
+| `enroll_authenticator` | Step 2 of the WebAuthn trust-tier upgrade ceremony: completes enrollment with the attestation produced by `navigator.credentials.create()` against the challenge from `request_authenticator_challenge`. On a tenant's first enrollment the tenant is promoted to `human_anchored`. |
+| `request_authenticator_revoke_challenge` | Issues a fresh-assertion challenge to authorize revoking one of a tenant's enrolled WebAuthn authenticators. Requires an interactive WebAuthn client + human touch to produce the assertion `revoke_authenticator` needs. |
+| `revoke_authenticator` | Revokes an enrolled authenticator using the assertion from `request_authenticator_revoke_challenge` (`navigator.credentials.get()` against an existing authenticator — human touch required). Refuses (409 `last_authenticator`) when it would leave a human-anchored tenant with no authenticators. |
 
 ## Wiki Attribution
 

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -437,6 +437,46 @@ async function restoreKbScope({ project_id }) {
   return toContent(result);
 }
 
+async function channelPost({ project_id, body, key, refs }) {
+  // Repo Coordination Bus (Epic 39): post a coordination message to a channel
+  // (a channel IS a project_id — a work project or a kb scope). Agent-role, RLS
+  // tenant-scoped — posting to your own tenant's channel is coordination, NOT
+  // self-approval (owner decision #331), so it carries no chain-of-custody authority.
+  const payload = { project_id, body };
+  if (key) payload.key = key;
+  if (refs) payload.refs = refs;
+  // host + session_id are proxy-filled (NOT caller args). host from os.hostname();
+  // session_id from CLAUDE_SESSION_ID (the SAME id SessionStart sees) so US-39.6
+  // self-dedup can skip a session's own echoed posts. Omit session_id entirely when
+  // unset — it is client-supplied + informational, never a security dependency.
+  payload.host = os.hostname();
+  if (process.env.CLAUDE_SESSION_ID) payload.session_id = process.env.CLAUDE_SESSION_ID;
+  const result = await apiCall(
+    "POST",
+    "/api/v1/channel/posts",
+    payload,
+    process.env.LOOPCTL_AGENT_KEY,
+  );
+  return toContent(result);
+}
+
+async function channelRecent({ project_id, since, limit }) {
+  // Read recent coordination posts for a channel (project_id) on the AGENT key.
+  // Oracle-safe read: returns the tenant's own channel only (RLS). `since` is a full
+  // ISO8601 instant (date-only is ignored server-side); limit defaults to 25, max 100.
+  const params = new URLSearchParams();
+  if (project_id) params.set("project_id", project_id);
+  if (since) params.set("since", since);
+  if (limit) params.set("limit", limit);
+  const result = await apiCall(
+    "GET",
+    `/api/v1/channel/posts?${params}`,
+    null,
+    process.env.LOOPCTL_AGENT_KEY,
+  );
+  return toContent(result);
+}
+
 async function deleteProject({ project_id }) {
   const result = await apiCall(
     "DELETE",
@@ -2203,6 +2243,62 @@ const TOOLS = [
       type: "object",
       properties: {
         project_id: { type: "string", description: "UUID of the archived :kb scope to restore." },
+      },
+      required: ["project_id"],
+    },
+  },
+  {
+    name: "channel_post",
+    description:
+      "Post a message to a repo coordination channel (Epic 39 Repo Coordination Bus) on the agent key. A channel IS a project_id (a work project or a kb scope); posts are tenant-isolated by RLS. This is an agent-role COORDINATION surface, not chain-of-custody — posting to your own tenant's channel is not self-approval. host is auto-filled from the proxy's os.hostname() and session_id is auto-filled from the Claude Code session id (both proxy-supplied, informational only — do NOT pass them). Provide a key to upsert your per-session working-state slot (200) instead of appending a new post (201); omit it to append.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        project_id: {
+          type: "string",
+          description: "UUID of the channel (a work project or kb scope) to post to.",
+        },
+        body: { type: "string", description: "The coordination message body." },
+        key: {
+          type: "string",
+          description:
+            "Optional per-session working-state slot key. When given, upserts the caller's slot for that key instead of appending a new post.",
+        },
+        refs: {
+          type: "object",
+          description:
+            "Optional structured references map: { file, pr, branch, commit }.",
+          properties: {
+            file: { type: "string" },
+            pr: { type: "string" },
+            branch: { type: "string" },
+            commit: { type: "string" },
+          },
+        },
+      },
+      required: ["project_id", "body"],
+    },
+  },
+  {
+    name: "channel_recent",
+    description:
+      "Read recent posts from a repo coordination channel (Epic 39 Repo Coordination Bus) on the agent key. A channel IS a project_id; RLS returns only your own tenant's channel, so this is an oracle-safe read. Use since (a full ISO8601 instant) to page forward from a known point and limit to cap results (default 25, max 100).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        project_id: {
+          type: "string",
+          description: "UUID of the channel (a work project or kb scope) to read.",
+        },
+        since: {
+          type: "string",
+          description:
+            "Optional ISO8601 instant; return posts newer than this (date-only is ignored server-side).",
+        },
+        limit: {
+          type: "integer",
+          description: "Optional max posts to return (default 25, max 100).",
+        },
       },
       required: ["project_id"],
     },
@@ -5016,6 +5112,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     case "restore_kb_scope":
       return await restoreKbScope(args);
+
+    case "channel_post":
+      return await channelPost(args);
+
+    case "channel_recent":
+      return await channelRecent(args);
 
     case "delete_project":
       return await deleteProject(args);

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -2262,7 +2262,7 @@ const TOOLS = [
         key: {
           type: "string",
           description:
-            "Optional per-session working-state slot key. When given, upserts the caller's slot for that key instead of appending a new post.",
+            "Optional per-session working-state slot key. When given, upserts the caller's slot for that key instead of appending a new post. Requires an active Claude Code session: the upsert is keyed on the auto-filled session_id (from CLAUDE_SESSION_ID), so a keyed post made outside a Claude Code session — where that env var is absent — is rejected with a 422 (session_id can't be blank). Omit key to append a plain post, which needs no session.",
         },
         refs: {
           type: "object",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.46.0",
+  "version": "2.47.0",
   "description": "MCP server for loopctl — structural trust for AI development loops",
   "type": "module",
   "main": "index.js",

--- a/mcp-server/test/mcp_arg_forwarding.test.js
+++ b/mcp-server/test/mcp_arg_forwarding.test.js
@@ -140,6 +140,65 @@ describe("#418: create_kb_scope wiring", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// #39.4: channel_post / channel_recent (Repo Coordination Bus proxy tools)
+// ---------------------------------------------------------------------------
+
+describe("#39.4: channel_post / channel_recent wiring", () => {
+  test("TOOLS declares channel_post and channel_recent", () => {
+    assert.match(INDEX_SRC, /name: "channel_post",/, 'must declare a "channel_post" tool');
+    assert.match(INDEX_SRC, /name: "channel_recent",/, 'must declare a "channel_recent" tool');
+  });
+
+  test("channelPost POSTs /channel/posts on the AGENT key", () => {
+    assert.match(
+      INDEX_SRC,
+      /async function channelPost\([\s\S]*?"POST",\s*"\/api\/v1\/channel\/posts",\s*payload,\s*process\.env\.LOOPCTL_AGENT_KEY/,
+      "channelPost must POST /api/v1/channel/posts with the agent key",
+    );
+  });
+
+  test("channelPost auto-fills host from os.hostname()", () => {
+    assert.match(
+      INDEX_SRC,
+      /async function channelPost\([\s\S]*?payload\.host = os\.hostname\(\)/,
+      "channelPost must set host from os.hostname()",
+    );
+  });
+
+  test("channelPost auto-fills session_id from CLAUDE_SESSION_ID when set", () => {
+    assert.match(
+      INDEX_SRC,
+      /async function channelPost\([\s\S]*?if \(process\.env\.CLAUDE_SESSION_ID\) payload\.session_id = process\.env\.CLAUDE_SESSION_ID/,
+      "channelPost must fill session_id from CLAUDE_SESSION_ID only when set",
+    );
+  });
+
+  test("channelRecent GETs /channel/posts on the AGENT key", () => {
+    assert.match(
+      INDEX_SRC,
+      /async function channelRecent\([\s\S]*?"GET",\s*`\/api\/v1\/channel\/posts\?\$\{params\}`,\s*null,\s*process\.env\.LOOPCTL_AGENT_KEY/,
+      "channelRecent must GET /api/v1/channel/posts with a query string on the agent key",
+    );
+  });
+
+  test("the channel_post dispatch case calls channelPost(args)", () => {
+    assert.match(
+      INDEX_SRC,
+      /case "channel_post":\s*\n\s*return await channelPost\(args\);/,
+      "the channel_post dispatch case must call channelPost(args)",
+    );
+  });
+
+  test("the channel_recent dispatch case calls channelRecent(args)", () => {
+    assert.match(
+      INDEX_SRC,
+      /case "channel_recent":\s*\n\s*return await channelRecent\(args\);/,
+      "the channel_recent dispatch case must call channelRecent(args)",
+    );
+  });
+});
+
 describe("KB-scope lifecycle: archive_kb_scope / restore_kb_scope wiring", () => {
   test("TOOLS declares archive_kb_scope and restore_kb_scope", () => {
     assert.match(INDEX_SRC, /name: "archive_kb_scope",/, 'must declare "archive_kb_scope"');

--- a/mcp-server/test/mcp_arg_forwarding.test.js
+++ b/mcp-server/test/mcp_arg_forwarding.test.js
@@ -182,6 +182,17 @@ describe("#39.4: channel_post / channel_recent wiring", () => {
     );
   });
 
+  test("the channel_post `key` property documents its active-session dependency", () => {
+    // A keyed upsert is keyed on the auto-filled session_id (from CLAUDE_SESSION_ID),
+    // which the server makes REQUIRED for keyed posts. Outside a Claude Code session
+    // that env var is absent and the post 422s — the description must warn about it.
+    assert.match(
+      INDEX_SRC,
+      /Optional per-session working-state slot key[\s\S]*?Requires an active Claude Code session[\s\S]*?422/,
+      "the channel_post `key` description must document that keyed posts require an active session (422 otherwise)",
+    );
+  });
+
   test("the channel_post dispatch case calls channelPost(args)", () => {
     assert.match(
       INDEX_SRC,


### PR DESCRIPTION
## US-39.4 — MCP tools channel_post + channel_recent (Node proxy, agent key) + publish

Adds two Node MCP proxy tools that map 1:1 onto the already-shipped Repo
Coordination Bus HTTP endpoints (US-39.2/39.3). Node-only change (mcp-server/);
no Elixir edits. Mirrors the existing create_kb_scope tool shape.

### What changed
- **channel_post(project_id, body, key?, refs?)** — POSTs to /api/v1/channel/posts
  on the agent key. host is auto-filled from os.hostname(); session_id is
  auto-filled from CLAUDE_SESSION_ID (the same identifier SessionStart sees, so
  US-39.6 self-dedup can match) and omitted entirely when unset. Both are
  proxy-filled, never caller arguments. Optional key upserts a per-session
  working-state slot; optional refs carries {file, pr, branch, commit}.
- **channel_recent(project_id, since?, limit?)** — GETs /api/v1/channel/posts on
  the agent key and returns recent posts. RLS returns only the caller tenant's
  channel (oracle-safe read).
- Both tools declared in TOOLS and wired into the dispatch switch next to
  create_kb_scope.
- Source-regex tests (test/mcp_arg_forwarding.test.js) assert each tool is
  declared, dispatched, hits the correct path/method on the agent key, and that
  host/session_id are auto-filled.
- Bumped mcp-server to 2.47.0 and added a CHANGELOG entry so the mcp-autopublish
  workflow publishes on merge.

### Coordination surface, not chain-of-custody
Posting to / reading your own tenant's channel is coordination, not self-approval
(owner decision #331). session_id is informational only — gracefully null when
absent, never a security dependency.

### Tests
Full mcp-server node --test suite green: 240 tests, 0 failures.

Closes #39.4
