### PR TITLE
fix(observability): harden ingestion-write-stats + health (pool starvation, audit race, 403 metric)

### DIFF
--- a/lib/loopctl/application.ex
+++ b/lib/loopctl/application.ex
@@ -46,9 +46,18 @@ defmodule Loopctl.Application do
       # increment is DROPPED (best-effort analytics, never blocks/fails the observed
       # write). Separate from the general `Loopctl.TaskSupervisor` so this backpressure
       # is isolated, mirroring `Loopctl.Memory.RecallBumpTaskSupervisor`.
+      #
+      # The cap is sized to the AdminRepo pool (ADMIN_POOL_SIZE, default 3), NOT set to
+      # a large fan-out: each task issues one AdminRepo checkout, so a cap far above the
+      # pool merely oversubscribes the 3-conn pool during a storm (queueing checkouts
+      # past `queue_target`/`queue_interval` and starving the co-tenant rate-limiter/auth
+      # upserts). A small multiple of the pool (default 10) allows brief overlap while
+      # keeping concurrent checkout demand bounded to roughly the pool depth — excess
+      # increments drop rather than pile onto the pool. Under normal low-frequency writes
+      # tasks complete in microseconds, so the cap is never approached.
       {Task.Supervisor,
        name: Loopctl.Telemetry.IngestionWriteStatsTaskSupervisor,
-       max_children: Application.get_env(:loopctl, :ingestion_write_stats_max_tasks, 200)},
+       max_children: Application.get_env(:loopctl, :ingestion_write_stats_max_tasks, 10)},
       # #411 Gap 3: owns the public ETS table that pre-filters recall-count hotness
       # bumps already inside their per-memory cooldown window, so an idle-window
       # recall issues ZERO background tasks and ZERO DB writes (the DB-side

--- a/lib/loopctl/knowledge/ingestion_health.ex
+++ b/lib/loopctl/knowledge/ingestion_health.ex
@@ -431,6 +431,16 @@ defmodule Loopctl.Knowledge.IngestionHealth do
     title_conflict = to_int(row.title_conflict)
     validation_error = to_int(row.validation_error)
 
+    # Denominator = ALL five write outcomes, including the SUCCESSFUL deduplicated
+    # and drafted outcomes. `reject_rate` is therefore "fraction of ALL write attempts
+    # rejected", not "fraction of new-content-CREATE attempts rejected". This is
+    # deliberate (tenant-wide, a pipeline that mostly dedups is largely working), but
+    # it is a KNOWN blind spot: a genuine title_conflict/validation reject storm on a
+    # source_type that ALSO carries heavy legitimate idempotent-dedup traffic can be
+    # diluted below `reject_rate_threshold` and evade this detector
+    # (e.g. 600 rejects / (1000 dedup + 600) = 0.375 < 0.5). If a source with high
+    # idempotent-dedup volume needs coverage, prefer a create+reject-only denominator
+    # or an absolute rejects/window rate for it rather than widening this ratio.
     total_attempts = created + deduplicated + drafted + title_conflict + validation_error
     rejects = title_conflict + validation_error
     reject_rate = if total_attempts > 0, do: rejects / total_attempts, else: 0.0
@@ -822,16 +832,34 @@ defmodule Loopctl.Knowledge.IngestionHealth do
   # Stamp the recovery time (episode ended) + mark resolved, auditing the resolve
   # transition only when the row was previously unresolved (an already-resolved row is
   # a system bookkeeping mark, not a state change worth a resolved-audit entry).
-  defp close_recovered_reject(%IngestionAnomaly{tenant_id: tenant_id} = anomaly, now) do
-    was_resolved = anomaly.resolved
-
+  #
+  # The candidate struct was bulk-loaded UNLOCKED in auto_resolve_recovered_reject_rate/1
+  # (AdminRepo.all, no FOR UPDATE). If an operator PATCH-resolves or archives the same
+  # anomaly between that load and this transaction, `anomaly.resolved` would be STALE
+  # (false), so trusting it would write a bogus resolved:false->true entry into the
+  # append-only, hash-chained audit log for a flip that already happened. So re-read the
+  # row FOR UPDATE inside the transaction and compute `was_resolved` from the LOCKED row
+  # — matching transition/8's locked, audit-honest flip.
+  defp close_recovered_reject(%IngestionAnomaly{id: id, tenant_id: tenant_id}, now) do
     multi =
       Multi.new()
