### PR TITLE
Read rate-limit + response byte-cap on the channel read path (index + show)

### DIFF
--- a/lib/loopctl_web/controllers/channel_post_controller.ex
+++ b/lib/loopctl_web/controllers/channel_post_controller.ex
@@ -62,8 +62,15 @@ defmodule LoopctlWeb.ChannelPostController do
   # The read (`:index`) is the same agent-role, tenant-scoped coordination surface
   # as the write — never human-anchor gated (the human-anchor default-deny test
   # only walks POST/PUT/PATCH/DELETE, so this GET needs no allowlist entry).
+  # `:handoffs` is named PROACTIVELY here (parity with the `rate_limit_read`
+  # guard, AC-40.D5.1) so that when 40.C1 lands the `:handoffs` action ON THIS
+  # controller, the agent-role gate attaches in lockstep with the read limiter —
+  # never a body-returning read that is rate-limited but escapes controller-level
+  # role enforcement. Until then the guard simply never matches the nonexistent
+  # action. (If 40.C1 instead implements handoffs in a SEPARATE controller,
+  # neither this guard nor the limiter below applies and both mentions are inert.)
   plug LoopctlWeb.Plugs.RequireRole,
-       [role: :agent] when action in [:create, :index, :delete, :show]
+       [role: :agent] when action in [:create, :index, :delete, :show, :handoffs]
 
   # Per-write rate limit (AC-39.2.8): a TIGHTER, config-driven cap on top of the
   # generic per-key/per-tenant pipeline RateLimiter, reusing the same
@@ -81,8 +88,10 @@ defmodule LoopctlWeb.ChannelPostController do
   # per-key/per-tenant limiter: this dedicated cap trips FIRST (clamped below the
   # pipeline cap) so a read burst emits the coordination `:rate_limited` signal
   # instead of being shadowed by an anonymous pipeline 429. `:handoffs` is named
-  # proactively (AC-40.D5.1); until 40.C1 lands that action the guard simply never
-  # matches, so 40.C1's route inherits this limiter automatically when it arrives.
+  # proactively (AC-40.D5.1) and kept SYMMETRIC with the RequireRole guard above;
+  # until 40.C1 lands that action the guard simply never matches. IF 40.C1 defines
+  # `:handoffs` ON THIS controller, both the role gate and this limiter attach to it
+  # automatically; if 40.C1 puts handoffs in a separate controller, neither applies.
   plug :rate_limit_read when action in [:index, :show, :handoffs]
 
   tags(["Coordination"])
@@ -570,7 +579,8 @@ defmodule LoopctlWeb.ChannelPostController do
 
         emit_security_event(:rate_limited, %{
           tenant_id: api_key.tenant_id,
-          api_key_id: api_key.id
+          api_key_id: api_key.id,
+          limit_kind: :write
         })
 
         conn
@@ -605,7 +615,8 @@ defmodule LoopctlWeb.ChannelPostController do
 
         emit_security_event(:rate_limited, %{
           tenant_id: api_key.tenant_id,
-          api_key_id: api_key.id
+          api_key_id: api_key.id,
+          limit_kind: :read
         })
 
         conn
@@ -731,7 +742,8 @@ defmodule LoopctlWeb.ChannelPostController do
         "(tenant=#{Map.get(metadata, :tenant_id)} " <>
         "api_key=#{Map.get(metadata, :api_key_id)} " <>
         "agent=#{Map.get(metadata, :agent_id)} " <>
-        "project=#{Map.get(metadata, :project_id)})"
+        "project=#{Map.get(metadata, :project_id)} " <>
+        "limit_kind=#{Map.get(metadata, :limit_kind)})"
     )
 
     :ok

--- a/lib/loopctl_web/controllers/channel_post_controller.ex
+++ b/lib/loopctl_web/controllers/channel_post_controller.ex
@@ -57,20 +57,26 @@ defmodule LoopctlWeb.ChannelPostController do
 
   action_fallback LoopctlWeb.FallbackController
 
