### PR TITLE
fix(mix): run test.e2e in the test env via preferred_envs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule Loopctl.MixProject do
 
   def cli do
     [
-      preferred_envs: [precommit: :test]
+      preferred_envs: [precommit: :test, "test.e2e": :test]
     ]
   end
 


### PR DESCRIPTION
## Problem

The global pre-push hook (added 2026-07-20) runs `mix test.e2e` before every push. But the `test.e2e` alias had no `preferred_envs` entry, so it launched in the **dev** env and bailed on Mix's "mix test is running in the dev environment" guard before any test executed — blocking every push repo-wide.

## Fix

Add `"test.e2e": :test` to `preferred_envs` in `mix.exs` so the alias self-selects the test env, matching the existing `precommit` entry.

## Verification

- `MIX_ENV=test mix test.e2e` → 15 tests, 0 failures.
- `mix test.e2e` (no explicit env) now runs in test and passes.
- Full `mix precommit` gate green; pre-push e2e gate green (this branch pushed through it).
