### PR TITLE
Harden break-glass clear-halt to actually verify the WebAuthn assertion

### DIFF
--- a/docs/articles/break-glass.md
+++ b/docs/articles/break-glass.md
@@ -17,11 +17,35 @@ This article documents the emergency procedures.
 
 ## Clearing a custody halt
 
+Clearing a halt is a mandatory **two-step, challenge-bound** WebAuthn ceremony.
+A superadmin key alone is NOT sufficient — each clear must be authorized by a
+fresh, single-use assertion from one of the target tenant's enrolled root
+authenticators. Both steps require superadmin.
+
+**Step 1 — request a challenge:**
+
+```bash
+POST /api/v1/admin/tenants/:id/clear-halt/challenge
+```
+
+Mints a server-side, single-use, TTL-bounded challenge bound to the target
+tenant and returns `challenge_id`, `challenge`, `allowed_credentials`, `rp_id`,
+and `expires_at`. Returns `422 no_authenticators` if the tenant has no enrolled
+root authenticator.
+
+**Step 2 — present the assertion:**
+
 ```bash
 POST /api/v1/admin/tenants/:id/clear-halt
 ```
 
-Requires a fresh WebAuthn assertion from a root authenticator.
+Send the WebAuthn assertion (in the `webauthn_assertion` field) produced for the
+challenge from step 1. The server verifies the assertion against the STORED
+challenge (challenge binding, origin, RP-ID, signature against the enrolled COSE
+key, sign-counter regression) and, on success, clears the halt. The challenge is
+consumed exactly once — one challenge authorizes exactly one attempt, and replay
+is rejected. Rejected attempts are recorded in the tenant's tamper-evident audit
+chain.
 
 ## Key recovery
 

--- a/lib/loopctl/api_spec/schemas.ex
+++ b/lib/loopctl/api_spec/schemas.ex
@@ -561,6 +561,25 @@ defmodule Loopctl.ApiSpec.Schemas do
     })
   end
 
+  defmodule ReauthAssertionRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "ReauthAssertionRequest",
+      description:
+        "Step 2 of the challenge-bound WebAuthn reauthentication ceremony, shared by " <>
+          "every custody-critical operation that gates on a fresh assertion (e.g. " <>
+          "break-glass clear-halt). Carries the WebAuthn assertion that is verified " <>
+          "against the STORED challenge from step 1 before the operation proceeds.",
+      type: :object,
+      required: [:webauthn_assertion],
+      properties: %{
+        webauthn_assertion: WebAuthnAssertion
+      }
+    })
+  end
+
   defmodule AuditKeyResponse do
     @moduledoc false
     require OpenApiSpex

--- a/lib/loopctl_web/controllers/admin_tenant_controller.ex
+++ b/lib/loopctl_web/controllers/admin_tenant_controller.ex
@@ -405,6 +405,17 @@ defmodule LoopctlWeb.AdminTenantController do
   consumed against the same `tenant_id` in `clear_halt/2`.
   """
   def clear_halt_challenge(conn, %{"id" => tenant_id}) do
+    # Guard the raw path :id up front: a non-UUID string would otherwise reach
+    # `where: tenant_id == ^tenant_id` on a :binary_id column and raise
+    # Ecto.Query.CastError (unhandled 500). Mirror record_rejected_break_glass:
+    # a malformed id addresses no real tenant, so 404.
+    case Ecto.UUID.cast(tenant_id) do
+      {:ok, uuid} -> issue_clear_halt_challenge(conn, uuid)
+      :error -> respond_tenant_not_found(conn)
+    end
+  end
+
+  defp issue_clear_halt_challenge(conn, tenant_id) do
     case Reauth.issue_challenge(tenant_id, @clear_halt_purpose) do
       {:ok, issued} ->
         conn
@@ -468,6 +479,18 @@ defmodule LoopctlWeb.AdminTenantController do
   exactly once; replay is rejected.
   """
   def clear_halt(conn, %{"id" => id} = params) do
+    # Guard the raw path :id up front: the verify path (verify_and_consume ->
+    # consume_challenge) runs `c.tenant_id == ^tenant_id` on a :binary_id
+    # column BEFORE any 404, so a malformed id would raise Ecto.Query.CastError
+    # (unhandled 500) even with a well-formed assertion body. A non-UUID id
+    # addresses no real tenant, so 404 — mirroring record_rejected_break_glass.
+    case Ecto.UUID.cast(id) do
+      {:ok, uuid} -> require_assertion_and_clear(conn, uuid, params)
+      :error -> respond_tenant_not_found(conn)
+    end
+  end
+
+  defp require_assertion_and_clear(conn, id, params) do
     # Break-glass requires a VERIFIED WebAuthn assertion, not merely a
     # present one. Mirror the rotate-audit-key guard: the assertion must be
     # a map (the separate base64url fields), then it is cryptographically
@@ -489,6 +512,10 @@ defmodule LoopctlWeb.AdminTenantController do
         }
       })
     end
+  end
+
+  defp respond_tenant_not_found(conn) do
+    conn |> put_status(:not_found) |> json(%{error: %{message: "Not found", status: 404}})
   end
 
   defp verify_and_clear_halt(conn, id, assertion) do
