### PR TITLE
Graduate a channel post to Knowledge — the durable home for a reusable finding with no external tracker

### DIFF
--- a/lib/loopctl/coordination.ex
+++ b/lib/loopctl/coordination.ex
@@ -906,18 +906,22 @@ defmodule Loopctl.Coordination do
   Returns the `propose_article/3` result unchanged on success, or `{:error,
   :not_found}` / `{:error, :unprocessable_entity, msg}` from the gates above, or a
   forwarded `{:error, :duplicate_title, %Article{}}` / `{:error,
-  %Ecto.Changeset{}}` (e.g. a missing required title).
+  %Ecto.Changeset{}}` (e.g. a missing required title). Because propose is called
+  with `on_gate_unavailable: :skip`, an embedding-backend outage returns `{:error,
+  :gate_unavailable}` WITHOUT creating an un-deduplicated article (retry once the
+  gate can assess) — matching the reviewed Memory graduation posture.
   """
   @spec graduate_post(Ecto.UUID.t(), Ecto.UUID.t(), atom(), term(), map()) ::
           {:ok, map()}
           | {:error, :not_found}
           | {:error, :unprocessable_entity, String.t()}
           | {:error, :duplicate_title, Knowledge.Article.t()}
+          | {:error, :gate_unavailable}
           | {:error, Ecto.Changeset.t()}
   def graduate_post(tenant_id, agent_id, role, post_id, %{} = params) do
     with {:ok, post} <- get_post(tenant_id, post_id),
          :ok <- project_writable_by_agent(tenant_id, agent_id, post.project_id, role),
-         :ok <- scan_graduation_content(params[:title], post.body) do
+         :ok <- scan_graduation_content(params[:title], post.body, params[:tags]) do
       attrs = %{
         title: params[:title],
         body: post.body,
@@ -933,24 +937,56 @@ defmodule Loopctl.Coordination do
         # unpublished outcome (the human-review queue).
         status: :published,
         project_id: post.project_id,
-        tags: params[:tags],
+        # `articles.tags` is NOT NULL (schema default []); casting an explicit nil
+        # overrides that default and 500s the insert, so a tag-less graduation must
+        # coalesce to [] here rather than pass nil through.
+        tags: params[:tags] || [],
         source_type: "channel_graduation",
         source_id: post.id,
         scope: :tenant
       }
 
-      Knowledge.propose_article(tenant_id, attrs, params[:audit] || [])
+      Knowledge.propose_article(tenant_id, attrs, propose_opts(agent_id, role, params))
     end
   end
 
-  # Explicit secret scan over BOTH the caller-supplied title and the post body BEFORE
-  # they reach Knowledge. Neither propose_article/3 nor create_article/3 scans, so this
-  # is the ONLY thing keeping a credential out of the durable, tenant-wide-readable
-  # knowledge plane on this path. The title is caller-supplied and lands in the durable
-  # plane just like the body, so it is scanned too — closing the adjacent smuggling
-  # vector. A hit is an explicit 422 rejection, never a silent drop.
-  defp scan_graduation_content(title, body) do
-    if SecretDenylist.contains_secret?(title) or SecretDenylist.contains_secret?(body) do
+  # Build the opts passed to `Knowledge.propose_article/3`, mirroring the reviewed
+  # sibling graduation paths (ArticleController.create + Memory graduation):
+  #
+  #   * `:visibility_agent_id` for AGENT-role callers (= the caller's agent id, #163).
+  #     The novelty-gate dedup assesses against the published corpus; WITHOUT a
+  #     visibility scope its near-neighbor pool would include OTHER agents' private/
+  #     owner memory articles, and a `:duplicate` verdict re-fetches + echoes that
+  #     article's id/title/status back to the caller — a cross-agent oracle. Scoping
+  #     the pool (and the canonical_neighbor re-fetch) to the caller's own visibility
+  #     closes the boundary #163 isolates. Higher roles (orchestrator/user/superadmin)
+  #     are trusted/observability and see everything, so no filter is applied — parity
+  #     with `LoopctlWeb.Helpers.Visibility.scope_opts/1`.
+  #   * `on_gate_unavailable: :skip` — automated graduation must NOT fall open and
+  #     inject an un-deduplicated published article during an embedding outage; it
+  #     returns `{:error, :gate_unavailable}` so the caller retries once embeddings
+  #     recover. Matches the reviewed Memory graduation posture (Memory.propose_opts/2).
+  defp propose_opts(agent_id, role, params) do
+    (params[:audit] || [])
+    |> Keyword.put(:on_gate_unavailable, :skip)
+    |> Keyword.merge(visibility_opts(agent_id, role))
+  end
+
+  defp visibility_opts(agent_id, :agent), do: [visibility_agent_id: to_string(agent_id)]
+  defp visibility_opts(_agent_id, _role), do: []
+
+  # Explicit secret scan over the caller-supplied title, the caller-supplied tags, and
+  # the post body BEFORE they reach Knowledge. Neither propose_article/3 nor
+  # create_article/3 scans, so this is the ONLY thing keeping a credential out of the
+  # durable, tenant-wide-readable knowledge plane on this path. The title AND tags are
+  # caller-supplied and brand-new at graduation (channel_posts carry no tags, so tags
+  # never passed the creation-path denylist), and they land in the durable plane just
+  # like the body — a token-shaped tag (e.g. a PAT/AWS key/Slack token, all of which fit
+  # Article's `^[A-Za-z0-9_-]+$` tag pattern) is the adjacent smuggling vector, so tags
+  # are scanned too. A hit is an explicit 422 rejection, never a silent drop.
+  defp scan_graduation_content(title, body, tags) do
+    if SecretDenylist.contains_secret?(title) or SecretDenylist.contains_secret?(body) or
+         Enum.any?(tags || [], &SecretDenylist.contains_secret?/1) do
       {:error, :unprocessable_entity,
        "graduation content contains a denylisted secret pattern; it cannot be graduated to the durable knowledge plane"}
     else

--- a/lib/loopctl/coordination.ex
+++ b/lib/loopctl/coordination.ex
@@ -884,11 +884,12 @@ defmodule Loopctl.Coordination do
        (US-40.D3): a non-member agent graduating a sibling-project post is denied
        identically to a not-found (`{:error, :not_found}`), no oracle. Elevated
        roles (`>= :user`) bypass, matching the redact/claim surfaces.
-    3. `SecretDenylist.contains_secret?/1` over the post body BEFORE proposing —
-       neither `propose_article/3` nor `create_article/3` runs a secret scan, so
-       this explicit step is what stops a credential being smuggled from the
-       coordination plane into the durable plane. A hit returns
-       `{:error, :unprocessable_entity, msg}` (→ 422) and nothing lands.
+    3. `SecretDenylist.contains_secret?/1` over BOTH the caller-supplied title and
+       the post body BEFORE proposing — neither `propose_article/3` nor
+       `create_article/3` runs a secret scan, so this explicit step is what stops a
+       credential being smuggled from the coordination plane into the durable plane
+       (both title and body land in the tenant-wide-readable knowledge plane). A hit
+       returns `{:error, :unprocessable_entity, msg}` (→ 422) and nothing lands.
     4. `Loopctl.Knowledge.propose_article/3` — the SEMANTIC NOVELTY gate (never
        `create_article/3` directly). A near-duplicate returns
        `%{verdict: :duplicate, article: existing, created: false}` and creates
@@ -916,13 +917,21 @@ defmodule Loopctl.Coordination do
   def graduate_post(tenant_id, agent_id, role, post_id, %{} = params) do
     with {:ok, post} <- get_post(tenant_id, post_id),
          :ok <- project_writable_by_agent(tenant_id, agent_id, post.project_id, role),
-         :ok <- scan_graduation_body(post.body) do
+         :ok <- scan_graduation_content(params[:title], post.body) do
       attrs = %{
         title: params[:title],
         body: post.body,
         # A graduated post is a reusable FINDING by default (the durable home for a
         # lesson with no external tracker); an explicit `category` may override it.
         category: params[:category] || :finding,
+        # PUBLISHED, not draft: knowledge_search/knowledge_context return PUBLISHED
+        # articles only, and the novelty gate assesses only the published corpus — so a
+        # draft graduation would be invisible AND would never dedup a sibling graduation,
+        # the exact wiki-pollution AC-40.E1 prevents. This mirrors the reviewed
+        # memory→knowledge precedent (Memory.memory_to_article_attrs/2). The novelty gate
+        # may still downgrade to :draft on a :low_novelty verdict — the ONE intended
+        # unpublished outcome (the human-review queue).
+        status: :published,
         project_id: post.project_id,
         tags: params[:tags],
         source_type: "channel_graduation",
@@ -934,14 +943,16 @@ defmodule Loopctl.Coordination do
     end
   end
 
-  # Explicit secret scan over the post body BEFORE it reaches Knowledge. Neither
-  # propose_article/3 nor create_article/3 scans, so this is the ONLY thing keeping
-  # a credential out of the durable, tenant-wide-readable knowledge plane on this
-  # path. A hit is an explicit 422 rejection, never a silent drop.
-  defp scan_graduation_body(body) do
-    if SecretDenylist.contains_secret?(body) do
+  # Explicit secret scan over BOTH the caller-supplied title and the post body BEFORE
+  # they reach Knowledge. Neither propose_article/3 nor create_article/3 scans, so this
+  # is the ONLY thing keeping a credential out of the durable, tenant-wide-readable
+  # knowledge plane on this path. The title is caller-supplied and lands in the durable
+  # plane just like the body, so it is scanned too — closing the adjacent smuggling
+  # vector. A hit is an explicit 422 rejection, never a silent drop.
+  defp scan_graduation_content(title, body) do
+    if SecretDenylist.contains_secret?(title) or SecretDenylist.contains_secret?(body) do
       {:error, :unprocessable_entity,
-       "post body contains a denylisted secret pattern; it cannot be graduated to the durable knowledge plane"}
+       "graduation content contains a denylisted secret pattern; it cannot be graduated to the durable knowledge plane"}
     else
       :ok
     end

--- a/lib/loopctl/coordination.ex
+++ b/lib/loopctl/coordination.ex
@@ -31,7 +31,9 @@ defmodule Loopctl.Coordination do
   alias Loopctl.Coordination.ChannelCursor
   alias Loopctl.Coordination.ChannelPost
   alias Loopctl.KeysetSeek
+  alias Loopctl.Knowledge
   alias Loopctl.Projects
+  alias Loopctl.Security.SecretDenylist
   alias Loopctl.WorkBreakdown.Story
 
   # Uniform retention for every post — one authoritative constant in code, not a
@@ -860,6 +862,88 @@ defmodule Loopctl.Coordination do
       end
     else
       {:error, :not_found}
+    end
+  end
+
+  @doc """
+  Graduates ONE coordination post into the durable Knowledge wiki (US-40.E1).
+
+  This is the CONTENT-SELECTIVE promotion of a genuinely reusable finding that has
+  no external tracker — NOT the general handoff-durability answer. A transient
+  "run this SQL" directive is left to expire (the 30-day TTL sweep reclaims it); a
+  reusable lesson graduates. There is NO automatic graduation — this is only ever
+  an explicit, deliberate agent call.
+
+  The orchestration lives HERE (not the controller) so the module boundary owns
+  the multi-context sequence, and it REUSES Knowledge's existing guardrails rather
+  than bypassing them:
+
+    1. `get_post/2` — tenant-scoped, oracle-safe fetch (foreign-tenant /
+       nonexistent / malformed id all collapse to `{:error, :not_found}`).
+    2. `project_writable_by_agent/4` — the SHARED project-membership gate
+       (US-40.D3): a non-member agent graduating a sibling-project post is denied
+       identically to a not-found (`{:error, :not_found}`), no oracle. Elevated
+       roles (`>= :user`) bypass, matching the redact/claim surfaces.
+    3. `SecretDenylist.contains_secret?/1` over the post body BEFORE proposing —
+       neither `propose_article/3` nor `create_article/3` runs a secret scan, so
+       this explicit step is what stops a credential being smuggled from the
+       coordination plane into the durable plane. A hit returns
+       `{:error, :unprocessable_entity, msg}` (→ 422) and nothing lands.
+    4. `Loopctl.Knowledge.propose_article/3` — the SEMANTIC NOVELTY gate (never
+       `create_article/3` directly). A near-duplicate returns
+       `%{verdict: :duplicate, article: existing, created: false}` and creates
+       nothing, so a single-use / duplicate finding does not pollute the wiki.
+
+  Provenance (AC-40.E1.3): the article carries `source_type: "channel_graduation"`
+  and `source_id` = the originating post id, attributed to the graduating agent
+  via the caller's audit context.
+
+  The source post is KEPT — the 30-day TTL sweep reclaims it (there is no
+  `graduated` column on `channel_posts`); the author may separately redact it via
+  the DELETE path.
+
+  Returns the `propose_article/3` result unchanged on success, or `{:error,
+  :not_found}` / `{:error, :unprocessable_entity, msg}` from the gates above, or a
+  forwarded `{:error, :duplicate_title, %Article{}}` / `{:error,
+  %Ecto.Changeset{}}` (e.g. a missing required title).
+  """
+  @spec graduate_post(Ecto.UUID.t(), Ecto.UUID.t(), atom(), term(), map()) ::
+          {:ok, map()}
+          | {:error, :not_found}
+          | {:error, :unprocessable_entity, String.t()}
+          | {:error, :duplicate_title, Knowledge.Article.t()}
+          | {:error, Ecto.Changeset.t()}
+  def graduate_post(tenant_id, agent_id, role, post_id, %{} = params) do
+    with {:ok, post} <- get_post(tenant_id, post_id),
+         :ok <- project_writable_by_agent(tenant_id, agent_id, post.project_id, role),
+         :ok <- scan_graduation_body(post.body) do
+      attrs = %{
+        title: params[:title],
+        body: post.body,
+        # A graduated post is a reusable FINDING by default (the durable home for a
+        # lesson with no external tracker); an explicit `category` may override it.
+        category: params[:category] || :finding,
+        project_id: post.project_id,
+        tags: params[:tags],
+        source_type: "channel_graduation",
+        source_id: post.id,
+        scope: :tenant
+      }
+
+      Knowledge.propose_article(tenant_id, attrs, params[:audit] || [])
+    end
+  end
+
+  # Explicit secret scan over the post body BEFORE it reaches Knowledge. Neither
+  # propose_article/3 nor create_article/3 scans, so this is the ONLY thing keeping
+  # a credential out of the durable, tenant-wide-readable knowledge plane on this
+  # path. A hit is an explicit 422 rejection, never a silent drop.
+  defp scan_graduation_body(body) do
+    if SecretDenylist.contains_secret?(body) do
+      {:error, :unprocessable_entity,
+       "post body contains a denylisted secret pattern; it cannot be graduated to the durable knowledge plane"}
+    else
+      :ok
     end
   end
 

--- a/lib/loopctl/knowledge/article.ex
+++ b/lib/loopctl/knowledge/article.ex
@@ -35,7 +35,7 @@ defmodule Loopctl.Knowledge.Article do
   @category_values Loopctl.Knowledge.Categories.all()
   @status_values [:draft, :published, :archived, :superseded]
   @scope_values [:tenant, :system]
-  @known_source_types ~w(review_finding manual agent session_log newsletter skill web_article ingestion)
+  @known_source_types ~w(review_finding manual agent session_log newsletter skill web_article ingestion channel_graduation)
   @tag_pattern ~r/^[a-zA-Z0-9_-]+$/
   @slug_format ~r/^[a-z0-9][a-z0-9-]*[a-z0-9]$/
   # Topical tags only. Structural identity (e.g. a "hub", or an article's source)

--- a/lib/loopctl_web/controllers/channel_post_controller.ex
+++ b/lib/loopctl_web/controllers/channel_post_controller.ex
@@ -327,6 +327,12 @@ defmodule LoopctlWeb.ChannelPostController do
              type: :string,
              description: "The Knowledge article title (required)"
            },
+           category: %OpenApiSpex.Schema{
+             type: :string,
+             description:
+               "Optional article category; defaults to 'finding' (a reusable lesson) when omitted",
+             default: "finding"
+           },
            tags: %OpenApiSpex.Schema{
              type: :array,
              items: %OpenApiSpex.Schema{type: :string},

--- a/lib/loopctl_web/controllers/channel_post_controller.ex
+++ b/lib/loopctl_web/controllers/channel_post_controller.ex
@@ -351,10 +351,16 @@ defmodule LoopctlWeb.ChannelPostController do
       404 =>
         {"Post not found (nonexistent, malformed id, in another tenant, or not a project member)",
          "application/json", Schemas.ErrorResponse},
+      409 =>
+        {"Title conflicts with an existing active article that has different content",
+         "application/json", Schemas.ErrorResponse},
       422 =>
-        {"Validation error, or the body carries a denylisted secret", "application/json",
+        {"Validation error, or the title/tags/body carry a denylisted secret", "application/json",
          Schemas.ErrorResponse},
-      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError},
+      503 =>
+        {"Novelty gate temporarily unavailable (embedding backend down); nothing graduated, retry",
+         "application/json", Schemas.ErrorResponse}
     }
   )
 
@@ -806,6 +812,26 @@ defmodule LoopctlWeb.ChannelPostController do
           "An article with this title already exists with different content. Choose a different " <>
             "title or update the existing article.",
         details: %{existing_article_id: existing.id}
+      }
+    })
+  end
+
+  # The novelty gate FELL OPEN (embedding backend down) and `on_gate_unavailable: :skip`
+  # short-circuited WITHOUT creating — automated graduation must not inject an
+  # un-deduplicated article during an outage. Transient server-side dependency outage →
+  # 503 so the caller retries once embeddings recover (mirrors MemoryController's
+  # graduation posture); the source post is kept and stays eligible.
+  defp render_graduation(conn, {:error, :gate_unavailable}) do
+    conn
+    |> put_status(:service_unavailable)
+    |> json(%{
+      error: %{
+        status: 503,
+        code: "gate_unavailable",
+        message:
+          "The novelty gate is temporarily unavailable (the embedding backend could not " <>
+            "assess this post), so nothing was graduated. The source post is kept — retry " <>
+            "once embeddings recover."
       }
     })
   end

--- a/lib/loopctl_web/controllers/channel_post_controller.ex
+++ b/lib/loopctl_web/controllers/channel_post_controller.ex
@@ -77,12 +77,18 @@ defmodule LoopctlWeb.ChannelPostController do
   # write — never human-anchor gated (the human-anchor default-deny test only
   # walks POST/PUT/PATCH/DELETE, so these GETs need no allowlist entry).
   plug LoopctlWeb.Plugs.RequireRole,
-       [role: :agent] when action in [:create, :delete] or action in @read_actions
+       [role: :agent]
+       when action in [:create, :delete, :graduate] or action in @read_actions
 
   # Per-write rate limit (AC-39.2.8): a TIGHTER, config-driven cap on top of the
   # generic per-key/per-tenant pipeline RateLimiter, reusing the same
   # `Loopctl.RateLimiter` behaviour seam. Bounds post spam / upsert thrash.
-  plug :rate_limit_write when action in [:create]
+  # `:graduate` (US-40.E1) is a WRITE into the durable Knowledge plane — it reuses
+  # the SAME per-write cap as `:create` (AC-40.E1.4: rate-bounded so it cannot
+  # bulk-flood Knowledge from the channel). Per-api_key + per-tenant buckets only —
+  # deliberately NO per-agent bucket (none exists). The generic pipeline per-key /
+  # per-tenant limiter still runs first.
+  plug :rate_limit_write when action in [:create, :graduate]
 
   # Per-read rate limit (AC-40.D5.1): a PARALLEL, config-driven cap on the
   # agent-facing read path — `:index` (channel_recent), `:show` (GET /:id, the
@@ -281,6 +287,66 @@ defmodule LoopctlWeb.ChannelPostController do
       200 => {"The post with its full body", "application/json", Schemas.ChannelPostFull},
       404 =>
         {"Post not found (nonexistent, malformed id, or in another tenant)", "application/json",
+         Schemas.ErrorResponse},
+      429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
+    }
+  )
+
+  operation(:graduate,
+    summary: "Graduate a coordination post into the durable Knowledge wiki",
+    description:
+      "Promotes ONE coordination post into the durable Knowledge wiki (US-40.E1). CONTENT-SELECTIVE: " <>
+        "this is for a genuinely REUSABLE finding that has no external tracker — NOT the general " <>
+        "handoff-durability answer. A transient directive (e.g. 'run this SQL') should be LEFT TO " <>
+        "EXPIRE (posts auto-expire in 30 days); a reusable lesson graduates. There is NO automatic " <>
+        "graduation — this is always an explicit, deliberate agent call. `title` is REQUIRED; the " <>
+        "body is carried from the post, project_id is carried over, `tags` are optional. Agent+ " <>
+        "role, project-scoped by membership (US-40.D3), NOT human-anchor gated (coordination surface, " <>
+        "owner decision #331). Reuses Knowledge's EXISTING guardrails — the SEMANTIC NOVELTY gate " <>
+        "(a near-duplicate returns 200 deduplicated and creates nothing) plus an explicit secret " <>
+        "scan over the body (a denylisted credential shape returns 422 and nothing lands) — never a " <>
+        "bypass. The article carries source_type 'channel_graduation' + source_id = the post id, " <>
+        "attributed to the graduating agent. The source post is KEPT (the 30-day TTL sweep reclaims " <>
+        "it); it is NOT marked graduated. Rate-bounded by the per-write cap so it cannot bulk-flood " <>
+        "Knowledge from the channel.",
+    parameters: [
+      id: [
+        in: :path,
+        type: :string,
+        required: true,
+        description: "The post id — must belong to the caller's tenant"
+      ]
+    ],
+    request_body:
+      {"Graduation params", "application/json",
+       %OpenApiSpex.Schema{
+         type: :object,
+         required: [:title],
+         properties: %{
+           title: %OpenApiSpex.Schema{
+             type: :string,
+             description: "The Knowledge article title (required)"
+           },
+           tags: %OpenApiSpex.Schema{
+             type: :array,
+             items: %OpenApiSpex.Schema{type: :string},
+             description: "Optional topical tags for the article"
+           }
+         }
+       }},
+    responses: %{
+      201 =>
+        {"Article created from the post", "application/json",
+         %OpenApiSpex.Schema{type: :object, additionalProperties: true}},
+      200 =>
+        {"A near-duplicate already exists; nothing created (deduplicated)", "application/json",
+         %OpenApiSpex.Schema{type: :object, additionalProperties: true}},
+      403 => {"Agent identity required", "application/json", Schemas.ErrorResponse},
+      404 =>
+        {"Post not found (nonexistent, malformed id, in another tenant, or not a project member)",
+         "application/json", Schemas.ErrorResponse},
+      422 =>
+        {"Validation error, or the body carries a denylisted secret", "application/json",
          Schemas.ErrorResponse},
       429 => {"Rate limit exceeded", "application/json", Schemas.RateLimitError}
     }
@@ -609,6 +675,138 @@ defmodule LoopctlWeb.ChannelPostController do
         {:error, changeset}
     end
   end
+
+  @doc """
+  POST /api/v1/channel/posts/:id/graduate
+
+  Graduates a coordination post into the durable Knowledge wiki (US-40.E1).
+  Requires agent+ role and a key that carries an agent identity (403
+  `agent_identity_required` otherwise — mirrors `create/2`).
+
+  CONTENT-SELECTIVE: for a genuinely REUSABLE finding with no external tracker,
+  NOT routine handoffs (a transient directive is left to expire). The orchestration
+  — tenant-scoped fetch, project-membership gate, secret scan, and the semantic
+  novelty gate — lives in `Coordination.graduate_post/5`, keeping the controller
+  thin. `{:error, :not_found}` (nonexistent / cross-tenant / non-member) and
+  `{:error, :unprocessable_entity, msg}` (denylisted secret) fall through to
+  `action_fallback`.
+  """
+  def graduate(conn, params) do
+    api_key = conn.assigns.current_api_key
+    tenant_id = api_key.tenant_id
+
+    case api_key.agent_id do
+      nil ->
+        # Parity with create/2: an attributed durable article requires a verified
+        # agent identity — no article is created without one.
+        emit_security_event(:agent_identity_required, %{
+          tenant_id: tenant_id,
+          api_key_id: api_key.id
+        })
+
+        conn
+        |> put_status(:forbidden)
+        |> json(%{
+          error: %{
+            status: 403,
+            code: "agent_identity_required",
+            message:
+              "This API key has no agent identity; it cannot graduate a channel post to Knowledge"
+          }
+        })
+
+      agent_id ->
+        graduate_params = %{
+          title: params["title"],
+          tags: params["tags"],
+          # Optional — the context defaults to :finding (a reusable lesson).
+          category: params["category"],
+          audit: AuditContext.from_conn(conn)
+        }
+
+        conn
+        |> render_graduation(
+          Coordination.graduate_post(
+            tenant_id,
+            agent_id,
+            api_key.role,
+            params["id"],
+            graduate_params
+          )
+        )
+    end
+  end
+
+  # Render the `Coordination.graduate_post/5` outcome, mirroring
+  # `LoopctlWeb.ArticleController.render_proposal/4`:
+  #   * :duplicate    → 200, nothing created, point at the canonical article
+  #     (so a single-use/duplicate finding does NOT pollute the wiki — AC-40.E1.2)
+  #   * :created / :gated_to_draft → 201, the created article
+  #   * :deduplicated (idempotency_key no-op) → 200 reference
+  # `{:error, :not_found}`, `{:error, :unprocessable_entity, msg}` (secret),
+  # `{:error, :duplicate_title, _}`, and `{:error, %Ecto.Changeset{}}` all fall
+  # through to `action_fallback` (404 / 422).
+  defp render_graduation(conn, {:ok, %{verdict: :duplicate, article: existing}}) do
+    conn
+    |> put_status(:ok)
+    |> json(%{
+      deduplicated: true,
+      data: %{id: existing.id, title: existing.title, status: to_string(existing.status)},
+      note:
+        "A near-duplicate already exists (id #{existing.id}). Nothing was graduated — read or " <>
+          "update the existing article instead."
+    })
+  end
+
+  defp render_graduation(conn, {:ok, %{verdict: :deduplicated, article: existing}}) do
+    conn
+    |> put_status(:ok)
+    |> json(%{
+      deduplicated: true,
+      data: %{id: existing.id, status: to_string(existing.status)},
+      note: "An article with this identity already exists. Nothing was graduated."
+    })
+  end
+
+  defp render_graduation(conn, {:ok, %{article: article}}) do
+    conn
+    |> put_status(:created)
+    |> json(%{
+      data: %{
+        id: article.id,
+        title: article.title,
+        status: to_string(article.status),
+        source_type: article.source_type,
+        source_id: article.source_id,
+        project_id: article.project_id
+      },
+      note:
+        "Graduated the coordination post into Knowledge (id #{article.id}). The source post is " <>
+          "kept and will expire on its 30-day TTL; redact it via DELETE if it must be removed sooner."
+    })
+  end
+
+  # Exact-title collision with a DIFFERENT-bodied active article (distinct from the
+  # semantic novelty gate — the title unique guard). Mirror article_controller's
+  # 409 title_conflict; the FallbackController has no clause for this 3-tuple.
+  defp render_graduation(conn, {:error, :duplicate_title, existing}) do
+    conn
+    |> put_status(:conflict)
+    |> json(%{
+      error: %{
+        status: 409,
+        code: "title_conflict",
+        message:
+          "An article with this title already exists with different content. Choose a different " <>
+            "title or update the existing article.",
+        details: %{existing_article_id: existing.id}
+      }
+    })
+  end
+
+  # {:error, :not_found} | {:error, :unprocessable_entity, msg} |
+  # {:error, %Ecto.Changeset{}} → FallbackController (404 / 422).
+  defp render_graduation(conn, error), do: LoopctlWeb.FallbackController.call(conn, error)
 
   @doc """
   DELETE /api/v1/channel/posts/:id

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -148,6 +148,15 @@ defmodule LoopctlWeb.Router do
     # human-anchor gated.
     delete "/channel/posts/:id", ChannelPostController, :delete
 
+    # Graduate a coordination post into the durable Knowledge wiki (Epic 40,
+    # US-40.E1) — the CONTENT-SELECTIVE promotion of a genuinely reusable finding
+    # with no external tracker (a transient directive is left to expire). Agent
+    # role, project-scoped by membership (US-40.D3), NOT human-anchor gated
+    # (coordination surface, owner decision #331). Goes through Knowledge's
+    # semantic novelty gate + an explicit secret scan — never a bypass. The static
+    # `/graduate` suffix does NOT shadow `get "/channel/posts/:id"`.
+    post "/channel/posts/:id/graduate", ChannelPostController, :graduate
+
     # Repo Coordination Bus CLAIM surface (Epic 40, US-40.B1) — exactly-once handoff
     # claims. INSERT-to-claim: the first inserter on (tenant_id, project_id, ref)
     # wins; a loser gets a distinct 409 already_claimed. Agent-role, project-scoped

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -121,7 +121,7 @@ REST endpoint (`PATCH /api/v1/tenants/me/llm-config`), and the docs — so you (
 autonomous agent) can self-remediate without a human. Full agent-tenant lifecycle:
 [`docs/onboarding-agent-tenant.md`](../docs/onboarding-agent-tenant.md).
 
-## Tools (95)
+## Tools (96)
 
 > Plus **per-tenant generated Context Retriever tools** (`cr_*`) appended
 > dynamically at runtime — see [Dynamic per-tenant Context Retriever
@@ -161,6 +161,7 @@ Epic 39 Repo Coordination Bus — a lightweight, tenant-isolated channel for age
 | `channel_claim` | Claim a handoff `ref` for EXACTLY ONE agent (Epic 40, US-40.B1) — coordinate an out-of-band unit of work (e.g. `handoff:repo#812`) among agents racing on the same repo. INSERT-to-claim: the first to claim `(tenant, project, ref)` wins; a concurrent LOSER gets a distinct 409 `already_claimed` (another agent already owns it — move on, do NOT retry the same ref). Project-scoped by membership. Optional `lease_seconds` (default 3600, max 86400). Required: `project_id`, `ref`. |
 | `channel_release` | Release YOUR OWN handoff claim so the `ref` reopens for another agent (deletes the claim). Owner-scoped: a claim you do not own / cross-tenant / nonexistent returns a byte-identical 404. Required: `project_id`, `ref`. |
 | `channel_done` | Mark YOUR OWN handoff claim done (sets `done_at`) — records you completed the claimed work; the row is retained ~7 days then swept. Owner-scoped like `channel_release`. Required: `project_id`, `ref`. |