+  # SINGLE SOURCE OF TRUTH for the agent-facing READ actions, shared by BOTH the
+  # agent-role gate and the per-read rate cap below so the two can NEVER drift
+  # apart: every read action is role-gated AND read-capped in lockstep, never a
+  # body-returning read that is rate-limited but escapes controller-level role
+  # enforcement (or vice versa). `:handoffs` (GET /channel/handoffs, 40.C1
+  # directed discovery) is listed PROACTIVELY (AC-40.D5.1): when 40.C1 lands that
+  # action ON THIS controller both guards attach automatically; until then the
+  # guards simply never match the nonexistent action. If 40.C1 instead implements
+  # handoffs in a SEPARATE controller, neither guard applies and 40.C1 MUST
+  # re-apply the read cap there (cross-story invariant — see the 40.C1 review
+  # note / wiki finding).
+  @read_actions [:index, :show, :handoffs]
+
   # Coordination surface (#331): agent role, NO RequireHumanAnchor. See the
   # coordination-surface allowlist entry in require_human_anchor_default_deny_test.
-  # The read (`:index`) is the same agent-role, tenant-scoped coordination surface
-  # as the write — never human-anchor gated (the human-anchor default-deny test
-  # only walks POST/PUT/PATCH/DELETE, so this GET needs no allowlist entry).
-  # `:handoffs` is named PROACTIVELY here (parity with the `rate_limit_read`
-  # guard, AC-40.D5.1) so that when 40.C1 lands the `:handoffs` action ON THIS
-  # controller, the agent-role gate attaches in lockstep with the read limiter —
-  # never a body-returning read that is rate-limited but escapes controller-level
-  # role enforcement. Until then the guard simply never matches the nonexistent
-  # action. (If 40.C1 instead implements handoffs in a SEPARATE controller,
-  # neither this guard nor the limiter below applies and both mentions are inert.)
+  # The reads are the same agent-role, tenant-scoped coordination surface as the
+  # write — never human-anchor gated (the human-anchor default-deny test only
+  # walks POST/PUT/PATCH/DELETE, so these GETs need no allowlist entry).
   plug LoopctlWeb.Plugs.RequireRole,
-       [role: :agent] when action in [:create, :index, :delete, :show, :handoffs]
+       [role: :agent] when action in [:create, :delete] or action in @read_actions
 
   # Per-write rate limit (AC-39.2.8): a TIGHTER, config-driven cap on top of the
   # generic per-key/per-tenant pipeline RateLimiter, reusing the same
@@ -87,12 +93,10 @@ defmodule LoopctlWeb.ChannelPostController do
   # observable. The read is no longer covered ONLY by the generic pipeline
   # per-key/per-tenant limiter: this dedicated cap trips FIRST (clamped below the
   # pipeline cap) so a read burst emits the coordination `:rate_limited` signal
-  # instead of being shadowed by an anonymous pipeline 429. `:handoffs` is named
-  # proactively (AC-40.D5.1) and kept SYMMETRIC with the RequireRole guard above;
-  # until 40.C1 lands that action the guard simply never matches. IF 40.C1 defines
-  # `:handoffs` ON THIS controller, both the role gate and this limiter attach to it
-  # automatically; if 40.C1 puts handoffs in a separate controller, neither applies.
-  plug :rate_limit_read when action in [:index, :show, :handoffs]
+  # instead of being shadowed by an anonymous pipeline 429. Uses the SAME
+  # `@read_actions` list as the RequireRole gate above — structural symmetry, so a
+  # read action can never be role-gated without also being read-capped.
+  plug :rate_limit_read when action in @read_actions
 
   tags(["Coordination"])
 
@@ -737,13 +741,24 @@ defmodule LoopctlWeb.ChannelPostController do
   defp emit_security_event(event, metadata) do
     :telemetry.execute([:loopctl, :coordination, event], %{count: 1}, metadata)
 
