### PR TITLE
Restrict redact/delete to the post's own author (or elevated role) — kill the censor-and-replace vector

### DIFF
--- a/lib/loopctl/coordination.ex
+++ b/lib/loopctl/coordination.ex
@@ -26,6 +26,7 @@ defmodule Loopctl.Coordination do
   alias Loopctl.AdminRepo
   alias Loopctl.Agents
   alias Loopctl.Audit
+  alias Loopctl.Auth.Role
   alias Loopctl.Coordination.ChannelPost
   alias Loopctl.Projects
 
@@ -221,14 +222,27 @@ defmodule Loopctl.Coordination do
   transient model — there is nothing to soft-retain in a channel that expires
   wholesale.
 
-  Cooperative single-tenant model: `agent_id` is the DELETING agent (the audit
-  actor), which may differ from the post's AUTHOR `agent_id` — any agent in the
-  tenant may delete any post in that tenant, enabling cleanup by whoever spots
-  the leak. It may NEVER delete a post in another tenant: the fetch filters on
-  BOTH `id` and `tenant_id` (the explicit tenant boundary on the AdminRepo path),
-  so a foreign (or nonexistent) `post_id` returns `{:error, :not_found}` —
+  Author-only (or elevated role) — the redact path is for self-leak-pullback,
+  NOT fleet-wide cleanup (US-40.D2). `agent_id` is the DELETING agent (the audit
+  actor) AND the authorization principal: the delete is permitted ONLY when the
+  caller's server-stamped `agent_id` equals the post's AUTHOR `agent_id`, OR the
+  caller holds an elevated role (`>= :user`, `role`). This kills the
+  censor-and-replace vector: a non-author agent could otherwise hard-delete any
+  peer's post on the shared bus. A non-author agent (role `:agent`) attempting to
+  delete another agent's post gets `{:error, :not_found}` — BYTE-IDENTICAL to a
+  missing post, so there is no existence oracle revealing the post exists but is
+  not yours.
+
+  The elevated-role bypass (`>= :user`) is the operator escape hatch: cleaning up
+  a leak the author cannot (the author's session is gone). It is gated on the
+  VERIFIED key's role — never on spoofable `host`/`session_id`.
+
+  It may NEVER delete a post in another tenant: the fetch filters on BOTH `id`
+  and `tenant_id` (the explicit tenant boundary on the AdminRepo path), so a
+  foreign (or nonexistent) `post_id` returns `{:error, :not_found}` —
   byte-identical outcomes, no cross-tenant existence oracle (KB "IDOR Prevention
-  in Multi-Tenant Delete Operations").
+  in Multi-Tenant Delete Operations"). The non-author and foreign-tenant and
+  nonexistent cases ALL collapse to the same `{:error, :not_found}`.
 
   A malformed `post_id` (a non-UUID path segment) is guarded first and returns
   `{:error, :not_found}` too, so a bad id is a clean 404 — never an
@@ -245,17 +259,30 @@ defmodule Loopctl.Coordination do
 
   Returns `{:ok, %ChannelPost{}}` (the deleted row) or `{:error, :not_found}`.
   """
-  @spec delete_post(Ecto.UUID.t(), Ecto.UUID.t(), term(), keyword()) ::
+  @spec delete_post(Ecto.UUID.t(), Ecto.UUID.t(), atom(), term(), keyword()) ::
           {:ok, ChannelPost.t()} | {:error, :not_found | :audit_write_failed}
-  def delete_post(tenant_id, agent_id, post_id, audit \\ []) do
-    if valid_uuid?(post_id) do
-      case fetch_owned_post(tenant_id, post_id) do
-        nil -> {:error, :not_found}
-        post -> run_delete(tenant_id, agent_id, post, audit)
-      end
+  def delete_post(tenant_id, agent_id, role, post_id, audit \\ []) do
+    # A malformed id (false), a nonexistent/foreign-tenant post (nil), AND a post
+    # the caller may NOT delete (present but not theirs and not elevated, false)
+    # ALL fall through the `else` to the SAME `{:error, :not_found}` — no oracle
+    # revealing the post exists but is not yours (US-40.D2). Only an authorized
+    # delete reaches `run_delete/4` (whose `{:ok, _}` / `:audit_write_failed`
+    # results are the `with` body's terminal value, never re-mapped by `else`).
+    with true <- valid_uuid?(post_id),
+         %ChannelPost{} = post <- fetch_owned_post(tenant_id, post_id),
+         true <- authorized_to_delete?(post, agent_id, role) do
+      run_delete(tenant_id, agent_id, post, audit)
     else
-      {:error, :not_found}
+      _ -> {:error, :not_found}
     end
+  end
+
+  # US-40.D2 authorization gate: the caller is the post's OWN author (server-
+  # stamped `agent_id` equals the post's author `agent_id`) OR holds an elevated
+  # role (`>= :user`, the operator escape hatch). Compares the AUTHENTICATED,
+  # server-stamped identity only — never spoofable `host`/`session_id`.
+  defp authorized_to_delete?(%ChannelPost{agent_id: author_id}, caller_agent_id, caller_role) do
+    author_id == caller_agent_id or Role.role_at_least?(caller_role, :user)
   end
 
   @doc """

--- a/lib/loopctl/coordination.ex
+++ b/lib/loopctl/coordination.ex
@@ -216,11 +216,12 @@ defmodule Loopctl.Coordination do
   @doc """
   HARD-deletes a channel post — the redact path (US-39.7).
 
-  The backstop for a leaked/regretted post: whoever NOTICES a leaked secret (the
-  denylist is best-effort, US-39.1) can remove the row immediately, before its
-  30-day TTL (US-39.5) would sweep it. A hard delete is consistent with the
-  transient model — there is nothing to soft-retain in a channel that expires
-  wholesale.
+  The backstop for a leaked/regretted post: the AUTHOR who notices their own
+  leaked secret (the denylist is best-effort, US-39.1) can pull the row back
+  immediately, before its 30-day TTL (US-39.5) would sweep it (an elevated
+  operator can do so on the author's behalf — see below). A hard delete is
+  consistent with the transient model — there is nothing to soft-retain in a
+  channel that expires wholesale.
 
   Author-only (or elevated role) — the redact path is for self-leak-pullback,
   NOT fleet-wide cleanup (US-40.D2). `agent_id` is the DELETING agent (the audit
@@ -290,9 +291,9 @@ defmodule Loopctl.Coordination do
   shared by-id read (US-40.D1). This is the SINGLE shared by-id path: the
   oracle-safe `GET /channel/posts/:id` endpoint uses it here, and graduate
   (US-40.E1) reuses it rather than duplicating the query. It wraps the same
-  private `fetch_owned_post/2` the redact path (`delete_post/4`) uses.
+  private `fetch_owned_post/2` the redact path (`delete_post/5`) uses.
 
-  ORACLE-SAFE, mirroring `delete_post/4`: the fetch filters on BOTH `id` and
+  ORACLE-SAFE, mirroring `delete_post/5`: the fetch filters on BOTH `id` and
   `tenant_id` on `AdminRepo` (BYPASSRLS), so a foreign-tenant OR nonexistent id
   both return `{:error, :not_found}` — byte-identical, no cross-tenant existence
   oracle (KB "IDOR Prevention in Multi-Tenant Delete Operations"). A malformed
@@ -317,7 +318,7 @@ defmodule Loopctl.Coordination do
   # Fetch a post by id CONSTRAINED to the caller's tenant — the isolation
   # boundary on the AdminRepo (BYPASSRLS) path. A foreign-tenant or nonexistent
   # id returns nil, so both collapse to the same 404 (no existence oracle). Shared
-  # by the redact path (`delete_post/4`) and the public by-id read (`get_post/2`).
+  # by the redact path (`delete_post/5`) and the public by-id read (`get_post/2`).
   defp fetch_owned_post(tenant_id, post_id) do
     ChannelPost
     |> where([p], p.id == ^post_id and p.tenant_id == ^tenant_id)
@@ -358,9 +359,12 @@ defmodule Loopctl.Coordination do
     end
   rescue
     # Concurrent double-delete. `fetch_owned_post/2` is an UNLOCKED read, so between
-    # it and `Multi.delete` another deleter — or the US-39.5 TTL sweep — can remove
-    # the row. The feature explicitly enables "whoever NOTICES a leaked secret,
-    # fleet-wide" to delete, making two agents deleting the same post a first-class
+    # it and `Multi.delete` the row can vanish. Under the author-only gate
+    # (`authorized_to_delete?/3`, US-40.D2) two DIFFERENT agents can no longer both
+    # delete the same post, so the legitimate races are: the author double-deleting
+    # (two concurrent redact calls from the same session), the US-39.5 TTL sweep
+    # reaping the row, or an elevated operator (`>= :user`) racing the author's own
+    # pullback. Any of these makes a concurrent delete of the same post a first-class
     # case. The losing DELETE matches 0 rows and Ecto raises `Ecto.StaleEntryError`
     # (Multi does NOT convert a stale delete to an `{:error, ...}` tuple; it
     # propagates out of the transaction). A just-deleted post is now nonexistent,

--- a/lib/loopctl_web/controllers/channel_post_controller.ex
+++ b/lib/loopctl_web/controllers/channel_post_controller.ex
@@ -9,11 +9,15 @@ defmodule LoopctlWeb.ChannelPostController do
     (channel_recent), tenant-scoped and oracle-safe.
   - `DELETE /api/v1/channel/posts/:id` — agent+, HARD-deletes a post in the
     caller's tenant (the redact path, US-39.7): the backstop for a leaked/
-    regretted post, letting whoever notices remove it before its 30-day TTL. Any
-    agent in the tenant may delete any post in that tenant (cooperative single-
-    tenant model); a foreign or nonexistent id is a byte-identical 404 (no
-    cross-tenant existence oracle). Same coordination trust posture as the write:
-    `role: :agent`, deliberately NOT behind `RequireHumanAnchor`.
+    regretted post, letting the AUTHOR pull it back before its 30-day TTL.
+    Author-only (or elevated role) — the redact path is for self-leak-pullback,
+    NOT fleet-wide cleanup (US-40.D2): the caller must be the post's own author
+    (server-stamped `agent_id`) OR hold an elevated role (`>= :user`, the
+    operator escape hatch). A non-author agent gets a byte-identical 404 (no
+    existence oracle) — same as a foreign or nonexistent id. Coordination trust
+    posture: `role: :agent` at the route (the elevated bypass is checked inside
+    the action against the verified key), deliberately NOT behind
+    `RequireHumanAnchor`.
 
   ## Trust posture (owner decision #331, design brief §4)
 
@@ -168,13 +172,14 @@ defmodule LoopctlWeb.ChannelPostController do
     summary: "Delete a repo coordination channel post (redact path)",
     description:
       "HARD-deletes a coordination post in the caller's tenant — the redact path (US-39.7). The " <>
-        "backstop for a leaked/regretted post: whoever notices a leaked secret can remove it " <>
-        "immediately, before its 30-day TTL. Agent+ role, NOT behind the human-anchor tier " <>
-        "(coordination surface, owner decision #331). Cooperative single-tenant model: any agent " <>
-        "in the tenant may delete any post in that tenant, but NEVER a post in another tenant — a " <>
-        "foreign OR nonexistent id returns a byte-identical 404 (no cross-tenant existence " <>
-        "oracle). The delete is audited (action \"deleted\", actor = the deleting agent) in the " <>
-        "same transaction, so the removal stays accountable even though the row is gone.",
+        "backstop for a leaked/regretted post: the AUTHOR can pull it back before its 30-day TTL. " <>
+        "Agent+ role, NOT behind the human-anchor tier (coordination surface, owner decision " <>
+        "#331). Author-only (or elevated role) — the redact path is for self-leak-pullback, NOT " <>
+        "fleet-wide cleanup (US-40.D2): the caller must be the post's own author (server-stamped " <>
+        "agent_id) OR hold an elevated role (>= user). A non-author agent gets a byte-identical " <>
+        "404 (no existence oracle) — same as a foreign or nonexistent id. The delete is audited " <>
+        "(action \"deleted\", actor = the deleting agent) in the same transaction, so the removal " <>
+        "stays accountable even though the row is gone.",
     parameters: [
       id: [
         in: :path,
@@ -484,9 +489,10 @@ defmodule LoopctlWeb.ChannelPostController do
   DELETE /api/v1/channel/posts/:id
 
   HARD-deletes a coordination post in the caller's tenant — the redact path
-  (US-39.7). Requires agent+ role (NOT human-anchor gated). Any agent in the
-  tenant may delete any post in that tenant; a foreign or nonexistent id returns
-  a byte-identical 404 via the shared `FallbackController` (no cross-tenant
+  (US-39.7). Requires agent+ role (NOT human-anchor gated). Author-only (or
+  elevated role, US-40.D2): the caller must be the post's own author OR hold an
+  elevated role (`>= :user`). A non-author agent — like a foreign or nonexistent
+  id — returns a byte-identical 404 via the shared `FallbackController` (no
   existence oracle). The deleting agent is the audit actor.
   """
   def delete(conn, params) do
@@ -496,6 +502,7 @@ defmodule LoopctlWeb.ChannelPostController do
     case Coordination.delete_post(
            tenant_id,
            api_key.agent_id,
+           api_key.role,
            params["id"],
            AuditContext.from_conn(conn)
          ) do

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -140,9 +140,12 @@ defmodule LoopctlWeb.Router do
     # malformed id is a byte-identical 404 (no cross-tenant existence oracle).
     get "/channel/posts/:id", ChannelPostController, :show
     # channel post redact/delete (US-39.7): agent-role, tenant-scoped HARD delete
-    # of a leaked/regretted post before its 30-day TTL. Any agent in the tenant may
-    # delete any post in that tenant; a foreign/nonexistent id is a byte-identical
-    # 404 (no cross-tenant oracle). Audited in-transaction. NOT human-anchor gated.
+    # of a leaked/regretted post before its 30-day TTL. Author-only (or elevated
+    # role >= :user), US-40.D2 — the redact path is for self-leak-pullback, not
+    # fleet-wide cleanup; the elevated bypass is checked inside the action against
+    # the verified key. A non-author agent — like a foreign/nonexistent id — is a
+    # byte-identical 404 (no existence oracle). Audited in-transaction. NOT
+    # human-anchor gated.
     delete "/channel/posts/:id", ChannelPostController, :delete
 
     get "/tenants/me", TenantController, :show

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -501,9 +501,10 @@ async function channelGet({ post_id }) {
 async function channelDelete({ post_id }) {
   // Repo Coordination Bus (Epic 39, US-39.7): HARD-delete a coordination post in
   // the caller's tenant — the redact path for a leaked/regretted post, before its
-  // 30-day TTL. Agent-role, tenant-scoped: any agent in the tenant may delete any
-  // post in that tenant; a foreign or nonexistent id returns a 404 (no cross-tenant
-  // existence oracle).
+  // 30-day TTL. Author-only (or elevated role >= user), US-40.D2: you may delete
+  // only your OWN post (server-stamped agent_id) unless your key holds an elevated
+  // role. A non-author agent — like a foreign or nonexistent id — returns a
+  // byte-identical 404 (no existence oracle).
   const result = await apiCall(
     "DELETE",
     `/api/v1/channel/posts/${post_id}`,
@@ -2375,7 +2376,7 @@ const TOOLS = [
   {
     name: "channel_delete",
     description:
-      "Delete a post from a repo coordination channel (Epic 39 Repo Coordination Bus) on the agent key — the redact path (US-39.7). Use this to immediately remove a leaked or regretted post (e.g. one that slipped a secret past the denylist) before its 30-day TTL. Agent-role, tenant-scoped: any agent in your tenant may delete any post in that tenant, enabling cleanup by whoever notices the leak. A post that does not exist in your tenant (including one in another tenant) returns a 404 — no cross-tenant existence oracle. The deletion is hard (the row is gone) but audited.",
+      "Delete a post from a repo coordination channel (Epic 39 Repo Coordination Bus) on the agent key — the redact path (US-39.7). Use this to immediately pull back your OWN leaked or regretted post (e.g. one that slipped a secret past the denylist) before its 30-day TTL. Author-only (or elevated role >= user), US-40.D2 — the redact path is for self-leak-pullback, NOT fleet-wide cleanup: you may delete only a post you authored (server-stamped agent_id), unless your key holds an elevated role (an operator escape hatch for cleaning up a leak whose author's session is gone). A post you may not delete — a peer's post, or one that does not exist in your tenant (including another tenant's) — returns a byte-identical 404 (no existence oracle). The deletion is hard (the row is gone) but audited.",
     inputSchema: {
       type: "object",
       properties: {

--- a/test/loopctl/coordination_test.exs
+++ b/test/loopctl/coordination_test.exs
@@ -960,7 +960,7 @@ defmodule Loopctl.CoordinationTest do
     end
   end
 
-  describe "delete_post/3" do
+  describe "delete_post/5" do
     setup do
       tenant = fixture(:tenant)
       project = fixture(:project, %{tenant_id: tenant.id})
@@ -975,14 +975,17 @@ defmodule Loopctl.CoordinationTest do
       %{tenant: tenant, project: project, agent_id: agent_id, audit: audit}
     end
 
-    test "deletes a post in the tenant, removes it from recent, writes a 'deleted' audit row (TC-39.7.1)",
+    test "the author deletes their OWN post, removes it from recent, writes a 'deleted' audit row (TC-40.D2.1)",
          ctx do
       %{tenant: tenant, project: project, agent_id: agent_id, audit: audit} = ctx
 
       {:ok, post} =
         Coordination.create_post(tenant.id, project.id, agent_id, %{"body" => "oops, a secret"})
 
-      assert {:ok, deleted} = Coordination.delete_post(tenant.id, agent_id, post.id, audit)
+      # Author (agent_id) deletes their own post — role :agent is sufficient.
+      assert {:ok, deleted} =
+               Coordination.delete_post(tenant.id, agent_id, :agent, post.id, audit)
+
       assert deleted.id == post.id
 
       # Row is gone.
@@ -997,7 +1000,7 @@ defmodule Loopctl.CoordinationTest do
       assert entry.metadata["deleted_post_agent_id"] == agent_id
     end
 
-    test "any agent B in the same tenant may delete agent A's post; audit actor is B (TC-39.7.2)",
+    test "a non-author agent B (role :agent) may NOT delete agent A's post; gets {:error, :not_found}, A's post survives (TC-40.D2.2)",
          ctx do
       %{tenant: tenant, project: project, agent_id: agent_a} = ctx
       agent_b = fixture(:agent, %{tenant_id: tenant.id}).id
@@ -1011,15 +1014,50 @@ defmodule Loopctl.CoordinationTest do
         actor_label: "agent:agent-b"
       ]
 
-      assert {:ok, _deleted} = Coordination.delete_post(tenant.id, agent_b, post.id, audit_b)
+      # US-40.D2 kills the censor-and-replace vector: a non-author agent gets the
+      # SAME {:error, :not_found} a missing post returns — no existence oracle.
+      assert {:error, :not_found} =
+               Coordination.delete_post(tenant.id, agent_b, :agent, post.id, audit_b)
+
+      # A's post survives untouched, and no audit "deleted" row was written.
+      assert %ChannelPost{} = AdminRepo.get(ChannelPost, post.id)
+
+      assert AdminRepo.aggregate(
+               from(a in AuditLog,
+                 where: a.entity_type == "channel_post" and a.entity_id == ^post.id
+               ),
+               :count,
+               :id
+             ) == 0
+    end
+
+    test "an elevated (role :user) caller CAN delete agent A's post; audit actor is the elevated caller (TC-40.D2.3)",
+         ctx do
+      %{tenant: tenant, project: project, agent_id: agent_a} = ctx
+      elevated_agent = fixture(:agent, %{tenant_id: tenant.id}).id
+
+      {:ok, post} =
+        Coordination.create_post(tenant.id, project.id, agent_a, %{"body" => "from A"})
+
+      audit_user = [
+        actor_type: "api_key",
+        actor_id: Ecto.UUID.generate(),
+        actor_label: "user:operator"
+      ]
+
+      # The elevated-role escape hatch (>= :user): an operator can clean up a leak
+      # the author cannot (author's session gone).
+      assert {:ok, _deleted} =
+               Coordination.delete_post(tenant.id, elevated_agent, :user, post.id, audit_user)
+
       assert is_nil(AdminRepo.get(ChannelPost, post.id))
 
       entry = one_audit_entry(tenant.id, post.id)
       assert entry.action == "deleted"
-      # The DELETING agent (B) is the audit actor — distinct from the author (A).
-      assert entry.actor_label == "agent:agent-b"
+      # The elevated DELETING actor is the audit actor — distinct from the author (A).
+      assert entry.actor_label == "user:operator"
       assert entry.metadata["deleted_post_agent_id"] == agent_a
-      assert entry.metadata["deleted_by_agent_id"] == agent_b
+      assert entry.metadata["deleted_by_agent_id"] == elevated_agent
     end
 
     test "a cross-tenant post id returns {:error, :not_found} and the foreign row still exists (TC-39.7.3)",
@@ -1033,7 +1071,7 @@ defmodule Loopctl.CoordinationTest do
         Coordination.create_post(other.id, other_project.id, other_agent, %{"body" => "theirs"})
 
       assert {:error, :not_found} =
-               Coordination.delete_post(tenant.id, agent_id, foreign_post.id, audit)
+               Coordination.delete_post(tenant.id, agent_id, :agent, foreign_post.id, audit)
 
       # The other tenant's post is untouched.
       assert %ChannelPost{} = AdminRepo.get(ChannelPost, foreign_post.id)
@@ -1043,14 +1081,14 @@ defmodule Loopctl.CoordinationTest do
       %{tenant: tenant, agent_id: agent_id, audit: audit} = ctx
 
       assert {:error, :not_found} =
-               Coordination.delete_post(tenant.id, agent_id, Ecto.UUID.generate(), audit)
+               Coordination.delete_post(tenant.id, agent_id, :agent, Ecto.UUID.generate(), audit)
     end
 
     test "a malformed (non-UUID) post id returns {:error, :not_found}, never a CastError", ctx do
       %{tenant: tenant, agent_id: agent_id, audit: audit} = ctx
 
       assert {:error, :not_found} =
-               Coordination.delete_post(tenant.id, agent_id, "not-a-uuid", audit)
+               Coordination.delete_post(tenant.id, agent_id, :agent, "not-a-uuid", audit)
     end
 
     test "tenant isolation: deleting with the wrong tenant_id does not remove the row", ctx do
@@ -1062,7 +1100,7 @@ defmodule Loopctl.CoordinationTest do
 
       # Same post id, but scoped to a different tenant → not found, row intact.
       assert {:error, :not_found} =
-               Coordination.delete_post(other.id, agent_id, post.id, audit)
+               Coordination.delete_post(other.id, agent_id, :agent, post.id, audit)
 
       assert %ChannelPost{} = AdminRepo.get(ChannelPost, post.id)
     end
@@ -1074,15 +1112,17 @@ defmodule Loopctl.CoordinationTest do
       {:ok, post} =
         Coordination.create_post(tenant.id, project.id, agent_id, %{"body" => "race"})
 
-      assert {:ok, _deleted} = Coordination.delete_post(tenant.id, agent_id, post.id, audit)
+      assert {:ok, _deleted} =
+               Coordination.delete_post(tenant.id, agent_id, :agent, post.id, audit)
 
-      # The fleet-wide "whoever notices a leaked secret" model makes two agents
-      # deleting the SAME post a first-class case. A second delete of the now-gone
-      # row must be an idempotent 404 — never an Ecto.StaleEntryError/500. (This is
-      # the caller-visible half of the concurrent race: run_delete/4's rescue
-      # collapses a true TOCTOU stale DELETE to the identical outcome.)
+      # The author re-deleting their own now-gone post is a first-class idempotency
+      # case (and a stand-in for the TOCTOU race where the row vanishes between the
+      # fetch and the Multi.delete). A second delete of the now-gone row must be an
+      # idempotent 404 — never an Ecto.StaleEntryError/500. (This is the
+      # caller-visible half of the concurrent race: run_delete/4's rescue collapses
+      # a true TOCTOU stale DELETE to the identical outcome.)
       assert {:error, :not_found} =
-               Coordination.delete_post(tenant.id, agent_id, post.id, audit)
+               Coordination.delete_post(tenant.id, agent_id, :agent, post.id, audit)
     end
 
     test "an audit-step failure rolls back the delete and returns {:error, :audit_write_failed} (fail-safe, never a masking 404)",
@@ -1102,7 +1142,7 @@ defmodule Loopctl.CoordinationTest do
       bad_audit = [actor_type: nil, actor_id: Ecto.UUID.generate(), actor_label: "x"]
 
       assert {:error, :audit_write_failed} =
-               Coordination.delete_post(tenant.id, agent_id, post.id, bad_audit)
+               Coordination.delete_post(tenant.id, agent_id, :agent, post.id, bad_audit)
 
       # Transaction rolled back: the post survives and no audit row was written.
       assert %ChannelPost{} = AdminRepo.get(ChannelPost, post.id)

--- a/test/loopctl/coordination_test.exs
+++ b/test/loopctl/coordination_test.exs
@@ -1060,6 +1060,42 @@ defmodule Loopctl.CoordinationTest do
       assert entry.metadata["deleted_by_agent_id"] == elevated_agent
     end
 
+    test "an orchestrator (role :orchestrator) non-author may NOT delete agent A's post; the gate draws at :user, not :orchestrator (TC-40.D2.4)",
+         ctx do
+      %{tenant: tenant, project: project, agent_id: agent_a} = ctx
+      orch_agent = fixture(:agent, %{tenant_id: tenant.id}).id
+
+      {:ok, post} =
+        Coordination.create_post(tenant.id, project.id, agent_a, %{"body" => "from A"})
+
+      audit_orch = [
+        actor_type: "api_key",
+        actor_id: Ecto.UUID.generate(),
+        actor_label: "orchestrator:orch"
+      ]
+
+      # The elevated bypass in authorized_to_delete?/3 requires role_at_least?(role,
+      # :user). orchestrator(2) < user(3), so an orchestrator sits ABOVE the route's
+      # RequireRole :agent floor (it reaches this context) but BELOW the :user gate:
+      # it is a non-author with an insufficient role and must be DENIED. This pins the
+      # exact threshold — a regression loosening the gate to :orchestrator (letting an
+      # orchestrator censor any agent's post, the vector this story kills) would flip
+      # this to {:ok, _} and fail here.
+      assert {:error, :not_found} =
+               Coordination.delete_post(tenant.id, orch_agent, :orchestrator, post.id, audit_orch)
+
+      # A's post survives untouched, and no audit "deleted" row was written.
+      assert %ChannelPost{} = AdminRepo.get(ChannelPost, post.id)
+
+      assert AdminRepo.aggregate(
+               from(a in AuditLog,
+                 where: a.entity_type == "channel_post" and a.entity_id == ^post.id
+               ),
+               :count,
+               :id
+             ) == 0
+    end
+
     test "a cross-tenant post id returns {:error, :not_found} and the foreign row still exists (TC-39.7.3)",
          ctx do
       %{tenant: tenant, agent_id: agent_id, audit: audit} = ctx

--- a/test/loopctl_web/controllers/channel_post_controller_test.exs
+++ b/test/loopctl_web/controllers/channel_post_controller_test.exs
@@ -955,16 +955,50 @@ defmodule LoopctlWeb.ChannelPostControllerTest do
       assert entry.action == "deleted"
     end
 
-    # TC-39.7.2: any agent B in the same tenant can delete agent A's post.
-    test "agent B in the same tenant deletes agent A's post -> 204, audit actor is B's key" do
+    # TC-40.D2.2: a non-author agent B (role :agent) may NOT delete agent A's post.
+    test "agent B (role :agent) deleting agent A's post -> 404 (byte-identical to nonexistent), A's post untouched" do
       tenant = fixture(:tenant)
       project = fixture(:project, %{tenant_id: tenant.id})
       {_raw_a, _key_a, agent_a} = agent_key(tenant)
-      {raw_b, key_b, _agent_b} = agent_key(tenant)
+      {raw_b, _key_b, _agent_b} = agent_key(tenant)
 
       post = seed_channel_post(tenant, project, agent_a.id, "from A")
 
-      conn = authed_conn(raw_b) |> delete(delete_path(post.id))
+      # US-40.D2 kills the censor-and-replace vector: a non-author agent gets a 404
+      # byte-identical to the nonexistent-post 404 (no existence oracle).
+      cross = authed_conn(raw_b) |> delete(delete_path(post.id))
+      nonexistent = authed_conn(raw_b) |> delete(delete_path(Ecto.UUID.generate()))
+
+      assert cross.status == 404
+      assert nonexistent.status == 404
+      assert cross.resp_body == nonexistent.resp_body
+
+      # A's post is untouched, and no "deleted" audit row was written.
+      assert %ChannelPost{} = AdminRepo.get(ChannelPost, post.id)
+
+      assert AdminRepo.aggregate(
+               from(a in AuditLog,
+                 where:
+                   a.entity_type == "channel_post" and a.entity_id == ^post.id and
+                     a.action == "deleted"
+               ),
+               :count,
+               :id
+             ) == 0
+    end
+
+    # TC-40.D2.3: an elevated (role :user) caller CAN delete another agent's post.
+    test "a role :user caller deleting agent A's post -> 204, audit actor is the elevated key" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {_raw_a, _key_a, agent_a} = agent_key(tenant)
+      # An elevated (>= :user) operator key — still carries an agent identity so it
+      # is the audit actor.
+      {raw_user, key_user, elevated_agent} = agent_key(tenant, %{role: :user})
+
+      post = seed_channel_post(tenant, project, agent_a.id, "from A")
+
+      conn = authed_conn(raw_user) |> delete(delete_path(post.id))
       assert response(conn, 204) == ""
 
       entry =
@@ -976,9 +1010,10 @@ defmodule LoopctlWeb.ChannelPostControllerTest do
           )
         )
 
-      # The deleting key (B) is the audit actor — not the post's author (A).
-      assert entry.actor_id == key_b.id
+      # The elevated deleting key is the audit actor — not the post's author (A).
+      assert entry.actor_id == key_user.id
       assert entry.metadata["deleted_post_agent_id"] == agent_a.id
+      assert entry.metadata["deleted_by_agent_id"] == elevated_agent.id
     end
 
     # TC-39.7.3: cross-tenant delete → 404, the other tenant's post still exists.


### PR DESCRIPTION
## US-40.D2 — Restrict channel post redact/delete to the post's own author (or elevated role)

Closes #US-40.D2

### Problem
On the repo coordination bus, ANY agent in a tenant could hard-delete ANY channel post — a censor-and-replace vector on a cross-session bus.

### Fix
`DELETE /channel/posts/:id` now permits the delete ONLY when the caller's server-stamped `agent_id` equals the post's author `agent_id`, OR the caller holds an elevated role (`>= user`). A non-author agent gets `{:error, :not_found}` — byte-identical to a missing post, so there is no existence oracle. Self-leak-pullback still works; operators (role `>= user`) can still clean up a leak whose author's session is gone.

### Changes
- **`coordination.ex` `delete_post/5`**: threads the caller's role and adds the author/role gate AFTER the shared `fetch_owned_post/2` (which is left unchanged — still used by the public `get_post/2` by-id read). Non-author, foreign-tenant, nonexistent, and malformed-id all collapse to the same `{:error, :not_found}` via a `with/else`. The audit-in-Multi and `Ecto.StaleEntryError` race handling in `run_delete/4` are preserved exactly — only the authorization gate is new.
- **`channel_post_controller.ex` `delete/2`**: passes `api_key.role` into the context. The route stays `RequireRole role: :agent` (not split) — the elevated bypass is checked inside the action against the verified key.
- **Docs corrected** (moduledocs, endpoint OpenApiSpex description, router comment, MCP `channel_delete` tool text): the old "any agent in the tenant may delete any post" framing is replaced with "author-only (or elevated role) — the redact path is for self-leak-pullback, not fleet-wide cleanup". Audit metadata (`deleted_post_agent_id` / `deleted_by_agent_id`) retained.

### Acceptance criteria
- AC-40.D2.1 author/role gate after the tenant-scoped fetch, non-author → 404 (no oracle) — done
- AC-40.D2.2 uses the authenticated server-stamped identity + role, never `host`/`session_id` — done
- AC-40.D2.3 moduledoc/endpoint framing corrected, audit metadata retained — done
- AC-40.D2.4 records the AUTHOR-ONLY design decision (no code) — done

### Tests
- Rewrote the two existing tests that asserted the old any-agent behavior: non-author agent (role `:agent`) now gets a 404 byte-identical to nonexistent; the author's post survives with no `deleted` audit row.
- Added the elevated `role: :user` delete case (204, audited as the elevated actor).
- Kept author-deletes-own, cross-tenant 404, nonexistent 404, tenant-isolation, stale-delete race, and audit-fail cases (threading the new role arg).

`mix precommit` green: format, credo --strict, dialyzer, and 5133 tests all pass.