+| `channel_graduate` | Graduate a coordination post into the durable Knowledge wiki (Epic 40, US-40.E1). CONTENT-SELECTIVE — ONLY for a genuinely REUSABLE finding with no external tracker, worth another agent reading later; a transient directive should be LEFT TO EXPIRE on its 30-day TTL, never graduated. No automatic graduation. Reuses Knowledge's guardrails, never a bypass: the semantic novelty gate (a near-duplicate returns 200 `deduplicated`, nothing created) plus a secret scan (a denylisted credential returns 422). Records `source_type` `channel_graduation` + the post id, attributed to you; the source post is KEPT (its TTL reclaims it). Project-scoped by membership. Optional `tags`, `category` (default `finding`). Required: `post_id`, `title`. |
 
 ### Story Tools
 

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -557,6 +557,26 @@ async function channelDelete({ post_id }) {
   return toContent(result);
 }
 
+async function channelGraduate({ post_id, title, tags, category }) {
+  // Repo Coordination Bus (Epic 40, US-40.E1): graduate a coordination post into
+  // the durable Knowledge wiki on the AGENT key. CONTENT-SELECTIVE — for a
+  // genuinely REUSABLE finding with no external tracker, NOT routine handoffs (a
+  // transient directive should be left to expire on its 30-day TTL). Reuses
+  // Knowledge's semantic novelty gate (a near-duplicate returns 200 deduplicated,
+  // nothing created) plus an explicit secret scan (a denylisted credential returns
+  // 422) — never a bypass. Project-scoped by membership; tenant/agent server-stamped.
+  const payload = { title };
+  if (tags) payload.tags = tags;
+  if (category) payload.category = category;
+  const result = await apiCall(
+    "POST",
+    `/api/v1/channel/posts/${post_id}/graduate`,
+    payload,
+    process.env.LOOPCTL_AGENT_KEY,
+  );
+  return toContent(result);
+}
+
 async function deleteProject({ project_id }) {
   const result = await apiCall(
     "DELETE",
@@ -2429,6 +2449,35 @@ const TOOLS = [
         },
       },
       required: ["post_id"],
+    },
+  },
+  {
+    name: "channel_graduate",
+    description:
+      "Graduate a repo coordination post into the durable Knowledge wiki (Epic 40 Repo Coordination Bus, US-40.E1), on the agent key. CONTENT-SELECTIVE — use this ONLY for a genuinely REUSABLE finding that has no external tracker and is worth another agent reading later (the durable home for a lesson learned). It is NOT the general handoff-durability answer: a transient directive (e.g. 'run this SQL now', 'rebasing branch X') should be LEFT TO EXPIRE on the post's 30-day TTL, never graduated. There is NO automatic graduation — this is always your explicit, deliberate decision. title is REQUIRED; the article body is carried from the post, project_id carries over, and tags are optional. Reuses Knowledge's EXISTING guardrails, never a bypass: the SEMANTIC NOVELTY gate (a near-duplicate returns 200 with deduplicated:true and creates nothing, pointing you at the canonical article) plus an explicit secret scan over the body (a denylisted credential shape returns 422 and nothing lands). The article records source_type 'channel_graduation' + the originating post id, attributed to you. The source post is KEPT (its TTL sweep reclaims it); redact it separately with channel_delete if it must go sooner. Project-scoped by membership; tenant/agent are server-stamped from your verified key. Rate-bounded so it cannot bulk-flood Knowledge from the channel.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        post_id: {
+          type: "string",
+          description: "UUID of the channel post to graduate (must be in your tenant).",
+        },
+        title: {
+          type: "string",
+          description: "Title for the durable Knowledge article (required).",
+        },
+        tags: {
+          type: "array",
+          items: { type: "string" },
+          description: "Optional topical tags for the article.",
+        },
+        category: {
+          type: "string",
+          description:
+            "Optional article category (defaults to 'finding' — a reusable lesson).",
+        },
+      },
+      required: ["post_id", "title"],
     },
   },
   {
@@ -5303,6 +5352,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     case "channel_delete":
       return await channelDelete(args);
+    case "channel_graduate":
+      return await channelGraduate(args);
 
     case "channel_claim":
       return await channelClaim(args);

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopctl-mcp-server",
-  "version": "2.49.0",
+  "version": "2.50.0",
   "description": "MCP server for loopctl — structural trust for AI development loops",
   "type": "module",
   "main": "index.js",

--- a/mcp-server/test/mcp_arg_forwarding.test.js
+++ b/mcp-server/test/mcp_arg_forwarding.test.js
@@ -397,6 +397,58 @@ describe("#40.D1: channel_get wiring + untrusted-DATA framing", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// #40.E1: channel_graduate (graduate a coordination post into Knowledge)
+// ---------------------------------------------------------------------------
+
+describe("#40.E1: channel_graduate wiring", () => {
+  test("TOOLS declares channel_graduate requiring post_id and title", () => {
+    assert.match(
+      INDEX_SRC,
+      /name: "channel_graduate",/,
+      'must declare a "channel_graduate" tool',
+    );
+    assert.match(
+      INDEX_SRC,
+      /name: "channel_graduate",[\s\S]*?required: \["post_id", "title"\]/,
+      "the channel_graduate inputSchema must require post_id and title",
+    );
+  });
+
+  test("channelGraduate POSTs /channel/posts/${post_id}/graduate on the AGENT key", () => {
+    assert.match(
+      INDEX_SRC,
+      /async function channelGraduate\([\s\S]*?"POST",\s*`\/api\/v1\/channel\/posts\/\$\{post_id\}\/graduate`,\s*payload,\s*process\.env\.LOOPCTL_AGENT_KEY/,
+      "channelGraduate must POST /api/v1/channel/posts/${post_id}/graduate with the agent key",
+    );
+  });
+
+  test("the channel_graduate dispatch case calls channelGraduate(args)", () => {
+    assert.match(
+      INDEX_SRC,
+      /case "channel_graduate":\s*\n\s*return await channelGraduate\(args\);/,
+      "the channel_graduate dispatch case must call channelGraduate(args)",
+    );
+  });
+
+  test("channel_graduate description states it is CONTENT-SELECTIVE and transient posts should expire (AC-40.E1.4/5)", () => {
+    const gradTool = /name: "channel_graduate",\s*\n\s*description:\s*\n?\s*"([^"]*)"/.exec(
+      INDEX_SRC,
+    );
+    assert.ok(gradTool, "channel_graduate must have a description");
+    assert.match(
+      gradTool[1],
+      /REUSABLE/,
+      "channel_graduate must state it is for a reusable finding",
+    );
+    assert.match(
+      gradTool[1],
+      /LEFT TO EXPIRE|left to expire/,
+      "channel_graduate must say transient directives should be left to expire",
+    );
+  });
+});
+
 describe("KB-scope lifecycle: archive_kb_scope / restore_kb_scope wiring", () => {
   test("TOOLS declares archive_kb_scope and restore_kb_scope", () => {
     assert.match(INDEX_SRC, /name: "archive_kb_scope",/, 'must declare "archive_kb_scope"');

--- a/test/loopctl/knowledge/article_test.exs
+++ b/test/loopctl/knowledge/article_test.exs
@@ -274,6 +274,25 @@ defmodule Loopctl.Knowledge.ArticleTest do
       end
     end
 
+    # TC-40.E1.5 — the graduate path (US-40.E1) stamps source_type
+    # "channel_graduation"; it must be in @known_source_types so validate_source_type/1
+    # passes rather than rejecting the durable provenance marker.
+    test "accepts the channel_graduation source_type (US-40.E1)" do
+      assert "channel_graduation" in Article.known_source_types()
+
+      changeset =
+        Article.create_changeset(%Article{}, %{
+          title: "Graduated finding",
+          body: "A reusable lesson.",
+          category: :finding,
+          source_type: "channel_graduation",
+          source_id: Ecto.UUID.generate()
+        })
+
+      assert changeset.valid?
+      refute errors_on(changeset)[:source_type]
+    end
+
     test "rejects non-map metadata" do
       changeset =
         Article.create_changeset(%Article{}, %{

--- a/test/loopctl_web/controllers/channel_post_graduate_test.exs
+++ b/test/loopctl_web/controllers/channel_post_graduate_test.exs
@@ -1,0 +1,229 @@
+defmodule LoopctlWeb.ChannelPostGraduateTest do
+  @moduledoc """
+  US-40.E1 — `POST /api/v1/channel/posts/:id/graduate`.
+
+  Graduating a coordination post into the durable Knowledge wiki: a CONTENT-
+  SELECTIVE, one-call, agent-triggered promotion of a genuinely reusable finding.
+  It reuses Knowledge's EXISTING guardrails — the semantic novelty gate + an
+  explicit secret scan — and is tenant/project-membership scoped.
+
+  Everything (auth resolution AND the graduate write) runs through
+  `Loopctl.AdminRepo`, one sandbox connection, so this stays `async: true`.
+  """
+  use LoopctlWeb.ConnCase, async: true
+
+  setup :verify_on_exit!
+
+  import Ecto.Query
+  import Mox
+
+  alias Loopctl.AdminRepo
+  alias Loopctl.Coordination
+  alias Loopctl.Coordination.ChannelPost
+  alias Loopctl.Knowledge
+
+  @sth_header "0:AAAAAAAAAAAAAAAAAAAAAA"
+
+  # A role:agent key whose api_key.agent_id points at a real agent in the tenant.
+  defp agent_key(tenant, attrs \\ %{}) do
+    agent = fixture(:agent, %{tenant_id: tenant.id})
+
+    {raw, key} =
+      fixture(
+        :api_key,
+        Map.merge(%{tenant_id: tenant.id, role: :agent, agent_id: agent.id}, attrs)
+      )
+
+    {raw, key, agent}
+  end
+
+  # A role:agent key whose agent is a WRITABLE MEMBER of `project` (US-40.D3):
+  # graduate is project-scoped by membership (shared with the claim/write gate).
+  # Assigning the agent a story in `project` admits its graduate through the gate.
+  defp member_agent_key(tenant, project, attrs \\ %{}) do
+    {raw, key, agent} = agent_key(tenant, attrs)
+
+    fixture(:story, %{
+      tenant_id: tenant.id,
+      project_id: project.id,
+      assigned_agent_id: agent.id,
+      agent_status: :assigned
+    })
+
+    {raw, key, agent}
+  end
+
+  defp authed_conn(raw) do
+    build_conn()
+    |> put_req_header("x-loopctl-last-known-sth", @sth_header)
+    |> put_req_header("authorization", "Bearer #{raw}")
+  end
+
+  defp graduate_path(id), do: "/api/v1/channel/posts/#{id}/graduate"
+
+  defp create_post(tenant, project, agent, body) do
+    {:ok, post} = Coordination.create_post(tenant.id, project.id, agent.id, %{"body" => body})
+    post
+  end
+
+  # Force the assessor verdict for one test (the DataCase default stubs :novel).
+  defp gate_verdict(verdict, neighbors) do
+    stub(Loopctl.MockProposalAssessor, :assess, fn _t, _a, _o ->
+      %{verdict: verdict, score: 0.98, neighbors: neighbors}
+    end)
+  end
+
+  describe "POST /api/v1/channel/posts/:id/graduate" do
+    # TC-40.E1.1 — a member agent graduates a post → a Knowledge article is created
+    # from the post body with project_id carried over, and provenance references the
+    # originating post (source_type + source_id) and passes source_type validation.
+    test "graduates a post into a Knowledge article with channel provenance" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, agent} = member_agent_key(tenant, project)
+
+      post = create_post(tenant, project, agent, "A reusable lesson worth keeping.")
+
+      conn =
+        authed_conn(raw)
+        |> post(graduate_path(post.id), %{"title" => "Reusable Lesson", "tags" => ["ops"]})
+
+      assert %{"data" => data} = json_response(conn, 201)
+      assert data["title"] == "Reusable Lesson"
+      assert data["source_type"] == "channel_graduation"
+      assert data["source_id"] == post.id
+      assert data["project_id"] == project.id
+
+      # The durable article really landed, carrying the post body + provenance.
+      assert {:ok, article} = Knowledge.get_article(tenant.id, data["id"])
+      assert article.body == "A reusable lesson worth keeping."
+      assert article.project_id == project.id
+      assert article.source_type == "channel_graduation"
+      assert article.source_id == post.id
+      assert article.tags == ["ops"]
+
+      # The source post is KEPT (30-day TTL sweep reclaims it) — not force-graduated.
+      assert {:ok, %ChannelPost{}} = Coordination.get_post(tenant.id, post.id)
+    end
+
+    # TC-40.E1.2 — the semantic novelty gate catches a near-duplicate: nothing is
+    # created, the caller is pointed at the canonical existing article.
+    test "a near-duplicate returns 200 deduplicated and creates nothing" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, agent} = member_agent_key(tenant, project)
+
+      existing =
+        fixture(:article, %{tenant_id: tenant.id, title: "Canonical", status: :published})
+
+      gate_verdict(:duplicate, [
+        %{id: existing.id, title: existing.title, similarity_score: 0.98}
+      ])
+
+      post = create_post(tenant, project, agent, "Same idea, reworded.")
+
+      count_before = AdminRepo.aggregate(from(a in "articles"), :count)
+
+      conn =
+        authed_conn(raw)
+        |> post(graduate_path(post.id), %{"title" => "Reworded canonical"})
+
+      body = json_response(conn, 200)
+      assert body["deduplicated"] == true
+      assert body["data"]["id"] == existing.id
+
+      # No wiki pollution: no new article row was inserted.
+      assert AdminRepo.aggregate(from(a in "articles"), :count) == count_before
+    end
+
+    # TC-40.E1.3 — a post whose body carries a denylisted secret → 422, nothing
+    # lands in Knowledge (the explicit secret scan runs BEFORE propose_article).
+    test "a post body carrying a secret is rejected with 422 and nothing is graduated" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, agent} = member_agent_key(tenant, project)
+
+      # Seed a benign post, then plant a secret directly (bypassing the write-path
+      # denylist) to simulate a credential that slipped through / was regretted.
+      post = create_post(tenant, project, agent, "placeholder")
+      secret_body = "here is the leaked key sk-abcdefghijklmnopqrstuvwxyz0123"
+
+      {1, _} =
+        AdminRepo.update_all(
+          from(p in ChannelPost, where: p.id == ^post.id),
+          set: [body: secret_body]
+        )
+
+      count_before = AdminRepo.aggregate(from(a in "articles"), :count)
+
+      conn =
+        authed_conn(raw)
+        |> post(graduate_path(post.id), %{"title" => "Should not land"})
+
+      assert %{"error" => _} = json_response(conn, 422)
+      assert AdminRepo.aggregate(from(a in "articles"), :count) == count_before
+    end
+
+    # TC-40.E1.4 (tenant isolation) — a post in ANOTHER tenant → 404, no article
+    # created. get_post/2 is tenant-scoped, so there is no cross-tenant oracle.
+    test "graduating another tenant's post returns 404 and creates no article" do
+      tenant = fixture(:tenant)
+      {raw, _key, _agent} = agent_key(tenant)
+
+      other = fixture(:tenant)
+      other_project = fixture(:project, %{tenant_id: other.id})
+      other_agent = fixture(:agent, %{tenant_id: other.id})
+      foreign = create_post(other, other_project, other_agent, "theirs")
+
+      count_before = AdminRepo.aggregate(from(a in "articles"), :count)
+
+      conn =
+        authed_conn(raw)
+        |> post(graduate_path(foreign.id), %{"title" => "Steal it"})
+
+      assert json_response(conn, 404) == %{
+               "error" => %{"status" => 404, "message" => "Not found"}
+             }
+
+      assert AdminRepo.aggregate(from(a in "articles"), :count) == count_before
+    end
+
+    # A non-member agent (no story assignment in the project) is denied identically
+    # to a not-found — the shared membership gate (US-40.D3), no oracle.
+    test "a non-member agent gets a byte-identical 404" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      # agent_key (NOT member_agent_key): no story assignment → not a member.
+      {raw, _key, agent} = agent_key(tenant)
+      author = fixture(:agent, %{tenant_id: tenant.id})
+      post = create_post(tenant, project, author, "a finding")
+
+      # Sanity: the caller is not the author and has no assignment.
+      refute agent.id == author.id
+
+      conn =
+        authed_conn(raw)
+        |> post(graduate_path(post.id), %{"title" => "Reusable"})
+
+      assert json_response(conn, 404) == %{
+               "error" => %{"status" => 404, "message" => "Not found"}
+             }
+    end
+
+    # A key with no agent identity cannot graduate (parity with create/2).
+    test "a key with no agent identity gets 403 agent_identity_required" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      agent = fixture(:agent, %{tenant_id: tenant.id})
+      post = create_post(tenant, project, agent, "a finding")
+
+      {raw, _key} = fixture(:api_key, %{tenant_id: tenant.id, role: :agent, agent_id: nil})
+
+      conn =
+        authed_conn(raw)
+        |> post(graduate_path(post.id), %{"title" => "Reusable"})
+
+      assert %{"error" => %{"code" => "agent_identity_required"}} = json_response(conn, 403)
+    end
+  end
+end

--- a/test/loopctl_web/controllers/channel_post_graduate_test.exs
+++ b/test/loopctl_web/controllers/channel_post_graduate_test.exs
@@ -175,6 +175,79 @@ defmodule LoopctlWeb.ChannelPostGraduateTest do
       assert AdminRepo.aggregate(from(a in "articles"), :count) == count_before
     end
 
+    # A token-shaped TAG carries a denylisted secret → 422, nothing graduated. Tags are
+    # caller-supplied and brand-new at graduation (channel_posts have no tags, so a tag
+    # never passed the creation-path denylist) and land in the same durable, tenant-wide-
+    # readable plane the scan protects. Regression for the tag smuggling vector.
+    test "a token-shaped tag carrying a secret is rejected with 422 and nothing is graduated" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, agent} = member_agent_key(tenant, project)
+
+      post = create_post(tenant, project, agent, "a perfectly benign finding")
+      count_before = AdminRepo.aggregate(from(a in "articles"), :count)
+
+      # A real GitHub PAT shape: fits Article's ^[A-Za-z0-9_-]+$ tag pattern AND fires
+      # the SecretDenylist. Title + body are clean — only the tag smuggles the secret.
+      conn =
+        authed_conn(raw)
+        |> post(graduate_path(post.id), %{
+          "title" => "Clean title",
+          "tags" => ["ops", "ghp_16C7e42F292c6912E7710c838347Ae178B4a"]
+        })
+
+      assert %{"error" => _} = json_response(conn, 422)
+      assert AdminRepo.aggregate(from(a in "articles"), :count) == count_before
+    end
+
+    # #163 — an AGENT-role graduation must scope the novelty-gate dedup to the caller's
+    # own visibility, or the near-neighbor pool (and a :duplicate re-fetch) can echo
+    # ANOTHER agent's private/owner memory id/title/status. Assert the caller's
+    # visibility_agent_id is threaded into the assessor opts.
+    test "an agent graduation threads the caller's visibility_agent_id into the novelty gate" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, agent} = member_agent_key(tenant, project)
+
+      test_pid = self()
+
+      stub(Loopctl.MockProposalAssessor, :assess, fn _t, _a, opts ->
+        send(test_pid, {:assess_opts, opts})
+        %{verdict: :novel, score: 0.0, neighbors: []}
+      end)
+
+      post = create_post(tenant, project, agent, "A scoped reusable lesson.")
+
+      conn =
+        authed_conn(raw)
+        |> post(graduate_path(post.id), %{"title" => "Scoped Lesson"})
+
+      assert json_response(conn, 201)
+      assert_received {:assess_opts, opts}
+      assert Keyword.get(opts, :visibility_agent_id) == to_string(agent.id)
+    end
+
+    # Finding 3 — the embedding backend is down: the gate falls open (:unknown) and
+    # `on_gate_unavailable: :skip` must short-circuit WITHOUT creating an un-deduplicated
+    # article. 503 + nothing graduated (mirrors the reviewed Memory graduation posture).
+    test "a fell-open novelty gate returns 503 and graduates nothing" do
+      tenant = fixture(:tenant)
+      project = fixture(:project, %{tenant_id: tenant.id})
+      {raw, _key, agent} = member_agent_key(tenant, project)
+
+      gate_verdict(:unknown, [])
+
+      post = create_post(tenant, project, agent, "A lesson the gate cannot assess.")
+      count_before = AdminRepo.aggregate(from(a in "articles"), :count)
+
+      conn =
+        authed_conn(raw)
+        |> post(graduate_path(post.id), %{"title" => "Outage lesson"})
+
+      assert %{"error" => %{"code" => "gate_unavailable"}} = json_response(conn, 503)
+      assert AdminRepo.aggregate(from(a in "articles"), :count) == count_before
+    end
+
     # TC-40.E1.4 (tenant isolation) — a post in ANOTHER tenant → 404, no article
     # created. get_post/2 is tenant-scoped, so there is no cross-tenant oracle.
     test "graduating another tenant's post returns 404 and creates no article" do

--- a/test/loopctl_web/controllers/channel_post_graduate_test.exs
+++ b/test/loopctl_web/controllers/channel_post_graduate_test.exs
@@ -102,6 +102,17 @@ defmodule LoopctlWeb.ChannelPostGraduateTest do
       assert article.source_id == post.id
       assert article.tags == ["ops"]
 
+      # Promotion into the DISCOVERABLE durable plane: a graduated finding must be
+      # PUBLISHED, not a draft — knowledge_search/knowledge_context return published
+      # articles only and the novelty gate assesses only the published corpus, so a
+      # draft graduation would be invisible AND would never dedup a sibling graduation.
+      assert article.status == :published
+
+      # And it is actually retrievable via the published-only keyword search surface,
+      # proving the promotion reached the discoverable plane (not just the row).
+      assert {:ok, %{results: results}} = Knowledge.search_keyword(tenant.id, "reusable")
+      assert data["id"] in Enum.map(results, & &1.id)
+
       # The source post is KEPT (30-day TTL sweep reclaims it) — not force-graduated.
       assert {:ok, %ChannelPost{}} = Coordination.get_post(tenant.id, post.id)
     end

--- a/test/loopctl_web/require_human_anchor_default_deny_test.exs
+++ b/test/loopctl_web/require_human_anchor_default_deny_test.exs
@@ -199,6 +199,17 @@ defmodule LoopctlWeb.RequireHumanAnchorDefaultDenyTest do
                # key, tenant-scoped), NOT chain-of-custody, so deliberately outside
                # the human-anchor tier gate (design brief §3, owner decision #331).
                {:delete, "/api/v1/channel/posts/:id"},
+               # US-40.E1 channel post → Knowledge graduation. An on-demand, agent-
+               # triggered promotion of a reusable coordination finding into the durable
+               # wiki — the SAME memory→knowledge graduation posture as
+               # /memory/graduate (allowlisted above) and knowledge_create, both
+               # agent-reachable. Agent-role, authorship/tenant server-derived from the
+               # verified key, project-scoped by membership (US-40.D3), reusing Knowledge's
+               # EXISTING guardrails (semantic novelty gate + secret scan) — a COORDINATION
+               # surface, NOT chain-of-custody, so deliberately outside the human-anchor
+               # tier gate (owner decision #331). ChannelPostController carries NO
+               # RequireHumanAnchor plug, so this classification is consistent.
+               {:post, "/api/v1/channel/posts/:id/graduate"},
                # US-40.B1 Repo Coordination Bus CLAIM surface — exactly-once handoff
                # claim/release/done. Same COORDINATION posture as the channel posts:
                # agent-role, tenant_id/agent_id/role server-stamped from the verified


### PR DESCRIPTION
## US-40.E1 — Graduate a channel post to Knowledge

Adds a one-call, agent-triggered promotion of a repo-coordination channel post into the durable Knowledge wiki. CONTENT-SELECTIVE: the durable home for a genuinely reusable finding with no external tracker, NOT the general handoff-durability answer. A transient directive is left to expire on the 30-day TTL; a reusable lesson graduates. It reuses Knowledge's EXISTING guardrails (semantic novelty gate + a separately-run secret scan) — never a bypass.

### What changed
- **Route**: `POST /api/v1/channel/posts/:id/graduate` (agent role, project-scoped by membership, NOT human-anchor gated). The static `/graduate` suffix does not shadow `GET /channel/posts/:id`.
- **Coordination.graduate_post/5** owns the orchestration (module-boundary convention): tenant-scoped `get_post/2`, the SHARED `project_writable_by_agent/4` membership gate (US-40.D3), an explicit `SecretDenylist.contains_secret?/1` scan over the post body BEFORE proposing (neither propose nor create scans), then `Knowledge.propose_article/3` — the semantic novelty gate, never `create_article/3` directly, so a near-duplicate creates nothing and does not pollute the wiki.
- **Provenance**: added `channel_graduation` to `@known_source_types`; the article carries `source_type: "channel_graduation"` + `source_id` = the originating post id, attributed to the graduating agent via the audit context.
- **Post fate**: the source post is KEPT (the 30-day TTL sweep reclaims it) — no `graduated` column.
- **Rate-bounded** by the existing per-write cap (per-api_key + per-tenant buckets, no per-agent bucket).
- **MCP**: `channel_graduate(post_id, title, tags?, category?)` tool on the agent key, description states it is for reusable findings and transient directives should be left to expire. mcp-server bumped to 2.50.0; README tool list updated.

### Acceptance criteria
All five ACs met: the graduate route creates a Knowledge article from the post (AC-40.E1.1); routes through the semantic novelty gate with the pre-propose secret scan and project/membership ownership (AC-40.E1.2); carries channel provenance via `channel_graduation` source_type option (a) (AC-40.E1.3); is content-selective and rate-bounded (AC-40.E1.4); ships the `channel_graduate` MCP tool (AC-40.E1.5).

### Tests
Request tests: create-from-post + provenance, near-duplicate dedup (200, nothing created), secret-scan 422, tenant-isolation 404, non-member 404, 403 no-agent-identity. A schema unit test for the `channel_graduation` source_type. MCP wiring tests. `mix precommit` is green except one pre-existing flaky, unrelated test (`KeysetCursorTest` byte-mutated cursor — probabilistic tamper test, no cursor code touched here; passes on the default seed).

### Note
`us_40.1.json` (refocused by this story) is already removed from the repo; `us_40.e1.json` is the current spec — no doc change needed.

Closes #US-40.E1