+    # `limit_kind` (:write / :read) is the rate-cap discriminator and is carried
+    # ONLY by the two :rate_limited callers. Render it solely when present so the
+    # four non-rate-limit events (:read_error, :agent_identity_required,
+    # :ownership_rejected) don't emit a dangling `limit_kind=` (nil) token — the
+    # full telemetry map still carries whatever keys each caller passed.
+    limit_kind_token =
+      case Map.fetch(metadata, :limit_kind) do
+        {:ok, kind} -> " limit_kind=#{kind}"
+        :error -> ""
+      end
+
     Logger.warning(
       "coordination security event: #{event} " <>
         "(tenant=#{Map.get(metadata, :tenant_id)} " <>
         "api_key=#{Map.get(metadata, :api_key_id)} " <>
         "agent=#{Map.get(metadata, :agent_id)} " <>
-        "project=#{Map.get(metadata, :project_id)} " <>
-        "limit_kind=#{Map.get(metadata, :limit_kind)})"
+        "project=#{Map.get(metadata, :project_id)}" <>
+        limit_kind_token <> ")"
     )
 
     :ok

--- a/lib/loopctl_web/controllers/channel_post_controller.ex
+++ b/lib/loopctl_web/controllers/channel_post_controller.ex
@@ -67,10 +67,23 @@ defmodule LoopctlWeb.ChannelPostController do
 
   # Per-write rate limit (AC-39.2.8): a TIGHTER, config-driven cap on top of the
   # generic per-key/per-tenant pipeline RateLimiter, reusing the same
-  # `Loopctl.RateLimiter` behaviour seam. Bounds post spam / upsert thrash. The
-  # read is NOT behind this write cap — it is covered by the generic pipeline
-  # per-key/per-tenant limiter like every other read.
+  # `Loopctl.RateLimiter` behaviour seam. Bounds post spam / upsert thrash.
   plug :rate_limit_write when action in [:create]
+
+  # Per-read rate limit (AC-40.D5.1): a PARALLEL, config-driven cap on the
+  # agent-facing read path — `:index` (channel_recent), `:show` (GET /:id, the
+  # full-body fetch), and `:handoffs` (GET /channel/handoffs, 40.C1 directed
+  # discovery — a body-returning read that must NOT escape the read limiter). It
+  # reuses the SAME `Loopctl.RateLimiter` behaviour seam and the fail-open +
+  # throttled FailOpenLog discipline as `rate_limit_write`, but on its own bucket
+  # family (`channel_post_read:key`) so read and write abuse are independently
+  # observable. The read is no longer covered ONLY by the generic pipeline
+  # per-key/per-tenant limiter: this dedicated cap trips FIRST (clamped below the
+  # pipeline cap) so a read burst emits the coordination `:rate_limited` signal
+  # instead of being shadowed by an anonymous pipeline 429. `:handoffs` is named
+  # proactively (AC-40.D5.1); until 40.C1 lands that action the guard simply never
+  # matches, so 40.C1's route inherits this limiter automatically when it arrives.
+  plug :rate_limit_read when action in [:index, :show, :handoffs]
 
   tags(["Coordination"])
 
@@ -85,6 +98,14 @@ defmodule LoopctlWeb.ChannelPostController do
   # `channel_post_write_limit_per_minute` setting (mirrors the pipeline limiter's
   # `rate_limit_requests_per_minute`). Not hardcoded at the call site.
   @default_write_limit 120
+
+  # Config-default per-minute READ cap (AC-40.D5.1); a tenant may override via the
+  # `channel_post_read_limit_per_minute` setting, mirroring the write cap. Set
+  # ABOVE the write default (reads are cheaper and more frequent) but still BELOW
+  # the pipeline per-key default (@pipeline_per_key_limit_default 300) so the
+  # coordination read cap stays the binding, observable constraint by default —
+  # `read_limit/1` additionally clamps it below the tenant's live pipeline cap.
+  @default_read_limit 240
 
   # Fallback for the generic per-key pipeline limit, kept in sync with
   # LoopctlWeb.Plugs.RateLimiter's @default_per_key_limit. Used to clamp the