@@ -528,23 +555,47 @@ defmodule LoopctlWeb.AdminTenantController do
         # responder can tie the recovery to a specific hardware factor.
         api_key = conn.assigns.current_api_key
 
-        Loopctl.AuditChain.append(tenant.id, %{
-          action: "halt_cleared",
-          actor_lineage: [],
-          entity_type: "tenant",
-          entity_id: tenant.id,
-          payload: %{
-            "cleared_by" => api_key.id,
-            "credential_id" =>
-              Base.url_encode64(verified.authenticator.credential_id, padding: false),
-            "sign_count" => verified.sign_count
-          }
-        })
+        append_result =
+          Loopctl.AuditChain.append(tenant.id, %{
+            action: "halt_cleared",
+            actor_lineage: [],
+            entity_type: "tenant",
+            entity_id: tenant.id,
+            payload: %{
+              "cleared_by" => api_key.id,
+              "credential_id" =>
+                Base.url_encode64(verified.authenticator.credential_id, padding: false),
+              "sign_count" => verified.sign_count
+            }
+          })
 
-        json(conn, %{data: %{id: tenant.id, custody_halted_at: nil, status: "halt_cleared"}})
+        # For an L6 break-glass recovery the forensic record is NOT optional: a
+        # cleared halt with no tamper-evident trace is exactly the byzantine
+        # state this control exists to prevent. Unlike the routine suspend/
+        # activate paths, do NOT fire-and-forget the append — if it fails, the
+        # halt is already cleared (recovery succeeded) but the audit chain is
+        # broken, so surface it loudly (500) instead of a misleading 200.
+        # clear_custody_halt is idempotent, so an operator retry is safe.
+        case append_result do
+          {:ok, _entry} ->
+            json(conn, %{data: %{id: tenant.id, custody_halted_at: nil, status: "halt_cleared"}})
+
+          {:error, _reason} ->
+            conn
+            |> put_status(:internal_server_error)
+            |> json(%{
+              error: %{
+                code: "audit_append_failed",
+                status: 500,
+                message:
+                  "Custody halt was cleared but the break-glass audit entry could not be " <>
+                    "recorded. Investigate the audit chain before relying on this recovery."
+              }
+            })
+        end
 
       {:error, :not_found} ->
-        conn |> put_status(:not_found) |> json(%{error: %{message: "Not found", status: 404}})
+        respond_tenant_not_found(conn)
     end
   end
 

--- a/lib/loopctl_web/controllers/admin_tenant_controller.ex
+++ b/lib/loopctl_web/controllers/admin_tenant_controller.ex
@@ -448,7 +448,7 @@ defmodule LoopctlWeb.AdminTenantController do
         "assertion is single-use — one challenge authorizes exactly one attempt. " <>
         "Requires superadmin.",
     parameters: [id: [in: :path, type: :string, description: "Tenant UUID"]],
