### PR TITLE
Advisory addressing: optional to_host / to_capability (surfacing-only, NEVER authz)

### DIFF
--- a/lib/loopctl/api_spec/schemas.ex
+++ b/lib/loopctl/api_spec/schemas.ex
@@ -925,6 +925,24 @@ defmodule Loopctl.ApiSpec.Schemas do
           description: "Client-supplied session id (required when key is set)"
         },
         host: %Schema{type: :string, nullable: true, description: "Client-supplied hostname"},
+        to_host: %Schema{
+          type: :string,
+          nullable: true,
+          description:
+            "Optional ADVISORY SURFACING address: the intended target host (<=255 bytes). " <>
+              "Client-supplied and SPOOFABLE — a discovery hint only, NEVER authorization, " <>
+              "ownership, or a delivery guarantee. It gates nothing; a post with no addressing " <>
+              "is a broadcast visible to everyone on the channel."
+        },
+        to_capability: %Schema{
+          type: :string,
+          nullable: true,
+          description:
+            "Optional ADVISORY SURFACING address: the intended target capability, e.g. " <>
+              "\"fly auth\" (<=128 bytes). Client-supplied and SPOOFABLE — a discovery hint " <>
+              "only, NEVER authorization, ownership, or a delivery guarantee. Prefer this over " <>
+              "to_host when the real target is a capability rather than a machine."
+        },
         refs: %Schema{
           type: :array,
           nullable: true,
@@ -984,6 +1002,16 @@ defmodule Loopctl.ApiSpec.Schemas do
             agent_id: %Schema{type: :string, format: :uuid},
             session_id: %Schema{type: :string, nullable: true},
             host: %Schema{type: :string, nullable: true},
+            to_host: %Schema{
+              type: :string,
+              nullable: true,
+              description: "Advisory surfacing address (spoofable, never authz)"
+            },
+            to_capability: %Schema{
+              type: :string,
+              nullable: true,
+              description: "Advisory surfacing address (spoofable, never authz)"
+            },
             key: %Schema{type: :string, nullable: true},
             body: %Schema{type: :string},
             refs: %Schema{
@@ -1016,6 +1044,16 @@ defmodule Loopctl.ApiSpec.Schemas do
         agent_id: %Schema{type: :string, format: :uuid},
         session_id: %Schema{type: :string, nullable: true},
         host: %Schema{type: :string, nullable: true},
+        to_host: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Advisory surfacing address (spoofable, never authz)"
+        },
+        to_capability: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Advisory surfacing address (spoofable, never authz)"
+        },
         key: %Schema{type: :string, nullable: true},
         body: %Schema{type: :string},
         refs: %Schema{

--- a/lib/loopctl/coordination.ex
+++ b/lib/loopctl/coordination.ex
@@ -112,8 +112,12 @@ defmodule Loopctl.Coordination do
   this changes nothing observable versus the doc's stale
   `(tenant, project, session, key)` target, but it MUST match the live index or
   the insert raises). A repeat write from the SAME session refreshes its own
-  slot (`body`/`refs`/`updated_at`/`expires_at`); a different session's same key
-  is a distinct row. Without a `key` every post is a new append-only row.
+  slot's caller-variable payload — `body`, `refs`, the advisory addressing
+  (`to_host`/`to_capability`, US-40.A5), `updated_at`, and `expires_at` — so a
+  keyed re-post can re-address a handoff slot or promote a broadcast slot to
+  directed; `inserted_at`, `host`, and `session_id` are set-once (kept from the
+  original insert). A different session's same key is a distinct row. Without a
+  `key` every post is a new append-only row.
 
   ## Returns
 
@@ -352,11 +356,28 @@ defmodule Loopctl.Coordination do
   # for the INSERT ATTEMPT (the existing row kept its own). Reading the row back
   # makes the returned struct — the response JSON, the audit entity_id, AND the
   # `post_outcome/1` timestamp comparison — reflect the real persisted row.
+  #
+  # The replace list carries the CALLER-VARIABLE payload — the fields a re-post of
+  # the SAME working-state slot may legitimately change:
+  #
+  #   * `body`/`refs` — the message content.
+  #   * `to_host`/`to_capability` (US-40.A5) — advisory addressing. These are
+  #     per-message intent, not slot-identity metadata, so a keyed re-post must be
+  #     able to re-address the slot (or promote a broadcast working-state slot to
+  #     directed) — otherwise the FIRST-set addressing sticks and 40.C1 directed
+  #     discovery (which surfaces "directed-to-me" posts by `to_host`/`to_capability`)
+  #     would read stale targets on a handoff refresh. They refresh like `body`.
+  #   * `updated_at`/`expires_at` — the refresh timestamp and the TTL extension.
+  #
+  # Deliberately EXCLUDED (set-once at first insert): `inserted_at` (so
+  # `post_outcome/1` can tell created from updated), and `host`/`session_id`, which
+  # are slot-identity/attribution metadata the story mandates mirroring from the
+  # original insert, not refreshable payload.
   defp insert_opts(nil), do: []
 
   defp insert_opts(_key) do
     [
-      on_conflict: {:replace, [:body, :refs, :updated_at, :expires_at]},
+      on_conflict: {:replace, [:body, :refs, :to_host, :to_capability, :updated_at, :expires_at]},
       conflict_target:
         {:unsafe_fragment,
          "(tenant_id, project_id, agent_id, session_id, key) WHERE key IS NOT NULL"},

--- a/lib/loopctl/coordination.ex
+++ b/lib/loopctl/coordination.ex
@@ -50,8 +50,10 @@ defmodule Loopctl.Coordination do
 
   `tenant_id`, `project_id`, `agent_id`, and `expires_at` are set programmatically
   on the struct (never from caller input); only `body` and the optional
-  `session_id`/`host`/`key`/`refs` are cast from `attrs`. `expires_at` is fixed at
-  `now + #{@retention_days} days`.
+  `session_id`/`host`/`key`/`refs`/`to_host`/`to_capability` are cast from `attrs`
+  (`to_host`/`to_capability` are the advisory, spoofable, surfacing-only addressing
+  fields — see the `ChannelPost` moduledoc trust boundary). `expires_at` is fixed
+  at `now + #{@retention_days} days`.
 
   Both `project_id` and `agent_id` must belong to `tenant_id`; a mispaired call
   returns `{:error, :not_found}` rather than inserting a cross-tenant-shaped row
@@ -112,10 +114,14 @@ defmodule Loopctl.Coordination do
   this changes nothing observable versus the doc's stale
   `(tenant, project, session, key)` target, but it MUST match the live index or
   the insert raises). A repeat write from the SAME session refreshes its own