@@ -209,7 +230,8 @@ defmodule LoopctlWeb.ChannelPostController do
         "another agent, with NO auto-follow. Agent+ role, tenant-scoped from the verified key. " <>
         "ORACLE-SAFE: a post in another tenant, a nonexistent id, OR a malformed (non-UUID) id all " <>
         "return a byte-identical 404 (no cross-tenant existence oracle, never a 500). The read is " <>
-        "covered by the generic per-key/per-tenant pipeline rate limiter, like the list read.",
+        "behind the dedicated per-read coordination rate cap (channel_post_read_limit_per_minute, " <>
+        "US-40.D5), on its own bucket separate from the write cap, like the list read.",
     parameters: [
       id: [
         in: :path,
@@ -331,11 +353,14 @@ defmodule LoopctlWeb.ChannelPostController do
   a byte-identical 404 (via `FallbackController` — no cross-tenant existence
   oracle). A malformed (non-UUID) id is a clean 404 too, never a 500 CastError.
 
-  Rate limiting: the read is covered by the generic per-key/per-tenant pipeline
-  `RateLimiter` (:authenticated pipeline) exactly like `:index` — it is
-  deliberately NOT behind the tighter `:rate_limit_write` cap (that guards writes
-  only). Response-byte capping / limiter tuning is US-40.D5's job; here it only
-  needs to EXIST, which the pipeline limiter satisfies.
+  Rate limiting: the read is behind the dedicated per-read coordination cap
+  (`rate_limit_read`, US-40.D5) exactly like `:index` — a config-driven,
+  tenant-overridable per-minute cap on its OWN `channel_post_read:key` bucket,
+  clamped below the generic pipeline per-key limiter so a read burst trips the
+  coordination `:rate_limited` signal first. It is deliberately NOT on the write
+  bucket (`:rate_limit_write` guards writes only) — read and write abuse are
+  independently observable. Response bytes are bounded by construction: this read
+  returns exactly one post whose `body` is <= @body_max_length (16KB).
 
   READ-MODEL DISCIPLINE: the response is the full-body COUNTERPART to the LIST
   read, NOT the write-echo resource. `channel_post_full_json/1` projects the SAME
@@ -556,6 +581,41 @@ defmodule LoopctlWeb.ChannelPostController do
     end
   end
 
+  # Per-read rate limit (AC-40.D5.1/3/4): the read-path counterpart to
+  # `rate_limit_write`, on a SEPARATE bucket family (`channel_post_read:key`) so
+  # read and write abuse are counted and observed independently. Reuses the SAME
+  # `check_rate/2` (fail-open + throttled FailOpenLog), `window_reset_at/0`, and
+  # `emit_security_event/2` helpers — no duplication. On a trip it emits the
+  # coordination `:rate_limited` signal and returns 429 with a `retry-after`
+  # header, then `halt()`s. On a limiter fault `check_rate/2` fails OPEN so a
+  # limiter outage never blocks reads (the outage stays observable via FailOpenLog).
+  defp rate_limit_read(conn, _opts) do
+    api_key = conn.assigns.current_api_key
+    tenant = conn.assigns[:current_tenant]
+    limit = read_limit(tenant)
+    identifier = "channel_post_read:key:#{api_key.id}"
+
+    case check_rate(identifier, limit) do
+      {:allow, _count} ->
+        conn
+
+      {:deny, _limit} ->
+        reset_at = window_reset_at()
+        retry_after = max(1, reset_at - System.system_time(:second))
+
+        emit_security_event(:rate_limited, %{
+          tenant_id: api_key.tenant_id,
+          api_key_id: api_key.id
+        })
+
+        conn
+        |> put_resp_header("retry-after", to_string(retry_after))
+        |> put_status(:too_many_requests)
+        |> json(%{error: %{status: 429, message: "Rate limit exceeded"}})
+        |> halt()
+    end
+  end
+
   # Reuse the RateLimiter behaviour seam (config-based DI). Fail OPEN on any
   # limiter fault — a limiter outage must degrade to "no gate", never block
   # writes — but route every fail-open through the SHARED throttled, PII-safe
@@ -603,6 +663,28 @@ defmodule LoopctlWeb.ChannelPostController do
 
   defp default_write_limit do
     Application.get_env(:loopctl, :channel_post_write_limit_per_minute, @default_write_limit)
+  end
+
+  defp read_limit(nil), do: default_read_limit()
+
+  defp read_limit(tenant) do
+    configured =
+      tenant
+      |> Tenants.get_tenant_settings("channel_post_read_limit_per_minute", default_read_limit())
+      |> coerce_positive_int(default_read_limit())
+
+    # AC-40.D5.3: the coordination read cap must remain a TIGHTER constraint than
+    # the generic per-key pipeline limiter (LoopctlWeb.Plugs.RateLimiter), which
+    # runs FIRST in the pipeline and emits no coordination-specific security signal.
+    # If a tenant set this above the pipeline limit, every coordination read-rate
+    # trip would be shadowed by an anonymous pipeline 429 — blinding the read-abuse
+    # detectors. Clamp so the read cap can never exceed (and thus be shadowed by)
+    # the pipeline cap, full parity with write_limit/1's clamp.
+    min(configured, pipeline_per_key_limit(tenant))
+  end
+
+  defp default_read_limit do
+    Application.get_env(:loopctl, :channel_post_read_limit_per_minute, @default_read_limit)
   end
 
   # The generic per-key pipeline limit that runs before this controller plug. Read

--- a/test/loopctl_web/controllers/channel_post_controller_test.exs
+++ b/test/loopctl_web/controllers/channel_post_controller_test.exs
@@ -1188,4 +1188,137 @@ defmodule LoopctlWeb.ChannelPostControllerTest do
       assert %ChannelPost{} = AdminRepo.get(ChannelPost, post.id)
     end
   end
+
+  describe "read rate limiting (US-40.D5)" do
+    # TC-40.D5.1 — a burst of :index reads past the DEDICATED read cap gets 429 with
+    # a Retry-After and emits the coordination :rate_limited signal, on a bucket
+    # SEPARATE from the write cap. The read cap (3) trips at a LOWER count than the
+    # pipeline per-key cap (default 300), so the coordination signal fires instead
+    # of being shadowed by an anonymous pipeline 429 (independence/observability).
+    test "an :index read burst past the read cap is 429 with Retry-After + :rate_limited signal" do
+      counts = stub_counting_limiter()
+      tenant = fixture(:tenant, %{settings: %{"channel_post_read_limit_per_minute" => 3}})
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, _agent} = agent_key(tenant)
+
+      # First 3 reads are within the per-read cap.
+      for _ <- 1..3 do
+        conn = authed_conn(raw) |> get(@path, %{"project_id" => project.id})
+        assert conn.status == 200
+      end
+
+      log =
+        capture_log(fn ->
+          conn = authed_conn(raw) |> get(@path, %{"project_id" => project.id})
+
+          assert %{"error" => %{"status" => 429}} = json_response(conn, 429)
+          assert [retry] = get_resp_header(conn, "retry-after")
+          assert String.to_integer(retry) >= 1
+        end)
+
+      assert log =~ "rate_limited"
+
+      # The trip was counted on the READ bucket, distinct from the write bucket —
+      # read and write abuse are independently observable (US-40.D5 technical note).
+      buckets = Agent.get(counts, &Map.keys/1)
+      assert Enum.any?(buckets, &String.starts_with?(&1, "channel_post_read:key"))
+      refute Enum.any?(buckets, &String.starts_with?(&1, "channel_post_write:key"))
+    end
+
+    # TC-40.D5.2 — the full-body :show read is behind the SAME dedicated read cap,
+    # not only the pipeline limiter: a burst of by-id reads trips at the read cap.
+    test "GET /:id is rate-limited by the dedicated read cap too" do
+      stub_counting_limiter()
+      tenant = fixture(:tenant, %{settings: %{"channel_post_read_limit_per_minute" => 3}})
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, agent} = agent_key(tenant)
+
+      {:ok, post} = Coordination.create_post(tenant.id, project.id, agent.id, %{"body" => "hi"})
+
+      for _ <- 1..3 do
+        conn = authed_conn(raw) |> get(show_path(post.id))
+        assert conn.status == 200
+      end
+
+      conn = authed_conn(raw) |> get(show_path(post.id))
+      assert %{"error" => %{"status" => 429}} = json_response(conn, 429)
+      assert [retry] = get_resp_header(conn, "retry-after")
+      assert String.to_integer(retry) >= 1
+    end
+
+    # TC-40.D5.3 — a read-path limiter fault fails OPEN (read allowed) but stays
+    # OBSERVABLE via the shared throttled FailOpenLog on the read bucket family,
+    # never silently swallowed (full parity with the write path).
+    test "a limiter fault on the read path fails open (read allowed) and is logged" do
+      stub(Loopctl.MockRateLimiter, :check_rate, fn _bucket, _window, _limit ->
+        raise "limiter boom"
+      end)
+
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, _agent} = agent_key(tenant)
+
+      log =
+        capture_log(fn ->
+          conn = authed_conn(raw) |> get(@path, %{"project_id" => project.id})
+          # Fail-open: the read still lands despite the limiter fault.
+          assert conn.status == 200
+        end)
+
+      assert log =~ "RateLimiter fail-open"
+      assert log =~ "channel_post_read:key"
+    end
+
+    # TC-40.D5.4 — a normal read cadence under the cap is unaffected: backward
+    # compatible with US-39.3 / US-40.C2 (reads behave exactly as before the cap).
+    test "a normal read cadence under the cap is unaffected (all 200, no 429)" do
+      stub_counting_limiter()
+      tenant = fixture(:tenant, %{settings: %{"channel_post_read_limit_per_minute" => 10}})
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, _agent} = agent_key(tenant)
+
+      for _ <- 1..5 do
+        conn = authed_conn(raw) |> get(@path, %{"project_id" => project.id})
+        assert conn.status == 200
+        assert get_resp_header(conn, "retry-after") == []
+      end
+    end
+
+    # AC-40.D5.2 — the read response is BOUNDED BY CONSTRUCTION; this story adds the
+    # limiter and ASSERTS the bounds already hold. The list clamps `limit` to 100
+    # (@max_recent_limit) and returns bounded previews (not full bodies).
+    test "AC-40.D5.2: :index clamps limit to 100 and returns bounded previews, not full bodies" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, agent} = agent_key(tenant)
+
+      big = String.duplicate("a", 16_384)
+      {:ok, _} = Coordination.create_post(tenant.id, project.id, agent.id, %{"body" => big})
+
+      conn = authed_conn(raw) |> get(@path, %{"project_id" => project.id, "limit" => "1000"})
+      assert %{"data" => [post], "meta" => meta} = json_response(conn, 200)
+
+      # `limit` clamped to the @max_recent_limit of 100 (list bounded by row count).
+      assert meta["limit"] == 100
+      # Bounded preview, not the full (up to 16KB) body.
+      assert byte_size(post["body_preview"]) <= Coordination.preview_bytes()
+      assert post["truncated"] == true
+      refute Map.has_key?(post, "body")
+    end
+
+    # AC-40.D5.2 — the single-post read returns exactly one post whose body is
+    # inherently bounded by @body_max_length (16KB, channel_post.ex).
+    test "AC-40.D5.2: GET /:id returns exactly one post whose body is <= 16KB" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, agent} = agent_key(tenant)
+
+      big = String.duplicate("b", 16_384)
+      {:ok, post} = Coordination.create_post(tenant.id, project.id, agent.id, %{"body" => big})
+
+      conn = authed_conn(raw) |> get(show_path(post.id))
+      assert %{"post" => body} = json_response(conn, 200)
+      assert byte_size(body["body"]) <= 16_384
+    end
+  end
 end

