### PR TITLE
fix(test): bound test concurrency and pool size so the suite fits max_connections

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -1,5 +1,24 @@
 import Config
 
+# Test concurrency + pool sizing — BOUNDED, and the two MUST move together.
+#
+# Three repos (Repo, AdminRepo, HeavyReadRepo) each open `pool_size` connections
+# EAGERLY at boot, so the suite's floor demand is 3 * pool_size before a single
+# test runs. Sizing that purely off the core count overruns a stock Postgres
+# `max_connections` (100) on a high-core dev box: 24 cores * 2 * 3 repos = 144,
+# which fails as `DBConnection.ConnectionError ... queue_timeout` on sandbox
+# checkout — a full DB that reads like a missing one. Capping keeps the floor at
+# 3 * 16 = 48 on every machine (mac-mini, blockit, beelink) and in CI, leaving
+# room for a second Elixir app sharing the same local Postgres.
+#
+# `max_cases` is derived from the SAME number on purpose: the pool must never be
+# smaller than the count of concurrently running async tests, or the suite
+# deadlocks on checkout from the other direction. Change one, change both.
+test_concurrency = min(System.schedulers_online(), 8)
+test_pool_size = test_concurrency * 2
+
+config :ex_unit, max_cases: test_concurrency
+
 # Configure your database
 #
 # The MIX_TEST_PARTITION environment variable can be used
@@ -11,7 +30,7 @@ config :loopctl, Loopctl.Repo,
   hostname: "localhost",
   database: "loopctl_test#{System.get_env("MIX_TEST_PARTITION")}",
   pool: Ecto.Adapters.SQL.Sandbox,
-  pool_size: System.schedulers_online() * 2
+  pool_size: test_pool_size
 
 # AdminRepo — same database, sandbox mode for tests
 config :loopctl, Loopctl.AdminRepo,
@@ -20,7 +39,7 @@ config :loopctl, Loopctl.AdminRepo,
   hostname: "localhost",
   database: "loopctl_test#{System.get_env("MIX_TEST_PARTITION")}",
   pool: Ecto.Adapters.SQL.Sandbox,
-  pool_size: System.schedulers_online() * 2,
+  pool_size: test_pool_size,
   # Scale tests seed ~80k rows under Sandbox.unboxed_run/2, which can exceed the
   # default 60s ownership timeout (the seed takes >2 min) → "owner process crashed".
   # Allow the unboxed connection to be held long enough for the prod-floor seed.
@@ -44,7 +63,7 @@ config :loopctl, Loopctl.HeavyReadRepo,
   hostname: "localhost",
   database: "loopctl_test#{System.get_env("MIX_TEST_PARTITION")}",
   pool: Ecto.Adapters.SQL.Sandbox,
-  pool_size: System.schedulers_online() * 2,
+  pool_size: test_pool_size,
   ownership_timeout: :timer.minutes(30)
 
 # The pool-wide DEFAULT server-side statement_timeout (US-27.13), applied via SET LOCAL on


### PR DESCRIPTION
## Problem

Three repos (`Repo`, `AdminRepo`, `HeavyReadRepo`) each opened `pool_size` connections **eagerly at boot**, sized `System.schedulers_online() * 2`. On a 24-core machine that is `24 * 2 * 3 = 144` connections demanded before a single test runs — against a stock Postgres `max_connections` of 100, and less in practice when a second Elixir app shares the same local server.

The symptom does not look like the cause. Sandbox checkout fails with:

```
DBConnection.ConnectionError ... connection not available and request was dropped
from queue after 4630ms ... reason: :queue_timeout
```

which reads as a missing or slow database. Postgres was up and accepting connections the entire time — the server was simply full. That misdirection cost a long diagnosis (checking whether the server was running, whether the test DB existed, whether pgvector was installed) before the connection math turned out to be the answer.

This is why it only ever failed on one machine: mac-mini (~10 cores) and blockit ask for ~60, comfortably under the ceiling. The 24-core box asks for 144 and cannot run the gate at all.

## Fix

Cap both concurrency and pool size from a single derived number:

```elixir
test_concurrency = min(System.schedulers_online(), 8)
test_pool_size = test_concurrency * 2
config :ex_unit, max_cases: test_concurrency
```

**The coupling is the load-bearing part.** `max_cases` is derived from the same value on purpose: the pool must never be smaller than the number of concurrently running async tests, or the suite deadlocks on checkout from the other direction. Capping `pool_size` alone would trade one hang for another. Change one, change both — the comment in the file says so.

Floor demand is now `3 * 16 = 48` on every machine and in CI.

## Why this shape rather than the alternatives

- **Raising `max_connections`** would need doing on three differently provisioned installs (brew PG 16, brew PG 14, docker `postgres:16`) and again on every new machine. Not portable.
- **A per-machine `ELIXIR_ERL_OPTIONS="+S 8"`** works but is per-invocation and, critically, does **not** reach the pre-commit hook's own environment — so commits would still fail on the affected box.
- This config change is machine-independent and needs no DB admin anywhere.

## Verification

Committed deliberately **without** any env override, to prove the config alone is sufficient:

```
Running ExUnit with seed: 671118, max_cases: 8
5284 tests, 0 failures (57 excluded)
✅ All pre-commit checks passed!
```

Full `mix precommit`: compile `--warnings-as-errors`, `deps.unlock --check-unused`, format, credo `--strict`, `loopctl.check_skill_citations`, `deps.audit`, dialyzer, tests.

## Tradeoff

Fewer parallel cases on a high-core machine (8 instead of 24), so the suite runs slower there. The benefit is that the gate runs at all on that machine, which it previously did not. Lower-core machines and CI are unaffected in behaviour.
