### PR TITLE
chore(dev): quiet dev console logs to :info level

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -96,6 +96,12 @@ config :loopctl, :webauthn,
   origin: "http://localhost:4030",
   user_verification: "preferred"
 
+# Quiet the dev console: :info drops Ecto SQL query logs and other :debug
+# chatter. Note this filters :debug at the LOGGER level, before any handler sees
+# it — so Tidewave's (MCP) get_logs will ALSO no longer surface SQL/:debug lines.
+# If you need to inspect SQL via get_logs, temporarily set this back to :debug.
+config :logger, level: :info
+
 # Do not include metadata nor timestamps in development logs
 config :logger, :default_handler,
   formatter: {:logger_formatter, %{template: [:level, ": ", :message, "\n"]}}


### PR DESCRIPTION
## What

Sets `config :logger, level: :info` in `config/dev.exs` so Ecto SQL query logs and other :debug chatter stop flooding the dev console.

## Tradeoff (documented inline)

Filtering happens at the Logger level, before any handler — so Tidewave's (MCP) `get_logs` will also no longer surface SQL/:debug lines. The inline comment documents flipping the level back to :debug when SQL inspection via get_logs is needed. info/warn/error still flow through get_logs unchanged.

## Scope

Dev-only config. No production impact. Full `mix precommit` gate passes locally (5461 tests, 0 failures).