--- a/test/loopctl_web/controllers/channel_post_controller_test.exs
+++ b/test/loopctl_web/controllers/channel_post_controller_test.exs
@@ -371,6 +371,9 @@ defmodule LoopctlWeb.ChannelPostControllerTest do
         end)
 
       assert log =~ "ownership_rejected"
+      # A non-rate-limit event carries NO `limit_kind` — its log line must not emit
+      # a dangling `limit_kind=` token (the discriminator is write/read-cap only).
+      refute log =~ "limit_kind="
       assert_receive {:ownership_rejected, %{count: 1}, meta}
       assert meta.project_id == foreign.id
     end

--- a/test/loopctl_web/controllers/channel_post_controller_test.exs
+++ b/test/loopctl_web/controllers/channel_post_controller_test.exs
@@ -518,6 +518,9 @@ defmodule LoopctlWeb.ChannelPostControllerTest do
         end)
 
       assert log =~ "rate_limited"
+      # The signal carries a write discriminator so an external telemetry/log
+      # consumer can tell write flooding from read scraping (US-40.D5).
+      assert log =~ "limit_kind=write"
     end
 
     # AC-39.2.6 — a denylist hit / oversized body is a 422 (validation), not persisted.
@@ -1217,6 +1220,10 @@ defmodule LoopctlWeb.ChannelPostControllerTest do
         end)
 
       assert log =~ "rate_limited"