-  slot's caller-variable payload — `body`, `refs`, the advisory addressing
-  (`to_host`/`to_capability`, US-40.A5), `updated_at`, and `expires_at` — so a
-  keyed re-post can re-address a handoff slot or promote a broadcast slot to
-  directed; `inserted_at`, `host`, and `session_id` are set-once (kept from the
+  slot's caller-variable payload — `body`, `refs`, `updated_at`, and `expires_at`
+  are fully replaced, while the advisory addressing (`to_host`/`to_capability`,
+  US-40.A5) is PRESERVE-ON-OMIT: a supplied value re-addresses a handoff slot or
+  promotes a broadcast slot to directed, but an OMITTED value keeps the
+  previously-set target (COALESCE) rather than NULL-wiping it — so a body-only or
+  TTL-only refresh never silently demotes a directed slot out of 40.C1 discovery
+  (clearing addressing by omission is intentionally unsupported; delete + re-post
+  to demote). `inserted_at`, `host`, and `session_id` are set-once (kept from the
   original insert). A different session's same key is a distinct row. Without a
   `key` every post is a new append-only row.
 
@@ -357,19 +363,36 @@ defmodule Loopctl.Coordination do
   # makes the returned struct — the response JSON, the audit entity_id, AND the
   # `post_outcome/1` timestamp comparison — reflect the real persisted row.
   #
-  # The replace list carries the CALLER-VARIABLE payload — the fields a re-post of
-  # the SAME working-state slot may legitimately change:
+  # The DO UPDATE refreshes the CALLER-VARIABLE payload — the fields a re-post of
+  # the SAME working-state slot may legitimately change — but with TWO distinct
+  # merge rules, because the fields differ in how a caller signals intent:
   #
-  #   * `body`/`refs` — the message content.
-  #   * `to_host`/`to_capability` (US-40.A5) — advisory addressing. These are
-  #     per-message intent, not slot-identity metadata, so a keyed re-post must be
-  #     able to re-address the slot (or promote a broadcast working-state slot to
-  #     directed) — otherwise the FIRST-set addressing sticks and 40.C1 directed
-  #     discovery (which surfaces "directed-to-me" posts by `to_host`/`to_capability`)
-  #     would read stale targets on a handoff refresh. They refresh like `body`.
-  #   * `updated_at`/`expires_at` — the refresh timestamp and the TTL extension.
+  #   * FULL REPLACE (`body`/`refs`/`updated_at`/`expires_at`) — overwritten with
+  #     the incoming values every time. `body` is `validate_required`, so it can
+  #     never be accidentally omitted; `refs` is content the caller re-curates with
+  #     each post; the two timestamps are the refresh instant and the TTL extension.
   #
-  # Deliberately EXCLUDED (set-once at first insert): `inserted_at` (so
+  #   * PRESERVE-ON-OMIT (`to_host`/`to_capability`, US-40.A5) — advisory addressing,
+  #     merged with `COALESCE(EXCLUDED.<field>, existing.<field>)`: a non-nil
+  #     incoming value re-addresses (or promotes a broadcast slot to directed), but
+  #     an OMITTED value (nil) KEEPS the previously-set target rather than wiping it.
+  #     This is deliberate and asymmetric to `body`: addressing is OPTIONAL and is
+  #     the field a refresh most commonly omits — the controller sends
+  #     `to_host: params["to_host"]` (nil when the JSON omits it) and the MCP proxy
+  #     only adds the keys when present (`if (to_host) payload.to_host = to_host`),
+  #     so a keyed re-post that touches only `body` or extends TTL through the normal
+  #     agent path carries NO addressing. Under a plain replace that would silently
+  #     NULL-wipe the routing and demote a directed handoff slot to broadcast,
+  #     dropping it out of 40.C1 directed discovery (`to_host=$me OR to_capability
+  #     IN $caps`) with no error surfaced — breaking the exact directed-handoff use
+  #     case this story exists to enable. COALESCE makes an accidental omission a
+  #     no-op instead of a silent routing loss. Re-addressing still works (a non-nil
+  #     value wins); the only thing you CANNOT do by omission is CLEAR addressing
+  #     (demote a directed slot back to broadcast) — a deliberately unsupported,
+  #     never-designed-for path. To demote, delete the slot (US-39.7) and re-post
+  #     without addressing.
+  #
+  # Deliberately UNTOUCHED (set-once at first insert): `inserted_at` (so
   # `post_outcome/1` can tell created from updated), and `host`/`session_id`, which
   # are slot-identity/attribution metadata the story mandates mirroring from the
   # original insert, not refreshable payload.
@@ -377,12 +400,34 @@ defmodule Loopctl.Coordination do
 
   defp insert_opts(_key) do
     [
-      on_conflict: {:replace, [:body, :refs, :to_host, :to_capability, :updated_at, :expires_at]},
+      on_conflict: keyed_slot_on_conflict(),
       conflict_target:
         {:unsafe_fragment,
          "(tenant_id, project_id, agent_id, session_id, key) WHERE key IS NOT NULL"},
       returning: true
     ]
+  end
+
+  # DO UPDATE for a keyed working-state slot. `body`/`refs`/`updated_at`/`expires_at`
+  # are replaced with the incoming values (`EXCLUDED.*` is the row we tried to
+  # insert); `to_host`/`to_capability` COALESCE the incoming value over the stored
+  # one so an OMITTED (nil) advisory target preserves the previously-set routing
+  # instead of NULL-wiping it (see the insert_opts/1 comment for why addressing is
+  # preserve-on-omit while body is full-replace). Mirrors the `EXCLUDED`-driven
+  # on_conflict query in `Loopctl.AuditChain`.
+  defp keyed_slot_on_conflict do
+    from(p in ChannelPost,
+      update: [
+        set: [
+          body: fragment("EXCLUDED.body"),
+          refs: fragment("EXCLUDED.refs"),
+          to_host: fragment("COALESCE(EXCLUDED.to_host, ?)", p.to_host),
+          to_capability: fragment("COALESCE(EXCLUDED.to_capability, ?)", p.to_capability),
+          updated_at: fragment("EXCLUDED.updated_at"),
+          expires_at: fragment("EXCLUDED.expires_at")
+        ]
+      ]
+    )
   end
 
   # Created vs in-place update, read from the PERSISTED row (see run_post/3). A

--- a/lib/loopctl/coordination/channel_post.ex
+++ b/lib/loopctl/coordination/channel_post.ex
@@ -26,6 +26,17 @@ defmodule Loopctl.Coordination.ChannelPost do
   `session_id` are client-supplied, informational, and spoofable — never used for
   authorization or as authoritative attribution.
 
+  `to_host` and `to_capability` (US-40.A5) are the same class: OPTIONAL, freeform,
+  client-supplied ADVISORY SURFACING fields that label a post's *intended* target
+  (a host or, primarily, a capability such as "fly auth"). They are SPOOFABLE — a
+  caller can address a post to ANY host/capability — and are read ONLY as a
+  discovery hint (40.C1 directed discovery surfaces "directed-to-me" posts). They
+  are NEVER read for authorization, ownership, or any delivery guarantee: they
+  gate NOTHING. A post may set neither, either, or both; a post with no addressing
+  remains a broadcast visible to EVERYONE on the channel exactly as today. The
+  ONLY authorization boundary remains the verified key's tenant (+ after 40.D3,
+  project membership).
+
   ## Isolation
 
   Runtime isolation is `AdminRepo` (BYPASSRLS) + an explicit `tenant_id` filter in
