### PR TITLE
Delete a channel post (redact path — remove a leaked/regretted post before its 30-day expiry)

### DIFF
--- a/lib/loopctl/coordination.ex
+++ b/lib/loopctl/coordination.ex
@@ -233,8 +233,35 @@ defmodule Loopctl.Coordination do
       end)
 
     case AdminRepo.transaction(multi) do
-      {:ok, %{post: post}} -> {:ok, post}
+      {:ok, %{post: post}} ->
+        {:ok, post}
+
+      # The only convertible Multi error is a failed step carrying an invalid
+      # changeset. `Multi.delete` never yields such a tuple (a missing row RAISES
+      # `Ecto.StaleEntryError`, rescued below), so today this can only be the
+      # `:audit` step. The audit attrs are built programmatically with every
+      # required field present, so this branch is UNREACHABLE with valid input; it
+      # exists to keep `run_delete/4` TOTAL — never a `CaseClauseError`/500 leaked
+      # to the controller — and, like sibling `run_post/3`, acts as a compile-gate:
+      # if `Audit.log_in_multi/3` is ever changed to fail with a non-changeset
+      # error this clause stops covering it and dialyzer fails the build here.
+      # `delete_post/3`'s contract admits only `:not_found`, and this branch rolls
+      # the whole transaction back (nothing deleted, nothing audited), so it
+      # normalises to the same 404 the story mandates.
+      {:error, _step, %Ecto.Changeset{}, _changes} ->
+        {:error, :not_found}
     end
+  rescue
+    # Concurrent double-delete. `fetch_owned_post/2` is an UNLOCKED read, so between
+    # it and `Multi.delete` another deleter — or the US-39.5 TTL sweep — can remove
+    # the row. The feature explicitly enables "whoever NOTICES a leaked secret,
+    # fleet-wide" to delete, making two agents deleting the same post a first-class
+    # case. The losing DELETE matches 0 rows and Ecto raises `Ecto.StaleEntryError`
+    # (Multi does NOT convert a stale delete to an `{:error, ...}` tuple; it
+    # propagates out of the transaction). A just-deleted post is now nonexistent,
+    # and the AC maps nonexistent → 404, so collapse the race to the SAME idempotent
+    # `{:error, :not_found}` a nonexistent id returns — never a 500.
+    Ecto.StaleEntryError -> {:error, :not_found}
   end
 
   defp delete_audit_attrs(tenant_id, agent_id, post, audit) do

--- a/lib/loopctl/coordination.ex
+++ b/lib/loopctl/coordination.ex
@@ -166,6 +166,97 @@ defmodule Loopctl.Coordination do
     end
   end
 
+  @doc """
+  HARD-deletes a channel post — the redact path (US-39.7).
+
+  The backstop for a leaked/regretted post: whoever NOTICES a leaked secret (the
+  denylist is best-effort, US-39.1) can remove the row immediately, before its
+  30-day TTL (US-39.5) would sweep it. A hard delete is consistent with the
+  transient model — there is nothing to soft-retain in a channel that expires
+  wholesale.
+
+  Cooperative single-tenant model: `agent_id` is the DELETING agent (the audit
+  actor), which may differ from the post's AUTHOR `agent_id` — any agent in the
+  tenant may delete any post in that tenant, enabling cleanup by whoever spots
+  the leak. It may NEVER delete a post in another tenant: the fetch filters on
+  BOTH `id` and `tenant_id` (the explicit tenant boundary on the AdminRepo path),
+  so a foreign (or nonexistent) `post_id` returns `{:error, :not_found}` —
+  byte-identical outcomes, no cross-tenant existence oracle (KB "IDOR Prevention
+  in Multi-Tenant Delete Operations").
+
+  A malformed `post_id` (a non-UUID path segment) is guarded first and returns
+  `{:error, :not_found}` too, so a bad id is a clean 404 — never an
+  `Ecto.Query.CastError`/500 (mirrors the `valid_uuid?` guard in `recent_page/3`).
+
+  The delete and its audit entry (`entity_type "channel_post"`, action
+  `"deleted"`, actor = the deleting agent's key context, capturing the deleted
+  post's `id` as `entity_id` and the original author `agent_id` in metadata) run
+  in ONE `Ecto.Multi` transaction, so the removal stays accountable even though
+  the row is gone.
+
+  `audit` is the actor-context keyword list from
+  `LoopctlWeb.AuditContext.from_conn/1`, threaded from the controller.
+
+  Returns `{:ok, %ChannelPost{}}` (the deleted row) or `{:error, :not_found}`.
+  """
+  @spec delete_post(Ecto.UUID.t(), Ecto.UUID.t(), term(), keyword()) ::
+          {:ok, ChannelPost.t()} | {:error, :not_found}
+  def delete_post(tenant_id, agent_id, post_id, audit \\ []) do
+    if valid_uuid?(post_id) do
+      case fetch_owned_post(tenant_id, post_id) do
+        nil -> {:error, :not_found}
+        post -> run_delete(tenant_id, agent_id, post, audit)
+      end
+    else
+      {:error, :not_found}
+    end
+  end
+
+  # Fetch a post by id CONSTRAINED to the caller's tenant — the isolation
+  # boundary on the AdminRepo (BYPASSRLS) path. A foreign-tenant or nonexistent
+  # id returns nil, so both collapse to the same 404 (no existence oracle).
+  defp fetch_owned_post(tenant_id, post_id) do
+    ChannelPost
+    |> where([p], p.id == ^post_id and p.tenant_id == ^tenant_id)
+    |> AdminRepo.one()
+  end
+
+  # Delete + audit in ONE transaction so the removal survives in the trail even
+  # though the row is hard-deleted (AC-39.7.3). The DELETING agent is the audit
+  # actor (from `audit`); the post's original author is captured in metadata.
+  defp run_delete(tenant_id, agent_id, post, audit) do
+    multi =
+      Multi.new()
+      |> Multi.delete(:post, post)
+      |> Audit.log_in_multi(:audit, fn %{post: deleted} ->
+        delete_audit_attrs(tenant_id, agent_id, deleted, audit)
+      end)
+
+    case AdminRepo.transaction(multi) do
+      {:ok, %{post: post}} -> {:ok, post}
+    end
+  end
+
+  defp delete_audit_attrs(tenant_id, agent_id, post, audit) do
+    %{
+      tenant_id: tenant_id,
+      project_id: post.project_id,
+      entity_type: "channel_post",
+      entity_id: post.id,
+      action: "deleted",
+      actor_type: Keyword.get(audit, :actor_type, "api_key"),
+      actor_id: Keyword.get(audit, :actor_id),
+      actor_label: Keyword.get(audit, :actor_label),
+      metadata:
+        audit
+        |> Keyword.get(:metadata, %{})
+        |> Map.merge(%{
+          "deleted_post_agent_id" => post.agent_id,
+          "deleted_by_agent_id" => agent_id
+        })
+    }
+  end
+
   # Assert the server-stamped agent belongs to the tenant, mapped to a DISTINCT
   # error from the project guard so the endpoint separates an identity fault (403)
   # from a cross-tenant project probe (422).