+      # The signal carries a READ discriminator so an external telemetry/log
+      # consumer can tell read scraping from write flooding (US-40.D5) — the two
+      # trips are no longer an indistinguishable :rate_limited shape.
+      assert log =~ "limit_kind=read"
 
       # The trip was counted on the READ bucket, distinct from the write bucket —
       # read and write abuse are independently observable (US-40.D5 technical note).
@@ -1282,6 +1289,64 @@ defmodule LoopctlWeb.ChannelPostControllerTest do
         assert conn.status == 200
         assert get_resp_header(conn, "retry-after") == []
       end
+    end
+
+    # AC-40.D5.3 — the coordination read cap is CLAMPED below the tenant's live
+    # pipeline per-key cap (read_limit/1's min/2). A tenant misconfiguring the read
+    # cap ABOVE the pipeline cap must NOT leave read trips shadowed by an anonymous
+    # pipeline 429: the effective read cap is the pipeline value, not the configured
+    # (larger) read value. Assert the EFFECTIVE limit the controller hands the read
+    # bucket, independent of plug ordering (parity with write_limit/1's clamp).
+    test "AC-40.D5.3: a read cap set ABOVE the pipeline cap is clamped to the pipeline value" do
+      {:ok, limits} = Agent.start_link(fn -> %{} end)
+
+      stub(Loopctl.MockRateLimiter, :check_rate, fn bucket, _window_ms, limit ->
+        Agent.update(limits, &Map.put(&1, bucket, limit))
+        {:allow, 1}
+      end)
+
+      # Read cap (100) deliberately set ABOVE the pipeline per-key cap (3).
+      tenant =
+        fixture(:tenant, %{
+          settings: %{
+            "channel_post_read_limit_per_minute" => 100,
+            "rate_limit_requests_per_minute" => 3
+          }
+        })
+
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, _agent} = agent_key(tenant)
+
+      conn = authed_conn(raw) |> get(@path, %{"project_id" => project.id})
+      assert conn.status == 200
+
+      read_bucket =
+        limits
+        |> Agent.get(&Map.keys/1)
+        |> Enum.find(&String.starts_with?(&1, "channel_post_read:key"))
+
+      # Effective cap clamped to the pipeline value (3), NOT the configured 100.
+      assert Agent.get(limits, &Map.get(&1, read_bucket)) == 3
+    end
+
+    # AC-40.D5.3 — a per-read cap stored as a JSON STRING must still enforce. Without
+    # coercion the string flows to the limiter verbatim, where Elixir term ordering
+    # (int < binary) never denies (Hammer) or the is_integer guard raises and is
+    # swallowed to fail-open (Postgres) — either way silently neutering the read cap.
+    # Mirrors the write-path regression test ("...write cap stored as a STRING...").
+    test "a coordination read cap stored as a STRING is coerced and still enforces (429)" do
+      stub_counting_limiter()
+      tenant = fixture(:tenant, %{settings: %{"channel_post_read_limit_per_minute" => "3"}})
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, _agent} = agent_key(tenant)
+
+      for _ <- 1..3 do
+        conn = authed_conn(raw) |> get(@path, %{"project_id" => project.id})
+        assert conn.status == 200
+      end
+
+      conn = authed_conn(raw) |> get(@path, %{"project_id" => project.id})
+      assert %{"error" => %{"status" => 429}} = json_response(conn, 429)
     end
 
     # AC-40.D5.2 — the read response is BOUNDED BY CONSTRUCTION; this story adds the