@@ -47,6 +58,7 @@ defmodule Loopctl.Coordination.ChannelPost do
   @key_max_length 200
   @session_id_max_length 200
   @host_max_length 255
+  @to_capability_max_length 128
 
   # `refs` is a bounded, typed-OPEN LIST of reference items
   # `[%{"type" => string, "value" => string, "label" => string?}]` (US-40.A1). The
@@ -76,7 +88,7 @@ defmodule Loopctl.Coordination.ChannelPost do
 
   # Text fields that must never carry a NUL byte (Postgres rejects them at insert
   # time with a raw Postgrex.Error/500) nor a denylisted credential shape.
-  @scanned_text_fields [:body, :key, :session_id, :host]
+  @scanned_text_fields [:body, :key, :session_id, :host, :to_host, :to_capability]
 
   @derive {Jason.Encoder,
            only: [
@@ -86,6 +98,8 @@ defmodule Loopctl.Coordination.ChannelPost do
              :agent_id,
              :session_id,
              :host,
+             :to_host,
+             :to_capability,
              :key,
              :body,
              :refs,
@@ -100,6 +114,9 @@ defmodule Loopctl.Coordination.ChannelPost do
     field :agent_id, :binary_id
     field :session_id, :string
     field :host, :string
+    # Advisory, spoofable, surfacing-only addressing (US-40.A5) — NEVER authz.
+    field :to_host, :string
+    field :to_capability, :string
     field :key, :string
     field :body, :string
     field :refs, RefsList
@@ -117,22 +134,29 @@ defmodule Loopctl.Coordination.ChannelPost do
   @doc """
   Changeset for creating a channel post.
 
-  Casts ONLY the caller-supplied fields `[:session_id, :host, :key, :body, :refs]`.
+  Casts ONLY the caller-supplied fields
+  `[:session_id, :host, :to_host, :to_capability, :key, :body, :refs]`.
   `tenant_id`, `project_id`, `agent_id`, and `expires_at` are set programmatically
   on the struct by the context and are validated for presence here as a guard
-  against a context bug — they are never castable.
+  against a context bug — they are never castable. `to_host`/`to_capability` are
+  OPTIONAL, freeform ADVISORY SURFACING fields (spoofable — see the moduledoc
+  trust boundary); they gate NOTHING and are validated only for size/NUL/secret
+  hygiene like `host`/`session_id`.
 
   Enforces the size/shape bounds (`body` <= 16KB, `key` <= 200 bytes,
-  `session_id` <= 200 bytes, `host` <= 255 bytes, and a bounded typed-open `refs`
-  LIST — at most #{@refs_max_items} items, each `%{"type" => .., "value" => ..,
-  "label"? => ..}` with per-field byte caps), rejects NUL bytes in every text
-  field AND every `refs` item field (Postgres cannot store them — the guard turns
-  a raw 500 into a 422), and runs the shared secret denylist over `body`, `key`,
-  `session_id`, `host`, and EVERY `refs` item field (`type`, `value`, `label`) — a
-  match rejects the write (surfaced as a 422) rather than silently dropping the
-  content or leaking a credential onto the shared, cross-session-readable channel.
+  `session_id` <= 200 bytes, `host` <= 255 bytes, `to_host` <= 255 bytes,
+  `to_capability` <= 128 bytes, and a bounded typed-open `refs` LIST — at most
+  #{@refs_max_items} items, each `%{"type" => .., "value" => .., "label"? => ..}`
+  with per-field byte caps), rejects NUL bytes in every text field AND every
+  `refs` item field (Postgres cannot store them — the guard turns a raw 500 into a
+  422), and runs the shared secret denylist over `body`, `key`, `session_id`,
+  `host`, `to_host`, `to_capability`, and EVERY `refs` item field (`type`,
+  `value`, `label`) — a match rejects the write (surfaced as a 422) rather than
+  silently dropping the content or leaking a credential onto the shared,
+  cross-session-readable channel.
 
-  A blank (`""`/whitespace-only) `body`, `key`, `session_id`, or `host` is
+  A blank (`""`/whitespace-only) `body`, `key`, `session_id`, `host`, `to_host`,
+  or `to_capability` is
   normalised to `nil` before the required/uniqueness checks: for `body` this
   makes `validate_required/2` reject a whitespace-only post (an effectively empty
   message must not land as noise on the shared, 30-day channel); for `key` it
@@ -149,13 +173,15 @@ defmodule Loopctl.Coordination.ChannelPost do
   @spec create_changeset(t(), map()) :: Ecto.Changeset.t()
   def create_changeset(post, attrs) do
     post
-    |> cast(attrs, [:session_id, :host, :key, :body, :refs])
-    |> normalize_blank([:body, :key, :session_id, :host])
+    |> cast(attrs, [:session_id, :host, :to_host, :to_capability, :key, :body, :refs])
+    |> normalize_blank([:body, :key, :session_id, :host, :to_host, :to_capability])
     |> validate_required([:tenant_id, :project_id, :agent_id, :body, :expires_at])
     |> validate_length(:body, max: @body_max_length, count: :bytes)
     |> validate_length(:key, max: @key_max_length, count: :bytes)
     |> validate_length(:session_id, max: @session_id_max_length, count: :bytes)
     |> validate_length(:host, max: @host_max_length, count: :bytes)
+    |> validate_length(:to_host, max: @host_max_length, count: :bytes)
+    |> validate_length(:to_capability, max: @to_capability_max_length, count: :bytes)
     |> maybe_require_session_for_key()
     |> validate_refs()
     |> scan_text_and_refs()

--- a/lib/loopctl_web/controllers/channel_post_controller.ex
+++ b/lib/loopctl_web/controllers/channel_post_controller.ex
@@ -257,13 +257,17 @@ defmodule LoopctlWeb.ChannelPostController do
   # which session / when" and to self-dedupe by session_id. Deliberately narrower
   # than the schema's `@derive Jason.Encoder` (which also carries
   # tenant_id/project_id/expires_at): a dedicated builder keeps the response to the
-  # AC's contract, matching the project_json/1 convention.
+  # AC's contract, matching the project_json/1 convention. `to_host`/`to_capability`
+  # (US-40.A5) are surfaced here so 40.C1 directed discovery can read a post's
+  # advisory addressing — they are surfacing-only hints, NEVER read for authz.
   defp channel_post_json(post) do
     %{
       id: post.id,
       agent_id: post.agent_id,
       session_id: post.session_id,
       host: post.host,
+      to_host: post.to_host,
+      to_capability: post.to_capability,
       key: post.key,
       body: post.body,
       refs: post.refs,
@@ -319,6 +323,9 @@ defmodule LoopctlWeb.ChannelPostController do
       refs: params["refs"],
       session_id: params["session_id"],
       host: params["host"],
+      # Advisory, spoofable, surfacing-only addressing (US-40.A5) — NEVER authz.
+      to_host: params["to_host"],
+      to_capability: params["to_capability"],
       audit: AuditContext.from_conn(conn)
     }
 

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -437,7 +437,7 @@ async function restoreKbScope({ project_id }) {
   return toContent(result);
 }
 
-async function channelPost({ project_id, body, key, refs }) {
+async function channelPost({ project_id, body, key, refs, to_host, to_capability }) {
   // Repo Coordination Bus (Epic 39): post a coordination message to a channel
   // (a channel IS a project_id — a work project or a kb scope). Agent-role, RLS
   // tenant-scoped — posting to your own tenant's channel is coordination, NOT
@@ -445,6 +445,12 @@ async function channelPost({ project_id, body, key, refs }) {
   const payload = { project_id, body };
   if (key) payload.key = key;
   if (refs) payload.refs = refs;
+  // Advisory, SPOOFABLE, surfacing-only addressing (US-40.A5): these label a
+  // post's intended target (a host or, primarily, a capability). They are caller
+  // args (NOT auto-filled like host/session_id) and are read only as a discovery
+  // hint by 40.C1 directed discovery — NEVER for authorization or delivery.
+  if (to_host) payload.to_host = to_host;
+  if (to_capability) payload.to_capability = to_capability;
   // host + session_id are proxy-filled (NOT caller args). host from os.hostname();
   // session_id from CLAUDE_SESSION_ID (the SAME id SessionStart sees) so US-39.6
   // self-dedup can skip a session's own echoed posts. Omit session_id entirely when
@@ -2265,7 +2271,7 @@ const TOOLS = [
   {
     name: "channel_post",
     description:
-      "Post a message to a repo coordination channel (Epic 39 Repo Coordination Bus) on the agent key. A channel IS a project_id (a work project or a kb scope); posts are tenant-isolated by RLS. This is an agent-role COORDINATION surface, not chain-of-custody — posting to your own tenant's channel is not self-approval. host is auto-filled from the proxy's os.hostname() and session_id is auto-filled from the Claude Code session id (both proxy-supplied, informational only — do NOT pass them). Provide a key to upsert your per-session working-state slot (200) instead of appending a new post (201); omit it to append.",
+      "Post a message to a repo coordination channel (Epic 39 Repo Coordination Bus) on the agent key. A channel IS a project_id (a work project or a kb scope); posts are tenant-isolated by RLS. This is an agent-role COORDINATION surface, not chain-of-custody — posting to your own tenant's channel is not self-approval. host is auto-filled from the proxy's os.hostname() and session_id is auto-filled from the Claude Code session id (both proxy-supplied, informational only — do NOT pass them). Provide a key to upsert your per-session working-state slot (200) instead of appending a new post (201); omit it to append. OPTIONAL advisory addressing: set to_capability (preferred) and/or to_host to LABEL a post's intended target (e.g. to_capability 'fly auth'). These are ADVISORY / SURFACING-ONLY and SPOOFABLE — a discovery hint that 40.C1 reads to surface directed-to-me posts, NEVER authorization, ownership, or a delivery guarantee. They gate nothing; a post with no addressing stays a broadcast visible to everyone on the channel.",
     inputSchema: {
       type: "object",
       properties: {
@@ -2278,6 +2284,16 @@ const TOOLS = [
           type: "string",
           description:
             "Optional per-session working-state slot key. When given, upserts the caller's slot for that key instead of appending a new post. Requires an active Claude Code session: the upsert is keyed on the auto-filled session_id (from CLAUDE_SESSION_ID), so a keyed post made outside a Claude Code session — where that env var is absent — is rejected with a 422 (session_id can't be blank). Omit key to append a plain post, which needs no session.",
+        },
+        to_capability: {
+          type: "string",
+          description:
+            "Optional ADVISORY / SURFACING-ONLY target capability, e.g. 'fly auth' (<=128 bytes). Preferred over to_host. SPOOFABLE — a discovery hint that 40.C1 reads to surface directed-to-me posts, NEVER authorization, ownership, or a delivery guarantee. Gates nothing.",
+        },
+        to_host: {
+          type: "string",
+          description:
+            "Optional ADVISORY / SURFACING-ONLY target host, e.g. 'mac-mini' (<=255 bytes). SPOOFABLE — a discovery hint only, NEVER authorization, ownership, or a delivery guarantee. Prefer to_capability when the real target is a capability rather than a machine.",
         },
         refs: {
           type: "array",

--- a/mcp-server/test/mcp_arg_forwarding.test.js
+++ b/mcp-server/test/mcp_arg_forwarding.test.js
@@ -174,6 +174,27 @@ describe("#39.4: channel_post / channel_recent wiring", () => {
     );
   });
 
+  test("channelPost forwards advisory to_host/to_capability only when set (US-40.A5)", () => {
+    // to_host/to_capability are caller args (unlike auto-filled host/session_id),
+    // conditionally added to the payload so an unset addressing field is omitted
+    // rather than sent as undefined. AC-40.A5.4 requires them settable via MCP.
+    assert.match(
+      INDEX_SRC,
+      /async function channelPost\([\s\S]*?if \(to_host\) payload\.to_host = to_host;/,
+      "channelPost must forward to_host only when set",
+    );
+    assert.match(
+      INDEX_SRC,
+      /async function channelPost\([\s\S]*?if \(to_capability\) payload\.to_capability = to_capability;/,
+      "channelPost must forward to_capability only when set",
+    );
+    assert.match(
+      INDEX_SRC,
+      /async function channelPost\(\{[^}]*\bto_host\b[^}]*\bto_capability\b[^}]*\}\)/,
+      "channelPost must destructure to_host and to_capability from its args",
+    );
+  });
+
   test("channelRecent GETs /channel/posts on the AGENT key", () => {
     assert.match(
       INDEX_SRC,

--- a/priv/repo/migrations/20260718140000_add_channel_posts_addressing.exs
+++ b/priv/repo/migrations/20260718140000_add_channel_posts_addressing.exs
@@ -1,0 +1,51 @@
+defmodule Loopctl.Repo.Migrations.AddChannelPostsAddressing do
+  use Ecto.Migration
+
+  # US-40.A5: optional ADVISORY addressing on channel_posts so a post can label
+  # its intended target (a host or, primarily, a capability) — e.g.
+  # "beelink -> mac-mini because it has the fly auth capability". A later story
+  # (40.C1, directed discovery) reads these columns to surface "directed-to-me"
+  # posts.
+  #
+  # Both columns are CLIENT-SUPPLIED and SPOOFABLE — SURFACING-ONLY read hints,
+  # NEVER authorization, ownership, or a delivery guarantee. They gate NOTHING
+  # (mirroring the `session_id`/`host` advisory framing in the original create
+  # migration, 20260717020000_create_channel_posts:18-22). The ONLY authorization
+  # boundary remains the verified key's tenant + explicit tenant_id filter. Both
+  # are nullable and backward-compatible: NULL on existing rows, and a post with
+  # no addressing remains a broadcast visible to everyone on the channel.
+
+  def up do
+    alter table(:channel_posts) do
+      add :to_host, :text, null: true
+      add :to_capability, :text, null: true
+    end
+
+    # Partial indexes serve 40.C1's directed read
+    # (to_host = $me OR to_capability IN $caps): only addressed rows are indexed.
+    create index(:channel_posts, [:tenant_id, :project_id, :to_capability],
+             where: "to_capability IS NOT NULL",
+             name: :channel_posts_to_capability_idx
+           )
+
+    create index(:channel_posts, [:tenant_id, :project_id, :to_host],
+             where: "to_host IS NOT NULL",
+             name: :channel_posts_to_host_idx
+           )
+  end
+
+  def down do
+    drop index(:channel_posts, [:tenant_id, :project_id, :to_host],
+           name: :channel_posts_to_host_idx
+         )
+
+    drop index(:channel_posts, [:tenant_id, :project_id, :to_capability],
+           name: :channel_posts_to_capability_idx
+         )
+
+    alter table(:channel_posts) do
+      remove :to_capability
+      remove :to_host
+    end
+  end
+end

--- a/test/loopctl/coordination/channel_post_test.exs
+++ b/test/loopctl/coordination/channel_post_test.exs
@@ -415,6 +415,99 @@ defmodule Loopctl.Coordination.ChannelPostTest do
       refute cs.valid?
       assert %{session_id: _} = errors_on(cs)
     end
+
+    # US-40.A5 — advisory addressing (to_host/to_capability): freeform, optional,
+    # spoofable surfacing fields. A post may set neither, either, or both.
+    test "accepts a post carrying both to_host and to_capability" do
+      cs =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "ok",
+          "to_host" => "mac-mini",
+          "to_capability" => "fly-auth"
+        })
+
+      assert cs.valid?
+      assert Ecto.Changeset.get_field(cs, :to_host) == "mac-mini"
+      assert Ecto.Changeset.get_field(cs, :to_capability) == "fly-auth"
+    end
+
+    test "accepts a post with only to_capability (host absent)" do
+      cs =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "ok",
+          "to_capability" => "fly-auth"
+        })
+
+      assert cs.valid?
+      assert is_nil(Ecto.Changeset.get_field(cs, :to_host))
+      assert Ecto.Changeset.get_field(cs, :to_capability) == "fly-auth"
+    end
+
+    test "accepts a post with only to_host (capability absent)" do
+      cs =
+        ChannelPost.create_changeset(base_struct(), %{"body" => "ok", "to_host" => "beelink"})
+
+      assert cs.valid?
+      assert Ecto.Changeset.get_field(cs, :to_host) == "beelink"
+      assert is_nil(Ecto.Changeset.get_field(cs, :to_capability))
+    end
+
+    test "a blank to_host/to_capability is normalised to nil" do
+      cs =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "ok",
+          "to_host" => "",
+          "to_capability" => "   "
+        })
+
+      assert cs.valid?
+      assert is_nil(Ecto.Changeset.get_field(cs, :to_host))
+      assert is_nil(Ecto.Changeset.get_field(cs, :to_capability))
+    end
+
+    test "rejects an over-long to_host (>255 bytes)" do
+      cs =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "ok",
+          "to_host" => String.duplicate("h", 256)
+        })
+
+      refute cs.valid?
+      assert %{to_host: _} = errors_on(cs)
+    end
+
+    test "rejects an over-long to_capability (>128 bytes)" do
+      cs =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "ok",
+          "to_capability" => String.duplicate("c", 129)
+        })
+
+      refute cs.valid?
+      assert %{to_capability: _} = errors_on(cs)
+    end
+
+    test "rejects a NUL byte in to_host" do
+      cs =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "ok",
+          "to_host" => "mac" <> <<0>> <> "mini"
+        })
+
+      refute cs.valid?
+      assert %{to_host: _} = errors_on(cs)
+    end
+
+    test "rejects a NUL byte in to_capability" do
+      cs =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "ok",
+          "to_capability" => "fly" <> <<0>> <> "auth"
+        })
+
+      refute cs.valid?
+      assert %{to_capability: _} = errors_on(cs)
+    end
   end
 
   describe "secret denylist" do
@@ -527,6 +620,31 @@ defmodule Loopctl.Coordination.ChannelPostTest do
 
       refute cs.valid?
       assert %{host: _} = errors_on(cs)
+    end
+
+    # US-40.A5 — to_host/to_capability are wired into @scanned_text_fields, so a
+    # credential shape in either advisory address is rejected (a spoofed address is
+    # still a cross-session-readable field that must never carry a secret).
+    test "rejects a secret in to_host" do
+      cs =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "ok",
+          "to_host" => "ghp_" <> String.duplicate("a", 30)
+        })
+
+      refute cs.valid?
+      assert %{to_host: _} = errors_on(cs)
+    end
+
+    test "rejects a secret in to_capability" do
+      cs =
+        ChannelPost.create_changeset(base_struct(), %{
+          "body" => "ok",
+          "to_capability" => "ghp_" <> String.duplicate("a", 30)
+        })
+
+      refute cs.valid?
+      assert %{to_capability: _} = errors_on(cs)
     end
 
     test "accumulates errors across every offending field in one pass" do

--- a/test/loopctl/coordination_test.exs
+++ b/test/loopctl/coordination_test.exs
@@ -579,8 +579,8 @@ defmodule Loopctl.CoordinationTest do
       # to_host/to_capability are caller-variable advisory PAYLOAD, not slot-identity
       # metadata — so a keyed re-post of the same working-state slot must be able to
       # re-address it (US-40.A5), otherwise 40.C1 directed discovery reads the stale
-      # FIRST-set target on a handoff refresh. They are in the on_conflict replace
-      # list alongside body/refs, so the upsert overwrites them.
+      # FIRST-set target on a handoff refresh. A SUPPLIED (non-nil) value overrides
+      # via COALESCE(EXCLUDED, existing) on the upsert.
       base = %{project_id: project.id, session_id: "S1", key: "handoff:fly", audit: audit}
 
       assert {:ok, first, :created} =
@@ -616,6 +616,73 @@ defmodule Loopctl.CoordinationTest do
       reloaded = AdminRepo.get!(ChannelPost, second.id)
       assert reloaded.to_host == "beelink"
       assert reloaded.to_capability == "fly-auth"
+
+      assert AdminRepo.aggregate(
+               from(p in ChannelPost, where: p.project_id == ^project.id),
+               :count,
+               :id
+             ) == 1
+    end
+
+    test "a keyed re-post that OMITS addressing preserves it (no silent demote to broadcast)",
+         ctx do
+      %{tenant: tenant, project: project, agent_id: agent_id, audit: audit} = ctx
+
+      # The directed-handoff footgun this story must NOT have: a session posts a
+      # directed slot, then re-posts the SAME slot to update only body / extend TTL
+      # and OMITS addressing (the default through the controller + MCP proxy, which
+      # send to_host/to_capability only when present). Addressing is preserve-on-omit
+      # (COALESCE(EXCLUDED, existing)), so the omitted target is KEPT — the slot stays
+      # directed and remains visible to 40.C1 directed discovery, rather than being
+      # silently NULL-wiped to a broadcast.
+      base = %{project_id: project.id, session_id: "S1", key: "handoff:fly", audit: audit}
+
+      assert {:ok, first, :created} =
+               Coordination.post(
+                 tenant.id,
+                 agent_id,
+                 base
+                 |> Map.put(:body, "directed handoff")
+                 |> Map.put(:to_host, "beelink")
+                 |> Map.put(:to_capability, "fly-auth")
+               )
+
+      assert first.to_host == "beelink"
+      assert first.to_capability == "fly-auth"
+
+      # Re-post the SAME slot updating ONLY body — no to_host/to_capability keys.
+      assert {:ok, second, :updated} =
+               Coordination.post(
+                 tenant.id,
+                 agent_id,
+                 base |> Map.put(:body, "still working, refreshed")
+               )
+
+      assert second.id == first.id
+      assert second.body == "still working, refreshed"
+
+      # Addressing survived the body-only refresh (both the returned struct and the
+      # persisted row) — the slot is still directed, not demoted to broadcast.
+      assert second.to_host == "beelink"
+      assert second.to_capability == "fly-auth"
+
+      reloaded = AdminRepo.get!(ChannelPost, second.id)
+      assert reloaded.to_host == "beelink"
+      assert reloaded.to_capability == "fly-auth"
+
+      # A subsequent re-post CAN still change one target while omitting the other:
+      # the supplied to_host overrides, the omitted to_capability is preserved.
+      assert {:ok, third, :updated} =
+               Coordination.post(
+                 tenant.id,
+                 agent_id,
+                 base
+                 |> Map.put(:body, "moved hosts")
+                 |> Map.put(:to_host, "mac-mini")
+               )
+
+      assert third.to_host == "mac-mini"
+      assert third.to_capability == "fly-auth"
 
       assert AdminRepo.aggregate(
                from(p in ChannelPost, where: p.project_id == ^project.id),

--- a/test/loopctl/coordination_test.exs
+++ b/test/loopctl/coordination_test.exs
@@ -573,6 +573,57 @@ defmodule Loopctl.CoordinationTest do
       assert audit_actions(tenant.id, second.id) == ["posted", "upserted"]
     end
 
+    test "a keyed re-post refreshes advisory addressing (to_host/to_capability) in place", ctx do
+      %{tenant: tenant, project: project, agent_id: agent_id, audit: audit} = ctx
+
+      # to_host/to_capability are caller-variable advisory PAYLOAD, not slot-identity
+      # metadata — so a keyed re-post of the same working-state slot must be able to
+      # re-address it (US-40.A5), otherwise 40.C1 directed discovery reads the stale
+      # FIRST-set target on a handoff refresh. They are in the on_conflict replace
+      # list alongside body/refs, so the upsert overwrites them.
+      base = %{project_id: project.id, session_id: "S1", key: "handoff:fly", audit: audit}
+
+      assert {:ok, first, :created} =
+               Coordination.post(
+                 tenant.id,
+                 agent_id,
+                 base
+                 |> Map.put(:body, "broadcast state")
+                 |> Map.put(:to_host, "mac-mini")
+               )
+
+      assert first.to_host == "mac-mini"
+      assert is_nil(first.to_capability)
+
+      # Re-post the SAME slot: change to_host AND newly add to_capability (promote a
+      # host-directed slot to a capability-directed one).
+      assert {:ok, second, :updated} =
+               Coordination.post(
+                 tenant.id,
+                 agent_id,
+                 base
+                 |> Map.put(:body, "directed handoff")
+                 |> Map.put(:to_host, "beelink")
+                 |> Map.put(:to_capability, "fly-auth")
+               )
+
+      assert second.id == first.id
+      assert second.to_host == "beelink"
+      assert second.to_capability == "fly-auth"
+
+      # The addressing on the PERSISTED row reflects the refresh (not a phantom on
+      # the returned struct only).
+      reloaded = AdminRepo.get!(ChannelPost, second.id)
+      assert reloaded.to_host == "beelink"
+      assert reloaded.to_capability == "fly-auth"
+
+      assert AdminRepo.aggregate(
+               from(p in ChannelPost, where: p.project_id == ^project.id),
+               :count,
+               :id
+             ) == 1
+    end
+
     test "a different session's same key is a distinct row (no cross-session clobber)", ctx do
       %{tenant: tenant, project: project, agent_id: agent_id, audit: audit} = ctx
 

--- a/test/loopctl_web/controllers/channel_post_controller_test.exs
+++ b/test/loopctl_web/controllers/channel_post_controller_test.exs
@@ -190,6 +190,95 @@ defmodule LoopctlWeb.ChannelPostControllerTest do
       assert Coordination.recent(tenant.id, project.id) == []
     end
 
+    # TC-40.A5.1 — advisory addressing round-trips on both the write and the read.
+    test "post with to_host + to_capability -> 201, and both surface on the read" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, _agent} = agent_key(tenant)
+
+      conn =
+        post_json(raw, %{
+          "project_id" => project.id,
+          "body" => "beelink -> mac-mini for fly auth",
+          "to_host" => "mac-mini",
+          "to_capability" => "fly-auth"
+        })
+
+      assert %{"post" => post} = json_response(conn, 201)
+      assert post["to_host"] == "mac-mini"
+      assert post["to_capability"] == "fly-auth"
+
+      read = authed_conn(raw) |> get(@path, %{"project_id" => project.id})
+      assert %{"data" => [read_post]} = json_response(read, 200)
+      assert read_post["to_host"] == "mac-mini"
+      assert read_post["to_capability"] == "fly-auth"
+    end
+
+    # TC-40.A5.2 — no addressing -> 201, both NULL, visible on plain channel_recent.
+    test "post with no to_host/to_capability -> 201, both null, visible on channel_recent" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, _agent} = agent_key(tenant)
+
+      conn = post_json(raw, %{"project_id" => project.id, "body" => "broadcast"})
+
+      assert %{"post" => post} = json_response(conn, 201)
+      assert is_nil(post["to_host"])
+      assert is_nil(post["to_capability"])
+
+      read = authed_conn(raw) |> get(@path, %{"project_id" => project.id})
+      assert %{"data" => [read_post]} = json_response(read, 200)
+      assert read_post["body"] == "broadcast"
+      assert is_nil(read_post["to_host"])
+      assert is_nil(read_post["to_capability"])
+    end
+
+    # TC-40.A5.3 — a secret in to_capability is rejected 422, nothing persisted.
+    test "a secret in to_capability is rejected 422 and not persisted" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, _agent} = agent_key(tenant)
+
+      conn =
+        post_json(raw, %{
+          "project_id" => project.id,
+          "body" => "ok",
+          "to_capability" => "ghp_ABCDEFGHIJKLMNOPQRST"
+        })
+
+      assert json_response(conn, 422)
+      assert Coordination.recent(tenant.id, project.id) == []
+    end
+
+    # TC-40.A5.4 — addressing is NOT authorization: a post addressed to_host a
+    # DIFFERENT machine is still visible to the whole tenant channel when read by a
+    # DIFFERENT agent. to_host labels the intended target; it never restricts who
+    # can READ (the only authz boundary is the verified key's tenant). This is the
+    # AC-40.A5.3 "no authz branch on to_host/to_capability" proof at the integration
+    # level: a spoofed address does not change read visibility.
+    test "a post addressed to another host is still visible to a different agent in the tenant" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw_a, _key_a, _agent_a} = agent_key(tenant)
+      {raw_b, _key_b, _agent_b} = agent_key(tenant)
+
+      conn =
+        post_json(raw_a, %{
+          "project_id" => project.id,
+          "body" => "addressed elsewhere",
+          "to_host" => "some-other-host"
+        })
+
+      assert json_response(conn, 201)
+
+      # A DIFFERENT agent in the SAME tenant reads the channel: the post IS visible,
+      # to_host did not restrict read visibility.
+      read = authed_conn(raw_b) |> get(@path, %{"project_id" => project.id})
+      assert %{"data" => [read_post]} = json_response(read, 200)
+      assert read_post["body"] == "addressed elsewhere"
+      assert read_post["to_host"] == "some-other-host"
+    end
+
     # TC-39.2.2
     test "agent_id/tenant_id in the body are ignored (server-stamped from the key)" do
       tenant = fixture(:tenant)
@@ -516,7 +605,7 @@ defmodule LoopctlWeb.ChannelPostControllerTest do
       first = hd(data)
 
       assert Map.keys(first) |> Enum.sort() ==
-               ~w(agent_id body host id inserted_at key refs session_id updated_at)
+               ~w(agent_id body host id inserted_at key refs session_id to_capability to_host updated_at)
 
       assert first["agent_id"] == agent.id
     end


### PR DESCRIPTION
## US-40.A5 — Advisory addressing on the Repo Coordination Bus

Adds two OPTIONAL, nullable, freeform, indexed columns to channel_posts so a
coordination post can label its intended target — a host or, primarily, a
capability such as 'fly auth'. A later story (40.C1 directed discovery) reads
these to surface directed-to-me posts.

### Critical security invariant

Both to_host and to_capability are client-supplied and SPOOFABLE. They are
SURFACING-ONLY read hints, NEVER authorization, ownership, or a delivery
guarantee — they gate nothing. The only authorization boundary remains the
verified key's tenant. They follow the exact advisory/spoofable framing already
used for host/session_id. A post may set neither, either, or both; a post with
no addressing stays a broadcast visible to everyone on the channel. Backward
compatible: NULL on existing rows.

### Changes

- Migration: to_host/to_capability columns + partial indexes on
  (tenant_id, project_id, to_capability|to_host) WHERE ... IS NOT NULL, serving
  40.C1's to_host = me OR to_capability IN caps directed read.
- Schema: cast + blank-normalize + length bounds (to_host <=255, to_capability
  <=128 bytes) + both added to the NUL and secret-denylist scan set and to the
  write-response Jason encoder. Moduledoc trust boundary and changeset doc spell
  out the advisory-never-authz invariant.
- Controller: threads both from params, returns both in the read.
- OpenApiSpex request/response/list-item schemas updated with the advisory note.
- MCP channel_post tool: caller args (not auto-filled like host/session_id),
  description carries the spoofable/surfacing-only invariant, to_capability
  emphasized.

### Tests

Changeset unit tests (both/neither/either, over-length, NUL, secret in each
field) and controller integration tests TC-40.A5.1 through TC-40.A5.4 —
including the cross-visibility test proving a spoofed to_host does not restrict
who can READ (addressing is not authorization).

Full gate green locally: format, credo --strict, dialyzer, 5113 tests 0 failures.

Story US-40.A5 is tracked in loopctl (no bundled GitHub issue).