--- a/lib/loopctl/coordination.ex
+++ b/lib/loopctl/coordination.ex
@@ -200,7 +200,7 @@ defmodule Loopctl.Coordination do
   Returns `{:ok, %ChannelPost{}}` (the deleted row) or `{:error, :not_found}`.
   """
   @spec delete_post(Ecto.UUID.t(), Ecto.UUID.t(), term(), keyword()) ::
-          {:ok, ChannelPost.t()} | {:error, :not_found}
+          {:ok, ChannelPost.t()} | {:error, :not_found | :audit_write_failed}
   def delete_post(tenant_id, agent_id, post_id, audit \\ []) do
     if valid_uuid?(post_id) do
       case fetch_owned_post(tenant_id, post_id) do
@@ -236,20 +236,22 @@ defmodule Loopctl.Coordination do
       {:ok, %{post: post}} ->
         {:ok, post}
 
-      # The only convertible Multi error is a failed step carrying an invalid
-      # changeset. `Multi.delete` never yields such a tuple (a missing row RAISES
-      # `Ecto.StaleEntryError`, rescued below), so today this can only be the
-      # `:audit` step. The audit attrs are built programmatically with every
-      # required field present, so this branch is UNREACHABLE with valid input; it
-      # exists to keep `run_delete/4` TOTAL — never a `CaseClauseError`/500 leaked
-      # to the controller — and, like sibling `run_post/3`, acts as a compile-gate:
-      # if `Audit.log_in_multi/3` is ever changed to fail with a non-changeset
-      # error this clause stops covering it and dialyzer fails the build here.
-      # `delete_post/3`'s contract admits only `:not_found`, and this branch rolls
-      # the whole transaction back (nothing deleted, nothing audited), so it
-      # normalises to the same 404 the story mandates.
-      {:error, _step, %Ecto.Changeset{}, _changes} ->
-        {:error, :not_found}
+      # The `:audit` step failed with an invalid changeset. `Multi.delete` never
+      # yields such a tuple (a missing row RAISES `Ecto.StaleEntryError`, rescued
+      # below), so a convertible Multi error here is ALWAYS the audit insert. Because
+      # the delete and the audit share ONE transaction, a failed audit rolls the
+      # DELETE back too: the post SURVIVES. This is the redact path (a leaked
+      # secret), so folding it into the contract's `:not_found` would be
+      # fail-UNSAFE — the caller would read the resulting 404 as "already
+      # gone/handled" and believe the secret (and its 30-day-TTL SessionStart
+      # injection) is removed when it is NOT. Instead surface a DISTINCT error the
+      # controller maps to a 5xx, so the agent RETRIES the redaction rather than
+      # trusting a false 404. Matching `:audit` explicitly (not `_step`) preserves
+      # the compile-gate `run_delete/4` had: if `Audit.log_in_multi/3` is ever
+      # changed to fail with a non-changeset value, this clause stops covering it
+      # and dialyzer fails the build here rather than silently mis-mapping it.
+      {:error, :audit, %Ecto.Changeset{}, _changes} ->
+        {:error, :audit_write_failed}
     end
   rescue
     # Concurrent double-delete. `fetch_owned_post/2` is an UNLOCKED read, so between

--- a/lib/loopctl_web/controllers/channel_post_controller.ex
+++ b/lib/loopctl_web/controllers/channel_post_controller.ex
@@ -187,7 +187,10 @@ defmodule LoopctlWeb.ChannelPostController do
       404 =>
         {"Post not found (nonexistent or in another tenant)", "application/json",
          Schemas.ErrorResponse},
-      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError},
+      500 =>
+        {"The delete could not be recorded in the audit trail and was rolled back; " <>
+           "the post still exists. Retry the request.", "application/json", Schemas.ErrorResponse}
     }
   )
 
@@ -395,6 +398,13 @@ defmodule LoopctlWeb.ChannelPostController do
         # Cross-tenant AND nonexistent both land here — the shared 404 body is
         # byte-identical (no existence oracle), guaranteed by the FallbackController.
         {:error, :not_found}
+
+      {:error, :audit_write_failed} = err ->
+        # The delete could not be durably audited, so the whole transaction rolled
+        # back and the post STILL EXISTS. On this redact path that MUST NOT masquerade
+        # as a 404 ("already gone") — the FallbackController maps this to a 5xx so the
+        # agent retries the redaction instead of trusting a false success.
+        err
     end
   end
 

--- a/lib/loopctl_web/controllers/channel_post_controller.ex
+++ b/lib/loopctl_web/controllers/channel_post_controller.ex
@@ -5,6 +5,15 @@ defmodule LoopctlWeb.ChannelPostController do
   - `POST /api/v1/channel/posts` — agent+, posts one short coordination message
     to a project's channel (a channel IS a `project_id`), optionally under a
     `key` that upserts the caller's own per-session working-state slot.
+  - `GET /api/v1/channel/posts` — agent+, reads a project's live channel
+    (channel_recent), tenant-scoped and oracle-safe.
+  - `DELETE /api/v1/channel/posts/:id` — agent+, HARD-deletes a post in the
+    caller's tenant (the redact path, US-39.7): the backstop for a leaked/
+    regretted post, letting whoever notices remove it before its 30-day TTL. Any
+    agent in the tenant may delete any post in that tenant (cooperative single-
+    tenant model); a foreign or nonexistent id is a byte-identical 404 (no
+    cross-tenant existence oracle). Same coordination trust posture as the write:
+    `role: :agent`, deliberately NOT behind `RequireHumanAnchor`.
 
   ## Trust posture (owner decision #331, design brief §4)
 
@@ -49,7 +58,7 @@ defmodule LoopctlWeb.ChannelPostController do
   # The read (`:index`) is the same agent-role, tenant-scoped coordination surface
   # as the write — never human-anchor gated (the human-anchor default-deny test
   # only walks POST/PUT/PATCH/DELETE, so this GET needs no allowlist entry).
-  plug LoopctlWeb.Plugs.RequireRole, [role: :agent] when action in [:create, :index]
+  plug LoopctlWeb.Plugs.RequireRole, [role: :agent] when action in [:create, :index, :delete]
 
   # Per-write rate limit (AC-39.2.8): a TIGHTER, config-driven cap on top of the
   # generic per-key/per-tenant pipeline RateLimiter, reusing the same
@@ -150,6 +159,34 @@ defmodule LoopctlWeb.ChannelPostController do
              }
            }
          }},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  operation(:delete,
+    summary: "Delete a repo coordination channel post (redact path)",
+    description:
+      "HARD-deletes a coordination post in the caller's tenant — the redact path (US-39.7). The " <>
+        "backstop for a leaked/regretted post: whoever notices a leaked secret can remove it " <>
+        "immediately, before its 30-day TTL. Agent+ role, NOT behind the human-anchor tier " <>
+        "(coordination surface, owner decision #331). Cooperative single-tenant model: any agent " <>
+        "in the tenant may delete any post in that tenant, but NEVER a post in another tenant — a " <>
+        "foreign OR nonexistent id returns a byte-identical 404 (no cross-tenant existence " <>
+        "oracle). The delete is audited (action \"deleted\", actor = the deleting agent) in the " <>
+        "same transaction, so the removal stays accountable even though the row is gone.",
+    parameters: [
+      id: [
+        in: :path,
+        type: :string,
+        required: true,
+        description: "The post id — must belong to the caller's tenant"
+      ]
+    ],
+    responses: %{
+      204 => "Post deleted (no content)",
+      404 =>
+        {"Post not found (nonexistent or in another tenant)", "application/json",
+         Schemas.ErrorResponse},
       429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
     }
   )
@@ -329,6 +366,35 @@ defmodule LoopctlWeb.ChannelPostController do
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:error, changeset}
+    end
+  end
+
+  @doc """
+  DELETE /api/v1/channel/posts/:id
+
+  HARD-deletes a coordination post in the caller's tenant — the redact path
+  (US-39.7). Requires agent+ role (NOT human-anchor gated). Any agent in the
+  tenant may delete any post in that tenant; a foreign or nonexistent id returns
+  a byte-identical 404 via the shared `FallbackController` (no cross-tenant
+  existence oracle). The deleting agent is the audit actor.
+  """
+  def delete(conn, params) do
+    api_key = conn.assigns.current_api_key
+    tenant_id = api_key.tenant_id
+
+    case Coordination.delete_post(
+           tenant_id,
+           api_key.agent_id,
+           params["id"],
+           AuditContext.from_conn(conn)
+         ) do
+      {:ok, _post} ->
+        send_resp(conn, :no_content, "")
+
+      {:error, :not_found} ->
+        # Cross-tenant AND nonexistent both land here — the shared 404 body is
+        # byte-identical (no existence oracle), guaranteed by the FallbackController.
+        {:error, :not_found}
     end
   end
 

--- a/lib/loopctl_web/fallback_controller.ex
+++ b/lib/loopctl_web/fallback_controller.ex
@@ -26,6 +26,8 @@ defmodule LoopctlWeb.FallbackController do
   - `{:error, %Ecto.Changeset{}}` -> 422 with field-level details
   - `{:error, :bad_request, message}` -> 400 with custom message
   - `{:error, :unprocessable_entity, message}` -> 422 with custom message
+  - `{:error, :audit_write_failed}` -> 500 (US-39.7 redact path: a hard delete whose
+    audit insert failed, rolling the delete back — never masked as a 404)
   - `{:error, %Postgrex.Error{}}` -> 504/503/500 by SQLSTATE class (US-27.3)
   - `{:error, %DBConnection.ConnectionError{}}` -> 503 with Retry-After (US-27.3)
   """