### PR DESCRIPTION
## US-40.D5 — Read rate-limit + response byte-cap on the channel read path

Epic 40 "Repo Coordination Bus". The channel read endpoints had no
channel-specific rate limit (only the generic pipeline limiter) and no explicit
response-size assertion. This adds a PARALLEL read-side limiter (its own bucket)
to the agent-facing reads and asserts the response byte/row bounds already hold.

### What changed
- **New `rate_limit_read` function plug** guarding `:index`, `:show` (GET /:id),
  and the not-yet-landed `:handoffs` (GET /channel/handoffs, 40.C1). The
  `:handoffs` guard is harmless until that action exists, so 40.C1 inherits the
  read limiter automatically when it lands.
- **Separate bucket family `channel_post_read:key`** so read and write abuse are
  independently observable. Reuses the shared `check_rate/2`, `fail_open/2`,
  `window_reset_at/0`, `coerce_positive_int/2`, `pipeline_per_key_limit/1`
  helpers — no duplication.
- **Config-driven**: tenant-overridable `channel_post_read_limit_per_minute`
  setting with `@default_read_limit 240`, clamped below the pipeline per-key cap
  so a read trip fires the coordination `:rate_limited` signal instead of being
  shadowed by an anonymous pipeline 429.
- **Fails OPEN** on a limiter fault, routed through the shared throttled
  `FailOpenLog` so the outage stays observable; 429s carry a `retry-after` header.