-      |> Multi.run(:anomaly, fn repo, _changes ->
-        anomaly |> IngestionAnomaly.reject_recovered_changeset(now) |> repo.update()
+      |> Multi.run(:locked, fn repo, _changes ->
+        locked =
+          IngestionAnomaly
+          |> where([a], a.id == ^id and a.tenant_id == ^tenant_id)
+          |> lock("FOR UPDATE")
+          |> repo.one()
+
+        {:ok, locked}
       end)
-      |> Multi.run(:audit, fn repo, %{anomaly: updated} ->
-        if was_resolved do
+      |> Multi.run(:anomaly, fn repo, %{locked: locked} ->
+        case locked do
+          nil -> {:error, :not_found}
+          row -> row |> IngestionAnomaly.reject_recovered_changeset(now) |> repo.update()
+        end
+      end)
+      |> Multi.run(:audit, fn repo, %{locked: locked, anomaly: updated} ->
+        if locked.resolved do
           {:ok, :skipped}
         else
           audit_insert(

--- a/lib/loopctl/knowledge/ingestion_write_stats.ex
+++ b/lib/loopctl/knowledge/ingestion_write_stats.ex
@@ -20,6 +20,15 @@ defmodule Loopctl.Knowledge.IngestionWriteStats do
   - `:gated_to_draft`   -> `drafted_count`
   - `:title_conflict`   -> `title_conflict_count`
   - `:validation_error` -> `validation_error_count`
+  - `:forbidden`        -> `forbidden_count`
+
+  `:forbidden` counts UPFRONT AUTHORIZATION rejections (a 403 — wrong scope/role or a
+  missing agent identity). It is tracked for observability but is DELIBERATELY EXCLUDED
+  from the high_reject_rate detector's reject numerator AND denominator
+  (`IngestionHealth.detect_high_reject_rate/1` selects only the five ingestion outcomes):
+  a caller merely mis-using scope/identity (a 403 storm) is permission misuse, NOT an
+  ingestion-pipeline outage, and must not page the operator with a `high_reject_rate`
+  alert nor dilute a genuine `title_conflict`/`validation_error` reject signal.
 
   `source_type` is NULLABLE (an article write may omit the advisory field); the
   `(tenant_id, COALESCE(source_type, ''), day)` unique index buckets NULL distinctly
@@ -30,6 +39,7 @@ defmodule Loopctl.Knowledge.IngestionWriteStats do
 
   @type t :: %__MODULE__{}
 
+  # The five INGESTION-pipeline outcome counters the high_reject_rate detector reads.
   @counter_fields [
     :created_count,
     :deduplicated_count,
@@ -38,6 +48,14 @@ defmodule Loopctl.Knowledge.IngestionWriteStats do
     :validation_error_count
   ]
 
+  # Upfront-authorization (403) rejections. Tracked for observability but kept OUT of
+  # @counter_fields so it is excluded from the reject-rate detector (numerator AND
+  # denominator) — a 403 storm is permission misuse, not an ingestion outage.
+  @authz_fields [:forbidden_count]
+
+  # All upsertable counter columns (ingestion outcomes + authz rejections).
+  @all_counter_fields @counter_fields ++ @authz_fields
+
   # Telemetry outcome -> counter column. The single source of truth for the mapping
   # (used by the telemetry handler and the reject-rate detector).
   @outcome_columns %{
@@ -45,7 +63,8 @@ defmodule Loopctl.Knowledge.IngestionWriteStats do
     deduplicated: :deduplicated_count,
     gated_to_draft: :drafted_count,
     title_conflict: :title_conflict_count,
-    validation_error: :validation_error_count
+    validation_error: :validation_error_count,
+    forbidden: :forbidden_count
   }
 
   @derive {Jason.Encoder,
@@ -55,7 +74,7 @@ defmodule Loopctl.Knowledge.IngestionWriteStats do
                :tenant_id,
                :source_type,
                :day
-             ] ++ @counter_fields ++ [:inserted_at, :updated_at]}
+             ] ++ @all_counter_fields ++ [:inserted_at, :updated_at]}
 
   schema "ingestion_write_stats" do
     tenant_field()
@@ -68,11 +87,12 @@ defmodule Loopctl.Knowledge.IngestionWriteStats do
     field :drafted_count, :integer, default: 0
     field :title_conflict_count, :integer, default: 0
     field :validation_error_count, :integer, default: 0
+    field :forbidden_count, :integer, default: 0
 
     timestamps(type: :utc_datetime_usec)
   end
 
-  @doc "The five per-outcome counter column names."
+  @doc "The five INGESTION-outcome counter column names read by the reject-rate detector."
   @spec counter_fields() :: [atom()]
   def counter_fields, do: @counter_fields
 
@@ -90,7 +110,7 @@ defmodule Loopctl.Knowledge.IngestionWriteStats do
   @spec changeset(t(), map()) :: Ecto.Changeset.t()
   def changeset(stats \\ %__MODULE__{}, attrs) do
     stats
-    |> cast(attrs, [:source_type, :day | @counter_fields])
+    |> cast(attrs, [:source_type, :day | @all_counter_fields])
     |> validate_required([:day])
     |> foreign_key_constraint(:tenant_id)
   end

--- a/lib/loopctl/telemetry/ingestion_write_stats.ex
+++ b/lib/loopctl/telemetry/ingestion_write_stats.ex
@@ -17,9 +17,26 @@ defmodule Loopctl.Telemetry.IngestionWriteStats do
   process, and the BYPASSRLS `AdminRepo` pool is small (3 conns in prod) and already
   carries the per-request rate-limiter upsert — so a blocking upsert here would couple
   article-write tail latency to AdminRepo pool checkout (up to the checkout timeout)
-  under pool pressure or a DB blip. To decouple, the increment is dispatched to a
-  supervised, fire-and-forget task (`async?/0`, default true) so the request path never
-  blocks on it.
+  under pool pressure or a DB blip. To decouple the SLOW part (the AdminRepo checkout +
+  upsert), the increment is dispatched to a supervised, fire-and-forget task
+  (`async?/0`, default true) so the request path never waits on the DB round-trip.
+
+  ### Residual coupling (honest bound, not "zero blocking")
+
+  The dispatch itself is `Task.Supervisor.start_child/2`, which is a `GenServer.call`
+  into the SINGLE bounded task-supervisor process. Under normal (low-frequency) write
+  load that call returns in microseconds. But the `:high_reject_rate` detector this feeds
+  triggers on a client HAMMERING create in a retry loop — a high-frequency write storm by
+  design — and during such a storm every request serializes through that one supervisor
+  mailbox, so the "async" dispatch is NOT fully decoupled from the request path: it is
+  BOUNDED (a fast mailbox enqueue, capped by the 5s call timeout whose EXIT is caught
+  below), not zero. This is acceptable for a best-effort analytics counter — correctness
+  is unaffected (drops/exits are caught and swallowed) — but it is real latency coupling
+  to a shared process precisely during the storm being observed. If that coupling ever
+  matters (writes grow hot enough that the supervisor mailbox is a measurable tail-latency
+  contributor), the drop-in upgrade is the ETS-buffer + periodic-flush design named below:
+  an `:ets.update_counter/3` on the hot path (no process call at all) with one flusher
+  owning AdminRepo.
 
   ## Bounded fan-out (the reject storm is the worst case)
 
@@ -29,11 +46,27 @@ defmodule Loopctl.Telemetry.IngestionWriteStats do
   upsert per rejected write, contending for the 3-conn pool (shared with the rate
   limiter + auth) and amplifying the very outage the detector exists to catch. So the
   dispatch goes through the BOUNDED `Loopctl.Telemetry.IngestionWriteStatsTaskSupervisor`
-  (`max_children`, default 200): over the cap `start_child` returns
-  `{:error, :max_children}` and the increment is DROPPED (best-effort analytics) rather
-  than queueing unbounded checkouts. If write volume ever grows hot enough to pressure
-  the pool even under the cap, an ETS-buffer+flush (ScaleAlerts style) is the drop-in
-  next step.
+  (`max_children`, default 10 — sized to the 3-conn AdminRepo pool, NOT a large fan-out,
+  so a storm cannot oversubscribe the pool with concurrent checkouts): over the cap
+  `start_child` returns `{:error, :max_children}` and the increment is DROPPED
+  (best-effort analytics) rather than queueing unbounded checkouts. If write volume ever
+  grows hot enough to pressure the pool even under the cap, an ETS-buffer+flush
+  (ScaleAlerts style) is the drop-in next step.
+
+  Because drops happen precisely DURING a reject storm, a per-drop `Logger.warning` would
+  itself flood the logging pipeline at exactly the wrong moment (a DoS amplification of
+  the incident being observed). So the drop log is SAMPLED: every drop bumps a shared
+  atomic counter and only one aggregate warning is emitted per `@drop_log_sample` drops
+  (plus the very first), bounding drop-log volume regardless of storm rate.
+
+  IMPORTANT — these counters are RATIO-safe but NOT absolute-count-safe under a storm.
+  Because drops at the `max_children` cap happen precisely DURING a reject storm, the
+  rollup systematically UNDERCOUNTS during the very incidents it records. That is fine for
+  the ratio-based `:high_reject_rate` detector — drops are outcome-independent, so
+  `reject_rate` is preserved and `total_attempts` still clears `min_attempts` during a
+  storm. Do NOT, however, layer any ABSOLUTE-volume alerting (e.g. "N rejects/window")
+  on `ingestion_write_stats` without accounting for this storm-time undercount, or move
+  to the ETS-buffer design first so bursts are absorbed rather than dropped.
 
   In TEST the dispatch runs INLINE (`config :loopctl, #{inspect(__MODULE__)}, async:
   false`) so the upsert shares the emitting test process's sandboxed connection and the
@@ -144,20 +177,56 @@ defmodule Loopctl.Telemetry.IngestionWriteStats do
       {:error, :max_children} ->
         # Bounded supervisor at capacity (a write burst): DROP the increment rather
         # than block the observed request or queue an unbounded AdminRepo checkout.
-        Logger.warning(
-          "IngestionWriteStats: task supervisor at capacity; dropping #{column} increment"
-        )
+        log_dropped_increment(:max_children, column)
 
       {:error, reason} ->
-        Logger.warning("IngestionWriteStats: failed to start upsert task: #{inspect(reason)}")
+        log_dropped_increment({:error, reason}, column)
     end
 
     :ok
   catch
     kind, reason ->
       # :exit (:noproc) if the supervisor is down, etc. Never let it escape to :telemetry.
-      Logger.warning("IngestionWriteStats: upsert dispatch #{kind}: #{inspect(reason)}")
+      log_dropped_increment({kind, reason}, column)
       :ok
+  end
+
+  # SAMPLED drop log. Drops happen precisely DURING a reject storm (the incident this
+  # rollup observes), so an unthrottled per-drop `Logger.warning` would flood the log
+  # pipeline exactly when the node is already under load — amplifying the storm. Count
+  # every drop in a shared atomic counter and emit ONE aggregate warning per
+  # `@drop_log_sample` drops (plus the very first, so a nascent storm still surfaces).
+  @drop_log_sample 1000
+  defp log_dropped_increment(cause, column) do
+    n = increment_drop_counter()
+
+    if rem(n - 1, @drop_log_sample) == 0 do
+      Logger.warning(
+        "IngestionWriteStats: dropping rollup increments under load " <>
+          "(#{n} dropped since boot; latest cause=#{inspect(cause)}, column=#{column})"
+      )
+    end
+
+    :ok
+  end
+
+  # Shared, lazily-initialized atomic drop counter (best-effort: a rare init race just
+  # loses a couple of counts, which is fine for a sampled diagnostic). `:counters` is
+  # lock-free with write concurrency, so bumping it on the drop path adds no contention.
+  defp increment_drop_counter do
+    ref =
+      case :persistent_term.get({__MODULE__, :drop_counter}, nil) do
+        nil ->
+          new = :counters.new(1, [:write_concurrency])
+          :persistent_term.put({__MODULE__, :drop_counter}, new)
+          new
+
+        existing ->
+          existing
+      end
+
+    :counters.add(ref, 1, 1)
+    :counters.get(ref, 1)
   end
 
   # Task body runs in its OWN process, outside handle_event's rescue, so it self-rescues:

--- a/lib/loopctl/telemetry_events.ex
+++ b/lib/loopctl/telemetry_events.ex
@@ -297,8 +297,11 @@ defmodule Loopctl.TelemetryEvents do
       `nil`, i.e. the unstamped bucket, so rollup cardinality stays bounded), and
       `outcome` is a BOUNDED atom: `:created` (novel/forced create), `:deduplicated`
       (200 idempotent/near-dup dedup), `:gated_to_draft` (novelty gate staged a
-      draft), `:title_conflict` (409 title taken), or `:validation_error`
-      (changeset/other 4xx, and the upfront 403/422 rejection paths).
+      draft), `:title_conflict` (409 title taken), `:validation_error`
+      (changeset/other 4xx, including the upfront malformed-param 422), or `:forbidden`
+      (upfront 403 authz rejection — wrong scope/role or missing agent identity;
+      tracked separately and EXCLUDED from the high_reject_rate detector so authz
+      misuse is not paged as an ingestion outage).
   """
   def article_write, do: [:loopctl, :knowledge, :article_write]
 

--- a/lib/loopctl/telemetry_events.ex
+++ b/lib/loopctl/telemetry_events.ex
@@ -279,9 +279,10 @@ defmodule Loopctl.TelemetryEvents do
   A KB article WRITE OUTCOME was rendered (PR B2). Emitted from EVERY outcome path of
   `LoopctlWeb.ArticleController.create` — both the create-path renderers (created,
   deduplicated, gated_to_draft, title_conflict, validation_error) AND the upfront
-  rejection paths that return before a create is attempted (system-scope 403,
-  malformed project_id 422, agent-identity-required 403, all counted as
-  `:validation_error`) — so write outcomes are observable even when NOTHING is
+  rejection paths that return before a create is attempted (system-scope 403 and
+  agent-identity-required 403 counted as `:forbidden` — excluded from the
+  high_reject_rate detector; malformed project_id 422 as `:validation_error`) — so
+  write outcomes are observable even when NOTHING is
   persisted (a rejected write leaves no article row). Folded into the durable
   `ingestion_write_stats` per-(tenant, source_type, day) rollup by the self-rescuing
   `Loopctl.Telemetry.IngestionWriteStats` handler, which

--- a/lib/loopctl/workers/ingestion_health_worker.ex
+++ b/lib/loopctl/workers/ingestion_health_worker.ex
@@ -122,7 +122,7 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
       "IngestionHealthWorker: #{length(candidates)} capture-silence candidate(s) detected"
     )
 
-    Enum.each(candidates, &flag_candidate/1)
+    flag_candidates(candidates, :capture_silence)
 
     # PR B2: the no-persist / high-rejection-rate sibling detector. A rejected write
     # leaves no article row, so it is invisible to the capture-silence scan above;
@@ -155,7 +155,7 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
         "IngestionHealthWorker: #{length(reject_candidates)} high-reject-rate candidate(s) detected"
       )
 
-      Enum.each(reject_candidates, &flag_candidate/1)
+      flag_candidates(reject_candidates, :high_reject_rate)
 
       # Close reject-rate anomalies whose reject rate recovered (no longer a candidate).
       # This resolves open rows that would otherwise freeze open, AND stamps the
@@ -224,35 +224,70 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
   # so this is a cheap, crash-free readiness probe for the version-skew window.
   defp anomalies_table_ready?, do: relation_present?("ingestion_anomalies")
 
+  # Batch the per-candidate existence/suppression probes into ONE set-based query per
+  # detector type, then process each candidate against the in-memory result. Previously
+  # each candidate ran 3-4 sequential AdminRepo queries (existing lookup + archived-
+  # suppression + acknowledged/resolved-suppression + the insert), so a WIDESPREAD outage
+  # (many candidates at once — the worst case this detector exists for) made the hourly
+  # job O(open anomalies) on the 3-conn AdminRepo pool. Prefetching keeps the probe cost
+  # constant, mirroring the set-based auto_resolve_recovered_* optimization.
+  defp flag_candidates([], _anomaly_type), do: :ok
+
+  defp flag_candidates(candidates, anomaly_type) do
+    by_key = prefetch_anomalies(candidates, anomaly_type)
+
+    Enum.each(candidates, fn candidate ->
+      rows = Map.get(by_key, {candidate.tenant_id, candidate.source_type}, [])
+      flag_candidate(anomaly_type, candidate, rows)
+    end)
+  end
+
+  # Load EVERY anomaly of `anomaly_type` (any resolved/archived state) for the candidate
+  # (tenant_id, source_type) keys in one query, grouped by key. Over-fetches the cartesian
+  # of the distinct tenant_ids × source_types then filters to the exact key set in memory
+  # (tuple IN is awkward in Ecto); the candidate set is small (bounded by tenants ×
+  # source_types), so this is a handful of rows and a single round-trip.
+  defp prefetch_anomalies(candidates, anomaly_type) do
+    keys = MapSet.new(candidates, &{&1.tenant_id, &1.source_type})
+    tenant_ids = candidates |> Enum.map(& &1.tenant_id) |> Enum.uniq()
+    source_types = candidates |> Enum.map(& &1.source_type) |> Enum.uniq()
+
+    IngestionAnomaly
+    |> where([a], a.anomaly_type == ^anomaly_type)
+    |> where([a], a.tenant_id in ^tenant_ids)
+    |> where([a], a.source_type in ^source_types)
+    |> AdminRepo.all()
+    |> Enum.filter(&MapSet.member?(keys, {&1.tenant_id, &1.source_type}))
+    |> Enum.group_by(&{&1.tenant_id, &1.source_type})
+  end
+
   # Dispatch by detector type: capture_silence (writes stopped) vs high_reject_rate
-  # (writes rejected). Both reuse the same persist/notify/at-least-once machinery.
-  defp flag_candidate(%{anomaly_type: :high_reject_rate} = candidate),
-    do: flag_reject_rate(candidate)
+  # (writes rejected). Both reuse the same persist/notify/at-least-once machinery and the
+  # prefetched `rows` for the candidate's (tenant, source_type) key.
+  defp flag_candidate(:high_reject_rate, candidate, rows),
+    do: flag_reject_rate(candidate, rows)
 
-  defp flag_candidate(candidate), do: flag_capture_silence(candidate)
+  defp flag_candidate(:capture_silence, candidate, rows),
+    do: flag_capture_silence(candidate, rows)
 
-  defp flag_capture_silence(%{
-         tenant_id: tenant_id,
-         source_type: source_type,
-         last_event_at: last_event_at,
-         hours_stale: hours_stale,
-         sample_count: sample_count
-       }) do
-    # Check first (like CostAnomalyWorker) so an UPDATE never emits audit/webhook/alert.
-    # The unique partial index still guards against races on the insert path below.
-    # NB: exclude archived rows here — an archived-but-unresolved row must not be
-    # silently update-refreshed; archival is handled explicitly below.
-    existing =
-      IngestionAnomaly
-      |> where([a], a.tenant_id == ^tenant_id)
-      |> where([a], a.source_type == ^source_type)
-      |> where([a], a.anomaly_type == :capture_silence)
-      |> where([a], a.resolved == false)
-      |> where([a], a.archived == false)
-      |> AdminRepo.one()
+  defp flag_capture_silence(
+         %{
+           tenant_id: tenant_id,
+           source_type: source_type,
+           last_event_at: last_event_at,
+           hours_stale: hours_stale,
+           sample_count: sample_count
+         },
+         rows
+       ) do
+    # Find the live (unresolved, non-archived) row like CostAnomalyWorker so an UPDATE
+    # never emits audit/webhook/alert. The unique partial index still guards against
+    # races on the insert path below. NB: an archived-but-unresolved row must not be
+    # silently update-refreshed; archival is handled explicitly by the first cond branch.
+    existing = Enum.find(rows, &(&1.resolved == false and &1.archived == false))
 
     cond do
-      archived_suppression?(tenant_id, source_type, :capture_silence) ->
+      archived_suppression?(rows) ->
         # Operator archived this source_type — escape hatch, never re-flag (until un-archived).
         :suppressed
 
@@ -266,7 +301,7 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
       existing ->
         update_existing(existing, last_event_at, hours_stale, sample_count)
 
-      acknowledged_silence?(tenant_id, source_type, last_event_at) ->
+      acknowledged_silence?(rows, last_event_at) ->
         # This exact silence is already covered by a resolved anomaly (no capture
         # since it was resolved) — suppress re-creation to avoid re-firing audit +
         # operator alert + webhook every hour. Re-flags only once captures resume
@@ -280,27 +315,17 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
 
   # An archived anomaly (resolved or not) suppresses re-detection for that
   # (source_type, anomaly_type) — the operator's escape hatch for a retired
-  # workflow, reversible via IngestionHealth.unarchive_anomaly/3.
-  defp archived_suppression?(tenant_id, source_type, anomaly_type) do
-    IngestionAnomaly
-    |> where([a], a.tenant_id == ^tenant_id)
-    |> where([a], a.source_type == ^source_type)
-    |> where([a], a.anomaly_type == ^anomaly_type)
-    |> where([a], a.archived == true)
-    |> AdminRepo.exists?()
-  end
+  # workflow, reversible via IngestionHealth.unarchive_anomaly/3. `rows` are already
+  # scoped to one (tenant, source_type, anomaly_type) key by the prefetch.
+  defp archived_suppression?(rows), do: Enum.any?(rows, & &1.archived)
 
   # True when a resolved (non-archived) anomaly's snapshot is at/after the current
   # silence's last_event_at, i.e. no NEW capture has arrived since it was resolved.
-  defp acknowledged_silence?(tenant_id, source_type, last_event_at) do
-    IngestionAnomaly
-    |> where([a], a.tenant_id == ^tenant_id)
-    |> where([a], a.source_type == ^source_type)
-    |> where([a], a.anomaly_type == :capture_silence)
-    |> where([a], a.resolved == true)
-    |> where([a], a.archived == false)
-    |> where([a], not is_nil(a.last_event_at) and a.last_event_at >= ^last_event_at)
-    |> AdminRepo.exists?()
+  defp acknowledged_silence?(rows, last_event_at) do
+    Enum.any?(rows, fn a ->
+      a.resolved and not a.archived and not is_nil(a.last_event_at) and
+        DateTime.compare(a.last_event_at, last_event_at) != :lt
+    end)
   end
 
   # --- High-reject-rate flagging (PR B2) ---
@@ -313,18 +338,11 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
   # (`last_event_at IS NULL`) — anti-alarm-fatigue while rejects persist — and re-arms
   # once recovery stamps `last_event_at`, so a future storm re-fires. Archiving is the
   # separate operator escape hatch.
-  defp flag_reject_rate(%{tenant_id: tenant_id, source_type: source_type} = candidate) do
-    existing =
-      IngestionAnomaly
-      |> where([a], a.tenant_id == ^tenant_id)
-      |> where([a], a.source_type == ^source_type)
-      |> where([a], a.anomaly_type == :high_reject_rate)
-      |> where([a], a.resolved == false)
-      |> where([a], a.archived == false)
-      |> AdminRepo.one()
+  defp flag_reject_rate(%{tenant_id: tenant_id} = candidate, rows) do
+    existing = Enum.find(rows, &(&1.resolved == false and &1.archived == false))
 
     cond do
-      archived_suppression?(tenant_id, source_type, :high_reject_rate) ->
+      archived_suppression?(rows) ->
         :suppressed
 
       existing && not existing.alerted ->
@@ -336,7 +354,7 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
       existing ->
         update_existing_reject(existing, candidate)
 
-      resolved_reject_suppression?(tenant_id, source_type) ->
+      resolved_reject_suppression?(rows) ->
         # Operator resolved it and rejects still persist — do not re-fire every run.
         :suppressed
 
@@ -352,16 +370,10 @@ defmodule Loopctl.Workers.IngestionHealthWorker do
   # stamps `last_event_at` (rejects fell below threshold), the resolved row stops
   # suppressing, so a FRESH storm for the same source_type re-fires instead of being
   # silenced forever. Without this scope a single operator resolve would blind the
-  # detector to every future outage of that source_type.
-  defp resolved_reject_suppression?(tenant_id, source_type) do
-    IngestionAnomaly
-    |> where([a], a.tenant_id == ^tenant_id)
-    |> where([a], a.source_type == ^source_type)
-    |> where([a], a.anomaly_type == :high_reject_rate)
-    |> where([a], a.resolved == true)
-    |> where([a], a.archived == false)
-    |> where([a], is_nil(a.last_event_at))
-    |> AdminRepo.exists?()
+  # detector to every future outage of that source_type. `rows` are prefetched and
+  # already scoped to the candidate's (tenant, source_type, high_reject_rate) key.
+  defp resolved_reject_suppression?(rows) do
+    Enum.any?(rows, &(&1.resolved and not &1.archived and is_nil(&1.last_event_at)))
   end
 
   defp create_new_reject(tenant_id, candidate) do

--- a/lib/loopctl_web/controllers/article_controller.ex
+++ b/lib/loopctl_web/controllers/article_controller.ex
@@ -284,9 +284,12 @@ defmodule LoopctlWeb.ArticleController do
 
     # System articles require superadmin role; everything else is agent+.
     if scope == "system" and api_key.role != :superadmin do
-      # Count the reject: an upfront authorization drop persists no article row, so
-      # without this the high_reject_rate detector would be blind to a 403 reject storm.
-      emit_write_telemetry(conn, params, :validation_error)
+      # Count the reject under the DISTINCT :forbidden outcome (a 403 authz drop persists
+      # no article row). It is tracked for observability but excluded from the
+      # high_reject_rate reject numerator/denominator — a scope-misuse 403 storm is
+      # permission misuse, not an ingestion-pipeline outage, and must not page the
+      # operator nor dilute a genuine title_conflict/validation_error signal.
+      emit_write_telemetry(conn, params, :forbidden)
 
       conn
       |> put_status(:forbidden)
@@ -336,8 +339,11 @@ defmodule LoopctlWeb.ArticleController do
         create_article(conn, tenant_id, bound_attrs, audit_opts, draft?, gate?)
 
       {:error, :no_agent_identity} ->
-        # Count the reject: an identity-required drop persists no article row.
-        emit_write_telemetry(conn, attrs, :validation_error)
+        # Count the reject under the DISTINCT :forbidden outcome (an identity-required
+        # 403 drop persists no article row) — excluded from the high_reject_rate
+        # detector, like the scope-forbidden case above: authz misuse is not an
+        # ingestion-pipeline outage.
+        emit_write_telemetry(conn, attrs, :forbidden)
 
         conn
         |> put_status(:forbidden)

--- a/priv/repo/migrations/20260718120000_add_forbidden_count_to_ingestion_write_stats.exs
+++ b/priv/repo/migrations/20260718120000_add_forbidden_count_to_ingestion_write_stats.exs
@@ -1,0 +1,22 @@
+defmodule Loopctl.Repo.Migrations.AddForbiddenCountToIngestionWriteStats do
+  use Ecto.Migration
+
+  @moduledoc """
+  Adds a distinct `forbidden_count` counter for UPFRONT AUTHORIZATION (403) rejections.
+
+  Previously the article-create controller folded 403 authz rejections (wrong
+  scope/role, missing agent identity) into `validation_error_count`, so a caller
+  merely mis-using scope/identity (a pure 403 storm) would trip the `high_reject_rate`
+  detector with a misleading `dominant_reason` and mask a genuine
+  `title_conflict`/`validation_error` ingestion outage. Authz rejections now increment
+  this separate column, which `IngestionHealth.detect_high_reject_rate/1` deliberately
+  does NOT read — permission misuse is tracked for observability but never counted as
+  ingestion-pipeline ill-health.
+  """
+
+  def change do
+    alter table(:ingestion_write_stats) do
+      add :forbidden_count, :bigint, default: 0, null: false
+    end
+  end
+end

--- a/priv/repo/migrations/20260718120100_drop_redundant_ingestion_write_stats_tenant_day_index.exs
+++ b/priv/repo/migrations/20260718120100_drop_redundant_ingestion_write_stats_tenant_day_index.exs
@@ -1,0 +1,24 @@
+defmodule Loopctl.Repo.Migrations.DropRedundantIngestionWriteStatsTenantDayIndex do
+  use Ecto.Migration
+
+  @moduledoc """
+  Drops the redundant `(tenant_id, day)` index on `ingestion_write_stats`.
+
+  The create migration added `index(:ingestion_write_stats, [:tenant_id, :day])`, but it
+  has NO read consumer:
+
+    * the reject-rate scan (`IngestionHealth.detect_high_reject_rate/1`) filters
+      `day >= window_start` with no tenant predicate, so it uses the day-leading
+      `[:day]` index (migration 20260717220000);
+    * retention pruning (`day < cutoff`) also uses `[:day]`;
+    * tenant+day point lookups are already served by the unique index on
+      `(tenant_id, COALESCE(source_type, ''), day)`.
+
+  So `(tenant_id, day)` was maintained on every write-outcome upsert (a hot, storm-time
+  path) for zero benefit — pure write amplification. Drop it.
+  """
+
+  def change do
+    drop_if_exists index(:ingestion_write_stats, [:tenant_id, :day])
+  end
+end


### PR DESCRIPTION
fix(observability): harden ingestion-write-stats + health (pool, audit race, 403 metric)

Real bugs surfaced while reviewing adjacent work; verified each against the
merged code and confirmed the fixes are correct.

- Pool starvation: the ingestion-rollup Task.Supervisor capped at max_children
  200 while each task does one AdminRepo (BYPASSRLS, 3-conn prod pool) checkout —
  a rollup burst (exactly when the high-reject detector fires) could oversubscribe
  the pool and starve the auth/rate-limiter path that shares it. Cap sized to the
  pool (default 10); excess increments drop (best-effort analytics).
- Audit-integrity race: close_recovered_reject/2 computed was_resolved from an
  UNLOCKED bulk-loaded row, so a concurrent operator resolve/archive could write a
  false append-only audit entry for a flip that already happened. Re-read the row
  FOR UPDATE inside the transaction and derive was_resolved from the locked row,
  matching transition/8's audit-honest flip.
- False anomaly signal: a 403 authz drop (scope-misuse / identity-required) was
  counted in the high_reject_rate detector's reject numerator/denominator, so a
  403 storm could false-trigger the ingestion anomaly. Count 403s under a distinct
  :forbidden outcome (new forbidden_count column) excluded from the reject rate.
- Perf: replaced a per-candidate N+1 probe in the health worker with a set-based
  prefetch; sampled the task-drop log (1/1000 via :counters) to prevent log
  flooding during a storm.
- Cleanup: dropped the redundant (tenant_id, day) index on ingestion_write_stats
  (verified unused — tenant reads use the (tenant_id, source_type, day) unique
  index, day-range/pruning use the [:day] index).

mix precommit green (5067 tests, 0 failures).