@@ -331,6 +333,26 @@ defmodule LoopctlWeb.FallbackController do
 
   def call(conn, {:error, %DBConnection.ConnectionError{} = error}),
     do: render_db_error(conn, error)
+
+  # US-39.7 redact path: a channel-post HARD delete could not be durably recorded
+  # in the audit trail, so the whole transaction rolled back and the post STILL
+  # EXISTS. Fail-safe-on-security-path: a rolled-back redaction is NEVER reported as
+  # a 404 ("already gone/handled") — that would let an agent believe a leaked secret
+  # was removed when it was not. A 500 tells the caller the delete did NOT happen so
+  # it retries the redaction.
+  def call(conn, {:error, :audit_write_failed}) do
+    conn
+    |> put_status(:internal_server_error)
+    |> json(%{
+      error: %{
+        status: 500,
+        code: "audit_write_failed",
+        message:
+          "The delete could not be recorded in the audit trail and was rolled back; " <>
+            "the post still exists. Retry the request."
+      }
+    })
+  end
 
   def call(conn, {:error, %Changeset{} = changeset}) do
     details = format_changeset_errors(changeset)

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -133,6 +133,11 @@ defmodule LoopctlWeb.Router do
     # of a project's live channel. project_id/since/limit query params; the tenant
     # is key-derived, never from params.
     get "/channel/posts", ChannelPostController, :index
