### PR TITLE
refs as a typed-open list (fix the shipped defect) + scan type/value/label + count cap

### DIFF
--- a/lib/loopctl/api_spec/schemas.ex
+++ b/lib/loopctl/api_spec/schemas.ex
@@ -936,6 +936,11 @@ defmodule Loopctl.ApiSpec.Schemas do
           items: %Schema{
             type: :object,
             required: [:type, :value],
+            # The server rejects any item carrying a key other than type/value/label
+            # (an extra key would be an unscanned exfil field) with a 422 — see
+            # `ChannelPost.valid_ref_item?/1`. Publish that strictness so a client
+            # following the contract does not add a field the spec calls legal.
+            additionalProperties: false,
             properties: %{
               type: %Schema{type: :string, description: "Free-form ref type (<=64 bytes)"},
               value: %Schema{type: :string, description: "Ref value (<=512 bytes)"},

--- a/lib/loopctl/api_spec/schemas.ex
+++ b/lib/loopctl/api_spec/schemas.ex
@@ -926,10 +926,26 @@ defmodule Loopctl.ApiSpec.Schemas do
         },
         host: %Schema{type: :string, nullable: true, description: "Client-supplied hostname"},
         refs: %Schema{
-          type: :object,
+          type: :array,
           nullable: true,
-          description: "Optional structured refs; allowed keys: file, pr, branch, commit",
-          additionalProperties: %Schema{type: :string}
+          description:
+            "Optional bounded, typed-open LIST of reference items (max 50). Each item is " <>
+              "{type, value, label?}: type is a FREE string (<=64 bytes, no allowlist), value " <>
+              "<=512 bytes, optional label <=128 bytes. A secret/NUL byte in ANY item field is " <>
+              "rejected (422).",
+          items: %Schema{
+            type: :object,
+            required: [:type, :value],
+            properties: %{
+              type: %Schema{type: :string, description: "Free-form ref type (<=64 bytes)"},
+              value: %Schema{type: :string, description: "Ref value (<=512 bytes)"},
+              label: %Schema{
+                type: :string,
+                nullable: true,
+                description: "Optional human label (<=128 bytes)"
+              }
+            }
+          }
         }
       },
       example: %{
@@ -937,7 +953,10 @@ defmodule Loopctl.ApiSpec.Schemas do
         body: "pushed PR #107, CI green",
         key: "session_goal",
         session_id: "S1",
-        refs: %{pr: "107", branch: "feature/us-39-2"}
+        refs: [
+          %{type: "pr", value: "107"},
+          %{type: "file", value: "lib/fly/auth.ex:42", label: "the failing call"}
+        ]
       }
     })
   end
@@ -962,7 +981,11 @@ defmodule Loopctl.ApiSpec.Schemas do
             host: %Schema{type: :string, nullable: true},
             key: %Schema{type: :string, nullable: true},
             body: %Schema{type: :string},
-            refs: %Schema{type: :object, nullable: true, additionalProperties: true},
+            refs: %Schema{
+              type: :array,
+              nullable: true,
+              items: %Schema{type: :object, additionalProperties: true}
+            },
             expires_at: %Schema{type: :string, format: :"date-time"},
             inserted_at: %Schema{type: :string, format: :"date-time"},
             updated_at: %Schema{type: :string, format: :"date-time"}
@@ -990,7 +1013,11 @@ defmodule Loopctl.ApiSpec.Schemas do
         host: %Schema{type: :string, nullable: true},
         key: %Schema{type: :string, nullable: true},
         body: %Schema{type: :string},
-        refs: %Schema{type: :object, nullable: true, additionalProperties: true},
+        refs: %Schema{
+          type: :array,
+          nullable: true,
+          items: %Schema{type: :object, additionalProperties: true}
+        },
         inserted_at: %Schema{type: :string, format: :"date-time"},
         updated_at: %Schema{type: :string, format: :"date-time"}
       }

--- a/lib/loopctl/coordination/channel_post.ex
+++ b/lib/loopctl/coordination/channel_post.ex
@@ -38,6 +38,7 @@ defmodule Loopctl.Coordination.ChannelPost do
 
   require Logger
 
+  alias Loopctl.Coordination.RefsList
   alias Loopctl.Security.SecretDenylist
 
   @type t :: %__MODULE__{}
@@ -46,9 +47,30 @@ defmodule Loopctl.Coordination.ChannelPost do
   @key_max_length 200
   @session_id_max_length 200
   @host_max_length 255
+
+  # `refs` is a bounded, typed-OPEN LIST of reference items
+  # `[%{"type" => string, "value" => string, "label" => string?}]` (US-40.A1). The
+  # item-COUNT cap is the PRIMARY bound; the serialized-bytes ceiling is secondary.
+  #
+  #   * <= @refs_max_items (50) items — the primary fan-out/injection bound (do NOT
+  #     rely on the byte backstop alone: at ~16KB it caps at an obscure ~32 items
+  #     and is an amplifier).
+  #   * per item: `type` <= 64 bytes, `value` <= 512 bytes, optional `label` <= 128
+  #     bytes — all FREE strings (no key allowlist; `type` is caller-chosen).
+  #   * total serialized JSON <= @refs_serialized_max_bytes. Sized for the 50-item
+  #     cap: worst case 50 * ({"type":"<=64>","value":"<=512>","label":"<=128>"})
+  #     ~= 37KB, so the ceiling is set above that (48KB) to never reject a legit
+  #     50-item post while still bounding a pathological payload.
+  @ref_type_max_length 64
   @ref_value_max_length 512
-  @refs_serialized_max_bytes 4_096
-  @allowed_ref_keys ~w(file pr branch commit)
+  @ref_label_max_length 128
+  @refs_max_items 50
+  @refs_serialized_max_bytes 49_152
+
+  # The ONLY keys a ref item may carry. Enforced so an item cannot smuggle an extra,
+  # UNSCANNED field onto the 30-day cross-session bus (the secret/NUL scan below
+  # only walks these three keys).
+  @allowed_ref_item_keys ~w(type value label)
 
   @secret_error_message "must not contain a secret or credential"
 
@@ -80,7 +102,7 @@ defmodule Loopctl.Coordination.ChannelPost do
     field :host, :string
     field :key, :string
     field :body, :string
-    field :refs, :map
+    field :refs, RefsList
 
     field :expires_at, :utc_datetime_usec
 