-    request_body: {"WebAuthn assertion", "application/json", Schemas.RotateAuditKeyRequest},
+    request_body: {"WebAuthn assertion", "application/json", Schemas.ReauthAssertionRequest},
     responses: %{
       200 =>
         {"Halt cleared", "application/json",
@@ -463,9 +463,9 @@ defmodule LoopctlWeb.AdminTenantController do
 
   Break-glass custody-halt recovery (Chain of Custody v2, L6). Superadmin
   key alone is NOT sufficient: the caller must present a WebAuthn assertion
-  verified against a challenge issued by `challenge/2` and the target
-  tenant's enrolled root authenticator. The challenge is consumed exactly
-  once; replay is rejected.
+  verified against a challenge issued by `clear_halt_challenge/2` and the
+  target tenant's enrolled root authenticator. The challenge is consumed
+  exactly once; replay is rejected.
   """
   def clear_halt(conn, %{"id" => id} = params) do
     # Break-glass requires a VERIFIED WebAuthn assertion, not merely a
@@ -497,10 +497,16 @@ defmodule LoopctlWeb.AdminTenantController do
     # ceremony is single-use: the challenge is consumed here regardless of
     # outcome. Only a genuinely verified assertion reaches do_clear_halt.
     case Reauth.verify_and_consume(id, @clear_halt_purpose, assertion) do
-      {:ok, _verified} ->
-        do_clear_halt(conn, id)
+      {:ok, verified} ->
+        do_clear_halt(conn, id, verified)
 
       {:error, _reason} ->
+        # A REJECTED break-glass attempt is the exact signal of a compromised
+        # superadmin key trying to clear a byzantine halt WITHOUT the hardware
+        # factor. Record it in the tamper-evident chain (L6 forensics) so the
+        # audit record shows failed attempts, not only successful clears.
+        record_rejected_break_glass(conn, id)
+
         conn
         |> put_status(:unauthorized)
         |> json(%{
@@ -513,10 +519,13 @@ defmodule LoopctlWeb.AdminTenantController do
     end
   end
 
-  defp do_clear_halt(conn, id) do
+  defp do_clear_halt(conn, id, verified) do
     case Tenants.clear_custody_halt(id) do
       {:ok, tenant} ->
-        # Break-glass: audit this critical operation
+        # Break-glass: audit this critical operation. Record WHICH enrolled
+        # authenticator authorized the clear (the verified credential + its
+        # advanced sign-counter), not only the superadmin key, so an incident
+        # responder can tie the recovery to a specific hardware factor.
         api_key = conn.assigns.current_api_key
 
         Loopctl.AuditChain.append(tenant.id, %{
@@ -524,13 +533,41 @@ defmodule LoopctlWeb.AdminTenantController do
           actor_lineage: [],
           entity_type: "tenant",
           entity_id: tenant.id,
-          payload: %{"cleared_by" => api_key.id}
+          payload: %{
+            "cleared_by" => api_key.id,
+            "credential_id" =>
+              Base.url_encode64(verified.authenticator.credential_id, padding: false),
+            "sign_count" => verified.sign_count
+          }
         })
 
         json(conn, %{data: %{id: tenant.id, custody_halted_at: nil, status: "halt_cleared"}})
 
       {:error, :not_found} ->
         conn |> put_status(:not_found) |> json(%{error: %{message: "Not found", status: 404}})
+    end
+  end
+
+  # Append a `halt_clear_rejected` entry to the tenant's audit chain. Guarded
+  # so it only fires for a real tenant: a garbage `:id` has no chain to append
+  # to (and the FK is not changeset-guarded, so an insert against a
+  # non-existent tenant would raise) and nothing to protect. The high-trust
+  # forensic signal is `rejected_by` — the server-verified superadmin key that
+  # attempted the clear and failed the hardware factor.
+  defp record_rejected_break_glass(conn, tenant_id) do
+    with {:ok, uuid} <- Ecto.UUID.cast(tenant_id),
+         {:ok, _tenant} <- Tenants.get_tenant(uuid) do
+      api_key = conn.assigns.current_api_key
+
+      Loopctl.AuditChain.append(uuid, %{
+        action: "halt_clear_rejected",
+        actor_lineage: [],
+        entity_type: "tenant",
+        entity_id: uuid,
+        payload: %{"rejected_by" => api_key.id}
+      })
+    else
+      _ -> :ok
     end
   end
 end

--- a/lib/loopctl_web/controllers/admin_tenant_controller.ex
+++ b/lib/loopctl_web/controllers/admin_tenant_controller.ex
@@ -18,11 +18,20 @@ defmodule LoopctlWeb.AdminTenantController do
   alias Loopctl.ApiSpec.Schemas
   alias Loopctl.Audit
   alias Loopctl.Tenants
+  alias Loopctl.WebAuthn.Reauth
   alias LoopctlWeb.AuditContext
 
   action_fallback LoopctlWeb.FallbackController
 
   plug LoopctlWeb.Plugs.RequireRole, exact_role: :superadmin
+
+  # Break-glass custody-halt recovery is a Chain of Custody v2 L6 control:
+  # even a compromised superadmin key MUST prove possession of the tenant's
+  # enrolled hardware authenticator. The purpose string is a compile-time
+  # constant (never user input) and is DISTINCT from the audit-key rotation
+  # purpose, so a challenge minted for one ceremony cannot be replayed against
+  # the other — `Reauth.consume_challenge/3` scopes by `(tenant_id, purpose)`.
+  @clear_halt_purpose "clear_custody_halt"
 
   tags(["Admin"])
 
@@ -366,12 +375,108 @@ defmodule LoopctlWeb.AdminTenantController do
     end
   end
 
-  @doc "POST /api/v1/admin/tenants/:id/clear-halt — clears custody halt (break-glass, requires WebAuthn)"
+  operation(:clear_halt_challenge,
+    summary: "Issue a break-glass clear-halt reauth challenge (admin)",
+    description:
+      "Step 1 of the challenge-bound WebAuthn reauthentication ceremony for " <>
+        "break-glass custody-halt recovery. Issues an authentication challenge bound " <>
+        "to the target tenant's enrolled root authenticators, stores it server-side " <>
+        "(single-use, short TTL) and returns the opaque `challenge_id`, the base64url " <>
+        "challenge bytes, and the allowed credential ids. Requires superadmin.",
+    parameters: [id: [in: :path, type: :string, description: "Tenant UUID"]],
+    responses: %{
+      200 => {"Reauth challenge", "application/json", Schemas.ReauthChallengeResponse},
+      403 => {"Forbidden", "application/json", Schemas.ErrorResponse},
+      422 => {"No enrolled authenticators", "application/json", Schemas.ErrorResponse}
+    }
+  )
+
+  @doc """
+  POST /api/v1/admin/tenants/:id/clear-halt/challenge
+
+  Step 1 of the break-glass reauth ceremony. Mints a server-side,
+  single-use, TTL-bounded authentication challenge bound to the TARGET
+  tenant (the path `:id`) and returns the opaque handle plus allowed
+  credential ids. Superadmin-only (controller-level `RequireRole` plug).
+
+  This is a cross-tenant superadmin operation, so there is NO ownership
+  check: the target tenant is the path `:id`, and tenant isolation holds
+  because the challenge is stored under that `tenant_id` and can only be
+  consumed against the same `tenant_id` in `clear_halt/2`.
+  """
+  def clear_halt_challenge(conn, %{"id" => tenant_id}) do
+    case Reauth.issue_challenge(tenant_id, @clear_halt_purpose) do
+      {:ok, issued} ->
+        conn
+        |> put_status(:ok)
+        |> json(%{
+          data: %{
+            challenge_id: issued.challenge_id,
+            challenge: issued.challenge,
+            allowed_credentials: issued.allowed_credentials,
+            rp_id: issued.rp_id,
+            expires_at: issued.expires_at
+          }
+        })
+
+      {:error, :no_authenticators} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> json(%{
+          error: %{
+            message:
+              "Tenant has no enrolled root authenticator to authorize break-glass recovery",
+            code: "no_authenticators",
+            status: 422
+          }
+        })
+
+      {:error, _reason} ->
+        conn
+        |> put_status(:internal_server_error)
+        |> json(%{error: %{message: "Failed to issue reauth challenge", status: 500}})
+    end
+  end
+
+  operation(:clear_halt,
+    summary: "Clear a tenant custody halt (break-glass, admin)",
+    description:
+      "Step 2 of the challenge-bound WebAuthn reauthentication ceremony. Verifies " <>
+        "the assertion against the STORED challenge from step 1 (challenge binding, " <>
+        "origin, RP-ID, signature against the enrolled COSE key, sign-counter " <>
+        "regression) and, on success, clears the tenant's custody halt. The " <>
+        "assertion is single-use — one challenge authorizes exactly one attempt. " <>
+        "Requires superadmin.",
+    parameters: [id: [in: :path, type: :string, description: "Tenant UUID"]],
+    request_body: {"WebAuthn assertion", "application/json", Schemas.RotateAuditKeyRequest},
+    responses: %{
+      200 =>
+        {"Halt cleared", "application/json",
+         %OpenApiSpex.Schema{type: :object, additionalProperties: true}},
+      401 => {"WebAuthn required or failed", "application/json", Schemas.ErrorResponse},
+      404 => {"Not found", "application/json", Schemas.ErrorResponse}
+    }
+  )
+
+  @doc """
+  POST /api/v1/admin/tenants/:id/clear-halt
+
+  Break-glass custody-halt recovery (Chain of Custody v2, L6). Superadmin
+  key alone is NOT sufficient: the caller must present a WebAuthn assertion
+  verified against a challenge issued by `challenge/2` and the target
+  tenant's enrolled root authenticator. The challenge is consumed exactly
+  once; replay is rejected.
+  """
   def clear_halt(conn, %{"id" => id} = params) do
-    # G7: Break-glass requires WebAuthn assertion
+    # Break-glass requires a VERIFIED WebAuthn assertion, not merely a
+    # present one. Mirror the rotate-audit-key guard: the assertion must be
+    # a map (the separate base64url fields), then it is cryptographically
+    # verified and the single-use challenge consumed before the halt clears.
     assertion = Map.get(params, "webauthn_assertion")
 
-    if is_nil(assertion) do
+    if is_map(assertion) do
+      verify_and_clear_halt(conn, id, assertion)
+    else
       conn
       |> put_status(:unauthorized)
       |> json(%{
@@ -383,8 +488,28 @@ defmodule LoopctlWeb.AdminTenantController do
           remediation: %{learn_more: "https://loopctl.com/wiki/break-glass"}
         }
       })
-    else
-      do_clear_halt(conn, id)
+    end
+  end
+
+  defp verify_and_clear_halt(conn, id, assertion) do
+    # Verify the assertion against the STORED challenge and the tenant's
+    # enrolled authenticator (challenge binding, signature, counter). The
+    # ceremony is single-use: the challenge is consumed here regardless of
+    # outcome. Only a genuinely verified assertion reaches do_clear_halt.
+    case Reauth.verify_and_consume(id, @clear_halt_purpose, assertion) do
+      {:ok, _verified} ->
+        do_clear_halt(conn, id)
+
+      {:error, _reason} ->
+        conn
+        |> put_status(:unauthorized)
+        |> json(%{
+          error: %{
+            code: "webauthn_failed",
+            status: 401,
+            message: "WebAuthn assertion verification failed"
+          }
+        })
     end
   end
 

--- a/lib/loopctl_web/router.ex
+++ b/lib/loopctl_web/router.ex
@@ -563,6 +563,12 @@ defmodule LoopctlWeb.Router do
     post "/violators/:id/ignore", AdminViolatorController, :ignore
 
     # US-26.5.2 — Custody halt management
+    # Break-glass clear-halt is a two-step, challenge-bound WebAuthn ceremony
+    # (Chain of Custody v2, L6): step 1 mints a single-use challenge, step 2
+    # verifies the assertion against it before clearing the halt. The
+    # controller-level `RequireRole, exact_role: :superadmin` plug applies to
+    # BOTH actions.
+    post "/tenants/:id/clear-halt/challenge", AdminTenantController, :clear_halt_challenge
     post "/tenants/:id/clear-halt", AdminTenantController, :clear_halt
   end
 end

--- a/test/loopctl_web/controllers/admin_tenant_controller_test.exs
+++ b/test/loopctl_web/controllers/admin_tenant_controller_test.exs
@@ -4,9 +4,24 @@ defmodule LoopctlWeb.AdminTenantControllerTest do
   setup :verify_on_exit!
 
   alias Loopctl.Audit
+  alias Loopctl.AuditChain
+  alias Loopctl.Tenants
 
   defp auth_conn(conn, raw_key) do
     put_req_header(conn, "authorization", "Bearer #{raw_key}")
+  end
+
+  # Builds the assertion request object with SEPARATE base64url fields — the
+  # crypto-01 shape consumed by Reauth.verify_and_consume/3 (never one blob
+  # reused for all four values, which was the placeholder bug).
+  defp assertion_body(challenge_id, credential_id) do
+    %{
+      "challenge_id" => challenge_id,
+      "credential_id" => Base.url_encode64(credential_id, padding: false),
+      "authenticator_data" => Base.url_encode64(:crypto.strong_rand_bytes(37), padding: false),
+      "signature" => Base.url_encode64(:crypto.strong_rand_bytes(64), padding: false),
+      "client_data_json" => Base.url_encode64(~s({"type":"webauthn.get"}), padding: false)
+    }
   end
 
   describe "GET /api/v1/admin/tenants" do
@@ -400,6 +415,248 @@ defmodule LoopctlWeb.AdminTenantControllerTest do
 
         assert resp.status == 403, "Expected 403 for #{method} #{path}, got #{resp.status}"
       end
+    end
+  end
+
+  describe "POST /api/v1/admin/tenants/:id/clear-halt/challenge" do
+    test "issues a challenge bound to the target tenant's authenticators", %{conn: conn} do
+      {raw_key, _} = fixture(:api_key, %{role: :superadmin})
+      tenant = fixture(:tenant, %{audit_signing_public_key: :crypto.strong_rand_bytes(32)})
+      auth = fixture(:root_authenticator, tenant_id: tenant.id)
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/admin/tenants/#{tenant.id}/clear-halt/challenge", %{})
+
+      data = json_response(conn, 200)["data"]
+      assert data["challenge_id"]
+      assert data["challenge"] != ""
+      assert Base.url_encode64(auth.credential_id, padding: false) in data["allowed_credentials"]
+    end
+
+    test "returns 422 when the tenant has no enrolled authenticator", %{conn: conn} do
+      {raw_key, _} = fixture(:api_key, %{role: :superadmin})
+      tenant = fixture(:tenant, %{audit_signing_public_key: :crypto.strong_rand_bytes(32)})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/admin/tenants/#{tenant.id}/clear-halt/challenge", %{})
+
+      assert json_response(conn, 422)["error"]["code"] == "no_authenticators"
+    end
+
+    test "rejects a non-superadmin key", %{conn: conn} do
+      tenant = fixture(:tenant, %{audit_signing_public_key: :crypto.strong_rand_bytes(32)})
+      _auth = fixture(:root_authenticator, tenant_id: tenant.id)
+      {raw_key, _} = fixture(:api_key, %{tenant_id: tenant.id, role: :user})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/admin/tenants/#{tenant.id}/clear-halt/challenge", %{})
+
+      assert conn.status == 403
+    end
+  end
+
+  describe "POST /api/v1/admin/tenants/:id/clear-halt" do
+    setup do
+      {raw_key, api_key} = fixture(:api_key, %{role: :superadmin})
+      tenant = fixture(:tenant, %{audit_signing_public_key: :crypto.strong_rand_bytes(32)})
+      auth = fixture(:root_authenticator, tenant_id: tenant.id, sign_count: 0)
+      {:ok, _halted} = Tenants.halt_custody(tenant.id)
+
+      %{raw_key: raw_key, api_key: api_key, tenant: tenant, auth: auth}
+    end
+
+    defp issue_challenge(conn, raw_key, tenant_id) do
+      conn
+      |> auth_conn(raw_key)
+      |> post(~p"/api/v1/admin/tenants/#{tenant_id}/clear-halt/challenge", %{})
+      |> json_response(200)
+      |> Map.fetch!("data")
+    end
+
+    test "clears the halt via the two-step challenge-bound ceremony", ctx do
+      %{conn: conn, raw_key: raw_key, api_key: api_key, tenant: tenant, auth: auth} = ctx
+
+      # Default MockWebAuthn stub verifies successfully (sign_count: 1).
+      challenge_data = issue_challenge(conn, raw_key, tenant.id)
+
+      clear_conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/admin/tenants/#{tenant.id}/clear-halt", %{
+          "webauthn_assertion" =>
+            assertion_body(challenge_data["challenge_id"], auth.credential_id)
+        })
+
+      resp = json_response(clear_conn, 200)
+      assert resp["data"]["id"] == tenant.id
+      assert resp["data"]["custody_halted_at"] == nil
+      assert resp["data"]["status"] == "halt_cleared"
+
+      # Halt is actually cleared in the DB.
+      {:ok, reloaded} = Tenants.get_tenant(tenant.id)
+      assert reloaded.custody_halted_at == nil
+
+      # The halt_cleared audit event was appended to the hash chain.
+      %{data: entries} = AuditChain.list_entries(tenant.id, action: "halt_cleared")
+      assert length(entries) == 1
+      assert hd(entries).payload["cleared_by"] == api_key.id
+    end
+
+    test "rejects a garbage assertion that fails verification and does NOT clear the halt", ctx do
+      %{conn: conn, raw_key: raw_key, tenant: tenant, auth: auth} = ctx
+
+      Mox.stub(Loopctl.MockWebAuthn, :verify_authentication, fn _p, _c, _o ->
+        {:error, :invalid_assertion}
+      end)
+
+      challenge_data = issue_challenge(conn, raw_key, tenant.id)
+
+      clear_conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/admin/tenants/#{tenant.id}/clear-halt", %{
+          "webauthn_assertion" =>
+            assertion_body(challenge_data["challenge_id"], auth.credential_id)
+        })
+
+      assert json_response(clear_conn, 401)["error"]["code"] == "webauthn_failed"
+
+      # Halt remains set.
+      {:ok, reloaded} = Tenants.get_tenant(tenant.id)
+      refute is_nil(reloaded.custody_halted_at)
+    end
+
+    test "rejects an assertion referencing a non-existent challenge and keeps the halt", ctx do
+      %{conn: conn, raw_key: raw_key, tenant: tenant, auth: auth} = ctx
+
+      clear_conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/admin/tenants/#{tenant.id}/clear-halt", %{
+          "webauthn_assertion" => assertion_body(Ecto.UUID.generate(), auth.credential_id)
+        })
+
+      assert json_response(clear_conn, 401)["error"]["code"] == "webauthn_failed"
+
+      {:ok, reloaded} = Tenants.get_tenant(tenant.id)
+      refute is_nil(reloaded.custody_halted_at)
+    end
+
+    test "a challenge is single-use — replaying the consumed assertion is rejected", ctx do
+      %{conn: conn, raw_key: raw_key, tenant: tenant, auth: auth} = ctx
+
+      challenge_data = issue_challenge(conn, raw_key, tenant.id)
+      body = assertion_body(challenge_data["challenge_id"], auth.credential_id)
+
+      # First use clears the halt.
+      assert conn
+             |> auth_conn(raw_key)
+             |> post(~p"/api/v1/admin/tenants/#{tenant.id}/clear-halt", %{
+               "webauthn_assertion" => body
+             })
+             |> json_response(200)
+
+      # Re-halt, then replay the SAME (already-consumed) challenge.
+      {:ok, _} = Tenants.halt_custody(tenant.id)
+
+      replay_conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/admin/tenants/#{tenant.id}/clear-halt", %{
+          "webauthn_assertion" => body
+        })
+
+      assert json_response(replay_conn, 401)["error"]["code"] == "webauthn_failed"
+
+      {:ok, reloaded} = Tenants.get_tenant(tenant.id)
+      refute is_nil(reloaded.custody_halted_at)
+    end
+
+    test "a missing webauthn_assertion is rejected (webauthn_required) and keeps the halt", ctx do
+      %{conn: conn, raw_key: raw_key, tenant: tenant} = ctx
+
+      clear_conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/admin/tenants/#{tenant.id}/clear-halt", %{})
+
+      assert json_response(clear_conn, 401)["error"]["code"] == "webauthn_required"
+
+      {:ok, reloaded} = Tenants.get_tenant(tenant.id)
+      refute is_nil(reloaded.custody_halted_at)
+    end
+
+    test "a non-map webauthn_assertion is rejected (webauthn_required)", ctx do
+      %{conn: conn, raw_key: raw_key, tenant: tenant} = ctx
+
+      clear_conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/admin/tenants/#{tenant.id}/clear-halt", %{
+          "webauthn_assertion" => Base.encode64(:crypto.strong_rand_bytes(64))
+        })
+
+      assert json_response(clear_conn, 401)["error"]["code"] == "webauthn_required"
+
+      {:ok, reloaded} = Tenants.get_tenant(tenant.id)
+      refute is_nil(reloaded.custody_halted_at)
+    end
+
+    test "a non-superadmin key is rejected on clear-halt (role gate unchanged)", ctx do
+      %{conn: conn, tenant: tenant, auth: auth} = ctx
+      # User key from a SEPARATE, non-halted tenant so the role gate (403) is
+      # exercised in isolation from any custody-halt request guard.
+      other = fixture(:tenant, %{slug: "role-gate-other"})
+      {user_key, _} = fixture(:api_key, %{tenant_id: other.id, role: :user})
+
+      clear_conn =
+        conn
+        |> auth_conn(user_key)
+        |> post(~p"/api/v1/admin/tenants/#{tenant.id}/clear-halt", %{
+          "webauthn_assertion" => assertion_body(Ecto.UUID.generate(), auth.credential_id)
+        })
+
+      assert clear_conn.status == 403
+
+      {:ok, reloaded} = Tenants.get_tenant(tenant.id)
+      refute is_nil(reloaded.custody_halted_at)
+    end
+
+    test "tenant isolation: a challenge for tenant A cannot clear tenant B's halt", ctx do
+      %{conn: conn, raw_key: raw_key, tenant: tenant_a, auth: auth_a} = ctx
+
+      # Tenant B is independently halted with its own enrolled authenticator.
+      tenant_b =
+        fixture(:tenant, %{
+          slug: "halt-b",
+          audit_signing_public_key: :crypto.strong_rand_bytes(32)
+        })
+
+      _auth_b = fixture(:root_authenticator, tenant_id: tenant_b.id, sign_count: 0)
+      {:ok, _} = Tenants.halt_custody(tenant_b.id)
+
+      # Mint a challenge for tenant A, then try to spend it against tenant B.
+      challenge_a = issue_challenge(conn, raw_key, tenant_a.id)
+
+      cross_conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/admin/tenants/#{tenant_b.id}/clear-halt", %{
+          "webauthn_assertion" =>
+            assertion_body(challenge_a["challenge_id"], auth_a.credential_id)
+        })
+
+      assert json_response(cross_conn, 401)["error"]["code"] == "webauthn_failed"
+
+      # Tenant B is still halted.
+      {:ok, reloaded_b} = Tenants.get_tenant(tenant_b.id)
+      refute is_nil(reloaded_b.custody_halted_at)
     end
   end
 end

--- a/test/loopctl_web/controllers/admin_tenant_controller_test.exs
+++ b/test/loopctl_web/controllers/admin_tenant_controller_test.exs
@@ -6,6 +6,7 @@ defmodule LoopctlWeb.AdminTenantControllerTest do
   alias Loopctl.Audit
   alias Loopctl.AuditChain
   alias Loopctl.Tenants
+  alias Loopctl.WebAuthn.Reauth
 
   defp auth_conn(conn, raw_key) do
     put_req_header(conn, "authorization", "Bearer #{raw_key}")
@@ -502,10 +503,72 @@ defmodule LoopctlWeb.AdminTenantControllerTest do
       {:ok, reloaded} = Tenants.get_tenant(tenant.id)
       assert reloaded.custody_halted_at == nil
 
-      # The halt_cleared audit event was appended to the hash chain.
+      # The halt_cleared audit event was appended to the hash chain, and it
+      # records WHICH verified authenticator (credential + advanced counter)
+      # authorized the break-glass clear — not only the superadmin key.
       %{data: entries} = AuditChain.list_entries(tenant.id, action: "halt_cleared")
       assert length(entries) == 1
-      assert hd(entries).payload["cleared_by"] == api_key.id
+      entry = hd(entries)
+      assert entry.payload["cleared_by"] == api_key.id
+
+      assert entry.payload["credential_id"] ==
+               Base.url_encode64(auth.credential_id, padding: false)
+
+      assert entry.payload["sign_count"] == 1
+    end
+
+    test "AC3: a rotate-audit-key challenge cannot clear a custody halt (cross-purpose)", ctx do
+      %{conn: conn, raw_key: raw_key, tenant: tenant, auth: auth} = ctx
+
+      # Mint a challenge for the DIFFERENT ceremony purpose (audit-key rotation)
+      # for the SAME tenant + enrolled authenticator. The default MockWebAuthn
+      # stub verifies any assertion successfully, so the ONLY thing standing
+      # between this cross-purpose challenge and a cleared halt is the purpose
+      # scoping in Reauth.consume_challenge (`c.purpose == ^purpose`).
+      {:ok, issued} = Reauth.issue_challenge(tenant.id, "rotate_audit_key")
+
+      clear_conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/admin/tenants/#{tenant.id}/clear-halt", %{
+          "webauthn_assertion" => assertion_body(issued.challenge_id, auth.credential_id)
+        })
+
+      assert json_response(clear_conn, 401)["error"]["code"] == "webauthn_failed"
+
+      # The halt remains set — a rotate-audit-key challenge cleared nothing.
+      {:ok, reloaded} = Tenants.get_tenant(tenant.id)
+      refute is_nil(reloaded.custody_halted_at)
+    end
+
+    test "a rejected break-glass attempt is recorded in the audit chain", ctx do
+      %{conn: conn, raw_key: raw_key, api_key: api_key, tenant: tenant, auth: auth} = ctx
+
+      Mox.stub(Loopctl.MockWebAuthn, :verify_authentication, fn _p, _c, _o ->
+        {:error, :invalid_assertion}
+      end)
+
+      challenge_data = issue_challenge(conn, raw_key, tenant.id)
+
+      clear_conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/admin/tenants/#{tenant.id}/clear-halt", %{
+          "webauthn_assertion" =>
+            assertion_body(challenge_data["challenge_id"], auth.credential_id)
+        })
+
+      assert json_response(clear_conn, 401)["error"]["code"] == "webauthn_failed"
+
+      # The rejection is forensically recorded (L6): a compromised superadmin
+      # key attempting break-glass without the hardware factor leaves a trace.
+      %{data: entries} = AuditChain.list_entries(tenant.id, action: "halt_clear_rejected")
+      assert length(entries) == 1
+      assert hd(entries).payload["rejected_by"] == api_key.id
+
+      # No successful clear was recorded.
+      %{data: cleared} = AuditChain.list_entries(tenant.id, action: "halt_cleared")
+      assert cleared == []
     end
 
     test "rejects a garbage assertion that fails verification and does NOT clear the halt", ctx do

--- a/test/loopctl_web/controllers/admin_tenant_controller_test.exs
+++ b/test/loopctl_web/controllers/admin_tenant_controller_test.exs
@@ -460,6 +460,17 @@ defmodule LoopctlWeb.AdminTenantControllerTest do
 
       assert conn.status == 403
     end
+
+    test "returns 404 (not 500) for a malformed non-UUID tenant id", %{conn: conn} do
+      {raw_key, _} = fixture(:api_key, %{role: :superadmin})
+
+      conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/admin/tenants/not-a-uuid/clear-halt/challenge", %{})
+
+      assert json_response(conn, 404)["error"]["status"] == 404
+    end
   end
 
   describe "POST /api/v1/admin/tenants/:id/clear-halt" do
@@ -669,6 +680,22 @@ defmodule LoopctlWeb.AdminTenantControllerTest do
 
       {:ok, reloaded} = Tenants.get_tenant(tenant.id)
       refute is_nil(reloaded.custody_halted_at)
+    end
+
+    test "returns 404 (not 500) for a malformed non-UUID id even with a well-formed body", ctx do
+      %{conn: conn, raw_key: raw_key, auth: auth} = ctx
+
+      # A well-formed assertion body but a garbage path id must be caught by the
+      # up-front UUID guard (404), NOT raise Ecto.Query.CastError deep in
+      # consume_challenge's tenant_id predicate (which would 500).
+      clear_conn =
+        conn
+        |> auth_conn(raw_key)
+        |> post(~p"/api/v1/admin/tenants/not-a-uuid/clear-halt", %{
+          "webauthn_assertion" => assertion_body(Ecto.UUID.generate(), auth.credential_id)
+        })
+
+      assert json_response(clear_conn, 404)["error"]["status"] == 404
     end
 
     test "a non-superadmin key is rejected on clear-halt (role gate unchanged)", ctx do

--- a/test/loopctl_web/require_human_anchor_default_deny_test.exs
+++ b/test/loopctl_web/require_human_anchor_default_deny_test.exs
@@ -248,7 +248,8 @@ defmodule LoopctlWeb.RequireHumanAnchorDefaultDenyTest do
                {:post, "/api/v1/admin/tenants/:id/activate"},
                {:post, "/api/v1/admin/violators/:id/resolve"},
                {:post, "/api/v1/admin/violators/:id/ignore"},
-               {:post, "/api/v1/admin/tenants/:id/clear-halt"}
+               {:post, "/api/v1/admin/tenants/:id/clear-halt"},
+               {:post, "/api/v1/admin/tenants/:id/clear-halt/challenge"}
              ])
 
   # Routes gated by `exact_role:` (not hierarchy) that a plain `:user` key


### PR DESCRIPTION
## Summary

Break-glass custody-halt recovery (`POST /api/v1/admin/tenants/:id/clear-halt`) previously accepted any non-nil `webauthn_assertion` parameter without cryptographically verifying it, so the second factor was decorative — a superadmin key alone could clear a byzantine custody halt. Per Chain of Custody v2 (L6), break-glass must require proof of possession of the tenant's enrolled hardware authenticator even if the superadmin key is compromised.

This replicates the already-shipped rotate-audit-key ceremony, a two-step, challenge-bound WebAuthn flow.

## Changes

- **New challenge endpoint** `POST /tenants/:id/clear-halt/challenge` issues a single-use, TTL-bounded challenge bound to the target tenant's enrolled root authenticators via `Reauth.issue_challenge/2`. Returns 422 `no_authenticators` when none is enrolled.
- **Verify in `clear_halt/2`**: the assertion must be a map (else 401 `webauthn_required`), then it is verified via `Reauth.verify_and_consume/3` (challenge binding, signature against the enrolled COSE key, sign-counter monotonicity), the challenge is consumed exactly once, and the halt clears only on success (else 401 `webauthn_failed`).
- **Dedicated purpose** constant distinct from audit-key rotation, so challenges are not cross-usable between ceremonies.
- **Unchanged**: the `exact_role: :superadmin` gate and the `halt_cleared` audit event. As a superadmin cross-tenant operation there is no ownership check; tenant isolation holds because the challenge is scoped by `(tenant_id, purpose)`.

## Tests

Controller tests cover: valid two-step ceremony clears the halt and emits the audit event; garbage/non-verifying assertion rejected (halt kept); non-existent challenge rejected; single-use replay rejected; missing/non-map assertion rejected; superadmin role gate unchanged; tenant isolation (a challenge for tenant A cannot clear tenant B); challenge endpoint returns 422 with no enrolled authenticator. The human-anchor default-deny route enumeration test allowlists the new route.

`mix precommit` green: compile clean, format, credo --strict no issues, dialyzer passed, 5472 tests 0 failures.