+    # channel post redact/delete (US-39.7): agent-role, tenant-scoped HARD delete
+    # of a leaked/regretted post before its 30-day TTL. Any agent in the tenant may
+    # delete any post in that tenant; a foreign/nonexistent id is a byte-identical
+    # 404 (no cross-tenant oracle). Audited in-transaction. NOT human-anchor gated.
+    delete "/channel/posts/:id", ChannelPostController, :delete
 
     get "/tenants/me", TenantController, :show
     patch "/tenants/me", TenantController, :update

--- a/mcp-server/CHANGELOG.md
+++ b/mcp-server/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to `loopctl-mcp-server` are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 2.48.0 — 2026-07-18 (repo coordination bus — redact/delete)
+
+### Added
+
+- **`channel_delete`** — hard-delete (redact) a coordination post over
+  `DELETE /api/v1/channel/posts/:id` on the agent key (Epic 39 Repo Coordination
+  Bus, US-39.7). The backstop for a leaked/regretted post: whoever NOTICES a
+  leaked secret can remove the row immediately, before its 30-day TTL sweeps it.
+  Cooperative single-tenant model — any agent in the tenant may delete any post
+  in that tenant (the deleting agent is the audit actor), but NEVER a post in
+  another tenant: a foreign or nonexistent id returns a byte-identical 404 (no
+  cross-tenant existence oracle). The delete and its `deleted` audit entry run in
+  one transaction, so the removal stays accountable even though the row is gone.
+
 ## 2.47.0 — 2026-07-18 (repo coordination bus tools)
 
 ### Added

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -477,6 +477,21 @@ async function channelRecent({ project_id, since, limit }) {
   return toContent(result);
 }
 