@@ -101,12 +123,14 @@ defmodule Loopctl.Coordination.ChannelPost do
   against a context bug — they are never castable.
 
   Enforces the size/shape bounds (`body` <= 16KB, `key` <= 200 bytes,
-  `session_id` <= 200 bytes, `host` <= 255 bytes, constrained `refs`), rejects
-  NUL bytes in every text field (Postgres cannot store them — the guard turns a
-  raw 500 into a 422), and runs the shared secret denylist over `body`, `key`,
-  `session_id`, `host`, and every `refs` value — a match rejects the write
-  (surfaced as a 422) rather than silently dropping the content or leaking a
-  credential onto the shared, cross-session-readable channel.
+  `session_id` <= 200 bytes, `host` <= 255 bytes, and a bounded typed-open `refs`
+  LIST — at most #{@refs_max_items} items, each `%{"type" => .., "value" => ..,
+  "label"? => ..}` with per-field byte caps), rejects NUL bytes in every text
+  field AND every `refs` item field (Postgres cannot store them — the guard turns
+  a raw 500 into a 422), and runs the shared secret denylist over `body`, `key`,
+  `session_id`, `host`, and EVERY `refs` item field (`type`, `value`, `label`) — a
+  match rejects the write (surfaced as a 422) rather than silently dropping the
+  content or leaking a credential onto the shared, cross-session-readable channel.
 
   A blank (`""`/whitespace-only) `body`, `key`, `session_id`, or `host` is
   normalised to `nil` before the required/uniqueness checks: for `body` this
@@ -148,9 +172,9 @@ defmodule Loopctl.Coordination.ChannelPost do
   @spec body_max_length() :: pos_integer()
   def body_max_length, do: @body_max_length
 
-  @doc "Allowed keys for the `refs` map."
-  @spec allowed_ref_keys() :: [String.t()]
-  def allowed_ref_keys, do: @allowed_ref_keys
+  @doc "Maximum number of items allowed in the `refs` list."
+  @spec refs_max_items() :: pos_integer()
+  def refs_max_items, do: @refs_max_items
 
   # JSON clients routinely send `""` (or whitespace) for an absent field, and in
   # Elixir `""` is truthy — so a blank `key` would force `session_id` to be
@@ -246,19 +270,30 @@ defmodule Loopctl.Coordination.ChannelPost do
     end
   end
 
+  # `refs` is a bounded, typed-OPEN LIST (US-40.A1). The `RefsList` custom type has
+  # already admitted a list (a non-list scalar 422s as a cast error before this
+  # runs); here we enforce the deep invariants and produce SPECIFIC 422 messages.
+  # `cond` order: the item-COUNT cap is checked before per-item shape so a 51-item
+  # payload fails fast on the primary bound; the shape gate must pass before the NUL
+  # scan (which reads item fields); serialized bytes is the secondary ceiling last.
   defp validate_refs(changeset) do
     validate_change(changeset, :refs, fn :refs, refs ->
       cond do
-        not (is_map(refs) and not is_struct(refs)) ->
-          [refs: "must be a map"]
+        not is_list(refs) ->
+          [refs: "must be a list"]
 
-        not (Map.keys(refs) |> Enum.map(&to_string/1) |> Enum.all?(&(&1 in @allowed_ref_keys))) ->
-          [refs: "may only contain keys #{Enum.join(@allowed_ref_keys, ", ")}"]
+        length(refs) > @refs_max_items ->
+          [refs: "must have at most #{@refs_max_items} items"]
 
-        not Enum.all?(Map.values(refs), &valid_ref_value?/1) ->
-          [refs: "values must be strings of at most #{@ref_value_max_length} bytes"]
+        not Enum.all?(refs, &valid_ref_item?/1) ->
+          [
+            refs:
+              "each item must be a map with a string \"type\" (<=#{@ref_type_max_length} bytes) " <>
+                "and \"value\" (<=#{@ref_value_max_length} bytes) and an optional string " <>
+                "\"label\" (<=#{@ref_label_max_length} bytes), and no other keys"
+          ]
 
-        Enum.any?(Map.values(refs), &(is_binary(&1) and String.contains?(&1, <<0>>))) ->
+        Enum.any?(refs, &ref_item_has_null_byte?/1) ->
           # jsonb cannot store a NUL ( ) in a string value — Postgres raises a
           # raw Postgrex.Error (500) at insert. Reject it as a 422 here, matching the
           # text-field NUL guard, so no field is a 500 vector.
@@ -273,13 +308,55 @@ defmodule Loopctl.Coordination.ChannelPost do
     end)
   end
 
-  # Byte-based to match the other text bounds (body/key/session_id/host all use
-  # `validate_length(count: :bytes)`): a grapheme count would let a 512-grapheme
-  # value of multibyte chars blow past the intended per-value storage cap.
-  defp valid_ref_value?(value) when is_binary(value),
-    do: byte_size(value) <= @ref_value_max_length
+  # A valid ref item is a plain map carrying a string `type` and `value` (both
+  # required) and an OPTIONAL string `label` — and NO other keys (an extra key would
+  # be an unscanned exfil field). Missing `type`/`value`, a non-string field, an
+  # over-length field, or an unexpected key all fail → 422.
+  defp valid_ref_item?(item) when is_map(item) and not is_struct(item) do
+    Map.has_key?(item, "type") and Map.has_key?(item, "value") and
+      Enum.all?(Map.keys(item), &(&1 in @allowed_ref_item_keys)) and
+      valid_ref_field?(Map.get(item, "type"), @ref_type_max_length) and
+      valid_ref_field?(Map.get(item, "value"), @ref_value_max_length) and
+      valid_ref_label?(Map.get(item, "label"))
+  end
 
-  defp valid_ref_value?(_), do: false
+  defp valid_ref_item?(_), do: false
+
+  # `label` is optional: absent (`nil`) is fine, otherwise a bounded string.
+  defp valid_ref_label?(nil), do: true
+  defp valid_ref_label?(label), do: valid_ref_field?(label, @ref_label_max_length)
+
+  # Byte-based to match the other text bounds (body/key/session_id/host all use
+  # `validate_length(count: :bytes)`): a grapheme count would let a value of
+  # multibyte chars blow past the intended per-field storage cap.
+  defp valid_ref_field?(value, max) when is_binary(value), do: byte_size(value) <= max
+  defp valid_ref_field?(_, _), do: false
+
+  # True if ANY of a ref item's scanned fields (`type`/`value`/`label`) contains a
+  # NUL byte. Non-map / non-string fields are simply skipped.
+  defp ref_item_has_null_byte?(item) when is_map(item) do
+    item
+    |> Map.take(@allowed_ref_item_keys)
+    |> Map.values()
+    |> Enum.any?(&(is_binary(&1) and String.contains?(&1, <<0>>)))
+  end
+
+  defp ref_item_has_null_byte?(_), do: false
+
+  # Flatten every ref item's scanned string fields (`type`/`value`/`label`) into one
+  # list for the secret denylist scan (AC-40.A1.3) — `nil` labels and any non-string
+  # values drop out via the `is_binary/1` filter.
+  defp flatten_ref_fields(refs) when is_list(refs) do
+    Enum.flat_map(refs, fn
+      item when is_map(item) ->
+        item |> Map.take(@allowed_ref_item_keys) |> Map.values() |> Enum.filter(&is_binary/1)
+
+      _ ->
+        []
+    end)
+  end
+
+  defp flatten_ref_fields(_), do: []
 
   defp refs_serialized_size(refs) do
     case Jason.encode(refs) do
@@ -302,7 +379,11 @@ defmodule Loopctl.Coordination.ChannelPost do
     changeset
     |> add_secret_errors(@scanned_text_fields, &(changeset |> get_field(&1) |> scan_slice()))
     |> add_secret_errors([:refs], fn :refs ->
-      changeset |> get_field(:refs) |> Kernel.||(%{}) |> Map.values() |> Enum.map(&scan_slice/1)
+      # Scan EVERY item field — `type`, `value`, AND `label` — not just values
+      # (AC-40.A1.3): keys/labels are now attacker-writable, so a secret in a ref
+      # `type`/`label` must be rejected exactly as one in `value`. Each field is
+      # `scan_slice/1`'d (bounded scan cost) before the denylist walk.
+      changeset |> get_field(:refs) |> flatten_ref_fields() |> Enum.map(&scan_slice/1)
     end)
   end
 

--- a/lib/loopctl/coordination/channel_post.ex
+++ b/lib/loopctl/coordination/channel_post.ex
@@ -383,9 +383,26 @@ defmodule Loopctl.Coordination.ChannelPost do
       # (AC-40.A1.3): keys/labels are now attacker-writable, so a secret in a ref
       # `type`/`label` must be rejected exactly as one in `value`. Each field is
       # `scan_slice/1`'d (bounded scan cost) before the denylist walk.
-      changeset |> get_field(:refs) |> flatten_ref_fields() |> Enum.map(&scan_slice/1)
+      #
+      # Cap the item COUNT at @refs_max_items BEFORE flattening: an over-cap list is
+      # already rejected by `validate_refs/1`, so items past the cap never persist
+      # and need not be scanned. Without this cap the secret scan walks EVERY item
+      # of an arbitrarily long (up to the 2MB-body) list — a per-rejected-request
+      # CPU-amplification surface that the item-count cap exists precisely to bound
+      # (AC-40.A1.2). `Enum.take/2` on a non-list is a no-op via `cap_refs_for_scan/1`.
+      changeset
+      |> get_field(:refs)
+      |> cap_refs_for_scan()
+      |> flatten_ref_fields()
+      |> Enum.map(&scan_slice/1)
     end)
   end
+
+  # Bound the fan-out of the secret scan to the same item-count cap the persist path
+  # enforces: only the first @refs_max_items items can ever land, so scanning more is
+  # wasted work an attacker could weaponise on a rejected request.
+  defp cap_refs_for_scan(refs) when is_list(refs), do: Enum.take(refs, @refs_max_items)
+  defp cap_refs_for_scan(other), do: other
 
   defp add_secret_errors(changeset, fields, extractor) do
     Enum.reduce(fields, changeset, fn field, acc ->

--- a/lib/loopctl/coordination/refs_list.ex
+++ b/lib/loopctl/coordination/refs_list.ex
@@ -27,6 +27,16 @@ defmodule Loopctl.Coordination.RefsList do
   so a bad scalar/map can never 500 downstream. `load/1`/`dump/1` round-trip the
   list unchanged (already string-keyed maps from `jsonb`), which keeps the keyed-
   slot `on_conflict` upsert (`Loopctl.Coordination`) correct.
+
+  ## Legacy-map load coercion (AC-40.A1.5 — no live row breaks)
+
+  Before US-40.A1 `refs` was a fixed-key MAP, and an empty `%{}` was a valid,
+  persistable value. `load/1` therefore ALSO coerces a stored JSON OBJECT into the
+  list form (`%{}` → `[]`, `{file, pr}` → `[{file}, {pr}]`, key-sorted to mirror
+  the data migration) instead of raising. This is defense-in-depth: the
+  `ReshapeChannelPostsRefsToList` data migration reshapes every object row, but a
+  single legacy row that escaped it (a replica lag, a manual write) must not 500
+  the whole channel read — one un-loadable row would deny the coordination bus.
   """
   use Ecto.Type
 
@@ -41,6 +51,19 @@ defmodule Loopctl.Coordination.RefsList do
   @impl true
   def load(nil), do: {:ok, nil}
   def load(list) when is_list(list), do: {:ok, list}
+  # Coerce a legacy fixed-key MAP (pre-US-40.A1 shape, incl. an empty `%{}`) into
+  # the list form rather than raising — see "Legacy-map load coercion" above. Keys
+  # are sorted so the item order matches the data migration's `ORDER BY key`; each
+  # value is kept as-is (old-shape values were always strings).
+  def load(map) when is_map(map) and not is_struct(map) do
+    list =
+      map
+      |> Enum.sort_by(fn {k, _v} -> k end)
+      |> Enum.map(fn {k, v} -> %{"type" => to_string(k), "value" => v} end)
+
+    {:ok, list}
+  end
+
   def load(_), do: :error
 
   @impl true

--- a/lib/loopctl/coordination/refs_list.ex
+++ b/lib/loopctl/coordination/refs_list.ex
@@ -28,17 +28,26 @@ defmodule Loopctl.Coordination.RefsList do
   list unchanged (already string-keyed maps from `jsonb`), which keeps the keyed-
   slot `on_conflict` upsert (`Loopctl.Coordination`) correct.
 
-  ## Legacy-map load coercion (AC-40.A1.5 — no live row breaks)
+  ## Load fail-soft (AC-40.A1.5 — no live row breaks)
 
   Before US-40.A1 `refs` was a fixed-key MAP, and an empty `%{}` was a valid,
-  persistable value. `load/1` therefore ALSO coerces a stored JSON OBJECT into the
-  list form (`%{}` → `[]`, `{file, pr}` → `[{file}, {pr}]`, key-sorted to mirror
-  the data migration) instead of raising. This is defense-in-depth: the
+  persistable value. `load/1` therefore coerces a stored JSON OBJECT into the list
+  form (`%{}` → `[]`, `{file, pr}` → `[{file}, {pr}]`, key-sorted to mirror the
+  data migration) instead of raising. This is defense-in-depth: the
   `ReshapeChannelPostsRefsToList` data migration reshapes every object row, but a
   single legacy row that escaped it (a replica lag, a manual write) must not 500
   the whole channel read — one un-loadable row would deny the coordination bus.
+
+  For completeness the SAME invariant covers an UNEXPECTED stored jsonb SCALAR
+  (string/number/boolean) — a shape neither the old fixed-key map schema nor `up/0`
+  could ever persist, reachable only via corruption or a manual write. Rather than
+  raise an `Ecto` load error and 500 the channel read, `load/1` coerces it to `nil`
+  (an empty ref set) and logs a warning so the corrupt row is surfaced, not
+  silently hidden. Any loadable value is thus one no un-loadable row can deny.
   """
   use Ecto.Type
+
+  require Logger
 
   @impl true
   def type, do: :map
@@ -64,7 +73,17 @@ defmodule Loopctl.Coordination.RefsList do
     {:ok, list}
   end
 
-  def load(_), do: :error
+  # Fail-soft on an unexpected stored jsonb SCALAR (string/number/boolean) — a shape
+  # neither the old map schema nor `up/0` could persist, only reachable via
+  # corruption/manual write. Coerce to `nil` (empty ref set) instead of raising a
+  # load error that would 500 the channel read; log so the corrupt row is surfaced.
+  def load(other) do
+    Logger.warning(
+      "RefsList.load/1 coercing unexpected stored refs value to nil: #{inspect(other)}"
+    )
+
+    {:ok, nil}
+  end
 
   @impl true
   def dump(nil), do: {:ok, nil}

--- a/lib/loopctl/coordination/refs_list.ex
+++ b/lib/loopctl/coordination/refs_list.ex
@@ -1,0 +1,60 @@
+defmodule Loopctl.Coordination.RefsList do
+  @moduledoc """
+  Custom `Ecto.Type` for `channel_posts.refs`: a bounded, typed-OPEN LIST of
+  reference items `[%{"type" => string, "value" => string, "label" => string?}]`.
+
+  ## Why a custom type (US-40.A1)
+
+  `refs` was a FIXED-KEY map (`field :refs, :map`, allowlist `~w(file pr branch
+  commit)`). A map holds one value per key, so it cannot express a real handoff
+  pointing at many issues / many `file:line` pairs / several commits. The list
+  form does, with a FREE `type` (no allowlist) but an explicit item-count cap
+  (enforced in `ChannelPost.validate_refs/1`).
+
+  The list is stored in the EXISTING SCALAR `jsonb` column: `type/0` returns
+  `:map`, so Ecto/Postgrex encode the top-level JSON ARRAY into the same `jsonb`
+  column the fixed-key map used — no column-type change (a `{:array, :map}` field
+  would instead map to a Postgres `jsonb[]` ARRAY column and mismatch the scalar
+  `jsonb` column). A DATA migration reshapes any existing stored maps.
+
+  ## Leniency contract
+
+  `cast/1` is deliberately LENIENT: it admits ANY list (normalising each map
+  item's keys to strings) so the changeset's `validate_refs/1` runs the deep
+  checks — per-item shape, byte-length caps, item-count cap, NUL bytes, secret
+  denylist — and surfaces SPECIFIC accumulated 422 errors rather than a single
+  opaque cast error (AC-40.A1.4). `cast/1` rejects only a non-list, non-nil scalar
+  so a bad scalar/map can never 500 downstream. `load/1`/`dump/1` round-trip the
+  list unchanged (already string-keyed maps from `jsonb`), which keeps the keyed-
+  slot `on_conflict` upsert (`Loopctl.Coordination`) correct.
+  """
+  use Ecto.Type
+
+  @impl true
+  def type, do: :map
+
+  @impl true
+  def cast(nil), do: {:ok, nil}
+  def cast(list) when is_list(list), do: {:ok, Enum.map(list, &normalize_item/1)}
+  def cast(_), do: :error
+
+  @impl true
+  def load(nil), do: {:ok, nil}
+  def load(list) when is_list(list), do: {:ok, list}
+  def load(_), do: :error
+
+  @impl true
+  def dump(nil), do: {:ok, nil}
+  def dump(list) when is_list(list), do: {:ok, list}
+  def dump(_), do: :error
+
+  # Normalise a map item's keys to strings so `validate_refs/1`, the secret scan,
+  # and the JSON response see a uniform string-keyed shape regardless of whether
+  # the caller sent string or atom keys. A non-map item is passed through untouched
+  # for `validate_refs/1` to reject with a specific 422 (never swallowed here).
+  defp normalize_item(item) when is_map(item) and not is_struct(item) do
+    Map.new(item, fn {k, v} -> {to_string(k), v} end)
+  end
+
+  defp normalize_item(item), do: item
+end

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -2280,14 +2280,22 @@ const TOOLS = [
             "Optional per-session working-state slot key. When given, upserts the caller's slot for that key instead of appending a new post. Requires an active Claude Code session: the upsert is keyed on the auto-filled session_id (from CLAUDE_SESSION_ID), so a keyed post made outside a Claude Code session — where that env var is absent — is rejected with a 422 (session_id can't be blank). Omit key to append a plain post, which needs no session.",
         },
         refs: {
-          type: "object",
+          type: "array",
           description:
-            "Optional structured references map: { file, pr, branch, commit }.",
-          properties: {
-            file: { type: "string" },
-            pr: { type: "string" },
-            branch: { type: "string" },
-            commit: { type: "string" },
+            "Optional bounded LIST of structured reference items (max ~50 items). Each item is " +
+            "{ type, value, label? }: type is a FREE string (e.g. issue, file, pr, branch, commit, " +
+            "capability — no fixed allowlist), value is the pointer (e.g. #812, lib/fly/auth.ex:42), " +
+            "and label is an optional human note. Use one item PER reference — a handoff can point at " +
+            "many issues / file:line pairs / commits. Over the ~50-item cap is rejected (422); a " +
+            "secret or NUL byte in ANY item field (type/value/label) is also rejected (422).",
+          items: {
+            type: "object",
+            properties: {
+              type: { type: "string", description: "Free-form ref type (<=64 bytes)." },
+              value: { type: "string", description: "Ref value/pointer (<=512 bytes)." },
+              label: { type: "string", description: "Optional human label (<=128 bytes)." },
+            },
+            required: ["type", "value"],
           },
         },
       },

--- a/priv/repo/migrations/20260718010000_reshape_channel_posts_refs_to_list.exs
+++ b/priv/repo/migrations/20260718010000_reshape_channel_posts_refs_to_list.exs
@@ -1,0 +1,47 @@
+defmodule Loopctl.Repo.Migrations.ReshapeChannelPostsRefsToList do
+  @moduledoc """
+  US-40.A1: reshape `channel_posts.refs` from a fixed-key MAP
+  (`{file,pr,branch,commit}`) to a typed-OPEN LIST of items
+  `[{"type": <key>, "value": <value>}]`.
+
+  DATA migration only — the column stays a SCALAR `jsonb` (the new
+  `Loopctl.Coordination.RefsList` custom `Ecto.Type` maps to `:map`/`jsonb`, now
+  holding a top-level JSON array instead of an object). No column-type change.
+
+  Idempotent / re-run-safe: only rows whose `refs` is a JSON OBJECT are reshaped;
+  rows already an array, or NULL, or an empty `{}` are left untouched. Item order
+  is STABLE (`ORDER BY key`, deterministic) so a `{file, pr}` map reshapes to
+  `[{file}, {pr}]`.
+  """
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    UPDATE channel_posts
+    SET refs = (
+      SELECT jsonb_agg(
+               jsonb_build_object('type', key, 'value', value)
+               ORDER BY key
+             )
+      FROM jsonb_each_text(refs)
+    )
+    WHERE refs IS NOT NULL
+      AND jsonb_typeof(refs) = 'object'
+      AND refs <> '{}'::jsonb
+    """)
+  end
+
+  def down do
+    execute("""
+    UPDATE channel_posts
+    SET refs = (
+      SELECT jsonb_object_agg(item ->> 'type', item ->> 'value')
+      FROM jsonb_array_elements(refs) AS item
+      WHERE item ? 'type' AND item ? 'value'
+    )
+    WHERE refs IS NOT NULL
+      AND jsonb_typeof(refs) = 'array'
+      AND jsonb_array_length(refs) > 0
+    """)
+  end
+end

--- a/priv/repo/migrations/20260718010000_reshape_channel_posts_refs_to_list.exs
+++ b/priv/repo/migrations/20260718010000_reshape_channel_posts_refs_to_list.exs
@@ -16,6 +16,24 @@ defmodule Loopctl.Repo.Migrations.ReshapeChannelPostsRefsToList do
   row MUST be normalised, not just the non-empty ones (AC-40.A1.5: no live row
   breaks). Rows already an array, or NULL, are left untouched. Item order is STABLE
   (`ORDER BY key`, deterministic) so a `{file, pr}` map reshapes to `[{file}, {pr}]`.
+
+  ## `down/0` is INTENTIONALLY LOSSY
+
+  Rolling back folds the list back to a fixed-key map via `jsonb_object_agg(type ->
+  value)`. This is a deliberately lossy inverse because the reshape is an
+  EXPRESSIVENESS EXPANSION the old map shape cannot represent:
+
+    * Multiple items sharing a `type` (the exact multi-issue / multi-`file:line`
+      handoff this story exists to enable) collapse to the LAST value for that key —
+      `[{file:a}, {file:b}]` rolls back to `{"file": "b"}`.
+    * The optional `label` is dropped entirely (`down` folds only `type -> value`).
+
+  This is acceptable: `down/0` exists to restore the OLD SCHEMA shape, not to
+  round-trip data the old schema never supported. The `WHERE item ->> 'type' IS NOT
+  NULL` guard skips any element with a JSON-null `type` (only reachable via a
+  corrupt/manual row — `validate_refs` and `up/0` never emit one) so
+  `jsonb_object_agg` cannot raise `field name must not be null` and abort the
+  rollback.
   """
   use Ecto.Migration
 
@@ -45,6 +63,7 @@ defmodule Loopctl.Repo.Migrations.ReshapeChannelPostsRefsToList do
         SELECT jsonb_object_agg(item ->> 'type', item ->> 'value')
         FROM jsonb_array_elements(refs) AS item
         WHERE item ? 'type' AND item ? 'value'
+          AND item ->> 'type' IS NOT NULL
       ),
       '{}'::jsonb
     )

--- a/priv/repo/migrations/20260718010000_reshape_channel_posts_refs_to_list.exs
+++ b/priv/repo/migrations/20260718010000_reshape_channel_posts_refs_to_list.exs
@@ -8,40 +8,48 @@ defmodule Loopctl.Repo.Migrations.ReshapeChannelPostsRefsToList do
   `Loopctl.Coordination.RefsList` custom `Ecto.Type` maps to `:map`/`jsonb`, now
   holding a top-level JSON array instead of an object). No column-type change.
 
-  Idempotent / re-run-safe: only rows whose `refs` is a JSON OBJECT are reshaped;
-  rows already an array, or NULL, or an empty `{}` are left untouched. Item order
-  is STABLE (`ORDER BY key`, deterministic) so a `{file, pr}` map reshapes to
-  `[{file}, {pr}]`.
+  Idempotent / re-run-safe: EVERY row whose `refs` is a JSON OBJECT is reshaped —
+  including an empty `{}`, which becomes an empty LIST `[]` (via `COALESCE(..,
+  '[]')`, since `jsonb_agg` over zero pairs is NULL). Skipping `{}` would leave a
+  live row the `RefsList` custom type cannot load (`load/1` accepts only a list or
+  nil and would raise on a map), 500-ing the whole channel read — so every object
+  row MUST be normalised, not just the non-empty ones (AC-40.A1.5: no live row
+  breaks). Rows already an array, or NULL, are left untouched. Item order is STABLE
+  (`ORDER BY key`, deterministic) so a `{file, pr}` map reshapes to `[{file}, {pr}]`.
   """
   use Ecto.Migration
 
   def up do
     execute("""
     UPDATE channel_posts
-    SET refs = (
-      SELECT jsonb_agg(
-               jsonb_build_object('type', key, 'value', value)
-               ORDER BY key
-             )
-      FROM jsonb_each_text(refs)
+    SET refs = COALESCE(
+      (
+        SELECT jsonb_agg(
+                 jsonb_build_object('type', key, 'value', value)
+                 ORDER BY key
+               )
+        FROM jsonb_each_text(refs)
+      ),
+      '[]'::jsonb
     )
     WHERE refs IS NOT NULL
       AND jsonb_typeof(refs) = 'object'
-      AND refs <> '{}'::jsonb
     """)
   end
 
   def down do
     execute("""
     UPDATE channel_posts
-    SET refs = (
-      SELECT jsonb_object_agg(item ->> 'type', item ->> 'value')
-      FROM jsonb_array_elements(refs) AS item
-      WHERE item ? 'type' AND item ? 'value'
+    SET refs = COALESCE(
+      (
+        SELECT jsonb_object_agg(item ->> 'type', item ->> 'value')
+        FROM jsonb_array_elements(refs) AS item
+        WHERE item ? 'type' AND item ? 'value'
+      ),
+      '{}'::jsonb
     )
     WHERE refs IS NOT NULL
       AND jsonb_typeof(refs) = 'array'
-      AND jsonb_array_length(refs) > 0
     """)
   end
 end

--- a/test/loopctl/coordination/channel_post_test.exs
+++ b/test/loopctl/coordination/channel_post_test.exs
@@ -150,6 +150,54 @@ defmodule Loopctl.Coordination.ChannelPostTest do
       assert %{refs: _} = errors_on(cs)
     end
 
+    # AC-40.A1.4 — a non-string field (a scalar number, or a nested map/list value)
+    # in an otherwise well-shaped item is malformed and must be rejected as a 422,
+    # not persisted or crashed. The `is_binary` guard in valid_ref_field?/2 (and the
+    # nil clause in valid_ref_label?/1) handle it; this pins the AC-named edge case.
+    test "rejects a non-string ref value (number)" do
+      cs =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "ok",
+          "refs" => [%{"type" => "file", "value" => 123}]
+        })
+
+      refute cs.valid?
+      assert %{refs: _} = errors_on(cs)
+    end
+
+    test "rejects a non-string ref type (number)" do
+      cs =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "ok",
+          "refs" => [%{"type" => 7, "value" => "x"}]
+        })
+
+      refute cs.valid?
+      assert %{refs: _} = errors_on(cs)
+    end
+
+    test "rejects a nested (non-string) ref value" do
+      cs =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "ok",
+          "refs" => [%{"type" => "file", "value" => %{"nested" => "obj"}}]
+        })
+
+      refute cs.valid?
+      assert %{refs: _} = errors_on(cs)
+    end
+
+    test "rejects a non-string ref label" do
+      cs =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "ok",
+          "refs" => [%{"type" => "file", "value" => "x", "label" => 99}]
+        })
+
+      refute cs.valid?
+      assert %{refs: _} = errors_on(cs)
+    end
+
     test "rejects an over-length ref type" do
       cs =
         ChannelPost.create_changeset(base_struct(), %{

--- a/test/loopctl/coordination/channel_post_test.exs
+++ b/test/loopctl/coordination/channel_post_test.exs
@@ -72,22 +72,111 @@ defmodule Loopctl.Coordination.ChannelPostTest do
       assert %{body: _} = errors_on(cs)
     end
 
-    test "rejects refs with a key outside the allowlist" do
+    # TC-40.A1.1 — a multi-item typed-open list is accepted and round-trips as the list.
+    test "accepts a multi-item typed-open refs list" do
+      refs = [
+        %{"type" => "issue", "value" => "#812"},
+        %{"type" => "file", "value" => "lib/a.ex:1", "label" => "the failing call"},
+        %{"type" => "commit", "value" => "abc123"}
+      ]
+
+      cs = ChannelPost.create_changeset(base_struct(), %{"body" => "ok", "refs" => refs})
+      assert cs.valid?
+      assert Ecto.Changeset.get_field(cs, :refs) == refs
+    end
+
+    # TC-40.A1.2 — the fixed-key allowlist is GONE; a free `type` is accepted.
+    test "accepts a free ref type not in the old allowlist" do
       cs =
         ChannelPost.create_changeset(base_struct(), %{
           "body" => "ok",
-          "refs" => %{"evil" => "value"}
+          "refs" => [%{"type" => "capability", "value" => "read:secrets"}]
+        })
+
+      assert cs.valid?
+    end
+
+    # TC-40.A1.5 — the explicit item-count cap (not just the byte backstop).
+    test "rejects a refs list over the item-count cap" do
+      over =
+        for i <- 1..(ChannelPost.refs_max_items() + 1), do: %{"type" => "t", "value" => "#{i}"}
+
+      cs = ChannelPost.create_changeset(base_struct(), %{"body" => "ok", "refs" => over})
+      refute cs.valid?
+      assert %{refs: _} = errors_on(cs)
+    end
+
+    test "accepts a refs list exactly at the item-count cap" do
+      at = for i <- 1..ChannelPost.refs_max_items(), do: %{"type" => "t", "value" => "#{i}"}
+      cs = ChannelPost.create_changeset(base_struct(), %{"body" => "ok", "refs" => at})
+      assert cs.valid?
+    end
+
+    # TC-40.A1.6 — malformed items are 422 changeset errors, never a 500.
+    test "rejects malformed refs items as 422, not a crash" do
+      # item missing a required `type`
+      cs_missing =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "ok",
+          "refs" => [%{"value" => "x"}]
+        })
+
+      refute cs_missing.valid?
+      assert %{refs: _} = errors_on(cs_missing)
+
+      # items that are not maps
+      cs_scalars =
+        ChannelPost.create_changeset(base_struct(), %{"body" => "ok", "refs" => ["a", "b"]})
+
+      refute cs_scalars.valid?
+      assert %{refs: _} = errors_on(cs_scalars)
+
+      # a non-list refs value (cast-level rejection, still a 422 not a 500)
+      cs_nonlist =
+        ChannelPost.create_changeset(base_struct(), %{"body" => "ok", "refs" => %{"file" => "x"}})
+
+      refute cs_nonlist.valid?
+      assert %{refs: _} = errors_on(cs_nonlist)
+    end
+
+    test "rejects a ref item carrying an unexpected key (no unscanned exfil field)" do
+      cs =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "ok",
+          "refs" => [%{"type" => "file", "value" => "x", "evil" => "y"}]
         })
 
       refute cs.valid?
       assert %{refs: _} = errors_on(cs)
     end
 
-    test "rejects an over-large refs value" do
+    test "rejects an over-length ref type" do
       cs =
         ChannelPost.create_changeset(base_struct(), %{
           "body" => "ok",
-          "refs" => %{"branch" => String.duplicate("x", 9_000)}
+          "refs" => [%{"type" => String.duplicate("t", 65), "value" => "x"}]
+        })
+
+      refute cs.valid?
+      assert %{refs: _} = errors_on(cs)
+    end
+
+    test "rejects an over-length ref value" do
+      cs =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "ok",
+          "refs" => [%{"type" => "branch", "value" => String.duplicate("x", 513)}]
+        })
+
+      refute cs.valid?
+      assert %{refs: _} = errors_on(cs)
+    end
+
+    test "rejects an over-length ref label" do
+      cs =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "ok",
+          "refs" => [%{"type" => "file", "value" => "x", "label" => String.duplicate("l", 129)}]
         })
 
       refute cs.valid?
@@ -145,7 +234,7 @@ defmodule Loopctl.Coordination.ChannelPostTest do
       end
     end
 
-    test "refs value cap is byte-based, not grapheme-based" do
+    test "ref value cap is byte-based, not grapheme-based" do
       # 200 four-byte chars = 800 bytes > 512, but only 200 graphemes — a
       # grapheme-based cap would wrongly accept it.
       val = String.duplicate("😀", 200)
@@ -155,7 +244,7 @@ defmodule Loopctl.Coordination.ChannelPostTest do
       cs =
         ChannelPost.create_changeset(base_struct(), %{
           "body" => "ok",
-          "refs" => %{"branch" => val}
+          "refs" => [%{"type" => "branch", "value" => val}]
         })
 
       refute cs.valid?
@@ -191,8 +280,8 @@ defmodule Loopctl.Coordination.ChannelPostTest do
       assert Enum.any?(errors_on(cs).host, &(&1 =~ "byte"))
     end
 
-    test "an oversized refs value cannot bypass the secret scan cap" do
-      # refs values are also scanned over a bounded slice — an oversized refs value
+    test "an oversized ref value cannot bypass the secret scan cap" do
+      # ref fields are also scanned over a bounded slice — an oversized ref value
       # (rejected by validate_refs) does not amplify the denylist scan, and a
       # credential in its leading bytes is still detected.
       big_ref = "sk-" <> String.duplicate("a", 2_000)
@@ -200,7 +289,7 @@ defmodule Loopctl.Coordination.ChannelPostTest do
       cs =
         ChannelPost.create_changeset(base_struct(), %{
           "body" => "ok",
-          "refs" => %{"file" => big_ref}
+          "refs" => [%{"type" => "file", "value" => big_ref}]
         })
 
       refute cs.valid?
@@ -237,15 +326,35 @@ defmodule Loopctl.Coordination.ChannelPostTest do
       assert %{body: _} = errors_on(cs)
     end
 
-    test "rejects a NUL byte in a refs value (jsonb would 500 otherwise)" do
+    test "rejects a NUL byte in a ref value (jsonb would 500 otherwise)" do
       cs =
         ChannelPost.create_changeset(base_struct(), %{
           "body" => "ok",
-          "refs" => %{"branch" => "main" <> <<0>> <> "x"}
+          "refs" => [%{"type" => "branch", "value" => "main" <> <<0>> <> "x"}]
         })
 
       refute cs.valid?
       assert %{refs: _} = errors_on(cs)
+    end
+
+    test "rejects a NUL byte in a ref type or label" do
+      cs_type =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "ok",
+          "refs" => [%{"type" => "br" <> <<0>> <> "anch", "value" => "x"}]
+        })
+
+      refute cs_type.valid?
+      assert %{refs: _} = errors_on(cs_type)
+
+      cs_label =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "ok",
+          "refs" => [%{"type" => "file", "value" => "x", "label" => "a" <> <<0>> <> "b"}]
+        })
+
+      refute cs_label.valid?
+      assert %{refs: _} = errors_on(cs_label)
     end
 
     test "rejects a NUL byte in session_id" do
@@ -271,15 +380,72 @@ defmodule Loopctl.Coordination.ChannelPostTest do
       assert %{body: _} = errors_on(cs)
     end
 
-    test "rejects a secret in a refs value" do
+    test "rejects a secret in a ref value" do
       cs =
         ChannelPost.create_changeset(base_struct(), %{
           "body" => "ok",
-          "refs" => %{"branch" => "lc_" <> String.duplicate("a", 30)}
+          "refs" => [%{"type" => "branch", "value" => "lc_" <> String.duplicate("a", 30)}]
         })
 
       refute cs.valid?
       assert %{refs: _} = errors_on(cs)
+    end
+
+    # TC-40.A1.3 — a secret in a ref TYPE is scanned + rejected (keys are now
+    # attacker-writable), exactly as one in `value`.
+    test "rejects a secret in a ref type" do
+      cs =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "ok",
+          "refs" => [%{"type" => "lc_" <> String.duplicate("a", 30), "value" => "x"}]
+        })
+
+      refute cs.valid?
+      assert %{refs: _} = errors_on(cs)
+    end
+
+    # TC-40.A1.4 — a secret in a ref LABEL is scanned + rejected.
+    test "rejects a secret in a ref label" do
+      cs =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "ok",
+          "refs" => [
+            %{"type" => "file", "value" => "x", "label" => "sk-" <> String.duplicate("a", 30)}
+          ]
+        })
+
+      refute cs.valid?
+      assert %{refs: _} = errors_on(cs)
+    end
+
+    # The refs secret hit fires the operator-visible secret_blocked signal on the
+    # :refs field (the rejection path), same as a body hit.
+    test "a secret in a ref field fires the secret_blocked signal for :refs" do
+      struct = base_struct()
+      tenant_id = struct.tenant_id
+      handler_id = "chanpost-refs-secret-#{System.unique_integer([:positive])}"
+      test_pid = self()
+
+      :telemetry.attach(
+        handler_id,
+        [:loopctl, :coordination, :secret_blocked],
+        fn _event, _measurements, meta, _cfg ->
+          if meta[:tenant_id] == tenant_id and meta[:field] == :refs,
+            do: send(test_pid, :refs_secret_blocked)
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      cs =
+        ChannelPost.create_changeset(struct, %{
+          "body" => "ok",
+          "refs" => [%{"type" => "lc_" <> String.duplicate("a", 30), "value" => "x"}]
+        })
+
+      ChannelPost.emit_secret_blocked_events(cs)
+      assert_receive :refs_secret_blocked, 100
     end
 
     test "rejects a secret in the key" do

--- a/test/loopctl/coordination_test.exs
+++ b/test/loopctl/coordination_test.exs
@@ -100,18 +100,25 @@ defmodule Loopctl.CoordinationTest do
       assert %{key: _} = errors_on(cs)
     end
 
-    test "accepts valid refs restricted to the allowlist" do
+    test "accepts a typed-open refs list and round-trips it through the DB" do
       tenant = fixture(:tenant)
       project = fixture(:project, %{tenant_id: tenant.id})
       agent_id = fixture(:agent, %{tenant_id: tenant.id}).id
 
+      refs = [
+        %{"type" => "pr", "value" => "107"},
+        %{"type" => "branch", "value" => "epic-39-us-39.1"}
+      ]
+
       assert {:ok, post} =
                Coordination.create_post(tenant.id, project.id, agent_id, %{
                  "body" => "see the fix",
-                 "refs" => %{"pr" => "107", "branch" => "epic-39-us-39.1"}
+                 "refs" => refs
                })
 
-      assert post.refs == %{"pr" => "107", "branch" => "epic-39-us-39.1"}
+      assert post.refs == refs
+      # persisted list survives a fresh read (RefsList.load round-trip)
+      assert [%ChannelPost{refs: ^refs}] = Coordination.recent(tenant.id, project.id)
     end
   end
 

--- a/test/loopctl/repo/reshape_channel_posts_refs_migration_test.exs
+++ b/test/loopctl/repo/reshape_channel_posts_refs_migration_test.exs
@@ -1,0 +1,63 @@
+defmodule Loopctl.Repo.ReshapeChannelPostsRefsMigrationTest do
+  @moduledoc """
+  US-40.A1 / TC-40.A1.7 — the data migration
+  `ReshapeChannelPostsRefsToList` reshapes any existing stored `refs` MAP
+  (`{file, pr}`) into the typed-open LIST form
+  (`[{type: file, value: ...}, {type: pr, value: ...}]`) so no live row breaks
+  when `field :refs` becomes the `RefsList` custom type.
+
+  We seed a row, then stamp its `refs` column with the OLD map shape via raw SQL
+  (the changeset now rejects a map, so we bypass it), run the migration's `up`
+  transformation, and assert the row is now the list — with a STABLE item order
+  (`ORDER BY key`, so `file` precedes `pr`).
+  """
+  use Loopctl.DataCase, async: true
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Coordination
+  alias Loopctl.Coordination.ChannelPost
+
+  # Mirrors ReshapeChannelPostsRefsToList.up/0 exactly (a data migration's UPDATE),
+  # run inside the test transaction against the seeded old-shape row. Kept in sync
+  # with priv/repo/migrations/20260718010000_reshape_channel_posts_refs_to_list.exs.
+  @reshape_up """
+  UPDATE channel_posts
+  SET refs = (
+    SELECT jsonb_agg(jsonb_build_object('type', key, 'value', value) ORDER BY key)
+    FROM jsonb_each_text(refs)
+  )
+  WHERE refs IS NOT NULL
+    AND jsonb_typeof(refs) = 'object'
+    AND refs <> '{}'::jsonb
+  """
+
+  test "reshapes an existing refs map into the typed-open list, order stable" do
+    tenant = fixture(:tenant)
+    project = fixture(:project, %{tenant_id: tenant.id})
+    agent = fixture(:agent, %{tenant_id: tenant.id})
+
+    {:ok, post} = Coordination.create_post(tenant.id, project.id, agent.id, %{"body" => "seed"})
+
+    # Stamp the OLD fixed-key MAP shape directly into the jsonb column. Pass an
+    # Elixir MAP (not a JSON string) so Postgrex encodes a jsonb OBJECT — a text
+    # param would be double-encoded into a jsonb string scalar.
+    %{num_rows: 1} =
+      AdminRepo.query!(
+        "UPDATE channel_posts SET refs = $1 WHERE id = $2",
+        [%{"file" => "x", "pr" => "1"}, Ecto.UUID.dump!(post.id)]
+      )
+
+    # Run the migration's reshape transformation — it matches our object row.
+    %{num_rows: reshaped} = AdminRepo.query!(@reshape_up)
+    assert reshaped >= 1
+
+    # Read back through the schema (RefsList.load) — the row now loads as the list.
+    reloaded = AdminRepo.get!(ChannelPost, post.id)
+
+    # file precedes pr (ORDER BY key), values preserved.
+    assert reloaded.refs == [
+             %{"type" => "file", "value" => "x"},
+             %{"type" => "pr", "value" => "1"}
+           ]
+  end
+end

--- a/test/loopctl/repo/reshape_channel_posts_refs_migration_test.exs
+++ b/test/loopctl/repo/reshape_channel_posts_refs_migration_test.exs
@@ -6,50 +6,84 @@ defmodule Loopctl.Repo.ReshapeChannelPostsRefsMigrationTest do
   (`[{type: file, value: ...}, {type: pr, value: ...}]`) so no live row breaks
   when `field :refs` becomes the `RefsList` custom type.
 
-  We seed a row, then stamp its `refs` column with the OLD map shape via raw SQL
-  (the changeset now rejects a map, so we bypass it), run the migration's `up`
-  transformation, and assert the row is now the list — with a STABLE item order
-  (`ORDER BY key`, so `file` precedes `pr`).
+  We seed a row, stamp its `refs` column with the OLD map shape via raw SQL (the
+  changeset now rejects a map, so we bypass it), then drive the REAL migration
+  module's `up/0` and assert the row is now the list.
+
+  ## How the migration is driven
+
+  The migration file under `priv/repo/migrations` is not compiled into the app, so
+  it is loaded here at runtime (`Code.require_file`) and driven with
+  `Ecto.Migration.Runner.run/8` DIRECTLY — the same entry point
+  `Ecto.Migrator.attempt/7` uses — rather than via `Ecto.Migrator.up`. `Runner.run`
+  performs the operation in THIS process, so the UPDATE executes inside the sandbox
+  transaction (and is rolled back on exit) instead of a spawned Task under its own
+  transaction/lock that could not check out the sandbox-owned connection. This
+  exercises the SHIPPED `up/0` verbatim (single source of truth), so a defect edited
+  into the migration file WILL fail this test — unlike a hand-copied SQL heredoc.
   """
   use Loopctl.DataCase, async: true
 
+  alias Ecto.Migration.Runner
   alias Loopctl.AdminRepo
   alias Loopctl.Coordination
   alias Loopctl.Coordination.ChannelPost
 
-  # Mirrors ReshapeChannelPostsRefsToList.up/0 exactly (a data migration's UPDATE),
-  # run inside the test transaction against the seeded old-shape row. Kept in sync
-  # with priv/repo/migrations/20260718010000_reshape_channel_posts_refs_to_list.exs.
-  @reshape_up """
-  UPDATE channel_posts
-  SET refs = (
-    SELECT jsonb_agg(jsonb_build_object('type', key, 'value', value) ORDER BY key)
-    FROM jsonb_each_text(refs)
-  )
-  WHERE refs IS NOT NULL
-    AND jsonb_typeof(refs) = 'object'
-    AND refs <> '{}'::jsonb
-  """
+  @migration_version 20_260_718_010_000
+  @migration_file Path.wildcard(
+                    Path.join([
+                      File.cwd!(),
+                      "priv",
+                      "repo",
+                      "migrations",
+                      "#{@migration_version}_*.exs"
+                    ])
+                  )
+                  |> hd()
 
-  test "reshapes an existing refs map into the typed-open list, order stable" do
+  Code.require_file(@migration_file)
+
+  alias Loopctl.Repo.Migrations.ReshapeChannelPostsRefsToList
+
+  # Drive the real migration's up/0 in THIS process (mirrors Ecto.Migrator.attempt/7
+  # for an explicit up/0 running :forward), so the UPDATE runs inside the sandbox
+  # transaction against the seeded row.
+  defp run_migration_up do
+    Runner.run(
+      AdminRepo,
+      AdminRepo.config(),
+      @migration_version,
+      ReshapeChannelPostsRefsToList,
+      :forward,
+      :up,
+      :up,
+      log: false
+    )
+  end
+
+  # Seed a valid post, then stamp its `refs` column with an arbitrary raw jsonb
+  # value (an Elixir term Postgrex encodes as jsonb — a MAP for the old object shape,
+  # never a JSON string which would double-encode into a jsonb string scalar).
+  defp seed_post_with_raw_refs(raw_refs) do
     tenant = fixture(:tenant)
     project = fixture(:project, %{tenant_id: tenant.id})
     agent = fixture(:agent, %{tenant_id: tenant.id})
 
     {:ok, post} = Coordination.create_post(tenant.id, project.id, agent.id, %{"body" => "seed"})
 
-    # Stamp the OLD fixed-key MAP shape directly into the jsonb column. Pass an
-    # Elixir MAP (not a JSON string) so Postgrex encodes a jsonb OBJECT — a text
-    # param would be double-encoded into a jsonb string scalar.
     %{num_rows: 1} =
       AdminRepo.query!(
         "UPDATE channel_posts SET refs = $1 WHERE id = $2",
-        [%{"file" => "x", "pr" => "1"}, Ecto.UUID.dump!(post.id)]
+        [raw_refs, Ecto.UUID.dump!(post.id)]
       )
 
-    # Run the migration's reshape transformation — it matches our object row.
-    %{num_rows: reshaped} = AdminRepo.query!(@reshape_up)
-    assert reshaped >= 1
+    post
+  end
+
+  test "reshapes an existing refs map into the typed-open list, order stable" do
+    post = seed_post_with_raw_refs(%{"file" => "x", "pr" => "1"})
+
+    assert :ok = run_migration_up()
 
     # Read back through the schema (RefsList.load) — the row now loads as the list.
     reloaded = AdminRepo.get!(ChannelPost, post.id)
@@ -59,5 +93,29 @@ defmodule Loopctl.Repo.ReshapeChannelPostsRefsMigrationTest do
              %{"type" => "file", "value" => "x"},
              %{"type" => "pr", "value" => "1"}
            ]
+  end
+
+  # AC-40.A1.5 — a legacy EMPTY map (`{}`) was a valid persistable value under the
+  # old fixed-key-map shape. The migration must normalise it to an empty list `[]`;
+  # skipping it (as the original `refs <> '{}'` guard did) leaves a row the RefsList
+  # type cannot load, which would 500 the whole channel read.
+  test "normalises a legacy empty-map row to an empty list (does not skip it)" do
+    post = seed_post_with_raw_refs(%{})
+
+    assert :ok = run_migration_up()
+
+    reloaded = AdminRepo.get!(ChannelPost, post.id)
+    assert reloaded.refs == []
+  end
+
+  # Defense-in-depth: even WITHOUT the migration, a legacy map row must not crash the
+  # schema load (one un-loadable row denies the coordination bus). RefsList.load/1
+  # coerces the map to the list form.
+  test "RefsList.load coerces a legacy empty-map row without the migration" do
+    post = seed_post_with_raw_refs(%{})
+
+    # No migration run here — load must still succeed.
+    reloaded = AdminRepo.get!(ChannelPost, post.id)
+    assert reloaded.refs == []
   end
 end

--- a/test/loopctl/repo/reshape_channel_posts_refs_migration_test.exs
+++ b/test/loopctl/repo/reshape_channel_posts_refs_migration_test.exs
@@ -61,6 +61,23 @@ defmodule Loopctl.Repo.ReshapeChannelPostsRefsMigrationTest do
     )
   end
 
+  # Drive the real migration's down/0 in THIS process. Mirrors Ecto.Migrator's
+  # `attempt(.., :forward, :down, :down, ..)` for an explicit down/0 (the raw execute
+  # SQL runs forward as written), folding the list back to the old fixed-key map —
+  # intentionally lossy.
+  defp run_migration_down do
+    Runner.run(
+      AdminRepo,
+      AdminRepo.config(),
+      @migration_version,
+      ReshapeChannelPostsRefsToList,
+      :forward,
+      :down,
+      :down,
+      log: false
+    )
+  end
+
   # Seed a valid post, then stamp its `refs` column with an arbitrary raw jsonb
   # value (an Elixir term Postgrex encodes as jsonb — a MAP for the old object shape,
   # never a JSON string which would double-encode into a jsonb string scalar).
@@ -117,5 +134,74 @@ defmodule Loopctl.Repo.ReshapeChannelPostsRefsMigrationTest do
     # No migration run here — load must still succeed.
     reloaded = AdminRepo.get!(ChannelPost, post.id)
     assert reloaded.refs == []
+  end
+
+  # AC-40.A1.5 fail-soft: an UNEXPECTED stored jsonb SCALAR (only reachable via
+  # corruption / a manual write — neither the old map schema nor up/0 can persist it)
+  # must NOT raise an Ecto load error that 500s the channel read. RefsList.load/1
+  # coerces it to nil (empty ref set) instead of falling through to :error.
+  test "RefsList.load fails soft on an unexpected jsonb scalar row (no 500)" do
+    post = seed_post_with_raw_refs("i-am-a-scalar-string")
+
+    reloaded = AdminRepo.get!(ChannelPost, post.id)
+    assert reloaded.refs == nil
+  end
+
+  # Read the RAW stored refs column (bypassing RefsList.load) so a down/0 test can
+  # assert the exact folded MAP shape the old schema expects.
+  defp raw_refs(post_id) do
+    %{rows: [[refs]]} =
+      AdminRepo.query!(
+        "SELECT refs FROM channel_posts WHERE id = $1",
+        [Ecto.UUID.dump!(post_id)]
+      )
+
+    refs
+  end
+
+  # down/0 restores the OLD fixed-key-map shape. It is INTENTIONALLY LOSSY: the
+  # optional label is dropped and items sharing a type collapse to the last value —
+  # the old map could never hold those. This documents the accepted lossiness.
+  test "down/0 folds the list back to a map, dropping label (intentionally lossy)" do
+    post =
+      seed_post_with_raw_refs([
+        %{"type" => "pr", "value" => "107", "label" => "the fix"},
+        %{"type" => "file", "value" => "lib/a.ex:42"}
+      ])
+
+    assert :ok = run_migration_down()
+
+    # type -> value only; label is gone.
+    assert raw_refs(post.id) == %{"pr" => "107", "file" => "lib/a.ex:42"}
+  end
+
+  # down/0 on multiple items sharing a type keeps the LAST value (jsonb_object_agg
+  # collapses duplicate keys) — the documented lossy collapse the old map forces.
+  test "down/0 collapses duplicate types to the last value (lossy expansion reverse)" do
+    post =
+      seed_post_with_raw_refs([
+        %{"type" => "file", "value" => "a"},
+        %{"type" => "file", "value" => "b"}
+      ])
+
+    assert :ok = run_migration_down()
+
+    assert raw_refs(post.id) == %{"file" => "b"}
+  end
+
+  # A corrupt item whose `type` is JSON null (key present, value null) previously
+  # crashed jsonb_object_agg ("field name must not be null"), aborting the whole
+  # rollback. The `WHERE item ->> 'type' IS NOT NULL` guard skips it so down/0
+  # completes, folding only the well-formed items.
+  test "down/0 skips a JSON-null type item instead of crashing the rollback" do
+    post =
+      seed_post_with_raw_refs([
+        %{"type" => nil, "value" => "orphan"},
+        %{"type" => "pr", "value" => "5"}
+      ])
+
+    assert :ok = run_migration_down()
+
+    assert raw_refs(post.id) == %{"pr" => "5"}
   end
 end

--- a/test/loopctl_web/controllers/channel_post_controller_test.exs
+++ b/test/loopctl_web/controllers/channel_post_controller_test.exs
@@ -83,6 +83,113 @@ defmodule LoopctlWeb.ChannelPostControllerTest do
       assert_in_delta DateTime.to_unix(expires), DateTime.to_unix(expected), 120
     end
 
+    # TC-40.A1.1 — a multi-item typed-open refs LIST is persisted and returned as-is.
+    test "a multi-item typed-open refs list is persisted and returned -> 201" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, _agent} = agent_key(tenant)
+
+      refs = [
+        %{"type" => "issue", "value" => "#812"},
+        %{"type" => "file", "value" => "lib/a.ex:1", "label" => "x"},
+        %{"type" => "commit", "value" => "abc123"}
+      ]
+
+      conn = post_json(raw, %{"project_id" => project.id, "body" => "handoff", "refs" => refs})
+
+      assert %{"post" => post} = json_response(conn, 201)
+      assert post["refs"] == refs
+
+      # and it reads back from channel_recent as the same list
+      read = authed_conn(raw) |> get(@path, %{"project_id" => project.id})
+      assert %{"data" => [read_post]} = json_response(read, 200)
+      assert read_post["refs"] == refs
+    end
+
+    # TC-40.A1.2 — a free `type` not in the removed allowlist is accepted.
+    test "a free ref type (capability) not in the old allowlist -> 201" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, _agent} = agent_key(tenant)
+
+      conn =
+        post_json(raw, %{
+          "project_id" => project.id,
+          "body" => "ok",
+          "refs" => [%{"type" => "capability", "value" => "read:secrets"}]
+        })
+
+      assert %{"post" => post} = json_response(conn, 201)
+      assert post["refs"] == [%{"type" => "capability", "value" => "read:secrets"}]
+    end
+
+    # TC-40.A1.5 — over the item-count cap is a 422 and nothing is persisted.
+    test "a refs list over the item-count cap is 422 and not persisted" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, _agent} = agent_key(tenant)
+
+      over =
+        for i <- 1..(ChannelPost.refs_max_items() + 1), do: %{"type" => "t", "value" => "#{i}"}
+
+      conn = post_json(raw, %{"project_id" => project.id, "body" => "ok", "refs" => over})
+      assert json_response(conn, 422)
+      assert Coordination.recent(tenant.id, project.id) == []
+    end
+
+    # TC-40.A1.3 — a secret in a ref TYPE is rejected 422, nothing persisted.
+    test "a secret in a ref type is rejected 422 and not persisted" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, _agent} = agent_key(tenant)
+
+      refs = [%{"type" => "lc_" <> String.duplicate("a", 30), "value" => "x"}]
+      conn = post_json(raw, %{"project_id" => project.id, "body" => "ok", "refs" => refs})
+      assert json_response(conn, 422)
+      assert Coordination.recent(tenant.id, project.id) == []
+    end
+
+    # TC-40.A1.4 — a secret in a ref LABEL is rejected 422, nothing persisted.
+    test "a secret in a ref label is rejected 422 and not persisted" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, _agent} = agent_key(tenant)
+
+      refs = [%{"type" => "file", "value" => "x", "label" => "sk-" <> String.duplicate("a", 30)}]
+      conn = post_json(raw, %{"project_id" => project.id, "body" => "ok", "refs" => refs})
+      assert json_response(conn, 422)
+      assert Coordination.recent(tenant.id, project.id) == []
+    end
+
+    # TC-40.A1.6 — malformed refs items are a 422 changeset error, never a 500.
+    test "malformed refs items are 422, not 500" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, _agent} = agent_key(tenant)
+
+      # missing `type`
+      c1 =
+        post_json(raw, %{
+          "project_id" => project.id,
+          "body" => "ok",
+          "refs" => [%{"value" => "x"}]
+        })
+
+      assert json_response(c1, 422)
+
+      # items not maps
+      c2 = post_json(raw, %{"project_id" => project.id, "body" => "ok", "refs" => ["a", "b"]})
+      assert json_response(c2, 422)
+
+      # non-list refs
+      c3 =
+        post_json(raw, %{"project_id" => project.id, "body" => "ok", "refs" => %{"file" => "x"}})
+
+      assert json_response(c3, 422)
+
+      assert Coordination.recent(tenant.id, project.id) == []
+    end
+
     # TC-39.2.2
     test "agent_id/tenant_id in the body are ignored (server-stamped from the key)" do
       tenant = fixture(:tenant)


### PR DESCRIPTION
## US-40.A1 — refs as a typed-open LIST

Fixes the shipped defect where channel_posts.refs was a FIXED-KEY map ({file,pr,branch,commit}) that could hold only one value per key — so a real handoff pointing at many issues / many file:line pairs / several commits was inexpressible.

### What changed
- refs is now a bounded, typed-OPEN LIST of items `[{"type","value","label"?}]` (AC-40.A1.1). type is a FREE string (allowlist removed) bounded to 64 bytes; value <= 512 bytes; optional label <= 128 bytes.
- New custom `Ecto.Type` `Loopctl.Coordination.RefsList` keeps the existing SCALAR jsonb column (type/0 -> :map) now holding a top-level JSON array. cast/1 is lenient so validate_refs/1 emits specific 422 messages; a non-list scalar 422s at cast — never a 500.
- Explicit item-COUNT cap of 50 (primary bound), plus a raised serialized-bytes ceiling (48KB) sized for 50 max items as a secondary ceiling (AC-40.A1.2).
- The secret denylist AND NUL-byte scan now cover EVERY item field — type, value, AND label — not just values, closing the previously-unscanned type/label exfil channel onto the 30-day cross-session bus (AC-40.A1.3). Items with an unexpected key are rejected so no field escapes the scan.
- Malformed items (non-list refs, non-map item, missing type/value, non-string/over-length field, NUL byte) are all 422 changeset errors, never a 500 (AC-40.A1.4).
- Data migration reshapes any stored refs map `{k:v}` -> `[{type:k,value:v}]` with a stable ORDER BY key; column type unchanged (AC-40.A1.5). Response shape (@derive + channel_post_json) returns the list; OpenApiSpex request/response schemas and the MCP channel_post refs inputSchema updated to the list shape with a count-cap doc note.

### Tests
Changeset-level and controller-integration tests (TC-40.A1.1 through .6), a data-migration test (TC-40.A1.7), and existing tenant-isolation coverage. mix precommit green (format, credo --strict, dialyzer, 5085 tests 0 failures).