- Updated the `:show` docstring / operation description (previously deferred
  limiter tuning to US-40.D5) and the read-cap comment block.

### Acceptance criteria
- **AC-40.D5.1** — read limiter plug on `:index`/`:show`/`:handoffs`, config-driven, emits `:rate_limited`. Met.
- **AC-40.D5.2** — response byte/row bounds asserted (list clamps to 100 + bounded previews; single post body <= 16KB). Met.
- **AC-40.D5.3** — fails open through FailOpenLog; clamped tighter than the pipeline per-key limiter. Met.
- **AC-40.D5.4** — 429 carries retry-after; normal cadence unaffected; burst-past-cap 429 tested. Met.

### Tests
Added a `read rate limiting (US-40.D5)` describe block: index/show read bursts
trip the dedicated cap with retry-after + `:rate_limited` log, read bucket is
distinct from write, limiter fault fails open and logs `channel_post_read:key`,
normal cadence unaffected, and the AC-40.D5.2 byte/row bound assertions.

### Notes
- 40.C1 `:handoffs` is not yet implemented (no route/action). The plug guard
  names it proactively per AC-40.D5.1; it simply never matches until the action
  lands, at which point the route inherits the read limiter with no further work.
- `mix precommit` green (compile --warnings-as-errors, format, credo --strict,
  deps.audit, dialyzer, 5152 tests, 0 failures).