+async function channelDelete({ post_id }) {
+  // Repo Coordination Bus (Epic 39, US-39.7): HARD-delete a coordination post in
+  // the caller's tenant — the redact path for a leaked/regretted post, before its
+  // 30-day TTL. Agent-role, tenant-scoped: any agent in the tenant may delete any
+  // post in that tenant; a foreign or nonexistent id returns a 404 (no cross-tenant
+  // existence oracle).
+  const result = await apiCall(
+    "DELETE",
+    `/api/v1/channel/posts/${post_id}`,
+    null,
+    process.env.LOOPCTL_AGENT_KEY,
+  );
+  return toContent(result);
+}
+
 async function deleteProject({ project_id }) {
   const result = await apiCall(
     "DELETE",
@@ -2301,6 +2316,21 @@ const TOOLS = [
         },
       },
       required: ["project_id"],
+    },
+  },
+  {
+    name: "channel_delete",
+    description:
+      "Delete a post from a repo coordination channel (Epic 39 Repo Coordination Bus) on the agent key — the redact path (US-39.7). Use this to immediately remove a leaked or regretted post (e.g. one that slipped a secret past the denylist) before its 30-day TTL. Agent-role, tenant-scoped: any agent in your tenant may delete any post in that tenant, enabling cleanup by whoever notices the leak. A post that does not exist in your tenant (including one in another tenant) returns a 404 — no cross-tenant existence oracle. The deletion is hard (the row is gone) but audited.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        post_id: {
+          type: "string",
+          description: "UUID of the channel post to delete (must be in your tenant).",
+        },
+      },
+      required: ["post_id"],
     },
   },
   {
@@ -5118,6 +5148,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     case "channel_recent":
       return await channelRecent(args);
+
+    case "channel_delete":
+      return await channelDelete(args);
 
     case "delete_project":
       return await deleteProject(args);

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.47.0",
+  "version": "2.48.0",
   "description": "MCP server for loopctl — structural trust for AI development loops",
   "type": "module",
   "main": "index.js",

--- a/mcp-server/test/mcp_arg_forwarding.test.js
+++ b/mcp-server/test/mcp_arg_forwarding.test.js
@@ -210,6 +210,40 @@ describe("#39.4: channel_post / channel_recent wiring", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// #39.7: channel_delete (Repo Coordination Bus redact path)
+// ---------------------------------------------------------------------------
+
+describe("#39.7: channel_delete wiring", () => {
+  test("TOOLS declares channel_delete", () => {
+    assert.match(INDEX_SRC, /name: "channel_delete",/, 'must declare a "channel_delete" tool');
+  });
+
+  test("channelDelete DELETEs /channel/posts/${post_id} on the AGENT key", () => {
+    assert.match(
+      INDEX_SRC,
+      /async function channelDelete\([\s\S]*?"DELETE",\s*`\/api\/v1\/channel\/posts\/\$\{post_id\}`,\s*null,\s*process\.env\.LOOPCTL_AGENT_KEY/,
+      "channelDelete must DELETE /api/v1/channel/posts/${post_id} with the agent key",
+    );
+  });
+
+  test("the channel_delete tool requires post_id", () => {
+    assert.match(
+      INDEX_SRC,
+      /name: "channel_delete",[\s\S]*?required: \["post_id"\]/,
+      "the channel_delete inputSchema must require post_id",
+    );
+  });
+
+  test("the channel_delete dispatch case calls channelDelete(args)", () => {
+    assert.match(
+      INDEX_SRC,
+      /case "channel_delete":\s*\n\s*return await channelDelete\(args\);/,
+      "the channel_delete dispatch case must call channelDelete(args)",
+    );
+  });
+});
+
 describe("KB-scope lifecycle: archive_kb_scope / restore_kb_scope wiring", () => {
   test("TOOLS declares archive_kb_scope and restore_kb_scope", () => {
     assert.match(INDEX_SRC, /name: "archive_kb_scope",/, 'must declare "archive_kb_scope"');

--- a/test/loopctl/coordination_test.exs
+++ b/test/loopctl/coordination_test.exs
@@ -692,6 +692,114 @@ defmodule Loopctl.CoordinationTest do
     end
   end
 
+  describe "delete_post/3" do
+    setup do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      agent_id = fixture(:agent, %{tenant_id: tenant.id}).id
+
+      audit = [
+        actor_type: "api_key",
+        actor_id: Ecto.UUID.generate(),
+        actor_label: "agent:deleter-1"
+      ]
+
+      %{tenant: tenant, project: project, agent_id: agent_id, audit: audit}
+    end
+
+    test "deletes a post in the tenant, removes it from recent, writes a 'deleted' audit row (TC-39.7.1)",
+         ctx do
+      %{tenant: tenant, project: project, agent_id: agent_id, audit: audit} = ctx
+
+      {:ok, post} =
+        Coordination.create_post(tenant.id, project.id, agent_id, %{"body" => "oops, a secret"})
+
+      assert {:ok, deleted} = Coordination.delete_post(tenant.id, agent_id, post.id, audit)
+      assert deleted.id == post.id
+
+      # Row is gone.
+      assert is_nil(AdminRepo.get(ChannelPost, post.id))
+      refute Enum.any?(Coordination.recent(tenant.id, project.id), &(&1.id == post.id))
+
+      # Audit trail survives the hard delete.
+      entry = one_audit_entry(tenant.id, post.id)
+      assert entry.action == "deleted"
+      assert entry.entity_type == "channel_post"
+      assert entry.actor_label == "agent:deleter-1"
+      assert entry.metadata["deleted_post_agent_id"] == agent_id
+    end
+
+    test "any agent B in the same tenant may delete agent A's post; audit actor is B (TC-39.7.2)",
+         ctx do
+      %{tenant: tenant, project: project, agent_id: agent_a} = ctx
+      agent_b = fixture(:agent, %{tenant_id: tenant.id}).id
+
+      {:ok, post} =
+        Coordination.create_post(tenant.id, project.id, agent_a, %{"body" => "from A"})
+
+      audit_b = [
+        actor_type: "api_key",
+        actor_id: Ecto.UUID.generate(),
+        actor_label: "agent:agent-b"
+      ]
+
+      assert {:ok, _deleted} = Coordination.delete_post(tenant.id, agent_b, post.id, audit_b)
+      assert is_nil(AdminRepo.get(ChannelPost, post.id))
+
+      entry = one_audit_entry(tenant.id, post.id)
+      assert entry.action == "deleted"
+      # The DELETING agent (B) is the audit actor — distinct from the author (A).
+      assert entry.actor_label == "agent:agent-b"
+      assert entry.metadata["deleted_post_agent_id"] == agent_a
+      assert entry.metadata["deleted_by_agent_id"] == agent_b
+    end
+
+    test "a cross-tenant post id returns {:error, :not_found} and the foreign row still exists (TC-39.7.3)",
+         ctx do
+      %{tenant: tenant, agent_id: agent_id, audit: audit} = ctx
+      other = fixture(:tenant)
+      other_project = fixture(:project, %{tenant_id: other.id})
+      other_agent = fixture(:agent, %{tenant_id: other.id}).id
+
+      {:ok, foreign_post} =
+        Coordination.create_post(other.id, other_project.id, other_agent, %{"body" => "theirs"})
+
+      assert {:error, :not_found} =
+               Coordination.delete_post(tenant.id, agent_id, foreign_post.id, audit)
+
+      # The other tenant's post is untouched.
+      assert %ChannelPost{} = AdminRepo.get(ChannelPost, foreign_post.id)
+    end
+
+    test "a nonexistent random UUID returns {:error, :not_found} (TC-39.7.4)", ctx do
+      %{tenant: tenant, agent_id: agent_id, audit: audit} = ctx
+
+      assert {:error, :not_found} =
+               Coordination.delete_post(tenant.id, agent_id, Ecto.UUID.generate(), audit)
+    end
+
+    test "a malformed (non-UUID) post id returns {:error, :not_found}, never a CastError", ctx do
+      %{tenant: tenant, agent_id: agent_id, audit: audit} = ctx
+
+      assert {:error, :not_found} =
+               Coordination.delete_post(tenant.id, agent_id, "not-a-uuid", audit)
+    end
+
+    test "tenant isolation: deleting with the wrong tenant_id does not remove the row", ctx do
+      %{tenant: tenant, project: project, agent_id: agent_id, audit: audit} = ctx
+      other = fixture(:tenant)
+
+      {:ok, post} =
+        Coordination.create_post(tenant.id, project.id, agent_id, %{"body" => "mine"})
+
+      # Same post id, but scoped to a different tenant → not found, row intact.
+      assert {:error, :not_found} =
+               Coordination.delete_post(other.id, agent_id, post.id, audit)
+
+      assert %ChannelPost{} = AdminRepo.get(ChannelPost, post.id)
+    end
+  end
+
   defp one_audit_entry(tenant_id, entity_id) do
     AdminRepo.one!(
       from(a in AuditLog,

--- a/test/loopctl/coordination_test.exs
+++ b/test/loopctl/coordination_test.exs
@@ -798,6 +798,53 @@ defmodule Loopctl.CoordinationTest do
 
       assert %ChannelPost{} = AdminRepo.get(ChannelPost, post.id)
     end
+
+    test "deleting an already-deleted post is an idempotent {:error, :not_found}, never a raise (stale-delete race)",
+         ctx do
+      %{tenant: tenant, project: project, agent_id: agent_id, audit: audit} = ctx
+
+      {:ok, post} =
+        Coordination.create_post(tenant.id, project.id, agent_id, %{"body" => "race"})
+
+      assert {:ok, _deleted} = Coordination.delete_post(tenant.id, agent_id, post.id, audit)
+
+      # The fleet-wide "whoever notices a leaked secret" model makes two agents
+      # deleting the SAME post a first-class case. A second delete of the now-gone
+      # row must be an idempotent 404 — never an Ecto.StaleEntryError/500. (This is
+      # the caller-visible half of the concurrent race: run_delete/4's rescue
+      # collapses a true TOCTOU stale DELETE to the identical outcome.)
+      assert {:error, :not_found} =
+               Coordination.delete_post(tenant.id, agent_id, post.id, audit)
+    end
+
+    test "an audit-step failure rolls back the delete and returns {:error, :not_found}, never a 500",
+         ctx do
+      %{tenant: tenant, project: project, agent_id: agent_id} = ctx
+
+      {:ok, post} =
+        Coordination.create_post(tenant.id, project.id, agent_id, %{"body" => "keepme"})
+
+      # Force the audit insert to fail: actor_type is a REQUIRED audit field, and an
+      # explicit nil in the audit context overrides run_delete's "api_key" default,
+      # yielding an invalid audit changeset — the {:error, :audit, changeset, _}
+      # Multi branch. It must NOT CaseClauseError/500; run_delete/4 normalises it to
+      # the contract's 404 and the whole transaction rolls back.
+      bad_audit = [actor_type: nil, actor_id: Ecto.UUID.generate(), actor_label: "x"]
+
+      assert {:error, :not_found} =
+               Coordination.delete_post(tenant.id, agent_id, post.id, bad_audit)
+
+      # Transaction rolled back: the post survives and no audit row was written.
+      assert %ChannelPost{} = AdminRepo.get(ChannelPost, post.id)
+
+      assert AdminRepo.aggregate(
+               from(a in AuditLog,
+                 where: a.entity_type == "channel_post" and a.entity_id == ^post.id
+               ),
+               :count,
+               :id
+             ) == 0
+    end
   end
 
   defp one_audit_entry(tenant_id, entity_id) do

--- a/test/loopctl/coordination_test.exs
+++ b/test/loopctl/coordination_test.exs
@@ -817,7 +817,7 @@ defmodule Loopctl.CoordinationTest do
                Coordination.delete_post(tenant.id, agent_id, post.id, audit)
     end
 
-    test "an audit-step failure rolls back the delete and returns {:error, :not_found}, never a 500",
+    test "an audit-step failure rolls back the delete and returns {:error, :audit_write_failed} (fail-safe, never a masking 404)",
          ctx do
       %{tenant: tenant, project: project, agent_id: agent_id} = ctx
 
@@ -827,11 +827,13 @@ defmodule Loopctl.CoordinationTest do
       # Force the audit insert to fail: actor_type is a REQUIRED audit field, and an
       # explicit nil in the audit context overrides run_delete's "api_key" default,
       # yielding an invalid audit changeset — the {:error, :audit, changeset, _}
-      # Multi branch. It must NOT CaseClauseError/500; run_delete/4 normalises it to
-      # the contract's 404 and the whole transaction rolls back.
+      # Multi branch. Because the delete shares the transaction, the post SURVIVES,
+      # so the redact path must NOT report a masking 404 ("already gone") — it
+      # surfaces a DISTINCT {:error, :audit_write_failed} the controller maps to a
+      # 5xx so the agent retries. It must never CaseClauseError/leak a raw 500.
       bad_audit = [actor_type: nil, actor_id: Ecto.UUID.generate(), actor_label: "x"]
 
-      assert {:error, :not_found} =
+      assert {:error, :audit_write_failed} =
                Coordination.delete_post(tenant.id, agent_id, post.id, bad_audit)
 
       # Transaction rolled back: the post survives and no audit row was written.

--- a/test/loopctl_web/controllers/channel_post_controller_test.exs
+++ b/test/loopctl_web/controllers/channel_post_controller_test.exs
@@ -13,6 +13,7 @@ defmodule LoopctlWeb.ChannelPostControllerTest do
   import ExUnit.CaptureLog
 
   alias Loopctl.AdminRepo
+  alias Loopctl.Audit.AuditLog
   alias Loopctl.Coordination
   alias Loopctl.Coordination.ChannelPost
 
@@ -571,6 +572,123 @@ defmodule LoopctlWeb.ChannelPostControllerTest do
         |> get(@path, %{"project_id" => project.id})
 
       assert conn.status in [401, 403]
+    end
+  end
+
+  describe "DELETE /api/v1/channel/posts/:id" do
+    defp delete_path(id), do: "#{@path}/#{id}"
+
+    defp seed_channel_post(tenant, project, agent_id, body \\ "leaked secret") do
+      {:ok, post} =
+        Coordination.create_post(tenant.id, project.id, agent_id, %{"body" => body})
+
+      post
+    end
+
+    # TC-39.7.1 + AC-39.7.5 (end to end): deletes → 204, gone from channel_recent.
+    test "an agent deletes a post in its tenant -> 204 and it is gone from channel_recent" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, agent} = agent_key(tenant)
+      post = seed_channel_post(tenant, project, agent.id)
+
+      conn = authed_conn(raw) |> delete(delete_path(post.id))
+      assert response(conn, 204) == ""
+
+      # AC-39.7.5: no longer surfaced by channel_recent.
+      read = authed_conn(raw) |> get(@path, %{"project_id" => project.id})
+      assert %{"data" => data} = json_response(read, 200)
+      refute Enum.any?(data, &(&1["id"] == post.id))
+
+      # AC-39.7.3: the deletion is audited even though the row is gone.
+      entry =
+        AdminRepo.one!(
+          from(a in AuditLog,
+            where:
+              a.tenant_id == ^tenant.id and a.entity_type == "channel_post" and
+                a.entity_id == ^post.id and a.action == "deleted"
+          )
+        )
+
+      assert entry.action == "deleted"
+    end
+
+    # TC-39.7.2: any agent B in the same tenant can delete agent A's post.
+    test "agent B in the same tenant deletes agent A's post -> 204, audit actor is B's key" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {_raw_a, _key_a, agent_a} = agent_key(tenant)
+      {raw_b, key_b, _agent_b} = agent_key(tenant)
+
+      post = seed_channel_post(tenant, project, agent_a.id, "from A")
+
+      conn = authed_conn(raw_b) |> delete(delete_path(post.id))
+      assert response(conn, 204) == ""
+
+      entry =
+        AdminRepo.one!(
+          from(a in AuditLog,
+            where:
+              a.tenant_id == ^tenant.id and a.entity_type == "channel_post" and
+                a.entity_id == ^post.id and a.action == "deleted"
+          )
+        )
+
+      # The deleting key (B) is the audit actor — not the post's author (A).
+      assert entry.actor_id == key_b.id
+      assert entry.metadata["deleted_post_agent_id"] == agent_a.id
+    end
+
+    # TC-39.7.3: cross-tenant delete → 404, the other tenant's post still exists.
+    test "a cross-tenant delete returns 404 and the other tenant's post still exists" do
+      tenant = fixture(:tenant)
+      {raw, _key, _agent} = agent_key(tenant)
+
+      other = fixture(:tenant)
+      other_project = fixture(:project, %{tenant_id: other.id})
+      other_agent = fixture(:agent, %{tenant_id: other.id})
+      foreign_post = seed_channel_post(other, other_project, other_agent.id, "theirs")
+
+      conn = authed_conn(raw) |> delete(delete_path(foreign_post.id))
+      assert json_response(conn, 404)
+
+      # The foreign row is untouched.
+      assert %ChannelPost{} = AdminRepo.get(ChannelPost, foreign_post.id)
+    end
+
+    # TC-39.7.4: nonexistent random UUID → 404, body byte-identical to cross-tenant.
+    test "a nonexistent random UUID returns 404 with a body byte-identical to the cross-tenant 404" do
+      tenant = fixture(:tenant)
+      {raw, _key, _agent} = agent_key(tenant)
+
+      other = fixture(:tenant)
+      other_project = fixture(:project, %{tenant_id: other.id})
+      other_agent = fixture(:agent, %{tenant_id: other.id})
+      foreign_post = seed_channel_post(other, other_project, other_agent.id, "theirs")
+
+      cross = authed_conn(raw) |> delete(delete_path(foreign_post.id))
+      nonexistent = authed_conn(raw) |> delete(delete_path(Ecto.UUID.generate()))
+
+      assert cross.status == 404
+      assert nonexistent.status == 404
+      # No existence oracle: the two 404 bodies are byte-identical.
+      assert cross.resp_body == nonexistent.resp_body
+    end
+
+    test "the route requires agent role (an unauthenticated caller cannot delete)" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {_raw, _key, agent} = agent_key(tenant)
+      post = seed_channel_post(tenant, project, agent.id)
+
+      conn =
+        build_conn()
+        |> put_req_header("x-loopctl-last-known-sth", @sth_header)
+        |> delete(delete_path(post.id))
+
+      assert conn.status in [401, 403]
+      # The post is untouched by the rejected request.
+      assert %ChannelPost{} = AdminRepo.get(ChannelPost, post.id)
     end
   end
 end

--- a/test/loopctl_web/controllers/fallback_controller_test.exs
+++ b/test/loopctl_web/controllers/fallback_controller_test.exs
@@ -67,6 +67,20 @@ defmodule LoopctlWeb.FallbackControllerTest do
       assert body["error"]["message"] == "Conflict"
     end
 
+    # US-39.7 redact path: a rolled-back hard delete (audit insert failed) must
+    # surface as a 5xx, never a masking 404 — the post still exists, so the agent
+    # must retry rather than believe a leaked secret was removed.
+    test "renders 500 for :audit_write_failed (never masked as a 404)", %{conn: conn} do
+      conn = call_fallback(conn, {:error, :audit_write_failed})
+
+      assert conn.status == 500
+      body = Jason.decode!(conn.resp_body)
+      assert body["error"]["status"] == 500
+      assert body["error"]["code"] == "audit_write_failed"
+      assert body["error"]["message"] =~ "still exists"
+      assert body["error"]["message"] =~ "Retry"
+    end
+
     test "renders 429 for :rate_limited with default retry hint", %{conn: conn} do
       conn = call_fallback(conn, {:error, :rate_limited})
 

--- a/test/loopctl_web/require_human_anchor_default_deny_test.exs
+++ b/test/loopctl_web/require_human_anchor_default_deny_test.exs
@@ -194,6 +194,11 @@ defmodule LoopctlWeb.RequireHumanAnchorDefaultDenyTest do
                # server-stamped from the verified key, tenant-scoped — so it is
                # deliberately OUTSIDE the human-anchor tier gate (design brief §4).
                {:post, "/api/v1/channel/posts"},
+               # US-39.7 channel post redact/delete — same COORDINATION surface
+               # (agent-role, authorship/tenant server-derived from the verified
+               # key, tenant-scoped), NOT chain-of-custody, so deliberately outside
+               # the human-anchor tier gate (design brief §3, owner decision #331).
+               {:delete, "/api/v1/channel/posts/:id"},
 
                # Superadmin-only admin scope — RequireRole already pins these
                # to superadmin; Impersonate explicitly skips


### PR DESCRIPTION
## US-39.7 — Delete a channel post (redact path)

Adds the backstop for the Repo Coordination Bus (Epic 39): an agent-role, tenant-scoped, audited HARD delete so whoever NOTICES a leaked secret can remove it immediately, before its 30-day TTL sweep. The secret denylist (US-39.1) is best-effort; when it misses, a leaked secret is published AND amplified fleet-wide via SessionStart injection (US-39.6) for up to 30 days. This is the redact path.

### What changed
- **Context** `Loopctl.Coordination.delete_post/3` — UUID-guards the id (malformed -> clean 404, never a CastError/500), fetches via `AdminRepo` with an explicit `tenant_id` filter (IDOR-safe: a foreign or nonexistent id returns `{:error, :not_found}`, no cross-tenant oracle), then deletes + audits in ONE `Ecto.Multi` transaction. The audit entry records action `deleted`, the DELETING agent as actor, and the original author `agent_id` in metadata — so removals stay accountable even though the row is gone.
- **Controller** `DELETE /api/v1/channel/posts/:id` — `RequireRole :agent`, deliberately NOT behind `RequireHumanAnchor` (coordination surface, owner decision #331). 204 on success; bare `{:error, :not_found}` routes through the shared `FallbackController` so the cross-tenant and nonexistent 404 bodies are byte-identical. `operation(:delete)` OpenApiSpex spec declared.
- **Router** + **require_human_anchor_default_deny** allowlist entry (with justification).
- **MCP proxy** `channel_delete` tool (agent key) + source-regex tests; `mcp-server` bumped 2.47.0 -> 2.48.0.

### Tests
- Context (`delete_post/3`): happy delete + audit, agent B deletes agent A's post (actor == B), cross-tenant -> not_found with foreign row intact, malformed/random UUID -> not_found, tenant isolation.
- Controller: 204 + gone from channel_recent end-to-end (AC-39.7.5), agent B deletes A's post, cross-tenant 404 with foreign row intact, nonexistent 404 byte-identical to cross-tenant 404, role guard.
- MCP: TOOLS declares channel_delete, DELETEs `/channel/posts/${post_id}` on the agent key, requires post_id, dispatch case wired.

### Gate
`mix precommit` green (compile --warnings-as-errors, format, credo --strict, deps.audit, dialyzer, 5064 tests 0 failures). MCP proxy: 245 tests, 0 failures.

Closes #39.7
